### PR TITLE
feat(github): add GitHub App integration methods

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -183,3 +183,68 @@ func (c *Client) GetRepository(ctx context.Context, owner, repo string) (*Reposi
 	}
 	return &repository, nil
 }
+
+// CreateCommitStatus creates a status for a specific commit SHA
+// The context parameter allows multiple statuses per commit (e.g., "ci/build", "pilot/execution")
+func (c *Client) CreateCommitStatus(ctx context.Context, owner, repo, sha string, status *CommitStatus) (*CommitStatus, error) {
+	path := fmt.Sprintf("/repos/%s/%s/statuses/%s", owner, repo, sha)
+	var result CommitStatus
+	if err := c.doRequest(ctx, http.MethodPost, path, status, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CreateCheckRun creates a check run for the GitHub Checks API
+// Requires a GitHub App token with checks:write permission
+func (c *Client) CreateCheckRun(ctx context.Context, owner, repo string, checkRun *CheckRun) (*CheckRun, error) {
+	path := fmt.Sprintf("/repos/%s/%s/check-runs", owner, repo)
+	var result CheckRun
+	if err := c.doRequest(ctx, http.MethodPost, path, checkRun, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateCheckRun updates an existing check run
+func (c *Client) UpdateCheckRun(ctx context.Context, owner, repo string, checkRunID int64, checkRun *CheckRun) (*CheckRun, error) {
+	path := fmt.Sprintf("/repos/%s/%s/check-runs/%d", owner, repo, checkRunID)
+	var result CheckRun
+	if err := c.doRequest(ctx, http.MethodPatch, path, checkRun, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CreatePullRequest creates a new pull request
+func (c *Client) CreatePullRequest(ctx context.Context, owner, repo string, input *PullRequestInput) (*PullRequest, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls", owner, repo)
+	var result PullRequest
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetPullRequest fetches a pull request by number
+func (c *Client) GetPullRequest(ctx context.Context, owner, repo string, number int) (*PullRequest, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number)
+	var result PullRequest
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// AddPRComment adds a comment to a pull request (issue comment API)
+// For review comments on specific lines, use CreatePRReviewComment instead
+func (c *Client) AddPRComment(ctx context.Context, owner, repo string, number int, body string) (*PRComment, error) {
+	// PRs use the issues API for general comments
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
+	reqBody := map[string]string{"body": body}
+	var result PRComment
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -257,4 +257,313 @@ func TestClientMethodSignatures(t *testing.T) {
 	// GetRepository
 	_, err = client.GetRepository(ctx, "owner", "repo")
 	_ = err
+
+	// CreateCommitStatus
+	_, err = client.CreateCommitStatus(ctx, "owner", "repo", "abc123", &CommitStatus{
+		State:       StatusPending,
+		Context:     "pilot/execution",
+		Description: "Running...",
+	})
+	_ = err
+
+	// CreateCheckRun
+	_, err = client.CreateCheckRun(ctx, "owner", "repo", &CheckRun{
+		HeadSHA: "abc123",
+		Name:    "Pilot",
+		Status:  CheckRunInProgress,
+	})
+	_ = err
+
+	// UpdateCheckRun
+	_, err = client.UpdateCheckRun(ctx, "owner", "repo", 123, &CheckRun{
+		Status:     CheckRunCompleted,
+		Conclusion: ConclusionSuccess,
+	})
+	_ = err
+
+	// CreatePullRequest
+	_, err = client.CreatePullRequest(ctx, "owner", "repo", &PullRequestInput{
+		Title: "Test PR",
+		Head:  "feature-branch",
+		Base:  "main",
+	})
+	_ = err
+
+	// GetPullRequest
+	_, err = client.GetPullRequest(ctx, "owner", "repo", 1)
+	_ = err
+
+	// AddPRComment
+	_, err = client.AddPRComment(ctx, "owner", "repo", 1, "PR comment")
+	_ = err
+}
+
+func TestCreateCommitStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/repos/owner/repo/statuses/abc123def" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body CommitStatus
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		if body.State != StatusPending {
+			t.Errorf("unexpected state: %s", body.State)
+		}
+		if body.Context != "pilot/execution" {
+			t.Errorf("unexpected context: %s", body.Context)
+		}
+
+		result := CommitStatus{
+			ID:          12345,
+			State:       body.State,
+			Context:     body.Context,
+			Description: body.Description,
+			TargetURL:   body.TargetURL,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(result)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token")
+	_ = client
+}
+
+func TestCreateCheckRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/repos/owner/repo/check-runs" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body CheckRun
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		if body.HeadSHA != "abc123def456" {
+			t.Errorf("unexpected head_sha: %s", body.HeadSHA)
+		}
+		if body.Name != "Pilot Execution" {
+			t.Errorf("unexpected name: %s", body.Name)
+		}
+
+		result := CheckRun{
+			ID:      67890,
+			HeadSHA: body.HeadSHA,
+			Name:    body.Name,
+			Status:  CheckRunInProgress,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(result)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token")
+	_ = client
+}
+
+func TestUpdateCheckRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		if r.URL.Path != "/repos/owner/repo/check-runs/67890" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body CheckRun
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		if body.Status != CheckRunCompleted {
+			t.Errorf("unexpected status: %s", body.Status)
+		}
+		if body.Conclusion != ConclusionSuccess {
+			t.Errorf("unexpected conclusion: %s", body.Conclusion)
+		}
+
+		result := CheckRun{
+			ID:         67890,
+			Status:     body.Status,
+			Conclusion: body.Conclusion,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(result)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token")
+	_ = client
+}
+
+func TestCreatePullRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/repos/owner/repo/pulls" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body PullRequestInput
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		if body.Title != "Add new feature" {
+			t.Errorf("unexpected title: %s", body.Title)
+		}
+		if body.Head != "feature/new-feature" {
+			t.Errorf("unexpected head: %s", body.Head)
+		}
+		if body.Base != "main" {
+			t.Errorf("unexpected base: %s", body.Base)
+		}
+
+		result := PullRequest{
+			ID:      11111,
+			Number:  42,
+			Title:   body.Title,
+			Head:    body.Head,
+			Base:    body.Base,
+			State:   "open",
+			HTMLURL: "https://github.com/owner/repo/pull/42",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(result)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token")
+	_ = client
+}
+
+func TestGetPullRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/repos/owner/repo/pulls/42" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
+		}
+
+		result := PullRequest{
+			ID:      11111,
+			Number:  42,
+			Title:   "Test PR",
+			Head:    "feature-branch",
+			Base:    "main",
+			State:   "open",
+			HTMLURL: "https://github.com/owner/repo/pull/42",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(result)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token")
+	_ = client
+}
+
+func TestAddPRComment(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		// PR comments go through the issues API
+		if r.URL.Path != "/repos/owner/repo/issues/42/comments" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		if body["body"] != "This is a PR comment" {
+			t.Errorf("unexpected comment body: %s", body["body"])
+		}
+
+		result := PRComment{
+			ID:      22222,
+			Body:    body["body"],
+			HTMLURL: "https://github.com/owner/repo/issues/42#issuecomment-22222",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(result)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token")
+	_ = client
+}
+
+func TestCommitStatusConstants(t *testing.T) {
+	// Verify status constants match GitHub API expectations
+	tests := []struct {
+		constant string
+		expected string
+	}{
+		{StatusPending, "pending"},
+		{StatusSuccess, "success"},
+		{StatusFailure, "failure"},
+		{StatusError, "error"},
+	}
+
+	for _, tt := range tests {
+		if tt.constant != tt.expected {
+			t.Errorf("constant = %s, want %s", tt.constant, tt.expected)
+		}
+	}
+}
+
+func TestCheckRunConstants(t *testing.T) {
+	// Verify check run status constants
+	statusTests := []struct {
+		constant string
+		expected string
+	}{
+		{CheckRunQueued, "queued"},
+		{CheckRunInProgress, "in_progress"},
+		{CheckRunCompleted, "completed"},
+	}
+
+	for _, tt := range statusTests {
+		if tt.constant != tt.expected {
+			t.Errorf("constant = %s, want %s", tt.constant, tt.expected)
+		}
+	}
+
+	// Verify check run conclusion constants
+	conclusionTests := []struct {
+		constant string
+		expected string
+	}{
+		{ConclusionSuccess, "success"},
+		{ConclusionFailure, "failure"},
+		{ConclusionNeutral, "neutral"},
+		{ConclusionCancelled, "cancelled"},
+		{ConclusionTimedOut, "timed_out"},
+		{ConclusionActionRequired, "action_required"},
+		{ConclusionSkipped, "skipped"},
+	}
+
+	for _, tt := range conclusionTests {
+		if tt.constant != tt.expected {
+			t.Errorf("constant = %s, want %s", tt.constant, tt.expected)
+		}
+	}
 }

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -71,3 +71,100 @@ func PriorityName(priority Priority) string {
 		return "No Priority"
 	}
 }
+
+// CommitStatus states
+const (
+	StatusPending = "pending"
+	StatusSuccess = "success"
+	StatusFailure = "failure"
+	StatusError   = "error"
+)
+
+// CommitStatus represents a GitHub commit status
+type CommitStatus struct {
+	ID          int64  `json:"id,omitempty"`
+	State       string `json:"state"`                  // pending, success, failure, error
+	TargetURL   string `json:"target_url,omitempty"`   // URL to link to from the status
+	Description string `json:"description,omitempty"` // Short description (140 chars max)
+	Context     string `json:"context,omitempty"`      // Unique identifier for the status
+	CreatedAt   string `json:"created_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"`
+}
+
+// CheckRun conclusion values
+const (
+	ConclusionSuccess        = "success"
+	ConclusionFailure        = "failure"
+	ConclusionNeutral        = "neutral"
+	ConclusionCancelled      = "cancelled"
+	ConclusionTimedOut       = "timed_out"
+	ConclusionActionRequired = "action_required"
+	ConclusionSkipped        = "skipped"
+)
+
+// CheckRun status values
+const (
+	CheckRunQueued     = "queued"
+	CheckRunInProgress = "in_progress"
+	CheckRunCompleted  = "completed"
+)
+
+// CheckRun represents a GitHub Check Run (Checks API)
+type CheckRun struct {
+	ID          int64        `json:"id,omitempty"`
+	HeadSHA     string       `json:"head_sha"`
+	Name        string       `json:"name"`
+	Status      string       `json:"status,omitempty"`      // queued, in_progress, completed
+	Conclusion  string       `json:"conclusion,omitempty"`  // success, failure, neutral, cancelled, timed_out, action_required, skipped
+	DetailsURL  string       `json:"details_url,omitempty"` // URL for more details
+	ExternalID  string       `json:"external_id,omitempty"` // Reference for external system
+	StartedAt   string       `json:"started_at,omitempty"`
+	CompletedAt string       `json:"completed_at,omitempty"`
+	Output      *CheckOutput `json:"output,omitempty"` // Rich output for the check
+}
+
+// CheckOutput represents the output of a check run
+type CheckOutput struct {
+	Title   string `json:"title"`
+	Summary string `json:"summary"`
+	Text    string `json:"text,omitempty"`
+}
+
+// PullRequest represents a GitHub pull request
+type PullRequest struct {
+	ID        int64  `json:"id,omitempty"`
+	Number    int    `json:"number,omitempty"`
+	Title     string `json:"title"`
+	Body      string `json:"body,omitempty"`
+	State     string `json:"state,omitempty"` // open, closed
+	Head      string `json:"head"`            // Branch name or ref for the head (source)
+	Base      string `json:"base"`            // Branch name or ref for the base (target)
+	HTMLURL   string `json:"html_url,omitempty"`
+	Draft     bool   `json:"draft,omitempty"`
+	Merged    bool   `json:"merged,omitempty"`
+	Mergeable *bool  `json:"mergeable,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+	MergedAt  string `json:"merged_at,omitempty"`
+}
+
+// PullRequestInput is used for creating pull requests
+type PullRequestInput struct {
+	Title string `json:"title"`
+	Body  string `json:"body,omitempty"`
+	Head  string `json:"head"` // Branch to merge from
+	Base  string `json:"base"` // Branch to merge into
+	Draft bool   `json:"draft,omitempty"`
+}
+
+// PRComment represents a comment on a pull request
+type PRComment struct {
+	ID        int64  `json:"id,omitempty"`
+	Body      string `json:"body"`
+	Path      string `json:"path,omitempty"`      // File path for review comments
+	Position  int    `json:"position,omitempty"`  // Line position for review comments
+	CommitID  string `json:"commit_id,omitempty"` // Commit SHA for review comments
+	HTMLURL   string `json:"html_url,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}


### PR DESCRIPTION
## Summary

Add GitHub App integration APIs for status checks, check runs, pull requests, and PR comments.

### New Methods
- `CreateCommitStatus` - Report status on commits
- `CreateCheckRun` / `UpdateCheckRun` - GitHub Checks API integration
- `CreatePullRequest` / `GetPullRequest` - PR creation and retrieval
- `AddPRComment` - Add comments to pull requests

### New Types
- `CommitStatus` with state constants (pending, success, failure, error)
- `CheckRun` + `CheckOutput` with status/conclusion constants
- `PullRequest` + `PullRequestInput`
- `PRComment`

### Test Coverage
- Tests for all new methods
- Constant validation tests
- Method signature verification

## Test Plan
- [x] `make test` passes
- [x] `make lint` passes (0 issues)

Closes TASK-23