### PR TITLE
TASK-41: Prevent Fake Secrets in Tests from Triggering Push Protection

### DIFF
--- a/.agent/tasks/TASK-41-test-secret-patterns.md
+++ b/.agent/tasks/TASK-41-test-secret-patterns.md
@@ -1,6 +1,6 @@
 # TASK-41: Prevent Fake Secrets in Tests from Triggering Push Protection
 
-**Status**: 📋 Planned
+**Status**: ✅ Complete
 **Priority**: High (P1)
 **Created**: 2026-01-28
 
@@ -122,12 +122,12 @@ Update existing test files to use safe tokens:
 
 ## Acceptance Criteria
 
-- [ ] Pre-commit hook blocks commits with realistic secret patterns
-- [ ] CI fails if realistic patterns found in test files
-- [ ] `internal/testutil/tokens.go` exists with safe constants
-- [ ] CLAUDE.md documents the guideline
-- [ ] `make install-hooks` installs the pre-commit hook
-- [ ] All existing tests use safe token patterns
+- [x] Pre-commit hook blocks commits with realistic secret patterns
+- [x] CI fails if realistic patterns found in test files
+- [x] `internal/testutil/tokens.go` exists with safe constants
+- [x] CLAUDE.md documents the guideline
+- [x] `make install-hooks` installs the pre-commit hook
+- [x] All existing tests use safe token patterns
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,15 @@ on:
     branches: [main]
 
 jobs:
+  secret-patterns:
+    name: Check Secret Patterns
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for realistic secret patterns in tests
+        run: ./scripts/check-secret-patterns.sh
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,30 @@ pilot/
 - **Architecture**: KISS, DRY, SOLID
 - **Testing**: Table-driven tests for Go
 
+## Test Token Guidelines
+
+When writing tests that need API tokens or secrets:
+
+- ❌ **DON'T** use realistic patterns that trigger GitHub push protection:
+  - `xoxb-123456789012-1234567890123-abcdefghij` (Slack)
+  - `sk-abcdefghijklmnopqrstuvwxyz123456` (OpenAI)
+  - `ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` (GitHub PAT)
+  - `AKIAIOSFODNN7EXAMPLE` (AWS)
+
+- ✅ **DO** use obviously fake tokens:
+  - `test-slack-bot-token`
+  - `fake-api-key`
+  - `test-github-token`
+
+- ✅ **DO** use constants from `internal/testutil/tokens.go`:
+  ```go
+  import "github.com/anthropics/pilot/internal/testutil"
+
+  token := testutil.FakeSlackBotToken
+  ```
+
+**Why?** GitHub's push protection blocks realistic-looking secrets even in test files. 9 branches were blocked for hours due to this.
+
 ## Key Commands
 
 ```bash
@@ -65,6 +89,8 @@ make dev            # Run in dev mode
 make test           # Run tests
 make lint           # Run linter
 make fmt            # Format code
+make install-hooks  # Install git pre-commit hooks
+make check-secrets  # Check for secret patterns in tests
 ```
 
 ## Configuration

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-e2e clean install lint fmt deps dev
+.PHONY: build run test test-e2e clean install lint fmt deps dev install-hooks check-secrets
 
 # Variables
 BINARY_NAME=pilot
@@ -95,6 +95,14 @@ mocks:
 test-orchestrator:
 	cd orchestrator && python -m pytest -v
 
+# Install git hooks (pre-commit for secret pattern detection)
+install-hooks:
+	@./scripts/install-hooks.sh
+
+# Check for realistic secret patterns in test files
+check-secrets:
+	@./scripts/check-secret-patterns.sh
+
 # Help
 help:
 	@echo "Pilot Makefile Commands:"
@@ -113,4 +121,6 @@ help:
 	@echo "  make clean          Clean build artifacts"
 	@echo "  make install        Install to GOPATH/bin"
 	@echo "  make install-global Install to /usr/local/bin"
+	@echo "  make install-hooks  Install git pre-commit hooks"
+	@echo "  make check-secrets  Check for secret patterns in tests"
 	@echo ""

--- a/internal/testutil/tokens.go
+++ b/internal/testutil/tokens.go
@@ -1,0 +1,45 @@
+// Package testutil provides testing utilities for the pilot project.
+package testutil
+
+// Safe test tokens that won't trigger GitHub's push protection.
+// These are intentionally simple and obviously fake to avoid secret scanning.
+//
+// ❌ DON'T use patterns like: xoxb-123456789012-1234567890123-abcdefghij
+// ✅ DO use these constants or similarly obvious fakes.
+const (
+	// FakeSlackBotToken is a safe test token for Slack bot authentication.
+	FakeSlackBotToken = "test-slack-bot-token"
+
+	// FakeSlackAppToken is a safe test token for Slack app authentication.
+	FakeSlackAppToken = "test-slack-app-token"
+
+	// FakeSlackWebhookURL is a safe test URL for Slack webhooks.
+	FakeSlackWebhookURL = "https://hooks.slack.test/services/TEST/WEBHOOK/URL"
+
+	// FakeGitHubToken is a safe test token for GitHub API authentication.
+	FakeGitHubToken = "test-github-token"
+
+	// FakeGitHubPAT is a safe test personal access token for GitHub.
+	FakeGitHubPAT = "test-github-pat"
+
+	// FakeOpenAIKey is a safe test API key for OpenAI.
+	FakeOpenAIKey = "test-openai-api-key"
+
+	// FakeAnthropicKey is a safe test API key for Anthropic.
+	FakeAnthropicKey = "test-anthropic-api-key"
+
+	// FakeLinearAPIKey is a safe test API key for Linear.
+	FakeLinearAPIKey = "test-linear-api-key"
+
+	// FakeAWSAccessKeyID is a safe test AWS access key ID.
+	FakeAWSAccessKeyID = "test-aws-access-key-id"
+
+	// FakeAWSSecretKey is a safe test AWS secret access key.
+	FakeAWSSecretKey = "test-aws-secret-key"
+
+	// FakeJWT is a safe test JWT token.
+	FakeJWT = "test.jwt.token"
+
+	// FakeBearerToken is a safe test bearer token.
+	FakeBearerToken = "test-bearer-token"
+)

--- a/scripts/check-secret-patterns.sh
+++ b/scripts/check-secret-patterns.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Check for realistic-looking secret patterns in test files
+# Used by CI to catch patterns that might have bypassed pre-commit hook
+
+set -e
+
+echo "Scanning for realistic secret patterns in test files..."
+
+# Patterns that look like real secrets (will trigger GitHub push protection)
+PATTERNS=(
+    'xoxb-[0-9]{10,}-[0-9]{10,}'           # Slack bot token
+    'xoxa-[0-9]{10,}-[0-9]{10,}'           # Slack app token
+    'xoxp-[0-9]{10,}-[0-9]{10,}'           # Slack user token
+    'sk-[a-zA-Z0-9]{32,}'                   # OpenAI API key
+    'ghp_[a-zA-Z0-9]{36}'                   # GitHub PAT
+    'gho_[a-zA-Z0-9]{36}'                   # GitHub OAuth token
+    'ghu_[a-zA-Z0-9]{36}'                   # GitHub user-to-server token
+    'ghs_[a-zA-Z0-9]{36}'                   # GitHub server-to-server token
+    'github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}'  # GitHub fine-grained PAT
+    'AKIA[0-9A-Z]{16}'                      # AWS access key ID
+    'lin_api_[a-zA-Z0-9]{40}'               # Linear API key
+)
+
+FOUND_SECRETS=0
+
+for pattern in "${PATTERNS[@]}"; do
+    # Search in all test files
+    MATCHES=$(grep -rE "$pattern" --include='*_test.go' . 2>/dev/null || true)
+    if [ -n "$MATCHES" ]; then
+        echo ""
+        echo "❌ ERROR: Found realistic-looking secret pattern"
+        echo "   Pattern: $pattern"
+        echo ""
+        echo "$MATCHES" | head -10
+        echo ""
+        FOUND_SECRETS=1
+    fi
+done
+
+if [ $FOUND_SECRETS -eq 1 ]; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "CI CHECK FAILED: Realistic secret patterns detected"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "GitHub's push protection will block these patterns."
+    echo ""
+    echo "Instead, use obviously fake tokens:"
+    echo "  ✅ test-slack-bot-token"
+    echo "  ✅ fake-api-key"
+    echo "  ✅ Constants from internal/testutil/tokens.go"
+    echo ""
+    exit 1
+fi
+
+echo "✓ No realistic secret patterns found in test files"
+exit 0

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Install git hooks for the pilot project
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+HOOKS_DIR="$PROJECT_ROOT/.git/hooks"
+
+echo "Installing git hooks..."
+
+# Create hooks directory if it doesn't exist
+mkdir -p "$HOOKS_DIR"
+
+# Install pre-commit hook
+cat > "$HOOKS_DIR/pre-commit" << 'EOF'
+#!/bin/bash
+# Pre-commit hook to prevent realistic-looking secrets in test files
+# This helps avoid GitHub push protection blocks
+
+set -e
+
+echo "Checking for realistic secret patterns in staged files..."
+
+# Get list of staged Go test files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '_test\.go$' || true)
+
+if [ -z "$STAGED_FILES" ]; then
+    exit 0
+fi
+
+# Patterns that look like real secrets (will trigger GitHub push protection)
+# These are regex patterns for grep -E
+PATTERNS=(
+    'xoxb-[0-9]{10,}-[0-9]{10,}'           # Slack bot token
+    'xoxa-[0-9]{10,}-[0-9]{10,}'           # Slack app token
+    'xoxp-[0-9]{10,}-[0-9]{10,}'           # Slack user token
+    'sk-[a-zA-Z0-9]{32,}'                   # OpenAI API key
+    'ghp_[a-zA-Z0-9]{36}'                   # GitHub PAT
+    'gho_[a-zA-Z0-9]{36}'                   # GitHub OAuth token
+    'ghu_[a-zA-Z0-9]{36}'                   # GitHub user-to-server token
+    'ghs_[a-zA-Z0-9]{36}'                   # GitHub server-to-server token
+    'github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}'  # GitHub fine-grained PAT
+    'AKIA[0-9A-Z]{16}'                      # AWS access key ID
+    'lin_api_[a-zA-Z0-9]{40}'               # Linear API key
+)
+
+FOUND_SECRETS=0
+
+for file in $STAGED_FILES; do
+    if [ -f "$file" ]; then
+        for pattern in "${PATTERNS[@]}"; do
+            if grep -qE "$pattern" "$file" 2>/dev/null; then
+                echo ""
+                echo "❌ ERROR: Found realistic-looking secret pattern in: $file"
+                echo "   Pattern: $pattern"
+                echo ""
+                grep -nE "$pattern" "$file" | head -3
+                echo ""
+                FOUND_SECRETS=1
+            fi
+        done
+    fi
+done
+
+if [ $FOUND_SECRETS -eq 1 ]; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "COMMIT BLOCKED: Realistic secret patterns detected"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "GitHub's push protection will block these patterns."
+    echo ""
+    echo "Instead, use obviously fake tokens:"
+    echo "  ✅ test-slack-bot-token"
+    echo "  ✅ fake-api-key"
+    echo "  ✅ Constants from internal/testutil/tokens.go"
+    echo ""
+    echo "To bypass this check (not recommended):"
+    echo "  git commit --no-verify"
+    echo ""
+    exit 1
+fi
+
+echo "✓ No realistic secret patterns found"
+exit 0
+EOF
+
+chmod +x "$HOOKS_DIR/pre-commit"
+
+echo "✓ Pre-commit hook installed successfully"
+echo ""
+echo "The hook will check for realistic-looking secrets in test files."
+echo "Use 'git commit --no-verify' to bypass (not recommended)."


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-33.

## Changes

GitHub Issue #33: TASK-41: Prevent Fake Secrets in Tests from Triggering Push Protection

## Problem

Pilot wrote tests with realistic-looking fake tokens that triggered GitHub's push protection. 9 branches were blocked for hours.

**Example of bad pattern:**
```
xoxb-123456789012-1234567890123-abcdefghijklmnopqrstuvwx
```

## Solution

1. **Pre-commit hook** - Block commits with realistic secret patterns
2. **CI check** - Safety net if hook bypassed
3. **Test token constants** - `internal/testutil/tokens.go` with safe tokens
4. **CLAUDE.md guidelines** - Document for Pilot to follow

## Implementation

- Add secret pattern check to CI
- Create `internal/testutil/tokens.go` 
- Add pre-commit hook via `make install-hooks`
- Update CLAUDE.md with test guidelines

## Acceptance Criteria

- [ ] Pre-commit hook blocks realistic patterns
- [ ] CI fails on realistic patterns in tests
- [ ] Safe token constants exist
- [ ] Guidelines documented

See: `.agent/tasks/TASK-41-test-secret-patterns.md`