### PR TITLE
TASK-45: Wire up testutil package. Read .agent/tasks/TASK-45-wire-testutil.md for requirements. Find all test files with inline fake tokens (grep for patterns like 'fake.*token', 'test.*key', 'mock.*secret') and replace them with constants from internal/testutil/tokens.go. Add any missing token constants to testutil. This is a refactoring task - all tests must still pass after the changes.

### DIFF
--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -8,15 +8,17 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 func TestNewClient(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeGitHubToken)
 	if client == nil {
 		t.Fatal("NewClient returned nil")
 	}
-	if client.token != "test-token" {
-		t.Errorf("client.token = %s, want test-token", client.token)
+	if client.token != testutil.FakeGitHubToken {
+		t.Errorf("client.token = %s, want %s", client.token, testutil.FakeGitHubToken)
 	}
 	if client.baseURL != githubAPIURL {
 		t.Errorf("client.baseURL = %s, want %s", client.baseURL, githubAPIURL)
@@ -25,12 +27,12 @@ func TestNewClient(t *testing.T) {
 
 func TestNewClientWithBaseURL(t *testing.T) {
 	customURL := "https://custom.api.example.com"
-	client := NewClientWithBaseURL("test-token", customURL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, customURL)
 	if client == nil {
 		t.Fatal("NewClientWithBaseURL returned nil")
 	}
-	if client.token != "test-token" {
-		t.Errorf("client.token = %s, want test-token", client.token)
+	if client.token != testutil.FakeGitHubToken {
+		t.Errorf("client.token = %s, want %s", client.token, testutil.FakeGitHubToken)
 	}
 	if client.baseURL != customURL {
 		t.Errorf("client.baseURL = %s, want %s", client.baseURL, customURL)
@@ -79,7 +81,7 @@ func TestGetIssue(t *testing.T) {
 				if r.Method != http.MethodGet {
 					t.Errorf("expected GET, got %s", r.Method)
 				}
-				if r.Header.Get("Authorization") != "Bearer test-token" {
+				if r.Header.Get("Authorization") != "Bearer "+testutil.FakeGitHubToken {
 					t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
 				}
 				if r.Header.Get("Accept") != "application/vnd.github+json" {
@@ -92,7 +94,7 @@ func TestGetIssue(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			issue, err := client.GetIssue(context.Background(), "owner", "repo", 42)
 
 			if (err != nil) != tt.wantErr {
@@ -157,7 +159,7 @@ func TestAddComment(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			comment, err := client.AddComment(context.Background(), "owner", "repo", 42, tt.commentBody)
 
 			if (err != nil) != tt.wantErr {
@@ -218,7 +220,7 @@ func TestAddLabels(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			err := client.AddLabels(context.Background(), "owner", "repo", 42, tt.labels)
 
 			if (err != nil) != tt.wantErr {
@@ -269,7 +271,7 @@ func TestRemoveLabel(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			err := client.RemoveLabel(context.Background(), "owner", "repo", 42, tt.label)
 
 			if (err != nil) != tt.wantErr {
@@ -326,7 +328,7 @@ func TestUpdateIssueState(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			err := client.UpdateIssueState(context.Background(), "owner", "repo", 42, tt.state)
 
 			if (err != nil) != tt.wantErr {
@@ -374,7 +376,7 @@ func TestGetRepository(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			repo, err := client.GetRepository(context.Background(), "owner", "repo")
 
 			if (err != nil) != tt.wantErr {
@@ -463,7 +465,7 @@ func TestCreateCommitStatus(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			result, err := client.CreateCommitStatus(context.Background(), "owner", "repo", "abc123def", tt.status)
 
 			if (err != nil) != tt.wantErr {
@@ -542,7 +544,7 @@ func TestCreateCheckRun(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			result, err := client.CreateCheckRun(context.Background(), "owner", "repo", tt.checkRun)
 
 			if (err != nil) != tt.wantErr {
@@ -619,7 +621,7 @@ func TestUpdateCheckRun(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			result, err := client.UpdateCheckRun(context.Background(), "owner", "repo", tt.checkRunID, tt.checkRun)
 
 			if (err != nil) != tt.wantErr {
@@ -709,7 +711,7 @@ func TestCreatePullRequest(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			result, err := client.CreatePullRequest(context.Background(), "owner", "repo", tt.input)
 
 			if (err != nil) != tt.wantErr {
@@ -761,7 +763,7 @@ func TestGetPullRequest(t *testing.T) {
 				if r.URL.Path != "/repos/owner/repo/pulls/42" {
 					t.Errorf("unexpected path: %s", r.URL.Path)
 				}
-				if r.Header.Get("Authorization") != "Bearer test-token" {
+				if r.Header.Get("Authorization") != "Bearer "+testutil.FakeGitHubToken {
 					t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
 				}
 
@@ -770,7 +772,7 @@ func TestGetPullRequest(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			result, err := client.GetPullRequest(context.Background(), "owner", "repo", 42)
 
 			if (err != nil) != tt.wantErr {
@@ -837,7 +839,7 @@ func TestAddPRComment(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			result, err := client.AddPRComment(context.Background(), "owner", "repo", 42, tt.commentBody)
 
 			if (err != nil) != tt.wantErr {
@@ -923,7 +925,7 @@ func TestListIssues(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			issues, err := client.ListIssues(context.Background(), "owner", "repo", tt.opts)
 
 			if (err != nil) != tt.wantErr {
@@ -1066,7 +1068,7 @@ func TestDoRequest_ErrorHandling(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			_, err := client.GetIssue(context.Background(), "owner", "repo", 1)
 
 			if (err != nil) != tt.wantErr {
@@ -1086,7 +1088,7 @@ func TestDoRequest_InvalidJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL("test-token", server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	_, err := client.GetIssue(context.Background(), "owner", "repo", 1)
 
 	if err == nil {

--- a/internal/adapters/github/notifier_test.go
+++ b/internal/adapters/github/notifier_test.go
@@ -7,10 +7,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 func TestNewNotifier(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeGitHubToken)
 	notifier := NewNotifier(client, "pilot")
 
 	if notifier == nil {
@@ -96,7 +98,7 @@ func TestNotifyTaskStarted(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			notifier := NewNotifier(client, "pilot")
 
 			err := notifier.NotifyTaskStarted(context.Background(), "owner", "repo", 42, "TASK-123")
@@ -200,7 +202,7 @@ func TestNotifyProgress(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			notifier := NewNotifier(client, "pilot")
 
 			err := notifier.NotifyProgress(context.Background(), "owner", "repo", 42, tt.phase, tt.details)
@@ -337,7 +339,7 @@ func TestNotifyTaskCompleted(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			notifier := NewNotifier(client, "pilot")
 
 			err := notifier.NotifyTaskCompleted(context.Background(), "owner", "repo", 42, tt.prURL, tt.summary)
@@ -435,7 +437,7 @@ func TestNotifyTaskFailed(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			notifier := NewNotifier(client, "pilot")
 
 			err := notifier.NotifyTaskFailed(context.Background(), "owner", "repo", 42, tt.reason)
@@ -499,7 +501,7 @@ func TestLinkPR(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			notifier := NewNotifier(client, "pilot")
 
 			err := notifier.LinkPR(context.Background(), "owner", "repo", 1, tt.prNumber, tt.prURL)
@@ -542,7 +544,7 @@ func TestNotifyProgress_PhaseEmojis(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			notifier := NewNotifier(client, "pilot")
 
 			err := notifier.NotifyProgress(context.Background(), "owner", "repo", 42, p.phase, "details")

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 func TestNewPoller(t *testing.T) {
@@ -52,7 +54,7 @@ func TestNewPoller(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := NewClient("test-token")
+			client := NewClient(testutil.FakeGitHubToken)
 			poller, err := NewPoller(client, tt.repo, tt.label, tt.interval)
 
 			if (err != nil) != tt.wantErr {
@@ -79,7 +81,7 @@ func TestNewPoller(t *testing.T) {
 }
 
 func TestNewPoller_ParsesOwnerAndRepo(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeGitHubToken)
 	poller, err := NewPoller(client, "myorg/myrepo", "pilot", 30*time.Second)
 
 	if err != nil {
@@ -95,7 +97,7 @@ func TestNewPoller_ParsesOwnerAndRepo(t *testing.T) {
 }
 
 func TestWithPollerLogger(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeGitHubToken)
 
 	// Create a custom logger
 	customLogger := slog.Default()
@@ -113,7 +115,7 @@ func TestWithPollerLogger(t *testing.T) {
 }
 
 func TestWithPollerLogger_DefaultLogger(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeGitHubToken)
 
 	// Without custom logger, should use default
 	poller, err := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
@@ -127,7 +129,7 @@ func TestWithPollerLogger_DefaultLogger(t *testing.T) {
 }
 
 func TestWithOnIssue(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeGitHubToken)
 
 	called := false
 	callback := func(ctx context.Context, issue *Issue) error {
@@ -152,7 +154,7 @@ func TestWithOnIssue(t *testing.T) {
 }
 
 func TestPoller_IsProcessed(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeGitHubToken)
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	// Initially should not be processed
@@ -175,7 +177,7 @@ func TestPoller_IsProcessed(t *testing.T) {
 }
 
 func TestPoller_ProcessedCount(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeGitHubToken)
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	if poller.ProcessedCount() != 0 {
@@ -201,7 +203,7 @@ func TestPoller_ProcessedCount(t *testing.T) {
 }
 
 func TestPoller_Reset(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeGitHubToken)
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	// Mark some issues
@@ -226,7 +228,7 @@ func TestPoller_Reset(t *testing.T) {
 }
 
 func TestPoller_ConcurrentAccess(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeGitHubToken)
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	var wg sync.WaitGroup
@@ -315,7 +317,7 @@ func TestPoller_CheckForNewIssues(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 
 			processedIssues := []*Issue{}
 			var mu sync.Mutex
@@ -348,7 +350,7 @@ func TestPoller_CheckForNewIssues_APIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL("test-token", server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 
 	callbackCalled := false
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -378,7 +380,7 @@ func TestPoller_CheckForNewIssues_CallbackError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL("test-token", server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 
 	callCount := 0
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -415,7 +417,7 @@ func TestPoller_CheckForNewIssues_NoCallback(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL("test-token", server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 
 	// Create poller without callback
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
@@ -441,7 +443,7 @@ func TestPoller_CheckForNewIssues_SkipsAlreadyProcessed(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL("test-token", server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 
 	callCount := 0
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -463,7 +465,7 @@ func TestPoller_CheckForNewIssues_SkipsAlreadyProcessed(t *testing.T) {
 }
 
 func TestPoller_Start_CancelsOnContextDone(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeGitHubToken)
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 100*time.Millisecond)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -502,7 +504,7 @@ func TestPoller_Start_InitialCheck(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL("test-token", server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 
 	callbackCalled := make(chan struct{}, 1)
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 1*time.Hour, // Long interval

--- a/internal/adapters/github/webhook_test.go
+++ b/internal/adapters/github/webhook_test.go
@@ -10,10 +10,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 func TestNewWebhookHandler(t *testing.T) {
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeGitHubToken)
 	handler := NewWebhookHandler(client, "secret123", "pilot")
 
 	if handler == nil {
@@ -271,7 +273,7 @@ func TestHandleIssueOpened(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			handler := NewWebhookHandler(client, "", "pilot")
 
 			processed := false
@@ -407,7 +409,7 @@ func TestHandleIssueLabeled(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL("test-token", server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			handler := NewWebhookHandler(client, "", "pilot")
 
 			processed := false
@@ -443,7 +445,7 @@ func TestHandleIssueLabeled_CustomLabel(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL("test-token", server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	handler := NewWebhookHandler(client, "", "ai-assist") // Custom pilot label
 
 	processed := false
@@ -506,7 +508,7 @@ func TestProcessIssue_CallbackError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL("test-token", server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	handler := NewWebhookHandler(client, "", "pilot")
 
 	expectedErr := errors.New("callback error")
@@ -568,7 +570,7 @@ func TestProcessIssue_NoCallback(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL("test-token", server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	handler := NewWebhookHandler(client, "", "pilot")
 	// No callback set
 
@@ -615,7 +617,7 @@ func TestProcessIssue_APIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL("test-token", server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	handler := NewWebhookHandler(client, "", "pilot")
 
 	handler.OnIssue(func(ctx context.Context, issue *Issue, repo *Repository) error {

--- a/internal/adapters/jira/webhook_test.go
+++ b/internal/adapters/jira/webhook_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 func TestNewWebhookHandler(t *testing.T) {
@@ -35,7 +37,7 @@ func TestVerifySignature(t *testing.T) {
 		},
 		{
 			name:      "valid signature",
-			secret:    "test-secret",
+			secret:    testutil.FakeWebhookSecret,
 			signature: "5d8e1c2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d",
 			want:      false, // Won't match unless we compute actual HMAC
 		},

--- a/internal/adapters/linear/client_test.go
+++ b/internal/adapters/linear/client_test.go
@@ -10,15 +10,17 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 func TestNewClient(t *testing.T) {
-	client := NewClient("test-api-key")
+	client := NewClient(testutil.FakeLinearAPIKey)
 	if client == nil {
 		t.Fatal("NewClient returned nil")
 	}
-	if client.apiKey != "test-api-key" {
-		t.Errorf("client.apiKey = %s, want test-api-key", client.apiKey)
+	if client.apiKey != testutil.FakeLinearAPIKey {
+		t.Errorf("client.apiKey = %s, want %s", client.apiKey, testutil.FakeLinearAPIKey)
 	}
 	if client.httpClient == nil {
 		t.Error("client.httpClient is nil")
@@ -39,8 +41,8 @@ func TestExecute_Success(t *testing.T) {
 		if r.Header.Get("Content-Type") != "application/json" {
 			t.Errorf("Content-Type = %s, want application/json", r.Header.Get("Content-Type"))
 		}
-		if r.Header.Get("Authorization") != "test-api-key" {
-			t.Errorf("Authorization = %s, want test-api-key", r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") != testutil.FakeLinearAPIKey {
+			t.Errorf("Authorization = %s, want "+testutil.FakeLinearAPIKey, r.Header.Get("Authorization"))
 		}
 
 		// Verify request body
@@ -61,7 +63,7 @@ func TestExecute_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	var result struct {
 		Viewer struct {
@@ -98,7 +100,7 @@ func TestExecute_WithVariables(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	var result struct {
 		Issue struct {
@@ -125,7 +127,7 @@ func TestExecute_GraphQLError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	err := client.execute(context.Background(), "query { issue(id: \"invalid\") { id } }", nil, nil)
 	if err == nil {
@@ -171,7 +173,7 @@ func TestExecute_HTTPError(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := newTestableClient(server.URL, "test-api-key")
+			client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 			err := client.execute(context.Background(), "query { viewer { id } }", nil, nil)
 			if err == nil {
@@ -191,7 +193,7 @@ func TestExecute_InvalidJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	err := client.execute(context.Background(), "query { viewer { id } }", nil, nil)
 	if err == nil {
@@ -212,7 +214,7 @@ func TestExecute_NilResult(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	// Should not error when result is nil
 	err := client.execute(context.Background(), "mutation { doSomething { success } }", nil, nil)
@@ -231,7 +233,7 @@ func TestExecute_ContextCanceled(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
@@ -302,7 +304,7 @@ func TestGetIssue_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	issue, err := client.getIssue(context.Background(), "issue-123")
 	if err != nil {
@@ -357,7 +359,7 @@ func TestGetIssue_NotFound(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	_, err := client.getIssue(context.Background(), "nonexistent")
 	if err == nil {
@@ -401,7 +403,7 @@ func TestGetIssue_NullAssigneeAndProject(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	issue, err := client.getIssue(context.Background(), "issue-123")
 	if err != nil {
@@ -450,7 +452,7 @@ func TestUpdateIssueState_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	err := client.updateIssueState(context.Background(), "issue-123", "state-456")
 	if err != nil {
@@ -470,7 +472,7 @@ func TestUpdateIssueState_Error(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	err := client.updateIssueState(context.Background(), "issue-123", "invalid-state")
 	if err == nil {
@@ -506,7 +508,7 @@ func TestAddComment_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	err := client.addComment(context.Background(), "issue-123", "This is a test comment")
 	if err != nil {
@@ -526,7 +528,7 @@ func TestAddComment_Error(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newTestableClient(server.URL, "test-api-key")
+	client := newTestableClient(server.URL, testutil.FakeLinearAPIKey)
 
 	err := client.addComment(context.Background(), "issue-123", "comment")
 	if err == nil {
@@ -536,7 +538,7 @@ func TestAddComment_Error(t *testing.T) {
 
 // TestClientMethodSignatures verifies all client methods have correct signatures
 func TestClientMethodSignatures(t *testing.T) {
-	client := NewClient("test-key")
+	client := NewClient(testutil.FakeLinearAPIKey)
 	ctx := context.Background()
 
 	// These verify signatures compile correctly (actual calls will fail without mock server)

--- a/internal/adapters/linear/webhook_test.go
+++ b/internal/adapters/linear/webhook_test.go
@@ -7,10 +7,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 func TestNewWebhookHandler(t *testing.T) {
-	client := NewClient("test-api-key")
+	client := NewClient(testutil.FakeLinearAPIKey)
 	handler := NewWebhookHandler(client, "pilot")
 
 	if handler == nil {
@@ -28,7 +30,7 @@ func TestNewWebhookHandler(t *testing.T) {
 }
 
 func TestOnIssue(t *testing.T) {
-	client := NewClient("test-api-key")
+	client := NewClient(testutil.FakeLinearAPIKey)
 	handler := NewWebhookHandler(client, "pilot")
 
 	var callbackSet bool
@@ -123,7 +125,7 @@ func TestHandle_IssueCreated_WithPilotLabel(t *testing.T) {
 }
 
 func TestHandle_IssueCreated_NoPilotLabel(t *testing.T) {
-	client := NewClient("test-api-key")
+	client := NewClient(testutil.FakeLinearAPIKey)
 	handler := NewWebhookHandler(client, "pilot")
 
 	var callbackCalled bool
@@ -155,7 +157,7 @@ func TestHandle_IssueCreated_NoPilotLabel(t *testing.T) {
 }
 
 func TestHandle_IssueUpdated(t *testing.T) {
-	client := NewClient("test-api-key")
+	client := NewClient(testutil.FakeLinearAPIKey)
 	handler := NewWebhookHandler(client, "pilot")
 
 	var callbackCalled bool
@@ -187,7 +189,7 @@ func TestHandle_IssueUpdated(t *testing.T) {
 }
 
 func TestHandle_CommentEvent(t *testing.T) {
-	client := NewClient("test-api-key")
+	client := NewClient(testutil.FakeLinearAPIKey)
 	handler := NewWebhookHandler(client, "pilot")
 
 	var callbackCalled bool
@@ -216,7 +218,7 @@ func TestHandle_CommentEvent(t *testing.T) {
 }
 
 func TestHandle_IssueDeleted(t *testing.T) {
-	client := NewClient("test-api-key")
+	client := NewClient(testutil.FakeLinearAPIKey)
 	handler := NewWebhookHandler(client, "pilot")
 
 	var callbackCalled bool
@@ -342,7 +344,7 @@ func TestHandle_CallbackError(t *testing.T) {
 }
 
 func TestHandle_InvalidDataType(t *testing.T) {
-	client := NewClient("test-api-key")
+	client := NewClient(testutil.FakeLinearAPIKey)
 	handler := NewWebhookHandler(client, "pilot")
 
 	var callbackCalled bool
@@ -395,7 +397,7 @@ func TestHandle_MissingActionOrType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := NewClient("test-api-key")
+			client := NewClient(testutil.FakeLinearAPIKey)
 			handler := NewWebhookHandler(client, "pilot")
 
 			var callbackCalled bool
@@ -477,7 +479,7 @@ func TestHasPilotLabel_WithLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := NewClient("test-api-key")
+			client := NewClient(testutil.FakeLinearAPIKey)
 			handler := NewWebhookHandler(client, tt.pilotLabel)
 
 			got := handler.hasPilotLabel(tt.data)
@@ -521,7 +523,7 @@ func TestHasPilotLabel_WithLabelIds(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := NewClient("test-api-key")
+			client := NewClient(testutil.FakeLinearAPIKey)
 			handler := NewWebhookHandler(client, tt.pilotLabel)
 
 			got := handler.hasPilotLabel(tt.data)
@@ -566,7 +568,7 @@ func TestHasPilotLabel_InvalidLabelFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := NewClient("test-api-key")
+			client := NewClient(testutil.FakeLinearAPIKey)
 			handler := NewWebhookHandler(client, "pilot")
 
 			got := handler.hasPilotLabel(tt.data)
@@ -704,6 +706,6 @@ func (h *testWebhookHandler) hasPilotLabel(data map[string]interface{}) bool {
 }
 
 func (h *testWebhookHandler) getIssue(ctx context.Context, id string) (*Issue, error) {
-	client := newTestableClient(h.serverURL, "test-api-key")
+	client := newTestableClient(h.serverURL, testutil.FakeLinearAPIKey)
 	return client.getIssue(ctx, id)
 }

--- a/internal/adapters/slack/client_test.go
+++ b/internal/adapters/slack/client_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 // TestNewClient tests client creation
@@ -20,7 +22,7 @@ func TestNewClient(t *testing.T) {
 	}{
 		{
 			name:     "valid token",
-			botToken: "xoxb-test-fake-token-for-testing",
+			botToken: testutil.FakeSlackBotToken,
 		},
 		{
 			name:     "empty token",
@@ -28,7 +30,7 @@ func TestNewClient(t *testing.T) {
 		},
 		{
 			name:     "simple token",
-			botToken: "test-token",
+			botToken: testutil.FakeSlackBotToken,
 		},
 	}
 
@@ -224,7 +226,7 @@ func TestClientPostMessage(t *testing.T) {
 
 			// Create client pointing to test server
 			client := &Client{
-				botToken:   "test-token",
+				botToken:   testutil.FakeSlackBotToken,
 				httpClient: &http.Client{Timeout: 30 * time.Second},
 			}
 
@@ -234,7 +236,7 @@ func TestClientPostMessage(t *testing.T) {
 
 			// Create a custom client that hits our test server
 			testClient := &Client{
-				botToken:   "test-token",
+				botToken:   testutil.FakeSlackBotToken,
 				httpClient: server.Client(),
 			}
 
@@ -422,7 +424,7 @@ func TestClientUpdateMessage(t *testing.T) {
 			body, _ := json.Marshal(payload)
 			req, _ := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/chat.update", strings.NewReader(string(body)))
 			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("Authorization", "Bearer test-token")
+			req.Header.Set("Authorization", "Bearer "+testutil.FakeSlackBotToken)
 
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
@@ -792,7 +794,7 @@ func TestClientContextCancellation(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeSlackBotToken)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Cancel immediately
@@ -953,7 +955,7 @@ func TestClientPostMessageWithMockTransport(t *testing.T) {
 			}
 
 			client := &Client{
-				botToken: "test-token",
+				botToken: testutil.FakeSlackBotToken,
 				httpClient: &http.Client{
 					Transport: transport,
 					Timeout:   30 * time.Second,
@@ -1102,7 +1104,7 @@ func TestClientUpdateMessageWithMockTransport(t *testing.T) {
 			}
 
 			client := &Client{
-				botToken: "test-token",
+				botToken: testutil.FakeSlackBotToken,
 				httpClient: &http.Client{
 					Transport: transport,
 					Timeout:   30 * time.Second,
@@ -1136,7 +1138,7 @@ func TestClientPostMessageNetworkError(t *testing.T) {
 	}
 
 	client := &Client{
-		botToken: "test-token",
+		botToken: testutil.FakeSlackBotToken,
 		httpClient: &http.Client{
 			Transport: transport,
 			Timeout:   30 * time.Second,
@@ -1164,7 +1166,7 @@ func TestClientUpdateMessageNetworkError(t *testing.T) {
 	}
 
 	client := &Client{
-		botToken: "test-token",
+		botToken: testutil.FakeSlackBotToken,
 		httpClient: &http.Client{
 			Transport: transport,
 			Timeout:   30 * time.Second,
@@ -1196,7 +1198,7 @@ func TestClientPostMessageInvalidJSON(t *testing.T) {
 	}
 
 	client := &Client{
-		botToken: "test-token",
+		botToken: testutil.FakeSlackBotToken,
 		httpClient: &http.Client{
 			Transport: transport,
 			Timeout:   30 * time.Second,
@@ -1228,7 +1230,7 @@ func TestClientUpdateMessageInvalidJSON(t *testing.T) {
 	}
 
 	client := &Client{
-		botToken: "test-token",
+		botToken: testutil.FakeSlackBotToken,
 		httpClient: &http.Client{
 			Transport: transport,
 			Timeout:   30 * time.Second,

--- a/internal/adapters/slack/notifier_test.go
+++ b/internal/adapters/slack/notifier_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 // TestNewNotifier tests notifier creation
@@ -20,7 +22,7 @@ func TestNewNotifier(t *testing.T) {
 		{
 			name: "basic config",
 			config: &Config{
-				BotToken: "xoxb-test-token",
+				BotToken: testutil.FakeSlackBotToken,
 				Channel:  "#dev-notifications",
 			},
 			channel: "#dev-notifications",
@@ -28,7 +30,7 @@ func TestNewNotifier(t *testing.T) {
 		{
 			name: "empty channel defaults",
 			config: &Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeSlackBotToken,
 				Channel:  "",
 			},
 			channel: "",
@@ -36,7 +38,7 @@ func TestNewNotifier(t *testing.T) {
 		{
 			name: "custom channel",
 			config: &Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeSlackBotToken,
 				Channel:  "#custom-channel",
 			},
 			channel: "#custom-channel",
@@ -82,15 +84,15 @@ func TestDefaultConfig(t *testing.T) {
 func TestConfigFields(t *testing.T) {
 	config := &Config{
 		Enabled:  true,
-		BotToken: "test-slack-token",
+		BotToken: testutil.FakeSlackBotToken,
 		Channel:  "#pilot-notifications",
 	}
 
 	if !config.Enabled {
 		t.Error("Enabled should be true")
 	}
-	if config.BotToken != "test-slack-token" {
-		t.Errorf("BotToken = %q, want test-slack-token", config.BotToken)
+	if config.BotToken != testutil.FakeSlackBotToken {
+		t.Errorf("BotToken = %q, want %s", config.BotToken, testutil.FakeSlackBotToken)
 	}
 	if config.Channel != "#pilot-notifications" {
 		t.Errorf("Channel = %q, want #pilot-notifications", config.Channel)
@@ -275,7 +277,7 @@ func TestNotifierTaskStarted(t *testing.T) {
 
 			// Test with real notifier - method signature verification
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeSlackBotToken,
 				Channel:  "#test",
 			})
 
@@ -357,7 +359,7 @@ func TestNotifierTaskProgress(t *testing.T) {
 			defer server.Close()
 
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeSlackBotToken,
 				Channel:  "#test",
 			})
 
@@ -422,7 +424,7 @@ func TestNotifierTaskCompleted(t *testing.T) {
 			defer server.Close()
 
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeSlackBotToken,
 				Channel:  "#test",
 			})
 
@@ -499,7 +501,7 @@ func TestNotifierTaskFailed(t *testing.T) {
 			defer server.Close()
 
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeSlackBotToken,
 				Channel:  "#test",
 			})
 
@@ -589,7 +591,7 @@ func TestNotifierPRReady(t *testing.T) {
 			defer server.Close()
 
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeSlackBotToken,
 				Channel:  "#test",
 			})
 
@@ -662,7 +664,7 @@ func TestNotifierMessageFormatting(t *testing.T) {
 			defer server.Close()
 
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeSlackBotToken,
 				Channel:  "#test",
 			})
 
@@ -686,7 +688,7 @@ func TestNotifierMessageFormatting(t *testing.T) {
 // TestNotifierBlocksUseMarkdown tests that blocks use markdown formatting
 func TestNotifierBlocksUseMarkdown(t *testing.T) {
 	notifier := NewNotifier(&Config{
-		BotToken: "test-token",
+		BotToken: testutil.FakeSlackBotToken,
 		Channel:  "#test",
 	})
 
@@ -731,7 +733,7 @@ func TestNotifierChannelConfiguration(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeSlackBotToken,
 				Channel:  tt.channel,
 			})
 

--- a/internal/adapters/telegram/client_test.go
+++ b/internal/adapters/telegram/client_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 func TestCheckSingleton(t *testing.T) {
@@ -90,7 +92,7 @@ func TestCheckSingletonIntegration(t *testing.T) {
 	defer mockServer.Close()
 
 	// Test passes if we can create a client and the method exists
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeTelegramBotToken)
 	if client == nil {
 		t.Fatal("NewClient returned nil")
 	}
@@ -126,7 +128,7 @@ func TestNewClient(t *testing.T) {
 		},
 		{
 			name:     "simple token",
-			botToken: "test-token",
+			botToken: testutil.FakeTelegramBotToken,
 		},
 	}
 
@@ -301,7 +303,7 @@ func TestClientSendMessage(t *testing.T) {
 
 			// We can't easily redirect the client to the test server
 			// Test verifies method signature exists
-			client := NewClient("test-token")
+			client := NewClient(testutil.FakeTelegramBotToken)
 			ctx := context.Background()
 			_, _ = client.SendMessage(ctx, tt.chatID, tt.text, tt.parseMode)
 		})
@@ -344,7 +346,7 @@ func TestClientSendMessageWithKeyboard(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient("test-token")
+	client := NewClient(testutil.FakeTelegramBotToken)
 	ctx := context.Background()
 	_, _ = client.SendMessageWithKeyboard(ctx, "123456", "Choose:", "", keyboard)
 }
@@ -379,7 +381,7 @@ func TestClientEditMessage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := NewClient("test-token")
+			client := NewClient(testutil.FakeTelegramBotToken)
 			ctx := context.Background()
 			// Method signature test
 			_ = client.EditMessage(ctx, tt.chatID, tt.messageID, tt.text, tt.parseMode)
@@ -408,7 +410,7 @@ func TestClientAnswerCallback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := NewClient("test-token")
+			client := NewClient(testutil.FakeTelegramBotToken)
 			ctx := context.Background()
 			_ = client.AnswerCallback(ctx, tt.callbackID, tt.text)
 		})
@@ -450,7 +452,7 @@ func TestClientGetFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := NewClient("test-token")
+			client := NewClient(testutil.FakeTelegramBotToken)
 			ctx := context.Background()
 			_, _ = client.GetFile(ctx, tt.fileID)
 		})
@@ -475,7 +477,7 @@ func TestClientDownloadFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := NewClient("test-token")
+			client := NewClient(testutil.FakeTelegramBotToken)
 			ctx := context.Background()
 			_, _ = client.DownloadFile(ctx, tt.filePath)
 		})

--- a/internal/adapters/telegram/commands_test.go
+++ b/internal/adapters/telegram/commands_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 // mockTelegramServer creates a test server that captures sent messages
@@ -60,7 +62,7 @@ func TestCommandHandler_HandleHelp(t *testing.T) {
 	defer mock.close()
 
 	h := &Handler{
-		client:        NewClient("test-token"),
+		client:        NewClient(testutil.FakeTelegramBotToken),
 		pendingTasks:  make(map[string]*PendingTask),
 		runningTasks:  make(map[string]*RunningTask),
 		activeProject: make(map[string]string),
@@ -79,7 +81,7 @@ func TestCommandHandler_HandleHelp(t *testing.T) {
 // TestCommandHandler_HandleStatus tests the /status command
 func TestCommandHandler_HandleStatus(t *testing.T) {
 	h := &Handler{
-		client:        NewClient("test-token"),
+		client:        NewClient(testutil.FakeTelegramBotToken),
 		pendingTasks:  make(map[string]*PendingTask),
 		runningTasks:  make(map[string]*RunningTask),
 		activeProject: make(map[string]string),
@@ -139,7 +141,7 @@ func TestCommandHandler_HandleStatus(t *testing.T) {
 // TestCommandHandler_HandleCancel tests the /cancel command
 func TestCommandHandler_HandleCancel(t *testing.T) {
 	h := &Handler{
-		client:        NewClient("test-token"),
+		client:        NewClient(testutil.FakeTelegramBotToken),
 		pendingTasks:  make(map[string]*PendingTask),
 		runningTasks:  make(map[string]*RunningTask),
 		activeProject: make(map[string]string),
@@ -225,7 +227,7 @@ func TestCommandHandler_HandleCancel(t *testing.T) {
 // TestCommandHandler_HandleQueue tests the /queue command
 func TestCommandHandler_HandleQueue(t *testing.T) {
 	h := &Handler{
-		client:        NewClient("test-token"),
+		client:        NewClient(testutil.FakeTelegramBotToken),
 		pendingTasks:  make(map[string]*PendingTask),
 		runningTasks:  make(map[string]*RunningTask),
 		activeProject: make(map[string]string),
@@ -293,7 +295,7 @@ func TestCommandHandler_HandleProjects(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &Handler{
-				client:        NewClient("test-token"),
+				client:        NewClient(testutil.FakeTelegramBotToken),
 				pendingTasks:  make(map[string]*PendingTask),
 				runningTasks:  make(map[string]*RunningTask),
 				activeProject: make(map[string]string),
@@ -318,7 +320,7 @@ func TestCommandHandler_HandleSwitch(t *testing.T) {
 	}
 
 	h := &Handler{
-		client:        NewClient("test-token"),
+		client:        NewClient(testutil.FakeTelegramBotToken),
 		pendingTasks:  make(map[string]*PendingTask),
 		runningTasks:  make(map[string]*RunningTask),
 		activeProject: make(map[string]string),
@@ -366,7 +368,7 @@ func TestCommandHandler_HandleSwitch(t *testing.T) {
 // TestCommandHandler_HandleHistory tests the /history command
 func TestCommandHandler_HandleHistory(t *testing.T) {
 	h := &Handler{
-		client:        NewClient("test-token"),
+		client:        NewClient(testutil.FakeTelegramBotToken),
 		pendingTasks:  make(map[string]*PendingTask),
 		runningTasks:  make(map[string]*RunningTask),
 		activeProject: make(map[string]string),
@@ -402,7 +404,7 @@ func TestCommandHandler_HandleHistory(t *testing.T) {
 // TestCommandHandler_HandleBudget tests the /budget command
 func TestCommandHandler_HandleBudget(t *testing.T) {
 	h := &Handler{
-		client:        NewClient("test-token"),
+		client:        NewClient(testutil.FakeTelegramBotToken),
 		pendingTasks:  make(map[string]*PendingTask),
 		runningTasks:  make(map[string]*RunningTask),
 		activeProject: make(map[string]string),
@@ -418,7 +420,7 @@ func TestCommandHandler_HandleBudget(t *testing.T) {
 // TestCommandHandler_HandleTasks tests the /tasks command
 func TestCommandHandler_HandleTasks(t *testing.T) {
 	h := &Handler{
-		client:        NewClient("test-token"),
+		client:        NewClient(testutil.FakeTelegramBotToken),
 		pendingTasks:  make(map[string]*PendingTask),
 		runningTasks:  make(map[string]*RunningTask),
 		activeProject: make(map[string]string),
@@ -434,7 +436,7 @@ func TestCommandHandler_HandleTasks(t *testing.T) {
 // TestCommandHandler_UnknownCommand tests handling of unknown commands
 func TestCommandHandler_UnknownCommand(t *testing.T) {
 	h := &Handler{
-		client:        NewClient("test-token"),
+		client:        NewClient(testutil.FakeTelegramBotToken),
 		pendingTasks:  make(map[string]*PendingTask),
 		runningTasks:  make(map[string]*RunningTask),
 		activeProject: make(map[string]string),
@@ -503,7 +505,7 @@ func TestFormatTimeAgo_OldDates(t *testing.T) {
 // TestNewCommandHandler tests command handler creation
 func TestNewCommandHandler(t *testing.T) {
 	h := &Handler{
-		client:        NewClient("test-token"),
+		client:        NewClient(testutil.FakeTelegramBotToken),
 		pendingTasks:  make(map[string]*PendingTask),
 		runningTasks:  make(map[string]*RunningTask),
 		activeProject: make(map[string]string),
@@ -549,7 +551,7 @@ func TestCommandHandler_HandleCallbackSwitch(t *testing.T) {
 	}
 
 	h := &Handler{
-		client:        NewClient("test-token"),
+		client:        NewClient(testutil.FakeTelegramBotToken),
 		pendingTasks:  make(map[string]*PendingTask),
 		runningTasks:  make(map[string]*RunningTask),
 		activeProject: make(map[string]string),
@@ -572,7 +574,7 @@ func TestCommandHandler_HandleCallbackSwitch(t *testing.T) {
 // TestCommandRouting tests that commands are routed correctly
 func TestCommandRouting(t *testing.T) {
 	h := &Handler{
-		client:        NewClient("test-token"),
+		client:        NewClient(testutil.FakeTelegramBotToken),
 		pendingTasks:  make(map[string]*PendingTask),
 		runningTasks:  make(map[string]*RunningTask),
 		activeProject: make(map[string]string),

--- a/internal/adapters/telegram/handler_test.go
+++ b/internal/adapters/telegram/handler_test.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 // MockRunner implements a minimal executor.Runner interface for testing
@@ -47,7 +49,7 @@ func TestNewHandler(t *testing.T) {
 		{
 			name: "basic config",
 			config: &HandlerConfig{
-				BotToken:    "test-token",
+				BotToken:    testutil.FakeTelegramBotToken,
 				ProjectPath: "/test/path",
 			},
 			wantAllowIDs: 0,
@@ -55,7 +57,7 @@ func TestNewHandler(t *testing.T) {
 		{
 			name: "with allowed IDs",
 			config: &HandlerConfig{
-				BotToken:    "test-token",
+				BotToken:    testutil.FakeTelegramBotToken,
 				ProjectPath: "/test/path",
 				AllowedIDs:  []int64{123, 456, 789},
 			},
@@ -64,7 +66,7 @@ func TestNewHandler(t *testing.T) {
 		{
 			name: "empty allowed IDs",
 			config: &HandlerConfig{
-				BotToken:    "test-token",
+				BotToken:    testutil.FakeTelegramBotToken,
 				ProjectPath: "/test/path",
 				AllowedIDs:  []int64{},
 			},
@@ -794,7 +796,7 @@ func TestHandlerCheckSingleton(t *testing.T) {
 	defer server.Close()
 
 	h := &Handler{
-		client: NewClient("test-token"),
+		client: NewClient(testutil.FakeTelegramBotToken),
 	}
 
 	// The actual check will fail because it can't reach real Telegram API
@@ -1161,14 +1163,14 @@ func TestHandlerConfigStruct(t *testing.T) {
 	}
 
 	config := &HandlerConfig{
-		BotToken:    "test-token",
+		BotToken:    testutil.FakeTelegramBotToken,
 		ProjectPath: "/project/path",
 		Projects:    projects,
 		AllowedIDs:  []int64{123, 456},
 	}
 
-	if config.BotToken != "test-token" {
-		t.Errorf("BotToken = %q, want test-token", config.BotToken)
+	if config.BotToken != testutil.FakeTelegramBotToken {
+		t.Errorf("BotToken = %q, want %s", config.BotToken, testutil.FakeTelegramBotToken)
 	}
 	if config.ProjectPath != "/project/path" {
 		t.Errorf("ProjectPath = %q, want /project/path", config.ProjectPath)
@@ -1191,7 +1193,7 @@ func TestNewHandlerWithProjects(t *testing.T) {
 	}
 
 	config := &HandlerConfig{
-		BotToken: "test-token",
+		BotToken: testutil.FakeTelegramBotToken,
 		Projects: projects,
 		// Note: ProjectPath is empty, should use default from Projects
 	}
@@ -1347,7 +1349,7 @@ func TestVoiceNotAvailableMessageWithAPIKeyError(t *testing.T) {
 func TestNewHandlerWithTranscriptionError(t *testing.T) {
 	// This test verifies that handler creation works even if transcription fails
 	config := &HandlerConfig{
-		BotToken:    "test-token",
+		BotToken:    testutil.FakeTelegramBotToken,
 		ProjectPath: "/test/path",
 		// Transcription with invalid config would fail
 	}

--- a/internal/adapters/telegram/notifier_test.go
+++ b/internal/adapters/telegram/notifier_test.go
@@ -7,12 +7,14 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 // TestNewNotifier tests notifier creation
 func TestNewNotifier(t *testing.T) {
 	config := &Config{
-		BotToken: "test-token",
+		BotToken: testutil.FakeTelegramBotToken,
 		ChatID:   "123456",
 	}
 
@@ -132,7 +134,7 @@ func TestNotifierSendMessage(t *testing.T) {
 			// Note: We can't easily override the API URL in the current implementation
 			// This test verifies the method signature and basic behavior
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeTelegramBotToken,
 				ChatID:   "123456",
 			})
 
@@ -169,7 +171,7 @@ func TestNotifierSendTaskStarted(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeTelegramBotToken,
 				ChatID:   "123456",
 			})
 
@@ -205,7 +207,7 @@ func TestNotifierSendTaskCompleted(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeTelegramBotToken,
 				ChatID:   "123456",
 			})
 
@@ -240,7 +242,7 @@ func TestNotifierSendTaskFailed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeTelegramBotToken,
 				ChatID:   "123456",
 			})
 
@@ -281,7 +283,7 @@ func TestNotifierTaskProgress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeTelegramBotToken,
 				ChatID:   "123456",
 			})
 
@@ -319,7 +321,7 @@ func TestNotifierPRReady(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			notifier := NewNotifier(&Config{
-				BotToken: "test-token",
+				BotToken: testutil.FakeTelegramBotToken,
 				ChatID:   "123456",
 			})
 

--- a/internal/alerts/channels_test.go
+++ b/internal/alerts/channels_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 // =============================================================================
@@ -183,7 +185,7 @@ func TestWebhookChannel_Send_NetworkError(t *testing.T) {
 func TestWebhookChannel_Sign(t *testing.T) {
 	config := &WebhookChannelConfig{
 		URL:    "https://example.com",
-		Secret: "test-secret",
+		Secret: testutil.FakeWebhookSecret,
 	}
 
 	ch := NewWebhookChannel("test", config)
@@ -594,7 +596,7 @@ func TestPagerDutyChannel_Send(t *testing.T) {
 	// Create channel with mocked URL (we'll need to override the const)
 	ch := &PagerDutyChannel{
 		name:       "test-pd",
-		routingKey: "test-routing-key",
+		routingKey: testutil.FakePagerDutyRoutingKey,
 		serviceID:  "test-service-id",
 		client: &http.Client{
 			Timeout: 5 * time.Second,
@@ -603,8 +605,8 @@ func TestPagerDutyChannel_Send(t *testing.T) {
 
 	// We can't easily test this without modifying pagerDutyEventsAPI constant
 	// So we test the struct fields instead
-	if ch.routingKey != "test-routing-key" {
-		t.Errorf("expected routingKey 'test-routing-key', got '%s'", ch.routingKey)
+	if ch.routingKey != testutil.FakePagerDutyRoutingKey {
+		t.Errorf("expected routingKey %q, got '%s'", testutil.FakePagerDutyRoutingKey, ch.routingKey)
 	}
 	if ch.serviceID != "test-service-id" {
 		t.Errorf("expected serviceID 'test-service-id', got '%s'", ch.serviceID)

--- a/internal/gateway/auth_test.go
+++ b/internal/gateway/auth_test.go
@@ -5,12 +5,14 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 func TestNewAuthenticator(t *testing.T) {
 	config := &AuthConfig{
 		Type:  AuthTypeAPIToken,
-		Token: "test-token",
+		Token: testutil.FakeBearerToken,
 	}
 
 	auth := NewAuthenticator(config)
@@ -376,7 +378,7 @@ func TestTokenIsExpired(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			token := &Token{
-				Value:     "test-token",
+				Value:     testutil.FakeBearerToken,
 				ExpiresAt: tt.expiresAt,
 			}
 
@@ -448,7 +450,7 @@ func TestTokenHasScope(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			token := &Token{
-				Value:     "test-token",
+				Value:     testutil.FakeBearerToken,
 				ExpiresAt: time.Now().Add(1 * time.Hour),
 				Scopes:    tt.scopes,
 			}

--- a/internal/testutil/tokens.go
+++ b/internal/testutil/tokens.go
@@ -42,4 +42,16 @@ const (
 
 	// FakeBearerToken is a safe test bearer token.
 	FakeBearerToken = "test-bearer-token"
+
+	// FakeTelegramBotToken is a safe test token for Telegram bot authentication.
+	FakeTelegramBotToken = "test-telegram-bot-token"
+
+	// FakeWebhookSecret is a safe test secret for webhook signatures.
+	FakeWebhookSecret = "test-webhook-secret"
+
+	// FakePagerDutyRoutingKey is a safe test routing key for PagerDuty.
+	FakePagerDutyRoutingKey = "test-pagerduty-routing-key"
+
+	// FakeJiraAPIToken is a safe test API token for Jira.
+	FakeJiraAPIToken = "test-jira-api-token"
 )

--- a/internal/webhooks/manager_test.go
+++ b/internal/webhooks/manager_test.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
 )
 
 func TestManager_Dispatch_SingleEndpoint(t *testing.T) {
@@ -33,7 +35,7 @@ func TestManager_Dispatch_SingleEndpoint(t *testing.T) {
 				ID:      "ep_test",
 				Name:    "Test Endpoint",
 				URL:     server.URL,
-				Secret:  "test-secret",
+				Secret:  testutil.FakeWebhookSecret,
 				Events:  []EventType{EventTaskCompleted},
 				Enabled: true,
 			},
@@ -198,7 +200,7 @@ func TestManager_Sign(t *testing.T) {
 	payload := []byte(`{"type":"task.completed"}`)
 
 	// With secret
-	sig := manager.sign(payload, "test-secret")
+	sig := manager.sign(payload, testutil.FakeWebhookSecret)
 	if sig == "" {
 		t.Error("expected signature, got empty string")
 	}
@@ -215,7 +217,7 @@ func TestManager_Sign(t *testing.T) {
 
 func TestVerifySignature(t *testing.T) {
 	manager := NewManager(nil, nil)
-	secret := "test-secret"
+	secret := testutil.FakeWebhookSecret
 	payload := []byte(`{"type":"task.completed"}`)
 
 	// Generate signature


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task TASK-3334.

## Changes

TASK-45: Wire up testutil package. Read .agent/tasks/TASK-45-wire-testutil.md for requirements. Find all test files with inline fake tokens (grep for patterns like 'fake.*token', 'test.*key', 'mock.*secret') and replace them with constants from internal/testutil/tokens.go. Add any missing token constants to testutil. This is a refactoring task - all tests must still pass after the changes.