### PR TITLE
Feature: Sequential execution mode - wait for PR merge before next issue

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -29,10 +29,28 @@ adapters:
     bot_token: "${SLACK_BOT_TOKEN}"
     channel: "#dev-notifications"
 
+  # GitHub - Issue polling and PR creation
+  github:
+    enabled: false
+    token: "${GITHUB_TOKEN}"
+    repo: "owner/repo"           # Repository to poll for issues
+    pilot_label: "pilot"         # Issues with this label are picked up
+    polling:
+      enabled: true
+      interval: 30s              # How often to check for new issues
+      label: "pilot"             # Label to watch for
+
 # Orchestrator settings
 orchestrator:
   model: "claude-sonnet-4-20250514"
   max_concurrent: 2          # Max parallel tasks
+
+  # Execution mode settings (GH-92)
+  execution:
+    mode: "sequential"       # "sequential" (default) or "parallel"
+    wait_for_merge: true     # Wait for PR merge before next task (sequential only)
+    poll_interval: 30s       # How often to check PR status
+    pr_timeout: 1h           # Max time to wait for PR merge (0 = no timeout)
 
   # Daily brief
   daily_brief:

--- a/internal/adapters/github/merger.go
+++ b/internal/adapters/github/merger.go
@@ -1,0 +1,283 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// MergeWaitResult contains the result of waiting for a PR merge
+type MergeWaitResult struct {
+	Merged      bool
+	Closed      bool
+	Conflict    bool
+	TimedOut    bool
+	PRNumber    int
+	MergeCommit string
+	Error       error
+}
+
+// MergeWaiterConfig configures the PR merge waiter
+type MergeWaiterConfig struct {
+	// PollInterval is how often to check PR status (default: 30s)
+	PollInterval time.Duration
+	// Timeout is max time to wait for merge (0 = no timeout)
+	Timeout time.Duration
+	// OnStatusChange is called when PR status changes
+	OnStatusChange func(status *PRStatus)
+}
+
+// DefaultMergeWaiterConfig returns default merge waiter settings
+func DefaultMergeWaiterConfig() *MergeWaiterConfig {
+	return &MergeWaiterConfig{
+		PollInterval: 30 * time.Second,
+		Timeout:      1 * time.Hour,
+	}
+}
+
+// MergeWaiter polls a PR until it's merged, closed, or times out
+type MergeWaiter struct {
+	client *Client
+	owner  string
+	repo   string
+	config *MergeWaiterConfig
+	logger *slog.Logger
+}
+
+// NewMergeWaiter creates a new PR merge waiter
+func NewMergeWaiter(client *Client, owner, repo string, config *MergeWaiterConfig) *MergeWaiter {
+	if config == nil {
+		config = DefaultMergeWaiterConfig()
+	}
+	return &MergeWaiter{
+		client: client,
+		owner:  owner,
+		repo:   repo,
+		config: config,
+		logger: logging.WithComponent("merge-waiter"),
+	}
+}
+
+// ErrPRClosed is returned when PR is closed without merge
+var ErrPRClosed = errors.New("PR was closed without merge")
+
+// ErrPRConflict is returned when PR has merge conflicts
+var ErrPRConflict = errors.New("PR has merge conflicts")
+
+// ErrPRTimeout is returned when PR merge times out
+var ErrPRTimeout = errors.New("PR merge timed out")
+
+// WaitForMerge waits for a PR to be merged
+// Returns nil on successful merge, or an error if closed/conflict/timeout
+func (w *MergeWaiter) WaitForMerge(ctx context.Context, prNumber int) (*MergeWaitResult, error) {
+	w.logger.Info("Waiting for PR merge",
+		slog.Int("pr", prNumber),
+		slog.String("repo", w.owner+"/"+w.repo),
+		slog.Duration("poll_interval", w.config.PollInterval),
+		slog.Duration("timeout", w.config.Timeout),
+	)
+
+	result := &MergeWaitResult{PRNumber: prNumber}
+
+	// Set up timeout if configured
+	var cancel context.CancelFunc
+	if w.config.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, w.config.Timeout)
+		defer cancel()
+	}
+
+	ticker := time.NewTicker(w.config.PollInterval)
+	defer ticker.Stop()
+
+	// Check immediately before first tick
+	status, err := w.checkStatus(ctx, prNumber)
+	if err != nil {
+		result.Error = err
+		return result, err
+	}
+	if done, err := w.handleStatus(status, result); done {
+		return result, err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.DeadlineExceeded {
+				w.logger.Warn("PR merge wait timed out",
+					slog.Int("pr", prNumber),
+					slog.Duration("timeout", w.config.Timeout),
+				)
+				result.TimedOut = true
+				result.Error = ErrPRTimeout
+				return result, ErrPRTimeout
+			}
+			result.Error = ctx.Err()
+			return result, ctx.Err()
+
+		case <-ticker.C:
+			status, err := w.checkStatus(ctx, prNumber)
+			if err != nil {
+				// Log but continue polling - transient errors are OK
+				w.logger.Warn("Failed to check PR status",
+					slog.Int("pr", prNumber),
+					slog.Any("error", err),
+				)
+				continue
+			}
+
+			if done, err := w.handleStatus(status, result); done {
+				return result, err
+			}
+		}
+	}
+}
+
+// checkStatus fetches current PR status
+func (w *MergeWaiter) checkStatus(ctx context.Context, prNumber int) (*PRStatus, error) {
+	return w.client.GetPRStatus(ctx, w.owner, w.repo, prNumber)
+}
+
+// handleStatus processes PR status and returns (done, error)
+func (w *MergeWaiter) handleStatus(status *PRStatus, result *MergeWaitResult) (bool, error) {
+	// Notify callback if configured
+	if w.config.OnStatusChange != nil {
+		w.config.OnStatusChange(status)
+	}
+
+	switch status.State {
+	case PRStateMerged:
+		w.logger.Info("PR merged",
+			slog.Int("pr", status.Number),
+		)
+		result.Merged = true
+		result.MergeCommit = status.MergeCommit
+		return true, nil
+
+	case PRStateClosed:
+		w.logger.Warn("PR closed without merge",
+			slog.Int("pr", status.Number),
+		)
+		result.Closed = true
+		result.Error = ErrPRClosed
+		return true, ErrPRClosed
+
+	case PRStateConflict:
+		w.logger.Warn("PR has merge conflicts",
+			slog.Int("pr", status.Number),
+		)
+		result.Conflict = true
+		result.Error = ErrPRConflict
+		return true, ErrPRConflict
+
+	case PRStateOpen:
+		w.logger.Debug("PR still open, waiting...",
+			slog.Int("pr", status.Number),
+		)
+		return false, nil
+
+	default:
+		w.logger.Debug("PR in unknown state, waiting...",
+			slog.Int("pr", status.Number),
+			slog.String("state", string(status.State)),
+		)
+		return false, nil
+	}
+}
+
+// WaitForMergeByBranch finds PR by branch and waits for merge
+func (w *MergeWaiter) WaitForMergeByBranch(ctx context.Context, branch string) (*MergeWaitResult, error) {
+	// Find PR by branch
+	pr, err := w.client.FindPRByBranch(ctx, w.owner, w.repo, branch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find PR for branch %s: %w", branch, err)
+	}
+	if pr == nil {
+		return nil, fmt.Errorf("no PR found for branch %s", branch)
+	}
+
+	return w.WaitForMerge(ctx, pr.Number)
+}
+
+// PRWatcherStatus represents the final status of a PR watch
+type PRWatcherStatus string
+
+const (
+	PRStatusMerged   PRWatcherStatus = "merged"
+	PRStatusClosed   PRWatcherStatus = "closed"
+	PRStatusConflict PRWatcherStatus = "conflict"
+	PRStatusTimeout  PRWatcherStatus = "timeout"
+	PRStatusError    PRWatcherStatus = "error"
+)
+
+// PRWatchResult is the result of watching a PR for merge
+type PRWatchResult struct {
+	Status       PRWatcherStatus
+	WaitDuration time.Duration
+	Error        error
+}
+
+// PRWatcher watches a PR for merge/close/conflict
+type PRWatcher struct {
+	client       *Client
+	owner        string
+	repo         string
+	pollInterval time.Duration
+	timeout      time.Duration
+	logger       *slog.Logger
+}
+
+// NewPRWatcher creates a new PR watcher
+func NewPRWatcher(client *Client, owner, repo string, pollInterval, timeout time.Duration) *PRWatcher {
+	if pollInterval == 0 {
+		pollInterval = 30 * time.Second
+	}
+	if timeout == 0 {
+		timeout = 1 * time.Hour
+	}
+	return &PRWatcher{
+		client:       client,
+		owner:        owner,
+		repo:         repo,
+		pollInterval: pollInterval,
+		timeout:      timeout,
+		logger:       logging.WithComponent("pr-watcher"),
+	}
+}
+
+// WaitForMerge waits for a PR to be merged, closed, or timeout
+func (w *PRWatcher) WaitForMerge(ctx context.Context, prNumber int) *PRWatchResult {
+	startTime := time.Now()
+
+	waiter := NewMergeWaiter(w.client, w.owner, w.repo, &MergeWaiterConfig{
+		PollInterval: w.pollInterval,
+		Timeout:      w.timeout,
+	})
+
+	result, err := waiter.WaitForMerge(ctx, prNumber)
+	duration := time.Since(startTime)
+
+	if err != nil {
+		switch {
+		case result != nil && result.Merged:
+			return &PRWatchResult{Status: PRStatusMerged, WaitDuration: duration}
+		case result != nil && result.Closed:
+			return &PRWatchResult{Status: PRStatusClosed, WaitDuration: duration}
+		case result != nil && result.Conflict:
+			return &PRWatchResult{Status: PRStatusConflict, WaitDuration: duration}
+		case result != nil && result.TimedOut:
+			return &PRWatchResult{Status: PRStatusTimeout, WaitDuration: duration, Error: err}
+		default:
+			return &PRWatchResult{Status: PRStatusError, WaitDuration: duration, Error: err}
+		}
+	}
+
+	if result.Merged {
+		return &PRWatchResult{Status: PRStatusMerged, WaitDuration: duration}
+	}
+
+	return &PRWatchResult{Status: PRStatusError, WaitDuration: duration}
+}

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -4,12 +4,33 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/alekspetrov/pilot/internal/logging"
 )
+
+// ExecutionMode determines how tasks are executed
+type ExecutionMode string
+
+const (
+	// ExecutionModeSequential processes one issue at a time, waiting for PR merge
+	ExecutionModeSequential ExecutionMode = "sequential"
+	// ExecutionModeParallel processes issues as they arrive (legacy behavior)
+	ExecutionModeParallel ExecutionMode = "parallel"
+)
+
+// SequentialConfig configures sequential execution mode
+type SequentialConfig struct {
+	// WaitForMerge waits for PR to be merged before next task
+	WaitForMerge bool
+	// PollInterval is how often to check PR status
+	PollInterval time.Duration
+	// PRTimeout is max time to wait for PR merge (0 = no timeout)
+	PRTimeout time.Duration
+}
 
 // Poller polls GitHub for issues with a specific label
 type Poller struct {
@@ -22,6 +43,11 @@ type Poller struct {
 	mu        sync.RWMutex
 	onIssue   func(ctx context.Context, issue *Issue) error
 	logger    *slog.Logger
+
+	// Sequential mode settings
+	mode             ExecutionMode
+	sequentialConfig *SequentialConfig
+	onPRStatus       func(prNumber int, status *PRStatus)
 }
 
 // PollerOption configures a Poller
@@ -41,6 +67,30 @@ func WithOnIssue(fn func(ctx context.Context, issue *Issue) error) PollerOption 
 	}
 }
 
+// WithExecutionMode sets the execution mode (sequential or parallel)
+func WithExecutionMode(mode ExecutionMode) PollerOption {
+	return func(p *Poller) {
+		p.mode = mode
+	}
+}
+
+// WithSequentialConfig sets the sequential mode configuration
+func WithSequentialConfig(config *SequentialConfig) PollerOption {
+	return func(p *Poller) {
+		p.sequentialConfig = config
+		if config != nil {
+			p.mode = ExecutionModeSequential
+		}
+	}
+}
+
+// WithOnPRStatus sets the callback for PR status updates during sequential mode
+func WithOnPRStatus(fn func(prNumber int, status *PRStatus)) PollerOption {
+	return func(p *Poller) {
+		p.onPRStatus = fn
+	}
+}
+
 // NewPoller creates a new GitHub issue poller
 func NewPoller(client *Client, repo string, label string, interval time.Duration, opts ...PollerOption) (*Poller, error) {
 	parts := strings.Split(repo, "/")
@@ -56,6 +106,7 @@ func NewPoller(client *Client, repo string, label string, interval time.Duration
 		interval:  interval,
 		processed: make(map[int]bool),
 		logger:    logging.WithComponent("github-poller"),
+		mode:      ExecutionModeSequential, // Default to sequential
 	}
 
 	for _, opt := range opts {
@@ -71,8 +122,111 @@ func (p *Poller) Start(ctx context.Context) {
 		slog.String("repo", p.owner+"/"+p.repo),
 		slog.String("label", p.label),
 		slog.Duration("interval", p.interval),
+		slog.String("mode", string(p.mode)),
 	)
 
+	if p.mode == ExecutionModeSequential {
+		p.startSequential(ctx)
+	} else {
+		p.startParallel(ctx)
+	}
+}
+
+// startSequential runs in sequential mode - one issue at a time, waiting for PR merge
+func (p *Poller) startSequential(ctx context.Context) {
+	p.logger.Info("Running in sequential mode - will wait for PR merge before next issue")
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("GitHub poller stopped")
+			return
+		default:
+			// Find oldest unprocessed issue
+			issue := p.findOldestUnprocessedIssue(ctx)
+			if issue == nil {
+				// No issues to process, wait and try again
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(p.interval):
+					continue
+				}
+			}
+
+			// Process the issue (task execution + PR creation)
+			p.logger.Info("Processing issue in sequential mode",
+				slog.Int("number", issue.Number),
+				slog.String("title", issue.Title),
+			)
+
+			prNumber, err := p.processIssueSequential(ctx, issue)
+			if err != nil {
+				p.logger.Error("Failed to process issue",
+					slog.Int("number", issue.Number),
+					slog.Any("error", err),
+				)
+				// Mark as processed to avoid retry loop
+				p.markProcessed(issue.Number)
+				continue
+			}
+
+			// If PR was created and we should wait for merge
+			if prNumber > 0 && p.sequentialConfig != nil && p.sequentialConfig.WaitForMerge {
+				p.logger.Info("Waiting for PR merge before next issue",
+					slog.Int("pr", prNumber),
+					slog.Int("issue", issue.Number),
+				)
+
+				waiter := NewMergeWaiter(p.client, p.owner, p.repo, &MergeWaiterConfig{
+					PollInterval: p.sequentialConfig.PollInterval,
+					Timeout:      p.sequentialConfig.PRTimeout,
+					OnStatusChange: func(status *PRStatus) {
+						if p.onPRStatus != nil {
+							p.onPRStatus(prNumber, status)
+						}
+					},
+				})
+
+				result, err := waiter.WaitForMerge(ctx, prNumber)
+				if err != nil {
+					p.logger.Warn("PR merge wait ended with error",
+						slog.Int("pr", prNumber),
+						slog.Any("error", err),
+					)
+					// Handle different error cases
+					switch {
+					case result != nil && result.Closed:
+						p.logger.Warn("PR was closed without merge - marking issue for re-review",
+							slog.Int("pr", prNumber),
+							slog.Int("issue", issue.Number),
+						)
+					case result != nil && result.Conflict:
+						p.logger.Warn("PR has merge conflicts - needs manual resolution",
+							slog.Int("pr", prNumber),
+							slog.Int("issue", issue.Number),
+						)
+					case result != nil && result.TimedOut:
+						p.logger.Warn("PR merge wait timed out - continuing with next issue",
+							slog.Int("pr", prNumber),
+							slog.Int("issue", issue.Number),
+						)
+					}
+				} else {
+					p.logger.Info("PR merged successfully, proceeding to next issue",
+						slog.Int("pr", prNumber),
+						slog.Int("issue", issue.Number),
+					)
+				}
+			}
+
+			p.markProcessed(issue.Number)
+		}
+	}
+}
+
+// startParallel runs in parallel mode (legacy behavior)
+func (p *Poller) startParallel(ctx context.Context) {
 	// Do an initial check immediately
 	p.checkForNewIssues(ctx)
 
@@ -88,6 +242,75 @@ func (p *Poller) Start(ctx context.Context) {
 			p.checkForNewIssues(ctx)
 		}
 	}
+}
+
+// findOldestUnprocessedIssue finds the oldest issue with the pilot label that hasn't been processed
+func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) *Issue {
+	issues, err := p.client.ListIssues(ctx, p.owner, p.repo, &ListIssuesOptions{
+		Labels: []string{p.label},
+		State:  StateOpen,
+		Sort:   "created", // Sort by creation date
+	})
+	if err != nil {
+		p.logger.Warn("Failed to fetch issues", slog.Any("error", err))
+		return nil
+	}
+
+	// Sort by creation date (oldest first)
+	sort.Slice(issues, func(i, j int) bool {
+		return issues[i].CreatedAt.Before(issues[j].CreatedAt)
+	})
+
+	for _, issue := range issues {
+		// Skip if already processed
+		p.mu.RLock()
+		processed := p.processed[issue.Number]
+		p.mu.RUnlock()
+
+		if processed {
+			continue
+		}
+
+		// Skip if already in progress or done
+		if HasLabel(issue, LabelInProgress) || HasLabel(issue, LabelDone) {
+			p.markProcessed(issue.Number)
+			continue
+		}
+
+		return issue
+	}
+
+	return nil
+}
+
+// processIssueSequential processes an issue and returns the PR number if one was created
+func (p *Poller) processIssueSequential(ctx context.Context, issue *Issue) (int, error) {
+	if p.onIssue == nil {
+		return 0, nil
+	}
+
+	// Call the issue handler
+	if err := p.onIssue(ctx, issue); err != nil {
+		return 0, err
+	}
+
+	// Try to find the PR that was created for this issue
+	// Convention: branch name is pilot/GH-<issue_number>
+	branchName := fmt.Sprintf("pilot/GH-%d", issue.Number)
+	pr, err := p.client.FindPRByBranch(ctx, p.owner, p.repo, branchName)
+	if err != nil {
+		p.logger.Debug("Could not find PR for branch",
+			slog.String("branch", branchName),
+			slog.Any("error", err),
+		)
+		return 0, nil // Not an error - PR might not have been created
+	}
+
+	if pr != nil {
+		return pr.Number, nil
+	}
+
+	return 0, nil
 }
 
 // checkForNewIssues fetches issues and processes new ones


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-92.

## Changes

GitHub Issue #92: Feature: Sequential execution mode - wait for PR merge before next issue

## Problem

Pilot creates PRs faster than they can be merged, causing cascading conflicts:

1. Pilot picks up GH-57, 58, 61, 62... (multiple issues)
2. Creates PRs for each in parallel
3. User merges PR #1
4. PRs #2-8 now have conflicts
5. Must close all, restart - wasted work

**Observed:** 8 PRs all conflicting after merging first one.

## Solution: Sequential Execution Mode

Pilot should work on **ONE issue at a time** and wait for PR merge before picking up next.

### Behavior

```
1. Poll GitHub → Find issue with `pilot` label
2. Pick OLDEST issue (by creation date)
3. Add `pilot-in-progress` label
4. Execute task → Create PR
5. **WAIT** for PR merge (poll PR status)
6. On merge → Remove labels, close issue
7. Go to step 1
```

### Config

```yaml
execution:
  mode: sequential  # default: sequential | parallel
  wait_for_merge: true
  poll_interval: 30s  # How often to check PR status
```

### CLI Flag

```bash
pilot start --sequential  # Force sequential even if config says parallel
pilot start --parallel    # Force parallel (old behavior)
```

### PR Status Polling

```go
// After creating PR, poll until merged
for {
    pr, _ := client.GetPR(prNumber)
    switch pr.State {
    case "merged":
        return nil  // Success, pick next issue
    case "closed":
        return ErrPRClosed  // PR rejected, mark issue failed
    case "open":
        if pr.Mergeable == "CONFLICTING" {
            // Auto-rebase or notify user
        }
        time.Sleep(pollInterval)
    }
}
```

## Benefits

- **Zero conflicts** - Only one branch active at a time
- **Cleaner history** - Sequential commits on main
- **Predictable** - User knows exactly what's being worked on
- **Reviewable** - Time to review each PR before next starts

## Acceptance Criteria

- [ ] `execution.mode: sequential` in config
- [ ] Pilot waits for PR merge before next issue
- [ ] PR status polling with configurable interval
- [ ] `--sequential` / `--parallel` CLI flags
- [ ] Handle PR closed (rejected) case
- [ ] Handle PR conflicts (notify or auto-rebase)
- [ ] Timeout for stuck PRs (configurable, default 1h)