### PR TITLE
Fix: Github → GitHub naming convention (19+ usages)

### DIFF
--- a/cmd/pilot/config_cmd.go
+++ b/cmd/pilot/config_cmd.go
@@ -206,9 +206,9 @@ func newConfigValidateCmd() *cobra.Command {
 						warnings = append(warnings, "Slack enabled but bot_token not set")
 					}
 				}
-				if cfg.Adapters.Github != nil && cfg.Adapters.Github.Enabled {
+				if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
 					hasAdapter = true
-					if cfg.Adapters.Github.Token == "" && os.Getenv("GITHUB_TOKEN") == "" {
+					if cfg.Adapters.GitHub.Token == "" && os.Getenv("GITHUB_TOKEN") == "" {
 						warnings = append(warnings, "GitHub enabled but token not set")
 					}
 				}

--- a/cmd/pilot/interactive.go
+++ b/cmd/pilot/interactive.go
@@ -394,7 +394,7 @@ func interactiveStatus(cfg *config.Config) error {
 	if cfg.Adapters.Slack != nil && cfg.Adapters.Slack.Enabled {
 		fmt.Println("    + Slack")
 	}
-	if cfg.Adapters.Github != nil && cfg.Adapters.Github.Enabled {
+	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
 		fmt.Println("    + GitHub")
 	}
 	fmt.Println()

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -153,8 +153,8 @@ Examples:
 
 			// Determine mode based on what's enabled
 			hasTelegram := cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled
-			hasGithubPolling := cfg.Adapters.Github != nil && cfg.Adapters.Github.Enabled &&
-				cfg.Adapters.Github.Polling != nil && cfg.Adapters.Github.Polling.Enabled
+			hasGithubPolling := cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled &&
+				cfg.Adapters.GitHub.Polling != nil && cfg.Adapters.GitHub.Polling.Enabled
 			hasLinear := cfg.Adapters.Linear != nil && cfg.Adapters.Linear.Enabled
 			hasJira := cfg.Adapters.Jira != nil && cfg.Adapters.Jira.Enabled
 
@@ -277,14 +277,14 @@ func applyInputOverrides(cfg *config.Config, telegramFlag, githubFlag, linearFla
 		cfg.Adapters.Telegram.Polling = *telegramFlag
 	}
 	if githubFlag != nil {
-		if cfg.Adapters.Github == nil {
-			cfg.Adapters.Github = github.DefaultConfig()
+		if cfg.Adapters.GitHub == nil {
+			cfg.Adapters.GitHub = github.DefaultConfig()
 		}
-		cfg.Adapters.Github.Enabled = *githubFlag
-		if cfg.Adapters.Github.Polling == nil {
-			cfg.Adapters.Github.Polling = &github.PollingConfig{}
+		cfg.Adapters.GitHub.Enabled = *githubFlag
+		if cfg.Adapters.GitHub.Polling == nil {
+			cfg.Adapters.GitHub.Polling = &github.PollingConfig{}
 		}
-		cfg.Adapters.Github.Polling.Enabled = *githubFlag
+		cfg.Adapters.GitHub.Polling.Enabled = *githubFlag
 	}
 	if linearFlag != nil {
 		if cfg.Adapters.Linear == nil {
@@ -391,21 +391,21 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 
 	// Start GitHub polling if enabled
 	var ghPoller *github.Poller
-	if cfg.Adapters.Github != nil && cfg.Adapters.Github.Enabled &&
-		cfg.Adapters.Github.Polling != nil && cfg.Adapters.Github.Polling.Enabled {
+	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled &&
+		cfg.Adapters.GitHub.Polling != nil && cfg.Adapters.GitHub.Polling.Enabled {
 
-		token := cfg.Adapters.Github.Token
+		token := cfg.Adapters.GitHub.Token
 		if token == "" {
 			token = os.Getenv("GITHUB_TOKEN")
 		}
 
-		if token != "" && cfg.Adapters.Github.Repo != "" {
+		if token != "" && cfg.Adapters.GitHub.Repo != "" {
 			client := github.NewClient(token)
-			label := cfg.Adapters.Github.Polling.Label
+			label := cfg.Adapters.GitHub.Polling.Label
 			if label == "" {
-				label = cfg.Adapters.Github.PilotLabel
+				label = cfg.Adapters.GitHub.PilotLabel
 			}
-			interval := cfg.Adapters.Github.Polling.Interval
+			interval := cfg.Adapters.GitHub.Polling.Interval
 			if interval == 0 {
 				interval = 30 * time.Second
 			}
@@ -451,7 +451,7 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 			}
 
 			var err error
-			ghPoller, err = github.NewPoller(client, cfg.Adapters.Github.Repo, label, interval, pollerOpts...)
+			ghPoller, err = github.NewPoller(client, cfg.Adapters.GitHub.Repo, label, interval, pollerOpts...)
 			if err != nil {
 				fmt.Printf("⚠️  GitHub polling disabled: %v\n", err)
 			} else {
@@ -459,7 +459,7 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 				if execMode == github.ExecutionModeParallel {
 					modeStr = "parallel"
 				}
-				fmt.Printf("🐙 GitHub polling enabled: %s (every %s, mode: %s)\n", cfg.Adapters.Github.Repo, interval, modeStr)
+				fmt.Printf("🐙 GitHub polling enabled: %s (every %s, mode: %s)\n", cfg.Adapters.GitHub.Repo, interval, modeStr)
 				if execMode == github.ExecutionModeSequential && waitForMerge {
 					fmt.Printf("   ⏳ Sequential mode: waiting for PR merge before next issue (timeout: %s)\n", prTimeout)
 				}
@@ -500,7 +500,7 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 func handleGitHubIssue(ctx context.Context, cfg *config.Config, client *github.Client, issue *github.Issue, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner) error {
 	fmt.Printf("\n📥 GitHub Issue #%d: %s\n", issue.Number, issue.Title)
 
-	parts := strings.Split(cfg.Adapters.Github.Repo, "/")
+	parts := strings.Split(cfg.Adapters.GitHub.Repo, "/")
 	if len(parts) == 2 {
 		_ = client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelInProgress})
 	}
@@ -574,7 +574,7 @@ func handleGitHubIssue(ctx context.Context, cfg *config.Config, client *github.C
 func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client *github.Client, issue *github.Issue, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner) (*github.IssueResult, error) {
 	fmt.Printf("\n📥 GitHub Issue #%d: %s\n", issue.Number, issue.Title)
 
-	parts := strings.Split(cfg.Adapters.Github.Repo, "/")
+	parts := strings.Split(cfg.Adapters.GitHub.Repo, "/")
 	if len(parts) == 2 {
 		_ = client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelInProgress})
 	}
@@ -697,7 +697,7 @@ func newStatusCmd() *cobra.Command {
 						"linear":   cfg.Adapters.Linear != nil && cfg.Adapters.Linear.Enabled,
 						"slack":    cfg.Adapters.Slack != nil && cfg.Adapters.Slack.Enabled,
 						"telegram": cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled,
-						"github":   cfg.Adapters.Github != nil && cfg.Adapters.Github.Enabled,
+						"github":   cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled,
 						"jira":     cfg.Adapters.Jira != nil && cfg.Adapters.Jira.Enabled,
 					},
 					"projects": cfg.Projects,
@@ -733,7 +733,7 @@ func newStatusCmd() *cobra.Command {
 			} else {
 				fmt.Println("  ○ Telegram (disabled)")
 			}
-			if cfg.Adapters.Github != nil && cfg.Adapters.Github.Enabled {
+			if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
 				fmt.Println("  ✓ GitHub (enabled)")
 			} else {
 				fmt.Println("  ○ GitHub (disabled)")
@@ -1274,11 +1274,11 @@ Examples:
 			}
 
 			// Check GitHub is configured
-			if cfg.Adapters == nil || cfg.Adapters.Github == nil || !cfg.Adapters.Github.Enabled {
+			if cfg.Adapters == nil || cfg.Adapters.GitHub == nil || !cfg.Adapters.GitHub.Enabled {
 				return fmt.Errorf("GitHub adapter not enabled. Run 'pilot setup' or edit ~/.pilot/config.yaml")
 			}
 
-			token := cfg.Adapters.Github.Token
+			token := cfg.Adapters.GitHub.Token
 			if token == "" {
 				token = os.Getenv("GITHUB_TOKEN")
 			}
@@ -1288,7 +1288,7 @@ Examples:
 
 			// Determine repo
 			if repo == "" {
-				repo = cfg.Adapters.Github.Repo
+				repo = cfg.Adapters.GitHub.Repo
 			}
 			if repo == "" {
 				return fmt.Errorf("no repository specified. Use --repo owner/repo or set in config")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,7 +54,7 @@ type AdaptersConfig struct {
 	Linear   *linear.Config   `yaml:"linear"`
 	Slack    *slack.Config    `yaml:"slack"`
 	Telegram *telegram.Config `yaml:"telegram"`
-	Github   *github.Config   `yaml:"github"`
+	GitHub   *github.Config   `yaml:"github"`
 	Jira     *jira.Config     `yaml:"jira"`
 }
 
@@ -249,7 +249,7 @@ func DefaultConfig() *Config {
 			Linear:   linear.DefaultConfig(),
 			Slack:    slack.DefaultConfig(),
 			Telegram: telegram.DefaultConfig(),
-			Github:   github.DefaultConfig(),
+			GitHub:   github.DefaultConfig(),
 			Jira:     jira.DefaultConfig(),
 		},
 		Orchestrator: &OrchestratorConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -56,8 +56,8 @@ func TestDefaultConfig(t *testing.T) {
 		if config.Adapters.Telegram == nil {
 			t.Error("Adapters.Telegram is nil")
 		}
-		if config.Adapters.Github == nil {
-			t.Error("Adapters.Github is nil")
+		if config.Adapters.GitHub == nil {
+			t.Error("Adapters.GitHub is nil")
 		}
 		if config.Adapters.Jira == nil {
 			t.Error("Adapters.Jira is nil")

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -97,15 +97,15 @@ func New(cfg *config.Config) (*Pilot, error) {
 	}
 
 	// Initialize GitHub adapter if enabled
-	if cfg.Adapters.Github != nil && cfg.Adapters.Github.Enabled {
-		p.githubClient = github.NewClient(cfg.Adapters.Github.Token)
+	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
+		p.githubClient = github.NewClient(cfg.Adapters.GitHub.Token)
 		p.githubWH = github.NewWebhookHandler(
 			p.githubClient,
-			cfg.Adapters.Github.WebhookSecret,
-			cfg.Adapters.Github.PilotLabel,
+			cfg.Adapters.GitHub.WebhookSecret,
+			cfg.Adapters.GitHub.PilotLabel,
 		)
 		p.githubWH.OnIssue(p.handleGithubIssue)
-		p.githubNotify = github.NewNotifier(p.githubClient, cfg.Adapters.Github.PilotLabel)
+		p.githubNotify = github.NewNotifier(p.githubClient, cfg.Adapters.GitHub.PilotLabel)
 	}
 
 	// Initialize alerts engine if enabled
@@ -238,7 +238,7 @@ func (p *Pilot) GetStatus() map[string]interface{} {
 		"config": map[string]interface{}{
 			"gateway":  fmt.Sprintf("%s:%d", p.config.Gateway.Host, p.config.Gateway.Port),
 			"linear":   p.config.Adapters.Linear != nil && p.config.Adapters.Linear.Enabled,
-			"github":   p.config.Adapters.Github != nil && p.config.Adapters.Github.Enabled,
+			"github":   p.config.Adapters.GitHub != nil && p.config.Adapters.GitHub.Enabled,
 			"slack":    p.config.Adapters.Slack != nil && p.config.Adapters.Slack.Enabled,
 			"webhooks": p.webhookManager.IsEnabled(),
 		},


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-61.

## Changes

GitHub Issue #61: Fix: Github → GitHub naming convention (19+ usages)

## Problem

Inconsistent naming violates Go conventions for acronyms:

**Config field:** `Github *github.Config` (should be `GitHub`)
**Type name:** `ProjectGitHubConfig` (correct)
**Usage:** `cfg.Adapters.Github` (19 occurrences in main.go)

## Files

- `internal/config/config.go:56` - struct field definition
- `cmd/pilot/main.go` - 19+ usages of `cfg.Adapters.Github`

## Solution

1. Rename `Github` → `GitHub` in config struct
2. Update all 19+ usages in main.go
3. Update YAML tag if needed: `yaml:"github"`

## Acceptance Criteria

- [ ] Config struct uses `GitHub` (capital H)
- [ ] All usages updated
- [ ] Tests pass
- [ ] YAML config still works (tag unchanged)