### PR TITLE
Fix: GlobalPatternStore deadlock (blocks all pattern learning)

### DIFF
--- a/internal/executor/alerts.go
+++ b/internal/executor/alerts.go
@@ -32,4 +32,5 @@ const (
 	AlertEventTypeTaskProgress  AlertEventType = "task_progress"
 	AlertEventTypeTaskCompleted AlertEventType = "task_completed"
 	AlertEventTypeTaskFailed    AlertEventType = "task_failed"
+	AlertEventTypeTaskRetry     AlertEventType = "task_retry"
 )

--- a/internal/memory/graph_test.go
+++ b/internal/memory/graph_test.go
@@ -6,10 +6,6 @@ import (
 )
 
 func TestNewKnowledgeGraph(t *testing.T) {
-	// The KnowledgeGraph has the same deadlock bug as GlobalPatternStore
-	// Add() holds Lock() then calls save() which tries RLock()
-	// Skip tests that trigger Add()
-
 	t.Run("create new graph in empty directory", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "kg-test-*")
 		if err != nil {
@@ -29,34 +25,228 @@ func TestNewKnowledgeGraph(t *testing.T) {
 	})
 
 	t.Run("load existing graph", func(t *testing.T) {
-		// Skip: triggers deadlock through Add()
-		t.Skip("Skipping due to known deadlock in KnowledgeGraph.Add()")
+		tmpDir, err := os.MkdirTemp("", "kg-test-*")
+		if err != nil {
+			t.Fatalf("failed to create temp dir: %v", err)
+		}
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		// Create and populate a graph
+		kg1, err := NewKnowledgeGraph(tmpDir)
+		if err != nil {
+			t.Fatalf("failed to create first graph: %v", err)
+		}
+
+		node := &GraphNode{
+			ID:      "test-node",
+			Type:    "pattern",
+			Title:   "Test Node",
+			Content: "Test content",
+		}
+		if err := kg1.Add(node); err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+
+		// Load a new graph from the same path
+		kg2, err := NewKnowledgeGraph(tmpDir)
+		if err != nil {
+			t.Fatalf("failed to load existing graph: %v", err)
+		}
+
+		if kg2.Count() != 1 {
+			t.Errorf("loaded graph Count() = %d, want 1", kg2.Count())
+		}
 	})
 }
 
 func TestKnowledgeGraph_AddAndGet(t *testing.T) {
-	// Skip: Production code has a deadlock bug in KnowledgeGraph.Add()
-	t.Skip("Skipping due to known deadlock in KnowledgeGraph.Add()")
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	kg, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	node := &GraphNode{
+		ID:      "test-add",
+		Type:    "learning",
+		Title:   "Test Learning",
+		Content: "This is a test learning node",
+	}
+
+	if err := kg.Add(node); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	got, ok := kg.Get("test-add")
+	if !ok {
+		t.Fatal("Get() returned ok=false, want true")
+	}
+
+	if got.Title != "Test Learning" {
+		t.Errorf("Get().Title = %q, want %q", got.Title, "Test Learning")
+	}
+
+	if got.CreatedAt.IsZero() {
+		t.Error("CreatedAt should be set")
+	}
 }
 
 func TestKnowledgeGraph_Search(t *testing.T) {
-	// Skip: Production code has a deadlock bug in KnowledgeGraph.Add()
-	t.Skip("Skipping due to known deadlock in KnowledgeGraph.Add()")
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	kg, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	nodes := []*GraphNode{
+		{ID: "n1", Type: "pattern", Title: "Error Handling", Content: "How to handle errors"},
+		{ID: "n2", Type: "pattern", Title: "Logging Best Practices", Content: "Structured logging"},
+		{ID: "n3", Type: "learning", Title: "Testing Strategies", Content: "Error handling in tests"},
+	}
+
+	for _, n := range nodes {
+		if err := kg.Add(n); err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+	}
+
+	// Search by title
+	results := kg.Search("Error")
+	if len(results) != 2 {
+		t.Errorf("Search('Error') returned %d results, want 2", len(results))
+	}
+
+	// Search by content
+	results = kg.Search("structured")
+	if len(results) != 1 {
+		t.Errorf("Search('structured') returned %d results, want 1", len(results))
+	}
+
+	// Search by type
+	results = kg.Search("learning")
+	if len(results) != 1 {
+		t.Errorf("Search('learning') returned %d results, want 1", len(results))
+	}
 }
 
 func TestKnowledgeGraph_GetByType(t *testing.T) {
-	// Skip: Production code has a deadlock bug in KnowledgeGraph.Add()
-	t.Skip("Skipping due to known deadlock in KnowledgeGraph.Add()")
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	kg, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	nodes := []*GraphNode{
+		{ID: "p1", Type: "pattern", Title: "Pattern 1"},
+		{ID: "p2", Type: "pattern", Title: "Pattern 2"},
+		{ID: "l1", Type: "learning", Title: "Learning 1"},
+	}
+
+	for _, n := range nodes {
+		if err := kg.Add(n); err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+	}
+
+	patterns := kg.GetByType("pattern")
+	if len(patterns) != 2 {
+		t.Errorf("GetByType('pattern') returned %d results, want 2", len(patterns))
+	}
+
+	learnings := kg.GetByType("learning")
+	if len(learnings) != 1 {
+		t.Errorf("GetByType('learning') returned %d results, want 1", len(learnings))
+	}
 }
 
 func TestKnowledgeGraph_GetRelated(t *testing.T) {
-	// Skip: Production code has a deadlock bug in KnowledgeGraph.Add()
-	t.Skip("Skipping due to known deadlock in KnowledgeGraph.Add()")
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	kg, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	// Add nodes with relations
+	nodeA := &GraphNode{
+		ID:        "node-a",
+		Type:      "pattern",
+		Title:     "Node A",
+		Relations: []string{"node-b", "node-c"},
+	}
+	nodeB := &GraphNode{ID: "node-b", Type: "pattern", Title: "Node B"}
+	nodeC := &GraphNode{ID: "node-c", Type: "pattern", Title: "Node C"}
+
+	for _, n := range []*GraphNode{nodeA, nodeB, nodeC} {
+		if err := kg.Add(n); err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+	}
+
+	related := kg.GetRelated("node-a")
+	if len(related) != 2 {
+		t.Errorf("GetRelated('node-a') returned %d results, want 2", len(related))
+	}
+
+	// Non-existent node returns nil
+	related = kg.GetRelated("non-existent")
+	if related != nil {
+		t.Errorf("GetRelated('non-existent') returned %v, want nil", related)
+	}
 }
 
 func TestKnowledgeGraph_Remove(t *testing.T) {
-	// Skip: Production code has a deadlock bug in KnowledgeGraph.Add()
-	t.Skip("Skipping due to known deadlock in KnowledgeGraph.Add()")
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	kg, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	node := &GraphNode{ID: "to-remove", Type: "pattern", Title: "Remove Me"}
+	if err := kg.Add(node); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	if kg.Count() != 1 {
+		t.Errorf("Count() after add = %d, want 1", kg.Count())
+	}
+
+	if err := kg.Remove("to-remove"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+
+	if kg.Count() != 0 {
+		t.Errorf("Count() after remove = %d, want 0", kg.Count())
+	}
+
+	_, ok := kg.Get("to-remove")
+	if ok {
+		t.Error("Get() after remove returned ok=true, want false")
+	}
 }
 
 func TestKnowledgeGraph_Count(t *testing.T) {
@@ -71,28 +261,172 @@ func TestKnowledgeGraph_Count(t *testing.T) {
 		t.Fatalf("failed to create knowledge graph: %v", err)
 	}
 
-	// Only test empty count (can't test Add due to deadlock)
 	if count := kg.Count(); count != 0 {
 		t.Errorf("Count() = %d, want 0 for empty graph", count)
+	}
+
+	// Add nodes and verify count
+	for i := 0; i < 3; i++ {
+		node := &GraphNode{ID: string(rune('a' + i)), Type: "test", Title: "Test"}
+		if err := kg.Add(node); err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+	}
+
+	if count := kg.Count(); count != 3 {
+		t.Errorf("Count() = %d, want 3", count)
 	}
 }
 
 func TestKnowledgeGraph_AddPattern(t *testing.T) {
-	// Skip: Production code has a deadlock bug in KnowledgeGraph.Add()
-	t.Skip("Skipping due to known deadlock in KnowledgeGraph.Add()")
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	kg, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	metadata := map[string]interface{}{"language": "go"}
+	if err := kg.AddPattern("error_handling", "Always check errors", metadata); err != nil {
+		t.Fatalf("AddPattern() error = %v", err)
+	}
+
+	patterns := kg.GetPatterns()
+	if len(patterns) != 1 {
+		t.Fatalf("GetPatterns() returned %d, want 1", len(patterns))
+	}
+
+	if patterns[0].Title != "error_handling" {
+		t.Errorf("Pattern Title = %q, want 'error_handling'", patterns[0].Title)
+	}
+
+	if patterns[0].Content != "Always check errors" {
+		t.Errorf("Pattern Content = %q, want 'Always check errors'", patterns[0].Content)
+	}
 }
 
 func TestKnowledgeGraph_AddLearning(t *testing.T) {
-	// Skip: Production code has a deadlock bug in KnowledgeGraph.Add()
-	t.Skip("Skipping due to known deadlock in KnowledgeGraph.Add()")
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	kg, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	metadata := map[string]interface{}{"project": "pilot"}
+	if err := kg.AddLearning("Context cancellation", "Always propagate context", metadata); err != nil {
+		t.Fatalf("AddLearning() error = %v", err)
+	}
+
+	learnings := kg.GetLearnings()
+	if len(learnings) != 1 {
+		t.Fatalf("GetLearnings() returned %d, want 1", len(learnings))
+	}
+
+	if learnings[0].Title != "Context cancellation" {
+		t.Errorf("Learning Title = %q, want 'Context cancellation'", learnings[0].Title)
+	}
 }
 
 func TestKnowledgeGraph_Persistence(t *testing.T) {
-	// Skip: Production code has a deadlock bug in KnowledgeGraph.Add()
-	t.Skip("Skipping due to known deadlock in KnowledgeGraph.Add()")
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create and populate graph
+	kg1, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	node := &GraphNode{
+		ID:      "persist-test",
+		Type:    "learning",
+		Title:   "Persistent Node",
+		Content: "Should survive reload",
+	}
+	if err := kg1.Add(node); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	// Load new graph from same path
+	kg2, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() reload error = %v", err)
+	}
+
+	got, ok := kg2.Get("persist-test")
+	if !ok {
+		t.Fatal("Get() after reload returned ok=false")
+	}
+
+	if got.Title != "Persistent Node" {
+		t.Errorf("Title after reload = %q, want %q", got.Title, "Persistent Node")
+	}
+
+	if got.Content != "Should survive reload" {
+		t.Errorf("Content after reload = %q, want %q", got.Content, "Should survive reload")
+	}
 }
 
 func TestKnowledgeGraph_UpdateExistingNode(t *testing.T) {
-	// Skip: Production code has a deadlock bug in KnowledgeGraph.Add()
-	t.Skip("Skipping due to known deadlock in KnowledgeGraph.Add()")
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	kg, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	// Add initial node
+	node := &GraphNode{
+		ID:      "update-test",
+		Type:    "pattern",
+		Title:   "Original Title",
+		Content: "Original Content",
+	}
+	if err := kg.Add(node); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	got, _ := kg.Get("update-test")
+	originalCreatedAt := got.CreatedAt
+
+	// Update node
+	updatedNode := &GraphNode{
+		ID:      "update-test",
+		Type:    "pattern",
+		Title:   "Updated Title",
+		Content: "Updated Content",
+	}
+	if err := kg.Add(updatedNode); err != nil {
+		t.Fatalf("Add() update error = %v", err)
+	}
+
+	got, _ = kg.Get("update-test")
+
+	if got.Title != "Updated Title" {
+		t.Errorf("Title after update = %q, want %q", got.Title, "Updated Title")
+	}
+
+	if !got.CreatedAt.Equal(originalCreatedAt) {
+		t.Error("CreatedAt should be preserved on update")
+	}
+
+	if !got.UpdatedAt.After(originalCreatedAt) {
+		t.Error("UpdatedAt should be after CreatedAt after update")
+	}
 }

--- a/internal/memory/patterns_test.go
+++ b/internal/memory/patterns_test.go
@@ -27,44 +27,343 @@ func TestNewGlobalPatternStore(t *testing.T) {
 }
 
 func TestGlobalPatternStore_AddAndGet(t *testing.T) {
-	// Skip: Production code has a deadlock bug in GlobalPatternStore.Add()
-	// The Add() method holds a write Lock then calls save() which tries RLock
-	t.Skip("Skipping due to known deadlock in GlobalPatternStore.Add()")
+	tmpDir, err := os.MkdirTemp("", "patterns-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewGlobalPatternStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewGlobalPatternStore() error = %v", err)
+	}
+
+	pattern := &GlobalPattern{
+		ID:          "test-pattern-1",
+		Type:        PatternTypeCode,
+		Title:       "Test Pattern",
+		Description: "A test pattern",
+		Confidence:  0.9,
+	}
+
+	if err := store.Add(pattern); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	got, ok := store.Get("test-pattern-1")
+	if !ok {
+		t.Fatal("Get() returned ok=false, want true")
+	}
+
+	if got.Title != "Test Pattern" {
+		t.Errorf("Get().Title = %q, want %q", got.Title, "Test Pattern")
+	}
+
+	if got.Uses != 1 {
+		t.Errorf("Get().Uses = %d, want 1", got.Uses)
+	}
 }
 
 func TestGlobalPatternStore_GetByType(t *testing.T) {
-	// Skip: Production code has a deadlock bug in GlobalPatternStore.Add()
-	t.Skip("Skipping due to known deadlock in GlobalPatternStore.Add()")
+	tmpDir, err := os.MkdirTemp("", "patterns-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewGlobalPatternStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewGlobalPatternStore() error = %v", err)
+	}
+
+	// Add patterns of different types
+	patterns := []*GlobalPattern{
+		{ID: "code-1", Type: PatternTypeCode, Title: "Code Pattern 1"},
+		{ID: "code-2", Type: PatternTypeCode, Title: "Code Pattern 2"},
+		{ID: "naming-1", Type: PatternTypeNaming, Title: "Naming Pattern 1"},
+	}
+
+	for _, p := range patterns {
+		if err := store.Add(p); err != nil {
+			t.Fatalf("Add() error = %v", err)
+		}
+	}
+
+	codePatterns := store.GetByType(PatternTypeCode)
+	if len(codePatterns) != 2 {
+		t.Errorf("GetByType(Code) returned %d patterns, want 2", len(codePatterns))
+	}
+
+	namingPatterns := store.GetByType(PatternTypeNaming)
+	if len(namingPatterns) != 1 {
+		t.Errorf("GetByType(Naming) returned %d patterns, want 1", len(namingPatterns))
+	}
 }
 
 func TestGlobalPatternStore_GetForProject(t *testing.T) {
-	// Skip: Production code has a deadlock bug in GlobalPatternStore.Add()
-	t.Skip("Skipping due to known deadlock in GlobalPatternStore.Add()")
+	tmpDir, err := os.MkdirTemp("", "patterns-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewGlobalPatternStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewGlobalPatternStore() error = %v", err)
+	}
+
+	// Add global pattern (no projects)
+	globalPattern := &GlobalPattern{
+		ID:    "global-1",
+		Type:  PatternTypeCode,
+		Title: "Global Pattern",
+	}
+
+	// Add project-specific pattern
+	projectPattern := &GlobalPattern{
+		ID:       "project-1",
+		Type:     PatternTypeCode,
+		Title:    "Project Pattern",
+		Projects: []string{"/path/to/project"},
+	}
+
+	if err := store.Add(globalPattern); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+	if err := store.Add(projectPattern); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	// Should get both global and project-specific
+	patterns := store.GetForProject("/path/to/project")
+	if len(patterns) != 2 {
+		t.Errorf("GetForProject() returned %d patterns, want 2", len(patterns))
+	}
+
+	// Should only get global for different project
+	patterns = store.GetForProject("/other/project")
+	if len(patterns) != 1 {
+		t.Errorf("GetForProject(other) returned %d patterns, want 1", len(patterns))
+	}
 }
 
 func TestGlobalPatternStore_IncrementUse(t *testing.T) {
-	// Skip: Production code has a deadlock bug in GlobalPatternStore operations
-	t.Skip("Skipping due to known deadlock in GlobalPatternStore.Add()")
+	tmpDir, err := os.MkdirTemp("", "patterns-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewGlobalPatternStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewGlobalPatternStore() error = %v", err)
+	}
+
+	pattern := &GlobalPattern{
+		ID:    "test-increment",
+		Type:  PatternTypeCode,
+		Title: "Test Pattern",
+	}
+
+	if err := store.Add(pattern); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	// Initial use count should be 1
+	got, _ := store.Get("test-increment")
+	if got.Uses != 1 {
+		t.Errorf("Initial Uses = %d, want 1", got.Uses)
+	}
+
+	// Increment
+	if err := store.IncrementUse("test-increment"); err != nil {
+		t.Fatalf("IncrementUse() error = %v", err)
+	}
+
+	got, _ = store.Get("test-increment")
+	if got.Uses != 2 {
+		t.Errorf("After increment Uses = %d, want 2", got.Uses)
+	}
+
+	// Non-existent pattern should error
+	if err := store.IncrementUse("non-existent"); err == nil {
+		t.Error("IncrementUse(non-existent) should return error")
+	}
 }
 
 func TestGlobalPatternStore_Remove(t *testing.T) {
-	// Skip: Production code has a deadlock bug in GlobalPatternStore operations
-	t.Skip("Skipping due to known deadlock in GlobalPatternStore.Add()")
+	tmpDir, err := os.MkdirTemp("", "patterns-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewGlobalPatternStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewGlobalPatternStore() error = %v", err)
+	}
+
+	pattern := &GlobalPattern{
+		ID:    "test-remove",
+		Type:  PatternTypeCode,
+		Title: "Test Pattern",
+	}
+
+	if err := store.Add(pattern); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	if store.Count() != 1 {
+		t.Errorf("Count() after add = %d, want 1", store.Count())
+	}
+
+	if err := store.Remove("test-remove"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+
+	if store.Count() != 0 {
+		t.Errorf("Count() after remove = %d, want 0", store.Count())
+	}
+
+	_, ok := store.Get("test-remove")
+	if ok {
+		t.Error("Get() after remove returned ok=true, want false")
+	}
 }
 
 func TestGlobalPatternStore_Persistence(t *testing.T) {
-	// Skip: Production code has a deadlock bug in GlobalPatternStore.Add()
-	t.Skip("Skipping due to known deadlock in GlobalPatternStore.Add()")
+	tmpDir, err := os.MkdirTemp("", "patterns-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create store and add pattern
+	store1, err := NewGlobalPatternStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewGlobalPatternStore() error = %v", err)
+	}
+
+	pattern := &GlobalPattern{
+		ID:          "persist-test",
+		Type:        PatternTypeWorkflow,
+		Title:       "Persistent Pattern",
+		Description: "Should survive reload",
+	}
+
+	if err := store1.Add(pattern); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	// Create new store from same path
+	store2, err := NewGlobalPatternStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewGlobalPatternStore() reload error = %v", err)
+	}
+
+	got, ok := store2.Get("persist-test")
+	if !ok {
+		t.Fatal("Get() after reload returned ok=false")
+	}
+
+	if got.Title != "Persistent Pattern" {
+		t.Errorf("Title after reload = %q, want %q", got.Title, "Persistent Pattern")
+	}
+
+	if got.Description != "Should survive reload" {
+		t.Errorf("Description after reload = %q, want %q", got.Description, "Should survive reload")
+	}
 }
 
 func TestGlobalPatternStore_UpdateExistingPattern(t *testing.T) {
-	// Skip: Production code has a deadlock bug in GlobalPatternStore.Add()
-	t.Skip("Skipping due to known deadlock in GlobalPatternStore.Add()")
+	tmpDir, err := os.MkdirTemp("", "patterns-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewGlobalPatternStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewGlobalPatternStore() error = %v", err)
+	}
+
+	// Add initial pattern
+	pattern := &GlobalPattern{
+		ID:          "update-test",
+		Type:        PatternTypeCode,
+		Title:       "Original Title",
+		Description: "Original Description",
+	}
+
+	if err := store.Add(pattern); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+
+	got, _ := store.Get("update-test")
+	originalCreatedAt := got.CreatedAt
+
+	// Update pattern
+	updatedPattern := &GlobalPattern{
+		ID:          "update-test",
+		Type:        PatternTypeCode,
+		Title:       "Updated Title",
+		Description: "Updated Description",
+	}
+
+	if err := store.Add(updatedPattern); err != nil {
+		t.Fatalf("Add() update error = %v", err)
+	}
+
+	got, _ = store.Get("update-test")
+
+	if got.Title != "Updated Title" {
+		t.Errorf("Title after update = %q, want %q", got.Title, "Updated Title")
+	}
+
+	if got.Uses != 2 {
+		t.Errorf("Uses after update = %d, want 2", got.Uses)
+	}
+
+	if !got.CreatedAt.Equal(originalCreatedAt) {
+		t.Error("CreatedAt should be preserved on update")
+	}
 }
 
 func TestPatternLearner_LearnFromExecution(t *testing.T) {
-	// Skip: Production code has a deadlock bug in GlobalPatternStore.Add()
-	t.Skip("Skipping due to known deadlock in GlobalPatternStore.Add()")
+	tmpDir, err := os.MkdirTemp("", "patterns-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	patternStore, err := NewGlobalPatternStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewGlobalPatternStore() error = %v", err)
+	}
+
+	// Create memory store for executions
+	memStore, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	defer memStore.Close()
+
+	learner := NewPatternLearner(patternStore, memStore)
+
+	// Test with non-completed execution (should skip)
+	exec := &Execution{
+		ID:     "test-exec-1",
+		Status: "running",
+	}
+
+	if err := learner.LearnFromExecution(nil, exec); err != nil {
+		t.Errorf("LearnFromExecution() on running exec error = %v", err)
+	}
+
+	// Verify no patterns learned from incomplete execution
+	if patternStore.Count() != 0 {
+		t.Errorf("PatternStore.Count() = %d after incomplete exec, want 0", patternStore.Count())
+	}
 }
 
 func TestPatternTypeConstants(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-79.

## Changes

GitHub Issue #79: Fix: GlobalPatternStore deadlock (blocks all pattern learning)

## Problem (P1 CRITICAL)

`GlobalPatternStore.Add()` acquires a write lock then calls `save()` which tries to acquire a read lock. **This causes deadlock** - Go's sync.RWMutex cannot be read-locked by a goroutine holding the write lock.

**File:** `internal/memory/patterns.go:100-120`

```go
func (s *GlobalPatternStore) Add(pattern *GlobalPattern) error {
    s.mu.Lock()  // ← Write lock held
    defer s.mu.Unlock()
    // ... operations ...
    return s.save()  // ← Calls save() while lock held
}

func (s *GlobalPatternStore) save() error {
    s.mu.RLock()  // ← Tries to acquire read lock - DEADLOCK!
    // ...
}
```

## Impact

- **BLOCKING:** All 8 tests for GlobalPatternStore are SKIPPED
- **BREAKING:** Pattern storage is non-functional in production
- **File:** `internal/memory/patterns_test.go:29-68`

## Solution

Option 1: Don't hold lock during save
```go
func (s *GlobalPatternStore) Add(pattern *GlobalPattern) error {
    s.mu.Lock()
    // ... operations ...
    s.mu.Unlock()  // Release before save
    return s.save()
}
```

Option 2: Refactor save() to not require lock (internal helper)
```go
func (s *GlobalPatternStore) save() error {
    // Caller must hold lock - don't acquire here
    patterns := make([]*GlobalPattern, 0, len(s.patterns))
    // ...
}
```

## Acceptance Criteria

- [ ] No deadlock in Add/Remove/save operations
- [ ] All 8 skipped tests unskipped and passing
- [ ] Pattern learning functional