### PR TITLE
fix(executor): suppress slog output when visual progress display is active

### DIFF
--- a/cmd/pilot/interactive.go
+++ b/cmd/pilot/interactive.go
@@ -167,6 +167,9 @@ func interactiveNewTask(cfg *config.Config) error {
 	runner := executor.NewRunner()
 	progress := executor.NewProgressDisplay(task.ID, taskDesc, true)
 
+	// Suppress slog progress output when visual display is active
+	runner.SuppressProgressLogs(true)
+
 	// Track Navigator mode
 	var detectedNavMode string
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1271,6 +1271,9 @@ Examples:
 			// Create progress display (disabled in verbose mode - show raw JSON instead)
 			progress := executor.NewProgressDisplay(task.ID, taskDesc, !verbose)
 
+			// Suppress slog progress output when visual display is active
+			runner.SuppressProgressLogs(!verbose)
+
 			// Track Navigator mode detection
 			var detectedNavMode string
 


### PR DESCRIPTION
## Summary
- Progress logs were spamming terminal output even when ProgressDisplay was rendering visual progress bars
- Added `SuppressProgressLogs()` method to Runner that disables slog.Info calls when visual display is active

## Changes
- Add `suppressProgressLogs` field to Runner struct
- Add `SuppressProgressLogs(bool)` method
- Wire suppression in `pilot task` and interactive mode when visual progress is enabled
- Add test for log suppression behavior

## Test plan
- [x] Unit test: `TestSuppressProgressLogs`
- [ ] Manual: Run `pilot task` and verify visual progress bar shows instead of log spam