### PR TITLE
Add CI failure auto-fix workflow

### DIFF
--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -1,0 +1,88 @@
+name: CI Auto-Fix
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  create-fix-issue:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if already has fix issue
+        uses: actions/github-script@v7
+        id: check-existing
+        with:
+          script: |
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'ci-fix',
+              state: 'open'
+            });
+            // Don't create duplicate fix issues
+            const runId = context.payload.workflow_run.id;
+            const existing = issues.data.find(i => i.body.includes(`run_id: ${runId}`));
+            return { exists: !!existing };
+
+      - name: Get failed job info
+        if: ${{ !fromJSON(steps.check-existing.outputs.result).exists }}
+        uses: actions/github-script@v7
+        id: get-failure
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: run.id
+            });
+
+            const failedJobs = jobs.data.jobs.filter(j => j.conclusion === 'failure');
+            const jobNames = failedJobs.map(j => j.name).join(', ');
+
+            return {
+              runId: run.id,
+              runUrl: run.html_url,
+              branch: run.head_branch,
+              sha: run.head_sha.substring(0, 7),
+              jobs: jobNames
+            };
+
+      - name: Create fix issue
+        if: ${{ !fromJSON(steps.check-existing.outputs.result).exists }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const info = ${{ steps.get-failure.outputs.result }};
+
+            // Don't auto-fix on pilot branches (prevent loops)
+            if (info.branch.startsWith('pilot/')) {
+              console.log('Skipping auto-fix for pilot branch');
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `CI Fix: ${info.jobs} failed on ${info.branch}`,
+              labels: ['pilot', 'ci-fix'],
+              body: `## CI Failure Auto-Fix Request
+
+**Branch:** ${info.branch}
+**Commit:** ${info.sha}
+**Failed jobs:** ${info.jobs}
+**Run:** ${info.runUrl}
+
+<!-- run_id: ${info.runId} -->
+
+---
+
+Pilot: Please analyze the CI failure logs at the run URL above and fix the issues. Focus on:
+1. Lint errors (golangci-lint)
+2. Test failures
+3. Build errors
+
+Create a PR with the fix.`
+            });


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-160.

## Changes

GitHub Issue #160: Add CI failure auto-fix workflow

## Summary

Add a GitHub Actions workflow that automatically triggers Pilot when CI fails, allowing Pilot to attempt fixes.

## Design

### Flow
```
CI fails → Action extracts error → Creates issue with `pilot` label
    → Pilot picks up issue → Attempts fix → Creates PR
```

### Implementation

Create `.github/workflows/ci-autofix.yml`:

```yaml
name: CI Auto-Fix

on:
  workflow_run:
    workflows: ["CI"]
    types: [completed]

jobs:
  create-fix-issue:
    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
    runs-on: ubuntu-latest
    steps:
      - name: Check if already has fix issue
        uses: actions/github-script@v7
        id: check-existing
        with:
          script: |
            const issues = await github.rest.issues.listForRepo({
              owner: context.repo.owner,
              repo: context.repo.repo,
              labels: 'ci-fix',
              state: 'open'
            });
            // Don't create duplicate fix issues
            const runId = context.payload.workflow_run.id;
            const existing = issues.data.find(i => i.body.includes(`run_id: ${runId}`));
            return { exists: !!existing };

      - name: Get failed job info
        if: ${{ !fromJSON(steps.check-existing.outputs.result).exists }}
        uses: actions/github-script@v7
        id: get-failure
        with:
          script: |
            const run = context.payload.workflow_run;
            const jobs = await github.rest.actions.listJobsForWorkflowRun({
              owner: context.repo.owner,
              repo: context.repo.repo,
              run_id: run.id
            });
            
            const failedJobs = jobs.data.jobs.filter(j => j.conclusion === 'failure');
            const jobNames = failedJobs.map(j => j.name).join(', ');
            
            return {
              runId: run.id,
              runUrl: run.html_url,
              branch: run.head_branch,
              sha: run.head_sha.substring(0, 7),
              jobs: jobNames
            };

      - name: Create fix issue
        if: ${{ !fromJSON(steps.check-existing.outputs.result).exists }}
        uses: actions/github-script@v7
        with:
          script: |
            const info = ${{ steps.get-failure.outputs.result }};
            
            // Don't auto-fix on pilot branches (prevent loops)
            if (info.branch.startsWith('pilot/')) {
              console.log('Skipping auto-fix for pilot branch');
              return;
            }
            
            await github.rest.issues.create({
              owner: context.repo.owner,
              repo: context.repo.repo,
              title: `CI Fix: ${info.jobs} failed on ${info.branch}`,
              labels: ['pilot', 'ci-fix'],
              body: `## CI Failure Auto-Fix Request

**Branch:** ${info.branch}
**Commit:** ${info.sha}
**Failed jobs:** ${info.jobs}
**Run:** ${info.runUrl}

<!-- run_id: ${info.runId} -->

---

Pilot: Please analyze the CI failure logs at the run URL above and fix the issues. Focus on:
1. Lint errors (golangci-lint)
2. Test failures
3. Build errors

Create a PR with the fix.`
            });
```

### Safety Features

1. **Loop prevention**: Skip branches starting with `pilot/`
2. **Deduplication**: Check for existing open `ci-fix` issues for same run
3. **Scoped fixes**: Prompt focuses on lint/test/build only

### Labels

- `pilot` - Triggers Pilot to pick up the issue
- `ci-fix` - Marks as auto-generated CI fix request (for filtering)

## Acceptance Criteria

- [ ] Workflow triggers on CI failure
- [ ] Extracts failed job names from workflow run
- [ ] Creates issue with `pilot` and `ci-fix` labels
- [ ] Skips pilot/* branches to prevent loops
- [ ] Doesn't create duplicate issues for same failure
- [ ] Pilot successfully picks up and attempts fix