### PR TITLE
Wire quality gates to orchestrator for polling/webhook modes

### DIFF
--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -289,6 +289,13 @@ func (p *Pilot) SuppressProgressLogs(suppress bool) {
 	p.orchestrator.SuppressProgressLogs(suppress)
 }
 
+// SetQualityCheckerFactory sets the factory for creating quality checkers.
+// Quality gates run after task execution to validate code quality before PR creation.
+// This allows main.go to wire the factory without creating import cycles.
+func (p *Pilot) SetQualityCheckerFactory(factory executor.QualityCheckerFactory) {
+	p.orchestrator.SetQualityCheckerFactory(factory)
+}
+
 // handleGithubIssue handles a new GitHub issue
 func (p *Pilot) handleGithubIssue(ctx context.Context, issue *github.Issue, repo *github.Repository) error {
 	logging.WithComponent("pilot").Info("Received GitHub issue",


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-207.

## Changes

GitHub Issue #207: Wire quality gates to orchestrator for polling/webhook modes

## Problem

Quality gates are implemented but only wired for `pilot task` CLI command. They are NOT running in:
- `pilot start --github` (polling mode)
- `pilot start --telegram` 
- Linear/Jira webhook handlers

## Root Cause

`internal/orchestrator/orchestrator.go:63` creates `executor.NewRunner()` but never calls `SetQualityCheckerFactory()`.

The factory is only set in `cmd/pilot/main.go:1482` for direct task execution.

## Solution

1. Add `QualityCheckerFactory` field to `Orchestrator` struct
2. Add `SetQualityCheckerFactory(factory)` method to Orchestrator
3. Pass factory to runner in `processTask()` method
4. Wire factory in `cmd/pilot/main.go` start command where orchestrator is created

## Files to Modify

- `internal/orchestrator/orchestrator.go` - Add factory field and method
- `cmd/pilot/main.go` - Wire factory when creating Pilot/orchestrator for start command

## Acceptance Criteria

- [ ] Quality gates run in GitHub polling mode
- [ ] Quality gates run in Telegram mode  
- [ ] Quality gates configurable via `quality:` section in config.yaml
- [ ] Failed gates block PR creation and trigger retry