### PR TITLE
Wire task decomposition for complex tasks

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -413,8 +413,15 @@ func padOrTruncate(s string, targetWidth int) string {
 	return s + strings.Repeat(" ", targetWidth-visualWidth)
 }
 
-// truncateVisual truncates string to targetWidth visual chars, adding "..." if needed
+// truncateVisual truncates string to targetWidth visual chars, adding "..." only if needed
 func truncateVisual(s string, targetWidth int) string {
+	visualWidth := lipgloss.Width(s)
+
+	// If string already fits, return as-is (no truncation needed)
+	if visualWidth <= targetWidth {
+		return s
+	}
+
 	if targetWidth <= 3 {
 		return strings.Repeat(".", targetWidth)
 	}

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -31,6 +31,10 @@ type ExecuteOptions struct {
 	// Verbose enables detailed output logging
 	Verbose bool
 
+	// Model specifies the model to use for execution (e.g., "claude-haiku", "claude-opus").
+	// If empty, the backend's default model is used.
+	Model string
+
 	// EventHandler receives streaming events during execution
 	// The handler receives the raw event line from the backend
 	EventHandler func(event BackendEvent)

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -58,6 +58,13 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, opts ExecuteOptions) (*
 		"--output-format", "stream-json",
 		"--dangerously-skip-permissions",
 	}
+
+	// Add model flag if specified (model routing GH-215)
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+		b.log.Info("Using routed model", slog.String("model", opts.Model))
+	}
+
 	args = append(args, b.config.ExtraArgs...)
 
 	cmd := exec.CommandContext(ctx, b.config.Command, args...)

--- a/internal/executor/complexity.go
+++ b/internal/executor/complexity.go
@@ -153,3 +153,9 @@ func (c Complexity) ShouldSkipNavigator() bool {
 func (c Complexity) String() string {
 	return string(c)
 }
+
+// ShouldRunResearch returns true if parallel research phase should run.
+// Medium and complex tasks benefit from pre-execution research.
+func (c Complexity) ShouldRunResearch() bool {
+	return c == ComplexityMedium || c == ComplexityComplex
+}

--- a/internal/executor/complexity_test.go
+++ b/internal/executor/complexity_test.go
@@ -139,11 +139,12 @@ func TestComplexity_Methods(t *testing.T) {
 		isTrivial           bool
 		isSimple            bool
 		shouldSkipNavigator bool
+		shouldRunResearch   bool
 	}{
-		{ComplexityTrivial, true, true, true},
-		{ComplexitySimple, false, true, false},
-		{ComplexityMedium, false, false, false},
-		{ComplexityComplex, false, false, false},
+		{ComplexityTrivial, true, true, true, false},
+		{ComplexitySimple, false, true, false, false},
+		{ComplexityMedium, false, false, false, true},
+		{ComplexityComplex, false, false, false, true},
 	}
 
 	for _, tt := range tests {
@@ -156,6 +157,9 @@ func TestComplexity_Methods(t *testing.T) {
 			}
 			if got := tt.complexity.ShouldSkipNavigator(); got != tt.shouldSkipNavigator {
 				t.Errorf("ShouldSkipNavigator() = %v, want %v", got, tt.shouldSkipNavigator)
+			}
+			if got := tt.complexity.ShouldRunResearch(); got != tt.shouldRunResearch {
+				t.Errorf("ShouldRunResearch() = %v, want %v", got, tt.shouldRunResearch)
 			}
 		})
 	}

--- a/internal/executor/quality.go
+++ b/internal/executor/quality.go
@@ -1,6 +1,20 @@
 package executor
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// QualityGateDetail represents detailed information about a single gate check.
+// This is used to pass gate results from the quality package to the executor
+// without creating import cycles.
+type QualityGateDetail struct {
+	Name       string
+	Passed     bool
+	Duration   time.Duration
+	RetryCount int
+	Error      string
+}
 
 // QualityOutcome represents the result of quality gate checks.
 // This mirrors quality.ExecutionOutcome to avoid import cycles.
@@ -9,6 +23,10 @@ type QualityOutcome struct {
 	ShouldRetry   bool
 	RetryFeedback string // Error feedback to send to Claude for retry
 	Attempt       int
+	// GateDetails contains detailed results for each gate
+	GateDetails []QualityGateDetail
+	// TotalDuration is the total time spent running all gates
+	TotalDuration time.Duration
 }
 
 // QualityChecker is an interface for running quality gate checks.

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -470,6 +470,7 @@ func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, err
 		Prompt:      prompt,
 		ProjectPath: task.ProjectPath,
 		Verbose:     task.Verbose,
+		Model:       selectedModel,
 		EventHandler: func(event BackendEvent) {
 			// Record the event
 			if recorder != nil {
@@ -755,6 +756,7 @@ func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, err
 						Prompt:      retryPrompt,
 						ProjectPath: task.ProjectPath,
 						Verbose:     task.Verbose,
+						Model:       selectedModel,
 						EventHandler: func(event BackendEvent) {
 							if recorder != nil {
 								if recErr := recorder.RecordEvent(event.Raw); recErr != nil {

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -203,6 +203,7 @@ type Runner struct {
 	qualityCheckerFactory QualityCheckerFactory // Optional factory for creating quality checkers
 	modelRouter           *ModelRouter          // Model and timeout routing based on complexity
 	parallelRunner        *ParallelRunner       // Optional parallel research runner (GH-217)
+	decomposer            *TaskDecomposer       // Optional task decomposer for complex tasks (GH-218)
 	suppressProgressLogs  bool                  // Suppress slog output for progress (use when visual display is active)
 }
 
@@ -247,6 +248,11 @@ func NewRunnerWithConfig(config *BackendConfig) (*Runner, error) {
 	// Configure model routing and timeouts from config
 	if config != nil {
 		runner.modelRouter = NewModelRouter(config.ModelRouting, config.Timeout)
+
+		// Configure task decomposition (GH-218)
+		if config.Decompose != nil && config.Decompose.Enabled {
+			runner.decomposer = NewTaskDecomposer(config.Decompose)
+		}
 	}
 
 	return runner, nil
@@ -311,6 +317,23 @@ func (r *Runner) SetParallelRunner(runner *ParallelRunner) {
 // This is a convenience method to enable parallel research with default settings.
 func (r *Runner) EnableParallelResearch() {
 	r.parallelRunner = NewParallelRunner(DefaultParallelConfig(), r.modelRouter)
+}
+
+// SetDecomposer sets the task decomposer for auto-splitting complex tasks (GH-218).
+// When set and enabled, complex tasks are decomposed into subtasks that run sequentially,
+// with only the final subtask creating a PR.
+func (r *Runner) SetDecomposer(decomposer *TaskDecomposer) {
+	r.decomposer = decomposer
+}
+
+// EnableDecomposition creates and configures a default task decomposer.
+// This is a convenience method to enable decomposition with default settings.
+func (r *Runner) EnableDecomposition(config *DecomposeConfig) {
+	if config == nil {
+		config = DefaultDecomposeConfig()
+		config.Enabled = true // Enable by default when called explicitly
+	}
+	r.decomposer = NewTaskDecomposer(config)
 }
 
 // getRecordingsPath returns the recordings path, using default if not set
@@ -393,11 +416,29 @@ func (r *Runner) EmitProgress(taskID, phase string, progress int, message string
 // backend invocation, progress tracking, and optional PR creation.
 // The context can be used to cancel execution. Returns an error only for
 // setup failures; execution failures are reported in ExecutionResult.
+//
+// When a decomposer is configured and enabled, complex tasks are automatically
+// split into subtasks that run sequentially (GH-218). Only the final subtask
+// creates a PR, accumulating all changes from previous subtasks.
 func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, error) {
 	start := time.Now()
 
 	// Detect complexity for routing decisions
 	complexity := DetectComplexity(task)
+
+	// Check for task decomposition (GH-218)
+	// Decomposition happens before timeout setup because subtasks have their own timeouts
+	if r.decomposer != nil {
+		result := r.decomposer.Decompose(task)
+		if result.Decomposed && len(result.Subtasks) > 1 {
+			r.log.Info("Task decomposed",
+				slog.String("task_id", task.ID),
+				slog.Int("subtask_count", len(result.Subtasks)),
+				slog.String("reason", result.Reason),
+			)
+			return r.executeDecomposedTask(ctx, task, result.Subtasks)
+		}
+	}
 
 	// Apply timeout based on task complexity
 	timeout := r.modelRouter.SelectTimeout(task)
@@ -1007,6 +1048,198 @@ func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, err
 	}
 
 	return result, nil
+}
+
+// executeDecomposedTask runs subtasks sequentially and aggregates results (GH-218).
+// Each subtask runs to completion before the next starts. Only the final subtask
+// creates a PR (CreatePR is already set by the decomposer). All changes accumulate
+// on the same branch, so the final PR contains all subtask work.
+func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, subtasks []*Task) (*ExecutionResult, error) {
+	start := time.Now()
+	totalSubtasks := len(subtasks)
+
+	r.log.Info("Starting decomposed task execution",
+		slog.String("parent_id", parentTask.ID),
+		slog.Int("subtask_count", totalSubtasks),
+	)
+
+	// Emit parent task started event
+	r.emitAlertEvent(AlertEvent{
+		Type:      AlertEventTypeTaskStarted,
+		TaskID:    parentTask.ID,
+		TaskTitle: parentTask.Title,
+		Project:   parentTask.ProjectPath,
+		Metadata: map[string]string{
+			"decomposed":    "true",
+			"subtask_count": fmt.Sprintf("%d", totalSubtasks),
+		},
+		Timestamp: time.Now(),
+	})
+
+	// Dispatch webhook for decomposed task started
+	r.dispatchWebhook(ctx, webhooks.EventTaskStarted, webhooks.TaskStartedData{
+		TaskID:      parentTask.ID,
+		Title:       parentTask.Title,
+		Description: fmt.Sprintf("Decomposed into %d subtasks: %s", totalSubtasks, parentTask.Description),
+		Project:     parentTask.ProjectPath,
+		Source:      "pilot",
+	})
+
+	// Initialize git and create branch ONCE for all subtasks
+	git := NewGitOperations(parentTask.ProjectPath)
+	if parentTask.Branch != "" {
+		r.reportProgress(parentTask.ID, "Branching", 2, fmt.Sprintf("Creating branch %s...", parentTask.Branch))
+		if err := git.CreateBranch(ctx, parentTask.Branch); err != nil {
+			if switchErr := git.SwitchBranch(ctx, parentTask.Branch); switchErr != nil {
+				return nil, fmt.Errorf("failed to create/switch branch: %w", err)
+			}
+		}
+		r.reportProgress(parentTask.ID, "Branching", 5, fmt.Sprintf("Branch %s ready", parentTask.Branch))
+	}
+
+	// Aggregate result
+	aggregateResult := &ExecutionResult{
+		TaskID:  parentTask.ID,
+		Success: true,
+	}
+
+	// Execute each subtask sequentially
+	for i, subtask := range subtasks {
+		subtaskNum := i + 1
+
+		// Report progress with subtask counter
+		progressPct := 5 + (85 * subtaskNum / totalSubtasks)
+		r.reportProgress(parentTask.ID, "Decomposed", progressPct,
+			fmt.Sprintf("Subtask %d/%d: %s", subtaskNum, totalSubtasks, truncateText(subtask.Title, 40)))
+
+		r.log.Info("Executing subtask",
+			slog.String("parent_id", parentTask.ID),
+			slog.String("subtask_id", subtask.ID),
+			slog.Int("index", subtaskNum),
+			slog.Int("total", totalSubtasks),
+		)
+
+		// Execute subtask (recursively calls Execute, but subtasks won't decompose further)
+		// Clear the branch since we already created it
+		subtask.Branch = ""
+
+		// Temporarily disable decomposer to prevent recursive decomposition
+		savedDecomposer := r.decomposer
+		r.decomposer = nil
+
+		subtaskResult, err := r.Execute(ctx, subtask)
+
+		// Restore decomposer
+		r.decomposer = savedDecomposer
+
+		if err != nil {
+			r.log.Error("Subtask execution error",
+				slog.String("subtask_id", subtask.ID),
+				slog.Any("error", err),
+			)
+			aggregateResult.Success = false
+			aggregateResult.Error = fmt.Sprintf("subtask %d/%d failed: %v", subtaskNum, totalSubtasks, err)
+			break
+		}
+
+		if !subtaskResult.Success {
+			r.log.Warn("Subtask failed",
+				slog.String("subtask_id", subtask.ID),
+				slog.String("error", subtaskResult.Error),
+			)
+			aggregateResult.Success = false
+			aggregateResult.Error = fmt.Sprintf("subtask %d/%d failed: %s", subtaskNum, totalSubtasks, subtaskResult.Error)
+			break
+		}
+
+		// Aggregate metrics
+		aggregateResult.TokensInput += subtaskResult.TokensInput
+		aggregateResult.TokensOutput += subtaskResult.TokensOutput
+		aggregateResult.TokensTotal += subtaskResult.TokensTotal
+		aggregateResult.ResearchTokens += subtaskResult.ResearchTokens
+		aggregateResult.FilesChanged += subtaskResult.FilesChanged
+		aggregateResult.LinesAdded += subtaskResult.LinesAdded
+		aggregateResult.LinesRemoved += subtaskResult.LinesRemoved
+
+		// Keep last commit SHA and PR URL
+		if subtaskResult.CommitSHA != "" {
+			aggregateResult.CommitSHA = subtaskResult.CommitSHA
+		}
+		if subtaskResult.PRUrl != "" {
+			aggregateResult.PRUrl = subtaskResult.PRUrl
+		}
+		if subtaskResult.ModelName != "" {
+			aggregateResult.ModelName = subtaskResult.ModelName
+		}
+
+		// Track quality gates from final subtask
+		if subtask.CreatePR && subtaskResult.QualityGates != nil {
+			aggregateResult.QualityGates = subtaskResult.QualityGates
+		}
+
+		r.log.Info("Subtask completed",
+			slog.String("subtask_id", subtask.ID),
+			slog.Int("index", subtaskNum),
+			slog.Int("total", totalSubtasks),
+		)
+	}
+
+	aggregateResult.Duration = time.Since(start)
+	aggregateResult.EstimatedCostUSD = estimateCost(
+		aggregateResult.TokensInput+aggregateResult.ResearchTokens,
+		aggregateResult.TokensOutput,
+		aggregateResult.ModelName,
+	)
+
+	// Emit completion event
+	if aggregateResult.Success {
+		r.reportProgress(parentTask.ID, "Completed", 100,
+			fmt.Sprintf("All %d subtasks completed", totalSubtasks))
+
+		r.emitAlertEvent(AlertEvent{
+			Type:      AlertEventTypeTaskCompleted,
+			TaskID:    parentTask.ID,
+			TaskTitle: parentTask.Title,
+			Project:   parentTask.ProjectPath,
+			Metadata: map[string]string{
+				"duration_ms":   fmt.Sprintf("%d", aggregateResult.Duration.Milliseconds()),
+				"pr_url":        aggregateResult.PRUrl,
+				"subtask_count": fmt.Sprintf("%d", totalSubtasks),
+			},
+			Timestamp: time.Now(),
+		})
+
+		r.dispatchWebhook(ctx, webhooks.EventTaskCompleted, webhooks.TaskCompletedData{
+			TaskID:    parentTask.ID,
+			Title:     parentTask.Title,
+			Project:   parentTask.ProjectPath,
+			Duration:  aggregateResult.Duration,
+			PRCreated: aggregateResult.PRUrl != "",
+			PRURL:     aggregateResult.PRUrl,
+		})
+	} else {
+		r.reportProgress(parentTask.ID, "Failed", 100, aggregateResult.Error)
+
+		r.emitAlertEvent(AlertEvent{
+			Type:      AlertEventTypeTaskFailed,
+			TaskID:    parentTask.ID,
+			TaskTitle: parentTask.Title,
+			Project:   parentTask.ProjectPath,
+			Error:     aggregateResult.Error,
+			Timestamp: time.Now(),
+		})
+
+		r.dispatchWebhook(ctx, webhooks.EventTaskFailed, webhooks.TaskFailedData{
+			TaskID:   parentTask.ID,
+			Title:    parentTask.Title,
+			Project:  parentTask.ProjectPath,
+			Duration: aggregateResult.Duration,
+			Error:    aggregateResult.Error,
+			Phase:    "Decomposed",
+		})
+	}
+
+	return aggregateResult, nil
 }
 
 // Cancel terminates a running task by killing its Claude Code process.

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2175,13 +2175,7 @@ func (r *Runner) buildQualityGatesResult(outcome *QualityOutcome, totalRetries i
 	}
 
 	for i, detail := range outcome.GateDetails {
-		qgResult.Gates[i] = QualityGateResult{
-			Name:       detail.Name,
-			Passed:     detail.Passed,
-			Duration:   detail.Duration,
-			RetryCount: detail.RetryCount,
-			Error:      detail.Error,
-		}
+		qgResult.Gates[i] = QualityGateResult(detail)
 	}
 
 	return qgResult


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-218.

## Changes

GitHub Issue #218: Wire task decomposition for complex tasks

## Problem

GH-54 implemented `TaskDecomposer` in `internal/executor/decompose.go` but it's never invoked.

Supports:
- Breaking complex tasks into subtasks
- Four decomposition strategies (numbered, bullets, criteria, file groups)
- Only final subtask creates PR

## Current State

Dead code - TaskDecomposer exists but not called in execution flow.

## Solution

1. For complex tasks with decompose enabled, break into subtasks
2. Execute subtasks sequentially
3. Only create PR after final subtask

```go
// In runner.Execute() or dispatcher:
if cfg.Decompose.Enabled && complexity.IsComplex() {
    decomposer := NewTaskDecomposer(cfg.Decompose)
    subtasks := decomposer.Decompose(task)
    for i, subtask := range subtasks {
        subtask.CreatePR = (i == len(subtasks)-1)
        r.Execute(ctx, subtask)
    }
}
```

## Configuration

```yaml
executor:
  decompose:
    enabled: true
    min_complexity: "complex"
    max_subtasks: 5
```

## Files to Modify

- `internal/executor/runner.go` or `dispatcher.go` - Add decomposition logic
- `internal/config/config.go` - Ensure decompose config is loaded

## Acceptance Criteria

- [ ] Complex tasks decomposed into subtasks when enabled
- [ ] Subtasks execute sequentially
- [ ] Only final subtask creates PR
- [ ] Progress shows subtask count (2/5, etc.)
- [ ] Disabled by default (opt-in)