### PR TITLE
feat(adapters): Add Asana inbound adapter

### DIFF
--- a/internal/adapters/asana/client.go
+++ b/internal/adapters/asana/client.go
@@ -1,0 +1,307 @@
+package asana
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// BaseURL is the Asana API base URL
+	BaseURL = "https://app.asana.com/api/1.0"
+)
+
+// Client is an Asana API client
+type Client struct {
+	baseURL     string
+	accessToken string
+	workspaceID string
+	httpClient  *http.Client
+}
+
+// NewClient creates a new Asana client
+func NewClient(accessToken, workspaceID string) *Client {
+	return &Client{
+		baseURL:     BaseURL,
+		accessToken: accessToken,
+		workspaceID: workspaceID,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// NewClientWithBaseURL creates a new Asana client with a custom base URL (for testing)
+func NewClientWithBaseURL(baseURL, accessToken, workspaceID string) *Client {
+	return &Client{
+		baseURL:     strings.TrimSuffix(baseURL, "/"),
+		accessToken: accessToken,
+		workspaceID: workspaceID,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// doRequest performs an HTTP request to the Asana API
+func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}, result interface{}) error {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyBytes, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	url := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Bearer token authentication
+	req.Header.Set("Authorization", "Bearer "+c.accessToken)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Try to parse Asana error response
+		var apiResp APIResponse[interface{}]
+		if err := json.Unmarshal(respBody, &apiResp); err == nil && len(apiResp.Errors) > 0 {
+			return fmt.Errorf("Asana API error (status %d): %s", resp.StatusCode, apiResp.Errors[0].Message)
+		}
+		return fmt.Errorf("Asana API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("failed to parse response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// GetTask fetches a task by GID
+func (c *Client) GetTask(ctx context.Context, taskGID string) (*Task, error) {
+	path := fmt.Sprintf("/tasks/%s", taskGID)
+	var resp APIResponse[Task]
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// GetTaskWithFields fetches a task with specific fields
+func (c *Client) GetTaskWithFields(ctx context.Context, taskGID string, fields []string) (*Task, error) {
+	path := fmt.Sprintf("/tasks/%s?opt_fields=%s", taskGID, strings.Join(fields, ","))
+	var resp APIResponse[Task]
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// UpdateTask updates task fields
+func (c *Client) UpdateTask(ctx context.Context, taskGID string, data map[string]interface{}) (*Task, error) {
+	path := fmt.Sprintf("/tasks/%s", taskGID)
+	reqBody := map[string]interface{}{
+		"data": data,
+	}
+	var resp APIResponse[Task]
+	if err := c.doRequest(ctx, http.MethodPut, path, reqBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// CompleteTask marks a task as completed
+func (c *Client) CompleteTask(ctx context.Context, taskGID string) (*Task, error) {
+	return c.UpdateTask(ctx, taskGID, map[string]interface{}{
+		"completed": true,
+	})
+}
+
+// AddComment adds a comment (story) to a task
+func (c *Client) AddComment(ctx context.Context, taskGID, text string) (*Story, error) {
+	path := fmt.Sprintf("/tasks/%s/stories", taskGID)
+	reqBody := map[string]interface{}{
+		"data": map[string]string{
+			"text": text,
+		},
+	}
+	var resp APIResponse[Story]
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// AddHTMLComment adds an HTML-formatted comment to a task
+func (c *Client) AddHTMLComment(ctx context.Context, taskGID, htmlText string) (*Story, error) {
+	path := fmt.Sprintf("/tasks/%s/stories", taskGID)
+	reqBody := map[string]interface{}{
+		"data": map[string]string{
+			"html_text": htmlText,
+		},
+	}
+	var resp APIResponse[Story]
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// GetTaskStories fetches stories (comments and activity) for a task
+func (c *Client) GetTaskStories(ctx context.Context, taskGID string) ([]Story, error) {
+	path := fmt.Sprintf("/tasks/%s/stories", taskGID)
+	var resp PagedResponse[Story]
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// AddTag adds a tag to a task
+func (c *Client) AddTag(ctx context.Context, taskGID, tagGID string) error {
+	path := fmt.Sprintf("/tasks/%s/addTag", taskGID)
+	reqBody := map[string]interface{}{
+		"data": map[string]string{
+			"tag": tagGID,
+		},
+	}
+	return c.doRequest(ctx, http.MethodPost, path, reqBody, nil)
+}
+
+// RemoveTag removes a tag from a task
+func (c *Client) RemoveTag(ctx context.Context, taskGID, tagGID string) error {
+	path := fmt.Sprintf("/tasks/%s/removeTag", taskGID)
+	reqBody := map[string]interface{}{
+		"data": map[string]string{
+			"tag": tagGID,
+		},
+	}
+	return c.doRequest(ctx, http.MethodPost, path, reqBody, nil)
+}
+
+// GetWorkspaceTags fetches all tags in the workspace
+func (c *Client) GetWorkspaceTags(ctx context.Context) ([]Tag, error) {
+	path := fmt.Sprintf("/workspaces/%s/tags", c.workspaceID)
+	var resp PagedResponse[Tag]
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// FindTagByName finds a tag by name in the workspace
+func (c *Client) FindTagByName(ctx context.Context, name string) (*Tag, error) {
+	tags, err := c.GetWorkspaceTags(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, tag := range tags {
+		if strings.EqualFold(tag.Name, name) {
+			return &tag, nil
+		}
+	}
+	return nil, nil
+}
+
+// CreateTag creates a new tag in the workspace
+func (c *Client) CreateTag(ctx context.Context, name string) (*Tag, error) {
+	path := "/tags"
+	reqBody := map[string]interface{}{
+		"data": map[string]string{
+			"name":      name,
+			"workspace": c.workspaceID,
+		},
+	}
+	var resp APIResponse[Tag]
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// AddAttachment adds an external attachment (URL) to a task
+func (c *Client) AddAttachment(ctx context.Context, taskGID, url, name string) (*Attachment, error) {
+	path := fmt.Sprintf("/tasks/%s/attachments", taskGID)
+	reqBody := map[string]interface{}{
+		"data": map[string]interface{}{
+			"resource_subtype": "external",
+			"url":              url,
+			"name":             name,
+		},
+	}
+	var resp APIResponse[Attachment]
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// GetProject fetches project info
+func (c *Client) GetProject(ctx context.Context, projectGID string) (*Project, error) {
+	path := fmt.Sprintf("/projects/%s", projectGID)
+	var resp APIResponse[Project]
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// GetWorkspace fetches workspace info
+func (c *Client) GetWorkspace(ctx context.Context) (*Workspace, error) {
+	path := fmt.Sprintf("/workspaces/%s", c.workspaceID)
+	var resp APIResponse[Workspace]
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// SearchTasks searches for tasks matching a query
+func (c *Client) SearchTasks(ctx context.Context, query string) ([]Task, error) {
+	path := fmt.Sprintf("/workspaces/%s/tasks/search?text=%s", c.workspaceID, query)
+	var resp PagedResponse[Task]
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// GetTasksByTag fetches tasks with a specific tag
+func (c *Client) GetTasksByTag(ctx context.Context, tagGID string) ([]Task, error) {
+	path := fmt.Sprintf("/tags/%s/tasks", tagGID)
+	var resp PagedResponse[Task]
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// Ping checks if the Asana API is accessible and the token is valid
+func (c *Client) Ping(ctx context.Context) error {
+	_, err := c.GetWorkspace(ctx)
+	return err
+}

--- a/internal/adapters/asana/client_test.go
+++ b/internal/adapters/asana/client_test.go
@@ -1,0 +1,775 @@
+package asana
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestNewClient(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	if client == nil {
+		t.Fatal("NewClient returned nil")
+	}
+	if client.baseURL != BaseURL {
+		t.Errorf("client.baseURL = %s, want %s", client.baseURL, BaseURL)
+	}
+	if client.workspaceID != testutil.FakeAsanaWorkspaceID {
+		t.Errorf("client.workspaceID = %s, want %s", client.workspaceID, testutil.FakeAsanaWorkspaceID)
+	}
+}
+
+func TestNewClientWithBaseURL(t *testing.T) {
+	customURL := "https://custom.asana.test"
+	client := NewClientWithBaseURL(customURL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	if client.baseURL != customURL {
+		t.Errorf("client.baseURL = %s, want %s", client.baseURL, customURL)
+	}
+}
+
+func TestNewClientWithBaseURL_TrimsTrailingSlash(t *testing.T) {
+	client := NewClientWithBaseURL("https://custom.asana.test/", testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	if client.baseURL != "https://custom.asana.test" {
+		t.Errorf("client.baseURL = %s, want no trailing slash", client.baseURL)
+	}
+}
+
+func TestGetTask(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request
+		if r.URL.Path != "/tasks/123456" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer "+testutil.FakeAsanaAccessToken {
+			t.Error("missing or incorrect Authorization header")
+		}
+		if r.Header.Get("Accept") != "application/json" {
+			t.Error("missing Accept header")
+		}
+
+		resp := APIResponse[Task]{
+			Data: Task{
+				GID:  "123456",
+				Name: "Test Task",
+				Notes: "Task description",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	task, err := client.GetTask(context.Background(), "123456")
+	if err != nil {
+		t.Fatalf("GetTask failed: %v", err)
+	}
+	if task.GID != "123456" {
+		t.Errorf("task.GID = %s, want 123456", task.GID)
+	}
+	if task.Name != "Test Task" {
+		t.Errorf("task.Name = %s, want Test Task", task.Name)
+	}
+}
+
+func TestGetTaskWithFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify fields parameter
+		fields := r.URL.Query().Get("opt_fields")
+		if fields == "" {
+			t.Error("expected opt_fields query parameter")
+		}
+
+		resp := APIResponse[Task]{
+			Data: Task{
+				GID:  "123456",
+				Name: "Test Task",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	task, err := client.GetTaskWithFields(context.Background(), "123456", []string{"gid", "name", "notes"})
+	if err != nil {
+		t.Fatalf("GetTaskWithFields failed: %v", err)
+	}
+	if task.GID != "123456" {
+		t.Errorf("task.GID = %s, want 123456", task.GID)
+	}
+}
+
+func TestUpdateTask(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		data, ok := body["data"].(map[string]interface{})
+		if !ok {
+			t.Error("expected data wrapper in request body")
+		}
+		if data["completed"] != true {
+			t.Error("expected completed to be true")
+		}
+
+		resp := APIResponse[Task]{
+			Data: Task{
+				GID:       "123456",
+				Completed: true,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	task, err := client.UpdateTask(context.Background(), "123456", map[string]interface{}{
+		"completed": true,
+	})
+	if err != nil {
+		t.Fatalf("UpdateTask failed: %v", err)
+	}
+	if !task.Completed {
+		t.Error("expected task to be completed")
+	}
+}
+
+func TestCompleteTask(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := APIResponse[Task]{
+			Data: Task{
+				GID:       "123456",
+				Completed: true,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	task, err := client.CompleteTask(context.Background(), "123456")
+	if err != nil {
+		t.Fatalf("CompleteTask failed: %v", err)
+	}
+	if !task.Completed {
+		t.Error("expected task to be completed")
+	}
+}
+
+func TestAddComment(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/tasks/123456/stories" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		data, ok := body["data"].(map[string]interface{})
+		if !ok {
+			t.Error("expected data wrapper in request body")
+		}
+		if data["text"] != "Test comment" {
+			t.Errorf("unexpected comment text: %v", data["text"])
+		}
+
+		resp := APIResponse[Story]{
+			Data: Story{
+				GID:  "789",
+				Text: "Test comment",
+				Type: "comment",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	story, err := client.AddComment(context.Background(), "123456", "Test comment")
+	if err != nil {
+		t.Fatalf("AddComment failed: %v", err)
+	}
+	if story.Text != "Test comment" {
+		t.Errorf("story.Text = %s, want Test comment", story.Text)
+	}
+}
+
+func TestAddHTMLComment(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		data, ok := body["data"].(map[string]interface{})
+		if !ok {
+			t.Error("expected data wrapper in request body")
+		}
+		if data["html_text"] != "<b>Bold</b> text" {
+			t.Errorf("unexpected html_text: %v", data["html_text"])
+		}
+
+		resp := APIResponse[Story]{
+			Data: Story{
+				GID:      "789",
+				HTMLText: "<b>Bold</b> text",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	_, err := client.AddHTMLComment(context.Background(), "123456", "<b>Bold</b> text")
+	if err != nil {
+		t.Fatalf("AddHTMLComment failed: %v", err)
+	}
+}
+
+func TestAddTag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/tasks/123456/addTag" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		data := body["data"].(map[string]interface{})
+		if data["tag"] != "999" {
+			t.Errorf("unexpected tag GID: %v", data["tag"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	err := client.AddTag(context.Background(), "123456", "999")
+	if err != nil {
+		t.Fatalf("AddTag failed: %v", err)
+	}
+}
+
+func TestRemoveTag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tasks/123456/removeTag" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	err := client.RemoveTag(context.Background(), "123456", "999")
+	if err != nil {
+		t.Fatalf("RemoveTag failed: %v", err)
+	}
+}
+
+func TestGetWorkspaceTags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedPath := "/workspaces/" + testutil.FakeAsanaWorkspaceID + "/tags"
+		if r.URL.Path != expectedPath {
+			t.Errorf("unexpected path: %s, want %s", r.URL.Path, expectedPath)
+		}
+
+		resp := PagedResponse[Tag]{
+			Data: []Tag{
+				{GID: "1", Name: "pilot"},
+				{GID: "2", Name: "urgent"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	tags, err := client.GetWorkspaceTags(context.Background())
+	if err != nil {
+		t.Fatalf("GetWorkspaceTags failed: %v", err)
+	}
+	if len(tags) != 2 {
+		t.Errorf("expected 2 tags, got %d", len(tags))
+	}
+}
+
+func TestFindTagByName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := PagedResponse[Tag]{
+			Data: []Tag{
+				{GID: "1", Name: "pilot"},
+				{GID: "2", Name: "urgent"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+
+	// Test case-insensitive match
+	tag, err := client.FindTagByName(context.Background(), "PILOT")
+	if err != nil {
+		t.Fatalf("FindTagByName failed: %v", err)
+	}
+	if tag == nil {
+		t.Fatal("expected to find tag")
+	}
+	if tag.GID != "1" {
+		t.Errorf("tag.GID = %s, want 1", tag.GID)
+	}
+}
+
+func TestFindTagByName_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := PagedResponse[Tag]{
+			Data: []Tag{
+				{GID: "1", Name: "other"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	tag, err := client.FindTagByName(context.Background(), "pilot")
+	if err != nil {
+		t.Fatalf("FindTagByName failed: %v", err)
+	}
+	if tag != nil {
+		t.Error("expected nil when tag not found")
+	}
+}
+
+func TestCreateTag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/tags" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		data := body["data"].(map[string]interface{})
+		if data["name"] != "pilot" {
+			t.Errorf("unexpected tag name: %v", data["name"])
+		}
+		if data["workspace"] != testutil.FakeAsanaWorkspaceID {
+			t.Errorf("unexpected workspace: %v", data["workspace"])
+		}
+
+		resp := APIResponse[Tag]{
+			Data: Tag{
+				GID:  "999",
+				Name: "pilot",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	tag, err := client.CreateTag(context.Background(), "pilot")
+	if err != nil {
+		t.Fatalf("CreateTag failed: %v", err)
+	}
+	if tag.Name != "pilot" {
+		t.Errorf("tag.Name = %s, want pilot", tag.Name)
+	}
+}
+
+func TestAddAttachment(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/tasks/123456/attachments" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		data := body["data"].(map[string]interface{})
+		if data["resource_subtype"] != "external" {
+			t.Errorf("unexpected resource_subtype: %v", data["resource_subtype"])
+		}
+		if data["url"] != "https://github.com/owner/repo/pull/123" {
+			t.Errorf("unexpected url: %v", data["url"])
+		}
+
+		resp := APIResponse[Attachment]{
+			Data: Attachment{
+				GID:     "attach-1",
+				Name:    "PR #123",
+				ViewURL: "https://github.com/owner/repo/pull/123",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	attachment, err := client.AddAttachment(context.Background(), "123456", "https://github.com/owner/repo/pull/123", "PR #123")
+	if err != nil {
+		t.Fatalf("AddAttachment failed: %v", err)
+	}
+	if attachment.Name != "PR #123" {
+		t.Errorf("attachment.Name = %s, want PR #123", attachment.Name)
+	}
+}
+
+func TestGetWorkspace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedPath := "/workspaces/" + testutil.FakeAsanaWorkspaceID
+		if r.URL.Path != expectedPath {
+			t.Errorf("unexpected path: %s, want %s", r.URL.Path, expectedPath)
+		}
+
+		resp := APIResponse[Workspace]{
+			Data: Workspace{
+				GID:  testutil.FakeAsanaWorkspaceID,
+				Name: "Test Workspace",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	workspace, err := client.GetWorkspace(context.Background())
+	if err != nil {
+		t.Fatalf("GetWorkspace failed: %v", err)
+	}
+	if workspace.Name != "Test Workspace" {
+		t.Errorf("workspace.Name = %s, want Test Workspace", workspace.Name)
+	}
+}
+
+func TestPing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := APIResponse[Workspace]{
+			Data: Workspace{
+				GID:  testutil.FakeAsanaWorkspaceID,
+				Name: "Test Workspace",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	err := client.Ping(context.Background())
+	if err != nil {
+		t.Fatalf("Ping failed: %v", err)
+	}
+}
+
+func TestDoRequest_ErrorHandling(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		response   string
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			response:   `{"data": {"gid": "1"}}`,
+			wantErr:    false,
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			response:   `{"errors": [{"message": "Not found"}]}`,
+			wantErr:    true,
+		},
+		{
+			name:       "unauthorized",
+			statusCode: http.StatusUnauthorized,
+			response:   `{"errors": [{"message": "Not Authorized"}]}`,
+			wantErr:    true,
+		},
+		{
+			name:       "rate limited",
+			statusCode: http.StatusTooManyRequests,
+			response:   `{"errors": [{"message": "Rate limit exceeded"}]}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+			_, err := client.GetTask(context.Background(), "123")
+
+			if tt.wantErr && err == nil {
+				t.Error("expected error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Enabled != false {
+		t.Errorf("default Enabled = %v, want false", cfg.Enabled)
+	}
+	if cfg.PilotTag != "pilot" {
+		t.Errorf("default PilotTag = %s, want 'pilot'", cfg.PilotTag)
+	}
+}
+
+func TestPriorityFromTags(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []Tag
+		want Priority
+	}{
+		{
+			name: "urgent tag",
+			tags: []Tag{{GID: "1", Name: "urgent"}},
+			want: PriorityUrgent,
+		},
+		{
+			name: "high tag",
+			tags: []Tag{{GID: "1", Name: "High"}},
+			want: PriorityHigh,
+		},
+		{
+			name: "medium tag",
+			tags: []Tag{{GID: "1", Name: "MEDIUM"}},
+			want: PriorityMedium,
+		},
+		{
+			name: "low tag",
+			tags: []Tag{{GID: "1", Name: "low"}},
+			want: PriorityLow,
+		},
+		{
+			name: "critical tag",
+			tags: []Tag{{GID: "1", Name: "Critical"}},
+			want: PriorityUrgent,
+		},
+		{
+			name: "no priority tags",
+			tags: []Tag{{GID: "1", Name: "bug"}, {GID: "2", Name: "feature"}},
+			want: PriorityNone,
+		},
+		{
+			name: "empty tags",
+			tags: []Tag{},
+			want: PriorityNone,
+		},
+		{
+			name: "priority in mixed tags",
+			tags: []Tag{{GID: "1", Name: "bug"}, {GID: "2", Name: "urgent"}, {GID: "3", Name: "feature"}},
+			want: PriorityUrgent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PriorityFromTags(tt.tags)
+			if got != tt.want {
+				t.Errorf("PriorityFromTags() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPriorityName(t *testing.T) {
+	tests := []struct {
+		priority Priority
+		want     string
+	}{
+		{PriorityUrgent, "Urgent"},
+		{PriorityHigh, "High"},
+		{PriorityMedium, "Medium"},
+		{PriorityLow, "Low"},
+		{PriorityNone, "No Priority"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := PriorityName(tt.priority)
+			if got != tt.want {
+				t.Errorf("PriorityName(%d) = %s, want %s", tt.priority, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertToTaskInfo(t *testing.T) {
+	task := &Task{
+		GID:   "123456",
+		Name:  "Implement feature",
+		Notes: "Feature description here",
+		Tags: []Tag{
+			{GID: "1", Name: "pilot"},
+			{GID: "2", Name: "urgent"},
+		},
+		Projects: []Project{
+			{GID: "proj-1", Name: "Main Project"},
+		},
+		Permalink: "https://app.asana.com/0/0/123456",
+	}
+
+	info := ConvertToTaskInfo(task)
+
+	if info.ID != "ASANA-123456" {
+		t.Errorf("info.ID = %s, want ASANA-123456", info.ID)
+	}
+	if info.Title != "Implement feature" {
+		t.Errorf("info.Title = %s, want Implement feature", info.Title)
+	}
+	if info.Description != "Feature description here" {
+		t.Errorf("info.Description = %s, want Feature description here", info.Description)
+	}
+	if info.Priority != PriorityUrgent {
+		t.Errorf("info.Priority = %d, want %d", info.Priority, PriorityUrgent)
+	}
+	if len(info.Labels) != 2 {
+		t.Errorf("len(info.Labels) = %d, want 2", len(info.Labels))
+	}
+	if info.TaskGID != "123456" {
+		t.Errorf("info.TaskGID = %s, want 123456", info.TaskGID)
+	}
+	if info.TaskURL != "https://app.asana.com/0/0/123456" {
+		t.Errorf("info.TaskURL = %s, want https://app.asana.com/0/0/123456", info.TaskURL)
+	}
+	if info.ProjectName != "Main Project" {
+		t.Errorf("info.ProjectName = %s, want Main Project", info.ProjectName)
+	}
+}
+
+func TestConvertToTaskInfo_NoPermalink(t *testing.T) {
+	task := &Task{
+		GID:  "123456",
+		Name: "Task without permalink",
+	}
+
+	info := ConvertToTaskInfo(task)
+
+	expectedURL := "https://app.asana.com/0/0/123456"
+	if info.TaskURL != expectedURL {
+		t.Errorf("info.TaskURL = %s, want %s", info.TaskURL, expectedURL)
+	}
+}
+
+// Integration test helper - verifies client method signatures compile
+func TestClientMethodSignatures(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	ctx := context.Background()
+
+	// These won't actually work without a real API, but verify the signatures compile
+	var err error
+
+	_, err = client.GetTask(ctx, "123")
+	_ = err
+
+	_, err = client.GetTaskWithFields(ctx, "123", []string{"gid", "name"})
+	_ = err
+
+	_, err = client.UpdateTask(ctx, "123", map[string]interface{}{"completed": true})
+	_ = err
+
+	_, err = client.CompleteTask(ctx, "123")
+	_ = err
+
+	_, err = client.AddComment(ctx, "123", "comment")
+	_ = err
+
+	_, err = client.AddHTMLComment(ctx, "123", "<b>html</b>")
+	_ = err
+
+	_, err = client.GetTaskStories(ctx, "123")
+	_ = err
+
+	err = client.AddTag(ctx, "123", "456")
+	_ = err
+
+	err = client.RemoveTag(ctx, "123", "456")
+	_ = err
+
+	_, err = client.GetWorkspaceTags(ctx)
+	_ = err
+
+	_, err = client.FindTagByName(ctx, "pilot")
+	_ = err
+
+	_, err = client.CreateTag(ctx, "newtag")
+	_ = err
+
+	_, err = client.AddAttachment(ctx, "123", "https://example.com", "Link")
+	_ = err
+
+	_, err = client.GetProject(ctx, "proj-1")
+	_ = err
+
+	_, err = client.GetWorkspace(ctx)
+	_ = err
+
+	_, err = client.SearchTasks(ctx, "query")
+	_ = err
+
+	_, err = client.GetTasksByTag(ctx, "tag-1")
+	_ = err
+
+	err = client.Ping(ctx)
+	_ = err
+}

--- a/internal/adapters/asana/notifier.go
+++ b/internal/adapters/asana/notifier.go
@@ -1,0 +1,204 @@
+package asana
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// Notifier handles status updates to Asana tasks
+type Notifier struct {
+	client      *Client
+	pilotTag    string
+	pilotTagGID string // Cached GID for the pilot tag
+}
+
+// NewNotifier creates a new Asana notifier
+func NewNotifier(client *Client, pilotTag string) *Notifier {
+	return &Notifier{
+		client:   client,
+		pilotTag: pilotTag,
+	}
+}
+
+// NotifyTaskStarted posts a comment indicating Pilot started work
+func (n *Notifier) NotifyTaskStarted(ctx context.Context, taskGID, pilotTaskID string) error {
+	comment := fmt.Sprintf("🤖 **Pilot started working on this task**\n\nTask ID: `%s`\n\nI'll post updates as I make progress.", pilotTaskID)
+
+	if _, err := n.client.AddComment(ctx, taskGID, comment); err != nil {
+		return fmt.Errorf("failed to add start comment: %w", err)
+	}
+
+	logging.WithComponent("asana").Info("Notified task started",
+		slog.String("task_gid", taskGID),
+		slog.String("pilot_task_id", pilotTaskID))
+
+	return nil
+}
+
+// NotifyProgress posts a progress update comment
+func (n *Notifier) NotifyProgress(ctx context.Context, taskGID, phase, details string) error {
+	var emoji string
+	switch strings.ToLower(phase) {
+	case "exploring", "research":
+		emoji = "🔍"
+	case "implementing", "impl":
+		emoji = "🔨"
+	case "testing", "verify":
+		emoji = "🧪"
+	case "committing":
+		emoji = "📝"
+	case "reviewing":
+		emoji = "👀"
+	default:
+		emoji = "⏳"
+	}
+
+	comment := fmt.Sprintf("%s **Phase: %s**\n\n%s", emoji, phase, details)
+
+	if _, err := n.client.AddComment(ctx, taskGID, comment); err != nil {
+		return fmt.Errorf("failed to add progress comment: %w", err)
+	}
+
+	logging.WithComponent("asana").Debug("Posted progress update",
+		slog.String("task_gid", taskGID),
+		slog.String("phase", phase))
+
+	return nil
+}
+
+// NotifyTaskCompleted posts completion comment and marks task as complete
+func (n *Notifier) NotifyTaskCompleted(ctx context.Context, taskGID, prURL, summary string) error {
+	// Post completion comment
+	var comment strings.Builder
+	comment.WriteString("✅ **Pilot completed this task!**\n\n")
+
+	if prURL != "" {
+		comment.WriteString(fmt.Sprintf("**Pull Request**: %s\n\n", prURL))
+	}
+
+	if summary != "" {
+		comment.WriteString("**Summary**:\n")
+		comment.WriteString(summary)
+		comment.WriteString("\n\n")
+	}
+
+	comment.WriteString("_This task will be marked complete when the PR is merged._")
+
+	if _, err := n.client.AddComment(ctx, taskGID, comment.String()); err != nil {
+		return fmt.Errorf("failed to add completion comment: %w", err)
+	}
+
+	logging.WithComponent("asana").Info("Notified task completed",
+		slog.String("task_gid", taskGID),
+		slog.String("pr_url", prURL))
+
+	return nil
+}
+
+// CompleteTask marks the task as completed in Asana
+func (n *Notifier) CompleteTask(ctx context.Context, taskGID string) error {
+	if _, err := n.client.CompleteTask(ctx, taskGID); err != nil {
+		return fmt.Errorf("failed to complete task: %w", err)
+	}
+
+	logging.WithComponent("asana").Info("Marked task as complete",
+		slog.String("task_gid", taskGID))
+
+	return nil
+}
+
+// NotifyTaskFailed posts failure comment
+func (n *Notifier) NotifyTaskFailed(ctx context.Context, taskGID, reason string) error {
+	comment := fmt.Sprintf("❌ **Pilot could not complete this task**\n\n**Reason**: %s\n\n_Please review the task and consider manual intervention or reopening with more details._", reason)
+
+	if _, err := n.client.AddComment(ctx, taskGID, comment); err != nil {
+		return fmt.Errorf("failed to add failure comment: %w", err)
+	}
+
+	logging.WithComponent("asana").Warn("Notified task failed",
+		slog.String("task_gid", taskGID),
+		slog.String("reason", reason))
+
+	return nil
+}
+
+// LinkPR adds a PR link as an attachment to the task
+func (n *Notifier) LinkPR(ctx context.Context, taskGID string, prNumber int, prURL string) error {
+	prName := fmt.Sprintf("Pull Request #%d", prNumber)
+
+	if _, err := n.client.AddAttachment(ctx, taskGID, prURL, prName); err != nil {
+		logging.WithComponent("asana").Warn("Failed to add PR attachment, posting comment instead",
+			slog.String("task_gid", taskGID),
+			slog.Any("error", err))
+		// Fall back to comment
+	}
+
+	// Also post a comment for visibility
+	comment := fmt.Sprintf("🔗 **Pull Request Created**: [PR #%d](%s)\n\n_This PR implements the changes for this task._", prNumber, prURL)
+
+	if _, err := n.client.AddComment(ctx, taskGID, comment); err != nil {
+		return fmt.Errorf("failed to add PR link comment: %w", err)
+	}
+
+	logging.WithComponent("asana").Info("Linked PR to task",
+		slog.String("task_gid", taskGID),
+		slog.Int("pr_number", prNumber))
+
+	return nil
+}
+
+// RemovePilotTag removes the pilot tag from a task (after completion)
+func (n *Notifier) RemovePilotTag(ctx context.Context, taskGID string) error {
+	// Find pilot tag GID if not cached
+	if n.pilotTagGID == "" {
+		tag, err := n.client.FindTagByName(ctx, n.pilotTag)
+		if err != nil {
+			return fmt.Errorf("failed to find pilot tag: %w", err)
+		}
+		if tag == nil {
+			// Tag doesn't exist, nothing to remove
+			return nil
+		}
+		n.pilotTagGID = tag.GID
+	}
+
+	if err := n.client.RemoveTag(ctx, taskGID, n.pilotTagGID); err != nil {
+		// Log but don't fail - tag might already be removed
+		logging.WithComponent("asana").Warn("Failed to remove pilot tag",
+			slog.String("task_gid", taskGID),
+			slog.Any("error", err))
+	}
+
+	return nil
+}
+
+// AddPilotTag adds the pilot tag to a task
+func (n *Notifier) AddPilotTag(ctx context.Context, taskGID string) error {
+	// Find or create pilot tag
+	if n.pilotTagGID == "" {
+		tag, err := n.client.FindTagByName(ctx, n.pilotTag)
+		if err != nil {
+			return fmt.Errorf("failed to find pilot tag: %w", err)
+		}
+		if tag == nil {
+			// Create the tag
+			newTag, err := n.client.CreateTag(ctx, n.pilotTag)
+			if err != nil {
+				return fmt.Errorf("failed to create pilot tag: %w", err)
+			}
+			n.pilotTagGID = newTag.GID
+		} else {
+			n.pilotTagGID = tag.GID
+		}
+	}
+
+	if err := n.client.AddTag(ctx, taskGID, n.pilotTagGID); err != nil {
+		return fmt.Errorf("failed to add pilot tag: %w", err)
+	}
+
+	return nil
+}

--- a/internal/adapters/asana/notifier_test.go
+++ b/internal/adapters/asana/notifier_test.go
@@ -1,0 +1,516 @@
+package asana
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestNewNotifier(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	notifier := NewNotifier(client, "pilot")
+
+	if notifier == nil {
+		t.Fatal("NewNotifier returned nil")
+	}
+	if notifier.pilotTag != "pilot" {
+		t.Errorf("notifier.pilotTag = %s, want pilot", notifier.pilotTag)
+	}
+}
+
+func TestNotifyTaskStarted(t *testing.T) {
+	var capturedComment string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		data := body["data"].(map[string]interface{})
+		capturedComment = data["text"].(string)
+
+		resp := APIResponse[Story]{
+			Data: Story{
+				GID:  "story-1",
+				Text: capturedComment,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.NotifyTaskStarted(context.Background(), "123456", "PILOT-001")
+	if err != nil {
+		t.Fatalf("NotifyTaskStarted failed: %v", err)
+	}
+
+	if !strings.Contains(capturedComment, "Pilot started working") {
+		t.Errorf("comment should mention Pilot started, got: %s", capturedComment)
+	}
+	if !strings.Contains(capturedComment, "PILOT-001") {
+		t.Errorf("comment should contain task ID, got: %s", capturedComment)
+	}
+}
+
+func TestNotifyProgress(t *testing.T) {
+	tests := []struct {
+		phase    string
+		wantEmoji string
+	}{
+		{"exploring", "🔍"},
+		{"research", "🔍"},
+		{"implementing", "🔨"},
+		{"impl", "🔨"},
+		{"testing", "🧪"},
+		{"verify", "🧪"},
+		{"committing", "📝"},
+		{"reviewing", "👀"},
+		{"unknown", "⏳"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.phase, func(t *testing.T) {
+			var capturedComment string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]interface{}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("failed to decode body: %v", err)
+				}
+				data := body["data"].(map[string]interface{})
+				capturedComment = data["text"].(string)
+
+				resp := APIResponse[Story]{
+					Data: Story{GID: "story-1", Text: capturedComment},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+			notifier := NewNotifier(client, "pilot")
+
+			err := notifier.NotifyProgress(context.Background(), "123456", tt.phase, "Progress details")
+			if err != nil {
+				t.Fatalf("NotifyProgress failed: %v", err)
+			}
+
+			if !strings.Contains(capturedComment, tt.wantEmoji) {
+				t.Errorf("comment should contain emoji %s, got: %s", tt.wantEmoji, capturedComment)
+			}
+			if !strings.Contains(capturedComment, tt.phase) {
+				t.Errorf("comment should contain phase %s, got: %s", tt.phase, capturedComment)
+			}
+		})
+	}
+}
+
+func TestNotifyTaskCompleted(t *testing.T) {
+	var capturedComment string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		data := body["data"].(map[string]interface{})
+		capturedComment = data["text"].(string)
+
+		resp := APIResponse[Story]{
+			Data: Story{GID: "story-1", Text: capturedComment},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.NotifyTaskCompleted(context.Background(), "123456", "https://github.com/owner/repo/pull/42", "Added feature X")
+	if err != nil {
+		t.Fatalf("NotifyTaskCompleted failed: %v", err)
+	}
+
+	if !strings.Contains(capturedComment, "Pilot completed") {
+		t.Errorf("comment should mention completion, got: %s", capturedComment)
+	}
+	if !strings.Contains(capturedComment, "github.com/owner/repo/pull/42") {
+		t.Errorf("comment should contain PR URL, got: %s", capturedComment)
+	}
+	if !strings.Contains(capturedComment, "Added feature X") {
+		t.Errorf("comment should contain summary, got: %s", capturedComment)
+	}
+}
+
+func TestNotifyTaskCompleted_NoPR(t *testing.T) {
+	var capturedComment string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		data := body["data"].(map[string]interface{})
+		capturedComment = data["text"].(string)
+
+		resp := APIResponse[Story]{
+			Data: Story{GID: "story-1", Text: capturedComment},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.NotifyTaskCompleted(context.Background(), "123456", "", "")
+	if err != nil {
+		t.Fatalf("NotifyTaskCompleted failed: %v", err)
+	}
+
+	if !strings.Contains(capturedComment, "Pilot completed") {
+		t.Errorf("comment should mention completion, got: %s", capturedComment)
+	}
+}
+
+func TestNotifier_CompleteTask(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+
+		data := body["data"].(map[string]interface{})
+		if data["completed"] != true {
+			t.Error("expected completed to be true")
+		}
+
+		resp := APIResponse[Task]{
+			Data: Task{GID: "123456", Completed: true},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.CompleteTask(context.Background(), "123456")
+	if err != nil {
+		t.Fatalf("CompleteTask failed: %v", err)
+	}
+}
+
+func TestNotifyTaskFailed(t *testing.T) {
+	var capturedComment string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		data := body["data"].(map[string]interface{})
+		capturedComment = data["text"].(string)
+
+		resp := APIResponse[Story]{
+			Data: Story{GID: "story-1", Text: capturedComment},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.NotifyTaskFailed(context.Background(), "123456", "Build failed with errors")
+	if err != nil {
+		t.Fatalf("NotifyTaskFailed failed: %v", err)
+	}
+
+	if !strings.Contains(capturedComment, "could not complete") {
+		t.Errorf("comment should mention failure, got: %s", capturedComment)
+	}
+	if !strings.Contains(capturedComment, "Build failed with errors") {
+		t.Errorf("comment should contain reason, got: %s", capturedComment)
+	}
+}
+
+func TestLinkPR(t *testing.T) {
+	requestCount := 0
+	var capturedComment string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		if strings.Contains(r.URL.Path, "/attachments") {
+			// Attachment request
+			resp := APIResponse[Attachment]{
+				Data: Attachment{GID: "attach-1", Name: "PR #42"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if strings.Contains(r.URL.Path, "/stories") {
+			// Comment request
+			var body map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode body: %v", err)
+			}
+			data := body["data"].(map[string]interface{})
+			capturedComment = data["text"].(string)
+
+			resp := APIResponse[Story]{
+				Data: Story{GID: "story-1", Text: capturedComment},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		t.Errorf("unexpected request path: %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.LinkPR(context.Background(), "123456", 42, "https://github.com/owner/repo/pull/42")
+	if err != nil {
+		t.Fatalf("LinkPR failed: %v", err)
+	}
+
+	if requestCount < 2 {
+		t.Errorf("expected at least 2 requests (attachment + comment), got %d", requestCount)
+	}
+
+	if !strings.Contains(capturedComment, "PR #42") {
+		t.Errorf("comment should mention PR number, got: %s", capturedComment)
+	}
+	if !strings.Contains(capturedComment, "github.com/owner/repo/pull/42") {
+		t.Errorf("comment should contain PR URL, got: %s", capturedComment)
+	}
+}
+
+func TestRemovePilotTag(t *testing.T) {
+	requestCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		if strings.Contains(r.URL.Path, "/tags") && r.Method == http.MethodGet {
+			// Get workspace tags
+			resp := PagedResponse[Tag]{
+				Data: []Tag{
+					{GID: "pilot-tag-1", Name: "pilot"},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if strings.Contains(r.URL.Path, "/removeTag") {
+			// Remove tag request
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{}}`))
+			return
+		}
+
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.RemovePilotTag(context.Background(), "123456")
+	if err != nil {
+		t.Fatalf("RemovePilotTag failed: %v", err)
+	}
+
+	if requestCount != 2 {
+		t.Errorf("expected 2 requests (get tags + remove tag), got %d", requestCount)
+	}
+}
+
+func TestRemovePilotTag_CachedGID(t *testing.T) {
+	requestCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		if strings.Contains(r.URL.Path, "/removeTag") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{}}`))
+			return
+		}
+
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	notifier := NewNotifier(client, "pilot")
+	notifier.pilotTagGID = "cached-tag-gid" // Pre-cache the GID
+
+	err := notifier.RemovePilotTag(context.Background(), "123456")
+	if err != nil {
+		t.Fatalf("RemovePilotTag failed: %v", err)
+	}
+
+	// Should only make the remove request, not the get tags request
+	if requestCount != 1 {
+		t.Errorf("expected 1 request (remove tag only), got %d", requestCount)
+	}
+}
+
+func TestAddPilotTag(t *testing.T) {
+	requestCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		if strings.Contains(r.URL.Path, "/workspaces/") && strings.Contains(r.URL.Path, "/tags") {
+			// Get workspace tags
+			resp := PagedResponse[Tag]{
+				Data: []Tag{
+					{GID: "pilot-tag-1", Name: "pilot"},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if strings.Contains(r.URL.Path, "/addTag") {
+			// Add tag request
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{}}`))
+			return
+		}
+
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.AddPilotTag(context.Background(), "123456")
+	if err != nil {
+		t.Fatalf("AddPilotTag failed: %v", err)
+	}
+
+	if requestCount != 2 {
+		t.Errorf("expected 2 requests (get tags + add tag), got %d", requestCount)
+	}
+}
+
+func TestAddPilotTag_CreateNew(t *testing.T) {
+	requestCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		if strings.Contains(r.URL.Path, "/workspaces/") && strings.Contains(r.URL.Path, "/tags") {
+			// Get workspace tags - return empty (tag doesn't exist)
+			resp := PagedResponse[Tag]{
+				Data: []Tag{},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if r.URL.Path == "/tags" && r.Method == http.MethodPost {
+			// Create tag request
+			resp := APIResponse[Tag]{
+				Data: Tag{GID: "new-tag-1", Name: "pilot"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if strings.Contains(r.URL.Path, "/addTag") {
+			// Add tag request
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{}}`))
+			return
+		}
+
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.AddPilotTag(context.Background(), "123456")
+	if err != nil {
+		t.Fatalf("AddPilotTag failed: %v", err)
+	}
+
+	// Should make: get tags, create tag, add tag
+	if requestCount != 3 {
+		t.Errorf("expected 3 requests, got %d", requestCount)
+	}
+}
+
+func TestNotifierMethodSignatures(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	notifier := NewNotifier(client, "pilot")
+	ctx := context.Background()
+
+	// Verify method signatures compile
+	var err error
+
+	err = notifier.NotifyTaskStarted(ctx, "123", "PILOT-001")
+	_ = err
+
+	err = notifier.NotifyProgress(ctx, "123", "implementing", "details")
+	_ = err
+
+	err = notifier.NotifyTaskCompleted(ctx, "123", "https://github.com/pr", "summary")
+	_ = err
+
+	err = notifier.CompleteTask(ctx, "123")
+	_ = err
+
+	err = notifier.NotifyTaskFailed(ctx, "123", "reason")
+	_ = err
+
+	err = notifier.LinkPR(ctx, "123", 42, "https://github.com/pr")
+	_ = err
+
+	err = notifier.RemovePilotTag(ctx, "123")
+	_ = err
+
+	err = notifier.AddPilotTag(ctx, "123")
+	_ = err
+}

--- a/internal/adapters/asana/types.go
+++ b/internal/adapters/asana/types.go
@@ -1,0 +1,277 @@
+// Package asana provides an adapter for Asana task management.
+package asana
+
+import "time"
+
+// Config holds Asana adapter configuration
+type Config struct {
+	Enabled       bool   `yaml:"enabled"`
+	AccessToken   string `yaml:"access_token"`    // Personal access token or OAuth token
+	WorkspaceID   string `yaml:"workspace_id"`    // Asana workspace GID
+	WebhookSecret string `yaml:"webhook_secret"`  // For X-Hook-Secret verification
+	PilotTag      string `yaml:"pilot_tag"`       // Tag name that triggers Pilot (default: "pilot")
+}
+
+// DefaultConfig returns default Asana configuration
+func DefaultConfig() *Config {
+	return &Config{
+		Enabled:  false,
+		PilotTag: "pilot",
+	}
+}
+
+// Priority represents task priority levels
+type Priority int
+
+const (
+	PriorityNone   Priority = 0
+	PriorityUrgent Priority = 1
+	PriorityHigh   Priority = 2
+	PriorityMedium Priority = 3
+	PriorityLow    Priority = 4
+)
+
+// PriorityFromTags extracts priority from Asana tags
+func PriorityFromTags(tags []Tag) Priority {
+	for _, tag := range tags {
+		switch tag.Name {
+		case "urgent", "Urgent", "URGENT", "critical", "Critical", "CRITICAL":
+			return PriorityUrgent
+		case "high", "High", "HIGH":
+			return PriorityHigh
+		case "medium", "Medium", "MEDIUM":
+			return PriorityMedium
+		case "low", "Low", "LOW":
+			return PriorityLow
+		}
+	}
+	return PriorityNone
+}
+
+// PriorityName returns the human-readable priority name
+func PriorityName(priority Priority) string {
+	switch priority {
+	case PriorityUrgent:
+		return "Urgent"
+	case PriorityHigh:
+		return "High"
+	case PriorityMedium:
+		return "Medium"
+	case PriorityLow:
+		return "Low"
+	default:
+		return "No Priority"
+	}
+}
+
+// Task represents an Asana task
+type Task struct {
+	GID          string     `json:"gid"`
+	Name         string     `json:"name"`
+	Notes        string     `json:"notes"`
+	HTMLNotes    string     `json:"html_notes,omitempty"`
+	Completed    bool       `json:"completed"`
+	CompletedAt  *time.Time `json:"completed_at,omitempty"`
+	Assignee     *User      `json:"assignee,omitempty"`
+	AssigneeSection *Section `json:"assignee_section,omitempty"`
+	Projects     []Project  `json:"projects,omitempty"`
+	Tags         []Tag      `json:"tags,omitempty"`
+	Workspace    *Workspace `json:"workspace,omitempty"`
+	Parent       *Task      `json:"parent,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	ModifiedAt   time.Time  `json:"modified_at"`
+	DueOn        string     `json:"due_on,omitempty"`
+	DueAt        *time.Time `json:"due_at,omitempty"`
+	StartOn      string     `json:"start_on,omitempty"`
+	Permalink    string     `json:"permalink_url,omitempty"`
+	ResourceType string     `json:"resource_type"`
+}
+
+// User represents an Asana user
+type User struct {
+	GID          string `json:"gid"`
+	Name         string `json:"name"`
+	Email        string `json:"email,omitempty"`
+	ResourceType string `json:"resource_type"`
+}
+
+// Project represents an Asana project
+type Project struct {
+	GID          string `json:"gid"`
+	Name         string `json:"name"`
+	ResourceType string `json:"resource_type"`
+}
+
+// Tag represents an Asana tag
+type Tag struct {
+	GID          string `json:"gid"`
+	Name         string `json:"name"`
+	Color        string `json:"color,omitempty"`
+	ResourceType string `json:"resource_type"`
+}
+
+// Section represents an Asana project section
+type Section struct {
+	GID          string `json:"gid"`
+	Name         string `json:"name"`
+	ResourceType string `json:"resource_type"`
+}
+
+// Workspace represents an Asana workspace
+type Workspace struct {
+	GID          string `json:"gid"`
+	Name         string `json:"name"`
+	ResourceType string `json:"resource_type"`
+}
+
+// Story represents an Asana story (comment or activity)
+type Story struct {
+	GID          string    `json:"gid"`
+	Text         string    `json:"text"`
+	HTMLText     string    `json:"html_text,omitempty"`
+	Type         string    `json:"type"` // "comment" or "system"
+	CreatedAt    time.Time `json:"created_at"`
+	CreatedBy    *User     `json:"created_by,omitempty"`
+	ResourceType string    `json:"resource_type"`
+}
+
+// Attachment represents an Asana attachment
+type Attachment struct {
+	GID          string    `json:"gid"`
+	Name         string    `json:"name"`
+	Host         string    `json:"host,omitempty"`
+	ViewURL      string    `json:"view_url,omitempty"`
+	DownloadURL  string    `json:"download_url,omitempty"`
+	Permanent    bool      `json:"permanent"`
+	CreatedAt    time.Time `json:"created_at"`
+	ResourceType string    `json:"resource_type"`
+}
+
+// APIResponse wraps all Asana API responses
+type APIResponse[T any] struct {
+	Data   T           `json:"data"`
+	Errors []APIError  `json:"errors,omitempty"`
+}
+
+// APIError represents an Asana API error
+type APIError struct {
+	Message string `json:"message"`
+	Help    string `json:"help,omitempty"`
+}
+
+// PagedResponse wraps paginated Asana API responses
+type PagedResponse[T any] struct {
+	Data     []T       `json:"data"`
+	NextPage *NextPage `json:"next_page,omitempty"`
+}
+
+// NextPage represents pagination info
+type NextPage struct {
+	Offset string `json:"offset"`
+	Path   string `json:"path"`
+	URI    string `json:"uri"`
+}
+
+// Webhook types
+
+// WebhookEventType represents the type of webhook event
+type WebhookEventType string
+
+const (
+	// Task events
+	EventTaskAdded     WebhookEventType = "added"
+	EventTaskChanged   WebhookEventType = "changed"
+	EventTaskRemoved   WebhookEventType = "removed"
+	EventTaskDeleted   WebhookEventType = "deleted"
+	EventTaskUndeleted WebhookEventType = "undeleted"
+)
+
+// WebhookPayload represents the webhook request body from Asana
+type WebhookPayload struct {
+	Events []WebhookEvent `json:"events"`
+}
+
+// WebhookEvent represents a single event in the webhook payload
+type WebhookEvent struct {
+	Action   string          `json:"action"`   // "added", "changed", "removed", "deleted", "undeleted"
+	User     *User           `json:"user"`     // User who triggered the event
+	Resource WebhookResource `json:"resource"` // The resource that changed
+	Parent   *WebhookResource `json:"parent,omitempty"` // Parent resource (for subtasks, stories, etc.)
+	Change   *WebhookChange  `json:"change,omitempty"` // Details about what changed
+	CreatedAt time.Time      `json:"created_at"`
+}
+
+// WebhookResource represents the resource in a webhook event
+type WebhookResource struct {
+	GID          string `json:"gid"`
+	ResourceType string `json:"resource_type"` // "task", "story", "project", etc.
+	Name         string `json:"name,omitempty"`
+}
+
+// WebhookChange represents what changed in an event
+type WebhookChange struct {
+	Field     string      `json:"field"`
+	Action    string      `json:"action"`
+	AddedValue  interface{} `json:"added_value,omitempty"`
+	RemovedValue interface{} `json:"removed_value,omitempty"`
+	NewValue   interface{} `json:"new_value,omitempty"`
+}
+
+// WebhookRegistration represents a webhook subscription
+type WebhookRegistration struct {
+	GID        string    `json:"gid"`
+	Resource   Resource  `json:"resource"`
+	Target     string    `json:"target"`
+	Active     bool      `json:"active"`
+	CreatedAt  time.Time `json:"created_at"`
+	LastFailureAt *time.Time `json:"last_failure_at,omitempty"`
+	LastSuccessAt *time.Time `json:"last_success_at,omitempty"`
+}
+
+// Resource represents a generic Asana resource reference
+type Resource struct {
+	GID          string `json:"gid"`
+	Name         string `json:"name,omitempty"`
+	ResourceType string `json:"resource_type"`
+}
+
+// TaskInfo represents the normalized task information for Pilot
+type TaskInfo struct {
+	ID          string   // "ASANA-{gid}"
+	Title       string
+	Description string
+	Priority    Priority
+	Labels      []string // Tag names
+	TaskGID     string   // Original Asana GID
+	TaskURL     string   // Permalink to task
+	ProjectName string   // First project name
+}
+
+// ConvertToTaskInfo converts an Asana Task to a TaskInfo
+func ConvertToTaskInfo(task *Task) *TaskInfo {
+	labels := make([]string, len(task.Tags))
+	for i, tag := range task.Tags {
+		labels[i] = tag.Name
+	}
+
+	projectName := ""
+	if len(task.Projects) > 0 {
+		projectName = task.Projects[0].Name
+	}
+
+	taskURL := task.Permalink
+	if taskURL == "" {
+		taskURL = "https://app.asana.com/0/0/" + task.GID
+	}
+
+	return &TaskInfo{
+		ID:          "ASANA-" + task.GID,
+		Title:       task.Name,
+		Description: task.Notes,
+		Priority:    PriorityFromTags(task.Tags),
+		Labels:      labels,
+		TaskGID:     task.GID,
+		TaskURL:     taskURL,
+		ProjectName: projectName,
+	}
+}

--- a/internal/adapters/asana/webhook.go
+++ b/internal/adapters/asana/webhook.go
@@ -1,0 +1,248 @@
+package asana
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// WebhookHandler handles Asana webhooks
+type WebhookHandler struct {
+	client        *Client
+	webhookSecret string
+	pilotTag      string
+	onTask        func(context.Context, *Task) error
+}
+
+// NewWebhookHandler creates a new webhook handler
+func NewWebhookHandler(client *Client, webhookSecret, pilotTag string) *WebhookHandler {
+	return &WebhookHandler{
+		client:        client,
+		webhookSecret: webhookSecret,
+		pilotTag:      pilotTag,
+	}
+}
+
+// OnTask sets the callback for when a pilot-tagged task is received
+func (h *WebhookHandler) OnTask(callback func(context.Context, *Task) error) {
+	h.onTask = callback
+}
+
+// VerifySignature verifies the Asana webhook signature using X-Hook-Secret
+// Asana uses HMAC-SHA256 for webhook signature verification
+func (h *WebhookHandler) VerifySignature(payload []byte, signature string) bool {
+	if h.webhookSecret == "" {
+		// No secret configured, skip verification (development mode)
+		return true
+	}
+
+	mac := hmac.New(sha256.New, []byte(h.webhookSecret))
+	mac.Write(payload)
+	expectedSig := hex.EncodeToString(mac.Sum(nil))
+
+	return hmac.Equal([]byte(signature), []byte(expectedSig))
+}
+
+// HandleHandshake handles the initial webhook handshake from Asana
+// Returns the X-Hook-Secret value that should be echoed back
+func (h *WebhookHandler) HandleHandshake(hookSecret string) string {
+	// Store the secret for future verification
+	// In production, this would typically be saved to config
+	return hookSecret
+}
+
+// Handle processes a webhook payload
+func (h *WebhookHandler) Handle(ctx context.Context, payload *WebhookPayload) error {
+	for _, event := range payload.Events {
+		if err := h.handleEvent(ctx, event); err != nil {
+			logging.WithComponent("asana").Error("Failed to handle event",
+				slog.String("action", event.Action),
+				slog.String("resource_type", event.Resource.ResourceType),
+				slog.Any("error", err))
+			// Continue processing other events
+		}
+	}
+	return nil
+}
+
+// handleEvent processes a single webhook event
+func (h *WebhookHandler) handleEvent(ctx context.Context, event WebhookEvent) error {
+	logging.WithComponent("asana").Debug("Processing Asana webhook event",
+		slog.String("action", event.Action),
+		slog.String("resource_type", event.Resource.ResourceType),
+		slog.String("resource_gid", event.Resource.GID))
+
+	// Only process task events
+	if event.Resource.ResourceType != "task" {
+		logging.WithComponent("asana").Debug("Ignoring non-task event",
+			slog.String("resource_type", event.Resource.ResourceType))
+		return nil
+	}
+
+	switch WebhookEventType(event.Action) {
+	case EventTaskAdded, EventTaskChanged:
+		return h.handleTaskEvent(ctx, event)
+	default:
+		logging.WithComponent("asana").Debug("Ignoring event action",
+			slog.String("action", event.Action))
+		return nil
+	}
+}
+
+// handleTaskEvent processes task create/update events
+func (h *WebhookHandler) handleTaskEvent(ctx context.Context, event WebhookEvent) error {
+	taskGID := event.Resource.GID
+
+	// Check if this is a tag change event - if so, verify pilot tag was added
+	if event.Change != nil && event.Change.Field == "tags" {
+		if !h.wasTagAdded(event.Change) {
+			logging.WithComponent("asana").Debug("Tag change but pilot tag not added, skipping",
+				slog.String("task_gid", taskGID))
+			return nil
+		}
+	}
+
+	// Fetch full task details
+	task, err := h.client.GetTaskWithFields(ctx, taskGID, []string{
+		"gid", "name", "notes", "html_notes", "completed", "completed_at",
+		"assignee", "projects", "tags", "workspace", "parent",
+		"created_at", "modified_at", "due_on", "due_at", "start_on", "permalink_url",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to fetch task details: %w", err)
+	}
+
+	// Check if task has pilot tag
+	if !h.hasPilotTag(task) {
+		logging.WithComponent("asana").Debug("Task does not have pilot tag, skipping",
+			slog.String("gid", taskGID),
+			slog.String("name", task.Name))
+		return nil
+	}
+
+	// Skip completed tasks
+	if task.Completed {
+		logging.WithComponent("asana").Debug("Task is already completed, skipping",
+			slog.String("gid", taskGID))
+		return nil
+	}
+
+	return h.processTask(ctx, task)
+}
+
+// processTask processes a task that should be handled by Pilot
+func (h *WebhookHandler) processTask(ctx context.Context, task *Task) error {
+	logging.WithComponent("asana").Info("Processing pilot task",
+		slog.String("gid", task.GID),
+		slog.String("name", task.Name))
+
+	// Call the callback
+	if h.onTask != nil {
+		return h.onTask(ctx, task)
+	}
+
+	return nil
+}
+
+// hasPilotTag checks if the task has the pilot tag
+func (h *WebhookHandler) hasPilotTag(task *Task) bool {
+	for _, tag := range task.Tags {
+		if strings.EqualFold(tag.Name, h.pilotTag) {
+			return true
+		}
+	}
+	return false
+}
+
+// wasTagAdded checks if the pilot tag was added in this change
+func (h *WebhookHandler) wasTagAdded(change *WebhookChange) bool {
+	if change.Action != "added" {
+		return false
+	}
+
+	// AddedValue might be a map with tag info
+	if addedTag, ok := change.AddedValue.(map[string]interface{}); ok {
+		if name, ok := addedTag["name"].(string); ok {
+			return strings.EqualFold(name, h.pilotTag)
+		}
+		// Check by GID if name not available
+		if gid, ok := addedTag["gid"].(string); ok {
+			// Would need to look up tag name, for now just log
+			logging.WithComponent("asana").Debug("Tag added by GID",
+				slog.String("gid", gid))
+			return true // Optimistically assume it might be pilot tag
+		}
+	}
+
+	return false
+}
+
+// HandleRaw processes a raw webhook payload (for use with net/http handlers)
+func (h *WebhookHandler) HandleRaw(ctx context.Context, events []map[string]interface{}) error {
+	for _, eventData := range events {
+		event := h.parseEvent(eventData)
+		if err := h.handleEvent(ctx, event); err != nil {
+			logging.WithComponent("asana").Error("Failed to handle raw event",
+				slog.Any("error", err))
+		}
+	}
+	return nil
+}
+
+// parseEvent parses a raw event map into a WebhookEvent
+func (h *WebhookHandler) parseEvent(data map[string]interface{}) WebhookEvent {
+	event := WebhookEvent{}
+
+	if action, ok := data["action"].(string); ok {
+		event.Action = action
+	}
+
+	if resource, ok := data["resource"].(map[string]interface{}); ok {
+		if gid, ok := resource["gid"].(string); ok {
+			event.Resource.GID = gid
+		}
+		if resourceType, ok := resource["resource_type"].(string); ok {
+			event.Resource.ResourceType = resourceType
+		}
+		if name, ok := resource["name"].(string); ok {
+			event.Resource.Name = name
+		}
+	}
+
+	if parent, ok := data["parent"].(map[string]interface{}); ok {
+		event.Parent = &WebhookResource{}
+		if gid, ok := parent["gid"].(string); ok {
+			event.Parent.GID = gid
+		}
+		if resourceType, ok := parent["resource_type"].(string); ok {
+			event.Parent.ResourceType = resourceType
+		}
+	}
+
+	if change, ok := data["change"].(map[string]interface{}); ok {
+		event.Change = &WebhookChange{}
+		if field, ok := change["field"].(string); ok {
+			event.Change.Field = field
+		}
+		if action, ok := change["action"].(string); ok {
+			event.Change.Action = action
+		}
+		if addedValue, ok := change["added_value"]; ok {
+			event.Change.AddedValue = addedValue
+		}
+		if removedValue, ok := change["removed_value"]; ok {
+			event.Change.RemovedValue = removedValue
+		}
+		if newValue, ok := change["new_value"]; ok {
+			event.Change.NewValue = newValue
+		}
+	}
+
+	return event
+}

--- a/internal/adapters/asana/webhook_test.go
+++ b/internal/adapters/asana/webhook_test.go
@@ -1,0 +1,540 @@
+package asana
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestNewWebhookHandler(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, testutil.FakeAsanaWebhookSecret, "pilot")
+
+	if handler == nil {
+		t.Fatal("NewWebhookHandler returned nil")
+	}
+	if handler.pilotTag != "pilot" {
+		t.Errorf("handler.pilotTag = %s, want pilot", handler.pilotTag)
+	}
+}
+
+func TestVerifySignature(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, testutil.FakeAsanaWebhookSecret, "pilot")
+
+	tests := []struct {
+		name      string
+		payload   []byte
+		signature string
+		want      bool
+	}{
+		{
+			name:      "valid signature",
+			payload:   []byte(`{"events":[]}`),
+			signature: "5d8d5c5f7a8d5c5f7a8d5c5f7a8d5c5f7a8d5c5f7a8d5c5f7a8d5c5f7a8d5c5f", // This won't match but tests the flow
+			want:      false,
+		},
+		{
+			name:      "empty signature",
+			payload:   []byte(`{"events":[]}`),
+			signature: "",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := handler.VerifySignature(tt.payload, tt.signature)
+			if got != tt.want {
+				t.Errorf("VerifySignature() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerifySignature_NoSecret(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, "", "pilot") // No secret = dev mode
+
+	// Should always return true in dev mode
+	got := handler.VerifySignature([]byte(`{"events":[]}`), "any-signature")
+	if !got {
+		t.Error("expected VerifySignature to return true when no secret configured")
+	}
+}
+
+func TestHandleHandshake(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	hookSecret := "abc123secret"
+	result := handler.HandleHandshake(hookSecret)
+
+	if result != hookSecret {
+		t.Errorf("HandleHandshake() = %s, want %s", result, hookSecret)
+	}
+}
+
+func TestHandle_EmptyPayload(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	payload := &WebhookPayload{
+		Events: []WebhookEvent{},
+	}
+
+	err := handler.Handle(context.Background(), payload)
+	if err != nil {
+		t.Errorf("Handle() returned error: %v", err)
+	}
+}
+
+func TestHandle_NonTaskEvent(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	// Set callback that should NOT be called
+	callbackCalled := false
+	handler.OnTask(func(ctx context.Context, task *Task) error {
+		callbackCalled = true
+		return nil
+	})
+
+	payload := &WebhookPayload{
+		Events: []WebhookEvent{
+			{
+				Action: "added",
+				Resource: WebhookResource{
+					GID:          "123",
+					ResourceType: "project", // Not a task
+				},
+			},
+		},
+	}
+
+	err := handler.Handle(context.Background(), payload)
+	if err != nil {
+		t.Errorf("Handle() returned error: %v", err)
+	}
+	if callbackCalled {
+		t.Error("callback should not be called for non-task events")
+	}
+}
+
+func TestHandle_TaskWithPilotTag(t *testing.T) {
+	// Create mock server that returns task with pilot tag
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := APIResponse[Task]{
+			Data: Task{
+				GID:       "123456",
+				Name:      "Test Task",
+				Completed: false,
+				Tags: []Tag{
+					{GID: "1", Name: "pilot"},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	// Set callback
+	var receivedTask *Task
+	handler.OnTask(func(ctx context.Context, task *Task) error {
+		receivedTask = task
+		return nil
+	})
+
+	payload := &WebhookPayload{
+		Events: []WebhookEvent{
+			{
+				Action: "added",
+				Resource: WebhookResource{
+					GID:          "123456",
+					ResourceType: "task",
+				},
+			},
+		},
+	}
+
+	err := handler.Handle(context.Background(), payload)
+	if err != nil {
+		t.Errorf("Handle() returned error: %v", err)
+	}
+	if receivedTask == nil {
+		t.Error("callback was not called")
+	}
+	if receivedTask != nil && receivedTask.GID != "123456" {
+		t.Errorf("received task GID = %s, want 123456", receivedTask.GID)
+	}
+}
+
+func TestHandle_TaskWithoutPilotTag(t *testing.T) {
+	// Create mock server that returns task without pilot tag
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := APIResponse[Task]{
+			Data: Task{
+				GID:       "123456",
+				Name:      "Test Task",
+				Completed: false,
+				Tags: []Tag{
+					{GID: "1", Name: "other-tag"},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	// Set callback that should NOT be called
+	callbackCalled := false
+	handler.OnTask(func(ctx context.Context, task *Task) error {
+		callbackCalled = true
+		return nil
+	})
+
+	payload := &WebhookPayload{
+		Events: []WebhookEvent{
+			{
+				Action: "added",
+				Resource: WebhookResource{
+					GID:          "123456",
+					ResourceType: "task",
+				},
+			},
+		},
+	}
+
+	err := handler.Handle(context.Background(), payload)
+	if err != nil {
+		t.Errorf("Handle() returned error: %v", err)
+	}
+	if callbackCalled {
+		t.Error("callback should not be called for tasks without pilot tag")
+	}
+}
+
+func TestHandle_CompletedTask(t *testing.T) {
+	// Create mock server that returns completed task
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := APIResponse[Task]{
+			Data: Task{
+				GID:       "123456",
+				Name:      "Test Task",
+				Completed: true, // Already completed
+				Tags: []Tag{
+					{GID: "1", Name: "pilot"},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	// Set callback that should NOT be called
+	callbackCalled := false
+	handler.OnTask(func(ctx context.Context, task *Task) error {
+		callbackCalled = true
+		return nil
+	})
+
+	payload := &WebhookPayload{
+		Events: []WebhookEvent{
+			{
+				Action: "changed",
+				Resource: WebhookResource{
+					GID:          "123456",
+					ResourceType: "task",
+				},
+			},
+		},
+	}
+
+	err := handler.Handle(context.Background(), payload)
+	if err != nil {
+		t.Errorf("Handle() returned error: %v", err)
+	}
+	if callbackCalled {
+		t.Error("callback should not be called for completed tasks")
+	}
+}
+
+func TestHasPilotTag(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	tests := []struct {
+		name string
+		task *Task
+		want bool
+	}{
+		{
+			name: "has pilot tag",
+			task: &Task{
+				Tags: []Tag{{GID: "1", Name: "pilot"}},
+			},
+			want: true,
+		},
+		{
+			name: "has PILOT tag (case insensitive)",
+			task: &Task{
+				Tags: []Tag{{GID: "1", Name: "PILOT"}},
+			},
+			want: true,
+		},
+		{
+			name: "no pilot tag",
+			task: &Task{
+				Tags: []Tag{{GID: "1", Name: "other"}},
+			},
+			want: false,
+		},
+		{
+			name: "empty tags",
+			task: &Task{
+				Tags: []Tag{},
+			},
+			want: false,
+		},
+		{
+			name: "pilot among other tags",
+			task: &Task{
+				Tags: []Tag{
+					{GID: "1", Name: "bug"},
+					{GID: "2", Name: "pilot"},
+					{GID: "3", Name: "urgent"},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := handler.hasPilotTag(tt.task)
+			if got != tt.want {
+				t.Errorf("hasPilotTag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWasTagAdded(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	tests := []struct {
+		name   string
+		change *WebhookChange
+		want   bool
+	}{
+		{
+			name: "pilot tag added",
+			change: &WebhookChange{
+				Field:  "tags",
+				Action: "added",
+				AddedValue: map[string]interface{}{
+					"gid":  "123",
+					"name": "pilot",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "other tag added",
+			change: &WebhookChange{
+				Field:  "tags",
+				Action: "added",
+				AddedValue: map[string]interface{}{
+					"gid":  "123",
+					"name": "other",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "tag removed (not added)",
+			change: &WebhookChange{
+				Field:  "tags",
+				Action: "removed",
+				RemovedValue: map[string]interface{}{
+					"gid":  "123",
+					"name": "pilot",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "tag added by GID only",
+			change: &WebhookChange{
+				Field:  "tags",
+				Action: "added",
+				AddedValue: map[string]interface{}{
+					"gid": "123",
+				},
+			},
+			want: true, // Optimistically returns true
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := handler.wasTagAdded(tt.change)
+			if got != tt.want {
+				t.Errorf("wasTagAdded() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleRaw(t *testing.T) {
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := APIResponse[Task]{
+			Data: Task{
+				GID:       "123456",
+				Name:      "Test Task",
+				Completed: false,
+				Tags: []Tag{
+					{GID: "1", Name: "pilot"},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	var receivedTask *Task
+	handler.OnTask(func(ctx context.Context, task *Task) error {
+		receivedTask = task
+		return nil
+	})
+
+	events := []map[string]interface{}{
+		{
+			"action": "added",
+			"resource": map[string]interface{}{
+				"gid":           "123456",
+				"resource_type": "task",
+			},
+		},
+	}
+
+	err := handler.HandleRaw(context.Background(), events)
+	if err != nil {
+		t.Errorf("HandleRaw() returned error: %v", err)
+	}
+	if receivedTask == nil {
+		t.Error("callback was not called")
+	}
+}
+
+func TestParseEvent(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	data := map[string]interface{}{
+		"action": "changed",
+		"resource": map[string]interface{}{
+			"gid":           "123",
+			"resource_type": "task",
+			"name":          "Test Task",
+		},
+		"parent": map[string]interface{}{
+			"gid":           "456",
+			"resource_type": "project",
+		},
+		"change": map[string]interface{}{
+			"field":  "completed",
+			"action": "changed",
+			"new_value": true,
+		},
+	}
+
+	event := handler.parseEvent(data)
+
+	if event.Action != "changed" {
+		t.Errorf("event.Action = %s, want changed", event.Action)
+	}
+	if event.Resource.GID != "123" {
+		t.Errorf("event.Resource.GID = %s, want 123", event.Resource.GID)
+	}
+	if event.Resource.ResourceType != "task" {
+		t.Errorf("event.Resource.ResourceType = %s, want task", event.Resource.ResourceType)
+	}
+	if event.Parent == nil {
+		t.Error("event.Parent is nil")
+	} else if event.Parent.GID != "456" {
+		t.Errorf("event.Parent.GID = %s, want 456", event.Parent.GID)
+	}
+	if event.Change == nil {
+		t.Error("event.Change is nil")
+	} else {
+		if event.Change.Field != "completed" {
+			t.Errorf("event.Change.Field = %s, want completed", event.Change.Field)
+		}
+	}
+}
+
+func TestOnTask_Callback(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	called := false
+	handler.OnTask(func(ctx context.Context, task *Task) error {
+		called = true
+		return nil
+	})
+
+	if handler.onTask == nil {
+		t.Error("onTask callback not set")
+	}
+
+	// Verify callback is stored
+	err := handler.onTask(context.Background(), &Task{})
+	if err != nil {
+		t.Errorf("callback returned error: %v", err)
+	}
+	if !called {
+		t.Error("callback was not called")
+	}
+}
+
+func TestWebhookEventTypes(t *testing.T) {
+	// Verify constants are defined correctly
+	if EventTaskAdded != "added" {
+		t.Errorf("EventTaskAdded = %s, want added", EventTaskAdded)
+	}
+	if EventTaskChanged != "changed" {
+		t.Errorf("EventTaskChanged = %s, want changed", EventTaskChanged)
+	}
+	if EventTaskRemoved != "removed" {
+		t.Errorf("EventTaskRemoved = %s, want removed", EventTaskRemoved)
+	}
+	if EventTaskDeleted != "deleted" {
+		t.Errorf("EventTaskDeleted = %s, want deleted", EventTaskDeleted)
+	}
+	if EventTaskUndeleted != "undeleted" {
+		t.Errorf("EventTaskUndeleted = %s, want undeleted", EventTaskUndeleted)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/alekspetrov/pilot/internal/adapters/asana"
 	"github.com/alekspetrov/pilot/internal/adapters/github"
 	"github.com/alekspetrov/pilot/internal/adapters/jira"
 	"github.com/alekspetrov/pilot/internal/adapters/linear"
@@ -58,6 +59,7 @@ type AdaptersConfig struct {
 	Telegram *telegram.Config `yaml:"telegram"`
 	GitHub   *github.Config   `yaml:"github"`
 	Jira     *jira.Config     `yaml:"jira"`
+	Asana    *asana.Config    `yaml:"asana"`
 }
 
 // OrchestratorConfig holds settings for the task orchestrator including
@@ -225,6 +227,7 @@ func DefaultConfig() *Config {
 			Telegram: telegram.DefaultConfig(),
 			GitHub:   github.DefaultConfig(),
 			Jira:     jira.DefaultConfig(),
+			Asana:    asana.DefaultConfig(),
 		},
 		Orchestrator: &OrchestratorConfig{
 			Model:         "claude-sonnet-4-20250514",

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -413,8 +413,15 @@ func padOrTruncate(s string, targetWidth int) string {
 	return s + strings.Repeat(" ", targetWidth-visualWidth)
 }
 
-// truncateVisual truncates string to targetWidth visual chars, adding "..." if needed
+// truncateVisual truncates string to targetWidth visual chars, adding "..." only if needed
 func truncateVisual(s string, targetWidth int) string {
+	visualWidth := lipgloss.Width(s)
+
+	// If string already fits, return as-is (no truncation needed)
+	if visualWidth <= targetWidth {
+		return s
+	}
+
 	if targetWidth <= 3 {
 		return strings.Repeat(".", targetWidth)
 	}

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -31,6 +31,10 @@ type ExecuteOptions struct {
 	// Verbose enables detailed output logging
 	Verbose bool
 
+	// Model specifies the model to use for execution (e.g., "claude-haiku", "claude-opus").
+	// If empty, the backend's default model is used.
+	Model string
+
 	// EventHandler receives streaming events during execution
 	// The handler receives the raw event line from the backend
 	EventHandler func(event BackendEvent)

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -58,6 +58,13 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, opts ExecuteOptions) (*
 		"--output-format", "stream-json",
 		"--dangerously-skip-permissions",
 	}
+
+	// Add model flag if specified (model routing GH-215)
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+		b.log.Info("Using routed model", slog.String("model", opts.Model))
+	}
+
 	args = append(args, b.config.ExtraArgs...)
 
 	cmd := exec.CommandContext(ctx, b.config.Command, args...)

--- a/internal/executor/complexity.go
+++ b/internal/executor/complexity.go
@@ -153,3 +153,9 @@ func (c Complexity) ShouldSkipNavigator() bool {
 func (c Complexity) String() string {
 	return string(c)
 }
+
+// ShouldRunResearch returns true if parallel research phase should run.
+// Medium and complex tasks benefit from pre-execution research.
+func (c Complexity) ShouldRunResearch() bool {
+	return c == ComplexityMedium || c == ComplexityComplex
+}

--- a/internal/executor/complexity_test.go
+++ b/internal/executor/complexity_test.go
@@ -139,11 +139,12 @@ func TestComplexity_Methods(t *testing.T) {
 		isTrivial           bool
 		isSimple            bool
 		shouldSkipNavigator bool
+		shouldRunResearch   bool
 	}{
-		{ComplexityTrivial, true, true, true},
-		{ComplexitySimple, false, true, false},
-		{ComplexityMedium, false, false, false},
-		{ComplexityComplex, false, false, false},
+		{ComplexityTrivial, true, true, true, false},
+		{ComplexitySimple, false, true, false, false},
+		{ComplexityMedium, false, false, false, true},
+		{ComplexityComplex, false, false, false, true},
 	}
 
 	for _, tt := range tests {
@@ -156,6 +157,9 @@ func TestComplexity_Methods(t *testing.T) {
 			}
 			if got := tt.complexity.ShouldSkipNavigator(); got != tt.shouldSkipNavigator {
 				t.Errorf("ShouldSkipNavigator() = %v, want %v", got, tt.shouldSkipNavigator)
+			}
+			if got := tt.complexity.ShouldRunResearch(); got != tt.shouldRunResearch {
+				t.Errorf("ShouldRunResearch() = %v, want %v", got, tt.shouldRunResearch)
 			}
 		})
 	}

--- a/internal/executor/quality.go
+++ b/internal/executor/quality.go
@@ -1,6 +1,20 @@
 package executor
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// QualityGateDetail represents detailed information about a single gate check.
+// This is used to pass gate results from the quality package to the executor
+// without creating import cycles.
+type QualityGateDetail struct {
+	Name       string
+	Passed     bool
+	Duration   time.Duration
+	RetryCount int
+	Error      string
+}
 
 // QualityOutcome represents the result of quality gate checks.
 // This mirrors quality.ExecutionOutcome to avoid import cycles.
@@ -9,6 +23,10 @@ type QualityOutcome struct {
 	ShouldRetry   bool
 	RetryFeedback string // Error feedback to send to Claude for retry
 	Attempt       int
+	// GateDetails contains detailed results for each gate
+	GateDetails []QualityGateDetail
+	// TotalDuration is the total time spent running all gates
+	TotalDuration time.Duration
 }
 
 // QualityChecker is an interface for running quality gate checks.

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -470,6 +470,7 @@ func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, err
 		Prompt:      prompt,
 		ProjectPath: task.ProjectPath,
 		Verbose:     task.Verbose,
+		Model:       selectedModel,
 		EventHandler: func(event BackendEvent) {
 			// Record the event
 			if recorder != nil {
@@ -755,6 +756,7 @@ func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, err
 						Prompt:      retryPrompt,
 						ProjectPath: task.ProjectPath,
 						Verbose:     task.Verbose,
+						Model:       selectedModel,
 						EventHandler: func(event BackendEvent) {
 							if recorder != nil {
 								if recErr := recorder.RecordEvent(event.Raw); recErr != nil {

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -203,6 +203,7 @@ type Runner struct {
 	qualityCheckerFactory QualityCheckerFactory // Optional factory for creating quality checkers
 	modelRouter           *ModelRouter          // Model and timeout routing based on complexity
 	parallelRunner        *ParallelRunner       // Optional parallel research runner (GH-217)
+	decomposer            *TaskDecomposer       // Optional task decomposer for complex tasks (GH-218)
 	suppressProgressLogs  bool                  // Suppress slog output for progress (use when visual display is active)
 }
 
@@ -247,6 +248,11 @@ func NewRunnerWithConfig(config *BackendConfig) (*Runner, error) {
 	// Configure model routing and timeouts from config
 	if config != nil {
 		runner.modelRouter = NewModelRouter(config.ModelRouting, config.Timeout)
+
+		// Configure task decomposition (GH-218)
+		if config.Decompose != nil && config.Decompose.Enabled {
+			runner.decomposer = NewTaskDecomposer(config.Decompose)
+		}
 	}
 
 	return runner, nil
@@ -311,6 +317,23 @@ func (r *Runner) SetParallelRunner(runner *ParallelRunner) {
 // This is a convenience method to enable parallel research with default settings.
 func (r *Runner) EnableParallelResearch() {
 	r.parallelRunner = NewParallelRunner(DefaultParallelConfig(), r.modelRouter)
+}
+
+// SetDecomposer sets the task decomposer for auto-splitting complex tasks (GH-218).
+// When set and enabled, complex tasks are decomposed into subtasks that run sequentially,
+// with only the final subtask creating a PR.
+func (r *Runner) SetDecomposer(decomposer *TaskDecomposer) {
+	r.decomposer = decomposer
+}
+
+// EnableDecomposition creates and configures a default task decomposer.
+// This is a convenience method to enable decomposition with default settings.
+func (r *Runner) EnableDecomposition(config *DecomposeConfig) {
+	if config == nil {
+		config = DefaultDecomposeConfig()
+		config.Enabled = true // Enable by default when called explicitly
+	}
+	r.decomposer = NewTaskDecomposer(config)
 }
 
 // getRecordingsPath returns the recordings path, using default if not set
@@ -393,11 +416,29 @@ func (r *Runner) EmitProgress(taskID, phase string, progress int, message string
 // backend invocation, progress tracking, and optional PR creation.
 // The context can be used to cancel execution. Returns an error only for
 // setup failures; execution failures are reported in ExecutionResult.
+//
+// When a decomposer is configured and enabled, complex tasks are automatically
+// split into subtasks that run sequentially (GH-218). Only the final subtask
+// creates a PR, accumulating all changes from previous subtasks.
 func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, error) {
 	start := time.Now()
 
 	// Detect complexity for routing decisions
 	complexity := DetectComplexity(task)
+
+	// Check for task decomposition (GH-218)
+	// Decomposition happens before timeout setup because subtasks have their own timeouts
+	if r.decomposer != nil {
+		result := r.decomposer.Decompose(task)
+		if result.Decomposed && len(result.Subtasks) > 1 {
+			r.log.Info("Task decomposed",
+				slog.String("task_id", task.ID),
+				slog.Int("subtask_count", len(result.Subtasks)),
+				slog.String("reason", result.Reason),
+			)
+			return r.executeDecomposedTask(ctx, task, result.Subtasks)
+		}
+	}
 
 	// Apply timeout based on task complexity
 	timeout := r.modelRouter.SelectTimeout(task)
@@ -1007,6 +1048,198 @@ func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, err
 	}
 
 	return result, nil
+}
+
+// executeDecomposedTask runs subtasks sequentially and aggregates results (GH-218).
+// Each subtask runs to completion before the next starts. Only the final subtask
+// creates a PR (CreatePR is already set by the decomposer). All changes accumulate
+// on the same branch, so the final PR contains all subtask work.
+func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, subtasks []*Task) (*ExecutionResult, error) {
+	start := time.Now()
+	totalSubtasks := len(subtasks)
+
+	r.log.Info("Starting decomposed task execution",
+		slog.String("parent_id", parentTask.ID),
+		slog.Int("subtask_count", totalSubtasks),
+	)
+
+	// Emit parent task started event
+	r.emitAlertEvent(AlertEvent{
+		Type:      AlertEventTypeTaskStarted,
+		TaskID:    parentTask.ID,
+		TaskTitle: parentTask.Title,
+		Project:   parentTask.ProjectPath,
+		Metadata: map[string]string{
+			"decomposed":    "true",
+			"subtask_count": fmt.Sprintf("%d", totalSubtasks),
+		},
+		Timestamp: time.Now(),
+	})
+
+	// Dispatch webhook for decomposed task started
+	r.dispatchWebhook(ctx, webhooks.EventTaskStarted, webhooks.TaskStartedData{
+		TaskID:      parentTask.ID,
+		Title:       parentTask.Title,
+		Description: fmt.Sprintf("Decomposed into %d subtasks: %s", totalSubtasks, parentTask.Description),
+		Project:     parentTask.ProjectPath,
+		Source:      "pilot",
+	})
+
+	// Initialize git and create branch ONCE for all subtasks
+	git := NewGitOperations(parentTask.ProjectPath)
+	if parentTask.Branch != "" {
+		r.reportProgress(parentTask.ID, "Branching", 2, fmt.Sprintf("Creating branch %s...", parentTask.Branch))
+		if err := git.CreateBranch(ctx, parentTask.Branch); err != nil {
+			if switchErr := git.SwitchBranch(ctx, parentTask.Branch); switchErr != nil {
+				return nil, fmt.Errorf("failed to create/switch branch: %w", err)
+			}
+		}
+		r.reportProgress(parentTask.ID, "Branching", 5, fmt.Sprintf("Branch %s ready", parentTask.Branch))
+	}
+
+	// Aggregate result
+	aggregateResult := &ExecutionResult{
+		TaskID:  parentTask.ID,
+		Success: true,
+	}
+
+	// Execute each subtask sequentially
+	for i, subtask := range subtasks {
+		subtaskNum := i + 1
+
+		// Report progress with subtask counter
+		progressPct := 5 + (85 * subtaskNum / totalSubtasks)
+		r.reportProgress(parentTask.ID, "Decomposed", progressPct,
+			fmt.Sprintf("Subtask %d/%d: %s", subtaskNum, totalSubtasks, truncateText(subtask.Title, 40)))
+
+		r.log.Info("Executing subtask",
+			slog.String("parent_id", parentTask.ID),
+			slog.String("subtask_id", subtask.ID),
+			slog.Int("index", subtaskNum),
+			slog.Int("total", totalSubtasks),
+		)
+
+		// Execute subtask (recursively calls Execute, but subtasks won't decompose further)
+		// Clear the branch since we already created it
+		subtask.Branch = ""
+
+		// Temporarily disable decomposer to prevent recursive decomposition
+		savedDecomposer := r.decomposer
+		r.decomposer = nil
+
+		subtaskResult, err := r.Execute(ctx, subtask)
+
+		// Restore decomposer
+		r.decomposer = savedDecomposer
+
+		if err != nil {
+			r.log.Error("Subtask execution error",
+				slog.String("subtask_id", subtask.ID),
+				slog.Any("error", err),
+			)
+			aggregateResult.Success = false
+			aggregateResult.Error = fmt.Sprintf("subtask %d/%d failed: %v", subtaskNum, totalSubtasks, err)
+			break
+		}
+
+		if !subtaskResult.Success {
+			r.log.Warn("Subtask failed",
+				slog.String("subtask_id", subtask.ID),
+				slog.String("error", subtaskResult.Error),
+			)
+			aggregateResult.Success = false
+			aggregateResult.Error = fmt.Sprintf("subtask %d/%d failed: %s", subtaskNum, totalSubtasks, subtaskResult.Error)
+			break
+		}
+
+		// Aggregate metrics
+		aggregateResult.TokensInput += subtaskResult.TokensInput
+		aggregateResult.TokensOutput += subtaskResult.TokensOutput
+		aggregateResult.TokensTotal += subtaskResult.TokensTotal
+		aggregateResult.ResearchTokens += subtaskResult.ResearchTokens
+		aggregateResult.FilesChanged += subtaskResult.FilesChanged
+		aggregateResult.LinesAdded += subtaskResult.LinesAdded
+		aggregateResult.LinesRemoved += subtaskResult.LinesRemoved
+
+		// Keep last commit SHA and PR URL
+		if subtaskResult.CommitSHA != "" {
+			aggregateResult.CommitSHA = subtaskResult.CommitSHA
+		}
+		if subtaskResult.PRUrl != "" {
+			aggregateResult.PRUrl = subtaskResult.PRUrl
+		}
+		if subtaskResult.ModelName != "" {
+			aggregateResult.ModelName = subtaskResult.ModelName
+		}
+
+		// Track quality gates from final subtask
+		if subtask.CreatePR && subtaskResult.QualityGates != nil {
+			aggregateResult.QualityGates = subtaskResult.QualityGates
+		}
+
+		r.log.Info("Subtask completed",
+			slog.String("subtask_id", subtask.ID),
+			slog.Int("index", subtaskNum),
+			slog.Int("total", totalSubtasks),
+		)
+	}
+
+	aggregateResult.Duration = time.Since(start)
+	aggregateResult.EstimatedCostUSD = estimateCost(
+		aggregateResult.TokensInput+aggregateResult.ResearchTokens,
+		aggregateResult.TokensOutput,
+		aggregateResult.ModelName,
+	)
+
+	// Emit completion event
+	if aggregateResult.Success {
+		r.reportProgress(parentTask.ID, "Completed", 100,
+			fmt.Sprintf("All %d subtasks completed", totalSubtasks))
+
+		r.emitAlertEvent(AlertEvent{
+			Type:      AlertEventTypeTaskCompleted,
+			TaskID:    parentTask.ID,
+			TaskTitle: parentTask.Title,
+			Project:   parentTask.ProjectPath,
+			Metadata: map[string]string{
+				"duration_ms":   fmt.Sprintf("%d", aggregateResult.Duration.Milliseconds()),
+				"pr_url":        aggregateResult.PRUrl,
+				"subtask_count": fmt.Sprintf("%d", totalSubtasks),
+			},
+			Timestamp: time.Now(),
+		})
+
+		r.dispatchWebhook(ctx, webhooks.EventTaskCompleted, webhooks.TaskCompletedData{
+			TaskID:    parentTask.ID,
+			Title:     parentTask.Title,
+			Project:   parentTask.ProjectPath,
+			Duration:  aggregateResult.Duration,
+			PRCreated: aggregateResult.PRUrl != "",
+			PRURL:     aggregateResult.PRUrl,
+		})
+	} else {
+		r.reportProgress(parentTask.ID, "Failed", 100, aggregateResult.Error)
+
+		r.emitAlertEvent(AlertEvent{
+			Type:      AlertEventTypeTaskFailed,
+			TaskID:    parentTask.ID,
+			TaskTitle: parentTask.Title,
+			Project:   parentTask.ProjectPath,
+			Error:     aggregateResult.Error,
+			Timestamp: time.Now(),
+		})
+
+		r.dispatchWebhook(ctx, webhooks.EventTaskFailed, webhooks.TaskFailedData{
+			TaskID:   parentTask.ID,
+			Title:    parentTask.Title,
+			Project:  parentTask.ProjectPath,
+			Duration: aggregateResult.Duration,
+			Error:    aggregateResult.Error,
+			Phase:    "Decomposed",
+		})
+	}
+
+	return aggregateResult, nil
 }
 
 // Cancel terminates a running task by killing its Claude Code process.

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2175,13 +2175,7 @@ func (r *Runner) buildQualityGatesResult(outcome *QualityOutcome, totalRetries i
 	}
 
 	for i, detail := range outcome.GateDetails {
-		qgResult.Gates[i] = QualityGateResult{
-			Name:       detail.Name,
-			Passed:     detail.Passed,
-			Duration:   detail.Duration,
-			RetryCount: detail.RetryCount,
-			Error:      detail.Error,
-		}
+		qgResult.Gates[i] = QualityGateResult(detail)
 	}
 
 	return qgResult

--- a/internal/testutil/tokens.go
+++ b/internal/testutil/tokens.go
@@ -60,4 +60,13 @@ const (
 
 	// FakeStripeKey is a safe test API key for Stripe.
 	FakeStripeKey = "test-stripe-api-key"
+
+	// FakeAsanaAccessToken is a safe test access token for Asana.
+	FakeAsanaAccessToken = "test-asana-access-token"
+
+	// FakeAsanaWebhookSecret is a safe test webhook secret for Asana.
+	FakeAsanaWebhookSecret = "test-asana-webhook-secret"
+
+	// FakeAsanaWorkspaceID is a safe test workspace ID for Asana.
+	FakeAsanaWorkspaceID = "1234567890"
 )


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-223.

## Changes

GitHub Issue #223: feat(adapters): Add Asana inbound adapter

## Context

Asana is mentioned in original requirements but no adapter exists. Teams using Asana cannot use Pilot for task automation.

## Goal

Implement Asana inbound adapter following existing Linear/Jira/GitHub patterns.

## Scope

### Inbound (Ticket Source)
- Webhook handler for task events (created, updated, completed)
- REST API client for task operations
- Label/tag-based filtering (`pilot` tag triggers execution)

### Outbound (Updates)
- Add comments to tasks
- Update task status
- Link PRs to tasks

## Implementation

### Files to Create

| File | Purpose |
|------|---------|
| `internal/adapters/asana/client.go` | REST API client |
| `internal/adapters/asana/webhook.go` | Webhook handler |
| `internal/adapters/asana/types.go` | Config and types |
| `internal/adapters/asana/notifier.go` | Status notifications |
| `internal/adapters/asana/client_test.go` | Tests |
| `internal/adapters/asana/webhook_test.go` | Tests |

### Configuration

```yaml
adapters:
  asana:
    enabled: true
    access_token: "..."
    workspace_id: "..."
    webhook_secret: "..."
    pilot_tag: "pilot"
```

### API Reference

- Base URL: `https://app.asana.com/api/1.0`
- Auth: Bearer token (PAT or OAuth)
- Webhooks: X-Hook-Secret verification

## Acceptance Criteria

- [ ] Asana tasks with `pilot` tag trigger execution
- [ ] Pilot posts progress comments to Asana tasks
- [ ] PR links added to completed tasks
- [ ] Webhook signature verification works
- [ ] `pilot doctor` shows Asana status

## Reference

Follow patterns from existing adapters:
- `internal/adapters/jira/` (closest match - REST API)
- `internal/adapters/github/`
- `internal/adapters/linear/`