### PR TITLE
Wire task decomposition for complex tasks

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -203,6 +203,7 @@ type Runner struct {
 	qualityCheckerFactory QualityCheckerFactory // Optional factory for creating quality checkers
 	modelRouter           *ModelRouter          // Model and timeout routing based on complexity
 	parallelRunner        *ParallelRunner       // Optional parallel research runner (GH-217)
+	decomposer            *TaskDecomposer       // Optional task decomposer for complex tasks (GH-218)
 	suppressProgressLogs  bool                  // Suppress slog output for progress (use when visual display is active)
 }
 
@@ -247,6 +248,11 @@ func NewRunnerWithConfig(config *BackendConfig) (*Runner, error) {
 	// Configure model routing and timeouts from config
 	if config != nil {
 		runner.modelRouter = NewModelRouter(config.ModelRouting, config.Timeout)
+
+		// Configure task decomposition (GH-218)
+		if config.Decompose != nil && config.Decompose.Enabled {
+			runner.decomposer = NewTaskDecomposer(config.Decompose)
+		}
 	}
 
 	return runner, nil
@@ -311,6 +317,23 @@ func (r *Runner) SetParallelRunner(runner *ParallelRunner) {
 // This is a convenience method to enable parallel research with default settings.
 func (r *Runner) EnableParallelResearch() {
 	r.parallelRunner = NewParallelRunner(DefaultParallelConfig(), r.modelRouter)
+}
+
+// SetDecomposer sets the task decomposer for auto-splitting complex tasks (GH-218).
+// When set and enabled, complex tasks are decomposed into subtasks that run sequentially,
+// with only the final subtask creating a PR.
+func (r *Runner) SetDecomposer(decomposer *TaskDecomposer) {
+	r.decomposer = decomposer
+}
+
+// EnableDecomposition creates and configures a default task decomposer.
+// This is a convenience method to enable decomposition with default settings.
+func (r *Runner) EnableDecomposition(config *DecomposeConfig) {
+	if config == nil {
+		config = DefaultDecomposeConfig()
+		config.Enabled = true // Enable by default when called explicitly
+	}
+	r.decomposer = NewTaskDecomposer(config)
 }
 
 // getRecordingsPath returns the recordings path, using default if not set
@@ -393,11 +416,29 @@ func (r *Runner) EmitProgress(taskID, phase string, progress int, message string
 // backend invocation, progress tracking, and optional PR creation.
 // The context can be used to cancel execution. Returns an error only for
 // setup failures; execution failures are reported in ExecutionResult.
+//
+// When a decomposer is configured and enabled, complex tasks are automatically
+// split into subtasks that run sequentially (GH-218). Only the final subtask
+// creates a PR, accumulating all changes from previous subtasks.
 func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, error) {
 	start := time.Now()
 
 	// Detect complexity for routing decisions
 	complexity := DetectComplexity(task)
+
+	// Check for task decomposition (GH-218)
+	// Decomposition happens before timeout setup because subtasks have their own timeouts
+	if r.decomposer != nil {
+		result := r.decomposer.Decompose(task)
+		if result.Decomposed && len(result.Subtasks) > 1 {
+			r.log.Info("Task decomposed",
+				slog.String("task_id", task.ID),
+				slog.Int("subtask_count", len(result.Subtasks)),
+				slog.String("reason", result.Reason),
+			)
+			return r.executeDecomposedTask(ctx, task, result.Subtasks)
+		}
+	}
 
 	// Apply timeout based on task complexity
 	timeout := r.modelRouter.SelectTimeout(task)
@@ -1007,6 +1048,198 @@ func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, err
 	}
 
 	return result, nil
+}
+
+// executeDecomposedTask runs subtasks sequentially and aggregates results (GH-218).
+// Each subtask runs to completion before the next starts. Only the final subtask
+// creates a PR (CreatePR is already set by the decomposer). All changes accumulate
+// on the same branch, so the final PR contains all subtask work.
+func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, subtasks []*Task) (*ExecutionResult, error) {
+	start := time.Now()
+	totalSubtasks := len(subtasks)
+
+	r.log.Info("Starting decomposed task execution",
+		slog.String("parent_id", parentTask.ID),
+		slog.Int("subtask_count", totalSubtasks),
+	)
+
+	// Emit parent task started event
+	r.emitAlertEvent(AlertEvent{
+		Type:      AlertEventTypeTaskStarted,
+		TaskID:    parentTask.ID,
+		TaskTitle: parentTask.Title,
+		Project:   parentTask.ProjectPath,
+		Metadata: map[string]string{
+			"decomposed":    "true",
+			"subtask_count": fmt.Sprintf("%d", totalSubtasks),
+		},
+		Timestamp: time.Now(),
+	})
+
+	// Dispatch webhook for decomposed task started
+	r.dispatchWebhook(ctx, webhooks.EventTaskStarted, webhooks.TaskStartedData{
+		TaskID:      parentTask.ID,
+		Title:       parentTask.Title,
+		Description: fmt.Sprintf("Decomposed into %d subtasks: %s", totalSubtasks, parentTask.Description),
+		Project:     parentTask.ProjectPath,
+		Source:      "pilot",
+	})
+
+	// Initialize git and create branch ONCE for all subtasks
+	git := NewGitOperations(parentTask.ProjectPath)
+	if parentTask.Branch != "" {
+		r.reportProgress(parentTask.ID, "Branching", 2, fmt.Sprintf("Creating branch %s...", parentTask.Branch))
+		if err := git.CreateBranch(ctx, parentTask.Branch); err != nil {
+			if switchErr := git.SwitchBranch(ctx, parentTask.Branch); switchErr != nil {
+				return nil, fmt.Errorf("failed to create/switch branch: %w", err)
+			}
+		}
+		r.reportProgress(parentTask.ID, "Branching", 5, fmt.Sprintf("Branch %s ready", parentTask.Branch))
+	}
+
+	// Aggregate result
+	aggregateResult := &ExecutionResult{
+		TaskID:  parentTask.ID,
+		Success: true,
+	}
+
+	// Execute each subtask sequentially
+	for i, subtask := range subtasks {
+		subtaskNum := i + 1
+
+		// Report progress with subtask counter
+		progressPct := 5 + (85 * subtaskNum / totalSubtasks)
+		r.reportProgress(parentTask.ID, "Decomposed", progressPct,
+			fmt.Sprintf("Subtask %d/%d: %s", subtaskNum, totalSubtasks, truncateText(subtask.Title, 40)))
+
+		r.log.Info("Executing subtask",
+			slog.String("parent_id", parentTask.ID),
+			slog.String("subtask_id", subtask.ID),
+			slog.Int("index", subtaskNum),
+			slog.Int("total", totalSubtasks),
+		)
+
+		// Execute subtask (recursively calls Execute, but subtasks won't decompose further)
+		// Clear the branch since we already created it
+		subtask.Branch = ""
+
+		// Temporarily disable decomposer to prevent recursive decomposition
+		savedDecomposer := r.decomposer
+		r.decomposer = nil
+
+		subtaskResult, err := r.Execute(ctx, subtask)
+
+		// Restore decomposer
+		r.decomposer = savedDecomposer
+
+		if err != nil {
+			r.log.Error("Subtask execution error",
+				slog.String("subtask_id", subtask.ID),
+				slog.Any("error", err),
+			)
+			aggregateResult.Success = false
+			aggregateResult.Error = fmt.Sprintf("subtask %d/%d failed: %v", subtaskNum, totalSubtasks, err)
+			break
+		}
+
+		if !subtaskResult.Success {
+			r.log.Warn("Subtask failed",
+				slog.String("subtask_id", subtask.ID),
+				slog.String("error", subtaskResult.Error),
+			)
+			aggregateResult.Success = false
+			aggregateResult.Error = fmt.Sprintf("subtask %d/%d failed: %s", subtaskNum, totalSubtasks, subtaskResult.Error)
+			break
+		}
+
+		// Aggregate metrics
+		aggregateResult.TokensInput += subtaskResult.TokensInput
+		aggregateResult.TokensOutput += subtaskResult.TokensOutput
+		aggregateResult.TokensTotal += subtaskResult.TokensTotal
+		aggregateResult.ResearchTokens += subtaskResult.ResearchTokens
+		aggregateResult.FilesChanged += subtaskResult.FilesChanged
+		aggregateResult.LinesAdded += subtaskResult.LinesAdded
+		aggregateResult.LinesRemoved += subtaskResult.LinesRemoved
+
+		// Keep last commit SHA and PR URL
+		if subtaskResult.CommitSHA != "" {
+			aggregateResult.CommitSHA = subtaskResult.CommitSHA
+		}
+		if subtaskResult.PRUrl != "" {
+			aggregateResult.PRUrl = subtaskResult.PRUrl
+		}
+		if subtaskResult.ModelName != "" {
+			aggregateResult.ModelName = subtaskResult.ModelName
+		}
+
+		// Track quality gates from final subtask
+		if subtask.CreatePR && subtaskResult.QualityGates != nil {
+			aggregateResult.QualityGates = subtaskResult.QualityGates
+		}
+
+		r.log.Info("Subtask completed",
+			slog.String("subtask_id", subtask.ID),
+			slog.Int("index", subtaskNum),
+			slog.Int("total", totalSubtasks),
+		)
+	}
+
+	aggregateResult.Duration = time.Since(start)
+	aggregateResult.EstimatedCostUSD = estimateCost(
+		aggregateResult.TokensInput+aggregateResult.ResearchTokens,
+		aggregateResult.TokensOutput,
+		aggregateResult.ModelName,
+	)
+
+	// Emit completion event
+	if aggregateResult.Success {
+		r.reportProgress(parentTask.ID, "Completed", 100,
+			fmt.Sprintf("All %d subtasks completed", totalSubtasks))
+
+		r.emitAlertEvent(AlertEvent{
+			Type:      AlertEventTypeTaskCompleted,
+			TaskID:    parentTask.ID,
+			TaskTitle: parentTask.Title,
+			Project:   parentTask.ProjectPath,
+			Metadata: map[string]string{
+				"duration_ms":   fmt.Sprintf("%d", aggregateResult.Duration.Milliseconds()),
+				"pr_url":        aggregateResult.PRUrl,
+				"subtask_count": fmt.Sprintf("%d", totalSubtasks),
+			},
+			Timestamp: time.Now(),
+		})
+
+		r.dispatchWebhook(ctx, webhooks.EventTaskCompleted, webhooks.TaskCompletedData{
+			TaskID:    parentTask.ID,
+			Title:     parentTask.Title,
+			Project:   parentTask.ProjectPath,
+			Duration:  aggregateResult.Duration,
+			PRCreated: aggregateResult.PRUrl != "",
+			PRURL:     aggregateResult.PRUrl,
+		})
+	} else {
+		r.reportProgress(parentTask.ID, "Failed", 100, aggregateResult.Error)
+
+		r.emitAlertEvent(AlertEvent{
+			Type:      AlertEventTypeTaskFailed,
+			TaskID:    parentTask.ID,
+			TaskTitle: parentTask.Title,
+			Project:   parentTask.ProjectPath,
+			Error:     aggregateResult.Error,
+			Timestamp: time.Now(),
+		})
+
+		r.dispatchWebhook(ctx, webhooks.EventTaskFailed, webhooks.TaskFailedData{
+			TaskID:   parentTask.ID,
+			Title:    parentTask.Title,
+			Project:  parentTask.ProjectPath,
+			Duration: aggregateResult.Duration,
+			Error:    aggregateResult.Error,
+			Phase:    "Decomposed",
+		})
+	}
+
+	return aggregateResult, nil
 }
 
 // Cancel terminates a running task by killing its Claude Code process.


### PR DESCRIPTION
## Summary

- Wire TaskDecomposer into Runner.Execute() for complex task auto-splitting (GH-218)
- Add executeDecomposedTask() for sequential subtask execution with aggregated results
- Only final subtask creates PR; all changes accumulate on same branch

## Changes

**internal/executor/runner.go:**
- Add `decomposer *TaskDecomposer` field to Runner struct
- Configure decomposer from BackendConfig.Decompose in NewRunnerWithConfig()
- Add SetDecomposer() and EnableDecomposition() methods
- Check for decomposition in Execute() before timeout setup
- Add executeDecomposedTask() implementing:
  - Sequential subtask execution
  - Token/metrics aggregation across subtasks
  - Alert and webhook events for parent task
  - Branch creation once for all subtasks

**internal/executor/dispatcher.go:**
- Add SetDecomposer() method
- Check decomposition in QueueTask()
- Add queueDecomposedTask() for storing parent as "decomposed" status

**internal/executor/runner_test.go:**
- Add TestRunner_Execute_WithDecomposition
- Add TestRunner_EnableDecomposition

## Configuration

```yaml
executor:
  decompose:
    enabled: true
    min_complexity: "complex"
    max_subtasks: 5
    min_description_words: 50
```

## Test Plan

- [x] Unit tests pass
- [x] Lint passes
- [ ] Manual test with complex task

Closes #218