### PR TITLE
feat(dashboard): Add Enter key to open selected issue in browser

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -989,7 +989,7 @@ func handleGitHubIssueWithMonitor(ctx context.Context, cfg *config.Config, clien
 
 	// Register task with monitor if in dashboard mode
 	if monitor != nil {
-		monitor.Register(taskID, issue.Title)
+		monitor.Register(taskID, issue.Title, issue.HTMLURL)
 		monitor.Start(taskID)
 	}
 	if program != nil {
@@ -1026,7 +1026,7 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 
 	// Register task with monitor if in dashboard mode
 	if monitor != nil {
-		monitor.Register(taskID, issue.Title)
+		monitor.Register(taskID, issue.Title, issue.HTMLURL)
 		monitor.Start(taskID)
 	}
 	if program != nil {
@@ -3055,6 +3055,8 @@ func convertTaskStatesToDisplay(states []*executor.TaskState) []dashboard.TaskDi
 			Phase:    state.Phase,
 			Progress: state.Progress,
 			Duration: duration,
+			IssueURL: state.IssueURL,
+			PRURL:    state.PRUrl,
 		}
 	}
 	return displays

--- a/internal/executor/monitor.go
+++ b/internal/executor/monitor.go
@@ -30,6 +30,7 @@ type TaskState struct {
 	CompletedAt *time.Time
 	Error       string
 	PRUrl       string
+	IssueURL    string
 }
 
 // Monitor tracks task execution progress
@@ -46,7 +47,7 @@ func NewMonitor() *Monitor {
 }
 
 // Register registers a new task
-func (m *Monitor) Register(taskID, title string) {
+func (m *Monitor) Register(taskID, title, issueURL string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -56,6 +57,7 @@ func (m *Monitor) Register(taskID, title string) {
 		Status:   StatusPending,
 		Phase:    "Pending",
 		Progress: 0,
+		IssueURL: issueURL,
 	}
 }
 

--- a/internal/executor/monitor_test.go
+++ b/internal/executor/monitor_test.go
@@ -18,7 +18,7 @@ func TestNewMonitor(t *testing.T) {
 func TestMonitorRegister(t *testing.T) {
 	monitor := NewMonitor()
 
-	monitor.Register("task-1", "Test Task")
+	monitor.Register("task-1", "Test Task", "")
 
 	state, ok := monitor.Get("task-1")
 	if !ok {
@@ -37,7 +37,7 @@ func TestMonitorRegister(t *testing.T) {
 
 func TestMonitorStart(t *testing.T) {
 	monitor := NewMonitor()
-	monitor.Register("task-1", "Test Task")
+	monitor.Register("task-1", "Test Task", "")
 
 	monitor.Start("task-1")
 
@@ -52,7 +52,7 @@ func TestMonitorStart(t *testing.T) {
 
 func TestMonitorUpdateProgress(t *testing.T) {
 	monitor := NewMonitor()
-	monitor.Register("task-1", "Test Task")
+	monitor.Register("task-1", "Test Task", "")
 	monitor.Start("task-1")
 
 	monitor.UpdateProgress("task-1", "IMPL", 50, "Working...")
@@ -71,7 +71,7 @@ func TestMonitorUpdateProgress(t *testing.T) {
 
 func TestMonitorComplete(t *testing.T) {
 	monitor := NewMonitor()
-	monitor.Register("task-1", "Test Task")
+	monitor.Register("task-1", "Test Task", "")
 	monitor.Start("task-1")
 
 	monitor.Complete("task-1", "https://github.com/org/repo/pull/1")
@@ -90,7 +90,7 @@ func TestMonitorComplete(t *testing.T) {
 
 func TestMonitorFail(t *testing.T) {
 	monitor := NewMonitor()
-	monitor.Register("task-1", "Test Task")
+	monitor.Register("task-1", "Test Task", "")
 	monitor.Start("task-1")
 
 	monitor.Fail("task-1", "Something went wrong")
@@ -106,9 +106,9 @@ func TestMonitorFail(t *testing.T) {
 
 func TestMonitorGetAll(t *testing.T) {
 	monitor := NewMonitor()
-	monitor.Register("task-1", "Task 1")
-	monitor.Register("task-2", "Task 2")
-	monitor.Register("task-3", "Task 3")
+	monitor.Register("task-1", "Task 1", "")
+	monitor.Register("task-2", "Task 2", "")
+	monitor.Register("task-3", "Task 3", "")
 
 	all := monitor.GetAll()
 	if len(all) != 3 {
@@ -118,8 +118,8 @@ func TestMonitorGetAll(t *testing.T) {
 
 func TestMonitorGetRunning(t *testing.T) {
 	monitor := NewMonitor()
-	monitor.Register("task-1", "Task 1")
-	monitor.Register("task-2", "Task 2")
+	monitor.Register("task-1", "Task 1", "")
+	monitor.Register("task-2", "Task 2", "")
 	monitor.Start("task-1")
 
 	running := monitor.GetRunning()
@@ -138,8 +138,8 @@ func TestMonitorCount(t *testing.T) {
 		t.Error("Expected count 0 for empty monitor")
 	}
 
-	monitor.Register("task-1", "Task 1")
-	monitor.Register("task-2", "Task 2")
+	monitor.Register("task-1", "Task 1", "")
+	monitor.Register("task-2", "Task 2", "")
 
 	if monitor.Count() != 2 {
 		t.Errorf("Expected count 2, got %d", monitor.Count())
@@ -148,7 +148,7 @@ func TestMonitorCount(t *testing.T) {
 
 func TestMonitorRemove(t *testing.T) {
 	monitor := NewMonitor()
-	monitor.Register("task-1", "Task 1")
+	monitor.Register("task-1", "Task 1", "")
 
 	monitor.Remove("task-1")
 
@@ -160,7 +160,7 @@ func TestMonitorRemove(t *testing.T) {
 
 func TestMonitorCancel(t *testing.T) {
 	monitor := NewMonitor()
-	monitor.Register("task-1", "Test Task")
+	monitor.Register("task-1", "Test Task", "")
 	monitor.Start("task-1")
 
 	monitor.Cancel("task-1")
@@ -211,7 +211,7 @@ func TestMonitorOperationsOnNonexistent(t *testing.T) {
 
 func TestMonitorUpdateProgressEmptyMessage(t *testing.T) {
 	monitor := NewMonitor()
-	monitor.Register("task-1", "Test Task")
+	monitor.Register("task-1", "Test Task", "")
 	monitor.UpdateProgress("task-1", "Phase1", 25, "Initial message")
 
 	// Update with empty message should not overwrite existing message
@@ -231,7 +231,7 @@ func TestMonitorUpdateProgressEmptyMessage(t *testing.T) {
 
 func TestMonitorGetReturnsCopy(t *testing.T) {
 	monitor := NewMonitor()
-	monitor.Register("task-1", "Test Task")
+	monitor.Register("task-1", "Test Task", "")
 	monitor.Start("task-1")
 
 	state1, _ := monitor.Get("task-1")
@@ -245,9 +245,9 @@ func TestMonitorGetReturnsCopy(t *testing.T) {
 
 func TestMonitorGetRunningMultiple(t *testing.T) {
 	monitor := NewMonitor()
-	monitor.Register("task-1", "Task 1")
-	monitor.Register("task-2", "Task 2")
-	monitor.Register("task-3", "Task 3")
+	monitor.Register("task-1", "Task 1", "")
+	monitor.Register("task-2", "Task 2", "")
+	monitor.Register("task-3", "Task 3", "")
 
 	monitor.Start("task-1")
 	monitor.Start("task-2")
@@ -273,8 +273,8 @@ func TestMonitorGetRunningMultiple(t *testing.T) {
 
 func TestMonitorGetRunningNoRunning(t *testing.T) {
 	monitor := NewMonitor()
-	monitor.Register("task-1", "Task 1")
-	monitor.Register("task-2", "Task 2")
+	monitor.Register("task-1", "Task 1", "")
+	monitor.Register("task-2", "Task 2", "")
 
 	running := monitor.GetRunning()
 	if len(running) != 0 {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -29,14 +29,14 @@ type Orchestrator struct {
 	monitor  *executor.Monitor
 	notifier *slack.Notifier
 
-	taskQueue               chan *Task
-	running                 map[string]bool
-	progressCallback        func(taskID, phase string, progress int, message string)
-	qualityCheckerFactory   executor.QualityCheckerFactory
-	mu                      sync.Mutex
-	wg                      sync.WaitGroup
-	ctx                     context.Context
-	cancel                  context.CancelFunc
+	taskQueue             chan *Task
+	running               map[string]bool
+	progressCallback      func(taskID, phase string, progress int, message string)
+	qualityCheckerFactory executor.QualityCheckerFactory
+	mu                    sync.Mutex
+	wg                    sync.WaitGroup
+	ctx                   context.Context
+	cancel                context.CancelFunc
 }
 
 // Task represents a task to be processed
@@ -138,7 +138,7 @@ func (o *Orchestrator) ProcessTicket(ctx context.Context, issue *linear.Issue, p
 
 // QueueTask adds a task to the processing queue
 func (o *Orchestrator) QueueTask(task *Task) {
-	o.monitor.Register(task.ID, task.Document.Title)
+	o.monitor.Register(task.ID, task.Document.Title, "")
 
 	select {
 	case o.taskQueue <- task:


### PR DESCRIPTION
## Summary
- Add Enter key handler to open selected issue URL in browser
- Add IssueURL field to TaskState and TaskDisplay
- Cross-platform browser open support (darwin/linux/windows)
- Update help text to show "enter: open"

Closes GH-225

Recreated from #243 which had stale commits.