### PR TITLE
feat(briefs): Add Telegram delivery channel and /brief command

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -68,11 +68,26 @@ executor:
   auto_create_pr: true         # Create PR by default after task completion
                                # Use --no-pr flag to disable for individual tasks
 
-  # Daily brief
-  daily_brief:
-    enabled: false
-    time: "09:00"
-    timezone: "America/New_York"
+# Daily briefs configuration
+briefs:
+  enabled: false
+  schedule: "0 9 * * 1-5"      # Cron: 9 AM weekdays
+  timezone: "America/New_York"
+  channels:
+    # Slack channel
+    - type: slack
+      channel: "#dev-updates"
+    # Telegram chat
+    - type: telegram
+      channel: "${TELEGRAM_CHAT_ID}"  # Your Telegram chat ID
+    # Email recipients
+    # - type: email
+    #   recipients:
+    #     - team@example.com
+  content:
+    include_metrics: true
+    include_errors: true
+    max_items_per_section: 10
 
 # Memory settings
 memory:

--- a/internal/adapters/telegram/client.go
+++ b/internal/adapters/telegram/client.go
@@ -466,3 +466,21 @@ func (c *Client) DownloadFile(ctx context.Context, filePath string) ([]byte, err
 
 	return data, nil
 }
+
+// BriefMessageResponse is a simplified response for brief delivery
+type BriefMessageResponse struct {
+	MessageID int64
+}
+
+// SendBriefMessage sends a message and returns a simplified response for brief delivery.
+// This method satisfies the briefs.TelegramSender interface.
+func (c *Client) SendBriefMessage(ctx context.Context, chatID, text, parseMode string) (*BriefMessageResponse, error) {
+	resp, err := c.SendMessage(ctx, chatID, text, parseMode)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || resp.Result == nil {
+		return nil, nil
+	}
+	return &BriefMessageResponse{MessageID: resp.Result.MessageID}, nil
+}

--- a/internal/briefs/delivery_test.go
+++ b/internal/briefs/delivery_test.go
@@ -50,7 +50,6 @@ func (m *mockEmailSender) Send(ctx context.Context, to []string, subject, htmlBo
 	return nil
 }
 
-
 func TestNewDeliveryService(t *testing.T) {
 	config := &BriefConfig{
 		Enabled:  true,
@@ -519,7 +518,6 @@ func createSlackClientWrapper(mock *mockSlackClient) *slack.Client {
 	return nil
 }
 
-
 // Override test to work with actual mock injection
 func TestDeliveryServiceIntegrationSlack(t *testing.T) {
 	// Skip if we can't mock properly
@@ -583,9 +581,9 @@ func TestDeliveryServiceIntegrationEmail(t *testing.T) {
 func containsString(haystack, needle string) bool {
 	return len(haystack) >= len(needle) &&
 		(haystack == needle ||
-		 len(haystack) > len(needle) &&
-		 (haystack[:len(needle)] == needle ||
-		  containsString(haystack[1:], needle)))
+			len(haystack) > len(needle) &&
+				(haystack[:len(needle)] == needle ||
+					containsString(haystack[1:], needle)))
 }
 
 func TestFormatTelegramBrief(t *testing.T) {
@@ -670,11 +668,11 @@ func TestWithSlackClient(t *testing.T) {
 	}
 }
 
-func TestWithTelegramClient(t *testing.T) {
+func TestWithTelegramSender(t *testing.T) {
 	config := &BriefConfig{}
 
-	// WithTelegramClient accepts nil without panic
-	service := NewDeliveryService(config, WithTelegramClient(nil))
+	// WithTelegramSender accepts nil without panic
+	service := NewDeliveryService(config, WithTelegramSender(nil))
 	if service == nil {
 		t.Fatal("expected service, got nil")
 	}

--- a/internal/briefs/types.go
+++ b/internal/briefs/types.go
@@ -64,8 +64,8 @@ type BriefConfig struct {
 
 // ChannelConfig defines a delivery channel
 type ChannelConfig struct {
-	Type       string   `yaml:"type"`       // "slack", "email"
-	Channel    string   `yaml:"channel"`    // For Slack: "#channel-name"
+	Type       string   `yaml:"type"`       // "slack", "email", "telegram"
+	Channel    string   `yaml:"channel"`    // For Slack: "#channel-name", For Telegram: chat_id
 	Recipients []string `yaml:"recipients"` // For email
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-245.

## Changes

GitHub Issue #245: feat(briefs): Add Telegram delivery channel and /brief command

## Problem
Briefs only support Slack/email delivery. No Telegram channel or on-demand command.

## Implementation

### 1. Add Telegram channel in `internal/briefs/delivery.go`

```go
type TelegramChannel struct {
    handler *telegram.Handler
    chatID  int64
}

func (t *TelegramChannel) Deliver(ctx context.Context, brief *Brief) error {
    msg := FormatPlainText(brief)
    return t.handler.SendMessage(ctx, t.chatID, msg)
}
```

### 2. Add `/brief` command in `internal/adapters/telegram/commands.go`

```go
case "/brief":
    generator := briefs.NewGenerator(h.memStore)
    brief, err := generator.GenerateDaily(ctx)
    if err != nil {
        return h.sendError(chatID, "Failed to generate brief: "+err.Error())
    }
    return h.sendMessage(chatID, briefs.FormatPlainText(brief))
```

### 3. Update config support
Add `telegram` channel type with `chat_id` field.

### 4. Update help text
Add `/brief` to Telegram command help.

## Files
- `internal/briefs/delivery.go`
- `internal/adapters/telegram/commands.go`
- `internal/config/config.go` (if needed)
- `configs/pilot.example.yaml`

## Verification
- `/brief` command returns daily summary in Telegram
- Scheduled briefs deliver to Telegram when configured