### PR TITLE
feat(autopilot): Scan existing PRs on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,31 +23,46 @@ Autonomous AI development pipeline. Receives tickets, implements features, creat
 
 ## Features
 
-| Feature | Status | Since | Description |
-|---------|--------|-------|-------------|
-| **Autopilot** | ✅ | v0.3.2 | CI monitoring, auto-merge, feedback loop (dev/stage/prod modes) |
-| **Task Decomposition** | ✅ | v0.4.0 | Complex tasks auto-split into sequential subtasks |
-| **Research Subagents** | ✅ | v0.4.0 | Haiku-powered parallel codebase exploration |
-| **Asana Adapter** | ✅ | v0.4.0 | Webhooks with HMAC verification, task sync |
-| **Execution Replay** | ✅ | v0.3.0 | Record, playback, analyze, export (HTML/JSON/Markdown) |
-| **Model Routing** | ✅ | v0.3.0 | Haiku (trivial) → Sonnet (standard) → Opus (complex) |
-| **Quality Gates** | ✅ | v0.3.0 | Test/lint/build validation with auto-retry on failure |
-| **Cost Controls** | ✅ | v0.3.0 | Budget limits with hard enforcement |
-| **Dashboard TUI** | ✅ | v0.3.0 | Live monitoring, token/cost tracking, autopilot status |
-| **Telegram Bot** | ✅ | v0.1.0 | Chat-based task execution with voice & image support |
-| **GitHub Polling** | ✅ | v0.2.0 | Auto-pick issues with `pilot` label |
-| **Jira Adapter** | ✅ | v0.2.0 | Issue sync and updates |
-| **Sequential Execution** | ✅ | v0.2.0 | Wait for PR merge before next issue |
-| **Hot Upgrade** | ✅ | v0.2.0 | Self-update with `pilot upgrade` |
-| **Daily Briefs** | ✅ | v0.2.0 | Scheduled reports via Slack/Email/Telegram |
-| **Alerting** | ✅ | v0.2.0 | Task failures, cost thresholds, stuck detection |
-| **Cross-Project Memory** | ✅ | v0.2.0 | Shared patterns and context across repositories |
-| **Navigator Integration** | ✅ | v0.2.0 | Auto-detected `.agent/`, skipped for trivial tasks (v0.4.0) |
-| **Multiple Backends** | ✅ | v0.2.0 | Claude Code + OpenCode support |
-| **BYOK** | ✅ | v0.2.0 | Bring your own Anthropic key, Bedrock, or Vertex |
-| **Voice Transcription** | ✅ | v0.1.0 | Whisper API via Telegram |
-| **Image Analysis** | ✅ | v0.1.0 | Multimodal input via Telegram |
-| **Structured Logging** | ✅ | v0.1.0 | JSON logs with correlation IDs |
+### Core Execution
+
+| Feature | Since | Description |
+|---------|-------|-------------|
+| Autopilot | v0.3.2 | CI monitoring, auto-merge, feedback loop (dev/stage/prod) |
+| Task Decomposition | v0.4.0 | Complex tasks auto-split into sequential subtasks |
+| Sequential Execution | v0.2.0 | Wait for PR merge before next issue |
+| Quality Gates | v0.3.0 | Test/lint/build validation with auto-retry |
+| Execution Replay | v0.3.0 | Record, playback, analyze, export (HTML/JSON/MD) |
+
+### Intelligence
+
+| Feature | Since | Description |
+|---------|-------|-------------|
+| Research Subagents | v0.4.0 | Haiku-powered parallel codebase exploration |
+| Model Routing | v0.3.0 | Haiku (trivial) → Sonnet (standard) → Opus (complex) |
+| Navigator Integration | v0.2.0 | Auto-detected `.agent/`, skipped for trivial tasks |
+| Cross-Project Memory | v0.2.0 | Shared patterns and context across repositories |
+
+### Integrations
+
+| Feature | Since | Description |
+|---------|-------|-------------|
+| Telegram Bot | v0.1.0 | Chat-based tasks with voice transcription & images |
+| GitHub Polling | v0.2.0 | Auto-pick issues with `pilot` label |
+| Asana Adapter | v0.4.0 | Webhooks with HMAC verification, task sync |
+| Jira Adapter | v0.2.0 | Issue sync and updates |
+| Daily Briefs | v0.2.0 | Scheduled reports via Slack/Email/Telegram |
+| Alerting | v0.2.0 | Task failures, cost thresholds, stuck detection |
+
+### Infrastructure
+
+| Feature | Since | Description |
+|---------|-------|-------------|
+| Dashboard TUI | v0.3.0 | Live monitoring, token/cost tracking, autopilot status |
+| Hot Upgrade | v0.2.0 | Self-update with `pilot upgrade` |
+| Cost Controls | v0.3.0 | Budget limits with hard enforcement |
+| Multiple Backends | v0.2.0 | Claude Code + OpenCode support |
+| BYOK | v0.2.0 | Bring your own Anthropic key, Bedrock, or Vertex |
+| Structured Logging | v0.1.0 | JSON logs with correlation IDs |
 
 ### Sequential Execution Mode
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -723,6 +723,13 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 
 				// Start autopilot processing loop if controller initialized
 				if autopilotCtrl != nil {
+					// Scan for existing PRs created by Pilot before starting the loop
+					if err := autopilotCtrl.ScanExistingPRs(ctx); err != nil {
+						logging.WithComponent("autopilot").Warn("failed to scan existing PRs",
+							slog.Any("error", err),
+						)
+					}
+
 					fmt.Printf("🤖 Autopilot enabled: %s environment\n", cfg.Orchestrator.Autopilot.Environment)
 					go func() {
 						if err := autopilotCtrl.Run(ctx); err != nil && err != context.Canceled {

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -392,3 +392,14 @@ func (c *Client) GetBranch(ctx context.Context, owner, repo, branch string) (*Br
 	}
 	return &result, nil
 }
+
+// ListPullRequests lists pull requests for a repository
+// state can be "open", "closed", or "all"
+func (c *Client) ListPullRequests(ctx context.Context, owner, repo, state string) ([]*PullRequest, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls?state=%s", owner, repo, state)
+	var result []*PullRequest
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -167,6 +167,12 @@ type CheckOutput struct {
 	Text    string `json:"text,omitempty"`
 }
 
+// PRRef represents a branch reference with SHA (matches GitHub API response for head/base)
+type PRRef struct {
+	Ref string `json:"ref"` // branch name
+	SHA string `json:"sha"` // commit sha
+}
+
 // PullRequest represents a GitHub pull request
 type PullRequest struct {
 	ID        int64  `json:"id,omitempty"`
@@ -174,8 +180,8 @@ type PullRequest struct {
 	Title     string `json:"title"`
 	Body      string `json:"body,omitempty"`
 	State     string `json:"state,omitempty"` // open, closed
-	Head      string `json:"head"`            // Branch name or ref for the head (source)
-	Base      string `json:"base"`            // Branch name or ref for the base (target)
+	Head      PRRef  `json:"head"`            // Head reference with branch name and SHA
+	Base      PRRef  `json:"base"`            // Base reference with branch name and SHA
 	HTMLURL   string `json:"html_url,omitempty"`
 	Draft     bool   `json:"draft,omitempty"`
 	Merged    bool   `json:"merged,omitempty"`


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-257.

## Changes

GitHub Issue #257: feat(autopilot): Scan existing PRs on startup

## Problem

Autopilot only tracks PRs created during the current session via `OnPRCreated` callback. When Pilot restarts, the `activePRs` map is empty and existing open PRs are invisible to autopilot.

**Symptom**: Dashboard shows `Active PRs: 0` even when open PRs exist.

## Solution

Scan for existing open PRs with `pilot/GH-*` branch pattern on startup and restore their tracking state.

## Implementation

### 1. Enhance GitHub Client
- Add `ListPullRequests(ctx, owner, repo, state)` method
- Update `PullRequest` struct - change `Head string` to `HeadRef` struct with `Ref` and `SHA` fields

### 2. Add Startup Scanning
- Add `ScanExistingPRs(ctx)` method to `autopilot.Controller`
- Filter PRs by branch pattern `pilot/GH-*`
- Extract issue number from branch name
- Register via existing `OnPRCreated`

### 3. Wire in main.go
- Call `ScanExistingPRs` after controller creation, before `Run()`

## Files to Modify

- `internal/adapters/github/types.go` - Update PullRequest struct
- `internal/adapters/github/client.go` - Add ListPullRequests
- `internal/autopilot/controller.go` - Add ScanExistingPRs
- `cmd/pilot/main.go` - Wire startup scan
- Tests for new methods

## Acceptance Criteria

- [ ] Autopilot scans existing open PRs on startup
- [ ] Only PRs with `pilot/GH-*` branch pattern are tracked
- [ ] Dashboard shows correct Active PRs count after restart
- [ ] Tests pass

## Task Doc

See `.agent/tasks/GH-253-autopilot-startup-pr-scan.md`