### PR TITLE
Fix YAML syntax error in ci-autofix.yml (line 14)

### DIFF
--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: CI Status
-        run: echo "CI completed with status: ${{ github.event.workflow_run.conclusion }}"
+        run: 'echo "CI completed with status: ${{ github.event.workflow_run.conclusion }}"'
 
   create-fix-issue:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-270.

## Changes

GitHub Issue #270: Fix YAML syntax error in ci-autofix.yml (line 14)

## Summary

The `ci-autofix.yml` workflow has never worked due to a YAML syntax error. All 139 runs fail immediately with event `push` and 0s duration.

## Root Cause

**YAML syntax error at line 14, column 44:**

```
mapping values are not allowed in this context at line 14 column 44
```

The problematic line:
```yaml
run: echo "CI completed with status: ${{ github.event.workflow_run.conclusion }}"
```

YAML interprets the colon in `status:` as a mapping key separator because the string is not properly quoted.

## Fix

Wrap the `run` value in single quotes:

```yaml
# Line 14 - change from:
run: echo "CI completed with status: ${{ github.event.workflow_run.conclusion }}"

# To:
run: 'echo "CI completed with status: ${{ github.event.workflow_run.conclusion }}"'
```

## File

- `.github/workflows/ci-autofix.yml` - Line 14

## Verification

After fixing:
1. Push to main
2. Wait for CI to complete  
3. Check ci-autofix triggers correctly:
   ```bash
   gh run list --workflow ci-autofix.yml --limit 5
   # Should show event: workflow_run (not push)
   ```
4. Verify workflow name is recognized:
   ```bash
   gh workflow list
   # Should show "CI Auto-Fix" instead of path
   ```