### PR TITLE
Implement GitLab adapter

### DIFF
--- a/internal/adapters/gitlab/cleanup.go
+++ b/internal/adapters/gitlab/cleanup.go
@@ -1,0 +1,223 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+	"github.com/alekspetrov/pilot/internal/memory"
+)
+
+// Cleaner handles automatic cleanup of stale pilot-in-progress labels.
+// When Pilot crashes or is killed, labels remain on issues. This cleaner
+// periodically checks for such orphaned labels and removes them.
+type Cleaner struct {
+	client    *Client
+	store     *memory.Store
+	interval  time.Duration
+	threshold time.Duration
+	logger    *slog.Logger
+
+	mu      sync.Mutex
+	running bool
+	stopCh  chan struct{}
+}
+
+// CleanerOption configures a Cleaner
+type CleanerOption func(*Cleaner)
+
+// WithCleanerLogger sets the logger for the cleaner
+func WithCleanerLogger(logger *slog.Logger) CleanerOption {
+	return func(c *Cleaner) {
+		c.logger = logger
+	}
+}
+
+// NewCleaner creates a new stale label cleaner.
+func NewCleaner(client *Client, store *memory.Store, config *StaleLabelCleanupConfig, opts ...CleanerOption) *Cleaner {
+	interval := config.Interval
+	if interval == 0 {
+		interval = 30 * time.Minute
+	}
+
+	threshold := config.Threshold
+	if threshold == 0 {
+		threshold = 1 * time.Hour
+	}
+
+	c := &Cleaner{
+		client:    client,
+		store:     store,
+		interval:  interval,
+		threshold: threshold,
+		logger:    logging.WithComponent("gitlab-cleanup"),
+		stopCh:    make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// Start begins the periodic cleanup loop.
+// It runs in the background and can be stopped with Stop().
+func (c *Cleaner) Start(ctx context.Context) {
+	c.mu.Lock()
+	if c.running {
+		c.mu.Unlock()
+		return
+	}
+	c.running = true
+	c.stopCh = make(chan struct{})
+	c.mu.Unlock()
+
+	c.logger.Info("Starting stale label cleaner",
+		slog.Duration("interval", c.interval),
+		slog.Duration("threshold", c.threshold),
+	)
+
+	// Run initial cleanup
+	if err := c.Cleanup(ctx); err != nil {
+		c.logger.Warn("Initial cleanup failed", slog.Any("error", err))
+	}
+
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("Stale label cleaner stopped (context cancelled)")
+			return
+		case <-c.stopCh:
+			c.logger.Info("Stale label cleaner stopped")
+			return
+		case <-ticker.C:
+			if err := c.Cleanup(ctx); err != nil {
+				c.logger.Warn("Cleanup failed", slog.Any("error", err))
+			}
+		}
+	}
+}
+
+// Stop stops the periodic cleanup loop
+func (c *Cleaner) Stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.running {
+		close(c.stopCh)
+		c.running = false
+	}
+}
+
+// Cleanup performs a single cleanup pass:
+// 1. Lists all issues with pilot-in-progress label
+// 2. Cross-references with active executions in memory store
+// 3. Removes label from issues with no matching active execution
+func (c *Cleaner) Cleanup(ctx context.Context) error {
+	c.logger.Debug("Running stale label cleanup")
+
+	// Get all issues with in-progress label
+	issues, err := c.client.ListIssues(ctx, &ListIssuesOptions{
+		Labels: []string{LabelInProgress},
+		State:  StateOpened,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list issues with in-progress label: %w", err)
+	}
+
+	if len(issues) == 0 {
+		c.logger.Debug("No issues with in-progress label found")
+		return nil
+	}
+
+	c.logger.Debug("Found issues with in-progress label", slog.Int("count", len(issues)))
+
+	// Get active executions from memory store
+	activeExecutions, err := c.store.GetActiveExecutions()
+	if err != nil {
+		return fmt.Errorf("failed to get active executions: %w", err)
+	}
+
+	// Build a map of active task IDs for quick lookup
+	activeTaskIDs := make(map[string]bool)
+	for _, exec := range activeExecutions {
+		activeTaskIDs[exec.TaskID] = true
+	}
+
+	c.logger.Debug("Active executions found", slog.Int("count", len(activeExecutions)))
+
+	// Check each issue
+	cleanedCount := 0
+	for _, issue := range issues {
+		// Check if there's an active execution for this issue
+		// Task IDs are typically formatted as "GL-<iid>" for GitLab
+		taskID := fmt.Sprintf("GL-%d", issue.IID)
+		if activeTaskIDs[taskID] {
+			c.logger.Debug("Issue has active execution, skipping",
+				slog.Int("issue_iid", issue.IID),
+				slog.String("task_id", taskID),
+			)
+			continue
+		}
+
+		// Check if the issue's label update is older than threshold
+		// Use UpdatedAt as a proxy for when the label was added
+		if time.Since(issue.UpdatedAt) < c.threshold {
+			c.logger.Debug("Issue recently updated, skipping",
+				slog.Int("issue_iid", issue.IID),
+				slog.Duration("age", time.Since(issue.UpdatedAt)),
+			)
+			continue
+		}
+
+		// Remove the stale label
+		c.logger.Info("Removing stale in-progress label",
+			slog.Int("issue_iid", issue.IID),
+			slog.String("title", issue.Title),
+			slog.Duration("age", time.Since(issue.UpdatedAt)),
+		)
+
+		if err := c.client.RemoveIssueLabel(ctx, issue.IID, LabelInProgress); err != nil {
+			c.logger.Warn("Failed to remove stale label",
+				slog.Int("issue_iid", issue.IID),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		// Optionally add a comment explaining the cleanup
+		comment := "🧹 **Pilot cleanup**: Removed stale `pilot-in-progress` label.\n\n" +
+			"This issue was marked as in-progress but no active Pilot execution was found. " +
+			"This can happen if Pilot was interrupted or crashed. The issue is now available for processing again."
+
+		if _, err := c.client.AddIssueNote(ctx, issue.IID, comment); err != nil {
+			c.logger.Warn("Failed to add cleanup comment",
+				slog.Int("issue_iid", issue.IID),
+				slog.Any("error", err),
+			)
+		}
+
+		cleanedCount++
+	}
+
+	if cleanedCount > 0 {
+		c.logger.Info("Stale label cleanup completed",
+			slog.Int("cleaned", cleanedCount),
+			slog.Int("total_checked", len(issues)),
+		)
+	}
+
+	return nil
+}
+
+// CleanupStaleLabels is a convenience method that performs a single cleanup
+// without starting the periodic loop. Useful for one-off cleanup operations.
+func (c *Cleaner) CleanupStaleLabels(ctx context.Context) error {
+	return c.Cleanup(ctx)
+}

--- a/internal/adapters/gitlab/client.go
+++ b/internal/adapters/gitlab/client.go
@@ -1,0 +1,311 @@
+package gitlab
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	gitlabAPIURL = "https://gitlab.com"
+)
+
+// Client is a GitLab API client
+type Client struct {
+	token      string
+	httpClient *http.Client
+	baseURL    string // For testing - defaults to gitlabAPIURL
+	projectID  string // URL-encoded project path (namespace%2Fproject)
+}
+
+// NewClient creates a new GitLab client
+// project should be in "namespace/project" format
+func NewClient(token, project string) *Client {
+	return &Client{
+		token:     token,
+		baseURL:   gitlabAPIURL,
+		projectID: url.PathEscape(project),
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// NewClientWithBaseURL creates a new GitLab client with a custom base URL (for testing)
+func NewClientWithBaseURL(token, project, baseURL string) *Client {
+	return &Client{
+		token:     token,
+		baseURL:   baseURL,
+		projectID: url.PathEscape(project),
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// doRequest performs an HTTP request to the GitLab API
+func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}, result interface{}) error {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyBytes, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("PRIVATE-TOKEN", c.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("failed to parse response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// GetProject fetches project info
+func (c *Client) GetProject(ctx context.Context) (*Project, error) {
+	path := fmt.Sprintf("/api/v4/projects/%s", c.projectID)
+	var project Project
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &project); err != nil {
+		return nil, err
+	}
+	return &project, nil
+}
+
+// GetIssue fetches an issue by IID (project-scoped issue number)
+func (c *Client) GetIssue(ctx context.Context, iid int) (*Issue, error) {
+	path := fmt.Sprintf("/api/v4/projects/%s/issues/%d", c.projectID, iid)
+	var issue Issue
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &issue); err != nil {
+		return nil, err
+	}
+	return &issue, nil
+}
+
+// ListIssues lists issues for the project with optional filters
+func (c *Client) ListIssues(ctx context.Context, opts *ListIssuesOptions) ([]*Issue, error) {
+	path := fmt.Sprintf("/api/v4/projects/%s/issues?", c.projectID)
+
+	// Build query parameters
+	params := []string{}
+	if opts != nil {
+		if len(opts.Labels) > 0 {
+			for _, label := range opts.Labels {
+				params = append(params, "labels="+url.QueryEscape(label))
+			}
+		}
+		if opts.State != "" {
+			params = append(params, "state="+opts.State)
+		}
+		if opts.Sort != "" {
+			params = append(params, "sort="+opts.Sort)
+		}
+		if opts.OrderBy != "" {
+			params = append(params, "order_by="+opts.OrderBy)
+		}
+		if !opts.UpdatedAt.IsZero() {
+			params = append(params, "updated_after="+opts.UpdatedAt.Format(time.RFC3339))
+		}
+	}
+
+	for i, p := range params {
+		if i > 0 {
+			path += "&"
+		}
+		path += p
+	}
+
+	var issues []*Issue
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &issues); err != nil {
+		return nil, err
+	}
+	return issues, nil
+}
+
+// AddIssueNote adds a comment (note) to an issue
+func (c *Client) AddIssueNote(ctx context.Context, iid int, body string) (*Note, error) {
+	path := fmt.Sprintf("/api/v4/projects/%s/issues/%d/notes", c.projectID, iid)
+	reqBody := map[string]string{"body": body}
+	var note Note
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &note); err != nil {
+		return nil, err
+	}
+	return &note, nil
+}
+
+// AddIssueLabels adds labels to an issue
+func (c *Client) AddIssueLabels(ctx context.Context, iid int, labels []string) error {
+	// GitLab uses PUT to update issue, and labels are comma-separated
+	// First get current labels, then add new ones
+	issue, err := c.GetIssue(ctx, iid)
+	if err != nil {
+		return fmt.Errorf("failed to get issue: %w", err)
+	}
+
+	// Merge existing and new labels
+	labelSet := make(map[string]bool)
+	for _, l := range issue.Labels {
+		labelSet[l] = true
+	}
+	for _, l := range labels {
+		labelSet[l] = true
+	}
+
+	// Convert back to slice
+	allLabels := make([]string, 0, len(labelSet))
+	for l := range labelSet {
+		allLabels = append(allLabels, l)
+	}
+
+	path := fmt.Sprintf("/api/v4/projects/%s/issues/%d", c.projectID, iid)
+	reqBody := map[string]interface{}{"labels": allLabels}
+	return c.doRequest(ctx, http.MethodPut, path, reqBody, nil)
+}
+
+// RemoveIssueLabel removes a label from an issue
+func (c *Client) RemoveIssueLabel(ctx context.Context, iid int, label string) error {
+	// GitLab uses PUT to update issue, need to get current labels and remove the one
+	issue, err := c.GetIssue(ctx, iid)
+	if err != nil {
+		// 404 is OK - issue might not exist
+		return nil
+	}
+
+	// Remove the label from the list
+	newLabels := make([]string, 0, len(issue.Labels))
+	found := false
+	for _, l := range issue.Labels {
+		if l != label {
+			newLabels = append(newLabels, l)
+		} else {
+			found = true
+		}
+	}
+
+	// If label wasn't there, nothing to do
+	if !found {
+		return nil
+	}
+
+	path := fmt.Sprintf("/api/v4/projects/%s/issues/%d", c.projectID, iid)
+	reqBody := map[string]interface{}{"labels": newLabels}
+	return c.doRequest(ctx, http.MethodPut, path, reqBody, nil)
+}
+
+// CreateMergeRequest creates a new merge request
+func (c *Client) CreateMergeRequest(ctx context.Context, input *MergeRequestInput) (*MergeRequest, error) {
+	path := fmt.Sprintf("/api/v4/projects/%s/merge_requests", c.projectID)
+	var mr MergeRequest
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &mr); err != nil {
+		return nil, err
+	}
+	return &mr, nil
+}
+
+// GetMergeRequest fetches a merge request by IID
+func (c *Client) GetMergeRequest(ctx context.Context, iid int) (*MergeRequest, error) {
+	path := fmt.Sprintf("/api/v4/projects/%s/merge_requests/%d", c.projectID, iid)
+	var mr MergeRequest
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &mr); err != nil {
+		return nil, err
+	}
+	return &mr, nil
+}
+
+// MergeMergeRequest merges a merge request
+func (c *Client) MergeMergeRequest(ctx context.Context, iid int, squash bool) (*MergeRequest, error) {
+	path := fmt.Sprintf("/api/v4/projects/%s/merge_requests/%d/merge", c.projectID, iid)
+	reqBody := map[string]interface{}{
+		"squash": squash,
+	}
+	var mr MergeRequest
+	if err := c.doRequest(ctx, http.MethodPut, path, reqBody, &mr); err != nil {
+		return nil, err
+	}
+	return &mr, nil
+}
+
+// ListMergeRequests lists merge requests for the project
+func (c *Client) ListMergeRequests(ctx context.Context, state string) ([]*MergeRequest, error) {
+	path := fmt.Sprintf("/api/v4/projects/%s/merge_requests?state=%s", c.projectID, state)
+	var mrs []*MergeRequest
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &mrs); err != nil {
+		return nil, err
+	}
+	return mrs, nil
+}
+
+// GetPipeline fetches a pipeline by ID
+func (c *Client) GetPipeline(ctx context.Context, pipelineID int) (*Pipeline, error) {
+	path := fmt.Sprintf("/api/v4/projects/%s/pipelines/%d", c.projectID, pipelineID)
+	var pipeline Pipeline
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &pipeline); err != nil {
+		return nil, err
+	}
+	return &pipeline, nil
+}
+
+// HasLabel checks if an issue has a specific label
+func HasLabel(issue *Issue, labelName string) bool {
+	for _, label := range issue.Labels {
+		if label == labelName {
+			return true
+		}
+	}
+	return false
+}
+
+// UpdateIssueState updates an issue's state (close/reopen)
+func (c *Client) UpdateIssueState(ctx context.Context, iid int, state string) error {
+	path := fmt.Sprintf("/api/v4/projects/%s/issues/%d", c.projectID, iid)
+	// GitLab uses state_event: "close" or "reopen"
+	stateEvent := "close"
+	if state == StateOpened {
+		stateEvent = "reopen"
+	}
+	reqBody := map[string]string{"state_event": stateEvent}
+	return c.doRequest(ctx, http.MethodPut, path, reqBody, nil)
+}
+
+// AddMergeRequestNote adds a comment to a merge request
+func (c *Client) AddMergeRequestNote(ctx context.Context, iid int, body string) (*Note, error) {
+	path := fmt.Sprintf("/api/v4/projects/%s/merge_requests/%d/notes", c.projectID, iid)
+	reqBody := map[string]string{"body": body}
+	var note Note
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &note); err != nil {
+		return nil, err
+	}
+	return &note, nil
+}

--- a/internal/adapters/gitlab/client_test.go
+++ b/internal/adapters/gitlab/client_test.go
@@ -1,0 +1,662 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestNewClient(t *testing.T) {
+	client := NewClient(testutil.FakeGitLabToken, "namespace/project")
+	if client == nil {
+		t.Fatal("NewClient returned nil")
+	}
+	if client.token != testutil.FakeGitLabToken {
+		t.Errorf("client.token = %s, want %s", client.token, testutil.FakeGitLabToken)
+	}
+	if client.baseURL != gitlabAPIURL {
+		t.Errorf("client.baseURL = %s, want %s", client.baseURL, gitlabAPIURL)
+	}
+	// Project path should be URL-encoded
+	if client.projectID != "namespace%2Fproject" {
+		t.Errorf("client.projectID = %s, want namespace%%2Fproject", client.projectID)
+	}
+}
+
+func TestNewClientWithBaseURL(t *testing.T) {
+	customURL := "https://custom.gitlab.example.com"
+	client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", customURL)
+	if client == nil {
+		t.Fatal("NewClientWithBaseURL returned nil")
+	}
+	if client.token != testutil.FakeGitLabToken {
+		t.Errorf("client.token = %s, want %s", client.token, testutil.FakeGitLabToken)
+	}
+	if client.baseURL != customURL {
+		t.Errorf("client.baseURL = %s, want %s", client.baseURL, customURL)
+	}
+}
+
+func TestGetProject(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		response   interface{}
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			response: Project{
+				ID:                12345,
+				Name:              "project",
+				PathWithNamespace: "namespace/project",
+				WebURL:            "https://gitlab.com/namespace/project",
+				DefaultBranch:     "main",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			response:   map[string]string{"message": "404 Project Not Found"},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET, got %s", r.Method)
+				}
+				if r.Header.Get("PRIVATE-TOKEN") != testutil.FakeGitLabToken {
+					t.Errorf("unexpected auth header: %s", r.Header.Get("PRIVATE-TOKEN"))
+				}
+
+				w.WriteHeader(tt.statusCode)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(tt.response)
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", server.URL)
+			project, err := client.GetProject(context.Background())
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetProject() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && project.Name != "project" {
+				t.Errorf("project.Name = %s, want project", project.Name)
+			}
+		})
+	}
+}
+
+func TestGetIssue(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		response   interface{}
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			response: Issue{
+				ID:          1001,
+				IID:         42,
+				Title:       "Test Issue",
+				Description: "Issue description",
+				State:       StateOpened,
+				WebURL:      "https://gitlab.com/namespace/project/-/issues/42",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			response:   map[string]string{"message": "404 Issue Not Found"},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.Contains(r.URL.Path, "/issues/42") {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET, got %s", r.Method)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				_ = json.NewEncoder(w).Encode(tt.response)
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", server.URL)
+			issue, err := client.GetIssue(context.Background(), 42)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetIssue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && issue.IID != 42 {
+				t.Errorf("issue.IID = %d, want 42", issue.IID)
+			}
+		})
+	}
+}
+
+func TestListIssues(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       *ListIssuesOptions
+		statusCode int
+		response   interface{}
+		wantErr    bool
+		wantCount  int
+	}{
+		{
+			name:       "success - no options",
+			opts:       nil,
+			statusCode: http.StatusOK,
+			response: []*Issue{
+				{IID: 1, Title: "Issue 1"},
+				{IID: 2, Title: "Issue 2"},
+			},
+			wantErr:   false,
+			wantCount: 2,
+		},
+		{
+			name: "success - with labels",
+			opts: &ListIssuesOptions{
+				Labels: []string{"pilot", "bug"},
+				State:  StateOpened,
+			},
+			statusCode: http.StatusOK,
+			response: []*Issue{
+				{IID: 1, Title: "Issue 1"},
+			},
+			wantErr:   false,
+			wantCount: 1,
+		},
+		{
+			name:       "unauthorized",
+			opts:       nil,
+			statusCode: http.StatusUnauthorized,
+			response:   map[string]string{"message": "401 Unauthorized"},
+			wantErr:    true,
+			wantCount:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET, got %s", r.Method)
+				}
+				if !strings.Contains(r.URL.Path, "/issues") {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				_ = json.NewEncoder(w).Encode(tt.response)
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", server.URL)
+			issues, err := client.ListIssues(context.Background(), tt.opts)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ListIssues() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && len(issues) != tt.wantCount {
+				t.Errorf("ListIssues() returned %d issues, want %d", len(issues), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestAddIssueNote(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		statusCode int
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			body:       "Test comment",
+			statusCode: http.StatusCreated,
+			wantErr:    false,
+		},
+		{
+			name:       "server error",
+			body:       "Test comment",
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST, got %s", r.Method)
+				}
+
+				var body map[string]string
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("failed to decode body: %v", err)
+				}
+
+				if body["body"] != tt.body {
+					t.Errorf("unexpected comment body: %s", body["body"])
+				}
+
+				w.WriteHeader(tt.statusCode)
+				if tt.statusCode < 300 {
+					note := Note{
+						ID:   123,
+						Body: tt.body,
+					}
+					_ = json.NewEncoder(w).Encode(note)
+				}
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", server.URL)
+			note, err := client.AddIssueNote(context.Background(), 42, tt.body)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AddIssueNote() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && note.ID != 123 {
+				t.Errorf("note.ID = %d, want 123", note.ID)
+			}
+		})
+	}
+}
+
+func TestCreateMergeRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      *MergeRequestInput
+		statusCode int
+		wantErr    bool
+	}{
+		{
+			name: "success",
+			input: &MergeRequestInput{
+				Title:        "Add new feature",
+				Description:  "This MR adds a new feature",
+				SourceBranch: "feature/new-feature",
+				TargetBranch: "main",
+			},
+			statusCode: http.StatusCreated,
+			wantErr:    false,
+		},
+		{
+			name: "unprocessable entity - branch doesn't exist",
+			input: &MergeRequestInput{
+				Title:        "Add new feature",
+				SourceBranch: "nonexistent-branch",
+				TargetBranch: "main",
+			},
+			statusCode: http.StatusUnprocessableEntity,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST, got %s", r.Method)
+				}
+				if !strings.Contains(r.URL.Path, "/merge_requests") {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+
+				var body MergeRequestInput
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("failed to decode body: %v", err)
+				}
+
+				if body.Title != tt.input.Title {
+					t.Errorf("unexpected title: %s", body.Title)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				if tt.statusCode < 300 {
+					result := MergeRequest{
+						ID:           11111,
+						IID:          42,
+						Title:        body.Title,
+						SourceBranch: body.SourceBranch,
+						TargetBranch: body.TargetBranch,
+						State:        MRStateOpened,
+						WebURL:       "https://gitlab.com/namespace/project/-/merge_requests/42",
+					}
+					_ = json.NewEncoder(w).Encode(result)
+				}
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", server.URL)
+			result, err := client.CreateMergeRequest(context.Background(), tt.input)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateMergeRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && result.IID != 42 {
+				t.Errorf("result.IID = %d, want 42", result.IID)
+			}
+		})
+	}
+}
+
+func TestGetMergeRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		response   interface{}
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			response: MergeRequest{
+				ID:           11111,
+				IID:          42,
+				Title:        "Test MR",
+				SourceBranch: "feature-branch",
+				TargetBranch: "main",
+				State:        MRStateOpened,
+				WebURL:       "https://gitlab.com/namespace/project/-/merge_requests/42",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			response:   map[string]string{"message": "404 Merge Request Not Found"},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET, got %s", r.Method)
+				}
+				if !strings.Contains(r.URL.Path, "/merge_requests/42") {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				_ = json.NewEncoder(w).Encode(tt.response)
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", server.URL)
+			result, err := client.GetMergeRequest(context.Background(), 42)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetMergeRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && result.IID != 42 {
+				t.Errorf("result.IID = %d, want 42", result.IID)
+			}
+		})
+	}
+}
+
+func TestMergeMergeRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		squash     bool
+		statusCode int
+		wantErr    bool
+	}{
+		{
+			name:       "success - no squash",
+			squash:     false,
+			statusCode: http.StatusOK,
+			wantErr:    false,
+		},
+		{
+			name:       "success - with squash",
+			squash:     true,
+			statusCode: http.StatusOK,
+			wantErr:    false,
+		},
+		{
+			name:       "not mergeable - conflicts",
+			squash:     false,
+			statusCode: http.StatusMethodNotAllowed,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPut {
+					t.Errorf("expected PUT, got %s", r.Method)
+				}
+				if !strings.Contains(r.URL.Path, "/merge_requests/42/merge") {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+
+				var body map[string]interface{}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("failed to decode body: %v", err)
+				}
+
+				if body["squash"] != tt.squash {
+					t.Errorf("unexpected squash: %v, want %v", body["squash"], tt.squash)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				if tt.statusCode == http.StatusOK {
+					mr := MergeRequest{
+						IID:   42,
+						State: MRStateMerged,
+					}
+					_ = json.NewEncoder(w).Encode(mr)
+				}
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", server.URL)
+			_, err := client.MergeMergeRequest(context.Background(), 42, tt.squash)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MergeMergeRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHasLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		issue     *Issue
+		labelName string
+		want      bool
+	}{
+		{
+			name: "has label - first",
+			issue: &Issue{
+				Labels: []string{"pilot", "bug"},
+			},
+			labelName: "pilot",
+			want:      true,
+		},
+		{
+			name: "has label - last",
+			issue: &Issue{
+				Labels: []string{"bug", "enhancement", "pilot"},
+			},
+			labelName: "pilot",
+			want:      true,
+		},
+		{
+			name: "does not have label",
+			issue: &Issue{
+				Labels: []string{"bug", "enhancement"},
+			},
+			labelName: "pilot",
+			want:      false,
+		},
+		{
+			name: "empty labels",
+			issue: &Issue{
+				Labels: []string{},
+			},
+			labelName: "pilot",
+			want:      false,
+		},
+		{
+			name:      "nil labels",
+			issue:     &Issue{},
+			labelName: "pilot",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HasLabel(tt.issue, tt.labelName)
+			if got != tt.want {
+				t.Errorf("HasLabel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Enabled != false {
+		t.Errorf("default Enabled = %v, want false", cfg.Enabled)
+	}
+
+	if cfg.BaseURL != "https://gitlab.com" {
+		t.Errorf("default BaseURL = %s, want 'https://gitlab.com'", cfg.BaseURL)
+	}
+
+	if cfg.PilotLabel != "pilot" {
+		t.Errorf("default PilotLabel = %s, want 'pilot'", cfg.PilotLabel)
+	}
+
+	if cfg.Polling == nil {
+		t.Fatal("default Polling config is nil")
+	}
+
+	if cfg.Polling.Enabled != false {
+		t.Errorf("default Polling.Enabled = %v, want false", cfg.Polling.Enabled)
+	}
+
+	if cfg.Polling.Label != "pilot" {
+		t.Errorf("default Polling.Label = %s, want 'pilot'", cfg.Polling.Label)
+	}
+}
+
+func TestPriorityFromLabel(t *testing.T) {
+	tests := []struct {
+		label string
+		want  Priority
+	}{
+		{"priority::urgent", PriorityUrgent},
+		{"P0", PriorityUrgent},
+		{"priority::high", PriorityHigh},
+		{"P1", PriorityHigh},
+		{"priority::medium", PriorityMedium},
+		{"P2", PriorityMedium},
+		{"priority::low", PriorityLow},
+		{"P3", PriorityLow},
+		{"bug", PriorityNone},
+		{"", PriorityNone},
+		{"random-label", PriorityNone},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.label, func(t *testing.T) {
+			got := PriorityFromLabel(tt.label)
+			if got != tt.want {
+				t.Errorf("PriorityFromLabel(%s) = %d, want %d", tt.label, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStateConstants(t *testing.T) {
+	if StateOpened != "opened" {
+		t.Errorf("StateOpened = %s, want 'opened'", StateOpened)
+	}
+	if StateClosed != "closed" {
+		t.Errorf("StateClosed = %s, want 'closed'", StateClosed)
+	}
+}
+
+func TestMRStateConstants(t *testing.T) {
+	if MRStateOpened != "opened" {
+		t.Errorf("MRStateOpened = %s, want 'opened'", MRStateOpened)
+	}
+	if MRStateClosed != "closed" {
+		t.Errorf("MRStateClosed = %s, want 'closed'", MRStateClosed)
+	}
+	if MRStateMerged != "merged" {
+		t.Errorf("MRStateMerged = %s, want 'merged'", MRStateMerged)
+	}
+}
+
+func TestLabelConstants(t *testing.T) {
+	if LabelInProgress != "pilot-in-progress" {
+		t.Errorf("LabelInProgress = %s, want 'pilot-in-progress'", LabelInProgress)
+	}
+	if LabelDone != "pilot-done" {
+		t.Errorf("LabelDone = %s, want 'pilot-done'", LabelDone)
+	}
+	if LabelFailed != "pilot-failed" {
+		t.Errorf("LabelFailed = %s, want 'pilot-failed'", LabelFailed)
+	}
+}
+
+func TestPipelineStatusConstants(t *testing.T) {
+	tests := []struct {
+		constant string
+		expected string
+	}{
+		{PipelinePending, "pending"},
+		{PipelineRunning, "running"},
+		{PipelineSuccess, "success"},
+		{PipelineFailed, "failed"},
+		{PipelineCanceled, "canceled"},
+		{PipelineSkipped, "skipped"},
+		{PipelineManual, "manual"},
+	}
+
+	for _, tt := range tests {
+		if tt.constant != tt.expected {
+			t.Errorf("constant = %s, want %s", tt.constant, tt.expected)
+		}
+	}
+}

--- a/internal/adapters/gitlab/converter.go
+++ b/internal/adapters/gitlab/converter.go
@@ -1,0 +1,193 @@
+package gitlab
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// TaskInfo contains the extracted task information from a GitLab issue
+type TaskInfo struct {
+	ID          string
+	Title       string
+	Description string
+	Priority    Priority
+	Labels      []string
+	ProjectPath string // namespace/project format
+	IssueIID    int
+	IssueURL    string
+	CloneURL    string
+}
+
+// ConvertIssueToTask converts a GitLab issue to a TaskInfo
+func ConvertIssueToTask(issue *Issue, project *Project) *TaskInfo {
+	// Construct clone URL from project web URL
+	cloneURL := project.WebURL + ".git"
+
+	task := &TaskInfo{
+		ID:          fmt.Sprintf("GL-%d", issue.IID),
+		Title:       issue.Title,
+		Description: extractDescription(issue.Description),
+		Priority:    extractPriority(issue.Labels),
+		Labels:      extractLabelNames(issue.Labels),
+		ProjectPath: project.PathWithNamespace,
+		IssueIID:    issue.IID,
+		IssueURL:    issue.WebURL,
+		CloneURL:    cloneURL,
+	}
+
+	return task
+}
+
+// extractDescription extracts and cleans the task description
+func extractDescription(body string) string {
+	if body == "" {
+		return ""
+	}
+
+	// Remove common GitLab issue template sections that aren't useful for tasks
+	lines := strings.Split(body, "\n")
+	var filtered []string
+	skipSection := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Skip template sections (GitLab uses similar patterns)
+		if strings.HasPrefix(trimmed, "### Checklist") ||
+			strings.HasPrefix(trimmed, "### Environment") ||
+			strings.HasPrefix(trimmed, "### Bug Report") ||
+			strings.HasPrefix(trimmed, "/label ") ||
+			strings.HasPrefix(trimmed, "/assign ") ||
+			strings.HasPrefix(trimmed, "/milestone ") {
+			skipSection = true
+			continue
+		}
+
+		// Resume at next heading
+		if skipSection && strings.HasPrefix(trimmed, "### ") {
+			skipSection = false
+		}
+
+		if !skipSection {
+			filtered = append(filtered, line)
+		}
+	}
+
+	return strings.TrimSpace(strings.Join(filtered, "\n"))
+}
+
+// extractPriority determines priority from labels
+func extractPriority(labels []string) Priority {
+	for _, label := range labels {
+		name := strings.ToLower(label)
+
+		// GitLab scoped labels use :: as separator
+		// e.g., priority::urgent, priority::high
+
+		// Common priority label patterns
+		if strings.Contains(name, "urgent") || strings.Contains(name, "critical") || name == "p0" || name == "priority::urgent" {
+			return PriorityUrgent
+		}
+		if strings.Contains(name, "high") || name == "p1" || name == "priority::high" {
+			return PriorityHigh
+		}
+		if strings.Contains(name, "medium") || name == "p2" || name == "priority::medium" {
+			return PriorityMedium
+		}
+		if strings.Contains(name, "low") || name == "p3" || name == "priority::low" {
+			return PriorityLow
+		}
+	}
+
+	return PriorityNone
+}
+
+// extractLabelNames returns a list of label names excluding pilot/priority labels
+func extractLabelNames(labels []string) []string {
+	var names []string
+	for _, label := range labels {
+		name := strings.ToLower(label)
+		// Skip pilot and priority labels
+		if strings.HasPrefix(name, "pilot") ||
+			strings.HasPrefix(name, "priority") ||
+			strings.HasPrefix(name, "p0") || strings.HasPrefix(name, "p1") ||
+			strings.HasPrefix(name, "p2") || strings.HasPrefix(name, "p3") {
+			continue
+		}
+		names = append(names, label)
+	}
+	return names
+}
+
+// ExtractAcceptanceCriteria extracts acceptance criteria from issue body
+func ExtractAcceptanceCriteria(body string) []string {
+	var criteria []string
+
+	// Look for common acceptance criteria patterns
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)### acceptance criteria\s*\n([\s\S]*?)(?:\n###|\z)`),
+		regexp.MustCompile(`(?i)### criteria\s*\n([\s\S]*?)(?:\n###|\z)`),
+		regexp.MustCompile(`(?i)## acceptance criteria\s*\n([\s\S]*?)(?:\n##|\z)`),
+	}
+
+	for _, pattern := range patterns {
+		matches := pattern.FindStringSubmatch(body)
+		if len(matches) > 1 {
+			// Extract checkbox items (GitLab uses same format)
+			checkboxPattern := regexp.MustCompile(`- \[[ x]\] (.+)`)
+			items := checkboxPattern.FindAllStringSubmatch(matches[1], -1)
+			for _, item := range items {
+				if len(item) > 1 {
+					criteria = append(criteria, strings.TrimSpace(item[1]))
+				}
+			}
+			// Also extract plain list items
+			if len(criteria) == 0 {
+				listPattern := regexp.MustCompile(`- (.+)`)
+				items = listPattern.FindAllStringSubmatch(matches[1], -1)
+				for _, item := range items {
+					if len(item) > 1 {
+						criteria = append(criteria, strings.TrimSpace(item[1]))
+					}
+				}
+			}
+			break
+		}
+	}
+
+	return criteria
+}
+
+// BuildTaskPrompt creates a prompt for Claude Code from the task info
+func BuildTaskPrompt(task *TaskInfo) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("# Task: %s\n\n", task.Title))
+	sb.WriteString(fmt.Sprintf("**Issue**: %s\n", task.IssueURL))
+	sb.WriteString(fmt.Sprintf("**Priority**: %s\n\n", PriorityName(task.Priority)))
+
+	if task.Description != "" {
+		sb.WriteString("## Description\n\n")
+		sb.WriteString(task.Description)
+		sb.WriteString("\n\n")
+	}
+
+	// Extract acceptance criteria if available
+	criteria := ExtractAcceptanceCriteria(task.Description)
+	if len(criteria) > 0 {
+		sb.WriteString("## Acceptance Criteria\n\n")
+		for _, c := range criteria {
+			sb.WriteString(fmt.Sprintf("- [ ] %s\n", c))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("## Requirements\n\n")
+	sb.WriteString("1. Implement the changes described above\n")
+	sb.WriteString("2. Write tests for new functionality\n")
+	sb.WriteString("3. Ensure all existing tests pass\n")
+	sb.WriteString("4. Follow the project's code style and conventions\n")
+
+	return sb.String()
+}

--- a/internal/adapters/gitlab/converter_test.go
+++ b/internal/adapters/gitlab/converter_test.go
@@ -1,0 +1,377 @@
+package gitlab
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConvertIssueToTask(t *testing.T) {
+	issue := &Issue{
+		ID:          1001,
+		IID:         42,
+		Title:       "Implement feature X",
+		Description: "This is the description\n\nWith multiple lines",
+		State:       StateOpened,
+		Labels:      []string{"pilot", "bug", "priority::high"},
+		WebURL:      "https://gitlab.com/namespace/project/-/issues/42",
+	}
+
+	project := &Project{
+		ID:                12345,
+		Name:              "project",
+		PathWithNamespace: "namespace/project",
+		WebURL:            "https://gitlab.com/namespace/project",
+		DefaultBranch:     "main",
+	}
+
+	task := ConvertIssueToTask(issue, project)
+
+	if task.ID != "GL-42" {
+		t.Errorf("task.ID = %s, want GL-42", task.ID)
+	}
+
+	if task.Title != "Implement feature X" {
+		t.Errorf("task.Title = %s, want 'Implement feature X'", task.Title)
+	}
+
+	if task.IssueIID != 42 {
+		t.Errorf("task.IssueIID = %d, want 42", task.IssueIID)
+	}
+
+	if task.ProjectPath != "namespace/project" {
+		t.Errorf("task.ProjectPath = %s, want namespace/project", task.ProjectPath)
+	}
+
+	if task.IssueURL != "https://gitlab.com/namespace/project/-/issues/42" {
+		t.Errorf("task.IssueURL = %s, want https://gitlab.com/namespace/project/-/issues/42", task.IssueURL)
+	}
+
+	if task.CloneURL != "https://gitlab.com/namespace/project.git" {
+		t.Errorf("task.CloneURL = %s, want https://gitlab.com/namespace/project.git", task.CloneURL)
+	}
+
+	if task.Priority != PriorityHigh {
+		t.Errorf("task.Priority = %d, want %d (PriorityHigh)", task.Priority, PriorityHigh)
+	}
+}
+
+func TestExtractDescription(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "simple description",
+			body: "This is a simple description.",
+			want: "This is a simple description.",
+		},
+		{
+			name: "removes checklist section",
+			body: "Main content\n\n### Checklist\n- [ ] Item 1\n- [ ] Item 2",
+			want: "Main content",
+		},
+		{
+			name: "removes environment section",
+			body: "Main content\n\n### Environment\nOS: Linux",
+			want: "Main content",
+		},
+		{
+			name: "removes GitLab quick actions",
+			body: "Main content\n/label ~bug\n/assign @user",
+			want: "Main content",
+		},
+		{
+			name: "empty body",
+			body: "",
+			want: "",
+		},
+		{
+			name: "whitespace only",
+			body: "   \n\n   ",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractDescription(tt.body)
+			if got != tt.want {
+				t.Errorf("extractDescription() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractPriority(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []string
+		want   Priority
+	}{
+		{
+			name:   "scoped label - urgent",
+			labels: []string{"priority::urgent", "bug"},
+			want:   PriorityUrgent,
+		},
+		{
+			name:   "scoped label - high",
+			labels: []string{"priority::high", "enhancement"},
+			want:   PriorityHigh,
+		},
+		{
+			name:   "scoped label - medium",
+			labels: []string{"bug", "priority::medium"},
+			want:   PriorityMedium,
+		},
+		{
+			name:   "scoped label - low",
+			labels: []string{"priority::low"},
+			want:   PriorityLow,
+		},
+		{
+			name:   "P0 label",
+			labels: []string{"P0", "bug"},
+			want:   PriorityUrgent,
+		},
+		{
+			name:   "P1 label",
+			labels: []string{"P1"},
+			want:   PriorityHigh,
+		},
+		{
+			name:   "P2 label",
+			labels: []string{"P2"},
+			want:   PriorityMedium,
+		},
+		{
+			name:   "P3 label",
+			labels: []string{"P3"},
+			want:   PriorityLow,
+		},
+		{
+			name:   "critical keyword",
+			labels: []string{"critical-issue"},
+			want:   PriorityUrgent,
+		},
+		{
+			name:   "high keyword",
+			labels: []string{"high-priority"},
+			want:   PriorityHigh,
+		},
+		{
+			name:   "no priority labels",
+			labels: []string{"bug", "enhancement"},
+			want:   PriorityNone,
+		},
+		{
+			name:   "empty labels",
+			labels: []string{},
+			want:   PriorityNone,
+		},
+		{
+			name:   "nil labels",
+			labels: nil,
+			want:   PriorityNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractPriority(tt.labels)
+			if got != tt.want {
+				t.Errorf("extractPriority() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractLabelNames(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []string
+		want   []string
+	}{
+		{
+			name:   "filters out pilot and priority labels",
+			labels: []string{"pilot", "bug", "priority::high", "P1", "enhancement"},
+			want:   []string{"bug", "enhancement"},
+		},
+		{
+			name:   "keeps all non-filtered labels",
+			labels: []string{"bug", "documentation", "feature"},
+			want:   []string{"bug", "documentation", "feature"},
+		},
+		{
+			name:   "all labels filtered",
+			labels: []string{"pilot", "pilot-in-progress", "P0"},
+			want:   nil,
+		},
+		{
+			name:   "empty labels",
+			labels: []string{},
+			want:   nil,
+		},
+		{
+			name:   "nil labels",
+			labels: nil,
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractLabelNames(tt.labels)
+
+			if len(got) != len(tt.want) {
+				t.Errorf("extractLabelNames() returned %d labels, want %d", len(got), len(tt.want))
+				return
+			}
+
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("extractLabelNames()[%d] = %s, want %s", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestExtractAcceptanceCriteria(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantLen   int
+		wantFirst string
+	}{
+		{
+			name: "markdown checkboxes",
+			body: `## Description
+Some description
+
+### Acceptance Criteria
+- [ ] First criterion
+- [x] Second criterion completed
+- [ ] Third criterion
+
+### Notes`,
+			wantLen:   3,
+			wantFirst: "First criterion",
+		},
+		{
+			name: "plain list items",
+			body: `### Acceptance criteria
+- First item
+- Second item
+
+### Other section`,
+			wantLen:   2,
+			wantFirst: "First item",
+		},
+		{
+			name: "double hash section",
+			body: `## Acceptance Criteria
+- [ ] Criterion one
+- [ ] Criterion two
+
+## Implementation`,
+			wantLen:   2,
+			wantFirst: "Criterion one",
+		},
+		{
+			name:      "no acceptance criteria section",
+			body:      "Just a description without criteria",
+			wantLen:   0,
+			wantFirst: "",
+		},
+		{
+			name:      "empty body",
+			body:      "",
+			wantLen:   0,
+			wantFirst: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractAcceptanceCriteria(tt.body)
+
+			if len(got) != tt.wantLen {
+				t.Errorf("ExtractAcceptanceCriteria() returned %d criteria, want %d", len(got), tt.wantLen)
+				return
+			}
+
+			if tt.wantLen > 0 && got[0] != tt.wantFirst {
+				t.Errorf("ExtractAcceptanceCriteria()[0] = %s, want %s", got[0], tt.wantFirst)
+			}
+		})
+	}
+}
+
+func TestBuildTaskPrompt(t *testing.T) {
+	task := &TaskInfo{
+		ID:          "GL-42",
+		Title:       "Implement feature X",
+		Description: "This is the description\n\n### Acceptance Criteria\n- [ ] Test criterion",
+		Priority:    PriorityHigh,
+		Labels:      []string{"bug", "enhancement"},
+		ProjectPath: "namespace/project",
+		IssueIID:    42,
+		IssueURL:    "https://gitlab.com/namespace/project/-/issues/42",
+		CloneURL:    "https://gitlab.com/namespace/project.git",
+	}
+
+	prompt := BuildTaskPrompt(task)
+
+	// Check required sections are present
+	if !strings.Contains(prompt, "# Task: Implement feature X") {
+		t.Error("prompt missing task title")
+	}
+
+	if !strings.Contains(prompt, "**Issue**: https://gitlab.com/namespace/project/-/issues/42") {
+		t.Error("prompt missing issue URL")
+	}
+
+	if !strings.Contains(prompt, "**Priority**: High") {
+		t.Error("prompt missing priority")
+	}
+
+	if !strings.Contains(prompt, "## Description") {
+		t.Error("prompt missing description section")
+	}
+
+	if !strings.Contains(prompt, "## Acceptance Criteria") {
+		t.Error("prompt missing acceptance criteria section")
+	}
+
+	if !strings.Contains(prompt, "Test criterion") {
+		t.Error("prompt missing acceptance criterion")
+	}
+
+	if !strings.Contains(prompt, "## Requirements") {
+		t.Error("prompt missing requirements section")
+	}
+}
+
+func TestPriorityName(t *testing.T) {
+	tests := []struct {
+		priority Priority
+		want     string
+	}{
+		{PriorityUrgent, "Urgent"},
+		{PriorityHigh, "High"},
+		{PriorityMedium, "Medium"},
+		{PriorityLow, "Low"},
+		{PriorityNone, "No Priority"},
+		{Priority(99), "No Priority"}, // Unknown priority
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := PriorityName(tt.priority)
+			if got != tt.want {
+				t.Errorf("PriorityName(%d) = %s, want %s", tt.priority, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/adapters/gitlab/merger.go
+++ b/internal/adapters/gitlab/merger.go
@@ -1,0 +1,288 @@
+package gitlab
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// MergeWaitResult represents the outcome of waiting for an MR to merge
+type MergeWaitResult struct {
+	Merged       bool   // MR was successfully merged
+	Closed       bool   // MR was closed without merging
+	HasConflicts bool   // MR has merge conflicts
+	TimedOut     bool   // Wait timed out
+	MRNumber     int    // The MR IID
+	MRURL        string // The MR URL
+	Message      string // Human-readable status message
+}
+
+// MergeWaiterConfig holds configuration for the merge waiter
+type MergeWaiterConfig struct {
+	PollInterval time.Duration // How often to check MR status
+	Timeout      time.Duration // Max time to wait for merge
+}
+
+// DefaultMergeWaiterConfig returns sensible defaults
+func DefaultMergeWaiterConfig() *MergeWaiterConfig {
+	return &MergeWaiterConfig{
+		PollInterval: 30 * time.Second,
+		Timeout:      1 * time.Hour,
+	}
+}
+
+// MergeWaiter waits for an MR to be merged
+type MergeWaiter struct {
+	client *Client
+	config *MergeWaiterConfig
+	logger *slog.Logger
+}
+
+// NewMergeWaiter creates a new merge waiter
+func NewMergeWaiter(client *Client, config *MergeWaiterConfig) *MergeWaiter {
+	if config == nil {
+		config = DefaultMergeWaiterConfig()
+	}
+	return &MergeWaiter{
+		client: client,
+		config: config,
+		logger: logging.WithComponent("gitlab-merge-waiter"),
+	}
+}
+
+// Common errors
+var (
+	ErrMRClosed       = errors.New("MR was closed without merging")
+	ErrMRConflict     = errors.New("MR has merge conflicts")
+	ErrMergeTimeout   = errors.New("timed out waiting for MR merge")
+	ErrPipelineFailed = errors.New("pipeline failed")
+)
+
+// WaitForMerge polls the MR status until it's merged, closed, or times out
+func (m *MergeWaiter) WaitForMerge(ctx context.Context, mrIID int) (*MergeWaitResult, error) {
+	m.logger.Info("Waiting for MR merge",
+		slog.Int("mr_iid", mrIID),
+		slog.Duration("timeout", m.config.Timeout),
+		slog.Duration("poll_interval", m.config.PollInterval),
+	)
+
+	deadline := time.Now().Add(m.config.Timeout)
+	ticker := time.NewTicker(m.config.PollInterval)
+	defer ticker.Stop()
+
+	// Check immediately, then on ticker
+	for {
+		result, err := m.checkMRStatus(ctx, mrIID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check MR status: %w", err)
+		}
+
+		// If we have a terminal state, return
+		if result.Merged || result.Closed || result.HasConflicts {
+			return result, nil
+		}
+
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			return &MergeWaitResult{
+				MRNumber: mrIID,
+				Message:  "Context cancelled while waiting for merge",
+			}, ctx.Err()
+		default:
+		}
+
+		// Check timeout
+		if time.Now().After(deadline) {
+			m.logger.Warn("MR merge timed out",
+				slog.Int("mr_iid", mrIID),
+				slog.Duration("timeout", m.config.Timeout),
+			)
+			return &MergeWaitResult{
+				MRNumber: mrIID,
+				TimedOut: true,
+				Message:  fmt.Sprintf("Timed out waiting for MR !%d to merge after %s", mrIID, m.config.Timeout),
+			}, ErrMergeTimeout
+		}
+
+		// Wait for next tick
+		select {
+		case <-ctx.Done():
+			return &MergeWaitResult{
+				MRNumber: mrIID,
+				Message:  "Context cancelled while waiting for merge",
+			}, ctx.Err()
+		case <-ticker.C:
+			m.logger.Debug("Polling MR status",
+				slog.Int("mr_iid", mrIID),
+				slog.Duration("remaining", time.Until(deadline)),
+			)
+		}
+	}
+}
+
+// checkMRStatus fetches and interprets the current MR status
+func (m *MergeWaiter) checkMRStatus(ctx context.Context, mrIID int) (*MergeWaitResult, error) {
+	mr, err := m.client.GetMergeRequest(ctx, mrIID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &MergeWaitResult{
+		MRNumber: mrIID,
+		MRURL:    mr.WebURL,
+	}
+
+	// Check if merged
+	if mr.State == MRStateMerged {
+		m.logger.Info("MR merged successfully",
+			slog.Int("mr_iid", mrIID),
+		)
+		result.Merged = true
+		result.Message = fmt.Sprintf("MR !%d was merged", mrIID)
+		return result, nil
+	}
+
+	// Check if closed without merge
+	if mr.State == MRStateClosed {
+		m.logger.Warn("MR closed without merging",
+			slog.Int("mr_iid", mrIID),
+		)
+		result.Closed = true
+		result.Message = fmt.Sprintf("MR !%d was closed without merging", mrIID)
+		return result, nil
+	}
+
+	// Check for merge conflicts
+	if mr.HasConflicts {
+		m.logger.Warn("MR has merge conflicts",
+			slog.Int("mr_iid", mrIID),
+		)
+		result.HasConflicts = true
+		result.Message = fmt.Sprintf("MR !%d has merge conflicts", mrIID)
+		return result, nil
+	}
+
+	// Check pipeline status if available
+	if mr.HeadPipeline != nil {
+		switch mr.HeadPipeline.Status {
+		case PipelineFailed:
+			result.Message = fmt.Sprintf("MR !%d pipeline failed", mrIID)
+		case PipelineRunning, PipelinePending:
+			result.Message = fmt.Sprintf("MR !%d pipeline in progress", mrIID)
+		case PipelineSuccess:
+			result.Message = fmt.Sprintf("MR !%d ready for merge", mrIID)
+		}
+		return result, nil
+	}
+
+	// Still open and no conflicts
+	result.Message = fmt.Sprintf("MR !%d is open, waiting for merge...", mrIID)
+	return result, nil
+}
+
+// WaitWithCallback is like WaitForMerge but calls the callback on each poll
+// This allows the caller to update UI or logs with current status
+func (m *MergeWaiter) WaitWithCallback(ctx context.Context, mrIID int, onPoll func(result *MergeWaitResult)) (*MergeWaitResult, error) {
+	m.logger.Info("Waiting for MR merge with callback",
+		slog.Int("mr_iid", mrIID),
+	)
+
+	deadline := time.Now().Add(m.config.Timeout)
+	ticker := time.NewTicker(m.config.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		result, err := m.checkMRStatus(ctx, mrIID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check MR status: %w", err)
+		}
+
+		// Call the callback with current status
+		if onPoll != nil {
+			onPoll(result)
+		}
+
+		// If we have a terminal state, return
+		if result.Merged || result.Closed || result.HasConflicts {
+			return result, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return &MergeWaitResult{
+				MRNumber: mrIID,
+				Message:  "Context cancelled",
+			}, ctx.Err()
+		default:
+		}
+
+		if time.Now().After(deadline) {
+			return &MergeWaitResult{
+				MRNumber: mrIID,
+				TimedOut: true,
+				Message:  fmt.Sprintf("Timed out after %s", m.config.Timeout),
+			}, ErrMergeTimeout
+		}
+
+		select {
+		case <-ctx.Done():
+			return &MergeWaitResult{
+				MRNumber: mrIID,
+				Message:  "Context cancelled",
+			}, ctx.Err()
+		case <-ticker.C:
+			// Continue polling
+		}
+	}
+}
+
+// WaitForPipeline waits for the MR's pipeline to complete
+func (m *MergeWaiter) WaitForPipeline(ctx context.Context, mrIID int) (string, error) {
+	m.logger.Info("Waiting for pipeline",
+		slog.Int("mr_iid", mrIID),
+	)
+
+	deadline := time.Now().Add(m.config.Timeout)
+	ticker := time.NewTicker(m.config.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		mr, err := m.client.GetMergeRequest(ctx, mrIID)
+		if err != nil {
+			return "", fmt.Errorf("failed to get MR: %w", err)
+		}
+
+		if mr.HeadPipeline != nil {
+			switch mr.HeadPipeline.Status {
+			case PipelineSuccess:
+				return PipelineSuccess, nil
+			case PipelineFailed:
+				return PipelineFailed, ErrPipelineFailed
+			case PipelineCanceled:
+				return PipelineCanceled, fmt.Errorf("pipeline was canceled")
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+		}
+
+		if time.Now().After(deadline) {
+			return "", ErrMergeTimeout
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ticker.C:
+			// Continue polling
+		}
+	}
+}

--- a/internal/adapters/gitlab/merger_test.go
+++ b/internal/adapters/gitlab/merger_test.go
@@ -1,0 +1,125 @@
+package gitlab
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestMergeWaitResult(t *testing.T) {
+	tests := []struct {
+		name   string
+		result MergeWaitResult
+	}{
+		{
+			name: "merged result",
+			result: MergeWaitResult{
+				Merged:   true,
+				MRNumber: 42,
+				MRURL:    "https://gitlab.com/namespace/project/-/merge_requests/42",
+				Message:  "MR !42 was merged",
+			},
+		},
+		{
+			name: "closed result",
+			result: MergeWaitResult{
+				Closed:   true,
+				MRNumber: 42,
+				Message:  "MR !42 was closed without merging",
+			},
+		},
+		{
+			name: "has conflicts",
+			result: MergeWaitResult{
+				HasConflicts: true,
+				MRNumber:     42,
+				Message:      "MR !42 has merge conflicts",
+			},
+		},
+		{
+			name: "timed out",
+			result: MergeWaitResult{
+				TimedOut: true,
+				MRNumber: 42,
+				Message:  "Timed out waiting for MR !42 to merge after 1h0m0s",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Just verify the struct can be created and fields accessed
+			if tt.result.MRNumber != 42 {
+				t.Errorf("MRNumber = %d, want 42", tt.result.MRNumber)
+			}
+		})
+	}
+}
+
+func TestDefaultMergeWaiterConfig(t *testing.T) {
+	config := DefaultMergeWaiterConfig()
+
+	if config.PollInterval != 30*time.Second {
+		t.Errorf("PollInterval = %v, want 30s", config.PollInterval)
+	}
+
+	if config.Timeout != 1*time.Hour {
+		t.Errorf("Timeout = %v, want 1h", config.Timeout)
+	}
+}
+
+func TestNewMergeWaiter(t *testing.T) {
+	client := NewClient("test-token", "namespace/project")
+
+	// With nil config - should use defaults
+	waiter := NewMergeWaiter(client, nil)
+	if waiter == nil {
+		t.Fatal("NewMergeWaiter returned nil")
+	}
+	if waiter.config.PollInterval != 30*time.Second {
+		t.Errorf("default PollInterval = %v, want 30s", waiter.config.PollInterval)
+	}
+
+	// With custom config
+	customConfig := &MergeWaiterConfig{
+		PollInterval: 10 * time.Second,
+		Timeout:      30 * time.Minute,
+	}
+	waiter = NewMergeWaiter(client, customConfig)
+	if waiter.config.PollInterval != 10*time.Second {
+		t.Errorf("custom PollInterval = %v, want 10s", waiter.config.PollInterval)
+	}
+	if waiter.config.Timeout != 30*time.Minute {
+		t.Errorf("custom Timeout = %v, want 30m", waiter.config.Timeout)
+	}
+}
+
+func TestMergeWaiterErrors(t *testing.T) {
+	// Test error constants exist and are the expected types
+	if !errors.Is(ErrMRClosed, ErrMRClosed) {
+		t.Error("ErrMRClosed should be equal to itself")
+	}
+	if !errors.Is(ErrMRConflict, ErrMRConflict) {
+		t.Error("ErrMRConflict should be equal to itself")
+	}
+	if !errors.Is(ErrMergeTimeout, ErrMergeTimeout) {
+		t.Error("ErrMergeTimeout should be equal to itself")
+	}
+	if !errors.Is(ErrPipelineFailed, ErrPipelineFailed) {
+		t.Error("ErrPipelineFailed should be equal to itself")
+	}
+
+	// Verify they have meaningful error messages
+	if ErrMRClosed.Error() == "" {
+		t.Error("ErrMRClosed should have an error message")
+	}
+	if ErrMRConflict.Error() == "" {
+		t.Error("ErrMRConflict should have an error message")
+	}
+	if ErrMergeTimeout.Error() == "" {
+		t.Error("ErrMergeTimeout should have an error message")
+	}
+	if ErrPipelineFailed.Error() == "" {
+		t.Error("ErrPipelineFailed should have an error message")
+	}
+}

--- a/internal/adapters/gitlab/notifier.go
+++ b/internal/adapters/gitlab/notifier.go
@@ -1,0 +1,127 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Notifier handles status updates to GitLab issues
+type Notifier struct {
+	client     *Client
+	pilotLabel string
+}
+
+// NewNotifier creates a new GitLab notifier
+func NewNotifier(client *Client, pilotLabel string) *Notifier {
+	return &Notifier{
+		client:     client,
+		pilotLabel: pilotLabel,
+	}
+}
+
+// NotifyTaskStarted posts a comment and adds in-progress label
+func (n *Notifier) NotifyTaskStarted(ctx context.Context, issueIID int, taskID string) error {
+	// Add in-progress label
+	if err := n.client.AddIssueLabels(ctx, issueIID, []string{LabelInProgress}); err != nil {
+		return fmt.Errorf("failed to add in-progress label: %w", err)
+	}
+
+	// Post comment
+	comment := fmt.Sprintf("🤖 **Pilot started working on this issue**\n\nTask ID: `%s`\n\nI'll post updates as I make progress.", taskID)
+	if _, err := n.client.AddIssueNote(ctx, issueIID, comment); err != nil {
+		return fmt.Errorf("failed to add start comment: %w", err)
+	}
+
+	return nil
+}
+
+// NotifyProgress posts a progress update comment
+func (n *Notifier) NotifyProgress(ctx context.Context, issueIID int, phase string, details string) error {
+	var emoji string
+	switch strings.ToLower(phase) {
+	case "exploring", "research":
+		emoji = "🔍"
+	case "implementing", "impl":
+		emoji = "🔨"
+	case "testing", "verify":
+		emoji = "🧪"
+	case "committing":
+		emoji = "📝"
+	default:
+		emoji = "⏳"
+	}
+
+	comment := fmt.Sprintf("%s **Phase: %s**\n\n%s", emoji, phase, details)
+	if _, err := n.client.AddIssueNote(ctx, issueIID, comment); err != nil {
+		return fmt.Errorf("failed to add progress comment: %w", err)
+	}
+
+	return nil
+}
+
+// NotifyTaskCompleted posts completion comment and updates labels
+func (n *Notifier) NotifyTaskCompleted(ctx context.Context, issueIID int, mrURL string, summary string) error {
+	// Remove in-progress label (best-effort, non-critical)
+	// Label may not exist if task started before labeling was added
+	_ = n.client.RemoveIssueLabel(ctx, issueIID, LabelInProgress)
+
+	// Remove pilot trigger label (best-effort, non-critical)
+	_ = n.client.RemoveIssueLabel(ctx, issueIID, n.pilotLabel)
+
+	// Add done label
+	if err := n.client.AddIssueLabels(ctx, issueIID, []string{LabelDone}); err != nil {
+		return fmt.Errorf("failed to add done label: %w", err)
+	}
+
+	// Post completion comment
+	var comment strings.Builder
+	comment.WriteString("✅ **Pilot completed this task!**\n\n")
+
+	if mrURL != "" {
+		comment.WriteString(fmt.Sprintf("**Merge Request**: %s\n\n", mrURL))
+	}
+
+	if summary != "" {
+		comment.WriteString("**Summary**:\n")
+		comment.WriteString(summary)
+		comment.WriteString("\n\n")
+	}
+
+	comment.WriteString("_This issue will be closed when the MR is merged._")
+
+	if _, err := n.client.AddIssueNote(ctx, issueIID, comment.String()); err != nil {
+		return fmt.Errorf("failed to add completion comment: %w", err)
+	}
+
+	return nil
+}
+
+// NotifyTaskFailed posts failure comment and updates labels
+func (n *Notifier) NotifyTaskFailed(ctx context.Context, issueIID int, reason string) error {
+	// Remove in-progress label (best-effort, non-critical)
+	_ = n.client.RemoveIssueLabel(ctx, issueIID, LabelInProgress)
+
+	// Add failed label
+	if err := n.client.AddIssueLabels(ctx, issueIID, []string{LabelFailed}); err != nil {
+		return fmt.Errorf("failed to add failed label: %w", err)
+	}
+
+	// Post failure comment
+	comment := fmt.Sprintf("❌ **Pilot could not complete this task**\n\n**Reason**: %s\n\n_Please review the issue and consider manual intervention or reopening with more details._", reason)
+	if _, err := n.client.AddIssueNote(ctx, issueIID, comment); err != nil {
+		return fmt.Errorf("failed to add failure comment: %w", err)
+	}
+
+	return nil
+}
+
+// LinkMR adds a comment linking the created MR
+func (n *Notifier) LinkMR(ctx context.Context, issueIID int, mrIID int, mrURL string) error {
+	comment := fmt.Sprintf("🔗 **Merge Request Created**: !%d\n\n%s\n\n_This MR implements the changes for this issue._", mrIID, mrURL)
+	if _, err := n.client.AddIssueNote(ctx, issueIID, comment); err != nil {
+		return fmt.Errorf("failed to add MR link comment: %w", err)
+	}
+
+	return nil
+}

--- a/internal/adapters/gitlab/notifier_test.go
+++ b/internal/adapters/gitlab/notifier_test.go
@@ -1,0 +1,269 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestNewNotifier(t *testing.T) {
+	client := NewClient(testutil.FakeGitLabToken, "namespace/project")
+	notifier := NewNotifier(client, "pilot")
+
+	if notifier == nil {
+		t.Fatal("NewNotifier returned nil")
+	}
+
+	if notifier.pilotLabel != "pilot" {
+		t.Errorf("notifier.pilotLabel = %s, want 'pilot'", notifier.pilotLabel)
+	}
+}
+
+func TestNotifyTaskStarted(t *testing.T) {
+	// Track requests
+	var labelsRequest map[string]interface{}
+	var noteRequest map[string]string
+	requestCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		switch {
+		case strings.Contains(r.URL.Path, "/issues/42") && r.Method == http.MethodGet:
+			// Get issue request for adding labels
+			issue := Issue{IID: 42, Labels: []string{"bug"}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(issue)
+
+		case strings.Contains(r.URL.Path, "/issues/42") && r.Method == http.MethodPut:
+			// Update labels request
+			_ = json.NewDecoder(r.Body).Decode(&labelsRequest)
+			w.WriteHeader(http.StatusOK)
+
+		case strings.Contains(r.URL.Path, "/notes") && r.Method == http.MethodPost:
+			// Add note request
+			_ = json.NewDecoder(r.Body).Decode(&noteRequest)
+			note := Note{ID: 123, Body: noteRequest["body"]}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(note)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", server.URL)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.NotifyTaskStarted(context.Background(), 42, "GL-42")
+	if err != nil {
+		t.Errorf("NotifyTaskStarted() error = %v", err)
+	}
+
+	// Verify labels were updated
+	if labelsRequest == nil {
+		t.Error("expected labels to be updated")
+	}
+
+	// Verify note was added with correct content
+	if noteRequest == nil {
+		t.Error("expected note to be added")
+	}
+	if !strings.Contains(noteRequest["body"], "Pilot started working") {
+		t.Errorf("note body should contain 'Pilot started working', got: %s", noteRequest["body"])
+	}
+	if !strings.Contains(noteRequest["body"], "GL-42") {
+		t.Errorf("note body should contain task ID 'GL-42', got: %s", noteRequest["body"])
+	}
+}
+
+func TestNotifyProgress(t *testing.T) {
+	tests := []struct {
+		name      string
+		phase     string
+		details   string
+		wantEmoji string
+	}{
+		{
+			name:      "exploring phase",
+			phase:     "exploring",
+			details:   "Analyzing codebase",
+			wantEmoji: "🔍",
+		},
+		{
+			name:      "implementing phase",
+			phase:     "implementing",
+			details:   "Writing code",
+			wantEmoji: "🔨",
+		},
+		{
+			name:      "testing phase",
+			phase:     "testing",
+			details:   "Running tests",
+			wantEmoji: "🧪",
+		},
+		{
+			name:      "committing phase",
+			phase:     "committing",
+			details:   "Creating commit",
+			wantEmoji: "📝",
+		},
+		{
+			name:      "unknown phase",
+			phase:     "unknown",
+			details:   "Doing something",
+			wantEmoji: "⏳",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var noteRequest map[string]string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.Contains(r.URL.Path, "/notes") && r.Method == http.MethodPost {
+					_ = json.NewDecoder(r.Body).Decode(&noteRequest)
+					note := Note{ID: 123}
+					w.WriteHeader(http.StatusCreated)
+					_ = json.NewEncoder(w).Encode(note)
+				}
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", server.URL)
+			notifier := NewNotifier(client, "pilot")
+
+			err := notifier.NotifyProgress(context.Background(), 42, tt.phase, tt.details)
+			if err != nil {
+				t.Errorf("NotifyProgress() error = %v", err)
+			}
+
+			if !strings.Contains(noteRequest["body"], tt.wantEmoji) {
+				t.Errorf("note body should contain emoji %s, got: %s", tt.wantEmoji, noteRequest["body"])
+			}
+			if !strings.Contains(noteRequest["body"], tt.phase) {
+				t.Errorf("note body should contain phase name, got: %s", noteRequest["body"])
+			}
+		})
+	}
+}
+
+func TestNotifyTaskCompleted(t *testing.T) {
+	var noteRequest map[string]string
+	var labelsUpdated bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/issues/42") && r.Method == http.MethodGet:
+			issue := Issue{IID: 42, Labels: []string{"pilot", "pilot-in-progress"}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(issue)
+
+		case strings.Contains(r.URL.Path, "/issues/42") && r.Method == http.MethodPut:
+			labelsUpdated = true
+			w.WriteHeader(http.StatusOK)
+
+		case strings.Contains(r.URL.Path, "/notes") && r.Method == http.MethodPost:
+			_ = json.NewDecoder(r.Body).Decode(&noteRequest)
+			note := Note{ID: 123}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(note)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", server.URL)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.NotifyTaskCompleted(context.Background(), 42, "https://gitlab.com/namespace/project/-/merge_requests/10", "Added new feature")
+	if err != nil {
+		t.Errorf("NotifyTaskCompleted() error = %v", err)
+	}
+
+	if !labelsUpdated {
+		t.Error("expected labels to be updated")
+	}
+
+	if !strings.Contains(noteRequest["body"], "Pilot completed") {
+		t.Errorf("note should contain completion message, got: %s", noteRequest["body"])
+	}
+	if !strings.Contains(noteRequest["body"], "merge_requests/10") {
+		t.Errorf("note should contain MR URL, got: %s", noteRequest["body"])
+	}
+}
+
+func TestNotifyTaskFailed(t *testing.T) {
+	var noteRequest map[string]string
+	var labelsUpdated bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/issues/42") && r.Method == http.MethodGet:
+			issue := Issue{IID: 42, Labels: []string{"pilot", "pilot-in-progress"}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(issue)
+
+		case strings.Contains(r.URL.Path, "/issues/42") && r.Method == http.MethodPut:
+			labelsUpdated = true
+			w.WriteHeader(http.StatusOK)
+
+		case strings.Contains(r.URL.Path, "/notes") && r.Method == http.MethodPost:
+			_ = json.NewDecoder(r.Body).Decode(&noteRequest)
+			note := Note{ID: 123}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(note)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", server.URL)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.NotifyTaskFailed(context.Background(), 42, "Build failed with errors")
+	if err != nil {
+		t.Errorf("NotifyTaskFailed() error = %v", err)
+	}
+
+	if !labelsUpdated {
+		t.Error("expected labels to be updated")
+	}
+
+	if !strings.Contains(noteRequest["body"], "could not complete") {
+		t.Errorf("note should contain failure message, got: %s", noteRequest["body"])
+	}
+	if !strings.Contains(noteRequest["body"], "Build failed with errors") {
+		t.Errorf("note should contain failure reason, got: %s", noteRequest["body"])
+	}
+}
+
+func TestLinkMR(t *testing.T) {
+	var noteRequest map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/notes") && r.Method == http.MethodPost {
+			_ = json.NewDecoder(r.Body).Decode(&noteRequest)
+			note := Note{ID: 123}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(note)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitLabToken, "namespace/project", server.URL)
+	notifier := NewNotifier(client, "pilot")
+
+	err := notifier.LinkMR(context.Background(), 42, 10, "https://gitlab.com/namespace/project/-/merge_requests/10")
+	if err != nil {
+		t.Errorf("LinkMR() error = %v", err)
+	}
+
+	if !strings.Contains(noteRequest["body"], "!10") {
+		t.Errorf("note should contain MR reference !10, got: %s", noteRequest["body"])
+	}
+	if !strings.Contains(noteRequest["body"], "merge_requests/10") {
+		t.Errorf("note should contain MR URL, got: %s", noteRequest["body"])
+	}
+}

--- a/internal/adapters/gitlab/poller.go
+++ b/internal/adapters/gitlab/poller.go
@@ -1,0 +1,474 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// ExecutionMode determines how issues are processed
+type ExecutionMode string
+
+const (
+	// ExecutionModeSequential processes one issue at a time, waiting for MR merge
+	ExecutionModeSequential ExecutionMode = "sequential"
+	// ExecutionModeParallel processes issues concurrently (legacy behavior)
+	ExecutionModeParallel ExecutionMode = "parallel"
+)
+
+// IssueResult is returned by the issue handler with MR information
+type IssueResult struct {
+	Success  bool
+	MRNumber int    // MR IID if created
+	MRURL    string // MR URL if created
+	HeadSHA  string // Head commit SHA of the MR
+	Error    error
+}
+
+// Poller polls GitLab for issues with a specific label
+type Poller struct {
+	client    *Client
+	label     string
+	interval  time.Duration
+	processed map[int]bool
+	mu        sync.RWMutex
+	onIssue   func(ctx context.Context, issue *Issue) error
+	// onIssueWithResult is called for sequential mode, returns MR info
+	onIssueWithResult func(ctx context.Context, issue *Issue) (*IssueResult, error)
+	// OnMRCreated is called when an MR is created after issue processing
+	// Parameters: mrIID, mrURL, issueIID, headSHA
+	OnMRCreated func(mrIID int, mrURL string, issueIID int, headSHA string)
+	logger      *slog.Logger
+
+	// Sequential mode configuration
+	executionMode  ExecutionMode
+	mergeWaiter    *MergeWaiter
+	waitForMerge   bool
+	mrTimeout      time.Duration
+	mrPollInterval time.Duration
+}
+
+// PollerOption configures a Poller
+type PollerOption func(*Poller)
+
+// WithPollerLogger sets the logger for the poller
+func WithPollerLogger(logger *slog.Logger) PollerOption {
+	return func(p *Poller) {
+		p.logger = logger
+	}
+}
+
+// WithOnIssue sets the callback for new issues (parallel mode)
+func WithOnIssue(fn func(ctx context.Context, issue *Issue) error) PollerOption {
+	return func(p *Poller) {
+		p.onIssue = fn
+	}
+}
+
+// WithOnIssueWithResult sets the callback for new issues that returns MR info (sequential mode)
+func WithOnIssueWithResult(fn func(ctx context.Context, issue *Issue) (*IssueResult, error)) PollerOption {
+	return func(p *Poller) {
+		p.onIssueWithResult = fn
+	}
+}
+
+// WithExecutionMode sets the execution mode (sequential or parallel)
+func WithExecutionMode(mode ExecutionMode) PollerOption {
+	return func(p *Poller) {
+		p.executionMode = mode
+	}
+}
+
+// WithSequentialConfig configures sequential execution settings
+func WithSequentialConfig(waitForMerge bool, pollInterval, timeout time.Duration) PollerOption {
+	return func(p *Poller) {
+		p.waitForMerge = waitForMerge
+		p.mrPollInterval = pollInterval
+		p.mrTimeout = timeout
+	}
+}
+
+// WithOnMRCreated sets the callback for MR creation events
+func WithOnMRCreated(fn func(mrIID int, mrURL string, issueIID int, headSHA string)) PollerOption {
+	return func(p *Poller) {
+		p.OnMRCreated = fn
+	}
+}
+
+// NewPoller creates a new GitLab issue poller
+func NewPoller(client *Client, label string, interval time.Duration, opts ...PollerOption) *Poller {
+	p := &Poller{
+		client:         client,
+		label:          label,
+		interval:       interval,
+		processed:      make(map[int]bool),
+		logger:         logging.WithComponent("gitlab-poller"),
+		executionMode:  ExecutionModeParallel, // Default for backward compatibility
+		waitForMerge:   true,
+		mrPollInterval: 30 * time.Second,
+		mrTimeout:      1 * time.Hour,
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	// Create merge waiter if in sequential mode
+	if p.executionMode == ExecutionModeSequential && p.waitForMerge {
+		p.mergeWaiter = NewMergeWaiter(client, &MergeWaiterConfig{
+			PollInterval: p.mrPollInterval,
+			Timeout:      p.mrTimeout,
+		})
+	}
+
+	return p
+}
+
+// Start begins polling for issues
+func (p *Poller) Start(ctx context.Context) {
+	p.logger.Info("Starting GitLab poller",
+		slog.String("label", p.label),
+		slog.Duration("interval", p.interval),
+		slog.String("mode", string(p.executionMode)),
+	)
+
+	if p.executionMode == ExecutionModeSequential {
+		p.startSequential(ctx)
+	} else {
+		p.startParallel(ctx)
+	}
+}
+
+// startParallel runs the legacy parallel execution mode
+func (p *Poller) startParallel(ctx context.Context) {
+	// Do an initial check immediately
+	p.checkForNewIssues(ctx)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("GitLab poller stopped")
+			return
+		case <-ticker.C:
+			p.checkForNewIssues(ctx)
+		}
+	}
+}
+
+// startSequential runs the sequential execution mode
+// Processes one issue at a time, waits for MR merge before next
+func (p *Poller) startSequential(ctx context.Context) {
+	p.logger.Info("Running in sequential mode",
+		slog.Bool("wait_for_merge", p.waitForMerge),
+		slog.Duration("mr_timeout", p.mrTimeout),
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("Sequential poller stopped")
+			return
+		default:
+		}
+
+		// Find oldest unprocessed issue
+		issue, err := p.findOldestUnprocessedIssue(ctx)
+		if err != nil {
+			p.logger.Warn("Failed to find issues", slog.Any("error", err))
+			time.Sleep(p.interval)
+			continue
+		}
+
+		if issue == nil {
+			// No issues to process, wait before checking again
+			p.logger.Debug("No unprocessed issues found, waiting...")
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(p.interval):
+				continue
+			}
+		}
+
+		// Process the issue
+		p.logger.Info("Processing issue in sequential mode",
+			slog.Int("iid", issue.IID),
+			slog.String("title", issue.Title),
+		)
+
+		result, err := p.processIssueSequential(ctx, issue)
+		if err != nil {
+			p.logger.Error("Failed to process issue",
+				slog.Int("iid", issue.IID),
+				slog.Any("error", err),
+			)
+			// Mark as processed to avoid infinite retry loop
+			// The issue will have pilot-failed label
+			p.markProcessed(issue.IID)
+			continue
+		}
+
+		// Notify autopilot controller of new MR (if callback registered)
+		if result != nil && result.MRNumber > 0 && p.OnMRCreated != nil {
+			p.logger.Info("Notifying autopilot of MR creation",
+				slog.Int("mr_iid", result.MRNumber),
+				slog.Int("issue_iid", issue.IID),
+			)
+			p.OnMRCreated(result.MRNumber, result.MRURL, issue.IID, result.HeadSHA)
+		}
+
+		// If we created an MR and should wait for merge
+		if result != nil && result.MRNumber > 0 && p.waitForMerge && p.mergeWaiter != nil {
+			p.logger.Info("Waiting for MR merge before next issue",
+				slog.Int("mr_iid", result.MRNumber),
+				slog.String("mr_url", result.MRURL),
+			)
+
+			mergeResult, err := p.mergeWaiter.WaitWithCallback(ctx, result.MRNumber, func(r *MergeWaitResult) {
+				p.logger.Debug("MR status check",
+					slog.Int("mr_iid", r.MRNumber),
+					slog.String("status", r.Message),
+				)
+			})
+
+			if err != nil {
+				p.logger.Warn("Error waiting for MR merge, pausing sequential processing",
+					slog.Int("mr_iid", result.MRNumber),
+					slog.Any("error", err),
+				)
+				// DON'T mark as processed - leave for retry after fix
+				time.Sleep(5 * time.Minute)
+				continue
+			}
+
+			p.logger.Info("MR merge wait completed",
+				slog.Int("mr_iid", result.MRNumber),
+				slog.Bool("merged", mergeResult.Merged),
+				slog.Bool("closed", mergeResult.Closed),
+				slog.Bool("has_conflicts", mergeResult.HasConflicts),
+				slog.Bool("timed_out", mergeResult.TimedOut),
+			)
+
+			// Check if MR has conflicts - stop processing
+			if mergeResult.HasConflicts {
+				p.logger.Warn("MR has conflicts, pausing sequential processing",
+					slog.Int("mr_iid", result.MRNumber),
+					slog.String("mr_url", result.MRURL),
+				)
+				// DON'T mark as processed - needs manual resolution or rebase
+				time.Sleep(5 * time.Minute)
+				continue
+			}
+
+			// Check if MR timed out
+			if mergeResult.TimedOut {
+				p.logger.Warn("MR merge timed out, pausing sequential processing",
+					slog.Int("mr_iid", result.MRNumber),
+					slog.String("mr_url", result.MRURL),
+				)
+				// DON'T mark as processed - needs investigation
+				time.Sleep(5 * time.Minute)
+				continue
+			}
+
+			// Only mark as processed if actually merged
+			if mergeResult.Merged {
+				p.markProcessed(issue.IID)
+				continue
+			}
+
+			// MR was closed without merge
+			if mergeResult.Closed {
+				p.logger.Info("MR was closed without merge",
+					slog.Int("mr_iid", result.MRNumber),
+				)
+				// DON'T mark as processed - issue may need re-execution
+				continue
+			}
+		}
+
+		// Direct commit case: no MR to wait for, proceed to next issue
+		if result != nil && result.Success && result.MRNumber == 0 {
+			p.logger.Info("Direct commit completed, proceeding to next issue",
+				slog.Int("issue_iid", issue.IID),
+				slog.String("commit_sha", result.HeadSHA),
+			)
+			p.markProcessed(issue.IID)
+			continue
+		}
+
+		// MR was created but we're not waiting for merge, or no MR was created
+		p.markProcessed(issue.IID)
+	}
+}
+
+// findOldestUnprocessedIssue finds the oldest issue with the pilot label
+// that hasn't been processed yet
+func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error) {
+	issues, err := p.client.ListIssues(ctx, &ListIssuesOptions{
+		Labels:  []string{p.label},
+		State:   StateOpened,
+		Sort:    "asc", // Oldest first
+		OrderBy: "created_at",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out already processed and in-progress issues
+	var candidates []*Issue
+	for _, issue := range issues {
+		p.mu.RLock()
+		processed := p.processed[issue.IID]
+		p.mu.RUnlock()
+
+		if processed {
+			continue
+		}
+
+		if HasLabel(issue, LabelInProgress) || HasLabel(issue, LabelDone) {
+			continue
+		}
+
+		candidates = append(candidates, issue)
+	}
+
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	// Sort by creation date (oldest first)
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].CreatedAt.Before(candidates[j].CreatedAt)
+	})
+
+	return candidates[0], nil
+}
+
+// processIssueSequential processes a single issue and returns MR info
+func (p *Poller) processIssueSequential(ctx context.Context, issue *Issue) (*IssueResult, error) {
+	// Use the new callback if available
+	if p.onIssueWithResult != nil {
+		return p.onIssueWithResult(ctx, issue)
+	}
+
+	// Fall back to legacy callback
+	if p.onIssue != nil {
+		err := p.onIssue(ctx, issue)
+		if err != nil {
+			return &IssueResult{Success: false, Error: err}, err
+		}
+		return &IssueResult{Success: true}, nil
+	}
+
+	return nil, fmt.Errorf("no issue handler configured")
+}
+
+// checkForNewIssues fetches issues and processes new ones (parallel mode)
+func (p *Poller) checkForNewIssues(ctx context.Context) {
+	issues, err := p.client.ListIssues(ctx, &ListIssuesOptions{
+		Labels:  []string{p.label},
+		State:   StateOpened,
+		Sort:    "desc",
+		OrderBy: "updated_at",
+	})
+	if err != nil {
+		p.logger.Warn("Failed to fetch issues", slog.Any("error", err))
+		return
+	}
+
+	for _, issue := range issues {
+		// Skip if already processed
+		p.mu.RLock()
+		processed := p.processed[issue.IID]
+		p.mu.RUnlock()
+
+		if processed {
+			continue
+		}
+
+		// Skip if already in progress or done
+		if HasLabel(issue, LabelInProgress) || HasLabel(issue, LabelDone) {
+			p.markProcessed(issue.IID)
+			continue
+		}
+
+		// Process the issue
+		p.logger.Info("Found new issue",
+			slog.Int("iid", issue.IID),
+			slog.String("title", issue.Title),
+		)
+
+		if p.onIssue != nil {
+			if err := p.onIssue(ctx, issue); err != nil {
+				p.logger.Error("Failed to process issue",
+					slog.Int("iid", issue.IID),
+					slog.Any("error", err),
+				)
+				// Don't mark as processed so we can retry
+				continue
+			}
+		}
+
+		p.markProcessed(issue.IID)
+	}
+}
+
+// markProcessed marks an issue as processed
+func (p *Poller) markProcessed(iid int) {
+	p.mu.Lock()
+	p.processed[iid] = true
+	p.mu.Unlock()
+}
+
+// IsProcessed checks if an issue has been processed
+func (p *Poller) IsProcessed(iid int) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.processed[iid]
+}
+
+// ProcessedCount returns the number of processed issues
+func (p *Poller) ProcessedCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.processed)
+}
+
+// Reset clears the processed issues map
+func (p *Poller) Reset() {
+	p.mu.Lock()
+	p.processed = make(map[int]bool)
+	p.mu.Unlock()
+}
+
+// ExtractMRNumber extracts MR IID from a GitLab MR URL
+// e.g., "https://gitlab.com/namespace/project/-/merge_requests/123" -> 123
+func ExtractMRNumber(mrURL string) (int, error) {
+	if mrURL == "" {
+		return 0, fmt.Errorf("empty MR URL")
+	}
+
+	// Match pattern: /-/merge_requests/123 or /merge_requests/123
+	re := regexp.MustCompile(`/(?:-/)?merge_requests/(\d+)`)
+	matches := re.FindStringSubmatch(mrURL)
+	if len(matches) < 2 {
+		return 0, fmt.Errorf("could not extract MR number from URL: %s", mrURL)
+	}
+
+	var num int
+	if _, err := fmt.Sscanf(matches[1], "%d", &num); err != nil {
+		return 0, fmt.Errorf("invalid MR number in URL: %s", mrURL)
+	}
+
+	return num, nil
+}

--- a/internal/adapters/gitlab/poller_test.go
+++ b/internal/adapters/gitlab/poller_test.go
@@ -1,0 +1,197 @@
+package gitlab
+
+import (
+	"testing"
+	"time"
+)
+
+func TestExtractMRNumber(t *testing.T) {
+	tests := []struct {
+		name    string
+		mrURL   string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "standard GitLab MR URL",
+			mrURL:   "https://gitlab.com/namespace/project/-/merge_requests/123",
+			want:    123,
+			wantErr: false,
+		},
+		{
+			name:    "GitLab MR URL without dash",
+			mrURL:   "https://gitlab.com/namespace/project/merge_requests/456",
+			want:    456,
+			wantErr: false,
+		},
+		{
+			name:    "self-hosted GitLab",
+			mrURL:   "https://gitlab.example.com/org/repo/-/merge_requests/789",
+			want:    789,
+			wantErr: false,
+		},
+		{
+			name:    "nested group",
+			mrURL:   "https://gitlab.com/org/subgroup/project/-/merge_requests/42",
+			want:    42,
+			wantErr: false,
+		},
+		{
+			name:    "empty URL",
+			mrURL:   "",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL - no MR number",
+			mrURL:   "https://gitlab.com/namespace/project/-/issues/123",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL - random string",
+			mrURL:   "not-a-url",
+			want:    0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractMRNumber(tt.mrURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExtractMRNumber() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ExtractMRNumber() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewPoller(t *testing.T) {
+	client := NewClient("test-token", "namespace/project")
+	label := "pilot"
+	interval := 30 * time.Second
+
+	poller := NewPoller(client, label, interval)
+
+	if poller == nil {
+		t.Fatal("NewPoller returned nil")
+	}
+
+	if poller.label != label {
+		t.Errorf("poller.label = %s, want %s", poller.label, label)
+	}
+
+	if poller.interval != interval {
+		t.Errorf("poller.interval = %v, want %v", poller.interval, interval)
+	}
+
+	if poller.executionMode != ExecutionModeParallel {
+		t.Errorf("poller.executionMode = %v, want %v", poller.executionMode, ExecutionModeParallel)
+	}
+}
+
+func TestNewPollerWithOptions(t *testing.T) {
+	client := NewClient("test-token", "namespace/project")
+	label := "pilot"
+	interval := 30 * time.Second
+
+	poller := NewPoller(client, label, interval,
+		WithExecutionMode(ExecutionModeSequential),
+		WithSequentialConfig(true, 30*time.Second, 1*time.Hour),
+	)
+
+	if poller.executionMode != ExecutionModeSequential {
+		t.Errorf("poller.executionMode = %v, want %v", poller.executionMode, ExecutionModeSequential)
+	}
+
+	if !poller.waitForMerge {
+		t.Error("poller.waitForMerge = false, want true")
+	}
+
+	if poller.mrPollInterval != 30*time.Second {
+		t.Errorf("poller.mrPollInterval = %v, want 30s", poller.mrPollInterval)
+	}
+
+	if poller.mrTimeout != 1*time.Hour {
+		t.Errorf("poller.mrTimeout = %v, want 1h", poller.mrTimeout)
+	}
+
+	if poller.mergeWaiter == nil {
+		t.Error("poller.mergeWaiter is nil, expected non-nil for sequential mode")
+	}
+}
+
+func TestPoller_IsProcessed(t *testing.T) {
+	client := NewClient("test-token", "namespace/project")
+	poller := NewPoller(client, "pilot", 30*time.Second)
+
+	// Initially not processed
+	if poller.IsProcessed(42) {
+		t.Error("expected issue 42 to not be processed initially")
+	}
+
+	// Mark as processed
+	poller.markProcessed(42)
+
+	// Now should be processed
+	if !poller.IsProcessed(42) {
+		t.Error("expected issue 42 to be processed after marking")
+	}
+
+	// Other issues still not processed
+	if poller.IsProcessed(43) {
+		t.Error("expected issue 43 to not be processed")
+	}
+}
+
+func TestPoller_ProcessedCount(t *testing.T) {
+	client := NewClient("test-token", "namespace/project")
+	poller := NewPoller(client, "pilot", 30*time.Second)
+
+	if poller.ProcessedCount() != 0 {
+		t.Errorf("ProcessedCount() = %d, want 0", poller.ProcessedCount())
+	}
+
+	poller.markProcessed(1)
+	poller.markProcessed(2)
+	poller.markProcessed(3)
+
+	if poller.ProcessedCount() != 3 {
+		t.Errorf("ProcessedCount() = %d, want 3", poller.ProcessedCount())
+	}
+}
+
+func TestPoller_Reset(t *testing.T) {
+	client := NewClient("test-token", "namespace/project")
+	poller := NewPoller(client, "pilot", 30*time.Second)
+
+	poller.markProcessed(1)
+	poller.markProcessed(2)
+
+	if poller.ProcessedCount() != 2 {
+		t.Errorf("ProcessedCount() before reset = %d, want 2", poller.ProcessedCount())
+	}
+
+	poller.Reset()
+
+	if poller.ProcessedCount() != 0 {
+		t.Errorf("ProcessedCount() after reset = %d, want 0", poller.ProcessedCount())
+	}
+
+	if poller.IsProcessed(1) {
+		t.Error("expected issue 1 to not be processed after reset")
+	}
+}
+
+func TestExecutionModeConstants(t *testing.T) {
+	if ExecutionModeSequential != "sequential" {
+		t.Errorf("ExecutionModeSequential = %s, want 'sequential'", ExecutionModeSequential)
+	}
+	if ExecutionModeParallel != "parallel" {
+		t.Errorf("ExecutionModeParallel = %s, want 'parallel'", ExecutionModeParallel)
+	}
+}

--- a/internal/adapters/gitlab/types.go
+++ b/internal/adapters/gitlab/types.go
@@ -244,14 +244,14 @@ const (
 
 // IssueWebhookPayload represents a GitLab issue webhook event
 type IssueWebhookPayload struct {
-	ObjectKind       string             `json:"object_kind"` // "issue"
-	EventType        string             `json:"event_type"`  // "issue"
-	User             *User              `json:"user"`
-	Project          *WebhookProject    `json:"project"`
-	ObjectAttributes *IssueAttributes   `json:"object_attributes"`
-	Labels           []*WebhookLabel    `json:"labels"`
-	Changes          *IssueChanges      `json:"changes,omitempty"`
-	Assignees        []*User            `json:"assignees,omitempty"`
+	ObjectKind       string           `json:"object_kind"` // "issue"
+	EventType        string           `json:"event_type"`  // "issue"
+	User             *User            `json:"user"`
+	Project          *WebhookProject  `json:"project"`
+	ObjectAttributes *IssueAttributes `json:"object_attributes"`
+	Labels           []*WebhookLabel  `json:"labels"`
+	Changes          *IssueChanges    `json:"changes,omitempty"`
+	Assignees        []*User          `json:"assignees,omitempty"`
 }
 
 // WebhookProject contains project info in webhook payloads

--- a/internal/adapters/gitlab/webhook.go
+++ b/internal/adapters/gitlab/webhook.go
@@ -1,0 +1,165 @@
+package gitlab
+
+import (
+	"context"
+	"crypto/subtle"
+	"fmt"
+	"log/slog"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// WebhookHandler handles GitLab webhooks
+type WebhookHandler struct {
+	client        *Client
+	webhookSecret string
+	pilotLabel    string
+	onIssue       func(context.Context, *Issue, *Project) error
+}
+
+// NewWebhookHandler creates a new webhook handler
+func NewWebhookHandler(client *Client, webhookSecret, pilotLabel string) *WebhookHandler {
+	return &WebhookHandler{
+		client:        client,
+		webhookSecret: webhookSecret,
+		pilotLabel:    pilotLabel,
+	}
+}
+
+// OnIssue sets the callback for when a pilot-labeled issue is received
+func (h *WebhookHandler) OnIssue(callback func(context.Context, *Issue, *Project) error) {
+	h.onIssue = callback
+}
+
+// VerifyToken verifies the GitLab webhook token
+// GitLab uses simple token comparison via X-Gitlab-Token header (not HMAC)
+func (h *WebhookHandler) VerifyToken(token string) bool {
+	if h.webhookSecret == "" {
+		// No secret configured, skip verification (development mode)
+		return true
+	}
+
+	// Use constant-time comparison to prevent timing attacks
+	return subtle.ConstantTimeCompare([]byte(token), []byte(h.webhookSecret)) == 1
+}
+
+// Handle processes a webhook payload
+func (h *WebhookHandler) Handle(ctx context.Context, eventType string, payload *IssueWebhookPayload) error {
+	if payload.ObjectAttributes == nil {
+		return nil
+	}
+
+	action := payload.ObjectAttributes.Action
+	logging.WithComponent("gitlab").Debug("GitLab webhook",
+		slog.String("event", eventType),
+		slog.String("action", action))
+
+	// Only process issue events
+	if eventType != WebhookEventIssue {
+		return nil
+	}
+
+	// Process open/update events
+	switch action {
+	case "open":
+		return h.handleIssueOpened(ctx, payload)
+	case "update":
+		return h.handleIssueUpdated(ctx, payload)
+	default:
+		return nil
+	}
+}
+
+// handleIssueOpened processes newly created issues
+func (h *WebhookHandler) handleIssueOpened(ctx context.Context, payload *IssueWebhookPayload) error {
+	// Check if issue has pilot label
+	if !h.hasPilotLabel(payload.Labels) {
+		logging.WithComponent("gitlab").Debug("Issue does not have pilot label, skipping",
+			slog.Int("iid", payload.ObjectAttributes.IID))
+		return nil
+	}
+
+	return h.processIssue(ctx, payload)
+}
+
+// handleIssueUpdated processes issue updates (label changes)
+func (h *WebhookHandler) handleIssueUpdated(ctx context.Context, payload *IssueWebhookPayload) error {
+	// Check if pilot label was added
+	if payload.Changes == nil || payload.Changes.Labels == nil {
+		return nil
+	}
+
+	labelAdded := h.wasLabelAdded(payload.Changes.Labels)
+	if !labelAdded {
+		logging.WithComponent("gitlab").Debug("Pilot label was not added, skipping",
+			slog.Int("iid", payload.ObjectAttributes.IID))
+		return nil
+	}
+
+	return h.processIssue(ctx, payload)
+}
+
+// processIssue processes an issue that should be handled by Pilot
+func (h *WebhookHandler) processIssue(ctx context.Context, payload *IssueWebhookPayload) error {
+	logging.WithComponent("gitlab").Info("Processing pilot issue",
+		slog.String("project", payload.Project.PathWithNamespace),
+		slog.Int("iid", payload.ObjectAttributes.IID),
+		slog.String("title", payload.ObjectAttributes.Title))
+
+	// Fetch full issue details via API (webhook payload may be incomplete)
+	fullIssue, err := h.client.GetIssue(ctx, payload.ObjectAttributes.IID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch issue details: %w", err)
+	}
+
+	// Fetch project info
+	project := &Project{
+		ID:                payload.Project.ID,
+		Name:              payload.Project.Name,
+		PathWithNamespace: payload.Project.PathWithNamespace,
+		WebURL:            payload.Project.WebURL,
+		DefaultBranch:     payload.Project.DefaultBranch,
+	}
+
+	// Call the callback
+	if h.onIssue != nil {
+		return h.onIssue(ctx, fullIssue, project)
+	}
+
+	return nil
+}
+
+// hasPilotLabel checks if the labels include the pilot label
+func (h *WebhookHandler) hasPilotLabel(labels []*WebhookLabel) bool {
+	for _, label := range labels {
+		if label.Title == h.pilotLabel {
+			return true
+		}
+	}
+	return false
+}
+
+// wasLabelAdded checks if the pilot label was added in this update
+func (h *WebhookHandler) wasLabelAdded(labelChange *LabelChange) bool {
+	// Check if pilot label is in current but not in previous
+	hasCurrent := false
+	for _, label := range labelChange.Current {
+		if label.Title == h.pilotLabel {
+			hasCurrent = true
+			break
+		}
+	}
+
+	if !hasCurrent {
+		return false
+	}
+
+	// Check if it was in previous (if it was, it's not a new addition)
+	for _, label := range labelChange.Previous {
+		if label.Title == h.pilotLabel {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/adapters/gitlab/webhook_test.go
+++ b/internal/adapters/gitlab/webhook_test.go
@@ -1,0 +1,236 @@
+package gitlab
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestVerifyToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		secret    string
+		token     string
+		wantValid bool
+	}{
+		{
+			name:      "valid token",
+			secret:    testutil.FakeGitLabWebhookSecret,
+			token:     testutil.FakeGitLabWebhookSecret,
+			wantValid: true,
+		},
+		{
+			name:      "invalid token",
+			secret:    testutil.FakeGitLabWebhookSecret,
+			token:     "wrong-token",
+			wantValid: false,
+		},
+		{
+			name:      "empty token",
+			secret:    testutil.FakeGitLabWebhookSecret,
+			token:     "",
+			wantValid: false,
+		},
+		{
+			name:      "no secret configured - development mode",
+			secret:    "",
+			token:     "any-token",
+			wantValid: true,
+		},
+		{
+			name:      "no secret configured - empty token",
+			secret:    "",
+			token:     "",
+			wantValid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient(testutil.FakeGitLabToken, "namespace/project")
+			handler := NewWebhookHandler(client, tt.secret, "pilot")
+
+			got := handler.VerifyToken(tt.token)
+			if got != tt.wantValid {
+				t.Errorf("VerifyToken() = %v, want %v", got, tt.wantValid)
+			}
+		})
+	}
+}
+
+func TestNewWebhookHandler(t *testing.T) {
+	client := NewClient(testutil.FakeGitLabToken, "namespace/project")
+	handler := NewWebhookHandler(client, testutil.FakeGitLabWebhookSecret, "pilot")
+
+	if handler == nil {
+		t.Fatal("NewWebhookHandler returned nil")
+	}
+	if handler.webhookSecret != testutil.FakeGitLabWebhookSecret {
+		t.Errorf("handler.webhookSecret = %s, want %s", handler.webhookSecret, testutil.FakeGitLabWebhookSecret)
+	}
+	if handler.pilotLabel != "pilot" {
+		t.Errorf("handler.pilotLabel = %s, want pilot", handler.pilotLabel)
+	}
+}
+
+func TestWebhookHandler_OnIssue(t *testing.T) {
+	client := NewClient(testutil.FakeGitLabToken, "namespace/project")
+	handler := NewWebhookHandler(client, testutil.FakeGitLabWebhookSecret, "pilot")
+
+	handler.OnIssue(func(ctx context.Context, issue *Issue, project *Project) error {
+		return nil
+	})
+
+	// Verify callback was registered (handler.onIssue should be non-nil)
+	if handler.onIssue == nil {
+		t.Error("OnIssue callback was not registered")
+	}
+}
+
+func TestWebhookHandler_HasPilotLabel(t *testing.T) {
+	client := NewClient(testutil.FakeGitLabToken, "namespace/project")
+	handler := NewWebhookHandler(client, testutil.FakeGitLabWebhookSecret, "pilot")
+
+	tests := []struct {
+		name   string
+		labels []*WebhookLabel
+		want   bool
+	}{
+		{
+			name: "has pilot label",
+			labels: []*WebhookLabel{
+				{ID: 1, Title: "bug"},
+				{ID: 2, Title: "pilot"},
+			},
+			want: true,
+		},
+		{
+			name: "does not have pilot label",
+			labels: []*WebhookLabel{
+				{ID: 1, Title: "bug"},
+				{ID: 2, Title: "enhancement"},
+			},
+			want: false,
+		},
+		{
+			name:   "empty labels",
+			labels: []*WebhookLabel{},
+			want:   false,
+		},
+		{
+			name:   "nil labels",
+			labels: nil,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := handler.hasPilotLabel(tt.labels)
+			if got != tt.want {
+				t.Errorf("hasPilotLabel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWebhookHandler_WasLabelAdded(t *testing.T) {
+	client := NewClient(testutil.FakeGitLabToken, "namespace/project")
+	handler := NewWebhookHandler(client, testutil.FakeGitLabWebhookSecret, "pilot")
+
+	tests := []struct {
+		name        string
+		labelChange *LabelChange
+		want        bool
+	}{
+		{
+			name: "pilot label was added",
+			labelChange: &LabelChange{
+				Previous: []*WebhookLabel{
+					{ID: 1, Title: "bug"},
+				},
+				Current: []*WebhookLabel{
+					{ID: 1, Title: "bug"},
+					{ID: 2, Title: "pilot"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pilot label was already present",
+			labelChange: &LabelChange{
+				Previous: []*WebhookLabel{
+					{ID: 1, Title: "pilot"},
+				},
+				Current: []*WebhookLabel{
+					{ID: 1, Title: "pilot"},
+					{ID: 2, Title: "bug"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pilot label was removed",
+			labelChange: &LabelChange{
+				Previous: []*WebhookLabel{
+					{ID: 1, Title: "pilot"},
+				},
+				Current: []*WebhookLabel{
+					{ID: 2, Title: "bug"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pilot label not present in either",
+			labelChange: &LabelChange{
+				Previous: []*WebhookLabel{
+					{ID: 1, Title: "bug"},
+				},
+				Current: []*WebhookLabel{
+					{ID: 1, Title: "bug"},
+					{ID: 2, Title: "enhancement"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty previous labels",
+			labelChange: &LabelChange{
+				Previous: []*WebhookLabel{},
+				Current: []*WebhookLabel{
+					{ID: 1, Title: "pilot"},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := handler.wasLabelAdded(tt.labelChange)
+			if got != tt.want {
+				t.Errorf("wasLabelAdded() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWebhookEventConstants(t *testing.T) {
+	tests := []struct {
+		constant string
+		expected string
+	}{
+		{WebhookEventIssue, "Issue Hook"},
+		{WebhookEventMergeRequest, "Merge Request Hook"},
+		{WebhookEventPipeline, "Pipeline Hook"},
+		{WebhookEventNote, "Note Hook"},
+	}
+
+	for _, tt := range tests {
+		if tt.constant != tt.expected {
+			t.Errorf("constant = %s, want %s", tt.constant, tt.expected)
+		}
+	}
+}

--- a/internal/autopilot/auto_merger_test.go
+++ b/internal/autopilot/auto_merger_test.go
@@ -643,10 +643,10 @@ func TestAutoMerger_WithApprovalTimeout(t *testing.T) {
 
 func TestAutoMerger_VerifyCIBeforeMerge(t *testing.T) {
 	tests := []struct {
-		name         string
-		ciStatus     CIStatus
-		wantErr      bool
-		errContains  string
+		name        string
+		ciStatus    CIStatus
+		wantErr     bool
+		errContains string
 	}{
 		{
 			name:     "CI success - verification passes",


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-274.

## Changes

GitHub Issue #274: Implement GitLab adapter

## Summary

Implement full GitLab adapter following GitHub adapter patterns. Config and types.go skeleton already created.

## Pre-existing (already committed)
- `internal/adapters/gitlab/types.go` - Config and type definitions
- `internal/config/config.go` - GitLab added to AdaptersConfig
- `internal/testutil/tokens.go` - FakeGitLabToken added
- `configs/pilot.example.yaml` - gitlab config section added

## Implementation Required

### Adapter Files (internal/adapters/gitlab/)
1. **client.go** - REST API client for /api/v4
   - Auth via PRIVATE-TOKEN header
   - Project path URL encoding (namespace%2Fproject)
   - Methods: GetIssue, ListIssues, AddIssueNote, AddIssueLabels, RemoveIssueLabel, GetProject, CreateMergeRequest, GetMergeRequest, MergeMergeRequest

2. **webhook.go** - Webhook handler
   - X-Gitlab-Token auth (simple string match, not HMAC)
   - Handle Issue Hook events (open, update)
   - Detect pilot label on create or when added

3. **poller.go** - Issue polling
   - Poll for issues with pilot label
   - Skip pilot-in-progress and pilot-done
   - Sequential mode (wait for MR merge)

4. **notifier.go** - Status notifications
   - NotifyTaskStarted, NotifyProgress, NotifyTaskCompleted, NotifyTaskFailed
   - Label management (pilot-in-progress, pilot-done, pilot-failed)

5. **merger.go** - MR merge waiting
   - Poll MR status until merged/closed/conflict
   - Pipeline status checking

6. **cleanup.go** - Stale label cleanup
7. **converter.go** - Issue → TaskInfo conversion

### Integration (modify existing)
1. **internal/gateway/server.go** - Add /webhooks/gitlab endpoint
2. **internal/pilot/pilot.go** - Initialize and register GitLab adapter

### Reference
- Follow `internal/adapters/github/*` patterns exactly
- Use `testutil.FakeGitLabToken` in tests

## Key GitLab API Differences

| Aspect | GitHub | GitLab |
|--------|--------|--------|
| API Base | `/repos/owner/repo` | `/api/v4/projects/namespace%2Fproject` |
| Auth | `Authorization: Bearer` | `PRIVATE-TOKEN` header |
| Issue ID | `number` | `iid` (project-scoped) |
| PRs | Pull Request | Merge Request |
| Webhook Auth | HMAC SHA-256 | Simple token comparison |
| Webhook Header | `X-Hub-Signature-256` | `X-Gitlab-Token` |
| Event Header | `X-GitHub-Event` | `X-Gitlab-Event` |

## Acceptance Criteria
- [ ] All adapter files with tests pass
- [ ] Gateway webhook endpoint works
- [ ] Pilot initializes GitLab adapter when enabled
- [ ] `go test ./internal/adapters/gitlab/...` passes