### PR TITLE
Implement Azure DevOps adapter

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -52,6 +52,28 @@ adapters:
       interval: 30m
       threshold: 1h
 
+  # Azure DevOps - Work item polling and PR creation
+  azure_devops:
+    enabled: false
+    pat: "${AZURE_DEVOPS_PAT}"         # Personal Access Token
+    organization: "my-org"             # Azure DevOps organization
+    project: "my-project"              # Project name
+    repository: "my-repo"              # Repository name (optional, defaults to project)
+    base_url: "https://dev.azure.com"  # Or Azure DevOps Server URL
+    pilot_tag: "pilot"                 # Work items with this tag are picked up
+    webhook_secret: "${AZURE_DEVOPS_WEBHOOK_SECRET}"
+    work_item_types:                   # Which work item types to process
+      - "Bug"
+      - "Task"
+      - "User Story"
+    polling:
+      enabled: true
+      interval: 30s
+    stale_label_cleanup:
+      enabled: true
+      interval: 30m
+      threshold: 1h
+
   # Linear - Issue tracking (webhooks)
   linear:
     enabled: false

--- a/internal/adapters/azuredevops/cleanup.go
+++ b/internal/adapters/azuredevops/cleanup.go
@@ -1,0 +1,232 @@
+package azuredevops
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+	"github.com/alekspetrov/pilot/internal/memory"
+)
+
+// Cleaner handles automatic cleanup of stale pilot-in-progress tags.
+// When Pilot crashes or is killed, tags remain on work items. This cleaner
+// periodically checks for such orphaned tags and removes them.
+type Cleaner struct {
+	client        *Client
+	store         *memory.Store
+	interval      time.Duration
+	threshold     time.Duration
+	logger        *slog.Logger
+	workItemTypes []string
+
+	mu      sync.Mutex
+	running bool
+	stopCh  chan struct{}
+}
+
+// CleanerOption configures a Cleaner
+type CleanerOption func(*Cleaner)
+
+// WithCleanerLogger sets the logger for the cleaner
+func WithCleanerLogger(logger *slog.Logger) CleanerOption {
+	return func(c *Cleaner) {
+		c.logger = logger
+	}
+}
+
+// WithCleanerWorkItemTypes sets the work item types to clean
+func WithCleanerWorkItemTypes(types []string) CleanerOption {
+	return func(c *Cleaner) {
+		c.workItemTypes = types
+	}
+}
+
+// NewCleaner creates a new stale tag cleaner
+func NewCleaner(client *Client, store *memory.Store, config *StaleLabelCleanupConfig, opts ...CleanerOption) *Cleaner {
+	interval := config.Interval
+	if interval == 0 {
+		interval = 30 * time.Minute
+	}
+
+	threshold := config.Threshold
+	if threshold == 0 {
+		threshold = 1 * time.Hour
+	}
+
+	c := &Cleaner{
+		client:        client,
+		store:         store,
+		interval:      interval,
+		threshold:     threshold,
+		logger:        logging.WithComponent("azuredevops-cleanup"),
+		stopCh:        make(chan struct{}),
+		workItemTypes: []string{"Bug", "Task", "User Story"},
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// Start begins the periodic cleanup loop.
+// It runs in the background and can be stopped with Stop().
+func (c *Cleaner) Start(ctx context.Context) {
+	c.mu.Lock()
+	if c.running {
+		c.mu.Unlock()
+		return
+	}
+	c.running = true
+	c.stopCh = make(chan struct{})
+	c.mu.Unlock()
+
+	c.logger.Info("Starting stale tag cleaner",
+		slog.Duration("interval", c.interval),
+		slog.Duration("threshold", c.threshold),
+	)
+
+	// Run initial cleanup
+	if err := c.Cleanup(ctx); err != nil {
+		c.logger.Warn("Initial cleanup failed", slog.Any("error", err))
+	}
+
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("Stale tag cleaner stopped (context cancelled)")
+			return
+		case <-c.stopCh:
+			c.logger.Info("Stale tag cleaner stopped")
+			return
+		case <-ticker.C:
+			if err := c.Cleanup(ctx); err != nil {
+				c.logger.Warn("Cleanup failed", slog.Any("error", err))
+			}
+		}
+	}
+}
+
+// Stop stops the periodic cleanup loop
+func (c *Cleaner) Stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.running {
+		close(c.stopCh)
+		c.running = false
+	}
+}
+
+// Cleanup performs a single cleanup pass:
+// 1. Lists all work items with pilot-in-progress tag
+// 2. Cross-references with active executions in memory store
+// 3. Removes tag from work items with no matching active execution
+func (c *Cleaner) Cleanup(ctx context.Context) error {
+	c.logger.Debug("Running stale tag cleanup")
+
+	// Get all work items with in-progress tag
+	workItems, err := c.client.ListWorkItems(ctx, &ListWorkItemsOptions{
+		Tags:          []string{TagInProgress},
+		States:        []string{StateNew, StateActive},
+		WorkItemTypes: c.workItemTypes,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list work items with in-progress tag: %w", err)
+	}
+
+	if len(workItems) == 0 {
+		c.logger.Debug("No work items with in-progress tag found")
+		return nil
+	}
+
+	c.logger.Debug("Found work items with in-progress tag", slog.Int("count", len(workItems)))
+
+	// Get active executions from memory store
+	activeExecutions, err := c.store.GetActiveExecutions()
+	if err != nil {
+		return fmt.Errorf("failed to get active executions: %w", err)
+	}
+
+	// Build a map of active task IDs for quick lookup
+	activeTaskIDs := make(map[string]bool)
+	for _, exec := range activeExecutions {
+		activeTaskIDs[exec.TaskID] = true
+	}
+
+	c.logger.Debug("Active executions found", slog.Int("count", len(activeExecutions)))
+
+	// Check each work item
+	cleanedCount := 0
+	for _, wi := range workItems {
+		// Check if there's an active execution for this work item
+		// Task IDs are typically formatted as "AZDO-<id>"
+		taskID := fmt.Sprintf("AZDO-%d", wi.ID)
+		if activeTaskIDs[taskID] {
+			c.logger.Debug("Work item has active execution, skipping",
+				slog.Int("id", wi.ID),
+				slog.String("task_id", taskID),
+			)
+			continue
+		}
+
+		// Check if the work item's last update is older than threshold
+		if time.Since(wi.GetChangedDate()) < c.threshold {
+			c.logger.Debug("Work item recently updated, skipping",
+				slog.Int("id", wi.ID),
+				slog.Duration("age", time.Since(wi.GetChangedDate())),
+			)
+			continue
+		}
+
+		// Remove the stale tag
+		c.logger.Info("Removing stale in-progress tag",
+			slog.Int("id", wi.ID),
+			slog.String("title", wi.GetTitle()),
+			slog.Duration("age", time.Since(wi.GetChangedDate())),
+		)
+
+		if err := c.client.RemoveWorkItemTag(ctx, wi.ID, TagInProgress); err != nil {
+			c.logger.Warn("Failed to remove stale tag",
+				slog.Int("id", wi.ID),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		// Optionally add a comment explaining the cleanup
+		comment := "🧹 **Pilot cleanup**: Removed stale `pilot-in-progress` tag.\n\n" +
+			"This work item was marked as in-progress but no active Pilot execution was found. " +
+			"This can happen if Pilot was interrupted or crashed. The work item is now available for processing again."
+
+		if _, err := c.client.AddWorkItemComment(ctx, wi.ID, comment); err != nil {
+			c.logger.Warn("Failed to add cleanup comment",
+				slog.Int("id", wi.ID),
+				slog.Any("error", err),
+			)
+		}
+
+		cleanedCount++
+	}
+
+	if cleanedCount > 0 {
+		c.logger.Info("Stale tag cleanup completed",
+			slog.Int("cleaned", cleanedCount),
+			slog.Int("total_checked", len(workItems)),
+		)
+	}
+
+	return nil
+}
+
+// CleanupStaleTags is a convenience method that performs a single cleanup
+// without starting the periodic loop. Useful for one-off cleanup operations.
+func (c *Cleaner) CleanupStaleTags(ctx context.Context) error {
+	return c.Cleanup(ctx)
+}

--- a/internal/adapters/azuredevops/client.go
+++ b/internal/adapters/azuredevops/client.go
@@ -1,0 +1,695 @@
+package azuredevops
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultBaseURL     = "https://dev.azure.com"
+	apiVersion         = "7.1"
+	apiVersionPreview  = "7.1-preview"
+)
+
+// Client is an Azure DevOps API client
+type Client struct {
+	pat          string
+	organization string
+	project      string
+	repository   string
+	httpClient   *http.Client
+	baseURL      string
+}
+
+// NewClient creates a new Azure DevOps client
+func NewClient(pat, organization, project string) *Client {
+	return &Client{
+		pat:          pat,
+		organization: organization,
+		project:      project,
+		repository:   project, // Default repository name to project name
+		baseURL:      defaultBaseURL,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// NewClientWithConfig creates a new Azure DevOps client from config
+func NewClientWithConfig(config *Config) *Client {
+	c := NewClient(config.PAT, config.Organization, config.Project)
+	if config.Repository != "" {
+		c.repository = config.Repository
+	}
+	if config.BaseURL != "" {
+		c.baseURL = config.BaseURL
+	}
+	return c
+}
+
+// NewClientWithBaseURL creates a new Azure DevOps client with a custom base URL (for testing)
+func NewClientWithBaseURL(pat, organization, project, baseURL string) *Client {
+	return &Client{
+		pat:          pat,
+		organization: organization,
+		project:      project,
+		repository:   project,
+		baseURL:      baseURL,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// SetRepository sets the repository name (if different from project)
+func (c *Client) SetRepository(repo string) {
+	c.repository = repo
+}
+
+// doRequest performs an HTTP request to the Azure DevOps API
+func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}, result interface{}) error {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyBytes, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	fullURL := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Azure DevOps uses Basic auth with empty username and PAT as password
+	auth := base64.StdEncoding.EncodeToString([]byte(":" + c.pat))
+	req.Header.Set("Authorization", "Basic "+auth)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("failed to parse response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// doRequestWithPatch performs a PATCH request with JSON Patch content type
+func (c *Client) doRequestWithPatch(ctx context.Context, path string, body interface{}, result interface{}) error {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyBytes, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	fullURL := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, fullURL, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	auth := base64.StdEncoding.EncodeToString([]byte(":" + c.pat))
+	req.Header.Set("Authorization", "Basic "+auth)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json-patch+json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("failed to parse response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Work Item API methods
+
+// GetWorkItem fetches a work item by ID
+func (c *Client) GetWorkItem(ctx context.Context, id int) (*WorkItem, error) {
+	path := fmt.Sprintf("/%s/%s/_apis/wit/workitems/%d?api-version=%s",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		id,
+		apiVersion,
+	)
+	var wi WorkItem
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &wi); err != nil {
+		return nil, err
+	}
+	return &wi, nil
+}
+
+// ListWorkItemsByWIQL executes a WIQL query and returns work items
+func (c *Client) ListWorkItemsByWIQL(ctx context.Context, wiql string) ([]*WorkItem, error) {
+	path := fmt.Sprintf("/%s/%s/_apis/wit/wiql?api-version=%s",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		apiVersion,
+	)
+
+	reqBody := map[string]string{"query": wiql}
+	var queryResult WIQLQueryResult
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &queryResult); err != nil {
+		return nil, fmt.Errorf("failed to execute WIQL query: %w", err)
+	}
+
+	if len(queryResult.WorkItems) == 0 {
+		return []*WorkItem{}, nil
+	}
+
+	// Get work item IDs
+	ids := make([]int, len(queryResult.WorkItems))
+	for i, ref := range queryResult.WorkItems {
+		ids[i] = ref.ID
+	}
+
+	// Fetch full work item details
+	return c.GetWorkItems(ctx, ids)
+}
+
+// GetWorkItems fetches multiple work items by IDs
+func (c *Client) GetWorkItems(ctx context.Context, ids []int) ([]*WorkItem, error) {
+	if len(ids) == 0 {
+		return []*WorkItem{}, nil
+	}
+
+	// Azure DevOps limits to 200 items per request
+	const batchSize = 200
+	var allWorkItems []*WorkItem
+
+	for i := 0; i < len(ids); i += batchSize {
+		end := i + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+
+		batch := ids[i:end]
+		idStrs := make([]string, len(batch))
+		for j, id := range batch {
+			idStrs[j] = strconv.Itoa(id)
+		}
+
+		path := fmt.Sprintf("/%s/%s/_apis/wit/workitems?ids=%s&api-version=%s",
+			url.PathEscape(c.organization),
+			url.PathEscape(c.project),
+			strings.Join(idStrs, ","),
+			apiVersion,
+		)
+
+		var result struct {
+			Count     int         `json:"count"`
+			Value     []*WorkItem `json:"value"`
+		}
+		if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+			return nil, err
+		}
+
+		allWorkItems = append(allWorkItems, result.Value...)
+	}
+
+	return allWorkItems, nil
+}
+
+// ListWorkItems lists work items with the specified options
+func (c *Client) ListWorkItems(ctx context.Context, opts *ListWorkItemsOptions) ([]*WorkItem, error) {
+	// Build WIQL query
+	wiql := "SELECT [System.Id] FROM WorkItems WHERE "
+	conditions := []string{}
+
+	// Filter by tags
+	if opts != nil && len(opts.Tags) > 0 {
+		for _, tag := range opts.Tags {
+			conditions = append(conditions, fmt.Sprintf("[System.Tags] CONTAINS '%s'", tag))
+		}
+	}
+
+	// Filter by states (exclude specified states)
+	if opts != nil && len(opts.States) > 0 {
+		stateConditions := []string{}
+		for _, state := range opts.States {
+			stateConditions = append(stateConditions, fmt.Sprintf("[System.State] = '%s'", state))
+		}
+		conditions = append(conditions, "("+strings.Join(stateConditions, " OR ")+")")
+	}
+
+	// Filter by work item types
+	if opts != nil && len(opts.WorkItemTypes) > 0 {
+		typeConditions := []string{}
+		for _, wit := range opts.WorkItemTypes {
+			typeConditions = append(typeConditions, fmt.Sprintf("[System.WorkItemType] = '%s'", wit))
+		}
+		conditions = append(conditions, "("+strings.Join(typeConditions, " OR ")+")")
+	}
+
+	// Filter by updated date
+	if opts != nil && !opts.UpdatedAfter.IsZero() {
+		conditions = append(conditions, fmt.Sprintf("[System.ChangedDate] >= '%s'", opts.UpdatedAfter.Format("2006-01-02T15:04:05Z")))
+	}
+
+	if len(conditions) == 0 {
+		wiql += "1=1"
+	} else {
+		wiql += strings.Join(conditions, " AND ")
+	}
+
+	wiql += " ORDER BY [System.CreatedDate] ASC"
+
+	return c.ListWorkItemsByWIQL(ctx, wiql)
+}
+
+// PatchOperation represents a JSON Patch operation
+type PatchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+	From  string      `json:"from,omitempty"`
+}
+
+// UpdateWorkItem updates a work item with JSON Patch operations
+func (c *Client) UpdateWorkItem(ctx context.Context, id int, operations []PatchOperation) (*WorkItem, error) {
+	path := fmt.Sprintf("/%s/%s/_apis/wit/workitems/%d?api-version=%s",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		id,
+		apiVersion,
+	)
+
+	var wi WorkItem
+	if err := c.doRequestWithPatch(ctx, path, operations, &wi); err != nil {
+		return nil, err
+	}
+	return &wi, nil
+}
+
+// AddWorkItemTag adds a tag to a work item
+func (c *Client) AddWorkItemTag(ctx context.Context, id int, tag string) error {
+	// First get current tags
+	wi, err := c.GetWorkItem(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to get work item: %w", err)
+	}
+
+	currentTags := ""
+	if tags, ok := wi.Fields["System.Tags"].(string); ok {
+		currentTags = tags
+	}
+
+	newTags := addTag(currentTags, tag)
+	if newTags == currentTags {
+		return nil // Tag already exists
+	}
+
+	ops := []PatchOperation{
+		{
+			Op:    "add",
+			Path:  "/fields/System.Tags",
+			Value: newTags,
+		},
+	}
+
+	_, err = c.UpdateWorkItem(ctx, id, ops)
+	return err
+}
+
+// RemoveWorkItemTag removes a tag from a work item
+func (c *Client) RemoveWorkItemTag(ctx context.Context, id int, tag string) error {
+	// First get current tags
+	wi, err := c.GetWorkItem(ctx, id)
+	if err != nil {
+		// If work item doesn't exist, nothing to do
+		return nil
+	}
+
+	currentTags := ""
+	if tags, ok := wi.Fields["System.Tags"].(string); ok {
+		currentTags = tags
+	}
+
+	newTags := removeTag(currentTags, tag)
+	if newTags == currentTags {
+		return nil // Tag wasn't there
+	}
+
+	ops := []PatchOperation{
+		{
+			Op:    "add",
+			Path:  "/fields/System.Tags",
+			Value: newTags,
+		},
+	}
+
+	_, err = c.UpdateWorkItem(ctx, id, ops)
+	return err
+}
+
+// AddWorkItemComment adds a comment to a work item
+func (c *Client) AddWorkItemComment(ctx context.Context, id int, text string) (*Comment, error) {
+	path := fmt.Sprintf("/%s/%s/_apis/wit/workitems/%d/comments?api-version=%s-preview",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		id,
+		apiVersion,
+	)
+
+	reqBody := map[string]string{"text": text}
+	var comment Comment
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &comment); err != nil {
+		return nil, err
+	}
+	return &comment, nil
+}
+
+// UpdateWorkItemState updates a work item's state
+func (c *Client) UpdateWorkItemState(ctx context.Context, id int, state string) error {
+	ops := []PatchOperation{
+		{
+			Op:    "add",
+			Path:  "/fields/System.State",
+			Value: state,
+		},
+	}
+
+	_, err := c.UpdateWorkItem(ctx, id, ops)
+	return err
+}
+
+// Git/Repository API methods
+
+// GetDefaultBranch returns the default branch of the repository
+func (c *Client) GetDefaultBranch(ctx context.Context) (string, error) {
+	path := fmt.Sprintf("/%s/%s/_apis/git/repositories/%s?api-version=%s",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		url.PathEscape(c.repository),
+		apiVersion,
+	)
+
+	var repo struct {
+		DefaultBranch string `json:"defaultBranch"`
+	}
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &repo); err != nil {
+		return "", err
+	}
+
+	// Default branch is returned as "refs/heads/main"
+	branch := strings.TrimPrefix(repo.DefaultBranch, "refs/heads/")
+	return branch, nil
+}
+
+// GetBranch gets a branch reference
+func (c *Client) GetBranch(ctx context.Context, branchName string) (*GitRef, error) {
+	refName := branchName
+	if !strings.HasPrefix(refName, "refs/heads/") {
+		refName = "refs/heads/" + branchName
+	}
+
+	path := fmt.Sprintf("/%s/%s/_apis/git/repositories/%s/refs?filter=%s&api-version=%s",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		url.PathEscape(c.repository),
+		url.QueryEscape(refName),
+		apiVersion,
+	)
+
+	var result struct {
+		Value []GitRef `json:"value"`
+	}
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return nil, err
+	}
+
+	for _, ref := range result.Value {
+		if ref.Name == refName {
+			return &ref, nil
+		}
+	}
+
+	return nil, fmt.Errorf("branch not found: %s", branchName)
+}
+
+// CreateBranch creates a new branch from a source ref
+func (c *Client) CreateBranch(ctx context.Context, branchName, fromRef string) error {
+	// Get the source ref to get the commit SHA
+	sourceBranch, err := c.GetBranch(ctx, fromRef)
+	if err != nil {
+		return fmt.Errorf("failed to get source branch: %w", err)
+	}
+
+	newRefName := branchName
+	if !strings.HasPrefix(newRefName, "refs/heads/") {
+		newRefName = "refs/heads/" + branchName
+	}
+
+	path := fmt.Sprintf("/%s/%s/_apis/git/repositories/%s/refs?api-version=%s",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		url.PathEscape(c.repository),
+		apiVersion,
+	)
+
+	refUpdates := []GitRefUpdate{
+		{
+			Name:        newRefName,
+			OldObjectID: "0000000000000000000000000000000000000000", // 40 zeros for new branch
+			NewObjectID: sourceBranch.ObjectID,
+		},
+	}
+
+	var result struct {
+		Value []GitRef `json:"value"`
+	}
+	if err := c.doRequest(ctx, http.MethodPost, path, refUpdates, &result); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Pull Request API methods
+
+// CreatePullRequest creates a new pull request
+func (c *Client) CreatePullRequest(ctx context.Context, input *PullRequestInput) (*PullRequest, error) {
+	// Ensure refs are in full format
+	sourceRef := input.SourceRefName
+	if !strings.HasPrefix(sourceRef, "refs/heads/") {
+		sourceRef = "refs/heads/" + sourceRef
+	}
+	targetRef := input.TargetRefName
+	if !strings.HasPrefix(targetRef, "refs/heads/") {
+		targetRef = "refs/heads/" + targetRef
+	}
+
+	path := fmt.Sprintf("/%s/%s/_apis/git/repositories/%s/pullrequests?api-version=%s",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		url.PathEscape(c.repository),
+		apiVersion,
+	)
+
+	reqBody := map[string]interface{}{
+		"title":         input.Title,
+		"description":   input.Description,
+		"sourceRefName": sourceRef,
+		"targetRefName": targetRef,
+	}
+	if input.IsDraft {
+		reqBody["isDraft"] = true
+	}
+
+	var pr PullRequest
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &pr); err != nil {
+		return nil, err
+	}
+	return &pr, nil
+}
+
+// GetPullRequest fetches a pull request by ID
+func (c *Client) GetPullRequest(ctx context.Context, id int) (*PullRequest, error) {
+	path := fmt.Sprintf("/%s/%s/_apis/git/repositories/%s/pullrequests/%d?api-version=%s",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		url.PathEscape(c.repository),
+		id,
+		apiVersion,
+	)
+
+	var pr PullRequest
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &pr); err != nil {
+		return nil, err
+	}
+	return &pr, nil
+}
+
+// CompletePullRequest completes (merges) a pull request
+func (c *Client) CompletePullRequest(ctx context.Context, id int, deleteSourceBranch bool) (*PullRequest, error) {
+	// First get the PR to get the last merge source commit
+	pr, err := c.GetPullRequest(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pull request: %w", err)
+	}
+
+	if pr.LastMergeSourceCommit == nil {
+		return nil, fmt.Errorf("pull request has no source commit")
+	}
+
+	path := fmt.Sprintf("/%s/%s/_apis/git/repositories/%s/pullrequests/%d?api-version=%s",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		url.PathEscape(c.repository),
+		id,
+		apiVersion,
+	)
+
+	reqBody := map[string]interface{}{
+		"status":                   PRStateCompleted,
+		"lastMergeSourceCommit": map[string]string{
+			"commitId": pr.LastMergeSourceCommit.CommitID,
+		},
+		"completionOptions": map[string]interface{}{
+			"deleteSourceBranch": deleteSourceBranch,
+			"mergeCommitMessage": pr.Title,
+		},
+	}
+
+	var result PullRequest
+	if err := c.doRequest(ctx, http.MethodPatch, path, reqBody, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// AbandonPullRequest abandons (closes without merge) a pull request
+func (c *Client) AbandonPullRequest(ctx context.Context, id int) (*PullRequest, error) {
+	path := fmt.Sprintf("/%s/%s/_apis/git/repositories/%s/pullrequests/%d?api-version=%s",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		url.PathEscape(c.repository),
+		id,
+		apiVersion,
+	)
+
+	reqBody := map[string]interface{}{
+		"status": PRStateAbandoned,
+	}
+
+	var pr PullRequest
+	if err := c.doRequest(ctx, http.MethodPatch, path, reqBody, &pr); err != nil {
+		return nil, err
+	}
+	return &pr, nil
+}
+
+// ListPullRequests lists pull requests with optional status filter
+func (c *Client) ListPullRequests(ctx context.Context, status string) ([]*PullRequest, error) {
+	path := fmt.Sprintf("/%s/%s/_apis/git/repositories/%s/pullrequests?api-version=%s",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		url.PathEscape(c.repository),
+		apiVersion,
+	)
+
+	if status != "" {
+		path += "&searchCriteria.status=" + status
+	}
+
+	var result struct {
+		Value []*PullRequest `json:"value"`
+	}
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return nil, err
+	}
+	return result.Value, nil
+}
+
+// AddPRComment adds a comment to a pull request thread
+func (c *Client) AddPRComment(ctx context.Context, prID int, comment string) error {
+	path := fmt.Sprintf("/%s/%s/_apis/git/repositories/%s/pullrequests/%d/threads?api-version=%s",
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		url.PathEscape(c.repository),
+		prID,
+		apiVersion,
+	)
+
+	reqBody := map[string]interface{}{
+		"comments": []map[string]string{
+			{"content": comment},
+		},
+	}
+
+	return c.doRequest(ctx, http.MethodPost, path, reqBody, nil)
+}
+
+// GetWorkItemWebURL constructs the web URL for a work item
+func (c *Client) GetWorkItemWebURL(id int) string {
+	return fmt.Sprintf("%s/%s/%s/_workitems/edit/%d",
+		c.baseURL,
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		id,
+	)
+}
+
+// GetPullRequestWebURL constructs the web URL for a pull request
+func (c *Client) GetPullRequestWebURL(id int) string {
+	return fmt.Sprintf("%s/%s/%s/_git/%s/pullrequest/%d",
+		c.baseURL,
+		url.PathEscape(c.organization),
+		url.PathEscape(c.project),
+		url.PathEscape(c.repository),
+		id,
+	)
+}
+
+// HasTag checks if a work item has a specific tag
+func HasTag(wi *WorkItem, tag string) bool {
+	return wi.HasTag(tag)
+}

--- a/internal/adapters/azuredevops/client_test.go
+++ b/internal/adapters/azuredevops/client_test.go
@@ -1,0 +1,449 @@
+package azuredevops
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestNewClient(t *testing.T) {
+	client := NewClient(testutil.FakeAzureDevOpsPAT, "my-org", "my-project")
+
+	if client.pat != testutil.FakeAzureDevOpsPAT {
+		t.Errorf("expected PAT %s, got %s", testutil.FakeAzureDevOpsPAT, client.pat)
+	}
+	if client.organization != "my-org" {
+		t.Errorf("expected organization my-org, got %s", client.organization)
+	}
+	if client.project != "my-project" {
+		t.Errorf("expected project my-project, got %s", client.project)
+	}
+	if client.repository != "my-project" {
+		t.Errorf("expected repository to default to project name, got %s", client.repository)
+	}
+	if client.baseURL != defaultBaseURL {
+		t.Errorf("expected baseURL %s, got %s", defaultBaseURL, client.baseURL)
+	}
+}
+
+func TestNewClientWithConfig(t *testing.T) {
+	config := &Config{
+		PAT:          testutil.FakeAzureDevOpsPAT,
+		Organization: "test-org",
+		Project:      "test-project",
+		Repository:   "test-repo",
+		BaseURL:      "https://azure.example.com",
+	}
+
+	client := NewClientWithConfig(config)
+
+	if client.pat != testutil.FakeAzureDevOpsPAT {
+		t.Errorf("expected PAT %s, got %s", testutil.FakeAzureDevOpsPAT, client.pat)
+	}
+	if client.organization != "test-org" {
+		t.Errorf("expected organization test-org, got %s", client.organization)
+	}
+	if client.project != "test-project" {
+		t.Errorf("expected project test-project, got %s", client.project)
+	}
+	if client.repository != "test-repo" {
+		t.Errorf("expected repository test-repo, got %s", client.repository)
+	}
+	if client.baseURL != "https://azure.example.com" {
+		t.Errorf("expected baseURL https://azure.example.com, got %s", client.baseURL)
+	}
+}
+
+func TestGetWorkItem(t *testing.T) {
+	workItem := WorkItem{
+		ID:  123,
+		Rev: 1,
+		Fields: map[string]interface{}{
+			"System.Title":       "Test work item",
+			"System.Description": "Test description",
+			"System.State":       "New",
+			"System.Tags":        "pilot; bug",
+		},
+		URL: "https://dev.azure.com/org/project/_apis/wit/workitems/123",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.Header.Get("Authorization") == "" {
+			t.Error("expected Authorization header")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(workItem)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	ctx := context.Background()
+
+	result, err := client.GetWorkItem(ctx, 123)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.ID != 123 {
+		t.Errorf("expected ID 123, got %d", result.ID)
+	}
+	if result.GetTitle() != "Test work item" {
+		t.Errorf("expected title 'Test work item', got '%s'", result.GetTitle())
+	}
+}
+
+func TestListWorkItemsByWIQL(t *testing.T) {
+	// Mock WIQL response
+	wiqlResponse := WIQLQueryResult{
+		QueryType:       "flat",
+		QueryResultType: "workItem",
+		WorkItems: []WIQLWorkItemRef{
+			{ID: 1, URL: "url1"},
+			{ID: 2, URL: "url2"},
+		},
+	}
+
+	// Mock work items response
+	workItemsResponse := struct {
+		Count int         `json:"count"`
+		Value []*WorkItem `json:"value"`
+	}{
+		Count: 2,
+		Value: []*WorkItem{
+			{ID: 1, Fields: map[string]interface{}{"System.Title": "Item 1"}},
+			{ID: 2, Fields: map[string]interface{}{"System.Title": "Item 2"}},
+		},
+	}
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		if callCount == 1 {
+			// WIQL query
+			_ = json.NewEncoder(w).Encode(wiqlResponse)
+		} else {
+			// Work items batch
+			_ = json.NewEncoder(w).Encode(workItemsResponse)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	ctx := context.Background()
+
+	results, err := client.ListWorkItemsByWIQL(ctx, "SELECT [System.Id] FROM WorkItems")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(results))
+	}
+}
+
+func TestAddWorkItemTag(t *testing.T) {
+	// First call: GET work item
+	workItem := WorkItem{
+		ID:     123,
+		Fields: map[string]interface{}{"System.Tags": "existing-tag"},
+	}
+
+	// Second call: PATCH to update
+	updatedWorkItem := WorkItem{
+		ID:     123,
+		Fields: map[string]interface{}{"System.Tags": "existing-tag; new-tag"},
+	}
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		if callCount == 1 {
+			// GET work item
+			_ = json.NewEncoder(w).Encode(workItem)
+		} else {
+			// PATCH to update
+			if r.Method != http.MethodPatch {
+				t.Errorf("expected PATCH for update, got %s", r.Method)
+			}
+			if r.Header.Get("Content-Type") != "application/json-patch+json" {
+				t.Errorf("expected JSON Patch content type, got %s", r.Header.Get("Content-Type"))
+			}
+			_ = json.NewEncoder(w).Encode(updatedWorkItem)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	ctx := context.Background()
+
+	err := client.AddWorkItemTag(ctx, 123, "new-tag")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls, got %d", callCount)
+	}
+}
+
+func TestRemoveWorkItemTag(t *testing.T) {
+	// First call: GET work item
+	workItem := WorkItem{
+		ID:     123,
+		Fields: map[string]interface{}{"System.Tags": "keep-tag; remove-tag"},
+	}
+
+	// Second call: PATCH to update
+	updatedWorkItem := WorkItem{
+		ID:     123,
+		Fields: map[string]interface{}{"System.Tags": "keep-tag"},
+	}
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		if callCount == 1 {
+			_ = json.NewEncoder(w).Encode(workItem)
+		} else {
+			_ = json.NewEncoder(w).Encode(updatedWorkItem)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	ctx := context.Background()
+
+	err := client.RemoveWorkItemTag(ctx, 123, "remove-tag")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreatePullRequest(t *testing.T) {
+	expectedPR := PullRequest{
+		PullRequestID: 42,
+		Title:         "Test PR",
+		Description:   "Test description",
+		Status:        PRStateActive,
+		SourceRefName: "refs/heads/feature",
+		TargetRefName: "refs/heads/main",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		var input map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+
+		// Verify refs are in full format
+		if input["sourceRefName"] != "refs/heads/feature" {
+			t.Errorf("expected source ref refs/heads/feature, got %s", input["sourceRefName"])
+		}
+		if input["targetRefName"] != "refs/heads/main" {
+			t.Errorf("expected target ref refs/heads/main, got %s", input["targetRefName"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(expectedPR)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	ctx := context.Background()
+
+	pr, err := client.CreatePullRequest(ctx, &PullRequestInput{
+		Title:         "Test PR",
+		Description:   "Test description",
+		SourceRefName: "feature", // Should be expanded to refs/heads/feature
+		TargetRefName: "main",    // Should be expanded to refs/heads/main
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if pr.PullRequestID != 42 {
+		t.Errorf("expected PR ID 42, got %d", pr.PullRequestID)
+	}
+}
+
+func TestGetPullRequest(t *testing.T) {
+	expectedPR := PullRequest{
+		PullRequestID: 42,
+		Title:         "Test PR",
+		Status:        PRStateActive,
+		MergeStatus:   MergeStatusQueued,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(expectedPR)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	ctx := context.Background()
+
+	pr, err := client.GetPullRequest(ctx, 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if pr.PullRequestID != 42 {
+		t.Errorf("expected PR ID 42, got %d", pr.PullRequestID)
+	}
+	if pr.Status != PRStateActive {
+		t.Errorf("expected status active, got %s", pr.Status)
+	}
+}
+
+func TestGetWorkItemWebURL(t *testing.T) {
+	client := NewClient(testutil.FakeAzureDevOpsPAT, "my-org", "my-project")
+
+	url := client.GetWorkItemWebURL(123)
+	expected := "https://dev.azure.com/my-org/my-project/_workitems/edit/123"
+
+	if url != expected {
+		t.Errorf("expected %s, got %s", expected, url)
+	}
+}
+
+func TestGetPullRequestWebURL(t *testing.T) {
+	client := NewClient(testutil.FakeAzureDevOpsPAT, "my-org", "my-project")
+	client.SetRepository("my-repo")
+
+	url := client.GetPullRequestWebURL(42)
+	expected := "https://dev.azure.com/my-org/my-project/_git/my-repo/pullrequest/42"
+
+	if url != expected {
+		t.Errorf("expected %s, got %s", expected, url)
+	}
+}
+
+func TestWorkItemHelpers(t *testing.T) {
+	wi := &WorkItem{
+		ID: 123,
+		Fields: map[string]interface{}{
+			"System.Title":                  "Test Title",
+			"System.Description":            "Test Description",
+			"System.State":                  "Active",
+			"System.WorkItemType":           "Bug",
+			"System.Tags":                   "tag1; tag2; pilot",
+			"Microsoft.VSTS.Common.Priority": float64(2),
+			"System.CreatedDate":            "2024-01-15T10:30:00Z",
+			"System.ChangedDate":            "2024-01-16T15:45:00Z",
+		},
+	}
+
+	if wi.GetTitle() != "Test Title" {
+		t.Errorf("expected title 'Test Title', got '%s'", wi.GetTitle())
+	}
+
+	if wi.GetDescription() != "Test Description" {
+		t.Errorf("expected description 'Test Description', got '%s'", wi.GetDescription())
+	}
+
+	if wi.GetState() != "Active" {
+		t.Errorf("expected state 'Active', got '%s'", wi.GetState())
+	}
+
+	if wi.GetWorkItemType() != "Bug" {
+		t.Errorf("expected type 'Bug', got '%s'", wi.GetWorkItemType())
+	}
+
+	tags := wi.GetTags()
+	if len(tags) != 3 {
+		t.Errorf("expected 3 tags, got %d", len(tags))
+	}
+
+	if !wi.HasTag("pilot") {
+		t.Error("expected work item to have 'pilot' tag")
+	}
+
+	if wi.HasTag("nonexistent") {
+		t.Error("expected work item NOT to have 'nonexistent' tag")
+	}
+
+	if wi.GetPriority() != PriorityHigh {
+		t.Errorf("expected priority High (2), got %d", wi.GetPriority())
+	}
+
+	created := wi.GetCreatedDate()
+	if created.IsZero() {
+		t.Error("expected non-zero created date")
+	}
+	if created.Year() != 2024 || created.Month() != time.January || created.Day() != 15 {
+		t.Errorf("unexpected created date: %v", created)
+	}
+}
+
+func TestTagHelpers(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     string
+		expected []string
+	}{
+		{"empty", "", nil},
+		{"single", "tag1", []string{"tag1"}},
+		{"multiple", "tag1; tag2; tag3", []string{"tag1", "tag2", "tag3"}},
+		{"with spaces", "  tag1  ;  tag2  ", []string{"tag1", "tag2"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := splitTags(tt.tags)
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d tags, got %d", len(tt.expected), len(result))
+				return
+			}
+			for i, tag := range result {
+				if tag != tt.expected[i] {
+					t.Errorf("expected tag %d to be '%s', got '%s'", i, tt.expected[i], tag)
+				}
+			}
+		})
+	}
+
+	// Test joinTags
+	joined := joinTags([]string{"a", "b", "c"})
+	if joined != "a; b; c" {
+		t.Errorf("expected 'a; b; c', got '%s'", joined)
+	}
+
+	// Test addTag
+	newTags := addTag("existing", "new")
+	if newTags != "existing; new" {
+		t.Errorf("expected 'existing; new', got '%s'", newTags)
+	}
+
+	// Test addTag when tag exists
+	sameTags := addTag("existing; new", "new")
+	if sameTags != "existing; new" {
+		t.Errorf("expected 'existing; new', got '%s'", sameTags)
+	}
+
+	// Test removeTag
+	afterRemove := removeTag("keep; remove; also-keep", "remove")
+	if afterRemove != "keep; also-keep" {
+		t.Errorf("expected 'keep; also-keep', got '%s'", afterRemove)
+	}
+}

--- a/internal/adapters/azuredevops/converter.go
+++ b/internal/adapters/azuredevops/converter.go
@@ -1,0 +1,227 @@
+package azuredevops
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// TaskInfo contains the extracted task information from an Azure DevOps work item
+type TaskInfo struct {
+	ID           string
+	Title        string
+	Description  string
+	Priority     Priority
+	Tags         []string
+	Organization string
+	Project      string
+	Repository   string
+	WorkItemID   int
+	WorkItemURL  string
+	CloneURL     string
+}
+
+// ConvertWorkItemToTask converts an Azure DevOps work item to a TaskInfo
+func ConvertWorkItemToTask(wi *WorkItem, organization, project, repository, baseURL string) *TaskInfo {
+	// Construct clone URL
+	cloneURL := fmt.Sprintf("%s/%s/%s/_git/%s",
+		baseURL,
+		organization,
+		project,
+		repository,
+	)
+
+	// Construct work item URL
+	workItemURL := fmt.Sprintf("%s/%s/%s/_workitems/edit/%d",
+		baseURL,
+		organization,
+		project,
+		wi.ID,
+	)
+
+	task := &TaskInfo{
+		ID:           fmt.Sprintf("AZDO-%d", wi.ID),
+		Title:        wi.GetTitle(),
+		Description:  extractDescription(wi.GetDescription()),
+		Priority:     wi.GetPriority(),
+		Tags:         extractTagNames(wi.GetTags()),
+		Organization: organization,
+		Project:      project,
+		Repository:   repository,
+		WorkItemID:   wi.ID,
+		WorkItemURL:  workItemURL,
+		CloneURL:     cloneURL,
+	}
+
+	return task
+}
+
+// extractDescription extracts and cleans the task description
+// Azure DevOps stores descriptions as HTML
+func extractDescription(body string) string {
+	if body == "" {
+		return ""
+	}
+
+	// Remove HTML tags
+	body = stripHTML(body)
+
+	// Remove common Azure DevOps template sections
+	lines := strings.Split(body, "\n")
+	var filtered []string
+	skipSection := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Skip template sections
+		if strings.HasPrefix(trimmed, "### Checklist") ||
+			strings.HasPrefix(trimmed, "### Environment") ||
+			strings.HasPrefix(trimmed, "### Repro Steps") ||
+			strings.HasPrefix(trimmed, "### Expected Behavior") ||
+			strings.HasPrefix(trimmed, "### Actual Behavior") {
+			skipSection = true
+			continue
+		}
+
+		// Resume at next heading
+		if skipSection && strings.HasPrefix(trimmed, "### ") {
+			skipSection = false
+		}
+
+		if !skipSection {
+			filtered = append(filtered, line)
+		}
+	}
+
+	return strings.TrimSpace(strings.Join(filtered, "\n"))
+}
+
+// stripHTML removes HTML tags from a string
+func stripHTML(s string) string {
+	// Remove script and style tags with content
+	scriptRe := regexp.MustCompile(`(?i)<script[^>]*>[\s\S]*?</script>`)
+	s = scriptRe.ReplaceAllString(s, "")
+	styleRe := regexp.MustCompile(`(?i)<style[^>]*>[\s\S]*?</style>`)
+	s = styleRe.ReplaceAllString(s, "")
+
+	// Replace common HTML elements with appropriate text
+	s = strings.ReplaceAll(s, "<br>", "\n")
+	s = strings.ReplaceAll(s, "<br/>", "\n")
+	s = strings.ReplaceAll(s, "<br />", "\n")
+	s = strings.ReplaceAll(s, "</p>", "\n\n")
+	s = strings.ReplaceAll(s, "</div>", "\n")
+	s = strings.ReplaceAll(s, "</li>", "\n")
+	s = strings.ReplaceAll(s, "<li>", "- ")
+
+	// Remove all remaining HTML tags
+	tagRe := regexp.MustCompile(`<[^>]*>`)
+	s = tagRe.ReplaceAllString(s, "")
+
+	// Decode common HTML entities
+	s = strings.ReplaceAll(s, "&nbsp;", " ")
+	s = strings.ReplaceAll(s, "&amp;", "&")
+	s = strings.ReplaceAll(s, "&lt;", "<")
+	s = strings.ReplaceAll(s, "&gt;", ">")
+	s = strings.ReplaceAll(s, "&quot;", "\"")
+	s = strings.ReplaceAll(s, "&#39;", "'")
+
+	// Clean up multiple newlines
+	multiNewlineRe := regexp.MustCompile(`\n{3,}`)
+	s = multiNewlineRe.ReplaceAllString(s, "\n\n")
+
+	return strings.TrimSpace(s)
+}
+
+// extractTagNames returns a list of tag names excluding pilot/priority tags
+func extractTagNames(tags []string) []string {
+	var names []string
+	for _, tag := range tags {
+		name := strings.ToLower(tag)
+		// Skip pilot and priority tags
+		if strings.HasPrefix(name, "pilot") ||
+			strings.HasPrefix(name, "priority") ||
+			strings.HasPrefix(name, "p0") || strings.HasPrefix(name, "p1") ||
+			strings.HasPrefix(name, "p2") || strings.HasPrefix(name, "p3") {
+			continue
+		}
+		names = append(names, tag)
+	}
+	return names
+}
+
+// ExtractAcceptanceCriteria extracts acceptance criteria from work item description
+func ExtractAcceptanceCriteria(body string) []string {
+	var criteria []string
+
+	// First strip HTML if present
+	body = stripHTML(body)
+
+	// Look for common acceptance criteria patterns
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)### acceptance criteria\s*\n([\s\S]*?)(?:\n###|\z)`),
+		regexp.MustCompile(`(?i)### criteria\s*\n([\s\S]*?)(?:\n###|\z)`),
+		regexp.MustCompile(`(?i)## acceptance criteria\s*\n([\s\S]*?)(?:\n##|\z)`),
+		regexp.MustCompile(`(?i)acceptance criteria:?\s*\n([\s\S]*?)(?:\n[A-Z]|\z)`),
+	}
+
+	for _, pattern := range patterns {
+		matches := pattern.FindStringSubmatch(body)
+		if len(matches) > 1 {
+			// Extract checkbox items
+			checkboxPattern := regexp.MustCompile(`- \[[ x]\] (.+)`)
+			items := checkboxPattern.FindAllStringSubmatch(matches[1], -1)
+			for _, item := range items {
+				if len(item) > 1 {
+					criteria = append(criteria, strings.TrimSpace(item[1]))
+				}
+			}
+			// Also extract plain list items
+			if len(criteria) == 0 {
+				listPattern := regexp.MustCompile(`- (.+)`)
+				items = listPattern.FindAllStringSubmatch(matches[1], -1)
+				for _, item := range items {
+					if len(item) > 1 {
+						criteria = append(criteria, strings.TrimSpace(item[1]))
+					}
+				}
+			}
+			break
+		}
+	}
+
+	return criteria
+}
+
+// BuildTaskPrompt creates a prompt for Claude Code from the task info
+func BuildTaskPrompt(task *TaskInfo) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("# Task: %s\n\n", task.Title))
+	sb.WriteString(fmt.Sprintf("**Work Item**: %s\n", task.WorkItemURL))
+	sb.WriteString(fmt.Sprintf("**Priority**: %s\n\n", PriorityName(task.Priority)))
+
+	if task.Description != "" {
+		sb.WriteString("## Description\n\n")
+		sb.WriteString(task.Description)
+		sb.WriteString("\n\n")
+	}
+
+	// Extract acceptance criteria if available
+	criteria := ExtractAcceptanceCriteria(task.Description)
+	if len(criteria) > 0 {
+		sb.WriteString("## Acceptance Criteria\n\n")
+		for _, c := range criteria {
+			sb.WriteString(fmt.Sprintf("- [ ] %s\n", c))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("## Requirements\n\n")
+	sb.WriteString("1. Implement the changes described above\n")
+	sb.WriteString("2. Write tests for new functionality\n")
+	sb.WriteString("3. Ensure all existing tests pass\n")
+	sb.WriteString("4. Follow the project's code style and conventions\n")
+
+	return sb.String()
+}

--- a/internal/adapters/azuredevops/converter_test.go
+++ b/internal/adapters/azuredevops/converter_test.go
@@ -1,0 +1,302 @@
+package azuredevops
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConvertWorkItemToTask(t *testing.T) {
+	wi := &WorkItem{
+		ID:  123,
+		Rev: 1,
+		Fields: map[string]interface{}{
+			"System.Title":                  "Fix login bug",
+			"System.Description":            "Users cannot login when...",
+			"System.Tags":                   "pilot; bug; frontend",
+			"Microsoft.VSTS.Common.Priority": float64(2),
+		},
+	}
+
+	task := ConvertWorkItemToTask(wi, "my-org", "my-project", "my-repo", "https://dev.azure.com")
+
+	if task.ID != "AZDO-123" {
+		t.Errorf("expected ID 'AZDO-123', got '%s'", task.ID)
+	}
+
+	if task.Title != "Fix login bug" {
+		t.Errorf("expected title 'Fix login bug', got '%s'", task.Title)
+	}
+
+	if task.Priority != PriorityHigh {
+		t.Errorf("expected priority High, got %d", task.Priority)
+	}
+
+	if task.Organization != "my-org" {
+		t.Errorf("expected organization 'my-org', got '%s'", task.Organization)
+	}
+
+	if task.Project != "my-project" {
+		t.Errorf("expected project 'my-project', got '%s'", task.Project)
+	}
+
+	if task.Repository != "my-repo" {
+		t.Errorf("expected repository 'my-repo', got '%s'", task.Repository)
+	}
+
+	if task.WorkItemID != 123 {
+		t.Errorf("expected work item ID 123, got %d", task.WorkItemID)
+	}
+
+	if task.WorkItemURL != "https://dev.azure.com/my-org/my-project/_workitems/edit/123" {
+		t.Errorf("unexpected work item URL: %s", task.WorkItemURL)
+	}
+
+	if task.CloneURL != "https://dev.azure.com/my-org/my-project/_git/my-repo" {
+		t.Errorf("unexpected clone URL: %s", task.CloneURL)
+	}
+
+	// Tags should exclude pilot and priority tags
+	if len(task.Tags) != 2 {
+		t.Errorf("expected 2 tags (bug, frontend), got %d", len(task.Tags))
+	}
+}
+
+func TestExtractDescription(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "plain text",
+			input:    "Simple description",
+			expected: "Simple description",
+		},
+		{
+			name:     "with template sections",
+			input:    "Main description\n### Checklist\n- [ ] Done\n### Next section",
+			expected: "Main description\n### Next section",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractDescription(tt.input)
+			if result != tt.expected {
+				t.Errorf("expected '%s', got '%s'", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestStripHTML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no html",
+			input:    "plain text",
+			expected: "plain text",
+		},
+		{
+			name:     "simple tags",
+			input:    "<p>paragraph</p>",
+			expected: "paragraph",
+		},
+		{
+			name:     "br tags",
+			input:    "line1<br>line2<br/>line3",
+			expected: "line1\nline2\nline3",
+		},
+		{
+			name:     "list items",
+			input:    "<ul><li>item1</li><li>item2</li></ul>",
+			expected: "- item1\n- item2",
+		},
+		{
+			name:     "html entities",
+			input:    "&amp; &lt; &gt; &quot; &#39;",
+			expected: "& < > \" '",
+		},
+		{
+			name:     "script removal",
+			input:    "text<script>alert('xss')</script>more",
+			expected: "textmore",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripHTML(tt.input)
+			if result != tt.expected {
+				t.Errorf("expected '%s', got '%s'", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestExtractTagNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "empty",
+			input:    []string{},
+			expected: nil,
+		},
+		{
+			name:     "only pilot tags",
+			input:    []string{"pilot", "pilot-in-progress"},
+			expected: nil,
+		},
+		{
+			name:     "mixed tags",
+			input:    []string{"pilot", "bug", "frontend", "p1"},
+			expected: []string{"bug", "frontend"},
+		},
+		{
+			name:     "priority tags filtered",
+			input:    []string{"priority-high", "p0", "p1", "feature"},
+			expected: []string{"feature"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractTagNames(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d tags, got %d", len(tt.expected), len(result))
+				return
+			}
+			for i, tag := range result {
+				if tag != tt.expected[i] {
+					t.Errorf("tag %d: expected '%s', got '%s'", i, tt.expected[i], tag)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractAcceptanceCriteria(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "no acceptance criteria",
+			input:    "Just a description",
+			expected: nil,
+		},
+		{
+			name:     "with checkbox items",
+			input:    "### Acceptance Criteria\n- [ ] First item\n- [x] Second item\n### Other",
+			expected: []string{"First item", "Second item"},
+		},
+		{
+			name:     "with plain list",
+			input:    "### Acceptance Criteria\n- First item\n- Second item\n### Other",
+			expected: []string{"First item", "Second item"},
+		},
+		{
+			name:     "double hash heading",
+			input:    "## Acceptance Criteria\n- [ ] Item one\n## Next Section",
+			expected: []string{"Item one"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractAcceptanceCriteria(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d criteria, got %d: %v", len(tt.expected), len(result), result)
+				return
+			}
+			for i, item := range result {
+				if item != tt.expected[i] {
+					t.Errorf("criterion %d: expected '%s', got '%s'", i, tt.expected[i], item)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildTaskPrompt(t *testing.T) {
+	task := &TaskInfo{
+		ID:          "AZDO-123",
+		Title:       "Fix the bug",
+		Description: "The bug causes issues when...\n\n### Acceptance Criteria\n- [ ] Fix the issue\n- [ ] Add tests",
+		Priority:    PriorityHigh,
+		WorkItemURL: "https://dev.azure.com/org/proj/_workitems/edit/123",
+	}
+
+	prompt := BuildTaskPrompt(task)
+
+	// Check that key components are present
+	if !strings.Contains(prompt, "# Task: Fix the bug") {
+		t.Error("prompt should contain task title")
+	}
+
+	if !strings.Contains(prompt, "**Work Item**:") {
+		t.Error("prompt should contain work item link")
+	}
+
+	if !strings.Contains(prompt, "**Priority**: High") {
+		t.Error("prompt should contain priority")
+	}
+
+	if !strings.Contains(prompt, "## Description") {
+		t.Error("prompt should contain description section")
+	}
+
+	if !strings.Contains(prompt, "## Acceptance Criteria") {
+		t.Error("prompt should contain acceptance criteria section")
+	}
+
+	if !strings.Contains(prompt, "## Requirements") {
+		t.Error("prompt should contain requirements section")
+	}
+
+	if !strings.Contains(prompt, "Write tests for new functionality") {
+		t.Error("prompt should contain standard requirements")
+	}
+}
+
+func TestBuildTaskPromptMinimal(t *testing.T) {
+	task := &TaskInfo{
+		ID:          "AZDO-1",
+		Title:       "Simple task",
+		Description: "",
+		Priority:    PriorityNone,
+		WorkItemURL: "https://example.com/1",
+	}
+
+	prompt := BuildTaskPrompt(task)
+
+	if !strings.Contains(prompt, "# Task: Simple task") {
+		t.Error("prompt should contain task title")
+	}
+
+	if !strings.Contains(prompt, "No Priority") {
+		t.Error("prompt should show no priority")
+	}
+
+	// Should still have requirements even with minimal info
+	if !strings.Contains(prompt, "## Requirements") {
+		t.Error("prompt should contain requirements section")
+	}
+}

--- a/internal/adapters/azuredevops/merger.go
+++ b/internal/adapters/azuredevops/merger.go
@@ -1,0 +1,236 @@
+package azuredevops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// MergeWaitResult represents the outcome of waiting for a PR to merge
+type MergeWaitResult struct {
+	Merged       bool   // PR was successfully completed (merged)
+	Abandoned    bool   // PR was abandoned without merging
+	HasConflicts bool   // PR has merge conflicts
+	TimedOut     bool   // Wait timed out
+	PRNumber     int    // The PR ID
+	PRURL        string // The PR URL
+	Message      string // Human-readable status message
+}
+
+// MergeWaiterConfig holds configuration for the merge waiter
+type MergeWaiterConfig struct {
+	PollInterval time.Duration // How often to check PR status
+	Timeout      time.Duration // Max time to wait for merge
+}
+
+// DefaultMergeWaiterConfig returns sensible defaults
+func DefaultMergeWaiterConfig() *MergeWaiterConfig {
+	return &MergeWaiterConfig{
+		PollInterval: 30 * time.Second,
+		Timeout:      1 * time.Hour,
+	}
+}
+
+// MergeWaiter waits for a PR to be merged
+type MergeWaiter struct {
+	client *Client
+	config *MergeWaiterConfig
+	logger *slog.Logger
+}
+
+// NewMergeWaiter creates a new merge waiter
+func NewMergeWaiter(client *Client, config *MergeWaiterConfig) *MergeWaiter {
+	if config == nil {
+		config = DefaultMergeWaiterConfig()
+	}
+	return &MergeWaiter{
+		client: client,
+		config: config,
+		logger: logging.WithComponent("azuredevops-merge-waiter"),
+	}
+}
+
+// Common errors
+var (
+	ErrPRAbandoned    = errors.New("PR was abandoned without merging")
+	ErrPRConflict     = errors.New("PR has merge conflicts")
+	ErrMergeTimeout   = errors.New("timed out waiting for PR merge")
+)
+
+// WaitForMerge polls the PR status until it's merged, abandoned, or times out
+func (m *MergeWaiter) WaitForMerge(ctx context.Context, prID int) (*MergeWaitResult, error) {
+	m.logger.Info("Waiting for PR merge",
+		slog.Int("pr_id", prID),
+		slog.Duration("timeout", m.config.Timeout),
+		slog.Duration("poll_interval", m.config.PollInterval),
+	)
+
+	deadline := time.Now().Add(m.config.Timeout)
+	ticker := time.NewTicker(m.config.PollInterval)
+	defer ticker.Stop()
+
+	// Check immediately, then on ticker
+	for {
+		result, err := m.checkPRStatus(ctx, prID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check PR status: %w", err)
+		}
+
+		// If we have a terminal state, return
+		if result.Merged || result.Abandoned || result.HasConflicts {
+			return result, nil
+		}
+
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			return &MergeWaitResult{
+				PRNumber: prID,
+				Message:  "Context cancelled while waiting for merge",
+			}, ctx.Err()
+		default:
+		}
+
+		// Check timeout
+		if time.Now().After(deadline) {
+			m.logger.Warn("PR merge timed out",
+				slog.Int("pr_id", prID),
+				slog.Duration("timeout", m.config.Timeout),
+			)
+			return &MergeWaitResult{
+				PRNumber: prID,
+				TimedOut: true,
+				Message:  fmt.Sprintf("Timed out waiting for PR #%d to merge after %s", prID, m.config.Timeout),
+			}, ErrMergeTimeout
+		}
+
+		// Wait for next tick
+		select {
+		case <-ctx.Done():
+			return &MergeWaitResult{
+				PRNumber: prID,
+				Message:  "Context cancelled while waiting for merge",
+			}, ctx.Err()
+		case <-ticker.C:
+			m.logger.Debug("Polling PR status",
+				slog.Int("pr_id", prID),
+				slog.Duration("remaining", time.Until(deadline)),
+			)
+		}
+	}
+}
+
+// checkPRStatus fetches and interprets the current PR status
+func (m *MergeWaiter) checkPRStatus(ctx context.Context, prID int) (*MergeWaitResult, error) {
+	pr, err := m.client.GetPullRequest(ctx, prID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &MergeWaitResult{
+		PRNumber: prID,
+		PRURL:    m.client.GetPullRequestWebURL(prID),
+	}
+
+	// Check if completed (merged)
+	if pr.Status == PRStateCompleted {
+		m.logger.Info("PR merged successfully",
+			slog.Int("pr_id", prID),
+		)
+		result.Merged = true
+		result.Message = fmt.Sprintf("PR #%d was merged", prID)
+		return result, nil
+	}
+
+	// Check if abandoned without merge
+	if pr.Status == PRStateAbandoned {
+		m.logger.Warn("PR abandoned without merging",
+			slog.Int("pr_id", prID),
+		)
+		result.Abandoned = true
+		result.Message = fmt.Sprintf("PR #%d was abandoned without merging", prID)
+		return result, nil
+	}
+
+	// Check for merge conflicts
+	if pr.MergeStatus == MergeStatusConflicts {
+		m.logger.Warn("PR has merge conflicts",
+			slog.Int("pr_id", prID),
+		)
+		result.HasConflicts = true
+		result.Message = fmt.Sprintf("PR #%d has merge conflicts", prID)
+		return result, nil
+	}
+
+	// Still active
+	switch pr.MergeStatus {
+	case MergeStatusQueued:
+		result.Message = fmt.Sprintf("PR #%d merge is queued", prID)
+	case MergeStatusFailure:
+		result.Message = fmt.Sprintf("PR #%d merge failed (checks not passing)", prID)
+	default:
+		result.Message = fmt.Sprintf("PR #%d is active, waiting for merge...", prID)
+	}
+
+	return result, nil
+}
+
+// WaitWithCallback is like WaitForMerge but calls the callback on each poll
+// This allows the caller to update UI or logs with current status
+func (m *MergeWaiter) WaitWithCallback(ctx context.Context, prID int, onPoll func(result *MergeWaitResult)) (*MergeWaitResult, error) {
+	m.logger.Info("Waiting for PR merge with callback",
+		slog.Int("pr_id", prID),
+	)
+
+	deadline := time.Now().Add(m.config.Timeout)
+	ticker := time.NewTicker(m.config.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		result, err := m.checkPRStatus(ctx, prID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check PR status: %w", err)
+		}
+
+		// Call the callback with current status
+		if onPoll != nil {
+			onPoll(result)
+		}
+
+		// If we have a terminal state, return
+		if result.Merged || result.Abandoned || result.HasConflicts {
+			return result, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return &MergeWaitResult{
+				PRNumber: prID,
+				Message:  "Context cancelled",
+			}, ctx.Err()
+		default:
+		}
+
+		if time.Now().After(deadline) {
+			return &MergeWaitResult{
+				PRNumber: prID,
+				TimedOut: true,
+				Message:  fmt.Sprintf("Timed out after %s", m.config.Timeout),
+			}, ErrMergeTimeout
+		}
+
+		select {
+		case <-ctx.Done():
+			return &MergeWaitResult{
+				PRNumber: prID,
+				Message:  "Context cancelled",
+			}, ctx.Err()
+		case <-ticker.C:
+			// Continue polling
+		}
+	}
+}

--- a/internal/adapters/azuredevops/merger_test.go
+++ b/internal/adapters/azuredevops/merger_test.go
@@ -1,0 +1,318 @@
+package azuredevops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestDefaultMergeWaiterConfig(t *testing.T) {
+	config := DefaultMergeWaiterConfig()
+
+	if config.PollInterval != 30*time.Second {
+		t.Errorf("expected PollInterval 30s, got %v", config.PollInterval)
+	}
+
+	if config.Timeout != 1*time.Hour {
+		t.Errorf("expected Timeout 1h, got %v", config.Timeout)
+	}
+}
+
+func TestNewMergeWaiter(t *testing.T) {
+	client := NewClient(testutil.FakeAzureDevOpsPAT, "org", "project")
+
+	// With nil config
+	waiter := NewMergeWaiter(client, nil)
+	if waiter.config.PollInterval != 30*time.Second {
+		t.Error("expected default config when nil passed")
+	}
+
+	// With custom config
+	customConfig := &MergeWaiterConfig{
+		PollInterval: 10 * time.Second,
+		Timeout:      30 * time.Minute,
+	}
+	waiter = NewMergeWaiter(client, customConfig)
+	if waiter.config.PollInterval != 10*time.Second {
+		t.Error("expected custom poll interval")
+	}
+}
+
+func TestMergeWaiterCheckPRStatusMerged(t *testing.T) {
+	pr := PullRequest{
+		PullRequestID: 42,
+		Status:        PRStateCompleted,
+		MergeStatus:   MergeStatusSucceeded,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	waiter := NewMergeWaiter(client, DefaultMergeWaiterConfig())
+
+	ctx := context.Background()
+	result, err := waiter.checkPRStatus(ctx, 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.Merged {
+		t.Error("expected Merged to be true")
+	}
+	if result.Abandoned {
+		t.Error("expected Abandoned to be false")
+	}
+	if result.HasConflicts {
+		t.Error("expected HasConflicts to be false")
+	}
+}
+
+func TestMergeWaiterCheckPRStatusAbandoned(t *testing.T) {
+	pr := PullRequest{
+		PullRequestID: 42,
+		Status:        PRStateAbandoned,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	waiter := NewMergeWaiter(client, DefaultMergeWaiterConfig())
+
+	ctx := context.Background()
+	result, err := waiter.checkPRStatus(ctx, 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Merged {
+		t.Error("expected Merged to be false")
+	}
+	if !result.Abandoned {
+		t.Error("expected Abandoned to be true")
+	}
+}
+
+func TestMergeWaiterCheckPRStatusConflicts(t *testing.T) {
+	pr := PullRequest{
+		PullRequestID: 42,
+		Status:        PRStateActive,
+		MergeStatus:   MergeStatusConflicts,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	waiter := NewMergeWaiter(client, DefaultMergeWaiterConfig())
+
+	ctx := context.Background()
+	result, err := waiter.checkPRStatus(ctx, 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Merged {
+		t.Error("expected Merged to be false")
+	}
+	if !result.HasConflicts {
+		t.Error("expected HasConflicts to be true")
+	}
+}
+
+func TestMergeWaiterCheckPRStatusActive(t *testing.T) {
+	pr := PullRequest{
+		PullRequestID: 42,
+		Status:        PRStateActive,
+		MergeStatus:   MergeStatusQueued,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	waiter := NewMergeWaiter(client, DefaultMergeWaiterConfig())
+
+	ctx := context.Background()
+	result, err := waiter.checkPRStatus(ctx, 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Merged || result.Abandoned || result.HasConflicts {
+		t.Error("expected no terminal state for active PR")
+	}
+
+	if result.Message == "" {
+		t.Error("expected non-empty message")
+	}
+}
+
+func TestMergeWaiterWaitForMergeImmediate(t *testing.T) {
+	// PR is already merged
+	pr := PullRequest{
+		PullRequestID: 42,
+		Status:        PRStateCompleted,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	waiter := NewMergeWaiter(client, &MergeWaiterConfig{
+		PollInterval: 100 * time.Millisecond,
+		Timeout:      5 * time.Second,
+	})
+
+	ctx := context.Background()
+	result, err := waiter.WaitForMerge(ctx, 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.Merged {
+		t.Error("expected Merged to be true")
+	}
+}
+
+func TestMergeWaiterWaitForMergeTimeout(t *testing.T) {
+	// PR stays active (never merges)
+	pr := PullRequest{
+		PullRequestID: 42,
+		Status:        PRStateActive,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	waiter := NewMergeWaiter(client, &MergeWaiterConfig{
+		PollInterval: 50 * time.Millisecond,
+		Timeout:      200 * time.Millisecond,
+	})
+
+	ctx := context.Background()
+	result, err := waiter.WaitForMerge(ctx, 42)
+
+	if err != ErrMergeTimeout {
+		t.Errorf("expected ErrMergeTimeout, got %v", err)
+	}
+
+	if !result.TimedOut {
+		t.Error("expected TimedOut to be true")
+	}
+}
+
+func TestMergeWaiterWaitForMergeContextCancelled(t *testing.T) {
+	// PR stays active
+	pr := PullRequest{
+		PullRequestID: 42,
+		Status:        PRStateActive,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Add a small delay to ensure context cancellation can happen during request
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	waiter := NewMergeWaiter(client, &MergeWaiterConfig{
+		PollInterval: 100 * time.Millisecond,
+		Timeout:      10 * time.Second,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a short delay (during first poll wait)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := waiter.WaitForMerge(ctx, 42)
+
+	// Error should be context.Canceled or contain it (may be wrapped)
+	if err == nil {
+		t.Error("expected error, got nil")
+	} else if err != context.Canceled && !errors.Is(err, context.Canceled) {
+		// Check if it contains "context canceled" in the message (wrapped error)
+		if !strings.Contains(err.Error(), "context canceled") {
+			t.Errorf("expected context cancellation error, got %v", err)
+		}
+	}
+}
+
+func TestMergeWaiterWaitWithCallback(t *testing.T) {
+	callCount := 0
+
+	// First call: active, second call: merged
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		pr := PullRequest{
+			PullRequestID: 42,
+			Status:        PRStateActive,
+		}
+
+		if callCount > 1 {
+			pr.Status = PRStateCompleted
+		}
+
+		_ = json.NewEncoder(w).Encode(pr)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	waiter := NewMergeWaiter(client, &MergeWaiterConfig{
+		PollInterval: 50 * time.Millisecond,
+		Timeout:      5 * time.Second,
+	})
+
+	var callbackCount int
+	callback := func(result *MergeWaitResult) {
+		callbackCount++
+	}
+
+	ctx := context.Background()
+	result, err := waiter.WaitWithCallback(ctx, 42, callback)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.Merged {
+		t.Error("expected Merged to be true")
+	}
+
+	if callbackCount < 2 {
+		t.Errorf("expected at least 2 callback calls, got %d", callbackCount)
+	}
+}

--- a/internal/adapters/azuredevops/notifier.go
+++ b/internal/adapters/azuredevops/notifier.go
@@ -1,0 +1,127 @@
+package azuredevops
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Notifier handles status updates to Azure DevOps work items
+type Notifier struct {
+	client   *Client
+	pilotTag string
+}
+
+// NewNotifier creates a new Azure DevOps notifier
+func NewNotifier(client *Client, pilotTag string) *Notifier {
+	return &Notifier{
+		client:   client,
+		pilotTag: pilotTag,
+	}
+}
+
+// NotifyTaskStarted posts a comment and adds in-progress tag
+func (n *Notifier) NotifyTaskStarted(ctx context.Context, workItemID int, taskID string) error {
+	// Add in-progress tag
+	if err := n.client.AddWorkItemTag(ctx, workItemID, TagInProgress); err != nil {
+		return fmt.Errorf("failed to add in-progress tag: %w", err)
+	}
+
+	// Post comment
+	comment := fmt.Sprintf("🤖 **Pilot started working on this work item**\n\nTask ID: `%s`\n\nI'll post updates as I make progress.", taskID)
+	if _, err := n.client.AddWorkItemComment(ctx, workItemID, comment); err != nil {
+		return fmt.Errorf("failed to add start comment: %w", err)
+	}
+
+	return nil
+}
+
+// NotifyProgress posts a progress update comment
+func (n *Notifier) NotifyProgress(ctx context.Context, workItemID int, phase string, details string) error {
+	var emoji string
+	switch strings.ToLower(phase) {
+	case "exploring", "research":
+		emoji = "🔍"
+	case "implementing", "impl":
+		emoji = "🔨"
+	case "testing", "verify":
+		emoji = "🧪"
+	case "committing":
+		emoji = "📝"
+	default:
+		emoji = "⏳"
+	}
+
+	comment := fmt.Sprintf("%s **Phase: %s**\n\n%s", emoji, phase, details)
+	if _, err := n.client.AddWorkItemComment(ctx, workItemID, comment); err != nil {
+		return fmt.Errorf("failed to add progress comment: %w", err)
+	}
+
+	return nil
+}
+
+// NotifyTaskCompleted posts completion comment and updates tags
+func (n *Notifier) NotifyTaskCompleted(ctx context.Context, workItemID int, prURL string, summary string) error {
+	// Remove in-progress tag (best-effort, non-critical)
+	// Tag may not exist if task started before tagging was added
+	_ = n.client.RemoveWorkItemTag(ctx, workItemID, TagInProgress)
+
+	// Remove pilot trigger tag (best-effort, non-critical)
+	_ = n.client.RemoveWorkItemTag(ctx, workItemID, n.pilotTag)
+
+	// Add done tag
+	if err := n.client.AddWorkItemTag(ctx, workItemID, TagDone); err != nil {
+		return fmt.Errorf("failed to add done tag: %w", err)
+	}
+
+	// Post completion comment
+	var comment strings.Builder
+	comment.WriteString("✅ **Pilot completed this task!**\n\n")
+
+	if prURL != "" {
+		comment.WriteString(fmt.Sprintf("**Pull Request**: %s\n\n", prURL))
+	}
+
+	if summary != "" {
+		comment.WriteString("**Summary**:\n")
+		comment.WriteString(summary)
+		comment.WriteString("\n\n")
+	}
+
+	comment.WriteString("_This work item will be resolved when the PR is merged._")
+
+	if _, err := n.client.AddWorkItemComment(ctx, workItemID, comment.String()); err != nil {
+		return fmt.Errorf("failed to add completion comment: %w", err)
+	}
+
+	return nil
+}
+
+// NotifyTaskFailed posts failure comment and updates tags
+func (n *Notifier) NotifyTaskFailed(ctx context.Context, workItemID int, reason string) error {
+	// Remove in-progress tag (best-effort, non-critical)
+	_ = n.client.RemoveWorkItemTag(ctx, workItemID, TagInProgress)
+
+	// Add failed tag
+	if err := n.client.AddWorkItemTag(ctx, workItemID, TagFailed); err != nil {
+		return fmt.Errorf("failed to add failed tag: %w", err)
+	}
+
+	// Post failure comment
+	comment := fmt.Sprintf("❌ **Pilot could not complete this task**\n\n**Reason**: %s\n\n_Please review the work item and consider manual intervention or reopening with more details._", reason)
+	if _, err := n.client.AddWorkItemComment(ctx, workItemID, comment); err != nil {
+		return fmt.Errorf("failed to add failure comment: %w", err)
+	}
+
+	return nil
+}
+
+// LinkPR adds a comment linking the created PR
+func (n *Notifier) LinkPR(ctx context.Context, workItemID int, prID int, prURL string) error {
+	comment := fmt.Sprintf("🔗 **Pull Request Created**: #%d\n\n%s\n\n_This PR implements the changes for this work item._", prID, prURL)
+	if _, err := n.client.AddWorkItemComment(ctx, workItemID, comment); err != nil {
+		return fmt.Errorf("failed to add PR link comment: %w", err)
+	}
+
+	return nil
+}

--- a/internal/adapters/azuredevops/poller.go
+++ b/internal/adapters/azuredevops/poller.go
@@ -1,0 +1,483 @@
+package azuredevops
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// ExecutionMode determines how work items are processed
+type ExecutionMode string
+
+const (
+	// ExecutionModeSequential processes one work item at a time, waiting for PR merge
+	ExecutionModeSequential ExecutionMode = "sequential"
+	// ExecutionModeParallel processes work items concurrently (legacy behavior)
+	ExecutionModeParallel ExecutionMode = "parallel"
+)
+
+// WorkItemResult is returned by the work item handler with PR information
+type WorkItemResult struct {
+	Success  bool
+	PRNumber int    // PR ID if created
+	PRURL    string // PR URL if created
+	HeadSHA  string // Head commit SHA of the PR
+	Error    error
+}
+
+// Poller polls Azure DevOps for work items with a specific tag
+type Poller struct {
+	client    *Client
+	tag       string
+	interval  time.Duration
+	processed map[int]bool
+	mu        sync.RWMutex
+	onWorkItem   func(ctx context.Context, wi *WorkItem) error
+	// onWorkItemWithResult is called for sequential mode, returns PR info
+	onWorkItemWithResult func(ctx context.Context, wi *WorkItem) (*WorkItemResult, error)
+	// OnPRCreated is called when a PR is created after work item processing
+	// Parameters: prID, prURL, workItemID, headSHA
+	OnPRCreated func(prID int, prURL string, workItemID int, headSHA string)
+	logger      *slog.Logger
+
+	// Work item filtering
+	workItemTypes []string
+
+	// Sequential mode configuration
+	executionMode  ExecutionMode
+	mergeWaiter    *MergeWaiter
+	waitForMerge   bool
+	prTimeout      time.Duration
+	prPollInterval time.Duration
+}
+
+// PollerOption configures a Poller
+type PollerOption func(*Poller)
+
+// WithPollerLogger sets the logger for the poller
+func WithPollerLogger(logger *slog.Logger) PollerOption {
+	return func(p *Poller) {
+		p.logger = logger
+	}
+}
+
+// WithOnWorkItem sets the callback for new work items (parallel mode)
+func WithOnWorkItem(fn func(ctx context.Context, wi *WorkItem) error) PollerOption {
+	return func(p *Poller) {
+		p.onWorkItem = fn
+	}
+}
+
+// WithOnWorkItemWithResult sets the callback for new work items that returns PR info (sequential mode)
+func WithOnWorkItemWithResult(fn func(ctx context.Context, wi *WorkItem) (*WorkItemResult, error)) PollerOption {
+	return func(p *Poller) {
+		p.onWorkItemWithResult = fn
+	}
+}
+
+// WithExecutionMode sets the execution mode (sequential or parallel)
+func WithExecutionMode(mode ExecutionMode) PollerOption {
+	return func(p *Poller) {
+		p.executionMode = mode
+	}
+}
+
+// WithSequentialConfig configures sequential execution settings
+func WithSequentialConfig(waitForMerge bool, pollInterval, timeout time.Duration) PollerOption {
+	return func(p *Poller) {
+		p.waitForMerge = waitForMerge
+		p.prPollInterval = pollInterval
+		p.prTimeout = timeout
+	}
+}
+
+// WithOnPRCreated sets the callback for PR creation events
+func WithOnPRCreated(fn func(prID int, prURL string, workItemID int, headSHA string)) PollerOption {
+	return func(p *Poller) {
+		p.OnPRCreated = fn
+	}
+}
+
+// WithWorkItemTypes sets the work item types to filter
+func WithWorkItemTypes(types []string) PollerOption {
+	return func(p *Poller) {
+		p.workItemTypes = types
+	}
+}
+
+// NewPoller creates a new Azure DevOps work item poller
+func NewPoller(client *Client, tag string, interval time.Duration, opts ...PollerOption) *Poller {
+	p := &Poller{
+		client:         client,
+		tag:            tag,
+		interval:       interval,
+		processed:      make(map[int]bool),
+		logger:         logging.WithComponent("azuredevops-poller"),
+		executionMode:  ExecutionModeParallel, // Default for backward compatibility
+		waitForMerge:   true,
+		prPollInterval: 30 * time.Second,
+		prTimeout:      1 * time.Hour,
+		workItemTypes:  []string{"Bug", "Task", "User Story"},
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	// Create merge waiter if in sequential mode
+	if p.executionMode == ExecutionModeSequential && p.waitForMerge {
+		p.mergeWaiter = NewMergeWaiter(client, &MergeWaiterConfig{
+			PollInterval: p.prPollInterval,
+			Timeout:      p.prTimeout,
+		})
+	}
+
+	return p
+}
+
+// Start begins polling for work items
+func (p *Poller) Start(ctx context.Context) {
+	p.logger.Info("Starting Azure DevOps poller",
+		slog.String("tag", p.tag),
+		slog.Duration("interval", p.interval),
+		slog.String("mode", string(p.executionMode)),
+	)
+
+	if p.executionMode == ExecutionModeSequential {
+		p.startSequential(ctx)
+	} else {
+		p.startParallel(ctx)
+	}
+}
+
+// startParallel runs the legacy parallel execution mode
+func (p *Poller) startParallel(ctx context.Context) {
+	// Do an initial check immediately
+	p.checkForNewWorkItems(ctx)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("Azure DevOps poller stopped")
+			return
+		case <-ticker.C:
+			p.checkForNewWorkItems(ctx)
+		}
+	}
+}
+
+// startSequential runs the sequential execution mode
+// Processes one work item at a time, waits for PR merge before next
+func (p *Poller) startSequential(ctx context.Context) {
+	p.logger.Info("Running in sequential mode",
+		slog.Bool("wait_for_merge", p.waitForMerge),
+		slog.Duration("pr_timeout", p.prTimeout),
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("Sequential poller stopped")
+			return
+		default:
+		}
+
+		// Find oldest unprocessed work item
+		wi, err := p.findOldestUnprocessedWorkItem(ctx)
+		if err != nil {
+			p.logger.Warn("Failed to find work items", slog.Any("error", err))
+			time.Sleep(p.interval)
+			continue
+		}
+
+		if wi == nil {
+			// No work items to process, wait before checking again
+			p.logger.Debug("No unprocessed work items found, waiting...")
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(p.interval):
+				continue
+			}
+		}
+
+		// Process the work item
+		p.logger.Info("Processing work item in sequential mode",
+			slog.Int("id", wi.ID),
+			slog.String("title", wi.GetTitle()),
+		)
+
+		result, err := p.processWorkItemSequential(ctx, wi)
+		if err != nil {
+			p.logger.Error("Failed to process work item",
+				slog.Int("id", wi.ID),
+				slog.Any("error", err),
+			)
+			// Mark as processed to avoid infinite retry loop
+			// The work item will have pilot-failed tag
+			p.markProcessed(wi.ID)
+			continue
+		}
+
+		// Notify autopilot controller of new PR (if callback registered)
+		if result != nil && result.PRNumber > 0 && p.OnPRCreated != nil {
+			p.logger.Info("Notifying autopilot of PR creation",
+				slog.Int("pr_id", result.PRNumber),
+				slog.Int("work_item_id", wi.ID),
+			)
+			p.OnPRCreated(result.PRNumber, result.PRURL, wi.ID, result.HeadSHA)
+		}
+
+		// If we created a PR and should wait for merge
+		if result != nil && result.PRNumber > 0 && p.waitForMerge && p.mergeWaiter != nil {
+			p.logger.Info("Waiting for PR merge before next work item",
+				slog.Int("pr_id", result.PRNumber),
+				slog.String("pr_url", result.PRURL),
+			)
+
+			mergeResult, err := p.mergeWaiter.WaitWithCallback(ctx, result.PRNumber, func(r *MergeWaitResult) {
+				p.logger.Debug("PR status check",
+					slog.Int("pr_id", r.PRNumber),
+					slog.String("status", r.Message),
+				)
+			})
+
+			if err != nil {
+				p.logger.Warn("Error waiting for PR merge, pausing sequential processing",
+					slog.Int("pr_id", result.PRNumber),
+					slog.Any("error", err),
+				)
+				// DON'T mark as processed - leave for retry after fix
+				time.Sleep(5 * time.Minute)
+				continue
+			}
+
+			p.logger.Info("PR merge wait completed",
+				slog.Int("pr_id", result.PRNumber),
+				slog.Bool("merged", mergeResult.Merged),
+				slog.Bool("abandoned", mergeResult.Abandoned),
+				slog.Bool("has_conflicts", mergeResult.HasConflicts),
+				slog.Bool("timed_out", mergeResult.TimedOut),
+			)
+
+			// Check if PR has conflicts - stop processing
+			if mergeResult.HasConflicts {
+				p.logger.Warn("PR has conflicts, pausing sequential processing",
+					slog.Int("pr_id", result.PRNumber),
+					slog.String("pr_url", result.PRURL),
+				)
+				// DON'T mark as processed - needs manual resolution or rebase
+				time.Sleep(5 * time.Minute)
+				continue
+			}
+
+			// Check if PR timed out
+			if mergeResult.TimedOut {
+				p.logger.Warn("PR merge timed out, pausing sequential processing",
+					slog.Int("pr_id", result.PRNumber),
+					slog.String("pr_url", result.PRURL),
+				)
+				// DON'T mark as processed - needs investigation
+				time.Sleep(5 * time.Minute)
+				continue
+			}
+
+			// Only mark as processed if actually merged
+			if mergeResult.Merged {
+				p.markProcessed(wi.ID)
+				continue
+			}
+
+			// PR was abandoned without merge
+			if mergeResult.Abandoned {
+				p.logger.Info("PR was abandoned without merge",
+					slog.Int("pr_id", result.PRNumber),
+				)
+				// DON'T mark as processed - work item may need re-execution
+				continue
+			}
+		}
+
+		// Direct commit case: no PR to wait for, proceed to next work item
+		if result != nil && result.Success && result.PRNumber == 0 {
+			p.logger.Info("Direct commit completed, proceeding to next work item",
+				slog.Int("work_item_id", wi.ID),
+				slog.String("commit_sha", result.HeadSHA),
+			)
+			p.markProcessed(wi.ID)
+			continue
+		}
+
+		// PR was created but we're not waiting for merge, or no PR was created
+		p.markProcessed(wi.ID)
+	}
+}
+
+// findOldestUnprocessedWorkItem finds the oldest work item with the pilot tag
+// that hasn't been processed yet
+func (p *Poller) findOldestUnprocessedWorkItem(ctx context.Context) (*WorkItem, error) {
+	workItems, err := p.client.ListWorkItems(ctx, &ListWorkItemsOptions{
+		Tags:          []string{p.tag},
+		States:        []string{StateNew, StateActive},
+		WorkItemTypes: p.workItemTypes,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out already processed and in-progress work items
+	var candidates []*WorkItem
+	for _, wi := range workItems {
+		p.mu.RLock()
+		processed := p.processed[wi.ID]
+		p.mu.RUnlock()
+
+		if processed {
+			continue
+		}
+
+		if HasTag(wi, TagInProgress) || HasTag(wi, TagDone) {
+			continue
+		}
+
+		candidates = append(candidates, wi)
+	}
+
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	// Sort by creation date (oldest first)
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].GetCreatedDate().Before(candidates[j].GetCreatedDate())
+	})
+
+	return candidates[0], nil
+}
+
+// processWorkItemSequential processes a single work item and returns PR info
+func (p *Poller) processWorkItemSequential(ctx context.Context, wi *WorkItem) (*WorkItemResult, error) {
+	// Use the new callback if available
+	if p.onWorkItemWithResult != nil {
+		return p.onWorkItemWithResult(ctx, wi)
+	}
+
+	// Fall back to legacy callback
+	if p.onWorkItem != nil {
+		err := p.onWorkItem(ctx, wi)
+		if err != nil {
+			return &WorkItemResult{Success: false, Error: err}, err
+		}
+		return &WorkItemResult{Success: true}, nil
+	}
+
+	return nil, fmt.Errorf("no work item handler configured")
+}
+
+// checkForNewWorkItems fetches work items and processes new ones (parallel mode)
+func (p *Poller) checkForNewWorkItems(ctx context.Context) {
+	workItems, err := p.client.ListWorkItems(ctx, &ListWorkItemsOptions{
+		Tags:          []string{p.tag},
+		States:        []string{StateNew, StateActive},
+		WorkItemTypes: p.workItemTypes,
+	})
+	if err != nil {
+		p.logger.Warn("Failed to fetch work items", slog.Any("error", err))
+		return
+	}
+
+	for _, wi := range workItems {
+		// Skip if already processed
+		p.mu.RLock()
+		processed := p.processed[wi.ID]
+		p.mu.RUnlock()
+
+		if processed {
+			continue
+		}
+
+		// Skip if already in progress or done
+		if HasTag(wi, TagInProgress) || HasTag(wi, TagDone) {
+			p.markProcessed(wi.ID)
+			continue
+		}
+
+		// Process the work item
+		p.logger.Info("Found new work item",
+			slog.Int("id", wi.ID),
+			slog.String("title", wi.GetTitle()),
+		)
+
+		if p.onWorkItem != nil {
+			if err := p.onWorkItem(ctx, wi); err != nil {
+				p.logger.Error("Failed to process work item",
+					slog.Int("id", wi.ID),
+					slog.Any("error", err),
+				)
+				// Don't mark as processed so we can retry
+				continue
+			}
+		}
+
+		p.markProcessed(wi.ID)
+	}
+}
+
+// markProcessed marks a work item as processed
+func (p *Poller) markProcessed(id int) {
+	p.mu.Lock()
+	p.processed[id] = true
+	p.mu.Unlock()
+}
+
+// IsProcessed checks if a work item has been processed
+func (p *Poller) IsProcessed(id int) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.processed[id]
+}
+
+// ProcessedCount returns the number of processed work items
+func (p *Poller) ProcessedCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.processed)
+}
+
+// Reset clears the processed work items map
+func (p *Poller) Reset() {
+	p.mu.Lock()
+	p.processed = make(map[int]bool)
+	p.mu.Unlock()
+}
+
+// ExtractPRNumber extracts PR ID from an Azure DevOps PR URL
+// e.g., "https://dev.azure.com/org/project/_git/repo/pullrequest/123" -> 123
+func ExtractPRNumber(prURL string) (int, error) {
+	if prURL == "" {
+		return 0, fmt.Errorf("empty PR URL")
+	}
+
+	// Match pattern: /pullrequest/123
+	re := regexp.MustCompile(`/pullrequest/(\d+)`)
+	matches := re.FindStringSubmatch(prURL)
+	if len(matches) < 2 {
+		return 0, fmt.Errorf("could not extract PR number from URL: %s", prURL)
+	}
+
+	var num int
+	if _, err := fmt.Sscanf(matches[1], "%d", &num); err != nil {
+		return 0, fmt.Errorf("invalid PR number in URL: %s", prURL)
+	}
+
+	return num, nil
+}

--- a/internal/adapters/azuredevops/poller_test.go
+++ b/internal/adapters/azuredevops/poller_test.go
@@ -1,0 +1,261 @@
+package azuredevops
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestNewPoller(t *testing.T) {
+	client := NewClient(testutil.FakeAzureDevOpsPAT, "org", "project")
+	poller := NewPoller(client, "pilot", 30*time.Second)
+
+	if poller.tag != "pilot" {
+		t.Errorf("expected tag 'pilot', got '%s'", poller.tag)
+	}
+
+	if poller.interval != 30*time.Second {
+		t.Errorf("expected interval 30s, got %v", poller.interval)
+	}
+
+	if poller.executionMode != ExecutionModeParallel {
+		t.Errorf("expected default mode parallel, got %s", poller.executionMode)
+	}
+
+	if !poller.waitForMerge {
+		t.Error("expected waitForMerge to be true by default")
+	}
+}
+
+func TestPollerWithOptions(t *testing.T) {
+	client := NewClient(testutil.FakeAzureDevOpsPAT, "org", "project")
+
+	handler := func(ctx context.Context, wi *WorkItem) error {
+		return nil
+	}
+
+	poller := NewPoller(client, "pilot", 30*time.Second,
+		WithOnWorkItem(handler),
+		WithExecutionMode(ExecutionModeSequential),
+		WithSequentialConfig(false, 10*time.Second, 30*time.Minute),
+		WithWorkItemTypes([]string{"Bug", "Task"}),
+	)
+
+	if poller.executionMode != ExecutionModeSequential {
+		t.Errorf("expected mode sequential, got %s", poller.executionMode)
+	}
+
+	if poller.waitForMerge {
+		t.Error("expected waitForMerge to be false")
+	}
+
+	if poller.prPollInterval != 10*time.Second {
+		t.Errorf("expected prPollInterval 10s, got %v", poller.prPollInterval)
+	}
+
+	if poller.prTimeout != 30*time.Minute {
+		t.Errorf("expected prTimeout 30m, got %v", poller.prTimeout)
+	}
+
+	if len(poller.workItemTypes) != 2 {
+		t.Errorf("expected 2 work item types, got %d", len(poller.workItemTypes))
+	}
+
+	// Test handler is set
+	if poller.onWorkItem == nil {
+		t.Error("expected onWorkItem handler to be set")
+	}
+}
+
+func TestPollerMarkProcessed(t *testing.T) {
+	client := NewClient(testutil.FakeAzureDevOpsPAT, "org", "project")
+	poller := NewPoller(client, "pilot", 30*time.Second)
+
+	if poller.IsProcessed(123) {
+		t.Error("expected 123 NOT to be processed initially")
+	}
+
+	poller.markProcessed(123)
+
+	if !poller.IsProcessed(123) {
+		t.Error("expected 123 to be processed after marking")
+	}
+
+	if poller.ProcessedCount() != 1 {
+		t.Errorf("expected processed count 1, got %d", poller.ProcessedCount())
+	}
+
+	poller.Reset()
+
+	if poller.IsProcessed(123) {
+		t.Error("expected 123 NOT to be processed after reset")
+	}
+
+	if poller.ProcessedCount() != 0 {
+		t.Errorf("expected processed count 0 after reset, got %d", poller.ProcessedCount())
+	}
+}
+
+func TestPollerFindOldestUnprocessedWorkItem(t *testing.T) {
+	// Create mock server
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		if callCount == 1 {
+			// WIQL query
+			wiqlResult := WIQLQueryResult{
+				WorkItems: []WIQLWorkItemRef{
+					{ID: 1},
+					{ID: 2},
+					{ID: 3},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(wiqlResult)
+		} else {
+			// Work items batch
+			workItems := struct {
+				Count int         `json:"count"`
+				Value []*WorkItem `json:"value"`
+			}{
+				Count: 3,
+				Value: []*WorkItem{
+					{
+						ID:     1,
+						Fields: map[string]interface{}{
+							"System.Title":       "First (oldest)",
+							"System.CreatedDate": "2024-01-01T10:00:00Z",
+							"System.Tags":        "pilot",
+						},
+					},
+					{
+						ID:     2,
+						Fields: map[string]interface{}{
+							"System.Title":       "Second",
+							"System.CreatedDate": "2024-01-02T10:00:00Z",
+							"System.Tags":        "pilot; pilot-in-progress", // Already in progress
+						},
+					},
+					{
+						ID:     3,
+						Fields: map[string]interface{}{
+							"System.Title":       "Third",
+							"System.CreatedDate": "2024-01-03T10:00:00Z",
+							"System.Tags":        "pilot",
+						},
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(workItems)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	poller := NewPoller(client, "pilot", 30*time.Second)
+
+	ctx := context.Background()
+	wi, err := poller.findOldestUnprocessedWorkItem(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if wi == nil {
+		t.Fatal("expected to find a work item")
+	}
+
+	// Should find ID 1 (oldest that's not in progress)
+	if wi.ID != 1 {
+		t.Errorf("expected oldest unprocessed work item ID 1, got %d", wi.ID)
+	}
+}
+
+func TestPollerFindOldestUnprocessedWorkItemNone(t *testing.T) {
+	// Create mock server with no work items
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		if callCount == 1 {
+			// Empty WIQL result
+			wiqlResult := WIQLQueryResult{
+				WorkItems: []WIQLWorkItemRef{},
+			}
+			_ = json.NewEncoder(w).Encode(wiqlResult)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	poller := NewPoller(client, "pilot", 30*time.Second)
+
+	ctx := context.Background()
+	wi, err := poller.findOldestUnprocessedWorkItem(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if wi != nil {
+		t.Errorf("expected nil when no work items, got ID %d", wi.ID)
+	}
+}
+
+func TestExtractPRNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected int
+		wantErr  bool
+	}{
+		{
+			name:     "valid PR URL",
+			url:      "https://dev.azure.com/org/project/_git/repo/pullrequest/123",
+			expected: 123,
+			wantErr:  false,
+		},
+		{
+			name:     "PR URL with trailing slash",
+			url:      "https://dev.azure.com/org/project/_git/repo/pullrequest/456/",
+			expected: 456,
+			wantErr:  false,
+		},
+		{
+			name:     "empty URL",
+			url:      "",
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "URL without PR number",
+			url:      "https://dev.azure.com/org/project/_git/repo",
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid URL format",
+			url:      "not a url",
+			expected: 0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ExtractPRNumber(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExtractPRNumber() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("ExtractPRNumber() = %d, expected %d", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/adapters/azuredevops/types.go
+++ b/internal/adapters/azuredevops/types.go
@@ -1,0 +1,491 @@
+package azuredevops
+
+import "time"
+
+// Config holds Azure DevOps adapter configuration
+type Config struct {
+	Enabled           bool                     `yaml:"enabled"`
+	PAT               string                   `yaml:"pat"`              // Personal Access Token
+	Organization      string                   `yaml:"organization"`     // Azure DevOps org name
+	Project           string                   `yaml:"project"`          // Project name
+	Repository        string                   `yaml:"repository"`       // Repository name (optional, defaults to project)
+	BaseURL           string                   `yaml:"base_url"`         // Default: https://dev.azure.com
+	WebhookSecret     string                   `yaml:"webhook_secret"`   // For basic auth on webhook endpoint
+	PilotTag          string                   `yaml:"pilot_tag"`        // Tag to watch (Azure uses tags, not labels)
+	WorkItemTypes     []string                 `yaml:"work_item_types"`  // e.g., ["Bug", "Task", "User Story"]
+	Polling           *PollingConfig           `yaml:"polling"`
+	StaleLabelCleanup *StaleLabelCleanupConfig `yaml:"stale_label_cleanup"`
+}
+
+// PollingConfig holds Azure DevOps polling settings
+type PollingConfig struct {
+	Enabled  bool          `yaml:"enabled"`
+	Interval time.Duration `yaml:"interval"` // Poll interval (default 30s)
+}
+
+// StaleLabelCleanupConfig holds settings for auto-cleanup of stale pilot-in-progress tags
+type StaleLabelCleanupConfig struct {
+	Enabled   bool          `yaml:"enabled"`
+	Interval  time.Duration `yaml:"interval"`  // How often to check for stale tags (default: 30m)
+	Threshold time.Duration `yaml:"threshold"` // How long before a tag is considered stale (default: 1h)
+}
+
+// DefaultConfig returns default Azure DevOps configuration
+func DefaultConfig() *Config {
+	return &Config{
+		Enabled:  false,
+		BaseURL:  "https://dev.azure.com",
+		PilotTag: "pilot",
+		WorkItemTypes: []string{
+			"Bug",
+			"Task",
+			"User Story",
+		},
+		Polling: &PollingConfig{
+			Enabled:  false,
+			Interval: 30 * time.Second,
+		},
+		StaleLabelCleanup: &StaleLabelCleanupConfig{
+			Enabled:   true,
+			Interval:  30 * time.Minute,
+			Threshold: 1 * time.Hour,
+		},
+	}
+}
+
+// ListWorkItemsOptions holds options for listing work items via WIQL
+type ListWorkItemsOptions struct {
+	Tags          []string
+	States        []string // New, Active, Resolved, Closed
+	WorkItemTypes []string
+	UpdatedAfter  time.Time
+}
+
+// Work item states
+const (
+	StateNew      = "New"
+	StateActive   = "Active"
+	StateResolved = "Resolved"
+	StateClosed   = "Closed"
+)
+
+// Tag names used by Pilot
+const (
+	TagInProgress = "pilot-in-progress"
+	TagDone       = "pilot-done"
+	TagFailed     = "pilot-failed"
+)
+
+// Priority mapping from Azure DevOps priority field
+type Priority int
+
+const (
+	PriorityNone   Priority = 0
+	PriorityUrgent Priority = 1
+	PriorityHigh   Priority = 2
+	PriorityMedium Priority = 3
+	PriorityLow    Priority = 4
+)
+
+// PriorityFromValue converts Azure DevOps priority value to internal Priority
+// Azure DevOps uses numeric priority: 1 = highest, 4 = lowest
+func PriorityFromValue(value int) Priority {
+	switch value {
+	case 1:
+		return PriorityUrgent
+	case 2:
+		return PriorityHigh
+	case 3:
+		return PriorityMedium
+	case 4:
+		return PriorityLow
+	default:
+		return PriorityNone
+	}
+}
+
+// PriorityName returns the human-readable priority name
+func PriorityName(priority Priority) string {
+	switch priority {
+	case PriorityUrgent:
+		return "Urgent"
+	case PriorityHigh:
+		return "High"
+	case PriorityMedium:
+		return "Medium"
+	case PriorityLow:
+		return "Low"
+	default:
+		return "No Priority"
+	}
+}
+
+// Pull request states
+const (
+	PRStateActive    = "active"
+	PRStateCompleted = "completed"
+	PRStateAbandoned = "abandoned"
+)
+
+// Merge status values
+const (
+	MergeStatusSucceeded = "succeeded"
+	MergeStatusConflicts = "conflicts"
+	MergeStatusFailure   = "failure"
+	MergeStatusQueued    = "queued"
+)
+
+// WorkItem represents an Azure DevOps work item
+type WorkItem struct {
+	ID     int                    `json:"id"`
+	Rev    int                    `json:"rev"`
+	Fields map[string]interface{} `json:"fields"`
+	URL    string                 `json:"url"`
+}
+
+// GetTitle returns the work item title
+func (w *WorkItem) GetTitle() string {
+	if title, ok := w.Fields["System.Title"].(string); ok {
+		return title
+	}
+	return ""
+}
+
+// GetDescription returns the work item description (HTML)
+func (w *WorkItem) GetDescription() string {
+	// Azure DevOps stores description in System.Description for Bugs
+	// and in System.Description or Microsoft.VSTS.TCM.ReproSteps for different types
+	if desc, ok := w.Fields["System.Description"].(string); ok {
+		return desc
+	}
+	if desc, ok := w.Fields["Microsoft.VSTS.TCM.ReproSteps"].(string); ok {
+		return desc
+	}
+	return ""
+}
+
+// GetState returns the work item state
+func (w *WorkItem) GetState() string {
+	if state, ok := w.Fields["System.State"].(string); ok {
+		return state
+	}
+	return ""
+}
+
+// GetWorkItemType returns the work item type (Bug, Task, User Story, etc.)
+func (w *WorkItem) GetWorkItemType() string {
+	if wit, ok := w.Fields["System.WorkItemType"].(string); ok {
+		return wit
+	}
+	return ""
+}
+
+// GetTags returns the work item tags as a slice
+// Azure DevOps stores tags as semicolon-separated string
+func (w *WorkItem) GetTags() []string {
+	if tagsStr, ok := w.Fields["System.Tags"].(string); ok && tagsStr != "" {
+		return splitTags(tagsStr)
+	}
+	return nil
+}
+
+// HasTag checks if the work item has a specific tag
+func (w *WorkItem) HasTag(tag string) bool {
+	for _, t := range w.GetTags() {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// GetPriority returns the work item priority as internal Priority type
+func (w *WorkItem) GetPriority() Priority {
+	if priority, ok := w.Fields["Microsoft.VSTS.Common.Priority"].(float64); ok {
+		return PriorityFromValue(int(priority))
+	}
+	return PriorityNone
+}
+
+// GetCreatedDate returns the work item creation date
+func (w *WorkItem) GetCreatedDate() time.Time {
+	if dateStr, ok := w.Fields["System.CreatedDate"].(string); ok {
+		t, _ := time.Parse(time.RFC3339, dateStr)
+		return t
+	}
+	return time.Time{}
+}
+
+// GetChangedDate returns the work item last changed date
+func (w *WorkItem) GetChangedDate() time.Time {
+	if dateStr, ok := w.Fields["System.ChangedDate"].(string); ok {
+		t, _ := time.Parse(time.RFC3339, dateStr)
+		return t
+	}
+	return time.Time{}
+}
+
+// GetWebURL constructs the web URL for the work item
+func (w *WorkItem) GetWebURL(baseURL, organization, project string) string {
+	return baseURL + "/" + organization + "/" + project + "/_workitems/edit/" + string(rune(w.ID))
+}
+
+// PullRequest represents an Azure DevOps pull request
+type PullRequest struct {
+	PullRequestID int       `json:"pullRequestId"`
+	Title         string    `json:"title"`
+	Description   string    `json:"description"`
+	Status        string    `json:"status"` // active, completed, abandoned
+	SourceRefName string    `json:"sourceRefName"`
+	TargetRefName string    `json:"targetRefName"`
+	MergeStatus   string    `json:"mergeStatus"`
+	IsDraft       bool      `json:"isDraft"`
+	CreationDate  time.Time `json:"creationDate"`
+	ClosedDate    time.Time `json:"closedDate,omitempty"`
+	URL           string    `json:"url"`
+	Repository    *GitRepo  `json:"repository,omitempty"`
+	CreatedBy     *Identity `json:"createdBy,omitempty"`
+	MergeID       string    `json:"mergeId,omitempty"`
+	LastMergeSourceCommit *GitCommitRef `json:"lastMergeSourceCommit,omitempty"`
+}
+
+// GitRepo represents a Git repository reference
+type GitRepo struct {
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	URL     string   `json:"url"`
+	Project *Project `json:"project,omitempty"`
+}
+
+// Project represents an Azure DevOps project reference
+type Project struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	URL   string `json:"url"`
+	State string `json:"state"`
+}
+
+// Identity represents an Azure DevOps user identity
+type Identity struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+	UniqueName  string `json:"uniqueName"`
+	URL         string `json:"url"`
+	ImageURL    string `json:"imageUrl,omitempty"`
+}
+
+// GitCommitRef represents a Git commit reference
+type GitCommitRef struct {
+	CommitID string `json:"commitId"`
+	URL      string `json:"url"`
+}
+
+// PullRequestInput is used for creating pull requests
+type PullRequestInput struct {
+	Title         string `json:"title"`
+	Description   string `json:"description,omitempty"`
+	SourceRefName string `json:"sourceRefName"` // refs/heads/branch-name
+	TargetRefName string `json:"targetRefName"` // refs/heads/main
+	IsDraft       bool   `json:"isDraft,omitempty"`
+}
+
+// GitRef represents a Git reference (branch/tag)
+type GitRef struct {
+	Name     string `json:"name"`     // refs/heads/branch-name
+	ObjectID string `json:"objectId"` // Commit SHA
+	URL      string `json:"url"`
+}
+
+// GitRefUpdate is used for creating/updating branches
+type GitRefUpdate struct {
+	Name        string `json:"name"`        // refs/heads/branch-name
+	OldObjectID string `json:"oldObjectId"` // 40 zeros for new branch
+	NewObjectID string `json:"newObjectId"` // Target commit SHA
+}
+
+// Comment represents a work item comment
+type Comment struct {
+	ID        int       `json:"id"`
+	Text      string    `json:"text"`
+	CreatedBy *Identity `json:"createdBy,omitempty"`
+	CreatedDate time.Time `json:"createdDate"`
+	ModifiedDate time.Time `json:"modifiedDate,omitempty"`
+}
+
+// WIQLQueryResult represents the result of a WIQL query
+type WIQLQueryResult struct {
+	QueryType        string              `json:"queryType"`
+	QueryResultType  string              `json:"queryResultType"`
+	AsOf             time.Time           `json:"asOf"`
+	Columns          []WIQLColumn        `json:"columns"`
+	WorkItems        []WIQLWorkItemRef   `json:"workItems"`
+	WorkItemRelations []WIQLWorkItemRelation `json:"workItemRelations,omitempty"`
+}
+
+// WIQLColumn represents a column in WIQL results
+type WIQLColumn struct {
+	ReferenceName string `json:"referenceName"`
+	Name          string `json:"name"`
+	URL           string `json:"url"`
+}
+
+// WIQLWorkItemRef represents a work item reference in WIQL results
+type WIQLWorkItemRef struct {
+	ID  int    `json:"id"`
+	URL string `json:"url"`
+}
+
+// WIQLWorkItemRelation represents a work item relation in WIQL results
+type WIQLWorkItemRelation struct {
+	Target *WIQLWorkItemRef `json:"target"`
+	Rel    string           `json:"rel,omitempty"`
+	Source *WIQLWorkItemRef `json:"source,omitempty"`
+}
+
+// Webhook payload types
+
+// WebhookPayload is the base webhook payload from Azure DevOps
+type WebhookPayload struct {
+	SubscriptionID string                 `json:"subscriptionId"`
+	NotificationID int                    `json:"notificationId"`
+	ID             string                 `json:"id"`
+	EventType      string                 `json:"eventType"`
+	PublisherID    string                 `json:"publisherId"`
+	Message        *WebhookMessage        `json:"message,omitempty"`
+	DetailedMessage *WebhookMessage       `json:"detailedMessage,omitempty"`
+	Resource       map[string]interface{} `json:"resource"`
+	ResourceVersion string                `json:"resourceVersion"`
+	ResourceContainers map[string]WebhookContainer `json:"resourceContainers"`
+	CreatedDate    time.Time              `json:"createdDate"`
+}
+
+// WebhookMessage contains the message text for webhooks
+type WebhookMessage struct {
+	Text     string `json:"text"`
+	HTML     string `json:"html,omitempty"`
+	Markdown string `json:"markdown,omitempty"`
+}
+
+// WebhookContainer contains resource container info
+type WebhookContainer struct {
+	ID      string `json:"id"`
+	BaseURL string `json:"baseUrl"`
+}
+
+// WorkItemWebhookResource is the resource payload for work item webhooks
+type WorkItemWebhookResource struct {
+	ID           int                    `json:"id"`
+	WorkItemID   int                    `json:"workItemId,omitempty"`
+	Rev          int                    `json:"rev"`
+	RevisedBy    *Identity              `json:"revisedBy,omitempty"`
+	RevisedDate  time.Time              `json:"revisedDate"`
+	Fields       map[string]interface{} `json:"fields"`
+	URL          string                 `json:"url"`
+	Revision     *WorkItemRevision      `json:"revision,omitempty"`
+}
+
+// WorkItemRevision represents a work item revision in webhook payload
+type WorkItemRevision struct {
+	ID     int                    `json:"id"`
+	Rev    int                    `json:"rev"`
+	Fields map[string]interface{} `json:"fields"`
+	URL    string                 `json:"url"`
+}
+
+// Webhook event types
+const (
+	WebhookEventWorkItemCreated = "workitem.created"
+	WebhookEventWorkItemUpdated = "workitem.updated"
+	WebhookEventWorkItemDeleted = "workitem.deleted"
+	WebhookEventWorkItemRestored = "workitem.restored"
+	WebhookEventPRCreated       = "git.pullrequest.created"
+	WebhookEventPRUpdated       = "git.pullrequest.updated"
+	WebhookEventPRMerged        = "git.pullrequest.merged"
+)
+
+// Helper functions
+
+// splitTags splits a semicolon-separated tag string into a slice
+func splitTags(tags string) []string {
+	if tags == "" {
+		return nil
+	}
+	var result []string
+	for _, tag := range splitAndTrim(tags, ";") {
+		if tag != "" {
+			result = append(result, tag)
+		}
+	}
+	return result
+}
+
+// splitAndTrim splits a string and trims whitespace from each part
+func splitAndTrim(s string, sep string) []string {
+	parts := make([]string, 0)
+	current := ""
+	for i := 0; i < len(s); i++ {
+		if i+len(sep) <= len(s) && s[i:i+len(sep)] == sep {
+			trimmed := trimSpace(current)
+			if trimmed != "" {
+				parts = append(parts, trimmed)
+			}
+			current = ""
+			i += len(sep) - 1
+		} else {
+			current += string(s[i])
+		}
+	}
+	if trimmed := trimSpace(current); trimmed != "" {
+		parts = append(parts, trimmed)
+	}
+	return parts
+}
+
+// trimSpace trims leading and trailing whitespace
+func trimSpace(s string) string {
+	start := 0
+	end := len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t' || s[start] == '\n' || s[start] == '\r') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t' || s[end-1] == '\n' || s[end-1] == '\r') {
+		end--
+	}
+	return s[start:end]
+}
+
+// joinTags joins tags into a semicolon-separated string
+func joinTags(tags []string) string {
+	if len(tags) == 0 {
+		return ""
+	}
+	result := tags[0]
+	for i := 1; i < len(tags); i++ {
+		result += "; " + tags[i]
+	}
+	return result
+}
+
+// addTag adds a tag to the tags string if not already present
+func addTag(tagsStr, newTag string) string {
+	tags := splitTags(tagsStr)
+	for _, t := range tags {
+		if t == newTag {
+			return tagsStr // Already has tag
+		}
+	}
+	tags = append(tags, newTag)
+	return joinTags(tags)
+}
+
+// removeTag removes a tag from the tags string
+func removeTag(tagsStr, tagToRemove string) string {
+	tags := splitTags(tagsStr)
+	result := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if t != tagToRemove {
+			result = append(result, t)
+		}
+	}
+	return joinTags(result)
+}

--- a/internal/adapters/azuredevops/types_test.go
+++ b/internal/adapters/azuredevops/types_test.go
@@ -1,0 +1,190 @@
+package azuredevops
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+
+	if config.Enabled {
+		t.Error("expected Enabled to be false by default")
+	}
+
+	if config.BaseURL != "https://dev.azure.com" {
+		t.Errorf("expected BaseURL 'https://dev.azure.com', got '%s'", config.BaseURL)
+	}
+
+	if config.PilotTag != "pilot" {
+		t.Errorf("expected PilotTag 'pilot', got '%s'", config.PilotTag)
+	}
+
+	if len(config.WorkItemTypes) != 3 {
+		t.Errorf("expected 3 work item types, got %d", len(config.WorkItemTypes))
+	}
+
+	if config.Polling == nil {
+		t.Fatal("expected Polling to be non-nil")
+	}
+	if config.Polling.Enabled {
+		t.Error("expected Polling.Enabled to be false by default")
+	}
+	if config.Polling.Interval != 30*time.Second {
+		t.Errorf("expected Polling.Interval 30s, got %v", config.Polling.Interval)
+	}
+
+	if config.StaleLabelCleanup == nil {
+		t.Fatal("expected StaleLabelCleanup to be non-nil")
+	}
+	if !config.StaleLabelCleanup.Enabled {
+		t.Error("expected StaleLabelCleanup.Enabled to be true by default")
+	}
+}
+
+func TestPriorityFromValue(t *testing.T) {
+	tests := []struct {
+		value    int
+		expected Priority
+	}{
+		{1, PriorityUrgent},
+		{2, PriorityHigh},
+		{3, PriorityMedium},
+		{4, PriorityLow},
+		{0, PriorityNone},
+		{5, PriorityNone},
+		{-1, PriorityNone},
+	}
+
+	for _, tt := range tests {
+		result := PriorityFromValue(tt.value)
+		if result != tt.expected {
+			t.Errorf("PriorityFromValue(%d) = %d, expected %d", tt.value, result, tt.expected)
+		}
+	}
+}
+
+func TestPriorityName(t *testing.T) {
+	tests := []struct {
+		priority Priority
+		expected string
+	}{
+		{PriorityUrgent, "Urgent"},
+		{PriorityHigh, "High"},
+		{PriorityMedium, "Medium"},
+		{PriorityLow, "Low"},
+		{PriorityNone, "No Priority"},
+	}
+
+	for _, tt := range tests {
+		result := PriorityName(tt.priority)
+		if result != tt.expected {
+			t.Errorf("PriorityName(%d) = '%s', expected '%s'", tt.priority, result, tt.expected)
+		}
+	}
+}
+
+func TestWorkItemMethods(t *testing.T) {
+	wi := &WorkItem{
+		ID:  42,
+		Rev: 3,
+		Fields: map[string]interface{}{
+			"System.Title":                  "Test Work Item",
+			"System.Description":            "<p>HTML Description</p>",
+			"System.State":                  StateActive,
+			"System.WorkItemType":           "Bug",
+			"System.Tags":                   "tag1; tag2",
+			"Microsoft.VSTS.Common.Priority": float64(1),
+			"System.CreatedDate":            "2024-06-15T10:00:00Z",
+			"System.ChangedDate":            "2024-06-16T12:00:00Z",
+		},
+	}
+
+	if wi.GetTitle() != "Test Work Item" {
+		t.Errorf("GetTitle() = '%s', expected 'Test Work Item'", wi.GetTitle())
+	}
+
+	if wi.GetState() != StateActive {
+		t.Errorf("GetState() = '%s', expected '%s'", wi.GetState(), StateActive)
+	}
+
+	if wi.GetWorkItemType() != "Bug" {
+		t.Errorf("GetWorkItemType() = '%s', expected 'Bug'", wi.GetWorkItemType())
+	}
+
+	tags := wi.GetTags()
+	if len(tags) != 2 {
+		t.Errorf("GetTags() returned %d tags, expected 2", len(tags))
+	}
+
+	if !wi.HasTag("tag1") {
+		t.Error("HasTag('tag1') = false, expected true")
+	}
+	if wi.HasTag("nonexistent") {
+		t.Error("HasTag('nonexistent') = true, expected false")
+	}
+
+	if wi.GetPriority() != PriorityUrgent {
+		t.Errorf("GetPriority() = %d, expected %d", wi.GetPriority(), PriorityUrgent)
+	}
+
+	created := wi.GetCreatedDate()
+	if created.Year() != 2024 || created.Month() != 6 || created.Day() != 15 {
+		t.Errorf("GetCreatedDate() = %v, unexpected value", created)
+	}
+
+	changed := wi.GetChangedDate()
+	if changed.Year() != 2024 || changed.Month() != 6 || changed.Day() != 16 {
+		t.Errorf("GetChangedDate() = %v, unexpected value", changed)
+	}
+}
+
+func TestWorkItemEmptyFields(t *testing.T) {
+	wi := &WorkItem{
+		ID:     1,
+		Fields: map[string]interface{}{},
+	}
+
+	if wi.GetTitle() != "" {
+		t.Errorf("GetTitle() on empty fields = '%s', expected empty", wi.GetTitle())
+	}
+
+	if wi.GetDescription() != "" {
+		t.Errorf("GetDescription() on empty fields = '%s', expected empty", wi.GetDescription())
+	}
+
+	if wi.GetState() != "" {
+		t.Errorf("GetState() on empty fields = '%s', expected empty", wi.GetState())
+	}
+
+	if wi.GetWorkItemType() != "" {
+		t.Errorf("GetWorkItemType() on empty fields = '%s', expected empty", wi.GetWorkItemType())
+	}
+
+	if wi.GetTags() != nil {
+		t.Errorf("GetTags() on empty fields = %v, expected nil", wi.GetTags())
+	}
+
+	if wi.GetPriority() != PriorityNone {
+		t.Errorf("GetPriority() on empty fields = %d, expected %d", wi.GetPriority(), PriorityNone)
+	}
+
+	if !wi.GetCreatedDate().IsZero() {
+		t.Error("GetCreatedDate() on empty fields should be zero")
+	}
+}
+
+func TestWorkItemReproStepsDescription(t *testing.T) {
+	// Some work item types use Microsoft.VSTS.TCM.ReproSteps instead of System.Description
+	wi := &WorkItem{
+		ID: 1,
+		Fields: map[string]interface{}{
+			"Microsoft.VSTS.TCM.ReproSteps": "Repro steps description",
+		},
+	}
+
+	desc := wi.GetDescription()
+	if desc != "Repro steps description" {
+		t.Errorf("GetDescription() from ReproSteps = '%s', expected 'Repro steps description'", desc)
+	}
+}

--- a/internal/adapters/azuredevops/webhook.go
+++ b/internal/adapters/azuredevops/webhook.go
@@ -1,0 +1,231 @@
+package azuredevops
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// WebhookHandler handles Azure DevOps service hook webhooks
+type WebhookHandler struct {
+	client        *Client
+	webhookSecret string
+	pilotTag      string
+	onWorkItem    func(context.Context, *WorkItem) error
+	workItemTypes []string
+}
+
+// NewWebhookHandler creates a new webhook handler
+func NewWebhookHandler(client *Client, webhookSecret, pilotTag string) *WebhookHandler {
+	return &WebhookHandler{
+		client:        client,
+		webhookSecret: webhookSecret,
+		pilotTag:      pilotTag,
+		workItemTypes: []string{"Bug", "Task", "User Story"},
+	}
+}
+
+// SetWorkItemTypes sets the work item types to handle
+func (h *WebhookHandler) SetWorkItemTypes(types []string) {
+	h.workItemTypes = types
+}
+
+// OnWorkItem sets the callback for when a pilot-tagged work item is received
+func (h *WebhookHandler) OnWorkItem(callback func(context.Context, *WorkItem) error) {
+	h.onWorkItem = callback
+}
+
+// VerifySecret verifies the webhook secret using basic auth
+// Azure DevOps service hooks support basic authentication
+func (h *WebhookHandler) VerifySecret(providedSecret string) bool {
+	if h.webhookSecret == "" {
+		// No secret configured, skip verification (development mode)
+		return true
+	}
+
+	// Use constant-time comparison to prevent timing attacks
+	return subtle.ConstantTimeCompare([]byte(providedSecret), []byte(h.webhookSecret)) == 1
+}
+
+// Handle processes a webhook payload
+func (h *WebhookHandler) Handle(ctx context.Context, payload *WebhookPayload) error {
+	logger := logging.WithComponent("azuredevops-webhook")
+	logger.Debug("Azure DevOps webhook received",
+		slog.String("event", payload.EventType),
+		slog.String("publisher", payload.PublisherID),
+	)
+
+	// Only process work item events from the tfs publisher
+	if payload.PublisherID != "tfs" {
+		return nil
+	}
+
+	switch payload.EventType {
+	case WebhookEventWorkItemCreated:
+		return h.handleWorkItemCreated(ctx, payload)
+	case WebhookEventWorkItemUpdated:
+		return h.handleWorkItemUpdated(ctx, payload)
+	default:
+		logger.Debug("Ignoring webhook event", slog.String("event", payload.EventType))
+		return nil
+	}
+}
+
+// handleWorkItemCreated processes newly created work items
+func (h *WebhookHandler) handleWorkItemCreated(ctx context.Context, payload *WebhookPayload) error {
+	logger := logging.WithComponent("azuredevops-webhook")
+
+	// Parse the resource as work item webhook resource
+	resource, err := h.parseWorkItemResource(payload.Resource)
+	if err != nil {
+		return fmt.Errorf("failed to parse work item resource: %w", err)
+	}
+
+	// Check if work item has pilot tag
+	if !h.hasPilotTag(resource.Fields) {
+		logger.Debug("Work item does not have pilot tag, skipping",
+			slog.Int("id", resource.ID))
+		return nil
+	}
+
+	// Check work item type
+	if !h.isAllowedWorkItemType(resource.Fields) {
+		logger.Debug("Work item type not in allowed list, skipping",
+			slog.Int("id", resource.ID))
+		return nil
+	}
+
+	return h.processWorkItem(ctx, resource.ID)
+}
+
+// handleWorkItemUpdated processes work item updates (tag changes)
+func (h *WebhookHandler) handleWorkItemUpdated(ctx context.Context, payload *WebhookPayload) error {
+	logger := logging.WithComponent("azuredevops-webhook")
+
+	// Parse the resource
+	resource, err := h.parseWorkItemResource(payload.Resource)
+	if err != nil {
+		return fmt.Errorf("failed to parse work item resource: %w", err)
+	}
+
+	// For updates, check if the pilot tag was added
+	// The revision contains the new values, we need to check if tag is now present
+	currentFields := resource.Fields
+	if resource.Revision != nil {
+		currentFields = resource.Revision.Fields
+	}
+
+	if !h.hasPilotTag(currentFields) {
+		logger.Debug("Work item does not have pilot tag after update, skipping",
+			slog.Int("id", resource.ID))
+		return nil
+	}
+
+	// Also check it's not already in progress or done
+	if h.hasTag(currentFields, TagInProgress) || h.hasTag(currentFields, TagDone) {
+		logger.Debug("Work item already processed, skipping",
+			slog.Int("id", resource.ID))
+		return nil
+	}
+
+	// Check work item type
+	if !h.isAllowedWorkItemType(currentFields) {
+		logger.Debug("Work item type not in allowed list, skipping",
+			slog.Int("id", resource.ID))
+		return nil
+	}
+
+	return h.processWorkItem(ctx, resource.ID)
+}
+
+// processWorkItem processes a work item that should be handled by Pilot
+func (h *WebhookHandler) processWorkItem(ctx context.Context, workItemID int) error {
+	logger := logging.WithComponent("azuredevops-webhook")
+	logger.Info("Processing pilot work item",
+		slog.Int("id", workItemID))
+
+	// Fetch full work item details via API (webhook payload may be incomplete)
+	fullWorkItem, err := h.client.GetWorkItem(ctx, workItemID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch work item details: %w", err)
+	}
+
+	logger.Info("Fetched work item details",
+		slog.Int("id", fullWorkItem.ID),
+		slog.String("title", fullWorkItem.GetTitle()),
+		slog.String("type", fullWorkItem.GetWorkItemType()),
+	)
+
+	// Call the callback
+	if h.onWorkItem != nil {
+		return h.onWorkItem(ctx, fullWorkItem)
+	}
+
+	return nil
+}
+
+// parseWorkItemResource parses the resource map into WorkItemWebhookResource
+func (h *WebhookHandler) parseWorkItemResource(resource map[string]interface{}) (*WorkItemWebhookResource, error) {
+	// Re-marshal and unmarshal to get proper typing
+	data, err := json.Marshal(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	var result WorkItemWebhookResource
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// hasPilotTag checks if the fields include the pilot tag
+func (h *WebhookHandler) hasPilotTag(fields map[string]interface{}) bool {
+	return h.hasTag(fields, h.pilotTag)
+}
+
+// hasTag checks if the fields include a specific tag
+func (h *WebhookHandler) hasTag(fields map[string]interface{}, tag string) bool {
+	tagsValue, ok := fields["System.Tags"]
+	if !ok {
+		return false
+	}
+
+	tagsStr, ok := tagsValue.(string)
+	if !ok {
+		return false
+	}
+
+	tags := splitTags(tagsStr)
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// isAllowedWorkItemType checks if the work item type is in the allowed list
+func (h *WebhookHandler) isAllowedWorkItemType(fields map[string]interface{}) bool {
+	witValue, ok := fields["System.WorkItemType"]
+	if !ok {
+		return false
+	}
+
+	wit, ok := witValue.(string)
+	if !ok {
+		return false
+	}
+
+	for _, allowedType := range h.workItemTypes {
+		if wit == allowedType {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/adapters/azuredevops/webhook_test.go
+++ b/internal/adapters/azuredevops/webhook_test.go
@@ -1,0 +1,335 @@
+package azuredevops
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestWebhookHandlerVerifySecret(t *testing.T) {
+	tests := []struct {
+		name           string
+		configuredSecret string
+		providedSecret string
+		expected       bool
+	}{
+		{
+			name:           "no secret configured",
+			configuredSecret: "",
+			providedSecret: "anything",
+			expected:       true,
+		},
+		{
+			name:           "correct secret",
+			configuredSecret: "my-secret",
+			providedSecret: "my-secret",
+			expected:       true,
+		},
+		{
+			name:           "wrong secret",
+			configuredSecret: "my-secret",
+			providedSecret: "wrong-secret",
+			expected:       false,
+		},
+		{
+			name:           "empty provided secret",
+			configuredSecret: "my-secret",
+			providedSecret: "",
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewWebhookHandler(nil, tt.configuredSecret, "pilot")
+			result := handler.VerifySecret(tt.providedSecret)
+			if result != tt.expected {
+				t.Errorf("VerifySecret() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWebhookHandlerHandle(t *testing.T) {
+	// Create a mock server that returns work item details
+	workItem := &WorkItem{
+		ID:  42,
+		Rev: 1,
+		Fields: map[string]interface{}{
+			"System.Title":        "Test Work Item",
+			"System.Tags":         "pilot",
+			"System.WorkItemType": "Bug",
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(workItem)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+
+	handler := NewWebhookHandler(client, testutil.FakeAzureDevOpsWebhookSecret, "pilot")
+
+	var processedWorkItem *WorkItem
+	handler.OnWorkItem(func(ctx context.Context, wi *WorkItem) error {
+		processedWorkItem = wi
+		return nil
+	})
+
+	ctx := context.Background()
+
+	// Test work item created event
+	payload := &WebhookPayload{
+		EventType:   WebhookEventWorkItemCreated,
+		PublisherID: "tfs",
+		Resource: map[string]interface{}{
+			"id":  float64(42),
+			"rev": float64(1),
+			"fields": map[string]interface{}{
+				"System.Title":        "Test Work Item",
+				"System.Tags":         "pilot",
+				"System.WorkItemType": "Bug",
+			},
+		},
+	}
+
+	err := handler.Handle(ctx, payload)
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	if processedWorkItem == nil {
+		t.Fatal("expected work item to be processed")
+	}
+
+	if processedWorkItem.ID != 42 {
+		t.Errorf("expected work item ID 42, got %d", processedWorkItem.ID)
+	}
+}
+
+func TestWebhookHandlerSkipsNonPilotItems(t *testing.T) {
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", "http://unused")
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	var processCalled bool
+	handler.OnWorkItem(func(ctx context.Context, wi *WorkItem) error {
+		processCalled = true
+		return nil
+	})
+
+	ctx := context.Background()
+
+	// Work item without pilot tag
+	payload := &WebhookPayload{
+		EventType:   WebhookEventWorkItemCreated,
+		PublisherID: "tfs",
+		Resource: map[string]interface{}{
+			"id":  float64(42),
+			"rev": float64(1),
+			"fields": map[string]interface{}{
+				"System.Title":        "Test Work Item",
+				"System.Tags":         "other-tag",
+				"System.WorkItemType": "Bug",
+			},
+		},
+	}
+
+	err := handler.Handle(ctx, payload)
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	if processCalled {
+		t.Error("expected work item NOT to be processed (no pilot tag)")
+	}
+}
+
+func TestWebhookHandlerSkipsNonTFSPublisher(t *testing.T) {
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", "http://unused")
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	var processCalled bool
+	handler.OnWorkItem(func(ctx context.Context, wi *WorkItem) error {
+		processCalled = true
+		return nil
+	})
+
+	ctx := context.Background()
+
+	// Non-tfs publisher
+	payload := &WebhookPayload{
+		EventType:   WebhookEventWorkItemCreated,
+		PublisherID: "other-publisher",
+		Resource: map[string]interface{}{
+			"id":  float64(42),
+			"rev": float64(1),
+			"fields": map[string]interface{}{
+				"System.Title": "Test Work Item",
+				"System.Tags":  "pilot",
+			},
+		},
+	}
+
+	err := handler.Handle(ctx, payload)
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	if processCalled {
+		t.Error("expected work item NOT to be processed (non-tfs publisher)")
+	}
+}
+
+func TestWebhookHandlerSkipsNonAllowedWorkItemType(t *testing.T) {
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", "http://unused")
+	handler := NewWebhookHandler(client, "", "pilot")
+	handler.SetWorkItemTypes([]string{"Bug", "Task"}) // Exclude "Feature"
+
+	var processCalled bool
+	handler.OnWorkItem(func(ctx context.Context, wi *WorkItem) error {
+		processCalled = true
+		return nil
+	})
+
+	ctx := context.Background()
+
+	// Feature type (not in allowed list)
+	payload := &WebhookPayload{
+		EventType:   WebhookEventWorkItemCreated,
+		PublisherID: "tfs",
+		Resource: map[string]interface{}{
+			"id":  float64(42),
+			"rev": float64(1),
+			"fields": map[string]interface{}{
+				"System.Title":        "Test Feature",
+				"System.Tags":         "pilot",
+				"System.WorkItemType": "Feature",
+			},
+		},
+	}
+
+	err := handler.Handle(ctx, payload)
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	if processCalled {
+		t.Error("expected work item NOT to be processed (Feature not in allowed types)")
+	}
+}
+
+func TestWebhookHandlerIgnoresUnknownEvents(t *testing.T) {
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", "http://unused")
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	ctx := context.Background()
+
+	// Unknown event type
+	payload := &WebhookPayload{
+		EventType:   "unknown.event",
+		PublisherID: "tfs",
+		Resource:    map[string]interface{}{},
+	}
+
+	err := handler.Handle(ctx, payload)
+	if err != nil {
+		t.Fatalf("Handle() should not error on unknown events: %v", err)
+	}
+}
+
+func TestWebhookHandlerWorkItemUpdated(t *testing.T) {
+	// Create a mock server that returns work item details
+	workItem := &WorkItem{
+		ID:  42,
+		Rev: 2,
+		Fields: map[string]interface{}{
+			"System.Title":        "Updated Work Item",
+			"System.Tags":         "pilot",
+			"System.WorkItemType": "Task",
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(workItem)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	var processedWorkItem *WorkItem
+	handler.OnWorkItem(func(ctx context.Context, wi *WorkItem) error {
+		processedWorkItem = wi
+		return nil
+	})
+
+	ctx := context.Background()
+
+	// Work item updated event with pilot tag added
+	payload := &WebhookPayload{
+		EventType:   WebhookEventWorkItemUpdated,
+		PublisherID: "tfs",
+		Resource: map[string]interface{}{
+			"id":  float64(42),
+			"rev": float64(2),
+			"fields": map[string]interface{}{
+				"System.Title":        "Updated Work Item",
+				"System.Tags":         "pilot",
+				"System.WorkItemType": "Task",
+			},
+		},
+	}
+
+	err := handler.Handle(ctx, payload)
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	if processedWorkItem == nil {
+		t.Fatal("expected work item to be processed")
+	}
+}
+
+func TestWebhookHandlerSkipsAlreadyProcessedItems(t *testing.T) {
+	client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", "http://unused")
+	handler := NewWebhookHandler(client, "", "pilot")
+
+	var processCalled bool
+	handler.OnWorkItem(func(ctx context.Context, wi *WorkItem) error {
+		processCalled = true
+		return nil
+	})
+
+	ctx := context.Background()
+
+	// Work item already has pilot-in-progress tag
+	payload := &WebhookPayload{
+		EventType:   WebhookEventWorkItemUpdated,
+		PublisherID: "tfs",
+		Resource: map[string]interface{}{
+			"id":  float64(42),
+			"rev": float64(2),
+			"fields": map[string]interface{}{
+				"System.Title":        "Already Processing",
+				"System.Tags":         "pilot; pilot-in-progress",
+				"System.WorkItemType": "Bug",
+			},
+		},
+	}
+
+	err := handler.Handle(ctx, payload)
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	if processCalled {
+		t.Error("expected work item NOT to be processed (already in progress)")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/alekspetrov/pilot/internal/adapters/asana"
+	"github.com/alekspetrov/pilot/internal/adapters/azuredevops"
 	"github.com/alekspetrov/pilot/internal/adapters/github"
 	"github.com/alekspetrov/pilot/internal/adapters/gitlab"
 	"github.com/alekspetrov/pilot/internal/adapters/jira"
@@ -55,13 +56,14 @@ type Config struct {
 // AdaptersConfig holds configuration for external service adapters.
 // Each adapter connects Pilot to a different service (Linear, Slack, GitHub, GitLab, etc.).
 type AdaptersConfig struct {
-	Linear   *linear.Config   `yaml:"linear"`
-	Slack    *slack.Config    `yaml:"slack"`
-	Telegram *telegram.Config `yaml:"telegram"`
-	GitHub   *github.Config   `yaml:"github"`
-	GitLab   *gitlab.Config   `yaml:"gitlab"`
-	Jira     *jira.Config     `yaml:"jira"`
-	Asana    *asana.Config    `yaml:"asana"`
+	Linear      *linear.Config      `yaml:"linear"`
+	Slack       *slack.Config       `yaml:"slack"`
+	Telegram    *telegram.Config    `yaml:"telegram"`
+	GitHub      *github.Config      `yaml:"github"`
+	GitLab      *gitlab.Config      `yaml:"gitlab"`
+	AzureDevOps *azuredevops.Config `yaml:"azure_devops"`
+	Jira        *jira.Config        `yaml:"jira"`
+	Asana       *asana.Config       `yaml:"asana"`
 }
 
 // OrchestratorConfig holds settings for the task orchestrator including
@@ -224,13 +226,14 @@ func DefaultConfig() *Config {
 			Type: gateway.AuthTypeClaudeCode,
 		},
 		Adapters: &AdaptersConfig{
-			Linear:   linear.DefaultConfig(),
-			Slack:    slack.DefaultConfig(),
-			Telegram: telegram.DefaultConfig(),
-			GitHub:   github.DefaultConfig(),
-			GitLab:   gitlab.DefaultConfig(),
-			Jira:     jira.DefaultConfig(),
-			Asana:    asana.DefaultConfig(),
+			Linear:      linear.DefaultConfig(),
+			Slack:       slack.DefaultConfig(),
+			Telegram:    telegram.DefaultConfig(),
+			GitHub:      github.DefaultConfig(),
+			GitLab:      gitlab.DefaultConfig(),
+			AzureDevOps: azuredevops.DefaultConfig(),
+			Jira:        jira.DefaultConfig(),
+			Asana:       asana.DefaultConfig(),
 		},
 		Orchestrator: &OrchestratorConfig{
 			Model:         "claude-sonnet-4-20250514",

--- a/internal/testutil/tokens.go
+++ b/internal/testutil/tokens.go
@@ -75,4 +75,10 @@ const (
 
 	// FakeGitLabWebhookSecret is a safe test secret for GitLab webhook verification.
 	FakeGitLabWebhookSecret = "test-gitlab-webhook-secret"
+
+	// FakeAzureDevOpsPAT is a safe test personal access token for Azure DevOps.
+	FakeAzureDevOpsPAT = "test-azure-devops-pat"
+
+	// FakeAzureDevOpsWebhookSecret is a safe test secret for Azure DevOps webhook verification.
+	FakeAzureDevOpsWebhookSecret = "test-azure-devops-webhook-secret"
 )


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-276.

## Changes

GitHub Issue #276: Implement Azure DevOps adapter

## Summary

Implement full Azure DevOps adapter following GitHub/GitLab adapter patterns. This enables Pilot to read work items and create PRs in Azure DevOps repositories.

**Requested by:** Community user on Threads (uses Azure DevOps daily)

## API Reference

- [Work Items REST API v7.1](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/work-items?view=azure-devops-rest-7.1)
- [Pull Requests REST API v7.1](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/create?view=azure-devops-rest-7.1)
- [Service Hooks (Webhooks)](https://learn.microsoft.com/en-us/azure/devops/service-hooks/services/webhooks?view=azure-devops)

## Pre-work Required

### 1. Create types.go skeleton
Location: `internal/adapters/azuredevops/types.go`

```go
package azuredevops

import "time"

// Config holds Azure DevOps adapter configuration
type Config struct {
    Enabled           bool                     `yaml:"enabled"`
    PAT               string                   `yaml:"pat"`              // Personal Access Token
    Organization      string                   `yaml:"organization"`     // Azure DevOps org name
    Project           string                   `yaml:"project"`          // Project name
    Repository        string                   `yaml:"repository"`       // Repository name (optional, defaults to project)
    BaseURL           string                   `yaml:"base_url"`         // Default: https://dev.azure.com
    WebhookSecret     string                   `yaml:"webhook_secret"`   // For basic auth on webhook endpoint
    PilotTag          string                   `yaml:"pilot_tag"`        // Tag to watch (Azure uses tags, not labels)
    WorkItemTypes     []string                 `yaml:"work_item_types"`  // e.g., ["Bug", "Task", "User Story"]
    Polling           *PollingConfig           `yaml:"polling"`
    StaleLabelCleanup *StaleLabelCleanupConfig `yaml:"stale_label_cleanup"`
}
```

### 2. Add to AdaptersConfig
Location: `internal/config/config.go`

```go
type AdaptersConfig struct {
    // ... existing adapters
    AzureDevOps *azuredevops.Config `yaml:"azure_devops"`
}
```

### 3. Add test token
Location: `internal/testutil/tokens.go`

```go
const FakeAzureDevOpsPAT = "test-azure-devops-pat"
```

### 4. Add example config
Location: `configs/pilot.example.yaml`

```yaml
  # Azure DevOps - Work item polling and PR creation
  azure_devops:
    enabled: false
    pat: "${AZURE_DEVOPS_PAT}"
    organization: "my-org"
    project: "my-project"
    repository: "my-repo"              # Optional, defaults to project name
    base_url: "https://dev.azure.com"  # Or Azure DevOps Server URL
    pilot_tag: "pilot"                 # Work items with this tag are picked up
    work_item_types:                   # Which work item types to process
      - "Bug"
      - "Task"
      - "User Story"
    polling:
      enabled: true
      interval: 30s
    stale_label_cleanup:
      enabled: true
      interval: 30m
      threshold: 1h
```

## Implementation Required

### Adapter Files (internal/adapters/azuredevops/)

#### 1. **client.go** - API client
Core HTTP client for Azure DevOps REST API v7.1:

```go
const azureDevOpsAPIVersion = "7.1"

type Client struct {
    pat          string
    organization string
    project      string
    repository   string
    httpClient   *http.Client
    baseURL      string
}

// Key methods:
// - GetWorkItem(ctx, id) (*WorkItem, error)
// - ListWorkItems(ctx, opts) ([]*WorkItem, error) 
// - UpdateWorkItem(ctx, id, ops) (*WorkItem, error)
// - AddWorkItemTag(ctx, id, tag) error
// - RemoveWorkItemTag(ctx, id, tag) error
// - CreatePullRequest(ctx, input) (*PullRequest, error)
// - GetPullRequest(ctx, id) (*PullRequest, error)
// - MergePullRequest(ctx, id, opts) error
// - CreateBranch(ctx, name, fromRef) error
// - GetDefaultBranch(ctx) (string, error)
// - AddPRComment(ctx, prID, comment) error
```

**API Endpoints:**
- Work Items: `GET/PATCH {org}/{project}/_apis/wit/workitems/{id}?api-version=7.1`
- List by WIQL: `POST {org}/{project}/_apis/wit/wiql?api-version=7.1`
- Pull Requests: `POST {org}/{project}/_apis/git/repositories/{repo}/pullrequests?api-version=7.1`
- Branches: `POST {org}/{project}/_apis/git/repositories/{repo}/refs?api-version=7.1`

**Auth:** Basic auth with empty username, PAT as password:
```go
req.SetBasicAuth("", c.pat)
```

#### 2. **types.go** - Type definitions
Already outlined above. Additional types needed:

```go
// WorkItem represents an Azure DevOps work item
type WorkItem struct {
    ID     int                    `json:"id"`
    Rev    int                    `json:"rev"`
    Fields map[string]interface{} `json:"fields"`
    URL    string                 `json:"url"`
}

// Common System.* fields:
// - System.Title
// - System.Description  
// - System.State (New, Active, Resolved, Closed)
// - System.WorkItemType (Bug, Task, User Story, etc.)
// - System.Tags (semicolon-separated)
// - System.AssignedTo

// PullRequest represents an Azure DevOps PR
type PullRequest struct {
    PullRequestID int       `json:"pullRequestId"`
    Title         string    `json:"title"`
    Description   string    `json:"description"`
    Status        string    `json:"status"` // active, completed, abandoned
    SourceRefName string    `json:"sourceRefName"`
    TargetRefName string    `json:"targetRefName"`
    MergeStatus   string    `json:"mergeStatus"`
    CreationDate  time.Time `json:"creationDate"`
    URL           string    `json:"url"`
}

// Webhook payload types for work item events
type WorkItemWebhookPayload struct {
    EventType        string                 `json:"eventType"`
    Resource         *WorkItemResource      `json:"resource"`
    ResourceContainers map[string]Container `json:"resourceContainers"`
}
```

#### 3. **poller.go** - Work item polling
Poll for work items with pilot tag using WIQL:

```wiql
SELECT [System.Id] 
FROM WorkItems 
WHERE [System.Tags] CONTAINS 'pilot' 
  AND [System.State] <> 'Closed'
  AND [System.WorkItemType] IN ('Bug', 'Task', 'User Story')
ORDER BY [System.ChangedDate] DESC
```

#### 4. **webhook.go** - Webhook handler
Handle Azure DevOps service hook events:
- `workitem.created`
- `workitem.updated`
- `git.pullrequest.created`
- `git.pullrequest.merged`

#### 5. **converter.go** - Convert to internal Task
Map Azure DevOps WorkItem → internal `task.Task`:

```go
func WorkItemToTask(wi *WorkItem) *task.Task {
    return &task.Task{
        ID:          fmt.Sprintf("azdo-%d", wi.ID),
        ExternalID:  strconv.Itoa(wi.ID),
        Source:      "azure_devops",
        Title:       wi.Fields["System.Title"].(string),
        Description: wi.Fields["System.Description"].(string),
        // ...
    }
}
```

#### 6. **merger.go** - PR merge logic
Handle merge completion and work item state transitions.

#### 7. **notifier.go** - Comment on work items
Add comments to work items for status updates.

#### 8. **cleanup.go** - Stale tag cleanup
Remove `pilot-in-progress` tags from abandoned work.

### Tests Required
- `client_test.go` - API client unit tests with mock server
- `poller_test.go` - Polling logic tests
- `webhook_test.go` - Webhook payload parsing tests
- `converter_test.go` - Work item → Task conversion tests

## Key Differences from GitHub/GitLab

| Aspect | GitHub/GitLab | Azure DevOps |
|--------|---------------|--------------|
| Labels | Native labels array | Tags (semicolon-separated string in System.Tags) |
| Issue numbers | Sequential per repo | Global work item IDs across org |
| PR refs | `branch-name` | `refs/heads/branch-name` (full ref required) |
| Auth | Token header | Basic auth (empty user, PAT password) |
| Webhooks | Single URL, multiple events | Service Hook subscriptions (one per event type) |
| Query | API filters | WIQL (Work Item Query Language) |

## Acceptance Criteria

- [ ] Pilot can poll Azure DevOps for work items with `pilot` tag
- [ ] Pilot can create branches and PRs in Azure DevOps repos
- [ ] Pilot updates work item tags (`pilot-in-progress`, `pilot-done`, `pilot-failed`)
- [ ] Pilot can receive webhooks for real-time work item updates
- [ ] Pilot adds comments to work items with status updates
- [ ] All existing tests pass
- [ ] New adapter has >80% test coverage

## Estimated Effort

Similar to GitLab adapter: ~1-2 weeks

## References

- GitLab adapter (just merged): `internal/adapters/gitlab/`
- GitHub adapter (reference): `internal/adapters/github/`