### PR TITLE
fix(dashboard): add top padding to ASCII logo (GH-284)

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -308,6 +308,7 @@ func (m Model) View() string {
 	var b strings.Builder
 
 	// Header with ASCII logo
+	b.WriteString("\n") // Top padding to match bottom spacing
 	logo := strings.TrimPrefix(banner.Logo, "\n") // Remove leading newline
 	b.WriteString(titleStyle.Render(logo))
 	b.WriteString(titleStyle.Render(fmt.Sprintf("   Pilot v%s", m.version)))


### PR DESCRIPTION
## Summary
- Add blank line before ASCII logo to match bottom spacing before the metrics panel

## Test plan
- [ ] Run `make build` - builds successfully
- [ ] Launch dashboard and verify top padding is visible

Closes #284