### PR TITLE
Fix PR creation false failure - handle 'already exists' gracefully

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1000,7 +1000,7 @@ func handleGitHubIssue(ctx context.Context, cfg *config.Config, client *github.C
 			if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
 				logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
 			}
-		} else if result != nil {
+		} else if result != nil && result.Success {
 			if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelDone}); err != nil {
 				logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
 			}
@@ -1009,6 +1009,15 @@ func handleGitHubIssue(ctx context.Context, cfg *config.Config, client *github.C
 			if result.PRUrl != "" {
 				comment += fmt.Sprintf("\n**PR:** %s", result.PRUrl)
 			}
+			if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
+				logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
+			}
+		} else if result != nil {
+			// result exists but Success is false - mark as failed
+			if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelFailed}); err != nil {
+				logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
+			}
+			comment := fmt.Sprintf("❌ Pilot execution completed but failed:\n\n```\n%s\n```", result.Error)
 			if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
 				logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
 			}
@@ -1185,7 +1194,7 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 			if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
 				logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
 			}
-		} else if result != nil {
+		} else if result != nil && result.Success {
 			if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelDone}); err != nil {
 				logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
 			}
@@ -1194,6 +1203,15 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 			if result.PRUrl != "" {
 				comment += fmt.Sprintf("\n**PR:** %s", result.PRUrl)
 			}
+			if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
+				logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
+			}
+		} else if result != nil {
+			// result exists but Success is false - mark as failed
+			if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelFailed}); err != nil {
+				logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
+			}
+			comment := fmt.Sprintf("❌ Pilot execution completed but failed:\n\n```\n%s\n```", result.Error)
 			if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
 				logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
 			}

--- a/internal/executor/git_test.go
+++ b/internal/executor/git_test.go
@@ -308,3 +308,56 @@ func TestSwitchToDefaultBranchAndPull_NewBranchFromMain(t *testing.T) {
 		t.Errorf("main branch SHA changed unexpectedly: was %s, now %s", mainSHA, currentMainSHA)
 	}
 }
+
+func TestExtractPRURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "simple URL",
+			input: "https://github.com/owner/repo/pull/123",
+			want:  "https://github.com/owner/repo/pull/123",
+		},
+		{
+			name:  "URL with already exists message",
+			input: "a]ready exists:\nhttps://github.com/owner/repo/pull/456\n",
+			want:  "https://github.com/owner/repo/pull/456",
+		},
+		{
+			name:  "gh CLI already exists output",
+			input: "a pull request for branch `feature` into `main` already exists:\nhttps://github.com/alekspetrov/pilot/pull/285",
+			want:  "https://github.com/alekspetrov/pilot/pull/285",
+		},
+		{
+			name:  "URL with trailing text",
+			input: "https://github.com/owner/repo/pull/789 (created)",
+			want:  "https://github.com/owner/repo/pull/789",
+		},
+		{
+			name:  "no URL",
+			input: "failed to create pull request",
+			want:  "",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "github URL but not PR",
+			input: "https://github.com/owner/repo/issues/123",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractPRURL(tt.input)
+			if got != tt.want {
+				t.Errorf("extractPRURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-286.

## Changes

GitHub Issue #286: Fix PR creation false failure - handle 'already exists' gracefully

## Problem

Pilot reports "PR Failed" even when PR is successfully created. Investigation from GH-284:

1. PR #285 was created successfully
2. Dashboard showed "PR Failed: failed to create PR..."
3. Issue got `pilot-done` label despite reported failure

## Root Cause

**Bug 1**: `CreatePR()` in `git.go` doesn't handle "PR already exists"
- `gh pr create` returns exit code 1 with URL when PR exists
- Code treats any non-zero exit as failure

**Bug 2**: `pilot-done` label added when `result.Success == false`
- Label logic checks `result != nil` instead of `result.Success`

## Implementation

### Fix 1: git.go - Handle "already exists"

```go
if err != nil {
    // Check if PR already exists - gh returns exit 1 but includes URL
    if strings.Contains(outputStr, "already exists") {
        if url := extractPRURL(outputStr); url != "" {
            return url, nil
        }
    }
    return "", fmt.Errorf("failed to create PR: %w: %s", err, output)
}
```

### Fix 2: main.go - Check result.Success

```go
// Before (buggy):
} else if result != nil {

// After (fixed):
} else if result != nil && result.Success {
```

## Files

- `internal/executor/git.go` - Add URL extraction, update CreatePR
- `cmd/pilot/main.go` - Fix label logic (~line 1188)

## Task Doc

`.agent/tasks/GH-286-pr-creation-false-failure.md`