### PR TITLE
fix(cli): fix --telegram flag not enabling Telegram polling

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -302,7 +302,9 @@ func newOptionalBool(ptr **bool) *optionalBool {
 }
 
 func (o *optionalBool) Set(s string) error {
-	v := s == "" || s == "true" || s == "1"
+	// For boolean flags, default to true unless explicitly false
+	// This handles edge cases where flag parser passes unexpected values
+	v := s != "false" && s != "0" && s != "no"
 	*o.ptr = &v
 	return nil
 }
@@ -767,6 +769,7 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 
 	// Start Telegram polling if enabled
 	if tgHandler != nil {
+		fmt.Println("📱 Telegram polling started")
 		tgHandler.StartPolling(ctx)
 	}
 


### PR DESCRIPTION
## Summary
- Fixed `optionalBool.Set()` to correctly parse boolean flag values
- When `--telegram -p ...` was used, cobra passed `-p` as the flag value, causing incorrect parsing
- Changed logic to default to `true` unless value is explicitly "false", "0", or "no"
- Added startup message "📱 Telegram polling started" for user feedback

## Root Cause
The original logic `v := s == "" || s == "true" || s == "1"` would evaluate to `false` when passed unexpected values like `-p`.

## Test Plan
- [x] Verified polling works with `--telegram` flag
- [x] Confirmed 409 conflict response when bot is actively polling