### PR TITLE
Add handleResearch() for Telegram research requests

### DIFF
--- a/internal/adapters/telegram/formatter.go
+++ b/internal/adapters/telegram/formatter.go
@@ -456,3 +456,32 @@ func truncateDescription(s string, maxLen int) string {
 	}
 	return s[:maxLen-3] + "..."
 }
+
+// chunkContent splits content into chunks of maxLen characters.
+// Tries to break at newlines for cleaner output.
+func chunkContent(content string, maxLen int) []string {
+	if len(content) <= maxLen {
+		return []string{content}
+	}
+
+	var chunks []string
+	remaining := content
+
+	for len(remaining) > 0 {
+		if len(remaining) <= maxLen {
+			chunks = append(chunks, remaining)
+			break
+		}
+
+		// Find a good break point (prefer newline)
+		breakPoint := maxLen
+		if idx := strings.LastIndex(remaining[:maxLen], "\n"); idx > maxLen/2 {
+			breakPoint = idx + 1
+		}
+
+		chunks = append(chunks, strings.TrimSpace(remaining[:breakPoint]))
+		remaining = strings.TrimSpace(remaining[breakPoint:])
+	}
+
+	return chunks
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-291.

## Changes

GitHub Issue #291: Add handleResearch() for Telegram research requests

## Summary

Add `handleResearch()` handler to process research requests. When user sends "research X" or "analyze Y", Claude Code executes in read-only mode and returns the analysis content directly to Telegram chat.

## Context

Research intent was added in GH-XXX. Now we need the handler that:
1. Executes Claude Code with a research-focused prompt (no code changes)
2. Sends the research output directly to Telegram (chunked if needed)
3. Optionally saves full report to `.agent/research/` directory

## Implementation

### File: `internal/adapters/telegram/handler.go`

Add `handleResearch()` method:

```go
func (h *Handler) handleResearch(ctx context.Context, chatID, query string) {
    // 1. Send acknowledgment
    _, _ = h.client.SendMessage(ctx, chatID, "🔬 Researching...", "")

    // 2. Create research task (no branch, no PR)
    taskID := fmt.Sprintf("RES-%d", time.Now().Unix())
    task := &executor.Task{
        ID:          taskID,
        Title:       "Research: " + truncateDescription(query, 40),
        Description: fmt.Sprintf(`Research and analyze: %s

Provide findings in a structured format with:
- Executive summary
- Key findings
- Relevant code/files if applicable
- Recommendations

DO NOT make any code changes. This is a read-only research task.`, query),
        ProjectPath: h.getActiveProjectPath(chatID),
        CreatePR:    false,
    }

    // 3. Execute with timeout (3 minutes for research)
    researchCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
    defer cancel()

    result, err := h.runner.Execute(researchCtx, task)
    if err != nil {
        if researchCtx.Err() == context.DeadlineExceeded {
            _, _ = h.client.SendMessage(ctx, chatID, "⏱ Research timed out. Try a more specific query.", "")
        } else {
            _, _ = h.client.SendMessage(ctx, chatID, fmt.Sprintf("❌ Research failed: %s", err.Error()), "")
        }
        return
    }

    // 4. Send content to Telegram (chunked if long)
    h.sendResearchOutput(ctx, chatID, query, result)
}

func (h *Handler) sendResearchOutput(ctx context.Context, chatID, query string, result *executor.ExecutionResult) {
    content := cleanInternalSignals(result.Output)
    if content == "" {
        _, _ = h.client.SendMessage(ctx, chatID, "🤷 No research findings to report.", "")
        return
    }

    // Chunk content for Telegram (4096 char limit, use 3800 for safety)
    chunks := chunkContent(content, 3800)

    for i, chunk := range chunks {
        msg := chunk
        if len(chunks) > 1 {
            msg = fmt.Sprintf("📄 Part %d/%d\n\n%s", i+1, len(chunks), chunk)
        }
        _, _ = h.client.SendMessage(ctx, chatID, msg, "")

        // Small delay between chunks to avoid rate limiting
        if i < len(chunks)-1 {
            time.Sleep(500 * time.Millisecond)
        }
    }

    // Optionally save to file
    h.saveResearchFile(query, content)
}

func (h *Handler) saveResearchFile(query, content string) {
    // Create .agent/research/ directory if it doesn't exist
    researchDir := filepath.Join(h.projectPath, ".agent", "research")
    if err := os.MkdirAll(researchDir, 0755); err != nil {
        return // Silent fail for file save
    }

    // Generate filename from query
    slug := strings.ToLower(query)
    slug = regexp.MustCompile(`[^a-z0-9]+`).ReplaceAllString(slug, "-")
    if len(slug) > 40 {
        slug = slug[:40]
    }
    filename := fmt.Sprintf("%s-%d.md", slug, time.Now().Unix())

    // Save file
    filePath := filepath.Join(researchDir, filename)
    _ = os.WriteFile(filePath, []byte(content), 0644)
}
```

### File: `internal/adapters/telegram/formatter.go`

Add helper function for content chunking:

```go
// chunkContent splits content into chunks of maxLen characters
// Tries to break at newlines for cleaner output
func chunkContent(content string, maxLen int) []string {
    if len(content) <= maxLen {
        return []string{content}
    }

    var chunks []string
    remaining := content

    for len(remaining) > 0 {
        if len(remaining) <= maxLen {
            chunks = append(chunks, remaining)
            break
        }

        // Find a good break point (prefer newline)
        breakPoint := maxLen
        if idx := strings.LastIndex(remaining[:maxLen], "\n"); idx > maxLen/2 {
            breakPoint = idx + 1
        }

        chunks = append(chunks, strings.TrimSpace(remaining[:breakPoint]))
        remaining = strings.TrimSpace(remaining[breakPoint:])
    }

    return chunks
}
```

### File: `internal/adapters/telegram/handler.go` - processUpdate

Update the switch in `processUpdate()` to route research intent:

```go
switch intent {
case IntentCommand:
    h.handleCommand(ctx, chatID, text)
case IntentGreeting:
    h.handleGreeting(ctx, chatID, msg.From)
case IntentQuestion:
    h.handleQuestion(ctx, chatID, text)
case IntentResearch:
    h.handleResearch(ctx, chatID, text)  // NEW
case IntentTask:
    h.handleTask(ctx, chatID, text)
default:
    h.handleTask(ctx, chatID, text)
}
```

## Acceptance Criteria

- [ ] "research X" triggers `handleResearch()` and returns content to chat
- [ ] Long research output is chunked properly (no message > 4096 chars)
- [ ] Research saves to `.agent/research/` with timestamped filename
- [ ] No PR created for research tasks
- [ ] 3-minute timeout with user-friendly error message

## Dependencies

- Depends on: GH-290 (intent types)
