### PR TITLE
feat(telegram): add plain text mode for messaging channels

### DIFF
--- a/internal/adapters/telegram/handler.go
+++ b/internal/adapters/telegram/handler.go
@@ -55,6 +55,7 @@ type Handler struct {
 	transcriptionErr error                  // Error from transcription init (for guidance)
 	store            *memory.Store          // Memory store for history/queue/budget (optional)
 	cmdHandler       *CommandHandler        // Command handler for /commands
+	plainTextMode    bool                   // Use plain text instead of Markdown
 }
 
 // HandlerConfig holds configuration for the Telegram handler
@@ -65,6 +66,7 @@ type HandlerConfig struct {
 	AllowedIDs    []int64               // User/chat IDs allowed to send tasks
 	Transcription *transcription.Config // Voice transcription config (optional)
 	Store         *memory.Store         // Memory store for history/queue/budget (optional)
+	PlainTextMode bool                  // Use plain text instead of Markdown (default: true)
 }
 
 // NewHandler creates a new Telegram message handler
@@ -93,6 +95,7 @@ func NewHandler(config *HandlerConfig, runner *executor.Runner) *Handler {
 		runningTasks:  make(map[string]*RunningTask),
 		stopCh:        make(chan struct{}),
 		store:         config.Store,
+		plainTextMode: config.PlainTextMode,
 	}
 
 	// Initialize command handler
@@ -150,6 +153,15 @@ func (h *Handler) getActiveProjectInfo(chatID string) *ProjectInfo {
 
 	path := h.getActiveProjectPath(chatID)
 	return h.projects.GetProjectByPath(path)
+}
+
+// getParseMode returns the parse mode based on plainTextMode setting.
+// Returns empty string for plain text, "Markdown" for markdown mode.
+func (h *Handler) getParseMode() string {
+	if h.plainTextMode {
+		return ""
+	}
+	return "Markdown"
 }
 
 // CheckSingleton verifies no other bot instance is already running.

--- a/internal/adapters/telegram/notifier_test.go
+++ b/internal/adapters/telegram/notifier_test.go
@@ -393,3 +393,77 @@ func TestEscapeMarkdownNotifier(t *testing.T) {
 		})
 	}
 }
+
+// TestDefaultConfigPlainTextMode tests that PlainTextMode defaults to true
+func TestDefaultConfigPlainTextMode(t *testing.T) {
+	config := DefaultConfig()
+
+	if !config.PlainTextMode {
+		t.Error("PlainTextMode should default to true for better messaging app compatibility")
+	}
+}
+
+// TestNotifierGetParseMode tests the getParseMode helper
+func TestNotifierGetParseMode(t *testing.T) {
+	tests := []struct {
+		name          string
+		plainTextMode bool
+		want          string
+	}{
+		{
+			name:          "plain text mode enabled",
+			plainTextMode: true,
+			want:          "",
+		},
+		{
+			name:          "plain text mode disabled (markdown)",
+			plainTextMode: false,
+			want:          "Markdown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notifier := &Notifier{
+				plainTextMode: tt.plainTextMode,
+			}
+			got := notifier.getParseMode()
+			if got != tt.want {
+				t.Errorf("getParseMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNotifierPlainTextModeConfig tests that notifier correctly inherits PlainTextMode from config
+func TestNotifierPlainTextModeConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		plainTextMode bool
+	}{
+		{
+			name:          "plain text enabled",
+			plainTextMode: true,
+		},
+		{
+			name:          "plain text disabled",
+			plainTextMode: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{
+				BotToken:      testutil.FakeTelegramBotToken,
+				ChatID:        "123456",
+				PlainTextMode: tt.plainTextMode,
+			}
+
+			notifier := NewNotifier(config)
+
+			if notifier.plainTextMode != tt.plainTextMode {
+				t.Errorf("notifier.plainTextMode = %v, want %v", notifier.plainTextMode, tt.plainTextMode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `PlainTextMode` config field to Telegram adapter (default: `true`)
- Thread plain text mode through Notifier and Handler
- Conditionally use `""` (plain) or `"Markdown"` parse mode
- Keep Markdown for Slack (which renders it properly)

## Problem

Telegram and other messaging apps don't render Markdown well. Current implementation uses `"Markdown"` parse mode everywhere, causing formatting artifacts like literal `*asterisks*` in chat.

## Changes

- `internal/adapters/telegram/notifier.go` - Add config field, getParseMode() helper, conditional formatting
- `internal/adapters/telegram/handler.go` - Add plainTextMode field, getParseMode() helper
- `internal/adapters/telegram/commands.go` - Update all command handlers for conditional formatting
- `internal/adapters/telegram/notifier_test.go` - Add tests for plain text mode behavior

## Test plan

- [x] All tests pass (`go test ./internal/adapters/telegram/... -v`)
- [x] Build succeeds (`go build ./...`)
- [x] Linter passes (`make lint`)
- [ ] Manual test: Telegram messages display clean plain text

Closes #304