### PR TITLE
feat(autopilot): add NotifyReleased to Telegram notifier (GH-307)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -22,6 +22,8 @@ type Notifier interface {
 	NotifyApprovalRequired(ctx context.Context, prState *PRState) error
 	// NotifyFixIssueCreated sends notification when a fix issue is auto-created.
 	NotifyFixIssueCreated(ctx context.Context, prState *PRState, issueNumber int) error
+	// NotifyReleased sends notification when a release is created.
+	NotifyReleased(ctx context.Context, prState *PRState, releaseURL string) error
 }
 
 // Controller orchestrates the autopilot loop for PR processing.

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -1098,6 +1098,7 @@ type mockNotifier struct {
 	notifyCIFailedFunc         func(ctx context.Context, prState *PRState, failedChecks []string) error
 	notifyApprovalRequiredFunc func(ctx context.Context, prState *PRState) error
 	notifyFixIssueCreatedFunc  func(ctx context.Context, prState *PRState, issueNumber int) error
+	notifyReleasedFunc         func(ctx context.Context, prState *PRState, releaseURL string) error
 }
 
 func (m *mockNotifier) NotifyMerged(ctx context.Context, prState *PRState) error {
@@ -1124,6 +1125,13 @@ func (m *mockNotifier) NotifyApprovalRequired(ctx context.Context, prState *PRSt
 func (m *mockNotifier) NotifyFixIssueCreated(ctx context.Context, prState *PRState, issueNumber int) error {
 	if m.notifyFixIssueCreatedFunc != nil {
 		return m.notifyFixIssueCreatedFunc(ctx, prState, issueNumber)
+	}
+	return nil
+}
+
+func (m *mockNotifier) NotifyReleased(ctx context.Context, prState *PRState, releaseURL string) error {
+	if m.notifyReleasedFunc != nil {
+		return m.notifyReleasedFunc(ctx, prState, releaseURL)
 	}
 	return nil
 }

--- a/internal/autopilot/telegram_notifier.go
+++ b/internal/autopilot/telegram_notifier.go
@@ -74,6 +74,34 @@ func (n *TelegramNotifier) NotifyFixIssueCreated(ctx context.Context, prState *P
 	return err
 }
 
+// NotifyReleased sends notification when a release is created.
+func (n *TelegramNotifier) NotifyReleased(ctx context.Context, prState *PRState, releaseURL string) error {
+	bumpLabel := "release"
+	switch prState.ReleaseBumpType {
+	case BumpMajor:
+		bumpLabel = "major release"
+	case BumpMinor:
+		bumpLabel = "minor release"
+	case BumpPatch:
+		bumpLabel = "patch release"
+	}
+
+	msg := fmt.Sprintf("✨ *Release %s Published*\n\n"+
+		"Version: `%s`\n"+
+		"Type: %s\n"+
+		"From PR: #%d\n\n"+
+		"[View Release](%s)",
+		escapeMarkdown(prState.ReleaseVersion),
+		prState.ReleaseVersion,
+		bumpLabel,
+		prState.PRNumber,
+		releaseURL,
+	)
+
+	_, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown")
+	return err
+}
+
 // escapeMarkdown escapes special characters for Telegram Markdown.
 func escapeMarkdown(s string) string {
 	replacer := strings.NewReplacer(


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-313.

## Changes

GitHub Issue #313: feat(autopilot): add NotifyReleased to Telegram notifier (GH-307)

## Summary

Add `NotifyReleased()` method to the Telegram notifier for release notifications.

## Context

This is Phase 5 of the auto-release feature. When a release is created, send a notification via Telegram with version info and release URL.

## Dependencies

- GH-312: Controller Integration (for `ReleaseNotifier` interface)

## Implementation

### 1. Add NotifyReleased to TelegramNotifier

In `internal/autopilot/telegram_notifier.go`:

```go
// NotifyReleased sends notification when a release is created.
func (n *TelegramNotifier) NotifyReleased(ctx context.Context, prState *PRState, releaseURL string) error {
    bumpLabel := "release"
    switch prState.ReleaseBumpType {
    case BumpMajor:
        bumpLabel = "major release"
    case BumpMinor:
        bumpLabel = "minor release"
    case BumpPatch:
        bumpLabel = "patch release"
    }

    msg := fmt.Sprintf("✨ *Release %s Published*\n\n"+
        "Version: `%s`\n"+
        "Type: %s\n"+
        "From PR: #%d\n\n"+
        "[View Release](%s)",
        escapeMarkdown(prState.ReleaseVersion),
        prState.ReleaseVersion,
        bumpLabel,
        prState.PRNumber,
        releaseURL,
    )

    _, err := n.client.SendMessage(ctx, n.chatID, msg, "Markdown")
    return err
}
```

### 2. Verify TelegramNotifier implements ReleaseNotifier

The `TelegramNotifier` should now implement both `Notifier` and `ReleaseNotifier` interfaces. No explicit declaration needed since Go uses structural typing.

### 3. Example notification output

```
✨ Release v0.7.0 Published

Version: `v0.7.0`
Type: minor release
From PR: #305

[View Release](https://github.com/alekspetrov/pilot/releases/tag/v0.7.0)
```

## Files to Modify

- `internal/autopilot/telegram_notifier.go`

## Verification

```bash
go build ./...
go test ./internal/autopilot/... -v
```

## Acceptance Criteria

- [ ] `NotifyReleased()` method added to `TelegramNotifier`
- [ ] Method signature matches `ReleaseNotifier` interface
- [ ] Message includes version, bump type, PR number, release URL
- [ ] Markdown properly escaped
- [ ] Bump type label is human-readable (major/minor/patch)