### PR TITLE
fix(ci): Add notify-failure job to dispatch on CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   secret-patterns:
     name: Check Secret Patterns
@@ -56,3 +59,15 @@ jobs:
         with:
           version: v2.0.2
           args: --timeout=5m
+
+  notify-failure:
+    name: Notify CI Failure
+    needs: [test, lint, secret-patterns]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch CI failure event
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: ci-failure
+          client-payload: '{"run_id": "${{ github.run_id }}", "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}", "branch": "${{ github.ref_name }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Summary

- Add `notify-failure` job to `ci.yml` that dispatches `ci-failure` event when any CI job fails
- Include `run_id`, `run_url`, `branch`, and `sha` in the event payload
- Add `permissions: contents: write` for repository dispatch

## Why

The `ci-autofix.yml` workflow uses `workflow_run` trigger which has 0 successful triggers in 200+ runs. This explicit dispatch mechanism enables the autofix workflow to receive failure notifications reliably.

## Test plan

- [ ] CI passes when all jobs succeed (notify-failure skipped)
- [ ] When a job fails, `ci-failure` event is dispatched
- [ ] ci-autofix workflow receives the event

Closes #318