### PR TITLE
docs: add cloud deployment configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@
   <a href="#quick-start">Quick Start</a> •
   <a href="#how-it-works">How It Works</a> •
   <a href="#features">Features</a> •
-  <a href="#cli-reference">CLI</a>
+  <a href="#cli-reference">CLI</a> •
+  <a href="docs/DEPLOYMENT.md">Deploy</a>
 </p>
 
 <br />

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,47 @@
+# Pilot Deployment Configs
+
+Pre-built configurations for deploying Pilot on various cloud platforms.
+
+## Quick Reference
+
+| Platform | Config | Deploy Command |
+|----------|--------|----------------|
+| [Fly.io](https://fly.io) | `fly.toml` | `fly launch && fly deploy` |
+| [Railway](https://railway.app) | `railway.toml` | `railway up` |
+| [Render](https://render.com) | `render.yaml` | Connect repo in dashboard |
+| [Cloudflare](https://developers.cloudflare.com/containers/) | `cloudflare/wrangler.toml` | `wrangler containers deploy` |
+| [Azure](https://azure.microsoft.com/en-us/products/container-apps) | `azure/container-app.bicep` | `az deployment group create ...` |
+| [AWS](https://aws.amazon.com/fargate/) | `aws/cloudformation.yaml` | `aws cloudformation deploy ...` |
+
+## Full Documentation
+
+See [docs/DEPLOYMENT.md](../docs/DEPLOYMENT.md) for:
+- Detailed setup instructions per platform
+- Environment variable reference
+- Persistent storage configuration
+- Cost estimates
+- Troubleshooting
+
+## Required Secrets
+
+All platforms need these environment variables:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...    # Required
+GITHUB_TOKEN=ghp_...            # For GitHub integration
+TELEGRAM_BOT_TOKEN=...          # For Telegram integration
+```
+
+## Docker
+
+For any platform supporting containers:
+
+```bash
+docker run -d \
+  --name pilot \
+  -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+  -e GITHUB_TOKEN=$GITHUB_TOKEN \
+  -v pilot-data:/data \
+  ghcr.io/alekspetrov/pilot:latest \
+  start --telegram --github
+```

--- a/deploy/aws/cloudformation.yaml
+++ b/deploy/aws/cloudformation.yaml
@@ -1,0 +1,236 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Pilot - AI Development Agent on AWS Fargate'
+
+Parameters:
+  AnthropicApiKey:
+    Type: String
+    NoEcho: true
+    Description: Anthropic API key for Claude
+
+  GitHubToken:
+    Type: String
+    NoEcho: true
+    Description: GitHub personal access token
+
+  TelegramBotToken:
+    Type: String
+    NoEcho: true
+    Default: ''
+    Description: Telegram bot token (optional)
+
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC for Fargate deployment
+
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: Subnets for Fargate tasks
+
+  ContainerImage:
+    Type: String
+    Default: ghcr.io/alekspetrov/pilot:latest
+    Description: Container image to deploy
+
+Resources:
+  # ECS Cluster
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: pilot-cluster
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+
+  # CloudWatch Log Group
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /ecs/pilot
+      RetentionInDays: 30
+
+  # Secrets in Secrets Manager
+  AnthropicApiKeySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: pilot/anthropic-api-key
+      SecretString: !Ref AnthropicApiKey
+
+  GitHubTokenSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: pilot/github-token
+      SecretString: !Ref GitHubToken
+
+  TelegramBotTokenSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: pilot/telegram-bot-token
+      SecretString: !Ref TelegramBotToken
+
+  # EFS File System for persistent storage
+  FileSystem:
+    Type: AWS::EFS::FileSystem
+    Properties:
+      Encrypted: true
+      PerformanceMode: generalPurpose
+      ThroughputMode: bursting
+      FileSystemTags:
+        - Key: Name
+          Value: pilot-data
+
+  MountTargetSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for EFS mount targets
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 2049
+          ToPort: 2049
+          SourceSecurityGroupId: !Ref TaskSecurityGroup
+
+  MountTarget:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Ref FileSystem
+      SubnetId: !Select [0, !Ref SubnetIds]
+      SecurityGroups:
+        - !Ref MountTargetSecurityGroup
+
+  # Task Execution Role
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: pilot-execution-role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Policies:
+        - PolicyName: SecretsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - !Ref AnthropicApiKeySecret
+                  - !Ref GitHubTokenSecret
+                  - !Ref TelegramBotTokenSecret
+
+  # Task Role
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: pilot-task-role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+
+  # Security Group for Tasks
+  TaskSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for Pilot tasks
+      VpcId: !Ref VpcId
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+
+  # Task Definition
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: pilot
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: '256'
+      Memory: '512'
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      Volumes:
+        - Name: pilot-data
+          EFSVolumeConfiguration:
+            FilesystemId: !Ref FileSystem
+            RootDirectory: /pilot
+            TransitEncryption: ENABLED
+      ContainerDefinitions:
+        - Name: pilot
+          Image: !Ref ContainerImage
+          Essential: true
+          Command:
+            - pilot
+            - start
+            - --telegram
+            - --github
+          Environment:
+            - Name: PILOT_DATA_DIR
+              Value: /data
+          Secrets:
+            - Name: ANTHROPIC_API_KEY
+              ValueFrom: !Ref AnthropicApiKeySecret
+            - Name: GITHUB_TOKEN
+              ValueFrom: !Ref GitHubTokenSecret
+            - Name: TELEGRAM_BOT_TOKEN
+              ValueFrom: !Ref TelegramBotTokenSecret
+          MountPoints:
+            - SourceVolume: pilot-data
+              ContainerPath: /data
+              ReadOnly: false
+          HealthCheck:
+            Command:
+              - CMD-SHELL
+              - curl -f http://localhost:9090/health || exit 1
+            Interval: 30
+            Timeout: 5
+            Retries: 3
+            StartPeriod: 60
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: pilot
+
+  # ECS Service
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn: MountTarget
+    Properties:
+      ServiceName: pilot
+      Cluster: !Ref Cluster
+      TaskDefinition: !Ref TaskDefinition
+      DesiredCount: 1
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - !Ref TaskSecurityGroup
+          Subnets: !Ref SubnetIds
+
+Outputs:
+  ClusterArn:
+    Description: ECS Cluster ARN
+    Value: !GetAtt Cluster.Arn
+
+  ServiceArn:
+    Description: ECS Service ARN
+    Value: !Ref Service
+
+  LogGroupName:
+    Description: CloudWatch Log Group
+    Value: !Ref LogGroup

--- a/deploy/aws/task-definition.json
+++ b/deploy/aws/task-definition.json
@@ -1,0 +1,69 @@
+{
+  "family": "pilot",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512",
+  "executionRoleArn": "arn:aws:iam::ACCOUNT_ID:role/ecsTaskExecutionRole",
+  "taskRoleArn": "arn:aws:iam::ACCOUNT_ID:role/pilotTaskRole",
+  "containerDefinitions": [
+    {
+      "name": "pilot",
+      "image": "ghcr.io/alekspetrov/pilot:latest",
+      "essential": true,
+      "command": ["pilot", "start", "--telegram", "--github"],
+      "environment": [
+        {
+          "name": "PILOT_DATA_DIR",
+          "value": "/data"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "ANTHROPIC_API_KEY",
+          "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT_ID:secret:pilot/anthropic-api-key"
+        },
+        {
+          "name": "GITHUB_TOKEN",
+          "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT_ID:secret:pilot/github-token"
+        },
+        {
+          "name": "TELEGRAM_BOT_TOKEN",
+          "valueFrom": "arn:aws:secretsmanager:REGION:ACCOUNT_ID:secret:pilot/telegram-bot-token"
+        }
+      ],
+      "mountPoints": [
+        {
+          "sourceVolume": "pilot-data",
+          "containerPath": "/data",
+          "readOnly": false
+        }
+      ],
+      "healthCheck": {
+        "command": ["CMD-SHELL", "curl -f http://localhost:9090/health || exit 1"],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 60
+      },
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/pilot",
+          "awslogs-region": "REGION",
+          "awslogs-stream-prefix": "pilot"
+        }
+      }
+    }
+  ],
+  "volumes": [
+    {
+      "name": "pilot-data",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "fs-XXXXXXXXX",
+        "rootDirectory": "/pilot",
+        "transitEncryption": "ENABLED"
+      }
+    }
+  ]
+}

--- a/deploy/azure/container-app.bicep
+++ b/deploy/azure/container-app.bicep
@@ -1,0 +1,159 @@
+// Azure Container Apps deployment for Pilot
+// https://learn.microsoft.com/en-us/azure/container-apps/
+//
+// Deploy:
+//   az group create --name pilot-rg --location eastus
+//   az deployment group create \
+//     --resource-group pilot-rg \
+//     --template-file deploy/azure/container-app.bicep \
+//     --parameters anthropicApiKey=$ANTHROPIC_API_KEY githubToken=$GITHUB_TOKEN
+
+@description('Anthropic API key for Claude')
+@secure()
+param anthropicApiKey string
+
+@description('GitHub token for repository access')
+@secure()
+param githubToken string
+
+@description('Telegram bot token (optional)')
+@secure()
+param telegramBotToken string = ''
+
+@description('Telegram chat ID (optional)')
+param telegramChatId string = ''
+
+@description('Azure region for deployment')
+param location string = resourceGroup().location
+
+@description('Container image to deploy')
+param containerImage string = 'ghcr.io/alekspetrov/pilot:latest'
+
+// Container Apps Environment
+resource environment 'Microsoft.App/managedEnvironments@2023-11-02-preview' = {
+  name: 'pilot-env'
+  location: location
+  properties: {
+    zoneRedundant: false
+  }
+}
+
+// Storage for SQLite knowledge graph
+resource storage 'Microsoft.App/managedEnvironments/storages@2023-11-02-preview' = {
+  parent: environment
+  name: 'pilot-storage'
+  properties: {
+    azureFile: {
+      accountName: storageAccount.name
+      accountKey: storageAccount.listKeys().keys[0].value
+      shareName: fileShare.name
+      accessMode: 'ReadWrite'
+    }
+  }
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'pilotdata${uniqueString(resourceGroup().id)}'
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}
+
+resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-01-01' = {
+  name: '${storageAccount.name}/default/pilot-data'
+  properties: {
+    shareQuota: 1
+  }
+}
+
+// Pilot Container App
+resource containerApp 'Microsoft.App/containerApps@2023-11-02-preview' = {
+  name: 'pilot'
+  location: location
+  properties: {
+    managedEnvironmentId: environment.id
+    configuration: {
+      secrets: [
+        {
+          name: 'anthropic-api-key'
+          value: anthropicApiKey
+        }
+        {
+          name: 'github-token'
+          value: githubToken
+        }
+        {
+          name: 'telegram-bot-token'
+          value: telegramBotToken
+        }
+      ]
+      registries: []
+    }
+    template: {
+      containers: [
+        {
+          name: 'pilot'
+          image: containerImage
+          command: ['pilot', 'start', '--telegram', '--github']
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            {
+              name: 'ANTHROPIC_API_KEY'
+              secretRef: 'anthropic-api-key'
+            }
+            {
+              name: 'GITHUB_TOKEN'
+              secretRef: 'github-token'
+            }
+            {
+              name: 'TELEGRAM_BOT_TOKEN'
+              secretRef: 'telegram-bot-token'
+            }
+            {
+              name: 'TELEGRAM_CHAT_ID'
+              value: telegramChatId
+            }
+            {
+              name: 'PILOT_DATA_DIR'
+              value: '/data'
+            }
+          ]
+          volumeMounts: [
+            {
+              volumeName: 'pilot-data'
+              mountPath: '/data'
+            }
+          ]
+          probes: [
+            {
+              type: 'Liveness'
+              httpGet: {
+                path: '/health'
+                port: 9090
+              }
+              periodSeconds: 30
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+      volumes: [
+        {
+          name: 'pilot-data'
+          storageName: 'pilot-storage'
+          storageType: 'AzureFile'
+        }
+      ]
+    }
+  }
+}
+
+output containerAppUrl string = 'https://${containerApp.properties.configuration.ingress.fqdn}'

--- a/deploy/cloudflare/wrangler.toml
+++ b/deploy/cloudflare/wrangler.toml
@@ -1,0 +1,34 @@
+# Cloudflare Containers configuration for Pilot
+# https://developers.cloudflare.com/containers/
+#
+# Note: Cloudflare Containers launched June 2025, may have limitations
+#
+# Deploy:
+#   wrangler login
+#   wrangler containers deploy
+
+name = "pilot"
+compatibility_date = "2025-06-01"
+
+[containers]
+image = "ghcr.io/alekspetrov/pilot:latest"
+command = ["pilot", "start", "--telegram", "--github"]
+
+# CPU and memory allocation
+cpu = 1
+memory = "512Mi"
+
+# Keep running (not scale-to-zero)
+min_instances = 1
+max_instances = 1
+
+[containers.env]
+PILOT_DATA_DIR = "/data"
+
+# Secrets (set via wrangler secret put)
+# wrangler secret put ANTHROPIC_API_KEY
+# wrangler secret put GITHUB_TOKEN
+# wrangler secret put TELEGRAM_BOT_TOKEN
+
+[containers.volumes]
+pilot_data = "/data"

--- a/deploy/fly.toml
+++ b/deploy/fly.toml
@@ -1,0 +1,45 @@
+# Fly.io deployment configuration for Pilot
+# https://fly.io/docs/reference/configuration/
+#
+# Deploy:
+#   fly launch --no-deploy
+#   fly secrets set ANTHROPIC_API_KEY=xxx GITHUB_TOKEN=xxx
+#   fly deploy
+
+app = "pilot"
+primary_region = "iad"
+
+[build]
+image = "ghcr.io/alekspetrov/pilot:latest"
+
+[env]
+PILOT_DATA_DIR = "/data"
+
+# Persistent storage for SQLite knowledge graph
+[mounts]
+source = "pilot_data"
+destination = "/data"
+
+# Keep at least one instance running
+[[services]]
+internal_port = 9090
+protocol = "tcp"
+auto_stop_machines = false
+auto_start_machines = true
+min_machines_running = 1
+
+[[services.ports]]
+port = 9090
+handlers = ["http"]
+
+[[services.http_checks]]
+interval = "30s"
+timeout = "5s"
+path = "/health"
+
+[processes]
+app = "pilot start --telegram --github"
+
+[[vm]]
+size = "shared-cpu-1x"
+memory = "512mb"

--- a/deploy/railway.toml
+++ b/deploy/railway.toml
@@ -1,0 +1,20 @@
+# Railway deployment configuration for Pilot
+# https://docs.railway.app/reference/config-as-code
+#
+# Deploy:
+#   railway login
+#   railway init
+#   railway variables set ANTHROPIC_API_KEY=xxx GITHUB_TOKEN=xxx
+#   railway up
+
+[build]
+builder = "nixpacks"
+
+[deploy]
+startCommand = "pilot start --telegram --github"
+restartPolicyType = "always"
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+
+# Railway auto-detects Go via go.mod
+# No Dockerfile needed

--- a/deploy/render.yaml
+++ b/deploy/render.yaml
@@ -1,0 +1,32 @@
+# Render deployment configuration for Pilot
+# https://render.com/docs/infrastructure-as-code
+#
+# Deploy:
+#   1. Connect GitHub repo to Render
+#   2. Select "Background Worker"
+#   3. Render auto-detects this file
+
+services:
+  - type: worker
+    name: pilot
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    region: oregon
+    plan: starter
+    envVars:
+      - key: ANTHROPIC_API_KEY
+        sync: false
+      - key: GITHUB_TOKEN
+        sync: false
+      - key: TELEGRAM_BOT_TOKEN
+        sync: false
+      - key: TELEGRAM_CHAT_ID
+        sync: false
+      - key: PILOT_DATA_DIR
+        value: /data
+    disk:
+      name: pilot-data
+      mountPath: /data
+      sizeGB: 1
+    healthCheckPath: /health
+    autoDeploy: true

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,407 @@
+# Deployment Guide
+
+Deploy Pilot on your preferred cloud platform. Pilot is a Go binary that runs as a long-running daemon, polling for tasks and executing them.
+
+## Requirements
+
+- Outbound HTTPS (Claude API, GitHub/Linear/Jira APIs)
+- Persistent disk for SQLite knowledge graph (~100MB)
+- `ANTHROPIC_API_KEY` environment variable
+- No inbound ports required (Pilot polls, doesn't need webhooks)
+
+## Platform Comparison
+
+### Recommended (Long-running daemon support)
+
+| Platform | Config | Min Cost | Notes |
+|----------|--------|----------|-------|
+| [Azure Container Apps](#azure-container-apps) | `deploy/azure/` | ~$5/mo | Always-on with reduced idle pricing |
+| [Cloudflare Containers](#cloudflare-containers) | `deploy/cloudflare/` | Usage-based | New in 2025, "Region: Earth" deployment |
+| [Fly.io](#flyio) | `deploy/fly.toml` | ~$2/mo | Hardware-virtualized, instant start |
+| [Railway](#railway) | `deploy/railway.toml` | ~$5/mo | Native Workers support, auto-detect Go |
+| [Render](#render) | `deploy/render.yaml` | ~$7/mo | Background workers + cron built-in |
+| [AWS Fargate](#aws-fargateecs) | `deploy/aws/` | ~$10/mo | Full control, enterprise-grade |
+
+### Not Recommended
+
+| Platform | Issue |
+|----------|-------|
+| Vercel | 5min function timeout, serverless-only |
+| AWS App Runner | No persistent processes, stateless only |
+| Cloudflare Workers (non-container) | 30s CPU limit |
+| AWS Lambda | 15min max, cold starts |
+
+## Quick Deploy
+
+### Docker (Any Platform)
+
+```bash
+docker run -d \
+  --name pilot \
+  -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+  -e GITHUB_TOKEN=$GITHUB_TOKEN \
+  -e TELEGRAM_BOT_TOKEN=$TELEGRAM_BOT_TOKEN \
+  -v pilot-data:/data \
+  -v /path/to/projects:/projects \
+  ghcr.io/alekspetrov/pilot:latest \
+  start --telegram --github
+```
+
+---
+
+## Azure Container Apps
+
+Azure Container Apps supports always-on background jobs with reduced idle pricing.
+
+### Deploy with Azure CLI
+
+```bash
+# Create resource group
+az group create --name pilot-rg --location eastus
+
+# Create Container Apps environment
+az containerapp env create \
+  --name pilot-env \
+  --resource-group pilot-rg \
+  --location eastus
+
+# Deploy Pilot
+az containerapp create \
+  --name pilot \
+  --resource-group pilot-rg \
+  --environment pilot-env \
+  --image ghcr.io/alekspetrov/pilot:latest \
+  --min-replicas 1 \
+  --max-replicas 1 \
+  --cpu 0.5 \
+  --memory 1Gi \
+  --env-vars \
+    ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+    GITHUB_TOKEN=$GITHUB_TOKEN \
+    TELEGRAM_BOT_TOKEN=$TELEGRAM_BOT_TOKEN \
+  --command "pilot" "start" "--telegram" "--github"
+```
+
+### Deploy with Bicep
+
+See `deploy/azure/container-app.bicep` for Infrastructure as Code.
+
+```bash
+az deployment group create \
+  --resource-group pilot-rg \
+  --template-file deploy/azure/container-app.bicep \
+  --parameters anthropicApiKey=$ANTHROPIC_API_KEY
+```
+
+**Estimated cost:** ~$5-15/mo depending on usage (idle replicas billed at reduced rate)
+
+---
+
+## Cloudflare Containers
+
+Cloudflare Containers (launched June 2025) allows running any Docker image globally.
+
+### Deploy
+
+```bash
+# Install Wrangler CLI
+npm install -g wrangler
+
+# Login to Cloudflare
+wrangler login
+
+# Deploy container
+wrangler containers deploy \
+  --name pilot \
+  --image ghcr.io/alekspetrov/pilot:latest
+```
+
+### Configuration
+
+See `deploy/cloudflare/wrangler.toml`:
+
+```toml
+name = "pilot"
+compatibility_date = "2025-06-01"
+
+[containers]
+image = "ghcr.io/alekspetrov/pilot:latest"
+command = ["pilot", "start", "--telegram", "--github"]
+
+[containers.env]
+ANTHROPIC_API_KEY = { type = "secret" }
+GITHUB_TOKEN = { type = "secret" }
+```
+
+**Note:** Cloudflare Containers is in beta. Check [Cloudflare docs](https://developers.cloudflare.com/containers/) for current limitations.
+
+**Estimated cost:** Usage-based, competitive with other platforms
+
+---
+
+## Fly.io
+
+Fly.io runs hardware-virtualized containers with instant start times. Great for Go binaries.
+
+### Deploy
+
+```bash
+# Install flyctl
+curl -L https://fly.io/install.sh | sh
+
+# Launch app
+fly launch --no-deploy
+
+# Set secrets
+fly secrets set \
+  ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+  GITHUB_TOKEN=$GITHUB_TOKEN \
+  TELEGRAM_BOT_TOKEN=$TELEGRAM_BOT_TOKEN
+
+# Deploy
+fly deploy
+```
+
+### Configuration
+
+See `deploy/fly.toml`:
+
+```toml
+app = "pilot"
+primary_region = "iad"
+
+[build]
+image = "ghcr.io/alekspetrov/pilot:latest"
+
+[env]
+PILOT_DATA_DIR = "/data"
+
+[mounts]
+source = "pilot_data"
+destination = "/data"
+
+[[services]]
+internal_port = 9090
+protocol = "tcp"
+auto_stop_machines = false
+auto_start_machines = true
+min_machines_running = 1
+
+[processes]
+app = "pilot start --telegram --github"
+```
+
+**Estimated cost:** ~$2-5/mo (shared-cpu-1x with 256MB)
+
+---
+
+## Railway
+
+Railway auto-detects Go projects and supports background workers natively.
+
+### Deploy
+
+```bash
+# Install Railway CLI
+npm install -g @railway/cli
+
+# Login
+railway login
+
+# Initialize project
+railway init
+
+# Deploy
+railway up
+```
+
+### Configuration
+
+See `deploy/railway.toml`:
+
+```toml
+[build]
+builder = "nixpacks"
+
+[deploy]
+startCommand = "pilot start --telegram --github"
+restartPolicyType = "always"
+```
+
+Set environment variables in Railway dashboard or CLI:
+
+```bash
+railway variables set ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
+railway variables set GITHUB_TOKEN=$GITHUB_TOKEN
+```
+
+**Estimated cost:** ~$5/mo (usage-based)
+
+---
+
+## Render
+
+Render has native background worker support with persistent disks.
+
+### Deploy
+
+1. Connect your GitHub repository
+2. Select "Background Worker" as service type
+3. Configure environment variables
+4. Deploy
+
+### Configuration
+
+See `deploy/render.yaml`:
+
+```yaml
+services:
+  - type: worker
+    name: pilot
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    envVars:
+      - key: ANTHROPIC_API_KEY
+        sync: false
+      - key: GITHUB_TOKEN
+        sync: false
+      - key: TELEGRAM_BOT_TOKEN
+        sync: false
+    disk:
+      name: pilot-data
+      mountPath: /data
+      sizeGB: 1
+```
+
+**Estimated cost:** ~$7/mo (Starter plan)
+
+---
+
+## AWS Fargate/ECS
+
+For enterprise deployments with full control.
+
+### Deploy with AWS CLI
+
+```bash
+# Create ECS cluster
+aws ecs create-cluster --cluster-name pilot-cluster
+
+# Register task definition
+aws ecs register-task-definition \
+  --cli-input-json file://deploy/aws/task-definition.json
+
+# Create service
+aws ecs create-service \
+  --cluster pilot-cluster \
+  --service-name pilot \
+  --task-definition pilot \
+  --desired-count 1 \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-xxx],securityGroups=[sg-xxx],assignPublicIp=ENABLED}"
+```
+
+### Configuration
+
+See `deploy/aws/task-definition.json` for full ECS task definition.
+
+**Estimated cost:** ~$10-20/mo (0.25 vCPU, 0.5GB)
+
+---
+
+## Self-Hosted (VM/VPS)
+
+For any Linux VM (Azure VM, EC2, DigitalOcean, etc.):
+
+```bash
+# Install Pilot
+curl -fsSL https://raw.githubusercontent.com/alekspetrov/pilot/main/install.sh | bash
+
+# Create systemd service
+sudo tee /etc/systemd/system/pilot.service > /dev/null <<EOF
+[Unit]
+Description=Pilot AI Development Agent
+After=network.target
+
+[Service]
+Type=simple
+User=pilot
+Environment=ANTHROPIC_API_KEY=your-key
+Environment=GITHUB_TOKEN=your-token
+ExecStart=/usr/local/bin/pilot start --telegram --github
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Enable and start
+sudo systemctl enable pilot
+sudo systemctl start pilot
+```
+
+**Estimated cost:** $4-10/mo (smallest VM tier)
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ANTHROPIC_API_KEY` | Yes | Claude API key |
+| `GITHUB_TOKEN` | For GitHub | Personal access token with repo scope |
+| `TELEGRAM_BOT_TOKEN` | For Telegram | Bot token from @BotFather |
+| `TELEGRAM_CHAT_ID` | For Telegram | Your chat ID |
+| `LINEAR_API_KEY` | For Linear | Linear API key |
+| `SLACK_BOT_TOKEN` | For Slack | Slack bot OAuth token |
+
+## Persistent Storage
+
+Pilot stores data in SQLite. Mount a persistent volume at:
+
+- Default: `~/.pilot/`
+- Override: `PILOT_DATA_DIR=/custom/path`
+
+Minimum disk: 100MB (grows with knowledge graph)
+
+## Health Checks
+
+Pilot exposes health endpoints when gateway is enabled:
+
+```bash
+# Health check
+curl http://localhost:9090/health
+
+# Ready check
+curl http://localhost:9090/ready
+```
+
+## Troubleshooting
+
+### Container won't start
+
+Check logs for missing environment variables:
+```bash
+docker logs pilot
+fly logs
+railway logs
+```
+
+### Can't connect to APIs
+
+Ensure outbound HTTPS (443) is allowed. No inbound ports needed.
+
+### High memory usage
+
+Pilot typically uses 50-200MB. If higher:
+- Check for stuck Claude Code processes
+- Restart the container
+
+---
+
+## Next Steps
+
+- [Configuration Guide](../README.md#configuration)
+- [CLI Reference](../README.md#cli-reference)
+- [Telegram Setup](./TELEGRAM.md)


### PR DESCRIPTION
## Summary

- Add `deploy/` directory with IaC configs for 6 cloud platforms
- Add `docs/DEPLOYMENT.md` with full deployment guide
- Update README nav to link to deployment docs

## Platforms Supported

| Platform | Config | Notes |
|----------|--------|-------|
| Azure Container Apps | `deploy/azure/container-app.bicep` | Always-on with reduced idle pricing |
| AWS Fargate/ECS | `deploy/aws/cloudformation.yaml` | Full CloudFormation stack |
| Cloudflare Containers | `deploy/cloudflare/wrangler.toml` | New 2025 platform |
| Fly.io | `deploy/fly.toml` | Hardware-virtualized containers |
| Railway | `deploy/railway.toml` | Native Workers support |
| Render | `deploy/render.yaml` | Background worker config |

## Research

Based on 2026 platform capabilities:
- Cloudflare Containers launched June 2025, now supports any Docker image
- Railway added native Cron & Workers
- Azure Container Apps has always-on at reduced idle rate
- Vercel/Lambda still not suitable for daemons (documented in guide)

## Test plan

- [ ] Review IaC configs for correctness
- [ ] Verify deployment guide accuracy