### PR TITLE
feat(approval): add GitHub PR review as approval source (GH-324)

### DIFF
--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -242,6 +242,25 @@ const (
 	ReviewEventComment        = "COMMENT"
 )
 
+// Review states returned by GitHub API
+const (
+	ReviewStateApproved         = "APPROVED"
+	ReviewStateChangesRequested = "CHANGES_REQUESTED"
+	ReviewStateCommented        = "COMMENTED"
+	ReviewStateDismissed        = "DISMISSED"
+	ReviewStatePending          = "PENDING"
+)
+
+// PullRequestReview represents a GitHub PR review
+type PullRequestReview struct {
+	ID          int64  `json:"id"`
+	User        User   `json:"user"`
+	Body        string `json:"body,omitempty"`
+	State       string `json:"state"` // APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED, PENDING
+	HTMLURL     string `json:"html_url,omitempty"`
+	SubmittedAt string `json:"submitted_at,omitempty"`
+}
+
 // Branch represents a GitHub branch
 type Branch struct {
 	Name      string       `json:"name"`

--- a/internal/approval/github.go
+++ b/internal/approval/github.go
@@ -1,0 +1,300 @@
+package approval
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// GitHubReviewClient defines the interface for GitHub PR review operations
+type GitHubReviewClient interface {
+	HasApprovalReview(ctx context.Context, owner, repo string, number int) (bool, string, error)
+}
+
+// GitHubHandler handles approval requests via GitHub PR reviews
+type GitHubHandler struct {
+	client       GitHubReviewClient
+	owner        string
+	repo         string
+	pollInterval time.Duration
+	pending      map[string]*githubPending // requestID -> pending state
+	mu           sync.RWMutex
+	log          *slog.Logger
+}
+
+// githubPending tracks a pending GitHub approval request
+type githubPending struct {
+	Request    *Request
+	PRNumber   int
+	ResponseCh chan *Response
+	CancelFn   context.CancelFunc
+}
+
+// GitHubHandlerConfig holds configuration for the GitHub approval handler
+type GitHubHandlerConfig struct {
+	Owner        string
+	Repo         string
+	PollInterval time.Duration // How often to check for reviews (default: 30s)
+}
+
+// NewGitHubHandler creates a new GitHub PR review approval handler
+func NewGitHubHandler(client GitHubReviewClient, cfg *GitHubHandlerConfig) *GitHubHandler {
+	pollInterval := cfg.PollInterval
+	if pollInterval == 0 {
+		pollInterval = 30 * time.Second
+	}
+
+	return &GitHubHandler{
+		client:       client,
+		owner:        cfg.Owner,
+		repo:         cfg.Repo,
+		pollInterval: pollInterval,
+		pending:      make(map[string]*githubPending),
+		log:          logging.WithComponent("approval.github"),
+	}
+}
+
+// Name returns the handler name
+func (h *GitHubHandler) Name() string {
+	return "github"
+}
+
+// SendApprovalRequest starts polling for PR approval reviews
+func (h *GitHubHandler) SendApprovalRequest(ctx context.Context, req *Request) (<-chan *Response, error) {
+	responseCh := make(chan *Response, 1)
+
+	// Extract PR number from metadata
+	prNumber, ok := req.Metadata["pr_number"].(int)
+	if !ok {
+		// Try float64 (JSON unmarshaling)
+		if prFloat, ok := req.Metadata["pr_number"].(float64); ok {
+			prNumber = int(prFloat)
+		} else {
+			return nil, fmt.Errorf("pr_number missing from approval request metadata")
+		}
+	}
+
+	// Create cancellable context for polling
+	pollCtx, cancelFn := context.WithCancel(ctx)
+
+	// Track pending request
+	h.mu.Lock()
+	h.pending[req.ID] = &githubPending{
+		Request:    req,
+		PRNumber:   prNumber,
+		ResponseCh: responseCh,
+		CancelFn:   cancelFn,
+	}
+	h.mu.Unlock()
+
+	h.log.Info("Waiting for GitHub PR approval",
+		slog.String("request_id", req.ID),
+		slog.Int("pr_number", prNumber),
+		slog.Duration("poll_interval", h.pollInterval))
+
+	// Start polling goroutine
+	go h.pollForApproval(pollCtx, req.ID)
+
+	return responseCh, nil
+}
+
+// pollForApproval polls GitHub for approval reviews
+func (h *GitHubHandler) pollForApproval(ctx context.Context, requestID string) {
+	ticker := time.NewTicker(h.pollInterval)
+	defer ticker.Stop()
+
+	// Check immediately first
+	if h.checkApproval(ctx, requestID) {
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			h.log.Debug("Polling cancelled",
+				slog.String("request_id", requestID))
+			return
+		case <-ticker.C:
+			if h.checkApproval(ctx, requestID) {
+				return
+			}
+		}
+	}
+}
+
+// checkApproval checks if the PR has been approved and sends response if so
+func (h *GitHubHandler) checkApproval(ctx context.Context, requestID string) bool {
+	h.mu.RLock()
+	pending, exists := h.pending[requestID]
+	h.mu.RUnlock()
+
+	if !exists {
+		return true // Request was cancelled/removed
+	}
+
+	approved, approver, err := h.client.HasApprovalReview(ctx, h.owner, h.repo, pending.PRNumber)
+	if err != nil {
+		h.log.Warn("Failed to check PR reviews",
+			slog.String("request_id", requestID),
+			slog.Int("pr_number", pending.PRNumber),
+			slog.Any("error", err))
+		return false
+	}
+
+	if approved {
+		h.log.Info("PR approved",
+			slog.String("request_id", requestID),
+			slog.Int("pr_number", pending.PRNumber),
+			slog.String("approver", approver))
+
+		// Remove from pending
+		h.mu.Lock()
+		delete(h.pending, requestID)
+		h.mu.Unlock()
+
+		// Send response
+		response := &Response{
+			RequestID:   requestID,
+			Decision:    DecisionApproved,
+			ApprovedBy:  approver,
+			RespondedAt: time.Now(),
+		}
+
+		select {
+		case pending.ResponseCh <- response:
+		default:
+		}
+		close(pending.ResponseCh)
+
+		return true
+	}
+
+	return false
+}
+
+// CancelRequest cancels a pending approval request
+func (h *GitHubHandler) CancelRequest(ctx context.Context, requestID string) error {
+	h.mu.Lock()
+	pending, exists := h.pending[requestID]
+	if exists {
+		delete(h.pending, requestID)
+	}
+	h.mu.Unlock()
+
+	if !exists {
+		return nil
+	}
+
+	// Cancel polling
+	pending.CancelFn()
+
+	// Close response channel
+	close(pending.ResponseCh)
+
+	h.log.Debug("Cancelled GitHub approval request",
+		slog.String("request_id", requestID))
+
+	return nil
+}
+
+// HandleReviewEvent handles a GitHub pull_request_review webhook event
+// This provides instant response instead of waiting for poll
+func (h *GitHubHandler) HandleReviewEvent(ctx context.Context, prNumber int, action, state, reviewer string) bool {
+	// Only process submitted reviews that are approvals
+	if action != "submitted" || state != "approved" {
+		return false
+	}
+
+	// Find pending request for this PR
+	h.mu.Lock()
+	var foundID string
+	var foundPending *githubPending
+	for id, pending := range h.pending {
+		if pending.PRNumber == prNumber {
+			foundID = id
+			foundPending = pending
+			delete(h.pending, id)
+			break
+		}
+	}
+	h.mu.Unlock()
+
+	if foundPending == nil {
+		return false
+	}
+
+	h.log.Info("PR approved via webhook",
+		slog.String("request_id", foundID),
+		slog.Int("pr_number", prNumber),
+		slog.String("reviewer", reviewer))
+
+	// Cancel polling
+	foundPending.CancelFn()
+
+	// Send response
+	response := &Response{
+		RequestID:   foundID,
+		Decision:    DecisionApproved,
+		ApprovedBy:  reviewer,
+		RespondedAt: time.Now(),
+	}
+
+	select {
+	case foundPending.ResponseCh <- response:
+	default:
+	}
+	close(foundPending.ResponseCh)
+
+	return true
+}
+
+// HandleChangesRequestedEvent handles when changes are requested on a PR
+// This rejects the approval request
+func (h *GitHubHandler) HandleChangesRequestedEvent(ctx context.Context, prNumber int, reviewer string) bool {
+	// Find pending request for this PR
+	h.mu.Lock()
+	var foundID string
+	var foundPending *githubPending
+	for id, pending := range h.pending {
+		if pending.PRNumber == prNumber {
+			foundID = id
+			foundPending = pending
+			delete(h.pending, id)
+			break
+		}
+	}
+	h.mu.Unlock()
+
+	if foundPending == nil {
+		return false
+	}
+
+	h.log.Info("PR changes requested via webhook",
+		slog.String("request_id", foundID),
+		slog.Int("pr_number", prNumber),
+		slog.String("reviewer", reviewer))
+
+	// Cancel polling
+	foundPending.CancelFn()
+
+	// Send rejection response
+	response := &Response{
+		RequestID:   foundID,
+		Decision:    DecisionRejected,
+		ApprovedBy:  reviewer,
+		Comment:     "Changes requested",
+		RespondedAt: time.Now(),
+	}
+
+	select {
+	case foundPending.ResponseCh <- response:
+	default:
+	}
+	close(foundPending.ResponseCh)
+
+	return true
+}

--- a/internal/approval/github_test.go
+++ b/internal/approval/github_test.go
@@ -1,0 +1,348 @@
+package approval
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// mockGitHubReviewClient implements GitHubReviewClient for testing
+type mockGitHubReviewClient struct {
+	hasApproval bool
+	approver    string
+	err         error
+	callCount   int
+}
+
+func (m *mockGitHubReviewClient) HasApprovalReview(ctx context.Context, owner, repo string, number int) (bool, string, error) {
+	m.callCount++
+	return m.hasApproval, m.approver, m.err
+}
+
+func TestNewGitHubHandler(t *testing.T) {
+	client := &mockGitHubReviewClient{}
+	cfg := &GitHubHandlerConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		PollInterval: 10 * time.Second,
+	}
+
+	handler := NewGitHubHandler(client, cfg)
+
+	if handler == nil {
+		t.Fatal("NewGitHubHandler returned nil")
+	}
+	if handler.owner != "owner" {
+		t.Errorf("handler.owner = %s, want owner", handler.owner)
+	}
+	if handler.repo != "repo" {
+		t.Errorf("handler.repo = %s, want repo", handler.repo)
+	}
+	if handler.pollInterval != 10*time.Second {
+		t.Errorf("handler.pollInterval = %v, want 10s", handler.pollInterval)
+	}
+}
+
+func TestNewGitHubHandler_DefaultPollInterval(t *testing.T) {
+	client := &mockGitHubReviewClient{}
+	cfg := &GitHubHandlerConfig{
+		Owner: "owner",
+		Repo:  "repo",
+		// PollInterval not set
+	}
+
+	handler := NewGitHubHandler(client, cfg)
+
+	if handler.pollInterval != 30*time.Second {
+		t.Errorf("handler.pollInterval = %v, want 30s default", handler.pollInterval)
+	}
+}
+
+func TestGitHubHandler_Name(t *testing.T) {
+	handler := &GitHubHandler{}
+	if handler.Name() != "github" {
+		t.Errorf("Name() = %s, want github", handler.Name())
+	}
+}
+
+func TestGitHubHandler_SendApprovalRequest_MissingPRNumber(t *testing.T) {
+	client := &mockGitHubReviewClient{}
+	cfg := &GitHubHandlerConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		PollInterval: time.Millisecond,
+	}
+	handler := NewGitHubHandler(client, cfg)
+
+	req := &Request{
+		ID:       "test-123",
+		TaskID:   "task-1",
+		Stage:    StagePreMerge,
+		Metadata: map[string]interface{}{}, // Missing pr_number
+	}
+
+	_, err := handler.SendApprovalRequest(context.Background(), req)
+	if err == nil {
+		t.Error("expected error for missing pr_number")
+	}
+}
+
+func TestGitHubHandler_SendApprovalRequest_ImmediateApproval(t *testing.T) {
+	client := &mockGitHubReviewClient{
+		hasApproval: true,
+		approver:    "alice",
+	}
+	cfg := &GitHubHandlerConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		PollInterval: time.Millisecond,
+	}
+	handler := NewGitHubHandler(client, cfg)
+
+	req := &Request{
+		ID:     "test-123",
+		TaskID: "task-1",
+		Stage:  StagePreMerge,
+		Metadata: map[string]interface{}{
+			"pr_number": 42,
+		},
+	}
+
+	responseCh, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("SendApprovalRequest failed: %v", err)
+	}
+
+	// Wait for response with timeout
+	select {
+	case resp := <-responseCh:
+		if resp.Decision != DecisionApproved {
+			t.Errorf("response.Decision = %s, want approved", resp.Decision)
+		}
+		if resp.ApprovedBy != "alice" {
+			t.Errorf("response.ApprovedBy = %s, want alice", resp.ApprovedBy)
+		}
+	case <-time.After(time.Second):
+		t.Error("timeout waiting for approval response")
+	}
+}
+
+func TestGitHubHandler_SendApprovalRequest_PRNumberAsFloat64(t *testing.T) {
+	client := &mockGitHubReviewClient{
+		hasApproval: true,
+		approver:    "bob",
+	}
+	cfg := &GitHubHandlerConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		PollInterval: time.Millisecond,
+	}
+	handler := NewGitHubHandler(client, cfg)
+
+	// JSON unmarshaling produces float64 for numbers
+	req := &Request{
+		ID:     "test-456",
+		TaskID: "task-2",
+		Stage:  StagePreMerge,
+		Metadata: map[string]interface{}{
+			"pr_number": float64(99),
+		},
+	}
+
+	responseCh, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("SendApprovalRequest failed: %v", err)
+	}
+
+	select {
+	case resp := <-responseCh:
+		if resp.Decision != DecisionApproved {
+			t.Errorf("response.Decision = %s, want approved", resp.Decision)
+		}
+	case <-time.After(time.Second):
+		t.Error("timeout waiting for approval response")
+	}
+}
+
+func TestGitHubHandler_CancelRequest(t *testing.T) {
+	client := &mockGitHubReviewClient{
+		hasApproval: false,
+	}
+	cfg := &GitHubHandlerConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		PollInterval: time.Hour, // Long interval to ensure polling doesn't complete
+	}
+	handler := NewGitHubHandler(client, cfg)
+
+	req := &Request{
+		ID:     "test-cancel",
+		TaskID: "task-3",
+		Stage:  StagePreMerge,
+		Metadata: map[string]interface{}{
+			"pr_number": 50,
+		},
+	}
+
+	responseCh, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("SendApprovalRequest failed: %v", err)
+	}
+
+	// Cancel the request
+	err = handler.CancelRequest(context.Background(), "test-cancel")
+	if err != nil {
+		t.Fatalf("CancelRequest failed: %v", err)
+	}
+
+	// Channel should be closed
+	select {
+	case _, ok := <-responseCh:
+		if ok {
+			t.Error("expected channel to be closed after cancel")
+		}
+	case <-time.After(time.Second):
+		t.Error("timeout waiting for channel close")
+	}
+}
+
+func TestGitHubHandler_CancelRequest_NotFound(t *testing.T) {
+	handler := &GitHubHandler{
+		pending: make(map[string]*githubPending),
+	}
+
+	// Should not error when cancelling non-existent request
+	err := handler.CancelRequest(context.Background(), "nonexistent")
+	if err != nil {
+		t.Errorf("CancelRequest should not error for non-existent request: %v", err)
+	}
+}
+
+func TestGitHubHandler_HandleReviewEvent_Approved(t *testing.T) {
+	client := &mockGitHubReviewClient{}
+	cfg := &GitHubHandlerConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		PollInterval: time.Hour,
+	}
+	handler := NewGitHubHandler(client, cfg)
+
+	// Create a pending request
+	responseCh := make(chan *Response, 1)
+	_, cancel := context.WithCancel(context.Background())
+	handler.pending["test-webhook"] = &githubPending{
+		Request:    &Request{ID: "test-webhook"},
+		PRNumber:   42,
+		ResponseCh: responseCh,
+		CancelFn:   cancel,
+	}
+
+	// Simulate webhook event
+	handled := handler.HandleReviewEvent(context.Background(), 42, "submitted", "approved", "charlie")
+
+	if !handled {
+		t.Error("HandleReviewEvent should return true for matching PR")
+	}
+
+	select {
+	case resp := <-responseCh:
+		if resp.Decision != DecisionApproved {
+			t.Errorf("response.Decision = %s, want approved", resp.Decision)
+		}
+		if resp.ApprovedBy != "charlie" {
+			t.Errorf("response.ApprovedBy = %s, want charlie", resp.ApprovedBy)
+		}
+	case <-time.After(time.Second):
+		t.Error("timeout waiting for response")
+	}
+}
+
+func TestGitHubHandler_HandleReviewEvent_WrongAction(t *testing.T) {
+	handler := &GitHubHandler{
+		pending: make(map[string]*githubPending),
+	}
+
+	// "dismissed" action should not be handled
+	handled := handler.HandleReviewEvent(context.Background(), 42, "dismissed", "approved", "charlie")
+
+	if handled {
+		t.Error("HandleReviewEvent should return false for non-submitted action")
+	}
+}
+
+func TestGitHubHandler_HandleReviewEvent_WrongState(t *testing.T) {
+	handler := &GitHubHandler{
+		pending: make(map[string]*githubPending),
+	}
+
+	// Non-approved state should not be handled
+	handled := handler.HandleReviewEvent(context.Background(), 42, "submitted", "commented", "charlie")
+
+	if handled {
+		t.Error("HandleReviewEvent should return false for non-approved state")
+	}
+}
+
+func TestGitHubHandler_HandleReviewEvent_NoPendingRequest(t *testing.T) {
+	handler := &GitHubHandler{
+		pending: make(map[string]*githubPending),
+	}
+
+	// No pending request for PR 42
+	handled := handler.HandleReviewEvent(context.Background(), 42, "submitted", "approved", "charlie")
+
+	if handled {
+		t.Error("HandleReviewEvent should return false when no pending request")
+	}
+}
+
+func TestGitHubHandler_HandleChangesRequestedEvent(t *testing.T) {
+	client := &mockGitHubReviewClient{}
+	cfg := &GitHubHandlerConfig{
+		Owner:        "owner",
+		Repo:         "repo",
+		PollInterval: time.Hour,
+	}
+	handler := NewGitHubHandler(client, cfg)
+
+	// Create a pending request
+	responseCh := make(chan *Response, 1)
+	_, cancel := context.WithCancel(context.Background())
+	handler.pending["test-changes"] = &githubPending{
+		Request:    &Request{ID: "test-changes"},
+		PRNumber:   42,
+		ResponseCh: responseCh,
+		CancelFn:   cancel,
+	}
+
+	// Simulate changes requested event
+	handled := handler.HandleChangesRequestedEvent(context.Background(), 42, "reviewer")
+
+	if !handled {
+		t.Error("HandleChangesRequestedEvent should return true for matching PR")
+	}
+
+	select {
+	case resp := <-responseCh:
+		if resp.Decision != DecisionRejected {
+			t.Errorf("response.Decision = %s, want rejected", resp.Decision)
+		}
+		if resp.ApprovedBy != "reviewer" {
+			t.Errorf("response.ApprovedBy = %s, want reviewer", resp.ApprovedBy)
+		}
+	case <-time.After(time.Second):
+		t.Error("timeout waiting for response")
+	}
+}
+
+func TestGitHubHandler_HandleChangesRequestedEvent_NoPendingRequest(t *testing.T) {
+	handler := &GitHubHandler{
+		pending: make(map[string]*githubPending),
+	}
+
+	handled := handler.HandleChangesRequestedEvent(context.Background(), 99, "reviewer")
+
+	if handled {
+		t.Error("HandleChangesRequestedEvent should return false when no pending request")
+	}
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -15,12 +15,36 @@ const (
 	EnvProd Environment = "prod"
 )
 
+// ApprovalSource specifies which channel to use for approval requests.
+type ApprovalSource string
+
+const (
+	// ApprovalSourceTelegram uses Telegram for approval requests.
+	ApprovalSourceTelegram ApprovalSource = "telegram"
+	// ApprovalSourceSlack uses Slack for approval requests.
+	ApprovalSourceSlack ApprovalSource = "slack"
+	// ApprovalSourceGitHubReview uses GitHub PR reviews for approval.
+	ApprovalSourceGitHubReview ApprovalSource = "github-review"
+)
+
+// GitHubReviewConfig holds configuration for GitHub PR review approval.
+type GitHubReviewConfig struct {
+	// PollInterval is how often to poll for PR reviews (default: 30s).
+	PollInterval time.Duration `yaml:"poll_interval"`
+}
+
 // Config holds autopilot configuration for automated PR handling.
 type Config struct {
 	// Enabled controls whether autopilot mode is active.
 	Enabled bool `yaml:"enabled"`
 	// Environment determines the automation level (dev/stage/prod).
 	Environment Environment `yaml:"environment"`
+
+	// Approval
+	// ApprovalSource specifies which channel to use for approvals (telegram, slack, github-review).
+	ApprovalSource ApprovalSource `yaml:"approval_source"`
+	// GitHubReview holds configuration for GitHub PR review approval.
+	GitHubReview *GitHubReviewConfig `yaml:"github_review"`
 
 	// PR Handling
 	// AutoReview enables automatic PR review comments.
@@ -65,6 +89,10 @@ func DefaultConfig() *Config {
 	return &Config{
 		Enabled:          false,
 		Environment:      EnvStage,
+		ApprovalSource:   ApprovalSourceTelegram, // Default to Telegram for backward compatibility
+		GitHubReview: &GitHubReviewConfig{
+			PollInterval: 30 * time.Second,
+		},
 		AutoReview:       true,
 		AutoMerge:        true,
 		MergeMethod:      "squash",


### PR DESCRIPTION
## Summary
- Add support for GitHub PR reviews (Approved/Changes Requested) as approval mechanism
- Natural dev workflow integration - merging PRs requires standard PR approval
- Supports both webhook-driven instant response and polling fallback

## Changes
- `internal/adapters/github/types.go`: Add `PullRequestReview` type and review state constants
- `internal/adapters/github/client.go`: Add `ListPullRequestReviews()` and `HasApprovalReview()` methods
- `internal/adapters/github/webhook.go`: Handle `pull_request_review` webhook events
- `internal/approval/github.go`: New `GitHubHandler` implementing `approval.Handler` interface
- `internal/autopilot/types.go`: Add `ApprovalSource` config (telegram/slack/github-review)

## Configuration
```yaml
orchestrator:
  autopilot:
    approval_source: "github-review"  # or "telegram", "slack"
    github_review:
      poll_interval: 30s
```

## Verification
1. Configure `autopilot.approval_source: "github-review"`
2. Run: `pilot start --github --autopilot=prod`
3. Create GitHub issue with "pilot" label
4. Wait for PR creation
5. Submit "Approve" review on PR
6. Verify: PR auto-merges after approval

## Test plan
- [x] Unit tests for `ListPullRequestReviews` and `HasApprovalReview`
- [x] Unit tests for `GitHubHandler` approval flow
- [x] Tests for webhook event handling
- [x] Build passes
- [x] Lint passes

Closes #324