### PR TITLE
fix(dashboard): suppress startup prints when TUI is active (GH-333)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -679,8 +679,10 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 		}
 	}
 
-	// Show startup banner
-	banner.StartupTelegram(version, projectPath, cfg.Adapters.Telegram.ChatID, cfg)
+	// Show startup banner (skip in dashboard mode to avoid corrupting TUI)
+	if !dashboardMode {
+		banner.StartupTelegram(version, projectPath, cfg.Adapters.Telegram.ChatID, cfg)
+	}
 
 	// Log autopilot status
 	if cfg.Orchestrator.Autopilot != nil && cfg.Orchestrator.Autopilot.Enabled {
@@ -873,15 +875,19 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 			var err error
 			ghPoller, err = github.NewPoller(client, cfg.Adapters.GitHub.Repo, label, interval, pollerOpts...)
 			if err != nil {
-				fmt.Printf("⚠️  GitHub polling disabled: %v\n", err)
+				if !dashboardMode {
+					fmt.Printf("⚠️  GitHub polling disabled: %v\n", err)
+				}
 			} else {
 				modeStr := "sequential"
 				if execMode == github.ExecutionModeParallel {
 					modeStr = "parallel"
 				}
-				fmt.Printf("🐙 GitHub polling enabled: %s (every %s, mode: %s)\n", cfg.Adapters.GitHub.Repo, interval, modeStr)
-				if execMode == github.ExecutionModeSequential && waitForMerge {
-					fmt.Printf("   ⏳ Sequential mode: waiting for PR merge before next issue (timeout: %s)\n", prTimeout)
+				if !dashboardMode {
+					fmt.Printf("🐙 GitHub polling enabled: %s (every %s, mode: %s)\n", cfg.Adapters.GitHub.Repo, interval, modeStr)
+					if execMode == github.ExecutionModeSequential && waitForMerge {
+						fmt.Printf("   ⏳ Sequential mode: waiting for PR merge before next issue (timeout: %s)\n", prTimeout)
+					}
 				}
 				go ghPoller.Start(ctx)
 
@@ -895,7 +901,9 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 						)
 					}
 
-					fmt.Printf("🤖 Autopilot enabled: %s environment\n", cfg.Orchestrator.Autopilot.Environment)
+					if !dashboardMode {
+						fmt.Printf("🤖 Autopilot enabled: %s environment\n", cfg.Orchestrator.Autopilot.Environment)
+					}
 					go func() {
 						if err := autopilotController.Run(ctx); err != nil && err != context.Canceled {
 							logging.WithComponent("autopilot").Error("autopilot controller stopped",
@@ -911,11 +919,15 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 				if store != nil {
 					cleaner, cleanerErr := github.NewCleaner(client, store, cfg.Adapters.GitHub.Repo, cfg.Adapters.GitHub.StaleLabelCleanup)
 					if cleanerErr != nil {
-						fmt.Printf("⚠️  Stale label cleanup disabled: %v\n", cleanerErr)
+						if !dashboardMode {
+							fmt.Printf("⚠️  Stale label cleanup disabled: %v\n", cleanerErr)
+						}
 					} else {
-						fmt.Printf("🧹 Stale label cleanup enabled (every %s, threshold: %s)\n",
-							cfg.Adapters.GitHub.StaleLabelCleanup.Interval,
-							cfg.Adapters.GitHub.StaleLabelCleanup.Threshold)
+						if !dashboardMode {
+							fmt.Printf("🧹 Stale label cleanup enabled (every %s, threshold: %s)\n",
+								cfg.Adapters.GitHub.StaleLabelCleanup.Interval,
+								cfg.Adapters.GitHub.StaleLabelCleanup.Threshold)
+						}
 						go cleaner.Start(ctx)
 					}
 				}
@@ -925,7 +937,9 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 
 	// Start Telegram polling if enabled
 	if tgHandler != nil {
-		fmt.Println("📱 Telegram polling started")
+		if !dashboardMode {
+			fmt.Println("📱 Telegram polling started")
+		}
 		tgHandler.StartPolling(ctx)
 	}
 


### PR DESCRIPTION
## Summary
Fix dashboard not showing when running `pilot start --dashboard --telegram --github`.

## Problem
Multiple `fmt.Print*` calls execute BEFORE `program.Run()`, corrupting the terminal before TUI takes over.

## Solution
Guard all startup prints with `if !dashboardMode`:

| Line | Code | Fixed |
|------|------|-------|
| 683 | `banner.StartupTelegram(...)` | ✅ |
| 878 | `fmt.Printf("⚠️  GitHub polling disabled...")` | ✅ |
| 884-886 | GitHub polling enabled + sequential mode | ✅ |
| 904 | `fmt.Printf("🤖 Autopilot enabled...")` | ✅ |
| 922-926 | Stale label cleanup prints | ✅ |
| 940 | `fmt.Println("📱 Telegram polling started")` | ✅ |

## Test
```bash
# Dashboard mode - should show TUI immediately
pilot start --autopilot=prod --telegram --github --dashboard -p ~/Projects/startups/pilot

# Non-dashboard mode - should show banner + status
pilot start --telegram --github -p ~/Projects/startups/pilot
```

Closes #333