### PR TITLE
feat(cli): add pilot allow command for Telegram user authorization (GH-344)

### DIFF
--- a/cmd/pilot/allow.go
+++ b/cmd/pilot/allow.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/alekspetrov/pilot/internal/adapters/telegram"
+	"github.com/alekspetrov/pilot/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newAllowCmd() *cobra.Command {
+	var (
+		remove bool
+		list   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "allow [user_id]",
+		Short: "Manage Telegram allowed users",
+		Long: `Add, remove, or list Telegram user IDs in allowed_ids.
+
+Examples:
+  pilot allow 123456789          # Add user
+  pilot allow --remove 123456789 # Remove user
+  pilot allow --list             # List allowed users`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// List mode
+			if list {
+				return listAllowedUsers()
+			}
+
+			// Add/remove requires a user ID
+			if len(args) == 0 {
+				return fmt.Errorf("user_id is required (or use --list to show current users)")
+			}
+
+			userID := args[0]
+
+			// Validate ID is numeric
+			id, err := strconv.ParseInt(userID, 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid user_id: must be a numeric Telegram user ID")
+			}
+
+			if remove {
+				return removeAllowedUser(id)
+			}
+			return addAllowedUser(id)
+		},
+	}
+
+	cmd.Flags().BoolVar(&remove, "remove", false, "Remove user from allowed_ids")
+	cmd.Flags().BoolVar(&list, "list", false, "List current allowed users")
+
+	return cmd
+}
+
+func listAllowedUsers() error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	if cfg.Adapters == nil || cfg.Adapters.Telegram == nil {
+		fmt.Println("No Telegram configuration found")
+		return nil
+	}
+
+	allowedIDs := cfg.Adapters.Telegram.AllowedIDs
+	if len(allowedIDs) == 0 {
+		fmt.Println("No allowed users configured")
+		return nil
+	}
+
+	fmt.Println("Allowed Telegram users:")
+	for _, id := range allowedIDs {
+		fmt.Printf("  %d\n", id)
+	}
+	fmt.Printf("\nTotal: %d user(s)\n", len(allowedIDs))
+
+	return nil
+}
+
+func addAllowedUser(id int64) error {
+	configPath := cfgFile
+	if configPath == "" {
+		configPath = config.DefaultConfigPath()
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Initialize adapters if nil
+	if cfg.Adapters == nil {
+		cfg.Adapters = &config.AdaptersConfig{}
+	}
+	if cfg.Adapters.Telegram == nil {
+		cfg.Adapters.Telegram = &telegram.Config{
+			Enabled: false,
+		}
+	}
+
+	// Check for duplicates
+	for _, existingID := range cfg.Adapters.Telegram.AllowedIDs {
+		if existingID == id {
+			fmt.Printf("User %d is already in allowed_ids\n", id)
+			return nil
+		}
+	}
+
+	// Add the ID
+	cfg.Adapters.Telegram.AllowedIDs = append(cfg.Adapters.Telegram.AllowedIDs, id)
+
+	// Save config
+	if err := config.Save(cfg, configPath); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	fmt.Printf("✓ Added Telegram user %d to allowed_ids\n", id)
+	fmt.Println("  Restart Pilot to apply: pilot restart")
+
+	return nil
+}
+
+func removeAllowedUser(id int64) error {
+	configPath := cfgFile
+	if configPath == "" {
+		configPath = config.DefaultConfigPath()
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if cfg.Adapters == nil || cfg.Adapters.Telegram == nil {
+		return fmt.Errorf("no Telegram configuration found")
+	}
+
+	// Find and remove the ID
+	found := false
+	newIDs := make([]int64, 0, len(cfg.Adapters.Telegram.AllowedIDs))
+	for _, existingID := range cfg.Adapters.Telegram.AllowedIDs {
+		if existingID == id {
+			found = true
+		} else {
+			newIDs = append(newIDs, existingID)
+		}
+	}
+
+	if !found {
+		fmt.Printf("User %d is not in allowed_ids\n", id)
+		return nil
+	}
+
+	cfg.Adapters.Telegram.AllowedIDs = newIDs
+
+	// Save config
+	if err := config.Save(cfg, configPath); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	fmt.Printf("✓ Removed Telegram user %d from allowed_ids\n", id)
+	fmt.Println("  Restart Pilot to apply: pilot restart")
+
+	return nil
+}
+
+// init registers the allow command - handled in main.go AddCommand

--- a/cmd/pilot/allow_test.go
+++ b/cmd/pilot/allow_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/config"
+)
+
+func TestAllowCommand_ValidateUserID(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "valid numeric ID",
+			args:    []string{"123456789"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid non-numeric ID",
+			args:    []string{"@username"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid empty",
+			args:    []string{""},
+			wantErr: true,
+		},
+		{
+			name:    "valid negative ID (groups) with separator",
+			args:    []string{"--", "-123456789"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newAllowCmd()
+			cmd.SetArgs(tt.args)
+
+			// Create temp config for test
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.yaml")
+
+			// Create minimal config
+			cfg := config.DefaultConfig()
+			if err := config.Save(cfg, configPath); err != nil {
+				t.Fatalf("failed to create test config: %v", err)
+			}
+
+			// Set the config file path
+			oldCfgFile := cfgFile
+			cfgFile = configPath
+			defer func() { cfgFile = oldCfgFile }()
+
+			err := cmd.Execute()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAddAllowedUser(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Create minimal config
+	cfg := config.DefaultConfig()
+	if err := config.Save(cfg, configPath); err != nil {
+		t.Fatalf("failed to create test config: %v", err)
+	}
+
+	// Set the config file path
+	oldCfgFile := cfgFile
+	cfgFile = configPath
+	defer func() { cfgFile = oldCfgFile }()
+
+	// Add a user
+	if err := addAllowedUser(123456789); err != nil {
+		t.Fatalf("addAllowedUser() error = %v", err)
+	}
+
+	// Reload and verify
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("failed to reload config: %v", err)
+	}
+
+	if cfg.Adapters == nil || cfg.Adapters.Telegram == nil {
+		t.Fatal("Telegram config not initialized")
+	}
+
+	if len(cfg.Adapters.Telegram.AllowedIDs) != 1 {
+		t.Errorf("expected 1 allowed ID, got %d", len(cfg.Adapters.Telegram.AllowedIDs))
+	}
+
+	if cfg.Adapters.Telegram.AllowedIDs[0] != 123456789 {
+		t.Errorf("expected ID 123456789, got %d", cfg.Adapters.Telegram.AllowedIDs[0])
+	}
+}
+
+func TestAddAllowedUser_PreventsDuplicates(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Create config with existing user
+	cfg := config.DefaultConfig()
+	cfg.Adapters.Telegram.AllowedIDs = []int64{123456789}
+	if err := config.Save(cfg, configPath); err != nil {
+		t.Fatalf("failed to create test config: %v", err)
+	}
+
+	// Set the config file path
+	oldCfgFile := cfgFile
+	cfgFile = configPath
+	defer func() { cfgFile = oldCfgFile }()
+
+	// Try to add the same user again (should not error, just skip)
+	if err := addAllowedUser(123456789); err != nil {
+		t.Fatalf("addAllowedUser() error = %v", err)
+	}
+
+	// Reload and verify no duplicate
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("failed to reload config: %v", err)
+	}
+
+	if len(cfg.Adapters.Telegram.AllowedIDs) != 1 {
+		t.Errorf("expected 1 allowed ID (no duplicate), got %d", len(cfg.Adapters.Telegram.AllowedIDs))
+	}
+}
+
+func TestRemoveAllowedUser(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Create config with users
+	cfg := config.DefaultConfig()
+	cfg.Adapters.Telegram.AllowedIDs = []int64{111, 222, 333}
+	if err := config.Save(cfg, configPath); err != nil {
+		t.Fatalf("failed to create test config: %v", err)
+	}
+
+	// Set the config file path
+	oldCfgFile := cfgFile
+	cfgFile = configPath
+	defer func() { cfgFile = oldCfgFile }()
+
+	// Remove middle user
+	if err := removeAllowedUser(222); err != nil {
+		t.Fatalf("removeAllowedUser() error = %v", err)
+	}
+
+	// Reload and verify
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("failed to reload config: %v", err)
+	}
+
+	if len(cfg.Adapters.Telegram.AllowedIDs) != 2 {
+		t.Errorf("expected 2 allowed IDs after removal, got %d", len(cfg.Adapters.Telegram.AllowedIDs))
+	}
+
+	// Verify correct users remain
+	expected := map[int64]bool{111: true, 333: true}
+	for _, id := range cfg.Adapters.Telegram.AllowedIDs {
+		if !expected[id] {
+			t.Errorf("unexpected ID %d in allowed list", id)
+		}
+	}
+}
+
+func TestRemoveAllowedUser_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Create config with users
+	cfg := config.DefaultConfig()
+	cfg.Adapters.Telegram.AllowedIDs = []int64{111, 222}
+	if err := config.Save(cfg, configPath); err != nil {
+		t.Fatalf("failed to create test config: %v", err)
+	}
+
+	// Set the config file path
+	oldCfgFile := cfgFile
+	cfgFile = configPath
+	defer func() { cfgFile = oldCfgFile }()
+
+	// Try to remove non-existent user (should not error)
+	if err := removeAllowedUser(999); err != nil {
+		t.Fatalf("removeAllowedUser() error = %v", err)
+	}
+
+	// Verify list unchanged
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("failed to reload config: %v", err)
+	}
+
+	if len(cfg.Adapters.Telegram.AllowedIDs) != 2 {
+		t.Errorf("expected 2 allowed IDs (unchanged), got %d", len(cfg.Adapters.Telegram.AllowedIDs))
+	}
+}
+
+func TestListAllowedUsers(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Create config with users
+	cfg := config.DefaultConfig()
+	cfg.Adapters.Telegram.AllowedIDs = []int64{111, 222, 333}
+	if err := config.Save(cfg, configPath); err != nil {
+		t.Fatalf("failed to create test config: %v", err)
+	}
+
+	// Set the config file path
+	oldCfgFile := cfgFile
+	cfgFile = configPath
+	defer func() { cfgFile = oldCfgFile }()
+
+	// List should succeed (output goes to stdout)
+	if err := listAllowedUsers(); err != nil {
+		t.Fatalf("listAllowedUsers() error = %v", err)
+	}
+}
+
+func TestListAllowedUsers_Empty(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Create config with no users
+	cfg := config.DefaultConfig()
+	cfg.Adapters.Telegram.AllowedIDs = []int64{}
+	if err := config.Save(cfg, configPath); err != nil {
+		t.Fatalf("failed to create test config: %v", err)
+	}
+
+	// Set the config file path
+	oldCfgFile := cfgFile
+	cfgFile = configPath
+	defer func() { cfgFile = oldCfgFile }()
+
+	// List should succeed with empty message
+	if err := listAllowedUsers(); err != nil {
+		t.Fatalf("listAllowedUsers() error = %v", err)
+	}
+}
+
+func TestAllowCommand_NoArgs(t *testing.T) {
+	cmd := newAllowCmd()
+	cmd.SetArgs([]string{})
+
+	// Should error without --list flag
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error when no args and no --list flag")
+	}
+}
+
+func TestAllowCommand_ListFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	cfg := config.DefaultConfig()
+	if err := config.Save(cfg, configPath); err != nil {
+		t.Fatalf("failed to create test config: %v", err)
+	}
+
+	oldCfgFile := cfgFile
+	cfgFile = configPath
+	defer func() { cfgFile = oldCfgFile }()
+
+	cmd := newAllowCmd()
+	cmd.SetArgs([]string{"--list"})
+
+	// Should succeed with --list flag
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("Execute() with --list error = %v", err)
+	}
+}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -169,6 +169,7 @@ func main() {
 		newWebhooksCmd(),
 		newUpgradeCmd(),
 		newReleaseCmd(),
+		newAllowCmd(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION
## Summary
- Add `pilot allow <telegram_user_id>` command to authorize Telegram users
- Allows admins to grant access without editing config files

## Test plan
- [ ] `pilot allow 123456789` adds user to allowed list
- [ ] Unauthorized users get rejection message
- [ ] Authorized users can interact with Pilot

Closes #344