### PR TITLE
fix(dispatcher): save PR URL and commit SHA to database after execution (GH-346)

### DIFF
--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -512,15 +512,16 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			if err := w.store.UpdateExecutionStatus(exec.ID, "completed"); err != nil {
 				w.log.Error("Failed to update status to completed", slog.Any("error", err))
 			}
+			// Update result fields (PR URL, commit SHA, duration)
+			if err := w.store.UpdateExecutionResult(exec.ID, result.PRUrl, result.CommitSHA, duration.Milliseconds()); err != nil {
+				w.log.Error("Failed to update execution result", slog.Any("error", err))
+			}
 			// Emit progress callback for task completed
 			msg := fmt.Sprintf("Completed in %s", duration.Round(time.Second))
 			if result.PRUrl != "" {
 				msg = fmt.Sprintf("Completed with PR: %s", result.PRUrl)
 			}
 			w.runner.EmitProgress(exec.TaskID, "Completed", 100, msg)
-
-			// Update execution with result details
-			// Note: For a full implementation, we'd update more fields here
 		}
 
 		w.currentTaskID.Store("")

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -673,6 +673,17 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 	return err
 }
 
+// UpdateExecutionResult updates the result fields of an execution record.
+// Called when task execution completes successfully with PR/commit info.
+func (s *Store) UpdateExecutionResult(id string, prURL, commitSHA string, durationMs int64) error {
+	_, err := s.db.Exec(`
+		UPDATE executions
+		SET pr_url = ?, commit_sha = ?, duration_ms = ?
+		WHERE id = ?
+	`, prURL, commitSHA, durationMs, id)
+	return err
+}
+
 // GetStaleRunningExecutions returns executions that have been in "running" status
 // for longer than the specified duration. Used to detect crashed workers on restart.
 func (s *Store) GetStaleRunningExecutions(staleDuration time.Duration) ([]*Execution, error) {


### PR DESCRIPTION
## Summary
- Add `UpdateExecutionResult()` to store PR URL, commit SHA, duration
- Call it from dispatcher success path

Fixes autopilot workflow - PRs will now be tracked and auto-merged.

Closes #346