### PR TITLE
Fix LLM intent classifier: pre-check clear question patterns

### DIFF
--- a/internal/adapters/telegram/handler.go
+++ b/internal/adapters/telegram/handler.go
@@ -419,6 +419,12 @@ func (h *Handler) detectIntentWithLLM(ctx context.Context, chatID, text string) 
 		return IntentCommand
 	}
 
+	// Fast path: clear question patterns don't need LLM verification
+	// Prevents Haiku from misclassifying "What's in roadmap" as Task
+	if isClearQuestion(text) {
+		return IntentQuestion
+	}
+
 	// Try LLM classification with timeout
 	classifyCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()

--- a/internal/adapters/telegram/intent.go
+++ b/internal/adapters/telegram/intent.go
@@ -277,6 +277,38 @@ func containsActionWord(msg string) bool {
 	return false
 }
 
+// isClearQuestion checks if message is unambiguously a question.
+// These patterns are high-confidence and don't need LLM verification.
+// Used as pre-check before LLM classification to avoid false Task classifications.
+func isClearQuestion(msg string) bool {
+	lower := strings.ToLower(strings.TrimSpace(msg))
+
+	// Ends with question mark - very clear signal
+	if strings.HasSuffix(lower, "?") {
+		return true
+	}
+
+	// Clear question starters that rarely indicate tasks
+	clearPatterns := []string{
+		"what's in", "what is in", "whats in",
+		"what's the", "what is the", "whats the",
+		"how does", "how do", "how can",
+		"where is", "where are", "where's",
+		"why is", "why are", "why does",
+		"when is", "when does", "when will",
+		"who is", "who are",
+		"which", "can you explain", "could you explain",
+	}
+
+	for _, pattern := range clearPatterns {
+		if strings.HasPrefix(lower, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IntentDescription returns a human-readable description of the intent
 func (i Intent) Description() string {
 	switch i {

--- a/internal/adapters/telegram/intent_test.go
+++ b/internal/adapters/telegram/intent_test.go
@@ -785,6 +785,62 @@ func TestIsEphemeralTaskPatterns(t *testing.T) {
 	}
 }
 
+// TestIsClearQuestion tests the isClearQuestion function for LLM pre-check (GH-382)
+func TestIsClearQuestion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		// Should be clear questions - ends with ?
+		{"What's in roadmap?", true},
+		{"What's in the backlog?", true},
+		{"How does auth work?", true},
+		{"Where is the config file?", true},
+		{"Why is this failing?", true},
+		{"Can you explain the architecture?", true},
+
+		// Should be clear questions - question starters (no ?)
+		{"What's in roadmap", true},
+		{"What is in the backlog", true},
+		{"How does the auth system work", true},
+		{"How do I run tests", true},
+		{"How can I debug this", true},
+		{"Where is the config", true},
+		{"Where are the tests", true},
+		{"Why is this failing", true},
+		{"Why are we using Go", true},
+		{"Why does it crash", true},
+		{"When is the release", true},
+		{"When does it deploy", true},
+		{"When will it be ready", true},
+		{"Who is the maintainer", true},
+		{"Who are the contributors", true},
+		{"Which library should I use", true},
+		{"Can you explain the flow", true},
+		{"Could you explain the architecture", true},
+
+		// Should NOT be clear questions (need LLM)
+		{"Add a logout button", false},
+		{"Fix the auth bug", false},
+		{"What do you think about adding X", false}, // chat, not question
+		{"Create a new endpoint", false},
+		{"Implement feature X", false},
+		{"Hello", false},
+		{"Hi there", false},
+		{"Research authentication methods", false},
+		{"Plan the migration", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := isClearQuestion(tt.input)
+			if got != tt.expected {
+				t.Errorf("isClearQuestion(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
 // TestContainsModificationIntent tests modification intent detection
 func TestContainsModificationIntent(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-382.

## Changes

GitHub Issue #382: Fix LLM intent classifier: pre-check clear question patterns

## Problem

LLM intent classifier (Claude Haiku) misclassifies clear question patterns as Tasks.

**Example**: "What's in roadmap" was classified as Task, triggering:
1. Task confirmation dialog
2. Branch creation (`pilot/TG-1770146756`)
3. Build gate execution (passed)
4. PR creation attempt (failed - no commits)

The rule-based `DetectIntent()` correctly identifies this as Question (starts with "what's"), but Haiku overrides it.

## Solution

Add pre-check in `detectIntentWithLLM()` for clear question patterns:

```go
// Fast path for clear question patterns
if isClearQuestion(text) {
    return IntentQuestion
}
```

Clear patterns:
- Ends with `?`
- Starts with: `what's in`, `how does`, `where is`, `why is`, etc.

## Files

- `internal/adapters/telegram/handler.go` - Add `isClearQuestion()` + pre-check
- `internal/adapters/telegram/intent_test.go` - Add test cases

## Implementation Plan

See: `.agent/tasks/GH-375-llm-intent-precheck.md`

## Acceptance Criteria

- [ ] "What's in roadmap" → Question (not Task)
- [ ] "What files handle auth?" → Question
- [ ] "How does X work?" → Question
- [ ] Ambiguous messages still use LLM
- [ ] All existing intent tests pass