### PR TITLE
feat(linear): add project filter support

### DIFF
--- a/internal/adapters/linear/types.go
+++ b/internal/adapters/linear/types.go
@@ -2,11 +2,12 @@ package linear
 
 // Config holds Linear adapter configuration
 type Config struct {
-	Enabled    bool   `yaml:"enabled"`
-	APIKey     string `yaml:"api_key"`
-	TeamID     string `yaml:"team_id"`
-	AutoAssign bool   `yaml:"auto_assign"`
-	PilotLabel string `yaml:"pilot_label"`
+	Enabled    bool     `yaml:"enabled"`
+	APIKey     string   `yaml:"api_key"`
+	TeamID     string   `yaml:"team_id"`
+	AutoAssign bool     `yaml:"auto_assign"`
+	PilotLabel string   `yaml:"pilot_label"`
+	ProjectIDs []string `yaml:"project_ids,omitempty"` // Filter issues by project ID(s)
 }
 
 // DefaultConfig returns default Linear configuration

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -200,7 +200,7 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 	// Initialize Linear adapter if enabled
 	if cfg.Adapters.Linear != nil && cfg.Adapters.Linear.Enabled {
 		p.linearClient = linear.NewClient(cfg.Adapters.Linear.APIKey)
-		p.linearWH = linear.NewWebhookHandler(p.linearClient, cfg.Adapters.Linear.PilotLabel)
+		p.linearWH = linear.NewWebhookHandler(p.linearClient, cfg.Adapters.Linear.PilotLabel, cfg.Adapters.Linear.ProjectIDs)
 		p.linearWH.OnIssue(p.handleLinearIssue)
 		p.linearNotify = linear.NewNotifier(p.linearClient)
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-390.

## Changes

GitHub Issue #390: feat(linear): add project filter support

# GH-390: Linear Project Filter Support

## Overview

Add project filter to Linear adapter so Pilot only picks up issues from specific Linear projects.

## Problem

Current Linear config only supports team-level filtering:
```yaml
linear:
  team_id: "APP"
  pilot_label: "pilot"
```

User has multiple projects in one team (e.g., `aso-brief-generator`, `other-project`) but wants Pilot to only work on issues from one specific project.

## Solution

Add `project_id` or `project_ids` field to Linear config:

```yaml
adapters:
  linear:
    enabled: true
    api_key: "${LINEAR_API_KEY}"
    team_id: "APP"
    pilot_label: "pilot"
    project_ids:              # NEW: Filter by project(s)
      - "2bcb89b25a01"        # aso-brief-generator project ID
```

## Implementation

### 1. Update Config (`internal/adapters/linear/types.go`)

```go
type Config struct {
    Enabled    bool     `yaml:"enabled"`
    APIKey     string   `yaml:"api_key"`
    TeamID     string   `yaml:"team_id"`
    AutoAssign bool     `yaml:"auto_assign"`
    PilotLabel string   `yaml:"pilot_label"`
    ProjectIDs []string `yaml:"project_ids,omitempty"`  // NEW
}
```

### 2. Update Webhook Handler (`internal/adapters/linear/webhook.go`)

When processing webhook events, check if issue belongs to allowed project:

```go
func (h *WebhookHandler) shouldProcess(issue *Issue) bool {
    // Existing checks...

    // Check project filter if configured
    if len(h.config.ProjectIDs) > 0 {
        if issue.ProjectID == "" {
            return false  // No project assigned
        }
        found := false
        for _, pid := range h.config.ProjectIDs {
            if issue.ProjectID == pid {
                found = true
                break
            }
        }
        if !found {
            return false
        }
    }

    return true
}
```

### 3. Update GraphQL Query (if polling is added later)

Add project filter to issue query:
```graphql
issues(filter: {
  team: { key: { eq: "APP" } },
  labels: { name: { eq: "pilot" } },
  project: { id: { in: ["2bcb89b25a01"] } }  # NEW
})
```

## Config Examples

### Single Project
```yaml
linear:
  project_ids:
    - "2bcb89b25a01"
```

### Multiple Projects
```yaml
linear:
  project_ids:
    - "2bcb89b25a01"  # aso-brief-generator
    - "abc123def456"  # another-project
```

### All Projects in Team (default, no filter)
```yaml
linear:
  # project_ids omitted = all projects
```

## Testing

1. Create issue in filtered project with `pilot` label → should be picked up
2. Create issue in different project with `pilot` label → should be ignored
3. Create issue with no project with `pilot` label → should be ignored (when filter active)
4. Empty `project_ids` → should pick up all (backward compatible)

## Acceptance Criteria

- [ ] `project_ids` field added to Linear config
- [ ] Webhook handler filters by project
- [ ] Empty/missing `project_ids` processes all projects (backward compatible)
- [ ] Config example updated
- [ ] Works with single or multiple project IDs