### PR TITLE
feat(linear): multi-workspace support

### DIFF
--- a/internal/adapters/linear/multi_workspace.go
+++ b/internal/adapters/linear/multi_workspace.go
@@ -1,0 +1,249 @@
+package linear
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// MultiWorkspaceHandler manages multiple Linear workspaces and routes webhooks to the correct handler
+type MultiWorkspaceHandler struct {
+	workspaces map[string]*WorkspaceHandler // keyed by team_id
+	mu         sync.RWMutex
+}
+
+// WorkspaceHandler handles webhooks for a single Linear workspace
+type WorkspaceHandler struct {
+	config   *WorkspaceConfig
+	client   *Client
+	webhook  *WebhookHandler
+	notifier *Notifier
+}
+
+// NewMultiWorkspaceHandler creates a handler for multiple Linear workspaces
+func NewMultiWorkspaceHandler(cfg *Config) (*MultiWorkspaceHandler, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	h := &MultiWorkspaceHandler{
+		workspaces: make(map[string]*WorkspaceHandler),
+	}
+
+	workspaces := cfg.GetWorkspaces()
+	for _, ws := range workspaces {
+		client := NewClient(ws.APIKey)
+		pilotLabel := ws.PilotLabel
+		if pilotLabel == "" {
+			pilotLabel = "pilot"
+		}
+
+		handler := &WorkspaceHandler{
+			config:   ws,
+			client:   client,
+			webhook:  NewWebhookHandler(client, pilotLabel, ws.ProjectIDs),
+			notifier: NewNotifier(client),
+		}
+
+		// Index by team_id for routing
+		if ws.TeamID != "" {
+			h.workspaces[ws.TeamID] = handler
+		}
+
+		logging.WithComponent("linear").Info("Registered Linear workspace",
+			slog.String("name", ws.Name),
+			slog.String("team_id", ws.TeamID),
+			slog.Int("projects", len(ws.Projects)))
+	}
+
+	return h, nil
+}
+
+// OnIssue sets the callback for when a pilot-labeled issue is received.
+// The callback receives the issue and the workspace name it came from.
+func (h *MultiWorkspaceHandler) OnIssue(callback func(context.Context, *Issue, string) error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for _, ws := range h.workspaces {
+		// Capture workspace name for closure
+		wsName := ws.config.Name
+		ws.webhook.OnIssue(func(ctx context.Context, issue *Issue) error {
+			return callback(ctx, issue, wsName)
+		})
+	}
+}
+
+// Handle processes a webhook payload, routing to the correct workspace handler
+func (h *MultiWorkspaceHandler) Handle(ctx context.Context, payload map[string]interface{}) error {
+	// Extract team info from payload
+	teamID := h.extractTeamID(payload)
+	if teamID == "" {
+		logging.WithComponent("linear").Debug("No team ID in payload, trying all handlers")
+		// If no team ID, try to find a handler that can process it
+		return h.handleWithoutTeamID(ctx, payload)
+	}
+
+	h.mu.RLock()
+	handler, ok := h.workspaces[teamID]
+	h.mu.RUnlock()
+
+	if !ok {
+		logging.WithComponent("linear").Warn("Unknown workspace for team",
+			slog.String("team_id", teamID))
+		return fmt.Errorf("unknown workspace for team %s", teamID)
+	}
+
+	return handler.webhook.Handle(ctx, payload)
+}
+
+// handleWithoutTeamID attempts to route webhook without team ID (fallback for legacy configs)
+func (h *MultiWorkspaceHandler) handleWithoutTeamID(ctx context.Context, payload map[string]interface{}) error {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	// If only one workspace, use it
+	if len(h.workspaces) == 1 {
+		for _, handler := range h.workspaces {
+			return handler.webhook.Handle(ctx, payload)
+		}
+	}
+
+	// Try all handlers, return first success
+	var lastErr error
+	for teamID, handler := range h.workspaces {
+		err := handler.webhook.Handle(ctx, payload)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		logging.WithComponent("linear").Debug("Handler failed",
+			slog.String("team_id", teamID),
+			slog.Any("error", err))
+	}
+
+	if lastErr != nil {
+		return lastErr
+	}
+	return nil
+}
+
+// extractTeamID extracts the team ID from a webhook payload
+func (h *MultiWorkspaceHandler) extractTeamID(payload map[string]interface{}) string {
+	// Try data.team.id first (full issue payload)
+	if data, ok := payload["data"].(map[string]interface{}); ok {
+		if team, ok := data["team"].(map[string]interface{}); ok {
+			if id, ok := team["id"].(string); ok {
+				return id
+			}
+		}
+		// Try data.teamId (webhook compact format)
+		if teamID, ok := data["teamId"].(string); ok {
+			return teamID
+		}
+	}
+	return ""
+}
+
+// GetWorkspace returns the handler for a specific workspace by name
+func (h *MultiWorkspaceHandler) GetWorkspace(name string) *WorkspaceHandler {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	for _, ws := range h.workspaces {
+		if ws.config.Name == name {
+			return ws
+		}
+	}
+	return nil
+}
+
+// GetWorkspaceByTeamID returns the handler for a specific workspace by team ID
+func (h *MultiWorkspaceHandler) GetWorkspaceByTeamID(teamID string) *WorkspaceHandler {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return h.workspaces[teamID]
+}
+
+// GetNotifier returns the notifier for a specific workspace
+func (h *MultiWorkspaceHandler) GetNotifier(workspaceName string) *Notifier {
+	ws := h.GetWorkspace(workspaceName)
+	if ws == nil {
+		return nil
+	}
+	return ws.notifier
+}
+
+// GetClient returns the client for a specific workspace
+func (h *MultiWorkspaceHandler) GetClient(workspaceName string) *Client {
+	ws := h.GetWorkspace(workspaceName)
+	if ws == nil {
+		return nil
+	}
+	return ws.client
+}
+
+// WorkspaceCount returns the number of configured workspaces
+func (h *MultiWorkspaceHandler) WorkspaceCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.workspaces)
+}
+
+// ListWorkspaces returns the names of all configured workspaces
+func (h *MultiWorkspaceHandler) ListWorkspaces() []string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	names := make([]string, 0, len(h.workspaces))
+	for _, ws := range h.workspaces {
+		names = append(names, ws.config.Name)
+	}
+	return names
+}
+
+// ResolvePilotProject returns the Pilot project name for an issue in a workspace
+func (ws *WorkspaceHandler) ResolvePilotProject(issue *Issue) string {
+	// If Linear issue has a project, try to match by project ID
+	if issue.Project != nil {
+		for _, projectID := range ws.config.ProjectIDs {
+			if projectID == issue.Project.ID {
+				// Found a match - if we have projects mapped, use first one
+				if len(ws.config.Projects) > 0 {
+					return ws.config.Projects[0]
+				}
+			}
+		}
+	}
+
+	// If only one Pilot project mapped, use it
+	if len(ws.config.Projects) == 1 {
+		return ws.config.Projects[0]
+	}
+
+	// Return first project as fallback
+	if len(ws.config.Projects) > 0 {
+		return ws.config.Projects[0]
+	}
+
+	return ""
+}
+
+// Config returns the workspace configuration
+func (ws *WorkspaceHandler) Config() *WorkspaceConfig {
+	return ws.config
+}
+
+// Notifier returns the workspace notifier
+func (ws *WorkspaceHandler) Notifier() *Notifier {
+	return ws.notifier
+}
+
+// Client returns the workspace client
+func (ws *WorkspaceHandler) Client() *Client {
+	return ws.client
+}

--- a/internal/adapters/linear/multi_workspace_test.go
+++ b/internal/adapters/linear/multi_workspace_test.go
@@ -1,0 +1,425 @@
+package linear
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewMultiWorkspaceHandler(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfg           *Config
+		wantErr       bool
+		wantCount     int
+		errContains   string
+	}{
+		{
+			name: "single workspace from workspaces array",
+			cfg: &Config{
+				Enabled: true,
+				Workspaces: []*WorkspaceConfig{
+					{
+						Name:       "workspace1",
+						APIKey:     "test-api-key-1",
+						TeamID:     "TEAM1",
+						PilotLabel: "pilot",
+						Projects:   []string{"project1"},
+					},
+				},
+			},
+			wantErr:   false,
+			wantCount: 1,
+		},
+		{
+			name: "multiple workspaces",
+			cfg: &Config{
+				Enabled: true,
+				Workspaces: []*WorkspaceConfig{
+					{
+						Name:       "appbooster",
+						APIKey:     "test-api-key-1",
+						TeamID:     "APP",
+						PilotLabel: "pilot",
+						Projects:   []string{"aso-generator", "pilot"},
+					},
+					{
+						Name:       "bostonteam",
+						APIKey:     "test-api-key-2",
+						TeamID:     "BT",
+						PilotLabel: "pilot",
+						Projects:   []string{"bostonteamgroup"},
+					},
+				},
+			},
+			wantErr:   false,
+			wantCount: 2,
+		},
+		{
+			name: "duplicate team IDs error",
+			cfg: &Config{
+				Enabled: true,
+				Workspaces: []*WorkspaceConfig{
+					{
+						Name:   "workspace1",
+						APIKey: "test-api-key-1",
+						TeamID: "SAME",
+					},
+					{
+						Name:   "workspace2",
+						APIKey: "test-api-key-2",
+						TeamID: "SAME",
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "duplicate team_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, err := NewMultiWorkspaceHandler(tt.cfg)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tt.errContains != "" && !containsSubstr(err.Error(), tt.errContains) {
+					t.Errorf("error = %q, want containing %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if handler.WorkspaceCount() != tt.wantCount {
+				t.Errorf("WorkspaceCount() = %d, want %d", handler.WorkspaceCount(), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestMultiWorkspaceHandler_OnIssue(t *testing.T) {
+	cfg := &Config{
+		Enabled: true,
+		Workspaces: []*WorkspaceConfig{
+			{
+				Name:       "workspace1",
+				APIKey:     "test-api-key",
+				TeamID:     "TEAM1",
+				PilotLabel: "pilot",
+			},
+		},
+	}
+
+	handler, err := NewMultiWorkspaceHandler(cfg)
+	if err != nil {
+		t.Fatalf("failed to create handler: %v", err)
+	}
+
+	callbackRegistered := false
+	handler.OnIssue(func(ctx context.Context, issue *Issue, wsName string) error {
+		callbackRegistered = true
+		_ = issue    // use variables
+		_ = wsName   // use variables
+		return nil
+	})
+
+	// The callback should be registered on workspace handlers
+	ws := handler.GetWorkspace("workspace1")
+	if ws == nil {
+		t.Fatal("workspace not found")
+	}
+
+	// Verify callback was registered by checking it's not nil
+	// (We don't call it directly since the webhook handler wraps it)
+	_ = callbackRegistered
+}
+
+func TestMultiWorkspaceHandler_GetWorkspace(t *testing.T) {
+	cfg := &Config{
+		Enabled: true,
+		Workspaces: []*WorkspaceConfig{
+			{Name: "ws1", APIKey: "key1", TeamID: "T1"},
+			{Name: "ws2", APIKey: "key2", TeamID: "T2"},
+		},
+	}
+
+	handler, err := NewMultiWorkspaceHandler(cfg)
+	if err != nil {
+		t.Fatalf("failed to create handler: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		lookup   string
+		wantNil  bool
+		wantName string
+	}{
+		{"existing workspace ws1", "ws1", false, "ws1"},
+		{"existing workspace ws2", "ws2", false, "ws2"},
+		{"non-existing workspace", "ws3", true, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := handler.GetWorkspace(tt.lookup)
+			if tt.wantNil {
+				if ws != nil {
+					t.Error("expected nil workspace")
+				}
+				return
+			}
+			if ws == nil {
+				t.Fatal("expected non-nil workspace")
+			}
+			if ws.Config().Name != tt.wantName {
+				t.Errorf("workspace name = %s, want %s", ws.Config().Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestMultiWorkspaceHandler_GetWorkspaceByTeamID(t *testing.T) {
+	cfg := &Config{
+		Enabled: true,
+		Workspaces: []*WorkspaceConfig{
+			{Name: "appbooster", APIKey: "key1", TeamID: "APP"},
+			{Name: "bostonteam", APIKey: "key2", TeamID: "BT"},
+		},
+	}
+
+	handler, err := NewMultiWorkspaceHandler(cfg)
+	if err != nil {
+		t.Fatalf("failed to create handler: %v", err)
+	}
+
+	tests := []struct {
+		teamID   string
+		wantNil  bool
+		wantName string
+	}{
+		{"APP", false, "appbooster"},
+		{"BT", false, "bostonteam"},
+		{"UNKNOWN", true, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.teamID, func(t *testing.T) {
+			ws := handler.GetWorkspaceByTeamID(tt.teamID)
+			if tt.wantNil {
+				if ws != nil {
+					t.Error("expected nil workspace")
+				}
+				return
+			}
+			if ws == nil {
+				t.Fatal("expected non-nil workspace")
+			}
+			if ws.Config().Name != tt.wantName {
+				t.Errorf("workspace name = %s, want %s", ws.Config().Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestMultiWorkspaceHandler_extractTeamID(t *testing.T) {
+	handler := &MultiWorkspaceHandler{}
+
+	tests := []struct {
+		name    string
+		payload map[string]interface{}
+		want    string
+	}{
+		{
+			name: "team.id in data",
+			payload: map[string]interface{}{
+				"data": map[string]interface{}{
+					"team": map[string]interface{}{
+						"id": "TEAM123",
+					},
+				},
+			},
+			want: "TEAM123",
+		},
+		{
+			name: "teamId in data",
+			payload: map[string]interface{}{
+				"data": map[string]interface{}{
+					"teamId": "TEAM456",
+				},
+			},
+			want: "TEAM456",
+		},
+		{
+			name: "no team info",
+			payload: map[string]interface{}{
+				"data": map[string]interface{}{
+					"id": "issue-123",
+				},
+			},
+			want: "",
+		},
+		{
+			name:    "empty payload",
+			payload: map[string]interface{}{},
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := handler.extractTeamID(tt.payload)
+			if got != tt.want {
+				t.Errorf("extractTeamID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMultiWorkspaceHandler_ListWorkspaces(t *testing.T) {
+	cfg := &Config{
+		Enabled: true,
+		Workspaces: []*WorkspaceConfig{
+			{Name: "alpha", APIKey: "key1", TeamID: "A"},
+			{Name: "beta", APIKey: "key2", TeamID: "B"},
+			{Name: "gamma", APIKey: "key3", TeamID: "G"},
+		},
+	}
+
+	handler, err := NewMultiWorkspaceHandler(cfg)
+	if err != nil {
+		t.Fatalf("failed to create handler: %v", err)
+	}
+
+	names := handler.ListWorkspaces()
+	if len(names) != 3 {
+		t.Errorf("ListWorkspaces() returned %d names, want 3", len(names))
+	}
+
+	// Check that all names are present (order may vary due to map iteration)
+	nameSet := make(map[string]bool)
+	for _, n := range names {
+		nameSet[n] = true
+	}
+	for _, expected := range []string{"alpha", "beta", "gamma"} {
+		if !nameSet[expected] {
+			t.Errorf("ListWorkspaces() missing %q", expected)
+		}
+	}
+}
+
+func TestWorkspaceHandler_ResolvePilotProject(t *testing.T) {
+	tests := []struct {
+		name       string
+		wsConfig   *WorkspaceConfig
+		issue      *Issue
+		wantResult string
+	}{
+		{
+			name: "single project mapped",
+			wsConfig: &WorkspaceConfig{
+				Projects: []string{"pilot"},
+			},
+			issue:      &Issue{},
+			wantResult: "pilot",
+		},
+		{
+			name: "multiple projects - returns first",
+			wsConfig: &WorkspaceConfig{
+				Projects: []string{"aso-generator", "pilot"},
+			},
+			issue:      &Issue{},
+			wantResult: "aso-generator",
+		},
+		{
+			name: "match by project ID",
+			wsConfig: &WorkspaceConfig{
+				ProjectIDs: []string{"proj-abc"},
+				Projects:   []string{"matched-project"},
+			},
+			issue: &Issue{
+				Project: &Project{ID: "proj-abc", Name: "Linear Project"},
+			},
+			wantResult: "matched-project",
+		},
+		{
+			name: "no projects mapped",
+			wsConfig: &WorkspaceConfig{
+				Projects: []string{},
+			},
+			issue:      &Issue{},
+			wantResult: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &WorkspaceHandler{config: tt.wsConfig}
+			got := ws.ResolvePilotProject(tt.issue)
+			if got != tt.wantResult {
+				t.Errorf("ResolvePilotProject() = %q, want %q", got, tt.wantResult)
+			}
+		})
+	}
+}
+
+func TestMultiWorkspaceHandler_GetNotifier(t *testing.T) {
+	cfg := &Config{
+		Enabled: true,
+		Workspaces: []*WorkspaceConfig{
+			{Name: "ws1", APIKey: "key1", TeamID: "T1"},
+		},
+	}
+
+	handler, err := NewMultiWorkspaceHandler(cfg)
+	if err != nil {
+		t.Fatalf("failed to create handler: %v", err)
+	}
+
+	notifier := handler.GetNotifier("ws1")
+	if notifier == nil {
+		t.Error("expected non-nil notifier for ws1")
+	}
+
+	notifier = handler.GetNotifier("nonexistent")
+	if notifier != nil {
+		t.Error("expected nil notifier for nonexistent workspace")
+	}
+}
+
+func TestMultiWorkspaceHandler_GetClient(t *testing.T) {
+	cfg := &Config{
+		Enabled: true,
+		Workspaces: []*WorkspaceConfig{
+			{Name: "ws1", APIKey: "key1", TeamID: "T1"},
+		},
+	}
+
+	handler, err := NewMultiWorkspaceHandler(cfg)
+	if err != nil {
+		t.Fatalf("failed to create handler: %v", err)
+	}
+
+	client := handler.GetClient("ws1")
+	if client == nil {
+		t.Error("expected non-nil client for ws1")
+	}
+
+	client = handler.GetClient("nonexistent")
+	if client != nil {
+		t.Error("expected nil client for nonexistent workspace")
+	}
+}
+
+// containsSubstr checks if a string contains a substring (renamed to avoid collision)
+func containsSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/adapters/linear/types.go
+++ b/internal/adapters/linear/types.go
@@ -2,12 +2,94 @@ package linear
 
 // Config holds Linear adapter configuration
 type Config struct {
-	Enabled    bool     `yaml:"enabled"`
+	Enabled    bool               `yaml:"enabled"`
+	Workspaces []*WorkspaceConfig `yaml:"workspaces,omitempty"`
+
+	// Legacy single-workspace fields (backward compatible)
+	APIKey     string   `yaml:"api_key,omitempty"`
+	TeamID     string   `yaml:"team_id,omitempty"`
+	AutoAssign bool     `yaml:"auto_assign"`
+	PilotLabel string   `yaml:"pilot_label,omitempty"`
+	ProjectIDs []string `yaml:"project_ids,omitempty"` // Filter issues by project ID(s)
+}
+
+// WorkspaceConfig holds configuration for a single Linear workspace
+type WorkspaceConfig struct {
+	Name       string   `yaml:"name"`
 	APIKey     string   `yaml:"api_key"`
 	TeamID     string   `yaml:"team_id"`
-	AutoAssign bool     `yaml:"auto_assign"`
 	PilotLabel string   `yaml:"pilot_label"`
-	ProjectIDs []string `yaml:"project_ids,omitempty"` // Filter issues by project ID(s)
+	ProjectIDs []string `yaml:"project_ids,omitempty"`
+	Projects   []string `yaml:"projects"` // Pilot project names
+	AutoAssign bool     `yaml:"auto_assign"`
+}
+
+// GetWorkspaces returns all configured workspaces.
+// If workspaces array is set, returns it directly.
+// Otherwise, converts legacy single-workspace config to a workspace slice for backward compatibility.
+func (c *Config) GetWorkspaces() []*WorkspaceConfig {
+	if len(c.Workspaces) > 0 {
+		return c.Workspaces
+	}
+
+	// Legacy single-workspace mode
+	if c.APIKey != "" {
+		pilotLabel := c.PilotLabel
+		if pilotLabel == "" {
+			pilotLabel = "pilot"
+		}
+		return []*WorkspaceConfig{{
+			Name:       "default",
+			APIKey:     c.APIKey,
+			TeamID:     c.TeamID,
+			PilotLabel: pilotLabel,
+			ProjectIDs: c.ProjectIDs,
+			AutoAssign: c.AutoAssign,
+		}}
+	}
+
+	return nil
+}
+
+// Validate checks the configuration for errors
+func (c *Config) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+
+	workspaces := c.GetWorkspaces()
+	if len(workspaces) == 0 {
+		return nil // No workspaces configured
+	}
+
+	// Check for duplicate team IDs
+	seenTeamIDs := make(map[string]string) // team_id -> workspace name
+	for _, ws := range workspaces {
+		if ws.TeamID == "" {
+			continue
+		}
+		if existing, ok := seenTeamIDs[ws.TeamID]; ok {
+			return &DuplicateTeamIDError{
+				TeamID:     ws.TeamID,
+				Workspace1: existing,
+				Workspace2: ws.Name,
+			}
+		}
+		seenTeamIDs[ws.TeamID] = ws.Name
+	}
+
+	return nil
+}
+
+// DuplicateTeamIDError is returned when two workspaces have the same team ID
+type DuplicateTeamIDError struct {
+	TeamID     string
+	Workspace1 string
+	Workspace2 string
+}
+
+func (e *DuplicateTeamIDError) Error() string {
+	return "duplicate team_id '" + e.TeamID + "' in workspaces '" + e.Workspace1 + "' and '" + e.Workspace2 + "'"
 }
 
 // DefaultConfig returns default Linear configuration


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-391.

## Changes

GitHub Issue #391: feat(linear): multi-workspace support

# GH-391: Linear Multi-Workspace Support

## Overview

Support multiple Linear workspaces in a single Pilot instance, mapping workspaces to specific projects.

## Problem

Current config only supports one Linear workspace:
```yaml
adapters:
  linear:
    api_key: "lin_api_xxx"
    team_id: "APP"
```

Users with multiple clients/workspaces (e.g., `appbooster`, `bostonteam`) must run separate Pilot instances with different config files.

## Solution

Add `workspaces` array to Linear config:

```yaml
adapters:
  linear:
    enabled: true
    workspaces:
      - name: appbooster
        api_key: "${LINEAR_API_KEY_APPBOOSTER}"
        team_id: "APP"
        pilot_label: "pilot"
        project_ids:
          - "2bcb89b25a01"      # aso-brief-generator
        projects:                # Map to Pilot projects
          - aso-generator
          - pilot

      - name: bostonteam
        api_key: "${LINEAR_API_KEY_BOSTON}"
        team_id: "BT"
        pilot_label: "pilot"
        projects:
          - bostonteamgroup
```

## Implementation

### 1. Update Config Types (`internal/adapters/linear/types.go`)

```go
type Config struct {
    Enabled    bool              `yaml:"enabled"`
    Workspaces []*WorkspaceConfig `yaml:"workspaces,omitempty"`

    // Legacy single-workspace fields (backward compatible)
    APIKey     string   `yaml:"api_key,omitempty"`
    TeamID     string   `yaml:"team_id,omitempty"`
    AutoAssign bool     `yaml:"auto_assign"`
    PilotLabel string   `yaml:"pilot_label,omitempty"`
    ProjectIDs []string `yaml:"project_ids,omitempty"`
}

type WorkspaceConfig struct {
    Name       string   `yaml:"name"`
    APIKey     string   `yaml:"api_key"`
    TeamID     string   `yaml:"team_id"`
    PilotLabel string   `yaml:"pilot_label"`
    ProjectIDs []string `yaml:"project_ids,omitempty"`
    Projects   []string `yaml:"projects"`  // Pilot project names
    AutoAssign bool     `yaml:"auto_assign"`
}
```

### 2. Backward Compatibility

If `workspaces` is empty but legacy fields are set, convert to single workspace:

```go
func (c *Config) GetWorkspaces() []*WorkspaceConfig {
    if len(c.Workspaces) > 0 {
        return c.Workspaces
    }

    // Legacy single-workspace mode
    if c.APIKey != "" {
        return []*WorkspaceConfig{{
            Name:       "default",
            APIKey:     c.APIKey,
            TeamID:     c.TeamID,
            PilotLabel: c.PilotLabel,
            ProjectIDs: c.ProjectIDs,
            AutoAssign: c.AutoAssign,
        }}
    }

    return nil
}
```

### 3. Webhook Handler Updates

Route webhooks to correct workspace based on team/signature:

```go
type MultiWorkspaceHandler struct {
    workspaces map[string]*WorkspaceHandler  // keyed by team_id
}

func (h *MultiWorkspaceHandler) HandleWebhook(r *http.Request) error {
    // Parse webhook to get team_id
    teamID := extractTeamID(r)

    handler, ok := h.workspaces[teamID]
    if !ok {
        return fmt.Errorf("unknown workspace for team %s", teamID)
    }

    return handler.Handle(r)
}
```

### 4. Project Mapping

When creating task from Linear issue, resolve Pilot project:

```go
func (w *WorkspaceConfig) ResolvePilotProject(issue *Issue) string {
    // If only one project mapped, use it
    if len(w.Projects) == 1 {
        return w.Projects[0]
    }

    // Otherwise, try to match by Linear project or use first
    return w.Projects[0]
}
```

### 5. Notifier Updates

Track which workspace to notify for task updates:

```go
type TaskMetadata struct {
    LinearWorkspace string  // Track originating workspace
    LinearIssueID   string
}
```

## Config Examples

### Multi-Workspace (New)
```yaml
adapters:
  linear:
    enabled: true
    workspaces:
      - name: appbooster
        api_key: "${LINEAR_API_KEY_APPBOOSTER}"
        team_id: "APP"
        pilot_label: "pilot"
        projects: [aso-generator, pilot]

      - name: bostonteam
        api_key: "${LINEAR_API_KEY_BOSTON}"
        team_id: "BT"
        pilot_label: "pilot"
        projects: [bostonteamgroup]
```

### Single Workspace (Legacy, still works)
```yaml
adapters:
  linear:
    enabled: true
    api_key: "lin_api_xxx"
    team_id: "APP"
    pilot_label: "pilot"
```

## Testing

1. Configure two workspaces with different API keys
2. Create issue in workspace A with `pilot` label → picks correct project
3. Create issue in workspace B with `pilot` label → picks correct project
4. Legacy single-workspace config still works
5. Notifications go back to correct workspace

## Acceptance Criteria

- [ ] `workspaces` array added to Linear config
- [ ] Each workspace has own API key, team_id, project mapping
- [ ] Backward compatible with single-workspace config
- [ ] Webhooks routed to correct workspace handler
- [ ] Task notifications go to originating workspace
- [ ] Config validation ensures no duplicate team_ids
- [ ] Example config updated