### PR TITLE
feat(linear): add polling support (mirror GitHub pattern)

### DIFF
--- a/internal/adapters/linear/client.go
+++ b/internal/adapters/linear/client.go
@@ -232,3 +232,187 @@ func (c *Client) AddComment(ctx context.Context, issueID, body string) error {
 		"body":    body,
 	}, nil)
 }
+
+// ListIssuesOptions configures issue listing
+type ListIssuesOptions struct {
+	TeamID     string
+	Label      string
+	ProjectIDs []string
+	States     []string // e.g., ["backlog", "unstarted", "started"]
+}
+
+// ListIssues fetches issues matching the filter criteria
+func (c *Client) ListIssues(ctx context.Context, opts *ListIssuesOptions) ([]*Issue, error) {
+	query := `
+		query ListIssues($teamId: String!, $label: String!, $states: [String!]) {
+			issues(
+				filter: {
+					team: { key: { eq: $teamId } }
+					labels: { name: { eq: $label } }
+					state: { type: { in: $states } }
+				}
+				first: 50
+				orderBy: createdAt
+			) {
+				nodes {
+					id
+					identifier
+					title
+					description
+					priority
+					state { id name type }
+					labels { nodes { id name } }
+					assignee { id name email }
+					project { id name }
+					team { id name key }
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`
+
+	states := opts.States
+	if len(states) == 0 {
+		states = []string{"backlog", "unstarted", "started"}
+	}
+
+	variables := map[string]interface{}{
+		"teamId": opts.TeamID,
+		"label":  opts.Label,
+		"states": states,
+	}
+
+	var result struct {
+		Issues struct {
+			Nodes []*issueListItem `json:"nodes"`
+		} `json:"issues"`
+	}
+
+	if err := c.Execute(ctx, query, variables, &result); err != nil {
+		return nil, err
+	}
+
+	// Convert responses to Issue objects
+	issues := make([]*Issue, 0, len(result.Issues.Nodes))
+	for _, resp := range result.Issues.Nodes {
+		issue := resp.toIssue()
+		// Filter by project if specified
+		if len(opts.ProjectIDs) > 0 {
+			if issue.Project == nil || !containsString(opts.ProjectIDs, issue.Project.ID) {
+				continue
+			}
+		}
+		issues = append(issues, issue)
+	}
+
+	return issues, nil
+}
+
+// issueListItem is the raw GraphQL response for an issue (labels have nested nodes)
+type issueListItem struct {
+	ID          string    `json:"id"`
+	Identifier  string    `json:"identifier"`
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	Priority    int       `json:"priority"`
+	State       State     `json:"state"`
+	Labels      struct {
+		Nodes []Label `json:"nodes"`
+	} `json:"labels"`
+	Assignee  *User     `json:"assignee"`
+	Project   *Project  `json:"project"`
+	Team      Team      `json:"team"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// toIssue converts the response to an Issue
+func (r *issueListItem) toIssue() *Issue {
+	return &Issue{
+		ID:          r.ID,
+		Identifier:  r.Identifier,
+		Title:       r.Title,
+		Description: r.Description,
+		Priority:    r.Priority,
+		State:       r.State,
+		Labels:      r.Labels.Nodes,
+		Assignee:    r.Assignee,
+		Project:     r.Project,
+		Team:        r.Team,
+		CreatedAt:   r.CreatedAt,
+		UpdatedAt:   r.UpdatedAt,
+	}
+}
+
+// containsString checks if a slice contains a string
+func containsString(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// AddLabel adds a label to an issue
+func (c *Client) AddLabel(ctx context.Context, issueID, labelID string) error {
+	mutation := `
+		mutation AddLabel($issueId: String!, $labelId: String!) {
+			issueAddLabel(id: $issueId, labelId: $labelId) {
+				success
+			}
+		}
+	`
+	return c.Execute(ctx, mutation, map[string]interface{}{
+		"issueId": issueID,
+		"labelId": labelID,
+	}, nil)
+}
+
+// RemoveLabel removes a label from an issue
+func (c *Client) RemoveLabel(ctx context.Context, issueID, labelID string) error {
+	mutation := `
+		mutation RemoveLabel($issueId: String!, $labelId: String!) {
+			issueRemoveLabel(id: $issueId, labelId: $labelId) {
+				success
+			}
+		}
+	`
+	return c.Execute(ctx, mutation, map[string]interface{}{
+		"issueId": issueID,
+		"labelId": labelID,
+	}, nil)
+}
+
+// GetLabelByName fetches a label ID by name for a team
+func (c *Client) GetLabelByName(ctx context.Context, teamID, labelName string) (string, error) {
+	query := `
+		query GetLabel($teamId: String!, $name: String!) {
+			issueLabels(filter: { team: { key: { eq: $teamId } }, name: { eq: $name } }) {
+				nodes { id name }
+			}
+		}
+	`
+	var result struct {
+		IssueLabels struct {
+			Nodes []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"nodes"`
+		} `json:"issueLabels"`
+	}
+
+	if err := c.Execute(ctx, query, map[string]interface{}{
+		"teamId": teamID,
+		"name":   labelName,
+	}, &result); err != nil {
+		return "", err
+	}
+
+	if len(result.IssueLabels.Nodes) == 0 {
+		return "", fmt.Errorf("label %q not found in team %s", labelName, teamID)
+	}
+
+	return result.IssueLabels.Nodes[0].ID, nil
+}

--- a/internal/adapters/linear/poller.go
+++ b/internal/adapters/linear/poller.go
@@ -1,0 +1,230 @@
+package linear
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// IssueResult is returned by the issue handler
+type IssueResult struct {
+	Success  bool
+	PRNumber int
+	PRURL    string
+	Error    error
+}
+
+// Poller polls Linear for issues with a specific label
+type Poller struct {
+	client    *Client
+	config    *WorkspaceConfig
+	interval  time.Duration
+	processed map[string]bool // Linear uses string IDs
+	mu        sync.RWMutex
+	onIssue   func(ctx context.Context, issue *Issue) (*IssueResult, error)
+	logger    *slog.Logger
+
+	// Labels cache
+	pilotLabelID      string
+	inProgressLabelID string
+	doneLabelID       string
+	failedLabelID     string
+}
+
+// PollerOption configures a Poller
+type PollerOption func(*Poller)
+
+// WithOnLinearIssue sets the callback for new issues
+func WithOnLinearIssue(fn func(ctx context.Context, issue *Issue) (*IssueResult, error)) PollerOption {
+	return func(p *Poller) {
+		p.onIssue = fn
+	}
+}
+
+// WithPollerLogger sets the logger for the poller
+func WithPollerLogger(logger *slog.Logger) PollerOption {
+	return func(p *Poller) {
+		p.logger = logger
+	}
+}
+
+// NewPoller creates a new Linear issue poller
+func NewPoller(client *Client, config *WorkspaceConfig, interval time.Duration, opts ...PollerOption) *Poller {
+	p := &Poller{
+		client:    client,
+		config:    config,
+		interval:  interval,
+		processed: make(map[string]bool),
+		logger:    logging.WithComponent("linear-poller"),
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
+}
+
+// Start begins polling for issues
+func (p *Poller) Start(ctx context.Context) error {
+	// Cache label IDs on startup
+	if err := p.cacheLabelIDs(ctx); err != nil {
+		return fmt.Errorf("failed to cache label IDs: %w", err)
+	}
+
+	p.logger.Info("Starting Linear poller",
+		slog.String("team", p.config.TeamID),
+		slog.String("label", p.config.PilotLabel),
+		slog.Duration("interval", p.interval),
+	)
+
+	// Initial check
+	p.checkForNewIssues(ctx)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("Linear poller stopped")
+			return nil
+		case <-ticker.C:
+			p.checkForNewIssues(ctx)
+		}
+	}
+}
+
+func (p *Poller) cacheLabelIDs(ctx context.Context) error {
+	var err error
+
+	p.pilotLabelID, err = p.client.GetLabelByName(ctx, p.config.TeamID, p.config.PilotLabel)
+	if err != nil {
+		return fmt.Errorf("pilot label: %w", err)
+	}
+
+	// These labels are optional - create if needed or skip
+	p.inProgressLabelID, _ = p.client.GetLabelByName(ctx, p.config.TeamID, "pilot-in-progress")
+	p.doneLabelID, _ = p.client.GetLabelByName(ctx, p.config.TeamID, "pilot-done")
+	p.failedLabelID, _ = p.client.GetLabelByName(ctx, p.config.TeamID, "pilot-failed")
+
+	return nil
+}
+
+func (p *Poller) checkForNewIssues(ctx context.Context) {
+	issues, err := p.client.ListIssues(ctx, &ListIssuesOptions{
+		TeamID:     p.config.TeamID,
+		Label:      p.config.PilotLabel,
+		ProjectIDs: p.config.ProjectIDs,
+	})
+	if err != nil {
+		p.logger.Warn("Failed to fetch issues", slog.Any("error", err))
+		return
+	}
+
+	// Sort by creation date (oldest first)
+	sort.Slice(issues, func(i, j int) bool {
+		return issues[i].CreatedAt.Before(issues[j].CreatedAt)
+	})
+
+	for _, issue := range issues {
+		// Skip if already processed
+		p.mu.RLock()
+		processed := p.processed[issue.ID]
+		p.mu.RUnlock()
+
+		if processed {
+			continue
+		}
+
+		// Skip if has in-progress, done, or failed label
+		if p.hasStatusLabel(issue) {
+			p.markProcessed(issue.ID)
+			continue
+		}
+
+		// Process the issue
+		p.logger.Info("Found new Linear issue",
+			slog.String("identifier", issue.Identifier),
+			slog.String("title", issue.Title),
+		)
+
+		if p.onIssue != nil {
+			// Add in-progress label
+			if p.inProgressLabelID != "" {
+				_ = p.client.AddLabel(ctx, issue.ID, p.inProgressLabelID)
+			}
+
+			result, err := p.onIssue(ctx, issue)
+			if err != nil {
+				p.logger.Error("Failed to process issue",
+					slog.String("identifier", issue.Identifier),
+					slog.Any("error", err),
+				)
+				// Remove in-progress label, add failed label
+				if p.inProgressLabelID != "" {
+					_ = p.client.RemoveLabel(ctx, issue.ID, p.inProgressLabelID)
+				}
+				if p.failedLabelID != "" {
+					_ = p.client.AddLabel(ctx, issue.ID, p.failedLabelID)
+				}
+				p.markProcessed(issue.ID)
+				continue
+			}
+
+			// Remove in-progress label
+			if p.inProgressLabelID != "" {
+				_ = p.client.RemoveLabel(ctx, issue.ID, p.inProgressLabelID)
+			}
+
+			// Add done label on success
+			if result != nil && result.Success && p.doneLabelID != "" {
+				_ = p.client.AddLabel(ctx, issue.ID, p.doneLabelID)
+			}
+		}
+
+		p.markProcessed(issue.ID)
+	}
+}
+
+func (p *Poller) hasStatusLabel(issue *Issue) bool {
+	for _, label := range issue.Labels {
+		switch label.Name {
+		case "pilot-in-progress", "pilot-done", "pilot-failed":
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Poller) markProcessed(id string) {
+	p.mu.Lock()
+	p.processed[id] = true
+	p.mu.Unlock()
+}
+
+// IsProcessed checks if an issue has been processed
+func (p *Poller) IsProcessed(id string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.processed[id]
+}
+
+// ProcessedCount returns the number of processed issues
+func (p *Poller) ProcessedCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.processed)
+}
+
+// Reset clears the processed issues map
+func (p *Poller) Reset() {
+	p.mu.Lock()
+	p.processed = make(map[string]bool)
+	p.mu.Unlock()
+}

--- a/internal/adapters/linear/types.go
+++ b/internal/adapters/linear/types.go
@@ -1,5 +1,7 @@
 package linear
 
+import "time"
+
 // Config holds Linear adapter configuration
 type Config struct {
 	Enabled    bool               `yaml:"enabled"`
@@ -11,6 +13,15 @@ type Config struct {
 	AutoAssign bool     `yaml:"auto_assign"`
 	PilotLabel string   `yaml:"pilot_label,omitempty"`
 	ProjectIDs []string `yaml:"project_ids,omitempty"` // Filter issues by project ID(s)
+
+	// Polling configuration
+	Polling *PollingConfig `yaml:"polling,omitempty"`
+}
+
+// PollingConfig holds polling configuration for Linear adapter
+type PollingConfig struct {
+	Enabled  bool          `yaml:"enabled"`
+	Interval time.Duration `yaml:"interval"`
 }
 
 // WorkspaceConfig holds configuration for a single Linear workspace
@@ -22,6 +33,9 @@ type WorkspaceConfig struct {
 	ProjectIDs []string `yaml:"project_ids,omitempty"`
 	Projects   []string `yaml:"projects"` // Pilot project names
 	AutoAssign bool     `yaml:"auto_assign"`
+
+	// Polling configuration (workspace-level override)
+	Polling *PollingConfig `yaml:"polling,omitempty"`
 }
 
 // GetWorkspaces returns all configured workspaces.
@@ -98,6 +112,10 @@ func DefaultConfig() *Config {
 		Enabled:    false,
 		PilotLabel: "pilot",
 		AutoAssign: true,
+		Polling: &PollingConfig{
+			Enabled:  true,
+			Interval: 30 * time.Second,
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-393.

## Changes

GitHub Issue #393: feat(linear): add polling support (mirror GitHub pattern)

# GH-393: Add Linear Polling Support

## Overview

Add polling support to Linear adapter, mirroring GitHub's proven polling pattern. This replaces webhook-based approach with simpler, more reliable polling.

## Rationale

| Aspect | Webhooks | Polling |
|--------|----------|---------|
| Setup | Tunnel + webhook config | Just API token |
| Reliability | Tunnel must run | Self-healing |
| Latency | Instant | 30s (acceptable) |
| Firewall | Needs public URL | Works anywhere |
| Complexity | High | Low |

**Decision:** Polling is simpler, more reliable, and consistent with GitHub adapter.

## Implementation

### 1. Add `ListIssues` to Linear Client (`internal/adapters/linear/client.go`)

```go
// ListIssuesOptions configures issue listing
type ListIssuesOptions struct {
    TeamID     string
    Label      string
    ProjectIDs []string
    States     []string // e.g., ["backlog", "unstarted", "started"]
}

// ListIssues fetches issues matching the filter criteria
func (c *Client) ListIssues(ctx context.Context, opts *ListIssuesOptions) ([]*Issue, error) {
    query := `
        query ListIssues($teamId: String!, $label: String!, $states: [String!]) {
            issues(
                filter: {
                    team: { key: { eq: $teamId } }
                    labels: { name: { eq: $label } }
                    state: { type: { in: $states } }
                }
                first: 50
                orderBy: createdAt
            ) {
                nodes {
                    id
                    identifier
                    title
                    description
                    priority
                    state { id name type }
                    labels { nodes { id name } }
                    assignee { id name email }
                    project { id name }
                    team { id name key }
                    createdAt
                    updatedAt
                }
            }
        }
    `

    variables := map[string]interface{}{
        "teamId": opts.TeamID,
        "label":  opts.Label,
        "states": []string{"backlog", "unstarted", "started"},
    }

    var result struct {
        Issues struct {
            Nodes []*Issue `json:"nodes"`
        } `json:"issues"`
    }

    if err := c.Execute(ctx, query, variables, &result); err != nil {
        return nil, err
    }

    // Filter by project if specified
    if len(opts.ProjectIDs) > 0 {
        filtered := make([]*Issue, 0)
        for _, issue := range result.Issues.Nodes {
            if issue.Project != nil && contains(opts.ProjectIDs, issue.Project.ID) {
                filtered = append(filtered, issue)
            }
        }
        return filtered, nil
    }

    return result.Issues.Nodes, nil
}
```

### 2. Add Label Management to Client

```go
// AddLabel adds a label to an issue
func (c *Client) AddLabel(ctx context.Context, issueID, labelID string) error {
    mutation := `
        mutation AddLabel($issueId: String!, $labelId: String!) {
            issueAddLabel(id: $issueId, labelId: $labelId) {
                success
            }
        }
    `
    return c.Execute(ctx, mutation, map[string]interface{}{
        "issueId": issueID,
        "labelId": labelID,
    }, nil)
}

// RemoveLabel removes a label from an issue
func (c *Client) RemoveLabel(ctx context.Context, issueID, labelID string) error {
    mutation := `
        mutation RemoveLabel($issueId: String!, $labelId: String!) {
            issueRemoveLabel(id: $issueId, labelId: $labelId) {
                success
            }
        }
    `
    return c.Execute(ctx, mutation, map[string]interface{}{
        "issueId": issueID,
        "labelId": labelID,
    }, nil)
}

// GetLabelByName fetches a label ID by name for a team
func (c *Client) GetLabelByName(ctx context.Context, teamID, labelName string) (string, error) {
    query := `
        query GetLabel($teamId: String!, $name: String!) {
            issueLabels(filter: { team: { key: { eq: $teamId } }, name: { eq: $name } }) {
                nodes { id name }
            }
        }
    `
    var result struct {
        IssueLabels struct {
            Nodes []struct {
                ID   string `json:"id"`
                Name string `json:"name"`
            } `json:"nodes"`
        } `json:"issueLabels"`
    }

    if err := c.Execute(ctx, query, map[string]interface{}{
        "teamId": teamID,
        "name":   labelName,
    }, &result); err != nil {
        return "", err
    }

    if len(result.IssueLabels.Nodes) == 0 {
        return "", fmt.Errorf("label %q not found in team %s", labelName, teamID)
    }

    return result.IssueLabels.Nodes[0].ID, nil
}
```

### 3. Create Linear Poller (`internal/adapters/linear/poller.go`)

```go
package linear

import (
    "context"
    "log/slog"
    "sort"
    "sync"
    "time"

    "github.com/alekspetrov/pilot/internal/logging"
)

// Poller polls Linear for issues with a specific label
type Poller struct {
    client     *Client
    config     *Config
    interval   time.Duration
    processed  map[string]bool  // Linear uses string IDs
    mu         sync.RWMutex
    onIssue    func(ctx context.Context, issue *Issue) (*IssueResult, error)
    logger     *slog.Logger

    // Labels cache
    pilotLabelID      string
    inProgressLabelID string
    doneLabelID       string
    failedLabelID     string
}

// IssueResult is returned by the issue handler
type IssueResult struct {
    Success  bool
    PRNumber int
    PRURL    string
    Error    error
}

// PollerOption configures a Poller
type PollerOption func(*Poller)

// WithOnLinearIssue sets the callback for new issues
func WithOnLinearIssue(fn func(ctx context.Context, issue *Issue) (*IssueResult, error)) PollerOption {
    return func(p *Poller) {
        p.onIssue = fn
    }
}

// NewPoller creates a new Linear issue poller
func NewPoller(client *Client, config *Config, interval time.Duration, opts ...PollerOption) *Poller {
    p := &Poller{
        client:    client,
        config:    config,
        interval:  interval,
        processed: make(map[string]bool),
        logger:    logging.WithComponent("linear-poller"),
    }

    for _, opt := range opts {
        opt(p)
    }

    return p
}

// Start begins polling for issues
func (p *Poller) Start(ctx context.Context) error {
    // Cache label IDs on startup
    if err := p.cacheLabelIDs(ctx); err != nil {
        return fmt.Errorf("failed to cache label IDs: %w", err)
    }

    p.logger.Info("Starting Linear poller",
        slog.String("team", p.config.TeamID),
        slog.String("label", p.config.PilotLabel),
        slog.Duration("interval", p.interval),
    )

    // Initial check
    p.checkForNewIssues(ctx)

    ticker := time.NewTicker(p.interval)
    defer ticker.Stop()

    for {
        select {
        case <-ctx.Done():
            p.logger.Info("Linear poller stopped")
            return nil
        case <-ticker.C:
            p.checkForNewIssues(ctx)
        }
    }
}

func (p *Poller) cacheLabelIDs(ctx context.Context) error {
    var err error

    p.pilotLabelID, err = p.client.GetLabelByName(ctx, p.config.TeamID, p.config.PilotLabel)
    if err != nil {
        return fmt.Errorf("pilot label: %w", err)
    }

    // These labels are optional - create if needed or skip
    p.inProgressLabelID, _ = p.client.GetLabelByName(ctx, p.config.TeamID, "pilot-in-progress")
    p.doneLabelID, _ = p.client.GetLabelByName(ctx, p.config.TeamID, "pilot-done")
    p.failedLabelID, _ = p.client.GetLabelByName(ctx, p.config.TeamID, "pilot-failed")

    return nil
}

func (p *Poller) checkForNewIssues(ctx context.Context) {
    issues, err := p.client.ListIssues(ctx, &ListIssuesOptions{
        TeamID:     p.config.TeamID,
        Label:      p.config.PilotLabel,
        ProjectIDs: p.config.ProjectIDs,
    })
    if err != nil {
        p.logger.Warn("Failed to fetch issues", slog.Any("error", err))
        return
    }

    // Sort by creation date (oldest first)
    sort.Slice(issues, func(i, j int) bool {
        return issues[i].CreatedAt.Before(issues[j].CreatedAt)
    })

    for _, issue := range issues {
        // Skip if already processed
        p.mu.RLock()
        processed := p.processed[issue.ID]
        p.mu.RUnlock()

        if processed {
            continue
        }

        // Skip if has in-progress, done, or failed label
        if p.hasStatusLabel(issue) {
            p.markProcessed(issue.ID)
            continue
        }

        // Process the issue
        p.logger.Info("Found new Linear issue",
            slog.String("identifier", issue.Identifier),
            slog.String("title", issue.Title),
        )

        if p.onIssue != nil {
            // Add in-progress label
            if p.inProgressLabelID != "" {
                _ = p.client.AddLabel(ctx, issue.ID, p.inProgressLabelID)
            }

            result, err := p.onIssue(ctx, issue)
            if err != nil {
                p.logger.Error("Failed to process issue",
                    slog.String("identifier", issue.Identifier),
                    slog.Any("error", err),
                )
                // Add failed label
                if p.failedLabelID != "" {
                    _ = p.client.AddLabel(ctx, issue.ID, p.failedLabelID)
                }
                continue
            }

            // Add done label on success
            if result != nil && result.Success && p.doneLabelID != "" {
                _ = p.client.AddLabel(ctx, issue.ID, p.doneLabelID)
            }
        }

        p.markProcessed(issue.ID)
    }
}

func (p *Poller) hasStatusLabel(issue *Issue) bool {
    for _, label := range issue.Labels {
        switch label.Name {
        case "pilot-in-progress", "pilot-done", "pilot-failed":
            return true
        }
    }
    return false
}

func (p *Poller) markProcessed(id string) {
    p.mu.Lock()
    p.processed[id] = true
    p.mu.Unlock()
}
```

### 4. Update Config (`internal/adapters/linear/types.go`)

```go
type Config struct {
    Enabled    bool     `yaml:"enabled"`
    APIKey     string   `yaml:"api_key"`
    TeamID     string   `yaml:"team_id"`
    AutoAssign bool     `yaml:"auto_assign"`
    PilotLabel string   `yaml:"pilot_label"`
    ProjectIDs []string `yaml:"project_ids,omitempty"`

    // Polling configuration
    Polling *PollingConfig `yaml:"polling,omitempty"`
}

type PollingConfig struct {
    Enabled  bool          `yaml:"enabled"`
    Interval time.Duration `yaml:"interval"`
}

func DefaultConfig() *Config {
    return &Config{
        Enabled:    false,
        PilotLabel: "pilot",
        AutoAssign: true,
        Polling: &PollingConfig{
            Enabled:  true,
            Interval: 30 * time.Second,
        },
    }
}
```

### 5. Wire into Start Command (`cmd/pilot/main.go`)

Add Linear poller alongside GitHub poller in polling mode:

```go
// In runPollingMode or gateway mode:
if hasLinear && cfg.Adapters.Linear.Polling != nil && cfg.Adapters.Linear.Polling.Enabled {
    linearClient := linear.NewClient(cfg.Adapters.Linear.APIKey)
    interval := cfg.Adapters.Linear.Polling.Interval
    if interval == 0 {
        interval = 30 * time.Second
    }

    linearPoller := linear.NewPoller(linearClient, cfg.Adapters.Linear, interval,
        linear.WithOnLinearIssue(func(ctx context.Context, issue *linear.Issue) (*linear.IssueResult, error) {
            // Convert Linear issue to task and execute
            return processLinearIssue(ctx, cfg, issue, projectPath)
        }),
    )

    go linearPoller.Start(ctx)
}
```

## Config Example

```yaml
adapters:
  linear:
    enabled: true
    api_key: "${LINEAR_API_KEY}"
    team_id: "APP"
    pilot_label: "pilot"
    project_ids:
      - "2bcb89b25a01"  # aso-brief-generator only
    polling:
      enabled: true
      interval: 30s
```

## Testing

1. Create Linear issue with `pilot` label → picked up within 30s
2. Issue in different project (when filter active) → ignored
3. Issue with `pilot-in-progress` label → skipped
4. Failed task → `pilot-failed` label added
5. Successful task → `pilot-done` label added, PR created

## Migration from Webhooks

- Webhooks still work if configured (for backward compatibility)
- Polling is default when `polling.enabled: true`
- Can run both if needed (polling catches missed webhooks)

## Acceptance Criteria

- [ ] `ListIssues` method added to Linear client
- [ ] Label management methods added (add/remove/get)
- [ ] `Poller` struct created mirroring GitHub pattern
- [ ] Polling config added to Linear config
- [ ] Wired into `pilot start` command
- [ ] Project filtering works
- [ ] Status labels applied (in-progress, done, failed)
- [ ] Works in both polling mode and gateway mode