### PR TITLE
feat(executor): add CreateSubIssues method for task decomposition

### DIFF
--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -232,3 +232,61 @@ func TestExecuteEpicTriggersPlanningMode(t *testing.T) {
 	}
 }
 
+func TestParseIssueNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected int
+	}{
+		{
+			name:     "standard github issue url",
+			url:      "https://github.com/anthropics/pilot/issues/123",
+			expected: 123,
+		},
+		{
+			name:     "github enterprise url",
+			url:      "https://github.example.com/org/repo/issues/456",
+			expected: 456,
+		},
+		{
+			name:     "url with trailing newline",
+			url:      "https://github.com/owner/repo/issues/789\n",
+			expected: 789,
+		},
+		{
+			name:     "large issue number",
+			url:      "https://github.com/owner/repo/issues/99999",
+			expected: 99999,
+		},
+		{
+			name:     "empty string",
+			url:      "",
+			expected: 0,
+		},
+		{
+			name:     "invalid url - no issues path",
+			url:      "https://github.com/owner/repo/pull/123",
+			expected: 0,
+		},
+		{
+			name:     "invalid url - no number",
+			url:      "https://github.com/owner/repo/issues/",
+			expected: 0,
+		},
+		{
+			name:     "plain text",
+			url:      "not a url at all",
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseIssueNumber(tt.url)
+			if result != tt.expected {
+				t.Errorf("parseIssueNumber(%q) = %d, want %d", tt.url, result, tt.expected)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-409.

## Changes

GitHub Issue #409: feat(executor): add CreateSubIssues method for task decomposition

## Goal

Add a method to create GitHub issues from planned subtasks.

## What to implement

In `internal/executor/epic.go`, add:

1. A `CreatedIssue` struct with Number, URL, and Subtask fields
2. A `CreateSubIssues` method on Runner that:
   - Takes context and a plan pointer
   - Loops through plan.Subtasks
   - Creates GitHub issues using `gh issue create` CLI
   - Returns slice of CreatedIssue

3. A helper `parseIssueNumber(url string) int` to extract issue number from URL

4. Unit test for parseIssueNumber in epic_test.go

## Acceptance Criteria

- [ ] Code compiles: `go build ./...`
- [ ] Tests pass: `go test ./internal/executor/...`