### PR TITLE
Create CountCheckboxes helper function

### DIFF
--- a/internal/executor/complexity.go
+++ b/internal/executor/complexity.go
@@ -173,6 +173,14 @@ func stripFilePaths(text string) string {
 	return filePathRegex.ReplaceAllString(text, " ")
 }
 
+// CountCheckboxes strips code blocks from the description and returns
+// the count of markdown checkboxes (- [ ] or - [x]) found.
+func CountCheckboxes(description string) int {
+	cleanDescription := stripCodeBlocks(description)
+	matches := checkboxRegex.FindAllString(cleanDescription, -1)
+	return len(matches)
+}
+
 // detectEpic checks if a task matches epic patterns.
 // Returns true if any epic indicator is found.
 func detectEpic(title, description, combined string) bool {
@@ -191,14 +199,13 @@ func detectEpic(title, description, combined string) bool {
 		return true
 	}
 
-	// Preprocess description for structural checks
-	cleanDescription := stripCodeBlocks(description)
-
 	// Check for 5+ checkboxes (acceptance criteria)
-	checkboxMatches := checkboxRegex.FindAllString(cleanDescription, -1)
-	if len(checkboxMatches) >= 5 {
+	if CountCheckboxes(description) >= 5 {
 		return true
 	}
+
+	// Preprocess description for structural checks
+	cleanDescription := stripCodeBlocks(description)
 
 	// Check for 3+ numbered phases/sections
 	phaseMatches := numberedPhaseRegex.FindAllString(cleanDescription, -1)

--- a/internal/executor/complexity_test.go
+++ b/internal/executor/complexity_test.go
@@ -286,6 +286,69 @@ func TestComplexity_Methods(t *testing.T) {
 	}
 }
 
+func TestCountCheckboxes(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		expected    int
+	}{
+		{
+			name:        "no checkboxes",
+			description: "Simple task with no checkboxes",
+			expected:    0,
+		},
+		{
+			name:        "single unchecked checkbox",
+			description: "- [ ] Do the thing",
+			expected:    1,
+		},
+		{
+			name:        "single checked checkbox",
+			description: "- [x] Done already",
+			expected:    1,
+		},
+		{
+			name: "multiple checkboxes",
+			description: `Task list:
+- [ ] First item
+- [x] Second item
+- [ ] Third item`,
+			expected: 3,
+		},
+		{
+			name: "checkboxes in code block ignored",
+			description: "Normal text\n```markdown\n- [ ] This is in a code block\n```\n- [ ] This is real",
+			expected:    1,
+		},
+		{
+			name: "indented checkboxes",
+			description: `Task:
+  - [ ] Indented item
+    - [x] More indented`,
+			expected: 2,
+		},
+		{
+			name:        "empty description",
+			description: "",
+			expected:    0,
+		},
+		{
+			name: "checkboxes in multiple code blocks",
+			description: "```\n- [ ] fake1\n```\n- [ ] real\n~~~\n- [ ] fake2\n~~~",
+			expected:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CountCheckboxes(tt.description)
+			if got != tt.expected {
+				t.Errorf("CountCheckboxes() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestComplexity_String(t *testing.T) {
 	tests := []struct {
 		complexity Complexity


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-428.

## Changes

Extract the checkbox counting regex logic from `detectEpic` into a standalone `CountCheckboxes(description string) int` function in `complexity.go`. This function strips code blocks and returns the count of markdown checkboxes found.