### PR TITLE
Refactor detectEpic to use new helpers

### DIFF
--- a/internal/executor/complexity.go
+++ b/internal/executor/complexity.go
@@ -173,6 +173,22 @@ func stripFilePaths(text string) string {
 	return filePathRegex.ReplaceAllString(text, " ")
 }
 
+// CountCheckboxes counts markdown checkboxes in text after stripping code blocks.
+// Returns the number of checkboxes found (both checked and unchecked).
+func CountCheckboxes(text string) int {
+	clean := stripCodeBlocks(text)
+	matches := checkboxRegex.FindAllString(clean, -1)
+	return len(matches)
+}
+
+// CountPhases counts numbered phase markers in text after stripping code blocks.
+// Matches patterns like "Phase 1", "Stage 2", "Part 3", "Milestone 4".
+func CountPhases(text string) int {
+	clean := stripCodeBlocks(text)
+	matches := numberedPhaseRegex.FindAllString(clean, -1)
+	return len(matches)
+}
+
 // detectEpic checks if a task matches epic patterns.
 // Returns true if any epic indicator is found.
 func detectEpic(title, description, combined string) bool {
@@ -191,22 +207,18 @@ func detectEpic(title, description, combined string) bool {
 		return true
 	}
 
-	// Preprocess description for structural checks
-	cleanDescription := stripCodeBlocks(description)
-
 	// Check for 5+ checkboxes (acceptance criteria)
-	checkboxMatches := checkboxRegex.FindAllString(cleanDescription, -1)
-	if len(checkboxMatches) >= 5 {
+	if CountCheckboxes(description) >= 5 {
 		return true
 	}
 
 	// Check for 3+ numbered phases/sections
-	phaseMatches := numberedPhaseRegex.FindAllString(cleanDescription, -1)
-	if len(phaseMatches) >= 3 {
+	if CountPhases(description) >= 3 {
 		return true
 	}
 
 	// Check for long description with structural markers
+	cleanDescription := stripCodeBlocks(description)
 	wordCount := len(strings.Fields(cleanDescription))
 	hasStructuralMarkers := strings.Contains(cleanDescription, "##") ||
 		strings.Contains(strings.ToLower(cleanDescription), "phase") ||


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-430.

## Changes

Update the `detectEpic` function to call `CountCheckboxes()` and `CountPhases()` instead of inline regex matching. Maintain the same threshold logic (5+ checkboxes, 3+ phases) for backward compatibility.