### PR TITLE
feat(dashboard): add sparkline utilities and MetricsCardData type

### DIFF
--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -1,0 +1,130 @@
+package dashboard
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func TestFormatCompact(t *testing.T) {
+	tests := []struct {
+		input int
+		want  string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1.0K"},
+		{57300, "57.3K"},
+		{1000000, "1.0M"},
+		{1234567, "1.2M"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := formatCompact(tt.input)
+			if got != tt.want {
+				t.Errorf("formatCompact(%d) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeToSparkline(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []float64
+		width  int
+		want   []int
+	}{
+		{
+			name:   "empty input returns all zeros",
+			values: nil,
+			width:  7,
+			want:   []int{0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:   "single value maps to midpoint",
+			values: []float64{42},
+			width:  7,
+			want:   []int{0, 0, 0, 0, 0, 0, 4},
+		},
+		{
+			name:   "all same values map to midpoint",
+			values: []float64{5, 5, 5, 5, 5, 5, 5},
+			width:  7,
+			want:   []int{4, 4, 4, 4, 4, 4, 4},
+		},
+		{
+			name:   "ascending values span full range",
+			values: []float64{0, 1, 2, 3, 4, 5, 6, 7, 8},
+			width:  9,
+			want:   []int{0, 1, 2, 3, 4, 5, 6, 7, 8},
+		},
+		{
+			name:   "fewer values than width left-pads with zeros",
+			values: []float64{0, 100},
+			width:  5,
+			want:   []int{0, 0, 0, 0, 8},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeToSparkline(tt.values, tt.width)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d", len(got), len(tt.want))
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d: got %d, want %d (full: %v)", i, got[i], tt.want[i], got)
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestRenderSparkline(t *testing.T) {
+	tests := []struct {
+		name    string
+		levels  []int
+		pulsing bool
+	}{
+		{
+			name:    "pulsing includes dot",
+			levels:  []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6},
+			pulsing: true,
+		},
+		{
+			name:    "not pulsing has space",
+			levels:  []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6},
+			pulsing: false,
+		},
+		{
+			name:    "all zeros",
+			levels:  []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			pulsing: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderSparkline(tt.levels, tt.pulsing)
+
+			// Visual width must equal cardInnerWidth (17)
+			runeCount := utf8.RuneCountInString(got)
+			if runeCount != cardInnerWidth {
+				t.Errorf("visual width = %d runes, want %d (got %q)", runeCount, cardInnerWidth, got)
+			}
+
+			// Check pulsing indicator
+			runes := []rune(got)
+			lastRune := runes[len(runes)-1]
+			if tt.pulsing && lastRune != '•' {
+				t.Errorf("pulsing=true but last rune = %q, want '•'", lastRune)
+			}
+			if !tt.pulsing && lastRune != ' ' {
+				t.Errorf("pulsing=false but last rune = %q, want ' '", lastRune)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-457.

## Changes

GitHub Issue #457: feat(dashboard): add sparkline utilities and MetricsCardData type

## Scope: Steps 1-2 — Constants, types, utility functions

### What to add

**File: `internal/dashboard/tui.go`**

**Constants & Types:**
```go
const (
    cardWidth      = 21  // 21*3 + 3*2 = 69 = panelTotalWidth
    cardInnerWidth = 17  // cardWidth - 4 (border + padding)
    cardGap        = 3   // space between cards
)

var sparkBlocks = []rune{' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}

type MetricsCardData struct {
    TotalTokens, InputTokens, OutputTokens int
    TotalCostUSD, CostPerTask              float64
    TotalTasks, Succeeded, Failed          int
    TokenHistory []int64   // 7 days
    CostHistory  []float64 // 7 days
    TaskHistory  []int     // 7 days
}
```

**New Model fields** (add to `Model` struct):
- `metricsCard MetricsCardData`
- `sparklineTick bool`

**Utility functions:**
- `formatCompact(n int) string` — compact number formatter: `0`→`"0"`, `999`→`"999"`, `1000`→`"1.0K"`, `57387`→`"57.3K"`, `1234567`→`"1.2M"`
- `normalizeToSparkline(values []float64, width int) []int` — scales float64 values to 0-8 range for sparkline rendering. Left-pads with zeros if fewer values than width. Returns slice of ints where each int maps to a `sparkBlocks` index.
- `renderSparkline(levels []int, pulsing bool) string` — maps int levels to `sparkBlocks` rune chars, appends pulsing `•` (when pulsing=true) or space. Total visual width should equal `cardInnerWidth` (17 chars).

### Tests to add

**File: `internal/dashboard/tui_test.go`** (create new file)

Table-driven tests:

- `TestFormatCompact` — cases: `0`→`"0"`, `999`→`"999"`, `1000`→`"1.0K"`, `57300`→`"57.3K"`, `1000000`→`"1.0M"`
- `TestNormalizeToSparkline` — cases: empty input→all zeros, single value→mid-range, all-same values→all 4s, ascending values→0..8 spread
- `TestRenderSparkline` — validate: output visual width equals `cardInnerWidth`, pulsing=true includes `•`, pulsing=false has space instead

### Reference
- `internal/memory/metrics.go` for `DailyMetrics` struct fields
- Existing styles in `tui.go` lines 26-74

### Verify
```bash
make build && make lint && make test
```