### PR TITLE
fix(autopilot): close failed PR to unblock sequential poller

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -249,6 +249,14 @@ func (c *Client) GetPullRequest(ctx context.Context, owner, repo string, number 
 	return &result, nil
 }
 
+// ClosePullRequest closes a pull request without merging.
+// Used by autopilot to close failed PRs so the sequential poller can unblock.
+func (c *Client) ClosePullRequest(ctx context.Context, owner, repo string, number int) error {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number)
+	payload := map[string]string{"state": "closed"}
+	return c.doRequest(ctx, http.MethodPatch, path, payload, nil)
+}
+
 // AddPRComment adds a comment to a pull request (issue comment API)
 // For review comments on specific lines, use CreatePRReviewComment instead
 func (c *Client) AddPRComment(ctx context.Context, owner, repo string, number int, body string) (*PRComment, error) {


### PR DESCRIPTION
## Summary

- When CI fails, autopilot creates a fix issue but never closed the failed PR on GitHub
- Sequential poller's merge waiter stays blocked waiting for PR to merge/close
- Pilot idles instead of picking up the fix issue and self-recovering

## Changes

- **client.go**: Add `ClosePullRequest` method (PATCH `state=closed`)
- **controller.go**: Close PR on GitHub in `handleCIFailed` after creating fix issue
- **Tests**: Verify PR close is called on CI failure

## Test plan

- [x] `go build ./...` passes
- [x] `TestController_ProcessPR_CIFailure` verifies PR close call
- [x] `TestClosePullRequest` verifies API method
- [x] Full autopilot and github adapter test suites pass