### PR TITLE
Flip the default in `DefaultDecomposeConfig()`

### DIFF
--- a/internal/executor/decompose.go
+++ b/internal/executor/decompose.go
@@ -28,7 +28,7 @@ type DecomposeConfig struct {
 // DefaultDecomposeConfig returns default decomposition settings.
 func DefaultDecomposeConfig() *DecomposeConfig {
 	return &DecomposeConfig{
-		Enabled:             false, // Disabled by default, opt-in
+		Enabled:             true, // Enabled by default since v0.21.0
 		MinComplexity:       "complex",
 		MaxSubtasks:         5,
 		MinDescriptionWords: 50,

--- a/internal/executor/decompose_test.go
+++ b/internal/executor/decompose_test.go
@@ -9,8 +9,8 @@ import (
 func TestDecomposeConfig_Defaults(t *testing.T) {
 	config := DefaultDecomposeConfig()
 
-	if config.Enabled {
-		t.Error("Expected Enabled to be false by default")
+	if !config.Enabled {
+		t.Error("Expected Enabled to be true by default")
 	}
 	if config.MinComplexity != "complex" {
 		t.Errorf("Expected MinComplexity to be 'complex', got %q", config.MinComplexity)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-492.

## Changes

Change `Enabled: false` to `Enabled: true` in `internal/executor/decompose.go` and update the accompanying comment.