### PR TITLE
Clean up dead code and update documentation

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -12,7 +12,7 @@ gateway:
 auth:
   type: "claude-code"  # "claude-code" (local) or "api-token" (remote)
   # token: "sk-ant-..."  # Required if type is "api-token"
-  # ANTHROPIC_API_KEY env var is required for Claude API access (all modes)
+  # ANTHROPIC_API_KEY env var enables Claude API features (Haiku subtask parsing, etc.)
 
 # Adapters
 adapters:

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -217,7 +217,7 @@ type Runner struct {
 	modelRouter           *ModelRouter          // Model and timeout routing based on complexity
 	parallelRunner        *ParallelRunner       // Optional parallel research runner (GH-217)
 	decomposer            *TaskDecomposer       // Optional task decomposer for complex tasks (GH-218)
-	subtaskParser         *SubtaskParser        // Optional Haiku-based subtask parser for epic planning (GH-501)
+	subtaskParser         *SubtaskParser        // Haiku-based subtask parser; nil falls back to regex (GH-501)
 	suppressProgressLogs  bool                  // Suppress slog output for progress (use when visual display is active)
 }
 
@@ -270,7 +270,7 @@ func NewRunnerWithConfig(config *BackendConfig) (*Runner, error) {
 		}
 	}
 
-	// Initialize Haiku subtask parser (GH-501)
+	// Initialize Haiku subtask parser; nil if ANTHROPIC_API_KEY unset (GH-501)
 	runner.subtaskParser = NewSubtaskParser(runner.log)
 
 	return runner, nil

--- a/internal/executor/subtask_parser.go
+++ b/internal/executor/subtask_parser.go
@@ -12,7 +12,9 @@ import (
 )
 
 // SubtaskParser extracts subtasks from planning output using the Anthropic Haiku API.
-// Falls back to regex parsing when the API is unavailable or fails.
+// Part of the epic planning pipeline: PlanEpic → parseSubtasksWithFallback → SubtaskParser.
+// When the API is unavailable or fails, parseSubtasksWithFallback falls back to
+// regex-based parseSubtasks() in epic.go.
 type SubtaskParser struct {
 	apiKey     string
 	baseURL    string // Base URL for API (default: https://api.anthropic.com)
@@ -153,8 +155,9 @@ Example response:
 	return result, nil
 }
 
-// parseSubtasksWithFallback tries Haiku structured extraction first,
-// falls back to regex parsing if the API is unavailable or fails.
+// parseSubtasksWithFallback is the primary entry point for subtask extraction.
+// Tries Haiku structured extraction first (SubtaskParser.Parse), then falls back
+// to regex-based parseSubtasks() in epic.go if the API is unavailable or fails.
 func parseSubtasksWithFallback(parser *SubtaskParser, output string) []PlannedSubtask {
 	if parser != nil {
 		subtasks, err := parser.Parse(context.Background(), output)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-525.

## Changes

GitHub Issue #525: Clean up dead code and update documentation

Parent: GH-501

Remove `SubtaskParser` references from any docs that were prematurely added in GH-506 (current branch). Remove `numberedListRegex` export if it was only used by `parseSubtasks()`. Update inline comments explaining the parsing pipeline. Verify `make test && make lint` pass.