### PR TITLE
Invoke callback in `ExecuteSubIssues()` after each sub-issue PR — In `internal/executor/epic.go`, after `r.Execute(ctx, subTask)` returns (~line 418) and the `result.PRUrl` is confirmed non-empty (~line 435), extract the PR number via `github.ExtractPRNumber()`, then call `r.onSubIssuePRCreated(prNumber, result.PRUrl, issue.Number, result.CommitSHA, subTask.Branch)`. Guard with nil check on the callback. This ensures each sub-issue PR is registered with the autopilot controller as soon as it's created, before the sub-issue is closed.

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -582,6 +582,8 @@ Examples:
 					// Wire autopilot OnPRCreated callback if controller initialized
 					if gwAutopilotController != nil {
 						pollerOpts = append(pollerOpts, github.WithOnPRCreated(gwAutopilotController.OnPRCreated))
+						// Wire sub-issue PR callback so epic sub-PRs are tracked by autopilot (GH-594)
+						gwRunner.SetOnSubIssuePRCreated(gwAutopilotController.OnPRCreated)
 					}
 
 					// Create rate limit retry scheduler
@@ -1244,6 +1246,8 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 				pollerOpts = append(pollerOpts,
 					github.WithOnPRCreated(autopilotController.OnPRCreated),
 				)
+				// Wire sub-issue PR callback so epic sub-PRs are tracked by autopilot (GH-594)
+				runner.SetOnSubIssuePRCreated(autopilotController.OnPRCreated)
 			}
 
 			// Create rate limit retry scheduler

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -229,6 +229,7 @@ type Runner struct {
 	subtaskParser         *SubtaskParser        // Haiku-based subtask parser; nil falls back to regex (GH-501)
 	suppressProgressLogs  bool                  // Suppress slog output for progress (use when visual display is active)
 	tokenLimitCheck       TokenLimitCallback    // Optional per-task token/duration limit check (GH-539)
+	onSubIssuePRCreated   func(prNumber int, prURL string, issueNumber int, headSHA string, branchName string) // Callback when a sub-issue PR is created during epic execution (GH-594)
 }
 
 // NewRunner creates a new Runner instance with Claude Code backend by default.
@@ -375,6 +376,13 @@ func (r *Runner) EnableDecomposition(config *DecomposeConfig) {
 // terminates with a budget-exceeded error.
 func (r *Runner) SetTokenLimitCheck(cb TokenLimitCallback) {
 	r.tokenLimitCheck = cb
+}
+
+// SetOnSubIssuePRCreated sets the callback invoked when a sub-issue PR is created
+// during epic execution (GH-594). This allows the autopilot controller to track
+// each sub-issue PR individually for CI monitoring and auto-merge.
+func (r *Runner) SetOnSubIssuePRCreated(fn func(prNumber int, prURL string, issueNumber int, headSHA string, branchName string)) {
+	r.onSubIssuePRCreated = fn
 }
 
 // getRecordingsPath returns the recordings path, using default if not set


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-594.

## Changes

