### PR TITLE
Wire callback in `cmd/pilot/main.go` — In the GitHub issue handler setup (~line 1270-1277), where `autopilotController` is wired to the poller via `WithOnPRCreated`, also call `runner.SetOnSubIssuePRCreated(autopilotController.OnPRCreated)` so the runner can forward sub-issue PR events to the same autopilot controller. Only wire when `autopilotController != nil`.

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -582,6 +582,8 @@ Examples:
 					// Wire autopilot OnPRCreated callback if controller initialized
 					if gwAutopilotController != nil {
 						pollerOpts = append(pollerOpts, github.WithOnPRCreated(gwAutopilotController.OnPRCreated))
+						// GH-595: Forward sub-issue PR events to the same autopilot controller
+						gwRunner.SetOnSubIssuePRCreated(gwAutopilotController.OnPRCreated)
 					}
 
 					// Create rate limit retry scheduler
@@ -1244,6 +1246,8 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 				pollerOpts = append(pollerOpts,
 					github.WithOnPRCreated(autopilotController.OnPRCreated),
 				)
+				// GH-595: Forward sub-issue PR events to the same autopilot controller
+				runner.SetOnSubIssuePRCreated(autopilotController.OnPRCreated)
 			}
 
 			// Create rate limit retry scheduler


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-595.

## Changes

