### PR TITLE
fix(docs): repair sync workflow nesting bug and add integrations nav

### DIFF
--- a/.agent/DEVELOPMENT-README.md
+++ b/.agent/DEVELOPMENT-README.md
@@ -96,7 +96,7 @@ if _, err := os.Stat(agentDir); err == nil {
 
 ## Current State
 
-**Current Version:** v0.22.1
+**Current Version:** v0.23.1
 
 **Full implementation status:** `.agent/system/FEATURE-MATRIX.md`
 
@@ -110,9 +110,9 @@ if _, err := os.Stat(agentDir); err == nil {
 | Alerts Engine | ✅ | Slack, Telegram, webhooks |
 | Quality Gates | ✅ | Test/lint/build gates with retry |
 | Task Dispatcher | ✅ | Per-project queue |
-| Dashboard TUI | ✅ | Sparkline cards, muted palette, SQLite persistence **(v0.19.0)** |
+| Dashboard TUI | ✅ | Sparkline cards, muted palette, SQLite persistence, **epic-aware HISTORY (v0.22.1)** |
 | Hot Upgrade | ✅ | Self-update via `pilot upgrade` or dashboard 'u' key, `syscall.Exec` restart |
-| **Autopilot** | ✅ | CI monitor, auto-merge, feedback loop, **CI fix on original branch (v0.19.1)** |
+| **Autopilot** | ✅ | CI monitor, auto-merge, feedback loop, **sub-issue PR wiring (v0.23.1)** |
 | **LLM Intent** | ✅ | Claude Haiku intent classification, low effort |
 | **Self-Review** | ✅ | Auto code review before PR |
 | **Auto Build Gate** | ✅ | Minimal build gate when none configured |
@@ -183,13 +183,22 @@ _Queue empty - create issues with `pilot` label to add work._
 
 | Priority | Topic | Why |
 |----------|-------|-----|
-| _(none)_ | | |
-| 🟡 P2 | Cost controls: wire TaskLimiter into executor + budget check in polling mode | Core enforcer works for `pilot task --budget` |
+| ~~P2~~ | ~~Cost controls~~ | Wired in v0.21.3 (GH-539) |
 | ~~P2~~ | ~~Approval workflows~~ | Fully wired: manager + Telegram/Slack/GitHub handlers + autopilot prod gate |
+| 🟡 P2 | Docs v2: Nextra 4 migration | Attempted, failed — docs still on Nextra v2 |
 
 **For accurate feature status, see:** `.agent/system/FEATURE-MATRIX.md`
 
 ---
+
+## Completed (2026-02-07)
+
+| Item | What |
+|------|------|
+| **v0.23.1** | fix(autopilot): wire sub-issue PR callback for epic execution (GH-588) |
+| **v0.22.1** | Dashboard epic-aware HISTORY panel, docs pages (why-pilot, how-it-works, model-routing, navigator, approvals) |
+| GH-588 | Epic sub-issue PRs now registered with autopilot controller for CI monitoring + auto-merge |
+| GH-498 | Epic-aware HISTORY: CompletedTask extended, groupedHistory(), renderHistory() with progress bars |
 
 ## Completed (2026-02-06)
 

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -40,11 +40,15 @@ jobs:
           find "$WORK" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
           cp -a docs/. "$WORK"/
 
+          # Remove dirs that should never be synced to GitLab
+          rm -rf "$WORK/.next" "$WORK/node_modules" "$WORK/.idea" "$WORK/~"
+
           # Restore GitLab CI infrastructure files (GitLab version wins)
           for f in .gitlab-ci.yml docker-compose.prod.yml docker-compose.yml; do
             [ -f "$BACKUP/$f" ] && cp "$BACKUP/$f" "$WORK/$f"
           done
-          [ -d "$BACKUP/docker" ] && cp -a "$BACKUP/docker" "$WORK/docker"
+          # Remove first to prevent cp -a nesting into existing dir
+          [ -d "$BACKUP/docker" ] && rm -rf "$WORK/docker" && cp -a "$BACKUP/docker" "$WORK/docker"
 
           cd "$WORK"
           git config user.name "Pilot CI"

--- a/docs/pages/_meta.json
+++ b/docs/pages/_meta.json
@@ -3,6 +3,7 @@
   "getting-started": "Getting Started",
   "concepts": "Concepts",
   "features": "Features",
+  "integrations": "Integrations",
   "navigator": "Navigator Integration",
   "cli": "CLI Reference",
   "community": "Community"

--- a/docs/pages/integrations/_meta.json
+++ b/docs/pages/integrations/_meta.json
@@ -1,0 +1,6 @@
+{
+  "linear": "Linear",
+  "gitlab": "GitLab",
+  "slack": "Slack",
+  "jira": "Jira"
+}


### PR DESCRIPTION
## Summary
- Fix `cp -a` nesting bug in `sync-docs.yml` — each run was creating `docker/docker/docker/.../Dockerfile` (6 levels deep) because `cp -a` copies INTO existing dirs. Now `rm -rf` target before restoring backup.
- Clean junk dirs (`.next`, `node_modules`, `.idea`, `~`) from sync payload
- Add missing `integrations` section to root `_meta.json` — Linear/GitLab/Slack/Jira pages were 404 because the nav didn't reference them
- Remove phantom `asana`/`azure-devops` entries from integrations `_meta.json` (no source files exist)
- Update DEVELOPMENT-README.md version to v0.23.1

## Context
After the recent docs rewrite (GH-564/565/566/582/583), several new pages were synced to GitLab but:
1. The nested docker dir bug corrupted the GitLab repo structure
2. The integrations section wasn't in the root nav, so all integration pages 404'd
3. GitLab CI manual deploy needs triggering after merge to rebuild the Docker image

## Test plan
- [ ] Merge and verify sync workflow runs without nesting
- [ ] Check `pilot.quantflow.studio/integrations/linear` resolves after deploy
- [ ] Trigger GitLab CI manual deploy to push new Docker image to VPS