### PR TITLE
ci(docs): auto-trigger GitLab deploy via prod tag

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -61,4 +61,12 @@ jobs:
           else
             git commit -m "sync: docs from pilot@${GITHUB_SHA::7}"
             git push origin main
+
+            # Auto-trigger GitLab deploy by pushing a prod tag
+            VERSION=$(git -C "$GITHUB_WORKSPACE" describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+            if [ -n "$VERSION" ]; then
+              git tag -f "prod-${VERSION}"
+              git push origin "prod-${VERSION}" --force
+              echo "Tagged prod-${VERSION} to trigger deploy"
+            fi
           fi


### PR DESCRIPTION
## Summary
- After syncing docs to GitLab, push a `prod-{version}` tag to auto-trigger the deploy pipeline
- Version derived from latest GitHub git tag (e.g. `v0.23.1` → `prod-0.23.1`)
- Force-push tag so repeated syncs at the same version still trigger deploy
- Eliminates manual GitLab CI deploy step

## Test plan
- [ ] Merge and verify sync workflow pushes `prod-0.23.1` tag to GitLab
- [ ] Verify GitLab CI deploy triggers automatically
- [ ] Check `pilot.quantflow.studio` serves updated pages