### PR TITLE
docs: add community page (GH-614)

### DIFF
--- a/docs/pages/community.mdx
+++ b/docs/pages/community.mdx
@@ -1,0 +1,23 @@
+# Community
+
+Pilot is source-available under [BSL 1.1](https://github.com/alekspetrov/pilot/blob/main/LICENSE). Free for internal use and self-hosting.
+
+## Get Involved
+
+- [GitHub Repository](https://github.com/alekspetrov/pilot) — Source code, issues, and releases
+- [Contributing Guide](https://github.com/alekspetrov/pilot/blob/main/CONTRIBUTING.md) — Dev setup, code standards, PR process
+- [Report an Issue](https://github.com/alekspetrov/pilot/issues/new) — Bug reports and feature requests
+- [GitHub Discussions](https://github.com/alekspetrov/pilot/discussions) — Questions, ideas, and community support
+
+## License
+
+Pilot uses the [Business Source License 1.1](https://github.com/alekspetrov/pilot/blob/main/LICENSE):
+
+- **Free** for internal use, self-hosting, and development
+- **Free** for organizations with fewer than 10 employees
+- **Commercial license** required for offering Pilot as a hosted service to third parties
+- Converts to Apache 2.0 after the change date
+
+## Built By
+
+[QuantFlow Studio](https://quantflow.studio) — Engineering tools for autonomous development.


### PR DESCRIPTION
## Summary
- Add `community.mdx` with GitHub links, BSL 1.1 license summary, and QuantFlow attribution
- Fixes broken nav link — `community` was in `_meta.json` but had no page

Closes #614

## Test plan
- [ ] Community page renders at `/community`
- [ ] Nav link works
- [ ] All external links resolve