### PR TITLE
Define event types and envelope parsing (`internal/adapters/slack/events.go`)

### DIFF
--- a/internal/adapters/slack/socketmode.go
+++ b/internal/adapters/slack/socketmode.go
@@ -1,0 +1,142 @@
+package slack
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ErrDisconnect is returned when the server sends a disconnect event.
+var ErrDisconnect = errors.New("slack: disconnect requested")
+
+// SocketEvent represents a parsed Slack event received via Socket Mode.
+type SocketEvent struct {
+	Type      string      // "message" or "app_mention"
+	UserID    string      // Slack user ID who sent the message
+	BotID     string      // Non-empty if sent by a bot
+	Text      string      // Raw message text (may contain <@UBOT> mention)
+	ChannelID string      // Channel or DM where the event occurred
+	ThreadTS  string      // Thread timestamp (empty if top-level)
+	TS        string      // Message timestamp
+	Files     []SlackFile // Attached files (images, docs, etc.)
+}
+
+// SlackFile represents a file attached to a Slack message.
+type SlackFile struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	MimeType string `json:"mimetype"`
+	URL      string `json:"url_private_download"`
+	Size     int    `json:"size"`
+}
+
+// SocketEnvelope is the top-level Socket Mode JSON wrapper.
+type SocketEnvelope struct {
+	Type       string          `json:"type"`
+	EnvelopeID string          `json:"envelope_id"`
+	Payload    json.RawMessage `json:"payload"`
+	// disconnect envelopes carry reason + debug_info at top level
+	Reason    string `json:"reason,omitempty"`
+	DebugInfo *struct {
+		Host string `json:"host,omitempty"`
+	} `json:"debug_info,omitempty"`
+}
+
+// EventPayload is the events_api payload inside the envelope.
+type EventPayload struct {
+	Token    string     `json:"token"`
+	TeamID   string     `json:"team_id"`
+	APIAppID string     `json:"api_app_id"`
+	Event    InnerEvent `json:"event"`
+	Type     string     `json:"type"`
+	EventID  string     `json:"event_id"`
+}
+
+// InnerEvent is the actual event inside the events_api payload.
+type InnerEvent struct {
+	Type      string      `json:"type"`
+	User      string      `json:"user"`
+	BotID     string      `json:"bot_id,omitempty"`
+	Text      string      `json:"text"`
+	Channel   string      `json:"channel"`
+	TS        string      `json:"ts"`
+	ThreadTS  string      `json:"thread_ts,omitempty"`
+	EventTS   string      `json:"event_ts,omitempty"`
+	ChannelType string    `json:"channel_type,omitempty"`
+	Files     []SlackFile `json:"files,omitempty"`
+}
+
+// parseEnvelope unmarshals a Socket Mode JSON frame and returns:
+//   - a *SocketEvent for message/app_mention events (nil for other types)
+//   - the envelope_id (for acknowledgement)
+//   - an error (ErrDisconnect for disconnect envelopes, parse errors otherwise)
+func parseEnvelope(raw []byte) (*SocketEvent, string, error) {
+	var env SocketEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, "", fmt.Errorf("unmarshal envelope: %w", err)
+	}
+
+	switch env.Type {
+	case "disconnect":
+		return nil, env.EnvelopeID, ErrDisconnect
+
+	case "events_api":
+		var payload EventPayload
+		if err := json.Unmarshal(env.Payload, &payload); err != nil {
+			return nil, env.EnvelopeID, fmt.Errorf("unmarshal events_api payload: %w", err)
+		}
+
+		inner := payload.Event
+
+		// Only handle message and app_mention events
+		switch inner.Type {
+		case "message", "app_mention":
+			// Filter bot self-messages
+			if inner.BotID != "" {
+				return nil, env.EnvelopeID, nil
+			}
+
+			evt := &SocketEvent{
+				Type:      inner.Type,
+				UserID:    inner.User,
+				BotID:     inner.BotID,
+				Text:      inner.Text,
+				ChannelID: inner.Channel,
+				ThreadTS:  inner.ThreadTS,
+				TS:        inner.TS,
+				Files:     inner.Files,
+			}
+			return evt, env.EnvelopeID, nil
+
+		default:
+			// Unhandled event subtype — ack but ignore
+			return nil, env.EnvelopeID, nil
+		}
+
+	default:
+		// hello, interactive, slash_commands, etc. — ack but ignore
+		return nil, env.EnvelopeID, nil
+	}
+}
+
+// mentionRe matches Slack user mentions like <@U12345> or <@U12345|username>.
+var mentionRe = regexp.MustCompile(`<@([A-Z0-9]+)(?:\|[^>]*)?>`)
+
+// stripMention removes the bot's @mention from the message text and trims whitespace.
+// If botID is empty, all mentions are stripped.
+func stripMention(text, botID string) string {
+	if botID == "" {
+		return strings.TrimSpace(mentionRe.ReplaceAllString(text, ""))
+	}
+
+	result := mentionRe.ReplaceAllStringFunc(text, func(match string) string {
+		subs := mentionRe.FindStringSubmatch(match)
+		if len(subs) >= 2 && subs[1] == botID {
+			return ""
+		}
+		return match
+	})
+	return strings.TrimSpace(result)
+}

--- a/internal/adapters/slack/socketmode_test.go
+++ b/internal/adapters/slack/socketmode_test.go
@@ -1,0 +1,395 @@
+package slack
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseEnvelope_Message(t *testing.T) {
+	raw := []byte(`{
+		"type": "events_api",
+		"envelope_id": "env-123",
+		"payload": {
+			"token": "tok",
+			"team_id": "T123",
+			"api_app_id": "A123",
+			"event": {
+				"type": "message",
+				"user": "U999",
+				"text": "hello pilot",
+				"channel": "C456",
+				"ts": "1234567890.123456",
+				"thread_ts": "1234567890.000001"
+			},
+			"type": "event_callback",
+			"event_id": "Ev123"
+		}
+	}`)
+
+	evt, envID, err := parseEnvelope(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envID != "env-123" {
+		t.Errorf("envelope_id = %q, want %q", envID, "env-123")
+	}
+	if evt == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if evt.Type != "message" {
+		t.Errorf("Type = %q, want %q", evt.Type, "message")
+	}
+	if evt.UserID != "U999" {
+		t.Errorf("UserID = %q, want %q", evt.UserID, "U999")
+	}
+	if evt.Text != "hello pilot" {
+		t.Errorf("Text = %q, want %q", evt.Text, "hello pilot")
+	}
+	if evt.ChannelID != "C456" {
+		t.Errorf("ChannelID = %q, want %q", evt.ChannelID, "C456")
+	}
+	if evt.TS != "1234567890.123456" {
+		t.Errorf("TS = %q, want %q", evt.TS, "1234567890.123456")
+	}
+	if evt.ThreadTS != "1234567890.000001" {
+		t.Errorf("ThreadTS = %q, want %q", evt.ThreadTS, "1234567890.000001")
+	}
+}
+
+func TestParseEnvelope_AppMention(t *testing.T) {
+	raw := []byte(`{
+		"type": "events_api",
+		"envelope_id": "env-456",
+		"payload": {
+			"token": "tok",
+			"team_id": "T123",
+			"api_app_id": "A123",
+			"event": {
+				"type": "app_mention",
+				"user": "U111",
+				"text": "<@UBOT> deploy staging",
+				"channel": "C789",
+				"ts": "1234567890.654321",
+				"channel_type": "channel"
+			},
+			"type": "event_callback",
+			"event_id": "Ev456"
+		}
+	}`)
+
+	evt, envID, err := parseEnvelope(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envID != "env-456" {
+		t.Errorf("envelope_id = %q, want %q", envID, "env-456")
+	}
+	if evt == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if evt.Type != "app_mention" {
+		t.Errorf("Type = %q, want %q", evt.Type, "app_mention")
+	}
+	if evt.UserID != "U111" {
+		t.Errorf("UserID = %q, want %q", evt.UserID, "U111")
+	}
+	if evt.Text != "<@UBOT> deploy staging" {
+		t.Errorf("Text = %q, want %q", evt.Text, "<@UBOT> deploy staging")
+	}
+}
+
+func TestParseEnvelope_BotSelfMessage(t *testing.T) {
+	raw := []byte(`{
+		"type": "events_api",
+		"envelope_id": "env-bot",
+		"payload": {
+			"token": "tok",
+			"team_id": "T123",
+			"api_app_id": "A123",
+			"event": {
+				"type": "message",
+				"bot_id": "B999",
+				"text": "I am a bot",
+				"channel": "C456",
+				"ts": "1234567890.111111"
+			},
+			"type": "event_callback",
+			"event_id": "Ev789"
+		}
+	}`)
+
+	evt, envID, err := parseEnvelope(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envID != "env-bot" {
+		t.Errorf("envelope_id = %q, want %q", envID, "env-bot")
+	}
+	if evt != nil {
+		t.Errorf("expected nil event for bot message, got %+v", evt)
+	}
+}
+
+func TestParseEnvelope_Disconnect(t *testing.T) {
+	raw := []byte(`{
+		"type": "disconnect",
+		"envelope_id": "env-dc",
+		"reason": "link_disabled",
+		"debug_info": {
+			"host": "wss-primary-1234.slack.com"
+		}
+	}`)
+
+	evt, envID, err := parseEnvelope(raw)
+	if !errors.Is(err, ErrDisconnect) {
+		t.Fatalf("expected ErrDisconnect, got: %v", err)
+	}
+	if envID != "env-dc" {
+		t.Errorf("envelope_id = %q, want %q", envID, "env-dc")
+	}
+	if evt != nil {
+		t.Errorf("expected nil event for disconnect, got %+v", evt)
+	}
+}
+
+func TestParseEnvelope_HelloIgnored(t *testing.T) {
+	raw := []byte(`{
+		"type": "hello",
+		"envelope_id": "",
+		"num_connections": 1
+	}`)
+
+	evt, envID, err := parseEnvelope(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envID != "" {
+		t.Errorf("envelope_id = %q, want empty", envID)
+	}
+	if evt != nil {
+		t.Errorf("expected nil event for hello, got %+v", evt)
+	}
+}
+
+func TestParseEnvelope_UnhandledEventType(t *testing.T) {
+	raw := []byte(`{
+		"type": "events_api",
+		"envelope_id": "env-other",
+		"payload": {
+			"token": "tok",
+			"team_id": "T123",
+			"api_app_id": "A123",
+			"event": {
+				"type": "reaction_added",
+				"user": "U111",
+				"item": {"type": "message"}
+			},
+			"type": "event_callback",
+			"event_id": "Ev999"
+		}
+	}`)
+
+	evt, envID, err := parseEnvelope(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envID != "env-other" {
+		t.Errorf("envelope_id = %q, want %q", envID, "env-other")
+	}
+	if evt != nil {
+		t.Errorf("expected nil event for reaction_added, got %+v", evt)
+	}
+}
+
+func TestParseEnvelope_InvalidJSON(t *testing.T) {
+	raw := []byte(`{not json}`)
+
+	_, _, err := parseEnvelope(raw)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestParseEnvelope_InvalidPayloadJSON(t *testing.T) {
+	raw := []byte(`{
+		"type": "events_api",
+		"envelope_id": "env-bad",
+		"payload": "not-an-object"
+	}`)
+
+	_, envID, err := parseEnvelope(raw)
+	if err == nil {
+		t.Fatal("expected error for invalid payload JSON")
+	}
+	if envID != "env-bad" {
+		t.Errorf("envelope_id = %q, want %q", envID, "env-bad")
+	}
+}
+
+func TestParseEnvelope_WithFiles(t *testing.T) {
+	raw := []byte(`{
+		"type": "events_api",
+		"envelope_id": "env-files",
+		"payload": {
+			"token": "tok",
+			"team_id": "T123",
+			"api_app_id": "A123",
+			"event": {
+				"type": "message",
+				"user": "U222",
+				"text": "check this screenshot",
+				"channel": "C456",
+				"ts": "1234567890.222222",
+				"files": [
+					{
+						"id": "F001",
+						"name": "screenshot.png",
+						"mimetype": "image/png",
+						"url_private_download": "https://files.slack.com/files-pri/T123-F001/screenshot.png",
+						"size": 102400
+					}
+				]
+			},
+			"type": "event_callback",
+			"event_id": "Ev222"
+		}
+	}`)
+
+	evt, envID, err := parseEnvelope(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envID != "env-files" {
+		t.Errorf("envelope_id = %q, want %q", envID, "env-files")
+	}
+	if evt == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if len(evt.Files) != 1 {
+		t.Fatalf("Files count = %d, want 1", len(evt.Files))
+	}
+	f := evt.Files[0]
+	if f.ID != "F001" {
+		t.Errorf("File.ID = %q, want %q", f.ID, "F001")
+	}
+	if f.Name != "screenshot.png" {
+		t.Errorf("File.Name = %q, want %q", f.Name, "screenshot.png")
+	}
+	if f.MimeType != "image/png" {
+		t.Errorf("File.MimeType = %q, want %q", f.MimeType, "image/png")
+	}
+	if f.Size != 102400 {
+		t.Errorf("File.Size = %d, want %d", f.Size, 102400)
+	}
+}
+
+func TestParseEnvelope_NoThreadTS(t *testing.T) {
+	raw := []byte(`{
+		"type": "events_api",
+		"envelope_id": "env-nothrd",
+		"payload": {
+			"token": "tok",
+			"team_id": "T123",
+			"api_app_id": "A123",
+			"event": {
+				"type": "message",
+				"user": "U333",
+				"text": "top-level message",
+				"channel": "C456",
+				"ts": "1234567890.333333"
+			},
+			"type": "event_callback",
+			"event_id": "Ev333"
+		}
+	}`)
+
+	evt, _, err := parseEnvelope(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if evt == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if evt.ThreadTS != "" {
+		t.Errorf("ThreadTS = %q, want empty for top-level message", evt.ThreadTS)
+	}
+}
+
+func TestStripMention(t *testing.T) {
+	tests := []struct {
+		name  string
+		text  string
+		botID string
+		want  string
+	}{
+		{
+			name:  "simple mention at start",
+			text:  "<@UBOT123> deploy staging",
+			botID: "UBOT123",
+			want:  "deploy staging",
+		},
+		{
+			name:  "mention with display name",
+			text:  "<@UBOT123|pilot> run tests",
+			botID: "UBOT123",
+			want:  "run tests",
+		},
+		{
+			name:  "mention in middle",
+			text:  "hey <@UBOT123> can you deploy?",
+			botID: "UBOT123",
+			want:  "hey  can you deploy?",
+		},
+		{
+			name:  "different bot mention preserved",
+			text:  "<@UOTHER> deploy staging",
+			botID: "UBOT123",
+			want:  "<@UOTHER> deploy staging",
+		},
+		{
+			name:  "multiple mentions mixed",
+			text:  "<@UBOT123> <@UOTHER> deploy",
+			botID: "UBOT123",
+			want:  "<@UOTHER> deploy",
+		},
+		{
+			name:  "no mention",
+			text:  "deploy staging",
+			botID: "UBOT123",
+			want:  "deploy staging",
+		},
+		{
+			name:  "empty botID strips all",
+			text:  "<@UBOT123> <@UOTHER> deploy",
+			botID: "",
+			want:  "deploy",
+		},
+		{
+			name:  "empty text",
+			text:  "",
+			botID: "UBOT123",
+			want:  "",
+		},
+		{
+			name:  "only mention",
+			text:  "<@UBOT123>",
+			botID: "UBOT123",
+			want:  "",
+		},
+		{
+			name:  "mention with extra whitespace",
+			text:  "  <@UBOT123>   hello  ",
+			botID: "UBOT123",
+			want:  "hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripMention(tt.text, tt.botID)
+			if got != tt.want {
+				t.Errorf("stripMention(%q, %q) = %q, want %q", tt.text, tt.botID, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-645.

## Changes

Define `SocketEvent`, `SlackFile`, and envelope structs (`SocketEnvelope`, `EventPayload`, `InnerEvent`). Implement `parseEnvelope(raw []byte) (*SocketEvent, string, error)` that unmarshals the Socket Mode JSON wrapper, extracts `envelope_id`, handles `events_api` type (returning parsed `SocketEvent` for `message`/`app_mention`), handles `disconnect` type (returning sentinel), and filters bot self-messages via `bot_id`. Implement `stripMention(text, botID) string` regex helper. No external dependencies beyond stdlib. Testable in isolation with raw JSON fixtures.