### PR TITLE
Implement Socket Mode WebSocket client — Create `internal/adapters/slack/socketmode.go` with `SocketModeClient` struct holding `appToken`, HTTP client, and dialer. Implement `OpenConnection(ctx) (string, error)` that POSTs to `apps.connections.open` with Bearer app-level token and extracts the WSS URL from the JSON response. Implement `Listen(ctx) (<-chan *SocketEvent, error)` that dials the WSS URL via `gorilla/websocket`, reads JSON envelopes in a goroutine loop, calls the parsing logic from subtask 1, sends `acknowledge` frames back for each `envelope_id`, and emits parsed events on the returned channel. Include proper context cancellation and clean connection shutdown.

### DIFF
--- a/internal/adapters/slack/events.go
+++ b/internal/adapters/slack/events.go
@@ -1,0 +1,104 @@
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+// SocketEvent represents a parsed Slack event received via Socket Mode.
+type SocketEvent struct {
+	Type      string     // "message", "app_mention"
+	ChannelID string     // Channel where the event occurred
+	UserID    string     // User who triggered the event
+	Text      string     // Message text (bot mention prefix stripped for app_mention)
+	ThreadTS  string     // Parent thread timestamp (for threaded replies)
+	Timestamp string     // Message timestamp
+	Files     []SlackFile // Optional file attachments
+}
+
+// SlackFile represents a file attachment in a Slack message.
+type SlackFile struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	MimeType string `json:"mimetype"`
+	URL      string `json:"url_private"`
+}
+
+// envelope is the outer wrapper for all Socket Mode messages.
+type envelope struct {
+	EnvelopeID string          `json:"envelope_id"`
+	Type       string          `json:"type"`       // "events_api", "disconnect", "hello"
+	Payload    json.RawMessage `json:"payload"`
+	Reason     string          `json:"reason,omitempty"` // For disconnect envelopes
+}
+
+// eventsAPIPayload is the payload for type="events_api" envelopes.
+type eventsAPIPayload struct {
+	Event innerEvent `json:"event"`
+}
+
+// innerEvent is the actual Slack event inside an events_api payload.
+type innerEvent struct {
+	Type      string     `json:"type"`       // "message", "app_mention"
+	Channel   string     `json:"channel"`
+	User      string     `json:"user"`
+	Text      string     `json:"text"`
+	ThreadTS  string     `json:"thread_ts"`
+	TS        string     `json:"ts"`
+	BotID     string     `json:"bot_id,omitempty"`
+	Subtype   string     `json:"subtype,omitempty"` // "bot_message", etc.
+	Files     []SlackFile `json:"files,omitempty"`
+}
+
+// botMentionRegex matches <@UBOTID> prefix (with optional trailing whitespace).
+var botMentionRegex = regexp.MustCompile(`^<@[A-Z0-9]+>\s*`)
+
+// parseEnvelope parses a raw WebSocket message into an envelope.
+func parseEnvelope(data []byte) (*envelope, error) {
+	var env envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("unmarshal envelope: %w", err)
+	}
+	return &env, nil
+}
+
+// parseSocketEvent extracts a SocketEvent from an events_api envelope payload.
+// Returns nil if the event should be ignored (bot's own message, unsupported type).
+func parseSocketEvent(payload json.RawMessage) (*SocketEvent, error) {
+	var p eventsAPIPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return nil, fmt.Errorf("unmarshal events_api payload: %w", err)
+	}
+
+	ev := p.Event
+
+	// Ignore bot messages
+	if ev.BotID != "" || ev.Subtype == "bot_message" {
+		return nil, nil
+	}
+
+	// Only handle message and app_mention events
+	switch ev.Type {
+	case "message", "app_mention":
+		// ok
+	default:
+		return nil, nil
+	}
+
+	text := ev.Text
+	// Strip <@BOTID> mention prefix from app_mention text
+	if ev.Type == "app_mention" {
+		text = botMentionRegex.ReplaceAllString(text, "")
+	}
+
+	return &SocketEvent{
+		Type:      ev.Type,
+		ChannelID: ev.Channel,
+		UserID:    ev.User,
+		Text:      text,
+		ThreadTS:  ev.ThreadTS,
+		Timestamp: ev.TS,
+		Files:     ev.Files,
+	}, nil
+}

--- a/internal/adapters/slack/socketmode.go
+++ b/internal/adapters/slack/socketmode.go
@@ -1,0 +1,304 @@
+package slack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	// connectionsOpenURL is the Slack API endpoint to open a Socket Mode connection.
+	connectionsOpenURL = "https://slack.com/api/apps.connections.open"
+
+	// Default backoff parameters for reconnection.
+	initialBackoff = 1 * time.Second
+	maxBackoff     = 30 * time.Second
+	backoffFactor  = 2
+
+	// WebSocket timeouts.
+	writeWait  = 10 * time.Second
+	pongWait   = 60 * time.Second
+	pingPeriod = 50 * time.Second // Must be less than pongWait.
+)
+
+// SocketModeClient connects to Slack via Socket Mode WebSocket.
+type SocketModeClient struct {
+	appToken   string
+	httpClient *http.Client
+	dialer     *websocket.Dialer
+	log        *slog.Logger
+
+	// apiURL overrides the connections.open endpoint for testing.
+	apiURL string
+}
+
+// NewSocketModeClient creates a new Socket Mode client.
+func NewSocketModeClient(appToken string) *SocketModeClient {
+	return &SocketModeClient{
+		appToken: appToken,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		dialer: websocket.DefaultDialer,
+		log:    logging.WithComponent("slack.socketmode"),
+		apiURL: connectionsOpenURL,
+	}
+}
+
+// connectionsOpenResponse is the JSON response from apps.connections.open.
+type connectionsOpenResponse struct {
+	OK    bool   `json:"ok"`
+	URL   string `json:"url"`
+	Error string `json:"error,omitempty"`
+}
+
+// OpenConnection calls apps.connections.open and returns the WSS URL.
+func (c *SocketModeClient) OpenConnection(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.appToken)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("open connection: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+
+	var result connectionsOpenResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("parse response: %w", err)
+	}
+
+	if !result.OK {
+		return "", fmt.Errorf("slack API error: %s", result.Error)
+	}
+
+	if result.URL == "" {
+		return "", fmt.Errorf("empty WSS URL in response")
+	}
+
+	return result.URL, nil
+}
+
+// Listen opens a Socket Mode connection and streams parsed events.
+// It automatically reconnects on disconnect with exponential backoff.
+// The returned channel is closed when ctx is cancelled.
+func (c *SocketModeClient) Listen(ctx context.Context) (<-chan *SocketEvent, error) {
+	wssURL, err := c.OpenConnection(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("initial connection: %w", err)
+	}
+
+	events := make(chan *SocketEvent, 64)
+
+	go c.listenLoop(ctx, wssURL, events)
+
+	return events, nil
+}
+
+// listenLoop manages the WebSocket connection lifecycle with auto-reconnect.
+func (c *SocketModeClient) listenLoop(ctx context.Context, wssURL string, events chan<- *SocketEvent) {
+	defer close(events)
+
+	backoff := initialBackoff
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		err := c.readLoop(ctx, wssURL, events)
+		if ctx.Err() != nil {
+			return
+		}
+
+		if err != nil {
+			c.log.Warn("WebSocket disconnected, reconnecting",
+				slog.String("error", err.Error()),
+				slog.Duration("backoff", backoff))
+		}
+
+		// Wait before reconnecting
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+
+		// Get a new WSS URL
+		newURL, err := c.OpenConnection(ctx)
+		if err != nil {
+			c.log.Error("Failed to get new WSS URL",
+				slog.String("error", err.Error()))
+
+			// Increase backoff
+			backoff = min(backoff*backoffFactor, maxBackoff)
+			continue
+		}
+
+		wssURL = newURL
+		backoff = initialBackoff
+	}
+}
+
+// readLoop connects to a WSS URL, reads messages, and emits events.
+// Returns when the connection is lost or ctx is cancelled.
+func (c *SocketModeClient) readLoop(ctx context.Context, wssURL string, events chan<- *SocketEvent) error {
+	conn, _, err := c.dialer.DialContext(ctx, wssURL, nil)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+
+	var closeOnce sync.Once
+	closeConn := func() {
+		closeOnce.Do(func() {
+			_ = conn.Close()
+		})
+	}
+	defer closeConn()
+
+	// Set up pong handler for keepalive
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(pongWait))
+	})
+	if err := conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
+		return fmt.Errorf("set read deadline: %w", err)
+	}
+
+	// Start ping ticker in background
+	pingDone := make(chan struct{})
+	go func() {
+		defer close(pingDone)
+		ticker := time.NewTicker(pingPeriod)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := conn.WriteControl(
+					websocket.PingMessage,
+					nil,
+					time.Now().Add(writeWait),
+				); err != nil {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Read messages
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			return fmt.Errorf("read message: %w", err)
+		}
+
+		env, err := parseEnvelope(raw)
+		if err != nil {
+			c.log.Warn("Failed to parse envelope",
+				slog.String("error", err.Error()))
+			continue
+		}
+
+		// Always acknowledge
+		if env.EnvelopeID != "" {
+			if ackErr := c.acknowledge(conn, env.EnvelopeID); ackErr != nil {
+				c.log.Warn("Failed to send acknowledgment",
+					slog.String("envelope_id", env.EnvelopeID),
+					slog.String("error", ackErr.Error()))
+			}
+		}
+
+		switch env.Type {
+		case "hello":
+			c.log.Info("Socket Mode connected")
+
+		case "disconnect":
+			c.log.Info("Received disconnect",
+				slog.String("reason", env.Reason))
+			return fmt.Errorf("server requested disconnect: %s", env.Reason)
+
+		case "events_api":
+			ev, err := parseSocketEvent(env.Payload)
+			if err != nil {
+				c.log.Warn("Failed to parse event",
+					slog.String("error", err.Error()))
+				continue
+			}
+			if ev == nil {
+				continue // Filtered event (bot message, unsupported type)
+			}
+
+			select {
+			case events <- ev:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+		default:
+			c.log.Debug("Ignoring envelope type",
+				slog.String("type", env.Type))
+		}
+	}
+}
+
+// acknowledge sends an acknowledgment frame back for an envelope.
+func (c *SocketModeClient) acknowledge(conn *websocket.Conn, envelopeID string) error {
+	ack := struct {
+		EnvelopeID string `json:"envelope_id"`
+	}{
+		EnvelopeID: envelopeID,
+	}
+
+	data, err := json.Marshal(ack)
+	if err != nil {
+		return fmt.Errorf("marshal ack: %w", err)
+	}
+
+	if err := conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
+		return fmt.Errorf("set write deadline: %w", err)
+	}
+
+	if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		return fmt.Errorf("write ack: %w", err)
+	}
+
+	return nil
+}
+
+// acknowledgePayload is used in tests to verify ack messages.
+type acknowledgePayload struct {
+	EnvelopeID string `json:"envelope_id"`
+}
+
+// parseAcknowledge parses an acknowledgment message.
+func parseAcknowledge(data []byte) (*acknowledgePayload, error) {
+	var ack acknowledgePayload
+	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&ack); err != nil {
+		return nil, err
+	}
+	return &ack, nil
+}

--- a/internal/adapters/slack/socketmode_test.go
+++ b/internal/adapters/slack/socketmode_test.go
@@ -1,0 +1,785 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+	"github.com/gorilla/websocket"
+)
+
+// TestOpenConnection tests the apps.connections.open API call.
+func TestOpenConnection(t *testing.T) {
+	tests := []struct {
+		name       string
+		response   connectionsOpenResponse
+		statusCode int
+		wantURL    string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name: "successful connection",
+			response: connectionsOpenResponse{
+				OK:  true,
+				URL: "wss://wss-primary.slack.com/link/?ticket=abc123",
+			},
+			statusCode: http.StatusOK,
+			wantURL:    "wss://wss-primary.slack.com/link/?ticket=abc123",
+			wantErr:    false,
+		},
+		{
+			name: "invalid auth",
+			response: connectionsOpenResponse{
+				OK:    false,
+				Error: "invalid_auth",
+			},
+			statusCode: http.StatusOK,
+			wantErr:    true,
+			errContain: "invalid_auth",
+		},
+		{
+			name: "not allowed token type",
+			response: connectionsOpenResponse{
+				OK:    false,
+				Error: "not_allowed_token_type",
+			},
+			statusCode: http.StatusOK,
+			wantErr:    true,
+			errContain: "not_allowed_token_type",
+		},
+		{
+			name: "empty URL in response",
+			response: connectionsOpenResponse{
+				OK:  true,
+				URL: "",
+			},
+			statusCode: http.StatusOK,
+			wantErr:    true,
+			errContain: "empty WSS URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify method
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %q, want POST", r.Method)
+				}
+
+				// Verify authorization header
+				auth := r.Header.Get("Authorization")
+				if !strings.HasPrefix(auth, "Bearer ") {
+					t.Errorf("Authorization = %q, want Bearer prefix", auth)
+				}
+				token := strings.TrimPrefix(auth, "Bearer ")
+				if token != testutil.FakeSlackAppToken {
+					t.Errorf("token = %q, want %q", token, testutil.FakeSlackAppToken)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				_ = json.NewEncoder(w).Encode(tt.response)
+			}))
+			defer server.Close()
+
+			client := NewSocketModeClient(testutil.FakeSlackAppToken)
+			client.apiURL = server.URL
+
+			ctx := context.Background()
+			url, err := client.OpenConnection(ctx)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errContain != "" && !strings.Contains(err.Error(), tt.errContain) {
+					t.Errorf("error = %q, want to contain %q", err.Error(), tt.errContain)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if url != tt.wantURL {
+					t.Errorf("url = %q, want %q", url, tt.wantURL)
+				}
+			}
+		})
+	}
+}
+
+// TestOpenConnectionContextCancelled tests context cancellation.
+func TestOpenConnectionContextCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(connectionsOpenResponse{OK: true, URL: "wss://test"})
+	}))
+	defer server.Close()
+
+	client := NewSocketModeClient(testutil.FakeSlackAppToken)
+	client.apiURL = server.URL
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.OpenConnection(ctx)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+// TestOpenConnectionInvalidJSON tests handling of invalid JSON response.
+func TestOpenConnectionInvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	client := NewSocketModeClient(testutil.FakeSlackAppToken)
+	client.apiURL = server.URL
+
+	ctx := context.Background()
+	_, err := client.OpenConnection(ctx)
+	if err == nil {
+		t.Fatal("expected error from invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "parse response") {
+		t.Errorf("error = %q, want to contain 'parse response'", err.Error())
+	}
+}
+
+// TestParseEnvelope tests envelope parsing for all envelope types.
+func TestParseEnvelope(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantType   string
+		wantID     string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:     "hello envelope",
+			input:    `{"envelope_id":"","type":"hello","payload":{}}`,
+			wantType: "hello",
+			wantID:   "",
+			wantErr:  false,
+		},
+		{
+			name:     "disconnect envelope",
+			input:    `{"envelope_id":"","type":"disconnect","reason":"link_disabled","payload":{}}`,
+			wantType: "disconnect",
+			wantID:   "",
+			wantErr:  false,
+		},
+		{
+			name:     "events_api envelope",
+			input:    `{"envelope_id":"abc-123","type":"events_api","payload":{"event":{"type":"message","channel":"C123","user":"U456","text":"hello"}}}`,
+			wantType: "events_api",
+			wantID:   "abc-123",
+			wantErr:  false,
+		},
+		{
+			name:       "invalid JSON",
+			input:      `not json`,
+			wantErr:    true,
+			errContain: "unmarshal envelope",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, err := parseEnvelope([]byte(tt.input))
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errContain != "" && !strings.Contains(err.Error(), tt.errContain) {
+					t.Errorf("error = %q, want to contain %q", err.Error(), tt.errContain)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if env.Type != tt.wantType {
+				t.Errorf("type = %q, want %q", env.Type, tt.wantType)
+			}
+			if env.EnvelopeID != tt.wantID {
+				t.Errorf("envelope_id = %q, want %q", env.EnvelopeID, tt.wantID)
+			}
+		})
+	}
+}
+
+// TestParseSocketEvent tests event extraction from events_api payloads.
+func TestParseSocketEvent(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   string
+		wantEvent *SocketEvent
+		wantErr   bool
+	}{
+		{
+			name:    "message event",
+			payload: `{"event":{"type":"message","channel":"C123","user":"U456","text":"hello world","ts":"1234567890.123456"}}`,
+			wantEvent: &SocketEvent{
+				Type:      "message",
+				ChannelID: "C123",
+				UserID:    "U456",
+				Text:      "hello world",
+				Timestamp: "1234567890.123456",
+			},
+		},
+		{
+			name:    "app_mention event strips bot mention",
+			payload: `{"event":{"type":"app_mention","channel":"C789","user":"U111","text":"<@U222BOT> deploy to prod","ts":"1234567890.654321"}}`,
+			wantEvent: &SocketEvent{
+				Type:      "app_mention",
+				ChannelID: "C789",
+				UserID:    "U111",
+				Text:      "deploy to prod",
+				Timestamp: "1234567890.654321",
+			},
+		},
+		{
+			name:    "app_mention without bot mention prefix",
+			payload: `{"event":{"type":"app_mention","channel":"C789","user":"U111","text":"deploy to prod","ts":"1234567890.654321"}}`,
+			wantEvent: &SocketEvent{
+				Type:      "app_mention",
+				ChannelID: "C789",
+				UserID:    "U111",
+				Text:      "deploy to prod",
+				Timestamp: "1234567890.654321",
+			},
+		},
+		{
+			name:    "threaded message",
+			payload: `{"event":{"type":"message","channel":"C123","user":"U456","text":"reply","thread_ts":"1234567890.000000","ts":"1234567890.123456"}}`,
+			wantEvent: &SocketEvent{
+				Type:      "message",
+				ChannelID: "C123",
+				UserID:    "U456",
+				Text:      "reply",
+				ThreadTS:  "1234567890.000000",
+				Timestamp: "1234567890.123456",
+			},
+		},
+		{
+			name:    "message with files",
+			payload: `{"event":{"type":"message","channel":"C123","user":"U456","text":"see attached","ts":"1234567890.123456","files":[{"id":"F01","name":"doc.pdf","mimetype":"application/pdf","url_private":"https://files.slack.com/files/F01/doc.pdf"}]}}`,
+			wantEvent: &SocketEvent{
+				Type:      "message",
+				ChannelID: "C123",
+				UserID:    "U456",
+				Text:      "see attached",
+				Timestamp: "1234567890.123456",
+				Files: []SlackFile{
+					{
+						ID:       "F01",
+						Name:     "doc.pdf",
+						MimeType: "application/pdf",
+						URL:      "https://files.slack.com/files/F01/doc.pdf",
+					},
+				},
+			},
+		},
+		{
+			name:      "bot message ignored",
+			payload:   `{"event":{"type":"message","channel":"C123","bot_id":"B999","text":"bot says hi","ts":"1234567890.123456"}}`,
+			wantEvent: nil,
+		},
+		{
+			name:      "bot_message subtype ignored",
+			payload:   `{"event":{"type":"message","channel":"C123","user":"U456","subtype":"bot_message","text":"bot says hi","ts":"1234567890.123456"}}`,
+			wantEvent: nil,
+		},
+		{
+			name:      "unsupported event type ignored",
+			payload:   `{"event":{"type":"reaction_added","channel":"C123","user":"U456"}}`,
+			wantEvent: nil,
+		},
+		{
+			name:    "invalid JSON",
+			payload: `not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev, err := parseSocketEvent(json.RawMessage(tt.payload))
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantEvent == nil {
+				if ev != nil {
+					t.Errorf("expected nil event, got %+v", ev)
+				}
+				return
+			}
+
+			if ev == nil {
+				t.Fatal("expected event, got nil")
+			}
+
+			if ev.Type != tt.wantEvent.Type {
+				t.Errorf("Type = %q, want %q", ev.Type, tt.wantEvent.Type)
+			}
+			if ev.ChannelID != tt.wantEvent.ChannelID {
+				t.Errorf("ChannelID = %q, want %q", ev.ChannelID, tt.wantEvent.ChannelID)
+			}
+			if ev.UserID != tt.wantEvent.UserID {
+				t.Errorf("UserID = %q, want %q", ev.UserID, tt.wantEvent.UserID)
+			}
+			if ev.Text != tt.wantEvent.Text {
+				t.Errorf("Text = %q, want %q", ev.Text, tt.wantEvent.Text)
+			}
+			if ev.ThreadTS != tt.wantEvent.ThreadTS {
+				t.Errorf("ThreadTS = %q, want %q", ev.ThreadTS, tt.wantEvent.ThreadTS)
+			}
+			if ev.Timestamp != tt.wantEvent.Timestamp {
+				t.Errorf("Timestamp = %q, want %q", ev.Timestamp, tt.wantEvent.Timestamp)
+			}
+			if len(ev.Files) != len(tt.wantEvent.Files) {
+				t.Errorf("Files len = %d, want %d", len(ev.Files), len(tt.wantEvent.Files))
+			} else {
+				for i, f := range ev.Files {
+					wf := tt.wantEvent.Files[i]
+					if f.ID != wf.ID {
+						t.Errorf("Files[%d].ID = %q, want %q", i, f.ID, wf.ID)
+					}
+					if f.Name != wf.Name {
+						t.Errorf("Files[%d].Name = %q, want %q", i, f.Name, wf.Name)
+					}
+					if f.MimeType != wf.MimeType {
+						t.Errorf("Files[%d].MimeType = %q, want %q", i, f.MimeType, wf.MimeType)
+					}
+					if f.URL != wf.URL {
+						t.Errorf("Files[%d].URL = %q, want %q", i, f.URL, wf.URL)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestBotMentionRegex tests the <@BOTID> stripping regex.
+func TestBotMentionRegex(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "standard mention",
+			input: "<@U123BOT> deploy",
+			want:  "deploy",
+		},
+		{
+			name:  "mention with extra spaces",
+			input: "<@U123BOT>   deploy to prod",
+			want:  "deploy to prod",
+		},
+		{
+			name:  "no mention",
+			input: "deploy to prod",
+			want:  "deploy to prod",
+		},
+		{
+			name:  "mention only",
+			input: "<@U123BOT>",
+			want:  "",
+		},
+		{
+			name:  "mention in middle not stripped",
+			input: "hey <@U123BOT> deploy",
+			want:  "hey <@U123BOT> deploy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := botMentionRegex.ReplaceAllString(tt.input, "")
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAcknowledge tests the acknowledge frame format.
+func TestAcknowledge(t *testing.T) {
+	tests := []struct {
+		name       string
+		envelopeID string
+	}{
+		{
+			name:       "standard envelope ID",
+			envelopeID: "abc-123-def-456",
+		},
+		{
+			name:       "UUID style envelope ID",
+			envelopeID: "550e8400-e29b-41d4-a716-446655440000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock WebSocket server
+			upgrader := websocket.Upgrader{
+				CheckOrigin: func(r *http.Request) bool { return true },
+			}
+
+			var receivedMsg []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, err := upgrader.Upgrade(w, r, nil)
+				if err != nil {
+					t.Fatalf("upgrade: %v", err)
+					return
+				}
+				defer func() { _ = conn.Close() }()
+
+				_, msg, err := conn.ReadMessage()
+				if err != nil {
+					return
+				}
+				receivedMsg = msg
+			}))
+			defer server.Close()
+
+			// Connect to the mock server
+			wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+			conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+			if err != nil {
+				t.Fatalf("dial: %v", err)
+			}
+			defer func() { _ = conn.Close() }()
+
+			client := NewSocketModeClient(testutil.FakeSlackAppToken)
+			err = client.acknowledge(conn, tt.envelopeID)
+			if err != nil {
+				t.Fatalf("acknowledge: %v", err)
+			}
+
+			// Give server time to receive
+			time.Sleep(50 * time.Millisecond)
+
+			// Parse and verify
+			ack, err := parseAcknowledge(receivedMsg)
+			if err != nil {
+				t.Fatalf("parse ack: %v", err)
+			}
+
+			if ack.EnvelopeID != tt.envelopeID {
+				t.Errorf("envelope_id = %q, want %q", ack.EnvelopeID, tt.envelopeID)
+			}
+		})
+	}
+}
+
+// TestListenReceivesEvents tests the full Listen pipeline with a mock WebSocket server.
+func TestListenReceivesEvents(t *testing.T) {
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+
+	// Mock WebSocket server that sends events
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		// Send hello
+		hello := `{"envelope_id":"","type":"hello","payload":{}}`
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(hello))
+
+		// Send a message event
+		msgEvent := `{"envelope_id":"env-001","type":"events_api","payload":{"event":{"type":"message","channel":"C123","user":"U456","text":"test message","ts":"111.222"}}}`
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(msgEvent))
+
+		// Read ack for the message event
+		_, ackData, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		ack, err := parseAcknowledge(ackData)
+		if err != nil {
+			t.Errorf("failed to parse ack: %v", err)
+			return
+		}
+		if ack.EnvelopeID != "env-001" {
+			t.Errorf("ack envelope_id = %q, want %q", ack.EnvelopeID, "env-001")
+		}
+
+		// Send an app_mention event
+		mentionEvent := `{"envelope_id":"env-002","type":"events_api","payload":{"event":{"type":"app_mention","channel":"C789","user":"U111","text":"<@U222BOT> do the thing","ts":"333.444"}}}`
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(mentionEvent))
+
+		// Read ack
+		_, _, _ = conn.ReadMessage()
+
+		// Keep connection open until context cancelled
+		for {
+			_, _, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+		}
+	}))
+	defer wsServer.Close()
+
+	// Mock API server for apps.connections.open
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(connectionsOpenResponse{
+			OK:  true,
+			URL: wsURL,
+		})
+	}))
+	defer apiServer.Close()
+
+	client := NewSocketModeClient(testutil.FakeSlackAppToken)
+	client.apiURL = apiServer.URL
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	// Collect events
+	var received []*SocketEvent
+	timeout := time.After(3 * time.Second)
+
+	for len(received) < 2 {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				t.Fatal("events channel closed unexpectedly")
+			}
+			received = append(received, ev)
+		case <-timeout:
+			t.Fatalf("timed out waiting for events, got %d", len(received))
+		}
+	}
+
+	cancel() // Clean shutdown
+
+	// Verify first event (message)
+	if received[0].Type != "message" {
+		t.Errorf("event[0].Type = %q, want %q", received[0].Type, "message")
+	}
+	if received[0].ChannelID != "C123" {
+		t.Errorf("event[0].ChannelID = %q, want %q", received[0].ChannelID, "C123")
+	}
+	if received[0].Text != "test message" {
+		t.Errorf("event[0].Text = %q, want %q", received[0].Text, "test message")
+	}
+
+	// Verify second event (app_mention with stripped prefix)
+	if received[1].Type != "app_mention" {
+		t.Errorf("event[1].Type = %q, want %q", received[1].Type, "app_mention")
+	}
+	if received[1].ChannelID != "C789" {
+		t.Errorf("event[1].ChannelID = %q, want %q", received[1].ChannelID, "C789")
+	}
+	if received[1].Text != "do the thing" {
+		t.Errorf("event[1].Text = %q, want %q", received[1].Text, "do the thing")
+	}
+}
+
+// TestListenFiltersBotMessages tests that bot messages are filtered out.
+func TestListenFiltersBotMessages(t *testing.T) {
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		// Send hello
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"hello"}`))
+
+		// Send bot message (should be filtered)
+		botMsg := `{"envelope_id":"env-bot","type":"events_api","payload":{"event":{"type":"message","channel":"C123","bot_id":"B999","text":"bot says hi","ts":"111.222"}}}`
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(botMsg))
+
+		// Read ack for bot message
+		_, _, _ = conn.ReadMessage()
+
+		// Send real user message
+		userMsg := `{"envelope_id":"env-user","type":"events_api","payload":{"event":{"type":"message","channel":"C123","user":"U456","text":"user says hi","ts":"333.444"}}}`
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(userMsg))
+
+		// Read ack
+		_, _, _ = conn.ReadMessage()
+
+		// Keep alive
+		for {
+			_, _, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+		}
+	}))
+	defer wsServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(connectionsOpenResponse{OK: true, URL: wsURL})
+	}))
+	defer apiServer.Close()
+
+	client := NewSocketModeClient(testutil.FakeSlackAppToken)
+	client.apiURL = apiServer.URL
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	// Should only get the user message (bot message filtered)
+	select {
+	case ev := <-events:
+		if ev.Text != "user says hi" {
+			t.Errorf("Text = %q, want %q", ev.Text, "user says hi")
+		}
+		if ev.UserID != "U456" {
+			t.Errorf("UserID = %q, want %q", ev.UserID, "U456")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for user event")
+	}
+
+	cancel()
+}
+
+// TestListenHandlesDisconnect tests that disconnect envelopes trigger reconnection.
+func TestListenHandlesDisconnect(t *testing.T) {
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+
+	connectionCount := 0
+
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		connectionCount++
+
+		// Send hello
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"hello"}`))
+
+		if connectionCount == 1 {
+			// First connection: send disconnect
+			_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"disconnect","reason":"link_disabled"}`))
+			return
+		}
+
+		// Second connection: send a message and keep alive
+		msg := `{"envelope_id":"env-reconnect","type":"events_api","payload":{"event":{"type":"message","channel":"C123","user":"U456","text":"after reconnect","ts":"555.666"}}}`
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(msg))
+
+		// Read ack
+		_, _, _ = conn.ReadMessage()
+
+		// Keep alive
+		for {
+			_, _, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+		}
+	}))
+	defer wsServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http")
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(connectionsOpenResponse{OK: true, URL: wsURL})
+	}))
+	defer apiServer.Close()
+
+	client := NewSocketModeClient(testutil.FakeSlackAppToken)
+	client.apiURL = apiServer.URL
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	events, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	// Should receive the message from the second connection (after reconnect)
+	select {
+	case ev := <-events:
+		if ev.Text != "after reconnect" {
+			t.Errorf("Text = %q, want %q", ev.Text, "after reconnect")
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("timed out waiting for event after reconnect")
+	}
+
+	cancel()
+
+	if connectionCount < 2 {
+		t.Errorf("connectionCount = %d, want >= 2", connectionCount)
+	}
+}
+
+// TestNewSocketModeClient tests client creation.
+func TestNewSocketModeClient(t *testing.T) {
+	client := NewSocketModeClient(testutil.FakeSlackAppToken)
+
+	if client == nil {
+		t.Fatal("NewSocketModeClient returned nil")
+	}
+	if client.appToken != testutil.FakeSlackAppToken {
+		t.Errorf("appToken = %q, want %q", client.appToken, testutil.FakeSlackAppToken)
+	}
+	if client.httpClient == nil {
+		t.Error("httpClient is nil")
+	}
+	if client.dialer == nil {
+		t.Error("dialer is nil")
+	}
+	if client.log == nil {
+		t.Error("log is nil")
+	}
+	if client.apiURL != connectionsOpenURL {
+		t.Errorf("apiURL = %q, want %q", client.apiURL, connectionsOpenURL)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-655.

## Changes

