### PR TITLE
Implement connection opening (`socketmode.go` — `OpenConnection`) — `SocketModeClient` struct with `appToken`, `httpClient`. POST to `apps.connections.open` with Bearer token, parse JSON response for WSS URL. Return typed errors for auth failures. ~60 LoC, testable with `httptest.NewServer`.

### DIFF
--- a/internal/adapters/slack/socketmode.go
+++ b/internal/adapters/slack/socketmode.go
@@ -1,0 +1,99 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// SocketModeClient connects to Slack's Socket Mode API using an app-level token.
+// It handles the initial HTTP handshake to obtain a WebSocket URL.
+type SocketModeClient struct {
+	appToken   string
+	apiURL     string
+	httpClient *http.Client
+}
+
+// NewSocketModeClient creates a new Socket Mode client with the given app-level token.
+// The token must be an xapp-... app-level token (not a bot token).
+func NewSocketModeClient(appToken string) *SocketModeClient {
+	return &SocketModeClient{
+		appToken:   appToken,
+		apiURL:     slackAPIURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// NewSocketModeClientWithBaseURL creates a Socket Mode client with a custom API base URL.
+// Used for testing with httptest.NewServer.
+func NewSocketModeClientWithBaseURL(appToken, baseURL string) *SocketModeClient {
+	return &SocketModeClient{
+		appToken:   appToken,
+		apiURL:     baseURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// connectionsOpenResponse is the JSON response from apps.connections.open.
+type connectionsOpenResponse struct {
+	OK    bool   `json:"ok"`
+	URL   string `json:"url,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+// ErrAuthFailure indicates the app-level token was rejected by Slack.
+var ErrAuthFailure = fmt.Errorf("slack socket mode: authentication failed")
+
+// ErrConnectionOpen indicates a non-auth failure when opening a connection.
+var ErrConnectionOpen = fmt.Errorf("slack socket mode: failed to open connection")
+
+// OpenConnection calls apps.connections.open with the app-level token
+// and returns the WebSocket URL for event streaming.
+func (s *SocketModeClient) OpenConnection(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.apiURL+"/apps.connections.open", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Bearer "+s.appToken)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrConnectionOpen, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("%w: failed to read response: %w", ErrConnectionOpen, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: HTTP %d: %s", ErrConnectionOpen, resp.StatusCode, string(body))
+	}
+
+	var result connectionsOpenResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("%w: failed to parse response: %w", ErrConnectionOpen, err)
+	}
+
+	if !result.OK {
+		// Slack returns specific error codes for auth issues
+		switch result.Error {
+		case "invalid_auth", "not_authed", "account_inactive", "token_revoked":
+			return "", fmt.Errorf("%w: %s", ErrAuthFailure, result.Error)
+		default:
+			return "", fmt.Errorf("%w: %s", ErrConnectionOpen, result.Error)
+		}
+	}
+
+	if result.URL == "" {
+		return "", fmt.Errorf("%w: empty WebSocket URL in response", ErrConnectionOpen)
+	}
+
+	return result.URL, nil
+}

--- a/internal/adapters/slack/socketmode_test.go
+++ b/internal/adapters/slack/socketmode_test.go
@@ -1,0 +1,181 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestOpenConnection(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		response   string
+		wantURL    string
+		wantErr    error
+		wantErrMsg string
+	}{
+		{
+			name:       "successful connection returns WSS URL",
+			statusCode: http.StatusOK,
+			response:   `{"ok":true,"url":"wss://wss-primary.slack.com/link/?ticket=abc123"}`,
+			wantURL:    "wss://wss-primary.slack.com/link/?ticket=abc123",
+		},
+		{
+			name:       "invalid auth error",
+			statusCode: http.StatusOK,
+			response:   `{"ok":false,"error":"invalid_auth"}`,
+			wantErr:    ErrAuthFailure,
+			wantErrMsg: "invalid_auth",
+		},
+		{
+			name:       "not authed error",
+			statusCode: http.StatusOK,
+			response:   `{"ok":false,"error":"not_authed"}`,
+			wantErr:    ErrAuthFailure,
+			wantErrMsg: "not_authed",
+		},
+		{
+			name:       "token revoked error",
+			statusCode: http.StatusOK,
+			response:   `{"ok":false,"error":"token_revoked"}`,
+			wantErr:    ErrAuthFailure,
+			wantErrMsg: "token_revoked",
+		},
+		{
+			name:       "account inactive error",
+			statusCode: http.StatusOK,
+			response:   `{"ok":false,"error":"account_inactive"}`,
+			wantErr:    ErrAuthFailure,
+			wantErrMsg: "account_inactive",
+		},
+		{
+			name:       "non-auth API error",
+			statusCode: http.StatusOK,
+			response:   `{"ok":false,"error":"too_many_websockets"}`,
+			wantErr:    ErrConnectionOpen,
+			wantErrMsg: "too_many_websockets",
+		},
+		{
+			name:       "HTTP 500 error",
+			statusCode: http.StatusInternalServerError,
+			response:   `Internal Server Error`,
+			wantErr:    ErrConnectionOpen,
+			wantErrMsg: "HTTP 500",
+		},
+		{
+			name:       "empty URL in response",
+			statusCode: http.StatusOK,
+			response:   `{"ok":true,"url":""}`,
+			wantErr:    ErrConnectionOpen,
+			wantErrMsg: "empty WebSocket URL",
+		},
+		{
+			name:       "malformed JSON response",
+			statusCode: http.StatusOK,
+			response:   `{not json`,
+			wantErr:    ErrConnectionOpen,
+			wantErrMsg: "failed to parse response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify request method and path
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST, got %s", r.Method)
+				}
+				if r.URL.Path != "/apps.connections.open" {
+					t.Errorf("expected /apps.connections.open, got %s", r.URL.Path)
+				}
+
+				// Verify auth header
+				auth := r.Header.Get("Authorization")
+				if auth != "Bearer "+testutil.FakeSlackAppToken {
+					t.Errorf("expected Bearer %s, got %s", testutil.FakeSlackAppToken, auth)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, server.URL)
+			url, err := client.OpenConnection(context.Background())
+
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("expected error wrapping %v, got: %v", tt.wantErr, err)
+				}
+				if tt.wantErrMsg != "" {
+					if got := err.Error(); !contains(got, tt.wantErrMsg) {
+						t.Errorf("error %q does not contain %q", got, tt.wantErrMsg)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if url != tt.wantURL {
+				t.Errorf("expected URL %q, got %q", tt.wantURL, url)
+			}
+		})
+	}
+}
+
+func TestOpenConnectionCancelledContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true,"url":"wss://example.com"}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	client := NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, server.URL)
+	_, err := client.OpenConnection(ctx)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+	if !errors.Is(err, ErrConnectionOpen) {
+		t.Errorf("expected ErrConnectionOpen, got: %v", err)
+	}
+}
+
+func TestNewSocketModeClient(t *testing.T) {
+	client := NewSocketModeClient(testutil.FakeSlackAppToken)
+	if client.appToken != testutil.FakeSlackAppToken {
+		t.Errorf("expected appToken %q, got %q", testutil.FakeSlackAppToken, client.appToken)
+	}
+	if client.apiURL != slackAPIURL {
+		t.Errorf("expected apiURL %q, got %q", slackAPIURL, client.apiURL)
+	}
+	if client.httpClient == nil {
+		t.Error("expected non-nil httpClient")
+	}
+}
+
+// contains checks if s contains substr (avoids importing strings for one use).
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-673.

## Changes

