### PR TITLE
Implement WebSocket listener with acknowledge (`socketmode.go` — `Listen`, `acknowledge`) — Connect to WSS URL via `gorilla/websocket`. Read loop

### DIFF
--- a/internal/adapters/slack/socket_mode.go
+++ b/internal/adapters/slack/socket_mode.go
@@ -1,0 +1,245 @@
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+	"github.com/gorilla/websocket"
+)
+
+// SocketEventType identifies the kind of event received over Socket Mode.
+type SocketEventType string
+
+const (
+	SocketEventMessage     SocketEventType = "events_api"
+	SocketEventInteraction SocketEventType = "interactive"
+	SocketEventSlashCmd    SocketEventType = "slash_commands"
+	SocketEventDisconnect  SocketEventType = "disconnect"
+)
+
+// SocketEvent is emitted on the events channel for each envelope received
+// from the Slack Socket Mode WebSocket connection.
+type SocketEvent struct {
+	Type       SocketEventType
+	EnvelopeID string
+	Payload    json.RawMessage // raw inner payload for caller to decode
+}
+
+// Envelope is the wire format Slack sends over Socket Mode.
+type Envelope struct {
+	EnvelopeID string          `json:"envelope_id"`
+	Type       string          `json:"type"`
+	Payload    json.RawMessage `json:"payload"`
+	// disconnect-specific fields
+	Reason string `json:"reason,omitempty"`
+}
+
+// envelopeAck is written back to acknowledge receipt.
+type envelopeAck struct {
+	EnvelopeID string `json:"envelope_id"`
+}
+
+// SocketModeHandler manages a Slack Socket Mode WebSocket connection.
+// It reads envelopes, acknowledges them, and emits SocketEvents on a channel.
+type SocketModeHandler struct {
+	conn   *websocket.Conn
+	events chan SocketEvent
+	done   chan struct{}
+	once   sync.Once
+	log    *slog.Logger
+
+	// PongWait is how long we wait for a pong before considering the
+	// connection dead. PingInterval is how often we send pings.
+	PongWait     time.Duration
+	PingInterval time.Duration
+}
+
+// NewSocketModeHandler wraps an established WebSocket connection and returns
+// the handler plus the channel that will receive parsed events.
+// Call Run() to start the read loop.
+func NewSocketModeHandler(conn *websocket.Conn) (*SocketModeHandler, <-chan SocketEvent) {
+	ch := make(chan SocketEvent, 64)
+	h := &SocketModeHandler{
+		conn:         conn,
+		events:       ch,
+		done:         make(chan struct{}),
+		log:          logging.WithComponent("slack.socket_mode"),
+		PongWait:     60 * time.Second,
+		PingInterval: 30 * time.Second,
+	}
+	return h, ch
+}
+
+// Run starts the read loop and ping ticker. It blocks until the connection
+// is closed or Close is called. The events channel is closed on return.
+func (h *SocketModeHandler) Run() {
+	defer h.cleanup()
+
+	h.wirePongHandler()
+
+	// Set initial read deadline based on PongWait.
+	_ = h.conn.SetReadDeadline(time.Now().Add(h.PongWait))
+
+	// Start ping ticker in a separate goroutine.
+	go h.pingLoop()
+
+	h.readLoop()
+}
+
+// Close terminates the handler gracefully.
+func (h *SocketModeHandler) Close() {
+	h.once.Do(func() {
+		close(h.done)
+		_ = h.conn.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+		)
+		_ = h.conn.Close()
+	})
+}
+
+// --- internals ---
+
+func (h *SocketModeHandler) cleanup() {
+	close(h.events)
+	h.Close()
+}
+
+func (h *SocketModeHandler) wirePongHandler() {
+	h.conn.SetPongHandler(func(appData string) error {
+		h.log.Debug("pong received")
+		return h.conn.SetReadDeadline(time.Now().Add(h.PongWait))
+	})
+}
+
+func (h *SocketModeHandler) pingLoop() {
+	ticker := time.NewTicker(h.PingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-h.done:
+			return
+		case <-ticker.C:
+			if err := h.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				h.log.Warn("ping write failed", slog.Any("error", err))
+				return
+			}
+		}
+	}
+}
+
+func (h *SocketModeHandler) readLoop() {
+	for {
+		select {
+		case <-h.done:
+			return
+		default:
+		}
+
+		_, data, err := h.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err,
+				websocket.CloseNormalClosure,
+				websocket.CloseGoingAway) {
+				h.log.Warn("websocket read error", slog.Any("error", err))
+			}
+			return
+		}
+
+		h.handleRawMessage(data)
+	}
+}
+
+func (h *SocketModeHandler) handleRawMessage(data []byte) {
+	var env Envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		h.log.Error("failed to parse envelope", slog.Any("error", err))
+		return
+	}
+
+	if env.EnvelopeID == "" {
+		h.log.Warn("envelope missing envelope_id, skipping")
+		return
+	}
+
+	// Acknowledge immediately — Slack requires this within 3 seconds.
+	if err := h.acknowledge(env.EnvelopeID); err != nil {
+		h.log.Error("failed to acknowledge envelope",
+			slog.String("envelope_id", env.EnvelopeID),
+			slog.Any("error", err))
+		// Continue processing even if ack fails; Slack will redeliver.
+	}
+
+	h.log.Debug("envelope received",
+		slog.String("type", env.Type),
+		slog.String("envelope_id", env.EnvelopeID))
+
+	// Handle disconnect: emit event and close.
+	if env.Type == "disconnect" {
+		reason := env.Reason
+		if reason == "" {
+			reason = "server requested disconnect"
+		}
+		h.log.Info("disconnect envelope received", slog.String("reason", reason))
+
+		h.emit(SocketEvent{
+			Type:       SocketEventDisconnect,
+			EnvelopeID: env.EnvelopeID,
+			Payload:    data, // full envelope so caller can inspect reason
+		})
+		h.Close()
+		return
+	}
+
+	evtType, ok := mapEnvelopeType(env.Type)
+	if !ok {
+		h.log.Warn("unknown envelope type, skipping",
+			slog.String("type", env.Type))
+		return
+	}
+
+	h.emit(SocketEvent{
+		Type:       evtType,
+		EnvelopeID: env.EnvelopeID,
+		Payload:    env.Payload,
+	})
+}
+
+func (h *SocketModeHandler) acknowledge(envelopeID string) error {
+	ack := envelopeAck{EnvelopeID: envelopeID}
+	data, err := json.Marshal(ack)
+	if err != nil {
+		return fmt.Errorf("marshal ack: %w", err)
+	}
+	return h.conn.WriteMessage(websocket.TextMessage, data)
+}
+
+func (h *SocketModeHandler) emit(evt SocketEvent) {
+	select {
+	case h.events <- evt:
+	default:
+		h.log.Warn("event channel full, dropping event",
+			slog.String("type", string(evt.Type)),
+			slog.String("envelope_id", evt.EnvelopeID))
+	}
+}
+
+func mapEnvelopeType(raw string) (SocketEventType, bool) {
+	switch raw {
+	case "events_api":
+		return SocketEventMessage, true
+	case "interactive":
+		return SocketEventInteraction, true
+	case "slash_commands":
+		return SocketEventSlashCmd, true
+	case "disconnect":
+		return SocketEventDisconnect, true
+	default:
+		return "", false
+	}
+}

--- a/internal/adapters/slack/socket_mode_test.go
+++ b/internal/adapters/slack/socket_mode_test.go
@@ -1,0 +1,321 @@
+package slack
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// newTestWSPair creates a connected client/server websocket pair for testing.
+func newTestWSPair(t *testing.T) (client *websocket.Conn, server *websocket.Conn) {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	var serverConn *websocket.Conn
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		serverConn, err = upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+		}
+		wg.Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	wg.Wait()
+	t.Cleanup(func() { _ = serverConn.Close() })
+
+	return clientConn, serverConn
+}
+
+func TestSocketModeHandler_EventsAPI(t *testing.T) {
+	client, server := newTestWSPair(t)
+
+	handler, events := NewSocketModeHandler(client)
+	handler.PongWait = 5 * time.Second
+	handler.PingInterval = 2 * time.Second
+
+	go handler.Run()
+	defer handler.Close()
+
+	// Server sends an events_api envelope.
+	env := Envelope{
+		EnvelopeID: "evt-123",
+		Type:       "events_api",
+		Payload:    json.RawMessage(`{"event":{"type":"message","text":"hello"}}`),
+	}
+	data, _ := json.Marshal(env)
+	if err := server.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Read the ack that the handler writes back.
+	_, ackData, err := server.ReadMessage()
+	if err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+	var ack envelopeAck
+	if err := json.Unmarshal(ackData, &ack); err != nil {
+		t.Fatalf("unmarshal ack: %v", err)
+	}
+	if ack.EnvelopeID != "evt-123" {
+		t.Errorf("ack envelope_id = %q, want %q", ack.EnvelopeID, "evt-123")
+	}
+
+	// Read the emitted event.
+	select {
+	case evt := <-events:
+		if evt.Type != SocketEventMessage {
+			t.Errorf("event type = %q, want %q", evt.Type, SocketEventMessage)
+		}
+		if evt.EnvelopeID != "evt-123" {
+			t.Errorf("event envelope_id = %q, want %q", evt.EnvelopeID, "evt-123")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func TestSocketModeHandler_InteractiveEnvelope(t *testing.T) {
+	client, server := newTestWSPair(t)
+
+	handler, events := NewSocketModeHandler(client)
+	handler.PongWait = 5 * time.Second
+	handler.PingInterval = 2 * time.Second
+
+	go handler.Run()
+	defer handler.Close()
+
+	env := Envelope{
+		EnvelopeID: "int-456",
+		Type:       "interactive",
+		Payload:    json.RawMessage(`{"type":"block_actions"}`),
+	}
+	data, _ := json.Marshal(env)
+	if err := server.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Consume ack.
+	_, _, _ = server.ReadMessage()
+
+	select {
+	case evt := <-events:
+		if evt.Type != SocketEventInteraction {
+			t.Errorf("event type = %q, want %q", evt.Type, SocketEventInteraction)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func TestSocketModeHandler_SlashCommand(t *testing.T) {
+	client, server := newTestWSPair(t)
+
+	handler, events := NewSocketModeHandler(client)
+	handler.PongWait = 5 * time.Second
+	handler.PingInterval = 2 * time.Second
+
+	go handler.Run()
+	defer handler.Close()
+
+	env := Envelope{
+		EnvelopeID: "cmd-789",
+		Type:       "slash_commands",
+		Payload:    json.RawMessage(`{"command":"/pilot"}`),
+	}
+	data, _ := json.Marshal(env)
+	if err := server.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, _, _ = server.ReadMessage()
+
+	select {
+	case evt := <-events:
+		if evt.Type != SocketEventSlashCmd {
+			t.Errorf("event type = %q, want %q", evt.Type, SocketEventSlashCmd)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func TestSocketModeHandler_Disconnect(t *testing.T) {
+	client, server := newTestWSPair(t)
+
+	handler, events := NewSocketModeHandler(client)
+	handler.PongWait = 5 * time.Second
+	handler.PingInterval = 2 * time.Second
+
+	go handler.Run()
+
+	env := Envelope{
+		EnvelopeID: "disc-001",
+		Type:       "disconnect",
+		Reason:     "link_disabled",
+	}
+	data, _ := json.Marshal(env)
+	if err := server.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Should receive disconnect event.
+	select {
+	case evt := <-events:
+		if evt.Type != SocketEventDisconnect {
+			t.Errorf("event type = %q, want %q", evt.Type, SocketEventDisconnect)
+		}
+		if evt.EnvelopeID != "disc-001" {
+			t.Errorf("envelope_id = %q, want %q", evt.EnvelopeID, "disc-001")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for disconnect event")
+	}
+
+	// Channel should close after disconnect.
+	select {
+	case _, ok := <-events:
+		if ok {
+			t.Error("expected events channel to be closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for events channel close")
+	}
+}
+
+func TestSocketModeHandler_UnknownType(t *testing.T) {
+	client, server := newTestWSPair(t)
+
+	handler, events := NewSocketModeHandler(client)
+	handler.PongWait = 5 * time.Second
+	handler.PingInterval = 2 * time.Second
+
+	go handler.Run()
+	defer handler.Close()
+
+	// Send unknown type — should be acked but not emitted.
+	env := Envelope{
+		EnvelopeID: "unk-001",
+		Type:       "unknown_type",
+		Payload:    json.RawMessage(`{}`),
+	}
+	data, _ := json.Marshal(env)
+	if err := server.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Ack should still be sent.
+	_, ackData, err := server.ReadMessage()
+	if err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+	var ack envelopeAck
+	if err := json.Unmarshal(ackData, &ack); err != nil {
+		t.Fatalf("unmarshal ack: %v", err)
+	}
+	if ack.EnvelopeID != "unk-001" {
+		t.Errorf("ack envelope_id = %q, want %q", ack.EnvelopeID, "unk-001")
+	}
+
+	// No event should be emitted. Send a known event to flush.
+	env2 := Envelope{
+		EnvelopeID: "evt-flush",
+		Type:       "events_api",
+		Payload:    json.RawMessage(`{}`),
+	}
+	data2, _ := json.Marshal(env2)
+	if err := server.WriteMessage(websocket.TextMessage, data2); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, _, _ = server.ReadMessage() // ack for flush
+
+	select {
+	case evt := <-events:
+		if evt.EnvelopeID == "unk-001" {
+			t.Error("unknown envelope type should not emit an event")
+		}
+		// Should be the flush event.
+		if evt.EnvelopeID != "evt-flush" {
+			t.Errorf("expected flush event, got %q", evt.EnvelopeID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for flush event")
+	}
+}
+
+func TestSocketModeHandler_MissingEnvelopeID(t *testing.T) {
+	client, server := newTestWSPair(t)
+
+	handler, events := NewSocketModeHandler(client)
+	handler.PongWait = 5 * time.Second
+	handler.PingInterval = 2 * time.Second
+
+	go handler.Run()
+	defer handler.Close()
+
+	// Send envelope without envelope_id — should be skipped.
+	if err := server.WriteMessage(websocket.TextMessage, []byte(`{"type":"events_api","payload":{}}`)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Send a valid one to verify the handler is still alive.
+	env := Envelope{
+		EnvelopeID: "valid-001",
+		Type:       "events_api",
+		Payload:    json.RawMessage(`{}`),
+	}
+	data, _ := json.Marshal(env)
+	if err := server.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, _, _ = server.ReadMessage() // ack
+
+	select {
+	case evt := <-events:
+		if evt.EnvelopeID != "valid-001" {
+			t.Errorf("expected valid-001, got %q", evt.EnvelopeID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestMapEnvelopeType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  SocketEventType
+		ok    bool
+	}{
+		{"events_api", SocketEventMessage, true},
+		{"interactive", SocketEventInteraction, true},
+		{"slash_commands", SocketEventSlashCmd, true},
+		{"disconnect", SocketEventDisconnect, true},
+		{"unknown", "", false},
+		{"", "", false},
+	}
+
+	for _, tt := range tests {
+		got, ok := mapEnvelopeType(tt.input)
+		if got != tt.want || ok != tt.ok {
+			t.Errorf("mapEnvelopeType(%q) = (%q, %v), want (%q, %v)",
+				tt.input, got, ok, tt.want, tt.ok)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-674.

## Changes

parse envelopes, acknowledge via `{"envelope_id":"..."}` write-back, emit `SocketEvent` on returned channel. Handle `disconnect` envelope type. Wire ping/pong handlers via `SetPongHandler`. ~120 LoC.