### PR TITLE
Add auto-reconnect with exponential backoff (`socketmode.go`) — Wrap the listen loop in reconnect logic

### DIFF
--- a/internal/adapters/slack/events.go
+++ b/internal/adapters/slack/events.go
@@ -1,0 +1,167 @@
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Socket Mode event types
+const (
+	EventTypeMessage    = "message"
+	EventTypeAppMention = "app_mention"
+)
+
+// Socket Mode envelope types
+const (
+	EnvelopeTypeEventsAPI  = "events_api"
+	EnvelopeTypeDisconnect = "disconnect"
+	EnvelopeTypeHello      = "hello"
+)
+
+// SocketEvent represents a parsed Slack event from Socket Mode.
+// It is the normalized output of parseEnvelope() — downstream consumers
+// work with this struct instead of raw JSON.
+type SocketEvent struct {
+	Type      string      // "message" or "app_mention"
+	ChannelID string      // Channel where the event occurred
+	UserID    string      // User who sent the message
+	Text      string      // Message text (with bot mention stripped for app_mention)
+	ThreadTS  string      // Parent thread timestamp (empty if not in thread)
+	Timestamp string      // Message timestamp
+	BotID     string      // Non-empty if message was sent by a bot
+	Files     []SlackFile // File attachments (images, documents, etc.)
+}
+
+// SlackFile represents a file attachment in a Slack message.
+type SlackFile struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Mimetype string `json:"mimetype"`
+	URL      string `json:"url_private"`
+	Size     int    `json:"size"`
+}
+
+// socketEnvelope is the top-level Socket Mode WebSocket message.
+type socketEnvelope struct {
+	EnvelopeID string          `json:"envelope_id"`
+	Type       string          `json:"type"`
+	Payload    json.RawMessage `json:"payload"`
+	// Disconnect-specific fields
+	Reason string `json:"reason,omitempty"`
+}
+
+// eventsAPIPayload wraps the Events API callback inside a Socket Mode envelope.
+type eventsAPIPayload struct {
+	Token  string          `json:"token"`
+	TeamID string          `json:"team_id"`
+	Event  json.RawMessage `json:"event"`
+	Type   string          `json:"type"` // "event_callback"
+}
+
+// innerEvent is the raw event object inside eventsAPIPayload.Event.
+type innerEvent struct {
+	Type     string      `json:"type"`
+	Channel  string      `json:"channel"`
+	User     string      `json:"user"`
+	Text     string      `json:"text"`
+	ThreadTS string      `json:"thread_ts,omitempty"`
+	TS       string      `json:"ts"`
+	BotID    string      `json:"bot_id,omitempty"`
+	Files    []SlackFile `json:"files,omitempty"`
+}
+
+// botMentionRegex matches <@UBOTID> patterns in Slack message text.
+// Slack encodes user mentions as <@U...> in the raw text.
+var botMentionRegex = regexp.MustCompile(`<@U[A-Z0-9]+>\s*`)
+
+// parseEnvelope parses a raw Socket Mode WebSocket message into a SocketEvent.
+// It returns the envelope ID (needed for acknowledgment), the parsed event
+// (nil for non-event envelopes like hello/disconnect), the envelope type, and any error.
+func parseEnvelope(data []byte) (envelopeID, envelopeType string, event *SocketEvent, err error) {
+	var env socketEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return "", "", nil, fmt.Errorf("unmarshal envelope: %w", err)
+	}
+
+	envelopeID = env.EnvelopeID
+	envelopeType = env.Type
+
+	switch env.Type {
+	case EnvelopeTypeEventsAPI:
+		evt, err := parseEventsAPIPayload(env.Payload)
+		if err != nil {
+			return envelopeID, envelopeType, nil, fmt.Errorf("parse events_api payload: %w", err)
+		}
+		return envelopeID, envelopeType, evt, nil
+
+	case EnvelopeTypeDisconnect:
+		// Disconnect envelopes signal the client to reconnect.
+		// Return nil event — caller handles reconnect logic.
+		return envelopeID, envelopeType, nil, nil
+
+	case EnvelopeTypeHello:
+		// Hello is sent on connection open. No event to process.
+		return envelopeID, envelopeType, nil, nil
+
+	default:
+		// Unknown envelope type — not an error, just nothing to process.
+		return envelopeID, envelopeType, nil, nil
+	}
+}
+
+// parseEventsAPIPayload extracts a SocketEvent from an events_api payload.
+func parseEventsAPIPayload(raw json.RawMessage) (*SocketEvent, error) {
+	var payload eventsAPIPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("unmarshal events_api payload: %w", err)
+	}
+
+	var inner innerEvent
+	if err := json.Unmarshal(payload.Event, &inner); err != nil {
+		return nil, fmt.Errorf("unmarshal inner event: %w", err)
+	}
+
+	// Only process message and app_mention events
+	switch inner.Type {
+	case EventTypeMessage, EventTypeAppMention:
+		// OK — continue
+	default:
+		return nil, nil
+	}
+
+	evt := &SocketEvent{
+		Type:      inner.Type,
+		ChannelID: inner.Channel,
+		UserID:    inner.User,
+		Text:      inner.Text,
+		ThreadTS:  inner.ThreadTS,
+		Timestamp: inner.TS,
+		BotID:     inner.BotID,
+		Files:     inner.Files,
+	}
+
+	// Strip <@BOTID> mention prefix from app_mention text
+	if evt.Type == EventTypeAppMention {
+		evt.Text = stripBotMention(evt.Text)
+	}
+
+	return evt, nil
+}
+
+// stripBotMention removes all <@U...> mention patterns from text and trims whitespace.
+func stripBotMention(text string) string {
+	cleaned := botMentionRegex.ReplaceAllString(text, "")
+	return strings.TrimSpace(cleaned)
+}
+
+// IsBotMessage returns true if the event was sent by a bot (including self).
+func (e *SocketEvent) IsBotMessage() bool {
+	return e.BotID != ""
+}
+
+// IsFromBot returns true if the event's BotID matches the given bot ID.
+func (e *SocketEvent) IsFromBot(botID string) bool {
+	return e.BotID == botID
+}

--- a/internal/adapters/slack/socketmode.go
+++ b/internal/adapters/slack/socketmode.go
@@ -1,0 +1,303 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+	"github.com/gorilla/websocket"
+)
+
+// Reconnect backoff constants.
+const (
+	initialBackoff = 1 * time.Second
+	maxBackoff     = 30 * time.Second
+	backoffFactor  = 2
+)
+
+// SocketModeClient connects to Slack's Socket Mode API using an app-level token.
+// It handles the HTTP handshake, WebSocket lifecycle, and auto-reconnect.
+type SocketModeClient struct {
+	appToken   string
+	apiURL     string
+	httpClient *http.Client
+	log        *slog.Logger
+}
+
+// NewSocketModeClient creates a new Socket Mode client with the given app-level token.
+// The token must be an xapp-... app-level token (not a bot token).
+func NewSocketModeClient(appToken string) *SocketModeClient {
+	return &SocketModeClient{
+		appToken:   appToken,
+		apiURL:     slackAPIURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		log:        logging.WithComponent("slack.socketmode"),
+	}
+}
+
+// NewSocketModeClientWithBaseURL creates a Socket Mode client with a custom API base URL.
+// Used for testing with httptest.NewServer.
+func NewSocketModeClientWithBaseURL(appToken, baseURL string) *SocketModeClient {
+	return &SocketModeClient{
+		appToken:   appToken,
+		apiURL:     baseURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		log:        logging.WithComponent("slack.socketmode"),
+	}
+}
+
+// connectionsOpenResponse is the JSON response from apps.connections.open.
+type connectionsOpenResponse struct {
+	OK    bool   `json:"ok"`
+	URL   string `json:"url,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+// ErrAuthFailure indicates the app-level token was rejected by Slack.
+var ErrAuthFailure = fmt.Errorf("slack socket mode: authentication failed")
+
+// ErrConnectionOpen indicates a non-auth failure when opening a connection.
+var ErrConnectionOpen = fmt.Errorf("slack socket mode: failed to open connection")
+
+// OpenConnection calls apps.connections.open with the app-level token
+// and returns the WebSocket URL for event streaming.
+func (s *SocketModeClient) OpenConnection(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.apiURL+"/apps.connections.open", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Bearer "+s.appToken)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrConnectionOpen, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("%w: failed to read response: %w", ErrConnectionOpen, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%w: HTTP %d: %s", ErrConnectionOpen, resp.StatusCode, string(body))
+	}
+
+	var result connectionsOpenResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("%w: failed to parse response: %w", ErrConnectionOpen, err)
+	}
+
+	if !result.OK {
+		switch result.Error {
+		case "invalid_auth", "not_authed", "account_inactive", "token_revoked":
+			return "", fmt.Errorf("%w: %s", ErrAuthFailure, result.Error)
+		default:
+			return "", fmt.Errorf("%w: %s", ErrConnectionOpen, result.Error)
+		}
+	}
+
+	if result.URL == "" {
+		return "", fmt.Errorf("%w: empty WebSocket URL in response", ErrConnectionOpen)
+	}
+
+	return result.URL, nil
+}
+
+// Listen connects to Slack Socket Mode and emits parsed SocketEvents on the
+// returned channel. On connection error or disconnect envelope, it closes the
+// socket, calls OpenConnection for a fresh WSS URL, and reconnects with
+// exponential backoff (1s → 2s → 4s → max 30s). Backoff resets on successful
+// connection. Context cancellation stops the reconnect loop and closes the channel.
+func (s *SocketModeClient) Listen(ctx context.Context) (<-chan *SocketEvent, error) {
+	// Validate we can connect at least once before returning the channel.
+	wssURL, err := s.OpenConnection(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("initial connection: %w", err)
+	}
+
+	ch := make(chan *SocketEvent, 64)
+
+	go s.listenLoop(ctx, wssURL, ch)
+
+	return ch, nil
+}
+
+// listenLoop is the reconnect wrapper around readLoop. It runs until ctx is cancelled.
+func (s *SocketModeClient) listenLoop(ctx context.Context, wssURL string, ch chan<- *SocketEvent) {
+	defer close(ch)
+
+	backoff := initialBackoff
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		conn, _, err := websocket.DefaultDialer.DialContext(ctx, wssURL, nil)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			s.log.Warn("websocket dial failed, retrying",
+				slog.Any("error", err),
+				slog.Duration("backoff", backoff))
+
+			if !s.sleepWithContext(ctx, backoff) {
+				return
+			}
+			backoff = nextBackoff(backoff)
+
+			// Get fresh URL on dial failure.
+			newURL, openErr := s.OpenConnection(ctx)
+			if openErr != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				s.log.Warn("OpenConnection failed, retrying",
+					slog.Any("error", openErr),
+					slog.Duration("backoff", backoff))
+				if !s.sleepWithContext(ctx, backoff) {
+					return
+				}
+				backoff = nextBackoff(backoff)
+				continue
+			}
+			wssURL = newURL
+			continue
+		}
+
+		// Connected — reset backoff.
+		backoff = initialBackoff
+		s.log.Info("socket mode connected")
+
+		// readLoop blocks until the connection drops or ctx is cancelled.
+		s.readLoop(ctx, conn, ch)
+
+		// Connection ended — close it and prepare to reconnect.
+		_ = conn.Close()
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		s.log.Info("connection lost, reconnecting",
+			slog.Duration("backoff", backoff))
+
+		if !s.sleepWithContext(ctx, backoff) {
+			return
+		}
+		backoff = nextBackoff(backoff)
+
+		// Get fresh WSS URL for reconnect.
+		newURL, openErr := s.OpenConnection(ctx)
+		if openErr != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			s.log.Warn("OpenConnection failed during reconnect",
+				slog.Any("error", openErr),
+				slog.Duration("backoff", backoff))
+			if !s.sleepWithContext(ctx, backoff) {
+				return
+			}
+			backoff = nextBackoff(backoff)
+			continue
+		}
+		wssURL = newURL
+		backoff = initialBackoff // fresh URL obtained — reset backoff
+	}
+}
+
+// readLoop reads envelopes from the WebSocket, acknowledges them, and emits
+// parsed events. Returns when the connection drops or ctx is cancelled.
+func (s *SocketModeClient) readLoop(ctx context.Context, conn *websocket.Conn, ch chan<- *SocketEvent) {
+	// Close the connection when ctx is cancelled to unblock ReadMessage.
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+
+	for {
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err,
+				websocket.CloseNormalClosure,
+				websocket.CloseGoingAway) {
+				s.log.Warn("websocket read error", slog.Any("error", err))
+			}
+			return
+		}
+
+		envelopeID, envelopeType, evt, parseErr := parseEnvelope(data)
+		if parseErr != nil {
+			s.log.Error("failed to parse envelope", slog.Any("error", parseErr))
+			continue
+		}
+
+		// Acknowledge every envelope with an envelope_id.
+		if envelopeID != "" {
+			if ackErr := s.acknowledge(conn, envelopeID); ackErr != nil {
+				s.log.Error("failed to acknowledge envelope",
+					slog.String("envelope_id", envelopeID),
+					slog.Any("error", ackErr))
+			}
+		}
+
+		// Disconnect envelope → return to trigger reconnect.
+		if envelopeType == EnvelopeTypeDisconnect {
+			s.log.Info("disconnect envelope received, will reconnect")
+			return
+		}
+
+		// Emit non-nil events.
+		if evt != nil && !evt.IsBotMessage() {
+			select {
+			case ch <- evt:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// acknowledge sends an envelope acknowledgment back over the WebSocket.
+func (s *SocketModeClient) acknowledge(conn *websocket.Conn, envelopeID string) error {
+	ack := struct {
+		EnvelopeID string `json:"envelope_id"`
+	}{EnvelopeID: envelopeID}
+	data, err := json.Marshal(ack)
+	if err != nil {
+		return fmt.Errorf("marshal ack: %w", err)
+	}
+	return conn.WriteMessage(websocket.TextMessage, data)
+}
+
+// sleepWithContext waits for the given duration or until ctx is cancelled.
+// Returns true if the sleep completed, false if ctx was cancelled.
+func (s *SocketModeClient) sleepWithContext(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// nextBackoff doubles the backoff duration, capping at maxBackoff.
+func nextBackoff(current time.Duration) time.Duration {
+	next := current * backoffFactor
+	if next > maxBackoff {
+		return maxBackoff
+	}
+	return next
+}

--- a/internal/adapters/slack/socketmode_test.go
+++ b/internal/adapters/slack/socketmode_test.go
@@ -1,0 +1,590 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+	"github.com/gorilla/websocket"
+)
+
+func TestOpenConnection(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		response   string
+		wantURL    string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:       "successful connection returns WSS URL",
+			statusCode: http.StatusOK,
+			response:   `{"ok":true,"url":"wss://wss-primary.slack.com/link/?ticket=abc123"}`,
+			wantURL:    "wss://wss-primary.slack.com/link/?ticket=abc123",
+		},
+		{
+			name:       "invalid auth error",
+			statusCode: http.StatusOK,
+			response:   `{"ok":false,"error":"invalid_auth"}`,
+			wantErr:    true,
+			errContain: "authentication failed",
+		},
+		{
+			name:       "non-auth API error",
+			statusCode: http.StatusOK,
+			response:   `{"ok":false,"error":"too_many_websockets"}`,
+			wantErr:    true,
+			errContain: "too_many_websockets",
+		},
+		{
+			name:       "HTTP 500 error",
+			statusCode: http.StatusInternalServerError,
+			response:   `Internal Server Error`,
+			wantErr:    true,
+			errContain: "HTTP 500",
+		},
+		{
+			name:       "empty URL in response",
+			statusCode: http.StatusOK,
+			response:   `{"ok":true,"url":""}`,
+			wantErr:    true,
+			errContain: "empty WebSocket URL",
+		},
+		{
+			name:       "malformed JSON response",
+			statusCode: http.StatusOK,
+			response:   `{not json`,
+			wantErr:    true,
+			errContain: "failed to parse response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %s, want POST", r.Method)
+				}
+				if !strings.HasSuffix(r.URL.Path, "/apps.connections.open") {
+					t.Errorf("path = %s, want /apps.connections.open", r.URL.Path)
+				}
+				auth := r.Header.Get("Authorization")
+				if auth != "Bearer "+testutil.FakeSlackAppToken {
+					t.Errorf("auth = %q, want Bearer %s", auth, testutil.FakeSlackAppToken)
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, server.URL)
+			url, err := client.OpenConnection(context.Background())
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContain) {
+					t.Errorf("error = %q, want containing %q", err.Error(), tt.errContain)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if url != tt.wantURL {
+				t.Errorf("url = %q, want %q", url, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestOpenConnection_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	client := NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, "http://localhost:1")
+	_, err := client.OpenConnection(ctx)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+// TestListen_ReceivesEvents verifies that Listen connects, receives events,
+// and acknowledges envelopes.
+func TestListen_ReceivesEvents(t *testing.T) {
+	var wsConns sync.WaitGroup
+
+	// Mock apps.connections.open → returns WSS URL pointing at our mock WS server.
+	wsMux := http.NewServeMux()
+	upgrader := websocket.Upgrader{}
+
+	wsMux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Logf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		wsConns.Done()
+
+		// Send a message event.
+		env := socketEnvelope{
+			EnvelopeID: "e1",
+			Type:       EnvelopeTypeEventsAPI,
+			Payload: mustMarshal(eventsAPIPayload{
+				Type: "event_callback",
+				Event: mustMarshal(innerEvent{
+					Type:    EventTypeMessage,
+					Channel: "C123",
+					User:    "U456",
+					Text:    "hello pilot",
+					TS:      "1234567890.123456",
+				}),
+			}),
+		}
+		data, _ := json.Marshal(env)
+		if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+			return
+		}
+
+		// Read ack.
+		_, ackData, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		var ack struct {
+			EnvelopeID string `json:"envelope_id"`
+		}
+		if err := json.Unmarshal(ackData, &ack); err != nil {
+			t.Errorf("unmarshal ack: %v", err)
+			return
+		}
+		if ack.EnvelopeID != "e1" {
+			t.Errorf("ack envelope_id = %q, want %q", ack.EnvelopeID, "e1")
+		}
+
+		// Keep connection alive until test completes.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	wsServer := httptest.NewServer(wsMux)
+	defer wsServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http") + "/ws"
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := connectionsOpenResponse{OK: true, URL: wsURL}
+		data, _ := json.Marshal(resp)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	}))
+	defer apiServer.Close()
+
+	wsConns.Add(1) // expect one connection
+
+	client := NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, apiServer.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	wsConns.Wait() // wait for WS connection
+
+	select {
+	case evt := <-ch:
+		if evt == nil {
+			t.Fatal("received nil event")
+		}
+		if evt.Type != EventTypeMessage {
+			t.Errorf("event type = %q, want %q", evt.Type, EventTypeMessage)
+		}
+		if evt.Text != "hello pilot" {
+			t.Errorf("event text = %q, want %q", evt.Text, "hello pilot")
+		}
+		if evt.ChannelID != "C123" {
+			t.Errorf("channel = %q, want %q", evt.ChannelID, "C123")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+// TestListen_ReconnectsOnDisconnect verifies the reconnect logic when
+// a disconnect envelope is received.
+func TestListen_ReconnectsOnDisconnect(t *testing.T) {
+	var connectCount atomic.Int32
+
+	upgrader := websocket.Upgrader{}
+
+	wsMux := http.NewServeMux()
+	wsMux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		n := connectCount.Add(1)
+
+		if n == 1 {
+			// First connection: send disconnect envelope.
+			env := socketEnvelope{
+				EnvelopeID: "disc-1",
+				Type:       EnvelopeTypeDisconnect,
+				Reason:     "link_disabled",
+			}
+			data, _ := json.Marshal(env)
+			_ = conn.WriteMessage(websocket.TextMessage, data)
+			// Read ack, then connection will close.
+			_, _, _ = conn.ReadMessage()
+			return
+		}
+
+		// Second connection: send a real event.
+		env := socketEnvelope{
+			EnvelopeID: "e2",
+			Type:       EnvelopeTypeEventsAPI,
+			Payload: mustMarshal(eventsAPIPayload{
+				Type: "event_callback",
+				Event: mustMarshal(innerEvent{
+					Type:    EventTypeMessage,
+					Channel: "C999",
+					User:    "U111",
+					Text:    "reconnected",
+					TS:      "9999999999.999999",
+				}),
+			}),
+		}
+		data, _ := json.Marshal(env)
+		_ = conn.WriteMessage(websocket.TextMessage, data)
+		// Keep alive.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	wsServer := httptest.NewServer(wsMux)
+	defer wsServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http") + "/ws"
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := connectionsOpenResponse{OK: true, URL: wsURL}
+		data, _ := json.Marshal(resp)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	}))
+	defer apiServer.Close()
+
+	client := NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, apiServer.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	// Should receive the event from the second connection.
+	select {
+	case evt := <-ch:
+		if evt == nil {
+			t.Fatal("received nil event")
+		}
+		if evt.Text != "reconnected" {
+			t.Errorf("text = %q, want %q", evt.Text, "reconnected")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for reconnected event")
+	}
+
+	got := int(connectCount.Load())
+	if got < 2 {
+		t.Errorf("connect count = %d, want >= 2", got)
+	}
+}
+
+// TestListen_ReconnectsOnConnectionError verifies reconnect when the
+// WebSocket connection drops unexpectedly.
+func TestListen_ReconnectsOnConnectionError(t *testing.T) {
+	var connectCount atomic.Int32
+
+	upgrader := websocket.Upgrader{}
+
+	wsMux := http.NewServeMux()
+	wsMux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+
+		n := connectCount.Add(1)
+
+		if n == 1 {
+			// First connection: close immediately to simulate error.
+			conn.Close()
+			return
+		}
+
+		defer conn.Close()
+
+		// Second connection: send event.
+		env := socketEnvelope{
+			EnvelopeID: "e3",
+			Type:       EnvelopeTypeEventsAPI,
+			Payload: mustMarshal(eventsAPIPayload{
+				Type: "event_callback",
+				Event: mustMarshal(innerEvent{
+					Type:    EventTypeMessage,
+					Channel: "C777",
+					User:    "U222",
+					Text:    "after error",
+					TS:      "8888888888.888888",
+				}),
+			}),
+		}
+		data, _ := json.Marshal(env)
+		_ = conn.WriteMessage(websocket.TextMessage, data)
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	wsServer := httptest.NewServer(wsMux)
+	defer wsServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http") + "/ws"
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := connectionsOpenResponse{OK: true, URL: wsURL}
+		data, _ := json.Marshal(resp)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	}))
+	defer apiServer.Close()
+
+	client := NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, apiServer.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	select {
+	case evt := <-ch:
+		if evt == nil {
+			t.Fatal("received nil event")
+		}
+		if evt.Text != "after error" {
+			t.Errorf("text = %q, want %q", evt.Text, "after error")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for event after reconnect")
+	}
+}
+
+// TestListen_ContextCancellationStopsReconnect verifies that cancelling
+// the context stops the reconnect loop and closes the channel.
+func TestListen_ContextCancellationStopsReconnect(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+
+	wsMux := http.NewServeMux()
+	wsMux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Keep reading until closed.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	wsServer := httptest.NewServer(wsMux)
+	defer wsServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http") + "/ws"
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := connectionsOpenResponse{OK: true, URL: wsURL}
+		data, _ := json.Marshal(resp)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	}))
+	defer apiServer.Close()
+
+	client := NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, apiServer.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ch, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	// Give time for connection to establish.
+	time.Sleep(100 * time.Millisecond)
+
+	// Cancel context.
+	cancel()
+
+	// Channel should close.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			// Might get a stale event; drain and check again.
+			for range ch {
+			}
+		}
+		// Channel closed — success.
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for channel close after context cancel")
+	}
+}
+
+// TestListen_BotMessagesFiltered verifies that bot messages are not emitted.
+func TestListen_BotMessagesFiltered(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+
+	wsMux := http.NewServeMux()
+	wsMux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		// Send a bot message (should be filtered).
+		botEnv := socketEnvelope{
+			EnvelopeID: "bot-1",
+			Type:       EnvelopeTypeEventsAPI,
+			Payload: mustMarshal(eventsAPIPayload{
+				Type: "event_callback",
+				Event: mustMarshal(innerEvent{
+					Type:    EventTypeMessage,
+					Channel: "C123",
+					User:    "U000",
+					Text:    "bot says hi",
+					TS:      "1111111111.111111",
+					BotID:   "B999",
+				}),
+			}),
+		}
+		data, _ := json.Marshal(botEnv)
+		_ = conn.WriteMessage(websocket.TextMessage, data)
+		_, _, _ = conn.ReadMessage() // ack
+
+		// Send a human message (should pass through).
+		humanEnv := socketEnvelope{
+			EnvelopeID: "human-1",
+			Type:       EnvelopeTypeEventsAPI,
+			Payload: mustMarshal(eventsAPIPayload{
+				Type: "event_callback",
+				Event: mustMarshal(innerEvent{
+					Type:    EventTypeMessage,
+					Channel: "C123",
+					User:    "U456",
+					Text:    "human says hi",
+					TS:      "2222222222.222222",
+				}),
+			}),
+		}
+		data, _ = json.Marshal(humanEnv)
+		_ = conn.WriteMessage(websocket.TextMessage, data)
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	wsServer := httptest.NewServer(wsMux)
+	defer wsServer.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsServer.URL, "http") + "/ws"
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := connectionsOpenResponse{OK: true, URL: wsURL}
+		data, _ := json.Marshal(resp)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	}))
+	defer apiServer.Close()
+
+	client := NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, apiServer.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	select {
+	case evt := <-ch:
+		if evt == nil {
+			t.Fatal("received nil event")
+		}
+		// Should be the human message, bot message was filtered.
+		if evt.Text != "human says hi" {
+			t.Errorf("text = %q, want %q", evt.Text, "human says hi")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func TestNextBackoff(t *testing.T) {
+	tests := []struct {
+		current time.Duration
+		want    time.Duration
+	}{
+		{1 * time.Second, 2 * time.Second},
+		{2 * time.Second, 4 * time.Second},
+		{4 * time.Second, 8 * time.Second},
+		{8 * time.Second, 16 * time.Second},
+		{16 * time.Second, 30 * time.Second}, // capped at max
+		{30 * time.Second, 30 * time.Second}, // stays at max
+	}
+
+	for _, tt := range tests {
+		got := nextBackoff(tt.current)
+		if got != tt.want {
+			t.Errorf("nextBackoff(%v) = %v, want %v", tt.current, got, tt.want)
+		}
+	}
+}
+
+// mustMarshal is a test helper that marshals v to json.RawMessage.
+func mustMarshal(v interface{}) json.RawMessage {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-675.

## Changes

on connection error or `disconnect` envelope, close socket, call `OpenConnection` for fresh WSS URL, reconnect. Exponential backoff (1s → 2s → 4s → max 30s), reset on successful connection. Context cancellation stops reconnect loop. ~60 LoC.