### PR TITLE
Add validation for Socket Mode config

### DIFF
--- a/internal/adapters/slack/socket_mode.go
+++ b/internal/adapters/slack/socket_mode.go
@@ -21,9 +21,9 @@ const (
 	SocketEventDisconnect  SocketEventType = "disconnect"
 )
 
-// SocketEvent is emitted on the events channel for each envelope received
+// SocketModeEvent is emitted on the events channel for each envelope received
 // from the Slack Socket Mode WebSocket connection.
-type SocketEvent struct {
+type SocketModeEvent struct {
 	Type       SocketEventType
 	EnvelopeID string
 	Payload    json.RawMessage // raw inner payload for caller to decode
@@ -44,10 +44,10 @@ type envelopeAck struct {
 }
 
 // SocketModeHandler manages a Slack Socket Mode WebSocket connection.
-// It reads envelopes, acknowledges them, and emits SocketEvents on a channel.
+// It reads envelopes, acknowledges them, and emits SocketModeEvents on a channel.
 type SocketModeHandler struct {
 	conn   *websocket.Conn
-	events chan SocketEvent
+	events chan SocketModeEvent
 	done   chan struct{}
 	once   sync.Once
 	log    *slog.Logger
@@ -61,8 +61,8 @@ type SocketModeHandler struct {
 // NewSocketModeHandler wraps an established WebSocket connection and returns
 // the handler plus the channel that will receive parsed events.
 // Call Run() to start the read loop.
-func NewSocketModeHandler(conn *websocket.Conn) (*SocketModeHandler, <-chan SocketEvent) {
-	ch := make(chan SocketEvent, 64)
+func NewSocketModeHandler(conn *websocket.Conn) (*SocketModeHandler, <-chan SocketModeEvent) {
+	ch := make(chan SocketModeEvent, 64)
 	h := &SocketModeHandler{
 		conn:         conn,
 		events:       ch,
@@ -187,7 +187,7 @@ func (h *SocketModeHandler) handleRawMessage(data []byte) {
 		}
 		h.log.Info("disconnect envelope received", slog.String("reason", reason))
 
-		h.emit(SocketEvent{
+		h.emit(SocketModeEvent{
 			Type:       SocketEventDisconnect,
 			EnvelopeID: env.EnvelopeID,
 			Payload:    data, // full envelope so caller can inspect reason
@@ -203,7 +203,7 @@ func (h *SocketModeHandler) handleRawMessage(data []byte) {
 		return
 	}
 
-	h.emit(SocketEvent{
+	h.emit(SocketModeEvent{
 		Type:       evtType,
 		EnvelopeID: env.EnvelopeID,
 		Payload:    env.Payload,
@@ -219,7 +219,7 @@ func (h *SocketModeHandler) acknowledge(envelopeID string) error {
 	return h.conn.WriteMessage(websocket.TextMessage, data)
 }
 
-func (h *SocketModeHandler) emit(evt SocketEvent) {
+func (h *SocketModeHandler) emit(evt SocketModeEvent) {
 	select {
 	case h.events <- evt:
 	default:

--- a/internal/adapters/slack/socketmode_test.go
+++ b/internal/adapters/slack/socketmode_test.go
@@ -166,16 +166,4 @@ func TestNewSocketModeClient(t *testing.T) {
 	}
 }
 
-// contains checks if s contains substr (avoids importing strings for one use).
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}
+// contains and searchString are defined in events_test.go

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -172,6 +172,9 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 	if cfg.Adapters.Slack != nil && cfg.Adapters.Slack.Enabled {
 		p.slackNotify = slack.NewNotifier(cfg.Adapters.Slack)
 
+		// Validate Socket Mode configuration (warns + disables if app_token missing)
+		cfg.Adapters.Slack.ValidateSocketMode()
+
 		// Initialize Slack approval handler if enabled
 		if cfg.Adapters.Slack.Approval != nil && cfg.Adapters.Slack.Approval.Enabled {
 			p.slackClient = slack.NewClient(cfg.Adapters.Slack.BotToken)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-685.

## Changes

When `SocketMode` is true but `AppToken` is empty, log a warning and disable Slack Socket Mode startup (don't crash). Place validation in the startup path where Slack gets initialized.