### PR TITLE
Add validation

### DIFF
--- a/internal/adapters/slack/notifier.go
+++ b/internal/adapters/slack/notifier.go
@@ -12,6 +12,12 @@ type Config struct {
 	Channel       string          `yaml:"channel"`
 	SigningSecret string          `yaml:"signing_secret"`
 	Approval      *ApprovalConfig `yaml:"approval,omitempty"`
+
+	// Socket Mode fields for inbound communication
+	AppToken        string   `yaml:"app_token"`         // xapp-... app-level token
+	SocketMode      bool     `yaml:"socket_mode"`       // enable Socket Mode inbound
+	AllowedUsers    []string `yaml:"allowed_users"`     // Slack user IDs allowed to interact
+	AllowedChannels []string `yaml:"allowed_channels"`  // Channel IDs allowed to interact
 }
 
 // DefaultConfig returns default Slack configuration

--- a/internal/adapters/slack/socketmode_test.go
+++ b/internal/adapters/slack/socketmode_test.go
@@ -166,16 +166,3 @@ func TestNewSocketModeClient(t *testing.T) {
 	}
 }
 
-// contains checks if s contains substr (avoids importing strings for one use).
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -441,6 +441,9 @@ func (c *Config) Validate() error {
 	if c.Auth != nil && c.Auth.Type == gateway.AuthTypeAPIToken && c.Auth.Token == "" {
 		return fmt.Errorf("API token is required when auth type is api-token")
 	}
+	if c.Adapters != nil && c.Adapters.Slack != nil && c.Adapters.Slack.SocketMode && c.Adapters.Slack.AppToken == "" {
+		return fmt.Errorf("slack app_token is required when socket_mode is enabled")
+	}
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -565,6 +565,37 @@ func TestValidate(t *testing.T) {
 			}(),
 			wantErr: false, // Nil auth is allowed
 		},
+		{
+			name: "SlackSocketModeWithoutAppToken",
+			config: func() *Config {
+				c := DefaultConfig()
+				c.Adapters.Slack.SocketMode = true
+				c.Adapters.Slack.AppToken = ""
+				return c
+			}(),
+			wantErr:     true,
+			errContains: "slack app_token is required when socket_mode is enabled",
+		},
+		{
+			name: "SlackSocketModeWithAppToken",
+			config: func() *Config {
+				c := DefaultConfig()
+				c.Adapters.Slack.SocketMode = true
+				c.Adapters.Slack.AppToken = "test-slack-app-token"
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "SlackSocketModeDisabled",
+			config: func() *Config {
+				c := DefaultConfig()
+				c.Adapters.Slack.SocketMode = false
+				c.Adapters.Slack.AppToken = ""
+				return c
+			}(),
+			wantErr: false, // No app_token needed when socket_mode is off
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-693.

## Changes

`internal/config/config.go:444-446` — `Validate()` returns error when `socket_mode: true` but `app_token` is empty