### PR TITLE
Implement Socket Mode connection and WebSocket listener

### DIFF
--- a/internal/adapters/slack/socketmode.go
+++ b/internal/adapters/slack/socketmode.go
@@ -5,16 +5,42 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+	"github.com/gorilla/websocket"
+)
+
+// wsDialer abstracts WebSocket dialing for testing.
+type wsDialer interface {
+	DialContext(ctx context.Context, url string) (*websocket.Conn, error)
+}
+
+// defaultDialer uses gorilla/websocket's default dialer.
+type defaultDialer struct{}
+
+func (d defaultDialer) DialContext(ctx context.Context, url string) (*websocket.Conn, error) {
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, url, nil)
+	return conn, err
+}
+
+// reconnectBackoff controls delays between reconnection attempts.
+const (
+	initialReconnectDelay = 1 * time.Second
+	maxReconnectDelay     = 30 * time.Second
 )
 
 // SocketModeClient connects to Slack's Socket Mode API using an app-level token.
-// It handles the initial HTTP handshake to obtain a WebSocket URL.
+// It handles the initial HTTP handshake to obtain a WebSocket URL, and provides
+// Listen() for a full event loop with automatic reconnection.
 type SocketModeClient struct {
 	appToken   string
 	apiURL     string
 	httpClient *http.Client
+	dialer     wsDialer
+	log        *slog.Logger
 }
 
 // NewSocketModeClient creates a new Socket Mode client with the given app-level token.
@@ -24,6 +50,8 @@ func NewSocketModeClient(appToken string) *SocketModeClient {
 		appToken:   appToken,
 		apiURL:     slackAPIURL,
 		httpClient: &http.Client{Timeout: 30 * time.Second},
+		dialer:     defaultDialer{},
+		log:        logging.WithComponent("slack.socketmode"),
 	}
 }
 
@@ -34,6 +62,8 @@ func NewSocketModeClientWithBaseURL(appToken, baseURL string) *SocketModeClient 
 		appToken:   appToken,
 		apiURL:     baseURL,
 		httpClient: &http.Client{Timeout: 30 * time.Second},
+		dialer:     defaultDialer{},
+		log:        logging.WithComponent("slack.socketmode"),
 	}
 }
 
@@ -96,4 +126,153 @@ func (s *SocketModeClient) OpenConnection(ctx context.Context) (string, error) {
 	}
 
 	return result.URL, nil
+}
+
+// Listen connects to Slack's Socket Mode WebSocket and emits parsed SocketEvents.
+// It automatically reconnects when the server sends a disconnect envelope or the
+// connection drops unexpectedly. Listen blocks until ctx is cancelled.
+//
+// The returned channel is closed when ctx is cancelled and all reconnect attempts
+// have stopped. Callers should range over the channel:
+//
+//	events, err := client.Listen(ctx)
+//	for evt := range events {
+//	    // handle evt
+//	}
+func (s *SocketModeClient) Listen(ctx context.Context) (<-chan SocketEvent, error) {
+	// Validate by establishing the first connection before returning.
+	wssURL, err := s.OpenConnection(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("initial connection: %w", err)
+	}
+
+	out := make(chan SocketEvent, 64)
+
+	go s.listenLoop(ctx, wssURL, out)
+
+	return out, nil
+}
+
+// listenLoop runs the connect → read → reconnect cycle until ctx is cancelled.
+func (s *SocketModeClient) listenLoop(ctx context.Context, initialURL string, out chan<- SocketEvent) {
+	defer close(out)
+
+	wssURL := initialURL
+	delay := initialReconnectDelay
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		reconnect := s.runConnection(ctx, wssURL, out)
+		if !reconnect || ctx.Err() != nil {
+			return
+		}
+
+		// Back off before reconnecting.
+		s.log.Info("reconnecting to Socket Mode",
+			slog.Duration("delay", delay))
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+
+		// Get a fresh WSS URL for each reconnection.
+		newURL, err := s.OpenConnection(ctx)
+		if err != nil {
+			s.log.Error("failed to get new WSS URL for reconnect",
+				slog.Any("error", err))
+			// Exponential backoff on handshake failure.
+			delay = min(delay*2, maxReconnectDelay)
+			continue
+		}
+
+		wssURL = newURL
+		delay = initialReconnectDelay // reset on successful handshake
+	}
+}
+
+// runConnection dials the WSS URL, creates a SocketModeHandler, and forwards
+// parsed SocketEvents to the output channel. Returns true if the caller should
+// reconnect (disconnect envelope or unexpected close), false on clean shutdown.
+func (s *SocketModeClient) runConnection(ctx context.Context, wssURL string, out chan<- SocketEvent) (reconnect bool) {
+	conn, err := s.dialer.DialContext(ctx, wssURL)
+	if err != nil {
+		if ctx.Err() != nil {
+			return false
+		}
+		s.log.Error("failed to dial WebSocket",
+			slog.String("url", wssURL),
+			slog.Any("error", err))
+		return true // retry
+	}
+
+	handler, rawEvents := NewSocketModeHandler(conn)
+
+	// Run handler in background — it will close rawEvents when done.
+	go handler.Run()
+
+	// Forward events until handler closes the channel or ctx is cancelled.
+	shouldReconnect := false
+	for {
+		select {
+		case <-ctx.Done():
+			handler.Close()
+			// Drain remaining events.
+			for range rawEvents {
+			}
+			return false
+
+		case raw, ok := <-rawEvents:
+			if !ok {
+				// Handler closed — connection dropped or server closed.
+				return shouldReconnect || true
+			}
+
+			// Disconnect signals reconnect.
+			if raw.Type == SocketEventDisconnect {
+				s.log.Info("disconnect received, will reconnect",
+					slog.String("envelope_id", raw.EnvelopeID))
+				shouldReconnect = true
+				continue
+			}
+
+			// Parse the raw payload into a high-level SocketEvent.
+			// The raw.Payload for events_api type contains the inner event payload.
+			evt, err := s.parseRawEvent(raw)
+			if err != nil {
+				s.log.Warn("failed to parse raw event",
+					slog.String("type", string(raw.Type)),
+					slog.Any("error", err))
+				continue
+			}
+			if evt == nil {
+				continue // non-event envelope (hello, unknown inner type, etc.)
+			}
+
+			select {
+			case out <- *evt:
+			case <-ctx.Done():
+				handler.Close()
+				for range rawEvents {
+				}
+				return false
+			}
+		}
+	}
+}
+
+// parseRawEvent converts a RawSocketEvent into a SocketEvent.
+// Only events_api envelopes produce SocketEvents; other types return nil.
+func (s *SocketModeClient) parseRawEvent(raw RawSocketEvent) (*SocketEvent, error) {
+	if raw.Type != SocketEventMessage {
+		// Interactive, slash_commands, etc. — not yet mapped to SocketEvent.
+		return nil, nil
+	}
+
+	// raw.Payload is the events_api payload (already unwrapped from envelope by handler).
+	return parseEventsAPIPayload(raw.Payload)
 }

--- a/internal/adapters/slack/socketmode_test.go
+++ b/internal/adapters/slack/socketmode_test.go
@@ -2,12 +2,19 @@ package slack
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/alekspetrov/pilot/internal/testutil"
+	"github.com/gorilla/websocket"
 )
 
 func TestOpenConnection(t *testing.T) {
@@ -167,3 +174,513 @@ func TestNewSocketModeClient(t *testing.T) {
 }
 
 // contains and searchString helpers are in events_test.go
+
+// --- Listen tests ---
+
+// setupListenTestServer creates a mock HTTP API server that returns a WS URL,
+// and a mock WebSocket server that accepts connections and invokes onConn.
+// Returns the SocketModeClient configured to use these servers.
+func setupListenTestServer(t *testing.T, onConn func(conn *websocket.Conn)) *SocketModeClient {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		onConn(conn)
+	}))
+	t.Cleanup(wsSrv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(wsSrv.URL, "http")
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := fmt.Sprintf(`{"ok":true,"url":%q}`, wsURL)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}))
+	t.Cleanup(apiSrv.Close)
+
+	return NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, apiSrv.URL)
+}
+
+func TestListen_ReceivesMessageEvents(t *testing.T) {
+	client := setupListenTestServer(t, func(conn *websocket.Conn) {
+		defer func() { _ = conn.Close() }()
+
+		// Send a message event.
+		env := map[string]interface{}{
+			"envelope_id": "listen-msg-001",
+			"type":        "events_api",
+			"payload": map[string]interface{}{
+				"token":   "t",
+				"team_id": "T1",
+				"type":    "event_callback",
+				"event": map[string]interface{}{
+					"type":    "message",
+					"channel": "C123",
+					"user":    "U456",
+					"text":    "hello from listen",
+					"ts":      "1.1",
+				},
+			},
+		}
+		data, _ := json.Marshal(env)
+		_ = conn.WriteMessage(websocket.TextMessage, data)
+
+		// Read ack.
+		_, _, _ = conn.ReadMessage()
+
+		// Keep connection open briefly for event to be forwarded.
+		time.Sleep(100 * time.Millisecond)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	select {
+	case evt, ok := <-events:
+		if !ok {
+			t.Fatal("events channel closed before receiving event")
+		}
+		if evt.Type != EventTypeMessage {
+			t.Errorf("event type = %q, want %q", evt.Type, EventTypeMessage)
+		}
+		if evt.ChannelID != "C123" {
+			t.Errorf("channel = %q, want %q", evt.ChannelID, "C123")
+		}
+		if evt.Text != "hello from listen" {
+			t.Errorf("text = %q, want %q", evt.Text, "hello from listen")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+
+	cancel()
+	// Channel should close after cancel.
+	for range events {
+	}
+}
+
+func TestListen_AppMentionStripsBot(t *testing.T) {
+	client := setupListenTestServer(t, func(conn *websocket.Conn) {
+		defer func() { _ = conn.Close() }()
+
+		env := map[string]interface{}{
+			"envelope_id": "listen-mention-001",
+			"type":        "events_api",
+			"payload": map[string]interface{}{
+				"token":   "t",
+				"team_id": "T1",
+				"type":    "event_callback",
+				"event": map[string]interface{}{
+					"type":    "app_mention",
+					"channel": "C123",
+					"user":    "U456",
+					"text":    "<@UBOT99> deploy prod",
+					"ts":      "2.2",
+				},
+			},
+		}
+		data, _ := json.Marshal(env)
+		_ = conn.WriteMessage(websocket.TextMessage, data)
+		_, _, _ = conn.ReadMessage() // ack
+		time.Sleep(100 * time.Millisecond)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	select {
+	case evt := <-events:
+		if evt.Text != "deploy prod" {
+			t.Errorf("text = %q, want %q (bot mention should be stripped)", evt.Text, "deploy prod")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+
+	cancel()
+	for range events {
+	}
+}
+
+func TestListen_DisconnectTriggersReconnect(t *testing.T) {
+	var connCount atomic.Int32
+
+	upgrader := websocket.Upgrader{}
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		n := connCount.Add(1)
+
+		if n == 1 {
+			// First connection: send disconnect.
+			env := map[string]interface{}{
+				"envelope_id": "disc-001",
+				"type":        "disconnect",
+				"reason":      "link_disabled",
+			}
+			data, _ := json.Marshal(env)
+			_ = conn.WriteMessage(websocket.TextMessage, data)
+			// Read ack.
+			_, _, _ = conn.ReadMessage()
+			return
+		}
+
+		// Second connection: send a message then stay alive.
+		env := map[string]interface{}{
+			"envelope_id": "reconnect-msg-001",
+			"type":        "events_api",
+			"payload": map[string]interface{}{
+				"token":   "t",
+				"team_id": "T1",
+				"type":    "event_callback",
+				"event": map[string]interface{}{
+					"type":    "message",
+					"channel": "C999",
+					"user":    "U111",
+					"text":    "after reconnect",
+					"ts":      "3.3",
+				},
+			},
+		}
+		data, _ := json.Marshal(env)
+		_ = conn.WriteMessage(websocket.TextMessage, data)
+		_, _, _ = conn.ReadMessage() // ack
+		// Keep alive long enough for event to be forwarded.
+		time.Sleep(500 * time.Millisecond)
+	}))
+	defer wsSrv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsSrv.URL, "http")
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := fmt.Sprintf(`{"ok":true,"url":%q}`, wsURL)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer apiSrv.Close()
+
+	client := NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, apiSrv.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	events, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	// Should receive the message from the second connection.
+	select {
+	case evt := <-events:
+		if evt.Text != "after reconnect" {
+			t.Errorf("text = %q, want %q", evt.Text, "after reconnect")
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("timed out waiting for event after reconnect")
+	}
+
+	if got := connCount.Load(); got < 2 {
+		t.Errorf("expected at least 2 connections (reconnect), got %d", got)
+	}
+
+	cancel()
+	for range events {
+	}
+}
+
+func TestListen_AuthFailure(t *testing.T) {
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_auth"}`))
+	}))
+	defer apiSrv.Close()
+
+	client := NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, apiSrv.URL)
+
+	_, err := client.Listen(context.Background())
+	if err == nil {
+		t.Fatal("expected error for auth failure")
+	}
+	if !errors.Is(err, ErrAuthFailure) {
+		t.Errorf("expected ErrAuthFailure, got: %v", err)
+	}
+}
+
+func TestListen_ContextCancelClosesChannel(t *testing.T) {
+	client := setupListenTestServer(t, func(conn *websocket.Conn) {
+		defer func() { _ = conn.Close() }()
+		// Keep connection alive until test cancels.
+		for {
+			_, _, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	events, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	// Cancel immediately.
+	cancel()
+
+	// Channel should close.
+	select {
+	case _, ok := <-events:
+		if ok {
+			// Might get a straggler event; drain and check again.
+			for range events {
+			}
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for events channel to close")
+	}
+}
+
+func TestListen_MultipleEvents(t *testing.T) {
+	client := setupListenTestServer(t, func(conn *websocket.Conn) {
+		defer func() { _ = conn.Close() }()
+
+		for i := 0; i < 3; i++ {
+			env := map[string]interface{}{
+				"envelope_id": fmt.Sprintf("multi-%d", i),
+				"type":        "events_api",
+				"payload": map[string]interface{}{
+					"token":   "t",
+					"team_id": "T1",
+					"type":    "event_callback",
+					"event": map[string]interface{}{
+						"type":    "message",
+						"channel": "C123",
+						"user":    "U456",
+						"text":    fmt.Sprintf("msg-%d", i),
+						"ts":      fmt.Sprintf("%d.%d", i, i),
+					},
+				},
+			}
+			data, _ := json.Marshal(env)
+			_ = conn.WriteMessage(websocket.TextMessage, data)
+			_, _, _ = conn.ReadMessage() // ack
+		}
+		time.Sleep(200 * time.Millisecond)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	var received []string
+	for i := 0; i < 3; i++ {
+		select {
+		case evt := <-events:
+			received = append(received, evt.Text)
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timed out waiting for event %d", i)
+		}
+	}
+
+	for i, want := range []string{"msg-0", "msg-1", "msg-2"} {
+		if received[i] != want {
+			t.Errorf("event[%d].Text = %q, want %q", i, received[i], want)
+		}
+	}
+
+	cancel()
+	for range events {
+	}
+}
+
+func TestListen_SkipsNonEventsAPITypes(t *testing.T) {
+	client := setupListenTestServer(t, func(conn *websocket.Conn) {
+		defer func() { _ = conn.Close() }()
+
+		// Send interactive envelope — should be skipped (not mapped to SocketEvent).
+		interactive := map[string]interface{}{
+			"envelope_id": "int-001",
+			"type":        "interactive",
+			"payload":     map[string]interface{}{"type": "block_actions"},
+		}
+		data, _ := json.Marshal(interactive)
+		_ = conn.WriteMessage(websocket.TextMessage, data)
+		_, _, _ = conn.ReadMessage() // ack
+
+		// Then send a real message event.
+		msg := map[string]interface{}{
+			"envelope_id": "msg-001",
+			"type":        "events_api",
+			"payload": map[string]interface{}{
+				"token":   "t",
+				"team_id": "T1",
+				"type":    "event_callback",
+				"event": map[string]interface{}{
+					"type":    "message",
+					"channel": "C123",
+					"user":    "U456",
+					"text":    "the real message",
+					"ts":      "5.5",
+				},
+			},
+		}
+		data, _ = json.Marshal(msg)
+		_ = conn.WriteMessage(websocket.TextMessage, data)
+		_, _, _ = conn.ReadMessage() // ack
+		time.Sleep(200 * time.Millisecond)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	// Should only receive the message event, not the interactive one.
+	select {
+	case evt := <-events:
+		if evt.Text != "the real message" {
+			t.Errorf("text = %q, want %q", evt.Text, "the real message")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+
+	cancel()
+	for range events {
+	}
+}
+
+func TestParseRawEvent_NonEventsAPI(t *testing.T) {
+	client := NewSocketModeClient(testutil.FakeSlackAppToken)
+
+	tests := []struct {
+		name    string
+		rawType SocketEventType
+	}{
+		{"interactive", SocketEventInteraction},
+		{"slash_commands", SocketEventSlashCmd},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evt, err := client.parseRawEvent(RawSocketEvent{
+				Type:       tt.rawType,
+				EnvelopeID: "test-001",
+				Payload:    json.RawMessage(`{}`),
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if evt != nil {
+				t.Errorf("expected nil event for %s type, got %+v", tt.rawType, evt)
+			}
+		})
+	}
+}
+
+func TestListen_ServerDropReconnects(t *testing.T) {
+	var connCount atomic.Int32
+	var mu sync.Mutex
+	var conns []*websocket.Conn
+
+	upgrader := websocket.Upgrader{}
+	wsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+
+		mu.Lock()
+		conns = append(conns, conn)
+		mu.Unlock()
+
+		n := connCount.Add(1)
+
+		if n == 1 {
+			// First connection: close abruptly.
+			_ = conn.Close()
+			return
+		}
+
+		// Second connection: send message.
+		env := map[string]interface{}{
+			"envelope_id": "drop-msg-001",
+			"type":        "events_api",
+			"payload": map[string]interface{}{
+				"token":   "t",
+				"team_id": "T1",
+				"type":    "event_callback",
+				"event": map[string]interface{}{
+					"type":    "message",
+					"channel": "C123",
+					"user":    "U456",
+					"text":    "after drop",
+					"ts":      "7.7",
+				},
+			},
+		}
+		data, _ := json.Marshal(env)
+		_ = conn.WriteMessage(websocket.TextMessage, data)
+		_, _, _ = conn.ReadMessage() // ack
+		time.Sleep(500 * time.Millisecond)
+		_ = conn.Close()
+	}))
+	defer wsSrv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(wsSrv.URL, "http")
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := fmt.Sprintf(`{"ok":true,"url":%q}`, wsURL)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer apiSrv.Close()
+
+	client := NewSocketModeClientWithBaseURL(testutil.FakeSlackAppToken, apiSrv.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	events, err := client.Listen(ctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	select {
+	case evt := <-events:
+		if evt.Text != "after drop" {
+			t.Errorf("text = %q, want %q", evt.Text, "after drop")
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("timed out waiting for event after server drop")
+	}
+
+	cancel()
+	for range events {
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-705.

## Changes

GitHub Issue #705: Implement Socket Mode connection and WebSocket listener

Parent: GH-642

Create `internal/adapters/slack/socketmode.go` with `SocketModeClient` struct holding `appToken` and `httpClient`. Implement `OpenConnection(ctx)` to POST `apps.connections.open` and return the WSS URL. Implement `Listen(ctx)` to dial the WSS URL, read JSON envelopes in a goroutine loop, parse them using the types from subtask 1, acknowledge each envelope by writing `{"envelope_id":"..."}` back, and emit `SocketEvent`s on a channel. Handle `disconnect` envelope type by triggering reconnect.