### PR TITLE
feat(executor): LLM complexity classifier replacing word-count heuristic

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1938,6 +1938,19 @@ func resolveGitHubMemberID(issue *github.Issue) string {
 	return memberID
 }
 
+// extractGitHubLabelNames returns label name strings from a GitHub issue (GH-727).
+// Used to flow labels into executor.Task for decomposition/complexity decisions.
+func extractGitHubLabelNames(issue *github.Issue) []string {
+	if issue == nil || len(issue.Labels) == 0 {
+		return nil
+	}
+	names := make([]string, len(issue.Labels))
+	for i, l := range issue.Labels {
+		names[i] = l.Name
+	}
+	return names
+}
+
 func handleGitHubIssue(ctx context.Context, cfg *config.Config, client *github.Client, issue *github.Issue, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner) error {
 	sourceRepo := cfg.Adapters.GitHub.Repo
 
@@ -1976,6 +1989,7 @@ func handleGitHubIssue(ctx context.Context, cfg *config.Config, client *github.C
 		CreatePR:    true,
 		SourceRepo:  sourceRepo,
 		MemberID:    resolveGitHubMemberID(issue), // GH-634: RBAC lookup
+		Labels:      extractGitHubLabelNames(issue),  // GH-727: flow labels for complexity classifier
 	}
 
 	var result *executor.ExecutionResult
@@ -2293,6 +2307,7 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 		CreatePR:    true,
 		SourceRepo:  sourceRepo,
 		MemberID:    resolveGitHubMemberID(issue), // GH-634: RBAC lookup
+		Labels:      extractGitHubLabelNames(issue),  // GH-727: flow labels for complexity classifier
 	}
 
 	var result *executor.ExecutionResult
@@ -3579,6 +3594,7 @@ Examples:
 				Branch:      branchName,
 				Verbose:     verbose,
 				CreatePR:    true,
+				Labels:      extractGitHubLabelNames(issue), // GH-727: flow labels for complexity classifier
 			}
 
 			// Dry run mode

--- a/internal/executor/complexity_classifier.go
+++ b/internal/executor/complexity_classifier.go
@@ -1,0 +1,219 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// ComplexityClassifier uses an LLM (Haiku) to classify task complexity
+// instead of word-count heuristics. Falls back to heuristic on API failure.
+// Caches results per task ID to avoid re-classification on retries.
+type ComplexityClassifier struct {
+	apiKey     string
+	apiURL     string
+	model      string
+	httpClient *http.Client
+	log        *slog.Logger
+
+	mu    sync.Mutex
+	cache map[string]Complexity // task ID → cached classification
+}
+
+// classificationResponse is the JSON structure returned by the LLM.
+type classificationResponse struct {
+	Complexity string `json:"complexity"`
+	Reason     string `json:"reason"`
+}
+
+const complexityClassifierSystemPrompt = `You are a task complexity classifier for a software development pipeline. Classify the given issue into exactly one complexity level.
+
+Levels:
+- TRIVIAL: Minimal changes like typos, log additions, renames, comment updates
+- SIMPLE: Small focused changes: add a field, small fix, single function change
+- MEDIUM: Standard feature work: new endpoint, component, integration. Also includes well-scoped issues with clear step-by-step instructions — these are NOT complex even if detailed
+- COMPLEX: Requires multiple independent components or architectural changes: refactors, migrations, system redesigns
+- EPIC: Too large for single execution: multi-phase projects with 5+ distinct phases
+
+IMPORTANT: A detailed issue with clear step-by-step instructions is NOT complex — it's well-scoped MEDIUM work. COMPLEX means the task requires changes across multiple independent systems or architectural decisions.
+
+Respond with ONLY a JSON object (no markdown, no explanation):
+{"complexity": "TRIVIAL|SIMPLE|MEDIUM|COMPLEX|EPIC", "reason": "brief one-sentence explanation"}`
+
+// NewComplexityClassifier creates a classifier that calls the Anthropic API.
+// Returns nil if apiKey is empty (caller should fall back to heuristic).
+func NewComplexityClassifier(apiKey string) *ComplexityClassifier {
+	if apiKey == "" {
+		return nil
+	}
+	return &ComplexityClassifier{
+		apiKey: apiKey,
+		apiURL: "https://api.anthropic.com/v1/messages",
+		model:  "claude-haiku-4-5-20251001",
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		log:   logging.WithComponent("complexity-classifier"),
+		cache: make(map[string]Complexity),
+	}
+}
+
+// newComplexityClassifierWithURL creates a classifier with a custom API URL for testing.
+func newComplexityClassifierWithURL(apiKey, url string) *ComplexityClassifier {
+	c := NewComplexityClassifier(apiKey)
+	if c == nil {
+		return nil
+	}
+	c.apiURL = url
+	return c
+}
+
+// Classify determines task complexity using the LLM.
+// Returns cached result if available for the given task ID.
+// Falls back to heuristic-based DetectComplexity on any API error.
+func (c *ComplexityClassifier) Classify(ctx context.Context, task *Task) Complexity {
+	if task == nil {
+		return ComplexityMedium
+	}
+
+	// Check cache first (prevents re-classification on retry)
+	if task.ID != "" {
+		c.mu.Lock()
+		if cached, ok := c.cache[task.ID]; ok {
+			c.mu.Unlock()
+			c.log.Debug("using cached complexity", slog.String("task_id", task.ID), slog.String("complexity", string(cached)))
+			return cached
+		}
+		c.mu.Unlock()
+	}
+
+	// Call LLM
+	result, err := c.callAPI(ctx, task)
+	if err != nil {
+		c.log.Warn("LLM classification failed, falling back to heuristic",
+			slog.String("task_id", task.ID),
+			slog.Any("error", err),
+		)
+		return DetectComplexity(task)
+	}
+
+	// Cache result
+	if task.ID != "" {
+		c.mu.Lock()
+		c.cache[task.ID] = result
+		c.mu.Unlock()
+	}
+
+	c.log.Info("LLM classified task complexity",
+		slog.String("task_id", task.ID),
+		slog.String("complexity", string(result)),
+	)
+
+	return result
+}
+
+// callAPI makes the Haiku API call and parses the response.
+func (c *ComplexityClassifier) callAPI(ctx context.Context, task *Task) (Complexity, error) {
+	userContent := fmt.Sprintf("## Issue Title\n%s\n\n## Issue Description\n%s", task.Title, task.Description)
+
+	// Truncate to avoid token overflow (description can be very long)
+	const maxChars = 4000
+	if len(userContent) > maxChars {
+		userContent = userContent[:maxChars] + "\n...[truncated]"
+	}
+
+	reqBody := haikuRequest{
+		Model:     c.model,
+		MaxTokens: 256,
+		System:    complexityClassifierSystemPrompt,
+		Messages: []haikuMessage{
+			{Role: "user", Content: userContent},
+		},
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL, bytes.NewReader(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("API request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	var apiResp haikuResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+
+	if len(apiResp.Content) == 0 || apiResp.Content[0].Text == "" {
+		return "", fmt.Errorf("empty response from API")
+	}
+
+	return parseClassificationResponse(apiResp.Content[0].Text)
+}
+
+// parseClassificationResponse extracts complexity from the LLM's JSON response.
+func parseClassificationResponse(text string) (Complexity, error) {
+	// Strip any markdown code fence wrapper
+	text = strings.TrimSpace(text)
+	text = strings.TrimPrefix(text, "```json")
+	text = strings.TrimPrefix(text, "```")
+	text = strings.TrimSuffix(text, "```")
+	text = strings.TrimSpace(text)
+
+	var resp classificationResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		return "", fmt.Errorf("parse classification JSON: %w (raw: %s)", err, text)
+	}
+
+	switch strings.ToLower(resp.Complexity) {
+	case "trivial":
+		return ComplexityTrivial, nil
+	case "simple":
+		return ComplexitySimple, nil
+	case "medium":
+		return ComplexityMedium, nil
+	case "complex":
+		return ComplexityComplex, nil
+	case "epic":
+		return ComplexityEpic, nil
+	default:
+		return "", fmt.Errorf("unknown complexity level: %q", resp.Complexity)
+	}
+}
+
+// HasLabel checks if the task has a specific label (case-insensitive).
+func HasLabel(task *Task, label string) bool {
+	if task == nil {
+		return false
+	}
+	label = strings.ToLower(label)
+	for _, l := range task.Labels {
+		if strings.ToLower(l) == label {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/executor/complexity_classifier_test.go
+++ b/internal/executor/complexity_classifier_test.go
@@ -1,0 +1,369 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// mockHaikuServer creates a test server that returns a canned classification response.
+func mockHaikuServer(complexity, reason string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"content": []map[string]string{
+				{"text": `{"complexity":"` + complexity + `","reason":"` + reason + `"}`},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+// mockHaikuServerError creates a test server that returns an error status.
+func mockHaikuServerError(status int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+	}))
+}
+
+func TestComplexityClassifier_SimpleTask(t *testing.T) {
+	server := mockHaikuServer("SIMPLE", "Single field addition")
+	defer server.Close()
+
+	classifier := newComplexityClassifierWithURL("test-api-key", server.URL)
+	task := &Task{
+		ID:          "GH-100",
+		Title:       "Add email field to user struct",
+		Description: "Add an email field to the user struct in models.go",
+	}
+
+	result := classifier.Classify(context.Background(), task)
+	if result != ComplexitySimple {
+		t.Errorf("expected SIMPLE, got %s", result)
+	}
+}
+
+func TestComplexityClassifier_MediumDetailedTask(t *testing.T) {
+	// This is the key test: a detailed but well-scoped issue should be MEDIUM, not COMPLEX
+	server := mockHaikuServer("MEDIUM", "Detailed instructions but single-scope feature")
+	defer server.Close()
+
+	classifier := newComplexityClassifierWithURL("test-api-key", server.URL)
+	task := &Task{
+		ID:    "GH-200",
+		Title: "Add webhook endpoint with retry logic",
+		Description: `Implement a webhook endpoint that:
+1. Accepts POST requests at /api/webhooks
+2. Validates the payload signature using HMAC-SHA256
+3. Stores the event in the database
+4. Implements retry logic with exponential backoff (max 3 retries)
+5. Returns 200 on success, 400 on invalid signature
+6. Add unit tests for all paths
+
+Use the existing http router and database connection.
+Follow the patterns in internal/api/handlers.go.`,
+	}
+
+	result := classifier.Classify(context.Background(), task)
+	if result != ComplexityMedium {
+		t.Errorf("expected MEDIUM (detailed but well-scoped), got %s", result)
+	}
+}
+
+func TestComplexityClassifier_ComplexTask(t *testing.T) {
+	server := mockHaikuServer("COMPLEX", "Requires architectural changes across multiple systems")
+	defer server.Close()
+
+	classifier := newComplexityClassifierWithURL("test-api-key", server.URL)
+	task := &Task{
+		ID:          "GH-300",
+		Title:       "Migrate authentication from sessions to JWT",
+		Description: "Rewrite the entire auth system from session-based to JWT. Requires database schema changes, new middleware, updated frontend token handling, and migration of existing sessions.",
+	}
+
+	result := classifier.Classify(context.Background(), task)
+	if result != ComplexityComplex {
+		t.Errorf("expected COMPLEX, got %s", result)
+	}
+}
+
+func TestComplexityClassifier_CachesResult(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		resp := map[string]interface{}{
+			"content": []map[string]string{
+				{"text": `{"complexity":"MEDIUM","reason":"standard work"}`},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	classifier := newComplexityClassifierWithURL("test-api-key", server.URL)
+	task := &Task{
+		ID:          "GH-400",
+		Title:       "Add logging",
+		Description: "Add structured logging to the API layer",
+	}
+
+	// First call hits API
+	result1 := classifier.Classify(context.Background(), task)
+	// Second call should use cache
+	result2 := classifier.Classify(context.Background(), task)
+
+	if result1 != result2 {
+		t.Errorf("cached result differs: %s vs %s", result1, result2)
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 API call (cached), got %d", callCount)
+	}
+}
+
+func TestComplexityClassifier_FallsBackOnError(t *testing.T) {
+	server := mockHaikuServerError(http.StatusInternalServerError)
+	defer server.Close()
+
+	classifier := newComplexityClassifierWithURL("test-api-key", server.URL)
+	task := &Task{
+		ID:          "GH-500",
+		Title:       "Fix typo in README",
+		Description: "Fix typo in README.md",
+	}
+
+	// Should fall back to heuristic (word count < 10 → Simple; "typo" pattern → Trivial)
+	result := classifier.Classify(context.Background(), task)
+	if result != ComplexityTrivial {
+		t.Errorf("expected fallback to heuristic (TRIVIAL), got %s", result)
+	}
+}
+
+func TestComplexityClassifier_NilTask(t *testing.T) {
+	server := mockHaikuServer("MEDIUM", "n/a")
+	defer server.Close()
+
+	classifier := newComplexityClassifierWithURL("test-api-key", server.URL)
+	result := classifier.Classify(context.Background(), nil)
+	if result != ComplexityMedium {
+		t.Errorf("expected MEDIUM for nil task, got %s", result)
+	}
+}
+
+func TestComplexityClassifier_NilAPIKey(t *testing.T) {
+	classifier := NewComplexityClassifier("")
+	if classifier != nil {
+		t.Error("expected nil classifier for empty API key")
+	}
+}
+
+func TestParseClassificationResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Complexity
+		wantErr  bool
+	}{
+		{
+			name:     "simple JSON",
+			input:    `{"complexity":"MEDIUM","reason":"standard work"}`,
+			expected: ComplexityMedium,
+		},
+		{
+			name:     "markdown wrapped",
+			input:    "```json\n{\"complexity\":\"COMPLEX\",\"reason\":\"arch change\"}\n```",
+			expected: ComplexityComplex,
+		},
+		{
+			name:     "lowercase",
+			input:    `{"complexity":"trivial","reason":"typo"}`,
+			expected: ComplexityTrivial,
+		},
+		{
+			name:     "epic",
+			input:    `{"complexity":"EPIC","reason":"multi-phase"}`,
+			expected: ComplexityEpic,
+		},
+		{
+			name:    "invalid JSON",
+			input:   "not json at all",
+			wantErr: true,
+		},
+		{
+			name:    "unknown level",
+			input:   `{"complexity":"MEGA","reason":"unknown"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseClassificationResponse(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestHasLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		task     *Task
+		label    string
+		expected bool
+	}{
+		{
+			name:     "nil task",
+			task:     nil,
+			label:    "no-decompose",
+			expected: false,
+		},
+		{
+			name:     "no labels",
+			task:     &Task{Labels: nil},
+			label:    "no-decompose",
+			expected: false,
+		},
+		{
+			name:     "label present",
+			task:     &Task{Labels: []string{"pilot", "no-decompose", "priority:high"}},
+			label:    "no-decompose",
+			expected: true,
+		},
+		{
+			name:     "case insensitive",
+			task:     &Task{Labels: []string{"No-Decompose"}},
+			label:    "no-decompose",
+			expected: true,
+		},
+		{
+			name:     "label absent",
+			task:     &Task{Labels: []string{"pilot", "enhancement"}},
+			label:    "no-decompose",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HasLabel(tt.task, tt.label)
+			if result != tt.expected {
+				t.Errorf("HasLabel() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDecomposer_NoDecomposeLabel(t *testing.T) {
+	config := &DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 10,
+	}
+	decomposer := NewTaskDecomposer(config)
+
+	// Task that would normally decompose (complex + numbered steps)
+	task := &Task{
+		ID:    "GH-600",
+		Title: "Refactor authentication system",
+		Description: `Refactor the entire authentication system:
+1. Update user model
+2. Rewrite login endpoint
+3. Add session middleware
+4. Update frontend components`,
+		Labels: []string{"pilot", "no-decompose"},
+	}
+
+	result := decomposer.Decompose(task)
+	if result.Decomposed {
+		t.Error("expected task with no-decompose label to NOT be decomposed")
+	}
+	if result.Reason != "skipped: no-decompose label" {
+		t.Errorf("expected reason 'skipped: no-decompose label', got %q", result.Reason)
+	}
+}
+
+func TestDecomposer_WithLLMClassifier(t *testing.T) {
+	// LLM says MEDIUM → should NOT decompose (threshold is complex)
+	server := mockHaikuServer("MEDIUM", "well-scoped feature with clear instructions")
+	defer server.Close()
+
+	config := &DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 10,
+	}
+	decomposer := NewTaskDecomposer(config)
+	classifier := newComplexityClassifierWithURL("test-api-key", server.URL)
+	decomposer.SetClassifier(classifier)
+
+	// This task has numbered steps and "refactor" keyword — heuristic would say COMPLEX
+	// But LLM correctly identifies it as MEDIUM (well-scoped)
+	task := &Task{
+		ID:    "GH-700",
+		Title: "Add retry logic to webhook handler",
+		Description: `Add retry logic to the webhook handler with exponential backoff:
+1. Add retry counter to webhook event struct
+2. Implement exponential backoff calculation
+3. Add retry queue worker
+4. Update webhook handler to enqueue failed events
+5. Add unit tests for retry logic
+
+Follow existing patterns in internal/webhooks/handler.go.`,
+	}
+
+	result := decomposer.DecomposeWithContext(context.Background(), task)
+	if result.Decomposed {
+		t.Error("expected LLM MEDIUM classification to prevent decomposition")
+	}
+	if result.Reason != "complexity below threshold: medium" {
+		t.Errorf("expected threshold reason, got %q", result.Reason)
+	}
+}
+
+func TestDecomposer_LLMClassifierFallback(t *testing.T) {
+	// LLM returns error → falls back to heuristic
+	server := mockHaikuServerError(http.StatusInternalServerError)
+	defer server.Close()
+
+	config := &DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 10,
+	}
+	decomposer := NewTaskDecomposer(config)
+	classifier := newComplexityClassifierWithURL("test-api-key", server.URL)
+	decomposer.SetClassifier(classifier)
+
+	// This task has "refactor" keyword → heuristic says COMPLEX → should decompose
+	task := &Task{
+		ID:    "GH-701",
+		Title: "Refactor authentication system",
+		Description: `Refactor the entire auth system:
+1. Update user model with new fields
+2. Rewrite login endpoint for MFA
+3. Add session validation middleware
+4. Update frontend auth components`,
+	}
+
+	result := decomposer.DecomposeWithContext(context.Background(), task)
+	// Heuristic fallback: "refactor" keyword → COMPLEX → should decompose
+	if !result.Decomposed {
+		t.Errorf("expected heuristic fallback to decompose (refactor = complex), reason: %s", result.Reason)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-727.

## Changes

GitHub Issue #727: feat(executor): LLM complexity classifier replacing word-count heuristic

## Problem
Current complexity detection uses word count >50 = ComplexityComplex → decomposer fires on every detailed issue. Well-scoped issues with clear instructions get shredded into sub-issues. This is GH-665 with clearer spec.

## Fix
In `internal/executor/decomposer.go` (or `complexity.go`):
1. Replace word-count heuristic with Haiku API call for classification
2. Prompt: "Classify this issue as SIMPLE, MEDIUM, or COMPLEX. COMPLEX means it requires multiple independent components or phases. A detailed issue with clear step-by-step instructions is NOT complex — it's well-scoped."
3. Use structured output (JSON mode) for reliable parsing
4. Fallback to word-count heuristic if Haiku API fails
5. Cache classification result per issue (don't re-classify on retry)
6. Also respect `no-decompose` label on issues (GH-664) — skip classification entirely

## Acceptance Criteria
- Haiku classifies complexity instead of word count
- Detailed but well-scoped issues classified as MEDIUM, not COMPLEX
- `no-decompose` label bypasses classification
- Fallback to heuristic on API failure
- Unit test with mock Haiku responses