### PR TITLE
feat(autopilot): persist state to SQLite for crash recovery

### DIFF
--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -1,0 +1,316 @@
+package autopilot
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// StateStore persists autopilot state to SQLite for crash recovery.
+// It stores PR lifecycle state and processed issue tracking so that
+// autopilot can resume from the correct stage after a restart.
+type StateStore struct {
+	db *sql.DB
+}
+
+// NewStateStore creates a StateStore using an existing *sql.DB connection.
+// It runs migrations to create the required tables if they don't exist.
+func NewStateStore(db *sql.DB) (*StateStore, error) {
+	s := &StateStore{db: db}
+	if err := s.migrate(); err != nil {
+		return nil, fmt.Errorf("autopilot state store migration failed: %w", err)
+	}
+	return s, nil
+}
+
+// NewStateStoreFromPath creates a StateStore by opening a new SQLite connection.
+// Used primarily for testing with in-memory databases (path = ":memory:").
+func NewStateStoreFromPath(path string) (*StateStore, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+	if _, err := db.Exec("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;"); err != nil {
+		return nil, fmt.Errorf("failed to set database pragmas: %w", err)
+	}
+	return NewStateStore(db)
+}
+
+func (s *StateStore) migrate() error {
+	migrations := []string{
+		`CREATE TABLE IF NOT EXISTS autopilot_pr_state (
+			pr_number INTEGER PRIMARY KEY,
+			pr_url TEXT NOT NULL,
+			issue_number INTEGER DEFAULT 0,
+			branch_name TEXT NOT NULL DEFAULT '',
+			head_sha TEXT DEFAULT '',
+			stage TEXT NOT NULL,
+			ci_status TEXT NOT NULL DEFAULT 'pending',
+			last_checked DATETIME,
+			ci_wait_started_at DATETIME,
+			merge_attempts INTEGER DEFAULT 0,
+			error TEXT DEFAULT '',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			release_version TEXT DEFAULT '',
+			release_bump_type TEXT DEFAULT ''
+		)`,
+		`CREATE TABLE IF NOT EXISTS autopilot_processed (
+			issue_number INTEGER PRIMARY KEY,
+			processed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			result TEXT DEFAULT ''
+		)`,
+		`CREATE TABLE IF NOT EXISTS autopilot_metadata (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL DEFAULT '',
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+	}
+
+	for _, m := range migrations {
+		if _, err := s.db.Exec(m); err != nil {
+			// Ignore "duplicate column" errors from ALTER TABLE migrations
+			if strings.Contains(err.Error(), "duplicate column") {
+				continue
+			}
+			return fmt.Errorf("migration failed: %w", err)
+		}
+	}
+	return nil
+}
+
+// SavePRState persists a PR state to the database (upsert).
+func (s *StateStore) SavePRState(pr *PRState) error {
+	_, err := s.db.Exec(`
+		INSERT INTO autopilot_pr_state (
+			pr_number, pr_url, issue_number, branch_name, head_sha,
+			stage, ci_status, last_checked, ci_wait_started_at,
+			merge_attempts, error, created_at, updated_at,
+			release_version, release_bump_type
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?)
+		ON CONFLICT(pr_number) DO UPDATE SET
+			pr_url = excluded.pr_url,
+			issue_number = excluded.issue_number,
+			branch_name = excluded.branch_name,
+			head_sha = excluded.head_sha,
+			stage = excluded.stage,
+			ci_status = excluded.ci_status,
+			last_checked = excluded.last_checked,
+			ci_wait_started_at = excluded.ci_wait_started_at,
+			merge_attempts = excluded.merge_attempts,
+			error = excluded.error,
+			updated_at = CURRENT_TIMESTAMP,
+			release_version = excluded.release_version,
+			release_bump_type = excluded.release_bump_type
+	`,
+		pr.PRNumber, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
+		string(pr.Stage), string(pr.CIStatus),
+		nullTime(pr.LastChecked), nullTime(pr.CIWaitStartedAt),
+		pr.MergeAttempts, pr.Error, nullTime(pr.CreatedAt),
+		pr.ReleaseVersion, string(pr.ReleaseBumpType),
+	)
+	return err
+}
+
+// GetPRState retrieves a single PR state by number.
+// Returns nil, nil if not found.
+func (s *StateStore) GetPRState(prNumber int) (*PRState, error) {
+	row := s.db.QueryRow(`
+		SELECT pr_number, pr_url, issue_number, branch_name, head_sha,
+			stage, ci_status, last_checked, ci_wait_started_at,
+			merge_attempts, error, created_at,
+			release_version, release_bump_type
+		FROM autopilot_pr_state WHERE pr_number = ?
+	`, prNumber)
+
+	pr, err := scanPRState(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return pr, nil
+}
+
+// LoadAllPRStates retrieves all persisted PR states.
+func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
+	rows, err := s.db.Query(`
+		SELECT pr_number, pr_url, issue_number, branch_name, head_sha,
+			stage, ci_status, last_checked, ci_wait_started_at,
+			merge_attempts, error, created_at,
+			release_version, release_bump_type
+		FROM autopilot_pr_state
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var states []*PRState
+	for rows.Next() {
+		var pr PRState
+		var lastChecked, ciWaitStartedAt, createdAt sql.NullTime
+		var stage, ciStatus, relBumpType string
+
+		if err := rows.Scan(
+			&pr.PRNumber, &pr.PRURL, &pr.IssueNumber, &pr.BranchName, &pr.HeadSHA,
+			&stage, &ciStatus, &lastChecked, &ciWaitStartedAt,
+			&pr.MergeAttempts, &pr.Error, &createdAt,
+			&pr.ReleaseVersion, &relBumpType,
+		); err != nil {
+			return nil, err
+		}
+
+		pr.Stage = PRStage(stage)
+		pr.CIStatus = CIStatus(ciStatus)
+		pr.ReleaseBumpType = BumpType(relBumpType)
+		if lastChecked.Valid {
+			pr.LastChecked = lastChecked.Time
+		}
+		if ciWaitStartedAt.Valid {
+			pr.CIWaitStartedAt = ciWaitStartedAt.Time
+		}
+		if createdAt.Valid {
+			pr.CreatedAt = createdAt.Time
+		}
+		states = append(states, &pr)
+	}
+	return states, nil
+}
+
+// RemovePRState deletes a PR state record.
+func (s *StateStore) RemovePRState(prNumber int) error {
+	_, err := s.db.Exec(`DELETE FROM autopilot_pr_state WHERE pr_number = ?`, prNumber)
+	return err
+}
+
+// MarkIssueProcessed records that an issue has been processed.
+func (s *StateStore) MarkIssueProcessed(issueNumber int, result string) error {
+	_, err := s.db.Exec(`
+		INSERT INTO autopilot_processed (issue_number, processed_at, result)
+		VALUES (?, CURRENT_TIMESTAMP, ?)
+		ON CONFLICT(issue_number) DO UPDATE SET
+			processed_at = CURRENT_TIMESTAMP,
+			result = excluded.result
+	`, issueNumber, result)
+	return err
+}
+
+// IsIssueProcessed checks if an issue has been previously processed.
+func (s *StateStore) IsIssueProcessed(issueNumber int) (bool, error) {
+	var count int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM autopilot_processed WHERE issue_number = ?`, issueNumber).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// LoadProcessedIssues returns a map of all processed issue numbers.
+func (s *StateStore) LoadProcessedIssues() (map[int]bool, error) {
+	rows, err := s.db.Query(`SELECT issue_number FROM autopilot_processed`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	processed := make(map[int]bool)
+	for rows.Next() {
+		var num int
+		if err := rows.Scan(&num); err != nil {
+			return nil, err
+		}
+		processed[num] = true
+	}
+	return processed, nil
+}
+
+// SaveMetadata stores a key-value pair in the metadata table.
+func (s *StateStore) SaveMetadata(key, value string) error {
+	_, err := s.db.Exec(`
+		INSERT INTO autopilot_metadata (key, value, updated_at)
+		VALUES (?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(key) DO UPDATE SET
+			value = excluded.value,
+			updated_at = CURRENT_TIMESTAMP
+	`, key, value)
+	return err
+}
+
+// GetMetadata retrieves a metadata value by key.
+// Returns empty string if not found.
+func (s *StateStore) GetMetadata(key string) (string, error) {
+	var value string
+	err := s.db.QueryRow(`SELECT value FROM autopilot_metadata WHERE key = ?`, key).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return value, err
+}
+
+// PurgeOldProcessedIssues removes processed issue records older than the given duration.
+func (s *StateStore) PurgeOldProcessedIssues(olderThan time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-olderThan)
+	result, err := s.db.Exec(`DELETE FROM autopilot_processed WHERE processed_at < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+// PurgeTerminalPRStates removes PR states in terminal stages (failed, merged+removed).
+// This is for housekeeping — active PRs are never purged.
+func (s *StateStore) PurgeTerminalPRStates(olderThan time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-olderThan)
+	result, err := s.db.Exec(`
+		DELETE FROM autopilot_pr_state
+		WHERE stage IN ('failed') AND updated_at < ?
+	`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+// scanPRState scans a single row into a PRState.
+func scanPRState(row *sql.Row) (*PRState, error) {
+	var pr PRState
+	var lastChecked, ciWaitStartedAt, createdAt sql.NullTime
+	var stage, ciStatus, relBumpType string
+
+	err := row.Scan(
+		&pr.PRNumber, &pr.PRURL, &pr.IssueNumber, &pr.BranchName, &pr.HeadSHA,
+		&stage, &ciStatus, &lastChecked, &ciWaitStartedAt,
+		&pr.MergeAttempts, &pr.Error, &createdAt,
+		&pr.ReleaseVersion, &relBumpType,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	pr.Stage = PRStage(stage)
+	pr.CIStatus = CIStatus(ciStatus)
+	pr.ReleaseBumpType = BumpType(relBumpType)
+	if lastChecked.Valid {
+		pr.LastChecked = lastChecked.Time
+	}
+	if ciWaitStartedAt.Valid {
+		pr.CIWaitStartedAt = ciWaitStartedAt.Time
+	}
+	if createdAt.Valid {
+		pr.CreatedAt = createdAt.Time
+	}
+	return &pr, nil
+}
+
+// nullTime converts a time.Time to sql.NullTime, treating zero time as NULL.
+func nullTime(t time.Time) sql.NullTime {
+	if t.IsZero() {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: t, Valid: true}
+}

--- a/internal/autopilot/state_store_test.go
+++ b/internal/autopilot/state_store_test.go
@@ -1,0 +1,513 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/adapters/github"
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func newTestStateStore(t *testing.T) *StateStore {
+	t.Helper()
+	store, err := NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test state store: %v", err)
+	}
+	return store
+}
+
+func TestStateStore_SaveAndLoadPRState(t *testing.T) {
+	store := newTestStateStore(t)
+
+	pr := &PRState{
+		PRNumber:        42,
+		PRURL:           "https://github.com/owner/repo/pull/42",
+		IssueNumber:     10,
+		BranchName:      "pilot/GH-10",
+		HeadSHA:         "abc123def456",
+		Stage:           StageWaitingCI,
+		CIStatus:        CIRunning,
+		LastChecked:     time.Now().Truncate(time.Second),
+		CIWaitStartedAt: time.Now().Add(-5 * time.Minute).Truncate(time.Second),
+		MergeAttempts:   1,
+		Error:           "",
+		CreatedAt:       time.Now().Add(-10 * time.Minute).Truncate(time.Second),
+		ReleaseVersion:  "",
+		ReleaseBumpType: BumpNone,
+	}
+
+	// Save
+	if err := store.SavePRState(pr); err != nil {
+		t.Fatalf("SavePRState failed: %v", err)
+	}
+
+	// Load single
+	loaded, err := store.GetPRState(42)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("GetPRState returned nil")
+	}
+
+	if loaded.PRNumber != 42 {
+		t.Errorf("PRNumber = %d, want 42", loaded.PRNumber)
+	}
+	if loaded.PRURL != pr.PRURL {
+		t.Errorf("PRURL = %s, want %s", loaded.PRURL, pr.PRURL)
+	}
+	if loaded.IssueNumber != 10 {
+		t.Errorf("IssueNumber = %d, want 10", loaded.IssueNumber)
+	}
+	if loaded.BranchName != "pilot/GH-10" {
+		t.Errorf("BranchName = %s, want pilot/GH-10", loaded.BranchName)
+	}
+	if loaded.HeadSHA != "abc123def456" {
+		t.Errorf("HeadSHA = %s, want abc123def456", loaded.HeadSHA)
+	}
+	if loaded.Stage != StageWaitingCI {
+		t.Errorf("Stage = %s, want %s", loaded.Stage, StageWaitingCI)
+	}
+	if loaded.CIStatus != CIRunning {
+		t.Errorf("CIStatus = %s, want %s", loaded.CIStatus, CIRunning)
+	}
+	if loaded.MergeAttempts != 1 {
+		t.Errorf("MergeAttempts = %d, want 1", loaded.MergeAttempts)
+	}
+}
+
+func TestStateStore_LoadAllPRStates(t *testing.T) {
+	store := newTestStateStore(t)
+
+	// Save multiple PRs
+	for _, num := range []int{1, 2, 3} {
+		pr := &PRState{
+			PRNumber:   num,
+			PRURL:      "https://github.com/owner/repo/pull/1",
+			BranchName: "pilot/GH-1",
+			Stage:      StagePRCreated,
+			CIStatus:   CIPending,
+			CreatedAt:  time.Now(),
+		}
+		if err := store.SavePRState(pr); err != nil {
+			t.Fatalf("SavePRState(%d) failed: %v", num, err)
+		}
+	}
+
+	states, err := store.LoadAllPRStates()
+	if err != nil {
+		t.Fatalf("LoadAllPRStates failed: %v", err)
+	}
+	if len(states) != 3 {
+		t.Errorf("got %d states, want 3", len(states))
+	}
+}
+
+func TestStateStore_UpdatePRState(t *testing.T) {
+	store := newTestStateStore(t)
+
+	pr := &PRState{
+		PRNumber:   42,
+		PRURL:      "https://github.com/owner/repo/pull/42",
+		BranchName: "pilot/GH-10",
+		Stage:      StagePRCreated,
+		CIStatus:   CIPending,
+		CreatedAt:  time.Now(),
+	}
+
+	if err := store.SavePRState(pr); err != nil {
+		t.Fatalf("initial SavePRState failed: %v", err)
+	}
+
+	// Update stage
+	pr.Stage = StageWaitingCI
+	pr.CIStatus = CIRunning
+	pr.CIWaitStartedAt = time.Now()
+	if err := store.SavePRState(pr); err != nil {
+		t.Fatalf("update SavePRState failed: %v", err)
+	}
+
+	loaded, err := store.GetPRState(42)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded.Stage != StageWaitingCI {
+		t.Errorf("Stage = %s, want %s", loaded.Stage, StageWaitingCI)
+	}
+	if loaded.CIStatus != CIRunning {
+		t.Errorf("CIStatus = %s, want %s", loaded.CIStatus, CIRunning)
+	}
+}
+
+func TestStateStore_RemovePRState(t *testing.T) {
+	store := newTestStateStore(t)
+
+	pr := &PRState{
+		PRNumber:   42,
+		PRURL:      "https://github.com/owner/repo/pull/42",
+		BranchName: "pilot/GH-10",
+		Stage:      StagePRCreated,
+		CIStatus:   CIPending,
+		CreatedAt:  time.Now(),
+	}
+
+	if err := store.SavePRState(pr); err != nil {
+		t.Fatalf("SavePRState failed: %v", err)
+	}
+
+	if err := store.RemovePRState(42); err != nil {
+		t.Fatalf("RemovePRState failed: %v", err)
+	}
+
+	loaded, err := store.GetPRState(42)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded != nil {
+		t.Error("expected nil after removal, got non-nil")
+	}
+}
+
+func TestStateStore_ProcessedIssues(t *testing.T) {
+	store := newTestStateStore(t)
+
+	// Not processed initially
+	processed, err := store.IsIssueProcessed(100)
+	if err != nil {
+		t.Fatalf("IsIssueProcessed failed: %v", err)
+	}
+	if processed {
+		t.Error("issue should not be processed initially")
+	}
+
+	// Mark processed
+	if err := store.MarkIssueProcessed(100, "success"); err != nil {
+		t.Fatalf("MarkIssueProcessed failed: %v", err)
+	}
+
+	processed, err = store.IsIssueProcessed(100)
+	if err != nil {
+		t.Fatalf("IsIssueProcessed failed: %v", err)
+	}
+	if !processed {
+		t.Error("issue should be processed after marking")
+	}
+
+	// Load all
+	all, err := store.LoadProcessedIssues()
+	if err != nil {
+		t.Fatalf("LoadProcessedIssues failed: %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("got %d processed, want 1", len(all))
+	}
+	if !all[100] {
+		t.Error("issue 100 should be in processed map")
+	}
+
+	// Idempotent mark
+	if err := store.MarkIssueProcessed(100, "failed"); err != nil {
+		t.Fatalf("idempotent MarkIssueProcessed failed: %v", err)
+	}
+	all, _ = store.LoadProcessedIssues()
+	if len(all) != 1 {
+		t.Errorf("got %d processed after idempotent mark, want 1", len(all))
+	}
+}
+
+func TestStateStore_Metadata(t *testing.T) {
+	store := newTestStateStore(t)
+
+	// Get non-existent key
+	val, err := store.GetMetadata("missing")
+	if err != nil {
+		t.Fatalf("GetMetadata failed: %v", err)
+	}
+	if val != "" {
+		t.Errorf("expected empty string for missing key, got %q", val)
+	}
+
+	// Set and get
+	if err := store.SaveMetadata("consecutive_failures", "5"); err != nil {
+		t.Fatalf("SaveMetadata failed: %v", err)
+	}
+
+	val, err = store.GetMetadata("consecutive_failures")
+	if err != nil {
+		t.Fatalf("GetMetadata failed: %v", err)
+	}
+	if val != "5" {
+		t.Errorf("got %q, want %q", val, "5")
+	}
+
+	// Update
+	if err := store.SaveMetadata("consecutive_failures", "0"); err != nil {
+		t.Fatalf("SaveMetadata update failed: %v", err)
+	}
+	val, _ = store.GetMetadata("consecutive_failures")
+	if val != "0" {
+		t.Errorf("got %q after update, want %q", val, "0")
+	}
+}
+
+func TestStateStore_PurgeOldProcessedIssues(t *testing.T) {
+	store := newTestStateStore(t)
+
+	// Mark some issues
+	for i := 1; i <= 5; i++ {
+		if err := store.MarkIssueProcessed(i, "success"); err != nil {
+			t.Fatalf("MarkIssueProcessed(%d) failed: %v", i, err)
+		}
+	}
+
+	// Purge older than 0 (all should be purged)
+	purged, err := store.PurgeOldProcessedIssues(0)
+	if err != nil {
+		t.Fatalf("PurgeOldProcessedIssues failed: %v", err)
+	}
+	if purged != 5 {
+		t.Errorf("purged = %d, want 5", purged)
+	}
+
+	all, _ := store.LoadProcessedIssues()
+	if len(all) != 0 {
+		t.Errorf("got %d after purge, want 0", len(all))
+	}
+}
+
+func TestStateStore_PurgeTerminalPRStates(t *testing.T) {
+	store := newTestStateStore(t)
+
+	// Save a failed PR and an active PR
+	failedPR := &PRState{
+		PRNumber:   1,
+		PRURL:      "https://github.com/owner/repo/pull/1",
+		BranchName: "pilot/GH-1",
+		Stage:      StageFailed,
+		CIStatus:   CIFailure,
+		CreatedAt:  time.Now(),
+	}
+	activePR := &PRState{
+		PRNumber:   2,
+		PRURL:      "https://github.com/owner/repo/pull/2",
+		BranchName: "pilot/GH-2",
+		Stage:      StageWaitingCI,
+		CIStatus:   CIRunning,
+		CreatedAt:  time.Now(),
+	}
+
+	if err := store.SavePRState(failedPR); err != nil {
+		t.Fatalf("SavePRState(failed) failed: %v", err)
+	}
+	if err := store.SavePRState(activePR); err != nil {
+		t.Fatalf("SavePRState(active) failed: %v", err)
+	}
+
+	// Purge terminal states older than 0 (immediate)
+	purged, err := store.PurgeTerminalPRStates(0)
+	if err != nil {
+		t.Fatalf("PurgeTerminalPRStates failed: %v", err)
+	}
+	if purged != 1 {
+		t.Errorf("purged = %d, want 1 (only failed)", purged)
+	}
+
+	// Active PR should still exist
+	states, _ := store.LoadAllPRStates()
+	if len(states) != 1 {
+		t.Fatalf("got %d states, want 1", len(states))
+	}
+	if states[0].PRNumber != 2 {
+		t.Errorf("remaining PR = %d, want 2", states[0].PRNumber)
+	}
+}
+
+func TestController_RestoreState(t *testing.T) {
+	store := newTestStateStore(t)
+
+	// Pre-populate store with PR states
+	pr1 := &PRState{
+		PRNumber:   42,
+		PRURL:      "https://github.com/owner/repo/pull/42",
+		IssueNumber: 10,
+		BranchName: "pilot/GH-10",
+		HeadSHA:    "abc123",
+		Stage:      StageWaitingCI,
+		CIStatus:   CIRunning,
+		CreatedAt:  time.Now(),
+	}
+	pr2 := &PRState{
+		PRNumber:   43,
+		PRURL:      "https://github.com/owner/repo/pull/43",
+		IssueNumber: 11,
+		BranchName: "pilot/GH-11",
+		HeadSHA:    "def456",
+		Stage:      StageCIPassed,
+		CIStatus:   CISuccess,
+		CreatedAt:  time.Now(),
+	}
+	// Failed PR should NOT be restored as active
+	pr3 := &PRState{
+		PRNumber:   44,
+		PRURL:      "https://github.com/owner/repo/pull/44",
+		IssueNumber: 12,
+		BranchName: "pilot/GH-12",
+		Stage:      StageFailed,
+		CIStatus:   CIFailure,
+		CreatedAt:  time.Now(),
+	}
+
+	for _, pr := range []*PRState{pr1, pr2, pr3} {
+		if err := store.SavePRState(pr); err != nil {
+			t.Fatalf("SavePRState(%d) failed: %v", pr.PRNumber, err)
+		}
+	}
+
+	// Save circuit breaker state
+	if err := store.SaveMetadata("consecutive_failures", "2"); err != nil {
+		t.Fatalf("SaveMetadata failed: %v", err)
+	}
+
+	// Create controller and restore
+	cfg := DefaultConfig()
+	c := NewController(cfg, nil, nil, "owner", "repo")
+	c.SetStateStore(store)
+
+	restored, err := c.RestoreState()
+	if err != nil {
+		t.Fatalf("RestoreState failed: %v", err)
+	}
+
+	// Should restore 3 total (from LoadAllPRStates), but only 2 active (failed filtered)
+	if restored != 3 {
+		t.Errorf("restored = %d, want 3 (total from store)", restored)
+	}
+
+	prs := c.GetActivePRs()
+	if len(prs) != 2 {
+		t.Fatalf("active PRs = %d, want 2 (failed should be excluded)", len(prs))
+	}
+
+	// Verify stages preserved
+	pr42, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("PR 42 not found in active PRs")
+	}
+	if pr42.Stage != StageWaitingCI {
+		t.Errorf("PR 42 stage = %s, want %s", pr42.Stage, StageWaitingCI)
+	}
+
+	pr43, ok := c.GetPRState(43)
+	if !ok {
+		t.Fatal("PR 43 not found in active PRs")
+	}
+	if pr43.Stage != StageCIPassed {
+		t.Errorf("PR 43 stage = %s, want %s", pr43.Stage, StageCIPassed)
+	}
+
+	// Failed PR should not be in active map
+	_, ok = c.GetPRState(44)
+	if ok {
+		t.Error("PR 44 (failed) should not be in active PRs")
+	}
+
+	// Circuit breaker restored
+	if c.ConsecutiveFailures() != 2 {
+		t.Errorf("consecutiveFailures = %d, want 2", c.ConsecutiveFailures())
+	}
+}
+
+func TestController_OnPRCreated_PersistsToStore(t *testing.T) {
+	store := newTestStateStore(t)
+
+	cfg := DefaultConfig()
+	c := NewController(cfg, nil, nil, "owner", "repo")
+	c.SetStateStore(store)
+
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10")
+
+	// Verify persisted to store
+	loaded, err := store.GetPRState(42)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("PR state not persisted to store")
+	}
+	if loaded.Stage != StagePRCreated {
+		t.Errorf("persisted stage = %s, want %s", loaded.Stage, StagePRCreated)
+	}
+}
+
+func TestController_RemovePR_RemovesFromStore(t *testing.T) {
+	store := newTestStateStore(t)
+
+	cfg := DefaultConfig()
+	c := NewController(cfg, nil, nil, "owner", "repo")
+	c.SetStateStore(store)
+
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10")
+
+	// Remove
+	c.removePR(42)
+
+	// Verify removed from store
+	loaded, err := store.GetPRState(42)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded != nil {
+		t.Error("PR state should be removed from store")
+	}
+}
+
+func TestController_ProcessPR_PersistsTransition(t *testing.T) {
+	// Set up mock GitHub server for CI check
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Return empty JSON for any request
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	store := newTestStateStore(t)
+	cfg := DefaultConfig()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(store)
+
+	// Register a PR
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10")
+
+	// Process — should transition from StagePRCreated to StageWaitingCI
+	if err := c.ProcessPR(context.Background(), 42); err != nil {
+		t.Fatalf("ProcessPR failed: %v", err)
+	}
+
+	// Verify state persisted with new stage
+	loaded, err := store.GetPRState(42)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("PR state not found in store after ProcessPR")
+	}
+	if loaded.Stage != StageWaitingCI {
+		t.Errorf("persisted stage = %s, want %s", loaded.Stage, StageWaitingCI)
+	}
+}
+
+func TestStateStore_MigrateIdempotent(t *testing.T) {
+	store := newTestStateStore(t)
+
+	// Running migrate again should not fail
+	if err := store.migrate(); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-726.

## Changes

GitHub Issue #726: feat(autopilot): persist state to SQLite for crash recovery

## Problem
All autopilot state (PR tracking, circuit breaker, failure counts) is in-memory. On restart:
- PR stages reset to `StagePRCreated` even if they were in `StageWaitingCI`
- Circuit breaker state lost
- Processed issue map lost (poller re-processes everything)
- No history of what failed and why

## Fix
Create `internal/autopilot/state_store.go`:
1. Use existing SQLite store (`internal/memory/store.go`) — add new table `autopilot_state`
2. Schema:
   ```sql
   CREATE TABLE autopilot_pr_state (
     pr_number INTEGER PRIMARY KEY,
     repo TEXT NOT NULL,
     branch TEXT NOT NULL,
     head_sha TEXT,
     stage TEXT NOT NULL,
     failure_count INTEGER DEFAULT 0,
     error TEXT,
     created_at TIMESTAMP,
     updated_at TIMESTAMP
   );
   CREATE TABLE autopilot_processed (
     issue_number INTEGER PRIMARY KEY,
     processed_at TIMESTAMP,
     result TEXT -- 'success', 'failed', 'skipped'
   );
   ```
3. On every state transition in controller, persist to SQLite
4. On startup, load state from SQLite instead of scanning GitHub PRs
5. Poller loads processed map from `autopilot_processed` table

## Acceptance Criteria
- Autopilot survives restart without losing PR tracking state
- PRs resume from correct stage after restart
- Processed map persisted — no duplicate execution
- Migration runs automatically on first start
- Unit tests with in-memory SQLite