### PR TITLE
Wire merge-wait callback into Runner

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -700,6 +700,18 @@ Examples:
 						pollerOpts = append(pollerOpts, github.WithOnPRCreated(gwAutopilotController.OnPRCreated))
 						// Wire sub-issue PR callback so epic sub-PRs are tracked by autopilot (GH-594)
 						gwRunner.SetOnSubIssuePRCreated(gwAutopilotController.OnPRCreated)
+						// Wire sub-issue merge waiter for sequential epic execution (GH-742)
+						gwRunner.SetOnSubIssueMergeWaiter(func(prNumber int, timeout time.Duration) (executor.PRMergeResult, error) {
+							result, err := gwAutopilotController.WaitForPRMerge(prNumber, timeout)
+							return executor.PRMergeResult{
+								Merged:   result.Merged,
+								Closed:   result.Closed,
+								Failed:   result.Failed,
+								Error:    result.Error,
+								MergeSHA: result.MergeSHA,
+								TimedOut: result.TimedOut,
+							}, err
+						})
 					}
 
 					// Create rate limit retry scheduler
@@ -1485,6 +1497,18 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 				)
 				// Wire sub-issue PR callback so epic sub-PRs are tracked by autopilot (GH-594)
 				runner.SetOnSubIssuePRCreated(autopilotController.OnPRCreated)
+				// Wire sub-issue merge waiter for sequential epic execution (GH-742)
+				runner.SetOnSubIssueMergeWaiter(func(prNumber int, timeout time.Duration) (executor.PRMergeResult, error) {
+					result, err := autopilotController.WaitForPRMerge(prNumber, timeout)
+					return executor.PRMergeResult{
+						Merged:   result.Merged,
+						Closed:   result.Closed,
+						Failed:   result.Failed,
+						Error:    result.Error,
+						MergeSHA: result.MergeSHA,
+						TimedOut: result.TimedOut,
+					}, err
+				})
 			}
 
 			// Create rate limit retry scheduler


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-742.

## Changes

GitHub Issue #742: Wire merge-wait callback into Runner

Parent: GH-723

Connect executor to autopilot's wait mechanism
Add a `SubIssueMergeWaiter` callback type (`func(prNumber int, timeout time.Duration) (PRMergeResult, error)`) to `Runner` in `internal/executor/runner.go`, similar to the existing `SubIssuePRCallback`. Wire it in `main.go` to call `autopilotController.WaitForPRMerge`. Add a `WithSubIssueMergeWaiter()` option. This keeps the executor decoupled from autopilot — it just calls a function and gets a result.