### PR TITLE
feat(autopilot): failure metrics and alerting dashboard

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1601,6 +1601,18 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 							)
 						}
 					}()
+
+					// Start metrics alerter (GH-728): bridges metrics → alerts engine
+					if alertsEngine != nil {
+						metricsAlerter := autopilot.NewMetricsAlerter(autopilotController, alertsEngine)
+						go metricsAlerter.Run(ctx)
+					}
+
+					// Start metrics persister (GH-728): snapshots → SQLite
+					if store != nil {
+						metricsPersister := autopilot.NewMetricsPersister(autopilotController, store)
+						go metricsPersister.Run(ctx)
+					}
 				}
 			}
 

--- a/internal/alerts/types_test.go
+++ b/internal/alerts/types_test.go
@@ -51,6 +51,11 @@ func TestDefaultRules(t *testing.T) {
 		AlertTypeConsecutiveFails: {"consecutive_failures", true},
 		AlertTypeDailySpend:       {"daily_spend", false},
 		AlertTypeBudgetDepleted:   {"budget_depleted", false},
+		// Autopilot health rules (GH-728)
+		AlertTypeFailedQueueHigh:    {"failed_queue_high", true},
+		AlertTypeCircuitBreakerTrip: {"circuit_breaker_trip", true},
+		AlertTypeAPIErrorRateHigh:   {"api_error_rate_high", true},
+		AlertTypePRStuckWaitingCI:   {"pr_stuck_waiting_ci", true},
 	}
 
 	if len(rules) != len(expectedRules) {

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -53,6 +53,9 @@ type Controller struct {
 	// Circuit breaker
 	consecutiveFailures int
 
+	// Metrics
+	metrics *Metrics
+
 	// Owner and repo for GitHub operations
 	owner string
 	repo  string
@@ -67,6 +70,7 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 		owner:       owner,
 		repo:        repo,
 		activePRs:   make(map[int]*PRState),
+		metrics:     NewMetrics(),
 		log:         slog.Default().With("component", "autopilot"),
 	}
 
@@ -129,6 +133,7 @@ func (c *Controller) ProcessPR(ctx context.Context, prNumber int) error {
 	// Circuit breaker check
 	if c.consecutiveFailures >= c.config.MaxFailures {
 		c.log.Warn("circuit breaker open", "failures", c.consecutiveFailures)
+		c.metrics.RecordCircuitBreakerTrip()
 		return fmt.Errorf("circuit breaker: too many consecutive failures (%d)", c.consecutiveFailures)
 	}
 
@@ -267,9 +272,15 @@ func (c *Controller) handleWaitingCI(ctx context.Context, prState *PRState) erro
 	case CISuccess:
 		c.log.Info("CI passed", "pr", prState.PRNumber, "sha", ShortSHA(sha))
 		prState.Stage = StageCIPassed
+		if !prState.CIWaitStartedAt.IsZero() {
+			c.metrics.RecordCIWaitDuration(time.Since(prState.CIWaitStartedAt))
+		}
 	case CIFailure:
 		c.log.Warn("CI failed", "pr", prState.PRNumber, "sha", ShortSHA(sha))
 		prState.Stage = StageCIFailed
+		if !prState.CIWaitStartedAt.IsZero() {
+			c.metrics.RecordCIWaitDuration(time.Since(prState.CIWaitStartedAt))
+		}
 	case CIPending, CIRunning:
 		// Stay in StageWaitingCI, will be checked next poll cycle
 		c.log.Debug("CI still running", "pr", prState.PRNumber, "status", status)
@@ -346,6 +357,7 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 	}
 
 	prState.Stage = StageFailed
+	c.metrics.RecordPRFailed()
 	return nil
 }
 
@@ -395,6 +407,8 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 
 	c.log.Info("PR merged successfully", "pr", prState.PRNumber)
 	prState.Stage = StageMerged
+	c.metrics.RecordPRMerged()
+	c.metrics.RecordPRTimeToMerge(time.Since(prState.CreatedAt))
 
 	// Notify merge success
 	if c.notifier != nil {
@@ -617,6 +631,11 @@ func (c *Controller) ConsecutiveFailures() int {
 	return c.consecutiveFailures
 }
 
+// Metrics returns the autopilot metrics collector.
+func (c *Controller) Metrics() *Metrics {
+	return c.metrics
+}
+
 // ScanExistingPRs scans for open PRs created by Pilot and restores their state.
 // This should be called on startup to track PRs that were created before the current session.
 func (c *Controller) ScanExistingPRs(ctx context.Context) error {
@@ -816,6 +835,10 @@ func (c *Controller) Run(ctx context.Context) error {
 // processAllPRs processes all active PRs in one iteration.
 func (c *Controller) processAllPRs(ctx context.Context) {
 	prs := c.GetActivePRs()
+
+	// Update active PR gauges every tick
+	c.metrics.UpdateActivePRs(prs)
+
 	if len(prs) == 0 {
 		return
 	}

--- a/internal/autopilot/metrics.go
+++ b/internal/autopilot/metrics.go
@@ -1,0 +1,292 @@
+package autopilot
+
+import (
+	"sync"
+	"time"
+)
+
+// Metrics collects autopilot operational metrics.
+// All methods are goroutine-safe.
+type Metrics struct {
+	mu sync.RWMutex
+
+	// Counters
+	IssuesProcessed   map[string]int64 // result → count (success, failed, rate_limited)
+	PRsMerged         int64
+	PRsFailed         int64
+	PRsConflicting    int64
+	CircuitBreakerTrips int64
+	APIErrors         map[string]int64 // endpoint → count
+	LabelCleanups     map[string]int64 // label → count
+
+	// Gauges (point-in-time values)
+	ActivePRsByStage  map[PRStage]int
+	QueueDepth        int // issues with `pilot` label, no `pilot-in-progress`
+	FailedQueueDepth  int // issues with `pilot-failed`
+
+	// Histograms (stored as recent samples for summary stats)
+	PRTimeToMerge     []time.Duration
+	CIWaitDurations   []time.Duration
+	ExecutionDurations []time.Duration
+
+	// Timestamps for rate calculation
+	apiErrorTimes []time.Time
+
+	// Maximum samples to keep for histograms
+	maxSamples int
+}
+
+// NewMetrics creates a new Metrics instance.
+func NewMetrics() *Metrics {
+	return &Metrics{
+		IssuesProcessed:    make(map[string]int64),
+		APIErrors:          make(map[string]int64),
+		LabelCleanups:      make(map[string]int64),
+		ActivePRsByStage:   make(map[PRStage]int),
+		PRTimeToMerge:      make([]time.Duration, 0, 100),
+		CIWaitDurations:    make([]time.Duration, 0, 100),
+		ExecutionDurations: make([]time.Duration, 0, 100),
+		apiErrorTimes:      make([]time.Time, 0, 100),
+		maxSamples:         1000,
+	}
+}
+
+// --- Counter increments ---
+
+// RecordIssueProcessed increments the processed issue counter by result.
+func (m *Metrics) RecordIssueProcessed(result string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.IssuesProcessed[result]++
+}
+
+// RecordPRMerged increments the merged PR counter.
+func (m *Metrics) RecordPRMerged() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PRsMerged++
+}
+
+// RecordPRFailed increments the failed PR counter.
+func (m *Metrics) RecordPRFailed() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PRsFailed++
+}
+
+// RecordPRConflicting increments the conflicting PR counter.
+func (m *Metrics) RecordPRConflicting() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PRsConflicting++
+}
+
+// RecordCircuitBreakerTrip increments the circuit breaker trip counter.
+func (m *Metrics) RecordCircuitBreakerTrip() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.CircuitBreakerTrips++
+}
+
+// RecordAPIError increments the API error counter for a given endpoint.
+func (m *Metrics) RecordAPIError(endpoint string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.APIErrors[endpoint]++
+	m.apiErrorTimes = append(m.apiErrorTimes, time.Now())
+	// Trim old entries (keep last maxSamples)
+	if len(m.apiErrorTimes) > m.maxSamples {
+		m.apiErrorTimes = m.apiErrorTimes[len(m.apiErrorTimes)-m.maxSamples:]
+	}
+}
+
+// RecordLabelCleanup increments the label cleanup counter.
+func (m *Metrics) RecordLabelCleanup(label string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.LabelCleanups[label]++
+}
+
+// --- Gauge updates ---
+
+// UpdateActivePRs recalculates active PR counts by stage from a snapshot.
+func (m *Metrics) UpdateActivePRs(prs []*PRState) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Reset all stages
+	m.ActivePRsByStage = make(map[PRStage]int)
+	for _, pr := range prs {
+		m.ActivePRsByStage[pr.Stage]++
+	}
+}
+
+// SetQueueDepth updates the queue depth gauge.
+func (m *Metrics) SetQueueDepth(depth int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.QueueDepth = depth
+}
+
+// SetFailedQueueDepth updates the failed queue depth gauge.
+func (m *Metrics) SetFailedQueueDepth(depth int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.FailedQueueDepth = depth
+}
+
+// --- Histogram recording ---
+
+// RecordPRTimeToMerge records the duration from PR creation to merge.
+func (m *Metrics) RecordPRTimeToMerge(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PRTimeToMerge = append(m.PRTimeToMerge, d)
+	if len(m.PRTimeToMerge) > m.maxSamples {
+		m.PRTimeToMerge = m.PRTimeToMerge[len(m.PRTimeToMerge)-m.maxSamples:]
+	}
+}
+
+// RecordCIWaitDuration records how long a PR waited for CI.
+func (m *Metrics) RecordCIWaitDuration(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.CIWaitDurations = append(m.CIWaitDurations, d)
+	if len(m.CIWaitDurations) > m.maxSamples {
+		m.CIWaitDurations = m.CIWaitDurations[len(m.CIWaitDurations)-m.maxSamples:]
+	}
+}
+
+// RecordExecutionDuration records task execution time.
+func (m *Metrics) RecordExecutionDuration(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ExecutionDurations = append(m.ExecutionDurations, d)
+	if len(m.ExecutionDurations) > m.maxSamples {
+		m.ExecutionDurations = m.ExecutionDurations[len(m.ExecutionDurations)-m.maxSamples:]
+	}
+}
+
+// --- Read accessors ---
+
+// Snapshot returns a point-in-time copy of all metrics.
+func (m *Metrics) Snapshot() MetricsSnapshot {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	snap := MetricsSnapshot{
+		IssuesProcessed:     copyStringIntMap(m.IssuesProcessed),
+		PRsMerged:           m.PRsMerged,
+		PRsFailed:           m.PRsFailed,
+		PRsConflicting:      m.PRsConflicting,
+		CircuitBreakerTrips: m.CircuitBreakerTrips,
+		APIErrors:           copyStringIntMap(m.APIErrors),
+		LabelCleanups:       copyStringIntMap(m.LabelCleanups),
+		ActivePRsByStage:    copyStageIntMap(m.ActivePRsByStage),
+		QueueDepth:          m.QueueDepth,
+		FailedQueueDepth:    m.FailedQueueDepth,
+		TotalActivePRs:      sumStageMap(m.ActivePRsByStage),
+		AvgPRTimeToMerge:    avgDuration(m.PRTimeToMerge),
+		AvgCIWaitDuration:   avgDuration(m.CIWaitDurations),
+		AvgExecutionDuration: avgDuration(m.ExecutionDurations),
+		APIErrorRate:         m.apiErrorRate(),
+		SnapshotAt:          time.Now(),
+	}
+
+	// Calculate success rate
+	total := int64(0)
+	for _, v := range m.IssuesProcessed {
+		total += v
+	}
+	if total > 0 {
+		snap.SuccessRate = float64(m.IssuesProcessed["success"]) / float64(total)
+	}
+
+	return snap
+}
+
+// apiErrorRate returns errors per minute in the last 5 minutes.
+// Must be called with mu held (at least RLock).
+func (m *Metrics) apiErrorRate() float64 {
+	cutoff := time.Now().Add(-5 * time.Minute)
+	count := 0
+	for _, t := range m.apiErrorTimes {
+		if t.After(cutoff) {
+			count++
+		}
+	}
+	return float64(count) / 5.0 // per minute
+}
+
+// MetricsSnapshot is a read-only copy of metrics at a point in time.
+type MetricsSnapshot struct {
+	// Counters
+	IssuesProcessed     map[string]int64
+	PRsMerged           int64
+	PRsFailed           int64
+	PRsConflicting      int64
+	CircuitBreakerTrips int64
+	APIErrors           map[string]int64
+	LabelCleanups       map[string]int64
+
+	// Gauges
+	ActivePRsByStage map[PRStage]int
+	TotalActivePRs   int
+	QueueDepth       int
+	FailedQueueDepth int
+
+	// Computed summaries
+	SuccessRate          float64
+	AvgPRTimeToMerge     time.Duration
+	AvgCIWaitDuration    time.Duration
+	AvgExecutionDuration time.Duration
+	APIErrorRate         float64 // errors per minute (5m window)
+
+	SnapshotAt time.Time
+}
+
+// TotalIssuesProcessed returns the sum of all issue results.
+func (s MetricsSnapshot) TotalIssuesProcessed() int64 {
+	var total int64
+	for _, v := range s.IssuesProcessed {
+		total += v
+	}
+	return total
+}
+
+// --- helpers ---
+
+func copyStringIntMap(src map[string]int64) map[string]int64 {
+	dst := make(map[string]int64, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func copyStageIntMap(src map[PRStage]int) map[PRStage]int {
+	dst := make(map[PRStage]int, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func sumStageMap(m map[PRStage]int) int {
+	total := 0
+	for _, v := range m {
+		total += v
+	}
+	return total
+}
+
+func avgDuration(samples []time.Duration) time.Duration {
+	if len(samples) == 0 {
+		return 0
+	}
+	var sum time.Duration
+	for _, d := range samples {
+		sum += d
+	}
+	return sum / time.Duration(len(samples))
+}

--- a/internal/autopilot/metrics_alerter.go
+++ b/internal/autopilot/metrics_alerter.go
@@ -1,0 +1,88 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/alerts"
+)
+
+// MetricsAlerter periodically evaluates autopilot metrics and sends events
+// to the alerts engine for rule evaluation.
+type MetricsAlerter struct {
+	controller *Controller
+	engine     *alerts.Engine
+	interval   time.Duration
+	log        *slog.Logger
+}
+
+// NewMetricsAlerter creates a new MetricsAlerter.
+func NewMetricsAlerter(controller *Controller, engine *alerts.Engine) *MetricsAlerter {
+	return &MetricsAlerter{
+		controller: controller,
+		engine:     engine,
+		interval:   30 * time.Second,
+		log:        slog.Default().With("component", "metrics-alerter"),
+	}
+}
+
+// Run starts the metrics alerter loop.
+func (ma *MetricsAlerter) Run(ctx context.Context) {
+	if ma.engine == nil {
+		ma.log.Debug("alerts engine not configured, metrics alerter disabled")
+		return
+	}
+
+	ticker := time.NewTicker(ma.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			ma.evaluate()
+		}
+	}
+}
+
+// evaluate takes a metrics snapshot and emits an autopilot_metrics event.
+func (ma *MetricsAlerter) evaluate() {
+	snap := ma.controller.Metrics().Snapshot()
+
+	// Calculate stuck PRs (in waiting_ci)
+	var prStuckCount int
+	var prMaxWaitMin float64
+
+	for _, pr := range ma.controller.GetActivePRs() {
+		if pr.Stage == StageWaitingCI && !pr.CIWaitStartedAt.IsZero() {
+			waitMin := time.Since(pr.CIWaitStartedAt).Minutes()
+			prStuckCount++
+			if waitMin > prMaxWaitMin {
+				prMaxWaitMin = waitMin
+			}
+		}
+	}
+
+	event := alerts.Event{
+		Type:      alerts.EventTypeAutopilotMetrics,
+		TaskID:    "autopilot",
+		TaskTitle: "Autopilot Health Check",
+		Project:   fmt.Sprintf("%s/%s", ma.controller.owner, ma.controller.repo),
+		Metadata: map[string]string{
+			"failed_queue_depth":    fmt.Sprintf("%d", snap.FailedQueueDepth),
+			"circuit_breaker_trips": fmt.Sprintf("%d", snap.CircuitBreakerTrips),
+			"api_error_rate":        fmt.Sprintf("%.2f", snap.APIErrorRate),
+			"pr_stuck_count":        fmt.Sprintf("%d", prStuckCount),
+			"pr_max_wait_minutes":   fmt.Sprintf("%.1f", prMaxWaitMin),
+			"success_rate":          fmt.Sprintf("%.2f", snap.SuccessRate),
+			"total_active_prs":      fmt.Sprintf("%d", snap.TotalActivePRs),
+			"queue_depth":           fmt.Sprintf("%d", snap.QueueDepth),
+		},
+		Timestamp: time.Now(),
+	}
+
+	ma.engine.ProcessEvent(event)
+}

--- a/internal/autopilot/metrics_persister.go
+++ b/internal/autopilot/metrics_persister.go
@@ -1,0 +1,96 @@
+package autopilot
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/memory"
+)
+
+// MetricsPersister periodically saves metrics snapshots to SQLite for history.
+type MetricsPersister struct {
+	controller *Controller
+	store      *memory.Store
+	interval   time.Duration
+	retention  time.Duration // How long to keep snapshots
+	log        *slog.Logger
+}
+
+// NewMetricsPersister creates a new MetricsPersister.
+// Saves snapshots every 5 minutes and retains 7 days of history.
+func NewMetricsPersister(controller *Controller, store *memory.Store) *MetricsPersister {
+	return &MetricsPersister{
+		controller: controller,
+		store:      store,
+		interval:   5 * time.Minute,
+		retention:  7 * 24 * time.Hour,
+		log:        slog.Default().With("component", "metrics-persister"),
+	}
+}
+
+// Run starts the persister loop.
+func (mp *MetricsPersister) Run(ctx context.Context) {
+	if mp.store == nil {
+		mp.log.Debug("no store configured, metrics persistence disabled")
+		return
+	}
+
+	ticker := time.NewTicker(mp.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Final snapshot on shutdown
+			mp.persist()
+			return
+		case <-ticker.C:
+			mp.persist()
+			mp.prune()
+		}
+	}
+}
+
+func (mp *MetricsPersister) persist() {
+	snap := mp.controller.Metrics().Snapshot()
+
+	// Sum up API errors total
+	var apiErrorsTotal int64
+	for _, count := range snap.APIErrors {
+		apiErrorsTotal += count
+	}
+
+	row := &memory.AutopilotMetricsRow{
+		SnapshotAt:          snap.SnapshotAt,
+		IssuesSuccess:       int(snap.IssuesProcessed["success"]),
+		IssuesFailed:        int(snap.IssuesProcessed["failed"]),
+		IssuesRateLimited:   int(snap.IssuesProcessed["rate_limited"]),
+		PRsMerged:           int(snap.PRsMerged),
+		PRsFailed:           int(snap.PRsFailed),
+		PRsConflicting:      int(snap.PRsConflicting),
+		CircuitBreakerTrips: int(snap.CircuitBreakerTrips),
+		APIErrorsTotal:      int(apiErrorsTotal),
+		APIErrorRate:        snap.APIErrorRate,
+		QueueDepth:          snap.QueueDepth,
+		FailedQueueDepth:    snap.FailedQueueDepth,
+		ActivePRs:           snap.TotalActivePRs,
+		SuccessRate:         snap.SuccessRate,
+		AvgCIWaitMs:         snap.AvgCIWaitDuration.Milliseconds(),
+		AvgMergeTimeMs:      snap.AvgPRTimeToMerge.Milliseconds(),
+		AvgExecutionMs:      snap.AvgExecutionDuration.Milliseconds(),
+	}
+
+	if err := mp.store.SaveAutopilotMetrics(row); err != nil {
+		mp.log.Warn("failed to persist autopilot metrics", slog.Any("error", err))
+	}
+}
+
+func (mp *MetricsPersister) prune() {
+	deleted, err := mp.store.PruneAutopilotMetrics(mp.retention)
+	if err != nil {
+		mp.log.Warn("failed to prune autopilot metrics", slog.Any("error", err))
+	} else if deleted > 0 {
+		mp.log.Debug("pruned old autopilot metrics", slog.Int64("deleted", deleted))
+	}
+}

--- a/internal/autopilot/metrics_test.go
+++ b/internal/autopilot/metrics_test.go
@@ -1,0 +1,203 @@
+package autopilot
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewMetrics(t *testing.T) {
+	m := NewMetrics()
+	if m == nil {
+		t.Fatal("NewMetrics returned nil")
+	}
+	snap := m.Snapshot()
+	if snap.TotalIssuesProcessed() != 0 {
+		t.Errorf("expected 0 issues processed, got %d", snap.TotalIssuesProcessed())
+	}
+	if snap.PRsMerged != 0 || snap.PRsFailed != 0 {
+		t.Error("expected zero PR counters")
+	}
+}
+
+func TestCounters(t *testing.T) {
+	m := NewMetrics()
+
+	m.RecordIssueProcessed("success")
+	m.RecordIssueProcessed("success")
+	m.RecordIssueProcessed("failed")
+	m.RecordIssueProcessed("rate_limited")
+
+	m.RecordPRMerged()
+	m.RecordPRMerged()
+	m.RecordPRFailed()
+	m.RecordPRConflicting()
+
+	m.RecordCircuitBreakerTrip()
+	m.RecordCircuitBreakerTrip()
+
+	m.RecordAPIError("GetPullRequest")
+	m.RecordAPIError("GetPullRequest")
+	m.RecordAPIError("MergePR")
+
+	m.RecordLabelCleanup("pilot-in-progress")
+	m.RecordLabelCleanup("pilot-failed")
+	m.RecordLabelCleanup("pilot-failed")
+
+	snap := m.Snapshot()
+
+	if snap.IssuesProcessed["success"] != 2 {
+		t.Errorf("expected 2 success, got %d", snap.IssuesProcessed["success"])
+	}
+	if snap.IssuesProcessed["failed"] != 1 {
+		t.Errorf("expected 1 failed, got %d", snap.IssuesProcessed["failed"])
+	}
+	if snap.TotalIssuesProcessed() != 4 {
+		t.Errorf("expected 4 total, got %d", snap.TotalIssuesProcessed())
+	}
+	if snap.PRsMerged != 2 {
+		t.Errorf("expected 2 merged, got %d", snap.PRsMerged)
+	}
+	if snap.PRsFailed != 1 {
+		t.Errorf("expected 1 failed PR, got %d", snap.PRsFailed)
+	}
+	if snap.PRsConflicting != 1 {
+		t.Errorf("expected 1 conflicting, got %d", snap.PRsConflicting)
+	}
+	if snap.CircuitBreakerTrips != 2 {
+		t.Errorf("expected 2 CB trips, got %d", snap.CircuitBreakerTrips)
+	}
+	if snap.APIErrors["GetPullRequest"] != 2 {
+		t.Errorf("expected 2 GetPullRequest errors, got %d", snap.APIErrors["GetPullRequest"])
+	}
+	if snap.LabelCleanups["pilot-failed"] != 2 {
+		t.Errorf("expected 2 pilot-failed cleanups, got %d", snap.LabelCleanups["pilot-failed"])
+	}
+}
+
+func TestGauges(t *testing.T) {
+	m := NewMetrics()
+
+	prs := []*PRState{
+		{PRNumber: 1, Stage: StageWaitingCI},
+		{PRNumber: 2, Stage: StageWaitingCI},
+		{PRNumber: 3, Stage: StageMerging},
+	}
+	m.UpdateActivePRs(prs)
+	m.SetQueueDepth(5)
+	m.SetFailedQueueDepth(2)
+
+	snap := m.Snapshot()
+
+	if snap.ActivePRsByStage[StageWaitingCI] != 2 {
+		t.Errorf("expected 2 waiting_ci, got %d", snap.ActivePRsByStage[StageWaitingCI])
+	}
+	if snap.ActivePRsByStage[StageMerging] != 1 {
+		t.Errorf("expected 1 merging, got %d", snap.ActivePRsByStage[StageMerging])
+	}
+	if snap.TotalActivePRs != 3 {
+		t.Errorf("expected 3 total active, got %d", snap.TotalActivePRs)
+	}
+	if snap.QueueDepth != 5 {
+		t.Errorf("expected queue depth 5, got %d", snap.QueueDepth)
+	}
+	if snap.FailedQueueDepth != 2 {
+		t.Errorf("expected failed depth 2, got %d", snap.FailedQueueDepth)
+	}
+}
+
+func TestHistograms(t *testing.T) {
+	m := NewMetrics()
+
+	m.RecordPRTimeToMerge(10 * time.Minute)
+	m.RecordPRTimeToMerge(20 * time.Minute)
+	m.RecordCIWaitDuration(3 * time.Minute)
+	m.RecordCIWaitDuration(7 * time.Minute)
+	m.RecordExecutionDuration(30 * time.Second)
+	m.RecordExecutionDuration(90 * time.Second)
+
+	snap := m.Snapshot()
+
+	if snap.AvgPRTimeToMerge != 15*time.Minute {
+		t.Errorf("expected avg merge time 15m, got %v", snap.AvgPRTimeToMerge)
+	}
+	if snap.AvgCIWaitDuration != 5*time.Minute {
+		t.Errorf("expected avg CI wait 5m, got %v", snap.AvgCIWaitDuration)
+	}
+	if snap.AvgExecutionDuration != 60*time.Second {
+		t.Errorf("expected avg exec 60s, got %v", snap.AvgExecutionDuration)
+	}
+}
+
+func TestSuccessRate(t *testing.T) {
+	m := NewMetrics()
+
+	m.RecordIssueProcessed("success")
+	m.RecordIssueProcessed("success")
+	m.RecordIssueProcessed("success")
+	m.RecordIssueProcessed("failed")
+
+	snap := m.Snapshot()
+
+	if snap.SuccessRate != 0.75 {
+		t.Errorf("expected success rate 0.75, got %f", snap.SuccessRate)
+	}
+}
+
+func TestAPIErrorRate(t *testing.T) {
+	m := NewMetrics()
+
+	// Add 10 errors "now" (within 5 min window)
+	for i := 0; i < 10; i++ {
+		m.RecordAPIError("test")
+	}
+
+	snap := m.Snapshot()
+
+	// 10 errors / 5 minutes = 2.0 per minute
+	if snap.APIErrorRate != 2.0 {
+		t.Errorf("expected API error rate 2.0/min, got %f", snap.APIErrorRate)
+	}
+}
+
+func TestSnapshotIsolation(t *testing.T) {
+	m := NewMetrics()
+	m.RecordPRMerged()
+
+	snap := m.Snapshot()
+
+	// Mutate after snapshot
+	m.RecordPRMerged()
+
+	if snap.PRsMerged != 1 {
+		t.Errorf("snapshot should be isolated, expected 1, got %d", snap.PRsMerged)
+	}
+
+	snap2 := m.Snapshot()
+	if snap2.PRsMerged != 2 {
+		t.Errorf("new snapshot should reflect mutation, expected 2, got %d", snap2.PRsMerged)
+	}
+}
+
+func TestUpdateActivePRsReset(t *testing.T) {
+	m := NewMetrics()
+
+	m.UpdateActivePRs([]*PRState{
+		{PRNumber: 1, Stage: StageWaitingCI},
+	})
+	if snap := m.Snapshot(); snap.TotalActivePRs != 1 {
+		t.Fatalf("expected 1, got %d", snap.TotalActivePRs)
+	}
+
+	// Replace with different set
+	m.UpdateActivePRs([]*PRState{
+		{PRNumber: 2, Stage: StageMerging},
+		{PRNumber: 3, Stage: StageMerging},
+	})
+	snap := m.Snapshot()
+	if snap.TotalActivePRs != 2 {
+		t.Errorf("expected 2 after reset, got %d", snap.TotalActivePRs)
+	}
+	if snap.ActivePRsByStage[StageWaitingCI] != 0 {
+		t.Errorf("waiting_ci should be 0 after reset, got %d", snap.ActivePRsByStage[StageWaitingCI])
+	}
+}

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -221,6 +221,110 @@ func (p *AutopilotPanel) stageIcon(stage autopilot.PRStage) string {
 	}
 }
 
+// HealthPanel displays autopilot health metrics in the dashboard.
+type HealthPanel struct {
+	controller *autopilot.Controller
+}
+
+// NewHealthPanel creates a health metrics panel.
+func NewHealthPanel(controller *autopilot.Controller) *HealthPanel {
+	return &HealthPanel{controller: controller}
+}
+
+// View renders the health metrics panel.
+func (p *HealthPanel) View() string {
+	var content strings.Builder
+	w := panelInnerWidth
+
+	if p.controller == nil || p.controller.Metrics() == nil {
+		content.WriteString("  No metrics available")
+		return renderPanel("HEALTH", content.String())
+	}
+
+	snap := p.controller.Metrics().Snapshot()
+
+	// Success rate
+	successPct := fmt.Sprintf("%.0f%%", snap.SuccessRate*100)
+	if snap.TotalIssuesProcessed() == 0 {
+		successPct = "—"
+	}
+	style := statusCompletedStyle
+	if snap.SuccessRate < 0.5 && snap.TotalIssuesProcessed() > 0 {
+		style = statusFailedStyle
+	} else if snap.SuccessRate < 0.8 && snap.TotalIssuesProcessed() > 0 {
+		style = warningStyle
+	}
+	content.WriteString(dotLeaderStyled("Success rate", successPct, style, w))
+	content.WriteString("\n")
+
+	// PRs: merged / failed / conflicting
+	prSummary := fmt.Sprintf("%d merged  %d failed  %d conflict",
+		snap.PRsMerged, snap.PRsFailed, snap.PRsConflicting)
+	content.WriteString(dotLeader("PRs", prSummary, w))
+	content.WriteString("\n")
+
+	// Queue depths
+	queueStr := fmt.Sprintf("%d pending  %d failed", snap.QueueDepth, snap.FailedQueueDepth)
+	if snap.FailedQueueDepth > 5 {
+		content.WriteString(dotLeaderStyled("Queue", queueStr, warningStyle, w))
+	} else {
+		content.WriteString(dotLeader("Queue", queueStr, w))
+	}
+	content.WriteString("\n")
+
+	// API error rate
+	errRateStr := fmt.Sprintf("%.1f/min", snap.APIErrorRate)
+	if snap.APIErrorRate >= 10 {
+		content.WriteString(dotLeaderStyled("API errors", errRateStr, statusFailedStyle, w))
+	} else if snap.APIErrorRate >= 1 {
+		content.WriteString(dotLeaderStyled("API errors", errRateStr, warningStyle, w))
+	} else {
+		content.WriteString(dotLeader("API errors", errRateStr, w))
+	}
+	content.WriteString("\n")
+
+	// Circuit breaker
+	cbStr := fmt.Sprintf("%d trips", snap.CircuitBreakerTrips)
+	if snap.CircuitBreakerTrips > 0 {
+		content.WriteString(dotLeaderStyled("CB trips", cbStr, statusFailedStyle, w))
+	} else {
+		content.WriteString(dotLeader("CB trips", cbStr, w))
+	}
+	content.WriteString("\n")
+
+	// Avg timings
+	if snap.AvgCIWaitDuration > 0 {
+		content.WriteString(dotLeader("Avg CI wait", formatDurationCompact(snap.AvgCIWaitDuration), w))
+		content.WriteString("\n")
+	}
+	if snap.AvgPRTimeToMerge > 0 {
+		content.WriteString(dotLeader("Avg merge time", formatDurationCompact(snap.AvgPRTimeToMerge), w))
+	}
+
+	return renderPanel("HEALTH", content.String())
+}
+
+// formatDurationCompact formats a duration compactly (e.g., "2m30s", "1h5m").
+func formatDurationCompact(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		m := int(d.Minutes())
+		s := int(d.Seconds()) % 60
+		if s == 0 {
+			return fmt.Sprintf("%dm", m)
+		}
+		return fmt.Sprintf("%dm%ds", m, s)
+	}
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	if m == 0 {
+		return fmt.Sprintf("%dh", h)
+	}
+	return fmt.Sprintf("%dh%dm", h, m)
+}
+
 // TaskDisplay represents a task for display
 type TaskDisplay struct {
 	ID       string
@@ -285,6 +389,7 @@ type Model struct {
 	completedTasks []CompletedTask
 	costPerMToken  float64
 	autopilotPanel *AutopilotPanel
+	healthPanel    *HealthPanel
 	version        string
 	store          *memory.Store // SQLite persistence (GH-367)
 	sessionID      string        // Current session ID for persistence
@@ -341,6 +446,7 @@ func NewModel(version string) Model {
 		completedTasks: []CompletedTask{},
 		costPerMToken:  3.0,
 		autopilotPanel: NewAutopilotPanel(nil), // Disabled by default
+		healthPanel:    NewHealthPanel(nil),
 		version:        version,
 	}
 }
@@ -355,6 +461,7 @@ func NewModelWithStore(version string, store *memory.Store) Model {
 		completedTasks: []CompletedTask{},
 		costPerMToken:  3.0,
 		autopilotPanel: NewAutopilotPanel(nil),
+		healthPanel:    NewHealthPanel(nil),
 		version:        version,
 		store:          store,
 	}
@@ -371,6 +478,7 @@ func NewModelWithAutopilot(version string, controller *autopilot.Controller) Mod
 		completedTasks: []CompletedTask{},
 		costPerMToken:  3.0,
 		autopilotPanel: NewAutopilotPanel(controller),
+		healthPanel:    NewHealthPanel(controller),
 		version:        version,
 	}
 }
@@ -384,6 +492,7 @@ func NewModelWithStoreAndAutopilot(version string, store *memory.Store, controll
 		completedTasks: []CompletedTask{},
 		costPerMToken:  3.0,
 		autopilotPanel: NewAutopilotPanel(controller),
+		healthPanel:    NewHealthPanel(controller),
 		version:        version,
 		store:          store,
 	}
@@ -526,6 +635,7 @@ func NewModelWithOptions(version string, store *memory.Store, controller *autopi
 		completedTasks: []CompletedTask{},
 		costPerMToken:  3.0,
 		autopilotPanel: NewAutopilotPanel(controller),
+		healthPanel:    NewHealthPanel(controller),
 		version:        version,
 		store:          store,
 		upgradeCh:      upgradeCh,
@@ -703,6 +813,12 @@ func (m Model) View() string {
 	// Autopilot panel
 	b.WriteString(m.autopilotPanel.View())
 	b.WriteString("\n")
+
+	// Health metrics panel (GH-728)
+	if m.healthPanel != nil {
+		b.WriteString(m.healthPanel.View())
+		b.WriteString("\n")
+	}
 
 	// History
 	b.WriteString(m.renderHistory())

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -180,6 +180,28 @@ func (s *Store) migrate() error {
 			tasks_failed INTEGER DEFAULT 0
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_date ON sessions(date)`,
+		// Autopilot metrics snapshots (GH-728)
+		`CREATE TABLE IF NOT EXISTS autopilot_metrics (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			snapshot_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			issues_success INTEGER DEFAULT 0,
+			issues_failed INTEGER DEFAULT 0,
+			issues_rate_limited INTEGER DEFAULT 0,
+			prs_merged INTEGER DEFAULT 0,
+			prs_failed INTEGER DEFAULT 0,
+			prs_conflicting INTEGER DEFAULT 0,
+			circuit_breaker_trips INTEGER DEFAULT 0,
+			api_errors_total INTEGER DEFAULT 0,
+			api_error_rate REAL DEFAULT 0.0,
+			queue_depth INTEGER DEFAULT 0,
+			failed_queue_depth INTEGER DEFAULT 0,
+			active_prs INTEGER DEFAULT 0,
+			success_rate REAL DEFAULT 0.0,
+			avg_ci_wait_ms INTEGER DEFAULT 0,
+			avg_merge_time_ms INTEGER DEFAULT 0,
+			avg_execution_ms INTEGER DEFAULT 0
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_autopilot_metrics_at ON autopilot_metrics(snapshot_at)`,
 	}
 
 	for _, migration := range migrations {
@@ -1224,4 +1246,88 @@ func (s *Store) EndSession(sessionID string) error {
 		UPDATE sessions SET ended_at = CURRENT_TIMESTAMP WHERE id = ?
 	`, sessionID)
 	return err
+}
+
+// AutopilotMetricsRow represents a persisted autopilot metrics snapshot.
+type AutopilotMetricsRow struct {
+	ID                  int64
+	SnapshotAt          time.Time
+	IssuesSuccess       int
+	IssuesFailed        int
+	IssuesRateLimited   int
+	PRsMerged           int
+	PRsFailed           int
+	PRsConflicting      int
+	CircuitBreakerTrips int
+	APIErrorsTotal      int
+	APIErrorRate        float64
+	QueueDepth          int
+	FailedQueueDepth    int
+	ActivePRs           int
+	SuccessRate         float64
+	AvgCIWaitMs         int64
+	AvgMergeTimeMs      int64
+	AvgExecutionMs      int64
+}
+
+// SaveAutopilotMetrics persists an autopilot metrics snapshot to SQLite.
+func (s *Store) SaveAutopilotMetrics(row *AutopilotMetricsRow) error {
+	_, err := s.db.Exec(`
+		INSERT INTO autopilot_metrics (
+			snapshot_at, issues_success, issues_failed, issues_rate_limited,
+			prs_merged, prs_failed, prs_conflicting, circuit_breaker_trips,
+			api_errors_total, api_error_rate, queue_depth, failed_queue_depth,
+			active_prs, success_rate, avg_ci_wait_ms, avg_merge_time_ms, avg_execution_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		row.SnapshotAt,
+		row.IssuesSuccess, row.IssuesFailed, row.IssuesRateLimited,
+		row.PRsMerged, row.PRsFailed, row.PRsConflicting,
+		row.CircuitBreakerTrips, row.APIErrorsTotal, row.APIErrorRate,
+		row.QueueDepth, row.FailedQueueDepth, row.ActivePRs,
+		row.SuccessRate, row.AvgCIWaitMs, row.AvgMergeTimeMs, row.AvgExecutionMs,
+	)
+	return err
+}
+
+// GetRecentAutopilotMetrics returns the most recent metrics snapshots.
+func (s *Store) GetRecentAutopilotMetrics(limit int) ([]*AutopilotMetricsRow, error) {
+	rows, err := s.db.Query(`
+		SELECT id, snapshot_at, issues_success, issues_failed, issues_rate_limited,
+			prs_merged, prs_failed, prs_conflicting, circuit_breaker_trips,
+			api_errors_total, api_error_rate, queue_depth, failed_queue_depth,
+			active_prs, success_rate, avg_ci_wait_ms, avg_merge_time_ms, avg_execution_ms
+		FROM autopilot_metrics
+		ORDER BY snapshot_at DESC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query autopilot metrics: %w", err)
+	}
+	defer rows.Close()
+
+	var result []*AutopilotMetricsRow
+	for rows.Next() {
+		r := &AutopilotMetricsRow{}
+		if err := rows.Scan(
+			&r.ID, &r.SnapshotAt, &r.IssuesSuccess, &r.IssuesFailed, &r.IssuesRateLimited,
+			&r.PRsMerged, &r.PRsFailed, &r.PRsConflicting, &r.CircuitBreakerTrips,
+			&r.APIErrorsTotal, &r.APIErrorRate, &r.QueueDepth, &r.FailedQueueDepth,
+			&r.ActivePRs, &r.SuccessRate, &r.AvgCIWaitMs, &r.AvgMergeTimeMs, &r.AvgExecutionMs,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan autopilot metrics: %w", err)
+		}
+		result = append(result, r)
+	}
+	return result, rows.Err()
+}
+
+// PruneAutopilotMetrics deletes snapshots older than the given duration.
+func (s *Store) PruneAutopilotMetrics(olderThan time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-olderThan)
+	result, err := s.db.Exec(`DELETE FROM autopilot_metrics WHERE snapshot_at < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-728.

## Changes

GitHub Issue #728: feat(autopilot): failure metrics and alerting dashboard

## Problem
No visibility into autopilot health. Silent failures accumulate. No way to know:
- How many issues are stuck in `pilot-failed`
- Circuit breaker trip frequency
- API error rate
- Average time in `StageWaitingCI`
- Success/failure ratio

## Fix

### Metrics collection
Create `internal/autopilot/metrics.go`:
1. Track counters:
   - `issues_processed_total` (by result: success, failed, rate_limited)
   - `prs_merged_total`, `prs_failed_total`, `prs_conflicting_total`
   - `circuit_breaker_trips_total`
   - `api_errors_total` (by endpoint)
   - `label_cleanup_total` (by label type)
2. Track gauges:
   - `active_prs` (by stage)
   - `queue_depth` (issues with `pilot` label, no `pilot-in-progress`)
   - `failed_queue_depth` (issues with `pilot-failed`)
3. Track histograms:
   - `pr_time_to_merge_seconds`
   - `ci_wait_duration_seconds`
   - `execution_duration_seconds`

### Alerting
Wire into existing alerts engine (`internal/alerts/`):
4. Alert rules:
   - `failed_queue_depth > 5` → Slack/Telegram warning
   - `circuit_breaker_trips > 0` → Slack/Telegram critical
   - `api_error_rate > 10/min` → Slack/Telegram warning
   - `pr_stuck_waiting_ci > 15min` → Slack/Telegram info

### Dashboard
5. Add METRICS card to TUI dashboard showing key health indicators

## Acceptance Criteria
- Metrics collected for all autopilot operations
- Alerts fire on critical conditions
- Dashboard shows health summary
- Metrics persisted to SQLite for history