### PR TITLE
Add RBAC check before task execution and tests

### DIFF
--- a/internal/adapters/slack/handler.go
+++ b/internal/adapters/slack/handler.go
@@ -1,0 +1,209 @@
+package slack
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// MemberResolver resolves a Slack user to a team member ID for RBAC (GH-786).
+// Decoupled from teams package to avoid import cycles.
+type MemberResolver interface {
+	// ResolveSlackIdentity maps a Slack user ID and/or email to a member ID.
+	// Returns ("", nil) when no match is found (= skip RBAC).
+	ResolveSlackIdentity(slackUserID, email string) (string, error)
+}
+
+// TeamChecker checks if a member has required permissions (GH-787).
+// Decoupled from teams package to avoid import cycles.
+type TeamChecker interface {
+	// CheckPermission verifies a member has a specific permission.
+	CheckPermission(memberID string, perm string) error
+}
+
+// Handler processes incoming Slack events and coordinates task execution.
+// Mirrors Telegram handler's RBAC support with memberResolver and lastSender tracking.
+type Handler struct {
+	client         *SocketModeClient
+	usersClient    *UsersClient         // Slack users API client (optional, for email lookup)
+	slackClient    *Client              // Slack API client for sending messages
+	memberResolver MemberResolver       // Team member resolver for RBAC (optional, GH-786)
+	teamChecker    TeamChecker          // Permission checker for RBAC (optional, GH-787)
+	lastSender     map[string]string    // channelID -> last sender Slack user ID
+	mu             sync.Mutex
+	log            *slog.Logger
+}
+
+// HandlerConfig holds configuration for the Slack handler.
+type HandlerConfig struct {
+	AppToken       string         // Slack app-level token (xapp-...)
+	BotToken       string         // Slack bot token (xoxb-...) for API calls
+	MemberResolver MemberResolver // Team member resolver for RBAC (optional, GH-786)
+	TeamChecker    TeamChecker    // Permission checker for RBAC (optional, GH-787)
+}
+
+// NewHandler creates a new Slack event handler.
+func NewHandler(config *HandlerConfig) *Handler {
+	h := &Handler{
+		client:         NewSocketModeClient(config.AppToken),
+		memberResolver: config.MemberResolver,
+		teamChecker:    config.TeamChecker,
+		lastSender:     make(map[string]string),
+		log:            logging.WithComponent("slack.handler"),
+	}
+
+	if config.BotToken != "" {
+		h.usersClient = NewUsersClient(config.BotToken)
+		h.slackClient = NewClient(config.BotToken)
+	}
+
+	return h
+}
+
+// TrackSender records the user ID of the last sender in a channel.
+// Called during event processing to track who sent messages for RBAC.
+func (h *Handler) TrackSender(channelID, userID string) {
+	if channelID == "" || userID == "" {
+		return
+	}
+	h.mu.Lock()
+	h.lastSender[channelID] = userID
+	h.mu.Unlock()
+}
+
+// resolveMemberID resolves the current Slack sender to a team member ID (GH-786).
+// Returns "" if no resolver is configured or no match is found.
+func (h *Handler) resolveMemberID(channelID string) string {
+	if h.memberResolver == nil {
+		return ""
+	}
+
+	h.mu.Lock()
+	senderID := h.lastSender[channelID]
+	h.mu.Unlock()
+
+	if senderID == "" {
+		return ""
+	}
+
+	// Try to resolve by Slack user ID first
+	memberID, err := h.memberResolver.ResolveSlackIdentity(senderID, "")
+	if err != nil {
+		h.log.Warn("failed to resolve Slack identity",
+			slog.String("slack_user_id", senderID),
+			slog.Any("error", err))
+		return ""
+	}
+
+	// If found by Slack user ID, return immediately
+	if memberID != "" {
+		h.log.Debug("resolved Slack user to team member",
+			slog.String("slack_user_id", senderID),
+			slog.String("member_id", memberID))
+		return memberID
+	}
+
+	// Fall back to email lookup if usersClient is available
+	if h.usersClient != nil {
+		userInfo, err := h.usersClient.GetUserInfo(context.Background(), senderID)
+		if err != nil {
+			h.log.Warn("failed to fetch Slack user info",
+				slog.String("slack_user_id", senderID),
+				slog.Any("error", err))
+			return ""
+		}
+
+		if userInfo.Email != "" {
+			memberID, err = h.memberResolver.ResolveSlackIdentity("", userInfo.Email)
+			if err != nil {
+				h.log.Warn("failed to resolve Slack identity by email",
+					slog.String("email", userInfo.Email),
+					slog.Any("error", err))
+				return ""
+			}
+			if memberID != "" {
+				h.log.Debug("resolved Slack user to team member via email",
+					slog.String("slack_user_id", senderID),
+					slog.String("email", userInfo.Email),
+					slog.String("member_id", memberID))
+				return memberID
+			}
+		}
+	}
+
+	return ""
+}
+
+// ResolveMemberIDForChannel resolves the Slack sender in a channel to a member ID (GH-787).
+// This is the public API for RBAC integration in the execution flow.
+// Returns "" if no resolver is configured or no match is found.
+func (h *Handler) ResolveMemberIDForChannel(channelID string) string {
+	return h.resolveMemberID(channelID)
+}
+
+// CheckTaskPermission verifies the sender has permission to execute tasks (GH-787).
+// Returns nil if:
+//   - No memberResolver or teamChecker is configured (RBAC disabled)
+//   - Member is found and has execute_tasks permission
+//
+// Returns error if member is found but lacks permission.
+// Sends rejection message to channel on permission denied.
+func (h *Handler) CheckTaskPermission(ctx context.Context, channelID, threadTS string) error {
+	if h.memberResolver == nil || h.teamChecker == nil {
+		// RBAC not configured — allow all
+		return nil
+	}
+
+	memberID := h.resolveMemberID(channelID)
+	if memberID == "" {
+		// No member mapping found — allow (soft RBAC)
+		h.log.Debug("no member mapping found, allowing task",
+			slog.String("channel_id", channelID))
+		return nil
+	}
+
+	err := h.teamChecker.CheckPermission(memberID, "execute_tasks")
+	if err != nil {
+		h.log.Warn("task execution denied by RBAC",
+			slog.String("member_id", memberID),
+			slog.String("channel_id", channelID),
+			slog.Any("error", err))
+
+		// Send rejection message if slackClient is available
+		if h.slackClient != nil {
+			h.sendRejectionMessage(ctx, channelID, threadTS)
+		}
+
+		return err
+	}
+
+	h.log.Debug("RBAC check passed",
+		slog.String("member_id", memberID),
+		slog.String("channel_id", channelID))
+	return nil
+}
+
+// sendRejectionMessage sends an unauthorized message to the channel.
+func (h *Handler) sendRejectionMessage(ctx context.Context, channelID, threadTS string) {
+	msg := &Message{
+		Channel:  channelID,
+		Text:     "You don't have permission to execute tasks. Please contact your team admin.",
+		ThreadTS: threadTS,
+	}
+
+	if _, err := h.slackClient.PostMessage(ctx, msg); err != nil {
+		h.log.Warn("failed to send rejection message",
+			slog.String("channel_id", channelID),
+			slog.Any("error", err))
+	}
+}
+
+// GetLastSender returns the last sender user ID for a channel.
+// Useful for testing and debugging.
+func (h *Handler) GetLastSender(channelID string) string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.lastSender[channelID]
+}

--- a/internal/adapters/slack/handler_test.go
+++ b/internal/adapters/slack/handler_test.go
@@ -1,0 +1,389 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// mockMemberResolver implements MemberResolver for testing.
+type mockMemberResolver struct {
+	mappings map[string]string // slackUserID or email -> memberID
+}
+
+func (m *mockMemberResolver) ResolveSlackIdentity(slackUserID, email string) (string, error) {
+	if m.mappings == nil {
+		return "", nil
+	}
+	if slackUserID != "" {
+		if id, ok := m.mappings[slackUserID]; ok {
+			return id, nil
+		}
+	}
+	if email != "" {
+		if id, ok := m.mappings[email]; ok {
+			return id, nil
+		}
+	}
+	return "", nil
+}
+
+// mockTeamChecker implements TeamChecker for testing.
+type mockTeamChecker struct {
+	permissions map[string]map[string]bool // memberID -> perm -> allowed
+}
+
+func (m *mockTeamChecker) CheckPermission(memberID string, perm string) error {
+	if m.permissions == nil {
+		return errors.New("permission denied")
+	}
+	if perms, ok := m.permissions[memberID]; ok {
+		if perms[perm] {
+			return nil
+		}
+	}
+	return errors.New("permission denied")
+}
+
+func TestHandler_TrackSender(t *testing.T) {
+	h := NewHandler(&HandlerConfig{
+		AppToken: "xapp-test-token",
+	})
+
+	// Track a sender
+	h.TrackSender("C12345", "U67890")
+
+	// Verify tracking
+	got := h.GetLastSender("C12345")
+	if got != "U67890" {
+		t.Errorf("GetLastSender() = %q, want %q", got, "U67890")
+	}
+
+	// Empty channel/user should not track
+	h.TrackSender("", "U11111")
+	h.TrackSender("C22222", "")
+
+	if h.GetLastSender("") != "" {
+		t.Error("empty channel should not be tracked")
+	}
+	if h.GetLastSender("C22222") != "" {
+		t.Error("empty user should not be tracked")
+	}
+}
+
+func TestHandler_TrackSender_OverwritesPrevious(t *testing.T) {
+	h := NewHandler(&HandlerConfig{
+		AppToken: "xapp-test-token",
+	})
+
+	h.TrackSender("C12345", "U11111")
+	h.TrackSender("C12345", "U22222")
+
+	got := h.GetLastSender("C12345")
+	if got != "U22222" {
+		t.Errorf("GetLastSender() = %q, want %q (should overwrite)", got, "U22222")
+	}
+}
+
+func TestHandler_ResolveMemberID_NoResolver(t *testing.T) {
+	h := NewHandler(&HandlerConfig{
+		AppToken: "xapp-test-token",
+		// No MemberResolver
+	})
+
+	h.TrackSender("C12345", "U67890")
+
+	// Without resolver, should return empty string
+	got := h.resolveMemberID("C12345")
+	if got != "" {
+		t.Errorf("resolveMemberID() without resolver = %q, want empty", got)
+	}
+}
+
+func TestHandler_ResolveMemberID_WithResolver(t *testing.T) {
+	resolver := &mockMemberResolver{
+		mappings: map[string]string{
+			"U67890": "member-alice",
+			"U11111": "member-bob",
+		},
+	}
+
+	h := NewHandler(&HandlerConfig{
+		AppToken:       "xapp-test-token",
+		MemberResolver: resolver,
+	})
+
+	// Track and resolve
+	h.TrackSender("C12345", "U67890")
+	got := h.resolveMemberID("C12345")
+	if got != "member-alice" {
+		t.Errorf("resolveMemberID() = %q, want %q", got, "member-alice")
+	}
+
+	// Different channel, different user
+	h.TrackSender("C99999", "U11111")
+	got = h.resolveMemberID("C99999")
+	if got != "member-bob" {
+		t.Errorf("resolveMemberID() = %q, want %q", got, "member-bob")
+	}
+}
+
+func TestHandler_ResolveMemberID_UnknownUser(t *testing.T) {
+	resolver := &mockMemberResolver{
+		mappings: map[string]string{
+			"U67890": "member-alice",
+		},
+	}
+
+	h := NewHandler(&HandlerConfig{
+		AppToken:       "xapp-test-token",
+		MemberResolver: resolver,
+	})
+
+	h.TrackSender("C12345", "U99999") // Unknown user
+	got := h.resolveMemberID("C12345")
+	if got != "" {
+		t.Errorf("resolveMemberID() for unknown user = %q, want empty", got)
+	}
+}
+
+func TestHandler_ResolveMemberID_NoSenderTracked(t *testing.T) {
+	resolver := &mockMemberResolver{
+		mappings: map[string]string{
+			"U67890": "member-alice",
+		},
+	}
+
+	h := NewHandler(&HandlerConfig{
+		AppToken:       "xapp-test-token",
+		MemberResolver: resolver,
+	})
+
+	// No sender tracked for this channel
+	got := h.resolveMemberID("C12345")
+	if got != "" {
+		t.Errorf("resolveMemberID() with no sender = %q, want empty", got)
+	}
+}
+
+func TestNewHandler(t *testing.T) {
+	resolver := &mockMemberResolver{}
+
+	h := NewHandler(&HandlerConfig{
+		AppToken:       "xapp-test-token",
+		MemberResolver: resolver,
+	})
+
+	if h.client == nil {
+		t.Error("NewHandler() should initialize client")
+	}
+	if h.memberResolver != resolver {
+		t.Error("NewHandler() should set memberResolver from config")
+	}
+	if h.lastSender == nil {
+		t.Error("NewHandler() should initialize lastSender map")
+	}
+	if h.log == nil {
+		t.Error("NewHandler() should initialize logger")
+	}
+}
+
+func TestNewHandler_WithBotToken(t *testing.T) {
+	h := NewHandler(&HandlerConfig{
+		AppToken: "xapp-test-token",
+		BotToken: "xoxb-test-token",
+	})
+
+	if h.usersClient == nil {
+		t.Error("NewHandler() with BotToken should initialize usersClient")
+	}
+	if h.slackClient == nil {
+		t.Error("NewHandler() with BotToken should initialize slackClient")
+	}
+}
+
+func TestHandler_CheckTaskPermission(t *testing.T) {
+	tests := []struct {
+		name        string
+		resolver    MemberResolver
+		checker     TeamChecker
+		channelID   string
+		senderID    string
+		wantErr     bool
+		description string
+	}{
+		{
+			name: "admin can execute",
+			resolver: &mockMemberResolver{
+				mappings: map[string]string{"U_ADMIN": "member-admin"},
+			},
+			checker: &mockTeamChecker{
+				permissions: map[string]map[string]bool{
+					"member-admin": {"execute_tasks": true},
+				},
+			},
+			channelID:   "C001",
+			senderID:    "U_ADMIN",
+			wantErr:     false,
+			description: "Admin with execute_tasks permission should be allowed",
+		},
+		{
+			name: "viewer cannot execute",
+			resolver: &mockMemberResolver{
+				mappings: map[string]string{"U_VIEWER": "member-viewer"},
+			},
+			checker: &mockTeamChecker{
+				permissions: map[string]map[string]bool{
+					"member-viewer": {"view_tasks": true},
+				},
+			},
+			channelID:   "C002",
+			senderID:    "U_VIEWER",
+			wantErr:     true,
+			description: "Viewer without execute_tasks permission should be denied",
+		},
+		{
+			name: "unknown user allowed (soft RBAC)",
+			resolver: &mockMemberResolver{
+				mappings: map[string]string{}, // user not mapped
+			},
+			checker: &mockTeamChecker{
+				permissions: map[string]map[string]bool{},
+			},
+			channelID:   "C003",
+			senderID:    "U_UNMAPPED",
+			wantErr:     false,
+			description: "Unmapped users should be allowed (soft RBAC)",
+		},
+		{
+			name:        "no resolver configured",
+			resolver:    nil,
+			checker:     &mockTeamChecker{},
+			channelID:   "C004",
+			senderID:    "U_ANY",
+			wantErr:     false,
+			description: "Without resolver, all should be allowed",
+		},
+		{
+			name: "no checker configured",
+			resolver: &mockMemberResolver{
+				mappings: map[string]string{"U_ANY": "member-any"},
+			},
+			checker:     nil,
+			channelID:   "C005",
+			senderID:    "U_ANY",
+			wantErr:     false,
+			description: "Without checker, all should be allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Handler{
+				memberResolver: tt.resolver,
+				teamChecker:    tt.checker,
+				lastSender:     make(map[string]string),
+				log:            slog.Default(),
+			}
+
+			if tt.senderID != "" {
+				h.TrackSender(tt.channelID, tt.senderID)
+			}
+
+			err := h.CheckTaskPermission(context.Background(), tt.channelID, "")
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error: %s", tt.description)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error (%s): %v", tt.description, err)
+			}
+		})
+	}
+}
+
+func TestHandler_ResolveMemberIDWithEmailFallback(t *testing.T) {
+	// Create a mock server that returns user info with email
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/users.info" {
+			userID := r.URL.Query().Get("user")
+			w.Header().Set("Content-Type", "application/json")
+			resp := usersInfoResponse{
+				OK: true,
+				User: struct {
+					ID       string `json:"id"`
+					Name     string `json:"name"`
+					RealName string `json:"real_name"`
+					Profile  struct {
+						Email    string `json:"email"`
+						RealName string `json:"real_name_normalized"`
+					} `json:"profile"`
+				}{
+					ID:   userID,
+					Name: "testuser",
+					Profile: struct {
+						Email    string `json:"email"`
+						RealName string `json:"real_name_normalized"`
+					}{
+						Email: "dev@example.com",
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	// Resolver that only knows about email, not slack user ID
+	resolver := &mockMemberResolver{
+		mappings: map[string]string{
+			"dev@example.com": "member-via-email",
+		},
+	}
+
+	h := &Handler{
+		memberResolver: resolver,
+		usersClient:    NewUsersClientWithBaseURL("test-token", server.URL),
+		lastSender:     make(map[string]string),
+		log:            slog.Default(),
+	}
+
+	h.TrackSender("C_TEST", "U_NEW_USER")
+
+	got := h.ResolveMemberIDForChannel("C_TEST")
+	if got != "member-via-email" {
+		t.Errorf("expected member-via-email, got %q", got)
+	}
+}
+
+func TestHandler_ResolveMemberIDForChannel(t *testing.T) {
+	resolver := &mockMemberResolver{
+		mappings: map[string]string{
+			"U12345": "member-123",
+		},
+	}
+
+	h := &Handler{
+		memberResolver: resolver,
+		lastSender:     make(map[string]string),
+		log:            slog.Default(),
+	}
+
+	h.TrackSender("C001", "U12345")
+
+	got := h.ResolveMemberIDForChannel("C001")
+	if got != "member-123" {
+		t.Errorf("ResolveMemberIDForChannel() = %q, want %q", got, "member-123")
+	}
+
+	// Unknown channel should return empty
+	got = h.ResolveMemberIDForChannel("C_UNKNOWN")
+	if got != "" {
+		t.Errorf("ResolveMemberIDForChannel() for unknown channel = %q, want empty", got)
+	}
+}

--- a/internal/adapters/slack/users.go
+++ b/internal/adapters/slack/users.go
@@ -1,0 +1,153 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// UserInfo represents Slack user profile data from users.info API.
+type UserInfo struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	RealName string `json:"real_name"`
+	Email    string `json:"email"`
+}
+
+// UsersClient provides access to Slack's users.* API endpoints with caching.
+type UsersClient struct {
+	botToken   string
+	apiURL     string
+	httpClient *http.Client
+
+	mu    sync.RWMutex
+	cache map[string]cachedUser
+}
+
+// cachedUser holds user info with expiry timestamp.
+type cachedUser struct {
+	user      *UserInfo
+	expiresAt time.Time
+}
+
+// cacheTTL defines how long cached user info remains valid.
+const cacheTTL = 5 * time.Minute
+
+// NewUsersClient creates a new Slack users API client.
+func NewUsersClient(botToken string) *UsersClient {
+	return &UsersClient{
+		botToken:   botToken,
+		apiURL:     slackAPIURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		cache:      make(map[string]cachedUser),
+	}
+}
+
+// NewUsersClientWithBaseURL creates a users client with custom API base URL (for testing).
+func NewUsersClientWithBaseURL(botToken, baseURL string) *UsersClient {
+	return &UsersClient{
+		botToken:   botToken,
+		apiURL:     baseURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		cache:      make(map[string]cachedUser),
+	}
+}
+
+// usersInfoResponse is the JSON response from users.info API.
+type usersInfoResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+	User  struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		RealName string `json:"real_name"`
+		Profile  struct {
+			Email    string `json:"email"`
+			RealName string `json:"real_name_normalized"`
+		} `json:"profile"`
+	} `json:"user"`
+}
+
+// GetUserInfo fetches user profile info by Slack user ID.
+// Results are cached for cacheTTL to reduce API calls.
+func (c *UsersClient) GetUserInfo(ctx context.Context, userID string) (*UserInfo, error) {
+	// Check cache first
+	c.mu.RLock()
+	cached, ok := c.cache[userID]
+	c.mu.RUnlock()
+
+	if ok && time.Now().Before(cached.expiresAt) {
+		return cached.user, nil
+	}
+
+	// Fetch from API
+	user, err := c.fetchUserInfo(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the result
+	c.mu.Lock()
+	c.cache[userID] = cachedUser{
+		user:      user,
+		expiresAt: time.Now().Add(cacheTTL),
+	}
+	c.mu.Unlock()
+
+	return user, nil
+}
+
+// fetchUserInfo calls users.info API without caching.
+func (c *UsersClient) fetchUserInfo(ctx context.Context, userID string) (*UserInfo, error) {
+	url := fmt.Sprintf("%s/users.info?user=%s", c.apiURL, userID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.botToken)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("users.info request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("users.info HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result usersInfoResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	if !result.OK {
+		return nil, fmt.Errorf("users.info error: %s", result.Error)
+	}
+
+	return &UserInfo{
+		ID:       result.User.ID,
+		Name:     result.User.Name,
+		RealName: result.User.RealName,
+		Email:    result.User.Profile.Email,
+	}, nil
+}
+
+// ClearCache removes all cached entries. Useful for testing.
+func (c *UsersClient) ClearCache() {
+	c.mu.Lock()
+	c.cache = make(map[string]cachedUser)
+	c.mu.Unlock()
+}

--- a/internal/adapters/slack/users_test.go
+++ b/internal/adapters/slack/users_test.go
@@ -1,0 +1,276 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestUsersClient_GetUserInfo(t *testing.T) {
+	tests := []struct {
+		name         string
+		userID       string
+		serverResp   usersInfoResponse
+		wantEmail    string
+		wantName     string
+		wantRealName string
+		wantErr      bool
+	}{
+		{
+			name:   "successful fetch",
+			userID: "U12345",
+			serverResp: usersInfoResponse{
+				OK: true,
+				User: struct {
+					ID       string `json:"id"`
+					Name     string `json:"name"`
+					RealName string `json:"real_name"`
+					Profile  struct {
+						Email    string `json:"email"`
+						RealName string `json:"real_name_normalized"`
+					} `json:"profile"`
+				}{
+					ID:       "U12345",
+					Name:     "testuser",
+					RealName: "Test User",
+					Profile: struct {
+						Email    string `json:"email"`
+						RealName string `json:"real_name_normalized"`
+					}{
+						Email:    "test@example.com",
+						RealName: "Test User",
+					},
+				},
+			},
+			wantEmail:    "test@example.com",
+			wantName:     "testuser",
+			wantRealName: "Test User",
+		},
+		{
+			name:   "user not found",
+			userID: "U99999",
+			serverResp: usersInfoResponse{
+				OK:    false,
+				Error: "user_not_found",
+			},
+			wantErr: true,
+		},
+		{
+			name:   "user without email",
+			userID: "U11111",
+			serverResp: usersInfoResponse{
+				OK: true,
+				User: struct {
+					ID       string `json:"id"`
+					Name     string `json:"name"`
+					RealName string `json:"real_name"`
+					Profile  struct {
+						Email    string `json:"email"`
+						RealName string `json:"real_name_normalized"`
+					} `json:"profile"`
+				}{
+					ID:   "U11111",
+					Name: "bot",
+				},
+			},
+			wantEmail:    "",
+			wantName:     "bot",
+			wantRealName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/users.info" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+
+				if r.URL.Query().Get("user") != tt.userID {
+					t.Errorf("unexpected user ID: got %s, want %s", r.URL.Query().Get("user"), tt.userID)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(tt.serverResp); err != nil {
+					t.Fatalf("failed to encode response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			client := NewUsersClientWithBaseURL("test-token", server.URL)
+			info, err := client.GetUserInfo(context.Background(), tt.userID)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if info.Email != tt.wantEmail {
+				t.Errorf("email: got %q, want %q", info.Email, tt.wantEmail)
+			}
+			if info.Name != tt.wantName {
+				t.Errorf("name: got %q, want %q", info.Name, tt.wantName)
+			}
+			if info.RealName != tt.wantRealName {
+				t.Errorf("real_name: got %q, want %q", info.RealName, tt.wantRealName)
+			}
+		})
+	}
+}
+
+func TestUsersClient_Caching(t *testing.T) {
+	callCount := 0
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := usersInfoResponse{
+			OK: true,
+			User: struct {
+				ID       string `json:"id"`
+				Name     string `json:"name"`
+				RealName string `json:"real_name"`
+				Profile  struct {
+					Email    string `json:"email"`
+					RealName string `json:"real_name_normalized"`
+				} `json:"profile"`
+			}{
+				ID:   "U12345",
+				Name: "testuser",
+				Profile: struct {
+					Email    string `json:"email"`
+					RealName string `json:"real_name_normalized"`
+				}{
+					Email: "test@example.com",
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewUsersClientWithBaseURL("test-token", server.URL)
+	ctx := context.Background()
+
+	// First call — should hit the server
+	_, err := client.GetUserInfo(ctx, "U12345")
+	if err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+
+	mu.Lock()
+	if callCount != 1 {
+		t.Errorf("first call: expected 1 server call, got %d", callCount)
+	}
+	mu.Unlock()
+
+	// Second call — should hit cache
+	_, err = client.GetUserInfo(ctx, "U12345")
+	if err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+
+	mu.Lock()
+	if callCount != 1 {
+		t.Errorf("second call: expected 1 server call (cached), got %d", callCount)
+	}
+	mu.Unlock()
+
+	// Different user — should hit server
+	_, _ = client.GetUserInfo(ctx, "U99999")
+
+	mu.Lock()
+	if callCount != 2 {
+		t.Errorf("different user: expected 2 server calls, got %d", callCount)
+	}
+	mu.Unlock()
+}
+
+func TestUsersClient_ClearCache(t *testing.T) {
+	callCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		resp := usersInfoResponse{
+			OK: true,
+			User: struct {
+				ID       string `json:"id"`
+				Name     string `json:"name"`
+				RealName string `json:"real_name"`
+				Profile  struct {
+					Email    string `json:"email"`
+					RealName string `json:"real_name_normalized"`
+				} `json:"profile"`
+			}{
+				ID:   "U12345",
+				Name: "testuser",
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewUsersClientWithBaseURL("test-token", server.URL)
+	ctx := context.Background()
+
+	// First call
+	_, _ = client.GetUserInfo(ctx, "U12345")
+	if callCount != 1 {
+		t.Errorf("expected 1 call, got %d", callCount)
+	}
+
+	// Clear cache
+	client.ClearCache()
+
+	// Second call should hit server again
+	_, _ = client.GetUserInfo(ctx, "U12345")
+	if callCount != 2 {
+		t.Errorf("expected 2 calls after cache clear, got %d", callCount)
+	}
+}
+
+func TestUsersClient_CacheExpiry(t *testing.T) {
+	// This test verifies the cache expiry logic by manually setting an expired entry
+	client := &UsersClient{
+		botToken:   "test-token",
+		apiURL:     "http://localhost",
+		httpClient: &http.Client{Timeout: 1 * time.Second},
+		cache:      make(map[string]cachedUser),
+	}
+
+	// Add an expired cache entry
+	client.cache["U12345"] = cachedUser{
+		user:      &UserInfo{ID: "U12345", Email: "old@example.com"},
+		expiresAt: time.Now().Add(-1 * time.Hour), // expired
+	}
+
+	// Check that we need to refresh (simulated by checking expiry)
+	client.mu.RLock()
+	cached, ok := client.cache["U12345"]
+	client.mu.RUnlock()
+
+	if !ok {
+		t.Fatal("expected cache entry to exist")
+	}
+
+	if time.Now().Before(cached.expiresAt) {
+		t.Error("expected cache entry to be expired")
+	}
+}

--- a/internal/teams/adapter.go
+++ b/internal/teams/adapter.go
@@ -35,3 +35,9 @@ func (a *ServiceAdapter) ResolveGitHubIdentity(ghUser, email string) (string, er
 func (a *ServiceAdapter) ResolveTelegramIdentity(telegramID int64, email string) (string, error) {
 	return a.service.ResolveTelegramIdentity(telegramID, email)
 }
+
+// ResolveSlackIdentity resolves a Slack user ID and/or email to a team member ID (GH-787).
+// Returns ("", nil) when no matching member is found.
+func (a *ServiceAdapter) ResolveSlackIdentity(slackUserID, email string) (string, error) {
+	return a.service.ResolveSlackIdentity(slackUserID, email)
+}

--- a/internal/teams/adapter_test.go
+++ b/internal/teams/adapter_test.go
@@ -185,3 +185,42 @@ func TestServiceAdapter_ResolveGitHubIdentity(t *testing.T) {
 		})
 	}
 }
+
+func TestServiceAdapter_ResolveSlackIdentity(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	store, _ := NewStore(db)
+	service := NewService(store)
+	adapter := NewServiceAdapter(service)
+
+	team, owner, _ := service.CreateTeam("Test Team", "owner@example.com")
+	dev, _ := service.AddMember(team.ID, owner.ID, "dev@example.com", RoleDeveloper, nil)
+	dev.SlackUserID = "U12345ABC"
+	_ = store.UpdateMember(dev)
+
+	tests := []struct {
+		name        string
+		slackUserID string
+		email       string
+		wantID      string
+	}{
+		{"by slack user id", "U12345ABC", "", dev.ID},
+		{"by email fallback", "", "dev@example.com", dev.ID},
+		{"slack user id priority", "U12345ABC", "wrong@example.com", dev.ID},
+		{"no match", "UUNKNOWN", "unknown@example.com", ""},
+		{"empty inputs", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := adapter.ResolveSlackIdentity(tt.slackUserID, tt.email)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantID {
+				t.Errorf("got %q, want %q", got, tt.wantID)
+			}
+		})
+	}
+}

--- a/internal/teams/store.go
+++ b/internal/teams/store.go
@@ -69,10 +69,13 @@ func (s *Store) migrate() error {
 		`ALTER TABLE team_members ADD COLUMN github_user TEXT`,
 		// GH-634: Add telegram_id column for Telegram identity mapping
 		`ALTER TABLE team_members ADD COLUMN telegram_id INTEGER DEFAULT 0`,
+		// GH-787: Add slack_user_id column for Slack identity mapping
+		`ALTER TABLE team_members ADD COLUMN slack_user_id TEXT`,
 		`CREATE INDEX IF NOT EXISTS idx_team_members_team ON team_members(team_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_team_members_email ON team_members(email)`,
 		`CREATE INDEX IF NOT EXISTS idx_team_members_github_user ON team_members(github_user)`,
 		`CREATE INDEX IF NOT EXISTS idx_team_members_telegram_id ON team_members(telegram_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_team_members_slack_user_id ON team_members(slack_user_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_team_audit_log_team ON team_audit_log(team_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_team_audit_log_created ON team_audit_log(created_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_team_audit_log_actor ON team_audit_log(actor_id)`,
@@ -197,14 +200,14 @@ func (s *Store) ListTeams() ([]*Team, error) {
 func (s *Store) AddMember(member *Member) error {
 	projects, _ := json.Marshal(member.Projects)
 	_, err := s.db.Exec(`
-		INSERT INTO team_members (id, team_id, email, name, github_user, telegram_id, role, projects, joined_at, invited_by)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, member.ID, member.TeamID, member.Email, member.Name, member.GitHubUser, member.TelegramID, string(member.Role), string(projects), member.JoinedAt, member.InvitedBy)
+		INSERT INTO team_members (id, team_id, email, name, github_user, telegram_id, slack_user_id, role, projects, joined_at, invited_by)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, member.ID, member.TeamID, member.Email, member.Name, member.GitHubUser, member.TelegramID, member.SlackUserID, string(member.Role), string(projects), member.JoinedAt, member.InvitedBy)
 	return err
 }
 
 // memberColumns is the standard set of columns selected from team_members.
-const memberColumns = `id, team_id, email, name, github_user, telegram_id, role, projects, joined_at, invited_by`
+const memberColumns = `id, team_id, email, name, github_user, telegram_id, slack_user_id, role, projects, joined_at, invited_by`
 
 // GetMember retrieves a member by ID
 func (s *Store) GetMember(id string) (*Member, error) {
@@ -252,6 +255,17 @@ func (s *Store) GetMembersByTelegramID(telegramID int64) ([]*Member, error) {
 	return s.scanMembers(rows)
 }
 
+// GetMembersBySlackUserID retrieves all memberships for a Slack user ID (across teams) (GH-787).
+func (s *Store) GetMembersBySlackUserID(slackUserID string) ([]*Member, error) {
+	rows, err := s.db.Query(`SELECT `+memberColumns+` FROM team_members WHERE slack_user_id = ? AND slack_user_id != ''`, slackUserID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	return s.scanMembers(rows)
+}
+
 // GetMembersByEmail retrieves all memberships for an email (across teams)
 func (s *Store) GetMembersByEmail(email string) ([]*Member, error) {
 	rows, err := s.db.Query(`SELECT `+memberColumns+` FROM team_members WHERE email = ?`, email)
@@ -278,9 +292,9 @@ func (s *Store) ListMembers(teamID string) ([]*Member, error) {
 func (s *Store) UpdateMember(member *Member) error {
 	projects, _ := json.Marshal(member.Projects)
 	_, err := s.db.Exec(`
-		UPDATE team_members SET name = ?, github_user = ?, telegram_id = ?, role = ?, projects = ?
+		UPDATE team_members SET name = ?, github_user = ?, telegram_id = ?, slack_user_id = ?, role = ?, projects = ?
 		WHERE id = ?
-	`, member.Name, member.GitHubUser, member.TelegramID, string(member.Role), string(projects), member.ID)
+	`, member.Name, member.GitHubUser, member.TelegramID, member.SlackUserID, string(member.Role), string(projects), member.ID)
 	return err
 }
 
@@ -302,11 +316,11 @@ func (s *Store) CountMembersByRole(teamID string, role Role) (int, error) {
 // scanMember scans a single member row
 func (s *Store) scanMember(row *sql.Row) (*Member, error) {
 	var member Member
-	var name, ghUser, projects, invitedBy sql.NullString
+	var name, ghUser, slackUserID, projects, invitedBy sql.NullString
 	var telegramID sql.NullInt64
 	var roleStr string
 
-	if err := row.Scan(&member.ID, &member.TeamID, &member.Email, &name, &ghUser, &telegramID, &roleStr, &projects, &member.JoinedAt, &invitedBy); err != nil {
+	if err := row.Scan(&member.ID, &member.TeamID, &member.Email, &name, &ghUser, &telegramID, &slackUserID, &roleStr, &projects, &member.JoinedAt, &invitedBy); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
@@ -323,6 +337,9 @@ func (s *Store) scanMember(row *sql.Row) (*Member, error) {
 	if telegramID.Valid {
 		member.TelegramID = telegramID.Int64
 	}
+	if slackUserID.Valid {
+		member.SlackUserID = slackUserID.String
+	}
 	if invitedBy.Valid {
 		member.InvitedBy = invitedBy.String
 	}
@@ -338,11 +355,11 @@ func (s *Store) scanMembers(rows *sql.Rows) ([]*Member, error) {
 	var members []*Member
 	for rows.Next() {
 		var member Member
-		var name, ghUser, projects, invitedBy sql.NullString
+		var name, ghUser, slackUserID, projects, invitedBy sql.NullString
 		var telegramID sql.NullInt64
 		var roleStr string
 
-		if err := rows.Scan(&member.ID, &member.TeamID, &member.Email, &name, &ghUser, &telegramID, &roleStr, &projects, &member.JoinedAt, &invitedBy); err != nil {
+		if err := rows.Scan(&member.ID, &member.TeamID, &member.Email, &name, &ghUser, &telegramID, &slackUserID, &roleStr, &projects, &member.JoinedAt, &invitedBy); err != nil {
 			return nil, err
 		}
 
@@ -355,6 +372,9 @@ func (s *Store) scanMembers(rows *sql.Rows) ([]*Member, error) {
 		}
 		if telegramID.Valid {
 			member.TelegramID = telegramID.Int64
+		}
+		if slackUserID.Valid {
+			member.SlackUserID = slackUserID.String
 		}
 		if invitedBy.Valid {
 			member.InvitedBy = invitedBy.String

--- a/internal/teams/types.go
+++ b/internal/teams/types.go
@@ -24,16 +24,17 @@ type Settings struct {
 
 // Member represents a team member
 type Member struct {
-	ID         string    `json:"id" yaml:"id"`
-	TeamID     string    `json:"team_id" yaml:"team_id"`
-	Email      string    `json:"email" yaml:"email"`
-	Name       string    `json:"name,omitempty" yaml:"name,omitempty"`
-	GitHubUser string    `json:"github_user,omitempty" yaml:"github_user,omitempty"` // GitHub username for identity mapping (GH-634)
-	TelegramID int64     `json:"telegram_id,omitempty" yaml:"telegram_id,omitempty"` // Telegram user ID for identity mapping (GH-634)
-	Role       Role      `json:"role" yaml:"role"`
-	Projects   []string  `json:"projects,omitempty" yaml:"projects,omitempty"` // Empty = all projects
-	JoinedAt   time.Time `json:"joined_at" yaml:"joined_at"`
-	InvitedBy  string    `json:"invited_by,omitempty" yaml:"invited_by,omitempty"`
+	ID          string    `json:"id" yaml:"id"`
+	TeamID      string    `json:"team_id" yaml:"team_id"`
+	Email       string    `json:"email" yaml:"email"`
+	Name        string    `json:"name,omitempty" yaml:"name,omitempty"`
+	GitHubUser  string    `json:"github_user,omitempty" yaml:"github_user,omitempty"`   // GitHub username for identity mapping (GH-634)
+	TelegramID  int64     `json:"telegram_id,omitempty" yaml:"telegram_id,omitempty"`   // Telegram user ID for identity mapping (GH-634)
+	SlackUserID string    `json:"slack_user_id,omitempty" yaml:"slack_user_id,omitempty"` // Slack user ID for identity mapping (GH-787)
+	Role        Role      `json:"role" yaml:"role"`
+	Projects    []string  `json:"projects,omitempty" yaml:"projects,omitempty"` // Empty = all projects
+	JoinedAt    time.Time `json:"joined_at" yaml:"joined_at"`
+	InvitedBy   string    `json:"invited_by,omitempty" yaml:"invited_by,omitempty"`
 }
 
 // Role defines permission levels within a team


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-787.

## Changes

Integrate RBAC check into task execution flow, send rejection messages for unauthorized users, add table-driven tests
**Files:**
- `internal/adapters/slack/handler.go` or event processor — Add RBAC check:
```go
if h.memberResolver != nil {
memberID, err := h.resolveMemberID(channelID)
if err != nil {
// send "unauthorized" message
return
}
task.MemberID = memberID
}
```
- `internal/adapters/slack/users_test.go` — Table-driven tests for GetUserInfo with caching
- `internal/teams/service_test.go` or `adapter_test.go` — Tests for ResolveSlackIdentity
**~70 LoC**
---
| # | Subtask | Key Files | LoC |
|---|---------|-----------|-----|
| 1 | Add SlackUserID to Member + store | types.go, store.go | ~50 |
| 2 | Add ResolveSlackIdentity to service/adapter | service.go, adapter.go | ~40 |
| 3 | Create Slack users.go with cached API | users.go (new) | ~80 |
| 4 | Add MemberResolver interface + handler wiring | events.go/handler.go | ~60 |
| 5 | RBAC check in execution + tests | handler.go, *_test.go | ~70 |
**Total: ~300 LoC** (slightly over estimate due to test coverage)