### PR TITLE
Create classifier and conversation components

### DIFF
--- a/internal/intent/classifier.go
+++ b/internal/intent/classifier.go
@@ -1,0 +1,177 @@
+package intent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Intent represents the detected intent of a message
+type Intent string
+
+const (
+	IntentCommand  Intent = "command"
+	IntentGreeting Intent = "greeting"
+	IntentResearch Intent = "research"
+	IntentPlanning Intent = "planning"
+	IntentQuestion Intent = "question"
+	IntentChat     Intent = "chat"
+	IntentTask     Intent = "task"
+)
+
+// ConversationMessage represents a message in the conversation
+type ConversationMessage struct {
+	Role    string `json:"role"` // "user" or "assistant"
+	Content string `json:"content"`
+}
+
+// ClassifyResponse is the response from the classification API
+type ClassifyResponse struct {
+	Intent     string  `json:"intent"`
+	Confidence float64 `json:"confidence"`
+}
+
+// Classifier classifies user messages into intents
+type Classifier interface {
+	Classify(ctx context.Context, messages []ConversationMessage, currentMessage string) (Intent, error)
+}
+
+// AnthropicClient provides direct access to Claude API for fast classification
+type AnthropicClient struct {
+	apiKey     string
+	httpClient *http.Client
+	model      string
+}
+
+// NewAnthropicClient creates a new Anthropic API client
+func NewAnthropicClient(apiKey string) *AnthropicClient {
+	return &AnthropicClient{
+		apiKey: apiKey,
+		httpClient: &http.Client{
+			Timeout: 5 * time.Second, // Fast timeout for classification
+		},
+		model: "claude-haiku-4-5-20251001",
+	}
+}
+
+// Classify determines the intent of a message using Claude Haiku
+func (c *AnthropicClient) Classify(ctx context.Context, messages []ConversationMessage, currentMessage string) (Intent, error) {
+	// Build the classification prompt
+	systemPrompt := `You are an intent classifier for a coding assistant bot. Classify the user's message into exactly one of these intents:
+
+- command: Message starts with /
+- greeting: Simple greeting like "hi", "hello", "hey"
+- research: Requests for analysis/research (e.g., "research how X works", "analyze the auth flow")
+- planning: Requests for implementation plans (e.g., "plan how to add X", "design a solution for Y")
+- question: Questions about code/project (e.g., "what files handle auth?", "how does X work?")
+- chat: Conversational/opinion-seeking (e.g., "what do you think about...", "should I...")
+- task: Requests to make changes (e.g., "add a button", "fix the bug", "implement feature X")
+
+IMPORTANT:
+- "What do you think about adding X?" is CHAT (asking opinion), not TASK
+- "Add X to the project" is TASK (direct instruction)
+- Questions that don't require code changes are QUESTION
+- Be conservative: when in doubt between task and chat, prefer chat
+
+Respond with JSON only: {"intent": "...", "confidence": 0.0-1.0}`
+
+	// Build messages array for API
+	apiMessages := []map[string]string{}
+
+	// Add conversation history (last 5 messages for context)
+	historyStart := 0
+	if len(messages) > 5 {
+		historyStart = len(messages) - 5
+	}
+	for _, msg := range messages[historyStart:] {
+		apiMessages = append(apiMessages, map[string]string{
+			"role":    msg.Role,
+			"content": msg.Content,
+		})
+	}
+
+	// Add the current message to classify
+	apiMessages = append(apiMessages, map[string]string{
+		"role":    "user",
+		"content": fmt.Sprintf("Classify this message: %s", currentMessage),
+	})
+
+	// Build request body
+	requestBody := map[string]interface{}{
+		"model":      c.model,
+		"max_tokens": 100,
+		"system":     systemPrompt,
+		"messages":   apiMessages,
+		"output_config": map[string]interface{}{
+			"effort": "low", // Fast classification, minimize token spend
+		},
+	}
+
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Make API request
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.anthropic.com/v1/messages", bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("API request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	// Parse response
+	var apiResp struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if len(apiResp.Content) == 0 {
+		return "", fmt.Errorf("empty response from API")
+	}
+
+	// Parse the JSON response
+	var classifyResp ClassifyResponse
+	if err := json.Unmarshal([]byte(apiResp.Content[0].Text), &classifyResp); err != nil {
+		return "", fmt.Errorf("failed to parse classification: %w", err)
+	}
+
+	// Map to Intent type
+	switch classifyResp.Intent {
+	case "command":
+		return IntentCommand, nil
+	case "greeting":
+		return IntentGreeting, nil
+	case "research":
+		return IntentResearch, nil
+	case "planning":
+		return IntentPlanning, nil
+	case "question":
+		return IntentQuestion, nil
+	case "chat":
+		return IntentChat, nil
+	case "task":
+		return IntentTask, nil
+	default:
+		return IntentTask, nil // Default fallback
+	}
+}

--- a/internal/intent/conversation.go
+++ b/internal/intent/conversation.go
@@ -1,0 +1,80 @@
+package intent
+
+import (
+	"sync"
+	"time"
+)
+
+// ConversationStore maintains recent message history per chat
+type ConversationStore struct {
+	mu       sync.RWMutex
+	history  map[string][]ConversationMessage // chatID -> messages
+	maxSize  int
+	ttl      time.Duration
+	lastSeen map[string]time.Time
+}
+
+// NewConversationStore creates a new conversation history store
+func NewConversationStore(maxSize int, ttl time.Duration) *ConversationStore {
+	store := &ConversationStore{
+		history:  make(map[string][]ConversationMessage),
+		maxSize:  maxSize,
+		ttl:      ttl,
+		lastSeen: make(map[string]time.Time),
+	}
+
+	// Start cleanup goroutine
+	go store.cleanupLoop()
+
+	return store
+}
+
+// Add adds a message to the conversation history
+func (s *ConversationStore) Add(chatID, role, content string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.history[chatID] = append(s.history[chatID], ConversationMessage{
+		Role:    role,
+		Content: content,
+	})
+
+	// Trim to max size
+	if len(s.history[chatID]) > s.maxSize {
+		s.history[chatID] = s.history[chatID][len(s.history[chatID])-s.maxSize:]
+	}
+
+	s.lastSeen[chatID] = time.Now()
+}
+
+// Get returns the conversation history for a chat
+func (s *ConversationStore) Get(chatID string) []ConversationMessage {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if msgs, ok := s.history[chatID]; ok {
+		// Return a copy
+		result := make([]ConversationMessage, len(msgs))
+		copy(result, msgs)
+		return result
+	}
+	return nil
+}
+
+// cleanupLoop removes stale conversations
+func (s *ConversationStore) cleanupLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		s.mu.Lock()
+		now := time.Now()
+		for chatID, lastSeen := range s.lastSeen {
+			if now.Sub(lastSeen) > s.ttl {
+				delete(s.history, chatID)
+				delete(s.lastSeen, chatID)
+			}
+		}
+		s.mu.Unlock()
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-802.

## Changes

Create `internal/intent/classifier.go` and `internal/intent/conversation.go` for LLM classification and history tracking
**classifier.go** - Move from `telegram/anthropic.go`:
- `type ConversationMessage struct`
- `type Classifier interface { Classify(ctx, []ConversationMessage, string) (Intent, error) }`
- `type AnthropicClient struct` with `NewAnthropicClient()` and `Classify()` method
- `type ClassifyResponse struct`
**conversation.go** - Move from `telegram/conversation.go`:
- `type ConversationStore struct` with `NewConversationStore()`, `Add()`, `Get()`, `cleanupLoop()`
~120 LoC. Verify package compiles with no import cycles.
---