### PR TITLE
Update telegram adapter

### DIFF
--- a/internal/adapters/telegram/handler.go
+++ b/internal/adapters/telegram/handler.go
@@ -442,7 +442,7 @@ func (h *Handler) detectIntentWithLLM(ctx context.Context, chatID, text string) 
 
 	// Fast path: clear question patterns don't need LLM verification
 	// Prevents Haiku from misclassifying "What's in roadmap" as Task
-	if isClearQuestion(text) {
+	if IsClearQuestion(text) {
 		return IntentQuestion
 	}
 

--- a/internal/adapters/telegram/intent.go
+++ b/internal/adapters/telegram/intent.go
@@ -18,17 +18,14 @@ const (
 	IntentTask     = intent.IntentTask
 )
 
-// DetectIntent re-exports intent.DetectIntent for backward compatibility
-func DetectIntent(message string) Intent {
-	return intent.DetectIntent(message)
-}
+// DetectIntent re-exports intent.DetectIntent for backward compatibility.
+// Use type alias (Option A from GH-644 spec).
+var DetectIntent = intent.DetectIntent
 
-// IsEphemeralTask re-exports intent.IsEphemeralTask for backward compatibility
-func IsEphemeralTask(description string) bool {
-	return intent.IsEphemeralTask(description)
-}
+// IsEphemeralTask re-exports intent.IsEphemeralTask for backward compatibility.
+// Use type alias (Option A from GH-644 spec).
+var IsEphemeralTask = intent.IsEphemeralTask
 
-// isClearQuestion wraps intent.IsClearQuestion for internal use in handler.go
-func isClearQuestion(msg string) bool {
-	return intent.IsClearQuestion(msg)
-}
+// IsClearQuestion re-exports intent.IsClearQuestion for backward compatibility.
+// Use type alias (Option A from GH-644 spec).
+var IsClearQuestion = intent.IsClearQuestion


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-813.

## Changes

GitHub Issue #813: Update telegram adapter

Parent: GH-644

Create re-export wrappers in telegram package using type aliases (Option A from the spec)
The implementation chose to consolidate everything into a single `internal/intent/intent.go` file rather than splitting into multiple files, which is reasonable for ~600 LoC.