### PR TITLE
fix(intent): remove duplicate Intent type declaration (GH-811)

### DIFF
--- a/internal/intent/classifier.go
+++ b/internal/intent/classifier.go
@@ -9,19 +9,6 @@ import (
 	"time"
 )
 
-// Intent represents the detected intent of a message
-type Intent string
-
-const (
-	IntentCommand  Intent = "command"
-	IntentGreeting Intent = "greeting"
-	IntentResearch Intent = "research"
-	IntentPlanning Intent = "planning"
-	IntentQuestion Intent = "question"
-	IntentChat     Intent = "chat"
-	IntentTask     Intent = "task"
-)
-
 // ConversationMessage represents a message in the conversation
 type ConversationMessage struct {
 	Role    string `json:"role"` // "user" or "assistant"


### PR DESCRIPTION
## Summary
- Removed duplicate `Intent` type and constants from `classifier.go`
- Definition kept in `intent.go` which has complete implementation including `Description()` method

## Verification
- Build passes: `go build ./...` ✅
- Tests pass: `go test ./internal/intent/... ./internal/adapters/telegram/...` ✅  
- Lint clean: `make lint` (0 issues) ✅
- No import cycles: intent package has no internal dependencies ✅

Closes #811