### PR TITLE
fix(intent): remove duplicate Intent type declaration

### DIFF
--- a/internal/intent/classifier.go
+++ b/internal/intent/classifier.go
@@ -9,19 +9,6 @@ import (
 	"time"
 )
 
-// Intent represents the detected intent of a message
-type Intent string
-
-const (
-	IntentCommand  Intent = "command"
-	IntentGreeting Intent = "greeting"
-	IntentResearch Intent = "research"
-	IntentPlanning Intent = "planning"
-	IntentQuestion Intent = "question"
-	IntentChat     Intent = "chat"
-	IntentTask     Intent = "task"
-)
-
 // ConversationMessage represents a message in the conversation
 type ConversationMessage struct {
 	Role    string `json:"role"` // "user" or "assistant"


### PR DESCRIPTION
## Summary

Fixes GH-809. The Intent type and constants were declared in both `intent.go` and `classifier.go`, causing build failures.

## Changes

- Removed duplicate `Intent` type and constants from `classifier.go`
- `intent.go` remains the canonical location for the Intent type

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/intent/...` passes  
- [x] `go test ./...` passes