### PR TITLE
fix(autopilot): remove pilot-failed label when PR succeeds

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -3523,6 +3523,8 @@ Examples:
 			if err := client.AddLabels(ctx, owner, repoName, int(issueNum), []string{"pilot-done"}); err != nil {
 				logGitHubAPIError("AddLabels", owner, repoName, int(issueNum), err)
 			}
+			// Remove pilot-failed if present (may exist from previous failed attempt)
+			_ = client.RemoveLabel(ctx, owner, repoName, int(issueNum), "pilot-failed")
 
 			comment := buildExecutionComment(result, branchName)
 			if _, err := client.AddComment(ctx, owner, repoName, int(issueNum), comment); err != nil {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-823.

## Changes

GitHub Issue #823: fix(autopilot): remove pilot-failed label when PR succeeds

## Problem

When a fix PR successfully creates a new PR after CI failure, the `pilot-failed` label is never removed from the issue. This blocks autopilot from merging the PR even after CI passes.

**Evidence:** Issue #817 had both `pilot-done` AND `pilot-failed` labels, blocking PR #822 from auto-merge.

## Root Cause

In `cmd/pilot/main.go:3523`, when Pilot succeeds and adds `pilot-done`, it doesn't remove `pilot-failed`:

```go
// Success with deliverables - add done label
if err := client.AddLabels(ctx, owner, repoName, int(issueNum), []string{"pilot-done"}); err != nil {
    logGitHubAPIError("AddLabels", owner, repoName, int(issueNum), err)
}
// BUG: pilot-failed not removed here
```

## Fix

After adding `pilot-done` (line 3523-3525), add:

```go
// Remove pilot-failed if present (may exist from previous failed attempt)
_ = client.RemoveLabel(ctx, owner, repoName, int(issueNum), "pilot-failed")
```

Ignore errors since the label may not exist.

## Files to Modify

- `cmd/pilot/main.go` — add `RemoveLabel("pilot-failed")` after `AddLabels("pilot-done")` around line 3525

## Acceptance Criteria

- [ ] When Pilot execution succeeds, `pilot-failed` is removed if present
- [ ] No error if `pilot-failed` doesn't exist
- [ ] Autopilot can merge PRs for previously-failed issues after successful retry