### PR TITLE
feat(slack): wire handler into pilot.go lifecycle (GH-652)

### DIFF
--- a/internal/config/projects.go
+++ b/internal/config/projects.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/alekspetrov/pilot/internal/adapters/slack"
 	"github.com/alekspetrov/pilot/internal/adapters/telegram"
 )
 
@@ -56,6 +57,65 @@ func (a *ProjectSourceAdapter) ListProjects() []*telegram.ProjectInfo {
 // toProjectInfo converts ProjectConfig to telegram.ProjectInfo
 func (a *ProjectSourceAdapter) toProjectInfo(proj *ProjectConfig) *telegram.ProjectInfo {
 	return &telegram.ProjectInfo{
+		Name:          proj.Name,
+		Path:          proj.Path,
+		Navigator:     proj.Navigator,
+		DefaultBranch: proj.DefaultBranch,
+	}
+}
+
+// SlackProjectSourceAdapter wraps Config to implement slack.ProjectSource (GH-652)
+type SlackProjectSourceAdapter struct {
+	cfg *Config
+}
+
+// NewSlackProjectSource creates a new slack.ProjectSource from Config
+func NewSlackProjectSource(cfg *Config) slack.ProjectSource {
+	if cfg == nil {
+		return nil
+	}
+	return &SlackProjectSourceAdapter{cfg: cfg}
+}
+
+// GetProjectByName returns project info by name
+func (a *SlackProjectSourceAdapter) GetProjectByName(name string) *slack.ProjectInfo {
+	proj := a.cfg.GetProjectByName(name)
+	if proj == nil {
+		return nil
+	}
+	return a.toSlackProjectInfo(proj)
+}
+
+// GetProjectByPath returns project info by path
+func (a *SlackProjectSourceAdapter) GetProjectByPath(path string) *slack.ProjectInfo {
+	proj := a.cfg.GetProject(path)
+	if proj == nil {
+		return nil
+	}
+	return a.toSlackProjectInfo(proj)
+}
+
+// GetDefaultProject returns the default project info
+func (a *SlackProjectSourceAdapter) GetDefaultProject() *slack.ProjectInfo {
+	proj := a.cfg.GetDefaultProject()
+	if proj == nil {
+		return nil
+	}
+	return a.toSlackProjectInfo(proj)
+}
+
+// ListProjects returns all configured projects
+func (a *SlackProjectSourceAdapter) ListProjects() []*slack.ProjectInfo {
+	result := make([]*slack.ProjectInfo, 0, len(a.cfg.Projects))
+	for _, proj := range a.cfg.Projects {
+		result = append(result, a.toSlackProjectInfo(proj))
+	}
+	return result
+}
+
+// toSlackProjectInfo converts ProjectConfig to slack.ProjectInfo
+func (a *SlackProjectSourceAdapter) toSlackProjectInfo(proj *ProjectConfig) *slack.ProjectInfo {
+	return &slack.ProjectInfo{
 		Name:          proj.Name,
 		Path:          proj.Path,
 		Navigator:     proj.Navigator,


### PR DESCRIPTION
## Summary

Wire Slack Socket Mode handler into Pilot application lifecycle. Final integration step for bidirectional Slack communication.

Closes #652

## Changes

**internal/pilot/pilot.go:**
- Add `slackHandler`, `slackRunner`, `slackMemberResolver` fields
- Add `WithSlackHandler()` option (mirrors Telegram pattern)
- Add `WithSlackMemberResolver()` option for RBAC
- Initialize handler in `New()` when socket_mode enabled
- Start handler in `Start()`, stop in `Stop()`

**internal/config/projects.go:**
- Add `SlackProjectSourceAdapter` implementing `slack.ProjectSource`
- Add `NewSlackProjectSource()` constructor

## Test plan

- [x] `go build ./...` compiles
- [x] `make test` passes
- [x] `make lint` passes
- [ ] Manual: `pilot start --slack` connects to Slack Socket Mode