### PR TITLE
fix(config): remove nonexistent 'build' from default required_checks

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -165,6 +165,18 @@ projects:
     navigator: true           # Use Navigator for context efficiency
     default_branch: "main"
 
+# Autopilot settings
+autopilot:
+  enabled: false
+  environment: "stage"         # dev, stage, prod
+  auto_merge: true
+  merge_method: "squash"
+  ci_wait_timeout: 30m
+  ci_poll_interval: 30s
+  required_checks:             # CI checks that must pass before merge
+    - test
+    - lint
+
 # Dashboard settings
 dashboard:
   refresh_interval: 1000     # ms

--- a/docs/pages/features/autopilot-environments.mdx
+++ b/docs/pages/features/autopilot-environments.mdx
@@ -56,7 +56,6 @@ orchestrator:
     max_failures: 3              # retry CI fixes up to 3 times
     max_merges_per_hour: 20      # higher limit for rapid iteration
     required_checks:
-      - build
       - test
 ```
 
@@ -114,7 +113,6 @@ orchestrator:
     max_failures: 3
     max_merges_per_hour: 10      # moderate rate limit
     required_checks:
-      - build
       - test
       - lint
     release:
@@ -178,7 +176,6 @@ orchestrator:
     max_failures: 2                   # fewer retries — fail fast
     max_merges_per_hour: 5            # conservative rate limit
     required_checks:
-      - build
       - test
       - lint
       - security                      # add security scanning

--- a/docs/pages/getting-started/configuration.mdx
+++ b/docs/pages/getting-started/configuration.mdx
@@ -277,7 +277,6 @@ orchestrator:
     dev_ci_timeout: 5m                    # shorter timeout for dev env
     ci_poll_interval: 30s
     required_checks:
-      - build
       - test
       - lint
 
@@ -315,7 +314,7 @@ orchestrator:
 | `ci_wait_timeout` | duration | `30m` | Max time to wait for CI |
 | `dev_ci_timeout` | duration | `5m` | CI timeout in dev environment |
 | `ci_poll_interval` | duration | `30s` | CI status polling interval |
-| `required_checks` | []string | `["build","test","lint"]` | CI checks that must pass |
+| `required_checks` | []string | `["test","lint"]` | CI checks that must pass |
 | `auto_create_issues` | bool | `true` | Create fix issues when CI fails |
 | `issue_labels` | []string | `["pilot","autopilot-fix"]` | Labels for auto-created fix issues |
 | `notify_on_failure` | bool | `true` | Send notification on failure |


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-857.

Closes #857

## Changes

GitHub Issue #857: fix(config): remove nonexistent 'build' from default required_checks

## Problem

Autopilot gets stuck in `waiting_ci` because `required_checks` in example config includes `build`, but CI workflow only has:
- `secret-patterns` (Check Secret Patterns)
- `test`
- `lint`

The `build` check doesn't exist, so autopilot waits forever.

## Solution

Update `configs/pilot.example.yaml` to match actual CI checks:

```yaml
required_checks:
    - test
    - lint
```

Note: `secret-patterns` job exists but uses name `Check Secret Patterns` — either update the job name or exclude from required checks since it's a pre-check.

## Files to modify

- `configs/pilot.example.yaml`

## Acceptance criteria

- [ ] `required_checks` matches actual CI workflow jobs
- [ ] Autopilot progresses past `waiting_ci` when CI passes