### PR TITLE
feat(autopilot): auto-discover CI check names from GitHub API

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -173,9 +173,24 @@ autopilot:
   merge_method: "squash"
   ci_wait_timeout: 30m
   ci_poll_interval: 30s
-  required_checks:             # CI checks that must pass before merge
-    - test
-    - lint
+
+  # CI check configuration
+  # Auto mode (default): discovers checks from GitHub API - zero config for most users
+  # Manual mode: uses explicitly listed checks (backward compatible with required_checks)
+  ci_checks:
+    mode: auto                   # auto | manual
+    exclude:                     # Glob patterns to ignore (auto mode only)
+      - "codecov/*"
+      - "*-optional"
+    # required:                  # Explicit check names (manual mode only)
+    #   - test
+    #   - lint
+    discovery_grace_period: 60s  # How long to wait for CI checks to appear
+
+  # Legacy: required_checks still works (triggers manual mode if present)
+  # required_checks:
+  #   - test
+  #   - lint
 
 # Dashboard settings
 dashboard:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-859.

Closes #859

## Changes

GitHub Issue #859: feat(autopilot): auto-discover CI check names from GitHub API

## Problem

Autopilot gets stuck in `waiting_ci` because `required_checks` config requires exact CI job names. Users don't know what names their CI uses, and misconfiguration causes autopilot to wait forever.

**Example**: Default config has `[build, test, lint]` but CI only has `test`, `lint` jobs.

## Solution

Add auto-discovery mode that detects CI check names from GitHub API on first poll.

## Implementation

### 1. Add CIChecksConfig struct (`internal/autopilot/types.go`)

```go
type CIChecksConfig struct {
    Mode                 string        `yaml:"mode"`                    // auto | manual
    Exclude              []string      `yaml:"exclude"`                 // glob patterns
    Required             []string      `yaml:"required"`                // for manual mode
    DiscoveryGracePeriod time.Duration `yaml:"discovery_grace_period"` // default 60s
}
```

Add to Config struct and PRState.

### 2. Modify CIMonitor (`internal/autopilot/ci_monitor.go`)

- Add `ciChecks *CIChecksConfig`, `discoveredChecks map[string][]string`, `discoveryStart map[string]time.Time`
- Update `NewCIMonitor()` to migrate legacy `required_checks` → manual mode
- Add `checkAutoDiscoveredRuns()` for auto mode
- Add `matchesExclude()` with glob pattern support via `path.Match`
- Add `GetDiscoveredChecks()`, `ClearDiscovery()`

### 3. Update Controller (`internal/autopilot/controller.go`)

- In `handleWaitingCI()`: capture discovered checks to PRState
- In `removePR()`: call `ClearDiscovery()`

### 4. Update Example Config (`configs/pilot.example.yaml`)

```yaml
autopilot:
  ci_checks:
    mode: auto
    exclude:
      - "codecov/*"
      - "*-optional"
    discovery_grace_period: 60s
```

### 5. Add Tests (`internal/autopilot/ci_monitor_test.go`)

- `TestCIMonitor_AutoDiscovery`
- `TestCIMonitor_AutoDiscovery_WithExclusions`
- `TestCIMonitor_AutoDiscovery_GracePeriod`
- `TestCIMonitor_ManualMode_BackwardCompat`
- `TestCIMonitor_matchesExclude_GlobPatterns`

## Files to Modify

- `internal/autopilot/types.go`
- `internal/autopilot/ci_monitor.go`
- `internal/autopilot/controller.go`
- `internal/autopilot/ci_monitor_test.go`
- `configs/pilot.example.yaml`

## Backward Compatibility

- Legacy `required_checks` triggers manual mode
- Default mode is `auto` — zero config for most users

## Acceptance Criteria

- [ ] Auto mode discovers checks from GitHub API
- [ ] Exclusion patterns work with globs
- [ ] Grace period handles CI startup delay
- [ ] Legacy config still works
- [ ] Tests pass

Supersedes #857