### PR TITLE
docs(config): add ci_checks config to example

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -173,9 +173,20 @@ autopilot:
   merge_method: "squash"
   ci_wait_timeout: 30m
   ci_poll_interval: 30s
-  required_checks:             # CI checks that must pass before merge
-    - test
-    - lint
+
+  # CI Check Discovery (v0.34+)
+  ci_checks:
+    mode: auto                    # auto | manual (default: auto)
+    exclude:                      # Check names to ignore in auto mode
+      - "codecov/*"              # Glob patterns supported
+      - "*-optional"
+    # required: []                # Only used in manual mode
+    discovery_grace_period: 60s   # Wait for CI to start
+
+  # Legacy (deprecated - use ci_checks.required instead)
+  # required_checks:
+  #   - test
+  #   - lint
 
 # Dashboard settings
 dashboard:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-863.

Closes #863

## Changes

GitHub Issue #863: docs(config): add ci_checks config to example

## Parent: #859
## Depends on: #860

Update example config with new ci_checks section.

## Changes to `configs/pilot.example.yaml`

Find the autopilot section and add ci_checks config:

```yaml
orchestrator:
  autopilot:
    enabled: true
    environment: stage
    
    # CI Check Discovery (NEW)
    ci_checks:
      mode: auto                    # auto | manual (default: auto)
      exclude:                      # Check names to ignore in auto mode
        - "codecov/*"              # Glob patterns supported
        - "*-optional"
      # required: []                # Only used in manual mode
      discovery_grace_period: 60s   # Wait for CI to start

    # Legacy (deprecated - use ci_checks.required instead)
    # required_checks:
    #   - test
    #   - lint
```

Comment out or remove the old required_checks section.

## Acceptance Criteria
- [ ] ci_checks section added to example config
- [ ] Old required_checks commented out with deprecation note
- [ ] YAML is valid: `python -c "import yaml; yaml.safe_load(open('configs/pilot.example.yaml'))"`