### PR TITLE
feat(autopilot): Circuit breaker escalation to PagerDuty

### DIFF
--- a/internal/autopilot/metrics_alerter.go
+++ b/internal/autopilot/metrics_alerter.go
@@ -4,27 +4,105 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/alekspetrov/pilot/internal/alerts"
 )
 
+// tripTracker tracks circuit breaker trips over time for escalation detection.
+// Escalates to PagerDuty after 3+ trips within 1 hour.
+type tripTracker struct {
+	trips                []time.Time
+	mu                   sync.Mutex
+	escalationThreshold  int
+	escalationWindow     time.Duration
+	lastEscalationSentAt time.Time
+	escalationCooldown   time.Duration
+}
+
+// newTripTracker creates a trip tracker with default settings (3 trips in 1 hour).
+func newTripTracker() *tripTracker {
+	return &tripTracker{
+		trips:               make([]time.Time, 0),
+		escalationThreshold: 3,
+		escalationWindow:    1 * time.Hour,
+		escalationCooldown:  1 * time.Hour,
+	}
+}
+
+// recordTrip records a circuit breaker trip and returns the count of trips
+// within the escalation window. Also cleans up old trips.
+func (t *tripTracker) recordTrip() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := time.Now()
+	t.trips = append(t.trips, now)
+
+	// Remove trips older than the escalation window
+	cutoff := now.Add(-t.escalationWindow)
+	filtered := make([]time.Time, 0, len(t.trips))
+	for _, trip := range t.trips {
+		if trip.After(cutoff) {
+			filtered = append(filtered, trip)
+		}
+	}
+	t.trips = filtered
+
+	return len(t.trips)
+}
+
+// shouldEscalate returns true if escalation should be triggered based on
+// the current trip count and cooldown period.
+func (t *tripTracker) shouldEscalate() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if len(t.trips) < t.escalationThreshold {
+		return false
+	}
+
+	// Check if we're still in cooldown from last escalation
+	if time.Since(t.lastEscalationSentAt) < t.escalationCooldown {
+		return false
+	}
+
+	return true
+}
+
+// markEscalationSent records that an escalation was sent.
+func (t *tripTracker) markEscalationSent() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lastEscalationSentAt = time.Now()
+}
+
+// recentTripCount returns the count of trips within the window (thread-safe read).
+func (t *tripTracker) recentTripCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.trips)
+}
+
 // MetricsAlerter periodically evaluates autopilot metrics and sends events
 // to the alerts engine for rule evaluation.
 type MetricsAlerter struct {
-	controller *Controller
-	engine     *alerts.Engine
-	interval   time.Duration
-	log        *slog.Logger
+	controller  *Controller
+	engine      *alerts.Engine
+	interval    time.Duration
+	log         *slog.Logger
+	tripTracker *tripTracker
 }
 
 // NewMetricsAlerter creates a new MetricsAlerter.
 func NewMetricsAlerter(controller *Controller, engine *alerts.Engine) *MetricsAlerter {
 	return &MetricsAlerter{
-		controller: controller,
-		engine:     engine,
-		interval:   30 * time.Second,
-		log:        slog.Default().With("component", "metrics-alerter"),
+		controller:  controller,
+		engine:      engine,
+		interval:    30 * time.Second,
+		log:         slog.Default().With("component", "metrics-alerter"),
+		tripTracker: newTripTracker(),
 	}
 }
 
@@ -120,4 +198,54 @@ func (ma *MetricsAlerter) evaluate() {
 	if noProgressMin >= 60 && !deadlockAlertSent && len(activePRs) > 0 {
 		ma.controller.MarkDeadlockAlertSent()
 	}
+}
+
+// RecordCircuitBreakerTrip records a circuit breaker trip and checks if escalation is needed.
+// If 3+ trips occur within 1 hour, emits an escalation alert for PagerDuty.
+func (ma *MetricsAlerter) RecordCircuitBreakerTrip(prNumber int, reason string) {
+	if ma.engine == nil {
+		return
+	}
+
+	// Record the trip and get the count within the window
+	tripCount := ma.tripTracker.recordTrip()
+
+	ma.log.Info("circuit breaker trip recorded",
+		"pr", prNumber,
+		"reason", reason,
+		"trips_in_window", tripCount,
+		"threshold", ma.tripTracker.escalationThreshold,
+	)
+
+	// Check if we should escalate to PagerDuty
+	if ma.tripTracker.shouldEscalate() {
+		ma.emitEscalationAlert(tripCount, prNumber, reason)
+		ma.tripTracker.markEscalationSent()
+	}
+}
+
+// emitEscalationAlert sends a critical escalation event for PagerDuty routing.
+func (ma *MetricsAlerter) emitEscalationAlert(tripCount int, lastPR int, lastReason string) {
+	ma.log.Warn("escalating to PagerDuty",
+		"trips_in_window", tripCount,
+		"last_pr", lastPR,
+		"last_reason", lastReason,
+	)
+
+	event := alerts.Event{
+		Type:      alerts.EventTypeEscalation,
+		TaskID:    "autopilot-circuit-breaker",
+		TaskTitle: "Autopilot Circuit Breaker Escalation",
+		Project:   fmt.Sprintf("%s/%s", ma.controller.owner, ma.controller.repo),
+		Metadata: map[string]string{
+			"trips_in_hour":        fmt.Sprintf("%d", tripCount),
+			"escalation_threshold": fmt.Sprintf("%d", ma.tripTracker.escalationThreshold),
+			"last_pr":              fmt.Sprintf("%d", lastPR),
+			"last_reason":          lastReason,
+			"severity":             string(alerts.SeverityCritical),
+		},
+		Timestamp: time.Now(),
+	}
+
+	ma.engine.ProcessEvent(event)
 }

--- a/internal/autopilot/metrics_alerter_test.go
+++ b/internal/autopilot/metrics_alerter_test.go
@@ -1,0 +1,189 @@
+package autopilot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/alerts"
+)
+
+func TestTripTracker_RecordTrip(t *testing.T) {
+	tracker := newTripTracker()
+
+	// Record first trip
+	count := tracker.recordTrip()
+	if count != 1 {
+		t.Errorf("expected 1 trip, got %d", count)
+	}
+
+	// Record second trip
+	count = tracker.recordTrip()
+	if count != 2 {
+		t.Errorf("expected 2 trips, got %d", count)
+	}
+
+	// Record third trip
+	count = tracker.recordTrip()
+	if count != 3 {
+		t.Errorf("expected 3 trips, got %d", count)
+	}
+}
+
+func TestTripTracker_OldTripsExpire(t *testing.T) {
+	tracker := newTripTracker()
+	// Use a shorter window for testing
+	tracker.escalationWindow = 100 * time.Millisecond
+
+	// Record a trip
+	tracker.recordTrip()
+
+	// Wait for it to expire
+	time.Sleep(150 * time.Millisecond)
+
+	// Record another trip - old one should be filtered out
+	count := tracker.recordTrip()
+	if count != 1 {
+		t.Errorf("expected 1 trip (old expired), got %d", count)
+	}
+}
+
+func TestTripTracker_ShouldEscalate(t *testing.T) {
+	tracker := newTripTracker()
+
+	// Not enough trips
+	tracker.recordTrip()
+	tracker.recordTrip()
+	if tracker.shouldEscalate() {
+		t.Error("should not escalate with only 2 trips")
+	}
+
+	// Third trip hits threshold
+	tracker.recordTrip()
+	if !tracker.shouldEscalate() {
+		t.Error("should escalate with 3 trips")
+	}
+}
+
+func TestTripTracker_EscalationCooldown(t *testing.T) {
+	tracker := newTripTracker()
+	// Use a shorter cooldown for testing
+	tracker.escalationCooldown = 100 * time.Millisecond
+
+	// Trigger escalation
+	tracker.recordTrip()
+	tracker.recordTrip()
+	tracker.recordTrip()
+
+	if !tracker.shouldEscalate() {
+		t.Error("should escalate initially")
+	}
+
+	// Mark sent
+	tracker.markEscalationSent()
+
+	// Should not escalate during cooldown
+	if tracker.shouldEscalate() {
+		t.Error("should not escalate during cooldown")
+	}
+
+	// Wait for cooldown to expire
+	time.Sleep(150 * time.Millisecond)
+
+	// Add another trip to stay above threshold
+	tracker.recordTrip()
+
+	// Should escalate again after cooldown
+	if !tracker.shouldEscalate() {
+		t.Error("should escalate after cooldown")
+	}
+}
+
+func TestTripTracker_RecentTripCount(t *testing.T) {
+	tracker := newTripTracker()
+
+	tracker.recordTrip()
+	tracker.recordTrip()
+
+	if count := tracker.recentTripCount(); count != 2 {
+		t.Errorf("expected 2 trips, got %d", count)
+	}
+}
+
+func TestMetricsAlerter_RecordCircuitBreakerTrip_NoEngine(t *testing.T) {
+	// With nil engine, should not panic
+	ma := &MetricsAlerter{
+		engine:      nil,
+		tripTracker: newTripTracker(),
+	}
+
+	// Should not panic
+	ma.RecordCircuitBreakerTrip(123, "test failure")
+}
+
+func TestMetricsAlerter_RecordCircuitBreakerTrip_NoEscalation(t *testing.T) {
+	config := alerts.DefaultConfig()
+	config.Enabled = true
+	engine := alerts.NewEngine(config)
+
+	controller := &Controller{
+		owner: "test",
+		repo:  "repo",
+	}
+
+	ma := NewMetricsAlerter(controller, engine)
+
+	// Record 2 trips - should not trigger escalation
+	ma.RecordCircuitBreakerTrip(1, "failure 1")
+	ma.RecordCircuitBreakerTrip(2, "failure 2")
+
+	// No escalation should have been sent (checked via tripTracker state)
+	if ma.tripTracker.lastEscalationSentAt.IsZero() == false {
+		// If not zero, escalation was sent prematurely
+		if ma.tripTracker.recentTripCount() < 3 {
+			t.Error("escalation sent before threshold reached")
+		}
+	}
+}
+
+func TestMetricsAlerter_RecordCircuitBreakerTrip_Escalation(t *testing.T) {
+	config := alerts.DefaultConfig()
+	config.Enabled = true
+	engine := alerts.NewEngine(config)
+
+	controller := &Controller{
+		owner: "test",
+		repo:  "repo",
+	}
+
+	ma := NewMetricsAlerter(controller, engine)
+
+	// Record 3 trips - should trigger escalation
+	ma.RecordCircuitBreakerTrip(1, "failure 1")
+	ma.RecordCircuitBreakerTrip(2, "failure 2")
+	ma.RecordCircuitBreakerTrip(3, "failure 3")
+
+	// Check that escalation was marked as sent
+	if ma.tripTracker.lastEscalationSentAt.IsZero() {
+		t.Error("escalation should have been sent after 3 trips")
+	}
+}
+
+func TestTripTracker_ThresholdCustomizable(t *testing.T) {
+	tracker := newTripTracker()
+	tracker.escalationThreshold = 5
+
+	// Record 4 trips
+	for i := 0; i < 4; i++ {
+		tracker.recordTrip()
+	}
+
+	if tracker.shouldEscalate() {
+		t.Error("should not escalate with threshold of 5 and only 4 trips")
+	}
+
+	// Fifth trip should trigger
+	tracker.recordTrip()
+	if !tracker.shouldEscalate() {
+		t.Error("should escalate after 5 trips with threshold of 5")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-885.

Closes #885

## Changes

GitHub Issue #885: feat(autopilot): Circuit breaker escalation to PagerDuty

## Problem
Multiple circuit breaker trips indicate systemic issues, but each trip only sends a warning alert. Need escalation to PagerDuty for human intervention.

## Solution
Track circuit breaker trips over time and escalate to PagerDuty after 3+ trips within 1 hour.

### Implementation
1. In `metrics_alerter.go`, add trip tracking:
```go
type tripTracker struct {
    trips []time.Time
    mu    sync.Mutex
}

func (t *tripTracker) recordTrip() int {
    t.mu.Lock()
    defer t.mu.Unlock()
    now := time.Now()
    // Remove trips older than 1 hour
    cutoff := now.Add(-1 * time.Hour)
    // ... filter and count
}
```

2. On `RecordCircuitBreakerTrip()`:
   - Call `tripTracker.recordTrip()`
   - If count >= 3, emit `AlertTypeEscalation` with `SeverityCritical`

### Files to Modify
- `internal/autopilot/metrics_alerter.go` — Add trip tracking and escalation

### Acceptance Criteria
- [ ] 3+ trips in 1 hour → PagerDuty incident
- [ ] Old trips (>1h) don't count toward threshold
- [ ] Single trip only sends warning (existing behavior)
- [ ] Unit test for escalation logic