### PR TITLE
feat(executor): Graceful shutdown terminates all subprocesses

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2002,6 +2002,9 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 		// Clean shutdown - cancel context to stop all goroutines
 		cancel()
 
+		// Terminate all running subprocesses (GH-883)
+		runner.CancelAll()
+
 		if tgHandler != nil {
 			tgHandler.Stop()
 		}
@@ -2021,6 +2024,10 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 
 	<-sigCh
 	fmt.Println("\n🛑 Shutting down...")
+
+	// Terminate all running subprocesses (GH-883)
+	runner.CancelAll()
+
 	if tgHandler != nil {
 		tgHandler.Stop()
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -98,6 +98,8 @@ func (o *Orchestrator) Start() {
 func (o *Orchestrator) Stop() {
 	o.cancel()
 	close(o.taskQueue)
+	// Terminate all running subprocesses (GH-883)
+	o.runner.CancelAll()
 	o.wg.Wait()
 	logging.WithComponent("orchestrator").Info("Orchestrator stopped")
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-883.

Closes #883

## Changes

GitHub Issue #883: feat(executor): Graceful shutdown terminates all subprocesses

## Problem
On SIGTERM/SIGINT, Pilot shuts down the HTTP server but may leave orphaned Claude Code subprocesses running.

## Solution
Add `Runner.CancelAll()` method and call it during shutdown sequence.

### Implementation
1. Add `CancelAll()` to Runner:
```go
func (r *Runner) CancelAll() {
    r.mu.Lock()
    defer r.mu.Unlock()
    for _, cmd := range r.running {
        cmd.Process.Signal(syscall.SIGTERM)
    }
    // Wait 10s, then SIGKILL any remaining
    time.AfterFunc(10*time.Second, func() {
        for _, cmd := range r.running {
            cmd.Process.Kill()
        }
    })
}
```

2. In `main.go` signal handler, call `runner.CancelAll()` before `server.Shutdown()`

### Pattern Reference
Similar kill pattern exists at `parallel.go:296-298`

### Files to Modify
- `internal/executor/runner.go` — Add CancelAll() method
- `cmd/pilot/main.go` — Wire into signal handler

### Acceptance Criteria
- [ ] All subprocesses receive SIGTERM on shutdown
- [ ] Remaining processes killed after 10s grace period
- [ ] No orphaned processes after Pilot exits
- [ ] Unit test for CancelAll()