### PR TITLE
feat(jira): Add polling support for Jira adapter

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/alekspetrov/pilot/internal/adapters/github"
+	"github.com/alekspetrov/pilot/internal/adapters/jira"
 	"github.com/alekspetrov/pilot/internal/adapters/linear"
 	"github.com/alekspetrov/pilot/internal/adapters/slack"
 	"github.com/alekspetrov/pilot/internal/adapters/telegram"
@@ -911,6 +912,42 @@ Examples:
 						}
 					}(linearPoller, ws.Name)
 				}
+			}
+
+			// Enable Jira polling in gateway mode if configured (GH-905)
+			if cfg.Adapters.Jira != nil && cfg.Adapters.Jira.Enabled &&
+				cfg.Adapters.Jira.Polling != nil && cfg.Adapters.Jira.Polling.Enabled {
+
+				// Determine interval
+				interval := 30 * time.Second
+				if cfg.Adapters.Jira.Polling.Interval > 0 {
+					interval = cfg.Adapters.Jira.Polling.Interval
+				}
+
+				jiraClient := jira.NewClient(
+					cfg.Adapters.Jira.BaseURL,
+					cfg.Adapters.Jira.Username,
+					cfg.Adapters.Jira.APIToken,
+					cfg.Adapters.Jira.Platform,
+				)
+				jiraPoller := jira.NewPoller(jiraClient, cfg.Adapters.Jira, interval,
+					jira.WithOnJiraIssue(func(issueCtx context.Context, issue *jira.Issue) (*jira.IssueResult, error) {
+						return handleJiraIssueWithResult(issueCtx, cfg, jiraClient, issue, projectPath, gwDispatcher, gwRunner, gwMonitor, gwProgram, gwAlertsEngine, gwEnforcer)
+					}),
+				)
+
+				logging.WithComponent("start").Info("Jira polling enabled in gateway mode",
+					slog.String("base_url", cfg.Adapters.Jira.BaseURL),
+					slog.String("project", cfg.Adapters.Jira.ProjectKey),
+					slog.Duration("interval", interval),
+				)
+				go func(p *jira.Poller) {
+					if err := p.Start(context.Background()); err != nil {
+						logging.WithComponent("jira").Error("Jira poller failed",
+							slog.Any("error", err),
+						)
+					}
+				}(jiraPoller)
 			}
 
 			// Wire teams service if --team flag provided (GH-633)
@@ -2631,6 +2668,263 @@ func handleLinearIssueWithResult(ctx context.Context, cfg *config.Config, client
 	}
 
 	return issueResult, execErr
+}
+
+// handleJiraIssueWithResult processes a Jira issue picked up by the poller (GH-905)
+func handleJiraIssueWithResult(ctx context.Context, cfg *config.Config, client *jira.Client, issue *jira.Issue, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner, monitor *executor.Monitor, program *tea.Program, alertsEngine *alerts.Engine, enforcer *budget.Enforcer) (*jira.IssueResult, error) {
+	taskID := issue.Key // e.g., "PROJ-123"
+
+	// Register task with monitor if in dashboard mode
+	if monitor != nil {
+		issueURL := fmt.Sprintf("%s/browse/%s", cfg.Adapters.Jira.BaseURL, issue.Key)
+		monitor.Register(taskID, issue.Fields.Summary, issueURL)
+		monitor.Start(taskID)
+	}
+	if program != nil {
+		program.Send(dashboard.AddLog(fmt.Sprintf("📊 Jira Issue %s: %s", issue.Key, issue.Fields.Summary))())
+	}
+
+	// Emit task started event (GH-337)
+	if alertsEngine != nil {
+		alertsEngine.ProcessEvent(alerts.Event{
+			Type:      alerts.EventTypeTaskStarted,
+			TaskID:    taskID,
+			TaskTitle: issue.Fields.Summary,
+			Project:   projectPath,
+			Timestamp: time.Now(),
+		})
+	}
+
+	// GH-539: Pre-execution budget check
+	if enforcer != nil {
+		checkResult, budgetErr := enforcer.CheckBudget(ctx, "", "")
+		if budgetErr != nil {
+			logging.WithComponent("budget").Warn("budget check failed, allowing task (fail-open)",
+				slog.String("task_id", taskID),
+				slog.Any("error", budgetErr),
+			)
+		} else if !checkResult.Allowed {
+			logging.WithComponent("budget").Warn("task blocked by budget enforcement",
+				slog.String("task_id", taskID),
+				slog.String("reason", checkResult.Reason),
+			)
+			if alertsEngine != nil {
+				alertsEngine.ProcessEvent(alerts.Event{
+					Type:      alerts.EventTypeBudgetExceeded,
+					TaskID:    taskID,
+					TaskTitle: issue.Fields.Summary,
+					Project:   projectPath,
+					Error:     checkResult.Reason,
+					Metadata: map[string]string{
+						"daily_left":   fmt.Sprintf("%.2f", checkResult.DailyLeft),
+						"monthly_left": fmt.Sprintf("%.2f", checkResult.MonthlyLeft),
+						"action":       string(checkResult.Action),
+					},
+					Timestamp: time.Now(),
+				})
+			}
+			budgetExceededErr := fmt.Errorf("budget enforcement: %s", checkResult.Reason)
+			return &jira.IssueResult{
+				Success: false,
+				Error:   budgetExceededErr,
+			}, budgetExceededErr
+		}
+	}
+
+	fmt.Printf("\n📊 Jira Issue %s: %s\n", issue.Key, issue.Fields.Summary)
+
+	taskDesc := fmt.Sprintf("Jira Issue %s: %s\n\n%s", issue.Key, issue.Fields.Summary, issue.Fields.Description)
+	branchName := fmt.Sprintf("pilot/%s", taskID)
+
+	task := &executor.Task{
+		ID:          taskID,
+		Title:       issue.Fields.Summary,
+		Description: taskDesc,
+		ProjectPath: projectPath,
+		Branch:      branchName,
+		CreatePR:    true,
+	}
+
+	var result *executor.ExecutionResult
+	var execErr error
+
+	if dispatcher != nil {
+		execID, qErr := dispatcher.QueueTask(ctx, task)
+		if qErr != nil {
+			execErr = fmt.Errorf("failed to queue task: %w", qErr)
+		} else {
+			fmt.Printf("   📋 Queued as execution %s\n", execID[:8])
+			exec, waitErr := dispatcher.WaitForExecution(ctx, execID, time.Second)
+			if waitErr != nil {
+				execErr = fmt.Errorf("failed waiting for execution: %w", waitErr)
+			} else if exec.Status == "failed" {
+				execErr = fmt.Errorf("execution failed: %s", exec.Error)
+			} else {
+				result = &executor.ExecutionResult{
+					TaskID:    task.ID,
+					Success:   exec.Status == "completed",
+					Output:    exec.Output,
+					Error:     exec.Error,
+					PRUrl:     exec.PRUrl,
+					CommitSHA: exec.CommitSHA,
+					Duration:  time.Duration(exec.DurationMs) * time.Millisecond,
+				}
+			}
+		}
+	} else {
+		result, execErr = runner.Execute(ctx, task)
+	}
+
+	// Update monitor with completion status
+	prURL := ""
+	if result != nil {
+		prURL = result.PRUrl
+	}
+	if monitor != nil {
+		if execErr != nil {
+			monitor.Fail(taskID, execErr.Error())
+		} else {
+			monitor.Complete(taskID, prURL)
+		}
+	}
+
+	// Emit task completed/failed event (GH-337)
+	if alertsEngine != nil {
+		if execErr != nil {
+			alertsEngine.ProcessEvent(alerts.Event{
+				Type:      alerts.EventTypeTaskFailed,
+				TaskID:    taskID,
+				TaskTitle: issue.Fields.Summary,
+				Project:   projectPath,
+				Error:     execErr.Error(),
+				Timestamp: time.Now(),
+			})
+		} else if result != nil && result.Success {
+			metadata := map[string]string{}
+			if result.PRUrl != "" {
+				metadata["pr_url"] = result.PRUrl
+			}
+			if result.Duration > 0 {
+				metadata["duration"] = result.Duration.String()
+			}
+			alertsEngine.ProcessEvent(alerts.Event{
+				Type:      alerts.EventTypeTaskCompleted,
+				TaskID:    taskID,
+				TaskTitle: issue.Fields.Summary,
+				Project:   projectPath,
+				Metadata:  metadata,
+				Timestamp: time.Now(),
+			})
+		} else if result != nil {
+			alertsEngine.ProcessEvent(alerts.Event{
+				Type:      alerts.EventTypeTaskFailed,
+				TaskID:    taskID,
+				TaskTitle: issue.Fields.Summary,
+				Project:   projectPath,
+				Error:     result.Error,
+				Timestamp: time.Now(),
+			})
+		}
+	}
+
+	// Add completed task to dashboard history
+	if program != nil {
+		status := "success"
+		duration := ""
+		if execErr != nil {
+			status = "failed"
+		} else if result != nil {
+			duration = result.Duration.String()
+		}
+		program.Send(dashboard.AddCompletedTask(taskID, issue.Fields.Summary, status, duration, "", false)())
+	}
+
+	// Build issue result
+	issueResult := &jira.IssueResult{
+		Success: execErr == nil && result != nil && result.Success,
+	}
+	if result != nil {
+		if result.PRUrl != "" {
+			issueResult.PRURL = result.PRUrl
+			if prNum, err := github.ExtractPRNumber(result.PRUrl); err == nil {
+				issueResult.PRNumber = prNum
+			}
+		}
+	}
+
+	// Add comment to Jira issue
+	if execErr != nil {
+		comment := fmt.Sprintf("❌ Pilot execution failed:\n\n%s", execErr.Error())
+		if _, err := client.AddComment(ctx, issue.Key, comment); err != nil {
+			logging.WithComponent("jira").Warn("Failed to add comment",
+				slog.String("issue", issue.Key),
+				slog.Any("error", err),
+			)
+		}
+	} else if result != nil && result.Success {
+		// Validate deliverables before marking as done
+		if result.CommitSHA == "" && result.PRUrl == "" {
+			comment := fmt.Sprintf("⚠️ Pilot execution completed but no changes were made.\n\nDuration: %s\nBranch: %s\n\nNo commits or PR were created. The task may need clarification or manual intervention.",
+				result.Duration, branchName)
+			if _, err := client.AddComment(ctx, issue.Key, comment); err != nil {
+				logging.WithComponent("jira").Warn("Failed to add comment",
+					slog.String("issue", issue.Key),
+					slog.Any("error", err),
+				)
+			}
+			issueResult.Success = false
+		} else {
+			comment := buildJiraExecutionComment(result, branchName)
+			if _, err := client.AddComment(ctx, issue.Key, comment); err != nil {
+				logging.WithComponent("jira").Warn("Failed to add comment",
+					slog.String("issue", issue.Key),
+					slog.Any("error", err),
+				)
+			}
+		}
+	} else if result != nil {
+		comment := buildJiraFailureComment(result)
+		if _, err := client.AddComment(ctx, issue.Key, comment); err != nil {
+			logging.WithComponent("jira").Warn("Failed to add comment",
+				slog.String("issue", issue.Key),
+				slog.Any("error", err),
+			)
+		}
+	}
+
+	return issueResult, execErr
+}
+
+// buildJiraExecutionComment creates a comment for successful Jira execution
+func buildJiraExecutionComment(result *executor.ExecutionResult, branchName string) string {
+	var parts []string
+	parts = append(parts, "✅ Pilot execution completed successfully!")
+	parts = append(parts, "")
+
+	if result.PRUrl != "" {
+		parts = append(parts, fmt.Sprintf("Pull Request: %s", result.PRUrl))
+	}
+	if result.CommitSHA != "" {
+		parts = append(parts, fmt.Sprintf("Commit: %s", result.CommitSHA[:min(8, len(result.CommitSHA))]))
+	}
+	parts = append(parts, fmt.Sprintf("Branch: %s", branchName))
+	parts = append(parts, fmt.Sprintf("Duration: %s", result.Duration))
+
+	return strings.Join(parts, "\n")
+}
+
+// buildJiraFailureComment creates a comment for failed Jira execution
+func buildJiraFailureComment(result *executor.ExecutionResult) string {
+	var parts []string
+	parts = append(parts, "❌ Pilot execution failed")
+	parts = append(parts, "")
+	if result.Error != "" {
+		parts = append(parts, fmt.Sprintf("Error: %s", result.Error))
+	}
+	if result.Duration > 0 {
+		parts = append(parts, fmt.Sprintf("Duration: %s", result.Duration))
+	}
+	return strings.Join(parts, "\n")
 }
 
 func newStopCmd() *cobra.Command {

--- a/internal/adapters/jira/poller.go
+++ b/internal/adapters/jira/poller.go
@@ -1,0 +1,242 @@
+package jira
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// Status labels for tracking issue progress
+const (
+	LabelInProgress = "pilot-in-progress"
+	LabelDone       = "pilot-done"
+	LabelFailed     = "pilot-failed"
+)
+
+// IssueResult is returned by the issue handler
+type IssueResult struct {
+	Success  bool
+	PRNumber int
+	PRURL    string
+	Error    error
+}
+
+// Poller polls Jira for issues with the pilot label
+type Poller struct {
+	client     *Client
+	config     *Config
+	interval   time.Duration
+	processed  map[string]bool // Jira uses string IDs (issue keys like PROJ-123)
+	mu         sync.RWMutex
+	onIssue    func(ctx context.Context, issue *Issue) (*IssueResult, error)
+	logger     *slog.Logger
+	pilotLabel string
+}
+
+// PollerOption configures a Poller
+type PollerOption func(*Poller)
+
+// WithOnJiraIssue sets the callback for new issues
+func WithOnJiraIssue(fn func(ctx context.Context, issue *Issue) (*IssueResult, error)) PollerOption {
+	return func(p *Poller) {
+		p.onIssue = fn
+	}
+}
+
+// WithJiraPollerLogger sets the logger for the poller
+func WithJiraPollerLogger(logger *slog.Logger) PollerOption {
+	return func(p *Poller) {
+		p.logger = logger
+	}
+}
+
+// NewPoller creates a new Jira issue poller
+func NewPoller(client *Client, config *Config, interval time.Duration, opts ...PollerOption) *Poller {
+	pilotLabel := config.PilotLabel
+	if pilotLabel == "" {
+		pilotLabel = "pilot"
+	}
+
+	p := &Poller{
+		client:     client,
+		config:     config,
+		interval:   interval,
+		processed:  make(map[string]bool),
+		logger:     logging.WithComponent("jira-poller"),
+		pilotLabel: pilotLabel,
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
+}
+
+// Start begins polling for issues
+func (p *Poller) Start(ctx context.Context) error {
+	p.logger.Info("Starting Jira poller",
+		slog.String("label", p.pilotLabel),
+		slog.String("project", p.config.ProjectKey),
+		slog.Duration("interval", p.interval),
+	)
+
+	// Initial check
+	p.checkForNewIssues(ctx)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("Jira poller stopped")
+			return nil
+		case <-ticker.C:
+			p.checkForNewIssues(ctx)
+		}
+	}
+}
+
+// buildJQL constructs the JQL query for finding pilot issues
+func (p *Poller) buildJQL() string {
+	var parts []string
+
+	// Filter by label
+	parts = append(parts, fmt.Sprintf("labels = \"%s\"", p.pilotLabel))
+
+	// Filter by project if configured
+	if p.config.ProjectKey != "" {
+		parts = append(parts, fmt.Sprintf("project = \"%s\"", p.config.ProjectKey))
+	}
+
+	// Exclude done/closed statuses (using status category for broader coverage)
+	parts = append(parts, "statusCategory != Done")
+
+	// Order by created date (oldest first)
+	jql := strings.Join(parts, " AND ") + " ORDER BY created ASC"
+
+	return jql
+}
+
+func (p *Poller) checkForNewIssues(ctx context.Context) {
+	jql := p.buildJQL()
+	issues, err := p.client.SearchIssues(ctx, jql, 50)
+	if err != nil {
+		p.logger.Warn("Failed to fetch issues", slog.Any("error", err))
+		return
+	}
+
+	// Sort by creation date (oldest first) - API should return sorted, but ensure it
+	sort.Slice(issues, func(i, j int) bool {
+		// Parse Jira's datetime format
+		ti, _ := time.Parse("2006-01-02T15:04:05.000-0700", issues[i].Fields.Created)
+		tj, _ := time.Parse("2006-01-02T15:04:05.000-0700", issues[j].Fields.Created)
+		return ti.Before(tj)
+	})
+
+	for _, issue := range issues {
+		// Skip if already processed
+		p.mu.RLock()
+		processed := p.processed[issue.Key]
+		p.mu.RUnlock()
+
+		if processed {
+			continue
+		}
+
+		// Skip if has in-progress, done, or failed label
+		if p.hasStatusLabel(issue) {
+			// Only mark as processed if it has done label (allow retry of failed)
+			if p.client.HasLabel(issue, LabelDone) {
+				p.markProcessed(issue.Key)
+			}
+			continue
+		}
+
+		// Process the issue
+		p.logger.Info("Found new Jira issue",
+			slog.String("key", issue.Key),
+			slog.String("summary", issue.Fields.Summary),
+		)
+
+		if p.onIssue != nil {
+			// Add in-progress label
+			if err := p.client.AddLabel(ctx, issue.Key, LabelInProgress); err != nil {
+				p.logger.Warn("Failed to add in-progress label",
+					slog.String("key", issue.Key),
+					slog.Any("error", err),
+				)
+			}
+
+			result, err := p.onIssue(ctx, issue)
+			if err != nil {
+				p.logger.Error("Failed to process issue",
+					slog.String("key", issue.Key),
+					slog.Any("error", err),
+				)
+				// Remove in-progress label, add failed label
+				_ = p.client.RemoveLabel(ctx, issue.Key, LabelInProgress)
+				_ = p.client.AddLabel(ctx, issue.Key, LabelFailed)
+				// Don't mark as processed so it can be retried after fixing
+				continue
+			}
+
+			// Remove in-progress label
+			_ = p.client.RemoveLabel(ctx, issue.Key, LabelInProgress)
+
+			// Add done label on success
+			if result != nil && result.Success {
+				_ = p.client.AddLabel(ctx, issue.Key, LabelDone)
+			}
+		}
+
+		p.markProcessed(issue.Key)
+	}
+}
+
+func (p *Poller) hasStatusLabel(issue *Issue) bool {
+	return p.client.HasLabel(issue, LabelInProgress) ||
+		p.client.HasLabel(issue, LabelDone) ||
+		p.client.HasLabel(issue, LabelFailed)
+}
+
+func (p *Poller) markProcessed(key string) {
+	p.mu.Lock()
+	p.processed[key] = true
+	p.mu.Unlock()
+}
+
+// IsProcessed checks if an issue has been processed
+func (p *Poller) IsProcessed(key string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.processed[key]
+}
+
+// ProcessedCount returns the number of processed issues
+func (p *Poller) ProcessedCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.processed)
+}
+
+// Reset clears the processed issues map
+func (p *Poller) Reset() {
+	p.mu.Lock()
+	p.processed = make(map[string]bool)
+	p.mu.Unlock()
+}
+
+// ClearProcessed removes a specific issue from the processed map (for retry)
+func (p *Poller) ClearProcessed(key string) {
+	p.mu.Lock()
+	delete(p.processed, key)
+	p.mu.Unlock()
+}

--- a/internal/adapters/jira/poller_test.go
+++ b/internal/adapters/jira/poller_test.go
@@ -1,0 +1,407 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestNewPoller(t *testing.T) {
+	client := NewClient("https://example.atlassian.net", testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, PlatformCloud)
+	config := &Config{
+		PilotLabel: "pilot",
+		ProjectKey: "TEST",
+	}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	if poller.pilotLabel != "pilot" {
+		t.Errorf("expected pilotLabel 'pilot', got '%s'", poller.pilotLabel)
+	}
+
+	if poller.interval != 30*time.Second {
+		t.Errorf("expected interval 30s, got %v", poller.interval)
+	}
+
+	if len(poller.processed) != 0 {
+		t.Error("expected empty processed map")
+	}
+}
+
+func TestNewPoller_DefaultLabel(t *testing.T) {
+	client := NewClient("https://example.atlassian.net", testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, PlatformCloud)
+	config := &Config{
+		PilotLabel: "", // Empty label should default to "pilot"
+	}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	if poller.pilotLabel != "pilot" {
+		t.Errorf("expected default pilotLabel 'pilot', got '%s'", poller.pilotLabel)
+	}
+}
+
+func TestPollerWithOptions(t *testing.T) {
+	client := NewClient("https://example.atlassian.net", testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, PlatformCloud)
+	config := &Config{PilotLabel: "pilot"}
+
+	var callbackCalled bool
+	handler := func(ctx context.Context, issue *Issue) (*IssueResult, error) {
+		callbackCalled = true
+		return &IssueResult{Success: true}, nil
+	}
+
+	poller := NewPoller(client, config, 30*time.Second,
+		WithOnJiraIssue(handler),
+	)
+
+	if poller.onIssue == nil {
+		t.Error("expected onIssue handler to be set")
+	}
+
+	// Call the handler to verify it's wired correctly
+	_, _ = poller.onIssue(context.Background(), &Issue{})
+	if !callbackCalled {
+		t.Error("expected callback to be called")
+	}
+}
+
+func TestPollerMarkProcessed(t *testing.T) {
+	client := NewClient("https://example.atlassian.net", testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, PlatformCloud)
+	config := &Config{PilotLabel: "pilot"}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	if poller.IsProcessed("TEST-123") {
+		t.Error("expected TEST-123 NOT to be processed initially")
+	}
+
+	poller.markProcessed("TEST-123")
+
+	if !poller.IsProcessed("TEST-123") {
+		t.Error("expected TEST-123 to be processed after marking")
+	}
+
+	if poller.ProcessedCount() != 1 {
+		t.Errorf("expected processed count 1, got %d", poller.ProcessedCount())
+	}
+
+	poller.Reset()
+
+	if poller.IsProcessed("TEST-123") {
+		t.Error("expected TEST-123 NOT to be processed after reset")
+	}
+
+	if poller.ProcessedCount() != 0 {
+		t.Errorf("expected processed count 0 after reset, got %d", poller.ProcessedCount())
+	}
+}
+
+func TestPollerClearProcessed(t *testing.T) {
+	client := NewClient("https://example.atlassian.net", testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, PlatformCloud)
+	config := &Config{PilotLabel: "pilot"}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	poller.markProcessed("TEST-123")
+	poller.markProcessed("TEST-456")
+
+	if poller.ProcessedCount() != 2 {
+		t.Errorf("expected processed count 2, got %d", poller.ProcessedCount())
+	}
+
+	poller.ClearProcessed("TEST-123")
+
+	if poller.IsProcessed("TEST-123") {
+		t.Error("expected TEST-123 NOT to be processed after clearing")
+	}
+	if !poller.IsProcessed("TEST-456") {
+		t.Error("expected TEST-456 to still be processed")
+	}
+	if poller.ProcessedCount() != 1 {
+		t.Errorf("expected processed count 1 after clearing one, got %d", poller.ProcessedCount())
+	}
+}
+
+func TestPollerConcurrentAccess(t *testing.T) {
+	client := NewClient("https://example.atlassian.net", testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, PlatformCloud)
+	config := &Config{PilotLabel: "pilot"}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := "TEST-" + string(rune('0'+n%10))
+			poller.markProcessed(key)
+			_ = poller.IsProcessed(key)
+			_ = poller.ProcessedCount()
+		}(i)
+	}
+	wg.Wait()
+
+	// No race condition should occur
+	count := poller.ProcessedCount()
+	if count == 0 {
+		t.Error("expected some processed items")
+	}
+}
+
+func TestPollerBuildJQL(t *testing.T) {
+	client := NewClient("https://example.atlassian.net", testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, PlatformCloud)
+
+	tests := []struct {
+		name       string
+		config     *Config
+		wantJQL    string
+	}{
+		{
+			name: "label only",
+			config: &Config{
+				PilotLabel: "pilot",
+			},
+			wantJQL: `labels = "pilot" AND statusCategory != Done ORDER BY created ASC`,
+		},
+		{
+			name: "label and project",
+			config: &Config{
+				PilotLabel: "pilot",
+				ProjectKey: "TEST",
+			},
+			wantJQL: `labels = "pilot" AND project = "TEST" AND statusCategory != Done ORDER BY created ASC`,
+		},
+		{
+			name: "custom label",
+			config: &Config{
+				PilotLabel: "autopilot",
+				ProjectKey: "MYPROJ",
+			},
+			wantJQL: `labels = "autopilot" AND project = "MYPROJ" AND statusCategory != Done ORDER BY created ASC`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			poller := NewPoller(client, tt.config, 30*time.Second)
+			got := poller.buildJQL()
+			if got != tt.wantJQL {
+				t.Errorf("buildJQL() = %q, want %q", got, tt.wantJQL)
+			}
+		})
+	}
+}
+
+func TestPollerCheckForNewIssues(t *testing.T) {
+	var requestCount int
+	var processedIssue *Issue
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		// Handle search request
+		if r.Method == http.MethodGet && r.URL.Path == "/rest/api/3/search" {
+			resp := SearchResponse{
+				Issues: []*Issue{
+					{
+						Key: "TEST-1",
+						Fields: Fields{
+							Summary:     "First issue",
+							Description: "Test description",
+							Created:     "2024-01-01T10:00:00.000+0000",
+							Labels:      []string{"pilot"},
+						},
+					},
+					{
+						Key: "TEST-2",
+						Fields: Fields{
+							Summary:     "Second issue (in progress)",
+							Description: "Already being worked on",
+							Created:     "2024-01-02T10:00:00.000+0000",
+							Labels:      []string{"pilot", "pilot-in-progress"},
+						},
+					},
+				},
+				Total:      2,
+				MaxResults: 50,
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		// Handle label add/remove
+		if r.Method == http.MethodPut {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, PlatformCloud)
+	config := &Config{PilotLabel: "pilot"}
+	poller := NewPoller(client, config, 30*time.Second,
+		WithOnJiraIssue(func(ctx context.Context, issue *Issue) (*IssueResult, error) {
+			processedIssue = issue
+			return &IssueResult{Success: true}, nil
+		}),
+	)
+
+	ctx := context.Background()
+	poller.checkForNewIssues(ctx)
+
+	// Should process TEST-1 but skip TEST-2 (has in-progress label)
+	if processedIssue == nil {
+		t.Fatal("expected an issue to be processed")
+	}
+
+	if processedIssue.Key != "TEST-1" {
+		t.Errorf("expected TEST-1 to be processed, got %s", processedIssue.Key)
+	}
+
+	// TEST-1 should be marked as processed
+	if !poller.IsProcessed("TEST-1") {
+		t.Error("expected TEST-1 to be marked as processed")
+	}
+}
+
+func TestPollerCheckForNewIssues_SkipsAlreadyProcessed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && r.URL.Path == "/rest/api/3/search" {
+			resp := SearchResponse{
+				Issues: []*Issue{
+					{
+						Key: "TEST-1",
+						Fields: Fields{
+							Summary: "Already processed",
+							Labels:  []string{"pilot"},
+						},
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, PlatformCloud)
+	config := &Config{PilotLabel: "pilot"}
+
+	var callCount int
+	poller := NewPoller(client, config, 30*time.Second,
+		WithOnJiraIssue(func(ctx context.Context, issue *Issue) (*IssueResult, error) {
+			callCount++
+			return &IssueResult{Success: true}, nil
+		}),
+	)
+
+	// Mark as already processed
+	poller.markProcessed("TEST-1")
+
+	ctx := context.Background()
+	poller.checkForNewIssues(ctx)
+
+	if callCount != 0 {
+		t.Errorf("expected callback not to be called for already processed issue, got %d calls", callCount)
+	}
+}
+
+func TestPollerStart_CancelsOnContextDone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := SearchResponse{Issues: []*Issue{}}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, PlatformCloud)
+	config := &Config{PilotLabel: "pilot"}
+	poller := NewPoller(client, config, 100*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- poller.Start(ctx)
+	}()
+
+	// Cancel after a short delay
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("expected nil error on cancel, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("poller did not stop after context cancellation")
+	}
+}
+
+func TestPollerHasStatusLabel(t *testing.T) {
+	client := NewClient("https://example.atlassian.net", testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, PlatformCloud)
+	config := &Config{PilotLabel: "pilot"}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	tests := []struct {
+		name   string
+		labels []string
+		want   bool
+	}{
+		{"no labels", []string{}, false},
+		{"pilot only", []string{"pilot"}, false},
+		{"in-progress", []string{"pilot", "pilot-in-progress"}, true},
+		{"done", []string{"pilot", "pilot-done"}, true},
+		{"failed", []string{"pilot", "pilot-failed"}, true},
+		{"case insensitive", []string{"PILOT-IN-PROGRESS"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &Issue{
+				Fields: Fields{Labels: tt.labels},
+			}
+			got := poller.hasStatusLabel(issue)
+			if got != tt.want {
+				t.Errorf("hasStatusLabel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClientHasLabel(t *testing.T) {
+	client := NewClient("https://example.atlassian.net", testutil.FakeJiraUsername, testutil.FakeJiraAPIToken, PlatformCloud)
+
+	tests := []struct {
+		name   string
+		labels []string
+		search string
+		want   bool
+	}{
+		{"exact match", []string{"pilot"}, "pilot", true},
+		{"case insensitive", []string{"Pilot"}, "pilot", true},
+		{"not found", []string{"pilot"}, "autopilot", false},
+		{"empty labels", []string{}, "pilot", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &Issue{
+				Fields: Fields{Labels: tt.labels},
+			}
+			got := client.HasLabel(issue, tt.search)
+			if got != tt.want {
+				t.Errorf("HasLabel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/adapters/jira/types.go
+++ b/internal/adapters/jira/types.go
@@ -1,18 +1,30 @@
 package jira
 
+import "time"
+
 // Config holds Jira adapter configuration
 type Config struct {
 	Enabled       bool   `yaml:"enabled"`
-	Platform      string `yaml:"platform"`       // "cloud" or "server"
-	BaseURL       string `yaml:"base_url"`       // e.g., "https://company.atlassian.net"
-	Username      string `yaml:"username"`       // Email for Cloud, username for Server
-	APIToken      string `yaml:"api_token"`      // API token (both Cloud and Server)
-	WebhookSecret string `yaml:"webhook_secret"` // For HMAC signature verification
-	PilotLabel    string `yaml:"pilot_label"`
+	Platform      string `yaml:"platform,omitempty"`       // "cloud" or "server"
+	BaseURL       string `yaml:"base_url,omitempty"`       // e.g., "https://company.atlassian.net"
+	Username      string `yaml:"username,omitempty"`       // Email for Cloud, username for Server
+	APIToken      string `yaml:"api_token,omitempty"`      // API token (both Cloud and Server)
+	WebhookSecret string `yaml:"webhook_secret,omitempty"` // For HMAC signature verification
+	PilotLabel    string `yaml:"pilot_label,omitempty"`
+	ProjectKey    string `yaml:"project_key,omitempty"` // Optional project filter (e.g., "PROJ")
 	Transitions   struct {
-		InProgress string `yaml:"in_progress"` // Jira transition ID
-		Done       string `yaml:"done"`        // Jira transition ID
-	} `yaml:"transitions"`
+		InProgress string `yaml:"in_progress,omitempty"` // Jira transition ID
+		Done       string `yaml:"done,omitempty"`        // Jira transition ID
+	} `yaml:"transitions,omitempty"`
+
+	// Polling configuration
+	Polling *PollingConfig `yaml:"polling,omitempty"`
+}
+
+// PollingConfig holds polling configuration for Jira adapter
+type PollingConfig struct {
+	Enabled  bool          `yaml:"enabled"`
+	Interval time.Duration `yaml:"interval"`
 }
 
 // DefaultConfig returns default Jira configuration

--- a/internal/testutil/tokens.go
+++ b/internal/testutil/tokens.go
@@ -58,6 +58,9 @@ const (
 	// FakeJiraAPIToken is a safe test API token for Jira.
 	FakeJiraAPIToken = "test-jira-api-token"
 
+	// FakeJiraUsername is a safe test username/email for Jira.
+	FakeJiraUsername = "test@example.com"
+
 	// FakeStripeKey is a safe test API key for Stripe.
 	FakeStripeKey = "test-stripe-api-key"
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-905.

Closes #905

## Changes

GitHub Issue #905: feat(jira): Add polling support for Jira adapter

## Summary

Add polling capability to Jira adapter, bringing it to parity with GitHub/GitLab/Linear adapters.

## Current State

Jira adapter only supports webhooks. No polling means:
- No fallback if webhook delivery fails
- Can't use `pilot start --jira` in polling mode

## Implementation

### New Files

**`internal/adapters/jira/poller.go`** (~280 LOC)
- `Poller` struct with interval, processed map, onIssue callback
- `Start(ctx)` polling loop
- `checkForNewIssues(ctx)` using JQL query
- Status label helpers: `HasLabel()`, `LabelInProgress`, `LabelDone`, `LabelFailed`

**`internal/adapters/jira/poller_test.go`** (~200 LOC)

### Modifications

**`internal/adapters/jira/client.go`** (+50 LOC)
```go
func (c *Client) SearchIssues(ctx context.Context, jql string, maxResults int) ([]*Issue, error)
```
- Uses `/rest/api/3/search` (Cloud) or `/rest/api/2/search` (Server)
- JQL: `labels = "pilot" AND status NOT IN (Done, Closed) ORDER BY created ASC`

**`internal/adapters/jira/types.go`** (+40 LOC)
```go
type PollingConfig struct {
    Enabled    bool          `yaml:"enabled"`
    Interval   time.Duration `yaml:"interval,omitempty"`
    ProjectKey string        `yaml:"project_key,omitempty"`
}
```

**`cmd/pilot/main.go`** (+160 LOC)
- Add `handleJiraIssueWithResult()` handler function
- Add Jira poller wiring block (follow Linear pattern at lines 874-914)

## Reference

- GitHub poller: `internal/adapters/github/poller.go` (~770 LOC)
- Linear poller: `internal/adapters/linear/poller.go` (~230 LOC) — simpler reference
- main.go wiring: lines 874-914 (Linear pattern)

## Acceptance Criteria

- [ ] `pilot start --jira` works in polling mode
- [ ] JQL query filters by pilot label and excludes Done/Closed
- [ ] Processed issue tracking prevents re-processing
- [ ] Status labels applied correctly (pilot-in-progress, pilot-done, pilot-failed)
- [ ] Tests pass