### PR TITLE
feat(asana): Add polling support for Asana adapter

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -21,6 +21,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
+	"github.com/alekspetrov/pilot/internal/adapters/asana"
 	"github.com/alekspetrov/pilot/internal/adapters/github"
 	"github.com/alekspetrov/pilot/internal/adapters/linear"
 	"github.com/alekspetrov/pilot/internal/adapters/slack"
@@ -911,6 +912,37 @@ Examples:
 						}
 					}(linearPoller, ws.Name)
 				}
+			}
+
+			// Enable Asana polling in gateway mode if configured (GH-906)
+			if cfg.Adapters.Asana != nil && cfg.Adapters.Asana.Enabled &&
+				cfg.Adapters.Asana.Polling != nil && cfg.Adapters.Asana.Polling.Enabled {
+
+				// Determine interval
+				interval := 30 * time.Second
+				if cfg.Adapters.Asana.Polling.Interval > 0 {
+					interval = cfg.Adapters.Asana.Polling.Interval
+				}
+
+				asanaClient := asana.NewClient(cfg.Adapters.Asana.AccessToken, cfg.Adapters.Asana.WorkspaceID)
+				asanaPoller := asana.NewPoller(asanaClient, cfg.Adapters.Asana, interval,
+					asana.WithOnAsanaTask(func(taskCtx context.Context, task *asana.Task) (*asana.TaskResult, error) {
+						return handleAsanaTaskWithResult(taskCtx, cfg, asanaClient, task, projectPath, gwDispatcher, gwRunner, gwMonitor, gwProgram, gwAlertsEngine, gwEnforcer)
+					}),
+				)
+
+				logging.WithComponent("start").Info("Asana polling enabled in gateway mode",
+					slog.String("workspace", cfg.Adapters.Asana.WorkspaceID),
+					slog.String("tag", cfg.Adapters.Asana.PilotTag),
+					slog.Duration("interval", interval),
+				)
+				go func() {
+					if err := asanaPoller.Start(context.Background()); err != nil {
+						logging.WithComponent("asana").Error("Asana poller failed",
+							slog.Any("error", err),
+						)
+					}
+				}()
 			}
 
 			// Wire teams service if --team flag provided (GH-633)
@@ -2631,6 +2663,242 @@ func handleLinearIssueWithResult(ctx context.Context, cfg *config.Config, client
 	}
 
 	return issueResult, execErr
+}
+
+func handleAsanaTaskWithResult(ctx context.Context, cfg *config.Config, client *asana.Client, task *asana.Task, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner, monitor *executor.Monitor, program *tea.Program, alertsEngine *alerts.Engine, enforcer *budget.Enforcer) (*asana.TaskResult, error) {
+	taskID := fmt.Sprintf("ASANA-%s", task.GID)
+
+	// Register task with monitor if in dashboard mode
+	if monitor != nil {
+		taskURL := task.Permalink
+		if taskURL == "" {
+			taskURL = fmt.Sprintf("https://app.asana.com/0/0/%s", task.GID)
+		}
+		monitor.Register(taskID, task.Name, taskURL)
+		monitor.Start(taskID)
+	}
+	if program != nil {
+		program.Send(dashboard.AddLog(fmt.Sprintf("📋 Asana Task %s: %s", task.GID, task.Name))())
+	}
+
+	// Emit task started event (GH-337)
+	if alertsEngine != nil {
+		alertsEngine.ProcessEvent(alerts.Event{
+			Type:      alerts.EventTypeTaskStarted,
+			TaskID:    taskID,
+			TaskTitle: task.Name,
+			Project:   projectPath,
+			Timestamp: time.Now(),
+		})
+	}
+
+	// GH-539: Pre-execution budget check
+	if enforcer != nil {
+		checkResult, budgetErr := enforcer.CheckBudget(ctx, "", "")
+		if budgetErr != nil {
+			logging.WithComponent("budget").Warn("budget check failed, allowing task (fail-open)",
+				slog.String("task_id", taskID),
+				slog.Any("error", budgetErr),
+			)
+		} else if !checkResult.Allowed {
+			logging.WithComponent("budget").Warn("task blocked by budget enforcement",
+				slog.String("task_id", taskID),
+				slog.String("reason", checkResult.Reason),
+			)
+			if alertsEngine != nil {
+				alertsEngine.ProcessEvent(alerts.Event{
+					Type:      alerts.EventTypeBudgetExceeded,
+					TaskID:    taskID,
+					TaskTitle: task.Name,
+					Project:   projectPath,
+					Error:     checkResult.Reason,
+					Metadata: map[string]string{
+						"daily_left":   fmt.Sprintf("%.2f", checkResult.DailyLeft),
+						"monthly_left": fmt.Sprintf("%.2f", checkResult.MonthlyLeft),
+						"action":       string(checkResult.Action),
+					},
+					Timestamp: time.Now(),
+				})
+			}
+			budgetExceededErr := fmt.Errorf("budget enforcement: %s", checkResult.Reason)
+			return &asana.TaskResult{
+				Success: false,
+				Error:   budgetExceededErr,
+			}, budgetExceededErr
+		}
+	}
+
+	fmt.Printf("\n📋 Asana Task %s: %s\n", task.GID, task.Name)
+
+	taskDesc := fmt.Sprintf("Asana Task %s: %s\n\n%s", task.GID, task.Name, task.Notes)
+	branchName := fmt.Sprintf("pilot/%s", taskID)
+
+	execTask := &executor.Task{
+		ID:          taskID,
+		Title:       task.Name,
+		Description: taskDesc,
+		ProjectPath: projectPath,
+		Branch:      branchName,
+		CreatePR:    true,
+	}
+
+	var result *executor.ExecutionResult
+	var execErr error
+
+	if dispatcher != nil {
+		execID, qErr := dispatcher.QueueTask(ctx, execTask)
+		if qErr != nil {
+			execErr = fmt.Errorf("failed to queue task: %w", qErr)
+		} else {
+			fmt.Printf("   📋 Queued as execution %s\n", execID[:8])
+			exec, waitErr := dispatcher.WaitForExecution(ctx, execID, time.Second)
+			if waitErr != nil {
+				execErr = fmt.Errorf("failed waiting for execution: %w", waitErr)
+			} else if exec.Status == "failed" {
+				execErr = fmt.Errorf("execution failed: %s", exec.Error)
+			} else {
+				result = &executor.ExecutionResult{
+					TaskID:    execTask.ID,
+					Success:   exec.Status == "completed",
+					Output:    exec.Output,
+					Error:     exec.Error,
+					PRUrl:     exec.PRUrl,
+					CommitSHA: exec.CommitSHA,
+					Duration:  time.Duration(exec.DurationMs) * time.Millisecond,
+				}
+			}
+		}
+	} else {
+		result, execErr = runner.Execute(ctx, execTask)
+	}
+
+	// Update monitor with completion status
+	prURL := ""
+	if result != nil {
+		prURL = result.PRUrl
+	}
+	if monitor != nil {
+		if execErr != nil {
+			monitor.Fail(taskID, execErr.Error())
+		} else {
+			monitor.Complete(taskID, prURL)
+		}
+	}
+
+	// Emit task completed/failed event (GH-337)
+	if alertsEngine != nil {
+		if execErr != nil {
+			alertsEngine.ProcessEvent(alerts.Event{
+				Type:      alerts.EventTypeTaskFailed,
+				TaskID:    taskID,
+				TaskTitle: task.Name,
+				Project:   projectPath,
+				Error:     execErr.Error(),
+				Timestamp: time.Now(),
+			})
+		} else if result != nil && result.Success {
+			metadata := map[string]string{}
+			if result.PRUrl != "" {
+				metadata["pr_url"] = result.PRUrl
+			}
+			if result.Duration > 0 {
+				metadata["duration"] = result.Duration.String()
+			}
+			alertsEngine.ProcessEvent(alerts.Event{
+				Type:      alerts.EventTypeTaskCompleted,
+				TaskID:    taskID,
+				TaskTitle: task.Name,
+				Project:   projectPath,
+				Metadata:  metadata,
+				Timestamp: time.Now(),
+			})
+		} else if result != nil {
+			alertsEngine.ProcessEvent(alerts.Event{
+				Type:      alerts.EventTypeTaskFailed,
+				TaskID:    taskID,
+				TaskTitle: task.Name,
+				Project:   projectPath,
+				Error:     result.Error,
+				Timestamp: time.Now(),
+			})
+		}
+	}
+
+	// Add completed task to dashboard history
+	if program != nil {
+		status := "success"
+		duration := ""
+		if execErr != nil {
+			status = "failed"
+		} else if result != nil {
+			duration = result.Duration.String()
+		}
+		program.Send(dashboard.AddCompletedTask(taskID, task.Name, status, duration, "", false)())
+	}
+
+	// Build task result
+	taskResult := &asana.TaskResult{
+		Success: execErr == nil && result != nil && result.Success,
+	}
+	if result != nil {
+		if result.PRUrl != "" {
+			taskResult.PRURL = result.PRUrl
+			if prNum, err := github.ExtractPRNumber(result.PRUrl); err == nil {
+				taskResult.PRNumber = prNum
+			}
+		}
+	}
+
+	// Add comment to Asana task
+	if execErr != nil {
+		comment := fmt.Sprintf("❌ Pilot execution failed:\n\n%s", execErr.Error())
+		if _, err := client.AddComment(ctx, task.GID, comment); err != nil {
+			logging.WithComponent("asana").Warn("Failed to add comment",
+				slog.String("task", task.GID),
+				slog.Any("error", err),
+			)
+		}
+	} else if result != nil && result.Success {
+		// Validate deliverables before marking as done
+		if result.CommitSHA == "" && result.PRUrl == "" {
+			comment := fmt.Sprintf("⚠️ Pilot execution completed but no changes were made.\n\nDuration: %s\nBranch: %s\n\nNo commits or PR were created. The task may need clarification or manual intervention.",
+				result.Duration, branchName)
+			if _, err := client.AddComment(ctx, task.GID, comment); err != nil {
+				logging.WithComponent("asana").Warn("Failed to add comment",
+					slog.String("task", task.GID),
+					slog.Any("error", err),
+				)
+			}
+			taskResult.Success = false
+		} else {
+			comment := buildExecutionComment(result, branchName)
+			if _, err := client.AddComment(ctx, task.GID, comment); err != nil {
+				logging.WithComponent("asana").Warn("Failed to add comment",
+					slog.String("task", task.GID),
+					slog.Any("error", err),
+				)
+			}
+			// Add PR as attachment
+			if result.PRUrl != "" {
+				if _, err := client.AddAttachment(ctx, task.GID, result.PRUrl, fmt.Sprintf("PR #%d", taskResult.PRNumber)); err != nil {
+					logging.WithComponent("asana").Warn("Failed to add PR attachment",
+						slog.String("task", task.GID),
+						slog.Any("error", err),
+					)
+				}
+			}
+		}
+	} else if result != nil {
+		comment := buildFailureComment(result)
+		if _, err := client.AddComment(ctx, task.GID, comment); err != nil {
+			logging.WithComponent("asana").Warn("Failed to add comment",
+				slog.String("task", task.GID),
+				slog.Any("error", err),
+			)
+		}
+	}
+
+	return taskResult, execErr
 }
 
 func newStopCmd() *cobra.Command {

--- a/internal/adapters/asana/poller.go
+++ b/internal/adapters/asana/poller.go
@@ -1,0 +1,235 @@
+package asana
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// TaskResult is returned by the task handler
+type TaskResult struct {
+	Success  bool
+	PRNumber int
+	PRURL    string
+	Error    error
+}
+
+// Poller polls Asana for tasks with a specific tag
+type Poller struct {
+	client    *Client
+	config    *Config
+	interval  time.Duration
+	processed map[string]bool // Asana uses string GIDs
+	mu        sync.RWMutex
+	onTask    func(ctx context.Context, task *Task) (*TaskResult, error)
+	logger    *slog.Logger
+
+	// Tag GID cache
+	pilotTagGID      string
+	inProgressTagGID string
+	doneTagGID       string
+	failedTagGID     string
+}
+
+// PollerOption configures a Poller
+type PollerOption func(*Poller)
+
+// WithOnAsanaTask sets the callback for new tasks
+func WithOnAsanaTask(fn func(ctx context.Context, task *Task) (*TaskResult, error)) PollerOption {
+	return func(p *Poller) {
+		p.onTask = fn
+	}
+}
+
+// WithAsanaPollerLogger sets the logger for the poller
+func WithAsanaPollerLogger(logger *slog.Logger) PollerOption {
+	return func(p *Poller) {
+		p.logger = logger
+	}
+}
+
+// NewPoller creates a new Asana task poller
+func NewPoller(client *Client, config *Config, interval time.Duration, opts ...PollerOption) *Poller {
+	p := &Poller{
+		client:    client,
+		config:    config,
+		interval:  interval,
+		processed: make(map[string]bool),
+		logger:    logging.WithComponent("asana-poller"),
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
+}
+
+// Start begins polling for tasks
+func (p *Poller) Start(ctx context.Context) error {
+	// Cache tag GIDs on startup
+	if err := p.cacheTagGIDs(ctx); err != nil {
+		return fmt.Errorf("failed to cache tag GIDs: %w", err)
+	}
+
+	p.logger.Info("Starting Asana poller",
+		slog.String("workspace", p.client.workspaceID),
+		slog.String("tag", p.config.PilotTag),
+		slog.Duration("interval", p.interval),
+	)
+
+	// Initial check
+	p.checkForNewTasks(ctx)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("Asana poller stopped")
+			return nil
+		case <-ticker.C:
+			p.checkForNewTasks(ctx)
+		}
+	}
+}
+
+func (p *Poller) cacheTagGIDs(ctx context.Context) error {
+	// Find or create pilot tag
+	pilotTag, err := p.client.FindTagByName(ctx, p.config.PilotTag)
+	if err != nil {
+		return fmt.Errorf("pilot tag lookup: %w", err)
+	}
+	if pilotTag == nil {
+		return fmt.Errorf("pilot tag %q not found in workspace", p.config.PilotTag)
+	}
+	p.pilotTagGID = pilotTag.GID
+
+	// Status tags are optional - create if needed or skip
+	if tag, _ := p.client.FindTagByName(ctx, "pilot-in-progress"); tag != nil {
+		p.inProgressTagGID = tag.GID
+	}
+	if tag, _ := p.client.FindTagByName(ctx, "pilot-done"); tag != nil {
+		p.doneTagGID = tag.GID
+	}
+	if tag, _ := p.client.FindTagByName(ctx, "pilot-failed"); tag != nil {
+		p.failedTagGID = tag.GID
+	}
+
+	return nil
+}
+
+func (p *Poller) checkForNewTasks(ctx context.Context) {
+	tasks, err := p.client.GetActiveTasksByTag(ctx, p.pilotTagGID)
+	if err != nil {
+		p.logger.Warn("Failed to fetch tasks", slog.Any("error", err))
+		return
+	}
+
+	// Sort by creation date (oldest first)
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].CreatedAt.Before(tasks[j].CreatedAt)
+	})
+
+	for _, task := range tasks {
+		// Skip if already processed
+		p.mu.RLock()
+		processed := p.processed[task.GID]
+		p.mu.RUnlock()
+
+		if processed {
+			continue
+		}
+
+		// Skip if has in-progress, done, or failed tag
+		if p.hasStatusTag(&task) {
+			p.markProcessed(task.GID)
+			continue
+		}
+
+		// Process the task
+		p.logger.Info("Found new Asana task",
+			slog.String("gid", task.GID),
+			slog.String("name", task.Name),
+		)
+
+		if p.onTask != nil {
+			// Add in-progress tag
+			if p.inProgressTagGID != "" {
+				_ = p.client.AddTag(ctx, task.GID, p.inProgressTagGID)
+			}
+
+			result, err := p.onTask(ctx, &task)
+			if err != nil {
+				p.logger.Error("Failed to process task",
+					slog.String("gid", task.GID),
+					slog.Any("error", err),
+				)
+				// Remove in-progress tag, add failed tag
+				if p.inProgressTagGID != "" {
+					_ = p.client.RemoveTag(ctx, task.GID, p.inProgressTagGID)
+				}
+				if p.failedTagGID != "" {
+					_ = p.client.AddTag(ctx, task.GID, p.failedTagGID)
+				}
+				p.markProcessed(task.GID)
+				continue
+			}
+
+			// Remove in-progress tag
+			if p.inProgressTagGID != "" {
+				_ = p.client.RemoveTag(ctx, task.GID, p.inProgressTagGID)
+			}
+
+			// Add done tag on success
+			if result != nil && result.Success && p.doneTagGID != "" {
+				_ = p.client.AddTag(ctx, task.GID, p.doneTagGID)
+			}
+		}
+
+		p.markProcessed(task.GID)
+	}
+}
+
+func (p *Poller) hasStatusTag(task *Task) bool {
+	for _, tag := range task.Tags {
+		switch tag.Name {
+		case "pilot-in-progress", "pilot-done", "pilot-failed":
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Poller) markProcessed(gid string) {
+	p.mu.Lock()
+	p.processed[gid] = true
+	p.mu.Unlock()
+}
+
+// IsProcessed checks if a task has been processed
+func (p *Poller) IsProcessed(gid string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.processed[gid]
+}
+
+// ProcessedCount returns the number of processed tasks
+func (p *Poller) ProcessedCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.processed)
+}
+
+// Reset clears the processed tasks map
+func (p *Poller) Reset() {
+	p.mu.Lock()
+	p.processed = make(map[string]bool)
+	p.mu.Unlock()
+}

--- a/internal/adapters/asana/poller_test.go
+++ b/internal/adapters/asana/poller_test.go
@@ -1,0 +1,540 @@
+package asana
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestNewPoller(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	cfg := DefaultConfig()
+	cfg.PilotTag = "pilot"
+
+	poller := NewPoller(client, cfg, 30*time.Second)
+
+	if poller == nil {
+		t.Fatal("NewPoller returned nil")
+	}
+	if poller.interval != 30*time.Second {
+		t.Errorf("poller.interval = %v, want 30s", poller.interval)
+	}
+	if poller.ProcessedCount() != 0 {
+		t.Errorf("ProcessedCount = %d, want 0", poller.ProcessedCount())
+	}
+}
+
+func TestNewPoller_WithOptions(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	cfg := DefaultConfig()
+
+	callbackCalled := false
+	poller := NewPoller(client, cfg, 30*time.Second,
+		WithOnAsanaTask(func(ctx context.Context, task *Task) (*TaskResult, error) {
+			callbackCalled = true
+			return &TaskResult{Success: true}, nil
+		}),
+	)
+
+	if poller.onTask == nil {
+		t.Error("expected onTask callback to be set")
+	}
+
+	// Verify callback works
+	_, _ = poller.onTask(context.Background(), &Task{})
+	if !callbackCalled {
+		t.Error("callback was not called")
+	}
+}
+
+func TestPoller_MarkProcessed(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	cfg := DefaultConfig()
+
+	poller := NewPoller(client, cfg, 30*time.Second)
+
+	// Initially not processed
+	if poller.IsProcessed("task-1") {
+		t.Error("task should not be processed initially")
+	}
+
+	// Mark as processed
+	poller.markProcessed("task-1")
+	if !poller.IsProcessed("task-1") {
+		t.Error("task should be processed after marking")
+	}
+
+	// Count should be 1
+	if poller.ProcessedCount() != 1 {
+		t.Errorf("ProcessedCount = %d, want 1", poller.ProcessedCount())
+	}
+
+	// Reset should clear
+	poller.Reset()
+	if poller.IsProcessed("task-1") {
+		t.Error("task should not be processed after reset")
+	}
+	if poller.ProcessedCount() != 0 {
+		t.Errorf("ProcessedCount = %d, want 0 after reset", poller.ProcessedCount())
+	}
+}
+
+func TestPoller_HasStatusTag(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	cfg := DefaultConfig()
+	poller := NewPoller(client, cfg, 30*time.Second)
+
+	tests := []struct {
+		name     string
+		task     *Task
+		expected bool
+	}{
+		{
+			name:     "no tags",
+			task:     &Task{Tags: []Tag{}},
+			expected: false,
+		},
+		{
+			name:     "pilot tag only",
+			task:     &Task{Tags: []Tag{{Name: "pilot"}}},
+			expected: false,
+		},
+		{
+			name:     "in-progress tag",
+			task:     &Task{Tags: []Tag{{Name: "pilot-in-progress"}}},
+			expected: true,
+		},
+		{
+			name:     "done tag",
+			task:     &Task{Tags: []Tag{{Name: "pilot-done"}}},
+			expected: true,
+		},
+		{
+			name:     "failed tag",
+			task:     &Task{Tags: []Tag{{Name: "pilot-failed"}}},
+			expected: true,
+		},
+		{
+			name:     "mixed tags with status",
+			task:     &Task{Tags: []Tag{{Name: "pilot"}, {Name: "pilot-done"}, {Name: "other"}}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := poller.hasStatusTag(tt.task)
+			if got != tt.expected {
+				t.Errorf("hasStatusTag() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPoller_CacheTagGIDs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/workspaces/"+testutil.FakeAsanaWorkspaceID+"/tags" {
+			resp := PagedResponse[Tag]{
+				Data: []Tag{
+					{GID: "tag-pilot", Name: "pilot"},
+					{GID: "tag-in-progress", Name: "pilot-in-progress"},
+					{GID: "tag-done", Name: "pilot-done"},
+					{GID: "tag-failed", Name: "pilot-failed"},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	cfg := DefaultConfig()
+	cfg.PilotTag = "pilot"
+
+	poller := NewPoller(client, cfg, 30*time.Second)
+
+	err := poller.cacheTagGIDs(context.Background())
+	if err != nil {
+		t.Fatalf("cacheTagGIDs failed: %v", err)
+	}
+
+	if poller.pilotTagGID != "tag-pilot" {
+		t.Errorf("pilotTagGID = %s, want tag-pilot", poller.pilotTagGID)
+	}
+	if poller.inProgressTagGID != "tag-in-progress" {
+		t.Errorf("inProgressTagGID = %s, want tag-in-progress", poller.inProgressTagGID)
+	}
+	if poller.doneTagGID != "tag-done" {
+		t.Errorf("doneTagGID = %s, want tag-done", poller.doneTagGID)
+	}
+	if poller.failedTagGID != "tag-failed" {
+		t.Errorf("failedTagGID = %s, want tag-failed", poller.failedTagGID)
+	}
+}
+
+func TestPoller_CacheTagGIDs_PilotTagNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return empty tag list
+		resp := PagedResponse[Tag]{
+			Data: []Tag{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	cfg := DefaultConfig()
+	cfg.PilotTag = "pilot"
+
+	poller := NewPoller(client, cfg, 30*time.Second)
+
+	err := poller.cacheTagGIDs(context.Background())
+	if err == nil {
+		t.Fatal("expected error when pilot tag not found")
+	}
+}
+
+func TestPoller_CheckForNewTasks(t *testing.T) {
+	var mu sync.Mutex
+	processedTasks := []string{}
+	addTagCalls := []string{}
+	removeTagCalls := []string{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		switch {
+		case r.URL.Path == "/tags/tag-pilot/tasks" && r.Method == http.MethodGet:
+			// Return list of tasks
+			resp := PagedResponse[Task]{
+				Data: []Task{
+					{GID: "task-1", Name: "Task 1"},
+					{GID: "task-2", Name: "Task 2"},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/tasks/task-1" && r.Method == http.MethodGet:
+			// Return full task details
+			resp := APIResponse[Task]{
+				Data: Task{
+					GID:       "task-1",
+					Name:      "Task 1",
+					Notes:     "Description 1",
+					Completed: false,
+					Tags:      []Tag{{GID: "tag-pilot", Name: "pilot"}},
+					CreatedAt: time.Now().Add(-time.Hour),
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/tasks/task-2" && r.Method == http.MethodGet:
+			// Already has status tag
+			resp := APIResponse[Task]{
+				Data: Task{
+					GID:       "task-2",
+					Name:      "Task 2",
+					Completed: false,
+					Tags:      []Tag{{GID: "tag-pilot", Name: "pilot"}, {GID: "tag-done", Name: "pilot-done"}},
+					CreatedAt: time.Now(),
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/tasks/task-1/addTag" && r.Method == http.MethodPost:
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			data := body["data"].(map[string]interface{})
+			addTagCalls = append(addTagCalls, data["tag"].(string))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{}}`))
+
+		case r.URL.Path == "/tasks/task-1/removeTag" && r.Method == http.MethodPost:
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			data := body["data"].(map[string]interface{})
+			removeTagCalls = append(removeTagCalls, data["tag"].(string))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{}}`))
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{}}`))
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	cfg := DefaultConfig()
+	cfg.PilotTag = "pilot"
+
+	poller := NewPoller(client, cfg, 30*time.Second,
+		WithOnAsanaTask(func(ctx context.Context, task *Task) (*TaskResult, error) {
+			mu.Lock()
+			processedTasks = append(processedTasks, task.GID)
+			mu.Unlock()
+			return &TaskResult{Success: true, PRNumber: 123, PRURL: "https://github.com/test/pr/123"}, nil
+		}),
+	)
+
+	// Set up tag GIDs manually (normally done in Start)
+	poller.pilotTagGID = "tag-pilot"
+	poller.inProgressTagGID = "tag-in-progress"
+	poller.doneTagGID = "tag-done"
+	poller.failedTagGID = "tag-failed"
+
+	// Run check
+	poller.checkForNewTasks(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Should have processed only task-1 (task-2 has pilot-done tag)
+	if len(processedTasks) != 1 {
+		t.Errorf("processed %d tasks, want 1", len(processedTasks))
+	}
+	if len(processedTasks) > 0 && processedTasks[0] != "task-1" {
+		t.Errorf("processed task %s, want task-1", processedTasks[0])
+	}
+
+	// Should have added in-progress tag before processing
+	if len(addTagCalls) < 1 || addTagCalls[0] != "tag-in-progress" {
+		t.Errorf("expected in-progress tag to be added first, got %v", addTagCalls)
+	}
+
+	// Should have removed in-progress and added done tag after success
+	if len(removeTagCalls) < 1 || removeTagCalls[0] != "tag-in-progress" {
+		t.Errorf("expected in-progress tag to be removed, got %v", removeTagCalls)
+	}
+}
+
+func TestPoller_CheckForNewTasks_HandlerError(t *testing.T) {
+	var mu sync.Mutex
+	addTagCalls := []string{}
+	removeTagCalls := []string{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		switch {
+		case r.URL.Path == "/tags/tag-pilot/tasks":
+			resp := PagedResponse[Task]{
+				Data: []Task{{GID: "task-1", Name: "Task 1"}},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/tasks/task-1" && r.Method == http.MethodGet:
+			resp := APIResponse[Task]{
+				Data: Task{
+					GID:       "task-1",
+					Name:      "Task 1",
+					Completed: false,
+					Tags:      []Tag{{GID: "tag-pilot", Name: "pilot"}},
+					CreatedAt: time.Now(),
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/tasks/task-1/addTag":
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			data := body["data"].(map[string]interface{})
+			addTagCalls = append(addTagCalls, data["tag"].(string))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{}}`))
+
+		case r.URL.Path == "/tasks/task-1/removeTag":
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			data := body["data"].(map[string]interface{})
+			removeTagCalls = append(removeTagCalls, data["tag"].(string))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{}}`))
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{}}`))
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	cfg := DefaultConfig()
+	cfg.PilotTag = "pilot"
+
+	poller := NewPoller(client, cfg, 30*time.Second,
+		WithOnAsanaTask(func(ctx context.Context, task *Task) (*TaskResult, error) {
+			return nil, context.Canceled // Simulate error
+		}),
+	)
+
+	poller.pilotTagGID = "tag-pilot"
+	poller.inProgressTagGID = "tag-in-progress"
+	poller.doneTagGID = "tag-done"
+	poller.failedTagGID = "tag-failed"
+
+	poller.checkForNewTasks(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// On error: should remove in-progress and add failed
+	foundInProgressRemove := false
+	for _, call := range removeTagCalls {
+		if call == "tag-in-progress" {
+			foundInProgressRemove = true
+		}
+	}
+	if !foundInProgressRemove {
+		t.Error("expected in-progress tag to be removed on error")
+	}
+
+	foundFailedAdd := false
+	for _, call := range addTagCalls {
+		if call == "tag-failed" {
+			foundFailedAdd = true
+		}
+	}
+	if !foundFailedAdd {
+		t.Error("expected failed tag to be added on error")
+	}
+
+	// Task should be marked as processed even on error
+	if !poller.IsProcessed("task-1") {
+		t.Error("task should be marked as processed even on error")
+	}
+}
+
+func TestPoller_Start_ContextCancel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/workspaces/"+testutil.FakeAsanaWorkspaceID+"/tags" {
+			resp := PagedResponse[Tag]{
+				Data: []Tag{{GID: "tag-pilot", Name: "pilot"}},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		if r.URL.Path == "/tags/tag-pilot/tasks" {
+			resp := PagedResponse[Task]{Data: []Task{}}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(server.URL, testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	cfg := DefaultConfig()
+	cfg.PilotTag = "pilot"
+
+	poller := NewPoller(client, cfg, 100*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- poller.Start(ctx)
+	}()
+
+	// Let it run one cycle
+	time.Sleep(150 * time.Millisecond)
+
+	// Cancel context
+	cancel()
+
+	// Should stop gracefully
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Error("Start did not stop after context cancel")
+	}
+}
+
+func TestPoller_ConcurrentAccess(t *testing.T) {
+	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
+	cfg := DefaultConfig()
+	poller := NewPoller(client, cfg, 30*time.Second)
+
+	// Test concurrent read/write access
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		taskID := string(rune('a' + i%26))
+
+		go func(id string) {
+			defer wg.Done()
+			poller.markProcessed(id)
+		}(taskID)
+
+		go func(id string) {
+			defer wg.Done()
+			_ = poller.IsProcessed(id)
+		}(taskID)
+	}
+	wg.Wait()
+
+	// Should not panic and count should be reasonable
+	count := poller.ProcessedCount()
+	if count < 1 || count > 26 {
+		t.Errorf("unexpected processed count: %d", count)
+	}
+}
+
+func TestTaskResult(t *testing.T) {
+	result := &TaskResult{
+		Success:  true,
+		PRNumber: 123,
+		PRURL:    "https://github.com/test/repo/pull/123",
+		Error:    nil,
+	}
+
+	if !result.Success {
+		t.Error("expected Success to be true")
+	}
+	if result.PRNumber != 123 {
+		t.Errorf("PRNumber = %d, want 123", result.PRNumber)
+	}
+	if result.PRURL != "https://github.com/test/repo/pull/123" {
+		t.Errorf("PRURL = %s, want https://github.com/test/repo/pull/123", result.PRURL)
+	}
+}
+
+func TestPollingConfig(t *testing.T) {
+	cfg := &PollingConfig{
+		Enabled:    true,
+		Interval:   60 * time.Second,
+		ProjectGID: "proj-123",
+	}
+
+	if !cfg.Enabled {
+		t.Error("expected Enabled to be true")
+	}
+	if cfg.Interval != 60*time.Second {
+		t.Errorf("Interval = %v, want 60s", cfg.Interval)
+	}
+	if cfg.ProjectGID != "proj-123" {
+		t.Errorf("ProjectGID = %s, want proj-123", cfg.ProjectGID)
+	}
+}

--- a/internal/adapters/asana/types.go
+++ b/internal/adapters/asana/types.go
@@ -5,11 +5,19 @@ import "time"
 
 // Config holds Asana adapter configuration
 type Config struct {
-	Enabled       bool   `yaml:"enabled"`
-	AccessToken   string `yaml:"access_token"`   // Personal access token or OAuth token
-	WorkspaceID   string `yaml:"workspace_id"`   // Asana workspace GID
-	WebhookSecret string `yaml:"webhook_secret"` // For X-Hook-Secret verification
-	PilotTag      string `yaml:"pilot_tag"`      // Tag name that triggers Pilot (default: "pilot")
+	Enabled       bool           `yaml:"enabled"`
+	AccessToken   string         `yaml:"access_token,omitempty"`   // Personal access token or OAuth token
+	WorkspaceID   string         `yaml:"workspace_id,omitempty"`   // Asana workspace GID
+	WebhookSecret string         `yaml:"webhook_secret,omitempty"` // For X-Hook-Secret verification
+	PilotTag      string         `yaml:"pilot_tag,omitempty"`      // Tag name that triggers Pilot (default: "pilot")
+	Polling       *PollingConfig `yaml:"polling,omitempty"`        // Polling configuration
+}
+
+// PollingConfig holds configuration for Asana task polling
+type PollingConfig struct {
+	Enabled    bool          `yaml:"enabled"`
+	Interval   time.Duration `yaml:"interval,omitempty"`    // Poll interval (default: 30s)
+	ProjectGID string        `yaml:"project_gid,omitempty"` // Optional: filter to specific project
 }
 
 // DefaultConfig returns default Asana configuration
@@ -17,6 +25,10 @@ func DefaultConfig() *Config {
 	return &Config{
 		Enabled:  false,
 		PilotTag: "pilot",
+		Polling: &PollingConfig{
+			Enabled:  true,
+			Interval: 30 * time.Second,
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-906.

Closes #906

## Changes

GitHub Issue #906: feat(asana): Add polling support for Asana adapter

## Summary

Add polling capability to Asana adapter, bringing it to parity with GitHub/GitLab/Linear adapters.

## Current State

Asana adapter only supports webhooks. No polling means:
- No fallback if webhook delivery fails
- Can't use `pilot start --asana` in polling mode

## Implementation

### New Files

**`internal/adapters/asana/poller.go`** (~250 LOC)
- `Poller` struct with interval, processed map, onTask callback
- Tag GID caching for pilot/in-progress/done/failed tags
- `Start(ctx)` polling loop
- `checkForNewTasks(ctx)` using tag-based query

**`internal/adapters/asana/poller_test.go`** (~200 LOC)

### Modifications

**`internal/adapters/asana/client.go`** (+30 LOC)
```go
func (c *Client) GetActiveTasksByTag(ctx context.Context, tagGID string) ([]Task, error)
```
- Filters completed tasks from `GetTasksByTag()` results

**`internal/adapters/asana/types.go`** (+35 LOC)
```go
type PollingConfig struct {
    Enabled    bool          `yaml:"enabled"`
    Interval   time.Duration `yaml:"interval,omitempty"`
    ProjectGID string        `yaml:"project_gid,omitempty"`
}
```

**`cmd/pilot/main.go`** (+160 LOC)
- Add `handleAsanaTaskWithResult()` handler function
- Add Asana poller wiring block

## Reference

- GitHub poller: `internal/adapters/github/poller.go` (~770 LOC)
- Linear poller: `internal/adapters/linear/poller.go` (~230 LOC) — simpler reference
- main.go wiring: lines 874-914 (Linear pattern)

## Acceptance Criteria

- [ ] `pilot start --asana` works in polling mode
- [ ] Query filters by pilot tag and excludes completed tasks
- [ ] Processed task tracking prevents re-processing
- [ ] Status tags applied correctly (pilot-in-progress, pilot-done, pilot-failed)
- [ ] Tests pass