### PR TITLE
Create stagnation.go with state hash tracking and escalation

### DIFF
--- a/internal/executor/stagnation.go
+++ b/internal/executor/stagnation.go
@@ -1,0 +1,348 @@
+package executor
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// StagnationLevel represents the severity of detected stagnation.
+// Higher levels indicate more serious stagnation requiring escalation.
+type StagnationLevel int
+
+const (
+	// StagnationNone indicates no stagnation detected
+	StagnationNone StagnationLevel = iota
+
+	// StagnationWarn indicates early warning (3+ identical states OR 10m no progress)
+	// Action: Log warning, emit alert, continue execution
+	StagnationWarn
+
+	// StagnationPause indicates significant stagnation (5+ identical states OR 20m no progress)
+	// Action: Alert, request human decision
+	StagnationPause
+
+	// StagnationAbort indicates critical stagnation (30m timeout OR iteration limit)
+	// Action: Graceful shutdown, commit partial work
+	StagnationAbort
+)
+
+// String returns the string representation of a StagnationLevel
+func (l StagnationLevel) String() string {
+	switch l {
+	case StagnationNone:
+		return "none"
+	case StagnationWarn:
+		return "warn"
+	case StagnationPause:
+		return "pause"
+	case StagnationAbort:
+		return "abort"
+	default:
+		return fmt.Sprintf("unknown(%d)", l)
+	}
+}
+
+// StagnationConfig holds configuration for stagnation detection thresholds.
+// All durations are specified as time.Duration values.
+type StagnationConfig struct {
+	// WarnAfterIdentical is the number of identical state hashes before warning (default: 3)
+	WarnAfterIdentical int `yaml:"warn_after_identical"`
+
+	// PauseAfterIdentical is the number of identical state hashes before pause (default: 5)
+	PauseAfterIdentical int `yaml:"pause_after_identical"`
+
+	// WarnAfterNoProgress is the duration without progress before warning (default: 10m)
+	WarnAfterNoProgress time.Duration `yaml:"warn_after_no_progress"`
+
+	// PauseAfterNoProgress is the duration without progress before pause (default: 20m)
+	PauseAfterNoProgress time.Duration `yaml:"pause_after_no_progress"`
+
+	// AbortAfterNoProgress is the duration without progress before abort (default: 30m)
+	AbortAfterNoProgress time.Duration `yaml:"abort_after_no_progress"`
+
+	// MaxIterations is the absolute iteration limit before abort (default: 10)
+	MaxIterations int `yaml:"max_iterations"`
+
+	// HistorySize is the number of state hashes to track (default: 20)
+	HistorySize int `yaml:"history_size"`
+}
+
+// DefaultStagnationConfig returns sensible default configuration values.
+func DefaultStagnationConfig() *StagnationConfig {
+	return &StagnationConfig{
+		WarnAfterIdentical:   3,
+		PauseAfterIdentical:  5,
+		WarnAfterNoProgress:  10 * time.Minute,
+		PauseAfterNoProgress: 20 * time.Minute,
+		AbortAfterNoProgress: 30 * time.Minute,
+		MaxIterations:        10,
+		HistorySize:          20,
+	}
+}
+
+// StagnationMonitor tracks execution state and detects stagnation patterns.
+// It uses state hash tracking and timeout-based detection to identify when
+// execution is stuck in a loop or making no meaningful progress.
+type StagnationMonitor struct {
+	config *StagnationConfig
+	log    *slog.Logger
+
+	// State tracking
+	stateHashes    []uint64
+	lastProgressAt time.Time
+	lastPhase      string
+	lastProgress   int
+	lastIteration  int
+	currentLevel   StagnationLevel
+	startedAt      time.Time
+
+	mu sync.Mutex
+}
+
+// NewStagnationMonitor creates a new StagnationMonitor with the given configuration.
+// If config is nil, DefaultStagnationConfig() is used.
+// If log is nil, slog.Default() is used.
+func NewStagnationMonitor(config *StagnationConfig, log *slog.Logger) *StagnationMonitor {
+	if config == nil {
+		config = DefaultStagnationConfig()
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+
+	now := time.Now()
+	return &StagnationMonitor{
+		config:         config,
+		log:            log,
+		stateHashes:    make([]uint64, 0, config.HistorySize),
+		lastProgressAt: now,
+		startedAt:      now,
+		lastProgress:   -1, // -1 indicates no progress recorded yet
+		lastIteration:  -1,
+		currentLevel:   StagnationNone,
+	}
+}
+
+// RecordState records a Navigator status update and checks for stagnation.
+// Returns the current stagnation level after evaluating all detection mechanisms.
+//
+// Detection mechanisms:
+// 1. State hash tracking - hash(phase + progress + iteration), detect consecutive identical
+// 2. Progress timeout - track time since last meaningful change
+// 3. Iteration limit - escalate at configurable thresholds
+func (m *StagnationMonitor) RecordState(phase string, progress, iteration int) StagnationLevel {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+
+	// Check for meaningful progress (phase change, progress increase, or iteration advance)
+	hasProgress := m.detectProgress(phase, progress, iteration)
+	if hasProgress {
+		m.lastProgressAt = now
+		m.log.Debug("stagnation monitor: progress detected",
+			"phase", phase,
+			"progress", progress,
+			"iteration", iteration,
+		)
+	}
+
+	// Update last seen values
+	m.lastPhase = phase
+	m.lastProgress = progress
+	m.lastIteration = iteration
+
+	// Compute and record state hash
+	hash := m.computeStateHash(phase, progress, iteration)
+	m.stateHashes = append(m.stateHashes, hash)
+
+	// Trim history to configured size
+	if len(m.stateHashes) > m.config.HistorySize {
+		m.stateHashes = m.stateHashes[len(m.stateHashes)-m.config.HistorySize:]
+	}
+
+	// Evaluate stagnation level
+	level := m.evaluateStagnation(now, iteration)
+
+	// Log level changes
+	if level != m.currentLevel {
+		m.log.Info("stagnation level changed",
+			"from", m.currentLevel.String(),
+			"to", level.String(),
+			"phase", phase,
+			"progress", progress,
+			"iteration", iteration,
+			"identical_hashes", m.countIdenticalHashes(),
+			"time_since_progress", now.Sub(m.lastProgressAt).String(),
+		)
+		m.currentLevel = level
+	}
+
+	return level
+}
+
+// GetCurrentLevel returns the current stagnation level without recording new state.
+func (m *StagnationMonitor) GetCurrentLevel() StagnationLevel {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.currentLevel
+}
+
+// Reset resets the monitor state for a new execution.
+func (m *StagnationMonitor) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	m.stateHashes = make([]uint64, 0, m.config.HistorySize)
+	m.lastProgressAt = now
+	m.startedAt = now
+	m.lastPhase = ""
+	m.lastProgress = -1
+	m.lastIteration = -1
+	m.currentLevel = StagnationNone
+}
+
+// TimeSinceProgress returns the duration since the last meaningful progress.
+func (m *StagnationMonitor) TimeSinceProgress() time.Duration {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return time.Since(m.lastProgressAt)
+}
+
+// IdenticalHashCount returns the count of consecutive identical hashes at the end of history.
+func (m *StagnationMonitor) IdenticalHashCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.countIdenticalHashes()
+}
+
+// detectProgress checks if there's meaningful progress compared to the last recorded state.
+func (m *StagnationMonitor) detectProgress(phase string, progress, iteration int) bool {
+	// First state is always progress
+	if m.lastProgress == -1 {
+		return true
+	}
+
+	// Phase change is progress
+	if phase != m.lastPhase {
+		return true
+	}
+
+	// Progress increase is progress
+	if progress > m.lastProgress {
+		return true
+	}
+
+	// Iteration advance is progress
+	if iteration > m.lastIteration {
+		return true
+	}
+
+	return false
+}
+
+// computeStateHash generates a hash from phase, progress, and iteration.
+// Uses SHA-256 for consistent hashing across different states.
+func (m *StagnationMonitor) computeStateHash(phase string, progress, iteration int) uint64 {
+	h := sha256.New()
+	h.Write([]byte(phase))
+	h.Write([]byte{0}) // separator
+
+	// Write progress as bytes
+	progBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(progBytes, uint32(progress))
+	h.Write(progBytes)
+
+	// Write iteration as bytes
+	iterBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(iterBytes, uint32(iteration))
+	h.Write(iterBytes)
+
+	// Take first 8 bytes of hash as uint64
+	sum := h.Sum(nil)
+	return binary.BigEndian.Uint64(sum[:8])
+}
+
+// countIdenticalHashes counts consecutive identical hashes at the end of history.
+func (m *StagnationMonitor) countIdenticalHashes() int {
+	if len(m.stateHashes) < 2 {
+		return len(m.stateHashes)
+	}
+
+	lastHash := m.stateHashes[len(m.stateHashes)-1]
+	count := 1
+
+	for i := len(m.stateHashes) - 2; i >= 0; i-- {
+		if m.stateHashes[i] == lastHash {
+			count++
+		} else {
+			break
+		}
+	}
+
+	return count
+}
+
+// evaluateStagnation determines the stagnation level based on all detection mechanisms.
+func (m *StagnationMonitor) evaluateStagnation(now time.Time, iteration int) StagnationLevel {
+	identicalCount := m.countIdenticalHashes()
+	timeSinceProgress := now.Sub(m.lastProgressAt)
+
+	// Check for abort conditions first (highest priority)
+	if timeSinceProgress >= m.config.AbortAfterNoProgress {
+		m.log.Warn("stagnation: abort threshold reached (timeout)",
+			"time_since_progress", timeSinceProgress.String(),
+			"threshold", m.config.AbortAfterNoProgress.String(),
+		)
+		return StagnationAbort
+	}
+
+	if iteration >= m.config.MaxIterations {
+		m.log.Warn("stagnation: abort threshold reached (max iterations)",
+			"iteration", iteration,
+			"max_iterations", m.config.MaxIterations,
+		)
+		return StagnationAbort
+	}
+
+	// Check for pause conditions
+	if identicalCount >= m.config.PauseAfterIdentical {
+		m.log.Warn("stagnation: pause threshold reached (identical states)",
+			"identical_count", identicalCount,
+			"threshold", m.config.PauseAfterIdentical,
+		)
+		return StagnationPause
+	}
+
+	if timeSinceProgress >= m.config.PauseAfterNoProgress {
+		m.log.Warn("stagnation: pause threshold reached (no progress)",
+			"time_since_progress", timeSinceProgress.String(),
+			"threshold", m.config.PauseAfterNoProgress.String(),
+		)
+		return StagnationPause
+	}
+
+	// Check for warn conditions
+	if identicalCount >= m.config.WarnAfterIdentical {
+		m.log.Debug("stagnation: warn threshold reached (identical states)",
+			"identical_count", identicalCount,
+			"threshold", m.config.WarnAfterIdentical,
+		)
+		return StagnationWarn
+	}
+
+	if timeSinceProgress >= m.config.WarnAfterNoProgress {
+		m.log.Debug("stagnation: warn threshold reached (no progress)",
+			"time_since_progress", timeSinceProgress.String(),
+			"threshold", m.config.WarnAfterNoProgress.String(),
+		)
+		return StagnationWarn
+	}
+
+	return StagnationNone
+}

--- a/internal/executor/stagnation_test.go
+++ b/internal/executor/stagnation_test.go
@@ -1,0 +1,420 @@
+package executor
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestStagnationLevel_String(t *testing.T) {
+	tests := []struct {
+		level    StagnationLevel
+		expected string
+	}{
+		{StagnationNone, "none"},
+		{StagnationWarn, "warn"},
+		{StagnationPause, "pause"},
+		{StagnationAbort, "abort"},
+		{StagnationLevel(99), "unknown(99)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.level.String(); got != tt.expected {
+				t.Errorf("StagnationLevel(%d).String() = %q, want %q", tt.level, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultStagnationConfig(t *testing.T) {
+	cfg := DefaultStagnationConfig()
+
+	if cfg.WarnAfterIdentical != 3 {
+		t.Errorf("WarnAfterIdentical = %d, want 3", cfg.WarnAfterIdentical)
+	}
+	if cfg.PauseAfterIdentical != 5 {
+		t.Errorf("PauseAfterIdentical = %d, want 5", cfg.PauseAfterIdentical)
+	}
+	if cfg.WarnAfterNoProgress != 10*time.Minute {
+		t.Errorf("WarnAfterNoProgress = %v, want 10m", cfg.WarnAfterNoProgress)
+	}
+	if cfg.PauseAfterNoProgress != 20*time.Minute {
+		t.Errorf("PauseAfterNoProgress = %v, want 20m", cfg.PauseAfterNoProgress)
+	}
+	if cfg.AbortAfterNoProgress != 30*time.Minute {
+		t.Errorf("AbortAfterNoProgress = %v, want 30m", cfg.AbortAfterNoProgress)
+	}
+	if cfg.MaxIterations != 10 {
+		t.Errorf("MaxIterations = %d, want 10", cfg.MaxIterations)
+	}
+	if cfg.HistorySize != 20 {
+		t.Errorf("HistorySize = %d, want 20", cfg.HistorySize)
+	}
+}
+
+func TestNewStagnationMonitor_Defaults(t *testing.T) {
+	// With nil config and logger
+	m := NewStagnationMonitor(nil, nil)
+
+	if m.config == nil {
+		t.Fatal("config should not be nil")
+	}
+	if m.log == nil {
+		t.Fatal("log should not be nil")
+	}
+	if m.currentLevel != StagnationNone {
+		t.Errorf("initial level = %v, want StagnationNone", m.currentLevel)
+	}
+	if m.lastProgress != -1 {
+		t.Errorf("lastProgress = %d, want -1", m.lastProgress)
+	}
+}
+
+func TestStagnationMonitor_RecordState_Progress(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	m := NewStagnationMonitor(nil, logger)
+
+	// First state - should be no stagnation
+	level := m.RecordState("INIT", 0, 1)
+	if level != StagnationNone {
+		t.Errorf("first state: level = %v, want StagnationNone", level)
+	}
+
+	// Progress increase - should remain no stagnation
+	level = m.RecordState("INIT", 25, 1)
+	if level != StagnationNone {
+		t.Errorf("progress increase: level = %v, want StagnationNone", level)
+	}
+
+	// Phase change - should remain no stagnation
+	level = m.RecordState("RESEARCH", 25, 1)
+	if level != StagnationNone {
+		t.Errorf("phase change: level = %v, want StagnationNone", level)
+	}
+
+	// Iteration advance - should remain no stagnation
+	level = m.RecordState("RESEARCH", 25, 2)
+	if level != StagnationNone {
+		t.Errorf("iteration advance: level = %v, want StagnationNone", level)
+	}
+}
+
+func TestStagnationMonitor_IdenticalStateDetection(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &StagnationConfig{
+		WarnAfterIdentical:   3,
+		PauseAfterIdentical:  5,
+		WarnAfterNoProgress:  1 * time.Hour, // Large timeout to test hash-based detection
+		PauseAfterNoProgress: 2 * time.Hour,
+		AbortAfterNoProgress: 3 * time.Hour,
+		MaxIterations:        100,
+		HistorySize:          20,
+	}
+	m := NewStagnationMonitor(cfg, logger)
+
+	// Record same state multiple times
+	phase, progress, iteration := "IMPL", 50, 3
+
+	// First 2 states - no stagnation (need 3 for warn)
+	for i := 0; i < 2; i++ {
+		level := m.RecordState(phase, progress, iteration)
+		if level != StagnationNone {
+			t.Errorf("iteration %d: level = %v, want StagnationNone", i, level)
+		}
+	}
+
+	// 3rd identical state - should warn
+	level := m.RecordState(phase, progress, iteration)
+	if level != StagnationWarn {
+		t.Errorf("3rd identical: level = %v, want StagnationWarn", level)
+	}
+
+	// 4th identical state - still warn
+	level = m.RecordState(phase, progress, iteration)
+	if level != StagnationWarn {
+		t.Errorf("4th identical: level = %v, want StagnationWarn", level)
+	}
+
+	// 5th identical state - should pause
+	level = m.RecordState(phase, progress, iteration)
+	if level != StagnationPause {
+		t.Errorf("5th identical: level = %v, want StagnationPause", level)
+	}
+}
+
+func TestStagnationMonitor_TimeoutDetection(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &StagnationConfig{
+		WarnAfterIdentical:   100, // Large to disable hash-based detection
+		PauseAfterIdentical:  100,
+		WarnAfterNoProgress:  100 * time.Millisecond,
+		PauseAfterNoProgress: 200 * time.Millisecond,
+		AbortAfterNoProgress: 300 * time.Millisecond,
+		MaxIterations:        100,
+		HistorySize:          20,
+	}
+	m := NewStagnationMonitor(cfg, logger)
+
+	// Initial state
+	m.RecordState("INIT", 0, 1)
+
+	// Wait for warn threshold
+	time.Sleep(150 * time.Millisecond)
+	level := m.RecordState("INIT", 0, 1) // Same state, no progress
+	if level != StagnationWarn {
+		t.Errorf("after warn timeout: level = %v, want StagnationWarn", level)
+	}
+
+	// Wait for pause threshold
+	time.Sleep(100 * time.Millisecond)
+	level = m.RecordState("INIT", 0, 1)
+	if level != StagnationPause {
+		t.Errorf("after pause timeout: level = %v, want StagnationPause", level)
+	}
+
+	// Wait for abort threshold
+	time.Sleep(150 * time.Millisecond)
+	level = m.RecordState("INIT", 0, 1)
+	if level != StagnationAbort {
+		t.Errorf("after abort timeout: level = %v, want StagnationAbort", level)
+	}
+}
+
+func TestStagnationMonitor_MaxIterationsAbort(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &StagnationConfig{
+		WarnAfterIdentical:   100,
+		PauseAfterIdentical:  100,
+		WarnAfterNoProgress:  1 * time.Hour,
+		PauseAfterNoProgress: 2 * time.Hour,
+		AbortAfterNoProgress: 3 * time.Hour,
+		MaxIterations:        5, // Low for testing
+		HistorySize:          20,
+	}
+	m := NewStagnationMonitor(cfg, logger)
+
+	// Iterations below max - no abort
+	for i := 1; i < 5; i++ {
+		level := m.RecordState("IMPL", i*20, i)
+		if level == StagnationAbort {
+			t.Errorf("iteration %d: should not abort yet", i)
+		}
+	}
+
+	// At max iterations - should abort
+	level := m.RecordState("IMPL", 100, 5)
+	if level != StagnationAbort {
+		t.Errorf("at max iterations: level = %v, want StagnationAbort", level)
+	}
+}
+
+func TestStagnationMonitor_Reset(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &StagnationConfig{
+		WarnAfterIdentical:   3,
+		PauseAfterIdentical:  5,
+		WarnAfterNoProgress:  1 * time.Hour,
+		PauseAfterNoProgress: 2 * time.Hour,
+		AbortAfterNoProgress: 3 * time.Hour,
+		MaxIterations:        100,
+		HistorySize:          20,
+	}
+	m := NewStagnationMonitor(cfg, logger)
+
+	// Build up some stagnation
+	for i := 0; i < 5; i++ {
+		m.RecordState("IMPL", 50, 3)
+	}
+
+	if m.GetCurrentLevel() == StagnationNone {
+		t.Error("should have stagnation before reset")
+	}
+
+	// Reset
+	m.Reset()
+
+	if m.GetCurrentLevel() != StagnationNone {
+		t.Errorf("after reset: level = %v, want StagnationNone", m.GetCurrentLevel())
+	}
+
+	if m.IdenticalHashCount() != 0 {
+		t.Errorf("after reset: hash count = %d, want 0", m.IdenticalHashCount())
+	}
+
+	// New state after reset should be clean
+	level := m.RecordState("INIT", 0, 1)
+	if level != StagnationNone {
+		t.Errorf("first state after reset: level = %v, want StagnationNone", level)
+	}
+}
+
+func TestStagnationMonitor_ProgressResetsTimer(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &StagnationConfig{
+		WarnAfterIdentical:   100,
+		PauseAfterIdentical:  100,
+		WarnAfterNoProgress:  100 * time.Millisecond,
+		PauseAfterNoProgress: 200 * time.Millisecond,
+		AbortAfterNoProgress: 300 * time.Millisecond,
+		MaxIterations:        100,
+		HistorySize:          20,
+	}
+	m := NewStagnationMonitor(cfg, logger)
+
+	// Initial state
+	m.RecordState("INIT", 0, 1)
+
+	// Wait almost to warn threshold
+	time.Sleep(80 * time.Millisecond)
+
+	// Make progress - should reset timer
+	m.RecordState("RESEARCH", 25, 1)
+
+	// Wait a bit more - should NOT warn because timer reset
+	time.Sleep(50 * time.Millisecond)
+	level := m.RecordState("RESEARCH", 30, 1)
+	if level != StagnationNone {
+		t.Errorf("after progress reset: level = %v, want StagnationNone", level)
+	}
+}
+
+func TestStagnationMonitor_ComputeStateHash(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	m := NewStagnationMonitor(nil, logger)
+
+	// Same inputs should produce same hash
+	hash1 := m.computeStateHash("IMPL", 50, 3)
+	hash2 := m.computeStateHash("IMPL", 50, 3)
+	if hash1 != hash2 {
+		t.Error("identical inputs should produce identical hash")
+	}
+
+	// Different phase should produce different hash
+	hash3 := m.computeStateHash("VERIFY", 50, 3)
+	if hash1 == hash3 {
+		t.Error("different phase should produce different hash")
+	}
+
+	// Different progress should produce different hash
+	hash4 := m.computeStateHash("IMPL", 51, 3)
+	if hash1 == hash4 {
+		t.Error("different progress should produce different hash")
+	}
+
+	// Different iteration should produce different hash
+	hash5 := m.computeStateHash("IMPL", 50, 4)
+	if hash1 == hash5 {
+		t.Error("different iteration should produce different hash")
+	}
+}
+
+func TestStagnationMonitor_HistorySizeLimit(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &StagnationConfig{
+		WarnAfterIdentical:   100,
+		PauseAfterIdentical:  100,
+		WarnAfterNoProgress:  1 * time.Hour,
+		PauseAfterNoProgress: 2 * time.Hour,
+		AbortAfterNoProgress: 3 * time.Hour,
+		MaxIterations:        100,
+		HistorySize:          5, // Small for testing
+	}
+	m := NewStagnationMonitor(cfg, logger)
+
+	// Record more states than history size
+	for i := 0; i < 10; i++ {
+		m.RecordState("IMPL", i*10, i+1)
+	}
+
+	// History should be limited to HistorySize
+	m.mu.Lock()
+	historyLen := len(m.stateHashes)
+	m.mu.Unlock()
+
+	if historyLen != 5 {
+		t.Errorf("history length = %d, want %d", historyLen, 5)
+	}
+}
+
+func TestStagnationMonitor_TimeSinceProgress(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	m := NewStagnationMonitor(nil, logger)
+
+	m.RecordState("INIT", 0, 1)
+
+	time.Sleep(50 * time.Millisecond)
+
+	duration := m.TimeSinceProgress()
+	if duration < 50*time.Millisecond {
+		t.Errorf("TimeSinceProgress = %v, want >= 50ms", duration)
+	}
+}
+
+func TestStagnationMonitor_IdenticalHashCount(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	m := NewStagnationMonitor(nil, logger)
+
+	// No hashes yet
+	if count := m.IdenticalHashCount(); count != 0 {
+		t.Errorf("empty: count = %d, want 0", count)
+	}
+
+	// One hash
+	m.RecordState("INIT", 0, 1)
+	if count := m.IdenticalHashCount(); count != 1 {
+		t.Errorf("one hash: count = %d, want 1", count)
+	}
+
+	// Different hash
+	m.RecordState("RESEARCH", 25, 1)
+	if count := m.IdenticalHashCount(); count != 1 {
+		t.Errorf("different hash: count = %d, want 1", count)
+	}
+
+	// Same as last
+	m.RecordState("RESEARCH", 25, 1)
+	if count := m.IdenticalHashCount(); count != 2 {
+		t.Errorf("two identical: count = %d, want 2", count)
+	}
+
+	// Another same
+	m.RecordState("RESEARCH", 25, 1)
+	if count := m.IdenticalHashCount(); count != 3 {
+		t.Errorf("three identical: count = %d, want 3", count)
+	}
+
+	// Break the chain
+	m.RecordState("IMPL", 50, 2)
+	if count := m.IdenticalHashCount(); count != 1 {
+		t.Errorf("chain broken: count = %d, want 1", count)
+	}
+}
+
+func TestStagnationMonitor_GetCurrentLevel(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	cfg := &StagnationConfig{
+		WarnAfterIdentical:   3,
+		PauseAfterIdentical:  5,
+		WarnAfterNoProgress:  1 * time.Hour,
+		PauseAfterNoProgress: 2 * time.Hour,
+		AbortAfterNoProgress: 3 * time.Hour,
+		MaxIterations:        100,
+		HistorySize:          20,
+	}
+	m := NewStagnationMonitor(cfg, logger)
+
+	if m.GetCurrentLevel() != StagnationNone {
+		t.Errorf("initial: level = %v, want StagnationNone", m.GetCurrentLevel())
+	}
+
+	// Build up to warn
+	for i := 0; i < 3; i++ {
+		m.RecordState("IMPL", 50, 3)
+	}
+
+	if m.GetCurrentLevel() != StagnationWarn {
+		t.Errorf("after 3 identical: level = %v, want StagnationWarn", m.GetCurrentLevel())
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-924.

Closes #924

## Changes

GitHub Issue #924: Create stagnation.go with state hash tracking and escalation

## Summary
Create Pilot-side stagnation detection with state hash tracking and escalation levels.

## Implementation

Create `internal/executor/stagnation.go`:

```go
package executor

type StagnationLevel int

const (
    StagnationNone StagnationLevel = iota
    StagnationWarn   // 3+ identical states OR 10m no progress
    StagnationPause  // 5+ identical states OR 20m no progress
    StagnationAbort  // 30m timeout OR iteration limit
)

type StagnationMonitor struct {
    config         *StagnationConfig
    log            *slog.Logger
    stateHashes    []uint64
    lastProgressAt time.Time
    lastPhase      string
    lastProgress   int
    lastIteration  int
    currentLevel   StagnationLevel
    mu             sync.Mutex
}

func NewStagnationMonitor(config *StagnationConfig, log *slog.Logger) *StagnationMonitor

// RecordState records Navigator status and checks for stagnation
func (m *StagnationMonitor) RecordState(phase string, progress, iteration int) StagnationLevel

// computeStateHash generates hash from phase + progress + iteration
func (m *StagnationMonitor) computeStateHash(phase string, progress, iteration int) uint64

// countIdenticalHashes counts consecutive identical hashes in history
func (m *StagnationMonitor) countIdenticalHashes() int
```

**Detection mechanisms**:
1. State hash tracking - hash(phase + progress + iteration), detect 3+ identical
2. Progress timeout - track time since last meaningful change
3. Iteration limit - escalate at configurable thresholds

**Escalation levels**:
- `StagnationWarn`: Log warning, emit alert, continue
- `StagnationPause`: Alert, request human decision
- `StagnationAbort`: Graceful shutdown, commit partial work

## Acceptance Criteria
- [ ] `stagnation.go` created with StagnationMonitor
- [ ] State hash calculation using crypto/sha256
- [ ] Consecutive identical hash detection
- [ ] Timeout-based detection
- [ ] Three escalation levels implemented
- [ ] `stagnation_test.go` with tests
- [ ] Tests pass: `go test ./internal/executor/... -run Stagnation`

## Related
Task doc: `.agent/tasks/GH-SIGNAL-PROTOCOL-V2.md`
Depends on: #923 (signal.go)