### PR TITLE
Phase 4: Create knowledge.go for experiential memory

### DIFF
--- a/internal/memory/knowledge.go
+++ b/internal/memory/knowledge.go
@@ -1,0 +1,540 @@
+package memory
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MemoryType categorizes experiential memories
+type MemoryType string
+
+const (
+	MemoryTypePattern  MemoryType = "pattern"  // "We use JWT for auth"
+	MemoryTypePitfall  MemoryType = "pitfall"  // "Auth changes break tests"
+	MemoryTypeDecision MemoryType = "decision" // "JWT over sessions for scaling"
+	MemoryTypeLearning MemoryType = "learning" // "This error usually means X"
+)
+
+// Memory represents an experiential memory entry
+type Memory struct {
+	ID         int64
+	Type       MemoryType
+	Content    string
+	Context    string  // Task/file where this was learned
+	Confidence float64 // 0.0-1.0, decays over time
+	ProjectID  string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// KnowledgeStore manages experiential memories
+type KnowledgeStore struct {
+	db *sql.DB
+}
+
+// NewKnowledgeStore creates a knowledge store
+func NewKnowledgeStore(db *sql.DB) *KnowledgeStore {
+	return &KnowledgeStore{db: db}
+}
+
+// InitSchema creates the memories table
+func (k *KnowledgeStore) InitSchema() error {
+	_, err := k.db.Exec(`
+		CREATE TABLE IF NOT EXISTS memories (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			type TEXT NOT NULL,
+			content TEXT NOT NULL,
+			context TEXT,
+			confidence REAL DEFAULT 1.0,
+			project_id TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to create memories table: %w", err)
+	}
+
+	// Create indexes
+	indexes := []string{
+		`CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(type)`,
+		`CREATE INDEX IF NOT EXISTS idx_memories_project ON memories(project_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_memories_confidence ON memories(confidence DESC)`,
+	}
+
+	for _, idx := range indexes {
+		if _, err := k.db.Exec(idx); err != nil {
+			return fmt.Errorf("failed to create index: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// AddMemory stores a new memory
+func (k *KnowledgeStore) AddMemory(m *Memory) error {
+	if m.Content == "" {
+		return fmt.Errorf("memory content is required")
+	}
+	if m.Type == "" {
+		return fmt.Errorf("memory type is required")
+	}
+
+	// Default confidence if not set
+	if m.Confidence == 0 {
+		m.Confidence = 1.0
+	}
+
+	result, err := k.db.Exec(`
+		INSERT INTO memories (type, content, context, confidence, project_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, m.Type, m.Content, m.Context, m.Confidence, m.ProjectID)
+	if err != nil {
+		return fmt.Errorf("failed to insert memory: %w", err)
+	}
+
+	m.ID, _ = result.LastInsertId()
+	m.CreatedAt = time.Now()
+	m.UpdatedAt = time.Now()
+	return nil
+}
+
+// GetMemory retrieves a memory by ID
+func (k *KnowledgeStore) GetMemory(id int64) (*Memory, error) {
+	row := k.db.QueryRow(`
+		SELECT id, type, content, context, confidence, project_id, created_at, updated_at
+		FROM memories
+		WHERE id = ?
+	`, id)
+
+	m := &Memory{}
+	var projectID sql.NullString
+	var context sql.NullString
+	err := row.Scan(&m.ID, &m.Type, &m.Content, &context, &m.Confidence, &projectID, &m.CreatedAt, &m.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	if projectID.Valid {
+		m.ProjectID = projectID.String
+	}
+	if context.Valid {
+		m.Context = context.String
+	}
+
+	return m, nil
+}
+
+// UpdateMemory updates an existing memory
+func (k *KnowledgeStore) UpdateMemory(m *Memory) error {
+	if m.ID == 0 {
+		return fmt.Errorf("memory ID is required for update")
+	}
+
+	_, err := k.db.Exec(`
+		UPDATE memories
+		SET type = ?, content = ?, context = ?, confidence = ?, project_id = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?
+	`, m.Type, m.Content, m.Context, m.Confidence, m.ProjectID, m.ID)
+	if err != nil {
+		return fmt.Errorf("failed to update memory: %w", err)
+	}
+
+	m.UpdatedAt = time.Now()
+	return nil
+}
+
+// DeleteMemory removes a memory by ID
+func (k *KnowledgeStore) DeleteMemory(id int64) error {
+	_, err := k.db.Exec(`DELETE FROM memories WHERE id = ?`, id)
+	return err
+}
+
+// QueryByTopic searches memories by content/context
+func (k *KnowledgeStore) QueryByTopic(topic string, projectID string) ([]*Memory, error) {
+	query := `
+		SELECT id, type, content, context, confidence, project_id, created_at, updated_at
+		FROM memories
+		WHERE (content LIKE ? OR context LIKE ?)
+		AND confidence > 0.1
+	`
+	args := []interface{}{"%" + topic + "%", "%" + topic + "%"}
+
+	if projectID != "" {
+		query += ` AND (project_id = ? OR project_id IS NULL OR project_id = '')`
+		args = append(args, projectID)
+	}
+
+	query += ` ORDER BY confidence DESC, updated_at DESC LIMIT 10`
+
+	rows, err := k.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query memories: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return k.scanMemories(rows)
+}
+
+// QueryByType retrieves memories by type
+func (k *KnowledgeStore) QueryByType(memType MemoryType, projectID string) ([]*Memory, error) {
+	query := `
+		SELECT id, type, content, context, confidence, project_id, created_at, updated_at
+		FROM memories
+		WHERE type = ?
+		AND confidence > 0.1
+	`
+	args := []interface{}{memType}
+
+	if projectID != "" {
+		query += ` AND (project_id = ? OR project_id IS NULL OR project_id = '')`
+		args = append(args, projectID)
+	}
+
+	query += ` ORDER BY confidence DESC, updated_at DESC`
+
+	rows, err := k.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query memories by type: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return k.scanMemories(rows)
+}
+
+// GetAllMemories retrieves all memories for a project (or global if projectID is empty)
+func (k *KnowledgeStore) GetAllMemories(projectID string) ([]*Memory, error) {
+	var rows *sql.Rows
+	var err error
+
+	if projectID != "" {
+		rows, err = k.db.Query(`
+			SELECT id, type, content, context, confidence, project_id, created_at, updated_at
+			FROM memories
+			WHERE (project_id = ? OR project_id IS NULL OR project_id = '')
+			AND confidence > 0.1
+			ORDER BY confidence DESC, updated_at DESC
+		`, projectID)
+	} else {
+		rows, err = k.db.Query(`
+			SELECT id, type, content, context, confidence, project_id, created_at, updated_at
+			FROM memories
+			WHERE confidence > 0.1
+			ORDER BY confidence DESC, updated_at DESC
+		`)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get memories: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return k.scanMemories(rows)
+}
+
+// scanMemories scans rows into Memory slice
+func (k *KnowledgeStore) scanMemories(rows *sql.Rows) ([]*Memory, error) {
+	var memories []*Memory
+	for rows.Next() {
+		m := &Memory{}
+		var projectID sql.NullString
+		var context sql.NullString
+		err := rows.Scan(&m.ID, &m.Type, &m.Content, &context, &m.Confidence, &projectID, &m.CreatedAt, &m.UpdatedAt)
+		if err != nil {
+			continue
+		}
+		if projectID.Valid {
+			m.ProjectID = projectID.String
+		}
+		if context.Valid {
+			m.Context = context.String
+		}
+		memories = append(memories, m)
+	}
+	return memories, rows.Err()
+}
+
+// DecayConfidence reduces confidence by rate per day since last update
+func (k *KnowledgeStore) DecayConfidence(rate float64) error {
+	if rate <= 0 {
+		return fmt.Errorf("decay rate must be positive")
+	}
+
+	_, err := k.db.Exec(`
+		UPDATE memories
+		SET confidence = MAX(0.0, confidence - (? * (julianday('now') - julianday(updated_at)))),
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE confidence > 0.1
+	`, rate)
+	if err != nil {
+		return fmt.Errorf("failed to decay confidence: %w", err)
+	}
+
+	return nil
+}
+
+// ReinforceMemory increases confidence when memory is validated
+func (k *KnowledgeStore) ReinforceMemory(id int64, boost float64) error {
+	if boost <= 0 {
+		boost = 0.1 // default boost
+	}
+
+	_, err := k.db.Exec(`
+		UPDATE memories
+		SET confidence = MIN(1.0, confidence + ?),
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE id = ?
+	`, boost, id)
+	if err != nil {
+		return fmt.Errorf("failed to reinforce memory: %w", err)
+	}
+
+	return nil
+}
+
+// PruneStale removes memories with confidence below threshold
+func (k *KnowledgeStore) PruneStale(threshold float64) (int64, error) {
+	if threshold <= 0 {
+		threshold = 0.1 // default threshold
+	}
+
+	result, err := k.db.Exec(`DELETE FROM memories WHERE confidence < ?`, threshold)
+	if err != nil {
+		return 0, fmt.Errorf("failed to prune stale memories: %w", err)
+	}
+
+	return result.RowsAffected()
+}
+
+// GetStats returns statistics about stored memories
+func (k *KnowledgeStore) GetStats() (*MemoryStats, error) {
+	var stats MemoryStats
+
+	row := k.db.QueryRow(`
+		SELECT
+			COUNT(*) as total,
+			COALESCE(SUM(CASE WHEN type = 'pattern' THEN 1 ELSE 0 END), 0) as patterns,
+			COALESCE(SUM(CASE WHEN type = 'pitfall' THEN 1 ELSE 0 END), 0) as pitfalls,
+			COALESCE(SUM(CASE WHEN type = 'decision' THEN 1 ELSE 0 END), 0) as decisions,
+			COALESCE(SUM(CASE WHEN type = 'learning' THEN 1 ELSE 0 END), 0) as learnings,
+			COALESCE(AVG(confidence), 0) as avg_confidence,
+			COUNT(DISTINCT project_id) as project_count
+		FROM memories
+		WHERE confidence > 0.1
+	`)
+
+	if err := row.Scan(
+		&stats.Total,
+		&stats.Patterns,
+		&stats.Pitfalls,
+		&stats.Decisions,
+		&stats.Learnings,
+		&stats.AvgConfidence,
+		&stats.ProjectCount,
+	); err != nil {
+		return nil, fmt.Errorf("failed to get memory stats: %w", err)
+	}
+
+	return &stats, nil
+}
+
+// MemoryStats holds aggregate statistics about memories
+type MemoryStats struct {
+	Total         int
+	Patterns      int
+	Pitfalls      int
+	Decisions     int
+	Learnings     int
+	AvgConfidence float64
+	ProjectCount  int
+}
+
+// MemoryFile represents a memory as a markdown file for git tracking
+type MemoryFile struct {
+	Type       MemoryType `yaml:"type"`
+	Content    string     `yaml:"content"`
+	Context    string     `yaml:"context,omitempty"`
+	Confidence float64    `yaml:"confidence"`
+	CreatedAt  time.Time  `yaml:"created_at"`
+	UpdatedAt  time.Time  `yaml:"updated_at"`
+}
+
+// SyncToFiles writes memories to .agent/memories/ for git tracking
+func (k *KnowledgeStore) SyncToFiles(agentPath string) error {
+	memoriesDir := filepath.Join(agentPath, "memories")
+	if err := os.MkdirAll(memoriesDir, 0755); err != nil {
+		return fmt.Errorf("failed to create memories directory: %w", err)
+	}
+
+	memories, err := k.GetAllMemories("")
+	if err != nil {
+		return fmt.Errorf("failed to get memories: %w", err)
+	}
+
+	// Group memories by type
+	byType := make(map[MemoryType][]*Memory)
+	for _, m := range memories {
+		byType[m.Type] = append(byType[m.Type], m)
+	}
+
+	// Write each type to its own file
+	for memType, mems := range byType {
+		filename := filepath.Join(memoriesDir, string(memType)+".md")
+		if err := k.writeMemoryFile(filename, memType, mems); err != nil {
+			return fmt.Errorf("failed to write %s memories: %w", memType, err)
+		}
+	}
+
+	return nil
+}
+
+// writeMemoryFile writes memories to a markdown file
+func (k *KnowledgeStore) writeMemoryFile(filename string, memType MemoryType, memories []*Memory) error {
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Write header
+	title := strings.Title(string(memType)) + "s"
+	fmt.Fprintf(f, "# %s\n\n", title)
+	fmt.Fprintf(f, "_Auto-generated from knowledge store. Do not edit directly._\n\n")
+
+	// Write each memory
+	for _, m := range memories {
+		fmt.Fprintf(f, "## %s\n\n", truncate(m.Content, 50))
+		fmt.Fprintf(f, "%s\n\n", m.Content)
+
+		if m.Context != "" {
+			fmt.Fprintf(f, "**Context:** %s\n\n", m.Context)
+		}
+
+		fmt.Fprintf(f, "**Confidence:** %.0f%%\n", m.Confidence*100)
+		fmt.Fprintf(f, "**Updated:** %s\n\n", m.UpdatedAt.Format("2006-01-02"))
+		fmt.Fprintf(f, "---\n\n")
+	}
+
+	return nil
+}
+
+// LoadFromFiles loads memories from .agent/memories/ files
+func (k *KnowledgeStore) LoadFromFiles(agentPath string, projectID string) error {
+	memoriesDir := filepath.Join(agentPath, "memories")
+
+	// Check if directory exists
+	if _, err := os.Stat(memoriesDir); os.IsNotExist(err) {
+		return nil // No memories directory, nothing to load
+	}
+
+	// Load each memory type file
+	for _, memType := range []MemoryType{MemoryTypePattern, MemoryTypePitfall, MemoryTypeDecision, MemoryTypeLearning} {
+		filename := filepath.Join(memoriesDir, string(memType)+".yaml")
+		if err := k.loadMemoryYAML(filename, projectID); err != nil {
+			// Log but don't fail on individual file errors
+			continue
+		}
+	}
+
+	return nil
+}
+
+// loadMemoryYAML loads memories from a YAML file
+func (k *KnowledgeStore) loadMemoryYAML(filename string, projectID string) error {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	var files []MemoryFile
+	if err := yaml.Unmarshal(data, &files); err != nil {
+		return fmt.Errorf("failed to parse %s: %w", filename, err)
+	}
+
+	for _, mf := range files {
+		// Check if memory already exists (by content match)
+		existing, _ := k.QueryByTopic(mf.Content, projectID)
+		if len(existing) > 0 {
+			// Memory already exists, reinforce it
+			_ = k.ReinforceMemory(existing[0].ID, 0.05)
+			continue
+		}
+
+		// Add new memory
+		m := &Memory{
+			Type:       mf.Type,
+			Content:    mf.Content,
+			Context:    mf.Context,
+			Confidence: mf.Confidence,
+			ProjectID:  projectID,
+		}
+		if err := k.AddMemory(m); err != nil {
+			continue
+		}
+	}
+
+	return nil
+}
+
+// truncate truncates a string to maxLen characters
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// FindSimilar finds memories similar to the given content
+func (k *KnowledgeStore) FindSimilar(content string, projectID string, limit int) ([]*Memory, error) {
+	if limit <= 0 {
+		limit = 5
+	}
+
+	// Extract keywords for matching
+	words := strings.Fields(strings.ToLower(content))
+	if len(words) == 0 {
+		return nil, nil
+	}
+
+	// Build LIKE conditions for each word
+	var conditions []string
+	var args []interface{}
+	for _, word := range words {
+		if len(word) > 3 { // Only use words longer than 3 chars
+			conditions = append(conditions, "(content LIKE ? OR context LIKE ?)")
+			args = append(args, "%"+word+"%", "%"+word+"%")
+		}
+	}
+
+	if len(conditions) == 0 {
+		return nil, nil
+	}
+
+	query := fmt.Sprintf(`
+		SELECT id, type, content, context, confidence, project_id, created_at, updated_at
+		FROM memories
+		WHERE (%s)
+		AND confidence > 0.1
+	`, strings.Join(conditions, " OR "))
+
+	if projectID != "" {
+		query += ` AND (project_id = ? OR project_id IS NULL OR project_id = '')`
+		args = append(args, projectID)
+	}
+
+	query += fmt.Sprintf(` ORDER BY confidence DESC LIMIT %d`, limit)
+
+	rows, err := k.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find similar memories: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return k.scanMemories(rows)
+}

--- a/internal/memory/knowledge_test.go
+++ b/internal/memory/knowledge_test.go
@@ -1,0 +1,615 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewKnowledgeStore(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-knowledge-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	if ks == nil {
+		t.Fatal("NewKnowledgeStore returned nil")
+	}
+
+	if err := ks.InitSchema(); err != nil {
+		t.Fatalf("InitSchema failed: %v", err)
+	}
+}
+
+func TestAddMemory(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	tests := []struct {
+		name      string
+		memory    *Memory
+		wantError bool
+	}{
+		{
+			name: "valid pattern",
+			memory: &Memory{
+				Type:       MemoryTypePattern,
+				Content:    "Use JWT for authentication",
+				Context:    "auth module implementation",
+				Confidence: 0.9,
+				ProjectID:  "test-project",
+			},
+			wantError: false,
+		},
+		{
+			name: "valid pitfall",
+			memory: &Memory{
+				Type:       MemoryTypePitfall,
+				Content:    "Auth changes often break tests",
+				Context:    "CI failures in auth module",
+				Confidence: 0.85,
+				ProjectID:  "test-project",
+			},
+			wantError: false,
+		},
+		{
+			name: "missing content",
+			memory: &Memory{
+				Type:      MemoryTypeDecision,
+				ProjectID: "test-project",
+			},
+			wantError: true,
+		},
+		{
+			name: "missing type",
+			memory: &Memory{
+				Content:   "Some content",
+				ProjectID: "test-project",
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ks.AddMemory(tt.memory)
+			if tt.wantError && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !tt.wantError && tt.memory.ID == 0 {
+				t.Error("memory ID not set after insert")
+			}
+		})
+	}
+}
+
+func TestGetMemory(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add a memory
+	m := &Memory{
+		Type:       MemoryTypeLearning,
+		Content:    "This error usually means missing dependencies",
+		Context:    "build failures",
+		Confidence: 0.8,
+		ProjectID:  "test-project",
+	}
+	_ = ks.AddMemory(m)
+
+	// Retrieve it
+	retrieved, err := ks.GetMemory(m.ID)
+	if err != nil {
+		t.Fatalf("GetMemory failed: %v", err)
+	}
+
+	if retrieved.Content != m.Content {
+		t.Errorf("Content = %q, want %q", retrieved.Content, m.Content)
+	}
+	if retrieved.Type != m.Type {
+		t.Errorf("Type = %q, want %q", retrieved.Type, m.Type)
+	}
+	if retrieved.Context != m.Context {
+		t.Errorf("Context = %q, want %q", retrieved.Context, m.Context)
+	}
+	if retrieved.ProjectID != m.ProjectID {
+		t.Errorf("ProjectID = %q, want %q", retrieved.ProjectID, m.ProjectID)
+	}
+}
+
+func TestGetMemory_NotFound(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	_, err := ks.GetMemory(999)
+	if err == nil {
+		t.Error("expected error for nonexistent memory")
+	}
+}
+
+func TestUpdateMemory(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add a memory
+	m := &Memory{
+		Type:       MemoryTypePattern,
+		Content:    "Original content",
+		Confidence: 0.7,
+	}
+	_ = ks.AddMemory(m)
+
+	// Update it
+	m.Content = "Updated content"
+	m.Confidence = 0.9
+
+	if err := ks.UpdateMemory(m); err != nil {
+		t.Fatalf("UpdateMemory failed: %v", err)
+	}
+
+	// Verify update
+	retrieved, _ := ks.GetMemory(m.ID)
+	if retrieved.Content != "Updated content" {
+		t.Errorf("Content = %q, want 'Updated content'", retrieved.Content)
+	}
+	if retrieved.Confidence != 0.9 {
+		t.Errorf("Confidence = %f, want 0.9", retrieved.Confidence)
+	}
+}
+
+func TestDeleteMemory(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add a memory
+	m := &Memory{
+		Type:    MemoryTypePattern,
+		Content: "To be deleted",
+	}
+	_ = ks.AddMemory(m)
+
+	// Delete it
+	if err := ks.DeleteMemory(m.ID); err != nil {
+		t.Fatalf("DeleteMemory failed: %v", err)
+	}
+
+	// Verify deletion
+	_, err := ks.GetMemory(m.ID)
+	if err == nil {
+		t.Error("expected error for deleted memory")
+	}
+}
+
+func TestQueryByTopic(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add memories
+	memories := []*Memory{
+		{Type: MemoryTypePattern, Content: "JWT authentication is preferred", Context: "auth", ProjectID: "proj-1"},
+		{Type: MemoryTypePitfall, Content: "Auth tests are flaky", Context: "auth testing", ProjectID: "proj-1"},
+		{Type: MemoryTypeDecision, Content: "Using PostgreSQL for database", Context: "db setup", ProjectID: "proj-1"},
+	}
+
+	for _, m := range memories {
+		_ = ks.AddMemory(m)
+	}
+
+	// Query by topic
+	results, err := ks.QueryByTopic("auth", "proj-1")
+	if err != nil {
+		t.Fatalf("QueryByTopic failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(results))
+	}
+}
+
+func TestQueryByType(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add memories of different types
+	memories := []*Memory{
+		{Type: MemoryTypePattern, Content: "Pattern 1"},
+		{Type: MemoryTypePattern, Content: "Pattern 2"},
+		{Type: MemoryTypePitfall, Content: "Pitfall 1"},
+		{Type: MemoryTypeLearning, Content: "Learning 1"},
+	}
+
+	for _, m := range memories {
+		_ = ks.AddMemory(m)
+	}
+
+	// Query patterns
+	patterns, err := ks.QueryByType(MemoryTypePattern, "")
+	if err != nil {
+		t.Fatalf("QueryByType failed: %v", err)
+	}
+
+	if len(patterns) != 2 {
+		t.Errorf("expected 2 patterns, got %d", len(patterns))
+	}
+}
+
+func TestDecayConfidence(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add a memory with high confidence
+	m := &Memory{
+		Type:       MemoryTypePattern,
+		Content:    "Test pattern",
+		Confidence: 1.0,
+	}
+	_ = ks.AddMemory(m)
+
+	// Apply decay (simulate 10 days with 0.05 rate = 0.5 total decay)
+	// For testing, we'll use a high rate
+	if err := ks.DecayConfidence(0.01); err != nil {
+		t.Fatalf("DecayConfidence failed: %v", err)
+	}
+
+	// Verify confidence decreased (exact amount depends on time since update)
+	retrieved, _ := ks.GetMemory(m.ID)
+	// Confidence should be less than or equal to original
+	if retrieved.Confidence > 1.0 {
+		t.Errorf("Confidence = %f, should be <= 1.0", retrieved.Confidence)
+	}
+}
+
+func TestReinforceMemory(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add a memory with low confidence
+	m := &Memory{
+		Type:       MemoryTypePattern,
+		Content:    "Test pattern",
+		Confidence: 0.5,
+	}
+	_ = ks.AddMemory(m)
+
+	// Reinforce it
+	if err := ks.ReinforceMemory(m.ID, 0.2); err != nil {
+		t.Fatalf("ReinforceMemory failed: %v", err)
+	}
+
+	// Verify confidence increased
+	retrieved, _ := ks.GetMemory(m.ID)
+	if retrieved.Confidence != 0.7 {
+		t.Errorf("Confidence = %f, want 0.7", retrieved.Confidence)
+	}
+}
+
+func TestReinforceMemory_MaxConfidence(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add a memory with high confidence
+	m := &Memory{
+		Type:       MemoryTypePattern,
+		Content:    "Test pattern",
+		Confidence: 0.95,
+	}
+	_ = ks.AddMemory(m)
+
+	// Reinforce it with large boost
+	_ = ks.ReinforceMemory(m.ID, 0.5)
+
+	// Verify confidence capped at 1.0
+	retrieved, _ := ks.GetMemory(m.ID)
+	if retrieved.Confidence > 1.0 {
+		t.Errorf("Confidence = %f, should be capped at 1.0", retrieved.Confidence)
+	}
+}
+
+func TestPruneStale(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add memories with varying confidence
+	memories := []*Memory{
+		{Type: MemoryTypePattern, Content: "High confidence", Confidence: 0.9},
+		{Type: MemoryTypePattern, Content: "Medium confidence", Confidence: 0.5},
+		{Type: MemoryTypePattern, Content: "Low confidence", Confidence: 0.05},
+	}
+
+	for _, m := range memories {
+		_ = ks.AddMemory(m)
+	}
+
+	// Prune with threshold 0.1
+	pruned, err := ks.PruneStale(0.1)
+	if err != nil {
+		t.Fatalf("PruneStale failed: %v", err)
+	}
+
+	if pruned != 1 {
+		t.Errorf("expected 1 pruned, got %d", pruned)
+	}
+
+	// Verify remaining memories
+	all, _ := ks.GetAllMemories("")
+	if len(all) != 2 {
+		t.Errorf("expected 2 remaining memories, got %d", len(all))
+	}
+}
+
+func TestGetStats(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add memories of different types
+	memories := []*Memory{
+		{Type: MemoryTypePattern, Content: "Pattern 1", Confidence: 0.8, ProjectID: "proj-1"},
+		{Type: MemoryTypePattern, Content: "Pattern 2", Confidence: 0.9, ProjectID: "proj-1"},
+		{Type: MemoryTypePitfall, Content: "Pitfall 1", Confidence: 0.7, ProjectID: "proj-2"},
+		{Type: MemoryTypeDecision, Content: "Decision 1", Confidence: 0.85, ProjectID: "proj-1"},
+		{Type: MemoryTypeLearning, Content: "Learning 1", Confidence: 0.75, ProjectID: "proj-3"},
+	}
+
+	for _, m := range memories {
+		_ = ks.AddMemory(m)
+	}
+
+	stats, err := ks.GetStats()
+	if err != nil {
+		t.Fatalf("GetStats failed: %v", err)
+	}
+
+	if stats.Total != 5 {
+		t.Errorf("Total = %d, want 5", stats.Total)
+	}
+	if stats.Patterns != 2 {
+		t.Errorf("Patterns = %d, want 2", stats.Patterns)
+	}
+	if stats.Pitfalls != 1 {
+		t.Errorf("Pitfalls = %d, want 1", stats.Pitfalls)
+	}
+	if stats.Decisions != 1 {
+		t.Errorf("Decisions = %d, want 1", stats.Decisions)
+	}
+	if stats.Learnings != 1 {
+		t.Errorf("Learnings = %d, want 1", stats.Learnings)
+	}
+	if stats.ProjectCount != 3 {
+		t.Errorf("ProjectCount = %d, want 3", stats.ProjectCount)
+	}
+}
+
+func TestSyncToFiles(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add memories
+	memories := []*Memory{
+		{Type: MemoryTypePattern, Content: "Pattern content", Context: "testing"},
+		{Type: MemoryTypePitfall, Content: "Pitfall content", Context: "debugging"},
+	}
+
+	for _, m := range memories {
+		_ = ks.AddMemory(m)
+	}
+
+	// Sync to files
+	agentPath := filepath.Join(tmpDir, ".agent")
+	if err := ks.SyncToFiles(agentPath); err != nil {
+		t.Fatalf("SyncToFiles failed: %v", err)
+	}
+
+	// Verify files created
+	memoriesDir := filepath.Join(agentPath, "memories")
+	if _, err := os.Stat(memoriesDir); os.IsNotExist(err) {
+		t.Error("memories directory not created")
+	}
+
+	patternFile := filepath.Join(memoriesDir, "pattern.md")
+	if _, err := os.Stat(patternFile); os.IsNotExist(err) {
+		t.Error("pattern.md not created")
+	}
+
+	pitfallFile := filepath.Join(memoriesDir, "pitfall.md")
+	if _, err := os.Stat(pitfallFile); os.IsNotExist(err) {
+		t.Error("pitfall.md not created")
+	}
+}
+
+func TestFindSimilar(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add memories
+	memories := []*Memory{
+		{Type: MemoryTypePattern, Content: "JWT authentication is the standard approach", Confidence: 0.9},
+		{Type: MemoryTypePitfall, Content: "Authentication tokens expire silently", Confidence: 0.8},
+		{Type: MemoryTypeDecision, Content: "Using PostgreSQL for the database layer", Confidence: 0.85},
+	}
+
+	for _, m := range memories {
+		_ = ks.AddMemory(m)
+	}
+
+	// Find similar to "authentication"
+	results, err := ks.FindSimilar("authentication issues", "", 5)
+	if err != nil {
+		t.Fatalf("FindSimilar failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("expected 2 similar memories, got %d", len(results))
+	}
+}
+
+func TestGetAllMemories(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-knowledge-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	ks := NewKnowledgeStore(store.DB())
+	_ = ks.InitSchema()
+
+	// Add memories for different projects
+	memories := []*Memory{
+		{Type: MemoryTypePattern, Content: "Pattern 1", ProjectID: "proj-1"},
+		{Type: MemoryTypePattern, Content: "Pattern 2", ProjectID: "proj-1"},
+		{Type: MemoryTypePattern, Content: "Pattern 3", ProjectID: "proj-2"},
+		{Type: MemoryTypePattern, Content: "Global pattern", ProjectID: ""},
+	}
+
+	for _, m := range memories {
+		_ = ks.AddMemory(m)
+	}
+
+	// Get all memories
+	all, err := ks.GetAllMemories("")
+	if err != nil {
+		t.Fatalf("GetAllMemories failed: %v", err)
+	}
+	if len(all) != 4 {
+		t.Errorf("expected 4 memories, got %d", len(all))
+	}
+
+	// Get memories for proj-1 (includes global)
+	proj1, err := ks.GetAllMemories("proj-1")
+	if err != nil {
+		t.Fatalf("GetAllMemories (proj-1) failed: %v", err)
+	}
+	if len(proj1) != 3 {
+		t.Errorf("expected 3 memories for proj-1, got %d", len(proj1))
+	}
+}
+
+func TestMemoryTypes(t *testing.T) {
+	// Verify memory type constants
+	if MemoryTypePattern != "pattern" {
+		t.Errorf("MemoryTypePattern = %q, want 'pattern'", MemoryTypePattern)
+	}
+	if MemoryTypePitfall != "pitfall" {
+		t.Errorf("MemoryTypePitfall = %q, want 'pitfall'", MemoryTypePitfall)
+	}
+	if MemoryTypeDecision != "decision" {
+		t.Errorf("MemoryTypeDecision = %q, want 'decision'", MemoryTypeDecision)
+	}
+	if MemoryTypeLearning != "learning" {
+		t.Errorf("MemoryTypeLearning = %q, want 'learning'", MemoryTypeLearning)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"short", 10, "short"},
+		{"exactly ten", 11, "exactly ten"},
+		{"this is a longer string", 10, "this is..."},
+		{"", 5, ""},
+	}
+
+	for _, tt := range tests {
+		got := truncate(tt.input, tt.maxLen)
+		if got != tt.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-991.

Closes #991

## Changes

GitHub Issue #991: Phase 4: Create knowledge.go for experiential memory

## Context

Part of Navigator port. Blocked by #990.

Persistent experiential memory that captures patterns, pitfalls, decisions, and learnings.

## Task

Create `internal/memory/knowledge.go` for knowledge graph operations.

## Implementation

```go
package memory

import (
    "database/sql"
    "time"
)

// MemoryType categorizes experiential memories
type MemoryType string

const (
    MemoryTypePattern  MemoryType = "pattern"   // "We use JWT for auth"
    MemoryTypePitfall  MemoryType = "pitfall"   // "Auth changes break tests"
    MemoryTypeDecision MemoryType = "decision"  // "JWT over sessions for scaling"
    MemoryTypeLearning MemoryType = "learning"  // "This error usually means X"
)

// Memory represents an experiential memory entry
type Memory struct {
    ID         int64
    Type       MemoryType
    Content    string
    Context    string     // Task/file where this was learned
    Confidence float64    // 0.0-1.0, decays over time
    ProjectID  string
    CreatedAt  time.Time
    UpdatedAt  time.Time
}

// KnowledgeStore manages experiential memories
type KnowledgeStore struct {
    db *sql.DB
}

// NewKnowledgeStore creates a knowledge store
func NewKnowledgeStore(db *sql.DB) *KnowledgeStore {
    return &KnowledgeStore{db: db}
}

// InitSchema creates the memories table
func (k *KnowledgeStore) InitSchema() error {
    _, err := k.db.Exec(`
        CREATE TABLE IF NOT EXISTS memories (
            id INTEGER PRIMARY KEY AUTOINCREMENT,
            type TEXT NOT NULL,
            content TEXT NOT NULL,
            context TEXT,
            confidence REAL DEFAULT 1.0,
            project_id TEXT,
            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
        );
        CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(type);
        CREATE INDEX IF NOT EXISTS idx_memories_project ON memories(project_id);
    `)
    return err
}

// AddMemory stores a new memory
func (k *KnowledgeStore) AddMemory(m *Memory) error {
    result, err := k.db.Exec(`
        INSERT INTO memories (type, content, context, confidence, project_id)
        VALUES (?, ?, ?, ?, ?)
    `, m.Type, m.Content, m.Context, m.Confidence, m.ProjectID)
    if err != nil {
        return err
    }
    m.ID, _ = result.LastInsertId()
    return nil
}

// QueryByTopic searches memories by content/context
func (k *KnowledgeStore) QueryByTopic(topic string, projectID string) ([]*Memory, error) {
    rows, err := k.db.Query(`
        SELECT id, type, content, context, confidence, project_id, created_at, updated_at
        FROM memories
        WHERE (content LIKE ? OR context LIKE ?)
        AND (project_id = ? OR project_id IS NULL)
        AND confidence > 0.1
        ORDER BY confidence DESC, updated_at DESC
        LIMIT 10
    `, "%"+topic+"%", "%"+topic+"%", projectID)
    if err != nil {
        return nil, err
    }
    defer rows.Close()
    
    var memories []*Memory
    for rows.Next() {
        m := &Memory{}
        err := rows.Scan(&m.ID, &m.Type, &m.Content, &m.Context, 
                         &m.Confidence, &m.ProjectID, &m.CreatedAt, &m.UpdatedAt)
        if err != nil {
            continue
        }
        memories = append(memories, m)
    }
    return memories, nil
}

// DecayConfidence reduces confidence by rate per day since last update
func (k *KnowledgeStore) DecayConfidence(rate float64) error {
    _, err := k.db.Exec(`
        UPDATE memories
        SET confidence = confidence - (? * (julianday('now') - julianday(updated_at)))
        WHERE confidence > 0.1
    `, rate)
    return err
}

// PruneStale removes memories with confidence below threshold
func (k *KnowledgeStore) PruneStale(threshold float64) error {
    _, err := k.db.Exec(`DELETE FROM memories WHERE confidence < ?`, threshold)
    return err
}

// SyncToFiles writes memories to .agent/memories/ for git tracking
func (k *KnowledgeStore) SyncToFiles(agentPath string) error {
    // Implementation: Write memories as markdown files
    return nil
}
```

## Acceptance Criteria

- [ ] File `internal/memory/knowledge.go` exists
- [ ] `KnowledgeStore` struct with SQLite backend
- [ ] `InitSchema()` creates memories table
- [ ] `AddMemory()` stores new memory
- [ ] `QueryByTopic()` searches by content/context
- [ ] `DecayConfidence()` applies time-based decay
- [ ] `PruneStale()` removes low-confidence memories
- [ ] Memory types: pattern, pitfall, decision, learning
- [ ] Build passes: `go build ./...`
- [ ] Tests pass: `go test ./internal/memory/...`