### PR TITLE
Phase 5: Create profile.go for user preferences

### DIFF
--- a/internal/memory/profile.go
+++ b/internal/memory/profile.go
@@ -1,0 +1,251 @@
+package memory
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// UserProfile stores learned user preferences across sessions.
+// It captures communication style, code preferences, and corrections
+// to improve AI responses over time.
+type UserProfile struct {
+	mu sync.RWMutex
+
+	// Communication style
+	Verbosity string `json:"verbosity,omitempty"` // "concise" or "detailed"
+
+	// Code preferences
+	Frameworks   []string          `json:"frameworks,omitempty"`   // e.g., ["gin", "gorm"]
+	Conventions  map[string]string `json:"conventions,omitempty"`  // e.g., {"indent": "tabs"}
+	CodePatterns []string          `json:"code_patterns,omitempty"` // e.g., ["early_returns"]
+
+	// Corrections learned from user feedback
+	Corrections []Correction `json:"corrections,omitempty"`
+}
+
+// Correction represents a learned correction from user feedback.
+// When a user corrects the AI, the pattern and correction are stored
+// to avoid repeating the same mistake.
+type Correction struct {
+	Pattern    string `json:"pattern"`    // What triggered the correction
+	Correction string `json:"correction"` // What user said/preferred
+	Count      int    `json:"count"`      // Times this correction came up
+}
+
+// ProfileManager handles loading and saving user profiles.
+// It supports both global profiles (~/.pilot/profile.json) and
+// project-specific profiles (.agent/.user-profile.json).
+type ProfileManager struct {
+	globalPath  string // e.g., ~/.pilot/profile.json
+	projectPath string // e.g., .agent/.user-profile.json
+}
+
+// NewProfileManager creates a profile manager with the given paths.
+// globalPath is typically ~/.pilot/profile.json
+// projectPath is typically .agent/.user-profile.json in the project root
+func NewProfileManager(globalPath, projectPath string) *ProfileManager {
+	return &ProfileManager{
+		globalPath:  globalPath,
+		projectPath: projectPath,
+	}
+}
+
+// Load loads the user profile, merging global defaults with project overrides.
+// Global profile is loaded first, then project-specific settings are applied on top.
+func (pm *ProfileManager) Load() (*UserProfile, error) {
+	profile := &UserProfile{
+		Conventions: make(map[string]string),
+	}
+
+	// Load global defaults
+	if data, err := os.ReadFile(pm.globalPath); err == nil {
+		_ = json.Unmarshal(data, profile)
+	}
+
+	// Apply project overrides
+	if data, err := os.ReadFile(pm.projectPath); err == nil {
+		var projectProfile UserProfile
+		if json.Unmarshal(data, &projectProfile) == nil {
+			pm.mergeProfiles(profile, &projectProfile)
+		}
+	}
+
+	// Ensure conventions map is initialized
+	if profile.Conventions == nil {
+		profile.Conventions = make(map[string]string)
+	}
+
+	return profile, nil
+}
+
+// Save saves the profile to the appropriate path.
+// If global is true, saves to globalPath; otherwise saves to projectPath.
+func (pm *ProfileManager) Save(profile *UserProfile, global bool) error {
+	profile.mu.RLock()
+	defer profile.mu.RUnlock()
+
+	data, err := json.MarshalIndent(profile, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	path := pm.projectPath
+	if global {
+		path = pm.globalPath
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0644)
+}
+
+// RecordCorrection learns from a user correction.
+// If the same pattern was corrected before, increments the count;
+// otherwise adds a new correction entry.
+func (profile *UserProfile) RecordCorrection(pattern, correction string) {
+	profile.mu.Lock()
+	defer profile.mu.Unlock()
+
+	// Check if we've seen this pattern before
+	for i := range profile.Corrections {
+		if profile.Corrections[i].Pattern == pattern {
+			profile.Corrections[i].Count++
+			profile.Corrections[i].Correction = correction
+			return
+		}
+	}
+
+	// New correction
+	profile.Corrections = append(profile.Corrections, Correction{
+		Pattern:    pattern,
+		Correction: correction,
+		Count:      1,
+	})
+}
+
+// SetPreference sets a convention preference.
+func (profile *UserProfile) SetPreference(key, value string) {
+	profile.mu.Lock()
+	defer profile.mu.Unlock()
+
+	if profile.Conventions == nil {
+		profile.Conventions = make(map[string]string)
+	}
+	profile.Conventions[key] = value
+}
+
+// GetPreference gets a convention preference.
+// Returns empty string if the key is not set.
+func (profile *UserProfile) GetPreference(key string) string {
+	profile.mu.RLock()
+	defer profile.mu.RUnlock()
+
+	if profile.Conventions == nil {
+		return ""
+	}
+	return profile.Conventions[key]
+}
+
+// AddFramework adds a framework to the user's preferences if not already present.
+func (profile *UserProfile) AddFramework(framework string) {
+	profile.mu.Lock()
+	defer profile.mu.Unlock()
+
+	for _, f := range profile.Frameworks {
+		if f == framework {
+			return // Already present
+		}
+	}
+	profile.Frameworks = append(profile.Frameworks, framework)
+}
+
+// AddCodePattern adds a code pattern preference if not already present.
+func (profile *UserProfile) AddCodePattern(pattern string) {
+	profile.mu.Lock()
+	defer profile.mu.Unlock()
+
+	for _, p := range profile.CodePatterns {
+		if p == pattern {
+			return // Already present
+		}
+	}
+	profile.CodePatterns = append(profile.CodePatterns, pattern)
+}
+
+// GetCorrection returns the learned correction for a pattern, if any.
+// Returns the correction string and true if found, empty string and false otherwise.
+func (profile *UserProfile) GetCorrection(pattern string) (string, bool) {
+	profile.mu.RLock()
+	defer profile.mu.RUnlock()
+
+	for _, c := range profile.Corrections {
+		if c.Pattern == pattern {
+			return c.Correction, true
+		}
+	}
+	return "", false
+}
+
+// mergeProfiles applies project overrides to the base profile.
+// Non-empty fields from override replace or extend the base.
+func (pm *ProfileManager) mergeProfiles(base, override *UserProfile) {
+	if override.Verbosity != "" {
+		base.Verbosity = override.Verbosity
+	}
+
+	// Append frameworks (deduplicate)
+	for _, f := range override.Frameworks {
+		found := false
+		for _, bf := range base.Frameworks {
+			if bf == f {
+				found = true
+				break
+			}
+		}
+		if !found {
+			base.Frameworks = append(base.Frameworks, f)
+		}
+	}
+
+	// Override conventions
+	if base.Conventions == nil {
+		base.Conventions = make(map[string]string)
+	}
+	for k, v := range override.Conventions {
+		base.Conventions[k] = v
+	}
+
+	// Append code patterns (deduplicate)
+	for _, p := range override.CodePatterns {
+		found := false
+		for _, bp := range base.CodePatterns {
+			if bp == p {
+				found = true
+				break
+			}
+		}
+		if !found {
+			base.CodePatterns = append(base.CodePatterns, p)
+		}
+	}
+
+	// Merge corrections (project corrections take precedence)
+	for _, oc := range override.Corrections {
+		found := false
+		for i, bc := range base.Corrections {
+			if bc.Pattern == oc.Pattern {
+				base.Corrections[i] = oc
+				found = true
+				break
+			}
+		}
+		if !found {
+			base.Corrections = append(base.Corrections, oc)
+		}
+	}
+}

--- a/internal/memory/profile_test.go
+++ b/internal/memory/profile_test.go
@@ -1,0 +1,428 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewProfileManager(t *testing.T) {
+	pm := NewProfileManager("/global/path", "/project/path")
+
+	if pm.globalPath != "/global/path" {
+		t.Errorf("globalPath = %q, want %q", pm.globalPath, "/global/path")
+	}
+
+	if pm.projectPath != "/project/path" {
+		t.Errorf("projectPath = %q, want %q", pm.projectPath, "/project/path")
+	}
+}
+
+func TestProfileManager_LoadEmpty(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "profile-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	pm := NewProfileManager(
+		filepath.Join(tmpDir, "global.json"),
+		filepath.Join(tmpDir, "project.json"),
+	)
+
+	profile, err := pm.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if profile == nil {
+		t.Fatal("Load() returned nil profile")
+	}
+
+	if profile.Conventions == nil {
+		t.Error("Load() returned profile with nil Conventions map")
+	}
+
+	if profile.Verbosity != "" {
+		t.Errorf("Verbosity = %q, want empty", profile.Verbosity)
+	}
+}
+
+func TestProfileManager_SaveAndLoad(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "profile-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	pm := NewProfileManager(
+		filepath.Join(tmpDir, "global.json"),
+		filepath.Join(tmpDir, "project.json"),
+	)
+
+	profile := &UserProfile{
+		Verbosity:    "concise",
+		Frameworks:   []string{"gin", "gorm"},
+		Conventions:  map[string]string{"indent": "tabs", "naming": "camelCase"},
+		CodePatterns: []string{"early_returns", "guard_clauses"},
+		Corrections: []Correction{
+			{Pattern: "use fmt.Printf", Correction: "use slog instead", Count: 3},
+		},
+	}
+
+	// Save to global
+	if err := pm.Save(profile, true); err != nil {
+		t.Fatalf("Save(global) error = %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(filepath.Join(tmpDir, "global.json")); os.IsNotExist(err) {
+		t.Error("global.json was not created")
+	}
+
+	// Load and verify
+	loaded, err := pm.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if loaded.Verbosity != "concise" {
+		t.Errorf("Verbosity = %q, want %q", loaded.Verbosity, "concise")
+	}
+
+	if len(loaded.Frameworks) != 2 {
+		t.Errorf("len(Frameworks) = %d, want 2", len(loaded.Frameworks))
+	}
+
+	if loaded.Conventions["indent"] != "tabs" {
+		t.Errorf("Conventions[indent] = %q, want %q", loaded.Conventions["indent"], "tabs")
+	}
+
+	if len(loaded.Corrections) != 1 {
+		t.Errorf("len(Corrections) = %d, want 1", len(loaded.Corrections))
+	}
+
+	if loaded.Corrections[0].Count != 3 {
+		t.Errorf("Corrections[0].Count = %d, want 3", loaded.Corrections[0].Count)
+	}
+}
+
+func TestProfileManager_MergeProfiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "profile-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	globalPath := filepath.Join(tmpDir, "global.json")
+	projectPath := filepath.Join(tmpDir, "project.json")
+	pm := NewProfileManager(globalPath, projectPath)
+
+	// Create global profile
+	globalProfile := &UserProfile{
+		Verbosity:    "detailed",
+		Frameworks:   []string{"gin"},
+		Conventions:  map[string]string{"indent": "spaces"},
+		CodePatterns: []string{"early_returns"},
+	}
+	if err := pm.Save(globalProfile, true); err != nil {
+		t.Fatalf("Save(global) error = %v", err)
+	}
+
+	// Create project profile (overrides)
+	projectProfile := &UserProfile{
+		Verbosity:    "concise",
+		Frameworks:   []string{"echo"}, // Different framework
+		Conventions:  map[string]string{"indent": "tabs", "test": "value"},
+		CodePatterns: []string{"guard_clauses"},
+	}
+	if err := pm.Save(projectProfile, false); err != nil {
+		t.Fatalf("Save(project) error = %v", err)
+	}
+
+	// Load merged profile
+	merged, err := pm.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	// Verbosity should be overridden by project
+	if merged.Verbosity != "concise" {
+		t.Errorf("Verbosity = %q, want %q (project override)", merged.Verbosity, "concise")
+	}
+
+	// Frameworks should be merged (deduplicated)
+	if len(merged.Frameworks) != 2 {
+		t.Errorf("len(Frameworks) = %d, want 2 (merged)", len(merged.Frameworks))
+	}
+
+	// Conventions should be merged with project taking precedence
+	if merged.Conventions["indent"] != "tabs" {
+		t.Errorf("Conventions[indent] = %q, want %q (project override)", merged.Conventions["indent"], "tabs")
+	}
+	if merged.Conventions["test"] != "value" {
+		t.Errorf("Conventions[test] = %q, want %q", merged.Conventions["test"], "value")
+	}
+
+	// CodePatterns should be merged
+	if len(merged.CodePatterns) != 2 {
+		t.Errorf("len(CodePatterns) = %d, want 2 (merged)", len(merged.CodePatterns))
+	}
+}
+
+func TestUserProfile_RecordCorrection(t *testing.T) {
+	profile := &UserProfile{
+		Conventions: make(map[string]string),
+	}
+
+	// First correction
+	profile.RecordCorrection("use println", "use slog.Info")
+
+	if len(profile.Corrections) != 1 {
+		t.Fatalf("len(Corrections) = %d, want 1", len(profile.Corrections))
+	}
+
+	if profile.Corrections[0].Count != 1 {
+		t.Errorf("Count = %d, want 1", profile.Corrections[0].Count)
+	}
+
+	// Same pattern again - should increment count
+	profile.RecordCorrection("use println", "use structured logging")
+
+	if len(profile.Corrections) != 1 {
+		t.Errorf("len(Corrections) = %d, want 1 (same pattern)", len(profile.Corrections))
+	}
+
+	if profile.Corrections[0].Count != 2 {
+		t.Errorf("Count = %d, want 2", profile.Corrections[0].Count)
+	}
+
+	if profile.Corrections[0].Correction != "use structured logging" {
+		t.Errorf("Correction = %q, want updated value", profile.Corrections[0].Correction)
+	}
+
+	// Different pattern - should add new correction
+	profile.RecordCorrection("use fmt.Errorf", "use errors.New")
+
+	if len(profile.Corrections) != 2 {
+		t.Errorf("len(Corrections) = %d, want 2", len(profile.Corrections))
+	}
+}
+
+func TestUserProfile_SetGetPreference(t *testing.T) {
+	profile := &UserProfile{
+		Conventions: make(map[string]string),
+	}
+
+	// Get non-existent preference
+	if got := profile.GetPreference("nonexistent"); got != "" {
+		t.Errorf("GetPreference(nonexistent) = %q, want empty", got)
+	}
+
+	// Set and get preference
+	profile.SetPreference("indent", "tabs")
+
+	if got := profile.GetPreference("indent"); got != "tabs" {
+		t.Errorf("GetPreference(indent) = %q, want %q", got, "tabs")
+	}
+
+	// Override preference
+	profile.SetPreference("indent", "spaces")
+
+	if got := profile.GetPreference("indent"); got != "spaces" {
+		t.Errorf("GetPreference(indent) after override = %q, want %q", got, "spaces")
+	}
+}
+
+func TestUserProfile_SetPreferenceNilMap(t *testing.T) {
+	profile := &UserProfile{}
+
+	// Should handle nil Conventions map
+	profile.SetPreference("key", "value")
+
+	if profile.Conventions == nil {
+		t.Error("SetPreference should initialize Conventions map")
+	}
+
+	if got := profile.GetPreference("key"); got != "value" {
+		t.Errorf("GetPreference(key) = %q, want %q", got, "value")
+	}
+}
+
+func TestUserProfile_GetPreferenceNilMap(t *testing.T) {
+	profile := &UserProfile{}
+
+	// Should handle nil Conventions map gracefully
+	if got := profile.GetPreference("key"); got != "" {
+		t.Errorf("GetPreference with nil map = %q, want empty", got)
+	}
+}
+
+func TestUserProfile_AddFramework(t *testing.T) {
+	profile := &UserProfile{}
+
+	profile.AddFramework("gin")
+	if len(profile.Frameworks) != 1 {
+		t.Errorf("len(Frameworks) = %d, want 1", len(profile.Frameworks))
+	}
+
+	// Add same framework again - should not duplicate
+	profile.AddFramework("gin")
+	if len(profile.Frameworks) != 1 {
+		t.Errorf("len(Frameworks) = %d, want 1 (no duplicate)", len(profile.Frameworks))
+	}
+
+	// Add different framework
+	profile.AddFramework("gorm")
+	if len(profile.Frameworks) != 2 {
+		t.Errorf("len(Frameworks) = %d, want 2", len(profile.Frameworks))
+	}
+}
+
+func TestUserProfile_AddCodePattern(t *testing.T) {
+	profile := &UserProfile{}
+
+	profile.AddCodePattern("early_returns")
+	if len(profile.CodePatterns) != 1 {
+		t.Errorf("len(CodePatterns) = %d, want 1", len(profile.CodePatterns))
+	}
+
+	// Add same pattern again - should not duplicate
+	profile.AddCodePattern("early_returns")
+	if len(profile.CodePatterns) != 1 {
+		t.Errorf("len(CodePatterns) = %d, want 1 (no duplicate)", len(profile.CodePatterns))
+	}
+
+	// Add different pattern
+	profile.AddCodePattern("guard_clauses")
+	if len(profile.CodePatterns) != 2 {
+		t.Errorf("len(CodePatterns) = %d, want 2", len(profile.CodePatterns))
+	}
+}
+
+func TestUserProfile_GetCorrection(t *testing.T) {
+	profile := &UserProfile{
+		Corrections: []Correction{
+			{Pattern: "use println", Correction: "use slog", Count: 3},
+		},
+	}
+
+	// Get existing correction
+	correction, found := profile.GetCorrection("use println")
+	if !found {
+		t.Error("GetCorrection should find existing pattern")
+	}
+	if correction != "use slog" {
+		t.Errorf("correction = %q, want %q", correction, "use slog")
+	}
+
+	// Get non-existent correction
+	_, found = profile.GetCorrection("nonexistent")
+	if found {
+		t.Error("GetCorrection should return false for non-existent pattern")
+	}
+}
+
+func TestUserProfile_ThreadSafety(t *testing.T) {
+	profile := &UserProfile{
+		Conventions: make(map[string]string),
+	}
+
+	done := make(chan bool)
+
+	// Concurrent writes
+	go func() {
+		for i := 0; i < 100; i++ {
+			profile.SetPreference("key", "value1")
+		}
+		done <- true
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			profile.SetPreference("key", "value2")
+		}
+		done <- true
+	}()
+
+	// Concurrent reads
+	go func() {
+		for i := 0; i < 100; i++ {
+			_ = profile.GetPreference("key")
+		}
+		done <- true
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			profile.RecordCorrection("pattern", "correction")
+		}
+		done <- true
+	}()
+
+	// Wait for all goroutines
+	for i := 0; i < 4; i++ {
+		<-done
+	}
+
+	// If we get here without a race detector error, the test passes
+}
+
+func TestProfileManager_MergeCorrectionsPrecedence(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "profile-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	globalPath := filepath.Join(tmpDir, "global.json")
+	projectPath := filepath.Join(tmpDir, "project.json")
+	pm := NewProfileManager(globalPath, projectPath)
+
+	// Create global profile with correction
+	globalProfile := &UserProfile{
+		Conventions: make(map[string]string),
+		Corrections: []Correction{
+			{Pattern: "shared", Correction: "global correction", Count: 5},
+			{Pattern: "global only", Correction: "only in global", Count: 1},
+		},
+	}
+	if err := pm.Save(globalProfile, true); err != nil {
+		t.Fatalf("Save(global) error = %v", err)
+	}
+
+	// Create project profile with override
+	projectProfile := &UserProfile{
+		Conventions: make(map[string]string),
+		Corrections: []Correction{
+			{Pattern: "shared", Correction: "project correction", Count: 10},
+			{Pattern: "project only", Correction: "only in project", Count: 2},
+		},
+	}
+	if err := pm.Save(projectProfile, false); err != nil {
+		t.Fatalf("Save(project) error = %v", err)
+	}
+
+	// Load merged
+	merged, err := pm.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	// Should have 3 corrections
+	if len(merged.Corrections) != 3 {
+		t.Errorf("len(Corrections) = %d, want 3", len(merged.Corrections))
+	}
+
+	// Verify project takes precedence for shared pattern
+	for _, c := range merged.Corrections {
+		if c.Pattern == "shared" {
+			if c.Correction != "project correction" {
+				t.Errorf("shared correction = %q, want project override", c.Correction)
+			}
+			if c.Count != 10 {
+				t.Errorf("shared count = %d, want 10", c.Count)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-993.

Closes #993

## Changes

GitHub Issue #993: Phase 5: Create profile.go for user preferences

## Context

Part of Navigator port. Blocked by #991.

Theory of Mind: Learn user preferences across sessions.

## Task

Create `internal/memory/profile.go` for user profile storage.

## Implementation

```go
package memory

import (
    "encoding/json"
    "os"
    "path/filepath"
    "sync"
)

// UserProfile stores learned user preferences
type UserProfile struct {
    mu sync.RWMutex
    
    // Communication style
    Verbosity string `json:"verbosity"` // "concise" or "detailed"
    
    // Code preferences
    Frameworks    []string          `json:"frameworks"`    // ["gin", "gorm"]
    Conventions   map[string]string `json:"conventions"`   // {"indent": "tabs"}
    CodePatterns  []string          `json:"code_patterns"` // ["early_returns"]
    
    // Corrections learned
    Corrections []Correction `json:"corrections"`
}

// Correction represents a learned correction
type Correction struct {
    Pattern     string `json:"pattern"`     // What triggered correction
    Correction  string `json:"correction"`  // What user said
    Count       int    `json:"count"`       // Times this came up
}

// ProfileManager handles profile loading/saving
type ProfileManager struct {
    globalPath  string // ~/.pilot/profile.json
    projectPath string // .agent/.user-profile.json
}

// NewProfileManager creates a profile manager
func NewProfileManager(globalPath, projectPath string) *ProfileManager {
    return &ProfileManager{
        globalPath:  globalPath,
        projectPath: projectPath,
    }
}

// Load loads profile with project overrides
func (pm *ProfileManager) Load() (*UserProfile, error) {
    profile := &UserProfile{
        Conventions: make(map[string]string),
    }
    
    // Load global defaults
    if data, err := os.ReadFile(pm.globalPath); err == nil {
        json.Unmarshal(data, profile)
    }
    
    // Apply project overrides
    if data, err := os.ReadFile(pm.projectPath); err == nil {
        var projectProfile UserProfile
        if json.Unmarshal(data, &projectProfile) == nil {
            pm.mergeProfiles(profile, &projectProfile)
        }
    }
    
    return profile, nil
}

// Save saves profile to both global and project paths
func (pm *ProfileManager) Save(profile *UserProfile, global bool) error {
    profile.mu.RLock()
    defer profile.mu.RUnlock()
    
    data, err := json.MarshalIndent(profile, "", "  ")
    if err != nil {
        return err
    }
    
    path := pm.projectPath
    if global {
        path = pm.globalPath
    }
    
    dir := filepath.Dir(path)
    if err := os.MkdirAll(dir, 0755); err != nil {
        return err
    }
    
    return os.WriteFile(path, data, 0644)
}

// RecordCorrection learns from a user correction
func (profile *UserProfile) RecordCorrection(pattern, correction string) {
    profile.mu.Lock()
    defer profile.mu.Unlock()
    
    // Check if we've seen this before
    for i := range profile.Corrections {
        if profile.Corrections[i].Pattern == pattern {
            profile.Corrections[i].Count++
            profile.Corrections[i].Correction = correction
            return
        }
    }
    
    // New correction
    profile.Corrections = append(profile.Corrections, Correction{
        Pattern:    pattern,
        Correction: correction,
        Count:      1,
    })
}

// SetPreference sets a convention preference
func (profile *UserProfile) SetPreference(key, value string) {
    profile.mu.Lock()
    defer profile.mu.Unlock()
    profile.Conventions[key] = value
}

// GetPreference gets a convention preference
func (profile *UserProfile) GetPreference(key string) string {
    profile.mu.RLock()
    defer profile.mu.RUnlock()
    return profile.Conventions[key]
}

// mergeProfiles applies project overrides to base profile
func (pm *ProfileManager) mergeProfiles(base, override *UserProfile) {
    if override.Verbosity != "" {
        base.Verbosity = override.Verbosity
    }
    base.Frameworks = append(base.Frameworks, override.Frameworks...)
    for k, v := range override.Conventions {
        base.Conventions[k] = v
    }
    base.CodePatterns = append(base.CodePatterns, override.CodePatterns...)
}
```

## Acceptance Criteria

- [ ] File `internal/memory/profile.go` exists
- [ ] `UserProfile` struct with preferences
- [ ] `ProfileManager` loads global + project profiles
- [ ] `Load()` merges global defaults with project overrides
- [ ] `Save()` writes to appropriate path
- [ ] `RecordCorrection()` learns from corrections
- [ ] `SetPreference()` / `GetPreference()` for conventions
- [ ] Thread-safe with mutex
- [ ] Build passes: `go build ./...`