### PR TITLE
docs: complete Configuration Reference with all adapters and features

### DIFF
--- a/docs/pages/getting-started/configuration.mdx
+++ b/docs/pages/getting-started/configuration.mdx
@@ -1430,6 +1430,36 @@ adapters:
 
 ---
 
+## Teams
+
+Team-based project access control for multi-user environments. When configured, task execution is scoped to the member's allowed projects.
+
+```yaml
+team:
+  enabled: true
+  team_id: "engineering"
+  member_email: "dev@example.com"
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable team-based access control |
+| `team_id` | string | — | Team ID or name to scope execution |
+| `member_email` | string | — | Email of the member executing tasks |
+
+**Environment variable alternative:**
+
+```bash
+PILOT_TEAM_ID="engineering"
+PILOT_MEMBER_EMAIL="dev@example.com"
+```
+
+<Callout type="info">
+Team configuration is optional. When not configured, Pilot runs without access restrictions. Enable it for multi-user deployments where you need to scope task execution to specific projects per team member.
+</Callout>
+
+---
+
 ## Projects
 
 Multi-project configuration for managing multiple repositories.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1054.

Closes #1054

## Changes

GitHub Issue #1054: docs: complete Configuration Reference with all adapters and features

## Context — v1.0 Roadmap Phase 4 (Docs Refresh)

## Problem

`docs/pages/getting-started/configuration.mdx` only covers GitHub, Telegram, and auth config. Missing sections for 8+ feature areas.

## Add Missing Sections

1. **Slack** — bot_token, app_token, channel, Socket Mode config
2. **Linear** — api_key, team_id, webhook setup
3. **Jira** — base_url, auth, project_key, webhook
4. **Azure DevOps** — org_url, project, pat
5. **Quality gates** — gates array, types, commands, max_retries
6. **Alerts** — channels array, rules, cooldowns
7. **Budget** — daily_limit, monthly_limit, per_task
8. **Teams** — enabled, members, project mapping
9. **Worktree** — executor.use_worktree setting
10. **Autopilot** — dev/stage/prod modes, CI check config
11. **Orchestrator** — max_concurrent, execution.mode, daily_brief

## Source of Truth

- `internal/config/config.go` — Full Config struct with all fields
- `configs/pilot.example.yaml` — Example config

## Acceptance Criteria

- [ ] All 11 sections above added to configuration page
- [ ] Each section has YAML examples
- [ ] Environment variable alternatives documented
- [ ] `npm run build` succeeds