### PR TITLE
fix(executor): decomposer branch creation fails when worktree already created branch

### DIFF
--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -28,6 +28,19 @@ func (g *GitOperations) CreateBranch(ctx context.Context, branchName string) err
 	return nil
 }
 
+// CreateOrResetBranch creates a branch or resets it if it already exists.
+// Uses git checkout -B (uppercase) which force-creates the branch.
+// This is safe when worktree already created the branch (GH-1235).
+func (g *GitOperations) CreateOrResetBranch(ctx context.Context, branchName string) error {
+	cmd := exec.CommandContext(ctx, "git", "checkout", "-B", branchName)
+	cmd.Dir = g.projectPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to create/reset branch: %w: %s", err, output)
+	}
+	return nil
+}
+
 // SwitchBranch switches to an existing branch
 func (g *GitOperations) SwitchBranch(ctx context.Context, branchName string) error {
 	cmd := exec.CommandContext(ctx, "git", "checkout", branchName)

--- a/internal/executor/git_test.go
+++ b/internal/executor/git_test.go
@@ -96,6 +96,40 @@ func TestGitOperationsInTempRepo(t *testing.T) {
 		}
 	})
 
+	t.Run("CreateOrResetBranch_NewBranch", func(t *testing.T) {
+		// GH-1235: CreateOrResetBranch should create new branch
+		err := git.CreateOrResetBranch(ctx, "new-reset-branch")
+		if err != nil {
+			t.Fatalf("CreateOrResetBranch (new) failed: %v", err)
+		}
+
+		branch, _ := git.GetCurrentBranch(ctx)
+		if branch != "new-reset-branch" {
+			t.Errorf("branch = %q, want new-reset-branch", branch)
+		}
+	})
+
+	t.Run("CreateOrResetBranch_ExistingBranch", func(t *testing.T) {
+		// GH-1235: CreateOrResetBranch should succeed even if branch exists
+		// First, go back to main
+		mainBranch := "main"
+		if git.branchExists(ctx, "master") && !git.branchExists(ctx, "main") {
+			mainBranch = "master"
+		}
+		_ = git.SwitchBranch(ctx, mainBranch)
+
+		// Now try to create/reset the branch that already exists
+		err := git.CreateOrResetBranch(ctx, "new-reset-branch")
+		if err != nil {
+			t.Fatalf("CreateOrResetBranch (existing) failed: %v", err)
+		}
+
+		branch, _ := git.GetCurrentBranch(ctx)
+		if branch != "new-reset-branch" {
+			t.Errorf("branch = %q, want new-reset-branch", branch)
+		}
+	})
+
 	t.Run("HasUncommittedChanges", func(t *testing.T) {
 		// Should have no changes
 		hasChanges, err := git.HasUncommittedChanges(ctx)

--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -58,10 +58,11 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 		}
 		r.reportProgress(parentTask.ID, "Branching", 2, fmt.Sprintf("On %s, creating %s...", defaultBranch, parentTask.Branch))
 
-		if err := git.CreateBranch(ctx, parentTask.Branch); err != nil {
-			if switchErr := git.SwitchBranch(ctx, parentTask.Branch); switchErr != nil {
-				return nil, fmt.Errorf("failed to create/switch branch: %w", err)
-			}
+		// GH-1235: Use CreateOrResetBranch (-B flag) instead of CreateBranch (-b flag)
+		// because worktree mode may have already created this branch. The -B flag
+		// handles both cases: creates if missing, resets if exists.
+		if err := git.CreateOrResetBranch(ctx, parentTask.Branch); err != nil {
+			return nil, fmt.Errorf("failed to create/reset branch: %w", err)
 		}
 		r.reportProgress(parentTask.ID, "Branching", 5, fmt.Sprintf("Branch %s ready", parentTask.Branch))
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1235.

Closes #1235

## Changes

GitHub Issue #1235: fix(executor): decomposer branch creation fails when worktree already created branch

## Problem

When a complex issue triggers decomposition, the execution flow creates a branch conflict:

1. `runner.go:697` — `CreateWorktreeWithBranch()` creates `pilot/GH-XXXX` with `-B` flag (force-create) in the worktree
2. `runner_decompose.go:48` — Creates `NewGitOperations(parentTask.ProjectPath)` pointing to the **original repo**, not the worktree
3. `runner_decompose.go:61` — Calls `git.CreateBranch()` which uses `git checkout -b` (lowercase, fails if exists)
4. The branch already exists in the shared git object store from step 1 → **permanent failure**

Error: `failed to create/switch branch: failed to create branch: exit status 128: fatal: a branch named 'pilot/GH-XXXX' already exists`

**Affected:** GH-1211 (webhooks) — classified as complex, decomposed, branch stuck

## Root Cause

`runner_decompose.go` is not worktree-aware:
- Line 48: `git := NewGitOperations(parentTask.ProjectPath)` — uses original repo path, not worktree
- Line 61: `git.CreateBranch()` uses `-b` flag — fails if branch exists (unlike `-B` used by worktree code)

## Fix

Two options (pick simplest):

### Option A: Use `-B` in decomposer (minimal change)
In `runner_decompose.go:61`, replace `CreateBranch` with a force-create variant:
```go
// Replace: git.CreateBranch(ctx, parentTask.Branch)
// With: git.CreateOrResetBranch(ctx, parentTask.Branch)
```
Add `CreateOrResetBranch()` to `git.go` using `git checkout -B`.

### Option B: Skip branch creation if worktree already created it
Pass `executionPath` to decomposer and use that for GitOperations:
```go
git := NewGitOperations(executionPath) // worktree path when enabled
```
And skip branch creation when worktree mode is active (branch already exists).

### Option A is preferred — simpler, no signature changes.

## Files
- `internal/executor/runner_decompose.go` — Line 48, 61
- `internal/executor/git.go` — Add `CreateOrResetBranch()` method

## Acceptance Criteria
- [ ] Complex issues that trigger decomposition work with `use_worktree: true`
- [ ] `go test -race ./internal/executor/...` passes
- [ ] No regressions for non-worktree mode