### PR TITLE
fix(executor): decomposer branch creation fails when worktree already created branch

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -920,7 +920,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				slog.Int("subtask_count", len(result.Subtasks)),
 				slog.String("reason", result.Reason),
 			)
-			return r.executeDecomposedTask(ctx, task, result.Subtasks)
+			return r.executeDecomposedTask(ctx, task, result.Subtasks, executionPath)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1235.

Closes #1235

## Changes

GitHub Issue #1235: fix(executor): decomposer branch creation fails when worktree already created branch

## Problem (Updated — second failure mode discovered)

When a complex issue triggers decomposition with `use_worktree: true`, TWO branch conflicts occur:

### Failure 1 (FIXED in PR #1236): Branch already exists
- `runner_decompose.go` used `git checkout -b` (fails if exists)
- **Fix**: Changed to `git checkout -B` (force-create/reset)

### Failure 2 (CURRENT): Branch locked by active worktree
- `Execute()` creates worktree at temp path with `pilot/GH-XXXX` branch checked out
- `executeDecomposedTask()` called at runner.go:923, AFTER worktree setup
- Decomposer uses `NewGitOperations(parentTask.ProjectPath)` — the ORIGINAL repo (line 48)
- `git checkout -B pilot/GH-XXXX` fails because branch is locked by the active worktree
- Error: `'pilot/GH-1211' is already used by worktree at '/tmp/pilot-worktree-...'`

## Root Cause

`executeDecomposedTask()` is not worktree-aware:
- Line 48: Uses `parentTask.ProjectPath` (original repo) instead of the worktree path
- Line 61-64: Tries to create/checkout branch that's already active in the worktree

## Fix

When worktree mode is active, the decomposer should:
1. Use the worktree path (`executionPath`) for git operations, NOT `parentTask.ProjectPath`
2. Skip branch creation entirely — the worktree already has the correct branch checked out

### Implementation

**Option A (recommended): Pass executionPath to decomposer**

In `runner.go:923`, pass `executionPath` so the decomposer knows where to operate:

```go
// Before:
return r.executeDecomposedTask(ctx, task, result.Subtasks)

// After:
return r.executeDecomposedTask(ctx, task, result.Subtasks, executionPath)
```

In `runner_decompose.go`, update signature and use `executionPath`:

```go
func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, subtasks []*Task, executionPath string) (*ExecutionResult, error) {
    git := NewGitOperations(executionPath)  // Use worktree path when available
    
    // Skip branch creation if executionPath != parentTask.ProjectPath
    // (means worktree already set up the branch)
    if parentTask.Branch != "" && executionPath == parentTask.ProjectPath {
        // Only create branch in non-worktree mode
        // ...existing branch creation code...
    }
```

Also update subtask ProjectPath to use executionPath:
```go
for i, subtask := range subtasks {
    subtask.ProjectPath = executionPath  // Execute in worktree, not original repo
}
```

## Files
- `internal/executor/runner.go` — Line 923: pass executionPath
- `internal/executor/runner_decompose.go` — Lines 12-68: accept executionPath, skip branch when worktree

## Acceptance Criteria
- [ ] Complex issues that trigger decomposition work with `use_worktree: true`
- [ ] Non-worktree mode still creates branches as before
- [ ] `go test -race ./internal/executor/...` passes
- [ ] GH-1211 can be retried successfully after this fix