### PR TITLE
feat(cli): pilot onboard — command skeleton, helpers, persona selection

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -95,6 +95,7 @@ func main() {
 		newAllowCmd(),
 		newProjectCmd(),
 		newAutopilotCmd(),
+		newOnboardCmd(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/pilot/onboard.go
+++ b/cmd/pilot/onboard.go
@@ -1,0 +1,661 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/alekspetrov/pilot/internal/banner"
+	"github.com/alekspetrov/pilot/internal/config"
+)
+
+// Persona represents the user's workflow persona
+type Persona int
+
+const (
+	PersonaSolo Persona = iota + 1
+	PersonaTeam
+	PersonaEnterprise
+)
+
+// String returns the persona display name
+func (p Persona) String() string {
+	switch p {
+	case PersonaSolo:
+		return "Solo"
+	case PersonaTeam:
+		return "Team"
+	case PersonaEnterprise:
+		return "Enterprise"
+	default:
+		return "Unknown"
+	}
+}
+
+// OnboardState holds the state during onboarding wizard
+type OnboardState struct {
+	Persona      Persona
+	Config       *config.Config
+	Reader       *bufio.Reader
+	StagesTotal  int
+	CurrentStage int
+}
+
+// Card dimensions for summary cards (21 chars wide, 3 columns)
+const (
+	summaryCardWidth      = 21
+	summaryCardInnerWidth = 17 // cardWidth - 4 (borders)
+)
+
+func newOnboardCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "onboard",
+		Short: "Interactive onboarding wizard",
+		Long: `Interactive wizard to configure Pilot for your workflow.
+
+Guides you through:
+  - Persona selection (Solo, Team, Enterprise)
+  - Project setup
+  - Ticket source configuration
+  - Notification settings
+  - Optional features (for Team/Enterprise)
+
+Examples:
+  pilot onboard    # Start interactive onboarding`,
+		RunE: runOnboard,
+	}
+
+	return cmd
+}
+
+func runOnboard(cmd *cobra.Command, args []string) error {
+	reader := bufio.NewReader(os.Stdin)
+
+	// Load existing config or create new
+	cfg, err := config.Load(config.DefaultConfigPath())
+	if err != nil {
+		cfg = config.DefaultConfig()
+	}
+
+	// Print welcome banner
+	fmt.Println()
+	banner.PrintWithVersion(version)
+
+	// Check current configuration status
+	hasProjects := len(cfg.Projects) > 0
+	hasTickets := hasTicketSource(cfg)
+	hasNotify := hasNotificationChannel(cfg)
+
+	// Show current status if config exists
+	if hasProjects || hasTickets || hasNotify {
+		printCurrentStatus(cfg, hasProjects, hasTickets, hasNotify)
+
+		// If all configured, ask to reconfigure
+		if hasProjects && hasTickets && hasNotify {
+			fmt.Println()
+			fmt.Print("  Reconfigure? [y/N]: ")
+			if !readYesNo(reader, false) {
+				fmt.Println()
+				fmt.Println("  Run 'pilot start' to begin")
+				return nil
+			}
+		}
+	}
+
+	// Persona selection
+	fmt.Println()
+	persona := selectPersona(reader)
+
+	// Create onboard state
+	state := &OnboardState{
+		Persona: persona,
+		Config:  cfg,
+		Reader:  reader,
+	}
+
+	// Set stage count based on persona
+	switch persona {
+	case PersonaSolo:
+		state.StagesTotal = 4
+	case PersonaTeam, PersonaEnterprise:
+		state.StagesTotal = 5
+	}
+
+	// Execute stages
+	state.CurrentStage = 1
+	if err := onboardProjectSetup(state); err != nil {
+		return err
+	}
+
+	state.CurrentStage = 2
+	if err := onboardTicketSetup(state); err != nil {
+		return err
+	}
+
+	state.CurrentStage = 3
+	if err := onboardNotifySetup(state); err != nil {
+		return err
+	}
+
+	// Optional setup for Team/Enterprise
+	if persona == PersonaTeam || persona == PersonaEnterprise {
+		state.CurrentStage = 4
+		if err := onboardOptionalSetup(state); err != nil {
+			return err
+		}
+	}
+
+	// Save config
+	configPath := config.DefaultConfigPath()
+	if err := config.Save(cfg, configPath); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	// Print summary
+	fmt.Println()
+	printOnboardSummary(state)
+
+	return nil
+}
+
+func selectPersona(reader *bufio.Reader) Persona {
+	options := []string{
+		"Solo Developer — Personal projects (4 stages)",
+		"Team — Shared repos, Slack notifications (5 stages)",
+		"Enterprise — Full automation, approvals (5 stages)",
+	}
+
+	idx := selectOption(reader, "Select your workflow:", options)
+
+	switch idx {
+	case 1:
+		return PersonaSolo
+	case 2:
+		return PersonaTeam
+	case 3:
+		return PersonaEnterprise
+	default:
+		return PersonaSolo
+	}
+}
+
+func hasTicketSource(cfg *config.Config) bool {
+	if cfg.Adapters == nil {
+		return false
+	}
+	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
+		return true
+	}
+	if cfg.Adapters.Linear != nil && cfg.Adapters.Linear.Enabled {
+		return true
+	}
+	if cfg.Adapters.Jira != nil && cfg.Adapters.Jira.Enabled {
+		return true
+	}
+	if cfg.Adapters.Asana != nil && cfg.Adapters.Asana.Enabled {
+		return true
+	}
+	return false
+}
+
+func hasNotificationChannel(cfg *config.Config) bool {
+	if cfg.Adapters == nil {
+		return false
+	}
+	if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled {
+		return true
+	}
+	if cfg.Adapters.Slack != nil && cfg.Adapters.Slack.Enabled {
+		return true
+	}
+	return false
+}
+
+func printCurrentStatus(cfg *config.Config, hasProjects, hasTickets, hasNotify bool) {
+	fmt.Println("  Current Configuration:")
+	fmt.Println()
+
+	if hasProjects {
+		fmt.Printf("    %s Projects: %d configured\n",
+			onboardSuccessStyle.Render("✓"),
+			len(cfg.Projects))
+	} else {
+		fmt.Printf("    %s Projects: not configured\n",
+			onboardDimStyle.Render("○"))
+	}
+
+	if hasTickets {
+		source := getTicketSourceName(cfg)
+		fmt.Printf("    %s Tickets: %s\n",
+			onboardSuccessStyle.Render("✓"),
+			source)
+	} else {
+		fmt.Printf("    %s Tickets: not configured\n",
+			onboardDimStyle.Render("○"))
+	}
+
+	if hasNotify {
+		channel := getNotifyChannelName(cfg)
+		fmt.Printf("    %s Notifications: %s\n",
+			onboardSuccessStyle.Render("✓"),
+			channel)
+	} else {
+		fmt.Printf("    %s Notifications: not configured\n",
+			onboardDimStyle.Render("○"))
+	}
+}
+
+func getTicketSourceName(cfg *config.Config) string {
+	var sources []string
+	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
+		sources = append(sources, "GitHub")
+	}
+	if cfg.Adapters.Linear != nil && cfg.Adapters.Linear.Enabled {
+		sources = append(sources, "Linear")
+	}
+	if cfg.Adapters.Jira != nil && cfg.Adapters.Jira.Enabled {
+		sources = append(sources, "Jira")
+	}
+	if cfg.Adapters.Asana != nil && cfg.Adapters.Asana.Enabled {
+		sources = append(sources, "Asana")
+	}
+	return strings.Join(sources, ", ")
+}
+
+func getNotifyChannelName(cfg *config.Config) string {
+	var channels []string
+	if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled {
+		channels = append(channels, "Telegram")
+	}
+	if cfg.Adapters.Slack != nil && cfg.Adapters.Slack.Enabled {
+		channels = append(channels, "Slack")
+	}
+	return strings.Join(channels, ", ")
+}
+
+// Stage stubs — will be implemented in subsequent issues
+
+func onboardProjectSetup(state *OnboardState) error {
+	printStageHeader("PROJECT SETUP", state.CurrentStage, state.StagesTotal)
+	fmt.Println()
+	fmt.Println("    " + onboardDimStyle.Render("Stage not yet implemented"))
+	fmt.Println()
+	printStageFooter()
+	return nil
+}
+
+func onboardTicketSetup(state *OnboardState) error {
+	printStageHeader("TICKET SOURCE", state.CurrentStage, state.StagesTotal)
+	fmt.Println()
+	fmt.Println("    " + onboardDimStyle.Render("Stage not yet implemented"))
+	fmt.Println()
+	printStageFooter()
+	return nil
+}
+
+func onboardNotifySetup(state *OnboardState) error {
+	printStageHeader("NOTIFICATIONS", state.CurrentStage, state.StagesTotal)
+	fmt.Println()
+	fmt.Println("    " + onboardDimStyle.Render("Stage not yet implemented"))
+	fmt.Println()
+	printStageFooter()
+	return nil
+}
+
+func onboardOptionalSetup(state *OnboardState) error {
+	printStageHeader("OPTIONAL FEATURES", state.CurrentStage, state.StagesTotal)
+	fmt.Println()
+	fmt.Println("    " + onboardDimStyle.Render("Stage not yet implemented"))
+	fmt.Println()
+	printStageFooter()
+	return nil
+}
+
+// printOnboardSummary prints the final summary with 3-column cards
+func printOnboardSummary(state *OnboardState) {
+	cfg := state.Config
+
+	printSectionDivider("SUMMARY")
+
+	// Print summary cards in rows of 3
+	cards := buildSummaryCards(cfg, state.Persona)
+
+	for i := 0; i < len(cards); i += 3 {
+		end := i + 3
+		if end > len(cards) {
+			end = len(cards)
+		}
+		printCardRow(cards[i:end])
+		if end < len(cards) {
+			fmt.Println()
+		}
+	}
+
+	// Print "Get started" section
+	fmt.Println()
+	printSectionDivider("GET STARTED")
+
+	printGetStartedCommands(cfg, state.Persona)
+}
+
+// SummaryCard represents a summary card
+type SummaryCard struct {
+	Title    string
+	Value    string
+	Line1    string
+	Line2    string
+	Configured bool
+}
+
+func buildSummaryCards(cfg *config.Config, persona Persona) []SummaryCard {
+	cards := []SummaryCard{
+		buildProjectCard(cfg),
+		buildTicketsCard(cfg),
+		buildNotifyCard(cfg),
+	}
+
+	// Add additional cards for Team/Enterprise
+	if persona == PersonaTeam || persona == PersonaEnterprise {
+		cards = append(cards,
+			buildPRsCard(cfg),
+			buildAutopilotCard(cfg),
+			buildBriefCard(cfg),
+		)
+	}
+
+	return cards
+}
+
+func buildProjectCard(cfg *config.Config) SummaryCard {
+	card := SummaryCard{Title: "PROJECT"}
+
+	if len(cfg.Projects) > 0 {
+		proj := cfg.Projects[0]
+		card.Value = proj.Name
+		if proj.GitHub != nil {
+			card.Line1 = fmt.Sprintf("%s/%s", proj.GitHub.Owner, proj.GitHub.Repo)
+		} else {
+			card.Line1 = truncate(proj.Path, summaryCardInnerWidth)
+		}
+		if proj.Navigator {
+			card.Line2 = "✓ Navigator"
+		}
+		card.Configured = true
+	} else {
+		card.Value = "—"
+		card.Line1 = "not configured"
+		card.Configured = false
+	}
+
+	return card
+}
+
+func buildTicketsCard(cfg *config.Config) SummaryCard {
+	card := SummaryCard{Title: "TICKETS"}
+
+	source := getTicketSourceName(cfg)
+	if source != "" {
+		card.Value = source
+		if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
+			label := "pilot"
+			if cfg.Adapters.GitHub.PilotLabel != "" {
+				label = cfg.Adapters.GitHub.PilotLabel
+			}
+			card.Line1 = fmt.Sprintf("label: %s", label)
+			if cfg.Adapters.GitHub.Polling != nil && cfg.Adapters.GitHub.Polling.Enabled {
+				card.Line2 = "polling: on"
+			}
+		}
+		card.Configured = true
+	} else {
+		card.Value = "—"
+		card.Line1 = "not configured"
+		card.Configured = false
+	}
+
+	return card
+}
+
+func buildNotifyCard(cfg *config.Config) SummaryCard {
+	card := SummaryCard{Title: "NOTIFY"}
+
+	channel := getNotifyChannelName(cfg)
+	if channel != "" {
+		card.Value = channel
+		if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled {
+			if cfg.Adapters.Telegram.ChatID != "" {
+				card.Line1 = fmt.Sprintf("chat: %s", cfg.Adapters.Telegram.ChatID)
+			}
+		}
+		card.Configured = true
+	} else {
+		card.Value = "—"
+		card.Line1 = "not configured"
+		card.Configured = false
+	}
+
+	return card
+}
+
+func buildPRsCard(cfg *config.Config) SummaryCard {
+	card := SummaryCard{Title: "PRS"}
+	card.Value = "auto-create"
+	card.Line1 = "self-review: on"
+	card.Configured = true
+	return card
+}
+
+func buildAutopilotCard(cfg *config.Config) SummaryCard {
+	card := SummaryCard{Title: "AUTOPILOT"}
+
+	if cfg.Orchestrator != nil && cfg.Orchestrator.Autopilot != nil {
+		env := string(cfg.Orchestrator.Autopilot.Environment)
+		if env == "" {
+			env = "dev"
+		}
+		card.Value = env
+		card.Line1 = "CI monitor: on"
+		card.Configured = true
+	} else {
+		card.Value = "dev"
+		card.Line1 = "CI monitor: off"
+		card.Configured = false
+	}
+
+	return card
+}
+
+func buildBriefCard(cfg *config.Config) SummaryCard {
+	card := SummaryCard{Title: "BRIEF"}
+
+	if cfg.Orchestrator != nil && cfg.Orchestrator.DailyBrief != nil && cfg.Orchestrator.DailyBrief.Enabled {
+		card.Value = "daily"
+		card.Line1 = cfg.Orchestrator.DailyBrief.Schedule
+		card.Configured = true
+	} else {
+		card.Value = "—"
+		card.Line1 = "not configured"
+		card.Configured = false
+	}
+
+	return card
+}
+
+func printCardRow(cards []SummaryCard) {
+	// Print each card line by line
+	// Line 1: top borders
+	for i, card := range cards {
+		fmt.Print(renderCardTopBorder(card.Title))
+		if i < len(cards)-1 {
+			fmt.Print(" ")
+		}
+	}
+	fmt.Println()
+
+	// Line 2: empty
+	for i := range cards {
+		fmt.Print(renderCardEmptyLine())
+		if i < len(cards)-1 {
+			fmt.Print(" ")
+		}
+	}
+	fmt.Println()
+
+	// Line 3: title and value
+	for i, card := range cards {
+		fmt.Print(renderCardTitleLine(card.Title, card.Value))
+		if i < len(cards)-1 {
+			fmt.Print(" ")
+		}
+	}
+	fmt.Println()
+
+	// Line 4: empty
+	for i := range cards {
+		fmt.Print(renderCardEmptyLine())
+		if i < len(cards)-1 {
+			fmt.Print(" ")
+		}
+	}
+	fmt.Println()
+
+	// Line 5: line1
+	for i, card := range cards {
+		fmt.Print(renderCardContentLine(card.Line1))
+		if i < len(cards)-1 {
+			fmt.Print(" ")
+		}
+	}
+	fmt.Println()
+
+	// Line 6: line2
+	for i, card := range cards {
+		fmt.Print(renderCardContentLine(card.Line2))
+		if i < len(cards)-1 {
+			fmt.Print(" ")
+		}
+	}
+	fmt.Println()
+
+	// Line 7: empty
+	for i := range cards {
+		fmt.Print(renderCardEmptyLine())
+		if i < len(cards)-1 {
+			fmt.Print(" ")
+		}
+	}
+	fmt.Println()
+
+	// Line 8: bottom border
+	for i := range cards {
+		fmt.Print(renderCardBottomBorder())
+		if i < len(cards)-1 {
+			fmt.Print(" ")
+		}
+	}
+	fmt.Println()
+}
+
+func renderCardTopBorder(title string) string {
+	// ╭───────────────────╮ (21 chars)
+	dashCount := summaryCardWidth - 2
+	return onboardBorderStyle.Render("╭" + strings.Repeat("─", dashCount) + "╮")
+}
+
+func renderCardBottomBorder() string {
+	// ╰───────────────────╯ (21 chars)
+	dashCount := summaryCardWidth - 2
+	return onboardBorderStyle.Render("╰" + strings.Repeat("─", dashCount) + "╯")
+}
+
+func renderCardEmptyLine() string {
+	// │                   │ (21 chars)
+	spaceCount := summaryCardWidth - 2
+	return onboardBorderStyle.Render("│") +
+		strings.Repeat(" ", spaceCount) +
+		onboardBorderStyle.Render("│")
+}
+
+func renderCardTitleLine(title, value string) string {
+	// │  TITLE    value  │
+	return onboardBorderStyle.Render("│") + " " +
+		onboardLabelStyle.Render(title) + "  " +
+		onboardValueStyle.Render(padRight(value, summaryCardInnerWidth-len(title)-4)) + " " +
+		onboardBorderStyle.Render("│")
+}
+
+func renderCardContentLine(content string) string {
+	// │  content...       │
+	if content == "" {
+		return renderCardEmptyLine()
+	}
+	truncated := truncate(content, summaryCardInnerWidth)
+	padded := padRight("  "+truncated, summaryCardInnerWidth)
+	return onboardBorderStyle.Render("│") + " " +
+		onboardDimStyle.Render(padded) + " " +
+		onboardBorderStyle.Render("│")
+}
+
+func padRight(s string, width int) string {
+	if len(s) >= width {
+		return s[:width]
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
+func printGetStartedCommands(cfg *config.Config, persona Persona) {
+	fmt.Println("  Start Pilot:")
+	fmt.Println()
+
+	var flags []string
+	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
+		flags = append(flags, "--github")
+	}
+	if cfg.Adapters.Linear != nil && cfg.Adapters.Linear.Enabled {
+		flags = append(flags, "--linear")
+	}
+	if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled {
+		flags = append(flags, "--telegram")
+	}
+	if cfg.Adapters.Slack != nil && cfg.Adapters.Slack.Enabled {
+		flags = append(flags, "--slack")
+	}
+
+	// Add autopilot for team/enterprise
+	if persona == PersonaTeam || persona == PersonaEnterprise {
+		flags = append(flags, "--autopilot=stage")
+	}
+
+	cmd := "pilot start"
+	if len(flags) > 0 {
+		cmd = cmd + " " + strings.Join(flags, " ")
+	}
+
+	fmt.Printf("    %s\n", onboardValueStyle.Render(cmd))
+	fmt.Println()
+
+	// Suggested first commands
+	fmt.Println("  Try these commands:")
+	fmt.Println()
+	fmt.Printf("    %s   # Check system health\n", onboardDimStyle.Render("pilot doctor"))
+	fmt.Printf("    %s   # Check status\n", onboardDimStyle.Render("pilot status"))
+
+	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
+		fmt.Printf("    %s   # List queued issues\n", onboardDimStyle.Render("gh issue list --label pilot"))
+	}
+
+	fmt.Println()
+}

--- a/cmd/pilot/onboard_helpers.go
+++ b/cmd/pilot/onboard_helpers.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// panelWidth for onboard screens (matches dashboard)
+const onboardPanelWidth = 69
+
+// Color palette (matching dashboard styles)
+var (
+	onboardTitleStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("#7eb8da")) // steel blue
+
+	onboardBorderStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#3d4450")) // slate
+
+	onboardSuccessStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#7ec699")) // sage green
+
+	onboardFailStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#d48a8a")) // dusty rose
+
+	onboardLabelStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#c9d1d9")) // light gray
+
+	onboardValueStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#7eb8da")) // steel blue
+
+	onboardDimStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#8b949e")) // mid gray
+
+	onboardCursorStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#d4a054")) // amber
+
+	onboardDividerStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#3d4450")) // slate
+)
+
+// selectOption displays numbered options, returns 1-based index
+func selectOption(reader *bufio.Reader, prompt string, options []string) int {
+	fmt.Println()
+	fmt.Println("  " + prompt)
+	fmt.Println()
+
+	for i, opt := range options {
+		fmt.Printf("    %s %s\n", onboardValueStyle.Render(fmt.Sprintf("[%d]", i+1)), opt)
+	}
+	fmt.Println()
+
+	fmt.Print("  " + onboardCursorStyle.Render("▸") + " ")
+	line := readLine(reader)
+
+	// Parse selection
+	var idx int
+	if _, err := fmt.Sscanf(line, "%d", &idx); err != nil || idx < 1 || idx > len(options) {
+		return 1 // Default to first option
+	}
+	return idx
+}
+
+// printStageHeader prints panel header with stage counter
+// Output: ╭─ TICKET SOURCE ───...───╮
+//
+//	│                 [2 of 5] │
+func printStageHeader(name string, current, total int) {
+	// Top border: ╭─ NAME ─────...─────╮
+	titleUpper := strings.ToUpper(name)
+	prefix := "╭─ "
+	prefixWidth := lipgloss.Width(prefix + titleUpper + " ")
+
+	dashCount := onboardPanelWidth - prefixWidth - 1 // -1 for ╮
+	if dashCount < 0 {
+		dashCount = 0
+	}
+
+	fmt.Println(onboardBorderStyle.Render(prefix) +
+		onboardLabelStyle.Render(titleUpper) +
+		onboardBorderStyle.Render(" "+strings.Repeat("─", dashCount)+"╮"))
+
+	// Stage counter line: │                 [2 of 5] │
+	counter := fmt.Sprintf("[%d of %d]", current, total)
+	counterWidth := lipgloss.Width(counter)
+	paddingWidth := onboardPanelWidth - 4 - counterWidth // -4 for "│ " + " │"
+	if paddingWidth < 0 {
+		paddingWidth = 0
+	}
+
+	border := onboardBorderStyle.Render("│")
+	fmt.Println(border + " " + strings.Repeat(" ", paddingWidth) +
+		onboardDimStyle.Render(counter) + " " + border)
+}
+
+// printStageFooter prints panel footer
+// Output: ╰───────────...───────────╯
+func printStageFooter() {
+	dashCount := onboardPanelWidth - 2
+	line := "╰" + strings.Repeat("─", dashCount) + "╯"
+	fmt.Println(onboardBorderStyle.Render(line))
+}
+
+// readLineWithDefault prompts with a default value
+// Output: "  Repository [me/myapp] ▸ "
+func readLineWithDefault(reader *bufio.Reader, prompt, defaultVal string) string {
+	if defaultVal != "" {
+		fmt.Printf("  %s %s %s ",
+			prompt,
+			onboardDimStyle.Render("["+defaultVal+"]"),
+			onboardCursorStyle.Render("▸"))
+	} else {
+		fmt.Printf("  %s %s ", prompt, onboardCursorStyle.Render("▸"))
+	}
+
+	line := readLine(reader)
+	if line == "" {
+		return defaultVal
+	}
+	return line
+}
+
+// detectGitRemote extracts owner/repo from git remote origin
+func detectGitRemote(projectPath string) (owner, repo string, err error) {
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = projectPath
+	out, err := cmd.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("no git remote found")
+	}
+
+	url := strings.TrimSpace(string(out))
+	return parseGitURL(url)
+}
+
+// parseGitURL extracts owner/repo from various git URL formats
+func parseGitURL(url string) (owner, repo string, err error) {
+	// Handle SSH format: git@github.com:owner/repo.git
+	if strings.HasPrefix(url, "git@") {
+		// git@github.com:owner/repo.git -> owner/repo
+		parts := strings.Split(url, ":")
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("invalid SSH URL")
+		}
+		path := strings.TrimSuffix(parts[1], ".git")
+		pathParts := strings.Split(path, "/")
+		if len(pathParts) >= 2 {
+			return pathParts[len(pathParts)-2], pathParts[len(pathParts)-1], nil
+		}
+	}
+
+	// Handle HTTPS format: https://github.com/owner/repo.git
+	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") {
+		path := strings.TrimPrefix(url, "https://")
+		path = strings.TrimPrefix(path, "http://")
+		path = strings.TrimSuffix(path, ".git")
+		// github.com/owner/repo -> owner, repo
+		parts := strings.Split(path, "/")
+		if len(parts) >= 3 {
+			return parts[len(parts)-2], parts[len(parts)-1], nil
+		}
+	}
+
+	return "", "", fmt.Errorf("unrecognized URL format")
+}
+
+// printSectionDivider prints a section divider with label
+// Output: ── SECTION ──────────────────────
+func printSectionDivider(label string) {
+	prefix := "── "
+	labelUpper := strings.ToUpper(label)
+	prefixWidth := lipgloss.Width(prefix + labelUpper + " ")
+	dashCount := onboardPanelWidth - prefixWidth
+	if dashCount < 3 {
+		dashCount = 3
+	}
+
+	fmt.Println()
+	fmt.Println(onboardDividerStyle.Render(prefix+labelUpper+" ") +
+		onboardDividerStyle.Render(strings.Repeat("─", dashCount)))
+	fmt.Println()
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1238.

Closes #1238

## Changes

GitHub Issue #1238: feat(cli): pilot onboard — command skeleton, helpers, persona selection

## Overview

Create the `pilot onboard` Cobra command — the new interactive onboarding wizard that replaces `pilot setup`. This issue builds the skeleton that subsequent issues plug into.

**Part 1 of 6** — must be merged first. Issues 2-5 depend on this.

## What to build

### 1. `cmd/pilot/onboard.go` (~250 LoC)

**OnboardState struct:**
```go
type Persona int
const (
    PersonaSolo Persona = iota + 1
    PersonaTeam
    PersonaEnterprise
)

type OnboardState struct {
    Persona      Persona
    Config       *config.Config
    Reader       *bufio.Reader
    StagesTotal  int
    CurrentStage int
}
```

**Cobra command** (`newOnboardCmd()`):
- `Use: "onboard"`, `Short: "Interactive onboarding wizard"`
- Loads existing config or creates default
- Shows welcome banner with version (use `banner.PrintWithVersion`)
- Shows current configuration status using summary cards (if config exists)
- If all configured: ask "Reconfigure? [y/N]"
- Persona selection: Solo (4 stages), Team (5 stages), Enterprise (5 stages)
- Calls stage functions in sequence (use **stubs** that print "not yet implemented" and return nil):
  - `onboardProjectSetup(state)` — stub
  - `onboardTicketSetup(state)` — stub  
  - `onboardNotifySetup(state)` — stub
  - `onboardOptionalSetup(state)` — stub (skipped for Solo)
- Saves config via `config.Save()`
- Prints summary with 3-column cards and "Get started" section

**Summary cards** (reuse dashboard card layout — 21 chars wide, 3 columns):
```
╭───────────────────╮ ╭───────────────────╮ ╭───────────────────╮
│                   │ │                   │ │                   │
│  PROJECT   myapp  │ │  TICKETS  GitHub  │ │  NOTIFY Telegram  │
│                   │ │                   │ │                   │
│  me/myapp         │ │  label: pilot     │ │  @MyPilotBot      │
│  ✓ Navigator      │ │  polling: on      │ │  chat: 87654321   │
│                   │ │                   │ │                   │
╰───────────────────╯ ╰───────────────────╯ ╰───────────────────╯
```

For Team/Enterprise, show 2 rows of cards (6 total: projects, tickets, notify, PRs, autopilot, brief).

**"Get started" section** — persona-aware:
- Solo: `pilot start --github`
- Team: `pilot start --github --linear --slack --autopilot=stage` (adapt to what was configured)
- Show suggested first tickets and other commands

### 2. `cmd/pilot/onboard_helpers.go` (~120 LoC)

Shared helper functions used by all onboard stages:

```go
// selectOption displays numbered options, returns 1-based index
func selectOption(reader *bufio.Reader, prompt string, options []string) int

// printStageHeader prints panel header with stage counter
// Output: ╭─ TICKET SOURCE ───...───╮
//         │                 [2 of 5] │
func printStageHeader(name string, current, total int)

// printStageFooter prints panel footer
// Output: ╰───────────...───────────╯
func printStageFooter()

// readLineWithDefault prompts with a default value
// Output: "  Repository [me/myapp] ▸ "
func readLineWithDefault(reader *bufio.Reader, prompt, defaultVal string) string

// detectGitRemote extracts owner/repo from git remote origin
func detectGitRemote(projectPath string) (owner, repo string, err error)

// detectDefaultBranch reads default branch from git
func detectDefaultBranch(projectPath string) string

// expandPath expands ~ to home directory
func expandPath(path string) string

// readLine reads a trimmed line from reader
func readLine(reader *bufio.Reader) string

// readYesNo reads y/n with a default
func readYesNo(reader *bufio.Reader, defaultYes bool) bool
```

### 3. `cmd/pilot/main.go` (1 line change)

Add `newOnboardCmd()` to `rootCmd.AddCommand()` block (~line 97).

## Visual Design

**Colors (lipgloss)**:
- Panel title: Steel blue `#7eb8da`
- `✓` success: Sage green `#7ec699`  
- `✗` failure: Dusty rose `#d48a8a`
- Card labels: Light gray `#c9d1d9`
- Card values: Steel blue `#7eb8da`
- Dim text: Mid gray `#8b949e`
- Stage counter: Mid gray `#8b949e`, right-aligned
- Input cursor: `▸` Amber `#d4a054`
- Section dividers: `── label ───` Slate `#3d4450`

**Panel width**: 69 chars total (matches dashboard)

## Files

- **Create**: `cmd/pilot/onboard.go`, `cmd/pilot/onboard_helpers.go`
- **Modify**: `cmd/pilot/main.go` (add 1 line to AddCommand block)

## Verification

- `make build` succeeds
- `./bin/pilot onboard --help` shows help text
- `./bin/pilot onboard` runs, shows welcome + persona selection, then "not yet implemented" stubs for stages, then summary
- No changes to existing `pilot setup` behavior

## References

- Existing setup pattern: `cmd/pilot/setup.go`
- Dashboard card layout: `internal/dashboard/tui.go`
- lipgloss styling: `cmd/pilot/interactive.go`
- Config loading: `internal/config/config.go` (`DefaultConfig()`, `Save()`, `Load()`)
- Banner: `cmd/pilot/banner/` package