### PR TITLE
feat(executor): session resume for self-review token savings

### DIFF
--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -41,6 +41,11 @@ type ExecuteOptions struct {
 	// Maps to Claude API output_config.effort or Claude Code --effort flag.
 	Effort string
 
+	// ResumeSessionID enables session resume for continued context (GH-1265).
+	// When set, uses --resume <session_id> to continue an existing Claude Code session,
+	// eliminating context rebuild overhead (~40% token savings for self-review).
+	ResumeSessionID string
+
 	// EventHandler receives streaming events during execution
 	// The handler receives the raw event line from the backend
 	EventHandler func(event BackendEvent)
@@ -96,6 +101,9 @@ type BackendEvent struct {
 
 	// Model is the model name used (if available)
 	Model string
+
+	// SessionID is the Claude Code session ID for resume support (GH-1265)
+	SessionID string
 }
 
 // BackendEventType categorizes backend events.
@@ -143,6 +151,9 @@ type BackendResult struct {
 
 	// Model is the model used for execution
 	Model string
+
+	// SessionID is the Claude Code session ID for resume support (GH-1265)
+	SessionID string
 }
 
 // BackendConfig contains configuration for executor backends.
@@ -390,6 +401,12 @@ type ClaudeCodeConfig struct {
 
 	// ExtraArgs are additional arguments to pass to the CLI
 	ExtraArgs []string `yaml:"extra_args,omitempty"`
+
+	// UseSessionResume enables session resume for self-review (GH-1265).
+	// When true, self-review uses --resume <session_id> to continue the
+	// original session, eliminating ~40% token waste from context rebuild.
+	// Default: false
+	UseSessionResume bool `yaml:"use_session_resume,omitempty"`
 }
 
 // OpenCodeConfig contains OpenCode backend configuration.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1265.

Closes #1265

## Changes

GitHub Issue #1265: feat(executor): session resume for self-review token savings

## Summary

Capture Claude Code `session_id` from init events and use `--resume <session_id>` for self-review, eliminating ~40% token waste from context rebuild.

## Context

Self-review (`runner.go:2395`) spawns a new `backend.Execute()` — Claude starts fresh, re-reads all modified files, rebuilds context. With `--resume`, self-review continues in the same session where Claude already has full context of what it changed.

Claude Code's stream-json init event contains `session_id`:
```json
{"type":"system","subtype":"init","session_id":"abc123"}
```

Currently `parseStreamEvent()` ignores this field.

## Implementation

### 1. Modify `internal/executor/runner.go` (line 25)

Add `SessionID` to `StreamEvent`:
```go
type StreamEvent struct {
    // ... existing fields
    SessionID string `json:"session_id,omitempty"`
}
```

### 2. Modify `internal/executor/backend.go`

Add fields:
```go
// In BackendEvent (line 66):
SessionID string

// In BackendResult (line 120):
SessionID string

// In ExecuteOptions (line 25):
ResumeSessionID string
```

### 3. Modify `internal/executor/backend_claudecode.go`

In `parseStreamEvent()` (line 465):
```go
case "system":
    if streamEvent.Subtype == "init" {
        event.Type = EventTypeInit
        event.SessionID = streamEvent.SessionID  // NEW
        event.Message = "Claude Code initialized"
    }
```

In `Execute()` stdout goroutine, capture session ID:
```go
if event.Type == EventTypeInit && event.SessionID != "" {
    result.SessionID = event.SessionID
}
```

In `Execute()` args construction (line 166), when `ResumeSessionID` is set:
```go
if opts.ResumeSessionID != "" {
    args = []string{
        "--resume", opts.ResumeSessionID,
        "-p", opts.Prompt,
        "--verbose",
        "--output-format", "stream-json",
        "--dangerously-skip-permissions",
    }
}
```

### 4. Modify `internal/executor/runner.go`

Add `sessionID string` to `progressState`.

In `processBackendEvent()`, capture session ID from init event.

In `runSelfReview()` (line 2395), pass session:
```go
result, err := r.backend.Execute(reviewCtx, ExecuteOptions{
    Prompt:          reviewPrompt,
    ProjectPath:     task.ProjectPath,
    ResumeSessionID: state.sessionID,  // NEW
})
```

### 5. Add config flag

In `ClaudeCodeConfig` (`backend.go` line 387):
```go
UseSessionResume bool `yaml:"use_session_resume,omitempty"`
```

Only use `--resume` when flag is `true`. Default: `false`.

### Config

```yaml
executor:
  claude_code:
    use_session_resume: true  # default: false
```

## Acceptance Criteria

- [ ] `StreamEvent` parses `session_id` from init JSON
- [ ] `BackendEvent` and `BackendResult` carry `SessionID`
- [ ] `parseStreamEvent()` captures session ID from init event
- [ ] `Execute()` builds args with `--resume <id>` when `ResumeSessionID` set
- [ ] `runSelfReview()` passes session ID when `use_session_resume: true`
- [ ] Existing behavior preserved when flag is `false`
- [ ] `make test` passes
- [ ] `make build` succeeds