### PR TITLE
fix(handlers): add unit test for parseAutopilotPR()

### DIFF
--- a/cmd/pilot/main_test.go
+++ b/cmd/pilot/main_test.go
@@ -312,6 +312,64 @@ func TestParseAutopilotBranch(t *testing.T) {
 	}
 }
 
+func TestParseAutopilotPR(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{
+			name: "valid metadata with pr",
+			body: "Some body text\n\n<!-- autopilot-meta branch:pilot/GH-10 pr:42 -->\n",
+			want: 42,
+		},
+		{
+			name: "metadata with context",
+			body: "# Fix\n\n## Context\n- **PR**: #42\n\n---\n\n<!-- autopilot-meta branch:pilot/GH-99 pr:123 -->\n",
+			want: 123,
+		},
+		{
+			name: "missing pr field",
+			body: "<!-- autopilot-meta branch:pilot/GH-10 -->",
+			want: 0,
+		},
+		{
+			name: "no metadata comment",
+			body: "just a normal issue body",
+			want: 0,
+		},
+		{
+			name: "empty body",
+			body: "",
+			want: 0,
+		},
+		{
+			name: "multiple metadata comments - first match wins",
+			body: "<!-- autopilot-meta branch:pilot/GH-1 pr:100 -->\nSome text\n<!-- autopilot-meta branch:pilot/GH-2 pr:200 -->",
+			want: 100,
+		},
+		{
+			name: "malformed - no closing comment",
+			body: "<!-- autopilot-meta branch:pilot/GH-10 pr:42",
+			want: 0,
+		},
+		{
+			name: "pr number only",
+			body: "<!-- autopilot-meta pr:999 -->",
+			want: 999,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAutopilotPR(tt.body)
+			if got != tt.want {
+				t.Errorf("parseAutopilotPR() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 // =============================================================================
 // GH-635: wireProjectAccessChecker tests
 // =============================================================================


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1280.

Closes #1280

## Changes

GitHub Issue #1280: fix(handlers): add unit test for parseAutopilotPR()

## Summary

`parseAutopilotPR()` in `cmd/pilot/handlers.go:49` has no unit test coverage. This function is in the critical autopilot CI-fix path — it extracts PR numbers from autopilot metadata comments to enable `--from-pr` session resumption (GH-1267).

## Context

- `parseAutopilotBranch()` (the sibling function) has tests, but `parseAutopilotPR()` does not
- The regex `.*?pr:(\d+).*?` works but could be tighter — consider enforcing field ordering
- Function is simple but untested code in a critical path is a reliability risk

## Implementation

### 1. Add tests in `cmd/pilot/handlers_test.go`

Table-driven tests covering:
- Standard metadata: `<!-- autopilot-meta branch:pilot/GH-10 pr:42 -->` → 42
- Missing PR field: `<!-- autopilot-meta branch:pilot/GH-10 -->` → 0
- No metadata comment: `"just a normal issue body"` → 0
- Empty body: `""` → 0
- Multiple metadata comments (edge case): first match wins

### 2. (Optional) Tighten regex

Current: `<!-- autopilot-meta.*?pr:(\d+).*?-->`
Better: `<!-- autopilot-meta branch:\S+ pr:(\d+) -->` (enforces field ordering)

## Acceptance Criteria

- [ ] Table-driven tests for `parseAutopilotPR()` covering happy path and edge cases
- [ ] `make test` passes