### PR TITLE
fix(executor): use configured command in getPostExecutionSummary()

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -3403,7 +3403,11 @@ func (r *Runner) getPostExecutionSummary(ctx context.Context) (*PostExecutionSum
 	prompt := "Report git state: run 'git log --oneline -1' and 'git branch --show-current' and 'git diff --name-only HEAD~1'. Return branch name, latest commit SHA, and changed files."
 
 	// Use fast Haiku model for this simple task
-	cmd := exec.CommandContext(ctx, "claude",
+	claudeCmd := "claude"
+	if r.config != nil && r.config.ClaudeCode != nil && r.config.ClaudeCode.Command != "" {
+		claudeCmd = r.config.ClaudeCode.Command
+	}
+	cmd := exec.CommandContext(ctx, claudeCmd,
 		"--print",
 		"-p", prompt,
 		"--model", "claude-haiku-4-5-20251001",


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1281.

Closes #1281

## Changes

GitHub Issue #1281: fix(executor): use configured command in getPostExecutionSummary()

## Summary

`getPostExecutionSummary()` in `internal/executor/runner.go:3408` hardcodes `"claude"` instead of using `r.config.ClaudeCode.Command`. This breaks for users with a custom Claude Code binary path.

## Context

All other Claude Code invocations use `b.config.Command` (set from config). The post-execution summary added in GH-1264 (v1.3.0) bypasses the backend and calls `exec.CommandContext` directly with a hardcoded `"claude"` string.

## Implementation

### 1. Modify `getPostExecutionSummary()` in `internal/executor/runner.go`

Replace:
```go
cmd := exec.CommandContext(ctx, "claude",
```

With:
```go
claudeCmd := "claude"
if r.config != nil && r.config.ClaudeCode != nil && r.config.ClaudeCode.Command != "" {
    claudeCmd = r.config.ClaudeCode.Command
}
cmd := exec.CommandContext(ctx, claudeCmd,
```

## Acceptance Criteria

- [ ] `getPostExecutionSummary()` uses `r.config.ClaudeCode.Command` when available
- [ ] Falls back to `"claude"` if config is nil or command is empty
- [ ] `make test` passes
- [ ] `make build` succeeds