### PR TITLE
docs: add GitHub API rate limiting and reliability guide

### DIFF
--- a/docs/pages/features/github.mdx
+++ b/docs/pages/features/github.mdx
@@ -85,3 +85,53 @@ pilot webhook setup --github
 ```
 
 This eliminates polling delay for instant task pickup.
+
+## Rate Limiting & Reliability
+
+Pilot is designed to run 24/7 without hitting GitHub API rate limits or database issues.
+
+### Rate Limit Handling
+
+The scheduler automatically tracks GitHub API quota via response headers:
+
+- **On 429 (rate limited)**: Automatic retry with `RetryBuffer` (5-minute safety margin before reset)
+- **Exponential backoff**: Transient failures trigger progressive delays (added in v0.34.0)
+- **Check interval**: 1-minute default polling cycle
+
+### Reducing API Usage
+
+**Use webhooks instead of polling** — Zero API quota consumed for issue detection:
+
+```bash
+pilot start --github --tunnel
+```
+
+**Increase poll interval** — If webhooks aren't an option:
+
+```yaml
+# ~/.pilot/config.yaml
+orchestrator:
+  execution:
+    poll_interval: 60s  # Default is 30s
+```
+
+**Stale label cleanup** — Configurable threshold reduces label API calls:
+
+```yaml
+orchestrator:
+  stale_cleanup:
+    threshold: 2h  # How long before in-progress labels are cleaned
+```
+
+### SQLite Reliability (v1.5.2+)
+
+Pilot uses SQLite for local state and history. The following reliability measures ensure stable 24/7 operation:
+
+| Feature | Purpose |
+|---------|---------|
+| WAL mode | Concurrent read/write without blocking |
+| `SetMaxOpenConns(1)` | Serializes writes (prevents SQLITE_BUSY) |
+| `withRetry()` | Exponential backoff on transient DB errors |
+| `busy_timeout=10000` | 10-second wait before failing (defense-in-depth) |
+
+These settings are automatic — no configuration needed.

--- a/docs/pages/guides/troubleshooting.mdx
+++ b/docs/pages/guides/troubleshooting.mdx
@@ -268,6 +268,70 @@ rm -rf /tmp/pilot-worktree-*
 
 ---
 
+## GitHub API Rate Limits
+
+### Pilot hits GitHub rate limit (429 errors)
+
+The scheduler handles this automatically, but you can reduce API usage:
+
+1. **Use webhooks instead of polling** — Zero quota for issue detection:
+   ```bash
+   pilot start --github --tunnel
+   ```
+
+2. **Increase poll interval** — If webhooks aren't an option:
+   ```yaml
+   orchestrator:
+     execution:
+       poll_interval: 60s  # Default is 30s
+   ```
+
+3. **Check rate limit status**:
+   ```bash
+   gh api rate_limit
+   ```
+
+The scheduler tracks quota via response headers and automatically waits for reset (with a 5-minute safety buffer).
+
+---
+
+## Database Issues
+
+### "Database is locked" error
+
+Fixed in v1.5.2. If you see `SQLITE_BUSY` or "Database locked, retrying" in logs:
+
+1. **Upgrade to v1.5.2+**:
+   ```bash
+   pilot upgrade
+   ```
+
+2. **Check for multiple instances** — Only one Pilot process should access the database:
+   ```bash
+   pgrep -f "pilot start"
+   ```
+
+3. **Verify WAL mode** — Should be enabled automatically:
+   ```bash
+   sqlite3 ~/.pilot/data/pilot.db "PRAGMA journal_mode"
+   # Should return: wal
+   ```
+
+### Dashboard freezes or hangs
+
+Often caused by the same SQLite contention. Check logs for "Database locked, retrying" messages:
+
+```bash
+grep -i "database.*locked\|sqlite.*busy" ~/.pilot/logs/pilot.log
+```
+
+If present, upgrade to v1.5.2+ which includes:
+- WAL mode for concurrent access
+- Connection serialization
+- Automatic retry with backoff
+
+---
+
 ## Getting Help
 
 If none of the above resolves your issue:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1291.

Closes #1291

## Changes

GitHub Issue #1291: docs: add GitHub API rate limiting and reliability guide

## Summary

Document GitHub API rate limit handling, the scheduler retry system, and SQLite reliability improvements. Users running Pilot 24/7 need to understand how rate limits are managed.

## Context

Pilot has a scheduler with retry/backoff for GitHub 429 responses, automatic rate limit reset tracking, and SQLite auto-recovery. None of this is documented.

## Implementation

### 1. New section in `docs/pages/features/github.mdx`

Add "Rate Limiting & Reliability" section:

**Rate Limit Handling**
- Scheduler tracks GitHub API quota via response headers
- On 429: automatic retry with `RetryBuffer` (5 min safety margin)
- `CheckInterval`: 1 minute default polling
- Exponential backoff on transient failures (GH API retry, v0.34.0)

**Reducing API Usage**
- Use `--tunnel` for webhooks instead of polling (zero quota for issue detection)
- Polling interval: `orchestrator.execution.poll_interval: 60s` (increase from 30s default)
- Stale label cleanup: configurable threshold to reduce label API calls

**SQLite Reliability (v1.5.2)**
- WAL mode enabled for concurrent read/write
- `SetMaxOpenConns(1)` serializes writes (prevents SQLITE_BUSY)
- `withRetry()` exponential backoff on transient DB errors
- `busy_timeout=10000` (10s) as defense-in-depth

### 2. Update `docs/pages/guides/troubleshooting.mdx`

Add troubleshooting entries:
- "Pilot hits GitHub rate limit" → increase poll interval, use tunnel
- "Database is locked error" → upgrade to v1.5.2+, check for multiple Pilot instances
- "Dashboard freezes" → same SQLite fix, check logs for "Database locked, retrying"

## Acceptance Criteria

- [ ] Rate limiting section added to GitHub feature page
- [ ] API usage reduction tips documented
- [ ] SQLite reliability documented
- [ ] Troubleshooting entries added
- [ ] `npm run build` in docs/ succeeds