### PR TITLE
fix(alerts): wire Email, Webhook, PagerDuty channels in main.go gateway/polling paths

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -467,6 +467,36 @@ Examples:
 						}
 					}
 
+					// Register webhook channels
+					for _, ch := range alertsCfg.Channels {
+						if ch.Type == "webhook" && ch.Enabled && ch.Webhook != nil {
+							webhookChannel := alerts.NewWebhookChannel(ch.Name, &alerts.WebhookChannelConfig{
+								URL:     ch.Webhook.URL,
+								Method:  ch.Webhook.Method,
+								Headers: ch.Webhook.Headers,
+								Secret:  ch.Webhook.Secret,
+							})
+							alertsDispatcher.RegisterChannel(webhookChannel)
+						}
+					}
+
+					// Register email channels
+					for _, ch := range alertsCfg.Channels {
+						if ch.Type == "email" && ch.Enabled && ch.Email != nil && ch.Email.SMTPHost != "" {
+							sender := alerts.NewSMTPSender(ch.Email.SMTPHost, ch.Email.SMTPPort, ch.Email.From, ch.Email.Username, ch.Email.Password)
+							emailChannel := alerts.NewEmailChannel(ch.Name, sender, ch.Email)
+							alertsDispatcher.RegisterChannel(emailChannel)
+						}
+					}
+
+					// Register PagerDuty channels
+					for _, ch := range alertsCfg.Channels {
+						if ch.Type == "pagerduty" && ch.Enabled && ch.PagerDuty != nil {
+							pdChannel := alerts.NewPagerDutyChannel(ch.Name, ch.PagerDuty)
+							alertsDispatcher.RegisterChannel(pdChannel)
+						}
+					}
+
 					ctx := context.Background()
 					gwAlertsEngine = alerts.NewEngine(alertsCfg, alerts.WithDispatcher(alertsDispatcher))
 					if alertErr := gwAlertsEngine.Start(ctx); alertErr != nil {
@@ -1446,6 +1476,36 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 					telegramChannel := alerts.NewTelegramChannel(ch.Name, telegramClient, ch.Telegram.ChatID)
 					alertsDispatcher.RegisterChannel(telegramChannel)
 				}
+			}
+		}
+
+		// Register webhook channels
+		for _, ch := range alertsCfg.Channels {
+			if ch.Type == "webhook" && ch.Enabled && ch.Webhook != nil {
+				webhookChannel := alerts.NewWebhookChannel(ch.Name, &alerts.WebhookChannelConfig{
+					URL:     ch.Webhook.URL,
+					Method:  ch.Webhook.Method,
+					Headers: ch.Webhook.Headers,
+					Secret:  ch.Webhook.Secret,
+				})
+				alertsDispatcher.RegisterChannel(webhookChannel)
+			}
+		}
+
+		// Register email channels
+		for _, ch := range alertsCfg.Channels {
+			if ch.Type == "email" && ch.Enabled && ch.Email != nil && ch.Email.SMTPHost != "" {
+				sender := alerts.NewSMTPSender(ch.Email.SMTPHost, ch.Email.SMTPPort, ch.Email.From, ch.Email.Username, ch.Email.Password)
+				emailChannel := alerts.NewEmailChannel(ch.Name, sender, ch.Email)
+				alertsDispatcher.RegisterChannel(emailChannel)
+			}
+		}
+
+		// Register PagerDuty channels
+		for _, ch := range alertsCfg.Channels {
+			if ch.Type == "pagerduty" && ch.Enabled && ch.PagerDuty != nil {
+				pdChannel := alerts.NewPagerDutyChannel(ch.Name, ch.PagerDuty)
+				alertsDispatcher.RegisterChannel(pdChannel)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1332.

Closes #1332

## Changes

GitHub Issue #1332: fix(alerts): wire Email, Webhook, PagerDuty channels in main.go gateway/polling paths

## Problem

`cmd/pilot/main.go` has two alert dispatcher registration blocks (gateway mode ~line 445, polling mode ~line 1428) that only register Slack and Telegram channels. Email, Webhook, and PagerDuty channels are missing.

Meanwhile, `internal/pilot/pilot.go:initAlerts()` (lines 1132-1219) correctly registers all 5 channel types. The gap is only in the legacy `main.go` code paths.

## Impact

- Email, Webhook, and PagerDuty alerts silently fail in gateway mode
- Users configure these channels in YAML but they never fire
- The `pilot.New()` → `pilot.Start()` path works correctly — only `gwAlertsEngine` paths are affected

## Fix

Add Email, Webhook, and PagerDuty registration loops to both alert blocks in `cmd/pilot/main.go`, matching the pattern already implemented in `internal/pilot/pilot.go:initAlerts()` (lines 1170-1212):

### Block 1: Gateway mode (~line 468, after Telegram registration)

```go
// Register webhook channels
for _, ch := range alertsCfg.Channels {
    if ch.Type == "webhook" && ch.Webhook != nil {
        webhookChannel := alerts.NewWebhookChannel(ch.Name, &alerts.WebhookChannelConfig{
            URL:     ch.Webhook.URL,
            Method:  ch.Webhook.Method,
            Headers: ch.Webhook.Headers,
            Secret:  ch.Webhook.Secret,
        })
        alertsDispatcher.RegisterChannel(webhookChannel)
    }
}

// Register email channels
for _, ch := range alertsCfg.Channels {
    if ch.Type == "email" && ch.Email != nil && ch.Email.SMTPHost != "" {
        sender := alerts.NewSMTPSender(ch.Email.SMTPHost, ch.Email.SMTPPort, ch.Email.From, ch.Email.Username, ch.Email.Password)
        emailChannel := alerts.NewEmailChannel(ch.Name, sender, ch.Email)
        alertsDispatcher.RegisterChannel(emailChannel)
    }
}

// Register PagerDuty channels
for _, ch := range alertsCfg.Channels {
    if ch.Type == "pagerduty" && ch.PagerDuty != nil {
        pdChannel := alerts.NewPagerDutyChannel(ch.Name, ch.PagerDuty)
        alertsDispatcher.RegisterChannel(pdChannel)
    }
}
```

### Block 2: Polling mode (~line 1450, after Telegram registration)

Same registration loops as Block 1.

## Files to modify

- `cmd/pilot/main.go` — two locations (~line 468 and ~line 1450)

## Reference

- Working implementation: `internal/pilot/pilot.go:initAlerts()` lines 1170-1212
- Channel implementations: `internal/alerts/channels.go`
- SMTP sender: `internal/alerts/smtp.go`