### PR TITLE
fix(dashboard): sync monitor state when autopilot merges PR

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -510,6 +510,10 @@ Examples:
 					gwRunner.SuppressProgressLogs(true)
 					gwMonitor = executor.NewMonitor()
 					gwRunner.SetMonitor(gwMonitor)
+					// GH-1336: Wire monitor to autopilot controller for state sync on merge
+					if gwAutopilotController != nil {
+						gwAutopilotController.SetMonitor(gwMonitor)
+					}
 					model := dashboard.NewModelWithOptions(version, gwStore, gwAutopilotController, nil)
 					gwProgram = tea.NewProgram(model,
 						tea.WithAltScreen(),
@@ -1320,6 +1324,10 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 
 		monitor = executor.NewMonitor()
 		runner.SetMonitor(monitor)
+		// GH-1336: Wire monitor to all autopilot controllers for state sync on merge
+		for _, controller := range autopilotControllers {
+			controller.SetMonitor(monitor)
+		}
 		upgradeRequestCh = make(chan struct{}, 1)
 		model := dashboard.NewModelWithOptions(version, store, autopilotController, upgradeRequestCh)
 		program = tea.NewProgram(model,


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1336.

Closes #1336

## Changes

GitHub Issue #1336: fix(dashboard): sync monitor state when autopilot merges PR

## Bug

Dashboard QUEUE panel shows `✗ failed` for tasks that actually succeeded (PR merged, issue closed with `pilot-done` label).

**Reproduction:** Any task where initial execution fails a quality gate or CI, then autopilot retries and eventually succeeds.

## Root Cause

Two separate state tracking systems that don't sync:

1. **`handlers.go:286`** calls `monitor.Fail(taskID, err)` when execution fails → monitor state = "failed"
2. **`controller.go:635` (`handleMerged`)** adds `pilot-done` label to GitHub but **never updates monitor state**
3. Dashboard reads from monitor → shows stale "failed" state

The `Controller` struct (`controller.go:45`) has no reference to `Monitor` — it can't update it even if it wanted to.

## Fix

### 1. Add monitor to Controller (`internal/autopilot/controller.go`)

Add `monitor` field to Controller struct:

```go
type Controller struct {
    // ... existing fields ...
    monitor  TaskMonitor // interface to avoid import cycle
}
```

### 2. Define TaskMonitor interface (`internal/autopilot/controller.go`)

To avoid importing `internal/executor` (which would create a cycle), define a minimal interface:

```go
// TaskMonitor allows autopilot to update task display state.
type TaskMonitor interface {
    Complete(taskID, prURL string)
}
```

### 3. Wire monitor in constructor

Add `WithMonitor(m TaskMonitor)` option or add to `NewController()` params.

### 4. Call Complete in handleMerged (`controller.go:635`)

In `handleMerged()`, after successfully adding `pilot-done` label:

```go
if c.monitor != nil {
    taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
    c.monitor.Complete(taskID, prState.PRURL)
}
```

### 5. Wire in main.go

Pass the monitor instance to the controller during initialization in `cmd/pilot/main.go`.

## Files

- `internal/autopilot/controller.go` — add `TaskMonitor` interface, `monitor` field, call in `handleMerged()`
- `cmd/pilot/main.go` — wire monitor into controller constructor
- `internal/autopilot/controller_test.go` — test: monitor.Complete() called when PR merges

## Acceptance Criteria

- [ ] Dashboard shows `✓ done` (not `✗ failed`) after autopilot merges a previously-failed task's PR
- [ ] `monitor.Complete()` called in `handleMerged()` with correct taskID
- [ ] No import cycles — uses interface, not concrete type
- [ ] Nil-safe — `c.monitor == nil` is a no-op (backward compatible)
- [ ] Tests pass: `go test ./internal/autopilot/...`