### PR TITLE
feat(doctor): check all backend CLIs and add IsAvailable() for Claude/Qwen

### DIFF
--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -158,23 +158,32 @@ func TestReadyToStart(t *testing.T) {
 		{
 			name: "all ok",
 			deps: []Check{
-				{Name: "claude", Status: StatusOK},
+				{Name: "claude", Status: StatusOK, Message: "1.0.0 [active backend]"},
 				{Name: "git", Status: StatusOK},
 			},
 			want: true,
 		},
 		{
-			name: "claude missing",
+			name: "active backend missing",
 			deps: []Check{
-				{Name: "claude", Status: StatusError},
+				{Name: "claude", Status: StatusError, Message: "not found [active backend]"},
 				{Name: "git", Status: StatusOK},
 			},
 			want: false,
 		},
 		{
+			name: "non-active backend missing is ok",
+			deps: []Check{
+				{Name: "claude", Status: StatusOK, Message: "1.0.0 [active backend]"},
+				{Name: "qwen", Status: StatusError, Message: "not found"},
+				{Name: "git", Status: StatusOK},
+			},
+			want: true,
+		},
+		{
 			name: "git missing",
 			deps: []Check{
-				{Name: "claude", Status: StatusOK},
+				{Name: "claude", Status: StatusOK, Message: "1.0.0 [active backend]"},
 				{Name: "git", Status: StatusError},
 			},
 			want: false,
@@ -182,7 +191,7 @@ func TestReadyToStart(t *testing.T) {
 		{
 			name: "gh warning is ok",
 			deps: []Check{
-				{Name: "claude", Status: StatusOK},
+				{Name: "claude", Status: StatusOK, Message: "1.0.0 [active backend]"},
 				{Name: "git", Status: StatusOK},
 				{Name: "gh", Status: StatusWarning},
 			},


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1341.

Closes #1341

## Changes

GitHub Issue #1341: feat(doctor): check all backend CLIs and add IsAvailable() for Claude/Qwen

## Context

`pilot doctor` only checks for `claude` and `git` CLIs. Since v1.9.0 added Qwen Code and OpenCode backends, doctor should verify whichever backend is configured. Also, `IsAvailable()` is only implemented for OpenCode — Claude Code and Qwen Code have no availability check and fail silently at runtime.

## Task

### 1. Add IsAvailable() to Claude Code backend

In `internal/executor/backend_claude.go`:

```go
func (b *ClaudeCodeBackend) IsAvailable() bool {
    _, err := exec.LookPath(b.config.Command) // default: "claude"
    return err == nil
}
```

### 2. Add IsAvailable() to Qwen Code backend

In `internal/executor/backend_qwen.go`:

```go
func (b *QwenCodeBackend) IsAvailable() bool {
    _, err := exec.LookPath(b.config.Command) // default: "qwen"
    return err == nil
}
```

### 3. Update pilot doctor

In `internal/health/health.go`, add backend-aware health checks:

- Read `executor.type` from config
- Check the **configured** backend CLI is installed (error if missing)
- Check other backends as informational (info if available, skip if not)
- Show backend version if available (`claude --version`, `qwen --version`, `opencode version`)

Example output:
```
Checking system health...

  ✓ git installed (2.44.0)
  ✓ gh installed (2.45.0)
  ✓ claude installed (1.0.26) [active backend]
  - qwen not installed (optional)
  - opencode not installed (optional)
  ✓ config valid
  ✓ API key configured

All checks passed!
```

### 4. Add IsAvailable() to Backend interface

If not already defined, add to the `Backend` interface in `internal/executor/backend.go`:

```go
type Backend interface {
    // ... existing methods ...
    IsAvailable() bool
}
```

This lets the factory validate before returning a backend instance.

## Files

- `internal/executor/backend_claude.go` — add `IsAvailable()`
- `internal/executor/backend_qwen.go` — add `IsAvailable()`
- `internal/executor/backend.go` — add `IsAvailable()` to interface if missing
- `internal/health/health.go` — backend-aware health checks

## Acceptance Criteria

- [ ] `pilot doctor` checks configured backend CLI and reports status
- [ ] `IsAvailable()` works for all 3 backends
- [ ] Missing configured backend = error in doctor output
- [ ] Missing non-configured backends = info/skip (not error)
- [ ] `go build ./...` passes
- [ ] `go test ./internal/executor/... ./internal/health/...` passes