### PR TITLE
fix(linear): poller re-dispatches issues after hot upgrade — no persistent processed store

### DIFF
--- a/internal/adapters/linear/poller_test.go
+++ b/internal/adapters/linear/poller_test.go
@@ -1,0 +1,208 @@
+package linear
+
+import (
+	"sync"
+	"testing"
+)
+
+// mockProcessedStore implements ProcessedStore for testing.
+// GH-1351: Tests Linear processed issue persistence.
+type mockProcessedStore struct {
+	mu        sync.Mutex
+	processed map[string]string // id -> result
+}
+
+func newMockProcessedStore() *mockProcessedStore {
+	return &mockProcessedStore{
+		processed: make(map[string]string),
+	}
+}
+
+func (m *mockProcessedStore) MarkLinearIssueProcessed(issueID string, result string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.processed[issueID] = result
+	return nil
+}
+
+func (m *mockProcessedStore) UnmarkLinearIssueProcessed(issueID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.processed, issueID)
+	return nil
+}
+
+func (m *mockProcessedStore) IsLinearIssueProcessed(issueID string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.processed[issueID]
+	return ok, nil
+}
+
+func (m *mockProcessedStore) LoadLinearProcessedIssues() (map[string]bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make(map[string]bool)
+	for id := range m.processed {
+		result[id] = true
+	}
+	return result, nil
+}
+
+// TestPoller_LoadsProcessedFromStore verifies that the poller loads
+// processed issues from the store on startup (GH-1351).
+func TestPoller_LoadsProcessedFromStore(t *testing.T) {
+	store := newMockProcessedStore()
+
+	// Pre-populate store with processed issues
+	store.processed["linear-issue-1"] = "processed"
+	store.processed["linear-issue-2"] = "processed"
+
+	config := &WorkspaceConfig{
+		TeamID:     "TEST",
+		PilotLabel: "pilot",
+	}
+
+	poller := NewPoller(nil, config, 30, WithProcessedStore(store))
+
+	// Verify processed issues were loaded
+	if poller.ProcessedCount() != 2 {
+		t.Errorf("ProcessedCount = %d, want 2", poller.ProcessedCount())
+	}
+
+	if !poller.IsProcessed("linear-issue-1") {
+		t.Error("linear-issue-1 should be processed")
+	}
+	if !poller.IsProcessed("linear-issue-2") {
+		t.Error("linear-issue-2 should be processed")
+	}
+	if poller.IsProcessed("linear-issue-3") {
+		t.Error("linear-issue-3 should not be processed")
+	}
+}
+
+// TestPoller_MarkProcessed_PersistsToStore verifies that marking an issue
+// as processed persists it to the store (GH-1351).
+func TestPoller_MarkProcessed_PersistsToStore(t *testing.T) {
+	store := newMockProcessedStore()
+	config := &WorkspaceConfig{
+		TeamID:     "TEST",
+		PilotLabel: "pilot",
+	}
+
+	poller := NewPoller(nil, config, 30, WithProcessedStore(store))
+
+	// Mark an issue as processed
+	poller.markProcessed("new-linear-issue")
+
+	// Verify it's in memory
+	if !poller.IsProcessed("new-linear-issue") {
+		t.Error("new-linear-issue should be processed in memory")
+	}
+
+	// Verify it's persisted to store
+	store.mu.Lock()
+	_, exists := store.processed["new-linear-issue"]
+	store.mu.Unlock()
+	if !exists {
+		t.Error("new-linear-issue should be persisted to store")
+	}
+}
+
+// TestPoller_ClearProcessed_RemovesFromStore verifies that clearing a processed
+// issue removes it from both memory and store (GH-1351).
+func TestPoller_ClearProcessed_RemovesFromStore(t *testing.T) {
+	store := newMockProcessedStore()
+	store.processed["issue-to-clear"] = "processed"
+
+	config := &WorkspaceConfig{
+		TeamID:     "TEST",
+		PilotLabel: "pilot",
+	}
+
+	poller := NewPoller(nil, config, 30, WithProcessedStore(store))
+
+	// Verify issue is loaded
+	if !poller.IsProcessed("issue-to-clear") {
+		t.Error("issue-to-clear should be processed initially")
+	}
+
+	// Clear the issue
+	poller.ClearProcessed("issue-to-clear")
+
+	// Verify it's removed from memory
+	if poller.IsProcessed("issue-to-clear") {
+		t.Error("issue-to-clear should not be processed after clearing")
+	}
+
+	// Verify it's removed from store
+	store.mu.Lock()
+	_, exists := store.processed["issue-to-clear"]
+	store.mu.Unlock()
+	if exists {
+		t.Error("issue-to-clear should be removed from store")
+	}
+}
+
+// TestPoller_WithoutStore_StillWorks verifies that the poller works
+// without a ProcessedStore (backward compatibility).
+func TestPoller_WithoutStore_StillWorks(t *testing.T) {
+	config := &WorkspaceConfig{
+		TeamID:     "TEST",
+		PilotLabel: "pilot",
+	}
+
+	// Create poller without store
+	poller := NewPoller(nil, config, 30)
+
+	// Should not panic and work with in-memory only
+	poller.markProcessed("memory-only-issue")
+
+	if !poller.IsProcessed("memory-only-issue") {
+		t.Error("memory-only-issue should be processed")
+	}
+
+	poller.ClearProcessed("memory-only-issue")
+
+	if poller.IsProcessed("memory-only-issue") {
+		t.Error("memory-only-issue should not be processed after clearing")
+	}
+}
+
+// TestPoller_Reset_ClearsMemoryOnly verifies that Reset clears the in-memory
+// map but doesn't affect the store.
+func TestPoller_Reset_ClearsMemoryOnly(t *testing.T) {
+	store := newMockProcessedStore()
+	config := &WorkspaceConfig{
+		TeamID:     "TEST",
+		PilotLabel: "pilot",
+	}
+
+	poller := NewPoller(nil, config, 30, WithProcessedStore(store))
+
+	// Mark and persist an issue
+	poller.markProcessed("persistent-issue")
+
+	// Verify it's in store
+	store.mu.Lock()
+	_, exists := store.processed["persistent-issue"]
+	store.mu.Unlock()
+	if !exists {
+		t.Fatal("persistent-issue should be in store")
+	}
+
+	// Reset clears in-memory map only
+	poller.Reset()
+
+	if poller.IsProcessed("persistent-issue") {
+		t.Error("persistent-issue should not be in memory after Reset")
+	}
+
+	// Store should still have it (Reset doesn't clear store)
+	store.mu.Lock()
+	_, exists = store.processed["persistent-issue"]
+	store.mu.Unlock()
+	if !exists {
+		t.Error("persistent-issue should still be in store after Reset")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1351.

Closes #1351

## Changes

GitHub Issue #1351: fix(linear): poller re-dispatches issues after hot upgrade — no persistent processed store

## Bug

Linear issues get re-dispatched after hot upgrade because the Linear poller only has an in-memory `processed` map with no SQLite persistence. When the process restarts (hot upgrade via `syscall.Exec`), the map is gone and previously processed issues get picked up again.

**Evidence:** APP-67 was picked up twice — once before upgrade, once after process restart.

**Why the GitHub poller doesn't have this problem:** It has `ProcessedStore` (SQLite-backed) that survives restarts. The Linear poller does not.

## Root Cause

`internal/adapters/linear/poller.go`:
- Line 27: `processed map[string]bool` — in-memory only
- No `ProcessedStore` interface, no SQLite persistence
- `hasStatusLabel()` (line 195) checks for `pilot-in-progress`/`pilot-done`/`pilot-failed` but these labels may not exist in Linear (line 112-114 `cacheLabelIDs` silently skips missing labels)
- After restart, issue has no status labels in Linear + not in processed map → re-dispatched

Compare with GitHub poller (`internal/adapters/github/poller.go`):
- Line 82: `processedStore ProcessedStore` — SQLite-backed
- Line 140-145: `WithProcessedStore()` option, loaded on startup
- Line 191-202: Loads processed issues from store on init

## Fix

Two complementary fixes needed:

### 1. Add ProcessedStore to Linear poller (matches GitHub poller pattern)
- Add `ProcessedStore` interface to Linear poller (reuse or mirror GitHub's)
- Add `WithProcessedStore()` option
- Load processed issues on startup, persist on `markProcessed()`
- Wire SQLite store in `cmd/pilot/main.go` at line ~1913

### 2. Ensure Linear status labels exist (defense in depth)
- In `cacheLabelIDs()`, if `pilot-done` / `pilot-in-progress` / `pilot-failed` labels don't exist in Linear, **create them**
- This ensures `hasStatusLabel()` check works as a secondary dedup after restart
- Currently line 112-114 silently ignores missing labels → status labels never added → dedup broken

### Key files
- `internal/adapters/linear/poller.go` — add ProcessedStore, create missing labels
- `internal/memory/store.go` — may need generic processed store (currently GitHub-specific?)
- `cmd/pilot/main.go` ~line 1913 — wire ProcessedStore for Linear poller

### Acceptance criteria
- [ ] Linear poller persists processed issues to SQLite
- [ ] After hot upgrade, previously processed Linear issues are NOT re-dispatched
- [ ] Missing status labels are auto-created in Linear team
- [ ] Existing GitHub ProcessedStore behavior unchanged