### PR TITLE
fix(linear): wire OnPRCreated to autopilot controller for Linear issues — PRs not auto-merged

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -601,7 +601,8 @@ func handleLinearIssueWithResult(ctx context.Context, cfg *config.Config, client
 
 	// Build issue result
 	issueResult := &linear.IssueResult{
-		Success: execErr == nil && result != nil && result.Success,
+		Success:    execErr == nil && result != nil && result.Success,
+		BranchName: branchName, // GH-1361: always set branch for autopilot wiring
 	}
 	if result != nil {
 		if result.PRUrl != "" {
@@ -610,6 +611,7 @@ func handleLinearIssueWithResult(ctx context.Context, cfg *config.Config, client
 				issueResult.PRNumber = prNum
 			}
 		}
+		issueResult.HeadSHA = result.CommitSHA // GH-1361: for autopilot CI monitoring
 	}
 
 	// Add comment to Linear issue

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -814,7 +814,15 @@ Examples:
 					// Build poller options
 					gwLinearPollerOpts := []linear.PollerOption{
 						linear.WithOnLinearIssue(func(issueCtx context.Context, issue *linear.Issue) (*linear.IssueResult, error) {
-							return handleLinearIssueWithResult(issueCtx, cfg, linearClient, issue, projectPath, gwDispatcher, gwRunner, gwMonitor, gwProgram, gwAlertsEngine, gwEnforcer)
+							result, err := handleLinearIssueWithResult(issueCtx, cfg, linearClient, issue, projectPath, gwDispatcher, gwRunner, gwMonitor, gwProgram, gwAlertsEngine, gwEnforcer)
+
+							// GH-1361: Wire PR to autopilot for CI monitoring + auto-merge
+							if result != nil && result.PRNumber > 0 && gwAutopilotController != nil {
+								// issueNumber=0 because Linear issues don't have GitHub issue numbers
+								gwAutopilotController.OnPRCreated(result.PRNumber, result.PRURL, 0, result.HeadSHA, result.BranchName)
+							}
+
+							return result, err
 						}),
 					}
 
@@ -1927,12 +1935,29 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 				linear.WithOnLinearIssue(func(issueCtx context.Context, issue *linear.Issue) (*linear.IssueResult, error) {
 					// GH-1348: Resolve project path per-issue using workspace→project mapping
 					issueProjectPath := projectPath // fallback to default
-					if pilotProject := wsConfig.ResolvePilotProject(issue); pilotProject != "" {
+					pilotProject := wsConfig.ResolvePilotProject(issue)
+					if pilotProject != "" {
 						if proj := cfg.GetProjectByName(pilotProject); proj != nil {
 							issueProjectPath = proj.Path
 						}
 					}
-					return handleLinearIssueWithResult(issueCtx, cfg, linearClient, issue, issueProjectPath, dispatcher, runner, monitor, program, alertsEngine, enforcer)
+					result, err := handleLinearIssueWithResult(issueCtx, cfg, linearClient, issue, issueProjectPath, dispatcher, runner, monitor, program, alertsEngine, enforcer)
+
+					// GH-1361: Wire PR to autopilot for CI monitoring + auto-merge
+					if result != nil && result.PRNumber > 0 {
+						// Resolve which autopilot controller to use based on project
+						if pilotProject != "" {
+							if proj := cfg.GetProjectByName(pilotProject); proj != nil && proj.GitHub != nil {
+								repoFullName := fmt.Sprintf("%s/%s", proj.GitHub.Owner, proj.GitHub.Repo)
+								if controller, ok := autopilotControllers[repoFullName]; ok && controller != nil {
+									// issueNumber=0 because Linear issues don't have GitHub issue numbers
+									controller.OnPRCreated(result.PRNumber, result.PRURL, 0, result.HeadSHA, result.BranchName)
+								}
+							}
+						}
+					}
+
+					return result, err
 				}),
 			}
 

--- a/internal/adapters/linear/poller.go
+++ b/internal/adapters/linear/poller.go
@@ -14,10 +14,12 @@ import (
 
 // IssueResult is returned by the issue handler
 type IssueResult struct {
-	Success  bool
-	PRNumber int
-	PRURL    string
-	Error    error
+	Success    bool
+	PRNumber   int
+	PRURL      string
+	HeadSHA    string // Head commit SHA of the PR (GH-1361: for autopilot wiring)
+	BranchName string // Head branch name e.g. "pilot/APP-123" (GH-1361: for autopilot wiring)
+	Error      error
 }
 
 // ProcessedStore persists which Linear issues have been processed across restarts.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1361.

Closes #1361

## Changes

GitHub Issue #1361: fix(linear): wire OnPRCreated to autopilot controller for Linear issues — PRs not auto-merged

## Bug

Linear issues that create PRs are never auto-merged because the Linear poller callback doesn't notify the autopilot controller about new PRs.

**Evidence:** APP-67 created PR #2 in `alekspetrov/aso-generator` but autopilot never picked it up for CI monitoring / auto-merge. PR sits open, issue marked as done manually.

## Root Cause

In `cmd/pilot/main.go` (~line 1916-1924), the Linear poller callback:
```go
linear.WithOnLinearIssue(func(issueCtx context.Context, issue *linear.Issue) (*linear.IssueResult, error) {
    // ... project path resolution (GH-1348)
    return handleLinearIssueWithResult(...)
})
```

The result contains `PRNumber`, `PRURL`, `HeadSHA`, `BranchName` — but nobody calls `controller.OnPRCreated()` with this data.

**Compare with GitHub poller** (line 1676-1714):
- `WithOnPRCreated(controller.OnPRCreated)` wired on the poller
- Explicit `controllerCapture.OnPRCreated(...)` call after issue handling

## Fix

After `handleLinearIssueWithResult` returns, call `OnPRCreated` on the appropriate autopilot controller:

```go
result, err := handleLinearIssueWithResult(...)

// Wire PR to autopilot for CI monitoring + auto-merge
if result != nil && result.PRNumber > 0 {
    // Resolve which autopilot controller to use based on project
    pilotProject := wsConfig.ResolvePilotProject(issue)
    if proj := cfg.GetProjectByName(pilotProject); proj != nil && proj.GitHub != nil {
        repoFullName := fmt.Sprintf("%s/%s", proj.GitHub.Owner, proj.GitHub.Repo)
        if controller, ok := autopilotControllers[repoFullName]; ok && controller != nil {
            controller.OnPRCreated(result.PRNumber, result.PRURL, 0, result.HeadSHA, result.BranchName)
        }
    }
}

return result, err
```

The `issueNumber` param is 0 because Linear issues don't have GitHub issue numbers. The controller should handle this gracefully (skip GitHub label management for issue 0).

### Key files
- `cmd/pilot/main.go` ~line 1916 (Linear poller callback — add OnPRCreated call)
- `cmd/pilot/main.go` ~line 1201 (autopilotControllers map — needs to be accessible in closure)
- `internal/autopilot/controller.go` (OnPRCreated — verify it handles issueNumber=0)

### Acceptance criteria
- [ ] Linear issues that create PRs are tracked by autopilot
- [ ] Autopilot monitors CI, auto-merges when checks pass
- [ ] Correct autopilot controller used per-project (aso-generator PR → aso-generator controller)
- [ ] No crash when issueNumber is 0 (Linear issues don't have GH issue numbers)
- [ ] GitHub issue flow unchanged