### PR TITLE
feat(executor): pre-push lint gate — run golangci-lint before creating PRs

### DIFF
--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -259,6 +259,13 @@ type BackendConfig struct {
 	// Simplification contains code simplification settings (GH-995)
 	// When enabled, Pilot auto-simplifies code after implementation for clarity.
 	Simplification *SimplifyConfig `yaml:"simplification,omitempty"`
+
+	// PrePushLint enables lint checking before pushing to remote.
+	// When true (default), Pilot runs linter (golangci-lint for Go projects) after commit.
+	// If fixable issues are found, they are auto-fixed and re-committed.
+	// Unfixable issues are included in the execution result for self-review.
+	// GH-1376: Added to prevent lint-failure cascades
+	PrePushLint *bool `yaml:"pre_push_lint,omitempty"`
 }
 
 // ModelRoutingConfig controls which model to use based on task complexity.
@@ -478,10 +485,12 @@ type OpenCodeConfig struct {
 func DefaultBackendConfig() *BackendConfig {
 	autoCreatePR := true
 	detectEphemeral := true
+	prePushLint := true
 	return &BackendConfig{
 		Type:            "claude-code",
 		AutoCreatePR:    &autoCreatePR,
 		DetectEphemeral: &detectEphemeral,
+		PrePushLint:     &prePushLint,
 		ClaudeCode: &ClaudeCodeConfig{
 			Command: "claude",
 		},

--- a/internal/executor/lint.go
+++ b/internal/executor/lint.go
@@ -1,0 +1,137 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// LintResult contains the result of a lint check
+type LintResult struct {
+	Clean    bool
+	Linter   string
+	Issues   []string
+	FixedAll bool
+}
+
+// runLintCheck detects and runs the appropriate linter for the project
+func (g *GitOperations) runLintCheck(ctx context.Context) *LintResult {
+	result := &LintResult{
+		Clean:  true,
+		Issues: []string{},
+	}
+
+	// Detect linter config (Go projects)
+	if hasGoLintConfig(g.projectPath) {
+		result.Linter = "golangci-lint"
+		// Check for lint issues on changed files only
+		output, err := g.runGoLint(ctx)
+		if err != nil {
+			result.Clean = false
+			result.Issues = []string{output}
+		}
+	}
+	// Could extend with eslint, ruff, etc. in the future
+
+	return result
+}
+
+// autoFixLint attempts to auto-fix linting issues
+func (g *GitOperations) autoFixLint(ctx context.Context) *LintResult {
+	result := g.runLintCheck(ctx)
+	if result.Clean {
+		return result
+	}
+
+	if result.Linter == "golangci-lint" {
+		// Attempt auto-fix
+		fixCmd := exec.CommandContext(ctx, "golangci-lint", "run", "--fix", "./...")
+		fixCmd.Dir = g.projectPath
+		output, err := fixCmd.CombinedOutput()
+		if err == nil {
+			// Verify fixes worked
+			verifyResult := g.runLintCheck(ctx)
+			if verifyResult.Clean {
+				// Stage and amend the last commit
+				g.stageAndAmendCommit(ctx, "[lint fix] Auto-fixed linting issues")
+				result.FixedAll = true
+				result.Clean = true
+				result.Issues = []string{}
+			} else {
+				result.Issues = verifyResult.Issues
+			}
+		} else {
+			result.Issues = []string{fmt.Sprintf("golangci-lint --fix failed: %s", output)}
+		}
+	}
+
+	return result
+}
+
+// runGoLint runs golangci-lint on changed files
+func (g *GitOperations) runGoLint(ctx context.Context) (string, error) {
+	// Run golangci-lint on changed files from origin/main
+	cmd := exec.CommandContext(ctx, "golangci-lint", "run",
+		"--new-from-rev=origin/main",
+		"./...",
+	)
+	cmd.Dir = g.projectPath
+	output, err := cmd.CombinedOutput()
+	outputStr := strings.TrimSpace(string(output))
+
+	if err != nil {
+		// Exit code 1 means issues found
+		return outputStr, err
+	}
+	return outputStr, nil
+}
+
+// stageAndAmendCommit stages all changes and amends the last commit
+func (g *GitOperations) stageAndAmendCommit(ctx context.Context, message string) error {
+	// Stage all changes
+	stageCmd := exec.CommandContext(ctx, "git", "add", "-A")
+	stageCmd.Dir = g.projectPath
+	if _, err := stageCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to stage changes: %w", err)
+	}
+
+	// Amend commit
+	amendCmd := exec.CommandContext(ctx, "git", "commit", "--amend", "--no-edit")
+	amendCmd.Dir = g.projectPath
+	if _, err := amendCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to amend commit: %w", err)
+	}
+
+	return nil
+}
+
+// hasGoLintConfig checks if the project has golangci-lint config
+func hasGoLintConfig(projectPath string) bool {
+	// Check for common golangci-lint config file names
+	configFiles := []string{
+		".golangci.yml",
+		".golangci.yaml",
+		".golangci.toml",
+		"golangci.yml",
+		"golangci.yaml",
+		"golangci.toml",
+	}
+
+	for _, cf := range configFiles {
+		if lintFileExists(filepath.Join(projectPath, cf)) {
+			return true
+		}
+	}
+
+	// Also check for go.mod which indicates a Go project
+	return lintFileExists(filepath.Join(projectPath, "go.mod"))
+}
+
+// lintFileExists checks if a file exists
+func lintFileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2210,6 +2210,18 @@ The previous execution completed but made no code changes. This task requires ac
 		}
 
 		// Handle direct commit mode: push directly to main
+
+		// Pre-push lint gate (GH-1376)
+		if r.config.PrePushLint != nil && *r.config.PrePushLint {
+			r.reportProgress(task.ID, "Linting", 95, "Running pre-push lint check...")
+			lintResult := git.autoFixLint(ctx)
+			if !lintResult.Clean && !lintResult.FixedAll {
+				// Include unfixable lint issues in execution result for self-review
+				if len(lintResult.Issues) > 0 {
+					result.IntentWarning = "Lint issues detected but not auto-fixable:\n" + strings.Join(lintResult.Issues, "\n")
+				}
+			}
+		}
 		if task.DirectCommit {
 			r.reportProgress(task.ID, "Pushing", 96, "Pushing to main...")
 
@@ -2235,6 +2247,18 @@ The previous execution completed but made no code changes. This task requires ac
 			// Create PR if requested and we have commits
 			r.reportProgress(task.ID, "Creating PR", 96, "Pushing branch...")
 
+
+			// Pre-push lint gate (GH-1376)
+			if r.config.PrePushLint != nil && *r.config.PrePushLint {
+				r.reportProgress(task.ID, "Linting", 95, "Running pre-push lint check...")
+				lintResult := git.autoFixLint(ctx)
+				if !lintResult.Clean && !lintResult.FixedAll {
+					// Include unfixable lint issues in execution result for self-review
+					if len(lintResult.Issues) > 0 {
+						result.IntentWarning = "Lint issues detected but not auto-fixable:\n" + strings.Join(lintResult.Issues, "\n")
+					}
+				}
+			}
 			// Push branch
 			if err := git.Push(ctx, task.Branch); err != nil {
 				result.Success = false


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1376.

Closes #1376

## Changes

GitHub Issue #1376: feat(executor): pre-push lint gate — run golangci-lint before creating PRs

## Problem

Pilot creates PRs that fail CI due to trivial lint errors (errcheck, staticcheck), then spawns CI fix issues, which cascade into more failures. This happened on GH-1354 batch: 3 PRs failed lint, spawned 3 CI fix issues, created 6 extra PRs — all for 3 one-line lint fixes.

**Evidence (2026-02-16):**
- PR #1365: `errcheck` — unchecked return values in test file
- PR #1368: `errcheck` — same pattern, branched from stale base
- PR #1370: `staticcheck QF1003` — if/else chain should be switch

All trivial, all preventable. Each failure costs tokens, time, and pollutes the issue tracker.

**Current 41% failure rate (340/828)** is partly driven by these avoidable lint cascades.

## Fix

Add a lint gate in `runner.go` **after commit, before push**. If lint fails, fix inline and re-commit before pushing.

### Implementation

In `internal/executor/runner.go`, after the Claude Code execution produces commits but before `git push`:

```go
// Pre-push lint gate
if r.config.Executor.PrePushLint {
    lintResult := r.runLintCheck(task.ProjectPath)
    if !lintResult.Clean {
        // Option A: fail with actionable error (fast, safe)
        // Option B: auto-fix with `golangci-lint run --fix` and re-commit (preferred)
        r.autoFixLint(task.ProjectPath, lintResult)
    }
}
```

### Detection logic

1. Detect project language (Go → `golangci-lint`, JS/TS → `eslint`, Python → `ruff`)
2. Run linter on changed files only: `golangci-lint run --new-from-rev=origin/main ./...`
3. If fixable: run `golangci-lint run --fix`, stage, amend commit
4. If not fixable: include lint output in execution result so self-review can address it

### Config

```yaml
executor:
  pre_push_lint: true  # default: true
```

### Key files
- `internal/executor/runner.go` — insert gate between commit and push phases
- `internal/executor/lint.go` — new file for lint detection and auto-fix logic

### Acceptance criteria
- [ ] Go projects: `golangci-lint run --new-from-rev` before push
- [ ] Auto-fix applied when possible (`--fix` flag)
- [ ] Unfixable errors included in execution result for self-review
- [ ] Config flag to disable (`pre_push_lint: false`)
- [ ] No impact on projects without linter config