### PR TITLE
Add HeadSHA and BranchName to Jira and Asana result structs

### DIFF
--- a/internal/adapters/asana/poller.go
+++ b/internal/adapters/asana/poller.go
@@ -22,10 +22,12 @@ const (
 
 // TaskResult is returned by the task handler
 type TaskResult struct {
-	Success  bool
-	PRNumber int
-	PRURL    string
-	Error    error
+	Success    bool
+	PRNumber   int
+	PRURL      string
+	HeadSHA    string // Head commit SHA of the PR (GH-1398: for autopilot wiring)
+	BranchName string // Head branch name e.g. "pilot/TASK-123" (GH-1398: for autopilot wiring)
+	Error      error
 }
 
 // ProcessedStore persists which Asana tasks have been processed across restarts.

--- a/internal/adapters/jira/poller.go
+++ b/internal/adapters/jira/poller.go
@@ -22,10 +22,12 @@ const (
 
 // IssueResult is returned by the issue handler
 type IssueResult struct {
-	Success  bool
-	PRNumber int
-	PRURL    string
-	Error    error
+	Success    bool
+	PRNumber   int
+	PRURL      string
+	HeadSHA    string // Head commit SHA of the PR (GH-1398: for autopilot wiring)
+	BranchName string // Head branch name e.g. "pilot/PROJ-123" (GH-1398: for autopilot wiring)
+	Error      error
 }
 
 // ProcessedStore persists which Jira issues have been processed across restarts.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1398.

Closes #1398

## Changes

Add `HeadSHA string` and `BranchName string` fields to `jira.IssueResult` in `internal/adapters/jira/poller.go` and `asana.TaskResult` in `internal/adapters/asana/poller.go`, mirroring the existing `linear.IssueResult` pattern. These are two independent packages with no overlap.