### PR TITLE
docs: add Navigator Auto-Init section to setup page

### DIFF
--- a/docs/content/navigator/setup.mdx
+++ b/docs/content/navigator/setup.mdx
@@ -29,6 +29,69 @@ pilot task "Add health check endpoint"
 
 The auto-generated index includes your project structure, detected framework, and component status.
 
+### What Gets Created
+
+Auto-init creates the full Navigator directory structure:
+
+```
+.agent/
+├── DEVELOPMENT-README.md     # Project-specific navigator guide
+├── .nav-config.json          # Navigator configuration
+├── .gitignore                # Excludes session-specific files
+├── tasks/                    # Implementation plans
+├── system/                   # Architecture docs
+└── sops/                     # Standard operating procedures
+    ├── integrations/
+    ├── debugging/
+    ├── development/
+    └── deployment/
+```
+
+### Tech Stack Detection
+
+Pilot auto-detects your technology stack from project files:
+
+| File | Detected Stack |
+|------|---------------|
+| `go.mod` | Go + detected frameworks (Gin, Gorilla, Fiber) + ORMs (GORM) |
+| `package.json` | Node.js + frameworks (Next.js, React, Vue, Express) + TypeScript |
+| `pyproject.toml` | Python + frameworks (FastAPI, Django, Flask) |
+| `Cargo.toml` | Rust + frameworks (Actix, Axum) |
+| (none found) | Uses directory name as project identifier |
+
+### Template Variables
+
+Templates use these placeholders, automatically replaced during initialization:
+
+| Variable | Value |
+|----------|-------|
+| `${PROJECT_NAME}` | Detected project name (Title Case) |
+| `${project_name}` | Lowercase project name with hyphens |
+| `${TECH_STACK}` | Detected technology stack string |
+| `${DATE}` | Current date (YYYY-MM-DD) |
+| `${YEAR}` | Current year |
+
+### Auto-Init Configuration
+
+Configure auto-initialization in your Pilot config:
+
+```yaml
+# ~/.pilot/config.yaml
+executor:
+  navigator:
+    auto_init: true                # Enable auto-init (default: true)
+    templates_path: "/custom/path" # Override template location (optional)
+```
+
+<Callout type="info">
+Auto-init is enabled by default. If you manage `.agent/` manually or use a custom Navigator setup, disable it with `auto_init: false`.
+</Callout>
+
+### Custom Templates
+
+If `templates_path` is set, Pilot uses templates from that directory instead of built-in ones.
+This is useful for organizations that want standardized Navigator setup across all projects.
+
 ## Custom Setup
 
 For projects that need a tailored context structure, initialize manually:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1417.

Closes #1417

## Changes

GitHub Issue #1417: docs: add Navigator Auto-Init section to setup page

## Task

Update the existing Navigator setup page at `docs/content/navigator/setup.mdx` to add a section documenting the Auto-Initialization feature.

## Context

Navigator auto-init (v0.33.16) automatically creates the `.agent/` directory structure on first task execution for projects that don't have it. It detects tech stack from project files and populates templates. Currently only mentioned as a config field without explanation.

## Requirements

### Update: `docs/content/navigator/setup.mdx`

Add a new **H2: Auto-Initialization** section. Place it early in the page (after the manual setup section, before advanced configuration).

**Content to add:**

1. **H2: Auto-Initialization** — Opening: Pilot can automatically set up Navigator for new projects on the first task execution.

2. **H3: What Gets Created** — Directory tree:
   ```
   .agent/
   ├── DEVELOPMENT-README.md     # Project-specific navigator guide
   ├── .nav-config.json          # Navigator configuration
   ├── .gitignore                # Excludes session-specific files
   ├── tasks/                    # Implementation plans
   ├── system/                   # Architecture docs
   └── sops/                     # Standard operating procedures
       ├── integrations/
       ├── debugging/
       ├── development/
       └── deployment/
   ```

3. **H3: Tech Stack Detection** — Pilot auto-detects your technology stack:
   | File | Detected Stack |
   |------|---------------|
   | `go.mod` | Go + detected frameworks (Gin, Gorilla, Fiber) + ORMs (GORM) |
   | `package.json` | Node.js + frameworks (Next.js, React, Vue, Express) + TypeScript |
   | `pyproject.toml` | Python + frameworks (FastAPI, Django, Flask) |
   | `Cargo.toml` | Rust + frameworks (Actix, Axum) |
   | (none found) | Uses directory name as project identifier |

4. **H3: Template Variables** — Templates use these placeholders:
   | Variable | Value |
   |----------|-------|
   | `${PROJECT_NAME}` | Detected project name (Title Case) |
   | `${project_name}` | Snake_case project name |
   | `${TECH_STACK}` | Detected technology stack string |
   | `${DATE}` | Current date |
   | `${YEAR}` | Current year |

5. **H3: Configuration**
   ```yaml
   executor:
     navigator:
       auto_init: true                # Enable auto-init (default: true)
       templates_path: "/custom/path" # Override template location (optional)
   ```

   <Callout type="info">
   Auto-init is enabled by default. If you manage `.agent/` manually or use a custom Navigator setup, disable it with `auto_init: false`.
   </Callout>

6. **H3: Custom Templates** — If `templates_path` is set, Pilot uses templates from that directory instead of built-in ones. Useful for organizations that want standardized Navigator setup across all projects.

## Source Files

- `internal/executor/navigator.go` — IsInitialized(), auto-init logic, tech stack detection, template rendering

## Style Guide

- Page already imports `Callout` — no new imports needed
- Match existing heading hierarchy
- Do NOT modify existing content — insert new section in logical position