### PR TITLE
docs: update homepage feature count and configuration reference

### DIFF
--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -221,7 +221,7 @@ executor:
 | `timeout.simple` | duration | `10m` | Timeout for simple tasks |
 | `timeout.medium` | duration | `30m` | Timeout for medium tasks |
 | `timeout.complex` | duration | `60m` | Timeout for complex tasks |
-| `decompose.enabled` | bool | `false` | Auto-decompose complex tasks into subtasks |
+| `decompose.enabled` | bool | `false` | Auto-decompose complex tasks into subtasks ([learn more](/features/epic-decomposition)) |
 | `decompose.min_complexity` | string | `"complex"` | Minimum complexity to trigger decomposition |
 | `decompose.max_subtasks` | int | `5` | Maximum subtasks created (2-10) |
 | `decompose.min_description_words` | int | `50` | Minimum description words to decompose |
@@ -259,6 +259,96 @@ executor:
 | `opencode.provider` | string | `"anthropic"` | LLM provider name |
 | `opencode.auto_start_server` | bool | `true` | Auto-start OpenCode server if not running |
 | `opencode.server_command` | string | `"opencode serve"` | Command to start the server |
+
+### Hooks
+
+Claude Code hooks provide inline quality gates during task execution.
+
+```yaml
+executor:
+  hooks:
+    enabled: false             # Enable Claude Code hooks
+    run_tests_on_stop: true    # Stop gate: run tests before completion
+    block_destructive: true    # PreToolUse: block destructive Bash commands
+    lint_on_save: false        # PostToolUse: run linter after file edits
+```
+
+[Learn more about hooks →](/features/hooks)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `hooks.enabled` | bool | `false` | Enable Claude Code hooks |
+| `hooks.run_tests_on_stop` | bool | `true` | Stop hook runs tests before completion |
+| `hooks.block_destructive` | bool | `true` | PreToolUse hook blocks dangerous commands |
+| `hooks.lint_on_save` | bool | `false` | PostToolUse hook runs linter after file changes |
+
+### Stagnation Monitor
+
+Detects when tasks are stuck in loops or making no progress.
+
+```yaml
+executor:
+  stagnation:
+    enabled: false
+    warn_timeout: 10m
+    pause_timeout: 20m
+    abort_timeout: 30m
+    warn_at_iteration: 8
+    pause_at_iteration: 12
+    abort_at_iteration: 15
+    state_history_size: 5
+    identical_states_threshold: 3
+    grace_period: 30s
+    commit_partial_work: true
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `stagnation.enabled` | bool | `false` | Enable stagnation detection |
+| `stagnation.warn_timeout` | duration | `10m` | Time before warning alert |
+| `stagnation.pause_timeout` | duration | `20m` | Time before pausing execution |
+| `stagnation.abort_timeout` | duration | `30m` | Time before aborting task |
+| `stagnation.warn_at_iteration` | int | `8` | Iteration count before warning |
+| `stagnation.pause_at_iteration` | int | `12` | Iteration count before pausing |
+| `stagnation.abort_at_iteration` | int | `15` | Iteration count before aborting |
+| `stagnation.state_history_size` | int | `5` | Size of state history for loop detection |
+| `stagnation.identical_states_threshold` | int | `3` | Identical states needed to detect loop |
+| `stagnation.grace_period` | duration | `30s` | Grace period after intervention |
+| `stagnation.commit_partial_work` | bool | `true` | Commit partial progress before aborting |
+
+### Claude Code SDK Features
+
+Advanced Claude Code backend features for session management and structured output.
+
+```yaml
+executor:
+  claude_code:
+    use_session_resume: false    # Reuse session for self-review
+    use_from_pr: false           # Resume PR context for CI fixes
+    use_structured_output: false # Machine-readable classifier output
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `claude_code.use_session_resume` | bool | `false` | Reuse session for self-review (~40% token savings) |
+| `claude_code.use_from_pr` | bool | `false` | Resume PR context for autopilot CI fixes |
+| `claude_code.use_structured_output` | bool | `false` | Enable structured JSON output for classifiers |
+
+### Navigator Auto-Init
+
+Automatically initialize Navigator documentation structure for projects.
+
+```yaml
+executor:
+  navigator:
+    auto_init: true
+    templates_path: ""          # Optional custom templates path
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `navigator.auto_init` | bool | `true` | Auto-create .agent/ on first task execution |
+| `navigator.templates_path` | string | `""` | Override plugin templates location |
 
 ### Worktree Isolation
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -9,7 +9,7 @@
 
 **AI that ships your tickets while you focus on architecture.**
 
-Pilot is an autonomous development pipeline. It picks up tickets from GitHub Issues, GitLab Issues, Linear, Jira, or Asana — plans the implementation using your codebase context, writes code with Claude Code, runs quality gates, and opens a pull request. You review and merge.
+Pilot is an autonomous development pipeline with **156 features** production-ready. It picks up tickets from GitHub Issues, GitLab Issues, Linear, Jira, or Asana — plans the implementation using your codebase context, writes code with Claude Code, runs quality gates, and opens a pull request. You review and merge.
 
 {/* ILLUSTRATION: Hero — Ticket → Pilot → PR flow diagram */}
 
@@ -79,7 +79,10 @@ Single Go binary. Runs on your infrastructure. Your secrets never leave your env
 | **Telegram Bot** | Chat, research, plan, and execute tasks from mobile |
 | **Quality Gates** | Test, lint, and build gates with automatic retry |
 | **Self-Review** | Code review runs before PR push |
-| **Epic Decomposition** | Complex tickets automatically split into subtasks |
+| **Epic Decomposition** | Complex tickets automatically split into subtasks ([learn more](/features/epic-decomposition)) |
+| **Claude Code Hooks** | Inline quality gates — stop gates, destructive command blocking |
+| **Multi-repo polling** | Manage multiple repositories from a single instance |
+| **Session Resume** | 40% token savings on self-review via context continuation |
 | **Model Routing** | Trivial tasks use fast models, complex tasks use deep reasoning |
 | **Dashboard** | Terminal UI with token usage, costs, and task history |
 | **Hot Upgrade** | Self-update without downtime, in-process binary replacement |


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1418.

Closes #1418

## Changes

GitHub Issue #1418: docs: update homepage feature count and configuration reference

## Task

Update the homepage (`docs/content/index.mdx`) and configuration reference (`docs/content/getting-started/configuration.mdx`) to reflect all 156 features and include newly documented config keys.

## Context

The homepage may show outdated feature counts, and the configuration reference is missing config keys for features added in v0.56.0–v1.27.0 (hooks, stagnation, SDK features, decomposition, navigator auto-init).

## Requirements

### Update: `docs/content/index.mdx`

1. Update any feature count references to **156 features**
2. If there's a feature grid/highlights section, ensure these are mentioned:
   - Epic Decomposition — automatic task splitting
   - Claude Code Hooks — inline quality gates
   - Multi-repo polling — manage multiple repos
   - Session Resume — 40% token savings on self-review
3. Cross-link to the new docs pages where relevant

### Update: `docs/content/getting-started/configuration.mdx`

Add or verify the following config keys are documented in the configuration reference:

1. **Hooks configuration:**
   ```yaml
   executor:
     hooks:
       enabled: false             # Enable Claude Code hooks
       run_tests_on_stop: true    # Stop gate: run tests before completion
       block_destructive: true    # PreToolUse: block destructive Bash commands
       lint_on_save: false        # PostToolUse: run linter after file edits
   ```

2. **Stagnation monitor:**
   ```yaml
   executor:
     stagnation:
       enabled: false
       warn_timeout: 10m
       pause_timeout: 20m
       abort_timeout: 30m
       warn_at_iteration: 8
       pause_at_iteration: 12
       abort_at_iteration: 15
       state_history_size: 5
       identical_states_threshold: 3
       grace_period: 30s
       commit_partial_work: true
   ```

3. **SDK features:**
   ```yaml
   executor:
     claude_code:
       use_session_resume: false    # Reuse session for self-review
       use_from_pr: false           # Resume PR context for CI fixes
       use_structured_output: false # Machine-readable classifier output
   ```

4. **Decomposition:**
   ```yaml
   executor:
     decompose:
       enabled: false
       min_complexity: "complex"
       max_subtasks: 5
       min_description_words: 50
   ```

5. **Navigator auto-init:**
   ```yaml
   executor:
     navigator:
       auto_init: true
       templates_path: ""          # Optional custom templates path
   ```

For each config section, add a brief one-line description of what it controls and link to the detailed feature page.

## Source Files

- `internal/config/config.go` — All config struct definitions
- `docs/content/index.mdx` — Homepage
- `docs/content/getting-started/configuration.mdx` — Config reference

## Style Guide

- Match existing page patterns
- Config sections should have brief descriptions + link to feature page
- Don't restructure existing content — add missing sections

## Planned Steps (execute all in sequence)

1. **Update homepage feature highlights (`docs/content/index.mdx`)** — Update any feature count references to 156 features. Add missing highlights to the Core Features table: Claude Code Hooks (inline quality gates), Multi-repo polling (manage multiple repos), and Session Resume (40% token savings on self-review). Add cross-links to feature pages where they exist (`/features/hooks`, `/features/epic-decomposition`). The homepage currently has no explicit numeric "156 features" claim, so add a brief count callout or work it into the hero copy.
2. **Add executor config sections to configuration reference (`docs/content/getting-started/configuration.mdx`) - Add five missing config sections to the Executor area of the configuration reference, each with a YAML example block, a brief one-line description, and a link to the relevant feature page (where one exists). Sections to add: (a) Hooks configuration (`executor.hooks`), (b) Stagnation monitor (`executor.stagnation`), (c) Claude Code SDK features (`executor.claude_code`** — `use_session_resume`, `use_from_pr`, `use_structured_output`), (d) Navigator auto-init (`executor.navigator`). The Decompose section already exists in the config reference, so verify it matches the issue spec and add any missing fields/links. Place new sections after the existing Executor section and before the Worktree Isolation subsection. Match the existing pattern: heading, one-line description, YAML block, field reference table, link to feature page.
