### PR TITLE
Update Navigator docs for v1.28.0–v1.39.0 features

### DIFF
--- a/.agent/DEVELOPMENT-README.md
+++ b/.agent/DEVELOPMENT-README.md
@@ -113,7 +113,7 @@ Disable via config: `executor.navigator.auto_init: false`
 
 ## Current State
 
-**Current Version:** v1.27.0 | **156 features working**
+**Current Version:** v1.39.0 | **159 features working**
 
 **Full implementation status:** `.agent/system/FEATURE-MATRIX.md`
 
@@ -187,6 +187,9 @@ Disable via config: `executor.navigator.auto_init: false`
 | Navigator Docs Update | Done | Auto-update feature matrix + knowledge capture post-execution (v1.19.0) |
 | Adapter State Transitions | Done | Transition Linear/Jira/Asana issues to Done on success (v1.19.0) |
 | Jira/Asana Autopilot Wire | Done | Wire OnPRCreated for Jira + Asana, add HeadSHA/BranchName (v1.19.0) |
+| URL-Encode Branch Names | Done | `url.PathEscape(branch)` in DeleteBranch/GetBranch — fixes 404 on slash branches (v1.28.0) |
+| Branch Cleanup on PR Close | Done | Delete remote branches on PR close/fail, not just merge (v1.35.0) |
+| Backend-Aware Preflight | Done | Preflight CLI check matches configured backend (claude/opencode/qwen) (v1.39.0) |
 
 ### Telegram Interaction Modes (v0.6.0)
 
@@ -298,6 +301,9 @@ Nextra 4 migration (PR #1409) + 8 docs pages covering all 156 features:
 
 | Item | What |
 |------|------|
+| **v1.39.0** | Backend-aware preflight checks: `PreflightOptions.BackendType` matches configured backend (claude/opencode/qwen) instead of hardcoding `claude` (GH-1483 — @kegesch contribution) |
+| **v1.35.0** | Delete branches on PR close/fail: `removePR()` in autopilot controller now calls `DeleteBranch()` for all PR removal paths, not just merged PRs |
+| **v1.28.0** | URL-encode branch names: `DeleteBranch()` and `GetBranch()` use `url.PathEscape(branch)` — fixes silent 404 on branch names with slashes (GH-1383 fix) |
 | **Docs refresh** | 8 issues (GH-1411–1418) all merged — epic decomp, hooks, multi-repo, signal parser, SDK features, stagnation, auto-init, config ref. 60 pages total. |
 | **Nextra 4** | Docs site migrated from Nextra 2 to Nextra 4 (App Router) — PR #1409, GH-1407 closed |
 | **v1.27.0** | Harden GH-1388: dedup modifiedFiles, case-insensitive feat( check, robust table insertion (no anchor dependency) |

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-02-14 (v1.0.0)
+**Last Updated:** 2026-02-17 (v1.39.0)
 
 ## Legend
 
@@ -40,6 +40,7 @@
 | Acceptance criteria | ✅ | executor | - | - | Extract from issue body, include in prompts (v0.51.0) |
 | Worktree isolation | ✅ | executor | - | `executor.use_worktree` | Execute in git worktree, allows uncommitted changes (v0.53.2) |
 | Signal parser v2 | ✅ | executor | - | - | JSON pilot-signal blocks with validation (v0.56.0) |
+| Backend-aware preflight | ✅ | executor | - | `executor.backend` | Preflight CLI check matches configured backend (claude/opencode/qwen) (v1.39.0) |
 
 ## Intelligence
 
@@ -216,6 +217,8 @@
 | GitHub API retry | ✅ | adapters/github | - | - | Exponential backoff, Retry-After header respect (v0.34.0) |
 | CI auto-discovery | ✅ | autopilot | - | - | Auto-detect check names from GitHub API (v0.41.0) |
 | Stagnation monitor | ✅ | executor | - | - | State hash tracking, escalation: warn → pause → abort (v0.56.0) |
+| URL-encode branch names | ✅ | adapters/github | - | - | `url.PathEscape(branch)` in DeleteBranch/GetBranch — fixes 404 on slash branches (v1.28.0) |
+| Branch cleanup on PR close | ✅ | autopilot | - | - | Delete remote branches on PR close/fail, not just merge (v1.35.0) |
 
 ## Epic Management
 
@@ -246,7 +249,7 @@
 
 | Category | ✅ Working | ⚠️ Implemented | 🚧 Partial | ❌ Missing |
 |----------|-----------|----------------|-----------|-----------|
-| Core Execution | 22 | 0 | 0 | 0 |
+| Core Execution | 23 | 0 | 0 | 0 |
 | Intelligence | 8 | 0 | 0 | 0 |
 | Input Adapters | 15 | 0 | 0 | 0 |
 | Output/Notifications | 5 | 0 | 0 | 0 |
@@ -260,10 +263,10 @@
 | Team Management | 3 | 0 | 0 | 0 |
 | Infrastructure | 8 | 0 | 0 | 0 |
 | Approval Workflows | 4 | 0 | 0 | 0 |
-| Autopilot | 17 | 0 | 0 | 0 |
+| Autopilot | 19 | 0 | 0 | 0 |
 | Self-Management | 6 | 0 | 0 | 0 |
 | Epic Management | 1 | 0 | 0 | 0 |
-| **Total** | **134** | **0** | **0** | **0** |
+| **Total** | **137** | **0** | **0** | **0** |
 
 ---
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1484.

Closes #1484

## Changes

GitHub Issue #1484: Update Navigator docs for v1.28.0–v1.39.0 features

## Context

Several features and fixes were shipped directly between v1.28.0 and v1.39.0. Navigator docs need updating.

## Changes to document

### v1.28.0 — URL-encode branch names (GH-1383 fix)
- `DeleteBranch()` and `GetBranch()` in `internal/adapters/github/client.go` now use `url.PathEscape(branch)` 
- Branch names with slashes (e.g. `pilot/GH-123`) were silently failing — GitHub API returned 404, error handler swallowed it
- Add to Known Bug Patterns section (resolved)

### v1.35.0 — Delete branches on PR close/fail
- `removePR()` in `internal/autopilot/controller.go` now calls `DeleteBranch()` for all PR removal paths
- Previously only merged PRs had branches deleted; closed/conflicting PRs left stale branches
- Add to Autopilot section and feature matrix

### v1.39.0 — Backend-aware preflight checks (GH-1483)
- `PreflightOptions.BackendType` in `internal/executor/preflight.go`
- Preflight CLI check now matches configured backend (claude/opencode/qwen) instead of hardcoding `claude`
- Community contribution fix from @kegesch
- Add to feature matrix

## Files to update
- `.agent/DEVELOPMENT-README.md` — Completed Log (2026-02-17 section), Current Version to v1.39.0, feature count
- `.agent/system/FEATURE-MATRIX.md` — Add new features if not already listed

## Important
Do NOT decompose this into sub-issues. Single PR with all doc updates.