### PR TITLE
Add Sonnet 4.6 to model routing defaults

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -136,6 +136,14 @@ executor:
   #   medium: "high"             # Standard (default behavior)
   #   complex: "max"             # Deepest reasoning (Opus 4.6 only)
 
+  # Model routing - select model by task complexity
+  # model_routing:
+  #   enabled: true
+  #   trivial: "claude-haiku"           # Typos, renames ($1/$5 per MTok)
+  #   simple: "claude-sonnet-4-6"       # Small fixes, config ($3/$15 per MTok)
+  #   medium: "claude-sonnet-4-6"       # Features, endpoints ($3/$15 per MTok)
+  #   complex: "claude-opus-4-6"        # Refactors, migrations ($5/$25 per MTok)
+
   # Smart retry (GH-920) - retry on transient errors with backoff
   # retry:
   #   enabled: true

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -532,12 +532,17 @@ func DefaultBackendConfig() *BackendConfig {
 //   - Simple: Small fixes, add/remove fields, config updates
 //   - Medium: New endpoints, components, moderate refactoring
 //   - Complex: Architecture changes, multi-file refactors, migrations
+//
+// DefaultModelRoutingConfig returns default model routing configuration.
+// Model routing is disabled by default; when enabled, uses Haiku for trivial
+// tasks (speed), Sonnet 4.6 for simple/medium tasks (near-Opus quality at 40%
+// lower cost), and Opus 4.6 for complex tasks (highest capability).
 func DefaultModelRoutingConfig() *ModelRoutingConfig {
 	return &ModelRoutingConfig{
 		Enabled: false,
 		Trivial: "claude-haiku",
-		Simple:  "claude-opus-4-6",
-		Medium:  "claude-opus-4-6",
+		Simple:  "claude-sonnet-4-6",
+		Medium:  "claude-sonnet-4-6",
 		Complex: "claude-opus-4-6",
 	}
 }

--- a/internal/executor/model_routing_test.go
+++ b/internal/executor/model_routing_test.go
@@ -37,20 +37,20 @@ func TestModelRouter_SelectModel(t *testing.T) {
 			config: &ModelRoutingConfig{
 				Enabled: true,
 				Trivial: "claude-haiku",
-				Simple:  "claude-sonnet",
-				Medium:  "claude-sonnet",
+				Simple:  "claude-sonnet-4-6",
+				Medium:  "claude-sonnet-4-6",
 				Complex: "claude-opus",
 			},
 			task:     &Task{Description: "Add field to struct"},
-			expected: "claude-sonnet",
+			expected: "claude-sonnet-4-6",
 		},
 		{
 			name: "complex task returns opus",
 			config: &ModelRoutingConfig{
 				Enabled: true,
 				Trivial: "claude-haiku",
-				Simple:  "claude-sonnet",
-				Medium:  "claude-sonnet",
+				Simple:  "claude-sonnet-4-6",
+				Medium:  "claude-sonnet-4-6",
 				Complex: "claude-opus",
 			},
 			task:     &Task{Description: "Refactor the authentication system"},
@@ -170,8 +170,8 @@ func TestModelRouter_GetModelForComplexity(t *testing.T) {
 	config := &ModelRoutingConfig{
 		Enabled: true,
 		Trivial: "haiku",
-		Simple:  "sonnet",
-		Medium:  "sonnet",
+		Simple:  "claude-sonnet-4-6",
+		Medium:  "claude-sonnet-4-6",
 		Complex: "opus",
 	}
 	router := NewModelRouter(config, nil)
@@ -181,10 +181,10 @@ func TestModelRouter_GetModelForComplexity(t *testing.T) {
 		expected   string
 	}{
 		{ComplexityTrivial, "haiku"},
-		{ComplexitySimple, "sonnet"},
-		{ComplexityMedium, "sonnet"},
+		{ComplexitySimple, "claude-sonnet-4-6"},
+		{ComplexityMedium, "claude-sonnet-4-6"},
 		{ComplexityComplex, "opus"},
-		{Complexity("unknown"), "sonnet"}, // Default to medium
+		{Complexity("unknown"), "claude-sonnet-4-6"}, // Default to medium
 	}
 
 	for _, tt := range tests {

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -3338,7 +3338,7 @@ func isValidSHA(s string) bool {
 func estimateCost(inputTokens, outputTokens int64, model string) float64 {
 	// Model pricing in USD per 1M tokens
 	const (
-		// Sonnet 4.5/4
+		// Sonnet 4.6/4.5/4
 		sonnetInputPrice  = 3.00
 		sonnetOutputPrice = 15.00
 		// Opus 4.6/4.5 (same pricing)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1488.

Closes #1488

## Changes

GitHub Issue #1488: Add Sonnet 4.6 to model routing defaults

## Summary

Claude Sonnet 4.6 released Feb 17, 2026. Same price as Sonnet 4.5 ($3/$15 per MTok) but near-Opus quality — preferred over Opus 4.5 ~59% of the time in Claude Code testing, less overengineering. Update model routing defaults to use Sonnet 4.6 for simple/medium tasks (40% cost savings vs Opus).

Model ID: `claude-sonnet-4-6`

## Changes Required

### 1. `internal/executor/backend.go` (~line 535-543)

Update `DefaultModelRoutingConfig()` defaults and comment:

```go
// DefaultModelRoutingConfig returns default model routing configuration.
// Model routing is disabled by default; when enabled, uses Haiku for trivial
// tasks (speed), Sonnet 4.6 for simple/medium tasks (near-Opus quality at 40%
// lower cost), and Opus 4.6 for complex tasks (highest capability).
func DefaultModelRoutingConfig() *ModelRoutingConfig {
    return &ModelRoutingConfig{
        Enabled: false,
        Trivial: "claude-haiku",
        Simple:  "claude-sonnet-4-6",   // was claude-opus-4-6
        Medium:  "claude-sonnet-4-6",   // was claude-opus-4-6
        Complex: "claude-opus-4-6",
    }
}
```

### 2. `internal/executor/runner.go` (~line 3341)

Update cost estimation comment only (no logic change — `claude-sonnet-4-6` already falls through to sonnet pricing via `default` case):

```go
// Sonnet 4.6/4.5/4
sonnetInputPrice  = 3.00
sonnetOutputPrice = 15.00
```

### 3. `configs/pilot.example.yaml` (after effort_routing section, ~line 138)

Add commented model_routing section:

```yaml
  # Model routing - select model by task complexity
  # model_routing:
  #   enabled: true
  #   trivial: "claude-haiku"           # Typos, renames ($1/$5 per MTok)
  #   simple: "claude-sonnet-4-6"       # Small fixes, config ($3/$15 per MTok)
  #   medium: "claude-sonnet-4-6"       # Features, endpoints ($3/$15 per MTok)
  #   complex: "claude-opus-4-6"        # Refactors, migrations ($5/$25 per MTok)
```

### 4. `internal/executor/model_routing_test.go`

Update test model IDs in `TestModelRouter_SelectModel` and `TestModelRouter_GetModelForComplexity` to use `claude-sonnet-4-6` where tests currently use `claude-sonnet` as the sonnet-class model, reflecting the new defaults.

## Verification

```bash
make test
make lint
make build
```

## Acceptance Criteria

- [ ] `DefaultModelRoutingConfig()` returns `claude-sonnet-4-6` for Simple and Medium
- [ ] Cost estimation comment updated to mention Sonnet 4.6
- [ ] Example config shows model_routing section with Sonnet 4.6
- [ ] All existing tests pass with updated model IDs
- [ ] `make build` succeeds