### PR TITLE
Update stale model IDs to Sonnet 4.6 / Opus 4.6 across codebase

### DIFF
--- a/cmd/pilot/onboard_optional.go
+++ b/cmd/pilot/onboard_optional.go
@@ -53,7 +53,7 @@ func onboardAutopilot(state *OnboardState) error {
 	// Initialize autopilot config if needed
 	if cfg.Orchestrator == nil {
 		cfg.Orchestrator = &config.OrchestratorConfig{
-			Model:         "claude-sonnet-4-5-20250929",
+			Model:         "claude-sonnet-4-6",
 			MaxConcurrent: 2,
 		}
 	}
@@ -138,7 +138,7 @@ func onboardDailyBrief(state *OnboardState) error {
 	// Initialize daily brief config
 	if cfg.Orchestrator == nil {
 		cfg.Orchestrator = &config.OrchestratorConfig{
-			Model:         "claude-sonnet-4-5-20250929",
+			Model:         "claude-sonnet-4-6",
 			MaxConcurrent: 2,
 		}
 	}

--- a/cmd/pilot/setup.go
+++ b/cmd/pilot/setup.go
@@ -397,7 +397,7 @@ func setupBriefs(reader *bufio.Reader, cfg *config.Config) error {
 	// Initialize config
 	if cfg.Orchestrator == nil {
 		cfg.Orchestrator = &config.OrchestratorConfig{
-			Model:         "claude-sonnet-4-5-20250929",
+			Model:         "claude-sonnet-4-6",
 			MaxConcurrent: 2,
 		}
 	}

--- a/e2e/mocks/claude.go
+++ b/e2e/mocks/claude.go
@@ -135,7 +135,7 @@ cat << 'EVENTS'
 {"type":"assistant","subtype":"tool_use","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"."}}]}}
 {"type":"user","subtype":"tool_result","tool_use_result":{"content":"Directory listing..."}}
 {"type":"assistant","subtype":"text","message":{"content":[{"type":"text","text":"Implementing changes..."}]}}
-{"type":"result","subtype":"success","result":%s,"is_error":false,"duration_ms":1000,"num_turns":3,"usage":{"input_tokens":500,"output_tokens":200},"model":"claude-opus-4-5"}
+{"type":"result","subtype":"success","result":%s,"is_error":false,"duration_ms":1000,"num_turns":3,"usage":{"input_tokens":500,"output_tokens":200},"model":"claude-opus-4-6"}
 EVENTS
 exit 0
 `, string(resultJSON)))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,7 +246,7 @@ func DefaultConfig() *Config {
 			Asana:       asana.DefaultConfig(),
 		},
 		Orchestrator: &OrchestratorConfig{
-			Model:         "claude-sonnet-4-5-20250929",
+			Model:         "claude-sonnet-4-6",
 			MaxConcurrent: 2,
 			DailyBrief: &DailyBriefConfig{
 				Enabled:  false,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -68,8 +68,8 @@ func TestDefaultConfig(t *testing.T) {
 		if config.Orchestrator == nil {
 			t.Fatal("Orchestrator config is nil")
 		}
-		if config.Orchestrator.Model != "claude-sonnet-4-5-20250929" {
-			t.Errorf("Orchestrator.Model = %q, want %q", config.Orchestrator.Model, "claude-sonnet-4-5-20250929")
+		if config.Orchestrator.Model != "claude-sonnet-4-6" {
+			t.Errorf("Orchestrator.Model = %q, want %q", config.Orchestrator.Model, "claude-sonnet-4-6")
 		}
 		if config.Orchestrator.MaxConcurrent != 2 {
 			t.Errorf("Orchestrator.MaxConcurrent = %d, want %d", config.Orchestrator.MaxConcurrent, 2)

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -503,7 +503,7 @@ func DefaultBackendConfig() *BackendConfig {
 		},
 		OpenCode: &OpenCodeConfig{
 			ServerURL:       "http://127.0.0.1:4096",
-			Model:           "anthropic/claude-sonnet-4-5",
+			Model:           "anthropic/claude-sonnet-4-6",
 			Provider:        "anthropic",
 			AutoStartServer: true,
 			ServerCommand:   "opencode serve",

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -127,7 +127,7 @@ func TestClaudeCodeBackendParseStreamEvent(t *testing.T) {
 func TestClaudeCodeBackendParseUsageInfo(t *testing.T) {
 	backend := NewClaudeCodeBackend(nil)
 
-	line := `{"type":"result","result":"Done","usage":{"input_tokens":100,"output_tokens":50},"model":"claude-sonnet-4-5"}`
+	line := `{"type":"result","result":"Done","usage":{"input_tokens":100,"output_tokens":50},"model":"claude-sonnet-4-6"}`
 	event := backend.parseStreamEvent(line)
 
 	if event.TokensInput != 100 {
@@ -136,8 +136,8 @@ func TestClaudeCodeBackendParseUsageInfo(t *testing.T) {
 	if event.TokensOutput != 50 {
 		t.Errorf("TokensOutput = %d, want 50", event.TokensOutput)
 	}
-	if event.Model != "claude-sonnet-4-5" {
-		t.Errorf("Model = %q, want claude-sonnet-4-5", event.Model)
+	if event.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model = %q, want claude-sonnet-4-6", event.Model)
 	}
 }
 

--- a/internal/executor/backend_test.go
+++ b/internal/executor/backend_test.go
@@ -32,7 +32,7 @@ func TestBackendEvent(t *testing.T) {
 		ToolInput:    map[string]interface{}{"file_path": "/test.go"},
 		TokensInput:  100,
 		TokensOutput: 50,
-		Model:        "claude-sonnet-4-5",
+		Model:        "claude-sonnet-4-6",
 	}
 
 	if event.Type != EventTypeToolUse {
@@ -52,7 +52,7 @@ func TestBackendResult(t *testing.T) {
 		Output:       "Task completed",
 		TokensInput:  1000,
 		TokensOutput: 500,
-		Model:        "claude-sonnet-4-5",
+		Model:        "claude-sonnet-4-6",
 	}
 
 	if !result.Success {

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1294,7 +1294,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 			result.TokensTotal = state.tokensInput + state.tokensOutput
 			result.ModelName = state.modelName
 			if result.ModelName == "" {
-				result.ModelName = "claude-opus-4-5"
+				result.ModelName = "claude-opus-4-6"
 			}
 			result.EstimatedCostUSD = estimateCost(result.TokensInput, result.TokensOutput, result.ModelName)
 			log.Warn("Task cancelled due to per-task budget limit",
@@ -1613,7 +1613,7 @@ retrySucceeded:
 		result.ModelName = state.modelName
 	}
 	if result.ModelName == "" {
-		result.ModelName = "claude-opus-4-5" // Default model
+		result.ModelName = "claude-opus-4-6" // Default model
 	}
 	// Estimate cost based on token usage (including research tokens)
 	result.EstimatedCostUSD = estimateCost(result.TokensInput+result.ResearchTokens, result.TokensOutput, result.ModelName)

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -615,7 +615,7 @@ func TestExecutionResultStruct(t *testing.T) {
 		FilesChanged:     3,
 		LinesAdded:       100,
 		LinesRemoved:     20,
-		ModelName:        "claude-sonnet-4-5",
+		ModelName:        "claude-sonnet-4-6",
 	}
 
 	if result.TaskID != "TASK-123" {
@@ -645,7 +645,7 @@ func TestEstimateCost(t *testing.T) {
 			name:         "sonnet zero tokens",
 			inputTokens:  0,
 			outputTokens: 0,
-			model:        "claude-sonnet-4-5",
+			model:        "claude-sonnet-4-6",
 			minCost:      0,
 			maxCost:      0,
 		},
@@ -653,7 +653,7 @@ func TestEstimateCost(t *testing.T) {
 			name:         "sonnet 1M input tokens",
 			inputTokens:  1000000,
 			outputTokens: 0,
-			model:        "claude-sonnet-4-5",
+			model:        "claude-sonnet-4-6",
 			minCost:      2.9,
 			maxCost:      3.1,
 		},
@@ -661,7 +661,7 @@ func TestEstimateCost(t *testing.T) {
 			name:         "sonnet 1M output tokens",
 			inputTokens:  0,
 			outputTokens: 1000000,
-			model:        "claude-sonnet-4-5",
+			model:        "claude-sonnet-4-6",
 			minCost:      14.9,
 			maxCost:      15.1,
 		},
@@ -685,7 +685,7 @@ func TestEstimateCost(t *testing.T) {
 			name:         "opus 4.5 1M input tokens (same as 4.6)",
 			inputTokens:  1000000,
 			outputTokens: 0,
-			model:        "claude-opus-4-5",
+			model:        "claude-opus-4-6",
 			minCost:      4.9,
 			maxCost:      5.1,
 		},
@@ -693,7 +693,7 @@ func TestEstimateCost(t *testing.T) {
 			name:         "opus 4.5 1M output tokens (same as 4.6)",
 			inputTokens:  0,
 			outputTokens: 1000000,
-			model:        "claude-opus-4-5",
+			model:        "claude-opus-4-6",
 			minCost:      24.9,
 			maxCost:      25.1,
 		},
@@ -717,7 +717,7 @@ func TestEstimateCost(t *testing.T) {
 			name:         "mixed usage sonnet",
 			inputTokens:  100000,
 			outputTokens: 50000,
-			model:        "claude-sonnet-4-5",
+			model:        "claude-sonnet-4-6",
 			minCost:      1.0,
 			maxCost:      1.1, // 0.3 + 0.75
 		},
@@ -944,7 +944,7 @@ func TestProgressStateStruct(t *testing.T) {
 		commitSHAs:   []string{"abc1234", "def5678"},
 		tokensInput:  1000,
 		tokensOutput: 500,
-		modelName:    "claude-sonnet-4-5",
+		modelName:    "claude-sonnet-4-6",
 	}
 
 	if state.phase != "Implementing" {
@@ -1284,7 +1284,7 @@ func TestParseStreamEventUsageTracking(t *testing.T) {
 	state := &progressState{phase: "Starting"}
 
 	// Event with usage info
-	jsonEvent := `{"type":"assistant","message":{"content":[]},"usage":{"input_tokens":100,"output_tokens":50},"model":"claude-sonnet-4-5"}`
+	jsonEvent := `{"type":"assistant","message":{"content":[]},"usage":{"input_tokens":100,"output_tokens":50},"model":"claude-sonnet-4-6"}`
 
 	runner.parseStreamEvent("TASK-1", jsonEvent, state)
 
@@ -1294,8 +1294,8 @@ func TestParseStreamEventUsageTracking(t *testing.T) {
 	if state.tokensOutput != 50 {
 		t.Errorf("tokensOutput = %d, want 50", state.tokensOutput)
 	}
-	if state.modelName != "claude-sonnet-4-5" {
-		t.Errorf("modelName = %q, want claude-sonnet-4-5", state.modelName)
+	if state.modelName != "claude-sonnet-4-6" {
+		t.Errorf("modelName = %q, want claude-sonnet-4-6", state.modelName)
 	}
 }
 
@@ -1355,7 +1355,7 @@ func TestStreamEventStructs(t *testing.T) {
 			InputTokens:  100,
 			OutputTokens: 50,
 		},
-		Model: "claude-sonnet-4-5",
+		Model: "claude-sonnet-4-6",
 	}
 
 	if event.Type != "assistant" {
@@ -1472,7 +1472,7 @@ func TestProcessBackendEventTokenTracking(t *testing.T) {
 	events := []BackendEvent{
 		{Type: EventTypeText, TokensInput: 100, TokensOutput: 50},
 		{Type: EventTypeText, TokensInput: 200, TokensOutput: 100},
-		{Type: EventTypeResult, TokensInput: 50, TokensOutput: 25, Model: "claude-sonnet-4-5"},
+		{Type: EventTypeResult, TokensInput: 50, TokensOutput: 25, Model: "claude-sonnet-4-6"},
 	}
 
 	for _, event := range events {
@@ -1488,8 +1488,8 @@ func TestProcessBackendEventTokenTracking(t *testing.T) {
 	if state.tokensOutput != expectedOutput {
 		t.Errorf("tokensOutput = %d, want %d", state.tokensOutput, expectedOutput)
 	}
-	if state.modelName != "claude-sonnet-4-5" {
-		t.Errorf("modelName = %q, want claude-sonnet-4-5", state.modelName)
+	if state.modelName != "claude-sonnet-4-6" {
+		t.Errorf("modelName = %q, want claude-sonnet-4-6", state.modelName)
 	}
 }
 

--- a/internal/memory/metering_test.go
+++ b/internal/memory/metering_test.go
@@ -266,7 +266,7 @@ func TestRecordUsageEvent_Metadata(t *testing.T) {
 		Metadata: map[string]interface{}{
 			"input_tokens":  10000,
 			"output_tokens": 5000,
-			"model":         "claude-sonnet-4-5",
+			"model":         "claude-sonnet-4-6",
 		},
 	}
 

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -216,7 +216,7 @@ func TestExecution_FullLifecycle(t *testing.T) {
 		FilesChanged:     5,
 		LinesAdded:       100,
 		LinesRemoved:     20,
-		ModelName:        "claude-sonnet-4-5",
+		ModelName:        "claude-sonnet-4-6",
 	}
 
 	// Save

--- a/internal/replay/export_test.go
+++ b/internal/replay/export_test.go
@@ -10,7 +10,7 @@ func TestExportHTMLReport(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	recorder, _ := NewRecorder("TASK-REPORT", "/test/project", tmpDir)
-	recorder.SetModel("claude-sonnet-4-5")
+	recorder.SetModel("claude-sonnet-4-6")
 	recorder.SetBranch("feature/test")
 	recorder.SetNavigator(true)
 
@@ -95,7 +95,7 @@ func TestExportToMarkdown(t *testing.T) {
 
 	recorder, _ := NewRecorder("TASK-MD", "/test/project", tmpDir)
 	recorder.SetBranch("test-branch")
-	recorder.SetModel("claude-sonnet-4-5")
+	recorder.SetModel("claude-sonnet-4-6")
 	recorder.SetNavigator(true)
 
 	events := []string{
@@ -345,7 +345,7 @@ func TestRenderHTMLSummary(t *testing.T) {
 			EstimatedCostUSD: 0.0245,
 		},
 		Metadata: &Metadata{
-			ModelName:    "claude-sonnet-4-5",
+			ModelName:    "claude-sonnet-4-6",
 			HasNavigator: true,
 		},
 	}

--- a/internal/replay/player_test.go
+++ b/internal/replay/player_test.go
@@ -431,7 +431,7 @@ func TestFormatReport(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	recorder, _ := NewRecorder("TASK-REPORT", "/test/project", tmpDir)
-	recorder.SetModel("claude-sonnet-4-5")
+	recorder.SetModel("claude-sonnet-4-6")
 
 	events := []string{
 		`{"type":"system","subtype":"init"}`,

--- a/internal/replay/recorder_test.go
+++ b/internal/replay/recorder_test.go
@@ -98,7 +98,7 @@ func TestSetMetadata(t *testing.T) {
 	recorder.SetCommitSHA("abc1234")
 	recorder.SetPRUrl("https://github.com/test/pr/123")
 	recorder.SetNavigator(true)
-	recorder.SetModel("claude-sonnet-4-5")
+	recorder.SetModel("claude-sonnet-4-6")
 	recorder.SetMetadata("custom_key", "custom_value")
 
 	if err := recorder.Finish("completed"); err != nil {
@@ -119,7 +119,7 @@ func TestSetMetadata(t *testing.T) {
 	if !recording.Metadata.HasNavigator {
 		t.Error("HasNavigator should be true")
 	}
-	if recording.Metadata.ModelName != "claude-sonnet-4-5" {
+	if recording.Metadata.ModelName != "claude-sonnet-4-6" {
 		t.Errorf("ModelName mismatch: %s", recording.Metadata.ModelName)
 	}
 	if recording.Metadata.Tags["custom_key"] != "custom_value" {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1490.

Closes #1490

## Changes

GitHub Issue #1490: Update stale model IDs to Sonnet 4.6 / Opus 4.6 across codebase

## Summary

Multiple files still reference `claude-sonnet-4-5-20250929` and `claude-opus-4-5` as defaults. These should be updated to `claude-sonnet-4-6` and `claude-opus-4-6` respectively, following the v1.40.0 model routing update (GH-1488).

## Production Code Changes

### 1. `internal/config/config.go` (line 249)
```go
// Change:
Model: "claude-sonnet-4-5-20250929",
// To:
Model: "claude-sonnet-4-6",
```

### 2. `cmd/pilot/setup.go` (line 400)
```go
// Change:
Model: "claude-sonnet-4-5-20250929",
// To:
Model: "claude-sonnet-4-6",
```

### 3. `cmd/pilot/onboard_optional.go` (lines 56, 141)
```go
// Change both occurrences:
Model: "claude-sonnet-4-5-20250929",
// To:
Model: "claude-sonnet-4-6",
```

### 4. `internal/executor/runner.go` (lines 1297, 1616)
```go
// Change both occurrences:
result.ModelName = "claude-opus-4-5"
// To:
result.ModelName = "claude-opus-4-6"
```

### 5. `internal/executor/backend.go` (line 506)
```go
// Change:
Model: "anthropic/claude-sonnet-4-5",
// To:
Model: "anthropic/claude-sonnet-4-6",
```

## Test Code Changes

Update model ID strings in test files to match new production defaults:

### 6. `internal/config/config_test.go` (lines 71-72)
Change assertion from `"claude-sonnet-4-5-20250929"` to `"claude-sonnet-4-6"`.

### 7. `internal/executor/runner_test.go`
Replace all `"claude-sonnet-4-5"` with `"claude-sonnet-4-6"` and `"claude-opus-4-5"` with `"claude-opus-4-6"` (~15 occurrences).

### 8. `internal/executor/backend_test.go` (lines 35, 55)
Replace `"claude-sonnet-4-5"` with `"claude-sonnet-4-6"` (2 occurrences).

### 9. `internal/executor/backend_claudecode_test.go` (lines 130, 139, 140)
Replace `"claude-sonnet-4-5"` with `"claude-sonnet-4-6"` (3 occurrences).

### 10. `internal/replay/*_test.go`
Replace `"claude-sonnet-4-5"` with `"claude-sonnet-4-6"` in `player_test.go`, `export_test.go`, `recorder_test.go` (5 occurrences).

### 11. `internal/memory/metering_test.go` (line 269) and `store_test.go` (line 219)
Replace `"claude-sonnet-4-5"` with `"claude-sonnet-4-6"` (2 occurrences).

### 12. `e2e/mocks/claude.go` (line 138)
Replace `"claude-opus-4-5"` with `"claude-opus-4-6"` (1 occurrence).

## DO NOT change

- `internal/memory/store.go:143` — SQLite migration default (historical, must stay)
- `internal/memory/metrics.go:130` — already `claude-opus-4-6`
- `internal/executor/model_routing_test.go` — already updated in GH-1488

## Verification

```bash
make test
make lint
make build
```

## Acceptance Criteria

- [ ] No remaining references to `claude-sonnet-4-5-20250929` in Go files (except store.go migration)
- [ ] No remaining references to `claude-opus-4-5` in Go files (except store.go migration)
- [ ] `make test` passes
- [ ] `make build` succeeds