### PR TITLE
Fix git graph: calculate visible lines from panel height

### DIFF
--- a/internal/dashboard/gitgraph_test.go
+++ b/internal/dashboard/gitgraph_test.go
@@ -483,6 +483,7 @@ func TestModelUpdate_ScrollWhenFocused(t *testing.T) {
 	m.gitGraphMode = GitGraphFull
 	m.gitGraphFocus = true
 	m.gitGraphScroll = 5
+	m.height = 40 // viewport = 35
 	m.gitGraphState = &GitGraphState{
 		Lines: make([]GitGraphLine, 50),
 	}
@@ -508,6 +509,7 @@ func TestModelUpdate_ScrollBoundaries(t *testing.T) {
 	m.gitGraphMode = GitGraphFull
 	m.gitGraphFocus = true
 	m.gitGraphScroll = 0
+	m.height = 8 // viewport = 3
 	m.gitGraphState = &GitGraphState{
 		Lines: make([]GitGraphLine, 5),
 	}
@@ -519,12 +521,12 @@ func TestModelUpdate_ScrollBoundaries(t *testing.T) {
 		t.Errorf("scroll should stay at 0, got %d", m.gitGraphScroll)
 	}
 
-	// Can't scroll down past len-1
-	m.gitGraphScroll = 4
+	// maxScroll = 5 - 3 = 2; can't scroll past that
+	m.gitGraphScroll = 2
 	updated, _ = m.Update(makeKey("j"))
 	m = updated.(Model)
-	if m.gitGraphScroll != 4 {
-		t.Errorf("scroll should stay at 4 (max), got %d", m.gitGraphScroll)
+	if m.gitGraphScroll != 2 {
+		t.Errorf("scroll should stay at 2 (max), got %d", m.gitGraphScroll)
 	}
 }
 
@@ -555,18 +557,19 @@ func TestModelUpdate_HalfPageScroll(t *testing.T) {
 	m.gitGraphMode = GitGraphFull
 	m.gitGraphFocus = true
 	m.gitGraphScroll = 0
+	m.height = 40 // viewport = 35, half-page = 17
 	m.gitGraphState = &GitGraphState{
 		Lines: make([]GitGraphLine, 100),
 	}
 
-	// Ctrl+D: down 15
+	// Ctrl+D: down half-page (35/2 = 17)
 	updated, _ := m.Update(makeKey("ctrl+d"))
 	m = updated.(Model)
-	if m.gitGraphScroll != 15 {
-		t.Errorf("ctrl+d: scroll = %d, want 15", m.gitGraphScroll)
+	if m.gitGraphScroll != 17 {
+		t.Errorf("ctrl+d: scroll = %d, want 17", m.gitGraphScroll)
 	}
 
-	// Ctrl+U: up 15
+	// Ctrl+U: up half-page (back to 0)
 	updated, _ = m.Update(makeKey("ctrl+u"))
 	m = updated.(Model)
 	if m.gitGraphScroll != 0 {

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -654,7 +654,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "down", "j":
 			if m.gitGraphFocus {
 				if m.gitGraphState != nil {
-					maxScroll := len(m.gitGraphState.Lines) - 1
+					viewportH := m.gitGraphViewportHeight()
+					maxScroll := len(m.gitGraphState.Lines) - viewportH
+					if maxScroll < 0 {
+						maxScroll = 0
+					}
 					if m.gitGraphScroll < maxScroll {
 						m.gitGraphScroll++
 					}
@@ -664,15 +668,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "ctrl+d":
 			if m.gitGraphFocus && m.gitGraphState != nil {
-				m.gitGraphScroll += 15
-				maxScroll := len(m.gitGraphState.Lines) - 1
+				viewportH := m.gitGraphViewportHeight()
+				m.gitGraphScroll += viewportH / 2
+				maxScroll := len(m.gitGraphState.Lines) - viewportH
+				if maxScroll < 0 {
+					maxScroll = 0
+				}
 				if m.gitGraphScroll > maxScroll {
 					m.gitGraphScroll = maxScroll
 				}
 			}
 		case "ctrl+u":
 			if m.gitGraphFocus {
-				m.gitGraphScroll -= 15
+				viewportH := m.gitGraphViewportHeight()
+				m.gitGraphScroll -= viewportH / 2
 				if m.gitGraphScroll < 0 {
 					m.gitGraphScroll = 0
 				}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1518.

Closes #1518

## Changes

GitHub Issue #1518: Fix git graph: calculate visible lines from panel height

## Context

The git graph panel (GH-1505) is now full terminal height, but the number of visible git log lines doesn't adapt to the available space. It shows a fixed number of lines regardless of window size, and scrolling (j/k) shifts content but the viewport size doesn't match the panel.

## Problem

The visible line count must be dynamically calculated:

```
visibleLines = terminalHeight - topBorder(1) - bottomBorder(1) - topPadding(1) - bottomPadding(1) - scrollIndicator(1)
             = terminalHeight - 5
```

Then render only `gitGraphState.Lines[scrollOffset : scrollOffset + visibleLines]`.

## Fix

In `internal/dashboard/gitgraph.go`, the `renderGitGraph()` function should:

1. **Calculate viewport size** from terminal height:
```go
viewportHeight := m.height - 5  // borders(2) + padding(2) + scroll indicator(1)
if viewportHeight < 1 {
    viewportHeight = 1
}
```

2. **Slice visible lines** using scroll offset:
```go
startIdx := m.gitGraphScroll
endIdx := startIdx + viewportHeight
if endIdx > len(m.gitGraphState.Lines) {
    endIdx = len(m.gitGraphState.Lines)
}
visibleLines := m.gitGraphState.Lines[startIdx:endIdx]
```

3. **Clamp scroll offset** to prevent scrolling past content:
```go
maxScroll := len(m.gitGraphState.Lines) - viewportHeight
if maxScroll < 0 {
    maxScroll = 0
}
if m.gitGraphScroll > maxScroll {
    m.gitGraphScroll = maxScroll
}
```

4. **Update scroll indicator** to reflect viewport:
```go
// Show: [startIdx+1 - endIdx of total]
fmt.Sprintf("[%d-%d of %d]", startIdx+1, endIdx, len(m.gitGraphState.Lines))
```

5. **Pad remaining lines** if content is shorter than viewport:
```go
for i := len(visibleLines); i < viewportHeight; i++ {
    // append empty padded line
}
```

6. **Scroll handler** should respect viewport bounds:
```go
case "j", "down":
    if m.gitGraphFocus {
        maxScroll := len(m.gitGraphState.Lines) - viewportHeight
        if m.gitGraphScroll < maxScroll {
            m.gitGraphScroll++
        }
    }
case "k", "up":
    if m.gitGraphFocus && m.gitGraphScroll > 0 {
        m.gitGraphScroll--
    }
case "ctrl+d":
    if m.gitGraphFocus {
        m.gitGraphScroll += viewportHeight / 2
        // clamp to max
    }
case "ctrl+u":
    if m.gitGraphFocus {
        m.gitGraphScroll -= viewportHeight / 2
        if m.gitGraphScroll < 0 { m.gitGraphScroll = 0 }
    }
```

## Files to Modify

- `internal/dashboard/gitgraph.go` — viewport calculation, line slicing, scroll clamping, padding

## Acceptance Criteria

- [ ] Visible lines fill exactly the panel inner height (no overflow, no underflow)
- [ ] Resizing terminal dynamically adjusts visible line count
- [ ] j/k scrolls one line at a time, stops at bounds
- [ ] Ctrl+d/Ctrl+u scrolls half-page
- [ ] Scroll indicator shows correct range: `[1-45 of 212]`
- [ ] Content shorter than viewport is padded with empty lines
- [ ] `go build ./...` passes