### PR TITLE
Redesign dashboard help footer: wrap to panel width

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -886,13 +886,31 @@ func (m Model) renderDashboard() string {
 	}
 
 	// Help footer
-	if m.gitGraphMode != GitGraphHidden {
-		b.WriteString(helpStyle.Render("q: quit  l: logs  g: cycle graph  tab: focus  j/k: scroll  enter: open"))
-	} else {
-		b.WriteString(helpStyle.Render("q: quit  l: logs  g: git graph  j/k: select  enter: open"))
-	}
+	b.WriteString(m.renderHelp())
 
 	return b.String()
+}
+
+// renderHelp returns a context-aware help footer that fits within panelTotalWidth (69 chars).
+// Keys shown depend on gitGraphMode and gitGraphFocus state.
+func (m Model) renderHelp() string {
+	var parts []string
+	switch {
+	case m.gitGraphMode == GitGraphHidden:
+		// Graph hidden: show navigation and graph-open key
+		parts = []string{"q: quit", "l: logs", "g: graph", "j/k: select", "⏎: open"}
+	case m.gitGraphFocus:
+		// Graph visible, graph panel focused
+		parts = []string{"q: quit", "g: cycle", "tab: dashboard", "j/k: scroll"}
+	default:
+		// Graph visible, dashboard focused
+		parts = []string{"q: quit", "g: cycle", "tab: graph", "j/k: select"}
+	}
+	help := strings.Join(parts, "  ")
+	if len(help) > panelTotalWidth {
+		help = help[:panelTotalWidth-3] + "..."
+	}
+	return helpStyle.Render(help)
 }
 
 // renderPanel builds a panel manually with guaranteed width


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1521.

Closes #1521

## Changes

GitHub Issue #1521: Redesign dashboard help footer: wrap to panel width

## Context

The help footer text overflows the dashboard panel width (69 chars) and spills into the git graph area:

\`\`\`
q: quit  l: logs  g: cycle graph  tab: focus  j/k: scroll  enter: open │
\`\`\`

Current text is ~72 chars and growing (adding \`b: banner\` makes it worse). The footer needs to stay within the 69-char dashboard width, or adapt when the graph panel is visible.

## Design

Redesign the help footer to fit within \`panelTotalWidth\` (69 chars). Two approaches, pick the one that fits best:

**Option A: Two-line footer**
\`\`\`
q: quit  l: logs  g: graph  b: banner
tab: focus  j/k: scroll  enter: open
\`\`\`

**Option B: Compact single line with shorter labels**
\`\`\`
q quit  l log  g graph  b banner  tab focus  j/k scroll  ⏎ open
\`\`\`

**Option C: Context-aware** — show only relevant keys based on state:
- Graph hidden: \`q: quit  l: logs  g: graph  b: banner  j/k: select  ⏎: open\`
- Graph visible, dashboard focused: \`q: quit  g: cycle  b: banner  tab: graph  j/k: select\`
- Graph visible, graph focused: \`q: quit  g: cycle  tab: dashboard  j/k: scroll  ^d/^u: page\`

**Recommended: Option C** — each line stays under 69 chars by showing only contextually relevant keys.

## Implementation

In \`internal/dashboard/tui.go\`, replace the hardcoded help string (line ~888) with a function:

\`\`\`go
func (m Model) renderHelp() string {
    var parts []string
    parts = append(parts, "q: quit")
    parts = append(parts, "l: logs")
    parts = append(parts, "g: graph")
    if m.showBanner {
        parts = append(parts, "b: hide banner")
    } else {
        parts = append(parts, "b: banner")
    }
    if m.gitGraphMode != GitGraphHidden {
        if m.gitGraphFocus {
            parts = append(parts, "tab: dashboard", "j/k: scroll")
        } else {
            parts = append(parts, "tab: graph", "j/k: select", "⏎: open")
        }
    } else {
        parts = append(parts, "j/k: select", "⏎: open")
    }
    help := strings.Join(parts, "  ")
    // Truncate to panelTotalWidth if somehow still too long
    if len(help) > panelTotalWidth {
        help = help[:panelTotalWidth-3] + "..."
    }
    return helpStyle.Render(help)
}
\`\`\`

## Files to Modify

- \`internal/dashboard/tui.go\` — replace hardcoded help string with \`renderHelp()\` method

## Acceptance Criteria

- [ ] Help footer stays within 69-char dashboard width
- [ ] No text spills into git graph area
- [ ] Keys shown are context-aware (graph state, focus state)
- [ ] All key bindings documented in at least one context
- [ ] \`go build ./...\` passes

## Planned Steps (execute all in sequence)

1. **Implement context-aware `renderHelp()` method and replace hardcoded footer** — In `internal/dashboard/tui.go`: extract the hardcoded help strings at lines 888-893 into a new `renderHelp()` method on the `Model` struct. The method builds the help string dynamically based on `gitGraphMode` and `gitGraphFocus` state: when the graph is hidden, show `q: quit  l: logs  g: graph  j/k: select  ⏎: open`; when graph is visible and dashboard is focused, show `q: quit  g: cycle  tab: graph  j/k: select`; when graph is visible and graph is focused, show `q: quit  g: cycle  tab: dashboard  j/k: scroll`. Note: there is no `showBanner` field on the Model (banner is always shown), so skip that toggle unless a `b: banner` keybinding already exists. Add a safety truncation to `panelTotalWidth` (69 chars). Replace the existing two `helpStyle.Render(...)` calls in `renderDashboard()` with a single `m.renderHelp()` call. Ensure `go build ./...` and `go test ./internal/dashboard/...` pass. Verify each context variant stays within 69 characters.
