### PR TITLE
fix(lint): resolve SA5011 nil pointer dereference warnings in tests

### DIFF
--- a/internal/adapters/asana/webhook_test.go
+++ b/internal/adapters/asana/webhook_test.go
@@ -14,9 +14,6 @@ func TestNewWebhookHandler(t *testing.T) {
 	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
 	handler := NewWebhookHandler(client, testutil.FakeAsanaWebhookSecret, "pilot")
 
-	if handler == nil {
-		t.Fatal("NewWebhookHandler returned nil")
-	}
 	if handler.pilotTag != "pilot" {
 		t.Errorf("handler.pilotTag = %s, want pilot", handler.pilotTag)
 	}

--- a/internal/adapters/azuredevops/poller_test.go
+++ b/internal/adapters/azuredevops/poller_test.go
@@ -166,12 +166,10 @@ func TestPollerFindOldestUnprocessedWorkItem(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	// Should find ID 1 (oldest that's not in progress)
 	if wi == nil {
 		t.Fatal("expected to find a work item")
-	}
-
-	// Should find ID 1 (oldest that's not in progress)
-	if wi.ID != 1 {
+	} else if wi.ID != 1 {
 		t.Errorf("expected oldest unprocessed work item ID 1, got %d", wi.ID)
 	}
 }

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -16,9 +16,6 @@ import (
 
 func TestNewClient(t *testing.T) {
 	client := NewClient(testutil.FakeGitHubToken)
-	if client == nil {
-		t.Fatal("NewClient returned nil")
-	}
 	if client.token != testutil.FakeGitHubToken {
 		t.Errorf("client.token = %s, want %s", client.token, testutil.FakeGitHubToken)
 	}
@@ -30,9 +27,6 @@ func TestNewClient(t *testing.T) {
 func TestNewClientWithBaseURL(t *testing.T) {
 	customURL := "https://custom.api.example.com"
 	client := NewClientWithBaseURL(testutil.FakeGitHubToken, customURL)
-	if client == nil {
-		t.Fatal("NewClientWithBaseURL returned nil")
-	}
 	if client.token != testutil.FakeGitHubToken {
 		t.Errorf("client.token = %s, want %s", client.token, testutil.FakeGitHubToken)
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1540.

Closes #1540

## Changes

- Removed nil-check-then-dereference patterns in 3 test files that triggered staticcheck SA5011
- `internal/adapters/asana/webhook_test.go`: removed redundant nil guard before field access
- `internal/adapters/github/client_test.go`: removed redundant nil guards in `TestNewClient` and `TestNewClientWithBaseURL`
- `internal/adapters/azuredevops/poller_test.go`: combined nil check with field access using `else if`

## Test plan

- [x] `go build ./...` passes
- [x] `go test` passes for all 3 affected packages
- [x] `make lint` reports 0 issues