### PR TITLE
fix(ci): use golangci-lint --new-from-rev to prevent unrelated lint blocking PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -58,7 +60,7 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         with:
           version: v2.0.2
-          args: --timeout=5m
+          args: --timeout=5m --new-from-rev=origin/main
 
   notify-failure:
     name: Notify CI Failure


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1569.

Closes #1569

## Changes

GitHub Issue #1569: fix(ci): use golangci-lint --new-from-rev to prevent unrelated lint blocking PRs

## Context

In the GH-1526 cascade, PRs that only changed `desktop/` files were blocked by pre-existing SA5011 lint errors in completely unrelated packages (`internal/adapters/asana/`, `internal/adapters/azuredevops/`, `internal/adapters/github/`).

This caused CI fix iterations to chase unrelated lint errors instead of the actual task, creating an oscillation loop.

## Task

Modify `.github/workflows/ci.yml` to use `--new-from-rev` flag so golangci-lint only reports NEW issues introduced by the PR, not pre-existing ones.

### Implementation

In the lint step, change:
```yaml
- name: golangci-lint
  uses: golangci/golangci-lint-action@v6
  with:
    version: latest
```

To:
```yaml
- name: golangci-lint
  uses: golangci/golangci-lint-action@v6
  with:
    version: latest
    args: --new-from-rev=origin/main
```

This makes the linter only flag issues introduced in the PR's commits, not pre-existing issues on main.

**Alternative approach** (if `--new-from-rev` has edge cases):
Use `--new` flag which only reports issues in new/modified lines:
```yaml
args: --new
```

**Key files:**
- `.github/workflows/ci.yml` (lint job)

## Acceptance Criteria

- [ ] golangci-lint only reports NEW issues introduced by the PR
- [ ] Pre-existing lint issues on main don't block unrelated PRs
- [ ] Lint still catches all issues in changed files
- [ ] Works correctly for PRs targeting main branch