### PR TITLE
fix(executor): add diagnostic logging for task.Labels before epic detection

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -230,6 +230,15 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 	// GH-386: Include SourceRepo for cross-project validation in executor
 	// GH-920: Extract acceptance criteria for prompt inclusion
 	// GH-1267: Include FromPR for --from-pr session resumption
+	labels := extractGitHubLabelNames(issue)
+
+	// GH-1565: Log label extraction for epic detection diagnostics
+	slog.Info("Task labels extracted",
+		slog.String("task_id", taskID),
+		slog.Any("labels", labels),
+		slog.Int("label_count", len(issue.Labels)),
+	)
+
 	task := &executor.Task{
 		ID:                 taskID,
 		Title:              issue.Title,
@@ -239,7 +248,7 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 		CreatePR:           true,
 		SourceRepo:         sourceRepo,
 		MemberID:           resolveGitHubMemberID(issue),                 // GH-634: RBAC lookup
-		Labels:             extractGitHubLabelNames(issue),               // GH-727: flow labels for complexity classifier
+		Labels:             labels,                                       // GH-727: flow labels for complexity classifier
 		AcceptanceCriteria: github.ExtractAcceptanceCriteria(issue.Body), // GH-920: acceptance criteria in prompts
 		FromPR:             fromPR,                                       // GH-1267: session resumption from PR context
 	}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -866,6 +866,16 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		}
 	}
 
+	// GH-1565: Diagnostic logging for epic detection
+	r.log.Info("Epic detection check",
+		slog.String("task_id", task.ID),
+		slog.String("task_title", task.Title),
+		slog.Any("labels", task.Labels),
+		slog.Bool("has_no_decompose", hasNoDecompose),
+		slog.Bool("is_epic", complexity.IsEpic()),
+		slog.String("complexity", string(complexity)),
+	)
+
 	// GH-405: Epic tasks trigger planning mode instead of execution
 	if complexity.IsEpic() && !hasNoDecompose {
 		r.log.Info("Epic task detected, running planning mode",


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1565.

Closes #1565

## Changes

GitHub Issue #1565: fix(executor): add diagnostic logging for task.Labels before epic detection

## Context

Investigation of GH-1503/GH-1526 CI fix cascade (14 iterations, 30 CI runs, ~2 hours wasted) revealed that `no-decompose` label was ignored. The epic detector fired on a task explicitly marked atomic.

**Root cause**: `task.Labels` may have been empty at runtime despite the GitHub API returning labels. Without logging, we can't confirm whether this is a label extraction bug or a race condition.

## Task

Add `slog.Info` logging in `internal/executor/runner.go` at line ~860 (before the `hasNoDecompose` check) to dump:

1. `task.Labels` (full slice)
2. `hasNoDecompose` result
3. `complexity.IsEpic()` result
4. `task.ID` and `task.Title` for correlation

Example:
```go
r.log.Info("Epic detection check",
    slog.String("task_id", task.ID),
    slog.Any("labels", task.Labels),
    slog.Bool("has_no_decompose", hasNoDecompose),
    slog.Bool("is_epic", complexity.IsEpic()),
    slog.String("complexity", string(complexity)),
)
```

Also add logging in `cmd/pilot/handlers.go` at line ~242 to confirm labels are extracted:
```go
slog.Info("Task labels extracted",
    slog.String("task_id", taskID),
    slog.Any("labels", extractGitHubLabelNames(issue)),
    slog.Int("label_count", len(issue.Labels)),
)
```

## Acceptance Criteria

- [ ] Labels logged before epic check in runner.go
- [ ] Labels logged at extraction point in handlers.go
- [ ] Both log entries include task ID for correlation
- [ ] No functional changes — logging only