### PR TITLE
fix(asana): satisfy staticcheck SA5011 in test files

### DIFF
--- a/internal/adapters/asana/client_test.go
+++ b/internal/adapters/asana/client_test.go
@@ -14,6 +14,7 @@ func TestNewClient(t *testing.T) {
 	client := NewClient(testutil.FakeAsanaAccessToken, testutil.FakeAsanaWorkspaceID)
 	if client == nil {
 		t.Fatal("NewClient returned nil")
+		return
 	}
 	if client.baseURL != BaseURL {
 		t.Errorf("client.baseURL = %s, want %s", client.baseURL, BaseURL)
@@ -346,6 +347,7 @@ func TestFindTagByName(t *testing.T) {
 	}
 	if tag == nil {
 		t.Fatal("expected to find tag")
+		return
 	}
 	if tag.GID != "1" {
 		t.Errorf("tag.GID = %s, want 1", tag.GID)

--- a/internal/adapters/asana/notifier_test.go
+++ b/internal/adapters/asana/notifier_test.go
@@ -17,6 +17,7 @@ func TestNewNotifier(t *testing.T) {
 
 	if notifier == nil {
 		t.Fatal("NewNotifier returned nil")
+		return
 	}
 	if notifier.pilotTag != "pilot" {
 		t.Errorf("notifier.pilotTag = %s, want pilot", notifier.pilotTag)


### PR DESCRIPTION
## Summary
- Adds `return` after `t.Fatal` calls in Asana test files to satisfy staticcheck SA5011 (possible nil pointer dereference)
- Fixes CI lint failure from PR #1576

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/adapters/asana/...` passes
- [x] `make lint` reports 0 issues

Fixes #1577