### PR TITLE
fix(executor): detectEpic should check no-decompose label as defense-in-depth

### DIFF
--- a/internal/executor/complexity.go
+++ b/internal/executor/complexity.go
@@ -121,6 +121,10 @@ func DetectComplexity(task *Task) Complexity {
 
 	// Check epic patterns first (these are too large for single execution)
 	if detectEpic(task.Title, task.Description, combined) {
+		// Defense-in-depth: no-decompose label prevents epic classification (GH-1568)
+		if HasLabel(task, NoDecomposeLabel) {
+			return ComplexityComplex
+		}
 		return ComplexityEpic
 	}
 

--- a/internal/executor/complexity_classifier_test.go
+++ b/internal/executor/complexity_classifier_test.go
@@ -342,6 +342,30 @@ func TestHasLabel(t *testing.T) {
 	}
 }
 
+func TestDetectComplexity_NoDecomposePreventsEpic(t *testing.T) {
+	task := &Task{
+		Title:       "[epic] Large refactor across multiple systems",
+		Description: "Phase 1: update models. Phase 2: rewrite API. Phase 3: migrate data. Phase 4: update frontend. Phase 5: integration tests.",
+		Labels:      []string{"pilot", "no-decompose"},
+	}
+
+	result := DetectComplexity(task)
+	if result != ComplexityComplex {
+		t.Errorf("expected ComplexityComplex when no-decompose label present, got %s", result)
+	}
+
+	// Verify same task WITHOUT no-decompose is detected as epic
+	taskWithoutLabel := &Task{
+		Title:       task.Title,
+		Description: task.Description,
+		Labels:      []string{"pilot"},
+	}
+	result2 := DetectComplexity(taskWithoutLabel)
+	if result2 != ComplexityEpic {
+		t.Errorf("expected ComplexityEpic without no-decompose label, got %s", result2)
+	}
+}
+
 func TestDecomposer_NoDecomposeLabel(t *testing.T) {
 	config := &DecomposeConfig{
 		Enabled:             true,


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1568.

Closes #1568

## Changes

GitHub Issue #1568: fix(executor): detectEpic should check no-decompose label as defense-in-depth

## Context

GH-1503 was decomposed despite `no-decompose` label. The guard at `runner.go:870` checks labels before entering epic mode, but `DetectComplexity()` in `complexity.go` has no awareness of labels — it purely analyzes text.

As defense-in-depth, `DetectComplexity` should accept labels and return non-epic when `no-decompose` is present. This prevents any code path from accidentally treating a no-decompose task as epic.

## Task

Modify `internal/executor/complexity.go`:

1. Change `DetectComplexity` signature to accept labels:
```go
func DetectComplexity(task *Task) Complexity {
```
Task already has `Labels []string`, so no signature change needed. Just add a check at the top of the function:

```go
func DetectComplexity(task *Task) Complexity {
    if task == nil {
        return ComplexityMedium
    }

    // Defense-in-depth: no-decompose label prevents epic classification
    if HasLabel(task, NoDecomposeLabel) {
        // Still detect complexity for model routing, but cap at Complex (never Epic)
        // Fall through to normal detection below
    }
    
    // ... existing code ...
    
    if detectEpic(task.Title, task.Description, combined) {
        // Check no-decompose AGAIN here as safety net
        if HasLabel(task, NoDecomposeLabel) {
            return ComplexityComplex  // Downgrade to complex, skip epic
        }
        return ComplexityEpic
    }
```

2. Update `complexity_classifier_test.go` to add test case:
```go
{
    name: "no-decompose prevents epic",
    task: &Task{
        Title: "[epic] Large refactor",
        Description: "Phase 1... Phase 2... Phase 3... Phase 4... Phase 5...",
        Labels: []string{"pilot", "no-decompose"},
    },
    expected: ComplexityComplex, // NOT Epic
},
```

**Key files:**
- `internal/executor/complexity.go` (DetectComplexity, detectEpic)
- `internal/executor/complexity_classifier_test.go`

## Acceptance Criteria

- [ ] `DetectComplexity` returns `ComplexityComplex` (not Epic) when `no-decompose` label present
- [ ] Model routing still works (complex tasks get Opus, not downgraded to simple)
- [ ] Test covers epic-pattern task with no-decompose label
- [ ] Existing epic detection unaffected when no-decompose absent