### PR TITLE
feat(desktop): wire AutopilotStatus.ActivePRs from daemon API

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -995,6 +995,11 @@ Examples:
 				logging.WithComponent("start").Info("quality gates enabled for webhook mode")
 			}
 
+			// GH-1585: Wire autopilot provider to gateway so /api/v1/autopilot returns live PR data
+			if gwAutopilotController != nil {
+				p.Gateway().SetAutopilotProvider(&autopilotProviderAdapter{controller: gwAutopilotController})
+			}
+
 			if err := p.Start(); err != nil {
 				return fmt.Errorf("failed to start Pilot: %w", err)
 			}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1585.

Closes #1585

## Changes

GitHub Issue #1585: feat(desktop): wire AutopilotStatus.ActivePRs from daemon API

## Context

The desktop app's `GetAutopilotStatus()` in `desktop/app.go` returns `ActivePRs: []ActivePR{}` (always empty). The autopilot controller has `GetActivePRs()` but it runs in the daemon process. Need a gateway API endpoint to expose this data.

## Implementation

### 1. Gateway endpoint (`internal/gateway/server.go`)

Add `/api/v1/autopilot` endpoint:

```go
// Add to Server struct
type AutopilotProvider interface {
    GetEnvironment() string
    GetActivePRs() []*autopilot.PRState
    GetFailureCount() int
    IsAutoReleaseEnabled() bool
}

func (s *Server) SetAutopilotProvider(p AutopilotProvider)
```

Register route in `Start()` at the `apiMux` block (~line 172):
```go
apiMux.HandleFunc("/api/v1/autopilot", s.handleAutopilot)
```

Handler returns JSON:
```json
{
  "enabled": true,
  "environment": "stage",
  "autoRelease": true,
  "activePRs": [{"number": 1578, "stage": "WaitingCI", "ciStatus": "pending"}],
  "failureCount": 0
}
```

### 2. Wire in `cmd/pilot/main.go`

After creating the autopilot controller, call:
```go
gatewayServer.SetAutopilotProvider(autopilotController)
```

Follow the same pattern as `SetMetricsSource()` (already exists).

### 3. Desktop app (`desktop/app.go`)

In `GetAutopilotStatus()`, after reading SQLite metrics:
- HTTP GET `http://127.0.0.1:<port>/api/v1/autopilot`
- Merge live `ActivePRs` into the response
- Fall back to SQLite-only data if daemon unreachable

## Acceptance Criteria

- AutopilotPanel shows active PRs with stage icons when daemon is running
- Graceful fallback to empty PRs when daemon is not running
- No new dependencies