### PR TITLE
feat(desktop): implement GetServerStatus with real daemon health check

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/alekspetrov/pilot/internal/config"
 	"github.com/alekspetrov/pilot/internal/memory"
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
@@ -15,13 +18,17 @@ import (
 // App is the Wails application struct. Its exported methods are bound to the
 // frontend and callable from JavaScript/TypeScript via the generated bindings.
 type App struct {
-	ctx   context.Context
-	store *memory.Store
+	ctx        context.Context
+	store      *memory.Store
+	httpClient *http.Client
+	gatewayURL string // e.g. "http://127.0.0.1:9090"
 }
 
 // NewApp creates a new App instance.
 func NewApp() *App {
-	return &App{}
+	return &App{
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+	}
 }
 
 // startup is called when the app starts. Opens the SQLite database.
@@ -39,6 +46,14 @@ func (a *App) startup(ctx context.Context) {
 		return
 	}
 	a.store = store
+
+	// Load config to determine gateway address
+	cfg, err := config.Load(config.DefaultConfigPath())
+	if err == nil && cfg.Gateway != nil {
+		a.gatewayURL = fmt.Sprintf("http://%s:%d", cfg.Gateway.Host, cfg.Gateway.Port)
+	} else {
+		a.gatewayURL = "http://127.0.0.1:9090"
+	}
 }
 
 // shutdown is called when the app is about to quit.
@@ -200,11 +215,43 @@ func (a *App) GetAutopilotStatus() AutopilotStatus {
 }
 
 // GetServerStatus checks whether the pilot daemon gateway is reachable.
-// It attempts a lightweight HTTP check against the configured gateway URL.
+// It hits the unauthenticated /health endpoint and, on success, fetches
+// version info from /api/v1/status.
 func (a *App) GetServerStatus() ServerStatus {
-	// Default gateway address — the daemon exposes this when running.
-	// We do a simple TCP probe; no auth needed for status.
-	return ServerStatus{Running: false}
+	if a.gatewayURL == "" {
+		return ServerStatus{Running: false}
+	}
+
+	// Health check (unauthenticated)
+	resp, err := a.httpClient.Get(a.gatewayURL + "/health")
+	if err != nil {
+		return ServerStatus{Running: false}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ServerStatus{Running: false}
+	}
+
+	status := ServerStatus{
+		Running:    true,
+		GatewayURL: a.gatewayURL,
+	}
+
+	// Try to get version from /api/v1/status (best-effort, may require auth)
+	if vResp, err := a.httpClient.Get(a.gatewayURL + "/api/v1/status"); err == nil {
+		defer vResp.Body.Close()
+		if vResp.StatusCode == http.StatusOK {
+			var body struct {
+				Version string `json:"version"`
+			}
+			if json.NewDecoder(vResp.Body).Decode(&body) == nil && body.Version != "" {
+				status.Version = body.Version
+			}
+		}
+	}
+
+	return status
 }
 
 // OpenInBrowser opens the given URL in the system default browser.

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGetServerStatus_DaemonRunning(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "healthy"})
+	})
+	mux.HandleFunc("/api/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"version": "1.40.1",
+			"running": true,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := &App{
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+		gatewayURL: srv.URL,
+	}
+
+	status := app.GetServerStatus()
+	if !status.Running {
+		t.Fatal("expected Running=true when daemon is healthy")
+	}
+	if status.Version != "1.40.1" {
+		t.Fatalf("expected version 1.40.1, got %q", status.Version)
+	}
+	if status.GatewayURL != srv.URL {
+		t.Fatalf("expected GatewayURL=%q, got %q", srv.URL, status.GatewayURL)
+	}
+}
+
+func TestGetServerStatus_DaemonNotRunning(t *testing.T) {
+	app := &App{
+		httpClient: &http.Client{Timeout: 1 * time.Second},
+		gatewayURL: "http://127.0.0.1:1", // nothing listening
+	}
+
+	status := app.GetServerStatus()
+	if status.Running {
+		t.Fatal("expected Running=false when daemon is unreachable")
+	}
+}
+
+func TestGetServerStatus_EmptyGatewayURL(t *testing.T) {
+	app := &App{
+		httpClient: &http.Client{Timeout: 1 * time.Second},
+		gatewayURL: "",
+	}
+
+	status := app.GetServerStatus()
+	if status.Running {
+		t.Fatal("expected Running=false when gatewayURL is empty")
+	}
+}
+
+func TestGetServerStatus_HealthOK_StatusUnauthorized(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "healthy"})
+	})
+	mux.HandleFunc("/api/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := &App{
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+		gatewayURL: srv.URL,
+	}
+
+	status := app.GetServerStatus()
+	if !status.Running {
+		t.Fatal("expected Running=true even when /api/v1/status returns 401")
+	}
+	if status.Version != "" {
+		t.Fatalf("expected empty version when status is unauthorized, got %q", status.Version)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1584.

Closes #1584

## Changes

GitHub Issue #1584: feat(desktop): implement GetServerStatus with real daemon health check

## Context

The desktop app's `GetServerStatus()` in `desktop/app.go` (line ~204) is a stub that always returns `{Running: false}`. It needs to actually check if the `pilot start` daemon is running by hitting the gateway's `/health` endpoint.

## Implementation

**File:** `desktop/app.go`

1. Replace the stub `GetServerStatus()` with an actual HTTP GET to `http://127.0.0.1:<port>/health`
2. Read the gateway port from config (`~/.pilot/config.yaml`) using `config.Load()` — the port is at `gateway.port` (default 8080, see `internal/config/config.go`)
3. Use `http.Client{Timeout: 2*time.Second}` to avoid blocking the UI
4. Also hit `/api/v1/status` to get the version string
5. On success: return `ServerStatus{Running: true, Version: ver, GatewayURL: url}`
6. On any error (connection refused, timeout): return `ServerStatus{Running: false}`

**Types** (already exist in `desktop/types.go`):
```go
type ServerStatus struct {
    Running    bool   `json:"running"`
    Version    string `json:"version,omitempty"`
    GatewayURL string `json:"gatewayURL,omitempty"`
}
```

Add an `httpClient *http.Client` field to the App struct, initialized in `NewApp()` with 2s timeout.

## Acceptance Criteria

- Desktop app shows green indicator in Header when `pilot start` is running
- Shows red/gray indicator when daemon is not running
- No UI freeze (2s timeout max)
- Works when config has custom gateway port