### PR TITLE
feat(desktop): add execution logs store and wire LogsPanel

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -199,6 +199,38 @@ func (a *App) GetAutopilotStatus() AutopilotStatus {
 	}
 }
 
+// GetLogs returns recent execution log entries for the logs panel.
+func (a *App) GetLogs(limit int) []LogEntry {
+	if a.store == nil {
+		return nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+
+	entries, err := a.store.GetRecentLogs(limit)
+	if err != nil {
+		return nil
+	}
+
+	result := make([]LogEntry, 0, len(entries))
+	for _, e := range entries {
+		result = append(result, LogEntry{
+			Ts:        e.Timestamp.Format("15:04:05"),
+			Level:     e.Level,
+			Message:   e.Message,
+			Component: e.Component,
+		})
+	}
+
+	// Reverse so oldest is first (panel auto-scrolls to bottom)
+	for i, j := 0, len(result)-1; i < j; i, j = i+1, j-1 {
+		result[i], result[j] = result[j], result[i]
+	}
+
+	return result
+}
+
 // GetServerStatus checks whether the pilot daemon gateway is reachable.
 // It attempts a lightweight HTTP check against the configured gateway URL.
 func (a *App) GetServerStatus() ServerStatus {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import { LogsPanel } from './components/LogsPanel'
 import { useDashboard } from './hooks/useDashboard'
 
 function App() {
-  const { metrics, queueTasks, history, autopilot, server } = useDashboard()
+  const { metrics, queueTasks, history, autopilot, server, logs } = useDashboard()
 
   return (
     <div className="flex flex-col h-full bg-bg overflow-hidden">
@@ -39,7 +39,7 @@ function App() {
 
         {/* Logs — collapsed at bottom */}
         <div className="shrink-0">
-          <LogsPanel entries={[]} />
+          <LogsPanel entries={logs} />
         </div>
       </div>
     </div>

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -53,6 +53,13 @@ export interface AutopilotStatus {
   failureCount: number
 }
 
+export interface LogEntry {
+  ts: string
+  level: string
+  message: string
+  component?: string
+}
+
 export interface ServerStatus {
   running: boolean
   version?: string

--- a/desktop/frontend/src/wailsjs.ts
+++ b/desktop/frontend/src/wailsjs.ts
@@ -2,7 +2,7 @@
 // The Go App methods are accessible via window.go.main.App.*
 // These wrappers provide TypeScript type safety.
 
-import type { DashboardMetrics, QueueTask, HistoryEntry, AutopilotStatus, ServerStatus } from './types'
+import type { DashboardMetrics, QueueTask, HistoryEntry, AutopilotStatus, ServerStatus, LogEntry } from './types'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const window: any
@@ -33,6 +33,10 @@ export function GetAutopilotStatus(): Promise<AutopilotStatus> {
 
 export function GetServerStatus(): Promise<ServerStatus> {
   return goCall<ServerStatus>('GetServerStatus')
+}
+
+export function GetLogs(limit: number): Promise<LogEntry[]> {
+  return goCall<LogEntry[]>('GetLogs', limit)
 }
 
 export function OpenInBrowser(url: string): Promise<void> {

--- a/desktop/types.go
+++ b/desktop/types.go
@@ -68,6 +68,14 @@ type ActivePR struct {
 	BranchName string `json:"branchName"`
 }
 
+// LogEntry represents a structured log entry for the logs panel.
+type LogEntry struct {
+	Ts        string `json:"ts"`
+	Level     string `json:"level"`
+	Message   string `json:"message"`
+	Component string `json:"component,omitempty"`
+}
+
 // ServerStatus holds the connection status of the running pilot daemon.
 type ServerStatus struct {
 	Running   bool   `json:"running"`


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1586.

Closes #1586

## Changes

GitHub Issue #1586: feat(desktop): add execution logs store and wire LogsPanel

## Context

The LogsPanel component in `desktop/frontend/src/components/LogsPanel.tsx` is fully implemented but receives an empty array (`<LogsPanel entries={[]} />` in App.tsx line 42). Need a data source for structured execution milestone logs.

## Implementation

### 1. SQLite migration (`internal/memory/store.go`)

Add new table in `migrate()`:

```sql
CREATE TABLE IF NOT EXISTS execution_logs (
    id INTEGER PRIMARY KEY AUTOINCREMENT,
    execution_id TEXT,
    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
    level TEXT NOT NULL DEFAULT 'info',
    message TEXT NOT NULL,
    component TEXT DEFAULT 'executor'
)
CREATE INDEX IF NOT EXISTS idx_execution_logs_timestamp ON execution_logs(timestamp)
```

Add types and methods:
```go
type LogEntry struct {
    ID          int64     `json:"id"`
    ExecutionID string    `json:"executionId,omitempty"`
    Timestamp   time.Time `json:"ts"`
    Level       string    `json:"level"`
    Message     string    `json:"message"`
    Component   string    `json:"component"`
}

func (s *Store) SaveLogEntry(entry *LogEntry) error
func (s *Store) GetRecentLogs(limit int) ([]*LogEntry, error)
```

`GetRecentLogs` orders by timestamp DESC, limits to N entries.

### 2. Desktop Go backend (`desktop/app.go`, `desktop/types.go`)

Add to `types.go`:
```go
type LogEntry struct {
    Ts        string `json:"ts"`
    Level     string `json:"level"`
    Message   string `json:"message"`
    Component string `json:"component,omitempty"`
}
```

Add to `app.go`:
```go
func (a *App) GetLogs(limit int) []LogEntry
```

Reads from store, converts timestamps to string format matching frontend expectations.

### 3. Frontend wiring

**`desktop/frontend/src/wailsjs.ts`** — add:
```typescript
export function GetLogs(limit: number): Promise<LogEntry[]> {
    return goCall<LogEntry[]>('GetLogs', limit)
}
```

**`desktop/frontend/src/hooks/useDashboard.ts`** — add `logs` state:
- Import `GetLogs` from wailsjs
- Add `const [logs, setLogs] = useState<LogEntry[]>([])`
- Poll `GetLogs(20)` every 2 seconds (separate from the 1s data poll)
- Return `logs` in the hook result

**`desktop/frontend/src/App.tsx`** — pass logs:
```tsx
<LogsPanel entries={logs} />
```

Update `DashboardState` interface to include `logs: LogEntry[]`.

## Acceptance Criteria

- LogsPanel displays execution milestone entries
- Entries show timestamp, level icon, and message
- Auto-scrolls to latest entry
- Empty state when no executions have run