### PR TITLE
fix(executor): add diagnostic logging for task.Labels before epic detection

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -241,6 +241,14 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 	// GH-386: Include SourceRepo for cross-project validation in executor
 	// GH-920: Extract acceptance criteria for prompt inclusion
 	// GH-1267: Include FromPR for --from-pr session resumption
+	labels := extractGitHubLabelNames(issue)
+
+	slog.Info("Task labels extracted",
+		slog.String("task_id", taskID),
+		slog.Any("labels", labels),
+		slog.Int("label_count", len(issue.Labels)),
+	)
+
 	task := &executor.Task{
 		ID:                 taskID,
 		Title:              issue.Title,
@@ -250,7 +258,7 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 		CreatePR:           true,
 		SourceRepo:         sourceRepo,
 		MemberID:           resolveGitHubMemberID(issue),                 // GH-634: RBAC lookup
-		Labels:             extractGitHubLabelNames(issue),               // GH-727: flow labels for complexity classifier
+		Labels:             labels,                                       // GH-727: flow labels for complexity classifier
 		AcceptanceCriteria: github.ExtractAcceptanceCriteria(issue.Body), // GH-920: acceptance criteria in prompts
 		FromPR:             fromPR,                                       // GH-1267: session resumption from PR context
 	}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -866,6 +866,16 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		}
 	}
 
+	// GH-1588: Diagnostic logging for epic detection
+	r.log.Info("Epic detection check",
+		slog.String("task_id", task.ID),
+		slog.String("task_title", task.Title),
+		slog.Any("labels", task.Labels),
+		slog.Bool("has_no_decompose", hasNoDecompose),
+		slog.Bool("is_epic", complexity.IsEpic()),
+		slog.String("complexity", string(complexity)),
+	)
+
 	// GH-405: Epic tasks trigger planning mode instead of execution
 	if complexity.IsEpic() && !hasNoDecompose {
 		r.log.Info("Epic task detected, running planning mode",


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1588.

Closes #1588

## Changes

GitHub Issue #1588: fix(executor): add diagnostic logging for task.Labels before epic detection

## Context

GH-1503 was decomposed despite having `no-decompose` label. We need to confirm whether `task.Labels` was empty at runtime or the check logic failed. This adds two slog.Info() calls for diagnostics.

**Previous attempt**: PR #1574 and #1580 both failed CI due to pre-existing SA5011 lint errors (now fixed by GH-1569 --new-from-rev).

## Implementation

### 1. `cmd/pilot/handlers.go` (~line 233)

After `extractGitHubLabelNames(issue)`, log the result before building the Task struct:

```go
labels := extractGitHubLabelNames(issue)

slog.Info("Task labels extracted",
    slog.String("task_id", taskID),
    slog.Any("labels", labels),
    slog.Int("label_count", len(issue.Labels)),
)
```

Then use `labels` variable in the Task struct instead of inline call.

### 2. `internal/executor/runner.go` (~line 869)

Before the epic detection gate (`if complexity.IsEpic() && !hasNoDecompose`), add:

```go
r.log.Info("Epic detection check",
    slog.String("task_id", task.ID),
    slog.String("task_title", task.Title),
    slog.Any("labels", task.Labels),
    slog.Bool("has_no_decompose", hasNoDecompose),
    slog.Bool("is_epic", complexity.IsEpic()),
    slog.String("complexity", string(complexity)),
)
```

## Acceptance Criteria

- `pilot start --github` logs label extraction when picking up issues
- Logs show all labels including `no-decompose` when present
- Epic detection gate logs whether it will block or allow decomposition
- No functional changes — logging only