### PR TITLE
fix(desktop): handle errcheck lint for resp.Body.Close in GetServerStatus

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/alekspetrov/pilot/internal/config"
 	"github.com/alekspetrov/pilot/internal/memory"
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
@@ -15,13 +18,17 @@ import (
 // App is the Wails application struct. Its exported methods are bound to the
 // frontend and callable from JavaScript/TypeScript via the generated bindings.
 type App struct {
-	ctx   context.Context
-	store *memory.Store
+	ctx        context.Context
+	store      *memory.Store
+	httpClient *http.Client
+	gatewayURL string // e.g. "http://127.0.0.1:9090"
 }
 
 // NewApp creates a new App instance.
 func NewApp() *App {
-	return &App{}
+	return &App{
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+	}
 }
 
 // startup is called when the app starts. Opens the SQLite database.
@@ -39,6 +46,14 @@ func (a *App) startup(ctx context.Context) {
 		return
 	}
 	a.store = store
+
+	// Load config to determine gateway address
+	cfg, err := config.Load(config.DefaultConfigPath())
+	if err == nil && cfg.Gateway != nil {
+		a.gatewayURL = fmt.Sprintf("http://%s:%d", cfg.Gateway.Host, cfg.Gateway.Port)
+	} else {
+		a.gatewayURL = "http://127.0.0.1:9090"
+	}
 }
 
 // shutdown is called when the app is about to quit.
@@ -232,11 +247,43 @@ func (a *App) GetLogs(limit int) []LogEntry {
 }
 
 // GetServerStatus checks whether the pilot daemon gateway is reachable.
-// It attempts a lightweight HTTP check against the configured gateway URL.
+// It hits the unauthenticated /health endpoint and, on success, fetches
+// version info from /api/v1/status.
 func (a *App) GetServerStatus() ServerStatus {
-	// Default gateway address — the daemon exposes this when running.
-	// We do a simple TCP probe; no auth needed for status.
-	return ServerStatus{Running: false}
+	if a.gatewayURL == "" {
+		return ServerStatus{Running: false}
+	}
+
+	// Health check (unauthenticated)
+	resp, err := a.httpClient.Get(a.gatewayURL + "/health")
+	if err != nil {
+		return ServerStatus{Running: false}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return ServerStatus{Running: false}
+	}
+
+	status := ServerStatus{
+		Running:    true,
+		GatewayURL: a.gatewayURL,
+	}
+
+	// Try to get version from /api/v1/status (best-effort, may require auth)
+	if vResp, err := a.httpClient.Get(a.gatewayURL + "/api/v1/status"); err == nil {
+		defer func() { _ = vResp.Body.Close() }()
+		if vResp.StatusCode == http.StatusOK {
+			var body struct {
+				Version string `json:"version"`
+			}
+			if json.NewDecoder(vResp.Body).Decode(&body) == nil && body.Version != "" {
+				status.Version = body.Version
+			}
+		}
+	}
+
+	return status
 }
 
 // OpenInBrowser opens the given URL in the system default browser.

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGetServerStatus_DaemonRunning(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "healthy"})
+	})
+	mux.HandleFunc("/api/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"version": "1.40.1",
+			"running": true,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := &App{
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+		gatewayURL: srv.URL,
+	}
+
+	status := app.GetServerStatus()
+	if !status.Running {
+		t.Fatal("expected Running=true when daemon is healthy")
+	}
+	if status.Version != "1.40.1" {
+		t.Fatalf("expected version 1.40.1, got %q", status.Version)
+	}
+	if status.GatewayURL != srv.URL {
+		t.Fatalf("expected GatewayURL=%q, got %q", srv.URL, status.GatewayURL)
+	}
+}
+
+func TestGetServerStatus_DaemonNotRunning(t *testing.T) {
+	app := &App{
+		httpClient: &http.Client{Timeout: 1 * time.Second},
+		gatewayURL: "http://127.0.0.1:1", // nothing listening
+	}
+
+	status := app.GetServerStatus()
+	if status.Running {
+		t.Fatal("expected Running=false when daemon is unreachable")
+	}
+}
+
+func TestGetServerStatus_EmptyGatewayURL(t *testing.T) {
+	app := &App{
+		httpClient: &http.Client{Timeout: 1 * time.Second},
+		gatewayURL: "",
+	}
+
+	status := app.GetServerStatus()
+	if status.Running {
+		t.Fatal("expected Running=false when gatewayURL is empty")
+	}
+}
+
+func TestGetServerStatus_HealthOK_StatusUnauthorized(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "healthy"})
+	})
+	mux.HandleFunc("/api/v1/status", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	app := &App{
+		httpClient: &http.Client{Timeout: 2 * time.Second},
+		gatewayURL: srv.URL,
+	}
+
+	status := app.GetServerStatus()
+	if !status.Running {
+		t.Fatal("expected Running=true even when /api/v1/status returns 401")
+	}
+	if status.Version != "" {
+		t.Fatalf("expected empty version when status is unauthorized, got %q", status.Version)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes CI lint failure from PR #1591 by wrapping `resp.Body.Close()` in deferred closures that discard the error value, satisfying the `errcheck` linter
- Includes the original feature (real daemon health check in `GetServerStatus`) and its tests

Closes #1592

## Test plan

- [x] `golangci-lint run ./desktop/...` passes (0 issues)
- [x] `go test ./desktop/...` passes