### PR TITLE
feat(executor): write execution milestones to log store

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -382,6 +382,11 @@ Examples:
 					}
 				}
 
+				// GH-1599: Wire log store for execution milestone entries (gateway mode)
+				if gwStore != nil {
+					gwRunner.SetLogStore(gwStore)
+				}
+
 				// Create approval manager for autopilot
 				approvalMgr := approval.NewManager(cfg.Approval)
 
@@ -1358,6 +1363,11 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 			runner.SetKnowledgeStore(knowledgeStore)
 			logging.WithComponent("knowledge").Debug("Knowledge store initialized for polling mode")
 		}
+	}
+
+	// GH-1599: Wire log store for execution milestone entries
+	if store != nil {
+		runner.SetLogStore(store)
 	}
 
 	// Create monitor and TUI program for dashboard mode


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1599.

Closes #1599

## Changes

GitHub Issue #1599: feat(executor): write execution milestones to log store

## Context

GH-1586 added the `execution_logs` SQLite table and `SaveLogEntry()`/`GetRecentLogs()` to the memory store, plus wired the LogsPanel in the desktop frontend. Now the executor needs to actually write milestone entries during task execution.

## Implementation

**File:** `internal/executor/runner.go`

1. Add a `logStore` field to the `Runner` struct:
```go
type Runner struct {
    // ... existing fields
    logStore *memory.Store
}
```

2. Set it in the constructor (or add a `SetLogStore(store *memory.Store)` method).

3. At each `monitor.UpdateProgress()` call site, also call `r.saveLogEntry()`:

```go
func (r *Runner) saveLogEntry(executionID, level, message string) {
    if r.logStore == nil {
        return
    }
    r.logStore.SaveLogEntry(&memory.LogEntry{
        ExecutionID: executionID,
        Level:       level,
        Message:     message,
        Component:   "executor",
    })
}
```

4. Key insertion points in `executeWithOptions()`:
   - Task started: `r.saveLogEntry(id, "info", "Task started: "+task.Title)`
   - Branch created: `r.saveLogEntry(id, "info", "Branch created: "+branchName)`
   - Exploring phase: `r.saveLogEntry(id, "info", "Exploring codebase...")`
   - Implementing phase: `r.saveLogEntry(id, "info", "Implementing changes...")`
   - Testing phase: `r.saveLogEntry(id, "info", "Running tests...")`
   - Self-review: `r.saveLogEntry(id, "info", "Running self-review...")`
   - PR created: `r.saveLogEntry(id, "info", "PR created: "+prURL)`
   - Complete: `r.saveLogEntry(id, "info", "Task completed successfully")`
   - Failed: `r.saveLogEntry(id, "error", "Task failed: "+err.Error())`

5. Wire in `cmd/pilot/main.go` — pass the store to the runner.

## Acceptance Criteria

- LogsPanel in desktop app shows milestone entries as tasks execute
- Each execution produces 5-10 structured log entries
- Entries have correct timestamps and levels (info/error)
- No performance impact (SaveLogEntry is fire-and-forget)