### PR TITLE
feat(gateway): replace /api/v1/tasks placeholder with real monitor data

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1000,6 +1000,12 @@ Examples:
 				p.Gateway().SetAutopilotProvider(&autopilotProviderAdapter{controller: gwAutopilotController})
 			}
 
+			// GH-1601: Wire task monitor to gateway so /api/v1/tasks returns live task data
+			p.Gateway().SetTaskMonitor(&taskStatesProviderAdapter{getStates: p.GetTaskStates})
+			if gwStore != nil {
+				p.Gateway().SetExecutionStore(&executionStoreAdapter{store: gwStore})
+			}
+
 			if err := p.Start(); err != nil {
 				return fmt.Errorf("failed to start Pilot: %w", err)
 			}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1601.

Closes #1601

## Changes

GitHub Issue #1601: feat(gateway): replace /api/v1/tasks placeholder with real monitor data

## Context

The gateway's `handleTasks` at `internal/gateway/server.go` (~line 411) returns a placeholder empty array `{"tasks": []}`. It should return real data from the in-memory task monitor and SQLite store.

## Implementation

### 1. Add TaskMonitor interface to `internal/gateway/server.go`

```go
type TaskMonitor interface {
    GetAll() []*executor.TaskState
    GetRunning() []*executor.TaskState
}

func (s *Server) SetTaskMonitor(m TaskMonitor)
```

Add `taskMonitor TaskMonitor` field to Server struct.

### 2. Update `handleTasks` handler

Replace the placeholder with real data:
```go
func (s *Server) handleTasks(w http.ResponseWriter, r *http.Request) {
    var tasks []TaskResponse

    // Live tasks from in-memory monitor (real-time progress)
    if s.taskMonitor != nil {
        for _, t := range s.taskMonitor.GetAll() {
            tasks = append(tasks, TaskResponse{
                ID:       t.ID,
                Title:    t.Title,
                Status:   string(t.Status),
                Phase:    t.Phase,
                Progress: t.Progress,
                PRUrl:    t.PRUrl,
                IssueURL: t.IssueURL,
                Message:  t.Message,
            })
        }
    }

    // If no live tasks, fall back to recent from store
    if len(tasks) == 0 && s.dashboardStore != nil {
        recent, _ := s.dashboardStore.GetRecentExecutions(10)
        for _, e := range recent {
            tasks = append(tasks, TaskResponse{
                ID:     e.TaskID,
                Title:  e.TaskTitle,
                Status: e.Status,
            })
        }
    }

    json.NewEncoder(w).Encode(map[string]interface{}{"tasks": tasks})
}
```

### 3. Wire in `cmd/pilot/main.go`

After creating the monitor and gateway server:
```go
gatewayServer.SetTaskMonitor(monitor)
```

Find both gateway initialization paths (gateway mode + polling mode) and wire in both.

## Acceptance Criteria

- `GET /api/v1/tasks` returns running tasks with real-time progress
- Falls back to recent executions when no tasks are active
- Shows task ID, title, status, phase, progress percentage
- No breaking changes to existing API consumers