### PR TITLE
feat(desktop): browser CSS adaptation with wails-mode class

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -9,11 +9,12 @@ import { useDashboard } from './hooks/useDashboard'
 
 function App() {
   const { metrics, queueTasks, history, autopilot, server, logs } = useDashboard()
+  const isWails = !!(window as any).go?.main?.App
 
   return (
-    <div className="flex flex-col h-full bg-bg overflow-hidden">
-      {/* macOS hidden-inset titlebar spacer */}
-      <div className="h-7 shrink-0" />
+    <div className={`flex flex-col h-full bg-bg overflow-hidden ${isWails ? 'wails-mode' : 'browser-mode'}`}>
+      {/* macOS hidden-inset titlebar spacer — only in Wails mode */}
+      {isWails && <div className="h-7 shrink-0" />}
 
       <Header serverRunning={server.running} version={server.version} />
 

--- a/desktop/frontend/src/styles/globals.css
+++ b/desktop/frontend/src/styles/globals.css
@@ -20,11 +20,21 @@
     font-size: 12px;
     line-height: 1.5;
     overflow: hidden;
-    /* Disable text selection for native app feel */
+  }
+
+  /* Wails-specific styles: disable text selection, add titlebar padding */
+  .wails-mode {
     -webkit-user-select: none;
     user-select: none;
     /* macOS traffic light buttons: add top padding when titlebar hidden-inset */
     padding-top: env(safe-area-inset-top, 0px);
+  }
+
+  /* Browser-mode styles: normal text selection, standard scrollbar */
+  .browser-mode {
+    -webkit-user-select: auto;
+    user-select: auto;
+    padding-top: 0;
   }
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1611.

Closes #1611

## Changes

GitHub Issue #1611: feat(desktop): browser CSS adaptation with wails-mode class

## Context

The desktop frontend CSS has Wails-specific styles (disabled text selection, macOS titlebar spacer) that should not apply when the same React app runs in a browser via the gateway `/dashboard` route.

## Task

Add conditional CSS styling based on runtime mode:

### 1. `desktop/frontend/src/App.tsx`
- Detect mode: `const isWails = !!(window as any).go?.main?.App`
- Add `wails-mode` class to root element when in Wails mode
- Conditional macOS titlebar spacer — only render in Wails mode
- Example: `<div className={\`app-root \${isWails ? 'wails-mode' : 'browser-mode'}\`}>`

### 2. `desktop/frontend/src/styles/globals.css`
- Move `user-select: none` into `.wails-mode` selector
- Move any `-webkit-app-region: drag` styles into `.wails-mode`
- Add `.browser-mode` styles:
  - Normal text selection enabled
  - Standard scrollbar styling
  - Optional: slightly different max-width or padding for browser viewport
- Keep shared styles (colors, layout, typography) outside both selectors

## Acceptance Criteria

- [ ] `.wails-mode` class applied only when running in Wails
- [ ] `.browser-mode` class applied when running in browser
- [ ] Text selection works in browser mode
- [ ] Titlebar spacer only shows in Wails mode
- [ ] Desktop app appearance unchanged
- [ ] No visual regressions in either mode
- [ ] Tests pass, lint clean

## Key Files
- `desktop/frontend/src/App.tsx` — mode detection + class application
- `desktop/frontend/src/styles/globals.css` — conditional styles

## Dependencies
- Parallel with Issue I (no file overlap)