### PR TITLE
feat(desktop): create HTTP data provider for browser mode

### DIFF
--- a/desktop/frontend/src/apijs.ts
+++ b/desktop/frontend/src/apijs.ts
@@ -1,0 +1,46 @@
+// HTTP-based data provider for browser mode.
+// Same function signatures as wailsjs.ts, but uses fetch() against gateway API endpoints.
+
+import type { DashboardMetrics, QueueTask, HistoryEntry, AutopilotStatus, ServerStatus, LogEntry } from './types'
+
+async function fetchJSON<T>(path: string): Promise<T> {
+  const res = await fetch(path)
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+  }
+  return res.json() as Promise<T>
+}
+
+export function GetMetrics(): Promise<DashboardMetrics> {
+  return fetchJSON<DashboardMetrics>('/api/v1/metrics')
+}
+
+export function GetQueueTasks(): Promise<QueueTask[]> {
+  return fetchJSON<QueueTask[]>('/api/v1/queue')
+}
+
+export function GetHistory(limit: number): Promise<HistoryEntry[]> {
+  return fetchJSON<HistoryEntry[]>(`/api/v1/history?limit=${limit}`)
+}
+
+export function GetLogs(limit: number): Promise<LogEntry[]> {
+  return fetchJSON<LogEntry[]>(`/api/v1/logs?limit=${limit}`)
+}
+
+export function GetAutopilotStatus(): Promise<AutopilotStatus> {
+  return fetchJSON<AutopilotStatus>('/api/v1/autopilot')
+}
+
+export function GetServerStatus(): Promise<ServerStatus> {
+  return fetch('/api/v1/status')
+    .then((res) => {
+      if (!res.ok) return { running: false } as ServerStatus
+      return res.json() as Promise<ServerStatus>
+    })
+    .catch(() => ({ running: false }) as ServerStatus)
+}
+
+export function OpenInBrowser(url: string): Promise<void> {
+  window.open(url, '_blank')
+  return Promise.resolve()
+}

--- a/desktop/frontend/src/components/AutopilotPanel.tsx
+++ b/desktop/frontend/src/components/AutopilotPanel.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Card } from './ui/Card'
-import { OpenInBrowser } from '../wailsjs'
+import { api } from '../provider'
+
+const { OpenInBrowser } = api
 import type { AutopilotStatus, ActivePR } from '../types'
 
 // Stage icon mapping — matches TUI autopilot panel

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Card } from './ui/Card'
-import { OpenInBrowser } from '../wailsjs'
+import { api } from '../provider'
+
+const { OpenInBrowser } = api
 import type { HistoryEntry } from '../types'
 
 function timeAgo(dateStr: string): string {

--- a/desktop/frontend/src/components/QueuePanel.tsx
+++ b/desktop/frontend/src/components/QueuePanel.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { Card } from './ui/Card'
 import { StatusIcon } from './ui/StatusIcon'
 import { ProgressBar } from './ui/ProgressBar'
-import { OpenInBrowser } from '../wailsjs'
+import { api } from '../provider'
+
+const { OpenInBrowser } = api
 import type { QueueTask } from '../types'
 
 type TaskStatus = 'done' | 'running' | 'queued' | 'pending' | 'failed'

--- a/desktop/frontend/src/hooks/useDashboard.ts
+++ b/desktop/frontend/src/hooks/useDashboard.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef } from 'react'
 import type { DashboardMetrics, QueueTask, HistoryEntry, AutopilotStatus, ServerStatus, LogEntry } from '../types'
-import { GetMetrics, GetQueueTasks, GetHistory, GetAutopilotStatus, GetServerStatus, GetLogs } from '../wailsjs'
+import { api } from '../provider'
+
+const { GetMetrics, GetQueueTasks, GetHistory, GetAutopilotStatus, GetServerStatus, GetLogs } = api
 
 export interface DashboardState {
   metrics: DashboardMetrics

--- a/desktop/frontend/src/provider.ts
+++ b/desktop/frontend/src/provider.ts
@@ -1,0 +1,10 @@
+// Runtime mode detection: Wails desktop app vs browser (HTTP gateway).
+// Exports a unified `api` object with the same function signatures regardless of mode.
+
+import * as wailsApi from './wailsjs'
+import * as httpApi from './apijs'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isWails = typeof window !== 'undefined' && !!(window as any).go?.main?.App
+
+export const api = isWails ? wailsApi : httpApi


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1610.

Closes #1610

## Changes

GitHub Issue #1610: feat(desktop): create HTTP data provider for browser mode

## Context

The desktop frontend (`desktop/frontend/src/`) currently imports directly from `wailsjs.ts` which assumes Wails runtime is always available. For the web UI (served from gateway at `/dashboard`), we need an HTTP-based data provider that calls the gateway API endpoints instead.

## Task

Create a dual-mode data provider abstraction:

### 1. `desktop/frontend/src/apijs.ts` (new file)
Same function signatures as `wailsjs.ts`, but uses `fetch('/api/v1/*')`:
- `GetMetrics()` → `fetch('/api/v1/metrics')`
- `GetQueueTasks()` → `fetch('/api/v1/queue')`
- `GetHistory(limit)` → `fetch('/api/v1/history?limit=N')`
- `GetLogs(limit)` → `fetch('/api/v1/logs?limit=N')`
- `GetAutopilotStatus()` → `fetch('/api/v1/autopilot')`
- `GetServerStatus()` → `fetch('/api/v1/status')` with error → `{Running: false}`
- `OpenInBrowser(url)` → `window.open(url, '_blank')`

### 2. `desktop/frontend/src/provider.ts` (new file)
Runtime mode detection and provider export:
```typescript
const isWails = typeof window !== 'undefined' && !!(window as any).go?.main?.App;
export const api = isWails ? wailsApi : httpApi;
```

### 3. Update `desktop/frontend/src/hooks/useDashboard.ts`
- Import from `provider` instead of directly from `wailsjs`
- No other changes needed — same function signatures

## Acceptance Criteria

- [ ] `apijs.ts` created with all fetch-based methods matching wailsjs.ts signatures
- [ ] `provider.ts` detects Wails vs browser mode correctly
- [ ] `useDashboard.ts` imports from provider
- [ ] Desktop app still works (Wails path unchanged)
- [ ] Types match between both providers
- [ ] Tests pass, lint clean

## Key Files
- `desktop/frontend/src/apijs.ts` — new HTTP provider
- `desktop/frontend/src/provider.ts` — new mode detector
- `desktop/frontend/src/hooks/useDashboard.ts` — update imports
- `desktop/frontend/src/wailsjs.ts` — reference for signatures

## Dependencies
- Depends on Issue F (dashboard API endpoints) — ✅ already merged (PR #1606)