### PR TITLE
Add desktop app documentation to docs site

### DIFF
--- a/docs/content/deployment/_meta.js
+++ b/docs/content/deployment/_meta.js
@@ -1,6 +1,7 @@
 export default {
   index: "Overview",
   local: "Local / Bare Metal",
+  "desktop-app": "Desktop App",
   docker: "Docker",
   "docker-helm": "Docker & Helm",
   kubernetes: "Kubernetes",

--- a/docs/content/deployment/desktop-app.mdx
+++ b/docs/content/deployment/desktop-app.mdx
@@ -1,0 +1,155 @@
+import { Callout, Steps } from 'nextra/components'
+
+# Desktop App
+
+A native macOS desktop application that mirrors the [Dashboard TUI](/features/dashboard) in a graphical window. Built with [Wails](https://wails.io) and React.
+
+<Callout type="info">
+The desktop app connects to your running Pilot daemon via the gateway API. Start `pilot start` in a terminal first, then open Pilot.app alongside it.
+</Callout>
+
+---
+
+## Prerequisites
+
+- **Go 1.24+** — [golang.org/dl](https://go.dev/dl/)
+- **Node.js 18+** — for the frontend build
+- **Wails CLI v2** — install with `go install github.com/wailsapp/wails/v2/cmd/wails@latest`
+
+Verify Wails is installed:
+
+```bash
+wails doctor
+```
+
+---
+
+## Build from Source
+
+<Steps>
+
+### Clone the repository
+
+```bash
+git clone https://github.com/anthropics/pilot
+cd pilot
+```
+
+### Build the app
+
+```bash
+make desktop-build
+```
+
+This installs frontend dependencies (`npm ci`) and compiles a universal macOS binary via Wails. The output is at:
+
+```
+desktop/build/bin/Pilot.app
+```
+
+### (Optional) Package as a zip
+
+```bash
+make desktop-package VERSION=v1.40.1
+```
+
+Produces `bin/Pilot-macOS-v1.40.1.zip`.
+
+</Steps>
+
+---
+
+## Usage
+
+1. Start the Pilot daemon in a terminal:
+
+```bash
+pilot start --github --autopilot=dev
+```
+
+2. Open `Pilot.app` (from `desktop/build/bin/` or wherever you placed it).
+
+The desktop app reads `~/.pilot/config.yaml` to determine the gateway address and connects to the daemon automatically. If the daemon is not running, panels display empty state and retry on each poll cycle.
+
+---
+
+## Dashboard Panels
+
+The desktop app displays the same panels as the terminal dashboard:
+
+| Panel | Description |
+|-------|-------------|
+| **Header** | Logo, version, and daemon connection status |
+| **Metrics Cards** | Tokens, cost, and queue depth with 7-day sparklines |
+| **Queue** | Active, queued, and pending tasks with progress bars |
+| **Autopilot** | Mode, auto-release status, and active PR tracking |
+| **History** | Recent completed tasks with success/failure indicators |
+| **Logs** | Live execution log entries from the daemon |
+
+Metrics are read from the shared SQLite database at `~/.pilot/pilot.db`, so data persists across restarts and is shared between the TUI and desktop app.
+
+---
+
+## Configuration
+
+The desktop app reads the same `~/.pilot/config.yaml` as the CLI. The gateway address is derived from:
+
+```yaml
+gateway:
+  host: "127.0.0.1"
+  port: 9090
+```
+
+If no config exists or the gateway section is missing, the app defaults to `http://127.0.0.1:9090`.
+
+No additional configuration is required for the desktop app itself.
+
+---
+
+## Development
+
+For hot-reload during frontend development:
+
+```bash
+make desktop-dev
+```
+
+This runs `wails dev`, which starts a Vite dev server for the React frontend and rebuilds the Go backend on changes. The app window opens automatically.
+
+### Project structure
+
+```
+desktop/
+├── main.go              # Wails entrypoint
+├── app.go               # Go backend — metrics, queue, autopilot APIs
+├── types.go             # Shared type definitions
+├── wails.json           # Wails project config
+├── build/
+│   ├── appicon.png
+│   └── darwin/Info.plist
+└── frontend/
+    ├── src/
+    │   ├── App.tsx              # Root component
+    │   ├── components/          # Panel components
+    │   │   ├── Header.tsx
+    │   │   ├── MetricsCards.tsx
+    │   │   ├── QueuePanel.tsx
+    │   │   ├── AutopilotPanel.tsx
+    │   │   ├── HistoryPanel.tsx
+    │   │   └── LogsPanel.tsx
+    │   └── hooks/
+    │       ├── useDashboard.ts  # Data fetching hook
+    │       └── usePolling.ts    # Poll interval logic
+    ├── package.json
+    └── vite.config.ts
+```
+
+### Make targets
+
+| Target | Description |
+|--------|-------------|
+| `make desktop-deps` | Install frontend dependencies |
+| `make desktop-dev` | Run in development mode with hot reload |
+| `make desktop-build` | Build production `Pilot.app` (darwin/universal) |
+| `make desktop-package` | Build and zip for distribution (`VERSION=vX.Y.Z`) |
+| `make desktop-clean` | Remove build artifacts and node_modules |

--- a/docs/content/features/dashboard.mdx
+++ b/docs/content/features/dashboard.mdx
@@ -4,6 +4,10 @@ import { Callout } from 'nextra/components'
 
 Real-time terminal interface for monitoring Pilot operations.
 
+<Callout type="info">
+Looking for a graphical interface? The [Desktop App](/deployment/desktop-app) provides the same panels in a native macOS window built with Wails.
+</Callout>
+
 ## Launching
 
 ```bash

--- a/docs/content/getting-started/quickstart.mdx
+++ b/docs/content/getting-started/quickstart.mdx
@@ -301,9 +301,24 @@ helm install pilot ./helm/pilot \
 See the [Docker & Helm deployment guide](/deployment/docker-helm) for full configuration, persistence setup, ingress for webhooks, monitoring, and security hardening.
 </Callout>
 
+## Desktop App
+
+Prefer a graphical interface? The Pilot desktop app provides the same dashboard panels in a native macOS window:
+
+```bash
+# Build from source (requires Wails CLI)
+make desktop-build
+
+# Open alongside your running Pilot daemon
+open desktop/build/bin/Pilot.app
+```
+
+See the [Desktop App guide](/deployment/desktop-app) for prerequisites and full setup.
+
 ## Next Steps
 
 - [Configuration](/getting-started/configuration) — Tune all config.yaml options
+- [Desktop App](/deployment/desktop-app) — Native macOS dashboard application
 - [Docker & Helm](/deployment/docker-helm) — Production container deployment
 - [Tunnel Setup](/guides/tunnel-setup) — Instant webhooks via Cloudflare or ngrok
 - [Autopilot](/features/autopilot) — Automatic CI monitoring and merge


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1504.

Closes #1504

## Changes

GitHub Issue #1504: Add desktop app documentation to docs site

## Context

Depends on GH-1503 (Wails desktop app). After that merges, add docs covering installation and usage.

## Implementation

### New page: `docs/content/deployment/desktop-app.mdx`

Sections:
1. **Prerequisites** — Wails CLI, Go 1.24+, Node.js
2. **Build from source** — `make desktop-build`, output at `desktop/build/bin/Pilot.app`
3. **Usage** — Run `pilot start` in terminal, open Pilot.app alongside
4. **Dashboard panels** — What each panel shows (metrics, queue, autopilot, history)
5. **Configuration** — Reads `~/.pilot/config.yaml`, connects to gateway on configured port
6. **Development** — `make desktop-dev` for hot reload

### Update existing pages
- `docs/content/getting-started/quickstart.mdx` — Add "Desktop App" section
- `docs/content/dashboard.mdx` — Cross-reference desktop app as GUI alternative to TUI

## Acceptance Criteria
- [ ] New `desktop-app.mdx` page with all sections
- [ ] Navigation updated in sidebar
- [ ] Cross-references from quickstart and dashboard pages
- [ ] `npm run build` succeeds in docs/