### PR TITLE
fix(gateway): handle errcheck lint errors in SPA handler (GH-1619)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ desktop/frontend/node_modules/
 desktop/frontend/dist/
 desktop/build/bin/
 !desktop/frontend/dist/.gitkeep
+
+# Embedded dashboard build artifact (created by make build-with-dashboard)
+cmd/pilot/dashboard_dist/

--- a/cmd/pilot/embed_dashboard.go
+++ b/cmd/pilot/embed_dashboard.go
@@ -1,0 +1,11 @@
+//go:build embed_dashboard
+
+package main
+
+import "embed"
+
+//go:embed all:dashboard_dist
+var dashboardFS embed.FS
+
+// dashboardEmbedded indicates whether the dashboard frontend is embedded in this build.
+const dashboardEmbedded = true

--- a/cmd/pilot/embed_dashboard_stub.go
+++ b/cmd/pilot/embed_dashboard_stub.go
@@ -1,0 +1,11 @@
+//go:build !embed_dashboard
+
+package main
+
+import "embed"
+
+// dashboardFS is an empty filesystem when building without embedded dashboard.
+var dashboardFS embed.FS
+
+// dashboardEmbedded indicates whether the dashboard frontend is embedded in this build.
+const dashboardEmbedded = false

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -286,6 +286,11 @@ Examples:
 			// Build Pilot options for gateway mode (GH-349)
 			var pilotOpts []pilot.Option
 
+			// Serve embedded React dashboard at /dashboard/ if available (GH-1612)
+			if dashboardEmbedded {
+				pilotOpts = append(pilotOpts, pilot.WithDashboardFS(dashboardFS))
+			}
+
 			// GH-392: Create shared infrastructure for polling adapters in gateway mode
 			// This allows GitHub polling to work alongside Linear/Jira webhooks
 			telegramFlagSet := cmd.Flags().Changed("telegram")

--- a/desktop/frontend/vite.config.ts
+++ b/desktop/frontend/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  base: process.env.VITE_BASE_PATH || '/',
   build: {
     outDir: 'dist',
     emptyOutDir: true,

--- a/internal/gateway/frontend.go
+++ b/internal/gateway/frontend.go
@@ -1,0 +1,100 @@
+package gateway
+
+import (
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// SetDashboardFS sets the embedded frontend filesystem for serving the React dashboard.
+// The fsys should contain the built frontend files (index.html, assets/, etc.)
+// under a "dashboard_dist" subdirectory (from the go:embed directive).
+// Must be called before Start().
+func (s *Server) SetDashboardFS(fsys fs.FS) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dashboardFS = fsys
+}
+
+// serveDashboard registers the /dashboard/ route on the given mux.
+// It serves static files from the embedded FS with SPA fallback:
+// any path under /dashboard/ that doesn't match a real file serves index.html.
+func (s *Server) serveDashboard(mux *http.ServeMux) {
+	s.mu.RLock()
+	fsys := s.dashboardFS
+	s.mu.RUnlock()
+
+	if fsys == nil {
+		return
+	}
+
+	// Try to access the "dashboard_dist" subdirectory from the embed.
+	// The go:embed directive includes the directory name, so we need Sub().
+	sub, err := fs.Sub(fsys, "dashboard_dist")
+	if err != nil {
+		logging.WithComponent("gateway").Warn("dashboard frontend not available", slog.Any("error", err))
+		return
+	}
+
+	// Verify index.html exists
+	if _, err := fs.Stat(sub, "index.html"); err != nil {
+		logging.WithComponent("gateway").Warn("dashboard frontend missing index.html", slog.Any("error", err))
+		return
+	}
+
+	handler := &spaHandler{
+		fs:     sub,
+		prefix: "/dashboard/",
+	}
+
+	mux.Handle("/dashboard/", handler)
+	logging.WithComponent("gateway").Info("dashboard frontend registered at /dashboard/")
+}
+
+// spaHandler serves static files from an embedded filesystem with SPA fallback.
+// For paths that don't match a real file, it serves index.html so client-side
+// routing works correctly.
+type spaHandler struct {
+	fs     fs.FS
+	prefix string
+}
+
+func (h *spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Strip the prefix to get the file path within the FS
+	path := strings.TrimPrefix(r.URL.Path, h.prefix)
+	if path == "" {
+		path = "index.html"
+	}
+
+	// Try to open the requested file
+	f, err := h.fs.Open(path)
+	if err == nil {
+		_ = f.Close()
+		// File exists — serve it with proper MIME type and cache headers
+		if isStaticAsset(path) {
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		}
+		http.StripPrefix(h.prefix, http.FileServer(http.FS(h.fs))).ServeHTTP(w, r)
+		return
+	}
+
+	// File not found — SPA fallback: serve index.html
+	indexFile, err := fs.ReadFile(h.fs, "index.html")
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
+	_, _ = w.Write(indexFile)
+}
+
+// isStaticAsset returns true for paths that are hashed static assets
+// (JS, CSS, images in /assets/) which can be cached aggressively.
+func isStaticAsset(path string) bool {
+	return strings.HasPrefix(path, "assets/")
+}

--- a/internal/gateway/frontend_test.go
+++ b/internal/gateway/frontend_test.go
@@ -1,0 +1,162 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+func TestSPAHandler_ServesIndexHTML(t *testing.T) {
+	fs := fstest.MapFS{
+		"index.html": &fstest.MapFile{Data: []byte("<html>dashboard</html>")},
+	}
+
+	handler := &spaHandler{fs: fs, prefix: "/dashboard/"}
+
+	req := httptest.NewRequest("GET", "/dashboard/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Errorf("expected text/html content type, got %q", ct)
+	}
+	if body := w.Body.String(); body != "<html>dashboard</html>" {
+		t.Errorf("unexpected body: %s", body)
+	}
+}
+
+func TestSPAHandler_ServesStaticAssets(t *testing.T) {
+	fs := fstest.MapFS{
+		"index.html":        &fstest.MapFile{Data: []byte("<html>dashboard</html>")},
+		"assets/index.js":   &fstest.MapFile{Data: []byte("console.log('app')")},
+		"assets/index.css":  &fstest.MapFile{Data: []byte("body{}")},
+	}
+
+	handler := &spaHandler{fs: fs, prefix: "/dashboard/"}
+
+	tests := []struct {
+		name       string
+		path       string
+		wantCache  string
+		wantStatus int
+	}{
+		{"js asset", "/dashboard/assets/index.js", "public, max-age=31536000, immutable", http.StatusOK},
+		{"css asset", "/dashboard/assets/index.css", "public, max-age=31536000, immutable", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected %d, got %d", tt.wantStatus, w.Code)
+			}
+			if cc := w.Header().Get("Cache-Control"); cc != tt.wantCache {
+				t.Errorf("expected cache-control %q, got %q", tt.wantCache, cc)
+			}
+		})
+	}
+}
+
+func TestSPAHandler_FallbackToIndex(t *testing.T) {
+	fs := fstest.MapFS{
+		"index.html": &fstest.MapFile{Data: []byte("<html>spa</html>")},
+	}
+
+	handler := &spaHandler{fs: fs, prefix: "/dashboard/"}
+
+	// Non-existent path should fall back to index.html (SPA routing)
+	req := httptest.NewRequest("GET", "/dashboard/settings/profile", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for SPA fallback, got %d", w.Code)
+	}
+	if body := w.Body.String(); body != "<html>spa</html>" {
+		t.Errorf("expected index.html content for SPA fallback, got %q", body)
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("expected no-cache for SPA fallback, got %q", cc)
+	}
+}
+
+func TestServeDashboard_NilFS(t *testing.T) {
+	s := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+	mux := http.NewServeMux()
+	// Should not panic with nil dashboardFS
+	s.serveDashboard(mux)
+}
+
+func TestServeDashboard_WithFS(t *testing.T) {
+	s := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+
+	fs := fstest.MapFS{
+		"dashboard_dist/index.html":       &fstest.MapFile{Data: []byte("<html>test</html>")},
+		"dashboard_dist/assets/app.js":    &fstest.MapFile{Data: []byte("app()")},
+	}
+	s.SetDashboardFS(fs)
+
+	mux := http.NewServeMux()
+	s.serveDashboard(mux)
+
+	// Test index route
+	req := httptest.NewRequest("GET", "/dashboard/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for /dashboard/, got %d", w.Code)
+	}
+	if body := w.Body.String(); body != "<html>test</html>" {
+		t.Errorf("unexpected body: %s", body)
+	}
+}
+
+func TestServeDashboard_SPARouting(t *testing.T) {
+	s := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+
+	fs := fstest.MapFS{
+		"dashboard_dist/index.html": &fstest.MapFile{Data: []byte("<html>spa</html>")},
+	}
+	s.SetDashboardFS(fs)
+
+	mux := http.NewServeMux()
+	s.serveDashboard(mux)
+
+	// Deep path should serve index.html
+	req := httptest.NewRequest("GET", "/dashboard/tasks/123/details", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for SPA route, got %d", w.Code)
+	}
+	if body := w.Body.String(); body != "<html>spa</html>" {
+		t.Errorf("expected index.html for SPA route, got %q", body)
+	}
+}
+
+func TestIsStaticAsset(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"assets/index.js", true},
+		{"assets/style.css", true},
+		{"index.html", false},
+		{"favicon.ico", false},
+	}
+
+	for _, tt := range tests {
+		if got := isStaticAsset(tt.path); got != tt.want {
+			t.Errorf("isStaticAsset(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Re-applies PR #1618 changes (embedded React dashboard at `/dashboard/`) with lint fixes
- Fixes two `errcheck` violations in `internal/gateway/frontend.go`: explicitly discards `f.Close()` and `w.Write()` return values

## Context
- **Original PR**: #1618 (closed due to CI lint failure)
- **Original Issue**: #1612
- **Fix Issue**: #1619

## Test plan
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] `go build ./...` passes
- [x] `go test ./internal/gateway/... ./internal/pilot/... ./cmd/pilot/...` passes

Closes #1619
Closes #1612