### PR TITLE
feat(gateway): WebSocket log streaming for web dashboard

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1013,6 +1013,7 @@ Examples:
 			// GH-1609: Wire dashboard store to gateway so /api/v1/{metrics,queue,history,logs} return 200
 			if gwStore != nil {
 				p.Gateway().SetDashboardStore(gwStore)
+				p.Gateway().SetLogStreamStore(gwStore)
 			}
 
 			if err := p.Start(); err != nil {

--- a/desktop/frontend/src/hooks/useWebSocket.ts
+++ b/desktop/frontend/src/hooks/useWebSocket.ts
@@ -1,0 +1,158 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import type { LogEntry } from '../types'
+import { api } from '../provider'
+
+const { GetLogs } = api
+
+/** Maximum number of log entries kept in state to bound memory. */
+const MAX_LOG_ENTRIES = 200
+
+/** Initial reconnect delay in ms — doubles on each failure (exponential backoff). */
+const INITIAL_RECONNECT_MS = 1000
+
+/** Maximum reconnect delay in ms. */
+const MAX_RECONNECT_MS = 30000
+
+/** Polling interval (ms) used as fallback when WebSocket is unavailable. */
+const POLL_INTERVAL_MS = 2000
+
+/**
+ * Resolves the WebSocket URL for the dashboard log stream endpoint.
+ * Uses the current page host so it works behind reverse proxies.
+ */
+function wsURL(): string {
+  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${proto}//${window.location.host}/ws/dashboard`
+}
+
+/**
+ * useDashboardLogs connects to the gateway WebSocket for real-time log streaming.
+ * Falls back to polling /api/v1/logs when WebSocket is unavailable (e.g. Wails mode).
+ */
+export function useDashboardLogs(): LogEntry[] {
+  const [logs, setLogs] = useState<LogEntry[]>([])
+  const wsRef = useRef<WebSocket | null>(null)
+  const reconnectDelay = useRef(INITIAL_RECONNECT_MS)
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const unmounted = useRef(false)
+  const usingFallback = useRef(false)
+
+  const appendLogs = useCallback((newEntries: LogEntry[]) => {
+    setLogs((prev) => {
+      const merged = [...prev, ...newEntries]
+      return merged.length > MAX_LOG_ENTRIES ? merged.slice(-MAX_LOG_ENTRIES) : merged
+    })
+  }, [])
+
+  useEffect(() => {
+    unmounted.current = false
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const isWails = typeof window !== 'undefined' && !!(window as any).go?.main?.App
+    if (isWails) {
+      // Wails mode: WebSocket not available, use polling.
+      usingFallback.current = true
+      const id = setInterval(async () => {
+        try {
+          const l = await GetLogs(20)
+          if (l && !unmounted.current) setLogs(l)
+        } catch {
+          // Graceful degradation
+        }
+      }, POLL_INTERVAL_MS)
+      return () => {
+        unmounted.current = true
+        clearInterval(id)
+      }
+    }
+
+    // Browser mode: use WebSocket with auto-reconnect.
+    function connect() {
+      if (unmounted.current) return
+
+      const ws = new WebSocket(wsURL())
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        reconnectDelay.current = INITIAL_RECONNECT_MS
+        usingFallback.current = false
+      }
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data)
+          if (Array.isArray(data)) {
+            // Initial batch
+            setLogs(data as LogEntry[])
+          } else {
+            // Single streamed entry
+            appendLogs([data as LogEntry])
+          }
+        } catch {
+          // Ignore malformed messages
+        }
+      }
+
+      ws.onclose = () => {
+        wsRef.current = null
+        if (unmounted.current) return
+        scheduleReconnect()
+      }
+
+      ws.onerror = () => {
+        // onclose will fire after onerror — reconnect handled there.
+        ws.close()
+      }
+    }
+
+    function scheduleReconnect() {
+      if (unmounted.current) return
+
+      // Start polling fallback while disconnected.
+      if (!usingFallback.current) {
+        usingFallback.current = true
+        startFallbackPolling()
+      }
+
+      const delay = reconnectDelay.current
+      reconnectDelay.current = Math.min(delay * 2, MAX_RECONNECT_MS)
+      reconnectTimer.current = setTimeout(connect, delay)
+    }
+
+    let fallbackInterval: ReturnType<typeof setInterval> | null = null
+
+    function startFallbackPolling() {
+      if (fallbackInterval) return
+      fallbackInterval = setInterval(async () => {
+        if (!usingFallback.current) {
+          if (fallbackInterval) {
+            clearInterval(fallbackInterval)
+            fallbackInterval = null
+          }
+          return
+        }
+        try {
+          const l = await GetLogs(20)
+          if (l && !unmounted.current) setLogs(l)
+        } catch {
+          // Graceful degradation
+        }
+      }, POLL_INTERVAL_MS)
+    }
+
+    connect()
+
+    return () => {
+      unmounted.current = true
+      if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
+      if (fallbackInterval) clearInterval(fallbackInterval)
+      if (wsRef.current) {
+        wsRef.current.onclose = null
+        wsRef.current.close()
+        wsRef.current = null
+      }
+    }
+  }, [appendLogs])
+
+  return logs
+}

--- a/internal/gateway/dashboard_ws.go
+++ b/internal/gateway/dashboard_ws.go
@@ -1,0 +1,148 @@
+package gateway
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+	"github.com/alekspetrov/pilot/internal/memory"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	// wsPingInterval is the interval between ping frames sent to the client.
+	wsPingInterval = 30 * time.Second
+	// wsPongTimeout is how long to wait for a pong response before closing.
+	wsPongTimeout = 10 * time.Second
+	// wsWriteTimeout is the deadline for writing a message to the client.
+	wsWriteTimeout = 5 * time.Second
+	// wsInitialLogCount is the number of historical log entries sent on connect.
+	wsInitialLogCount = 50
+)
+
+// LogStreamStore provides log subscription capabilities for WebSocket streaming.
+type LogStreamStore interface {
+	GetRecentLogs(limit int) ([]*memory.LogEntry, error)
+	SubscribeLogs() chan *memory.LogEntry
+	UnsubscribeLogs(ch chan *memory.LogEntry)
+}
+
+// SetLogStreamStore configures the store used by the dashboard WebSocket endpoint.
+func (s *Server) SetLogStreamStore(store LogStreamStore) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.logStreamStore = store
+}
+
+// handleDashboardWebSocket upgrades the connection to WebSocket and streams
+// log entries in real-time. On connect it sends the last 50 entries as an
+// initial payload, then pushes new entries as they arrive.
+func (s *Server) handleDashboardWebSocket(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	store := s.logStreamStore
+	s.mu.RUnlock()
+
+	if store == nil {
+		http.Error(w, "log stream store not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	conn, err := s.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		logging.WithComponent("gateway").Error("dashboard WS upgrade error", slog.Any("error", err))
+		return
+	}
+
+	log := logging.WithComponent("gateway")
+	log.Info("dashboard WebSocket connected", slog.String("remote", r.RemoteAddr))
+
+	// Subscribe to new log entries before fetching history to avoid gaps.
+	sub := store.SubscribeLogs()
+	defer store.UnsubscribeLogs(sub)
+
+	// Send initial batch of recent log entries.
+	if err := sendInitialLogs(conn, store); err != nil {
+		log.Warn("dashboard WS initial send failed", slog.Any("error", err))
+		_ = conn.Close()
+		return
+	}
+
+	// Set up pong handler for keepalive.
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(wsPingInterval + wsPongTimeout))
+	})
+	_ = conn.SetReadDeadline(time.Now().Add(wsPingInterval + wsPongTimeout))
+
+	// Read pump: drain client messages (none expected) and detect disconnect.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure, websocket.CloseAbnormalClosure) {
+					log.Warn("dashboard WS read error", slog.Any("error", err))
+				}
+				return
+			}
+		}
+	}()
+
+	// Write pump: stream new entries and send pings.
+	ticker := time.NewTicker(wsPingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case entry, ok := <-sub:
+			if !ok {
+				return
+			}
+			resp := logEntryResponse{
+				Ts:        entry.Timestamp.Format("15:04:05"),
+				Level:     entry.Level,
+				Message:   entry.Message,
+				Component: entry.Component,
+			}
+			_ = conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
+			if err := conn.WriteJSON(resp); err != nil {
+				log.Debug("dashboard WS write error", slog.Any("error", err))
+				return
+			}
+		case <-ticker.C:
+			_ = conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		case <-done:
+			return
+		}
+	}
+}
+
+// sendInitialLogs sends the last N log entries to the newly connected client.
+func sendInitialLogs(conn *websocket.Conn, store LogStreamStore) error {
+	entries, err := store.GetRecentLogs(wsInitialLogCount)
+	if err != nil {
+		return err
+	}
+
+	// GetRecentLogs returns DESC order; reverse for chronological display.
+	result := make([]logEntryResponse, len(entries))
+	for i, e := range entries {
+		result[len(entries)-1-i] = logEntryResponse{
+			Ts:        e.Timestamp.Format("15:04:05"),
+			Level:     e.Level,
+			Message:   e.Message,
+			Component: e.Component,
+		}
+	}
+
+	_ = conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
+	msg, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	return conn.WriteMessage(websocket.TextMessage, msg)
+}

--- a/internal/gateway/dashboard_ws_test.go
+++ b/internal/gateway/dashboard_ws_test.go
@@ -1,0 +1,206 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/memory"
+	"github.com/gorilla/websocket"
+)
+
+// mockLogStreamStore implements LogStreamStore for testing.
+type mockLogStreamStore struct {
+	logEntries []*memory.LogEntry
+	subs       []chan *memory.LogEntry
+}
+
+func (m *mockLogStreamStore) GetRecentLogs(_ int) ([]*memory.LogEntry, error) {
+	return m.logEntries, nil
+}
+
+func (m *mockLogStreamStore) SubscribeLogs() chan *memory.LogEntry {
+	ch := make(chan *memory.LogEntry, 64)
+	m.subs = append(m.subs, ch)
+	return ch
+}
+
+func (m *mockLogStreamStore) UnsubscribeLogs(ch chan *memory.LogEntry) {
+	for i, sub := range m.subs {
+		if sub == ch {
+			m.subs = append(m.subs[:i], m.subs[i+1:]...)
+			break
+		}
+	}
+	close(ch)
+}
+
+// publish sends a log entry to all current subscribers.
+func (m *mockLogStreamStore) publish(entry *memory.LogEntry) {
+	for _, ch := range m.subs {
+		select {
+		case ch <- entry:
+		default:
+		}
+	}
+}
+
+func TestDashboardWebSocket_InitialLogs(t *testing.T) {
+	now := time.Now()
+	store := &mockLogStreamStore{
+		logEntries: []*memory.LogEntry{
+			{ID: 2, Timestamp: now, Level: "info", Message: "second", Component: "test"},
+			{ID: 1, Timestamp: now.Add(-time.Second), Level: "warn", Message: "first", Component: "test"},
+		},
+	}
+
+	srv := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+	srv.logStreamStore = store
+
+	ts := httptest.NewServer(http.HandlerFunc(srv.handleDashboardWebSocket))
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("WebSocket dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	// Read initial batch
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage failed: %v", err)
+	}
+
+	var initial []logEntryResponse
+	if err := json.Unmarshal(msg, &initial); err != nil {
+		t.Fatalf("Unmarshal initial logs failed: %v", err)
+	}
+
+	if len(initial) != 2 {
+		t.Fatalf("Expected 2 initial entries, got %d", len(initial))
+	}
+
+	// Should be reversed to chronological order (oldest first)
+	if initial[0].Message != "first" {
+		t.Errorf("Expected first entry 'first', got %q", initial[0].Message)
+	}
+	if initial[1].Message != "second" {
+		t.Errorf("Expected second entry 'second', got %q", initial[1].Message)
+	}
+}
+
+func TestDashboardWebSocket_StreamEntry(t *testing.T) {
+	store := &mockLogStreamStore{}
+
+	srv := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+	srv.logStreamStore = store
+
+	ts := httptest.NewServer(http.HandlerFunc(srv.handleDashboardWebSocket))
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("WebSocket dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	// Read empty initial batch
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage failed: %v", err)
+	}
+
+	var initial []logEntryResponse
+	if err := json.Unmarshal(msg, &initial); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if len(initial) != 0 {
+		t.Fatalf("Expected 0 initial entries, got %d", len(initial))
+	}
+
+	// Publish a new entry
+	store.publish(&memory.LogEntry{
+		ID:        3,
+		Timestamp: time.Now(),
+		Level:     "error",
+		Message:   "streamed entry",
+		Component: "executor",
+	})
+
+	// Read streamed entry
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err = conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage for streamed entry failed: %v", err)
+	}
+
+	var entry logEntryResponse
+	if err := json.Unmarshal(msg, &entry); err != nil {
+		t.Fatalf("Unmarshal streamed entry failed: %v", err)
+	}
+
+	if entry.Message != "streamed entry" {
+		t.Errorf("Expected 'streamed entry', got %q", entry.Message)
+	}
+	if entry.Level != "error" {
+		t.Errorf("Expected level 'error', got %q", entry.Level)
+	}
+	if entry.Component != "executor" {
+		t.Errorf("Expected component 'executor', got %q", entry.Component)
+	}
+}
+
+func TestDashboardWebSocket_NoStore(t *testing.T) {
+	srv := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+	// logStreamStore is nil
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ws/dashboard", nil)
+	srv.handleDashboardWebSocket(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("Expected 503, got %d", rr.Code)
+	}
+}
+
+func TestDashboardWebSocket_ClientDisconnect(t *testing.T) {
+	store := &mockLogStreamStore{}
+
+	srv := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+	srv.logStreamStore = store
+
+	ts := httptest.NewServer(http.HandlerFunc(srv.handleDashboardWebSocket))
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("WebSocket dial failed: %v", err)
+	}
+
+	// Read initial batch
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _, _ = conn.ReadMessage()
+
+	// Verify subscriber was added
+	if len(store.subs) != 1 {
+		t.Fatalf("Expected 1 subscriber, got %d", len(store.subs))
+	}
+
+	// Close client connection
+	conn.Close()
+
+	// Give server time to clean up
+	time.Sleep(100 * time.Millisecond)
+
+	// After disconnect, subscriber should be cleaned up
+	if len(store.subs) != 0 {
+		t.Errorf("Expected 0 subscribers after disconnect, got %d", len(store.subs))
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -77,6 +77,7 @@ type Server struct {
 	prometheusExporter  *PrometheusExporter
 	autopilotProvider   AutopilotProvider
 	dashboardStore      DashboardStore
+	logStreamStore      LogStreamStore
 }
 
 // Config holds gateway server configuration including network binding options.
@@ -182,6 +183,9 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// WebSocket endpoint for control plane
 	mux.HandleFunc("/ws", s.handleWebSocket)
+
+	// WebSocket endpoint for dashboard log streaming
+	mux.HandleFunc("/ws/dashboard", s.handleDashboardWebSocket)
 
 	// Public endpoints (no auth required)
 	mux.HandleFunc("/health", s.handleHealth)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1613.

Closes #1613

## Changes

GitHub Issue #1613: feat(gateway): WebSocket log streaming for web dashboard

## Context

The browser dashboard currently polls `/api/v1/logs` every 2s. For real-time log streaming, add a WebSocket endpoint that pushes new log entries as they arrive.

## Task

### 1. `internal/gateway/dashboard_ws.go` (new file)
- New `/ws/dashboard` WebSocket endpoint (use `gorilla/websocket` or `nhooyr.io/websocket`)
- On connect: send last 50 log entries as initial payload
- Then stream new entries as they arrive
- Handle client disconnect gracefully
- Ping/pong keepalive

### 2. `internal/memory/store.go`
- Add `LogSubscriber` fan-out mechanism:
  - `SubscribeLogs() <-chan *LogEntry` — returns channel that receives new entries
  - `UnsubscribeLogs(ch <-chan *LogEntry)` — cleanup
  - `SaveLogEntry()` also sends to all subscribers after DB write
- Use sync.RWMutex for subscriber map

### 3. `desktop/frontend/src/hooks/useWebSocket.ts` (new file)
- WebSocket hook that connects to `ws://host/ws/dashboard`
- Auto-reconnect with exponential backoff on disconnect
- Falls back to polling (`/api/v1/logs`) if WebSocket fails
- Export `useDashboardLogs()` that returns log entries array

### 4. Update `desktop/frontend/src/hooks/useDashboard.ts`
- Use `useDashboardLogs()` for log data instead of polling
- Keep polling as fallback (Wails mode doesn't use WebSocket)

## Acceptance Criteria

- [ ] WebSocket endpoint streams log entries in real-time
- [ ] Initial connection receives last 50 entries
- [ ] Auto-reconnect on disconnect
- [ ] Graceful fallback to polling when WS unavailable
- [ ] No goroutine leaks on client disconnect
- [ ] Tests pass, lint clean

## Dependencies
- Depends on Issue C (log store) — ✅ already merged
- Depends on Issue F (dashboard API) — ✅ already merged