### PR TITLE
feat(release): GoReleaser desktop app artifact for macOS

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -220,6 +220,7 @@
 | Stagnation monitor | ✅ | executor | - | - | State hash tracking, escalation: warn → pause → abort (v0.56.0) |
 | URL-encode branch names | ✅ | adapters/github | - | - | `url.PathEscape(branch)` in DeleteBranch/GetBranch — fixes 404 on slash branches (v1.28.0) |
 | Branch cleanup on PR close | ✅ | autopilot | - | - | Delete remote branches on PR close/fail, not just merge (v1.35.0) |
+| Desktop app release | ✅ | ci | - | - | Separate GH Actions workflow builds Wails macOS universal binary, uploads to release (v1.41.0) |
 
 ## Epic Management
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,48 @@
+name: Release Desktop
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  desktop:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Wails
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Build desktop app
+        run: |
+          cd desktop/frontend && npm ci
+          cd ../.. && cd desktop && wails build -platform darwin/universal -ldflags "-X main.version=${{ steps.version.outputs.VERSION }}"
+
+      - name: Package archive
+        run: |
+          cd desktop/build/bin
+          COPYFILE_DISABLE=1 zip -r ../../../Pilot-macOS-universal.zip Pilot.app
+
+      - name: Upload to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ steps.version.outputs.VERSION }}" Pilot-macOS-universal.zip --clobber


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1614.

Closes #1614

## Changes

GitHub Issue #1614: feat(release): GoReleaser desktop app artifact for macOS

## Context

The desktop app (`desktop/`) builds via Wails but isn't included in GitHub Releases. The CLI binary is built by GoReleaser — the desktop app needs a separate build step since it requires CGO=1 (WebKit).

## Task

### Option A: Separate workflow (preferred)
Add `.github/workflows/release-desktop.yml`:
- Trigger on tag push (same as main release)
- macOS runner (macos-latest)
- Install Wails CLI, Node.js
- Build: `cd desktop && wails build -platform darwin/universal`
- Package: zip `Pilot.app` into `Pilot-macOS-universal.zip`
- Upload as extra asset to the existing GitHub Release using `gh release upload`

### Option B: GoReleaser extra artifact
If GoReleaser supports it, add to `.goreleaser.yaml`:
- Extra build with CGO_ENABLED=1
- macOS only (darwin/amd64 + darwin/arm64 universal)
- Separate from CLI binary build

### Notes
- Desktop requires CGO=1 for WebKit bindings — cannot cross-compile from Linux
- macOS only for now (Windows/Linux Wails support can come later)
- Version injection: pass build version via LDFLAGS to match CLI version
- Use `COPYFILE_DISABLE=1` to avoid macOS resource fork issues in archive

## Acceptance Criteria

- [ ] GitHub Release includes `Pilot-macOS-universal.zip` (or similar)
- [ ] Desktop app version matches CLI version
- [ ] Existing CLI release process unchanged
- [ ] Archive doesn't include macOS `._*` resource forks
- [ ] Tests pass, lint clean

## Dependencies
- Depends on Issue E (Makefile targets) — ✅ already merged