### PR TITLE
refactor(autopilot): Replace hardcoded environment checks with EnvironmentConfig + ResolvedEnv()

### DIFF
--- a/internal/autopilot/types_test.go
+++ b/internal/autopilot/types_test.go
@@ -1,0 +1,166 @@
+package autopilot
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolvedEnv_LegacyDev(t *testing.T) {
+	cfg := &Config{Environment: EnvDev}
+	env := cfg.ResolvedEnv()
+
+	if env.RequireApproval {
+		t.Error("dev: RequireApproval should be false")
+	}
+	if env.CITimeout != 5*time.Minute {
+		t.Errorf("dev: CITimeout = %v, want 5m", env.CITimeout)
+	}
+	if !env.SkipPostMergeCI {
+		t.Error("dev: SkipPostMergeCI should be true")
+	}
+}
+
+func TestResolvedEnv_LegacyStage(t *testing.T) {
+	cfg := &Config{Environment: EnvStage}
+	env := cfg.ResolvedEnv()
+
+	if env.RequireApproval {
+		t.Error("stage: RequireApproval should be false")
+	}
+	if env.CITimeout != 30*time.Minute {
+		t.Errorf("stage: CITimeout = %v, want 30m", env.CITimeout)
+	}
+	if env.SkipPostMergeCI {
+		t.Error("stage: SkipPostMergeCI should be false")
+	}
+}
+
+func TestResolvedEnv_LegacyProd(t *testing.T) {
+	cfg := &Config{Environment: EnvProd}
+	env := cfg.ResolvedEnv()
+
+	if !env.RequireApproval {
+		t.Error("prod: RequireApproval should be true")
+	}
+	if env.CITimeout != 30*time.Minute {
+		t.Errorf("prod: CITimeout = %v, want 30m", env.CITimeout)
+	}
+	if env.SkipPostMergeCI {
+		t.Error("prod: SkipPostMergeCI should be false")
+	}
+}
+
+func TestResolvedEnv_NewStyleMap(t *testing.T) {
+	cfg := &Config{
+		Environments: map[string]*EnvironmentConfig{
+			"staging": {
+				Branch:          "develop",
+				RequireApproval: false,
+				CITimeout:       15 * time.Minute,
+				SkipPostMergeCI: false,
+			},
+		},
+	}
+	if err := cfg.SetActiveEnvironment("staging"); err != nil {
+		t.Fatalf("SetActiveEnvironment: %v", err)
+	}
+
+	env := cfg.ResolvedEnv()
+	if env.Branch != "develop" {
+		t.Errorf("Branch = %q, want %q", env.Branch, "develop")
+	}
+	if env.CITimeout != 15*time.Minute {
+		t.Errorf("CITimeout = %v, want 15m", env.CITimeout)
+	}
+	if env.RequireApproval {
+		t.Error("RequireApproval should be false")
+	}
+}
+
+func TestResolvedEnv_CustomEnv(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Environments["qa"] = &EnvironmentConfig{
+		Branch:          "qa",
+		RequireApproval: true,
+		CITimeout:       10 * time.Minute,
+		SkipPostMergeCI: false,
+		PostMerge:       &PostMergeConfig{Action: "none"},
+	}
+
+	if err := cfg.SetActiveEnvironment("qa"); err != nil {
+		t.Fatalf("SetActiveEnvironment: %v", err)
+	}
+
+	env := cfg.ResolvedEnv()
+	if !env.RequireApproval {
+		t.Error("qa: RequireApproval should be true")
+	}
+	if env.CITimeout != 10*time.Minute {
+		t.Errorf("qa: CITimeout = %v, want 10m", env.CITimeout)
+	}
+	if env.Branch != "qa" {
+		t.Errorf("qa: Branch = %q, want %q", env.Branch, "qa")
+	}
+}
+
+func TestResolvedEnv_NewOverridesLegacy(t *testing.T) {
+	// Legacy field says prod (RequireApproval=true), but new-style active env is dev (RequireApproval=false).
+	cfg := &Config{
+		Environment: EnvProd,
+		Environments: map[string]*EnvironmentConfig{
+			"dev": {RequireApproval: false, CITimeout: 5 * time.Minute, SkipPostMergeCI: true},
+		},
+	}
+	if err := cfg.SetActiveEnvironment("dev"); err != nil {
+		t.Fatalf("SetActiveEnvironment: %v", err)
+	}
+
+	env := cfg.ResolvedEnv()
+	if env.RequireApproval {
+		t.Error("new-style dev should override legacy prod: RequireApproval should be false")
+	}
+}
+
+func TestEnvironmentName_Legacy(t *testing.T) {
+	tests := []struct {
+		env  Environment
+		want string
+	}{
+		{EnvDev, "dev"},
+		{EnvStage, "stage"},
+		{EnvProd, "prod"},
+	}
+	for _, tt := range tests {
+		cfg := &Config{Environment: tt.env}
+		got := cfg.EnvironmentName()
+		if got != tt.want {
+			t.Errorf("EnvironmentName() for env %q = %q, want %q", tt.env, got, tt.want)
+		}
+	}
+}
+
+func TestEnvironmentName_NewStyle(t *testing.T) {
+	cfg := DefaultConfig()
+	if err := cfg.SetActiveEnvironment("prod"); err != nil {
+		t.Fatalf("SetActiveEnvironment: %v", err)
+	}
+
+	got := cfg.EnvironmentName()
+	if got != "prod" {
+		t.Errorf("EnvironmentName() = %q, want %q", got, "prod")
+	}
+
+	// Custom env name
+	cfg2 := DefaultConfig()
+	cfg2.Environments["canary"] = &EnvironmentConfig{
+		RequireApproval: false,
+		CITimeout:       20 * time.Minute,
+	}
+	if err := cfg2.SetActiveEnvironment("canary"); err != nil {
+		t.Fatalf("SetActiveEnvironment canary: %v", err)
+	}
+	got2 := cfg2.EnvironmentName()
+	if got2 != "canary" {
+		t.Errorf("EnvironmentName() = %q, want %q", got2, "canary")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1640.

Closes #1640

## Changes

GitHub Issue #1640: refactor(autopilot): Replace hardcoded environment checks with EnvironmentConfig + ResolvedEnv()

## Context

`--autopilot=dev|stage|prod` currently controls approval gates via hardcoded `if env == EnvProd` checks, not deployment targets. We're restructuring the environment model so each environment is a **deployment pipeline** with its own config (branch, approval, CI timeout, post-merge action).

This is the foundational issue — all other environment redesign work depends on this.

## What to implement

### 1. New types in `internal/autopilot/types.go`

Add two new structs after line 16:

```go
// EnvironmentConfig defines a deployment pipeline for one target environment.
type EnvironmentConfig struct {
    // Branch is the target branch for PRs (e.g., "main", "develop").
    Branch string `yaml:"branch"`
    // RequireApproval gates merge on human approval.
    RequireApproval bool `yaml:"require_approval"`
    // ApprovalSource specifies which channel for approvals (telegram, slack, github-review).
    ApprovalSource ApprovalSource `yaml:"approval_source,omitempty"`
    // ApprovalTimeout is how long to wait for human approval.
    ApprovalTimeout time.Duration `yaml:"approval_timeout,omitempty"`
    // CITimeout overrides the CI wait timeout for this environment.
    CITimeout time.Duration `yaml:"ci_timeout"`
    // SkipPostMergeCI skips post-merge CI monitoring (fast path).
    SkipPostMergeCI bool `yaml:"skip_post_merge_ci"`
    // MergeMethod overrides the default merge method for this environment.
    MergeMethod string `yaml:"merge_method,omitempty"`
    // PostMerge defines what happens after merge (deployment trigger).
    PostMerge *PostMergeConfig `yaml:"post_merge,omitempty"`
    // Release holds per-environment release configuration.
    Release *ReleaseConfig `yaml:"release,omitempty"`
}

// PostMergeConfig defines the deployment trigger action after PR merge.
type PostMergeConfig struct {
    // Action: "none", "tag", "webhook", "branch-push"
    Action string `yaml:"action"`
    // WebhookURL for action "webhook".
    WebhookURL string `yaml:"webhook_url,omitempty"`
    // WebhookHeaders for action "webhook".
    WebhookHeaders map[string]string `yaml:"webhook_headers,omitempty"`
    // WebhookSecret for action "webhook" HMAC signing.
    WebhookSecret string `yaml:"webhook_secret,omitempty"`
    // DeployBranch for action "branch-push".
    DeployBranch string `yaml:"deploy_branch,omitempty"`
}
```

### 2. Update Config struct in `internal/autopilot/types.go`

Add new fields to Config (keep ALL existing fields for backwards compat):

```go
type Config struct {
    // ... all existing fields stay, add omitempty to Environment ...
    Environment Environment `yaml:"environment,omitempty"` // DEPRECATED

    // New fields:
    // DefaultEnvironment is the name of the environment used when --env is not specified.
    DefaultEnvironment string `yaml:"default_environment,omitempty"`
    // Environments is a map of named environment pipeline configs.
    Environments map[string]*EnvironmentConfig `yaml:"environments,omitempty"`
}
```

Add unexported runtime fields for the resolved environment:
- `activeEnvName string` (not serialized)
- `activeEnvConfig *EnvironmentConfig` (not serialized)

### 3. Add methods to Config

```go
// defaultEnvironments returns built-in environment configs matching legacy behavior.
func defaultEnvironments() map[string]*EnvironmentConfig {
    return map[string]*EnvironmentConfig{
        "dev": {
            Branch: "main", RequireApproval: false,
            CITimeout: 5 * time.Minute, SkipPostMergeCI: true,
            PostMerge: &PostMergeConfig{Action: "none"},
        },
        "stage": {
            Branch: "main", RequireApproval: false,
            CITimeout: 30 * time.Minute, SkipPostMergeCI: false,
            PostMerge: &PostMergeConfig{Action: "none"},
        },
        "prod": {
            Branch: "main", RequireApproval: true,
            ApprovalSource: ApprovalSourceTelegram,
            ApprovalTimeout: 1 * time.Hour,
            CITimeout: 30 * time.Minute, SkipPostMergeCI: false,
            PostMerge: &PostMergeConfig{Action: "tag"},
        },
    }
}

// ResolvedEnv returns the active environment config.
// If new-style Environments map is populated and activeEnvName is set, returns from map.
// Otherwise, falls back to legacy Environment field and synthesizes an EnvironmentConfig.
func (c *Config) ResolvedEnv() *EnvironmentConfig { ... }

// EnvironmentName returns the human-readable active environment name.
func (c *Config) EnvironmentName() string { ... }

// SetActiveEnvironment sets the runtime-resolved environment by name.
// Called during CLI flag processing.
func (c *Config) SetActiveEnvironment(name string) error { ... }
```

### 4. Replace hardcoded environment checks

**`internal/autopilot/controller.go` line 386:**
```go
// BEFORE:
if c.config.Environment == EnvDev && c.config.DevCITimeout > 0 {
    ciTimeout = c.config.DevCITimeout
}
// AFTER:
envCfg := c.config.ResolvedEnv()
if envCfg.CITimeout > 0 {
    ciTimeout = envCfg.CITimeout
}
```

**`internal/autopilot/controller.go` line 515:**
```go
// BEFORE:
if c.config.Environment == EnvProd {
    prState.Stage = StageAwaitApproval
    ...
} else {
    prState.Stage = StageMerging
}
// AFTER:
if c.config.ResolvedEnv().RequireApproval {
    prState.Stage = StageAwaitApproval
    ...
} else {
    prState.Stage = StageMerging
}
```

**`internal/autopilot/controller.go` line 734:**
```go
// BEFORE:
if c.config.Environment == EnvDev {
    // skip post-merge CI
}
// AFTER:
if c.config.ResolvedEnv().SkipPostMergeCI {
    // skip post-merge CI
}
```

**`internal/autopilot/auto_merger.go` line 97:**
```go
// BEFORE:
func (m *AutoMerger) requiresApproval(env Environment) bool {
    return env == EnvProd
}
// AFTER:
func (m *AutoMerger) requiresApproval(env Environment) bool {
    return m.config.ResolvedEnv().RequireApproval
}
```

Note: Also update the prod-safety check added by PR #1628 (merged today) in `requestApproval()` — the `if m.config.Environment == EnvProd` check around line 109 should become `if m.config.ResolvedEnv().RequireApproval`.

**`internal/autopilot/ci_monitor.go` line 37-41:**
```go
// BEFORE:
if cfg.Environment == EnvDev && cfg.DevCITimeout > 0 {
    timeout = cfg.DevCITimeout
}
// AFTER:
envCfg := cfg.ResolvedEnv()
if envCfg.CITimeout > 0 {
    timeout = envCfg.CITimeout
}
```

### 5. Update log statements

Replace all `"env", c.config.Environment` log fields with `"env", c.config.EnvironmentName()` in controller.go. Similarly in auto_merger.go and ci_monitor.go.

### 6. Update DefaultConfig()

Add `Environments: defaultEnvironments()` to DefaultConfig() so out-of-box configs have all 3 built-in environments.

### 7. Add tests in `internal/autopilot/types_test.go`

- `TestResolvedEnv_LegacyDev` — set `cfg.Environment = EnvDev`, verify RequireApproval=false, CITimeout=5m, SkipPostMergeCI=true
- `TestResolvedEnv_LegacyStage` — verify RequireApproval=false, CITimeout=30m, SkipPostMergeCI=false
- `TestResolvedEnv_LegacyProd` — verify RequireApproval=true, CITimeout=30m
- `TestResolvedEnv_NewStyleMap` — set Environments map + activeEnvName, verify correct env returned
- `TestResolvedEnv_CustomEnv` — add "qa" to Environments with custom config, verify lookup
- `TestResolvedEnv_NewOverridesLegacy` — set both old Environment and new Environments, verify new wins
- `TestEnvironmentName_Legacy` — verify returns "dev"/"stage"/"prod"
- `TestEnvironmentName_NewStyle` — verify returns activeEnvName

## Acceptance criteria

- [ ] All existing autopilot tests pass with ZERO modifications (ResolvedEnv handles legacy)
- [ ] New types_test.go covers legacy fallback, new-style, and custom environments
- [ ] No more `c.config.Environment == EnvProd` or `== EnvDev` checks in production code
- [ ] `make test && make lint` passes
- [ ] Legacy config YAML (`environment: stage`) still works identically

## Files to modify

- `internal/autopilot/types.go` — Core changes
- `internal/autopilot/controller.go` — 3 environment checks + log statements
- `internal/autopilot/auto_merger.go` — 1 environment check + PR #1628 check
- `internal/autopilot/ci_monitor.go` — 1 environment check
- `internal/autopilot/types_test.go` — New test file

## Planned Steps (execute all in sequence)

1. **Add EnvironmentConfig types, ResolvedEnv() methods, replace all hardcoded environment checks, and add tests** — All changes live in `internal/autopilot/` (one package). Specifically:
- **`types.go`**: Add `EnvironmentConfig` and `PostMergeConfig` structs (after line 28). Add `DefaultEnvironment`, `Environments`, `activeEnvName`, `activeEnvConfig` fields to `Config` struct. Add `omitempty` to existing `Environment` field. Add `defaultEnvironments()`, `ResolvedEnv()`, `EnvironmentName()`, `SetActiveEnvironment()` methods. Update `DefaultConfig()` to include `Environments: defaultEnvironments()`.
- **`controller.go`**: Replace 3 hardcoded checks — line 386 (`EnvDev` CI timeout → `ResolvedEnv().CITimeout`), line 515 (`EnvProd` approval gate → `ResolvedEnv().RequireApproval`), line 734 (`EnvDev` skip post-merge CI → `ResolvedEnv().SkipPostMergeCI`). Update all `"env", c.config.Environment` log fields to `"env", c.config.EnvironmentName()`.
- **`auto_merger.go`**: Replace `requiresApproval()` at line 97 (`env == EnvProd` → `m.config.ResolvedEnv().RequireApproval`). Replace PR #1628 safety check at line 109 (`m.config.Environment == EnvProd` → `m.config.ResolvedEnv().RequireApproval`). Update log fields.
- **`ci_monitor.go`**: Replace CI timeout selection at line 37 (`cfg.Environment == EnvDev` → `cfg.ResolvedEnv().CITimeout`). Update log fields.
- **`types_test.go`** (new file): 8 test cases covering legacy fallback (dev/stage/prod), new-style map lookup, custom environment, new-overrides-legacy precedence, and `EnvironmentName()` for both modes.
**Verification**: `make test && make lint` must pass. All existing tests in `auto_merger_test.go`, `controller_test.go`, and `controller_integration_test.go` must pass without modification (ResolvedEnv handles legacy transparently). No remaining `== EnvProd` or `== EnvDev` checks in production code.
