### PR TITLE
feat(autopilot): Add post-merge deployer with webhook and branch-push actions

### DIFF
--- a/internal/autopilot/deployer.go
+++ b/internal/autopilot/deployer.go
@@ -1,0 +1,173 @@
+package autopilot
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/adapters/github"
+)
+
+// Deployer executes post-merge deployment actions (webhook, branch-push, tag).
+type Deployer struct {
+	ghClient   *github.Client
+	releaser   *Releaser
+	owner      string
+	repo       string
+	log        *slog.Logger
+	httpClient *http.Client
+}
+
+// NewDeployer creates a new post-merge deployer.
+func NewDeployer(ghClient *github.Client, owner, repo string, log *slog.Logger) *Deployer {
+	return &Deployer{
+		ghClient: ghClient,
+		owner:    owner,
+		repo:     repo,
+		log:      log,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// SetReleaser sets the releaser for tag action delegation.
+func (d *Deployer) SetReleaser(r *Releaser) {
+	d.releaser = r
+}
+
+// WebhookPayload is the JSON body sent to webhook URLs on post-merge.
+type WebhookPayload struct {
+	PRNumber    int    `json:"pr_number"`
+	Branch      string `json:"branch"`
+	SHA         string `json:"sha"`
+	Environment string `json:"environment"`
+}
+
+// Execute runs the post-merge action for the given environment config.
+func (d *Deployer) Execute(ctx context.Context, envName string, envCfg *EnvironmentConfig, prState *PRState) error {
+	if envCfg.PostMerge == nil || envCfg.PostMerge.Action == "none" {
+		return nil
+	}
+
+	d.log.Info("executing post-merge action",
+		"action", envCfg.PostMerge.Action,
+		"pr", prState.PRNumber,
+		"env", envName,
+	)
+
+	switch envCfg.PostMerge.Action {
+	case "tag":
+		return d.createTag(ctx, prState)
+	case "webhook":
+		return d.callWebhook(ctx, envName, envCfg.PostMerge, prState)
+	case "branch-push":
+		return d.pushToBranch(ctx, envCfg.PostMerge, prState)
+	default:
+		return fmt.Errorf("unknown post-merge action: %s", envCfg.PostMerge.Action)
+	}
+}
+
+// createTag delegates to the releaser to create a version tag.
+func (d *Deployer) createTag(ctx context.Context, prState *PRState) error {
+	if d.releaser == nil {
+		return fmt.Errorf("releaser not configured for tag action")
+	}
+
+	currentVersion, err := d.releaser.GetCurrentVersion(ctx)
+	if err != nil {
+		d.log.Warn("failed to get current version, defaulting to 0.0.0", "error", err)
+		currentVersion = SemVer{}
+	}
+
+	// Get PR commits for bump type detection
+	commits, err := d.ghClient.GetPRCommits(ctx, d.owner, d.repo, prState.PRNumber)
+	if err != nil {
+		return fmt.Errorf("failed to get PR commits: %w", err)
+	}
+
+	bumpType := DetectBumpType(commits)
+	if bumpType == BumpNone {
+		bumpType = BumpPatch // Default to patch if no conventional commits
+	}
+
+	newVersion := currentVersion.Bump(bumpType)
+	tagName, err := d.releaser.CreateTag(ctx, prState, newVersion)
+	if err != nil {
+		return fmt.Errorf("failed to create tag: %w", err)
+	}
+
+	d.log.Info("post-merge tag created", "tag", tagName, "pr", prState.PRNumber)
+	return nil
+}
+
+// callWebhook sends an HTTP POST to the configured webhook URL.
+func (d *Deployer) callWebhook(ctx context.Context, envName string, cfg *PostMergeConfig, prState *PRState) error {
+	payload := WebhookPayload{
+		PRNumber:    prState.PRNumber,
+		Branch:      prState.BranchName,
+		SHA:         prState.HeadSHA,
+		Environment: envName,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal webhook payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.WebhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create webhook request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// Add custom headers
+	for k, v := range cfg.WebhookHeaders {
+		req.Header.Set(k, v)
+	}
+
+	// Add HMAC signature if secret is configured
+	if cfg.WebhookSecret != "" {
+		mac := hmac.New(sha256.New, []byte(cfg.WebhookSecret))
+		mac.Write(body)
+		sig := hex.EncodeToString(mac.Sum(nil))
+		req.Header.Set("X-Hub-Signature-256", "sha256="+sig)
+	}
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("webhook returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	d.log.Info("post-merge webhook called", "url", cfg.WebhookURL, "status", resp.StatusCode, "pr", prState.PRNumber)
+	return nil
+}
+
+// pushToBranch creates or updates a deploy branch to point at the merged PR's SHA.
+func (d *Deployer) pushToBranch(ctx context.Context, cfg *PostMergeConfig, prState *PRState) error {
+	if cfg.DeployBranch == "" {
+		return fmt.Errorf("deploy_branch not configured for branch-push action")
+	}
+
+	if err := d.ghClient.UpdateRef(ctx, d.owner, d.repo, cfg.DeployBranch, prState.HeadSHA); err != nil {
+		return fmt.Errorf("failed to push to branch %s: %w", cfg.DeployBranch, err)
+	}
+
+	d.log.Info("post-merge branch push", "branch", cfg.DeployBranch, "sha", ShortSHA(prState.HeadSHA), "pr", prState.PRNumber)
+	return nil
+}

--- a/internal/autopilot/deployer_test.go
+++ b/internal/autopilot/deployer_test.go
@@ -1,0 +1,270 @@
+package autopilot
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/adapters/github"
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestDeployer_None(t *testing.T) {
+	deployer := NewDeployer(nil, "owner", "repo", slog.Default())
+
+	tests := []struct {
+		name   string
+		envCfg *EnvironmentConfig
+	}{
+		{
+			name:   "nil PostMerge",
+			envCfg: &EnvironmentConfig{PostMerge: nil},
+		},
+		{
+			name:   "action none",
+			envCfg: &EnvironmentConfig{PostMerge: &PostMergeConfig{Action: "none"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := deployer.Execute(context.Background(), "dev", tt.envCfg, &PRState{PRNumber: 1})
+			if err != nil {
+				t.Fatalf("expected nil error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestDeployer_Webhook(t *testing.T) {
+	var (
+		receivedBody    []byte
+		receivedHeaders http.Header
+		receivedMethod  string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedHeaders = r.Header.Clone()
+		var err error
+		receivedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	secret := testutil.FakeWebhookSecret
+
+	deployer := NewDeployer(nil, "owner", "repo", slog.Default())
+
+	envCfg := &EnvironmentConfig{
+		PostMerge: &PostMergeConfig{
+			Action:     "webhook",
+			WebhookURL: server.URL,
+			WebhookHeaders: map[string]string{
+				"X-Deploy-Env": "staging",
+			},
+			WebhookSecret: secret,
+		},
+	}
+
+	prState := &PRState{
+		PRNumber:   42,
+		BranchName: "pilot/GH-42",
+		HeadSHA:    "abc123def456",
+	}
+
+	err := deployer.Execute(context.Background(), "stage", envCfg, prState)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+
+	// Verify method
+	if receivedMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", receivedMethod)
+	}
+
+	// Verify body
+	var payload WebhookPayload
+	if err := json.Unmarshal(receivedBody, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+	if payload.PRNumber != 42 {
+		t.Errorf("expected PRNumber 42, got %d", payload.PRNumber)
+	}
+	if payload.Branch != "pilot/GH-42" {
+		t.Errorf("expected branch pilot/GH-42, got %s", payload.Branch)
+	}
+	if payload.SHA != "abc123def456" {
+		t.Errorf("expected SHA abc123def456, got %s", payload.SHA)
+	}
+	if payload.Environment != "stage" {
+		t.Errorf("expected environment stage, got %s", payload.Environment)
+	}
+
+	// Verify custom headers
+	if receivedHeaders.Get("X-Deploy-Env") != "staging" {
+		t.Errorf("expected X-Deploy-Env=staging, got %s", receivedHeaders.Get("X-Deploy-Env"))
+	}
+	if receivedHeaders.Get("Content-Type") != "application/json" {
+		t.Errorf("expected Content-Type=application/json, got %s", receivedHeaders.Get("Content-Type"))
+	}
+
+	// Verify HMAC signature
+	sigHeader := receivedHeaders.Get("X-Hub-Signature-256")
+	if sigHeader == "" {
+		t.Fatal("expected X-Hub-Signature-256 header")
+	}
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(receivedBody)
+	expectedSig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if sigHeader != expectedSig {
+		t.Errorf("HMAC mismatch: got %s, expected %s", sigHeader, expectedSig)
+	}
+}
+
+func TestDeployer_BranchPush(t *testing.T) {
+	var (
+		requestPath   string
+		requestMethod string
+		requestBody   map[string]interface{}
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		requestMethod = r.Method
+
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &requestBody)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	deployer := NewDeployer(client, "owner", "repo", slog.Default())
+
+	envCfg := &EnvironmentConfig{
+		PostMerge: &PostMergeConfig{
+			Action:       "branch-push",
+			DeployBranch: "deploy/production",
+		},
+	}
+
+	prState := &PRState{
+		PRNumber: 99,
+		HeadSHA:  "deadbeef1234",
+	}
+
+	err := deployer.Execute(context.Background(), "prod", envCfg, prState)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+
+	// UpdateRef tries PATCH first
+	if requestMethod != http.MethodPatch {
+		t.Errorf("expected PATCH, got %s", requestMethod)
+	}
+	expectedPath := "/repos/owner/repo/git/refs/heads/deploy/production"
+	if requestPath != expectedPath {
+		t.Errorf("expected path %s, got %s", expectedPath, requestPath)
+	}
+	if requestBody["sha"] != "deadbeef1234" {
+		t.Errorf("expected sha deadbeef1234, got %v", requestBody["sha"])
+	}
+}
+
+func TestDeployer_Tag(t *testing.T) {
+	apiCalls := make(map[string]string) // path -> method
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalls[r.URL.Path] = r.Method
+
+		switch {
+		case r.URL.Path == "/repos/owner/repo/releases/latest":
+			// Return 404 — no releases exist → version starts at 0.0.0
+			w.WriteHeader(http.StatusNotFound)
+		case r.URL.Path == "/repos/owner/repo/pulls/10/commits":
+			// Return a feat commit for minor bump
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"sha":"abc","commit":{"message":"feat(deploy): add auto-deploy"}}]`))
+		case r.URL.Path == "/repos/owner/repo/git/refs":
+			// Tag creation
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	releaser := NewReleaser(client, "owner", "repo", DefaultReleaseConfig())
+
+	deployer := NewDeployer(client, "owner", "repo", slog.Default())
+	deployer.SetReleaser(releaser)
+
+	envCfg := &EnvironmentConfig{
+		PostMerge: &PostMergeConfig{Action: "tag"},
+	}
+	prState := &PRState{
+		PRNumber: 10,
+		HeadSHA:  "abc123",
+	}
+
+	err := deployer.Execute(context.Background(), "prod", envCfg, prState)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+
+	// Verify tag creation API was called
+	if _, ok := apiCalls["/repos/owner/repo/git/refs"]; !ok {
+		t.Error("expected tag creation API call to /repos/owner/repo/git/refs")
+	}
+	// Verify PR commits were fetched for bump detection
+	if _, ok := apiCalls["/repos/owner/repo/pulls/10/commits"]; !ok {
+		t.Error("expected PR commits API call")
+	}
+}
+
+func TestDeployer_Tag_NoReleaser(t *testing.T) {
+	deployer := NewDeployer(nil, "owner", "repo", slog.Default())
+
+	envCfg := &EnvironmentConfig{
+		PostMerge: &PostMergeConfig{Action: "tag"},
+	}
+
+	err := deployer.Execute(context.Background(), "prod", envCfg, &PRState{PRNumber: 1})
+	if err == nil {
+		t.Fatal("expected error when releaser is nil")
+	}
+	if err.Error() != "releaser not configured for tag action" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDeployer_UnknownAction(t *testing.T) {
+	deployer := NewDeployer(nil, "owner", "repo", slog.Default())
+
+	envCfg := &EnvironmentConfig{
+		PostMerge: &PostMergeConfig{Action: "deploy-spaceship"},
+	}
+
+	err := deployer.Execute(context.Background(), "prod", envCfg, &PRState{PRNumber: 1})
+	if err == nil {
+		t.Fatal("expected error for unknown action")
+	}
+	expected := "unknown post-merge action: deploy-spaceship"
+	if err.Error() != expected {
+		t.Errorf("expected error %q, got %q", expected, err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1641.

Closes #1641

## Changes

GitHub Issue #1641: feat(autopilot): Add post-merge deployer with webhook and branch-push actions

## Context

Part of autopilot environment redesign (depends on #1640 merging first).

After #1640, each environment has a `PostMergeConfig` with an `action` field. This issue implements the `Deployer` that executes those actions after PR merge.

## What to implement

### 1. New file: `internal/autopilot/deployer.go`

```go
type Deployer struct {
    ghClient *github.Client
    owner    string
    repo     string
    log      *slog.Logger
}

func NewDeployer(ghClient *github.Client, owner, repo string, log *slog.Logger) *Deployer

// Execute runs the post-merge action for the given environment config.
func (d *Deployer) Execute(ctx context.Context, envCfg *EnvironmentConfig, prState *PRState) error {
    if envCfg.PostMerge == nil || envCfg.PostMerge.Action == "none" {
        return nil
    }
    switch envCfg.PostMerge.Action {
    case "tag":
        // Delegate to existing Releaser.CreateTag() logic
    case "webhook":
        return d.callWebhook(ctx, envCfg.PostMerge, prState)
    case "branch-push":
        return d.pushToBranch(ctx, envCfg.PostMerge, prState)
    default:
        return fmt.Errorf("unknown post-merge action: %s", envCfg.PostMerge.Action)
    }
}
```

Webhook: HTTP POST to `WebhookURL` with JSON body containing PR number, branch, SHA, environment name. Include HMAC signature if `WebhookSecret` is set. Include custom headers from `WebhookHeaders`.

Branch-push: Use GitHub API to create a ref or merge commit on `DeployBranch`.

### 2. Wire into controller.go

In `handleMerged()`, after the existing post-merge CI / release logic, call `Deployer.Execute()` when `PostMerge.Action` is set. The deployer should be created in `NewController()` and stored as a field.

### 3. Tests: `internal/autopilot/deployer_test.go`

- `TestDeployer_None` — noop action returns nil
- `TestDeployer_Webhook` — httptest server verifies POST body, headers, HMAC
- `TestDeployer_BranchPush` — mock GitHub API, verify ref creation
- `TestDeployer_Tag` — verify delegation to releaser
- `TestDeployer_UnknownAction` — returns error

## Depends on

- #1640 (EnvironmentConfig + PostMergeConfig types must exist)

## Files

- `internal/autopilot/deployer.go` (new)
- `internal/autopilot/deployer_test.go` (new)
- `internal/autopilot/controller.go` (wire deployer)