### PR TITLE
fix(autopilot): resolve duplicate EnvironmentName method (GH-1646)

### DIFF
--- a/cmd/pilot/adapters.go
+++ b/cmd/pilot/adapters.go
@@ -275,7 +275,7 @@ type autopilotProviderAdapter struct {
 }
 
 func (a *autopilotProviderAdapter) GetEnvironment() string {
-	return string(a.controller.Config().Environment)
+	return a.controller.Config().EnvironmentName()
 }
 
 func (a *autopilotProviderAdapter) GetActivePRs() []*gateway.AutopilotPRState {

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -238,14 +238,15 @@ func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, he
 	defer c.mu.Unlock()
 
 	prState := &PRState{
-		PRNumber:    prNumber,
-		PRURL:       prURL,
-		IssueNumber: issueNumber,
-		BranchName:  branchName,
-		HeadSHA:     headSHA,
-		Stage:       StagePRCreated,
-		CIStatus:    CIPending,
-		CreatedAt:   time.Now(),
+		PRNumber:        prNumber,
+		PRURL:           prURL,
+		IssueNumber:     issueNumber,
+		BranchName:      branchName,
+		HeadSHA:         headSHA,
+		Stage:           StagePRCreated,
+		CIStatus:        CIPending,
+		CreatedAt:       time.Now(),
+		EnvironmentName: c.config.EnvironmentName(),
 	}
 	c.activePRs[prNumber] = prState
 
@@ -280,6 +281,16 @@ func (c *Controller) ProcessPR(ctx context.Context, prNumber int, ghPR *github.P
 		c.log.Warn("per-PR circuit breaker open", "pr", prNumber)
 		c.metrics.RecordCircuitBreakerTrip()
 		return fmt.Errorf("circuit breaker: PR %d has too many consecutive failures", prNumber)
+	}
+
+	// Populate PR metadata from GitHub response when available
+	if ghPR != nil {
+		if prState.PRTitle == "" && ghPR.Title != "" {
+			prState.PRTitle = ghPR.Title
+		}
+		if prState.TargetBranch == "" && ghPR.Base.Ref != "" {
+			prState.TargetBranch = ghPR.Base.Ref
+		}
 	}
 
 	previousStage := prState.Stage
@@ -1348,14 +1359,17 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 
 		// Create PR state and trigger release
 		prState := &PRState{
-			PRNumber:    pr.Number,
-			PRURL:       pr.HTMLURL,
-			IssueNumber: issueNum,
-			BranchName:  pr.Head.Ref,
-			HeadSHA:     pr.MergeCommitSHA,
-			Stage:       StageReleasing,
-			CIStatus:    CISuccess, // Assume CI passed if merged
-			CreatedAt:   time.Now(),
+			PRNumber:        pr.Number,
+			PRURL:           pr.HTMLURL,
+			IssueNumber:     issueNum,
+			BranchName:      pr.Head.Ref,
+			HeadSHA:         pr.MergeCommitSHA,
+			Stage:           StageReleasing,
+			CIStatus:        CISuccess, // Assume CI passed if merged
+			CreatedAt:       time.Now(),
+			EnvironmentName: c.config.EnvironmentName(),
+			PRTitle:         pr.Title,
+			TargetBranch:    pr.Base.Ref,
 		}
 
 		// Register and trigger release

--- a/internal/autopilot/telegram_notifier_test.go
+++ b/internal/autopilot/telegram_notifier_test.go
@@ -11,24 +11,67 @@ import (
 	"github.com/alekspetrov/pilot/internal/adapters/telegram"
 )
 
-func TestTelegramNotifier_NotifyMerged(t *testing.T) {
-	var receivedText string
-
+func newTestNotifier(t *testing.T, captureText *string) (*TelegramNotifier, *httptest.Server) {
+	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req telegram.SendMessageRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Errorf("failed to decode request: %v", err)
 		}
-		receivedText = req.Text
+		*captureText = req.Text
 
 		resp := telegram.SendMessageResponse{OK: true}
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(resp)
 	}))
-	defer server.Close()
 
 	client := telegram.NewClientWithBaseURL("test-token", server.URL)
 	notifier := NewTelegramNotifier(client, "123456")
+	return notifier, server
+}
+
+func TestTelegramNotifier_NotifyMerged(t *testing.T) {
+	var receivedText string
+	notifier, server := newTestNotifier(t, &receivedText)
+	defer server.Close()
+
+	prState := &PRState{
+		PRNumber:        42,
+		Stage:           StageMerged,
+		EnvironmentName: "staging",
+		PRTitle:         "feat: add search",
+		TargetBranch:    "main",
+	}
+
+	err := notifier.NotifyMerged(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("NotifyMerged error: %v", err)
+	}
+
+	if !strings.Contains(receivedText, "[staging]") {
+		t.Error("expected merged notification to contain [staging] prefix")
+	}
+	if !strings.Contains(receivedText, "✅") {
+		t.Error("expected merged notification to contain ✅")
+	}
+	if !strings.Contains(receivedText, "PR #42") {
+		t.Error("expected merged notification to contain PR number")
+	}
+	if !strings.Contains(receivedText, "merged") {
+		t.Error("expected merged notification to contain 'merged'")
+	}
+	if !strings.Contains(receivedText, "feat: add search") {
+		t.Error("expected merged notification to contain PR title")
+	}
+	if !strings.Contains(receivedText, "main") {
+		t.Error("expected merged notification to contain target branch")
+	}
+}
+
+func TestTelegramNotifier_NotifyMerged_NoEnv(t *testing.T) {
+	var receivedText string
+	notifier, server := newTestNotifier(t, &receivedText)
+	defer server.Close()
 
 	prState := &PRState{
 		PRNumber: 42,
@@ -40,37 +83,24 @@ func TestTelegramNotifier_NotifyMerged(t *testing.T) {
 		t.Fatalf("NotifyMerged error: %v", err)
 	}
 
-	if !strings.Contains(receivedText, "✅") {
-		t.Error("expected merged notification to contain ✅")
+	if strings.Contains(receivedText, "[") {
+		t.Error("expected no env prefix when EnvironmentName is empty")
 	}
 	if !strings.Contains(receivedText, "PR #42") {
-		t.Error("expected merged notification to contain PR number")
-	}
-	if !strings.Contains(receivedText, "merged") {
-		t.Error("expected merged notification to contain 'merged'")
+		t.Error("expected notification to contain PR number")
 	}
 }
 
 func TestTelegramNotifier_NotifyCIFailed(t *testing.T) {
 	var receivedText string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req telegram.SendMessageRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("failed to decode request: %v", err)
-		}
-		receivedText = req.Text
-
-		resp := telegram.SendMessageResponse{OK: true}
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	notifier, server := newTestNotifier(t, &receivedText)
 	defer server.Close()
 
-	client := telegram.NewClientWithBaseURL("test-token", server.URL)
-	notifier := NewTelegramNotifier(client, "123456")
-
-	prState := &PRState{PRNumber: 42}
+	prState := &PRState{
+		PRNumber:        42,
+		EnvironmentName: "production",
+		PRTitle:         "fix: login bug",
+	}
 	failedChecks := []string{"build", "lint"}
 
 	err := notifier.NotifyCIFailed(context.Background(), prState, failedChecks)
@@ -78,6 +108,9 @@ func TestTelegramNotifier_NotifyCIFailed(t *testing.T) {
 		t.Fatalf("NotifyCIFailed error: %v", err)
 	}
 
+	if !strings.Contains(receivedText, "[production]") {
+		t.Error("expected CI failed notification to contain [production] prefix")
+	}
 	if !strings.Contains(receivedText, "❌") {
 		t.Error("expected CI failed notification to contain ❌")
 	}
@@ -90,24 +123,15 @@ func TestTelegramNotifier_NotifyCIFailed(t *testing.T) {
 	if !strings.Contains(receivedText, "lint") {
 		t.Error("expected CI failed notification to contain failed check 'lint'")
 	}
+	if !strings.Contains(receivedText, "fix: login bug") {
+		t.Error("expected CI failed notification to contain PR title")
+	}
 }
 
 func TestTelegramNotifier_NotifyCIFailed_NoChecks(t *testing.T) {
 	var receivedText string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req telegram.SendMessageRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
-		receivedText = req.Text
-
-		resp := telegram.SendMessageResponse{OK: true}
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	notifier, server := newTestNotifier(t, &receivedText)
 	defer server.Close()
-
-	client := telegram.NewClientWithBaseURL("test-token", server.URL)
-	notifier := NewTelegramNotifier(client, "123456")
 
 	prState := &PRState{PRNumber: 42}
 
@@ -123,28 +147,22 @@ func TestTelegramNotifier_NotifyCIFailed_NoChecks(t *testing.T) {
 
 func TestTelegramNotifier_NotifyApprovalRequired(t *testing.T) {
 	var receivedText string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req telegram.SendMessageRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
-		receivedText = req.Text
-
-		resp := telegram.SendMessageResponse{OK: true}
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	notifier, server := newTestNotifier(t, &receivedText)
 	defer server.Close()
 
-	client := telegram.NewClientWithBaseURL("test-token", server.URL)
-	notifier := NewTelegramNotifier(client, "123456")
-
-	prState := &PRState{PRNumber: 42}
+	prState := &PRState{
+		PRNumber:        42,
+		EnvironmentName: "production",
+	}
 
 	err := notifier.NotifyApprovalRequired(context.Background(), prState)
 	if err != nil {
 		t.Fatalf("NotifyApprovalRequired error: %v", err)
 	}
 
+	if !strings.Contains(receivedText, "[production]") {
+		t.Error("expected approval notification to contain [production] prefix")
+	}
 	if !strings.Contains(receivedText, "⏳") {
 		t.Error("expected approval notification to contain ⏳")
 	}
@@ -161,28 +179,22 @@ func TestTelegramNotifier_NotifyApprovalRequired(t *testing.T) {
 
 func TestTelegramNotifier_NotifyFixIssueCreated(t *testing.T) {
 	var receivedText string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req telegram.SendMessageRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
-		receivedText = req.Text
-
-		resp := telegram.SendMessageResponse{OK: true}
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	notifier, server := newTestNotifier(t, &receivedText)
 	defer server.Close()
 
-	client := telegram.NewClientWithBaseURL("test-token", server.URL)
-	notifier := NewTelegramNotifier(client, "123456")
-
-	prState := &PRState{PRNumber: 42}
+	prState := &PRState{
+		PRNumber:        42,
+		EnvironmentName: "staging",
+	}
 
 	err := notifier.NotifyFixIssueCreated(context.Background(), prState, 100)
 	if err != nil {
 		t.Fatalf("NotifyFixIssueCreated error: %v", err)
 	}
 
+	if !strings.Contains(receivedText, "[staging]") {
+		t.Error("expected fix issue notification to contain [staging] prefix")
+	}
 	if !strings.Contains(receivedText, "🔄") {
 		t.Error("expected fix issue notification to contain 🔄")
 	}
@@ -191,6 +203,41 @@ func TestTelegramNotifier_NotifyFixIssueCreated(t *testing.T) {
 	}
 	if !strings.Contains(receivedText, "PR #42") {
 		t.Error("expected fix issue notification to contain PR number")
+	}
+}
+
+func TestTelegramNotifier_NotifyPipelineComplete(t *testing.T) {
+	var receivedText string
+	notifier, server := newTestNotifier(t, &receivedText)
+	defer server.Close()
+
+	prState := &PRState{
+		PRNumber:        123,
+		IssueNumber:     100,
+		EnvironmentName: "staging",
+		PRTitle:         "feat: new feature",
+		TargetBranch:    "main",
+	}
+
+	err := notifier.NotifyPipelineComplete(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("NotifyPipelineComplete error: %v", err)
+	}
+
+	if !strings.Contains(receivedText, "[staging]") {
+		t.Error("expected pipeline complete notification to contain [staging] prefix")
+	}
+	if !strings.Contains(receivedText, "Pipeline complete") {
+		t.Error("expected pipeline complete notification to contain 'Pipeline complete'")
+	}
+	if !strings.Contains(receivedText, "GH-100") {
+		t.Error("expected pipeline complete notification to contain issue number")
+	}
+	if !strings.Contains(receivedText, "PR #123") {
+		t.Error("expected pipeline complete notification to contain PR number")
+	}
+	if !strings.Contains(receivedText, "merged") {
+		t.Error("expected pipeline complete notification to contain 'merged'")
 	}
 }
 
@@ -204,6 +251,7 @@ func TestTelegramNotifier_NotifyReleased(t *testing.T) {
 			name:     "minor release",
 			bumpType: BumpMinor,
 			wantContains: []string{
+				"[staging]",
 				"✨",
 				"Published",
 				"Version:",
@@ -232,25 +280,14 @@ func TestTelegramNotifier_NotifyReleased(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var receivedText string
-
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var req telegram.SendMessageRequest
-				_ = json.NewDecoder(r.Body).Decode(&req)
-				receivedText = req.Text
-
-				resp := telegram.SendMessageResponse{OK: true}
-				w.WriteHeader(http.StatusOK)
-				_ = json.NewEncoder(w).Encode(resp)
-			}))
+			notifier, server := newTestNotifier(t, &receivedText)
 			defer server.Close()
-
-			client := telegram.NewClientWithBaseURL("test-token", server.URL)
-			notifier := NewTelegramNotifier(client, "123456")
 
 			prState := &PRState{
 				PRNumber:        42,
 				ReleaseVersion:  "v1.2.0",
 				ReleaseBumpType: tt.bumpType,
+				EnvironmentName: "staging",
 			}
 
 			err := notifier.NotifyReleased(context.Background(), prState, "https://github.com/owner/repo/releases/tag/v1.2.0")
@@ -300,6 +337,49 @@ func TestEscapeMarkdown(t *testing.T) {
 			result := escapeMarkdown(tt.input)
 			if result != tt.expected {
 				t.Errorf("escapeMarkdown(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEnvPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		envName  string
+		expected string
+	}{
+		{"with env", "staging", "[staging] "},
+		{"empty env", "", ""},
+		{"production env", "production", "[production] "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pr := &PRState{EnvironmentName: tt.envName}
+			got := envPrefix(pr)
+			if got != tt.expected {
+				t.Errorf("envPrefix() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEnvironmentName(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Config
+		expected string
+	}{
+		{"custom name", Config{Environment: EnvStage, Name: "staging"}, "staging"},
+		{"fallback to env", Config{Environment: EnvProd}, "prod"},
+		{"dev fallback", Config{Environment: EnvDev}, "dev"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.EnvironmentName()
+			if got != tt.expected {
+				t.Errorf("EnvironmentName() = %q, want %q", got, tt.expected)
 			}
 		})
 	}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -145,6 +145,10 @@ type Config struct {
 	// MergedPRScanWindow is how far back to look for merged PRs on startup (default: 30m).
 	// This catches PRs that were merged while Pilot was offline.
 	MergedPRScanWindow time.Duration `yaml:"merged_pr_scan_window"`
+
+	// Name is a user-friendly label for this environment (e.g. "staging", "production").
+	// When empty, defaults to the Environment value.
+	Name string `yaml:"name"`
 }
 
 // CIChecksConfig holds configuration for CI check monitoring.
@@ -221,7 +225,12 @@ func (c *Config) ResolvedEnv() *EnvironmentConfig {
 }
 
 // EnvironmentName returns the human-readable active environment name.
+// Checks Name field first (user-friendly label), then activeEnvName,
+// then falls back to the Environment enum value.
 func (c *Config) EnvironmentName() string {
+	if c.Name != "" {
+		return c.Name
+	}
 	if c.activeEnvName != "" {
 		return c.activeEnvName
 	}
@@ -420,4 +429,10 @@ type PRState struct {
 	DiscoveredChecks []string
 	// ConsecutiveAPIFailures counts consecutive CI check API failures.
 	ConsecutiveAPIFailures int
+	// EnvironmentName is the user-friendly environment label (e.g. "staging").
+	EnvironmentName string
+	// PRTitle is the title of the pull request.
+	PRTitle string
+	// TargetBranch is the base branch the PR merges into (e.g. "main").
+	TargetBranch string
 }

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -139,7 +139,21 @@ func (p *AutopilotPanel) View() string {
 	cfg := p.controller.Config()
 
 	// Environment/Mode
-	content.WriteString(dotLeader("Mode", string(cfg.Environment), w))
+	content.WriteString(dotLeader("Environment", cfg.EnvironmentName(), w))
+	content.WriteString("\n")
+
+	// Target branch
+	if cfg.Release != nil && cfg.Release.TagPrefix != "" {
+		content.WriteString(dotLeader("Tag prefix", cfg.Release.TagPrefix, w))
+		content.WriteString("\n")
+	}
+
+	// Post-merge action
+	postMerge := "none"
+	if cfg.Release != nil && cfg.Release.Enabled {
+		postMerge = "auto-release"
+	}
+	content.WriteString(dotLeader("Post-merge", postMerge, w))
 	content.WriteString("\n")
 
 	// Release status


### PR DESCRIPTION
## Summary
- Cherry-picks environment context feature from commit 19a9518 (original PR #1645)
- Fixes duplicate `Config.EnvironmentName()` method declaration that caused CI failure
- Merges two versions into single method: checks `Name` > `activeEnvName` > `Environment` > `"stage"`

## Changes
- `internal/autopilot/types.go`: Add `Name` field to Config, merge duplicate EnvironmentName methods, add PRState fields (EnvironmentName, PRTitle, TargetBranch)
- `internal/autopilot/controller.go`: Populate new PRState fields during pipeline processing
- `internal/autopilot/telegram_notifier.go`: Prefix notifications with `[env_name]`, include PR title/branch
- `internal/autopilot/telegram_notifier_test.go`: Updated tests for new notification format
- `cmd/pilot/adapters.go`: Use EnvironmentName() instead of raw Environment
- `internal/dashboard/tui.go`: Show environment name and post-merge action in autopilot panel

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/autopilot/...` passes
- [x] `go test ./internal/dashboard/... ./cmd/pilot/... ./e2e/...` passes
- [x] `golangci-lint run ./...` reports 0 issues

Fixes #1646