### PR TITLE
feat(autopilot): Add post-merge deployer with webhook and branch-push actions

### DIFF
--- a/internal/autopilot/deployer.go
+++ b/internal/autopilot/deployer.go
@@ -1,0 +1,134 @@
+package autopilot
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/alekspetrov/pilot/internal/adapters/github"
+)
+
+// Deployer executes post-merge deployment actions based on environment config.
+type Deployer struct {
+	ghClient   *github.Client
+	owner      string
+	repo       string
+	log        *slog.Logger
+	httpClient *http.Client
+}
+
+// NewDeployer creates a new post-merge deployer.
+func NewDeployer(ghClient *github.Client, owner, repo string, log *slog.Logger) *Deployer {
+	return &Deployer{
+		ghClient:   ghClient,
+		owner:      owner,
+		repo:       repo,
+		log:        log,
+		httpClient: &http.Client{},
+	}
+}
+
+// WebhookPayload is the JSON body sent to webhook endpoints.
+type WebhookPayload struct {
+	PRNumber    int    `json:"pr_number"`
+	Branch      string `json:"branch"`
+	SHA         string `json:"sha"`
+	Environment string `json:"environment"`
+}
+
+// Execute runs the post-merge action for the given environment config.
+func (d *Deployer) Execute(ctx context.Context, envCfg *EnvironmentConfig, prState *PRState) error {
+	if envCfg.PostMerge == nil || envCfg.PostMerge.Action == "none" {
+		return nil
+	}
+
+	switch envCfg.PostMerge.Action {
+	case "tag":
+		// Tag action is handled by the Releaser; deployer is a no-op for tags.
+		d.log.Info("post-merge action: tag (handled by releaser)", "pr", prState.PRNumber)
+		return nil
+	case "webhook":
+		return d.callWebhook(ctx, envCfg.PostMerge, prState)
+	case "branch-push":
+		return d.pushToBranch(ctx, envCfg.PostMerge, prState)
+	default:
+		return fmt.Errorf("unknown post-merge action: %s", envCfg.PostMerge.Action)
+	}
+}
+
+// callWebhook sends an HTTP POST to the configured webhook URL.
+func (d *Deployer) callWebhook(ctx context.Context, cfg *PostMergeConfig, prState *PRState) error {
+	payload := WebhookPayload{
+		PRNumber:    prState.PRNumber,
+		Branch:      prState.BranchName,
+		SHA:         prState.HeadSHA,
+		Environment: prState.EnvironmentName,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal webhook payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.WebhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create webhook request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// Add custom headers
+	for k, v := range cfg.WebhookHeaders {
+		req.Header.Set(k, v)
+	}
+
+	// HMAC signature if secret is configured
+	if cfg.WebhookSecret != "" {
+		mac := hmac.New(sha256.New, []byte(cfg.WebhookSecret))
+		mac.Write(body)
+		sig := hex.EncodeToString(mac.Sum(nil))
+		req.Header.Set("X-Signature-256", "sha256="+sig)
+	}
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook returned status %d", resp.StatusCode)
+	}
+
+	d.log.Info("post-merge webhook delivered",
+		"pr", prState.PRNumber,
+		"url", cfg.WebhookURL,
+		"status", resp.StatusCode,
+	)
+	return nil
+}
+
+// pushToBranch creates or updates a deploy branch ref via the GitHub API.
+func (d *Deployer) pushToBranch(ctx context.Context, cfg *PostMergeConfig, prState *PRState) error {
+	if cfg.DeployBranch == "" {
+		return fmt.Errorf("deploy_branch not configured for branch-push action")
+	}
+
+	err := d.ghClient.UpdateRef(ctx, d.owner, d.repo, cfg.DeployBranch, prState.HeadSHA)
+	if err != nil {
+		return fmt.Errorf("push to branch %s: %w", cfg.DeployBranch, err)
+	}
+
+	d.log.Info("post-merge branch-push complete",
+		"pr", prState.PRNumber,
+		"branch", cfg.DeployBranch,
+		"sha", ShortSHA(prState.HeadSHA),
+	)
+	return nil
+}

--- a/internal/autopilot/deployer_test.go
+++ b/internal/autopilot/deployer_test.go
@@ -1,0 +1,199 @@
+package autopilot
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/adapters/github"
+)
+
+func TestDeployer_None(t *testing.T) {
+	d := NewDeployer(nil, "owner", "repo", slog.Default())
+	pr := &PRState{PRNumber: 1}
+
+	// nil PostMerge
+	err := d.Execute(context.Background(), &EnvironmentConfig{}, pr)
+	if err != nil {
+		t.Fatalf("expected nil error for nil PostMerge, got %v", err)
+	}
+
+	// action "none"
+	err = d.Execute(context.Background(), &EnvironmentConfig{
+		PostMerge: &PostMergeConfig{Action: "none"},
+	}, pr)
+	if err != nil {
+		t.Fatalf("expected nil error for action none, got %v", err)
+	}
+}
+
+func TestDeployer_Webhook(t *testing.T) {
+	var received WebhookPayload
+	var headers http.Header
+	var sigHeader string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headers = r.Header
+		sigHeader = r.Header.Get("X-Signature-256")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewDeployer(nil, "owner", "repo", slog.Default())
+
+	pr := &PRState{
+		PRNumber:        42,
+		BranchName:      "feat/test",
+		HeadSHA:         "abc123",
+		EnvironmentName: "staging",
+	}
+
+	secret := "test-secret"
+	env := &EnvironmentConfig{
+		PostMerge: &PostMergeConfig{
+			Action:         "webhook",
+			WebhookURL:     srv.URL,
+			WebhookSecret:  secret,
+			WebhookHeaders: map[string]string{"X-Custom": "value"},
+		},
+	}
+
+	err := d.Execute(context.Background(), env, pr)
+	if err != nil {
+		t.Fatalf("webhook execute failed: %v", err)
+	}
+
+	// Verify payload
+	if received.PRNumber != 42 {
+		t.Errorf("expected PRNumber 42, got %d", received.PRNumber)
+	}
+	if received.Branch != "feat/test" {
+		t.Errorf("expected branch feat/test, got %s", received.Branch)
+	}
+	if received.SHA != "abc123" {
+		t.Errorf("expected SHA abc123, got %s", received.SHA)
+	}
+	if received.Environment != "staging" {
+		t.Errorf("expected environment staging, got %s", received.Environment)
+	}
+
+	// Verify custom header
+	if headers.Get("X-Custom") != "value" {
+		t.Errorf("expected X-Custom header, got %q", headers.Get("X-Custom"))
+	}
+
+	// Verify HMAC signature
+	payload, _ := json.Marshal(WebhookPayload{
+		PRNumber:    42,
+		Branch:      "feat/test",
+		SHA:         "abc123",
+		Environment: "staging",
+	})
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	expectedSig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if sigHeader != expectedSig {
+		t.Errorf("HMAC mismatch: got %q, want %q", sigHeader, expectedSig)
+	}
+}
+
+func TestDeployer_BranchPush(t *testing.T) {
+	var patchCalled, postCalled bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/git/refs/heads/deploy":
+			patchCalled = true
+			w.WriteHeader(http.StatusOK)
+		case "/repos/owner/repo/git/refs":
+			postCalled = true
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	ghClient := github.NewClientWithBaseURL("fake-token", srv.URL)
+	d := NewDeployer(ghClient, "owner", "repo", slog.Default())
+
+	pr := &PRState{
+		PRNumber:        10,
+		HeadSHA:         "def456",
+		EnvironmentName: "prod",
+	}
+
+	env := &EnvironmentConfig{
+		PostMerge: &PostMergeConfig{
+			Action:       "branch-push",
+			DeployBranch: "deploy",
+		},
+	}
+
+	err := d.Execute(context.Background(), env, pr)
+	if err != nil {
+		t.Fatalf("branch-push execute failed: %v", err)
+	}
+
+	if !patchCalled && !postCalled {
+		t.Error("expected either PATCH or POST to be called")
+	}
+}
+
+func TestDeployer_Tag(t *testing.T) {
+	d := NewDeployer(nil, "owner", "repo", slog.Default())
+	pr := &PRState{PRNumber: 5}
+
+	env := &EnvironmentConfig{
+		PostMerge: &PostMergeConfig{Action: "tag"},
+	}
+
+	// Tag action is a no-op in deployer (handled by releaser)
+	err := d.Execute(context.Background(), env, pr)
+	if err != nil {
+		t.Fatalf("tag action should be no-op, got %v", err)
+	}
+}
+
+func TestDeployer_UnknownAction(t *testing.T) {
+	d := NewDeployer(nil, "owner", "repo", slog.Default())
+	pr := &PRState{PRNumber: 1}
+
+	env := &EnvironmentConfig{
+		PostMerge: &PostMergeConfig{Action: "invalid"},
+	}
+
+	err := d.Execute(context.Background(), env, pr)
+	if err == nil {
+		t.Fatal("expected error for unknown action")
+	}
+	if err.Error() != "unknown post-merge action: invalid" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDeployer_BranchPush_NoBranch(t *testing.T) {
+	d := NewDeployer(nil, "owner", "repo", slog.Default())
+	pr := &PRState{PRNumber: 1}
+
+	env := &EnvironmentConfig{
+		PostMerge: &PostMergeConfig{
+			Action:       "branch-push",
+			DeployBranch: "",
+		},
+	}
+
+	err := d.Execute(context.Background(), env, pr)
+	if err == nil {
+		t.Fatal("expected error for empty deploy branch")
+	}
+}


### PR DESCRIPTION
## Summary

- Implement `Deployer` that executes post-merge deployment actions based on per-environment `PostMergeConfig`
- Support four action types: `none` (no-op), `tag` (delegated to Releaser), `webhook` (HTTP POST with HMAC-SHA256), `branch-push` (GitHub refs API)
- Wire deployer into `Controller.handleMerged()` to run after PR merge
- Add `UpdateRef` method to GitHub client for branch ref create/update operations
- Fix lint issue (QF1002: use tagged switch) that caused CI failure in PR #1649

Closes #1641
Closes #1650

## Test plan

- [x] `TestDeployer_None` — noop action returns nil
- [x] `TestDeployer_Webhook` — httptest server verifies POST body, headers, HMAC
- [x] `TestDeployer_BranchPush` — mock GitHub API, verify ref creation
- [x] `TestDeployer_Tag` — verify no-op delegation to releaser
- [x] `TestDeployer_UnknownAction` — returns error
- [x] `TestDeployer_BranchPush_NoBranch` — returns error for empty deploy branch
- [x] All 6 tests pass locally
- [x] `golangci-lint` reports 0 issues on new code
- [x] Full autopilot test suite passes