### PR TITLE
feat(autopilot): Add post-merge deployer with webhook and branch-push actions

### DIFF
--- a/internal/autopilot/deployer.go
+++ b/internal/autopilot/deployer.go
@@ -1,0 +1,158 @@
+package autopilot
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/adapters/github"
+)
+
+// Deployer executes post-merge deployment actions based on PostMergeConfig.
+type Deployer struct {
+	ghClient   *github.Client
+	httpClient *http.Client
+	owner      string
+	repo       string
+	config     *PostMergeConfig
+	log        *slog.Logger
+}
+
+// NewDeployer creates a deployer for the given post-merge configuration.
+func NewDeployer(ghClient *github.Client, owner, repo string, config *PostMergeConfig) *Deployer {
+	return &Deployer{
+		ghClient: ghClient,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		owner:  owner,
+		repo:   repo,
+		config: config,
+		log:    slog.Default().With("component", "deployer"),
+	}
+}
+
+// deployWebhookPayload is the JSON body sent for webhook deploy actions.
+type deployWebhookPayload struct {
+	Action    string `json:"action"`
+	Repo      string `json:"repo"`
+	PRNumber  int    `json:"pr_number"`
+	HeadSHA   string `json:"head_sha"`
+	Branch    string `json:"branch"`
+	Timestamp string `json:"timestamp"`
+}
+
+// Deploy executes the configured post-merge action for the given PR state.
+func (d *Deployer) Deploy(ctx context.Context, prState *PRState) error {
+	switch d.config.Action {
+	case "none", "":
+		d.log.Debug("deploy action is none, skipping", "pr", prState.PRNumber)
+		return nil
+
+	case "tag":
+		// Delegated to the releaser pipeline — deployer is a no-op for tags.
+		d.log.Info("deploy action is tag, delegated to releaser", "pr", prState.PRNumber)
+		return nil
+
+	case "webhook":
+		return d.deployWebhook(ctx, prState)
+
+	case "branch-push":
+		return d.deployBranchPush(ctx, prState)
+
+	default:
+		return fmt.Errorf("unknown deploy action: %q", d.config.Action)
+	}
+}
+
+// deployWebhook sends an HTTP POST to the configured webhook URL with HMAC-SHA256 signing.
+func (d *Deployer) deployWebhook(ctx context.Context, prState *PRState) error {
+	if d.config.WebhookURL == "" {
+		return fmt.Errorf("webhook_url is required for webhook deploy action")
+	}
+
+	payload := deployWebhookPayload{
+		Action:    "deploy",
+		Repo:      fmt.Sprintf("%s/%s", d.owner, d.repo),
+		PRNumber:  prState.PRNumber,
+		HeadSHA:   prState.HeadSHA,
+		Branch:    prState.TargetBranch,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal webhook payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.config.WebhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create webhook request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// Add custom headers
+	for k, v := range d.config.WebhookHeaders {
+		req.Header.Set(k, v)
+	}
+
+	// HMAC-SHA256 signing
+	if d.config.WebhookSecret != "" {
+		mac := hmac.New(sha256.New, []byte(d.config.WebhookSecret))
+		mac.Write(body)
+		sig := hex.EncodeToString(mac.Sum(nil))
+		req.Header.Set("X-Hub-Signature-256", "sha256="+sig)
+	}
+
+	d.log.Info("sending deploy webhook",
+		"pr", prState.PRNumber,
+		"url", d.config.WebhookURL,
+	)
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook returned status %d", resp.StatusCode)
+	}
+
+	d.log.Info("deploy webhook sent successfully",
+		"pr", prState.PRNumber,
+		"status", resp.StatusCode,
+	)
+	return nil
+}
+
+// deployBranchPush updates (or creates) a deploy branch ref to point at the merged SHA.
+func (d *Deployer) deployBranchPush(ctx context.Context, prState *PRState) error {
+	if d.config.DeployBranch == "" {
+		return fmt.Errorf("deploy_branch is required for branch-push deploy action")
+	}
+
+	d.log.Info("pushing to deploy branch",
+		"pr", prState.PRNumber,
+		"branch", d.config.DeployBranch,
+		"sha", ShortSHA(prState.HeadSHA),
+	)
+
+	if err := d.ghClient.UpdateRef(ctx, d.owner, d.repo, d.config.DeployBranch, prState.HeadSHA); err != nil {
+		return fmt.Errorf("failed to update deploy branch %q: %w", d.config.DeployBranch, err)
+	}
+
+	d.log.Info("deploy branch updated",
+		"pr", prState.PRNumber,
+		"branch", d.config.DeployBranch,
+	)
+	return nil
+}

--- a/internal/autopilot/deployer_test.go
+++ b/internal/autopilot/deployer_test.go
@@ -1,0 +1,176 @@
+package autopilot
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/adapters/github"
+)
+
+func TestDeployer_None(t *testing.T) {
+	d := NewDeployer(nil, "owner", "repo", &PostMergeConfig{Action: "none"})
+	err := d.Deploy(context.Background(), &PRState{PRNumber: 1})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestDeployer_Tag(t *testing.T) {
+	d := NewDeployer(nil, "owner", "repo", &PostMergeConfig{Action: "tag"})
+	err := d.Deploy(context.Background(), &PRState{PRNumber: 1})
+	if err != nil {
+		t.Fatalf("expected nil error for tag action (delegated to releaser), got %v", err)
+	}
+}
+
+func TestDeployer_Webhook(t *testing.T) {
+	var receivedBody deployWebhookPayload
+	var receivedHeaders http.Header
+	var receivedSignature string
+
+	secret := "test-webhook-secret"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header
+
+		bodyBytes, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(bodyBytes, &receivedBody)
+		receivedSignature = r.Header.Get("X-Hub-Signature-256")
+
+		// Verify HMAC
+		mac := hmac.New(sha256.New, []byte(secret))
+		mac.Write(bodyBytes)
+		expectedSig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+		if receivedSignature != expectedSig {
+			t.Errorf("HMAC mismatch: got %s, want %s", receivedSignature, expectedSig)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &PostMergeConfig{
+		Action:     "webhook",
+		WebhookURL: server.URL,
+		WebhookHeaders: map[string]string{
+			"X-Custom-Header": "custom-value",
+		},
+		WebhookSecret: secret,
+	}
+
+	d := NewDeployer(nil, "owner", "repo", cfg)
+	prState := &PRState{
+		PRNumber:     42,
+		HeadSHA:      "abc1234567890",
+		TargetBranch: "main",
+	}
+
+	err := d.Deploy(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	// Verify payload
+	if receivedBody.Action != "deploy" {
+		t.Errorf("expected action 'deploy', got %q", receivedBody.Action)
+	}
+	if receivedBody.PRNumber != 42 {
+		t.Errorf("expected PR number 42, got %d", receivedBody.PRNumber)
+	}
+	if receivedBody.HeadSHA != "abc1234567890" {
+		t.Errorf("expected SHA 'abc1234567890', got %q", receivedBody.HeadSHA)
+	}
+	if receivedBody.Repo != "owner/repo" {
+		t.Errorf("expected repo 'owner/repo', got %q", receivedBody.Repo)
+	}
+
+	// Verify custom header
+	if receivedHeaders.Get("X-Custom-Header") != "custom-value" {
+		t.Errorf("expected custom header 'custom-value', got %q", receivedHeaders.Get("X-Custom-Header"))
+	}
+
+	// Verify HMAC signature was present
+	if receivedSignature == "" {
+		t.Error("expected X-Hub-Signature-256 header to be set")
+	}
+}
+
+func TestDeployer_BranchPush(t *testing.T) {
+	var capturedPath string
+	var capturedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "PATCH" && r.URL.Path == "/repos/owner/repo/git/refs/heads/deploy-prod":
+			capturedPath = r.URL.Path
+			_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL("test-token", server.URL)
+
+	cfg := &PostMergeConfig{
+		Action:       "branch-push",
+		DeployBranch: "deploy-prod",
+	}
+
+	d := NewDeployer(ghClient, "owner", "repo", cfg)
+	prState := &PRState{
+		PRNumber: 42,
+		HeadSHA:  "abc1234567890",
+	}
+
+	err := d.Deploy(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if capturedPath != "/repos/owner/repo/git/refs/heads/deploy-prod" {
+		t.Errorf("expected path to refs/heads/deploy-prod, got %q", capturedPath)
+	}
+
+	if sha, ok := capturedBody["sha"].(string); !ok || sha != "abc1234567890" {
+		t.Errorf("expected SHA 'abc1234567890' in body, got %v", capturedBody["sha"])
+	}
+
+	if force, ok := capturedBody["force"].(bool); !ok || !force {
+		t.Errorf("expected force=true in body, got %v", capturedBody["force"])
+	}
+}
+
+func TestDeployer_UnknownAction(t *testing.T) {
+	d := NewDeployer(nil, "owner", "repo", &PostMergeConfig{Action: "invalid"})
+	err := d.Deploy(context.Background(), &PRState{PRNumber: 1})
+	if err == nil {
+		t.Fatal("expected error for unknown action, got nil")
+	}
+	expected := `unknown deploy action: "invalid"`
+	if err.Error() != expected {
+		t.Errorf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+func TestDeployer_BranchPush_NoBranch(t *testing.T) {
+	d := NewDeployer(nil, "owner", "repo", &PostMergeConfig{
+		Action:       "branch-push",
+		DeployBranch: "",
+	})
+	err := d.Deploy(context.Background(), &PRState{PRNumber: 1})
+	if err == nil {
+		t.Fatal("expected error for empty deploy branch, got nil")
+	}
+	if err.Error() != "deploy_branch is required for branch-push deploy action" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1653.

Closes #1653

## Changes

GitHub Issue #1653: feat(autopilot): Add post-merge deployer with webhook and branch-push actions

## Summary

- Implement `Deployer` that executes post-merge deployment actions based on per-environment `PostMergeConfig`
- Support four action types: `none` (no-op), `tag` (delegated to Releaser), `webhook` (HTTP POST with HMAC-SHA256), `branch-push` (GitHub refs API)
- Wire deployer into `Controller.handleMerged()` to run after PR merge
- Add `UpdateRef` method to GitHub client for branch ref create/update operations
- Fix lint issue (QF1002: use tagged switch) that caused CI failure in PR #1649

Closes #1641
Closes #1650

## Test plan

- [x] `TestDeployer_None` — noop action returns nil
- [x] `TestDeployer_Webhook` — httptest server verifies POST body, headers, HMAC
- [x] `TestDeployer_BranchPush` — mock GitHub API, verify ref creation
- [x] `TestDeployer_Tag` — verify no-op delegation to releaser
- [x] `TestDeployer_UnknownAction` — returns error
- [x] `TestDeployer_BranchPush_NoBranch` — returns error for empty deploy branch
- [x] All 6 tests pass locally
- [x] `golangci-lint` reports 0 issues on new code
- [x] Full autopilot test suite passes