### PR TITLE
Redesign desktop frontend layout and components to match TUI dashboard

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -24,32 +24,25 @@ function App() {
       {/* Metrics row */}
       <MetricsCards metrics={metrics} />
 
-      {/* Two-column layout: dashboard panels (left) + git graph (right) */}
+      {/* Two-column layout: left stack + right git graph */}
       <div className="flex-1 flex gap-1.5 px-2 pb-2 min-h-0 overflow-hidden">
-        {/* Left column: existing dashboard panels */}
+        {/* Left column: vertical stack matching TUI layout */}
         <div className="flex-[2] flex flex-col gap-1.5 min-w-0 min-h-0">
-          {/* Middle row: Queue (2/3) + History (1/3) */}
-          <div className="flex-1 flex gap-1.5 min-h-0">
-            <div className="flex-[2] min-w-0 min-h-0 flex flex-col">
-              <QueuePanel tasks={queueTasks} />
-            </div>
-            <div className="flex-1 min-w-0 min-h-0 flex flex-col">
-              <HistoryPanel entries={history} />
-            </div>
+          <div className="flex-[3] min-w-0 min-h-0 flex flex-col">
+            <QueuePanel tasks={queueTasks} />
           </div>
-
-          {/* Bottom row: Autopilot (1/3) + Logs (2/3) */}
-          <div className="shrink-0 flex gap-1.5" style={{ height: '30%', minHeight: '120px', maxHeight: '180px' }}>
-            <div className="flex-1 min-w-0 min-h-0 flex flex-col">
-              <AutopilotPanel status={autopilot} />
-            </div>
-            <div className="flex-[2] min-w-0 min-h-0 flex flex-col">
-              <LogsPanel entries={logs} />
-            </div>
+          <div className="flex-[2] min-w-0 min-h-0 flex flex-col">
+            <AutopilotPanel status={autopilot} />
+          </div>
+          <div className="flex-[3] min-w-0 min-h-0 flex flex-col">
+            <HistoryPanel entries={history} />
+          </div>
+          <div className="flex-[2] min-w-0 min-h-0 flex flex-col">
+            <LogsPanel entries={logs} />
           </div>
         </div>
 
-        {/* Right column: Git Graph */}
+        {/* Right column: full-height Git Graph */}
         <div className="flex-[3] min-w-0 min-h-0 flex flex-col">
           <GitGraphPanel data={gitGraph} />
         </div>

--- a/desktop/frontend/src/components/AutopilotPanel.tsx
+++ b/desktop/frontend/src/components/AutopilotPanel.tsx
@@ -52,8 +52,8 @@ function DotRow({ label, value, valueColor = 'text-lightgray' }: { label: string
   return (
     <div className="flex items-baseline gap-0 text-[10px]">
       <span className="text-midgray shrink-0">{label}</span>
-      <span className="flex-1 text-slate overflow-hidden whitespace-nowrap">
-        {' '}{'·'.repeat(20)}
+      <span className="flex-1 text-slate overflow-hidden whitespace-nowrap mx-0.5">
+        {'·'.repeat(80)}
       </span>
       <span className={`shrink-0 ${valueColor}`}>{value}</span>
     </div>

--- a/desktop/frontend/src/components/Header.tsx
+++ b/desktop/frontend/src/components/Header.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
 
+const PILOT_LOGO = `   ██████╗ ██╗██╗      ██████╗ ████████╗
+   ██╔══██╗██║██║     ██╔═══██╗╚══██╔══╝
+   ██████╔╝██║██║     ██║   ██║   ██║
+   ██╔═══╝ ██║██║     ██║   ██║   ██║
+   ██║     ██║███████╗╚██████╔╝   ██║
+   ╚═╝     ╚═╝╚══════╝ ╚═════╝    ╚═╝`
+
 interface HeaderProps {
   serverRunning: boolean
   version?: string
@@ -7,15 +14,19 @@ interface HeaderProps {
 
 export function Header({ serverRunning, version }: HeaderProps) {
   return (
-    <div className="flex items-center justify-between px-3 py-2 border-b border-border">
-      <div className="text-steel font-mono font-bold tracking-widest text-sm">
-        PILOT
-      </div>
-      <div className="flex items-center gap-3 text-[10px]">
-        {version && (
-          <span className="text-gray">{version}</span>
-        )}
-        <span className={`flex items-center gap-1 ${serverRunning ? 'text-sage' : 'text-gray'}`}>
+    <div className="px-3 py-2 border-b border-border">
+      <div className="flex items-start justify-between">
+        <div>
+          <pre className="text-steel font-mono font-bold text-[8px] leading-[1.1] select-none">
+            {PILOT_LOGO}
+          </pre>
+          {version && (
+            <div className="text-steel text-[10px] mt-0.5 ml-[12px]">
+              Pilot {version}
+            </div>
+          )}
+        </div>
+        <span className={`flex items-center gap-1 text-[10px] mt-1 ${serverRunning ? 'text-sage' : 'text-gray'}`}>
           <span className={`inline-block w-1.5 h-1.5 rounded-full ${serverRunning ? 'bg-sage pulse' : 'bg-gray'}`} />
           {serverRunning ? 'daemon running' : 'daemon offline'}
         </span>

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -22,7 +22,7 @@ interface HistoryRowProps {
 }
 
 function HistoryRow({ entry, isSubIssue = false }: HistoryRowProps) {
-  const icon = entry.status === 'completed' ? '✓' : '✗'
+  const icon = entry.status === 'completed' ? '+' : 'x'
   const iconColor = entry.status === 'completed' ? 'text-sage' : 'text-rose'
   const indent = isSubIssue ? 'pl-3' : ''
 
@@ -37,9 +37,9 @@ function HistoryRow({ entry, isSubIssue = false }: HistoryRowProps) {
       onClick={handleClick}
     >
       <span className={`text-[10px] ${iconColor} shrink-0`}>{icon}</span>
-      <span className="text-steel text-[10px] shrink-0 w-12">{entry.issueID}</span>
+      <span className="text-steel text-[10px] font-bold shrink-0 w-12">{entry.issueID}</span>
       <span className="text-lightgray text-[10px] flex-1 min-w-0 truncate">{entry.title}</span>
-      <span className="text-gray text-[10px] shrink-0">{timeAgo(entry.completedAt)}</span>
+      <span className="text-gray text-[10px] shrink-0 text-right">{timeAgo(entry.completedAt)}</span>
     </div>
   )
 }

--- a/desktop/frontend/src/components/LogsPanel.tsx
+++ b/desktop/frontend/src/components/LogsPanel.tsx
@@ -4,12 +4,6 @@ import type { LogEntry } from '../types'
 
 export type { LogEntry }
 
-const LEVEL_COLORS: Record<string, string> = {
-  info: 'text-midgray',
-  warn: 'text-amber',
-  error: 'text-rose',
-}
-
 interface LogsPanelProps {
   entries: LogEntry[]
 }
@@ -30,11 +24,11 @@ export function LogsPanel({ entries }: LogsPanelProps) {
           <div className="text-gray text-[10px]">no log entries</div>
         ) : (
           entries.map((e, i) => (
-            <div key={i} className="flex gap-2 text-[10px] leading-tight py-px">
-              <span className="text-gray shrink-0">{e.ts}</span>
-              <span className={LEVEL_COLORS[e.level ?? 'info'] ?? 'text-midgray'}>
-                {e.message}
-              </span>
+            <div key={i} className="flex gap-0 text-[10px] leading-tight py-px">
+              {e.component && (
+                <span className="text-steel shrink-0">[{e.component}]&nbsp;</span>
+              )}
+              <span className="text-lightgray truncate">{e.message}</span>
             </div>
           ))
         )}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1658.

Closes #1658

## Changes

GitHub Issue #1658: Redesign desktop frontend layout and components to match TUI dashboard

Parent: GH-1657

Implement all six changes in a single pass across `desktop/frontend/src/`:
- **Tailwind config**: Add custom color tokens (`text-steel`, `text-sage`, `text-amber`, `text-rose`, `text-midgray`, `text-slate`, `text-lightgray`, `bg-bg`, `border-border`) to `tailwind.config.js` so all components share the TUI palette.
- **App.tsx**: Replace the 2×2 grid with a two-column layout — left `flex-col` stack (Header → Metrics → Queue → Autopilot → History → Logs), right full-height Git Graph. Reference `internal/dashboard/tui.go:884-928`.
- **Header.tsx**: Add the PILOT ASCII block-art logo as a `<pre>` in steel blue (`#7eb8da`), with version below. Source: `internal/banner/banner.go`.
- **AutopilotPanel.tsx**: Add dot-leader rows (flex container: key, repeated `.` with `overflow:hidden`, value). Reference `tui.go:130-208`.
- **HistoryPanel.tsx**: Switch to compact single-line format: status prefix (`+`/`x`), bold steel-blue issue ID, truncated title, right-aligned relative time. Reference `tui.go:1602-1707`.
- **LogsPanel.tsx**: Task-prefixed format `[GH-XXXX] message`, steel-blue prefix, light-gray message, auto-scroll to bottom. Reference `tui.go:919-922`.
- **GitGraphPanel.tsx**: Color Unicode branch characters per track index using `branchColors`, style HEAD in steel-blue bold, branches in sage green, tags in amber bold. Reference `gitgraph.go:48-54, 234-292`.
- **Verify**: `cd desktop/frontend && npm run build` succeeds.
---
**Rationale for not splitting**: Every component file imports shared layout context from `App.tsx` and shares the same Tailwind color tokens. Parallel PRs touching these files would conflict on `App.tsx` layout changes and any shared CSS/config. A single atomic PR keeps the redesign coherent and conflict-free.