### PR TITLE
fix(desktop): deduplicate history and queue panels — show latest execution per issue

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -114,6 +114,110 @@ func TestGetServerStatus_EmptyGatewayURL(t *testing.T) {
 	}
 }
 
+func TestQueueTaskBetter(t *testing.T) {
+	now := time.Now()
+	earlier := now.Add(-time.Hour)
+
+	tests := []struct {
+		name      string
+		candidate QueueTask
+		existing  QueueTask
+		want      bool
+	}{
+		{
+			name:      "running beats done",
+			candidate: QueueTask{Status: "running", CreatedAt: earlier},
+			existing:  QueueTask{Status: "done", CreatedAt: now},
+			want:      true,
+		},
+		{
+			name:      "done beats failed",
+			candidate: QueueTask{Status: "done", CreatedAt: earlier},
+			existing:  QueueTask{Status: "failed", CreatedAt: now},
+			want:      true,
+		},
+		{
+			name:      "failed does not beat done",
+			candidate: QueueTask{Status: "failed", CreatedAt: now},
+			existing:  QueueTask{Status: "done", CreatedAt: earlier},
+			want:      false,
+		},
+		{
+			name:      "same status newer wins",
+			candidate: QueueTask{Status: "done", CreatedAt: now},
+			existing:  QueueTask{Status: "done", CreatedAt: earlier},
+			want:      true,
+		},
+		{
+			name:      "same status older loses",
+			candidate: QueueTask{Status: "done", CreatedAt: earlier},
+			existing:  QueueTask{Status: "done", CreatedAt: now},
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := queueTaskBetter(tt.candidate, tt.existing)
+			if got != tt.want {
+				t.Errorf("queueTaskBetter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHistoryEntryBetter(t *testing.T) {
+	now := time.Now()
+	earlier := now.Add(-time.Hour)
+
+	tests := []struct {
+		name      string
+		candidate HistoryEntry
+		existing  HistoryEntry
+		want      bool
+	}{
+		{
+			name:      "completed beats failed",
+			candidate: HistoryEntry{Status: "completed", CompletedAt: earlier},
+			existing:  HistoryEntry{Status: "failed", CompletedAt: now},
+			want:      true,
+		},
+		{
+			name:      "failed does not beat completed",
+			candidate: HistoryEntry{Status: "failed", CompletedAt: now},
+			existing:  HistoryEntry{Status: "completed", CompletedAt: earlier},
+			want:      false,
+		},
+		{
+			name:      "with PR URL beats without",
+			candidate: HistoryEntry{Status: "completed", PRURL: "https://pr/1", CompletedAt: earlier},
+			existing:  HistoryEntry{Status: "completed", CompletedAt: now},
+			want:      true,
+		},
+		{
+			name:      "without PR URL does not beat with",
+			candidate: HistoryEntry{Status: "completed", CompletedAt: now},
+			existing:  HistoryEntry{Status: "completed", PRURL: "https://pr/1", CompletedAt: earlier},
+			want:      false,
+		},
+		{
+			name:      "same status same PR newer wins",
+			candidate: HistoryEntry{Status: "failed", CompletedAt: now},
+			existing:  HistoryEntry{Status: "failed", CompletedAt: earlier},
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := historyEntryBetter(tt.candidate, tt.existing)
+			if got != tt.want {
+				t.Errorf("historyEntryBetter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetServerStatus_HealthOK_StatusUnauthorized(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1663.

Closes #1663

## Changes

GitHub Issue #1663: fix(desktop): deduplicate history and queue panels — show latest execution per issue

## Problem

Desktop app HISTORY and QUEUE panels show duplicate entries for the same issue when Pilot retries execution. Example: GH-1657 appears twice as failed, while GH-1658/GH-1660 (same work, later attempts) show as succeeded. Users see confusing noise instead of clean history.

**Root cause**: `desktop/app.go` `GetHistory()` and `GetQueueTasks()` return raw SQLite execution records — each retry is a separate row with no deduplication.

## Fix (2 changes in `desktop/app.go`)

### 1. Deduplicate `GetHistory()` (~line 165)

After fetching executions from `store.GetRecentExecutions(limit)`:
- Build a map keyed by `TaskID` (issue ID like "GH-1657")  
- For each issue, keep the **best** execution:
  - Success (`completed`) takes priority over failure
  - If same status, keep the most recent timestamp
  - Prefer entry with PR URL if available
- Return deduplicated list sorted by most recent first

### 2. Deduplicate `GetQueueTasks()` (~line 125)

Same dedup pattern:
- `running` takes priority over other statuses
- Then `completed` over `failed`
- Keep highest progress entry

## Expected result

Before: 
```
+ GH-1660  Redesign desktop...     2h ago
x GH-1657  fix(desktop): ...       2h ago
+ GH-1658  Redesign desktop...     2h ago
x GH-1657  fix(desktop): ...       2h ago
```

After:
```
+ GH-1660  Redesign desktop...     2h ago
+ GH-1658  Redesign desktop...     2h ago
+ GH-1657  fix(desktop): ...       2h ago
```

## Key files
- `desktop/app.go` — `GetHistory()` (~line 165), `GetQueueTasks()` (~line 125)

Task doc: `.agent/tasks/TASK-04-history-dedup.md`