### PR TITLE
fix(desktop): add version injection and fix hardcoded Info.plist version

### DIFF
--- a/desktop/build/darwin/Info.plist
+++ b/desktop/build/darwin/Info.plist
@@ -6,8 +6,8 @@
     <key>CFBundleIdentifier</key><string>ai.pilotdev.desktop</string>
     <key>CFBundleName</key><string>Pilot</string>
     <key>CFBundleDisplayName</key><string>Pilot</string>
-    <key>CFBundleVersion</key><string>1.0.0</string>
-    <key>CFBundleShortVersionString</key><string>1.0.0</string>
+    <key>CFBundleVersion</key><string>{{.Info.ProductVersion}}</string>
+    <key>CFBundleShortVersionString</key><string>{{.Info.ProductVersion}}</string>
     <key>CFBundlePackageType</key><string>APPL</string>
     <key>NSHighResolutionCapable</key><true/>
     <key>NSAppTransportSecurity</key>

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -12,6 +12,8 @@ import (
 //go:embed all:frontend/dist
 var assets embed.FS
 
+var version = "dev"
+
 func main() {
 	app := NewApp()
 
@@ -31,7 +33,7 @@ func main() {
 		Mac: &mac.Options{
 			TitleBar: mac.TitleBarDefault(),
 			About: &mac.AboutInfo{
-				Title:   "Pilot",
+				Title:   "Pilot " + version,
 				Message: "AI that ships your tickets",
 			},
 		},


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1666.

Closes #1666

## Changes

GitHub Issue #1666: fix(desktop): add version injection and fix hardcoded Info.plist version

## Problem

CI passes `-ldflags "-X main.version=$VERSION"` but `desktop/main.go` has no `var version` variable — the flag is silently ignored. `desktop/build/darwin/Info.plist` hardcodes `1.0.0`.

## Requirements

### 1. Add version variable to `desktop/main.go`

```go
var version = "dev"
```

Use it in the About dialog:

```go
Mac: &mac.Options{
    TitleBar: mac.TitleBarDefault(),
    About: &mac.AboutInfo{
        Title:   "Pilot " + version,
        Message: "AI that ships your tickets",
    },
},
```

### 2. Fix `desktop/build/darwin/Info.plist`

Replace hardcoded version strings with Wails template syntax:

```xml
<key>CFBundleVersion</key><string>{{.Info.ProductVersion}}</string>
<key>CFBundleShortVersionString</key><string>{{.Info.ProductVersion}}</string>
```

Keep all other fields (bundle ID, NSAppTransportSecurity, etc.) unchanged.

## Files

- `desktop/main.go`
- `desktop/build/darwin/Info.plist`

## Verification

- `wails build` locally, check About dialog shows version
- Verify Info.plist in built Pilot.app has correct version (not 1.0.0)