### PR TITLE
fix(desktop): add version injection and exclude desktop from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
         run: go mod download
 
       - name: Build
-        run: go build -v ./...
+        run: go build -v $(go list ./... | grep -v /desktop)
 
       - name: Test
-        run: go test -v -race -coverprofile=coverage.out ./...
+        run: go test -v -race -coverprofile=coverage.out $(go list ./... | grep -v /desktop)
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,9 @@ linters:
         - "-ST1020"  # Comment format
         - "-ST1021"  # Comment format
   exclusions:
+    paths:
+      # Desktop app requires Wails toolchain + built frontend assets
+      - desktop/
     rules:
       # Exclude unused save functions in memory package
       - path: internal/memory/

--- a/desktop/build/darwin/Info.plist
+++ b/desktop/build/darwin/Info.plist
@@ -6,8 +6,8 @@
     <key>CFBundleIdentifier</key><string>ai.pilotdev.desktop</string>
     <key>CFBundleName</key><string>Pilot</string>
     <key>CFBundleDisplayName</key><string>Pilot</string>
-    <key>CFBundleVersion</key><string>1.0.0</string>
-    <key>CFBundleShortVersionString</key><string>1.0.0</string>
+    <key>CFBundleVersion</key><string>{{.Info.ProductVersion}}</string>
+    <key>CFBundleShortVersionString</key><string>{{.Info.ProductVersion}}</string>
     <key>CFBundlePackageType</key><string>APPL</string>
     <key>NSHighResolutionCapable</key><true/>
     <key>NSAppTransportSecurity</key>

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -9,6 +9,8 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
 )
 
+var version = "dev"
+
 //go:embed all:frontend/dist
 var assets embed.FS
 
@@ -16,7 +18,7 @@ func main() {
 	app := NewApp()
 
 	if err := wails.Run(&options.App{
-		Title:     "Pilot",
+		Title:     "Pilot " + version,
 		Width:     480,
 		Height:    900,
 		MinWidth:  400,
@@ -31,7 +33,7 @@ func main() {
 		Mac: &mac.Options{
 			TitleBar: mac.TitleBarDefault(),
 			About: &mac.AboutInfo{
-				Title:   "Pilot",
+				Title:   "Pilot " + version,
 				Message: "AI that ships your tickets",
 			},
 		},


### PR DESCRIPTION
## Summary

- Add `var version = "dev"` to `desktop/main.go` for CI `-ldflags` injection
- Use version in window title and About dialog
- Replace hardcoded `1.0.0` in `Info.plist` with Wails `{{.Info.ProductVersion}}` template syntax
- Exclude `desktop/` from CI build, test, and lint — it requires Wails toolchain and built frontend assets (`//go:embed all:frontend/dist` fails without them)

## Root Cause

CI runs `go build ./...` which includes the `desktop/` package. The `//go:embed all:frontend/dist` directive fails because CI doesn't build the Wails frontend. The `dist/` directory only contains a `.gitkeep` placeholder.

Closes #1666, closes #1672

## Test plan

- [x] `go build $(go list ./... | grep -v /desktop)` passes
- [x] `go test $(go list ./... | grep -v /desktop)` passes  
- [x] `go build -o /dev/null ./desktop/` still works locally with Wails
- [ ] CI lint and test jobs pass