### PR TITLE
fix(ci): desktop release fails — app bundle name mismatch in wails.json

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         run: |
           cd desktop/build/bin
-          tar czf ../../../Pilot-Linux-amd64.tar.gz pilot
+          tar czf ../../../Pilot-Linux-amd64.tar.gz Pilot
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://wails.io/schemas/config.v2.json",
-  "name": "pilot-desktop",
+  "name": "Pilot",
   "outputfilename": "Pilot",
   "frontend:install": "npm install",
   "frontend:build": "npm run build",


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1682.

Closes #1682

## Changes

GitHub Issue #1682: fix(ci): desktop release fails — app bundle name mismatch in wails.json

## Problem

All desktop release CI runs fail with:
```
cp: desktop/build/bin/Pilot.app: No such file or directory
```

Wails outputs `pilot-desktop.app` (from `name: "pilot-desktop"` in wails.json), but CI packaging steps expect `Pilot.app`.

## Root Cause

`desktop/wails.json` has `"name": "pilot-desktop"`. Wails uses this as the `.app` bundle name on macOS: `pilot-desktop.app`. The `outputfilename` field only sets the binary name inside the bundle.

## Fix

### 1. `desktop/wails.json` — change name to "Pilot"

```json
{
  "name": "Pilot",
  "outputfilename": "Pilot",
  ...
}
```

This makes the macOS bundle `Pilot.app`, the Windows exe `Pilot.exe`, and the Linux binary `Pilot`.

### 2. `.github/workflows/release-desktop.yml` — fix Linux binary name

Line 105 references lowercase `pilot`:
```yaml
tar czf ../../../Pilot-Linux-amd64.tar.gz pilot
```

Should be `Pilot` (matching `outputfilename`):
```yaml
tar czf ../../../Pilot-Linux-amd64.tar.gz Pilot
```

### 3. Verify Windows artifact paths

The NSIS installer output name may also reference the old `pilot-desktop` name. After the name change, verify:
- `desktop/build/bin/Pilot.exe` exists
- NSIS installer is findable by the `find` command in the workflow

## Files

- `desktop/wails.json`
- `.github/workflows/release-desktop.yml` (line 105)

## Verification

After fix, push a new tag and confirm:
- macOS: `Pilot.app` in `desktop/build/bin/`
- DMG + ZIP artifacts uploaded to release
- Windows + Linux artifacts uploaded to release