### PR TITLE
Telegram: active project ignored when sending task - always uses default project

### DIFF
--- a/internal/adapters/telegram/handler.go
+++ b/internal/adapters/telegram/handler.go
@@ -565,7 +565,7 @@ If the question is too broad, ask for clarification instead of exploring everyth
 		ID:          taskID,
 		Title:       "Question: " + truncateDescription(question, 40),
 		Description: prompt,
-		ProjectPath: h.projectPath,
+		ProjectPath: h.getActiveProjectPath(chatID),
 		Verbose:     false,
 	}
 
@@ -662,13 +662,13 @@ func (h *Handler) sendResearchOutput(ctx context.Context, chatID, query string, 
 	}
 
 	// Optionally save to file
-	h.saveResearchFile(query, content)
+	h.saveResearchFile(chatID, query, content)
 }
 
 // saveResearchFile saves research output to .agent/research/ directory
-func (h *Handler) saveResearchFile(query, content string) {
+func (h *Handler) saveResearchFile(chatID, query, content string) {
 	// Create .agent/research/ directory if it doesn't exist
-	researchDir := filepath.Join(h.projectPath, ".agent", "research")
+	researchDir := filepath.Join(h.getActiveProjectPath(chatID), ".agent", "research")
 	if err := os.MkdirAll(researchDir, 0755); err != nil {
 		return // Silent fail for file save
 	}
@@ -912,7 +912,7 @@ func (h *Handler) handleTask(ctx context.Context, chatID, description string) {
 
 	// Send confirmation message with inline keyboard
 	// Use displayDesc for user-friendly display, description is kept for execution
-	confirmMsg := FormatTaskConfirmation(taskID, displayDesc, h.projectPath)
+	confirmMsg := FormatTaskConfirmation(taskID, displayDesc, h.getActiveProjectPath(chatID))
 
 	msgResp, err := h.client.SendMessageWithKeyboard(ctx, chatID, confirmMsg, "",
 		[][]InlineKeyboardButton{
@@ -1025,7 +1025,7 @@ func (h *Handler) executeTaskWithOptions(ctx context.Context, chatID, taskID, de
 		ID:          taskID,
 		Title:       truncateDescription(description, 50),
 		Description: description,
-		ProjectPath: h.projectPath,
+		ProjectPath: h.getActiveProjectPath(chatID),
 		Verbose:     false,
 		Branch:      branch,
 		BaseBranch:  baseBranch,
@@ -1401,7 +1401,7 @@ func (h *Handler) executeImageTask(ctx context.Context, chatID, imagePath, promp
 		ID:          taskID,
 		Title:       "Image analysis",
 		Description: prompt,
-		ProjectPath: h.projectPath,
+		ProjectPath: h.getActiveProjectPath(chatID),
 		Verbose:     false,
 		ImagePath:   imagePath,
 		Branch:      fmt.Sprintf("pilot/%s", taskID),


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1685.

Closes #1685

## Changes

GitHub Issue #1685: Telegram: active project ignored when sending task - always uses default project

## Bug Description

After switching projects via `/project <name>` or inline project buttons, any new task sent via Telegram is still confirmed and executed against the **default project** (`default_project` in config), not the switched project.

## Root Cause

In `internal/adapters/telegram/handler.go`, 5 locations use `h.projectPath` (the static default set at initialization) instead of `h.getActiveProjectPath(chatID)` which correctly returns the per-chat active project.

### Buggy Locations (all in handler.go)

| Line | Function | Fix |
|------|----------|-----|
| **568** | `handleQuestion()` | `ProjectPath: h.projectPath` → `h.getActiveProjectPath(chatID)` |
| **897** | `handleTask()` confirmation | `FormatTaskConfirmation(taskID, displayDesc, h.projectPath)` → `h.getActiveProjectPath(chatID)` |
| **1010** | `executeTaskWithOptions()` | `ProjectPath: h.projectPath` → `h.getActiveProjectPath(chatID)` |
| **1386** | `executeImageTask()` | `ProjectPath: h.projectPath` → `h.getActiveProjectPath(chatID)` |
| **671** | `saveResearchFile()` | `h.projectPath` → needs `chatID` parameter, then `h.getActiveProjectPath(chatID)` |

### Correctly Implemented (for reference)

- `handleResearch()` line 616 ✅
- `handlePlanning()` line 711 ✅  
- `handleChat()` line 805 ✅

All use `h.getActiveProjectPath(chatID)` correctly.

## Implementation

1. Replace `h.projectPath` → `h.getActiveProjectPath(chatID)` in lines 568, 897, 1010, 1386
2. Add `chatID` parameter to `saveResearchFile()` and use `h.getActiveProjectPath(chatID)` at line 671
3. Update all callers of `saveResearchFile()` to pass `chatID`
4. Add test verifying task execution uses active project, not default

## Steps to Reproduce

1. Configure multiple projects in `~/.pilot/config.yaml` with a `default_project`
2. Start the Telegram bot
3. Switch to a different project: `/project A`
4. Bot confirms: "Active project: A ✅"
5. Send a task: "add a button to the homepage"
6. **Bug:** Confirmation message shows the default project path, and task executes there

## Expected Behavior

After `/project A`, all tasks should be confirmed and executed in `A`.