### PR TITLE
Add Discord link to README and community docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-BSL_1.1-blue.svg?style=flat-square" alt="License: BSL 1.1"></a>
   <a href="https://github.com/alekspetrov/pilot/actions"><img src="https://github.com/alekspetrov/pilot/workflows/CI/badge.svg?style=flat-square" alt="CI"></a>
   <a href="https://goreportcard.com/report/github.com/alekspetrov/pilot"><img src="https://goreportcard.com/badge/github.com/alekspetrov/pilot?style=flat-square" alt="Go Report Card"></a>
+  <a href="https://discord.gg/K6mM8TzJ"><img src="https://img.shields.io/badge/Discord-Join%20Chat-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
 <p align="center">
@@ -27,6 +28,7 @@
   <a href="#how-it-works">How It Works</a> •
   <a href="#features">Features</a> •
   <a href="#cli-reference">CLI</a> •
+  <a href="https://discord.gg/K6mM8TzJ">Discord</a> •
   <a href="docs/DEPLOYMENT.md">Deploy</a>
 </p>
 

--- a/docs/content/community.mdx
+++ b/docs/content/community.mdx
@@ -4,6 +4,7 @@ Pilot is source-available under [BSL 1.1](https://github.com/alekspetrov/pilot/b
 
 ## Get Involved
 
+- [Discord Server](https://discord.gg/K6mM8TzJ) — Chat with the community, get help, share feedback
 - [GitHub Repository](https://github.com/alekspetrov/pilot) — Source code, issues, and releases
 - [Contributing Guide](https://github.com/alekspetrov/pilot/blob/main/CONTRIBUTING.md) — Dev setup, code standards, PR process
 - [Report an Issue](https://github.com/alekspetrov/pilot/issues/new) — Bug reports and feature requests


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1696.

Closes #1696

## Changes

GitHub Issue #1696: Add Discord link to README and community docs page

## Task

Add the Discord community link (`https://discord.gg/K6mM8TzJ`) to two files:

### 1. `README.md`

Add Discord to the nav links bar (line 23-31). Insert between existing links:

```html
<p align="center">
  <a href="https://pilot.quantflow.studio">Docs</a> •
  <a href="#install">Install</a> •
  <a href="#quick-start">Quick Start</a> •
  <a href="#how-it-works">How It Works</a> •
  <a href="#features">Features</a> •
  <a href="#cli-reference">CLI</a> •
  <a href="https://discord.gg/K6mM8TzJ">Discord</a> •
  <a href="docs/DEPLOYMENT.md">Deploy</a>
</p>
```

Also add a Discord badge to the badges section (line 16-21), after the Go Report Card badge:

```html
<a href="https://discord.gg/K6mM8TzJ"><img src="https://img.shields.io/badge/Discord-Join%20Chat-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
```

### 2. `docs/content/community.mdx`

Add Discord as the first item in the "Get Involved" section:

```markdown
## Get Involved

- [Discord Server](https://discord.gg/K6mM8TzJ) — Chat with the community, get help, share feedback
- [GitHub Repository](https://github.com/alekspetrov/pilot) — Source code, issues, and releases
...
```

### Files to modify
- `README.md` (lines 16-31)
- `docs/content/community.mdx` (line 7)

### NOT needed
- `docs/app/layout.tsx` already has Discord in the navbar chat link — no changes needed there