### PR TITLE
Wire GitLab polling in main.go

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/alekspetrov/pilot/internal/adapters/asana"
 	"github.com/alekspetrov/pilot/internal/adapters/github"
+	"github.com/alekspetrov/pilot/internal/adapters/gitlab"
 	"github.com/alekspetrov/pilot/internal/adapters/jira"
 	"github.com/alekspetrov/pilot/internal/adapters/linear"
 	"github.com/alekspetrov/pilot/internal/alerts"
@@ -1344,4 +1345,272 @@ func formatTokenCountComment(tokens int64) string {
 		return fmt.Sprintf("%.1fK", float64(tokens)/1000)
 	}
 	return fmt.Sprintf("%d", tokens)
+}
+
+// handleGitLabIssueWithResult processes a GitLab issue and returns MR info (GH-1698)
+func handleGitLabIssueWithResult(ctx context.Context, cfg *config.Config, client *gitlab.Client, issue *gitlab.Issue, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner, monitor *executor.Monitor, program *tea.Program, alertsEngine *alerts.Engine, enforcer *budget.Enforcer) (*gitlab.IssueResult, error) {
+	taskID := fmt.Sprintf("GL-%d", issue.IID)
+
+	// Register task with monitor if in dashboard mode
+	if monitor != nil {
+		monitor.Register(taskID, issue.Title, issue.WebURL)
+	}
+	if program != nil {
+		program.Send(dashboard.AddLog(fmt.Sprintf("🦊 GitLab Issue #%d: %s", issue.IID, issue.Title))())
+	}
+
+	// Emit task started event
+	if alertsEngine != nil {
+		alertsEngine.ProcessEvent(alerts.Event{
+			Type:      alerts.EventTypeTaskStarted,
+			TaskID:    taskID,
+			TaskTitle: issue.Title,
+			Project:   projectPath,
+			Timestamp: time.Now(),
+		})
+	}
+
+	// Pre-execution budget check
+	if enforcer != nil {
+		checkResult, budgetErr := enforcer.CheckBudget(ctx, "", "")
+		if budgetErr != nil {
+			logging.WithComponent("budget").Warn("budget check failed, allowing task (fail-open)",
+				slog.String("task_id", taskID),
+				slog.Any("error", budgetErr),
+			)
+		} else if !checkResult.Allowed {
+			logging.WithComponent("budget").Warn("task blocked by budget enforcement",
+				slog.String("task_id", taskID),
+				slog.String("reason", checkResult.Reason),
+			)
+			if alertsEngine != nil {
+				alertsEngine.ProcessEvent(alerts.Event{
+					Type:      alerts.EventTypeBudgetExceeded,
+					TaskID:    taskID,
+					TaskTitle: issue.Title,
+					Project:   projectPath,
+					Error:     checkResult.Reason,
+					Metadata: map[string]string{
+						"daily_left":   fmt.Sprintf("%.2f", checkResult.DailyLeft),
+						"monthly_left": fmt.Sprintf("%.2f", checkResult.MonthlyLeft),
+						"action":       string(checkResult.Action),
+					},
+					Timestamp: time.Now(),
+				})
+			}
+			budgetExceededErr := fmt.Errorf("budget enforcement: %s", checkResult.Reason)
+			return &gitlab.IssueResult{
+				Success: false,
+				Error:   budgetExceededErr,
+			}, budgetExceededErr
+		}
+	}
+
+	fmt.Printf("\n🦊 GitLab Issue #%d: %s\n", issue.IID, issue.Title)
+
+	taskDesc := fmt.Sprintf("GitLab Issue #%d: %s\n\n%s", issue.IID, issue.Title, issue.Description)
+	branchName := fmt.Sprintf("pilot/GL-%d", issue.IID)
+
+	task := &executor.Task{
+		ID:          taskID,
+		Title:       issue.Title,
+		Description: taskDesc,
+		ProjectPath: projectPath,
+		Branch:      branchName,
+		CreatePR:    true,
+	}
+
+	var result *executor.ExecutionResult
+	var execErr error
+
+	if dispatcher != nil {
+		execID, qErr := dispatcher.QueueTask(ctx, task)
+		if qErr != nil {
+			execErr = fmt.Errorf("failed to queue task: %w", qErr)
+		} else {
+			if monitor != nil {
+				monitor.Queue(taskID)
+			}
+			fmt.Printf("   📋 Queued as execution %s\n", execID[:8])
+			exec, waitErr := dispatcher.WaitForExecution(ctx, execID, time.Second)
+			if waitErr != nil {
+				execErr = fmt.Errorf("failed waiting for execution: %w", waitErr)
+			} else if exec.Status == "failed" {
+				execErr = fmt.Errorf("execution failed: %s", exec.Error)
+			} else {
+				result = &executor.ExecutionResult{
+					TaskID:    task.ID,
+					Success:   exec.Status == "completed",
+					Output:    exec.Output,
+					Error:     exec.Error,
+					PRUrl:     exec.PRUrl,
+					CommitSHA: exec.CommitSHA,
+					Duration:  time.Duration(exec.DurationMs) * time.Millisecond,
+				}
+			}
+		}
+	} else {
+		result, execErr = runner.Execute(ctx, task)
+	}
+
+	// Update monitor with completion status
+	prURL := ""
+	if result != nil {
+		prURL = result.PRUrl
+	}
+	if monitor != nil {
+		if execErr != nil {
+			monitor.Fail(taskID, execErr.Error())
+		} else {
+			monitor.Complete(taskID, prURL)
+		}
+	}
+
+	// Emit task completed/failed event
+	if alertsEngine != nil {
+		if execErr != nil {
+			alertsEngine.ProcessEvent(alerts.Event{
+				Type:      alerts.EventTypeTaskFailed,
+				TaskID:    taskID,
+				TaskTitle: issue.Title,
+				Project:   projectPath,
+				Error:     execErr.Error(),
+				Timestamp: time.Now(),
+			})
+		} else if result != nil && result.Success {
+			metadata := map[string]string{}
+			if result.PRUrl != "" {
+				metadata["pr_url"] = result.PRUrl
+			}
+			if result.Duration > 0 {
+				metadata["duration"] = result.Duration.String()
+			}
+			alertsEngine.ProcessEvent(alerts.Event{
+				Type:      alerts.EventTypeTaskCompleted,
+				TaskID:    taskID,
+				TaskTitle: issue.Title,
+				Project:   projectPath,
+				Metadata:  metadata,
+				Timestamp: time.Now(),
+			})
+		} else if result != nil {
+			alertsEngine.ProcessEvent(alerts.Event{
+				Type:      alerts.EventTypeTaskFailed,
+				TaskID:    taskID,
+				TaskTitle: issue.Title,
+				Project:   projectPath,
+				Error:     result.Error,
+				Timestamp: time.Now(),
+			})
+		}
+	}
+
+	// Add completed task to dashboard history
+	if program != nil {
+		status := "success"
+		duration := ""
+		if execErr != nil {
+			status = "failed"
+		} else if result != nil {
+			duration = result.Duration.String()
+		}
+		program.Send(dashboard.AddCompletedTask(taskID, issue.Title, status, duration, "", false)())
+	}
+
+	// Build issue result
+	issueResult := &gitlab.IssueResult{
+		Success:    execErr == nil && result != nil && result.Success,
+		BranchName: branchName,
+	}
+	if result != nil {
+		if result.PRUrl != "" {
+			issueResult.MRURL = result.PRUrl
+			if mrNum, err := gitlab.ExtractMRNumber(result.PRUrl); err == nil {
+				issueResult.MRNumber = mrNum
+			}
+		}
+		issueResult.HeadSHA = result.CommitSHA
+	}
+
+	// Add comment to GitLab issue
+	if execErr != nil {
+		comment := fmt.Sprintf("❌ Pilot execution failed:\n\n%s", execErr.Error())
+		if _, err := client.AddIssueNote(ctx, issue.IID, comment); err != nil {
+			logging.WithComponent("gitlab").Warn("Failed to add note",
+				slog.Int("issue", issue.IID),
+				slog.Any("error", err),
+			)
+		}
+	} else if result != nil && result.Success {
+		// Validate deliverables before marking as done
+		if result.CommitSHA == "" && result.PRUrl == "" {
+			comment := fmt.Sprintf("⚠️ Pilot execution completed but no changes were made.\n\nDuration: %s\nBranch: %s\n\nNo commits or MR were created. The task may need clarification or manual intervention.",
+				result.Duration, branchName)
+			if _, err := client.AddIssueNote(ctx, issue.IID, comment); err != nil {
+				logging.WithComponent("gitlab").Warn("Failed to add note",
+					slog.Int("issue", issue.IID),
+					slog.Any("error", err),
+				)
+			}
+			issueResult.Success = false
+		} else {
+			comment := buildGitLabExecutionComment(result, branchName)
+			if _, err := client.AddIssueNote(ctx, issue.IID, comment); err != nil {
+				logging.WithComponent("gitlab").Warn("Failed to add note",
+					slog.Int("issue", issue.IID),
+					slog.Any("error", err),
+				)
+			}
+
+			// Close the issue on success
+			if err := client.UpdateIssueState(ctx, issue.IID, "close"); err != nil {
+				logging.WithComponent("gitlab").Warn("failed to close issue",
+					slog.Int("issue", issue.IID),
+					slog.Any("error", err),
+				)
+			}
+		}
+	} else if result != nil {
+		comment := buildGitLabFailureComment(result)
+		if _, err := client.AddIssueNote(ctx, issue.IID, comment); err != nil {
+			logging.WithComponent("gitlab").Warn("Failed to add note",
+				slog.Int("issue", issue.IID),
+				slog.Any("error", err),
+			)
+		}
+	}
+
+	return issueResult, execErr
+}
+
+// buildGitLabExecutionComment creates a comment for successful GitLab execution
+func buildGitLabExecutionComment(result *executor.ExecutionResult, branchName string) string {
+	var parts []string
+	parts = append(parts, "✅ Pilot execution completed successfully!")
+	parts = append(parts, "")
+
+	if result.PRUrl != "" {
+		parts = append(parts, fmt.Sprintf("Merge Request: %s", result.PRUrl))
+	}
+	if result.CommitSHA != "" {
+		parts = append(parts, fmt.Sprintf("Commit: %s", result.CommitSHA[:min(8, len(result.CommitSHA))]))
+	}
+	parts = append(parts, fmt.Sprintf("Branch: %s", branchName))
+	parts = append(parts, fmt.Sprintf("Duration: %s", result.Duration))
+
+	return strings.Join(parts, "\n")
+}
+
+// buildGitLabFailureComment creates a comment for failed GitLab execution
+func buildGitLabFailureComment(result *executor.ExecutionResult) string {
+	var parts []string
+	parts = append(parts, "❌ Pilot execution failed")
+	parts = append(parts, "")
+	if result.Error != "" {
+		parts = append(parts, fmt.Sprintf("Error: %s", result.Error))
+	}
+	if result.Duration > 0 {
+		parts = append(parts, fmt.Sprintf("Duration: %s", result.Duration))
+	}
+	return strings.Join(parts, "\n")
 }

--- a/cmd/pilot/main_test.go
+++ b/cmd/pilot/main_test.go
@@ -910,6 +910,7 @@ func TestApplyInputOverrides(t *testing.T) {
 			cmd.Flags().Bool("telegram", false, "")
 			cmd.Flags().Bool("github", false, "")
 			cmd.Flags().Bool("linear", false, "")
+			cmd.Flags().Bool("gitlab", false, "")
 			cmd.Flags().Bool("slack", false, "")
 			cmd.Flags().Bool("tunnel", false, "")
 
@@ -917,7 +918,7 @@ func TestApplyInputOverrides(t *testing.T) {
 				_ = cmd.Flags().Set(k, v)
 			}
 
-			applyInputOverrides(cfg, cmd, tt.telegram, tt.github, tt.linear, tt.slack, tt.tunnel)
+			applyInputOverrides(cfg, cmd, tt.telegram, tt.github, tt.linear, false, tt.slack, tt.tunnel)
 
 			if tt.checkTelegram != nil {
 				if cfg.Adapters.Telegram == nil {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1698.

Closes #1698

## Changes

GitHub Issue #1698: Wire GitLab polling in main.go

## Task

Wire the GitLab adapter polling into `cmd/pilot/main.go`. The adapter is fully implemented but never instantiated in the polling lifecycle.

## Context

- GitLab poller: `internal/adapters/gitlab/poller.go` — `NewPoller()` at line 145
- Has `WithProcessedStore()` (line 127), `WithMaxConcurrent()` (line 135), `OnMRCreated` callback (line 57)
- Webhook already registered in gateway at `internal/gateway/server.go` line 219
- Config types exist in `internal/adapters/gitlab/types.go`

## Implementation

Follow the pattern from GitHub (main.go line 761), Linear (line 845), Jira (line 879), Asana (line 921):

1. Add GitLab poller initialization block in polling mode section of `cmd/pilot/main.go`
2. Wire `WithProcessedStore()` for dedup across restarts
3. Wire `WithMaxConcurrent()` from orchestrator config
4. Wire `OnMRCreated` callback to autopilot controller (same pattern as GitHub line 682)
5. Add `--gitlab` CLI flag if not present
6. Ensure config loading handles `cfg.Adapters.GitLab` nil check

## Acceptance Criteria

- [ ] GitLab polling starts when `--gitlab` flag is passed and config has `gitlab.polling.enabled: true`
- [ ] ProcessedStore wired for persistence
- [ ] Parallel execution respects `max_concurrent`
- [ ] OnMRCreated routes to autopilot controller
- [ ] Builds and passes `make test`