### PR TITLE
Fix lint failure: remove duplicate test declarations in upgrade package

### DIFF
--- a/.agent/tasks/gh-1710.md
+++ b/.agent/tasks/gh-1710.md
@@ -1,0 +1,27 @@
+# GH-1710
+
+**Created:** 2026-02-23
+
+## Problem
+
+GitHub Issue #1710: Add test coverage for upgrade package critical paths
+
+## Summary
+
+Automated PR created by Pilot for task GH-1703.
+
+Closes #1703, Closes #1708
+
+## Changes
+
+- Comprehensive test coverage for upgrade package critical paths (from PR #1707)
+- Fixed 7 `errcheck` lint warnings: wrapped deferred `os.Remove`, `os.Chmod`, and `Close` calls with anonymous functions discarding errors
+
+## Verification
+
+- `golangci-lint run ./internal/upgrade/...` → 0 issues
+- `go build ./...` → passes
+- `go test ./internal/upgrade/...` → passes
+
+## Acceptance Criteria
+


### PR DESCRIPTION
## Summary
- Removed 15 duplicate test function/type declarations from `upgrade_test.go` that conflicted with existing tests in `upgrade_critical_test.go`, `graceful_test.go`, and `hot_test.go`
- All unique new test coverage from PR #1711 is preserved
- `golangci-lint run ./internal/upgrade/...` → 0 issues

## Test plan
- [x] `golangci-lint run ./internal/upgrade/...` passes (0 issues)
- [x] `go test ./internal/upgrade/...` passes
- [x] `go build ./...` passes

Closes #1712