### PR TITLE
docs: Add planning_timeout config field to configuration reference

### DIFF
--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -165,6 +165,7 @@ executor:
   claude_code:
     command: "claude"                     # path to claude CLI
     extra_args: []                        # additional CLI arguments
+    planning_timeout: 2m                  # max time for epic planning before fallback to direct mode
 
   model_routing:
     enabled: false
@@ -204,6 +205,7 @@ executor:
 | `use_worktree` | bool | `false` | Execute tasks in isolated git worktrees (enables execution with uncommitted changes) |
 | `claude_code.command` | string | `"claude"` | Path to the Claude CLI binary |
 | `claude_code.extra_args` | []string | `[]` | Additional CLI arguments |
+| `claude_code.planning_timeout` | duration | `2m` | Maximum time for epic planning before fallback to direct execution. Affects Slack `/plan` and Telegram planning commands. |
 | `qwen_code.command` | string | `"qwen"` | Path to the Qwen Code CLI binary |
 | `qwen_code.use_session_resume` | bool | `false` | Reuse sessions for self-review |
 | `model_routing.enabled` | bool | `false` | Route tasks to different models by complexity |


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1733.

Closes #1733

## Changes

GitHub Issue #1733: docs: Add planning_timeout config field to configuration reference

## Task

Add the `planning_timeout` configuration field to the executor section of `docs/content/getting-started/configuration.mdx`.

## Context

PR #1690 added a configurable planning timeout to the executor backend. This field is missing from the docs configuration reference.

## Code References

- `internal/executor/backend.go:270-273` — `PlanningTimeout` field definition
- `internal/executor/backend.go:503` — Default value: `2 * time.Minute`
- `internal/adapters/slack/handler.go:623-627` — Slack uses it
- `internal/adapters/telegram/handler.go:716-720` — Telegram uses it
- YAML key: `planning_timeout` under `executor.claude_code`

## Changes Required

In `docs/content/getting-started/configuration.mdx`, add to the executor/claude_code section (near the existing `command` field):

```yaml
executor:
  claude_code:
    planning_timeout: 2m  # Maximum time for epic planning before fallback to direct mode (default: 2m)
```

Explain that if planning exceeds this timeout, execution falls through to direct (non-epic) mode. This affects both Slack and Telegram plan commands.

## Acceptance Criteria

- [ ] `planning_timeout` field documented with type, default, and description
- [ ] Mention it affects Slack `/plan` and Telegram planning commands
- [ ] No other files need changes