### PR TITLE
docs: Add ProcessedStore and CompleteTask callback to asana.mdx

### DIFF
--- a/docs/content/integrations/asana.mdx
+++ b/docs/content/integrations/asana.mdx
@@ -246,6 +246,27 @@ Asana tasks can belong to multiple projects. Pilot uses the first project for co
 # Pilot sees: ProjectName = "Backend"
 ```
 
+## Duplicate Prevention
+
+<Callout type="info">
+Available since v2.10.0. All non-GitHub pollers now share this reliability feature.
+</Callout>
+
+The Asana poller persists processed task state to SQLite via a `ProcessedStore`. This means:
+
+- **Survives restarts and hot upgrades** — tasks that were already dispatched are not re-dispatched after a restart.
+- **Automatic rollback on failure** — if execution fails, the task is unmarked so Pilot can retry it on the next poll cycle.
+- **Loaded on startup** — previously processed tasks are restored from the database before the first poll.
+
+No additional configuration is required. The store is enabled automatically when Pilot uses SQLite for memory.
+
+## Automatic Task Completion
+
+When Pilot creates a PR for an Asana task, the task is automatically marked as completed in Asana via the `CompleteTask` API call.
+
+- Completion happens as part of the success notification flow (after the PR comment is posted).
+- **Non-blocking** — if the `CompleteTask` call fails (e.g., network error, permission issue), the PR is still created and the task is still marked as `pilot-done` via tags. A warning is logged instead.
+
 ## Retry Behavior
 
 If execution fails:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1735.

Closes #1735

## Changes

GitHub Issue #1735: docs: Add ProcessedStore and CompleteTask callback to asana.mdx

## Task

Update `docs/content/integrations/asana.mdx` with two v2.10.0 reliability features.

## Feature 1: ProcessedStore (PR #1709)

Asana poller now tracks which tasks have been processed across restarts, preventing duplicate dispatch.

### Code References
- `internal/adapters/asana/poller.go:33-35` — `ProcessedStore` interface
- `internal/adapters/asana/poller.go:86-90` — `WithProcessedStore()` option
- `internal/adapters/asana/poller.go:120-121` — Load on startup
- `internal/adapters/asana/poller.go:381-382` — Mark processed
- `internal/adapters/asana/poller.go:417-418` — Unmark on failure

### What to Document
- Asana poller persists processed task state to SQLite
- Survives restarts and hot upgrades (no more re-dispatch of completed tasks)
- Part of v2.10.0 non-GitHub poller parity (all pollers now have this)

## Feature 2: CompleteTask Callback (PR #1720)

When Pilot creates a PR for an Asana task, the Asana task is automatically marked as completed.

### Code References
- `internal/adapters/asana/client.go:137-138` — `CompleteTask()` method
- `internal/adapters/asana/notifier.go:94,110-112` — Notifier wiring

### What to Document
- Automatic task completion on PR creation
- Non-blocking: if CompleteTask fails, execution still succeeds (notifier_test.go:248)

## Acceptance Criteria
- [ ] ProcessedStore explained in a "Reliability" or "Duplicate Prevention" section
- [ ] CompleteTask callback documented in "PR Integration" or similar section
- [ ] Mention this is part of v2.10.0 parity across all pollers