### PR TITLE
docs: Document retry-with-decomposition and smart word count gate in epic-decomposition.mdx

### DIFF
--- a/docs/content/features/epic-decomposition.mdx
+++ b/docs/content/features/epic-decomposition.mdx
@@ -346,6 +346,82 @@ Epic Decomposition:
 
 The 60% token increase is typically offset by reduced rework and higher success rates.
 
+## Retry with Decomposition
+
+When a task execution is killed by the OS (OOM or timeout), Pilot can automatically retry by first decomposing the task into subtasks.
+
+<Callout type="info" emoji="🔄">
+  Retry-with-decomposition is a safety net for tasks that slip through initial classification. Execution failure is strong evidence the task is too large.
+</Callout>
+
+### How It Works
+
+```
+Execution Killed → DecomposeForRetry → Subtask Issues → Sequential Retry
+```
+
+1. Pilot detects a `signal:killed` exit from Claude Code
+2. Calls `DecomposeForRetry()` — bypasses all gates (word count, complexity)
+3. Creates subtask issues from the decomposed plan
+4. Retries each subtask sequentially
+
+### Why Gates Are Bypassed
+
+The word count and complexity gates are skipped on retry because execution failure already proved the task is too large. Re-checking those gates would cause the same task to fail again.
+
+The `no-decompose` label is still respected — if present, retry-with-decomposition is skipped entirely.
+
+### Configuration
+
+```yaml
+# ~/.pilot/config.yaml
+retry:
+  decompose_on_kill: true  # Opt-in: retry killed executions via decomposition
+```
+
+This is opt-in. Without `decompose_on_kill: true`, killed tasks are not retried via decomposition.
+
+### Constraints
+
+- Only triggers on `signal:killed` failures (OOM/timeout)
+- Skipped if the issue has the `no-decompose` label
+- Requires structural split points in the task description — tasks with no decomposable structure are not retried
+
+## Smart Word Count Gate
+
+The word count gate in the decomposer is conditional on how complexity was determined.
+
+### Behavior
+
+| Classifier Mode | Word Count Gate |
+|-----------------|-----------------|
+| LLM classifier confirms COMPLEX | **Skipped** — trust the LLM |
+| Heuristic-only (no LLM) | **Enforced** — preserves GH-664/665 fix |
+
+### Why This Matters
+
+Without this logic, detailed issues with numbered steps (e.g., implementation plans) could exceed the word count threshold and be incorrectly decomposed in heuristic mode — even though they describe a single cohesive task.
+
+When the LLM classifier is attached and confirms the task is COMPLEX, the word count is irrelevant — the LLM already evaluated the task holistically. The gate is skipped.
+
+When running in heuristic-only mode (no LLM classifier configured), the word count gate is enforced to prevent over-decomposition of verbose but non-epic tasks.
+
+### Code Reference
+
+```go
+// internal/executor/decompose.go
+// Check description length — only enforce in heuristic mode (GH-1728).
+// When the LLM classifier is attached and confirmed COMPLEX, trust it over word count.
+wordCount := len(strings.Fields(task.Description))
+usedLLMClassifier := d.classifier != nil
+if !usedLLMClassifier && wordCount < d.config.MinDescriptionWords {
+    return &DecomposeResult{
+        Decomposed: false,
+        Reason:     "description too short for decomposition (heuristic mode)",
+    }
+}
+```
+
 ## Version History
 
 - **v0.20.2**: Initial epic decomposition with Claude Code planning
@@ -353,3 +429,6 @@ The 60% token increase is typically offset by reduced rework and higher success 
 - **v0.34.0**: Single-package scope detection to prevent conflicts
 - **v1.5.0**: Autopilot integration for sub-issue PR management
 - **v1.15.0**: Worktree isolation support for epic execution
+- **v2.10.0**:
+  - Retry-with-decomposition for killed executions (GH-1729)
+  - Smart word count gate: conditional on classifier type (GH-1728)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1734.

Closes #1734

## Changes

GitHub Issue #1734: docs: Document retry-with-decomposition and smart word count gate in epic-decomposition.mdx

## Task

Update `docs/content/features/epic-decomposition.mdx` with two new v2.10.0 features.

## Feature 1: Retry-with-Decomposition (GH-1729, PR #1732)

When a task execution fails with `signal:killed` (OOM/timeout), Pilot can now automatically retry by decomposing the task into subtasks first.

### Code References
- `internal/executor/decompose.go:158-162` — `DecomposeForRetry()` method
- `internal/executor/retry.go:66` — `DecomposeOnKill bool` config field
- `internal/executor/runner.go:1553-1560` — Trigger point in runner

### Config
```yaml
retry:
  decompose_on_kill: true  # Opt-in: retry failed tasks by decomposing them
```

### Behavior
- Bypasses ALL gates (word count, complexity) — execution failure already proved task is too large
- Still respects `no-decompose` label
- Only triggers on `signal:killed` failures
- Creates subtask issues from the decomposed plan, then retries each subtask

## Feature 2: Smart Decomposer Word Count Gate (GH-1728, PR #1731)

The word count gate in the decomposer is now conditional on the classifier type.

### Code References
- `internal/executor/decompose.go:115-133` — Conditional logic
- `internal/executor/decompose.go:435-451` — Explanation comments

### Behavior
- When LLM classifier confirms COMPLEX → word count gate is **skipped** (trust the LLM)
- Heuristic-only mode → word count gate is **enforced** (preserves GH-664/665 fix)
- This means detailed issues with numbered steps won't be incorrectly split when using heuristic mode, but genuinely complex tasks ARE split when the LLM agrees

## Changes Required

Add a new "v2.10.0" section to the version history. Add subsections explaining both features with config examples. Keep existing content intact.

## Acceptance Criteria
- [ ] Retry-with-decomposition documented with config example
- [ ] Smart word count gate explained
- [ ] Version history updated

## Planned Steps (execute all in sequence)

1. **Document retry-with-decomposition and smart word count gate in epic-decomposition.mdx** — Add a new `v2.10.0` section to the Version History at the bottom of `docs/content/features/epic-decomposition.mdx` with two entries. Then add two new documentation sections before the Version History:
**Section A: "Retry with Decomposition"** — Explain that when a task execution fails with `signal:killed` (OOM/timeout), Pilot can automatically retry by decomposing the task into subtasks (`DecomposeForRetry()`). Document the config (`retry.decompose_on_kill: true`), the opt-in nature, that it bypasses all gates (word count, complexity) since execution failure already proved the task is too large, that it still respects the `no-decompose` label, and that it only triggers on killed/timeout failures. Include a YAML config example and a flow diagram showing: `Execution Killed → DecomposeForRetry → Subtask Issues → Sequential Retry`.
**Section B: "Smart Word Count Gate"** — Explain the conditional word count gate logic: when the LLM classifier confirms COMPLEX, the word count gate is skipped (trust the LLM); when using heuristic-only mode, the word count gate is enforced (preserves GH-664/665 fix). This prevents detailed issues with numbered steps from being incorrectly split in heuristic mode while ensuring genuinely complex tasks are still decomposed when the LLM agrees.
**Version History entries**: Add `v2.10.0` with two bullet points: "Retry-with-decomposition for killed executions (GH-1729)" and "Smart word count gate: conditional on classifier type (GH-1728)".
Keep all existing content intact. Reference the code at `internal/executor/decompose.go` and `internal/executor/retry.go` for accuracy.
