### PR TITLE
docs: Update slack.mdx with improved planning error messages

### DIFF
--- a/docs/content/integrations/slack.mdx
+++ b/docs/content/integrations/slack.mdx
@@ -122,6 +122,25 @@ Each approval message includes context (PR URL, error details, timeout countdown
 
 Approval webhooks use HMAC-SHA256 signature verification with a 5-minute timestamp window to prevent replay attacks.
 
+## Planning Error Messages
+
+When using the `/plan` command, Pilot shows specific error messages based on the failure type:
+
+| Scenario | Message | Description |
+|----------|---------|-------------|
+| Timeout | ⏱ Planning timed out. Try a simpler request. | Planning exceeded the `planning_timeout` duration |
+| API/executor error | ❌ Planning failed: `<error>` | The executor returned an error during planning |
+| Empty result (error) | ❌ Planning error: `<error>` | Planning completed but produced an error |
+| Empty result (timeout) | ⏱ Planning timed out. Try a simpler request. | Planning finished without output due to timeout |
+| Empty result (success) | 🤷 The task may be too simple for planning. | No plan generated — try executing directly |
+
+The planning timeout is controlled by the `planning_timeout` field in the executor config (default: `2m`).
+
+```yaml
+executor:
+  planning_timeout: 3m  # increase for complex tasks
+```
+
 ## Daily Briefs
 
 Pilot can send daily or weekly summary digests to Slack channels.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1740.

Closes #1740

## Changes

GitHub Issue #1740: docs: Update slack.mdx with improved planning error messages

## Task

Update `docs/content/integrations/slack.mdx` with planning error message improvements from v2.10.0.

## Context (PR #1692)

Slack adapter now shows differentiated error messages for planning failures, matching Telegram adapter parity.

### Code References
- `internal/adapters/slack/handler.go:623-627` — Planning timeout with configurable duration
- `internal/adapters/slack/handler.go:646+` — Differentiated error messages

### What to Document
- Planning failures now show specific error type (timeout, API error, empty result)
- Uses configurable `planning_timeout` from executor config (default 2m)
- Brief addition — one paragraph or bullet list in the Slack features section

## Acceptance Criteria
- [ ] Planning error messages documented
- [ ] Reference to `planning_timeout` config