### PR TITLE
docs: Update telegram.mdx with improved planning error messages

### DIFF
--- a/docs/content/integrations/telegram.mdx
+++ b/docs/content/integrations/telegram.mdx
@@ -135,6 +135,13 @@ Pilot will:
 2. Draft an implementation plan
 3. Offer Execute/Cancel buttons to proceed
 
+If planning fails, Pilot shows a specific error message depending on the failure type:
+- **Timeout** — planning exceeded the configured `planning_timeout` duration
+- **API error** — the upstream LLM call failed
+- **Empty result** — planning completed but produced no output
+
+The timeout is controlled by the executor's `planning_timeout` setting.
+
 ### Chat Mode
 
 Triggered by conversational messages:
@@ -221,7 +228,7 @@ Switch between configured projects:
 /project           # Show current project
 ```
 
-Each chat maintains its own active project.
+Each chat maintains its own active project. When you submit a task, it is always routed to the currently active project — use `/switch` to change context before submitting.
 
 ## Task Confirmation
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1739.

Closes #1739

## Changes

GitHub Issue #1739: docs: Update telegram.mdx with improved planning error messages

## Task

Update `docs/content/integrations/telegram.mdx` with two improvements from v2.10.0.

## Change 1: Improved Planning Error Messages (PR #1691)

Telegram adapter now shows differentiated error messages for planning failures instead of a generic error.

### Code References
- `internal/adapters/telegram/handler.go:716-720` — Planning timeout with configurable duration
- `internal/adapters/telegram/handler.go:731+` — Differentiated error messages

### What to Document
- Planning failures now show specific error type (timeout, API error, empty result)
- Uses configurable `planning_timeout` from executor config

## Change 2: Active Project Fix (PR #1693)

Telegram now correctly respects the active project context when sending tasks.

### What to Document
- Brief mention that multi-project switching works correctly in task submission
- Previously active project was ignored; now the selected project context is used

## Acceptance Criteria
- [ ] Planning error messages documented (can be brief — one paragraph or bullet list)
- [ ] Active project behavior mentioned in multi-project section if not already there