### PR TITLE
docs: Update index.mdx feature count from 156 to current

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -9,7 +9,7 @@
 
 **AI that ships your tickets while you focus on architecture.**
 
-Pilot is an autonomous development pipeline with **156 features** production-ready. It picks up tickets from GitHub Issues, GitLab Issues, Linear, Jira, or Asana — plans the implementation using your codebase context, writes code with Claude Code, runs quality gates, and opens a pull request. You review and merge.
+Pilot is an autonomous development pipeline with **190+ features** production-ready. It picks up tickets from GitHub Issues, GitLab Issues, Linear, Jira, or Asana — plans the implementation using your codebase context, writes code with Claude Code, runs quality gates, and opens a pull request. You review and merge.
 
 {/* ILLUSTRATION: Hero — Ticket → Pilot → PR flow diagram */}
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1738.

Closes #1738

## Changes

GitHub Issue #1738: docs: Update index.mdx feature count from 156 to current

## Task

Update `docs/content/index.mdx` — the hero page currently states "156 features" which is outdated.

## What to Change

1. Update the feature count. Count the actual features from the codebase/changelog or use the latest verified count.
2. Optionally add a version badge showing v2.10.0

## Code Reference
- `docs/content/index.mdx` line ~12 — "156 features production-ready"
- The CLAUDE.md says 161 features at v1.40.1, so v2.10.0 should be higher

## Acceptance Criteria
- [ ] Feature count updated to accurate number
- [ ] No other content changes needed