### PR TITLE
docs: Add OnPRCreated callback and ProcessedStore to linear.mdx

### DIFF
--- a/docs/content/integrations/linear.mdx
+++ b/docs/content/integrations/linear.mdx
@@ -253,6 +253,22 @@ workspaces:
 
 If only one Pilot project is mapped, all issues from that workspace use it.
 
+## Autopilot Integration (v2.10.0)
+
+When Pilot creates a PR from a Linear issue, the autopilot controller automatically monitors CI status and can auto-merge the PR — the same pipeline that GitHub issues get.
+
+This is powered by the `OnPRCreated` callback on the Linear poller. After a successful execution produces a PR, the callback fires and hands off to autopilot for CI monitoring, status checks, and optional auto-merge. The callback only fires on successful execution — failed tasks do not trigger it.
+
+<Callout type="info">
+Previously, autopilot CI monitoring and auto-merge were GitHub-only. As of v2.10.0, Linear tasks get the full autopilot pipeline automatically with no extra configuration.
+</Callout>
+
+## Processed Issue Persistence (v2.10.0)
+
+The Linear poller uses a `ProcessedStore` to persist which issues have already been handled. This prevents re-dispatching issues after a restart or hot upgrade.
+
+The store is backed by SQLite (the same memory backend used by the rest of Pilot) and is enabled automatically — no configuration required.
+
 ### Resolution Precedence
 
 When an issue arrives, Pilot resolves the target project in this order:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1737.

Closes #1737

## Changes

GitHub Issue #1737: docs: Add OnPRCreated callback and ProcessedStore to linear.mdx

## Task

Update `docs/content/integrations/linear.mdx` with v2.10.0 features.

## Feature 1: OnPRCreated Callback (PR #1706)

Linear adapter now wires PR creation events to the autopilot controller for CI monitoring and auto-merge.

### Code References
- `internal/adapters/linear/poller.go:53-54` — `OnPRCreated` field
- `internal/adapters/linear/poller.go:74-78` — `WithOnPRCreated()` option
- `internal/adapters/linear/poller.go:359-360` — Fires after successful execution

### What to Document
- When Pilot creates a PR from a Linear issue, autopilot now monitors CI and can auto-merge
- Previously this was GitHub-only; Linear tasks now get the full autopilot pipeline
- Callback fires only on successful execution (not on failure)

## Feature 2: ProcessedStore Parity

Linear poller now has ProcessedStore for persistence across restarts.

### Code References
- `internal/adapters/linear/poller.go:25-27` — `ProcessedStore` interface
- `internal/adapters/linear/poller.go:89-93` — `WithProcessedStore()` option

### What to Document
- Prevents re-dispatch of processed Linear issues after restart/hot upgrade
- Part of v2.10.0 non-GitHub poller parity

Note: `linear_project_id` is already documented (lines 215-235). No changes needed there.

## Acceptance Criteria
- [ ] OnPRCreated callback and autopilot integration documented
- [ ] ProcessedStore mentioned for reliability
- [ ] Reference to v2.10.0 parity