### PR TITLE
docs: Add ProcessedStore and OnPRCreated parity to jira.mdx

### DIFF
--- a/docs/content/integrations/jira.mdx
+++ b/docs/content/integrations/jira.mdx
@@ -122,6 +122,26 @@ Jira issues are converted to Pilot tasks with the following mapping:
 | Labels | Labels | Filtered (excludes `pilot` and priority labels) |
 | Project key | ProjectKey | Direct |
 
+## Reliability Features (v2.10.0)
+
+### ProcessedStore — Duplicate Prevention
+
+The Jira poller tracks which issues have been processed using a persistent store backed by SQLite. This prevents duplicate task dispatch across restarts, hot upgrades, and crash recovery.
+
+On startup the poller loads previously processed issue keys. After successful execution an issue is marked as processed; if execution fails, the mark is removed so the issue is retried on the next poll cycle.
+
+No additional configuration is required — ProcessedStore is wired automatically when using the default Pilot setup.
+
+### Autopilot Pipeline via OnPRCreated
+
+Starting in v2.10.0, Jira-sourced tasks have full autopilot parity with GitHub issues. When Pilot creates a PR for a Jira issue, the `OnPRCreated` callback wires it into the autopilot controller, enabling:
+
+- **CI monitoring** — Pilot watches the PR's CI status and posts updates back to the Jira issue
+- **Auto-merge** — PRs that pass all quality gates are merged automatically (when enabled)
+- **Feedback loop** — CI failures trigger automatic fix attempts
+
+This brings Jira to the same level of automation previously available only for GitHub-sourced tasks.
+
 ## Status Transitions
 
 Pilot updates Jira issue status as it works:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1736.

Closes #1736

## Changes

GitHub Issue #1736: docs: Add ProcessedStore and OnPRCreated parity to jira.mdx

## Task

Update `docs/content/integrations/jira.mdx` with v2.10.0 reliability features.

## Feature 1: ProcessedStore (PR #1709)

Jira poller now tracks which issues have been processed across restarts.

### Code References
- `internal/adapters/jira/poller.go:33-35` — `ProcessedStore` interface
- `internal/adapters/jira/poller.go:81-85` — `WithProcessedStore()` option
- `internal/adapters/jira/poller.go:121-122` — Load on startup
- `internal/adapters/jira/poller.go:356-357` — Mark processed
- `internal/adapters/jira/poller.go:391-392` — Unmark on failure

## Feature 2: OnPRCreated Callback Parity

Jira issues now wire into the autopilot controller via OnPRCreated callback, enabling CI monitoring and auto-merge for Jira-sourced tasks (previously GitHub-only).

### What to Document
- ProcessedStore prevents duplicate dispatch across restarts/hot upgrades
- Jira tasks now get full autopilot pipeline (CI monitoring, auto-merge) via OnPRCreated
- Part of v2.10.0 non-GitHub poller parity

## Acceptance Criteria
- [ ] ProcessedStore documented
- [ ] OnPRCreated/autopilot parity mentioned
- [ ] Reference to v2.10.0 parity across all pollers