### PR TITLE
fix(telegram): Wire memory store to Telegram HandlerConfig

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1538,6 +1538,7 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 			Transcription: cfg.Adapters.Telegram.Transcription,
 			RateLimit:     cfg.Adapters.Telegram.RateLimit,
 			LLMClassifier: cfg.Adapters.Telegram.LLMClassifier,
+			Store:         store,
 		}
 		// GH-634: Wire team member resolver if available (avoid nil interface trap)
 		if teamAdapter != nil {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1753.

Closes #1753

## Changes

GitHub Issue #1753: fix(telegram): Wire memory store to Telegram HandlerConfig

## Problem

Telegram bot commands `/queue`, `/brief`, `/budget`, `/history` all return "not available (no memory store)" because the `Store` field is never set in the `tgConfig` struct literal.

## Root Cause

`cmd/pilot/main.go:1533-1541` — `tgConfig` is built without `Store: store`, even though:
- `store` is initialized at line ~1380 (`memory.NewStore(cfg.Memory.Path)`)
- `HandlerConfig.Store` field exists (`internal/adapters/telegram/handler.go:82`)
- `NewHandler` correctly passes `config.Store` to `NewCommandHandler` at line 131
- All command handlers properly nil-check `c.store` and show user-friendly errors

The wiring is simply missing.

## Fix

In `cmd/pilot/main.go`, add `Store: store` to the `tgConfig` struct at line ~1540:

```go
tgConfig := &telegram.HandlerConfig{
    BotToken:      cfg.Adapters.Telegram.BotToken,
    ProjectPath:   projectPath,
    Projects:      config.NewProjectSource(cfg),
    AllowedIDs:    allowedIDs,
    Transcription: cfg.Adapters.Telegram.Transcription,
    RateLimit:     cfg.Adapters.Telegram.RateLimit,
    LLMClassifier: cfg.Adapters.Telegram.LLMClassifier,
    Store:         store,  // ← ADD THIS
}
```

## Affected Commands

| Command | Current | After Fix |
|---------|---------|-----------|
| `/queue` | "Queue not available (no memory store)" | Shows task queue |
| `/history` | "History not available (no memory store)" | Shows execution history |
| `/budget` | "Budget not available (no memory store)" | Shows token usage & costs |
| `/brief` | "Brief not available (no memory store)" | Generates daily summary |

## Verification

1. `make build` — compiles
2. `make test` — passes
3. Start with `--telegram`, send `/queue` — should show queue (possibly empty, not error)
4. Send `/budget` — should show costs, not "no memory store"

## Scope

One-line change in `cmd/pilot/main.go`. No new tests needed — existing nil-check paths already tested.