### PR TITLE
refactor(telegram): Implement TelegramMessenger for comms.Messenger

### DIFF
--- a/internal/adapters/telegram/messenger.go
+++ b/internal/adapters/telegram/messenger.go
@@ -1,0 +1,192 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/alekspetrov/pilot/internal/executor"
+)
+
+// TelegramMessenger implements comms.Messenger interface for Telegram
+type TelegramMessenger struct {
+	client         *Client
+	plainTextMode  bool
+}
+
+// NewTelegramMessenger creates a new Telegram messenger
+func NewTelegramMessenger(client *Client, plainTextMode bool) *TelegramMessenger {
+	return &TelegramMessenger{
+		client:        client,
+		plainTextMode: plainTextMode,
+	}
+}
+
+// getParseMode returns the appropriate parse mode based on plainTextMode flag
+func (tm *TelegramMessenger) getParseMode() string {
+	if tm.plainTextMode {
+		return ""
+	}
+	return "MarkdownV2"
+}
+
+// SendText sends a plain text message to a chat
+func (tm *TelegramMessenger) SendText(chatID string, text string) (string, error) {
+	ctx := context.Background()
+	resp, err := tm.client.SendMessage(ctx, chatID, text, tm.getParseMode())
+	if err != nil {
+		return "", fmt.Errorf("failed to send text message: %w", err)
+	}
+
+	if resp == nil || resp.Result == nil {
+		return "", fmt.Errorf("empty response from send message")
+	}
+
+	// Convert message ID to string reference
+	messageRef := strconv.FormatInt(resp.Result.MessageID, 10)
+	return messageRef, nil
+}
+
+// SendConfirmation sends a confirmation message with execute/cancel buttons
+func (tm *TelegramMessenger) SendConfirmation(chatID string, taskID string, description string) (string, error) {
+	ctx := context.Background()
+	text := FormatTaskConfirmation(taskID, description, "")
+
+	keyboard := [][]InlineKeyboardButton{
+		{
+			InlineKeyboardButton{
+				Text:         "✅ Execute",
+				CallbackData: "execute:" + taskID,
+			},
+			InlineKeyboardButton{
+				Text:         "❌ Cancel",
+				CallbackData: "cancel:" + taskID,
+			},
+		},
+	}
+
+	resp, err := tm.client.SendMessageWithKeyboard(ctx, chatID, text, tm.getParseMode(), keyboard)
+	if err != nil {
+		return "", fmt.Errorf("failed to send confirmation message: %w", err)
+	}
+
+	if resp == nil || resp.Result == nil {
+		return "", fmt.Errorf("empty response from send message with keyboard")
+	}
+
+	// Convert message ID to string reference
+	messageRef := strconv.FormatInt(resp.Result.MessageID, 10)
+	return messageRef, nil
+}
+
+// SendProgress sends or updates a progress message
+func (tm *TelegramMessenger) SendProgress(chatID string, taskID string, phase string, progress int, message string, messageRef *string) (string, error) {
+	ctx := context.Background()
+	text := FormatProgressUpdate(taskID, phase, progress, message)
+
+	// If messageRef exists, try to edit the message
+	if messageRef != nil && *messageRef != "" {
+		messageID, err := strconv.ParseInt(*messageRef, 10, 64)
+		if err != nil {
+			// If we can't parse the message ID, send a new message instead
+			resp, err := tm.client.SendMessage(ctx, chatID, text, tm.getParseMode())
+			if err != nil {
+				return "", fmt.Errorf("failed to send progress message: %w", err)
+			}
+			if resp == nil || resp.Result == nil {
+				return "", fmt.Errorf("empty response from send message")
+			}
+			newRef := strconv.FormatInt(resp.Result.MessageID, 10)
+			return newRef, nil
+		}
+
+		// Try to edit the existing message
+		err = tm.client.EditMessage(ctx, chatID, messageID, text, tm.getParseMode())
+		if err != nil {
+			// If edit fails, send a new message instead
+			resp, err := tm.client.SendMessage(ctx, chatID, text, tm.getParseMode())
+			if err != nil {
+				return "", fmt.Errorf("failed to send progress message after edit failure: %w", err)
+			}
+			if resp == nil || resp.Result == nil {
+				return "", fmt.Errorf("empty response from send message")
+			}
+			newRef := strconv.FormatInt(resp.Result.MessageID, 10)
+			return newRef, nil
+		}
+
+		return *messageRef, nil
+	}
+
+	// Send a new message if no reference provided
+	resp, err := tm.client.SendMessage(ctx, chatID, text, tm.getParseMode())
+	if err != nil {
+		return "", fmt.Errorf("failed to send progress message: %w", err)
+	}
+
+	if resp == nil || resp.Result == nil {
+		return "", fmt.Errorf("empty response from send message")
+	}
+
+	newRef := strconv.FormatInt(resp.Result.MessageID, 10)
+	return newRef, nil
+}
+
+// SendResult sends a task result message
+func (tm *TelegramMessenger) SendResult(chatID string, result *executor.ExecutionResult) (string, error) {
+	ctx := context.Background()
+	text := FormatTaskResult(result)
+
+	resp, err := tm.client.SendMessage(ctx, chatID, text, tm.getParseMode())
+	if err != nil {
+		return "", fmt.Errorf("failed to send result message: %w", err)
+	}
+
+	if resp == nil || resp.Result == nil {
+		return "", fmt.Errorf("empty response from send message")
+	}
+
+	// Convert message ID to string reference
+	messageRef := strconv.FormatInt(resp.Result.MessageID, 10)
+	return messageRef, nil
+}
+
+// SendChunked splits large messages and sends them sequentially
+func (tm *TelegramMessenger) SendChunked(chatID string, text string) ([]string, error) {
+	ctx := context.Background()
+	maxLen := tm.MaxMessageLength()
+	chunks := chunkContent(text, maxLen)
+
+	var messageRefs []string
+	for _, chunk := range chunks {
+		resp, err := tm.client.SendMessage(ctx, chatID, chunk, tm.getParseMode())
+		if err != nil {
+			return messageRefs, fmt.Errorf("failed to send chunked message: %w", err)
+		}
+
+		if resp == nil || resp.Result == nil {
+			return messageRefs, fmt.Errorf("empty response from send chunked message")
+		}
+
+		// Convert message ID to string reference
+		messageRef := strconv.FormatInt(resp.Result.MessageID, 10)
+		messageRefs = append(messageRefs, messageRef)
+	}
+
+	return messageRefs, nil
+}
+
+// AcknowledgeCallback acknowledges a callback query (e.g., button press)
+func (tm *TelegramMessenger) AcknowledgeCallback(callbackID string, text string) error {
+	ctx := context.Background()
+	err := tm.client.AnswerCallback(ctx, callbackID, text)
+	if err != nil {
+		return fmt.Errorf("failed to acknowledge callback: %w", err)
+	}
+	return nil
+}
+
+// MaxMessageLength returns the maximum message length for Telegram
+func (tm *TelegramMessenger) MaxMessageLength() int {
+	return 4000
+}

--- a/internal/adapters/telegram/messenger_test.go
+++ b/internal/adapters/telegram/messenger_test.go
@@ -1,0 +1,376 @@
+package telegram
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/executor"
+)
+
+func TestTelegramMessenger_NewTelegramMessenger(t *testing.T) {
+	client := NewClient("test-token")
+
+	tests := []struct {
+		name           string
+		plainTextMode  bool
+		expectedMode   string
+	}{
+		{
+			name:           "markdown mode",
+			plainTextMode:  false,
+			expectedMode:   "MarkdownV2",
+		},
+		{
+			name:           "plain text mode",
+			plainTextMode:  true,
+			expectedMode:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messenger := NewTelegramMessenger(client, tt.plainTextMode)
+			if messenger == nil {
+				t.Fatal("NewTelegramMessenger returned nil")
+			}
+			if messenger.getParseMode() != tt.expectedMode {
+				t.Errorf("getParseMode() = %q, want %q", messenger.getParseMode(), tt.expectedMode)
+			}
+		})
+	}
+}
+
+func TestTelegramMessenger_MaxMessageLength(t *testing.T) {
+	client := NewClient("test-token")
+	messenger := NewTelegramMessenger(client, false)
+
+	if messenger.MaxMessageLength() != 4000 {
+		t.Errorf("MaxMessageLength() = %d, want 4000", messenger.MaxMessageLength())
+	}
+}
+
+func TestTelegramMessenger_SendText(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"ok": true,
+			"result": {
+				"message_id": 12345,
+				"chat_id": 67890,
+				"date": 1234567890,
+				"text": "test message"
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL("test-token", server.URL)
+	messenger := NewTelegramMessenger(client, false)
+
+	messageRef, err := messenger.SendText("67890", "test message")
+	if err != nil {
+		t.Fatalf("SendText() error = %v", err)
+	}
+
+	if messageRef != "12345" {
+		t.Errorf("SendText() messageRef = %q, want %q", messageRef, "12345")
+	}
+}
+
+func TestTelegramMessenger_SendConfirmation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"ok": true,
+			"result": {
+				"message_id": 54321,
+				"chat_id": 67890
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL("test-token", server.URL)
+	messenger := NewTelegramMessenger(client, false)
+
+	messageRef, err := messenger.SendConfirmation("67890", "TASK-001", "Test task")
+	if err != nil {
+		t.Fatalf("SendConfirmation() error = %v", err)
+	}
+
+	if messageRef != "54321" {
+		t.Errorf("SendConfirmation() messageRef = %q, want %q", messageRef, "54321")
+	}
+}
+
+func TestTelegramMessenger_SendProgress(t *testing.T) {
+	t.Run("new message", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"ok": true,
+				"result": {
+					"message_id": 99999,
+					"chat_id": 67890
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := NewClientWithBaseURL("test-token", server.URL)
+		messenger := NewTelegramMessenger(client, false)
+
+		messageRef, err := messenger.SendProgress("67890", "TASK-001", "Implementing", 50, "Working...", nil)
+		if err != nil {
+			t.Fatalf("SendProgress() error = %v", err)
+		}
+
+		if messageRef != "99999" {
+			t.Errorf("SendProgress() messageRef = %q, want %q", messageRef, "99999")
+		}
+	})
+
+	t.Run("update existing message", func(t *testing.T) {
+		callCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"ok": true,
+				"result": {
+					"message_id": 88888,
+					"chat_id": 67890
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := NewClientWithBaseURL("test-token", server.URL)
+		messenger := NewTelegramMessenger(client, false)
+
+		existingRef := "88888"
+		messageRef, err := messenger.SendProgress("67890", "TASK-001", "Testing", 75, "Running tests...", &existingRef)
+		if err != nil {
+			t.Fatalf("SendProgress() error = %v", err)
+		}
+
+		if messageRef != "88888" {
+			t.Errorf("SendProgress() messageRef = %q, want %q", messageRef, "88888")
+		}
+	})
+}
+
+func TestTelegramMessenger_SendResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"ok": true,
+			"result": {
+				"message_id": 77777,
+				"chat_id": 67890
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL("test-token", server.URL)
+	messenger := NewTelegramMessenger(client, false)
+
+	result := &executor.ExecutionResult{
+		TaskID:   "TASK-001",
+		Success:  true,
+		Output:   "Task completed successfully",
+		Duration: 5 * time.Second,
+	}
+
+	messageRef, err := messenger.SendResult("67890", result)
+	if err != nil {
+		t.Fatalf("SendResult() error = %v", err)
+	}
+
+	if messageRef != "77777" {
+		t.Errorf("SendResult() messageRef = %q, want %q", messageRef, "77777")
+	}
+}
+
+func TestTelegramMessenger_SendChunked(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Return different message IDs for each call
+		messageID := 10000 + callCount
+		w.Write([]byte(fmt.Sprintf(`{
+			"ok": true,
+			"result": {
+				"message_id": %d,
+				"chat_id": 67890
+			}
+		}`, messageID)))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL("test-token", server.URL)
+	messenger := NewTelegramMessenger(client, false)
+
+	// Create a message longer than 4000 characters
+	longMessage := ""
+	for i := 0; i < 5; i++ {
+		longMessage += "This is a test message that is repeated to make it longer. " // ~55 chars
+	}
+	for len(longMessage) < 5000 {
+		longMessage += "x"
+	}
+
+	messageRefs, err := messenger.SendChunked("67890", longMessage)
+	if err != nil {
+		t.Fatalf("SendChunked() error = %v", err)
+	}
+
+	if len(messageRefs) < 2 {
+		t.Errorf("SendChunked() should have returned at least 2 message refs, got %d", len(messageRefs))
+	}
+}
+
+func TestTelegramMessenger_AcknowledgeCallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"ok": true
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL("test-token", server.URL)
+	messenger := NewTelegramMessenger(client, false)
+
+	err := messenger.AcknowledgeCallback("callback-id-123", "✅ Executing task...")
+	if err != nil {
+		t.Fatalf("AcknowledgeCallback() error = %v", err)
+	}
+}
+
+func TestTelegramMessenger_MessageIDConversion(t *testing.T) {
+	// Test that we properly convert between int64 message IDs and string references
+	tests := []struct {
+		name        string
+		messageID   int64
+		expectStr   string
+	}{
+		{
+			name:        "small ID",
+			messageID:   12345,
+			expectStr:   "12345",
+		},
+		{
+			name:        "large ID",
+			messageID:   9223372036854775807, // max int64
+			expectStr:   "9223372036854775807",
+		},
+		{
+			name:        "zero",
+			messageID:   0,
+			expectStr:   "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test conversion logic (same as used in SendText)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{
+					"ok": true,
+					"result": {
+						"message_id": ` + tt.expectStr + `,
+						"chat_id": 67890
+					}
+				}`))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL("test-token", server.URL)
+			messenger := NewTelegramMessenger(client, false)
+
+			messageRef, err := messenger.SendText("67890", "test")
+			if err != nil {
+				t.Fatalf("SendText() error = %v", err)
+			}
+
+			if messageRef != tt.expectStr {
+				t.Errorf("messageRef = %q, want %q", messageRef, tt.expectStr)
+			}
+		})
+	}
+}
+
+func TestTelegramMessenger_PlainTextMode(t *testing.T) {
+	t.Run("plaintext mode disabled sends MarkdownV2", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// In a real scenario, we'd parse the JSON body to verify parse_mode
+			// For now, we just verify the messenger was called
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"ok": true,
+				"result": {
+					"message_id": 11111,
+					"chat_id": 67890
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := NewClientWithBaseURL("test-token", server.URL)
+		messenger := NewTelegramMessenger(client, false)
+
+		// Verify the parse mode
+		if messenger.getParseMode() != "MarkdownV2" {
+			t.Errorf("plainTextMode=false: getParseMode() = %q, want MarkdownV2", messenger.getParseMode())
+		}
+
+		_, err := messenger.SendText("67890", "test")
+		if err != nil {
+			t.Fatalf("SendText() error = %v", err)
+		}
+	})
+
+	t.Run("plaintext mode enabled sends empty parse mode", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"ok": true,
+				"result": {
+					"message_id": 22222,
+					"chat_id": 67890
+				}
+			}`))
+		}))
+		defer server.Close()
+
+		client := NewClientWithBaseURL("test-token", server.URL)
+		messenger := NewTelegramMessenger(client, true)
+
+		// Verify the parse mode
+		if messenger.getParseMode() != "" {
+			t.Errorf("plainTextMode=true: getParseMode() = %q, want empty string", messenger.getParseMode())
+		}
+
+		_, err := messenger.SendText("67890", "test")
+		if err != nil {
+			t.Fatalf("SendText() error = %v", err)
+		}
+	})
+}

--- a/internal/comms/messenger.go
+++ b/internal/comms/messenger.go
@@ -1,0 +1,27 @@
+package comms
+
+import "github.com/alekspetrov/pilot/internal/executor"
+
+// Messenger defines the interface for sending messages through various communication channels.
+type Messenger interface {
+	// SendText sends a plain text message
+	SendText(chatID string, text string) (string, error)
+
+	// SendConfirmation sends a confirmation message with execute/cancel buttons
+	SendConfirmation(chatID string, taskID string, description string) (string, error)
+
+	// SendProgress sends or updates a progress message
+	SendProgress(chatID string, taskID string, phase string, progress int, message string, messageRef *string) (string, error)
+
+	// SendResult sends a task result message
+	SendResult(chatID string, result *executor.ExecutionResult) (string, error)
+
+	// SendChunked splits and sends a large message in chunks
+	SendChunked(chatID string, text string) ([]string, error)
+
+	// AcknowledgeCallback acknowledges a callback query (e.g., button press)
+	AcknowledgeCallback(callbackID string, text string) error
+
+	// MaxMessageLength returns the maximum length of a single message for this channel
+	MaxMessageLength() int
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1758.

Closes #1758

## Changes

GitHub Issue #1758: refactor(telegram): Implement TelegramMessenger for comms.Messenger

## Step 4 of 10: Unified Communication Module

## Task

Create TelegramMessenger that implements `comms.Messenger` interface, wrapping existing Telegram client and formatter.

## Changes

1. Create `internal/adapters/telegram/messenger.go` (~120 lines):
   - `TelegramMessenger` struct wrapping `*Client` and `plainTextMode` flag
   - `SendText` → `client.SendMessage` with appropriate parse mode
   - `SendConfirmation` → `client.SendMessageWithKeyboard` with inline execute/cancel buttons
   - `SendProgress` → `client.EditMessage` (update existing) or `client.SendMessage` (new)
   - `SendResult` → format with `FormatTaskResult` and send
   - `SendChunked` → split by `MaxMessageLength()` and send sequentially
   - `AcknowledgeCallback` → `client.AnswerCallbackQuery`
   - `MaxMessageLength() int` → return 4000

2. Add tests in `internal/adapters/telegram/messenger_test.go`

## Key Detail

- Telegram message IDs are int64, but `messageRef` is string — convert at boundary with `strconv.FormatInt`/`ParseInt`
- `plainTextMode` determines parse mode ("" vs "MarkdownV2")
- Reuse existing `formatter.go` functions for message formatting

## Verification

- `make build` compiles
- `make test` passes
- New messenger tests verify all Messenger methods

## Scope

No behavior change — messenger exists alongside current handler code. Wiring happens in Step 8.