### PR TITLE
refactor(comms): Define Messenger interface and shared helpers

### DIFF
--- a/internal/comms/types.go
+++ b/internal/comms/types.go
@@ -1,0 +1,66 @@
+// Package comms defines shared communication contracts for adapter implementations.
+package comms
+
+import (
+	"context"
+	"time"
+)
+
+// IncomingMessage is the platform-agnostic representation of an inbound user message.
+type IncomingMessage struct {
+	ContextID  string      // chatID / channelID
+	SenderID   string      // user ID (string; adapters convert int64)
+	Text       string      // normalized message text
+	ThreadID   string      // thread context (Slack threadTS, Telegram reply, etc.)
+	ImagePath  string      // downloaded image path (optional)
+	VoiceText  string      // transcribed voice text (optional)
+	IsCallback bool        // true when this is a button callback
+	CallbackID string      // platform callback ID
+	ActionID   string      // button action ID
+	RawEvent   interface{} // platform-specific escape hatch
+}
+
+// Messenger is the interface every chat adapter must implement for outbound messaging.
+type Messenger interface {
+	// SendText sends a plain text message to the given context (channel/chat).
+	SendText(ctx context.Context, contextID, text string) error
+
+	// SendConfirmation sends a task confirmation prompt with approve/reject buttons.
+	// Returns a messageRef that can be used to update the message later.
+	SendConfirmation(ctx context.Context, contextID, threadID, taskID, desc, project string) (messageRef string, err error)
+
+	// SendProgress updates an existing message (identified by messageRef) with progress info.
+	// Returns a new messageRef if the platform creates a new message.
+	SendProgress(ctx context.Context, contextID, messageRef, taskID, phase string, progress int, detail string) (newRef string, err error)
+
+	// SendResult sends the final task result (success or failure).
+	SendResult(ctx context.Context, contextID, threadID, taskID string, success bool, output, prURL string) error
+
+	// SendChunked sends long content split into platform-appropriate chunks.
+	SendChunked(ctx context.Context, contextID, threadID, content, prefix string) error
+
+	// AcknowledgeCallback responds to a button/callback interaction.
+	AcknowledgeCallback(ctx context.Context, callbackID string) error
+
+	// MaxMessageLength returns the platform's maximum single-message length.
+	MaxMessageLength() int
+}
+
+// PendingTask represents a task awaiting user confirmation.
+type PendingTask struct {
+	TaskID      string
+	Description string
+	ContextID   string // chatID or channelID
+	ThreadID    string // threadTS or empty
+	MessageRef  string // platform message ID for later updates
+	SenderID    string // user who requested the task (for RBAC)
+	CreatedAt   time.Time
+}
+
+// RunningTask represents a task currently being executed.
+type RunningTask struct {
+	TaskID    string
+	ContextID string
+	StartedAt time.Time
+	Cancel    context.CancelFunc
+}

--- a/internal/comms/util.go
+++ b/internal/comms/util.go
@@ -1,0 +1,140 @@
+package comms
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// internalSignals lists patterns to strip from output before sending to users.
+var internalSignals = []string{
+	"EXIT_SIGNAL: true",
+	"EXIT_SIGNAL:true",
+	"LOOP COMPLETE",
+	"TASK MODE COMPLETE",
+	"NAVIGATOR_STATUS",
+	"━━━━━━━━━━",
+	"[EXIT_SIGNAL]",
+	"[NAV_COMPLETE]",
+	"[RESEARCH_DONE]",
+	"[IMPL_DONE]",
+}
+
+// CleanInternalSignals removes internal Navigator/Pilot signals from output text.
+func CleanInternalSignals(text string) string {
+	if text == "" {
+		return ""
+	}
+
+	lines := strings.Split(text, "\n")
+	var clean []string
+	skipBlock := false
+
+	for _, line := range lines {
+		if strings.Contains(line, "NAVIGATOR_STATUS") {
+			skipBlock = true
+			continue
+		}
+		if skipBlock {
+			if strings.HasPrefix(strings.TrimSpace(line), "━") && len(clean) > 0 {
+				skipBlock = false
+			}
+			continue
+		}
+
+		shouldSkip := false
+		for _, sig := range internalSignals {
+			if strings.Contains(line, sig) {
+				shouldSkip = true
+				break
+			}
+		}
+		if shouldSkip {
+			continue
+		}
+
+		// Skip leading blank lines
+		if len(clean) == 0 && strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		clean = append(clean, line)
+	}
+
+	// Trim trailing blank lines
+	for len(clean) > 0 && strings.TrimSpace(clean[len(clean)-1]) == "" {
+		clean = clean[:len(clean)-1]
+	}
+
+	return strings.Join(clean, "\n")
+}
+
+// ChunkContent splits text into chunks of at most maxLen characters,
+// preferring to break at newline boundaries.
+func ChunkContent(text string, maxLen int) []string {
+	if len(text) <= maxLen {
+		return []string{text}
+	}
+
+	var chunks []string
+	remaining := text
+
+	for len(remaining) > 0 {
+		if len(remaining) <= maxLen {
+			chunks = append(chunks, remaining)
+			break
+		}
+
+		breakPoint := maxLen
+		if idx := strings.LastIndex(remaining[:maxLen], "\n"); idx > maxLen/2 {
+			breakPoint = idx + 1
+		}
+
+		chunks = append(chunks, strings.TrimSpace(remaining[:breakPoint]))
+		remaining = strings.TrimSpace(remaining[breakPoint:])
+	}
+
+	return chunks
+}
+
+// TruncateText truncates text to maxLen characters, adding "..." if truncated.
+func TruncateText(text string, maxLen int) string {
+	if len(text) <= maxLen {
+		return text
+	}
+	if maxLen <= 3 {
+		return text[:maxLen]
+	}
+	return text[:maxLen-3] + "..."
+}
+
+// GenerateProgressBar returns a 10-segment text progress bar like "█████░░░░░".
+func GenerateProgressBar(progress int) string {
+	if progress < 0 {
+		progress = 0
+	}
+	if progress > 100 {
+		progress = 100
+	}
+	filled := progress / 10
+	empty := 10 - filled
+	return strings.Repeat("█", filled) + strings.Repeat("░", empty)
+}
+
+// FormatTimeAgo formats a time as a human-readable relative duration.
+func FormatTimeAgo(t time.Time) string {
+	d := time.Since(t)
+
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	case d < 7*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	default:
+		return t.Format("Jan 2")
+	}
+}

--- a/internal/comms/util_test.go
+++ b/internal/comms/util_test.go
@@ -1,0 +1,130 @@
+package comms
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCleanInternalSignals(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no signals", "hello world", "hello world"},
+		{"exit signal", "result\nEXIT_SIGNAL: true\ndone", "result\ndone"},
+		{"nav complete", "output\n[NAV_COMPLETE]\nfinal", "output\nfinal"},
+		{"navigator block", "before\nNAVIGATOR_STATUS\nPhase: IMPL\n━━━━━━━━━━\nafter", "before\nafter"},
+		{"leading blanks stripped", "\n\nhello", "hello"},
+		{"trailing blanks stripped", "hello\n\n", "hello"},
+		{"multiple signals", "[EXIT_SIGNAL]\n[IMPL_DONE]\nreal output", "real output"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CleanInternalSignals(tt.in)
+			if got != tt.want {
+				t.Errorf("CleanInternalSignals(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChunkContent(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		maxLen int
+		want   int // expected number of chunks
+	}{
+		{"short", "hello", 100, 1},
+		{"exact", "hello", 5, 1},
+		{"split", "hello world foo bar", 10, 2},
+		{"newline break", "line1\nline2\nline3", 12, 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunks := ChunkContent(tt.text, tt.maxLen)
+			if len(chunks) != tt.want {
+				t.Errorf("ChunkContent(%q, %d) returned %d chunks, want %d", tt.text, tt.maxLen, len(chunks), tt.want)
+			}
+			// Verify no chunk exceeds maxLen
+			for i, c := range chunks {
+				if len(c) > tt.maxLen {
+					t.Errorf("chunk[%d] length %d exceeds maxLen %d", i, len(c), tt.maxLen)
+				}
+			}
+		})
+	}
+}
+
+func TestTruncateText(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		maxLen int
+		want   string
+	}{
+		{"short", "hi", 10, "hi"},
+		{"exact", "hello", 5, "hello"},
+		{"truncated", "hello world", 8, "hello..."},
+		{"tiny max", "hello", 2, "he"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TruncateText(tt.text, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("TruncateText(%q, %d) = %q, want %q", tt.text, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateProgressBar(t *testing.T) {
+	tests := []struct {
+		progress int
+		want     string
+	}{
+		{0, "░░░░░░░░░░"},
+		{50, "█████░░░░░"},
+		{100, "██████████"},
+		{-10, "░░░░░░░░░░"},
+		{150, "██████████"},
+		{33, "███░░░░░░░"},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			got := GenerateProgressBar(tt.progress)
+			if got != tt.want {
+				t.Errorf("GenerateProgressBar(%d) = %q, want %q", tt.progress, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatTimeAgo(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name string
+		t    time.Time
+		want string
+	}{
+		{"just now", now.Add(-10 * time.Second), "just now"},
+		{"minutes", now.Add(-5 * time.Minute), "5m ago"},
+		{"hours", now.Add(-3 * time.Hour), "3h ago"},
+		{"days", now.Add(-2 * 24 * time.Hour), "2d ago"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatTimeAgo(tt.t)
+			if got != tt.want {
+				t.Errorf("FormatTimeAgo() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1757.

Closes #1757

## Changes

GitHub Issue #1757: refactor(comms): Define Messenger interface and shared helpers

## Step 3 of 10: Unified Communication Module

## Task

Define the core contracts for the comms module — Messenger interface, IncomingMessage, and shared utility functions.

## Changes

1. Create `internal/comms/types.go` (~80 lines):
   ```go
   type IncomingMessage struct {
       ContextID  string      // chatID / channelID
       SenderID   string      // user ID (string, adapters convert int64)
       Text       string      // normalized message text
       ThreadID   string      // thread context (Slack threadTS, etc.)
       ImagePath  string      // downloaded image path (optional)
       VoiceText  string      // transcribed voice text (optional)
       IsCallback bool        // button callback
       CallbackID string      // platform callback ID
       ActionID   string      // button action ID
       RawEvent   interface{} // platform-specific escape hatch
   }

   type Messenger interface {
       SendText(ctx context.Context, contextID, text string) error
       SendConfirmation(ctx context.Context, contextID, threadID, taskID, desc, project string) (messageRef string, err error)
       SendProgress(ctx context.Context, contextID, messageRef, taskID, phase string, progress int, detail string) (newRef string, err error)
       SendResult(ctx context.Context, contextID, threadID, taskID string, success bool, output, prURL string) error
       SendChunked(ctx context.Context, contextID, threadID, content, prefix string) error
       AcknowledgeCallback(ctx context.Context, callbackID string) error
       MaxMessageLength() int
   }

   type PendingTask struct { ... }
   type RunningTask struct { ... }
   ```

2. Create `internal/comms/util.go` (~100 lines):
   - `CleanInternalSignals(text string) string` — strip pilot-signal blocks
   - `ChunkContent(text string, maxLen int) []string` — split for platform limits
   - `TruncateText(text string, maxLen int) string`
   - `GenerateProgressBar(progress int) string` — identical in both adapters
   - `FormatTimeAgo(t time.Time) string`

## Verification

- `make build` compiles
- `make test` passes
- New package has unit tests for util functions

## Scope

Contracts only — no wiring yet. Adapters don't import this yet.