### PR TITLE
refactor(slack): Implement SlackMessenger for comms.Messenger

### DIFF
--- a/internal/adapters/slack/messenger.go
+++ b/internal/adapters/slack/messenger.go
@@ -1,0 +1,126 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+)
+
+// SlackMessenger implements comms.Messenger for Slack communication.
+type SlackMessenger struct {
+	client *Client
+}
+
+// NewSlackMessenger creates a new SlackMessenger wrapping the provided Slack client.
+func NewSlackMessenger(client *Client) *SlackMessenger {
+	return &SlackMessenger{
+		client: client,
+	}
+}
+
+// SendText sends a plain text message to the given channel.
+func (s *SlackMessenger) SendText(ctx context.Context, contextID, text string) error {
+	msg := &Message{
+		Channel: contextID,
+		Text:    text,
+	}
+
+	_, err := s.client.PostMessage(ctx, msg)
+	return err
+}
+
+// SendConfirmation sends a task confirmation prompt with approve/reject buttons.
+// Returns the message timestamp (messageRef) for later updates.
+func (s *SlackMessenger) SendConfirmation(ctx context.Context, contextID, threadID, taskID, desc, project string) (messageRef string, err error) {
+	blocks := BuildConfirmationBlocks(taskID, desc)
+
+	msg := &InteractiveMessage{
+		Channel: contextID,
+		Text:    fmt.Sprintf("Task: %s", taskID),
+		Blocks:  blocks,
+	}
+
+	resp, err := s.client.PostInteractiveMessage(ctx, msg)
+	if err != nil {
+		return "", err
+	}
+
+	return resp.TS, nil
+}
+
+// SendProgress updates an existing message with progress information.
+// If updating fails, posts a new message instead.
+func (s *SlackMessenger) SendProgress(ctx context.Context, contextID, messageRef, taskID, phase string, progress int, detail string) (newRef string, err error) {
+	blocks := BuildProgressBlocks(taskID, phase, progress, detail)
+
+	// Try to update the existing message
+	err = s.client.UpdateInteractiveMessage(ctx, contextID, messageRef, blocks, "")
+	if err == nil {
+		return messageRef, nil
+	}
+
+	// If update fails, post a new message
+	msg := &InteractiveMessage{
+		Channel: contextID,
+		Blocks:  blocks,
+	}
+
+	resp, err := s.client.PostInteractiveMessage(ctx, msg)
+	if err != nil {
+		return "", err
+	}
+
+	return resp.TS, nil
+}
+
+// SendResult sends the final task result with status and optional PR link.
+func (s *SlackMessenger) SendResult(ctx context.Context, contextID, threadID, taskID string, success bool, output, prURL string) error {
+	blocks := BuildResultBlocks(taskID, success, output, prURL)
+
+	msg := &InteractiveMessage{
+		Channel: contextID,
+		Blocks:  blocks,
+	}
+
+	_, err := s.client.PostInteractiveMessage(ctx, msg)
+	return err
+}
+
+// SendChunked sends long content split into platform-appropriate chunks.
+// Slack has a 3800 character limit for text content.
+func (s *SlackMessenger) SendChunked(ctx context.Context, contextID, threadID, content, prefix string) error {
+	chunks := ChunkContent(content, s.MaxMessageLength())
+
+	for i, chunk := range chunks {
+		var text string
+		if i == 0 && prefix != "" {
+			text = prefix + "\n\n" + chunk
+		} else {
+			text = chunk
+		}
+
+		msg := &Message{
+			Channel:  contextID,
+			Text:     text,
+			ThreadTS: threadID,
+		}
+
+		_, err := s.client.PostMessage(ctx, msg)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// AcknowledgeCallback responds to a button/callback interaction.
+// For Slack, this is a no-op as the HTTP response itself acknowledges the callback.
+func (s *SlackMessenger) AcknowledgeCallback(ctx context.Context, callbackID string) error {
+	return nil
+}
+
+// MaxMessageLength returns Slack's maximum single-message text length.
+// Slack's documented limit is 4000 chars, but we use 3800 to account for Block Kit markup.
+func (s *SlackMessenger) MaxMessageLength() int {
+	return 3800
+}

--- a/internal/adapters/slack/messenger_test.go
+++ b/internal/adapters/slack/messenger_test.go
@@ -1,0 +1,276 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+// TestNewSlackMessenger verifies messenger creation.
+func TestNewSlackMessenger(t *testing.T) {
+	client := NewClient(testutil.FakeSlackBotToken)
+	messenger := NewSlackMessenger(client)
+
+	if messenger == nil {
+		t.Fatal("NewSlackMessenger returned nil")
+	}
+	if messenger.client != client {
+		t.Error("messenger.client not set correctly")
+	}
+}
+
+// TestSendText verifies plain text message sending.
+func TestSendText(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat.postMessage" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var msg Message
+		if err := json.Unmarshal(body, &msg); err != nil {
+			t.Fatalf("failed to unmarshal request: %v", err)
+		}
+
+		if msg.Channel != "C123456" {
+			t.Errorf("channel = %q, want C123456", msg.Channel)
+		}
+		if msg.Text != "Hello world" {
+			t.Errorf("text = %q, want 'Hello world'", msg.Text)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok": true,
+			"ts": "1234567890.000001",
+		})
+	}))
+	defer server.Close()
+
+	client := &Client{
+		botToken: testutil.FakeSlackBotToken,
+		httpClient: &http.Client{},
+	}
+	client.httpClient.Transport = newTestTransport(server.URL)
+
+	messenger := NewSlackMessenger(client)
+	ctx := context.Background()
+
+	err := messenger.SendText(ctx, "C123456", "Hello world")
+	if err != nil {
+		t.Fatalf("SendText failed: %v", err)
+	}
+}
+
+// TestSendConfirmation verifies task confirmation message with buttons.
+func TestSendConfirmation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat.postMessage" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var msg InteractiveMessage
+		if err := json.Unmarshal(body, &msg); err != nil {
+			t.Fatalf("failed to unmarshal request: %v", err)
+		}
+
+		if msg.Channel != "C123456" {
+			t.Errorf("channel = %q, want C123456", msg.Channel)
+		}
+		if len(msg.Blocks) != 2 {
+			t.Errorf("blocks count = %d, want 2", len(msg.Blocks))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok": true,
+			"ts": "1234567890.000002",
+		})
+	}))
+	defer server.Close()
+
+	client := &Client{
+		botToken: testutil.FakeSlackBotToken,
+		httpClient: &http.Client{},
+	}
+	client.httpClient.Transport = newTestTransport(server.URL)
+
+	messenger := NewSlackMessenger(client)
+	ctx := context.Background()
+
+	messageRef, err := messenger.SendConfirmation(ctx, "C123456", "thread-ts", "TASK-001", "Review PR changes", "myproject")
+	if err != nil {
+		t.Fatalf("SendConfirmation failed: %v", err)
+	}
+	if messageRef != "1234567890.000002" {
+		t.Errorf("messageRef = %q, want 1234567890.000002", messageRef)
+	}
+}
+
+// TestSendProgress verifies progress update message.
+func TestSendProgress(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		// First call is update (which fails), second call is post (which succeeds)
+		if callCount == 1 {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok":    false,
+				"error": "message_not_found",
+			})
+		} else {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"ts": "1234567890.000003",
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := &Client{
+		botToken: testutil.FakeSlackBotToken,
+		httpClient: &http.Client{},
+	}
+	client.httpClient.Transport = newTestTransport(server.URL)
+
+	messenger := NewSlackMessenger(client)
+	ctx := context.Background()
+
+	newRef, err := messenger.SendProgress(ctx, "C123456", "1234567890.000002", "TASK-001", "planning", 50, "Analyzing requirements")
+	if err != nil {
+		t.Fatalf("SendProgress failed: %v", err)
+	}
+	if newRef != "1234567890.000003" {
+		t.Errorf("newRef = %q, want 1234567890.000003", newRef)
+	}
+}
+
+// TestSendResult verifies final result message.
+func TestSendResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var msg InteractiveMessage
+		if err := json.Unmarshal(body, &msg); err != nil {
+			t.Fatalf("failed to unmarshal request: %v", err)
+		}
+
+		if msg.Channel != "C123456" {
+			t.Errorf("channel = %q, want C123456", msg.Channel)
+		}
+		if len(msg.Blocks) == 0 {
+			t.Error("blocks should not be empty")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok": true,
+			"ts": "1234567890.000004",
+		})
+	}))
+	defer server.Close()
+
+	client := &Client{
+		botToken: testutil.FakeSlackBotToken,
+		httpClient: &http.Client{},
+	}
+	client.httpClient.Transport = newTestTransport(server.URL)
+
+	messenger := NewSlackMessenger(client)
+	ctx := context.Background()
+
+	err := messenger.SendResult(ctx, "C123456", "thread-ts", "TASK-001", true, "Task completed successfully", "https://github.com/pr/1")
+	if err != nil {
+		t.Fatalf("SendResult failed: %v", err)
+	}
+}
+
+// TestSendChunked verifies content chunking for long messages.
+func TestSendChunked(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok": true,
+			"ts": "1234567890.000005",
+		})
+	}))
+	defer server.Close()
+
+	client := &Client{
+		botToken: testutil.FakeSlackBotToken,
+		httpClient: &http.Client{},
+	}
+	client.httpClient.Transport = newTestTransport(server.URL)
+
+	messenger := NewSlackMessenger(client)
+	ctx := context.Background()
+
+	// Create content longer than MaxMessageLength
+	longContent := ""
+	for i := 0; i < 5000; i++ {
+		longContent += "x"
+	}
+
+	err := messenger.SendChunked(ctx, "C123456", "thread-ts", longContent, "Output:")
+	if err != nil {
+		t.Fatalf("SendChunked failed: %v", err)
+	}
+
+	// Should have made at least 2 calls due to chunking
+	if callCount < 2 {
+		t.Errorf("expected at least 2 API calls, got %d", callCount)
+	}
+}
+
+// TestAcknowledgeCallback verifies callback acknowledgment (should be no-op).
+func TestAcknowledgeCallback(t *testing.T) {
+	client := NewClient(testutil.FakeSlackBotToken)
+	messenger := NewSlackMessenger(client)
+	ctx := context.Background()
+
+	err := messenger.AcknowledgeCallback(ctx, "callback-123")
+	if err != nil {
+		t.Fatalf("AcknowledgeCallback failed: %v", err)
+	}
+}
+
+// TestMaxMessageLength verifies the maximum message length.
+func TestMaxMessageLength(t *testing.T) {
+	client := NewClient(testutil.FakeSlackBotToken)
+	messenger := NewSlackMessenger(client)
+
+	maxLen := messenger.MaxMessageLength()
+	if maxLen != 3800 {
+		t.Errorf("MaxMessageLength = %d, want 3800", maxLen)
+	}
+}
+
+// newTestTransport creates an HTTP transport that redirects requests to the test server.
+func newTestTransport(serverURL string) http.RoundTripper {
+	return &testTransport{serverURL: serverURL}
+}
+
+type testTransport struct {
+	serverURL string
+}
+
+func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace the host with the test server host
+	req.URL.Scheme = "http"
+	req.URL.Host = "localhost"
+	client := &http.Client{}
+
+	// Create a new request with the test server URL
+	newReq, _ := http.NewRequest(req.Method, t.serverURL+req.URL.Path, req.Body)
+	newReq.Header = req.Header
+
+	return client.Do(newReq)
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1759.

Closes #1759

## Changes

GitHub Issue #1759: refactor(slack): Implement SlackMessenger for comms.Messenger

## Step 5 of 10: Unified Communication Module

## Task

Create SlackMessenger that implements `comms.Messenger` interface, wrapping existing Slack client and Block Kit formatter.

## Changes

1. Create `internal/adapters/slack/messenger.go` (~120 lines):
   - `SlackMessenger` struct wrapping `*Client`
   - `SendText` → `client.PostMessage` with channel
   - `SendConfirmation` → `client.PostInteractiveMessage` with Block Kit action buttons
   - `SendProgress` → `client.UpdateMessage` (existing) or `client.PostMessage` (new)
   - `SendResult` → format with Block Kit attachment and send
   - `SendChunked` → split by `MaxMessageLength()` with thread support
   - `AcknowledgeCallback` → no-op (Slack handles via HTTP response)
   - `MaxMessageLength() int` → return 3800

2. Add tests in `internal/adapters/slack/messenger_test.go`

## Key Detail

- Slack uses timestamp strings as message refs — no conversion needed
- Thread support via `threadTS` field on messages
- Block Kit formatting via existing `formatter.go` functions

## Verification

- `make build` compiles
- `make test` passes
- New messenger tests verify all Messenger methods

## Scope

No behavior change — messenger exists alongside current handler code. Wiring happens in Step 9.