### PR TITLE
refactor(comms): Extract shared Handler with HandleMessage, intent dispatch, and task lifecycle

### DIFF
--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -1,0 +1,732 @@
+// Package comms provides shared communication handler logic for adapter implementations.
+package comms
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/executor"
+	"github.com/alekspetrov/pilot/internal/intent"
+	"github.com/alekspetrov/pilot/internal/logging"
+	"github.com/alekspetrov/pilot/internal/memory"
+)
+
+// MemberResolver resolves a platform user to a team member ID for RBAC.
+// Each adapter provides a concrete implementation.
+type MemberResolver interface {
+	// ResolveIdentity maps a sender ID to a team member ID.
+	// Returns ("", nil) when no match is found (= skip RBAC).
+	ResolveIdentity(senderID string) (string, error)
+}
+
+// HandlerConfig holds configuration for creating a shared Handler.
+type HandlerConfig struct {
+	Messenger      Messenger
+	Runner         *executor.Runner
+	Projects       ProjectSource
+	ProjectPath    string
+	RateLimit      *RateLimitConfig
+	LLMClassifier  intent.Classifier
+	ConvStore      *intent.ConversationStore
+	MemberResolver MemberResolver
+	Store          *memory.Store
+	// TaskIDPrefix is the adapter-specific prefix for task IDs (e.g., "TG", "SLACK").
+	TaskIDPrefix string
+	Log          *slog.Logger
+}
+
+// Handler implements platform-agnostic message handling with intent dispatch,
+// rate limiting, task lifecycle, and progress tracking.
+type Handler struct {
+	messenger      Messenger
+	runner         *executor.Runner
+	projects       ProjectSource
+	projectPath    string
+	rateLimit      *RateLimiter
+	llmClassifier  intent.Classifier
+	convStore      *intent.ConversationStore
+	memberResolver MemberResolver
+	store          *memory.Store
+	taskIDPrefix   string
+	log            *slog.Logger
+
+	activeProject map[string]string       // contextID -> projectPath
+	pendingTasks  map[string]*PendingTask // contextID -> pending task
+	runningTasks  map[string]*RunningTask // contextID -> running task
+	lastSender    map[string]string       // contextID -> senderID
+	mu            sync.Mutex
+}
+
+// NewHandler creates a shared Handler from the given config.
+func NewHandler(cfg *HandlerConfig) *Handler {
+	var rl *RateLimiter
+	if cfg.RateLimit != nil {
+		rl = NewRateLimiter(cfg.RateLimit)
+	} else {
+		rl = NewRateLimiter(DefaultRateLimitConfig())
+	}
+
+	prefix := cfg.TaskIDPrefix
+	if prefix == "" {
+		prefix = "MSG"
+	}
+
+	lg := cfg.Log
+	if lg == nil {
+		lg = logging.WithComponent("comms.handler")
+	}
+
+	return &Handler{
+		messenger:      cfg.Messenger,
+		runner:         cfg.Runner,
+		projects:       cfg.Projects,
+		projectPath:    cfg.ProjectPath,
+		rateLimit:      rl,
+		llmClassifier:  cfg.LLMClassifier,
+		convStore:      cfg.ConvStore,
+		memberResolver: cfg.MemberResolver,
+		store:          cfg.Store,
+		taskIDPrefix:   prefix,
+		log:            lg,
+		activeProject:  make(map[string]string),
+		pendingTasks:   make(map[string]*PendingTask),
+		runningTasks:   make(map[string]*RunningTask),
+		lastSender:     make(map[string]string),
+	}
+}
+
+// HandleMessage is the main entry point for processing an incoming message.
+// It performs rate limiting, intent detection, and dispatches to the appropriate handler.
+func (h *Handler) HandleMessage(ctx context.Context, msg *IncomingMessage) {
+	contextID := msg.ContextID
+	text := msg.Text
+
+	// Track sender for RBAC
+	if msg.SenderID != "" {
+		h.mu.Lock()
+		h.lastSender[contextID] = msg.SenderID
+		h.mu.Unlock()
+	}
+
+	// Rate limit check
+	if !h.rateLimit.AllowMessage(contextID) {
+		h.log.Warn("Message rate limit exceeded", slog.String("context_id", contextID))
+		_ = h.messenger.SendText(ctx, contextID, "⚠️ Rate limit exceeded. Please wait before sending more messages.")
+		return
+	}
+
+	// Handle callback (button press) — check pending confirmation
+	if msg.IsCallback {
+		_ = h.messenger.AcknowledgeCallback(ctx, msg.CallbackID)
+		confirmed := msg.ActionID == "execute" || msg.ActionID == "confirm" || msg.ActionID == "yes"
+		h.handleConfirmation(ctx, contextID, msg.ThreadID, confirmed)
+		return
+	}
+
+	// Text-based confirmation shortcuts
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if lower == "yes" || lower == "y" || lower == "confirm" || lower == "ok" {
+		h.handleConfirmation(ctx, contextID, msg.ThreadID, true)
+		return
+	}
+	if lower == "no" || lower == "n" || lower == "cancel" || lower == "nope" {
+		h.handleConfirmation(ctx, contextID, msg.ThreadID, false)
+		return
+	}
+
+	// Detect intent
+	detected := h.detectIntent(ctx, contextID, text)
+
+	// Record user message in conversation history
+	if h.convStore != nil {
+		h.convStore.Add(contextID, "user", TruncateText(text, 500))
+	}
+
+	// Dispatch
+	switch detected {
+	case intent.IntentGreeting:
+		h.handleGreeting(ctx, contextID)
+	case intent.IntentQuestion:
+		h.handleQuestion(ctx, contextID, msg.ThreadID, text)
+	case intent.IntentResearch:
+		h.handleResearch(ctx, contextID, msg.ThreadID, text)
+	case intent.IntentPlanning:
+		h.handlePlanning(ctx, contextID, msg.ThreadID, text)
+	case intent.IntentChat:
+		h.handleChat(ctx, contextID, msg.ThreadID, text)
+	case intent.IntentTask:
+		h.handleTask(ctx, contextID, msg.ThreadID, text, msg.SenderID)
+	default:
+		// Fallback: treat as task
+		h.handleTask(ctx, contextID, msg.ThreadID, text, msg.SenderID)
+	}
+}
+
+// ---------- intent detection ----------
+
+func (h *Handler) detectIntent(ctx context.Context, contextID, text string) intent.Intent {
+	// Fast path: commands
+	if strings.HasPrefix(text, "/") {
+		return intent.IntentCommand
+	}
+
+	// Fast path: clear questions
+	if intent.IsClearQuestion(text) {
+		return intent.IntentQuestion
+	}
+
+	// LLM classification if available
+	if h.llmClassifier != nil {
+		classifyCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+
+		var history []intent.ConversationMessage
+		if h.convStore != nil {
+			history = h.convStore.Get(contextID)
+		}
+
+		detected, err := h.llmClassifier.Classify(classifyCtx, history, text)
+		if err != nil {
+			h.log.Debug("LLM classification failed, using regex", slog.Any("error", err))
+			return intent.DetectIntent(text)
+		}
+
+		h.log.Debug("LLM classified intent",
+			slog.String("context_id", contextID),
+			slog.String("intent", string(detected)),
+			slog.String("text", TruncateText(text, 50)))
+		return detected
+	}
+
+	return intent.DetectIntent(text)
+}
+
+// ---------- intent handlers ----------
+
+func (h *Handler) handleGreeting(ctx context.Context, contextID string) {
+	_ = h.messenger.SendText(ctx, contextID, "👋 Hello! I'm Pilot — send me a task, question, or say /help.")
+}
+
+func (h *Handler) handleQuestion(ctx context.Context, contextID, threadID, question string) {
+	_ = h.messenger.SendText(ctx, contextID, "🔍 Looking into that...")
+
+	questionCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+
+	prompt := fmt.Sprintf(`Answer this question about the codebase. DO NOT make any changes, only read and analyze.
+
+Question: %s
+
+IMPORTANT: Be concise. Limit your exploration to 5-10 files max. Provide a brief, direct answer.
+If the question is too broad, ask for clarification instead of exploring everything.`, question)
+
+	taskID := fmt.Sprintf("Q-%d", time.Now().Unix())
+	task := &executor.Task{
+		ID:          taskID,
+		Title:       "Question: " + TruncateText(question, 40),
+		Description: prompt,
+		ProjectPath: h.getActiveProjectPath(contextID),
+		Verbose:     false,
+	}
+
+	h.log.Debug("Answering question", slog.String("task_id", taskID), slog.String("context_id", contextID))
+	result, err := h.runner.Execute(questionCtx, task)
+
+	if err != nil {
+		if questionCtx.Err() == context.DeadlineExceeded {
+			_ = h.messenger.SendText(ctx, contextID, "⏱ Question timed out. Try asking something more specific.")
+		} else {
+			_ = h.messenger.SendText(ctx, contextID, "❌ Sorry, I couldn't answer that question. Try rephrasing it.")
+		}
+		return
+	}
+
+	answer := CleanInternalSignals(result.Output)
+	if answer == "" {
+		answer = "I couldn't find a clear answer to that question."
+	}
+
+	_ = h.messenger.SendChunked(ctx, contextID, threadID, answer, "")
+}
+
+func (h *Handler) handleResearch(ctx context.Context, contextID, threadID, query string) {
+	_ = h.messenger.SendText(ctx, contextID, "🔬 Researching...")
+
+	taskID := fmt.Sprintf("RES-%d", time.Now().Unix())
+	task := &executor.Task{
+		ID:    taskID,
+		Title: "Research: " + TruncateText(query, 40),
+		Description: fmt.Sprintf(`Research and analyze: %s
+
+Provide findings in a structured format with:
+- Executive summary
+- Key findings
+- Relevant code/files if applicable
+- Recommendations
+
+DO NOT make any code changes. This is a read-only research task.`, query),
+		ProjectPath: h.getActiveProjectPath(contextID),
+		CreatePR:    false,
+	}
+
+	researchCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+
+	h.log.Info("Executing research", slog.String("task_id", taskID), slog.String("context_id", contextID))
+	result, err := h.runner.Execute(researchCtx, task)
+
+	if err != nil {
+		if researchCtx.Err() == context.DeadlineExceeded {
+			_ = h.messenger.SendText(ctx, contextID, "⏱ Research timed out. Try a more specific query.")
+		} else {
+			_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("❌ Research failed: %s", err.Error()))
+		}
+		return
+	}
+
+	content := CleanInternalSignals(result.Output)
+	if content == "" {
+		_ = h.messenger.SendText(ctx, contextID, "Research completed but produced no output.")
+		return
+	}
+
+	_ = h.messenger.SendChunked(ctx, contextID, threadID, content, "")
+}
+
+func (h *Handler) handlePlanning(ctx context.Context, contextID, threadID, request string) {
+	_ = h.messenger.SendText(ctx, contextID, "📐 Drafting plan...")
+
+	taskID := fmt.Sprintf("PLAN-%d", time.Now().Unix())
+	task := &executor.Task{
+		ID:    taskID,
+		Title: "Plan: " + TruncateText(request, 40),
+		Description: fmt.Sprintf(`Create an implementation plan for: %s
+
+Explore the codebase and propose a detailed plan. Include:
+1. Summary of approach
+2. Files to modify/create
+3. Step-by-step implementation phases
+4. Potential risks or considerations
+
+DO NOT make any code changes. Only explore and plan.`, request),
+		ProjectPath: h.getActiveProjectPath(contextID),
+		CreatePR:    false,
+	}
+
+	planTimeout := 2 * time.Minute
+	if h.runner.Config() != nil && h.runner.Config().PlanningTimeout > 0 {
+		planTimeout = h.runner.Config().PlanningTimeout
+	}
+	planCtx, cancel := context.WithTimeout(ctx, planTimeout)
+	defer cancel()
+
+	h.log.Info("Creating plan", slog.String("task_id", taskID), slog.String("context_id", contextID))
+	result, err := h.runner.Execute(planCtx, task)
+
+	if err != nil {
+		if planCtx.Err() == context.DeadlineExceeded {
+			_ = h.messenger.SendText(ctx, contextID, "⏱ Planning timed out. Try a simpler request.")
+		} else {
+			_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("❌ Planning failed: %s", err.Error()))
+		}
+		return
+	}
+
+	planContent := CleanInternalSignals(result.Output)
+	if planContent == "" {
+		_ = h.messenger.SendText(ctx, contextID, "Planning completed but produced no output.")
+		return
+	}
+
+	// Store plan as pending task for execution
+	h.mu.Lock()
+	h.pendingTasks[contextID] = &PendingTask{
+		TaskID:      taskID,
+		Description: fmt.Sprintf("## Implementation Plan\n\n%s\n\n## Original Request\n\n%s", planContent, request),
+		ContextID:   contextID,
+		ThreadID:    threadID,
+		SenderID:    h.lastSender[contextID],
+		CreatedAt:   time.Now(),
+	}
+	h.mu.Unlock()
+
+	// Send plan with confirmation prompt
+	summary := TruncateText(planContent, h.messenger.MaxMessageLength()-100)
+	_, err = h.messenger.SendConfirmation(ctx, contextID, threadID, taskID, summary, h.getActiveProjectPath(contextID))
+	if err != nil {
+		h.log.Warn("Failed to send plan confirmation, falling back to text", slog.Any("error", err))
+		_ = h.messenger.SendChunked(ctx, contextID, threadID, planContent, "📋 Implementation Plan")
+		_ = h.messenger.SendText(ctx, contextID, "Reply yes to execute or no to cancel.")
+	}
+}
+
+func (h *Handler) handleChat(ctx context.Context, contextID, threadID, message string) {
+	_ = h.messenger.SendText(ctx, contextID, "💬 Thinking...")
+
+	taskID := fmt.Sprintf("CHAT-%d", time.Now().Unix())
+	task := &executor.Task{
+		ID:    taskID,
+		Title: "Chat: " + TruncateText(message, 30),
+		Description: fmt.Sprintf(`You are Pilot, an AI assistant for the codebase at %s.
+
+The user wants to have a conversation (not execute a task).
+Respond helpfully and conversationally. You can reference project knowledge but DO NOT make code changes.
+
+Be concise - this is a chat conversation, not a report. Keep response under 500 words.
+
+User message: %s`, h.getActiveProjectPath(contextID), message),
+		ProjectPath: h.getActiveProjectPath(contextID),
+		CreatePR:    false,
+	}
+
+	chatCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	h.log.Debug("Chat response", slog.String("task_id", taskID), slog.String("context_id", contextID))
+	result, err := h.runner.Execute(chatCtx, task)
+
+	if err != nil {
+		if chatCtx.Err() == context.DeadlineExceeded {
+			_ = h.messenger.SendText(ctx, contextID, "⏱ Took too long to respond. Try a simpler question.")
+		} else {
+			_ = h.messenger.SendText(ctx, contextID, "Sorry, I couldn't process that. Try rephrasing?")
+		}
+		return
+	}
+
+	response := CleanInternalSignals(result.Output)
+	if response == "" {
+		response = "I'm not sure how to respond to that. Could you rephrase?"
+	}
+
+	// Truncate to fit platform limit
+	maxLen := h.messenger.MaxMessageLength()
+	if maxLen > 0 && len(response) > maxLen {
+		response = response[:maxLen-3] + "..."
+	}
+
+	_ = h.messenger.SendText(ctx, contextID, response)
+
+	// Record in conversation history
+	if h.convStore != nil {
+		h.convStore.Add(contextID, "assistant", TruncateText(response, 500))
+	}
+}
+
+func (h *Handler) handleTask(ctx context.Context, contextID, threadID, description, senderID string) {
+	// Task rate limit
+	if !h.rateLimit.AllowTask(contextID) {
+		h.log.Warn("Task rate limit exceeded", slog.String("context_id", contextID))
+		_ = h.messenger.SendText(ctx, contextID,
+			"⚠️ Task rate limit exceeded. You've submitted too many tasks recently. Please wait before submitting more.")
+		return
+	}
+
+	// Check for existing pending task
+	h.mu.Lock()
+	if existing, exists := h.pendingTasks[contextID]; exists {
+		h.mu.Unlock()
+		_ = h.messenger.SendText(ctx, contextID,
+			fmt.Sprintf("⚠️ You already have a pending task: %s\n\nReply yes to execute or no to cancel.", existing.TaskID))
+		return
+	}
+	h.mu.Unlock()
+
+	taskID := fmt.Sprintf("%s-%d", h.taskIDPrefix, time.Now().Unix())
+
+	h.mu.Lock()
+	h.pendingTasks[contextID] = &PendingTask{
+		TaskID:      taskID,
+		Description: description,
+		ContextID:   contextID,
+		ThreadID:    threadID,
+		SenderID:    senderID,
+		CreatedAt:   time.Now(),
+	}
+	h.mu.Unlock()
+
+	_, err := h.messenger.SendConfirmation(ctx, contextID, threadID, taskID, description, h.getActiveProjectPath(contextID))
+	if err != nil {
+		h.log.Warn("Failed to send task confirmation", slog.Any("error", err))
+		_ = h.messenger.SendText(ctx, contextID,
+			fmt.Sprintf("📋 Task %s\n\n%s\n\nReply yes to execute or no to cancel.",
+				taskID, TruncateText(description, 500)))
+	}
+}
+
+// ---------- confirmation & execution ----------
+
+func (h *Handler) handleConfirmation(ctx context.Context, contextID, threadID string, confirmed bool) {
+	h.mu.Lock()
+	pending, exists := h.pendingTasks[contextID]
+	if exists {
+		delete(h.pendingTasks, contextID)
+	}
+	h.mu.Unlock()
+
+	if !exists {
+		_ = h.messenger.SendText(ctx, contextID, "No pending task to confirm.")
+		return
+	}
+
+	if !confirmed {
+		_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("❌ Task %s cancelled.", pending.TaskID))
+		return
+	}
+
+	h.executeTask(ctx, contextID, threadID, pending.TaskID, pending.Description)
+}
+
+func (h *Handler) executeTask(ctx context.Context, contextID, threadID, taskID, description string) {
+	// Detect ephemeral tasks
+	createPR := true
+	detectEphemeral := true
+	if h.runner.Config() != nil && h.runner.Config().DetectEphemeral != nil {
+		detectEphemeral = *h.runner.Config().DetectEphemeral
+	}
+	if detectEphemeral && intent.IsEphemeralTask(description) {
+		createPR = false
+		h.log.Debug("Ephemeral task detected - skipping PR creation",
+			slog.String("task_id", taskID))
+	}
+
+	// Send starting message
+	prNote := ""
+	if !createPR {
+		prNote = " (no PR)"
+	}
+	detail := fmt.Sprintf("🚀 Starting %s%s...", taskID, prNote)
+	msgRef, err := h.messenger.SendProgress(ctx, contextID, "", taskID, "Starting"+prNote, 0, "Initializing...")
+	if err != nil {
+		h.log.Warn("Failed to send progress start", slog.Any("error", err))
+		_ = h.messenger.SendText(ctx, contextID, detail)
+	}
+
+	// Track running task
+	taskCtx, taskCancel := context.WithCancel(ctx)
+	h.mu.Lock()
+	h.runningTasks[contextID] = &RunningTask{
+		TaskID:    taskID,
+		ContextID: contextID,
+		StartedAt: time.Now(),
+		Cancel:    taskCancel,
+	}
+	h.mu.Unlock()
+
+	defer func() {
+		h.mu.Lock()
+		delete(h.runningTasks, contextID)
+		h.mu.Unlock()
+		taskCancel()
+	}()
+
+	// Build executor task
+	branch := ""
+	baseBranch := ""
+	if createPR {
+		branch = fmt.Sprintf("pilot/%s", taskID)
+		baseBranch = "main"
+	}
+
+	memberID := h.resolveMemberID(contextID)
+
+	task := &executor.Task{
+		ID:          taskID,
+		Title:       TruncateText(description, 50),
+		Description: description,
+		ProjectPath: h.getActiveProjectPath(contextID),
+		Verbose:     false,
+		Branch:      branch,
+		BaseBranch:  baseBranch,
+		CreatePR:    createPR,
+		MemberID:    memberID,
+	}
+
+	// Progress callback with throttling
+	if msgRef != "" && h.runner != nil {
+		var lastPhase string
+		var lastProgress int
+		var lastUpdate time.Time
+
+		h.runner.OnProgress(func(tid, phase string, progress int, message string) {
+			if tid != taskID {
+				return
+			}
+			now := time.Now()
+			phaseChanged := phase != lastPhase
+			progressChanged := progress-lastProgress >= 15
+			timeElapsed := now.Sub(lastUpdate) >= 3*time.Second
+			if !phaseChanged && !progressChanged && !timeElapsed {
+				return
+			}
+			lastPhase = phase
+			lastProgress = progress
+			lastUpdate = now
+
+			newRef, _ := h.messenger.SendProgress(ctx, contextID, msgRef, taskID, phase, progress, message)
+			if newRef != "" {
+				msgRef = newRef
+			}
+		})
+	}
+
+	// Execute
+	h.log.Info("Executing task", slog.String("task_id", taskID), slog.String("context_id", contextID))
+	result, err := h.runner.Execute(taskCtx, task)
+
+	// Clear progress callback
+	if h.runner != nil {
+		h.runner.OnProgress(nil)
+	}
+
+	if err != nil {
+		_ = h.messenger.SendResult(ctx, contextID, threadID, taskID, false, err.Error(), "")
+		return
+	}
+
+	output := CleanInternalSignals(result.Output)
+	_ = h.messenger.SendResult(ctx, contextID, threadID, taskID, result.Success, output, result.PRUrl)
+}
+
+// ---------- project management ----------
+
+func (h *Handler) getActiveProjectPath(contextID string) string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if path, ok := h.activeProject[contextID]; ok {
+		return path
+	}
+	return h.projectPath
+}
+
+// SetActiveProject sets the active project for a context by name.
+func (h *Handler) SetActiveProject(contextID, projectName string) error {
+	if h.projects == nil {
+		return fmt.Errorf("no projects configured")
+	}
+	proj := h.projects.GetProjectByName(projectName)
+	if proj == nil {
+		return fmt.Errorf("project '%s' not found", projectName)
+	}
+	h.mu.Lock()
+	h.activeProject[contextID] = proj.Path
+	h.mu.Unlock()
+	return nil
+}
+
+// GetActiveProject returns (name, path) for the active project in a given context.
+func (h *Handler) GetActiveProject(contextID string) (string, string) {
+	path := h.getActiveProjectPath(contextID)
+	if h.projects != nil {
+		if proj := h.projects.GetProjectByPath(path); proj != nil {
+			return proj.Name, proj.Path
+		}
+	}
+	return "", path
+}
+
+// ---------- RBAC ----------
+
+func (h *Handler) resolveMemberID(contextID string) string {
+	if h.memberResolver == nil {
+		return ""
+	}
+
+	h.mu.Lock()
+	senderID := h.lastSender[contextID]
+	h.mu.Unlock()
+
+	if senderID == "" {
+		return ""
+	}
+
+	memberID, err := h.memberResolver.ResolveIdentity(senderID)
+	if err != nil {
+		h.log.Warn("failed to resolve identity",
+			slog.String("sender_id", senderID),
+			slog.Any("error", err))
+		return ""
+	}
+	return memberID
+}
+
+// ---------- state accessors (for CommandHandler wiring) ----------
+
+// GetPendingTask returns the pending task for a context, if any.
+func (h *Handler) GetPendingTask(contextID string) *PendingTask {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.pendingTasks[contextID]
+}
+
+// GetRunningTask returns the running task for a context, if any.
+func (h *Handler) GetRunningTask(contextID string) *RunningTask {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.runningTasks[contextID]
+}
+
+// CancelTask cancels any pending or running task for a context.
+func (h *Handler) CancelTask(ctx context.Context, contextID string) error {
+	h.mu.Lock()
+	pending, hasPending := h.pendingTasks[contextID]
+	if hasPending {
+		delete(h.pendingTasks, contextID)
+	}
+	running, hasRunning := h.runningTasks[contextID]
+	if hasRunning {
+		running.Cancel()
+		delete(h.runningTasks, contextID)
+	}
+	h.mu.Unlock()
+
+	if hasPending {
+		_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("❌ Cancelled pending task %s", pending.TaskID))
+		return nil
+	}
+	if hasRunning {
+		_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("🛑 Stopping task %s", running.TaskID))
+		return nil
+	}
+	return fmt.Errorf("no task to cancel")
+}
+
+// ---------- cleanup ----------
+
+// CleanupLoop runs a background goroutine that removes expired pending tasks.
+// Call with go h.CleanupLoop(ctx) and track with a WaitGroup externally.
+func (h *Handler) CleanupLoop(ctx context.Context) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.cleanupExpiredTasks(ctx)
+		}
+	}
+}
+
+func (h *Handler) cleanupExpiredTasks(ctx context.Context) {
+	h.mu.Lock()
+	var expired []string
+	for id, task := range h.pendingTasks {
+		if time.Since(task.CreatedAt) > 5*time.Minute {
+			expired = append(expired, id)
+		}
+	}
+	for _, id := range expired {
+		delete(h.pendingTasks, id)
+	}
+	h.mu.Unlock()
+
+	for _, id := range expired {
+		_ = h.messenger.SendText(ctx, id, "⏰ Pending task expired (5 min timeout). Send a new request.")
+	}
+}

--- a/internal/comms/handler_test.go
+++ b/internal/comms/handler_test.go
@@ -1,0 +1,545 @@
+package comms
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/intent"
+)
+
+// handlerMock records all Messenger calls for assertion in handler tests.
+type handlerMock struct {
+	mu       sync.Mutex
+	texts    []hSentText
+	confirms []hSentConfirm
+	results  []hSentResult
+	chunks   []hSentChunk
+	progress []hSentProgress
+	acks     []string
+}
+
+type hSentText struct {
+	contextID, text string
+}
+type hSentConfirm struct {
+	contextID, threadID, taskID, desc, project string
+}
+type hSentResult struct {
+	contextID, threadID, taskID, output, prURL string
+	success                                    bool
+}
+type hSentChunk struct {
+	contextID, threadID, content, prefix string
+}
+type hSentProgress struct {
+	contextID, msgRef, taskID, phase, detail string
+	progress                                 int
+}
+
+func (m *handlerMock) SendText(_ context.Context, contextID, text string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.texts = append(m.texts, hSentText{contextID, text})
+	return nil
+}
+
+func (m *handlerMock) SendConfirmation(_ context.Context, contextID, threadID, taskID, desc, project string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.confirms = append(m.confirms, hSentConfirm{contextID, threadID, taskID, desc, project})
+	return "msg-ref-1", nil
+}
+
+func (m *handlerMock) SendProgress(_ context.Context, contextID, msgRef, taskID, phase string, progress int, detail string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.progress = append(m.progress, hSentProgress{contextID, msgRef, taskID, phase, detail, progress})
+	return msgRef, nil
+}
+
+func (m *handlerMock) SendResult(_ context.Context, contextID, threadID, taskID string, success bool, output, prURL string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.results = append(m.results, hSentResult{contextID, threadID, taskID, output, prURL, success})
+	return nil
+}
+
+func (m *handlerMock) SendChunked(_ context.Context, contextID, threadID, content, prefix string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.chunks = append(m.chunks, hSentChunk{contextID, threadID, content, prefix})
+	return nil
+}
+
+func (m *handlerMock) AcknowledgeCallback(_ context.Context, callbackID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.acks = append(m.acks, callbackID)
+	return nil
+}
+
+func (m *handlerMock) MaxMessageLength() int { return 4000 }
+
+func (m *handlerMock) getTexts() []hSentText {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]hSentText, len(m.texts))
+	copy(cp, m.texts)
+	return cp
+}
+
+// hMockClassifier returns a fixed intent.
+type hMockClassifier struct {
+	result intent.Intent
+	err    error
+}
+
+func (c *hMockClassifier) Classify(_ context.Context, _ []intent.ConversationMessage, _ string) (intent.Intent, error) {
+	return c.result, c.err
+}
+
+// hMockMemberResolver returns a fixed member ID.
+type hMockMemberResolver struct {
+	memberID string
+	err      error
+}
+
+func (r *hMockMemberResolver) ResolveIdentity(_ string) (string, error) {
+	return r.memberID, r.err
+}
+
+func newTestHandler(m *handlerMock) *Handler {
+	return NewHandler(&HandlerConfig{
+		Messenger:    m,
+		TaskIDPrefix: "TEST",
+	})
+}
+
+func TestNewHandler(t *testing.T) {
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		ProjectPath:  "/tmp/test-project",
+		TaskIDPrefix: "TG",
+	})
+
+	if h.taskIDPrefix != "TG" {
+		t.Errorf("expected prefix TG, got %s", h.taskIDPrefix)
+	}
+	if h.projectPath != "/tmp/test-project" {
+		t.Errorf("expected project path /tmp/test-project, got %s", h.projectPath)
+	}
+	if h.rateLimit == nil {
+		t.Error("expected rate limiter to be initialized")
+	}
+}
+
+func TestNewHandler_DefaultPrefix(t *testing.T) {
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{Messenger: m})
+	if h.taskIDPrefix != "MSG" {
+		t.Errorf("expected default prefix MSG, got %s", h.taskIDPrefix)
+	}
+}
+
+func TestHandleMessage_RateLimited(t *testing.T) {
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger: m,
+		RateLimit: &RateLimitConfig{
+			Enabled:           true,
+			MessagesPerMinute: 1,
+			BurstSize:         1,
+			TasksPerHour:      1,
+		},
+		TaskIDPrefix: "TEST",
+	})
+
+	ctx := context.Background()
+	// First message consumes the single token
+	h.HandleMessage(ctx, &IncomingMessage{ContextID: "ch1", SenderID: "u1", Text: "hello"})
+	// Second message should be rate limited
+	h.HandleMessage(ctx, &IncomingMessage{ContextID: "ch1", SenderID: "u1", Text: "hello again"})
+
+	texts := m.getTexts()
+	found := false
+	for _, st := range texts {
+		if st.text == "⚠️ Rate limit exceeded. Please wait before sending more messages." {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected rate limit message")
+	}
+}
+
+func TestHandleMessage_Greeting(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "u1",
+		Text:      "hello",
+	})
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected at least one text message")
+	}
+	if texts[0].text != "👋 Hello! I'm Pilot — send me a task, question, or say /help." {
+		t.Errorf("unexpected greeting: %s", texts[0].text)
+	}
+}
+
+func TestHandleMessage_ConfirmationNo(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	// Seed a pending task
+	h.mu.Lock()
+	h.pendingTasks["ch1"] = &PendingTask{
+		TaskID:      "TEST-123",
+		Description: "do something",
+		ContextID:   "ch1",
+		CreatedAt:   time.Now(),
+	}
+	h.mu.Unlock()
+
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "u1",
+		Text:      "no",
+	})
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected cancellation message")
+	}
+	if texts[0].text != "❌ Task TEST-123 cancelled." {
+		t.Errorf("unexpected message: %s", texts[0].text)
+	}
+
+	// Verify pending task was removed
+	h.mu.Lock()
+	_, exists := h.pendingTasks["ch1"]
+	h.mu.Unlock()
+	if exists {
+		t.Error("pending task should have been removed")
+	}
+}
+
+func TestHandleMessage_CallbackConfirmation(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.mu.Lock()
+	h.pendingTasks["ch1"] = &PendingTask{
+		TaskID:      "TEST-456",
+		Description: "build feature",
+		ContextID:   "ch1",
+		CreatedAt:   time.Now(),
+	}
+	h.mu.Unlock()
+
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID:  "ch1",
+		SenderID:   "u1",
+		IsCallback: true,
+		CallbackID: "cb-1",
+		ActionID:   "cancel",
+	})
+
+	if len(m.acks) == 0 {
+		t.Error("expected callback acknowledgment")
+	}
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected cancellation message")
+	}
+	if texts[0].text != "❌ Task TEST-456 cancelled." {
+		t.Errorf("unexpected: %s", texts[0].text)
+	}
+}
+
+func TestHandleMessage_NoConfirmationPending(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "u1",
+		Text:      "yes",
+	})
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected 'no pending task' message")
+	}
+	if texts[0].text != "No pending task to confirm." {
+		t.Errorf("unexpected: %s", texts[0].text)
+	}
+}
+
+func TestDetectIntent_Command(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	got := h.detectIntent(context.Background(), "ch1", "/help")
+	if got != intent.IntentCommand {
+		t.Errorf("expected command intent, got %s", got)
+	}
+}
+
+func TestDetectIntent_ClearQuestion(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	got := h.detectIntent(context.Background(), "ch1", "What does the auth handler do?")
+	if got != intent.IntentQuestion {
+		t.Errorf("expected question intent, got %s", got)
+	}
+}
+
+func TestDetectIntent_LLMClassifier(t *testing.T) {
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger:     m,
+		LLMClassifier: &hMockClassifier{result: intent.IntentResearch},
+		TaskIDPrefix:  "TEST",
+	})
+
+	got := h.detectIntent(context.Background(), "ch1", "analyze the codebase performance")
+	if got != intent.IntentResearch {
+		t.Errorf("expected research intent from LLM, got %s", got)
+	}
+}
+
+func TestDetectIntent_LLMFallback(t *testing.T) {
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger:     m,
+		LLMClassifier: &hMockClassifier{err: fmt.Errorf("timeout")},
+		TaskIDPrefix:  "TEST",
+	})
+
+	// Should fall back to regex
+	got := h.detectIntent(context.Background(), "ch1", "hello")
+	if got != intent.IntentGreeting {
+		t.Errorf("expected greeting intent from fallback, got %s", got)
+	}
+}
+
+func TestHandleTask_RateLimited(t *testing.T) {
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger: m,
+		RateLimit: &RateLimitConfig{
+			Enabled:           true,
+			MessagesPerMinute: 100,
+			TasksPerHour:      1,
+			BurstSize:         1,
+		},
+		TaskIDPrefix: "TEST",
+	})
+
+	ctx := context.Background()
+	// First task uses the token
+	h.handleTask(ctx, "ch1", "", "create a feature", "u1")
+	// Second task should be rate limited
+	h.handleTask(ctx, "ch1", "", "another feature", "u1")
+
+	texts := m.getTexts()
+	found := false
+	for _, st := range texts {
+		if st.text == "⚠️ Task rate limit exceeded. You've submitted too many tasks recently. Please wait before submitting more." {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected task rate limit message")
+	}
+}
+
+func TestHandleTask_ExistingPending(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.mu.Lock()
+	h.pendingTasks["ch1"] = &PendingTask{
+		TaskID:    "OLD-1",
+		ContextID: "ch1",
+		CreatedAt: time.Now(),
+	}
+	h.mu.Unlock()
+
+	h.handleTask(context.Background(), "ch1", "", "new task", "u1")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected warning about existing task")
+	}
+	if texts[0].contextID != "ch1" {
+		t.Error("wrong context")
+	}
+}
+
+func TestGetActiveProjectPath(t *testing.T) {
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		ProjectPath:  "/default/path",
+		TaskIDPrefix: "TEST",
+	})
+
+	// Default path
+	if got := h.getActiveProjectPath("ch1"); got != "/default/path" {
+		t.Errorf("expected default path, got %s", got)
+	}
+
+	// Set active
+	h.mu.Lock()
+	h.activeProject["ch1"] = "/custom/path"
+	h.mu.Unlock()
+
+	if got := h.getActiveProjectPath("ch1"); got != "/custom/path" {
+		t.Errorf("expected custom path, got %s", got)
+	}
+}
+
+func TestResolveMemberID(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolver MemberResolver
+		senderID string
+		want     string
+	}{
+		{"nil resolver", nil, "u1", ""},
+		{"no sender", &hMockMemberResolver{memberID: "m1"}, "", ""},
+		{"resolved", &hMockMemberResolver{memberID: "m1"}, "u1", "m1"},
+		{"error", &hMockMemberResolver{err: fmt.Errorf("fail")}, "u1", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &handlerMock{}
+			h := NewHandler(&HandlerConfig{
+				Messenger:      m,
+				MemberResolver: tt.resolver,
+				TaskIDPrefix:   "TEST",
+			})
+
+			if tt.senderID != "" {
+				h.mu.Lock()
+				h.lastSender["ch1"] = tt.senderID
+				h.mu.Unlock()
+			}
+
+			got := h.resolveMemberID("ch1")
+			if got != tt.want {
+				t.Errorf("resolveMemberID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCancelTask_Pending(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.mu.Lock()
+	h.pendingTasks["ch1"] = &PendingTask{
+		TaskID:    "T-1",
+		ContextID: "ch1",
+		CreatedAt: time.Now(),
+	}
+	h.mu.Unlock()
+
+	err := h.CancelTask(context.Background(), "ch1")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	h.mu.Lock()
+	_, exists := h.pendingTasks["ch1"]
+	h.mu.Unlock()
+	if exists {
+		t.Error("pending task should be removed")
+	}
+}
+
+func TestCancelTask_None(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	err := h.CancelTask(context.Background(), "ch1")
+	if err == nil {
+		t.Error("expected error when no task to cancel")
+	}
+}
+
+func TestCleanupExpiredTasks(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.mu.Lock()
+	h.pendingTasks["ch1"] = &PendingTask{
+		TaskID:    "T-OLD",
+		ContextID: "ch1",
+		CreatedAt: time.Now().Add(-10 * time.Minute), // expired
+	}
+	h.pendingTasks["ch2"] = &PendingTask{
+		TaskID:    "T-NEW",
+		ContextID: "ch2",
+		CreatedAt: time.Now(), // fresh
+	}
+	h.mu.Unlock()
+
+	h.cleanupExpiredTasks(context.Background())
+
+	h.mu.Lock()
+	_, ch1Exists := h.pendingTasks["ch1"]
+	_, ch2Exists := h.pendingTasks["ch2"]
+	h.mu.Unlock()
+
+	if ch1Exists {
+		t.Error("expired task should be removed")
+	}
+	if !ch2Exists {
+		t.Error("fresh task should remain")
+	}
+
+	// Verify notification sent for expired
+	texts := m.getTexts()
+	found := false
+	for _, txt := range texts {
+		if txt.contextID == "ch1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected expiration notification for ch1")
+	}
+}
+
+func TestSenderTracking(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "user-42",
+		Text:      "hello",
+	})
+
+	h.mu.Lock()
+	sender := h.lastSender["ch1"]
+	h.mu.Unlock()
+
+	if sender != "user-42" {
+		t.Errorf("expected sender user-42, got %s", sender)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1786.

Closes #1786

## Changes

GitHub Issue #1786: refactor(comms): Extract shared Handler with HandleMessage, intent dispatch, and task lifecycle

## Follow-up: Comms Module Migration (was GH-1760)

Previous PR #1771 was closed without merging. `internal/comms/handler.go` does not exist on main.

## Current State

- `internal/comms/` exists with: types.go, util.go, commands.go, project.go, ratelimit.go
- `internal/comms/handler.go` is **MISSING** — this is the core of the refactor
- `telegram/handler.go` is 1943 lines, `slack/handler.go` is 998 lines — still fully duplicated

## Task

Create `internal/comms/handler.go` (~450 lines) with the shared Handler that both adapters will delegate to.

## Changes

1. Create `internal/comms/handler.go`:

```go
type HandlerConfig struct {
    Messenger      Messenger              // from comms/types.go
    Runner         *executor.Runner
    Projects       ProjectSource          // from comms/project.go
    ProjectPath    string
    RateLimit      *RateLimitConfig       // from comms/ratelimit.go
    LLMClassifier  intent.Classifier
    ConvStore      *intent.ConversationStore
    MemberResolver MemberResolver
    Store          *memory.Store
}

type Handler struct { /* fields from config + maps for activeProject, pendingTasks, runningTasks, lastSender */ }

func NewHandler(cfg *HandlerConfig) *Handler
func (h *Handler) HandleMessage(ctx context.Context, msg *IncomingMessage)
```

2. Move these methods (currently ~85-95% identical in both adapters):
   - `handleGreeting` — format greeting, send via messenger
   - `handleQuestion` — wrap prompt, execute with timeout, send response
   - `handleResearch` — deep analysis, chunked output
   - `handlePlanning` — plan generation with confirmation
   - `handleChat` — conversational response with LLM context
   - `handleTask` — pending task creation + confirmation
   - `handleConfirmation` — yes/no resolution
   - `executeTask` — runner.Execute with progress updates
   - `cleanupLoop` — expired task cleanup goroutine

3. Intent dispatch in HandleMessage:
   - Track sender → rate limit check → confirmation check → callback check
   - Detect intent (LLM + regex) → switch on intent → call handler

4. Create `internal/comms/handler_test.go` — mock Messenger, table-driven tests

## Key Details

- All output through `h.messenger` interface — platform-agnostic
- `MemberResolver` interface for RBAC (adapters provide concrete impl)
- Uses `comms.IncomingMessage` from types.go
- Uses `comms.RateLimiter` from ratelimit.go
- Uses `comms.CommandHandler` from commands.go (already on main)

## Verification

- `make build` compiles
- `make test` passes (handler_test.go with mock Messenger)
- `make lint` clean

## Note

This creates the handler but does NOT yet wire it — adapters still use their own handlers until the Transport + Messenger + wiring steps.