### PR TITLE
refactor(comms): Implement TelegramMessenger and SlackMessenger for comms.Messenger

### DIFF
--- a/internal/adapters/slack/client.go
+++ b/internal/adapters/slack/client.go
@@ -17,6 +17,7 @@ const (
 // Client is a Slack API client
 type Client struct {
 	botToken   string
+	baseURL    string
 	httpClient *http.Client
 }
 
@@ -24,6 +25,18 @@ type Client struct {
 func NewClient(botToken string) *Client {
 	return &Client{
 		botToken: botToken,
+		baseURL:  slackAPIURL,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// NewClientWithBaseURL creates a new Slack client with a custom base URL (for testing).
+func NewClientWithBaseURL(botToken, baseURL string) *Client {
+	return &Client{
+		botToken: botToken,
+		baseURL:  baseURL,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
@@ -93,7 +106,7 @@ func (c *Client) PostMessage(ctx context.Context, msg *Message) (*PostMessageRes
 		return nil, fmt.Errorf("failed to marshal message: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, slackAPIURL+"/chat.postMessage", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat.postMessage", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -143,7 +156,7 @@ func (c *Client) UpdateMessage(ctx context.Context, channel, ts string, msg *Mes
 		return fmt.Errorf("failed to marshal message: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, slackAPIURL+"/chat.update", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat.update", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -187,7 +200,7 @@ func (c *Client) PostInteractiveMessage(ctx context.Context, msg *InteractiveMes
 		return nil, fmt.Errorf("failed to marshal message: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, slackAPIURL+"/chat.postMessage", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat.postMessage", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -237,7 +250,7 @@ func (c *Client) UpdateInteractiveMessage(ctx context.Context, channel, ts strin
 		return fmt.Errorf("failed to marshal message: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, slackAPIURL+"/chat.update", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat.update", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/adapters/slack/messenger.go
+++ b/internal/adapters/slack/messenger.go
@@ -1,0 +1,105 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alekspetrov/pilot/internal/comms"
+)
+
+// Compile-time check that SlackMessenger implements comms.Messenger.
+var _ comms.Messenger = (*SlackMessenger)(nil)
+
+// SlackMessenger implements comms.Messenger by wrapping the Slack Client.
+type SlackMessenger struct {
+	client *Client
+}
+
+// NewMessenger creates a SlackMessenger wrapping the given client.
+func NewMessenger(client *Client) *SlackMessenger {
+	return &SlackMessenger{client: client}
+}
+
+// SendText sends a plain text message to the given channel.
+func (m *SlackMessenger) SendText(ctx context.Context, contextID, text string) error {
+	msg := &Message{
+		Channel: contextID,
+		Text:    text,
+	}
+	_, err := m.client.PostMessage(ctx, msg)
+	return err
+}
+
+// SendConfirmation sends a task confirmation prompt with approve/reject buttons.
+// Returns the Slack message timestamp as messageRef.
+func (m *SlackMessenger) SendConfirmation(ctx context.Context, contextID, threadID, taskID, desc, project string) (string, error) {
+	blocks := BuildConfirmationBlocks(taskID, desc)
+
+	msg := &InteractiveMessage{
+		Channel: contextID,
+		Text:    FormatTaskConfirmation(taskID, desc, project),
+		Blocks:  blocks,
+	}
+
+	resp, err := m.client.PostInteractiveMessage(ctx, msg)
+	if err != nil {
+		return "", fmt.Errorf("send confirmation: %w", err)
+	}
+	return resp.TS, nil
+}
+
+// SendProgress updates the existing message with progress info.
+// Returns the same messageRef (Slack updates in place via timestamp).
+func (m *SlackMessenger) SendProgress(ctx context.Context, contextID, messageRef, taskID, phase string, progress int, detail string) (string, error) {
+	blocks := BuildProgressBlocks(taskID, phase, progress, detail)
+
+	err := m.client.UpdateInteractiveMessage(ctx, contextID, messageRef, blocks, FormatProgressUpdate(taskID, phase, progress, detail))
+	if err != nil {
+		return messageRef, fmt.Errorf("send progress: %w", err)
+	}
+	return messageRef, nil
+}
+
+// SendResult sends the final task result.
+func (m *SlackMessenger) SendResult(ctx context.Context, contextID, threadID, taskID string, success bool, output, prURL string) error {
+	blocks := BuildResultBlocks(taskID, success, output, prURL)
+
+	msg := &InteractiveMessage{
+		Channel: contextID,
+		Text:    FormatTaskResult(output, success, prURL),
+		Blocks:  blocks,
+	}
+
+	_, err := m.client.PostInteractiveMessage(ctx, msg)
+	return err
+}
+
+// SendChunked sends long content split into platform-appropriate chunks.
+func (m *SlackMessenger) SendChunked(ctx context.Context, contextID, threadID, content, prefix string) error {
+	chunks := ChunkContent(content, m.MaxMessageLength())
+	for i, chunk := range chunks {
+		text := chunk
+		if prefix != "" && i == 0 {
+			text = prefix + "\n\n" + chunk
+		}
+		msg := &Message{
+			Channel:  contextID,
+			Text:     text,
+			ThreadTS: threadID,
+		}
+		if _, err := m.client.PostMessage(ctx, msg); err != nil {
+			return fmt.Errorf("send chunk %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// AcknowledgeCallback is a no-op for Slack (callbacks are acknowledged via HTTP response).
+func (m *SlackMessenger) AcknowledgeCallback(_ context.Context, _ string) error {
+	return nil
+}
+
+// MaxMessageLength returns Slack's practical max message length.
+func (m *SlackMessenger) MaxMessageLength() int {
+	return 3800
+}

--- a/internal/adapters/slack/messenger_test.go
+++ b/internal/adapters/slack/messenger_test.go
@@ -1,0 +1,191 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/comms"
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+// Compile-time interface check.
+var _ comms.Messenger = (*SlackMessenger)(nil)
+
+func newTestSlackMessenger(t *testing.T, handler http.HandlerFunc) *SlackMessenger {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	client := NewClientWithBaseURL(testutil.FakeSlackBotToken, srv.URL)
+	return NewMessenger(client)
+}
+
+func slackOKHandler(ts string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(PostMessageResponse{
+			OK:      true,
+			TS:      ts,
+			Channel: "C123",
+		})
+	}
+}
+
+func TestSlackMessenger_SendText(t *testing.T) {
+	var captured string
+	m := newTestSlackMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+		var msg Message
+		_ = json.NewDecoder(r.Body).Decode(&msg)
+		captured = msg.Text
+		_ = json.NewEncoder(w).Encode(PostMessageResponse{OK: true, TS: "1234.5678", Channel: msg.Channel})
+	})
+
+	err := m.SendText(context.Background(), "C123", "hello slack")
+	if err != nil {
+		t.Fatalf("SendText returned error: %v", err)
+	}
+	if captured != "hello slack" {
+		t.Errorf("expected text %q, got %q", "hello slack", captured)
+	}
+}
+
+func TestSlackMessenger_SendConfirmation(t *testing.T) {
+	m := newTestSlackMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+		var raw map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&raw)
+		if raw["blocks"] == nil {
+			t.Error("expected blocks in request")
+		}
+		_ = json.NewEncoder(w).Encode(PostMessageResponse{OK: true, TS: "1234.5678", Channel: "C123"})
+	})
+
+	ref, err := m.SendConfirmation(context.Background(), "C123", "", "TASK-1", "Add feature", "/project")
+	if err != nil {
+		t.Fatalf("SendConfirmation returned error: %v", err)
+	}
+	if ref != "1234.5678" {
+		t.Errorf("expected messageRef %q, got %q", "1234.5678", ref)
+	}
+}
+
+func TestSlackMessenger_SendProgress(t *testing.T) {
+	var updatedText string
+	m := newTestSlackMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "chat.update") {
+			var raw map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&raw)
+			updatedText, _ = raw["text"].(string)
+		}
+		_ = json.NewEncoder(w).Encode(struct {
+			OK bool `json:"ok"`
+		}{OK: true})
+	})
+
+	newRef, err := m.SendProgress(context.Background(), "C123", "1234.5678", "TASK-1", "Implementing", 50, "writing code")
+	if err != nil {
+		t.Fatalf("SendProgress returned error: %v", err)
+	}
+	if newRef != "1234.5678" {
+		t.Errorf("expected same messageRef %q, got %q", "1234.5678", newRef)
+	}
+	if !strings.Contains(updatedText, "50%") {
+		t.Errorf("expected progress text to contain '50%%', got %q", updatedText)
+	}
+}
+
+func TestSlackMessenger_SendResult(t *testing.T) {
+	tests := []struct {
+		name    string
+		success bool
+		output  string
+		prURL   string
+	}{
+		{
+			name:    "success with PR",
+			success: true,
+			output:  "All done",
+			prURL:   "https://github.com/org/repo/pull/1",
+		},
+		{
+			name:    "failure no PR",
+			success: false,
+			output:  "build failed",
+			prURL:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestSlackMessenger(t, slackOKHandler("1234.5678"))
+
+			err := m.SendResult(context.Background(), "C123", "", "TASK-1", tt.success, tt.output, tt.prURL)
+			if err != nil {
+				t.Fatalf("SendResult returned error: %v", err)
+			}
+		})
+	}
+}
+
+func TestSlackMessenger_SendChunked(t *testing.T) {
+	var messageCount int
+	m := newTestSlackMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+		messageCount++
+		_ = json.NewEncoder(w).Encode(PostMessageResponse{OK: true, TS: "ts", Channel: "C123"})
+	})
+
+	// Short content → single message
+	messageCount = 0
+	err := m.SendChunked(context.Background(), "C123", "", "short content", "prefix")
+	if err != nil {
+		t.Fatalf("SendChunked returned error: %v", err)
+	}
+	if messageCount != 1 {
+		t.Errorf("expected 1 message for short content, got %d", messageCount)
+	}
+
+	// Long content → multiple messages
+	messageCount = 0
+	longContent := strings.Repeat("x", 5000)
+	err = m.SendChunked(context.Background(), "C123", "thread-ts", longContent, "")
+	if err != nil {
+		t.Fatalf("SendChunked returned error: %v", err)
+	}
+	if messageCount < 2 {
+		t.Errorf("expected multiple messages for long content, got %d", messageCount)
+	}
+}
+
+func TestSlackMessenger_SendChunked_WithThread(t *testing.T) {
+	var capturedThreadTS string
+	m := newTestSlackMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+		var msg Message
+		_ = json.NewDecoder(r.Body).Decode(&msg)
+		capturedThreadTS = msg.ThreadTS
+		_ = json.NewEncoder(w).Encode(PostMessageResponse{OK: true, TS: "ts", Channel: "C123"})
+	})
+
+	err := m.SendChunked(context.Background(), "C123", "parent-ts", "content", "")
+	if err != nil {
+		t.Fatalf("SendChunked returned error: %v", err)
+	}
+	if capturedThreadTS != "parent-ts" {
+		t.Errorf("expected threadTS %q, got %q", "parent-ts", capturedThreadTS)
+	}
+}
+
+func TestSlackMessenger_AcknowledgeCallback(t *testing.T) {
+	m := &SlackMessenger{}
+	err := m.AcknowledgeCallback(context.Background(), "cb-123")
+	if err != nil {
+		t.Fatalf("AcknowledgeCallback should be no-op, got error: %v", err)
+	}
+}
+
+func TestSlackMessenger_MaxMessageLength(t *testing.T) {
+	m := &SlackMessenger{}
+	if got := m.MaxMessageLength(); got != 3800 {
+		t.Errorf("expected 3800, got %d", got)
+	}
+}

--- a/internal/adapters/telegram/messenger.go
+++ b/internal/adapters/telegram/messenger.go
@@ -1,0 +1,130 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/alekspetrov/pilot/internal/comms"
+)
+
+// Compile-time check that TelegramMessenger implements comms.Messenger.
+var _ comms.Messenger = (*TelegramMessenger)(nil)
+
+// TelegramMessenger implements comms.Messenger by wrapping the Telegram Client.
+type TelegramMessenger struct {
+	client        *Client
+	plainTextMode bool
+}
+
+// NewMessenger creates a TelegramMessenger wrapping the given client.
+func NewMessenger(client *Client, plainTextMode bool) *TelegramMessenger {
+	return &TelegramMessenger{
+		client:        client,
+		plainTextMode: plainTextMode,
+	}
+}
+
+// parseMode returns the Telegram parse mode string.
+func (m *TelegramMessenger) parseMode() string {
+	if m.plainTextMode {
+		return ""
+	}
+	return "Markdown"
+}
+
+// SendText sends a plain text message to the given chat.
+func (m *TelegramMessenger) SendText(ctx context.Context, contextID, text string) error {
+	_, err := m.client.SendMessage(ctx, contextID, text, m.parseMode())
+	return err
+}
+
+// SendConfirmation sends a task confirmation prompt with approve/reject buttons.
+// Returns a string messageRef (the Telegram message ID).
+func (m *TelegramMessenger) SendConfirmation(ctx context.Context, contextID, threadID, taskID, desc, project string) (string, error) {
+	text := FormatTaskConfirmation(taskID, desc, project)
+
+	keyboard := [][]InlineKeyboardButton{
+		{
+			{Text: "✅ Execute", CallbackData: "execute_task:" + taskID},
+			{Text: "❌ Cancel", CallbackData: "cancel_task:" + taskID},
+		},
+	}
+
+	resp, err := m.client.SendMessageWithKeyboard(ctx, contextID, text, m.parseMode(), keyboard)
+	if err != nil {
+		return "", fmt.Errorf("send confirmation: %w", err)
+	}
+	if resp == nil || resp.Result == nil {
+		return "", fmt.Errorf("send confirmation: nil response")
+	}
+	return strconv.FormatInt(resp.Result.MessageID, 10), nil
+}
+
+// SendProgress updates the existing confirmation message with progress info.
+// Returns the same messageRef (Telegram edits in place).
+func (m *TelegramMessenger) SendProgress(ctx context.Context, contextID, messageRef, taskID, phase string, progress int, detail string) (string, error) {
+	text := FormatProgressUpdate(taskID, phase, progress, detail)
+
+	msgID, err := strconv.ParseInt(messageRef, 10, 64)
+	if err != nil {
+		return messageRef, fmt.Errorf("parse message ref: %w", err)
+	}
+
+	if err := m.client.EditMessage(ctx, contextID, msgID, text, m.parseMode()); err != nil {
+		return messageRef, fmt.Errorf("send progress: %w", err)
+	}
+	return messageRef, nil
+}
+
+// SendResult sends the final task result.
+func (m *TelegramMessenger) SendResult(ctx context.Context, contextID, threadID, taskID string, success bool, output, prURL string) error {
+	var icon, status string
+	if success {
+		icon = "✅"
+		status = "completed"
+	} else {
+		icon = "❌"
+		status = "failed"
+	}
+
+	text := fmt.Sprintf("%s Task %s: %s", icon, status, taskID)
+	if output != "" {
+		clean := cleanInternalSignals(output)
+		if len(clean) > 3000 {
+			clean = clean[:3000] + "..."
+		}
+		text += "\n\n" + clean
+	}
+	if prURL != "" {
+		text += fmt.Sprintf("\n\n🔗 PR: %s", prURL)
+	}
+
+	_, err := m.client.SendMessage(ctx, contextID, text, m.parseMode())
+	return err
+}
+
+// SendChunked sends long content split into platform-appropriate chunks.
+func (m *TelegramMessenger) SendChunked(ctx context.Context, contextID, threadID, content, prefix string) error {
+	chunks := chunkContent(content, m.MaxMessageLength())
+	for i, chunk := range chunks {
+		text := chunk
+		if prefix != "" && i == 0 {
+			text = prefix + "\n\n" + chunk
+		}
+		if _, err := m.client.SendMessage(ctx, contextID, text, m.parseMode()); err != nil {
+			return fmt.Errorf("send chunk %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// AcknowledgeCallback responds to a button callback interaction.
+func (m *TelegramMessenger) AcknowledgeCallback(ctx context.Context, callbackID string) error {
+	return m.client.AnswerCallback(ctx, callbackID, "")
+}
+
+// MaxMessageLength returns Telegram's practical max message length.
+func (m *TelegramMessenger) MaxMessageLength() int {
+	return 4000
+}

--- a/internal/adapters/telegram/messenger_test.go
+++ b/internal/adapters/telegram/messenger_test.go
@@ -1,0 +1,213 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/comms"
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+// Compile-time interface check.
+var _ comms.Messenger = (*TelegramMessenger)(nil)
+
+func newTestMessenger(t *testing.T, handler http.HandlerFunc) *TelegramMessenger {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	client := NewClientWithBaseURL(testutil.FakeTelegramBotToken, srv.URL)
+	return NewMessenger(client, true)
+}
+
+func okHandler(msgID int64) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(SendMessageResponse{
+			OK:     true,
+			Result: &Result{MessageID: msgID},
+		})
+	}
+}
+
+func TestTelegramMessenger_SendText(t *testing.T) {
+	var captured string
+	m := newTestMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+		var req SendMessageRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		captured = req.Text
+		_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: true, Result: &Result{MessageID: 1}})
+	})
+
+	err := m.SendText(context.Background(), "123", "hello world")
+	if err != nil {
+		t.Fatalf("SendText returned error: %v", err)
+	}
+	if captured != "hello world" {
+		t.Errorf("expected text %q, got %q", "hello world", captured)
+	}
+}
+
+func TestTelegramMessenger_SendConfirmation(t *testing.T) {
+	m := newTestMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+		// Verify keyboard was sent
+		body, _ := json.Marshal(map[string]interface{}{})
+		_ = body
+		var raw map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&raw)
+		if raw["reply_markup"] == nil {
+			t.Error("expected reply_markup in request")
+		}
+		_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: true, Result: &Result{MessageID: 42}})
+	})
+
+	ref, err := m.SendConfirmation(context.Background(), "123", "", "TASK-1", "Add feature", "/project")
+	if err != nil {
+		t.Fatalf("SendConfirmation returned error: %v", err)
+	}
+	if ref != "42" {
+		t.Errorf("expected messageRef %q, got %q", "42", ref)
+	}
+}
+
+func TestTelegramMessenger_SendProgress(t *testing.T) {
+	var editedText string
+	m := newTestMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "editMessageText") {
+			var raw map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&raw)
+			editedText, _ = raw["text"].(string)
+		}
+		_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: true, Result: &Result{MessageID: 42}})
+	})
+
+	newRef, err := m.SendProgress(context.Background(), "123", "42", "TASK-1", "Implementing", 50, "writing code")
+	if err != nil {
+		t.Fatalf("SendProgress returned error: %v", err)
+	}
+	if newRef != "42" {
+		t.Errorf("expected same messageRef %q, got %q", "42", newRef)
+	}
+	if editedText == "" {
+		t.Error("expected edit request to be sent")
+	}
+	if !strings.Contains(editedText, "50%") {
+		t.Errorf("expected progress text to contain '50%%', got %q", editedText)
+	}
+}
+
+func TestTelegramMessenger_SendProgress_InvalidRef(t *testing.T) {
+	m := newTestMessenger(t, okHandler(1))
+
+	_, err := m.SendProgress(context.Background(), "123", "not-a-number", "TASK-1", "Testing", 10, "")
+	if err == nil {
+		t.Fatal("expected error for invalid messageRef")
+	}
+	if !strings.Contains(err.Error(), "parse message ref") {
+		t.Errorf("expected parse error, got: %v", err)
+	}
+}
+
+func TestTelegramMessenger_SendResult(t *testing.T) {
+	tests := []struct {
+		name    string
+		success bool
+		output  string
+		prURL   string
+		wantSub string
+	}{
+		{
+			name:    "success with PR",
+			success: true,
+			output:  "All done",
+			prURL:   "https://github.com/org/repo/pull/1",
+			wantSub: "✅",
+		},
+		{
+			name:    "failure no PR",
+			success: false,
+			output:  "build failed",
+			prURL:   "",
+			wantSub: "❌",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured string
+			m := newTestMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+				var req SendMessageRequest
+				_ = json.NewDecoder(r.Body).Decode(&req)
+				captured = req.Text
+				_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: true, Result: &Result{MessageID: 1}})
+			})
+
+			err := m.SendResult(context.Background(), "123", "", "TASK-1", tt.success, tt.output, tt.prURL)
+			if err != nil {
+				t.Fatalf("SendResult returned error: %v", err)
+			}
+			if !strings.Contains(captured, tt.wantSub) {
+				t.Errorf("expected text to contain %q, got %q", tt.wantSub, captured)
+			}
+			if tt.prURL != "" && !strings.Contains(captured, tt.prURL) {
+				t.Errorf("expected text to contain PR URL %q", tt.prURL)
+			}
+		})
+	}
+}
+
+func TestTelegramMessenger_SendChunked(t *testing.T) {
+	var messageCount int
+	m := newTestMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+		messageCount++
+		_ = json.NewEncoder(w).Encode(SendMessageResponse{OK: true, Result: &Result{MessageID: int64(messageCount)}})
+	})
+
+	// Short content → single message
+	messageCount = 0
+	err := m.SendChunked(context.Background(), "123", "", "short content", "prefix")
+	if err != nil {
+		t.Fatalf("SendChunked returned error: %v", err)
+	}
+	if messageCount != 1 {
+		t.Errorf("expected 1 message for short content, got %d", messageCount)
+	}
+
+	// Long content → multiple messages
+	messageCount = 0
+	longContent := strings.Repeat("x", 5000)
+	err = m.SendChunked(context.Background(), "123", "", longContent, "")
+	if err != nil {
+		t.Fatalf("SendChunked returned error: %v", err)
+	}
+	if messageCount < 2 {
+		t.Errorf("expected multiple messages for long content, got %d", messageCount)
+	}
+}
+
+func TestTelegramMessenger_AcknowledgeCallback(t *testing.T) {
+	var called bool
+	m := newTestMessenger(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "answerCallbackQuery") {
+			called = true
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := m.AcknowledgeCallback(context.Background(), "cb-123")
+	if err != nil {
+		t.Fatalf("AcknowledgeCallback returned error: %v", err)
+	}
+	if !called {
+		t.Error("expected answerCallbackQuery to be called")
+	}
+}
+
+func TestTelegramMessenger_MaxMessageLength(t *testing.T) {
+	m := &TelegramMessenger{}
+	if got := m.MaxMessageLength(); got != 4000 {
+		t.Errorf("expected 4000, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1787.

Closes #1787

## Changes

GitHub Issue #1787: refactor(comms): Implement TelegramMessenger and SlackMessenger for comms.Messenger

## Follow-up: Comms Module Migration (was GH-1758 + GH-1759)

Previous PRs were closed without landing messenger files on main. Neither `telegram/messenger.go` nor `slack/messenger.go` exist.

## Task

Create platform-specific Messenger implementations that wrap existing API clients.

## Changes

### 1. Create `internal/adapters/telegram/messenger.go` (~120 lines)

```go
type TelegramMessenger struct {
    client        *Client
    plainTextMode bool
}

func (m *TelegramMessenger) SendText(ctx, contextID, text) error
func (m *TelegramMessenger) SendConfirmation(ctx, contextID, threadID, taskID, desc, project) (messageRef, error)
func (m *TelegramMessenger) SendProgress(ctx, contextID, messageRef, taskID, phase, progress, detail) (newRef, error)
func (m *TelegramMessenger) SendResult(ctx, contextID, threadID, taskID, success, output, prURL) error
func (m *TelegramMessenger) SendChunked(ctx, contextID, threadID, content, prefix) error
func (m *TelegramMessenger) AcknowledgeCallback(ctx, callbackID) error
func (m *TelegramMessenger) MaxMessageLength() int  // 4000
```

- Wraps existing `Client` methods + `formatter.go` functions
- Telegram int64 message IDs → string `messageRef` conversion at boundary
- Tests in `messenger_test.go`

### 2. Create `internal/adapters/slack/messenger.go` (~120 lines)

```go
type SlackMessenger struct {
    client *Client
}

func (m *SlackMessenger) SendText(ctx, contextID, text) error
func (m *SlackMessenger) SendConfirmation(ctx, contextID, threadID, taskID, desc, project) (messageRef, error)
func (m *SlackMessenger) SendProgress(ctx, contextID, messageRef, taskID, phase, progress, detail) (newRef, error)
func (m *SlackMessenger) SendResult(ctx, contextID, threadID, taskID, success, output, prURL) error
func (m *SlackMessenger) SendChunked(ctx, contextID, threadID, content, prefix) error
func (m *SlackMessenger) AcknowledgeCallback(ctx, callbackID) error  // no-op for Slack
func (m *SlackMessenger) MaxMessageLength() int  // 3800
```

- Wraps existing `Client` + Block Kit formatter
- Slack timestamps are already strings — no conversion needed
- Thread support via threadTS
- Tests in `messenger_test.go`

## Interface Reference

`comms.Messenger` is defined in `internal/comms/types.go` (already on main).

## Verification

- `make build` compiles
- `make test` passes
- Both messengers satisfy `comms.Messenger` interface (compile-time check)