### PR TITLE
fix(poller): Default execution mode should be sequential, not parallel

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -170,7 +170,7 @@ func NewPoller(client *Client, repo string, label string, interval time.Duration
 		interval:       interval,
 		processed:      make(map[int]bool),
 		logger:         logging.WithComponent("github-poller"),
-		executionMode:  ExecutionModeParallel, // Default for backward compatibility
+		executionMode:  ExecutionModeSequential, // Default matches config.DefaultExecutionConfig()
 		waitForMerge:   true,
 		prPollInterval: 30 * time.Second,
 		prTimeout:      1 * time.Hour,

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -634,13 +634,13 @@ func TestWithExecutionMode(t *testing.T) {
 		}
 	})
 
-	t.Run("default is parallel for backward compatibility", func(t *testing.T) {
+	t.Run("default is sequential matching config default", func(t *testing.T) {
 		poller, err := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 		if err != nil {
 			t.Fatalf("NewPoller() error = %v", err)
 		}
-		if poller.executionMode != ExecutionModeParallel {
-			t.Errorf("default executionMode = %v, want %v", poller.executionMode, ExecutionModeParallel)
+		if poller.executionMode != ExecutionModeSequential {
+			t.Errorf("default executionMode = %v, want %v", poller.executionMode, ExecutionModeSequential)
 		}
 	})
 }

--- a/stress/memory_test.go
+++ b/stress/memory_test.go
@@ -164,6 +164,7 @@ func TestMemory_ProcessedMapGrowth(t *testing.T) {
 		"owner/repo",
 		"pilot",
 		10*time.Millisecond,
+		github.WithExecutionMode(github.ExecutionModeParallel),
 		github.WithMaxConcurrent(20),
 		github.WithOnIssue(func(ctx context.Context, issue *github.Issue) error {
 			atomic.AddInt64(&processedCount, 1)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1793.

Closes #1793

## Changes

GitHub Issue #1793: fix(poller): Default execution mode should be sequential, not parallel

## Pipeline Hardening 1/7

## Problem

`DefaultExecutionConfig()` returns `Mode: "sequential"` (config.go:101) but `NewPoller()` defaults to `ExecutionModeParallel` (poller.go:173). When config doesn't explicitly set execution mode, the poller silently uses parallel — causing cascade failures when multiple issues touch the same package.

This mismatch caused the comms refactor failure: 10 sequential issues dispatched in parallel, 7/15 PRs closed.

## Fix

In `internal/adapters/github/poller.go` line 173, change:
```go
executionMode:  ExecutionModeParallel, // Default for backward compatibility
```
to:
```go
executionMode:  ExecutionModeSequential, // Default matches config.DefaultExecutionConfig()
```

Also update any tests that assume parallel default.

## Files

- `internal/adapters/github/poller.go` — line 173
- `internal/adapters/github/poller_test.go` — update tests if needed

## Verification

- `make build && make test && make lint`
- Verify `NewPoller()` without `WithExecutionMode()` starts in sequential mode