### PR TITLE
Extract directory-scope utilities into `internal/executor/scope.go`

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -229,24 +229,9 @@ func isSinglePackageScope(subtasks []PlannedSubtask, taskDescription string) boo
 }
 
 // extractUniqueDirectories finds file paths in text and returns their unique parent directories.
+// Delegates to the shared ExtractDirectoriesFromText (scope.go) for reuse across packages.
 func extractUniqueDirectories(text string) map[string]bool {
-	// Reuse the existing file path pattern from the decomposer
-	filePattern := regexp.MustCompile(`\b((?:[\w\-]+/)+[\w\-]+\.(?:go|py|ts|tsx|js|jsx|rs|java|rb))\b`)
-	matches := filePattern.FindAllStringSubmatch(text, -1)
-
-	dirs := make(map[string]bool)
-	for _, m := range matches {
-		if len(m) < 2 {
-			continue
-		}
-		filePath := m[1]
-		// Extract directory: "cmd/pilot/onboard.go" → "cmd/pilot"
-		lastSlash := strings.LastIndex(filePath, "/")
-		if lastSlash > 0 {
-			dirs[filePath[:lastSlash]] = true
-		}
-	}
-	return dirs
+	return ExtractDirectoriesFromText(text)
 }
 
 // detectSameComponentFromTitles checks if subtask titles all reference the same component.

--- a/internal/executor/scope.go
+++ b/internal/executor/scope.go
@@ -1,0 +1,64 @@
+package executor
+
+import (
+	"regexp"
+	"strings"
+)
+
+// filePathPattern matches file paths with common source-code extensions.
+// Examples: internal/executor/runner.go, src/app/main.ts, lib/utils.py
+var filePathPattern = regexp.MustCompile(`\b((?:[\w\-]+/)+[\w\-]+\.(?:go|py|ts|tsx|js|jsx|rs|java|rb|css|scss|html|yaml|yml|json|toml|sql|sh|md))\b`)
+
+// dirOnlyPattern matches directory-only references ending with a slash.
+// Examples: internal/comms/, src/utils/, cmd/pilot/
+var dirOnlyPattern = regexp.MustCompile(`\b((?:[\w\-]+/)+[\w\-]+/)(?:\s|$|[),;:"'])`)
+
+// ExtractDirectoriesFromText finds file paths and directory references in text
+// and returns their unique parent directories. Handles both file paths
+// (e.g., "internal/executor/runner.go" → "internal/executor") and bare directory
+// references (e.g., "internal/comms/" → "internal/comms").
+func ExtractDirectoriesFromText(text string) map[string]bool {
+	dirs := make(map[string]bool)
+
+	// Extract directories from file paths
+	matches := filePathPattern.FindAllStringSubmatch(text, -1)
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		filePath := m[1]
+		lastSlash := strings.LastIndex(filePath, "/")
+		if lastSlash > 0 {
+			dirs[filePath[:lastSlash]] = true
+		}
+	}
+
+	// Extract bare directory references (e.g., "internal/comms/")
+	dirMatches := dirOnlyPattern.FindAllStringSubmatch(text, -1)
+	for _, m := range dirMatches {
+		if len(m) < 2 {
+			continue
+		}
+		// Trim trailing slash
+		dir := strings.TrimRight(m[1], "/")
+		if dir != "" {
+			dirs[dir] = true
+		}
+	}
+
+	return dirs
+}
+
+// IssuesOverlap returns true if two issue bodies reference at least one common
+// directory, indicating they may cause merge conflicts when executed in parallel.
+func IssuesOverlap(bodyA, bodyB string) bool {
+	dirsA := ExtractDirectoriesFromText(bodyA)
+	dirsB := ExtractDirectoriesFromText(bodyB)
+
+	for dir := range dirsA {
+		if dirsB[dir] {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/executor/scope_test.go
+++ b/internal/executor/scope_test.go
@@ -1,0 +1,146 @@
+package executor
+
+import (
+	"testing"
+)
+
+func TestExtractDirectoriesFromText(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want map[string]bool
+	}{
+		{
+			name: "go files",
+			text: "Modify internal/executor/runner.go and internal/executor/monitor.go",
+			want: map[string]bool{"internal/executor": true},
+		},
+		{
+			name: "python files",
+			text: "Update orchestrator/planner.py to add new logic",
+			want: map[string]bool{"orchestrator": true},
+		},
+		{
+			name: "typescript files",
+			text: "Edit src/components/App.tsx and src/utils/helpers.ts",
+			want: map[string]bool{"src/components": true, "src/utils": true},
+		},
+		{
+			name: "multiple extensions",
+			text: "Change internal/gateway/server.go, docs/api/spec.yaml, scripts/deploy.sh",
+			want: map[string]bool{"internal/gateway": true, "docs/api": true, "scripts": true},
+		},
+		{
+			name: "same directory collapses",
+			text: "internal/alerts/engine.go internal/alerts/dispatcher.go internal/alerts/channels.go",
+			want: map[string]bool{"internal/alerts": true},
+		},
+		{
+			name: "no file paths returns empty",
+			text: "Add rate limiting to API endpoints. Improve performance and caching.",
+			want: map[string]bool{},
+		},
+		{
+			name: "directory-only reference with trailing slash",
+			text: "All changes are in internal/comms/ directory",
+			want: map[string]bool{"internal/comms": true},
+		},
+		{
+			name: "mixed file paths and directory references",
+			text: "Update internal/executor/runner.go and also touch internal/config/",
+			want: map[string]bool{"internal/executor": true, "internal/config": true},
+		},
+		{
+			name: "rust and java files",
+			text: "Modify src/lib/parser.rs and src/main/App.java",
+			want: map[string]bool{"src/lib": true, "src/main": true},
+		},
+		{
+			name: "css and html files",
+			text: "Update styles/theme.css and templates/index.html",
+			want: map[string]bool{"styles": true, "templates": true},
+		},
+		{
+			name: "json and toml config files",
+			text: "Edit configs/app.json and configs/settings.toml",
+			want: map[string]bool{"configs": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractDirectoriesFromText(tt.text)
+			if len(got) != len(tt.want) {
+				t.Errorf("ExtractDirectoriesFromText() returned %d dirs, want %d\n  got:  %v\n  want: %v",
+					len(got), len(tt.want), got, tt.want)
+				return
+			}
+			for dir := range tt.want {
+				if !got[dir] {
+					t.Errorf("ExtractDirectoriesFromText() missing directory %q\n  got: %v", dir, got)
+				}
+			}
+		})
+	}
+}
+
+func TestIssuesOverlap(t *testing.T) {
+	tests := []struct {
+		name  string
+		bodyA string
+		bodyB string
+		want  bool
+	}{
+		{
+			name:  "overlapping same directory",
+			bodyA: "Modify internal/executor/runner.go to add logging",
+			bodyB: "Update internal/executor/monitor.go for metrics",
+			want:  true,
+		},
+		{
+			name:  "disjoint directories",
+			bodyA: "Change internal/gateway/server.go",
+			bodyB: "Update internal/alerts/engine.go",
+			want:  false,
+		},
+		{
+			name:  "one body has no paths",
+			bodyA: "Add rate limiting to API endpoints",
+			bodyB: "Update internal/executor/runner.go",
+			want:  false,
+		},
+		{
+			name:  "both bodies have no paths",
+			bodyA: "Improve performance",
+			bodyB: "Add caching layer",
+			want:  false,
+		},
+		{
+			name:  "overlap via directory-only reference",
+			bodyA: "All work in internal/config/",
+			bodyB: "Edit internal/config/loader.go",
+			want:  true,
+		},
+		{
+			name:  "partial path overlap is not a match",
+			bodyA: "Edit internal/executor/runner.go",
+			bodyB: "Edit internal/executor-v2/runner.go",
+			want:  false,
+		},
+		{
+			name:  "multiple dirs with one overlap",
+			bodyA: "Change internal/gateway/server.go and internal/alerts/engine.go",
+			bodyB: "Update internal/alerts/dispatcher.go and internal/config/loader.go",
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IssuesOverlap(tt.bodyA, tt.bodyB)
+			if got != tt.want {
+				t.Errorf("IssuesOverlap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1805.

Closes #1805

## Changes

Create the new `scope.go` file with exported `ExtractDirectoriesFromText()` and `IssuesOverlap()` functions. Refactor the existing `extractUniqueDirectories()` in `epic.go` (line 232) to delegate to the new shared `ExtractDirectoriesFromText()`, preserving backward compatibility. Add comprehensive tests in `scope_test.go` covering: paths with various extensions (.go, .py, .ts, etc.), multiple files in the same directory collapsing to one entry, text with no file paths returning empty map, and `IssuesOverlap()` returning true/false correctly for overlapping and disjoint bodies. Also add a test for directory-only references (e.g. `internal/comms/` without a filename). Verify with `make build && make test && make lint` scoped to the executor package.