### PR TITLE
feat(executor): Add learning system fields and setters to Runner

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -27,7 +27,6 @@
 | Verbose output | ✅ | executor | `--verbose` | - | Stream raw JSON |
 | Task dispatcher | ✅ | executor | - | - | Per-project queue (GH-46) |
 | Sequential execution | ✅ | executor | `--sequential` | `orchestrator.execution.mode` | Wait for PR merge before next issue |
-| Auto execution mode | ✅ | poller | - | `orchestrator.execution.mode: auto` | Parallel dispatch with scope-overlap guard; default mode (GH-1799) |
 | Self-review | ✅ | executor | - | - | Auto code review before PR push (v0.13.0) |
 | Auto build gate | ✅ | executor | - | - | Minimal build gate when none configured (v0.13.0) |
 | Epic decomposition | ✅ | executor | - | `decompose.enabled` | PlanEpic + CreateSubIssues for complex tasks (v0.20.2) |
@@ -122,6 +121,7 @@
 | Knowledge graph | ✅ | memory | - | - | Internal only |
 | Knowledge store | ✅ | memory | - | - | Experiential memory with confidence tracking (v0.61.0) |
 | Profile manager | ✅ | memory | - | - | User preferences + correction learning (v0.61.0) |
+| Learning loop wiring | ✅ | executor | - | - | Runner fields + setters for learning loop & pattern context (GH-1811) |
 
 ## Dashboard
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -313,6 +313,9 @@ type Runner struct {
 	subIssueCreator       SubIssueCreator // Optional creator for sub-issues in external trackers
 	// GH-1599: Execution log store for milestone entries
 	logStore              *memory.Store // Optional log store for writing execution milestones
+	// GH-1811: Learning system (self-improvement)
+	learningLoop   *memory.LearningLoop // Optional learning loop for pattern extraction + feedback
+	patternContext *PatternContext       // Optional pattern context for prompt injection
 }
 
 // NewRunner creates a new Runner instance with Claude Code backend by default.
@@ -627,6 +630,16 @@ func (r *Runner) SetMonitor(m *Monitor) {
 // SetLogStore sets the memory store used for writing execution milestone log entries (GH-1599).
 func (r *Runner) SetLogStore(store *memory.Store) {
 	r.logStore = store
+}
+
+// SetLearningLoop sets the learning loop for post-execution pattern learning.
+func (r *Runner) SetLearningLoop(loop *memory.LearningLoop) {
+	r.learningLoop = loop
+}
+
+// SetPatternContext sets the pattern context for pre-execution pattern injection.
+func (r *Runner) SetPatternContext(ctx *PatternContext) {
+	r.patternContext = ctx
 }
 
 // saveLogEntry writes a structured log entry to the log store (fire-and-forget).


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1811.

Closes #1811

## Changes

GitHub Issue #1811: feat(executor): Add learning system fields and setters to Runner

## Wire Learning System 1/4

## Context

Pilot has a complete learning system in `internal/memory/` (pattern extraction, feedback loops, confidence decay, prompt injection) that is fully built and tested but entirely disconnected from the execution pipeline. This issue adds the Runner fields needed to wire it.

## Task

Add `learningLoop` and `patternContext` fields to the Runner struct with corresponding setter methods.

## Changes

In `internal/executor/runner.go`:

1. Add fields to Runner struct (after line ~315):
```go
// Learning system (self-improvement)
learningLoop   *memory.LearningLoop   // Optional learning loop for pattern extraction + feedback
patternContext *PatternContext          // Optional pattern context for prompt injection
```

2. Add setter methods:
```go
// SetLearningLoop sets the learning loop for post-execution pattern learning.
func (r *Runner) SetLearningLoop(loop *memory.LearningLoop) {
    r.learningLoop = loop
}

// SetPatternContext sets the pattern context for pre-execution pattern injection.
func (r *Runner) SetPatternContext(ctx *PatternContext) {
    r.patternContext = ctx
}
```

3. Import `memory` package if not already imported (it should be — `memory.KnowledgeStore` is already used).

## Files

- `internal/executor/runner.go` — add fields + setters

## Verification

- `make build && make test && make lint`
- No behavior change — just adding fields and setters