### PR TITLE
feat(executor): Record execution outcomes for pattern learning

### DIFF
--- a/internal/executor/learning.go
+++ b/internal/executor/learning.go
@@ -1,0 +1,14 @@
+package executor
+
+import (
+	"context"
+
+	"github.com/alekspetrov/pilot/internal/memory"
+)
+
+// LearningRecorder records execution outcomes for pattern learning.
+// This interface is satisfied by memory.LearningLoop and allows the executor
+// to record executions without tight coupling to the memory package implementation.
+type LearningRecorder interface {
+	RecordExecution(ctx context.Context, exec *memory.Execution, appliedPatterns []string) error
+}

--- a/internal/executor/learning_test.go
+++ b/internal/executor/learning_test.go
@@ -1,0 +1,191 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/memory"
+)
+
+// mockLearningRecorder implements LearningRecorder for testing.
+type mockLearningRecorder struct {
+	mu        sync.Mutex
+	calls     []*learningCall
+	returnErr error
+}
+
+type learningCall struct {
+	exec            *memory.Execution
+	appliedPatterns []string
+}
+
+func (m *mockLearningRecorder) RecordExecution(_ context.Context, exec *memory.Execution, appliedPatterns []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, &learningCall{exec: exec, appliedPatterns: appliedPatterns})
+	return m.returnErr
+}
+
+func TestRecordLearning_Success(t *testing.T) {
+	runner := NewRunner()
+	mock := &mockLearningRecorder{}
+	runner.SetLearningLoop(mock)
+
+	task := &Task{
+		ID:          "task-success",
+		Title:       "Test task",
+		ProjectPath: "/tmp/test-project",
+	}
+
+	result := &ExecutionResult{
+		Success:      true,
+		Output:       "all tests passed",
+		Duration:     5 * time.Second,
+		PRUrl:        "https://github.com/org/repo/pull/42",
+		CommitSHA:    "abc123",
+		TokensInput:  1000,
+		TokensOutput: 500,
+		FilesChanged: 3,
+		ModelName:    "claude-sonnet-4-5-20250514",
+	}
+
+	runner.recordLearning(context.Background(), task, result)
+
+	if len(mock.calls) != 1 {
+		t.Fatalf("expected 1 RecordExecution call, got %d", len(mock.calls))
+	}
+
+	call := mock.calls[0]
+	if call.exec.Status != "completed" {
+		t.Errorf("status = %q, want %q", call.exec.Status, "completed")
+	}
+	if call.exec.TaskID != "task-success" {
+		t.Errorf("taskID = %q, want %q", call.exec.TaskID, "task-success")
+	}
+	if call.exec.ProjectPath != "/tmp/test-project" {
+		t.Errorf("projectPath = %q, want %q", call.exec.ProjectPath, "/tmp/test-project")
+	}
+	if call.exec.Output != "all tests passed" {
+		t.Errorf("output = %q, want %q", call.exec.Output, "all tests passed")
+	}
+	if call.exec.PRUrl != "https://github.com/org/repo/pull/42" {
+		t.Errorf("prUrl = %q, want %q", call.exec.PRUrl, "https://github.com/org/repo/pull/42")
+	}
+	if call.exec.CommitSHA != "abc123" {
+		t.Errorf("commitSHA = %q, want %q", call.exec.CommitSHA, "abc123")
+	}
+	if call.exec.DurationMs != 5000 {
+		t.Errorf("durationMs = %d, want %d", call.exec.DurationMs, 5000)
+	}
+	if call.exec.TokensInput != 1000 {
+		t.Errorf("tokensInput = %d, want %d", call.exec.TokensInput, 1000)
+	}
+	if call.exec.TokensOutput != 500 {
+		t.Errorf("tokensOutput = %d, want %d", call.exec.TokensOutput, 500)
+	}
+	if call.exec.FilesChanged != 3 {
+		t.Errorf("filesChanged = %d, want %d", call.exec.FilesChanged, 3)
+	}
+	if call.exec.ModelName != "claude-sonnet-4-5-20250514" {
+		t.Errorf("modelName = %q, want %q", call.exec.ModelName, "claude-sonnet-4-5-20250514")
+	}
+	if call.appliedPatterns != nil {
+		t.Errorf("appliedPatterns = %v, want nil", call.appliedPatterns)
+	}
+}
+
+func TestRecordLearning_Failure(t *testing.T) {
+	runner := NewRunner()
+	mock := &mockLearningRecorder{}
+	runner.SetLearningLoop(mock)
+
+	task := &Task{
+		ID:          "task-failure",
+		Title:       "Failing task",
+		ProjectPath: "/tmp/test-project",
+	}
+
+	result := &ExecutionResult{
+		Success:      false,
+		Error:        "compilation failed",
+		Output:       "error: undefined variable",
+		Duration:     2 * time.Second,
+		TokensInput:  800,
+		TokensOutput: 200,
+		FilesChanged: 1,
+		ModelName:    "claude-sonnet-4-5-20250514",
+	}
+
+	runner.recordLearning(context.Background(), task, result)
+
+	if len(mock.calls) != 1 {
+		t.Fatalf("expected 1 RecordExecution call, got %d", len(mock.calls))
+	}
+
+	call := mock.calls[0]
+	if call.exec.Status != "failed" {
+		t.Errorf("status = %q, want %q", call.exec.Status, "failed")
+	}
+	if call.exec.Error != "compilation failed" {
+		t.Errorf("error = %q, want %q", call.exec.Error, "compilation failed")
+	}
+	if call.exec.TaskID != "task-failure" {
+		t.Errorf("taskID = %q, want %q", call.exec.TaskID, "task-failure")
+	}
+}
+
+func TestRecordLearning_NilLearningLoop(t *testing.T) {
+	runner := NewRunner()
+	// learningLoop is nil by default
+
+	task := &Task{
+		ID:          "task-nil",
+		Title:       "Test nil loop",
+		ProjectPath: "/tmp/test",
+	}
+
+	result := &ExecutionResult{
+		Success:  true,
+		Output:   "done",
+		Duration: time.Second,
+	}
+
+	// Should not panic
+	runner.recordLearning(context.Background(), task, result)
+}
+
+func TestRecordLearning_ErrorDoesNotPanic(t *testing.T) {
+	runner := NewRunner()
+	mock := &mockLearningRecorder{
+		returnErr: fmt.Errorf("database connection lost"),
+	}
+	runner.SetLearningLoop(mock)
+
+	task := &Task{
+		ID:          "task-learn-err",
+		Title:       "Test learning error",
+		ProjectPath: "/tmp/test",
+	}
+
+	result := &ExecutionResult{
+		Success:  true,
+		Output:   "all good",
+		Duration: time.Second,
+	}
+
+	// Should not panic - error is logged but not propagated
+	runner.recordLearning(context.Background(), task, result)
+
+	if len(mock.calls) != 1 {
+		t.Fatalf("expected RecordExecution to still be called, got %d calls", len(mock.calls))
+	}
+}
+
+func TestLearningRecorder_Interface(t *testing.T) {
+	// Verify that *memory.LearningLoop satisfies the LearningRecorder interface
+	// at compile time. This is a compile-time check only.
+	var _ LearningRecorder = (*memory.LearningLoop)(nil)
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1813.

Closes #1813

## Changes

GitHub Issue #1813: feat(executor): Record execution outcomes for pattern learning

## Wire Learning System 3/4

Depends on: #1811

## Context

`LearningLoop.RecordExecution()` exists in `internal/memory/feedback.go` — it records pattern feedback (success boosts confidence, failure decreases it) and triggers pattern extraction from output on success. Never called.

## Task

After execution completes in `runner.go`, call `RecordExecution()` to learn from every task.

## Changes

In `internal/executor/runner.go`, after the knowledge store block (~line 2593, before `return result, nil`):

```go
// Learn from execution (self-improvement)
if r.learningLoop != nil {
    statusStr := "completed"
    if !result.Success {
        statusStr = "failed"
    }
    exec := &memory.Execution{
        ID:               task.ID,
        TaskID:           task.ID,
        ProjectPath:      task.ProjectPath,
        Status:           statusStr,
        Output:           result.Output,
        Error:            result.Error,
        DurationMs:       result.Duration.Milliseconds(),
        PRUrl:            result.PRUrl,
        CommitSHA:        result.CommitSHA,
        TokensInput:      result.TokensInput,
        TokensOutput:     result.TokensOutput,
        FilesChanged:     result.FilesChanged,
        ModelName:        modelName,
    }
    if learnErr := r.learningLoop.RecordExecution(ctx, exec, nil); learnErr != nil {
        log.Warn("Failed to record execution for learning", slog.Any("error", learnErr))
    }
}
```

`RecordExecution` does:
- Records pattern feedback for applied patterns (confidence adjustment)
- On success: triggers `extractor.ExtractAndSave()` to discover new patterns
- On failure: extracts error patterns (anti-patterns)
- All non-fatal — execution already complete

Note: `modelName` variable is available in scope from the model selection logic earlier in the function. Check the exact variable name — may be `modelName`, `selectedModel`, or `r.config.Model`.

## Files

- `internal/executor/runner.go` — add learning hook after ~line 2593

## Verification

- `make build && make test && make lint`
- Unit test: with mock learning loop, verify RecordExecution called after success
- Unit test: verify RecordExecution called after failure with status="failed"
- Unit test: verify nil learningLoop doesn't panic