### PR TITLE
feat(adapters): Add Plane.so types, config, and REST client

### DIFF
--- a/internal/adapters/plane/client_test.go
+++ b/internal/adapters/plane/client_test.go
@@ -1,0 +1,314 @@
+package plane
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestNewClient(t *testing.T) {
+	c := NewClient("https://api.plane.so/", testutil.FakePlaneAPIKey)
+	if c.baseURL != "https://api.plane.so" {
+		t.Errorf("expected trailing slash stripped, got %s", c.baseURL)
+	}
+	if c.apiKey != testutil.FakePlaneAPIKey {
+		t.Errorf("expected apiKey %s, got %s", testutil.FakePlaneAPIKey, c.apiKey)
+	}
+}
+
+func TestNewClientWithOption(t *testing.T) {
+	custom := &http.Client{}
+	c := NewClient("https://plane.example.com", testutil.FakePlaneAPIKey, WithHTTPClient(custom))
+	if c.httpClient != custom {
+		t.Error("expected custom HTTP client to be set")
+	}
+}
+
+func TestListWorkItems(t *testing.T) {
+	tests := []struct {
+		name      string
+		labelID   string
+		wantPath  string
+		items     []WorkItem
+		wantCount int
+	}{
+		{
+			name:     "without label filter",
+			labelID:  "",
+			wantPath: "/api/v1/workspaces/ws/projects/proj-1/work-items/",
+			items: []WorkItem{
+				{ID: "wi-1", Name: "First"},
+				{ID: "wi-2", Name: "Second"},
+			},
+			wantCount: 2,
+		},
+		{
+			name:     "with label filter",
+			labelID:  "lbl-abc",
+			wantPath: "/api/v1/workspaces/ws/projects/proj-1/work-items/?label=lbl-abc",
+			items: []WorkItem{
+				{ID: "wi-3", Name: "Filtered"},
+			},
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("X-API-Key") != testutil.FakePlaneAPIKey {
+					http.Error(w, "unauthorized", http.StatusUnauthorized)
+					return
+				}
+				if r.URL.RequestURI() != tt.wantPath {
+					t.Errorf("unexpected path: got %s, want %s", r.URL.RequestURI(), tt.wantPath)
+				}
+				resp := paginatedResponse{Results: tt.items, TotalCount: len(tt.items)}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+			}))
+			defer srv.Close()
+
+			c := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+			items, err := c.ListWorkItems(context.Background(), "ws", "proj-1", tt.labelID)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(items) != tt.wantCount {
+				t.Errorf("got %d items, want %d", len(items), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestGetWorkItem(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		wantPath := "/api/v1/workspaces/ws/projects/proj-1/work-items/wi-42/"
+		if r.URL.Path != wantPath {
+			t.Errorf("unexpected path: got %s, want %s", r.URL.Path, wantPath)
+		}
+		item := WorkItem{ID: "wi-42", Name: "Test Item", Priority: PriorityHigh}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(item)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+	item, err := c.GetWorkItem(context.Background(), "ws", "proj-1", "wi-42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if item.ID != "wi-42" {
+		t.Errorf("expected ID wi-42, got %s", item.ID)
+	}
+	if item.Priority != PriorityHigh {
+		t.Errorf("expected priority %d, got %d", PriorityHigh, item.Priority)
+	}
+}
+
+func TestUpdateWorkItem(t *testing.T) {
+	var gotBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+	err := c.UpdateWorkItem(context.Background(), "ws", "proj-1", "wi-42", map[string]interface{}{
+		"state": "state-uuid",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotBody["state"] != "state-uuid" {
+		t.Errorf("expected state field in body, got %v", gotBody)
+	}
+}
+
+func TestCreateWorkItem(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		item := WorkItem{ID: "wi-new", Name: "New Item"}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(item)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+	item, err := c.CreateWorkItem(context.Background(), "ws", "proj-1", map[string]interface{}{
+		"name": "New Item",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if item.ID != "wi-new" {
+		t.Errorf("expected ID wi-new, got %s", item.ID)
+	}
+}
+
+func TestListStates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := "/api/v1/workspaces/ws/projects/proj-1/states/"
+		if r.URL.Path != wantPath {
+			t.Errorf("unexpected path: got %s, want %s", r.URL.Path, wantPath)
+		}
+		resp := statesResponse{Results: []State{
+			{ID: "s-1", Name: "Backlog", Group: StateGroupBacklog},
+			{ID: "s-2", Name: "In Progress", Group: StateGroupStarted},
+			{ID: "s-3", Name: "Done", Group: StateGroupCompleted},
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+	states, err := c.ListStates(context.Background(), "ws", "proj-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(states) != 3 {
+		t.Errorf("expected 3 states, got %d", len(states))
+	}
+	if states[0].Group != StateGroupBacklog {
+		t.Errorf("expected first state group backlog, got %s", states[0].Group)
+	}
+}
+
+func TestListLabels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := "/api/v1/workspaces/ws/projects/proj-1/labels/"
+		if r.URL.Path != wantPath {
+			t.Errorf("unexpected path: got %s, want %s", r.URL.Path, wantPath)
+		}
+		resp := labelsResponse{Results: []Label{
+			{ID: "lbl-1", Name: "pilot", Color: "#ff0000"},
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+	labels, err := c.ListLabels(context.Background(), "ws", "proj-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(labels) != 1 {
+		t.Errorf("expected 1 label, got %d", len(labels))
+	}
+	if labels[0].Name != "pilot" {
+		t.Errorf("expected label name pilot, got %s", labels[0].Name)
+	}
+}
+
+func TestAddComment(t *testing.T) {
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		wantPath := "/api/v1/workspaces/ws/projects/proj-1/work-items/wi-42/comments/"
+		if r.URL.Path != wantPath {
+			t.Errorf("unexpected path: got %s, want %s", r.URL.Path, wantPath)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+	err := c.AddComment(context.Background(), "ws", "proj-1", "wi-42", "<p>Hello</p>")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotBody["comment_html"] != "<p>Hello</p>" {
+		t.Errorf("expected comment_html in body, got %v", gotBody)
+	}
+}
+
+func TestAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+	_, err := c.GetWorkItem(context.Background(), "ws", "proj-1", "missing")
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+}
+
+func TestRateLimitRetry(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		item := WorkItem{ID: "wi-1", Name: "Retried"}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(item)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+	item, err := c.GetWorkItem(context.Background(), "ws", "proj-1", "wi-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls (1 retry), got %d", calls)
+	}
+	if item.Name != "Retried" {
+		t.Errorf("expected Name 'Retried', got %s", item.Name)
+	}
+}
+
+func TestPriorityName(t *testing.T) {
+	tests := []struct {
+		p    Priority
+		want string
+	}{
+		{PriorityNone, "None"},
+		{PriorityUrgent, "Urgent"},
+		{PriorityHigh, "High"},
+		{PriorityMedium, "Medium"},
+		{PriorityLow, "Low"},
+	}
+	for _, tt := range tests {
+		got := PriorityName(tt.p)
+		if got != tt.want {
+			t.Errorf("PriorityName(%d) = %s, want %s", tt.p, got, tt.want)
+		}
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Enabled {
+		t.Error("expected default config to be disabled")
+	}
+	if cfg.BaseURL != "https://api.plane.so" {
+		t.Errorf("expected default BaseURL https://api.plane.so, got %s", cfg.BaseURL)
+	}
+	if cfg.PilotLabel != "pilot" {
+		t.Errorf("expected default PilotLabel pilot, got %s", cfg.PilotLabel)
+	}
+}

--- a/internal/adapters/plane/types.go
+++ b/internal/adapters/plane/types.go
@@ -1,0 +1,121 @@
+package plane
+
+import "time"
+
+// Config holds Plane.so adapter configuration.
+type Config struct {
+	Enabled       bool           `yaml:"enabled"`
+	BaseURL       string         `yaml:"base_url"`       // https://api.plane.so (or self-hosted)
+	APIKey        string         `yaml:"api_key"`        // X-API-Key header value
+	WebhookSecret string         `yaml:"webhook_secret"` // For HMAC signature verification
+	WorkspaceSlug string         `yaml:"workspace_slug"`
+	ProjectIDs    []string       `yaml:"project_ids"`
+	PilotLabel    string         `yaml:"pilot_label"` // default: "pilot"
+	Polling       *PollingConfig `yaml:"polling,omitempty"`
+}
+
+// PollingConfig holds polling configuration for the Plane adapter.
+type PollingConfig struct {
+	Enabled  bool          `yaml:"enabled"`
+	Interval time.Duration `yaml:"interval"`
+}
+
+// DefaultConfig returns default Plane configuration.
+func DefaultConfig() *Config {
+	return &Config{
+		Enabled:    false,
+		BaseURL:    "https://api.plane.so",
+		PilotLabel: "pilot",
+	}
+}
+
+// StateGroup represents the fixed state group categories in Plane.
+// Every state belongs to exactly one of these five groups.
+type StateGroup string
+
+const (
+	StateGroupBacklog   StateGroup = "backlog"
+	StateGroupUnstarted StateGroup = "unstarted"
+	StateGroupStarted   StateGroup = "started"
+	StateGroupCompleted StateGroup = "completed"
+	StateGroupCancelled StateGroup = "cancelled"
+)
+
+// Priority represents a Plane work item priority (0=none, 1=urgent, 2=high, 3=medium, 4=low).
+type Priority int
+
+const (
+	PriorityNone   Priority = 0
+	PriorityUrgent Priority = 1
+	PriorityHigh   Priority = 2
+	PriorityMedium Priority = 3
+	PriorityLow    Priority = 4
+)
+
+// PriorityName returns the human-readable priority name.
+func PriorityName(p Priority) string {
+	switch p {
+	case PriorityUrgent:
+		return "Urgent"
+	case PriorityHigh:
+		return "High"
+	case PriorityMedium:
+		return "Medium"
+	case PriorityLow:
+		return "Low"
+	default:
+		return "None"
+	}
+}
+
+// WorkItem represents a Plane work item (formerly "issue").
+// Uses /work-items/ API endpoints (NOT deprecated /issues/).
+type WorkItem struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description_html,omitempty"`
+	StateID     string    `json:"state"`
+	Priority    Priority  `json:"priority"`
+	LabelIDs    []string  `json:"labels"`
+	AssigneeIDs []string  `json:"assignees"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// State represents a Plane workflow state.
+type State struct {
+	ID    string     `json:"id"`
+	Name  string     `json:"name"`
+	Group StateGroup `json:"group"`
+	Color string     `json:"color"`
+}
+
+// Label represents a Plane label.
+type Label struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+// Comment represents a Plane work item comment.
+type Comment struct {
+	ID          string    `json:"id"`
+	CommentHTML string    `json:"comment_html"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// paginatedResponse wraps paginated API responses from Plane.
+type paginatedResponse struct {
+	Results    []WorkItem `json:"results"`
+	TotalCount int        `json:"total_count"`
+}
+
+// statesResponse wraps the states list API response.
+type statesResponse struct {
+	Results []State `json:"results"`
+}
+
+// labelsResponse wraps the labels list API response.
+type labelsResponse struct {
+	Results []Label `json:"results"`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alekspetrov/pilot/internal/adapters/gitlab"
 	"github.com/alekspetrov/pilot/internal/adapters/jira"
 	"github.com/alekspetrov/pilot/internal/adapters/linear"
+	"github.com/alekspetrov/pilot/internal/adapters/plane"
 	"github.com/alekspetrov/pilot/internal/adapters/slack"
 	"github.com/alekspetrov/pilot/internal/adapters/telegram"
 	"github.com/alekspetrov/pilot/internal/alerts"
@@ -74,6 +75,7 @@ type AdaptersConfig struct {
 	AzureDevOps *azuredevops.Config `yaml:"azure_devops"`
 	Jira        *jira.Config        `yaml:"jira"`
 	Asana       *asana.Config       `yaml:"asana"`
+	Plane       *plane.Config       `yaml:"plane"`
 }
 
 // OrchestratorConfig holds settings for the task orchestrator including
@@ -270,6 +272,7 @@ func DefaultConfig() *Config {
 			AzureDevOps: azuredevops.DefaultConfig(),
 			Jira:        jira.DefaultConfig(),
 			Asana:       asana.DefaultConfig(),
+			Plane:       plane.DefaultConfig(),
 		},
 		Orchestrator: &OrchestratorConfig{
 			Model:         "claude-sonnet-4-6",

--- a/internal/testutil/tokens.go
+++ b/internal/testutil/tokens.go
@@ -84,4 +84,10 @@ const (
 
 	// FakeAzureDevOpsWebhookSecret is a safe test secret for Azure DevOps webhook verification.
 	FakeAzureDevOpsWebhookSecret = "test-azure-devops-webhook-secret"
+
+	// FakePlaneAPIKey is a safe test API key for Plane.so.
+	FakePlaneAPIKey = "test-plane-api-key"
+
+	// FakePlaneWebhookSecret is a safe test webhook secret for Plane.so.
+	FakePlaneWebhookSecret = "test-plane-webhook-secret"
 )


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1828.

Closes #1828

## Changes

GitHub Issue #1828: feat(adapters): Add Plane.so types, config, and REST client

## Parent: #1827

### What
Create the Plane.so adapter foundation: types, config struct, and REST API client.

### Files to Create
- `internal/adapters/plane/types.go` — Config struct, Issue/WorkItem struct, state group mappings, priority enum
- `internal/adapters/plane/client.go` — REST client with HTTP helpers

### Files to Modify
- `internal/config/config.go` — Add `Plane *plane.Config` to `AdaptersConfig`

### Reference (copy patterns from)
- `internal/adapters/linear/client.go` — REST client structure
- `internal/adapters/jira/client.go` — Client with base URL support
- `internal/adapters/jira/types.go` — Config pattern

### Client Methods Required
```go
NewClient(baseURL, apiKey string, opts ...ClientOption) *Client
ListWorkItems(ctx, workspaceSlug, projectID string, labelID string) ([]WorkItem, error)
GetWorkItem(ctx, workspaceSlug, projectID, workItemID string) (*WorkItem, error)
UpdateWorkItem(ctx, workspaceSlug, projectID, workItemID string, fields map[string]interface{}) error
ListStates(ctx, workspaceSlug, projectID string) ([]State, error)
ListLabels(ctx, workspaceSlug, projectID string) ([]Label, error)
AddComment(ctx, workspaceSlug, projectID, workItemID, commentHTML string) error
CreateWorkItem(ctx, workspaceSlug, projectID string, fields map[string]interface{}) (*WorkItem, error)
```

### Config Struct
```go
type Config struct {
    Enabled        bool              `yaml:"enabled"`
    BaseURL        string            `yaml:"base_url"`        // https://api.plane.so (or self-hosted)
    APIKey         string            `yaml:"api_key"`
    WebhookSecret  string            `yaml:"webhook_secret"`
    WorkspaceSlug  string            `yaml:"workspace_slug"`
    ProjectIDs     []string          `yaml:"project_ids"`
    PilotLabel     string            `yaml:"pilot_label"`     // default: "pilot"
    Polling        *PollingConfig    `yaml:"polling"`
}
```

### API Notes
- Auth header: `X-API-Key: plane_api_<token>`
- All paths: `/api/v1/workspaces/{slug}/projects/{project_id}/...`
- Use `/work-items/` endpoints (NOT deprecated `/issues/` — EOL March 2026)
- Rate limit: 60 req/min
- Labels are UUID arrays on work items (PATCH to add/remove)
- States have 5 fixed groups: backlog, unstarted, started, completed, cancelled

### Tests
- `internal/adapters/plane/client_test.go` — table-driven tests with httptest.NewServer
- Use `internal/testutil` for fake tokens

### Acceptance Criteria
- [ ] `plane.NewClient()` creates client with configurable base URL
- [ ] All client methods implemented with proper error handling
- [ ] Config struct added to AdaptersConfig
- [ ] Rate limit header respected
- [ ] Unit tests for client methods