### PR TITLE
feat(adapters): Add Plane.so poller with parallel execution

### DIFF
--- a/.agent/tasks/TASK-05-plane-adapter.md
+++ b/.agent/tasks/TASK-05-plane-adapter.md
@@ -1,0 +1,194 @@
+# TASK-05: Plane.so Adapter Integration
+
+**Status**: 🚧 In Progress
+**Created**: 2026-02-25
+**Parent Issue**: GH-1827
+
+---
+
+## Context
+
+**Problem**:
+Pilot has adapters for Linear, Jira, Asana, GitHub, GitLab, and Azure DevOps — but not for Plane.so, a popular open-source project planning tool. Self-hosted teams using Plane.so cannot integrate with Pilot.
+
+**Goal**:
+Add a Plane.so adapter (`internal/adapters/plane/`) that mirrors existing adapter capabilities: webhook intake, polling, bidirectional feedback (PR comments, state transitions), and parallel execution support.
+
+**Success Criteria**:
+- [ ] Plane.so poller picks up issues with `pilot` label
+- [ ] Bidirectional feedback: PR URL posted as comment, issue state updated on completion
+- [ ] Webhook handler for real-time intake
+- [ ] ProcessedStore for dedup across restarts
+- [ ] Parallel execution with scope-overlap guard
+- [ ] Wired into main.go with `--plane` flag
+- [ ] Unit tests for client, poller, webhook
+
+---
+
+## Implementation Plan
+
+### Phase 1: Types, Config, REST Client (GH-TBD-1)
+**Goal**: Foundation — types, config, and API client
+
+**Tasks**:
+- [ ] Create `internal/adapters/plane/types.go` — Config, Issue struct, state group mappings
+- [ ] Create `internal/adapters/plane/client.go` — REST client with methods:
+  - `ListWorkItems(ctx, filter)` — fetch issues by label
+  - `GetWorkItem(ctx, id)` — fetch single issue
+  - `UpdateWorkItem(ctx, id, fields)` — update state/labels
+  - `ListStates(ctx)` — get project states (cache by group)
+  - `ListLabels(ctx)` — get project labels
+  - `AddLabel(ctx, issueID, labelID)` / `RemoveLabel(ctx, issueID, labelID)`
+  - `AddComment(ctx, issueID, body)` — post PR comment
+  - `CreateWorkItem(ctx, fields)` — for epic decomposition
+- [ ] Add `Plane *plane.Config` to `AdaptersConfig` in `internal/config/config.go`
+
+**Files**:
+- `internal/adapters/plane/types.go` (create)
+- `internal/adapters/plane/client.go` (create)
+- `internal/config/config.go` (modify — add 1 field)
+
+**Reference**: `internal/adapters/linear/client.go`, `internal/adapters/jira/client.go`
+
+**API Notes**:
+- Base URL: `https://api.plane.so/` (configurable for self-hosted)
+- Auth header: `X-API-Key: plane_api_<token>`
+- All paths: `/api/v1/workspaces/{slug}/projects/{project_id}/...`
+- Use `/work-items/` endpoints (NOT deprecated `/issues/`)
+- Rate limit: 60 req/min — respect `X-RateLimit-Remaining` header
+- Labels assigned as UUID array on work item PATCH (not separate endpoint)
+
+### Phase 2: ProcessedStore (GH-TBD-2)
+**Goal**: Persistent dedup for Plane issues across restarts
+
+**Tasks**:
+- [ ] Add `plane_processed` table to `internal/autopilot/state_store.go`
+- [ ] Implement: `MarkPlaneIssueProcessed`, `UnmarkPlaneIssueProcessed`, `IsPlaneIssueProcessed`, `LoadPlaneProcessedIssues`
+
+**Files**:
+- `internal/autopilot/state_store.go` (modify — add table + 4 methods)
+
+**Reference**: Copy Jira processed pattern exactly (`jira_processed` table)
+
+### Phase 3: Poller (GH-TBD-3)
+**Goal**: Poll Plane.so for issues with `pilot` label, dispatch for execution
+
+**Tasks**:
+- [ ] Create `internal/adapters/plane/poller.go` — copy Jira poller structure
+- [ ] Label caching: resolve `pilot`, `pilot-in-progress`, `pilot-done`, `pilot-failed` label UUIDs on startup
+- [ ] Orphaned issue recovery: find `pilot-in-progress` issues on startup, remove label
+- [ ] Parallel execution with semaphore + WaitGroup
+- [ ] `PollerOption` builder pattern: OnIssue, ProcessedStore, MaxConcurrent, OnPRCreated, Logger
+- [ ] Filter by configured `project_ids`
+
+**Files**:
+- `internal/adapters/plane/poller.go` (create)
+
+**Reference**: `internal/adapters/jira/poller.go` (~90% copy), `internal/adapters/asana/poller.go`
+
+### Phase 4: Webhook Handler (GH-TBD-4)
+**Goal**: Real-time issue intake via Plane.so webhooks
+
+**Tasks**:
+- [ ] Create `internal/adapters/plane/webhook.go`
+  - HMAC-SHA256 signature verification (`X-Plane-Signature` header)
+  - Parse `issue` create/update events from webhook payload
+  - Filter by `pilot` label, ignore non-matching projects
+- [ ] Register `/webhooks/plane` route in `internal/gateway/server.go`
+
+**Files**:
+- `internal/adapters/plane/webhook.go` (create)
+- `internal/gateway/server.go` (modify — add 1 route)
+
+**Reference**: `internal/adapters/linear/webhook.go` (~80% copy)
+
+**Webhook Payload**:
+- Header `X-Plane-Event`: `issue`
+- Header `X-Plane-Signature`: HMAC-SHA256 hex digest
+- Body: `{ "event": "issue", "action": "created|updated", "data": { ...work item... } }`
+
+### Phase 5: State Transitions & PR Comments (GH-TBD-5)
+**Goal**: Update Plane.so issue state and post PR links on completion
+
+**Tasks**:
+- [ ] `UpdateWorkItemState()` — resolve state UUID by group (`started` → in-progress, `completed` → done)
+- [ ] `AddComment()` — post PR URL with `external_source: "pilot"`, `external_id: "pilot-exec-{id}"`
+- [ ] Wire state transitions into poller success/failure paths
+- [ ] Cache state UUIDs on startup (list states, group by category)
+
+**Files**:
+- `internal/adapters/plane/client.go` (modify — add state transition logic)
+- `internal/adapters/plane/poller.go` (modify — wire state updates)
+
+**Reference**: Linear `UpdateIssueState`, Jira `TransitionIssueTo`, Asana `CompleteTask`
+
+### Phase 6: Wire into main.go (GH-TBD-6)
+**Goal**: Full integration — CLI flag, poller startup, handler wiring
+
+**Tasks**:
+- [ ] Add `--plane` CLI flag to `cmd/pilot/main.go`
+- [ ] Wire poller startup (copy Linear wiring pattern, ~40 lines)
+- [ ] Create `handlePlaneIssueWithResult()` handler (copy `handleLinearIssueWithResult`)
+- [ ] Wire `OnPRCreated` callback to autopilot controller
+- [ ] Wire `SubIssueCreator` for epic decomposition
+- [ ] Add plane section to `configs/pilot.example.yaml`
+- [ ] Add plane adapter tests
+
+**Files**:
+- `cmd/pilot/main.go` (modify — ~80 lines)
+- `configs/pilot.example.yaml` (modify — add plane section)
+- `internal/adapters/plane/client_test.go` (create)
+- `internal/adapters/plane/poller_test.go` (create)
+- `internal/adapters/plane/webhook_test.go` (create)
+
+**Reference**: Linear wiring in `main.go` (~lines 824-860)
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|----------|---------|--------|-----------|
+| API endpoints | `/issues/` vs `/work-items/` | `/work-items/` | `/issues/` deprecated, EOL March 2026 |
+| Label management | Separate API vs PATCH array | PATCH array on work item | Plane assigns labels as UUID array, no separate label-issue endpoint |
+| State transitions | Hardcode state names vs group lookup | Group lookup | States are per-project, but groups are fixed (5 categories) |
+| PR feedback | Native PR field vs comment | Comment with `external_source` | Plane has no native PR field; `external_source`/`external_id` enable dedup |
+
+---
+
+## Dependencies
+
+**Requires**:
+- [ ] Plane.so API access (user provides API key)
+- [ ] Webhook secret (generated in Plane UI)
+
+**Blocks**:
+- [ ] Nothing
+
+---
+
+## Verify
+
+```bash
+make test
+make lint
+# User will E2E test against self-hosted and cloud Plane.so
+```
+
+---
+
+## Done
+
+- [ ] `internal/adapters/plane/` package exists with client, poller, webhook, types
+- [ ] ProcessedStore table for Plane in state_store.go
+- [ ] `--plane` CLI flag works
+- [ ] Poller picks up `pilot`-labeled issues
+- [ ] PR comment posted on completion
+- [ ] Issue state updated to `completed` group
+- [ ] Webhook handler verifies signature and dispatches
+- [ ] Unit tests pass
+- [ ] Example config documented
+
+---
+
+**Last Updated**: 2026-02-25

--- a/.agent/tasks/gh-1830.md
+++ b/.agent/tasks/gh-1830.md
@@ -1,0 +1,92 @@
+# GH-1830
+
+**Created:** 2026-02-25
+
+## Problem
+
+GitHub Issue #1830: feat(adapters): Add Plane.so poller with parallel execution
+
+## Parent: #1827
+## DependsOn: #1828, #1829
+
+### What
+Create the Plane.so poller that polls for issues with `pilot` label and dispatches them for execution with parallel support.
+
+### Files to Create
+- `internal/adapters/plane/poller.go` — Main poller (copy Jira poller ~90%)
+
+### Reference (copy pattern from)
+- `internal/adapters/jira/poller.go` — Primary reference (90% reuse)
+- `internal/adapters/asana/poller.go` — String-ID reference
+
+### Poller Structure
+```go
+type Poller struct {
+    client         *Client
+    config         *Config
+    interval       time.Duration
+    processed      map[string]bool
+    mu             sync.RWMutex
+    onIssue        func(ctx context.Context, issue *WorkItem) (*IssueResult, error)
+    maxConcurrent  int
+    semaphore      chan struct{}
+    activeWg       sync.WaitGroup
+    stopping       atomic.Bool
+    wgMu           sync.Mutex
+    processedStore ProcessedStore
+    onPRCreated    func(prNumber int, prURL, issueID, headSHA, branchName string)
+    log            *slog.Logger
+    // Label UUID cache
+    pilotLabelID       string
+    inProgressLabelID  string
+    doneLabelID        string
+    failedLabelID      string
+}
+```
+
+### Required Behavior
+1. **Startup**: Cache label UUIDs (resolve `pilot`, `pilot-in-progress`, `pilot-done`, `pilot-failed` by name)
+2. **Startup**: Recover orphaned issues (find `pilot-in-progress`, remove label)
+3. **Poll loop**: List work items with `pilot` label, skip processed, dispatch async
+4. **On dispatch**: Add `pilot-in-progress` label
+5. **On success**: Remove `pilot-in-progress`, add `pilot-done`, call OnPRCreated
+6. **On failure**: Remove `pilot-in-progress`, add `pilot-failed`
+7. **Parallel**: Semaphore + WaitGroup with `maxConcurrent` limit
+8. **Filter**: Only process issues from configured `project_ids`
+
+### PollerOption Pattern
+```go
+type PollerOption func(*Poller)
+WithOnIssue(fn) / WithProcessedStore(store) / WithMaxConcurrent(n)
+WithOnPRCreated(fn) / WithPollerLogger(logger)
+```
+
+### IssueResult
+```go
+type IssueResult struct {
+    Success    bool
+    PRNumber   int
+    PRURL      string
+    HeadSHA    string
+    BranchName string
+    Error      error
+}
+```
+
+### Label Management Note
+Plane assigns labels as UUID array on work items. To add/remove a label:
+1. GET work item → read current `labels` array
+2. Append/filter UUID
+3. PATCH work item with updated `labels` array
+
+### Acceptance Criteria
+- [ ] Poller starts, caches label UUIDs, recovers orphans
+- [ ] Polls at configured interval, dispatches new issues
+- [ ] Parallel execution with semaphore
+- [ ] ProcessedStore integration for dedup
+- [ ] Label lifecycle: in-progress → done/failed
+- [ ] OnPRCreated callback wired
+- [ ] Unit tests for poller logic
+
+## Acceptance Criteria
+

--- a/internal/adapters/plane/client.go
+++ b/internal/adapters/plane/client.go
@@ -1,0 +1,196 @@
+package plane
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client is a Plane.so API client
+type Client struct {
+	baseURL       string
+	apiKey        string
+	workspaceSlug string
+	httpClient    *http.Client
+}
+
+// NewClient creates a new Plane client
+func NewClient(baseURL, apiKey, workspaceSlug string) *Client {
+	return &Client{
+		baseURL:       strings.TrimSuffix(baseURL, "/"),
+		apiKey:        apiKey,
+		workspaceSlug: workspaceSlug,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// NewClientWithHTTP creates a new Plane client with a custom HTTP client (for testing)
+func NewClientWithHTTP(baseURL, apiKey, workspaceSlug string, httpClient *http.Client) *Client {
+	return &Client{
+		baseURL:       strings.TrimSuffix(baseURL, "/"),
+		apiKey:        apiKey,
+		workspaceSlug: workspaceSlug,
+		httpClient:    httpClient,
+	}
+}
+
+// doRequest performs an HTTP request to the Plane API
+func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}, result interface{}) error {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyBytes, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+
+	url := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("X-API-Key", c.apiKey)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// projectPath returns the API path prefix for a project
+func (c *Client) projectPath(projectID string) string {
+	return fmt.Sprintf("/api/v1/workspaces/%s/projects/%s", c.workspaceSlug, projectID)
+}
+
+// ListLabels lists all labels for a project
+func (c *Client) ListLabels(ctx context.Context, projectID string) ([]Label, error) {
+	path := c.projectPath(projectID) + "/labels/"
+	var resp ListResponse[Label]
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Results, nil
+}
+
+// ListWorkItems lists work items for a project with optional label filter
+func (c *Client) ListWorkItems(ctx context.Context, projectID string, labelID string) ([]WorkItem, error) {
+	path := c.projectPath(projectID) + "/work-items/"
+	if labelID != "" {
+		path += "?label=" + labelID
+	}
+	var resp ListResponse[WorkItem]
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Results, nil
+}
+
+// GetWorkItem fetches a single work item
+func (c *Client) GetWorkItem(ctx context.Context, projectID, workItemID string) (*WorkItem, error) {
+	path := c.projectPath(projectID) + "/work-items/" + workItemID + "/"
+	var item WorkItem
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &item); err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+// UpdateWorkItem updates a work item's fields
+func (c *Client) UpdateWorkItem(ctx context.Context, projectID, workItemID string, fields map[string]interface{}) error {
+	path := c.projectPath(projectID) + "/work-items/" + workItemID + "/"
+	return c.doRequest(ctx, http.MethodPatch, path, fields, nil)
+}
+
+// AddLabel adds a label UUID to a work item's labels array.
+// Plane stores labels as a UUID array on the work item — there is no separate label-issue endpoint.
+func (c *Client) AddLabel(ctx context.Context, projectID, workItemID, labelID string) error {
+	item, err := c.GetWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return fmt.Errorf("failed to get work item for label add: %w", err)
+	}
+
+	// Check if label already present
+	for _, l := range item.Labels {
+		if l == labelID {
+			return nil // already has the label
+		}
+	}
+
+	labels := append(item.Labels, labelID)
+	return c.UpdateWorkItem(ctx, projectID, workItemID, map[string]interface{}{
+		"labels": labels,
+	})
+}
+
+// RemoveLabel removes a label UUID from a work item's labels array.
+func (c *Client) RemoveLabel(ctx context.Context, projectID, workItemID, labelID string) error {
+	item, err := c.GetWorkItem(ctx, projectID, workItemID)
+	if err != nil {
+		return fmt.Errorf("failed to get work item for label remove: %w", err)
+	}
+
+	filtered := make([]string, 0, len(item.Labels))
+	for _, l := range item.Labels {
+		if l != labelID {
+			filtered = append(filtered, l)
+		}
+	}
+
+	if len(filtered) == len(item.Labels) {
+		return nil // label not present
+	}
+
+	return c.UpdateWorkItem(ctx, projectID, workItemID, map[string]interface{}{
+		"labels": filtered,
+	})
+}
+
+// HasLabelID checks if a work item has a specific label UUID
+func HasLabelID(item *WorkItem, labelID string) bool {
+	for _, l := range item.Labels {
+		if l == labelID {
+			return true
+		}
+	}
+	return false
+}
+
+// AddComment adds a comment to a work item
+func (c *Client) AddComment(ctx context.Context, projectID, workItemID, body string) error {
+	path := c.projectPath(projectID) + "/work-items/" + workItemID + "/comments/"
+	reqBody := map[string]string{
+		"comment_html": body,
+	}
+	return c.doRequest(ctx, http.MethodPost, path, reqBody, nil)
+}

--- a/internal/adapters/plane/poller.go
+++ b/internal/adapters/plane/poller.go
@@ -1,0 +1,496 @@
+package plane
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// Status labels for tracking work item progress
+const (
+	LabelPilot      = "pilot"
+	LabelInProgress = "pilot-in-progress"
+	LabelDone       = "pilot-done"
+	LabelFailed     = "pilot-failed"
+)
+
+// IssueResult is returned by the work item handler
+type IssueResult struct {
+	Success    bool
+	PRNumber   int
+	PRURL      string
+	HeadSHA    string // Head commit SHA of the PR (for autopilot wiring)
+	BranchName string // Head branch name e.g. "pilot/PLANE-123"
+	Error      error
+}
+
+// ProcessedStore persists which Plane work items have been processed across restarts.
+// GH-1830: Plane uses string UUIDs for work item IDs.
+type ProcessedStore interface {
+	MarkPlaneIssueProcessed(issueID string, result string) error
+	UnmarkPlaneIssueProcessed(issueID string) error
+	IsPlaneIssueProcessed(issueID string) (bool, error)
+	LoadPlaneProcessedIssues() (map[string]bool, error)
+}
+
+// Poller polls Plane.so for work items with the pilot label
+type Poller struct {
+	client   *Client
+	config   *Config
+	interval time.Duration
+
+	processed map[string]bool // Work item UUID → processed
+	mu        sync.RWMutex
+
+	onIssue     func(ctx context.Context, issue *WorkItem) (*IssueResult, error)
+	onPRCreated func(prNumber int, prURL, issueID, headSHA, branchName string)
+	logger      *slog.Logger
+
+	// Label UUID cache (resolved on startup by name)
+	pilotLabelID      string
+	inProgressLabelID string
+	doneLabelID       string
+	failedLabelID     string
+
+	// GH-1830: Persistent processed store (optional)
+	processedStore ProcessedStore
+
+	// GH-1830: Parallel execution configuration
+	maxConcurrent int
+	semaphore     chan struct{}
+	activeWg      sync.WaitGroup
+	stopping      atomic.Bool
+	wgMu          sync.Mutex // protects stopping + activeWg Add/Wait coordination
+}
+
+// PollerOption configures a Poller
+type PollerOption func(*Poller)
+
+// WithOnIssue sets the callback for new work items
+func WithOnIssue(fn func(ctx context.Context, issue *WorkItem) (*IssueResult, error)) PollerOption {
+	return func(p *Poller) {
+		p.onIssue = fn
+	}
+}
+
+// WithPollerLogger sets the logger for the poller
+func WithPollerLogger(logger *slog.Logger) PollerOption {
+	return func(p *Poller) {
+		p.logger = logger
+	}
+}
+
+// WithProcessedStore sets the persistent store for processed work item tracking.
+// GH-1830: On startup, processed items are loaded from the store to prevent re-processing after hot upgrade.
+func WithProcessedStore(store ProcessedStore) PollerOption {
+	return func(p *Poller) {
+		p.processedStore = store
+	}
+}
+
+// WithMaxConcurrent sets the maximum number of parallel work item executions.
+// GH-1830: Ported parallel execution pattern from other adapters.
+func WithMaxConcurrent(n int) PollerOption {
+	return func(p *Poller) {
+		if n < 1 {
+			n = 1
+		}
+		p.maxConcurrent = n
+	}
+}
+
+// WithOnPRCreated sets the callback for when a PR is created for a work item.
+func WithOnPRCreated(fn func(prNumber int, prURL, issueID, headSHA, branchName string)) PollerOption {
+	return func(p *Poller) {
+		p.onPRCreated = fn
+	}
+}
+
+// NewPoller creates a new Plane work item poller
+func NewPoller(client *Client, config *Config, interval time.Duration, opts ...PollerOption) *Poller {
+	pilotLabel := config.PilotLabel
+	if pilotLabel == "" {
+		pilotLabel = LabelPilot
+	}
+	// Store the configured label name for display; UUID resolved on Start()
+	_ = pilotLabel
+
+	p := &Poller{
+		client:    client,
+		config:    config,
+		interval:  interval,
+		processed: make(map[string]bool),
+		logger:    logging.WithComponent("plane-poller"),
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	// GH-1830: Load processed items from persistent store if available
+	if p.processedStore != nil {
+		loaded, err := p.processedStore.LoadPlaneProcessedIssues()
+		if err != nil {
+			p.logger.Warn("Failed to load processed issues from store", slog.Any("error", err))
+		} else if len(loaded) > 0 {
+			p.mu.Lock()
+			for id := range loaded {
+				p.processed[id] = true
+			}
+			p.mu.Unlock()
+			p.logger.Info("Loaded processed issues from store", slog.Int("count", len(loaded)))
+		}
+	}
+
+	// GH-1830: Initialize parallel semaphore
+	if p.maxConcurrent < 1 {
+		p.maxConcurrent = 2 // default
+	}
+	p.semaphore = make(chan struct{}, p.maxConcurrent)
+
+	return p
+}
+
+// Start begins polling for work items
+func (p *Poller) Start(ctx context.Context) error {
+	// Cache label UUIDs on startup
+	if err := p.cacheLabelIDs(ctx); err != nil {
+		return fmt.Errorf("failed to cache label IDs: %w", err)
+	}
+
+	p.logger.Info("Starting Plane poller",
+		slog.String("workspace", p.config.WorkspaceSlug),
+		slog.Int("projects", len(p.config.ProjectIDs)),
+		slog.Duration("interval", p.interval),
+		slog.Int("max_concurrent", p.maxConcurrent),
+	)
+
+	// GH-1830: Recover orphaned in-progress items from previous run
+	p.recoverOrphanedIssues(ctx)
+
+	// Initial check
+	p.checkForNewIssues(ctx)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("Plane poller stopping, waiting for active tasks...")
+			p.wgMu.Lock()
+			p.stopping.Store(true)
+			p.wgMu.Unlock()
+			p.activeWg.Wait()
+			p.logger.Info("Plane poller stopped")
+			return nil
+		case <-ticker.C:
+			p.checkForNewIssues(ctx)
+		}
+	}
+}
+
+// cacheLabelIDs fetches and caches the UUIDs for pilot-related labels across all configured projects.
+// Plane labels are per-project, so we resolve from the first project that has matching labels.
+func (p *Poller) cacheLabelIDs(ctx context.Context) error {
+	pilotLabelName := p.config.PilotLabel
+	if pilotLabelName == "" {
+		pilotLabelName = LabelPilot
+	}
+
+	for _, projectID := range p.config.ProjectIDs {
+		labels, err := p.client.ListLabels(ctx, projectID)
+		if err != nil {
+			p.logger.Warn("Failed to list labels for project",
+				slog.String("project_id", projectID),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		for _, label := range labels {
+			switch {
+			case strings.EqualFold(label.Name, pilotLabelName):
+				p.pilotLabelID = label.ID
+			case strings.EqualFold(label.Name, LabelInProgress):
+				p.inProgressLabelID = label.ID
+			case strings.EqualFold(label.Name, LabelDone):
+				p.doneLabelID = label.ID
+			case strings.EqualFold(label.Name, LabelFailed):
+				p.failedLabelID = label.ID
+			}
+		}
+
+		// If we found the pilot label, stop looking
+		if p.pilotLabelID != "" {
+			break
+		}
+	}
+
+	if p.pilotLabelID == "" {
+		return fmt.Errorf("pilot label %q not found in any configured project", pilotLabelName)
+	}
+
+	p.logger.Debug("Cached label IDs",
+		slog.String("pilot", p.pilotLabelID),
+		slog.String("in_progress", p.inProgressLabelID),
+		slog.String("done", p.doneLabelID),
+		slog.String("failed", p.failedLabelID),
+	)
+
+	return nil
+}
+
+// recoverOrphanedIssues finds work items with pilot-in-progress label from a previous run
+// and removes the label so they can be picked up again.
+// GH-1830: This handles restart/crash scenarios where items were left orphaned.
+func (p *Poller) recoverOrphanedIssues(ctx context.Context) {
+	if p.inProgressLabelID == "" {
+		return
+	}
+
+	for _, projectID := range p.config.ProjectIDs {
+		items, err := p.client.ListWorkItems(ctx, projectID, p.inProgressLabelID)
+		if err != nil {
+			p.logger.Warn("Failed to check for orphaned issues",
+				slog.String("project_id", projectID),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		if len(items) == 0 {
+			continue
+		}
+
+		p.logger.Info("Recovering orphaned in-progress issues",
+			slog.String("project_id", projectID),
+			slog.Int("count", len(items)),
+		)
+
+		for _, item := range items {
+			if err := p.client.RemoveLabel(ctx, projectID, item.ID, p.inProgressLabelID); err != nil {
+				p.logger.Warn("Failed to remove in-progress label from orphaned issue",
+					slog.String("id", item.ID),
+					slog.Any("error", err),
+				)
+				continue
+			}
+			p.logger.Info("Recovered orphaned issue",
+				slog.String("id", item.ID),
+				slog.String("name", item.Name),
+			)
+		}
+	}
+}
+
+func (p *Poller) checkForNewIssues(ctx context.Context) {
+	var allItems []WorkItem
+
+	for _, projectID := range p.config.ProjectIDs {
+		items, err := p.client.ListWorkItems(ctx, projectID, p.pilotLabelID)
+		if err != nil {
+			p.logger.Warn("Failed to fetch work items",
+				slog.String("project_id", projectID),
+				slog.Any("error", err),
+			)
+			continue
+		}
+		allItems = append(allItems, items...)
+	}
+
+	// Sort by creation date (oldest first)
+	sort.Slice(allItems, func(i, j int) bool {
+		return allItems[i].CreatedAt.Before(allItems[j].CreatedAt)
+	})
+
+	for _, item := range allItems {
+		// Skip if already processed
+		p.mu.RLock()
+		processed := p.processed[item.ID]
+		p.mu.RUnlock()
+
+		if processed {
+			continue
+		}
+
+		// Skip if has status label (in-progress, done, or failed)
+		if p.hasStatusLabel(&item) {
+			// Only mark as processed if it has done label (allow retry of failed)
+			if HasLabelID(&item, p.doneLabelID) {
+				p.markProcessed(item.ID)
+			}
+			continue
+		}
+
+		// Mark processed immediately to prevent duplicate dispatch on next tick
+		p.markProcessed(item.ID)
+
+		// Acquire semaphore slot (blocks if max_concurrent reached)
+		select {
+		case <-ctx.Done():
+			return
+		case p.semaphore <- struct{}{}:
+		}
+
+		p.logger.Info("Dispatching Plane work item for parallel execution",
+			slog.String("id", item.ID),
+			slog.String("name", item.Name),
+			slog.String("project", item.ProjectID),
+		)
+
+		// Use mutex to coordinate stopping flag check with WaitGroup Add
+		p.wgMu.Lock()
+		if p.stopping.Load() {
+			p.wgMu.Unlock()
+			<-p.semaphore // release slot we acquired
+			return
+		}
+		p.activeWg.Add(1)
+		p.wgMu.Unlock()
+
+		go p.processIssueAsync(ctx, item)
+	}
+}
+
+// processIssueAsync handles a single work item in a goroutine.
+// GH-1830: Extracted to enable parallel execution.
+func (p *Poller) processIssueAsync(ctx context.Context, item WorkItem) {
+	defer p.activeWg.Done()
+	defer func() { <-p.semaphore }() // release slot
+
+	if p.onIssue == nil {
+		return
+	}
+
+	// Add in-progress label
+	if p.inProgressLabelID != "" {
+		_ = p.client.AddLabel(ctx, item.ProjectID, item.ID, p.inProgressLabelID)
+	}
+
+	result, err := p.onIssue(ctx, &item)
+	if err != nil {
+		p.logger.Error("Failed to process work item",
+			slog.String("id", item.ID),
+			slog.Any("error", err),
+		)
+		// Remove in-progress label, add failed label
+		if p.inProgressLabelID != "" {
+			_ = p.client.RemoveLabel(ctx, item.ProjectID, item.ID, p.inProgressLabelID)
+		}
+		if p.failedLabelID != "" {
+			_ = p.client.AddLabel(ctx, item.ProjectID, item.ID, p.failedLabelID)
+		}
+		return
+	}
+
+	// Remove in-progress label
+	if p.inProgressLabelID != "" {
+		_ = p.client.RemoveLabel(ctx, item.ProjectID, item.ID, p.inProgressLabelID)
+	}
+
+	// Add done label on success
+	if result != nil && result.Success && p.doneLabelID != "" {
+		_ = p.client.AddLabel(ctx, item.ProjectID, item.ID, p.doneLabelID)
+	}
+
+	// Fire OnPRCreated callback
+	if result != nil && result.PRNumber > 0 && p.onPRCreated != nil {
+		p.onPRCreated(result.PRNumber, result.PRURL, item.ID, result.HeadSHA, result.BranchName)
+	}
+}
+
+// hasStatusLabel checks if a work item has any status label UUID
+func (p *Poller) hasStatusLabel(item *WorkItem) bool {
+	if p.inProgressLabelID != "" && HasLabelID(item, p.inProgressLabelID) {
+		return true
+	}
+	if p.doneLabelID != "" && HasLabelID(item, p.doneLabelID) {
+		return true
+	}
+	if p.failedLabelID != "" && HasLabelID(item, p.failedLabelID) {
+		return true
+	}
+	return false
+}
+
+func (p *Poller) markProcessed(id string) {
+	p.mu.Lock()
+	p.processed[id] = true
+	p.mu.Unlock()
+
+	// GH-1830: Persist to store if available
+	if p.processedStore != nil {
+		if err := p.processedStore.MarkPlaneIssueProcessed(id, "processed"); err != nil {
+			p.logger.Warn("Failed to persist processed issue", slog.String("id", id), slog.Any("error", err))
+		}
+	}
+}
+
+// IsProcessed checks if a work item has been processed
+func (p *Poller) IsProcessed(id string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.processed[id]
+}
+
+// ProcessedCount returns the number of processed work items
+func (p *Poller) ProcessedCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.processed)
+}
+
+// Reset clears the processed work items map
+func (p *Poller) Reset() {
+	p.mu.Lock()
+	p.processed = make(map[string]bool)
+	p.mu.Unlock()
+}
+
+// ClearProcessed removes a specific work item from the processed map (for retry).
+// GH-1830: Used when pilot-failed label is removed to allow retry.
+func (p *Poller) ClearProcessed(id string) {
+	p.mu.Lock()
+	delete(p.processed, id)
+	p.mu.Unlock()
+
+	// Also clear from persistent store
+	if p.processedStore != nil {
+		if err := p.processedStore.UnmarkPlaneIssueProcessed(id); err != nil {
+			p.logger.Warn("Failed to unmark issue in store",
+				slog.String("id", id),
+				slog.Any("error", err))
+		}
+	}
+
+	p.logger.Debug("Cleared issue from processed map",
+		slog.String("id", id))
+}
+
+// Drain stops accepting new work items and waits for active executions to finish.
+// GH-1830: Used during hot upgrade to let in-flight work complete before process restart.
+func (p *Poller) Drain() {
+	p.logger.Info("Draining poller — no new work items will be accepted")
+	p.wgMu.Lock()
+	p.stopping.Store(true)
+	p.wgMu.Unlock()
+	p.activeWg.Wait()
+	p.logger.Info("Poller drained — all active tasks completed")
+}
+
+// WaitForActive waits for all active parallel goroutines to finish.
+// GH-1830: Used in tests to synchronize after checkForNewIssues.
+func (p *Poller) WaitForActive() {
+	p.wgMu.Lock()
+	p.stopping.Store(true)
+	p.wgMu.Unlock()
+	p.activeWg.Wait()
+}

--- a/internal/adapters/plane/poller_test.go
+++ b/internal/adapters/plane/poller_test.go
@@ -1,0 +1,834 @@
+package plane
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+// Test UUIDs for labels and work items
+const (
+	testPilotLabelID      = "label-pilot-uuid"
+	testInProgressLabelID = "label-in-progress-uuid"
+	testDoneLabelID       = "label-done-uuid"
+	testFailedLabelID     = "label-failed-uuid"
+	testProjectID         = "project-uuid-1"
+	testWorkspaceSlug     = "test-workspace"
+)
+
+func TestNewPoller(t *testing.T) {
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{
+		PilotLabel:    "pilot",
+		WorkspaceSlug: testWorkspaceSlug,
+		ProjectIDs:    []string{testProjectID},
+	}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	if poller.interval != 30*time.Second {
+		t.Errorf("expected interval 30s, got %v", poller.interval)
+	}
+
+	if len(poller.processed) != 0 {
+		t.Error("expected empty processed map")
+	}
+}
+
+func TestPollerWithOptions(t *testing.T) {
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+
+	var callbackCalled bool
+	handler := func(ctx context.Context, issue *WorkItem) (*IssueResult, error) {
+		callbackCalled = true
+		return &IssueResult{Success: true}, nil
+	}
+
+	poller := NewPoller(client, config, 30*time.Second,
+		WithOnIssue(handler),
+	)
+
+	if poller.onIssue == nil {
+		t.Error("expected onIssue handler to be set")
+	}
+
+	// Call the handler to verify it's wired correctly
+	_, _ = poller.onIssue(context.Background(), &WorkItem{})
+	if !callbackCalled {
+		t.Error("expected callback to be called")
+	}
+}
+
+func TestPollerWithOnPRCreated(t *testing.T) {
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+
+	var prCalled bool
+	poller := NewPoller(client, config, 30*time.Second,
+		WithOnPRCreated(func(prNumber int, prURL, issueID, headSHA, branchName string) {
+			prCalled = true
+		}),
+	)
+
+	if poller.onPRCreated == nil {
+		t.Error("expected onPRCreated handler to be set")
+	}
+
+	poller.onPRCreated(42, "https://github.com/org/repo/pull/42", "issue-uuid", "abc123", "pilot/PLANE-1")
+	if !prCalled {
+		t.Error("expected PR callback to be called")
+	}
+}
+
+func TestPollerMarkProcessed(t *testing.T) {
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	if poller.IsProcessed("uuid-1") {
+		t.Error("expected uuid-1 NOT to be processed initially")
+	}
+
+	poller.markProcessed("uuid-1")
+
+	if !poller.IsProcessed("uuid-1") {
+		t.Error("expected uuid-1 to be processed after marking")
+	}
+
+	if poller.ProcessedCount() != 1 {
+		t.Errorf("expected processed count 1, got %d", poller.ProcessedCount())
+	}
+
+	poller.Reset()
+
+	if poller.IsProcessed("uuid-1") {
+		t.Error("expected uuid-1 NOT to be processed after reset")
+	}
+
+	if poller.ProcessedCount() != 0 {
+		t.Errorf("expected processed count 0 after reset, got %d", poller.ProcessedCount())
+	}
+}
+
+func TestPollerClearProcessed(t *testing.T) {
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	poller.markProcessed("uuid-1")
+	poller.markProcessed("uuid-2")
+
+	if poller.ProcessedCount() != 2 {
+		t.Errorf("expected processed count 2, got %d", poller.ProcessedCount())
+	}
+
+	poller.ClearProcessed("uuid-1")
+
+	if poller.IsProcessed("uuid-1") {
+		t.Error("expected uuid-1 NOT to be processed after clearing")
+	}
+	if !poller.IsProcessed("uuid-2") {
+		t.Error("expected uuid-2 to still be processed")
+	}
+	if poller.ProcessedCount() != 1 {
+		t.Errorf("expected processed count 1 after clearing one, got %d", poller.ProcessedCount())
+	}
+}
+
+func TestPollerConcurrentAccess(t *testing.T) {
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			id := "uuid-" + string(rune('0'+n%10))
+			poller.markProcessed(id)
+			_ = poller.IsProcessed(id)
+			_ = poller.ProcessedCount()
+		}(i)
+	}
+	wg.Wait()
+
+	count := poller.ProcessedCount()
+	if count == 0 {
+		t.Error("expected some processed items")
+	}
+}
+
+func TestPollerHasStatusLabel(t *testing.T) {
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	// Set cached label IDs
+	poller.pilotLabelID = testPilotLabelID
+	poller.inProgressLabelID = testInProgressLabelID
+	poller.doneLabelID = testDoneLabelID
+	poller.failedLabelID = testFailedLabelID
+
+	tests := []struct {
+		name   string
+		labels []string
+		want   bool
+	}{
+		{"no labels", []string{}, false},
+		{"pilot only", []string{testPilotLabelID}, false},
+		{"in-progress", []string{testPilotLabelID, testInProgressLabelID}, true},
+		{"done", []string{testPilotLabelID, testDoneLabelID}, true},
+		{"failed", []string{testPilotLabelID, testFailedLabelID}, true},
+		{"unrelated labels", []string{"some-other-uuid"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := &WorkItem{Labels: tt.labels}
+			got := poller.hasStatusLabel(item)
+			if got != tt.want {
+				t.Errorf("hasStatusLabel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasLabelID(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  []string
+		labelID string
+		want    bool
+	}{
+		{"exact match", []string{testPilotLabelID}, testPilotLabelID, true},
+		{"not found", []string{testPilotLabelID}, "other-uuid", false},
+		{"empty labels", []string{}, testPilotLabelID, false},
+		{"multiple labels", []string{"a", "b", testDoneLabelID}, testDoneLabelID, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := &WorkItem{Labels: tt.labels}
+			got := HasLabelID(item, tt.labelID)
+			if got != tt.want {
+				t.Errorf("HasLabelID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// newTestServer creates an httptest.Server that simulates the Plane API for poller tests.
+func newTestServer(t *testing.T, labels []Label, workItems []WorkItem) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		// Labels endpoint
+		if r.Method == http.MethodGet && contains(r.URL.Path, "/labels/") {
+			resp := ListResponse[Label]{Results: labels, TotalCount: len(labels)}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		// Work items list endpoint (GET with query param)
+		if r.Method == http.MethodGet && contains(r.URL.Path, "/work-items/") && !hasWorkItemID(r.URL.Path) {
+			// Filter by label if provided
+			labelFilter := r.URL.Query().Get("label")
+			var filtered []WorkItem
+			for _, item := range workItems {
+				if labelFilter == "" || hasLabel(item.Labels, labelFilter) {
+					filtered = append(filtered, item)
+				}
+			}
+			resp := ListResponse[WorkItem]{Results: filtered, TotalCount: len(filtered)}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		// Single work item GET (for AddLabel/RemoveLabel)
+		if r.Method == http.MethodGet && contains(r.URL.Path, "/work-items/") {
+			for _, item := range workItems {
+				if contains(r.URL.Path, item.ID) {
+					_ = json.NewEncoder(w).Encode(item)
+					return
+				}
+			}
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		// Work item PATCH (label update)
+		if r.Method == http.MethodPatch && contains(r.URL.Path, "/work-items/") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func hasWorkItemID(path string) bool {
+	// Check if path ends with a UUID-like segment (not just /work-items/)
+	parts := splitPath(path)
+	if len(parts) < 2 {
+		return false
+	}
+	last := parts[len(parts)-1]
+	// Work item IDs are UUIDs, list endpoint ends with "work-items"
+	return last != "work-items" && last != ""
+}
+
+func splitPath(path string) []string {
+	var parts []string
+	for _, p := range split(path, '/') {
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}
+
+func split(s string, sep byte) []string {
+	var parts []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == sep {
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+func hasLabel(labels []string, labelID string) bool {
+	for _, l := range labels {
+		if l == labelID {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPollerCacheLabelIDs(t *testing.T) {
+	labels := []Label{
+		{ID: testPilotLabelID, Name: "pilot"},
+		{ID: testInProgressLabelID, Name: "pilot-in-progress"},
+		{ID: testDoneLabelID, Name: "pilot-done"},
+		{ID: testFailedLabelID, Name: "pilot-failed"},
+	}
+
+	server := newTestServer(t, labels, nil)
+	defer server.Close()
+
+	client := NewClient(server.URL, testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{
+		PilotLabel:    "pilot",
+		WorkspaceSlug: testWorkspaceSlug,
+		ProjectIDs:    []string{testProjectID},
+	}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	err := poller.cacheLabelIDs(context.Background())
+	if err != nil {
+		t.Fatalf("cacheLabelIDs() error = %v", err)
+	}
+
+	if poller.pilotLabelID != testPilotLabelID {
+		t.Errorf("pilotLabelID = %q, want %q", poller.pilotLabelID, testPilotLabelID)
+	}
+	if poller.inProgressLabelID != testInProgressLabelID {
+		t.Errorf("inProgressLabelID = %q, want %q", poller.inProgressLabelID, testInProgressLabelID)
+	}
+	if poller.doneLabelID != testDoneLabelID {
+		t.Errorf("doneLabelID = %q, want %q", poller.doneLabelID, testDoneLabelID)
+	}
+	if poller.failedLabelID != testFailedLabelID {
+		t.Errorf("failedLabelID = %q, want %q", poller.failedLabelID, testFailedLabelID)
+	}
+}
+
+func TestPollerCacheLabelIDs_NotFound(t *testing.T) {
+	// No labels at all
+	server := newTestServer(t, nil, nil)
+	defer server.Close()
+
+	client := NewClient(server.URL, testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{
+		PilotLabel:    "pilot",
+		WorkspaceSlug: testWorkspaceSlug,
+		ProjectIDs:    []string{testProjectID},
+	}
+	poller := NewPoller(client, config, 30*time.Second)
+
+	err := poller.cacheLabelIDs(context.Background())
+	if err == nil {
+		t.Error("expected error when pilot label not found")
+	}
+}
+
+func TestPollerCheckForNewIssues(t *testing.T) {
+	labels := []Label{
+		{ID: testPilotLabelID, Name: "pilot"},
+		{ID: testInProgressLabelID, Name: "pilot-in-progress"},
+		{ID: testDoneLabelID, Name: "pilot-done"},
+		{ID: testFailedLabelID, Name: "pilot-failed"},
+	}
+
+	workItems := []WorkItem{
+		{
+			ID:        "item-1",
+			Name:      "First issue",
+			Labels:    []string{testPilotLabelID},
+			ProjectID: testProjectID,
+			CreatedAt: time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			ID:        "item-2",
+			Name:      "Second issue (in progress)",
+			Labels:    []string{testPilotLabelID, testInProgressLabelID},
+			ProjectID: testProjectID,
+			CreatedAt: time.Date(2024, 1, 2, 10, 0, 0, 0, time.UTC),
+		},
+	}
+
+	server := newTestServer(t, labels, workItems)
+	defer server.Close()
+
+	var processedItem *WorkItem
+	client := NewClient(server.URL, testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{
+		PilotLabel:    "pilot",
+		WorkspaceSlug: testWorkspaceSlug,
+		ProjectIDs:    []string{testProjectID},
+	}
+	poller := NewPoller(client, config, 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *WorkItem) (*IssueResult, error) {
+			processedItem = issue
+			return &IssueResult{Success: true}, nil
+		}),
+	)
+
+	// Set cached label IDs (bypass cacheLabelIDs for unit test)
+	poller.pilotLabelID = testPilotLabelID
+	poller.inProgressLabelID = testInProgressLabelID
+	poller.doneLabelID = testDoneLabelID
+	poller.failedLabelID = testFailedLabelID
+
+	ctx := context.Background()
+	poller.checkForNewIssues(ctx)
+	poller.WaitForActive()
+
+	// Should process item-1 but skip item-2 (has in-progress label)
+	if processedItem == nil {
+		t.Fatal("expected a work item to be processed")
+	}
+
+	if processedItem.ID != "item-1" {
+		t.Errorf("expected item-1 to be processed, got %s", processedItem.ID)
+	}
+
+	if !poller.IsProcessed("item-1") {
+		t.Error("expected item-1 to be marked as processed")
+	}
+}
+
+func TestPollerCheckForNewIssues_SkipsAlreadyProcessed(t *testing.T) {
+	labels := []Label{
+		{ID: testPilotLabelID, Name: "pilot"},
+	}
+	workItems := []WorkItem{
+		{
+			ID:        "item-1",
+			Name:      "Already processed",
+			Labels:    []string{testPilotLabelID},
+			ProjectID: testProjectID,
+		},
+	}
+
+	server := newTestServer(t, labels, workItems)
+	defer server.Close()
+
+	client := NewClient(server.URL, testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{
+		PilotLabel:    "pilot",
+		WorkspaceSlug: testWorkspaceSlug,
+		ProjectIDs:    []string{testProjectID},
+	}
+
+	var callCount int
+	poller := NewPoller(client, config, 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *WorkItem) (*IssueResult, error) {
+			callCount++
+			return &IssueResult{Success: true}, nil
+		}),
+	)
+
+	poller.pilotLabelID = testPilotLabelID
+
+	// Mark as already processed
+	poller.markProcessed("item-1")
+
+	ctx := context.Background()
+	poller.checkForNewIssues(ctx)
+
+	if callCount != 0 {
+		t.Errorf("expected callback not to be called for already processed issue, got %d calls", callCount)
+	}
+}
+
+func TestPollerStart_CancelsOnContextDone(t *testing.T) {
+	labels := []Label{
+		{ID: testPilotLabelID, Name: "pilot"},
+	}
+
+	server := newTestServer(t, labels, nil)
+	defer server.Close()
+
+	client := NewClient(server.URL, testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{
+		PilotLabel:    "pilot",
+		WorkspaceSlug: testWorkspaceSlug,
+		ProjectIDs:    []string{testProjectID},
+	}
+	poller := NewPoller(client, config, 100*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- poller.Start(ctx)
+	}()
+
+	// Cancel after a short delay
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("expected nil error on cancel, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("poller did not stop after context cancellation")
+	}
+}
+
+// mockProcessedStore implements ProcessedStore for testing.
+type mockProcessedStore struct {
+	mu        sync.Mutex
+	processed map[string]string // id -> result
+}
+
+func newMockProcessedStore() *mockProcessedStore {
+	return &mockProcessedStore{
+		processed: make(map[string]string),
+	}
+}
+
+func (m *mockProcessedStore) MarkPlaneIssueProcessed(issueID string, result string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.processed[issueID] = result
+	return nil
+}
+
+func (m *mockProcessedStore) UnmarkPlaneIssueProcessed(issueID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.processed, issueID)
+	return nil
+}
+
+func (m *mockProcessedStore) IsPlaneIssueProcessed(issueID string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.processed[issueID]
+	return ok, nil
+}
+
+func (m *mockProcessedStore) LoadPlaneProcessedIssues() (map[string]bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make(map[string]bool)
+	for key := range m.processed {
+		result[key] = true
+	}
+	return result, nil
+}
+
+func TestPoller_LoadsProcessedFromStore(t *testing.T) {
+	store := newMockProcessedStore()
+
+	// Pre-populate store with processed issues
+	store.processed["uuid-1"] = "processed"
+	store.processed["uuid-2"] = "processed"
+
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+
+	poller := NewPoller(client, config, 30*time.Second, WithProcessedStore(store))
+
+	if poller.ProcessedCount() != 2 {
+		t.Errorf("ProcessedCount = %d, want 2", poller.ProcessedCount())
+	}
+
+	if !poller.IsProcessed("uuid-1") {
+		t.Error("uuid-1 should be processed")
+	}
+	if !poller.IsProcessed("uuid-2") {
+		t.Error("uuid-2 should be processed")
+	}
+	if poller.IsProcessed("uuid-3") {
+		t.Error("uuid-3 should not be processed")
+	}
+}
+
+func TestPoller_MarkProcessed_PersistsToStore(t *testing.T) {
+	store := newMockProcessedStore()
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+
+	poller := NewPoller(client, config, 30*time.Second, WithProcessedStore(store))
+
+	poller.markProcessed("uuid-new")
+
+	if !poller.IsProcessed("uuid-new") {
+		t.Error("uuid-new should be processed in memory")
+	}
+
+	store.mu.Lock()
+	_, exists := store.processed["uuid-new"]
+	store.mu.Unlock()
+	if !exists {
+		t.Error("uuid-new should be persisted to store")
+	}
+}
+
+func TestPoller_ClearProcessed_RemovesFromStore(t *testing.T) {
+	store := newMockProcessedStore()
+	store.processed["uuid-clear"] = "processed"
+
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+
+	poller := NewPoller(client, config, 30*time.Second, WithProcessedStore(store))
+
+	if !poller.IsProcessed("uuid-clear") {
+		t.Error("uuid-clear should be processed initially")
+	}
+
+	poller.ClearProcessed("uuid-clear")
+
+	if poller.IsProcessed("uuid-clear") {
+		t.Error("uuid-clear should not be processed after clearing")
+	}
+
+	store.mu.Lock()
+	_, exists := store.processed["uuid-clear"]
+	store.mu.Unlock()
+	if exists {
+		t.Error("uuid-clear should be removed from store")
+	}
+}
+
+func TestPoller_WithMaxConcurrent(t *testing.T) {
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+
+	poller := NewPoller(client, config, 30*time.Second, WithMaxConcurrent(5))
+
+	if poller.maxConcurrent != 5 {
+		t.Errorf("maxConcurrent = %d, want 5", poller.maxConcurrent)
+	}
+
+	if cap(poller.semaphore) != 5 {
+		t.Errorf("semaphore capacity = %d, want 5", cap(poller.semaphore))
+	}
+}
+
+func TestPoller_WithMaxConcurrent_DefaultsToTwo(t *testing.T) {
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+
+	poller := NewPoller(client, config, 30*time.Second)
+
+	if poller.maxConcurrent != 2 {
+		t.Errorf("default maxConcurrent = %d, want 2", poller.maxConcurrent)
+	}
+}
+
+func TestPoller_WithMaxConcurrent_MinimumOne(t *testing.T) {
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+
+	poller := NewPoller(client, config, 30*time.Second, WithMaxConcurrent(0))
+
+	if poller.maxConcurrent != 1 {
+		t.Errorf("maxConcurrent with 0 = %d, want 1 (minimum)", poller.maxConcurrent)
+	}
+
+	poller2 := NewPoller(client, config, 30*time.Second, WithMaxConcurrent(-5))
+
+	if poller2.maxConcurrent != 1 {
+		t.Errorf("maxConcurrent with -5 = %d, want 1 (minimum)", poller2.maxConcurrent)
+	}
+}
+
+func TestPoller_Drain(t *testing.T) {
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+
+	poller := NewPoller(client, config, 30*time.Second)
+
+	// Simulate an active task
+	poller.semaphore <- struct{}{}
+	poller.activeWg.Add(1)
+
+	drainDone := make(chan struct{})
+	go func() {
+		poller.Drain()
+		close(drainDone)
+	}()
+
+	// Give Drain time to set stopping flag
+	time.Sleep(10 * time.Millisecond)
+
+	if !poller.stopping.Load() {
+		t.Error("stopping should be true after Drain called")
+	}
+
+	// Complete the active task
+	<-poller.semaphore
+	poller.activeWg.Done()
+
+	select {
+	case <-drainDone:
+		// Good
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Drain should complete after active tasks finish")
+	}
+}
+
+func TestPoller_WaitForActive(t *testing.T) {
+	client := NewClient("https://api.plane.so", testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{PilotLabel: "pilot", ProjectIDs: []string{testProjectID}}
+
+	poller := NewPoller(client, config, 30*time.Second)
+
+	// Simulate an active task
+	poller.semaphore <- struct{}{}
+	poller.activeWg.Add(1)
+
+	waitDone := make(chan struct{})
+	go func() {
+		poller.WaitForActive()
+		close(waitDone)
+	}()
+
+	// Give WaitForActive time to set stopping flag
+	time.Sleep(10 * time.Millisecond)
+
+	if !poller.stopping.Load() {
+		t.Error("stopping should be true after WaitForActive called")
+	}
+
+	// Complete the active task
+	<-poller.semaphore
+	poller.activeWg.Done()
+
+	select {
+	case <-waitDone:
+		// Good
+	case <-time.After(100 * time.Millisecond):
+		t.Error("WaitForActive should complete after active tasks finish")
+	}
+}
+
+func TestPollerRecoverOrphanedIssues(t *testing.T) {
+	labels := []Label{
+		{ID: testPilotLabelID, Name: "pilot"},
+		{ID: testInProgressLabelID, Name: "pilot-in-progress"},
+	}
+
+	orphanedItems := []WorkItem{
+		{
+			ID:        "orphan-1",
+			Name:      "Orphaned issue",
+			Labels:    []string{testPilotLabelID, testInProgressLabelID},
+			ProjectID: testProjectID,
+		},
+	}
+
+	var patchCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && containsStr(r.URL.Path, "/labels/") {
+			resp := ListResponse[Label]{Results: labels, TotalCount: len(labels)}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if r.Method == http.MethodGet && containsStr(r.URL.Path, "/work-items/") && !containsStr(r.URL.Path, "orphan-1") {
+			// List with in-progress label filter
+			resp := ListResponse[WorkItem]{Results: orphanedItems, TotalCount: 1}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if r.Method == http.MethodGet && containsStr(r.URL.Path, "orphan-1") {
+			_ = json.NewEncoder(w).Encode(orphanedItems[0])
+			return
+		}
+
+		if r.Method == http.MethodPatch {
+			patchCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, testutil.FakePlaneAPIKey, testWorkspaceSlug)
+	config := &Config{
+		PilotLabel:    "pilot",
+		WorkspaceSlug: testWorkspaceSlug,
+		ProjectIDs:    []string{testProjectID},
+	}
+	poller := NewPoller(client, config, 30*time.Second)
+	poller.inProgressLabelID = testInProgressLabelID
+
+	poller.recoverOrphanedIssues(context.Background())
+
+	// Should have made a PATCH call to remove the in-progress label
+	if patchCount == 0 {
+		t.Error("expected at least one PATCH call to remove in-progress label")
+	}
+}

--- a/internal/adapters/plane/types.go
+++ b/internal/adapters/plane/types.go
@@ -1,0 +1,88 @@
+// Package plane provides an adapter for Plane.so project management.
+package plane
+
+import "time"
+
+// Config holds Plane adapter configuration
+type Config struct {
+	Enabled       bool     `yaml:"enabled"`
+	BaseURL       string   `yaml:"base_url"`        // e.g., "https://api.plane.so" or self-hosted URL
+	APIKey        string   `yaml:"api_key"`          // Plane API key
+	WorkspaceSlug string   `yaml:"workspace_slug"`   // Workspace slug
+	ProjectIDs    []string `yaml:"project_ids"`      // Filter by project UUIDs
+	WebhookSecret string   `yaml:"webhook_secret"`   // For HMAC signature verification
+	PilotLabel    string   `yaml:"pilot_label"`      // Label name that triggers Pilot (default: "pilot")
+
+	// Polling configuration
+	Polling *PollingConfig `yaml:"polling,omitempty"`
+}
+
+// PollingConfig holds polling configuration for Plane adapter
+type PollingConfig struct {
+	Enabled  bool          `yaml:"enabled"`
+	Interval time.Duration `yaml:"interval,omitempty"`
+}
+
+// DefaultConfig returns default Plane configuration
+func DefaultConfig() *Config {
+	return &Config{
+		Enabled:    false,
+		BaseURL:    "https://api.plane.so",
+		PilotLabel: "pilot",
+	}
+}
+
+// WorkItem represents a Plane work item (issue)
+type WorkItem struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description_html,omitempty"`
+	StateID     string    `json:"state"`
+	Priority    string    `json:"priority"` // "urgent", "high", "medium", "low", "none"
+	Labels      []string  `json:"labels"`   // Array of label UUIDs
+	ProjectID   string    `json:"project"`
+	WorkspaceID string    `json:"workspace"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Sequence    int       `json:"sequence_id"`
+}
+
+// Label represents a Plane label
+type Label struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color,omitempty"`
+}
+
+// State represents a Plane project state
+type State struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Group string `json:"group"` // "backlog", "unstarted", "started", "completed", "cancelled"
+	Color string `json:"color,omitempty"`
+}
+
+// ListResponse wraps paginated API responses
+type ListResponse[T any] struct {
+	Results    []T  `json:"results"`
+	TotalCount int  `json:"total_count"`
+	NextPage   *int `json:"next_page_id,omitempty"`
+}
+
+// Priority levels matching Plane API
+const (
+	PriorityUrgent = "urgent"
+	PriorityHigh   = "high"
+	PriorityMedium = "medium"
+	PriorityLow    = "low"
+	PriorityNone   = "none"
+)
+
+// State groups (fixed in Plane)
+const (
+	StateGroupBacklog   = "backlog"
+	StateGroupUnstarted = "unstarted"
+	StateGroupStarted   = "started"
+	StateGroupCompleted = "completed"
+	StateGroupCancelled = "cancelled"
+)

--- a/internal/testutil/tokens.go
+++ b/internal/testutil/tokens.go
@@ -84,4 +84,10 @@ const (
 
 	// FakeAzureDevOpsWebhookSecret is a safe test secret for Azure DevOps webhook verification.
 	FakeAzureDevOpsWebhookSecret = "test-azure-devops-webhook-secret"
+
+	// FakePlaneAPIKey is a safe test API key for Plane.so.
+	FakePlaneAPIKey = "test-plane-api-key"
+
+	// FakePlaneWebhookSecret is a safe test webhook secret for Plane.so.
+	FakePlaneWebhookSecret = "test-plane-webhook-secret"
 )


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1830.

Closes #1830

## Changes

GitHub Issue #1830: feat(adapters): Add Plane.so poller with parallel execution

## Parent: #1827
## DependsOn: #1828, #1829

### What
Create the Plane.so poller that polls for issues with `pilot` label and dispatches them for execution with parallel support.

### Files to Create
- `internal/adapters/plane/poller.go` — Main poller (copy Jira poller ~90%)

### Reference (copy pattern from)
- `internal/adapters/jira/poller.go` — Primary reference (90% reuse)
- `internal/adapters/asana/poller.go` — String-ID reference

### Poller Structure
```go
type Poller struct {
    client         *Client
    config         *Config
    interval       time.Duration
    processed      map[string]bool
    mu             sync.RWMutex
    onIssue        func(ctx context.Context, issue *WorkItem) (*IssueResult, error)
    maxConcurrent  int
    semaphore      chan struct{}
    activeWg       sync.WaitGroup
    stopping       atomic.Bool
    wgMu           sync.Mutex
    processedStore ProcessedStore
    onPRCreated    func(prNumber int, prURL, issueID, headSHA, branchName string)
    log            *slog.Logger
    // Label UUID cache
    pilotLabelID       string
    inProgressLabelID  string
    doneLabelID        string
    failedLabelID      string
}
```

### Required Behavior
1. **Startup**: Cache label UUIDs (resolve `pilot`, `pilot-in-progress`, `pilot-done`, `pilot-failed` by name)
2. **Startup**: Recover orphaned issues (find `pilot-in-progress`, remove label)
3. **Poll loop**: List work items with `pilot` label, skip processed, dispatch async
4. **On dispatch**: Add `pilot-in-progress` label
5. **On success**: Remove `pilot-in-progress`, add `pilot-done`, call OnPRCreated
6. **On failure**: Remove `pilot-in-progress`, add `pilot-failed`
7. **Parallel**: Semaphore + WaitGroup with `maxConcurrent` limit
8. **Filter**: Only process issues from configured `project_ids`

### PollerOption Pattern
```go
type PollerOption func(*Poller)
WithOnIssue(fn) / WithProcessedStore(store) / WithMaxConcurrent(n)
WithOnPRCreated(fn) / WithPollerLogger(logger)
```

### IssueResult
```go
type IssueResult struct {
    Success    bool
    PRNumber   int
    PRURL      string
    HeadSHA    string
    BranchName string
    Error      error
}
```

### Label Management Note
Plane assigns labels as UUID array on work items. To add/remove a label:
1. GET work item → read current `labels` array
2. Append/filter UUID
3. PATCH work item with updated `labels` array

### Acceptance Criteria
- [ ] Poller starts, caches label UUIDs, recovers orphans
- [ ] Polls at configured interval, dispatches new issues
- [ ] Parallel execution with semaphore
- [ ] ProcessedStore integration for dedup
- [ ] Label lifecycle: in-progress → done/failed
- [ ] OnPRCreated callback wired
- [ ] Unit tests for poller logic