### PR TITLE
refactor(main): Extract poller registration pattern from main.go

### DIFF
--- a/cmd/pilot/poller_asana.go
+++ b/cmd/pilot/poller_asana.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/adapters/asana"
+	"github.com/alekspetrov/pilot/internal/config"
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+func asanaPollerRegistration() PollerRegistration {
+	return PollerRegistration{
+		Name: "asana",
+		Enabled: func(cfg *config.Config) bool {
+			return cfg.Adapters.Asana != nil && cfg.Adapters.Asana.Enabled &&
+				cfg.Adapters.Asana.Polling != nil && cfg.Adapters.Asana.Polling.Enabled
+		},
+		CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
+			// Determine interval
+			interval := 30 * time.Second
+			if deps.Cfg.Adapters.Asana.Polling.Interval > 0 {
+				interval = deps.Cfg.Adapters.Asana.Polling.Interval
+			}
+
+			asanaClient := asana.NewClient(
+				deps.Cfg.Adapters.Asana.AccessToken,
+				deps.Cfg.Adapters.Asana.WorkspaceID,
+			)
+			// GH-1701: Wire processed store for dedup persistence across restarts
+			asanaPollerOpts := []asana.PollerOption{
+				asana.WithOnAsanaTask(func(taskCtx context.Context, task *asana.Task) (*asana.TaskResult, error) {
+					result, err := handleAsanaTaskWithResult(taskCtx, deps.Cfg, asanaClient, task, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
+
+					// GH-1399: Wire PR to autopilot for CI monitoring + auto-merge
+					if result != nil && result.PRNumber > 0 && deps.AutopilotController != nil {
+						// issueNumber=0 because Asana tasks don't have GitHub issue numbers
+						deps.AutopilotController.OnPRCreated(result.PRNumber, result.PRURL, 0, result.HeadSHA, result.BranchName)
+					}
+
+					return result, err
+				}),
+			}
+			if deps.AutopilotStateStore != nil {
+				asanaPollerOpts = append(asanaPollerOpts, asana.WithProcessedStore(deps.AutopilotStateStore))
+			}
+			asanaPoller := asana.NewPoller(asanaClient, deps.Cfg.Adapters.Asana, interval, asanaPollerOpts...)
+
+			logging.WithComponent("start").Info("Asana polling enabled",
+				slog.String("workspace", deps.Cfg.Adapters.Asana.WorkspaceID),
+				slog.String("tag", deps.Cfg.Adapters.Asana.PilotTag),
+				slog.Duration("interval", interval),
+			)
+			go func(p *asana.Poller) {
+				if err := p.Start(ctx); err != nil {
+					logging.WithComponent("asana").Error("Asana poller failed",
+						slog.Any("error", err),
+					)
+				}
+			}(asanaPoller)
+		},
+	}
+}

--- a/cmd/pilot/poller_azuredevops.go
+++ b/cmd/pilot/poller_azuredevops.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/adapters/azuredevops"
+	"github.com/alekspetrov/pilot/internal/config"
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+func azuredevopsPollerRegistration() PollerRegistration {
+	return PollerRegistration{
+		Name: "azuredevops",
+		Enabled: func(cfg *config.Config) bool {
+			return cfg.Adapters.AzureDevOps != nil && cfg.Adapters.AzureDevOps.Enabled &&
+				cfg.Adapters.AzureDevOps.Polling != nil && cfg.Adapters.AzureDevOps.Polling.Enabled
+		},
+		CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
+			// Determine interval
+			interval := 30 * time.Second
+			if deps.Cfg.Adapters.AzureDevOps.Polling.Interval > 0 {
+				interval = deps.Cfg.Adapters.AzureDevOps.Polling.Interval
+			}
+
+			adoClient := azuredevops.NewClientWithConfig(deps.Cfg.Adapters.AzureDevOps)
+
+			adoPollerOpts := []azuredevops.PollerOption{
+				azuredevops.WithOnWorkItem(func(wiCtx context.Context, wi *azuredevops.WorkItem) error {
+					logging.WithComponent("azuredevops").Info("Work item picked up",
+						slog.Int("id", wi.ID),
+						slog.String("title", wi.GetTitle()),
+					)
+					return nil
+				}),
+			}
+
+			// Wire autopilot OnPRCreated callback
+			if deps.AutopilotController != nil {
+				adoPollerOpts = append(adoPollerOpts, azuredevops.WithOnPRCreated(func(prID int, prURL string, workItemID int, headSHA string, branchName string) {
+					deps.AutopilotController.OnPRCreated(prID, prURL, 0, headSHA, branchName)
+				}))
+			}
+
+			// Wire processed store for persistence
+			if deps.AutopilotStateStore != nil {
+				adoPollerOpts = append(adoPollerOpts, azuredevops.WithProcessedStore(deps.AutopilotStateStore))
+			}
+
+			pilotTag := deps.Cfg.Adapters.AzureDevOps.PilotTag
+			if pilotTag == "" {
+				pilotTag = "pilot"
+			}
+
+			adoPoller := azuredevops.NewPoller(adoClient, pilotTag, interval, adoPollerOpts...)
+
+			logging.WithComponent("start").Info("Azure DevOps polling enabled",
+				slog.String("organization", deps.Cfg.Adapters.AzureDevOps.Organization),
+				slog.String("project", deps.Cfg.Adapters.AzureDevOps.Project),
+				slog.Duration("interval", interval),
+			)
+			go adoPoller.Start(ctx)
+		},
+	}
+}

--- a/cmd/pilot/poller_jira.go
+++ b/cmd/pilot/poller_jira.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/alekspetrov/pilot/internal/adapters"
+	"github.com/alekspetrov/pilot/internal/adapters/jira"
+	"github.com/alekspetrov/pilot/internal/config"
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+func jiraPollerRegistration() PollerRegistration {
+	return PollerRegistration{
+		Name: "jira",
+		Enabled: func(cfg *config.Config) bool {
+			return cfg.Adapters.Jira != nil && cfg.Adapters.Jira.Enabled &&
+				cfg.Adapters.Jira.Polling != nil && cfg.Adapters.Jira.Polling.Enabled
+		},
+		CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
+			// GH-1838: Jira adapter via common adapter interface + registry
+			jiraAdapter := jira.NewAdapter(deps.Cfg.Adapters.Jira)
+			adapters.Register(jiraAdapter)
+
+			pollerDeps := adapters.PollerDeps{
+				MaxConcurrent: deps.Cfg.Orchestrator.MaxConcurrent,
+			}
+			if deps.AutopilotStateStore != nil {
+				pollerDeps.ProcessedStore = deps.AutopilotStateStore
+			}
+
+			jiraPoller := jiraAdapter.CreatePoller(pollerDeps, func(issueCtx context.Context, issue *jira.Issue) (*jira.IssueResult, error) {
+				result, err := handleJiraIssueWithResult(issueCtx, deps.Cfg, jiraAdapter.Client(), issue, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
+
+				// GH-1399: Wire PR to autopilot for CI monitoring + auto-merge
+				if result != nil && result.PRNumber > 0 && deps.AutopilotController != nil {
+					deps.AutopilotController.OnPRCreated(result.PRNumber, result.PRURL, 0, result.HeadSHA, result.BranchName)
+				}
+
+				return result, err
+			})
+
+			logging.WithComponent("start").Info("Jira polling enabled",
+				slog.String("base_url", deps.Cfg.Adapters.Jira.BaseURL),
+				slog.String("project", deps.Cfg.Adapters.Jira.ProjectKey),
+				slog.String("adapter", jiraAdapter.Name()),
+			)
+			go func(p *jira.Poller) {
+				if err := p.Start(ctx); err != nil {
+					logging.WithComponent("jira").Error("Jira poller failed",
+						slog.Any("error", err),
+					)
+				}
+			}(jiraPoller)
+		},
+	}
+}

--- a/cmd/pilot/poller_linear.go
+++ b/cmd/pilot/poller_linear.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/adapters/linear"
+	"github.com/alekspetrov/pilot/internal/config"
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+func linearPollerRegistration() PollerRegistration {
+	return PollerRegistration{
+		Name: "linear",
+		Enabled: func(cfg *config.Config) bool {
+			return cfg.Adapters.Linear != nil && cfg.Adapters.Linear.Enabled &&
+				cfg.Adapters.Linear.Polling != nil && cfg.Adapters.Linear.Polling.Enabled
+		},
+		CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
+			workspaces := deps.Cfg.Adapters.Linear.GetWorkspaces()
+			for _, ws := range workspaces {
+				// Determine interval: workspace override > global > default
+				interval := 30 * time.Second
+				if ws.Polling != nil && ws.Polling.Interval > 0 {
+					interval = ws.Polling.Interval
+				} else if deps.Cfg.Adapters.Linear.Polling.Interval > 0 {
+					interval = deps.Cfg.Adapters.Linear.Polling.Interval
+				}
+
+				// Check if workspace polling is explicitly disabled
+				if ws.Polling != nil && !ws.Polling.Enabled {
+					continue
+				}
+
+				linearClient := linear.NewClient(ws.APIKey)
+				// Capture workspace config for per-issue project resolution (GH-1348)
+				wsConfig := ws
+
+				// Build poller options
+				linearPollerOpts := []linear.PollerOption{
+					linear.WithOnLinearIssue(func(issueCtx context.Context, issue *linear.Issue) (*linear.IssueResult, error) {
+						// GH-1348: Resolve project path per-issue using workspace→project mapping
+						issueProjectPath := deps.ProjectPath // fallback to default
+						var resolvedProject *config.ProjectConfig
+
+						// GH-1684: Check project-level linear.project_id mapping first
+						if issue.Project != nil {
+							resolvedProject = deps.Cfg.GetProjectByLinearID(issue.Project.ID)
+						}
+
+						// Fall back to workspace-level resolution
+						if resolvedProject == nil {
+							pilotProject := wsConfig.ResolvePilotProject(issue)
+							if pilotProject != "" {
+								resolvedProject = deps.Cfg.GetProjectByName(pilotProject)
+							}
+						}
+
+						if resolvedProject != nil {
+							issueProjectPath = resolvedProject.Path
+						}
+
+						result, err := handleLinearIssueWithResult(issueCtx, deps.Cfg, linearClient, issue, issueProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
+
+						// Wire PR to autopilot for CI monitoring + auto-merge
+						if result != nil && result.PRNumber > 0 {
+							// GH-1361: Polling mode uses per-repo autopilot controllers
+							if deps.AutopilotControllers != nil && resolvedProject != nil && resolvedProject.GitHub != nil {
+								repoFullName := fmt.Sprintf("%s/%s", resolvedProject.GitHub.Owner, resolvedProject.GitHub.Repo)
+								if controller, ok := deps.AutopilotControllers[repoFullName]; ok && controller != nil {
+									controller.OnPRCreated(result.PRNumber, result.PRURL, 0, result.HeadSHA, result.BranchName)
+								}
+							} else if deps.AutopilotController != nil {
+								// GH-1700: Gateway mode uses single autopilot controller
+								deps.AutopilotController.OnPRCreated(result.PRNumber, result.PRURL, 0, result.HeadSHA, result.BranchName)
+							}
+						}
+
+						return result, err
+					}),
+				}
+
+				// GH-1351: Wire processed issue persistence to prevent re-dispatch after hot upgrade
+				if deps.AutopilotStateStore != nil {
+					linearPollerOpts = append(linearPollerOpts, linear.WithProcessedStore(deps.AutopilotStateStore))
+				}
+
+				// GH-1700: Wire OnPRCreated callback for gateway mode (direct wiring)
+				if deps.AutopilotController != nil && deps.AutopilotControllers == nil {
+					linearPollerOpts = append(linearPollerOpts, linear.WithOnPRCreated(deps.AutopilotController.OnPRCreated))
+				}
+
+				linearPoller := linear.NewPoller(linearClient, ws, interval, linearPollerOpts...)
+
+				logging.WithComponent("start").Info("Linear polling enabled",
+					slog.String("workspace", ws.Name),
+					slog.String("team", ws.TeamID),
+					slog.Duration("interval", interval),
+				)
+				go func(p *linear.Poller, name string) {
+					if err := p.Start(ctx); err != nil {
+						logging.WithComponent("linear").Error("Linear poller failed",
+							slog.String("workspace", name),
+							slog.Any("error", err),
+						)
+					}
+				}(linearPoller, ws.Name)
+			}
+		},
+	}
+}

--- a/cmd/pilot/poller_plane.go
+++ b/cmd/pilot/poller_plane.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/adapters/plane"
+	"github.com/alekspetrov/pilot/internal/config"
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+func planePollerRegistration() PollerRegistration {
+	return PollerRegistration{
+		Name: "plane",
+		Enabled: func(cfg *config.Config) bool {
+			return cfg.Adapters.Plane != nil && cfg.Adapters.Plane.Enabled &&
+				cfg.Adapters.Plane.Polling != nil && cfg.Adapters.Plane.Polling.Enabled
+		},
+		CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
+			// Determine interval
+			interval := 30 * time.Second
+			if deps.Cfg.Adapters.Plane.Polling.Interval > 0 {
+				interval = deps.Cfg.Adapters.Plane.Polling.Interval
+			}
+
+			planeClient := plane.NewClient(
+				deps.Cfg.Adapters.Plane.BaseURL,
+				deps.Cfg.Adapters.Plane.APIKey,
+			)
+
+			planePollerOpts := []plane.PollerOption{
+				plane.WithOnIssue(func(issueCtx context.Context, issue *plane.WorkItem) (*plane.IssueResult, error) {
+					result, err := handlePlaneIssueWithResult(issueCtx, deps.Cfg, planeClient, issue, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
+
+					// Wire PR to autopilot for CI monitoring + auto-merge
+					if result != nil && result.PRNumber > 0 && deps.AutopilotController != nil {
+						deps.AutopilotController.OnPRCreated(result.PRNumber, result.PRURL, 0, result.HeadSHA, result.BranchName)
+					}
+
+					return result, err
+				}),
+			}
+			if deps.AutopilotStateStore != nil {
+				planePollerOpts = append(planePollerOpts, plane.WithProcessedStore(deps.AutopilotStateStore))
+			}
+			if deps.Cfg.Orchestrator.MaxConcurrent > 0 {
+				planePollerOpts = append(planePollerOpts, plane.WithMaxConcurrent(deps.Cfg.Orchestrator.MaxConcurrent))
+			}
+			planePoller := plane.NewPoller(planeClient, deps.Cfg.Adapters.Plane, interval, planePollerOpts...)
+
+			logging.WithComponent("start").Info("Plane.so polling enabled",
+				slog.String("workspace", deps.Cfg.Adapters.Plane.WorkspaceSlug),
+				slog.Int("projects", len(deps.Cfg.Adapters.Plane.ProjectIDs)),
+				slog.Duration("interval", interval),
+			)
+			go func(p *plane.Poller) {
+				if err := p.Start(ctx); err != nil {
+					logging.WithComponent("plane").Error("Plane poller failed",
+						slog.Any("error", err),
+					)
+				}
+			}(planePoller)
+		},
+	}
+}

--- a/cmd/pilot/poller_registry.go
+++ b/cmd/pilot/poller_registry.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/alekspetrov/pilot/internal/alerts"
+	"github.com/alekspetrov/pilot/internal/autopilot"
+	"github.com/alekspetrov/pilot/internal/budget"
+	"github.com/alekspetrov/pilot/internal/config"
+	"github.com/alekspetrov/pilot/internal/executor"
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// PollerDeps groups shared infrastructure used by all adapter poller startup blocks.
+type PollerDeps struct {
+	Cfg         *config.Config
+	ProjectPath string
+
+	Dispatcher   *executor.Dispatcher
+	Runner       *executor.Runner
+	Monitor      *executor.Monitor
+	Program      *tea.Program
+	AlertsEngine *alerts.Engine
+	Enforcer     *budget.Enforcer
+
+	AutopilotController  *autopilot.Controller
+	AutopilotStateStore  *autopilot.StateStore
+	AutopilotControllers map[string]*autopilot.Controller // polling mode: per-repo controllers
+}
+
+// PollerRegistration describes a single adapter poller that can be conditionally started.
+type PollerRegistration struct {
+	Name           string
+	Enabled        func(cfg *config.Config) bool
+	CreateAndStart func(ctx context.Context, deps *PollerDeps)
+}
+
+// adapterPollerRegistrations returns the standard set of adapter poller registrations.
+// GitHub poller is NOT included — it has unique multi-repo, rate-limit, and execution mode complexity.
+func adapterPollerRegistrations() []PollerRegistration {
+	return []PollerRegistration{
+		linearPollerRegistration(),
+		jiraPollerRegistration(),
+		asanaPollerRegistration(),
+		azuredevopsPollerRegistration(),
+		planePollerRegistration(),
+	}
+}
+
+// StartAdapterPollers iterates registrations and starts each enabled poller.
+func StartAdapterPollers(ctx context.Context, deps *PollerDeps, registrations []PollerRegistration) {
+	for _, reg := range registrations {
+		if reg.Enabled(deps.Cfg) {
+			logging.WithComponent("start").Info("Starting adapter poller",
+				slog.String("adapter", reg.Name),
+			)
+			reg.CreateAndStart(ctx, deps)
+		}
+	}
+}

--- a/cmd/pilot/poller_registry_test.go
+++ b/cmd/pilot/poller_registry_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/config"
+)
+
+func TestStartAdapterPollers_OnlyStartsEnabled(t *testing.T) {
+	var started []string
+
+	registrations := []PollerRegistration{
+		{
+			Name:    "enabled-adapter",
+			Enabled: func(_ *config.Config) bool { return true },
+			CreateAndStart: func(_ context.Context, _ *PollerDeps) {
+				started = append(started, "enabled-adapter")
+			},
+		},
+		{
+			Name:    "disabled-adapter",
+			Enabled: func(_ *config.Config) bool { return false },
+			CreateAndStart: func(_ context.Context, _ *PollerDeps) {
+				started = append(started, "disabled-adapter")
+			},
+		},
+		{
+			Name:    "another-enabled",
+			Enabled: func(_ *config.Config) bool { return true },
+			CreateAndStart: func(_ context.Context, _ *PollerDeps) {
+				started = append(started, "another-enabled")
+			},
+		},
+	}
+
+	deps := &PollerDeps{Cfg: &config.Config{}}
+	StartAdapterPollers(context.Background(), deps, registrations)
+
+	if len(started) != 2 {
+		t.Fatalf("expected 2 pollers started, got %d", len(started))
+	}
+	if started[0] != "enabled-adapter" {
+		t.Errorf("expected first started = enabled-adapter, got %s", started[0])
+	}
+	if started[1] != "another-enabled" {
+		t.Errorf("expected second started = another-enabled, got %s", started[1])
+	}
+}
+
+func TestAdapterPollerRegistrations_ReturnsAllFive(t *testing.T) {
+	regs := adapterPollerRegistrations()
+	if len(regs) != 5 {
+		t.Fatalf("expected 5 registrations, got %d", len(regs))
+	}
+
+	expected := []string{"linear", "jira", "asana", "azuredevops", "plane"}
+	for i, name := range expected {
+		if regs[i].Name != name {
+			t.Errorf("registration[%d]: expected name %q, got %q", i, name, regs[i].Name)
+		}
+	}
+}
+
+func TestPollerRegistrations_EnabledChecksConfig(t *testing.T) {
+	regs := adapterPollerRegistrations()
+	// Config with initialized but empty Adapters
+	emptyCfg := &config.Config{
+		Adapters: &config.AdaptersConfig{},
+	}
+
+	for _, reg := range regs {
+		if reg.Enabled(emptyCfg) {
+			t.Errorf("registration %q should be disabled with empty config", reg.Name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1847.

Closes #1847

## Changes

GitHub Issue #1847: refactor(main): Extract poller registration pattern from main.go

## Context

`cmd/pilot/main.go` duplicates ~50 lines of poller wiring per adapter, and duplicates it AGAIN across gateway mode and polling mode. Adding a new adapter means adding the same block in 2 places. This extracts a registration pattern.

## Depends On

- #1845 (uses HandlerDeps from Phase 2)

## Changes

### `cmd/pilot/poller_registry.go` (create)

1. **`PollerRegistration` struct**:
```go
type PollerRegistration struct {
    Name           string
    Enabled        func(cfg *config.Config) bool
    CreateAndStart func(ctx context.Context, deps *PollerDeps)
}
```

2. **`PollerDeps` struct** — groups shared infra used by all poller startup blocks:
```go
type PollerDeps struct {
    Cfg                  *config.Config
    ProjectPath          string
    Dispatcher           *executor.Dispatcher
    Runner               *executor.Runner
    Monitor              *executor.Monitor
    Program              *tea.Program
    AlertsEngine         *alerts.Engine
    Enforcer             *budget.Enforcer
    AutopilotController  *autopilot.Controller
    AutopilotStateStore  *autopilot.StateStore
}
```

3. **`StartAdapterPollers(ctx, deps, registrations)`** — iterate enabled registrations and start each

### Per-adapter poller files (create, one each)

- `cmd/pilot/poller_linear.go` — `linearPollerRegistration()` extracted from inline main.go
- `cmd/pilot/poller_jira.go` — `jiraPollerRegistration()` 
- `cmd/pilot/poller_asana.go` — `asanaPollerRegistration()`
- `cmd/pilot/poller_azuredevops.go` — `azuredevopsPollerRegistration()`
- `cmd/pilot/poller_plane.go` — `planePollerRegistration()`

Each file contains a single function that returns `PollerRegistration` with:
- `Enabled`: check if adapter is configured and enabled in config
- `CreateAndStart`: create client, build poller options (OnIssue callback using `HandlerDeps`, wire processed store, wire autopilot OnPRCreated), create poller, start in goroutine

**Note**: GitHub poller NOT extracted — it has unique complexity (multi-repo, rate limit scheduler, sequential/parallel modes, execution mode config). Keep it inline.

### `cmd/pilot/main.go` (modify)

Replace 2x inline poller blocks (gateway mode lines ~807-1055 + polling mode equivalent) with:
```go
adapterPollers := []PollerRegistration{
    linearPollerRegistration(),
    jiraPollerRegistration(),
    asanaPollerRegistration(),
    azuredevopsPollerRegistration(),
    planePollerRegistration(),
}
StartAdapterPollers(ctx, deps, adapterPollers)
```

### Config: No Change (Deferred)

`AdaptersConfig` keeps named fields — changing to `map[string]AdapterConfig` would break YAML parsing for all users. Acceptable to add one more field for new adapters. Revisit at 10+ adapters.

## Verification

- `make test` — startup tests pass
- `make build` — compiles cleanly  
- Manual smoke: `pilot start --github --telegram` in both gateway and polling modes
- Verify each adapter's poller starts correctly with appropriate log messages