### PR TITLE
feat(github): Add ProjectBoardConfig types and NodeID to Issue struct

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -48,6 +48,7 @@ func NewClientWithBaseURL(token, baseURL string) *Client {
 // Issue represents a GitHub issue
 type Issue struct {
 	ID        int64     `json:"id"`
+	NodeID    string    `json:"node_id"` // GraphQL global node ID
 	Number    int       `json:"number"`
 	Title     string    `json:"title"`
 	Body      string    `json:"body"`

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -12,6 +12,7 @@ type Config struct {
 	ProjectPath       string                   `yaml:"project_path"`        // Required project path - must match repo (GH-386)
 	Polling           *PollingConfig           `yaml:"polling"`             // Polling configuration
 	StaleLabelCleanup *StaleLabelCleanupConfig `yaml:"stale_label_cleanup"` // Auto-cleanup stale labels
+	ProjectBoard      *ProjectBoardConfig      `yaml:"project_board"`       // GitHub Projects V2 board sync
 }
 
 // PollingConfig holds GitHub polling settings
@@ -27,6 +28,23 @@ type StaleLabelCleanupConfig struct {
 	Interval        time.Duration `yaml:"interval"`         // How often to check for stale labels (default: 30m)
 	Threshold       time.Duration `yaml:"threshold"`        // How long before pilot-in-progress is stale (default: 1h)
 	FailedThreshold time.Duration `yaml:"failed_threshold"` // How long before pilot-failed is stale (default: 24h)
+}
+
+// ProjectBoardConfig configures GitHub Projects V2 board sync.
+// When nil or Enabled=false, board sync is skipped.
+type ProjectBoardConfig struct {
+	Enabled       bool            `yaml:"enabled"`
+	ProjectNumber int             `yaml:"project_number"` // Project number from URL
+	StatusField   string          `yaml:"status_field"`   // Field name, e.g. "Status"
+	Statuses      ProjectStatuses `yaml:"statuses"`
+}
+
+// ProjectStatuses maps Pilot lifecycle events to board column names.
+type ProjectStatuses struct {
+	InProgress string `yaml:"in_progress"` // e.g. "In Dev"
+	Review     string `yaml:"review"`      // e.g. "Ready for Review"
+	Done       string `yaml:"done"`        // e.g. "Done"
+	Failed     string `yaml:"failed"`      // Optional — e.g. "Blocked"
 }
 
 // DefaultConfig returns default GitHub configuration


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1849.

Closes #1849

## Changes

GitHub Issue #1849: feat(github): Add ProjectBoardConfig types and NodeID to Issue struct

## Context

Part of GH-1834 (GitHub Projects V2 board sync). This issue adds config types and the NodeID field needed by subsequent issues.

## Changes

**File: `internal/adapters/github/types.go`**

1. Add `NodeID` field to `Issue` struct (GitHub REST API already returns `node_id`):
```go
type Issue struct {
    ID        int64     `json:"id"`
    NodeID    string    `json:"node_id"` // GraphQL global node ID
    Number    int       `json:"number"`
    // ... rest unchanged
}
```

2. Add new config structs after `StaleLabelCleanupConfig`:
```go
// ProjectBoardConfig configures GitHub Projects V2 board sync.
// When nil or Enabled=false, board sync is skipped.
type ProjectBoardConfig struct {
    Enabled       bool            `yaml:"enabled"`
    ProjectNumber int             `yaml:"project_number"` // Project number from URL
    StatusField   string          `yaml:"status_field"`   // Field name, e.g. "Status"
    Statuses      ProjectStatuses `yaml:"statuses"`
}

// ProjectStatuses maps Pilot lifecycle events to board column names.
type ProjectStatuses struct {
    InProgress string `yaml:"in_progress"` // e.g. "In Dev"
    Review     string `yaml:"review"`      // e.g. "Ready for Review"
    Done       string `yaml:"done"`        // e.g. "Done"
    Failed     string `yaml:"failed"`      // Optional — e.g. "Blocked"
}
```

3. Add `ProjectBoard` field to `Config`:
```go
type Config struct {
    // ... existing fields ...
    ProjectBoard *ProjectBoardConfig `yaml:"project_board"` // GitHub Projects V2 board sync
}
```

`DefaultConfig()` leaves `ProjectBoard` as nil (opt-in).

## Acceptance Criteria

- [ ] `go build ./...` compiles
- [ ] `go test ./internal/adapters/github/...` passes
- [ ] No changes to any other files