### PR TITLE
feat(github): Add project_board example to pilot.example.yaml

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -47,6 +47,18 @@ adapters:
       enabled: true
       interval: 30s
       label: "pilot"
+    # GitHub Projects V2 board sync (optional)
+    # Keeps your project board in sync as Pilot progresses through tasks.
+    # Requires classic PAT with "project" scope (fine-grained PATs not supported).
+    project_board:
+      enabled: false
+      project_number: 1            # Project number from URL (github.com/users/you/projects/1)
+      status_field: "Status"       # Name of the single-select status field
+      statuses:
+        in_progress: "In Dev"      # Set when Pilot starts working
+        review: "Ready for Review" # Set when PR is created (future)
+        done: "Done"               # Set when PR is merged
+        failed: "Blocked"          # Optional — set on execution failure
 
   # GitLab - Issue polling and MR creation
   gitlab:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1851.

Closes #1851

## Changes

GitHub Issue #1851: feat(github): Add project_board example to pilot.example.yaml

## Context

Part of GH-1834 (GitHub Projects V2 board sync). Add config documentation.

## Changes

**File: `configs/pilot.example.yaml`**

Add `project_board` block under the `github` adapter section, after `stale_label_cleanup`:

```yaml
    # GitHub Projects V2 board sync (optional)
    # Keeps your project board in sync as Pilot progresses through tasks.
    # Requires classic PAT with "project" scope (fine-grained PATs not supported).
    project_board:
      enabled: false
      project_number: 1            # Project number from URL (github.com/users/you/projects/1)
      status_field: "Status"       # Name of the single-select status field
      statuses:
        in_progress: "In Dev"      # Set when Pilot starts working
        review: "Ready for Review" # Set when PR is created (future)
        done: "Done"               # Set when PR is merged
        failed: "Blocked"          # Optional — set on execution failure
```

## Acceptance Criteria

- [ ] YAML is valid
- [ ] Example is clearly commented
- [ ] No changes to any other files