### PR TITLE
feat(github): Add ProjectBoardSync with GraphQL ID resolution and caching

### DIFF
--- a/internal/adapters/github/project_board.go
+++ b/internal/adapters/github/project_board.go
@@ -1,0 +1,269 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+// GraphQL queries for GitHub Projects V2.
+const (
+	queryProjectByOrg = `query($owner: String!, $number: Int!) {
+  organization(login: $owner) { projectV2(number: $number) { id } }
+}`
+
+	queryProjectByUser = `query($owner: String!, $number: Int!) {
+  user(login: $owner) { projectV2(number: $number) { id } }
+}`
+
+	queryFieldAndOptions = `query($projectID: ID!, $fieldName: String!) {
+  node(id: $projectID) {
+    ... on ProjectV2 {
+      field(name: $fieldName) {
+        ... on ProjectV2SingleSelectField { id options { id name } }
+      }
+    }
+  }
+}`
+
+	queryIssueProjectItems = `query($issueID: ID!) {
+  node(id: $issueID) {
+    ... on Issue { projectItems(first: 20) { nodes { id project { id } } } }
+  }
+}`
+
+	mutationSetItemFieldValue = `mutation($projectID: ID!, $itemID: ID!, $fieldID: ID!, $optionID: String!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $projectID, itemId: $itemID, fieldId: $fieldID,
+    value: { singleSelectOptionId: $optionID }
+  }) { projectV2Item { id } }
+}`
+)
+
+// Response types for GraphQL unmarshalling.
+type (
+	projectByOrgResponse struct {
+		Organization struct {
+			ProjectV2 struct {
+				ID string `json:"id"`
+			} `json:"projectV2"`
+		} `json:"organization"`
+	}
+
+	projectByUserResponse struct {
+		User struct {
+			ProjectV2 struct {
+				ID string `json:"id"`
+			} `json:"projectV2"`
+		} `json:"user"`
+	}
+
+	fieldAndOptionsResponse struct {
+		Node struct {
+			Field struct {
+				ID      string `json:"id"`
+				Options []struct {
+					ID   string `json:"id"`
+					Name string `json:"name"`
+				} `json:"options"`
+			} `json:"field"`
+		} `json:"node"`
+	}
+
+	issueProjectItemsResponse struct {
+		Node struct {
+			ProjectItems struct {
+				Nodes []struct {
+					ID      string `json:"id"`
+					Project struct {
+						ID string `json:"id"`
+					} `json:"project"`
+				} `json:"nodes"`
+			} `json:"projectItems"`
+		} `json:"node"`
+	}
+)
+
+// ProjectBoardSync manages GitHub Projects V2 board status updates.
+// It lazily resolves project/field/option IDs via GraphQL and caches them.
+type ProjectBoardSync struct {
+	client *Client
+	config *ProjectBoardConfig
+	owner  string
+
+	mu        sync.RWMutex
+	projectID string
+	fieldID   string
+	optionIDs map[string]string // lowercase status name -> option node ID
+}
+
+// NewProjectBoardSync returns a ProjectBoardSync instance, or nil if config is nil or disabled.
+func NewProjectBoardSync(client *Client, config *ProjectBoardConfig, owner string) *ProjectBoardSync {
+	if config == nil || !config.Enabled {
+		return nil
+	}
+	return &ProjectBoardSync{
+		client: client,
+		config: config,
+		owner:  owner,
+	}
+}
+
+// UpdateProjectItemStatus moves the issue's project card to the named status column.
+// Returns nil (not error) if: config disabled, issue not in project, or status not mapped.
+// Returns error only for unexpected API failures.
+func (p *ProjectBoardSync) UpdateProjectItemStatus(ctx context.Context, issueNodeID string, statusName string) error {
+	if statusName == "" {
+		return nil
+	}
+
+	if err := p.ensureResolved(ctx); err != nil {
+		return fmt.Errorf("resolve project board IDs: %w", err)
+	}
+
+	optionID, ok := p.optionIDs[strings.ToLower(statusName)]
+	if !ok {
+		slog.Warn("project board status not found in options", "status", statusName)
+		return nil
+	}
+
+	itemID, err := p.getIssueProjectItemID(ctx, issueNodeID)
+	if err != nil {
+		return fmt.Errorf("get issue project item: %w", err)
+	}
+	if itemID == "" {
+		slog.Warn("issue not found in project board", "issue_node_id", issueNodeID, "project_id", p.projectID)
+		return nil
+	}
+
+	if err := p.setItemFieldValue(ctx, itemID, optionID); err != nil {
+		return fmt.Errorf("set project item field value: %w", err)
+	}
+
+	return nil
+}
+
+// ensureResolved lazy-loads project/field/option IDs with a read-through cache.
+func (p *ProjectBoardSync) ensureResolved(ctx context.Context) error {
+	p.mu.RLock()
+	resolved := p.projectID != "" && p.fieldID != "" && p.optionIDs != nil
+	p.mu.RUnlock()
+
+	if resolved {
+		return nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if p.projectID != "" && p.fieldID != "" && p.optionIDs != nil {
+		return nil
+	}
+
+	projectID, err := p.resolveProjectID(ctx)
+	if err != nil {
+		return err
+	}
+	p.projectID = projectID
+
+	fieldID, optionIDs, err := p.resolveFieldAndOptions(ctx)
+	if err != nil {
+		return err
+	}
+	p.fieldID = fieldID
+	p.optionIDs = optionIDs
+
+	return nil
+}
+
+// resolveProjectID queries for the project ID, trying organization first then user.
+func (p *ProjectBoardSync) resolveProjectID(ctx context.Context) (string, error) {
+	vars := map[string]interface{}{
+		"owner":  p.owner,
+		"number": p.config.ProjectNumber,
+	}
+
+	// Try organization first.
+	var orgResp projectByOrgResponse
+	err := p.client.ExecuteGraphQL(ctx, queryProjectByOrg, vars, &orgResp)
+	if err == nil && orgResp.Organization.ProjectV2.ID != "" {
+		return orgResp.Organization.ProjectV2.ID, nil
+	}
+
+	// Fallback to user.
+	var userResp projectByUserResponse
+	err = p.client.ExecuteGraphQL(ctx, queryProjectByUser, vars, &userResp)
+	if err != nil {
+		return "", fmt.Errorf("resolve project ID for %s #%d: %w", p.owner, p.config.ProjectNumber, err)
+	}
+	if userResp.User.ProjectV2.ID == "" {
+		return "", fmt.Errorf("project #%d not found for owner %s", p.config.ProjectNumber, p.owner)
+	}
+
+	return userResp.User.ProjectV2.ID, nil
+}
+
+// resolveFieldAndOptions fetches the Status field ID and all option name→ID mappings.
+func (p *ProjectBoardSync) resolveFieldAndOptions(ctx context.Context) (string, map[string]string, error) {
+	fieldName := p.config.StatusField
+	if fieldName == "" {
+		fieldName = "Status"
+	}
+
+	vars := map[string]interface{}{
+		"projectID": p.projectID,
+		"fieldName": fieldName,
+	}
+
+	var resp fieldAndOptionsResponse
+	if err := p.client.ExecuteGraphQL(ctx, queryFieldAndOptions, vars, &resp); err != nil {
+		return "", nil, fmt.Errorf("resolve field %q: %w", fieldName, err)
+	}
+
+	if resp.Node.Field.ID == "" {
+		return "", nil, fmt.Errorf("field %q not found in project", fieldName)
+	}
+
+	optionIDs := make(map[string]string, len(resp.Node.Field.Options))
+	for _, opt := range resp.Node.Field.Options {
+		optionIDs[strings.ToLower(opt.Name)] = opt.ID
+	}
+
+	return resp.Node.Field.ID, optionIDs, nil
+}
+
+// getIssueProjectItemID finds the project item ID for the given issue in this project.
+// Returns "" if the issue is not in the project.
+func (p *ProjectBoardSync) getIssueProjectItemID(ctx context.Context, issueNodeID string) (string, error) {
+	vars := map[string]interface{}{
+		"issueID": issueNodeID,
+	}
+
+	var resp issueProjectItemsResponse
+	if err := p.client.ExecuteGraphQL(ctx, queryIssueProjectItems, vars, &resp); err != nil {
+		return "", fmt.Errorf("query issue project items: %w", err)
+	}
+
+	for _, item := range resp.Node.ProjectItems.Nodes {
+		if item.Project.ID == p.projectID {
+			return item.ID, nil
+		}
+	}
+
+	return "", nil
+}
+
+// setItemFieldValue calls the updateProjectV2ItemFieldValue mutation.
+func (p *ProjectBoardSync) setItemFieldValue(ctx context.Context, itemID string, optionID string) error {
+	vars := map[string]interface{}{
+		"projectID": p.projectID,
+		"itemID":    itemID,
+		"fieldID":   p.fieldID,
+		"optionID":  optionID,
+	}
+
+	return p.client.ExecuteGraphQL(ctx, mutationSetItemFieldValue, vars, nil)
+}

--- a/internal/adapters/github/project_board_test.go
+++ b/internal/adapters/github/project_board_test.go
@@ -1,0 +1,467 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestNewProjectBoardSync(t *testing.T) {
+	client := NewClient(testutil.FakeGitHubToken)
+
+	tests := []struct {
+		name   string
+		config *ProjectBoardConfig
+		wantNil bool
+	}{
+		{
+			name:    "nil config returns nil",
+			config:  nil,
+			wantNil: true,
+		},
+		{
+			name:    "disabled config returns nil",
+			config:  &ProjectBoardConfig{Enabled: false},
+			wantNil: true,
+		},
+		{
+			name: "enabled config returns instance",
+			config: &ProjectBoardConfig{
+				Enabled:       true,
+				ProjectNumber: 1,
+				StatusField:   "Status",
+			},
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewProjectBoardSync(client, tt.config, "testorg")
+			if (result == nil) != tt.wantNil {
+				t.Errorf("NewProjectBoardSync() nil = %v, wantNil %v", result == nil, tt.wantNil)
+			}
+		})
+	}
+}
+
+func TestUpdateProjectItemStatus_EmptyStatus(t *testing.T) {
+	client := NewClient(testutil.FakeGitHubToken)
+	pbs := &ProjectBoardSync{
+		client: client,
+		config: &ProjectBoardConfig{Enabled: true, ProjectNumber: 1, StatusField: "Status"},
+		owner:  "testorg",
+	}
+
+	err := pbs.UpdateProjectItemStatus(context.Background(), "ISSUE_123", "")
+	if err != nil {
+		t.Errorf("expected nil for empty status, got %v", err)
+	}
+}
+
+func TestUpdateProjectItemStatus_FullFlow(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		var resp string
+		switch {
+		case strings.Contains(req.Query, "organization"):
+			resp = `{"data":{"organization":{"projectV2":{"id":"PVT_org123"}}}}`
+			requestCount++
+		case strings.Contains(req.Query, "field(name:"):
+			resp = `{"data":{"node":{"field":{"id":"PVTSSF_field1","options":[{"id":"OPT_todo","name":"Todo"},{"id":"OPT_indev","name":"In Dev"},{"id":"OPT_done","name":"Done"}]}}}}`
+			requestCount++
+		case strings.Contains(req.Query, "projectItems"):
+			resp = `{"data":{"node":{"projectItems":{"nodes":[{"id":"PVTI_item1","project":{"id":"PVT_org123"}}]}}}}`
+			requestCount++
+		case strings.Contains(req.Query, "updateProjectV2ItemFieldValue"):
+			resp = `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_item1"}}}}`
+			requestCount++
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
+		Enabled:       true,
+		ProjectNumber: 5,
+		StatusField:   "Status",
+	}, "testorg")
+
+	err := pbs.UpdateProjectItemStatus(context.Background(), "ISSUE_node1", "In Dev")
+	if err != nil {
+		t.Fatalf("UpdateProjectItemStatus() error = %v", err)
+	}
+
+	if requestCount != 4 {
+		t.Errorf("expected 4 GraphQL requests, got %d", requestCount)
+	}
+}
+
+func TestUpdateProjectItemStatus_CachesIDs(t *testing.T) {
+	var resolveCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		var resp string
+		switch {
+		case strings.Contains(req.Query, "organization"):
+			resolveCount.Add(1)
+			resp = `{"data":{"organization":{"projectV2":{"id":"PVT_cached"}}}}`
+		case strings.Contains(req.Query, "field(name:"):
+			resolveCount.Add(1)
+			resp = `{"data":{"node":{"field":{"id":"PVTSSF_f1","options":[{"id":"OPT_done","name":"Done"}]}}}}`
+		case strings.Contains(req.Query, "projectItems"):
+			resp = `{"data":{"node":{"projectItems":{"nodes":[{"id":"PVTI_i1","project":{"id":"PVT_cached"}}]}}}}`
+		case strings.Contains(req.Query, "updateProjectV2ItemFieldValue"):
+			resp = `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_i1"}}}}`
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
+		Enabled:       true,
+		ProjectNumber: 1,
+		StatusField:   "Status",
+	}, "testorg")
+
+	// Call twice — resolution queries should only happen once.
+	for i := 0; i < 2; i++ {
+		err := pbs.UpdateProjectItemStatus(context.Background(), "ISSUE_1", "Done")
+		if err != nil {
+			t.Fatalf("call %d: UpdateProjectItemStatus() error = %v", i+1, err)
+		}
+	}
+
+	if resolveCount.Load() != 2 { // 1 for org project, 1 for field+options
+		t.Errorf("expected 2 resolve requests (cached), got %d", resolveCount.Load())
+	}
+}
+
+func TestResolveProjectID_OrgFirstUserFallback(t *testing.T) {
+	tests := []struct {
+		name        string
+		orgResp     string
+		orgStatus   int
+		userResp    string
+		userStatus  int
+		wantID      string
+		wantErr     bool
+	}{
+		{
+			name:      "org found",
+			orgResp:   `{"data":{"organization":{"projectV2":{"id":"PVT_org"}}}}`,
+			orgStatus: http.StatusOK,
+			wantID:    "PVT_org",
+		},
+		{
+			name:       "org empty, user found",
+			orgResp:    `{"data":{"organization":{"projectV2":{"id":""}}}}`,
+			orgStatus:  http.StatusOK,
+			userResp:   `{"data":{"user":{"projectV2":{"id":"PVT_user"}}}}`,
+			userStatus: http.StatusOK,
+			wantID:     "PVT_user",
+		},
+		{
+			name:       "org error, user found",
+			orgResp:    `{"data":null,"errors":[{"message":"not an org"}]}`,
+			orgStatus:  http.StatusOK,
+			userResp:   `{"data":{"user":{"projectV2":{"id":"PVT_user2"}}}}`,
+			userStatus: http.StatusOK,
+			wantID:     "PVT_user2",
+		},
+		{
+			name:       "both fail",
+			orgResp:    `{"data":null,"errors":[{"message":"not an org"}]}`,
+			orgStatus:  http.StatusOK,
+			userResp:   `{"data":null,"errors":[{"message":"not found"}]}`,
+			userStatus: http.StatusOK,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var callNum int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req GraphQLRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+
+				callNum++
+				if strings.Contains(req.Query, "organization") {
+					w.WriteHeader(tt.orgStatus)
+					_, _ = w.Write([]byte(tt.orgResp))
+				} else if strings.Contains(req.Query, "user") {
+					w.WriteHeader(tt.userStatus)
+					_, _ = w.Write([]byte(tt.userResp))
+				}
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			pbs := &ProjectBoardSync{
+				client: client,
+				config: &ProjectBoardConfig{ProjectNumber: 3},
+				owner:  "testowner",
+			}
+
+			id, err := pbs.resolveProjectID(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("resolveProjectID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && id != tt.wantID {
+				t.Errorf("resolveProjectID() = %q, want %q", id, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestUpdateProjectItemStatus_IssueNotInProject(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		var resp string
+		switch {
+		case strings.Contains(req.Query, "organization"):
+			resp = `{"data":{"organization":{"projectV2":{"id":"PVT_p1"}}}}`
+		case strings.Contains(req.Query, "field(name:"):
+			resp = `{"data":{"node":{"field":{"id":"PVTSSF_f1","options":[{"id":"OPT_done","name":"Done"}]}}}}`
+		case strings.Contains(req.Query, "projectItems"):
+			// Issue not in this project — different project ID.
+			resp = `{"data":{"node":{"projectItems":{"nodes":[{"id":"PVTI_other","project":{"id":"PVT_different"}}]}}}}`
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
+		Enabled:       true,
+		ProjectNumber: 1,
+		StatusField:   "Status",
+	}, "testorg")
+
+	// Should return nil (not error) when issue isn't in project.
+	err := pbs.UpdateProjectItemStatus(context.Background(), "ISSUE_orphan", "Done")
+	if err != nil {
+		t.Errorf("expected nil for issue not in project, got %v", err)
+	}
+}
+
+func TestUpdateProjectItemStatus_StatusNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		var resp string
+		switch {
+		case strings.Contains(req.Query, "organization"):
+			resp = `{"data":{"organization":{"projectV2":{"id":"PVT_p1"}}}}`
+		case strings.Contains(req.Query, "field(name:"):
+			resp = `{"data":{"node":{"field":{"id":"PVTSSF_f1","options":[{"id":"OPT_todo","name":"Todo"}]}}}}`
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
+		Enabled:       true,
+		ProjectNumber: 1,
+		StatusField:   "Status",
+	}, "testorg")
+
+	// "Nonexistent" isn't in the options — should return nil.
+	err := pbs.UpdateProjectItemStatus(context.Background(), "ISSUE_1", "Nonexistent")
+	if err != nil {
+		t.Errorf("expected nil for unknown status, got %v", err)
+	}
+}
+
+func TestUpdateProjectItemStatus_CaseInsensitiveMatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		var resp string
+		switch {
+		case strings.Contains(req.Query, "organization"):
+			resp = `{"data":{"organization":{"projectV2":{"id":"PVT_p1"}}}}`
+		case strings.Contains(req.Query, "field(name:"):
+			resp = `{"data":{"node":{"field":{"id":"PVTSSF_f1","options":[{"id":"OPT_indev","name":"In Dev"}]}}}}`
+		case strings.Contains(req.Query, "projectItems"):
+			resp = `{"data":{"node":{"projectItems":{"nodes":[{"id":"PVTI_i1","project":{"id":"PVT_p1"}}]}}}}`
+		case strings.Contains(req.Query, "updateProjectV2ItemFieldValue"):
+			// Verify the correct option ID was resolved.
+			vars := req.Variables
+			if vars["optionID"] != "OPT_indev" {
+				t.Errorf("expected optionID OPT_indev, got %v", vars["optionID"])
+			}
+			resp = `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_i1"}}}}`
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
+		Enabled:       true,
+		ProjectNumber: 1,
+		StatusField:   "Status",
+	}, "testorg")
+
+	// "in dev" should match "In Dev" (case insensitive).
+	err := pbs.UpdateProjectItemStatus(context.Background(), "ISSUE_1", "in dev")
+	if err != nil {
+		t.Fatalf("UpdateProjectItemStatus() error = %v", err)
+	}
+}
+
+func TestUpdateProjectItemStatus_GraphQLError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":null,"errors":[{"message":"insufficient permissions"}]}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
+		Enabled:       true,
+		ProjectNumber: 1,
+		StatusField:   "Status",
+	}, "testorg")
+
+	err := pbs.UpdateProjectItemStatus(context.Background(), "ISSUE_1", "Done")
+	if err == nil {
+		t.Fatal("expected error for GraphQL failure")
+	}
+	if !strings.Contains(err.Error(), "insufficient permissions") {
+		t.Errorf("error should mention permissions, got: %v", err)
+	}
+}
+
+func TestEnsureResolved_ConcurrentAccess(t *testing.T) {
+	var resolveCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode: %v", err)
+			return
+		}
+
+		var resp string
+		switch {
+		case strings.Contains(req.Query, "organization"):
+			resolveCount.Add(1)
+			resp = `{"data":{"organization":{"projectV2":{"id":"PVT_conc"}}}}`
+		case strings.Contains(req.Query, "field(name:"):
+			resolveCount.Add(1)
+			resp = `{"data":{"node":{"field":{"id":"PVTSSF_f1","options":[{"id":"OPT_done","name":"Done"}]}}}}`
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	pbs := &ProjectBoardSync{
+		client: client,
+		config: &ProjectBoardConfig{ProjectNumber: 1, StatusField: "Status"},
+		owner:  "testorg",
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = pbs.ensureResolved(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	// Should resolve at most 2 times (project + field), not 20.
+	if resolveCount.Load() > 2 {
+		t.Errorf("expected at most 2 resolve calls (cached), got %d", resolveCount.Load())
+	}
+}
+
+func TestResolveFieldAndOptions_DefaultFieldName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		// Verify the default field name "Status" is used.
+		if req.Variables["fieldName"] != "Status" {
+			t.Errorf("expected fieldName=Status, got %v", req.Variables["fieldName"])
+		}
+
+		resp := `{"data":{"node":{"field":{"id":"PVTSSF_f1","options":[{"id":"OPT_1","name":"Todo"}]}}}}`
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	pbs := &ProjectBoardSync{
+		client:    client,
+		config:    &ProjectBoardConfig{StatusField: ""}, // empty — should default to "Status"
+		owner:     "testorg",
+		projectID: "PVT_test",
+	}
+
+	fieldID, opts, err := pbs.resolveFieldAndOptions(context.Background())
+	if err != nil {
+		t.Fatalf("resolveFieldAndOptions() error = %v", err)
+	}
+	if fieldID != "PVTSSF_f1" {
+		t.Errorf("fieldID = %q, want PVTSSF_f1", fieldID)
+	}
+	if opts["todo"] != "OPT_1" {
+		t.Errorf("expected option todo=OPT_1, got %v", opts)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1852.

Closes #1852

## Changes

GitHub Issue #1852: feat(github): Add ProjectBoardSync with GraphQL ID resolution and caching

## Context

Part of GH-1834 (GitHub Projects V2 board sync). Core implementation — resolves project/field/option IDs via GraphQL and updates board status.

**Depends on:** GH-1849 (config types), GH-1850 (GraphQL transport)

## Changes

**New file: `internal/adapters/github/project_board.go`**

### Struct

```go
type ProjectBoardSync struct {
    client    *Client
    config    *ProjectBoardConfig
    owner     string

    mu        sync.RWMutex
    projectID string
    fieldID   string
    optionIDs map[string]string // lowercase status name -> option node ID
}
```

### Public API

```go
// NewProjectBoardSync returns nil if config is nil or disabled.
func NewProjectBoardSync(client *Client, config *ProjectBoardConfig, owner string) *ProjectBoardSync

// UpdateProjectItemStatus moves the issue's project card to the named status.
// Returns nil (not error) if: config disabled, issue not in project, status not mapped.
// Returns error only for unexpected API failures.
func (p *ProjectBoardSync) UpdateProjectItemStatus(ctx context.Context, issueNodeID string, statusName string) error
```

### Internal Methods

1. `ensureResolved(ctx)` — lazy-load project/field/option IDs with RWMutex (read-through cache)
2. `resolveProjectID(ctx)` — GraphQL query, try `organization` first, fallback to `user`
3. `resolveFieldAndOptions(ctx)` — fetch Status field ID + all option name→ID mappings
4. `getIssueProjectItemID(ctx, issueNodeID)` — find the project item for this issue; return "" if not in project
5. `setItemFieldValue(ctx, itemID, optionID)` — call `updateProjectV2ItemFieldValue` mutation

### GraphQL Queries (embed as constants)

```graphql
# resolveProjectID (org)
query($owner: String!, $number: Int!) {
  organization(login: $owner) { projectV2(number: $number) { id } }
}

# resolveProjectID (user fallback)
query($owner: String!, $number: Int!) {
  user(login: $owner) { projectV2(number: $number) { id } }
}

# resolveFieldAndOptions
query($projectID: ID!, $fieldName: String!) {
  node(id: $projectID) {
    ... on ProjectV2 {
      field(name: $fieldName) {
        ... on ProjectV2SingleSelectField { id options { id name } }
      }
    }
  }
}

# getIssueProjectItemID
query($issueID: ID!) {
  node(id: $issueID) {
    ... on Issue { projectItems(first: 20) { nodes { id project { id } } } }
  }
}

# setItemFieldValue
mutation($projectID: ID!, $itemID: ID!, $fieldID: ID!, $optionID: String!) {
  updateProjectV2ItemFieldValue(input: {
    projectId: $projectID, itemId: $itemID, fieldId: $fieldID,
    value: { singleSelectOptionId: $optionID }
  }) { projectV2Item { id } }
}
```

### Error Handling

- Empty `statusName` → return nil immediately
- `resolveProjectID` failure → return error (misconfiguration)
- Issue not in project → log warning, return nil
- Status option not found → log warning, return nil
- GraphQL errors → return wrapped error

### Response Types (internal, for JSON unmarshalling)

Define minimal response structs to unmarshal each GraphQL response. Follow the nesting pattern from the queries.

## Acceptance Criteria

- [ ] `go build ./...` compiles
- [ ] IDs are cached after first resolution (verified in tests)
- [ ] Org-first, user-fallback pattern for project discovery
- [ ] Graceful handling of issue-not-in-project
- [ ] All GraphQL queries use `client.ExecuteGraphQL()`