### PR TITLE
fix(github): Guard owner extraction in board sync construction

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -126,8 +126,12 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 	// boardSync is nil when project_board config is missing or disabled — syncBoardStatus handles nil safely.
 	var boardSync *github.ProjectBoardSync
 	if cfg.Adapters.GitHub.ProjectBoard != nil && cfg.Adapters.GitHub.ProjectBoard.Enabled {
-		owner := strings.Split(cfg.Adapters.GitHub.Repo, "/")[0]
-		boardSync = github.NewProjectBoardSync(client, cfg.Adapters.GitHub.ProjectBoard, owner)
+		parts := strings.Split(cfg.Adapters.GitHub.Repo, "/")
+		if len(parts) == 2 && parts[0] != "" {
+			boardSync = github.NewProjectBoardSync(client, cfg.Adapters.GitHub.ProjectBoard, parts[0])
+		} else {
+			slog.Warn("board sync disabled: invalid repo format, expected owner/repo", "repo", cfg.Adapters.GitHub.Repo)
+		}
 	}
 
 	// GH-386: Pre-execution validation - fail fast if repo doesn't match project


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1868.

Closes #1868

## Changes

GitHub Issue #1868: fix(github): Guard owner extraction in board sync construction

## Problem

In `cmd/pilot/handlers.go` line ~129, the board sync owner is extracted unsafely:

```go
owner := strings.Split(cfg.Adapters.GitHub.Repo, "/")[0]
```

If `Repo` is empty or malformed (no `/`), `owner` will be `""`, causing all GraphQL queries to fail with confusing errors. Compare to line ~202 in the same file where `sourceRepo` is split with a `len(parts) == 2` guard.

## Fix

Replace the unsafe extraction with a guarded version:

```go
var boardSync *github.ProjectBoardSync
if cfg.Adapters.GitHub.ProjectBoard != nil && cfg.Adapters.GitHub.ProjectBoard.Enabled {
    parts := strings.Split(cfg.Adapters.GitHub.Repo, "/")
    if len(parts) == 2 && parts[0] != "" {
        boardSync = github.NewProjectBoardSync(client, cfg.Adapters.GitHub.ProjectBoard, parts[0])
    } else {
        slog.Warn("board sync disabled: invalid repo format, expected owner/repo", "repo", cfg.Adapters.GitHub.Repo)
    }
}
```

## Acceptance Criteria

- [ ] `go build ./...` compiles
- [ ] Empty/malformed `Repo` logs a warning instead of creating a broken `ProjectBoardSync`
- [ ] Existing valid `owner/repo` format works as before