### PR TITLE
feat(github): Wire Review status transition on PR creation

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -284,6 +284,10 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelDone}); err != nil {
 					logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
 				}
+				// GH-1869: Move to Review column when PR is created
+				if hr.PRNumber > 0 {
+					syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Review)
+				}
 				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Done) // GH-1853
 
 				// GH-1302: Clean up stale pilot-failed label from prior failed attempt


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1869.

Closes #1869

## Changes

GitHub Issue #1869: feat(github): Wire Review status transition on PR creation

## Problem

`ProjectStatuses.Review` is defined in the config struct (`types.go:45`) but never used anywhere. Users who configure `statuses.review: "Ready for Review"` expect their board card to move when a PR is created. Nothing happens.

## Fix

Wire the Review status transition in `cmd/pilot/handlers.go` after a PR is successfully created.

Find the code path where `result.PRNumber > 0` and the PR URL is available (after `handleIssueGeneric` returns success with a PR). Add:

```go
if boardSync != nil && result.PRNumber > 0 {
    syncBoardStatus(ctx, boardSync, issue.NodeID, cfg.Adapters.GitHub.ProjectBoard.GetStatuses().Review)
}
```

This should happen AFTER the PR creation comment/label updates, alongside or after `LinkPR`.

The `Review` status is optional — if empty string, `syncBoardStatus` returns early (existing behavior).

## Acceptance Criteria

- [ ] `go build ./...` compiles
- [ ] Board card moves to Review column when PR is created
- [ ] Empty `review` status in config is a no-op (no error)
- [ ] Existing transitions (in_progress, done, failed) unchanged