### PR TITLE
feat(pilot): Wire Discord adapter — poller_discord.go, config, main.go flag

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -18,6 +18,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
+	"github.com/alekspetrov/pilot/internal/adapters/discord"
 	"github.com/alekspetrov/pilot/internal/adapters/github"
 	"github.com/alekspetrov/pilot/internal/adapters/linear"
 	"github.com/alekspetrov/pilot/internal/adapters/plane"
@@ -117,6 +118,7 @@ func newStartCmd() *cobra.Command {
 		enableLinear   bool
 		enableSlack    bool
 		enablePlane    bool
+		enableDiscord  bool
 		// Mode flags
 		noGateway    bool   // Lightweight mode: polling only, no HTTP gateway
 		sequential   bool   // Sequential execution mode (one issue at a time)
@@ -156,7 +158,7 @@ Examples:
 			}
 
 			// Apply flag overrides to config
-			applyInputOverrides(cfg, cmd, enableTelegram, enableGithub, enableLinear, enableSlack, enableTunnel, enablePlane)
+			applyInputOverrides(cfg, cmd, enableTelegram, enableGithub, enableLinear, enableSlack, enableTunnel, enablePlane, enableDiscord)
 
 			// Apply team ID override if flag provided
 			if teamID != "" {
@@ -990,6 +992,7 @@ Examples:
 	cmd.Flags().BoolVar(&enableLinear, "linear", false, "Enable Linear webhooks (overrides config)")
 	cmd.Flags().BoolVar(&enableSlack, "slack", false, "Enable Slack Socket Mode (overrides config)")
 	cmd.Flags().BoolVar(&enablePlane, "plane", false, "Enable Plane.so polling (overrides config)")
+	cmd.Flags().BoolVar(&enableDiscord, "discord", false, "Enable Discord bot (overrides config)")
 	cmd.Flags().BoolVar(&enableTunnel, "tunnel", false, "Enable public tunnel for webhook ingress (Cloudflare/ngrok)")
 	cmd.Flags().StringVar(&teamID, "team", "", "Team ID or name for project access scoping (overrides config)")
 	cmd.Flags().StringVar(&teamMember, "team-member", "", "Member email for team access scoping (overrides config)")
@@ -1000,7 +1003,7 @@ Examples:
 
 // applyInputOverrides applies CLI flag overrides to config
 // Uses cmd.Flags().Changed() to only apply flags that were explicitly set
-func applyInputOverrides(cfg *config.Config, cmd *cobra.Command, telegramFlag, githubFlag, linearFlag, slackFlag, tunnelFlag, planeFlag bool) {
+func applyInputOverrides(cfg *config.Config, cmd *cobra.Command, telegramFlag, githubFlag, linearFlag, slackFlag, tunnelFlag, planeFlag, discordFlag bool) {
 	if cmd.Flags().Changed("telegram") {
 		if cfg.Adapters.Telegram == nil {
 			cfg.Adapters.Telegram = telegram.DefaultConfig()
@@ -1046,6 +1049,12 @@ func applyInputOverrides(cfg *config.Config, cmd *cobra.Command, telegramFlag, g
 			cfg.Adapters.Plane.Polling = &plane.PollingConfig{}
 		}
 		cfg.Adapters.Plane.Polling.Enabled = planeFlag
+	}
+	if cmd.Flags().Changed("discord") {
+		if cfg.Adapters.Discord == nil {
+			cfg.Adapters.Discord = discord.DefaultConfig()
+		}
+		cfg.Adapters.Discord.Enabled = discordFlag
 	}
 }
 

--- a/cmd/pilot/main_test.go
+++ b/cmd/pilot/main_test.go
@@ -917,7 +917,7 @@ func TestApplyInputOverrides(t *testing.T) {
 				_ = cmd.Flags().Set(k, v)
 			}
 
-			applyInputOverrides(cfg, cmd, tt.telegram, tt.github, tt.linear, tt.slack, tt.tunnel, false)
+			applyInputOverrides(cfg, cmd, tt.telegram, tt.github, tt.linear, tt.slack, tt.tunnel, false, false)
 
 			if tt.checkTelegram != nil {
 				if cfg.Adapters.Telegram == nil {

--- a/cmd/pilot/poller_discord.go
+++ b/cmd/pilot/poller_discord.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/alekspetrov/pilot/internal/adapters/discord"
+	"github.com/alekspetrov/pilot/internal/config"
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+func discordPollerRegistration() PollerRegistration {
+	return PollerRegistration{
+		Name: "discord",
+		Enabled: func(cfg *config.Config) bool {
+			return cfg.Adapters.Discord != nil && cfg.Adapters.Discord.Enabled
+		},
+		CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
+			handler := discord.NewHandler(&discord.HandlerConfig{
+				BotToken:        deps.Cfg.Adapters.Discord.BotToken,
+				AllowedGuilds:   deps.Cfg.Adapters.Discord.AllowedGuilds,
+				AllowedChannels: deps.Cfg.Adapters.Discord.AllowedChannels,
+			}, deps.Runner)
+
+			go func() {
+				if err := handler.StartListening(ctx); err != nil {
+					logging.WithComponent("discord").Error("Discord listener error",
+						slog.Any("error", err),
+					)
+				}
+			}()
+			logging.WithComponent("start").Info("Discord bot started")
+		},
+	}
+}

--- a/cmd/pilot/poller_registry.go
+++ b/cmd/pilot/poller_registry.go
@@ -47,6 +47,7 @@ func adapterPollerRegistrations() []PollerRegistration {
 		asanaPollerRegistration(),
 		azuredevopsPollerRegistration(),
 		planePollerRegistration(),
+		discordPollerRegistration(),
 	}
 }
 

--- a/cmd/pilot/poller_registry_test.go
+++ b/cmd/pilot/poller_registry_test.go
@@ -50,11 +50,11 @@ func TestStartAdapterPollers_OnlyStartsEnabled(t *testing.T) {
 
 func TestAdapterPollerRegistrations_ReturnsAllFive(t *testing.T) {
 	regs := adapterPollerRegistrations()
-	if len(regs) != 5 {
-		t.Fatalf("expected 5 registrations, got %d", len(regs))
+	if len(regs) != 6 {
+		t.Fatalf("expected 6 registrations, got %d", len(regs))
 	}
 
-	expected := []string{"linear", "jira", "asana", "azuredevops", "plane"}
+	expected := []string{"linear", "jira", "asana", "azuredevops", "plane", "discord"}
 	for i, name := range expected {
 		if regs[i].Name != name {
 			t.Errorf("registration[%d]: expected name %q, got %q", i, name, regs[i].Name)

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -109,6 +109,14 @@ adapters:
       enabled: true
       interval: 30s
 
+  # Discord - Chat-based task execution via Discord bot
+  discord:
+    enabled: false
+    bot_token: "${DISCORD_BOT_TOKEN}"
+    allowed_guilds: []       # Guild IDs (empty = all)
+    allowed_channels: []     # Channel IDs (empty = all)
+    command_prefix: "/"
+
   # Slack - Notifications
   slack:
     enabled: false

--- a/internal/adapters/discord/types.go
+++ b/internal/adapters/discord/types.go
@@ -4,16 +4,18 @@ import "time"
 
 // Config holds Discord adapter configuration.
 type Config struct {
-	BotToken        string
-	AllowedGuilds   []string      // Guild IDs allowed to send tasks
-	AllowedChannels []string      // Channel IDs allowed to send tasks
-	RateLimit       *RateLimitConfig
+	Enabled         bool              `yaml:"enabled"`
+	BotToken        string            `yaml:"bot_token"`
+	AllowedGuilds   []string          `yaml:"allowed_guilds"`   // Guild IDs allowed to send tasks
+	AllowedChannels []string          `yaml:"allowed_channels"` // Channel IDs allowed to send tasks
+	CommandPrefix   string            `yaml:"command_prefix"`
+	RateLimit       *RateLimitConfig  `yaml:"rate_limit"`
 }
 
 // RateLimitConfig holds rate limiting configuration.
 type RateLimitConfig struct {
-	MessagesPerSecond int
-	TasksPerMinute    int
+	MessagesPerSecond int `yaml:"messages_per_second"`
+	TasksPerMinute    int `yaml:"tasks_per_minute"`
 }
 
 // DefaultConfig returns a Config with sensible defaults.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/alekspetrov/pilot/internal/adapters/asana"
 	"github.com/alekspetrov/pilot/internal/adapters/azuredevops"
+	"github.com/alekspetrov/pilot/internal/adapters/discord"
 	"github.com/alekspetrov/pilot/internal/adapters/github"
 	"github.com/alekspetrov/pilot/internal/adapters/gitlab"
 	"github.com/alekspetrov/pilot/internal/adapters/jira"
@@ -76,6 +77,7 @@ type AdaptersConfig struct {
 	Jira        *jira.Config        `yaml:"jira"`
 	Asana       *asana.Config       `yaml:"asana"`
 	Plane       *plane.Config       `yaml:"plane"`
+	Discord     *discord.Config     `yaml:"discord"`
 }
 
 // OrchestratorConfig holds settings for the task orchestrator including
@@ -273,6 +275,7 @@ func DefaultConfig() *Config {
 			Jira:        jira.DefaultConfig(),
 			Asana:       asana.DefaultConfig(),
 			Plane:       plane.DefaultConfig(),
+			Discord:     discord.DefaultConfig(),
 		},
 		Orchestrator: &OrchestratorConfig{
 			Model:         "claude-sonnet-4-6",


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1881.

Closes #1881

## Changes

GitHub Issue #1881: feat(pilot): Wire Discord adapter — poller_discord.go, config, main.go flag

## Context

The Discord adapter package exists at `internal/adapters/discord/` (merged in PR #1880) but is NOT wired into the application. No config, no CLI flag, no poller registration.

## IMPORTANT: Follow the Plane.so adapter pattern exactly

The codebase uses a registry-based adapter pattern. Reference these files:
- `cmd/pilot/poller_plane.go` — poller registration pattern to COPY
- `cmd/pilot/poller_registry.go` — where registrations are listed
- `cmd/pilot/main.go` — flag registration + `applyInputOverrides()`

## Files to Create

### `cmd/pilot/poller_discord.go` (NEW)

Copy `cmd/pilot/poller_plane.go` and adapt for Discord. The Discord adapter uses a Gateway WebSocket (like Slack), not polling. The registration should:

1. Check `cfg.Adapters.Discord != nil && cfg.Adapters.Discord.Enabled`
2. Create `discord.NewHandler()` with `discord.HandlerConfig`
3. Start `handler.StartListening(ctx)` in a goroutine
4. Log "Discord bot started"

```go
package main

import (
    "context"
    "log/slog"

    "github.com/alekspetrov/pilot/internal/adapters/discord"
    "github.com/alekspetrov/pilot/internal/config"
)

func discordPollerRegistration() PollerRegistration {
    return PollerRegistration{
        Name: "discord",
        Enabled: func(cfg *config.Config) bool {
            return cfg.Adapters.Discord != nil && cfg.Adapters.Discord.Enabled
        },
        CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
            handler := discord.NewHandler(&discord.HandlerConfig{
                BotToken:        deps.Config.Adapters.Discord.BotToken,
                ProjectPath:     deps.ProjectPath,
                AllowedGuilds:   deps.Config.Adapters.Discord.AllowedGuilds,
                AllowedChannels: deps.Config.Adapters.Discord.AllowedChannels,
            }, deps.Runner)

            go func() {
                if err := handler.StartListening(ctx); err != nil {
                    slog.Error("Discord listener error", slog.Any("error", err))
                }
            }()
            slog.Info("Discord bot started")
        },
    }
}
```

**IMPORTANT**: Check `PollerDeps` struct and `HandlerConfig` struct for exact field names. Adapt the code above to match actual types. Read `cmd/pilot/poller_plane.go` and `internal/adapters/discord/handler.go` to get the exact signatures.

## Files to Modify

### `cmd/pilot/poller_registry.go`

Add `discordPollerRegistration()` to the `adapterPollerRegistrations()` function's return slice.

### `internal/config/config.go`

Add Discord to `AdaptersConfig`:

```go
Discord *discord.Config `yaml:"discord"`
```

Add the import for `"github.com/alekspetrov/pilot/internal/adapters/discord"`.

### `cmd/pilot/main.go`

1. Add flag variable and registration:
```go
var enableDiscord bool
cmd.Flags().BoolVar(&enableDiscord, "discord", false, "Enable Discord bot")
```

2. In `applyInputOverrides()`, add Discord handling (look at how `--plane` or `--slack` is handled and copy that pattern):
```go
if cmd.Flags().Changed("discord") {
    if cfg.Adapters.Discord == nil {
        cfg.Adapters.Discord = discord.DefaultConfig()
    }
    cfg.Adapters.Discord.Enabled = enableDiscord
}
```

### `configs/pilot.example.yaml`

Add Discord section under `adapters:` (look at where `plane:` is and add after it):

```yaml
  discord:
    enabled: false
    bot_token: "${DISCORD_BOT_TOKEN}"
    allowed_guilds: []       # Guild IDs (empty = all)
    allowed_channels: []     # Channel IDs (empty = all)
    command_prefix: "/"
```

## Verification

- [ ] `go build ./...` compiles
- [ ] `go test ./...` passes
- [ ] `golangci-lint run --new-from-rev=origin/main` has zero issues
- [ ] `grep -r "discord" cmd/pilot/main.go` shows flag registration
- [ ] `grep -r "Discord" internal/config/config.go` shows config field
- [ ] `ls cmd/pilot/poller_discord.go` exists