### PR TITLE
docs: Add Discord and Plane.so integration pages

### DIFF
--- a/docs/content/integrations/_meta.js
+++ b/docs/content/integrations/_meta.js
@@ -5,6 +5,8 @@ export default {
   linear: "Linear",
   jira: "Jira",
   asana: "Asana",
+  plane: "Plane",
   slack: "Slack",
+  discord: "Discord",
   telegram: "Telegram"
 }

--- a/docs/content/integrations/discord.mdx
+++ b/docs/content/integrations/discord.mdx
@@ -1,0 +1,112 @@
+import { Callout } from 'nextra/components'
+
+# Discord Integration
+
+Pilot connects to your Discord server via a bot, allowing team members to submit tasks directly from Discord channels. Messages in allowed channels are converted to Pilot tasks with interactive confirmation buttons.
+
+## Setup
+
+### 1. Create a Discord Bot
+
+1. Go to the [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click **New Application** → name it (e.g., "Pilot Bot")
+3. Go to **Bot** → click **Add Bot**
+4. Under **Privileged Gateway Intents**, enable:
+   - `GUILD_MESSAGES`
+   - `DIRECT_MESSAGES`
+   - `MESSAGE_CONTENT` (privileged — required for reading message text)
+5. Copy the **Bot Token** from the Bot page
+
+<Callout type="warning">
+The `MESSAGE_CONTENT` intent is privileged and must be explicitly enabled in the Developer Portal. Without it, Pilot cannot read message content.
+</Callout>
+
+### 2. Invite the Bot to Your Server
+
+1. Go to **OAuth2** → **URL Generator**
+2. Select scopes: `bot`, `applications.commands`
+3. Select bot permissions: **Send Messages**, **Read Message History**, **Use Slash Commands**
+4. Copy the generated URL and open it to invite the bot
+
+### 3. Configure Pilot
+
+```yaml
+# ~/.pilot/config.yaml
+adapters:
+  discord:
+    enabled: true
+    bot_token: "${DISCORD_BOT_TOKEN}"
+    allowed_guilds: []       # Guild IDs (empty = all guilds)
+    allowed_channels: []     # Channel IDs (empty = all channels)
+    command_prefix: "/"
+```
+
+## Configuration Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable the Discord adapter |
+| `bot_token` | string | required | Discord bot token |
+| `allowed_guilds` | []string | `[]` | Guild IDs to allow (empty = all) |
+| `allowed_channels` | []string | `[]` | Channel IDs to allow (empty = all) |
+| `command_prefix` | string | `"/"` | Command prefix (reserved for future use) |
+
+## How It Works
+
+Pilot connects to Discord via the Gateway WebSocket for real-time message delivery — no polling required. The connection supports automatic reconnection with session resume on disconnect.
+
+**Constraints:**
+- One pending task per channel (prevents spam)
+- 5-minute task expiry for unconfirmed tasks
+
+### Task Flow
+
+1. User sends a message in an allowed channel
+2. Pilot replies with a task confirmation embed containing **Execute** (green) and **Cancel** (red) buttons
+3. User clicks **Execute** → Pilot dispatches the task
+4. Progress updates edit the original message in-place with a progress bar
+5. On completion, the result is posted with a PR link
+
+### Message Formats
+
+| Phase | Format |
+|-------|--------|
+| Confirmation | Task description + Execute / Cancel buttons |
+| Progress | `⚙️ [██████░░░░] 60%` with phase detail |
+| Success | `✅ Task completed` with PR link |
+| Failure | `❌ Task failed` with error summary |
+
+## Running Pilot with Discord
+
+```bash
+pilot start --discord --github
+```
+
+This starts the Discord adapter alongside the GitHub adapter for PR creation.
+
+## Troubleshooting
+
+### Bot Not Responding
+
+1. Verify the `MESSAGE_CONTENT` privileged intent is enabled in the Developer Portal
+2. Check that the bot is online in your server's member list
+3. Confirm the channel is in `allowed_channels` (or leave empty for all channels)
+
+### "Invalid Token" Close Code
+
+1. Regenerate the bot token in the Developer Portal → Bot → **Reset Token**
+2. Update `DISCORD_BOT_TOKEN` in your environment
+
+### Messages Not Received
+
+1. Verify `allowed_guilds` and `allowed_channels` lists are correct (or empty for all)
+2. Ensure the bot has **Read Message History** permission in the channel
+3. Check Pilot logs for gateway connection events
+
+### Rate Limits
+
+Discord enforces rate limits. Pilot defaults:
+- 5 messages per second per channel
+- 10 task dispatches per minute
+
+If you see `429 Too Many Requests` in logs, reduce concurrent task volume.

--- a/docs/content/integrations/plane.mdx
+++ b/docs/content/integrations/plane.mdx
@@ -1,0 +1,165 @@
+import { Callout } from 'nextra/components'
+
+# Plane Integration
+
+Pilot integrates with [Plane](https://plane.so) to receive work items and automatically implement them. It supports both Plane Cloud and self-hosted instances, with polling and webhook modes for issue detection.
+
+## Setup
+
+### 1. Create a Plane API Key
+
+1. Go to your Plane workspace → **Settings** → **API Tokens**
+2. Click **Create token**
+3. Copy the API key
+
+### 2. Find Your Project UUID
+
+Your project UUID is visible in the Plane URL when viewing a project:
+```
+https://app.plane.so/{workspace}/projects/{project-uuid}/issues
+```
+
+### 3. Set Up Webhooks (Optional)
+
+For real-time issue detection:
+
+1. Go to **Workspace Settings** → **Webhooks**
+2. Click **Create webhook**
+3. Set the URL to `https://your-pilot.example.com/webhooks/plane`
+4. Select events: **Issues**
+5. Copy the signing secret
+
+<Callout type="warning">
+Always set a `webhook_secret` in production. When empty, signature verification is disabled (development mode only).
+</Callout>
+
+### 4. Configure Pilot
+
+```yaml
+# ~/.pilot/config.yaml
+adapters:
+  plane:
+    enabled: true
+    base_url: "https://api.plane.so"   # Or self-hosted URL
+    api_key: "${PLANE_API_KEY}"
+    webhook_secret: "${PLANE_WEBHOOK_SECRET}"
+    workspace_slug: "my-team"
+    project_ids:
+      - "project-uuid-1"
+    pilot_label: "pilot"
+    polling:
+      enabled: true
+      interval: 30s
+```
+
+## Configuration Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable the Plane adapter |
+| `base_url` | string | `https://api.plane.so` | Plane API URL (cloud or self-hosted) |
+| `api_key` | string | required | Plane API key from workspace settings |
+| `webhook_secret` | string | — | HMAC-SHA256 secret for webhook verification |
+| `workspace_slug` | string | required | Your Plane workspace slug |
+| `project_ids` | []string | required | Project UUIDs to monitor |
+| `pilot_label` | string | `"pilot"` | Label name that triggers Pilot |
+| `polling.enabled` | bool | `false` | Enable polling for new issues |
+| `polling.interval` | duration | `30s` | Poll interval |
+
+## Polling Mode
+
+When polling is enabled, Pilot periodically queries Plane for issues matching:
+
+- **Project**: belongs to one of the configured `project_ids`
+- **Label**: has the `pilot_label` (default: `pilot`)
+
+Issues are processed oldest-first by creation date. Parallel execution is supported with configurable concurrency.
+
+### Crash-Safe Deduplication
+
+Pilot uses a `ProcessedStore` backed by SQLite to track which issues have been handled. This prevents re-dispatching issues after a restart or hot upgrade — no configuration required.
+
+## Webhook Mode
+
+For real-time issue detection, configure Plane webhooks to notify Pilot when issues are created or updated.
+
+### Endpoint
+
+```
+POST /webhooks/plane
+```
+
+### Signature Verification
+
+Plane signs webhook payloads with HMAC-SHA256. Pilot verifies the signature using the configured `webhook_secret`.
+
+<Callout type="info">
+If `webhook_secret` is empty, signature verification is skipped. This is intended for development only.
+</Callout>
+
+### Supported Events
+
+| Event | Behavior |
+|-------|----------|
+| Issue created | Process if issue has the pilot label |
+| Issue updated (label added) | Process if the pilot label was just added |
+
+## State Transitions
+
+Pilot updates issue state groups as it works:
+
+| Event | State Group |
+|-------|-------------|
+| Task dispatched | `started` |
+| Execution succeeded | `completed` |
+| Execution failed | State unchanged (manual triage) |
+
+### Labels Applied
+
+Pilot applies labels to track issue status:
+
+| Label | When |
+|-------|------|
+| `pilot-in-progress` | Task dispatched |
+| `pilot-done` | Execution succeeded |
+| `pilot-failed` | Execution failed |
+
+## Task ID Format
+
+Plane issues are converted to Pilot tasks with the format `PLANE-{first 8 chars of UUID}`:
+- Issue `a1b2c3d4-e5f6-...` → Task ID `PLANE-a1b2c3d4`
+- Branch name: `pilot/PLANE-a1b2c3d4`
+
+## Autopilot Integration
+
+PRs created from Plane issues are automatically wired into the autopilot pipeline. CI monitoring, auto-merge, and the feedback loop all work the same as with GitHub and Linear issues — no extra configuration required.
+
+## Running Pilot with Plane
+
+```bash
+pilot start --plane --github
+```
+
+This starts the Plane adapter alongside the GitHub adapter for PR creation.
+
+## Troubleshooting
+
+### Issues Not Picked Up
+
+1. Verify the project UUID matches exactly (check the URL in Plane)
+2. Confirm the label name matches `pilot_label` (case-sensitive)
+3. Check that `polling.enabled` is `true` or webhooks are configured
+4. Look for polling activity in Pilot logs
+
+### Webhook Not Triggering
+
+1. Verify the webhook URL is accessible from Plane's servers
+2. Check the signing secret matches between Plane and Pilot config
+3. Confirm the correct event types are selected in Plane webhook settings
+4. Check Pilot logs for signature verification errors
+
+### Self-Hosted Instances
+
+1. Ensure `base_url` includes the protocol (`https://`)
+2. Do not include a trailing slash in the URL
+3. Verify the API key has workspace-level access


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1888.

Closes #1888

## Changes

GitHub Issue #1888: docs: Add Discord and Plane.so integration pages

## Description

Add two new integration documentation pages for Discord and Plane.so adapters, and update the integrations navigation.

## Files to Create/Modify

### 1. Create `docs/content/integrations/discord.mdx`

Full Discord adapter integration page covering:

**Setup section:**
- Create a Discord Bot in Developer Portal (Applications → New Application → Bot)
- Required permissions: Send Messages, Read Message History, Use Slash Commands
- Required Gateway Intents: `GUILD_MESSAGES`, `DIRECT_MESSAGES`, `MESSAGE_CONTENT` (privileged)
- Bot token from Developer Portal → Bot → Token

**Configuration:**
```yaml
adapters:
  discord:
    enabled: true
    bot_token: "${DISCORD_BOT_TOKEN}"
    allowed_guilds: []       # Guild IDs (empty = all guilds)
    allowed_channels: []     # Channel IDs (empty = all channels)
    command_prefix: "/"
```

**Config reference table:**

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `enabled` | bool | `false` | Enable the Discord adapter |
| `bot_token` | string | required | Discord bot token |
| `allowed_guilds` | []string | `[]` | Guild IDs to allow (empty = all) |
| `allowed_channels` | []string | `[]` | Channel IDs to allow (empty = all) |
| `command_prefix` | string | `"/"` | Command prefix (reserved for future use) |

**How it works section:**
- Uses Discord Gateway WebSocket (real-time, not polling)
- Auto-reconnect with session resume on disconnect
- One pending task per channel (prevents spam)
- 5-minute task expiry for unconfirmed tasks

**Task flow:**
1. User sends message in allowed channel
2. Pilot shows task confirmation with Execute/Cancel buttons
3. User clicks Execute → Pilot runs task
4. Progress updates edit the original message in-place (progress bar)
5. Result posted with PR link on completion

**Message format:**
- Confirmation: task description + Execute (green) / Cancel (red) buttons
- Progress: `⚙️ [██████░░░░] 60%` with phase detail
- Success: `✅ Task completed` with PR link
- Failure: `❌ Task failed` with error

**Start Pilot with Discord:**
```bash
pilot start --discord --github
```

**Troubleshooting section:**
- Bot not responding → check MESSAGE_CONTENT intent is enabled
- "Invalid token" close code → regenerate bot token
- Messages not received → verify guild/channel allowlists
- Rate limits → default 5 messages/sec, 10 tasks/min

### 2. Create `docs/content/integrations/plane.mdx`

Full Plane.so adapter integration page covering:

**Setup section:**
- Works with Plane Cloud (api.plane.so) and self-hosted instances
- Create API key in Workspace Settings → API Tokens
- Set up webhook in Workspace Settings → Webhooks (optional, for real-time)

**Configuration:**
```yaml
adapters:
  plane:
    enabled: true
    base_url: "https://api.plane.so"   # Or self-hosted URL
    api_key: "${PLANE_API_KEY}"
    webhook_secret: "${PLANE_WEBHOOK_SECRET}"
    workspace_slug: "my-team"
    project_ids:
      - "project-uuid-1"
    pilot_label: "pilot"
    polling:
      enabled: true
      interval: 30s
```

**Config reference table:**

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `enabled` | bool | `false` | Enable the Plane adapter |
| `base_url` | string | `https://api.plane.so` | Plane API URL (cloud or self-hosted) |
| `api_key` | string | required | Plane API key from workspace settings |
| `webhook_secret` | string | — | HMAC-SHA256 secret for webhook verification |
| `workspace_slug` | string | required | Your Plane workspace slug |
| `project_ids` | []string | required | Project UUIDs to monitor |
| `pilot_label` | string | `"pilot"` | Label name that triggers Pilot |
| `polling.enabled` | bool | `false` | Enable polling for new issues |
| `polling.interval` | duration | `30s` | Poll interval |

**Polling mode section:**
- Polls work items with pilot label per project
- Oldest-first processing
- Parallel execution with configurable concurrency
- ProcessedStore for crash-safe deduplication

**Webhook mode section:**
- HMAC-SHA256 signature verification
- Endpoint: `POST /webhooks/plane`
- Events: issue created, issue updated (label added)
- Dev mode: empty webhook_secret disables verification

**State transitions:**
- Dispatch → `started` state group
- Success → `completed` state group
- Failure → state unchanged (manual triage)

**Labels applied:**

| Label | When |
|-------|------|
| `pilot-in-progress` | Task dispatched |
| `pilot-done` | Execution succeeded |
| `pilot-failed` | Execution failed |

**Task ID format:** `PLANE-{first 8 chars of UUID}`

**Autopilot integration:**
- PRs created from Plane issues are wired into autopilot pipeline
- CI monitoring, auto-merge, feedback loop all work

**Start Pilot with Plane:**
```bash
pilot start --plane --github
```

**Troubleshooting:**
- Issues not picked up → verify project UUID and label name match exactly
- Webhook not triggering → check signature and event types
- Self-hosted → ensure base_url includes protocol, no trailing slash

### 3. Update `docs/content/integrations/_meta.js`

Add Discord and Plane entries:

```js
export default {
  github: "GitHub",
  gitlab: "GitLab",
  "azure-devops": "Azure DevOps",
  linear: "Linear",
  jira: "Jira",
  asana: "Asana",
  plane: "Plane",
  slack: "Slack",
  discord: "Discord",
  telegram: "Telegram"
}
```

## Style Guide
- Follow existing integration page patterns (see github.mdx, linear.mdx for structure)
- Use `import { Callout } from 'nextra/components'` for tips/warnings
- Include a Callout for webhook_secret in production
- Keep tables consistent with other pages
- Reference the example config at `configs/pilot.example.yaml`

## Acceptance Criteria
- [ ] Discord integration page created with setup, config, task flow, troubleshooting
- [ ] Plane integration page created with setup, config, polling, webhooks, state transitions
- [ ] _meta.js updated with both entries in logical order
- [ ] Pages render without errors (no broken imports)