### PR TITLE
fix(dashboard): Wire projectPath to git graph panel — exit status 128

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -540,6 +540,7 @@ Examples:
 						gwAutopilotController.SetMonitor(gwMonitor)
 					}
 					model := dashboard.NewModelWithOptions(version, gwStore, gwAutopilotController, nil)
+					model.SetProjectPath(projectPath)
 					gwProgram = tea.NewProgram(model,
 						tea.WithAltScreen(),
 						tea.WithInput(os.Stdin),
@@ -1388,6 +1389,7 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 		}
 		upgradeRequestCh = make(chan struct{}, 1)
 		model := dashboard.NewModelWithOptions(version, store, autopilotController, upgradeRequestCh)
+		model.SetProjectPath(projectPath)
 		program = tea.NewProgram(model,
 			tea.WithAltScreen(),
 			tea.WithInput(os.Stdin),


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1899.

Closes #1899

## Changes

GitHub Issue #1899: fix(dashboard): Wire projectPath to git graph panel — exit status 128

## Bug

The GIT GRAPH panel in the TUI dashboard shows "exit status 128" because `SetProjectPath()` is never called after creating the dashboard model. The `projectPath` field stays empty string, causing `git -C "" log --graph` to fail.

## Root Cause

Two dashboard creation sites in `cmd/pilot/main.go` never wire the project path:

1. **Line 542** (gateway mode): `model := dashboard.NewModelWithOptions(version, gwStore, gwAutopilotController, nil)`
2. **Line 1390** (polling mode): `model := dashboard.NewModelWithOptions(version, store, autopilotController, upgradeRequestCh)`

Neither calls `model.SetProjectPath(projectPath)`.

The `SetProjectPath` method exists at `internal/dashboard/tui.go:621` but is only used in tests.

## Fix

Add `model.SetProjectPath(projectPath)` after each `NewModelWithOptions` call:

### Site 1 — Gateway mode (after line 542):
```go
model := dashboard.NewModelWithOptions(version, gwStore, gwAutopilotController, nil)
model.SetProjectPath(projectPath)
```

Note: In gateway mode, `projectPath` is available from the closure. Verify the variable name in scope — it should be the same `projectPath` resolved at lines 205-216.

### Site 2 — Polling mode (after line 1390):
```go
model := dashboard.NewModelWithOptions(version, store, autopilotController, upgradeRequestCh)
model.SetProjectPath(projectPath)
```

The `projectPath` variable is in scope here — it's a parameter of `runPollingMode()`.

## Verification

After the fix, pressing `g` in the dashboard should show the git graph with branch visualization instead of "exit status 128".

## Acceptance Criteria
- [ ] `SetProjectPath(projectPath)` called at both dashboard creation sites
- [ ] `make build` succeeds
- [ ] `make test` passes