### PR TITLE
refactor(dashboard): remove GitGraphSmall mode, simplify g toggle

### DIFF
--- a/internal/dashboard/gitgraph_test.go
+++ b/internal/dashboard/gitgraph_test.go
@@ -228,32 +228,6 @@ func TestRenderGraphLineFull_Connector(t *testing.T) {
 	}
 }
 
-// TestRenderGraphLineSmall verifies small-mode rendering.
-func TestRenderGraphLineSmall(t *testing.T) {
-	line := GitGraphLine{
-		GraphChars: "│ ",
-		SHA:        "a1b2c3d",
-		Message:    "fix: handle nil response in webhook handler",
-	}
-
-	width := 30
-	got := renderGraphLineSmall(line, width)
-
-	if got == "" {
-		t.Error("renderGraphLineSmall returned empty string")
-	}
-
-	plain := stripANSI(got)
-	// Should not include author or SHA (small mode: message only)
-	if strings.Contains(plain, "a1b2c3d") {
-		t.Error("small mode should not include SHA")
-	}
-	// Should contain truncated message
-	if !strings.Contains(plain, "fix:") {
-		t.Errorf("small mode should contain message start, got %q", plain)
-	}
-}
-
 // TestRenderGitGraph_Hidden verifies no output when mode is Hidden.
 func TestRenderGitGraph_Hidden(t *testing.T) {
 	m := NewModel("test")
@@ -360,29 +334,6 @@ func TestRenderGitGraph_WithData(t *testing.T) {
 	}
 }
 
-// TestRenderGitGraph_SmallMode verifies small mode uses "GIT" as title.
-func TestRenderGitGraph_SmallMode(t *testing.T) {
-	m := NewModel("test")
-	m.gitGraphMode = GitGraphSmall
-	m.width = 130
-	m.gitGraphState = &GitGraphState{
-		TotalCount: 1,
-		Lines: []GitGraphLine{
-			{GraphChars: "● ", SHA: "7eb8da1", Author: "Alice", Message: "fix: edge case"},
-		},
-	}
-
-	got := m.renderGitGraph()
-	if got == "" {
-		t.Fatal("small mode returned empty string")
-	}
-
-	plain := stripANSI(got)
-	if !strings.Contains(plain, "GIT") {
-		t.Error("small mode should have 'GIT' in panel title")
-	}
-}
-
 // TestRenderGitGraph_FocusedBorder verifies both focused and unfocused panels render.
 // Note: color differences require a TTY; here we only verify both render non-empty
 // and contain the correct panel structure.
@@ -417,7 +368,7 @@ func TestRenderGitGraph_FocusedBorder(t *testing.T) {
 	}
 }
 
-// TestModelUpdate_GToggle verifies 'g' key cycles through graph modes.
+// TestModelUpdate_GToggle verifies 'g' key toggles graph on/off.
 func TestModelUpdate_GToggle(t *testing.T) {
 	m := NewModel("test")
 	m.gitGraphMode = GitGraphHidden
@@ -430,18 +381,11 @@ func TestModelUpdate_GToggle(t *testing.T) {
 		t.Errorf("after 1st g: mode = %d, want GitGraphFull(%d)", m.gitGraphMode, GitGraphFull)
 	}
 
-	// Full → Small
-	updated, _ = m.Update(makeKey("g"))
-	m = updated.(Model)
-	if m.gitGraphMode != GitGraphSmall {
-		t.Errorf("after 2nd g: mode = %d, want GitGraphSmall(%d)", m.gitGraphMode, GitGraphSmall)
-	}
-
-	// Small → Hidden
+	// Full → Hidden
 	updated, _ = m.Update(makeKey("g"))
 	m = updated.(Model)
 	if m.gitGraphMode != GitGraphHidden {
-		t.Errorf("after 3rd g: mode = %d, want GitGraphHidden(%d)", m.gitGraphMode, GitGraphHidden)
+		t.Errorf("after 2nd g: mode = %d, want GitGraphHidden(%d)", m.gitGraphMode, GitGraphHidden)
 	}
 }
 

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -652,8 +652,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.showLogs = !m.showLogs
 			return m, tea.ClearScreen // GH-1249: Logs toggle changes height
 		case "g":
-			// Cycle git graph: Hidden → Full → Small → Hidden
-			m.gitGraphMode = (m.gitGraphMode + 1) % 3
+			// Toggle git graph: Hidden ↔ Full
+			if m.gitGraphMode == GitGraphHidden {
+				m.gitGraphMode = GitGraphFull
+			} else {
+				m.gitGraphMode = GitGraphHidden
+			}
 			m.gitGraphFocus = false
 			if m.gitGraphMode != GitGraphHidden {
 				// Start refresh and 15s tick when becoming visible
@@ -954,10 +958,10 @@ func (m Model) renderHelp() string {
 		parts = []string{"q: quit", "l: logs", "b: banner", "g: graph", "j/k: select"}
 	case m.gitGraphFocus:
 		// Graph visible, graph panel focused
-		parts = []string{"q: quit", "b: banner", "g: cycle", "tab: dashboard"}
+		parts = []string{"q: quit", "b: banner", "g: close", "tab: dashboard"}
 	default:
 		// Graph visible, dashboard focused
-		parts = []string{"q: quit", "b: banner", "g: cycle", "tab: graph"}
+		parts = []string{"q: quit", "b: banner", "g: close", "tab: graph"}
 	}
 	help := strings.Join(parts, "  ")
 	if len(help) > panelTotalWidth {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1905.

Closes #1905

## Changes

GitHub Issue #1905: refactor(dashboard): remove GitGraphSmall mode, simplify g toggle

## Problem

`g` currently cycles through 3 states: Hidden → Full → Small → Hidden.

Small mode caps the graph panel at 32 chars — nearly useless, content is truncated to unreadable. Adds confusion ("cycle" vs "toggle").

## Solution

Remove `GitGraphSmall` entirely. Make `g` a simple on/off toggle: Hidden ↔ Full.

Changes:
- Remove `GitGraphSmall` constant from `gitgraph.go`
- `g` handler: simple toggle instead of 3-state modulo
- Help tips: "g: graph" when hidden, "g: close" when visible
- Remove Small mode width cap and title logic from `renderGitGraph()`