### PR TITLE
fix(dashboard): responsive git graph — full-width stacked layout on narrow terminals

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -855,8 +855,14 @@ func (m Model) View() string {
 	if m.gitGraphMode == GitGraphHidden {
 		result = dashboard
 	} else if m.width > 0 && m.width < panelTotalWidth+1+20 {
-		// Terminal too narrow for side-by-side — stack graph below dashboard
-		graphPanel := m.renderGitGraph(panelTotalWidth)
+		// Terminal too narrow for side-by-side — stack graph below at full terminal width.
+		// Calculate remaining height after dashboard so graph doesn't pad to full m.height.
+		dashLines := strings.Count(dashboard, "\n") + 1
+		graphHeight := m.height - dashLines - 1 // -1 for help footer
+		if graphHeight < 8 {
+			graphHeight = 8 // minimum useful graph height
+		}
+		graphPanel := m.renderGitGraph(m.width, graphHeight)
 		if graphPanel == "" {
 			result = dashboard
 		} else {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1904.

Closes #1904

## Changes

GitHub Issue #1904: fix(dashboard): responsive git graph — full-width stacked layout on narrow terminals

## Problem

The git graph panel (`g` key) only renders side-by-side when terminal width ≥ 90 cols. On narrow terminals (Zellij splits, small screens), pressing `g` silently does nothing — no panel, no feedback.

v2.38.2-v2.38.4 attempted fixes that made it worse:
- v2.38.2: Blocked `g` key entirely on narrow terminals
- v2.38.3: Reverted key blocking
- v2.38.4: Added stacked layout at 69-char width (too narrow, pushed below viewport)

## Solution

Responsive layout like a website:
- **Wide (≥90 cols)**: Side-by-side (existing, works)
- **Narrow (<90 cols)**: Graph stacks below dashboard at **full terminal width** (`m.width`)

Height truncation cuts whatever doesn't fit — user can toggle banner/logs to make room.

## Files

- `internal/dashboard/tui.go` — View() layout logic
- `internal/dashboard/gitgraph.go` — renderGitGraph() width calculation
- `internal/dashboard/tui_test.go` — tests

Also: help footer must render after height truncation so keyboard hints always visible.