### PR TITLE
fix(dashboard): increase side-by-side breakpoint — graph too squeezed at medium widths

### DIFF
--- a/internal/dashboard/gitgraph.go
+++ b/internal/dashboard/gitgraph.go
@@ -403,7 +403,7 @@ func (m Model) renderGitGraph(opts ...int) string {
 	}
 	if graphWidth == 0 {
 		// Side-by-side layout: calculate from remaining terminal width
-		minTermWidth := panelTotalWidth + 1 + 20
+		minTermWidth := panelTotalWidth + 1 + 50
 		if m.width > 0 && m.width < minTermWidth {
 			return ""
 		}

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -858,7 +858,7 @@ func (m Model) View() string {
 	var result string
 	if m.gitGraphMode == GitGraphHidden {
 		result = dashboard
-	} else if m.width > 0 && m.width < panelTotalWidth+1+20 {
+	} else if m.width > 0 && m.width < panelTotalWidth+1+50 {
 		// Terminal too narrow for side-by-side — stack graph below at full terminal width.
 		// Calculate remaining height after dashboard so graph doesn't pad to full m.height.
 		dashLines := strings.Count(dashboard, "\n") + 1


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1908.

Closes #1908

## Changes

GitHub Issue #1908: fix(dashboard): increase side-by-side breakpoint — graph too squeezed at medium widths

## Problem

Side-by-side layout triggers at ≥90 cols, but when terminal is 90-120 cols the graph panel gets only ~20-50 chars — graph characters and truncated text, barely readable.

See: the graph shows `● (` and `Merge PR ... 6f04a22` with everything cut off.

## Solution

Raise the breakpoint so side-by-side only activates when the graph gets enough room to be useful (at least ~50 chars for the graph panel). Otherwise, use stacked layout.

Current: `panelTotalWidth + 1 + 20 = 90`
Proposed: `panelTotalWidth + 1 + 50 = 120` (or similar — the graph needs ~50 chars to show refs + SHA + message)

File: `internal/dashboard/tui.go` line 861, and `gitgraph.go` line 424 (minTermWidth)