### PR TITLE
docs: add review learning section to memory page

### DIFF
--- a/docs/content/features/memory.mdx
+++ b/docs/content/features/memory.mdx
@@ -87,6 +87,26 @@ pilot patterns stats
 Patterns with confidence below 0.1 are automatically pruned. High-confidence patterns (>0.7) are prioritized in future task prompts.
 </Callout>
 
+## Review Learning
+
+After a PR is merged, Pilot processes review comments left by human reviewers to learn patterns for future tasks. The `LearnFromReview()` method fetches PR review comments via the GitHub API and categorizes them by review type.
+
+| Review Type | Signal | Effect |
+|-------------|--------|--------|
+| Approved (with text) | Positive | Boost pattern confidence |
+| Changes requested | Negative | Create anti-pattern (max 0.85 confidence) |
+| Approved (no text) | None | Skipped |
+
+- **Approved reviews with text** — Reviewer comments on approved PRs are treated as positive signals. Patterns used in the execution get a confidence boost.
+- **Changes-requested reviews** — Reviewer feedback is extracted as anti-patterns, capped at 0.85 confidence to allow future override if conventions change.
+- **Empty approvals** — Approval clicks without review text are skipped since there is no actionable signal to extract.
+
+Learned patterns are injected into future execution prompts, so Pilot's code quality improves over time based on your team's feedback.
+
+<Callout type="info">
+Review learning runs automatically after PR merge. No configuration needed — it uses the same GitHub token configured for the GitHub adapter.
+</Callout>
+
 ## Knowledge Graph
 
 The knowledge graph stores relationships between concepts, files, and patterns.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1921.

Closes #1921

## Changes

GitHub Issue #1921: docs: add review learning section to memory page

Add PR review learning documentation to the Memory & Learning docs page.

## File
`docs/content/features/memory.mdx`

## Changes

### Add `## Review Learning` section
Insert after the "Cross-Project Patterns" section (after the Pattern Commands subsection, around line 77), before "Knowledge Graph" (line 90).

Content to document (source: `internal/memory/feedback.go` lines 295-339):

- **What it does**: After a PR is merged, Pilot processes review comments left by human reviewers to learn patterns
- **How it works**: `LearnFromReview()` fetches PR review comments via `GetPullRequestComments` from the GitHub API
- **Approved reviews with text**: Reviewer comments on approved PRs are treated as positive signals — patterns used in the execution get a confidence boost
- **Changes-requested reviews**: Reviewer feedback is extracted as anti-patterns (capped at 0.85 confidence to allow override)
- **Empty approvals**: Approval clicks without review text are skipped (no signal to extract)
- **Prompt injection**: Learned patterns from reviews are injected into future execution prompts, improving code quality over time based on team feedback

Include a simple table:

| Review Type | Signal | Effect |
|-------------|--------|--------|
| Approved (with text) | Positive | Boost pattern confidence |
| Changes requested | Negative | Create anti-pattern (max 0.85 confidence) |
| Approved (no text) | None | Skipped |

Add a callout note:
> Review learning runs automatically after PR merge. No configuration needed — it uses the same GitHub token configured for the GitHub adapter.

## Source References
- `internal/memory/feedback.go` lines 295-339: `LearnFromReview()` method
- `internal/memory/feedback.go` line 310: confidence cap at 0.85 for anti-patterns
- `internal/adapters/github/client.go`: `GetPullRequestComments` API method

## Acceptance Criteria
- Memory docs contain "Review Learning" section
- Review types table with signal types documented
- Explanation of how patterns feed into future prompts
- Content matches actual implementation