### PR TITLE
docs: add auto-rebase conflict resolution to autopilot page

### DIFF
--- a/docs/content/features/autopilot.mdx
+++ b/docs/content/features/autopilot.mdx
@@ -94,6 +94,39 @@ pilot rollback --last
 pilot rollback --pr 123
 ```
 
+## Conflict Resolution
+
+When a Pilot PR has a merge conflict, autopilot automatically attempts to resolve it via rebase before falling back to full re-execution.
+
+### Auto-Rebase Flow
+
+```
+Merge Conflict Detected
+       │
+       ▼
+┌──────────────────┐
+│ Update Branch    │ ← GitHub API rebase
+│ (auto-rebase)    │
+└────────┬─────────┘
+         │
+    ┌────┴────┐
+    │         │
+  Success   Failure
+    │         │
+    ▼         ▼
+WaitingCI   Close PR
+(re-run CI) (re-queue)
+```
+
+- **First attempt**: Uses GitHub's "Update branch" API — equivalent to clicking the "Update branch" button on the PR page
+- **If rebase succeeds**: The PR returns to the `WaitingCI` stage and CI re-runs on the updated branch
+- **If rebase fails**: The PR is closed with an explanatory comment, and the original issue returns to the queue for full re-execution from scratch
+- **Cost savings**: Avoids ~$8–15 per full re-execution for conflicts that are trivially resolvable via rebase
+
+## CI Fix Dependencies
+
+When autopilot's feedback loop creates a CI fix issue (after a CI failure), the fix issue body includes a `Depends on: #N` annotation linking it back to the original parent issue. This provides traceability between fix attempts and the tasks that triggered them.
+
 ## Stagnation Monitor
 
 Detects stuck executions by tracking state changes and escalating through progressive intervention levels.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1920.

Closes #1920

## Changes

GitHub Issue #1920: docs: add auto-rebase conflict resolution to autopilot page

Add auto-rebase conflict resolution and CI fix dependency annotations to autopilot docs.

## File
`docs/content/features/autopilot.mdx`

## Changes

### 1. Add `## Conflict Resolution` section
Insert after the "Rollback" section (line ~95), before "Stagnation Monitor" (line ~97).

Content to document (source: `internal/autopilot/controller.go` line 1048):

- When a Pilot PR has a merge conflict, the autopilot controller detects it and calls `handleMergeConflict()`
- **First attempt**: Uses GitHub's "Update branch" API (`UpdatePullRequestBranch`) — equivalent to clicking the "Update branch" button on GitHub's PR page
- **If rebase succeeds**: PR returns to `WaitingCI` stage, CI re-runs on the updated branch
- **If rebase fails**: PR is closed with an explanatory comment, and the original issue returns to the queue for full re-execution from scratch
- **Cost savings**: Avoids ~$8-15 per full re-execution for conflicts that are trivially resolvable via rebase

Include a simple flow diagram:
```
Merge Conflict Detected
       │
       ▼
┌──────────────────┐
│ Update Branch    │ ← GitHub API rebase
│ (auto-rebase)    │
└────────┬─────────┘
         │
    ┌────┴────┐
    │         │
  Success   Failure
    │         │
    ▼         ▼
WaitingCI   Close PR
(re-run CI) (re-queue)
```

### 2. Add CI Fix Dependency Annotation
Add a note in or near the existing CI Feedback Loop section. Content from `internal/autopilot/feedback_loop.go` line 154:

- When autopilot creates a CI fix issue, it includes a `Depends on: #N` annotation in the issue body
- This links the fix issue back to the original parent issue for traceability
- Helps track which fix attempts correspond to which original tasks

## Source References
- `internal/autopilot/controller.go` lines 1048-1069: `handleMergeConflict()`
- `internal/autopilot/feedback_loop.go` line 154: `Depends on: #%d` annotation
- `internal/autopilot/feedback_loop_test.go` lines 125-127: test confirming annotation

## Acceptance Criteria
- Autopilot docs contain "Conflict Resolution" section
- Auto-rebase flow documented with diagram
- CI fix dependency annotation mentioned
- Content matches actual implementation