### PR TITLE
Add `HasTokenLimitCheck` accessor to Runner (`internal/executor/runner.go`)

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -648,6 +648,9 @@ func (r *Runner) HasLearningLoop() bool { return r.learningLoop != nil }
 // HasPatternContext reports whether a pattern context is wired.
 func (r *Runner) HasPatternContext() bool { return r.patternContext != nil }
 
+// HasTokenLimitCheck reports whether a token limit check callback is wired.
+func (r *Runner) HasTokenLimitCheck() bool { return r.tokenLimitCheck != nil }
+
 // HasKnowledge reports whether a knowledge store is wired.
 func (r *Runner) HasKnowledge() bool { return r.knowledge != nil }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1934.

Closes #1934

## Changes

Add the missing `HasTokenLimitCheck() bool` method to `Runner`, returning `r.tokenLimitCheck != nil`. This is a one-line accessor that mirrors the existing `Has*` pattern (e.g., `HasLearningLoop`, `HasPatternContext`). No other files in this package need changes. This is a prerequisite for the wiring tests in subtask 3.