### PR TITLE
Add database indexes for pattern queries in `internal/memory/store.go`

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -159,6 +159,8 @@ func (s *Store) migrate() error {
 		`CREATE INDEX IF NOT EXISTS idx_cross_patterns_type ON cross_patterns(pattern_type)`,
 		`CREATE INDEX IF NOT EXISTS idx_cross_patterns_scope ON cross_patterns(scope)`,
 		`CREATE INDEX IF NOT EXISTS idx_cross_patterns_confidence ON cross_patterns(confidence DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_cross_patterns_updated ON cross_patterns(updated_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_cross_patterns_title ON cross_patterns(title)`,
 		`CREATE INDEX IF NOT EXISTS idx_pattern_projects_project ON pattern_projects(project_path)`,
 		`CREATE INDEX IF NOT EXISTS idx_pattern_feedback_pattern ON pattern_feedback(pattern_id)`,
 		// Usage metering tables (TASK-16)

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1372,3 +1372,77 @@ func TestLogSubscribeMultipleSubscribers(t *testing.T) {
 	store.UnsubscribeLogs(ch1)
 	store.UnsubscribeLogs(ch2)
 }
+
+func TestCrossPatternsIndexes(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Insert test data so the planner has something to work with
+	pattern := &CrossPattern{
+		ID:    "test-idx-1",
+		Type:  "naming",
+		Title: "Use camelCase",
+		Scope: "org",
+	}
+	if err := store.SaveCrossPattern(pattern); err != nil {
+		t.Fatalf("SaveCrossPattern failed: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		query string
+		index string
+	}{
+		{
+			name:  "scope filter uses index",
+			query: `EXPLAIN QUERY PLAN SELECT * FROM cross_patterns WHERE scope = 'org'`,
+			index: "idx_cross_patterns_scope",
+		},
+		{
+			name:  "updated_at filter uses index",
+			query: `EXPLAIN QUERY PLAN SELECT * FROM cross_patterns WHERE updated_at > '2025-01-01'`,
+			index: "idx_cross_patterns_updated",
+		},
+		{
+			name:  "title filter uses index",
+			query: `EXPLAIN QUERY PLAN SELECT * FROM cross_patterns WHERE title = 'Use camelCase'`,
+			index: "idx_cross_patterns_title",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := store.db.Query(tt.query)
+			if err != nil {
+				t.Fatalf("EXPLAIN QUERY PLAN failed: %v", err)
+			}
+			defer func() { _ = rows.Close() }()
+
+			var plan strings.Builder
+			for rows.Next() {
+				var id, parent, notused int
+				var detail string
+				if err := rows.Scan(&id, &parent, &notused, &detail); err != nil {
+					t.Fatalf("scan failed: %v", err)
+				}
+				_, _ = fmt.Fprintf(&plan, "%s\n", detail)
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatalf("rows iteration failed: %v", err)
+			}
+
+			if !strings.Contains(plan.String(), tt.index) {
+				t.Errorf("expected query plan to use %s, got:\n%s", tt.index, plan.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1951.

Closes #1951

## Changes

Add `CREATE INDEX IF NOT EXISTS` statements for `scope`, `updated_at`, and `title` columns on the `cross_patterns` table in the schema initialization function. Verify backward compatibility with `IF NOT EXISTS`, confirm existing memory tests pass, and validate with `EXPLAIN QUERY PLAN` that scope-filtered queries use the new indexes. Skip indexing `description` since SQLite B-tree indexes don't help with `LIKE '%keyword%'` substring matching.