### PR TITLE
Add `ExtractFromSelfReview()` method and self-review pattern categories in `internal/memory/`

### DIFF
--- a/internal/memory/extractor.go
+++ b/internal/memory/extractor.go
@@ -354,6 +354,123 @@ func (e *PatternExtractor) extractWorkflowPatterns(output string) []*ExtractedPa
 	return patterns
 }
 
+// selfReviewFinding defines a mapping from self-review markers to pattern types
+type selfReviewFinding struct {
+	regex   *regexp.Regexp
+	pType   PatternType
+	title   string
+	desc    string
+	context string
+}
+
+// selfReviewFindings are the matchers for self-review output markers
+var selfReviewFindings = []selfReviewFinding{
+	{
+		regex:   regexp.MustCompile(`(?i)(?:missing|no|lack(?:ing)?)\s+error\s+handl`),
+		pType:   PatternTypeError,
+		title:   "Missing error handling",
+		desc:    "Errors must be checked and propagated, not silently ignored",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)(?:unused\s+import|dead\s+code|unreachable\s+code)`),
+		pType:   PatternTypeCode,
+		title:   "Dead code detected",
+		desc:    "Remove unused imports, unreachable code, and dead code paths",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)(?:config\s+field\s+not\s+wired|struct\s+field\s+unused|field\s+.*not\s+(?:used|wired|connected))`),
+		pType:   PatternTypeStructure,
+		title:   "Unwired config or struct field",
+		desc:    "All config and struct fields must be wired through to their consumers",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)(?:test\s+coverage\s+gap|missing\s+test|no\s+test|lint\s+violation|linter\s+error)`),
+		pType:   PatternTypeWorkflow,
+		title:   "Test or lint gap",
+		desc:    "All new code paths must have test coverage; lint violations must be resolved",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)(?:build\s+(?:fail|verification\s+fail)|compilation?\s+(?:error|fail))`),
+		pType:   PatternTypeError,
+		title:   "Build verification failure",
+		desc:    "Code must compile and pass build verification before submission",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)(?:cross.file\s+parity|PARITY_GAP|parity\s+(?:issue|mismatch))`),
+		pType:   PatternTypeStructure,
+		title:   "Cross-file parity issue",
+		desc:    "Related changes across files must stay in sync (interfaces, implementations, tests)",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)REVIEW_FIXED:`),
+		pType:   PatternTypeCode,
+		title:   "Self-review fix applied",
+		desc:    "Issue caught and fixed during self-review pass",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)SUSPICIOUS_VALUE`),
+		pType:   PatternTypeCode,
+		title:   "Suspicious value detected",
+		desc:    "Hardcoded or suspicious values should be verified against requirements",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)INCOMPLETE`),
+		pType:   PatternTypeWorkflow,
+		title:   "Incomplete implementation",
+		desc:    "Implementation is missing required functionality or TODO items remain",
+		context: "Self-review",
+	},
+}
+
+// ExtractFromSelfReview extracts patterns from self-review output by parsing
+// finding markers (REVIEW_FIXED:, SUSPICIOUS_VALUE, PARITY_GAP, INCOMPLETE, etc.)
+// and mapping them to pattern types. Patterns are stored as anti-patterns with
+// confidence 0.5 (boosted on recurrence via existing SaveCrossPattern upsert logic).
+func (e *PatternExtractor) ExtractFromSelfReview(ctx context.Context, selfReviewOutput string, projectPath string) (*ExtractionResult, error) {
+	result := &ExtractionResult{
+		ExecutionID:  fmt.Sprintf("self_review_%d", time.Now().UnixNano()),
+		ProjectPath:  projectPath,
+		Patterns:     make([]*ExtractedPattern, 0),
+		AntiPatterns: make([]*ExtractedPattern, 0),
+		ExtractedAt:  time.Now(),
+	}
+
+	if strings.TrimSpace(selfReviewOutput) == "" {
+		return result, nil
+	}
+
+	for _, finding := range selfReviewFindings {
+		matches := finding.regex.FindAllString(selfReviewOutput, -1)
+		if len(matches) == 0 {
+			continue
+		}
+
+		examples := make([]string, 0, len(matches))
+		for _, m := range matches {
+			examples = append(examples, m)
+		}
+
+		result.AntiPatterns = append(result.AntiPatterns, &ExtractedPattern{
+			Type:        finding.pType,
+			Title:       finding.title,
+			Description: finding.desc,
+			Examples:    examples,
+			Confidence:  0.5,
+			Context:     finding.context,
+		})
+	}
+
+	return result, nil
+}
+
 // SaveExtractedPatterns saves extracted patterns to the store
 func (e *PatternExtractor) SaveExtractedPatterns(ctx context.Context, result *ExtractionResult) error {
 	for _, p := range result.Patterns {

--- a/internal/memory/extractor_test.go
+++ b/internal/memory/extractor_test.go
@@ -594,6 +594,168 @@ func TestMergePattern_AddsNewProjects(t *testing.T) {
 	}
 }
 
+func TestExtractFromSelfReview(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "extractor-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+	ctx := context.Background()
+
+	tests := []struct {
+		name              string
+		selfReviewOutput  string
+		wantAntiPatterns  int
+		wantPatternTypes  []PatternType // expected types in anti-patterns (order-independent)
+	}{
+		{
+			name: "multiple finding types",
+			selfReviewOutput: `REVIEW_FIXED: corrected nil check in handler.go
+Found missing error handling in database query at store.go:42
+PARITY_GAP: interface method added but not implemented in mock
+test coverage gap for new validateInput function
+SUSPICIOUS_VALUE detected in pricing constant`,
+			wantAntiPatterns: 5,
+			wantPatternTypes: []PatternType{
+				PatternTypeCode,      // REVIEW_FIXED
+				PatternTypeError,     // missing error handling
+				PatternTypeStructure, // PARITY_GAP
+				PatternTypeWorkflow,  // test coverage gap
+				PatternTypeCode,      // SUSPICIOUS_VALUE
+			},
+		},
+		{
+			name:             "empty output",
+			selfReviewOutput: "",
+			wantAntiPatterns: 0,
+			wantPatternTypes: nil,
+		},
+		{
+			name:             "whitespace only output",
+			selfReviewOutput: "   \n\t  \n  ",
+			wantAntiPatterns: 0,
+			wantPatternTypes: nil,
+		},
+		{
+			name:             "unparseable output with no markers",
+			selfReviewOutput: "All checks passed. Code looks clean. No issues found.",
+			wantAntiPatterns: 0,
+			wantPatternTypes: nil,
+		},
+		{
+			name: "mixed findings with clean output",
+			selfReviewOutput: `Self-review complete.
+Files checked: 5
+REVIEW_FIXED: corrected nil check in handler
+Everything else looks good.
+INCOMPLETE: TODO items remain in auth module`,
+			wantAntiPatterns: 2,
+			wantPatternTypes: []PatternType{
+				PatternTypeCode,     // REVIEW_FIXED
+				PatternTypeWorkflow, // INCOMPLETE
+			},
+		},
+		{
+			name:             "build failure only",
+			selfReviewOutput: "build verification failure: missing return statement in Calculate()",
+			wantAntiPatterns: 1,
+			wantPatternTypes: []PatternType{PatternTypeError},
+		},
+		{
+			name:             "dead code detection",
+			selfReviewOutput: "Found unused import: fmt in utils.go\nFound dead code in legacy handler",
+			wantAntiPatterns: 1, // single regex matches both
+			wantPatternTypes: []PatternType{PatternTypeCode},
+		},
+		{
+			name:             "struct field unwired",
+			selfReviewOutput: "config field not wired: MaxRetries defined in Config but never read",
+			wantAntiPatterns: 1,
+			wantPatternTypes: []PatternType{PatternTypeStructure},
+		},
+		{
+			name:             "lint violations",
+			selfReviewOutput: "lint violation: exported function missing doc comment\nlinter error on line 55",
+			wantAntiPatterns: 1,
+			wantPatternTypes: []PatternType{PatternTypeWorkflow},
+		},
+		{
+			name: "cross-file parity",
+			selfReviewOutput: `cross-file parity issue: AddUser added to service.go but not to service_test.go
+parity mismatch between interface and implementation`,
+			wantAntiPatterns: 1, // single regex matches both variants
+			wantPatternTypes: []PatternType{PatternTypeStructure},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := extractor.ExtractFromSelfReview(ctx, tt.selfReviewOutput, "/test/project")
+			if err != nil {
+				t.Fatalf("ExtractFromSelfReview() error = %v", err)
+			}
+
+			if result == nil {
+				t.Fatal("ExtractFromSelfReview() returned nil result")
+			}
+
+			if len(result.AntiPatterns) != tt.wantAntiPatterns {
+				types := make([]PatternType, len(result.AntiPatterns))
+				for i, ap := range result.AntiPatterns {
+					types[i] = ap.Type
+				}
+				t.Errorf("got %d anti-patterns %v, want %d", len(result.AntiPatterns), types, tt.wantAntiPatterns)
+				return
+			}
+
+			// Verify pattern types match (order-independent)
+			if tt.wantPatternTypes != nil {
+				gotTypes := make(map[PatternType]int)
+				for _, ap := range result.AntiPatterns {
+					gotTypes[ap.Type]++
+				}
+
+				wantTypes := make(map[PatternType]int)
+				for _, pt := range tt.wantPatternTypes {
+					wantTypes[pt]++
+				}
+
+				for pt, count := range wantTypes {
+					if gotTypes[pt] != count {
+						t.Errorf("pattern type %s: got %d, want %d", pt, gotTypes[pt], count)
+					}
+				}
+			}
+
+			// Verify all anti-patterns have confidence 0.5
+			for _, ap := range result.AntiPatterns {
+				if ap.Confidence != 0.5 {
+					t.Errorf("anti-pattern %q has confidence %f, want 0.5", ap.Title, ap.Confidence)
+				}
+				if ap.Context != "Self-review" {
+					t.Errorf("anti-pattern %q has context %q, want 'Self-review'", ap.Title, ap.Context)
+				}
+			}
+
+			// Verify project path is set
+			if result.ProjectPath != "/test/project" {
+				t.Errorf("ProjectPath = %q, want %q", result.ProjectPath, "/test/project")
+			}
+
+			// Verify no positive patterns (self-review findings are all anti-patterns)
+			if len(result.Patterns) != 0 {
+				t.Errorf("got %d positive patterns, want 0", len(result.Patterns))
+			}
+		})
+	}
+}
+
 func TestExtractFromReviewComments_TestingFeedback(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "extractor-test-*")
 	if err != nil {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1954.

Closes #1954

## Changes

Add the new `ExtractFromSelfReview(ctx, selfReviewOutput, projectPath)` method to `extractor.go`. This parses self-review output for finding markers (`REVIEW_FIXED:`, `SUSPICIOUS_VALUE`, `PARITY_GAP`, `INCOMPLETE`, etc.) and maps them to pattern types:
- Missing error handling → `PatternTypeError` (anti-pattern)
- Unused imports / dead code → `PatternTypeCode` (anti-pattern)
- Config field not wired / struct field unused → `PatternTypeStructure` (anti-pattern)
- Test coverage gaps / lint violations → `PatternTypeWorkflow` (anti-pattern)
- Build verification failures → `PatternTypeError` (anti-pattern)
- Cross-file parity issues → `PatternTypeStructure` (anti-pattern)
Returns `*ExtractionResult` using the existing struct. Patterns stored with confidence 0.5 (boosted on recurrence via existing `SaveCrossPattern` upsert logic). Include unit tests in `extractor_test.go` with table-driven tests covering: multiple finding types, empty output, unparseable output, mixed findings.