### PR TITLE
feat(executor): wire learned patterns into self-review checks

### DIFF
--- a/internal/executor/prompt_builder.go
+++ b/internal/executor/prompt_builder.go
@@ -257,7 +257,7 @@ func (r *Runner) buildRetryPrompt(task *Task, feedback string, attempt int) stri
 // buildSelfReviewPrompt constructs the prompt for self-review phase.
 // The prompt instructs Claude to examine its changes for common issues
 // and fix them before PR creation.
-func (r *Runner) buildSelfReviewPrompt(task *Task) string {
+func (r *Runner) buildSelfReviewPrompt(ctx context.Context, task *Task) string {
 	var sb strings.Builder
 
 	sb.WriteString("## Self-Review Phase\n\n")
@@ -329,6 +329,19 @@ func (r *Runner) buildSelfReviewPrompt(task *Task) string {
 	sb.WriteString("### 8. Lint Check\n")
 	sb.WriteString("Run `golangci-lint run --new-from-rev=origin/main ./...` and fix any violations.\n")
 	sb.WriteString("Common issue: unchecked return values in test mock handlers (w.Write, json.Encode, SendText).\n\n")
+
+	// GH-1949: Pattern compliance check from learned patterns
+	if r.patternContext != nil {
+		patterns, err := r.patternContext.GetPatternsForTask(ctx, task.ProjectPath, task.Description)
+		if err != nil {
+			slog.Warn("Failed to get patterns for self-review", slog.Any("error", err))
+		} else if patterns != "" {
+			sb.WriteString("### 9. Pattern Compliance Check\n")
+			sb.WriteString("Verify your changes comply with learned patterns from previous executions:\n\n")
+			sb.WriteString(patterns)
+			sb.WriteString("\n")
+		}
+	}
 
 	sb.WriteString("### Actions\n")
 	sb.WriteString("- If you find issues: FIX them and commit the fix\n")

--- a/internal/executor/prompt_builder_test.go
+++ b/internal/executor/prompt_builder_test.go
@@ -1,10 +1,13 @@
 package executor
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/alekspetrov/pilot/internal/memory"
 )
 
 func TestLoadProjectContext(t *testing.T) {
@@ -492,7 +495,7 @@ func TestBuildSelfReviewPromptContainsLintCheck(t *testing.T) {
 		Description: "Test self-review lint section",
 	}
 
-	prompt := runner.buildSelfReviewPrompt(task)
+	prompt := runner.buildSelfReviewPrompt(context.Background(), task)
 
 	// Verify self-review contains lint check section
 	if !strings.Contains(prompt, "### 8. Lint Check") {
@@ -578,5 +581,162 @@ func TestBuildPromptNoNavigator(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "Regular development task") {
 		t.Error("Should contain task description")
+	}
+}
+
+// TestBuildSelfReviewPrompt_PatternCompliance verifies that learned patterns
+// appear in self-review when PatternContext is set (GH-1949).
+func TestBuildSelfReviewPrompt_PatternCompliance(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-test-patterns-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Seed a recommended pattern (use "org" scope so it's found by project query)
+	err = store.SaveCrossPattern(&memory.CrossPattern{
+		ID:          "test-pattern-1",
+		Type:        "code",
+		Title:       "Error Wrapping",
+		Description: "Always wrap errors with context",
+		Context:     "Go error handling",
+		Confidence:  0.9,
+		Scope:       "org",
+	})
+	if err != nil {
+		t.Fatalf("Failed to save pattern: %v", err)
+	}
+
+	// Seed an anti-pattern (use "org" scope so it's found by project query)
+	err = store.SaveCrossPattern(&memory.CrossPattern{
+		ID:            "test-anti-1",
+		Type:          "error",
+		Title:         "[ANTI] Bare returns",
+		Description:   "AVOID: Returning errors without wrapping",
+		Confidence:    0.85,
+		IsAntiPattern: true,
+		Scope:         "org",
+	})
+	if err != nil {
+		t.Fatalf("Failed to save anti-pattern: %v", err)
+	}
+
+	runner := NewRunner()
+	runner.SetPatternContext(NewPatternContext(store))
+
+	task := &Task{
+		ID:          "GH-1949",
+		Title:       "Test pattern compliance",
+		Description: "Fix error handling in executor",
+		ProjectPath: "/tmp/test",
+	}
+
+	prompt := runner.buildSelfReviewPrompt(context.Background(), task)
+
+	// (a) Patterns appear in self-review
+	if !strings.Contains(prompt, "### 9. Pattern Compliance Check") {
+		t.Error("Self-review prompt should contain '### 9. Pattern Compliance Check' section")
+	}
+	if !strings.Contains(prompt, "Recommended Patterns") {
+		t.Error("Self-review prompt should contain recommended patterns")
+	}
+	if !strings.Contains(prompt, "Error Wrapping") {
+		t.Error("Self-review prompt should contain the seeded pattern title")
+	}
+
+	// (b) Anti-patterns appear as AVOID items
+	if !strings.Contains(prompt, "Anti-Patterns to Avoid") {
+		t.Error("Self-review prompt should contain anti-patterns section")
+	}
+	if !strings.Contains(prompt, "Bare returns") {
+		t.Error("Self-review prompt should contain the seeded anti-pattern title")
+	}
+
+	// Verify the section is between check 8 and Actions
+	lintPos := strings.Index(prompt, "### 8. Lint Check")
+	patternPos := strings.Index(prompt, "### 9. Pattern Compliance Check")
+	actionsPos := strings.Index(prompt, "### Actions")
+	if lintPos == -1 || patternPos == -1 || actionsPos == -1 {
+		t.Fatal("Missing expected sections in prompt")
+	}
+	if lintPos >= patternPos || patternPos >= actionsPos {
+		t.Error("Pattern compliance check should be between lint check and actions")
+	}
+}
+
+// TestBuildSelfReviewPrompt_NoPatterns verifies that the pattern compliance
+// section is omitted when no patterns exist (GH-1949).
+func TestBuildSelfReviewPrompt_NoPatterns(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-test-no-patterns-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// No patterns seeded — empty store
+	runner := NewRunner()
+	runner.SetPatternContext(NewPatternContext(store))
+
+	task := &Task{
+		ID:          "GH-1949",
+		Title:       "Test no patterns",
+		Description: "Simple change",
+		ProjectPath: "/tmp/test",
+	}
+
+	prompt := runner.buildSelfReviewPrompt(context.Background(), task)
+
+	// (c) Section is omitted when no patterns exist
+	if strings.Contains(prompt, "Pattern Compliance Check") {
+		t.Error("Self-review prompt should NOT contain pattern compliance section when no patterns exist")
+	}
+
+	// Existing checks still present
+	if !strings.Contains(prompt, "### 8. Lint Check") {
+		t.Error("Self-review prompt should still contain lint check")
+	}
+	if !strings.Contains(prompt, "### Actions") {
+		t.Error("Self-review prompt should still contain actions section")
+	}
+}
+
+// TestBuildSelfReviewPrompt_NilPatternContext verifies graceful degradation
+// when patternContext is nil (GH-1949).
+func TestBuildSelfReviewPrompt_NilPatternContext(t *testing.T) {
+	runner := NewRunner()
+	// patternContext is nil by default
+
+	task := &Task{
+		ID:          "GH-1949",
+		Title:       "Test nil context",
+		Description: "Simple change",
+		ProjectPath: "/tmp/test",
+	}
+
+	prompt := runner.buildSelfReviewPrompt(context.Background(), task)
+
+	// Should not contain pattern section
+	if strings.Contains(prompt, "Pattern Compliance Check") {
+		t.Error("Self-review prompt should NOT contain pattern compliance section when patternContext is nil")
+	}
+
+	// Should still have all standard checks
+	if !strings.Contains(prompt, "Self-Review Phase") {
+		t.Error("Self-review prompt should contain standard header")
+	}
+	if !strings.Contains(prompt, "### Actions") {
+		t.Error("Self-review prompt should contain actions section")
 	}
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2795,7 +2795,7 @@ func (r *Runner) runSelfReview(ctx context.Context, task *Task, state *progressS
 	r.log.Info("Running self-review phase", slog.String("task_id", task.ID))
 	r.reportProgress(task.ID, "Self-Review", 95, "Reviewing changes...")
 
-	reviewPrompt := r.buildSelfReviewPrompt(task)
+	reviewPrompt := r.buildSelfReviewPrompt(ctx, task)
 
 	// Execute self-review with shorter timeout (2 minutes)
 	reviewCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -1968,7 +1969,7 @@ func TestBuildSelfReviewPrompt(t *testing.T) {
 		ProjectPath: "/tmp/test",
 	}
 
-	prompt := runner.buildSelfReviewPrompt(task)
+	prompt := runner.buildSelfReviewPrompt(context.Background(), task)
 
 	// Verify key elements
 	if !strings.Contains(prompt, "Self-Review Phase") {
@@ -2633,7 +2634,7 @@ func TestBuildSelfReviewPrompt_ConstantValueSanity(t *testing.T) {
 		ProjectPath: "/tmp/test",
 	}
 
-	prompt := runner.buildSelfReviewPrompt(task)
+	prompt := runner.buildSelfReviewPrompt(context.Background(), task)
 
 	if !strings.Contains(prompt, "Constant Value Sanity Check") {
 		t.Error("Self-review prompt should contain 'Constant Value Sanity Check'")
@@ -2654,7 +2655,7 @@ func TestBuildSelfReviewPrompt_CrossFileParity(t *testing.T) {
 		ProjectPath: "/tmp/test",
 	}
 
-	prompt := runner.buildSelfReviewPrompt(task)
+	prompt := runner.buildSelfReviewPrompt(context.Background(), task)
 
 	if !strings.Contains(prompt, "Cross-File Parity Check") {
 		t.Error("Self-review prompt should contain 'Cross-File Parity Check'")


### PR DESCRIPTION
## Summary

- Add 9th check section to `buildSelfReviewPrompt()` that pulls learned patterns and anti-patterns from `patternContext`
- Recommended patterns appear as compliance checks, anti-patterns appear in an "Anti-Patterns to Avoid" block
- Section gracefully omitted when `patternContext` is nil or no patterns exist
- Fix staticcheck QF1001 lint issue (De Morgan's law) from original PR #1950

Closes #1941
Closes #1952

## Test plan

- [x] `golangci-lint run ./internal/executor/...` passes (0 issues)
- [x] `go build ./...` passes
- [x] `go test ./internal/executor/...` passes