### PR TITLE
fix(memory): replace loop with append for staticcheck S1011 (GH-1960)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -912,6 +912,7 @@ Examples:
 
 					gwRunner.SetLearningLoop(gwLearningLoop)
 					gwRunner.SetPatternContext(gwPatternContext)
+					gwRunner.SetSelfReviewExtractor(gwExtractor)
 
 					if gwAutopilotController != nil {
 						gwAutopilotController.SetLearningLoop(gwLearningLoop)
@@ -1334,6 +1335,7 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 
 			runner.SetLearningLoop(learningLoop)
 			runner.SetPatternContext(patternContext)
+			runner.SetSelfReviewExtractor(extractor)
 
 			// GH-1823: Wire review learning into autopilot controllers
 			for _, ctrl := range autopilotControllers {

--- a/internal/executor/learning.go
+++ b/internal/executor/learning.go
@@ -12,3 +12,11 @@ import (
 type LearningRecorder interface {
 	RecordExecution(ctx context.Context, exec *memory.Execution, appliedPatterns []string) error
 }
+
+// SelfReviewExtractor extracts and persists patterns from self-review output.
+// This interface is satisfied by memory.PatternExtractor and allows the executor
+// to extract patterns without tight coupling to the memory package implementation.
+type SelfReviewExtractor interface {
+	ExtractFromSelfReview(ctx context.Context, selfReviewOutput string, projectPath string) (*memory.ExtractionResult, error)
+	SaveExtractedPatterns(ctx context.Context, result *memory.ExtractionResult) error
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -314,8 +314,9 @@ type Runner struct {
 	// GH-1599: Execution log store for milestone entries
 	logStore              *memory.Store // Optional log store for writing execution milestones
 	// GH-1811: Learning system (self-improvement)
-	learningLoop   LearningRecorder     // Optional learning loop for pattern extraction + feedback
-	patternContext *PatternContext       // Optional pattern context for prompt injection
+	learningLoop         LearningRecorder     // Optional learning loop for pattern extraction + feedback
+	patternContext       *PatternContext       // Optional pattern context for prompt injection
+	selfReviewExtractor  SelfReviewExtractor   // Optional extractor for self-review pattern learning (GH-1955)
 }
 
 // NewRunner creates a new Runner instance with Claude Code backend by default.
@@ -647,6 +648,11 @@ func (r *Runner) HasLearningLoop() bool { return r.learningLoop != nil }
 
 // HasPatternContext reports whether a pattern context is wired.
 func (r *Runner) HasPatternContext() bool { return r.patternContext != nil }
+
+// SetSelfReviewExtractor sets the extractor for self-review pattern learning (GH-1955).
+func (r *Runner) SetSelfReviewExtractor(e SelfReviewExtractor) {
+	r.selfReviewExtractor = e
+}
 
 // HasTokenLimitCheck reports whether a token limit check callback is wired.
 func (r *Runner) HasTokenLimitCheck() bool { return r.tokenLimitCheck != nil }
@@ -2859,6 +2865,30 @@ func (r *Runner) runSelfReview(ctx context.Context, task *Task, state *progressS
 		r.log.Debug("Self-review completed (no explicit signal)",
 			slog.String("task_id", task.ID),
 		)
+	}
+
+	// GH-1955: Extract patterns from self-review output (non-blocking)
+	if r.selfReviewExtractor != nil && result.Output != "" {
+		extractResult, extractErr := r.selfReviewExtractor.ExtractFromSelfReview(ctx, result.Output, task.ProjectPath)
+		if extractErr != nil {
+			r.log.Warn("Failed to extract patterns from self-review",
+				slog.String("task_id", task.ID),
+				slog.Any("error", extractErr),
+			)
+		} else if len(extractResult.Patterns)+len(extractResult.AntiPatterns) > 0 {
+			if saveErr := r.selfReviewExtractor.SaveExtractedPatterns(ctx, extractResult); saveErr != nil {
+				r.log.Warn("Failed to save self-review patterns",
+					slog.String("task_id", task.ID),
+					slog.Any("error", saveErr),
+				)
+			} else {
+				r.log.Info("Saved patterns from self-review",
+					slog.String("task_id", task.ID),
+					slog.Int("patterns", len(extractResult.Patterns)),
+					slog.Int("anti_patterns", len(extractResult.AntiPatterns)),
+				)
+			}
+		}
 	}
 
 	return nil

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -1,11 +1,13 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2769,5 +2771,205 @@ func TestRunner_saveLogEntry_ErrorLevel(t *testing.T) {
 	}
 	if logs[0].Message != "Task failed: compilation error" {
 		t.Errorf("message = %q, want %q", logs[0].Message, "Task failed: compilation error")
+	}
+}
+
+// --- GH-1955: Self-review pattern extraction ---
+
+// mockSelfReviewBackend implements Backend for self-review tests.
+type mockSelfReviewBackend struct {
+	output string
+}
+
+func (m *mockSelfReviewBackend) Name() string        { return "mock" }
+func (m *mockSelfReviewBackend) IsAvailable() bool    { return true }
+func (m *mockSelfReviewBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+	return &BackendResult{Success: true, Output: m.output}, nil
+}
+
+// mockSelfReviewExtractor implements SelfReviewExtractor for testing.
+type mockSelfReviewExtractor struct {
+	mu             sync.Mutex
+	extractCalls   int
+	saveCalls      int
+	lastResult     *memory.ExtractionResult
+	extractFunc    func(ctx context.Context, output string, projectPath string) (*memory.ExtractionResult, error)
+}
+
+func (m *mockSelfReviewExtractor) ExtractFromSelfReview(ctx context.Context, output string, projectPath string) (*memory.ExtractionResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.extractCalls++
+	if m.extractFunc != nil {
+		return m.extractFunc(ctx, output, projectPath)
+	}
+	return &memory.ExtractionResult{}, nil
+}
+
+func (m *mockSelfReviewExtractor) SaveExtractedPatterns(ctx context.Context, result *memory.ExtractionResult) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.saveCalls++
+	m.lastResult = result
+	return nil
+}
+
+func TestRunSelfReview_ExtractsPatterns(t *testing.T) {
+	backend := &mockSelfReviewBackend{
+		output: "REVIEW_FIXED: found unwired config field\nSUSPICIOUS_VALUE: hardcoded 999",
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+
+	extractor := &mockSelfReviewExtractor{
+		extractFunc: func(_ context.Context, output string, projectPath string) (*memory.ExtractionResult, error) {
+			// Delegate to real PatternExtractor logic via simple simulation
+			result := &memory.ExtractionResult{
+				ExecutionID: "test",
+				ProjectPath: projectPath,
+			}
+			if strings.Contains(output, "REVIEW_FIXED") {
+				result.AntiPatterns = append(result.AntiPatterns, &memory.ExtractedPattern{
+					Type:        "review_fix",
+					Title:       "Self-review fix",
+					Description: "Self-review found and fixed issues",
+					Confidence:  0.5,
+				})
+			}
+			if strings.Contains(output, "SUSPICIOUS_VALUE") {
+				result.AntiPatterns = append(result.AntiPatterns, &memory.ExtractedPattern{
+					Type:        "suspicious_value",
+					Title:       "Suspicious hardcoded value",
+					Description: "Hardcoded constant needs verification",
+					Confidence:  0.5,
+				})
+			}
+			return result, nil
+		},
+	}
+	runner.SetSelfReviewExtractor(extractor)
+
+	task := &Task{
+		ID:          "SR-001",
+		Title:       "Add user authentication with JWT tokens and session management",
+		Description: "Implement full auth flow with JWT tokens, refresh tokens, and session management",
+		ProjectPath: t.TempDir(),
+	}
+	state := &progressState{}
+
+	err := runner.runSelfReview(context.Background(), task, state)
+	if err != nil {
+		t.Fatalf("runSelfReview returned error: %v", err)
+	}
+
+	extractor.mu.Lock()
+	defer extractor.mu.Unlock()
+
+	if extractor.extractCalls != 1 {
+		t.Errorf("expected 1 extract call, got %d", extractor.extractCalls)
+	}
+	if extractor.saveCalls != 1 {
+		t.Errorf("expected 1 save call, got %d", extractor.saveCalls)
+	}
+	if extractor.lastResult == nil {
+		t.Fatal("expected lastResult to be set")
+	}
+	if len(extractor.lastResult.AntiPatterns) != 2 {
+		t.Errorf("expected 2 anti-patterns, got %d", len(extractor.lastResult.AntiPatterns))
+	}
+}
+
+func TestRunSelfReview_SkipsExtractionWhenNoExtractor(t *testing.T) {
+	backend := &mockSelfReviewBackend{
+		output: "REVIEW_FIXED: found issue",
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+
+	// No extractor set — should not panic
+	task := &Task{
+		ID:          "SR-002",
+		Title:       "Add complex feature with multiple components",
+		Description: "Implement a complex multi-step feature requiring significant changes",
+		ProjectPath: t.TempDir(),
+	}
+	state := &progressState{}
+
+	err := runner.runSelfReview(context.Background(), task, state)
+	if err != nil {
+		t.Fatalf("runSelfReview returned error: %v", err)
+	}
+}
+
+func TestRunSelfReview_SkipsExtractionWhenEmptyOutput(t *testing.T) {
+	backend := &mockSelfReviewBackend{
+		output: "", // empty output
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+
+	extractor := &mockSelfReviewExtractor{}
+	runner.SetSelfReviewExtractor(extractor)
+
+	task := &Task{
+		ID:          "SR-003",
+		Title:       "Add complex feature with multiple components",
+		Description: "Implement a complex multi-step feature requiring significant changes",
+		ProjectPath: t.TempDir(),
+	}
+	state := &progressState{}
+
+	err := runner.runSelfReview(context.Background(), task, state)
+	if err != nil {
+		t.Fatalf("runSelfReview returned error: %v", err)
+	}
+
+	extractor.mu.Lock()
+	defer extractor.mu.Unlock()
+
+	if extractor.extractCalls != 0 {
+		t.Errorf("expected 0 extract calls for empty output, got %d", extractor.extractCalls)
+	}
+}
+
+func TestRunSelfReview_SkipsSaveWhenNoPatternsExtracted(t *testing.T) {
+	backend := &mockSelfReviewBackend{
+		output: "REVIEW_PASSED",
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+
+	extractor := &mockSelfReviewExtractor{
+		extractFunc: func(_ context.Context, _ string, _ string) (*memory.ExtractionResult, error) {
+			// No patterns found
+			return &memory.ExtractionResult{
+				Patterns:     make([]*memory.ExtractedPattern, 0),
+				AntiPatterns: make([]*memory.ExtractedPattern, 0),
+			}, nil
+		},
+	}
+	runner.SetSelfReviewExtractor(extractor)
+
+	task := &Task{
+		ID:          "SR-004",
+		Title:       "Add complex feature with multiple components",
+		Description: "Implement a complex multi-step feature requiring significant changes",
+		ProjectPath: t.TempDir(),
+	}
+	state := &progressState{}
+
+	err := runner.runSelfReview(context.Background(), task, state)
+	if err != nil {
+		t.Fatalf("runSelfReview returned error: %v", err)
+	}
+
+	extractor.mu.Lock()
+	defer extractor.mu.Unlock()
+
+	if extractor.extractCalls != 1 {
+		t.Errorf("expected 1 extract call, got %d", extractor.extractCalls)
+	}
+	if extractor.saveCalls != 0 {
+		t.Errorf("expected 0 save calls when no patterns extracted, got %d", extractor.saveCalls)
 	}
 }

--- a/internal/memory/extractor.go
+++ b/internal/memory/extractor.go
@@ -354,6 +354,120 @@ func (e *PatternExtractor) extractWorkflowPatterns(output string) []*ExtractedPa
 	return patterns
 }
 
+// selfReviewFinding defines a mapping from self-review markers to pattern types
+type selfReviewFinding struct {
+	regex   *regexp.Regexp
+	pType   PatternType
+	title   string
+	desc    string
+	context string
+}
+
+// selfReviewFindings are the matchers for self-review output markers
+var selfReviewFindings = []selfReviewFinding{
+	{
+		regex:   regexp.MustCompile(`(?i)(?:missing|no|lack(?:ing)?)\s+error\s+handl`),
+		pType:   PatternTypeError,
+		title:   "Missing error handling",
+		desc:    "Errors must be checked and propagated, not silently ignored",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)(?:unused\s+import|dead\s+code|unreachable\s+code)`),
+		pType:   PatternTypeCode,
+		title:   "Dead code detected",
+		desc:    "Remove unused imports, unreachable code, and dead code paths",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)(?:config\s+field\s+not\s+wired|struct\s+field\s+unused|field\s+.*not\s+(?:used|wired|connected))`),
+		pType:   PatternTypeStructure,
+		title:   "Unwired config or struct field",
+		desc:    "All config and struct fields must be wired through to their consumers",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)(?:test\s+coverage\s+gap|missing\s+test|no\s+test|lint\s+violation|linter\s+error)`),
+		pType:   PatternTypeWorkflow,
+		title:   "Test or lint gap",
+		desc:    "All new code paths must have test coverage; lint violations must be resolved",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)(?:build\s+(?:fail|verification\s+fail)|compilation?\s+(?:error|fail))`),
+		pType:   PatternTypeError,
+		title:   "Build verification failure",
+		desc:    "Code must compile and pass build verification before submission",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)(?:cross.file\s+parity|PARITY_GAP|parity\s+(?:issue|mismatch))`),
+		pType:   PatternTypeStructure,
+		title:   "Cross-file parity issue",
+		desc:    "Related changes across files must stay in sync (interfaces, implementations, tests)",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)REVIEW_FIXED:`),
+		pType:   PatternTypeCode,
+		title:   "Self-review fix applied",
+		desc:    "Issue caught and fixed during self-review pass",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)SUSPICIOUS_VALUE`),
+		pType:   PatternTypeCode,
+		title:   "Suspicious value detected",
+		desc:    "Hardcoded or suspicious values should be verified against requirements",
+		context: "Self-review",
+	},
+	{
+		regex:   regexp.MustCompile(`(?i)INCOMPLETE`),
+		pType:   PatternTypeWorkflow,
+		title:   "Incomplete implementation",
+		desc:    "Implementation is missing required functionality or TODO items remain",
+		context: "Self-review",
+	},
+}
+
+// ExtractFromSelfReview extracts patterns from self-review output by parsing
+// finding markers (REVIEW_FIXED:, SUSPICIOUS_VALUE, PARITY_GAP, INCOMPLETE, etc.)
+// and mapping them to pattern types. Patterns are stored as anti-patterns with
+// confidence 0.5 (boosted on recurrence via existing SaveCrossPattern upsert logic).
+func (e *PatternExtractor) ExtractFromSelfReview(ctx context.Context, selfReviewOutput string, projectPath string) (*ExtractionResult, error) {
+	result := &ExtractionResult{
+		ExecutionID:  fmt.Sprintf("self_review_%d", time.Now().UnixNano()),
+		ProjectPath:  projectPath,
+		Patterns:     make([]*ExtractedPattern, 0),
+		AntiPatterns: make([]*ExtractedPattern, 0),
+		ExtractedAt:  time.Now(),
+	}
+
+	if strings.TrimSpace(selfReviewOutput) == "" {
+		return result, nil
+	}
+
+	for _, finding := range selfReviewFindings {
+		matches := finding.regex.FindAllString(selfReviewOutput, -1)
+		if len(matches) == 0 {
+			continue
+		}
+
+		examples := append([]string{}, matches...)
+
+		result.AntiPatterns = append(result.AntiPatterns, &ExtractedPattern{
+			Type:        finding.pType,
+			Title:       finding.title,
+			Description: finding.desc,
+			Examples:    examples,
+			Confidence:  0.5,
+			Context:     finding.context,
+		})
+	}
+
+	return result, nil
+}
+
 // SaveExtractedPatterns saves extracted patterns to the store
 func (e *PatternExtractor) SaveExtractedPatterns(ctx context.Context, result *ExtractionResult) error {
 	for _, p := range result.Patterns {

--- a/internal/memory/extractor_test.go
+++ b/internal/memory/extractor_test.go
@@ -594,6 +594,168 @@ func TestMergePattern_AddsNewProjects(t *testing.T) {
 	}
 }
 
+func TestExtractFromSelfReview(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "extractor-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+	ctx := context.Background()
+
+	tests := []struct {
+		name              string
+		selfReviewOutput  string
+		wantAntiPatterns  int
+		wantPatternTypes  []PatternType // expected types in anti-patterns (order-independent)
+	}{
+		{
+			name: "multiple finding types",
+			selfReviewOutput: `REVIEW_FIXED: corrected nil check in handler.go
+Found missing error handling in database query at store.go:42
+PARITY_GAP: interface method added but not implemented in mock
+test coverage gap for new validateInput function
+SUSPICIOUS_VALUE detected in pricing constant`,
+			wantAntiPatterns: 5,
+			wantPatternTypes: []PatternType{
+				PatternTypeCode,      // REVIEW_FIXED
+				PatternTypeError,     // missing error handling
+				PatternTypeStructure, // PARITY_GAP
+				PatternTypeWorkflow,  // test coverage gap
+				PatternTypeCode,      // SUSPICIOUS_VALUE
+			},
+		},
+		{
+			name:             "empty output",
+			selfReviewOutput: "",
+			wantAntiPatterns: 0,
+			wantPatternTypes: nil,
+		},
+		{
+			name:             "whitespace only output",
+			selfReviewOutput: "   \n\t  \n  ",
+			wantAntiPatterns: 0,
+			wantPatternTypes: nil,
+		},
+		{
+			name:             "unparseable output with no markers",
+			selfReviewOutput: "All checks passed. Code looks clean. No issues found.",
+			wantAntiPatterns: 0,
+			wantPatternTypes: nil,
+		},
+		{
+			name: "mixed findings with clean output",
+			selfReviewOutput: `Self-review complete.
+Files checked: 5
+REVIEW_FIXED: corrected nil check in handler
+Everything else looks good.
+INCOMPLETE: TODO items remain in auth module`,
+			wantAntiPatterns: 2,
+			wantPatternTypes: []PatternType{
+				PatternTypeCode,     // REVIEW_FIXED
+				PatternTypeWorkflow, // INCOMPLETE
+			},
+		},
+		{
+			name:             "build failure only",
+			selfReviewOutput: "build verification failure: missing return statement in Calculate()",
+			wantAntiPatterns: 1,
+			wantPatternTypes: []PatternType{PatternTypeError},
+		},
+		{
+			name:             "dead code detection",
+			selfReviewOutput: "Found unused import: fmt in utils.go\nFound dead code in legacy handler",
+			wantAntiPatterns: 1, // single regex matches both
+			wantPatternTypes: []PatternType{PatternTypeCode},
+		},
+		{
+			name:             "struct field unwired",
+			selfReviewOutput: "config field not wired: MaxRetries defined in Config but never read",
+			wantAntiPatterns: 1,
+			wantPatternTypes: []PatternType{PatternTypeStructure},
+		},
+		{
+			name:             "lint violations",
+			selfReviewOutput: "lint violation: exported function missing doc comment\nlinter error on line 55",
+			wantAntiPatterns: 1,
+			wantPatternTypes: []PatternType{PatternTypeWorkflow},
+		},
+		{
+			name: "cross-file parity",
+			selfReviewOutput: `cross-file parity issue: AddUser added to service.go but not to service_test.go
+parity mismatch between interface and implementation`,
+			wantAntiPatterns: 1, // single regex matches both variants
+			wantPatternTypes: []PatternType{PatternTypeStructure},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := extractor.ExtractFromSelfReview(ctx, tt.selfReviewOutput, "/test/project")
+			if err != nil {
+				t.Fatalf("ExtractFromSelfReview() error = %v", err)
+			}
+
+			if result == nil {
+				t.Fatal("ExtractFromSelfReview() returned nil result")
+			}
+
+			if len(result.AntiPatterns) != tt.wantAntiPatterns {
+				types := make([]PatternType, len(result.AntiPatterns))
+				for i, ap := range result.AntiPatterns {
+					types[i] = ap.Type
+				}
+				t.Errorf("got %d anti-patterns %v, want %d", len(result.AntiPatterns), types, tt.wantAntiPatterns)
+				return
+			}
+
+			// Verify pattern types match (order-independent)
+			if tt.wantPatternTypes != nil {
+				gotTypes := make(map[PatternType]int)
+				for _, ap := range result.AntiPatterns {
+					gotTypes[ap.Type]++
+				}
+
+				wantTypes := make(map[PatternType]int)
+				for _, pt := range tt.wantPatternTypes {
+					wantTypes[pt]++
+				}
+
+				for pt, count := range wantTypes {
+					if gotTypes[pt] != count {
+						t.Errorf("pattern type %s: got %d, want %d", pt, gotTypes[pt], count)
+					}
+				}
+			}
+
+			// Verify all anti-patterns have confidence 0.5
+			for _, ap := range result.AntiPatterns {
+				if ap.Confidence != 0.5 {
+					t.Errorf("anti-pattern %q has confidence %f, want 0.5", ap.Title, ap.Confidence)
+				}
+				if ap.Context != "Self-review" {
+					t.Errorf("anti-pattern %q has context %q, want 'Self-review'", ap.Title, ap.Context)
+				}
+			}
+
+			// Verify project path is set
+			if result.ProjectPath != "/test/project" {
+				t.Errorf("ProjectPath = %q, want %q", result.ProjectPath, "/test/project")
+			}
+
+			// Verify no positive patterns (self-review findings are all anti-patterns)
+			if len(result.Patterns) != 0 {
+				t.Errorf("got %d positive patterns, want 0", len(result.Patterns))
+			}
+		})
+	}
+}
+
 func TestExtractFromReviewComments_TestingFeedback(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "extractor-test-*")
 	if err != nil {


### PR DESCRIPTION
## Summary

- Reapplies PR #1959 changes (self-review pattern extraction from GH-1955)
- Fixes lint failure: replaced manual loop with `append([]string{}, matches...)` to satisfy `staticcheck S1011`

## Changes

- `internal/memory/extractor.go`: Added `ExtractFromSelfReview()` method with regex-based finding extraction; fixed S1011 lint
- `internal/memory/extractor_test.go`: Tests for self-review extraction (multiple findings, empty output, persistence)
- `internal/executor/runner.go`: Added `selfReviewExtractor` field + `SetSelfReviewExtractor()` + extraction call in `runSelfReview()`
- `internal/executor/runner_test.go`: Tests for extraction integration (patterns found, no extractor, empty output, no patterns)
- `internal/executor/learning.go`: Added `SelfReviewExtractor` interface
- `cmd/pilot/main.go`: Wired extractor in both gateway and polling modes

## Test plan

- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...` — passes
- [x] `go test ./internal/memory/... ./internal/executor/...` — passes

Closes #1960
Closes #1955