### PR TITLE
Add CI-specific error matchers to PatternExtractor

### DIFF
--- a/internal/memory/extractor.go
+++ b/internal/memory/extractor.go
@@ -292,6 +292,73 @@ func (e *PatternExtractor) extractErrorPatterns(errorOutput string) []*Extracted
 			desc:    "Restructure packages to avoid import cycles",
 			context: "Go package structure",
 		},
+		// CI compilation errors
+		{
+			regex:   regexp.MustCompile(`(?i)undefined:\s*\w+`),
+			pType:   PatternTypeError,
+			title:   "Undefined identifier",
+			desc:    "Ensure all identifiers are declared or imported before use",
+			context: "Go compilation",
+		},
+		{
+			regex:   regexp.MustCompile(`(?i)\w+\s+declared\s+(?:and\s+)?not\s+used`),
+			pType:   PatternTypeError,
+			title:   "Unused variable or import",
+			desc:    "Remove unused variables and imports to pass compilation",
+			context: "Go compilation",
+		},
+		{
+			regex:   regexp.MustCompile(`(?i)cannot\s+use\s+.*\s+as\s+.*\s+in`),
+			pType:   PatternTypeError,
+			title:   "Type mismatch",
+			desc:    "Ensure type compatibility in assignments and function calls",
+			context: "Go compilation",
+		},
+		// CI test failures
+		{
+			regex:   regexp.MustCompile(`(?m)^---\s+FAIL:\s+\w+`),
+			pType:   PatternTypeError,
+			title:   "Test failure",
+			desc:    "One or more tests failed during CI; investigate and fix failing assertions",
+			context: "Go test",
+		},
+		{
+			regex:   regexp.MustCompile(`(?i)panic:\s+test\s+timed\s+out|test\s+.*\s+timed?\s*out`),
+			pType:   PatternTypeError,
+			title:   "Test timeout",
+			desc:    "Test exceeded its deadline; check for blocking operations or infinite loops",
+			context: "Go test",
+		},
+		{
+			regex:   regexp.MustCompile(`(?i)panic:\s+runtime\s+error`),
+			pType:   PatternTypeError,
+			title:   "Runtime panic in test",
+			desc:    "A test triggered a runtime panic; add nil checks and bounds validation",
+			context: "Go test",
+		},
+		// CI lint errors
+		{
+			regex:   regexp.MustCompile(`(?i)(?:golangci-lint|staticcheck|errcheck|govet|gosimple)\s*[:\[]`),
+			pType:   PatternTypeWorkflow,
+			title:   "Lint violation",
+			desc:    "Code does not pass linter checks; fix reported issues before merging",
+			context: "Go lint",
+		},
+		// CI build/module errors
+		{
+			regex:   regexp.MustCompile(`(?i)missing\s+go\.sum\s+entry|missing\s+module`),
+			pType:   PatternTypeError,
+			title:   "Missing module",
+			desc:    "Run 'go mod tidy' to resolve missing module or go.sum entries",
+			context: "Go modules",
+		},
+		{
+			regex:   regexp.MustCompile(`(?i)require\s+.*:\s+version\s+"[^"]*"\s+invalid|go\.mod\s+.*\s+version\s+mismatch`),
+			pType:   PatternTypeError,
+			title:   "Module version conflict",
+			desc:    "Resolve version conflicts in go.mod; ensure compatible dependency versions",
+			context: "Go modules",
+		},
 	}
 
 	for _, matcher := range errorMatchers {
@@ -308,6 +375,21 @@ func (e *PatternExtractor) extractErrorPatterns(errorOutput string) []*Extracted
 	}
 
 	return patterns
+}
+
+// extractCIErrorPatterns extracts error patterns from CI logs with CI-appropriate
+// confidence (0.5 initial) and source:ci context tagging.
+func (e *PatternExtractor) extractCIErrorPatterns(ciLogs string) []*ExtractedPattern {
+	// Reuse the same matchers from extractErrorPatterns
+	rawPatterns := e.extractErrorPatterns(ciLogs)
+
+	// Adjust for CI context: lower initial confidence, add source:ci tag
+	for _, p := range rawPatterns {
+		p.Confidence = 0.5
+		p.Context = "source:ci " + p.Context
+	}
+
+	return rawPatterns
 }
 
 // extractWorkflowPatterns extracts workflow-related patterns

--- a/internal/memory/extractor_test.go
+++ b/internal/memory/extractor_test.go
@@ -756,6 +756,306 @@ parity mismatch between interface and implementation`,
 	}
 }
 
+func TestExtractErrorPatterns_CICompilationErrors(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "extractor-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+	ctx := context.Background()
+
+	tests := []struct {
+		name             string
+		errorOutput      string
+		wantAntiPatterns int
+		wantTitle        string
+	}{
+		{
+			name:             "undefined identifier",
+			errorOutput:      "./main.go:15:2: undefined: myFunc",
+			wantAntiPatterns: 1,
+			wantTitle:        "Undefined identifier",
+		},
+		{
+			name:             "unused variable",
+			errorOutput:      "./handler.go:10:2: x declared and not used",
+			wantAntiPatterns: 1,
+			wantTitle:        "Unused variable or import",
+		},
+		{
+			name:             "type mismatch",
+			errorOutput:      "cannot use val (variable of type string) as int in argument to process",
+			wantAntiPatterns: 1,
+			wantTitle:        "Type mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &Execution{
+				ID:          "test-ci-compile",
+				ProjectPath: "/test/project",
+				Status:      "completed",
+				Output:      "output",
+				Error:       tt.errorOutput,
+			}
+
+			result, err := extractor.ExtractFromExecution(ctx, exec)
+			if err != nil {
+				t.Fatalf("ExtractFromExecution failed: %v", err)
+			}
+
+			if len(result.AntiPatterns) < tt.wantAntiPatterns {
+				t.Errorf("got %d anti-patterns, want at least %d", len(result.AntiPatterns), tt.wantAntiPatterns)
+			}
+
+			found := false
+			for _, ap := range result.AntiPatterns {
+				if ap.Title == tt.wantTitle {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected anti-pattern with title %q not found", tt.wantTitle)
+			}
+		})
+	}
+}
+
+func TestExtractErrorPatterns_CITestFailures(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "extractor-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+	ctx := context.Background()
+
+	tests := []struct {
+		name             string
+		errorOutput      string
+		wantAntiPatterns int
+		wantTitle        string
+	}{
+		{
+			name:             "test FAIL line",
+			errorOutput:      "--- FAIL: TestHandler (0.01s)\n    handler_test.go:42: expected 200, got 500",
+			wantAntiPatterns: 1,
+			wantTitle:        "Test failure",
+		},
+		{
+			name:             "test timeout panic",
+			errorOutput:      "panic: test timed out after 30s",
+			wantAntiPatterns: 1,
+			wantTitle:        "Test timeout",
+		},
+		{
+			name:             "runtime panic in test",
+			errorOutput:      "panic: runtime error: index out of range [5] with length 3",
+			wantAntiPatterns: 1,
+			wantTitle:        "Runtime panic in test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &Execution{
+				ID:          "test-ci-test",
+				ProjectPath: "/test/project",
+				Status:      "completed",
+				Output:      "output",
+				Error:       tt.errorOutput,
+			}
+
+			result, err := extractor.ExtractFromExecution(ctx, exec)
+			if err != nil {
+				t.Fatalf("ExtractFromExecution failed: %v", err)
+			}
+
+			if len(result.AntiPatterns) < tt.wantAntiPatterns {
+				t.Errorf("got %d anti-patterns, want at least %d", len(result.AntiPatterns), tt.wantAntiPatterns)
+			}
+
+			found := false
+			for _, ap := range result.AntiPatterns {
+				if ap.Title == tt.wantTitle {
+					found = true
+					break
+				}
+			}
+			if !found {
+				titles := make([]string, len(result.AntiPatterns))
+				for i, ap := range result.AntiPatterns {
+					titles[i] = ap.Title
+				}
+				t.Errorf("expected anti-pattern %q not found, got: %v", tt.wantTitle, titles)
+			}
+		})
+	}
+}
+
+func TestExtractErrorPatterns_CILintAndBuildErrors(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "extractor-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+	ctx := context.Background()
+
+	tests := []struct {
+		name             string
+		errorOutput      string
+		wantAntiPatterns int
+		wantTitle        string
+	}{
+		{
+			name:             "golangci-lint error",
+			errorOutput:      "golangci-lint: error at handler.go:55 (errcheck)",
+			wantAntiPatterns: 1,
+			wantTitle:        "Lint violation",
+		},
+		{
+			name:             "staticcheck error",
+			errorOutput:      "staticcheck: SA1019 deprecated function used",
+			wantAntiPatterns: 1,
+			wantTitle:        "Lint violation",
+		},
+		{
+			name:             "missing module",
+			errorOutput:      "missing go.sum entry for module providing package github.com/foo/bar",
+			wantAntiPatterns: 1,
+			wantTitle:        "Missing module",
+		},
+		{
+			name:             "version conflict",
+			errorOutput:      `require github.com/foo/bar: version "v1.2.3" invalid`,
+			wantAntiPatterns: 1,
+			wantTitle:        "Module version conflict",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &Execution{
+				ID:          "test-ci-lint",
+				ProjectPath: "/test/project",
+				Status:      "completed",
+				Output:      "output",
+				Error:       tt.errorOutput,
+			}
+
+			result, err := extractor.ExtractFromExecution(ctx, exec)
+			if err != nil {
+				t.Fatalf("ExtractFromExecution failed: %v", err)
+			}
+
+			if len(result.AntiPatterns) < tt.wantAntiPatterns {
+				t.Errorf("got %d anti-patterns, want at least %d", len(result.AntiPatterns), tt.wantAntiPatterns)
+			}
+
+			found := false
+			for _, ap := range result.AntiPatterns {
+				if ap.Title == tt.wantTitle {
+					found = true
+					break
+				}
+			}
+			if !found {
+				titles := make([]string, len(result.AntiPatterns))
+				for i, ap := range result.AntiPatterns {
+					titles[i] = ap.Title
+				}
+				t.Errorf("expected anti-pattern %q not found, got: %v", tt.wantTitle, titles)
+			}
+		})
+	}
+}
+
+func TestExtractCIErrorPatterns(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "extractor-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+
+	tests := []struct {
+		name           string
+		ciLogs         string
+		wantPatterns   int
+		wantConfidence float64
+		wantCIContext  bool
+	}{
+		{
+			name:           "compilation error with CI confidence",
+			ciLogs:         "undefined: processItem",
+			wantPatterns:   1,
+			wantConfidence: 0.5,
+			wantCIContext:  true,
+		},
+		{
+			name:           "test failure with CI context",
+			ciLogs:         "--- FAIL: TestProcess (0.05s)\npanic: runtime error: nil pointer dereference",
+			wantPatterns:   3, // FAIL line + nil pointer dereference + runtime panic
+			wantConfidence: 0.5,
+			wantCIContext:  true,
+		},
+		{
+			name:         "no matching patterns",
+			ciLogs:       "Build succeeded. All tests passed.",
+			wantPatterns: 0,
+		},
+		{
+			name:         "empty logs",
+			ciLogs:       "",
+			wantPatterns: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patterns := extractor.extractCIErrorPatterns(tt.ciLogs)
+
+			if len(patterns) != tt.wantPatterns {
+				t.Errorf("got %d patterns, want %d", len(patterns), tt.wantPatterns)
+				return
+			}
+
+			for _, p := range patterns {
+				if p.Confidence != tt.wantConfidence {
+					t.Errorf("pattern %q confidence = %f, want %f", p.Title, p.Confidence, tt.wantConfidence)
+				}
+				if tt.wantCIContext && !strings.HasPrefix(p.Context, "source:ci") {
+					t.Errorf("pattern %q context = %q, want source:ci prefix", p.Title, p.Context)
+				}
+			}
+		})
+	}
+}
+
 func TestExtractFromReviewComments_TestingFeedback(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "extractor-test-*")
 	if err != nil {

--- a/internal/memory/feedback.go
+++ b/internal/memory/feedback.go
@@ -352,6 +352,43 @@ func (l *LearningLoop) LearnFromReview(ctx context.Context, projectPath string,
 	return nil
 }
 
+// LearnFromCIFailure extracts patterns from CI failure logs and saves them.
+// It builds a synthetic extraction result from the CI logs, tags patterns with
+// CI check names, and persists them via the extractor's SaveExtractedPatterns.
+func (l *LearningLoop) LearnFromCIFailure(ctx context.Context, projectPath string, ciLogs string, checkNames []string) error {
+	if l.extractor == nil {
+		return fmt.Errorf("pattern extractor is required for CI failure learning")
+	}
+
+	if strings.TrimSpace(ciLogs) == "" {
+		return nil
+	}
+
+	// Extract CI-specific patterns (confidence 0.5, source:ci tagged)
+	ciPatterns := l.extractor.extractCIErrorPatterns(ciLogs)
+	if len(ciPatterns) == 0 {
+		return nil
+	}
+
+	// Tag patterns with CI check names
+	checkContext := strings.Join(checkNames, ", ")
+	for _, p := range ciPatterns {
+		if len(checkNames) > 0 {
+			p.Context = p.Context + " checks:" + checkContext
+		}
+	}
+
+	result := &ExtractionResult{
+		ExecutionID:  fmt.Sprintf("ci_failure_%d", time.Now().UnixNano()),
+		ProjectPath:  projectPath,
+		Patterns:     make([]*ExtractedPattern, 0),
+		AntiPatterns: ciPatterns,
+		ExtractedAt:  time.Now(),
+	}
+
+	return l.extractor.SaveExtractedPatterns(ctx, result)
+}
+
 // BoostPatternConfidence manually boosts a pattern's confidence
 func (l *LearningLoop) BoostPatternConfidence(ctx context.Context, patternID string, amount float64) error {
 	pattern, err := l.store.GetCrossPattern(patternID)

--- a/internal/memory/feedback_test.go
+++ b/internal/memory/feedback_test.go
@@ -881,6 +881,142 @@ func TestLearnFromReview_NoExtractor(t *testing.T) {
 	}
 }
 
+func TestLearnFromCIFailure(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "feedback-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+	loop := NewLearningLoop(store, extractor, nil)
+	ctx := context.Background()
+
+	ciLogs := `./internal/handler.go:15:2: undefined: processItem
+--- FAIL: TestHandler (0.01s)
+    handler_test.go:42: expected 200, got 500
+golangci-lint: errcheck violation at store.go:55`
+
+	err = loop.LearnFromCIFailure(ctx, "/test/project", ciLogs, []string{"build", "test", "lint"})
+	if err != nil {
+		t.Fatalf("LearnFromCIFailure failed: %v", err)
+	}
+
+	// Should have extracted CI-related anti-patterns
+	if patternStore.Count() < 1 {
+		t.Errorf("Expected at least 1 pattern from CI logs, got %d", patternStore.Count())
+	}
+
+	// Verify all saved patterns have [ANTI] prefix (CI patterns are anti-patterns)
+	for _, pt := range []PatternType{PatternTypeError, PatternTypeWorkflow} {
+		for _, p := range patternStore.GetByType(pt) {
+			if !strings.HasPrefix(p.Title, "[ANTI]") {
+				t.Errorf("CI pattern %q should have [ANTI] prefix", p.Title)
+			}
+		}
+	}
+}
+
+func TestLearnFromCIFailure_EmptyLogs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "feedback-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+	loop := NewLearningLoop(store, extractor, nil)
+	ctx := context.Background()
+
+	err = loop.LearnFromCIFailure(ctx, "/test/project", "", []string{"build"})
+	if err != nil {
+		t.Fatalf("LearnFromCIFailure with empty logs should not error: %v", err)
+	}
+
+	if patternStore.Count() != 0 {
+		t.Errorf("Empty CI logs should produce no patterns, got %d", patternStore.Count())
+	}
+}
+
+func TestLearnFromCIFailure_NoExtractor(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "feedback-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	loop := NewLearningLoop(store, nil, nil) // No extractor
+	ctx := context.Background()
+
+	err = loop.LearnFromCIFailure(ctx, "/test/project", "undefined: foo", []string{"build"})
+	if err == nil {
+		t.Error("LearnFromCIFailure should fail without extractor")
+	}
+}
+
+func TestLearnFromCIFailure_NoMatchingPatterns(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "feedback-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+	loop := NewLearningLoop(store, extractor, nil)
+	ctx := context.Background()
+
+	err = loop.LearnFromCIFailure(ctx, "/test/project", "All checks passed", []string{"build"})
+	if err != nil {
+		t.Fatalf("LearnFromCIFailure with no matches should not error: %v", err)
+	}
+
+	if patternStore.Count() != 0 {
+		t.Errorf("Non-matching CI logs should produce no patterns, got %d", patternStore.Count())
+	}
+}
+
+func TestLearnFromCIFailure_CheckNameTagging(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "feedback-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+	loop := NewLearningLoop(store, extractor, nil)
+	ctx := context.Background()
+
+	err = loop.LearnFromCIFailure(ctx, "/test/project", "undefined: myFunc", []string{"go-build", "compile"})
+	if err != nil {
+		t.Fatalf("LearnFromCIFailure failed: %v", err)
+	}
+
+	// Verify patterns were saved (check names tag is embedded in Context during extraction,
+	// then stored as metadata by SaveExtractedPatterns)
+	if patternStore.Count() < 1 {
+		t.Errorf("Expected at least 1 pattern, got %d", patternStore.Count())
+	}
+}
+
 func TestLearnFromReview_NoReviews(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "feedback-test-*")
 	if err != nil {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1963.

Closes #1963

## Changes

GitHub Issue #1963: Add CI-specific error matchers to PatternExtractor

Parent: GH-1944

In `internal/memory/extractor.go`, add new regex matchers to `extractErrorPatterns()` covering the 4 CI error categories: compilation errors (`undefined`, `unused`, `type mismatch`), test failures (`FAIL`, `timeout`, `panic`), lint errors (linter rule patterns from `golangci-lint`), and build errors (`missing module`, `version conflicts`). Also add a new `extractCIErrorPatterns(ciLogs string) []*ExtractedPattern` method that wraps these with CI-appropriate confidence (0.5 initial) and context tagging (`source:ci`). Add a public `LearnFromCIFailure(ctx, projectPath, ciLogs string, checkNames []string) error` method to `LearningLoop` in `feedback.go` that builds a synthetic extraction result and saves patterns. Include unit tests in `internal/memory/` for both the new matchers and the `LearnFromCIFailure` flow.