### PR TITLE
Confidence boosting for recurring CI patterns and integration test

### DIFF
--- a/internal/memory/extractor.go
+++ b/internal/memory/extractor.go
@@ -599,8 +599,45 @@ func (e *PatternExtractor) SaveExtractedPatterns(ctx context.Context, result *Ex
 			},
 		}
 
-		if err := e.store.Add(globalPattern); err != nil {
-			return fmt.Errorf("failed to save anti-pattern: %w", err)
+		// Recurrence detection: if a similar anti-pattern already exists,
+		// boost confidence instead of creating a duplicate.
+		effectiveConfidence := p.Confidence
+		if existing := e.findSimilarPattern(globalPattern); existing != nil {
+			isCISourced := strings.HasPrefix(fmt.Sprintf("%v", existing.Metadata["context"]), "source:ci") ||
+				strings.HasPrefix(p.Context, "source:ci")
+			if isCISourced {
+				// CI recurrence: boost by 1.5x, capped at 0.95
+				existing.Confidence = min(0.95, existing.Confidence*1.5)
+			} else {
+				e.mergePattern(existing, globalPattern, result.ProjectPath)
+			}
+			effectiveConfidence = existing.Confidence
+			if err := e.store.Add(existing); err != nil {
+				return fmt.Errorf("failed to update anti-pattern: %w", err)
+			}
+		} else {
+			if err := e.store.Add(globalPattern); err != nil {
+				return fmt.Errorf("failed to save anti-pattern: %w", err)
+			}
+		}
+
+		// Also persist CI-sourced anti-patterns to SQLite CrossPattern store
+		// so they are visible to PatternContext.InjectPatterns().
+		if strings.HasPrefix(p.Context, "source:ci") && e.execStore != nil {
+			crossPattern := &CrossPattern{
+				ID:            fmt.Sprintf("ci_%s_%s", p.Type, strings.ReplaceAll(strings.ToLower(p.Title), " ", "_")),
+				Type:          string(p.Type),
+				Title:         "[ANTI] " + p.Title,
+				Description:   "AVOID: " + p.Description,
+				Context:       p.Context,
+				Examples:      p.Examples,
+				Confidence:    effectiveConfidence,
+				Occurrences:   1,
+				IsAntiPattern: true,
+				Scope:         "project",
+			}
+			_ = e.execStore.SaveCrossPattern(crossPattern)
+			_ = e.execStore.LinkPatternToProject(crossPattern.ID, result.ProjectPath)
 		}
 	}
 

--- a/internal/memory/extractor_test.go
+++ b/internal/memory/extractor_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -1222,6 +1223,233 @@ func TestExtractFromReviewComments_NoPatterns(t *testing.T) {
 	if len(result.Patterns) > 0 || len(result.AntiPatterns) > 0 {
 		t.Errorf("Expected no patterns for generic comment, got %d patterns and %d anti-patterns",
 			len(result.Patterns), len(result.AntiPatterns))
+	}
+}
+
+func TestSaveExtractedPatterns_CIRecurrenceBoost(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "extractor-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+	ctx := context.Background()
+
+	// Simulate first CI failure → extract CI patterns
+	ciLogs := "undefined: processItem"
+	ciPatterns := extractor.extractCIErrorPatterns(ciLogs)
+	if len(ciPatterns) == 0 {
+		t.Fatal("expected at least 1 CI error pattern")
+	}
+
+	result1 := &ExtractionResult{
+		ExecutionID:  "ci-run-1",
+		ProjectPath:  "/test/project",
+		AntiPatterns: ciPatterns,
+		Patterns:     make([]*ExtractedPattern, 0),
+	}
+
+	if err := extractor.SaveExtractedPatterns(ctx, result1); err != nil {
+		t.Fatalf("first SaveExtractedPatterns failed: %v", err)
+	}
+
+	// Record initial confidence
+	allPatterns := patternStore.GetByType(ciPatterns[0].Type)
+	if len(allPatterns) == 0 {
+		t.Fatal("expected pattern to be saved")
+	}
+	initialConfidence := allPatterns[0].Confidence
+
+	// Simulate same CI failure recurring → extract again
+	ciPatterns2 := extractor.extractCIErrorPatterns(ciLogs)
+	result2 := &ExtractionResult{
+		ExecutionID:  "ci-run-2",
+		ProjectPath:  "/test/project",
+		AntiPatterns: ciPatterns2,
+		Patterns:     make([]*ExtractedPattern, 0),
+	}
+
+	if err := extractor.SaveExtractedPatterns(ctx, result2); err != nil {
+		t.Fatalf("second SaveExtractedPatterns failed: %v", err)
+	}
+
+	// Verify confidence was boosted by 1.5x
+	boostedPatterns := patternStore.GetByType(ciPatterns[0].Type)
+	var found *GlobalPattern
+	for _, p := range boostedPatterns {
+		if strings.Contains(p.Title, ciPatterns[0].Title) {
+			found = p
+			break
+		}
+	}
+
+	if found == nil {
+		t.Fatal("boosted pattern not found")
+	}
+
+	expectedConfidence := min(0.95, initialConfidence*1.5)
+	if found.Confidence != expectedConfidence {
+		t.Errorf("confidence = %f, want %f (initial %f * 1.5)", found.Confidence, expectedConfidence, initialConfidence)
+	}
+
+	// Verify no duplicate was created
+	count := 0
+	for _, p := range boostedPatterns {
+		if strings.Contains(p.Title, ciPatterns[0].Title) {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 pattern (deduped), got %d", count)
+	}
+}
+
+func TestSaveExtractedPatterns_CIRecurrenceBoost_CappedAt095(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "extractor-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+	ctx := context.Background()
+
+	ciLogs := "undefined: processItem"
+
+	// Save repeatedly to push confidence toward cap
+	for i := 0; i < 10; i++ {
+		ciPatterns := extractor.extractCIErrorPatterns(ciLogs)
+		result := &ExtractionResult{
+			ExecutionID:  fmt.Sprintf("ci-run-%d", i),
+			ProjectPath:  "/test/project",
+			AntiPatterns: ciPatterns,
+			Patterns:     make([]*ExtractedPattern, 0),
+		}
+		if err := extractor.SaveExtractedPatterns(ctx, result); err != nil {
+			t.Fatalf("SaveExtractedPatterns iteration %d failed: %v", i, err)
+		}
+	}
+
+	// Verify confidence is capped at 0.95
+	allPatterns := patternStore.GetByType(PatternTypeError)
+	for _, p := range allPatterns {
+		if p.Confidence > 0.95 {
+			t.Errorf("confidence %f exceeds cap of 0.95 for pattern %q", p.Confidence, p.Title)
+		}
+	}
+}
+
+// TestCIPatternRecurrence_EndToEnd is an integration test that validates the full loop:
+// CI failure → pattern extracted → same failure recurs → confidence boosted →
+// pattern appears in PatternContext.InjectPatterns() output.
+func TestCIPatternRecurrence_EndToEnd(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "extractor-e2e-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+	ctx := context.Background()
+
+	projectPath := "/test/ci-project"
+	ciLogs := "--- FAIL: TestProcess (0.05s)\n    process_test.go:42: expected nil, got error"
+
+	// Step 1: First CI failure → extract patterns
+	ciPatterns := extractor.extractCIErrorPatterns(ciLogs)
+	if len(ciPatterns) == 0 {
+		t.Fatal("expected CI error patterns from FAIL log line")
+	}
+	result1 := &ExtractionResult{
+		ExecutionID:  "ci-run-1",
+		ProjectPath:  projectPath,
+		AntiPatterns: ciPatterns,
+		Patterns:     make([]*ExtractedPattern, 0),
+	}
+	if err := extractor.SaveExtractedPatterns(ctx, result1); err != nil {
+		t.Fatalf("first save failed: %v", err)
+	}
+
+	// Verify CrossPattern was created in SQLite
+	crossPatterns, err := store.GetCrossPatternsForProject(projectPath, true)
+	if err != nil {
+		t.Fatalf("GetCrossPatternsForProject failed: %v", err)
+	}
+	if len(crossPatterns) == 0 {
+		t.Fatal("expected CrossPattern to be saved to SQLite for CI pattern")
+	}
+	initialCrossConfidence := crossPatterns[0].Confidence
+
+	// Step 2: Same CI failure recurs → extract and save again
+	ciPatterns2 := extractor.extractCIErrorPatterns(ciLogs)
+	result2 := &ExtractionResult{
+		ExecutionID:  "ci-run-2",
+		ProjectPath:  projectPath,
+		AntiPatterns: ciPatterns2,
+		Patterns:     make([]*ExtractedPattern, 0),
+	}
+	if err := extractor.SaveExtractedPatterns(ctx, result2); err != nil {
+		t.Fatalf("second save failed: %v", err)
+	}
+
+	// Step 3: Verify confidence was boosted in CrossPattern
+	crossPatternsAfter, err := store.GetCrossPatternsForProject(projectPath, true)
+	if err != nil {
+		t.Fatalf("GetCrossPatternsForProject after boost failed: %v", err)
+	}
+	if len(crossPatternsAfter) == 0 {
+		t.Fatal("expected CrossPattern after boost")
+	}
+
+	// Find the matching pattern
+	var boostedCross *CrossPattern
+	for _, cp := range crossPatternsAfter {
+		if cp.IsAntiPattern {
+			boostedCross = cp
+			break
+		}
+	}
+	if boostedCross == nil {
+		t.Fatal("no anti-pattern CrossPattern found after boost")
+	}
+
+	expectedBoostedConfidence := min(0.95, initialCrossConfidence*1.5)
+	if boostedCross.Confidence != expectedBoostedConfidence {
+		t.Errorf("CrossPattern confidence = %f, want %f (boosted from %f)",
+			boostedCross.Confidence, expectedBoostedConfidence, initialCrossConfidence)
+	}
+
+	// Step 4: Verify pattern appears in FormatForPrompt output
+	queryService := NewPatternQueryService(store)
+	promptBlock, err := queryService.FormatForPrompt(ctx, projectPath, "CI test failure fix")
+	if err != nil {
+		t.Fatalf("FormatForPrompt failed: %v", err)
+	}
+
+	if promptBlock == "" {
+		t.Fatal("FormatForPrompt returned empty string; expected CI pattern to be injected")
+	}
+
+	if !strings.Contains(promptBlock, "Anti-Patterns to Avoid") {
+		t.Error("expected 'Anti-Patterns to Avoid' section in prompt block")
+	}
+
+	// Verify the specific CI pattern title appears
+	if !strings.Contains(promptBlock, "Test failure") {
+		t.Errorf("expected 'Test failure' pattern in prompt block, got:\n%s", promptBlock)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1965.

Closes #1965

## Changes

GitHub Issue #1965: Confidence boosting for recurring CI patterns and integration test

Parent: GH-1944

In `internal/memory/extractor.go`'s `SaveExtractedPatterns()`, add recurrence detection for CI-sourced patterns: when a pattern with the same title already exists, boost confidence by 1.5x (capped at 0.95) instead of creating a duplicate. Add an end-to-end integration test that simulates: CI failure → pattern extracted → same failure recurs → confidence boosted → pattern appears in `PatternContext.InjectPatterns()` output. This validates the full loop from CI log capture through to prompt injection.