### PR TITLE
Add acceptance criteria verification to self-review prompt

### DIFF
--- a/internal/executor/prompt_builder.go
+++ b/internal/executor/prompt_builder.go
@@ -330,6 +330,16 @@ func (r *Runner) buildSelfReviewPrompt(task *Task) string {
 	sb.WriteString("Run `golangci-lint run --new-from-rev=origin/main ./...` and fix any violations.\n")
 	sb.WriteString("Common issue: unchecked return values in test mock handlers (w.Write, json.Encode, SendText).\n\n")
 
+	// GH-1966: Acceptance criteria verification in self-review
+	if len(task.AcceptanceCriteria) > 0 {
+		sb.WriteString("### 9. Acceptance Criteria Verification\n")
+		sb.WriteString("Verify each acceptance criterion against your diff:\n\n")
+		for i, criterion := range task.AcceptanceCriteria {
+			sb.WriteString(fmt.Sprintf("- [ ] **AC%d**: %s — MET / UNMET (cite diff evidence)\n", i+1, criterion))
+		}
+		sb.WriteString("\nIf any criterion is UNMET, fix the implementation before proceeding.\n\n")
+	}
+
 	sb.WriteString("### Actions\n")
 	sb.WriteString("- If you find issues: FIX them and commit the fix\n")
 	sb.WriteString("- Output `REVIEW_FIXED: <description>` if you fixed something\n")

--- a/internal/executor/prompt_builder_test.go
+++ b/internal/executor/prompt_builder_test.go
@@ -506,6 +506,79 @@ func TestBuildSelfReviewPromptContainsLintCheck(t *testing.T) {
 	}
 }
 
+func TestBuildSelfReviewPromptWithAcceptanceCriteria(t *testing.T) {
+	runner := NewRunner()
+
+	t.Run("AC section appears when criteria present", func(t *testing.T) {
+		task := &Task{
+			ID:    "GH-1966",
+			Title: "Add AC verification",
+			AcceptanceCriteria: []string{
+				"Function returns error on invalid input",
+				"Unit tests cover edge cases",
+				"Documentation updated",
+			},
+		}
+
+		prompt := runner.buildSelfReviewPrompt(task)
+
+		if !strings.Contains(prompt, "### 9. Acceptance Criteria Verification") {
+			t.Error("Self-review prompt should contain AC verification section when ACs present")
+		}
+	})
+
+	t.Run("each AC listed individually", func(t *testing.T) {
+		task := &Task{
+			ID:    "GH-1966",
+			Title: "Add AC verification",
+			AcceptanceCriteria: []string{
+				"Function returns error on invalid input",
+				"Unit tests cover edge cases",
+			},
+		}
+
+		prompt := runner.buildSelfReviewPrompt(task)
+
+		if !strings.Contains(prompt, "**AC1**: Function returns error on invalid input") {
+			t.Error("Self-review prompt should list first AC individually")
+		}
+		if !strings.Contains(prompt, "**AC2**: Unit tests cover edge cases") {
+			t.Error("Self-review prompt should list second AC individually")
+		}
+		if !strings.Contains(prompt, "MET / UNMET (cite diff evidence)") {
+			t.Error("Self-review prompt should instruct MET/UNMET with evidence")
+		}
+	})
+
+	t.Run("AC section omitted when empty", func(t *testing.T) {
+		task := &Task{
+			ID:                 "GH-1966",
+			Title:              "No ACs",
+			AcceptanceCriteria: []string{},
+		}
+
+		prompt := runner.buildSelfReviewPrompt(task)
+
+		if strings.Contains(prompt, "Acceptance Criteria Verification") {
+			t.Error("Self-review prompt should NOT contain AC section when ACs are empty")
+		}
+	})
+
+	t.Run("AC section omitted when nil", func(t *testing.T) {
+		task := &Task{
+			ID:                 "GH-1966",
+			Title:              "Nil ACs",
+			AcceptanceCriteria: nil,
+		}
+
+		prompt := runner.buildSelfReviewPrompt(task)
+
+		if strings.Contains(prompt, "Acceptance Criteria Verification") {
+			t.Error("Self-review prompt should NOT contain AC section when ACs are nil")
+		}
+	})
+}
+
 func TestBuildPromptSkipsNavigatorForTrivialTask(t *testing.T) {
 	// Create temporary test environment with .agent/
 	tempDir, err := os.MkdirTemp("", "pilot-test-trivial")


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1966.

Closes #1966

## Changes

GitHub Issue #1966: Add acceptance criteria verification to self-review prompt

Parent: GH-1945

In `internal/executor/prompt_builder.go`, modify `buildSelfReviewPrompt()` (lines 260-341) to append an "Acceptance Criteria Verification" section when `task.AcceptanceCriteria` is non-empty. Each criterion should be listed as a checkbox item with instructions to mark MET/UNMET with evidence from the diff. When no ACs exist, the section is omitted entirely. Add corresponding test cases in `prompt_builder_test.go` verifying: (a) AC section appears when ACs are present, (b) each AC is listed individually, (c) section is omitted when ACs slice is empty/nil. Ensure all existing self-review tests continue to pass.