### PR TITLE
Wire CI log learning into autopilot controller and feedback loop

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -644,6 +644,13 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 		return fmt.Errorf("failed to create fix issue: %w", err)
 	}
 
+	// GH-1964: Learn from CI failure patterns (self-improvement).
+	if c.learningLoop != nil {
+		if learnErr := c.learningLoop.LearnFromCIFailure(ctx, "", ciLogs, failedChecks); learnErr != nil {
+			c.log.Warn("Failed to learn from CI failure", slog.Any("error", learnErr))
+		}
+	}
+
 	// Notify fix issue created
 	if c.notifier != nil {
 		if err := c.notifier.NotifyFixIssueCreated(ctx, prState, issueNum); err != nil {
@@ -900,6 +907,14 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 		} else {
 			c.log.Info("created fix issue for post-merge CI failure", "pr", prState.PRNumber, "issue", issueNum)
 		}
+
+		// GH-1964: Learn from post-merge CI failure patterns (self-improvement).
+		if c.learningLoop != nil {
+			if learnErr := c.learningLoop.LearnFromCIFailure(ctx, "", ciLogs, failedChecks); learnErr != nil {
+				c.log.Warn("Failed to learn from post-merge CI failure", slog.Any("error", learnErr))
+			}
+		}
+
 		c.removePR(prState.PRNumber)
 		return nil
 	}

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -3155,6 +3155,171 @@ func TestHandleMerged_NilLearningLoop(t *testing.T) {
 	}
 }
 
+// TestHandleCIFailed_LearnsFromCIFailure verifies that handleCIFailed calls
+// LearnFromCIFailure when a learning loop is configured.
+func TestHandleCIFailed_LearnsFromCIFailure(t *testing.T) {
+	issueCreated := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/sha123/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == "POST":
+			issueCreated = true
+			resp := github.Issue{Number: 200}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	loop, cleanup := newTestLearningLoop(t)
+	defer cleanup()
+	c.SetLearningLoop(loop)
+
+	prState := &PRState{
+		PRNumber: 42,
+		HeadSHA:  "sha123",
+		Stage:    StageCIFailed,
+	}
+
+	err := c.handleCIFailed(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+
+	if !issueCreated {
+		t.Error("expected fix issue to be created")
+	}
+
+	// The learning loop was set, so LearnFromCIFailure was called.
+	// With nil extractor it returns an error (logged as warning), but must not panic.
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+	}
+}
+
+// TestHandleCIFailed_NilLearningLoop verifies that handleCIFailed does not panic
+// when no learning loop is configured (nil guard).
+func TestHandleCIFailed_NilLearningLoop(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/sha456/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "lint", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == "POST":
+			resp := github.Issue{Number: 201}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	// learningLoop intentionally not set
+
+	prState := &PRState{
+		PRNumber: 43,
+		HeadSHA:  "sha456",
+		Stage:    StageCIFailed,
+	}
+
+	// Must not panic
+	err := c.handleCIFailed(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+	}
+}
+
+// TestHandlePostMergeCI_LearnsFromCIFailure verifies that handlePostMergeCI calls
+// LearnFromCIFailure when post-merge CI fails and a learning loop is configured.
+func TestHandlePostMergeCI_LearnsFromCIFailure(t *testing.T) {
+	issueCreated := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/branches/main":
+			resp := map[string]interface{}{
+				"commit": map[string]string{"sha": "mainsha1"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/commits/mainsha1/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "e2e", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == "POST":
+			issueCreated = true
+			resp := github.Issue{Number: 300}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 1 * time.Second
+	cfg.RequiredChecks = []string{"e2e"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	loop, cleanup := newTestLearningLoop(t)
+	defer cleanup()
+	c.SetLearningLoop(loop)
+
+	prState := &PRState{
+		PRNumber: 44,
+		Stage:    StagePostMergeCI,
+	}
+
+	err := c.handlePostMergeCI(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("handlePostMergeCI returned unexpected error: %v", err)
+	}
+
+	if !issueCreated {
+		t.Error("expected post-merge fix issue to be created")
+	}
+}
+
 // mustJSON serialises v to JSON and fails the test on error.
 func mustJSON(t *testing.T, v any) []byte {
 	t.Helper()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1964.

Closes #1964

## Changes

GitHub Issue #1964: Wire CI log learning into autopilot controller and feedback loop

Parent: GH-1944

In `internal/autopilot/controller.go`, after the existing `CreateFailureIssue()` calls in both `handleCIFailed()` (~line 642) and `handlePostMergeCI()` (~line 897), add calls to `c.learningLoop.LearnFromCIFailure(ctx, projectPath, ciLogs, failedChecks)` with a nil-guard (learningLoop is optional). No changes needed to `FeedbackLoop` struct itself — the learning call goes through the controller's existing `learningLoop` field. Add unit tests in `internal/autopilot/` verifying that CI failures trigger pattern extraction and that nil learningLoop is handled gracefully.