### PR TITLE
feat(poller): Merged PR guard — prevent retry of completed work

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -771,6 +771,22 @@ func (c *Client) ExecuteGraphQL(ctx context.Context, query string, variables map
 	return nil
 }
 
+// SearchMergedPRsForIssue checks if any merged PRs exist that reference the given
+// issue number in their title (e.g. "GH-123" pattern). Uses the GitHub Search API.
+// Returns true if at least one merged PR is found.
+func (c *Client) SearchMergedPRsForIssue(ctx context.Context, owner, repo string, issueNumber int) (bool, error) {
+	q := fmt.Sprintf("repo:%s/%s GH-%d in:title is:pr is:merged", owner, repo, issueNumber)
+	path := fmt.Sprintf("/search/issues?q=%s&per_page=1", url.QueryEscape(q))
+
+	var result struct {
+		TotalCount int `json:"total_count"`
+	}
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return false, fmt.Errorf("search merged PRs for issue %d: %w", issueNumber, err)
+	}
+	return result.TotalCount > 0, nil
+}
+
 // UpdatePullRequestBranch updates the PR branch with the latest base branch.
 // Uses GitHub API: PUT /repos/{owner}/{repo}/pulls/{number}/update-branch
 // Returns nil on success, error if the branch cannot be automatically updated (true conflict).

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -2521,3 +2521,74 @@ func TestExecuteGraphQL(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchMergedPRsForIssue(t *testing.T) {
+	tests := []struct {
+		name        string
+		issueNumber int
+		statusCode  int
+		response    string
+		wantFound   bool
+		wantErr     bool
+	}{
+		{
+			name:        "merged PRs exist",
+			issueNumber: 42,
+			statusCode:  http.StatusOK,
+			response:    `{"total_count": 2}`,
+			wantFound:   true,
+		},
+		{
+			name:        "no merged PRs",
+			issueNumber: 99,
+			statusCode:  http.StatusOK,
+			response:    `{"total_count": 0}`,
+			wantFound:   false,
+		},
+		{
+			name:        "open PRs only - not counted",
+			issueNumber: 55,
+			statusCode:  http.StatusOK,
+			response:    `{"total_count": 0}`,
+			wantFound:   false,
+		},
+		{
+			name:        "API error",
+			issueNumber: 10,
+			statusCode:  http.StatusForbidden,
+			response:    `{"message": "rate limit"}`,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasPrefix(r.URL.Path, "/search/issues") {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				q := r.URL.Query().Get("q")
+				expectedQ := fmt.Sprintf("repo:owner/repo GH-%d in:title is:pr is:merged", tt.issueNumber)
+				if q != expectedQ {
+					t.Errorf("query = %q, want %q", q, expectedQ)
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			found, err := client.SearchMergedPRsForIssue(context.Background(), "owner", "repo", tt.issueNumber)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SearchMergedPRsForIssue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && found != tt.wantFound {
+				t.Errorf("SearchMergedPRsForIssue() = %v, want %v", found, tt.wantFound)
+			}
+		})
+	}
+}

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -513,6 +513,11 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 						slog.Any("error", err))
 				}
 			}
+
+			// GH-1983: Before retrying, check if merged PRs already exist
+			if p.hasMergedWork(ctx, issue) {
+				continue
+			}
 		}
 
 		candidates = append(candidates, issue)
@@ -669,6 +674,11 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 						slog.Int("number", issue.Number),
 						slog.Any("error", err))
 				}
+			}
+
+			// GH-1983: Before retrying, check if merged PRs already exist
+			if p.hasMergedWork(ctx, issue) {
+				continue
 			}
 		}
 
@@ -899,6 +909,35 @@ func ParseDependencies(body string) []int {
 	}
 
 	return deps
+}
+
+// hasMergedWork checks if the issue already has merged PRs (e.g. "GH-123" in title).
+// If merged work exists, the issue is marked as done and should be skipped.
+func (p *Poller) hasMergedWork(ctx context.Context, issue *Issue) bool {
+	found, err := p.client.SearchMergedPRsForIssue(ctx, p.owner, p.repo, issue.Number)
+	if err != nil {
+		p.logger.Warn("Failed to check for merged PRs",
+			slog.Int("issue", issue.Number),
+			slog.Any("error", err),
+		)
+		return false // Don't block on API errors
+	}
+	if !found {
+		return false
+	}
+
+	p.logger.Info("Issue already has merged PRs, marking as done",
+		slog.Int("issue", issue.Number),
+		slog.String("title", issue.Title),
+	)
+	if err := p.client.AddLabels(ctx, p.owner, p.repo, issue.Number, []string{LabelDone}); err != nil {
+		p.logger.Warn("Failed to add pilot-done label",
+			slog.Int("issue", issue.Number),
+			slog.Any("error", err),
+		)
+	}
+	p.markProcessed(issue.Number)
+	return true
 }
 
 // hasPendingDependencies checks if any of the issue's dependencies are still open.

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -1606,3 +1606,159 @@ func TestPoller_AutoMode_OverlappingDispatchesOldestOnly(t *testing.T) {
 		t.Errorf("auto mode dispatched issue %d, want 1 (oldest)", dispatched[0])
 	}
 }
+
+func TestPoller_HasMergedWork(t *testing.T) {
+	tests := []struct {
+		name           string
+		searchResponse string
+		wantSkip       bool
+		wantLabeled    bool
+	}{
+		{
+			name:           "merged PRs exist - skip and label",
+			searchResponse: `{"total_count": 2}`,
+			wantSkip:       true,
+			wantLabeled:    true,
+		},
+		{
+			name:           "no merged PRs - allow retry",
+			searchResponse: `{"total_count": 0}`,
+			wantSkip:       false,
+			wantLabeled:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var labeled bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.URL.Path == "/search/issues":
+					_, _ = w.Write([]byte(tt.searchResponse))
+				case r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/issues/42/labels":
+					labeled = true
+					w.WriteHeader(http.StatusOK)
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+			issue := &Issue{Number: 42, Title: "Test issue"}
+			got := poller.hasMergedWork(context.Background(), issue)
+
+			if got != tt.wantSkip {
+				t.Errorf("hasMergedWork() = %v, want %v", got, tt.wantSkip)
+			}
+			if labeled != tt.wantLabeled {
+				t.Errorf("labeled = %v, want %v", labeled, tt.wantLabeled)
+			}
+			if tt.wantSkip && !poller.IsProcessed(42) {
+				t.Error("issue should be marked as processed when skipped")
+			}
+		})
+	}
+}
+
+func TestPoller_HasMergedWork_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message": "rate limit"}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue := &Issue{Number: 42, Title: "Test issue"}
+	got := poller.hasMergedWork(context.Background(), issue)
+
+	// Should not block on API errors — allow the issue through
+	if got {
+		t.Error("hasMergedWork() should return false on API error")
+	}
+}
+
+func TestPoller_CheckForNewIssues_SkipsRetryWithMergedPRs(t *testing.T) {
+	issues := []*Issue{
+		{Number: 1, Title: "GH-1 feature", Labels: []Label{{Name: "pilot"}}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode(issues)
+		case r.URL.Path == "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 1}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+	)
+
+	// Pre-mark as processed (simulating previous failed attempt)
+	poller.markProcessed(1)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	// Should NOT retry since merged PRs exist
+	if got := atomic.LoadInt32(&callCount); got != 0 {
+		t.Errorf("callback called %d times, want 0 (should skip issue with merged PRs)", got)
+	}
+}
+
+func TestPoller_FindOldestUnprocessedIssue_SkipsRetryWithMergedPRs(t *testing.T) {
+	issues := []*Issue{
+		{
+			Number:    1,
+			Title:     "GH-1 feature",
+			Labels:    []Label{{Name: "pilot"}},
+			CreatedAt: time.Now().Add(-1 * time.Hour),
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode(issues)
+		case r.URL.Path == "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 3}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithExecutionMode(ExecutionModeSequential),
+	)
+
+	// Pre-mark as processed (simulating previous failed attempt)
+	poller.markProcessed(1)
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue != nil {
+		t.Errorf("findOldestUnprocessedIssue() returned issue %d, want nil (should skip issue with merged PRs)", issue.Number)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1983.

Closes #1983

## Changes

GitHub Issue #1983: feat(poller): Merged PR guard — prevent retry of completed work

## TASK-06: Merged PR Guard — Prevent Retry of Completed Work

**Priority**: P1

### Problem

When `pilot-failed` is removed from an issue, the poller clears ProcessedStore and re-dispatches — even when merged PRs already exist. This causes:
1. Decomposition into duplicate sub-issues
2. Execution against already-merged code (no changes)
3. "No commits" failure → `pilot-failed` → infinite retry loop

**Incident**: GH-1944 had 3 merged PRs. On retry, Pilot decomposed into duplicate sub-issues, failed on empty push.

### Solution

Add `hasMergedWork()` guard in poller before dispatching any issue:

1. **New client method**: `SearchMergedPRsForIssue(ctx, owner, repo, issueNumber)` — uses GitHub Search API to check for merged PRs with `GH-{number}` in title
2. **Poller guard**: Insert in both `checkForNewIssues()` (line ~673) and `findOldestUnprocessedIssue()` (line ~516) — after ProcessedStore clear, before candidate append
3. **On match**: Add `pilot-done` label, mark processed, skip issue

### Files to Modify

- `internal/adapters/github/client.go` — add `SearchMergedPRsForIssue()` (~20 lines)
- `internal/adapters/github/client_test.go` — table-driven test
- `internal/adapters/github/poller.go` — add `hasMergedWork()` + 2 insertion points (~30 lines)
- `internal/adapters/github/poller_test.go` — table-driven tests

### Acceptance Criteria

- [ ] Poller skips issues with merged PRs in both parallel and sequential paths
- [ ] Skipped issues get `pilot-done` label
- [ ] No API rate impact (single search query per retry candidate)
- [ ] Table-driven tests: no PRs, open PRs only, merged PRs exist
- [ ] `make test && make lint` pass