### PR TITLE
Add `model_outcomes` table and `ModelOutcomeTracker` in `internal/memory/`

### DIFF
--- a/internal/memory/model_tracker.go
+++ b/internal/memory/model_tracker.go
@@ -1,0 +1,131 @@
+package memory
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// ModelOutcomeTracker tracks model success/failure outcomes per task type
+// to inform escalation decisions (e.g., Haiku → Sonnet → Opus).
+type ModelOutcomeTracker struct {
+	store             *Store
+	failureThreshold  float64
+	recentWindowSize  int
+}
+
+// ModelOutcomeTrackerOption configures a ModelOutcomeTracker.
+type ModelOutcomeTrackerOption func(*ModelOutcomeTracker)
+
+// WithFailureThreshold sets the failure rate threshold for escalation (default 0.3).
+func WithFailureThreshold(t float64) ModelOutcomeTrackerOption {
+	return func(m *ModelOutcomeTracker) {
+		m.failureThreshold = t
+	}
+}
+
+// WithRecentWindowSize sets how many recent outcomes to consider (default 10).
+func WithRecentWindowSize(n int) ModelOutcomeTrackerOption {
+	return func(m *ModelOutcomeTracker) {
+		m.recentWindowSize = n
+	}
+}
+
+// NewModelOutcomeTracker creates a tracker backed by the given Store.
+func NewModelOutcomeTracker(store *Store, opts ...ModelOutcomeTrackerOption) *ModelOutcomeTracker {
+	t := &ModelOutcomeTracker{
+		store:            store,
+		failureThreshold: 0.3,
+		recentWindowSize: 10,
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+// RecordOutcome records a model execution outcome.
+func (t *ModelOutcomeTracker) RecordOutcome(taskType, model, outcome string, tokens int, duration time.Duration) error {
+	return t.store.withRetry("record_model_outcome", func() error {
+		_, err := t.store.db.Exec(
+			`INSERT INTO model_outcomes (task_type, model, outcome, tokens_used, duration_ms) VALUES (?, ?, ?, ?, ?)`,
+			taskType, model, outcome, tokens, duration.Milliseconds(),
+		)
+		return err
+	})
+}
+
+// GetFailureRate returns the failure rate for a task type and model
+// over the most recent outcomes (window size configurable, default 10).
+// Returns 0.0 if no outcomes exist.
+func (t *ModelOutcomeTracker) GetFailureRate(taskType, model string) float64 {
+	rows, err := t.store.db.Query(
+		`SELECT outcome FROM model_outcomes WHERE task_type = ? AND model = ? ORDER BY id DESC LIMIT ?`,
+		taskType, model, t.recentWindowSize,
+	)
+	if err != nil {
+		return 0.0
+	}
+	defer rows.Close()
+
+	var total, failures int
+	for rows.Next() {
+		var outcome string
+		if err := rows.Scan(&outcome); err != nil {
+			continue
+		}
+		total++
+		if outcome == "failure" || outcome == "error" || outcome == "killed" {
+			failures++
+		}
+	}
+
+	if total == 0 {
+		return 0.0
+	}
+	return float64(failures) / float64(total)
+}
+
+// escalationPath defines the model upgrade order.
+var escalationPath = []string{
+	"claude-haiku-4-5",
+	"claude-sonnet-4-6",
+	"claude-opus-4-6",
+}
+
+// ShouldEscalate checks if the failure rate for the given task type and model
+// exceeds the threshold. Returns true with the suggested next model if escalation
+// is warranted. Returns false if the model is already at the top of the escalation
+// path or the failure rate is acceptable.
+func (t *ModelOutcomeTracker) ShouldEscalate(taskType, model string) (bool, string) {
+	rate := t.GetFailureRate(taskType, model)
+	if rate <= t.failureThreshold {
+		return false, ""
+	}
+
+	// Find current model in escalation path
+	for i, m := range escalationPath {
+		if m == model && i+1 < len(escalationPath) {
+			return true, escalationPath[i+1]
+		}
+	}
+
+	return false, ""
+}
+
+// GetOutcomeStats returns aggregate stats for a task type and model.
+func (t *ModelOutcomeTracker) GetOutcomeStats(taskType, model string) (total int, failures int, avgTokens float64, err error) {
+	row := t.store.db.QueryRow(
+		`SELECT COUNT(*), COALESCE(SUM(CASE WHEN outcome IN ('failure','error','killed') THEN 1 ELSE 0 END), 0), COALESCE(AVG(tokens_used), 0)
+		 FROM (SELECT outcome, tokens_used FROM model_outcomes WHERE task_type = ? AND model = ? ORDER BY id DESC LIMIT ?)`,
+		taskType, model, t.recentWindowSize,
+	)
+	err = row.Scan(&total, &failures, &avgTokens)
+	if err == sql.ErrNoRows {
+		return 0, 0, 0, nil
+	}
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("query outcome stats: %w", err)
+	}
+	return total, failures, avgTokens, nil
+}

--- a/internal/memory/model_tracker_test.go
+++ b/internal/memory/model_tracker_test.go
@@ -1,0 +1,295 @@
+package memory
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func newTestTracker(t *testing.T, opts ...ModelOutcomeTrackerOption) *ModelOutcomeTracker {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "model-tracker-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	return NewModelOutcomeTracker(store, opts...)
+}
+
+func TestRecordOutcome(t *testing.T) {
+	tracker := newTestTracker(t)
+
+	err := tracker.RecordOutcome("build", "claude-haiku-4-5", "success", 1000, 5*time.Second)
+	if err != nil {
+		t.Fatalf("RecordOutcome: %v", err)
+	}
+
+	// Verify it was stored
+	var count int
+	err = tracker.store.db.QueryRow("SELECT COUNT(*) FROM model_outcomes").Scan(&count)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 row, got %d", count)
+	}
+}
+
+func TestGetFailureRate(t *testing.T) {
+	tests := []struct {
+		name     string
+		outcomes []string
+		wantRate float64
+	}{
+		{
+			name:     "all success",
+			outcomes: []string{"success", "success", "success"},
+			wantRate: 0.0,
+		},
+		{
+			name:     "all failure",
+			outcomes: []string{"failure", "failure", "failure"},
+			wantRate: 1.0,
+		},
+		{
+			name:     "mixed outcomes",
+			outcomes: []string{"success", "failure", "success", "failure", "success"},
+			wantRate: 0.4,
+		},
+		{
+			name:     "includes error and killed",
+			outcomes: []string{"success", "error", "killed", "success"},
+			wantRate: 0.5,
+		},
+		{
+			name:     "empty data",
+			outcomes: nil,
+			wantRate: 0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker := newTestTracker(t)
+			for _, outcome := range tt.outcomes {
+				if err := tracker.RecordOutcome("test-task", "claude-haiku-4-5", outcome, 500, time.Second); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := tracker.GetFailureRate("test-task", "claude-haiku-4-5")
+			if got != tt.wantRate {
+				t.Errorf("GetFailureRate() = %v, want %v", got, tt.wantRate)
+			}
+		})
+	}
+}
+
+func TestGetFailureRateWindowLimit(t *testing.T) {
+	tracker := newTestTracker(t, WithRecentWindowSize(3))
+
+	// Record 7 failures then 3 successes (most recent)
+	for i := 0; i < 7; i++ {
+		if err := tracker.RecordOutcome("task", "claude-haiku-4-5", "failure", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		if err := tracker.RecordOutcome("task", "claude-haiku-4-5", "success", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Window of 3 should only see the 3 most recent (all success)
+	got := tracker.GetFailureRate("task", "claude-haiku-4-5")
+	if got != 0.0 {
+		t.Errorf("GetFailureRate() = %v, want 0.0 (window should see only recent successes)", got)
+	}
+}
+
+func TestShouldEscalate(t *testing.T) {
+	tests := []struct {
+		name      string
+		model     string
+		outcomes  []string
+		wantEsc   bool
+		wantModel string
+	}{
+		{
+			name:      "haiku failing escalates to sonnet",
+			model:     "claude-haiku-4-5",
+			outcomes:  []string{"failure", "failure", "failure", "success"},
+			wantEsc:   true,
+			wantModel: "claude-sonnet-4-6",
+		},
+		{
+			name:      "sonnet failing escalates to opus",
+			model:     "claude-sonnet-4-6",
+			outcomes:  []string{"failure", "failure", "success"},
+			wantEsc:   true,
+			wantModel: "claude-opus-4-6",
+		},
+		{
+			name:      "opus failing cannot escalate further",
+			model:     "claude-opus-4-6",
+			outcomes:  []string{"failure", "failure", "failure"},
+			wantEsc:   false,
+			wantModel: "",
+		},
+		{
+			name:      "low failure rate no escalation",
+			model:     "claude-haiku-4-5",
+			outcomes:  []string{"success", "success", "success", "failure"},
+			wantEsc:   false,
+			wantModel: "",
+		},
+		{
+			name:      "unknown model no escalation",
+			model:     "some-other-model",
+			outcomes:  []string{"failure", "failure", "failure"},
+			wantEsc:   false,
+			wantModel: "",
+		},
+		{
+			name:      "no data no escalation",
+			model:     "claude-haiku-4-5",
+			outcomes:  nil,
+			wantEsc:   false,
+			wantModel: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker := newTestTracker(t)
+			for _, outcome := range tt.outcomes {
+				if err := tracker.RecordOutcome("build", tt.model, outcome, 500, time.Second); err != nil {
+					t.Fatal(err)
+				}
+			}
+			gotEsc, gotModel := tracker.ShouldEscalate("build", tt.model)
+			if gotEsc != tt.wantEsc {
+				t.Errorf("ShouldEscalate() escalate = %v, want %v", gotEsc, tt.wantEsc)
+			}
+			if gotModel != tt.wantModel {
+				t.Errorf("ShouldEscalate() model = %q, want %q", gotModel, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestThresholdBoundary(t *testing.T) {
+	// Exactly at threshold (30%) should NOT escalate (uses >)
+	tracker := newTestTracker(t, WithFailureThreshold(0.3))
+
+	// 3 failures out of 10 = exactly 0.3
+	for i := 0; i < 7; i++ {
+		if err := tracker.RecordOutcome("task", "claude-haiku-4-5", "success", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		if err := tracker.RecordOutcome("task", "claude-haiku-4-5", "failure", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	esc, _ := tracker.ShouldEscalate("task", "claude-haiku-4-5")
+	if esc {
+		t.Error("should NOT escalate at exactly threshold (0.3)")
+	}
+
+	// One more failure tips it over: 4/10 = 0.4 but window recalculates from latest 10
+	// Add one more failure to push past
+	if err := tracker.RecordOutcome("task", "claude-haiku-4-5", "failure", 100, time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now window is last 10: 6 success + 4 failure = 0.4
+	esc, model := tracker.ShouldEscalate("task", "claude-haiku-4-5")
+	if !esc {
+		t.Error("should escalate above threshold")
+	}
+	if model != "claude-sonnet-4-6" {
+		t.Errorf("expected claude-sonnet-4-6, got %s", model)
+	}
+}
+
+func TestCustomThreshold(t *testing.T) {
+	tracker := newTestTracker(t, WithFailureThreshold(0.5))
+
+	// 4/10 = 0.4, below 0.5 threshold
+	for i := 0; i < 6; i++ {
+		if err := tracker.RecordOutcome("task", "claude-haiku-4-5", "success", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 4; i++ {
+		if err := tracker.RecordOutcome("task", "claude-haiku-4-5", "failure", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	esc, _ := tracker.ShouldEscalate("task", "claude-haiku-4-5")
+	if esc {
+		t.Error("should not escalate at 0.4 with 0.5 threshold")
+	}
+}
+
+func TestIsolationByTaskType(t *testing.T) {
+	tracker := newTestTracker(t)
+
+	// Task A: all failures
+	for i := 0; i < 5; i++ {
+		if err := tracker.RecordOutcome("task-a", "claude-haiku-4-5", "failure", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Task B: all success
+	for i := 0; i < 5; i++ {
+		if err := tracker.RecordOutcome("task-b", "claude-haiku-4-5", "success", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rateA := tracker.GetFailureRate("task-a", "claude-haiku-4-5")
+	rateB := tracker.GetFailureRate("task-b", "claude-haiku-4-5")
+
+	if rateA != 1.0 {
+		t.Errorf("task-a failure rate = %v, want 1.0", rateA)
+	}
+	if rateB != 0.0 {
+		t.Errorf("task-b failure rate = %v, want 0.0", rateB)
+	}
+}
+
+func TestGetOutcomeStats(t *testing.T) {
+	tracker := newTestTracker(t)
+
+	if err := tracker.RecordOutcome("build", "claude-haiku-4-5", "success", 1000, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := tracker.RecordOutcome("build", "claude-haiku-4-5", "failure", 2000, 10*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	total, failures, avgTokens, err := tracker.GetOutcomeStats("build", "claude-haiku-4-5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 {
+		t.Errorf("total = %d, want 2", total)
+	}
+	if failures != 1 {
+		t.Errorf("failures = %d, want 1", failures)
+	}
+	if avgTokens != 1500.0 {
+		t.Errorf("avgTokens = %v, want 1500", avgTokens)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -236,6 +236,18 @@ func (s *Store) migrate() error {
 			component TEXT DEFAULT 'executor'
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_execution_logs_timestamp ON execution_logs(timestamp)`,
+		// Model outcomes table (GH-1990)
+		`CREATE TABLE IF NOT EXISTS model_outcomes (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			task_type TEXT NOT NULL,
+			model TEXT NOT NULL,
+			outcome TEXT NOT NULL,
+			tokens_used INTEGER DEFAULT 0,
+			duration_ms INTEGER DEFAULT 0,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_model_outcomes_task_model ON model_outcomes(task_type, model)`,
+		`CREATE INDEX IF NOT EXISTS idx_model_outcomes_created ON model_outcomes(created_at)`,
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1990.

Closes #1990

## Changes

Add the `model_outcomes` SQLite table with migration in `store.go` (using the existing `CREATE TABLE IF NOT EXISTS` + index pattern). Create a new `model_tracker.go` file with `ModelOutcomeTracker` struct that takes `*Store` and exposes: `RecordOutcome(taskType, model, outcome, tokens, duration) error`, `GetFailureRate(taskType, model) float64` (last 10 outcomes), and `ShouldEscalate(taskType, model) (bool, string)` (failure rate > 30% threshold, configurable). Add table-driven tests in `model_tracker_test.go` covering: recording outcomes, failure rate calculation, escalation logic (Haiku→Sonnet→Opus path), threshold boundary cases, and empty-data behavior.