### PR TITLE
feat(memory): Expand pattern extractors to 11 categories

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-03-04 (v2.52.0)
+**Last Updated:** 2026-03-04 (v2.53.0)
 
 ## Legend
 
@@ -93,6 +93,7 @@
 | CI-specific error matchers | ✅ | memory | - | - | Add CI-specific error matchers to PatternExtractor (v2.47.0, PR #1973) |
 | CI pattern confidence boost | ✅ | memory | - | - | Confidence boosting for recurring CI patterns (v2.48.0, PR #1975) |
 | CI log learning pipeline | ✅ | autopilot | - | - | Wire CI log learning into autopilot controller and feedback loop (v2.50.0, PR #1977) |
+| Expanded pattern extractors (11 categories) | ✅ | memory | - | - | Added API design, concurrency, config wiring, test patterns, performance, security matchers (v2.54.0, GH-1989) |
 
 ## Input Adapters
 

--- a/internal/memory/extractor.go
+++ b/internal/memory/extractor.go
@@ -175,56 +175,113 @@ func (e *PatternExtractor) ExtractFromReviewComments(ctx context.Context,
 	return result, nil
 }
 
+// codePatternMatcher maps a compiled regex to the pattern metadata it produces.
+type codePatternMatcher struct {
+	regex   *regexp.Regexp
+	pType   PatternType
+	title   string
+	desc    string
+	context string
+}
+
+// codePatternMatchers holds all 11 categories of code pattern matchers used by
+// extractCodePatterns. len(codePatternMatchers) == 11.
+var codePatternMatchers = []codePatternMatcher{
+	// 1. Context / cancellation
+	{
+		regex:   regexp.MustCompile(`(?i)using\s+context\.Context\s+in\s+(\w+)`),
+		pType:   PatternTypeCode,
+		title:   "Use context.Context for cancellation",
+		desc:    "Pass context.Context to functions for proper cancellation and timeout handling",
+		context: "Go handlers",
+	},
+	// 2. Error handling
+	{
+		regex:   regexp.MustCompile(`(?i)added\s+error\s+handling\s+for\s+(\w+)`),
+		pType:   PatternTypeCode,
+		title:   "Explicit error handling",
+		desc:    "Always handle errors explicitly rather than ignoring them",
+		context: "Go functions",
+	},
+	// 3. Test-driven implementation
+	{
+		regex:   regexp.MustCompile(`(?i)created?\s+test[s]?\s+for\s+(\w+)`),
+		pType:   PatternTypeWorkflow,
+		title:   "Test-driven implementation",
+		desc:    "Create tests alongside implementation code",
+		context: "All code",
+	},
+	// 4. Structured logging
+	{
+		regex:   regexp.MustCompile(`(?i)using\s+(zap|slog|logrus)\s+for\s+logging`),
+		pType:   PatternTypeCode,
+		title:   "Structured logging",
+		desc:    "Use structured logging library instead of fmt.Printf",
+		context: "Go services",
+	},
+	// 5. Input validation
+	{
+		regex:   regexp.MustCompile(`(?i)added?\s+validation\s+for\s+(\w+)`),
+		pType:   PatternTypeCode,
+		title:   "Input validation",
+		desc:    "Validate inputs at system boundaries",
+		context: "API handlers",
+	},
+	// 6. API Design — endpoint patterns, request/response structure, middleware usage
+	{
+		regex:   regexp.MustCompile(`(?i)(?:http\.Handler|router\.\w+|\bendpoint\b|\bmiddleware\b|\bREST\b|\bGraphQL\b)`),
+		pType:   PatternTypeCode,
+		title:   "API design pattern",
+		desc:    "Organise HTTP handlers, middleware, and routing following REST or GraphQL conventions",
+		context: "API design",
+	},
+	// 7. Concurrency — goroutine patterns, mutex usage, channel patterns, sync primitives
+	{
+		regex:   regexp.MustCompile(`(?i)(?:go\s+func|sync\.Mutex|sync\.WaitGroup|chan\s+\w+|select\s*\{|sync\.Once)`),
+		pType:   PatternTypeCode,
+		title:   "Concurrency pattern",
+		desc:    "Use goroutines, channels, and sync primitives for safe concurrent access",
+		context: "Concurrency",
+	},
+	// 8. Config wiring — YAML tags, env vars, Viper, mapstructure
+	{
+		regex:   regexp.MustCompile("(?i)(?:yaml:\"|env:\"|config\\.\\w+|viper\\.\\w+|\\bmapstructure\\b|os\\.Getenv)"),
+		pType:   PatternTypeCode,
+		title:   "Config wiring pattern",
+		desc:    "Load configuration from YAML, environment variables, or Viper with proper struct tags",
+		context: "Config wiring",
+	},
+	// 9. Test patterns — table-driven tests, httptest, mocks, testify assertions
+	{
+		regex:   regexp.MustCompile(`(?i)(?:t\.Run\s*\(|httptest\.\w+|\bmock\w*\b|\btestify\b|assert\.\w+|require\.\w+)`),
+		pType:   PatternTypeWorkflow,
+		title:   "Test pattern",
+		desc:    "Use table-driven tests, httptest, mocks, and testify assertions for comprehensive coverage",
+		context: "Test patterns",
+	},
+	// 10. Performance — caching, connection pooling, batch ops, indexing
+	{
+		regex:   regexp.MustCompile(`(?i)(?:\bcache\b|\bpool\b|\bbatch\b|\bindex\b|\bSetMaxOpenConns\b|sync\.Pool)`),
+		pType:   PatternTypeCode,
+		title:   "Performance pattern",
+		desc:    "Apply caching, connection pooling, batching, and indexing for performance-critical paths",
+		context: "Performance",
+	},
+	// 11. Security — auth, token validation, sanitisation, RBAC, HMAC
+	{
+		regex:   regexp.MustCompile(`(?i)(?:\bauthentication\b|\bauthorization\b|\btoken\s+\w+|\bsanitize\b|\bescape\b|\bpermission\b|\brbac\b|\bhmac\b)`),
+		pType:   PatternTypeCode,
+		title:   "Security pattern",
+		desc:    "Apply authentication, token validation, input sanitisation, RBAC, and HMAC signing",
+		context: "Security",
+	},
+}
+
 // extractCodePatterns extracts code-related patterns
 func (e *PatternExtractor) extractCodePatterns(output string) []*ExtractedPattern {
 	var patterns []*ExtractedPattern
 
-	// Look for common successful patterns in output
-	patternMatchers := []struct {
-		regex   *regexp.Regexp
-		pType   PatternType
-		title   string
-		desc    string
-		context string
-	}{
-		{
-			regex:   regexp.MustCompile(`(?i)using\s+context\.Context\s+in\s+(\w+)`),
-			pType:   PatternTypeCode,
-			title:   "Use context.Context for cancellation",
-			desc:    "Pass context.Context to functions for proper cancellation and timeout handling",
-			context: "Go handlers",
-		},
-		{
-			regex:   regexp.MustCompile(`(?i)added\s+error\s+handling\s+for\s+(\w+)`),
-			pType:   PatternTypeCode,
-			title:   "Explicit error handling",
-			desc:    "Always handle errors explicitly rather than ignoring them",
-			context: "Go functions",
-		},
-		{
-			regex:   regexp.MustCompile(`(?i)created?\s+test[s]?\s+for\s+(\w+)`),
-			pType:   PatternTypeWorkflow,
-			title:   "Test-driven implementation",
-			desc:    "Create tests alongside implementation code",
-			context: "All code",
-		},
-		{
-			regex:   regexp.MustCompile(`(?i)using\s+(zap|slog|logrus)\s+for\s+logging`),
-			pType:   PatternTypeCode,
-			title:   "Structured logging",
-			desc:    "Use structured logging library instead of fmt.Printf",
-			context: "Go services",
-		},
-		{
-			regex:   regexp.MustCompile(`(?i)added?\s+validation\s+for\s+(\w+)`),
-			pType:   PatternTypeCode,
-			title:   "Input validation",
-			desc:    "Validate inputs at system boundaries",
-			context: "API handlers",
-		},
-	}
-
-	for _, matcher := range patternMatchers {
+	for _, matcher := range codePatternMatchers {
 		if matches := matcher.regex.FindAllStringSubmatch(output, -1); len(matches) > 0 {
 			examples := make([]string, 0, len(matches))
 			for _, m := range matches {

--- a/internal/memory/extractor_test.go
+++ b/internal/memory/extractor_test.go
@@ -1632,3 +1632,192 @@ func TestExtractFromReviewComments_Documentation(t *testing.T) {
 		t.Error("Expected documentation anti-pattern")
 	}
 }
+
+// TestCodePatternMatcherCount verifies exactly 11 categories are registered.
+func TestCodePatternMatcherCount(t *testing.T) {
+	if got := len(codePatternMatchers); got != 11 {
+		t.Errorf("len(codePatternMatchers) = %d, want 11", got)
+	}
+}
+
+// TestNewCodePatternCategories verifies the 6 new matcher categories (API Design,
+// Concurrency, Config Wiring, Test Patterns, Performance, Security) each fire on
+// matching input and stay silent on unrelated input.
+func TestNewCodePatternCategories(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "extractor-new-cats-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	patternStore, _ := NewGlobalPatternStore(tmpDir)
+	extractor := NewPatternExtractor(patternStore, store)
+
+	tests := []struct {
+		name        string
+		output      string
+		wantTitle   string // substring of expected pattern title
+		wantMatch   bool
+	}{
+		// --- API Design ---
+		{
+			name:      "api design: http.Handler match",
+			output:    "implemented http.Handler interface for the webhook route",
+			wantTitle: "API design",
+			wantMatch: true,
+		},
+		{
+			name:      "api design: REST endpoint match",
+			output:    "added REST endpoint with middleware for rate limiting",
+			wantTitle: "API design",
+			wantMatch: true,
+		},
+		{
+			name:      "api design: no match",
+			output:    "wrote a helper function to format timestamps",
+			wantTitle: "API design",
+			wantMatch: false,
+		},
+		// --- Concurrency ---
+		{
+			name:      "concurrency: sync.Mutex match",
+			output:    "protected shared counter using sync.Mutex to avoid data races",
+			wantTitle: "Concurrency",
+			wantMatch: true,
+		},
+		{
+			name:      "concurrency: go func match",
+			output:    "launched background worker via go func with sync.WaitGroup",
+			wantTitle: "Concurrency",
+			wantMatch: true,
+		},
+		{
+			name:      "concurrency: no match",
+			output:    "added a simple sequential loop to process items",
+			wantTitle: "Concurrency",
+			wantMatch: false,
+		},
+		// --- Config Wiring ---
+		{
+			name:      "config wiring: yaml tag match",
+			output:    `added yaml:"timeout" struct tag and os.Getenv fallback`,
+			wantTitle: "Config wiring",
+			wantMatch: true,
+		},
+		{
+			name:      "config wiring: viper match",
+			output:    "loading settings via viper.GetString and mapstructure decode",
+			wantTitle: "Config wiring",
+			wantMatch: true,
+		},
+		{
+			name:      "config wiring: no match",
+			output:    "refactored the retry loop to use exponential backoff",
+			wantTitle: "Config wiring",
+			wantMatch: false,
+		},
+		// --- Test Patterns ---
+		{
+			name:      "test patterns: t.Run match",
+			output:    "added table-driven tests using t.Run( for each scenario",
+			wantTitle: "Test pattern",
+			wantMatch: true,
+		},
+		{
+			name:      "test patterns: httptest match",
+			output:    "wrote handler test with httptest.NewRecorder and assert.Equal",
+			wantTitle: "Test pattern",
+			wantMatch: true,
+		},
+		{
+			name:      "test patterns: no match",
+			output:    "updated the deployment manifest",
+			wantTitle: "Test pattern",
+			wantMatch: false,
+		},
+		// --- Performance ---
+		{
+			name:      "performance: SetMaxOpenConns match",
+			output:    "tuned database pool with SetMaxOpenConns to reduce contention",
+			wantTitle: "Performance",
+			wantMatch: true,
+		},
+		{
+			name:      "performance: cache match",
+			output:    "added in-memory cache layer to avoid redundant database queries",
+			wantTitle: "Performance",
+			wantMatch: true,
+		},
+		{
+			name:      "performance: no match",
+			output:    "formatted the codebase with gofmt",
+			wantTitle: "Performance",
+			wantMatch: false,
+		},
+		// --- Security ---
+		{
+			name:      "security: authentication match",
+			output:    "added authentication middleware with token validation",
+			wantTitle: "Security",
+			wantMatch: true,
+		},
+		{
+			name:      "security: hmac match",
+			output:    "signing webhook payloads with hmac and checking permission on every call",
+			wantTitle: "Security",
+			wantMatch: true,
+		},
+		{
+			name:      "security: no match",
+			output:    "added structured logging to the service startup path",
+			wantTitle: "Security",
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &Execution{
+				ID:          "test-exec",
+				ProjectPath: "/test/project",
+				Status:      "completed",
+				Output:      tt.output,
+			}
+
+			result, err := extractor.ExtractFromExecution(context.Background(), exec)
+			if err != nil {
+				t.Fatalf("ExtractFromExecution failed: %v", err)
+			}
+
+			found := false
+			for _, p := range result.Patterns {
+				if strings.Contains(p.Title, tt.wantTitle) {
+					found = true
+					break
+				}
+			}
+
+			if found != tt.wantMatch {
+				if tt.wantMatch {
+					t.Errorf("expected pattern with title containing %q, got none (patterns: %v)",
+						tt.wantTitle, patternTitles(result.Patterns))
+				} else {
+					t.Errorf("expected no pattern with title containing %q, but found one",
+						tt.wantTitle)
+				}
+			}
+		})
+	}
+}
+
+// patternTitles returns the titles of extracted patterns for test diagnostics.
+func patternTitles(patterns []*ExtractedPattern) []string {
+	titles := make([]string, len(patterns))
+	for i, p := range patterns {
+		titles[i] = p.Title
+	}
+	return titles
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1989.

Closes #1989

## Changes

GitHub Issue #1989: feat(memory): Expand pattern extractors to 11 categories

## ROAD-09: Expand Pattern Extractors

**Priority**: P1 | **Roadmap**: v3.0 Self-Improvement — Phase 3

### Problem

`internal/memory/extractor.go` (lines 183-244) has only 5 pattern matchers:
1. Context/architecture
2. Error handling
3. Testing
4. Logging
5. Validation

This misses 6 major categories that Pilot encounters regularly. Concurrency patterns, API design, config wiring, performance, and security patterns are never extracted — even when PRs contain them.

### Solution

Add 6 new matcher categories to `PatternExtractor` in `internal/memory/extractor.go`:

6. **API Design** — endpoint patterns, request/response structure, middleware usage, route organization
   - Match: `http.Handler`, `router.`, `endpoint`, `middleware`, `REST`, `GraphQL`

7. **Concurrency** — goroutine patterns, mutex usage, channel patterns, sync primitives
   - Match: `go func`, `sync.Mutex`, `chan `, `sync.WaitGroup`, `context.Context`, `select {`

8. **Config Wiring** — configuration loading, env vars, struct tags, validation
   - Match: `yaml:`, `env:`, `config.`, `viper`, `mapstructure`, `os.Getenv`

9. **Test Patterns** — table-driven tests, mock setup, test helpers, assertion patterns
   - Match: `t.Run(`, `httptest.`, `mock`, `testify`, `assert.`, `require.`

10. **Performance** — caching, connection pooling, batch operations, indexing
    - Match: `cache`, `pool`, `batch`, `index`, `SetMaxOpenConns`, `sync.Pool`

11. **Security** — auth patterns, token handling, input sanitization, RBAC
    - Match: `auth`, `token`, `sanitize`, `escape`, `permission`, `rbac`, `hmac`

Each matcher follows the existing pattern:
```go
type PatternMatcher struct {
    Category    string
    Keywords    []string
    Extract     func(content string) []Pattern
}
```

### Files to Modify

- `internal/memory/extractor.go` — add 6 new matchers to `defaultMatchers()` or equivalent initialization
- `internal/memory/extractor_test.go` — table-driven tests for each new category

### Acceptance Criteria

- [ ] 6 new pattern categories added (API, Concurrency, Config, Test, Performance, Security)
- [ ] Each category has at least 5 keyword triggers
- [ ] Each category extracts meaningful patterns (not just keyword matches)
- [ ] Table-driven tests: each category has at least 2 test cases (match + no-match)
- [ ] Existing 5 categories unchanged and tests pass
- [ ] Total matcher count verifiable: `len(matchers) == 11`
- [ ] Pattern extraction includes category label in stored pattern

## Planned Steps (execute all in sequence)

1. **Add 6 new pattern matcher categories with table-driven tests** — Add the 6 missing pattern matchers (API Design, Concurrency, Config Wiring, Test Patterns, Performance, Security) to `internal/memory/extractor.go` following the existing `PatternMatcher` structure. Each category gets 5+ keyword triggers and a meaningful `Extract` function. Add table-driven tests in `extractor_test.go` with at least 2 cases per category (match + no-match). Verify `len(matchers) == 11` and that existing 5 categories remain unchanged and passing. Files: `internal/memory/extractor.go`, `internal/memory/extractor_test.go`.
