### PR TITLE
Add `model_outcomes` table and `ModelOutcomeTracker` in `internal/memory/`

### DIFF
--- a/internal/memory/model_tracker.go
+++ b/internal/memory/model_tracker.go
@@ -1,0 +1,108 @@
+package memory
+
+import (
+	"database/sql"
+	"time"
+)
+
+// DefaultFailureThreshold is the failure rate above which escalation is recommended.
+const DefaultFailureThreshold = 0.30
+
+// DefaultOutcomeWindow is the number of recent outcomes considered for failure rate.
+const DefaultOutcomeWindow = 10
+
+// EscalationPath defines the model upgrade sequence.
+var EscalationPath = []string{"haiku", "sonnet", "opus"}
+
+// ModelOutcomeTracker tracks per-model success/failure outcomes and recommends escalation.
+type ModelOutcomeTracker struct {
+	store            *Store
+	failureThreshold float64
+	outcomeWindow    int
+}
+
+// NewModelOutcomeTracker creates a tracker with default settings.
+func NewModelOutcomeTracker(store *Store) *ModelOutcomeTracker {
+	return &ModelOutcomeTracker{
+		store:            store,
+		failureThreshold: DefaultFailureThreshold,
+		outcomeWindow:    DefaultOutcomeWindow,
+	}
+}
+
+// WithFailureThreshold sets a custom failure threshold (0.0–1.0).
+func (t *ModelOutcomeTracker) WithFailureThreshold(threshold float64) *ModelOutcomeTracker {
+	t.failureThreshold = threshold
+	return t
+}
+
+// RecordOutcome persists a model execution outcome.
+func (t *ModelOutcomeTracker) RecordOutcome(taskType, model, outcome string, tokens int, duration time.Duration) error {
+	return t.store.withRetry("RecordModelOutcome", func() error {
+		_, err := t.store.db.Exec(
+			`INSERT INTO model_outcomes (task_type, model, outcome, tokens_used, duration_ms) VALUES (?, ?, ?, ?, ?)`,
+			taskType, model, outcome, tokens, duration.Milliseconds(),
+		)
+		return err
+	})
+}
+
+// GetFailureRate returns the failure rate for a task type + model over the last N outcomes.
+// Returns 0.0 if no outcomes exist.
+func (t *ModelOutcomeTracker) GetFailureRate(taskType, model string) float64 {
+	var total, failures int
+	rows, err := t.store.db.Query(
+		`SELECT outcome FROM model_outcomes WHERE task_type = ? AND model = ? ORDER BY id DESC LIMIT ?`,
+		taskType, model, t.outcomeWindow,
+	)
+	if err != nil {
+		return 0.0
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var outcome string
+		if err := rows.Scan(&outcome); err != nil {
+			continue
+		}
+		total++
+		if outcome == "failure" {
+			failures++
+		}
+	}
+	if total == 0 {
+		return 0.0
+	}
+	return float64(failures) / float64(total)
+}
+
+// ShouldEscalate returns true and the recommended model if the failure rate exceeds threshold.
+// Returns false if no escalation is needed or the model is already at the top of the path.
+func (t *ModelOutcomeTracker) ShouldEscalate(taskType, model string) (bool, string) {
+	rate := t.GetFailureRate(taskType, model)
+	if rate <= t.failureThreshold {
+		return false, ""
+	}
+
+	// Find next model in escalation path
+	for i, m := range EscalationPath {
+		if m == model && i+1 < len(EscalationPath) {
+			return true, EscalationPath[i+1]
+		}
+	}
+	return false, ""
+}
+
+// GetOutcomeStats returns aggregate stats for a task type + model.
+func (t *ModelOutcomeTracker) GetOutcomeStats(taskType, model string) (total int, failures int, avgTokens float64, err error) {
+	row := t.store.db.QueryRow(
+		`SELECT COUNT(*), COALESCE(SUM(CASE WHEN outcome='failure' THEN 1 ELSE 0 END),0), COALESCE(AVG(tokens_used),0)
+		 FROM (SELECT outcome, tokens_used FROM model_outcomes WHERE task_type = ? AND model = ? ORDER BY id DESC LIMIT ?)`,
+		taskType, model, t.outcomeWindow,
+	)
+	err = row.Scan(&total, &failures, &avgTokens)
+	if err == sql.ErrNoRows {
+		return 0, 0, 0, nil
+	}
+	return
+}

--- a/internal/memory/model_tracker_test.go
+++ b/internal/memory/model_tracker_test.go
@@ -1,0 +1,260 @@
+package memory
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func newTestTracker(t *testing.T) (*ModelOutcomeTracker, func()) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "model-tracker-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		t.Fatalf("failed to create store: %v", err)
+	}
+	tracker := NewModelOutcomeTracker(store)
+	cleanup := func() {
+		_ = store.Close()
+		_ = os.RemoveAll(tmpDir)
+	}
+	return tracker, cleanup
+}
+
+func TestRecordOutcome(t *testing.T) {
+	tr, cleanup := newTestTracker(t)
+	defer cleanup()
+
+	err := tr.RecordOutcome("bug-fix", "haiku", "success", 1000, 5*time.Second)
+	if err != nil {
+		t.Fatalf("RecordOutcome failed: %v", err)
+	}
+
+	// Verify it was stored by checking failure rate (should be 0)
+	rate := tr.GetFailureRate("bug-fix", "haiku")
+	if rate != 0.0 {
+		t.Errorf("expected failure rate 0.0, got %f", rate)
+	}
+}
+
+func TestFailureRateCalculation(t *testing.T) {
+	tests := []struct {
+		name     string
+		outcomes []string // "success" or "failure"
+		wantRate float64
+	}{
+		{
+			name:     "all success",
+			outcomes: []string{"success", "success", "success"},
+			wantRate: 0.0,
+		},
+		{
+			name:     "all failure",
+			outcomes: []string{"failure", "failure", "failure"},
+			wantRate: 1.0,
+		},
+		{
+			name:     "mixed 50%",
+			outcomes: []string{"success", "failure", "success", "failure"},
+			wantRate: 0.5,
+		},
+		{
+			name:     "one of three",
+			outcomes: []string{"success", "failure", "success"},
+			wantRate: 1.0 / 3.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr, cl := newTestTracker(t)
+			defer cl()
+
+			for _, o := range tt.outcomes {
+				if err := tr.RecordOutcome("test-task", "sonnet", o, 500, time.Second); err != nil {
+					t.Fatalf("RecordOutcome: %v", err)
+				}
+			}
+
+			got := tr.GetFailureRate("test-task", "sonnet")
+			if diff := got - tt.wantRate; diff > 0.001 || diff < -0.001 {
+				t.Errorf("failure rate = %f, want %f", got, tt.wantRate)
+			}
+		})
+	}
+}
+
+func TestFailureRateWindowLimit(t *testing.T) {
+	tracker, cleanup := newTestTracker(t)
+	defer cleanup()
+
+	// Record 10 successes then 10 failures; window=10 should only see failures
+	for i := 0; i < 10; i++ {
+		if err := tracker.RecordOutcome("task", "haiku", "success", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 10; i++ {
+		if err := tracker.RecordOutcome("task", "haiku", "failure", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rate := tracker.GetFailureRate("task", "haiku")
+	if rate != 1.0 {
+		t.Errorf("expected 1.0 (last 10 all failures), got %f", rate)
+	}
+}
+
+func TestFailureRateEmptyData(t *testing.T) {
+	tracker, cleanup := newTestTracker(t)
+	defer cleanup()
+
+	rate := tracker.GetFailureRate("nonexistent", "haiku")
+	if rate != 0.0 {
+		t.Errorf("expected 0.0 for empty data, got %f", rate)
+	}
+}
+
+func TestShouldEscalate(t *testing.T) {
+	tests := []struct {
+		name        string
+		model       string
+		outcomes    []string
+		wantEscal   bool
+		wantTarget  string
+	}{
+		{
+			name:       "haiku high failure -> sonnet",
+			model:      "haiku",
+			outcomes:   []string{"failure", "failure", "failure", "success"},
+			wantEscal:  true,
+			wantTarget: "sonnet",
+		},
+		{
+			name:       "sonnet high failure -> opus",
+			model:      "sonnet",
+			outcomes:   []string{"failure", "failure", "failure", "success"},
+			wantEscal:  true,
+			wantTarget: "opus",
+		},
+		{
+			name:       "opus high failure -> no escalation",
+			model:      "opus",
+			outcomes:   []string{"failure", "failure", "failure"},
+			wantEscal:  false,
+			wantTarget: "",
+		},
+		{
+			name:       "haiku low failure -> no escalation",
+			model:      "haiku",
+			outcomes:   []string{"success", "success", "success", "failure"},
+			wantEscal:  false,
+			wantTarget: "",
+		},
+		{
+			name:       "unknown model -> no escalation",
+			model:      "unknown",
+			outcomes:   []string{"failure", "failure", "failure"},
+			wantEscal:  false,
+			wantTarget: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker, cleanup := newTestTracker(t)
+			defer cleanup()
+
+			for _, o := range tt.outcomes {
+				if err := tracker.RecordOutcome("task", tt.model, o, 500, time.Second); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			gotEscal, gotTarget := tracker.ShouldEscalate("task", tt.model)
+			if gotEscal != tt.wantEscal {
+				t.Errorf("ShouldEscalate = %v, want %v", gotEscal, tt.wantEscal)
+			}
+			if gotTarget != tt.wantTarget {
+				t.Errorf("escalation target = %q, want %q", gotTarget, tt.wantTarget)
+			}
+		})
+	}
+}
+
+func TestThresholdBoundary(t *testing.T) {
+	tracker, cleanup := newTestTracker(t)
+	defer cleanup()
+
+	// Exactly 30% failure (3/10) — should NOT escalate (threshold is >30%, not >=)
+	for i := 0; i < 7; i++ {
+		if err := tracker.RecordOutcome("task", "haiku", "success", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		if err := tracker.RecordOutcome("task", "haiku", "failure", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	escalate, _ := tracker.ShouldEscalate("task", "haiku")
+	if escalate {
+		t.Error("should not escalate at exactly 30% threshold")
+	}
+
+	// Add one more failure (4/10 = 40%) — should escalate
+	if err := tracker.RecordOutcome("task", "haiku", "failure", 100, time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	escalate, target := tracker.ShouldEscalate("task", "haiku")
+	if !escalate {
+		t.Error("should escalate at 40% failure rate")
+	}
+	if target != "sonnet" {
+		t.Errorf("expected sonnet, got %q", target)
+	}
+}
+
+func TestCustomThreshold(t *testing.T) {
+	tracker, cleanup := newTestTracker(t)
+	defer cleanup()
+
+	tracker.WithFailureThreshold(0.5)
+
+	// 40% failure — below custom 50% threshold
+	for i := 0; i < 6; i++ {
+		if err := tracker.RecordOutcome("task", "haiku", "success", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 4; i++ {
+		if err := tracker.RecordOutcome("task", "haiku", "failure", 100, time.Second); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	escalate, _ := tracker.ShouldEscalate("task", "haiku")
+	if escalate {
+		t.Error("should not escalate at 40% with 50% threshold")
+	}
+}
+
+func TestShouldEscalateEmptyData(t *testing.T) {
+	tracker, cleanup := newTestTracker(t)
+	defer cleanup()
+
+	escalate, target := tracker.ShouldEscalate("nonexistent", "haiku")
+	if escalate {
+		t.Error("should not escalate with no data")
+	}
+	if target != "" {
+		t.Errorf("expected empty target, got %q", target)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -236,6 +236,17 @@ func (s *Store) migrate() error {
 			component TEXT DEFAULT 'executor'
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_execution_logs_timestamp ON execution_logs(timestamp)`,
+		`CREATE TABLE IF NOT EXISTS model_outcomes (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			task_type TEXT NOT NULL,
+			model TEXT NOT NULL,
+			outcome TEXT NOT NULL,
+			tokens_used INTEGER DEFAULT 0,
+			duration_ms INTEGER DEFAULT 0,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_model_outcomes_task_model ON model_outcomes(task_type, model)`,
+		`CREATE INDEX IF NOT EXISTS idx_model_outcomes_created ON model_outcomes(created_at)`,
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1990.

Closes #1990

## Changes

GitHub Issue #1990: Add `model_outcomes` table and `ModelOutcomeTracker` in `internal/memory/`

Parent: GH-1988

Add the `model_outcomes` SQLite table with migration in `store.go` (using the existing `CREATE TABLE IF NOT EXISTS` + index pattern). Create a new `model_tracker.go` file with `ModelOutcomeTracker` struct that takes `*Store` and exposes: `RecordOutcome(taskType, model, outcome, tokens, duration) error`, `GetFailureRate(taskType, model) float64` (last 10 outcomes), and `ShouldEscalate(taskType, model) (bool, string)` (failure rate > 30% threshold, configurable). Add table-driven tests in `model_tracker_test.go` covering: recording outcomes, failure rate calculation, escalation logic (Haiku→Sonnet→Opus path), threshold boundary cases, and empty-data behavior.