### PR TITLE
docs(website): Version sync to v2.53.0 — stale versions, models, feature counts

### DIFF
--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -620,8 +620,8 @@ Displays the current Pilot version and build time.
 ```bash
 pilot version
 # Output:
-# Pilot v0.63.0
-# Built: 2024-01-15T10:30:00Z
+# Pilot v2.53.0
+# Built: 2026-03-01T10:30:00Z
 ```
 
 ---
@@ -2642,8 +2642,8 @@ pilot release --dry-run
 
 # Output:
 # Would create release:
-#   Current version: v2.38.11
-#   New version: v2.38.12
+#   Current version: v2.53.0
+#   New version: v2.53.1
 #   Bump type: patch
 #   Draft: false
 ```

--- a/docs/content/deployment/desktop-app.mdx
+++ b/docs/content/deployment/desktop-app.mdx
@@ -183,10 +183,10 @@ desktop/build/bin/Pilot.app
 ### (Optional) Package as a zip
 
 ```bash
-make desktop-package VERSION=v1.40.1
+make desktop-package VERSION=v2.53.0
 ```
 
-Produces `bin/Pilot-macOS-v1.40.1.zip`.
+Produces `bin/Pilot-macOS-v2.53.0.zip`.
 
 </Steps>
 

--- a/docs/content/deployment/docker-helm.mdx
+++ b/docs/content/deployment/docker-helm.mdx
@@ -52,7 +52,7 @@ Pilot starts polling for issues labeled `pilot` on the configured repository wit
 docker pull ghcr.io/anthropics/pilot:latest
 
 # Pin to a specific version (recommended for production)
-docker pull ghcr.io/anthropics/pilot:v1.40.1
+docker pull ghcr.io/anthropics/pilot:v2.53.0
 ```
 
 ### Build from Source
@@ -139,7 +139,7 @@ For production use with Telegram, Slack, and multiple adapters:
 ```yaml
 services:
   pilot:
-    image: ghcr.io/anthropics/pilot:v1.40.1
+    image: ghcr.io/anthropics/pilot:v2.53.0
     ports:
       - "9090:9090"
     environment:
@@ -252,7 +252,7 @@ helm install pilot ./helm/pilot \
 
 ```bash
 helm upgrade pilot ./helm/pilot --reuse-values \
-  --set image.tag=v1.40.1
+  --set image.tag=v2.53.0
 ```
 
 ### values.yaml Reference
@@ -261,7 +261,7 @@ helm upgrade pilot ./helm/pilot --reuse-values \
 # Image
 image:
   repository: ghcr.io/anthropics/pilot
-  tag: v1.40.1           # pin to a specific version in production
+  tag: v2.53.0           # pin to a specific version in production
   pullPolicy: IfNotPresent
 
 # Replica count — always 1 (SQLite constraint)
@@ -338,7 +338,7 @@ podSecurityContext:
 
 ```bash
 # Change image tag
-helm upgrade pilot ./helm/pilot --set image.tag=v1.41.0
+helm upgrade pilot ./helm/pilot --set image.tag=v2.53.0
 
 # Enable ingress
 helm upgrade pilot ./helm/pilot \

--- a/docs/content/features/budget.mdx
+++ b/docs/content/features/budget.mdx
@@ -142,9 +142,9 @@ Pilot uses Anthropic's published pricing for cost estimation:
 
 | Model | Input (per 1M tokens) | Output (per 1M tokens) |
 |-------|----------------------:|------------------------:|
-| Opus 4.6/4.5 | $5.00 | $25.00 |
+| Opus 4.6 | $5.00 | $25.00 |
 | Opus 4.1/4.0 | $15.00 | $75.00 |
-| Sonnet 4.5/4 | $3.00 | $15.00 |
+| Sonnet 4.6 | $3.00 | $15.00 |
 | Haiku 4.5 | $1.00 | $5.00 |
 
 <Callout type="info">
@@ -294,9 +294,9 @@ Pilot's effort routing automatically selects cost-effective models:
 | Task Type | Model | Typical Cost |
 |-----------|-------|--------------|
 | Trivial (typos, comments) | Haiku 4.5 | $0.01-0.05 |
-| Simple (small fixes) | Opus 4.5 | $0.10-0.50 |
-| Medium (features) | Opus 4.5 | $0.50-2.00 |
-| Complex (architecture) | Opus 4.5 | $2.00-5.00 |
+| Simple (small fixes) | Opus 4.6 | $0.10-0.50 |
+| Medium (features) | Opus 4.6 | $0.50-2.00 |
+| Complex (architecture) | Opus 4.6 | $2.00-5.00 |
 
 ### Batch Similar Tasks
 

--- a/docs/content/features/dashboard.mdx
+++ b/docs/content/features/dashboard.mdx
@@ -207,7 +207,7 @@ When a new Pilot version is detected, an orange notification appears:
 
 ```
 ╭─ ^ UPDATE ──────────────────────────────────────────────────────╮
-│  v0.62.0 -> v0.63.0 available                                   │
+│  v2.52.0 -> v2.53.0 available                                   │
 ╰─────────────────────────────────────────────────────────────────╯
                                                          u: upgrade
 ```
@@ -216,7 +216,7 @@ Press `u` to upgrade in-place. Progress is shown during download:
 
 ```
 ╭─ * UPGRADING ───────────────────────────────────────────────────╮
-│  Installing v0.63.0... [████████████░░░░░░] 65%                 │
+│  Installing v2.53.0... [████████████░░░░░░] 65%                 │
 ╰─────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/content/getting-started/installation.mdx
+++ b/docs/content/getting-started/installation.mdx
@@ -45,7 +45,7 @@ cp ./bin/pilot ~/.local/bin/pilot
 
 ```bash
 pilot --version
-# pilot version v2.38.11
+# pilot version v2.53.0
 ```
 
 Run the health check to verify all dependencies:

--- a/docs/content/getting-started/quickstart.mdx
+++ b/docs/content/getting-started/quickstart.mdx
@@ -38,7 +38,7 @@ Verify:
 
 ```bash
 pilot --version
-# pilot version v2.38.11
+# pilot version v2.53.0
 ```
 
 ### Run the Setup Wizard

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -9,7 +9,7 @@
 
 **AI that ships your tickets while you focus on architecture.**
 
-Pilot is an autonomous development pipeline with **240+ features** production-ready. It picks up tickets from GitHub Issues, GitLab Issues, Linear, Jira, Asana, Plane, or Discord — plans the implementation using your codebase context, writes code with Claude Code, runs quality gates, and opens a pull request. You review and merge.
+Pilot is an autonomous development pipeline with **250+ features** production-ready. It picks up tickets from GitHub Issues, GitLab Issues, Linear, Jira, Asana, Plane, or Discord — plans the implementation using your codebase context, writes code with Claude Code, runs quality gates, and opens a pull request. You review and merge.
 
 {/* ILLUSTRATION: Hero — Ticket → Pilot → PR flow diagram */}
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-1999.

Closes #1999

## Changes

GitHub Issue #1999: docs(website): Version sync to v2.53.0 — stale versions, models, feature counts

## Docs Website Version Sync to v2.53.0

**Priority**: P1

### Problem

9 docs files reference stale versions (v2.38.11, v1.40.1), outdated model names (Opus 4.5), and old feature counts (240+). Current version is v2.53.0 with 317 features in the matrix.

### Changes Required

**Version strings (v2.38.11 → v2.53.0):**
- `docs/content/getting-started/installation.mdx` line 48 — version output example
- `docs/content/getting-started/quickstart.mdx` line 41 — version output example

**Feature count (240+ → 250+):**
- `docs/content/index.mdx` line 12 — homepage hero

**Model names (4.5 → 4.6):**
- `docs/content/features/budget.mdx` lines 145-148, 296-299 — Opus 4.5/Sonnet 4.5 → Opus 4.6/Sonnet 4.6

**Docker/Helm tags (v1.40.1 → v2.53.0):**
- `docs/content/deployment/docker-helm.mdx` lines 55, 142, 255, 264, 341
- `docs/content/deployment/desktop-app.mdx` lines 186, 189

**Example output versions (cosmetic):**
- `docs/content/cli/commands.mdx` lines 623, 2645-2646
- `docs/content/features/dashboard.mdx` lines 210, 219

### Acceptance Criteria

- [ ] No references to v2.38.11 or v1.40.1 in docs content
- [ ] Homepage shows "250+ features"
- [ ] Budget docs reference Opus 4.6 / Sonnet 4.6
- [ ] Docker/Helm examples use v2.53.0 tag
- [ ] `npm run build` succeeds (no broken MDX)