### PR TITLE
Enhance knowledge graph with execution-aware methods (`internal/memory/`)

### DIFF
--- a/internal/memory/graph.go
+++ b/internal/memory/graph.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -204,6 +205,136 @@ func (kg *KnowledgeGraph) AddLearning(title, content string, metadata map[string
 		Metadata: metadata,
 	}
 	return kg.Add(node)
+}
+
+// AddExecutionLearning adds a learning node with relations linking task→files,
+// files→patterns, patterns→outcome. Unlike AddLearning which creates flat nodes,
+// this populates the Relations field to connect related concept nodes.
+func (kg *KnowledgeGraph) AddExecutionLearning(title, content string, filesChanged []string, patterns []string, outcome string) error {
+	now := time.Now()
+	nano := now.UnixNano()
+
+	learningID := fmt.Sprintf("exec_learning_%d", nano)
+	var relationIDs []string
+
+	// Create file nodes and collect their IDs
+	for i, file := range filesChanged {
+		fileID := fmt.Sprintf("file_%d_%d", nano, i)
+		fileNode := &GraphNode{
+			ID:    fileID,
+			Type:  "file",
+			Title: file,
+			Metadata: map[string]interface{}{
+				"learning_id": learningID,
+			},
+		}
+		if err := kg.Add(fileNode); err != nil {
+			return fmt.Errorf("add file node %q: %w", file, err)
+		}
+		relationIDs = append(relationIDs, fileID)
+	}
+
+	// Create pattern nodes and collect their IDs
+	for i, pattern := range patterns {
+		patternID := fmt.Sprintf("exec_pattern_%d_%d", nano, i)
+		patternNode := &GraphNode{
+			ID:    patternID,
+			Type:  "pattern",
+			Title: pattern,
+			Metadata: map[string]interface{}{
+				"learning_id": learningID,
+			},
+		}
+		if err := kg.Add(patternNode); err != nil {
+			return fmt.Errorf("add pattern node %q: %w", pattern, err)
+		}
+		relationIDs = append(relationIDs, patternID)
+	}
+
+	// Create outcome node
+	outcomeID := fmt.Sprintf("outcome_%d", nano)
+	outcomeNode := &GraphNode{
+		ID:    outcomeID,
+		Type:  "outcome",
+		Title: outcome,
+		Metadata: map[string]interface{}{
+			"learning_id": learningID,
+		},
+	}
+	if err := kg.Add(outcomeNode); err != nil {
+		return fmt.Errorf("add outcome node: %w", err)
+	}
+	relationIDs = append(relationIDs, outcomeID)
+
+	// Create the learning node with all relations
+	learningNode := &GraphNode{
+		ID:      learningID,
+		Type:    "execution_learning",
+		Title:   title,
+		Content: content,
+		Metadata: map[string]interface{}{
+			"files_changed": filesChanged,
+			"patterns":      patterns,
+			"outcome":       outcome,
+		},
+		Relations: relationIDs,
+	}
+	return kg.Add(learningNode)
+}
+
+// GetRelatedByKeywords searches nodes by keywords across title, content, and
+// metadata values. Returns matching nodes sorted by recency (newest first).
+func (kg *KnowledgeGraph) GetRelatedByKeywords(keywords []string) []*GraphNode {
+	if len(keywords) == 0 {
+		return nil
+	}
+
+	kg.mu.RLock()
+	defer kg.mu.RUnlock()
+
+	var results []*GraphNode
+	for _, node := range kg.nodes {
+		if kg.nodeMatchesKeywords(node, keywords) {
+			results = append(results, node)
+		}
+	}
+
+	// Sort by UpdatedAt descending (newest first)
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].UpdatedAt.After(results[j].UpdatedAt)
+	})
+
+	return results
+}
+
+// nodeMatchesKeywords checks if any keyword matches the node's title, content,
+// or metadata string values. All comparisons are case-insensitive.
+func (kg *KnowledgeGraph) nodeMatchesKeywords(node *GraphNode, keywords []string) bool {
+	titleLower := strings.ToLower(node.Title)
+	contentLower := strings.ToLower(node.Content)
+
+	for _, kw := range keywords {
+		kwLower := strings.ToLower(kw)
+		if strings.Contains(titleLower, kwLower) || strings.Contains(contentLower, kwLower) {
+			return true
+		}
+		// Search metadata values
+		for _, v := range node.Metadata {
+			switch val := v.(type) {
+			case string:
+				if strings.Contains(strings.ToLower(val), kwLower) {
+					return true
+				}
+			case []interface{}:
+				for _, item := range val {
+					if s, ok := item.(string); ok && strings.Contains(strings.ToLower(s), kwLower) {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
 }
 
 // GetPatterns retrieves all patterns

--- a/internal/memory/graph_test.go
+++ b/internal/memory/graph_test.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"os"
 	"testing"
+	"time"
 )
 
 func TestNewKnowledgeGraph(t *testing.T) {
@@ -428,5 +429,260 @@ func TestKnowledgeGraph_UpdateExistingNode(t *testing.T) {
 
 	if !got.UpdatedAt.After(originalCreatedAt) {
 		t.Error("UpdatedAt should be after CreatedAt after update")
+	}
+}
+
+func TestKnowledgeGraph_AddExecutionLearning(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	kg, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	files := []string{"internal/executor/runner.go", "internal/executor/monitor.go"}
+	patterns := []string{"error-handling", "retry-logic"}
+	outcome := "success"
+
+	if err := kg.AddExecutionLearning("Fix timeout bug", "Added retry with backoff", files, patterns, outcome); err != nil {
+		t.Fatalf("AddExecutionLearning() error = %v", err)
+	}
+
+	// Should have: 1 learning + 2 file nodes + 2 pattern nodes + 1 outcome = 6
+	if count := kg.Count(); count != 6 {
+		t.Errorf("Count() = %d, want 6", count)
+	}
+
+	// Verify the learning node has relations
+	learnings := kg.GetByType("execution_learning")
+	if len(learnings) != 1 {
+		t.Fatalf("GetByType('execution_learning') returned %d, want 1", len(learnings))
+	}
+
+	learning := learnings[0]
+	if learning.Title != "Fix timeout bug" {
+		t.Errorf("Title = %q, want %q", learning.Title, "Fix timeout bug")
+	}
+	if learning.Content != "Added retry with backoff" {
+		t.Errorf("Content = %q, want %q", learning.Content, "Added retry with backoff")
+	}
+	// 2 files + 2 patterns + 1 outcome = 5 relations
+	if len(learning.Relations) != 5 {
+		t.Errorf("Relations count = %d, want 5", len(learning.Relations))
+	}
+
+	// Verify related nodes are retrievable
+	related := kg.GetRelated(learning.ID)
+	if len(related) != 5 {
+		t.Errorf("GetRelated() returned %d, want 5", len(related))
+	}
+
+	// Verify metadata
+	if learning.Metadata["outcome"] != "success" {
+		t.Errorf("Metadata[outcome] = %v, want %q", learning.Metadata["outcome"], "success")
+	}
+
+	// Verify file nodes exist
+	fileNodes := kg.GetByType("file")
+	if len(fileNodes) != 2 {
+		t.Errorf("GetByType('file') returned %d, want 2", len(fileNodes))
+	}
+
+	// Verify outcome node exists
+	outcomeNodes := kg.GetByType("outcome")
+	if len(outcomeNodes) != 1 {
+		t.Errorf("GetByType('outcome') returned %d, want 1", len(outcomeNodes))
+	}
+	if outcomeNodes[0].Title != "success" {
+		t.Errorf("Outcome Title = %q, want %q", outcomeNodes[0].Title, "success")
+	}
+}
+
+func TestKnowledgeGraph_AddExecutionLearning_EmptyInputs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	kg, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	// Empty files and patterns — should still create learning + outcome
+	if err := kg.AddExecutionLearning("Minimal learning", "No files changed", nil, nil, "success"); err != nil {
+		t.Fatalf("AddExecutionLearning() error = %v", err)
+	}
+
+	// 1 learning + 1 outcome = 2
+	if count := kg.Count(); count != 2 {
+		t.Errorf("Count() = %d, want 2", count)
+	}
+
+	learnings := kg.GetByType("execution_learning")
+	if len(learnings) != 1 {
+		t.Fatalf("GetByType('execution_learning') returned %d, want 1", len(learnings))
+	}
+	// Only the outcome relation
+	if len(learnings[0].Relations) != 1 {
+		t.Errorf("Relations count = %d, want 1", len(learnings[0].Relations))
+	}
+}
+
+func TestKnowledgeGraph_GetRelatedByKeywords(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	kg, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	// Add execution learnings with a small time gap to ensure ordering
+	files1 := []string{"internal/executor/runner.go"}
+	if err := kg.AddExecutionLearning("Fix timeout bug", "Added retry with exponential backoff", files1, []string{"retry"}, "success"); err != nil {
+		t.Fatalf("AddExecutionLearning() error = %v", err)
+	}
+
+	// Small delay to ensure different timestamps
+	time.Sleep(10 * time.Millisecond)
+
+	files2 := []string{"internal/gateway/server.go"}
+	if err := kg.AddExecutionLearning("Add WebSocket auth", "Token validation for WebSocket connections", files2, []string{"auth"}, "success"); err != nil {
+		t.Fatalf("AddExecutionLearning() error = %v", err)
+	}
+
+	t.Run("search by title keyword", func(t *testing.T) {
+		results := kg.GetRelatedByKeywords([]string{"timeout"})
+		if len(results) == 0 {
+			t.Fatal("expected at least 1 result for keyword 'timeout'")
+		}
+		found := false
+		for _, r := range results {
+			if r.Title == "Fix timeout bug" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected to find 'Fix timeout bug' in results")
+		}
+	})
+
+	t.Run("search by content keyword", func(t *testing.T) {
+		results := kg.GetRelatedByKeywords([]string{"backoff"})
+		if len(results) == 0 {
+			t.Fatal("expected at least 1 result for keyword 'backoff'")
+		}
+	})
+
+	t.Run("search by metadata keyword", func(t *testing.T) {
+		results := kg.GetRelatedByKeywords([]string{"runner.go"})
+		if len(results) == 0 {
+			t.Fatal("expected at least 1 result for keyword 'runner.go'")
+		}
+	})
+
+	t.Run("case insensitive search", func(t *testing.T) {
+		results := kg.GetRelatedByKeywords([]string{"WEBSOCKET"})
+		if len(results) == 0 {
+			t.Fatal("expected at least 1 result for case-insensitive 'WEBSOCKET'")
+		}
+	})
+
+	t.Run("multiple keywords match union", func(t *testing.T) {
+		results := kg.GetRelatedByKeywords([]string{"timeout", "WebSocket"})
+		// Should find nodes from both learnings
+		if len(results) < 2 {
+			t.Errorf("expected at least 2 results for multiple keywords, got %d", len(results))
+		}
+	})
+
+	t.Run("sorted by recency", func(t *testing.T) {
+		results := kg.GetRelatedByKeywords([]string{"success"})
+		if len(results) < 2 {
+			t.Fatalf("expected at least 2 results, got %d", len(results))
+		}
+		// First result should be more recent than second
+		if results[0].UpdatedAt.Before(results[1].UpdatedAt) {
+			t.Error("results not sorted by recency (newest first)")
+		}
+	})
+
+	t.Run("empty keywords returns nil", func(t *testing.T) {
+		results := kg.GetRelatedByKeywords(nil)
+		if results != nil {
+			t.Errorf("expected nil for empty keywords, got %d results", len(results))
+		}
+
+		results = kg.GetRelatedByKeywords([]string{})
+		if results != nil {
+			t.Errorf("expected nil for empty slice, got %d results", len(results))
+		}
+	})
+
+	t.Run("no matches returns empty", func(t *testing.T) {
+		results := kg.GetRelatedByKeywords([]string{"nonexistent-keyword-xyz"})
+		if len(results) != 0 {
+			t.Errorf("expected 0 results for non-matching keyword, got %d", len(results))
+		}
+	})
+}
+
+func TestKnowledgeGraph_AddExecutionLearning_Persistence(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "kg-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create graph and add execution learning
+	kg1, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() error = %v", err)
+	}
+
+	if err := kg1.AddExecutionLearning("Persistent learning", "Should survive reload", []string{"file.go"}, []string{"pattern-a"}, "success"); err != nil {
+		t.Fatalf("AddExecutionLearning() error = %v", err)
+	}
+
+	// Reload from disk
+	kg2, err := NewKnowledgeGraph(tmpDir)
+	if err != nil {
+		t.Fatalf("NewKnowledgeGraph() reload error = %v", err)
+	}
+
+	learnings := kg2.GetByType("execution_learning")
+	if len(learnings) != 1 {
+		t.Fatalf("after reload: GetByType('execution_learning') returned %d, want 1", len(learnings))
+	}
+
+	if learnings[0].Title != "Persistent learning" {
+		t.Errorf("after reload: Title = %q, want %q", learnings[0].Title, "Persistent learning")
+	}
+
+	// Relations should persist
+	if len(learnings[0].Relations) != 3 {
+		t.Errorf("after reload: Relations count = %d, want 3", len(learnings[0].Relations))
+	}
+
+	// Related nodes should be retrievable after reload
+	related := kg2.GetRelated(learnings[0].ID)
+	if len(related) != 3 {
+		t.Errorf("after reload: GetRelated() returned %d, want 3", len(related))
+	}
+
+	// Keywords search should work after reload
+	results := kg2.GetRelatedByKeywords([]string{"Persistent"})
+	if len(results) == 0 {
+		t.Error("after reload: GetRelatedByKeywords found no results")
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2014.

Closes #2014

## Changes

- In `graph.go`: Add `AddExecutionLearning(title, content, filesChanged []string, patterns []string, outcome string)` that creates a learning node with proper relations linking task→files, files→patterns, patterns→outcome. Add `GetRelatedByKeywords(keywords []string) []*GraphNode` that searches nodes by keywords across title/content/metadata and returns relevant learnings sorted by recency. Current `AddLearning()` creates a flat node with no relations — the new method should populate the `Relations` field to connect task type, files, patterns, and outcome nodes.
- In `graph_test.go`: Add round-trip tests — add execution learning with files/patterns/outcome, query by keywords, verify related learnings appear in results. Test edge cases: empty keywords, no matches, multiple overlapping learnings.