### PR TITLE
feat(memory): add pattern_performance table with contextual confidence

### DIFF
--- a/internal/memory/feedback.go
+++ b/internal/memory/feedback.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 )
@@ -402,4 +403,63 @@ func (l *LearningLoop) ResetPatternStats(ctx context.Context, patternID string) 
 	pattern.Occurrences = 1
 	pattern.Confidence = 0.5 // Reset to neutral
 	return l.store.SaveCrossPattern(pattern)
+}
+
+// RecordPatternOutcome records a success or failure for a pattern in a specific
+// project/task-type context. Uses UPSERT on the (pattern_id, project_id, task_type)
+// unique constraint to accumulate counts and refresh last_used.
+func (s *Store) RecordPatternOutcome(patternID, projectID, taskType, model string, success bool) error {
+	return s.withRetry("RecordPatternOutcome", func() error {
+		if success {
+			_, err := s.db.Exec(`
+				INSERT INTO pattern_performance (pattern_id, project_id, task_type, model, success_count, failure_count, last_used)
+				VALUES (?, ?, ?, ?, 1, 0, CURRENT_TIMESTAMP)
+				ON CONFLICT(pattern_id, project_id, task_type) DO UPDATE SET
+					success_count = pattern_performance.success_count + 1,
+					model = excluded.model,
+					last_used = CURRENT_TIMESTAMP
+			`, patternID, projectID, taskType, model)
+			return err
+		}
+		_, err := s.db.Exec(`
+			INSERT INTO pattern_performance (pattern_id, project_id, task_type, model, success_count, failure_count, last_used)
+			VALUES (?, ?, ?, ?, 0, 1, CURRENT_TIMESTAMP)
+			ON CONFLICT(pattern_id, project_id, task_type) DO UPDATE SET
+				failure_count = pattern_performance.failure_count + 1,
+				model = excluded.model,
+				last_used = CURRENT_TIMESTAMP
+		`, patternID, projectID, taskType, model)
+		return err
+	})
+}
+
+// GetContextualConfidence computes a contextual confidence score for a pattern
+// in a given project and task type. The score combines:
+//   - Project-specific success rate (success / total outcomes)
+//   - Recency decay: 1.0 / (1.0 + daysSinceLastUse/30)
+//
+// Returns 0.5 (neutral) when no outcome data exists.
+func (s *Store) GetContextualConfidence(patternID, projectID, taskType string) float64 {
+	var successCount, failureCount int
+	var lastUsed time.Time
+
+	err := s.db.QueryRow(`
+		SELECT success_count, failure_count, last_used
+		FROM pattern_performance
+		WHERE pattern_id = ? AND project_id = ? AND task_type = ?
+	`, patternID, projectID, taskType).Scan(&successCount, &failureCount, &lastUsed)
+	if err != nil {
+		return 0.5 // No data — neutral default
+	}
+
+	total := successCount + failureCount
+	if total == 0 {
+		return 0.5
+	}
+
+	successRate := float64(successCount) / float64(total)
+	daysSince := time.Since(lastUsed).Hours() / 24.0
+	recencyDecay := 1.0 / (1.0 + daysSince/30.0)
+
+	return math.Min(1.0, successRate*recencyDecay)
 }

--- a/internal/memory/feedback_test.go
+++ b/internal/memory/feedback_test.go
@@ -1017,6 +1017,204 @@ func TestLearnFromCIFailure_CheckNameTagging(t *testing.T) {
 	}
 }
 
+func TestRecordPatternOutcomeAndContextualConfidence(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pattern-perf-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T)
+		patternID  string
+		projectID  string
+		taskType   string
+		wantMin    float64
+		wantMax    float64
+	}{
+		{
+			name:      "fresh pattern returns default 0.5",
+			setup:     func(t *testing.T) {},
+			patternID: "nonexistent-pattern",
+			projectID: "proj-a",
+			taskType:  "feat",
+			wantMin:   0.5,
+			wantMax:   0.5,
+		},
+		{
+			name: "100% success rate with fresh timestamp",
+			setup: func(t *testing.T) {
+				for i := 0; i < 5; i++ {
+					if err := store.RecordPatternOutcome("fresh-success", "proj-a", "feat", "opus", true); err != nil {
+						t.Fatalf("RecordPatternOutcome failed: %v", err)
+					}
+				}
+			},
+			patternID: "fresh-success",
+			projectID: "proj-a",
+			taskType:  "feat",
+			// successRate=1.0, recency≈1.0 (just recorded) → ~1.0
+			wantMin: 0.95,
+			wantMax: 1.0,
+		},
+		{
+			name: "mixed outcomes 60% success",
+			setup: func(t *testing.T) {
+				for i := 0; i < 3; i++ {
+					if err := store.RecordPatternOutcome("mixed-pat", "proj-b", "fix", "sonnet", true); err != nil {
+						t.Fatalf("RecordPatternOutcome failed: %v", err)
+					}
+				}
+				for i := 0; i < 2; i++ {
+					if err := store.RecordPatternOutcome("mixed-pat", "proj-b", "fix", "sonnet", false); err != nil {
+						t.Fatalf("RecordPatternOutcome failed: %v", err)
+					}
+				}
+			},
+			patternID: "mixed-pat",
+			projectID: "proj-b",
+			taskType:  "fix",
+			// successRate=0.6, recency≈1.0 → ~0.6
+			wantMin: 0.55,
+			wantMax: 0.65,
+		},
+		{
+			name: "cross-project divergence — high success project",
+			setup: func(t *testing.T) {
+				for i := 0; i < 8; i++ {
+					if err := store.RecordPatternOutcome("diverge-pat", "proj-high", "refactor", "opus", true); err != nil {
+						t.Fatalf("RecordPatternOutcome failed: %v", err)
+					}
+				}
+				for i := 0; i < 2; i++ {
+					if err := store.RecordPatternOutcome("diverge-pat", "proj-high", "refactor", "opus", false); err != nil {
+						t.Fatalf("RecordPatternOutcome failed: %v", err)
+					}
+				}
+			},
+			patternID: "diverge-pat",
+			projectID: "proj-high",
+			taskType:  "refactor",
+			// successRate=0.8, recency≈1.0 → ~0.8
+			wantMin: 0.75,
+			wantMax: 0.85,
+		},
+		{
+			name: "cross-project divergence — low success project",
+			setup: func(t *testing.T) {
+				for i := 0; i < 2; i++ {
+					if err := store.RecordPatternOutcome("diverge-pat", "proj-low", "refactor", "opus", true); err != nil {
+						t.Fatalf("RecordPatternOutcome failed: %v", err)
+					}
+				}
+				for i := 0; i < 8; i++ {
+					if err := store.RecordPatternOutcome("diverge-pat", "proj-low", "refactor", "opus", false); err != nil {
+						t.Fatalf("RecordPatternOutcome failed: %v", err)
+					}
+				}
+			},
+			patternID: "diverge-pat",
+			projectID: "proj-low",
+			taskType:  "refactor",
+			// successRate=0.2, recency≈1.0 → ~0.2
+			wantMin: 0.15,
+			wantMax: 0.25,
+		},
+		{
+			name: "mixed task types — feat vs fix same pattern",
+			setup: func(t *testing.T) {
+				for i := 0; i < 5; i++ {
+					if err := store.RecordPatternOutcome("tasktype-pat", "proj-c", "feat", "sonnet", true); err != nil {
+						t.Fatalf("RecordPatternOutcome failed: %v", err)
+					}
+				}
+				for i := 0; i < 5; i++ {
+					if err := store.RecordPatternOutcome("tasktype-pat", "proj-c", "fix", "sonnet", false); err != nil {
+						t.Fatalf("RecordPatternOutcome failed: %v", err)
+					}
+				}
+			},
+			patternID: "tasktype-pat",
+			projectID: "proj-c",
+			taskType:  "feat",
+			// feat: 5 success, 0 fail → rate=1.0, recency≈1.0
+			wantMin: 0.95,
+			wantMax: 1.0,
+		},
+		{
+			name: "UPSERT accumulates correctly",
+			setup: func(t *testing.T) {
+				// Record same combo multiple times
+				if err := store.RecordPatternOutcome("upsert-pat", "proj-d", "test", "haiku", true); err != nil {
+					t.Fatalf("RecordPatternOutcome failed: %v", err)
+				}
+				if err := store.RecordPatternOutcome("upsert-pat", "proj-d", "test", "haiku", true); err != nil {
+					t.Fatalf("RecordPatternOutcome failed: %v", err)
+				}
+				if err := store.RecordPatternOutcome("upsert-pat", "proj-d", "test", "haiku", false); err != nil {
+					t.Fatalf("RecordPatternOutcome failed: %v", err)
+				}
+			},
+			patternID: "upsert-pat",
+			projectID: "proj-d",
+			taskType:  "test",
+			// 2 success, 1 failure → rate=0.667, recency≈1.0
+			wantMin: 0.6,
+			wantMax: 0.7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup(t)
+			got := store.GetContextualConfidence(tt.patternID, tt.projectID, tt.taskType)
+			if got < tt.wantMin || got > tt.wantMax {
+				t.Errorf("GetContextualConfidence() = %f, want [%f, %f]", got, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestGetContextualConfidence_DecayedPattern(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pattern-perf-decay-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Insert a record with an old last_used timestamp (90 days ago)
+	_, err = store.db.Exec(`
+		INSERT INTO pattern_performance (pattern_id, project_id, task_type, model, success_count, failure_count, last_used)
+		VALUES (?, ?, ?, ?, 10, 0, ?)
+	`, "old-pattern", "proj-e", "feat", "opus", time.Now().AddDate(0, 0, -90).Format("2006-01-02 15:04:05"))
+	if err != nil {
+		t.Fatalf("failed to insert old pattern: %v", err)
+	}
+
+	got := store.GetContextualConfidence("old-pattern", "proj-e", "feat")
+	// successRate=1.0, recencyDecay = 1/(1+90/30) = 1/4 = 0.25
+	// contextual = 1.0 * 0.25 = 0.25
+	if got > 0.26 {
+		t.Errorf("Decayed pattern confidence = %f, want <= 0.25", got)
+	}
+	if got < 0.20 {
+		t.Errorf("Decayed pattern confidence = %f, want >= 0.20 (should be ~0.25)", got)
+	}
+}
+
 func TestLearnFromReview_NoReviews(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "feedback-test-*")
 	if err != nil {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -247,6 +247,20 @@ func (s *Store) migrate() error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_model_outcomes_task_model ON model_outcomes(task_type, model)`,
 		`CREATE INDEX IF NOT EXISTS idx_model_outcomes_created ON model_outcomes(created_at)`,
+		// Pattern performance tracking (GH-2020)
+		`CREATE TABLE IF NOT EXISTS pattern_performance (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			pattern_id TEXT NOT NULL,
+			project_id TEXT NOT NULL,
+			task_type TEXT NOT NULL,
+			model TEXT NOT NULL DEFAULT '',
+			success_count INTEGER DEFAULT 0,
+			failure_count INTEGER DEFAULT 0,
+			last_used DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(pattern_id, project_id, task_type)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_pattern_performance_pattern ON pattern_performance(pattern_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_pattern_performance_project ON pattern_performance(project_id)`,
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Summary
- Add `pattern_performance` SQLite table migration with UNIQUE constraint on `(pattern_id, project_id, task_type)`
- Implement `RecordPatternOutcome()` with UPSERT to accumulate success/failure counts per pattern-project-task combo
- Implement `GetContextualConfidence()` combining project-specific success rate with recency decay formula `1.0 / (1.0 + daysSinceLastUse/30)`
- Returns 0.5 (neutral) when no outcome data exists

## Test plan
- [x] Fresh pattern returns default 0.5
- [x] 100% success rate with fresh timestamp → ~1.0
- [x] Mixed outcomes (60% success) → ~0.6
- [x] Cross-project divergence: high-success project (80%) vs low-success project (20%)
- [x] Mixed task types: same pattern, different task types tracked independently
- [x] UPSERT accumulates correctly on unique constraint
- [x] Decayed pattern (90+ days old) → ≤25% confidence
- [x] All existing feedback tests pass

Closes #2020