### PR TITLE
fix(ci): Enable auto-merge on docs-version-sync PRs

### DIFF
--- a/.github/workflows/docs-version-sync.yml
+++ b/.github/workflows/docs-version-sync.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true'
+        id: pr
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,3 +62,12 @@ jobs:
           branch: docs/version-sync-${{ steps.version.outputs.VERSION }}
           base: main
           labels: documentation
+
+      - name: Enable auto-merge
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${{ steps.pr.outputs.pull-request-number }}" ]; then
+            gh pr merge "${{ steps.pr.outputs.pull-request-number }}" --auto --squash
+          fi

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -45,7 +45,7 @@ export default async function RootLayout({
               logo={
                 <span style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
                   <img src="/logo.svg" alt="Pilot" height={24} style={{ height: 24, width: 'auto', alignSelf: 'center' }} />
-                  <span style={{ fontSize: '0.5em', opacity: 0.5, fontWeight: 400 }}>v2.38.11</span>
+                  <span style={{ fontSize: '0.5em', opacity: 0.5, fontWeight: 400 }}>v2.56.0</span>
                 </span>
               }
               projectLink="https://github.com/alekspetrov/pilot"


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2026.

Closes #2026

## Changes

GitHub Issue #2026: fix(ci): Enable auto-merge on docs-version-sync PRs

## Auto-Merge Version Sync PRs

### Problem

`docs-version-sync.yml` creates PRs on every release to update version strings in docs, but they require manual merge. From v2.38.11 to v2.56.0, sync PRs were superseded without merging. The docs header is stuck at v2.38.11.

### Fix

In `.github/workflows/docs-version-sync.yml`, add a step after PR creation to enable GitHub auto-merge:

```yaml
      - name: Enable auto-merge
        if: steps.changes.outputs.changed == 'true'
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
          # Wait for PR to be created
          sleep 5
          PR_NUM=$(gh pr list --head "docs/version-sync-${{ steps.version.outputs.VERSION }}" --json number --jq '.[0].number')
          if [ -n "$PR_NUM" ]; then
            gh pr merge "$PR_NUM" --auto --squash
          fi
```

### Also

Update `docs/app/layout.tsx` line 48 version badge from `v2.38.11` to `v2.56.0` to fix the current stale version.

### Acceptance Criteria

- [ ] Workflow enables auto-merge on the created PR
- [ ] `docs/app/layout.tsx` shows `v2.56.0`
- [ ] Next release tag auto-syncs and auto-merges version without manual intervention