### PR TITLE
fix(poller): Filter out pull requests from issue polling

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -75,9 +75,10 @@ type Issue struct {
 	Assignee  *User     `json:"assignee"`
 	Assignees []User    `json:"assignees"`
 	User      User      `json:"user"` // Issue author
-	HTMLURL   string    `json:"html_url"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	HTMLURL     string    `json:"html_url"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	PullRequest *struct{} `json:"pull_request,omitempty"` // Non-nil when item is a PR (GitHub Issues API returns both)
 }
 
 // Label represents a GitHub label

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -488,6 +488,11 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 	// Filter out already processed and in-progress issues
 	var candidates []*Issue
 	for _, issue := range issues {
+		// Skip pull requests (GitHub Issues API returns both issues and PRs)
+		if issue.PullRequest != nil {
+			continue
+		}
+
 		// Skip if has status labels
 		if HasLabel(issue, LabelInProgress) || HasLabel(issue, LabelDone) || HasLabel(issue, LabelFailed) {
 			continue
@@ -645,6 +650,11 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 	// Phase 1: Collect candidates eligible for dispatch
 	var candidates []*Issue
 	for _, issue := range issues {
+		// Skip pull requests (GitHub Issues API returns both issues and PRs)
+		if issue.PullRequest != nil {
+			continue
+		}
+
 		// Skip if already in progress or failed (check before processed to allow retry)
 		if HasLabel(issue, LabelInProgress) || HasLabel(issue, LabelFailed) {
 			continue

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -1762,3 +1762,77 @@ func TestPoller_FindOldestUnprocessedIssue_SkipsRetryWithMergedPRs(t *testing.T)
 		t.Errorf("findOldestUnprocessedIssue() returned issue %d, want nil (should skip issue with merged PRs)", issue.Number)
 	}
 }
+
+func TestPoller_CheckForNewIssues_SkipsPullRequests(t *testing.T) {
+	pr := &struct{}{}
+	items := []*Issue{
+		{Number: 1, Title: "Real issue", Labels: []Label{{Name: "pilot"}}},
+		{Number: 2, Title: "A pull request", Labels: []Label{{Name: "pilot"}}, PullRequest: pr},
+		{Number: 3, Title: "Another issue", Labels: []Label{{Name: "pilot"}}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(items)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var dispatched []int
+	var mu sync.Mutex
+
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			mu.Lock()
+			dispatched = append(dispatched, issue.Number)
+			mu.Unlock()
+			return nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(dispatched) != 2 {
+		t.Fatalf("dispatched %d issues, want 2 (PRs should be skipped)", len(dispatched))
+	}
+
+	for _, num := range dispatched {
+		if num == 2 {
+			t.Errorf("PR (issue #2) should not have been dispatched")
+		}
+	}
+}
+
+func TestPoller_FindOldestUnprocessedIssue_SkipsPullRequests(t *testing.T) {
+	pr := &struct{}{}
+	now := time.Now()
+	items := []*Issue{
+		{Number: 10, Title: "A pull request", Labels: []Label{{Name: "pilot"}}, PullRequest: pr, CreatedAt: now.Add(-2 * time.Hour)},
+		{Number: 20, Title: "Real issue", Labels: []Label{{Name: "pilot"}}, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(items)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil {
+		t.Fatal("expected an issue, got nil")
+	}
+	if issue.Number != 20 {
+		t.Errorf("got issue #%d, want #20 (PR #10 should be skipped)", issue.Number)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2025.

Closes #2025

## Changes

GitHub Issue #2025: fix(poller): Filter out pull requests from issue polling

## Bug: Poller picks up PRs as tasks

### Problem

GitHub's Issues API (`/repos/{owner}/{repo}/issues`) returns both issues AND pull requests when filtering by label. The poller in `internal/adapters/github/poller.go` has no PR filtering — if a PR has the `pilot` label, Pilot will try to execute it as a task.

This is a latent bug for all users. Any PR with `pilot` label (manually added, from CI workflows, or accidental) would trigger spurious task execution.

### Fix

In `internal/adapters/github/poller.go`, the `Issue` struct from the GitHub API includes a `PullRequest` field (non-nil when the item is a PR). Filter these out in both `findOldestUnprocessedIssue()` and `checkForNewIssues()`.

1. Add `PullRequest` field to the Issue struct if not already present:
   ```go
   PullRequest *struct{} `json:"pull_request,omitempty"`
   ```

2. Skip PRs early in both polling paths:
   ```go
   if issue.PullRequest != nil {
       continue
   }
   ```

### Files to Modify

- `internal/adapters/github/poller.go` — add PR field to Issue struct, add filter in both polling functions
- `internal/adapters/github/poller_test.go` — test that PR items are skipped

### Acceptance Criteria

- [ ] Issue struct has `PullRequest` field mapped from GitHub API
- [ ] `findOldestUnprocessedIssue()` skips items where PullRequest is non-nil
- [ ] `checkForNewIssues()` skips items where PullRequest is non-nil
- [ ] Test: mock response with mixed issues and PRs — only issues dispatched
- [ ] Existing poller tests pass