### PR TITLE
fix(labels): Remove stale pilot-failed in hasMergedWork and notifyExternalClose

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -936,6 +936,13 @@ func (p *Poller) hasMergedWork(ctx context.Context, issue *Issue) bool {
 			slog.Any("error", err),
 		)
 	}
+	// Remove stale pilot-failed label (GH-1302 gap)
+	if err := p.client.RemoveLabel(ctx, p.owner, p.repo, issue.Number, LabelFailed); err != nil {
+		p.logger.Debug("Failed to remove pilot-failed (may not exist)",
+			slog.Int("issue", issue.Number),
+			slog.Any("error", err),
+		)
+	}
 	p.markProcessed(issue.Number)
 	return true
 }

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1718,6 +1718,10 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelInProgress); err != nil {
 			c.log.Warn("failed to remove pilot-in-progress label", "issue", prState.IssueNumber, "error", err)
 		}
+		// Remove stale pilot-failed label (GH-1302 gap)
+		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelFailed); err != nil {
+			c.log.Debug("failed to remove pilot-failed (may not exist)", "issue", prState.IssueNumber, "error", err)
+		}
 		c.log.Info("marked issue as pilot-retry-ready (PR closed without merge)", "issue", prState.IssueNumber, "pr", prState.PRNumber)
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2029.

Closes #2029

## Changes

GitHub Issue #2029: fix(labels): Remove stale pilot-failed in hasMergedWork and notifyExternalClose

## Bug: Stale pilot-failed Labels on Retry Success

**Priority**: P0 | **Related**: GH-1302 (v1.8.1 partial fix)

### Problem

When decomposed sub-issues fail then succeed on retry, the `pilot-failed` label persists alongside `pilot-done`. Example: issues #2021, #2020, #2016, #2015, #2014 all show both labels.

GH-1302 (v1.8.1) fixed this in 3 of 5 code paths but missed 2:

### Gap 1: `hasMergedWork()` in poller.go

**File**: `internal/adapters/github/poller.go`, `hasMergedWork()` function (around line 933)

Currently:
```go
p.client.AddLabels(ctx, p.owner, p.repo, issue.Number, []string{LabelDone})
p.markProcessed(issue.Number)
```

Missing:
```go
// Remove stale pilot-failed label (GH-1302 gap)
if err := p.client.RemoveLabel(ctx, p.owner, p.repo, issue.Number, LabelFailed); err != nil {
    p.logger.Debug("Failed to remove pilot-failed (may not exist)", slog.Any("error", err))
}
```

### Gap 2: `notifyExternalClose()` in controller.go

**File**: `internal/autopilot/controller.go`, `notifyExternalClose()` function (around line 1715)

Currently adds `pilot-retry-ready` and removes `pilot-in-progress`, but does NOT remove `pilot-failed`.

Add after the existing `RemoveLabel` call:
```go
// Remove stale pilot-failed label (GH-1302 gap)
if err := c.github.RemoveLabel(ctx, owner, repo, issueNum, github.LabelFailed); err != nil {
    c.logger.Debug("Failed to remove pilot-failed (may not exist)", slog.Any("error", err))
}
```

### Context: All 5 Code Paths

| Path | Location | Removes pilot-failed? |
|------|----------|----------------------|
| Handler success | `handlers.go:299` | Yes (GH-1302) |
| Autopilot merge | `controller.go:758` | Yes (GH-1302) |
| External merge | `controller.go:1657` | Yes (GH-1302) |
| **hasMergedWork** | **poller.go:933** | **No — FIX THIS** |
| **notifyExternalClose** | **controller.go:1715** | **No — FIX THIS** |

### Files to Modify

- `internal/adapters/github/poller.go` — add `RemoveLabel(LabelFailed)` in `hasMergedWork()`
- `internal/autopilot/controller.go` — add `RemoveLabel(LabelFailed)` in `notifyExternalClose()`

### Acceptance Criteria

- [ ] `hasMergedWork()` removes `pilot-failed` label when adding `pilot-done`
- [ ] `notifyExternalClose()` removes `pilot-failed` label when adding `pilot-retry-ready`
- [ ] Both use Debug-level logging for 404 errors (label may not exist)
- [ ] Pattern matches existing GH-1302 fix style (unconditional remove, silent 404)
- [ ] Existing poller and controller tests pass