### PR TITLE
Wire Discord handler into polling mode (TASK-10)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2056,6 +2056,28 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 		logging.WithComponent("start").Info("Slack Socket Mode started in polling mode")
 	}
 
+	// Start Discord bot if enabled (TASK-10)
+	var discordHandler *discord.Handler
+	if cfg.Adapters.Discord != nil && cfg.Adapters.Discord.Enabled &&
+		cfg.Adapters.Discord.BotToken != "" {
+		discordHandler = discord.NewHandler(&discord.HandlerConfig{
+			BotToken:        cfg.Adapters.Discord.BotToken,
+			AllowedGuilds:   cfg.Adapters.Discord.AllowedGuilds,
+			AllowedChannels: cfg.Adapters.Discord.AllowedChannels,
+		}, runner)
+
+		go func() {
+			if err := discordHandler.StartListening(ctx); err != nil {
+				logging.WithComponent("discord").Error("Discord bot error", slog.Any("error", err))
+			}
+		}()
+
+		if !dashboardMode {
+			fmt.Println("🎮 Discord bot started")
+		}
+		logging.WithComponent("start").Info("Discord bot started in polling mode")
+	}
+
 	// Start brief scheduler if enabled
 	var briefScheduler *briefs.Scheduler
 	if cfg.Orchestrator.DailyBrief != nil && cfg.Orchestrator.DailyBrief.Enabled {
@@ -2254,6 +2276,9 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 		if tgHandler != nil {
 			tgHandler.Stop()
 		}
+		if discordHandler != nil {
+			discordHandler.Stop()
+		}
 		// ghPoller stops via context cancellation (no explicit stop needed)
 		if dispatcher != nil {
 			dispatcher.Stop()
@@ -2276,6 +2301,9 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 
 	if tgHandler != nil {
 		tgHandler.Stop()
+	}
+	if discordHandler != nil {
+		discordHandler.Stop()
 	}
 	if len(ghPollers) > 0 {
 		fmt.Printf("🐙 Stopping GitHub pollers (%d)...\n", len(ghPollers))


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2041.

Closes #2041

## Changes

GitHub Issue #2041: Wire Discord handler into polling mode (TASK-10)

## Summary

Discord adapter is fully implemented (`internal/adapters/discord/`) but never instantiated in `cmd/pilot/main.go`. The `--discord` CLI flag exists and toggles config, but no handler is created. `pilot start --discord` does nothing for Discord.

## What to do

### 1. Wire Discord handler in `cmd/pilot/main.go`

Insert after Slack Socket Mode block (after the `logging.WithComponent("start").Info("Slack Socket Mode started in polling mode")` line), following the same pattern:

```go
// Start Discord bot if enabled (TASK-10)
var discordHandler *discord.Handler
if cfg.Adapters.Discord != nil && cfg.Adapters.Discord.Enabled &&
    cfg.Adapters.Discord.BotToken != "" {
    discordHandler = discord.NewHandler(&discord.HandlerConfig{
        BotToken:        cfg.Adapters.Discord.BotToken,
        AllowedGuilds:   cfg.Adapters.Discord.AllowedGuilds,
        AllowedChannels: cfg.Adapters.Discord.AllowedChannels,
    }, runner)

    go func() {
        if err := discordHandler.StartListening(ctx); err != nil {
            logging.WithComponent("discord").Error("Discord bot error", slog.Any("error", err))
        }
    }()

    if !dashboardMode {
        fmt.Println("🎮 Discord bot started")
    }
    logging.WithComponent("start").Info("Discord bot started in polling mode")
}
```

### 2. Add graceful shutdown

Find the cleanup/shutdown section where `tgHandler` and `slackHandler` are stopped. Add:

```go
if discordHandler != nil {
    discordHandler.Stop()
}
```

### 3. Update example config

Add discord section to `configs/pilot.example.yaml` if not already present.

## Files to modify

- `cmd/pilot/main.go` — handler init + startup + shutdown (~20 lines)

## Existing code (no changes needed)

- `internal/adapters/discord/handler.go` — `NewHandler()`, `StartListening()`, `Stop()`
- `internal/adapters/discord/types.go` — `Config`, `HandlerConfig`
- `internal/config/config.go` — Already has `Discord *discord.Config` in `AdaptersConfig`

## Verification

```bash
make build && make test
```

## Acceptance Criteria

- [ ] `pilot start --discord` instantiates Discord handler and connects to Gateway
- [ ] Handler receives and processes Discord messages
- [ ] Graceful shutdown on context cancellation
- [ ] Build and tests pass