### PR TITLE
Register Asana and Plane webhook handlers in pilot.go

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -8,10 +8,12 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/alekspetrov/pilot/internal/adapters/asana"
 	"github.com/alekspetrov/pilot/internal/adapters/github"
 	"github.com/alekspetrov/pilot/internal/adapters/gitlab"
 	"github.com/alekspetrov/pilot/internal/adapters/jira"
 	"github.com/alekspetrov/pilot/internal/adapters/linear"
+	"github.com/alekspetrov/pilot/internal/adapters/plane"
 	"github.com/alekspetrov/pilot/internal/adapters/slack"
 	"github.com/alekspetrov/pilot/internal/executor"
 	"github.com/alekspetrov/pilot/internal/logging"
@@ -440,6 +442,69 @@ func (o *Orchestrator) ProcessJiraTicket(ctx context.Context, task *jira.TaskInf
 	}
 
 	// Queue task
+	o.QueueTask(internalTask)
+
+	return nil
+}
+
+// ProcessAsanaTicket processes a new ticket from Asana (GH-2044)
+func (o *Orchestrator) ProcessAsanaTicket(ctx context.Context, task *asana.TaskInfo, projectPath string) error {
+	ticket := &TicketData{
+		ID:          task.ID,
+		Identifier:  task.ID,
+		Title:       task.Title,
+		Description: task.Description,
+		Priority:    int(task.Priority),
+		Labels:      task.Labels,
+		Project:     task.ProjectName,
+	}
+
+	doc, err := o.bridge.PlanTicket(ctx, ticket)
+	if err != nil {
+		return fmt.Errorf("failed to plan ticket: %w", err)
+	}
+
+	if err := o.saveTaskDocument(projectPath, doc); err != nil {
+		logging.WithComponent("orchestrator").Warn("Failed to save task document", slog.Any("error", err))
+	}
+
+	internalTask := &Task{
+		ID:          doc.ID,
+		Document:    doc,
+		ProjectPath: projectPath,
+		Branch:      fmt.Sprintf("pilot/%s", task.ID),
+		Priority:    float64(task.Priority),
+	}
+
+	o.QueueTask(internalTask)
+
+	return nil
+}
+
+// ProcessPlaneTicket processes a new ticket from Plane (GH-2044)
+func (o *Orchestrator) ProcessPlaneTicket(ctx context.Context, item *plane.WebhookWorkItemData, projectPath string) error {
+	ticket := &TicketData{
+		ID:         item.ID,
+		Identifier: fmt.Sprintf("PLANE-%d", item.SequenceID),
+		Title:      item.Name,
+	}
+
+	doc, err := o.bridge.PlanTicket(ctx, ticket)
+	if err != nil {
+		return fmt.Errorf("failed to plan ticket: %w", err)
+	}
+
+	if err := o.saveTaskDocument(projectPath, doc); err != nil {
+		logging.WithComponent("orchestrator").Warn("Failed to save task document", slog.Any("error", err))
+	}
+
+	internalTask := &Task{
+		ID:          doc.ID,
+		Document:    doc,
+		ProjectPath: projectPath,
+		Branch:      fmt.Sprintf("pilot/PLANE-%d", item.SequenceID),
+	}
+
 	o.QueueTask(internalTask)
 
 	return nil

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -8,11 +8,13 @@ import (
 	"log/slog"
 	"sync"
 
+	"github.com/alekspetrov/pilot/internal/adapters/asana"
 	"github.com/alekspetrov/pilot/internal/adapters/azuredevops"
 	"github.com/alekspetrov/pilot/internal/adapters/github"
 	"github.com/alekspetrov/pilot/internal/adapters/gitlab"
 	"github.com/alekspetrov/pilot/internal/adapters/jira"
 	"github.com/alekspetrov/pilot/internal/adapters/linear"
+	"github.com/alekspetrov/pilot/internal/adapters/plane"
 	"github.com/alekspetrov/pilot/internal/adapters/slack"
 	"github.com/alekspetrov/pilot/internal/adapters/telegram"
 	"github.com/alekspetrov/pilot/internal/alerts"
@@ -46,6 +48,9 @@ type Pilot struct {
 	jiraWH                 *jira.WebhookHandler
 	azureDevOpsClient      *azuredevops.Client
 	azureDevOpsWH          *azuredevops.WebhookHandler
+	asanaClient            *asana.Client
+	asanaWH                *asana.WebhookHandler
+	planeWH                *plane.WebhookHandler
 	slackNotify            *slack.Notifier
 	slackClient            *slack.Client
 	slackInteractionWH     *slack.InteractionHandler
@@ -355,6 +360,27 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 		}
 	}
 
+	// GH-2044: Initialize Asana adapter if enabled
+	if cfg.Adapters.Asana != nil && cfg.Adapters.Asana.Enabled {
+		p.asanaClient = asana.NewClient(cfg.Adapters.Asana.AccessToken, cfg.Adapters.Asana.WorkspaceID)
+		pilotTag := cfg.Adapters.Asana.PilotTag
+		if pilotTag == "" {
+			pilotTag = "pilot"
+		}
+		p.asanaWH = asana.NewWebhookHandler(p.asanaClient, cfg.Adapters.Asana.WebhookSecret, pilotTag)
+		p.asanaWH.OnTask(p.handleAsanaTask)
+	}
+
+	// GH-2044: Initialize Plane adapter if enabled
+	if cfg.Adapters.Plane != nil && cfg.Adapters.Plane.Enabled {
+		pilotLabel := cfg.Adapters.Plane.PilotLabel
+		if pilotLabel == "" {
+			pilotLabel = "pilot"
+		}
+		p.planeWH = plane.NewWebhookHandler(cfg.Adapters.Plane.WebhookSecret, pilotLabel, cfg.Adapters.Plane.ProjectIDs)
+		p.planeWH.OnWorkItem(p.handlePlaneWorkItem)
+	}
+
 	// Initialize alerts engine if enabled
 	if cfg.Alerts != nil && cfg.Alerts.Enabled {
 		p.initAlerts(cfg)
@@ -450,6 +476,41 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 
 			if err := p.azureDevOpsWH.Handle(ctx, &webhookPayload); err != nil {
 				logging.WithComponent("pilot").Error("Azure DevOps webhook error", slog.Any("error", err))
+			}
+		})
+	}
+
+	// GH-2044: Register Asana webhook handler
+	if p.asanaWH != nil {
+		p.gateway.Router().RegisterWebhookHandler("asana", func(payload map[string]interface{}) {
+			// Parse the map payload into WebhookPayload
+			payloadBytes, err := json.Marshal(payload)
+			if err != nil {
+				logging.WithComponent("pilot").Error("Failed to marshal Asana payload", slog.Any("error", err))
+				return
+			}
+
+			var webhookPayload asana.WebhookPayload
+			if err := json.Unmarshal(payloadBytes, &webhookPayload); err != nil {
+				logging.WithComponent("pilot").Error("Failed to parse Asana webhook payload", slog.Any("error", err))
+				return
+			}
+
+			if err := p.asanaWH.Handle(ctx, &webhookPayload); err != nil {
+				logging.WithComponent("pilot").Error("Asana webhook error", slog.Any("error", err))
+			}
+		})
+	}
+
+	// GH-2044: Register Plane webhook handler
+	if p.planeWH != nil {
+		p.gateway.Router().RegisterWebhookHandler("plane", func(payload map[string]interface{}) {
+			// Plane handler needs raw bytes + signature for HMAC verification
+			rawBody, _ := payload["_raw_body"].(string)
+			signature, _ := payload["_signature"].(string)
+
+			if err := p.planeWH.Handle(ctx, []byte(rawBody), signature); err != nil {
+				logging.WithComponent("pilot").Error("Plane webhook error", slog.Any("error", err))
 			}
 		})
 	}
@@ -1021,6 +1082,39 @@ func (p *Pilot) findProjectForJiraProject(projectKey string) string {
 		return p.config.Projects[0].Path
 	}
 
+	return ""
+}
+
+// handleAsanaTask handles a new Asana task (GH-2044)
+func (p *Pilot) handleAsanaTask(ctx context.Context, task *asana.Task) error {
+	logging.WithComponent("pilot").Info("Received Asana task",
+		slog.String("gid", task.GID),
+		slog.String("name", task.Name))
+
+	taskInfo := asana.ConvertToTaskInfo(task)
+
+	// Find project (use first project as fallback)
+	projectPath := p.defaultProjectPath()
+
+	return p.orchestrator.ProcessAsanaTicket(ctx, taskInfo, projectPath)
+}
+
+// handlePlaneWorkItem handles a new Plane work item (GH-2044)
+func (p *Pilot) handlePlaneWorkItem(ctx context.Context, item *plane.WebhookWorkItemData) error {
+	logging.WithComponent("pilot").Info("Received Plane work item",
+		slog.String("id", item.ID),
+		slog.String("name", item.Name))
+
+	projectPath := p.defaultProjectPath()
+
+	return p.orchestrator.ProcessPlaneTicket(ctx, item, projectPath)
+}
+
+// defaultProjectPath returns the first configured project path
+func (p *Pilot) defaultProjectPath() string {
+	if len(p.config.Projects) > 0 {
+		return p.config.Projects[0].Path
+	}
 	return ""
 }
 

--- a/internal/pilot/webhook_handlers_test.go
+++ b/internal/pilot/webhook_handlers_test.go
@@ -1,0 +1,118 @@
+package pilot
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/adapters/asana"
+	"github.com/alekspetrov/pilot/internal/adapters/plane"
+	"github.com/alekspetrov/pilot/internal/gateway"
+)
+
+func TestAsanaWebhookHandlerRegistration(t *testing.T) {
+	router := gateway.NewRouter()
+	wh := asana.NewWebhookHandler(nil, "", "pilot")
+
+	var handlerCalled bool
+	wh.OnTask(func(_ context.Context, task *asana.Task) error {
+		handlerCalled = true
+		return nil
+	})
+
+	ctx := context.Background()
+	router.RegisterWebhookHandler("asana", func(payload map[string]interface{}) {
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("Failed to marshal payload: %v", err)
+		}
+
+		var webhookPayload asana.WebhookPayload
+		if err := json.Unmarshal(payloadBytes, &webhookPayload); err != nil {
+			t.Fatalf("Failed to unmarshal payload: %v", err)
+		}
+
+		if err := wh.Handle(ctx, &webhookPayload); err != nil {
+			t.Fatalf("Handle error: %v", err)
+		}
+	})
+
+	// Verify handler is registered
+	router.HandleWebhook("asana", map[string]interface{}{
+		"events": []interface{}{},
+	})
+
+	// With empty events, the task callback won't fire, but the handler ran without error
+	if handlerCalled {
+		t.Error("Expected handler not to be called with empty events")
+	}
+}
+
+func TestPlaneWebhookHandlerRegistration(t *testing.T) {
+	router := gateway.NewRouter()
+	wh := plane.NewWebhookHandler("", "pilot", nil)
+
+	var handlerCalled bool
+	wh.OnWorkItem(func(_ context.Context, _ *plane.WebhookWorkItemData) error {
+		handlerCalled = true
+		return nil
+	})
+
+	ctx := context.Background()
+	router.RegisterWebhookHandler("plane", func(payload map[string]interface{}) {
+		rawBody, _ := payload["_raw_body"].(string)
+		signature, _ := payload["_signature"].(string)
+
+		if err := wh.Handle(ctx, []byte(rawBody), signature); err != nil {
+			t.Fatalf("Handle error: %v", err)
+		}
+	})
+
+	// Simulate gateway-style payload with raw body containing a non-issue event
+	rawPayload := `{"event":"module","action":"created","data":{}}`
+	router.HandleWebhook("plane", map[string]interface{}{
+		"_raw_body":  rawPayload,
+		"_signature": "",
+	})
+
+	if handlerCalled {
+		t.Error("Expected handler not to be called for non-issue event")
+	}
+}
+
+func TestPlaneWebhookHandlerWithIssueEvent(t *testing.T) {
+	router := gateway.NewRouter()
+	wh := plane.NewWebhookHandler("", "pilot-label", nil)
+
+	var receivedItem *plane.WebhookWorkItemData
+	wh.OnWorkItem(func(_ context.Context, item *plane.WebhookWorkItemData) error {
+		receivedItem = item
+		return nil
+	})
+
+	ctx := context.Background()
+	router.RegisterWebhookHandler("plane", func(payload map[string]interface{}) {
+		rawBody, _ := payload["_raw_body"].(string)
+		signature, _ := payload["_signature"].(string)
+
+		if err := wh.Handle(ctx, []byte(rawBody), signature); err != nil {
+			t.Fatalf("Handle error: %v", err)
+		}
+	})
+
+	rawPayload := `{"event":"issue","action":"created","data":{"id":"item-1","name":"Test Issue","sequence_id":42,"labels":["pilot-label"]}}`
+	router.HandleWebhook("plane", map[string]interface{}{
+		"_raw_body":  rawPayload,
+		"_signature": "",
+	})
+
+	if receivedItem == nil {
+		t.Fatal("Expected work item callback to be called")
+	}
+	if receivedItem.ID != "item-1" {
+		t.Errorf("Expected ID 'item-1', got %q", receivedItem.ID)
+	}
+	if receivedItem.Name != "Test Issue" {
+		t.Errorf("Expected Name 'Test Issue', got %q", receivedItem.Name)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2044.

Closes #2044

## Changes

GitHub Issue #2044: Register Asana and Plane webhook handlers in pilot.go

## Problem

The gateway router defines routes for `/webhooks/asana` and `/webhooks/plane`, but neither adapter's webhook handler is registered in `internal/pilot/pilot.go` `registerWebhookHandlers()`.

**Registered:** Linear, GitHub, GitLab, Jira, Azure DevOps, Slack
**Missing:** Asana, Plane

Both adapters have fully implemented webhook handlers:
- `internal/adapters/asana/webhook.go` — `WebhookHandler` with `OnTask` callback, HMAC-SHA256 verification
- `internal/adapters/plane/webhook.go` — `WebhookHandler` with `OnWorkItem` callback, HMAC-SHA256 verification

**Result:** Incoming webhooks from Asana/Plane hit the gateway route but get silently dropped — no handler processes them. Polling works for both, webhooks don't.

## Implementation

In `internal/pilot/pilot.go` `registerWebhookHandlers()` (around line 455), add registration blocks following the existing pattern:

### Asana
```go
if p.asanaWH != nil {
    p.gateway.Router().RegisterWebhookHandler("asana", func(payload map[string]interface{}) {
        if err := p.asanaWH.Handle(ctx, payload); err != nil {
            logging.WithComponent("pilot").Error("Asana webhook error", slog.Any("error", err))
        }
    })
}
```

### Plane
```go
if p.planeWH != nil {
    p.gateway.Router().RegisterWebhookHandler("plane", func(payload map[string]interface{}) {
        if err := p.planeWH.Handle(ctx, payload); err != nil {
            logging.WithComponent("pilot").Error("Plane webhook error", slog.Any("error", err))
        }
    })
}
```

Also need to ensure `p.asanaWH` and `p.planeWH` fields exist on the `Pilot` struct and are initialized during `New()` when those adapters are configured in gateway mode.

## Key Files

- `internal/pilot/pilot.go:370-455` — webhook handler registration (add entries)
- `internal/pilot/pilot.go` — Pilot struct fields + `New()` constructor (init handlers)
- `internal/adapters/asana/webhook.go` — `Handle(ctx, payload)` signature
- `internal/adapters/plane/webhook.go` — `Handle(ctx, payload)` signature

## Tests

- Unit test that Asana/Plane handlers are registered when config is enabled
- `make test` passes