### PR TITLE
Wire GitLab polling into poller registry

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/alekspetrov/pilot/internal/adapters/asana"
 	"github.com/alekspetrov/pilot/internal/adapters/github"
+	"github.com/alekspetrov/pilot/internal/adapters/gitlab"
 	"github.com/alekspetrov/pilot/internal/adapters/jira"
 	"github.com/alekspetrov/pilot/internal/adapters/linear"
 	"github.com/alekspetrov/pilot/internal/adapters/plane"
@@ -919,4 +920,100 @@ func buildPlaneExecutionComment(result *executor.ExecutionResult, branchName str
 		comment += fmt.Sprintf("<p>⏱ Duration: %s</p>", result.Duration)
 	}
 	return comment
+}
+
+func handleGitLabIssueWithResult(ctx context.Context, cfg *config.Config, client *gitlab.Client, issue *gitlab.Issue, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner, monitor *executor.Monitor, program *tea.Program, alertsEngine *alerts.Engine, enforcer *budget.Enforcer) (*gitlab.IssueResult, error) {
+	taskID := fmt.Sprintf("GL-%d", issue.IID)
+	branchName := fmt.Sprintf("pilot/%s", taskID)
+
+	taskDesc := fmt.Sprintf("GitLab Issue %s: %s\n\n%s", taskID, issue.Title, issue.Description)
+
+	task := &executor.Task{
+		ID:          taskID,
+		Title:       issue.Title,
+		Description: taskDesc,
+		ProjectPath: projectPath,
+		Branch:      branchName,
+		CreatePR:    true,
+	}
+
+	deps := HandlerDeps{
+		Cfg:          cfg,
+		Dispatcher:   dispatcher,
+		Runner:       runner,
+		Monitor:      monitor,
+		Program:      program,
+		AlertsEngine: alertsEngine,
+		Enforcer:     enforcer,
+		ProjectPath:  projectPath,
+	}
+	info := IssueInfo{
+		TaskID:   taskID,
+		Title:    issue.Title,
+		URL:      issue.WebURL,
+		Adapter:  "gitlab",
+		LogEmoji: "🦊",
+	}
+
+	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
+
+	issueResult := &gitlab.IssueResult{
+		Success:    hr.Success,
+		BranchName: hr.BranchName,
+		MRNumber:   hr.PRNumber,
+		MRURL:      hr.PRURL,
+		HeadSHA:    hr.HeadSHA,
+		Error:      hr.Error,
+	}
+
+	if execErr != nil {
+		note := fmt.Sprintf("❌ Pilot execution failed:\n\n%s", execErr.Error())
+		if _, err := client.AddIssueNote(ctx, issue.IID, note); err != nil {
+			logging.WithComponent("gitlab").Warn("Failed to add failure note",
+				slog.Int("iid", issue.IID),
+				slog.Any("error", err),
+			)
+		}
+	} else if hr.Result != nil && hr.Result.Success {
+		if hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" {
+			note := fmt.Sprintf("⚠️ Pilot execution completed but no changes were made.\n\nDuration: %s\nBranch: %s\n\nNo commits or MR were created. The task may need clarification or manual intervention.",
+				hr.Result.Duration, branchName)
+			if _, err := client.AddIssueNote(ctx, issue.IID, note); err != nil {
+				logging.WithComponent("gitlab").Warn("Failed to add note",
+					slog.Int("iid", issue.IID),
+					slog.Any("error", err),
+				)
+			}
+			issueResult.Success = false
+		} else {
+			var parts []string
+			parts = append(parts, "✅ Pilot execution completed successfully!")
+			parts = append(parts, "")
+			if hr.Result.PRUrl != "" {
+				parts = append(parts, fmt.Sprintf("Merge Request: %s", hr.Result.PRUrl))
+			}
+			if hr.Result.CommitSHA != "" {
+				parts = append(parts, fmt.Sprintf("Commit: %s", hr.Result.CommitSHA[:min(8, len(hr.Result.CommitSHA))]))
+			}
+			parts = append(parts, fmt.Sprintf("Branch: %s", branchName))
+			parts = append(parts, fmt.Sprintf("Duration: %s", hr.Result.Duration))
+			note := strings.Join(parts, "\n")
+			if _, err := client.AddIssueNote(ctx, issue.IID, note); err != nil {
+				logging.WithComponent("gitlab").Warn("Failed to add success note",
+					slog.Int("iid", issue.IID),
+					slog.Any("error", err),
+				)
+			}
+		}
+	} else if hr.Result != nil {
+		note := fmt.Sprintf("❌ Pilot execution failed\n\nError: %s\nDuration: %s", hr.Result.Error, hr.Result.Duration)
+		if _, err := client.AddIssueNote(ctx, issue.IID, note); err != nil {
+			logging.WithComponent("gitlab").Warn("Failed to add failure note",
+				slog.Int("iid", issue.IID),
+				slog.Any("error", err),
+			)
+		}
+	}
+
+	return issueResult, execErr
 }

--- a/cmd/pilot/poller_gitlab.go
+++ b/cmd/pilot/poller_gitlab.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/alekspetrov/pilot/internal/adapters/gitlab"
+	"github.com/alekspetrov/pilot/internal/config"
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+func gitlabPollerRegistration() PollerRegistration {
+	return PollerRegistration{
+		Name: "gitlab",
+		Enabled: func(cfg *config.Config) bool {
+			return cfg.Adapters.GitLab != nil && cfg.Adapters.GitLab.Enabled &&
+				cfg.Adapters.GitLab.Polling != nil && cfg.Adapters.GitLab.Polling.Enabled
+		},
+		CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
+			// Determine interval
+			interval := 30 * time.Second
+			if deps.Cfg.Adapters.GitLab.Polling.Interval > 0 {
+				interval = deps.Cfg.Adapters.GitLab.Polling.Interval
+			}
+
+			gitlabClient := gitlab.NewClientWithBaseURL(
+				deps.Cfg.Adapters.GitLab.Token,
+				deps.Cfg.Adapters.GitLab.Project,
+				deps.Cfg.Adapters.GitLab.BaseURL,
+			)
+
+			label := deps.Cfg.Adapters.GitLab.PilotLabel
+			if label == "" {
+				label = "pilot"
+			}
+
+			gitlabPollerOpts := []gitlab.PollerOption{
+				gitlab.WithOnIssueWithResult(func(issueCtx context.Context, issue *gitlab.Issue) (*gitlab.IssueResult, error) {
+					result, err := handleGitLabIssueWithResult(issueCtx, deps.Cfg, gitlabClient, issue, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
+
+					// Wire MR to autopilot for CI monitoring + auto-merge
+					if result != nil && result.MRNumber > 0 && deps.AutopilotController != nil {
+						deps.AutopilotController.OnPRCreated(result.MRNumber, result.MRURL, 0, result.HeadSHA, result.BranchName, "")
+					}
+
+					return result, err
+				}),
+			}
+
+			if deps.AutopilotStateStore != nil {
+				gitlabPollerOpts = append(gitlabPollerOpts, gitlab.WithProcessedStore(deps.AutopilotStateStore))
+			}
+
+			// Wire OnMRCreated for autopilot controller
+			if deps.AutopilotController != nil {
+				ctrl := deps.AutopilotController
+				gitlabPollerOpts = append(gitlabPollerOpts, gitlab.WithOnMRCreated(func(mrIID int, mrURL string, issueIID int, headSHA string, branchName string) {
+					ctrl.OnPRCreated(mrIID, mrURL, issueIID, headSHA, branchName, "")
+				}))
+			}
+
+			if deps.Cfg.Orchestrator.MaxConcurrent > 0 {
+				gitlabPollerOpts = append(gitlabPollerOpts, gitlab.WithMaxConcurrent(deps.Cfg.Orchestrator.MaxConcurrent))
+			}
+
+			gitlabPoller := gitlab.NewPoller(gitlabClient, label, interval, gitlabPollerOpts...)
+
+			logging.WithComponent("start").Info("GitLab polling enabled",
+				slog.String("project", deps.Cfg.Adapters.GitLab.Project),
+				slog.String("label", label),
+				slog.Duration("interval", interval),
+			)
+			go func(p *gitlab.Poller) {
+				p.Start(ctx)
+			}(gitlabPoller)
+		},
+	}
+}

--- a/cmd/pilot/poller_registry.go
+++ b/cmd/pilot/poller_registry.go
@@ -48,6 +48,7 @@ func adapterPollerRegistrations() []PollerRegistration {
 		azuredevopsPollerRegistration(),
 		planePollerRegistration(),
 		discordPollerRegistration(),
+		gitlabPollerRegistration(),
 	}
 }
 

--- a/cmd/pilot/poller_registry_test.go
+++ b/cmd/pilot/poller_registry_test.go
@@ -50,11 +50,11 @@ func TestStartAdapterPollers_OnlyStartsEnabled(t *testing.T) {
 
 func TestAdapterPollerRegistrations_ReturnsAllFive(t *testing.T) {
 	regs := adapterPollerRegistrations()
-	if len(regs) != 6 {
-		t.Fatalf("expected 6 registrations, got %d", len(regs))
+	if len(regs) != 7 {
+		t.Fatalf("expected 7 registrations, got %d", len(regs))
 	}
 
-	expected := []string{"linear", "jira", "asana", "azuredevops", "plane", "discord"}
+	expected := []string{"linear", "jira", "asana", "azuredevops", "plane", "discord", "gitlab"}
 	for i, name := range expected {
 		if regs[i].Name != name {
 			t.Errorf("registration[%d]: expected name %q, got %q", i, name, regs[i].Name)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2043.

Closes #2043

## Changes

GitHub Issue #2043: Wire GitLab polling into poller registry

## Problem

GitLab poller is fully implemented in `internal/adapters/gitlab/poller.go` (519 lines, `NewPoller` constructor with options pattern) but **never registered** in the poller registry. There is no `cmd/pilot/poller_gitlab.go` file.

All other adapters have their poller wiring: Linear, Jira, Asana, Azure DevOps, Plane, Discord — GitLab is the only one missing.

**Result:** GitLab webhooks work, but GitLab polling mode is completely non-functional.

## Implementation

1. Create `cmd/pilot/poller_gitlab.go` following the exact pattern from existing files (e.g., `poller_linear.go`, `poller_asana.go`):
   - Return a `PollerRegistration` with `Name: "gitlab"`
   - `Enabled` checks `cfg.Adapters.GitLab != nil && cfg.Adapters.GitLab.Enabled && cfg.Adapters.GitLab.Polling != nil && cfg.Adapters.GitLab.Polling.Enabled`
   - `CreateAndStart` instantiates `gitlab.NewClient`, builds `PollerOption` slice, creates `gitlab.NewPoller`, starts in goroutine
   - Wire: ProcessedStore, OnMRCreated → autopilot, maxConcurrent from config, execution mode

2. Add `gitlabPollerRegistration()` to the slice in `cmd/pilot/poller_registry.go` `adapterPollerRegistrations()`

## Key Files

- `cmd/pilot/poller_registry.go:47-54` — registration slice (add entry)
- `cmd/pilot/poller_gitlab.go` — new file
- `internal/adapters/gitlab/poller.go` — existing poller (reference for constructor signature)
- `cmd/pilot/poller_linear.go` — reference pattern

## Tests

- Add test case to `cmd/pilot/poller_registry_test.go` verifying GitLab appears in registrations
- `make test` passes