### PR TITLE
Fix docs inaccuracies from unwired features audit

### DIFF
--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -14,6 +14,7 @@ pilot start [flags]
 |------|-------------|
 | `--telegram` | Enable Telegram polling (overrides config) |
 | `--github` | Enable GitHub polling (overrides config) |
+| `--gitlab` | Enable GitLab polling (overrides config) |
 | `--linear` | Enable Linear webhooks (overrides config) |
 | `--slack` | Enable Slack Socket Mode (overrides config) |
 | `--discord` | Enable Discord bot (overrides config) |
@@ -21,7 +22,6 @@ pilot start [flags]
 | `--autopilot=ENV` | Enable autopilot: `dev`, `stage`, `prod` |
 | `--auto-release` | Enable tag-based release automation (requires autopilot=prod) |
 | `--dashboard` | Show TUI dashboard for real-time task monitoring |
-| `-d`, `--daemon` | Run in background (daemon mode) |
 | `-p`, `--project` | Project path (default: config default or cwd) |
 | `--replace` | Kill existing bot instance before starting |
 | `--no-gateway` | Run polling adapters only (no HTTP gateway) |
@@ -48,9 +48,6 @@ pilot start --github --sequential
 
 # Production with auto-release
 pilot start --github --autopilot=prod --auto-release
-
-# Run in background
-pilot start --telegram --github -d
 
 # With JSON logging for aggregation systems
 pilot start --github --log-format=json
@@ -253,37 +250,6 @@ pilot logs --json
 ```
 
 ---
-
-## Daemon Control
-
-### pilot stop
-
-Stop the Pilot daemon.
-
-```bash
-pilot stop
-```
-
-Signals the running Pilot daemon to shut down gracefully. For daemons started with `pilot start -d`, this command provides guidance on stopping the process.
-
-#### Usage Notes
-
-- Use `Ctrl+C` to stop a foreground Pilot process
-- Use `SIGTERM` to stop a background daemon: `kill $(pgrep pilot)`
-- For systemd/launchd managed services, use the appropriate service manager commands
-
-#### Examples
-
-```bash
-# Stop daemon (shows guidance)
-pilot stop
-
-# Alternative: stop via signal
-kill -TERM $(pgrep -f "pilot start")
-
-# Alternative: stop via pkill
-pkill -f "pilot start"
-```
 
 ### pilot status
 

--- a/docs/content/concepts/adapters.mdx
+++ b/docs/content/concepts/adapters.mdx
@@ -189,7 +189,7 @@ Each adapter manages issue state transitions using platform-native mechanisms. T
 | **Azure DevOps** | Update work item state | Update state to "Done" | Update state |
 | **Plane** | Update issue state | Update state | Update state |
 
-Each adapter's notifier (`internal/adapters/{name}/notifier.go`) handles these transitions and posts status comments at each stage.
+Each adapter defines state transitions in its notifier (`internal/adapters/{name}/notifier.go`). Label and state changes are applied during execution. Status comment posting back to source systems is planned but not yet wired into the executor runner.
 
 ## Parallel Execution
 

--- a/docs/content/deployment/networking.mdx
+++ b/docs/content/deployment/networking.mdx
@@ -34,6 +34,7 @@ gateway:
 | `/webhooks/linear` | POST | Linear webhook |
 | `/webhooks/jira` | POST | Jira webhook |
 | `/webhooks/asana` | POST | Asana webhook |
+| `/webhooks/plane` | POST | Plane webhook |
 
 ### Authentication
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2051.

Closes #2051

## Changes

GitHub Issue #2051: Fix docs inaccuracies from unwired features audit

## Problem

The unwired features audit (GH-2043–2047) found 4 documentation inaccuracies where docs claim features work that are either non-functional or don't exist.

**Do NOT touch integration pages** (`gitlab.mdx`, `asana.mdx`, `plane.mdx`) — code fixes via GH-2043–2046 will make those docs accurate.

## Changes Required

### 1. Add notifier caveat — `docs/content/concepts/adapters.mdx:192`

Current (inaccurate):
```
Each adapter's notifier (`internal/adapters/{name}/notifier.go`) handles these transitions and posts status comments at each stage.
```

Replace with:
```
Each adapter defines state transitions in its notifier (`internal/adapters/{name}/notifier.go`). Label and state changes are applied during execution. Status comment posting back to source systems is planned but not yet wired into the executor runner.
```

### 2. Remove dead `--daemon` flag docs — `docs/content/cli/commands.mdx`

Three removals:

**a) Flags table (line 24)** — delete this row:
```
| `-d`, `--daemon` | Run in background (daemon mode) |
```

**b) Example (lines 52-53)** — delete:
```bash
# Run in background
pilot start --telegram --github -d
```

**c) Daemon Control section (lines 257-286)** — delete the entire section:
```markdown
## Daemon Control

### pilot stop
...through...
pkill -f "pilot start"
```

Keep `### pilot status` (line 288+) intact — it follows the deleted section.

### 3. Add `/webhooks/plane` — `docs/content/deployment/networking.mdx:36`

After the `/webhooks/asana` row, add:
```
| `/webhooks/plane` | POST | Plane webhook |
```

### 4. Add `--gitlab` flag — `docs/content/cli/commands.mdx` flags table

After the `--github` row (line 16), add:
```
| `--gitlab` | Enable GitLab polling (overrides config) |
```

## Task doc

`.agent/tasks/TASK-11-docs-unwired-audit-fixes.md`

## Verify

```bash
cd docs && npm run build
```