### PR TITLE
feat(memory): add eval_tasks table, EvalTask struct, and extraction logic

### DIFF
--- a/internal/memory/eval.go
+++ b/internal/memory/eval.go
@@ -1,0 +1,166 @@
+package memory
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// EvalTask represents a captured evaluation task derived from a real execution.
+// It stores enough context to replay the task as a benchmark or regression test.
+type EvalTask struct {
+	ID           string         `json:"id"`
+	ExecutionID  string         `json:"execution_id"`
+	IssueNumber  int            `json:"issue_number"`
+	IssueTitle   string         `json:"issue_title"`
+	Repo         string         `json:"repo"`
+	Success      bool           `json:"success"`
+	PassCriteria []PassCriteria `json:"pass_criteria,omitempty"`
+	FilesChanged []string       `json:"files_changed,omitempty"`
+	DurationMs   int64          `json:"duration_ms"`
+	CreatedAt    time.Time      `json:"created_at"`
+}
+
+// PassCriteria defines a single criterion that must pass for an eval task to succeed.
+type PassCriteria struct {
+	Type    string `json:"type"`    // "build", "test", "lint", "custom"
+	Command string `json:"command"` // The gate command (if known)
+	Passed  bool   `json:"passed"`
+}
+
+// EvalInput carries the execution data needed to build an EvalTask.
+// Callers construct this from executor.ExecutionResult to avoid an import cycle.
+type EvalInput struct {
+	TaskID       string
+	Success      bool
+	DurationMs   int64
+	GateResults  []EvalGateResult
+	Repo         string
+	IssueNumber  int
+	IssueTitle   string
+	FilesChanged []string
+}
+
+// EvalGateResult is a quality gate outcome, mirroring executor.QualityGateResult.
+type EvalGateResult struct {
+	Name   string
+	Passed bool
+}
+
+// ExtractEvalTask builds an EvalTask from execution data and issue metadata.
+// It generates a deterministic ID from the repo and issue number.
+func ExtractEvalTask(in EvalInput) *EvalTask {
+	h := sha256.Sum256([]byte(fmt.Sprintf("%s#%d", in.Repo, in.IssueNumber)))
+	id := fmt.Sprintf("eval-%x", h[:8])
+
+	var criteria []PassCriteria
+	for _, g := range in.GateResults {
+		criteria = append(criteria, PassCriteria{
+			Type:   g.Name,
+			Passed: g.Passed,
+		})
+	}
+
+	return &EvalTask{
+		ID:           id,
+		ExecutionID:  in.TaskID,
+		IssueNumber:  in.IssueNumber,
+		IssueTitle:   in.IssueTitle,
+		Repo:         in.Repo,
+		Success:      in.Success,
+		PassCriteria: criteria,
+		FilesChanged: in.FilesChanged,
+		DurationMs:   in.DurationMs,
+		CreatedAt:    time.Now(),
+	}
+}
+
+// SaveEvalTask persists an eval task. On duplicate (repo, issue_number) it updates the existing row.
+func (s *Store) SaveEvalTask(task *EvalTask) error {
+	criteriaJSON, err := json.Marshal(task.PassCriteria)
+	if err != nil {
+		return fmt.Errorf("marshal pass_criteria: %w", err)
+	}
+	filesJSON, err := json.Marshal(task.FilesChanged)
+	if err != nil {
+		return fmt.Errorf("marshal files_changed: %w", err)
+	}
+
+	return s.withRetry("SaveEvalTask", func() error {
+		_, err := s.db.Exec(`
+			INSERT INTO eval_tasks (id, execution_id, issue_number, issue_title, repo, success, pass_criteria, files_changed, duration_ms)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(repo, issue_number) DO UPDATE SET
+				execution_id = excluded.execution_id,
+				success = excluded.success,
+				pass_criteria = excluded.pass_criteria,
+				files_changed = excluded.files_changed,
+				duration_ms = excluded.duration_ms
+		`, task.ID, task.ExecutionID, task.IssueNumber, task.IssueTitle, task.Repo, task.Success,
+			string(criteriaJSON), string(filesJSON), task.DurationMs)
+		return err
+	})
+}
+
+// EvalTaskFilter controls which eval tasks are returned by ListEvalTasks.
+type EvalTaskFilter struct {
+	Repo        string
+	SuccessOnly bool
+	FailedOnly  bool
+	Limit       int
+}
+
+// ListEvalTasks returns eval tasks matching the given filter, ordered by created_at DESC.
+func (s *Store) ListEvalTasks(filter EvalTaskFilter) ([]*EvalTask, error) {
+	var conditions []string
+	var args []interface{}
+
+	if filter.Repo != "" {
+		conditions = append(conditions, "repo = ?")
+		args = append(args, filter.Repo)
+	}
+	if filter.SuccessOnly {
+		conditions = append(conditions, "success = 1")
+	}
+	if filter.FailedOnly {
+		conditions = append(conditions, "success = 0")
+	}
+
+	query := "SELECT id, execution_id, issue_number, issue_title, repo, success, pass_criteria, files_changed, duration_ms, created_at FROM eval_tasks"
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+	query += " ORDER BY created_at DESC"
+
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	query += fmt.Sprintf(" LIMIT %d", limit)
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query eval_tasks: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tasks []*EvalTask
+	for rows.Next() {
+		var t EvalTask
+		var criteriaJSON, filesJSON string
+		if err := rows.Scan(&t.ID, &t.ExecutionID, &t.IssueNumber, &t.IssueTitle, &t.Repo,
+			&t.Success, &criteriaJSON, &filesJSON, &t.DurationMs, &t.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan eval_task: %w", err)
+		}
+		if criteriaJSON != "" {
+			_ = json.Unmarshal([]byte(criteriaJSON), &t.PassCriteria)
+		}
+		if filesJSON != "" {
+			_ = json.Unmarshal([]byte(filesJSON), &t.FilesChanged)
+		}
+		tasks = append(tasks, &t)
+	}
+	return tasks, rows.Err()
+}

--- a/internal/memory/eval_test.go
+++ b/internal/memory/eval_test.go
@@ -1,0 +1,338 @@
+package memory
+
+import (
+	"os"
+	"testing"
+)
+
+func newTestStoreForEval(t *testing.T) (*Store, func()) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "pilot-eval-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		t.Fatalf("NewStore: %v", err)
+	}
+	return store, func() {
+		_ = store.Close()
+		_ = os.RemoveAll(tmpDir)
+	}
+}
+
+func TestExtractEvalTask(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        EvalInput
+		wantSuccess  bool
+		wantCriteria int
+	}{
+		{
+			name: "successful execution with quality gates",
+			input: EvalInput{
+				TaskID:     "exec-1",
+				Success:    true,
+				DurationMs: 5000,
+				GateResults: []EvalGateResult{
+					{Name: "build", Passed: true},
+					{Name: "test", Passed: true},
+					{Name: "lint", Passed: true},
+				},
+				Repo:         "org/repo",
+				IssueNumber:  42,
+				IssueTitle:   "Add feature X",
+				FilesChanged: []string{"main.go", "main_test.go"},
+			},
+			wantSuccess:  true,
+			wantCriteria: 3,
+		},
+		{
+			name: "failed execution",
+			input: EvalInput{
+				TaskID:     "exec-2",
+				Success:    false,
+				DurationMs: 2000,
+				GateResults: []EvalGateResult{
+					{Name: "build", Passed: true},
+					{Name: "test", Passed: false},
+				},
+				Repo:         "org/repo",
+				IssueNumber:  43,
+				IssueTitle:   "Fix bug Y",
+				FilesChanged: []string{"bug.go"},
+			},
+			wantSuccess:  false,
+			wantCriteria: 2,
+		},
+		{
+			name: "nil quality gates",
+			input: EvalInput{
+				TaskID:      "exec-3",
+				Success:     true,
+				DurationMs:  1000,
+				GateResults: nil,
+				Repo:        "org/repo",
+				IssueNumber: 44,
+				IssueTitle:  "Docs update",
+			},
+			wantSuccess:  true,
+			wantCriteria: 0,
+		},
+		{
+			name: "empty files changed",
+			input: EvalInput{
+				TaskID:       "exec-4",
+				Success:      true,
+				DurationMs:   500,
+				Repo:         "org/other",
+				IssueNumber:  1,
+				IssueTitle:   "Init",
+				FilesChanged: []string{},
+			},
+			wantSuccess:  true,
+			wantCriteria: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := ExtractEvalTask(tt.input)
+
+			if task.ID == "" {
+				t.Error("expected non-empty ID")
+			}
+			if task.ExecutionID != tt.input.TaskID {
+				t.Errorf("ExecutionID = %q, want %q", task.ExecutionID, tt.input.TaskID)
+			}
+			if task.Success != tt.wantSuccess {
+				t.Errorf("Success = %v, want %v", task.Success, tt.wantSuccess)
+			}
+			if len(task.PassCriteria) != tt.wantCriteria {
+				t.Errorf("PassCriteria len = %d, want %d", len(task.PassCriteria), tt.wantCriteria)
+			}
+			if task.IssueNumber != tt.input.IssueNumber {
+				t.Errorf("IssueNumber = %d, want %d", task.IssueNumber, tt.input.IssueNumber)
+			}
+			if task.Repo != tt.input.Repo {
+				t.Errorf("Repo = %q, want %q", task.Repo, tt.input.Repo)
+			}
+			if task.DurationMs != tt.input.DurationMs {
+				t.Errorf("DurationMs = %d, want %d", task.DurationMs, tt.input.DurationMs)
+			}
+		})
+	}
+}
+
+func TestSaveAndListEvalTasks(t *testing.T) {
+	store, cleanup := newTestStoreForEval(t)
+	defer cleanup()
+
+	task1 := &EvalTask{
+		ID:          "eval-aaa",
+		ExecutionID: "exec-1",
+		IssueNumber: 10,
+		IssueTitle:  "Feature A",
+		Repo:        "org/repo",
+		Success:     true,
+		PassCriteria: []PassCriteria{
+			{Type: "build", Passed: true},
+			{Type: "test", Passed: true},
+		},
+		FilesChanged: []string{"a.go", "b.go"},
+		DurationMs:   3000,
+	}
+	task2 := &EvalTask{
+		ID:           "eval-bbb",
+		ExecutionID:  "exec-2",
+		IssueNumber:  11,
+		IssueTitle:   "Feature B",
+		Repo:         "org/repo",
+		Success:      false,
+		PassCriteria: []PassCriteria{{Type: "test", Passed: false}},
+		FilesChanged: []string{"c.go"},
+		DurationMs:   1500,
+	}
+	task3 := &EvalTask{
+		ID:          "eval-ccc",
+		ExecutionID: "exec-3",
+		IssueNumber: 20,
+		IssueTitle:  "Other repo task",
+		Repo:        "org/other",
+		Success:     true,
+		DurationMs:  500,
+	}
+
+	for _, task := range []*EvalTask{task1, task2, task3} {
+		if err := store.SaveEvalTask(task); err != nil {
+			t.Fatalf("SaveEvalTask(%s): %v", task.ID, err)
+		}
+	}
+
+	tests := []struct {
+		name      string
+		filter    EvalTaskFilter
+		wantCount int
+		wantIDs   []string
+	}{
+		{
+			name:      "all tasks",
+			filter:    EvalTaskFilter{},
+			wantCount: 3,
+		},
+		{
+			name:      "filter by repo",
+			filter:    EvalTaskFilter{Repo: "org/repo"},
+			wantCount: 2,
+		},
+		{
+			name:      "filter by repo other",
+			filter:    EvalTaskFilter{Repo: "org/other"},
+			wantCount: 1,
+			wantIDs:   []string{"eval-ccc"},
+		},
+		{
+			name:      "success only",
+			filter:    EvalTaskFilter{SuccessOnly: true},
+			wantCount: 2,
+		},
+		{
+			name:      "failed only",
+			filter:    EvalTaskFilter{FailedOnly: true},
+			wantCount: 1,
+			wantIDs:   []string{"eval-bbb"},
+		},
+		{
+			name:      "repo + success",
+			filter:    EvalTaskFilter{Repo: "org/repo", SuccessOnly: true},
+			wantCount: 1,
+			wantIDs:   []string{"eval-aaa"},
+		},
+		{
+			name:      "limit",
+			filter:    EvalTaskFilter{Limit: 1},
+			wantCount: 1,
+		},
+		{
+			name:      "no matches",
+			filter:    EvalTaskFilter{Repo: "nonexistent/repo"},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tasks, err := store.ListEvalTasks(tt.filter)
+			if err != nil {
+				t.Fatalf("ListEvalTasks: %v", err)
+			}
+			if len(tasks) != tt.wantCount {
+				t.Errorf("got %d tasks, want %d", len(tasks), tt.wantCount)
+			}
+			if tt.wantIDs != nil {
+				for i, wantID := range tt.wantIDs {
+					if i < len(tasks) && tasks[i].ID != wantID {
+						t.Errorf("tasks[%d].ID = %q, want %q", i, tasks[i].ID, wantID)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSaveEvalTaskDuplicatePrevention(t *testing.T) {
+	store, cleanup := newTestStoreForEval(t)
+	defer cleanup()
+
+	task := &EvalTask{
+		ID:          "eval-dup",
+		ExecutionID: "exec-1",
+		IssueNumber: 10,
+		IssueTitle:  "Feature A",
+		Repo:        "org/repo",
+		Success:     false,
+		DurationMs:  1000,
+	}
+	if err := store.SaveEvalTask(task); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	// Save again with same repo+issue_number but updated fields
+	updated := &EvalTask{
+		ID:           "eval-dup-v2",
+		ExecutionID:  "exec-2",
+		IssueNumber:  10,
+		IssueTitle:   "Feature A",
+		Repo:         "org/repo",
+		Success:      true,
+		PassCriteria: []PassCriteria{{Type: "build", Passed: true}},
+		DurationMs:   2000,
+	}
+	if err := store.SaveEvalTask(updated); err != nil {
+		t.Fatalf("upsert save: %v", err)
+	}
+
+	tasks, err := store.ListEvalTasks(EvalTaskFilter{Repo: "org/repo"})
+	if err != nil {
+		t.Fatalf("ListEvalTasks: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task after upsert, got %d", len(tasks))
+	}
+	if !tasks[0].Success {
+		t.Error("expected success=true after upsert")
+	}
+	if tasks[0].ExecutionID != "exec-2" {
+		t.Errorf("expected execution_id=exec-2 after upsert, got %s", tasks[0].ExecutionID)
+	}
+	if tasks[0].DurationMs != 2000 {
+		t.Errorf("expected duration_ms=2000 after upsert, got %d", tasks[0].DurationMs)
+	}
+}
+
+func TestEvalTaskPassCriteriaRoundTrip(t *testing.T) {
+	store, cleanup := newTestStoreForEval(t)
+	defer cleanup()
+
+	criteria := []PassCriteria{
+		{Type: "build", Command: "go build ./...", Passed: true},
+		{Type: "test", Command: "go test ./...", Passed: true},
+		{Type: "lint", Command: "golangci-lint run", Passed: false},
+	}
+	task := &EvalTask{
+		ID:           "eval-criteria",
+		ExecutionID:  "exec-c",
+		IssueNumber:  99,
+		IssueTitle:   "Criteria test",
+		Repo:         "org/repo",
+		Success:      false,
+		PassCriteria: criteria,
+		FilesChanged: []string{"x.go", "y.go", "z.go"},
+		DurationMs:   4000,
+	}
+	if err := store.SaveEvalTask(task); err != nil {
+		t.Fatalf("SaveEvalTask: %v", err)
+	}
+
+	tasks, err := store.ListEvalTasks(EvalTaskFilter{Repo: "org/repo"})
+	if err != nil {
+		t.Fatalf("ListEvalTasks: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	got := tasks[0]
+	if len(got.PassCriteria) != 3 {
+		t.Fatalf("expected 3 pass criteria, got %d", len(got.PassCriteria))
+	}
+	if got.PassCriteria[0].Command != "go build ./..." {
+		t.Errorf("criteria[0].Command = %q, want %q", got.PassCriteria[0].Command, "go build ./...")
+	}
+	if got.PassCriteria[2].Passed {
+		t.Error("criteria[2] should be failed")
+	}
+	if len(got.FilesChanged) != 3 {
+		t.Errorf("expected 3 files, got %d", len(got.FilesChanged))
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -261,6 +261,23 @@ func (s *Store) migrate() error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_pattern_performance_pattern ON pattern_performance(pattern_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_pattern_performance_project ON pattern_performance(project_id)`,
+		// Eval tasks table (GH-2058)
+		`CREATE TABLE IF NOT EXISTS eval_tasks (
+			id TEXT PRIMARY KEY,
+			execution_id TEXT NOT NULL,
+			issue_number INTEGER NOT NULL,
+			issue_title TEXT NOT NULL,
+			repo TEXT NOT NULL,
+			success BOOLEAN NOT NULL,
+			pass_criteria TEXT,
+			files_changed TEXT,
+			duration_ms INTEGER DEFAULT 0,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(repo, issue_number)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_eval_tasks_repo ON eval_tasks(repo)`,
+		`CREATE INDEX IF NOT EXISTS idx_eval_tasks_success ON eval_tasks(success)`,
+		`CREATE INDEX IF NOT EXISTS idx_eval_tasks_created ON eval_tasks(created_at)`,
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2058.

Closes #2058

## Changes

Add the `eval_tasks` table migration to `internal/memory/store.go` (CREATE TABLE + indexes). Create `internal/memory/eval.go` with the `EvalTask` struct, `PassCriteria` struct, `ExtractEvalTask()` function (builds eval task from execution result + issue data), and store methods `SaveEvalTask()` / `ListEvalTasks()` with UNIQUE constraint handling. Create `internal/memory/eval_test.go` with table-driven tests covering: extraction from successful execution, pass criteria generation from QualityGatesResult, duplicate prevention (UNIQUE constraint), listing with filters, edge cases (nil quality gates, empty files). All work is in `internal/memory/`.