### PR TITLE
GH-2080: Webhook wiring

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -886,6 +886,14 @@ Examples:
 			// GH-1585: Wire autopilot provider to gateway so /api/v1/autopilot returns live PR data
 			if gwAutopilotController != nil {
 				p.Gateway().SetAutopilotProvider(&autopilotProviderAdapter{controller: gwAutopilotController})
+
+				// GH-2080: Wire PR review events to autopilot controller
+				p.SetOnPRReview(func(ctx context.Context, prNumber int, action, state, reviewer string, repo *github.Repository) error {
+					if action == "submitted" {
+						gwAutopilotController.OnReviewRequested(prNumber, action, state, reviewer)
+					}
+					return nil
+				})
 			}
 
 			// GH-1609: Wire dashboard store to gateway so /api/v1/{metrics,queue,history,logs} return 200
@@ -1462,6 +1470,31 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 		gwServer := gateway.NewServer(cfg.Gateway)
 		if autopilotController != nil {
 			gwServer.SetAutopilotProvider(&autopilotProviderAdapter{controller: autopilotController})
+		}
+
+		// GH-2080: Wire PR review webhook events to autopilot controller in polling mode
+		if autopilotController != nil && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
+			capturedController := autopilotController
+			token := cfg.Adapters.GitHub.Token
+			if token == "" {
+				token = os.Getenv("GITHUB_TOKEN")
+			}
+			if token != "" {
+				ghClient := github.NewClient(token)
+				ghWH := github.NewWebhookHandler(ghClient, cfg.Adapters.GitHub.WebhookSecret, cfg.Adapters.GitHub.PilotLabel)
+				ghWH.OnPRReview(func(ctx context.Context, prNumber int, action, state, reviewer string, repo *github.Repository) error {
+					if action == "submitted" {
+						capturedController.OnReviewRequested(prNumber, action, state, reviewer)
+					}
+					return nil
+				})
+				gwServer.Router().RegisterWebhookHandler("github", func(payload map[string]interface{}) {
+					eventType, _ := payload["_event_type"].(string)
+					if err := ghWH.Handle(context.Background(), eventType, payload); err != nil {
+						logging.WithComponent("pilot").Error("GitHub webhook error (polling mode)", slog.Any("error", err))
+					}
+				})
+			}
 		}
 		if store != nil {
 			gwServer.SetDashboardStore(store)

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -318,6 +318,34 @@ func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, he
 	)
 }
 
+// OnReviewRequested handles PR review events from GitHub webhooks.
+// It logs the review and, for changes_requested reviews, records the event on tracked PRs.
+func (c *Controller) OnReviewRequested(prNumber int, action, state, reviewer string) {
+	c.mu.RLock()
+	prState, tracked := c.activePRs[prNumber]
+	c.mu.RUnlock()
+
+	c.log.Info("PR review received",
+		"pr", prNumber,
+		"action", action,
+		"state", state,
+		"reviewer", reviewer,
+		"tracked", tracked,
+	)
+
+	if !tracked {
+		return
+	}
+
+	if state == "changes_requested" {
+		c.log.Warn("Changes requested on PR",
+			"pr", prNumber,
+			"reviewer", reviewer,
+			"current_stage", prState.Stage,
+		)
+	}
+}
+
 // ProcessPR processes a single PR through the state machine.
 // Returns error if processing fails; caller should retry based on error type.
 // Accepts optional cached ghPR to avoid redundant API calls.

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -95,6 +95,32 @@ func TestController_GetPRState(t *testing.T) {
 	}
 }
 
+func TestController_OnReviewRequested(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Should not panic on untracked PR
+	c.OnReviewRequested(99, "submitted", "changes_requested", "reviewer1")
+
+	// Register a PR and send review
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", "")
+	c.OnReviewRequested(42, "submitted", "changes_requested", "reviewer1")
+
+	// PR should still be tracked (OnReviewRequested is informational for now)
+	pr, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("expected PR to be tracked after review event")
+	}
+	if pr.PRNumber != 42 {
+		t.Errorf("PRNumber = %d, want 42", pr.PRNumber)
+	}
+
+	// Approved review should also not panic
+	c.OnReviewRequested(42, "submitted", "approved", "reviewer2")
+}
+
 func TestController_ProcessPR_NotTracked(t *testing.T) {
 	ghClient := github.NewClient(testutil.FakeGitHubToken)
 	cfg := DefaultConfig()

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -989,6 +989,15 @@ func (p *Pilot) SetQualityCheckerFactory(factory executor.QualityCheckerFactory)
 	p.orchestrator.SetQualityCheckerFactory(factory)
 }
 
+// SetOnPRReview wires a PR review callback on the GitHub webhook handler.
+// This allows cmd/pilot/main.go to route review events to the autopilot controller
+// without creating import cycles.
+func (p *Pilot) SetOnPRReview(callback github.PRReviewCallback) {
+	if p.githubWH != nil {
+		p.githubWH.OnPRReview(callback)
+	}
+}
+
 // handleGithubIssue handles a new GitHub issue
 func (p *Pilot) handleGithubIssue(ctx context.Context, issue *github.Issue, repo *github.Repository) error {
 	logging.WithComponent("pilot").Info("Received GitHub issue",


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2080.

Closes #2080

## Changes

GitHub Issue #2080: Webhook wiring

Parent: GH-2077

connect PR review events to autopilot controller (`internal/pilot/pilot.go` + `cmd/pilot/main.go`)
Wire `OnPRReview` callback in polling mode (`internal/pilot/pilot.go`, after existing `OnIssue` wiring ~line 318) to route `CHANGES_REQUESTED` + `submitted` events to `autopilotController.OnReviewRequested()`. Add the same wiring in gateway mode (`cmd/pilot/main.go`) where `ghWebhookHandler` is configured. Both are thin glue code — filter on state/action, delegate to controller.
---
**Dependency order**: Subtask 1 → Subtask 2 → Subtask 3 (each depends on the prior). Subtask 2 needs the GitHub client methods from subtask 1. Subtask 3 needs `OnReviewRequested()` from subtask 2 and `OnPRReview()` from subtask 1.