### PR TITLE
GH-2085: GitHub client: Add `SearchOpenSubIssues()` method

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -804,6 +804,21 @@ func (c *Client) SearchMergedPRsForIssue(ctx context.Context, owner, repo string
 	return result.TotalCount > 0, nil
 }
 
+// SearchOpenSubIssues counts open issues in a repo whose body contains "Parent: GH-{parentNum}".
+// Uses the GitHub Search API to find sub-issues referencing the given parent.
+func (c *Client) SearchOpenSubIssues(ctx context.Context, owner, repo string, parentNum int) (int, error) {
+	q := fmt.Sprintf(`repo:%s/%s "Parent: GH-%d" is:issue is:open`, owner, repo, parentNum)
+	path := fmt.Sprintf("/search/issues?q=%s&per_page=1", url.QueryEscape(q))
+
+	var result struct {
+		TotalCount int `json:"total_count"`
+	}
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return 0, fmt.Errorf("search open sub-issues for parent %d: %w", parentNum, err)
+	}
+	return result.TotalCount, nil
+}
+
 // UpdatePullRequestBranch updates the PR branch with the latest base branch.
 // Uses GitHub API: PUT /repos/{owner}/{repo}/pulls/{number}/update-branch
 // Returns nil on success, error if the branch cannot be automatically updated (true conflict).

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -2592,3 +2592,67 @@ func TestSearchMergedPRsForIssue(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchOpenSubIssues(t *testing.T) {
+	tests := []struct {
+		name       string
+		parentNum  int
+		statusCode int
+		response   string
+		wantCount  int
+		wantErr    bool
+	}{
+		{
+			name:       "parent with open siblings",
+			parentNum:  100,
+			statusCode: http.StatusOK,
+			response:   `{"total_count": 3}`,
+			wantCount:  3,
+		},
+		{
+			name:       "all siblings closed",
+			parentNum:  200,
+			statusCode: http.StatusOK,
+			response:   `{"total_count": 0}`,
+			wantCount:  0,
+		},
+		{
+			name:       "API error",
+			parentNum:  300,
+			statusCode: http.StatusForbidden,
+			response:   `{"message": "rate limit"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasPrefix(r.URL.Path, "/search/issues") {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				q := r.URL.Query().Get("q")
+				expectedQ := fmt.Sprintf(`repo:owner/repo "Parent: GH-%d" is:issue is:open`, tt.parentNum)
+				if q != expectedQ {
+					t.Errorf("query = %q, want %q", q, expectedQ)
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			count, err := client.SearchOpenSubIssues(context.Background(), "owner", "repo", tt.parentNum)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SearchOpenSubIssues() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && count != tt.wantCount {
+				t.Errorf("SearchOpenSubIssues() = %d, want %d", count, tt.wantCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2085.

Closes #2085

## Changes

In `internal/adapters/github/client.go`, add `SearchOpenSubIssues(ctx, owner, repo, parentNum) (int, error)` that uses the GitHub search API with query `repo:{owner}/{repo} "Parent: GH-{parentNum}" is:issue is:open` and returns the count of matching open issues. Update the `GitHubClient` interface (or equivalent) to include this new method. Add table-driven tests in `internal/adapters/github/client_test.go` covering: parent with open siblings, parent with all siblings closed (returns 0), and API error handling. Verify `ParseParentIssueNumber()` already exists in `grouping.go` and works for the expected format.