### PR TITLE
GH-2086: Autopilot controller: Add `maybeCloseParentIssue()` and wire into `handleMerg...

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1103,6 +1103,9 @@ func (c *Controller) handleMerged(ctx context.Context, prState *PRState) error {
 		}
 	}
 
+	// GH-2086: Check if parent epic can be auto-closed (all sub-issues done).
+	c.maybeCloseParentIssue(ctx, prState)
+
 	if c.config.ResolvedEnv().SkipPostMergeCI {
 		// Fast path: skip post-merge CI, check if we should release immediately
 		if c.shouldTriggerRelease() && !c.resolvedRelease().RequireCI {
@@ -1124,6 +1127,66 @@ func (c *Controller) handleMerged(ctx context.Context, prState *PRState) error {
 	)
 	prState.Stage = StagePostMergeCI
 	return nil
+}
+
+// maybeCloseParentIssue checks if the merged PR's issue is a sub-issue of a parent epic,
+// and if all sibling sub-issues are now closed, closes the parent issue with a summary comment.
+// All errors are logged as warnings without blocking the merge flow.
+func (c *Controller) maybeCloseParentIssue(ctx context.Context, prState *PRState) {
+	if prState.IssueNumber <= 0 {
+		return
+	}
+
+	// Fetch the sub-issue body to find parent reference
+	issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, prState.IssueNumber)
+	if err != nil {
+		c.log.Warn("maybeCloseParentIssue: failed to fetch sub-issue", "issue", prState.IssueNumber, "error", err)
+		return
+	}
+
+	parentNum := github.ParseParentIssueNumber(issue.Body)
+	if parentNum == 0 {
+		return // Not a sub-issue
+	}
+
+	// Count remaining open siblings (excluding this one, which should already be closed)
+	openCount, err := c.ghClient.SearchOpenSubIssues(ctx, c.owner, c.repo, parentNum)
+	if err != nil {
+		c.log.Warn("maybeCloseParentIssue: failed to search open sub-issues", "parent", parentNum, "error", err)
+		return
+	}
+
+	if openCount > 0 {
+		c.log.Info("maybeCloseParentIssue: siblings still open, skipping parent close",
+			"parent", parentNum, "open_siblings", openCount)
+		return
+	}
+
+	// All sub-issues closed — close the parent
+	c.log.Info("maybeCloseParentIssue: all sub-issues closed, closing parent", "parent", parentNum)
+
+	// Label cleanup: add pilot-done, remove pilot-failed and pilot-in-progress
+	if err := c.ghClient.AddLabels(ctx, c.owner, c.repo, parentNum, []string{github.LabelDone}); err != nil {
+		c.log.Warn("maybeCloseParentIssue: failed to add pilot-done to parent", "parent", parentNum, "error", err)
+	}
+	if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, parentNum, github.LabelFailed); err != nil {
+		c.log.Debug("maybeCloseParentIssue: pilot-failed cleanup on parent", "parent", parentNum, "error", err)
+	}
+	if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, parentNum, github.LabelInProgress); err != nil {
+		c.log.Debug("maybeCloseParentIssue: pilot-in-progress cleanup on parent", "parent", parentNum, "error", err)
+	}
+
+	// Close the parent issue
+	if err := c.ghClient.UpdateIssueState(ctx, c.owner, c.repo, parentNum, "closed"); err != nil {
+		c.log.Warn("maybeCloseParentIssue: failed to close parent issue", "parent", parentNum, "error", err)
+		return
+	}
+
+	// Post summary comment
+	comment := fmt.Sprintf("All sub-issues completed. Parent closed automatically by Pilot after GH-%d merged (PR #%d).", prState.IssueNumber, prState.PRNumber)
+	if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, parentNum, comment); err != nil {
+		c.log.Warn("maybeCloseParentIssue: failed to post summary comment", "parent", parentNum, "error", err)
+	}
 }
 
 // handlePostMergeCI monitors deployment/post-merge checks.

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -3787,3 +3787,156 @@ func TestController_HasChangesRequested_FilterByTime(t *testing.T) {
 		t.Error("hasChangesRequested should return false for reviews submitted before PR creation")
 	}
 }
+
+func TestController_MaybeCloseParentIssue(t *testing.T) {
+	tests := []struct {
+		name           string
+		issueNumber    int
+		issueBody      string // Body of the sub-issue (returned by GetIssue)
+		openSubCount   int    // Count returned by SearchOpenSubIssues
+		searchErr      bool   // If true, search API returns error
+		getIssueErr    bool   // If true, GetIssue returns error
+		wantClosed     bool   // Whether parent issue should be closed
+		wantComment    bool   // Whether summary comment should be posted
+		wantLabelAdded bool   // Whether pilot-done label should be added
+	}{
+		{
+			name:           "last sub-issue triggers parent close",
+			issueNumber:    10,
+			issueBody:      "Some description\n\nParent: GH-5\n",
+			openSubCount:   0,
+			wantClosed:     true,
+			wantComment:    true,
+			wantLabelAdded: true,
+		},
+		{
+			name:         "sibling still open - no-op",
+			issueNumber:  10,
+			issueBody:    "Some description\n\nParent: GH-5\n",
+			openSubCount: 2,
+			wantClosed:   false,
+			wantComment:  false,
+		},
+		{
+			name:        "issue with no parent reference - no-op",
+			issueNumber: 10,
+			issueBody:   "Just a regular issue with no parent link",
+			wantClosed:  false,
+			wantComment: false,
+		},
+		{
+			name:        "no issue number - no-op",
+			issueNumber: 0,
+			wantClosed:  false,
+		},
+		{
+			name:        "GetIssue API error - graceful no-op",
+			issueNumber: 10,
+			getIssueErr: true,
+			wantClosed:  false,
+		},
+		{
+			name:        "SearchOpenSubIssues API error - graceful no-op",
+			issueNumber: 10,
+			issueBody:   "Parent: GH-5\n",
+			searchErr:   true,
+			wantClosed:  false,
+		},
+		{
+			name:           "label cleanup - pilot-failed removed on parent close",
+			issueNumber:    10,
+			issueBody:      "Parent: GH-5",
+			openSubCount:   0,
+			wantClosed:     true,
+			wantComment:    true,
+			wantLabelAdded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parentClosed := false
+			commentPosted := false
+			labelAdded := false
+			labelFailedRemoved := false
+			labelInProgressRemoved := false
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/repos/owner/repo/issues/10" && r.Method == http.MethodGet:
+					if tt.getIssueErr {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					issue := github.Issue{Number: 10, Body: tt.issueBody, State: "closed"}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(issue)
+
+				case r.URL.Path == "/search/issues" && r.Method == http.MethodGet:
+					if tt.searchErr {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					resp := struct {
+						TotalCount int `json:"total_count"`
+					}{TotalCount: tt.openSubCount}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+
+				case r.URL.Path == "/repos/owner/repo/issues/5/labels" && r.Method == http.MethodPost:
+					labelAdded = true
+					w.WriteHeader(http.StatusOK)
+
+				case r.URL.Path == "/repos/owner/repo/issues/5/labels/pilot-failed" && r.Method == http.MethodDelete:
+					labelFailedRemoved = true
+					w.WriteHeader(http.StatusOK)
+
+				case r.URL.Path == "/repos/owner/repo/issues/5/labels/pilot-in-progress" && r.Method == http.MethodDelete:
+					labelInProgressRemoved = true
+					w.WriteHeader(http.StatusOK)
+
+				case r.URL.Path == "/repos/owner/repo/issues/5" && r.Method == http.MethodPatch:
+					parentClosed = true
+					w.WriteHeader(http.StatusOK)
+
+				case r.URL.Path == "/repos/owner/repo/issues/5/comments" && r.Method == http.MethodPost:
+					commentPosted = true
+					resp := github.Comment{ID: 1, Body: "test"}
+					w.WriteHeader(http.StatusCreated)
+					_ = json.NewEncoder(w).Encode(resp)
+
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			prState := &PRState{
+				PRNumber:    42,
+				IssueNumber: tt.issueNumber,
+			}
+
+			c.maybeCloseParentIssue(context.Background(), prState)
+
+			if parentClosed != tt.wantClosed {
+				t.Errorf("parent closed = %v, want %v", parentClosed, tt.wantClosed)
+			}
+			if commentPosted != tt.wantComment {
+				t.Errorf("comment posted = %v, want %v", commentPosted, tt.wantComment)
+			}
+			if tt.wantLabelAdded && !labelAdded {
+				t.Error("expected pilot-done label to be added to parent")
+			}
+			if tt.wantClosed && !labelFailedRemoved {
+				t.Error("expected pilot-failed label removal attempt on parent")
+			}
+			if tt.wantClosed && !labelInProgressRemoved {
+				t.Error("expected pilot-in-progress label removal attempt on parent")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2086.

Closes #2086

## Changes

GitHub Issue #2086: Autopilot controller: Add `maybeCloseParentIssue()` and wire into `handleMerg...

Parent: GH-2084

In `internal/autopilot/controller.go`, add `maybeCloseParentIssue(ctx, prState)` that: fetches the sub-issue body, calls `ParseParentIssueNumber()`, calls `SearchOpenSubIssues()`, and if zero open siblings remain, adds `pilot-done` label, removes `pilot-failed`/`pilot-in-progress` labels, closes the parent issue, and posts a summary comment. All errors are logged as warnings without blocking the merge flow. Call this method at the end of `handleMerged()`. Add table-driven tests in `internal/autopilot/controller_test.go` covering: last sub-issue triggers parent close, sibling still open → no-op, issue with no parent reference → no-op, API errors → graceful no-op, and label cleanup (pilot-failed removed). Ensure all existing tests pass.