### PR TITLE
GH-2093: docs: Add auto-close parent issue section to epic decomposition page

### DIFF
--- a/docs/content/features/epic-decomposition.mdx
+++ b/docs/content/features/epic-decomposition.mdx
@@ -422,6 +422,56 @@ if !usedLLMClassifier && wordCount < d.config.MinDescriptionWords {
 }
 ```
 
+## Parent Issue Lifecycle
+
+When all sub-issues of a decomposed epic are completed, Pilot automatically closes the parent issue.
+
+<Callout type="info" emoji="🔗">
+  Added in v2.76.0. Parent auto-close is non-blocking — any errors are logged as warnings without affecting the merge flow.
+</Callout>
+
+### How It Works
+
+```
+Sub-issue PR Merged → Check Siblings → All Closed? → Close Parent
+```
+
+1. On each sub-issue PR merge, autopilot's `handleMerged()` calls `maybeCloseParentIssue()`
+2. The method reads the sub-issue body and looks for a `Parent: GH-{num}` reference
+3. Calls `SearchOpenSubIssues()` to count remaining open sibling issues
+4. If zero open siblings remain, closes the parent issue with a summary comment
+
+### Detection Mechanism
+
+Sub-issues are linked to their parent via a text pattern in the issue body, added automatically during epic decomposition:
+
+```markdown
+Parent: GH-123
+
+Implement OAuth flow for Google and GitHub providers...
+```
+
+The `ParseParentIssueNumber()` function extracts the parent issue number from this pattern. Issues without a `Parent: GH-{num}` reference are not treated as sub-issues.
+
+### Closure Flow
+
+When the last sub-issue is closed:
+
+1. `pilot-done` label is added to the parent issue
+2. `pilot-failed` and `pilot-in-progress` labels are removed (if present)
+3. The parent issue is closed
+4. A summary comment is posted on the parent issue
+
+### Search Query
+
+Open siblings are found using the GitHub search API:
+
+```
+repo:{owner}/{repo} "Parent: GH-{parentNum}" is:issue is:open
+```
+
+If the search returns zero results, all siblings are complete and the parent is eligible for closure.
+
 ## Version History
 
 - **v0.20.2**: Initial epic decomposition with Claude Code planning


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2093.

Closes #2093

## Changes

GitHub Issue #2093: docs: Add auto-close parent issue section to epic decomposition page

# Add Auto-Close Parent Issue Documentation

Update the epic decomposition docs page to cover automatic parent issue closure (v2.76.0).

## File

Update `docs/content/features/epic-decomposition.mdx` — add a "Parent Issue Lifecycle" section.

## Content to Cover

1. **Auto-close behavior** — When all sub-issues of a decomposed epic are closed (via merged PRs), the parent issue is automatically closed by `maybeCloseParentIssue()` in the autopilot controller's `handleMerged()` flow.

2. **How it works**:
   - On each PR merge, autopilot checks if the linked issue is a sub-issue
   - Uses `SearchOpenSubIssues()` to count remaining open siblings
   - If zero open siblings remain, closes the parent issue
   - All errors are non-blocking (logged as warnings)

3. **Detection** — Sub-issues are identified by `Parent: GH-{num}` text in the issue body (standard metadata from epic decomposition)

## Reference

- PRs #2087 (`SearchOpenSubIssues` method), #2088 (`maybeCloseParentIssue` + wiring)
- GH-2084 (parent issue)

## Acceptance Criteria

- [ ] New section in epic-decomposition.mdx explaining parent auto-close
- [ ] Describes detection mechanism (body text pattern)
- [ ] `cd docs && npm run build` passes