### PR TITLE
GH-2099: Add reviewers config for auto-assigning PR reviewers

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -47,6 +47,34 @@ func logGitHubAPIError(operation string, owner, repo string, issueNum int, err e
 	}
 }
 
+// requestReviewersFromConfig looks up the project config for the given sourceRepo
+// and requests PR reviewers if configured. Errors are logged but not propagated.
+func requestReviewersFromConfig(ctx context.Context, cfg *config.Config, client *github.Client, sourceRepo, owner, repo string, prNumber int) {
+	proj := cfg.FindProjectByRepo(sourceRepo)
+	if proj == nil {
+		return
+	}
+	if len(proj.Reviewers) == 0 && len(proj.TeamReviewers) == 0 {
+		return
+	}
+	if err := client.RequestReviewers(ctx, owner, repo, prNumber, proj.Reviewers, proj.TeamReviewers); err != nil {
+		logging.WithComponent("github").Warn("Failed to request PR reviewers",
+			slog.String("repo", sourceRepo),
+			slog.Int("pr", prNumber),
+			slog.Any("reviewers", proj.Reviewers),
+			slog.Any("team_reviewers", proj.TeamReviewers),
+			slog.Any("error", err),
+		)
+	} else {
+		slog.Info("PR reviewers requested",
+			slog.String("repo", sourceRepo),
+			slog.Int("pr", prNumber),
+			slog.Any("reviewers", proj.Reviewers),
+			slog.Any("team_reviewers", proj.TeamReviewers),
+		)
+	}
+}
+
 // parseAutopilotBranch extracts the target branch from an autopilot-fix issue's metadata comment.
 // Returns empty string if no metadata found.
 // Supports both old format (branch:X) and new format (branch:X pr:N).
@@ -292,6 +320,9 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				// GH-1869: Move to Review column when PR is created
 				if hr.PRNumber > 0 {
 					syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Review)
+
+					// GH-2099: Auto-assign PR reviewers from project config
+					requestReviewersFromConfig(ctx, cfg, client, sourceRepo, parts[0], parts[1], hr.PRNumber)
 				}
 				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Done) // GH-1853
 

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -238,6 +238,12 @@ projects:
     path: "/path/to/my-app"
     navigator: true           # Use Navigator for context efficiency
     default_branch: "main"
+    # PR reviewers - auto-assigned when Pilot creates a PR
+    # reviewers:
+    #   - alice
+    #   - bob
+    # team_reviewers:
+    #   - backend-team
     # GitHub integration for PR creation
     # github:
     #   owner: "my-org"

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -278,6 +278,25 @@ func (c *Client) CreatePullRequest(ctx context.Context, owner, repo string, inpu
 	}, DefaultRetryOptions())
 }
 
+// RequestReviewers requests reviewers for a pull request.
+// reviewers are individual GitHub usernames, teamReviewers are team slugs.
+func (c *Client) RequestReviewers(ctx context.Context, owner, repo string, number int, reviewers, teamReviewers []string) error {
+	if len(reviewers) == 0 && len(teamReviewers) == 0 {
+		return nil
+	}
+	return WithRetryVoid(ctx, func() error {
+		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, number)
+		body := map[string][]string{}
+		if len(reviewers) > 0 {
+			body["reviewers"] = reviewers
+		}
+		if len(teamReviewers) > 0 {
+			body["team_reviewers"] = teamReviewers
+		}
+		return c.doRequest(ctx, http.MethodPost, path, body, nil)
+	}, DefaultRetryOptions())
+}
+
 // GetPullRequest fetches a pull request by number
 func (c *Client) GetPullRequest(ctx context.Context, owner, repo string, number int) (*PullRequest, error) {
 	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number)

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -1921,6 +1921,90 @@ func TestHasApprovalReview(t *testing.T) {
 	}
 }
 
+func TestRequestReviewers(t *testing.T) {
+	tests := []struct {
+		name          string
+		reviewers     []string
+		teamReviewers []string
+		statusCode    int
+		wantErr       bool
+		wantSkipped   bool // expect no HTTP call
+	}{
+		{
+			name:       "success - individual reviewers",
+			reviewers:  []string{"alice", "bob"},
+			statusCode: http.StatusCreated,
+		},
+		{
+			name:          "success - team reviewers",
+			teamReviewers: []string{"backend-team"},
+			statusCode:    http.StatusCreated,
+		},
+		{
+			name:          "success - both individual and team",
+			reviewers:     []string{"alice"},
+			teamReviewers: []string{"frontend-team"},
+			statusCode:    http.StatusCreated,
+		},
+		{
+			name:        "skip - no reviewers",
+			wantSkipped: true,
+		},
+		{
+			name:       "error - not found",
+			reviewers:  []string{"nonexistent"},
+			statusCode: http.StatusUnprocessableEntity,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST, got %s", r.Method)
+				}
+				if !strings.Contains(r.URL.Path, "/requested_reviewers") {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+
+				var body map[string][]string
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("failed to decode request body: %v", err)
+				}
+				if len(tt.reviewers) > 0 {
+					if len(body["reviewers"]) != len(tt.reviewers) {
+						t.Errorf("reviewers = %v, want %v", body["reviewers"], tt.reviewers)
+					}
+				}
+				if len(tt.teamReviewers) > 0 {
+					if len(body["team_reviewers"]) != len(tt.teamReviewers) {
+						t.Errorf("team_reviewers = %v, want %v", body["team_reviewers"], tt.teamReviewers)
+					}
+				}
+
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			err := client.RequestReviewers(context.Background(), "owner", "repo", 42, tt.reviewers, tt.teamReviewers)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RequestReviewers() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantSkipped && called {
+				t.Error("RequestReviewers() should not make HTTP call when no reviewers specified")
+			}
+			if !tt.wantSkipped && !tt.wantErr && !called {
+				t.Error("RequestReviewers() should have made HTTP call")
+			}
+		})
+	}
+}
+
 func TestListPullRequests(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -173,6 +173,8 @@ type ProjectConfig struct {
 	Path          string               `yaml:"path"`
 	Navigator     bool                 `yaml:"navigator"`
 	DefaultBranch string               `yaml:"default_branch"`
+	Reviewers     []string             `yaml:"reviewers,omitempty"`
+	TeamReviewers []string             `yaml:"team_reviewers,omitempty"`
 	GitHub        *ProjectGitHubConfig `yaml:"github,omitempty"`
 	Linear        *ProjectLinearConfig `yaml:"linear,omitempty"`
 }
@@ -186,6 +188,19 @@ type ProjectGitHubConfig struct {
 // ProjectLinearConfig holds Linear-specific project configuration for project pairing.
 type ProjectLinearConfig struct {
 	ProjectID string `yaml:"project_id"`
+}
+
+// FindProjectByRepo returns the ProjectConfig whose GitHub owner/repo matches
+// the given "owner/repo" string, or nil if no match is found.
+func (c *Config) FindProjectByRepo(ownerRepo string) *ProjectConfig {
+	for _, p := range c.Projects {
+		if p.GitHub != nil {
+			if fmt.Sprintf("%s/%s", p.GitHub.Owner, p.GitHub.Repo) == ownerRepo {
+				return p
+			}
+		}
+	}
+	return nil
 }
 
 // DashboardConfig holds settings for the terminal UI dashboard.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1272,3 +1272,110 @@ team:
 		}
 	})
 }
+
+func TestFindProjectByRepo(t *testing.T) {
+	cfg := &Config{
+		Projects: []*ProjectConfig{
+			{
+				Name:          "app-one",
+				Reviewers:     []string{"alice", "bob"},
+				TeamReviewers: []string{"backend-team"},
+				GitHub: &ProjectGitHubConfig{
+					Owner: "my-org",
+					Repo:  "app-one",
+				},
+			},
+			{
+				Name: "app-two",
+				GitHub: &ProjectGitHubConfig{
+					Owner: "my-org",
+					Repo:  "app-two",
+				},
+			},
+			{
+				Name: "no-github",
+			},
+		},
+	}
+
+	t.Run("found with reviewers", func(t *testing.T) {
+		proj := cfg.FindProjectByRepo("my-org/app-one")
+		if proj == nil {
+			t.Fatal("expected project, got nil")
+		}
+		if proj.Name != "app-one" {
+			t.Errorf("Name = %s, want app-one", proj.Name)
+		}
+		if len(proj.Reviewers) != 2 {
+			t.Errorf("Reviewers count = %d, want 2", len(proj.Reviewers))
+		}
+		if len(proj.TeamReviewers) != 1 {
+			t.Errorf("TeamReviewers count = %d, want 1", len(proj.TeamReviewers))
+		}
+	})
+
+	t.Run("found without reviewers", func(t *testing.T) {
+		proj := cfg.FindProjectByRepo("my-org/app-two")
+		if proj == nil {
+			t.Fatal("expected project, got nil")
+		}
+		if len(proj.Reviewers) != 0 {
+			t.Errorf("Reviewers count = %d, want 0", len(proj.Reviewers))
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		proj := cfg.FindProjectByRepo("other-org/other-repo")
+		if proj != nil {
+			t.Errorf("expected nil, got %v", proj)
+		}
+	})
+
+	t.Run("empty config", func(t *testing.T) {
+		empty := &Config{}
+		proj := empty.FindProjectByRepo("my-org/app-one")
+		if proj != nil {
+			t.Errorf("expected nil, got %v", proj)
+		}
+	})
+}
+
+func TestProjectConfigReviewersYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+version: "1.0"
+projects:
+  - name: "my-app"
+    path: "/tmp/my-app"
+    reviewers:
+      - alice
+      - bob
+    team_reviewers:
+      - backend-team
+    github:
+      owner: "my-org"
+      repo: "my-app"
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if len(cfg.Projects) != 1 {
+		t.Fatalf("Projects count = %d, want 1", len(cfg.Projects))
+	}
+
+	proj := cfg.Projects[0]
+	if len(proj.Reviewers) != 2 || proj.Reviewers[0] != "alice" || proj.Reviewers[1] != "bob" {
+		t.Errorf("Reviewers = %v, want [alice bob]", proj.Reviewers)
+	}
+	if len(proj.TeamReviewers) != 1 || proj.TeamReviewers[0] != "backend-team" {
+		t.Errorf("TeamReviewers = %v, want [backend-team]", proj.TeamReviewers)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2099.

Closes #2099

## Changes

GitHub Issue #2099: Add reviewers config for auto-assigning PR reviewers

## Context

Requested in #2098 — users want to specify who to tag for code review.

Currently Pilot creates PRs without reviewers. Users must rely on GitHub CODEOWNERS or branch protection rules.

## Requirements

Add a `reviewers` field to project config:

```yaml
projects:
  my-project:
    reviewers:
      - alice
      - bob
    team_reviewers:
      - backend-team
```

When Pilot creates a PR, call the GitHub API to request reviewers:
- `POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers`
- Body: `{"reviewers": ["alice","bob"], "team_reviewers": ["backend-team"]}`

## Implementation

1. Add `Reviewers []string` and `TeamReviewers []string` to `ProjectConfig` in `internal/config/`
2. In `internal/adapters/github/client.go`, add `RequestReviewers(owner, repo string, prNumber int, reviewers, teamReviewers []string)` method
3. Call it after PR creation in `cmd/pilot/handlers.go` (the `onPRCreated` path)
4. Add to example config

## Scope

- Config parsing + validation
- GitHub API call after PR creation
- Example config update
- Tests for the new method