### PR TITLE
GH-2100: Add pilot init command for project scaffolding

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -143,11 +143,36 @@ func newStatusCmd() *cobra.Command {
 
 func newInitCmd() *cobra.Command {
 	var force bool
+	var projectMode bool
 
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Initialize Pilot configuration",
+		Short: "Initialize Pilot configuration or scaffold a project",
+		Long: `Initialize Pilot configuration or scaffold a project with CLAUDE.md.
+
+Without flags: initialize ~/.pilot/config.yaml (global Pilot config).
+With --project: run the interactive project scaffolding wizard in the current directory.
+
+The --project wizard:
+  - Detects the project language (Go, TypeScript, Python)
+  - Generates CLAUDE.md with coding conventions and quality gates
+  - Adds the project to ~/.pilot/config.yaml
+  - Optionally creates a .agent/ Navigator structure
+
+Examples:
+  pilot init            # Initialize global config
+  pilot init --project  # Scaffold project in current directory
+  pilot init --force    # Reinitialize global config (backs up existing)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Project scaffolding mode
+			if projectMode {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return fmt.Errorf("failed to get current directory: %w", err)
+				}
+				return runInitProject(cwd)
+			}
+
 			configPath := config.DefaultConfigPath()
 
 			// Check if config already exists
@@ -189,6 +214,7 @@ func newInitCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&force, "force", false, "Reinitialize config (backs up existing to .bak)")
+	cmd.Flags().BoolVar(&projectMode, "project", false, "Scaffold a project in the current directory (generates CLAUDE.md)")
 
 	return cmd
 }

--- a/cmd/pilot/init_project.go
+++ b/cmd/pilot/init_project.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alekspetrov/pilot/internal/config"
+)
+
+// ProjectTemplate represents the language/framework template for CLAUDE.md generation.
+type ProjectTemplate int
+
+const (
+	TemplateGo         ProjectTemplate = iota
+	TemplateTypeScript                 // TypeScript/Node
+	TemplatePython
+	TemplateGeneric
+)
+
+// String returns the display name of the template.
+func (t ProjectTemplate) String() string {
+	switch t {
+	case TemplateGo:
+		return "Go"
+	case TemplateTypeScript:
+		return "TypeScript/Node"
+	case TemplatePython:
+		return "Python"
+	default:
+		return "Generic"
+	}
+}
+
+// initProjectData holds all data collected during the project init wizard.
+type initProjectData struct {
+	ProjectName     string
+	ProjectPath     string
+	Template        ProjectTemplate
+	Conventions     []string
+	CommitFormat    string
+	Reviewers       []string
+	LintCmd         string
+	TestCmd         string
+	BuildCmd        string
+	CreateNavigator bool
+}
+
+// runInitProject runs the interactive project scaffolding wizard.
+// It generates CLAUDE.md in the current directory, updates ~/.pilot/config.yaml,
+// and optionally creates a .agent/ Navigator structure.
+func runInitProject(projectPath string) error {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Println()
+	printStageHeader("PROJECT INIT", 1, 1)
+	fmt.Println()
+
+	data := &initProjectData{
+		ProjectPath: projectPath,
+	}
+
+	// Step 1: Project name
+	defaultName := filepath.Base(projectPath)
+	data.ProjectName = readLineWithDefault(reader, "Project name", defaultName)
+
+	// Step 2: Language template (auto-detect, offer change)
+	detected := detectProjectTemplate(projectPath)
+	fmt.Println()
+	fmt.Printf("  Detected template: %s\n", onboardValueStyle.Render(detected.String()))
+	fmt.Println()
+	fmt.Print("  Change template? [y/N] ")
+	if readYesNo(reader, false) {
+		idx := selectOption(reader, "Select template:", []string{
+			"Go",
+			"TypeScript/Node",
+			"Python",
+			"Generic",
+		})
+		data.Template = ProjectTemplate(idx - 1)
+	} else {
+		data.Template = detected
+	}
+
+	// Step 3: Coding conventions (one per line, blank line to finish)
+	fmt.Println()
+	fmt.Println("  " + onboardLabelStyle.Render("Coding conventions") + " " + onboardDimStyle.Render("(one per line, empty to finish)"))
+	for {
+		fmt.Printf("  %s ", onboardCursorStyle.Render("▸"))
+		line := readLine(reader)
+		if line == "" {
+			break
+		}
+		data.Conventions = append(data.Conventions, line)
+	}
+
+	// Step 4: Commit message format
+	fmt.Println()
+	data.CommitFormat = readLineWithDefault(reader, "Commit format", "type(scope): description")
+
+	// Step 5: PR reviewers (GitHub usernames, comma-separated)
+	fmt.Println()
+	fmt.Println("  " + onboardLabelStyle.Render("PR reviewers") + " " + onboardDimStyle.Render("(GitHub usernames, comma-separated, optional)"))
+	fmt.Printf("  %s ", onboardCursorStyle.Render("▸"))
+	reviewersLine := readLine(reader)
+	if reviewersLine != "" {
+		for _, r := range strings.Split(reviewersLine, ",") {
+			r = strings.TrimSpace(r)
+			if r != "" {
+				data.Reviewers = append(data.Reviewers, r)
+			}
+		}
+	}
+
+	// Step 6: Quality gates
+	fmt.Println()
+	fmt.Println("  " + onboardLabelStyle.Render("Quality gates"))
+	data.LintCmd = readLineWithDefault(reader, "  Lint command", defaultLintCmd(data.Template))
+	data.TestCmd = readLineWithDefault(reader, "  Test command", defaultTestCmd(data.Template))
+	data.BuildCmd = readLineWithDefault(reader, "  Build command", defaultBuildCmd(data.Template))
+
+	// Step 7: Navigator structure (only ask if not already present)
+	if !detectNavigator(projectPath) {
+		fmt.Println()
+		fmt.Print("  Create .agent/ Navigator structure? [y/N] ")
+		data.CreateNavigator = readYesNo(reader, false)
+	}
+
+	fmt.Println()
+	printStageFooter()
+	fmt.Println()
+
+	// Generate CLAUDE.md
+	claudePath := filepath.Join(projectPath, "CLAUDE.md")
+	claudeContent := buildClaudeMD(data)
+	if err := os.WriteFile(claudePath, []byte(claudeContent), 0o644); err != nil {
+		return fmt.Errorf("failed to write CLAUDE.md: %w", err)
+	}
+	fmt.Printf("  %s CLAUDE.md created\n", onboardSuccessStyle.Render("✓"))
+
+	// Create .agent/ structure if requested
+	if data.CreateNavigator {
+		if err := createNavigatorStructure(projectPath, data); err != nil {
+			fmt.Printf("  %s Warning: failed to create .agent/: %v\n", onboardFailStyle.Render("!"), err)
+		} else {
+			fmt.Printf("  %s .agent/ Navigator structure created\n", onboardSuccessStyle.Render("✓"))
+		}
+	}
+
+	// Update ~/.pilot/config.yaml
+	if err := addProjectToConfig(data); err != nil {
+		fmt.Printf("  %s Warning: failed to update Pilot config: %v\n", onboardFailStyle.Render("!"), err)
+	} else {
+		fmt.Printf("  %s Project added to ~/.pilot/config.yaml\n", onboardSuccessStyle.Render("✓"))
+	}
+
+	fmt.Println()
+	fmt.Println("  Next steps:")
+	fmt.Println("  1. Review and customize CLAUDE.md")
+	fmt.Println("  2. Run " + onboardValueStyle.Render("pilot start") + " to begin processing tasks")
+
+	return nil
+}
+
+// detectProjectTemplate auto-detects the language template from project files.
+func detectProjectTemplate(projectPath string) ProjectTemplate {
+	// Go: go.mod present
+	if fileExists(filepath.Join(projectPath, "go.mod")) {
+		return TemplateGo
+	}
+	// TypeScript: tsconfig.json or package.json
+	if fileExists(filepath.Join(projectPath, "tsconfig.json")) {
+		return TemplateTypeScript
+	}
+	if fileExists(filepath.Join(projectPath, "package.json")) {
+		return TemplateTypeScript
+	}
+	// Python: pyproject.toml, setup.py, or requirements.txt
+	if fileExists(filepath.Join(projectPath, "pyproject.toml")) ||
+		fileExists(filepath.Join(projectPath, "setup.py")) ||
+		fileExists(filepath.Join(projectPath, "requirements.txt")) {
+		return TemplatePython
+	}
+	return TemplateGeneric
+}
+
+// fileExists returns true if the path exists.
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// defaultLintCmd returns the default lint command for a given template.
+func defaultLintCmd(t ProjectTemplate) string {
+	switch t {
+	case TemplateGo:
+		return "golangci-lint run ./..."
+	case TemplateTypeScript:
+		return "npm run lint"
+	case TemplatePython:
+		return "ruff check ."
+	default:
+		return ""
+	}
+}
+
+// defaultTestCmd returns the default test command for a given template.
+func defaultTestCmd(t ProjectTemplate) string {
+	switch t {
+	case TemplateGo:
+		return "go test ./..."
+	case TemplateTypeScript:
+		return "npm test"
+	case TemplatePython:
+		return "pytest"
+	default:
+		return ""
+	}
+}
+
+// defaultBuildCmd returns the default build command for a given template.
+func defaultBuildCmd(t ProjectTemplate) string {
+	switch t {
+	case TemplateGo:
+		return "go build ./..."
+	case TemplateTypeScript:
+		return "npm run build"
+	case TemplatePython:
+		return ""
+	default:
+		return ""
+	}
+}
+
+// buildClaudeMD generates the CLAUDE.md content from the collected wizard data.
+func buildClaudeMD(data *initProjectData) string {
+	var sb strings.Builder
+
+	sb.WriteString("# " + data.ProjectName + "\n\n")
+
+	// Language-specific header block
+	switch data.Template {
+	case TemplateGo:
+		sb.WriteString("## Code Standards\n\n")
+		sb.WriteString("- Follow standard Go conventions, `go fmt`, `golangci-lint`\n")
+		sb.WriteString("- Table-driven tests for Go\n")
+	case TemplateTypeScript:
+		sb.WriteString("## Code Standards\n\n")
+		sb.WriteString("- Follow TypeScript best practices, strict mode enabled\n")
+		sb.WriteString("- Use ESLint + Prettier for formatting\n")
+		sb.WriteString("- Write tests with Jest or Vitest\n")
+	case TemplatePython:
+		sb.WriteString("## Code Standards\n\n")
+		sb.WriteString("- PEP 8, type hints, dataclasses\n")
+		sb.WriteString("- Use Ruff for linting, Black for formatting\n")
+		sb.WriteString("- Write tests with pytest\n")
+	default:
+		sb.WriteString("## Code Standards\n\n")
+	}
+
+	// Custom conventions
+	for _, c := range data.Conventions {
+		sb.WriteString("- " + c + "\n")
+	}
+	sb.WriteString("\n")
+
+	// Commit format
+	sb.WriteString("## Commit Format\n\n")
+	sb.WriteString("```\n")
+	sb.WriteString(data.CommitFormat + "\n")
+	sb.WriteString("```\n\n")
+
+	// Quality gates
+	hasGates := data.LintCmd != "" || data.TestCmd != "" || data.BuildCmd != ""
+	if hasGates {
+		sb.WriteString("## Quality Gates\n\n")
+		if data.LintCmd != "" {
+			sb.WriteString("```bash\n" + data.LintCmd + "\n```\n\n")
+		}
+		if data.TestCmd != "" {
+			sb.WriteString("```bash\n" + data.TestCmd + "\n```\n\n")
+		}
+		if data.BuildCmd != "" {
+			sb.WriteString("```bash\n" + data.BuildCmd + "\n```\n\n")
+		}
+	}
+
+	// PR reviewers
+	if len(data.Reviewers) > 0 {
+		sb.WriteString("## Review Assignments\n\n")
+		for _, r := range data.Reviewers {
+			sb.WriteString("- @" + r + "\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// createNavigatorStructure creates the .agent/ directory with a basic README.
+func createNavigatorStructure(projectPath string, data *initProjectData) error {
+	agentDir := filepath.Join(projectPath, ".agent")
+	tasksDir := filepath.Join(agentDir, "tasks")
+	sopsDir := filepath.Join(agentDir, "sops")
+
+	for _, dir := range []string{agentDir, tasksDir, sopsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", dir, err)
+		}
+	}
+
+	readmeContent := "# Navigator Index\n\n" +
+		"## Project: " + data.ProjectName + "\n\n" +
+		"## Key Docs\n\n" +
+		"- `tasks/` — Implementation plans\n" +
+		"- `sops/` — Standard Operating Procedures\n\n" +
+		"## Quick Commands\n\n" +
+		"```bash\n" +
+		"/nav-start          # Start session, load context\n" +
+		"/nav-task \"feature\" # Plan implementation\n" +
+		"```\n"
+
+	readmePath := filepath.Join(agentDir, "DEVELOPMENT-README.md")
+	return os.WriteFile(readmePath, []byte(readmeContent), 0o644)
+}
+
+// addProjectToConfig adds the project to ~/.pilot/config.yaml.
+// Creates the config file with defaults if it does not exist.
+func addProjectToConfig(data *initProjectData) error {
+	configPath := config.DefaultConfigPath()
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		cfg = config.DefaultConfig()
+	}
+
+	// Check for duplicate project path or name
+	for _, existing := range cfg.Projects {
+		if existing.Path == data.ProjectPath || existing.Name == data.ProjectName {
+			return nil // Already registered, skip silently
+		}
+	}
+
+	proj := &config.ProjectConfig{
+		Name:          data.ProjectName,
+		Path:          data.ProjectPath,
+		Navigator:     data.CreateNavigator || detectNavigator(data.ProjectPath),
+		DefaultBranch: detectDefaultBranch(data.ProjectPath),
+	}
+
+	// Parse git remote for GitHub owner/repo
+	owner, repo, err := detectGitRemote(data.ProjectPath)
+	if err == nil && owner != "" && repo != "" {
+		proj.GitHub = &config.ProjectGitHubConfig{
+			Owner: owner,
+			Repo:  repo,
+		}
+	}
+
+	cfg.Projects = append(cfg.Projects, proj)
+
+	if len(cfg.Projects) == 1 {
+		cfg.DefaultProject = data.ProjectName
+	}
+
+	return config.Save(cfg, configPath)
+}

--- a/cmd/pilot/init_project_test.go
+++ b/cmd/pilot/init_project_test.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDetectProjectTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    []string // files to create in temp dir
+		expected ProjectTemplate
+	}{
+		{
+			name:     "detects Go from go.mod",
+			files:    []string{"go.mod"},
+			expected: TemplateGo,
+		},
+		{
+			name:     "detects TypeScript from tsconfig.json",
+			files:    []string{"tsconfig.json"},
+			expected: TemplateTypeScript,
+		},
+		{
+			name:     "detects TypeScript from package.json",
+			files:    []string{"package.json"},
+			expected: TemplateTypeScript,
+		},
+		{
+			name:     "detects Python from pyproject.toml",
+			files:    []string{"pyproject.toml"},
+			expected: TemplatePython,
+		},
+		{
+			name:     "detects Python from setup.py",
+			files:    []string{"setup.py"},
+			expected: TemplatePython,
+		},
+		{
+			name:     "detects Python from requirements.txt",
+			files:    []string{"requirements.txt"},
+			expected: TemplatePython,
+		},
+		{
+			name:     "falls back to Generic when no markers present",
+			files:    []string{"README.md"},
+			expected: TemplateGeneric,
+		},
+		{
+			name:     "Go takes priority over TypeScript",
+			files:    []string{"go.mod", "package.json"},
+			expected: TemplateGo,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range tt.files {
+				if err := os.WriteFile(filepath.Join(dir, f), []byte(""), 0o644); err != nil {
+					t.Fatalf("failed to create %s: %v", f, err)
+				}
+			}
+
+			got := detectProjectTemplate(dir)
+			if got != tt.expected {
+				t.Errorf("detectProjectTemplate() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestProjectTemplateString(t *testing.T) {
+	tests := []struct {
+		tmpl     ProjectTemplate
+		expected string
+	}{
+		{TemplateGo, "Go"},
+		{TemplateTypeScript, "TypeScript/Node"},
+		{TemplatePython, "Python"},
+		{TemplateGeneric, "Generic"},
+	}
+	for _, tt := range tests {
+		if got := tt.tmpl.String(); got != tt.expected {
+			t.Errorf("ProjectTemplate(%d).String() = %q, want %q", tt.tmpl, got, tt.expected)
+		}
+	}
+}
+
+func TestDefaultCommands(t *testing.T) {
+	tests := []struct {
+		tmpl      ProjectTemplate
+		lintWant  string
+		testWant  string
+		buildWant string
+	}{
+		{TemplateGo, "golangci-lint run ./...", "go test ./...", "go build ./..."},
+		{TemplateTypeScript, "npm run lint", "npm test", "npm run build"},
+		{TemplatePython, "ruff check .", "pytest", ""},
+		{TemplateGeneric, "", "", ""},
+	}
+	for _, tt := range tests {
+		if got := defaultLintCmd(tt.tmpl); got != tt.lintWant {
+			t.Errorf("defaultLintCmd(%v) = %q, want %q", tt.tmpl, got, tt.lintWant)
+		}
+		if got := defaultTestCmd(tt.tmpl); got != tt.testWant {
+			t.Errorf("defaultTestCmd(%v) = %q, want %q", tt.tmpl, got, tt.testWant)
+		}
+		if got := defaultBuildCmd(tt.tmpl); got != tt.buildWant {
+			t.Errorf("defaultBuildCmd(%v) = %q, want %q", tt.tmpl, got, tt.buildWant)
+		}
+	}
+}
+
+func TestBuildClaudeMD(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     *initProjectData
+		contains []string
+		absent   []string
+	}{
+		{
+			name: "Go template with all fields",
+			data: &initProjectData{
+				ProjectName:  "myapp",
+				Template:     TemplateGo,
+				Conventions:  []string{"Keep it simple", "No globals"},
+				CommitFormat: "feat(scope): description",
+				Reviewers:    []string{"alice", "bob"},
+				LintCmd:      "golangci-lint run ./...",
+				TestCmd:      "go test ./...",
+				BuildCmd:     "go build ./...",
+			},
+			contains: []string{
+				"# myapp",
+				"go fmt",
+				"golangci-lint",
+				"Table-driven tests",
+				"Keep it simple",
+				"No globals",
+				"feat(scope): description",
+				"@alice",
+				"@bob",
+				"golangci-lint run ./...",
+				"go test ./...",
+				"go build ./...",
+			},
+		},
+		{
+			name: "TypeScript template",
+			data: &initProjectData{
+				ProjectName: "webapp",
+				Template:    TemplateTypeScript,
+				LintCmd:     "npm run lint",
+				TestCmd:     "npm test",
+				BuildCmd:    "npm run build",
+			},
+			contains: []string{
+				"# webapp",
+				"TypeScript",
+				"ESLint",
+				"npm run lint",
+				"npm test",
+			},
+		},
+		{
+			name: "Python template",
+			data: &initProjectData{
+				ProjectName: "myservice",
+				Template:    TemplatePython,
+				LintCmd:     "ruff check .",
+				TestCmd:     "pytest",
+			},
+			contains: []string{
+				"# myservice",
+				"PEP 8",
+				"pytest",
+				"ruff check .",
+			},
+		},
+		{
+			name: "Generic template minimal",
+			data: &initProjectData{
+				ProjectName:  "tool",
+				Template:     TemplateGeneric,
+				CommitFormat: "type: msg",
+			},
+			contains: []string{
+				"# tool",
+				"type: msg",
+			},
+		},
+		{
+			name: "No reviewers section when empty",
+			data: &initProjectData{
+				ProjectName:  "svc",
+				Template:     TemplateGo,
+				CommitFormat: "feat: msg",
+				Reviewers:    nil,
+			},
+			absent: []string{"## Review Assignments"},
+		},
+		{
+			name: "No quality gates section when all empty",
+			data: &initProjectData{
+				ProjectName:  "svc",
+				Template:     TemplateGeneric,
+				CommitFormat: "feat: msg",
+				LintCmd:      "",
+				TestCmd:      "",
+				BuildCmd:     "",
+			},
+			absent: []string{"## Quality Gates"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildClaudeMD(tt.data)
+
+			for _, want := range tt.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("buildClaudeMD() missing %q\nGot:\n%s", want, got)
+				}
+			}
+
+			for _, absent := range tt.absent {
+				if strings.Contains(got, absent) {
+					t.Errorf("buildClaudeMD() should not contain %q\nGot:\n%s", absent, got)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateNavigatorStructure(t *testing.T) {
+	dir := t.TempDir()
+	data := &initProjectData{
+		ProjectName: "testproject",
+		ProjectPath: dir,
+	}
+
+	if err := createNavigatorStructure(dir, data); err != nil {
+		t.Fatalf("createNavigatorStructure() error: %v", err)
+	}
+
+	// Verify directories exist
+	for _, sub := range []string{".agent", ".agent/tasks", ".agent/sops"} {
+		info, err := os.Stat(filepath.Join(dir, sub))
+		if err != nil {
+			t.Errorf("expected directory %s to exist: %v", sub, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("expected %s to be a directory", sub)
+		}
+	}
+
+	// Verify DEVELOPMENT-README.md exists and contains project name
+	readmePath := filepath.Join(dir, ".agent", "DEVELOPMENT-README.md")
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("failed to read DEVELOPMENT-README.md: %v", err)
+	}
+	if !strings.Contains(string(content), "testproject") {
+		t.Errorf("DEVELOPMENT-README.md does not contain project name")
+	}
+}
+
+func TestAddProjectToConfig_NoDuplicate(t *testing.T) {
+	// Write a temp config
+	dir := t.TempDir()
+	if err := os.Setenv("HOME", dir); err != nil { // redirect config path
+		t.Fatalf("failed to set HOME: %v", err)
+	}
+	defer func() { _ = os.Unsetenv("HOME") }()
+
+	data := &initProjectData{
+		ProjectName: "proj",
+		ProjectPath: dir,
+	}
+
+	// First call should succeed
+	if err := addProjectToConfig(data); err != nil {
+		t.Fatalf("addProjectToConfig() first call error: %v", err)
+	}
+
+	// Second call with same path should not error and not duplicate
+	if err := addProjectToConfig(data); err != nil {
+		t.Fatalf("addProjectToConfig() second call error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2100.

Closes #2100

## Changes

GitHub Issue #2100: Add pilot init command for project scaffolding

## Context

Requested in #2098 — users don't know about CLAUDE.md as the custom rules mechanism. Need a guided setup.

## Requirements

`pilot init` command that scaffolds project configuration:

1. **Interactive wizard** (similar to `npm init`):
   - Project name
   - Coding patterns/conventions
   - Commit message format
   - Review assignment preferences
   - Quality gates (lint, test commands)

2. **Output files**:
   - `CLAUDE.md` with project rules template
   - Update `~/.pilot/config.yaml` with project entry
   - Optionally create `.agent/` Navigator structure

3. **Templates**:
   - Go project template
   - Node/TypeScript template
   - Python template
   - Generic template

## Implementation

1. Add `initCmd` to `cmd/pilot/` using cobra
2. Interactive prompts via `survey` or `bubbletea` (we already have bubbletea)
3. Template files in `internal/executor/templates/` (extend existing Navigator templates)
4. Write CLAUDE.md + update config

## Scope

- CLI command + interactive prompts
- 4 language templates
- Config file generation
- Tests