### PR TITLE
GH-2103: fix(executor): LocalMode prompt priority + heartbeat cancel on result

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -313,6 +313,7 @@ func newTaskCmd() *cobra.Command {
 	var verbose bool
 	var enableAlerts bool
 	var enableBudget bool
+	var localMode bool    // GH-2103: problem-solving prompt without PR constraints
 	var teamID string     // GH-635: team project access scoping
 	var teamMember string // GH-635: member email for access scoping
 
@@ -328,7 +329,8 @@ Examples:
   pilot task "Fix the login bug in auth.go" --project /path/to/project
   pilot task "Refactor the API handlers" --dry-run
   pilot task "Add index.py with hello world" --verbose
-  pilot task "Fix bug" --alerts`,
+  pilot task "Fix bug" --alerts
+  pilot task "Fix bug" --local`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			taskDesc := args[0]
@@ -389,6 +391,7 @@ Examples:
 				Branch:      branchName,
 				Verbose:     verbose,
 				CreatePR:    true,
+				LocalMode:   localMode, // GH-2103
 			}
 
 			// Dry run mode - just show what would happen
@@ -745,6 +748,7 @@ Examples:
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Stream Claude Code output")
 	cmd.Flags().BoolVar(&enableAlerts, "alerts", false, "Enable alerts for task execution")
 	cmd.Flags().BoolVar(&enableBudget, "budget", false, "Enable budget enforcement for this task")
+	cmd.Flags().BoolVar(&localMode, "local", false, "Use problem-solving prompt without PR/Navigator constraints")
 	cmd.Flags().StringVar(&teamID, "team", "", "Team ID or name for project access scoping (overrides config)")
 	cmd.Flags().StringVar(&teamMember, "team-member", "", "Member email for team access scoping (overrides config)")
 

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -411,6 +411,11 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 
 			// Track final result
 			if event.Type == EventTypeResult {
+				// GH-2103: Cancel heartbeat on result event.
+				// On slow I/O flush, the heartbeat timer could fire and kill
+				// the process after it had already produced output.
+				cancelHeartbeat()
+
 				if event.IsError {
 					result.Error = event.Message
 				} else {

--- a/internal/executor/prompt_builder.go
+++ b/internal/executor/prompt_builder.go
@@ -22,6 +22,13 @@ func (r *Runner) BuildPrompt(task *Task, executionPath string) string {
 		return sb.String()
 	}
 
+	// GH-2103: LocalMode takes priority over Navigator detection.
+	// Sandbox environments with .agent/ dirs would hijack the prompt to Navigator path,
+	// ignoring --local flag entirely.
+	if task.LocalMode {
+		return r.buildLocalModePrompt(task)
+	}
+
 	// Check if project has Navigator initialized (use executionPath for worktree support)
 	agentDir := filepath.Join(executionPath, ".agent")
 	hasNavigator := false
@@ -247,6 +254,52 @@ func (r *Runner) BuildPrompt(task *Task, executionPath string) string {
 	}
 
 	return prompt
+}
+
+// buildLocalModePrompt constructs a problem-solving prompt for local execution (GH-2103).
+// It skips Navigator workflow, PR constraints, and project context injection.
+// Designed for `pilot task --local` where the goal is direct problem-solving.
+func (r *Runner) buildLocalModePrompt(task *Task) string {
+	var sb strings.Builder
+
+	sb.WriteString("## Problem-Solving Mode\n\n")
+	sb.WriteString("You are solving a development task locally. Focus on the problem, not process.\n\n")
+
+	sb.WriteString(fmt.Sprintf("## Task: %s\n\n", task.ID))
+	sb.WriteString(fmt.Sprintf("%s\n\n", task.Description))
+
+	// Include acceptance criteria if present
+	if len(task.AcceptanceCriteria) > 0 {
+		sb.WriteString("## Acceptance Criteria\n\n")
+		for i, criterion := range task.AcceptanceCriteria {
+			sb.WriteString(fmt.Sprintf("%d. [ ] %s\n", i+1, criterion))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("## Instructions\n\n")
+
+	// Test-first instruction when task mentions test files
+	if hasTestFiles(task.Description) {
+		sb.WriteString("- Write tests FIRST, then implement the solution\n")
+	}
+
+	sb.WriteString("- Read existing code before making changes\n")
+	sb.WriteString("- Make minimal, focused changes\n")
+	sb.WriteString("- Verify build passes: `go build ./...` (or equivalent)\n")
+	sb.WriteString("- Run tests for changed packages\n")
+	sb.WriteString("- Commit with format: `type(scope): description`\n\n")
+	sb.WriteString("Work autonomously. Do not ask for confirmation.\n")
+
+	return sb.String()
+}
+
+// hasTestFiles checks if the task description references test files.
+func hasTestFiles(description string) bool {
+	desc := strings.ToLower(description)
+	return strings.Contains(desc, "_test.go") ||
+		strings.Contains(desc, "test_") ||
+		strings.Contains(desc, "test file")
 }
 
 // buildRetryPrompt constructs a prompt for Claude Code to fix quality gate failures.

--- a/internal/executor/prompt_builder_test.go
+++ b/internal/executor/prompt_builder_test.go
@@ -618,6 +618,88 @@ func TestBuildPromptSkipsNavigatorForTrivialTask(t *testing.T) {
 	}
 }
 
+func TestBuildPromptLocalMode(t *testing.T) {
+	// GH-2103: LocalMode should use problem-solving prompt even if .agent/ exists
+	tempDir, err := os.MkdirTemp("", "pilot-test-local")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	// Create .agent/ directory to simulate Navigator project
+	agentDir := filepath.Join(tempDir, ".agent")
+	if err := os.MkdirAll(agentDir, 0755); err != nil {
+		t.Fatalf("Failed to create .agent dir: %v", err)
+	}
+
+	runner := NewRunner()
+	task := &Task{
+		ID:          "LOCAL-123",
+		Title:       "Fix bug locally",
+		Description: "Fix the authentication bug in auth_test.go",
+		ProjectPath: tempDir,
+		LocalMode:   true,
+	}
+
+	prompt := runner.BuildPrompt(task, tempDir)
+
+	// Should use problem-solving prompt
+	if !strings.Contains(prompt, "## Problem-Solving Mode") {
+		t.Error("LocalMode should produce problem-solving prompt")
+	}
+
+	// Should NOT contain Navigator/PR workflow elements
+	if strings.Contains(prompt, "PILOT EXECUTION MODE") {
+		t.Error("LocalMode should not contain PILOT EXECUTION MODE header")
+	}
+	if strings.Contains(prompt, "## Project Context") {
+		t.Error("LocalMode should not inject project context")
+	}
+	if strings.Contains(prompt, "## Relevant SOPs") {
+		t.Error("LocalMode should not inject SOPs")
+	}
+	if strings.Contains(prompt, "optionally CREATE PRs") {
+		t.Error("LocalMode should not mention PR creation constraints")
+	}
+
+	// Should contain task details
+	if !strings.Contains(prompt, "## Task: LOCAL-123") {
+		t.Error("LocalMode should contain task ID")
+	}
+	if !strings.Contains(prompt, "Fix the authentication bug") {
+		t.Error("LocalMode should contain task description")
+	}
+
+	// Should include test-first instruction since description mentions test file
+	if !strings.Contains(prompt, "Write tests FIRST") {
+		t.Error("LocalMode should include test-first instruction when task mentions test files")
+	}
+}
+
+func TestBuildPromptLocalModeWithoutTestFiles(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "pilot-test-local-notest")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	runner := NewRunner()
+	task := &Task{
+		ID:          "LOCAL-456",
+		Title:       "Add feature",
+		Description: "Add rate limiting to API endpoints",
+		ProjectPath: tempDir,
+		LocalMode:   true,
+	}
+
+	prompt := runner.BuildPrompt(task, tempDir)
+
+	// Should NOT include test-first instruction for non-test tasks
+	if strings.Contains(prompt, "Write tests FIRST") {
+		t.Error("LocalMode should not include test-first instruction when task doesn't mention test files")
+	}
+}
+
 func TestBuildPromptNoNavigator(t *testing.T) {
 	// Test with non-Navigator project (no .agent/ directory)
 	tempDir, err := os.MkdirTemp("", "pilot-test-no-nav")

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -156,6 +156,10 @@ type Task struct {
 	// For Jira: issue key (e.g., "PROJ-789")
 	// Used as parentID when creating sub-issues via SubIssueCreator.
 	SourceIssueID string
+	// LocalMode enables problem-solving prompt without PR constraints (GH-2103).
+	// When true, BuildPrompt skips Navigator detection and uses a focused
+	// problem-solving prompt suitable for local execution.
+	LocalMode bool
 }
 
 // QualityGateResult represents the result of a single quality gate check.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2103.

Closes #2103

## Changes

GitHub Issue #2103: fix(executor): LocalMode prompt priority + heartbeat cancel on result

## Context

Bench validation (val10) revealed two bugs in the executor that affect `pilot exec --local` and general execution reliability.

**Source branch**: `feat/pilot-bench-real` commit `010cb448`

## Problem

1. **LocalMode prompt ignored**: `BuildPrompt()` checked for Navigator (`.agent/` dir) before checking `task.LocalMode`. Sandbox environments with `.agent/` dirs hijacked the prompt to Navigator path, ignoring `--local` flag entirely.

2. **Post-completion heartbeat kills**: Heartbeat timer continued running after receiving a `result` event. On slow I/O flush, the timer could fire and kill the process *after* it had already produced output.

## Implementation

### Cherry-pick from `feat/pilot-bench-real` (commit `010cb448`):

**`internal/executor/prompt_builder.go`**:
- Check `task.LocalMode` FIRST (line 27), before Navigator detection (line 32)
- Extract `buildLocalModePrompt()` — problem-solving prompt without restrictive PR constraints
- Includes test-first instruction for tasks with test files

**`internal/executor/runner.go`**:
- Add `LocalMode bool` field to `Task` struct (line 159-162)

**`cmd/pilot/commands.go`**:
- Wire `task.LocalMode = true` when `--local` flag is set

**`internal/executor/backend_claudecode.go`**:
- Cancel heartbeat goroutine on `result` event (line 419)

**`internal/executor/prompt_builder_test.go`**:
- `TestBuildPromptLocalMode` — verifies problem-solving prompt, no PR constraint leakage

## Acceptance Criteria

- [ ] `pilot exec --local` uses problem-solving prompt even if `.agent/` exists in working dir
- [ ] Heartbeat timer stops on result event
- [ ] `TestBuildPromptLocalMode` passes
- [ ] All existing tests pass (`go test ./internal/executor/...`)

## Notes

Do NOT cherry-pick the `HeartbeatTimeout = 15 * time.Minute` constant change — that's handled separately in a configurable timeout issue.