### PR TITLE
GH-2104: feat(executor): configurable HeartbeatTimeout via config.yaml

### DIFF
--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -267,6 +267,11 @@ type BackendConfig struct {
 	// GH-1376: Added to prevent lint-failure cascades
 	PrePushLint *bool `yaml:"pre_push_lint,omitempty"`
 
+	// HeartbeatTimeout is the time to wait for any stream-json event before
+	// considering the subprocess hung and killing it.
+	// Valid range: 1m to 30m. Default: 5m.
+	HeartbeatTimeout time.Duration `yaml:"heartbeat_timeout,omitempty"`
+
 	// PlanningTimeout is the maximum time to wait for epic planning (PlanEpic).
 	// If planning exceeds this timeout, execution falls through to direct (non-epic) mode.
 	// Default: 2m
@@ -275,6 +280,21 @@ type BackendConfig struct {
 	// Version is the Pilot binary version, set at startup from the build-time version var.
 	// Used for feature matrix updates and execution reports. Not a config file field.
 	Version string `yaml:"-"`
+}
+
+// EffectiveHeartbeatTimeout returns the heartbeat timeout to use, applying
+// defaults and clamping to the valid range [1m, 30m].
+func (c *BackendConfig) EffectiveHeartbeatTimeout() time.Duration {
+	if c == nil || c.HeartbeatTimeout <= 0 {
+		return DefaultHeartbeatTimeout
+	}
+	if c.HeartbeatTimeout < MinHeartbeatTimeout {
+		return MinHeartbeatTimeout
+	}
+	if c.HeartbeatTimeout > MaxHeartbeatTimeout {
+		return MaxHeartbeatTimeout
+	}
+	return c.HeartbeatTimeout
 }
 
 // ModelRoutingConfig controls which model to use based on task complexity.

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -20,8 +20,14 @@ import (
 // This allows the process to clean up gracefully if it responds to SIGTERM.
 const GracePeriod = 5 * time.Second
 
-// HeartbeatTimeout is the time to wait for any stream-json event before considering the process hung.
-const HeartbeatTimeout = 5 * time.Minute
+// DefaultHeartbeatTimeout is the default time to wait for any stream-json event before considering the process hung.
+const DefaultHeartbeatTimeout = 5 * time.Minute
+
+// MinHeartbeatTimeout is the minimum allowed heartbeat timeout.
+const MinHeartbeatTimeout = 1 * time.Minute
+
+// MaxHeartbeatTimeout is the maximum allowed heartbeat timeout.
+const MaxHeartbeatTimeout = 30 * time.Minute
 
 // HeartbeatCheckInterval is how often to check for heartbeat timeout.
 const HeartbeatCheckInterval = 30 * time.Second
@@ -156,8 +162,9 @@ func parseClaudeCodeError(stderr string, originalErr error) error {
 
 // ClaudeCodeBackend implements Backend for Claude Code CLI.
 type ClaudeCodeBackend struct {
-	config *ClaudeCodeConfig
-	log    *slog.Logger
+	config           *ClaudeCodeConfig
+	heartbeatTimeout time.Duration
+	log              *slog.Logger
 }
 
 // NewClaudeCodeBackend creates a new Claude Code backend.
@@ -169,9 +176,15 @@ func NewClaudeCodeBackend(config *ClaudeCodeConfig) *ClaudeCodeBackend {
 		config.Command = "claude"
 	}
 	return &ClaudeCodeBackend{
-		config: config,
-		log:    logging.WithComponent("executor.claudecode"),
+		config:           config,
+		heartbeatTimeout: DefaultHeartbeatTimeout,
+		log:              logging.WithComponent("executor.claudecode"),
 	}
+}
+
+// SetHeartbeatTimeout sets a custom heartbeat timeout for this backend.
+func (b *ClaudeCodeBackend) SetHeartbeatTimeout(d time.Duration) {
+	b.heartbeatTimeout = d
 }
 
 // Name returns the backend identifier.
@@ -314,11 +327,11 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 				lastNano := lastEventAt.Load()
 				lastTime := time.Unix(0, lastNano)
 				age := time.Since(lastTime)
-				if age > HeartbeatTimeout {
+				if age > b.heartbeatTimeout {
 					b.log.Warn("Heartbeat timeout detected, killing hung process",
 						slog.Int("pid", cmd.Process.Pid),
 						slog.Duration("last_event_age", age),
-						slog.Duration("timeout", HeartbeatTimeout),
+						slog.Duration("timeout", b.heartbeatTimeout),
 					)
 
 					// Invoke callback if provided

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -231,8 +231,14 @@ func TestClaudeCodeBackendContextCancellation(t *testing.T) {
 
 func TestHeartbeatConstants(t *testing.T) {
 	// Verify heartbeat constants are set to expected values
-	if HeartbeatTimeout != 5*time.Minute {
-		t.Errorf("HeartbeatTimeout = %v, want 5m", HeartbeatTimeout)
+	if DefaultHeartbeatTimeout != 5*time.Minute {
+		t.Errorf("DefaultHeartbeatTimeout = %v, want 5m", DefaultHeartbeatTimeout)
+	}
+	if MinHeartbeatTimeout != 1*time.Minute {
+		t.Errorf("MinHeartbeatTimeout = %v, want 1m", MinHeartbeatTimeout)
+	}
+	if MaxHeartbeatTimeout != 30*time.Minute {
+		t.Errorf("MaxHeartbeatTimeout = %v, want 30m", MaxHeartbeatTimeout)
 	}
 	if HeartbeatCheckInterval != 30*time.Second {
 		t.Errorf("HeartbeatCheckInterval = %v, want 30s", HeartbeatCheckInterval)
@@ -342,6 +348,92 @@ func TestExecuteOptionsWatchdogCallback(t *testing.T) {
 	opts.WatchdogCallback(1234, opts.WatchdogTimeout)
 	if !callbackCalled {
 		t.Error("WatchdogCallback was not called")
+	}
+}
+
+func TestEffectiveHeartbeatTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *BackendConfig
+		expected time.Duration
+	}{
+		{
+			name:     "nil config returns default",
+			config:   nil,
+			expected: DefaultHeartbeatTimeout,
+		},
+		{
+			name:     "zero value returns default",
+			config:   &BackendConfig{},
+			expected: DefaultHeartbeatTimeout,
+		},
+		{
+			name:     "custom value within range",
+			config:   &BackendConfig{HeartbeatTimeout: 10 * time.Minute},
+			expected: 10 * time.Minute,
+		},
+		{
+			name:     "below minimum clamped to min",
+			config:   &BackendConfig{HeartbeatTimeout: 30 * time.Second},
+			expected: MinHeartbeatTimeout,
+		},
+		{
+			name:     "above maximum clamped to max",
+			config:   &BackendConfig{HeartbeatTimeout: 45 * time.Minute},
+			expected: MaxHeartbeatTimeout,
+		},
+		{
+			name:     "exact minimum allowed",
+			config:   &BackendConfig{HeartbeatTimeout: 1 * time.Minute},
+			expected: 1 * time.Minute,
+		},
+		{
+			name:     "exact maximum allowed",
+			config:   &BackendConfig{HeartbeatTimeout: 30 * time.Minute},
+			expected: 30 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.EffectiveHeartbeatTimeout()
+			if got != tt.expected {
+				t.Errorf("EffectiveHeartbeatTimeout() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClaudeCodeBackendHeartbeatTimeout(t *testing.T) {
+	// Default backend should use DefaultHeartbeatTimeout
+	b := NewClaudeCodeBackend(nil)
+	if b.heartbeatTimeout != DefaultHeartbeatTimeout {
+		t.Errorf("default heartbeatTimeout = %v, want %v", b.heartbeatTimeout, DefaultHeartbeatTimeout)
+	}
+
+	// SetHeartbeatTimeout should update the value
+	b.SetHeartbeatTimeout(15 * time.Minute)
+	if b.heartbeatTimeout != 15*time.Minute {
+		t.Errorf("after SetHeartbeatTimeout(15m), heartbeatTimeout = %v, want 15m", b.heartbeatTimeout)
+	}
+}
+
+func TestBackendFactoryHeartbeatTimeout(t *testing.T) {
+	// Factory should wire heartbeat timeout from BackendConfig
+	config := &BackendConfig{
+		Type:             BackendTypeClaudeCode,
+		HeartbeatTimeout: 12 * time.Minute,
+	}
+	backend, err := NewBackend(config)
+	if err != nil {
+		t.Fatalf("NewBackend() error: %v", err)
+	}
+	ccb, ok := backend.(*ClaudeCodeBackend)
+	if !ok {
+		t.Fatal("expected *ClaudeCodeBackend")
+	}
+	if ccb.heartbeatTimeout != 12*time.Minute {
+		t.Errorf("heartbeatTimeout = %v, want 12m", ccb.heartbeatTimeout)
 	}
 }
 

--- a/internal/executor/backend_factory.go
+++ b/internal/executor/backend_factory.go
@@ -10,16 +10,21 @@ func NewBackend(config *BackendConfig) (Backend, error) {
 		config = DefaultBackendConfig()
 	}
 
+	heartbeatTimeout := config.EffectiveHeartbeatTimeout()
+
 	switch config.Type {
 	case BackendTypeClaudeCode, "":
-		// Default to Claude Code
-		return NewClaudeCodeBackend(config.ClaudeCode), nil
+		b := NewClaudeCodeBackend(config.ClaudeCode)
+		b.SetHeartbeatTimeout(heartbeatTimeout)
+		return b, nil
 
 	case BackendTypeOpenCode:
 		return NewOpenCodeBackend(config.OpenCode), nil
 
 	case BackendTypeQwenCode:
-		return NewQwenCodeBackend(config.QwenCode), nil
+		b := NewQwenCodeBackend(config.QwenCode)
+		b.SetHeartbeatTimeout(heartbeatTimeout)
+		return b, nil
 
 	default:
 		return nil, fmt.Errorf("unknown backend type: %s", config.Type)

--- a/internal/executor/backend_qwencode.go
+++ b/internal/executor/backend_qwencode.go
@@ -158,8 +158,9 @@ func classifyQwenCodeError(stderr string, originalErr error) *QwenCodeError {
 // Qwen Code is a Gemini CLI fork that supports --output-format stream-json
 // with a nearly identical event structure to Claude Code.
 type QwenCodeBackend struct {
-	config *QwenCodeConfig
-	log    *slog.Logger
+	config           *QwenCodeConfig
+	heartbeatTimeout time.Duration
+	log              *slog.Logger
 }
 
 // NewQwenCodeBackend creates a new Qwen Code backend.
@@ -171,9 +172,15 @@ func NewQwenCodeBackend(config *QwenCodeConfig) *QwenCodeBackend {
 		config.Command = "qwen"
 	}
 	return &QwenCodeBackend{
-		config: config,
-		log:    logging.WithComponent("executor.qwencode"),
+		config:           config,
+		heartbeatTimeout: DefaultHeartbeatTimeout,
+		log:              logging.WithComponent("executor.qwencode"),
 	}
+}
+
+// SetHeartbeatTimeout sets a custom heartbeat timeout for this backend.
+func (b *QwenCodeBackend) SetHeartbeatTimeout(d time.Duration) {
+	b.heartbeatTimeout = d
 }
 
 // Name returns the backend identifier.
@@ -287,11 +294,11 @@ func (b *QwenCodeBackend) Execute(ctx context.Context, opts ExecuteOptions) (*Ba
 				lastNano := lastEventAt.Load()
 				lastTime := time.Unix(0, lastNano)
 				age := time.Since(lastTime)
-				if age > HeartbeatTimeout {
+				if age > b.heartbeatTimeout {
 					b.log.Warn("Heartbeat timeout detected, killing hung process",
 						slog.Int("pid", cmd.Process.Pid),
 						slog.Duration("last_event_age", age),
-						slog.Duration("timeout", HeartbeatTimeout),
+						slog.Duration("timeout", b.heartbeatTimeout),
 					)
 
 					if opts.HeartbeatCallback != nil {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2104.

Closes #2104

## Changes

GitHub Issue #2104: feat(executor): configurable HeartbeatTimeout via config.yaml

## Context

HeartbeatTimeout is hardcoded to 5 minutes (was bumped to 15m on bench branch but that's too aggressive for production). Long-running tasks (bench suites, complex features, monorepo refactors) get killed prematurely.

## Problem

`HeartbeatTimeout = 5 * time.Minute` in `backend_claudecode.go` is a compile-time constant. No way to tune it per-project or per-task without recompiling.

## Implementation

### Config schema (`internal/config/`)
Add to executor config:

```yaml
executor:
  heartbeat_timeout: 10m  # default: 5m, max: 30m
```

### Changes needed

**`internal/config/config.go`**:
- Add `HeartbeatTimeout` field to executor config (type `time.Duration` or string parsed to duration)
- Default: `5m`
- Validation: min 1m, max 30m

**`internal/executor/backend_claudecode.go`**:
- Replace `HeartbeatTimeout` constant with configurable value
- Accept timeout via `ClaudeCodeBackend` struct or constructor option
- Fallback to 5m default if not configured

**`internal/executor/backend_claudecode_test.go`**:
- Test custom timeout value is respected
- Test default fallback

### CLI override (optional)
```bash
pilot exec --local --heartbeat-timeout 15m "task description"
```

## Acceptance Criteria

- [ ] HeartbeatTimeout configurable via `config.yaml` under `executor.heartbeat_timeout`
- [ ] Default remains 5 minutes (no behavior change for existing users)
- [ ] Validated: min 1m, max 30m
- [ ] Existing heartbeat tests still pass
- [ ] New test for custom timeout value