### PR TITLE
GH-2107: fix(executor): recover success when Claude Code times out after completing work

### DIFF
--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -171,6 +171,11 @@ type BackendResult struct {
 
 	// SessionID is the Claude Code session ID for resume support (GH-1265)
 	SessionID string
+
+	// SawSuccessResult tracks whether a successful result event was observed during
+	// stream-json parsing. Used to recover success when the process exits with an error
+	// after completing work (e.g., timeout on final summary). GH-2107.
+	SawSuccessResult bool
 }
 
 // BackendConfig contains configuration for executor backends.

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -433,6 +433,7 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 					result.Error = event.Message
 				} else {
 					result.Output = event.Message
+					result.SawSuccessResult = true // GH-2107: track successful result for timeout recovery
 				}
 			}
 
@@ -519,6 +520,18 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 	close(cmdDone) // Signal that command is done
 
 	if err != nil {
+		// GH-2107: If a successful result event was seen before the process exited with
+		// an error, the work was completed but Claude Code timed out on a subsequent turn
+		// (e.g., writing final summary). Recover as success.
+		if result.SawSuccessResult {
+			b.log.Info("Recovering success: process exited with error after successful result event (GH-2107)",
+				slog.String("exit_error", err.Error()),
+				slog.String("output_preview", truncate(result.Output, 200)),
+			)
+			result.Success = true
+			return result, nil
+		}
+
 		result.Success = false
 
 		// GH-917: Classify the error for better handling
@@ -542,6 +555,14 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 
 	result.Success = true
 	return result, nil
+}
+
+// truncate returns the first n characters of s, appending "..." if truncated.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
 }
 
 // parseStreamEvent converts Claude Code stream-json to BackendEvent.

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -555,6 +555,78 @@ func TestParseClaudeCodeError(t *testing.T) {
 	}
 }
 
+func TestSawSuccessResultRecovery(t *testing.T) {
+	// GH-2107: When a successful result event was seen but the process exits with
+	// an error (e.g., timeout on final summary), SawSuccessResult should be set.
+	t.Run("successful result sets SawSuccessResult", func(t *testing.T) {
+		backend := NewClaudeCodeBackend(nil)
+		event := backend.parseStreamEvent(`{"type":"result","result":"All tasks completed.","is_error":false}`)
+		if event.Type != EventTypeResult {
+			t.Fatalf("expected result event, got %s", event.Type)
+		}
+		if event.IsError {
+			t.Fatal("expected non-error result")
+		}
+
+		// Simulate what executeWithFromPR does: set SawSuccessResult when result is not error
+		result := &BackendResult{}
+		if event.Type == EventTypeResult && !event.IsError {
+			result.Output = event.Message
+			result.SawSuccessResult = true
+		}
+
+		if !result.SawSuccessResult {
+			t.Error("SawSuccessResult should be true for non-error result")
+		}
+		if result.Output != "All tasks completed." {
+			t.Errorf("Output = %q, want %q", result.Output, "All tasks completed.")
+		}
+	})
+
+	t.Run("error result does not set SawSuccessResult", func(t *testing.T) {
+		backend := NewClaudeCodeBackend(nil)
+		event := backend.parseStreamEvent(`{"type":"result","result":"Failed to complete","is_error":true}`)
+
+		result := &BackendResult{}
+		if event.Type == EventTypeResult {
+			if event.IsError {
+				result.Error = event.Message
+			} else {
+				result.SawSuccessResult = true
+			}
+		}
+
+		if result.SawSuccessResult {
+			t.Error("SawSuccessResult should be false for error result")
+		}
+	})
+
+	t.Run("no result event does not set SawSuccessResult", func(t *testing.T) {
+		result := &BackendResult{}
+		if result.SawSuccessResult {
+			t.Error("SawSuccessResult should default to false")
+		}
+	})
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input    string
+		n        int
+		expected string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 5, "hello..."},
+		{"", 5, ""},
+	}
+	for _, tt := range tests {
+		got := truncate(tt.input, tt.n)
+		if got != tt.expected {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.n, got, tt.expected)
+		}
+	}
+}
+
 func TestClaudeCodeError_Error(t *testing.T) {
 	t.Run("with stderr", func(t *testing.T) {
 		err := &ClaudeCodeError{


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2107.

Closes #2107

## Changes

GitHub Issue #2107: fix(executor): recover success when Claude Code times out after completing work

## Problem

When Claude Code completes work (tests pass, code committed) but times out on a subsequent turn (e.g., writing a final summary), the process exits with code 1. Pilot currently marks this as a failure, creating false negatives.

Observed in bench (v3 run, 48.4%): `portfolio-optimization` and `break-filter-js-from-html` both solved the task and committed code, but were scored as failures because Claude Code timed out after the work was done.

This affects production too — any task where Claude Code is slow to write its final response after completing work gets marked failed, triggering unnecessary retries.

## Solution

Track whether a successful `result` event was seen during stream-json parsing. When the process exits with an error but a successful result was previously observed, override to `Success = true`.

### Implementation

**`internal/executor/backend.go`**:
- Add `SawSuccessResult bool` field to `BackendResult` struct

**`internal/executor/backend_claudecode.go`**:
- In the result event handler: when result is not an error, set `result.SawSuccessResult = true`
- In the error handler (after `cmd.Wait()`): if `SawSuccessResult` is true, log info and return `result.Success = true`

### Reference

Working implementation on `feat/pilot-bench-real` branch (commit 409781c8):
- `backend.go:175-179` — SawSuccessResult field
- `backend_claudecode.go:423` — set on successful result event
- `backend_claudecode.go:520` — recovery check on exit error

## Acceptance Criteria

- [ ] False negative recovery works: task with successful result event + exit error = success
- [ ] Normal failures (no successful result seen) still fail correctly
- [ ] Info-level log emitted when recovery triggers
- [ ] Unit test covering the recovery path