### PR TITLE
GH-2108: fix(executor): skip Navigator auto-init in LocalMode

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -972,7 +972,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 
 	// Auto-init Navigator if configured and missing
 	// Use executionPath to check/init in worktree if worktree isolation is active
-	if r.config != nil && r.config.Navigator != nil && r.config.Navigator.AutoInit {
+	if !task.LocalMode && r.config != nil && r.config.Navigator != nil && r.config.Navigator.AutoInit {
 		if err := r.maybeInitNavigator(executionPath); err != nil {
 			r.log.Warn("Navigator auto-init failed", slog.Any("error", err))
 			// Continue without Navigator - graceful degradation

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -2973,3 +2973,42 @@ func TestRunSelfReview_SkipsSaveWhenNoPatternsExtracted(t *testing.T) {
 		t.Errorf("expected 0 save calls when no patterns extracted, got %d", extractor.saveCalls)
 	}
 }
+
+func TestLocalModeSkipsNavigatorAutoInit(t *testing.T) {
+	projectDir := t.TempDir()
+
+	backend := &mockSelfReviewBackend{output: "done"}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{
+		Navigator: &NavigatorConfig{
+			AutoInit: true,
+		},
+	}
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+
+	task := &Task{
+		ID:          "LOCAL-001",
+		Title:       "Local mode task",
+		Description: "Should skip Navigator init",
+		ProjectPath: projectDir,
+		LocalMode:   true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Execute() not successful: %s", result.Error)
+	}
+
+	// Verify .agent/ directory was NOT created
+	agentDir := filepath.Join(projectDir, ".agent")
+	if _, err := os.Stat(agentDir); err == nil {
+		t.Errorf(".agent/ directory was created in LocalMode — Navigator auto-init should be skipped")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2108.

Closes #2108

## Changes

GitHub Issue #2108: fix(executor): skip Navigator auto-init in LocalMode

## Problem

When running with `--local` flag (LocalMode), Pilot still triggers Navigator auto-init (`maybeInitNavigator`), creating an `.agent/` directory. This is wrong because:

1. LocalMode tasks are standalone problem-solving tasks — they don't use Navigator workflow
2. Creating `.agent/` wastes setup time
3. The `.agent/` directory can confuse Claude Code's CLAUDE.md detection, potentially hijacking the prompt to Navigator path instead of LocalMode path

## Solution

Add `!task.LocalMode` guard before `maybeInitNavigator()` call in `runner.go`.

### Implementation

**`internal/executor/runner.go`** (~line 974):
```go
// Before (broken):
if r.config != nil && r.config.Navigator != nil && r.config.Navigator.AutoInit {

// After (fixed):
if !task.LocalMode && r.config != nil && r.config.Navigator != nil && r.config.Navigator.AutoInit {
```

### Reference

Working implementation on `feat/pilot-bench-real` branch (commit 409781c8):
- `runner.go:976` — `!task.LocalMode` guard

## Acceptance Criteria

- [ ] LocalMode tasks do not trigger Navigator auto-init
- [ ] Normal tasks still auto-init Navigator when configured
- [ ] Unit test verifying LocalMode skips init