### PR TITLE
GH-2111: fix(executor): skip quality gates in LocalMode

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2013,8 +2013,8 @@ The previous execution completed but made no code changes. This task requires ac
 		// Track if quality gates passed for self-review decision (GH-1079)
 		qualityGatesPassed := false
 
-		// Run quality gates if configured
-		if r.qualityCheckerFactory != nil {
+		// Run quality gates if configured (skip in LocalMode — no PR workflow)
+		if r.qualityCheckerFactory != nil && !task.LocalMode {
 			const maxAutoRetries = 2 // Circuit breaker to prevent infinite loops
 
 			// Track quality gate results across retries (GH-209)

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3012,3 +3012,44 @@ func TestLocalModeSkipsNavigatorAutoInit(t *testing.T) {
 		t.Errorf(".agent/ directory was created in LocalMode — Navigator auto-init should be skipped")
 	}
 }
+
+func TestLocalModeSkipsQualityGates(t *testing.T) {
+	projectDir := t.TempDir()
+
+	backend := &mockSelfReviewBackend{output: "done"}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{}
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+
+	qualityGateCalled := false
+	runner.SetQualityCheckerFactory(func(taskID, projectPath string) QualityChecker {
+		qualityGateCalled = true
+		return &mockQualityChecker{
+			outcome: &QualityOutcome{Passed: true},
+		}
+	})
+
+	task := &Task{
+		ID:          "LOCAL-QG-001",
+		Title:       "Local mode quality gate skip",
+		Description: "Quality gates should not run in LocalMode",
+		ProjectPath: projectDir,
+		LocalMode:   true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Execute() not successful: %s", result.Error)
+	}
+
+	if qualityGateCalled {
+		t.Errorf("quality checker factory was called in LocalMode — quality gates should be skipped")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2111.

Closes #2111

## Changes

GitHub Issue #2111: fix(executor): skip quality gates in LocalMode

## Problem

Quality gates (build/test/lint) run in LocalMode (`--local` flag) even though LocalMode is a standalone problem-solving mode without PR workflow. Quality gates abort tasks after 2 retries even when the work is mostly done.

Observed in bench v5m:
- `path-tracing-reverse`: 2/3 tests passed, quality gates killed it
- `make-doom-for-mips`: 2/3 tests passed, quality gates killed it

## Solution

Skip quality gates when `task.LocalMode` is true. In `runner.go` ~line 2018:

```go
// Before:
if r.qualityCheckerFactory != nil {

// After:
if r.qualityCheckerFactory != nil && !task.LocalMode {
```

LocalMode tasks don't create PRs, so quality gates serve no purpose — the bench verifier handles validation independently.

## Acceptance Criteria

- [ ] Quality gates skipped when `task.LocalMode == true`
- [ ] Normal (non-local) tasks still run quality gates
- [ ] Unit test covering LocalMode quality gate skip