### PR TITLE
GH-2112: fix(executor): handle OOM/SIGKILL (exit 139) gracefully

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -313,9 +313,10 @@ func newTaskCmd() *cobra.Command {
 	var verbose bool
 	var enableAlerts bool
 	var enableBudget bool
-	var localMode bool    // GH-2103: problem-solving prompt without PR constraints
-	var teamID string     // GH-635: team project access scoping
-	var teamMember string // GH-635: member email for access scoping
+	var localMode bool      // GH-2103: problem-solving prompt without PR constraints
+	var teamID string       // GH-635: team project access scoping
+	var teamMember string   // GH-635: member email for access scoping
+	var resultJSONPath string // GH-2112: crash-resilient result JSON output
 
 	cmd := &cobra.Command{
 		Use:   "task [description]",
@@ -669,12 +670,33 @@ Examples:
 			}
 			fmt.Println()
 
+			// GH-2112: Write partial result JSON before execution for crash resilience.
+			// If the process is OOM-killed, at least a partial result file exists.
+			if resultJSONPath != "" {
+				partialResult := map[string]interface{}{
+					"task_id":    taskID,
+					"task_title": taskDesc,
+					"status":     "running",
+					"started_at": time.Now().UTC().Format(time.RFC3339),
+				}
+				if writeErr := writeResultJSON(resultJSONPath, partialResult); writeErr != nil {
+					fmt.Printf("   ⚠️  Failed to write partial result JSON: %s\n", writeErr)
+				}
+			}
+
 			// Start progress display with Navigator check
 			progress.StartWithNavigatorCheck(projectPath)
 
 			// Execute the task
 			result, err := runner.Execute(ctx, task)
 			if err != nil {
+				// GH-2112: Write failure result JSON even on execution error
+				if resultJSONPath != "" {
+					failResult := buildResultJSON(taskID, taskDesc, result, err)
+					if writeErr := writeResultJSON(resultJSONPath, failResult); writeErr != nil {
+						fmt.Printf("   ⚠️  Failed to write result JSON: %s\n", writeErr)
+					}
+				}
 				return fmt.Errorf("execution failed: %w", err)
 			}
 
@@ -698,6 +720,14 @@ Examples:
 
 			// Finish progress display with comprehensive report
 			progress.FinishWithReport(report)
+
+			// GH-2112: Write final result JSON (overwrites partial)
+			if resultJSONPath != "" {
+				finalResult := buildResultJSON(taskID, taskDesc, result, nil)
+				if writeErr := writeResultJSON(resultJSONPath, finalResult); writeErr != nil {
+					fmt.Printf("   ⚠️  Failed to write result JSON: %s\n", writeErr)
+				}
+			}
 
 			// Send alerts based on result
 			if result.Success {
@@ -751,8 +781,63 @@ Examples:
 	cmd.Flags().BoolVar(&localMode, "local", false, "Use problem-solving prompt without PR/Navigator constraints")
 	cmd.Flags().StringVar(&teamID, "team", "", "Team ID or name for project access scoping (overrides config)")
 	cmd.Flags().StringVar(&teamMember, "team-member", "", "Member email for team access scoping (overrides config)")
+	cmd.Flags().StringVar(&resultJSONPath, "result-json", "", "Write execution result to JSON file (crash-resilient: partial result written before execution)")
 
 	return cmd
+}
+
+// writeResultJSON writes a result map to a JSON file atomically.
+// GH-2112: Used for crash-resilient result reporting.
+func writeResultJSON(path string, data map[string]interface{}) error {
+	jsonBytes, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal result JSON: %w", err)
+	}
+	return os.WriteFile(path, jsonBytes, 0644)
+}
+
+// buildResultJSON creates a result map from execution result.
+// GH-2112: Ensures all metrics are captured even on OOM/crash.
+func buildResultJSON(taskID, taskTitle string, result *executor.ExecutionResult, execErr error) map[string]interface{} {
+	data := map[string]interface{}{
+		"task_id":       taskID,
+		"task_title":    taskTitle,
+		"completed_at":  time.Now().UTC().Format(time.RFC3339),
+	}
+
+	if result != nil {
+		data["success"] = result.Success
+		data["duration_ms"] = result.Duration.Milliseconds()
+		data["tokens_input"] = result.TokensInput
+		data["tokens_output"] = result.TokensOutput
+		data["tokens_total"] = result.TokensInput + result.TokensOutput
+		data["estimated_cost_usd"] = result.EstimatedCostUSD
+		data["model"] = result.ModelName
+		data["files_changed"] = result.FilesChanged
+		data["lines_added"] = result.LinesAdded
+		data["lines_removed"] = result.LinesRemoved
+		data["pr_url"] = result.PRUrl
+		data["commit_sha"] = result.CommitSHA
+		if result.Error != "" {
+			data["error"] = result.Error
+		}
+		if result.Success {
+			data["status"] = "completed"
+		} else {
+			data["status"] = "failed"
+		}
+	} else {
+		data["status"] = "failed"
+		data["success"] = false
+	}
+
+	if execErr != nil {
+		data["exec_error"] = execErr.Error()
+		data["status"] = "failed"
+		data["success"] = false
+	}
+
+	return data
 }
 
 // killExistingTelegramBot finds and kills any running pilot process with Telegram enabled

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -49,6 +50,9 @@ const (
 	ErrorTypeAPIError ClaudeCodeErrorType = "api_error"
 	// ErrorTypeTimeout indicates the process was killed due to timeout
 	ErrorTypeTimeout ClaudeCodeErrorType = "timeout"
+	// ErrorTypeOOM indicates the process was OOM-killed (exit 137/139)
+	// GH-2112: SIGKILL (137) or SIGSEGV (139) from kernel OOM killer
+	ErrorTypeOOM ClaudeCodeErrorType = "oom_killed"
 	// ErrorTypeSessionNotFound indicates the session for --from-pr or --resume was not found (GH-1267)
 	ErrorTypeSessionNotFound ClaudeCodeErrorType = "session_not_found"
 	// ErrorTypeUnknown indicates an unclassified error
@@ -78,8 +82,21 @@ func (e *ClaudeCodeError) ErrorMessage() string { return e.Message }
 // ErrorStderr implements BackendError.
 func (e *ClaudeCodeError) ErrorStderr() string { return e.Stderr }
 
-// classifyClaudeCodeError examines stderr output to classify the error.
+// classifyClaudeCodeError examines stderr output and exit code to classify the error.
+// GH-2112: Exit codes 137 (SIGKILL) and 139 (SIGSEGV) are classified as OOM before
+// falling through to stderr-based detection.
 func classifyClaudeCodeError(stderr string, originalErr error) *ClaudeCodeError {
+	// GH-2112: Check exit code first for OOM detection.
+	// Exit 137 = killed by SIGKILL (128+9), exit 139 = killed by SIGSEGV (128+11).
+	// Both are commonly caused by the kernel OOM killer.
+	if exitCode := extractExitCode(originalErr); exitCode == 137 || exitCode == 139 {
+		return &ClaudeCodeError{
+			Type:    ErrorTypeOOM,
+			Message: fmt.Sprintf("Process OOM-killed (exit code %d)", exitCode),
+			Stderr:  strings.TrimSpace(stderr),
+		}
+	}
+
 	stderrLower := strings.ToLower(stderr)
 
 	// Rate limit detection
@@ -152,6 +169,18 @@ func classifyClaudeCodeError(stderr string, originalErr error) *ClaudeCodeError 
 		Message: msg,
 		Stderr:  strings.TrimSpace(stderr),
 	}
+}
+
+// extractExitCode returns the process exit code from an *exec.ExitError, or -1 if unavailable.
+func extractExitCode(err error) int {
+	if err == nil {
+		return -1
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
 }
 
 // parseClaudeCodeError examines stderr output to classify the error.
@@ -538,11 +567,22 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 		stderr := stderrOutput.String()
 		ccErr := parseClaudeCodeError(stderr, err).(*ClaudeCodeError)
 
-		b.log.Warn("Claude Code execution failed",
-			slog.String("error_type", string(ccErr.Type)),
-			slog.String("message", ccErr.Message),
-			slog.String("stderr", ccErr.Stderr),
-		)
+		// GH-2112: Log OOM kills at Error level with distinct message for monitoring
+		if ccErr.Type == ErrorTypeOOM {
+			b.log.Error("Claude Code process OOM-killed",
+				slog.String("error_type", string(ccErr.Type)),
+				slog.String("message", ccErr.Message),
+				slog.String("stderr", ccErr.Stderr),
+				slog.Int64("tokens_input", result.TokensInput),
+				slog.Int64("tokens_output", result.TokensOutput),
+			)
+		} else {
+			b.log.Warn("Claude Code execution failed",
+				slog.String("error_type", string(ccErr.Type)),
+				slog.String("message", ccErr.Message),
+				slog.String("stderr", ccErr.Stderr),
+			)
+		}
 
 		// Store classified error info in result
 		if result.Error == "" {

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -2,6 +2,8 @@ package executor
 
 import (
 	"context"
+	"fmt"
+	"os/exec"
 	"testing"
 	"time"
 )
@@ -651,4 +653,106 @@ func TestClaudeCodeError_Error(t *testing.T) {
 			t.Errorf("Error() = %q, unexpected format", errStr)
 		}
 	})
+}
+
+// TestExtractExitCode verifies exit code extraction from exec.ExitError.
+func TestExtractExitCode(t *testing.T) {
+	t.Run("nil error returns -1", func(t *testing.T) {
+		if got := extractExitCode(nil); got != -1 {
+			t.Errorf("extractExitCode(nil) = %d, want -1", got)
+		}
+	})
+
+	t.Run("non-ExitError returns -1", func(t *testing.T) {
+		if got := extractExitCode(fmt.Errorf("some error")); got != -1 {
+			t.Errorf("extractExitCode(generic) = %d, want -1", got)
+		}
+	})
+
+	t.Run("ExitError returns exit code", func(t *testing.T) {
+		// Run a command that exits with code 1 to get a real ExitError
+		cmd := exec.Command("sh", "-c", "exit 1")
+		err := cmd.Run()
+		if err == nil {
+			t.Fatal("expected error from exit 1")
+		}
+		if got := extractExitCode(err); got != 1 {
+			t.Errorf("extractExitCode(exit 1) = %d, want 1", got)
+		}
+	})
+}
+
+// TestClassifyClaudeCodeErrorOOM verifies OOM classification via exit codes.
+// GH-2112: Exit codes 137 (SIGKILL) and 139 (SIGSEGV) should be classified as OOM.
+func TestClassifyClaudeCodeErrorOOM(t *testing.T) {
+	tests := []struct {
+		name       string
+		exitCode   int
+		stderr     string
+		expectType ClaudeCodeErrorType
+	}{
+		{
+			name:       "exit 139 - SIGSEGV/OOM",
+			exitCode:   139,
+			stderr:     "",
+			expectType: ErrorTypeOOM,
+		},
+		{
+			name:       "exit 137 - SIGKILL/OOM",
+			exitCode:   137,
+			stderr:     "",
+			expectType: ErrorTypeOOM,
+		},
+		{
+			name:       "exit 139 with stderr - still OOM (exit code takes precedence)",
+			exitCode:   139,
+			stderr:     "signal: killed",
+			expectType: ErrorTypeOOM,
+		},
+		{
+			name:       "exit 1 with signal:killed stderr - timeout (not OOM)",
+			exitCode:   1,
+			stderr:     "signal: killed",
+			expectType: ErrorTypeTimeout,
+		},
+		{
+			name:       "exit 1 with rate limit stderr",
+			exitCode:   1,
+			stderr:     "Error: You've hit your limit",
+			expectType: ErrorTypeRateLimit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a real ExitError by running a command with the desired exit code
+			cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", tt.exitCode))
+			exitErr := cmd.Run()
+			if exitErr == nil {
+				t.Fatalf("expected error from exit %d", tt.exitCode)
+			}
+
+			ccErr := classifyClaudeCodeError(tt.stderr, exitErr)
+			if ccErr.Type != tt.expectType {
+				t.Errorf("classifyClaudeCodeError() type = %q, want %q", ccErr.Type, tt.expectType)
+			}
+		})
+	}
+}
+
+// TestOOMErrorMessage verifies OOM error message format.
+func TestOOMErrorMessage(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 139")
+	exitErr := cmd.Run()
+	if exitErr == nil {
+		t.Fatal("expected error")
+	}
+
+	ccErr := classifyClaudeCodeError("", exitErr)
+	if ccErr.Type != ErrorTypeOOM {
+		t.Fatalf("expected OOM, got %q", ccErr.Type)
+	}
+	if ccErr.Message != "Process OOM-killed (exit code 139)" {
+		t.Errorf("unexpected message: %q", ccErr.Message)
+	}
 }

--- a/internal/executor/backend_qwencode.go
+++ b/internal/executor/backend_qwencode.go
@@ -51,6 +51,7 @@ const (
 	QwenErrorTypeRateLimit        QwenCodeErrorType = "rate_limit"
 	QwenErrorTypeAPIError         QwenCodeErrorType = "api_error"
 	QwenErrorTypeTimeout          QwenCodeErrorType = "timeout"
+	QwenErrorTypeOOM              QwenCodeErrorType = "oom_killed" // GH-2112
 	QwenErrorTypeInvalidConfig    QwenCodeErrorType = "invalid_config"
 	QwenErrorTypeSessionNotFound  QwenCodeErrorType = "session_not_found"
 	QwenErrorTypeUnknown          QwenCodeErrorType = "unknown"
@@ -79,8 +80,18 @@ func (e *QwenCodeError) ErrorMessage() string { return e.Message }
 // ErrorStderr implements BackendError.
 func (e *QwenCodeError) ErrorStderr() string { return e.Stderr }
 
-// classifyQwenCodeError examines stderr output to classify the error.
+// classifyQwenCodeError examines stderr output and exit code to classify the error.
+// GH-2112: Exit codes 137/139 classified as OOM before stderr-based detection.
 func classifyQwenCodeError(stderr string, originalErr error) *QwenCodeError {
+	// GH-2112: Check exit code first for OOM detection
+	if exitCode := extractExitCode(originalErr); exitCode == 137 || exitCode == 139 {
+		return &QwenCodeError{
+			Type:    QwenErrorTypeOOM,
+			Message: fmt.Sprintf("Process OOM-killed (exit code %d)", exitCode),
+			Stderr:  strings.TrimSpace(stderr),
+		}
+	}
+
 	stderrLower := strings.ToLower(stderr)
 
 	// Rate limit detection

--- a/internal/executor/retry.go
+++ b/internal/executor/retry.go
@@ -159,6 +159,12 @@ func (r *Retrier) Evaluate(err error, attempt int, originalTimeout time.Duration
 			ShouldRetry: false,
 			Reason:      "invalid_config errors are not retryable (fail fast)",
 		}
+	case "oom_killed":
+		// GH-2112: OOM kills indicate resource exhaustion - retrying won't help
+		return RetryDecision{
+			ShouldRetry: false,
+			Reason:      "oom_killed errors are not retryable (resource exhaustion)",
+		}
 	default:
 		// Unknown errors use default behavior (no smart retry)
 		return RetryDecision{

--- a/internal/executor/retry_test.go
+++ b/internal/executor/retry_test.go
@@ -123,6 +123,25 @@ func TestRetrier_Evaluate_InvalidConfig_FailFast(t *testing.T) {
 	}
 }
 
+// TestRetrier_Evaluate_OOM verifies OOM errors are not retried.
+// GH-2112: OOM kills indicate resource exhaustion, retrying won't help.
+func TestRetrier_Evaluate_OOM(t *testing.T) {
+	config := &RetryConfig{
+		Enabled: true,
+	}
+	retrier := NewRetrier(config)
+
+	err := &ClaudeCodeError{Type: ErrorTypeOOM, Message: "Process OOM-killed (exit code 139)"}
+
+	decision := retrier.Evaluate(err, 0, 10*time.Minute)
+	if decision.ShouldRetry {
+		t.Error("Expected ShouldRetry=false for OOM (resource exhaustion)")
+	}
+	if decision.Reason != "oom_killed errors are not retryable (resource exhaustion)" {
+		t.Errorf("Unexpected reason: %s", decision.Reason)
+	}
+}
+
 func TestRetrier_Evaluate_Disabled(t *testing.T) {
 	config := &RetryConfig{
 		Enabled: false, // Disabled

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1570,6 +1570,18 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 					)
 					r.reportProgress(task.ID, "API Error", 100, beErr.ErrorMessage())
 
+				case "oom_killed":
+					// GH-2112: OOM/SIGKILL classification
+					alertType = AlertEventTypeTaskFailed
+					errorCategory = "oom_killed"
+					log.Error("Backend process OOM-killed",
+						slog.String("task_id", task.ID),
+						slog.String("message", beErr.ErrorMessage()),
+						slog.String("stderr", beErr.ErrorStderr()),
+						slog.Duration("duration", duration),
+					)
+					r.reportProgress(task.ID, "OOM Killed", 100, beErr.ErrorMessage())
+
 				default:
 					// GH-917-5: Log stderr for process errors and unknown errors too
 					log.Error("Backend execution failed",
@@ -2173,6 +2185,12 @@ The previous execution completed but made no code changes. This task requires ac
 								errorCategory = "api_error"
 								log.Error("Retry failed: API error", slog.String("message", beErr.ErrorMessage()))
 								r.reportProgress(task.ID, "API Error", 100, beErr.ErrorMessage())
+							case "oom_killed":
+								// GH-2112: OOM/SIGKILL classification in retry path
+								alertType = AlertEventTypeTaskFailed
+								errorCategory = "oom_killed"
+								log.Error("Retry failed: process OOM-killed", slog.String("message", beErr.ErrorMessage()))
+								r.reportProgress(task.ID, "OOM Killed", 100, beErr.ErrorMessage())
 							default:
 								log.Error("Retry execution failed", slog.Any("error", retryErr))
 								r.reportProgress(task.ID, "Retry Failed", 100, result.Error)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2112.

Closes #2112

## Changes

GitHub Issue #2112: fix(executor): handle OOM/SIGKILL (exit 139) gracefully

## Problem

When Claude Code is OOM-killed (exit code 139 = SIGKILL), Pilot writes no result JSON. The process dies mid-execution and `pilot-result.json` is never created, losing all progress information.

Observed in bench v5m on Modal: 4 tasks (`hf-model-inference`, `train-fasttext`, `kv-store-grpc`, `sqlite-db-truncate`) all exited with code 139. No pilot-result.json, no tokens tracked, no error classification.

## Solution

1. In `backend_claudecode.go` error handling: detect exit code 139 and classify as `ErrorTypeOOM`
2. Add `ErrorTypeOOM` to the error type enum in `backend.go`
3. Ensure `pilot-result.json` is always written, even on catastrophic process death — write a partial result with the error type before execution starts, update it on completion
4. Log OOM kills distinctly for monitoring

### Implementation

**`internal/executor/backend.go`**:
- Add `ErrorTypeOOM ErrorType = "oom_killed"` 

**`internal/executor/backend_claudecode.go`**:
- In `parseClaudeCodeError()`: check if exit code is 137 or 139 → `ErrorTypeOOM`
- Consider writing partial result before execution for crash resilience

## Acceptance Criteria

- [ ] Exit code 139 classified as OOM error
- [ ] Exit code 137 (SIGKILL) also classified as OOM
- [ ] Error type appears in execution result
- [ ] Partial result written even on process death
- [ ] Unit test for OOM error classification