### PR TITLE
GH-2122: fix(slack): remove regex intent fallback — default to IntentChat on LLM failure

### DIFF
--- a/internal/adapters/slack/handler.go
+++ b/internal/adapters/slack/handler.go
@@ -399,9 +399,10 @@ func (h *Handler) detectIntent(ctx context.Context, channelID, text string) inte
 		return intent.IntentQuestion
 	}
 
-	// If LLM classifier not available, use regex
+	// If LLM classifier not available, default to chat (safe — never triggers task execution)
 	if h.llmClassifier == nil {
-		return intent.DetectIntent(text)
+		h.log.Warn("no LLM classifier configured, defaulting all messages to chat")
+		return intent.IntentChat
 	}
 
 	// Try LLM classification with timeout
@@ -416,9 +417,9 @@ func (h *Handler) detectIntent(ctx context.Context, channelID, text string) inte
 
 	detectedIntent, err := h.llmClassifier.Classify(classifyCtx, history, text)
 	if err != nil {
-		h.log.Debug("LLM classification failed, using regex",
+		h.log.Warn("LLM classification failed, defaulting to chat",
 			slog.Any("error", err))
-		return intent.DetectIntent(text)
+		return intent.IntentChat
 	}
 
 	h.log.Debug("LLM classified intent",


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2122.

Closes #2122

## Changes

GitHub Issue #2122: fix(slack): remove regex intent fallback — default to IntentChat on LLM failure

## Problem

Slack handler falls back to regex-based `DetectIntent()` when LLM classifier fails or times out (handler.go lines 404 and 421). The regex classifier was deemed unreliable and replaced with Haiku — but the fallback still uses it.

```go
// handler.go:400-404 — no LLM classifier configured
if h.llmClassifier == nil {
    return intent.DetectIntent(text)  // regex fallback — unreliable
}

// handler.go:417-421 — LLM call failed
detectedIntent, err := h.llmClassifier.Classify(classifyCtx, history, text)
if err != nil {
    return intent.DetectIntent(text)  // regex fallback — unreliable
}
```

Regex misclassification can turn a greeting or question into a task execution.

## Fix

1. Replace both `intent.DetectIntent(text)` fallbacks with `intent.IntentChat`
2. Chat is the safe default — never accidentally executes a task
3. If no LLM classifier configured, log a warning and default all messages to chat

## Files

- `internal/adapters/slack/handler.go` — lines 404 and 421

## Test plan

- [ ] Disable LLM classifier → all messages get chat response (not task)
- [ ] Simulate LLM timeout → message defaults to chat
- [ ] Normal operation with LLM → intent classified correctly