### PR TITLE
GH-2127: fix(discord): bot mention not stripped — intent classifier sees raw <@ID> markup

### DIFF
--- a/internal/adapters/discord/handler.go
+++ b/internal/adapters/discord/handler.go
@@ -120,6 +120,11 @@ func (h *Handler) StartListening(ctx context.Context) error {
 		return fmt.Errorf("start listening: %w", err)
 	}
 
+	// Pick up bot user ID from READY event if not configured
+	if h.botID == "" {
+		h.botID = h.gatewayClient.BotUserID()
+	}
+
 	h.log.Info("Discord handler listening for events")
 
 	// Start cleanup goroutine
@@ -222,6 +227,14 @@ func (h *Handler) stripMention(content string) string {
 		content = strings.TrimPrefix(content, prefix1)
 		content = strings.TrimPrefix(content, prefix2)
 		content = strings.TrimSpace(content)
+		return content
+	}
+
+	// Fallback: strip any leading <@...> or <@!...> mention when botID is unknown
+	if strings.HasPrefix(content, "<@") {
+		if idx := strings.Index(content, ">"); idx != -1 {
+			content = strings.TrimSpace(content[idx+1:])
+		}
 	}
 	return content
 }

--- a/internal/adapters/discord/handler_test.go
+++ b/internal/adapters/discord/handler_test.go
@@ -257,6 +257,64 @@ func TestIntentRouting(t *testing.T) {
 	}
 }
 
+func TestMentionStrippedBeforeIntentClassification(t *testing.T) {
+	var receivedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Capture the message body sent by the greeting handler
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/messages") {
+			buf := new(strings.Builder)
+			_, _ = fmt.Fprintf(buf, "")
+			var payload map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			if content, ok := payload["content"].(string); ok {
+				receivedBody = content
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "msg1"})
+	}))
+	defer server.Close()
+
+	// No botID configured — relies on fallback stripping
+	config := &HandlerConfig{
+		BotToken: testutil.FakeBearerToken,
+	}
+	h := NewHandler(config, nil)
+	h.apiClient = NewClientWithBaseURL(testutil.FakeBearerToken, server.URL)
+
+	// Simulate "@Pilot hi" which Discord delivers as "<@1481980896998326383> hi"
+	msg := MessageCreate{
+		ID:        "msg1",
+		ChannelID: "chan1",
+		Author:    User{ID: "user1", Username: "testuser"},
+		Content:   "<@1481980896998326383> hi",
+	}
+
+	msgData, _ := json.Marshal(msg)
+	event := &GatewayEvent{
+		T: stringPtr("MESSAGE_CREATE"),
+		D: json.RawMessage(msgData),
+	}
+
+	ctx := context.Background()
+	h.handleMessageCreate(ctx, event)
+
+	// Should NOT create a pending task (greeting, not task)
+	h.mu.Lock()
+	_, hasPending := h.pendingTasks["chan1"]
+	h.mu.Unlock()
+
+	if hasPending {
+		t.Error("mention + greeting should not create pending task")
+	}
+
+	// Greeting handler should have sent a response
+	if receivedBody == "" {
+		t.Error("expected greeting response to be sent")
+	}
+}
+
 func TestDetectIntentWithLLMFallback(t *testing.T) {
 	// Without LLM classifier, should use regex
 	config := &HandlerConfig{
@@ -619,14 +677,26 @@ func TestMentionStripping(t *testing.T) {
 			expected: "<@987654321> deploy the thing",
 		},
 		{
-			name:     "empty bot ID does nothing",
+			name:     "empty bot ID strips leading mention (fallback)",
 			botID:    "",
 			content:  "<@123456789> deploy the thing",
-			expected: "<@123456789> deploy the thing",
+			expected: "deploy the thing",
+		},
+		{
+			name:     "empty bot ID strips nickname mention (fallback)",
+			botID:    "",
+			content:  "<@!123456789> deploy the thing",
+			expected: "deploy the thing",
 		},
 		{
 			name:     "mention only",
 			botID:    "123456789",
+			content:  "<@123456789>",
+			expected: "",
+		},
+		{
+			name:     "empty bot ID mention only",
+			botID:    "",
 			content:  "<@123456789>",
 			expected: "",
 		},

--- a/internal/adapters/discord/transport.go
+++ b/internal/adapters/discord/transport.go
@@ -18,6 +18,7 @@ type GatewayClient struct {
 	intents       int
 	conn          *websocket.Conn
 	sessionID     string
+	botUserID     string
 	seq           *int
 	heartbeatTick *time.Ticker
 	stopCh        chan struct{}
@@ -218,13 +219,21 @@ func (g *GatewayClient) Listen(ctx context.Context) (<-chan GatewayEvent, error)
 			if event.T != nil && *event.T == "READY" {
 				var readyData struct {
 					SessionID string `json:"session_id"`
+					User      struct {
+						ID string `json:"id"`
+					} `json:"user"`
 				}
 				data, _ := json.Marshal(event.D)
 				if err := json.Unmarshal(data, &readyData); err == nil {
 					g.mu.Lock()
 					g.sessionID = readyData.SessionID
+					if readyData.User.ID != "" {
+						g.botUserID = readyData.User.ID
+					}
 					g.mu.Unlock()
-					g.log.Info("Received READY", slog.String("session_id", readyData.SessionID))
+					g.log.Info("Received READY",
+						slog.String("session_id", readyData.SessionID),
+						slog.String("bot_user_id", readyData.User.ID))
 				}
 			}
 
@@ -383,6 +392,13 @@ func (g *GatewayClient) Resume(ctx context.Context) error {
 
 	g.log.Info("Sent RESUME", slog.String("session_id", g.sessionID))
 	return nil
+}
+
+// BotUserID returns the bot's user ID extracted from the READY event.
+func (g *GatewayClient) BotUserID() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.botUserID
 }
 
 // Close closes the WebSocket connection. Safe to call multiple times.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2127.

Closes #2127

## Changes

GitHub Issue #2127: fix(discord): bot mention not stripped — intent classifier sees raw <@ID> markup

## Bug

Discord messages like `@Pilot hi` arrive as `<@1481980896998326383> hi` in `msg.Content`. The `stripMention()` function requires `h.botID` to be set, but:

1. `bot_id` is not in the user's config
2. The READY event handler in `transport.go` only extracts `session_id`, not the bot's `user.id`

Result: `stripMention` is a no-op → intent classifier sees `<@1481980896998326383> hi` → regex doesn't match greeting → every message treated as a task.

**Confirmed on v2.80.2** with screenshot evidence.

## Root Cause

`internal/adapters/discord/handler.go` line 218:
```go
func (h *Handler) stripMention(content string) string {
    if h.botID != "" {  // <-- always empty when bot_id not in config
```

`internal/adapters/discord/transport.go` line 217-229: READY event parsed but only `session_id` extracted, not `user.id`.

## Fix

### 1. Extract bot user ID from READY event (`transport.go`)

In the READY handler (~line 219), expand the struct to include the bot user:

```go
var readyData struct {
    SessionID string `json:"session_id"`
    User      struct {
        ID string `json:"id"`
    } `json:"user"`
}
```

Store `readyData.User.ID` in a new `botUserID` field on `GatewayClient`. Add `BotUserID() string` getter.

### 2. Handler picks up bot ID after Connect (`handler.go`)

In `StartListening()`, after `h.gatewayClient.Connect(ctx)` succeeds:

```go
if h.botID == "" {
    h.botID = h.gatewayClient.BotUserID()
}
```

### 3. Fallback: generic mention strip (`handler.go`)

In `stripMention`, when `botID` is still empty, strip any leading mention:

```go
if h.botID == "" {
    // Fallback: strip any leading <@...> or <@!...> mention
    if idx := strings.Index(content, ">"); idx != -1 && strings.HasPrefix(content, "<@") {
        content = strings.TrimSpace(content[idx+1:])
    }
    return content
}
```

### 4. Tests

- Add test: `stripMention` with empty `botID` still strips `<@123> hi` → `hi`
- Add test: `handleMessageCreate` with mention prefix routes to `handleGreeting`
- Update existing `TestHandlerBotMessageSkipping` if needed

## Files to Change

- `internal/adapters/discord/transport.go` — extract user.id from READY
- `internal/adapters/discord/handler.go` — pick up botID, fallback strip
- `internal/adapters/discord/handler_test.go` — new test cases