### PR TITLE
GH-2129: fix(telegram): bot mention not stripped — intent classifier sees raw @username

### DIFF
--- a/internal/adapters/telegram/client.go
+++ b/internal/adapters/telegram/client.go
@@ -199,6 +199,46 @@ func (c *Client) CheckSingleton(ctx context.Context) error {
 	return nil
 }
 
+// GetMeResponse represents the response from getMe
+type GetMeResponse struct {
+	OK          bool   `json:"ok"`
+	Result      *User  `json:"result,omitempty"`
+	Description string `json:"description,omitempty"`
+	ErrorCode   int    `json:"error_code,omitempty"`
+}
+
+// GetMe returns the bot's user info from the Telegram API.
+func (c *Client) GetMe(ctx context.Context) (*User, error) {
+	url := fmt.Sprintf("%s%s/getMe", c.baseURL, c.botToken)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call getMe: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var result GetMeResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if !result.OK {
+		return nil, fmt.Errorf("telegram API error: %s (code: %d)", result.Description, result.ErrorCode)
+	}
+
+	return result.Result, nil
+}
+
 // GetUpdates retrieves updates using long polling
 func (c *Client) GetUpdates(ctx context.Context, offset int64, timeout int) ([]*Update, error) {
 	url := fmt.Sprintf("%s%s/getUpdates?offset=%d&timeout=%d", c.baseURL, c.botToken, offset, timeout)

--- a/internal/adapters/telegram/handler.go
+++ b/internal/adapters/telegram/handler.go
@@ -72,6 +72,7 @@ type Handler struct {
 	conversationStore *intent.ConversationStore // Conversation history per chat (optional)
 	memberResolver    MemberResolver         // Team member resolver for RBAC (optional, GH-634)
 	lastSender        map[string]int64       // chatID -> last sender Telegram user ID (GH-634)
+	botUsername       string                 // Bot username for mention stripping (GH-2129)
 }
 
 // HandlerConfig holds configuration for the Telegram handler
@@ -230,6 +231,14 @@ func (h *Handler) CheckSingleton(ctx context.Context) error {
 
 // StartPolling starts polling for updates in a goroutine
 func (h *Handler) StartPolling(ctx context.Context) {
+	// Fetch bot username for mention stripping (GH-2129)
+	if me, err := h.client.GetMe(ctx); err != nil {
+		logging.WithComponent("telegram").Warn("Failed to fetch bot username via getMe", slog.String("error", err.Error()))
+	} else if me != nil {
+		h.botUsername = me.Username
+		logging.WithComponent("telegram").Debug("Bot username resolved", slog.String("username", me.Username))
+	}
+
 	h.wg.Add(1)
 	go h.pollLoop(ctx)
 
@@ -387,6 +396,7 @@ func (h *Handler) processUpdate(ctx context.Context, update *Update) {
 	}
 
 	text := strings.TrimSpace(msg.Text)
+	text = stripBotMention(text, h.botUsername)
 
 	// Check for confirmation responses
 	textLower := strings.ToLower(text)
@@ -1591,6 +1601,18 @@ func (h *Handler) tryFastAnswer(question string) string {
 	}
 
 	return "" // Fall back to Claude
+}
+
+// stripBotMention removes a leading @username mention from message text (GH-2129).
+func stripBotMention(text, botUsername string) string {
+	if botUsername == "" {
+		return text
+	}
+	prefix := "@" + botUsername
+	if len(text) >= len(prefix) && strings.EqualFold(text[:len(prefix)], prefix) {
+		text = strings.TrimSpace(text[len(prefix):])
+	}
+	return text
 }
 
 // containsAny returns true if s contains any of the substrings

--- a/internal/adapters/telegram/handler_test.go
+++ b/internal/adapters/telegram/handler_test.go
@@ -1606,3 +1606,28 @@ func TestPlanEmptyMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestStripBotMention(t *testing.T) {
+	tests := []struct {
+		name        string
+		text        string
+		botUsername string
+		want        string
+	}{
+		{"with mention", "@PilotBot hi", "PilotBot", "hi"},
+		{"no mention", "hi", "PilotBot", "hi"},
+		{"mention only", "@PilotBot", "PilotBot", ""},
+		{"case insensitive", "@pilotbot hi", "PilotBot", "hi"},
+		{"empty username", "@PilotBot hi", "", "@PilotBot hi"},
+		{"mention with extra spaces", "@PilotBot   hello world", "PilotBot", "hello world"},
+		{"mention mid-text", "hey @PilotBot hi", "PilotBot", "hey @PilotBot hi"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripBotMention(tt.text, tt.botUsername)
+			if got != tt.want {
+				t.Errorf("stripBotMention(%q, %q) = %q, want %q", tt.text, tt.botUsername, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2129.

Closes #2129

## Changes

GitHub Issue #2129: fix(telegram): bot mention not stripped — intent classifier sees raw @username

## Bug

Same class of bug as GH-2127 (Discord mention stripping).

In Telegram group chats, users address the bot with `@PilotBot hi`. The handler at `internal/adapters/telegram/handler.go:389` does `text := strings.TrimSpace(msg.Text)` but never strips the `@username` mention prefix.

Result: intent classifier sees `@PilotBot hi` → regex doesn't match greeting → treated as task.

**Related:** GH-2127 (Discord), Slack adapter already handles this correctly via `stripBotMention()` in `events.go:152`.

## Root Cause

`internal/adapters/telegram/handler.go` line 389:
```go
text := strings.TrimSpace(msg.Text)
// No mention stripping — raw @username passed to detectIntentWithLLM()
```

Line 403 passes raw text directly:
```go
msgIntent := h.detectIntentWithLLM(ctx, chatID, text)
```

## Fix

### 1. Add `stripBotMention()` to Telegram handler

Strip leading `@username` mention before intent detection. Telegram bot username is available from the Bot API `getMe` response or from config.

```go
// stripBotMention removes leading @username mention from message text.
func stripBotMention(text, botUsername string) string {
    if botUsername == "" {
        return text
    }
    prefix := "@" + botUsername
    if strings.HasPrefix(strings.ToLower(text), strings.ToLower(prefix)) {
        text = strings.TrimSpace(text[len(prefix):])
    }
    return text
}
```

### 2. Get bot username

The Telegram Bot API token can be used to call `getMe` on startup to get the bot's username. Alternatively, add `bot_username` to config, or extract from the existing Telegram API client if available.

### 3. Apply before intent detection

In `processUpdate()` (~line 389):
```go
text := strings.TrimSpace(msg.Text)
text = stripBotMention(text, h.botUsername)
```

### 4. Tests

- Test: `stripBotMention("@PilotBot hi", "PilotBot")` → `"hi"`
- Test: `stripBotMention("hi", "PilotBot")` → `"hi"` (no mention)
- Test: `stripBotMention("@PilotBot", "PilotBot")` → `""` (mention only)
- Test: case insensitive `@pilotbot hi` → `"hi"`

## Files to Change

- `internal/adapters/telegram/handler.go` — add stripping, wire before intent detection
- `internal/adapters/telegram/handler_test.go` — new test cases