### PR TITLE
GH-2132: fix(adapters): wire dead Notifiers — Discord, AzureDevOps, Asana, Jira, Plane never connected

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/alekspetrov/pilot/internal/adapters/asana"
+	"github.com/alekspetrov/pilot/internal/adapters/azuredevops"
 	"github.com/alekspetrov/pilot/internal/adapters/github"
 	"github.com/alekspetrov/pilot/internal/adapters/gitlab"
 	"github.com/alekspetrov/pilot/internal/adapters/jira"
@@ -1047,4 +1048,110 @@ func handleGitLabIssueWithResult(ctx context.Context, cfg *config.Config, client
 	}
 
 	return issueResult, execErr
+}
+
+// handleAzureDevOpsWorkItemWithResult processes an Azure DevOps work item picked up by the poller (GH-2132).
+func handleAzureDevOpsWorkItemWithResult(ctx context.Context, cfg *config.Config, client *azuredevops.Client, notifier *azuredevops.Notifier, wi *azuredevops.WorkItem, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner, monitor *executor.Monitor, program *tea.Program, alertsEngine *alerts.Engine, enforcer *budget.Enforcer) (*azuredevops.WorkItemResult, error) {
+	taskID := fmt.Sprintf("ADO-%d", wi.ID)
+	title := wi.GetTitle()
+
+	taskDesc := fmt.Sprintf("Azure DevOps Work Item %d: %s\n\n%s", wi.ID, title, wi.GetDescription())
+	branchName := fmt.Sprintf("pilot/%s", taskID)
+
+	task := &executor.Task{
+		ID:          taskID,
+		Title:       title,
+		Description: taskDesc,
+		ProjectPath: projectPath,
+		Branch:      branchName,
+		CreatePR:    true,
+	}
+
+	// GH-2132: Notify task started via notifier (adds in-progress tag + comment)
+	if notifier != nil {
+		if err := notifier.NotifyTaskStarted(ctx, wi.ID, taskID); err != nil {
+			logging.WithComponent("azuredevops").Warn("Failed to notify task started",
+				slog.Int("work_item_id", wi.ID),
+				slog.Any("error", err),
+			)
+		}
+	}
+
+	deps := HandlerDeps{
+		Cfg:          cfg,
+		Dispatcher:   dispatcher,
+		Runner:       runner,
+		Monitor:      monitor,
+		Program:      program,
+		AlertsEngine: alertsEngine,
+		Enforcer:     enforcer,
+		ProjectPath:  projectPath,
+	}
+	info := IssueInfo{
+		TaskID:   taskID,
+		Title:    title,
+		URL:      wi.URL,
+		Adapter:  "azuredevops",
+		LogEmoji: "🔷",
+	}
+
+	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
+
+	// Build work item result
+	wiResult := &azuredevops.WorkItemResult{
+		Success:    hr.Success,
+		BranchName: hr.BranchName,
+		PRNumber:   hr.PRNumber,
+		PRURL:      hr.PRURL,
+		HeadSHA:    hr.HeadSHA,
+		Error:      hr.Error,
+	}
+
+	// Post-execution notifications via notifier
+	if notifier != nil {
+		if execErr != nil {
+			if err := notifier.NotifyTaskFailed(ctx, wi.ID, execErr.Error()); err != nil {
+				logging.WithComponent("azuredevops").Warn("Failed to notify task failed",
+					slog.Int("work_item_id", wi.ID),
+					slog.Any("error", err),
+				)
+			}
+		} else if hr.Result != nil && hr.Result.Success {
+			if hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" {
+				if err := notifier.NotifyTaskFailed(ctx, wi.ID, "Execution completed but no changes were made"); err != nil {
+					logging.WithComponent("azuredevops").Warn("Failed to notify no-changes",
+						slog.Int("work_item_id", wi.ID),
+						slog.Any("error", err),
+					)
+				}
+				wiResult.Success = false
+			} else {
+				summary := fmt.Sprintf("Duration: %s", hr.Result.Duration)
+				if err := notifier.NotifyTaskCompleted(ctx, wi.ID, hr.Result.PRUrl, summary); err != nil {
+					logging.WithComponent("azuredevops").Warn("Failed to notify task completed",
+						slog.Int("work_item_id", wi.ID),
+						slog.Any("error", err),
+					)
+				}
+				// Link PR if created
+				if hr.PRNumber > 0 {
+					if err := notifier.LinkPR(ctx, wi.ID, hr.PRNumber, hr.PRURL); err != nil {
+						logging.WithComponent("azuredevops").Warn("Failed to link PR",
+							slog.Int("work_item_id", wi.ID),
+							slog.Any("error", err),
+						)
+					}
+				}
+			}
+		} else if hr.Result != nil {
+			if err := notifier.NotifyTaskFailed(ctx, wi.ID, hr.Result.Error); err != nil {
+				logging.WithComponent("azuredevops").Warn("Failed to notify task failed",
+					slog.Int("work_item_id", wi.ID),
+					slog.Any("error", err),
+				)
+			}
+		}
+	}
+
+	return wiResult, execErr
 }

--- a/cmd/pilot/poller_asana.go
+++ b/cmd/pilot/poller_asana.go
@@ -28,10 +28,38 @@ func asanaPollerRegistration() PollerRegistration {
 				deps.Cfg.Adapters.Asana.AccessToken,
 				deps.Cfg.Adapters.Asana.WorkspaceID,
 			)
+
+			// GH-2132: Create notifier for task lifecycle notifications
+			asanaPilotTag := deps.Cfg.Adapters.Asana.PilotTag
+			if asanaPilotTag == "" {
+				asanaPilotTag = "pilot"
+			}
+			asanaNotifier := asana.NewNotifier(asanaClient, asanaPilotTag)
+
 			// GH-1701: Wire processed store for dedup persistence across restarts
 			asanaPollerOpts := []asana.PollerOption{
 				asana.WithOnAsanaTask(func(taskCtx context.Context, task *asana.Task) (*asana.TaskResult, error) {
+					taskID := "ASANA-" + task.GID
+
+					// GH-2132: Notify task started
+					if err := asanaNotifier.NotifyTaskStarted(taskCtx, task.GID, taskID); err != nil {
+						logging.WithComponent("asana").Warn("Failed to notify task started",
+							slog.String("task_gid", task.GID),
+							slog.Any("error", err),
+						)
+					}
+
 					result, err := handleAsanaTaskWithResult(taskCtx, deps.Cfg, asanaClient, task, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
+
+					// GH-2132: Link PR via notifier
+					if result != nil && result.PRNumber > 0 {
+						if linkErr := asanaNotifier.LinkPR(taskCtx, task.GID, result.PRNumber, result.PRURL); linkErr != nil {
+							logging.WithComponent("asana").Warn("Failed to link PR",
+								slog.String("task_gid", task.GID),
+								slog.Any("error", linkErr),
+							)
+						}
+					}
 
 					// GH-1399: Wire PR to autopilot for CI monitoring + auto-merge
 					if result != nil && result.PRNumber > 0 && deps.AutopilotController != nil {

--- a/cmd/pilot/poller_azuredevops.go
+++ b/cmd/pilot/poller_azuredevops.go
@@ -26,13 +26,23 @@ func azuredevopsPollerRegistration() PollerRegistration {
 
 			adoClient := azuredevops.NewClientWithConfig(deps.Cfg.Adapters.AzureDevOps)
 
+			// GH-2132: Create notifier for task lifecycle notifications
+			pilotTag := deps.Cfg.Adapters.AzureDevOps.PilotTag
+			if pilotTag == "" {
+				pilotTag = "pilot"
+			}
+			adoNotifier := azuredevops.NewNotifier(adoClient, pilotTag)
+
 			adoPollerOpts := []azuredevops.PollerOption{
-				azuredevops.WithOnWorkItem(func(wiCtx context.Context, wi *azuredevops.WorkItem) error {
-					logging.WithComponent("azuredevops").Info("Work item picked up",
-						slog.Int("id", wi.ID),
-						slog.String("title", wi.GetTitle()),
-					)
-					return nil
+				azuredevops.WithOnWorkItemWithResult(func(wiCtx context.Context, wi *azuredevops.WorkItem) (*azuredevops.WorkItemResult, error) {
+					result, err := handleAzureDevOpsWorkItemWithResult(wiCtx, deps.Cfg, adoClient, adoNotifier, wi, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
+
+					// GH-2132: Wire PR to autopilot for CI monitoring + auto-merge
+					if result != nil && result.PRNumber > 0 && deps.AutopilotController != nil {
+						deps.AutopilotController.OnPRCreated(result.PRNumber, result.PRURL, 0, result.HeadSHA, result.BranchName, "")
+					}
+
+					return result, err
 				}),
 			}
 
@@ -46,11 +56,6 @@ func azuredevopsPollerRegistration() PollerRegistration {
 			// Wire processed store for persistence
 			if deps.AutopilotStateStore != nil {
 				adoPollerOpts = append(adoPollerOpts, azuredevops.WithProcessedStore(deps.AutopilotStateStore))
-			}
-
-			pilotTag := deps.Cfg.Adapters.AzureDevOps.PilotTag
-			if pilotTag == "" {
-				pilotTag = "pilot"
 			}
 
 			adoPoller := azuredevops.NewPoller(adoClient, pilotTag, interval, adoPollerOpts...)

--- a/cmd/pilot/poller_discord.go
+++ b/cmd/pilot/poller_discord.go
@@ -26,6 +26,10 @@ func discordPollerRegistration() PollerRegistration {
 				LLMClassifier:   deps.Cfg.Adapters.Discord.LLMClassifier,
 			}, deps.Runner)
 
+			// GH-2132: Wire notifier for task lifecycle messages
+			discordClient := discord.NewClient(deps.Cfg.Adapters.Discord.BotToken)
+			handler.SetNotifier(discord.NewNotifier(discordClient))
+
 			go func() {
 				if err := handler.StartListening(ctx); err != nil {
 					logging.WithComponent("discord").Error("Discord listener error",

--- a/cmd/pilot/poller_jira.go
+++ b/cmd/pilot/poller_jira.go
@@ -22,6 +22,13 @@ func jiraPollerRegistration() PollerRegistration {
 			jiraAdapter := jira.NewAdapter(deps.Cfg.Adapters.Jira)
 			adapters.Register(jiraAdapter)
 
+			// GH-2132: Create notifier for task lifecycle notifications
+			jiraNotifier := jira.NewNotifier(
+				jiraAdapter.Client(),
+				deps.Cfg.Adapters.Jira.Transitions.InProgress,
+				deps.Cfg.Adapters.Jira.Transitions.Done,
+			)
+
 			pollerDeps := adapters.PollerDeps{
 				MaxConcurrent: deps.Cfg.Orchestrator.MaxConcurrent,
 			}
@@ -30,7 +37,25 @@ func jiraPollerRegistration() PollerRegistration {
 			}
 
 			jiraPoller := jiraAdapter.CreatePoller(pollerDeps, func(issueCtx context.Context, issue *jira.Issue) (*jira.IssueResult, error) {
+				// GH-2132: Notify task started (transitions to In Progress + posts comment)
+				if err := jiraNotifier.NotifyTaskStarted(issueCtx, issue.Key, issue.Key); err != nil {
+					logging.WithComponent("jira").Warn("Failed to notify task started",
+						slog.String("issue", issue.Key),
+						slog.Any("error", err),
+					)
+				}
+
 				result, err := handleJiraIssueWithResult(issueCtx, deps.Cfg, jiraAdapter.Client(), issue, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
+
+				// GH-2132: Link PR via notifier
+				if result != nil && result.PRNumber > 0 {
+					if linkErr := jiraNotifier.LinkPR(issueCtx, issue.Key, result.PRNumber, result.PRURL); linkErr != nil {
+						logging.WithComponent("jira").Warn("Failed to link PR",
+							slog.String("issue", issue.Key),
+							slog.Any("error", linkErr),
+						)
+					}
+				}
 
 				// GH-1399: Wire PR to autopilot for CI monitoring + auto-merge
 				if result != nil && result.PRNumber > 0 && deps.AutopilotController != nil {

--- a/cmd/pilot/poller_plane.go
+++ b/cmd/pilot/poller_plane.go
@@ -29,9 +29,32 @@ func planePollerRegistration() PollerRegistration {
 				deps.Cfg.Adapters.Plane.APIKey,
 			)
 
+			// GH-2132: Create notifier for task lifecycle notifications
+			planeNotifier := plane.NewNotifier(planeClient, deps.Cfg.Adapters.Plane.WorkspaceSlug)
+
 			planePollerOpts := []plane.PollerOption{
 				plane.WithOnIssue(func(issueCtx context.Context, issue *plane.WorkItem) (*plane.IssueResult, error) {
+					taskID := "PLANE-" + issue.ID[:8]
+
+					// GH-2132: Notify task started
+					if err := planeNotifier.NotifyTaskStarted(issueCtx, issue.ProjectID, issue.ID, taskID); err != nil {
+						logging.WithComponent("plane").Warn("Failed to notify task started",
+							slog.String("work_item_id", issue.ID),
+							slog.Any("error", err),
+						)
+					}
+
 					result, err := handlePlaneIssueWithResult(issueCtx, deps.Cfg, planeClient, issue, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
+
+					// GH-2132: Link PR via notifier
+					if result != nil && result.PRNumber > 0 {
+						if linkErr := planeNotifier.LinkPR(issueCtx, issue.ProjectID, issue.ID, result.PRNumber, result.PRURL); linkErr != nil {
+							logging.WithComponent("plane").Warn("Failed to link PR",
+								slog.String("work_item_id", issue.ID),
+								slog.Any("error", linkErr),
+							)
+						}
+					}
 
 					// Wire PR to autopilot for CI monitoring + auto-merge
 					if result != nil && result.PRNumber > 0 && deps.AutopilotController != nil {

--- a/internal/adapters/discord/handler.go
+++ b/internal/adapters/discord/handler.go
@@ -19,6 +19,7 @@ import (
 type Handler struct {
 	gatewayClient     *GatewayClient
 	apiClient         *Client
+	notifier          *Notifier // GH-2132: task lifecycle notifications
 	runner            *executor.Runner
 	allowedGuilds     map[string]bool
 	allowedChannels   map[string]bool
@@ -110,6 +111,11 @@ func NewHandler(config *HandlerConfig, runner *executor.Runner) *Handler {
 	}
 
 	return h
+}
+
+// SetNotifier sets the notifier for task lifecycle messages (GH-2132).
+func (h *Handler) SetNotifier(n *Notifier) {
+	h.notifier = n
 }
 
 // StartListening connects to Discord and starts listening for events
@@ -668,6 +674,13 @@ func (h *Handler) handleConfirmation(ctx context.Context, channelID, userID stri
 
 // executeTask executes a confirmed task.
 func (h *Handler) executeTask(ctx context.Context, channelID, taskID, description string) {
+	// GH-2132: Notify task started via notifier
+	if h.notifier != nil {
+		if err := h.notifier.NotifyTaskStarted(ctx, channelID, taskID, description); err != nil {
+			h.log.Warn("Failed to send task started notification", slog.Any("error", err))
+		}
+	}
+
 	// Send execution started message
 	progressMsg := FormatProgressUpdate(taskID, "Starting", 0, "Initializing...")
 	msg, err := h.apiClient.SendMessage(ctx, channelID, progressMsg)
@@ -737,6 +750,10 @@ func (h *Handler) executeTask(ctx context.Context, channelID, taskID, descriptio
 	if err != nil {
 		errMsg := fmt.Sprintf("❌ Task failed\n%s\n\n%s", taskID, err.Error())
 		_, _ = h.apiClient.SendMessage(ctx, channelID, errMsg)
+		// GH-2132: Notify failure via notifier
+		if h.notifier != nil {
+			_ = h.notifier.NotifyTaskFailed(ctx, channelID, taskID, err.Error())
+		}
 		return
 	}
 
@@ -746,4 +763,9 @@ func (h *Handler) executeTask(ctx context.Context, channelID, taskID, descriptio
 	resultMsg := FormatTaskResult(output, true, prURL)
 
 	_, _ = h.apiClient.SendMessage(ctx, channelID, resultMsg)
+
+	// GH-2132: Notify completion via notifier
+	if h.notifier != nil {
+		_ = h.notifier.NotifyTaskCompleted(ctx, channelID, taskID, output, prURL)
+	}
 }

--- a/internal/adapters/plane/notifier.go
+++ b/internal/adapters/plane/notifier.go
@@ -1,0 +1,86 @@
+package plane
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/alekspetrov/pilot/internal/logging"
+)
+
+// Notifier handles status updates to Plane.so work items.
+type Notifier struct {
+	client        *Client
+	workspaceSlug string
+}
+
+// NewNotifier creates a new Plane notifier.
+func NewNotifier(client *Client, workspaceSlug string) *Notifier {
+	return &Notifier{
+		client:        client,
+		workspaceSlug: workspaceSlug,
+	}
+}
+
+// NotifyTaskStarted posts a comment when Pilot starts working on a work item.
+func (n *Notifier) NotifyTaskStarted(ctx context.Context, projectID, workItemID, taskID string) error {
+	comment := fmt.Sprintf("<p>🤖 <strong>Pilot started working on this issue</strong></p><p>Task ID: <code>%s</code></p><p>I'll post updates as I make progress.</p>", taskID)
+	if err := n.client.AddComment(ctx, n.workspaceSlug, projectID, workItemID, comment); err != nil {
+		return fmt.Errorf("failed to add start comment: %w", err)
+	}
+
+	logging.WithComponent("plane").Info("Notified task started",
+		slog.String("work_item_id", workItemID),
+		slog.String("task_id", taskID))
+
+	return nil
+}
+
+// NotifyTaskCompleted posts a completion comment.
+func (n *Notifier) NotifyTaskCompleted(ctx context.Context, projectID, workItemID, prURL, summary string) error {
+	comment := "<p>✅ <strong>Pilot completed this task!</strong></p>"
+	if prURL != "" {
+		comment += fmt.Sprintf("<p><strong>Pull Request</strong>: <a href=\"%s\">%s</a></p>", prURL, prURL)
+	}
+	if summary != "" {
+		comment += fmt.Sprintf("<p><strong>Summary</strong>: %s</p>", summary)
+	}
+
+	if err := n.client.AddComment(ctx, n.workspaceSlug, projectID, workItemID, comment); err != nil {
+		return fmt.Errorf("failed to add completion comment: %w", err)
+	}
+
+	logging.WithComponent("plane").Info("Notified task completed",
+		slog.String("work_item_id", workItemID),
+		slog.String("pr_url", prURL))
+
+	return nil
+}
+
+// NotifyTaskFailed posts a failure comment.
+func (n *Notifier) NotifyTaskFailed(ctx context.Context, projectID, workItemID, reason string) error {
+	comment := fmt.Sprintf("<p>❌ <strong>Pilot could not complete this task</strong></p><p><strong>Reason</strong>: %s</p><p><em>Please review the issue and consider manual intervention or reopening with more details.</em></p>", reason)
+	if err := n.client.AddComment(ctx, n.workspaceSlug, projectID, workItemID, comment); err != nil {
+		return fmt.Errorf("failed to add failure comment: %w", err)
+	}
+
+	logging.WithComponent("plane").Warn("Notified task failed",
+		slog.String("work_item_id", workItemID),
+		slog.String("reason", reason))
+
+	return nil
+}
+
+// LinkPR posts a comment linking the created PR.
+func (n *Notifier) LinkPR(ctx context.Context, projectID, workItemID string, prNumber int, prURL string) error {
+	comment := fmt.Sprintf("<p>🔗 <strong>Pull Request Created</strong>: <a href=\"%s\">PR #%d</a></p><p><em>This PR implements the changes for this issue.</em></p>", prURL, prNumber)
+	if err := n.client.AddComment(ctx, n.workspaceSlug, projectID, workItemID, comment); err != nil {
+		return fmt.Errorf("failed to add PR link comment: %w", err)
+	}
+
+	logging.WithComponent("plane").Info("Linked PR to work item",
+		slog.String("work_item_id", workItemID),
+		slog.Int("pr_number", prNumber))
+
+	return nil
+}

--- a/internal/adapters/plane/notifier_test.go
+++ b/internal/adapters/plane/notifier_test.go
@@ -1,0 +1,156 @@
+package plane
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alekspetrov/pilot/internal/testutil"
+)
+
+func TestNewNotifier(t *testing.T) {
+	client := NewClient("https://plane.example.com", testutil.FakePlaneAPIKey)
+	notifier := NewNotifier(client, "test-workspace")
+
+	if notifier == nil {
+		t.Fatal("NewNotifier returned nil")
+	}
+	if notifier.workspaceSlug != "test-workspace" {
+		t.Errorf("workspaceSlug = %q, want %q", notifier.workspaceSlug, "test-workspace")
+	}
+}
+
+func TestPlaneNotifyTaskStarted(t *testing.T) {
+	var capturedComment string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		// Verify path contains workspace/project/work-item
+		if !strings.Contains(r.URL.Path, "ws/projects/proj-1/work-items/wi-42/comments") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		capturedComment = body["comment_html"]
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+	notifier := NewNotifier(client, "ws")
+
+	err := notifier.NotifyTaskStarted(context.Background(), "proj-1", "wi-42", "PLANE-abcd1234")
+	if err != nil {
+		t.Fatalf("NotifyTaskStarted failed: %v", err)
+	}
+
+	if !strings.Contains(capturedComment, "Pilot started working") {
+		t.Errorf("comment should mention Pilot started, got: %s", capturedComment)
+	}
+	if !strings.Contains(capturedComment, "PLANE-abcd1234") {
+		t.Errorf("comment should contain task ID, got: %s", capturedComment)
+	}
+}
+
+func TestPlaneNotifyTaskCompleted(t *testing.T) {
+	var capturedComment string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		capturedComment = body["comment_html"]
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+	notifier := NewNotifier(client, "ws")
+
+	err := notifier.NotifyTaskCompleted(context.Background(), "proj-1", "wi-42", "https://github.com/org/repo/pull/5", "Added feature X")
+	if err != nil {
+		t.Fatalf("NotifyTaskCompleted failed: %v", err)
+	}
+
+	if !strings.Contains(capturedComment, "Pilot completed") {
+		t.Errorf("comment should mention completion, got: %s", capturedComment)
+	}
+	if !strings.Contains(capturedComment, "pull/5") {
+		t.Errorf("comment should contain PR URL, got: %s", capturedComment)
+	}
+}
+
+func TestPlaneNotifyTaskFailed(t *testing.T) {
+	var capturedComment string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		capturedComment = body["comment_html"]
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+	notifier := NewNotifier(client, "ws")
+
+	err := notifier.NotifyTaskFailed(context.Background(), "proj-1", "wi-42", "build failed")
+	if err != nil {
+		t.Fatalf("NotifyTaskFailed failed: %v", err)
+	}
+
+	if !strings.Contains(capturedComment, "could not complete") {
+		t.Errorf("comment should mention failure, got: %s", capturedComment)
+	}
+	if !strings.Contains(capturedComment, "build failed") {
+		t.Errorf("comment should contain reason, got: %s", capturedComment)
+	}
+}
+
+func TestPlaneLinkPR(t *testing.T) {
+	var capturedComment string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		capturedComment = body["comment_html"]
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, testutil.FakePlaneAPIKey)
+	notifier := NewNotifier(client, "ws")
+
+	err := notifier.LinkPR(context.Background(), "proj-1", "wi-42", 5, "https://github.com/org/repo/pull/5")
+	if err != nil {
+		t.Fatalf("LinkPR failed: %v", err)
+	}
+
+	if !strings.Contains(capturedComment, "Pull Request Created") {
+		t.Errorf("comment should mention PR, got: %s", capturedComment)
+	}
+	if !strings.Contains(capturedComment, "PR #5") {
+		t.Errorf("comment should contain PR number, got: %s", capturedComment)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2132.

Closes #2132

## Changes

GitHub Issue #2132: fix(adapters): wire dead Notifiers — Discord, AzureDevOps, Asana, Jira, Plane never connected

## Bug

Five adapter Notifiers are exported but never wired to autopilot. Task start/complete/fail notifications silently don't fire for these adapters.

### Wired (working)
- ✅ Slack (`slack.Notifier`)
- ✅ Telegram (`telegram.Notifier`)  
- ✅ Linear (`linear.Notifier`)
- ✅ GitLab (`gitlab.Notifier`)

### Dead (built, never connected)
- ❌ `discord.Notifier` — 0 external refs
- ❌ `azuredevops.Notifier` — 0 external refs
- ❌ `asana.Notifier` — 0 external refs
- ❌ `jira.Notifier` — 0 external refs
- ❌ `plane.Notifier` — 0 external refs

## Root Cause

Each notifier was added as part of adapter PRs but the wiring step in `cmd/pilot/main.go` or `cmd/pilot/handlers.go` was missed. The notifier code passes package-level tests but there's no integration test verifying the connection.

## Fix

Wire each notifier in the respective poller registration or handler wiring:

1. **Discord** — `cmd/pilot/poller_discord.go`: create `discord.NewNotifier(apiClient)`, pass to handler or wire to autopilot `OnTaskCompleted` callback
2. **AzureDevOps** — `cmd/pilot/poller_azuredevops.go`: same pattern as GitLab notifier wiring
3. **Asana** — `cmd/pilot/poller_asana.go`: same pattern
4. **Jira** — `cmd/pilot/poller_jira.go`: same pattern (Jira has webhook mode too — wire in both paths)
5. **Plane** — `cmd/pilot/poller_plane.go`: same pattern

Reference working wiring: check how `linear.Notifier` or `slack.Notifier` are connected in `main.go`.

## Files to Change

- `cmd/pilot/poller_discord.go`
- `cmd/pilot/poller_azuredevops.go`
- `cmd/pilot/poller_asana.go`
- `cmd/pilot/poller_jira.go`
- `cmd/pilot/poller_plane.go`
- `cmd/pilot/main.go` (gateway mode wiring if applicable)