### PR TITLE
GH-2136: fix(executor): complexity detection checks trivial patterns before complex — body phrases override title

### DIFF
--- a/internal/executor/complexity.go
+++ b/internal/executor/complexity.go
@@ -128,23 +128,46 @@ func DetectComplexity(task *Task) Complexity {
 		return ComplexityEpic
 	}
 
-	// Check trivial patterns (fastest path for small changes)
-	for _, pattern := range trivialPatterns {
-		if strings.Contains(combined, pattern) {
-			return ComplexityTrivial
-		}
-	}
-
-	// Check complex patterns next (prevents false simple classification)
+	// Check title for complex patterns first (title is strongest signal - GH-2136)
+	// If title indicates complex work, use complex classification regardless of body
 	for _, pattern := range complexPatterns {
-		if strings.Contains(combined, pattern) {
+		if strings.Contains(title, pattern) {
 			return ComplexityComplex
 		}
 	}
 
-	// Check simple patterns
+	// Check title for trivial patterns (second priority)
+	for _, pattern := range trivialPatterns {
+		if strings.Contains(title, pattern) {
+			return ComplexityTrivial
+		}
+	}
+
+	// Check title for simple patterns
 	for _, pattern := range simplePatterns {
-		if strings.Contains(combined, pattern) {
+		if strings.Contains(title, pattern) {
+			return ComplexitySimple
+		}
+	}
+
+	// Fall back to body-based detection if title had no matches
+	// Check complex patterns in description
+	for _, pattern := range complexPatterns {
+		if strings.Contains(desc, pattern) {
+			return ComplexityComplex
+		}
+	}
+
+	// Check trivial patterns in description
+	for _, pattern := range trivialPatterns {
+		if strings.Contains(desc, pattern) {
+			return ComplexityTrivial
+		}
+	}
+
+	// Check simple patterns in description
+	for _, pattern := range simplePatterns {
+		if strings.Contains(desc, pattern) {
 			return ComplexitySimple
 		}
 	}

--- a/internal/executor/complexity_test.go
+++ b/internal/executor/complexity_test.go
@@ -266,6 +266,22 @@ Regular sync meetings with stakeholders will be necessary to ensure alignment on
 			task:     &Task{Description: "Rewrite the parser from scratch"},
 			expected: ComplexityComplex,
 		},
+		{
+			name: "GH-2136: refactor in title overrides trivial in body",
+			task: &Task{
+				Title: "refactor(adapters): wire Slack/Telegram/Discord to use shared comms.Handler pipeline",
+				Description: `Consolidate adapter implementations to reduce duplication.
+
+Steps:
+- Delete from each adapter the duplicate pipeline code
+- Remove unused helper methods
+- Delete unused constants and types
+- Integrate shared Handler
+
+This affects adapters/slack, adapters/telegram, adapters/discord.`,
+			},
+			expected: ComplexityComplex, // Title says "refactor" → complex, NOT trivial despite "delete unused"
+		},
 
 		// Medium cases (default)
 		{


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2136.

Closes #2136

## Changes

GitHub Issue #2136: fix(executor): complexity detection checks trivial patterns before complex — body phrases override title

## Bug

`DetectComplexity()` in `internal/executor/complexity.go` checks `trivialPatterns` (line 131-136) **before** `complexPatterns` (line 138-143). Both match against `combined = description + title`.

This means a refactor issue whose body mentions "remove unused" or "delete unused" as a sub-step gets classified as **trivial** even though the title says "refactor" (a complex pattern).

### Example (GH-2131)

- **Title**: `refactor(adapters): wire Slack/Telegram/Discord to use shared comms.Handler pipeline`
- **Body** includes: `"Delete from each adapter... remove unused... delete unused"`
- **Result**: `"remove unused"` matched trivial pattern → `ComplexityTrivial` → **15m timeout** → timed out
- **Expected**: `"refactor"` in title → `ComplexityComplex` → 60m timeout

### Root Cause

```go
// Line 131: Checked FIRST
for _, pattern := range trivialPatterns {
    if strings.Contains(combined, pattern) {
        return ComplexityTrivial  // ← wins even if title says "refactor"
    }
}

// Line 138: Never reached
for _, pattern := range complexPatterns {
    if strings.Contains(combined, pattern) {
        return ComplexityComplex
    }
}
```

## Fix

**Option A (recommended): Check title first, then body**

Title is a stronger signal than body. If title matches complex → complex, regardless of body:

```go
// 1. Check title for complex/epic patterns first (strongest signal)
for _, pattern := range complexPatterns {
    if strings.Contains(title, pattern) {
        return ComplexityComplex
    }
}

// 2. Check title for trivial patterns
for _, pattern := range trivialPatterns {
    if strings.Contains(title, pattern) {
        return ComplexityTrivial
    }
}

// 3. Fall through to body-based detection
```

**Option B: Check complex before trivial (simple reorder)**

Move complex pattern check above trivial. Trade-off: a genuinely trivial task with "refactor" in body text would be over-classified. Less risky than under-classifying.

**Option C: Highest-wins scoring**

Scan all patterns, return the highest complexity found across both title and body. Most accurate but more code.

## Files to Change

- `internal/executor/complexity.go` — reorder or restructure pattern matching
- `internal/executor/complexity_test.go` — add test case for "refactor with trivial sub-steps"

## Impact

Any issue with a complex title but body mentioning trivial keywords gets misclassified → wrong model, wrong timeout, wrong effort. This likely affected multiple tasks silently (they succeeded within 15m by luck, or Haiku handled them worse than Opus would have).