### PR TITLE
GH-2142: Extend `comms.Handler` for adapter delegation

### DIFF
--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -546,13 +546,14 @@ func (h *Handler) executeTask(ctx context.Context, contextID, threadID, taskID, 
 		MemberID:    memberID,
 	}
 
-	// Progress callback with throttling
+	// Progress callback with throttling (named callback for parallel-safe execution)
+	callbackName := fmt.Sprintf("comms-%s", taskID)
 	if msgRef != "" && h.runner != nil {
 		var lastPhase string
 		var lastProgress int
 		var lastUpdate time.Time
 
-		h.runner.OnProgress(func(tid, phase string, progress int, message string) {
+		h.runner.AddProgressCallback(callbackName, func(tid, phase string, progress int, message string) {
 			if tid != taskID {
 				return
 			}
@@ -575,12 +576,14 @@ func (h *Handler) executeTask(ctx context.Context, contextID, threadID, taskID, 
 	}
 
 	// Execute
-	h.log.Info("Executing task", slog.String("task_id", taskID), slog.String("context_id", contextID))
+	h.log.Info("Executing task",
+		slog.String("task_id", taskID),
+		slog.String("context_id", contextID))
 	result, err := h.runner.Execute(taskCtx, task)
 
-	// Clear progress callback
+	// Remove named progress callback
 	if h.runner != nil {
-		h.runner.OnProgress(nil)
+		h.runner.RemoveProgressCallback(callbackName)
 	}
 
 	if err != nil {

--- a/internal/comms/handler_test.go
+++ b/internal/comms/handler_test.go
@@ -543,3 +543,109 @@ func TestSenderTracking(t *testing.T) {
 		t.Errorf("expected sender user-42, got %s", sender)
 	}
 }
+
+func TestIncomingMessage_PlatformFields(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	now := time.Now()
+	msg := &IncomingMessage{
+		ContextID:  "ch1",
+		SenderID:   "u1",
+		SenderName: "Alice",
+		Text:       "hello",
+		Platform:   "discord",
+		GuildID:    "guild-123",
+		Timestamp:  now,
+	}
+
+	// Verify fields pass through HandleMessage without error
+	h.HandleMessage(context.Background(), msg)
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected at least one response")
+	}
+
+	// Verify struct fields are accessible and correct
+	if msg.Platform != "discord" {
+		t.Errorf("expected platform discord, got %s", msg.Platform)
+	}
+	if msg.GuildID != "guild-123" {
+		t.Errorf("expected guild-123, got %s", msg.GuildID)
+	}
+	if msg.SenderName != "Alice" {
+		t.Errorf("expected sender name Alice, got %s", msg.SenderName)
+	}
+	if msg.Timestamp.IsZero() {
+		t.Error("expected non-zero timestamp")
+	}
+}
+
+func TestIncomingMessage_PlatformFieldsZeroValues(t *testing.T) {
+	// Verify backward compatibility: new fields default to zero values
+	msg := &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "u1",
+		Text:      "hello",
+	}
+
+	if msg.Platform != "" {
+		t.Errorf("expected empty platform, got %s", msg.Platform)
+	}
+	if msg.GuildID != "" {
+		t.Errorf("expected empty guild ID, got %s", msg.GuildID)
+	}
+	if msg.SenderName != "" {
+		t.Errorf("expected empty sender name, got %s", msg.SenderName)
+	}
+	if !msg.Timestamp.IsZero() {
+		t.Error("expected zero timestamp")
+	}
+}
+
+func TestHandleMessage_CallbackWithPlatformFields(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.mu.Lock()
+	h.pendingTasks["ch1"] = &PendingTask{
+		TaskID:      "TEST-789",
+		Description: "test task",
+		ContextID:   "ch1",
+		CreatedAt:   time.Now(),
+	}
+	h.mu.Unlock()
+
+	// Use "cancel" action to avoid triggering executeTask (requires runner)
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID:  "ch1",
+		SenderID:   "u1",
+		SenderName: "Bob",
+		Platform:   "slack",
+		IsCallback: true,
+		CallbackID: "cb-2",
+		ActionID:   "cancel",
+	})
+
+	if len(m.acks) == 0 {
+		t.Error("expected callback acknowledgment")
+	}
+
+	// Verify sender was tracked despite being a callback
+	h.mu.Lock()
+	sender := h.lastSender["ch1"]
+	h.mu.Unlock()
+	if sender != "u1" {
+		t.Errorf("expected sender u1, got %s", sender)
+	}
+
+	// Verify task was cancelled
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected cancellation message")
+	}
+	if texts[0].text != "❌ Task TEST-789 cancelled." {
+		t.Errorf("unexpected message: %s", texts[0].text)
+	}
+}

--- a/internal/comms/types.go
+++ b/internal/comms/types.go
@@ -10,8 +10,12 @@ import (
 type IncomingMessage struct {
 	ContextID  string      // chatID / channelID
 	SenderID   string      // user ID (string; adapters convert int64)
+	SenderName string      // display name (optional; for logging/notifications)
 	Text       string      // normalized message text
 	ThreadID   string      // thread context (Slack threadTS, Telegram reply, etc.)
+	Platform   string      // source adapter: "telegram", "slack", "discord"
+	GuildID    string      // Discord server/guild ID (empty on other platforms)
+	Timestamp  time.Time   // message creation time (zero value if unavailable)
 	ImagePath  string      // downloaded image path (optional)
 	VoiceText  string      // transcribed voice text (optional)
 	IsCallback bool        // true when this is a button callback


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2142.

Closes #2142

## Changes

Audit `internal/comms/handler.go` and `types.go` to ensure `HandleMessage()` and `IncomingMessage` cover all adapter needs. Verify the `Messenger` interface is complete for all three adapters. Add any missing fields (e.g., platform-specific metadata on `IncomingMessage`, named progress callback support for Discord). Ensure `CleanupLoop()` signature works when called from each adapter's lifecycle. Add tests for any new surface area. Scope: `internal/comms/` only.