### PR TITLE
GH-2145: fix(executor): LLM effort classifier should influence model and timeout selection — not just effort

### DIFF
--- a/internal/executor/model_routing.go
+++ b/internal/executor/model_routing.go
@@ -43,6 +43,59 @@ func NewModelRouterWithEffort(modelConfig *ModelRoutingConfig, timeoutConfig *Ti
 	return router
 }
 
+// complexityRank returns a numeric rank for a Complexity value, used for comparison.
+func complexityRank(c Complexity) int {
+	switch c {
+	case ComplexityTrivial:
+		return 0
+	case ComplexitySimple:
+		return 1
+	case ComplexityMedium:
+		return 2
+	case ComplexityComplex:
+		return 3
+	case ComplexityEpic:
+		return 4
+	default:
+		return 2
+	}
+}
+
+// resolveComplexity combines the heuristic complexity with the LLM effort classifier floor.
+// The LLM can only upgrade the complexity, never downgrade it (floor mechanism).
+func (r *ModelRouter) resolveComplexity(task *Task) Complexity {
+	heuristic := DetectComplexity(task)
+
+	if r.effortClassifier == nil {
+		return heuristic
+	}
+
+	effort := r.effortClassifier.Classify(context.Background(), task)
+
+	var floor Complexity
+	switch effort {
+	case "high":
+		floor = ComplexityComplex
+	case "medium":
+		floor = ComplexityMedium
+	case "low":
+		floor = ComplexitySimple
+	default:
+		return heuristic
+	}
+
+	if complexityRank(floor) > complexityRank(heuristic) {
+		slog.Info("LLM effort classifier upgraded complexity",
+			slog.String("task_id", task.ID),
+			slog.String("heuristic", string(heuristic)),
+			slog.String("llm_effort", effort),
+			slog.String("resolved", string(floor)),
+		)
+		return floor
+	}
+	return heuristic
+}
+
 // SelectModel returns the appropriate model name for a task based on its complexity.
 // If model routing is disabled, returns empty string (use backend default).
 // When an outcome tracker is set, checks failure rates and escalates if needed (GH-1991).
@@ -51,7 +104,7 @@ func (r *ModelRouter) SelectModel(task *Task) string {
 		return ""
 	}
 
-	complexity := DetectComplexity(task)
+	complexity := r.resolveComplexity(task)
 	model := r.GetModelForComplexity(complexity)
 
 	// GH-1991: Check outcome tracker for escalation
@@ -93,7 +146,7 @@ func (r *ModelRouter) GetModelForComplexity(complexity Complexity) string {
 
 // SelectTimeout returns the appropriate timeout duration for a task based on its complexity.
 func (r *ModelRouter) SelectTimeout(task *Task) time.Duration {
-	complexity := DetectComplexity(task)
+	complexity := r.resolveComplexity(task)
 	return r.GetTimeoutForComplexity(complexity)
 }
 

--- a/internal/executor/model_routing_test.go
+++ b/internal/executor/model_routing_test.go
@@ -496,6 +496,86 @@ func TestModelRouter_SelectModelNilTrackerNoEscalation(t *testing.T) {
 	}
 }
 
+func TestResolveComplexity_LLMUpgradesHeuristic(t *testing.T) {
+	router := NewModelRouter(nil, nil)
+	// Attach LLM classifier returning "high"
+	classifier := newEffortClassifierWithRunner(mockEffortRunner("high", "large refactor"))
+	router.SetEffortClassifier(classifier)
+
+	// "remove unused" matches trivial heuristic, but LLM says high → complex
+	task := &Task{ID: "GH-2131", Description: "remove unused imports"}
+	got := router.resolveComplexity(task)
+	if got != ComplexityComplex {
+		t.Errorf("Expected ComplexityComplex (LLM floor), got %s", got)
+	}
+}
+
+func TestResolveComplexity_HeuristicWinsWhenHigher(t *testing.T) {
+	router := NewModelRouter(nil, nil)
+	// Attach LLM classifier returning "low"
+	classifier := newEffortClassifierWithRunner(mockEffortRunner("low", "trivial"))
+	router.SetEffortClassifier(classifier)
+
+	// Heuristic returns complex, LLM says low → heuristic wins
+	task := &Task{ID: "GH-999", Description: "Refactor the authentication system"}
+	got := router.resolveComplexity(task)
+	if got != ComplexityComplex {
+		t.Errorf("Expected ComplexityComplex (heuristic wins), got %s", got)
+	}
+}
+
+func TestResolveComplexity_NoClassifier(t *testing.T) {
+	router := NewModelRouter(nil, nil)
+	// No LLM classifier — pure heuristic
+
+	task := &Task{ID: "GH-1", Description: "Fix typo in README"}
+	got := router.resolveComplexity(task)
+	heuristic := DetectComplexity(task)
+	if got != heuristic {
+		t.Errorf("Expected heuristic %s, got %s", heuristic, got)
+	}
+}
+
+func TestSelectModel_UsesResolvedComplexity(t *testing.T) {
+	config := &ModelRoutingConfig{
+		Enabled: true,
+		Trivial: "haiku",
+		Simple:  "sonnet",
+		Medium:  "sonnet",
+		Complex: "opus",
+	}
+	router := NewModelRouter(config, nil)
+	// LLM says "high" → should select opus despite trivial heuristic
+	classifier := newEffortClassifierWithRunner(mockEffortRunner("high", "security sensitive"))
+	router.SetEffortClassifier(classifier)
+
+	task := &Task{ID: "GH-2145", Description: "remove unused imports"}
+	got := router.SelectModel(task)
+	if got != "opus" {
+		t.Errorf("Expected 'opus' (LLM effort floor), got %q", got)
+	}
+}
+
+func TestSelectTimeout_UsesResolvedComplexity(t *testing.T) {
+	timeoutConfig := &TimeoutConfig{
+		Default: "30m",
+		Trivial: "5m",
+		Simple:  "10m",
+		Medium:  "30m",
+		Complex: "60m",
+	}
+	router := NewModelRouter(nil, timeoutConfig)
+	// LLM says "high" → should get 60m despite trivial heuristic
+	classifier := newEffortClassifierWithRunner(mockEffortRunner("high", "large refactor"))
+	router.SetEffortClassifier(classifier)
+
+	task := &Task{ID: "GH-2145", Description: "remove unused imports"}
+	got := router.SelectTimeout(task)
+	if got != 60*time.Minute {
+		t.Errorf("Expected 60m (LLM effort floor), got %v", got)
+	}
+}
+
 func TestModelRouter_SetOutcomeTracker(t *testing.T) {
 	tracker, cleanup := newTestOutcomeTracker(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2145.

Closes #2145

## Changes

GitHub Issue #2145: fix(executor): LLM effort classifier should influence model and timeout selection — not just effort

## Problem

`SelectModel()` and `SelectTimeout()` in `internal/executor/model_routing.go` use only the heuristic `DetectComplexity()` for model and timeout routing. The Haiku LLM effort classifier (`effort_classifier`) already runs and correctly classifies task difficulty, but its result is **only used for effort routing** — model and timeout ignore it.

This caused GH-2131 to be classified as "trivial" (15m timeout, Haiku model) despite being a 3000-line, 8-file refactor — because the issue body contained "remove unused" which matched a trivial heuristic pattern. The effort classifier likely returned "high" but that was ignored for model/timeout.

### Current flow

```
SelectModel(task)  → DetectComplexity(task) [heuristic only] → model
SelectTimeout(task) → DetectComplexity(task) [heuristic only] → timeout
SelectEffort(task)  → effortClassifier.Classify(task) [LLM]  → effort ✅
```

### Desired flow

```
SelectModel(task)  → max(heuristic, LLM floor) → model
SelectTimeout(task) → max(heuristic, LLM floor) → timeout
SelectEffort(task)  → effortClassifier.Classify(task)  → effort (unchanged)
```

## Fix

### 1. Add `resolveComplexity()` method to `ModelRouter`

Private method that combines heuristic + LLM effort floor:

```go
func (r *ModelRouter) resolveComplexity(task *Task) Complexity {
    heuristic := DetectComplexity(task)

    // If no LLM classifier, use heuristic only
    if r.effortClassifier == nil {
        return heuristic
    }

    // Get LLM effort (cached per task ID — no extra latency)
    effort := r.effortClassifier.Classify(context.Background(), task)

    // Map effort to minimum complexity floor
    var floor Complexity
    switch effort {
    case "high":
        floor = ComplexityComplex
    case "medium":
        floor = ComplexityMedium
    case "low":
        floor = ComplexitySimple
    default:
        return heuristic
    }

    // Return the higher of heuristic vs LLM floor
    if complexityRank(floor) > complexityRank(heuristic) {
        slog.Info("LLM effort classifier upgraded complexity",
            slog.String("task_id", task.ID),
            slog.String("heuristic", string(heuristic)),
            slog.String("llm_effort", effort),
            slog.String("resolved", string(floor)),
        )
        return floor
    }
    return heuristic
}
```

### 2. Add `complexityRank()` helper

```go
func complexityRank(c Complexity) int {
    switch c {
    case ComplexityTrivial: return 0
    case ComplexitySimple:  return 1
    case ComplexityMedium:  return 2
    case ComplexityComplex: return 3
    case ComplexityEpic:    return 4
    default:                return 2
    }
}
```

### 3. Update `SelectModel` and `SelectTimeout`

Replace `DetectComplexity(task)` with `r.resolveComplexity(task)`:

```go
func (r *ModelRouter) SelectModel(task *Task) string {
    // ...
    complexity := r.resolveComplexity(task)  // was: DetectComplexity(task)
    model := r.GetModelForComplexity(complexity)
    // ... (outcome tracker unchanged)
}

func (r *ModelRouter) SelectTimeout(task *Task) time.Duration {
    complexity := r.resolveComplexity(task)  // was: DetectComplexity(task)
    return r.GetTimeoutForComplexity(complexity)
}
```

### 4. Tests

Add to `model_routing_test.go`:

- **TestResolveComplexity_LLMUpgradesHeuristic**: Heuristic returns trivial, LLM effort "high" → resolved to complex
- **TestResolveComplexity_HeuristicWinsWhenHigher**: Heuristic returns complex, LLM effort "low" → stays complex
- **TestResolveComplexity_NoClassifier**: No LLM classifier attached → uses heuristic only
- **TestSelectModel_UsesResolvedComplexity**: End-to-end: trivial heuristic + high effort → complex model
- **TestSelectTimeout_UsesResolvedComplexity**: End-to-end: trivial heuristic + high effort → complex timeout

## Files to Change

- `internal/executor/model_routing.go` — add `resolveComplexity()`, `complexityRank()`, update `SelectModel`/`SelectTimeout`
- `internal/executor/model_routing_test.go` — new test cases

## Notes

- The effort classifier caches results per task ID (`EffortClassifier.cache`), so calling it from `SelectModel`/`SelectTimeout` after `SelectEffort` adds zero latency
- This is a **floor** mechanism — LLM can only upgrade, never downgrade the heuristic. If heuristic says complex but LLM says low, complex wins
- Epic detection is unaffected (checked before this code path)

## Planned Steps (execute all in sequence)

1. **Add LLM effort floor to model and timeout routing - In `internal/executor/model_routing.go`: add `complexityRank()` helper function, add `resolveComplexity()` method on `ModelRouter` that combines heuristic complexity with LLM effort classifier floor (max of both), then update `SelectModel()` and `SelectTimeout()` to call `r.resolveComplexity(task)` instead of `DetectComplexity(task)`. In `internal/executor/model_routing_test.go`: add five test cases** — `TestResolveComplexity_LLMUpgradesHeuristic`, `TestResolveComplexity_HeuristicWinsWhenHigher`, `TestResolveComplexity_NoClassifier`, `TestSelectModel_UsesResolvedComplexity`, `TestSelectTimeout_UsesResolvedComplexity`. Run `make test` to verify.
