### PR TITLE
fix(discord): greeting-prefixed messages misclassified as questions

### DIFF
--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -174,6 +174,13 @@ func (h *Handler) detectIntent(ctx context.Context, contextID, text string) inte
 		return intent.IntentCommand
 	}
 
+	// Fast path: greeting-prefixed messages (e.g. "Hello! How is it going?")
+	// Must be checked before IsClearQuestion so that greetings with trailing
+	// questions don't get misclassified as codebase questions.
+	if intent.StartsWithGreeting(text) {
+		return intent.IntentGreeting
+	}
+
 	// Fast path: clear questions
 	if intent.IsClearQuestion(text) {
 		return intent.IntentQuestion

--- a/internal/intent/intent.go
+++ b/internal/intent/intent.go
@@ -157,6 +157,38 @@ func IsLikelyGreeting(msg string) bool {
 	return false
 }
 
+// StartsWithGreeting returns true when the message opens with a greeting word
+// regardless of length. This catches conversational greetings like "Hello! How
+// is it going?" that are too long for IsGreeting but clearly not codebase questions.
+func StartsWithGreeting(msg string) bool {
+	lower := strings.ToLower(strings.TrimSpace(msg))
+	words := strings.Fields(lower)
+	if len(words) == 0 || len(words) > 10 {
+		return false
+	}
+	for _, pattern := range greetingPatterns {
+		pWords := strings.Fields(pattern)
+		if len(pWords) == 1 {
+			// Single-word greeting: match word or word + punctuation
+			w := strings.TrimRight(words[0], "!?,.")
+			if w == pattern {
+				return true
+			}
+		} else if len(words) >= len(pWords) {
+			// Multi-word greeting (e.g. "good morning")
+			// Strip trailing punctuation from the last pattern word for matching
+			cleaned := make([]string, len(pWords))
+			for i, w := range words[:len(pWords)] {
+				cleaned[i] = strings.TrimRight(w, "!?,.")
+			}
+			if strings.Join(cleaned, " ") == pattern {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // IsGreeting checks if the message is a greeting
 func IsGreeting(msg string) bool {
 	// Very short messages that are just greetings

--- a/internal/intent/intent_test.go
+++ b/internal/intent/intent_test.go
@@ -145,6 +145,47 @@ func TestIsGreeting(t *testing.T) {
 	}
 }
 
+func TestStartsWithGreeting(t *testing.T) {
+	tests := []struct {
+		message  string
+		expected bool
+	}{
+		// Short greetings (also caught by IsGreeting)
+		{"hi", true},
+		{"hello", true},
+		{"hey", true},
+
+		// Greeting-prefixed longer messages (the main use case)
+		{"Hello! How is it going?", true},
+		{"hello, how are you today", true},
+		{"hey what's up", true},
+		{"hi, can you help me?", true},
+		{"good morning! how's everything?", true},
+		{"good afternoon, quick question", true},
+		{"привет, как дела", true},
+		{"yo, what's the status?", true},
+
+		// NOT greetings
+		{"what is the auth handler?", false},
+		{"create a new file", false},
+		{"fix the bug", false},
+		{"how do I run tests", false},
+		{"", false},
+
+		// Too long (> 10 words)
+		{"hello I have a very long message that goes on and on about nothing", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.message, func(t *testing.T) {
+			got := StartsWithGreeting(tt.message)
+			if got != tt.expected {
+				t.Errorf("StartsWithGreeting(%q) = %v, want %v", tt.message, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestIsQuestion(t *testing.T) {
 	tests := []struct {
 		message  string


### PR DESCRIPTION
## Summary

- Messages like "Hello! How is it going?" were treated as codebase questions (→ "Looking into that...") instead of greetings
- Root cause: `IsClearQuestion()` fast path (matches `?` suffix) fired before greeting detection in `comms.Handler.detectIntent()`
- Added `intent.StartsWithGreeting()` — detects messages starting with greeting words (hi, hello, hey, good morning, etc.) up to 10 words
- Greeting check now runs before the question fast path

## Test plan

- [x] `TestStartsWithGreeting` — 17 cases covering single-word, multi-word, punctuation, non-greetings, edge cases
- [x] All existing intent + comms tests pass (no regressions)
- [ ] Manual test: send `@Pilot Hello! How is it going?` in Discord → should get greeting response

Closes #2159, #2160, #2161