### PR TITLE
GH-2163: feat(executor): expose 1M context window control + update budget defaults

### DIFF
--- a/internal/budget/enforcer_test.go
+++ b/internal/budget/enforcer_test.go
@@ -42,6 +42,17 @@ func (m *mockUsageProvider) Reset() {
 	m.mu.Unlock()
 }
 
+func TestDefaultConfig_BudgetDefaults(t *testing.T) {
+	// GH-2163: Budget defaults updated for 1M context window
+	cfg := DefaultConfig()
+	if cfg.PerTask.MaxTokens != 500000 {
+		t.Errorf("PerTask.MaxTokens = %d, want 500000", cfg.PerTask.MaxTokens)
+	}
+	if cfg.PerTask.MaxDuration != 60*time.Minute {
+		t.Errorf("PerTask.MaxDuration = %v, want 60m", cfg.PerTask.MaxDuration)
+	}
+}
+
 func TestEnforcer_CheckBudget_Disabled(t *testing.T) {
 	config := &Config{
 		Enabled: false,

--- a/internal/budget/middleware_test.go
+++ b/internal/budget/middleware_test.go
@@ -200,12 +200,12 @@ func TestDefaultConfig(t *testing.T) {
 		t.Errorf("expected MonthlyLimit 500.00, got %v", config.MonthlyLimit)
 	}
 
-	if config.PerTask.MaxTokens != 100000 {
-		t.Errorf("expected PerTask.MaxTokens 100000, got %v", config.PerTask.MaxTokens)
+	if config.PerTask.MaxTokens != 500000 {
+		t.Errorf("expected PerTask.MaxTokens 500000, got %v", config.PerTask.MaxTokens)
 	}
 
-	if config.PerTask.MaxDuration != 30*time.Minute {
-		t.Errorf("expected PerTask.MaxDuration 30m, got %v", config.PerTask.MaxDuration)
+	if config.PerTask.MaxDuration != 60*time.Minute {
+		t.Errorf("expected PerTask.MaxDuration 60m, got %v", config.PerTask.MaxDuration)
 	}
 
 	if config.OnExceed.Daily != ActionPause {

--- a/internal/budget/types.go
+++ b/internal/budget/types.go
@@ -58,8 +58,8 @@ func DefaultConfig() *Config {
 		DailyLimit:   50.00,
 		MonthlyLimit: 500.00,
 		PerTask: PerTaskConfig{
-			MaxTokens:   100000,
-			MaxDuration: 30 * time.Minute,
+			MaxTokens:   500000,
+			MaxDuration: 60 * time.Minute,
 		},
 		OnExceed: ExceedAction{
 			Daily:   ActionPause,

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -480,6 +480,13 @@ type ClaudeCodeConfig struct {
 	// linked to the original PR, giving Claude full context of previous changes.
 	// Default: false
 	UseFromPR bool `yaml:"use_from_pr,omitempty"`
+
+	// Disable1MContext opts out of 1M context (sets CLAUDE_CODE_DISABLE_1M_CONTEXT=1).
+	// When true, forces 200K context window. Default false = use Claude Code defaults.
+	Disable1MContext bool `yaml:"disable_1m_context,omitempty"`
+
+	// MaxOutputTokens sets CLAUDE_CODE_MAX_OUTPUT_TOKENS. Default 0 = Claude Code default (32K).
+	MaxOutputTokens int `yaml:"max_output_tokens,omitempty"`
 }
 
 // QwenCodeConfig contains Qwen Code backend configuration.

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -309,6 +310,18 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 
 	cmd := exec.CommandContext(ctx, b.config.Command, args...)
 	cmd.Dir = opts.ProjectPath
+
+	// Pass context window and output token env vars if configured (GH-2163).
+	if b.config.Disable1MContext || b.config.MaxOutputTokens > 0 {
+		env := os.Environ()
+		if b.config.Disable1MContext {
+			env = append(env, "CLAUDE_CODE_DISABLE_1M_CONTEXT=1")
+		}
+		if b.config.MaxOutputTokens > 0 {
+			env = append(env, fmt.Sprintf("CLAUDE_CODE_MAX_OUTPUT_TOKENS=%d", b.config.MaxOutputTokens))
+		}
+		cmd.Env = env
+	}
 
 	b.log.Debug("Starting Claude Code",
 		slog.String("command", b.config.Command),

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -732,6 +732,91 @@ func TestExtractExitCode(t *testing.T) {
 	})
 }
 
+func TestClaudeCodeConfigContextWindow(t *testing.T) {
+	// GH-2163: Verify 1M context and max output tokens config fields
+	tests := []struct {
+		name                string
+		config              *ClaudeCodeConfig
+		expectDisable1M     bool
+		expectMaxOutput     int
+		expectEnvContains   []string
+		expectEnvNotContain []string
+	}{
+		{
+			name:                "default config - no context window flags",
+			config:              &ClaudeCodeConfig{Command: "claude"},
+			expectDisable1M:     false,
+			expectMaxOutput:     0,
+			expectEnvNotContain: []string{"CLAUDE_CODE_DISABLE_1M_CONTEXT", "CLAUDE_CODE_MAX_OUTPUT_TOKENS"},
+		},
+		{
+			name:              "disable 1M context",
+			config:            &ClaudeCodeConfig{Command: "claude", Disable1MContext: true},
+			expectDisable1M:   true,
+			expectEnvContains: []string{"CLAUDE_CODE_DISABLE_1M_CONTEXT=1"},
+		},
+		{
+			name:              "max output tokens set",
+			config:            &ClaudeCodeConfig{Command: "claude", MaxOutputTokens: 128000},
+			expectMaxOutput:   128000,
+			expectEnvContains: []string{"CLAUDE_CODE_MAX_OUTPUT_TOKENS=128000"},
+		},
+		{
+			name:            "both flags set",
+			config:          &ClaudeCodeConfig{Command: "claude", Disable1MContext: true, MaxOutputTokens: 64000},
+			expectDisable1M: true,
+			expectMaxOutput: 64000,
+			expectEnvContains: []string{
+				"CLAUDE_CODE_DISABLE_1M_CONTEXT=1",
+				"CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.config.Disable1MContext != tt.expectDisable1M {
+				t.Errorf("Disable1MContext = %v, want %v", tt.config.Disable1MContext, tt.expectDisable1M)
+			}
+			if tt.config.MaxOutputTokens != tt.expectMaxOutput {
+				t.Errorf("MaxOutputTokens = %d, want %d", tt.config.MaxOutputTokens, tt.expectMaxOutput)
+			}
+
+			// Simulate the env-building logic from Execute()
+			var env []string
+			if tt.config.Disable1MContext || tt.config.MaxOutputTokens > 0 {
+				env = []string{"PATH=/usr/bin"} // minimal base env for test
+				if tt.config.Disable1MContext {
+					env = append(env, "CLAUDE_CODE_DISABLE_1M_CONTEXT=1")
+				}
+				if tt.config.MaxOutputTokens > 0 {
+					env = append(env, fmt.Sprintf("CLAUDE_CODE_MAX_OUTPUT_TOKENS=%d", tt.config.MaxOutputTokens))
+				}
+			}
+
+			for _, expected := range tt.expectEnvContains {
+				found := false
+				for _, e := range env {
+					if e == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("env should contain %q, got %v", expected, env)
+				}
+			}
+			for _, notExpected := range tt.expectEnvNotContain {
+				for _, e := range env {
+					if len(e) >= len(notExpected) && e[:len(notExpected)] == notExpected {
+						t.Errorf("env should NOT contain %q, got %v", notExpected, env)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestClaudeCodeError_Error(t *testing.T) {
 	t.Run("with stderr", func(t *testing.T) {
 		err := &ClaudeCodeError{


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2163.

Closes #2163

## Changes

GitHub Issue #2163: feat(executor): expose 1M context window control + update budget defaults

## Context

Claude Code v2.1.75 (March 13, 2026) made 1M context the default for Max/Team/Enterprise. Pilot currently passes NO context window flags to Claude Code — it silently inherits whatever Claude Code defaults to. Users have no way to control this via Pilot config.

Additionally, budget defaults (`per_task.max_tokens: 100000`) were set for 200K context and may be insufficient with 1M context.

## What to Do

### 1. Add config fields to `ClaudeCodeConfig`

**File:** `internal/executor/backend.go` — `ClaudeCodeConfig` struct (~line 443)

```go
// Disable1MContext opts out of 1M context (sets CLAUDE_CODE_DISABLE_1M_CONTEXT=1).
// When true, forces 200K context window. Default false = use Claude Code defaults.
Disable1MContext bool `yaml:"disable_1m_context,omitempty"`
// MaxOutputTokens sets CLAUDE_CODE_MAX_OUTPUT_TOKENS. Default 0 = Claude Code default (32K).
MaxOutputTokens  int  `yaml:"max_output_tokens,omitempty"`
```

### 2. Pass env vars to Claude Code subprocess

**File:** `internal/executor/backend_claudecode.go` — after `cmd.Dir = opts.ProjectPath`

```go
env := os.Environ()
if b.config.Disable1MContext {
    env = append(env, "CLAUDE_CODE_DISABLE_1M_CONTEXT=1")
}
if b.config.MaxOutputTokens > 0 {
    env = append(env, fmt.Sprintf("CLAUDE_CODE_MAX_OUTPUT_TOKENS=%d", b.config.MaxOutputTokens))
}
if b.config.Disable1MContext || b.config.MaxOutputTokens > 0 {
    cmd.Env = env
}
```

### 3. Update budget defaults

**File:** `internal/budget/types.go` (~line 55)

- `MaxTokens`: 100K → 500K (1M context increases typical token consumption)
- `MaxDuration`: 30m → 60m

## Acceptance Criteria

- [ ] `disable_1m_context: true` in config → `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` in subprocess env
- [ ] `max_output_tokens: 128000` → `CLAUDE_CODE_MAX_OUTPUT_TOKENS=128000` in subprocess env
- [ ] Default (no config) → no env vars set, Claude Code uses its own defaults
- [ ] Budget defaults updated to 500K tokens / 60m
- [ ] Unit test for env var passthrough
- [ ] Tests pass: `go test ./internal/executor/... ./internal/budget/...`