### PR TITLE
GH-2164: feat(executor): cache-aware token tracking and cost estimation for 1M context

### DIFF
--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -104,6 +104,12 @@ type BackendEvent struct {
 	// TokensOutput is the output token count (if available)
 	TokensOutput int64
 
+	// CacheCreationInputTokens is the cache creation input token count (GH-2164)
+	CacheCreationInputTokens int64
+
+	// CacheReadInputTokens is the cache read input token count (GH-2164)
+	CacheReadInputTokens int64
+
 	// Model is the model name used (if available)
 	Model string
 
@@ -165,6 +171,12 @@ type BackendResult struct {
 
 	// TokensOutput is the total output tokens generated
 	TokensOutput int64
+
+	// CacheCreationInputTokens is the total cache creation input tokens (GH-2164)
+	CacheCreationInputTokens int64
+
+	// CacheReadInputTokens is the total cache read input tokens (GH-2164)
+	CacheReadInputTokens int64
 
 	// Model is the model used for execution
 	Model string

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -478,6 +478,8 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 			// Accumulate token usage
 			result.TokensInput += event.TokensInput
 			result.TokensOutput += event.TokensOutput
+			result.CacheCreationInputTokens += event.CacheCreationInputTokens
+			result.CacheReadInputTokens += event.CacheReadInputTokens
 			if event.Model != "" {
 				result.Model = event.Model
 			}
@@ -667,6 +669,8 @@ func (b *ClaudeCodeBackend) parseStreamEvent(line string) BackendEvent {
 	if streamEvent.Usage != nil {
 		event.TokensInput = streamEvent.Usage.InputTokens
 		event.TokensOutput = streamEvent.Usage.OutputTokens
+		event.CacheCreationInputTokens = streamEvent.Usage.CacheCreationInputTokens
+		event.CacheReadInputTokens = streamEvent.Usage.CacheReadInputTokens
 	}
 	if streamEvent.Model != "" {
 		event.Model = streamEvent.Model

--- a/internal/executor/metrics.go
+++ b/internal/executor/metrics.go
@@ -29,6 +29,12 @@ type ExecutionMetrics struct {
 	// TokensOut is the number of output tokens generated
 	TokensOut int64
 
+	// CacheCreationTokens is the number of cache creation input tokens (GH-2164)
+	CacheCreationTokens int64
+
+	// CacheReadTokens is the number of cache read input tokens (GH-2164)
+	CacheReadTokens int64
+
 	// EstimatedCostUSD is the estimated cost based on model and token usage
 	EstimatedCostUSD float64
 
@@ -61,6 +67,8 @@ func (m *ExecutionMetrics) LogAttrs() []slog.Attr {
 		slog.Bool("navigator_skipped", m.NavigatorSkipped),
 		slog.Int64("tokens_in", m.TokensIn),
 		slog.Int64("tokens_out", m.TokensOut),
+		slog.Int64("cache_creation_tokens", m.CacheCreationTokens),
+		slog.Int64("cache_read_tokens", m.CacheReadTokens),
 		slog.Float64("cost_usd", m.EstimatedCostUSD),
 		slog.String("phase", m.Phase),
 		slog.Int("files_read", m.FilesRead),
@@ -92,9 +100,11 @@ func NewExecutionMetrics(
 		Model:            model,
 		Duration:         duration,
 		NavigatorSkipped: complexity.ShouldSkipNavigator(),
-		TokensIn:         state.tokensInput,
-		TokensOut:        state.tokensOutput,
-		EstimatedCostUSD: estimateCost(state.tokensInput, state.tokensOutput, model),
+		TokensIn:            state.tokensInput,
+		TokensOut:           state.tokensOutput,
+		CacheCreationTokens: state.cacheCreationInputTokens,
+		CacheReadTokens:     state.cacheReadInputTokens,
+		EstimatedCostUSD:    estimateCostWithCache(state.tokensInput, state.tokensOutput, state.cacheCreationInputTokens, state.cacheReadInputTokens, model),
 		Phase:            state.phase,
 		FilesRead:        state.filesRead,
 		FilesWritten:     state.filesWrite,

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -40,8 +40,10 @@ type StreamEvent struct {
 
 // UsageInfo represents token usage in stream events
 type UsageInfo struct {
-	InputTokens  int64 `json:"input_tokens"`
-	OutputTokens int64 `json:"output_tokens"`
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens,omitempty"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens,omitempty"`
 }
 
 // AssistantMsg represents the message field in assistant events
@@ -82,9 +84,11 @@ type progressState struct {
 	exitSignal   bool     // Navigator EXIT_SIGNAL detected
 	commitSHAs   []string // Extracted commit SHAs from git output
 	// Metrics tracking (TASK-13)
-	tokensInput  int64  // Input tokens used
-	tokensOutput int64  // Output tokens used
-	modelName    string // Model used
+	tokensInput              int64  // Input tokens used
+	tokensOutput             int64  // Output tokens used
+	cacheCreationInputTokens int64  // Cache creation input tokens (GH-2164)
+	cacheReadInputTokens     int64  // Cache read input tokens (GH-2164)
+	modelName                string // Model used
 	// Note: filesChanged/linesAdded/linesRemoved tracked via git diff at commit time
 	// Intent judge retry tracking (GH-624)
 	intentRetried bool // Set after first intent retry to prevent infinite loops
@@ -214,6 +218,10 @@ type ExecutionResult struct {
 	TokensOutput int64
 	// TokensTotal is the total token count (input + output).
 	TokensTotal int64
+	// CacheCreationInputTokens is the number of cache creation input tokens (GH-2164).
+	CacheCreationInputTokens int64
+	// CacheReadInputTokens is the number of cache read input tokens (GH-2164).
+	CacheReadInputTokens int64
 	// ResearchTokens is the number of tokens used by parallel research phase (GH-217).
 	ResearchTokens int64
 	// EstimatedCostUSD is the estimated cost in USD based on token usage.
@@ -1452,11 +1460,13 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 			result.TokensInput = state.tokensInput
 			result.TokensOutput = state.tokensOutput
 			result.TokensTotal = state.tokensInput + state.tokensOutput
+			result.CacheCreationInputTokens = state.cacheCreationInputTokens
+			result.CacheReadInputTokens = state.cacheReadInputTokens
 			result.ModelName = state.modelName
 			if result.ModelName == "" {
 				result.ModelName = "claude-opus-4-6"
 			}
-			result.EstimatedCostUSD = estimateCost(result.TokensInput, result.TokensOutput, result.ModelName)
+			result.EstimatedCostUSD = estimateCostWithCache(result.TokensInput, result.TokensOutput, result.CacheCreationInputTokens, result.CacheReadInputTokens, result.ModelName)
 			log.Warn("Task cancelled due to per-task budget limit",
 				slog.String("task_id", task.ID),
 				slog.String("reason", state.budgetReason),
@@ -1789,14 +1799,16 @@ retrySucceeded:
 
 	// Fill in additional metrics from state
 	result.FilesChanged = state.filesWrite
+	result.CacheCreationInputTokens = state.cacheCreationInputTokens
+	result.CacheReadInputTokens = state.cacheReadInputTokens
 	if result.ModelName == "" {
 		result.ModelName = state.modelName
 	}
 	if result.ModelName == "" {
 		result.ModelName = "claude-opus-4-6" // Default model
 	}
-	// Estimate cost based on token usage (including research tokens)
-	result.EstimatedCostUSD = estimateCost(result.TokensInput+result.ResearchTokens, result.TokensOutput, result.ModelName)
+	// Estimate cost based on token usage (including research tokens) with cache-aware pricing (GH-2164)
+	result.EstimatedCostUSD = estimateCostWithCache(result.TokensInput+result.ResearchTokens, result.TokensOutput, result.CacheCreationInputTokens, result.CacheReadInputTokens, result.ModelName)
 
 	if !result.Success {
 		log.Error("Task execution failed",
@@ -1913,6 +1925,8 @@ The previous execution completed but made no code changes. This task requires ac
 						// Track tokens from retry
 						state.tokensInput += event.TokensInput
 						state.tokensOutput += event.TokensOutput
+						state.cacheCreationInputTokens += event.CacheCreationInputTokens
+						state.cacheReadInputTokens += event.CacheReadInputTokens
 						// Extract any commit SHAs from retry
 						if event.Type == EventTypeToolResult && event.ToolResult != "" {
 							extractCommitSHA(event.ToolResult, state)
@@ -2407,6 +2421,8 @@ The previous execution completed but made no code changes. This task requires ac
 						EventHandler: func(event BackendEvent) {
 							state.tokensInput += event.TokensInput
 							state.tokensOutput += event.TokensOutput
+							state.cacheCreationInputTokens += event.CacheCreationInputTokens
+							state.cacheReadInputTokens += event.CacheReadInputTokens
 							if event.Type == EventTypeToolResult && event.ToolResult != "" {
 								extractCommitSHA(event.ToolResult, state)
 							}
@@ -2952,6 +2968,8 @@ func (r *Runner) runSelfReview(ctx context.Context, task *Task, state *progressS
 			// Track tokens from self-review
 			state.tokensInput += event.TokensInput
 			state.tokensOutput += event.TokensOutput
+			state.cacheCreationInputTokens += event.CacheCreationInputTokens
+			state.cacheReadInputTokens += event.CacheReadInputTokens
 			// Extract any new commit SHAs from self-review fixes
 			if event.Type == EventTypeToolResult && event.ToolResult != "" {
 				extractCommitSHA(event.ToolResult, state)
@@ -3058,6 +3076,8 @@ func (r *Runner) parseStreamEvent(taskID, line string, state *progressState) (st
 		if event.Usage != nil {
 			state.tokensInput += event.Usage.InputTokens
 			state.tokensOutput += event.Usage.OutputTokens
+			state.cacheCreationInputTokens += event.Usage.CacheCreationInputTokens
+			state.cacheReadInputTokens += event.Usage.CacheReadInputTokens
 		}
 		if event.Model != "" {
 			state.modelName = event.Model
@@ -3078,6 +3098,8 @@ func (r *Runner) parseStreamEvent(taskID, line string, state *progressState) (st
 	if event.Usage != nil {
 		state.tokensInput += event.Usage.InputTokens
 		state.tokensOutput += event.Usage.OutputTokens
+		state.cacheCreationInputTokens += event.Usage.CacheCreationInputTokens
+		state.cacheReadInputTokens += event.Usage.CacheReadInputTokens
 		// Report token usage to callbacks (e.g., dashboard)
 		r.reportTokens(taskID, state.tokensInput, state.tokensOutput)
 	}
@@ -3094,6 +3116,8 @@ func (r *Runner) processBackendEvent(taskID string, event BackendEvent, state *p
 	// Track token usage
 	state.tokensInput += event.TokensInput
 	state.tokensOutput += event.TokensOutput
+	state.cacheCreationInputTokens += event.CacheCreationInputTokens
+	state.cacheReadInputTokens += event.CacheReadInputTokens
 	if event.Model != "" {
 		state.modelName = event.Model
 	}
@@ -3668,9 +3692,9 @@ func isValidSHA(s string) bool {
 	return true
 }
 
-// estimateCost calculates estimated cost from token usage (TASK-13)
+// modelPricing returns (inputPrice, outputPrice) in USD per 1M tokens for the given model.
 // Pricing source: https://platform.claude.com/docs/en/about-claude/pricing
-func estimateCost(inputTokens, outputTokens int64, model string) float64 {
+func modelPricing(model string) (inputPrice, outputPrice float64) {
 	// Model pricing in USD per 1M tokens
 	const (
 		// Sonnet 4.6/4.5/4
@@ -3687,41 +3711,48 @@ func estimateCost(inputTokens, outputTokens int64, model string) float64 {
 		haikuOutputPrice = 5.00
 	)
 
-	var inputPrice, outputPrice float64
 	modelLower := strings.ToLower(model)
 	switch {
 	case strings.Contains(modelLower, "opus-4-1") || strings.Contains(modelLower, "opus-4-0") || model == "claude-opus-4":
 		// Legacy Opus 4.1/4.0
-		inputPrice = opus41InputPrice
-		outputPrice = opus41OutputPrice
+		return opus41InputPrice, opus41OutputPrice
 	case strings.Contains(modelLower, "opus"):
 		// Opus 4.6/4.5 ($5/$25)
-		inputPrice = opusInputPrice
-		outputPrice = opusOutputPrice
+		return opusInputPrice, opusOutputPrice
 	case strings.Contains(modelLower, "haiku"):
-		inputPrice = haikuInputPrice
-		outputPrice = haikuOutputPrice
+		return haikuInputPrice, haikuOutputPrice
 	case strings.Contains(modelLower, "qwen"):
 		// Qwen3-Coder pricing (per 1M tokens)
 		switch {
 		case strings.Contains(modelLower, "480b") || strings.Contains(modelLower, "plus"):
-			inputPrice = 1.00  // Qwen3-Coder-Plus (International, 0-32K)
-			outputPrice = 5.00
+			return 1.00, 5.00 // Qwen3-Coder-Plus (International, 0-32K)
 		case strings.Contains(modelLower, "flash"):
-			inputPrice = 0.30
-			outputPrice = 1.50
+			return 0.30, 1.50
 		default:
-			inputPrice = 0.07  // Qwen3-Coder-Next (default)
-			outputPrice = 0.30
+			return 0.07, 0.30 // Qwen3-Coder-Next (default)
 		}
 	default:
-		inputPrice = sonnetInputPrice
-		outputPrice = sonnetOutputPrice
+		return sonnetInputPrice, sonnetOutputPrice
 	}
+}
 
-	inputCost := float64(inputTokens) * inputPrice / 1_000_000
-	outputCost := float64(outputTokens) * outputPrice / 1_000_000
-	return inputCost + outputCost
+// estimateCost calculates estimated cost from token usage (TASK-13).
+// Backward-compatible wrapper — treats all input tokens at full price.
+func estimateCost(inputTokens, outputTokens int64, model string) float64 {
+	return estimateCostWithCache(inputTokens, outputTokens, 0, 0, model)
+}
+
+// estimateCostWithCache calculates estimated cost with cache-aware pricing (GH-2164).
+// Cache creation tokens cost 125% of input price, cache read tokens cost 10%.
+// Pricing source: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#pricing
+func estimateCostWithCache(input, output, cacheCreation, cacheRead int64, model string) float64 {
+	inputPrice, outputPrice := modelPricing(model)
+
+	inputCost := float64(input) * inputPrice / 1_000_000
+	outputCost := float64(output) * outputPrice / 1_000_000
+	cacheCreateCost := float64(cacheCreation) * (inputPrice * 1.25) / 1_000_000
+	cacheReadCost := float64(cacheRead) * (inputPrice * 0.10) / 1_000_000
+	return inputCost + outputCost + cacheCreateCost + cacheReadCost
 }
 
 // emitAlertEvent sends an event to the alert processor if configured

--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -141,6 +141,8 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 		aggregateResult.TokensInput += subtaskResult.TokensInput
 		aggregateResult.TokensOutput += subtaskResult.TokensOutput
 		aggregateResult.TokensTotal += subtaskResult.TokensTotal
+		aggregateResult.CacheCreationInputTokens += subtaskResult.CacheCreationInputTokens
+		aggregateResult.CacheReadInputTokens += subtaskResult.CacheReadInputTokens
 		aggregateResult.ResearchTokens += subtaskResult.ResearchTokens
 		aggregateResult.FilesChanged += subtaskResult.FilesChanged
 		aggregateResult.LinesAdded += subtaskResult.LinesAdded
@@ -170,9 +172,11 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 	}
 
 	aggregateResult.Duration = time.Since(start)
-	aggregateResult.EstimatedCostUSD = estimateCost(
+	aggregateResult.EstimatedCostUSD = estimateCostWithCache(
 		aggregateResult.TokensInput+aggregateResult.ResearchTokens,
 		aggregateResult.TokensOutput,
+		aggregateResult.CacheCreationInputTokens,
+		aggregateResult.CacheReadInputTokens,
 		aggregateResult.ModelName,
 	)
 

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -806,6 +807,147 @@ func TestEstimateCost(t *testing.T) {
 				t.Errorf("estimateCost() = %f, want between %f and %f", cost, tt.minCost, tt.maxCost)
 			}
 		})
+	}
+}
+
+func TestEstimateCostWithCache(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         int64
+		output        int64
+		cacheCreation int64
+		cacheRead     int64
+		model         string
+		minCost       float64
+		maxCost       float64
+	}{
+		{
+			name:          "no cache tokens matches estimateCost",
+			input:         1000000,
+			output:        100000,
+			cacheCreation: 0,
+			cacheRead:     0,
+			model:         "claude-sonnet-4-6",
+			minCost:       4.49, // 3.0 + 1.5
+			maxCost:       4.51,
+		},
+		{
+			name:          "sonnet cache creation 1M tokens at 125% of input price",
+			input:         0,
+			output:        0,
+			cacheCreation: 1000000,
+			cacheRead:     0,
+			model:         "claude-sonnet-4-6",
+			minCost:       3.74, // 3.00 * 1.25 = 3.75
+			maxCost:       3.76,
+		},
+		{
+			name:          "sonnet cache read 1M tokens at 10% of input price",
+			input:         0,
+			output:        0,
+			cacheCreation: 0,
+			cacheRead:     1000000,
+			model:         "claude-sonnet-4-6",
+			minCost:       0.29, // 3.00 * 0.10 = 0.30
+			maxCost:       0.31,
+		},
+		{
+			name:          "opus cache creation 1M tokens",
+			input:         0,
+			output:        0,
+			cacheCreation: 1000000,
+			cacheRead:     0,
+			model:         "claude-opus-4-6",
+			minCost:       6.24, // 5.00 * 1.25 = 6.25
+			maxCost:       6.26,
+		},
+		{
+			name:          "opus cache read 1M tokens",
+			input:         0,
+			output:        0,
+			cacheCreation: 0,
+			cacheRead:     1000000,
+			model:         "claude-opus-4-6",
+			minCost:       0.49, // 5.00 * 0.10 = 0.50
+			maxCost:       0.51,
+		},
+		{
+			name:          "mixed usage with cache - realistic scenario",
+			input:         50000,  // 50K regular input
+			output:        20000,  // 20K output
+			cacheCreation: 100000, // 100K cache write
+			cacheRead:     800000, // 800K cache read (typical with 1M context)
+			model:         "claude-sonnet-4-6",
+			// input: 50000 * 3.00 / 1M = 0.15
+			// output: 20000 * 15.00 / 1M = 0.30
+			// cache_create: 100000 * 3.75 / 1M = 0.375
+			// cache_read: 800000 * 0.30 / 1M = 0.24
+			minCost: 1.06,
+			maxCost: 1.07,
+		},
+		{
+			name:          "backward compat: estimateCost equals estimateCostWithCache(0,0)",
+			input:         500000,
+			output:        100000,
+			cacheCreation: 0,
+			cacheRead:     0,
+			model:         "claude-opus-4-6",
+			minCost:       4.99, // 500K * 5/1M + 100K * 25/1M = 2.5 + 2.5
+			maxCost:       5.01,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cost := estimateCostWithCache(tt.input, tt.output, tt.cacheCreation, tt.cacheRead, tt.model)
+			if cost < tt.minCost || cost > tt.maxCost {
+				t.Errorf("estimateCostWithCache() = %f, want between %f and %f", cost, tt.minCost, tt.maxCost)
+			}
+		})
+	}
+
+	// Verify backward compatibility: estimateCost == estimateCostWithCache with zero cache
+	t.Run("backward_compat_wrapper", func(t *testing.T) {
+		old := estimateCost(1000000, 500000, "claude-opus-4-6")
+		new := estimateCostWithCache(1000000, 500000, 0, 0, "claude-opus-4-6")
+		if old != new {
+			t.Errorf("estimateCost(%f) != estimateCostWithCache(%f) — backward compat broken", old, new)
+		}
+	})
+}
+
+func TestUsageInfoCacheFields(t *testing.T) {
+	// Verify UsageInfo correctly unmarshals cache token fields from stream-json
+	jsonStr := `{"input_tokens": 1000, "output_tokens": 500, "cache_creation_input_tokens": 200, "cache_read_input_tokens": 800}`
+	var usage UsageInfo
+	if err := json.Unmarshal([]byte(jsonStr), &usage); err != nil {
+		t.Fatalf("Failed to unmarshal UsageInfo: %v", err)
+	}
+	if usage.InputTokens != 1000 {
+		t.Errorf("InputTokens = %d, want 1000", usage.InputTokens)
+	}
+	if usage.OutputTokens != 500 {
+		t.Errorf("OutputTokens = %d, want 500", usage.OutputTokens)
+	}
+	if usage.CacheCreationInputTokens != 200 {
+		t.Errorf("CacheCreationInputTokens = %d, want 200", usage.CacheCreationInputTokens)
+	}
+	if usage.CacheReadInputTokens != 800 {
+		t.Errorf("CacheReadInputTokens = %d, want 800", usage.CacheReadInputTokens)
+	}
+
+	// Verify omitempty: zero cache fields should not appear in JSON
+	usage2 := UsageInfo{InputTokens: 100, OutputTokens: 50}
+	data, err := json.Marshal(usage2)
+	if err != nil {
+		t.Fatalf("Failed to marshal UsageInfo: %v", err)
+	}
+	str := string(data)
+	if strings.Contains(str, "cache_creation") {
+		t.Errorf("Zero cache_creation should be omitted, got: %s", str)
+	}
+	if strings.Contains(str, "cache_read") {
+		t.Errorf("Zero cache_read should be omitted, got: %s", str)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2164.

Closes #2164

## Changes

GitHub Issue #2164: feat(executor): cache-aware token tracking and cost estimation for 1M context

## Context

With 1M context active, Claude Code uses prompt caching extensively. Cache creation tokens cost 125% of input price, cache reads cost 10%. Pilot currently counts all tokens at full input price, overstating costs.

Additionally, cache token fields (`cache_creation_input_tokens`, `cache_read_input_tokens`) from Claude Code's stream-json are not captured.

## What to Do

### 1. Add cache token fields to structs

Add `CacheCreationInputTokens int64` and `CacheReadInputTokens int64` to:
- `UsageInfo` in `runner.go` (~line 41) — JSON tags: `cache_creation_input_tokens`, `cache_read_input_tokens`
- `BackendEvent` in `backend.go` (~line 76)
- `BackendResult` in `backend.go` (~line 153)
- `ExecutionResult` in `runner.go` (~line 196)
- `ExecutionMetrics` in `metrics.go` (~line 10)
- `progressState` in `runner.go` (~line 72)

### 2. Propagate cache tokens through pipeline

- `backend_claudecode.go` parseStreamEvent: read cache fields from stream JSON usage object
- Accumulate in `BackendResult` (alongside existing `TokensInput += event.TokensInput`)
- `runner.go` processBackendEvent: accumulate in `progressState`
- `metrics.go` LogAttrs: include cache token counts

### 3. Cache-aware cost estimation

Add `estimateCostWithCache()` alongside existing `estimateCost()`:

```go
func estimateCostWithCache(input, output, cacheCreation, cacheRead int64, model string) float64 {
    // same pricing lookup as estimateCost...
    inputCost := float64(input) * inputPrice / 1_000_000
    outputCost := float64(output) * outputPrice / 1_000_000
    cacheCreateCost := float64(cacheCreation) * (inputPrice * 1.25) / 1_000_000
    cacheReadCost := float64(cacheRead) * (inputPrice * 0.10) / 1_000_000
    return inputCost + outputCost + cacheCreateCost + cacheReadCost
}
```

Keep `estimateCost()` as a wrapper for backward compatibility. Update call sites that have access to cache tokens to use `estimateCostWithCache()`.

## Acceptance Criteria

- [ ] Cache token fields parsed from stream-json events
- [ ] `estimateCostWithCache` produces correct costs (unit test with known values)
- [ ] `estimateCost` still works unchanged (backward compat)
- [ ] Cache tokens logged in execution metrics
- [ ] Tests pass: `go test ./internal/executor/...`