### PR TITLE
GH-2167: fix(dashboard): git graph should follow focused task's project

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -2311,14 +2311,16 @@ func convertTaskStatesToDisplay(states []*executor.TaskState) []dashboard.TaskDi
 		}
 
 		displays = append(displays, dashboard.TaskDisplay{
-			ID:       state.ID,
-			Title:    state.Title,
-			Status:   status,
-			Phase:    state.Phase,
-			Progress: state.Progress,
-			Duration: duration,
-			IssueURL: state.IssueURL,
-			PRURL:    state.PRUrl,
+			ID:          state.ID,
+			Title:       state.Title,
+			Status:      status,
+			Phase:       state.Phase,
+			Progress:    state.Progress,
+			Duration:    duration,
+			IssueURL:    state.IssueURL,
+			PRURL:       state.PRUrl,
+			ProjectPath: state.ProjectPath,
+			ProjectName: state.ProjectName,
 		})
 	}
 	return displays

--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -72,6 +73,8 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	// 1. Register with monitor
 	if deps.Monitor != nil {
 		deps.Monitor.Register(taskID, title, info.URL)
+		// GH-2167: Attach project path so dashboard git graph can follow focused task
+		deps.Monitor.SetProjectInfo(taskID, projectPath, filepath.Base(projectPath))
 	}
 
 	// 2. Log to dashboard

--- a/cmd/pilot/wiring_utils_test.go
+++ b/cmd/pilot/wiring_utils_test.go
@@ -360,14 +360,16 @@ func TestConvertTaskStatesToDisplay_FieldMapping(t *testing.T) {
 	now := time.Now()
 	states := []*executor.TaskState{
 		{
-			ID:       "GH-5",
-			Title:    "Test task",
-			Status:   executor.StatusRunning,
-			Phase:    "verify",
-			Progress: 80,
-			IssueURL: "https://github.com/org/repo/issues/5",
-			PRUrl:    "https://github.com/org/repo/pull/10",
-			StartedAt: &now,
+			ID:          "GH-5",
+			Title:       "Test task",
+			Status:      executor.StatusRunning,
+			Phase:       "verify",
+			Progress:    80,
+			IssueURL:    "https://github.com/org/repo/issues/5",
+			PRUrl:       "https://github.com/org/repo/pull/10",
+			StartedAt:   &now,
+			ProjectPath: "/home/user/projects/pilot",
+			ProjectName: "pilot",
 		},
 	}
 
@@ -376,13 +378,15 @@ func TestConvertTaskStatesToDisplay_FieldMapping(t *testing.T) {
 
 	// Verify all fields map correctly
 	want := dashboard.TaskDisplay{
-		ID:       "GH-5",
-		Title:    "Test task",
-		Status:   "running",
-		Phase:    "verify",
-		Progress: 80,
-		IssueURL: "https://github.com/org/repo/issues/5",
-		PRURL:    "https://github.com/org/repo/pull/10",
+		ID:          "GH-5",
+		Title:       "Test task",
+		Status:      "running",
+		Phase:       "verify",
+		Progress:    80,
+		IssueURL:    "https://github.com/org/repo/issues/5",
+		PRURL:       "https://github.com/org/repo/pull/10",
+		ProjectPath: "/home/user/projects/pilot",
+		ProjectName: "pilot",
 	}
 
 	if d.ID != want.ID {
@@ -405,5 +409,11 @@ func TestConvertTaskStatesToDisplay_FieldMapping(t *testing.T) {
 	}
 	if d.PRURL != want.PRURL {
 		t.Errorf("PRURL = %q, want %q", d.PRURL, want.PRURL)
+	}
+	if d.ProjectPath != want.ProjectPath {
+		t.Errorf("ProjectPath = %q, want %q", d.ProjectPath, want.ProjectPath)
+	}
+	if d.ProjectName != want.ProjectName {
+		t.Errorf("ProjectName = %q, want %q", d.ProjectName, want.ProjectName)
 	}
 }

--- a/internal/dashboard/gitgraph.go
+++ b/internal/dashboard/gitgraph.go
@@ -484,10 +484,13 @@ func (m Model) renderGitGraph(opts ...int) string {
 		size = gitGraphSizeSmall
 	}
 
-	// Title based on size
+	// Title based on size, with project name suffix (GH-2167)
 	title := "GIT"
 	if size == gitGraphSizeFull {
 		title = "GIT GRAPH"
+	}
+	if m.gitProjectName != "" {
+		title += " — " + m.gitProjectName
 	}
 
 	// Build content lines

--- a/internal/dashboard/gitgraph_test.go
+++ b/internal/dashboard/gitgraph_test.go
@@ -805,3 +805,135 @@ func TestGitGraphState_ScrollIndicator(t *testing.T) {
 		t.Errorf("scroll indicator incorrect, got:\n%s", plain)
 	}
 }
+
+// =============================================================================
+// GH-2167: Git graph follows focused task's project
+// =============================================================================
+
+// TestSyncGitGraph_SwitchesProjectOnTaskChange verifies that navigating to a task
+// with a different project path triggers a git graph refresh.
+func TestSyncGitGraph_SwitchesProjectOnTaskChange(t *testing.T) {
+	m := NewModel("test")
+	m.SetProjectPath("/home/user/pilot")
+	m.gitGraphMode = GitGraphVisible
+	m.tasks = []TaskDisplay{
+		{ID: "1", Title: "Task A", Status: "running", ProjectPath: "/home/user/pilot", ProjectName: "pilot"},
+		{ID: "2", Title: "Task B", Status: "queued", ProjectPath: "/home/user/aso-generator", ProjectName: "aso-generator"},
+	}
+	m.selectedTask = 0
+
+	// Navigate down to task B (different project)
+	updated, cmd := m.Update(makeKey("j"))
+	m = updated.(Model)
+
+	if m.selectedTask != 1 {
+		t.Errorf("selectedTask = %d, want 1", m.selectedTask)
+	}
+	if m.projectPath != "/home/user/aso-generator" {
+		t.Errorf("projectPath = %q, want /home/user/aso-generator", m.projectPath)
+	}
+	if m.gitProjectName != "aso-generator" {
+		t.Errorf("gitProjectName = %q, want aso-generator", m.gitProjectName)
+	}
+	if cmd == nil {
+		t.Error("expected refresh cmd when project changes, got nil")
+	}
+	if m.gitGraphScroll != 0 {
+		t.Errorf("gitGraphScroll should reset to 0, got %d", m.gitGraphScroll)
+	}
+}
+
+// TestSyncGitGraph_NoRefreshWhenSameProject verifies no refresh when navigating
+// between tasks in the same project.
+func TestSyncGitGraph_NoRefreshWhenSameProject(t *testing.T) {
+	m := NewModel("test")
+	m.SetProjectPath("/home/user/pilot")
+	m.gitGraphMode = GitGraphVisible
+	m.tasks = []TaskDisplay{
+		{ID: "1", Title: "Task A", Status: "running", ProjectPath: "/home/user/pilot", ProjectName: "pilot"},
+		{ID: "2", Title: "Task B", Status: "queued", ProjectPath: "/home/user/pilot", ProjectName: "pilot"},
+	}
+	m.selectedTask = 0
+
+	updated, cmd := m.Update(makeKey("j"))
+	m = updated.(Model)
+
+	if m.selectedTask != 1 {
+		t.Errorf("selectedTask = %d, want 1", m.selectedTask)
+	}
+	// No refresh needed — same project
+	if cmd != nil {
+		t.Error("expected nil cmd when project unchanged")
+	}
+}
+
+// TestSyncGitGraph_FallsBackToDefault verifies that when tasks have no project path,
+// the default project path is used.
+func TestSyncGitGraph_FallsBackToDefault(t *testing.T) {
+	m := NewModel("test")
+	m.SetProjectPath("/home/user/pilot")
+	m.gitGraphMode = GitGraphVisible
+	m.projectPath = "/home/user/aso-generator" // currently showing different project
+	m.tasks = []TaskDisplay{
+		{ID: "1", Title: "Task A", Status: "running"}, // no ProjectPath
+	}
+	m.selectedTask = 0
+
+	cmd := m.syncGitGraphToSelectedTask()
+
+	if m.projectPath != "/home/user/pilot" {
+		t.Errorf("projectPath = %q, want default /home/user/pilot", m.projectPath)
+	}
+	if cmd == nil {
+		t.Error("expected refresh cmd when reverting to default project")
+	}
+}
+
+// TestGitGraphTitle_IncludesProjectName verifies the panel title shows the project name.
+func TestGitGraphTitle_IncludesProjectName(t *testing.T) {
+	m := NewModel("test")
+	m.gitGraphMode = GitGraphVisible
+	m.gitProjectName = "aso-generator"
+	m.width = 140
+	m.height = 40
+	m.gitGraphState = &GitGraphState{
+		TotalCount: 1,
+		Lines: []GitGraphLine{
+			{GraphChars: "● ", SHA: "abc1234", Message: "init"},
+		},
+	}
+
+	output := m.renderGitGraph()
+	plain := stripANSI(output)
+
+	if !strings.Contains(plain, "ASO-GENERATOR") {
+		t.Errorf("git graph title should contain project name (uppercased), got:\n%s", plain)
+	}
+}
+
+// TestSyncGitGraph_UpNavigation verifies project switch on upward navigation.
+func TestSyncGitGraph_UpNavigation(t *testing.T) {
+	m := NewModel("test")
+	m.SetProjectPath("/home/user/pilot")
+	m.gitGraphMode = GitGraphVisible
+	m.tasks = []TaskDisplay{
+		{ID: "1", Title: "Task A", Status: "running", ProjectPath: "/home/user/pilot", ProjectName: "pilot"},
+		{ID: "2", Title: "Task B", Status: "queued", ProjectPath: "/home/user/aso-generator", ProjectName: "aso-generator"},
+	}
+	m.selectedTask = 1
+	m.projectPath = "/home/user/aso-generator"
+	m.gitProjectName = "aso-generator"
+
+	updated, cmd := m.Update(makeKey("k"))
+	m = updated.(Model)
+
+	if m.selectedTask != 0 {
+		t.Errorf("selectedTask = %d, want 0", m.selectedTask)
+	}
+	if m.projectPath != "/home/user/pilot" {
+		t.Errorf("projectPath = %q, want /home/user/pilot", m.projectPath)
+	}
+	if cmd == nil {
+		t.Error("expected refresh cmd when project changes via k")
+	}
+}

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"math"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -295,14 +296,16 @@ func (p *AutopilotPanel) stageLabel(stage autopilot.PRStage) string {
 
 // TaskDisplay represents a task for display
 type TaskDisplay struct {
-	ID       string
-	Title    string
-	Status   string
-	Phase    string
-	Progress int
-	Duration string
-	IssueURL string
-	PRURL    string
+	ID          string
+	Title       string
+	Status      string
+	Phase       string
+	Progress    int
+	Duration    string
+	IssueURL    string
+	PRURL       string
+	ProjectPath string // Resolved project directory (GH-2167)
+	ProjectName string // Short project name for git graph title (GH-2167)
 }
 
 // TokenUsage tracks token consumption
@@ -382,7 +385,9 @@ type Model struct {
 	gitGraphState  *GitGraphState
 	gitGraphScroll int
 	gitGraphFocus  bool
-	projectPath    string // Working directory for git commands
+	projectPath        string // Working directory for git commands
+	defaultProjectPath string // Fallback project path from config (GH-2167)
+	gitProjectName     string // Current project name shown in git panel title (GH-2167)
 }
 
 // isStackedMode returns true when the git graph is visible and the terminal is
@@ -643,8 +648,46 @@ func NewModelWithOptions(version string, store *memory.Store, controller *autopi
 }
 
 // SetProjectPath sets the working directory used for git graph commands.
+// The first call also sets the default fallback path (GH-2167).
 func (m *Model) SetProjectPath(path string) {
 	m.projectPath = path
+	if m.defaultProjectPath == "" {
+		m.defaultProjectPath = path
+	}
+}
+
+// syncGitGraphToSelectedTask updates projectPath to match the selected task's project.
+// Returns a tea.Cmd to refresh the git graph if the project changed, nil otherwise.
+// Falls back to defaultProjectPath when no task is selected or the task has no project. (GH-2167)
+func (m *Model) syncGitGraphToSelectedTask() tea.Cmd {
+	if m.gitGraphMode == GitGraphHidden {
+		return nil
+	}
+
+	newPath := m.defaultProjectPath
+	newName := ""
+
+	if m.selectedTask >= 0 && m.selectedTask < len(m.tasks) {
+		task := m.tasks[m.selectedTask]
+		if task.ProjectPath != "" {
+			newPath = task.ProjectPath
+			newName = task.ProjectName
+			if newName == "" {
+				newName = filepath.Base(newPath)
+			}
+		}
+	}
+
+	if newPath == m.projectPath {
+		// Project unchanged — just update display name if needed
+		m.gitProjectName = newName
+		return nil
+	}
+
+	m.projectPath = newPath
+	m.gitProjectName = newName
+	m.gitGraphScroll = 0
+	return refreshGitGraphCmd(m.projectPath)
 }
 
 // Init initializes the model
@@ -704,6 +747,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			} else if m.selectedTask > 0 {
 				m.selectedTask--
+				if cmd := m.syncGitGraphToSelectedTask(); cmd != nil {
+					return m, cmd
+				}
 			}
 		case "down", "j":
 			if m.gitGraphFocus {
@@ -719,6 +765,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			} else if m.selectedTask < len(m.tasks)-1 {
 				m.selectedTask++
+				if cmd := m.syncGitGraphToSelectedTask(); cmd != nil {
+					return m, cmd
+				}
 			}
 		case "ctrl+d":
 			if m.gitGraphFocus && m.gitGraphState != nil {
@@ -774,10 +823,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case updateTasksMsg:
 		prevLen := len(m.tasks)
 		m.tasks = msg
+		// GH-2167: Sync git graph to selected task's project when task list updates
+		gitCmd := m.syncGitGraphToSelectedTask()
 		if len(m.tasks) != prevLen {
 			// GH-1249: Task count changed → content height changed.
 			// Force full repaint to prevent ghost lines from Bubbletea's diff renderer.
+			if gitCmd != nil {
+				return m, tea.Batch(gitCmd, tea.ClearScreen)
+			}
 			return m, tea.ClearScreen
+		}
+		if gitCmd != nil {
+			return m, gitCmd
 		}
 
 	case addLogMsg:

--- a/internal/executor/monitor.go
+++ b/internal/executor/monitor.go
@@ -33,6 +33,8 @@ type TaskState struct {
 	Error       string
 	PRUrl       string
 	IssueURL    string
+	ProjectPath string // Resolved project directory for this task (GH-2167)
+	ProjectName string // Short project name for display (GH-2167)
 }
 
 // Monitor tracks task execution progress
@@ -60,6 +62,17 @@ func (m *Monitor) Register(taskID, title, issueURL string) {
 		Phase:    "Pending",
 		Progress: 0,
 		IssueURL: issueURL,
+	}
+}
+
+// SetProjectInfo sets the project path and name for a task (GH-2167).
+func (m *Monitor) SetProjectInfo(taskID, projectPath, projectName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if state, ok := m.tasks[taskID]; ok {
+		state.ProjectPath = projectPath
+		state.ProjectName = projectName
 	}
 }
 

--- a/internal/executor/monitor_test.go
+++ b/internal/executor/monitor_test.go
@@ -433,3 +433,27 @@ func TestTaskStateFields(t *testing.T) {
 		t.Errorf("Message = %q, want Working on it", state.Message)
 	}
 }
+
+// GH-2167: SetProjectInfo attaches project path and name to a registered task.
+func TestMonitorSetProjectInfo(t *testing.T) {
+	m := NewMonitor()
+	m.Register("GH-1", "Test task", "https://example.com/1")
+	m.SetProjectInfo("GH-1", "/home/user/pilot", "pilot")
+
+	state, ok := m.Get("GH-1")
+	if !ok {
+		t.Fatal("task not found")
+	}
+	if state.ProjectPath != "/home/user/pilot" {
+		t.Errorf("ProjectPath = %q, want /home/user/pilot", state.ProjectPath)
+	}
+	if state.ProjectName != "pilot" {
+		t.Errorf("ProjectName = %q, want pilot", state.ProjectName)
+	}
+}
+
+func TestMonitorSetProjectInfo_NonExistent(t *testing.T) {
+	m := NewMonitor()
+	// Should not panic on non-existent task
+	m.SetProjectInfo("GH-999", "/tmp/foo", "foo")
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2167.

Closes #2167

## Changes

GitHub Issue #2167: fix(dashboard): git graph should follow focused task's project

## Context

The GIT panel in the TUI dashboard always shows `projectPath` from `default_project` config, regardless of which project's tasks are executing. When running multi-project (e.g., pilot + aso-generator), the git graph is misleading — it shows pilot's history while aso-generator tasks are running.

## Requirements

Wire the git graph `projectPath` to the currently selected/focused task in the queue panel.

**Key files:**
- `internal/dashboard/tui.go` — `Model.projectPath` (line ~385), `SetProjectPath()` (line ~646)
- `internal/dashboard/gitgraph.go` — `FetchGitGraph(projectPath, limit)` (line ~77), `refreshGitGraphCmd()` (line ~422)
- `cmd/pilot/main.go` — `model.SetProjectPath(projectPath)` (lines ~545, ~1533)

**Implementation:**
1. The queue panel already tracks a focused/selected task. Each task has a resolved project path (from `config.Projects` by name).
2. When the focused task changes, update `m.projectPath` to that task's project path and trigger a git graph refresh.
3. If no task is focused or queue is empty, fall back to `default_project` path (current behavior).
4. Update the GIT panel title to include the project name (e.g., `GIT — aso-generator`) so it's clear which repo is shown.

## Constraints

- Do NOT change git graph rendering logic — only the data source (`projectPath`)
- Do NOT refresh git graph on every queue scroll — debounce or only refresh when the focused task's project actually changes
- Preserve existing keyboard navigation (j/k scroll, tab focus)