### PR TITLE
GH-2171: fix(autopilot): squash merge should use PR title as commit message, not 'Merge PR #N'

### DIFF
--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -84,7 +84,12 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 	}
 
 	// Merge the PR
+	// For squash merges, use PR title as commit message to preserve conventional commit prefixes
+	// (e.g. "feat(scope): ...") so parseBumpFromMessage() can detect release bumps.
 	commitTitle := fmt.Sprintf("Merge PR #%d", prState.PRNumber)
+	if mergeMethod == github.MergeMethodSquash && prState.PRTitle != "" {
+		commitTitle = prState.PRTitle
+	}
 	if err := m.ghClient.MergePullRequest(ctx, m.owner, m.repo, prState.PRNumber, mergeMethod, commitTitle); err != nil {
 		return fmt.Errorf("merge failed: %w", err)
 	}

--- a/internal/autopilot/auto_merger_test.go
+++ b/internal/autopilot/auto_merger_test.go
@@ -632,6 +632,76 @@ func TestAutoMerger_MergePR_AllMergeMethods(t *testing.T) {
 	}
 }
 
+func TestAutoMerger_MergePR_SquashUsePRTitle(t *testing.T) {
+	tests := []struct {
+		name        string
+		method      string
+		prTitle     string
+		wantTitle   string
+	}{
+		{
+			name:      "squash with PR title uses PR title",
+			method:    github.MergeMethodSquash,
+			prTitle:   "feat(api): add rate limiting",
+			wantTitle: "feat(api): add rate limiting",
+		},
+		{
+			name:      "squash without PR title falls back to default",
+			method:    github.MergeMethodSquash,
+			prTitle:   "",
+			wantTitle: "Merge PR #42",
+		},
+		{
+			name:      "regular merge ignores PR title",
+			method:    github.MergeMethodMerge,
+			prTitle:   "feat(api): add rate limiting",
+			wantTitle: "Merge PR #42",
+		},
+		{
+			name:      "rebase ignores PR title",
+			method:    github.MergeMethodRebase,
+			prTitle:   "fix(auth): token refresh",
+			wantTitle: "Merge PR #42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capturedTitle := ""
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/repos/owner/repo/pulls/42/merge" {
+					var body map[string]string
+					_ = json.NewDecoder(r.Body).Decode(&body)
+					capturedTitle = body["commit_title"]
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.Environment = EnvDev
+			cfg.AutoReview = false
+			cfg.MergeMethod = tt.method
+
+			merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
+
+			err := merger.MergePR(context.Background(), &PRState{
+				PRNumber: 42,
+				PRTitle:  tt.prTitle,
+			})
+			if err != nil {
+				t.Errorf("MergePR() error = %v", err)
+			}
+
+			if capturedTitle != tt.wantTitle {
+				t.Errorf("commit_title = %q, want %q", capturedTitle, tt.wantTitle)
+			}
+		})
+	}
+}
+
 func TestAutoMerger_CanMerge_IntegrationScenarios(t *testing.T) {
 	// Test real-world PR state combinations
 	tests := []struct {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2171.

Closes #2171

## Changes

GitHub Issue #2171: fix(autopilot): squash merge should use PR title as commit message, not 'Merge PR #N'

## Context

Squash merges use hardcoded `Merge PR #%d` as the commit title (auto_merger.go:87). This breaks conventional commits — `parseBumpFromMessage()` returns `BumpNone` because there's no `feat()/fix()` prefix, so autopilot never tags a release.

Discovered on PR #2170: title was `GH-2168: fix(executor): clean up stale worktrees...` but merge commit was `Merge PR #2170` → no release tag.

## Fix

**File: `internal/autopilot/auto_merger.go`, line 87**

```go
// Current (broken):
commitTitle := fmt.Sprintf("Merge PR #%d", prState.PRNumber)

// Fix: use PR title for squash merges (contains conventional commit prefix)
commitTitle := fmt.Sprintf("Merge PR #%d", prState.PRNumber)
if mergeMethod == github.MergeMethodSquash && prState.PRTitle != "" {
    commitTitle = prState.PRTitle
}
```

## Constraints

- Only change behavior for squash merges — regular merge commits should keep `Merge PR #N`
- Preserve PR number somewhere (GitHub UI already links squash commits to the PR)
- Verify `prState.PRTitle` is populated in all code paths that call `MergePR()`