### PR TITLE
GH-2179: Wire SubIssueMergeWaitFn in main.go and harness.go

### DIFF
--- a/.agent/tasks/gh-2179.md
+++ b/.agent/tasks/gh-2179.md
@@ -1,0 +1,18 @@
+# GH-2179: Wire SubIssueMergeWaitFn in main.go and harness.go
+
+**Created:** 2026-04-04
+**Status:** Done
+**Parent:** GH-2177
+
+## Changes
+
+### `cmd/pilot/main.go`
+- **Gateway mode** (~line 700): After `SetOnSubIssuePRCreated`, wire `SetSubIssueMergeWait` with a `MergeWaiter` closure gated on `waitForMerge`. Uses `client` (gateway GitHub client) and splits `cfg.Adapters.GitHub.Repo` for owner/repo.
+- **Polling mode** (~line 2116): Same pattern after `SetOnSubIssuePRCreated`. Uses `client` (polling GitHub client) with `pollInterval`/`prTimeout` from execution config.
+
+### `internal/wiring/harness.go`
+- Both `NewPollingHarness` and `NewGatewayHarness` wire an immediate-success stub: `func(_ context.Context, _ int) error { return nil }`
+
+### `internal/wiring/parity_test.go`
+- Added `HasSubIssueMergeWait` to `allChecks` (18 total, was 17)
+- Added always-true assertion in `TestHarnessFieldsWithMinimalConfig`

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -699,6 +699,21 @@ Examples:
 						gwRunner.SetOnSubIssuePRCreated(gwAutopilotController.OnPRCreated)
 					}
 
+					// Wire sub-issue merge-wait so epic sub-issues block until their PR merges (GH-2179)
+					if waitForMerge {
+						gwRepoParts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2)
+						if len(gwRepoParts) == 2 {
+							mergeWaiter := github.NewMergeWaiter(client, gwRepoParts[0], gwRepoParts[1], &github.MergeWaiterConfig{
+								PollInterval: pollInterval,
+								Timeout:      prTimeout,
+							})
+							gwRunner.SetSubIssueMergeWait(func(ctx context.Context, prNumber int) error {
+								_, err := mergeWaiter.WaitForMerge(ctx, prNumber)
+								return err
+							})
+						}
+					}
+
 					// GH-726: Wire processed issue persistence for gateway poller
 					if gwAutopilotStateStore != nil {
 						pollerOpts = append(pollerOpts, github.WithProcessedStore(gwAutopilotStateStore))
@@ -2096,6 +2111,21 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 				// Wire sub-issue PR callback for default controller (GH-594)
 				if autopilotController != nil {
 					runner.SetOnSubIssuePRCreated(autopilotController.OnPRCreated)
+				}
+
+				// Wire sub-issue merge-wait so epic sub-issues block until their PR merges (GH-2179)
+				if waitForMerge && cfg.Adapters.GitHub.Repo != "" {
+					parts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2)
+					if len(parts) == 2 {
+						mergeWaiter := github.NewMergeWaiter(client, parts[0], parts[1], &github.MergeWaiterConfig{
+							PollInterval: pollInterval,
+							Timeout:      prTimeout,
+						})
+						runner.SetSubIssueMergeWait(func(ctx context.Context, prNumber int) error {
+							_, err := mergeWaiter.WaitForMerge(ctx, prNumber)
+							return err
+						})
+					}
 				}
 			}
 

--- a/internal/wiring/harness.go
+++ b/internal/wiring/harness.go
@@ -4,6 +4,7 @@
 package wiring
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -140,6 +141,9 @@ func NewPollingHarness(t *testing.T, cfg *config.Config) *Harness {
 	// OnSubIssuePRCreated callback → autopilot
 	h.Runner.SetOnSubIssuePRCreated(ctrl.OnPRCreated)
 
+	// SubIssueMergeWait — immediate success for tests (GH-2179)
+	h.Runner.SetSubIssueMergeWait(func(_ context.Context, _ int) error { return nil })
+
 	return h
 }
 
@@ -251,6 +255,9 @@ func NewGatewayHarness(t *testing.T, cfg *config.Config) *Harness {
 
 	// OnSubIssuePRCreated callback → autopilot
 	h.Runner.SetOnSubIssuePRCreated(ctrl.OnPRCreated)
+
+	// SubIssueMergeWait — immediate success for tests (GH-2179)
+	h.Runner.SetSubIssueMergeWait(func(_ context.Context, _ int) error { return nil })
 
 	return h
 }

--- a/internal/wiring/parity_test.go
+++ b/internal/wiring/parity_test.go
@@ -55,7 +55,7 @@ func TestPollingGatewayParity(t *testing.T) {
 		},
 	}
 
-	// All 17 Has* accessors on Runner.
+	// All 18 Has* accessors on Runner.
 	type hasCheck struct {
 		field string
 		get   func(*Harness) bool
@@ -65,6 +65,7 @@ func TestPollingGatewayParity(t *testing.T) {
 		{"HasLogStore", func(h *Harness) bool { return h.Runner.HasLogStore() }},
 		{"HasMonitor", func(h *Harness) bool { return h.Runner.HasMonitor() }},
 		{"HasOnSubIssuePRCreated", func(h *Harness) bool { return h.Runner.HasOnSubIssuePRCreated() }},
+		{"HasSubIssueMergeWait", func(h *Harness) bool { return h.Runner.HasSubIssueMergeWait() }},
 		{"HasModelRouter", func(h *Harness) bool { return h.Runner.HasModelRouter() }},
 		{"HasQualityCheckerFactory", func(h *Harness) bool { return h.Runner.HasQualityCheckerFactory() }},
 		{"HasLearningLoop", func(h *Harness) bool { return h.Runner.HasLearningLoop() }},
@@ -139,6 +140,9 @@ func TestHarnessFieldsWithMinimalConfig(t *testing.T) {
 			}
 			if !h.Runner.HasOnSubIssuePRCreated() {
 				t.Error("HasOnSubIssuePRCreated should be true")
+			}
+			if !h.Runner.HasSubIssueMergeWait() {
+				t.Error("HasSubIssueMergeWait should be true")
 			}
 			if !h.Runner.HasModelRouter() {
 				t.Error("HasModelRouter should be true")


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2179.

Closes #2179

## Changes

GitHub Issue #2179: Wire SubIssueMergeWaitFn in main.go and harness.go

Parent: GH-2177

`cmd/pilot/` + `internal/wiring/`
Wire the callback from production and test harness entry points:
- **`cmd/pilot/main.go`** (near line 2098, after `SetOnSubIssuePRCreated`): Create a `github.MergeWaiter` using the existing `client`, `owner`, `repo`, config (`pollInterval`, `prTimeout` — already extracted at lines 1872-1887). Gate on `waitForMerge` (already read from `cfg.Orchestrator.Execution.WaitForMerge`). Set closure: `runner.SetSubIssueMergeWait(func(ctx, prNum) error { result, err := waiter.WaitForMerge(ctx, prNum); ... translate MergeWaitResult to error })`. Do the same for gateway mode (~line 699)
- **`internal/wiring/harness.go`** (after lines 141 and 253): Wire a test-appropriate merge-wait function (immediate success) for both standard and gateway harnesses. Add `HasSubIssueMergeWait` to any wiring parity assertions if they exist
- Update `.agent/tasks/` with task documentation
**Key references**: `github.NewMergeWaiter` at `merger.go:47`, `DefaultMergeWaiterConfig` at `merger.go:30`, existing poller wiring pattern at `main.go:670-700` for gateway and `main.go:1870-1910` for multi-repo mode.