### PR TITLE
GH-2185: chore: update CLAUDE.md version to v2.89.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,14 +183,14 @@ Documentation in `.agent/`:
 
 ## Current Status
 
-**Version:** v2.38.11 | **240+ features implemented**
+**Version:** v2.89.0 | **240+ features implemented**
 
 **Core:**
 - ✅ Task execution with Navigator integration
 - ✅ Autopilot: CI monitor, auto-merge, auto-rebase, feedback loop, tag-only release
 - ✅ Intent judge in execution pipeline
 - ✅ Rich PR comments with execution metrics
-- ✅ Epic decomposition with sub-issue PR wiring
+- ✅ Epic decomposition with sub-issue PR wiring + merge-wait (`SubIssueMergeWaitFn`, `execution.wait_for_merge`)
 - ✅ Self-review, quality gates, effort routing
 - ✅ Pattern learning from PR reviews
 - ✅ GitHub Projects V2 board sync


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2185.

Closes #2185

## Changes

GitHub Issue #2185: chore: update CLAUDE.md version to v2.89.0

## What

Update version references in project documentation:

1. **CLAUDE.md line 186**: Change `v2.38.11 | 240+ features` to `v2.89.0 | 240+ features`
2. **CLAUDE.md architecture section**: Add note about merge-wait if there's an autopilot/epic section:
   - `SubIssueMergeWaitFn` callback pattern in `epic.go` — waits for PR merge between sub-issues
   - Config: `execution.wait_for_merge: true`
   - Wired in both multi-repo poller and gateway modes

## Why

CLAUDE.md version hasn't been updated in a while (still says v2.38.11, we're at v2.89.0). This is the version Pilot reads when executing tasks — stale version info can confuse context.

## Files
- `CLAUDE.md` — update version string and add architecture note