### PR TITLE
GH-2183: docs(epic): add merge-wait section to epic-decomposition page

### DIFF
--- a/docs/content/features/epic-decomposition.mdx
+++ b/docs/content/features/epic-decomposition.mdx
@@ -15,7 +15,7 @@ When Pilot detects a complex task (epic), it automatically:
 1. **Plans** the implementation using Claude Code in planning mode
 2. **Decomposes** the epic into 3-5 sequential subtasks
 3. **Creates** separate GitHub issues for each subtask
-4. **Executes** subtasks sequentially, updating progress on the parent issue
+4. **Executes** subtasks sequentially, updating progress on the parent issue (optionally waiting for each PR to merge before starting the next — see [Merge-Wait](#merge-wait-between-sub-issues))
 5. **Closes** completed subtasks and the parent epic
 
 ```
@@ -61,6 +61,43 @@ orchestrator:
       max_subtasks: 5         # Limit subtask count
       min_description_words: 100  # Word threshold for decomposition
 ```
+
+## Merge-Wait Between Sub-Issues
+
+### Problem
+
+By default, all sub-issues branch from the same `main` HEAD. If two subtasks touch overlapping files, the second PR will conflict with the first once it's merged — causing CI failures and manual resolution work.
+
+### Solution
+
+Set `execution.wait_for_merge: true` in config. Pilot will wait for each sub-issue's PR to be merged before branching and executing the next one.
+
+```yaml
+# ~/.pilot/config.yaml
+orchestrator:
+  execution:
+    wait_for_merge: true  # Wait for each sub-issue PR to merge before next
+```
+
+### How It Works
+
+```
+Sub-issue N → PR Created → Poll until Merged → Sync main → Sub-issue N+1 branches from updated main
+```
+
+1. After sub-issue N's PR is created, Pilot polls GitHub until it is merged
+2. `syncMainBranch` pulls the merged changes into the local `main`
+3. Sub-issue N+1 branches from the updated `main`, picking up N's changes
+4. The last sub-issue skips the wait (nothing follows it)
+5. If the PR is closed without merging, or the merge times out, the epic aborts with a clear error
+
+<Callout type="tip" emoji="💡">
+  Enable merge-wait for epics where sub-issues touch overlapping files or packages. Without it, sub-issues branch in parallel from the same HEAD — which is faster but risks merge conflicts when PRs land.
+</Callout>
+
+### Backwards Compatibility
+
+Without `wait_for_merge: true`, sub-issues continue to fire in parallel (the default behavior before v2.87.5). Existing configs require no changes.
 
 ## Planning Process
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2183.

Closes #2183

## Changes

GitHub Issue #2183: docs(epic): add merge-wait section to epic-decomposition page

## Context

v2.87.5–v2.89.0 shipped merge-wait between epic sub-issues (GH-2177). The docs site at `docs/content/features/epic-decomposition.mdx` has no mention of this capability.

## What to Add

Add a new section **"Merge-Wait Between Sub-Issues"** after the existing "Configuration" section in `docs/content/features/epic-decomposition.mdx`.

### Content to cover:

1. **Problem**: Sub-issues all branch from same `main` HEAD → conflicts when touching overlapping files
2. **Solution**: `execution.wait_for_merge: true` in config — Pilot waits for each sub-issue's PR to merge before starting the next
3. **How it works**:
   - After sub-issue N's PR is created, Pilot polls GitHub until it's merged
   - `syncMainBranch` updates local main with the merged changes
   - Sub-issue N+1 branches from updated main
   - Last sub-issue skips the wait
   - If merge fails (conflict/timeout/closed), epic aborts with clear error
4. **Config example**:
   ```yaml
   orchestrator:
     execution:
       wait_for_merge: true  # Wait for each sub-issue PR to merge before next
   ```
5. **Callout**: This is backwards-compatible — without config, sub-issues fire in parallel (old behavior)

### Also update:
- The "How It Works" numbered list (step 4) to mention merge-wait as optional behavior
- Add a Callout tip about when to enable it (epics where sub-issues touch overlapping files)

## Key files
- `docs/content/features/epic-decomposition.mdx` — main target
- `internal/executor/epic.go` — implementation reference
- `internal/executor/runner.go:266-623` — type/setter reference

## Planned Steps (execute all in sequence)

1. **Add merge-wait documentation to epic-decomposition page** — Edit `docs/content/features/epic-decomposition.mdx` to: (a) add a new "Merge-Wait Between Sub-Issues" section after the existing "Configuration" section covering the problem, solution, how-it-works flow, config example (`execution.wait_for_merge: true`), and backwards-compatibility note; (b) update the existing "How It Works" numbered list (step 4) to mention merge-wait as optional behavior; (c) add a Callout tip advising when to enable it (epics where sub-issues touch overlapping files). Reference `internal/executor/epic.go` and `internal/executor/runner.go:266-623` for implementation accuracy.
