### PR TITLE
GH-2189: fix(docs): correct brew tap and install script repo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Pilot picks up tickets from GitHub, Linear, Jira, or Asana—plans the implement
 ### Homebrew (recommended)
 
 ```bash
-brew tap qf-studio/pilot
+brew tap alekspetrov/pilot
 brew install pilot
 ```
 

--- a/docs/content/getting-started/installation.mdx
+++ b/docs/content/getting-started/installation.mdx
@@ -11,7 +11,7 @@ Pilot is a single Go binary. Install it, run `pilot doctor`, and you're ready.
 The install script downloads the latest release for your platform and installs to `~/.local/bin/pilot`.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/alekspetrov/pilot/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/qf-studio/pilot/main/install.sh | bash
 ```
 
 This method supports **hot-upgrade** — Pilot can update itself in-place without manual intervention. When running in daemon mode (`pilot start`), press `u` in the dashboard to upgrade without downtime. See [Hot Upgrade](/features/hot-upgrade) for details.

--- a/docs/content/getting-started/quickstart.mdx
+++ b/docs/content/getting-started/quickstart.mdx
@@ -17,7 +17,7 @@ This guide takes you from zero to your first AI-generated pull request.
 <Tabs items={['Quick Install (recommended)', 'Homebrew', 'From Source']}>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/alekspetrov/pilot/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/qf-studio/pilot/main/install.sh | bash
 ```
 
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,9 +1,9 @@
 # Pilot installer for Windows
-# Usage: irm https://raw.githubusercontent.com/alekspetrov/pilot/main/install.ps1 | iex
+# Usage: irm https://raw.githubusercontent.com/qf-studio/pilot/main/install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 
-$REPO = "alekspetrov/pilot"
+$REPO = "qf-studio/pilot"
 $BINARY_NAME = "pilot.exe"
 $INSTALL_DIR = "$env:LOCALAPPDATA\pilot\bin"
 

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Pilot installer script
-# Usage: curl -fsSL https://raw.githubusercontent.com/alekspetrov/pilot/main/install.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/qf-studio/pilot/main/install.sh | bash
 
 set -e
 
-REPO="alekspetrov/pilot"
+REPO="qf-studio/pilot"
 BINARY_NAME="pilot"
 INSTALL_DIR="$HOME/.local/bin"
 

--- a/llms.txt
+++ b/llms.txt
@@ -37,12 +37,12 @@ Body:
 
 ## Documentation
 
-- [README](https://github.com/alekspetrov/pilot#readme): Full documentation, installation, configuration
-- [Deployment Guide](https://github.com/alekspetrov/pilot/blob/main/docs/DEPLOYMENT.md): Cloud deployment options
-- [CLI Reference](https://github.com/alekspetrov/pilot#cli-reference): All commands and flags
+- [README](https://github.com/qf-studio/pilot#readme): Full documentation, installation, configuration
+- [Deployment Guide](https://github.com/qf-studio/pilot/blob/main/docs/DEPLOYMENT.md): Cloud deployment options
+- [CLI Reference](https://github.com/qf-studio/pilot#cli-reference): All commands and flags
 
 ## Optional
 
-- [Configuration](https://github.com/alekspetrov/pilot#configuration): YAML config reference
-- [Autopilot Modes](https://github.com/alekspetrov/pilot#autopilot-modes): dev/stage/prod autonomy levels
-- [Telegram Integration](https://github.com/alekspetrov/pilot#telegram-integration): Chat, voice, and image support
+- [Configuration](https://github.com/qf-studio/pilot#configuration): YAML config reference
+- [Autopilot Modes](https://github.com/qf-studio/pilot#autopilot-modes): dev/stage/prod autonomy levels
+- [Telegram Integration](https://github.com/qf-studio/pilot#telegram-integration): Chat, voice, and image support


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2189.

Closes #2189

## Changes

GitHub Issue #2189: fix(docs): correct brew tap and install script repo references

## Problem

Repo was moved from `alekspetrov/pilot` to `qf-studio/pilot` but install references were never fully updated. Brew tap in README points to nonexistent `qf-studio/homebrew-pilot`.

## Changes

### 1. `README.md` line 68 — Fix brew tap org

```diff
-brew tap qf-studio/pilot
+brew tap alekspetrov/pilot
```

The Homebrew tap repo lives at `alekspetrov/homebrew-pilot`. The README incorrectly references `qf-studio/pilot` which doesn't resolve to a tap repo.

### 2. `install.sh` lines 3 and 7 — Fix repo to qf-studio

```diff
-# Usage: curl -fsSL https://raw.githubusercontent.com/alekspetrov/pilot/main/install.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/qf-studio/pilot/main/install.sh | bash
```

```diff
-REPO="alekspetrov/pilot"
+REPO="qf-studio/pilot"
```

### 3. `install.ps1` lines 2 and 6 — Fix repo to qf-studio

```diff
-# Usage: irm https://raw.githubusercontent.com/alekspetrov/pilot/main/install.ps1 | iex
+# Usage: irm https://raw.githubusercontent.com/qf-studio/pilot/main/install.ps1 | iex
```

```diff
-$REPO = "alekspetrov/pilot"
+$REPO = "qf-studio/pilot"
```

### 4. `docs/content/getting-started/installation.mdx` line 14 — Fix curl URL

```diff
-curl -fsSL https://raw.githubusercontent.com/alekspetrov/pilot/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/qf-studio/pilot/main/install.sh | bash
```

(Line 26 `brew tap alekspetrov/pilot` is already correct — do NOT change it.)

### 5. `docs/content/getting-started/quickstart.mdx` line 20 — Fix curl URL

```diff
-curl -fsSL https://raw.githubusercontent.com/alekspetrov/pilot/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/qf-studio/pilot/main/install.sh | bash
```

(Line 25 `brew tap alekspetrov/pilot` is already correct — do NOT change it.)

### 6. `llms.txt` lines 40-48 — Fix all GitHub URLs

Replace all occurrences of `github.com/alekspetrov/pilot` with `github.com/qf-studio/pilot` in this file.

## Constraints
- Do NOT touch `.goreleaser.yaml` or `.github/workflows/` (separate issue)
- Do NOT touch `go.mod` or any `.go` files
- The brew tap name stays `alekspetrov/pilot` (that's where the tap repo lives)
- The release/install repo is `qf-studio/pilot` (that's where releases are published)

## Verification
- `grep -r "alekspetrov/pilot" README.md install.sh install.ps1 llms.txt docs/content/getting-started/` should only return brew tap lines (which correctly point to `alekspetrov/pilot`)
- No Go build changes needed