### PR TITLE
GH-2188: feat(release): add GoReleaser brews section for Homebrew auto-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,3 +88,20 @@ release:
   prerelease: auto
   mode: append
   name_template: "{{.ProjectName}} v{{.Version}}"
+
+brews:
+  - repository:
+      owner: alekspetrov
+      name: homebrew-pilot
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://pilot.quantflow.studio"
+    description: "AI that ships your tickets — autonomous development pipeline"
+    license: "MIT"
+    install: |
+      bin.install "pilot"
+    test: |
+      system "#{bin}/pilot", "version"
+    commit_author:
+      name: "Pilot Bot"
+      email: "pilot@quantflow.studio"


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2188.

Closes #2188

## Changes

GitHub Issue #2188: feat(release): add GoReleaser brews section for Homebrew auto-publish

## Problem

Homebrew formula at `alekspetrov/homebrew-pilot` is stuck at v0.3.3 (current: v2.89.0). GoReleaser has no `brews:` section — formula never auto-updates on release.

## Changes

### 1. `.goreleaser.yaml` — Add `brews:` section after the `release:` block (after line 91)

```yaml
brews:
  - repository:
      owner: alekspetrov
      name: homebrew-pilot
      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
    directory: Formula
    homepage: "https://pilot.quantflow.studio"
    description: "AI that ships your tickets — autonomous development pipeline"
    license: "MIT"
    install: |
      bin.install "pilot"
    test: |
      system "#{bin}/pilot", "version"
    commit_author:
      name: "Pilot Bot"
      email: "pilot@quantflow.studio"
```

### 2. `.github/workflows/release.yml` — Add `HOMEBREW_TAP_GITHUB_TOKEN` env var

At line 32, alongside existing `GITHUB_TOKEN`:
```yaml
env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
```

## Constraints
- Do NOT modify any other files
- Do NOT change existing GoReleaser config — only append the `brews:` section
- The `release.yml` change is a single line addition

## Verification
- `go build ./...` passes (no Go changes)
- YAML is valid (no syntax errors in `.goreleaser.yaml`)