### PR TITLE
GH-2192: fix: update llms.txt GitHub URLs from alekspetrov to qf-studio

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -37,12 +37,12 @@ Body:
 
 ## Documentation
 
-- [README](https://github.com/alekspetrov/pilot#readme): Full documentation, installation, configuration
-- [Deployment Guide](https://github.com/alekspetrov/pilot/blob/main/docs/DEPLOYMENT.md): Cloud deployment options
-- [CLI Reference](https://github.com/alekspetrov/pilot#cli-reference): All commands and flags
+- [README](https://github.com/qf-studio/pilot#readme): Full documentation, installation, configuration
+- [Deployment Guide](https://github.com/qf-studio/pilot/blob/main/docs/DEPLOYMENT.md): Cloud deployment options
+- [CLI Reference](https://github.com/qf-studio/pilot#cli-reference): All commands and flags
 
 ## Optional
 
-- [Configuration](https://github.com/alekspetrov/pilot#configuration): YAML config reference
-- [Autopilot Modes](https://github.com/alekspetrov/pilot#autopilot-modes): dev/stage/prod autonomy levels
-- [Telegram Integration](https://github.com/alekspetrov/pilot#telegram-integration): Chat, voice, and image support
+- [Configuration](https://github.com/qf-studio/pilot#configuration): YAML config reference
+- [Autopilot Modes](https://github.com/qf-studio/pilot#autopilot-modes): dev/stage/prod autonomy levels
+- [Telegram Integration](https://github.com/qf-studio/pilot#telegram-integration): Chat, voice, and image support


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2192.

Closes #2192

## Changes

GitHub Issue #2192: fix: update llms.txt GitHub URLs from alekspetrov to qf-studio

## Problem

`llms.txt` contains GitHub URLs pointing to old `alekspetrov/pilot` repo instead of `qf-studio/pilot`.

## Changes

In `llms.txt`, replace all occurrences of `github.com/alekspetrov/pilot` with `github.com/qf-studio/pilot`.

Lines to update (40-48):
- `https://github.com/alekspetrov/pilot#readme` → `https://github.com/qf-studio/pilot#readme`
- `https://github.com/alekspetrov/pilot/blob/main/docs/DEPLOYMENT.md` → `https://github.com/qf-studio/pilot/blob/main/docs/DEPLOYMENT.md`
- `https://github.com/alekspetrov/pilot#cli-reference` → `https://github.com/qf-studio/pilot#cli-reference`
- `https://github.com/alekspetrov/pilot#configuration` → `https://github.com/qf-studio/pilot#configuration`
- `https://github.com/alekspetrov/pilot#autopilot-modes` → `https://github.com/qf-studio/pilot#autopilot-modes`
- `https://github.com/alekspetrov/pilot#telegram-integration` → `https://github.com/qf-studio/pilot#telegram-integration`

## Constraints
- Only touch `llms.txt`
- Simple find-and-replace: `github.com/alekspetrov/pilot` → `github.com/qf-studio/pilot`