### PR TITLE
GH-2196: fix: update remaining alekspetrov/pilot references to qf-studio in non-Go files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Pilot is source-available under [BSL 1.1](LICENSE). Contributions are welcome an
 ### Clone and Build
 
 ```bash
-git clone https://github.com/alekspetrov/pilot.git
+git clone https://github.com/qf-studio/pilot.git
 cd pilot
 make build
 ```
@@ -43,7 +43,7 @@ make fmt
 
 ### Report Bugs
 
-Open a [GitHub Issue](https://github.com/alekspetrov/pilot/issues/new) with:
+Open a [GitHub Issue](https://github.com/qf-studio/pilot/issues/new) with:
 - Steps to reproduce
 - Expected vs actual behavior
 - Pilot version (`pilot --version`)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -42,6 +42,6 @@ docker run -d \
   -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
   -e GITHUB_TOKEN=$GITHUB_TOKEN \
   -v pilot-data:/data \
-  ghcr.io/alekspetrov/pilot:latest \
+  ghcr.io/qf-studio/pilot:latest \
   start --telegram --github
 ```

--- a/deploy/aws/cloudformation.yaml
+++ b/deploy/aws/cloudformation.yaml
@@ -28,7 +28,7 @@ Parameters:
 
   ContainerImage:
     Type: String
-    Default: ghcr.io/alekspetrov/pilot:latest
+    Default: ghcr.io/qf-studio/pilot:latest
     Description: Container image to deploy
 
 Resources:

--- a/deploy/aws/task-definition.json
+++ b/deploy/aws/task-definition.json
@@ -9,7 +9,7 @@
   "containerDefinitions": [
     {
       "name": "pilot",
-      "image": "ghcr.io/alekspetrov/pilot:latest",
+      "image": "ghcr.io/qf-studio/pilot:latest",
       "essential": true,
       "command": ["pilot", "start", "--telegram", "--github"],
       "environment": [

--- a/deploy/helm/pilot/Chart.yaml
+++ b/deploy/helm/pilot/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - ci
 home: https://pilot.quantflow.studio
 sources:
-  - https://github.com/alekspetrov/pilot
+  - https://github.com/qf-studio/pilot
 maintainers:
   - name: alekspetrov
     url: https://github.com/alekspetrov

--- a/deploy/helm/pilot/values.yaml
+++ b/deploy/helm/pilot/values.yaml
@@ -6,7 +6,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/alekspetrov/pilot
+  repository: ghcr.io/qf-studio/pilot
   # Defaults to Chart.appVersion when empty
   tag: ""
   pullPolicy: IfNotPresent

--- a/docs/content/features/hot-upgrade.mdx
+++ b/docs/content/features/hot-upgrade.mdx
@@ -68,7 +68,7 @@ brew upgrade pilot
 To switch to self-managed installation (enables hot-upgrade):
 ```bash
 brew uninstall pilot
-curl -fsSL https://raw.githubusercontent.com/alekspetrov/pilot/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/qf-studio/pilot/main/install.sh | bash
 ```
 </Callout>
 

--- a/docs/content/guides/troubleshooting.mdx
+++ b/docs/content/guides/troubleshooting.mdx
@@ -128,7 +128,7 @@ Or switch to self-managed installation:
 
 ```bash
 brew uninstall pilot
-curl -fsSL https://raw.githubusercontent.com/alekspetrov/pilot/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/qf-studio/pilot/main/install.sh | bash
 ```
 
 ### Upgrade failed / binary corrupted


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2196.

Closes #2196

## Changes

GitHub Issue #2196: fix: update remaining alekspetrov/pilot references to qf-studio in non-Go files

## Problem

Several non-Go files still reference `alekspetrov/pilot` (old org). These are deploy configs, docs, and CONTRIBUTING.md.

## Changes

Replace `alekspetrov/pilot` with `qf-studio/pilot` in these files:

### Deploy configs
- `deploy/README.md` — `ghcr.io/alekspetrov/pilot:latest` → `ghcr.io/qf-studio/pilot:latest`
- `deploy/aws/cloudformation.yaml` — same GHCR image reference
- `deploy/aws/task-definition.json` — same GHCR image reference
- `deploy/helm/pilot/Chart.yaml` — GitHub URL
- `deploy/helm/pilot/values.yaml` — GHCR image repository

### Docs
- `docs/content/features/hot-upgrade.mdx` — curl install URL
- `docs/content/guides/troubleshooting.mdx` — curl install URL

### CONTRIBUTING.md
- `git clone` URL
- GitHub Issues URL
- Note: the `import "github.com/alekspetrov/pilot/internal/testutil"` line must stay — it matches go.mod module path

## Constraints
- Do NOT touch any `.go` files or `go.mod` — the module path is `github.com/alekspetrov/pilot` and changing it is a breaking change (separate epic)
- Do NOT touch `CONTRIBUTING.md` import example — keep it matching go.mod
- Only change URLs and image references, not Go import paths
- Simple find-and-replace in each file

## Verification
After changes, run:
```bash
grep -r "alekspetrov/pilot" --include="*.md" --include="*.mdx" --include="*.yaml" --include="*.yml" --include="*.json" . | grep -v node_modules | grep -v .next | grep -v .git/ | grep -v .agent/ | grep -v "check-secret" | grep -v "install-hooks"
```
Should only return the `CONTRIBUTING.md` Go import example line.