### PR TITLE
GH-2198: fix(autopilot): call maybeCloseParentIssue in notifyExternalClose path

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2062,4 +2062,8 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 		}
 		c.log.Info("marked issue as pilot-retry-ready (PR closed without merge)", "issue", prState.IssueNumber, "pr", prState.PRNumber)
 	}
+
+	// GH-2198: Close parent epic when all sub-issues are done (even if this one
+	// was closed without merge). maybeCloseParentIssue no-ops for non-sub-issues.
+	c.maybeCloseParentIssue(ctx, prState)
 }

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -3953,3 +3953,103 @@ func TestMaybeCloseParentIssue(t *testing.T) {
 		})
 	}
 }
+
+// TestNotifyExternalClose_MaybeCloseParent verifies that notifyExternalClose
+// calls maybeCloseParentIssue so parent epics are auto-closed when the last
+// sub-issue PR is closed without merge (GH-2198).
+func TestNotifyExternalClose_MaybeCloseParent(t *testing.T) {
+	tests := []struct {
+		name             string
+		issueNumber      int
+		issueBody        string
+		openSubIssues    int
+		wantParentClosed bool
+	}{
+		{
+			name:             "last sub-issue PR closed externally - parent closes",
+			issueNumber:      10,
+			issueBody:        "Fix the bug\n\nParent: GH-5\n",
+			openSubIssues:    0,
+			wantParentClosed: true,
+		},
+		{
+			name:             "non-last sub-issue - parent stays open",
+			issueNumber:      10,
+			issueBody:        "Fix the bug\n\nParent: GH-5\n",
+			openSubIssues:    1,
+			wantParentClosed: false,
+		},
+		{
+			name:             "non-sub-issue - no parent lookup",
+			issueNumber:      10,
+			issueBody:        "Standalone issue",
+			openSubIssues:    0,
+			wantParentClosed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var parentCloseCalled bool
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				// Label/remove calls for the sub-issue itself (notifyExternalClose)
+				case r.URL.Path == "/repos/owner/repo/issues/10/labels" && r.Method == http.MethodPost:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("[]"))
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/10/labels/") && r.Method == http.MethodDelete:
+					w.WriteHeader(http.StatusOK)
+
+				// maybeCloseParentIssue: fetch sub-issue body
+				case r.URL.Path == "/repos/owner/repo/issues/10" && r.Method == http.MethodGet:
+					issue := github.Issue{Number: 10, Body: tt.issueBody}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(issue)
+
+				// maybeCloseParentIssue: count open siblings
+				case strings.HasPrefix(r.URL.Path, "/search/issues"):
+					resp := struct {
+						TotalCount int `json:"total_count"`
+					}{TotalCount: tt.openSubIssues}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+
+				// maybeCloseParentIssue: close parent
+				case r.URL.Path == "/repos/owner/repo/issues/5" && r.Method == http.MethodPatch:
+					parentCloseCalled = true
+					w.WriteHeader(http.StatusOK)
+
+				// parent label / comment calls
+				case r.URL.Path == "/repos/owner/repo/issues/5/labels" && r.Method == http.MethodPost:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("[]"))
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/5/labels/") && r.Method == http.MethodDelete:
+					w.WriteHeader(http.StatusOK)
+				case r.URL.Path == "/repos/owner/repo/issues/5/comments" && r.Method == http.MethodPost:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"id":1}`))
+
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			prState := &PRState{
+				PRNumber:    42,
+				IssueNumber: tt.issueNumber,
+			}
+
+			c.notifyExternalClose(context.Background(), prState)
+
+			if parentCloseCalled != tt.wantParentClosed {
+				t.Errorf("parent closed = %v, want %v", parentCloseCalled, tt.wantParentClosed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2198.

Closes #2198

## Changes

GitHub Issue #2198: fix(autopilot): call maybeCloseParentIssue in notifyExternalClose path

## Problem

When a sub-issue PR is closed externally (without merge), `notifyExternalClose()` in `controller.go:2047` handles retry labeling but does NOT call `maybeCloseParentIssue()`. This means parent epic issues are never auto-closed when their last sub-issue PR is closed without merge.

**Observed in**: `qf-studio/auth-service` GH-39 — sub-issues #54/#55/#56 executed, PRs #77/#78 merged, PR #79 closed without merge. Parent #39 stayed open with `pilot-failed`.

With the new merge-wait flow (GH-2178), this is more impactful: if a sub-issue PR is closed during merge-wait, execution fails early AND the autopilot path doesn't trigger parent close either — dead end.

## Root Cause

`maybeCloseParentIssue()` is only called in `handleMerged()` (controller.go:1116). The `notifyExternalClose()` path (controller.go:2047-2065) has no equivalent call.

## Fix

Add `c.maybeCloseParentIssue(ctx, prState)` at the end of `notifyExternalClose()`, after the retry-ready labeling. The existing `maybeCloseParentIssue()` already checks:
1. Whether the issue is a sub-issue (has parent reference in body)
2. Whether all sibling sub-issues are closed
3. Only closes parent when `openCount == 0`

So it's safe to call on every external close — it will no-op for non-sub-issues.

## Files

- `internal/autopilot/controller.go:2047` — add `maybeCloseParentIssue` call
- Test: verify parent closes when last sub-issue PR is closed without merge

## Acceptance Criteria

- [ ] `notifyExternalClose()` calls `maybeCloseParentIssue()`
- [ ] Parent issue closes when all sub-issue PRs are closed (mix of merged and externally closed)
- [ ] Parent stays open if sibling sub-issues are still open
- [ ] Table-driven test covering: last sub-issue closed → parent closes, non-last → parent stays open

## Planned Steps (execute all in sequence)

1. **Add `maybeCloseParentIssue` call to `notifyExternalClose` + table-driven tests** — In `internal/autopilot/controller.go:2064`, add `c.maybeCloseParentIssue(ctx, prState)` at the end of `notifyExternalClose()`, after the retry-ready labeling block (before the closing brace at line 2065). The existing `maybeCloseParentIssue()` (line 1144) already guards against non-sub-issues (returns early if no parent reference) and only closes the parent when `openCount == 0`, so it's safe to call unconditionally. Then add a table-driven test in the existing test file (`controller_test.go` or a new `controller_external_close_test.go` in the same package) covering: (a) last sub-issue PR closed externally → parent issue gets closed with `pilot-done` label, (b) non-last sub-issue PR closed → parent stays open, (c) non-sub-issue PR closed → no parent lookup attempted. Mock `GetIssue`, `SearchOpenSubIssues`, `AddLabels`, `RemoveLabel`, `AddComment`, and `UpdateIssueState` on the GitHub client interface.
