### PR TITLE
GH-2201: Add retry grace period and TaskChecker to GitHub poller

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -719,6 +719,11 @@ Examples:
 						pollerOpts = append(pollerOpts, github.WithProcessedStore(gwAutopilotStateStore))
 					}
 
+					// GH-2201: Wire task checker for retry grace period (gateway mode)
+					if gwStore != nil {
+						pollerOpts = append(pollerOpts, github.WithTaskChecker(storeTaskChecker{store: gwStore}))
+					}
+
 					// Create rate limit retry scheduler
 					repoParts := strings.Split(cfg.Adapters.GitHub.Repo, "/")
 					if len(repoParts) != 2 {
@@ -1939,6 +1944,9 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 					pollerOpts = append(pollerOpts, github.WithProcessedStore(autopilotStateStore))
 				}
 
+				// GH-2201: Wire task checker for retry grace period
+				pollerOpts = append(pollerOpts, github.WithTaskChecker(storeTaskChecker{store: store}))
+
 				// Capture variables for closures
 				sourceRepo := repoFullName
 				projPathCapture := projPath
@@ -2533,4 +2541,19 @@ func cleanStartupHooks(cfg *config.Config, projectPath string) {
 			slog.Warn("failed to clean stale hooks", "path", p.Path, "error", err)
 		}
 	}
+}
+
+// storeTaskChecker adapts memory.Store to the github.TaskChecker interface.
+// GH-2201: Used by the poller to check if a task is still queued/in-progress
+// before allowing retry after the grace period expires.
+type storeTaskChecker struct {
+	store *memory.Store
+}
+
+func (s storeTaskChecker) IsTaskQueued(taskID string) bool {
+	queued, err := s.store.IsTaskQueued(taskID)
+	if err != nil {
+		return false // Don't block retry on DB errors
+	}
+	return queued
 }

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -37,6 +37,13 @@ type ProcessedStore interface {
 	LoadProcessedIssues() (map[int]bool, error)
 }
 
+// TaskChecker checks whether a task is currently queued or in-progress.
+// Used during retry grace-period evaluation to avoid re-dispatching issues
+// that are still being executed.
+type TaskChecker interface {
+	IsTaskQueued(taskID string) bool
+}
+
 // IssueResult is returned by the issue handler with PR information
 type IssueResult struct {
 	Success    bool
@@ -54,7 +61,7 @@ type Poller struct {
 	repo      string
 	label     string
 	interval  time.Duration
-	processed map[int]bool
+	processed map[int]time.Time
 	mu        sync.RWMutex
 	onIssue   func(ctx context.Context, issue *Issue) error
 	// onIssueWithResult is called for sequential mode, returns PR info
@@ -83,6 +90,15 @@ type Poller struct {
 
 	// Persistent processed store (optional)
 	processedStore ProcessedStore
+
+	// GH-2201: Retry grace period prevents rapid re-dispatch of recently-processed issues.
+	// When a processed issue's status labels are removed, the poller waits this duration
+	// before allowing retry. Default: 5 minutes.
+	retryGracePeriod time.Duration
+
+	// GH-2201: TaskChecker verifies whether an issue is still queued/in-progress
+	// before allowing retry after the grace period expires.
+	taskChecker TaskChecker
 }
 
 // PollerOption configures a Poller
@@ -149,6 +165,22 @@ func WithProcessedStore(store ProcessedStore) PollerOption {
 	}
 }
 
+// WithRetryGracePeriod sets the minimum time that must elapse after an issue is
+// marked processed before the retry path will allow re-dispatch. Default: 5 minutes.
+func WithRetryGracePeriod(d time.Duration) PollerOption {
+	return func(p *Poller) {
+		p.retryGracePeriod = d
+	}
+}
+
+// WithTaskChecker sets the task checker used to verify whether an issue is still
+// queued or in-progress before allowing retry after the grace period expires.
+func WithTaskChecker(tc TaskChecker) PollerOption {
+	return func(p *Poller) {
+		p.taskChecker = tc
+	}
+}
+
 // WithMaxConcurrent sets the maximum number of parallel issue executions
 func WithMaxConcurrent(n int) PollerOption {
 	return func(p *Poller) {
@@ -167,17 +199,18 @@ func NewPoller(client *Client, repo string, label string, interval time.Duration
 	}
 
 	p := &Poller{
-		client:         client,
-		owner:          parts[0],
-		repo:           parts[1],
-		label:          label,
-		interval:       interval,
-		processed:      make(map[int]bool),
-		logger:         logging.WithComponent("github-poller"),
-		executionMode:  ExecutionModeAuto, // Default matches config.DefaultExecutionConfig()
-		waitForMerge:   true,
-		prPollInterval: 30 * time.Second,
-		prTimeout:      1 * time.Hour,
+		client:           client,
+		owner:            parts[0],
+		repo:             parts[1],
+		label:            label,
+		interval:         interval,
+		processed:        make(map[int]time.Time),
+		logger:           logging.WithComponent("github-poller"),
+		executionMode:    ExecutionModeAuto, // Default matches config.DefaultExecutionConfig()
+		waitForMerge:     true,
+		prPollInterval:   30 * time.Second,
+		prTimeout:        1 * time.Hour,
+		retryGracePeriod: 5 * time.Minute, // GH-2201: default grace period
 	}
 
 	for _, opt := range opts {
@@ -200,7 +233,7 @@ func NewPoller(client *Client, repo string, label string, interval time.Duration
 		} else if len(loaded) > 0 {
 			p.mu.Lock()
 			for num := range loaded {
-				p.processed[num] = true
+				p.processed[num] = time.Now()
 			}
 			p.mu.Unlock()
 			p.logger.Info("Loaded processed issues from store", slog.Int("count", len(loaded)))
@@ -510,11 +543,31 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 
 		// Check if previously processed
 		p.mu.RLock()
-		processed := p.processed[issue.Number]
+		processedAt, processed := p.processed[issue.Number]
 		p.mu.RUnlock()
 
 		// If processed but no status labels, allow retry (pilot-failed was removed)
 		if processed {
+			// GH-2201: Check grace period before allowing retry
+			if p.retryGracePeriod > 0 && time.Since(processedAt) < p.retryGracePeriod {
+				p.logger.Debug("Issue within retry grace period, skipping",
+					slog.Int("number", issue.Number),
+					slog.Duration("elapsed", time.Since(processedAt)),
+					slog.Duration("grace_period", p.retryGracePeriod))
+				continue
+			}
+
+			// GH-2201: Check if task is still queued/in-progress
+			if p.taskChecker != nil {
+				taskID := fmt.Sprintf("GH-%d", issue.Number)
+				if p.taskChecker.IsTaskQueued(taskID) {
+					p.logger.Debug("Issue still queued/in-progress, skipping retry",
+						slog.Int("number", issue.Number),
+						slog.String("task_id", taskID))
+					continue
+				}
+			}
+
 			p.logger.Info("Issue was processed but status labels removed, allowing retry",
 				slog.Int("number", issue.Number))
 			p.mu.Lock()
@@ -678,11 +731,31 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 
 		// Check if already processed
 		p.mu.RLock()
-		processed := p.processed[issue.Number]
+		processedAt, processed := p.processed[issue.Number]
 		p.mu.RUnlock()
 
 		// If processed but no status labels, allow retry (pilot-failed was removed)
 		if processed {
+			// GH-2201: Check grace period before allowing retry
+			if p.retryGracePeriod > 0 && time.Since(processedAt) < p.retryGracePeriod {
+				p.logger.Debug("Issue within retry grace period, skipping",
+					slog.Int("number", issue.Number),
+					slog.Duration("elapsed", time.Since(processedAt)),
+					slog.Duration("grace_period", p.retryGracePeriod))
+				continue
+			}
+
+			// GH-2201: Check if task is still queued/in-progress
+			if p.taskChecker != nil {
+				taskID := fmt.Sprintf("GH-%d", issue.Number)
+				if p.taskChecker.IsTaskQueued(taskID) {
+					p.logger.Debug("Issue still queued/in-progress, skipping retry",
+						slog.Int("number", issue.Number),
+						slog.String("task_id", taskID))
+					continue
+				}
+			}
+
 			p.logger.Info("Issue was processed but status labels removed, allowing retry",
 				slog.Int("number", issue.Number))
 			p.mu.Lock()
@@ -802,10 +875,10 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 	}
 }
 
-// markProcessed marks an issue as processed
+// markProcessed marks an issue as processed with the current timestamp
 func (p *Poller) markProcessed(number int) {
 	p.mu.Lock()
-	p.processed[number] = true
+	p.processed[number] = time.Now()
 	p.mu.Unlock()
 
 	// Persist to store if available
@@ -854,7 +927,8 @@ func (p *Poller) WaitForActive() {
 func (p *Poller) IsProcessed(number int) bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return p.processed[number]
+	_, ok := p.processed[number]
+	return ok
 }
 
 // ProcessedCount returns the number of processed issues
@@ -867,7 +941,7 @@ func (p *Poller) ProcessedCount() int {
 // Reset clears the processed issues map
 func (p *Poller) Reset() {
 	p.mu.Lock()
-	p.processed = make(map[int]bool)
+	p.processed = make(map[int]time.Time)
 	p.mu.Unlock()
 }
 

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -519,6 +519,7 @@ func TestPoller_CheckForNewIssues_AllowsRetryWhenLabelsRemoved(t *testing.T) {
 
 	var callCount int32
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithRetryGracePeriod(0), // GH-2201: disable grace period for test
 		WithOnIssue(func(ctx context.Context, issue *Issue) error {
 			atomic.AddInt32(&callCount, 1)
 			return nil
@@ -790,7 +791,9 @@ func TestPoller_FindOldestUnprocessedIssue_AllowsRetryWhenFailedLabelRemoved(t *
 	defer server.Close()
 
 	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
-	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithRetryGracePeriod(0), // GH-2201: disable grace period for test
+	)
 
 	// Simulate: issue was processed (failed) but pilot-failed label was removed
 	poller.markProcessed(1)
@@ -1706,6 +1709,7 @@ func TestPoller_CheckForNewIssues_SkipsRetryWithMergedPRs(t *testing.T) {
 
 	var callCount int32
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithRetryGracePeriod(0), // GH-2201: disable grace period for test
 		WithOnIssue(func(ctx context.Context, issue *Issue) error {
 			atomic.AddInt32(&callCount, 1)
 			return nil
@@ -1750,6 +1754,7 @@ func TestPoller_FindOldestUnprocessedIssue_SkipsRetryWithMergedPRs(t *testing.T)
 	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithExecutionMode(ExecutionModeSequential),
+		WithRetryGracePeriod(0), // GH-2201: disable grace period for test
 	)
 
 	// Pre-mark as processed (simulating previous failed attempt)
@@ -1835,5 +1840,201 @@ func TestPoller_FindOldestUnprocessedIssue_SkipsPullRequests(t *testing.T) {
 	}
 	if issue.Number != 20 {
 		t.Errorf("got issue #%d, want #20 (PR #10 should be skipped)", issue.Number)
+	}
+}
+
+// --- GH-2201: Retry grace period and task checker tests ---
+
+// mockTaskChecker implements TaskChecker for testing
+type mockTaskChecker struct {
+	queued map[string]bool
+}
+
+func (m *mockTaskChecker) IsTaskQueued(taskID string) bool {
+	return m.queued[taskID]
+}
+
+func TestPoller_SkipsRecentlyProcessed(t *testing.T) {
+	issues := []*Issue{
+		{Number: 1, Title: "Issue 1", Labels: []Label{{Name: "pilot"}}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithRetryGracePeriod(10*time.Minute), // Long grace period
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+	)
+
+	// Pre-mark as processed (just now — within grace period)
+	poller.markProcessed(1)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	// Should NOT retry — still within grace period
+	if got := atomic.LoadInt32(&callCount); got != 0 {
+		t.Errorf("callback called %d times, want 0 (should skip recently processed issue)", got)
+	}
+	// Should still be in processed map
+	if !poller.IsProcessed(1) {
+		t.Error("issue should still be in processed map during grace period")
+	}
+}
+
+func TestPoller_AllowsRetryAfterGrace(t *testing.T) {
+	issues := []*Issue{
+		{Number: 1, Title: "Issue 1", Labels: []Label{{Name: "pilot"}}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithRetryGracePeriod(1*time.Millisecond), // Tiny grace period
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+	)
+
+	// Pre-mark as processed, then wait for grace period to expire
+	poller.markProcessed(1)
+	time.Sleep(5 * time.Millisecond)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	// Should retry — grace period expired
+	if got := atomic.LoadInt32(&callCount); got != 1 {
+		t.Errorf("callback called %d times, want 1 (should retry after grace period)", got)
+	}
+}
+
+func TestPoller_SkipsQueuedTask(t *testing.T) {
+	issues := []*Issue{
+		{Number: 42, Title: "Issue 42", Labels: []Label{{Name: "pilot"}}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	checker := &mockTaskChecker{queued: map[string]bool{"GH-42": true}}
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithRetryGracePeriod(0), // No grace period — only task checker blocks
+		WithTaskChecker(checker),
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+	)
+
+	// Pre-mark as processed
+	poller.markProcessed(42)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	// Should NOT retry — task is still queued
+	if got := atomic.LoadInt32(&callCount); got != 0 {
+		t.Errorf("callback called %d times, want 0 (should skip queued task)", got)
+	}
+	// Should still be in processed map
+	if !poller.IsProcessed(42) {
+		t.Error("issue should still be in processed map when task is queued")
+	}
+}
+
+func TestPoller_AllowsRetryCompletedTask(t *testing.T) {
+	issues := []*Issue{
+		{Number: 42, Title: "Issue 42", Labels: []Label{{Name: "pilot"}}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	checker := &mockTaskChecker{queued: map[string]bool{}} // Not queued
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithRetryGracePeriod(0), // No grace period
+		WithTaskChecker(checker),
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+	)
+
+	// Pre-mark as processed
+	poller.markProcessed(42)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	// Should retry — task is not queued and grace period is 0
+	if got := atomic.LoadInt32(&callCount); got != 1 {
+		t.Errorf("callback called %d times, want 1 (should retry completed task)", got)
+	}
+}
+
+func TestPoller_ProcessedMapStoresTimestamps(t *testing.T) {
+	client := NewClient(testutil.FakeGitHubToken)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	before := time.Now()
+	poller.markProcessed(1)
+	after := time.Now()
+
+	poller.mu.RLock()
+	ts, ok := poller.processed[1]
+	poller.mu.RUnlock()
+
+	if !ok {
+		t.Fatal("issue 1 should be in processed map")
+	}
+	if ts.Before(before) || ts.After(after) {
+		t.Errorf("processed timestamp %v not between %v and %v", ts, before, after)
+	}
+
+	// Verify IsProcessed still works
+	if !poller.IsProcessed(1) {
+		t.Error("IsProcessed should return true")
+	}
+	if poller.IsProcessed(2) {
+		t.Error("IsProcessed should return false for unprocessed issue")
+	}
+
+	// Verify Reset clears timestamps
+	poller.Reset()
+	if poller.IsProcessed(1) {
+		t.Error("IsProcessed should return false after Reset")
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2201.

Closes #2201

## Changes

Implement the full fix in a single subtask: (a) change `processed map[int]bool` → `map[int]time.Time` in `internal/adapters/github/poller.go` with all downstream adjustments (init, markProcessed, IsProcessed, LoadProcessedIssues, ClearProcessed); (b) add `retryGracePeriod` field with 5-minute default and `WithRetryGracePeriod` option; (c) insert grace-period check in both retry paths (parallel ~line 684, sequential ~line 517) before unmarking; (d) define `TaskChecker` interface and `WithTaskChecker` option, add the queued-check after grace period passes in both retry paths; (e) wire `github.WithTaskChecker(store)` in `cmd/pilot/main.go` ~line 1997; (f) add 5 new table-driven tests (`SkipsRecentlyProcessed`, `AllowsRetryAfterGrace`, `SkipsQueuedTask`, `AllowsRetryCompletedTask`, `ProcessedMapStoresTimestamps`) and update existing `TestPoller_CheckForNewIssues_AllowsRetryWhenLabelsRemoved` with `WithRetryGracePeriod(0)` in `internal/adapters/github/poller_test.go`; (g) verify `make test` and `make lint` pass.