### PR TITLE
GH-2201: Add retry grace period and TaskChecker to GitHub poller

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -719,6 +719,11 @@ Examples:
 						pollerOpts = append(pollerOpts, github.WithProcessedStore(gwAutopilotStateStore))
 					}
 
+					// GH-2201: Wire task checker to prevent retry of queued/running tasks
+					if gwStore != nil {
+						pollerOpts = append(pollerOpts, github.WithTaskChecker(gwStore))
+					}
+
 					// Create rate limit retry scheduler
 					repoParts := strings.Split(cfg.Adapters.GitHub.Repo, "/")
 					if len(repoParts) != 2 {
@@ -1937,6 +1942,11 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 				// GH-726: Wire processed issue persistence
 				if autopilotStateStore != nil {
 					pollerOpts = append(pollerOpts, github.WithProcessedStore(autopilotStateStore))
+				}
+
+				// GH-2201: Wire task checker to prevent retry of queued/running tasks
+				if store != nil {
+					pollerOpts = append(pollerOpts, github.WithTaskChecker(store))
 				}
 
 				// Capture variables for closures

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -37,6 +37,12 @@ type ProcessedStore interface {
 	LoadProcessedIssues() (map[int]bool, error)
 }
 
+// TaskChecker checks whether a task is currently queued or running.
+// Used to prevent retry of issues that are still being executed.
+type TaskChecker interface {
+	IsTaskQueued(taskID string) (bool, error)
+}
+
 // IssueResult is returned by the issue handler with PR information
 type IssueResult struct {
 	Success    bool
@@ -54,7 +60,7 @@ type Poller struct {
 	repo      string
 	label     string
 	interval  time.Duration
-	processed map[int]bool
+	processed map[int]time.Time
 	mu        sync.RWMutex
 	onIssue   func(ctx context.Context, issue *Issue) error
 	// onIssueWithResult is called for sequential mode, returns PR info
@@ -83,6 +89,12 @@ type Poller struct {
 
 	// Persistent processed store (optional)
 	processedStore ProcessedStore
+
+	// Retry grace period: minimum time after marking processed before allowing retry
+	retryGracePeriod time.Duration
+
+	// TaskChecker checks if a task is currently queued/running (optional)
+	taskChecker TaskChecker
 }
 
 // PollerOption configures a Poller
@@ -149,6 +161,22 @@ func WithProcessedStore(store ProcessedStore) PollerOption {
 	}
 }
 
+// WithRetryGracePeriod sets the minimum time after marking an issue processed
+// before allowing it to be retried. Default is 5 minutes.
+func WithRetryGracePeriod(d time.Duration) PollerOption {
+	return func(p *Poller) {
+		p.retryGracePeriod = d
+	}
+}
+
+// WithTaskChecker sets the task checker used to verify whether a task
+// is currently queued or running before allowing retry.
+func WithTaskChecker(tc TaskChecker) PollerOption {
+	return func(p *Poller) {
+		p.taskChecker = tc
+	}
+}
+
 // WithMaxConcurrent sets the maximum number of parallel issue executions
 func WithMaxConcurrent(n int) PollerOption {
 	return func(p *Poller) {
@@ -167,17 +195,18 @@ func NewPoller(client *Client, repo string, label string, interval time.Duration
 	}
 
 	p := &Poller{
-		client:         client,
-		owner:          parts[0],
-		repo:           parts[1],
-		label:          label,
-		interval:       interval,
-		processed:      make(map[int]bool),
-		logger:         logging.WithComponent("github-poller"),
-		executionMode:  ExecutionModeAuto, // Default matches config.DefaultExecutionConfig()
-		waitForMerge:   true,
-		prPollInterval: 30 * time.Second,
-		prTimeout:      1 * time.Hour,
+		client:           client,
+		owner:            parts[0],
+		repo:             parts[1],
+		label:            label,
+		interval:         interval,
+		processed:        make(map[int]time.Time),
+		logger:           logging.WithComponent("github-poller"),
+		executionMode:    ExecutionModeAuto, // Default matches config.DefaultExecutionConfig()
+		waitForMerge:     true,
+		prPollInterval:   30 * time.Second,
+		prTimeout:        1 * time.Hour,
+		retryGracePeriod: 5 * time.Minute,
 	}
 
 	for _, opt := range opts {
@@ -200,7 +229,7 @@ func NewPoller(client *Client, repo string, label string, interval time.Duration
 		} else if len(loaded) > 0 {
 			p.mu.Lock()
 			for num := range loaded {
-				p.processed[num] = true
+				p.processed[num] = time.Now()
 			}
 			p.mu.Unlock()
 			p.logger.Info("Loaded processed issues from store", slog.Int("count", len(loaded)))
@@ -510,11 +539,35 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 
 		// Check if previously processed
 		p.mu.RLock()
-		processed := p.processed[issue.Number]
+		processedAt, processed := p.processed[issue.Number]
 		p.mu.RUnlock()
 
 		// If processed but no status labels, allow retry (pilot-failed was removed)
 		if processed {
+			// GH-2201: Skip retry if within grace period
+			if p.retryGracePeriod > 0 && time.Since(processedAt) < p.retryGracePeriod {
+				p.logger.Debug("Issue within retry grace period, skipping",
+					slog.Int("number", issue.Number),
+					slog.Duration("elapsed", time.Since(processedAt)),
+					slog.Duration("grace_period", p.retryGracePeriod))
+				continue
+			}
+
+			// GH-2201: Skip retry if task is still queued/running
+			if p.taskChecker != nil {
+				taskID := fmt.Sprintf("GH-%d", issue.Number)
+				queued, err := p.taskChecker.IsTaskQueued(taskID)
+				if err != nil {
+					p.logger.Warn("Failed to check task queue status",
+						slog.Int("number", issue.Number),
+						slog.Any("error", err))
+				} else if queued {
+					p.logger.Info("Issue task still queued/running, skipping retry",
+						slog.Int("number", issue.Number))
+					continue
+				}
+			}
+
 			p.logger.Info("Issue was processed but status labels removed, allowing retry",
 				slog.Int("number", issue.Number))
 			p.mu.Lock()
@@ -678,11 +731,35 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 
 		// Check if already processed
 		p.mu.RLock()
-		processed := p.processed[issue.Number]
+		processedAt, processed := p.processed[issue.Number]
 		p.mu.RUnlock()
 
 		// If processed but no status labels, allow retry (pilot-failed was removed)
 		if processed {
+			// GH-2201: Skip retry if within grace period
+			if p.retryGracePeriod > 0 && time.Since(processedAt) < p.retryGracePeriod {
+				p.logger.Debug("Issue within retry grace period, skipping",
+					slog.Int("number", issue.Number),
+					slog.Duration("elapsed", time.Since(processedAt)),
+					slog.Duration("grace_period", p.retryGracePeriod))
+				continue
+			}
+
+			// GH-2201: Skip retry if task is still queued/running
+			if p.taskChecker != nil {
+				taskID := fmt.Sprintf("GH-%d", issue.Number)
+				queued, err := p.taskChecker.IsTaskQueued(taskID)
+				if err != nil {
+					p.logger.Warn("Failed to check task queue status",
+						slog.Int("number", issue.Number),
+						slog.Any("error", err))
+				} else if queued {
+					p.logger.Info("Issue task still queued/running, skipping retry",
+						slog.Int("number", issue.Number))
+					continue
+				}
+			}
+
 			p.logger.Info("Issue was processed but status labels removed, allowing retry",
 				slog.Int("number", issue.Number))
 			p.mu.Lock()
@@ -802,10 +879,10 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 	}
 }
 
-// markProcessed marks an issue as processed
+// markProcessed marks an issue as processed with the current timestamp
 func (p *Poller) markProcessed(number int) {
 	p.mu.Lock()
-	p.processed[number] = true
+	p.processed[number] = time.Now()
 	p.mu.Unlock()
 
 	// Persist to store if available
@@ -854,7 +931,8 @@ func (p *Poller) WaitForActive() {
 func (p *Poller) IsProcessed(number int) bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return p.processed[number]
+	_, ok := p.processed[number]
+	return ok
 }
 
 // ProcessedCount returns the number of processed issues
@@ -867,7 +945,7 @@ func (p *Poller) ProcessedCount() int {
 // Reset clears the processed issues map
 func (p *Poller) Reset() {
 	p.mu.Lock()
-	p.processed = make(map[int]bool)
+	p.processed = make(map[int]time.Time)
 	p.mu.Unlock()
 }
 

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -523,6 +523,7 @@ func TestPoller_CheckForNewIssues_AllowsRetryWhenLabelsRemoved(t *testing.T) {
 			atomic.AddInt32(&callCount, 1)
 			return nil
 		}),
+		WithRetryGracePeriod(0), // GH-2201: Disable grace period for test
 	)
 
 	// Pre-mark as processed (simulating previous failed attempt)
@@ -534,6 +535,199 @@ func TestPoller_CheckForNewIssues_AllowsRetryWhenLabelsRemoved(t *testing.T) {
 	// Should retry since labels were removed
 	if got := atomic.LoadInt32(&callCount); got != 1 {
 		t.Errorf("callback called %d times, want 1 (should retry after labels removed)", got)
+	}
+}
+
+// mockTaskChecker implements TaskChecker for tests.
+type mockTaskChecker struct {
+	queued map[string]bool
+}
+
+func (m *mockTaskChecker) IsTaskQueued(taskID string) (bool, error) {
+	return m.queued[taskID], nil
+}
+
+func TestPoller_SkipsRecentlyProcessed(t *testing.T) {
+	issues := []*Issue{
+		{Number: 1, Title: "Issue 1", Labels: []Label{{Name: "pilot"}}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+		WithRetryGracePeriod(10*time.Minute), // Long grace period
+	)
+
+	// Pre-mark as processed (simulating recent processing)
+	poller.markProcessed(1)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	// Should NOT retry because grace period hasn't elapsed
+	if got := atomic.LoadInt32(&callCount); got != 0 {
+		t.Errorf("callback called %d times, want 0 (should skip during grace period)", got)
+	}
+}
+
+func TestPoller_AllowsRetryAfterGrace(t *testing.T) {
+	issues := []*Issue{
+		{Number: 1, Title: "Issue 1", Labels: []Label{{Name: "pilot"}}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+		WithRetryGracePeriod(1*time.Millisecond), // Very short grace period
+	)
+
+	// Pre-mark as processed with a timestamp in the past
+	poller.mu.Lock()
+	poller.processed[1] = time.Now().Add(-1 * time.Second)
+	poller.mu.Unlock()
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	// Should retry because grace period has elapsed
+	if got := atomic.LoadInt32(&callCount); got != 1 {
+		t.Errorf("callback called %d times, want 1 (should retry after grace period)", got)
+	}
+}
+
+func TestPoller_SkipsQueuedTask(t *testing.T) {
+	issues := []*Issue{
+		{Number: 42, Title: "Issue 42", Labels: []Label{{Name: "pilot"}}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	checker := &mockTaskChecker{queued: map[string]bool{"GH-42": true}}
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+		WithRetryGracePeriod(0),
+		WithTaskChecker(checker),
+	)
+
+	// Pre-mark as processed
+	poller.mu.Lock()
+	poller.processed[42] = time.Now().Add(-1 * time.Hour)
+	poller.mu.Unlock()
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	// Should NOT retry because task is still queued
+	if got := atomic.LoadInt32(&callCount); got != 0 {
+		t.Errorf("callback called %d times, want 0 (should skip queued task)", got)
+	}
+}
+
+func TestPoller_AllowsRetryCompletedTask(t *testing.T) {
+	issues := []*Issue{
+		{Number: 42, Title: "Issue 42", Labels: []Label{{Name: "pilot"}}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	// Task is NOT queued (completed)
+	checker := &mockTaskChecker{queued: map[string]bool{}}
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+		WithRetryGracePeriod(0),
+		WithTaskChecker(checker),
+	)
+
+	// Pre-mark as processed with old timestamp
+	poller.mu.Lock()
+	poller.processed[42] = time.Now().Add(-1 * time.Hour)
+	poller.mu.Unlock()
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	// Should retry because task is completed and grace period elapsed
+	if got := atomic.LoadInt32(&callCount); got != 1 {
+		t.Errorf("callback called %d times, want 1 (should retry completed task)", got)
+	}
+}
+
+func TestPoller_ProcessedMapStoresTimestamps(t *testing.T) {
+	client := NewClient(testutil.FakeGitHubToken)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	before := time.Now()
+	poller.markProcessed(1)
+	after := time.Now()
+
+	poller.mu.RLock()
+	ts, ok := poller.processed[1]
+	poller.mu.RUnlock()
+
+	if !ok {
+		t.Fatal("issue 1 not found in processed map")
+	}
+
+	if ts.Before(before) || ts.After(after) {
+		t.Errorf("processed timestamp %v not between %v and %v", ts, before, after)
+	}
+
+	// Verify IsProcessed still works
+	if !poller.IsProcessed(1) {
+		t.Error("IsProcessed(1) = false, want true")
+	}
+	if poller.IsProcessed(2) {
+		t.Error("IsProcessed(2) = true, want false")
+	}
+
+	// Verify ClearProcessed works
+	poller.ClearProcessed(1)
+	if poller.IsProcessed(1) {
+		t.Error("IsProcessed(1) = true after ClearProcessed, want false")
 	}
 }
 
@@ -790,7 +984,9 @@ func TestPoller_FindOldestUnprocessedIssue_AllowsRetryWhenFailedLabelRemoved(t *
 	defer server.Close()
 
 	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
-	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithRetryGracePeriod(0), // GH-2201: Disable grace period for test
+	)
 
 	// Simulate: issue was processed (failed) but pilot-failed label was removed
 	poller.markProcessed(1)
@@ -1710,6 +1906,7 @@ func TestPoller_CheckForNewIssues_SkipsRetryWithMergedPRs(t *testing.T) {
 			atomic.AddInt32(&callCount, 1)
 			return nil
 		}),
+		WithRetryGracePeriod(0), // GH-2201: Disable grace period for test
 	)
 
 	// Pre-mark as processed (simulating previous failed attempt)
@@ -1750,6 +1947,7 @@ func TestPoller_FindOldestUnprocessedIssue_SkipsRetryWithMergedPRs(t *testing.T)
 	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithExecutionMode(ExecutionModeSequential),
+		WithRetryGracePeriod(0), // GH-2201: Disable grace period for test
 	)
 
 	// Pre-mark as processed (simulating previous failed attempt)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2201.

Closes #2201

## Changes

GitHub Issue #2201: Add retry grace period and TaskChecker to GitHub poller

Parent: GH-2200

Implement the full fix in a single subtask: (a) change `processed map[int]bool` → `map[int]time.Time` in `internal/adapters/github/poller.go` with all downstream adjustments (init, markProcessed, IsProcessed, LoadProcessedIssues, ClearProcessed); (b) add `retryGracePeriod` field with 5-minute default and `WithRetryGracePeriod` option; (c) insert grace-period check in both retry paths (parallel ~line 684, sequential ~line 517) before unmarking; (d) define `TaskChecker` interface and `WithTaskChecker` option, add the queued-check after grace period passes in both retry paths; (e) wire `github.WithTaskChecker(store)` in `cmd/pilot/main.go` ~line 1997; (f) add 5 new table-driven tests (`SkipsRecentlyProcessed`, `AllowsRetryAfterGrace`, `SkipsQueuedTask`, `AllowsRetryCompletedTask`, `ProcessedMapStoresTimestamps`) and update existing `TestPoller_CheckForNewIssues_AllowsRetryWhenLabelsRemoved` with `WithRetryGracePeriod(0)` in `internal/adapters/github/poller_test.go`; (g) verify `make test` and `make lint` pass.