### PR TITLE
GH-2204: fix(alerts): task_stuck floods Slack — progress never emitted, per-rule cooldown rotates, no orphan cleanup

### DIFF
--- a/docs/content/features/alerts.mdx
+++ b/docs/content/features/alerts.mdx
@@ -417,10 +417,11 @@ Cooldowns prevent alert fatigue by limiting how often a rule can fire.
 
 ### How Cooldowns Work
 
-1. **Per-rule tracking** — Each rule maintains its own last-fired timestamp
-2. **Check before firing** — The engine calls `shouldFire()` before dispatching an alert
-3. **Zero cooldown** — A cooldown of `0` means fire every time (no rate limiting)
-4. **Independent tracking** — Different rules have independent cooldown timers
+1. **Per-rule tracking** — Most rules maintain a per-rule last-fired timestamp
+2. **Per-task tracking (stuck tasks)** — The `task_stuck` rule uses per-task cooldowns so that multiple stuck tasks can all fire independently in the same evaluation cycle, rather than a single task blocking alerts for all others
+3. **Check before firing** — The engine checks cooldown state before dispatching an alert
+4. **Zero cooldown** — A cooldown of `0` means fire every time (no rate limiting)
+5. **Progress resets cooldown** — For stuck-task alerts, receiving a progress event resets the per-task cooldown, so the task can re-alert if it gets stuck again later
 
 ```
 Rule fires at t=0
@@ -429,6 +430,10 @@ Rule fires at t=0
 ├── t=15m: New event matches rule → Cooldown expired, fire alert
 └── t=16m: New event matches rule → Cooldown active (15m), skip
 ```
+
+### Orphan Eviction
+
+Tasks tracked for stuck-task detection are automatically evicted if they remain stuck for **4× the configured threshold** (e.g., 40 minutes with the default 10-minute threshold). This prevents zombie entries from accumulating when task completion/failure events are missed (e.g., due to process crashes or hot upgrades). Evictions are logged at `WARN` level with the task ID.
 
 ### When to Use Which Cooldown
 

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -30,9 +30,10 @@ type Engine struct {
 }
 
 type progressState struct {
-	Progress  int
-	UpdatedAt time.Time
-	Phase     string
+	Progress      int
+	UpdatedAt     time.Time
+	Phase         string
+	LastAlertedAt time.Time // Per-task alert cooldown (GH-2204)
 }
 
 // Event represents an event that might trigger an alert
@@ -212,6 +213,8 @@ func (e *Engine) handleTaskProgress(event Event) {
 			Progress:  event.Progress,
 			UpdatedAt: event.Timestamp,
 			Phase:     event.Phase,
+			// Reset per-task alert cooldown when progress advances (GH-2204)
+			LastAlertedAt: time.Time{},
 		}
 	}
 }
@@ -366,14 +369,16 @@ func (e *Engine) checkStuckTasks(ctx context.Context) {
 }
 
 func (e *Engine) evaluateStuckTasks(ctx context.Context) {
+	now := time.Now()
+
+	// Collect orphan IDs under read lock, then evict under write lock (GH-2204)
 	e.mu.RLock()
 	tasks := make(map[string]progressState)
+	var orphans []string
 	for k, v := range e.taskLastProgress {
 		tasks[k] = v
 	}
 	e.mu.RUnlock()
-
-	now := time.Now()
 
 	for _, rule := range e.config.Rules {
 		if !rule.Enabled || rule.Type != AlertTypeTaskStuck {
@@ -385,21 +390,61 @@ func (e *Engine) evaluateStuckTasks(ctx context.Context) {
 			threshold = 10 * time.Minute
 		}
 
+		cooldown := rule.Cooldown
+		orphanThreshold := 4 * threshold // Evict entries stuck for 4× the threshold (GH-2204)
+
 		for taskID, state := range tasks {
-			if now.Sub(state.UpdatedAt) > threshold && e.shouldFire(rule) {
-				event := Event{
-					Type:      EventTypeTaskProgress,
-					TaskID:    taskID,
-					Phase:     state.Phase,
-					Progress:  state.Progress,
-					Timestamp: now,
-				}
-				alert := e.createAlert(rule, event,
-					fmt.Sprintf("Task %s stuck at %d%% (%s) for %v",
-						taskID, state.Progress, state.Phase, now.Sub(state.UpdatedAt).Round(time.Minute)))
-				e.fireAlert(ctx, rule, alert)
+			stuckDuration := now.Sub(state.UpdatedAt)
+
+			// Orphan eviction: remove entries that have been stuck far too long (GH-2204)
+			if stuckDuration > orphanThreshold {
+				orphans = append(orphans, taskID)
+				e.logger.Warn("evicting orphaned stuck-task entry",
+					"task_id", taskID,
+					"stuck_for", stuckDuration.Round(time.Minute),
+					"orphan_threshold", orphanThreshold,
+				)
+				continue
 			}
+
+			if stuckDuration <= threshold {
+				continue
+			}
+
+			// Per-task cooldown: skip if already alerted recently for THIS task (GH-2204)
+			if !state.LastAlertedAt.IsZero() && cooldown > 0 && now.Sub(state.LastAlertedAt) < cooldown {
+				continue
+			}
+
+			event := Event{
+				Type:      EventTypeTaskProgress,
+				TaskID:    taskID,
+				Phase:     state.Phase,
+				Progress:  state.Progress,
+				Timestamp: now,
+			}
+			alert := e.createAlert(rule, event,
+				fmt.Sprintf("Task %s stuck at %d%% (%s) for %v",
+					taskID, state.Progress, state.Phase, stuckDuration.Round(time.Minute)))
+			e.fireAlert(ctx, rule, alert)
+
+			// Record per-task alert time (GH-2204)
+			e.mu.Lock()
+			if s, ok := e.taskLastProgress[taskID]; ok {
+				s.LastAlertedAt = now
+				e.taskLastProgress[taskID] = s
+			}
+			e.mu.Unlock()
 		}
+	}
+
+	// Evict orphans
+	if len(orphans) > 0 {
+		e.mu.Lock()
+		for _, id := range orphans {
+			delete(e.taskLastProgress, id)
+		}
+		e.mu.Unlock()
 	}
 }
 

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -3,6 +3,7 @@ package alerts
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"testing"
@@ -1689,7 +1690,7 @@ func TestEngine_EvaluateStuckTasks(t *testing.T) {
 				Type:    AlertTypeTaskStuck,
 				Enabled: true,
 				Condition: RuleCondition{
-					ProgressUnchangedFor: 1 * time.Millisecond, // Very short for testing
+					ProgressUnchangedFor: 5 * time.Minute,
 				},
 				Severity: SeverityWarning,
 				Channels: []string{"test-channel"},
@@ -1704,12 +1705,12 @@ func TestEngine_EvaluateStuckTasks(t *testing.T) {
 
 	engine := NewEngine(config, WithDispatcher(dispatcher))
 
-	// Add a stuck task
+	// Add a stuck task (10 min > 5 min threshold but < 20 min orphan threshold)
 	engine.mu.Lock()
 	engine.taskLastProgress["TASK-STUCK"] = progressState{
 		Progress:  50,
 		Phase:     "coding",
-		UpdatedAt: time.Now().Add(-1 * time.Hour), // Old timestamp - will be stuck
+		UpdatedAt: time.Now().Add(-10 * time.Minute),
 	}
 	engine.mu.Unlock()
 
@@ -1790,7 +1791,7 @@ func TestEngine_EvaluateStuckTasks_DisabledRule(t *testing.T) {
 				Type:    AlertTypeTaskStuck,
 				Enabled: false, // Disabled
 				Condition: RuleCondition{
-					ProgressUnchangedFor: 1 * time.Millisecond,
+					ProgressUnchangedFor: 5 * time.Minute,
 				},
 				Severity: SeverityWarning,
 				Channels: []string{"test-channel"},
@@ -1805,12 +1806,12 @@ func TestEngine_EvaluateStuckTasks_DisabledRule(t *testing.T) {
 
 	engine := NewEngine(config, WithDispatcher(dispatcher))
 
-	// Add a stuck task
+	// Add a stuck task (10 min > 5 min threshold, < 20 min orphan)
 	engine.mu.Lock()
 	engine.taskLastProgress["TASK-STUCK"] = progressState{
 		Progress:  50,
 		Phase:     "coding",
-		UpdatedAt: time.Now().Add(-1 * time.Hour),
+		UpdatedAt: time.Now().Add(-10 * time.Minute),
 	}
 	engine.mu.Unlock()
 
@@ -1850,12 +1851,12 @@ func TestEngine_EvaluateStuckTasks_WrongRuleType(t *testing.T) {
 
 	engine := NewEngine(config, WithDispatcher(dispatcher))
 
-	// Add a stuck task
+	// Add a stuck task (10 min > default 10 min threshold won't fire, but rule type is wrong anyway)
 	engine.mu.Lock()
 	engine.taskLastProgress["TASK-STUCK"] = progressState{
 		Progress:  50,
 		Phase:     "coding",
-		UpdatedAt: time.Now().Add(-1 * time.Hour),
+		UpdatedAt: time.Now().Add(-15 * time.Minute),
 	}
 	engine.mu.Unlock()
 
@@ -1868,6 +1869,309 @@ func TestEngine_EvaluateStuckTasks_WrongRuleType(t *testing.T) {
 	alerts := mockCh.getAlerts()
 	if len(alerts) != 0 {
 		t.Errorf("expected 0 alerts (wrong rule type), got %d", len(alerts))
+	}
+}
+
+// =============================================================================
+// GH-2204: Per-task cooldown, multi-task alert, orphan eviction tests
+// =============================================================================
+
+func TestEngine_EvaluateStuckTasks_MultipleTasksAllFire(t *testing.T) {
+	// Bug 2 regression: with per-rule cooldown, only 1 of N stuck tasks would fire.
+	// With per-task cooldown, all N should fire on the same cycle.
+	config := &AlertConfig{
+		Enabled: true,
+		Channels: []ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []AlertRule{
+			{
+				Name:    "task_stuck",
+				Type:    AlertTypeTaskStuck,
+				Enabled: true,
+				Condition: RuleCondition{
+					ProgressUnchangedFor: 5 * time.Minute,
+				},
+				Severity: SeverityWarning,
+				Channels: []string{"test-channel"},
+				Cooldown: 15 * time.Minute,
+			},
+		},
+	}
+
+	mockCh := newMockChannel("test-channel", "webhook")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	engine := NewEngine(config, WithDispatcher(dispatcher))
+
+	// Add 10 stuck tasks (all between threshold and orphan threshold)
+	engine.mu.Lock()
+	for i := 0; i < 10; i++ {
+		engine.taskLastProgress[fmt.Sprintf("GH-%d", i)] = progressState{
+			Progress:  0,
+			Phase:     "",
+			UpdatedAt: time.Now().Add(-10 * time.Minute), // > 5 min threshold, < 20 min orphan
+		}
+	}
+	engine.mu.Unlock()
+
+	ctx := context.Background()
+	engine.evaluateStuckTasks(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+
+	alerts := mockCh.getAlerts()
+	if len(alerts) != 10 {
+		t.Errorf("expected 10 stuck task alerts (one per task), got %d", len(alerts))
+	}
+}
+
+func TestEngine_EvaluateStuckTasks_PerTaskCooldown(t *testing.T) {
+	// Same task on second cycle within cooldown should NOT re-alert.
+	config := &AlertConfig{
+		Enabled: true,
+		Channels: []ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []AlertRule{
+			{
+				Name:    "task_stuck",
+				Type:    AlertTypeTaskStuck,
+				Enabled: true,
+				Condition: RuleCondition{
+					ProgressUnchangedFor: 5 * time.Minute,
+				},
+				Severity: SeverityWarning,
+				Channels: []string{"test-channel"},
+				Cooldown: 15 * time.Minute,
+			},
+		},
+	}
+
+	mockCh := newMockChannel("test-channel", "webhook")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	engine := NewEngine(config, WithDispatcher(dispatcher))
+
+	engine.mu.Lock()
+	engine.taskLastProgress["GH-100"] = progressState{
+		Progress:  0,
+		UpdatedAt: time.Now().Add(-10 * time.Minute),
+	}
+	engine.mu.Unlock()
+
+	ctx := context.Background()
+
+	// First cycle: should fire
+	engine.evaluateStuckTasks(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	alerts := mockCh.getAlerts()
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert on first cycle, got %d", len(alerts))
+	}
+
+	// Second cycle immediately after: should NOT fire (per-task cooldown)
+	engine.evaluateStuckTasks(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	alerts = mockCh.getAlerts()
+	if len(alerts) != 1 {
+		t.Errorf("expected still 1 alert after second cycle (cooldown), got %d", len(alerts))
+	}
+}
+
+func TestEngine_EvaluateStuckTasks_ProgressResetsCooldown(t *testing.T) {
+	// After progress advances, cooldown resets and task can re-alert if stuck again.
+	config := &AlertConfig{
+		Enabled: true,
+		Channels: []ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []AlertRule{
+			{
+				Name:    "task_stuck",
+				Type:    AlertTypeTaskStuck,
+				Enabled: true,
+				Condition: RuleCondition{
+					ProgressUnchangedFor: 5 * time.Minute,
+				},
+				Severity: SeverityWarning,
+				Channels: []string{"test-channel"},
+				Cooldown: 1 * time.Hour, // Long cooldown
+			},
+		},
+	}
+
+	mockCh := newMockChannel("test-channel", "webhook")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	engine := NewEngine(config, WithDispatcher(dispatcher))
+
+	engine.mu.Lock()
+	engine.taskLastProgress["GH-200"] = progressState{
+		Progress:  0,
+		UpdatedAt: time.Now().Add(-10 * time.Minute),
+	}
+	engine.mu.Unlock()
+
+	ctx := context.Background()
+
+	// First cycle: fires
+	engine.evaluateStuckTasks(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	alerts := mockCh.getAlerts()
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+
+	// Simulate progress event — resets cooldown
+	engine.handleTaskProgress(Event{
+		Type:      EventTypeTaskProgress,
+		TaskID:    "GH-200",
+		Progress:  30,
+		Phase:     "coding",
+		Timestamp: time.Now(),
+	})
+
+	// Simulate getting stuck again (manually set UpdatedAt back)
+	engine.mu.Lock()
+	s := engine.taskLastProgress["GH-200"]
+	s.UpdatedAt = time.Now().Add(-10 * time.Minute)
+	engine.taskLastProgress["GH-200"] = s
+	engine.mu.Unlock()
+
+	// Should fire again because progress reset the cooldown
+	engine.evaluateStuckTasks(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	alerts = mockCh.getAlerts()
+	if len(alerts) != 2 {
+		t.Errorf("expected 2 alerts (cooldown reset by progress), got %d", len(alerts))
+	}
+}
+
+func TestEngine_EvaluateStuckTasks_OrphanEviction(t *testing.T) {
+	// Tasks stuck for 4× threshold should be evicted from the map.
+	config := &AlertConfig{
+		Enabled: true,
+		Channels: []ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []AlertRule{
+			{
+				Name:    "task_stuck",
+				Type:    AlertTypeTaskStuck,
+				Enabled: true,
+				Condition: RuleCondition{
+					ProgressUnchangedFor: 10 * time.Minute,
+				},
+				Severity: SeverityWarning,
+				Channels: []string{"test-channel"},
+				Cooldown: 0,
+			},
+		},
+	}
+
+	mockCh := newMockChannel("test-channel", "webhook")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	logger := slog.Default()
+	engine := NewEngine(config, WithDispatcher(dispatcher), WithLogger(logger))
+
+	// Add an orphaned task: stuck for 50 min > 4 * 10 min = 40 min orphan threshold
+	engine.mu.Lock()
+	engine.taskLastProgress["GH-ORPHAN"] = progressState{
+		Progress:  0,
+		UpdatedAt: time.Now().Add(-50 * time.Minute),
+	}
+	// Also add a non-orphan stuck task: 15 min > 10 min threshold, < 40 min orphan
+	engine.taskLastProgress["GH-STUCK"] = progressState{
+		Progress:  0,
+		UpdatedAt: time.Now().Add(-15 * time.Minute),
+	}
+	engine.mu.Unlock()
+
+	ctx := context.Background()
+	engine.evaluateStuckTasks(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Orphan should be evicted, non-orphan should alert
+	engine.mu.RLock()
+	_, orphanExists := engine.taskLastProgress["GH-ORPHAN"]
+	_, stuckExists := engine.taskLastProgress["GH-STUCK"]
+	engine.mu.RUnlock()
+
+	if orphanExists {
+		t.Error("expected GH-ORPHAN to be evicted from taskLastProgress")
+	}
+	if !stuckExists {
+		t.Error("expected GH-STUCK to still exist in taskLastProgress")
+	}
+
+	alerts := mockCh.getAlerts()
+	if len(alerts) != 1 {
+		t.Errorf("expected 1 alert (only GH-STUCK, orphan evicted), got %d", len(alerts))
+	}
+}
+
+func TestEngine_TaskProgressUpdatesStuckState(t *testing.T) {
+	// Verify that handleTaskProgress updates UpdatedAt so stuck detection resets.
+	config := &AlertConfig{
+		Enabled: true,
+		Channels: []ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []AlertRule{
+			{
+				Name:    "task_stuck",
+				Type:    AlertTypeTaskStuck,
+				Enabled: true,
+				Condition: RuleCondition{
+					ProgressUnchangedFor: 5 * time.Minute,
+				},
+				Severity: SeverityWarning,
+				Channels: []string{"test-channel"},
+				Cooldown: 0,
+			},
+		},
+	}
+
+	mockCh := newMockChannel("test-channel", "webhook")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	engine := NewEngine(config, WithDispatcher(dispatcher))
+
+	// Start a task
+	engine.handleTaskStarted(Event{
+		Type:      EventTypeTaskStarted,
+		TaskID:    "GH-300",
+		Timestamp: time.Now().Add(-10 * time.Minute), // Started 10 min ago
+	})
+
+	// Without progress, it would be stuck. Send a progress event.
+	engine.handleTaskProgress(Event{
+		Type:      EventTypeTaskProgress,
+		TaskID:    "GH-300",
+		Progress:  40,
+		Phase:     "impl",
+		Timestamp: time.Now(), // Fresh timestamp
+	})
+
+	ctx := context.Background()
+	engine.evaluateStuckTasks(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	alerts := mockCh.getAlerts()
+	if len(alerts) != 0 {
+		t.Errorf("expected 0 alerts (progress updated recently), got %d", len(alerts))
 	}
 }
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -3812,6 +3812,15 @@ func (r *Runner) reportProgress(taskID, phase string, progress int, message stri
 		r.taskProgressMu.Unlock()
 	}
 
+	// Emit task progress to alerts engine so stuck-task detection sees updates (GH-2204)
+	r.emitAlertEvent(AlertEvent{
+		Type:      AlertEventTypeTaskProgress,
+		TaskID:    taskID,
+		Phase:     phase,
+		Progress:  progress,
+		Timestamp: time.Now(),
+	})
+
 	// Log progress unless suppressed (e.g., when visual progress display is active)
 	if !r.suppressProgressLogs {
 		r.log.Info("Task progress",


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2204.

Closes #2204

## Changes

GitHub Issue #2204: fix(alerts): task_stuck floods Slack — progress never emitted, per-rule cooldown rotates, no orphan cleanup

## Symptom

Slack channel flooded with `task_stuck` alerts every ~16 minutes, rotating through different task IDs forever:

```
1:07  Task GH-273 stuck at 0% () for 23m0s
1:23  Task GH-273 stuck at 0% () for 39m0s
1:39  Task GH-275 stuck at 0% () for 36m0s
1:55  Task GH-41  stuck at 0% () for 40m0s
2:11  Task GH-25  stuck at 0% () for 52m0s
...
```

Every alert says **0%**. Cadence is exactly 1 min ticker + 15 min cooldown = 16 min between alerts.

## Root cause (three compounding bugs)

### Bug 1: `task_progress` event is never emitted

`AlertEventTypeTaskProgress` is defined in `internal/executor/alerts.go:32` but **no code path ever calls `ProcessEvent` with `EventTypeTaskProgress`**.

`SignalParser.GetLatestProgress` exists in `internal/executor/signal.go:118` but `runner.go` never reads it to forward progress to the alerts engine. Result: `handleTaskStarted` (`internal/alerts/engine.go:194`) writes `Progress=0, UpdatedAt=now`, and `state.UpdatedAt` is never advanced.

**Every task that runs longer than 10 minutes is "stuck at 0%" by definition.**

Verification:

```
$ rg 'AlertEventTypeTaskProgress|EventTypeTaskProgress.*ProcessEvent' internal/ cmd/
internal/executor/alerts.go:32:	AlertEventTypeTaskProgress     AlertEventType = "task_progress"
internal/executor/alerts_test.go:12:		AlertEventTypeTaskProgress,
```
No emit sites. Only the constant definition and the test that enumerates constants.

### Bug 2: Per-rule cooldown rotates through stuck tasks

`internal/alerts/engine.go:368-403` `evaluateStuckTasks` loops over all stuck tasks, but `shouldFire(rule)` (line 407) keys cooldown by `rule.Name` — global per rule, not per task.

With N stuck tasks:
1. First eligible task fires → rule cooldown locks for 15 min
2. All other stuck tasks silently skipped
3. 16 min later (1 min ticker + 15 min cooldown) the next pass picks one
4. Go map iteration is randomized → appears to "rotate" through different task IDs forever

This is exactly what the Slack timeline shows.

### Bug 3: No orphan cleanup in `taskLastProgress`

`taskLastProgress` is only cleared in `handleTaskCompleted` / `handleTaskFailed`. If those events are missed (process killed mid-run, hot upgrade between start and complete, dispatcher path drops the event, panic), the entry sits forever. Combined with Bug 1, every task that ever started becomes a permanent zombie.

## Scope

Fix the alerts engine and wire actual progress events.

### 1. `internal/alerts/engine.go` — per-task dedup + orphan cleanup

- Add `lastAlertedAt` per task (new field on `progressState` or a sibling map). In `evaluateStuckTasks`:
  - Skip task if `lastAlertedAt` exists and `now - lastAlertedAt < rule.Cooldown`
  - Set `lastAlertedAt = now` when firing
  - Clear `lastAlertedAt` whenever progress advances (in `handleTaskProgress`)
- Remove the `shouldFire(rule)` call inside the per-task loop — it shouldn't gate per-task alerts at all.
- Add orphan eviction: in `evaluateStuckTasks`, evict entries where `now - state.UpdatedAt > orphanThreshold` (default `4 * threshold`, e.g. 40 min). Log eviction with task ID.
- Optional: instead of one alert per task, aggregate into a single message per cycle: `"5 tasks stuck >10min: GH-273, GH-275, GH-41, GH-25, GH-280"`. Drastically reduces channel noise. Make this configurable via `rule.Condition.AggregateAlerts: true`.

### 2. Wire `EventTypeTaskProgress` from runner

- In `internal/executor/runner.go`, after parsing each `pilot-signal` JSON block (or at major phase boundaries: planning → executing → gates → push), call `r.alerts.ProcessEvent(alerts.Event{Type: EventTypeTaskProgress, TaskID: ..., Progress: ..., Phase: ..., Timestamp: time.Now()})`.
- Use `SignalParser.GetLatestProgress` to extract from collected signals.
- Minimum: emit at phase transitions even if signal block missing.
- Verify alerts engine has access via `deps.AlertsEngine` or runner.alerts (whichever is wired today — `cmd/pilot/handler_common.go:88` shows the pattern).

### 3. Tests

- `internal/alerts/engine_test.go`:
  - 10 stuck tasks, single cycle → expect 10 fires (or 1 aggregated), not 1.
  - Same task on second cycle within cooldown → expect 0 fires.
  - Same task that makes progress → cooldown reset.
  - Orphan eviction: task untouched for `4 * threshold` → removed from map with log.
- New test: progress event from runner reaches engine and updates `state.UpdatedAt`.

### 4. Docs

- `docs/content/features/alerts.mdx`: document the rule semantics, the new `aggregate_alerts` field, and the orphan eviction behavior.

## Acceptance criteria

- Run a 30-min task with no `pilot-signal` progress blocks: receive **at most one** `task_stuck` alert (not 2+).
- Run 5 tasks stuck simultaneously: receive either 5 individual alerts (no rotation) OR 1 aggregated alert — not 1 per 16 min for 80 min.
- Same stuck task does not re-alert without making progress.
- Killing pilot mid-task and restarting: orphaned entries from previous run don't re-alert (covered by orphan eviction OR by the fact that `taskLastProgress` is in-memory and resets on restart — verify behavior).
- Tests pass: `make test`, `make lint`.

## Out of scope

- Replacing the alert with a heartbeat-based liveness check (separate larger refactor).
- Persisting `taskLastProgress` to SQLite (in-memory is fine; restart wipes it).
- Channel routing (sending stuck-task warnings to a separate `#pilot-alerts` channel) — config-time concern.

## Workaround for users hit by this now

In `~/.pilot/config.yaml`:

```yaml
alerts:
  rules:
    - name: task_stuck
      enabled: false
```

Then restart Pilot. Document this in the release notes.

## Key files

- `internal/alerts/engine.go` — `evaluateStuckTasks`, `shouldFire`, `handleTaskProgress`, `handleTaskStarted`
- `internal/alerts/types.go:209` — default rule
- `internal/executor/alerts.go:32` — unused constant
- `internal/executor/runner.go` — emit `TaskProgress` events
- `internal/executor/signal.go:118` — `GetLatestProgress` to plug in
- `cmd/pilot/handler_common.go:88` — existing emit pattern to mirror