### PR TITLE
GH-2206: fix(docs): navbar stuck at v2.87.2 — docs-version-sync workflow trigger broken (GoReleaser GITHUB_TOKEN limitation)

### DIFF
--- a/.github/workflows/docs-version-sync.yml
+++ b/.github/workflows/docs-version-sync.yml
@@ -1,8 +1,9 @@
 name: Sync Docs Version
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       version:
@@ -27,7 +28,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           else
-            echo "VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+            echo "VERSION=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Close previous version-sync PRs

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -45,7 +45,7 @@ export default async function RootLayout({
               logo={
                 <span style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
                   <img src="/logo.svg" alt="Pilot" height={24} style={{ height: 24, width: 'auto', alignSelf: 'center' }} />
-                  <span style={{ fontSize: '0.5em', opacity: 0.5, fontWeight: 400 }}>v2.87.2</span>
+                  <span style={{ fontSize: '0.5em', opacity: 0.5, fontWeight: 400 }}>v2.90.1</span>
                 </span>
               }
               projectLink="https://github.com/qf-studio/pilot"


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2206.

Closes #2206

## Changes

GitHub Issue #2206: fix(docs): navbar stuck at v2.87.2 — docs-version-sync workflow trigger broken (GoReleaser GITHUB_TOKEN limitation)

## Symptom

The docs site navbar at https://pilot.quantflow.studio shows **v2.87.2** while the released version is **v2.90.1**. Three releases (v2.88, v2.89, v2.90) shipped without updating the badge.

```
$ grep 'v2\.' docs/app/layout.tsx
docs/app/layout.tsx:48:  <span ...>v2.87.2</span>
```

## Root cause (already known, never fixed)

`.github/workflows/docs-version-sync.yml` triggers on `release: published`. GoReleaser publishes releases using `GITHUB_TOKEN`, and **GitHub does not fire downstream workflow events from `GITHUB_TOKEN`-created releases** — this is a documented platform limitation:

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN` will not create a new workflow run.
> — https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

This was identified in March 2026 (v2.75.0 incident) but never fixed structurally — the workflow has been silently no-op for the entire v2.88-v2.90 series.

## Scope

### 1. Bump navbar to v2.90.1 (immediate, unblocks site)

`docs/app/layout.tsx:48`:

```diff
- <span ...>v2.87.2</span>
+ <span ...>v2.90.1</span>
```

### 2. Fix the workflow trigger so this stops recurring

Replace the `release: published` trigger with a tag-push trigger, which fires regardless of which token created the tag:

`.github/workflows/docs-version-sync.yml`:

```diff
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       version:
         description: 'Version tag (e.g. v2.87.2)'
         required: true
```

And update the version-extraction step to read from `github.ref_name` for tag-push events:

```yaml
- name: Get release version
  id: version
  run: |
    if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
      echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
    elif [ "${{ github.event_name }}" = "push" ]; then
      echo "VERSION=${{ github.ref_name }}" >> $GITHUB_OUTPUT
    else
      echo "VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
    fi
```

**Why tag-push works**: GitHub's `GITHUB_TOKEN` restriction applies to webhook events created from API actions; `git push` of a tag is treated as a normal push and fires `push` events normally, even when GoReleaser performs the push. (Verified by other repos in the org that use this exact pattern.)

Alternative fix considered: switch GoReleaser to a PAT — rejected because it requires secret rotation and broader permissions than the workflow needs. Tag-push is simpler.

### 3. Backfill: run the workflow once for v2.90.1

After merging, manually trigger:

```bash
gh workflow run docs-version-sync.yml -f version=v2.90.1
```

Or just let the next release tag fire it naturally — but the navbar should be current when this PR merges since change #1 hard-codes it.

### 4. Verify the auto-PR + auto-merge path still works

The workflow uses `peter-evans/create-pull-request@v6` and `gh pr merge --auto --squash`. Since the trigger now fires from a tag-push (not a release event), the PR's base branch is still `main` and the auto-merge logic should be unchanged. Sanity check after merge by triggering manually with a test version.

## Acceptance criteria

- `docs/app/layout.tsx:48` shows `v2.90.1`
- Site at https://pilot.quantflow.studio shows v2.90.1 in navbar after Vercel/Netlify rebuild
- Manual `gh workflow run docs-version-sync.yml -f version=v2.99.0` (or similar dry-run version) creates and auto-merges a PR
- Next real release tag (v2.90.2 or v2.91.0) fires the workflow without any human action

## Out of scope

- Adding a "What's new in v2.90.1" page or release notes section to docs (separate task — currently no such page exists in `docs/content/`)
- Updating hardcoded `v2.56.0` example output in `docs/content/getting-started/quickstart.mdx`, `installation.mdx`, `cli/commands.mdx`, `deployment/docker-helm.mdx`, `deployment/desktop-app.mdx` — these are illustrative examples, not version-pinned operational docs (call out as a follow-up)
- Backfilling FEATURE-MATRIX.md from v2.53 → v2.90 (37 minor versions of features missing — separate task)

## Key files

- `docs/app/layout.tsx:48` — navbar version stamp
- `.github/workflows/docs-version-sync.yml` — broken trigger
- `scripts/docs-version-sync.sh` — already correct, no changes needed