### PR TITLE
GH-2211: Wire native sub-issue linking into epic decomposition (`internal/executor/`)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -431,6 +431,8 @@ Examples:
 						parts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2)
 						if len(parts) == 2 {
 							ghClient := github.NewClient(ghToken)
+							// GH-2211: Wire native sub-issue linker for epic decomposition.
+							gwRunner.SetSubIssueLinker(ghClient)
 							// GH-1870: Board sync option for gateway autopilot controller.
 							var gwBoardOpts []autopilot.ControllerOption
 							if cfg.Adapters.GitHub.ProjectBoard != nil && cfg.Adapters.GitHub.ProjectBoard.Enabled {
@@ -1296,6 +1298,9 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 		}
 		if ghToken != "" {
 			ghClient := github.NewClient(ghToken)
+
+			// GH-2211: Wire native sub-issue linker so epic decomposition creates native parent→child links.
+			runner.SetSubIssueLinker(ghClient)
 
 			// GH-1870: Build board sync option for autopilot controllers.
 			var autopilotBoardOpts []autopilot.ControllerOption

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -864,6 +864,47 @@ func (c *Client) SearchOpenSubIssues(ctx context.Context, owner, repo string, pa
 	return result.TotalCount, nil
 }
 
+// GetIssueNodeID returns the GraphQL global node ID for a GitHub issue.
+// The node ID is required for GraphQL mutations such as addSubIssue.
+func (c *Client) GetIssueNodeID(ctx context.Context, owner, repo string, number int) (string, error) {
+	issue, err := c.GetIssue(ctx, owner, repo, number)
+	if err != nil {
+		return "", fmt.Errorf("get issue node ID for %s/%s#%d: %w", owner, repo, number, err)
+	}
+	if issue.NodeID == "" {
+		return "", fmt.Errorf("empty node ID returned for %s/%s#%d", owner, repo, number)
+	}
+	return issue.NodeID, nil
+}
+
+// LinkSubIssue establishes a native GitHub sub-issue relationship between two issues
+// using the addSubIssue GraphQL mutation. Both issue node IDs are resolved via REST
+// before calling the mutation.
+//
+// This is a best-effort call: callers should log a warning on failure and keep any
+// text-based "Parent: GH-N" fallback intact.
+func (c *Client) LinkSubIssue(ctx context.Context, owner, repo string, parentNum, childNum int) error {
+	parentNodeID, err := c.GetIssueNodeID(ctx, owner, repo, parentNum)
+	if err != nil {
+		return fmt.Errorf("resolve parent node ID: %w", err)
+	}
+	childNodeID, err := c.GetIssueNodeID(ctx, owner, repo, childNum)
+	if err != nil {
+		return fmt.Errorf("resolve child node ID: %w", err)
+	}
+
+	const mutation = `mutation($parentId: ID!, $childId: ID!) {
+  addSubIssue(input: { issueId: $parentId, subIssueId: $childId }) {
+    issue { id }
+  }
+}`
+	vars := map[string]interface{}{
+		"parentId": parentNodeID,
+		"childId":  childNodeID,
+	}
+	return c.ExecuteGraphQL(ctx, mutation, vars, nil)
+}
+
 // UpdatePullRequestBranch updates the PR branch with the latest base branch.
 // Uses GitHub API: PUT /repos/{owner}/{repo}/pulls/{number}/update-branch
 // Returns nil on success, error if the branch cannot be automatically updated (true conflict).

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -2861,3 +2861,96 @@ func TestUpdateRelease(t *testing.T) {
 		})
 	}
 }
+
+func TestGetIssueNodeID(t *testing.T) {
+	tests := []struct {
+		name       string
+		issueResp  string
+		statusCode int
+		wantNodeID string
+		wantErr    bool
+	}{
+		{
+			name:       "returns node_id",
+			statusCode: http.StatusOK,
+			issueResp:  `{"number":42,"node_id":"MDU6SXNzdWU0Mg==","title":"Test"}`,
+			wantNodeID: "MDU6SXNzdWU0Mg==",
+		},
+		{
+			name:       "empty node_id",
+			statusCode: http.StatusOK,
+			issueResp:  `{"number":42,"node_id":"","title":"Test"}`,
+			wantErr:    true,
+		},
+		{
+			name:       "api error",
+			statusCode: http.StatusNotFound,
+			issueResp:  `{"message":"Not Found"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = fmt.Fprint(w, tt.issueResp)
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			nodeID, err := client.GetIssueNodeID(context.Background(), "owner", "repo", 42)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("GetIssueNodeID() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && nodeID != tt.wantNodeID {
+				t.Errorf("GetIssueNodeID() = %q, want %q", nodeID, tt.wantNodeID)
+			}
+		})
+	}
+}
+
+func TestLinkSubIssue(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var graphqlCalled bool
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "/graphql") {
+				graphqlCalled = true
+				// First two calls are GetIssueNodeID (via GetIssue REST); third is GraphQL mutation.
+				// In this test server we handle both REST issue fetches and the GraphQL mutation.
+				_, _ = fmt.Fprint(w, `{"data":{"addSubIssue":{"issue":{"id":"parent-id"}}}}`)
+				return
+			}
+			// REST: return issue with a node_id
+			issueNum := "1"
+			if strings.Contains(r.URL.Path, "/issues/2") {
+				issueNum = "2"
+			}
+			_, _ = fmt.Fprintf(w, `{"number":%s,"node_id":"node-%s"}`, issueNum, issueNum)
+		}))
+		defer server.Close()
+
+		client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		err := client.LinkSubIssue(context.Background(), "owner", "repo", 1, 2)
+		if err != nil {
+			t.Fatalf("LinkSubIssue() unexpected error: %v", err)
+		}
+		if !graphqlCalled {
+			t.Error("LinkSubIssue() did not call GraphQL endpoint")
+		}
+	})
+
+	t.Run("parent node id error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprint(w, `{"message":"Not Found"}`)
+		}))
+		defer server.Close()
+
+		client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		err := client.LinkSubIssue(context.Background(), "owner", "repo", 1, 2)
+		if err == nil {
+			t.Fatal("LinkSubIssue() expected error, got nil")
+		}
+	})
+}

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -568,6 +568,30 @@ func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, e
 			"issue_number", issueNumber,
 			"url", issueURL,
 		)
+
+		// GH-2211: Establish native GitHub sub-issue relationship when possible.
+		// Non-fatal — the "Parent: GH-N" text in the body remains as fallback.
+		if r.subIssueLinker != nil && issueNumber > 0 &&
+			plan.ParentTask != nil && plan.ParentTask.SourceIssueID != "" && plan.ParentTask.SourceRepo != "" {
+			parentNum, parseErr := strconv.Atoi(plan.ParentTask.SourceIssueID)
+			if parseErr == nil && parentNum > 0 {
+				parts := strings.SplitN(plan.ParentTask.SourceRepo, "/", 2)
+				if len(parts) == 2 {
+					if linkErr := r.subIssueLinker.LinkSubIssue(ctx, parts[0], parts[1], parentNum, issueNumber); linkErr != nil {
+						r.log.Warn("Failed to link sub-issue natively (text fallback intact)",
+							"parent", parentNum,
+							"child", issueNumber,
+							"error", linkErr,
+						)
+					} else {
+						r.log.Debug("Linked native GitHub sub-issue",
+							"parent", parentNum,
+							"child", issueNumber,
+						)
+					}
+				}
+			}
+		}
 	}
 
 	return created, nil

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -1423,3 +1423,84 @@ func TestCreatedIssue_IdentifierField(t *testing.T) {
 		})
 	}
 }
+
+// mockSubIssueLinker records LinkSubIssue calls for testing.
+type mockSubIssueLinker struct {
+	Calls  []mockLinkCall
+	RetErr error
+}
+
+type mockLinkCall struct {
+	Owner, Repo      string
+	ParentNum, ChildNum int
+}
+
+func (m *mockSubIssueLinker) LinkSubIssue(_ context.Context, owner, repo string, parentNum, childNum int) error {
+	m.Calls = append(m.Calls, mockLinkCall{Owner: owner, Repo: repo, ParentNum: parentNum, ChildNum: childNum})
+	return m.RetErr
+}
+
+// TestSetSubIssueLinker verifies the setter and that the interface is stored correctly.
+func TestSetSubIssueLinker(t *testing.T) {
+	runner := NewRunner()
+	if runner.subIssueLinker != nil {
+		t.Fatal("subIssueLinker should be nil initially")
+	}
+
+	mock := &mockSubIssueLinker{}
+	runner.SetSubIssueLinker(mock)
+	if runner.subIssueLinker == nil {
+		t.Fatal("SetSubIssueLinker did not store the linker")
+	}
+}
+
+// TestCreateSubIssues_LinkerNotCalledWhenGhFails verifies that the SubIssueLinker
+// is never invoked when gh CLI fails (error from gh → early return before linking).
+func TestCreateSubIssues_LinkerNotCalledWhenGhFails(t *testing.T) {
+	runner := NewRunner()
+	linker := &mockSubIssueLinker{}
+	runner.SetSubIssueLinker(linker)
+
+	plan := &EpicPlan{
+		ParentTask: &Task{
+			ID:            "GH-100",
+			SourceIssueID: "100",
+			SourceRepo:    "owner/repo",
+		},
+		Subtasks: []PlannedSubtask{
+			{Title: "Test subtask", Description: "Test", Order: 1},
+		},
+	}
+
+	// gh CLI will fail in /nonexistent/path → createSubIssuesViaGitHub returns error → linker not called.
+	_, _ = runner.CreateSubIssues(context.Background(), plan, "/nonexistent/path")
+
+	if len(linker.Calls) != 0 {
+		t.Errorf("expected 0 linker calls when gh CLI fails, got %d", len(linker.Calls))
+	}
+}
+
+// TestCreateSubIssues_LinkerNotCalledWhenNoSourceRepo verifies that the SubIssueLinker
+// is skipped when the parent task has no SourceRepo (defensive guard).
+func TestCreateSubIssues_LinkerNotCalledWhenNoSourceRepo(t *testing.T) {
+	runner := NewRunner()
+	linker := &mockSubIssueLinker{}
+	runner.SetSubIssueLinker(linker)
+
+	plan := &EpicPlan{
+		ParentTask: &Task{
+			ID:            "GH-100",
+			SourceIssueID: "100",
+			SourceRepo:    "", // empty — guard should skip linking
+		},
+		Subtasks: []PlannedSubtask{
+			{Title: "Test subtask", Description: "Test", Order: 1},
+		},
+	}
+
+	_, _ = runner.CreateSubIssues(context.Background(), plan, "/nonexistent/path")
+
+	if len(linker.Calls) != 0 {
+		t.Errorf("expected 0 linker calls when SourceRepo is empty, got %d", len(linker.Calls))
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -268,6 +268,15 @@ type SubIssuePRCallback func(prNumber int, prURL string, issueNumber int, headSH
 // to enforce sequential ordering: sub-issue N+1 only starts after sub-issue N is merged.
 type SubIssueMergeWaitFn func(ctx context.Context, prNumber int) error
 
+// SubIssueLinker establishes a native parent→child relationship between GitHub issues.
+// Implemented by *github.Client. Kept as a narrow interface so the executor package
+// does not import the github adapter package directly.
+type SubIssueLinker interface {
+	// LinkSubIssue adds childNum as a sub-issue of parentNum in the given repo.
+	// Non-fatal: callers should warn on error and keep text fallbacks intact.
+	LinkSubIssue(ctx context.Context, owner, repo string, parentNum, childNum int) error
+}
+
 // SubIssueCreator is an interface for creating sub-issues in external issue trackers.
 // Adapters like Linear, Jira, GitLab, and Azure DevOps can implement this interface
 // to allow epic decomposition to create sub-issues in the source tracker rather than GitHub.
@@ -329,6 +338,8 @@ type Runner struct {
 	worktreeManager       *WorktreeManager // Optional worktree manager with pool support
 	// GH-1471: SubIssueCreator for non-GitHub adapters
 	subIssueCreator       SubIssueCreator // Optional creator for sub-issues in external trackers
+	// GH-2211: SubIssueLinker for native GitHub parent→child relationships
+	subIssueLinker        SubIssueLinker // Optional linker for native GitHub sub-issue API
 	// GH-1599: Execution log store for milestone entries
 	logStore              *memory.Store // Optional log store for writing execution milestones
 	// GH-1811: Learning system (self-improvement)
@@ -627,6 +638,13 @@ func (r *Runner) HasSubIssueMergeWait() bool { return r.subIssueMergeWait != nil
 // via this interface instead of using the gh CLI.
 func (r *Runner) SetSubIssueCreator(creator SubIssueCreator) {
 	r.subIssueCreator = creator
+}
+
+// SetSubIssueLinker sets the linker for native GitHub parent→child sub-issue relationships (GH-2211).
+// When set, createSubIssuesViaGitHub calls LinkSubIssue after each gh issue create succeeds.
+// Failures are non-fatal: a warning is logged and the "Parent: GH-N" text fallback remains.
+func (r *Runner) SetSubIssueLinker(linker SubIssueLinker) {
+	r.subIssueLinker = linker
 }
 
 // SetIntentJudge sets the intent judge for diff-vs-ticket alignment verification (GH-624).


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2211.

Closes #2211

## Changes

In `createSubIssuesViaGitHub()` (epic.go ~line 556), after the `gh issue create` succeeds and the issue number is parsed:
- Instantiate or receive a `*github.Client` — Runner currently has no `ghClient` field. Add one, initialized from the GitHub adapter token already available in config. Alternatively, accept a `SubIssueLinker` interface with just `LinkSubIssue` to keep the dependency narrow.
- Call `LinkSubIssue(ctx, owner, repo, parentNum, childNum)` with a warn-level log on failure (non-fatal — the text marker remains as fallback).
- Extract `owner`/`repo` from the execution context or `executionPath` (the worktree's git remote). Check how the existing code resolves these — `plan.ParentTask.SourceIssueID` and adapter metadata likely have them.
- Keep the existing `Parent: GH-N` body text intact for backwards compatibility.
**Files:** `internal/executor/epic.go`, `internal/executor/runner.go` (add field + constructor wiring)
---