### PR TITLE
GH-2212: Replace search-based parent closing with native GraphQL + fallback (`internal/autopilot/`)

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -864,6 +864,61 @@ func (c *Client) SearchOpenSubIssues(ctx context.Context, owner, repo string, pa
 	return result.TotalCount, nil
 }
 
+// GetOpenSubIssueCount queries the GitHub GraphQL API for native sub-issues linked to parentNum.
+// Returns (openCount, hasNativeLinks, error).
+// hasNativeLinks is true when the parent has at least one natively linked sub-issue (totalCount > 0).
+// When hasNativeLinks is false, the caller should fall back to text-search (SearchOpenSubIssues).
+func (c *Client) GetOpenSubIssueCount(ctx context.Context, owner, repo string, parentNum int) (int, bool, error) {
+	const query = `query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      subIssues(first: 100) {
+        totalCount
+        nodes {
+          state
+        }
+      }
+    }
+  }
+}`
+	vars := map[string]interface{}{
+		"owner":  owner,
+		"repo":   repo,
+		"number": parentNum,
+	}
+
+	var resp struct {
+		Repository struct {
+			Issue struct {
+				SubIssues struct {
+					TotalCount int `json:"totalCount"`
+					Nodes      []struct {
+						State string `json:"state"`
+					} `json:"nodes"`
+				} `json:"subIssues"`
+			} `json:"issue"`
+		} `json:"repository"`
+	}
+
+	if err := c.ExecuteGraphQL(ctx, query, vars, &resp); err != nil {
+		return 0, false, fmt.Errorf("get native sub-issues for parent %d: %w", parentNum, err)
+	}
+
+	totalCount := resp.Repository.Issue.SubIssues.TotalCount
+	if totalCount == 0 {
+		// No native sub-issue links — caller should fall back to text search.
+		return 0, false, nil
+	}
+
+	openCount := 0
+	for _, node := range resp.Repository.Issue.SubIssues.Nodes {
+		if node.State == "OPEN" {
+			openCount++
+		}
+	}
+	return openCount, true, nil
+}
+
 // UpdatePullRequestBranch updates the PR branch with the latest base branch.
 // Uses GitHub API: PUT /repos/{owner}/{repo}/pulls/{number}/update-branch
 // Returns nil on success, error if the branch cannot be automatically updated (true conflict).

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -2741,6 +2741,92 @@ func TestSearchOpenSubIssues(t *testing.T) {
 	}
 }
 
+func TestGetOpenSubIssueCount(t *testing.T) {
+	tests := []struct {
+		name            string
+		parentNum       int
+		graphqlResponse string
+		statusCode      int
+		wantCount       int
+		wantHasLinks    bool
+		wantErr         bool
+	}{
+		{
+			name:      "native links with open sub-issues",
+			parentNum: 5,
+			graphqlResponse: `{"data":{"repository":{"issue":{"subIssues":{"totalCount":3,"nodes":[
+				{"state":"OPEN"},{"state":"OPEN"},{"state":"CLOSED"}
+			]}}}}}`,
+			statusCode:   http.StatusOK,
+			wantCount:    2,
+			wantHasLinks: true,
+		},
+		{
+			name:      "native links all closed",
+			parentNum: 6,
+			graphqlResponse: `{"data":{"repository":{"issue":{"subIssues":{"totalCount":2,"nodes":[
+				{"state":"CLOSED"},{"state":"CLOSED"}
+			]}}}}}`,
+			statusCode:   http.StatusOK,
+			wantCount:    0,
+			wantHasLinks: true,
+		},
+		{
+			name:            "no native links - fall back signal",
+			parentNum:       7,
+			graphqlResponse: `{"data":{"repository":{"issue":{"subIssues":{"totalCount":0,"nodes":[]}}}}}`,
+			statusCode:      http.StatusOK,
+			wantCount:       0,
+			wantHasLinks:    false,
+		},
+		{
+			name:         "graphql error",
+			parentNum:    8,
+			graphqlResponse: `{"data":null,"errors":[{"message":"not found"}]}`,
+			statusCode:   http.StatusOK,
+			wantErr:      true,
+		},
+		{
+			name:         "http error",
+			parentNum:    9,
+			statusCode:   http.StatusInternalServerError,
+			graphqlResponse: `{"message":"internal error"}`,
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/graphql" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.graphqlResponse))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			count, hasLinks, err := client.GetOpenSubIssueCount(context.Background(), "owner", "repo", tt.parentNum)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetOpenSubIssueCount() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if count != tt.wantCount {
+					t.Errorf("GetOpenSubIssueCount() count = %d, want %d", count, tt.wantCount)
+				}
+				if hasLinks != tt.wantHasLinks {
+					t.Errorf("GetOpenSubIssueCount() hasLinks = %v, want %v", hasLinks, tt.wantHasLinks)
+				}
+			}
+		})
+	}
+}
+
 func TestGetReleaseByTag(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1159,10 +1159,20 @@ func (c *Controller) maybeCloseParentIssue(ctx context.Context, prState *PRState
 	}
 
 	// Check how many sibling sub-issues are still open.
-	openCount, err := c.ghClient.SearchOpenSubIssues(ctx, c.owner, c.repo, parentNum)
-	if err != nil {
-		c.log.Warn("maybeCloseParentIssue: failed to search open sub-issues", slog.Int("parent", parentNum), slog.Any("error", err))
-		return
+	// Tier 1: try native GitHub sub-issues GraphQL API (more reliable, works even without text patterns).
+	// Tier 2: fall back to text search when native links are absent (legacy repos use body "Parent: GH-N" only).
+	openCount, hasNativeLinks, err := c.ghClient.GetOpenSubIssueCount(ctx, c.owner, c.repo, parentNum)
+	if err != nil || !hasNativeLinks {
+		if err != nil {
+			c.log.Warn("maybeCloseParentIssue: native sub-issue count failed, falling back to search", slog.Int("parent", parentNum), slog.Any("error", err))
+		} else {
+			c.log.Debug("maybeCloseParentIssue: no native sub-issue links, falling back to search", slog.Int("parent", parentNum))
+		}
+		openCount, err = c.ghClient.SearchOpenSubIssues(ctx, c.owner, c.repo, parentNum)
+		if err != nil {
+			c.log.Warn("maybeCloseParentIssue: failed to search open sub-issues", slog.Int("parent", parentNum), slog.Any("error", err))
+			return
+		}
 	}
 
 	if openCount > 0 {

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -3790,18 +3790,20 @@ func TestController_HasChangesRequested_FilterByTime(t *testing.T) {
 
 func TestMaybeCloseParentIssue(t *testing.T) {
 	tests := []struct {
-		name           string
-		issueNumber    int
-		issueBody      string
-		openSubIssues  int
-		getIssueErr    bool
-		searchErr      bool
-		wantClosed     bool
-		wantLabeled    bool
-		wantCommented  bool
+		name              string
+		issueNumber       int
+		issueBody         string
+		openSubIssues     int // used by text-search fallback
+		getIssueErr       bool
+		searchErr         bool
+		nativeTotal       int    // totalCount returned by GraphQL native sub-issues
+		nativeOpenStates  []string // states of natively linked sub-issues
+		wantClosed        bool
+		wantLabeled       bool
+		wantCommented     bool
 	}{
 		{
-			name:          "last sub-issue triggers parent close",
+			name:          "last sub-issue triggers parent close (text-search path)",
 			issueNumber:   10,
 			issueBody:     "Fix the bug\n\nParent: GH-5\n",
 			openSubIssues: 0,
@@ -3810,7 +3812,7 @@ func TestMaybeCloseParentIssue(t *testing.T) {
 			wantCommented: true,
 		},
 		{
-			name:          "sibling still open - no-op",
+			name:          "sibling still open - no-op (text-search path)",
 			issueNumber:   10,
 			issueBody:     "Fix the bug\n\nParent: GH-5\n",
 			openSubIssues: 2,
@@ -3856,15 +3858,35 @@ func TestMaybeCloseParentIssue(t *testing.T) {
 			wantLabeled:   true,
 			wantCommented: true,
 		},
+		{
+			name:             "native links all closed - closes parent",
+			issueNumber:      10,
+			issueBody:        "Fix the bug\n\nParent: GH-5\n",
+			nativeTotal:      2,
+			nativeOpenStates: []string{"CLOSED", "CLOSED"},
+			wantClosed:       true,
+			wantLabeled:      true,
+			wantCommented:    true,
+		},
+		{
+			name:             "native links with open sibling - no-op",
+			issueNumber:      10,
+			issueBody:        "Fix the bug\n\nParent: GH-5\n",
+			nativeTotal:      2,
+			nativeOpenStates: []string{"OPEN", "CLOSED"},
+			wantClosed:       false,
+			wantLabeled:      false,
+			wantCommented:    false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var (
-				closeCalled       bool
-				addLabelsCalled   bool
-				removeLabelCalls  []string
-				commentCalled     bool
+				closeCalled      bool
+				addLabelsCalled  bool
+				removeLabelCalls []string
+				commentCalled    bool
 			)
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3881,6 +3903,27 @@ func TestMaybeCloseParentIssue(t *testing.T) {
 					}
 					w.WriteHeader(http.StatusOK)
 					_ = json.NewEncoder(w).Encode(issue)
+
+				case r.URL.Path == "/graphql" && r.Method == http.MethodPost:
+					// Serve native sub-issues GraphQL response.
+					nodes := make([]map[string]string, len(tt.nativeOpenStates))
+					for i, s := range tt.nativeOpenStates {
+						nodes[i] = map[string]string{"state": s}
+					}
+					resp := map[string]interface{}{
+						"data": map[string]interface{}{
+							"repository": map[string]interface{}{
+								"issue": map[string]interface{}{
+									"subIssues": map[string]interface{}{
+										"totalCount": tt.nativeTotal,
+										"nodes":      nodes,
+									},
+								},
+							},
+						},
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
 
 				case strings.HasPrefix(r.URL.Path, "/search/issues"):
 					if tt.searchErr {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2212.

Closes #2212

## Changes

In `maybeCloseParentIssue()` (controller.go ~line 1162), replace the `SearchOpenSubIssues` call with a two-tier approach: