### PR TITLE
GH-2176: fix(poller): auto-retry issues stuck with pilot-failed from execution failures

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -99,6 +99,11 @@ type Poller struct {
 	// GH-2201: TaskChecker verifies whether an issue is still queued/in-progress
 	// before allowing retry after the grace period expires.
 	taskChecker TaskChecker
+
+	// GH-2176: Auto-retry issues stuck with pilot-failed from execution failures.
+	// Tracks how many times each issue has been retried after pilot-failed.
+	failedRetryCount map[int]int
+	maxFailedRetries int // default: 3
 }
 
 // PollerOption configures a Poller
@@ -181,6 +186,17 @@ func WithTaskChecker(tc TaskChecker) PollerOption {
 	}
 }
 
+// WithMaxFailedRetries sets the maximum number of auto-retries for issues
+// that are stuck with pilot-failed label from execution failures. Default: 3.
+func WithMaxFailedRetries(n int) PollerOption {
+	return func(p *Poller) {
+		if n < 0 {
+			n = 0
+		}
+		p.maxFailedRetries = n
+	}
+}
+
 // WithMaxConcurrent sets the maximum number of parallel issue executions
 func WithMaxConcurrent(n int) PollerOption {
 	return func(p *Poller) {
@@ -211,6 +227,8 @@ func NewPoller(client *Client, repo string, label string, interval time.Duration
 		prPollInterval:   30 * time.Second,
 		prTimeout:        1 * time.Hour,
 		retryGracePeriod: 5 * time.Minute, // GH-2201: default grace period
+		failedRetryCount: make(map[int]int),
+		maxFailedRetries: 3, // GH-2176: default max retries for pilot-failed issues
 	}
 
 	for _, opt := range opts {
@@ -536,9 +554,17 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 			continue
 		}
 
-		// Skip if has status labels
-		if HasLabel(issue, LabelInProgress) || HasLabel(issue, LabelDone) || HasLabel(issue, LabelFailed) {
+		// Skip if in-progress or done
+		if HasLabel(issue, LabelInProgress) || HasLabel(issue, LabelDone) {
 			continue
+		}
+
+		// GH-2176: Auto-retry issues stuck with pilot-failed (no pilot-done)
+		if HasLabel(issue, LabelFailed) {
+			if !p.shouldRetryFailedIssue(ctx, issue) {
+				continue
+			}
+			// Label removed, fall through to candidate selection
 		}
 
 		// Check if previously processed
@@ -718,9 +744,17 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 			continue
 		}
 
-		// Skip if already in progress or failed (check before processed to allow retry)
-		if HasLabel(issue, LabelInProgress) || HasLabel(issue, LabelFailed) {
+		// Skip if already in progress
+		if HasLabel(issue, LabelInProgress) {
 			continue
+		}
+
+		// GH-2176: Auto-retry issues stuck with pilot-failed (no pilot-done)
+		if HasLabel(issue, LabelFailed) {
+			if !p.shouldRetryFailedIssue(ctx, issue) {
+				continue
+			}
+			// Label removed, fall through to candidate selection
 		}
 
 		// Skip and mark done issues as permanently processed
@@ -1064,6 +1098,58 @@ func (p *Poller) hasMergedWork(ctx context.Context, issue *Issue) bool {
 		)
 	}
 	p.markProcessed(issue.Number)
+	return true
+}
+
+// shouldRetryFailedIssue checks if a pilot-failed issue should be auto-retried.
+// Returns true if the issue should be retried (label removed), false if it should be skipped.
+// GH-2176: Issues stuck with pilot-failed get retried up to maxFailedRetries times.
+func (p *Poller) shouldRetryFailedIssue(ctx context.Context, issue *Issue) bool {
+	// Never retry if also marked done
+	if HasLabel(issue, LabelDone) {
+		return false
+	}
+
+	p.mu.RLock()
+	retries := p.failedRetryCount[issue.Number]
+	p.mu.RUnlock()
+
+	if retries >= p.maxFailedRetries {
+		p.logger.Warn("Issue has reached max failed retries, skipping",
+			slog.Int("number", issue.Number),
+			slog.Int("retries", retries),
+			slog.Int("max", p.maxFailedRetries),
+		)
+		return false
+	}
+
+	// Check if merged work already exists before retrying
+	if p.hasMergedWork(ctx, issue) {
+		return false
+	}
+
+	// Remove pilot-failed label and increment retry count
+	if err := p.client.RemoveLabel(ctx, p.owner, p.repo, issue.Number, LabelFailed); err != nil {
+		p.logger.Warn("Failed to remove pilot-failed label for retry",
+			slog.Int("number", issue.Number),
+			slog.Any("error", err),
+		)
+		return false
+	}
+
+	p.mu.Lock()
+	p.failedRetryCount[issue.Number] = retries + 1
+	p.mu.Unlock()
+
+	// Clear from processed map so the issue can be re-picked
+	p.ClearProcessed(issue.Number)
+
+	p.logger.Info("Auto-retrying pilot-failed issue",
+		slog.Int("number", issue.Number),
+		slog.Int("retry", retries+1),
+		slog.Int("max", p.maxFailedRetries),
+	)
+
 	return true
 }
 

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -471,7 +471,7 @@ func TestPoller_CheckForNewIssues_NoCallback(t *testing.T) {
 }
 
 func TestPoller_CheckForNewIssues_SkipsAlreadyProcessed(t *testing.T) {
-	// Issue 1 has pilot-failed so should be skipped
+	// Issue 1 has pilot-failed and is at max retries — should be skipped
 	// Issue 2 has only pilot so should be processed
 	issues := []*Issue{
 		{Number: 1, Title: "Issue 1", Labels: []Label{{Name: "pilot"}, {Name: "pilot-failed"}}},
@@ -492,14 +492,20 @@ func TestPoller_CheckForNewIssues_SkipsAlreadyProcessed(t *testing.T) {
 			atomic.AddInt32(&callCount, 1)
 			return nil
 		}),
+		WithMaxFailedRetries(3),
 	)
+
+	// GH-2176: Set retry count to max so issue is skipped (not auto-retried)
+	poller.mu.Lock()
+	poller.failedRetryCount[1] = 3
+	poller.mu.Unlock()
 
 	poller.checkForNewIssues(context.Background())
 	poller.WaitForActive()
 
-	// Only issue 2 should trigger callback (issue 1 has pilot-failed)
+	// Only issue 2 should trigger callback (issue 1 at max retries)
 	if got := atomic.LoadInt32(&callCount); got != 1 {
-		t.Errorf("callback called %d times, want 1 (issue with status labels should be skipped)", got)
+		t.Errorf("callback called %d times, want 1 (issue at retry limit should be skipped)", got)
 	}
 }
 
@@ -2036,5 +2042,210 @@ func TestPoller_ProcessedMapStoresTimestamps(t *testing.T) {
 	poller.Reset()
 	if poller.IsProcessed(1) {
 		t.Error("IsProcessed should return false after Reset")
+	}
+}
+
+func TestPoller_AutoRetryFailedIssue_FirstFailure(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+
+	var labelRemoved atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Handle label removal
+		if r.Method == http.MethodDelete && r.URL.Path == "/repos/owner/repo/issues/42/labels/"+LabelFailed {
+			labelRemoved.Store(true)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// Handle search (hasMergedWork check) — no merged PRs
+		if r.URL.Path == "/search/issues" {
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+			return
+		}
+		// Handle list issues
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithRetryGracePeriod(0),
+	)
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil {
+		t.Fatal("issue should not be nil — pilot-failed issue should be retried on first failure")
+	}
+	if issue.Number != 42 {
+		t.Errorf("got issue #%d, want #42", issue.Number)
+	}
+	if !labelRemoved.Load() {
+		t.Error("pilot-failed label should have been removed")
+	}
+
+	// Verify retry count incremented
+	poller.mu.RLock()
+	retries := poller.failedRetryCount[42]
+	poller.mu.RUnlock()
+	if retries != 1 {
+		t.Errorf("retry count = %d, want 1", retries)
+	}
+}
+
+func TestPoller_AutoRetryFailedIssue_RetryLimitReached(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, Title: "Available issue", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithMaxFailedRetries(3),
+	)
+
+	// Simulate: already retried 3 times
+	poller.mu.Lock()
+	poller.failedRetryCount[42] = 3
+	poller.mu.Unlock()
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil {
+		t.Fatal("issue should not be nil — #43 should be picked")
+	}
+	if issue.Number != 43 {
+		t.Errorf("got issue #%d, want #43 (should skip #42 at retry limit)", issue.Number)
+	}
+}
+
+func TestPoller_AutoRetryFailedIssue_SkipsDoneIssues(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		// Has both pilot-failed AND pilot-done — should NOT be retried
+		{Number: 42, Title: "Done+Failed", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}, {Name: LabelDone}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, Title: "Available", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil {
+		t.Fatal("issue should not be nil — #43 should be picked")
+	}
+	if issue.Number != 43 {
+		t.Errorf("got issue #%d, want #43 (should skip #42 with pilot-done)", issue.Number)
+	}
+}
+
+func TestPoller_AutoRetryFailedIssue_ParallelMode(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+
+	var labelRemoved atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodDelete && r.URL.Path == "/repos/owner/repo/issues/42/labels/"+LabelFailed {
+			labelRemoved.Store(true)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/search/issues" {
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var processedIssues []*Issue
+	var mu sync.Mutex
+
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			mu.Lock()
+			processedIssues = append(processedIssues, issue)
+			mu.Unlock()
+			return nil
+		}),
+		WithRetryGracePeriod(0),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	mu.Lock()
+	got := len(processedIssues)
+	mu.Unlock()
+
+	if got != 1 {
+		t.Errorf("processed %d issues, want 1", got)
+	}
+	if !labelRemoved.Load() {
+		t.Error("pilot-failed label should have been removed in parallel mode")
+	}
+}
+
+func TestPoller_AutoRetryFailedIssue_ParallelMode_LimitReached(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var processedCount atomic.Int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			processedCount.Add(1)
+			return nil
+		}),
+		WithMaxFailedRetries(2),
+	)
+
+	// Simulate: already at max retries
+	poller.mu.Lock()
+	poller.failedRetryCount[42] = 2
+	poller.mu.Unlock()
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if processedCount.Load() != 0 {
+		t.Errorf("processed %d issues, want 0 (should skip at retry limit)", processedCount.Load())
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2176.

Closes #2176

## Changes

GitHub Issue #2176: fix(poller): auto-retry issues stuck with pilot-failed from execution failures

## Bug

When a task fails at the executor level (before a PR is created), the notifier adds `pilot-failed` but nothing ever removes it. The autopilot retry mechanism only handles PR-lifecycle failures (CI, merge conflicts). Issues get stuck permanently.

## Root Cause

1. `internal/adapters/github/notifier.go:119` — adds `pilot-failed` on any execution failure
2. `internal/adapters/github/poller.go:497-499` — skips issues with `pilot-failed`
3. Autopilot controller removes `pilot-failed` only on: successful merge, retry-ready, or parent close
4. **Gap**: execution fails before PR → no autopilot path fires → `pilot-failed` persists → issue stuck forever

## Fix

In `internal/adapters/github/poller.go` — `findOldestUnprocessedIssue()`:

When an issue has `pilot-failed` but NOT `pilot-done`:
1. Check retry count (track via in-memory map or comment metadata)
2. If under limit (3): remove `pilot-failed`, allow re-pick
3. If at limit: skip (leave `pilot-failed`, log warning)

## Files
- `internal/adapters/github/poller.go`
- `internal/adapters/github/poller_test.go`

## Reproduce
- Issues qf-studio/auth-service#7 and qf-studio/auth-service#13 are stuck in this state

## Acceptance
- Issues with `pilot-failed` (no `pilot-done`) get retried up to 3 times
- After 3 failures, issue stays with `pilot-failed` (no infinite loop)
- Tests cover: retry on first failure, retry limit reached, skip `pilot-done` issues