### PR TITLE
GH-2221: Add `GetStaleQueuedExecutions` to memory store (`internal/memory/`)

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -900,6 +900,37 @@ func (s *Store) GetStaleRunningExecutions(staleDuration time.Duration) ([]*Execu
 	return executions, nil
 }
 
+// GetStaleQueuedExecutions returns executions that have been in "queued" status
+// for longer than the specified duration. Used to detect stuck queue entries.
+func (s *Store) GetStaleQueuedExecutions(staleDuration time.Duration) ([]*Execution, error) {
+	staleTime := time.Now().Add(-staleDuration)
+	rows, err := s.db.Query(`
+		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at
+		FROM executions
+		WHERE status = 'queued' AND created_at < ?
+		ORDER BY created_at ASC
+	`, staleTime)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var executions []*Execution
+	for rows.Next() {
+		var exec Execution
+		var completedAt sql.NullTime
+		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &completedAt); err != nil {
+			return nil, err
+		}
+		if completedAt.Valid {
+			exec.CompletedAt = &completedAt.Time
+		}
+		executions = append(executions, &exec)
+	}
+
+	return executions, nil
+}
+
 // IsTaskQueued checks if a task with the given ID is already queued or running.
 // Used to prevent duplicate task submissions.
 func (s *Store) IsTaskQueued(taskID string) (bool, error) {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1446,3 +1446,52 @@ func TestCrossPatternsIndexes(t *testing.T) {
 		})
 	}
 }
+
+func TestGetStaleQueuedExecutions(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	staleDuration := time.Hour
+
+	now := time.Now()
+
+	insertAt := func(exec *Execution, createdAt time.Time) {
+		t.Helper()
+		if err := store.SaveExecution(exec); err != nil {
+			t.Fatalf("SaveExecution %s: %v", exec.ID, err)
+		}
+		if _, err := store.db.Exec(
+			`UPDATE executions SET created_at = ? WHERE id = ?`, createdAt, exec.ID,
+		); err != nil {
+			t.Fatalf("set created_at for %s: %v", exec.ID, err)
+		}
+	}
+
+	// Fresh queued execution (created now — should NOT be returned).
+	insertAt(&Execution{ID: "queued-fresh", TaskID: "TASK-fresh", ProjectPath: "/proj", Status: "queued"}, now)
+
+	// Stale queued execution (created 2 hours ago — should be returned).
+	insertAt(&Execution{ID: "queued-stale", TaskID: "TASK-stale", ProjectPath: "/proj", Status: "queued"}, now.Add(-2*time.Hour))
+
+	// Stale running execution — must NOT appear in queued results.
+	insertAt(&Execution{ID: "running-stale", TaskID: "TASK-running", ProjectPath: "/proj", Status: "running"}, now.Add(-2*time.Hour))
+
+	results, err := store.GetStaleQueuedExecutions(staleDuration)
+	if err != nil {
+		t.Fatalf("GetStaleQueuedExecutions: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 stale queued execution, got %d", len(results))
+	}
+	if results[0].ID != "queued-stale" {
+		t.Errorf("expected ID %q, got %q", "queued-stale", results[0].ID)
+	}
+	if results[0].Status != "queued" {
+		t.Errorf("expected status 'queued', got %q", results[0].Status)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2221.

Closes #2221

## Changes

Add a new `GetStaleQueuedExecutions(staleDuration time.Duration) ([]*Execution, error)` method to `internal/memory/store.go` that mirrors `GetStaleRunningExecutions` but filters on `status = 'queued'`. Add test `TestGetStaleQueuedExecutions` to `internal/memory/store_test.go` verifying threshold filtering (fresh queued rows not returned, old ones returned). This is the data-access foundation the dispatcher will consume.