### PR TITLE
Fix/gh 2232 gitlab parallel onissue with result

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -298,10 +298,19 @@ Examples:
 			telegramFlagSet := cmd.Flags().Changed("telegram")
 			githubFlagSet := cmd.Flags().Changed("github")
 			slackFlagSet := cmd.Flags().Changed("slack")
+			// GH-2232: Check if any adapter-registry poller is enabled (GitLab, Linear, Jira, etc.)
+			adapterPollerEnabled := false
+			for _, reg := range adapterPollerRegistrations() {
+				if reg.Enabled(cfg) {
+					adapterPollerEnabled = true
+					break
+				}
+			}
 			needsPollingInfra := (telegramFlagSet && hasTelegram && cfg.Adapters.Telegram.Polling) ||
 				(githubFlagSet && hasGithubPolling && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled &&
 					cfg.Adapters.GitHub.Polling != nil && cfg.Adapters.GitHub.Polling.Enabled) ||
-				(slackFlagSet && hasSlack)
+				(slackFlagSet && hasSlack) ||
+				adapterPollerEnabled
 
 			// Shared infrastructure for polling adapters
 			var gwRunner *executor.Runner

--- a/internal/adapters/gitlab/poller.go
+++ b/internal/adapters/gitlab/poller.go
@@ -549,7 +549,7 @@ func (p *Poller) processIssueAsync(ctx context.Context, issue *Issue) {
 	defer p.activeWg.Done()
 	defer func() { <-p.semaphore }() // release slot
 
-	if p.onIssue == nil {
+	if p.onIssueWithResult == nil && p.onIssue == nil {
 		return
 	}
 
@@ -561,22 +561,51 @@ func (p *Poller) processIssueAsync(ctx context.Context, issue *Issue) {
 		)
 	}
 
+	// GH-2232: Check onIssueWithResult first (matches GitHub parallel dispatch pattern)
+	if p.onIssueWithResult != nil {
+		result, err := p.onIssueWithResult(ctx, issue)
+		if err != nil {
+			p.logger.Error("Failed to process issue",
+				slog.Int("iid", issue.IID),
+				slog.Any("error", err),
+			)
+			_ = p.client.RemoveIssueLabel(ctx, issue.IID, LabelInProgress)
+			_ = p.client.AddIssueLabels(ctx, issue.IID, []string{LabelFailed})
+			p.ClearProcessed(issue.IID)
+			return
+		}
+
+		// Unmark if execution failed without creating an MR
+		if result != nil && !result.Success && result.MRNumber == 0 {
+			p.logger.Info("Execution failed without MR, unmarking for retry",
+				slog.Int("iid", issue.IID),
+			)
+			p.ClearProcessed(issue.IID)
+		}
+
+		// Notify autopilot controller of new MR
+		if result != nil && result.MRNumber > 0 && p.OnMRCreated != nil {
+			p.OnMRCreated(result.MRNumber, result.MRURL, issue.IID, result.HeadSHA, result.BranchName)
+		}
+
+		_ = p.client.RemoveIssueLabel(ctx, issue.IID, LabelInProgress)
+		_ = p.client.AddIssueLabels(ctx, issue.IID, []string{LabelDone})
+		return
+	}
+
+	// Legacy fallback: onIssue
 	err := p.onIssue(ctx, issue)
 	if err != nil {
 		p.logger.Error("Failed to process issue",
 			slog.Int("iid", issue.IID),
 			slog.Any("error", err),
 		)
-		// Remove in-progress label, add failed label
 		_ = p.client.RemoveIssueLabel(ctx, issue.IID, LabelInProgress)
 		_ = p.client.AddIssueLabels(ctx, issue.IID, []string{LabelFailed})
 		return
 	}
 
-	// Remove in-progress label
 	_ = p.client.RemoveIssueLabel(ctx, issue.IID, LabelInProgress)
-
-	// Add done label on success
 	_ = p.client.AddIssueLabels(ctx, issue.IID, []string{LabelDone})
 }
 


### PR DESCRIPTION
## Summary

Two bugs prevented GitLab issues from being executed in gateway mode:

- **Bug 1 — silent drop**: `processIssueAsync` only checked `p.onIssue` (legacy callback), but the handler is registered via `WithOnIssueWithResult` — every dispatched issue returned silently without executing
- **Bug 2 — nil runner** (masked by Bug 1): `needsPollingInfra` didn't include adapter-registry pollers (GitLab, Linear, Jira, etc.), so the shared Runner/Dispatcher were never initialized in gateway mode — causing a nil pointer panic once Bug 1 was fixed
- **Fix 1**: `processIssueAsync` now checks `onIssueWithResult` first (matching GitHub parallel dispatch and GitLab sequential patterns), with proper `IssueResult` handling, `OnMRCreated` callback, and `ClearProcessed` retry logic
- **Fix 2**: `needsPollingInfra` now checks if any adapter-registry poller is enabled, so shared infrastructure is created for all adapters

Closes #2232

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/adapters/gitlab/...` — all tests pass
- [x] `go test ./cmd/pilot/...` — all tests pass
- [x] Manual: start Pilot in gateway mode with GitLab adapter enabled, create an issue with `pilot` label, confirm it gets picked up and executed

