### PR TITLE
GH-2242: fix(poller): re-queues completed tasks after restart when pilot-done label missing

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -727,6 +727,11 @@ Examples:
 						pollerOpts = append(pollerOpts, github.WithTaskChecker(storeTaskChecker{store: gwStore}))
 					}
 
+					// GH-2242: Wire execution checker to prevent re-dispatch of completed tasks (gateway mode)
+					if gwStore != nil {
+						pollerOpts = append(pollerOpts, github.WithExecutionChecker(gwStore, projectPath))
+					}
+
 					// Create rate limit retry scheduler
 					repoParts := strings.Split(cfg.Adapters.GitHub.Repo, "/")
 					if len(repoParts) != 2 {
@@ -1949,6 +1954,11 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 
 				// GH-2201: Wire task checker for retry grace period
 				pollerOpts = append(pollerOpts, github.WithTaskChecker(storeTaskChecker{store: store}))
+
+				// GH-2242: Wire execution checker to prevent re-dispatch of completed tasks
+				if store != nil {
+					pollerOpts = append(pollerOpts, github.WithExecutionChecker(store, projPath))
+				}
 
 				// Capture variables for closures
 				sourceRepo := repoFullName

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -44,6 +44,12 @@ type TaskChecker interface {
 	IsTaskQueued(taskID string) bool
 }
 
+// ExecutionChecker verifies whether a completed execution exists for a task.
+// GH-2242: Prevents re-dispatch of completed tasks when pilot-done label is missing.
+type ExecutionChecker interface {
+	HasCompletedExecution(taskID, projectPath string) (bool, error)
+}
+
 // IssueResult is returned by the issue handler with PR information
 type IssueResult struct {
 	Success    bool
@@ -104,6 +110,11 @@ type Poller struct {
 	// Tracks how many times each issue has been retried after pilot-failed.
 	failedRetryCount map[int]int
 	maxFailedRetries int // default: 3
+
+	// GH-2242: ExecutionChecker prevents re-dispatch of completed tasks
+	// when pilot-done label failed to apply.
+	execChecker ExecutionChecker
+	projectPath string
 }
 
 // PollerOption configures a Poller
@@ -183,6 +194,15 @@ func WithRetryGracePeriod(d time.Duration) PollerOption {
 func WithTaskChecker(tc TaskChecker) PollerOption {
 	return func(p *Poller) {
 		p.taskChecker = tc
+	}
+}
+
+// WithExecutionChecker sets the execution checker used to prevent re-dispatch
+// of tasks that already have a completed execution in the database (GH-2242).
+func WithExecutionChecker(ec ExecutionChecker, projectPath string) PollerOption {
+	return func(p *Poller) {
+		p.execChecker = ec
+		p.projectPath = projectPath
 	}
 }
 
@@ -815,6 +835,24 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 				slog.Int("number", issue.Number),
 			)
 			continue
+		}
+
+		// GH-2242: Before dispatching, check if we already have a completed execution.
+		// This prevents re-dispatch when pilot-done label failed to apply.
+		if p.execChecker != nil {
+			taskID := fmt.Sprintf("GH-%d", issue.Number)
+			completed, err := p.execChecker.HasCompletedExecution(taskID, p.projectPath)
+			if err != nil {
+				p.logger.Warn("Failed to check execution status",
+					slog.Int("number", issue.Number),
+					slog.Any("error", err))
+			} else if completed {
+				p.logger.Info("Skipping re-dispatch — completed execution exists",
+					slog.Int("number", issue.Number),
+					slog.String("task_id", taskID))
+				p.markProcessed(issue.Number)
+				continue
+			}
 		}
 
 		candidates = append(candidates, issue)

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -2247,5 +2248,99 @@ func TestPoller_AutoRetryFailedIssue_ParallelMode_LimitReached(t *testing.T) {
 
 	if processedCount.Load() != 0 {
 		t.Errorf("processed %d issues, want 0 (should skip at retry limit)", processedCount.Load())
+	}
+}
+
+// mockExecutionChecker implements ExecutionChecker for testing.
+type mockExecutionChecker struct {
+	completed map[string]bool // key: "taskID:projectPath"
+}
+
+func (m *mockExecutionChecker) HasCompletedExecution(taskID, projectPath string) (bool, error) {
+	return m.completed[taskID+":"+projectPath], nil
+}
+
+func TestPoller_SkipsCompletedExecution(t *testing.T) {
+	// GH-2242: Issue is open, no pilot-done label, but has completed execution — should NOT dispatch
+	issues := []*Issue{
+		{Number: 42, Title: "Issue 42", Labels: []Label{{Name: "pilot"}}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/issues") {
+			_ = json.NewEncoder(w).Encode(issues)
+			return
+		}
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	execChecker := &mockExecutionChecker{
+		completed: map[string]bool{
+			"GH-42:/project": true,
+		},
+	}
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithExecutionChecker(execChecker, "/project"),
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&callCount); got != 0 {
+		t.Errorf("callback called %d times, want 0 (completed execution should skip dispatch)", got)
+	}
+
+	// Should be marked as processed
+	if !poller.IsProcessed(42) {
+		t.Error("completed issue should be marked as processed")
+	}
+}
+
+func TestPoller_DispatchesWhenNoCompletedExecution(t *testing.T) {
+	// GH-2242: Issue has no completed execution — should dispatch normally
+	issues := []*Issue{
+		{Number: 99, Title: "Issue 99", Labels: []Label{{Name: "pilot"}}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/issues") {
+			_ = json.NewEncoder(w).Encode(issues)
+			return
+		}
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	execChecker := &mockExecutionChecker{
+		completed: map[string]bool{}, // No completed executions
+	}
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithExecutionChecker(execChecker, "/project"),
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&callCount); got != 1 {
+		t.Errorf("callback called %d times, want 1 (should dispatch when no completed execution)", got)
 	}
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -427,6 +427,20 @@ func (s *Store) GetExecution(id string) (*Execution, error) {
 	return &exec, nil
 }
 
+// HasCompletedExecution checks whether a completed execution exists for the given task and project.
+// It returns true if at least one execution with status "completed" exists.
+func (s *Store) HasCompletedExecution(taskID, projectPath string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(`
+		SELECT COUNT(*) FROM executions
+		WHERE task_id = ? AND project_path = ? AND status = 'completed'
+	`, taskID, projectPath).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 // GetRecentExecutions returns the most recent executions ordered by creation time.
 // The limit parameter specifies the maximum number of executions to return.
 func (s *Store) GetRecentExecutions(limit int) ([]*Execution, error) {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -277,6 +277,59 @@ func TestGetExecution_NotFound(t *testing.T) {
 	}
 }
 
+func TestHasCompletedExecution(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	// No executions yet — should return false
+	completed, err := store.HasCompletedExecution("GH-42", "/project")
+	if err != nil {
+		t.Fatalf("HasCompletedExecution failed: %v", err)
+	}
+	if completed {
+		t.Error("expected false for non-existent task")
+	}
+
+	// Save a non-completed execution
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-pending",
+		TaskID:      "GH-42",
+		ProjectPath: "/project",
+		Status:      "running",
+	})
+	completed, err = store.HasCompletedExecution("GH-42", "/project")
+	if err != nil {
+		t.Fatalf("HasCompletedExecution failed: %v", err)
+	}
+	if completed {
+		t.Error("expected false for running task")
+	}
+
+	// Save a completed execution
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-done",
+		TaskID:      "GH-42",
+		ProjectPath: "/project",
+		Status:      "completed",
+	})
+	completed, err = store.HasCompletedExecution("GH-42", "/project")
+	if err != nil {
+		t.Fatalf("HasCompletedExecution failed: %v", err)
+	}
+	if !completed {
+		t.Error("expected true for completed task")
+	}
+
+	// Different project path — should return false
+	completed, _ = store.HasCompletedExecution("GH-42", "/other-project")
+	if completed {
+		t.Error("expected false for different project path")
+	}
+}
+
 func TestPattern_Update(t *testing.T) {
 	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
 	defer func() { _ = os.RemoveAll(tmpDir) }()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2242.

Closes #2242

## Changes

GitHub Issue #2242: fix(poller): re-queues completed tasks after restart when pilot-done label missing

## Bug

After Pilot restart, GH-2237 was re-queued even though:
- Execution was "completed" in the DB with PR merged
- Issue was closed on GitHub

The poller relies on `pilot-done` label + `hasMergedWork()` fallback (GH-1983 fix, poller.go:806-808). If label application fails (API error at line 1087), the task gets re-dispatched on restart.

## Root Cause

`checkForNewIssues()` (poller.go:729-810) fetches open issues and checks:
1. Is it in processed map? (LoadProcessedIssues from state store)
2. Does it have `pilot-done` label?
3. Fallback: `hasMergedWork()` check

Gap: if the issue is still OPEN and `pilot-done` label failed to apply, and `hasMergedWork()` has an API error, the issue is re-dispatched despite having a completed execution row.

## Fix

Add execution-status check before dispatching. In `checkForNewIssues()`, after the processed map check:

```go
// Before dispatching, check if we already have a completed execution
if p.execStore != nil {
    taskID := fmt.Sprintf("GH-%d", issue.Number)
    completed, _ := p.execStore.HasCompletedExecution(taskID, p.projectPath)
    if completed {
        logger.Info("Skipping re-dispatch — completed execution exists", "task", taskID)
        p.processedStore.MarkProcessed(issue.Number)
        continue
    }
}
```

This is a defense-in-depth check — the primary path (pilot-done label) should still work, but this prevents re-dispatch when it fails.

## Files

- `internal/adapters/github/poller.go:729-810` — checkForNewIssues
- `internal/adapters/github/poller.go:247-259` — LoadProcessedIssues startup

## Acceptance Criteria

- [ ] Completed tasks are NOT re-queued on restart even if pilot-done label is missing
- [ ] Execution store is checked before dispatch
- [ ] Skipped tasks are marked in processed store to prevent future re-checks
- [ ] Test: completed execution + no pilot-done label + restart = no re-dispatch