### PR TITLE
GH-2241: fix(dispatcher): orphan rows marked failed when task already completed

### DIFF
--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -168,6 +168,18 @@ func (d *Dispatcher) recoverStaleTasks() int {
 		d.log.Warn("Failed to fetch stale running executions", slog.Any("error", err))
 	}
 	for _, exec := range staleRunning {
+		// If this task already completed successfully, delete the orphan row
+		// instead of marking it failed (avoids dashboard showing false failures).
+		if completed, _ := d.store.HasCompletedExecution(exec.TaskID, exec.ProjectPath); completed {
+			d.log.Info("Deleting orphan running row (task already completed)",
+				slog.String("execution_id", exec.ID),
+				slog.String("task_id", exec.TaskID),
+			)
+			if err := d.store.DeleteExecution(exec.ID); err != nil {
+				d.log.Error("Failed to delete orphan running row", slog.String("id", exec.ID), slog.Any("error", err))
+			}
+			continue
+		}
 		d.log.Warn("Marking stale running task as failed",
 			slog.String("execution_id", exec.ID),
 			slog.String("task_id", exec.TaskID),
@@ -186,6 +198,16 @@ func (d *Dispatcher) recoverStaleTasks() int {
 		d.log.Warn("Failed to fetch stale queued executions", slog.Any("error", err))
 	}
 	for _, exec := range staleQueued {
+		if completed, _ := d.store.HasCompletedExecution(exec.TaskID, exec.ProjectPath); completed {
+			d.log.Info("Deleting orphan queued row (task already completed)",
+				slog.String("execution_id", exec.ID),
+				slog.String("task_id", exec.TaskID),
+			)
+			if err := d.store.DeleteExecution(exec.ID); err != nil {
+				d.log.Error("Failed to delete orphan queued row", slog.String("id", exec.ID), slog.Any("error", err))
+			}
+			continue
+		}
 		d.log.Warn("Marking stale queued task as failed",
 			slog.String("execution_id", exec.ID),
 			slog.String("task_id", exec.TaskID),

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -662,6 +662,195 @@ func TestRunStaleRecoveryLoop_Periodic(t *testing.T) {
 	}
 }
 
+func TestRecoverStaleTasks_DeletesOrphanWhenCompleted(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Scenario: same TaskID has a completed row AND an orphan running/queued row.
+	executions := []*memory.Execution{
+		{ID: "exec-completed", TaskID: "TASK-ORPHAN", ProjectPath: "/project", Status: "completed"},
+		{ID: "exec-orphan-run", TaskID: "TASK-ORPHAN", ProjectPath: "/project", Status: "running"},
+		{ID: "exec-orphan-q", TaskID: "TASK-ORPHAN", ProjectPath: "/project", Status: "queued"},
+	}
+	for _, exec := range executions {
+		if err := store.SaveExecution(exec); err != nil {
+			t.Fatalf("failed to save execution: %v", err)
+		}
+	}
+
+	config := &DispatcherConfig{
+		StaleRunningThreshold: 0,
+		StaleQueuedThreshold:  0,
+		StaleRecoveryInterval: time.Hour,
+	}
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, config)
+
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	// Orphan rows should be deleted, not marked failed.
+	for _, id := range []string{"exec-orphan-run", "exec-orphan-q"} {
+		exec, err := store.GetExecution(id)
+		if err == nil && exec != nil {
+			t.Errorf("expected orphan %s to be deleted, but it still exists with status '%s'", id, exec.Status)
+		}
+	}
+
+	// Completed row should remain untouched.
+	exec, err := store.GetExecution("exec-completed")
+	if err != nil {
+		t.Fatalf("failed to get completed execution: %v", err)
+	}
+	if exec.Status != "completed" {
+		t.Errorf("expected completed execution to remain 'completed', got '%s'", exec.Status)
+	}
+}
+
+func TestRecoverStaleTasks_MarksFailedWhenNoCompleted(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Scenario: orphan rows with no completed execution for the same TaskID.
+	executions := []*memory.Execution{
+		{ID: "exec-only-run", TaskID: "TASK-NOCOMPLETE", ProjectPath: "/project", Status: "running"},
+		{ID: "exec-only-q", TaskID: "TASK-NOCOMPLETE-Q", ProjectPath: "/project", Status: "queued"},
+	}
+	for _, exec := range executions {
+		if err := store.SaveExecution(exec); err != nil {
+			t.Fatalf("failed to save execution: %v", err)
+		}
+	}
+
+	config := &DispatcherConfig{
+		StaleRunningThreshold: 0,
+		StaleQueuedThreshold:  0,
+		StaleRecoveryInterval: time.Hour,
+	}
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, config)
+
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	// Both should be marked failed (no completed execution exists).
+	for _, id := range []string{"exec-only-run", "exec-only-q"} {
+		exec, err := store.GetExecution(id)
+		if err != nil {
+			t.Fatalf("failed to get execution %s: %v", id, err)
+		}
+		if exec.Status != "failed" {
+			t.Errorf("expected %s to be 'failed', got '%s'", id, exec.Status)
+		}
+	}
+}
+
+func TestRecoverStaleTasks_DifferentProjectPath(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Scenario: completed execution exists for a DIFFERENT project path.
+	// The orphan should still be marked failed (HasCompletedExecution checks both fields).
+	executions := []*memory.Execution{
+		{ID: "exec-diff-completed", TaskID: "TASK-DIFF", ProjectPath: "/project-a", Status: "completed"},
+		{ID: "exec-diff-orphan", TaskID: "TASK-DIFF", ProjectPath: "/project-b", Status: "running"},
+	}
+	for _, exec := range executions {
+		if err := store.SaveExecution(exec); err != nil {
+			t.Fatalf("failed to save execution: %v", err)
+		}
+	}
+
+	config := &DispatcherConfig{
+		StaleRunningThreshold: 0,
+		StaleQueuedThreshold:  0,
+		StaleRecoveryInterval: time.Hour,
+	}
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, config)
+
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	// Different project path → no match → should be marked failed, not deleted.
+	exec, err := store.GetExecution("exec-diff-orphan")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected orphan with different project to be 'failed', got '%s'", exec.Status)
+	}
+}
+
+func TestStore_HasCompletedExecution(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	executions := []*memory.Execution{
+		{ID: "exec-hce-1", TaskID: "TASK-HCE", ProjectPath: "/project-a", Status: "completed"},
+		{ID: "exec-hce-2", TaskID: "TASK-HCE", ProjectPath: "/project-b", Status: "running"},
+		{ID: "exec-hce-3", TaskID: "TASK-HCE-NONE", ProjectPath: "/project-a", Status: "failed"},
+	}
+	for _, exec := range executions {
+		if err := store.SaveExecution(exec); err != nil {
+			t.Fatalf("failed to save execution: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name        string
+		taskID      string
+		projectPath string
+		want        bool
+	}{
+		{"completed exists", "TASK-HCE", "/project-a", true},
+		{"different project", "TASK-HCE", "/project-b", false},
+		{"only failed", "TASK-HCE-NONE", "/project-a", false},
+		{"nonexistent task", "TASK-NOPE", "/project-a", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := store.HasCompletedExecution(tc.taskID, tc.projectPath)
+			if err != nil {
+				t.Fatalf("HasCompletedExecution error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("HasCompletedExecution(%q, %q) = %v, want %v", tc.taskID, tc.projectPath, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStore_DeleteExecution(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{
+		ID:          "exec-del",
+		TaskID:      "TASK-DEL",
+		ProjectPath: "/project",
+		Status:      "running",
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("failed to save execution: %v", err)
+	}
+
+	if err := store.DeleteExecution("exec-del"); err != nil {
+		t.Fatalf("DeleteExecution error: %v", err)
+	}
+
+	got, err := store.GetExecution("exec-del")
+	if err == nil && got != nil {
+		t.Errorf("expected execution to be deleted, but found status '%s'", got.Status)
+	}
+}
+
 func TestQueueTask_AfterRecovery(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -931,6 +931,28 @@ func (s *Store) GetStaleQueuedExecutions(staleDuration time.Duration) ([]*Execut
 	return executions, nil
 }
 
+// HasCompletedExecution checks if a task already has a completed execution for
+// the given project. Used by stale recovery to avoid marking orphan rows as
+// failed when the task already succeeded.
+func (s *Store) HasCompletedExecution(taskID, projectPath string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(`
+		SELECT COUNT(*) FROM executions
+		WHERE task_id = ? AND project_path = ? AND status = 'completed'
+	`, taskID, projectPath).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// DeleteExecution removes an execution row by ID. Used to clean up orphan rows
+// when the same task already has a completed execution.
+func (s *Store) DeleteExecution(id string) error {
+	_, err := s.db.Exec("DELETE FROM executions WHERE id = ?", id)
+	return err
+}
+
 // IsTaskQueued checks if a task with the given ID is already queued or running.
 // Used to prevent duplicate task submissions.
 func (s *Store) IsTaskQueued(taskID string) (bool, error) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2241.

Closes #2241

## Changes

GitHub Issue #2241: fix(dispatcher): orphan rows marked failed when task already completed

## Bug

`recoverStaleTasks()` in `dispatcher.go:162-203` marks stale running/queued executions as `failed` without checking if the same TaskID already has a `completed` execution.

Observed: GH-2237 had 3 rows — 1 completed (with PR), 1 failed (orphan), 1 queued (orphan). Dashboard showed the task as failed even though it succeeded.

## Root Cause

`GetStaleRunningExecutions()` and `GetStaleQueuedExecutions()` (store.go:874-930) fetch ALL rows matching status+threshold. Recovery marks each independently without per-TaskID dedup.

## Fix

In `recoverStaleTasks()`, before marking as failed, check if the same TaskID has a completed execution:

```go
for _, exec := range staleRunning {
    // Check if this task already completed successfully
    completed, _ := d.store.HasCompletedExecution(exec.TaskID, exec.ProjectPath)
    if completed {
        // Delete orphan row instead of marking failed
        d.store.DeleteExecution(exec.ID)
        continue
    }
    // Only mark failed if no completed execution exists
    d.store.UpdateExecutionStatus(exec.ID, "failed", "stale running task recovered")
}
```

Add `HasCompletedExecution(taskID, projectPath)` to store.go:
```go
func (s *Store) HasCompletedExecution(taskID, projectPath string) (bool, error) {
    var count int
    err := s.db.QueryRow(
        "SELECT COUNT(*) FROM executions WHERE task_id = ? AND project_path = ? AND status = 'completed'",
        taskID, projectPath,
    ).Scan(&count)
    return count > 0, err
}
```

Same pattern for stale queued cleanup.

## Files

- `internal/executor/dispatcher.go:162-203` — recoverStaleTasks
- `internal/memory/store.go:874-930` — GetStaleRunningExecutions, GetStaleQueuedExecutions
- `internal/memory/store.go` — add HasCompletedExecution

## Acceptance Criteria

- [ ] Orphan rows deleted (not marked failed) when completed execution exists
- [ ] Dashboard shows correct status for completed tasks
- [ ] HasCompletedExecution checks both task_id AND project_path
- [ ] Tests cover: completed+orphan scenario, no-completed scenario