### PR TITLE
GH-2242: fix(poller): re-queues completed tasks after restart when pilot-done label missing

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -725,6 +725,8 @@ Examples:
 					// GH-2201: Wire task checker for retry grace period (gateway mode)
 					if gwStore != nil {
 						pollerOpts = append(pollerOpts, github.WithTaskChecker(storeTaskChecker{store: gwStore}))
+						// GH-2242: Wire execution checker to prevent re-dispatch of completed tasks
+						pollerOpts = append(pollerOpts, github.WithExecutionChecker(gwStore))
 					}
 
 					// Create rate limit retry scheduler
@@ -1949,6 +1951,8 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 
 				// GH-2201: Wire task checker for retry grace period
 				pollerOpts = append(pollerOpts, github.WithTaskChecker(storeTaskChecker{store: store}))
+				// GH-2242: Wire execution checker to prevent re-dispatch of completed tasks
+				pollerOpts = append(pollerOpts, github.WithExecutionChecker(store))
 
 				// Capture variables for closures
 				sourceRepo := repoFullName

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -44,6 +44,12 @@ type TaskChecker interface {
 	IsTaskQueued(taskID string) bool
 }
 
+// ExecutionChecker checks whether a completed execution exists for a task.
+// GH-2242: Defense-in-depth to prevent re-dispatch when pilot-done label is missing.
+type ExecutionChecker interface {
+	HasCompletedExecution(taskID string) (bool, error)
+}
+
 // IssueResult is returned by the issue handler with PR information
 type IssueResult struct {
 	Success    bool
@@ -99,6 +105,10 @@ type Poller struct {
 	// GH-2201: TaskChecker verifies whether an issue is still queued/in-progress
 	// before allowing retry after the grace period expires.
 	taskChecker TaskChecker
+
+	// GH-2242: ExecutionChecker prevents re-dispatch of completed tasks
+	// when pilot-done label is missing (e.g. label API error).
+	execChecker ExecutionChecker
 
 	// GH-2176: Auto-retry issues stuck with pilot-failed from execution failures.
 	// Tracks how many times each issue has been retried after pilot-failed.
@@ -183,6 +193,14 @@ func WithRetryGracePeriod(d time.Duration) PollerOption {
 func WithTaskChecker(tc TaskChecker) PollerOption {
 	return func(p *Poller) {
 		p.taskChecker = tc
+	}
+}
+
+// WithExecutionChecker sets the execution checker used to prevent re-dispatch
+// of tasks that already have a completed execution in the database.
+func WithExecutionChecker(ec ExecutionChecker) PollerOption {
+	return func(p *Poller) {
+		p.execChecker = ec
 	}
 }
 
@@ -614,6 +632,23 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 			}
 		}
 
+		// GH-2242: Defense-in-depth — check execution store for completed tasks
+		if p.execChecker != nil {
+			taskID := fmt.Sprintf("GH-%d", issue.Number)
+			completed, checkErr := p.execChecker.HasCompletedExecution(taskID)
+			if checkErr != nil {
+				p.logger.Warn("Failed to check execution status",
+					slog.Int("number", issue.Number),
+					slog.Any("error", checkErr))
+			} else if completed {
+				p.logger.Info("Skipping re-dispatch — completed execution exists",
+					slog.Int("number", issue.Number),
+					slog.String("task_id", taskID))
+				p.markProcessed(issue.Number)
+				continue
+			}
+		}
+
 		candidates = append(candidates, issue)
 	}
 
@@ -815,6 +850,24 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 				slog.Int("number", issue.Number),
 			)
 			continue
+		}
+
+		// GH-2242: Defense-in-depth — check execution store for completed tasks
+		// before dispatching. Prevents re-dispatch when pilot-done label failed to apply.
+		if p.execChecker != nil {
+			taskID := fmt.Sprintf("GH-%d", issue.Number)
+			completed, err := p.execChecker.HasCompletedExecution(taskID)
+			if err != nil {
+				p.logger.Warn("Failed to check execution status",
+					slog.Int("number", issue.Number),
+					slog.Any("error", err))
+			} else if completed {
+				p.logger.Info("Skipping re-dispatch — completed execution exists",
+					slog.Int("number", issue.Number),
+					slog.String("task_id", taskID))
+				p.markProcessed(issue.Number)
+				continue
+			}
 		}
 
 		candidates = append(candidates, issue)

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2249,3 +2249,136 @@ func TestPoller_AutoRetryFailedIssue_ParallelMode_LimitReached(t *testing.T) {
 		t.Errorf("processed %d issues, want 0 (should skip at retry limit)", processedCount.Load())
 	}
 }
+
+// mockExecutionChecker implements ExecutionChecker for testing.
+type mockExecutionChecker struct {
+	completed map[string]bool
+	err       error
+}
+
+func (m *mockExecutionChecker) HasCompletedExecution(taskID string) (bool, error) {
+	if m.err != nil {
+		return false, m.err
+	}
+	return m.completed[taskID], nil
+}
+
+func TestPoller_CheckForNewIssues_SkipsCompletedExecution(t *testing.T) {
+	// GH-2242: Issue has no pilot-done label but execution store shows completed.
+	// Should skip dispatch and mark processed.
+	issues := []*Issue{
+		{Number: 42, Title: "Already completed", Labels: []Label{{Name: "pilot"}}, CreatedAt: time.Now()},
+		{Number: 43, Title: "New issue", Labels: []Label{{Name: "pilot"}}, CreatedAt: time.Now()},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var processedIssues []int
+	var mu sync.Mutex
+
+	checker := &mockExecutionChecker{
+		completed: map[string]bool{"GH-42": true},
+	}
+
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			mu.Lock()
+			processedIssues = append(processedIssues, issue.Number)
+			mu.Unlock()
+			return nil
+		}),
+		WithExecutionChecker(checker),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(processedIssues) != 1 {
+		t.Fatalf("processed %d issues, want 1", len(processedIssues))
+	}
+	if processedIssues[0] != 43 {
+		t.Errorf("processed issue %d, want 43", processedIssues[0])
+	}
+
+	// Verify issue 42 was marked as processed
+	if !poller.IsProcessed(42) {
+		t.Error("issue 42 should be marked as processed")
+	}
+}
+
+func TestPoller_FindOldestUnprocessedIssue_SkipsCompletedExecution(t *testing.T) {
+	// GH-2242: Sequential mode — issue with completed execution should be skipped.
+	issues := []*Issue{
+		{Number: 42, Title: "Already completed", Labels: []Label{{Name: "pilot"}}, CreatedAt: time.Now()},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	checker := &mockExecutionChecker{
+		completed: map[string]bool{"GH-42": true},
+	}
+
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithExecutionChecker(checker),
+	)
+	poller.executionMode = ExecutionModeSequential
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if issue != nil {
+		t.Errorf("expected nil issue, got #%d", issue.Number)
+	}
+	if !poller.IsProcessed(42) {
+		t.Error("issue 42 should be marked as processed")
+	}
+}
+
+func TestPoller_CheckForNewIssues_ExecutionCheckError(t *testing.T) {
+	// GH-2242: If execution check fails, issue should still be dispatched (fail-open).
+	issues := []*Issue{
+		{Number: 42, Title: "Check fails", Labels: []Label{{Name: "pilot"}}, CreatedAt: time.Now()},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var processedCount atomic.Int32
+	checker := &mockExecutionChecker{err: errors.New("db error")}
+
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			processedCount.Add(1)
+			return nil
+		}),
+		WithExecutionChecker(checker),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if processedCount.Load() != 1 {
+		t.Errorf("processed %d issues, want 1 (should dispatch on check error)", processedCount.Load())
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -856,6 +856,20 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 	})
 }
 
+// HasCompletedExecution checks whether a completed execution exists for the given task ID.
+// Used as a defense-in-depth check to prevent re-dispatch of already-completed tasks.
+func (s *Store) HasCompletedExecution(taskID string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(`
+		SELECT COUNT(*) FROM executions
+		WHERE task_id = ? AND status = 'completed'
+	`, taskID).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("HasCompletedExecution: %w", err)
+	}
+	return count > 0, nil
+}
+
 // UpdateExecutionResult updates the result fields of an execution record.
 // Called when task execution completes successfully with PR/commit info.
 func (s *Store) UpdateExecutionResult(id string, prURL, commitSHA string, durationMs int64) error {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1495,3 +1495,52 @@ func TestGetStaleQueuedExecutions(t *testing.T) {
 		t.Errorf("expected status 'queued', got %q", results[0].Status)
 	}
 }
+
+func TestHasCompletedExecution(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	// No executions — should return false
+	has, err := store.HasCompletedExecution("GH-42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if has {
+		t.Error("expected false for non-existent task")
+	}
+
+	// Add a failed execution — should still return false
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-failed",
+		TaskID:      "GH-42",
+		ProjectPath: "/repo",
+		Status:      "failed",
+	})
+
+	has, err = store.HasCompletedExecution("GH-42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if has {
+		t.Error("expected false for failed-only task")
+	}
+
+	// Add a completed execution — should return true
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-done",
+		TaskID:      "GH-42",
+		ProjectPath: "/repo",
+		Status:      "completed",
+	})
+
+	has, err = store.HasCompletedExecution("GH-42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !has {
+		t.Error("expected true for completed task")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2242.

Closes #2242

## Changes

GitHub Issue #2242: fix(poller): re-queues completed tasks after restart when pilot-done label missing

## Bug

After Pilot restart, GH-2237 was re-queued even though:
- Execution was "completed" in the DB with PR merged
- Issue was closed on GitHub

The poller relies on `pilot-done` label + `hasMergedWork()` fallback (GH-1983 fix, poller.go:806-808). If label application fails (API error at line 1087), the task gets re-dispatched on restart.

## Root Cause

`checkForNewIssues()` (poller.go:729-810) fetches open issues and checks:
1. Is it in processed map? (LoadProcessedIssues from state store)
2. Does it have `pilot-done` label?
3. Fallback: `hasMergedWork()` check

Gap: if the issue is still OPEN and `pilot-done` label failed to apply, and `hasMergedWork()` has an API error, the issue is re-dispatched despite having a completed execution row.

## Fix

Add execution-status check before dispatching. In `checkForNewIssues()`, after the processed map check:

```go
// Before dispatching, check if we already have a completed execution
if p.execStore != nil {
    taskID := fmt.Sprintf("GH-%d", issue.Number)
    completed, _ := p.execStore.HasCompletedExecution(taskID, p.projectPath)
    if completed {
        logger.Info("Skipping re-dispatch — completed execution exists", "task", taskID)
        p.processedStore.MarkProcessed(issue.Number)
        continue
    }
}
```

This is a defense-in-depth check — the primary path (pilot-done label) should still work, but this prevents re-dispatch when it fails.

## Files

- `internal/adapters/github/poller.go:729-810` — checkForNewIssues
- `internal/adapters/github/poller.go:247-259` — LoadProcessedIssues startup

## Acceptance Criteria

- [ ] Completed tasks are NOT re-queued on restart even if pilot-done label is missing
- [ ] Execution store is checked before dispatch
- [ ] Skipped tasks are marked in processed store to prevent future re-checks
- [ ] Test: completed execution + no pilot-done label + restart = no re-dispatch