### PR TITLE
fix(autopilot): no release tag when PRs are merged externally (GH-2251)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1749,9 +1749,10 @@ func (c *Controller) ScanExistingPRs(ctx context.Context) error {
 	return nil
 }
 
-// ScanRecentlyMergedPRs scans for Pilot PRs that were merged while Pilot was offline.
-// This catches PRs that need release triggering but were merged externally.
-// Called on startup after ScanExistingPRs.
+// ScanRecentlyMergedPRs scans for Pilot PRs that were merged externally.
+// This catches PRs that need release triggering but were merged outside of
+// autopilot (e.g. via `gh pr merge` or the GitHub UI).
+// Called on startup and periodically from the Run loop.
 func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 	// Skip if auto-release is not enabled
 	if !c.shouldTriggerRelease() {
@@ -1818,6 +1819,14 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			continue
 		}
 		if mergedAt.Before(cutoff) {
+			continue
+		}
+
+		// Skip if already tracked in activePRs (avoid duplicate processing)
+		c.mu.RLock()
+		_, alreadyTracked := c.activePRs[pr.Number]
+		c.mu.RUnlock()
+		if alreadyTracked {
 			continue
 		}
 
@@ -1892,6 +1901,15 @@ func (c *Controller) Run(ctx context.Context) error {
 	idlePollInterval := 60 * time.Second
 	currentInterval := basePollInterval
 
+	// GH-2251: Periodic scan for externally-merged PRs.
+	// Use half the scan window as the interval so merges are detected well within the window.
+	mergedScanInterval := c.config.MergedPRScanWindow / 2
+	if mergedScanInterval < 5*time.Minute {
+		mergedScanInterval = 5 * time.Minute
+	}
+	mergedScanTicker := time.NewTicker(mergedScanInterval)
+	defer mergedScanTicker.Stop()
+
 	ticker := time.NewTicker(currentInterval)
 	defer ticker.Stop()
 
@@ -1900,6 +1918,12 @@ func (c *Controller) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			c.log.Info("autopilot controller stopping")
 			return ctx.Err()
+		case <-mergedScanTicker.C:
+			// GH-2251: Periodically scan for externally-merged PRs that
+			// were never tracked by autopilot (e.g. merged via gh pr merge).
+			if err := c.ScanRecentlyMergedPRs(ctx); err != nil {
+				c.log.Warn("periodic merged PR scan failed", "error", err)
+			}
 		case <-ticker.C:
 			c.processAllPRs(ctx)
 

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -4104,3 +4104,211 @@ func TestNotifyExternalClose_MaybeCloseParent(t *testing.T) {
 		})
 	}
 }
+
+// GH-2251: Test that ScanRecentlyMergedPRs discovers externally-merged PRs
+// and skips those already tracked.
+func TestController_ScanRecentlyMergedPRs(t *testing.T) {
+	recentMergedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	oldMergedAt := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+
+	tests := []struct {
+		name             string
+		prs              []github.PullRequest
+		existingTracked  []int // PR numbers already in activePRs
+		wantTriggered    int
+		wantPRNumbers    []int
+	}{
+		{
+			name: "discovers externally merged pilot PR",
+			prs: []github.PullRequest{
+				{
+					Number:         42,
+					Head:           github.PRRef{Ref: "pilot/GH-100", SHA: "sha1"},
+					Base:           github.PRRef{Ref: "main"},
+					HTMLURL:        "https://github.com/owner/repo/pull/42",
+					Title:          "feat(api): add endpoint",
+					Merged:         true,
+					MergedAt:       recentMergedAt,
+					MergeCommitSHA: "merge-sha-42",
+				},
+			},
+			wantTriggered: 1,
+			wantPRNumbers: []int{42},
+		},
+		{
+			name: "skips PR already tracked in activePRs",
+			prs: []github.PullRequest{
+				{
+					Number:         42,
+					Head:           github.PRRef{Ref: "pilot/GH-100", SHA: "sha1"},
+					Base:           github.PRRef{Ref: "main"},
+					HTMLURL:        "https://github.com/owner/repo/pull/42",
+					Title:          "feat(api): add endpoint",
+					Merged:         true,
+					MergedAt:       recentMergedAt,
+					MergeCommitSHA: "merge-sha-42",
+				},
+			},
+			existingTracked: []int{42},
+			wantTriggered:   0,
+			wantPRNumbers:   []int{},
+		},
+		{
+			name: "skips PR merged outside scan window",
+			prs: []github.PullRequest{
+				{
+					Number:         42,
+					Head:           github.PRRef{Ref: "pilot/GH-100", SHA: "sha1"},
+					Base:           github.PRRef{Ref: "main"},
+					HTMLURL:        "https://github.com/owner/repo/pull/42",
+					Title:          "feat(api): add endpoint",
+					Merged:         true,
+					MergedAt:       oldMergedAt,
+					MergeCommitSHA: "merge-sha-42",
+				},
+			},
+			wantTriggered: 0,
+			wantPRNumbers: []int{},
+		},
+		{
+			name: "skips non-pilot branches and unmerged PRs",
+			prs: []github.PullRequest{
+				{
+					Number:   1,
+					Head:     github.PRRef{Ref: "feature/stuff", SHA: "sha1"},
+					Base:     github.PRRef{Ref: "main"},
+					HTMLURL:  "https://github.com/owner/repo/pull/1",
+					Merged:   true,
+					MergedAt: recentMergedAt,
+				},
+				{
+					Number:  2,
+					Head:    github.PRRef{Ref: "pilot/GH-200", SHA: "sha2"},
+					Base:    github.PRRef{Ref: "main"},
+					HTMLURL: "https://github.com/owner/repo/pull/2",
+					Merged:  false, // closed but not merged
+				},
+			},
+			wantTriggered: 0,
+			wantPRNumbers: []int{},
+		},
+		{
+			name: "mixed: discovers one, skips tracked and old",
+			prs: []github.PullRequest{
+				{
+					Number:         10,
+					Head:           github.PRRef{Ref: "pilot/GH-10", SHA: "sha10"},
+					Base:           github.PRRef{Ref: "main"},
+					HTMLURL:        "https://github.com/owner/repo/pull/10",
+					Title:          "fix(db): connection leak",
+					Merged:         true,
+					MergedAt:       recentMergedAt,
+					MergeCommitSHA: "merge-sha-10",
+				},
+				{
+					Number:         20,
+					Head:           github.PRRef{Ref: "pilot/GH-20", SHA: "sha20"},
+					Base:           github.PRRef{Ref: "main"},
+					HTMLURL:        "https://github.com/owner/repo/pull/20",
+					Title:          "feat(ui): dashboard",
+					Merged:         true,
+					MergedAt:       recentMergedAt,
+					MergeCommitSHA: "merge-sha-20",
+				},
+				{
+					Number:         30,
+					Head:           github.PRRef{Ref: "pilot/GH-30", SHA: "sha30"},
+					Base:           github.PRRef{Ref: "main"},
+					HTMLURL:        "https://github.com/owner/repo/pull/30",
+					Title:          "chore: cleanup",
+					Merged:         true,
+					MergedAt:       oldMergedAt, // outside window
+					MergeCommitSHA: "merge-sha-30",
+				},
+			},
+			existingTracked: []int{20}, // already tracked
+			wantTriggered:   1,         // only PR 10
+			wantPRNumbers:   []int{10},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+					prs := make([]*github.PullRequest, len(tt.prs))
+					for i := range tt.prs {
+						prs[i] = &tt.prs[i]
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(prs)
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/releases"):
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("[]"))
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.Release = &ReleaseConfig{
+				Enabled:   true,
+				Trigger:   "on_merge",
+				TagPrefix: "v",
+			}
+			cfg.MergedPRScanWindow = 30 * time.Minute
+
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			// Pre-populate tracked PRs
+			for _, prNum := range tt.existingTracked {
+				c.mu.Lock()
+				c.activePRs[prNum] = &PRState{PRNumber: prNum, Stage: StageWaitingCI}
+				c.mu.Unlock()
+			}
+
+			err := c.ScanRecentlyMergedPRs(context.Background())
+			if err != nil {
+				t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+			}
+
+			// Count newly triggered PRs (exclude pre-existing tracked ones)
+			triggered := 0
+			for _, pr := range c.GetActivePRs() {
+				isPreExisting := false
+				for _, existing := range tt.existingTracked {
+					if pr.PRNumber == existing {
+						isPreExisting = true
+						break
+					}
+				}
+				if !isPreExisting {
+					triggered++
+				}
+			}
+
+			if triggered != tt.wantTriggered {
+				t.Errorf("triggered %d PRs, want %d", triggered, tt.wantTriggered)
+			}
+
+			for _, wantPR := range tt.wantPRNumbers {
+				found := false
+				for _, pr := range c.GetActivePRs() {
+					if pr.PRNumber == wantPR {
+						if pr.Stage != StageReleasing {
+							t.Errorf("PR %d stage = %v, want StageReleasing", wantPR, pr.Stage)
+						}
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("PR %d not found in active PRs", wantPR)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Bug**: When PRs were merged externally (via `gh pr merge` or GitHub UI), no release tag was created because `ScanRecentlyMergedPRs` only ran at startup — it never fired during normal operation
- **Fix**: Added periodic merged-PR scan to the autopilot `Run` loop (every `MergedPRScanWindow/2`, minimum 5 minutes), so externally-merged PRs are discovered within one scan cycle
- Added duplicate-tracking guard: PRs already in `activePRs` are skipped to prevent double-processing

## Test plan

- [x] Table-driven tests covering 5 scenarios: discovery, dedup (already tracked), window filtering (too old), non-pilot branches, mixed cases
- [x] Full autopilot test suite passes
- [x] `go build ./...` passes
- [ ] Manual: merge a PR via `gh pr merge`, verify release tag appears within scan interval

Closes #2251