### PR TITLE
GH-2252: fix(poller): shouldRetryFailedIssue retries closed issues with stale pilot-failed label

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -1143,6 +1143,15 @@ func (p *Poller) hasMergedWork(ctx context.Context, issue *Issue) bool {
 // Returns true if the issue should be retried (label removed), false if it should be skipped.
 // GH-2176: Issues stuck with pilot-failed get retried up to maxFailedRetries times.
 func (p *Poller) shouldRetryFailedIssue(ctx context.Context, issue *Issue) bool {
+	// Don't retry closed issues — they may have stale pilot-failed labels (GH-2252)
+	if issue.State != "open" {
+		p.logger.Info("Skipping retry — issue is closed",
+			slog.Int("number", issue.Number),
+			slog.String("state", issue.State),
+		)
+		return false
+	}
+
 	// Never retry if also marked done
 	if HasLabel(issue, LabelDone) {
 		return false

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2049,7 +2049,7 @@ func TestPoller_ProcessedMapStoresTimestamps(t *testing.T) {
 func TestPoller_AutoRetryFailedIssue_FirstFailure(t *testing.T) {
 	now := time.Now()
 	issues := []*Issue{
-		{Number: 42, Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
 	}
 
 	var labelRemoved atomic.Bool
@@ -2102,8 +2102,8 @@ func TestPoller_AutoRetryFailedIssue_FirstFailure(t *testing.T) {
 func TestPoller_AutoRetryFailedIssue_RetryLimitReached(t *testing.T) {
 	now := time.Now()
 	issues := []*Issue{
-		{Number: 42, Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
-		{Number: 43, Title: "Available issue", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, State: "open", Title: "Available issue", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2138,8 +2138,8 @@ func TestPoller_AutoRetryFailedIssue_SkipsDoneIssues(t *testing.T) {
 	now := time.Now()
 	issues := []*Issue{
 		// Has both pilot-failed AND pilot-done — should NOT be retried
-		{Number: 42, Title: "Done+Failed", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}, {Name: LabelDone}}, CreatedAt: now.Add(-1 * time.Hour)},
-		{Number: 43, Title: "Available", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+		{Number: 42, State: "open", Title: "Done+Failed", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}, {Name: LabelDone}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, State: "open", Title: "Available", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2163,10 +2163,39 @@ func TestPoller_AutoRetryFailedIssue_SkipsDoneIssues(t *testing.T) {
 	}
 }
 
+func TestPoller_AutoRetryFailedIssue_SkipsClosedIssues(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		// Closed issue with stale pilot-failed label — should NOT be retried (GH-2252)
+		{Number: 42, State: "closed", Title: "Closed+Failed", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, State: "open", Title: "Available", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil {
+		t.Fatal("issue should not be nil — #43 should be picked")
+	}
+	if issue.Number != 43 {
+		t.Errorf("got issue #%d, want #43 (should skip closed #42 with pilot-failed)", issue.Number)
+	}
+}
+
 func TestPoller_AutoRetryFailedIssue_ParallelMode(t *testing.T) {
 	now := time.Now()
 	issues := []*Issue{
-		{Number: 42, Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
 	}
 
 	var labelRemoved atomic.Bool
@@ -2218,7 +2247,7 @@ func TestPoller_AutoRetryFailedIssue_ParallelMode(t *testing.T) {
 func TestPoller_AutoRetryFailedIssue_ParallelMode_LimitReached(t *testing.T) {
 	now := time.Now()
 	issues := []*Issue{
-		{Number: 42, Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2252.

Closes #2252

## Changes

GitHub Issue #2252: fix(poller): shouldRetryFailedIssue retries closed issues with stale pilot-failed label

## Bug

After Pilot restart, CLOSED issue #2248 was re-dispatched because it still had the `pilot-failed` label from earlier orphan recovery. The poller should only retry OPEN issues.

## Root Cause

`shouldRetryFailedIssue()` at `poller.go:1145-1192` does NOT check if the issue is OPEN before retrying. While `ListIssues` correctly filters `State: StateOpen`, there's a race: the issue can be closed (by PR merge) between fetch and retry evaluation.

The function checks:
- Has `pilot-done` label
- Retry count vs max
- Has merged work
- But NOT `issue.State == "open"`

## Fix

Add state check at top of `shouldRetryFailedIssue()`:

```go
func (p *Poller) shouldRetryFailedIssue(ctx context.Context, issue *Issue) bool {
    // Don't retry closed issues — they may have stale pilot-failed labels
    if issue.State != "open" {
        p.logger.Info("Skipping retry — issue is closed",
            slog.Int("number", issue.Number),
            slog.String("state", issue.State))
        return false
    }
    // ... rest of existing function unchanged
}
```

## Files

- `internal/adapters/github/poller.go:1145` — `shouldRetryFailedIssue()`

## Acceptance Criteria

- [ ] `shouldRetryFailedIssue()` returns false for non-open issues
- [ ] Closed issues with stale `pilot-failed` are not re-dispatched
- [ ] Test: mock closed issue with pilot-failed label → verify no dispatch