### PR TITLE
GH-2258: Add dryRun guard and idempotency check to Runner's gh CLI methods

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -593,6 +593,10 @@ func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, e
 
 // UpdateIssueProgress adds a progress comment to an issue.
 func (r *Runner) UpdateIssueProgress(ctx context.Context, projectPath string, issueID string, message string) error {
+	if r.dryRun {
+		r.log.Info("dryRun: skipping UpdateIssueProgress", "issue", issueID)
+		return nil
+	}
 	args := []string{"issue", "comment", issueID, "--body", message}
 	cmd := exec.CommandContext(ctx, "gh", args...)
 	if projectPath != "" {
@@ -609,7 +613,27 @@ func (r *Runner) UpdateIssueProgress(ctx context.Context, projectPath string, is
 }
 
 // CloseIssueWithComment closes an issue with a completion comment.
+// Includes an idempotency guard: if the issue is already CLOSED, it short-circuits.
 func (r *Runner) CloseIssueWithComment(ctx context.Context, projectPath string, issueID string, comment string) error {
+	if r.dryRun {
+		r.log.Info("dryRun: skipping CloseIssueWithComment", "issue", issueID)
+		return nil
+	}
+
+	// Idempotency guard: check if issue is already closed
+	checkArgs := []string{"issue", "view", issueID, "--json", "state", "--jq", ".state"}
+	checkCmd := exec.CommandContext(ctx, "gh", checkArgs...)
+	if projectPath != "" {
+		checkCmd.Dir = projectPath
+	}
+	if out, err := checkCmd.Output(); err == nil {
+		state := strings.TrimSpace(string(out))
+		if state == "CLOSED" {
+			r.log.Info("issue already closed, skipping", "issue", issueID)
+			return nil
+		}
+	}
+
 	args := []string{"issue", "close", issueID, "--comment", comment}
 	cmd := exec.CommandContext(ctx, "gh", args...)
 	if projectPath != "" {

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -342,6 +342,7 @@ type Runner struct {
 	// GH-1811: Learning system (self-improvement)
 	learningLoop         LearningRecorder              // Optional learning loop for pattern extraction + feedback
 	patternContext       *PatternContext                // Optional pattern context for prompt injection
+	dryRun               bool                          // Skip real gh CLI calls (for testing)
 	selfReviewExtractor  SelfReviewExtractor            // Optional extractor for self-review pattern learning (GH-1955)
 	outcomeTracker       *memory.ModelOutcomeTracker    // Optional outcome tracker for model escalation (GH-1991)
 	// GH-2015: Knowledge graph integration for execution learnings

--- a/internal/executor/sub_issue_callback_test.go
+++ b/internal/executor/sub_issue_callback_test.go
@@ -35,6 +35,7 @@ func newTestRunnerWithExecFunc(execFn func(ctx context.Context, task *Task) (*Ex
 		log:               slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
 		modelRouter:       NewModelRouter(nil, nil),
 		executeFunc:       execFn,
+		dryRun:            true,
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2258.

Closes #2258

## Changes

In `internal/executor/runner.go`, add a `dryRun bool` field to the `Runner` struct. In `internal/executor/epic.go`, wrap `CloseIssueWithComment`, `UpdateIssueProgress`, and `CommentOnIssue` with an early-return when `dryRun` is true (logging the skip). Additionally, add an idempotency guard to `CloseIssueWithComment` that checks issue state via `gh issue view --json state` before attempting to close, short-circuiting if already `CLOSED`. In `internal/executor/sub_issue_callback_test.go`, set `dryRun: true` on the runner returned by `newTestRunnerWithExecFunc()`. Verify with `go test ./internal/executor/ -run TestSequential` producing zero real `gh` API calls, and confirm all existing tests still pass with `go test ./internal/executor/...`.