### PR TITLE
GH-2260: fix(install): replace fragile grep+sed version parsing with jq

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -63,10 +63,14 @@ detect_platform() {
 # Get latest version from GitHub
 get_latest_version() {
     info "Fetching latest version..."
-    VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+    if command -v jq &>/dev/null; then
+        VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | jq -r '.tag_name')
+    else
+        VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+    fi
 
-    if [ -z "$VERSION" ]; then
-        VERSION="v0.1.0"  # Fallback
+    if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+        VERSION="v2.91.0"
         warn "Could not fetch latest version, using $VERSION"
     fi
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2260.

Closes #2260

## Changes

GitHub Issue #2260: fix(install): replace fragile grep+sed version parsing with jq

## Bug

Reported by community user toddboom (#2234). `install.sh` generates wrong download URL — uses `mentions_count` instead of version number.

## Root Cause

Line 66 of `install.sh` uses `grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/'` to parse the GitHub API response. This is fragile — if the API response structure changes or the grep matches a different field, the version extraction breaks.

## Fix

Replace with `jq` parsing (with curl fallback):

```bash
get_latest_version() {
    info "Fetching latest version..."
    
    if command -v jq &>/dev/null; then
        VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | jq -r '.tag_name')
    else
        VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
    fi

    if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
        VERSION="v2.91.0"
        warn "Could not fetch latest version, using $VERSION"
    fi

    info "Latest version: $VERSION"
}
```

## Files

- `install.sh:60-72` — `get_latest_version()` function

## Acceptance Criteria

- [ ] Uses `jq` when available, falls back to grep+sed
- [ ] `head -1` added to grep fallback to prevent multi-match
- [ ] Fallback version updated to current release
- [ ] Closes #2234