### PR TITLE
Fix/gitlab mr creation

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -961,13 +961,19 @@ func handleGitLabIssueWithResult(ctx context.Context, cfg *config.Config, client
 	taskDesc := fmt.Sprintf("GitLab Issue %s: %s\n\n%s", taskID, issue.Title, issue.Description)
 
 	task := &executor.Task{
-		ID:          taskID,
-		Title:       issue.Title,
-		Description: taskDesc,
-		ProjectPath: projectPath,
-		Branch:      branchName,
-		CreatePR:    true,
+		ID:            taskID,
+		Title:         issue.Title,
+		Description:   taskDesc,
+		ProjectPath:   projectPath,
+		Branch:        branchName,
+		CreatePR:      true,
+		SourceAdapter: "gitlab",
+		SourceIssueID: fmt.Sprintf("%d", issue.IID),
 	}
+
+	// Wire GitLab client as PRCreator so the runner creates MRs via
+	// the GitLab API instead of the gh CLI.
+	runner.SetPRCreator(client)
 
 	deps := HandlerDeps{
 		Cfg:          cfg,

--- a/internal/adapters/gitlab/client.go
+++ b/internal/adapters/gitlab/client.go
@@ -234,6 +234,22 @@ func (c *Client) CreateMergeRequest(ctx context.Context, input *MergeRequestInpu
 	return &mr, nil
 }
 
+// CreatePR implements the executor.PRCreator interface.
+// It creates a GitLab merge request and returns the web URL.
+func (c *Client) CreatePR(ctx context.Context, sourceBranch, targetBranch, title, body string) (string, error) {
+	mr, err := c.CreateMergeRequest(ctx, &MergeRequestInput{
+		Title:              title,
+		Description:        body,
+		SourceBranch:       sourceBranch,
+		TargetBranch:       targetBranch,
+		RemoveSourceBranch: true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("GitLab MR creation failed: %w", err)
+	}
+	return mr.WebURL, nil
+}
+
 // GetMergeRequest fetches a merge request by IID
 func (c *Client) GetMergeRequest(ctx context.Context, iid int) (*MergeRequest, error) {
 	path := fmt.Sprintf("/api/v4/projects/%s/merge_requests/%d", c.projectID, iid)

--- a/internal/adapters/gitlab/client_test.go
+++ b/internal/adapters/gitlab/client_test.go
@@ -369,6 +369,47 @@ func TestCreateMergeRequest(t *testing.T) {
 	}
 }
 
+func TestCreatePR_PRCreatorInterface(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		var body MergeRequestInput
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if body.SourceBranch != "pilot/GL-1" {
+			t.Errorf("source_branch = %q, want %q", body.SourceBranch, "pilot/GL-1")
+		}
+		if body.TargetBranch != "main" {
+			t.Errorf("target_branch = %q, want %q", body.TargetBranch, "main")
+		}
+		if !body.RemoveSourceBranch {
+			t.Error("remove_source_branch should be true")
+		}
+		w.WriteHeader(http.StatusCreated)
+		result := MergeRequest{
+			IID:          7,
+			Title:        body.Title,
+			SourceBranch: body.SourceBranch,
+			TargetBranch: body.TargetBranch,
+			State:        MRStateOpened,
+			WebURL:       "https://gitlab.com/ns/proj/-/merge_requests/7",
+		}
+		_ = json.NewEncoder(w).Encode(result)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitLabToken, "ns/proj", server.URL)
+	url, err := client.CreatePR(context.Background(), "pilot/GL-1", "main", "GL-1: Fix bug", "## Summary\n\nFix it")
+	if err != nil {
+		t.Fatalf("CreatePR() error = %v", err)
+	}
+	if url != "https://gitlab.com/ns/proj/-/merge_requests/7" {
+		t.Errorf("CreatePR() url = %q, want gitlab MR URL", url)
+	}
+}
+
 func TestGetMergeRequest(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -257,16 +257,18 @@ func (d *Dispatcher) queueDecomposedTask(ctx context.Context, parent *Task, resu
 
 	// Save parent as "decomposed" status
 	parentExec := &memory.Execution{
-		ID:              parentExecID,
-		TaskID:          parent.ID,
-		ProjectPath:     parent.ProjectPath,
-		Status:          "decomposed",
-		TaskTitle:       parent.Title,
-		TaskDescription: parent.Description,
-		TaskBranch:      parent.Branch,
-		TaskBaseBranch:  parent.BaseBranch,
-		TaskCreatePR:    parent.CreatePR,
-		TaskVerbose:     parent.Verbose,
+		ID:                parentExecID,
+		TaskID:            parent.ID,
+		ProjectPath:       parent.ProjectPath,
+		Status:            "decomposed",
+		TaskTitle:         parent.Title,
+		TaskDescription:   parent.Description,
+		TaskBranch:        parent.Branch,
+		TaskBaseBranch:    parent.BaseBranch,
+		TaskCreatePR:      parent.CreatePR,
+		TaskVerbose:       parent.Verbose,
+		TaskSourceAdapter: parent.SourceAdapter,
+		TaskSourceIssueID: parent.SourceIssueID,
 	}
 
 	if err := d.store.SaveExecution(parentExec); err != nil {
@@ -312,16 +314,18 @@ func (d *Dispatcher) queueSingleTask(ctx context.Context, task *Task) (string, e
 
 	// Save to SQLite with status='queued' and full task details
 	exec := &memory.Execution{
-		ID:              execID,
-		TaskID:          task.ID,
-		ProjectPath:     task.ProjectPath,
-		Status:          "queued",
-		TaskTitle:       task.Title,
-		TaskDescription: task.Description,
-		TaskBranch:      task.Branch,
-		TaskBaseBranch:  task.BaseBranch,
-		TaskCreatePR:    task.CreatePR,
-		TaskVerbose:     task.Verbose,
+		ID:                execID,
+		TaskID:            task.ID,
+		ProjectPath:       task.ProjectPath,
+		Status:            "queued",
+		TaskTitle:         task.Title,
+		TaskDescription:   task.Description,
+		TaskBranch:        task.Branch,
+		TaskBaseBranch:    task.BaseBranch,
+		TaskCreatePR:      task.CreatePR,
+		TaskVerbose:       task.Verbose,
+		TaskSourceAdapter: task.SourceAdapter,
+		TaskSourceIssueID: task.SourceIssueID,
 	}
 
 	if err := d.store.SaveExecution(exec); err != nil {
@@ -561,14 +565,16 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 
 		// Build task from execution record (full details stored when queued)
 		task := &Task{
-			ID:          exec.TaskID,
-			Title:       exec.TaskTitle,
-			Description: exec.TaskDescription,
-			ProjectPath: exec.ProjectPath,
-			Branch:      exec.TaskBranch,
-			BaseBranch:  exec.TaskBaseBranch,
-			CreatePR:    exec.TaskCreatePR,
-			Verbose:     exec.TaskVerbose,
+			ID:            exec.TaskID,
+			Title:         exec.TaskTitle,
+			Description:   exec.TaskDescription,
+			ProjectPath:   exec.ProjectPath,
+			Branch:        exec.TaskBranch,
+			BaseBranch:    exec.TaskBaseBranch,
+			CreatePR:      exec.TaskCreatePR,
+			Verbose:       exec.TaskVerbose,
+			SourceAdapter: exec.TaskSourceAdapter,
+			SourceIssueID: exec.TaskSourceIssueID,
 		}
 
 		// Execute (blocking)

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -281,6 +281,14 @@ type SubIssueCreator interface {
 	CreateIssue(ctx context.Context, parentID, title, body string, labels []string) (identifier string, url string, err error)
 }
 
+// PRCreator is an interface for creating pull/merge requests in external forges.
+// Adapters like GitLab, Azure DevOps, etc. can implement this interface so the runner
+// creates MRs via their native API instead of the gh CLI.
+type PRCreator interface {
+	// CreatePR creates a pull/merge request and returns its URL.
+	CreatePR(ctx context.Context, sourceBranch, targetBranch, title, body string) (url string, err error)
+}
+
 // SubIssueLinker links a child issue to a parent issue using GitHub's native sub-issue API (GH-2211).
 // *github.Client satisfies this interface via its LinkSubIssue method.
 type SubIssueLinker interface {
@@ -335,6 +343,7 @@ type Runner struct {
 	worktreeManager       *WorktreeManager // Optional worktree manager with pool support
 	// GH-1471: SubIssueCreator for non-GitHub adapters
 	subIssueCreator       SubIssueCreator // Optional creator for sub-issues in external trackers
+	prCreator             PRCreator       // Optional creator for MRs/PRs in external forges
 	// GH-2211: SubIssueLinker for native GitHub sub-issue API linking
 	subIssueLinker        SubIssueLinker // Optional linker for native GitHub parent→child wiring
 	// GH-1599: Execution log store for milestone entries
@@ -637,6 +646,11 @@ func (r *Runner) HasSubIssueMergeWait() bool { return r.subIssueMergeWait != nil
 // via this interface instead of using the gh CLI.
 func (r *Runner) SetSubIssueCreator(creator SubIssueCreator) {
 	r.subIssueCreator = creator
+}
+
+// SetPRCreator sets the creator for pull/merge requests in external forges.
+func (r *Runner) SetPRCreator(creator PRCreator) {
+	r.prCreator = creator
 }
 
 // SetSubIssueLinker sets the linker for native GitHub sub-issue linking (GH-2211).
@@ -2586,18 +2600,33 @@ The previous execution completed but made no code changes. This task requires ac
 				}
 			}
 
-			// Generate PR body with GitHub auto-close keyword
-			issueNum := strings.TrimPrefix(task.ID, "GH-")
-			prBody := fmt.Sprintf("## Summary\n\nAutomated PR created by Pilot for task %s.\n\nCloses #%s\n\n## Changes\n\n%s", task.ID, issueNum, task.Description)
-
-			// Create PR
 			prTitle := fmt.Sprintf("%s: %s", task.ID, task.Title)
-			prURL, err := git.CreatePR(ctx, prTitle, prBody, baseBranch)
-			if err != nil {
-				result.Success = false
-				result.Error = fmt.Sprintf("PR creation failed: %v", err)
-				r.reportProgress(task.ID, "PR Failed", 100, result.Error)
-				return result, nil
+
+			// Route PR/MR creation through adapter-specific creator when available
+			var prURL string
+			if r.prCreator != nil && task.SourceAdapter != "" && task.SourceAdapter != "github" {
+				// Non-GitHub adapter: use PRCreator (e.g., GitLab MR API)
+				prBody := fmt.Sprintf("## Summary\n\nAutomated MR created by Pilot for task %s.\n\n## Changes\n\n%s", task.ID, task.Description)
+				var createErr error
+				prURL, createErr = r.prCreator.CreatePR(ctx, task.Branch, baseBranch, prTitle, prBody)
+				if createErr != nil {
+					result.Success = false
+					result.Error = fmt.Sprintf("MR creation failed: %v", createErr)
+					r.reportProgress(task.ID, "MR Failed", 100, result.Error)
+					return result, nil
+				}
+			} else {
+				// GitHub: use gh CLI with auto-close keyword
+				issueNum := strings.TrimPrefix(task.ID, "GH-")
+				prBody := fmt.Sprintf("## Summary\n\nAutomated PR created by Pilot for task %s.\n\nCloses #%s\n\n## Changes\n\n%s", task.ID, issueNum, task.Description)
+				var createErr error
+				prURL, createErr = git.CreatePR(ctx, prTitle, prBody, baseBranch)
+				if createErr != nil {
+					result.Success = false
+					result.Error = fmt.Sprintf("PR creation failed: %v", createErr)
+					r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+					return result, nil
+				}
 			}
 
 			result.PRUrl = prURL

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2606,7 +2606,12 @@ The previous execution completed but made no code changes. This task requires ac
 			var prURL string
 			if r.prCreator != nil && task.SourceAdapter != "" && task.SourceAdapter != "github" {
 				// Non-GitHub adapter: use PRCreator (e.g., GitLab MR API)
-				prBody := fmt.Sprintf("## Summary\n\nAutomated MR created by Pilot for task %s.\n\n## Changes\n\n%s", task.ID, task.Description)
+				// Include "Closes #N" keyword so GitLab auto-closes the source issue on merge
+				closeKeyword := ""
+				if task.SourceIssueID != "" {
+					closeKeyword = fmt.Sprintf("\n\nCloses #%s", task.SourceIssueID)
+				}
+				prBody := fmt.Sprintf("## Summary\n\nAutomated MR created by Pilot for task %s.%s\n\n## Changes\n\n%s", task.ID, closeKeyword, task.Description)
 				var createErr error
 				prURL, createErr = r.prCreator.CreatePR(ctx, task.Branch, baseBranch, prTitle, prBody)
 				if createErr != nil {

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3195,3 +3195,66 @@ func TestLocalModeSkipsQualityGates(t *testing.T) {
 		t.Errorf("quality checker factory was called in LocalMode — quality gates should be skipped")
 	}
 }
+
+// mockPRCreator records calls to CreatePR for testing.
+type mockPRCreator struct {
+	Called       bool
+	SourceBranch string
+	TargetBranch string
+	Title        string
+	Body         string
+	ReturnURL    string
+	ReturnErr    error
+}
+
+func (m *mockPRCreator) CreatePR(_ context.Context, sourceBranch, targetBranch, title, body string) (string, error) {
+	m.Called = true
+	m.SourceBranch = sourceBranch
+	m.TargetBranch = targetBranch
+	m.Title = title
+	m.Body = body
+	return m.ReturnURL, m.ReturnErr
+}
+
+func TestSetPRCreator(t *testing.T) {
+	runner := NewRunner()
+	if runner.prCreator != nil {
+		t.Error("prCreator should be nil by default")
+	}
+	mock := &mockPRCreator{}
+	runner.SetPRCreator(mock)
+	if runner.prCreator == nil {
+		t.Fatal("prCreator should be set after SetPRCreator")
+	}
+}
+
+func TestPRCreator_RoutingCondition(t *testing.T) {
+	runner := NewRunner()
+	mock := &mockPRCreator{ReturnURL: "https://gitlab.com/ns/proj/-/merge_requests/1"}
+	runner.SetPRCreator(mock)
+	task := &Task{ID: "GL-1", SourceAdapter: "gitlab"}
+	useAdapter := runner.prCreator != nil && task.SourceAdapter != "" && task.SourceAdapter != "github"
+	if !useAdapter {
+		t.Error("should use PRCreator for gitlab adapter")
+	}
+}
+
+func TestPRCreator_NotUsedForGitHubAdapter(t *testing.T) {
+	runner := NewRunner()
+	runner.SetPRCreator(&mockPRCreator{})
+	task := &Task{SourceAdapter: "github"}
+	useAdapter := runner.prCreator != nil && task.SourceAdapter != "" && task.SourceAdapter != "github"
+	if useAdapter {
+		t.Error("should NOT use PRCreator for github adapter")
+	}
+}
+
+func TestPRCreator_NotUsedWhenEmpty(t *testing.T) {
+	runner := NewRunner()
+	runner.SetPRCreator(&mockPRCreator{})
+	task := &Task{SourceAdapter: ""}
+	useAdapter := runner.prCreator != nil && task.SourceAdapter != "" && task.SourceAdapter != "github"
+	if useAdapter {
+		t.Error("should NOT use PRCreator when SourceAdapter is empty")
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -820,7 +820,8 @@ func (s *Store) GetQueuedTasksForProject(projectPath string, limit int) ([]*Exec
 	rows, err := s.db.Query(`
 		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at,
 			COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
-			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0)
+			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
+			COALESCE(task_source_adapter, ''), COALESCE(task_source_issue_id, '')
 		FROM executions
 		WHERE (status = 'queued' OR status = 'pending') AND project_path = ?
 		ORDER BY created_at ASC
@@ -836,7 +837,8 @@ func (s *Store) GetQueuedTasksForProject(projectPath string, limit int) ([]*Exec
 		var exec Execution
 		var completedAt sql.NullTime
 		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &completedAt,
-			&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose); err != nil {
+			&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose,
+			&exec.TaskSourceAdapter, &exec.TaskSourceIssueID); err != nil {
 			return nil, err
 		}
 		if completedAt.Valid {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -153,6 +153,8 @@ func (s *Store) migrate() error {
 		`ALTER TABLE executions ADD COLUMN task_base_branch TEXT`,
 		`ALTER TABLE executions ADD COLUMN task_create_pr BOOLEAN DEFAULT FALSE`,
 		`ALTER TABLE executions ADD COLUMN task_verbose BOOLEAN DEFAULT FALSE`,
+		`ALTER TABLE executions ADD COLUMN task_source_adapter TEXT DEFAULT ''`,
+		`ALTER TABLE executions ADD COLUMN task_source_issue_id TEXT DEFAULT ''`,
 		`CREATE INDEX IF NOT EXISTS idx_executions_status ON executions(status)`,
 		`CREATE INDEX IF NOT EXISTS idx_patterns_project ON patterns(project_path)`,
 		// Cross-project pattern indexes
@@ -378,8 +380,10 @@ type Execution struct {
 	TaskDescription string
 	TaskBranch      string
 	TaskBaseBranch  string
-	TaskCreatePR    bool
-	TaskVerbose     bool
+	TaskCreatePR      bool
+	TaskVerbose       bool
+	TaskSourceAdapter string // Source adapter (e.g., "github", "gitlab", "linear")
+	TaskSourceIssueID string // Issue ID in the source adapter
 }
 
 // SaveExecution saves an execution record to the database.
@@ -389,11 +393,13 @@ func (s *Store) SaveExecution(exec *Execution) error {
 		_, err := s.db.Exec(`
 			INSERT INTO executions (id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, completed_at,
 				tokens_input, tokens_output, tokens_total, estimated_cost_usd, files_changed, lines_added, lines_removed, model_name,
-				task_title, task_description, task_branch, task_base_branch, task_create_pr, task_verbose)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				task_title, task_description, task_branch, task_base_branch, task_create_pr, task_verbose,
+				task_source_adapter, task_source_issue_id)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, exec.ID, exec.TaskID, exec.ProjectPath, exec.Status, exec.Output, exec.Error, exec.DurationMs, exec.PRUrl, exec.CommitSHA, exec.CompletedAt,
 			exec.TokensInput, exec.TokensOutput, exec.TokensTotal, exec.EstimatedCostUSD, exec.FilesChanged, exec.LinesAdded, exec.LinesRemoved, exec.ModelName,
-			exec.TaskTitle, exec.TaskDescription, exec.TaskBranch, exec.TaskBaseBranch, exec.TaskCreatePR, exec.TaskVerbose)
+			exec.TaskTitle, exec.TaskDescription, exec.TaskBranch, exec.TaskBaseBranch, exec.TaskCreatePR, exec.TaskVerbose,
+			exec.TaskSourceAdapter, exec.TaskSourceIssueID)
 		return err
 	})
 }
@@ -407,7 +413,8 @@ func (s *Store) GetExecution(id string) (*Execution, error) {
 			COALESCE(estimated_cost_usd, 0), COALESCE(files_changed, 0), COALESCE(lines_added, 0),
 			COALESCE(lines_removed, 0), COALESCE(model_name, ''),
 			COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
-			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0)
+			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
+			COALESCE(task_source_adapter, ''), COALESCE(task_source_issue_id, '')
 		FROM executions WHERE id = ?
 	`, id)
 
@@ -415,7 +422,8 @@ func (s *Store) GetExecution(id string) (*Execution, error) {
 	var completedAt sql.NullTime
 	err := row.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &completedAt,
 		&exec.TokensInput, &exec.TokensOutput, &exec.TokensTotal, &exec.EstimatedCostUSD, &exec.FilesChanged, &exec.LinesAdded, &exec.LinesRemoved, &exec.ModelName,
-		&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose)
+		&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose,
+		&exec.TaskSourceAdapter, &exec.TaskSourceIssueID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix GitLab merge request creation by routing MR creation through the native GitLab API instead of the GitHub CLI (`gh`).

  When Pilot processes a GitLab issue, it successfully creates a branch, makes commits, and pushes — but then fails at PR creation because the executor
  unconditionally calls `gh pr create`, which only works against GitHub remotes. For GitLab repositories this produces GraphQL errors:

  ```
  Head sha can't be blank, Base sha can't be blank, No commits between main and pilot/GL-1
  ```

  The failed execution then runs until the stale threshold and gets recovered as an "orphaned worker".

  ## Changes

  ### 1. `PRCreator` interface (`internal/executor/runner.go`)

  Introduces a `PRCreator` interface (modeled after the existing `SubIssueCreator` pattern) so non-GitHub adapters can create PRs/MRs via their native API:

  ```go
  type PRCreator interface {
      CreatePR(ctx context.Context, sourceBranch, targetBranch, title, body string) (url string, err error)
  }
  ```

  The runner's PR creation logic now checks `task.SourceAdapter` — when a `PRCreator` is wired and the adapter is non-GitHub, it delegates to the adapter's
  API. The GitHub `gh` CLI path remains the default fallback.

  ### 2. GitLab `PRCreator` implementation (`internal/adapters/gitlab/client.go`)

  The GitLab client gains a `CreatePR()` method that satisfies the `PRCreator` interface by delegating to the existing `CreateMergeRequest()` API call.

  ### 3. Handler wiring (`cmd/pilot/handlers.go`)

  `handleGitLabIssueWithResult` now sets `SourceAdapter: "gitlab"` and `SourceIssueID` on the task (previously missing — unlike the Linear and Plane
  handlers), and wires the GitLab client as the runner's `PRCreator`.

  ### 4. Database schema update (`internal/memory/store.go`)

  Two new columns are added to the `executions` table:

  | Column | Type | Default |
  |--------|------|---------|
  | `task_source_adapter` | `TEXT` | `''` |
  | `task_source_issue_id` | `TEXT` | `''` |

  **Why this is needed:** The dispatcher serializes tasks to SQLite when queuing, then the worker reconstructs them for execution. Without persisting
  `SourceAdapter`, the reconstructed task always had an empty value — causing the runner to fall through to the `gh` CLI path even when the `PRCreator` was
  correctly wired on the runner. The migration uses the existing `ALTER TABLE ADD COLUMN` pattern with `DEFAULT` values, so it's backward-compatible with
  existing databases (no data loss, no manual migration required).

  ### 5. Dispatcher queue/reconstruct (`internal/executor/dispatcher.go`)

  `queueSingleTask`, `queueDecomposedTask`, and the worker's task reconstruction all now include `SourceAdapter` and `SourceIssueID`.

  ### 6. Query fix (`internal/memory/store.go`)

  `GetQueuedTasksForProject` — the query used by the per-project worker to fetch the next task — now SELECTs and scans the new columns.

  ## Test plan

  - [x] `TestCreatePR_PRCreatorInterface` — GitLab client creates MR via API and returns web URL
  - [x] `TestSetPRCreator` — Runner stores PRCreator reference
  - [x] `TestPRCreator_RoutingCondition` — Routes to PRCreator when `SourceAdapter=gitlab`
  - [x] `TestPRCreator_NotUsedForGitHubAdapter` — Falls back to `gh` CLI when `SourceAdapter=github`
  - [x] `TestPRCreator_NotUsedWhenEmpty` — Falls back to `gh` CLI when `SourceAdapter` is empty
  - [x] Existing executor and GitLab adapter test suites pass
  - [x] Manual: trigger a GitLab issue with `pilot` label, verify MR is created via GitLab API