### PR TITLE
GH-2269: fix(bench/aws): stale task manifest — always regenerate before run

### DIFF
--- a/pilot-bench/.gitignore
+++ b/pilot-bench/.gitignore
@@ -2,4 +2,5 @@ jobs/
 .analysis/
 aws/results/
 aws/tasks-manifest.json
+tasks-manifest.json
 aws/__pycache__/

--- a/pilot-bench/aws/extract_tasks.py
+++ b/pilot-bench/aws/extract_tasks.py
@@ -185,7 +185,17 @@ def main():
         action="store_true",
         help="Upload manifest to S3 after generation",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing manifest file (default when called from run-aws-bench.sh)",
+    )
     args = parser.parse_args()
+
+    output_path = Path(args.output)
+    if output_path.exists() and not args.force:
+        print(f"Manifest already exists at {output_path}. Use --force to overwrite.")
+        return 0
 
     repo_path = Path(args.repo_path)
 

--- a/pilot-bench/aws/run-aws-bench.sh
+++ b/pilot-bench/aws/run-aws-bench.sh
@@ -61,16 +61,22 @@ if ! python3 -c "import boto3" 2>/dev/null; then
     exit 1
 fi
 
-# Generate task manifest if missing
+# Always regenerate task manifest to avoid stale data
 MANIFEST="tasks-manifest.json"
-if [ ! -f "$MANIFEST" ]; then
-    echo "Generating task manifest..."
-    python3 extract_tasks.py --output "$MANIFEST"
-fi
+echo "Generating task manifest..."
+python3 extract_tasks.py --output "$MANIFEST" --force
 
 if [ "$EXTRACT_ONLY" = true ]; then
     echo "Manifest generated. Exiting (--extract-only)."
     exit 0
+fi
+
+# Validate manifest task count
+TASK_COUNT=$(python3 -c "import json; print(len(json.load(open('$MANIFEST')).get('tasks',[])))")
+echo "Manifest: $TASK_COUNT tasks"
+if [ "$TASK_COUNT" -lt 80 ]; then
+    echo "ERROR: Manifest has only $TASK_COUNT tasks (expected ~89 for TB 2.0). Aborting."
+    exit 1
 fi
 
 # Check pilot binary


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2269.

Closes #2269

## Changes

GitHub Issue #2269: fix(bench/aws): stale task manifest — always regenerate before run

## Problem

`run-aws-bench.sh:66-69` only generates the task manifest if the file is missing:

```bash
if [ ! -f "$MANIFEST" ]; then
    echo "Generating task manifest..."
    python3 extract_tasks.py --output "$MANIFEST"
fi
```

A stale 5-task manifest was committed to the repo. Since the file existed, `extract_tasks.py` was never called. The run launched with 5 tasks instead of the full 89-task TB 2.0 suite.

## Required Changes

### 1. Always regenerate manifest (`run-aws-bench.sh`, line 66-69)

Remove the `if [ ! -f ]` guard. Always regenerate:

```bash
echo "Generating task manifest..."
python3 extract_tasks.py --output "$MANIFEST" --force
```

### 2. Add `--force` flag to `extract_tasks.py`

Add a `--force` / `--overwrite` argument that overwrites existing manifest. Make it default when called from `run-aws-bench.sh`.

### 3. Validate manifest task count after generation

After generating, sanity-check the count. Abort if suspiciously low:

```bash
TASK_COUNT=$(python3 -c "import json; print(len(json.load(open('$MANIFEST')).get('tasks',[])))")
echo "Manifest: $TASK_COUNT tasks"
if [ "$TASK_COUNT" -lt 80 ]; then
    echo "ERROR: Manifest has only $TASK_COUNT tasks (expected ~89 for TB 2.0). Aborting."
    exit 1
fi
```

### 4. Add `tasks-manifest.json` to `.gitignore`

Prevent stale manifests from being committed. The manifest should always be generated at run time from the cloned TB repo.

Add to `pilot-bench/.gitignore`:
```
tasks-manifest.json
```

## Files to modify

- `pilot-bench/aws/run-aws-bench.sh` — remove staleness guard, add validation
- `pilot-bench/aws/extract_tasks.py` — add `--force` flag
- `pilot-bench/.gitignore` — add `tasks-manifest.json`

## Branch

Target branch: `feat/aws-bench`

## Task doc

`.agent/tasks/TASK-20-manifest-always-regenerate.md`