### PR TITLE
GH-2276: feat(github): auto-retry issues with pilot-retry-ready label

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -111,6 +111,10 @@ type Poller struct {
 	failedRetryCount map[int]int
 	maxFailedRetries int // default: 3
 
+	// GH-2276: Auto-retry issues with pilot-retry-ready (PR closed without merge).
+	retryReadyCount      map[int]int
+	maxRetryReadyRetries int // default: 3
+
 	// GH-2242: ExecutionChecker prevents re-dispatch of completed tasks
 	// when pilot-done label failed to apply.
 	execChecker ExecutionChecker
@@ -217,6 +221,17 @@ func WithMaxFailedRetries(n int) PollerOption {
 	}
 }
 
+// WithMaxRetryReadyRetries sets the maximum number of auto-retries for issues
+// with pilot-retry-ready label (PR closed without merge). Default: 3.
+func WithMaxRetryReadyRetries(n int) PollerOption {
+	return func(p *Poller) {
+		if n < 0 {
+			n = 0
+		}
+		p.maxRetryReadyRetries = n
+	}
+}
+
 // WithMaxConcurrent sets the maximum number of parallel issue executions
 func WithMaxConcurrent(n int) PollerOption {
 	return func(p *Poller) {
@@ -247,8 +262,10 @@ func NewPoller(client *Client, repo string, label string, interval time.Duration
 		prPollInterval:   30 * time.Second,
 		prTimeout:        1 * time.Hour,
 		retryGracePeriod: 5 * time.Minute, // GH-2201: default grace period
-		failedRetryCount: make(map[int]int),
-		maxFailedRetries: 3, // GH-2176: default max retries for pilot-failed issues
+		failedRetryCount:     make(map[int]int),
+		maxFailedRetries:     3, // GH-2176: default max retries for pilot-failed issues
+		retryReadyCount:      make(map[int]int),
+		maxRetryReadyRetries: 3, // GH-2276: default max retries for pilot-retry-ready issues
 	}
 
 	for _, opt := range opts {
@@ -587,6 +604,14 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 			// Label removed, fall through to candidate selection
 		}
 
+		// GH-2276: Auto-retry issues with pilot-retry-ready (PR closed without merge)
+		if HasLabel(issue, LabelRetryReady) {
+			if !p.shouldRetryRetryReadyIssue(ctx, issue) {
+				continue
+			}
+			// Label removed, fall through to candidate selection
+		}
+
 		// Check if previously processed
 		p.mu.RLock()
 		processedAt, processed := p.processed[issue.Number]
@@ -772,6 +797,14 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 		// GH-2176: Auto-retry issues stuck with pilot-failed (no pilot-done)
 		if HasLabel(issue, LabelFailed) {
 			if !p.shouldRetryFailedIssue(ctx, issue) {
+				continue
+			}
+			// Label removed, fall through to candidate selection
+		}
+
+		// GH-2276: Auto-retry issues with pilot-retry-ready (PR closed without merge)
+		if HasLabel(issue, LabelRetryReady) {
+			if !p.shouldRetryRetryReadyIssue(ctx, issue) {
 				continue
 			}
 			// Label removed, fall through to candidate selection
@@ -1195,6 +1228,67 @@ func (p *Poller) shouldRetryFailedIssue(ctx context.Context, issue *Issue) bool 
 		slog.Int("number", issue.Number),
 		slog.Int("retry", retries+1),
 		slog.Int("max", p.maxFailedRetries),
+	)
+
+	return true
+}
+
+// shouldRetryRetryReadyIssue checks if a pilot-retry-ready issue should be auto-retried.
+// Returns true if the issue should be retried (label removed), false if it should be skipped.
+// GH-2276: Issues with pilot-retry-ready (PR closed without merge) get retried up to maxRetryReadyRetries times.
+func (p *Poller) shouldRetryRetryReadyIssue(ctx context.Context, issue *Issue) bool {
+	// Don't retry closed issues
+	if issue.State != "open" {
+		p.logger.Info("Skipping retry — issue is closed",
+			slog.Int("number", issue.Number),
+			slog.String("state", issue.State),
+		)
+		return false
+	}
+
+	// Never retry if also marked done
+	if HasLabel(issue, LabelDone) {
+		return false
+	}
+
+	p.mu.RLock()
+	retries := p.retryReadyCount[issue.Number]
+	p.mu.RUnlock()
+
+	if retries >= p.maxRetryReadyRetries {
+		p.logger.Warn("Issue has reached max retry-ready retries, skipping",
+			slog.Int("number", issue.Number),
+			slog.Int("retries", retries),
+			slog.Int("max", p.maxRetryReadyRetries),
+		)
+		return false
+	}
+
+	// Check if merged work already exists before retrying
+	if p.hasMergedWork(ctx, issue) {
+		return false
+	}
+
+	// Remove pilot-retry-ready label and increment retry count
+	if err := p.client.RemoveLabel(ctx, p.owner, p.repo, issue.Number, LabelRetryReady); err != nil {
+		p.logger.Warn("Failed to remove pilot-retry-ready label for retry",
+			slog.Int("number", issue.Number),
+			slog.Any("error", err),
+		)
+		return false
+	}
+
+	p.mu.Lock()
+	p.retryReadyCount[issue.Number] = retries + 1
+	p.mu.Unlock()
+
+	// Clear from processed map so the issue can be re-picked
+	p.ClearProcessed(issue.Number)
+
+	p.logger.Info("Auto-retrying pilot-retry-ready issue",
+		slog.Int("number", issue.Number),
+		slog.Int("retry", retries+1),
+		slog.Int("max", p.maxRetryReadyRetries),
 	)
 
 	return true

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2373,3 +2373,212 @@ func TestPoller_DispatchesWhenNoCompletedExecution(t *testing.T) {
 		t.Errorf("callback called %d times, want 1 (should dispatch when no completed execution)", got)
 	}
 }
+
+func TestPoller_AutoRetryRetryReadyIssue_FirstRetry(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelRetryReady}}, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+
+	var labelRemoved atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodDelete && r.URL.Path == "/repos/owner/repo/issues/42/labels/"+LabelRetryReady {
+			labelRemoved.Store(true)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/search/issues" {
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithRetryGracePeriod(0),
+	)
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil {
+		t.Fatal("issue should not be nil — pilot-retry-ready issue should be retried on first attempt")
+	}
+	if issue.Number != 42 {
+		t.Errorf("got issue #%d, want #42", issue.Number)
+	}
+	if !labelRemoved.Load() {
+		t.Error("pilot-retry-ready label should have been removed")
+	}
+
+	poller.mu.RLock()
+	retries := poller.retryReadyCount[42]
+	poller.mu.RUnlock()
+	if retries != 1 {
+		t.Errorf("retry count = %d, want 1", retries)
+	}
+}
+
+func TestPoller_AutoRetryRetryReadyIssue_RetryLimitReached(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelRetryReady}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, State: "open", Title: "Available issue", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithMaxRetryReadyRetries(3),
+	)
+
+	poller.mu.Lock()
+	poller.retryReadyCount[42] = 3
+	poller.mu.Unlock()
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil {
+		t.Fatal("issue should not be nil — #43 should be picked")
+	}
+	if issue.Number != 43 {
+		t.Errorf("got issue #%d, want #43 (should skip #42 at retry limit)", issue.Number)
+	}
+}
+
+func TestPoller_AutoRetryRetryReadyIssue_SkipsDoneIssues(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Done+RetryReady", Labels: []Label{{Name: "pilot"}, {Name: LabelRetryReady}, {Name: LabelDone}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, State: "open", Title: "Available", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil {
+		t.Fatal("issue should not be nil — #43 should be picked")
+	}
+	if issue.Number != 43 {
+		t.Errorf("got issue #%d, want #43 (should skip #42 with pilot-done)", issue.Number)
+	}
+}
+
+func TestPoller_AutoRetryRetryReadyIssue_SkipsClosedIssues(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "closed", Title: "Closed+RetryReady", Labels: []Label{{Name: "pilot"}, {Name: LabelRetryReady}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, State: "open", Title: "Available", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil {
+		t.Fatal("issue should not be nil — #43 should be picked")
+	}
+	if issue.Number != 43 {
+		t.Errorf("got issue #%d, want #43 (should skip closed #42 with pilot-retry-ready)", issue.Number)
+	}
+}
+
+func TestPoller_AutoRetryRetryReadyIssue_ParallelMode(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelRetryReady}}, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+
+	var labelRemoved atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodDelete && r.URL.Path == "/repos/owner/repo/issues/42/labels/"+LabelRetryReady {
+			labelRemoved.Store(true)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/search/issues" {
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var processedIssues []*Issue
+	var mu sync.Mutex
+
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			mu.Lock()
+			processedIssues = append(processedIssues, issue)
+			mu.Unlock()
+			return nil
+		}),
+		WithRetryGracePeriod(0),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	mu.Lock()
+	got := len(processedIssues)
+	mu.Unlock()
+
+	if got != 1 {
+		t.Errorf("processed %d issues, want 1", got)
+	}
+	if !labelRemoved.Load() {
+		t.Error("pilot-retry-ready label should have been removed in parallel mode")
+	}
+}
+
+func TestPoller_WithMaxRetryReadyRetries(t *testing.T) {
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, "http://localhost")
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithMaxRetryReadyRetries(5),
+	)
+	if poller.maxRetryReadyRetries != 5 {
+		t.Errorf("maxRetryReadyRetries = %d, want 5", poller.maxRetryReadyRetries)
+	}
+
+	// Negative values should be clamped to 0
+	poller2, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithMaxRetryReadyRetries(-1),
+	)
+	if poller2.maxRetryReadyRetries != 0 {
+		t.Errorf("maxRetryReadyRetries = %d, want 0 for negative input", poller2.maxRetryReadyRetries)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2276.

Closes #2276

## Changes

GitHub Issue #2276: feat(github): auto-retry issues with pilot-retry-ready label

## Problem

When a PR is closed without merge, the autopilot controller adds `pilot-retry-ready` and removes `pilot-in-progress`. The issue retains the `pilot` label so the poller finds it, but it stays stuck in the `processed` map with no explicit handler to clear it and re-dispatch.

The `pilot-failed` label has explicit handling via `shouldRetryFailedIssue()` (poller.go:1145-1201). `pilot-retry-ready` has no equivalent — it's a dead-end label. Issues #2268 and #2266 are currently stuck with this label.

## Solution

Mirror `shouldRetryFailedIssue()` for `pilot-retry-ready` in `internal/adapters/github/poller.go`.

## Implementation

### 1. Add struct fields (after line 112)

```go
// Auto-retry issues with pilot-retry-ready (PR closed without merge).
retryReadyCount      map[int]int
maxRetryReadyRetries int // default: 3
```

### 2. Add constructor option (after `WithMaxFailedRetries`, line 218)

```go
// WithMaxRetryReadyRetries sets the maximum number of auto-retries for issues
// with pilot-retry-ready label (PR closed without merge). Default: 3.
func WithMaxRetryReadyRetries(n int) PollerOption {
    return func(p *Poller) {
        if n < 0 {
            n = 0
        }
        p.maxRetryReadyRetries = n
    }
}
```

### 3. Initialize in `NewPoller()` (after line 251)

```go
retryReadyCount:      make(map[int]int),
maxRetryReadyRetries: 3,
```

### 4. Add `shouldRetryRetryReadyIssue()` method (after line 1201)

Clone of `shouldRetryFailedIssue()` with these substitutions:
- `LabelFailed` → `LabelRetryReady`
- `failedRetryCount` → `retryReadyCount`
- `maxFailedRetries` → `maxRetryReadyRetries`
- Log messages: "pilot-failed" → "pilot-retry-ready"

Same logic: check open + not LabelDone, check retry count, check hasMergedWork, remove label, increment count, ClearProcessed, return true.

### 5. Hook into sequential mode `findOldestUnprocessedIssue()` (after line 588)

Insert AFTER the `LabelFailed` block, BEFORE "Check if previously processed" (line 590):

```go
// Auto-retry issues with pilot-retry-ready (PR closed without merge)
if HasLabel(issue, LabelRetryReady) {
    if !p.shouldRetryRetryReadyIssue(ctx, issue) {
        continue
    }
}
```

### 6. Hook into parallel mode `checkForNewIssues()` (after line 778)

Insert AFTER the `LabelFailed` block, BEFORE `LabelDone` check (line 780):

```go
// Auto-retry issues with pilot-retry-ready (PR closed without merge)
if HasLabel(issue, LabelRetryReady) {
    if !p.shouldRetryRetryReadyIssue(ctx, issue) {
        continue
    }
}
```

### 7. Tests in `internal/adapters/github/poller_test.go`

Add tests mirroring existing `TestPoller_AutoRetryFailedIssue_*` patterns:
- `TestPoller_AutoRetryRetryReadyIssue_FirstRetry` — happy path
- `TestPoller_AutoRetryRetryReadyIssue_RetryLimitReached` — at max, skipped
- `TestPoller_AutoRetryRetryReadyIssue_SkipsDoneIssues` — has pilot-done, skipped
- `TestPoller_AutoRetryRetryReadyIssue_SkipsClosedIssues` — state=closed, skipped
- `TestPoller_AutoRetryRetryReadyIssue_ParallelMode` — exercises checkForNewIssues()
- `TestPoller_WithMaxRetryReadyRetries` — constructor option

## Files to modify

- `internal/adapters/github/poller.go` — all logic changes
- `internal/adapters/github/poller_test.go` — all tests

## Verification

```bash
go test ./internal/adapters/github/... -run TestPoller_AutoRetryRetryReady -v
go test ./internal/adapters/github/... -count=1
go build ./...
```