### PR TITLE
GH-2279: fix(autopilot): update execution status to completed when PR is merged externally

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -65,6 +65,9 @@ type TaskMonitor interface {
 // EvalStore persists eval tasks extracted from merged PRs.
 type EvalStore interface {
 	SaveEvalTask(task *memory.EvalTask) error
+	// UpdateExecutionStatusByTaskID updates execution status by task ID.
+	// Used to mark failed executions as completed when the PR is merged.
+	UpdateExecutionStatusByTaskID(taskID, status string) error
 }
 
 // ControllerOption is a functional option for Controller configuration.
@@ -985,6 +988,15 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 			taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
 			c.monitor.Complete(taskID, prState.PRURL)
 			c.log.Debug("updated monitor state to completed", "task", taskID, "pr", prState.PRNumber)
+		}
+
+		// GH-2279: Update execution record from "failed" to "completed" when PR is merged
+		if c.evalStore != nil {
+			taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
+			if err := c.evalStore.UpdateExecutionStatusByTaskID(taskID, "completed"); err != nil {
+				c.log.Warn("failed to update execution status on merge",
+					"task_id", taskID, "error", err)
+			}
 		}
 
 		// GH-1870: Sync board card to "Done" column on merge

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -3445,6 +3445,10 @@ func (m *mockEvalStore) SaveEvalTask(task *memory.EvalTask) error {
 	return nil
 }
 
+func (m *mockEvalStore) UpdateExecutionStatusByTaskID(taskID, status string) error {
+	return nil
+}
+
 // TestHandleMerged_ExtractsEvalTask verifies that handleMerged extracts and saves
 // an eval task when evalStore is configured and the PR has a linked issue.
 func TestHandleMerged_ExtractsEvalTask(t *testing.T) {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -870,6 +870,20 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 	})
 }
 
+// UpdateExecutionStatusByTaskID updates the status of the most recent execution
+// for a given task ID. Used by autopilot to mark failed executions as completed
+// when the PR is merged externally.
+func (s *Store) UpdateExecutionStatusByTaskID(taskID, status string) error {
+	return s.withRetry("UpdateExecutionStatusByTaskID", func() error {
+		_, err := s.db.Exec(`
+			UPDATE executions
+			SET status = ?, completed_at = CURRENT_TIMESTAMP
+			WHERE task_id = ? AND status = 'failed'
+		`, status, taskID)
+		return err
+	})
+}
+
 // UpdateExecutionResult updates the result fields of an execution record.
 // Called when task execution completes successfully with PR/commit info.
 func (s *Store) UpdateExecutionResult(id string, prURL, commitSHA string, durationMs int64) error {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1548,3 +1548,72 @@ func TestGetStaleQueuedExecutions(t *testing.T) {
 		t.Errorf("expected status 'queued', got %q", results[0].Status)
 	}
 }
+
+func TestUpdateExecutionStatusByTaskID_UpdatesFailedToCompleted(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-fail-1",
+		TaskID:      "GH-100",
+		ProjectPath: "/tmp/proj",
+		Status:      "failed",
+		Error:       "quality gate failed",
+	})
+
+	if err := store.UpdateExecutionStatusByTaskID("GH-100", "completed"); err != nil {
+		t.Fatalf("UpdateExecutionStatusByTaskID failed: %v", err)
+	}
+
+	exec, err := store.GetExecution("exec-fail-1")
+	if err != nil {
+		t.Fatalf("GetExecution failed: %v", err)
+	}
+	if exec.Status != "completed" {
+		t.Errorf("expected status 'completed', got %q", exec.Status)
+	}
+	if exec.CompletedAt == nil {
+		t.Error("expected completed_at to be set")
+	}
+}
+
+func TestUpdateExecutionStatusByTaskID_SkipsNonFailed(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-ok-1",
+		TaskID:      "GH-200",
+		ProjectPath: "/tmp/proj",
+		Status:      "completed",
+	})
+
+	if err := store.UpdateExecutionStatusByTaskID("GH-200", "completed"); err != nil {
+		t.Fatalf("UpdateExecutionStatusByTaskID failed: %v", err)
+	}
+
+	exec, _ := store.GetExecution("exec-ok-1")
+	// Status should remain "completed" — the WHERE clause only targets "failed"
+	if exec.Status != "completed" {
+		t.Errorf("expected status 'completed', got %q", exec.Status)
+	}
+}
+
+func TestUpdateExecutionStatusByTaskID_NoMatchingTask(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	// Should not error even with no matching rows
+	if err := store.UpdateExecutionStatusByTaskID("GH-999", "completed"); err != nil {
+		t.Fatalf("expected no error for non-existent task, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2279.

Closes #2279

## Changes

GitHub Issue #2279: fix(autopilot): update execution status to completed when PR is merged externally

## Problem

When a PR is merged (externally or via autopilot), the execution record in SQLite stays `status = "failed"` forever if the initial execution had a failure (e.g., quality gate). The dashboard shows the task as failed even though the PR was successfully merged and the code is deployed.

The autopilot controller's `handleMerging()` already adds `pilot-done`, removes `pilot-failed`, and closes the issue — but it never updates the execution record in the DB.

## Root Cause

- `UpdateExecutionStatus(id, status)` in `store.go:845` takes the UUID execution ID, not task ID
- No `UpdateExecutionStatusByTaskID` exists
- The controller has no direct `*memory.Store` reference, but it DOES have `EvalStore` (already wired)

## Solution

Extend the `EvalStore` interface to include execution status updates, add a store method that updates by task_id, and call it from the merge-success path.

### 1. Add `UpdateExecutionStatusByTaskID` to `internal/memory/store.go`

Add after `UpdateExecutionStatus` (line 845):

```go
// UpdateExecutionStatusByTaskID updates the status of the most recent execution
// for a given task ID. Used by autopilot to mark failed executions as completed
// when the PR is merged externally.
func (s *Store) UpdateExecutionStatusByTaskID(taskID, status string) error {
    return s.withRetry(func() error {
        _, err := s.db.Exec(`
            UPDATE executions 
            SET status = ?, completed_at = CURRENT_TIMESTAMP
            WHERE task_id = ? AND status = 'failed'
        `, status, taskID)
        return err
    })
}
```

### 2. Extend `EvalStore` interface in `internal/autopilot/controller.go`

Find the `EvalStore` interface definition and add:

```go
UpdateExecutionStatusByTaskID(taskID, status string) error
```

### 3. Call from merge-success path in `handleMerging()` (around line 985)

In the `if prState.IssueNumber > 0` block, right after `monitor.Complete` (line 988), add:

```go
// GH-XXXX: Update execution record from "failed" to "completed" when PR is merged
if c.evalStore != nil {
    taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
    if err := c.evalStore.UpdateExecutionStatusByTaskID(taskID, "completed"); err != nil {
        c.log.Warn("failed to update execution status on merge",
            "task_id", taskID, "error", err)
    }
}
```

Note: `taskID` is already constructed at line 985 for `monitor.Complete` — reuse it.

### 4. Update mock/test implementations of `EvalStore`

Search for any mock or test implementations of `EvalStore` and add the new method stub:

```go
func (m *mockEvalStore) UpdateExecutionStatusByTaskID(taskID, status string) error {
    return nil
}
```

### 5. Tests

Add to `internal/memory/store_test.go`:
- `TestUpdateExecutionStatusByTaskID_UpdatesFailedToCompleted` — save exec with status "failed", call update, verify status is "completed"
- `TestUpdateExecutionStatusByTaskID_SkipsNonFailed` — save exec with status "completed", call update, verify it's unchanged (the WHERE clause filters on `status = 'failed'`)
- `TestUpdateExecutionStatusByTaskID_NoMatchingTask` — call with nonexistent task_id, verify no error (0 rows affected is fine)

## Files to modify

- `internal/memory/store.go` — add `UpdateExecutionStatusByTaskID`
- `internal/autopilot/controller.go` — extend `EvalStore` interface + call from `handleMerging`
- `internal/memory/store_test.go` — add tests
- Any mock `EvalStore` implementations (search for `SaveEvalTask` to find them)

## Verification

```bash
go test ./internal/memory/... -run TestUpdateExecutionStatusByTaskID -v
go test ./internal/autopilot/... -count=1
go build ./...
```