### PR TITLE
GH-2280: fix(dashboard): sparkline graphs wiped after 5s DB refresh

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -966,6 +966,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		prevLen := len(m.completedTasks)
 		m.completedTasks = msg.completedTasks
 		m.metricsCard = msg.metricsCard
+		m.loadMetricsHistory()
 		if len(m.completedTasks) != prevLen {
 			return m, tea.ClearScreen
 		}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2280.

Closes #2280

## Changes

GitHub Issue #2280: fix(dashboard): sparkline graphs wiped after 5s DB refresh

## Problem

Dashboard sparkline graphs show only a single dot "•" instead of actual data. The graphs render correctly for the first 5 seconds after startup, then go blank.

## Root Cause

Commit `3cc191df` (GH-2248) added a 5-second DB refresh via `storeRefreshCmd` (tui.go:712-775). This function builds `msg.metricsCard` with scalar fields only (TotalTokens, TotalCostUSD, etc.) but **never populates** `TokenHistory`, `CostHistory`, or `TaskHistory`.

When the `storeRefreshMsg` handler (tui.go:964) assigns `m.metricsCard = msg.metricsCard`, the history slices are wiped to `nil`. `normalizeToSparkline(nil, 16)` returns all zeros → sparkline renders as empty space + one pulsing dot.

`loadMetricsHistory()` (tui.go:604) correctly queries `GetDailyMetrics` for 7 days and fills all three history slices, but it's only called at startup via `hydrateFromStore()` (tui.go:590).

## Fix

In `internal/dashboard/tui.go`, in the `storeRefreshMsg` handler (around line 964-971), add `m.loadMetricsHistory()` after the metricsCard assignment:

```go
case storeRefreshMsg:
    prevLen := len(m.completedTasks)
    m.completedTasks = msg.completedTasks
    m.metricsCard = msg.metricsCard
    m.loadMetricsHistory()          // ← add this line
    if len(m.completedTasks) != prevLen {
        return m, tea.ClearScreen
    }
```

This mirrors the startup path and ensures history data survives the periodic refresh.

## Files to modify

- `internal/dashboard/tui.go` — one line addition in `storeRefreshMsg` handler (~line 967)

## Verification

```bash
go build ./...
# Manual: run `pilot start --dashboard`, wait >5 seconds, verify sparklines persist
```