### PR TITLE
fix(dashboard): adapter poller tasks invisible in gateway mode with --dashboard

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -2219,20 +2219,65 @@ func checkForUpdates() {
 }
 
 // runDashboardMode runs the TUI dashboard with live task updates
-func runDashboardMode(p *pilot.Pilot, cfg *config.Config) error {
+func runDashboardMode(p *pilot.Pilot, cfg *config.Config, gwProgram *tea.Program, gwMonitor *executor.Monitor, gwRunner *executor.Runner) error {
 	// Suppress slog output to prevent corrupting TUI display (GH-164)
 	logging.Suppress()
 	p.SuppressProgressLogs(true)
 
-	// Create TUI program
-	model := dashboard.NewModel(version)
-	program := tea.NewProgram(model, tea.WithAltScreen())
+	// GH-2291: Use the pre-built gateway program when adapter pollers are active.
+	// gwProgram has the richer model (store, autopilot, project path) and is already
+	// referenced by handler_common.go's deps.Program for task start/complete log sends.
+	// When no adapter pollers are active, create a basic program for pure webhook mode.
+	program := gwProgram
+	if program == nil {
+		model := dashboard.NewModel(version)
+		program = tea.NewProgram(model, tea.WithAltScreen())
+	}
 
 	// Set up event bridge: poll task states and send to dashboard
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Register progress callback on Pilot's orchestrator
+	// GH-2291: collectTasks merges task states from adapter pollers (gwMonitor)
+	// and gateway webhook tasks (p.GetTaskStates()) into a single view.
+	// convertTaskStatesToDisplay deduplicates by task ID.
+	collectTasks := func() []dashboard.TaskDisplay {
+		var allStates []*executor.TaskState
+		if gwMonitor != nil {
+			allStates = append(allStates, gwMonitor.GetAll()...)
+		}
+		allStates = append(allStates, p.GetTaskStates()...)
+		return convertTaskStatesToDisplay(allStates)
+	}
+
+	// GH-2291: Wire adapter poller runner progress/token callbacks to the dashboard.
+	// These callbacks also update gwMonitor so collectTasks() returns current data.
+	if gwRunner != nil && gwMonitor != nil {
+		var gwLastUpdate time.Time
+		var gwMu sync.Mutex
+		gwRunner.AddProgressCallback("dashboard", func(taskID, phase string, progress int, message string) {
+			gwMonitor.UpdateProgress(taskID, phase, progress, message)
+
+			gwMu.Lock()
+			if time.Since(gwLastUpdate) < 200*time.Millisecond {
+				gwMu.Unlock()
+				return // Skip — periodic ticker will catch it
+			}
+			gwLastUpdate = time.Now()
+			gwMu.Unlock()
+
+			tasks := collectTasks()
+			program.Send(dashboard.UpdateTasks(tasks)())
+			logMsg := fmt.Sprintf("[%s] %s: %s (%d%%)", taskID, phase, message, progress)
+			program.Send(dashboard.AddLog(logMsg)())
+		})
+
+		gwRunner.AddTokenCallback("dashboard", func(taskID string, inputTokens, outputTokens int64) {
+			program.Send(dashboard.UpdateTokens(int(inputTokens), int(outputTokens))())
+		})
+	}
+
+	// Register progress callback on Pilot's orchestrator (gateway webhook tasks)
 	// GH-1220: Throttle progress callbacks to 200ms to prevent message flooding
 	var lastDashboardUpdate time.Time
 	var dashboardMu sync.Mutex
@@ -2245,11 +2290,9 @@ func runDashboardMode(p *pilot.Pilot, cfg *config.Config) error {
 		lastDashboardUpdate = time.Now()
 		dashboardMu.Unlock()
 
-		// Convert current task states to dashboard display format
-		tasks := convertTaskStatesToDisplay(p.GetTaskStates())
+		tasks := collectTasks()
 		program.Send(dashboard.UpdateTasks(tasks)())
 
-		// Also add progress message as log
 		logMsg := fmt.Sprintf("[%s] %s: %s (%d%%)", taskID, phase, message, progress)
 		program.Send(dashboard.AddLog(logMsg)())
 	})
@@ -2269,7 +2312,7 @@ func runDashboardMode(p *pilot.Pilot, cfg *config.Config) error {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				tasks := convertTaskStatesToDisplay(p.GetTaskStates())
+				tasks := collectTasks()
 				program.Send(dashboard.UpdateTasks(tasks)())
 			}
 		}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -557,32 +557,8 @@ Examples:
 						tea.WithInput(os.Stdin),
 						tea.WithOutput(os.Stdout),
 					)
-
-					// Wire runner progress updates to dashboard
-					// GH-1220: Throttle progress callbacks to 200ms to prevent message flooding
-					var gwLastDashboardUpdate time.Time
-					var gwDashboardMu sync.Mutex
-					gwRunner.AddProgressCallback("dashboard", func(taskID, phase string, progress int, message string) {
-						gwMonitor.UpdateProgress(taskID, phase, progress, message)
-
-						gwDashboardMu.Lock()
-						if time.Since(gwLastDashboardUpdate) < 200*time.Millisecond {
-							gwDashboardMu.Unlock()
-							return // Skip — periodic ticker will catch it
-						}
-						gwLastDashboardUpdate = time.Now()
-						gwDashboardMu.Unlock()
-
-						tasks := convertTaskStatesToDisplay(gwMonitor.GetAll())
-						gwProgram.Send(dashboard.UpdateTasks(tasks)())
-						logMsg := fmt.Sprintf("[%s] %s: %s (%d%%)", taskID, phase, message, progress)
-						gwProgram.Send(dashboard.AddLog(logMsg)())
-					})
-
-					// Wire token usage updates to dashboard
-					gwRunner.AddTokenCallback("dashboard", func(taskID string, inputTokens, outputTokens int64) {
-						gwProgram.Send(dashboard.UpdateTokens(int(inputTokens), int(outputTokens))())
-					})
+					// GH-2291: Progress/token callbacks are registered by runDashboardMode
+					// which merges task states from both adapter pollers and gateway webhooks.
 				}
 			}
 
@@ -1013,8 +989,9 @@ Examples:
 			go checkForUpdates()
 
 			if dashboardMode {
-				// Run TUI dashboard mode
-				return runDashboardMode(p, cfg)
+				// GH-2291: Pass adapter poller infrastructure so the dashboard
+				// merges task states from both adapter pollers and gateway webhooks.
+				return runDashboardMode(p, cfg, gwProgram, gwMonitor, gwRunner)
 			}
 
 			// Show startup banner (headless mode)


### PR DESCRIPTION
## Summary

Closes #2291

- Adapter-registry pollers (GitLab, Linear, Jira, Asana, Azure DevOps, Plane, Discord) dispatched tasks through a separate `gwRunner`/`gwMonitor` whose `gwProgram` was never `Run()`, making all adapter poller tasks invisible on the TUI dashboard in gateway mode
- `runDashboardMode` now accepts the pre-built `gwProgram`, `gwMonitor`, and `gwRunner`; reuses the richer program, registers merged progress/token callbacks, and `collectTasks` combines both monitors so all tasks appear on a single dashboard
- When no adapter pollers are active (pure webhook mode), behavior is unchanged — a basic program is created as before

## Test plan

- [ ] Run `pilot start --dashboard` with GitLab polling enabled — verify polled issues appear on the dashboard
- [ ] Run `pilot start --dashboard` with another adapter-registry poller (e.g. Linear polling) — verify tasks show on dashboard
- [ ] Run `pilot start --dashboard --github` — verify GitHub polling still works (uses `runPollingMode`, unaffected)
- [ ] Run `pilot start` (headless, no `--dashboard`) — verify no regression in headless output
- [ ] Run `go test ./cmd/pilot/ -count=1` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)