### PR TITLE
fix(handler): use adapter-specific PR/MR number extraction for GitLab and Azure DevOps

### DIFF
--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -9,7 +9,9 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/qf-studio/pilot/internal/adapters/azuredevops"
 	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/adapters/gitlab"
 	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/budget"
 	"github.com/qf-studio/pilot/internal/config"
@@ -243,8 +245,21 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	if result != nil {
 		if result.PRUrl != "" {
 			hr.PRURL = result.PRUrl
-			if prNum, err := github.ExtractPRNumber(result.PRUrl); err == nil {
-				hr.PRNumber = prNum
+			// GH-2293: Use adapter-specific PR/MR number extraction.
+			// Each forge has a different URL format for pull/merge requests.
+			switch info.Adapter {
+			case "gitlab":
+				if mrNum, err := gitlab.ExtractMRNumber(result.PRUrl); err == nil {
+					hr.PRNumber = mrNum
+				}
+			case "azuredevops":
+				if prNum, err := azuredevops.ExtractPRNumber(result.PRUrl); err == nil {
+					hr.PRNumber = prNum
+				}
+			default:
+				if prNum, err := github.ExtractPRNumber(result.PRUrl); err == nil {
+					hr.PRNumber = prNum
+				}
 			}
 		}
 		hr.HeadSHA = result.CommitSHA

--- a/cmd/pilot/handler_common_test.go
+++ b/cmd/pilot/handler_common_test.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/qf-studio/pilot/internal/adapters/azuredevops"
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/adapters/gitlab"
 	"github.com/qf-studio/pilot/internal/budget"
 	"github.com/qf-studio/pilot/internal/executor"
 )
@@ -88,6 +91,86 @@ func TestHandleIssueGeneric_MonitorRegistration(t *testing.T) {
 	}
 	if state.Title != "Linear task title" {
 		t.Errorf("expected task title %q, got %q", "Linear task title", state.Title)
+	}
+}
+
+// TestAdapterSpecificPRNumberExtraction verifies that PR/MR number extraction
+// uses the correct adapter-specific regex for each forge (GH-2293).
+func TestAdapterSpecificPRNumberExtraction(t *testing.T) {
+	tests := []struct {
+		name     string
+		adapter  string
+		prURL    string
+		wantNum  int
+		wantFail bool
+	}{
+		{
+			name:    "github PR URL",
+			adapter: "github",
+			prURL:   "https://github.com/org/repo/pull/42",
+			wantNum: 42,
+		},
+		{
+			name:    "gitlab MR URL",
+			adapter: "gitlab",
+			prURL:   "https://gitlab.com/namespace/project/-/merge_requests/17",
+			wantNum: 17,
+		},
+		{
+			name:    "gitlab MR URL without dash prefix",
+			adapter: "gitlab",
+			prURL:   "https://gitlab.example.com/group/repo/merge_requests/99",
+			wantNum: 99,
+		},
+		{
+			name:    "azuredevops PR URL",
+			adapter: "azuredevops",
+			prURL:   "https://dev.azure.com/org/project/_git/repo/pullrequest/55",
+			wantNum: 55,
+		},
+		{
+			name:     "github extractor does not match gitlab URL",
+			adapter:  "github",
+			prURL:    "https://gitlab.com/ns/proj/-/merge_requests/10",
+			wantNum:  0,
+			wantFail: true,
+		},
+		{
+			name:     "gitlab extractor does not match github URL",
+			adapter:  "gitlab",
+			prURL:    "https://github.com/org/repo/pull/10",
+			wantNum:  0,
+			wantFail: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got int
+			var err error
+			switch tc.adapter {
+			case "gitlab":
+				got, err = gitlab.ExtractMRNumber(tc.prURL)
+			case "azuredevops":
+				got, err = azuredevops.ExtractPRNumber(tc.prURL)
+			default:
+				got, err = github.ExtractPRNumber(tc.prURL)
+			}
+
+			if tc.wantFail {
+				if err == nil {
+					t.Errorf("expected extraction to fail for adapter=%s url=%s, got %d", tc.adapter, tc.prURL, got)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("extraction failed for adapter=%s url=%s: %v", tc.adapter, tc.prURL, err)
+			}
+			if got != tc.wantNum {
+				t.Errorf("expected PR number %d, got %d (adapter=%s url=%s)", tc.wantNum, got, tc.adapter, tc.prURL)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #2293

- `handler_common.go` used `github.ExtractPRNumber` (regex `/pulls?/\d+`) for **all** adapters, silently failing on GitLab (`/-/merge_requests/N`) and Azure DevOps (`/pullrequest/N`) URLs — leaving `hr.PRNumber = 0`
- This broke autopilot notification, merge-wait logic in sequential mode, and caused GitLab issues to be mislabeled as `pilot-failed` or treated as "direct commits"
- Now dispatches extraction based on `info.Adapter` using each forge's existing extractor: `gitlab.ExtractMRNumber`, `azuredevops.ExtractPRNumber`, and `github.ExtractPRNumber` as the default
- Added table-driven tests verifying correct extraction for all three forges and cross-forge rejection

## Test plan

- [x] `go build ./cmd/pilot/` compiles cleanly
- [x] `go test ./cmd/pilot/ -count=1` — all tests pass
- [x] New `TestAdapterSpecificPRNumberExtraction` covers GitHub, GitLab (with and without `/-/` prefix), Azure DevOps, and cross-forge negative cases
- [x] Manual: run `pilot start` with GitLab polling, create a `pilot`-labeled issue — verify MR number is extracted and autopilot is notified
- [x] Manual: verify `pilot-done` label is applied (not `pilot-failed`) after successful MR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)