### PR TITLE
fix(gitlab): wrong type for MergeRequest.detailed_merge_status

### DIFF
--- a/internal/adapters/gitlab/types.go
+++ b/internal/adapters/gitlab/types.go
@@ -188,7 +188,7 @@ type MergeRequest struct {
 	Labels         []string  `json:"labels"`
 	Draft          bool      `json:"draft"`
 	HeadPipeline   *Pipeline `json:"head_pipeline,omitempty"`
-	DetailedStatus *Status   `json:"detailed_merge_status,omitempty"`
+	DetailedMergeStatus string `json:"detailed_merge_status,omitempty"`
 }
 
 // MergeRequestInput is used for creating merge requests


### PR DESCRIPTION
## Summary

- GitLab's API returns `detailed_merge_status` as a plain string (`"mergeable"`, `"checking"`, `"not_open"`, etc.), but the `MergeRequest` struct had it typed as `*Status` — a struct with `Icon`/`Text`/`Label` fields
- This caused `json.Unmarshal` to fail on every MR creation response, reporting "MR Failed" even though the MR was successfully created on GitLab
- Changed field from `DetailedStatus *Status` to `DetailedMergeStatus string`

## Test plan

- [x] `go build ./internal/adapters/gitlab/...` passes
- [x] `go vet ./internal/adapters/gitlab/...` passes
- [x] `go test ./internal/adapters/gitlab/...` passes
- [ ] Create a GitLab MR via Pilot and verify no unmarshal error in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)