### PR TITLE
GH-2286: fix: all bare NewRunner() callsites ignore executor config

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -409,15 +409,32 @@ Examples:
 
 			// Dry run mode - just show what would happen
 			if dryRun {
+				// GH-2286: load config to respect executor.type setting
+				dryRunCfgPath := cfgFile
+				if dryRunCfgPath == "" {
+					dryRunCfgPath = config.DefaultConfigPath()
+				}
+				dryRunCfg, cfgErr := config.Load(dryRunCfgPath)
+				if cfgErr != nil {
+					return fmt.Errorf("failed to load config for dry-run: %w", cfgErr)
+				}
+				dryRunBackendCfg := dryRunCfg.Executor
+				if dryRunBackendCfg == nil {
+					dryRunBackendCfg = executor.DefaultBackendConfig()
+				}
+
 				fmt.Println("🧪 DRY RUN - showing what would execute:")
 				fmt.Println()
-				fmt.Println("Command: claude -p \"<prompt>\" --verbose --output-format stream-json")
+				fmt.Printf("Command: %s -p \"<prompt>\" --verbose --output-format stream-json\n", dryRunBackendCfg.Type)
 				fmt.Println("Working directory:", projectPath)
 				fmt.Println()
 				fmt.Println("Prompt:")
 				fmt.Println("─────────────────────────────────────")
-				// Build actual prompt using a temporary runner
-				runner := executor.NewRunner()
+				// Build actual prompt using a runner with config
+				runner, runnerErr := executor.NewRunnerWithConfig(dryRunBackendCfg)
+				if runnerErr != nil {
+					return fmt.Errorf("failed to create runner for dry-run: %w", runnerErr)
+				}
 				prompt := runner.BuildPrompt(task, task.ProjectPath)
 				fmt.Println(prompt)
 				fmt.Println("─────────────────────────────────────")
@@ -1061,9 +1078,17 @@ Examples:
 
 			// Dry run mode
 			if dryRun {
+				// GH-2286: use executor config from already-loaded cfg
+				ghBackendCfg := cfg.Executor
+				if ghBackendCfg == nil {
+					ghBackendCfg = executor.DefaultBackendConfig()
+				}
 				fmt.Println("🧪 DRY RUN - showing what would execute:")
 				fmt.Println()
-				runner := executor.NewRunner()
+				runner, runnerErr := executor.NewRunnerWithConfig(ghBackendCfg)
+				if runnerErr != nil {
+					return fmt.Errorf("failed to create runner for dry-run: %w", runnerErr)
+				}
 				prompt := runner.BuildPrompt(task, task.ProjectPath)
 				fmt.Println("Prompt:")
 				fmt.Println("─────────────────────────────────────")

--- a/cmd/pilot/interactive.go
+++ b/cmd/pilot/interactive.go
@@ -164,7 +164,15 @@ func interactiveNewTask(cfg *config.Config) error {
 		Branch:      branchName,
 	}
 
-	runner := executor.NewRunner()
+	// GH-2286: use executor config from config.yaml instead of hardcoded defaults
+	backendCfg := cfg.Executor
+	if backendCfg == nil {
+		backendCfg = executor.DefaultBackendConfig()
+	}
+	runner, err := executor.NewRunnerWithConfig(backendCfg)
+	if err != nil {
+		return fmt.Errorf("failed to create runner: %w", err)
+	}
 	progress := executor.NewProgressDisplay(task.ID, taskDesc, true)
 
 	// Suppress slog progress output when visual display is active
@@ -189,7 +197,7 @@ func interactiveNewTask(cfg *config.Config) error {
 	})
 
 	fmt.Println()
-	fmt.Println("  Executing task with Claude Code...")
+	fmt.Printf("  Executing task with %s...\n", backendCfg.Type)
 	fmt.Println()
 
 	// Start with Navigator check

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -23,6 +23,7 @@ import (
 type Config struct {
 	Model         string
 	MaxConcurrent int
+	BackendConfig *executor.BackendConfig // GH-2286: pass executor config to runner
 }
 
 // Orchestrator coordinates ticket processing and task execution
@@ -63,10 +64,21 @@ func NewOrchestrator(config *Config, notifier *slack.Notifier) (*Orchestrator, e
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	// GH-2286: use executor config instead of hardcoded defaults
+	backendCfg := config.BackendConfig
+	if backendCfg == nil {
+		backendCfg = executor.DefaultBackendConfig()
+	}
+	runner, runnerErr := executor.NewRunnerWithConfig(backendCfg)
+	if runnerErr != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to create runner: %w", runnerErr)
+	}
+
 	o := &Orchestrator{
 		config:    config,
 		bridge:    bridge,
-		runner:    executor.NewRunner(),
+		runner:    runner,
 		monitor:   executor.NewMonitor(),
 		notifier:  notifier,
 		taskQueue: make(chan *Task, 100),

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -258,6 +258,7 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 	orchConfig := &orchestrator.Config{
 		Model:         cfg.Orchestrator.Model,
 		MaxConcurrent: cfg.Orchestrator.MaxConcurrent,
+		BackendConfig: cfg.Executor, // GH-2286: pass executor config to runner
 	}
 	orch, err := orchestrator.NewOrchestrator(orchConfig, p.slackNotify)
 	if err != nil {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2286.

Closes #2286

## Changes

GitHub Issue #2286: fix: all bare NewRunner() callsites ignore executor config

## Problem

4 production callsites use `executor.NewRunner()` which hardcodes `NewClaudeCodeBackend(nil)`, silently ignoring `config.yaml executor.type` setting.

## Callsites

### 1. `cmd/pilot/interactive.go:167` — `interactiveNewTask()`
`cfg` is already a function parameter. Replace:
```go
runner := executor.NewRunner()
```
with:
```go
backendCfg := cfg.Executor
if backendCfg == nil {
    backendCfg = executor.DefaultBackendConfig()
}
runner, err := executor.NewRunnerWithConfig(backendCfg)
if err != nil {
    return fmt.Errorf("failed to create runner: %w", err)
}
```
Also update the hardcoded message on line 192:
```go
// Before
fmt.Println("  Executing task with Claude Code...")
// After
fmt.Printf("  Executing task with %s...\n", backendCfg.Type)
```

### 2. `cmd/pilot/commands.go:420` — `pilot task --dry-run`
Config is loaded at line 551 but the dry-run block returns at line 424 before reaching it. Move config loading before the dry-run check. Replace:
```go
// Build actual prompt using a temporary runner
runner := executor.NewRunner()
prompt := runner.BuildPrompt(task, task.ProjectPath)
```
with config-loaded version using same pattern as line 560.

### 3. `cmd/pilot/commands.go:1066` — `pilot github run --dry-run`
Same pattern as #2. Config is loaded at line 954. The dry-run at line 1066 returns before the `NewRunnerWithConfig` call at line 1082. Load config earlier or reuse the already-loaded `cfg`.

### 4. `internal/orchestrator/orchestrator.go:69` — `NewOrchestrator()`
```go
runner: executor.NewRunner(),
```
The `Config` parameter is the orchestrator's own config struct, not `executor.BackendConfig`. Options:
- Add a `*executor.BackendConfig` field to orchestrator's `Config` struct
- Or pass it as a separate parameter to `NewOrchestrator`
Then use `NewRunnerWithConfig()` with nil-safe fallback.

## Correct Pattern (already used elsewhere)

Both `pilot serve` and the non-dry-run paths of `pilot task` / `pilot github run` already use:
```go
runner, err := executor.NewRunnerWithConfig(cfg.Executor)
```

## Test Callsites

Test files also use `NewRunner()` extensively (`main_test.go`, `dispatcher_test.go`, `prompt_builder_test.go`). These are fine — tests intentionally use the default ClaudeCode backend. **Do NOT change test callsites.**

## References

- `internal/executor/runner.go:364` — `NewRunner()` definition
- `internal/executor/runner.go:399` — `NewRunnerWithConfig()` definition
- `cmd/pilot/commands.go:560` — correct pattern for `pilot task` non-dry-run
- `cmd/pilot/commands.go:1082` — correct pattern for `pilot github run` non-dry-run
- GitHub Issue: #2283