### PR TITLE
GH-2297: fix(autopilot): post success comment on merge close — stale failure comments

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -18,6 +18,23 @@ import (
 // iterationRe matches the iteration field in autopilot-meta comments.
 var iterationRe = regexp.MustCompile(`<!-- autopilot-meta.*?iteration:(\d+).*?-->`)
 
+// buildMergeCompletionComment creates a success comment to post on an issue
+// after its associated PR is merged. This ensures the last comment on the issue
+// is a success message rather than a stale failure comment from a prior attempt.
+func buildMergeCompletionComment(prState *PRState) string {
+	var sb strings.Builder
+	sb.WriteString("✅ PR merged successfully!\n\n")
+	sb.WriteString("| Metric | Value |\n")
+	sb.WriteString("|--------|-------|\n")
+	sb.WriteString(fmt.Sprintf("| PR | #%d |\n", prState.PRNumber))
+	sb.WriteString(fmt.Sprintf("| Branch | `%s` |\n", prState.BranchName))
+	if !prState.CreatedAt.IsZero() {
+		duration := time.Since(prState.CreatedAt).Round(time.Second)
+		sb.WriteString(fmt.Sprintf("| Time to merge | %s |\n", duration))
+	}
+	return sb.String()
+}
+
 // parseAutopilotIteration extracts the CI fix iteration counter from an issue body.
 // Returns 0 if no iteration metadata is found (i.e., the issue is not a fix issue).
 func parseAutopilotIteration(body string) int {
@@ -982,6 +999,12 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 			c.log.Warn("failed to close issue after merge", "issue", prState.IssueNumber, "error", err)
 		}
 		c.log.Info("closed issue after merge", "issue", prState.IssueNumber, "pr", prState.PRNumber)
+
+		// GH-2297: Post success comment so last comment isn't stale failure
+		comment := buildMergeCompletionComment(prState)
+		if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); err != nil {
+			c.log.Warn("failed to post merge completion comment", "issue", prState.IssueNumber, "error", err)
+		}
 
 		// GH-1336: Sync monitor state so dashboard shows "done" instead of stale "failed"
 		if c.monitor != nil {
@@ -2052,6 +2075,12 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 				c.log.Warn("failed to close issue after external merge", "issue", prState.IssueNumber, "error", err)
 			} else {
 				c.log.Info("closed issue after external merge", "issue", prState.IssueNumber, "pr", prState.PRNumber)
+
+			// GH-2297: Post success comment so last comment isn't stale failure
+			comment := buildMergeCompletionComment(prState)
+			if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); err != nil {
+				c.log.Warn("failed to post merge completion comment on external merge", "issue", prState.IssueNumber, "error", err)
+			}
 			}
 		}
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2297.

Closes #2297

## Changes

GitHub Issue #2297: fix(autopilot): post success comment on merge close — stale failure comments

## Problem

When Pilot merges a PR and closes the issue, it adds `pilot-done` label and closes the issue but **never posts a success comment**. The last comment on the issue is always a stale failure message from a prior retry attempt. See GH-2286 and GH-2287 for examples — both merged successfully but show only `❌ Pilot execution failed` comments.

## Root Cause

Two code paths close issues without posting a success comment:

1. **`handleMergeComplete()`** in `internal/autopilot/controller.go` ~line 960-996:
   - Adds `pilot-done` label, removes `pilot-failed`, closes issue, syncs monitor/board
   - But never calls `buildExecutionComment()` or any success comment function

2. **`checkExternalMergeOrClose()`** in `internal/autopilot/controller.go` ~line 2025-2043:
   - Same pattern — closes issue on external merge, no success comment

The `buildExecutionComment()` function exists in `cmd/pilot/handlers.go:752` but is only called in the execution handler path (handlers.go:342), not the autopilot merge path.

## Fix

1. Add a `buildMergeCompletionComment(prState *PRState) string` function to `controller.go`:

```go
func buildMergeCompletionComment(prState *PRState) string {
    var sb strings.Builder
    sb.WriteString("✅ PR merged successfully!\n\n")
    sb.WriteString("| Metric | Value |\n")
    sb.WriteString("|--------|-------|\n")
    sb.WriteString(fmt.Sprintf("| PR | #%d |\n", prState.PRNumber))
    sb.WriteString(fmt.Sprintf("| Branch | `%s` |\n", prState.BranchName))
    if !prState.CreatedAt.IsZero() {
        duration := time.Since(prState.CreatedAt).Round(time.Second)
        sb.WriteString(fmt.Sprintf("| Time to merge | %s |\n", duration))
    }
    return sb.String()
}
```

2. After line 981 (`c.log.Info("closed issue after merge"...)`) in `handleMergeComplete()`, add:

```go
// Post success comment so last comment isn't stale failure
if prState.IssueNumber > 0 {
    comment := buildMergeCompletionComment(prState)
    if err := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); err != nil {
        c.log.Warn("failed to post merge completion comment", "issue", prState.IssueNumber, "error", err)
    }
}
```

3. After line 2042 (`c.log.Info("closed issue after external merge"...)`) in `checkExternalMergeOrClose()`, add the same comment posting logic.

## Acceptance Criteria

- [ ] After PR merge + issue close, a success comment is posted as the last comment
- [ ] Works for both autopilot merge and external merge paths
- [ ] `make build` and `make test` pass

## Files

- `internal/autopilot/controller.go` — Add `buildMergeCompletionComment()`, call in 2 merge paths