### PR TITLE
GH-2298: feat(github): add issue templates for bug reports, features, and pilot tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in Pilot
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear description of the bug
+      placeholder: "What went wrong?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this behavior?
+      placeholder: |
+        1. Run `pilot start`
+        2. Create an issue with `pilot` label
+        3. ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: false
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Pilot Version
+      description: What version of Pilot are you running?
+      placeholder: "e.g., v2.87.4"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What OS are you running Pilot on?
+      options:
+        - macOS
+        - Linux
+        - Windows
+    validations:
+      required: false
+
+  - type: dropdown
+    id: adapter
+    attributes:
+      label: Adapter
+      description: Which adapter is affected?
+      options:
+        - GitHub
+        - GitLab
+        - Linear
+        - Jira
+        - Slack
+        - Discord
+        - Telegram
+        - Azure DevOps
+        - Plane
+        - Asana
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant log output (redact any secrets)
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://pilot.quantflow.studio
+    about: Read the Pilot documentation and guides
+  - name: GitHub Discussions
+    url: https://github.com/anthropics/pilot/discussions
+    about: Ask questions and discuss with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for Pilot
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve?
+      placeholder: "I'm frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should this work?
+      placeholder: "It would be great if..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches have you considered?
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: adapters
+    attributes:
+      label: Affected Adapters
+      description: Which adapters would this feature affect?
+      options:
+        - label: GitHub
+        - label: GitLab
+        - label: Linear
+        - label: Jira
+        - label: Slack
+        - label: Discord
+        - label: Telegram
+        - label: Azure DevOps
+        - label: Plane
+        - label: Asana
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this to you?
+      options:
+        - Low
+        - Medium
+        - High
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/pilot_task.yml
+++ b/.github/ISSUE_TEMPLATE/pilot_task.yml
@@ -1,0 +1,54 @@
+name: Pilot Task
+description: Create a task for Pilot to execute autonomously
+labels: ["pilot"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Task Description
+      description: |
+        Describe what Pilot should implement. Include acceptance criteria.
+        Be specific about expected behavior and edge cases.
+      placeholder: |
+        ## What
+        Implement X by doing Y.
+
+        ## Acceptance Criteria
+        - [ ] Feature does A
+        - [ ] Edge case B is handled
+        - [ ] Tests cover C
+    validations:
+      required: true
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Files to Modify
+      description: List specific files or packages that need changes (optional)
+      placeholder: |
+        - internal/executor/runner.go
+        - internal/config/config.go
+    validations:
+      required: false
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Any related issues, PRs, or external dependencies
+      placeholder: "Depends on #123, blocked by #456"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: complexity
+    attributes:
+      label: Complexity Hint
+      description: Help Pilot choose the right execution strategy
+      options:
+        - trivial
+        - simple
+        - medium
+        - complex
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2298.

Closes #2298

## Changes

GitHub Issue #2298: feat(github): add issue templates for bug reports, features, and pilot tasks

## Problem

Pilot has no GitHub issue templates (`.github/ISSUE_TEMPLATE/` doesn't exist). Issues created manually or by Pilot look like flat text with no structure. This makes it harder for users to report bugs clearly and for Pilot to parse task descriptions.

## Fix

Create `.github/ISSUE_TEMPLATE/` with 4 files:

### 1. `bug_report.yml`
Standard bug report form with:
- Summary (textarea, required)
- Steps to reproduce (textarea)
- Expected behavior (textarea)
- Actual behavior (textarea)
- Pilot version (input)
- OS (dropdown: macOS, Linux, Windows)
- Adapter (dropdown: GitHub, GitLab, Linear, Jira, Slack, Discord, Telegram, Azure DevOps, Plane, Asana)
- Logs (textarea, render as code)

### 2. `feature_request.yml`
Feature request form with:
- Problem description (textarea, required)
- Proposed solution (textarea, required)
- Alternatives considered (textarea)
- Affected adapters (checkboxes: GitHub, GitLab, Linear, Jira, Slack, Discord, Telegram, Azure DevOps, Plane, Asana)
- Priority (dropdown: Low, Medium, High)

### 3. `pilot_task.yml`
Pilot-executable task template optimized for Pilot to parse:
- Task description with acceptance criteria (textarea, required)
- Files to modify (textarea, optional)
- Dependencies (textarea, optional)
- Complexity hint (dropdown: trivial, simple, medium, complex)
- This template should auto-add `pilot` label

### 4. `config.yml`
Template chooser configuration:
- `blank_issues_enabled: false`
- Contact links to docs site (pilot.quantflow.studio) and GitHub Discussions

## Acceptance Criteria

- [ ] `.github/ISSUE_TEMPLATE/` directory exists with all 4 files
- [ ] Templates render correctly on GitHub (New Issue button shows template chooser)
- [ ] Bug report and feature request templates have proper form fields
- [ ] Pilot task template auto-adds `pilot` label
- [ ] `make build` passes (templates are YAML, no code changes)

## Files

- `.github/ISSUE_TEMPLATE/bug_report.yml` — Create
- `.github/ISSUE_TEMPLATE/feature_request.yml` — Create
- `.github/ISSUE_TEMPLATE/pilot_task.yml` — Create
- `.github/ISSUE_TEMPLATE/config.yml` — Create

## Planned Steps (execute all in sequence)

1. **Create GitHub issue templates directory with all 4 template files** — Create `.github/ISSUE_TEMPLATE/` with:
- **`bug_report.yml`** — Bug report form: summary, steps to reproduce, expected/actual behavior, Pilot version, OS dropdown (macOS/Linux/Windows), adapter dropdown (GitHub/GitLab/Linear/Jira/Slack/Discord/Telegram/Azure DevOps/Plane/Asana), logs textarea (render as code block).
- **`feature_request.yml`** — Feature request form: problem description, proposed solution, alternatives considered, affected adapters (checkboxes for all 10 adapters), priority dropdown (Low/Medium/High).
- **`pilot_task.yml`** — Pilot-executable task template: task description with acceptance criteria, files to modify, dependencies, complexity hint dropdown (trivial/simple/medium/complex). Must include `labels: ["pilot"]` in the frontmatter so GitHub auto-applies the `pilot` label.
- **`config.yml`** — Template chooser config: `blank_issues_enabled: false`, contact links to docs site (`pilot.quantflow.studio`) and GitHub Discussions.
Verification: `make build` passes (YAML only, no code changes). Templates render on GitHub's "New Issue" page.
