### PR TITLE
GH-2301: fix(poller): clear stale pilot-in-progress on startup to avoid restart requirement

### DIFF
--- a/internal/adapters/asana/poller.go
+++ b/internal/adapters/asana/poller.go
@@ -248,6 +248,8 @@ func (p *Poller) recoverOrphanedTasks(ctx context.Context) {
 			)
 			continue
 		}
+		// GH-2301: Also clear from processed map/store so the first poll cycle picks it up.
+		p.ClearProcessed(task.GID)
 		p.logger.Info("Recovered orphaned task",
 			slog.String("gid", task.GID),
 			slog.String("name", task.Name),

--- a/internal/adapters/azuredevops/poller.go
+++ b/internal/adapters/azuredevops/poller.go
@@ -251,6 +251,8 @@ func (p *Poller) recoverOrphanedWorkItems(ctx context.Context) {
 			)
 			continue
 		}
+		// GH-2301: Also clear from processed map/store so the first poll cycle picks it up.
+		p.ClearProcessed(wi.ID)
 		p.logger.Info("Recovered orphaned work item",
 			slog.Int("id", wi.ID),
 			slog.String("title", wi.GetTitle()),

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -356,6 +356,8 @@ func (p *Poller) recoverOrphanedIssues(ctx context.Context) {
 			)
 			continue
 		}
+		// GH-2301: Also clear from processed map/store so the first poll cycle picks it up.
+		p.unmarkProcessed(issue.Number)
 		p.logger.Info("Recovered orphaned issue",
 			slog.Int("number", issue.Number),
 			slog.String("title", issue.Title),

--- a/internal/adapters/gitlab/poller.go
+++ b/internal/adapters/gitlab/poller.go
@@ -239,6 +239,8 @@ func (p *Poller) recoverOrphanedIssues(ctx context.Context) {
 			)
 			continue
 		}
+		// GH-2301: Also clear from processed map/store so the first poll cycle picks it up.
+		p.ClearProcessed(issue.IID)
 		p.logger.Info("Recovered orphaned issue",
 			slog.Int("iid", issue.IID),
 			slog.String("title", issue.Title),

--- a/internal/adapters/jira/poller.go
+++ b/internal/adapters/jira/poller.go
@@ -231,6 +231,8 @@ func (p *Poller) recoverOrphanedIssues(ctx context.Context) {
 			)
 			continue
 		}
+		// GH-2301: Also clear from processed map/store so the first poll cycle picks it up.
+		p.ClearProcessed(issue.Key)
 		p.logger.Info("Recovered orphaned issue",
 			slog.String("key", issue.Key),
 			slog.String("summary", issue.Fields.Summary),

--- a/internal/adapters/linear/poller.go
+++ b/internal/adapters/linear/poller.go
@@ -246,6 +246,8 @@ func (p *Poller) recoverOrphanedIssues(ctx context.Context) {
 			)
 			continue
 		}
+		// GH-2301: Also clear from processed map/store so the first poll cycle picks it up.
+		p.ClearProcessed(issue.ID)
 		p.logger.Info("Recovered orphaned issue",
 			slog.String("identifier", issue.Identifier),
 			slog.String("title", issue.Title),

--- a/internal/adapters/plane/poller.go
+++ b/internal/adapters/plane/poller.go
@@ -320,6 +320,8 @@ func (p *Poller) recoverOrphanedIssues(ctx context.Context) {
 				)
 				continue
 			}
+			// GH-2301: Also clear from processed map/store so the first poll cycle picks it up.
+			p.ClearProcessed(item.ID)
 			p.logger.Info("Recovered orphaned issue",
 				slog.String("id", item.ID),
 				slog.String("name", item.Name),


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2301.

Closes #2301

## Changes

GitHub Issue #2301: fix(poller): clear stale pilot-in-progress on startup to avoid restart requirement

## Problem

When Pilot's worker crashes or gets killed mid-execution, issues keep the `pilot-in-progress` label. On next startup, the poller skips these issues because they appear to be actively worked on. The orphan recovery eventually picks them up, but only after a timeout (5+ minutes). Users have to manually restart Pilot or remove the labels to unstick the queue.

This happened with GH-2286 and GH-2287 — both had `pilot-in-progress` after worker crashes, and Pilot wouldn't re-pick them until the labels were manually cleared or Pilot was restarted.

## Root Cause

The poller's `isProcessable()` check skips issues with `pilot-in-progress`. On startup, there's no cleanup step that checks if any `pilot-in-progress` issues are actually being worked on (no live worker for them).

## Fix

On Pilot startup (in the poller init path), scan for issues with `pilot-in-progress` label and verify each has an active worker. If no worker is running for an issue:

1. Remove `pilot-in-progress` label
2. Log a warning: "cleared stale pilot-in-progress label on issue N"

This should happen in the GitHub poller initialization, before the first poll cycle. The same pattern should apply to other adapters (Linear, Jira, etc.) that use `pilot-in-progress`.

### Implementation

**File**: `internal/adapters/github/poller.go`

Add a `clearStaleInProgressLabels(ctx)` method called during `Start()`:

```go
func (p *Poller) clearStaleInProgressLabels(ctx context.Context) {
    if p.client == nil {
        return
    }
    issues, err := p.client.ListIssuesByLabel(ctx, p.owner, p.repo, LabelInProgress)
    if err != nil {
        p.log.Warn("failed to scan stale in-progress issues", "error", err)
        return
    }
    for _, issue := range issues {
        // No worker can be active on fresh start — clear all
        p.log.Info("clearing stale pilot-in-progress label", "issue", issue.Number)
        p.client.RemoveLabel(ctx, p.owner, p.repo, issue.Number, LabelInProgress)
    }
}
```

Call it once at the beginning of `Start()` before the poll loop begins.

**Files**:
- `internal/adapters/github/poller.go` — Add `clearStaleInProgressLabels()`, call in `Start()`
- `internal/adapters/linear/poller.go` — Same pattern for Linear
- `internal/adapters/jira/poller.go` — Same pattern for Jira
- Other adapters as needed

## Acceptance Criteria

- [ ] On startup, Pilot scans for `pilot-in-progress` issues and clears the label
- [ ] No manual label cleanup needed after restart
- [ ] Issues with `pilot-in-progress` get re-picked on first poll cycle
- [ ] `make build && make test` pass