### PR TITLE
GH-2306: Add GitHub adapter config validation to `pilot doctor`

### DIFF
--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -369,6 +369,44 @@ func checkConfig(cfg *config.Config) []ConfigCheck {
 		}
 	}
 
+	// Check GitHub config
+	if cfg.Adapters != nil && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
+		if cfg.Adapters.GitHub.Token == "" {
+			checks = append(checks, ConfigCheck{
+				Name:    "github.token",
+				Status:  StatusError,
+				Message: "enabled but token missing",
+				Fix:     "Add github.token to config (personal access token or GitHub App token)",
+			})
+		} else {
+			// Token present — check repo configuration for polling mode
+			hasDefaultRepo := cfg.Adapters.GitHub.Repo != ""
+			hasProjectRepos := false
+			for _, p := range cfg.Projects {
+				if p.GitHub != nil && p.GitHub.Owner != "" && p.GitHub.Repo != "" {
+					hasProjectRepos = true
+					break
+				}
+			}
+			pollingEnabled := cfg.Adapters.GitHub.Polling != nil && cfg.Adapters.GitHub.Polling.Enabled
+
+			if pollingEnabled && !hasDefaultRepo && !hasProjectRepos {
+				checks = append(checks, ConfigCheck{
+					Name:    "github.repos",
+					Status:  StatusWarning,
+					Message: "polling enabled but no repos configured",
+					Fix:     "Set adapters.github.repo (\"owner/repo\") or add github.owner/repo to each project",
+				})
+			} else {
+				checks = append(checks, ConfigCheck{
+					Name:    "github",
+					Status:  StatusOK,
+					Message: "configured",
+				})
+			}
+		}
+	}
+
 	// Check daily brief schedule
 	if cfg.Orchestrator != nil && cfg.Orchestrator.DailyBrief != nil {
 		if cfg.Orchestrator.DailyBrief.Enabled {

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -3,8 +3,10 @@ package health
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/adapters/slack"
 	"github.com/qf-studio/pilot/internal/adapters/telegram"
 	"github.com/qf-studio/pilot/internal/config"
@@ -632,6 +634,124 @@ func findCheck(checks []Check, name string) *Check {
 		}
 	}
 	return nil
+}
+
+func TestCheckConfig_GitHubChecks(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            *config.Config
+		wantCheckName  string
+		wantStatus     Status
+	}{
+		{
+			name: "enabled no token",
+			cfg: &config.Config{
+				Adapters: &config.AdaptersConfig{
+					GitHub: &github.Config{
+						Enabled: true,
+						Token:   "",
+					},
+				},
+			},
+			wantCheckName: "github.token",
+			wantStatus:    StatusError,
+		},
+		{
+			name: "enabled no repos polling on",
+			cfg: &config.Config{
+				Adapters: &config.AdaptersConfig{
+					GitHub: &github.Config{
+						Enabled:  true,
+						Token:    "test-gh-token",
+						Polling:  &github.PollingConfig{Enabled: true},
+					},
+				},
+			},
+			wantCheckName: "github.repos",
+			wantStatus:    StatusWarning,
+		},
+		{
+			name: "fully configured",
+			cfg: &config.Config{
+				Adapters: &config.AdaptersConfig{
+					GitHub: &github.Config{
+						Enabled: true,
+						Token:   "test-gh-token",
+						Repo:    "org/repo",
+					},
+				},
+			},
+			wantCheckName: "github",
+			wantStatus:    StatusOK,
+		},
+		{
+			name: "disabled entirely",
+			cfg: &config.Config{
+				Adapters: &config.AdaptersConfig{
+					GitHub: &github.Config{
+						Enabled: false,
+					},
+				},
+			},
+			wantCheckName: "", // no github check expected
+			wantStatus:    StatusDisabled,
+		},
+		{
+			name: "token with project-level repos",
+			cfg: &config.Config{
+				Adapters: &config.AdaptersConfig{
+					GitHub: &github.Config{
+						Enabled: true,
+						Token:   "test-gh-token",
+						Polling: &github.PollingConfig{Enabled: true},
+					},
+				},
+				Projects: []*config.ProjectConfig{
+					{
+						Name: "myproj",
+						Path: "/tmp",
+						GitHub: &config.ProjectGitHubConfig{
+							Owner: "org",
+							Repo:  "repo",
+						},
+					},
+				},
+			},
+			wantCheckName: "github",
+			wantStatus:    StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checks := checkConfig(tt.cfg)
+			if tt.wantCheckName == "" {
+				// No GitHub check should appear
+				for _, c := range checks {
+					if strings.HasPrefix(c.Name, "github") {
+						t.Errorf("found unexpected github check %q (status=%v), want none", c.Name, c.Status)
+					}
+				}
+				return
+			}
+			found := findConfigCheck(checks, tt.wantCheckName)
+			if found == nil {
+				t.Fatalf("expected check %q, not found in %v", tt.wantCheckName, checkNames(checks))
+			}
+			if found.Status != tt.wantStatus {
+				t.Errorf("%q status = %v, want %v", tt.wantCheckName, found.Status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// checkNames returns all check names for error messages
+func checkNames(checks []ConfigCheck) []string {
+	names := make([]string, len(checks))
+	for i, c := range checks {
+		names[i] = c.Name
+	}
+	return names
 }
 
 func findConfigCheck(checks []ConfigCheck, name string) *ConfigCheck {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2306.

Closes #2306

## Changes

In `internal/health/health.go`, extend `checkConfig()` with three GitHub-specific checks: (a) `adapters.github.enabled` with no token → error, (b) polling enabled but no default repo AND no project-level `github.owner`/`github.repo` → warning with actionable fix message, (c) token + repos present → ok. Add table-driven tests in `internal/health/health_test.go` covering: enabled-no-token, enabled-no-repos, fully-configured, disabled-entirely. No shared helpers needed — repo count logic is straightforward inline checks against `cfg.Adapters.GitHub` and `cfg.Projects`.