### PR TITLE
GH-2307: Fix dashboard startup log and add zero-poller warning

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2097,6 +2097,11 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 				go poller.Start(ctx)
 			}
 
+			if len(ghPollers) == 0 {
+				logging.WithComponent("github").Warn("GitHub polling enabled but no repos configured — set adapters.github.repo or add project-level github.owner/github.repo",
+					slog.Int("pollers", 0))
+			}
+
 			if len(ghPollers) > 0 {
 				if !dashboardMode && execMode == github.ExecutionModeSequential && waitForMerge {
 					fmt.Printf("   ⏳ Sequential mode: waiting for PR merge before next issue (timeout: %s)\n", prTimeout)
@@ -2426,7 +2431,12 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 			hasGitHubPolling := cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled &&
 				cfg.Adapters.GitHub.Polling != nil && cfg.Adapters.GitHub.Polling.Enabled
 			if hasGitHubPolling {
-				program.Send(dashboard.AddLog(fmt.Sprintf("🐙 GitHub polling: %s", cfg.Adapters.GitHub.Repo))())
+				repoCount := countGitHubRepos(cfg)
+				if repoCount == 0 {
+					program.Send(dashboard.AddLog("🐙 GitHub polling: no repos configured")())
+				} else {
+					program.Send(dashboard.AddLog(fmt.Sprintf("🐙 GitHub polling: %d repo(s) configured", repoCount))())
+				}
 			}
 			hasLinearPolling := cfg.Adapters.Linear != nil && cfg.Adapters.Linear.Enabled &&
 				cfg.Adapters.Linear.Polling != nil && cfg.Adapters.Linear.Polling.Enabled
@@ -2587,4 +2597,18 @@ func (s storeTaskChecker) IsTaskQueued(taskID string) bool {
 		return false // Don't block retry on DB errors
 	}
 	return queued
+}
+
+// countGitHubRepos counts unique GitHub repos from the default config and project-level entries.
+func countGitHubRepos(cfg *config.Config) int {
+	seen := make(map[string]bool)
+	if cfg.Adapters != nil && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Repo != "" {
+		seen[cfg.Adapters.GitHub.Repo] = true
+	}
+	for _, proj := range cfg.Projects {
+		if proj.GitHub != nil && proj.GitHub.Owner != "" && proj.GitHub.Repo != "" {
+			seen[fmt.Sprintf("%s/%s", proj.GitHub.Owner, proj.GitHub.Repo)] = true
+		}
+	}
+	return len(seen)
 }

--- a/cmd/pilot/main_test.go
+++ b/cmd/pilot/main_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	_ "modernc.org/sqlite"
 
+	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/teams"
@@ -971,3 +972,70 @@ func TestApplyInputOverrides(t *testing.T) {
 }
 
 func boolPtr(b bool) *bool { return &b }
+
+func TestCountGitHubRepos(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want int
+	}{
+		{
+			name: "nil github adapter",
+			cfg:  &config.Config{},
+			want: 0,
+		},
+		{
+			name: "default repo only",
+			cfg: &config.Config{
+				Adapters: &config.AdaptersConfig{
+					GitHub: &github.Config{Repo: "owner/repo"},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "project repos only",
+			cfg: &config.Config{
+				Projects: []*config.ProjectConfig{
+					{Name: "a", GitHub: &config.ProjectGitHubConfig{Owner: "org", Repo: "proj-a"}},
+					{Name: "b", GitHub: &config.ProjectGitHubConfig{Owner: "org", Repo: "proj-b"}},
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "default plus projects deduped",
+			cfg: &config.Config{
+				Adapters: &config.AdaptersConfig{
+					GitHub: &github.Config{Repo: "org/proj-a"},
+				},
+				Projects: []*config.ProjectConfig{
+					{Name: "a", GitHub: &config.ProjectGitHubConfig{Owner: "org", Repo: "proj-a"}},
+					{Name: "b", GitHub: &config.ProjectGitHubConfig{Owner: "org", Repo: "proj-b"}},
+				},
+			},
+			want: 2, // org/proj-a deduplicated
+		},
+		{
+			name: "empty strings ignored",
+			cfg: &config.Config{
+				Adapters: &config.AdaptersConfig{
+					GitHub: &github.Config{Repo: ""},
+				},
+				Projects: []*config.ProjectConfig{
+					{Name: "a", GitHub: &config.ProjectGitHubConfig{Owner: "org", Repo: ""}},
+					{Name: "b", GitHub: &config.ProjectGitHubConfig{Owner: "", Repo: "repo"}},
+				},
+			},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countGitHubRepos(tt.cfg)
+			if got != tt.want {
+				t.Errorf("countGitHubRepos() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2307.

Closes #2307

## Changes

In `cmd/pilot/main.go`, make two changes: (a) around line 2427, replace the empty-repo log with a repo-count summary or a "no repos configured" warning — add a small `countGitHubRepos(cfg)` helper inline or as a local func that counts default `cfg.Adapters.GitHub.Repo` plus project-level `github.owner`/`github.repo` entries; (b) after the poller-creation loop (~line 2097), if `len(ghPollers) == 0` and GitHub polling is enabled, emit a dashboard warning log. Both changes are in the same file so they ship together. Test manually with: config that has no repos (see warning), config with repos (see count), existing config with `repo` field (unchanged behavior).