### PR TITLE
GH-2312: fix(autopilot): strip GH-XXXX prefix from squash commit title for conventional commit detection

### DIFF
--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/approval"
@@ -89,6 +90,12 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 	commitTitle := fmt.Sprintf("Merge PR #%d", prState.PRNumber)
 	if mergeMethod == github.MergeMethodSquash && prState.PRTitle != "" {
 		commitTitle = prState.PRTitle
+		// Strip "GH-XXXX: " prefix from Pilot-generated PR titles so
+		// parseBumpFromMessage() sees the conventional commit prefix (e.g. "fix(scope): ...").
+		if prState.IssueNumber > 0 {
+			prefix := fmt.Sprintf("GH-%d: ", prState.IssueNumber)
+			commitTitle = strings.TrimPrefix(commitTitle, prefix)
+		}
 	}
 	if err := m.ghClient.MergePullRequest(ctx, m.owner, m.repo, prState.PRNumber, mergeMethod, commitTitle); err != nil {
 		return fmt.Errorf("merge failed: %w", err)

--- a/internal/autopilot/auto_merger_test.go
+++ b/internal/autopilot/auto_merger_test.go
@@ -702,6 +702,77 @@ func TestAutoMerger_MergePR_SquashUsePRTitle(t *testing.T) {
 	}
 }
 
+func TestAutoMerger_MergePR_SquashStripsIssuePrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		prTitle     string
+		issueNumber int
+		wantTitle   string
+	}{
+		{
+			name:        "strips GH-XXXX: prefix from squash commit",
+			prTitle:     "GH-2312: fix(autopilot): strip issue prefix from squash title",
+			issueNumber: 2312,
+			wantTitle:   "fix(autopilot): strip issue prefix from squash title",
+		},
+		{
+			name:        "no strip when issue number mismatches",
+			prTitle:     "GH-9999: feat(scope): something",
+			issueNumber: 2312,
+			wantTitle:   "GH-9999: feat(scope): something",
+		},
+		{
+			name:        "no strip when no issue number",
+			prTitle:     "GH-2312: fix(autopilot): something",
+			issueNumber: 0,
+			wantTitle:   "GH-2312: fix(autopilot): something",
+		},
+		{
+			name:        "plain conventional commit unchanged",
+			prTitle:     "feat(api): add endpoint",
+			issueNumber: 2312,
+			wantTitle:   "feat(api): add endpoint",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capturedTitle := ""
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/repos/owner/repo/pulls/42/merge" {
+					var body map[string]string
+					_ = json.NewDecoder(r.Body).Decode(&body)
+					capturedTitle = body["commit_title"]
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.Environment = EnvDev
+			cfg.AutoReview = false
+			cfg.MergeMethod = github.MergeMethodSquash
+
+			merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
+
+			err := merger.MergePR(context.Background(), &PRState{
+				PRNumber:    42,
+				PRTitle:     tt.prTitle,
+					IssueNumber: tt.issueNumber,
+			})
+			if err != nil {
+				t.Errorf("MergePR() error = %v", err)
+			}
+
+			if capturedTitle != tt.wantTitle {
+				t.Errorf("commit_title = %q, want %q", capturedTitle, tt.wantTitle)
+			}
+		})
+	}
+}
+
 func TestAutoMerger_CanMerge_IntegrationScenarios(t *testing.T) {
 	// Test real-world PR state combinations
 	tests := []struct {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2312.

Closes #2312

## Changes

GitHub Issue #2312: fix(autopilot): strip GH-XXXX prefix from squash commit title for conventional commit detection

## Problem

When Pilot creates PRs, the title format is `GH-2304: fix(doctor): validate GitHub config...`. When autopilot squash-merges these PRs, it uses the full PR title as the commit message. The release handler's `parseBumpFromMessage()` sees `GH-2304:` as the type prefix, which doesn't match conventional commit types (`fix`, `feat`, etc.) → returns `BumpNone` → no release tag is created.

This caused 5 merged PRs to not trigger releases (v2.95.0..origin/main had unreleased commits).

## Root Cause

1. **runner.go:2646** — PR title: `fmt.Sprintf("%s: %s", task.ID, task.Title)` → `GH-2304: fix(doctor): ...`
2. **auto_merger.go:91** — Squash commit uses `prState.PRTitle` directly as commit title
3. **releaser.go:122** — `parseBumpFromMessage()` matches `GH` as type, not in recognized list → `BumpNone`

## Fix

In `internal/autopilot/auto_merger.go`, strip the `GH-XXXX: ` prefix from `PRTitle` before using it as the squash commit title:

```go
// Line 89-91, current:
commitTitle := fmt.Sprintf("Merge PR #%d", prState.PRNumber)
if mergeMethod == github.MergeMethodSquash && prState.PRTitle != "" {
    commitTitle = prState.PRTitle
}

// Fix: strip issue ID prefix so conventional commit is detected
commitTitle := fmt.Sprintf("Merge PR #%d", prState.PRNumber)
if mergeMethod == github.MergeMethodSquash && prState.PRTitle != "" {
    commitTitle = prState.PRTitle
    // Strip "GH-XXXX: " prefix from Pilot-generated PR titles
    // so "GH-2304: fix(doctor): ..." becomes "fix(doctor): ..."
    if prState.IssueNumber > 0 {
        prefix := fmt.Sprintf("GH-%d: ", prState.IssueNumber)
        commitTitle = strings.TrimPrefix(commitTitle, prefix)
    }
}
```

Keep PR titles as-is (they're useful on GitHub for traceability). Only strip the prefix from the squash commit message.

## Acceptance Criteria

- [ ] Squash commit messages from Pilot PRs strip the `GH-XXXX:` prefix
- [ ] Conventional commit types (`fix:`, `feat:`) are correctly detected after stripping
- [ ] Releases trigger correctly after merge
- [ ] PR titles on GitHub remain unchanged (still show `GH-XXXX:`)
- [ ] `make build && make test` pass

## Files

- `internal/autopilot/auto_merger.go` — Strip prefix at line ~91
- `internal/autopilot/auto_merger_test.go` — Add test for prefix stripping (extend `TestAutoMerger_MergePR_SquashUsePRTitle`)