### PR TITLE
GH-2315: Dispatcher `recoverStaleTasks()` (line 188) already marks orphans as `"failed"`, not `"completed"`. The status appears correct in the current code.

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -436,12 +436,16 @@ func (s *Store) GetExecution(id string) (*Execution, error) {
 }
 
 // HasCompletedExecution checks whether a completed execution exists for the given task and project.
-// It returns true if at least one execution with status "completed" exists.
+// It returns true if at least one execution with status "completed" exists AND has no error.
+// Executions marked "completed" but with a non-empty error field (e.g., orphan recovery) are
+// excluded — they didn't genuinely succeed and should not block re-dispatch.
+// GH-2315: Defense-in-depth against orphan recovery blocking re-dispatch.
 func (s *Store) HasCompletedExecution(taskID, projectPath string) (bool, error) {
 	var count int
 	err := s.db.QueryRow(`
 		SELECT COUNT(*) FROM executions
 		WHERE task_id = ? AND project_path = ? AND status = 'completed'
+			AND (error IS NULL OR error = '')
 	`, taskID, projectPath).Scan(&count)
 	if err != nil {
 		return false, err

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -330,6 +330,66 @@ func TestHasCompletedExecution(t *testing.T) {
 	}
 }
 
+// TestHasCompletedExecution_OrphanRecovery verifies that a completed execution
+// with a non-empty error field (e.g., from orphan recovery) does NOT count as
+// completed. This prevents orphan-recovered executions from blocking re-dispatch.
+// GH-2315: Defense-in-depth against orphan recovery blocking re-dispatch.
+func TestHasCompletedExecution_OrphanRecovery(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	taskID := "GH-2305"
+	projectPath := "/project"
+
+	// Simulate 5 failed executions (original scenario from GH-2314)
+	for i := 0; i < 5; i++ {
+		execID := fmt.Sprintf("exec-failed-%d", i)
+		_ = store.SaveExecution(&Execution{
+			ID:          execID,
+			TaskID:      taskID,
+			ProjectPath: projectPath,
+			Status:      "failed",
+		})
+	}
+
+	// Simulate orphan recovery: marks stale running task as "completed" with error
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-orphan",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "running",
+	})
+	// Orphan recovery calls UpdateExecutionStatus with error message
+	_ = store.UpdateExecutionStatus("exec-orphan", "completed", "stale running task recovered (orphaned worker)")
+
+	// The orphan-recovered "completed" execution should NOT count as completed
+	completed, err := store.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasCompletedExecution failed: %v", err)
+	}
+	if completed {
+		t.Error("expected false — orphan-recovered execution with error should not block re-dispatch")
+	}
+
+	// Now add a genuine completed execution (no error)
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-genuine",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "completed",
+	})
+	completed, err = store.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasCompletedExecution failed: %v", err)
+	}
+	if !completed {
+		t.Error("expected true — genuine completed execution should be found")
+	}
+}
+
 func TestPattern_Update(t *testing.T) {
 	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
 	defer func() { _ = os.RemoveAll(tmpDir) }()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2315.

Closes #2315

## Changes

