### PR TITLE
fix(dispatcher): persist Task.Labels across queue round-trip

### DIFF
--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -9,9 +9,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
-	"github.com/google/uuid"
 )
 
 // DispatcherConfig configures the task dispatcher behavior.
@@ -269,6 +269,7 @@ func (d *Dispatcher) queueDecomposedTask(ctx context.Context, parent *Task, resu
 		TaskVerbose:       parent.Verbose,
 		TaskSourceAdapter: parent.SourceAdapter,
 		TaskSourceIssueID: parent.SourceIssueID,
+		TaskLabels:        parent.Labels, // GH-2326: persist labels for no-decompose/autopilot-fix gates
 	}
 
 	if err := d.store.SaveExecution(parentExec); err != nil {
@@ -326,6 +327,7 @@ func (d *Dispatcher) queueSingleTask(ctx context.Context, task *Task) (string, e
 		TaskVerbose:       task.Verbose,
 		TaskSourceAdapter: task.SourceAdapter,
 		TaskSourceIssueID: task.SourceIssueID,
+		TaskLabels:        task.Labels, // GH-2326: persist labels for no-decompose/autopilot-fix gates
 	}
 
 	if err := d.store.SaveExecution(exec); err != nil {
@@ -564,6 +566,8 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 		w.runner.EmitProgress(exec.TaskID, "Running", 2, fmt.Sprintf("Worker started: %s", truncateForLog(exec.TaskTitle, 40)))
 
 		// Build task from execution record (full details stored when queued)
+		// GH-2326: restore Labels so runner-side no-decompose / autopilot-fix
+		// gates see the same labels the dispatch-time Decompose() saw.
 		task := &Task{
 			ID:            exec.TaskID,
 			Title:         exec.TaskTitle,
@@ -575,6 +579,7 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			Verbose:       exec.TaskVerbose,
 			SourceAdapter: exec.TaskSourceAdapter,
 			SourceIssueID: exec.TaskSourceIssueID,
+			Labels:        exec.TaskLabels,
 		}
 
 		// Execute (blocking)

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -21,7 +21,7 @@ type Store struct {
 	db   *sql.DB
 	path string
 
-	logSubMu      sync.RWMutex
+	logSubMu       sync.RWMutex
 	logSubscribers map[chan *LogEntry]struct{}
 }
 
@@ -155,6 +155,8 @@ func (s *Store) migrate() error {
 		`ALTER TABLE executions ADD COLUMN task_verbose BOOLEAN DEFAULT FALSE`,
 		`ALTER TABLE executions ADD COLUMN task_source_adapter TEXT DEFAULT ''`,
 		`ALTER TABLE executions ADD COLUMN task_source_issue_id TEXT DEFAULT ''`,
+		// GH-2326: persist Task.Labels across queue round-trip so no-decompose survives dispatch
+		`ALTER TABLE executions ADD COLUMN task_labels TEXT DEFAULT ''`,
 		`CREATE INDEX IF NOT EXISTS idx_executions_status ON executions(status)`,
 		`CREATE INDEX IF NOT EXISTS idx_patterns_project ON patterns(project_path)`,
 		// Cross-project pattern indexes
@@ -376,32 +378,66 @@ type Execution struct {
 	LinesRemoved     int
 	ModelName        string
 	// Task queue fields (GH-46) - store task details for deferred execution
-	TaskTitle       string
-	TaskDescription string
-	TaskBranch      string
-	TaskBaseBranch  string
+	TaskTitle         string
+	TaskDescription   string
+	TaskBranch        string
+	TaskBaseBranch    string
 	TaskCreatePR      bool
 	TaskVerbose       bool
 	TaskSourceAdapter string // Source adapter (e.g., "github", "gitlab", "linear")
 	TaskSourceIssueID string // Issue ID in the source adapter
+	// GH-2326: persisted Task.Labels so label-driven gates (no-decompose, autopilot-fix, etc.)
+	// survive the dispatcher queue → worker round-trip.
+	TaskLabels []string
 }
 
 // SaveExecution saves an execution record to the database.
 // The execution ID must be unique; duplicate IDs will cause an error.
 func (s *Store) SaveExecution(exec *Execution) error {
+	labelsJSON, err := marshalLabels(exec.TaskLabels)
+	if err != nil {
+		return fmt.Errorf("failed to marshal task labels: %w", err)
+	}
 	return s.withRetry("SaveExecution", func() error {
 		_, err := s.db.Exec(`
 			INSERT INTO executions (id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, completed_at,
 				tokens_input, tokens_output, tokens_total, estimated_cost_usd, files_changed, lines_added, lines_removed, model_name,
 				task_title, task_description, task_branch, task_base_branch, task_create_pr, task_verbose,
-				task_source_adapter, task_source_issue_id)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				task_source_adapter, task_source_issue_id, task_labels)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, exec.ID, exec.TaskID, exec.ProjectPath, exec.Status, exec.Output, exec.Error, exec.DurationMs, exec.PRUrl, exec.CommitSHA, exec.CompletedAt,
 			exec.TokensInput, exec.TokensOutput, exec.TokensTotal, exec.EstimatedCostUSD, exec.FilesChanged, exec.LinesAdded, exec.LinesRemoved, exec.ModelName,
 			exec.TaskTitle, exec.TaskDescription, exec.TaskBranch, exec.TaskBaseBranch, exec.TaskCreatePR, exec.TaskVerbose,
-			exec.TaskSourceAdapter, exec.TaskSourceIssueID)
+			exec.TaskSourceAdapter, exec.TaskSourceIssueID, labelsJSON)
 		return err
 	})
+}
+
+// marshalLabels serializes labels to JSON; returns "" when the slice is empty
+// so the DB column stays compatible with pre-migration rows and default "".
+func marshalLabels(labels []string) (string, error) {
+	if len(labels) == 0 {
+		return "", nil
+	}
+	b, err := json.Marshal(labels)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// unmarshalLabels parses JSON-encoded labels; empty/whitespace → nil slice.
+func unmarshalLabels(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	var labels []string
+	if err := json.Unmarshal([]byte(s), &labels); err != nil {
+		// Legacy / malformed rows: return nil rather than failing the read.
+		return nil
+	}
+	return labels
 }
 
 // GetExecution retrieves an execution by its unique ID.
@@ -414,19 +450,22 @@ func (s *Store) GetExecution(id string) (*Execution, error) {
 			COALESCE(lines_removed, 0), COALESCE(model_name, ''),
 			COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
 			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
-			COALESCE(task_source_adapter, ''), COALESCE(task_source_issue_id, '')
+			COALESCE(task_source_adapter, ''), COALESCE(task_source_issue_id, ''),
+			COALESCE(task_labels, '')
 		FROM executions WHERE id = ?
 	`, id)
 
 	var exec Execution
 	var completedAt sql.NullTime
+	var labelsJSON string
 	err := row.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &completedAt,
 		&exec.TokensInput, &exec.TokensOutput, &exec.TokensTotal, &exec.EstimatedCostUSD, &exec.FilesChanged, &exec.LinesAdded, &exec.LinesRemoved, &exec.ModelName,
 		&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose,
-		&exec.TaskSourceAdapter, &exec.TaskSourceIssueID)
+		&exec.TaskSourceAdapter, &exec.TaskSourceIssueID, &labelsJSON)
 	if err != nil {
 		return nil, err
 	}
+	exec.TaskLabels = unmarshalLabels(labelsJSON)
 
 	if completedAt.Valid {
 		exec.CompletedAt = &completedAt.Time
@@ -825,7 +864,8 @@ func (s *Store) GetQueuedTasksForProject(projectPath string, limit int) ([]*Exec
 		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at,
 			COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
 			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
-			COALESCE(task_source_adapter, ''), COALESCE(task_source_issue_id, '')
+			COALESCE(task_source_adapter, ''), COALESCE(task_source_issue_id, ''),
+			COALESCE(task_labels, '')
 		FROM executions
 		WHERE (status = 'queued' OR status = 'pending') AND project_path = ?
 		ORDER BY created_at ASC
@@ -840,14 +880,16 @@ func (s *Store) GetQueuedTasksForProject(projectPath string, limit int) ([]*Exec
 	for rows.Next() {
 		var exec Execution
 		var completedAt sql.NullTime
+		var labelsJSON string
 		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &completedAt,
 			&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose,
-			&exec.TaskSourceAdapter, &exec.TaskSourceIssueID); err != nil {
+			&exec.TaskSourceAdapter, &exec.TaskSourceIssueID, &labelsJSON); err != nil {
 			return nil, err
 		}
 		if completedAt.Valid {
 			exec.CompletedAt = &completedAt.Time
 		}
+		exec.TaskLabels = unmarshalLabels(labelsJSON)
 		executions = append(executions, &exec)
 	}
 

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -656,6 +656,79 @@ func TestGetQueuedTasks(t *testing.T) {
 	}
 }
 
+// TestTaskLabelsRoundTrip verifies that Task.Labels survive the queue round-trip
+// (SaveExecution → GetExecution and GetQueuedTasksForProject). Without this, labels
+// like "no-decompose" are silently dropped and runner-side gates bypassed (GH-2326).
+func TestTaskLabelsRoundTrip(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	cases := []struct {
+		name   string
+		labels []string
+	}{
+		{"nil labels", nil},
+		{"empty slice", []string{}},
+		{"single label", []string{"no-decompose"}},
+		{"multiple labels", []string{"pilot", "no-decompose", "priority:high"}},
+		{"special chars", []string{"kind/bug", "area/executor", "v1.0+"}},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			execID := fmt.Sprintf("exec-labels-%d", i)
+			input := &Execution{
+				ID:          execID,
+				TaskID:      fmt.Sprintf("T-%d", i),
+				ProjectPath: "/project/a",
+				Status:      "queued",
+				TaskTitle:   "test",
+				TaskLabels:  tc.labels,
+			}
+			if err := store.SaveExecution(input); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			got, err := store.GetExecution(execID)
+			if err != nil {
+				t.Fatalf("GetExecution: %v", err)
+			}
+			// nil and empty slice both normalize to nil on read
+			wantLen := len(tc.labels)
+			if len(got.TaskLabels) != wantLen {
+				t.Fatalf("labels length: got %d (%v), want %d (%v)", len(got.TaskLabels), got.TaskLabels, wantLen, tc.labels)
+			}
+			for j, l := range tc.labels {
+				if got.TaskLabels[j] != l {
+					t.Errorf("labels[%d]: got %q, want %q", j, got.TaskLabels[j], l)
+				}
+			}
+
+			// Also verify the worker-facing read path returns labels.
+			queued, err := store.GetQueuedTasksForProject("/project/a", 100)
+			if err != nil {
+				t.Fatalf("GetQueuedTasksForProject: %v", err)
+			}
+			var found *Execution
+			for _, e := range queued {
+				if e.ID == execID {
+					found = e
+					break
+				}
+			}
+			if found == nil {
+				t.Fatalf("execution %s not in queued list", execID)
+			}
+			if len(found.TaskLabels) != wantLen {
+				t.Errorf("queued read labels length: got %d (%v), want %d", len(found.TaskLabels), found.TaskLabels, wantLen)
+			}
+		})
+	}
+}
+
 func TestGetExecutionsInPeriod(t *testing.T) {
 	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
 	defer func() { _ = os.RemoveAll(tmpDir) }()
@@ -1044,12 +1117,12 @@ func TestGetLifetimeTaskCounts(t *testing.T) {
 
 func TestBriefHistory(t *testing.T) {
 	tests := []struct {
-		name           string
-		setup          func(*Store)
-		channel        string
-		wantNil        bool
-		wantBriefType  string
-		wantRecipient  string
+		name          string
+		setup         func(*Store)
+		channel       string
+		wantNil       bool
+		wantBriefType string
+		wantRecipient string
 	}{
 		{
 			name:    "empty table returns nil",


### PR DESCRIPTION
## Problem

`Task.Labels` is silently dropped when the dispatcher serializes a task to SQLite. When the worker pulls it back, label-driven gates see empty labels and decompose the task anyway — exploding issue-body markdown into bogus subtasks that crash Claude Code with \`exit status 1\`.

## Live evidence

GH-2305, GH-2324, GH-2325 all carried \`no-decompose\` label and still failed 13+ times with \"subtask 1/3 failed: unknown: exit status 1\". The regex-generated subtask titles (e.g. \`**Look like prose/analysis**, not action items:\`) confirmed \`analyzeAndSplit\` was running despite the label being present at dispatch time.

## Root cause flow

1. [handlers.go:231](../blob/main/cmd/pilot/handlers.go#L231) populates \`task.Labels\`
2. [dispatcher.go:242](../blob/main/internal/executor/dispatcher.go#L242) \`Decompose(task)\` sees labels in memory → returns not-decomposed
3. [dispatcher.go:316](../blob/main/internal/executor/dispatcher.go#L316) \`queueSingleTask\` saves to DB — no \`TaskLabels\` field existed
4. [dispatcher.go:567](../blob/main/internal/executor/dispatcher.go#L567) worker rebuilds task — no \`Labels:\` field
5. [runner.go:1073](../blob/main/internal/executor/runner.go#L1073) \`hasNoDecompose=false\`
6. [runner.go:1227](../blob/main/internal/executor/runner.go#L1227) second \`decomposer.Decompose\` → bullets become subtasks → fail

## Fix

- Add \`TaskLabels []string\` to \`memory.Execution\`
- Migration: \`ALTER TABLE executions ADD COLUMN task_labels TEXT DEFAULT ''\` (JSON-encoded)
- \`SaveExecution\`, \`GetExecution\`, \`GetQueuedTasksForProject\` round-trip labels
- \`dispatcher.queueSingleTask\` / \`queueDecomposedTask\` persist \`task.Labels\`; worker rehydrates at pickup

## Test plan

- [x] \`TestTaskLabelsRoundTrip\` covers nil / empty / single / multiple / special-char labels through both \`GetExecution\` and \`GetQueuedTasksForProject\`
- [x] All existing dispatcher/memory tests pass
- [x] \`go vet ./...\` clean
- [ ] Manual: re-queue GH-2305/2324/2325 after merge and confirm \`no-decompose\` actually prevents decomposition