### PR TITLE
docs(claude): scope Navigator-only rules to interactive sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,33 @@
 
 **Navigator plans. Pilot executes.**
 
-## ⚠️ WORKFLOW: Navigator + Pilot Pipeline
+## Who is reading this file?
 
-**This Claude Code session uses Navigator for planning, Pilot for execution.**
+This project ships an autonomous executor (Pilot) that runs Claude Code
+against this very repo to implement tickets. That means this `CLAUDE.md`
+is read by two very different kinds of sessions:
+
+1. **Pilot-executor sessions** — spawned by `pilot start` to implement a
+   specific GitHub issue. The prompt describes a concrete task and expects
+   code changes, a commit, and a PR. **In these sessions, YOU ARE Pilot.
+   Implement the task directly. The "Navigator + Pilot pipeline" rules in
+   the next section DO NOT apply — you are the execution leg of that
+   pipeline.** Signals you're in this mode:
+   - Prompt begins with `GitHub Issue #NNN:` or `Task:`
+   - No interactive user is following up
+   - CWD is inside a pilot worktree or a branch named `pilot/GH-*`
+2. **Interactive dev sessions** — a human developer is planning or
+   reviewing work on the Pilot project itself. In these, follow the
+   Navigator + Pilot pipeline below.
+
+When in doubt, look at the incoming prompt: if it hands you a specific
+task with file paths and expected outputs, implement it. If it's a human
+asking open-ended questions about the project, plan via Navigator.
+
+## ⚠️ WORKFLOW: Navigator + Pilot Pipeline (interactive sessions only)
+
+**If this is an interactive dev session**, use Navigator to plan and Pilot
+to execute:
 
 | Phase | Tool | Action |
 |-------|------|--------|
@@ -29,14 +53,18 @@ gh issue list --label pilot --state open
 gh pr view <number> && gh pr merge <number>
 ```
 
-### Rules
+### Rules (interactive sessions)
 
 - ✅ Use `/nav-task` for planning and design
 - ✅ Create GitHub issues with `pilot` label for execution
 - ✅ Review every PR before merging
-- ❌ DO NOT write code directly in this session
-- ❌ DO NOT make commits manually
-- ❌ DO NOT create PRs manually
+- ❌ In *interactive* sessions, do not write code directly — defer to
+  Pilot so the knowledge graph and quality gates run
+- ❌ Do not make commits manually from an interactive planning session
+- ❌ Do not create PRs manually from an interactive planning session
+
+Pilot-executor sessions are the exception: they MUST write code, commit,
+and push — that's their entire job.
 
 **Pilot runs in a separate terminal** (`pilot start --telegram --github`) and auto-picks issues labeled `pilot`.
 


### PR DESCRIPTION
## Problem

Pilot's executor spawns Claude Code against this very repo to implement tickets. When it does, Claude reads `CLAUDE.md` — especially \"❌ DO NOT write code directly in this session\" — and refuses every task with \"violates project workflow.\"

Three issues (GH-2305 / GH-2324 / GH-2325) failed dozens of times before this was diagnosed. The refusal text wasn't in stderr, so Pilot's error classifier reported only `unknown: exit status 1`.

## Fix

Lead `CLAUDE.md` with a **\"Who is reading this file?\"** section that distinguishes:

- **Pilot-executor sessions** — spawned by `pilot start` with a concrete task prompt. In these, Claude **is Pilot** — implement directly. The planning rules DO NOT apply.
- **Interactive dev sessions** — a human planning or reviewing on the Pilot project. In these, follow the Navigator + Pilot pipeline as before.

Detection signals for executor mode (documented in the file):
- Prompt begins with \`GitHub Issue #NNN:\` or \`Task:\`
- No interactive user follow-up
- CWD is inside a pilot worktree or a \`pilot/GH-*\` branch

The \"DO NOT write code / commit / create PRs manually\" bullets are now explicitly scoped to interactive planning sessions. Pilot-executor sessions are called out as the one exception.

## Verification

Reproduced GH-2305 manually with the scoped \`CLAUDE.md\`:
- **Before**: Claude refused with \"Refusing direct implementation — violates project workflow.\"
- **After**: Claude implemented the changes (helper extraction, dashboard warning, empty-repo display fix) and returned a summary.

Auto-memory file \`feedback_never_execute_directly.md\` was scoped in the same way (not in this repo — lives in \`~/.claude/projects/\`) to avoid the same trap coming back via memory.

## Follow-ups (separate)

- Pilot should inject an executor-mode system prompt and set an env var so Claude doesn't need to infer the mode from file markers.
- Pilot should persist full stderr + final assistant message to \`execution_logs\` on failure. Would have saved hours of diagnosis here.

## Test plan

- [x] Manual reproduction: task succeeds with scoped rules
- [ ] After merge: retrigger GH-2305 / GH-2324 / GH-2325 and confirm Pilot executor implements them