### PR TITLE
fix(executor): persist backend stderr + final message on failure

### DIFF
--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -188,6 +188,20 @@ type BackendResult struct {
 	// stream-json parsing. Used to recover success when the process exits with an error
 	// after completing work (e.g., timeout on final summary). GH-2107.
 	SawSuccessResult bool
+
+	// Stderr is the full captured stderr output from the backend subprocess.
+	// Populated even on success so Pilot can log warnings; critical on failure
+	// for diagnosing `unknown: exit status 1`. GH-2328.
+	Stderr string
+
+	// LastAssistantText is the final assistant `text` block observed in the
+	// stream-json output. When Claude refuses a task (exits 0 or non-zero with
+	// no stderr), this captures the refusal reason for diagnosis. GH-2328.
+	LastAssistantText string
+
+	// ErrorType classifies the failure (rate_limit, api_error, oom_killed,
+	// session_not_found, timeout, invalid_config, unknown). GH-2328.
+	ErrorType string
 }
 
 // BackendConfig contains configuration for executor backends.

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -468,6 +468,12 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 				opts.EventHandler(event)
 			}
 
+			// GH-2328: track the last assistant text block so refusals (Claude
+			// exits 0 after politely declining) can be surfaced to the user.
+			if event.Type == EventTypeText && event.Message != "" {
+				result.LastAssistantText = event.Message
+			}
+
 			// Track final result
 			if event.Type == EventTypeResult {
 				// GH-2103: Cancel heartbeat on result event.
@@ -588,6 +594,13 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 		stderr := stderrOutput.String()
 		ccErr := parseClaudeCodeError(stderr, err).(*ClaudeCodeError)
 
+		// GH-2328: surface the raw stderr + classification so the runner can
+		// write them to execution_logs. Without this, "unknown: exit status 1"
+		// is all the user ever sees and diagnosis requires re-running with a
+		// patched binary.
+		result.Stderr = stderr
+		result.ErrorType = string(ccErr.Type)
+
 		// GH-2112: Log OOM kills at error level for monitoring
 		if ccErr.Type == ErrorTypeOOM {
 			b.log.Error("Claude Code process OOM-killed",
@@ -613,6 +626,9 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 	}
 
 	result.Success = true
+	// GH-2328: expose stderr on success too so warnings (e.g. rate-limit
+	// overage rejected, context window warnings) can be logged.
+	result.Stderr = stderrOutput.String()
 	return result, nil
 }
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -826,6 +826,40 @@ func (r *Runner) saveLogEntry(executionID, level, message string) {
 	}
 }
 
+// persistBackendDiagnostics writes the backend's stderr, error type, and final
+// assistant text to execution_logs so `unknown: exit status 1` failures are
+// actually diagnosable. Previously these bytes were only emitted via slog to
+// stdout and disappeared when Pilot restarted. GH-2328.
+func (r *Runner) persistBackendDiagnostics(executionID string, backendResult *BackendResult) {
+	if backendResult == nil || r.logStore == nil {
+		return
+	}
+
+	const (
+		stderrMaxChars  = 16 * 1024
+		messageMaxChars = 4 * 1024
+	)
+
+	if backendResult.ErrorType != "" {
+		r.saveLogEntry(executionID, "error",
+			"Backend error classification: "+backendResult.ErrorType)
+	}
+
+	if stderr := strings.TrimSpace(backendResult.Stderr); stderr != "" {
+		if len(stderr) > stderrMaxChars {
+			stderr = stderr[:stderrMaxChars] + "\n[...truncated]"
+		}
+		r.saveLogEntry(executionID, "error", "Backend stderr:\n"+stderr)
+	}
+
+	if msg := strings.TrimSpace(backendResult.LastAssistantText); msg != "" {
+		if len(msg) > messageMaxChars {
+			msg = msg[:messageMaxChars] + "\n[...truncated]"
+		}
+		r.saveLogEntry(executionID, "error", "Final assistant message:\n"+msg)
+	}
+}
+
 // getRecordingsPath returns the recordings path, using default if not set
 func (r *Runner) getRecordingsPath() string {
 	if r.recordingsPath != "" {
@@ -1817,6 +1851,12 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		// GH-1599: Log task failed milestone
 		r.saveLogEntry(task.ID, "error", "Task failed: "+result.Error)
 
+		// GH-2328: persist stderr + final assistant message + error type so
+		// "unknown: exit status 1" is actually diagnosable. Without this,
+		// failures look identical regardless of whether Claude refused, hit a
+		// rate limit, was OOM-killed, or crashed silently.
+		r.persistBackendDiagnostics(task.ID, backendResult)
+
 		// Finish recording with failed status
 		if recorder != nil {
 			recorder.SetModel(state.modelName)
@@ -1912,6 +1952,9 @@ retrySucceeded:
 		)
 		r.reportProgress(task.ID, "Failed", 100, result.Error)
 		r.saveLogEntry(task.ID, "error", "Task failed: "+result.Error)
+
+		// GH-2328: persist stderr + final assistant message + error type.
+		r.persistBackendDiagnostics(task.ID, backendResult)
 
 		// Emit task failed event
 		r.emitAlertEvent(AlertEvent{


### PR DESCRIPTION
## Problem

When Claude Code exited 1 with empty stderr, Pilot logged only \`unknown: exit status 1\` to the executions table. Every failure looked identical — refusals, rate-limit aborts, OOM kills, silent crashes — so diagnosis required patching the binary and re-running.

Hit three times in one session (GH-2305 / GH-2324 / GH-2325) and cost hours each time.

## Changes

- \`BackendResult\` gains \`Stderr\`, \`LastAssistantText\`, \`ErrorType\` fields (populated on both success and failure)
- Claude Code backend captures:
  - last assistant \`text\` block from the stream — surfaces refusals that exit 0
  - raw stderr
  - classified error type (\`rate_limit\`, \`api_error\`, \`oom_killed\`, \`session_not_found\`, \`timeout\`, \`invalid_config\`, \`unknown\`)
- Runner's two failure paths call new \`persistBackendDiagnostics\` helper which writes to \`execution_logs\` with clear prefixes:
  - \`Backend error classification: <type>\`
  - \`Backend stderr:\\n<...>\` (truncated to 16 KB)
  - \`Final assistant message:\\n<...>\` (truncated to 4 KB)

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/executor/ -run 'TestDispatcher|TestBackend'\` pass
- [x] Additive changes only — no behavior change on success paths
- [ ] Next executor failure will write human-readable diagnostics to the DB instead of \`unknown: exit status 1\`

## Scope

Partial fix for [GH-2328](https://github.com/qf-studio/pilot/issues/2328). Still open:
- \`PILOT_EXECUTOR=1\` env-var signal (the prompt-builder already prepends "PILOT EXECUTION MODE" which did the job here)
- \`ErrorTypeNoChanges\` for Claude exit-0 with empty diff