### PR TITLE
fix(dispatcher): don't reap queued tasks when live worker exists

### DIFF
--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -193,6 +193,11 @@ func (d *Dispatcher) recoverStaleTasks() int {
 	}
 
 	// Recover stale queued tasks (stuck in queue with no worker).
+	// GH-2331: Don't mark queued tasks stale when a live worker exists for the
+	// project — they're just waiting their turn. Pilot runs tasks serially per
+	// project; when one task takes 8+ minutes (common for epic/Navigator work),
+	// its siblings exceed the 5-minute threshold purely by waiting, and get
+	// killed mid-queue. Only orphans (no worker alive) should be reaped.
 	staleQueued, err := d.store.GetStaleQueuedExecutions(d.config.StaleQueuedThreshold)
 	if err != nil {
 		d.log.Warn("Failed to fetch stale queued executions", slog.Any("error", err))
@@ -208,6 +213,16 @@ func (d *Dispatcher) recoverStaleTasks() int {
 			}
 			continue
 		}
+
+		if d.hasLiveWorker(exec.ProjectPath) {
+			d.log.Debug("Skipping stale queued reap — live worker for project exists",
+				slog.String("execution_id", exec.ID),
+				slog.String("task_id", exec.TaskID),
+				slog.String("project", exec.ProjectPath),
+			)
+			continue
+		}
+
 		d.log.Warn("Marking stale queued task as failed",
 			slog.String("execution_id", exec.ID),
 			slog.String("task_id", exec.TaskID),
@@ -222,6 +237,16 @@ func (d *Dispatcher) recoverStaleTasks() int {
 
 	d.log.Info("stale recovery complete, reset N tasks", slog.Int("count", resetCount))
 	return resetCount
+}
+
+// hasLiveWorker reports whether a worker goroutine exists for the given
+// project path. Used by stale recovery to avoid killing queued tasks that
+// are simply waiting their turn behind a long-running sibling. GH-2331.
+func (d *Dispatcher) hasLiveWorker(projectPath string) bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	_, ok := d.workers[projectPath]
+	return ok
 }
 
 // QueueTask adds a task to the execution queue and returns the execution ID.


### PR DESCRIPTION
## Problem

\`recoverStaleTasks\` marks any execution with status=\`queued\` older than \`StaleQueuedThreshold\` (5 min default) as failed. But Pilot runs tasks **serially per project**. When one task takes 8+ minutes (common for Navigator/epic work), its queued siblings exceed the threshold purely by waiting — and get killed mid-queue, triggering an immediate retry that's also reaped 5 minutes later. Repeat forever.

Hit repeatedly today:
- GH-2305 ran for 8 minutes (produced PR #2329)
- GH-2324 / GH-2325 / GH-2328 sat in queue → all killed as \"stale queued (no worker picked up)\"
- Re-dispatched → killed again → ...

## Fix

In the stale-queued loop, skip any execution whose project still has a live worker entry in \`d.workers\`. Those tasks aren't orphans — they're waiting behind a long-running sibling. Only when no worker exists for the project does the stale reap fire.

\`StaleRunningThreshold\` (30 min) is untouched — genuinely crashed workers are still recovered.

## Changes

- \`Dispatcher.hasLiveWorker(projectPath)\` — new helper, read-locked map check
- \`recoverStaleTasks\` — per-execution guard: skip reap if live worker exists for the project, continue to the completed-row cleanup / real orphan reap as before

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/executor/ -run 'TestDispatcher'\` pass
- [ ] After merge: 4+ queued issues for the same project no longer get killed while waiting