### PR TITLE
GH-2324: fix(epic): validate sub-issue titles — reject LLM analysis-style titles in decomposition

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -9,7 +9,117 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
+
+// conventionalCommitPrefixRegex matches conventional-commit type prefixes like
+// "fix:", "feat(scope):", "chore(epic):" at the start of a title.
+var conventionalCommitPrefixRegex = regexp.MustCompile(`^(?i)(fix|feat|chore|docs|test|refactor|style|perf|ci|build|revert)(\([^)]+\))?:`)
+
+// subtaskActionVerbs is the allow-list of first words that identify a subtask
+// title as an action item (vs LLM analysis/prose). Kept intentionally broad to
+// cover normal engineering verbs without admitting analysis sentences.
+var subtaskActionVerbs = map[string]bool{
+	"add": true, "adjust": true, "allow": true, "apply": true, "audit": true,
+	"block": true, "build": true, "bump": true, "cache": true, "check": true,
+	"clean": true, "cleanup": true, "clear": true, "consolidate": true,
+	"convert": true, "create": true, "decouple": true, "dedupe": true,
+	"delete": true, "deploy": true, "deprecate": true, "detect": true,
+	"disable": true, "document": true, "drop": true, "emit": true, "enable": true,
+	"enforce": true, "ensure": true, "expose": true, "extract": true,
+	"fallback": true, "filter": true, "fix": true, "gate": true, "generate": true,
+	"guard": true, "handle": true, "harden": true, "hide": true, "implement": true,
+	"improve": true, "init": true, "inject": true, "install": true,
+	"instrument": true, "introduce": true, "invalidate": true, "limit": true,
+	"load": true, "log": true, "make": true, "merge": true, "migrate": true,
+	"move": true, "normalize": true, "parse": true, "patch": true, "persist": true,
+	"plumb": true, "port": true, "prefix": true, "prevent": true, "propagate": true,
+	"protect": true, "provide": true, "publish": true, "refactor": true,
+	"register": true, "reject": true, "remove": true, "rename": true,
+	"replace": true, "reset": true, "restore": true, "retry": true, "return": true,
+	"revert": true, "rewrite": true, "route": true, "sanitize": true, "scope": true,
+	"seed": true, "send": true, "serialize": true, "set": true, "setup": true,
+	"simplify": true, "skip": true, "split": true, "standardize": true,
+	"stop": true, "store": true, "strip": true, "support": true, "surface": true,
+	"switch": true, "sync": true, "teach": true, "test": true, "throttle": true,
+	"trim": true, "truncate": true, "unify": true, "unwire": true, "update": true,
+	"upgrade": true, "use": true, "validate": true, "verify": true, "wait": true,
+	"warn": true, "wire": true, "wrap": true, "write": true,
+}
+
+// subtaskProseIndicators are phrases that strongly signal a subtask "title" is
+// actually LLM analysis/prose rather than an action item. See GH-2324 / GH-2315.
+var subtaskProseIndicators = []string{
+	", not ", " but ", " however", "however,",
+	"appears correct", "appears to ", "looks good", "looks correct",
+	" is fine", " is correct", " is actually ", " already ",
+	"already marks", "already handles", "already does",
+	" seems to ", " seems like", " should already",
+	"the status appears", "the current code",
+}
+
+// validateSubtaskTitle reports an error when a subtask title extracted from LLM
+// planning output is structurally unsuitable for use as a GitHub issue title.
+//
+// Incident (GH-2324): the decomposition of GH-2314 produced GH-2315 with this
+// as its title, directly from the LLM's skeptical analysis of the parent issue:
+//
+//	"Dispatcher `recoverStaleTasks()` (line 188) already marks orphans as
+//	 `\"failed\"`, not `\"completed\"`. The status appears correct in the
+//	 current code."
+//
+// The string flowed verbatim into the sub-issue title, PR #2317 title, the
+// squash-merge commit subject, and the public v2.95.3 changelog. This validator
+// rejects such titles before they reach the tracker.
+//
+// Rejection criteria:
+//  1. Contains prose/analysis indicators (", not ", " but ", "appears correct",
+//     "already", ...).
+//  2. Exceeds 15 words — real action titles are terse.
+//  3. First significant word is neither a conventional-commit type prefix nor
+//     an allow-listed action verb.
+func validateSubtaskTitle(title string) error {
+	t := strings.TrimSpace(title)
+	if t == "" {
+		return fmt.Errorf("empty title")
+	}
+
+	lower := strings.ToLower(t)
+	for _, ind := range subtaskProseIndicators {
+		if strings.Contains(lower, ind) {
+			return fmt.Errorf("title contains analysis/prose indicator %q", strings.TrimSpace(ind))
+		}
+	}
+
+	words := strings.Fields(t)
+	if len(words) > 15 {
+		return fmt.Errorf("title has %d words (>15); action titles should be terse", len(words))
+	}
+
+	if conventionalCommitPrefixRegex.MatchString(t) {
+		return nil
+	}
+
+	firstWord := strings.ToLower(strings.Trim(words[0], "*_`\"'.,:;()[]"))
+	if firstWord == "" {
+		return fmt.Errorf("title has no leading word")
+	}
+	if !subtaskActionVerbs[firstWord] {
+		return fmt.Errorf("title does not start with an action verb or conventional-commit prefix (got %q)", firstWord)
+	}
+	return nil
+}
+
+// syntheticSubtaskTitle builds a fallback title for subtasks whose LLM-produced
+// title failed validateSubtaskTitle. Uses the parent ID so the sub-issue is
+// still traceable back to the epic. GH-2324.
+func syntheticSubtaskTitle(parent *Task, order int) string {
+	parentID := "epic"
+	if parent != nil && parent.ID != "" {
+		parentID = parent.ID
+	}
+	return fmt.Sprintf("%s: Subtask %d", parentID, order)
+}
 
 // HasNoPlanKeyword checks whether the task title or description contains the [no-plan]
 // keyword, allowing users to bypass epic planning (GH-1687).
@@ -463,6 +573,35 @@ func (r *Runner) createSubIssuesViaAdapter(ctx context.Context, plan *EpicPlan) 
 		// Truncate title (adapter may have different limits, but 80 is reasonable)
 		title := truncateTitle(subtask.Title, 80)
 
+		// GH-2324: Reject LLM analysis-style titles before they reach the tracker.
+		// Falls back to a synthetic parent-derived title, emits an alert so the
+		// regression is visible.
+		if err := validateSubtaskTitle(title); err != nil {
+			fallback := syntheticSubtaskTitle(plan.ParentTask, subtask.Order)
+			r.log.Warn("Rejected invalid LLM subtask title; using synthetic fallback",
+				"original_title", subtask.Title,
+				"fallback_title", fallback,
+				"reason", err.Error(),
+				"subtask_order", subtask.Order,
+				"parent_id", parentID,
+			)
+			r.emitAlertEvent(AlertEvent{
+				Type:      AlertEventTypeConfigError,
+				TaskID:    parentID,
+				TaskTitle: plan.ParentTask.Title,
+				Project:   plan.ParentTask.ProjectPath,
+				Error:     fmt.Sprintf("invalid subtask title rejected: %v", err),
+				Metadata: map[string]string{
+					"event":          "invalid_subtask_title",
+					"original_title": subtask.Title,
+					"fallback_title": fallback,
+					"subtask_order":  strconv.Itoa(subtask.Order),
+				},
+				Timestamp: time.Now(),
+			})
+			title = fallback
+		}
+
 		r.log.Debug("Creating sub-issue via adapter",
 			"subtask_order", subtask.Order,
 			"title", title,
@@ -519,6 +658,43 @@ func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, e
 
 		// Truncate title to max 80 chars for GitHub issue limits (GH-1133)
 		title := truncateTitle(subtask.Title, 80)
+
+		// GH-2324: Reject LLM analysis-style titles before they reach GitHub.
+		// Falls back to a synthetic parent-derived title, emits an alert so the
+		// regression is visible.
+		if err := validateSubtaskTitle(title); err != nil {
+			fallback := syntheticSubtaskTitle(plan.ParentTask, subtask.Order)
+			parentID := ""
+			parentProject := ""
+			parentTitle := ""
+			if plan.ParentTask != nil {
+				parentID = plan.ParentTask.ID
+				parentProject = plan.ParentTask.ProjectPath
+				parentTitle = plan.ParentTask.Title
+			}
+			r.log.Warn("Rejected invalid LLM subtask title; using synthetic fallback",
+				"original_title", subtask.Title,
+				"fallback_title", fallback,
+				"reason", err.Error(),
+				"subtask_order", subtask.Order,
+				"parent_id", parentID,
+			)
+			r.emitAlertEvent(AlertEvent{
+				Type:      AlertEventTypeConfigError,
+				TaskID:    parentID,
+				TaskTitle: parentTitle,
+				Project:   parentProject,
+				Error:     fmt.Sprintf("invalid subtask title rejected: %v", err),
+				Metadata: map[string]string{
+					"event":          "invalid_subtask_title",
+					"original_title": subtask.Title,
+					"fallback_title": fallback,
+					"subtask_order":  strconv.Itoa(subtask.Order),
+				},
+				Timestamp: time.Now(),
+			})
+			title = fallback
+		}
 
 		// Create issue using gh CLI
 		args := []string{

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -1094,8 +1094,8 @@ func TestCreateSubIssues_UsesAdapterForNonGitHub(t *testing.T) {
 			SourceIssueID: "APP-100",
 		},
 		Subtasks: []PlannedSubtask{
-			{Title: "First subtask", Description: "Do first thing", Order: 1},
-			{Title: "Second subtask", Description: "Do second thing", Order: 2},
+			{Title: "Add first subtask", Description: "Do first thing", Order: 1},
+			{Title: "Add second subtask", Description: "Do second thing", Order: 2},
 		},
 	}
 
@@ -1115,8 +1115,8 @@ func TestCreateSubIssues_UsesAdapterForNonGitHub(t *testing.T) {
 	if mock.Called[0].ParentID != "APP-100" {
 		t.Errorf("First call parentID = %q, want APP-100", mock.Called[0].ParentID)
 	}
-	if mock.Called[0].Title != "First subtask" {
-		t.Errorf("First call title = %q, want 'First subtask'", mock.Called[0].Title)
+	if mock.Called[0].Title != "Add first subtask" {
+		t.Errorf("First call title = %q, want 'Add first subtask'", mock.Called[0].Title)
 	}
 
 	// Verify second call
@@ -1163,7 +1163,7 @@ func TestCreateSubIssues_FallsBackToGitHubWhenNoAdapter(t *testing.T) {
 			// SourceAdapter not set - defaults to empty string
 		},
 		Subtasks: []PlannedSubtask{
-			{Title: "Test subtask", Description: "Test", Order: 1},
+			{Title: "Add test subtask", Description: "Test", Order: 1},
 		},
 	}
 
@@ -1198,7 +1198,7 @@ func TestCreateSubIssues_FallsBackToGitHubWhenAdapterIsGitHub(t *testing.T) {
 			SourceIssueID: "100",
 		},
 		Subtasks: []PlannedSubtask{
-			{Title: "Test subtask", Description: "Test", Order: 1},
+			{Title: "Add test subtask", Description: "Test", Order: 1},
 		},
 	}
 
@@ -1226,7 +1226,7 @@ func TestCreateSubIssues_FallsBackToGitHubWhenNoCreator(t *testing.T) {
 			SourceIssueID: "APP-100",
 		},
 		Subtasks: []PlannedSubtask{
-			{Title: "Test subtask", Description: "Test", Order: 1},
+			{Title: "Add test subtask", Description: "Test", Order: 1},
 		},
 	}
 
@@ -1262,7 +1262,7 @@ func TestCreateSubIssues_AdapterError(t *testing.T) {
 			SourceIssueID: "APP-100",
 		},
 		Subtasks: []PlannedSubtask{
-			{Title: "Test subtask", Description: "Test", Order: 1},
+			{Title: "Add test subtask", Description: "Test", Order: 1},
 		},
 	}
 
@@ -1354,8 +1354,8 @@ func TestCreateSubIssues_AdapterNoDependsOnWhenEmpty(t *testing.T) {
 			SourceIssueID: "APP-100",
 		},
 		Subtasks: []PlannedSubtask{
-			{Title: "First", Description: "Do first", Order: 1},
-			{Title: "Second", Description: "Do second", Order: 2},
+			{Title: "Add first", Description: "Do first", Order: 1},
+			{Title: "Add second", Description: "Do second", Order: 2},
 		},
 	}
 
@@ -1483,7 +1483,7 @@ func TestCreateSubIssues_LinkerInvokedAfterGhCreate(t *testing.T) {
 			SourceIssueID: "10",
 		},
 		Subtasks: []PlannedSubtask{
-			{Title: "Child task", Description: "Do it", Order: 1},
+			{Title: "Add child task", Description: "Do it", Order: 1},
 		},
 	}
 
@@ -1545,7 +1545,7 @@ func TestCreateSubIssues_LinkerErrorIsNonFatal(t *testing.T) {
 			SourceIssueID: "5",
 		},
 		Subtasks: []PlannedSubtask{
-			{Title: "Child", Description: "child", Order: 1},
+			{Title: "Add child", Description: "child", Order: 1},
 		},
 	}
 
@@ -1584,7 +1584,7 @@ func TestCreateSubIssues_LinkerSkippedWhenSourceRepoEmpty(t *testing.T) {
 			// SourceRepo intentionally empty
 		},
 		Subtasks: []PlannedSubtask{
-			{Title: "Child", Description: "child", Order: 1},
+			{Title: "Add child", Description: "child", Order: 1},
 		},
 	}
 
@@ -1593,5 +1593,167 @@ func TestCreateSubIssues_LinkerSkippedWhenSourceRepoEmpty(t *testing.T) {
 
 	if len(mock.Calls) != 0 {
 		t.Errorf("linker must not be called when SourceRepo is empty, got %d calls", len(mock.Calls))
+	}
+}
+
+// TestValidateSubtaskTitle covers GH-2324: rejecting LLM analysis-style titles
+// before they become sub-issue titles / PR titles / commit subjects.
+func TestValidateSubtaskTitle(t *testing.T) {
+	tests := []struct {
+		name      string
+		title     string
+		wantError bool
+	}{
+		// GH-2315 incident — the exact string that flowed into commit 70c14dc5.
+		{
+			name:      "GH-2315 incident title is rejected",
+			title:     "Dispatcher `recoverStaleTasks()` (line 188) already marks orphans as `\"failed\"`, not `\"completed\"`. The status appears correct in the current code.",
+			wantError: true,
+		},
+		{
+			name:      "analysis clause with 'already' is rejected",
+			title:     "Dispatcher already marks orphans as failed",
+			wantError: true,
+		},
+		{
+			name:      "contrast clause 'not X' is rejected",
+			title:     "Adds a label, not a comment, on completion",
+			wantError: true,
+		},
+		{
+			name:      "'appears correct' evaluative phrase is rejected",
+			title:     "Handler appears correct in current code",
+			wantError: true,
+		},
+		{
+			name:      "too many words is rejected",
+			title:     "Add a function that takes a parameter and returns a value and also handles errors in a nice way always",
+			wantError: true,
+		},
+		{
+			name:      "first word is a noun, not an action verb, is rejected",
+			title:     "Dispatcher recovery semantics",
+			wantError: true,
+		},
+		{
+			name:      "empty title is rejected",
+			title:     "   ",
+			wantError: true,
+		},
+
+		// Positive cases — realistic action-item titles that must pass.
+		{
+			name:      "plain action verb title passes",
+			title:     "Add validateSubtaskTitle helper",
+			wantError: false,
+		},
+		{
+			name:      "conventional commit prefix passes",
+			title:     "fix(epic): validate sub-issue titles",
+			wantError: false,
+		},
+		{
+			name:      "conventional commit no scope passes",
+			title:     "feat: introduce sub-issue title validator",
+			wantError: false,
+		},
+		{
+			name:      "refactor verb passes",
+			title:     "Refactor splitTitleDescription to handle edge cases",
+			wantError: false,
+		},
+		{
+			name:      "wire action verb passes",
+			title:     "Wire validator into both create paths",
+			wantError: false,
+		},
+		{
+			name:      "terse fix title passes",
+			title:     "Fix stale SHA in autopilot",
+			wantError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSubtaskTitle(tc.title)
+			if tc.wantError && err == nil {
+				t.Errorf("validateSubtaskTitle(%q) = nil, want error", tc.title)
+			}
+			if !tc.wantError && err != nil {
+				t.Errorf("validateSubtaskTitle(%q) = %v, want nil", tc.title, err)
+			}
+		})
+	}
+}
+
+// TestSyntheticSubtaskTitle verifies fallback titles are deterministic and
+// include the parent ID so sub-issues remain traceable to the epic.
+func TestSyntheticSubtaskTitle(t *testing.T) {
+	t.Run("uses parent ID when present", func(t *testing.T) {
+		got := syntheticSubtaskTitle(&Task{ID: "GH-2314"}, 2)
+		want := "GH-2314: Subtask 2"
+		if got != want {
+			t.Errorf("syntheticSubtaskTitle = %q, want %q", got, want)
+		}
+	})
+	t.Run("uses 'epic' fallback when parent ID is empty", func(t *testing.T) {
+		got := syntheticSubtaskTitle(&Task{}, 1)
+		want := "epic: Subtask 1"
+		if got != want {
+			t.Errorf("syntheticSubtaskTitle = %q, want %q", got, want)
+		}
+	})
+	t.Run("handles nil parent", func(t *testing.T) {
+		got := syntheticSubtaskTitle(nil, 3)
+		want := "epic: Subtask 3"
+		if got != want {
+			t.Errorf("syntheticSubtaskTitle = %q, want %q", got, want)
+		}
+	})
+}
+
+// TestCreateSubIssues_RejectsAnalysisTitle ensures the GH-2324 guard kicks in
+// end-to-end through the adapter path: an LLM analysis sentence must not reach
+// the tracker verbatim; a synthetic fallback is used instead.
+func TestCreateSubIssues_RejectsAnalysisTitle(t *testing.T) {
+	runner := NewRunner()
+
+	mock := &mockSubIssueCreator{
+		Returns: []mockCreateIssueReturn{
+			{Identifier: "APP-101", URL: "https://linear.app/test/issue/APP-101"},
+		},
+	}
+	runner.SetSubIssueCreator(mock)
+
+	// Exact incident string from GH-2315.
+	badTitle := "Dispatcher `recoverStaleTasks()` (line 188) already marks orphans as `\"failed\"`, not `\"completed\"`. The status appears correct in the current code."
+
+	plan := &EpicPlan{
+		ParentTask: &Task{
+			ID:            "APP-100",
+			SourceAdapter: "linear",
+			SourceIssueID: "APP-100",
+			Title:         "Parent epic",
+		},
+		Subtasks: []PlannedSubtask{
+			{Title: badTitle, Description: "body", Order: 1},
+		},
+	}
+
+	ctx := context.Background()
+	if _, err := runner.CreateSubIssues(ctx, plan, ""); err != nil {
+		t.Fatalf("CreateSubIssues failed: %v", err)
+	}
+
+	if len(mock.Called) != 1 {
+		t.Fatalf("expected 1 adapter call, got %d", len(mock.Called))
+	}
+	got := mock.Called[0].Title
+	if got == badTitle {
+		t.Errorf("analysis-style title was passed through unchanged: %q", got)
+	}
+	if got != "APP-100: Subtask 1" {
+		t.Errorf("fallback title = %q, want %q", got, "APP-100: Subtask 1")
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2324.

Closes #2324

## Changes

GitHub Issue #2324: fix(epic): validate sub-issue titles — reject LLM analysis-style titles in decomposition

## Problem

Epic decomposition can emit LLM analysis text as a sub-issue title. Real incident: GH-2314 was decomposed into GH-2315 whose title was the LLM's skeptical analysis of the parent issue verbatim:

> "Dispatcher \`recoverStaleTasks()\` (line 188) already marks orphans as \`\"failed\"\`, not \`\"completed\"\`. The status appears correct in the current code."

That string became:
- Sub-issue title (GH-2315)
- PR title (#2317)
- Squash merge commit subject (70c14dc5) — now permanent in \`main\`'s history
- v2.95.3 changelog entry (garbled, public-facing)

The commit also lacked a conventional-commit type (\`fix:\`/\`feat:\`), so \`parseBumpFromMessage()\` classified it as \`BumpNone\`. Only because other commits landed minutes later did a release still cut.

## Root Cause

\`internal/executor/epic.go\`:
- \`parseSubtasks()\` (line ~280) extracts titles from LLM planning output via regex with no content validation.
- \`splitTitleDescription()\` (line ~343) only splits on \`—\`, \`-\`, \`:\`, \`–\`; if none found, the entire string becomes the title.
- \`createSubIssuesViaAdapter()\` (line ~464) and \`createSubIssuesViaGitHub()\` (line ~521) only call \`truncateTitle(subtask.Title, 80)\` — no structural validation.

Any LLM opinion/analysis that happens to lack a separator flows through verbatim as a title.

## Fix

Add a \`validateSubtaskTitle(title string) error\` in \`epic.go\` used by both create paths. Reject titles that:

1. **Look like prose/analysis**, not action items:
   - Start with code tokens followed by prose (e.g., backtick-wrapped identifier + verb like "already", "appears", "is", "does")
   - Contain clause indicators like \`, not \`, \` but \`, \` however \`
   - Contain evaluative words: \"appears correct\", \"already\", \"is fine\", \"looks good\"
2. **Lack an action verb** as the first word (allow: add, fix, refactor, remove, rename, update, create, wire, guard, prevent, block, etc.)
3. **Exceed a sane word count** (> 15 words) — real action titles are terse.

On failure:
- Log warning with the offending title.
- Fall back to deriving a title from the parent issue title + subtask order (\`GH-{parent}: Subtask {N}\`) or skip the subtask.
- Emit an alert event so this is visible (don't silently proceed).

## Acceptance Criteria

- [ ] New \`validateSubtaskTitle()\` function with unit tests covering positive and negative cases from GH-2315.
- [ ] Both \`createSubIssuesViaAdapter\` and \`createSubIssuesViaGitHub\` call the validator.
- [ ] Invalid titles do NOT reach GitHub (no sub-issue created with garbage title).
- [ ] Fallback path produces a sensible synthetic title, or the subtask is skipped with a warning.
- [ ] Existing epic decomposition tests still pass.
- [ ] \`make build && make test\` pass.

## Files

- \`internal/executor/epic.go\` — add validator, call from both create paths
- \`internal/executor/epic_test.go\` — unit tests

## Related

- GH-2314 / GH-2315 / PR #2317 / commit 70c14dc5 — the incident that surfaced this
- GH-2312 (strip \`GH-XXXX\` prefix) — already handles a different form of malformed titles