### PR TITLE
fix(executor): gate PR creation on conventional-commit title (GH-2325)

### DIFF
--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -90,8 +90,17 @@ func (g *GitOperations) Push(ctx context.Context, branchName string) error {
 	return nil
 }
 
-// CreatePR creates a pull request using gh CLI
+// CreatePR creates a pull request using gh CLI.
+// GH-2325: title is validated against the conventional commit format before
+// the remote call so malformed titles cannot reach main (and public release
+// notes). The expected shape is "<issue-id>: <type>(<scope>)?: <subject>",
+// which matches what the squash-merge path strips back to a conventional
+// commit message.
 func (g *GitOperations) CreatePR(ctx context.Context, title, body, baseBranch string) (string, error) {
+	if err := validatePRTitle(title); err != nil {
+		return "", err
+	}
+
 	// GH-2177: Detect current branch to pass --head explicitly.
 	// In worktree mode, gh may see uncommitted changes and refuse to infer the head branch.
 	// Using --head bypasses the dirty working tree check.

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2690,7 +2690,22 @@ The previous execution completed but made no code changes. This task requires ac
 				}
 			}
 
-			prTitle := fmt.Sprintf("%s: %s", task.ID, task.Title)
+			// GH-2325: ensure the subject passed through to the PR (and the squash
+			// commit on main) is a conventional commit. Falls back to a
+			// label-derived prefix; aborts if neither applies.
+			normalizedTitle, titleErr := normalizeTitle(task.Title, task.Labels)
+			if titleErr != nil {
+				result.Success = false
+				result.Error = fmt.Sprintf("PR creation refused: %v", titleErr)
+				log.Warn("PR creation refused: non-conventional title",
+					slog.String("task_id", task.ID),
+					slog.String("title", task.Title),
+					slog.Any("labels", task.Labels),
+				)
+				r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+				return result, nil
+			}
+			prTitle := fmt.Sprintf("%s: %s", task.ID, normalizedTitle)
 
 			// Route PR/MR creation through adapter-specific creator when available
 			var prURL string

--- a/internal/executor/title.go
+++ b/internal/executor/title.go
@@ -1,0 +1,98 @@
+package executor
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// conventionalCommitRegex matches titles in the form:
+//
+//	type(scope)?!?: description
+//
+// where type is one of the standard conventional commit types. Duplicated
+// here intentionally — the autopilot package owns release-time parsing,
+// and this copy gates PR creation at write time (GH-2325).
+var conventionalCommitRegex = regexp.MustCompile(
+	`^(feat|fix|docs|refactor|test|chore|ci|build|perf|revert|style)(\([^)]+\))?!?:\s+.+`,
+)
+
+// issuePrefixRegex strips adapter-specific issue prefixes that Pilot prepends
+// to PR titles (e.g. "GH-2325: ", "APP-123: ") before conventional-commit
+// validation. The downstream squash-merge path strips the same prefix
+// (see internal/autopilot/auto_merger.go).
+var issuePrefixRegex = regexp.MustCompile(`^[A-Z][A-Z0-9]*-\d+:\s+`)
+
+// ErrNonConventionalTitle is returned when a title does not match the
+// conventional commit format and could not be auto-corrected. Callers use
+// errors.Is to distinguish this from transport failures.
+var ErrNonConventionalTitle = errors.New("title is not a conventional commit")
+
+// labelPrefixMap maps issue labels (lowercased) to conventional commit types.
+// Keep narrow — only labels that map unambiguously to a commit type.
+var labelPrefixMap = map[string]string{
+	"bug":           "fix",
+	"bugfix":        "fix",
+	"enhancement":   "feat",
+	"feature":       "feat",
+	"docs":          "docs",
+	"documentation": "docs",
+	"refactor":      "refactor",
+	"refactoring":   "refactor",
+	"test":          "test",
+	"tests":         "test",
+	"chore":         "chore",
+	"ci":            "ci",
+	"build":         "build",
+	"perf":          "perf",
+	"performance":   "perf",
+}
+
+// validatePRTitle returns nil when title matches conventional commit format,
+// accepting an optional issue-id prefix like "GH-123: " that Pilot prepends.
+func validatePRTitle(title string) error {
+	trimmed := strings.TrimSpace(title)
+	if trimmed == "" {
+		return fmt.Errorf("%w: empty title", ErrNonConventionalTitle)
+	}
+	stripped := issuePrefixRegex.ReplaceAllString(trimmed, "")
+	if !conventionalCommitRegex.MatchString(stripped) {
+		return fmt.Errorf("%w: %q", ErrNonConventionalTitle, truncateTitle(trimmed, 80))
+	}
+	return nil
+}
+
+// autoPrefixTitle prepends a conventional commit prefix derived from issue
+// labels. Returns the new title and true on success; if no label maps, the
+// original title and false.
+func autoPrefixTitle(title string, labels []string) (string, bool) {
+	trimmed := strings.TrimSpace(title)
+	if trimmed == "" {
+		return trimmed, false
+	}
+	for _, label := range labels {
+		key := strings.ToLower(strings.TrimSpace(label))
+		if prefix, ok := labelPrefixMap[key]; ok {
+			return prefix + ": " + trimmed, true
+		}
+	}
+	return trimmed, false
+}
+
+// normalizeTitle returns a conventional-commit title derived from title and
+// labels. If title already conforms it is returned as-is. Otherwise auto-prefix
+// is attempted from labels. If neither succeeds the result wraps
+// ErrNonConventionalTitle so callers can abort PR creation.
+func normalizeTitle(title string, labels []string) (string, error) {
+	trimmed := strings.TrimSpace(title)
+	if err := validatePRTitle(trimmed); err == nil {
+		return trimmed, nil
+	}
+	if prefixed, ok := autoPrefixTitle(trimmed, labels); ok {
+		if err := validatePRTitle(prefixed); err == nil {
+			return prefixed, nil
+		}
+	}
+	return trimmed, fmt.Errorf("%w: could not auto-correct %q", ErrNonConventionalTitle, truncateTitle(trimmed, 80))
+}

--- a/internal/executor/title_test.go
+++ b/internal/executor/title_test.go
@@ -1,0 +1,163 @@
+package executor
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidatePRTitle(t *testing.T) {
+	tests := []struct {
+		name    string
+		title   string
+		wantErr bool
+	}{
+		{"plain fix", "fix: handle nil response", false},
+		{"feat with scope", "feat(api): add rate limiting", false},
+		{"breaking change", "feat(api)!: drop v1 endpoint", false},
+		{"docs", "docs: update README", false},
+		{"refactor", "refactor(executor): extract title validation", false},
+		{"with issue prefix", "GH-2325: fix(git): validate PR title", false},
+		{"linear-style prefix", "APP-123: feat(auth): oauth flow", false},
+		{"no prefix at all", "add rate limiting", true},
+		{"analysis-style title", `Dispatcher recoverStaleTasks() already marks orphans as "failed", not "completed"`, true},
+		{"empty title", "", true},
+		{"whitespace only", "   ", true},
+		{"type without colon", "fix handle nil", true},
+		{"unknown type", "wip: something", true},
+		{"type with no subject", "fix:", true},
+		{"type with only space", "fix: ", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePRTitle(tt.title)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tt.title)
+				}
+				if !errors.Is(err, ErrNonConventionalTitle) {
+					t.Fatalf("expected ErrNonConventionalTitle, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.title, err)
+			}
+		})
+	}
+}
+
+func TestAutoPrefixTitle(t *testing.T) {
+	tests := []struct {
+		name    string
+		title   string
+		labels  []string
+		want    string
+		wantOK  bool
+	}{
+		{"bug label", "handle nil response", []string{"bug"}, "fix: handle nil response", true},
+		{"enhancement label", "add rate limiting", []string{"enhancement"}, "feat: add rate limiting", true},
+		{"docs label", "update README", []string{"docs"}, "docs: update README", true},
+		{"refactor label", "extract parser", []string{"refactor"}, "refactor: extract parser", true},
+		{"documentation variant", "update guide", []string{"documentation"}, "docs: update guide", true},
+		{"first matching label wins", "fix X", []string{"pilot", "bug", "enhancement"}, "fix: fix X", true},
+		{"case insensitive", "fix X", []string{"Bug"}, "fix: fix X", true},
+		{"no matching label", "handle nil", []string{"pilot", "triage"}, "handle nil", false},
+		{"empty labels", "handle nil", nil, "handle nil", false},
+		{"empty title", "", []string{"bug"}, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := autoPrefixTitle(tt.title, tt.labels)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeTitle(t *testing.T) {
+	tests := []struct {
+		name    string
+		title   string
+		labels  []string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "already conventional is returned as-is",
+			title: "fix(git): validate PR title",
+			want:  "fix(git): validate PR title",
+		},
+		{
+			name:   "auto-prefixed from bug label",
+			title:  "handle nil response",
+			labels: []string{"bug"},
+			want:   "fix: handle nil response",
+		},
+		{
+			name:   "auto-prefixed from enhancement label",
+			title:  "add rate limiting",
+			labels: []string{"enhancement"},
+			want:   "feat: add rate limiting",
+		},
+		{
+			name:    "non-conventional with no useful labels aborts",
+			title:   "add rate limiting",
+			labels:  []string{"pilot", "triage"},
+			wantErr: true,
+		},
+		{
+			name:    "analysis-style title aborts",
+			title:   `Dispatcher recoverStaleTasks() already marks orphans as "failed"`,
+			labels:  []string{"pilot"},
+			wantErr: true,
+		},
+		{
+			name:    "empty title aborts",
+			title:   "",
+			labels:  []string{"bug"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeTitle(tt.title, tt.labels)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				if !errors.Is(err, ErrNonConventionalTitle) {
+					t.Fatalf("expected ErrNonConventionalTitle, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+			// Result must itself validate.
+			if verr := validatePRTitle(got); verr != nil {
+				t.Fatalf("normalized title failed validation: %v", verr)
+			}
+		})
+	}
+}
+
+func TestValidatePRTitle_GH2315Regression(t *testing.T) {
+	// Real incident from GH-2315: LLM analysis text leaked into an issue
+	// title which became a PR title and then the squash-merge commit (70c14dc5).
+	bad := `Dispatcher recoverStaleTasks() (line 188) already marks orphans as "failed", not "completed". The status appears correct in the current code.`
+
+	if err := validatePRTitle(bad); err == nil {
+		t.Fatal("expected validation to reject analysis-style title")
+	} else if !strings.Contains(err.Error(), "conventional commit") {
+		t.Fatalf("error should mention conventional commit, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2325.

Closes #2325

## Changes

Adds defense-in-depth validation so malformed issue titles can't become PR titles, squash commits, or GoReleaser changelog entries (incident: 70c14dc5 in v2.95.3 release notes).

- `internal/executor/title.go`: `validatePRTitle`, `autoPrefixTitle`, `normalizeTitle`, `ErrNonConventionalTitle`. Conventional-commit regex accepts `feat|fix|docs|refactor|test|chore|ci|build|perf|revert|style`, optional scope, optional `!`, with an `issue-id` prefix (`GH-123:`, `APP-7:`) allowed.
- `internal/executor/runner.go`: normalizes `task.Title` with `task.Labels` before formatting the PR title. Aborts with a typed error if title is non-conventional and no label maps; the existing handler path then applies `pilot-failed` and posts a failure comment.
- `internal/executor/git.go`: `CreatePR` runs `validatePRTitle` as a safety net.
- Label heuristics: `bug`/`bugfix` → `fix`, `enhancement`/`feature` → `feat`, `docs`/`documentation` → `docs`, `refactor`/`refactoring` → `refactor`, plus `test`, `chore`, `ci`, `build`, `perf`/`performance`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [x] New unit tests: `TestValidatePRTitle`, `TestAutoPrefixTitle`, `TestNormalizeTitle`, `TestValidatePRTitle_GH2315Regression` (exercises the exact analysis-style string that leaked into v2.95.3)