### PR TITLE
fix(executor): signal executor mode to Claude + classify no-diff (GH-2328)

### DIFF
--- a/docs/content/features/_meta.js
+++ b/docs/content/features/_meta.js
@@ -17,5 +17,6 @@ export default {
   "self-improvement": "Self-Improvement",
   "evaluation-system": "Evaluation System",
   "self-healing": "Self-Healing",
-  hooks: "Claude Code Hooks"
+  hooks: "Claude Code Hooks",
+  "executor-mode-signal": "Executor-Mode Signal"
 }

--- a/docs/content/features/executor-mode-signal.mdx
+++ b/docs/content/features/executor-mode-signal.mdx
@@ -1,0 +1,87 @@
+import { Callout } from 'nextra/components'
+
+# Executor-Mode Signal
+
+Pilot tells the Claude Code subprocess it was invoked by the executor (not a
+human Navigator session) via two explicit signals. Project `CLAUDE.md` and
+auto-memory files can cooperate with these signals to skip Navigator-only
+"don't write code" rules without relying on fragile CWD or prompt-prefix
+heuristics. (GH-2328)
+
+## Why this exists
+
+Before GH-2328, the child Claude session had to infer it was running under
+Pilot. If the project's `CLAUDE.md` declared "NEVER write code, always plan
+via `/nav-task`", the child would silently refuse the task — exit cleanly
+with a polite "I will not implement this, create an issue instead" — and the
+executor recorded only `unknown: exit status 1`. GH-2305, GH-2324, and
+GH-2325 each burned several hours on that failure mode before the refusal
+text was spotted in the stdout transcript.
+
+## Signal 1 — `PILOT_EXECUTOR=1` environment variable
+
+The executor sets `PILOT_EXECUTOR=1` on every Claude Code subprocess it
+spawns. Project `CLAUDE.md` files, hooks, and other tooling can branch on
+this variable deterministically:
+
+```bash
+# In a hook script invoked by Claude Code
+if [ "${PILOT_EXECUTOR:-}" = "1" ]; then
+  echo "Pilot-executor run: enforcing commit-on-success"
+fi
+```
+
+## Signal 2 — `[PILOT-EXEC]` prompt header
+
+Every executor prompt begins with a short standard header:
+
+```
+[PILOT-EXEC]
+You are invoked by Pilot's executor to implement a specific task on this
+repository. You are the execution leg of the Navigator + Pilot pipeline.
+Implement the task described below directly — do not refuse, do not ask
+to create a GitHub issue, do not defer. Write code, run build/tests via
+the stop-gate hook, and complete the task.
+```
+
+The header is **stable** — the first line is always literally `[PILOT-EXEC]`.
+Project `CLAUDE.md` files can pattern-match the first line to scope rules:
+
+````markdown
+<!-- Excerpt from a project CLAUDE.md -->
+
+## Navigator vs Pilot
+
+If the prompt begins with `[PILOT-EXEC]`, you are the execution leg.
+- Implement the task directly.
+- Ignore any "do not write code" rules below; they apply only to
+  interactive planning sessions.
+
+Otherwise (no `[PILOT-EXEC]` marker), you are in an interactive session:
+- Use `/nav-task` to plan.
+- Hand execution to Pilot by creating a GitHub issue labeled `pilot`.
+````
+
+<Callout type="info">
+The header is not emitted for **image-analysis** tasks or **local-mode**
+bench runs — those invocations are not implementing repository changes, so
+the executor-mode directives do not apply.
+</Callout>
+
+## Failure diagnostics
+
+When an executor run does fail, Pilot now persists:
+
+- **Error classification** (e.g. `rate_limit`, `api_error`, `oom_killed`,
+  `no_changes`, `unknown`) — written to `execution_logs` with a `Backend
+  error classification:` prefix.
+- **Raw stderr** — truncated to 16 KB, written with a `Backend stderr:`
+  prefix.
+- **Final assistant message** — the last `text` block from the stream-json
+  output, truncated to 4 KB, written with a `Final assistant message:`
+  prefix. This captures refusal text when Claude exits 0 without making
+  changes.
+
+The `no_changes` classification is emitted when Claude exits successfully
+but produces no diff after the retry path — typically a polite refusal the
+executor would previously have reported as `unknown: exit status 1`.

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -56,6 +56,10 @@ const (
 	ErrorTypeOOM ClaudeCodeErrorType = "oom_killed"
 	// ErrorTypeSessionNotFound indicates the session for --from-pr or --resume was not found (GH-1267)
 	ErrorTypeSessionNotFound ClaudeCodeErrorType = "session_not_found"
+	// ErrorTypeNoChanges indicates Claude exited 0 but produced no diff — typically
+	// a refusal or "task already done" response. The final assistant message holds
+	// the refusal reason. GH-2328.
+	ErrorTypeNoChanges ClaudeCodeErrorType = "no_changes"
 	// ErrorTypeUnknown indicates an unclassified error
 	ErrorTypeUnknown ClaudeCodeErrorType = "unknown"
 )
@@ -311,17 +315,18 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 	cmd := exec.CommandContext(ctx, b.config.Command, args...)
 	cmd.Dir = opts.ProjectPath
 
+	// GH-2328: Signal executor mode to the child process. Project `CLAUDE.md`
+	// and auto-memory can detect this and skip Navigator-only "DO NOT write
+	// code" rules without relying on prompt-prefix heuristics.
+	env := append(os.Environ(), "PILOT_EXECUTOR=1")
 	// Pass context window and output token env vars if configured (GH-2163).
-	if b.config.Disable1MContext || b.config.MaxOutputTokens > 0 {
-		env := os.Environ()
-		if b.config.Disable1MContext {
-			env = append(env, "CLAUDE_CODE_DISABLE_1M_CONTEXT=1")
-		}
-		if b.config.MaxOutputTokens > 0 {
-			env = append(env, fmt.Sprintf("CLAUDE_CODE_MAX_OUTPUT_TOKENS=%d", b.config.MaxOutputTokens))
-		}
-		cmd.Env = env
+	if b.config.Disable1MContext {
+		env = append(env, "CLAUDE_CODE_DISABLE_1M_CONTEXT=1")
 	}
+	if b.config.MaxOutputTokens > 0 {
+		env = append(env, fmt.Sprintf("CLAUDE_CODE_MAX_OUTPUT_TOKENS=%d", b.config.MaxOutputTokens))
+	}
+	cmd.Env = env
 
 	b.log.Debug("Starting Claude Code",
 		slog.String("command", b.config.Command),

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -842,3 +842,37 @@ func TestClaudeCodeError_Error(t *testing.T) {
 		}
 	})
 }
+
+// TestErrorTypeNoChanges verifies that the no_changes classification constant
+// is defined and distinguishable from other error types. GH-2328.
+func TestErrorTypeNoChanges(t *testing.T) {
+	if ErrorTypeNoChanges != "no_changes" {
+		t.Errorf("ErrorTypeNoChanges = %q, want %q", ErrorTypeNoChanges, "no_changes")
+	}
+
+	// Must not collide with any other classification the runner already depends on.
+	others := []ClaudeCodeErrorType{
+		ErrorTypeRateLimit,
+		ErrorTypeInvalidConfig,
+		ErrorTypeAPIError,
+		ErrorTypeTimeout,
+		ErrorTypeOOM,
+		ErrorTypeSessionNotFound,
+		ErrorTypeUnknown,
+	}
+	for _, o := range others {
+		if ErrorTypeNoChanges == o {
+			t.Errorf("ErrorTypeNoChanges collides with %q", o)
+		}
+	}
+
+	// A ClaudeCodeError carrying no_changes must render the final assistant
+	// text via Error() so the autopilot failure comment surfaces the refusal.
+	err := &ClaudeCodeError{
+		Type:    ErrorTypeNoChanges,
+		Message: "refused: this task is out of scope",
+	}
+	if got := err.Error(); got != "no_changes: refused: this task is out of scope" {
+		t.Errorf("Error() = %q, want %q", got, "no_changes: refused: this task is out of scope")
+	}
+}

--- a/internal/executor/prompt_builder.go
+++ b/internal/executor/prompt_builder.go
@@ -9,6 +9,18 @@ import (
 	"strings"
 )
 
+// ExecutorPromptHeader is prepended to every executor-mode prompt so the child
+// Claude Code session (and any `CLAUDE.md` in the project) can identify itself
+// as a Pilot execution leg, rather than inferring from CWD or prompt-prefix
+// heuristics. Keep the first line stable — project `CLAUDE.md` files use it
+// with `if prompt begins with [PILOT-EXEC] ...`. GH-2328.
+const ExecutorPromptHeader = "[PILOT-EXEC]\n" +
+	"You are invoked by Pilot's executor to implement a specific task on this " +
+	"repository. You are the execution leg of the Navigator + Pilot pipeline. " +
+	"Implement the task described below directly — do not refuse, do not ask " +
+	"to create a GitHub issue, do not defer. Write code, run build/tests via " +
+	"the stop-gate hook, and complete the task.\n\n"
+
 // BuildPrompt constructs the prompt for Claude Code execution.
 // executionPath may differ from task.ProjectPath when using worktree isolation.
 func (r *Runner) BuildPrompt(task *Task, executionPath string) string {
@@ -21,6 +33,11 @@ func (r *Runner) BuildPrompt(task *Task, executionPath string) string {
 		sb.WriteString("Respond directly with your analysis. Be concise.\n")
 		return sb.String()
 	}
+
+	// GH-2328: Prepend [PILOT-EXEC] executor-mode header so the child Claude
+	// session and any project CLAUDE.md can skip Navigator-only "don't write
+	// code" rules explicitly, without relying on CWD or prompt-prefix sniffing.
+	sb.WriteString(ExecutorPromptHeader)
 
 	// GH-2103: LocalMode takes priority over Navigator detection.
 	// Sandbox environments with .agent/ dirs would hijack the prompt to Navigator path,

--- a/internal/executor/prompt_builder_test.go
+++ b/internal/executor/prompt_builder_test.go
@@ -581,6 +581,113 @@ func TestBuildSelfReviewPromptWithAcceptanceCriteria(t *testing.T) {
 	})
 }
 
+// TestBuildPromptExecutorHeader verifies the [PILOT-EXEC] executor-mode header
+// is emitted for every non-image, non-local-mode task so the child Claude
+// session (and project CLAUDE.md) can tell it was invoked by Pilot without
+// sniffing CWD or prompt-prefix heuristics. GH-2328.
+func TestBuildPromptExecutorHeader(t *testing.T) {
+	runner := NewRunner()
+
+	cases := []struct {
+		name  string
+		task  *Task
+		setup func(t *testing.T) string
+		want  bool
+	}{
+		{
+			name: "navigator task has header",
+			task: &Task{
+				ID:          "GH-2328",
+				Title:       "Signal executor mode",
+				Description: "Signal executor mode to Claude",
+				Branch:      "pilot/GH-2328",
+			},
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				if err := os.MkdirAll(filepath.Join(dir, ".agent"), 0755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				return dir
+			},
+			want: true,
+		},
+		{
+			name: "trivial navigator task has header",
+			task: &Task{
+				ID:          "TRIVIAL-1",
+				Title:       "Fix typo",
+				Description: "Fix typo in README.md",
+			},
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				if err := os.MkdirAll(filepath.Join(dir, ".agent"), 0755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				return dir
+			},
+			want: true,
+		},
+		{
+			name: "non-navigator project has header",
+			task: &Task{
+				ID:          "NONAV-1",
+				Title:       "Add file",
+				Description: "Create a config file",
+			},
+			setup: func(t *testing.T) string { return t.TempDir() },
+			want:  true,
+		},
+		{
+			name: "local mode does not include header",
+			task: &Task{
+				ID:          "LOCAL-1",
+				Title:       "Sandbox run",
+				Description: "Solve bench task",
+				LocalMode:   true,
+			},
+			setup: func(t *testing.T) string { return t.TempDir() },
+			want:  false,
+		},
+		{
+			name: "image task does not include header",
+			task: &Task{
+				ID:          "IMG-1",
+				Title:       "Describe image",
+				Description: "Describe the image",
+				ImagePath:   "/tmp/nonexistent.png",
+			},
+			setup: func(t *testing.T) string { return t.TempDir() },
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := tc.setup(t)
+			tc.task.ProjectPath = dir
+
+			prompt := runner.BuildPrompt(tc.task, dir)
+			got := strings.HasPrefix(prompt, "[PILOT-EXEC]")
+			if got != tc.want {
+				t.Errorf("header present = %v, want %v\nprompt[:80]=%q",
+					got, tc.want, prompt[:min(len(prompt), 80)])
+			}
+
+			if tc.want {
+				// The body of the header must tell Claude not to defer. Without
+				// this, a refusal-prone project CLAUDE.md could still veto the
+				// task on mixed heuristics.
+				if !strings.Contains(prompt, "do not refuse") {
+					t.Error("executor header missing 'do not refuse' directive")
+				}
+				if !strings.Contains(prompt, "Navigator + Pilot pipeline") {
+					t.Error("executor header should name the Navigator + Pilot pipeline")
+				}
+			}
+		})
+	}
+}
+
 func TestBuildPromptSkipsNavigatorForTrivialTask(t *testing.T) {
 	// Create temporary test environment with .agent/
 	tempDir, err := os.MkdirTemp("", "pilot-test-trivial")

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -826,6 +826,24 @@ func (r *Runner) saveLogEntry(executionID, level, message string) {
 	}
 }
 
+// Diagnostic truncation caps used by persistBackendDiagnostics. Exposed as
+// constants so tests can assert the ceiling and project-side tooling can
+// depend on a fixed upper bound. GH-2328.
+const (
+	diagnosticsStderrMaxChars  = 16 * 1024
+	diagnosticsMessageMaxChars = 4 * 1024
+)
+
+// truncateDiagnostic trims `s` to at most `max` characters, appending a
+// "\n[...truncated]" marker when truncation occurs. Callers should TrimSpace
+// the input first so empty messages don't hit the log store.
+func truncateDiagnostic(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "\n[...truncated]"
+}
+
 // persistBackendDiagnostics writes the backend's stderr, error type, and final
 // assistant text to execution_logs so `unknown: exit status 1` failures are
 // actually diagnosable. Previously these bytes were only emitted via slog to
@@ -835,28 +853,19 @@ func (r *Runner) persistBackendDiagnostics(executionID string, backendResult *Ba
 		return
 	}
 
-	const (
-		stderrMaxChars  = 16 * 1024
-		messageMaxChars = 4 * 1024
-	)
-
 	if backendResult.ErrorType != "" {
 		r.saveLogEntry(executionID, "error",
 			"Backend error classification: "+backendResult.ErrorType)
 	}
 
 	if stderr := strings.TrimSpace(backendResult.Stderr); stderr != "" {
-		if len(stderr) > stderrMaxChars {
-			stderr = stderr[:stderrMaxChars] + "\n[...truncated]"
-		}
-		r.saveLogEntry(executionID, "error", "Backend stderr:\n"+stderr)
+		r.saveLogEntry(executionID, "error",
+			"Backend stderr:\n"+truncateDiagnostic(stderr, diagnosticsStderrMaxChars))
 	}
 
 	if msg := strings.TrimSpace(backendResult.LastAssistantText); msg != "" {
-		if len(msg) > messageMaxChars {
-			msg = msg[:messageMaxChars] + "\n[...truncated]"
-		}
-		r.saveLogEntry(executionID, "error", "Final assistant message:\n"+msg)
+		r.saveLogEntry(executionID, "error",
+			"Final assistant message:\n"+truncateDiagnostic(msg, diagnosticsMessageMaxChars))
 	}
 }
 
@@ -2088,11 +2097,34 @@ The previous execution completed but made no code changes. This task requires ac
 				commitCount, _ = git.CountNewCommits(ctx, baseBranch)
 				if commitCount == 0 {
 					result.Success = false
-					result.Error = "Claude completed but made no code changes after retry"
+					// GH-2328: classify this as ErrorTypeNoChanges and carry the
+					// final assistant message so the failure comment surfaces the
+					// refusal reason instead of a generic "no changes" string.
+					refusal := ""
+					if backendResult != nil {
+						refusal = strings.TrimSpace(backendResult.LastAssistantText)
+						if retryResult != nil && strings.TrimSpace(retryResult.LastAssistantText) != "" {
+							refusal = strings.TrimSpace(retryResult.LastAssistantText)
+						}
+					}
+					if refusal != "" {
+						result.Error = fmt.Sprintf("no_changes: Claude completed but made no code changes after retry — %s", refusal)
+					} else {
+						result.Error = "no_changes: Claude completed but made no code changes after retry"
+					}
+					if backendResult != nil {
+						backendResult.ErrorType = string(ErrorTypeNoChanges)
+						if refusal != "" {
+							backendResult.LastAssistantText = refusal
+						}
+					}
 					log.Error("No commits after retry",
 						slog.String("task_id", task.ID),
 					)
 					r.reportProgress(task.ID, "Failed", 100, result.Error)
+
+					// GH-2328: persist no_changes classification + refusal text.
+					r.persistBackendDiagnostics(task.ID, backendResult)
 
 					// Emit task failed event
 					r.emitAlertEvent(AlertEvent{

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3260,3 +3260,75 @@ func TestPRCreator_NotUsedWhenEmpty(t *testing.T) {
 		t.Error("should NOT use PRCreator when SourceAdapter is empty")
 	}
 }
+
+// TestTruncateDiagnostic verifies the diagnostic truncation helper used by
+// persistBackendDiagnostics honors its character ceilings and appends a
+// visible marker so readers know the payload was clipped. GH-2328.
+func TestTruncateDiagnostic(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		max     int
+		want    string
+		trunced bool
+	}{
+		{
+			name:  "under limit unchanged",
+			input: "short stderr",
+			max:   100,
+			want:  "short stderr",
+		},
+		{
+			name:  "equal to limit unchanged",
+			input: strings.Repeat("x", 10),
+			max:   10,
+			want:  strings.Repeat("x", 10),
+		},
+		{
+			name:    "over limit truncated with marker",
+			input:   strings.Repeat("y", 20),
+			max:     5,
+			want:    strings.Repeat("y", 5) + "\n[...truncated]",
+			trunced: true,
+		},
+		{
+			name:    "stderr ceiling (16 KB)",
+			input:   strings.Repeat("e", 20*1024),
+			max:     diagnosticsStderrMaxChars,
+			trunced: true,
+		},
+		{
+			name:    "message ceiling (4 KB)",
+			input:   strings.Repeat("m", 10*1024),
+			max:     diagnosticsMessageMaxChars,
+			trunced: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateDiagnostic(tt.input, tt.max)
+			if !tt.trunced && got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+			if tt.trunced {
+				if !strings.HasSuffix(got, "\n[...truncated]") {
+					t.Errorf("expected truncation marker, got %q", got[max(0, len(got)-32):])
+				}
+				// Output length = max + len marker.
+				expectedLen := tt.max + len("\n[...truncated]")
+				if len(got) != expectedLen {
+					t.Errorf("truncated length = %d, want %d", len(got), expectedLen)
+				}
+			}
+		})
+	}
+
+	// Ceiling constants must match the design target so project-side tooling
+	// that assumes ≤16 KB / ≤4 KB keeps working. GH-2328 acceptance.
+	if diagnosticsStderrMaxChars != 16*1024 {
+		t.Errorf("diagnosticsStderrMaxChars = %d, want 16384", diagnosticsStderrMaxChars)
+	}
+	if diagnosticsMessageMaxChars != 4*1024 {
+		t.Errorf("diagnosticsMessageMaxChars = %d, want 4096", diagnosticsMessageMaxChars)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the remaining scope of #2328 after #2330 landed stderr + final-
assistant-message capture. Makes executor mode explicit and gives the
"Claude refused and wrote nothing" case a real classification.

- **`PILOT_EXECUTOR=1`** is now always exported on the spawned `claude`
  subprocess. Project `CLAUDE.md` / hooks can branch on it instead of
  sniffing CWD or prompt-prefix heuristics.
- **`[PILOT-EXEC]` header** is prepended to every non-image, non-local-
  mode prompt. The first line is stable so `CLAUDE.md` files can
  pattern-match it to scope Navigator-only rules.
- **`ErrorTypeNoChanges`** classification is emitted when Claude exits 0
  but produces no diff after the existing retry path. The failure
  message now carries the refusal text from `LastAssistantText`, so
  `pilot-failed` comments read `no_changes: <refusal>` instead of
  `unknown: exit status 1`.
- **Truncation helper** (`truncateDiagnostic`) + constants
  (`diagnosticsStderrMaxChars = 16 KB`, `diagnosticsMessageMaxChars =
  4 KB`) extracted so the ceiling is testable and documentable.
- **Docs**: new `docs/content/features/executor-mode-signal.mdx`
  documenting both signals and the new classification, with a
  `CLAUDE.md` cooperation example.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/executor/` — full package (22 s)
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/executor/...`
- [x] New tests: `TestBuildPromptExecutorHeader`,
      `TestErrorTypeNoChanges`, `TestTruncateDiagnostic`
- [ ] Observe a real `pilot-failed` comment after landing and verify the
      classification + refusal text surface end-to-end.