### PR TITLE
fix(dashboard): gate stdout prints on dashboard mode (GH-2333)

### DIFF
--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -133,8 +133,10 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 		}
 	}
 
-	// 5. Print to stdout
-	fmt.Printf("\n%s %s: %s\n", info.LogEmoji, taskID, title)
+	// 5. Print to stdout (skip in dashboard mode to avoid corrupting the TUI alt-screen)
+	if deps.Program == nil {
+		fmt.Printf("\n%s %s: %s\n", info.LogEmoji, taskID, title)
+	}
 
 	// 6. Dispatch via dispatcher OR direct execute via runner
 	var result *executor.ExecutionResult
@@ -148,7 +150,9 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 			if deps.Monitor != nil {
 				deps.Monitor.Queue(taskID)
 			}
-			fmt.Printf("   📋 Queued as execution %s\n", execID[:8])
+			if deps.Program == nil {
+				fmt.Printf("   📋 Queued as execution %s\n", execID[:8])
+			}
 			exec, waitErr := deps.Dispatcher.WaitForExecution(ctx, execID, time.Second)
 			if waitErr != nil {
 				execErr = fmt.Errorf("failed waiting for execution: %w", waitErr)


### PR DESCRIPTION
## Summary
- Guard the two `fmt.Printf` calls in `cmd/pilot/handler_common.go` with `deps.Program == nil` so they don't corrupt the bubbletea alt-screen when `--dashboard` is active.
- CLI-mode (no dashboard) output is preserved.

Fixes #2333

## Test plan
- [ ] `pilot start --dashboard --github` — no stray output below TUI during task dispatch
- [ ] `pilot start --github` — queued message still prints to stdout