### PR TITLE
fix(epic): validate sub-issue titles, reject LLM analysis prose (GH-2324)

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -371,6 +371,120 @@ func finalizeSubtask(subtask *PlannedSubtask, lines []string) {
 	}
 }
 
+// actionVerbs is the allowlist of first-word verbs accepted by validateSubtaskTitle.
+// Real subtask titles are imperative ("Add X", "Fix Y"). LLM analysis output
+// usually starts with an identifier or noun, so requiring an action verb filters
+// out the most common malformed titles. Compared lower-case.
+var actionVerbs = map[string]bool{
+	"add": true, "allow": true, "attach": true, "audit": true,
+	"block": true, "build": true, "bump": true,
+	"cache": true, "check": true, "clean": true, "configure": true,
+	"convert": true, "create": true,
+	"decouple": true, "delete": true, "deprecate": true, "detect": true,
+	"disable": true, "dispatch": true, "document": true, "drop": true,
+	"emit": true, "enable": true, "ensure": true, "expose": true,
+	"extract": true,
+	"fall": true, "fetch": true, "fix": true, "flag": true,
+	"gate": true, "generate": true, "guard": true,
+	"handle": true, "hide": true,
+	"implement": true, "improve": true, "init": true, "initialize": true,
+	"inject": true, "install": true, "integrate": true, "invalidate": true,
+	"link": true, "load": true, "log": true,
+	"merge": true, "migrate": true, "move": true,
+	"normalize": true,
+	"parse": true, "persist": true, "port": true, "prevent": true,
+	"propagate": true, "publish": true, "purge": true,
+	"refactor": true, "register": true, "reject": true, "remove": true,
+	"rename": true, "replace": true, "reset": true, "restore": true,
+	"retry": true, "route": true, "run": true,
+	"sanitize": true, "schedule": true, "send": true, "set": true,
+	"setup": true, "show": true, "skip": true, "split": true, "stop": true,
+	"strip": true, "support": true, "sync": true,
+	"test": true, "throttle": true, "trigger": true, "truncate": true,
+	"unlink": true, "update": true, "upgrade": true, "use": true,
+	"validate": true, "verify": true,
+	"wait": true, "warn": true, "wire": true, "wrap": true,
+}
+
+// validateSubtaskTitle rejects titles that look like LLM analysis or prose
+// instead of action items. Catches the GH-2315 incident: a sub-issue title
+// containing the LLM's skeptical analysis of the parent issue ("`fn()` already
+// marks ... appears correct in the current code") flowed unchecked through to
+// GitHub, the PR title, and a permanent commit in main's history.
+//
+// Rules:
+//  1. Empty title is invalid.
+//  2. Title must contain at most 15 words.
+//  3. Title must not contain prose/analysis indicators (", not ", " but ",
+//     " however ", "appears correct", "already ", "is fine", "looks good",
+//     "in the current code").
+//  4. First non-symbol word must be an action verb (see actionVerbs).
+func validateSubtaskTitle(title string) error {
+	t := strings.TrimSpace(title)
+	if t == "" {
+		return fmt.Errorf("empty title")
+	}
+
+	if wc := len(strings.Fields(t)); wc > 15 {
+		return fmt.Errorf("title too long (%d words, max 15)", wc)
+	}
+
+	lower := strings.ToLower(t)
+	proseMarkers := []string{
+		", not ", " but ", " however ",
+		"appears correct", "already marks", "is fine", "looks good",
+		"in the current code", "the status appears", "no longer needed",
+	}
+	for _, m := range proseMarkers {
+		if strings.Contains(lower, m) {
+			return fmt.Errorf("title contains analysis prose: %q", m)
+		}
+	}
+
+	first := firstWord(t)
+	if first == "" {
+		return fmt.Errorf("no leading word found")
+	}
+	if !actionVerbs[strings.ToLower(first)] {
+		return fmt.Errorf("first word %q is not an action verb", first)
+	}
+
+	return nil
+}
+
+// firstWord returns the first whitespace-separated token of s, with backticks,
+// markdown bold markers, and surrounding punctuation stripped. Returns "" if
+// the leading token is purely a code/identifier fragment (e.g. "`fn()`") with
+// no alphabetic content after stripping.
+func firstWord(s string) string {
+	for _, raw := range strings.Fields(s) {
+		w := strings.Trim(raw, "`*_\"'.,:;()[]{}")
+		// Reject pure code identifiers like "recoverStaleTasks()" — they
+		// usually contain parens or camelCase markers; treat as non-word
+		// so the verb check fails on the *next* token.
+		if w == "" {
+			continue
+		}
+		if strings.ContainsAny(raw, "`(){}") {
+			// Code fragment — skip and try the next token.
+			continue
+		}
+		return w
+	}
+	return ""
+}
+
+// fallbackSubtaskTitle synthesizes a safe title when the planner-supplied one
+// fails validation. Format: "GH-{parent}: Subtask {N}". When parentID is
+// empty, falls back to "Subtask {N}". Used by both create paths so an
+// incident like GH-2315 can never propagate a garbage title to GitHub.
+func fallbackSubtaskTitle(parentID string, order int) string {
+	if parentID == "" {
+		return fmt.Sprintf("Subtask %d", order)
+	}
+	return fmt.Sprintf("%s: Subtask %d", parentID, order)
+}
+
 // issueNumberRegex extracts the issue number from a GitHub issue URL.
 // Matches patterns like: https://github.com/owner/repo/issues/123
 var issueNumberRegex = regexp.MustCompile(`/issues/(\d+)`)
@@ -460,6 +574,21 @@ func (r *Runner) createSubIssuesViaAdapter(ctx context.Context, plan *EpicPlan) 
 			}
 		}
 
+		// GH-2324: Validate title before sending to the adapter. Reject LLM
+		// analysis-style titles and substitute a synthetic fallback so garbage
+		// can't reach the issue tracker, PR title, or commit history.
+		if err := validateSubtaskTitle(subtask.Title); err != nil {
+			fallback := fallbackSubtaskTitle(plan.ParentTask.ID, subtask.Order)
+			r.log.Warn("Rejected invalid subtask title; using fallback",
+				"original", subtask.Title,
+				"fallback", fallback,
+				"reason", err,
+				"parent_id", parentID,
+				"subtask_order", subtask.Order,
+			)
+			subtask.Title = fallback
+		}
+
 		// Truncate title (adapter may have different limits, but 80 is reasonable)
 		title := truncateTitle(subtask.Title, 80)
 
@@ -515,6 +644,25 @@ func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, e
 			if depNum, ok := orderToIssueNumber[depOrder]; ok {
 				body += fmt.Sprintf("\n\nDepends on: #%d", depNum)
 			}
+		}
+
+		// GH-2324: Validate title before creating the GitHub issue. See
+		// validateSubtaskTitle for the rules; on failure we substitute a
+		// synthetic fallback so analysis-style strings (incident GH-2315)
+		// can't become permanent in the issue tracker or commit history.
+		if err := validateSubtaskTitle(subtask.Title); err != nil {
+			parentID := ""
+			if plan.ParentTask != nil {
+				parentID = plan.ParentTask.ID
+			}
+			fallback := fallbackSubtaskTitle(parentID, subtask.Order)
+			r.log.Warn("Rejected invalid subtask title; using fallback",
+				"original", subtask.Title,
+				"fallback", fallback,
+				"reason", err,
+				"subtask_order", subtask.Order,
+			)
+			subtask.Title = fallback
 		}
 
 		// Truncate title to max 80 chars for GitHub issue limits (GH-1133)

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -1094,8 +1094,8 @@ func TestCreateSubIssues_UsesAdapterForNonGitHub(t *testing.T) {
 			SourceIssueID: "APP-100",
 		},
 		Subtasks: []PlannedSubtask{
-			{Title: "First subtask", Description: "Do first thing", Order: 1},
-			{Title: "Second subtask", Description: "Do second thing", Order: 2},
+			{Title: "Add first subtask", Description: "Do first thing", Order: 1},
+			{Title: "Add second subtask", Description: "Do second thing", Order: 2},
 		},
 	}
 
@@ -1115,8 +1115,8 @@ func TestCreateSubIssues_UsesAdapterForNonGitHub(t *testing.T) {
 	if mock.Called[0].ParentID != "APP-100" {
 		t.Errorf("First call parentID = %q, want APP-100", mock.Called[0].ParentID)
 	}
-	if mock.Called[0].Title != "First subtask" {
-		t.Errorf("First call title = %q, want 'First subtask'", mock.Called[0].Title)
+	if mock.Called[0].Title != "Add first subtask" {
+		t.Errorf("First call title = %q, want 'Add first subtask'", mock.Called[0].Title)
 	}
 
 	// Verify second call
@@ -1593,5 +1593,125 @@ func TestCreateSubIssues_LinkerSkippedWhenSourceRepoEmpty(t *testing.T) {
 
 	if len(mock.Calls) != 0 {
 		t.Errorf("linker must not be called when SourceRepo is empty, got %d calls", len(mock.Calls))
+	}
+}
+
+// TestValidateSubtaskTitle covers GH-2324: titles emitted by the LLM planner
+// occasionally contain analysis prose instead of action items (incident
+// GH-2315). Validator must reject these without false-positives on real titles.
+func TestValidateSubtaskTitle(t *testing.T) {
+	tests := []struct {
+		name    string
+		title   string
+		wantErr bool
+	}{
+		// --- Negative cases (must be rejected) ---
+		{
+			name:    "GH-2315 incident verbatim",
+			title:   "Dispatcher `recoverStaleTasks()` (line 188) already marks orphans as \"failed\", not \"completed\". The status appears correct in the current code.",
+			wantErr: true,
+		},
+		{
+			name:    "leading code identifier with prose",
+			title:   "`fn()` already handles this case",
+			wantErr: true,
+		},
+		{
+			name:    "comma-not clause",
+			title:   "Marks tasks as failed, not completed",
+			wantErr: true,
+		},
+		{
+			name:    "appears correct phrase",
+			title:   "Add validation appears correct already",
+			wantErr: true,
+		},
+		{
+			name:    "empty title",
+			title:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only",
+			title:   "   \t\n",
+			wantErr: true,
+		},
+		{
+			name:    "first word not an action verb",
+			title:   "The dispatcher should reject stale tasks now",
+			wantErr: true,
+		},
+		{
+			name:    "too many words",
+			title:   "Add a really long subtask title that goes on forever and definitely exceeds the fifteen word limit imposed",
+			wantErr: true,
+		},
+
+		// --- Positive cases (must pass) ---
+		{
+			name:    "simple add title",
+			title:   "Add rate limiting to webhook handler",
+			wantErr: false,
+		},
+		{
+			name:    "fix prefix",
+			title:   "Fix nil pointer in adapter init",
+			wantErr: false,
+		},
+		{
+			name:    "refactor prefix",
+			title:   "Refactor signal parsing into separate file",
+			wantErr: false,
+		},
+		{
+			name:    "wire prefix",
+			title:   "Wire alert engine to executor pipeline",
+			wantErr: false,
+		},
+		{
+			name:    "validate prefix",
+			title:   "Validate subtask titles before issue creation",
+			wantErr: false,
+		},
+		{
+			name:    "case insensitive verb",
+			title:   "ADD authentication middleware",
+			wantErr: false,
+		},
+		{
+			name:    "markdown bold prefix",
+			title:   "**Add** caching layer to reduce DB load",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSubtaskTitle(tt.title)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateSubtaskTitle(%q) error = %v, wantErr %v",
+					tt.title, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFallbackSubtaskTitle(t *testing.T) {
+	tests := []struct {
+		parentID string
+		order    int
+		want     string
+	}{
+		{"GH-2314", 1, "GH-2314: Subtask 1"},
+		{"GH-2314", 5, "GH-2314: Subtask 5"},
+		{"", 2, "Subtask 2"},
+		{"APP-99", 3, "APP-99: Subtask 3"},
+	}
+	for _, tt := range tests {
+		got := fallbackSubtaskTitle(tt.parentID, tt.order)
+		if got != tt.want {
+			t.Errorf("fallbackSubtaskTitle(%q, %d) = %q, want %q",
+				tt.parentID, tt.order, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
Closes #2324

## Summary
- Add `validateSubtaskTitle()` in `internal/executor/epic.go` and call it from both `createSubIssuesViaAdapter` and `createSubIssuesViaGitHub` so analysis-style titles never reach GitHub/Linear/Jira.
- On rejection, `fallbackSubtaskTitle()` substitutes `"{parent}: Subtask {N}"` and a warning is logged.
- Unit tests cover the GH-2315 incident verbatim plus prose markers, missing action verbs, length limit, and positive cases.

## Why
GH-2315 was created from a sub-issue whose title was the LLM's analysis of the parent issue verbatim ("`recoverStaleTasks()` (line 188) already marks orphans as \"failed\", not \"completed\"…"). That string flowed through unchecked into PR #2317 and squash commit `70c14dc5`, now permanent in `main`'s history.

## Validation rules
- Reject empty / whitespace-only.
- Reject > 15 words.
- Reject prose markers: `, not `, ` but `, ` however `, `appears correct`, `already marks`, `is fine`, `looks good`, `in the current code`, `the status appears`, `no longer needed`.
- Require first non-symbol word to be in the action-verb allowlist (add, fix, refactor, wire, validate, …).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/executor/` — all pass (incl. updated `TestCreateSubIssues_UsesAdapterForNonGitHub` whose fixture used "First subtask" / "Second subtask" — replaced with action-verb prefixed titles).
- [x] `TestValidateSubtaskTitle` — 15 cases (8 negative incl. GH-2315 verbatim, 7 positive).
- [x] `TestFallbackSubtaskTitle` — 4 cases.