### PR TITLE
GH-2340: fix(autopilot): skip pilot-retry-ready when pilot-done already on issue

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2131,6 +2131,20 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 	// GH-1015: Add pilot-retry-ready label so the issue can be retried
 	// Remove pilot-in-progress to allow the poller to re-pick it
 	if prState.IssueNumber > 0 {
+		// GH-2340: Skip pilot-retry-ready when the issue already carries
+		// pilot-done. This happens when Pilot itself closed a duplicate PR
+		// (e.g. via handleMergeConflict) after the original PR was already
+		// merged. Adding pilot-retry-ready in that case strands the label
+		// on a closed/done issue forever (poller skips non-open issues).
+		issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, prState.IssueNumber)
+		if err != nil {
+			c.log.Warn("failed to fetch issue for label check", "issue", prState.IssueNumber, "error", err)
+		} else if github.HasLabel(issue, github.LabelDone) {
+			c.log.Info("skipping pilot-retry-ready: issue already pilot-done", "issue", prState.IssueNumber, "pr", prState.PRNumber)
+			c.maybeCloseParentIssue(ctx, prState)
+			return
+		}
+
 		if err := c.ghClient.AddLabels(ctx, c.owner, c.repo, prState.IssueNumber, []string{github.LabelRetryReady}); err != nil {
 			c.log.Warn("failed to add pilot-retry-ready label", "issue", prState.IssueNumber, "error", err)
 		}

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -4109,6 +4109,76 @@ func TestNotifyExternalClose_MaybeCloseParent(t *testing.T) {
 	}
 }
 
+// GH-2340: notifyExternalClose must not stamp pilot-retry-ready on issues
+// that already carry pilot-done. This happens when Pilot itself closed a
+// duplicate PR after the original PR was merged — the issue is closed and
+// done, and adding pilot-retry-ready strands the label forever (poller
+// skips non-open issues).
+func TestNotifyExternalClose_SkipsRetryReadyWhenDone(t *testing.T) {
+	tests := []struct {
+		name              string
+		issueLabels       []github.Label
+		wantRetryAdded    bool
+	}{
+		{
+			name:           "issue already pilot-done - skip retry-ready",
+			issueLabels:    []github.Label{{Name: github.LabelDone}},
+			wantRetryAdded: false,
+		},
+		{
+			name:           "issue not done - add retry-ready",
+			issueLabels:    []github.Label{},
+			wantRetryAdded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var retryReadyAdded bool
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/repos/owner/repo/issues/10" && r.Method == http.MethodGet:
+					issue := github.Issue{Number: 10, State: "closed", Labels: tt.issueLabels}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(issue)
+
+				case r.URL.Path == "/repos/owner/repo/issues/10/labels" && r.Method == http.MethodPost:
+					var body struct {
+						Labels []string `json:"labels"`
+					}
+					_ = json.NewDecoder(r.Body).Decode(&body)
+					for _, l := range body.Labels {
+						if l == github.LabelRetryReady {
+							retryReadyAdded = true
+						}
+					}
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("[]"))
+
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/10/labels/") && r.Method == http.MethodDelete:
+					w.WriteHeader(http.StatusOK)
+
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			prState := &PRState{PRNumber: 42, IssueNumber: 10}
+			c.notifyExternalClose(context.Background(), prState)
+
+			if retryReadyAdded != tt.wantRetryAdded {
+				t.Errorf("pilot-retry-ready added = %v, want %v", retryReadyAdded, tt.wantRetryAdded)
+			}
+		})
+	}
+}
+
 // GH-2251: Test that ScanRecentlyMergedPRs discovers externally-merged PRs
 // and skips those already tracked.
 func TestController_ScanRecentlyMergedPRs(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2340.

Closes #2340

## Changes

GitHub Issue #2340: fix(autopilot): skip pilot-retry-ready when pilot-done already on issue

## Symptom

GH-2324 ended up in a contradictory state — `pilot-done` + `pilot-retry-ready` both set, issue closed. `pilot-retry-ready` is supposed to mark issues needing re-execution, but the work was already merged via PR #2334.

## Root cause

`notifyExternalClose` in `internal/autopilot/controller.go:2128-2150` adds `pilot-retry-ready` unconditionally when a PR transitions to `closed`, without checking whether the issue already carries `pilot-done`.

**Sequence for GH-2324:**
1. PR #2334 merged at 14:01:40Z → `handleMerging` adds `pilot-done` + closes issue
2. Duplicate PR #2339 created at 14:03:40Z (same branch `pilot/GH-2324`) — see companion issue for duplicate-dispatch root cause
3. `handleMergeConflict` (`controller.go:1471`) closes PR #2339, sets `StageFailed`, removes `pilot-in-progress`
4. Next tick: `checkExternalMergeOrClose` (`controller.go:2021`) sees PR #2339 as `closed`, can't distinguish internal-close-by-Pilot from external-close-by-human
5. Calls `notifyExternalClose` → adds `pilot-retry-ready` (`controller.go:2134`)
6. Issue is already closed → `shouldRetryRetryReadyIssue` skips it (state != open, poller.go:1244) → label stuck forever

## Fix options (pick one)

### Option A — Check pilot-done before adding pilot-retry-ready (simpler)

In `notifyExternalClose` (`internal/autopilot/controller.go:2128-2150`), before calling `AddLabels` for `LabelRetryReady`, fetch issue labels and skip if `LabelDone` already present.

### Option B — Mark Pilot-closed PRs to avoid the external-close path (cleaner)

Add `ClosedByPilot bool` field to `prState`. Set it to `true` in `handleMergeConflict` when Pilot closes the PR itself. In `checkExternalMergeOrClose`, skip the `notifyExternalClose` path when `prState.ClosedByPilot` is set.

Option B is better architecturally — `notifyExternalClose` should only fire on actually-external closes. But Option A is a one-liner and fully addresses the stuck-label symptom.

## Test plan

- Unit test: simulate PR conflict-close path; assert `pilot-retry-ready` not added when `pilot-done` present
- Unit test: external close path still adds `pilot-retry-ready` when appropriate (no `pilot-done`)

## Files

- `internal/autopilot/controller.go:2128-2150` (notifyExternalClose)
- `internal/autopilot/controller.go:1471-1482` (handleMergeConflict) — if Option B
- `internal/autopilot/controller.go:2021-2110` (checkExternalMergeOrClose) — if Option B

## Related

- GH-2029: removed stale `pilot-failed` in `notifyExternalClose` (same function, different label)