### PR TITLE
GH-2344: fix(dispatcher): add hasLiveWorker guard to running-task reaper (mirror GH-2331)

### DIFF
--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -180,6 +180,14 @@ func (d *Dispatcher) recoverStaleTasks() int {
 			}
 			continue
 		}
+		if d.hasLiveWorker(exec.ProjectPath) {
+			d.log.Debug("Skipping stale running reap — live worker for project exists",
+				slog.String("execution_id", exec.ID),
+				slog.String("task_id", exec.TaskID),
+				slog.String("project", exec.ProjectPath),
+			)
+			continue
+		}
 		d.log.Warn("Marking stale running task as failed",
 			slog.String("execution_id", exec.ID),
 			slog.String("task_id", exec.TaskID),

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -570,6 +570,71 @@ func TestRecoverStaleTasks_QueuedAndRunning(t *testing.T) {
 	}
 }
 
+func TestRecoverStaleTasks_RunningSkipsWhenLiveWorker(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{ID: "exec-live-run", TaskID: "TASK-LR", ProjectPath: "/project-live", Status: "running"}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("failed to save execution: %v", err)
+	}
+
+	config := &DispatcherConfig{
+		StaleRunningThreshold: 0,
+		StaleQueuedThreshold:  0,
+		StaleRecoveryInterval: time.Hour,
+	}
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, config)
+
+	// Inject a live worker for the project so the reaper should skip it.
+	dispatcher.mu.Lock()
+	dispatcher.workers["/project-live"] = &ProjectWorker{projectPath: "/project-live"}
+	dispatcher.mu.Unlock()
+
+	dispatcher.recoverStaleTasks()
+
+	got, err := store.GetExecution("exec-live-run")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if got.Status != "running" {
+		t.Errorf("expected running task with live worker to remain 'running', got '%s'", got.Status)
+	}
+}
+
+func TestRecoverStaleTasks_QueuedSkipsWhenLiveWorker(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{ID: "exec-live-q", TaskID: "TASK-LQ", ProjectPath: "/project-live", Status: "queued"}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("failed to save execution: %v", err)
+	}
+
+	config := &DispatcherConfig{
+		StaleRunningThreshold: 0,
+		StaleQueuedThreshold:  0,
+		StaleRecoveryInterval: time.Hour,
+	}
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, config)
+
+	dispatcher.mu.Lock()
+	dispatcher.workers["/project-live"] = &ProjectWorker{projectPath: "/project-live"}
+	dispatcher.mu.Unlock()
+
+	dispatcher.recoverStaleTasks()
+
+	got, err := store.GetExecution("exec-live-q")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if got.Status != "queued" {
+		t.Errorf("expected queued task with live worker to remain 'queued', got '%s'", got.Status)
+	}
+}
+
 func TestRecoverStaleTasks_RespectsThresholds(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2344.

Closes #2344

## Changes

GitHub Issue #2344: fix(dispatcher): add hasLiveWorker guard to running-task reaper (mirror GH-2331)

## Symptom

`stale running task recovered (orphaned worker)` error fires for tasks whose
worker is actively running but whose elapsed time exceeds
`StaleRunningThreshold` (30 min). Observed on GH-2324 at 13:12:48Z and 14:03:18Z,
both AFTER PR #2331 merged at 10:29Z.

## Root cause

PR #2331 (commit `4f75b237`) added a `hasLiveWorker()` guard to the
**queued**-task reaper in `internal/executor/dispatcher.go` lines 217-224.
The **running**-task reaper in the same `recoverStaleTasks()` function
(lines 165-193, error emitted at line 188) was left unchanged.

Long-running Navigator/epic tasks (45+ min) exceed `StaleRunningThreshold` and
get their own running task reaped out from under an active worker, despite
the worker still being alive in `d.workers`.

## Fix

Insert the same `hasLiveWorker()` guard into the running path, between lines
182 and 183 of `internal/executor/dispatcher.go`. `hasLiveWorker()` already
exists at lines 242-250 — no new helpers needed.

```go
if d.hasLiveWorker(exec.ProjectPath) {
    d.log.Debug("Skipping stale running reap — live worker for project exists",
        slog.String("execution_id", exec.ID),
        slog.String("task_id", exec.TaskID),
        slog.String("project", exec.ProjectPath),
    )
    continue
}
```

## Test plan

- Add `TestRecoverStaleTasks_RunningSkipsWhenLiveWorker` modeled on
  existing `TestRecoverStaleTasks_QueuedAndRunning` (`dispatcher_test.go:522`)
  and `TestRecoverStaleTasks_RespectsThresholds` (`dispatcher_test.go:573`)
- Backfill a matching test for the queued branch — PR #2331 shipped without one

## Files

- `internal/executor/dispatcher.go` (~8 line insertion)
- `internal/executor/dispatcher_test.go` (~40 line test, plus backfill)

## Related

- PR #2331 — queued-path fix (partial)
- GH-2324 — triggered the observation