### PR TITLE
GH-2345: fix(autopilot): idempotent merge-completion notification (dedup on re-entry)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1000,10 +1000,15 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 		}
 		c.log.Info("closed issue after merge", "issue", prState.IssueNumber, "pr", prState.PRNumber)
 
-		// GH-2297: Post success comment so last comment isn't stale failure
-		comment := buildMergeCompletionComment(prState)
-		if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); err != nil {
-			c.log.Warn("failed to post merge completion comment", "issue", prState.IssueNumber, "error", err)
+		// GH-2297: Post success comment so last comment isn't stale failure.
+		// GH-2345: Guard against re-entry producing duplicate comments.
+		if !prState.MergeNotificationPosted {
+			comment := buildMergeCompletionComment(prState)
+			if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); err != nil {
+				c.log.Warn("failed to post merge completion comment", "issue", prState.IssueNumber, "error", err)
+			} else {
+				prState.MergeNotificationPosted = true
+			}
 		}
 
 		// GH-1336: Sync monitor state so dashboard shows "done" instead of stale "failed"

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -4316,3 +4316,184 @@ func TestController_ScanRecentlyMergedPRs(t *testing.T) {
 		})
 	}
 }
+
+// mergeMockServer returns an httptest server that answers the handleMerging
+// happy-path requests (PR fetch, merge, labels) and counts POSTs to the
+// issue comments endpoint.
+func mergeMockServer(t *testing.T, prNumber, issueNumber int, commentCount *int) *httptest.Server {
+	t.Helper()
+	commentPath := "/repos/owner/repo/issues/" + itoa(issueNumber) + "/comments"
+	prPath := "/repos/owner/repo/pulls/" + itoa(prNumber)
+	mergePath := prPath + "/merge"
+	labelsPath := "/repos/owner/repo/issues/" + itoa(issueNumber) + "/labels"
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: "completed", Conclusion: "success"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == commentPath && r.Method == http.MethodPost:
+			*commentCount++
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": 1})
+		case r.URL.Path == mergePath && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"sha": "merged123", "merged": true, "message": "Pull Request successfully merged",
+			})
+		case r.URL.Path == prPath && r.Method == http.MethodGet:
+			pr := github.PullRequest{
+				Number: prNumber,
+				State:  "open",
+				Head:   github.PRRef{Ref: "pilot/GH-" + itoa(issueNumber), SHA: "abc1234"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(pr)
+		case r.URL.Path == labelsPath && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{{Name: github.LabelDone}})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// TestController_handleMerging_IdempotentCompletionComment tests GH-2345:
+// Re-entering StageMerging for an already-merged PR must not produce a second
+// "PR merged" comment.
+func TestController_handleMerging_IdempotentCompletionComment(t *testing.T) {
+	commentCount := 0
+	server := mergeMockServer(t, 42, 10, &commentCount)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoReview = false
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc1234", "pilot/GH-10", "")
+	prState, _ := c.GetPRState(42)
+	prState.Stage = StageMerging
+
+	ctx := context.Background()
+
+	// First entry: posts the completion comment and advances stage.
+	if err := c.handleMerging(ctx, prState); err != nil {
+		t.Fatalf("first handleMerging returned error: %v", err)
+	}
+	if commentCount != 1 {
+		t.Fatalf("after first handleMerging: comment count = %d, want 1", commentCount)
+	}
+	if !prState.MergeNotificationPosted {
+		t.Fatal("MergeNotificationPosted should be true after first successful post")
+	}
+
+	// Simulate re-entry (e.g. via duplicate-dispatch or crash recovery).
+	prState.Stage = StageMerging
+	if err := c.handleMerging(ctx, prState); err != nil {
+		t.Fatalf("re-entry handleMerging returned error: %v", err)
+	}
+	if commentCount != 1 {
+		t.Errorf("after re-entry: comment count = %d, want 1 (no duplicate)", commentCount)
+	}
+}
+
+// TestController_handleMerging_CommentFlagPersists tests GH-2345:
+// MergeNotificationPosted round-trips through SavePRState/LoadAllPRStates so
+// that crash recovery honors the flag and a restored PR never re-posts.
+func TestController_handleMerging_CommentFlagPersists(t *testing.T) {
+	store := newTestStateStore(t)
+
+	pr := &PRState{
+		PRNumber:                42,
+		PRURL:                   "https://github.com/owner/repo/pull/42",
+		IssueNumber:             10,
+		BranchName:              "pilot/GH-10",
+		HeadSHA:                 "abc1234",
+		Stage:                   StageMerging,
+		CIStatus:                CIPending,
+		CreatedAt:               time.Now().Add(-5 * time.Minute).Truncate(time.Second),
+		MergeNotificationPosted: true,
+	}
+	if err := store.SavePRState(pr); err != nil {
+		t.Fatalf("SavePRState failed: %v", err)
+	}
+
+	loaded, err := store.GetPRState(42)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded == nil || !loaded.MergeNotificationPosted {
+		t.Fatalf("MergeNotificationPosted did not persist: got %+v", loaded)
+	}
+
+	all, err := store.LoadAllPRStates()
+	if err != nil {
+		t.Fatalf("LoadAllPRStates failed: %v", err)
+	}
+	if len(all) != 1 || !all[0].MergeNotificationPosted {
+		t.Fatalf("LoadAllPRStates did not preserve MergeNotificationPosted: %+v", all)
+	}
+
+	// Wire the restored state into a controller and run handleMerging — it
+	// must not post a duplicate comment because the flag is already set.
+	commentCount := 0
+	server := mergeMockServer(t, 42, 10, &commentCount)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoReview = false
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(store)
+	if _, err := c.RestoreState(); err != nil {
+		t.Fatalf("RestoreState failed: %v", err)
+	}
+
+	restored, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("restored PR not tracked")
+	}
+	restored.Stage = StageMerging
+
+	if err := c.handleMerging(context.Background(), restored); err != nil {
+		t.Fatalf("handleMerging after restore returned error: %v", err)
+	}
+	if commentCount != 0 {
+		t.Errorf("after restore: comment count = %d, want 0 (flag honored)", commentCount)
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -58,6 +58,10 @@ func (s *StateStore) migrate() error {
 			release_version TEXT DEFAULT '',
 			release_bump_type TEXT DEFAULT ''
 		)`,
+		// GH-2345: Track whether the merge-completion comment has been posted,
+		// so re-entry into StageMerging (e.g. after crash recovery) does not
+		// emit duplicate "PR merged" comments on the linked issue.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN merge_notification_posted INTEGER NOT NULL DEFAULT 0`,
 		`CREATE TABLE IF NOT EXISTS autopilot_processed (
 			issue_number INTEGER PRIMARY KEY,
 			processed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -139,8 +143,8 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at, updated_at,
-			release_version, release_bump_type
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?)
+			release_version, release_bump_type, merge_notification_posted
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?)
 		ON CONFLICT(pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -154,13 +158,14 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			error = excluded.error,
 			updated_at = CURRENT_TIMESTAMP,
 			release_version = excluded.release_version,
-			release_bump_type = excluded.release_bump_type
+			release_bump_type = excluded.release_bump_type,
+			merge_notification_posted = excluded.merge_notification_posted
 	`,
 		pr.PRNumber, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
 		nullTime(pr.LastChecked), nullTime(pr.CIWaitStartedAt),
 		pr.MergeAttempts, pr.Error, nullTime(pr.CreatedAt),
-		pr.ReleaseVersion, string(pr.ReleaseBumpType),
+		pr.ReleaseVersion, string(pr.ReleaseBumpType), pr.MergeNotificationPosted,
 	)
 	return err
 }
@@ -172,7 +177,7 @@ func (s *StateStore) GetPRState(prNumber int) (*PRState, error) {
 		SELECT pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at,
-			release_version, release_bump_type
+			release_version, release_bump_type, merge_notification_posted
 		FROM autopilot_pr_state WHERE pr_number = ?
 	`, prNumber)
 
@@ -192,7 +197,7 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 		SELECT pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at,
-			release_version, release_bump_type
+			release_version, release_bump_type, merge_notification_posted
 		FROM autopilot_pr_state
 	`)
 	if err != nil {
@@ -210,7 +215,7 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 			&pr.PRNumber, &pr.PRURL, &pr.IssueNumber, &pr.BranchName, &pr.HeadSHA,
 			&stage, &ciStatus, &lastChecked, &ciWaitStartedAt,
 			&pr.MergeAttempts, &pr.Error, &createdAt,
-			&pr.ReleaseVersion, &relBumpType,
+			&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
 		); err != nil {
 			return nil, err
 		}
@@ -802,7 +807,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&pr.PRNumber, &pr.PRURL, &pr.IssueNumber, &pr.BranchName, &pr.HeadSHA,
 		&stage, &ciStatus, &lastChecked, &ciWaitStartedAt,
 		&pr.MergeAttempts, &pr.Error, &createdAt,
-		&pr.ReleaseVersion, &relBumpType,
+		&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -460,6 +460,10 @@ type PRState struct {
 	TargetBranch string
 	// IssueNodeID is the GraphQL global node ID of the linked issue, used for board sync.
 	IssueNodeID string
+	// MergeNotificationPosted is true once the merge-completion comment has been
+	// posted to the linked issue. Prevents duplicate comments on state-machine
+	// re-entry for an already-merged PR (GH-2345).
+	MergeNotificationPosted bool
 }
 
 // RepoOwnerAndName extracts the repository owner and name from the PR URL.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2345.

Closes #2345

## Changes

GitHub Issue #2345: fix(autopilot): idempotent merge-completion notification (dedup on re-entry)

## Symptom

GH-2324 received THREE identical "✅ PR merged successfully!" comments for
the SAME PR #2334 at 14:01:44Z / 14:02:32Z / 14:03:17Z, each with a
different "Time to merge" value (3m27s / 4m15s / 5m0s). Three separate calls
to `AddComment`, 45-50 seconds apart.

## Root cause

`handleMerging` at `internal/autopilot/controller.go:1004` posts a comment
unconditionally every time it runs:

```go
comment := buildMergeCompletionComment(prState)
if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); err != nil { ... }
```

`PRState` (`internal/autopilot/types.go` lines 422-463) has no dedup flag.
If the state machine re-enters `StageMerging` for an already-merged PR — due
to the duplicate-dispatch bug in GH-2341, crash recovery reloading state, or
concurrent task contexts racing on the same PR number — a fresh comment is
posted on every entry with `time.Since(prState.CreatedAt)` computed anew
(`buildMergeCompletionComment` at `controller.go:24-36`).

## Fix

Add idempotency at the emit site so re-entry produces no duplicate comment.

1. Add `MergeNotificationPosted bool` to `PRState` in
   `internal/autopilot/types.go` (struct at lines 422-463).
2. Guard the comment post at `controller.go:1004-1007`:

```go
if !prState.MergeNotificationPosted {
    comment := buildMergeCompletionComment(prState)
    if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); err != nil {
        c.log.Warn("failed to post merge completion comment", "issue", prState.IssueNumber, "error", err)
    } else {
        prState.MergeNotificationPosted = true
    }
}
```

3. Ensure the flag is persisted via the existing `SavePRState` path.
   Verify current sqlite schema in `internal/memory/` — add migration if
   needed so crash recovery honors the flag.

## Test plan

- Re-entry test: call `handleMerging` twice for the same `prState` after
  first success → assert `AddComment` called exactly once
- Persistence test: save `prState` with flag true, reload via `RestoreState`,
  call `handleMerging` → assert no new comment emitted

## Files

- `internal/autopilot/types.go` (+1 field)
- `internal/autopilot/controller.go` (~5 lines at line 1004)
- `internal/autopilot/controller_test.go` (2 new tests)
- Possibly schema migration in `internal/memory/` (verify first)

## Note

This patches the symptom, not the root cause. The upstream cause (multiple
contexts racing on one PR) is covered by GH-2341. Both fixes should ship
independently — this one is the belt-and-braces guard that would have
prevented user-visible noise even while GH-2341 was latent.

## Related

- GH-2341 — duplicate-dispatch root cause (upstream)
- GH-2324 — triggered the observation