### PR TITLE
GH-2341: fix(poller): duplicate dispatch — Search API lag + stale ListIssues snapshot

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -500,6 +500,19 @@ func (c *Client) ListPullRequests(ctx context.Context, owner, repo, state string
 	return result, nil
 }
 
+// ListPullRequestsByHead lists pull requests filtered by head branch.
+// Uses GitHub's pulls?head=owner:branch filter, which is strongly consistent
+// (unlike the Search API, which has indexing lag).
+func (c *Client) ListPullRequestsByHead(ctx context.Context, owner, repo, branch string) ([]*PullRequest, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls?state=all&head=%s:%s&per_page=10",
+		owner, repo, owner, url.QueryEscape(branch))
+	var result []*PullRequest
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // CreateRelease creates a new release
 func (c *Client) CreateRelease(ctx context.Context, owner, repo string, input *ReleaseInput) (*Release, error) {
 	return WithRetry(ctx, func() (*Release, error) {

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -917,6 +917,22 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 
 	// Phase 3: Dispatch selected issues
 	for _, issue := range toDispatch {
+		// GH-2341: Defense-in-depth. The `issues` snapshot from ListIssues can
+		// be stale by seconds; a pilot-done / pilot-in-progress label added
+		// between list fetch and dispatch would otherwise cause duplicate work.
+		// Re-fetch the single issue to get fresh labels before committing.
+		if fresh, err := p.client.GetIssue(ctx, p.owner, p.repo, issue.Number); err == nil && fresh != nil {
+			if HasLabel(fresh, LabelDone) || HasLabel(fresh, LabelInProgress) {
+				p.logger.Info("Skipping dispatch — fresh labels show issue already handled",
+					slog.Int("number", issue.Number),
+					slog.Bool("done", HasLabel(fresh, LabelDone)),
+					slog.Bool("in_progress", HasLabel(fresh, LabelInProgress)),
+				)
+				p.markProcessed(issue.Number)
+				continue
+			}
+		}
+
 		// Mark processed immediately to prevent duplicate dispatch on next tick
 		p.markProcessed(issue.Number)
 
@@ -1141,6 +1157,10 @@ func ParseDependencies(body string) []int {
 
 // hasMergedWork checks if the issue already has merged PRs (e.g. "GH-123" in title).
 // If merged work exists, the issue is marked as done and should be skipped.
+//
+// GH-2341: Search API has up to ~30s indexing lag after a merge. If search returns
+// empty, also check the expected branch `pilot/GH-{number}` via REST (strongly
+// consistent) to avoid duplicate dispatch during the indexing window.
 func (p *Poller) hasMergedWork(ctx context.Context, issue *Issue) bool {
 	found, err := p.client.SearchMergedPRsForIssue(ctx, p.owner, p.repo, issue.Number)
 	if err != nil {
@@ -1148,7 +1168,14 @@ func (p *Poller) hasMergedWork(ctx context.Context, issue *Issue) bool {
 			slog.Int("issue", issue.Number),
 			slog.Any("error", err),
 		)
-		return false // Don't block on API errors
+		// Fall through to REST check — don't block on Search API errors but
+		// still try the strongly-consistent path.
+	}
+	if !found {
+		// GH-2341: Bypass Search API indexing lag via direct branch lookup.
+		if p.hasMergedPRForBranch(ctx, issue.Number) {
+			found = true
+		}
 	}
 	if !found {
 		return false
@@ -1173,6 +1200,34 @@ func (p *Poller) hasMergedWork(ctx context.Context, issue *Issue) bool {
 	}
 	p.markProcessed(issue.Number)
 	return true
+}
+
+// hasMergedPRForBranch checks whether a merged PR exists for the canonical
+// pilot branch `pilot/GH-{number}`. Uses the REST pulls?head= filter which is
+// strongly consistent — unlike the Search API, it reflects merges immediately.
+// GH-2341: covers the Search API indexing-lag window (~30s after merge).
+func (p *Poller) hasMergedPRForBranch(ctx context.Context, issueNumber int) bool {
+	branch := fmt.Sprintf("pilot/GH-%d", issueNumber)
+	prs, err := p.client.ListPullRequestsByHead(ctx, p.owner, p.repo, branch)
+	if err != nil {
+		p.logger.Debug("Failed to list PRs by head branch",
+			slog.Int("issue", issueNumber),
+			slog.String("branch", branch),
+			slog.Any("error", err),
+		)
+		return false
+	}
+	for _, pr := range prs {
+		if pr.Merged || pr.MergedAt != "" {
+			p.logger.Info("Found merged PR via branch lookup (Search API lag bypass)",
+				slog.Int("issue", issueNumber),
+				slog.String("branch", branch),
+				slog.Int("pr", pr.Number),
+			)
+			return true
+		}
+	}
+	return false
 }
 
 // shouldRetryFailedIssue checks if a pilot-failed issue should be auto-retried.

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -1675,6 +1675,142 @@ func TestPoller_HasMergedWork(t *testing.T) {
 	}
 }
 
+// GH-2341: Search API returns empty (indexing lag) but a merged PR exists on
+// the canonical pilot branch. hasMergedWork must fall through to the REST
+// branch lookup and still return true to prevent duplicate dispatch.
+func TestPoller_HasMergedWork_SearchLagBypassedByBranchLookup(t *testing.T) {
+	var labeled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.URL.Query().Get("head") == "owner:pilot/GH-42":
+			_, _ = w.Write([]byte(`[{"number": 100, "state": "closed", "merged": true, "merged_at": "2026-04-17T14:01:40Z"}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/issues/42/labels":
+			labeled = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue := &Issue{Number: 42, Title: "Test issue"}
+	got := poller.hasMergedWork(context.Background(), issue)
+
+	if !got {
+		t.Error("hasMergedWork() = false, want true (branch lookup should bypass Search API lag)")
+	}
+	if !labeled {
+		t.Error("pilot-done label should have been applied")
+	}
+	if !poller.IsProcessed(42) {
+		t.Error("issue should be marked processed")
+	}
+}
+
+// GH-2341: When Search API returns empty AND no merged PR exists on branch,
+// hasMergedWork returns false and allows retry (the original behavior).
+func TestPoller_HasMergedWork_NoMergedWork(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+		case r.URL.Path == "/repos/owner/repo/pulls":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue := &Issue{Number: 42, Title: "Test issue"}
+	if poller.hasMergedWork(context.Background(), issue) {
+		t.Error("hasMergedWork() = true, want false (no merged work anywhere)")
+	}
+}
+
+// GH-2341: If branch lookup returns only closed-without-merge PRs, it should
+// NOT count as merged work.
+func TestPoller_HasMergedWork_ClosedNotMergedOnBranch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+		case r.URL.Path == "/repos/owner/repo/pulls":
+			_, _ = w.Write([]byte(`[{"number": 100, "state": "closed", "merged": false, "merged_at": ""}]`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue := &Issue{Number: 42, Title: "Test issue"}
+	if poller.hasMergedWork(context.Background(), issue) {
+		t.Error("hasMergedWork() = true, want false (PR closed but not merged)")
+	}
+}
+
+// GH-2341: Defense-in-depth. The issues snapshot from ListIssues can be stale.
+// Before dispatching, poller re-fetches the issue and skips if pilot-done or
+// pilot-in-progress appear on the fresh copy.
+func TestPoller_CheckForNewIssues_SkipsWhenFreshLabelsShowDone(t *testing.T) {
+	// Snapshot: issue has no pilot-done.
+	snapshotIssues := []*Issue{
+		{Number: 42, Title: "GH-42 feature", Labels: []Label{{Name: "pilot"}}},
+	}
+	// Fresh single-issue GET: pilot-done now present.
+	freshIssue := &Issue{
+		Number: 42, Title: "GH-42 feature",
+		Labels: []Label{{Name: "pilot"}, {Name: LabelDone}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode(snapshotIssues)
+		case "/repos/owner/repo/issues/42":
+			_ = json.NewEncoder(w).Encode(freshIssue)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&callCount); got != 0 {
+		t.Errorf("dispatched %d times, want 0 (fresh labels show pilot-done)", got)
+	}
+	if !poller.IsProcessed(42) {
+		t.Error("issue should be marked processed after skip")
+	}
+}
+
 func TestPoller_HasMergedWork_APIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2341.

Closes #2341

## Changes

GitHub Issue #2341: fix(poller): duplicate dispatch — Search API lag + stale ListIssues snapshot

## Symptom

GH-2324 was dispatched TWICE within 2 minutes:
- **PR #2334** merged 14:01:40Z (first attempt, correct)
- **PR #2339** created 14:03:40Z on the SAME branch `pilot/GH-2324`, same change → guaranteed self-conflict → auto-closed by `handleMergeConflict`

This wasted a full Claude Code run and left the issue in contradictory label state (see companion issue GH-2340).

## Root cause

Two compounding issues in `internal/adapters/github/poller.go`:

### 1. GitHub Search API indexing lag

`hasMergedWork` (`poller.go:1271`) calls `SearchMergedPRsForIssue` which uses the GitHub **Search API** (`internal/adapters/github/client.go:840`). Search API has up to ~30s indexing lag after a merge.

If the poller ticks within that window after PR #2334 merged:
- Search returns empty → `hasMergedWork` returns `false`
- `shouldRetryRetryReadyIssue` guard passes (`poller.go:1252-1254`)
- Issue re-dispatched → PR #2339 created

### 2. Stale ListIssues snapshot

Poller operates on the snapshot from `ListIssues` fetched at `poller.go:777`. If `pilot-done` is added between `ListIssues` and the label evaluation at `poller.go:1244-1254`, the snapshot doesn't reflect it. `HasLabel(issue, LabelDone)` returns false against stale data.

## Fix

### Primary — bypass Search API lag (`poller.go:1271`)

In `shouldRetryRetryReadyIssue`, supplement `SearchMergedPRsForIssue` with a direct PR lookup:
- Construct the expected branch name (`pilot/GH-{number}`)
- Call `GetPullRequest` via REST (strongly consistent, no indexing lag)
- If a merged PR exists on that branch, treat as `hasMergedWork == true` even if search returned empty

### Defense-in-depth — refresh labels before dispatch (`poller.go:808-814`)

Before the goroutine launches at `poller.go:921`, re-fetch the issue's current labels with a single-issue GET (bypasses the snapshot). If `pilot-done` or `pilot-in-progress` are present, skip dispatch.

## Test plan

- Unit test: mock Search API returning empty + REST returning merged PR → guard blocks dispatch
- Unit test: mock stale snapshot without `pilot-done` + fresh fetch with `pilot-done` → no dispatch
- Integration: simulate merge → next-tick race → assert only one dispatch

## Files

- `internal/adapters/github/poller.go:1252-1273` (shouldRetryRetryReadyIssue + hasMergedWork)
- `internal/adapters/github/poller.go:808-921` (checkForNewIssues dispatch path)
- `internal/adapters/github/client.go:840` (SearchMergedPRsForIssue)

## Related

- GH-1983: Merged PR guard — prevent retry of completed work (initial guard, didn't cover Search API lag)
- Companion: GH-2340 (stuck `pilot-retry-ready` — downstream symptom of this bug)