### PR TITLE
GH-2349: fix(autopilot): ScanExistingPRs clobbers RestoreState on startup

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1773,6 +1773,19 @@ func (c *Controller) ScanExistingPRs(ctx context.Context) error {
 			continue
 		}
 
+		// Skip PRs already tracked via RestoreState — OnPRCreated would clobber
+		// their persisted stage (e.g. StageWaitingCI) back to StagePRCreated and
+		// reset CIWaitStartedAt, making CI timers restart from zero after every
+		// Pilot restart. RestoreState is authoritative for PRs in SQLite; this
+		// scan only registers genuine orphans (PRs created while Pilot was down).
+		c.mu.RLock()
+		_, alreadyTracked := c.activePRs[pr.Number]
+		c.mu.RUnlock()
+		if alreadyTracked {
+			c.log.Debug("skipping already-tracked PR in scan", "pr", pr.Number, "branch", pr.Head.Ref)
+			continue
+		}
+
 		c.log.Info("restoring Pilot PR for tracking",
 			"pr", pr.Number,
 			"branch", pr.Head.Ref,

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -804,6 +804,61 @@ func TestController_ScanExistingPRs(t *testing.T) {
 	}
 }
 
+// TestController_ScanExistingPRs_PreservesTrackedState verifies that PRs
+// already tracked (e.g. restored from SQLite via RestoreState) are not
+// clobbered back to StagePRCreated by a subsequent ScanExistingPRs call.
+// Regression test for GH-2349.
+func TestController_ScanExistingPRs_PreservesTrackedState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls" {
+			prs := []*github.PullRequest{
+				{Number: 42, Head: github.PRRef{Ref: "pilot/GH-100", SHA: "sha-new"}, HTMLURL: "url"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Simulate RestoreState having already populated this PR at StageCIPassed
+	// with a non-zero CIWaitStartedAt.
+	ciWaitStart := time.Now().Add(-30 * time.Minute)
+	c.mu.Lock()
+	c.activePRs[42] = &PRState{
+		PRNumber:        42,
+		IssueNumber:     100,
+		BranchName:      "pilot/GH-100",
+		HeadSHA:         "sha-old",
+		Stage:           StageCIPassed,
+		CIWaitStartedAt: ciWaitStart,
+	}
+	c.mu.Unlock()
+
+	if err := c.ScanExistingPRs(context.Background()); err != nil {
+		t.Fatalf("ScanExistingPRs() error = %v", err)
+	}
+
+	pr, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("PR 42 missing after scan")
+	}
+	if pr.Stage != StageCIPassed {
+		t.Errorf("Stage = %v, want %v (regressed by scan)", pr.Stage, StageCIPassed)
+	}
+	if !pr.CIWaitStartedAt.Equal(ciWaitStart) {
+		t.Errorf("CIWaitStartedAt reset by scan: got %v, want %v", pr.CIWaitStartedAt, ciWaitStart)
+	}
+	if pr.HeadSHA != "sha-old" {
+		t.Errorf("HeadSHA = %q, want %q (clobbered by scan)", pr.HeadSHA, "sha-old")
+	}
+}
+
 func TestController_ScanExistingPRs_Error(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2349.

Closes #2349

## Changes

GitHub Issue #2349: fix(autopilot): ScanExistingPRs clobbers RestoreState on startup

## Symptom

After Pilot restart, all in-flight PRs have their autopilot state regressed to `StagePRCreated` with `CIWaitStartedAt` reset. The CI-wait timer restarts from zero. Observed today: PRs #2342 (GH-2340, 73 min old), #2347 (GH-2345, 24 min old), #2343 (GH-2341) all sat idle post-restart while autopilot treated them as freshly-created PRs.

## Root cause

Startup sequence in `cmd/pilot/main.go`:
1. Line 1373: `RestoreState()` loads SQLite → populates `activePRs` with persisted stages (`StageWaitingCI`, `StageCIPassed`, etc.)
2. Line 2090: `ScanExistingPRs()` runs **after** restore

`ScanExistingPRs` at `internal/autopilot/controller.go:1779` unconditionally calls `c.OnPRCreated(...)` for every open `pilot/GH-*` PR. **No "skip if already tracked" guard.**

`OnPRCreated` at `controller.go:322-334` unconditionally constructs a fresh `PRState{Stage: StagePRCreated, CIWaitStartedAt: zero}` and writes it to both the in-memory map and SQLite. Every mid-flight PR gets its stage regressed and its CI timer reset.

## Compare with existing guard

`ScanRecentlyMergedPRs` at `controller.go:1862` **does** have the guard:

```go
c.mu.RLock()
_, alreadyTracked := c.activePRs[pr.Number]
c.mu.RUnlock()
if alreadyTracked {
    continue
}
```

`ScanExistingPRs` was written without it.

## Fix

Mirror the guard into `ScanExistingPRs`. Insert at line 1763, before the `OnPRCreated` call:

```go
c.mu.RLock()
_, alreadyTracked := c.activePRs[pr.Number]
c.mu.RUnlock()
if alreadyTracked {
    c.log.Debug("skipping already-tracked PR in scan", "pr", pr.Number, "branch", pr.Head.Ref)
    continue
}
```

This makes `RestoreState` authoritative for PRs already in SQLite. `ScanExistingPRs` only registers genuinely new orphans (PRs created while Pilot was down, never persisted to SQLite).

## Secondary gap (not required for this fix, document only)

Not persisted in SQLite schema (`internal/memory/state_store.go:136-165`):
- `EnvironmentName` — repopulated generically on restart
- `IssueNodeID` — repopulated empty → GitHub Projects V2 board sync may miss operations
- `DiscoveredChecks` — re-discovered on next tick, minor cost

Consider extending schema in a follow-up.

## Test plan

- Unit test: populate `activePRs` with a `StageCIPassed` PR; run `ScanExistingPRs` with the same PR in the list; assert stage unchanged.
- Integration: start Pilot, open a PR, transition it to `StageWaitingCI`, restart Pilot, assert the PR is still at `StageWaitingCI` (not regressed to `StagePRCreated`).

## Files

- `internal/autopilot/controller.go:1763` (5 line insertion)
- `internal/autopilot/controller_test.go` (1 new test)

## Related

- Observed on PRs #2342, #2347, #2343 (all stuck post-restart)
- Companion: GH-2340, GH-2341, GH-2344, GH-2345 — the fix-PRs themselves caught in this bug