### PR TITLE
GH-2341: fix(poller): duplicate dispatch — Search API lag + stale ListIssues snapshot

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -849,6 +849,26 @@ func (c *Client) SearchMergedPRsForIssue(ctx context.Context, owner, repo string
 	return result.TotalCount > 0, nil
 }
 
+// FindMergedPRByBranch looks up PRs by head branch via the strongly-consistent REST API
+// (no Search API indexing lag). Returns true if any PR on that branch is merged.
+// GH-2341: bypasses Search API lag that allowed duplicate dispatch of recently-merged issues.
+func (c *Client) FindMergedPRByBranch(ctx context.Context, owner, repo, branch string) (bool, error) {
+	head := fmt.Sprintf("%s:%s", owner, branch)
+	path := fmt.Sprintf("/repos/%s/%s/pulls?head=%s&state=closed&per_page=10",
+		owner, repo, url.QueryEscape(head))
+
+	var prs []*PullRequest
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &prs); err != nil {
+		return false, fmt.Errorf("list PRs by branch %s: %w", branch, err)
+	}
+	for _, pr := range prs {
+		if pr.MergedAt != "" || pr.Merged {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // SearchOpenSubIssues counts open issues in a repo whose body contains "Parent: GH-{parentNum}".
 // Uses the GitHub Search API to find sub-issues referencing the given parent.
 func (c *Client) SearchOpenSubIssues(ctx context.Context, owner, repo string, parentNum int) (int, error) {

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -2677,6 +2677,76 @@ func TestSearchMergedPRsForIssue(t *testing.T) {
 	}
 }
 
+func TestFindMergedPRByBranch(t *testing.T) {
+	tests := []struct {
+		name       string
+		branch     string
+		response   string
+		wantFound  bool
+		wantErr    bool
+		statusCode int
+	}{
+		{
+			name:       "merged PR on branch",
+			branch:     "pilot/GH-42",
+			statusCode: http.StatusOK,
+			response:   `[{"number": 100, "merged_at": "2026-04-17T14:01:40Z"}]`,
+			wantFound:  true,
+		},
+		{
+			name:       "closed but not merged",
+			branch:     "pilot/GH-43",
+			statusCode: http.StatusOK,
+			response:   `[{"number": 101, "merged_at": ""}]`,
+			wantFound:  false,
+		},
+		{
+			name:       "no PRs on branch",
+			branch:     "pilot/GH-44",
+			statusCode: http.StatusOK,
+			response:   `[]`,
+			wantFound:  false,
+		},
+		{
+			name:       "API error",
+			branch:     "pilot/GH-45",
+			statusCode: http.StatusForbidden,
+			response:   `{"message":"rate limit"}`,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/repos/owner/repo/pulls" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				if got := r.URL.Query().Get("head"); got != "owner:"+tt.branch {
+					t.Errorf("head filter = %q, want %q", got, "owner:"+tt.branch)
+				}
+				if got := r.URL.Query().Get("state"); got != "closed" {
+					t.Errorf("state = %q, want closed", got)
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			found, err := client.FindMergedPRByBranch(context.Background(), "owner", "repo", tt.branch)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindMergedPRByBranch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && found != tt.wantFound {
+				t.Errorf("FindMergedPRByBranch() = %v, want %v", found, tt.wantFound)
+			}
+		})
+	}
+}
+
 func TestSearchOpenSubIssues(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -917,6 +917,26 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 
 	// Phase 3: Dispatch selected issues
 	for _, issue := range toDispatch {
+		// GH-2341: Refresh labels via single-issue GET to bypass stale ListIssues snapshot.
+		// If pilot-done or pilot-in-progress was added after the list was fetched,
+		// the snapshot's Labels will not reflect it — fetch fresh state.
+		if fresh, ferr := p.client.GetIssue(ctx, p.owner, p.repo, issue.Number); ferr == nil && fresh != nil {
+			if HasLabel(fresh, LabelDone) || HasLabel(fresh, LabelInProgress) {
+				p.logger.Info("Skipping dispatch — fresh labels show issue already handled",
+					slog.Int("number", issue.Number),
+					slog.Bool("done", HasLabel(fresh, LabelDone)),
+					slog.Bool("in_progress", HasLabel(fresh, LabelInProgress)),
+				)
+				p.markProcessed(issue.Number)
+				continue
+			}
+		} else if ferr != nil {
+			p.logger.Debug("Failed to refresh issue labels before dispatch — proceeding with snapshot",
+				slog.Int("number", issue.Number),
+				slog.Any("error", ferr),
+			)
+		}
+
 		// Mark processed immediately to prevent duplicate dispatch on next tick
 		p.markProcessed(issue.Number)
 
@@ -1148,10 +1168,29 @@ func (p *Poller) hasMergedWork(ctx context.Context, issue *Issue) bool {
 			slog.Int("issue", issue.Number),
 			slog.Any("error", err),
 		)
-		return false // Don't block on API errors
+		// Fall through to branch lookup below — don't block on Search API errors alone.
 	}
+
+	// GH-2341: Search API has up to ~30s indexing lag. Supplement with a direct REST
+	// lookup by branch (strongly consistent) to catch just-merged PRs on pilot/GH-N.
 	if !found {
-		return false
+		branch := fmt.Sprintf("pilot/GH-%d", issue.Number)
+		branchFound, berr := p.client.FindMergedPRByBranch(ctx, p.owner, p.repo, branch)
+		if berr != nil {
+			p.logger.Warn("Failed to check merged PRs by branch",
+				slog.Int("issue", issue.Number),
+				slog.String("branch", branch),
+				slog.Any("error", berr),
+			)
+			return false
+		}
+		if !branchFound {
+			return false
+		}
+		p.logger.Info("Merged PR found via branch lookup (Search API lag)",
+			slog.Int("issue", issue.Number),
+			slog.String("branch", branch),
+		)
 	}
 
 	p.logger.Info("Issue already has merged PRs, marking as done",

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2591,3 +2591,116 @@ func TestPoller_DispatchesWhenNoCompletedExecution(t *testing.T) {
 		t.Errorf("callback called %d times, want 1 (should dispatch when no completed execution)", got)
 	}
 }
+
+// GH-2341: Search API may lag up to ~30s after a merge. hasMergedWork must
+// supplement with a direct REST PR lookup by branch to catch that window.
+func TestPoller_HasMergedWork_SearchLag_BranchFallback(t *testing.T) {
+	var searchCalls, pullsCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/search/issues":
+			atomic.AddInt32(&searchCalls, 1)
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+		case "/repos/owner/repo/pulls":
+			atomic.AddInt32(&pullsCalls, 1)
+			head := r.URL.Query().Get("head")
+			if head != "owner:pilot/GH-42" {
+				t.Errorf("unexpected head filter: %q", head)
+			}
+			_, _ = w.Write([]byte(`[{"number": 100, "merged_at": "2026-04-17T14:01:40Z", "head": {"ref": "pilot/GH-42"}}]`))
+		case "/repos/owner/repo/issues/42/labels":
+			if r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusOK)
+			}
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue := &Issue{Number: 42, Title: "Test issue"}
+	got := poller.hasMergedWork(context.Background(), issue)
+
+	if !got {
+		t.Error("hasMergedWork() should return true when branch has merged PR (even with Search API empty)")
+	}
+	if atomic.LoadInt32(&pullsCalls) == 0 {
+		t.Error("expected branch REST lookup to be called when Search API returned empty")
+	}
+	_ = searchCalls
+}
+
+// GH-2341: If neither Search API nor branch REST find a merged PR, allow retry.
+func TestPoller_HasMergedWork_NoMerges_NoFallbackBlock(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+		case "/repos/owner/repo/pulls":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue := &Issue{Number: 42, Title: "Test issue"}
+	if poller.hasMergedWork(context.Background(), issue) {
+		t.Error("hasMergedWork() should return false when no merged PRs exist on branch")
+	}
+}
+
+// GH-2341: Fresh label fetch before dispatch blocks re-dispatch when the
+// ListIssues snapshot is stale and pilot-done was added in between.
+func TestPoller_CheckForNewIssues_StaleSnapshot_RefreshesLabels(t *testing.T) {
+	// Snapshot returned by ListIssues has NO pilot-done label.
+	staleIssues := []*Issue{
+		{Number: 42, Title: "GH-42 feature", State: "open", Labels: []Label{{Name: "pilot"}}},
+	}
+	// Fresh GetIssue response includes pilot-done.
+	freshIssue := &Issue{
+		Number: 42, Title: "GH-42 feature", State: "open",
+		Labels: []Label{{Name: "pilot"}, {Name: LabelDone}},
+	}
+
+	var dispatches int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode(staleIssues)
+		case "/repos/owner/repo/issues/42":
+			_ = json.NewEncoder(w).Encode(freshIssue)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&dispatches, 1)
+			return nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&dispatches); got != 0 {
+		t.Errorf("dispatched %d times, want 0 (fresh GetIssue shows pilot-done)", got)
+	}
+}


### PR DESCRIPTION
Re-open of #2350 after CI lint fix already pushed on this branch.

## Summary
- Adds REST-consistent `ListPullRequestsByHead` to supplement Search API in `hasMergedWork()` (fixes Search API indexing lag).
- Dispatch path re-fetches issue via `GetIssue` to catch fresh labels.
- Tagged switches on `r.URL.Path` in tests (fixes staticcheck QF1002 lint from #2350).

Fixes #2341. Closes #2351.