### PR TITLE
GH-2354: fix(dashboard): queue view includes closed issues with stale pilot-in-progress label

### DIFF
--- a/.agent/tasks/gh-2354.md
+++ b/.agent/tasks/gh-2354.md
@@ -1,0 +1,43 @@
+# GH-2354
+
+**Created:** 2026-04-17
+
+## Problem
+
+GitHub Issue #2354: fix(dashboard): queue view includes closed issues with stale pilot-in-progress label
+
+## Symptom
+
+Dashboard TUI queue view shows issues that are CLOSED on GitHub but still carry the `pilot-in-progress` label. These issues are not actively running — they represent stale label state after an external close (e.g. someone ran `gh issue close` without clearing the label).
+
+## Reproduction
+
+1. Create an issue labeled `pilot`, let Pilot pick it up → it gets `pilot-in-progress`
+2. Run `gh issue close <n>` externally (or close via UI) WITHOUT removing `pilot-in-progress`
+3. Dashboard still shows the issue in the queue, rendering "◌ queued #1" or similar
+
+## Observed today
+
+GH-2348 and GH-2351 (autopilot-fix issues for closed parent PRs) were closed via `gh issue close`. Both retained `pilot-in-progress`. Dashboard continued to show them as queued/running.
+
+## Root cause hypothesis
+
+Dashboard data source filters issues by label only, not by `state=OPEN`. The `pilot-in-progress` label is treated as ground truth for "currently executing" without cross-checking GitHub issue state.
+
+## Fix
+
+Filter dashboard queue view by `state=OPEN` AND `pilot-in-progress` label. Or separately — display only issues whose state matches the label semantics.
+
+Likely file: `internal/dashboard/` — search for where the queue panel renders rows, whatever fetches the issue list.
+
+## Test plan
+
+- Unit test for the dashboard query/filter function with mixed open/closed issues bearing `pilot-in-progress`
+- Assert closed issues are excluded
+
+## Related
+
+- Companion issue (to be filed): `pilot-in-progress` label should be cleared when issue is externally closed
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2162,6 +2162,14 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 							}
 						}))
 					}
+					// GH-2354: when pilot-in-progress is stripped from a closed
+					// issue, remove its task from the dashboard monitor so it
+					// stops showing in the queue view.
+					if monitor != nil {
+						cleanerOpts = append(cleanerOpts, github.WithOnInProgressCleaned(func(issueNumber int) {
+							monitor.Remove(fmt.Sprintf("GH-%d", issueNumber))
+						}))
+					}
 					cleaner, cleanerErr := github.NewCleaner(client, store, cfg.Adapters.GitHub.Repo, cfg.Adapters.GitHub.StaleLabelCleanup, cleanerOpts...)
 					if cleanerErr != nil {
 						if !dashboardMode {

--- a/internal/adapters/github/cleanup.go
+++ b/internal/adapters/github/cleanup.go
@@ -29,6 +29,11 @@ type Cleaner struct {
 	// Used to clear the issue from the poller's processed map.
 	OnFailedCleaned func(issueNumber int)
 
+	// OnInProgressCleaned is called when a pilot-in-progress label is removed
+	// from a closed issue. Used to prune the dashboard monitor so the task
+	// stops appearing in the queue view (GH-2354).
+	OnInProgressCleaned func(issueNumber int)
+
 	mu      sync.Mutex
 	running bool
 	stopCh  chan struct{}
@@ -49,6 +54,15 @@ func WithCleanerLogger(logger *slog.Logger) CleanerOption {
 func WithOnFailedCleaned(fn func(issueNumber int)) CleanerOption {
 	return func(c *Cleaner) {
 		c.OnFailedCleaned = fn
+	}
+}
+
+// WithOnInProgressCleaned sets the callback for when a pilot-in-progress label
+// is removed from a closed issue. The callback receives the issue number and
+// should remove the task from the dashboard monitor (GH-2354).
+func WithOnInProgressCleaned(fn func(issueNumber int)) CleanerOption {
+	return func(c *Cleaner) {
+		c.OnInProgressCleaned = fn
 	}
 }
 
@@ -174,16 +188,25 @@ func (c *Cleaner) Cleanup(ctx context.Context) error {
 		return fmt.Errorf("failed to cleanup in-progress labels: %w", err)
 	}
 
+	// GH-2354: Also clean up pilot-in-progress labels left on CLOSED issues.
+	// Externally closed issues (e.g. `gh issue close`) retain the label; the
+	// dashboard monitor keeps them in its queue view until the task is pruned.
+	closedCleaned, err := c.cleanupClosedInProgressLabels(ctx, activeTaskIDs)
+	if err != nil {
+		return fmt.Errorf("failed to cleanup closed in-progress labels: %w", err)
+	}
+
 	// Clean up stale pilot-failed labels
 	failedCleaned, err := c.cleanupLabel(ctx, LabelFailed, c.failedThreshold, activeTaskIDs)
 	if err != nil {
 		return fmt.Errorf("failed to cleanup failed labels: %w", err)
 	}
 
-	totalCleaned := inProgressCleaned + failedCleaned
+	totalCleaned := inProgressCleaned + closedCleaned + failedCleaned
 	if totalCleaned > 0 {
 		c.logger.Info("Stale label cleanup completed",
 			slog.Int("in_progress_cleaned", inProgressCleaned),
+			slog.Int("closed_in_progress_cleaned", closedCleaned),
 			slog.Int("failed_cleaned", failedCleaned),
 		)
 	}
@@ -275,6 +298,74 @@ func (c *Cleaner) cleanupLabel(ctx context.Context, label string, threshold time
 		// For failed labels, notify callback to clear from processed map
 		if label == LabelFailed && c.OnFailedCleaned != nil {
 			c.OnFailedCleaned(issue.Number)
+		}
+
+		cleanedCount++
+	}
+
+	return cleanedCount, nil
+}
+
+// cleanupClosedInProgressLabels removes the pilot-in-progress label from
+// issues that are CLOSED on GitHub but still carry the label. This happens
+// when an issue is closed externally (e.g. `gh issue close`) without the
+// label being cleared. The dashboard monitor treats such tasks as live and
+// keeps them in the queue view — GH-2354.
+//
+// No staleness threshold is applied: a closed issue should never carry the
+// in-progress label, so we clean immediately on discovery. Active executions
+// (tracked in the memory store) are still skipped so an in-flight run isn't
+// silently stripped while it's still working.
+func (c *Cleaner) cleanupClosedInProgressLabels(ctx context.Context, activeTaskIDs map[string]bool) (int, error) {
+	issues, err := c.client.ListIssues(ctx, c.owner, c.repo, &ListIssuesOptions{
+		Labels: []string{LabelInProgress},
+		State:  StateClosed,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list closed issues with %s label: %w", LabelInProgress, err)
+	}
+
+	if len(issues) == 0 {
+		return 0, nil
+	}
+
+	c.logger.Debug("Found closed issues with in-progress label",
+		slog.Int("count", len(issues)),
+	)
+
+	cleanedCount := 0
+	for _, issue := range issues {
+		// Defensive: only act on issues that are genuinely closed. GitHub's
+		// real API honours the state=closed filter, but we don't want to
+		// strip labels from open issues if the response is ambiguous.
+		if issue.State != StateClosed {
+			continue
+		}
+
+		taskID := fmt.Sprintf("GH-%d", issue.Number)
+		if activeTaskIDs[taskID] {
+			c.logger.Debug("Closed issue has active execution, skipping",
+				slog.Int("issue", issue.Number),
+				slog.String("task_id", taskID),
+			)
+			continue
+		}
+
+		c.logger.Info("Removing in-progress label from closed issue",
+			slog.Int("issue", issue.Number),
+			slog.String("title", issue.Title),
+		)
+
+		if err := c.client.RemoveLabel(ctx, c.owner, c.repo, issue.Number, LabelInProgress); err != nil {
+			c.logger.Warn("Failed to remove in-progress label from closed issue",
+				slog.Int("issue", issue.Number),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		if c.OnInProgressCleaned != nil {
+			c.OnInProgressCleaned(issue.Number)
 		}
 
 		cleanedCount++

--- a/internal/adapters/github/cleanup_test.go
+++ b/internal/adapters/github/cleanup_test.go
@@ -665,6 +665,146 @@ func TestCleaner_FailedThreshold_DefaultValue(t *testing.T) {
 	}
 }
 
+// GH-2354: pilot-in-progress label on externally-closed issues should be
+// cleaned up immediately, and the dashboard monitor callback should fire.
+func TestCleaner_Cleanup_ClosedInProgressIssueCleaned(t *testing.T) {
+	store := createTestStore(t)
+	defer func() { _ = store.Close() }()
+
+	closedIssues := []*Issue{
+		{
+			Number:    2348,
+			Title:     "Externally closed issue",
+			Labels:    []Label{{Name: LabelInProgress}},
+			State:     StateClosed,
+			UpdatedAt: time.Now(), // recent — threshold must be ignored for closed
+		},
+	}
+
+	var (
+		mu              sync.Mutex
+		removeLabelHit  bool
+		sawStateClosed  bool
+		commentOnClosed bool
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues" {
+			state := r.URL.Query().Get("state")
+			if state == "closed" {
+				sawStateClosed = true
+				_ = json.NewEncoder(w).Encode(closedIssues)
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]*Issue{})
+			return
+		}
+
+		if r.Method == http.MethodDelete && r.URL.Path == "/repos/owner/repo/issues/2348/labels/"+LabelInProgress {
+			removeLabelHit = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		if r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/issues/2348/comments" {
+			commentOnClosed = true
+			_ = json.NewEncoder(w).Encode(&Comment{ID: 1})
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	var callbackIssue int
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
+		Enabled:   true,
+		Interval:  30 * time.Minute,
+		Threshold: 1 * time.Hour,
+	}, WithOnInProgressCleaned(func(n int) { callbackIssue = n }))
+
+	if err := cleaner.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if !sawStateClosed {
+		t.Error("expected ListIssues to be called with state=closed")
+	}
+	if !removeLabelHit {
+		t.Error("RemoveLabel should have been called for closed in-progress issue")
+	}
+	if commentOnClosed {
+		t.Error("AddComment must NOT be called for closed-issue cleanup (silent)")
+	}
+	if callbackIssue != 2348 {
+		t.Errorf("OnInProgressCleaned callback issue = %d, want 2348", callbackIssue)
+	}
+}
+
+// GH-2354: active executions for closed issues must NOT have the label stripped
+// while the task is still running in-memory.
+func TestCleaner_Cleanup_ClosedInProgressWithActiveExecutionSkipped(t *testing.T) {
+	store := createTestStore(t)
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-2351",
+		TaskID:      "GH-2351",
+		ProjectPath: "/test/project",
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	closedIssues := []*Issue{
+		{Number: 2351, Title: "Closed but still running", Labels: []Label{{Name: LabelInProgress}}, State: StateClosed, UpdatedAt: time.Now()},
+	}
+
+	removeLabelHit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues" {
+			if r.URL.Query().Get("state") == "closed" {
+				_ = json.NewEncoder(w).Encode(closedIssues)
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]*Issue{})
+			return
+		}
+		if r.Method == http.MethodDelete {
+			removeLabelHit = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	callbackFired := false
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
+		Enabled: true, Interval: 30 * time.Minute, Threshold: 1 * time.Hour,
+	}, WithOnInProgressCleaned(func(int) { callbackFired = true }))
+
+	if err := cleaner.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	if removeLabelHit {
+		t.Error("RemoveLabel must NOT be called for closed issue with active execution")
+	}
+	if callbackFired {
+		t.Error("OnInProgressCleaned must NOT fire for closed issue with active execution")
+	}
+}
+
 // Helper function to create a test memory store
 func createTestStore(t *testing.T) *memory.Store {
 	t.Helper()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2354.

Closes #2354

## Changes

GitHub Issue #2354: fix(dashboard): queue view includes closed issues with stale pilot-in-progress label

## Symptom

Dashboard TUI queue view shows issues that are CLOSED on GitHub but still carry the `pilot-in-progress` label. These issues are not actively running — they represent stale label state after an external close (e.g. someone ran `gh issue close` without clearing the label).

## Reproduction

1. Create an issue labeled `pilot`, let Pilot pick it up → it gets `pilot-in-progress`
2. Run `gh issue close <n>` externally (or close via UI) WITHOUT removing `pilot-in-progress`
3. Dashboard still shows the issue in the queue, rendering "◌ queued #1" or similar

## Observed today

GH-2348 and GH-2351 (autopilot-fix issues for closed parent PRs) were closed via `gh issue close`. Both retained `pilot-in-progress`. Dashboard continued to show them as queued/running.

## Root cause hypothesis

Dashboard data source filters issues by label only, not by `state=OPEN`. The `pilot-in-progress` label is treated as ground truth for "currently executing" without cross-checking GitHub issue state.

## Fix

Filter dashboard queue view by `state=OPEN` AND `pilot-in-progress` label. Or separately — display only issues whose state matches the label semantics.

Likely file: `internal/dashboard/` — search for where the queue panel renders rows, whatever fetches the issue list.

## Test plan

- Unit test for the dashboard query/filter function with mixed open/closed issues bearing `pilot-in-progress`
- Assert closed issues are excluded

## Related

- Companion issue (to be filed): `pilot-in-progress` label should be cleared when issue is externally closed