### PR TITLE
GH-2355: fix(poller): clear pilot-in-progress label when issue is externally closed

### DIFF
--- a/internal/adapters/github/cleanup.go
+++ b/internal/adapters/github/cleanup.go
@@ -180,11 +180,20 @@ func (c *Cleaner) Cleanup(ctx context.Context) error {
 		return fmt.Errorf("failed to cleanup failed labels: %w", err)
 	}
 
-	totalCleaned := inProgressCleaned + failedCleaned
+	// Clean up pilot-in-progress on externally-closed issues (GH-2355).
+	// A closed issue carrying pilot-in-progress is contradictory state — the
+	// label should be cleared immediately regardless of age.
+	closedInProgressCleaned, err := c.cleanupClosedInProgress(ctx, activeTaskIDs)
+	if err != nil {
+		return fmt.Errorf("failed to cleanup closed in-progress labels: %w", err)
+	}
+
+	totalCleaned := inProgressCleaned + failedCleaned + closedInProgressCleaned
 	if totalCleaned > 0 {
 		c.logger.Info("Stale label cleanup completed",
 			slog.Int("in_progress_cleaned", inProgressCleaned),
 			slog.Int("failed_cleaned", failedCleaned),
+			slog.Int("closed_in_progress_cleaned", closedInProgressCleaned),
 		)
 	}
 
@@ -275,6 +284,58 @@ func (c *Cleaner) cleanupLabel(ctx context.Context, label string, threshold time
 		// For failed labels, notify callback to clear from processed map
 		if label == LabelFailed && c.OnFailedCleaned != nil {
 			c.OnFailedCleaned(issue.Number)
+		}
+
+		cleanedCount++
+	}
+
+	return cleanedCount, nil
+}
+
+// cleanupClosedInProgress removes pilot-in-progress from issues that are CLOSED.
+// A closed issue with that label is contradictory state (externally closed via
+// `gh issue close` or UI without label cleanup). No age threshold — clear on
+// first observation. Active executions are still skipped so we don't race a
+// legitimate in-flight run that closed the issue itself.
+func (c *Cleaner) cleanupClosedInProgress(ctx context.Context, activeTaskIDs map[string]bool) (int, error) {
+	issues, err := c.client.ListIssues(ctx, c.owner, c.repo, &ListIssuesOptions{
+		Labels: []string{LabelInProgress},
+		State:  StateClosed,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list closed issues with %s label: %w", LabelInProgress, err)
+	}
+
+	if len(issues) == 0 {
+		return 0, nil
+	}
+
+	c.logger.Debug("Found closed issues with pilot-in-progress label",
+		slog.Int("count", len(issues)),
+	)
+
+	cleanedCount := 0
+	for _, issue := range issues {
+		taskID := fmt.Sprintf("GH-%d", issue.Number)
+		if activeTaskIDs[taskID] {
+			c.logger.Debug("Closed issue has active execution, skipping",
+				slog.Int("issue", issue.Number),
+				slog.String("task_id", taskID),
+			)
+			continue
+		}
+
+		c.logger.Info("Removing pilot-in-progress from externally-closed issue",
+			slog.Int("issue", issue.Number),
+			slog.String("title", issue.Title),
+		)
+
+		if err := c.client.RemoveLabel(ctx, c.owner, c.repo, issue.Number, LabelInProgress); err != nil {
+			c.logger.Warn("Failed to remove pilot-in-progress from closed issue",
+				slog.Int("issue", issue.Number),
+				slog.Any("error", err),
+			)
+			continue
 		}
 
 		cleanedCount++

--- a/internal/adapters/github/cleanup_test.go
+++ b/internal/adapters/github/cleanup_test.go
@@ -248,8 +248,13 @@ func TestCleaner_Cleanup_RecentIssuesSkipped(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		// List issues endpoint
+		// List issues endpoint — only return the recent open issue for state=open
+		// queries. The closed-state scan (GH-2355) should receive an empty list.
 		if r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues" {
+			if r.URL.Query().Get("state") == StateClosed {
+				_ = json.NewEncoder(w).Encode([]*Issue{})
+				return
+			}
 			_ = json.NewEncoder(w).Encode(issues)
 			return
 		}
@@ -340,6 +345,140 @@ func TestCleaner_Cleanup_ActiveExecutionsSkipped(t *testing.T) {
 
 	if removeLabelCalled {
 		t.Error("RemoveLabel should NOT have been called for issue with active execution")
+	}
+}
+
+// TestCleaner_Cleanup_ClosedInProgressRemoved verifies GH-2355: closed issues
+// with pilot-in-progress label get the label cleared regardless of age.
+func TestCleaner_Cleanup_ClosedInProgressRemoved(t *testing.T) {
+	store := createTestStore(t)
+	defer func() { _ = store.Close() }()
+
+	// Issue updated 5 minutes ago — well under the 1h threshold. Would NOT be
+	// cleaned by the existing open-issue path. Should still be cleaned here
+	// because it's closed with pilot-in-progress.
+	recentTime := time.Now().Add(-5 * time.Minute)
+	closedIssues := []*Issue{
+		{
+			Number:    2348,
+			Title:     "Externally closed",
+			Labels:    []Label{{Name: LabelInProgress}},
+			UpdatedAt: recentTime,
+		},
+	}
+
+	var removeLabelCalled bool
+	var listClosedCalled bool
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues" {
+			if r.URL.Query().Get("state") == StateClosed {
+				listClosedCalled = true
+				_ = json.NewEncoder(w).Encode(closedIssues)
+				return
+			}
+			// Open-issue listings (called for in-progress + failed threshold paths)
+			_ = json.NewEncoder(w).Encode([]*Issue{})
+			return
+		}
+
+		if r.Method == http.MethodDelete && r.URL.Path == "/repos/owner/repo/issues/2348/labels/"+LabelInProgress {
+			removeLabelCalled = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
+		Enabled:   true,
+		Interval:  30 * time.Minute,
+		Threshold: 1 * time.Hour,
+	})
+
+	if err := cleaner.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if !listClosedCalled {
+		t.Error("expected ListIssues with state=closed to be called")
+	}
+	if !removeLabelCalled {
+		t.Error("expected RemoveLabel to be called for closed in-progress issue")
+	}
+}
+
+// TestCleaner_Cleanup_ClosedInProgressSkipsActive verifies that a closed issue
+// with an active execution is NOT touched — the worker may still be wrapping up.
+func TestCleaner_Cleanup_ClosedInProgressSkipsActive(t *testing.T) {
+	store := createTestStore(t)
+	defer func() { _ = store.Close() }()
+
+	exec := &memory.Execution{
+		ID:          "exec-2348",
+		TaskID:      "GH-2348",
+		ProjectPath: "/test/project",
+		Status:      "running",
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	closedIssues := []*Issue{
+		{
+			Number:    2348,
+			Title:     "Closed but active",
+			Labels:    []Label{{Name: LabelInProgress}},
+			UpdatedAt: time.Now(),
+		},
+	}
+
+	removeLabelCalled := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues" {
+			if r.URL.Query().Get("state") == StateClosed {
+				_ = json.NewEncoder(w).Encode(closedIssues)
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]*Issue{})
+			return
+		}
+
+		if r.Method == http.MethodDelete {
+			removeLabelCalled = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
+		Enabled:   true,
+		Interval:  30 * time.Minute,
+		Threshold: 1 * time.Hour,
+	})
+
+	if err := cleaner.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	if removeLabelCalled {
+		t.Error("RemoveLabel should NOT be called when an active execution exists")
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2355.

Closes #2355

## Changes

GitHub Issue #2355: fix(poller): clear pilot-in-progress label when issue is externally closed

## Symptom

When an issue with `pilot-in-progress` is closed externally (via `gh issue close`, GitHub UI, or any non-Pilot actor), the label is not removed. The issue stays CLOSED but keeps the label, producing contradictory state visible in Pilot dashboard and throwing off any label-based queries.

## Reproduction

1. Issue labeled `pilot` + `pilot-in-progress` (actively running)
2. Externally close the issue: `gh issue close <n>`
3. Pilot's poller or autopilot does NOT clear `pilot-in-progress`
4. Issue state: `CLOSED, labels=[pilot, pilot-in-progress]` — contradictory

## Observed today

GH-2348 and GH-2351 closed via `gh issue close`, both retained `pilot-in-progress`. Had to manually strip the label with `gh issue edit --remove-label`.

## Root cause hypothesis

Poller's reconciliation loop doesn't detect "issue closed while `pilot-in-progress`" as a stop condition. `checkForNewIssues` operates on open issues only (`state=OPEN`), so closed issues never re-enter the code paths that could clean labels.

## Fix

Add a periodic scan for issues that are CLOSED + have `pilot-in-progress`. For each:
1. If a running execution exists for that issue, cancel it (worker may be abandoned).
2. Remove `pilot-in-progress` label.

Alternatively: scan at Pilot startup as part of `ScanExistingPRs`-style reconciliation — find contradictory-state issues and clean labels.

Likely files:
- `internal/adapters/github/poller.go`
- `internal/autopilot/controller.go` (state reconciliation paths)

## Test plan

- Unit: simulate issue closed externally with `pilot-in-progress` set; assert next poll cycle removes the label
- Integration: open issue, let Pilot start executing, close via API, wait for next tick, assert label cleared

## Related

- Companion issue (filed): dashboard queue view includes closed issues with stale label
- Similar pattern to GH-1302 (stale `pilot-failed` on retry) — same class of label-hygiene gap