### PR TITLE
GH-2361: fix(doctor): warn when projects configured but no issue adapter enabled; fail start --github loudly

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -159,6 +159,14 @@ Examples:
 				return fmt.Errorf("failed to load config: %w", err)
 			}
 
+			// GH-2361: Fail loudly when an adapter flag is used but the
+			// corresponding adapter block is missing from config. Previously,
+			// `pilot start --github` would silently auto-enable a defaulted
+			// adapter with no token/repo and poll nothing.
+			if err := validateAdapterFlags(cfg, cmd); err != nil {
+				return err
+			}
+
 			// Apply flag overrides to config
 			applyInputOverrides(cfg, cmd, enableTelegram, enableGithub, enableLinear, enableSlack, enableTunnel, enablePlane, enableDiscord)
 
@@ -1114,6 +1122,39 @@ cmd.Flags().BoolVar(&dashboardMode, "dashboard", false, "Show TUI dashboard for 
 	cmd.Flags().StringVar(&logFormat, "log-format", "text", "Log output format: text or json (for log aggregation systems)")
 
 	return cmd
+}
+
+// validateAdapterFlags returns an error when an adapter flag is set but the
+// corresponding adapter block is missing or disabled in config. This prevents
+// `pilot start --github` from silently auto-enabling a blank adapter and
+// launching a no-op poller (GH-2361).
+func validateAdapterFlags(cfg *config.Config, cmd *cobra.Command) error {
+	type adapterCheck struct {
+		flag    string
+		enabled bool
+		exists  bool
+	}
+	adapters := []adapterCheck{
+		{"github", cfg.Adapters != nil && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled, cfg.Adapters != nil && cfg.Adapters.GitHub != nil},
+		{"linear", cfg.Adapters != nil && cfg.Adapters.Linear != nil && cfg.Adapters.Linear.Enabled, cfg.Adapters != nil && cfg.Adapters.Linear != nil},
+		{"plane", cfg.Adapters != nil && cfg.Adapters.Plane != nil && cfg.Adapters.Plane.Enabled, cfg.Adapters != nil && cfg.Adapters.Plane != nil},
+		{"discord", cfg.Adapters != nil && cfg.Adapters.Discord != nil && cfg.Adapters.Discord.Enabled, cfg.Adapters != nil && cfg.Adapters.Discord != nil},
+	}
+	for _, a := range adapters {
+		if !cmd.Flags().Changed(a.flag) {
+			continue
+		}
+		if a.enabled {
+			continue
+		}
+		if a.exists {
+			return fmt.Errorf("--%s flag set but adapters.%s.enabled is false in config.\nFix: set adapters.%s.enabled: true, or run 'pilot setup'",
+				a.flag, a.flag, a.flag)
+		}
+		return fmt.Errorf("--%s flag set but adapters.%s block is missing in config.\nFix: add adapters.%s block, or run 'pilot setup'",
+			a.flag, a.flag, a.flag)
+	}
+	return nil
 }
 
 // applyInputOverrides applies CLI flag overrides to config

--- a/cmd/pilot/validate_flags_test.go
+++ b/cmd/pilot/validate_flags_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/adapters/linear"
+	"github.com/qf-studio/pilot/internal/config"
+)
+
+// newTestStartCmd creates a start command and sets the given flag-name pairs
+// so cmd.Flags().Changed() reports them as set.
+func newTestStartCmd(t *testing.T, setFlags ...string) *cobra.Command {
+	t.Helper()
+	cmd := newStartCmd()
+	for _, name := range setFlags {
+		if err := cmd.Flags().Set(name, "true"); err != nil {
+			t.Fatalf("failed to set flag %q: %v", name, err)
+		}
+	}
+	return cmd
+}
+
+// GH-2361: --github with no adapter block must fail loudly.
+func TestValidateAdapterFlags_GithubMissingBlock(t *testing.T) {
+	cfg := &config.Config{
+		Projects: []*config.ProjectConfig{{Name: "myrepo", Path: "/tmp"}},
+		Adapters: &config.AdaptersConfig{},
+	}
+	cmd := newTestStartCmd(t, "github")
+
+	err := validateAdapterFlags(cfg, cmd)
+	if err == nil {
+		t.Fatal("expected error when --github set and adapter block missing")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "--github") || !strings.Contains(msg, "missing") {
+		t.Errorf("error = %q, want mention of --github and 'missing'", msg)
+	}
+}
+
+// GH-2361: --github with adapter block disabled must fail loudly.
+func TestValidateAdapterFlags_GithubDisabled(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: false},
+		},
+	}
+	cmd := newTestStartCmd(t, "github")
+
+	err := validateAdapterFlags(cfg, cmd)
+	if err == nil {
+		t.Fatal("expected error when --github set and adapter disabled")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "adapters.github.enabled is false") {
+		t.Errorf("error = %q, want mention of 'adapters.github.enabled is false'", msg)
+	}
+}
+
+// GH-2361: --github with adapter enabled passes validation.
+func TestValidateAdapterFlags_GithubEnabled(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: true},
+		},
+	}
+	cmd := newTestStartCmd(t, "github")
+
+	if err := validateAdapterFlags(cfg, cmd); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// No flags set → no validation failures even if all adapters absent.
+func TestValidateAdapterFlags_NoFlagsSet(t *testing.T) {
+	cfg := &config.Config{Adapters: &config.AdaptersConfig{}}
+	cmd := newStartCmd()
+
+	if err := validateAdapterFlags(cfg, cmd); err != nil {
+		t.Errorf("unexpected error when no adapter flags set: %v", err)
+	}
+}
+
+// GH-2361: --linear with adapter block disabled must fail loudly.
+func TestValidateAdapterFlags_LinearDisabled(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			Linear: &linear.Config{Enabled: false},
+		},
+	}
+	cmd := newTestStartCmd(t, "linear")
+
+	err := validateAdapterFlags(cfg, cmd)
+	if err == nil {
+		t.Fatal("expected error when --linear set and adapter disabled")
+	}
+	if !strings.Contains(err.Error(), "adapters.linear.enabled is false") {
+		t.Errorf("error = %q, want mention of 'adapters.linear.enabled is false'", err.Error())
+	}
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -260,6 +260,55 @@ func checkMacSleep() Check {
 	}
 }
 
+// issueSourceAdapters lists config paths to adapters that can ingest issues
+// for Pilot to execute. At least one must be enabled for the daemon to
+// actually pick up work — otherwise `pilot start` launches a no-op poller.
+func enabledIssueSources(cfg *config.Config) []string {
+	if cfg.Adapters == nil {
+		return nil
+	}
+	var enabled []string
+	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
+		enabled = append(enabled, "github")
+	}
+	if cfg.Adapters.GitLab != nil && cfg.Adapters.GitLab.Enabled {
+		enabled = append(enabled, "gitlab")
+	}
+	if cfg.Adapters.Linear != nil && cfg.Adapters.Linear.Enabled {
+		enabled = append(enabled, "linear")
+	}
+	if cfg.Adapters.Jira != nil && cfg.Adapters.Jira.Enabled {
+		enabled = append(enabled, "jira")
+	}
+	if cfg.Adapters.Asana != nil && cfg.Adapters.Asana.Enabled {
+		enabled = append(enabled, "asana")
+	}
+	if cfg.Adapters.AzureDevOps != nil && cfg.Adapters.AzureDevOps.Enabled {
+		enabled = append(enabled, "azure_devops")
+	}
+	if cfg.Adapters.Plane != nil && cfg.Adapters.Plane.Enabled {
+		enabled = append(enabled, "plane")
+	}
+	return enabled
+}
+
+func checkIssueSourceAdapter(cfg *config.Config) ConfigCheck {
+	enabled := enabledIssueSources(cfg)
+	if len(enabled) == 0 {
+		return ConfigCheck{
+			Name:    "adapters",
+			Status:  StatusWarning,
+			Message: "no issue source enabled",
+			Fix:     "Enable at least one of: github, gitlab, linear, jira, asana, azure_devops, plane. Run 'pilot setup'.",
+		}
+	}
+	return ConfigCheck{
+		Name:    "adapters",
+		Status:  StatusOK,
+		Message: strings.Join(enabled, ", "),
+	}
+}
+
 // checkConfig validates configuration
 func checkConfig(cfg *config.Config) []ConfigCheck {
 	checks := []ConfigCheck{}
@@ -335,6 +384,13 @@ func checkConfig(cfg *config.Config) []ConfigCheck {
 				Fix:     "Add xoxb-... token to config",
 			})
 		}
+	}
+
+	// Check that at least one issue-source adapter is enabled when projects
+	// are configured. Prevents silent "no poller running" when a user has
+	// `projects:` set but no `adapters:` block (GH-2361).
+	if len(cfg.Projects) > 0 {
+		checks = append(checks, checkIssueSourceAdapter(cfg))
 	}
 
 	// Check projects

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -270,6 +270,76 @@ func TestCheckConfig_InvalidProjectPath(t *testing.T) {
 	}
 }
 
+// GH-2361: warn when projects are configured but no issue-source adapter is enabled.
+func TestCheckConfig_Adapters_ProjectsButNoAdapter(t *testing.T) {
+	cfg := &config.Config{
+		Projects: []*config.ProjectConfig{
+			{Name: "myrepo", Path: os.TempDir()},
+		},
+	}
+	checks := checkConfig(cfg)
+
+	found := findConfigCheck(checks, "adapters")
+	if found == nil {
+		t.Fatal("expected 'adapters' check")
+	}
+	if found.Status != StatusWarning {
+		t.Errorf("adapters status = %v, want StatusWarning", found.Status)
+	}
+	if !strings.Contains(found.Message, "no issue source") {
+		t.Errorf("adapters message = %q, want mention of 'no issue source'", found.Message)
+	}
+}
+
+func TestCheckConfig_Adapters_GitHubEnabled(t *testing.T) {
+	cfg := &config.Config{
+		Projects: []*config.ProjectConfig{
+			{Name: "myrepo", Path: os.TempDir()},
+		},
+		Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: true, Token: "test-gh-token", Repo: "org/repo"},
+		},
+	}
+	checks := checkConfig(cfg)
+
+	found := findConfigCheck(checks, "adapters")
+	if found == nil {
+		t.Fatal("expected 'adapters' check")
+	}
+	if found.Status != StatusOK {
+		t.Errorf("adapters status = %v, want StatusOK", found.Status)
+	}
+}
+
+func TestCheckConfig_Adapters_GitHubPresentButDisabled(t *testing.T) {
+	cfg := &config.Config{
+		Projects: []*config.ProjectConfig{
+			{Name: "myrepo", Path: os.TempDir()},
+		},
+		Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: false},
+		},
+	}
+	checks := checkConfig(cfg)
+
+	found := findConfigCheck(checks, "adapters")
+	if found == nil {
+		t.Fatal("expected 'adapters' check")
+	}
+	if found.Status != StatusWarning {
+		t.Errorf("adapters status = %v, want StatusWarning", found.Status)
+	}
+}
+
+func TestCheckConfig_Adapters_NoProjectsSkipped(t *testing.T) {
+	cfg := &config.Config{}
+	checks := checkConfig(cfg)
+
+	if found := findConfigCheck(checks, "adapters"); found != nil {
+		t.Errorf("adapters check should not appear when no projects configured, got %+v", found)
+	}
+}
+
 func TestCheckConfig_TelegramEnabled_NoToken(t *testing.T) {
 	cfg := &config.Config{
 		Adapters: &config.AdaptersConfig{


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2361.

Closes #2361

## Changes

GitHub Issue #2361: fix(doctor): warn when projects configured but no issue adapter enabled; fail start --github loudly

## Context

Reporter of GH-2284 ran `pilot doctor` and saw "All systems operational!" — 4 projects configured, all green. Yet `pilot start --github --dashboard` never picked up any issue labeled `pilot`. Doctor failed to surface the actual problem.

Root cause: `pilot doctor` only reports GitHub-adapter status when `adapters.github.enabled: true` is set. If the adapter block is missing or disabled, doctor stays silent and `pilot start --github` quietly does nothing. Projects exist but no adapter polls them.

## Reproduction

```yaml
# ~/.pilot/config.yaml (minimal — what a user gets if they skip `pilot setup`/`pilot onboard`)
projects:
  - name: myrepo
    path: /Users/me/code/myrepo
# No `adapters:` block at all
```

```bash
pilot doctor       # → "All systems operational!" (wrong)
pilot start --github  # → dashboard launches, poller never runs, zero warnings
```

## Expected behaviour

1. **`pilot doctor`** must warn when projects are configured but **no** issue-source adapter is enabled (github/gitlab/linear/jira/asana/azuredevops/plane). Example:
   ```
   ⚠ adapters              no issue source enabled
                           → Enable at least one of: github, gitlab, linear, jira, asana. Run 'pilot setup'.
   ```
2. **`pilot start --github`** (and `--gitlab`, `--linear`, etc.) must fail loudly if the corresponding adapter is not enabled in config:
   ```
   Error: --github flag set but adapters.github.enabled is false in config.
   Fix: add adapters.github block, or run 'pilot setup'.
   ```
3. **Stretch (optional)**: detect orphan projects — projects that don't map to any enabled adapter (e.g., a project with `github.owner/repo` set but `adapters.github` disabled).

## Files

### Primary
- [internal/health/health.go:340-437](internal/health/health.go:340) — `checkConfig` function. Add a new `ConfigCheck` named `adapters` that enumerates issue-source adapters and returns `StatusWarning` when none are enabled.

### Secondary
- [cmd/pilot/main.go:299-311](cmd/pilot/main.go:299) — `--github` flag evaluation. When `githubFlagSet && !hasGithubPolling`, return a clear error instead of silently skipping. Same pattern for `--gitlab`, `--linear`, etc. if those flags exist.

### Tests
- `internal/health/health_test.go` — add cases: (a) projects configured + no adapters → warning; (b) projects + github adapter enabled → OK; (c) projects + github adapter disabled → warning.
- `cmd/pilot/main_test.go` or equivalent — test the `start --github` without adapter config returns non-zero exit + actionable message.

## Acceptance

```bash
# Repro case: projects but no adapters
pilot doctor
# → shows: ⚠ adapters  no issue source enabled

pilot start --github
# → exits 1 with: "Error: --github flag set but adapters.github.enabled is false in config..."
```

## Related

- GH-2284 (user impact — wasted 15 min waiting for a silent poller)

## Out of scope

- Actually *configuring* the adapter automatically. The fix is **detection + clear error**, not auto-repair.
