### PR TITLE
GH-2363: feat(autopilot): after 2nd conventional-commit rejection, post suggested rewrite + stop retrying

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -345,14 +345,21 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				}
 			}
 		} else if hr.Result != nil {
-			// result exists but Success is false - mark as failed
-			if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelFailed}); err != nil {
-				logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
-			}
-			syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Failed) // GH-1853
-			comment := buildFailureComment(hr.Result)
-			if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
-				logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
+			// GH-2363: Title-guard escalation already posted its own structured
+			// comment and added pilot-failed + pilot-title-rejected. Skip the
+			// generic failure-comment path to avoid duplicate noise.
+			if hr.Result.TitleRejected {
+				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Failed)
+			} else {
+				// result exists but Success is false - mark as failed
+				if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelFailed}); err != nil {
+					logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
+				}
+				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Failed) // GH-1853
+				comment := buildFailureComment(hr.Result)
+				if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
+					logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
+				}
 			}
 		}
 	}

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -1232,6 +1232,15 @@ func (p *Poller) shouldRetryFailedIssue(ctx context.Context, issue *Issue) bool 
 		return false
 	}
 
+	// GH-2363: Title-guard escalation explicitly halted retries. A human must
+	// edit the title and remove pilot-title-rejected before we try again.
+	if HasLabel(issue, LabelTitleRejected) {
+		p.logger.Info("Skipping retry — pilot-title-rejected set (GH-2363)",
+			slog.Int("number", issue.Number),
+		)
+		return false
+	}
+
 	p.mu.RLock()
 	retries := p.failedRetryCount[issue.Number]
 	p.mu.RUnlock()

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -94,7 +94,8 @@ const (
 	LabelInProgress = "pilot-in-progress"
 	LabelDone       = "pilot-done"
 	LabelFailed     = "pilot-failed"
-	LabelRetryReady = "pilot-retry-ready" // PR closed without merge, issue ready for retry
+	LabelRetryReady    = "pilot-retry-ready"    // PR closed without merge, issue ready for retry
+	LabelTitleRejected = "pilot-title-rejected" // GH-2363: title guard escalation; blocks auto-retry until human edits title
 )
 
 // Priority mapping from GitHub labels

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -243,6 +243,10 @@ type ExecutionResult struct {
 	// IntentWarning contains the reason if the intent judge flagged a mismatch.
 	// When set, the PR was created despite intent misalignment (after retry failed).
 	IntentWarning string
+	// TitleRejected indicates the task failed at the conventional-commit title
+	// guard and the runner has already posted a structured "how to fix" comment
+	// (GH-2363). Callers should skip their generic failure-comment path.
+	TitleRejected bool
 }
 
 // ProgressCallback is a function called during execution with progress updates.
@@ -357,6 +361,9 @@ type Runner struct {
 	knowledgeGraph       KnowledgeGraphRecorder         // Optional knowledge graph for cross-project learnings
 	// GH-2256: Dry-run mode to suppress real gh CLI calls (issue close/comment)
 	dryRun               bool
+	// GH-2363: Track consecutive title-rejection failures per issue so we stop
+	// retrying and post a helpful comment after the 2nd identical rejection.
+	titleRejections      *titleRejectionTracker
 }
 
 // NewRunner creates a new Runner instance with Claude Code backend by default.
@@ -373,6 +380,7 @@ func NewRunner() *Runner {
 		enableRecording:   true, // Recording enabled by default
 		modelRouter:       NewModelRouter(nil, nil),
 		signalParser:      NewSignalParser(log),
+		titleRejections:   newTitleRejectionTracker(),
 	}
 }
 
@@ -392,6 +400,7 @@ func NewRunnerWithBackend(backend Backend) *Runner {
 		enableRecording:   true,
 		modelRouter:       NewModelRouter(nil, nil),
 		signalParser:      NewSignalParser(log),
+		titleRejections:   newTitleRejectionTracker(),
 	}
 }
 
@@ -2753,8 +2762,34 @@ The previous execution completed but made no code changes. This task requires ac
 					slog.String("title", task.Title),
 					slog.Any("labels", task.Labels),
 				)
+
+				// GH-2363: On the 2nd consecutive rejection for this exact title,
+				// escalate with a structured comment + stop-retry labels so we
+				// don't spam the same failure every retry cycle.
+				if r.titleRejections != nil {
+					count := r.titleRejections.record(task.ID, task.Title)
+					if count >= titleRejectionMaxCount {
+						if err := r.postTitleRejectionEscalation(ctx, task); err != nil {
+							log.Warn("title-rejection escalation failed",
+								slog.String("task_id", task.ID),
+								slog.Any("error", err),
+							)
+						} else {
+							result.TitleRejected = true
+							log.Info("title-rejection escalated — posted guidance comment, stopping retries",
+								slog.String("task_id", task.ID),
+								slog.Int("count", count),
+							)
+						}
+					}
+				}
+
 				r.reportProgress(task.ID, "PR Failed", 100, result.Error)
 				return result, nil
+			}
+			// Title accepted — clear any prior rejection bookkeeping for this task.
+			if r.titleRejections != nil {
+				r.titleRejections.clear(task.ID)
 			}
 			prTitle := fmt.Sprintf("%s: %s", task.ID, normalizedTitle)
 

--- a/internal/executor/title_rejection.go
+++ b/internal/executor/title_rejection.go
@@ -1,0 +1,212 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"unicode"
+)
+
+// GH-2363: After the 2nd consecutive rejection for the same title, stop
+// retrying the issue and post a structured "how to fix" comment instead of
+// spamming the same "PR creation refused" error comment every retry.
+
+// titleRejectionMaxCount is the threshold at which Pilot emits the structured
+// comment + escalation labels. 2 means: first failure uses normal retry path,
+// second failure (same title) escalates.
+const titleRejectionMaxCount = 2
+
+// titleRejection tracks consecutive rejections for a single issue.
+type titleRejection struct {
+	hash  string // sha256 of the rejected title (hex)
+	count int    // consecutive rejections of that exact hash
+}
+
+// titleRejectionTracker is a process-local counter keyed by task ID.
+// Process restarts reset the counter — acceptable because the user still gets
+// at most a handful of redundant comments before the guard re-engages.
+type titleRejectionTracker struct {
+	mu   sync.Mutex
+	seen map[string]*titleRejection
+}
+
+func newTitleRejectionTracker() *titleRejectionTracker {
+	return &titleRejectionTracker{seen: make(map[string]*titleRejection)}
+}
+
+// record returns the updated consecutive-rejection count for taskID/title.
+// A different title resets the counter to 1.
+func (t *titleRejectionTracker) record(taskID, title string) int {
+	h := hashTitle(title)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	cur, ok := t.seen[taskID]
+	if !ok || cur.hash != h {
+		t.seen[taskID] = &titleRejection{hash: h, count: 1}
+		return 1
+	}
+	cur.count++
+	return cur.count
+}
+
+// clear drops any tracked rejection for taskID. Called on successful PR
+// creation so a future title change starts from a clean slate.
+func (t *titleRejectionTracker) clear(taskID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.seen, taskID)
+}
+
+func hashTitle(title string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(title)))
+	return hex.EncodeToString(sum[:])
+}
+
+// suggestConventionalTitle generates a best-effort conventional-commit rewrite
+// for a non-conventional title. Heuristic only — the human is expected to
+// refine it. Falls back to `chore(repo): <title>` when no signal is found.
+func suggestConventionalTitle(title string, labels []string) string {
+	trimmed := strings.TrimSpace(title)
+	if trimmed == "" {
+		return "chore: update repository"
+	}
+	// Strip any leading issue-id prefix the user may have typed (e.g. "GH-123: ")
+	trimmed = issuePrefixRegex.ReplaceAllString(trimmed, "")
+
+	// Prefer a label-derived prefix when available.
+	if prefixed, ok := autoPrefixTitle(trimmed, labels); ok {
+		return lowercaseFirstRune(prefixed)
+	}
+
+	// Heuristic: first verb in the title hints at the commit type.
+	first := strings.ToLower(firstWord(trimmed))
+	verbToType := map[string]string{
+		"fix":       "fix",
+		"fixes":     "fix",
+		"fixed":     "fix",
+		"bug":       "fix",
+		"add":       "feat",
+		"adds":      "feat",
+		"added":     "feat",
+		"implement": "feat",
+		"introduce": "feat",
+		"migrate":   "chore",
+		"rename":    "refactor",
+		"refactor":  "refactor",
+		"cleanup":   "chore",
+		"remove":    "chore",
+		"update":    "chore",
+		"document":  "docs",
+		"docs":      "docs",
+		"test":      "test",
+		"tests":     "test",
+	}
+	kind := verbToType[first]
+	if kind == "" {
+		kind = "chore"
+	}
+	return fmt.Sprintf("%s(repo): %s", kind, lowercaseFirstRune(trimmed))
+}
+
+func firstWord(s string) string {
+	s = strings.TrimSpace(s)
+	for i, r := range s {
+		if unicode.IsSpace(r) {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+func lowercaseFirstRune(s string) string {
+	if s == "" {
+		return s
+	}
+	runes := []rune(s)
+	runes[0] = unicode.ToLower(runes[0])
+	return string(runes)
+}
+
+// buildTitleRejectionComment renders the structured "how to fix" comment
+// posted on the 2nd consecutive rejection.
+func buildTitleRejectionComment(issueNumber int, title string, labels []string) string {
+	suggestion := suggestConventionalTitle(title, labels)
+	var b strings.Builder
+	fmt.Fprintf(&b, "⚠️ Pilot can't open a PR: this issue's title isn't a conventional commit.\n\n")
+	fmt.Fprintf(&b, "**Current title**: `%s`\n", strings.TrimSpace(title))
+	fmt.Fprintf(&b, "**Suggested rewrite**: `%s`\n\n", suggestion)
+	fmt.Fprintf(&b, "To re-dispatch, run:\n")
+	fmt.Fprintf(&b, "```\ngh issue edit %d --title %q --remove-label pilot-failed --remove-label pilot-title-rejected --add-label pilot-retry-ready\n```\n\n",
+		issueNumber, suggestion)
+	fmt.Fprintf(&b, "See the [Conventional Commits spec](https://www.conventionalcommits.org/) for the accepted format.\n")
+	return b.String()
+}
+
+// postTitleRejectionEscalation posts the structured comment and adds both
+// pilot-failed and pilot-title-rejected labels via the gh CLI. The latter
+// is read by the GitHub poller to block auto-retry until the title changes.
+//
+// Only runs for GitHub-sourced tasks; other adapters will fall through to
+// their normal failure path (which is already a one-shot label, not a loop).
+func (r *Runner) postTitleRejectionEscalation(ctx context.Context, task *Task) error {
+	if task.SourceAdapter != "" && task.SourceAdapter != "github" {
+		return nil
+	}
+	issueNum := strings.TrimPrefix(task.ID, "GH-")
+	if task.SourceIssueID != "" {
+		issueNum = task.SourceIssueID
+	}
+	if issueNum == "" {
+		return fmt.Errorf("no issue number for task %s", task.ID)
+	}
+	var parsed int
+	if _, err := fmt.Sscanf(issueNum, "%d", &parsed); err != nil || parsed <= 0 {
+		return fmt.Errorf("invalid issue number %q: %w", issueNum, err)
+	}
+	comment := buildTitleRejectionComment(parsed, task.Title, task.Labels)
+
+	if err := ghIssueComment(ctx, task.ProjectPath, issueNum, comment); err != nil {
+		return fmt.Errorf("post comment: %w", err)
+	}
+	// Both labels are best-effort; log but don't fail.
+	if err := ghAddLabels(ctx, task.ProjectPath, issueNum, []string{"pilot-failed", "pilot-title-rejected"}); err != nil {
+		r.log.Warn("title-rejection: failed to add labels",
+			"task_id", task.ID, "issue", issueNum, "error", err)
+	}
+	return nil
+}
+
+func ghIssueComment(ctx context.Context, dir, issueID, body string) error {
+	cmd := exec.CommandContext(ctx, "gh", "issue", "comment", issueID, "--body", body)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh issue comment: %w (stderr: %s)", err, stderr.String())
+	}
+	return nil
+}
+
+func ghAddLabels(ctx context.Context, dir, issueID string, labels []string) error {
+	args := []string{"issue", "edit", issueID}
+	for _, l := range labels {
+		args = append(args, "--add-label", l)
+	}
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh issue edit: %w (stderr: %s)", err, stderr.String())
+	}
+	return nil
+}

--- a/internal/executor/title_rejection_test.go
+++ b/internal/executor/title_rejection_test.go
@@ -1,0 +1,116 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTitleRejectionTracker_SameTitleIncrements(t *testing.T) {
+	tr := newTitleRejectionTracker()
+	if got := tr.record("GH-1", "bad title"); got != 1 {
+		t.Fatalf("first record = %d, want 1", got)
+	}
+	if got := tr.record("GH-1", "bad title"); got != 2 {
+		t.Fatalf("second record = %d, want 2", got)
+	}
+	if got := tr.record("GH-1", "bad title"); got != 3 {
+		t.Fatalf("third record = %d, want 3", got)
+	}
+}
+
+func TestTitleRejectionTracker_TitleChangeResets(t *testing.T) {
+	tr := newTitleRejectionTracker()
+	tr.record("GH-1", "bad title one")
+	tr.record("GH-1", "bad title one")
+	if got := tr.record("GH-1", "bad title two"); got != 1 {
+		t.Fatalf("title change record = %d, want 1 (reset)", got)
+	}
+}
+
+func TestTitleRejectionTracker_WhitespaceInsensitive(t *testing.T) {
+	tr := newTitleRejectionTracker()
+	tr.record("GH-1", "bad title")
+	if got := tr.record("GH-1", "  bad title  "); got != 2 {
+		t.Fatalf("whitespace-only diff record = %d, want 2", got)
+	}
+}
+
+func TestTitleRejectionTracker_Clear(t *testing.T) {
+	tr := newTitleRejectionTracker()
+	tr.record("GH-1", "bad title")
+	tr.clear("GH-1")
+	if got := tr.record("GH-1", "bad title"); got != 1 {
+		t.Fatalf("after clear, record = %d, want 1", got)
+	}
+}
+
+func TestTitleRejectionTracker_PerIssueIsolation(t *testing.T) {
+	tr := newTitleRejectionTracker()
+	tr.record("GH-1", "title a")
+	tr.record("GH-1", "title a")
+	if got := tr.record("GH-2", "title a"); got != 1 {
+		t.Fatalf("cross-issue record = %d, want 1", got)
+	}
+}
+
+func TestSuggestConventionalTitle(t *testing.T) {
+	tests := []struct {
+		name    string
+		title   string
+		labels  []string
+		wantPfx string // prefix we expect the suggestion to start with
+	}{
+		{"fix verb", "Fix null pointer in handler", nil, "fix"},
+		{"add verb", "Add rate limiting", nil, "feat(repo): "},
+		{"migrate verb", "Migrate alekspetrov/pilot references", nil, "chore(repo): "},
+		{"label bug", "improve validation", []string{"bug"}, "fix: "},
+		{"label enhancement", "retries", []string{"enhancement"}, "feat: "},
+		{"unknown verb falls back to chore", "xyzzy the thing", nil, "chore(repo): "},
+		{"empty title", "", nil, "chore"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := suggestConventionalTitle(tt.title, tt.labels)
+			if !strings.HasPrefix(got, tt.wantPfx) {
+				t.Fatalf("suggest(%q,%v) = %q, want prefix %q", tt.title, tt.labels, got, tt.wantPfx)
+			}
+			// The suggestion itself should satisfy the conventional-commit regex
+			// (otherwise we'd loop users back to the same error).
+			if tt.title != "" {
+				if err := validatePRTitle(got); err != nil {
+					t.Fatalf("suggestion %q does not pass validation: %v", got, err)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildTitleRejectionComment_ContainsKeyElements(t *testing.T) {
+	comment := buildTitleRejectionComment(2175, "Migrate all alekspetrov/pilot references to qf-studio/pilot", nil)
+
+	musts := []string{
+		"Pilot can't open a PR",
+		"Current title",
+		"Migrate all alekspetrov/pilot references to qf-studio/pilot",
+		"Suggested rewrite",
+		"gh issue edit 2175",
+		"--remove-label pilot-failed",
+		"--remove-label pilot-title-rejected",
+		"--add-label pilot-retry-ready",
+		"conventionalcommits.org",
+	}
+	for _, m := range musts {
+		if !strings.Contains(comment, m) {
+			t.Errorf("comment missing %q\n---\n%s", m, comment)
+		}
+	}
+}
+
+func TestHashTitle_StableAndTrimmed(t *testing.T) {
+	if hashTitle("hello") != hashTitle("  hello  ") {
+		t.Error("hashTitle should trim whitespace")
+	}
+	if hashTitle("hello") == hashTitle("Hello") {
+		t.Error("hashTitle should be case-sensitive")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2363.

Closes #2363

## Changes

GitHub Issue #2363: feat(autopilot): after 2nd conventional-commit rejection, post suggested rewrite + stop retrying

## Context

When autopilot's conventional-commit title guard (GH-2325) rejects an issue title, Pilot currently silently retries forever. GH-2175 got the same "execution failed: PR creation refused: title is not a conventional commit" comment **4 times in 12 minutes**, each failure burning a full Claude Code run, until a human renamed the title manually.

The failure message is identical each retry. The issue title never changes. There's no human-facing signal that intervention is required.

## Expected behaviour

After the **2nd** consecutive rejection for the same title:

1. **Stop retrying** (mark `pilot-failed` with a specific sub-label or comment flag).
2. **Post a single helpful comment** on the issue:
   - Quote the rejected title
   - Suggest a conventional-commit rewrite (e.g., LLM-generated or simple heuristic: `chore(repo): <original title lowercased, first-verb-normalized>`)
   - Give a copy-pasteable `gh issue edit` command
   - Link to the conventional-commits spec
3. **Do NOT post the same "PR creation refused" failure comment again** on this issue until the title changes.

Example comment:

> ⚠️ Pilot can't open a PR: this issue's title isn't a conventional-commit.
>
> **Current title**: `Migrate all alekspetrov/pilot references to qf-studio/pilot`
> **Suggested rewrite**: `chore(repo): migrate alekspetrov/pilot references to qf-studio/pilot`
>
> To re-dispatch, run:
> ```
> gh issue edit 2175 --title "chore(repo): migrate alekspetrov/pilot references to qf-studio/pilot" --remove-label pilot-failed --add-label pilot-retry-ready
> ```
>
> [Conventional Commits spec](https://www.conventionalcommits.org/)

## Implementation sketch

- Wherever the title-rejection path emits the "PR creation refused: title is not a conventional commit" error, check a per-issue counter (in memory or SQLite).
- On the 1st failure: emit the current retry behavior.
- On the 2nd failure for the same title (hash or exact-match): emit the structured comment above and add `pilot-failed`. Do not retry again until the title hash changes.
- Store the rejected-title hash on the issue to detect a rename.

## Files to investigate

- Search for the error string `"title is not a conventional commit"` to find the rejection site.
- Look at where `pilot-failed` is added (`cmd/pilot/handlers.go`, `internal/autopilot/controller.go`).
- Rejected-title memory could live on `internal/adapters/github/processed.go` (ProcessedStore) keyed by issue ID.

## Related

- GH-2325 — the title guard itself (already landed)
- GH-2175 — the incident that motivated this (4 retries, human intervention required)
