### PR TITLE
GH-2289: fix(jira): migrate search from removed /rest/api/2|3/search to /rest/api/3/search/jql

### DIFF
--- a/.agent/tasks/gh-2289.md
+++ b/.agent/tasks/gh-2289.md
@@ -1,0 +1,67 @@
+# GH-2289
+
+**Created:** 2026-04-18
+
+## Problem
+
+GitHub Issue #2289: fix(jira): migrate search from removed /rest/api/2|3/search to /rest/api/3/search/jql
+
+## Context
+
+Reported by @ashleyww93 ([original issue](https://github.com/qf-studio/pilot/issues/2289)). Jira polling fails with `status 410`:
+
+```
+API error (status 410): {"errorMessages":["The requested API has been removed.
+Please migrate to the /rest/api/3/search/jql API. A full migration guideline is
+available at https://developer.atlassian.com/changelog/#CHANGE-2046"]}
+```
+
+Atlassian removed the Cloud `/rest/api/3/search` (and v2 search) endpoints in May 2025. The replacement is `/rest/api/3/search/jql` with a different response shape (cursor-based pagination, `isLast`/`nextPageToken` instead of `startAt`).
+
+## Root cause
+
+`internal/adapters/jira/client.go:226` constructs requests as:
+
+```go
+path := fmt.Sprintf("/search?jql=%s&maxResults=%d", ...)
+```
+
+Combined with the API-version prefix at [client.go:43-45](internal/adapters/jira/client.go:43) (`/rest/api/3` for Cloud, `/rest/api/2` for Server/DC), this hits the removed Cloud endpoint.
+
+## Fix
+
+In [`internal/adapters/jira/client.go:220-226`](internal/adapters/jira/client.go:220) (`SearchIssues`):
+
+1. Detect whether the instance is Cloud (`*.atlassian.net` or explicitly configured):
+   - **Cloud** → use `/rest/api/3/search/jql` with `POST` (JQL + `fields` + `nextPageToken` in body)
+   - **Server/DC** → keep existing `/rest/api/2/search` with `GET` + query params (still supported on self-hosted)
+2. Update response parsing to handle the new Cloud shape:
+   - `issues` array → same
+   - Remove `total`, `startAt` dependencies (not returned on Cloud jql endpoint)
+   - Add `nextPageToken` handling if we need pagination (current code requests `maxResults=50` in one call — likely fine for now)
+3. Include explicit `fields` parameter in the POST body — the new endpoint doesn't return all fields by default.
+
+### API docs
+
+- [Atlassian changelog CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046)
+- [New `/rest/api/3/search/jql` endpoint](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post)
+
+## Files
+
+- [internal/adapters/jira/client.go:220-260](internal/adapters/jira/client.go:220) — `SearchIssues`
+- [internal/adapters/jira/client.go:212-218](internal/adapters/jira/client.go:212) — `SearchResponse` type
+- Tests in `internal/adapters/jira/client_test.go` — add case for the new endpoint shape
+
+## Acceptance
+
+- Unit test: mocked `POST /rest/api/3/search/jql` returning `{"issues":[...],"nextPageToken":null,"isLast":true}` → `SearchIssues` returns the issues.
+- Unit test: Server/DC instance URL still routes to `GET /rest/api/2/search`.
+- Integration: against a real Jira Cloud instance, polling no longer returns 410.
+
+## Related
+
+- Upstream bug: [GH-2289](https://github.com/qf-studio/pilot/issues/2289)
+
+
+## Acceptance Criteria
+

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-1607898525/pilot-bash-guard.sh"
+            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-4094032350/pilot-bash-guard.sh"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-1607898525/pilot-stop-gate.sh"
+            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-4094032350/pilot-stop-gate.sh"
           }
         ]
       }

--- a/internal/adapters/jira/client.go
+++ b/internal/adapters/jira/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -209,21 +210,50 @@ func (c *Client) GetProject(ctx context.Context, projectKey string) (*Project, e
 	return &project, nil
 }
 
-// SearchResponse represents the response from the search API
+// SearchResponse represents the response from the search API.
+// Server/DC returns Total/StartAt/MaxResults; Cloud /search/jql returns
+// NextPageToken/IsLast instead (the legacy fields are absent).
 type SearchResponse struct {
-	Issues     []*Issue `json:"issues"`
-	Total      int      `json:"total"`
-	StartAt    int      `json:"startAt"`
-	MaxResults int      `json:"maxResults"`
+	Issues        []*Issue `json:"issues"`
+	Total         int      `json:"total,omitempty"`
+	StartAt       int      `json:"startAt,omitempty"`
+	MaxResults    int      `json:"maxResults,omitempty"`
+	NextPageToken string   `json:"nextPageToken,omitempty"`
+	IsLast        bool     `json:"isLast,omitempty"`
 }
 
-// SearchIssues searches for issues using JQL
+// searchFields is the explicit field list requested from the Cloud
+// /rest/api/3/search/jql endpoint — it does not return all fields by default.
+var searchFields = []string{
+	"summary", "description", "issuetype", "status", "priority",
+	"labels", "assignee", "reporter", "project", "created", "updated",
+}
+
+// SearchIssues searches for issues using JQL.
+//
+// Atlassian removed the legacy /rest/api/3/search endpoint in May 2025
+// (CHANGE-2046). Cloud instances now use POST /rest/api/3/search/jql with
+// a JSON body and cursor-based pagination. Server/Data Center still
+// supports the legacy GET /rest/api/2/search.
 func (c *Client) SearchIssues(ctx context.Context, jql string, maxResults int) ([]*Issue, error) {
 	if maxResults <= 0 {
 		maxResults = 50
 	}
 
-	path := fmt.Sprintf("/search?jql=%s&maxResults=%d", strings.ReplaceAll(jql, " ", "+"), maxResults)
+	if c.platform == PlatformCloud {
+		reqBody := map[string]interface{}{
+			"jql":        jql,
+			"maxResults": maxResults,
+			"fields":     searchFields,
+		}
+		var resp SearchResponse
+		if err := c.doRequest(ctx, http.MethodPost, "/search/jql", reqBody, &resp); err != nil {
+			return nil, err
+		}
+		return resp.Issues, nil
+	}
+
+	path := fmt.Sprintf("/search?jql=%s&maxResults=%d", url.QueryEscape(jql), maxResults)
 	var resp SearchResponse
 	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
 		return nil, err

--- a/internal/adapters/jira/client_test.go
+++ b/internal/adapters/jira/client_test.go
@@ -334,6 +334,85 @@ func TestDoRequest_ErrorHandling(t *testing.T) {
 	}
 }
 
+func TestSearchIssues_Cloud_UsesJQLEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		if r.Body != nil {
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(SearchResponse{
+			Issues: []*Issue{
+				{Key: "TEST-1", Fields: Fields{Summary: "first"}},
+				{Key: "TEST-2", Fields: Fields{Summary: "second"}},
+			},
+			IsLast: true,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "api-token", PlatformCloud)
+	issues, err := client.SearchIssues(context.Background(), "labels = pilot", 50)
+	if err != nil {
+		t.Fatalf("SearchIssues failed: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotPath != "/rest/api/3/search/jql" {
+		t.Errorf("expected /rest/api/3/search/jql, got %s", gotPath)
+	}
+	if gotBody["jql"] != "labels = pilot" {
+		t.Errorf("expected jql in body, got %v", gotBody["jql"])
+	}
+	if _, ok := gotBody["fields"]; !ok {
+		t.Error("expected fields in body")
+	}
+	if len(issues) != 2 {
+		t.Errorf("expected 2 issues, got %d", len(issues))
+	}
+}
+
+func TestSearchIssues_Server_UsesLegacyEndpoint(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(SearchResponse{
+			Issues: []*Issue{{Key: "TEST-9", Fields: Fields{Summary: "dc"}}},
+			Total:  1,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "admin", "token", PlatformServer)
+	issues, err := client.SearchIssues(context.Background(), "labels = pilot", 25)
+	if err != nil {
+		t.Fatalf("SearchIssues failed: %v", err)
+	}
+
+	if gotMethod != http.MethodGet {
+		t.Errorf("expected GET, got %s", gotMethod)
+	}
+	if gotPath != "/rest/api/2/search" {
+		t.Errorf("expected /rest/api/2/search, got %s", gotPath)
+	}
+	if gotQuery == "" {
+		t.Error("expected query params on GET")
+	}
+	if len(issues) != 1 {
+		t.Errorf("expected 1 issue, got %d", len(issues))
+	}
+}
+
 // Integration test helper - verifies client can be created and method signatures are correct
 func TestClientMethodSignatures(t *testing.T) {
 	client := NewClient("https://jira.example.com", "user", "token", PlatformCloud)

--- a/internal/adapters/jira/poller_test.go
+++ b/internal/adapters/jira/poller_test.go
@@ -203,7 +203,7 @@ func TestPollerCheckForNewIssues(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		// Handle search request
-		if r.Method == http.MethodGet && r.URL.Path == "/rest/api/3/search" {
+		if r.Method == http.MethodPost && r.URL.Path == "/rest/api/3/search/jql" {
 			resp := SearchResponse{
 				Issues: []*Issue{
 					{
@@ -275,7 +275,7 @@ func TestPollerCheckForNewIssues_SkipsAlreadyProcessed(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		if r.Method == http.MethodGet && r.URL.Path == "/rest/api/3/search" {
+		if r.Method == http.MethodPost && r.URL.Path == "/rest/api/3/search/jql" {
 			resp := SearchResponse{
 				Issues: []*Issue{
 					{


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2289.

Closes #2289

## Changes

GitHub Issue #2289: fix(jira): migrate search from removed /rest/api/2|3/search to /rest/api/3/search/jql

## Context

Reported by @ashleyww93 ([original issue](https://github.com/qf-studio/pilot/issues/2289)). Jira polling fails with `status 410`:

```
API error (status 410): {"errorMessages":["The requested API has been removed.
Please migrate to the /rest/api/3/search/jql API. A full migration guideline is
available at https://developer.atlassian.com/changelog/#CHANGE-2046"]}
```

Atlassian removed the Cloud `/rest/api/3/search` (and v2 search) endpoints in May 2025. The replacement is `/rest/api/3/search/jql` with a different response shape (cursor-based pagination, `isLast`/`nextPageToken` instead of `startAt`).

## Root cause

`internal/adapters/jira/client.go:226` constructs requests as:

```go
path := fmt.Sprintf("/search?jql=%s&maxResults=%d", ...)
```

Combined with the API-version prefix at [client.go:43-45](internal/adapters/jira/client.go:43) (`/rest/api/3` for Cloud, `/rest/api/2` for Server/DC), this hits the removed Cloud endpoint.

## Fix

In [`internal/adapters/jira/client.go:220-226`](internal/adapters/jira/client.go:220) (`SearchIssues`):

1. Detect whether the instance is Cloud (`*.atlassian.net` or explicitly configured):
   - **Cloud** → use `/rest/api/3/search/jql` with `POST` (JQL + `fields` + `nextPageToken` in body)
   - **Server/DC** → keep existing `/rest/api/2/search` with `GET` + query params (still supported on self-hosted)
2. Update response parsing to handle the new Cloud shape:
   - `issues` array → same
   - Remove `total`, `startAt` dependencies (not returned on Cloud jql endpoint)
   - Add `nextPageToken` handling if we need pagination (current code requests `maxResults=50` in one call — likely fine for now)
3. Include explicit `fields` parameter in the POST body — the new endpoint doesn't return all fields by default.

### API docs

- [Atlassian changelog CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046)
- [New `/rest/api/3/search/jql` endpoint](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post)

## Files

- [internal/adapters/jira/client.go:220-260](internal/adapters/jira/client.go:220) — `SearchIssues`
- [internal/adapters/jira/client.go:212-218](internal/adapters/jira/client.go:212) — `SearchResponse` type
- Tests in `internal/adapters/jira/client_test.go` — add case for the new endpoint shape

## Acceptance

- Unit test: mocked `POST /rest/api/3/search/jql` returning `{"issues":[...],"nextPageToken":null,"isLast":true}` → `SearchIssues` returns the issues.
- Unit test: Server/DC instance URL still routes to `GET /rest/api/2/search`.
- Integration: against a real Jira Cloud instance, polling no longer returns 410.

## Related

- Upstream bug: [GH-2289](https://github.com/qf-studio/pilot/issues/2289)
