### PR TITLE
GH-2365: docs(site): refresh discord invite and bump header version to v2.95.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-BSL_1.1-blue.svg?style=flat-square" alt="License: BSL 1.1"></a>
   <a href="https://github.com/qf-studio/pilot/actions"><img src="https://github.com/qf-studio/pilot/workflows/CI/badge.svg?style=flat-square" alt="CI"></a>
   <a href="https://goreportcard.com/report/github.com/qf-studio/pilot"><img src="https://goreportcard.com/badge/github.com/qf-studio/pilot?style=flat-square" alt="Go Report Card"></a>
-  <a href="https://discord.gg/K6mM8TzJ"><img src="https://img.shields.io/badge/Discord-Join%20Chat-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://discord.gg/Hsz63MTB3c"><img src="https://img.shields.io/badge/Discord-Join%20Chat-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
 <p align="center">
@@ -29,7 +29,7 @@
   <a href="#how-it-works">How It Works</a> •
   <a href="#features">Features</a> •
   <a href="#cli-reference">CLI</a> •
-  <a href="https://discord.gg/K6mM8TzJ">Discord</a> •
+  <a href="https://discord.gg/Hsz63MTB3c">Discord</a> •
   <a href="docs/DEPLOYMENT.md">Deploy</a>
 </p>
 

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -45,11 +45,11 @@ export default async function RootLayout({
               logo={
                 <span style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
                   <img src="/logo.svg" alt="Pilot" height={24} style={{ height: 24, width: 'auto', alignSelf: 'center' }} />
-                  <span style={{ fontSize: '0.5em', opacity: 0.5, fontWeight: 400 }}>v2.76.0</span>
+                  <span style={{ fontSize: '0.5em', opacity: 0.5, fontWeight: 400 }}>v2.95.13</span>
                 </span>
               }
               projectLink="https://github.com/qf-studio/pilot"
-              chatLink="https://discord.gg/K6mM8TzJ"
+              chatLink="https://discord.gg/Hsz63MTB3c"
             />
           }
           pageMap={await getPageMap()}

--- a/docs/content/community.mdx
+++ b/docs/content/community.mdx
@@ -4,7 +4,7 @@ Pilot is source-available under [BSL 1.1](https://github.com/qf-studio/pilot/blo
 
 ## Get Involved
 
-- [Discord Server](https://discord.gg/K6mM8TzJ) — Chat with the community, get help, share feedback
+- [Discord Server](https://discord.gg/Hsz63MTB3c) — Chat with the community, get help, share feedback
 - [GitHub Repository](https://github.com/qf-studio/pilot) — Source code, issues, and releases
 - [Contributing Guide](https://github.com/qf-studio/pilot/blob/main/CONTRIBUTING.md) — Dev setup, code standards, PR process
 - [Report an Issue](https://github.com/qf-studio/pilot/issues/new) — Bug reports and feature requests


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2365.

Closes #2365

## Changes

GitHub Issue #2365: docs(site): refresh discord invite and bump header version to v2.95.13

## Context

Two user-visible issues with the public docs + README:

1. **Discord invite expired** (reported in GH-2285). Link currently points to `https://discord.gg/K6mM8TzJ` which is broken. New permanent invite: **`https://discord.gg/Hsz63MTB3c`**.

2. **Docs site header shows stale version `v2.76.0`** — current release is `v2.95.13` (19 versions behind). Visible to every docs visitor on `pilot.quantflow.studio`.

## Scope

### Discord link — replace in all 4 locations

| File | Line | Current |
|---|---|---|
| [README.md:21](README.md:21) | badge `<a href>` | `discord.gg/K6mM8TzJ` |
| [README.md:32](README.md:32) | footer link | `discord.gg/K6mM8TzJ` |
| [docs/app/layout.tsx:52](docs/app/layout.tsx:52) | `chatLink` prop | `discord.gg/K6mM8TzJ` |
| [docs/content/community.mdx:7](docs/content/community.mdx:7) | markdown link | `discord.gg/K6mM8TzJ` |

Replace all with: **`https://discord.gg/Hsz63MTB3c`**

### Version bump

[docs/app/layout.tsx:48](docs/app/layout.tsx:48):
```tsx
<span style={{ fontSize: '0.5em', opacity: 0.5, fontWeight: 400 }}>v2.76.0</span>
```

Bump to `v2.95.13`.

**Note:** other `v2.56.0` / `v2.76.0` references in `docs/content/**/*.mdx` are historical examples (CLI output samples, changelog mentions) — **leave those alone**. Only the site header badge is user-misleading.

## Acceptance

```bash
# No stale Discord invite anywhere
rg 'discord\.gg/K6mM8TzJ' --glob '!.git/**'
# → no output

# New invite present in the 4 expected locations
rg 'discord\.gg/Hsz63MTB3c' --glob '!.git/**' | wc -l
# → 4

# Site header shows current version
grep -n 'v2\.95\.13' docs/app/layout.tsx
# → line 48
```

Visual check after deploy: `pilot.quantflow.studio` header shows `v2.95.13`, Discord chat link resolves.

## Related

- [GH-2285](https://github.com/qf-studio/pilot/issues/2285) — original broken-link report (close after this ships)
