### PR TITLE
GH-2371: feat(executor): inject api_base_url/default_model/api_auth_token into Claude Code subprocess env (GH-2287 follow-up)

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -148,6 +148,14 @@ executor:
                                # When enabled with flag, skips branches and PRs, pushes directly to main
                                # Intended for users who rely on manual QA instead of code review
 
+  # Non-Anthropic provider routing (GH-2287, GH-2371)
+  # Configure once here — Pilot injects ANTHROPIC_BASE_URL/AUTH_TOKEN/MODEL
+  # into the Claude Code subprocess env, so ~/.claude/settings.json does not
+  # need to change. Leave these unset for default Anthropic behavior.
+  # api_base_url: "https://api.z.ai/api/anthropic"   # e.g. Z.AI GLM, OpenRouter Anthropic-compat
+  # api_auth_token: "${ZAI_API_KEY}"                  # ${ENV_VAR} is expanded on load
+  # default_model: "glm-4.6"                          # model name for the configured provider
+
   # Worktree isolation - execute tasks in temporary git worktree
   # use_worktree: false        # When true, creates isolated worktree per task
                                # Allows execution even with uncommitted changes in working directory

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -321,6 +321,15 @@ type BackendConfig struct {
 	// When empty, defaults to "https://api.anthropic.com".
 	APIBaseURL string `yaml:"api_base_url,omitempty"`
 
+	// APIAuthToken is the auth token for non-Anthropic providers (GH-2371).
+	// Supports ${ENV_VAR} expansion (via os.ExpandEnv during config load).
+	// When set together with APIBaseURL, Pilot injects ANTHROPIC_BASE_URL,
+	// ANTHROPIC_AUTH_TOKEN, and ANTHROPIC_MODEL into the Claude Code
+	// subprocess env so a single config drives both Pilot-internal HTTP calls
+	// and the CC subprocess. When empty, the CC subprocess uses its own auth
+	// (~/.claude/settings.json, ANTHROPIC_API_KEY, or CC OAuth).
+	APIAuthToken string `yaml:"api_auth_token,omitempty"`
+
 	// Version is the Pilot binary version, set at startup from the build-time version var.
 	// Used for feature matrix updates and execution reports. Not a config file field.
 	Version string `yaml:"-"`

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -210,6 +210,14 @@ type ClaudeCodeBackend struct {
 	config           *ClaudeCodeConfig
 	heartbeatTimeout time.Duration
 	log              *slog.Logger
+
+	// GH-2371: provider routing env vars injected into the subprocess.
+	// Sourced from BackendConfig.APIBaseURL / APIAuthToken / DefaultModel
+	// via the factory. Empty = preserve today's CC defaults (OAuth /
+	// ~/.claude/settings.json / ANTHROPIC_API_KEY).
+	apiBaseURL   string
+	apiAuthToken string
+	defaultModel string
 }
 
 // NewClaudeCodeBackend creates a new Claude Code backend.
@@ -230,6 +238,18 @@ func NewClaudeCodeBackend(config *ClaudeCodeConfig) *ClaudeCodeBackend {
 // SetHeartbeatTimeout sets a custom heartbeat timeout for this backend.
 func (b *ClaudeCodeBackend) SetHeartbeatTimeout(d time.Duration) {
 	b.heartbeatTimeout = d
+}
+
+// SetProviderEnv configures provider-routing env vars injected into the
+// Claude Code subprocess (GH-2371). When any value is non-empty, the
+// corresponding ANTHROPIC_* env var is appended to the subprocess env,
+// letting a single Pilot config route both Pilot-internal HTTP calls and
+// the CC subprocess to a non-Anthropic provider (Z.AI, OpenRouter, etc.).
+// All empty = today's behavior (CC uses its own auth).
+func (b *ClaudeCodeBackend) SetProviderEnv(baseURL, authToken, model string) {
+	b.apiBaseURL = baseURL
+	b.apiAuthToken = authToken
+	b.defaultModel = model
 }
 
 // Name returns the backend identifier.
@@ -326,6 +346,18 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 	// and auto-memory can detect this and skip Navigator-only "DO NOT write
 	// code" rules without relying on prompt-prefix heuristics.
 	env := append(os.Environ(), "PILOT_EXECUTOR=1")
+	// GH-2371: route the CC subprocess to the configured provider when set.
+	// Values are appended after os.Environ() so they win on Node's last-write
+	// lookup if the user's shell also exports ANTHROPIC_*.
+	if b.apiBaseURL != "" {
+		env = append(env, "ANTHROPIC_BASE_URL="+b.apiBaseURL)
+	}
+	if b.apiAuthToken != "" {
+		env = append(env, "ANTHROPIC_AUTH_TOKEN="+b.apiAuthToken)
+	}
+	if b.defaultModel != "" {
+		env = append(env, "ANTHROPIC_MODEL="+b.defaultModel)
+	}
 	// Pass context window and output token env vars if configured (GH-2163).
 	if b.config.Disable1MContext {
 		env = append(env, "CLAUDE_CODE_DISABLE_1M_CONTEXT=1")

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -876,3 +876,119 @@ func TestErrorTypeNoChanges(t *testing.T) {
 		t.Errorf("Error() = %q, want %q", got, "no_changes: refused: this task is out of scope")
 	}
 }
+
+// TestSetProviderEnv verifies the GH-2371 provider routing fields are stored
+// on the backend and surface in the subprocess env build. The env-build logic
+// in Execute() is mirrored here to avoid spawning a real claude CLI.
+func TestSetProviderEnv(t *testing.T) {
+	tests := []struct {
+		name              string
+		baseURL           string
+		authToken         string
+		model             string
+		expectContains    []string
+		expectNotContains []string
+	}{
+		{
+			name:              "all empty - no injection (Anthropic default)",
+			expectNotContains: []string{"ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL"},
+		},
+		{
+			name:              "base URL only",
+			baseURL:           "https://api.z.ai/api/anthropic",
+			expectContains:    []string{"ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic"},
+			expectNotContains: []string{"ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL"},
+		},
+		{
+			name:      "all three set (Z.AI)",
+			baseURL:   "https://api.z.ai/api/anthropic",
+			authToken: "zai-fake-token",
+			model:     "glm-4.6",
+			expectContains: []string{
+				"ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic",
+				"ANTHROPIC_AUTH_TOKEN=zai-fake-token",
+				"ANTHROPIC_MODEL=glm-4.6",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewClaudeCodeBackend(nil)
+			b.SetProviderEnv(tt.baseURL, tt.authToken, tt.model)
+
+			if b.apiBaseURL != tt.baseURL {
+				t.Errorf("apiBaseURL = %q, want %q", b.apiBaseURL, tt.baseURL)
+			}
+			if b.apiAuthToken != tt.authToken {
+				t.Errorf("apiAuthToken = %q, want %q", b.apiAuthToken, tt.authToken)
+			}
+			if b.defaultModel != tt.model {
+				t.Errorf("defaultModel = %q, want %q", b.defaultModel, tt.model)
+			}
+
+			// Mirror Execute()'s env-build logic.
+			env := []string{"PATH=/usr/bin", "PILOT_EXECUTOR=1"}
+			if b.apiBaseURL != "" {
+				env = append(env, "ANTHROPIC_BASE_URL="+b.apiBaseURL)
+			}
+			if b.apiAuthToken != "" {
+				env = append(env, "ANTHROPIC_AUTH_TOKEN="+b.apiAuthToken)
+			}
+			if b.defaultModel != "" {
+				env = append(env, "ANTHROPIC_MODEL="+b.defaultModel)
+			}
+
+			for _, want := range tt.expectContains {
+				found := false
+				for _, e := range env {
+					if e == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("env should contain %q, got %v", want, env)
+				}
+			}
+			for _, banned := range tt.expectNotContains {
+				for _, e := range env {
+					if len(e) >= len(banned) && e[:len(banned)] == banned {
+						t.Errorf("env should NOT contain prefix %q, got %v", banned, env)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestNewBackendWiresProviderEnv verifies the factory propagates
+// BackendConfig.{APIBaseURL,APIAuthToken,DefaultModel} onto the
+// ClaudeCodeBackend so users configure provider routing once (GH-2371).
+func TestNewBackendWiresProviderEnv(t *testing.T) {
+	cfg := &BackendConfig{
+		Type:         BackendTypeClaudeCode,
+		APIBaseURL:   "https://api.z.ai/api/anthropic",
+		APIAuthToken: "zai-fake-token",
+		DefaultModel: "glm-4.6",
+		ClaudeCode:   &ClaudeCodeConfig{Command: "claude"},
+	}
+
+	backend, err := NewBackend(cfg)
+	if err != nil {
+		t.Fatalf("NewBackend error: %v", err)
+	}
+	cc, ok := backend.(*ClaudeCodeBackend)
+	if !ok {
+		t.Fatalf("expected *ClaudeCodeBackend, got %T", backend)
+	}
+	if cc.apiBaseURL != cfg.APIBaseURL {
+		t.Errorf("apiBaseURL = %q, want %q", cc.apiBaseURL, cfg.APIBaseURL)
+	}
+	if cc.apiAuthToken != cfg.APIAuthToken {
+		t.Errorf("apiAuthToken = %q, want %q", cc.apiAuthToken, cfg.APIAuthToken)
+	}
+	if cc.defaultModel != cfg.DefaultModel {
+		t.Errorf("defaultModel = %q, want %q", cc.defaultModel, cfg.DefaultModel)
+	}
+}

--- a/internal/executor/backend_factory.go
+++ b/internal/executor/backend_factory.go
@@ -16,6 +16,11 @@ func NewBackend(config *BackendConfig) (Backend, error) {
 	case BackendTypeClaudeCode, "":
 		b := NewClaudeCodeBackend(config.ClaudeCode)
 		b.SetHeartbeatTimeout(heartbeatTimeout)
+		// GH-2371: single-source provider routing — inject configured
+		// api_base_url / api_auth_token / default_model into the CC
+		// subprocess env so users don't need to also edit
+		// ~/.claude/settings.json.
+		b.SetProviderEnv(config.APIBaseURL, config.APIAuthToken, config.DefaultModel)
 		return b, nil
 
 	case BackendTypeOpenCode:

--- a/internal/executor/backend_test.go
+++ b/internal/executor/backend_test.go
@@ -202,3 +202,18 @@ func TestResolveAPIBaseURL(t *testing.T) {
 		})
 	}
 }
+
+// TestBackendConfigAPIAuthToken covers the GH-2371 field: default empty,
+// and round-trips a plain value. Env expansion itself is done during
+// config.Load (os.ExpandEnv) — tested separately in internal/config.
+func TestBackendConfigAPIAuthToken(t *testing.T) {
+	var zero BackendConfig
+	if zero.APIAuthToken != "" {
+		t.Errorf("zero-value APIAuthToken = %q, want empty", zero.APIAuthToken)
+	}
+
+	cfg := &BackendConfig{APIAuthToken: "zai-fake-token"}
+	if cfg.APIAuthToken != "zai-fake-token" {
+		t.Errorf("APIAuthToken = %q, want %q", cfg.APIAuthToken, "zai-fake-token")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2371.

Closes #2371

## Changes

GitHub Issue #2371: feat(executor): inject api_base_url/default_model/api_auth_token into Claude Code subprocess env (GH-2287 follow-up)

## Context

GH-2287 added `executor.api_base_url` and `executor.default_model` to Pilot's YAML config so non-Anthropic providers (Z.AI/GLM, OpenRouter Anthropic-compat, LiteLLM, etc.) can be targeted from Pilot's own HTTP calls (effort classifier, intent judge, release summary).

**But the fix stopped halfway.** The main Claude Code subprocess — which does the actual code-writing — still reads its auth and endpoint from `os.Environ()` / `~/.claude/settings.json`. The commit message of GH-2287 even acknowledges this: *"main execution skips --model entirely, letting CC CLI use its own ANTHROPIC_MODEL from settings.json."*

Result: users wanting to route Pilot end-to-end at a non-Anthropic provider must configure it in **two places** (`~/.pilot/config.yaml` AND `~/.claude/settings.json`). This is confusing and error-prone — we stripped stale Z.AI config from `~/.claude/settings.json` last session precisely because the dual-config leads to mismatched state.

## Fix

Inject the CC subprocess's Anthropic env vars from Pilot's existing `executor.*` config, so users configure **one place**. Anthropic users (empty config) keep today's behavior exactly — fully backward-compatible.

### Config shape

```yaml
executor:
  type: "claude-code"
  api_base_url: "https://api.z.ai/api/anthropic"   # existing (GH-2287)
  default_model: "glm-4.6"                          # existing (GH-2287)
  api_auth_token: "${ZAI_API_KEY}"                  # NEW — expanded via os.ExpandEnv (already supported, config.go:425)
```

### Code changes

**1. Add field** — [internal/executor/backend.go:322](internal/executor/backend.go:322):

```go
// APIAuthToken is the auth token for non-Anthropic providers.
// Supports ${ENV_VAR} expansion. When empty, the CC subprocess uses its own
// auth (~/.claude/settings.json, ANTHROPIC_API_KEY, or CC OAuth).
APIAuthToken string `yaml:"api_auth_token,omitempty"`
```

**2. Inject into CC subprocess** — [internal/executor/backend_claudecode.go:328-336](internal/executor/backend_claudecode.go:328):

```go
env := append(os.Environ(), "PILOT_EXECUTOR=1")

// NEW — route subprocess to configured provider, when set
if b.config.APIBaseURL != "" {
    env = append(env, "ANTHROPIC_BASE_URL="+b.config.APIBaseURL)
}
if b.config.APIAuthToken != "" {
    env = append(env, "ANTHROPIC_AUTH_TOKEN="+b.config.APIAuthToken)
}
if b.config.DefaultModel != "" {
    env = append(env, "ANTHROPIC_MODEL="+b.config.DefaultModel)
}

// existing 1M-context / max-output-tokens injection...
if b.config.Disable1MContext { ... }
if b.config.MaxOutputTokens > 0 { ... }
cmd.Env = env
```

**3. Pilot-internal HTTP calls** — already covered by GH-2287's `ResolveAPIBaseURL()` / `ResolveModel()`. No change needed.

## Precedence / backward compat

| User type | `api_base_url` set? | Behavior |
|---|---|---|
| Anthropic (default) | no | No env injection. CC subprocess uses OAuth / `~/.claude/settings.json` / `ANTHROPIC_API_KEY` — exactly as today. |
| Non-Anthropic (Z.AI/GLM/etc.) | yes | Pilot injects `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_MODEL` into subprocess env. CC routes to the configured provider. |
| Dual-config (stale CC settings.json) | yes | Pilot-injected env vars take precedence because `cmd.Env` is built from `os.Environ()` + appends. Node's env lookup picks the last-appended value. **Verify this in tests** — if CC's lookup order reads settings.json *before* env, we'd need to either strip CC's settings or document the precedence explicitly. |

## Why a new field (not reuse `ANTHROPIC_AUTH_TOKEN` env directly)

- Declarative config (single file, no `export` in shell profile required)
- Per-project tokens via `${PROJECT_ZAI_KEY}` expansion
- Consistent with existing adapter convention (`adapters.github.token: "${GITHUB_TOKEN}"`)

## Tests

- [backend_test.go](internal/executor/backend_test.go): add cases for `APIAuthToken` field (expansion, empty default).
- [backend_claudecode_test.go](internal/executor/backend_claudecode_test.go): verify `cmd.Env` contains `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_MODEL` when config set; verify they're ABSENT when config empty.
- Integration: set a fake `api_base_url` + `api_auth_token` in test config → spawn CC subprocess with `--dry-run` or a mock backend → assert subprocess received expected env.

## Acceptance

```bash
# Z.AI user — no ~/.claude/settings.json changes needed
cat ~/.pilot/config.yaml
# executor:
#   type: "claude-code"
#   api_base_url: "https://api.z.ai/api/anthropic"
#   api_auth_token: "${ZAI_API_KEY}"
#   default_model: "glm-4.6"

export ZAI_API_KEY=...
pilot task 123    # CC subprocess hits Z.AI; Pilot's Go calls hit Z.AI; single source of truth
```

## Doc follow-up

- Update [configs/pilot.example.yaml](configs/pilot.example.yaml) with the new `api_auth_token` field and a non-Anthropic example.
- Update docs/integrations or getting-started section with the single-config pattern.
- Update [reply on GH-2285](https://github.com/qf-studio/pilot/issues/2285#issuecomment-4273534396) once shipped to recommend the single-place config instead of dual.

## Related

- GH-2287 — original non-Anthropic provider support (half-fix, Pilot-internal only)
- GH-2285 — user question about Anthropic-compatible endpoints that exposed the gap
