### PR TITLE
docs: sync version to v2.98.0

### DIFF
--- a/.agent/DEVELOPMENT-README.md
+++ b/.agent/DEVELOPMENT-README.md
@@ -123,7 +123,7 @@ Disable via config: `executor.navigator.auto_init: false`
 
 ## Current State
 
-**Current Version:** v2.53.0 | **316 features working**
+**Current Version:** v2.98.0 | **316 features working**
 
 **Full implementation status:** `.agent/system/FEATURE-MATRIX.md`
 

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-03-05 (v2.53.0)
+**Last Updated:** 2026-04-18 (v2.53.0)
 
 ## Legend
 

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -45,7 +45,7 @@ export default async function RootLayout({
               logo={
                 <span style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
                   <img src="/logo.svg" alt="Pilot" height={24} style={{ height: 24, width: 'auto', alignSelf: 'center' }} />
-                  <span style={{ fontSize: '0.5em', opacity: 0.5, fontWeight: 400 }}>v2.95.13</span>
+                  <span style={{ fontSize: '0.5em', opacity: 0.5, fontWeight: 400 }}>v2.98.0</span>
                 </span>
               }
               projectLink="https://github.com/qf-studio/pilot"


### PR DESCRIPTION
Manual PR — docs-version-sync.yml workflow blocked by repo setting 'Allow GitHub Actions to create and approve pull requests'.

Updates version references after v2.98.0 release:
- `.agent/DEVELOPMENT-README.md`
- `.agent/system/FEATURE-MATRIX.md`
- `docs/app/layout.tsx` (navbar version)

Merging will trigger `Sync Docs to GitLab` → pilot.quantflow.studio deploy.