### PR TITLE
refactor(autopilot): remove dead prod-X.Y.Z tag auto-push

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1389,7 +1389,7 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	)
 
 	// Create git tag in the correct repo
-	tagName, deployTag, err := c.releaser.CreateTagForRepo(ctx, owner, repo, prState, newVersion)
+	tagName, err := c.releaser.CreateTagForRepo(ctx, owner, repo, prState, newVersion)
 	if err != nil {
 		return fmt.Errorf("failed to create tag: %w", err)
 	}
@@ -1399,14 +1399,7 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		"pr", prState.PRNumber,
 		"version", prState.ReleaseVersion,
 		"tag", tagName,
-		"deploy_tag", deployTag,
 	)
-	if rel.DeployTagPrefix != "" && deployTag == "" {
-		c.log.Warn("deploy tag push failed; downstream deploy pipeline will not fire",
-			"pr", prState.PRNumber,
-			"prefix", rel.DeployTagPrefix,
-		)
-	}
 
 	// Enrich release with LLM-generated summary (best-effort, non-blocking).
 	// Runs in a goroutine because it polls for GoReleaser to publish the release

--- a/internal/autopilot/releaser.go
+++ b/internal/autopilot/releaser.go
@@ -258,35 +258,29 @@ func GenerateChangelog(commits []*github.Commit, prNumber int) string {
 // The actual GitHub Release (with binary assets) is created by GoReleaser CI
 // which triggers on tag push. This avoids the conflict where both Pilot and
 // GoReleaser try to create the same release.
-//
-// When config.DeployTagPrefix is non-empty, a second tag (e.g. "prod-X.Y.Z")
-// is also pushed at the same SHA to trigger downstream deploy pipelines that
-// watch a separate tag namespace (e.g. docs site). The deploy tag is
-// best-effort: a failure to create it does NOT fail the release. The returned
-// deployTag is empty when disabled or when the push failed.
-func (r *Releaser) CreateTag(ctx context.Context, prState *PRState, newVersion SemVer) (tagName, deployTag string, err error) {
-	return r.CreateTagForRepo(ctx, r.owner, r.repo, prState, newVersion)
+func (r *Releaser) CreateTag(ctx context.Context, prState *PRState, newVersion SemVer) (string, error) {
+	tagName := newVersion.String(r.config.TagPrefix)
+	sha := prState.HeadSHA
+
+	if err := r.ghClient.CreateGitTag(ctx, r.owner, r.repo, tagName, sha); err != nil {
+		return "", fmt.Errorf("failed to create tag %s: %w", tagName, err)
+	}
+
+	return tagName, nil
 }
 
 // CreateTagForRepo creates a lightweight git tag in the specified repository.
 // Used for cross-repo PRs where the tag should be created in the source repo,
 // not the default repo configured in the Releaser.
-func (r *Releaser) CreateTagForRepo(ctx context.Context, owner, repo string, prState *PRState, newVersion SemVer) (tagName, deployTag string, err error) {
-	tagName = newVersion.String(r.config.TagPrefix)
+func (r *Releaser) CreateTagForRepo(ctx context.Context, owner, repo string, prState *PRState, newVersion SemVer) (string, error) {
+	tagName := newVersion.String(r.config.TagPrefix)
 	sha := prState.HeadSHA
 
 	if err := r.ghClient.CreateGitTag(ctx, owner, repo, tagName, sha); err != nil {
-		return "", "", fmt.Errorf("failed to create tag %s: %w", tagName, err)
+		return "", fmt.Errorf("failed to create tag %s: %w", tagName, err)
 	}
 
-	if r.config.DeployTagPrefix != "" {
-		candidate := newVersion.String(r.config.DeployTagPrefix)
-		if deployErr := r.ghClient.CreateGitTag(ctx, owner, repo, candidate, sha); deployErr == nil {
-			deployTag = candidate
-		}
-	}
-
-	return tagName, deployTag, nil
+	return tagName, nil
 }
 
 // GetCurrentVersionForRepo gets the current version from the specified repository.

--- a/internal/autopilot/releaser_test.go
+++ b/internal/autopilot/releaser_test.go
@@ -499,7 +499,7 @@ func TestReleaser_CreateTag(t *testing.T) {
 	prState := &PRState{PRNumber: 42, HeadSHA: "abc123"}
 	newVersion := SemVer{Major: 1, Minor: 0, Patch: 0}
 
-	tagName, deployTag, err := r.CreateTag(context.Background(), prState, newVersion)
+	tagName, err := r.CreateTag(context.Background(), prState, newVersion)
 	if err != nil {
 		t.Fatalf("CreateTag() error = %v", err)
 	}
@@ -508,112 +508,12 @@ func TestReleaser_CreateTag(t *testing.T) {
 		t.Errorf("CreateTag() = %v, want v1.0.0", tagName)
 	}
 
-	if deployTag != "" {
-		t.Errorf("CreateTag() deployTag = %q, want empty (DeployTagPrefix not set)", deployTag)
-	}
-
 	if capturedBody["ref"] != "refs/tags/v1.0.0" {
 		t.Errorf("CreateTag() ref = %v, want refs/tags/v1.0.0", capturedBody["ref"])
 	}
 
 	if capturedBody["sha"] != "abc123" {
 		t.Errorf("CreateTag() sha = %v, want abc123", capturedBody["sha"])
-	}
-}
-
-func TestReleaser_CreateTag_PushesDeployTag(t *testing.T) {
-	var capturedRefs []string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/repos/owner/repo/git/refs" && r.Method == "POST" {
-			var body map[string]interface{}
-			_ = json.NewDecoder(r.Body).Decode(&body)
-			if ref, ok := body["ref"].(string); ok {
-				capturedRefs = append(capturedRefs, ref)
-			}
-			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"ref":    body["ref"],
-				"object": map[string]string{"sha": "abc123"},
-			})
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer server.Close()
-
-	client := github.NewClientWithBaseURL("test-token", server.URL)
-	config := &ReleaseConfig{
-		Enabled:         true,
-		Trigger:         "on_merge",
-		TagPrefix:       "v",
-		DeployTagPrefix: "prod-",
-	}
-	r := NewReleaser(client, "owner", "repo", config)
-
-	prState := &PRState{PRNumber: 42, HeadSHA: "abc123"}
-	newVersion := SemVer{Major: 1, Minor: 2, Patch: 3}
-
-	tagName, deployTag, err := r.CreateTag(context.Background(), prState, newVersion)
-	if err != nil {
-		t.Fatalf("CreateTag() error = %v", err)
-	}
-
-	if tagName != "v1.2.3" {
-		t.Errorf("tagName = %q, want v1.2.3", tagName)
-	}
-	if deployTag != "prod-1.2.3" {
-		t.Errorf("deployTag = %q, want prod-1.2.3", deployTag)
-	}
-
-	wantRefs := []string{"refs/tags/v1.2.3", "refs/tags/prod-1.2.3"}
-	if len(capturedRefs) != 2 ||
-		capturedRefs[0] != wantRefs[0] ||
-		capturedRefs[1] != wantRefs[1] {
-		t.Errorf("captured refs = %v, want %v", capturedRefs, wantRefs)
-	}
-}
-
-func TestReleaser_CreateTag_DeployTagFailureNonFatal(t *testing.T) {
-	calls := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/repos/owner/repo/git/refs" && r.Method == "POST" {
-			calls++
-			if calls == 1 {
-				w.WriteHeader(http.StatusCreated)
-				_, _ = w.Write([]byte(`{"ref":"refs/tags/v1.0.0","object":{"sha":"abc123"}}`))
-				return
-			}
-			// Second call (deploy tag) fails
-			w.WriteHeader(http.StatusUnprocessableEntity)
-			_, _ = w.Write([]byte(`{"message":"Reference already exists"}`))
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer server.Close()
-
-	client := github.NewClientWithBaseURL("test-token", server.URL)
-	config := &ReleaseConfig{
-		Enabled:         true,
-		Trigger:         "on_merge",
-		TagPrefix:       "v",
-		DeployTagPrefix: "prod-",
-	}
-	r := NewReleaser(client, "owner", "repo", config)
-
-	prState := &PRState{PRNumber: 42, HeadSHA: "abc123"}
-	newVersion := SemVer{Major: 1, Minor: 0, Patch: 0}
-
-	tagName, deployTag, err := r.CreateTag(context.Background(), prState, newVersion)
-	if err != nil {
-		t.Fatalf("CreateTag() error = %v, want nil (deploy tag failure must not fail release)", err)
-	}
-	if tagName != "v1.0.0" {
-		t.Errorf("tagName = %q, want v1.0.0", tagName)
-	}
-	if deployTag != "" {
-		t.Errorf("deployTag = %q, want empty on push failure", deployTag)
 	}
 }
 
@@ -641,7 +541,7 @@ func TestReleaser_CreateTagForRepo(t *testing.T) {
 	newVersion := SemVer{Major: 2, Minor: 0, Patch: 0}
 
 	// Call with a different owner/repo than the releaser default
-	tagName, _, err := r.CreateTagForRepo(context.Background(), "qf-studio", "auth-service", prState, newVersion)
+	tagName, err := r.CreateTagForRepo(context.Background(), "qf-studio", "auth-service", prState, newVersion)
 	if err != nil {
 		t.Fatalf("CreateTagForRepo() error = %v", err)
 	}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -330,11 +330,6 @@ type ReleaseConfig struct {
 	VersionStrategy string `yaml:"version_strategy"`
 	// TagPrefix is prepended to version (default "v").
 	TagPrefix string `yaml:"tag_prefix"`
-	// DeployTagPrefix is an optional secondary tag prefix pushed alongside
-	// TagPrefix at the same SHA. Used to trigger downstream pipelines that
-	// watch a different tag namespace (e.g. a docs deploy that fires on
-	// `prod-X.Y.Z`). Empty disables the secondary tag. Default "prod-".
-	DeployTagPrefix string `yaml:"deploy_tag_prefix"`
 	// GenerateChangelog enables changelog generation from commits.
 	GenerateChangelog bool `yaml:"generate_changelog"`
 	// NotifyOnRelease sends notification when release is created.
@@ -352,7 +347,6 @@ func DefaultReleaseConfig() *ReleaseConfig {
 		Trigger:           "on_merge",
 		VersionStrategy:   "conventional_commits",
 		TagPrefix:         "v",
-		DeployTagPrefix:   "prod-",
 		GenerateChangelog: true,
 		NotifyOnRelease:   true,
 		RequireCI:         true,


### PR DESCRIPTION
## Summary

Reverts PR #2370 (commit `02d258a5`). That change pushed a secondary `prod-X.Y.Z` tag to the Pilot GitHub repo on each release, claiming it would trigger docs deploy — but **no GitHub workflow listens for `prod-*` tags on this repo**.

The actual docs deploy pipeline (`.github/workflows/sync-docs.yml`) fires on push to `main` with `docs/**` changes, mirrors `docs/` to GitLab, and creates its own unique `prod-VERSION-TIMESTAMP` tag **there** (GitLab CI deploys pilot.quantflow.studio from it).

So the GitHub-side `prod-X.Y.Z` push was dead weight. Stale `prod-2.97.0` tag deleted from remote.

## Changes

- Revert `DeployTagPrefix` field on `ReleaseConfig`
- Revert signature change on `CreateTag` / `CreateTagForRepo` (back to single return)
- Revert controller wiring in `handleReleasing`
- Revert added tests (`CreateTag_PushesDeployTag`, `CreateTag_DeployTagFailureNonFatal`)
- Deleted `prod-2.97.0` tag from GitHub remote (manual, out-of-band)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/autopilot/...` passes
- [x] No behavior change to docs deploy (still driven by `sync-docs.yml`)

Closes #2374 (rework of #2369).