### PR TITLE
GH-2289: fix(jira): migrate search from removed /rest/api/2|3/search to /rest/api/3/search/jql

### DIFF
--- a/internal/adapters/jira/client.go
+++ b/internal/adapters/jira/client.go
@@ -209,18 +209,40 @@ func (c *Client) GetProject(ctx context.Context, projectKey string) (*Project, e
 	return &project, nil
 }
 
-// SearchResponse represents the response from the search API
+// SearchResponse represents the response from the legacy search API (Server/DC).
+// Cloud's /rest/api/3/search/jql returns a subset of these fields (no total/startAt).
 type SearchResponse struct {
-	Issues     []*Issue `json:"issues"`
-	Total      int      `json:"total"`
-	StartAt    int      `json:"startAt"`
-	MaxResults int      `json:"maxResults"`
+	Issues        []*Issue `json:"issues"`
+	Total         int      `json:"total,omitempty"`
+	StartAt       int      `json:"startAt,omitempty"`
+	MaxResults    int      `json:"maxResults,omitempty"`
+	NextPageToken string   `json:"nextPageToken,omitempty"`
+	IsLast        bool     `json:"isLast,omitempty"`
 }
 
-// SearchIssues searches for issues using JQL
+// SearchIssues searches for issues using JQL.
+//
+// Cloud uses POST /rest/api/3/search/jql (the legacy /search endpoint was removed
+// in May 2025 — see Atlassian changelog CHANGE-2046). Server/DC still uses the
+// legacy GET /rest/api/2/search endpoint.
 func (c *Client) SearchIssues(ctx context.Context, jql string, maxResults int) ([]*Issue, error) {
 	if maxResults <= 0 {
 		maxResults = 50
+	}
+
+	if c.platform == PlatformCloud {
+		reqBody := map[string]interface{}{
+			"jql":        jql,
+			"maxResults": maxResults,
+			// The new jql endpoint returns only id/key by default — request all
+			// fields to preserve prior behavior (summary/status/labels/etc).
+			"fields": []string{"*all"},
+		}
+		var resp SearchResponse
+		if err := c.doRequest(ctx, http.MethodPost, "/search/jql", reqBody, &resp); err != nil {
+			return nil, err
+		}
+		return resp.Issues, nil
 	}
 
 	path := fmt.Sprintf("/search?jql=%s&maxResults=%d", strings.ReplaceAll(jql, " ", "+"), maxResults)

--- a/internal/adapters/jira/client_test.go
+++ b/internal/adapters/jira/client_test.go
@@ -334,6 +334,83 @@ func TestDoRequest_ErrorHandling(t *testing.T) {
 	}
 }
 
+func TestSearchIssues_Cloud(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/rest/api/3/search/jql" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if body["jql"] != "labels = pilot" {
+			t.Errorf("unexpected jql: %v", body["jql"])
+		}
+		if _, ok := body["fields"]; !ok {
+			t.Error("expected fields in body")
+		}
+
+		resp := map[string]interface{}{
+			"issues": []Issue{
+				{ID: "10001", Key: "PROJ-1", Fields: Fields{Summary: "First"}},
+				{ID: "10002", Key: "PROJ-2", Fields: Fields{Summary: "Second"}},
+			},
+			"nextPageToken": nil,
+			"isLast":        true,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "api-token", PlatformCloud)
+	issues, err := client.SearchIssues(context.Background(), "labels = pilot", 50)
+	if err != nil {
+		t.Fatalf("SearchIssues failed: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+	if issues[0].Key != "PROJ-1" {
+		t.Errorf("expected first issue PROJ-1, got %s", issues[0].Key)
+	}
+}
+
+func TestSearchIssues_Server(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/rest/api/2/search" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("jql") == "" {
+			t.Error("expected jql query param")
+		}
+
+		resp := SearchResponse{
+			Issues: []*Issue{{ID: "10001", Key: "PROJ-1"}},
+			Total:  1,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "admin", "token", PlatformServer)
+	issues, err := client.SearchIssues(context.Background(), "labels = pilot", 50)
+	if err != nil {
+		t.Fatalf("SearchIssues failed: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+}
+
 // Integration test helper - verifies client can be created and method signatures are correct
 func TestClientMethodSignatures(t *testing.T) {
 	client := NewClient("https://jira.example.com", "user", "token", PlatformCloud)

--- a/internal/adapters/jira/poller_test.go
+++ b/internal/adapters/jira/poller_test.go
@@ -202,8 +202,8 @@ func TestPollerCheckForNewIssues(t *testing.T) {
 		requestCount++
 		w.Header().Set("Content-Type", "application/json")
 
-		// Handle search request
-		if r.Method == http.MethodGet && r.URL.Path == "/rest/api/3/search" {
+		// Handle search request (Cloud uses POST /search/jql since May 2025)
+		if r.Method == http.MethodPost && r.URL.Path == "/rest/api/3/search/jql" {
 			resp := SearchResponse{
 				Issues: []*Issue{
 					{
@@ -225,8 +225,7 @@ func TestPollerCheckForNewIssues(t *testing.T) {
 						},
 					},
 				},
-				Total:      2,
-				MaxResults: 50,
+				IsLast: true,
 			}
 			_ = json.NewEncoder(w).Encode(resp)
 			return
@@ -275,7 +274,7 @@ func TestPollerCheckForNewIssues_SkipsAlreadyProcessed(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		if r.Method == http.MethodGet && r.URL.Path == "/rest/api/3/search" {
+		if r.Method == http.MethodPost && r.URL.Path == "/rest/api/3/search/jql" {
 			resp := SearchResponse{
 				Issues: []*Issue{
 					{


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2289.

Closes #2289

## Changes

GitHub Issue #2289: fix(jira): migrate search from removed /rest/api/2|3/search to /rest/api/3/search/jql

## Context

Reported by @ashleyww93 ([original issue](https://github.com/qf-studio/pilot/issues/2289)). Jira polling fails with `status 410`:

```
API error (status 410): {"errorMessages":["The requested API has been removed.
Please migrate to the /rest/api/3/search/jql API. A full migration guideline is
available at https://developer.atlassian.com/changelog/#CHANGE-2046"]}
```

Atlassian removed the Cloud `/rest/api/3/search` (and v2 search) endpoints in May 2025. The replacement is `/rest/api/3/search/jql` with a different response shape (cursor-based pagination, `isLast`/`nextPageToken` instead of `startAt`).

## Root cause

`internal/adapters/jira/client.go:226` constructs requests as:

```go
path := fmt.Sprintf("/search?jql=%s&maxResults=%d", ...)
```

Combined with the API-version prefix at [client.go:43-45](internal/adapters/jira/client.go:43) (`/rest/api/3` for Cloud, `/rest/api/2` for Server/DC), this hits the removed Cloud endpoint.

## Fix

In [`internal/adapters/jira/client.go:220-226`](internal/adapters/jira/client.go:220) (`SearchIssues`):

1. Detect whether the instance is Cloud (`*.atlassian.net` or explicitly configured):
   - **Cloud** → use `/rest/api/3/search/jql` with `POST` (JQL + `fields` + `nextPageToken` in body)
   - **Server/DC** → keep existing `/rest/api/2/search` with `GET` + query params (still supported on self-hosted)
2. Update response parsing to handle the new Cloud shape:
   - `issues` array → same
   - Remove `total`, `startAt` dependencies (not returned on Cloud jql endpoint)
   - Add `nextPageToken` handling if we need pagination (current code requests `maxResults=50` in one call — likely fine for now)
3. Include explicit `fields` parameter in the POST body — the new endpoint doesn't return all fields by default.

### API docs

- [Atlassian changelog CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046)
- [New `/rest/api/3/search/jql` endpoint](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post)

## Files

- [internal/adapters/jira/client.go:220-260](internal/adapters/jira/client.go:220) — `SearchIssues`
- [internal/adapters/jira/client.go:212-218](internal/adapters/jira/client.go:212) — `SearchResponse` type
- Tests in `internal/adapters/jira/client_test.go` — add case for the new endpoint shape

## Acceptance

- Unit test: mocked `POST /rest/api/3/search/jql` returning `{"issues":[...],"nextPageToken":null,"isLast":true}` → `SearchIssues` returns the issues.
- Unit test: Server/DC instance URL still routes to `GET /rest/api/2/search`.
- Integration: against a real Jira Cloud instance, polling no longer returns 410.

## Related

- Upstream bug: [GH-2289](https://github.com/qf-studio/pilot/issues/2289)
