### PR TITLE
GH-2377: fix(executor): self-review --resume fallback + sanitize marker filename path separators

### DIFF
--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -149,8 +149,11 @@ func classifyClaudeCodeError(stderr string, originalErr error) *ClaudeCodeError 
 	}
 
 	// Session not found (GH-1267: --from-pr or --resume failed)
+	// GH-2377: include "no conversation found" — CC emits this exact phrase
+	// when --resume targets an evicted/expired session ID.
 	if strings.Contains(stderrLower, "session not found") ||
 		strings.Contains(stderrLower, "no session") ||
+		strings.Contains(stderrLower, "no conversation found") ||
 		strings.Contains(stderrLower, "session expired") ||
 		strings.Contains(stderrLower, "could not find session") ||
 		strings.Contains(stderrLower, "invalid session") {
@@ -277,6 +280,21 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, opts ExecuteOptions) (*
 			)
 			// Retry without --from-pr
 			return b.executeWithFromPR(ctx, opts, false)
+		}
+	}
+
+	// GH-2377: Fallback if --resume fails with session not found.
+	// Self-review reuses the main-execution session ID to save tokens
+	// (GH-1265); when CC has evicted that session, drop --resume and
+	// run a fresh session rather than silently skipping self-review.
+	if err != nil && opts.ResumeSessionID != "" {
+		if ccErr, ok := err.(*ClaudeCodeError); ok && ccErr.Type == ErrorTypeSessionNotFound {
+			b.log.Warn("Session not found for --resume, retrying without it",
+				slog.String("session_id", opts.ResumeSessionID),
+				slog.String("error", ccErr.Message),
+			)
+			opts.ResumeSessionID = ""
+			return b.Execute(ctx, opts)
 		}
 	}
 

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -3,8 +3,10 @@ package executor
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -480,6 +482,19 @@ func TestClassifyClaudeCodeError(t *testing.T) {
 			name:       "timeout - killed",
 			stderr:     "signal: killed",
 			expectType: ErrorTypeTimeout,
+		},
+		{
+			// GH-2377: CC emits "No conversation found with session ID: <uuid>"
+			// when --resume targets an evicted session. Must classify as
+			// session_not_found so the --resume fallback triggers.
+			name:       "session not found - no conversation found",
+			stderr:     "No conversation found with session ID: 723e1e6e-0253-45ae-a7e4-e79112d73deb",
+			expectType: ErrorTypeSessionNotFound,
+		},
+		{
+			name:       "session not found - classic phrasing",
+			stderr:     "Error: session not found",
+			expectType: ErrorTypeSessionNotFound,
 		},
 		{
 			name:       "unknown error",
@@ -990,5 +1005,69 @@ func TestNewBackendWiresProviderEnv(t *testing.T) {
 	}
 	if cc.defaultModel != cfg.DefaultModel {
 		t.Errorf("defaultModel = %q, want %q", cc.defaultModel, cfg.DefaultModel)
+	}
+}
+
+// TestClaudeCodeBackendResumeSessionFallback verifies the GH-2377 fix:
+// when Execute is called with ResumeSessionID set and the CLI exits with a
+// "session not found" stderr, the backend retries Execute without --resume.
+//
+// Strategy: install a tiny shell script as the "claude" command that writes
+// its full argv to a counter file, then exits with different stderr on the
+// first vs second invocation. If the fallback fires, we expect exactly 2
+// invocations — the first containing "--resume" and the second not.
+func TestClaudeCodeBackendResumeSessionFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-CLI test relies on shell scripts; skipping on windows")
+	}
+
+	tmpDir := t.TempDir()
+	logFile := tmpDir + "/calls.log"
+	script := tmpDir + "/fake-claude"
+
+	// Script logs argv and exits with different stderr based on call count.
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> ` + logFile + `
+COUNT=$(wc -l < ` + logFile + ` | tr -d ' ')
+if [ "$COUNT" = "1" ]; then
+  echo "No conversation found with session ID: abc-123" >&2
+  exit 1
+fi
+echo "fake retry stderr" >&2
+exit 2
+`
+	if err := os.WriteFile(script, []byte(body), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	backend := NewClaudeCodeBackend(&ClaudeCodeConfig{Command: script})
+	opts := ExecuteOptions{
+		Prompt:          "hello",
+		ProjectPath:     tmpDir,
+		ResumeSessionID: "abc-123",
+		EventHandler:    func(BackendEvent) {},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := backend.Execute(ctx, opts)
+	if err == nil {
+		t.Fatal("expected error from fake CLI, got nil")
+	}
+
+	// Verify exactly 2 invocations and --resume dropped on retry.
+	data, readErr := os.ReadFile(logFile)
+	if readErr != nil {
+		t.Fatalf("read log: %v", readErr)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 CLI invocations, got %d: %q", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "--resume") || !strings.Contains(lines[0], "abc-123") {
+		t.Errorf("first invocation missing --resume: %q", lines[0])
+	}
+	if strings.Contains(lines[1], "--resume") {
+		t.Errorf("second invocation should not contain --resume: %q", lines[1])
 	}
 }

--- a/internal/executor/docs.go
+++ b/internal/executor/docs.go
@@ -61,8 +61,21 @@ func formatTaskDoc(task *Task) string {
 	return sb.String()
 }
 
+// sanitizeFilename converts a human title into a path-safe filename fragment.
+// GH-2377: previously only lowercased + replaced spaces, so titles containing
+// "/", ":", "|" (common in REST-path or pipe-delimited titles) leaked into
+// os.WriteFile and were interpreted as subdirectories, failing marker writes.
 func sanitizeFilename(s string) string {
-	return strings.ReplaceAll(strings.ToLower(s), " ", "-")
+	s = strings.ToLower(s)
+	unsafe := []string{"/", "\\", ":", "|", "<", ">", "?", "*", "\""}
+	for _, c := range unsafe {
+		s = strings.ReplaceAll(s, c, "-")
+	}
+	s = strings.ReplaceAll(s, " ", "-")
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+	return strings.Trim(s, "-")
 }
 
 // UpdateFeatureMatrix appends a new feature row to .agent/system/FEATURE-MATRIX.md

--- a/internal/executor/docs_test.go
+++ b/internal/executor/docs_test.go
@@ -175,3 +175,38 @@ func TestExtractFeatureName(t *testing.T) {
 		})
 	}
 }
+
+// TestSanitizeFilename verifies GH-2377 fix: titles containing path
+// separators (/, \) and other filesystem-unsafe chars (:|<>?*") must not
+// leak into os.WriteFile paths as subdirectory traversals.
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"spaces lowercased", "Hello World", "hello-world"},
+		{"forward slash", "fix(jira): migrate /rest/api/2 to /rest/api/3", "fix(jira)-migrate-rest-api-2-to-rest-api-3"},
+		{"pipe and slash", "fix: /rest/api/2|3/search", "fix-rest-api-2-3-search"},
+		{"colon", "task: do a thing", "task-do-a-thing"},
+		{"backslash", "path\\to\\thing", "path-to-thing"},
+		{"angle brackets", "<foo> vs <bar>", "foo-vs-bar"},
+		{"question mark and star", "what? *now*", "what-now"},
+		{"quote", `say "hi"`, "say-hi"},
+		{"trim leading trailing dashes", "/leading/", "leading"},
+		{"collapse consecutive dashes", "a // b", "a-b"},
+		{"plain simple", "simple-id", "simple-id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeFilename(tt.input)
+			if got != tt.expected {
+				t.Errorf("sanitizeFilename(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+			if strings.ContainsAny(got, `/\:|<>?*"`) {
+				t.Errorf("sanitizeFilename(%q) = %q still contains unsafe chars", tt.input, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2377.

Closes #2377

## Changes

GitHub Issue #2377: fix(executor): self-review --resume fallback + sanitize marker filename path separators

Two related warnings surfaced during GH-2289 execution (PR #2376). Both are low-impact but real bugs in the post-execution pipeline.

## Bug 1: self-review skipped when session expires

### Symptom
\`\`\`
level=WARN msg="Claude Code execution failed" component=executor.claudecode error_type=unknown message="exit status 1" stderr="No conversation found with session ID: 723e1e6e-0253-45ae-a7e4-e79112d73deb"
level=WARN msg="Self-review execution failed" ... error="unknown: exit status 1 (stderr: No conversation found with session ID: ...)"
\`\`\`

Self-review uses \`--resume\` with the session ID from the main execution ([GH-1265](https://github.com/qf-studio/pilot/issues/1265), ~40% token savings). When Claude Code has cleaned up the session (e.g., longer-running task, CC cache eviction), \`--resume\` fails and self-review is silently skipped entirely — we lose the self-review quality gate AND the warning gets logged as \`error_type=unknown\` (it's actually \`session_not_found\`).

### Root cause
[\`internal/executor/backend_claudecode.go:240-247\`](internal/executor/backend_claudecode.go) has a fallback for \`ErrorTypeSessionNotFound\` — but only when \`opts.FromPR > 0\` (the PR-context path). There is no analogous fallback for \`opts.ResumeSessionID != ""\` (the self-review path).

The Qwen backend already has the right pattern at [\`internal/executor/backend_qwencode.go:482-486\`](internal/executor/backend_qwencode.go):
\`\`\`go
if qcErr.Type == QwenErrorTypeSessionNotFound && opts.ResumeSessionID != "" {
    b.log.Warn("qwen-code: session not found, retrying without --resume",
        "session_id", opts.ResumeSessionID)
    opts.ResumeSessionID = ""
    return b.Execute(ctx, opts)
}
\`\`\`

### Fix
Mirror the Qwen fallback in \`backend_claudecode.go\`. After the existing \`--from-pr\` retry block (around line 247), add:

\`\`\`go
if err != nil && opts.ResumeSessionID != "" {
    if ccErr, ok := err.(*ClaudeCodeError); ok && ccErr.Type == ErrorTypeSessionNotFound {
        b.log.Warn("Session not found for --resume, retrying without it",
            slog.String("session_id", opts.ResumeSessionID),
            slog.String("error", ccErr.Message),
        )
        opts.ResumeSessionID = ""
        return b.Execute(ctx, opts)
    }
}
\`\`\`

Also: log-level should be \`Warn\` with \`error_type=session_not_found\`, not \`Warn\` with \`error_type=unknown\` — verify classifier hits the right branch first.

## Bug 2: completion marker write fails on task titles containing \`/\`

### Symptom
\`\`\`
level=WARN msg="Failed to create completion marker" ... error="open /var/folders/.../pilot-worktree-GH-2289-.../.agent/.context-markers/2026-04-18-1811_task-completed:-fix(jira):-migrate-search-from-removed-/rest/api/2|3/search-to-/rest/api/3/search/jql.md: no such file or directory"
\`\`\`

### Root cause
[\`internal/executor/docs.go:64-66\`](internal/executor/docs.go):

\`\`\`go
func sanitizeFilename(s string) string {
    return strings.ReplaceAll(strings.ToLower(s), " ", "-")
}
\`\`\`

Only lowercases and replaces spaces. Forward slashes in task descriptions (common in titles mentioning REST paths, file paths, etc.) survive into filenames, so \`os.WriteFile\` in \`markers.go:CreateMarker\` interprets them as subdirectories and fails.

### Fix
Strip or replace filesystem-unsafe characters. Suggested replacement list: \`/\`, \`\\\`, \`:\`, \`|\`, \`<\`, \`>\`, \`?\`, \`*\`, \`\"\`. Use \`-\` as the replacement:

\`\`\`go
func sanitizeFilename(s string) string {
    s = strings.ToLower(s)
    unsafe := []string{"/", "\\\\", ":", "|", "<", ">", "?", "*", \"\\\"\"}
    for _, c := range unsafe {
        s = strings.ReplaceAll(s, c, "-")
    }
    s = strings.ReplaceAll(s, " ", "-")
    // Collapse multiple dashes
    for strings.Contains(s, "--") {
        s = strings.ReplaceAll(s, "--", "-")
    }
    return strings.Trim(s, "-")
}
\`\`\`

Verify this is safe for other callers — \`sanitizeFilename\` is also used for archived task docs (\`ArchiveTaskDoc\` flow in \`docs.go\`).

## Acceptance criteria

- [ ] \`backend_claudecode.go\`: add \`--resume\` fallback mirroring Qwen logic
- [ ] \`backend_claudecode_test.go\`: add test covering session-not-found retry when \`ResumeSessionID\` is set
- [ ] \`docs.go\`: \`sanitizeFilename\` strips \`/ \\\\ : | < > ? * \"\` and collapses consecutive dashes
- [ ] \`docs_test.go\` (or equivalent): add cases for titles containing \`/\`, \`:\`, \`|\`
- [ ] Verify no regression in \`ArchiveTaskDoc\` filename generation

## Files to touch

- \`internal/executor/backend_claudecode.go\` (add fallback block)
- \`internal/executor/backend_claudecode_test.go\` (test)
- \`internal/executor/docs.go\` (sanitizer)
- related test file for docs.go