### PR TITLE
GH-2379: docs(nav): bring .agent/DEVELOPMENT-README.md current to v2.99.1

### DIFF
--- a/.agent/DEVELOPMENT-README.md
+++ b/.agent/DEVELOPMENT-README.md
@@ -123,7 +123,7 @@ Disable via config: `executor.navigator.auto_init: false`
 
 ## Current State
 
-**Current Version:** v2.98.0 | **316 features working**
+**Current Version:** v2.99.1 | **319 features working**
 
 **Full implementation status:** `.agent/system/FEATURE-MATRIX.md`
 
@@ -393,6 +393,32 @@ Nextra 4 migration (PR #1409) + 8 docs pages covering all 156 features:
 ---
 
 ## Completed Log
+
+### 2026-04-18
+
+| Item | What |
+|------|------|
+| **v2.99.1** | `fix(executor)`: self-review `--resume` fallback mirrors Qwen logic + `sanitizeFilename` strips path separators (GH-2377, PR #2378) |
+| **v2.99.0** | `refactor(autopilot)`: remove dead `prod-X.Y.Z` tag auto-push — `sync-docs.yml` already handles GitLab deploy (GH-2374, PR #2375 reverts #2370) |
+| **v2.98.1 / v2.98.0** | Executor env injection of `api_base_url`/`default_model`/`api_auth_token` into Claude Code subprocess (GH-2287/GH-2371); `default_branch` honored (GH-2286); conventional-commit rewrite suggestion after 2nd reject; docs version sync unblocked manually via [PR #2373](https://github.com/qf-studio/pilot/pull/2373) (GitHub Actions lacks PR-create permission at repo level) |
+| **Jira search migration** | GH-2289 deprecated `/rest/api/2|3/search` → `/rest/api/3/search/jql` (PR #2376, ghost-abandoned on first retry then recovered via escape-hatch dispatch) |
+| **Known gotcha** | `docs-version-sync.yml` can't auto-PR after release — `GITHUB_TOKEN` lacks PR-create permission (repo Settings toggle required) |
+| **Reverted premise** | [PR #2370](https://github.com/qf-studio/pilot/pull/2370) shipped on a wrong assumption: `prod-X.Y.Z` GitHub tags trigger nothing — deploy lives in `sync-docs.yml`'s tag-push to GitLab. v2.99.0 reverts. |
+
+### 2026-04 (between 2026-03-13 and 2026-04-17)
+
+| Cluster | Highlights |
+|---------|------------|
+| **Autopilot hardening** | `ScanExistingPRs` no longer clobbers `RestoreState` on startup; idempotent merge-completion notification (dedup re-entry); skip `pilot-retry-ready` when `pilot-done` already set; periodic external-merge scan (GH-2251); cross-repo PR release-op fix (GH-2243); `notifyExternalClose` now closes parent (GH-2198); strip `GH-XXXX` prefix from squash titles for conventional-commit detection (GH-2312); post success comment on merge close (GH-2297) |
+| **Executor / non-Anthropic providers** | `default_model` + `api_base_url` for Z.AI/GLM/OpenRouter/LiteLLM (GH-2287, TASK-24); fix bare `NewRunner()` callsites ignoring executor config (GH-2286); cache-aware token tracking + cost estimation (GH-2164); 1M context window control + updated budget defaults (GH-2163); OOM/SIGKILL handling for Claude Code subprocess on large Navigator contexts (GH-2324); gate PR creation on conventional-commit title (GH-2325); signal executor mode + classify no-diff (GH-2328); persist backend stderr + final message on failure |
+| **Dispatcher / poller** | `hasLiveWorker` guard on running-task reaper (GH-2331); persist `Task.Labels` across queue round-trip (GH-2326); delete orphan rows for already-completed tasks; check execution store before re-dispatch (GH-2242); skip retry of closed issues with stale `pilot-failed` (GH-2252); auto-retry stuck `pilot-failed` (GH-2176); clear stale `pilot-in-progress` on startup (GH-2301); retry grace period + TaskChecker (GH-2201); resolve stale-threshold defaults treating 0 as unset (GH-2226) |
+| **Epic / sub-issues** | Validate sub-issue titles — reject LLM analysis-style titles (decomposition); native sub-issue GraphQL linking (GH-2210/2211/2212); merge-wait wired via `SubIssueMergeWaitFn` (GH-2178/2179); worktree isolation for sub-issues (GH-2178); sub-issues branch from real repo (GH-2177); `gh pr create --head` to bypass dirty worktree check |
+| **Dashboard** | Adapter poller tasks visible in gateway+dashboard mode (GH-2291); refresh history/metrics from DB every 5s (GH-2248) and stop wiping sparklines (GH-2280); gate stdout prints on dashboard mode (GH-2333); zero-poller startup warning (GH-2307) |
+| **Adapters** | GitLab: string type for `MergeRequest.detailed_merge_status` (#2295), MR creation fixes (#2271), parallel `OnIssue` with result (#2236); GitHub: adapter-specific PR/MR number extraction (GH-2293); auto-retry issues with `pilot-retry-ready` (GH-2276); Discord greeting-prefix misclassification (#2162); broken Discord invite link (#2231); GitHub issue templates (GH-2298) |
+| **Release / packaging** | GoReleaser `brews` section for Homebrew auto-publish (GH-2188); migrate tap to `qf-studio/homebrew-pilot` (#1); LLM-generated GitHub release notes summary (GH-2173); `pilot doctor` GitHub config validation (GH-2304/2306); install script jq-based version parsing (GH-2260) |
+| **Bench / Harbor** | Self-verification harness for `PilotAgent` (#2238); remove oracle test access (GH-2237 — Harbor compliance); AWS orchestrator signal handling (GH-2267); always regenerate stale task manifest (GH-2269) |
+| **Alerts** | `task_stuck` Slack flood fix — wire progress events, per-rule cooldown, orphan cleanup (GH-2204) |
+| **Docs / project** | Repo rename `alekspetrov` → `qf-studio` across non-Go files (GH-2196), llms.txt URLs (GH-2192), brew tap refs (GH-2189); navbar version-sync workflow trigger fix via `workflow_dispatch` (GH-2206); Terminal-Bench #1 ranking + flow diagram fixes; epic merge-wait docs (GH-2183); Navigator-only rules scoped to interactive sessions (#2327) |
 
 ### 2026-03-13
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2379.

Closes #2379

## Changes

GitHub Issue #2379: docs(nav): bring .agent/DEVELOPMENT-README.md current to v2.99.1

Navigator index drifted — last Completed Log entry is \`2026-03-13\`, version header stuck at \`v2.98.0\`. Meanwhile main is at v2.99.1 with ~35 days of merged work. v1.19.0's auto-update feature maintains FEATURE-MATRIX.md per-PR, but DEVELOPMENT-README.md's version header and Completed Log need a manual catch-up pass.

## Scope

Update \`.agent/DEVELOPMENT-README.md\` only. Do NOT touch FEATURE-MATRIX.md (handled by post-execution hook).

### 1. Version header

Line ~125:
\`\`\`
**Current Version:** v2.98.0 | **316 features working**
\`\`\`

→ \`v2.99.1\` and correct feature count (check FEATURE-MATRIX.md for current).

### 2. Add new Completed Log section for 2026-04-18

Before the existing \`### 2026-03-13\` block. Cover the releases shipped today:

- **v2.99.1** — \`fix(executor)\`: self-review \`--resume\` fallback mirrors Qwen logic + \`sanitizeFilename\` strips path separators (GH-2377, PR #2378)
- **v2.99.0** — \`refactor(autopilot)\`: remove dead prod-X.Y.Z tag auto-push — sync-docs.yml already handles GitLab deploy (GH-2374, PR #2375)
- **v2.98.1 / v2.98.0** — executor env injection (GH-2287/GH-2371), default_branch honored (GH-2286), conventional-commit rewrite suggestion after 2nd reject, docs version sync unblocked manually ([PR #2373](https://github.com/qf-studio/pilot/pull/2373) because GitHub Actions lacks PR-create permission at repo level)
- **Jira search migration** — GH-2289 deprecated \`/rest/api/2|3/search\` → \`/rest/api/3/search/jql\` (PR #2376, ghost-abandoned on first retry then recovered via escape-hatch dispatch)

### 3. Also cover work from between 2026-03-13 and 2026-04-18

Review \`git log main --since=2026-03-13 --until=2026-04-17 --oneline\` and summarize significant merges. Group by week or release cluster. Don't enumerate every commit — focus on features, fixes, and architectural shifts.

## Known gotchas to document (optional)

If adding a \"Known Bug Patterns\" section would help, reference these discovered today but don't block on this:
- \`docs-version-sync.yml\` GitHub Actions PR-create permission blocks auto-PR after release — requires repo Settings toggle
- [PR #2370](https://github.com/qf-studio/pilot/pull/2370) shipped with wrong premise (reverted in v2.99.0) — \`prod-X.Y.Z\` tags on GitHub don't trigger anything; deploy lives in sync-docs.yml's tag-push to GitLab

## Acceptance criteria

- [ ] \`**Current Version:**\` updated to \`v2.99.1\` with accurate feature count
- [ ] New \`### 2026-04-18\` entry at top of Completed Log covering v2.98.0–v2.99.1
- [ ] Summary entries for merged work between 2026-03-13 and 2026-04-17
- [ ] Only \`.agent/DEVELOPMENT-README.md\` touched (no code, no other docs)
- [ ] PR title follows conventional-commit: \`docs(nav): ...\`