### PR TITLE
docs(guides): add custom model providers guide

### DIFF
--- a/docs/content/concepts/execution-backends.mdx
+++ b/docs/content/concepts/execution-backends.mdx
@@ -65,6 +65,10 @@ executor:
 | `use_session_resume` | bool | `false` | Reuse sessions for self-review (~40% token savings) |
 | `use_from_pr` | bool | `false` | Use `--from-pr` to resume from PR context |
 
+<Callout type="info">
+  For non-Anthropic providers (Z.AI, OpenRouter, LiteLLM), set `executor.api_base_url` / `api_auth_token` / `default_model` at the top of the `executor:` block — Pilot propagates them into the Claude Code subprocess env automatically. See [Custom Providers guide](/guides/custom-providers).
+</Callout>
+
 ### Strengths
 
 - ✅ Full feature parity with Pilot

--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -194,6 +194,11 @@ executor:
   skip_self_review: false                 # skip self-review step
   use_worktree: false                     # execute tasks in isolated git worktrees
 
+  # Non-Anthropic provider routing — see Custom Providers guide
+  # api_base_url: "https://api.z.ai/api/anthropic"
+  # api_auth_token: "${ZAI_API_KEY}"
+  # default_model: "glm-4.6"
+
   claude_code:
     command: "claude"                     # path to claude CLI
     extra_args: []                        # additional CLI arguments
@@ -235,6 +240,9 @@ executor:
 | `detect_ephemeral` | bool | `true` | Detect and skip ephemeral file changes |
 | `skip_self_review` | bool | `false` | Skip the self-review step |
 | `use_worktree` | bool | `false` | Execute tasks in isolated git worktrees (enables execution with uncommitted changes) |
+| `api_base_url` | string | `""` | Anthropic-compatible endpoint (e.g. Z.AI, OpenRouter). See [Custom Providers](/guides/custom-providers). |
+| `api_auth_token` | string | `""` | Auth token for the custom provider. Supports `${ENV_VAR}` expansion. |
+| `default_model` | string | `""` | Model name for the custom provider (e.g. `glm-4.6`). |
 | `claude_code.command` | string | `"claude"` | Path to the Claude CLI binary |
 | `claude_code.extra_args` | []string | `[]` | Additional CLI arguments |
 | `claude_code.planning_timeout` | duration | `2m` | Maximum time for epic planning before fallback to direct execution. Affects Slack `/plan` and Telegram planning commands. |

--- a/docs/content/guides/_meta.js
+++ b/docs/content/guides/_meta.js
@@ -1,5 +1,6 @@
 export default {
   "tunnel-setup": "Tunnel Setup",
   "multi-repo": "Multi-Repo Polling",
+  "custom-providers": "Custom Model Providers",
   troubleshooting: "Troubleshooting"
 }

--- a/docs/content/guides/custom-providers.mdx
+++ b/docs/content/guides/custom-providers.mdx
@@ -1,0 +1,190 @@
+import { Callout, Steps, Tabs } from 'nextra/components'
+
+# Custom Model Providers
+
+Route Pilot to any Anthropic-compatible endpoint — Z.AI (GLM), OpenRouter, LiteLLM, or a self-hosted proxy — from a single config block. Pilot propagates the base URL, auth token, and default model to both its own LLM calls **and** the Claude Code subprocess, so you don't need to edit `~/.claude/settings.json`.
+
+<Callout type="info">
+  Shipped in v2.98.0 ([GH-2287](https://github.com/qf-studio/pilot/issues/2287), [GH-2371](https://github.com/qf-studio/pilot/issues/2371)). Requires an endpoint that speaks Anthropic's Messages API wire format.
+</Callout>
+
+## Why
+
+- **Cost** — Z.AI's GLM-4.6 runs ~5x cheaper per task than Claude Opus on comparable work.
+- **Subscriptions without caps** — flat-fee providers (Z.AI MAX, OpenRouter credits) sidestep Anthropic's weekly rate limits for heavy users.
+- **Regional / compliance** — route through providers with in-region data residency or enterprise SLAs.
+- **Single source of truth** — one YAML block instead of juggling shell env vars and CC settings.
+
+## Quick Start: Z.AI GLM-4.6
+
+<Steps>
+
+### Set your provider API key
+
+```bash
+export ZAI_API_KEY="your-z.ai-token"
+```
+
+Add this to your shell rc file so it persists across Pilot restarts.
+
+### Configure `executor` block
+
+Edit `~/.pilot/config.yaml`:
+
+```yaml
+executor:
+  type: "claude-code"
+
+  api_base_url: "https://api.z.ai/api/anthropic"
+  api_auth_token: "${ZAI_API_KEY}"
+  default_model: "glm-4.6"
+
+  claude_code:
+    command: "claude"
+```
+
+`${ZAI_API_KEY}` is expanded at config-load time via `os.ExpandEnv`. You can also inline the token directly, but env-var substitution is preferred for secrets.
+
+### Restart Pilot
+
+```bash
+pilot start --github --env stage
+```
+
+Pilot injects `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_MODEL` into every Claude Code subprocess — no changes to `~/.claude/settings.json` required.
+
+### Verify
+
+Run a task and check logs for the auth source. Pilot logs the resolved provider at startup:
+
+```
+level=INFO msg="Backend configured with custom provider" api_base_url=https://api.z.ai/api/anthropic default_model=glm-4.6
+```
+
+Or trigger a trivial task (`pilot github run <issue-number>`) and check the execution report — `Model:` will show your configured default.
+
+</Steps>
+
+## Field Reference
+
+All three fields live under the top-level `executor:` block.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_base_url` | string | `""` (Anthropic) | Base URL of an Anthropic-compatible endpoint. Example: `https://api.z.ai/api/anthropic`. |
+| `api_auth_token` | string | `""` | Bearer token for the provider. Supports `${ENV_VAR}` expansion. |
+| `default_model` | string | `""` (use Pilot defaults) | Model name the provider recognises (e.g. `glm-4.6`, `openrouter/anthropic/claude-sonnet-4-6`). |
+
+All three are optional. Leave empty for default Anthropic behavior — Pilot uses OAuth, `~/.claude/settings.json`, or `ANTHROPIC_API_KEY` as before.
+
+## How Injection Works
+
+Pilot uses the custom provider in two places:
+
+```
+                    ┌──────────────────────────────┐
+                    │  executor config (YAML)      │
+                    │  api_base_url                │
+                    │  api_auth_token              │
+                    │  default_model               │
+                    └──────────────┬───────────────┘
+                                   │
+           ┌───────────────────────┴────────────────────────┐
+           │                                                │
+           ▼                                                ▼
+  ┌─────────────────────────┐              ┌──────────────────────────────┐
+  │  Pilot internal HTTP    │              │  Claude Code subprocess env  │
+  │  • effort classifier    │              │  ANTHROPIC_BASE_URL=...      │
+  │  • intent judge         │              │  ANTHROPIC_AUTH_TOKEN=...    │
+  │  • subtask parser       │              │  ANTHROPIC_MODEL=...         │
+  │  • release summary      │              │  (appended after os.Environ) │
+  └─────────────────────────┘              └──────────────────────────────┘
+```
+
+Pilot-injected env vars are appended **after** `os.Environ()`, so they win over any stale shell exports in the parent process.
+
+## Provider Compatibility
+
+The endpoint must expose the Anthropic Messages API shape. Known-good providers:
+
+| Provider | `api_base_url` | Notes |
+|----------|----------------|-------|
+| **Z.AI (GLM)** | `https://api.z.ai/api/anthropic` | GLM-4.6 / GLM-5.1. MAX subscription has no session caps. |
+| **OpenRouter (Anthropic-compat)** | `https://openrouter.ai/api/v1` | Prefix model names (e.g. `anthropic/claude-sonnet-4-6`). |
+| **LiteLLM proxy** | `http://your-proxy:4000` | Self-hosted gateway that translates to OpenAI / Bedrock / Gemini. |
+| **Anthropic (default)** | *(leave empty)* | First-party. |
+| **AWS Bedrock / Vertex** | *(use CC native env)* | Use `CLAUDE_CODE_USE_BEDROCK=1` / `CLAUDE_CODE_USE_VERTEX=1` instead. |
+
+<Callout type="warning">
+  Model routing ([configure](/concepts/model-routing)) still works, but the model names you configure in `model_routing.*` must be recognised by your provider. Prefer setting `default_model` alone for non-Anthropic providers until you confirm per-complexity names resolve.
+</Callout>
+
+## Common Setups
+
+### Mix: Pilot on Anthropic, CC on Z.AI
+
+Only set `api_base_url` + `api_auth_token` without `default_model` to route Claude Code to the provider while leaving Pilot's internal classifiers on Anthropic. This is niche — most users want all-or-nothing.
+
+### Env-var-only (no YAML)
+
+Skip the YAML fields entirely and export the Anthropic env vars yourself before starting Pilot:
+
+```bash
+export ANTHROPIC_BASE_URL="https://api.z.ai/api/anthropic"
+export ANTHROPIC_AUTH_TOKEN="$ZAI_API_KEY"
+export ANTHROPIC_MODEL="glm-4.6"
+pilot start --github --env stage
+```
+
+Works, but you lose the single-source-of-truth benefit and Pilot's internal HTTP calls still hit Anthropic.
+
+## Verification
+
+After restart, confirm routing worked:
+
+1. **Logs** — search Pilot logs for `api_base_url=` at startup. Absence means config didn't load.
+2. **Execution report** — the `Model:` line in the post-task report reflects `default_model`.
+3. **Provider dashboard** — check request volume on your provider's billing page after triggering a task.
+4. **Network** — `lsof -i` during execution should show connections to your provider's host, not `api.anthropic.com`.
+
+## Troubleshooting
+
+### `401 Unauthorized` from provider
+
+The token isn't being passed. Check:
+
+- `echo $ZAI_API_KEY` returns a non-empty value in the shell that started Pilot.
+- `api_auth_token:` line uses `${ZAI_API_KEY}` (with `$`) and not literal `ZAI_API_KEY`.
+- You restarted Pilot after editing config — config is read at startup, not hot-reloaded.
+
+### Claude Code still hits `api.anthropic.com`
+
+- Verify both `api_base_url` AND `api_auth_token` are set — injection requires both.
+- Check `~/.claude/settings.json` doesn't hardcode an endpoint that overrides env vars.
+- Pilot logs `ANTHROPIC_BASE_URL injected into subprocess env` when propagation works.
+
+### Model name not recognized
+
+Providers use their own naming. Cross-check:
+
+- Z.AI: `glm-4.6`, `glm-5.1` — not `claude-*`.
+- OpenRouter: needs provider prefix — `anthropic/claude-sonnet-4-6`.
+- LiteLLM: depends on your proxy's model mapping.
+
+### Effort routing unexpectedly enabled or silent
+
+Effort routing ([model-routing](/concepts/model-routing)) passes `--model` flags. If your provider ignores or rejects them, disable:
+
+```yaml
+executor:
+  effort_routing:
+    enabled: false
+  model_routing:
+    enabled: false
+```
+
+## Related
+
+- [Execution Backends](/concepts/execution-backends) — backend selection (Claude Code, Qwen, OpenCode)
+- [Model Routing](/concepts/model-routing) — complexity-based model selection
+- [Configuration Reference](/getting-started/configuration#executor) — full executor block


### PR DESCRIPTION
## Summary

Documents the \`executor.api_base_url\` / \`api_auth_token\` / \`default_model\` fields shipped in v2.98.0 ([GH-2287](https://github.com/qf-studio/pilot/issues/2287), [GH-2371](https://github.com/qf-studio/pilot/issues/2371)) for routing Pilot to Anthropic-compatible providers (Z.AI, OpenRouter, LiteLLM).

## Changes

- **New guide** \`docs/content/guides/custom-providers.mdx\` (190 lines) — quick start with Z.AI GLM-4.6, field reference, injection diagram, provider matrix, troubleshooting
- **\`configuration.mdx\`** — 3 new fields in executor YAML block + reference table rows
- **\`execution-backends.mdx\`** — Callout cross-link in Claude Code section
- **\`guides/_meta.js\`** — register new guide page

## Test plan

- [x] MDX imports + heading structure sound
- [x] Internal links resolve to existing pages (\`/concepts/model-routing\`, \`/concepts/execution-backends\`, \`/getting-started/configuration\`)
- [ ] Renders on pilot.quantflow.studio after merge + sync-docs workflow