### PR TITLE
fix: nil pointer dereference in processTask for non-Linear adapters

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -206,11 +206,15 @@ func (o *Orchestrator) processTask(task *Task) {
 	}
 
 	// Execute task
+	var priority int
+	if task.Ticket != nil {
+		priority = task.Ticket.Priority
+	}
 	execTask := &executor.Task{
 		ID:          task.ID,
 		Title:       task.Document.Title,
 		Description: task.Document.Markdown,
-		Priority:    task.Ticket.Priority,
+		Priority:    priority,
 		ProjectPath: task.ProjectPath,
 		Branch:      task.Branch,
 	}


### PR DESCRIPTION
## Summary

Fixes #2384

`task.Ticket` is only populated by the Linear adapter. All other adapters (Jira, GitLab, GitHub, Asana, Plane) leave it `nil`, causing a panic when `processTask` unconditionally dereferences `task.Ticket.Priority`.

## Change

Added a nil guard before constructing the `executor.Task`:

```go
var priority int
if task.Ticket != nil {
    priority = task.Ticket.Priority
}
execTask := &executor.Task{
    ...
    Priority:    priority,
    ...
}
```

## Impact

Without this fix, Pilot panics and crashes immediately when processing any ticket from Jira, GitLab, GitHub, Asana, or Plane — making it non-functional for all adapters except Linear.

## Test plan
- [ ] Process a Jira ticket with the `pilot` label — no panic
- [ ] Process a GitLab issue — no panic  
- [ ] Process a Linear ticket — priority still populated correctly
- [ ] Existing tests pass