### PR TITLE
fix(orchestrator): preserve priority from non-Linear adapters in processTask

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -206,11 +206,19 @@ func (o *Orchestrator) processTask(task *Task) {
 	}
 
 	// Execute task
+	// Priority resolution (GH-2386):
+	// - Non-Linear adapters (GitHub/GitLab/Jira/Asana/Plane) set task.Priority directly.
+	// - Linear adapter populates task.Ticket; prefer Ticket.Priority when present.
+	// - task.Ticket is nil for all non-Linear adapters — must guard against deref (GH-2384).
+	priority := int(task.Priority)
+	if task.Ticket != nil {
+		priority = task.Ticket.Priority
+	}
 	execTask := &executor.Task{
 		ID:          task.ID,
 		Title:       task.Document.Title,
 		Description: task.Document.Markdown,
-		Priority:    task.Ticket.Priority,
+		Priority:    priority,
 		ProjectPath: task.ProjectPath,
 		Branch:      task.Branch,
 	}


### PR DESCRIPTION
## Summary

- Fixes #2386. Supersedes #2385.
- Guards against nil `task.Ticket` deref (the original panic from #2384).
- Preserves `task.Priority` (float64) for non-Linear adapters instead of zeroing it.

## Why #2385 wasn't enough

#2385 prevents the panic, but the nil branch initializes priority to `0`, discarding the value that GitHub/GitLab/Jira/Asana/Plane adapters already set on `task.Priority` (see `ProcessGithubTicket`, `ProcessGitlabTicket`, etc. — each sets `internalTask.Priority = float64(task.Priority)`).

## Change

```go
// Before (#2385):
var priority int
if task.Ticket != nil {
    priority = task.Ticket.Priority
}

// This PR:
priority := int(task.Priority)   // base: what non-Linear adapters populate
if task.Ticket != nil {
    priority = task.Ticket.Priority  // Linear override
}
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/orchestrator/...` passes
- [x] `gofmt -l` clean, `go vet` clean
- [ ] Process a Jira ticket — no panic, priority reaches executor
- [ ] Process a Linear ticket — priority still driven by Ticket.Priority