### PR TITLE
fix(executor): remove oracle-test paths from buildLocalModePrompt

### DIFF
--- a/internal/executor/prompt_builder.go
+++ b/internal/executor/prompt_builder.go
@@ -38,7 +38,7 @@ const ExecutorPromptHeader = "[PILOT-EXEC]\n" +
 	"You are invoked by Pilot's executor to implement a specific task on this " +
 	"repository. You are the execution leg of the Navigator + Pilot pipeline. " +
 	"Implement the task described below directly — do not refuse, do not ask " +
-	"to create a GitHub issue, do not defer. Write code, run build/tests via " +
+	"to create a GitHub issue, do not defer. Write code, run build and tests via " +
 	"the stop-gate hook, and complete the task.\n\n"
 
 // BuildPrompt constructs the prompt for Claude Code execution.
@@ -367,15 +367,15 @@ func (r *Runner) buildLocalModePrompt(task *Task) (prompt string) {
 	// Phase 1: Mandatory reconnaissance (ForgeCode: +28pts from enforced planning)
 	sb.WriteString("## Phase 1: RECON (mandatory — do ALL before writing ANY code)\n\n")
 	sb.WriteString("You MUST complete every step below before writing a single line of solution code.\n\n")
-	sb.WriteString("1. **Read test file**: `cat /tests/test_outputs.py` — this defines pass/fail. Understand EXACTLY what outputs are expected, what format, what tolerances.\n")
-	sb.WriteString("2. **Inventory the workspace**: `ls -la /app/` and read every relevant file. Understand what exists.\n")
+	sb.WriteString("1. **Discover the spec**: read whatever instruction files, README, or example fixtures exist in the workspace. Identify EXACTLY what the task asks you to produce, what format it should take, and what success looks like. Do NOT assume a specific test-file path exists; check the workspace to see what's there.\n")
+	sb.WriteString("2. **Inventory the workspace**: list the working directory and read every relevant file. Understand what exists before writing code.\n")
 	sb.WriteString("3. **Write a plan**: Create a TODO list with specific steps. State which approach you'll use and why. This is NOT optional.\n\n")
 
 	// Phase 2: Implementation
 	sb.WriteString("## Phase 2: IMPLEMENT\n\n")
 	sb.WriteString("1. **Start with the simplest working approach** — brute-force beats elegant theory you never finish.\n")
 	sb.WriteString("2. **Produce output files EARLY** — partial/placeholder output beats no output.\n")
-	sb.WriteString("3. **Run tests after EVERY significant change**: `cd /app && python3 -m pytest /tests/test_outputs.py -v 2>&1`\n")
+	sb.WriteString("3. **Verify after EVERY significant change**: run whatever check the workspace provides (test runner, validation script, or comparing your output to the expected fixtures you discovered in RECON).\n")
 	sb.WriteString("4. **If tests pass, STOP IMMEDIATELY.** No cleanup, no refactoring, no summary.\n\n")
 
 	// Phase 3: Recovery
@@ -436,7 +436,7 @@ func (r *Runner) buildRetryPrompt(task *Task, feedback string, attempt int) (pro
 	sb.WriteString("1. Run `git diff HEAD~1` to see what you tried before\n")
 	sb.WriteString("2. DELETE your previous approach entirely\n")
 	sb.WriteString("3. Implement a COMPLETELY DIFFERENT solution\n")
-	sb.WriteString("4. Run tests to verify: `cd /app && python3 -m pytest /tests/test_outputs.py -v`\n")
+	sb.WriteString("4. Verify using whatever check the workspace provides (test runner or validation script discovered in RECON).\n")
 	sb.WriteString("5. If tests pass, STOP.\n\n")
 	sb.WriteString("Work autonomously. Do not ask for confirmation.\n")
 

--- a/internal/executor/prompt_builder_test.go
+++ b/internal/executor/prompt_builder_test.go
@@ -790,6 +790,42 @@ func TestBuildPromptLocalMode(t *testing.T) {
 	}
 }
 
+func TestBuildPromptLocalModeNoOraclePaths(t *testing.T) {
+	// GH-2393: prompt must not name oracle test paths; agent should discover
+	// the spec from the workspace. Naming /tests/test_outputs.py blocks
+	// Terminal-Bench 2.0 leaderboard submission (Harbor compliance).
+	tempDir, err := os.MkdirTemp("", "pilot-test-local-oracle")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	runner := NewRunner()
+	task := &Task{
+		ID:          "LOCAL-2393",
+		Title:       "Oracle compliance",
+		Description: "Solve task",
+		ProjectPath: tempDir,
+		LocalMode:   true,
+	}
+
+	prompt := runner.BuildPrompt(task, tempDir)
+
+	forbidden := []string{"/tests", "test_outputs", "test.sh", "conftest"}
+	for _, s := range forbidden {
+		if strings.Contains(prompt, s) {
+			t.Errorf("LocalMode prompt must not mention oracle path %q", s)
+		}
+	}
+
+	if !strings.Contains(prompt, "Discover the spec") {
+		t.Error("LocalMode prompt should instruct agent to discover the spec from the workspace")
+	}
+	if !strings.Contains(prompt, "Do NOT assume a specific test-file path") {
+		t.Error("LocalMode prompt should warn against assuming a specific test-file path")
+	}
+}
+
 func TestBuildPromptLocalModeWithoutTestFiles(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "pilot-test-local-notest")
 	if err != nil {
@@ -996,8 +1032,8 @@ func TestBuildPromptLocalModeBench(t *testing.T) {
 	if !strings.Contains(prompt, "## Phase 3: RECOVERY") {
 		t.Error("Should contain recovery phase")
 	}
-	if !strings.Contains(prompt, "test_outputs.py") {
-		t.Error("Should mention test files")
+	if !strings.Contains(prompt, "Discover the spec") {
+		t.Error("Should instruct agent to discover the spec from the workspace (GH-2393)")
 	}
 
 	// Should have environment section with pre-installed deps


### PR DESCRIPTION
## Summary
- Replaces Phase 1 RECON oracle-path naming (`/tests/test_outputs.py`, `test.sh`, `conftest.py`) in `buildLocalModePrompt` with workspace-discovery wording per GH-2392 spec.
- Updates Phase 2 / `buildRetryPrompt` verification bullets to reference whatever check the workspace provides instead of hard-coded pytest paths.
- Adds `TestBuildPromptLocalModeNoOraclePaths` asserting forbidden strings absent and discovery wording present; updates existing bench test to match new wording.

Closes #2393. Parent: #2392.

## Verification
- `grep -rE "/tests|test_outputs|test\.sh|conftest" internal/executor/prompt_builder.go` → 0 matches
- `go build ./...` clean
- `go test ./internal/executor/...` passes

## Test plan
- [x] Build passes
- [x] Existing prompt_builder tests pass
- [x] New test asserts oracle-path strings are absent from local-mode prompt