### PR TITLE
GH-2398: feat(quality): DetectTestCommand for bench / non-Makefile workspaces

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2205,6 +2205,7 @@ The previous execution completed but made no code changes. This task requires ac
 		// This ensures broken code never becomes a PR, even without explicit quality config
 		if r.qualityCheckerFactory == nil {
 			buildCmd := quality.DetectBuildCommand(executionPath)
+			testCmd := quality.DetectTestCommand(executionPath)
 			if buildCmd != "" {
 				log.Info("Auto-enabling build gate (no quality config)",
 					slog.String("command", buildCmd),
@@ -2213,6 +2214,23 @@ The previous execution completed but made no code changes. This task requires ac
 				// Create minimal quality checker with auto-detected build command
 				minimalConfig := quality.MinimalBuildGate()
 				minimalConfig.Gates[0].Command = buildCmd
+
+				// GH-2398: also auto-enable a test gate when a test runner is
+				// detectable. Empty testCmd → skip the gate entirely instead of
+				// failing it on workspaces that lack a Makefile / test harness.
+				if testCmd != "" {
+					log.Info("Auto-enabling test gate", slog.String("command", testCmd))
+					minimalConfig.Gates = append(minimalConfig.Gates, &quality.Gate{
+						Name:        "test",
+						Type:        quality.GateTest,
+						Command:     testCmd,
+						Required:    true,
+						Timeout:     5 * time.Minute,
+						MaxRetries:  1,
+						RetryDelay:  3 * time.Second,
+						FailureHint: "Fix failing tests in the changed files",
+					})
+				}
 
 				r.qualityCheckerFactory = func(taskID, projectPath string) QualityChecker {
 					return &simpleQualityChecker{

--- a/internal/quality/types.go
+++ b/internal/quality/types.go
@@ -3,9 +3,11 @@
 package quality
 
 import (
+	"bufio"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -286,4 +288,77 @@ func DetectBuildCommand(projectPath string) string {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// DetectTestCommand returns the appropriate test command for the project.
+// Priority order:
+//  1. `make test` if Makefile exists and contains a `test:` target
+//  2. `pytest -v 2>&1` if any Python sources or Python project markers exist
+//  3. `npm test` if package.json exists
+//  4. `cargo test` if Cargo.toml exists
+//  5. `go test ./...` if go.mod exists
+//
+// Returns empty string if no test command can be detected.
+func DetectTestCommand(projectPath string) string {
+	if hasMakefileTarget(filepath.Join(projectPath, "Makefile"), "test") {
+		return "make test"
+	}
+	if hasPythonProject(projectPath) {
+		return "pytest -v 2>&1"
+	}
+	if fileExists(filepath.Join(projectPath, "package.json")) {
+		return "npm test"
+	}
+	if fileExists(filepath.Join(projectPath, "Cargo.toml")) {
+		return "cargo test"
+	}
+	if fileExists(filepath.Join(projectPath, "go.mod")) {
+		return "go test ./..."
+	}
+	return ""
+}
+
+// hasMakefileTarget reports whether the Makefile at path declares the given
+// target (e.g. a line beginning with `test:`). Returns false if the file is
+// missing or unreadable.
+func hasMakefileTarget(path, target string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+
+	prefix := target + ":"
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasPythonProject reports whether projectPath looks like a Python project:
+// either a Python project marker file is present, or at least one *.py file
+// exists at the top level.
+func hasPythonProject(projectPath string) bool {
+	for _, marker := range []string{"pyproject.toml", "setup.py", "requirements.txt"} {
+		if fileExists(filepath.Join(projectPath, marker)) {
+			return true
+		}
+	}
+	entries, err := os.ReadDir(projectPath)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(entry.Name(), ".py") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/quality/types_test.go
+++ b/internal/quality/types_test.go
@@ -356,6 +356,81 @@ func TestDetectBuildCommand(t *testing.T) {
 	}
 }
 
+func TestDetectTestCommand(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "quality-test-detect-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	tests := []struct {
+		name        string
+		files       map[string]string // relative path → content
+		expectedCmd string
+	}{
+		{
+			name:        "make with test target",
+			files:       map[string]string{"Makefile": "build:\n\techo build\n\ntest:\n\techo run tests\n"},
+			expectedCmd: "make test",
+		},
+		{
+			name:        "make without test target",
+			files:       map[string]string{"Makefile": "build:\n\techo build\n", "go.mod": ""},
+			expectedCmd: "go test ./...",
+		},
+		{
+			name:        "pytest via py file",
+			files:       map[string]string{"app.py": "print('hi')\n"},
+			expectedCmd: "pytest -v 2>&1",
+		},
+		{
+			name:        "pytest via pyproject",
+			files:       map[string]string{"pyproject.toml": ""},
+			expectedCmd: "pytest -v 2>&1",
+		},
+		{
+			name:        "npm test",
+			files:       map[string]string{"package.json": "{}"},
+			expectedCmd: "npm test",
+		},
+		{
+			name:        "cargo test",
+			files:       map[string]string{"Cargo.toml": ""},
+			expectedCmd: "cargo test",
+		},
+		{
+			name:        "go test",
+			files:       map[string]string{"go.mod": "module x\n"},
+			expectedCmd: "go test ./...",
+		},
+		{
+			name:        "empty workspace",
+			files:       map[string]string{},
+			expectedCmd: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := filepath.Join(tmpDir, tt.name)
+			if err := os.MkdirAll(testDir, 0755); err != nil {
+				t.Fatalf("failed to create test dir: %v", err)
+			}
+			for name, content := range tt.files {
+				path := filepath.Join(testDir, name)
+				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+					t.Fatalf("failed to create file %s: %v", name, err)
+				}
+			}
+
+			got := DetectTestCommand(testDir)
+			if got != tt.expectedCmd {
+				t.Errorf("DetectTestCommand() = %q, want %q", got, tt.expectedCmd)
+			}
+		})
+	}
+}
+
 func TestDetectBuildCommand_Priority(t *testing.T) {
 	// Test that Go takes priority when multiple indicators exist
 	tmpDir, err := os.MkdirTemp("", "quality-priority-*")


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2398.

Closes #2398

## Changes

Add `DetectTestCommand(projectPath string) string` to `internal/quality/types.go` mirroring the existing `DetectBuildCommand` pattern, with priority order: (1) `make test` if `Makefile` exists and contains `^test:` target, (2) `pytest -v 2>&1` if any `*.py` files OR `pyproject.toml`/`setup.py`/`requirements.txt` present, (3) `npm test` if `package.json` exists, (4) `cargo test` if `Cargo.toml` exists, (5) `go test ./...` if `go.mod` exists, (6) `""` otherwise. Add unit tests in the same package covering pytest, npm, cargo, go, make-with-test-target, make-without-test-target, and empty-workspace cases. In `internal/executor/runner.go` near line 2114 (alongside the existing `DetectBuildCommand` call), invoke `DetectTestCommand`; when non-empty, override the test gate's `Command`; when empty, skip the test gate rather than failing it. Verify existing `make test` Go/Node projects remain unaffected and that flipping `pilot-bench/aws/run-bench-task.sh` to `quality.enabled: true` on a TB2 workspace runs gates without phantom Makefile failures.
Note: although this touches two packages (`internal/quality` and `internal/executor`), splitting would create a sequencing dependency where the executor subtask blocks on the quality subtask and risks merge friction over a ~1-day scope. Keeping as a single subtask.