### PR TITLE
feat(quality): DetectTestCommand + skip-on-empty test gate (GH-2397)

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2214,6 +2214,25 @@ The previous execution completed but made no code changes. This task requires ac
 				minimalConfig := quality.MinimalBuildGate()
 				minimalConfig.Gates[0].Command = buildCmd
 
+				// Auto-detect test command for the test gate (GH-2397).
+				// Override the test gate's command when detection succeeds; mark it
+				// skipped (rather than failing) when no test runner is recognised.
+				testCmd := quality.DetectTestCommand(executionPath)
+				for _, g := range minimalConfig.Gates {
+					if g.Type == quality.GateTest {
+						if testCmd != "" {
+							g.Command = testCmd
+							log.Info("Auto-enabling test gate",
+								slog.String("command", testCmd),
+							)
+						} else {
+							g.Skip = true
+							log.Info("No test runner detected - skipping test gate")
+						}
+						break
+					}
+				}
+
 				r.qualityCheckerFactory = func(taskID, projectPath string) QualityChecker {
 					return &simpleQualityChecker{
 						config:      minimalConfig,

--- a/internal/quality/runner.go
+++ b/internal/quality/runner.go
@@ -132,6 +132,14 @@ func (r *Runner) runGate(ctx context.Context, gate *Gate) *Result {
 		StartedAt: time.Now(),
 	}
 
+	if gate.Skip {
+		result.Status = StatusSkipped
+		result.CompletedAt = time.Now()
+		result.Duration = result.CompletedAt.Sub(result.StartedAt)
+		r.reportProgress(gate.Name, StatusSkipped, fmt.Sprintf("%s gate skipped", gate.Name))
+		return result
+	}
+
 	r.reportProgress(gate.Name, StatusRunning, fmt.Sprintf("Running %s gate...", gate.Name))
 
 	maxAttempts := gate.MaxRetries + 1

--- a/internal/quality/runner_test.go
+++ b/internal/quality/runner_test.go
@@ -838,3 +838,29 @@ func TestConfig_IsParallel(t *testing.T) {
 func boolPtr(b bool) *bool {
 	return &b
 }
+
+func TestRunGate_SkipFlag(t *testing.T) {
+	// Skipped gates must short-circuit without invoking the shell.
+	// `false` exits non-zero, so if the gate ran it would fail.
+	config := &Config{
+		Enabled: true,
+		Gates: []*Gate{
+			{Name: "test", Type: GateTest, Command: "false", Required: true, Skip: true},
+		},
+	}
+
+	runner := NewRunner(config, "/tmp")
+	results, err := runner.RunAll(context.Background(), "skip-test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !results.AllPassed {
+		t.Error("expected AllPassed=true when only gate is skipped")
+	}
+	if len(results.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results.Results))
+	}
+	if results.Results[0].Status != StatusSkipped {
+		t.Errorf("expected StatusSkipped, got %s", results.Results[0].Status)
+	}
+}

--- a/internal/quality/types.go
+++ b/internal/quality/types.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 )
 
@@ -53,6 +54,7 @@ type Gate struct {
 	MaxRetries  int           `yaml:"max_retries" json:"max_retries"`   // Retry count on failure
 	RetryDelay  time.Duration `yaml:"retry_delay" json:"retry_delay"`   // Delay between retries
 	FailureHint string        `yaml:"failure_hint" json:"failure_hint"` // Hint for Claude on failure
+	Skip        bool          `yaml:"skip" json:"skip"`                 // Skip this gate (returns StatusSkipped without executing)
 }
 
 // DefaultTimeout returns default timeout for a gate type
@@ -222,16 +224,17 @@ func (c *Config) Validate() error {
 		if g.Name == "" {
 			return errors.New("quality gate name is required")
 		}
-		if g.Command == "" {
+		if g.Command == "" && !g.Skip {
 			return errors.New("quality gate command is required for gate: " + g.Name)
 		}
 	}
 	return nil
 }
 
-// MinimalBuildGate returns a minimal quality gate config with just build verification.
+// MinimalBuildGate returns a minimal quality gate config with build + test verification.
 // Used when quality gates are not explicitly configured but we still want basic safety.
-// The build command should be set via DetectBuildCommand() based on project type.
+// The build command should be set via DetectBuildCommand() and test command via
+// DetectTestCommand() based on project type.
 func MinimalBuildGate() *Config {
 	return &Config{
 		Enabled: true,
@@ -245,6 +248,16 @@ func MinimalBuildGate() *Config {
 				MaxRetries:  1, // Single retry for build fixes
 				RetryDelay:  3 * time.Second,
 				FailureHint: "Fix compilation errors in the changed files",
+			},
+			{
+				Name:        "test",
+				Type:        GateTest,
+				Command:     "go test ./...", // Default for Go projects, override via DetectTestCommand
+				Required:    false,           // Don't block PR on test failures in minimal mode
+				Timeout:     5 * time.Minute,
+				MaxRetries:  0,
+				RetryDelay:  3 * time.Second,
+				FailureHint: "Fix failing tests in the changed files",
 			},
 		},
 		OnFailure: FailureConfig{
@@ -286,4 +299,58 @@ func DetectBuildCommand(projectPath string) string {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// makefileHasTestTarget reports whether the Makefile at projectPath defines a
+// "test" target (a line beginning with "test:" at column zero).
+func makefileHasTestTarget(projectPath string) bool {
+	data, err := os.ReadFile(filepath.Join(projectPath, "Makefile"))
+	if err != nil {
+		return false
+	}
+	// Multi-line: target lines like `test:` or `test: deps` at start of line.
+	pattern := regexp.MustCompile(`(?m)^test:`)
+	return pattern.Match(data)
+}
+
+// hasPythonProject checks for any Python project indicator in projectPath:
+// a *.py file in the root, pyproject.toml, setup.py, or requirements.txt.
+func hasPythonProject(projectPath string) bool {
+	if fileExists(filepath.Join(projectPath, "pyproject.toml")) ||
+		fileExists(filepath.Join(projectPath, "setup.py")) ||
+		fileExists(filepath.Join(projectPath, "requirements.txt")) {
+		return true
+	}
+	matches, err := filepath.Glob(filepath.Join(projectPath, "*.py"))
+	if err != nil {
+		return false
+	}
+	return len(matches) > 0
+}
+
+// DetectTestCommand returns the appropriate test command for the project.
+// Priority order:
+//  1. `make test` if Makefile defines a `test:` target
+//  2. `pytest -v 2>&1` if any Python project indicator is present
+//  3. `npm test` for package.json
+//  4. `cargo test` for Cargo.toml
+//  5. `go test ./...` for go.mod
+//  6. "" if no test runner can be inferred
+func DetectTestCommand(projectPath string) string {
+	if fileExists(filepath.Join(projectPath, "Makefile")) && makefileHasTestTarget(projectPath) {
+		return "make test"
+	}
+	if hasPythonProject(projectPath) {
+		return "pytest -v 2>&1"
+	}
+	if fileExists(filepath.Join(projectPath, "package.json")) {
+		return "npm test"
+	}
+	if fileExists(filepath.Join(projectPath, "Cargo.toml")) {
+		return "cargo test"
+	}
+	if fileExists(filepath.Join(projectPath, "go.mod")) {
+		return "go test ./..."
+	}
+	return ""
 }

--- a/internal/quality/types_test.go
+++ b/internal/quality/types_test.go
@@ -251,8 +251,8 @@ func TestMinimalBuildGate(t *testing.T) {
 		t.Error("expected minimal build gate to be enabled")
 	}
 
-	if len(config.Gates) != 1 {
-		t.Errorf("expected 1 gate, got %d", len(config.Gates))
+	if len(config.Gates) != 2 {
+		t.Errorf("expected 2 gates (build + test), got %d", len(config.Gates))
 	}
 
 	gate := config.Gates[0]
@@ -270,6 +270,17 @@ func TestMinimalBuildGate(t *testing.T) {
 	}
 	if gate.MaxRetries != 1 {
 		t.Errorf("expected 1 max retry, got %d", gate.MaxRetries)
+	}
+
+	testGate := config.Gates[1]
+	if testGate.Name != "test" {
+		t.Errorf("expected second gate name 'test', got '%s'", testGate.Name)
+	}
+	if testGate.Type != GateTest {
+		t.Errorf("expected gate type %s, got %s", GateTest, testGate.Type)
+	}
+	if testGate.Required {
+		t.Error("expected test gate to be non-required in minimal config")
 	}
 
 	// Check failure config
@@ -351,6 +362,98 @@ func TestDetectBuildCommand(t *testing.T) {
 			got := DetectBuildCommand(testDir)
 			if got != tt.expectedCmd {
 				t.Errorf("DetectBuildCommand() = %q, want %q", got, tt.expectedCmd)
+			}
+		})
+	}
+}
+
+func TestDetectTestCommand(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "quality-test-detect-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	type fileSpec struct {
+		name    string
+		content string
+	}
+
+	tests := []struct {
+		name        string
+		setupFiles  []fileSpec
+		expectedCmd string
+	}{
+		{
+			name:        "go project",
+			setupFiles:  []fileSpec{{name: "go.mod"}},
+			expectedCmd: "go test ./...",
+		},
+		{
+			name:        "node project",
+			setupFiles:  []fileSpec{{name: "package.json"}},
+			expectedCmd: "npm test",
+		},
+		{
+			name:        "rust project",
+			setupFiles:  []fileSpec{{name: "Cargo.toml"}},
+			expectedCmd: "cargo test",
+		},
+		{
+			name:        "python pyproject",
+			setupFiles:  []fileSpec{{name: "pyproject.toml"}},
+			expectedCmd: "pytest -v 2>&1",
+		},
+		{
+			name:        "python loose .py file",
+			setupFiles:  []fileSpec{{name: "main.py"}},
+			expectedCmd: "pytest -v 2>&1",
+		},
+		{
+			name:        "python requirements.txt",
+			setupFiles:  []fileSpec{{name: "requirements.txt"}},
+			expectedCmd: "pytest -v 2>&1",
+		},
+		{
+			name: "makefile with test target",
+			setupFiles: []fileSpec{
+				{name: "Makefile", content: "build:\n\techo build\n\ntest:\n\techo test\n"},
+				{name: "go.mod"}, // would otherwise return go test
+			},
+			expectedCmd: "make test",
+		},
+		{
+			name: "makefile without test target falls through",
+			setupFiles: []fileSpec{
+				{name: "Makefile", content: "build:\n\techo build\n"},
+				{name: "go.mod"},
+			},
+			expectedCmd: "go test ./...",
+		},
+		{
+			name:        "empty workspace",
+			setupFiles:  nil,
+			expectedCmd: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDir := filepath.Join(tmpDir, tt.name)
+			if err := os.MkdirAll(testDir, 0755); err != nil {
+				t.Fatalf("failed to create test dir: %v", err)
+			}
+
+			for _, f := range tt.setupFiles {
+				p := filepath.Join(testDir, f.name)
+				if err := os.WriteFile(p, []byte(f.content), 0644); err != nil {
+					t.Fatalf("failed to create file %s: %v", f.name, err)
+				}
+			}
+
+			got := DetectTestCommand(testDir)
+			if got != tt.expectedCmd {
+				t.Errorf("DetectTestCommand() = %q, want %q", got, tt.expectedCmd)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Implements GH-2397: auto-detect a test command for the minimal quality gate config and skip cleanly when no test runner can be inferred.

- `quality.DetectTestCommand(projectPath)` mirrors `DetectBuildCommand` with priority: `make test` (when `Makefile` has a `^test:` target) → `pytest -v 2>&1` (any `*.py` / `pyproject.toml` / `setup.py` / `requirements.txt`) → `npm test` → `cargo test` → `go test ./...` → `""`.
- `Gate.Skip` short-circuits to `StatusSkipped` without invoking the command; `Validate()` no longer rejects empty `Command` when `Skip` is set.
- `MinimalBuildGate()` now ships a non-required test gate alongside the build gate.
- Executor wiring (next to the existing `DetectBuildCommand` call site) overrides the test gate's `Command` when detected, otherwise sets `Skip=true` so non-Makefile / unknown workspaces (e.g. SWE-bench tasks) pass quality gates without a spurious failure.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/quality/...`
- [ ] CI green