### PR TITLE
GH-2402: fix(executor,autopilot,github): block stranded sub-issue dispatch + break deterministic-failure retry loop

### DIFF
--- a/.agent/tasks/gh-2402.md
+++ b/.agent/tasks/gh-2402.md
@@ -1,0 +1,10 @@
+# GH-2402
+
+**Created:** 2026-04-25
+
+## Problem
+
+Implement all four fixes from the plan as a single bundled change. The fixes share new label vocabulary (`LabelSuperseded`, `LabelBlocked` in `internal/adapters/github/types.go`) that must be defined before consumers in `poller.go`, `cmd/pilot/handlers.go`, `cmd/pilot/main.go`, `internal/executor/runner.go`, and `internal/autopilot/controller.go` can reference them. Splitting this into separate subtasks would force one to land label constants in isolation (dead code) and create merge conflicts on `types.go` and `poller.go` which receive multiple edits. Scope: (1) add `LabelSuperseded`/`LabelBlocked` constants; (2) add parent-merged pre-dispatch guard in poller (parallel + sequential paths) and skip rule for `LabelBlocked`; (3) add `IsPermanentFailure` helper in runner and wire failure classification in handlers to choose `LabelBlocked` vs `LabelFailed`; (4) wire `OnLabelRemoved("pilot-blocked")` → `ProcessedStore.Clear` in `main.go`; (5) make `pilot-failed` removal unconditional at handlers.go:331; (6) self-heal execution row to `completed` in autopilot controller after merge. Includes unit tests in `poller_test.go`, `runner_test.go`, `handlers_test.go`, `controller_test.go`. Single PR, ~150–250 LOC + ~80 LOC tests.
+
+## Acceptance Criteria
+

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -25,6 +25,17 @@ import (
 	"github.com/qf-studio/pilot/internal/logging"
 )
 
+// classifyFailureLabel chooses the GitHub label to apply to a failed
+// execution. Permanent (non-retriable) failures route to LabelBlocked so the
+// poller skips auto-retry; transient failures route to LabelFailed and remain
+// auto-retriable (GH-2402).
+func classifyFailureLabel(execErr error) string {
+	if executor.IsPermanentFailure(execErr) {
+		return github.LabelBlocked
+	}
+	return github.LabelFailed
+}
+
 // syncBoardStatus updates a GitHub Projects V2 board column for an issue.
 // It is a no-op when boardSync is nil or status is empty. Errors are logged, never propagated.
 func syncBoardStatus(ctx context.Context, boardSync *github.ProjectBoardSync, nodeID string, status string) {
@@ -300,11 +311,18 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 		boardStatuses := cfg.Adapters.GitHub.ProjectBoard.GetStatuses()
 
 		if execErr != nil {
-			if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelFailed}); err != nil {
+			// GH-2402: Classify failure — permanent failures (cross-project, permission denied,
+			// pre-flight, worktree setup) get pilot-blocked and stop auto-retry. Transient
+			// failures get pilot-failed and remain auto-retriable.
+			failureLabel := classifyFailureLabel(execErr)
+			if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{failureLabel}); err != nil {
 				logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
 			}
 			syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Failed) // GH-1853
 			comment := fmt.Sprintf("❌ Pilot execution failed:\n\n```\n%s\n```", execErr.Error())
+			if failureLabel == github.LabelBlocked {
+				comment += "\n\n_Marked `pilot-blocked` — not retriable automatically. Remove the label after fixing the underlying environment/permissions issue to allow retry._"
+			}
 			if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
 				logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
 			}
@@ -340,11 +358,12 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				}
 				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Done) // GH-1853
 
-				// GH-1302: Clean up stale pilot-failed label from prior failed attempt
-				if github.HasLabel(issue, github.LabelFailed) {
-					if err := client.RemoveLabel(ctx, parts[0], parts[1], issue.Number, github.LabelFailed); err != nil {
-						logGitHubAPIError("RemoveLabel", parts[0], parts[1], issue.Number, err)
-					}
+				// GH-1302/GH-2402: Clean up stale pilot-failed label from prior failed attempt.
+				// Removal is unconditional — `issue.Labels` is a stale snapshot from the
+				// list call, so a label added between dispatch and now wouldn't appear here.
+				// RemoveLabel returns 404 silently when the label is absent.
+				if err := client.RemoveLabel(ctx, parts[0], parts[1], issue.Number, github.LabelFailed); err != nil {
+					logGitHubAPIError("RemoveLabel", parts[0], parts[1], issue.Number, err)
 				}
 
 				// Close the issue so dependent issues can proceed

--- a/cmd/pilot/handlers_test.go
+++ b/cmd/pilot/handlers_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+)
+
+// GH-2402: classifyFailureLabel routes permanent failures to LabelBlocked
+// (no auto-retry) and transient failures to LabelFailed (auto-retriable).
+func TestClassifyFailureLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"transient generic", errors.New("network blip"), github.LabelFailed},
+		{"transient rate-limit", errors.New("hit your limit, resets 6am (UTC)"), github.LabelFailed},
+		{"permanent cross-project", errors.New("cross-project execution blocked: foo"), github.LabelBlocked},
+		{"permanent permission denied", errors.New("permission denied"), github.LabelBlocked},
+		{"permanent permission check", errors.New("permission check failed: missing role"), github.LabelBlocked},
+		{"permanent preflight", errors.New("pre-flight check failed: dirty repo"), github.LabelBlocked},
+		{"permanent worktree", errors.New("worktree creation failed: disk full"), github.LabelBlocked},
+		{"permanent navigator", errors.New("navigator worktree setup failed: missing dir"), github.LabelBlocked},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyFailureLabel(tt.err)
+			if got != tt.want {
+				t.Errorf("classifyFailureLabel(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -713,6 +713,22 @@ Examples:
 					// GH-726: Wire processed issue persistence for gateway poller
 					if gwAutopilotStateStore != nil {
 						pollerOpts = append(pollerOpts, github.WithProcessedStore(gwAutopilotStateStore))
+
+						// GH-2402: Clear processed-store entry when human strips
+						// pilot-blocked, so the issue is re-dispatched on next poll
+						// without waiting for the retry grace period.
+						gwStateStoreCapture := gwAutopilotStateStore
+						pollerOpts = append(pollerOpts, github.WithOnLabelRemoved(func(label string, issueNumber int) {
+							if label != github.LabelBlocked {
+								return
+							}
+							if err := gwStateStoreCapture.UnmarkIssueProcessed(issueNumber); err != nil {
+								logging.WithComponent("github-poller").Warn("Failed to clear processed entry on pilot-blocked removal",
+									slog.Int("issue", issueNumber),
+									slog.Any("error", err),
+								)
+							}
+						}))
 					}
 
 					// GH-2201: Wire task checker for retry grace period (gateway mode)
@@ -1986,6 +2002,22 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 				// GH-726: Wire processed issue persistence
 				if autopilotStateStore != nil {
 					pollerOpts = append(pollerOpts, github.WithProcessedStore(autopilotStateStore))
+
+					// GH-2402: Clear processed-store entry when human strips
+					// pilot-blocked, so the issue is re-dispatched on next poll
+					// without waiting for the retry grace period.
+					stateStoreCapture := autopilotStateStore
+					pollerOpts = append(pollerOpts, github.WithOnLabelRemoved(func(label string, issueNumber int) {
+						if label != github.LabelBlocked {
+							return
+						}
+						if err := stateStoreCapture.UnmarkIssueProcessed(issueNumber); err != nil {
+							logging.WithComponent("github-poller").Warn("Failed to clear processed entry on pilot-blocked removal",
+								slog.Int("issue", issueNumber),
+								slog.Any("error", err),
+							)
+						}
+					}))
 				}
 
 				// GH-2201: Wire task checker for retry grace period

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -121,6 +121,17 @@ type Poller struct {
 	// when pilot-done label failed to apply.
 	execChecker ExecutionChecker
 	projectPath string
+
+	// GH-2402: Tracks issues we previously observed carrying LabelBlocked, so we
+	// can fire OnLabelRemoved when a human strips the label and the issue should
+	// be re-dispatched. Protected by mu.
+	blockedIssues map[int]bool
+
+	// GH-2402: OnLabelRemoved fires when the poller detects a label was removed
+	// from an issue it had previously observed carrying that label. The callback
+	// is intended for wiring into ProcessedStore.UnmarkIssueProcessed so retries
+	// of pilot-blocked issues bypass the grace period.
+	onLabelRemoved func(label string, issueNumber int)
 }
 
 // PollerOption configures a Poller
@@ -234,6 +245,16 @@ func WithMaxRetryReadyRetries(n int) PollerOption {
 	}
 }
 
+// WithOnLabelRemoved sets a callback that fires when the poller detects a
+// label has been removed from an issue it previously observed carrying that
+// label. Currently emitted for LabelBlocked (GH-2402). Wire to ProcessedStore
+// clearing so the issue can be re-dispatched immediately on next poll.
+func WithOnLabelRemoved(fn func(label string, issueNumber int)) PollerOption {
+	return func(p *Poller) {
+		p.onLabelRemoved = fn
+	}
+}
+
 // WithMaxConcurrent sets the maximum number of parallel issue executions
 func WithMaxConcurrent(n int) PollerOption {
 	return func(p *Poller) {
@@ -268,6 +289,7 @@ func NewPoller(client *Client, repo string, label string, interval time.Duration
 		maxFailedRetries:     3, // GH-2176: default max retries for pilot-failed issues
 		retryReadyCount:      make(map[int]int),
 		maxRetryReadyRetries: 3, // GH-2276: default max retries for pilot-retry-ready issues
+		blockedIssues:        make(map[int]bool), // GH-2402: track pilot-blocked observations
 	}
 
 	for _, opt := range opts {
@@ -612,6 +634,19 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 			continue
 		}
 
+		// GH-2402: Issues marked pilot-blocked are permanent failures and
+		// must NOT be auto-retried. observeBlockedLabel also fires
+		// onLabelRemoved when the label disappears so the issue can be
+		// re-dispatched on the next cycle.
+		if p.observeBlockedLabel(issue) {
+			continue
+		}
+
+		// GH-2402: Skip pilot-superseded — parent epic was merged first.
+		if HasLabel(issue, LabelSuperseded) {
+			continue
+		}
+
 		// GH-2176: Auto-retry issues stuck with pilot-failed (no pilot-done)
 		if HasLabel(issue, LabelFailed) {
 			if !p.shouldRetryFailedIssue(ctx, issue) {
@@ -626,6 +661,13 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 				continue
 			}
 			// Label removed, fall through to candidate selection
+		}
+
+		// GH-2402: Pre-dispatch guard — sub-issues whose parent epic has already
+		// merged are typically rolled into the parent's PR. Tag pilot-superseded
+		// and skip rather than re-running them.
+		if p.hasMergedParent(ctx, issue) {
+			continue
 		}
 
 		// Check if previously processed
@@ -812,6 +854,18 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 			continue
 		}
 
+		// GH-2402: pilot-blocked is a permanent failure — never auto-retry.
+		// observeBlockedLabel also fires onLabelRemoved so a human-removed
+		// label triggers ProcessedStore clear for next-tick re-dispatch.
+		if p.observeBlockedLabel(issue) {
+			continue
+		}
+
+		// GH-2402: Skip pilot-superseded — parent epic merged first.
+		if HasLabel(issue, LabelSuperseded) {
+			continue
+		}
+
 		// GH-2176: Auto-retry issues stuck with pilot-failed (no pilot-done)
 		if HasLabel(issue, LabelFailed) {
 			if !p.shouldRetryFailedIssue(ctx, issue) {
@@ -831,6 +885,11 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 		// Skip and mark done issues as permanently processed
 		if HasLabel(issue, LabelDone) {
 			p.markProcessed(issue.Number)
+			continue
+		}
+
+		// GH-2402: Parent-merged pre-dispatch guard.
+		if p.hasMergedParent(ctx, issue) {
 			continue
 		}
 
@@ -1357,6 +1416,97 @@ func (p *Poller) shouldRetryRetryReadyIssue(ctx context.Context, issue *Issue) b
 		slog.Int("max", p.maxRetryReadyRetries),
 	)
 
+	return true
+}
+
+// observeBlockedLabel updates the poller's blocked-label tracking and fires
+// onLabelRemoved when an issue that previously carried LabelBlocked no longer
+// does. This lets the wiring layer (main.go) clear the ProcessedStore entry so
+// the issue is eligible for re-dispatch on the next poll cycle (GH-2402).
+//
+// Returns true when the issue currently carries LabelBlocked (caller should skip).
+func (p *Poller) observeBlockedLabel(issue *Issue) bool {
+	hasBlocked := HasLabel(issue, LabelBlocked)
+
+	p.mu.Lock()
+	previouslyBlocked := p.blockedIssues[issue.Number]
+	if hasBlocked {
+		p.blockedIssues[issue.Number] = true
+	} else if previouslyBlocked {
+		delete(p.blockedIssues, issue.Number)
+	}
+	p.mu.Unlock()
+
+	if previouslyBlocked && !hasBlocked && p.onLabelRemoved != nil {
+		p.logger.Info("pilot-blocked label removed, signalling for retry",
+			slog.Int("number", issue.Number),
+		)
+		p.onLabelRemoved(LabelBlocked, issue.Number)
+	}
+
+	return hasBlocked
+}
+
+// hasMergedParent checks whether the issue references a parent epic whose own
+// PR has already been merged. When a parent epic is merged before its
+// sub-issues finish dispatching, those sub-issues are typically already
+// rolled into the parent's PR — re-running them creates duplicate or
+// conflicting work. The pre-dispatch guard tags such issues with
+// LabelSuperseded and instructs callers to skip them (GH-2402).
+//
+// Returns true (and applies LabelSuperseded best-effort) when the parent is
+// closed AND has a merged Pilot PR. A network error is logged and treated as
+// "not superseded" — we don't want a transient API failure to block dispatch.
+func (p *Poller) hasMergedParent(ctx context.Context, issue *Issue) bool {
+	if issue == nil {
+		return false
+	}
+	parentNum := ParseParentIssueNumber(text.SanitizeUntrustedString(issue.Body))
+	if parentNum == 0 {
+		return false
+	}
+
+	parent, err := p.client.GetIssue(ctx, p.owner, p.repo, parentNum)
+	if err != nil || parent == nil {
+		if err != nil {
+			p.logger.Debug("Failed to fetch parent issue for merge check",
+				slog.Int("issue", issue.Number),
+				slog.Int("parent", parentNum),
+				slog.Any("error", err),
+			)
+		}
+		return false
+	}
+
+	// Parent must be closed; only then is a merged-PR check meaningful.
+	if parent.State != StateClosed {
+		return false
+	}
+
+	parentBranch := fmt.Sprintf("pilot/GH-%d", parentNum)
+	merged, berr := p.client.FindMergedPRByBranch(ctx, p.owner, p.repo, parentBranch)
+	if berr != nil {
+		p.logger.Debug("Parent merged-PR lookup failed, not blocking dispatch",
+			slog.Int("issue", issue.Number),
+			slog.Int("parent", parentNum),
+			slog.Any("error", berr),
+		)
+		return false
+	}
+	if !merged {
+		return false
+	}
+
+	p.logger.Info("Issue superseded by parent's merged PR — skipping dispatch",
+		slog.Int("issue", issue.Number),
+		slog.Int("parent", parentNum),
+	)
+	if err := p.client.AddLabels(ctx, p.owner, p.repo, issue.Number, []string{LabelSuperseded}); err != nil {
+		p.logger.Warn("Failed to add pilot-superseded label",
+			slog.Int("issue", issue.Number),
+			slog.Any("error", err),
+		)
+	}
 	return true
 }
 

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2704,3 +2704,250 @@ func TestPoller_CheckForNewIssues_StaleSnapshot_RefreshesLabels(t *testing.T) {
 		t.Errorf("dispatched %d times, want 0 (fresh GetIssue shows pilot-done)", got)
 	}
 }
+
+// GH-2402: Issues with pilot-blocked must not be dispatched (parallel mode).
+func TestPoller_BlockedLabel_SkipsDispatch_Parallel(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Blocked", Labels: []Label{{Name: "pilot"}, {Name: LabelBlocked}}, CreatedAt: now},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var dispatches int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&dispatches, 1)
+			return nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&dispatches); got != 0 {
+		t.Errorf("dispatched %d times, want 0 (pilot-blocked must skip)", got)
+	}
+}
+
+// GH-2402: Issues with pilot-blocked must not be picked in sequential mode.
+func TestPoller_BlockedLabel_SkipsDispatch_Sequential(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Blocked", Labels: []Label{{Name: "pilot"}, {Name: LabelBlocked}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, State: "open", Title: "Available", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil || issue.Number != 43 {
+		got := -1
+		if issue != nil {
+			got = issue.Number
+		}
+		t.Errorf("expected issue #43 (skip blocked #42), got #%d", got)
+	}
+}
+
+// GH-2402: When pilot-blocked is removed between polls, OnLabelRemoved fires
+// so the wiring layer can clear the ProcessedStore for immediate re-dispatch.
+func TestPoller_OnLabelRemoved_FiresWhenBlockedDisappears(t *testing.T) {
+	now := time.Now()
+	withBlocked := []*Issue{
+		{Number: 42, State: "open", Title: "Blocked", Labels: []Label{{Name: "pilot"}, {Name: LabelBlocked}}, CreatedAt: now},
+	}
+	withoutBlocked := []*Issue{
+		{Number: 42, State: "open", Title: "Blocked", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	var phase atomic.Int32 // 0 = first poll (blocked), 1 = second poll (unblocked)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if phase.Load() == 0 {
+			_ = json.NewEncoder(w).Encode(withBlocked)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(withoutBlocked)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	type cb struct {
+		label  string
+		number int
+	}
+	var (
+		mu       sync.Mutex
+		captured []cb
+	)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnLabelRemoved(func(label string, number int) {
+			mu.Lock()
+			defer mu.Unlock()
+			captured = append(captured, cb{label, number})
+		}),
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			return nil
+		}),
+	)
+
+	// First poll: observe blocked
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	mu.Lock()
+	if len(captured) != 0 {
+		t.Errorf("first poll: callback fired %d times, want 0", len(captured))
+	}
+	mu.Unlock()
+
+	// Second poll: blocked removed → callback should fire
+	phase.Store(1)
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) != 1 {
+		t.Fatalf("second poll: callback fired %d times, want 1", len(captured))
+	}
+	if captured[0].label != LabelBlocked || captured[0].number != 42 {
+		t.Errorf("callback got (%s, %d), want (%s, 42)", captured[0].label, captured[0].number, LabelBlocked)
+	}
+}
+
+// GH-2402: When a parent epic is closed AND has a merged Pilot PR, child
+// sub-issues are tagged pilot-superseded and skipped from dispatch.
+func TestPoller_ParentMergedGuard_TagsSupersededAndSkips(t *testing.T) {
+	now := time.Now()
+	subIssues := []*Issue{
+		{
+			Number:    101,
+			State:     "open",
+			Title:     "Sub-issue",
+			Labels:    []Label{{Name: "pilot"}},
+			Body:      "Parent: GH-100\n\nDo the thing",
+			CreatedAt: now,
+		},
+	}
+	parent := &Issue{Number: 100, State: "closed", Title: "Epic"}
+
+	var (
+		labeledSuperseded atomic.Bool
+		dispatches        int32
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(subIssues)
+		case r.URL.Path == "/repos/owner/repo/issues/100":
+			_ = json.NewEncoder(w).Encode(parent)
+		case r.URL.Path == "/repos/owner/repo/issues/101":
+			_ = json.NewEncoder(w).Encode(subIssues[0])
+		case r.URL.Path == "/repos/owner/repo/pulls":
+			head := r.URL.Query().Get("head")
+			if head == "owner:pilot/GH-100" {
+				_, _ = w.Write([]byte(`[{"number": 200, "merged_at": "2026-04-17T14:01:40Z", "head": {"ref": "pilot/GH-100"}}]`))
+				return
+			}
+			_, _ = w.Write([]byte(`[]`))
+		case r.URL.Path == "/repos/owner/repo/issues/101/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for _, l := range body["labels"] {
+				if l == LabelSuperseded {
+					labeledSuperseded.Store(true)
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&dispatches, 1)
+			return nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&dispatches); got != 0 {
+		t.Errorf("dispatched %d times, want 0 (parent-merged guard must skip)", got)
+	}
+	if !labeledSuperseded.Load() {
+		t.Error("expected pilot-superseded label to be added on parent-merged guard")
+	}
+}
+
+// GH-2402: When parent is open, sub-issue dispatches normally.
+func TestPoller_ParentMergedGuard_OpenParent_DispatchesNormally(t *testing.T) {
+	now := time.Now()
+	subIssues := []*Issue{
+		{
+			Number:    101,
+			State:     "open",
+			Title:     "Sub-issue",
+			Labels:    []Label{{Name: "pilot"}},
+			Body:      "Parent: GH-100\n\nDo the thing",
+			CreatedAt: now,
+		},
+	}
+	parent := &Issue{Number: 100, State: "open", Title: "Epic"}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(subIssues)
+		case r.URL.Path == "/repos/owner/repo/issues/100":
+			_ = json.NewEncoder(w).Encode(parent)
+		case r.URL.Path == "/repos/owner/repo/issues/101":
+			_ = json.NewEncoder(w).Encode(subIssues[0])
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	var dispatches int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&dispatches, 1)
+			return nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&dispatches); got != 1 {
+		t.Errorf("dispatched %d times, want 1 (open parent should not block)", got)
+	}
+}

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -96,6 +96,16 @@ const (
 	LabelFailed     = "pilot-failed"
 	LabelRetryReady    = "pilot-retry-ready"    // PR closed without merge, issue ready for retry
 	LabelTitleRejected = "pilot-title-rejected" // GH-2363: title guard escalation; blocks auto-retry until human edits title
+	// LabelBlocked marks an issue that hit a permanent (non-retriable) failure
+	// such as cross-project violation, permission denied, or environment setup
+	// failure. Unlike pilot-failed, LabelBlocked is NOT auto-retried — a human
+	// must remove the label after fixing the underlying issue (GH-2402).
+	LabelBlocked = "pilot-blocked"
+	// LabelSuperseded marks a sub-issue whose parent epic was merged before
+	// this sub-issue was dispatched, indicating the work was rolled into the
+	// parent's PR and re-running it would create duplicate or conflicting
+	// changes (GH-2402).
+	LabelSuperseded = "pilot-superseded"
 )
 
 // Priority mapping from GitHub labels

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2100,6 +2100,17 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 				c.log.Warn("failed to post merge completion comment on external merge", "issue", prState.IssueNumber, "error", err)
 			}
 			}
+
+			// GH-2402: Self-heal execution row to "completed" on external merge.
+			// Mirrors the in-controller merge path (handleMerging) so dashboards
+			// and queries don't see a stale "failed" status after the PR landed.
+			if c.evalStore != nil {
+				taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
+				if err := c.evalStore.UpdateExecutionStatusByTaskID(taskID, "completed"); err != nil {
+					c.log.Warn("failed to update execution status on external merge",
+						"task_id", taskID, "error", err)
+				}
+			}
 		}
 
 		// GH-411: Trigger release for externally merged PRs if auto-release is enabled

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -1212,6 +1212,50 @@ func TestController_CheckExternalMerge_ClosesIssue(t *testing.T) {
 	}
 }
 
+// GH-2402: External merge must self-heal the execution row to "completed" so
+// dashboards/queries don't see a stale "failed" status after the PR landed.
+func TestController_CheckExternalMerge_SelfHealsExecutionStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/42":
+			resp := github.PullRequest{
+				Number:  42,
+				State:   "closed",
+				Merged:  true,
+				HTMLURL: "https://github.com/owner/repo/pull/42",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	evalMock := &mockEvalStore{}
+	c.SetEvalStore(evalMock)
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", "")
+
+	c.processAllPRs(context.Background())
+
+	if len(evalMock.statusUpdates) == 0 {
+		t.Fatal("expected UpdateExecutionStatusByTaskID to be called on external merge")
+	}
+	got := evalMock.statusUpdates[len(evalMock.statusUpdates)-1]
+	if got.taskID != "GH-10" {
+		t.Errorf("status update task_id = %q, want %q", got.taskID, "GH-10")
+	}
+	if got.status != "completed" {
+		t.Errorf("status update status = %q, want %q", got.status, "completed")
+	}
+}
+
 func TestController_CheckExternalMerge_MultiplePRs(t *testing.T) {
 	// Test processing multiple PRs where some are merged externally
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3490,9 +3534,15 @@ func TestSetLearningLoop_ForwardsToFeedbackLoop(t *testing.T) {
 	}
 }
 
-// mockEvalStore captures SaveEvalTask calls for testing.
+// mockEvalStore captures SaveEvalTask and UpdateExecutionStatusByTaskID calls.
 type mockEvalStore struct {
-	saved []*memory.EvalTask
+	saved          []*memory.EvalTask
+	statusUpdates  []evalStatusUpdate // GH-2402: capture status updates
+}
+
+type evalStatusUpdate struct {
+	taskID string
+	status string
 }
 
 func (m *mockEvalStore) SaveEvalTask(task *memory.EvalTask) error {
@@ -3501,6 +3551,7 @@ func (m *mockEvalStore) SaveEvalTask(task *memory.EvalTask) error {
 }
 
 func (m *mockEvalStore) UpdateExecutionStatusByTaskID(taskID, status string) error {
+	m.statusUpdates = append(m.statusUpdates, evalStatusUpdate{taskID: taskID, status: status})
 	return nil
 }
 

--- a/internal/executor/failure.go
+++ b/internal/executor/failure.go
@@ -1,0 +1,43 @@
+package executor
+
+import "strings"
+
+// IsPermanentFailure reports whether an execution error represents a
+// non-retriable, environmental or policy-level failure. Such failures will
+// not improve on retry and should route the issue to LabelBlocked rather
+// than LabelFailed (GH-2402).
+//
+// Categories considered permanent:
+//   - cross-project execution violations (GH-386)
+//   - team-permission denials (GH-634)
+//   - pre-flight environment failures
+//   - worktree creation / Navigator setup failures
+//
+// Rate-limit errors are explicitly NOT permanent — those route through the
+// scheduler. A nil error is treated as non-permanent.
+func IsPermanentFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+
+	// Rate-limit failures are transient — handled by the scheduler.
+	if IsRateLimitError(msg) {
+		return false
+	}
+
+	permanentMarkers := []string{
+		"cross-project execution blocked",
+		"permission check failed",
+		"permission denied",
+		"pre-flight check failed",
+		"worktree creation failed",
+		"navigator worktree setup failed",
+	}
+	for _, marker := range permanentMarkers {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/executor/failure_test.go
+++ b/internal/executor/failure_test.go
@@ -1,0 +1,35 @@
+package executor
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsPermanentFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"empty message", errors.New(""), false},
+		{"random transient", errors.New("connection reset by peer"), false},
+		{"rate limit not permanent", errors.New("hit your limit, resets 6am (UTC)"), false},
+
+		{"cross-project blocked", errors.New("cross-project execution blocked: repo mismatch"), true},
+		{"permission check failed", errors.New("permission check failed: missing role"), true},
+		{"permission denied bare", errors.New("permission denied"), true},
+		{"preflight failed", errors.New("pre-flight check failed: dirty git state"), true},
+		{"worktree creation failed", errors.New("worktree creation failed: disk full"), true},
+		{"navigator worktree setup failed", errors.New("navigator worktree setup failed: missing config"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsPermanentFailure(tt.err)
+			if got != tt.want {
+				t.Errorf("IsPermanentFailure(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2402.

Closes #2402

## Changes

Implement all four fixes from the plan as a single bundled change. The fixes share new label vocabulary (`LabelSuperseded`, `LabelBlocked` in `internal/adapters/github/types.go`) that must be defined before consumers in `poller.go`, `cmd/pilot/handlers.go`, `cmd/pilot/main.go`, `internal/executor/runner.go`, and `internal/autopilot/controller.go` can reference them. Splitting this into separate subtasks would force one to land label constants in isolation (dead code) and create merge conflicts on `types.go` and `poller.go` which receive multiple edits. Scope: (1) add `LabelSuperseded`/`LabelBlocked` constants; (2) add parent-merged pre-dispatch guard in poller (parallel + sequential paths) and skip rule for `LabelBlocked`; (3) add `IsPermanentFailure` helper in runner and wire failure classification in handlers to choose `LabelBlocked` vs `LabelFailed`; (4) wire `OnLabelRemoved("pilot-blocked")` → `ProcessedStore.Clear` in `main.go`; (5) make `pilot-failed` removal unconditional at handlers.go:331; (6) self-heal execution row to `completed` in autopilot controller after merge. Includes unit tests in `poller_test.go`, `runner_test.go`, `handlers_test.go`, `controller_test.go`. Single PR, ~150–250 LOC + ~80 LOC tests.