### PR TITLE
fix(executor,autopilot,github): block stranded sub-issue dispatch + break deterministic-failure retry loop

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -300,11 +300,20 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 		boardStatuses := cfg.Adapters.GitHub.ProjectBoard.GetStatuses()
 
 		if execErr != nil {
-			if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelFailed}); err != nil {
+			// GH-2402: Classify deterministic failures (e.g. non-conventional title)
+			// as pilot-blocked instead of pilot-failed so the poller stops retrying.
+			failureLabel := github.LabelFailed
+			if executor.IsPermanentFailure(execErr.Error()) {
+				failureLabel = github.LabelBlocked
+			}
+			if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{failureLabel}); err != nil {
 				logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
 			}
 			syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Failed) // GH-1853
 			comment := fmt.Sprintf("❌ Pilot execution failed:\n\n```\n%s\n```", execErr.Error())
+			if failureLabel == github.LabelBlocked {
+				comment += "\n\nThis is a deterministic failure (`pilot-blocked`). Retries are paused — fix the underlying issue (e.g. rename to a conventional commit title) and remove the `pilot-blocked` label to resume."
+			}
 			if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
 				logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
 			}
@@ -340,11 +349,13 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				}
 				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Done) // GH-1853
 
-				// GH-1302: Clean up stale pilot-failed label from prior failed attempt
-				if github.HasLabel(issue, github.LabelFailed) {
-					if err := client.RemoveLabel(ctx, parts[0], parts[1], issue.Number, github.LabelFailed); err != nil {
-						logGitHubAPIError("RemoveLabel", parts[0], parts[1], issue.Number, err)
-					}
+				// GH-1302/GH-2402: Clean up stale pilot-failed label from prior failed attempt.
+				// Removed unconditionally — the in-memory `issue` object is the snapshot
+				// from dispatch and won't reflect labels added during execution
+				// (e.g. by an earlier retry on the same poll cycle).
+				if err := client.RemoveLabel(ctx, parts[0], parts[1], issue.Number, github.LabelFailed); err != nil {
+					// 404 is expected if label doesn't exist — log at debug level
+					slog.Debug("pilot-failed label cleanup", "issue", issue.Number, "error", err)
 				}
 
 				// Close the issue so dependent issues can proceed
@@ -365,11 +376,19 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Failed)
 			} else {
 				// result exists but Success is false - mark as failed
-				if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelFailed}); err != nil {
+				// GH-2402: Use pilot-blocked for deterministic failures so we don't retry.
+				failureLabel := github.LabelFailed
+				if hr.Result.Error != "" && executor.IsPermanentFailure(hr.Result.Error) {
+					failureLabel = github.LabelBlocked
+				}
+				if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{failureLabel}); err != nil {
 					logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
 				}
 				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Failed) // GH-1853
 				comment := buildFailureComment(hr.Result)
+				if failureLabel == github.LabelBlocked {
+					comment += "\n\nThis is a deterministic failure (`pilot-blocked`). Retries are paused — fix the underlying issue and remove the `pilot-blocked` label to resume."
+				}
 				if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
 					logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
 				}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2202,6 +2202,12 @@ func runPollingMode(cfg *config.Config, projectPath string, replace, dashboardMo
 								p.ClearProcessed(issueNumber)
 							}
 						}))
+						// GH-2402: Same wiring for pilot-blocked so removal allows re-dispatch.
+						cleanerOpts = append(cleanerOpts, github.WithOnBlockedCleaned(func(issueNumber int) {
+							for _, p := range ghPollers {
+								p.ClearProcessed(issueNumber)
+							}
+						}))
 					}
 					// GH-2354: when pilot-in-progress is stripped from a closed
 					// issue, remove its task from the dashboard monitor so it

--- a/internal/adapters/github/cleanup.go
+++ b/internal/adapters/github/cleanup.go
@@ -34,6 +34,11 @@ type Cleaner struct {
 	// stops appearing in the queue view (GH-2354).
 	OnInProgressCleaned func(issueNumber int)
 
+	// OnBlockedCleaned is called when a pilot-blocked label is removed.
+	// Used to clear the issue from the poller's processed map so it can be
+	// re-dispatched after a human resolves the blocking condition (GH-2402).
+	OnBlockedCleaned func(issueNumber int)
+
 	mu      sync.Mutex
 	running bool
 	stopCh  chan struct{}
@@ -63,6 +68,16 @@ func WithOnFailedCleaned(fn func(issueNumber int)) CleanerOption {
 func WithOnInProgressCleaned(fn func(issueNumber int)) CleanerOption {
 	return func(c *Cleaner) {
 		c.OnInProgressCleaned = fn
+	}
+}
+
+// WithOnBlockedCleaned sets the callback for when a pilot-blocked label is
+// detected as removed. The callback receives the issue number and should
+// clear it from the poller's processed map so the next poll can re-dispatch.
+// GH-2402.
+func WithOnBlockedCleaned(fn func(issueNumber int)) CleanerOption {
+	return func(c *Cleaner) {
+		c.OnBlockedCleaned = fn
 	}
 }
 
@@ -202,12 +217,21 @@ func (c *Cleaner) Cleanup(ctx context.Context) error {
 		return fmt.Errorf("failed to cleanup failed labels: %w", err)
 	}
 
-	totalCleaned := inProgressCleaned + closedCleaned + failedCleaned
+	// GH-2402: Clean up stale pilot-blocked labels. Blocked issues are paused
+	// until human intervention, but the same staleness threshold as pilot-failed
+	// is applied as a safety net so a forgotten label doesn't strand work forever.
+	blockedCleaned, err := c.cleanupLabel(ctx, LabelBlocked, c.failedThreshold, activeTaskIDs)
+	if err != nil {
+		return fmt.Errorf("failed to cleanup blocked labels: %w", err)
+	}
+
+	totalCleaned := inProgressCleaned + closedCleaned + failedCleaned + blockedCleaned
 	if totalCleaned > 0 {
 		c.logger.Info("Stale label cleanup completed",
 			slog.Int("in_progress_cleaned", inProgressCleaned),
 			slog.Int("closed_in_progress_cleaned", closedCleaned),
 			slog.Int("failed_cleaned", failedCleaned),
+			slog.Int("blocked_cleaned", blockedCleaned),
 		)
 	}
 
@@ -286,6 +310,10 @@ func (c *Cleaner) cleanupLabel(ctx context.Context, label string, threshold time
 			comment = "🧹 **Pilot cleanup**: Removed stale `pilot-failed` label.\n\n" +
 				"This issue was marked as failed but has been stale for over 24 hours. " +
 				"The label has been removed to allow Pilot to retry this issue automatically."
+		case LabelBlocked:
+			comment = "🧹 **Pilot cleanup**: Removed stale `pilot-blocked` label.\n\n" +
+				"This issue was paused on a deterministic failure (e.g. non-conventional title) but has " +
+				"been stale for the configured threshold. The label has been removed so Pilot can retry."
 		}
 
 		if _, err := c.client.AddComment(ctx, c.owner, c.repo, issue.Number, comment); err != nil {
@@ -295,9 +323,16 @@ func (c *Cleaner) cleanupLabel(ctx context.Context, label string, threshold time
 			)
 		}
 
-		// For failed labels, notify callback to clear from processed map
-		if label == LabelFailed && c.OnFailedCleaned != nil {
-			c.OnFailedCleaned(issue.Number)
+		// Notify callbacks so the poller can clear its processed map and pick up the issue again.
+		switch label {
+		case LabelFailed:
+			if c.OnFailedCleaned != nil {
+				c.OnFailedCleaned(issue.Number)
+			}
+		case LabelBlocked:
+			if c.OnBlockedCleaned != nil {
+				c.OnBlockedCleaned(issue.Number)
+			}
 		}
 
 		cleanedCount++

--- a/internal/adapters/github/cleanup_test.go
+++ b/internal/adapters/github/cleanup_test.go
@@ -588,6 +588,86 @@ func TestCleaner_Cleanup_StaleFailedLabelsRemoved(t *testing.T) {
 	}
 }
 
+// GH-2402: Cleaner removes stale pilot-blocked labels and fires OnBlockedCleaned
+// so the poller can clear the issue from its processed map.
+func TestCleaner_Cleanup_StaleBlockedLabelsRemoved(t *testing.T) {
+	store := createTestStore(t)
+	defer func() { _ = store.Close() }()
+
+	staleTime := time.Now().Add(-25 * time.Hour)
+	allIssues := []*Issue{
+		{
+			Number:    789,
+			Title:     "Stale Blocked Issue",
+			Labels:    []Label{{Name: LabelBlocked}},
+			UpdatedAt: staleTime,
+		},
+	}
+
+	var (
+		mu                     sync.Mutex
+		removeLabelCalled      bool
+		addCommentCalled       bool
+		onBlockedCleanedCalled bool
+		cleanedIssueNumber     int
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues" {
+			_ = json.NewEncoder(w).Encode(allIssues)
+			return
+		}
+		if r.Method == http.MethodDelete && r.URL.Path == "/repos/owner/repo/issues/789/labels/"+LabelBlocked {
+			removeLabelCalled = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/issues/789/comments" {
+			addCommentCalled = true
+			_ = json.NewEncoder(w).Encode(&Comment{ID: 1, Body: "cleanup"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
+		Enabled:         true,
+		Interval:        30 * time.Minute,
+		Threshold:       1 * time.Hour,
+		FailedThreshold: 24 * time.Hour,
+	}, WithOnBlockedCleaned(func(issueNumber int) {
+		mu.Lock()
+		onBlockedCleanedCalled = true
+		cleanedIssueNumber = issueNumber
+		mu.Unlock()
+	}))
+
+	if err := cleaner.Cleanup(context.Background()); err != nil {
+		t.Errorf("Cleanup() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !removeLabelCalled {
+		t.Error("RemoveLabel should have been called for stale blocked issue")
+	}
+	if !addCommentCalled {
+		t.Error("AddComment should have been called for stale blocked issue")
+	}
+	if !onBlockedCleanedCalled {
+		t.Error("OnBlockedCleaned callback should have been called")
+	}
+	if cleanedIssueNumber != 789 {
+		t.Errorf("OnBlockedCleaned called with issue %d, want 789", cleanedIssueNumber)
+	}
+}
+
 func TestCleaner_Cleanup_RecentFailedIssuesSkipped(t *testing.T) {
 	store := createTestStore(t)
 	defer func() { _ = store.Close() }()

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -612,6 +612,17 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 			continue
 		}
 
+		// GH-2402: Skip permanently-blocked issues. The user must remove
+		// the pilot-blocked label to retry (e.g. after fixing a non-conventional title).
+		if HasLabel(issue, LabelBlocked) {
+			continue
+		}
+
+		// GH-2402: Auto-close sub-issues whose parent epic already shipped.
+		if p.skipSupersededByParent(ctx, issue) {
+			continue
+		}
+
 		// GH-2176: Auto-retry issues stuck with pilot-failed (no pilot-done)
 		if HasLabel(issue, LabelFailed) {
 			if !p.shouldRetryFailedIssue(ctx, issue) {
@@ -809,6 +820,17 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 
 		// Skip if already in progress
 		if HasLabel(issue, LabelInProgress) {
+			continue
+		}
+
+		// GH-2402: Skip permanently-blocked issues. The user must remove
+		// the pilot-blocked label to retry (e.g. after fixing a non-conventional title).
+		if HasLabel(issue, LabelBlocked) {
+			continue
+		}
+
+		// GH-2402: Auto-close sub-issues whose parent epic already shipped.
+		if p.skipSupersededByParent(ctx, issue) {
 			continue
 		}
 
@@ -1357,6 +1379,69 @@ func (p *Poller) shouldRetryRetryReadyIssue(ctx context.Context, issue *Issue) b
 		slog.Int("max", p.maxRetryReadyRetries),
 	)
 
+	return true
+}
+
+// skipSupersededByParent auto-closes a sub-issue whose parent epic has already
+// shipped (closed AND has pilot-done). Returns true if the issue was closed
+// and should be skipped from dispatch. GH-2402.
+//
+// On transient API errors (e.g. failed parent lookup) the function returns
+// false so the issue falls through to normal dispatch — we never want to lose
+// work because of a flaky GET.
+func (p *Poller) skipSupersededByParent(ctx context.Context, issue *Issue) bool {
+	parentNum := ParseParentIssueNumber(issue.Body)
+	if parentNum <= 0 {
+		return false
+	}
+
+	parent, err := p.client.GetIssue(ctx, p.owner, p.repo, parentNum)
+	if err != nil {
+		p.logger.Warn("Failed to fetch parent issue, falling through to normal dispatch",
+			slog.Int("issue", issue.Number),
+			slog.Int("parent", parentNum),
+			slog.Any("error", err),
+		)
+		return false
+	}
+
+	// Parent must be both closed AND marked done. A closed-without-done parent
+	// (e.g. user closed the epic manually before Pilot finished) shouldn't
+	// strand sub-issues.
+	if parent.State != StateClosed || !HasLabel(parent, LabelDone) {
+		return false
+	}
+
+	p.logger.Info("Auto-closing sub-issue: parent epic already shipped",
+		slog.Int("issue", issue.Number),
+		slog.Int("parent", parentNum),
+	)
+
+	comment := fmt.Sprintf(
+		"🔁 Auto-closed by Pilot: parent epic #%d already shipped this work. "+
+			"This sub-issue is redundant.",
+		parentNum,
+	)
+	if _, cerr := p.client.AddComment(ctx, p.owner, p.repo, issue.Number, comment); cerr != nil {
+		p.logger.Warn("Failed to post superseded comment",
+			slog.Int("issue", issue.Number),
+			slog.Any("error", cerr),
+		)
+	}
+	if lerr := p.client.AddLabels(ctx, p.owner, p.repo, issue.Number, []string{LabelSuperseded}); lerr != nil {
+		p.logger.Warn("Failed to add pilot-superseded label",
+			slog.Int("issue", issue.Number),
+			slog.Any("error", lerr),
+		)
+	}
+	if uerr := p.client.UpdateIssueState(ctx, p.owner, p.repo, issue.Number, StateClosed); uerr != nil {
+		p.logger.Warn("Failed to close superseded sub-issue",
+			slog.Int("issue", issue.Number),
+			slog.Any("error", uerr),
+		)
+	}
+
+	p.markProcessed(issue.Number)
 	return true
 }
 

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2704,3 +2704,183 @@ func TestPoller_CheckForNewIssues_StaleSnapshot_RefreshesLabels(t *testing.T) {
 		t.Errorf("dispatched %d times, want 0 (fresh GetIssue shows pilot-done)", got)
 	}
 }
+
+// GH-2402: Sub-issues whose parent epic already shipped must be auto-closed
+// with pilot-superseded instead of dispatched.
+func TestPoller_CheckForNewIssues_SkipsSupersededByParent(t *testing.T) {
+	subIssue := &Issue{
+		Number: 200,
+		Title:  "Sub-issue under shipped epic",
+		Body:   "Parent: GH-100\n\nSome work.",
+		State:  "open",
+		Labels: []Label{{Name: "pilot"}},
+	}
+	parent := &Issue{
+		Number: 100,
+		Title:  "Epic",
+		State:  "closed",
+		Labels: []Label{{Name: "pilot"}, {Name: LabelDone}},
+	}
+
+	var (
+		mu               sync.Mutex
+		gotComment       string
+		gotLabels        []string
+		closedIssueState string
+		dispatches       int32
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode([]*Issue{subIssue})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/100":
+			_ = json.NewEncoder(w).Encode(parent)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/200":
+			_ = json.NewEncoder(w).Encode(subIssue)
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/issues/200/comments":
+			var payload struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			mu.Lock()
+			gotComment = payload.Body
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{"id":1}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/issues/200/labels":
+			var payload struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			mu.Lock()
+			gotLabels = append(gotLabels, payload.Labels...)
+			mu.Unlock()
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPatch && r.URL.Path == "/repos/owner/repo/issues/200":
+			var payload struct {
+				State string `json:"state"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			mu.Lock()
+			closedIssueState = payload.State
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&dispatches, 1)
+			return nil
+		}),
+	)
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&dispatches); got != 0 {
+		t.Errorf("dispatched %d times, want 0 (sub-issue should be auto-closed)", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !strings.Contains(gotComment, "parent epic #100") {
+		t.Errorf("comment missing parent reference: %q", gotComment)
+	}
+	hasSuperseded := false
+	for _, l := range gotLabels {
+		if l == LabelSuperseded {
+			hasSuperseded = true
+			break
+		}
+	}
+	if !hasSuperseded {
+		t.Errorf("expected pilot-superseded label, got %v", gotLabels)
+	}
+	if closedIssueState != "closed" {
+		t.Errorf("expected sub-issue closed, got state=%q", closedIssueState)
+	}
+}
+
+// GH-2402: Sub-issues whose parent is closed but NOT marked done should NOT
+// be auto-closed (e.g. user manually closed the epic before Pilot finished).
+func TestPoller_CheckForNewIssues_DoesNotSupersedeWhenParentNotDone(t *testing.T) {
+	subIssue := &Issue{
+		Number: 201,
+		Title:  "Sub-issue",
+		Body:   "Parent: GH-101\n",
+		State:  "open",
+		Labels: []Label{{Name: "pilot"}},
+	}
+	parent := &Issue{
+		Number: 101,
+		Title:  "Epic",
+		State:  "closed",
+		Labels: []Label{{Name: "pilot"}}, // No LabelDone
+	}
+
+	var dispatches int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode([]*Issue{subIssue})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/101":
+			_ = json.NewEncoder(w).Encode(parent)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/201":
+			_ = json.NewEncoder(w).Encode(subIssue)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&dispatches, 1)
+			return nil
+		}),
+	)
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&dispatches); got != 1 {
+		t.Errorf("dispatched %d times, want 1 (parent closed but not done — should dispatch)", got)
+	}
+}
+
+// GH-2402: Issues with pilot-blocked must be skipped — no dispatch and no retry
+// until the user removes the label.
+func TestPoller_CheckForNewIssues_SkipsBlockedIssues(t *testing.T) {
+	blocked := &Issue{
+		Number: 300,
+		Title:  "deterministic failure",
+		State:  "open",
+		Labels: []Label{{Name: "pilot"}, {Name: LabelBlocked}},
+	}
+
+	var dispatches int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]*Issue{blocked})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&dispatches, 1)
+			return nil
+		}),
+	)
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&dispatches); got != 0 {
+		t.Errorf("dispatched %d times, want 0 (pilot-blocked must skip)", got)
+	}
+}

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -96,6 +96,8 @@ const (
 	LabelFailed     = "pilot-failed"
 	LabelRetryReady    = "pilot-retry-ready"    // PR closed without merge, issue ready for retry
 	LabelTitleRejected = "pilot-title-rejected" // GH-2363: title guard escalation; blocks auto-retry until human edits title
+	LabelSuperseded    = "pilot-superseded"     // GH-2402: sub-issue auto-closed because parent epic already shipped the work
+	LabelBlocked       = "pilot-blocked"        // GH-2402: deterministic failure that won't change between retries (e.g. non-conventional title)
 )
 
 // Priority mapping from GitHub labels

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -85,6 +85,9 @@ type EvalStore interface {
 	// UpdateExecutionStatusByTaskID updates execution status by task ID.
 	// Used to mark failed executions as completed when the PR is merged.
 	UpdateExecutionStatusByTaskID(taskID, status string) error
+	// SelfHealExecutionAfterMerge promotes failed rows to completed and
+	// stamps the PR URL after a successful merge. GH-2402.
+	SelfHealExecutionAfterMerge(taskID, prURL string) error
 }
 
 // ControllerOption is a functional option for Controller configuration.
@@ -1018,11 +1021,14 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 			c.log.Debug("updated monitor state to completed", "task", taskID, "pr", prState.PRNumber)
 		}
 
-		// GH-2279: Update execution record from "failed" to "completed" when PR is merged
+		// GH-2279/GH-2402: Self-heal execution record on merge. Promotes any prior
+		// "failed" row to "completed" and stamps the PR URL so the dashboard
+		// reflects the merged outcome (handles user-pushed commits, sub-issues
+		// merged via parent, etc.).
 		if c.evalStore != nil {
 			taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
-			if err := c.evalStore.UpdateExecutionStatusByTaskID(taskID, "completed"); err != nil {
-				c.log.Warn("failed to update execution status on merge",
+			if err := c.evalStore.SelfHealExecutionAfterMerge(taskID, prState.PRURL); err != nil {
+				c.log.Warn("failed to self-heal execution on merge",
 					"task_id", taskID, "error", err)
 			}
 		}

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -415,6 +415,72 @@ func TestController_ProcessPR_CIFailure(t *testing.T) {
 	}
 }
 
+// GH-2402: After a successful merge, the controller must call
+// SelfHealExecutionAfterMerge so any prior failed execution row for the
+// same task ID is promoted to "completed" with the PR URL stamped.
+func TestController_HandleMerging_SelfHealsExecution(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/abc1234/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/pulls/42/merge":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"merged123","merged":true,"message":"merged"}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoReview = false
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	evalMock := &mockEvalStore{}
+	c.SetEvalStore(evalMock)
+
+	c.mu.Lock()
+	c.activePRs[42] = &PRState{
+		PRNumber:    42,
+		PRURL:       "https://github.com/owner/repo/pull/42",
+		HeadSHA:     "abc1234",
+		IssueNumber: 99,
+		Stage:       StageMerging,
+	}
+	c.mu.Unlock()
+
+	if err := c.ProcessPR(context.Background(), 42, nil); err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	if len(evalMock.selfHealed) != 1 {
+		t.Fatalf("expected 1 self-heal call, got %d", len(evalMock.selfHealed))
+	}
+	got := evalMock.selfHealed[0]
+	if got.TaskID != "GH-99" {
+		t.Errorf("self-heal task ID = %q, want GH-99", got.TaskID)
+	}
+	if got.PRURL != "https://github.com/owner/repo/pull/42" {
+		t.Errorf("self-heal PR URL = %q, want PR URL", got.PRURL)
+	}
+	// Old UpdateExecutionStatusByTaskID path must NOT also be invoked — self-heal
+	// supersedes it so we don't write stale rows without the PR URL.
+	if len(evalMock.updateStatus) != 0 {
+		t.Errorf("expected 0 UpdateExecutionStatusByTaskID calls (self-heal replaces it), got %d", len(evalMock.updateStatus))
+	}
+}
+
 func TestController_CircuitBreaker(t *testing.T) {
 	// Test per-PR circuit breaker trips after max failures for that specific PR
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3492,7 +3558,19 @@ func TestSetLearningLoop_ForwardsToFeedbackLoop(t *testing.T) {
 
 // mockEvalStore captures SaveEvalTask calls for testing.
 type mockEvalStore struct {
-	saved []*memory.EvalTask
+	saved        []*memory.EvalTask
+	selfHealed   []selfHealCall
+	updateStatus []updateStatusCall
+}
+
+type selfHealCall struct {
+	TaskID string
+	PRURL  string
+}
+
+type updateStatusCall struct {
+	TaskID string
+	Status string
 }
 
 func (m *mockEvalStore) SaveEvalTask(task *memory.EvalTask) error {
@@ -3501,6 +3579,12 @@ func (m *mockEvalStore) SaveEvalTask(task *memory.EvalTask) error {
 }
 
 func (m *mockEvalStore) UpdateExecutionStatusByTaskID(taskID, status string) error {
+	m.updateStatus = append(m.updateStatus, updateStatusCall{TaskID: taskID, Status: status})
+	return nil
+}
+
+func (m *mockEvalStore) SelfHealExecutionAfterMerge(taskID, prURL string) error {
+	m.selfHealed = append(m.selfHealed, selfHealCall{TaskID: taskID, PRURL: prURL})
 	return nil
 }
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -21,6 +21,31 @@ import (
 	"github.com/qf-studio/pilot/internal/webhooks"
 )
 
+// permanentFailurePatterns are substrings in error messages that indicate
+// failures which won't change between retries (e.g. invalid issue title).
+// GH-2402: terminal-classify these so the poller stops the retry loop.
+var permanentFailurePatterns = []string{
+	"title is not a conventional commit",
+	"could not auto-correct",
+	"PR creation refused",
+}
+
+// IsPermanentFailure reports whether an error message represents a
+// deterministic failure that won't change between retries. Callers should
+// label such failures with pilot-blocked instead of pilot-failed so the
+// poller doesn't burn cycles on identical retries. GH-2402.
+func IsPermanentFailure(errStr string) bool {
+	if errStr == "" {
+		return false
+	}
+	for _, pat := range permanentFailurePatterns {
+		if strings.Contains(errStr, pat) {
+			return true
+		}
+	}
+	return false
+}
+
 // StreamEvent represents a Claude Code stream-json event
 type StreamEvent struct {
 	Type          string          `json:"type"`

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3332,3 +3332,29 @@ func TestTruncateDiagnostic(t *testing.T) {
 		t.Errorf("diagnosticsMessageMaxChars = %d, want 4096", diagnosticsMessageMaxChars)
 	}
 }
+
+// GH-2402: IsPermanentFailure must classify deterministic errors so the
+// caller can apply pilot-blocked instead of pilot-failed (which auto-retries).
+func TestIsPermanentFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		err  string
+		want bool
+	}{
+		{"empty string", "", false},
+		{"transient network error", "connection refused: dial tcp", false},
+		{"rate limit hit", "rate limit exceeded, retry after 60s", false},
+		{"non-conventional title", "PR creation refused: title is not a conventional commit: 'Implement test thing'", true},
+		{"could not auto-correct title", "title is invalid: could not auto-correct to a conventional commit", true},
+		{"PR creation refused (catch-all)", "PR creation refused: some reason", true},
+		{"random failure", "no_changes: Claude completed but made no code changes", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPermanentFailure(tt.err); got != tt.want {
+				t.Errorf("IsPermanentFailure(%q) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -940,6 +940,24 @@ func (s *Store) UpdateExecutionStatusByTaskID(taskID, status string) error {
 	})
 }
 
+// SelfHealExecutionAfterMerge promotes any "failed" rows for the given task ID
+// to "completed" and stamps the PR URL so the dashboard reflects the merged
+// outcome. Used when autopilot observes a merge for an issue whose previous
+// execution row was recorded as failed (e.g. user-pushed commits, sub-issue
+// shipped via parent epic). GH-2402.
+func (s *Store) SelfHealExecutionAfterMerge(taskID, prURL string) error {
+	return s.withRetry("SelfHealExecutionAfterMerge", func() error {
+		_, err := s.db.Exec(`
+			UPDATE executions
+			SET status = 'completed',
+				completed_at = CURRENT_TIMESTAMP,
+				pr_url = CASE WHEN ? <> '' THEN ? ELSE pr_url END
+			WHERE task_id = ? AND status = 'failed'
+		`, prURL, prURL, taskID)
+		return err
+	})
+}
+
 // UpdateExecutionResult updates the result fields of an execution record.
 // Called when task execution completes successfully with PR/commit info.
 func (s *Store) UpdateExecutionResult(id string, prURL, commitSHA string, durationMs int64) error {


### PR DESCRIPTION
## Summary

Closes #2402.

Stops Pilot from spinning on two failure modes observed during the GH-2396 epic on 2026-04-25:
- Sub-issues stranded after the parent epic shipped directly (GH-2397, GH-2398)
- Title-rejection failures retried 5× in 42 minutes producing identical errors

### Changes

- **`internal/adapters/github/types.go`** — new label constants `LabelSuperseded` (`pilot-superseded`) and `LabelBlocked` (`pilot-blocked`).
- **`internal/adapters/github/poller.go`** — `skipSupersededByParent` auto-closes sub-issues whose parent epic is closed AND has `pilot-done`, posting a comment + adding `pilot-superseded`. Wired into both parallel and sequential dispatch paths. Also skips issues with `pilot-blocked` so deterministic failures don't re-dispatch until a human removes the label.
- **`internal/executor/runner.go`** — `IsPermanentFailure(errStr)` classifies `title is not a conventional commit`, `could not auto-correct`, and `PR creation refused` errors as deterministic.
- **`cmd/pilot/handlers.go`** — failure path picks `pilot-blocked` for permanent failures, `pilot-failed` otherwise; comment instructs user to fix and remove the label. `pilot-failed` cleanup at the success path is now unconditional (stale-label snapshot bug).
- **`internal/adapters/github/cleanup.go`** — stale `pilot-blocked` labels get removed after `failedThreshold` and fire `OnBlockedCleaned` so the poller can clear its processed map.
- **`cmd/pilot/main.go`** — wires `WithOnBlockedCleaned` → `ClearProcessed` (mirrors existing failed-cleanup callback).
- **`internal/memory/store.go` + `internal/autopilot/controller.go`** — new `SelfHealExecutionAfterMerge(taskID, prURL)` promotes prior failed execution rows to `completed` and stamps the PR URL on merge so the dashboard self-heals when work is shipped via user-pushed commits or a parent epic. Replaces the GH-2279 status-only update at the post-merge call site.

### Tests

- `internal/adapters/github/poller_test.go` — superseded-by-parent guard, parent-closed-but-not-done case, blocked-label skip
- `internal/executor/runner_test.go` — `IsPermanentFailure` table tests (transient vs deterministic)
- `internal/adapters/github/cleanup_test.go` — stale `pilot-blocked` cleanup fires `OnBlockedCleaned`
- `internal/autopilot/controller_test.go` — `handleMerging` calls `SelfHealExecutionAfterMerge` with the correct task ID + PR URL after a successful merge

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/adapters/github/ ./internal/executor/ ./internal/autopilot/ ./internal/memory/ ./cmd/pilot/` all pass
- [x] `go vet ./...` clean
- [ ] Post-deploy: create non-conventional-title issue, verify `pilot-blocked` applied (not `pilot-failed`) and no retry loop
- [ ] Post-deploy: verify stale GH-2398 cleanup once `pilot-blocked` removal triggers re-dispatch