### PR TITLE
fix(executor): support modern opencode message schema

### DIFF
--- a/internal/executor/backend_opencode.go
+++ b/internal/executor/backend_opencode.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -26,6 +27,21 @@ type OpenCodeBackend struct {
 	httpClient *http.Client
 	serverCmd  *exec.Cmd
 	serverMu   sync.Mutex
+}
+
+type openCodeModelRef struct {
+	ProviderID string `json:"providerID"`
+	ModelID    string `json:"modelID"`
+}
+
+type openCodeTextPart struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type openCodeMessagePayload struct {
+	Model interface{}        `json:"model,omitempty"`
+	Parts []openCodeTextPart `json:"parts"`
 }
 
 // NewOpenCodeBackend creates a new OpenCode backend.
@@ -200,45 +216,23 @@ func (b *OpenCodeBackend) createSession(ctx context.Context, projectPath string)
 func (b *OpenCodeBackend) sendMessage(ctx context.Context, sessionID string, opts ExecuteOptions) (*BackendResult, error) {
 	result := &BackendResult{}
 
-	// Build message payload
-	payload := map[string]interface{}{
-		"parts": []map[string]interface{}{
-			{
-				"type": "text",
-				"text": opts.Prompt,
-			},
-		},
-	}
-
-	if b.config.Model != "" {
-		payload["model"] = b.config.Model
-	}
-
-	jsonData, err := json.Marshal(payload)
+	payloads, err := b.buildMessagePayloads(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	// Use async endpoint for streaming
-	req, err := http.NewRequestWithContext(ctx, "POST",
-		fmt.Sprintf("%s/session/%s/message", b.config.ServerURL, sessionID),
-		bytes.NewBuffer(jsonData))
+	resp, err := b.doMessageRequest(ctx, sessionID, payloads[0])
 	if err != nil {
-		return nil, err
+		var messageErr *openCodeMessageError
+		if len(payloads) > 1 && errors.As(err, &messageErr) && shouldRetryOpenCodeMessageLegacy(messageErr.Body) {
+			b.log.Warn("OpenCode message payload rejected, retrying with legacy schema")
+			resp, err = b.doMessageRequest(ctx, sessionID, payloads[1])
+		}
 	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "text/event-stream")
-
-	resp, err := b.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("message failed: %s", string(body))
-	}
 
 	// Check if streaming response
 	if strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
@@ -267,6 +261,97 @@ func (b *OpenCodeBackend) sendMessage(ctx context.Context, sessionID string, opt
 	}
 
 	return result, nil
+}
+
+type openCodeMessageError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *openCodeMessageError) Error() string {
+	return fmt.Sprintf("message failed: %s", e.Body)
+}
+
+func (b *OpenCodeBackend) buildMessagePayloads(opts ExecuteOptions) ([]openCodeMessagePayload, error) {
+	parts := []openCodeTextPart{{Type: "text", Text: opts.Prompt}}
+	modern := openCodeMessagePayload{Parts: parts}
+	legacy := openCodeMessagePayload{Parts: parts}
+
+	modelRef, modelString := b.resolveOpenCodeModel(opts.Model)
+	if modelRef != nil {
+		modern.Model = modelRef
+		legacy.Model = modelString
+		return []openCodeMessagePayload{modern, legacy}, nil
+	}
+	if modelString != "" {
+		modern.Model = modelString
+		return []openCodeMessagePayload{modern}, nil
+	}
+
+	return []openCodeMessagePayload{modern}, nil
+}
+
+func (b *OpenCodeBackend) doMessageRequest(ctx context.Context, sessionID string, payload openCodeMessagePayload) (*http.Response, error) {
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST",
+		fmt.Sprintf("%s/session/%s/message", b.config.ServerURL, sessionID),
+		bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusOK {
+		return resp, nil
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	return nil, &openCodeMessageError{StatusCode: resp.StatusCode, Body: string(body)}
+}
+
+func (b *OpenCodeBackend) resolveOpenCodeModel(override string) (*openCodeModelRef, string) {
+	raw := strings.TrimSpace(override)
+	if raw == "" {
+		raw = strings.TrimSpace(b.config.Model)
+	}
+	provider := strings.TrimSpace(b.config.Provider)
+	if raw == "" {
+		return nil, ""
+	}
+
+	if strings.Contains(raw, "/") {
+		parts := strings.SplitN(raw, "/", 2)
+		if parts[0] != "" && parts[1] != "" {
+			return &openCodeModelRef{ProviderID: parts[0], ModelID: parts[1]}, raw
+		}
+	}
+
+	if provider != "" {
+		return &openCodeModelRef{ProviderID: provider, ModelID: raw}, provider + "/" + raw
+	}
+
+	return nil, raw
+}
+
+func shouldRetryOpenCodeMessageLegacy(body string) bool {
+	body = strings.ToLower(body)
+	if strings.Contains(body, `"path":["model"]`) && strings.Contains(body, "expected string") {
+		return true
+	}
+	if strings.Contains(body, `"path":["parts",0,"type"]`) {
+		return true
+	}
+	return false
 }
 
 // parseSSEStream parses Server-Sent Events from OpenCode.

--- a/internal/executor/backend_opencode_test.go
+++ b/internal/executor/backend_opencode_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -289,14 +288,10 @@ func TestOpenCodeBackendBuildMessagePayloads(t *testing.T) {
 		t.Fatalf("payload count = %d, want 2", len(payloads))
 	}
 
-	modernJSON, _ := json.Marshal(payloads[0])
-	legacyJSON, _ := json.Marshal(payloads[1])
-	if !strings.Contains(string(modernJSON), `"model":{"providerID":"dokproxy","modelID":"gpt-5.4"}`) {
-		t.Fatalf("modern payload missing model object: %s", string(modernJSON))
-	}
-	if !strings.Contains(string(legacyJSON), `"model":"dokproxy/gpt-5.4"`) {
-		t.Fatalf("legacy payload missing model string: %s", string(legacyJSON))
-	}
+	assertTextPartsPayload(t, payloads[0], "hello")
+	assertTextPartsPayload(t, payloads[1], "hello")
+	assertObjectModelPayload(t, payloads[0], "dokproxy", "gpt-5.4")
+	assertStringModelPayload(t, payloads[1], "dokproxy/gpt-5.4")
 }
 
 func TestOpenCodeBackendSendMessageRetriesLegacyOnSchemaMismatch(t *testing.T) {
@@ -307,19 +302,17 @@ func TestOpenCodeBackendSendMessageRetriesLegacyOnSchemaMismatch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read body: %v", err)
 		}
-		payload := string(body)
+		payloadMap := decodePayloadMap(t, body)
 
 		switch requestCount.Load() {
 		case 1:
-			if !strings.Contains(payload, `"model":{"providerID":"dokproxy","modelID":"gpt-5.4"}`) {
-				t.Fatalf("first payload missing modern model object: %s", payload)
-			}
+			assertPayloadPartsMap(t, payloadMap, "hello")
+			assertPayloadObjectModelMap(t, payloadMap, "dokproxy", "gpt-5.4")
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte(`{"error":[{"expected":"string","path":["model"],"message":"Invalid input: expected string, received object"}]}`))
 		case 2:
-			if !strings.Contains(payload, `"model":"dokproxy/gpt-5.4"`) {
-				t.Fatalf("second payload missing legacy model string: %s", payload)
-			}
+			assertPayloadPartsMap(t, payloadMap, "hello")
+			assertPayloadStringModelMap(t, payloadMap, "dokproxy/gpt-5.4")
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"success":true,"output":"ok"}`))
 		default:
@@ -347,5 +340,95 @@ func TestShouldRetryOpenCodeMessageLegacy(t *testing.T) {
 	}
 	if shouldRetryOpenCodeMessageLegacy(`{"error":"boom"}`) {
 		t.Fatal("unexpected retry for unrelated error")
+	}
+}
+
+func decodePayloadMap(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var payload map[string]interface{}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v\nbody=%s", err, string(body))
+	}
+	return payload
+}
+
+func assertTextPartsPayload(t *testing.T, payload openCodeMessagePayload, wantText string) {
+	t.Helper()
+	if len(payload.Parts) != 1 {
+		t.Fatalf("parts len = %d, want 1", len(payload.Parts))
+	}
+	if payload.Parts[0].Type != "text" {
+		t.Fatalf("part type = %q, want text", payload.Parts[0].Type)
+	}
+	if payload.Parts[0].Text != wantText {
+		t.Fatalf("part text = %q, want %q", payload.Parts[0].Text, wantText)
+	}
+}
+
+func assertObjectModelPayload(t *testing.T, payload openCodeMessagePayload, wantProvider, wantModel string) {
+	t.Helper()
+	model, ok := payload.Model.(*openCodeModelRef)
+	if !ok {
+		t.Fatalf("model type = %T, want *openCodeModelRef", payload.Model)
+	}
+	if model.ProviderID != wantProvider {
+		t.Fatalf("providerID = %q, want %q", model.ProviderID, wantProvider)
+	}
+	if model.ModelID != wantModel {
+		t.Fatalf("modelID = %q, want %q", model.ModelID, wantModel)
+	}
+}
+
+func assertStringModelPayload(t *testing.T, payload openCodeMessagePayload, want string) {
+	t.Helper()
+	model, ok := payload.Model.(string)
+	if !ok {
+		t.Fatalf("model type = %T, want string", payload.Model)
+	}
+	if model != want {
+		t.Fatalf("model = %q, want %q", model, want)
+	}
+}
+
+func assertPayloadPartsMap(t *testing.T, payload map[string]interface{}, wantText string) {
+	t.Helper()
+	parts, ok := payload["parts"].([]interface{})
+	if !ok || len(parts) != 1 {
+		t.Fatalf("parts = %#v, want single-element slice", payload["parts"])
+	}
+	part, ok := parts[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("part type = %T, want object", parts[0])
+	}
+	if part["type"] != "text" {
+		t.Fatalf("part type = %#v, want text", part["type"])
+	}
+	if part["text"] != wantText {
+		t.Fatalf("part text = %#v, want %q", part["text"], wantText)
+	}
+}
+
+func assertPayloadObjectModelMap(t *testing.T, payload map[string]interface{}, wantProvider, wantModel string) {
+	t.Helper()
+	model, ok := payload["model"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("model type = %T, want object", payload["model"])
+	}
+	if model["providerID"] != wantProvider {
+		t.Fatalf("providerID = %#v, want %q", model["providerID"], wantProvider)
+	}
+	if model["modelID"] != wantModel {
+		t.Fatalf("modelID = %#v, want %q", model["modelID"], wantModel)
+	}
+}
+
+func assertPayloadStringModelMap(t *testing.T, payload map[string]interface{}, want string) {
+	t.Helper()
+	model, ok := payload["model"].(string)
+	if !ok {
+		t.Fatalf("model type = %T, want string", payload["model"])
+	}
+	if model != want {
+		t.Fatalf("model = %q, want %q", model, want)
 	}
 }

--- a/internal/executor/backend_opencode_test.go
+++ b/internal/executor/backend_opencode_test.go
@@ -1,6 +1,13 @@
 package executor
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -255,5 +262,90 @@ func TestOpenCodeEventStructs(t *testing.T) {
 	}
 	if event.Usage.InputTokens != 100 {
 		t.Errorf("Usage.InputTokens = %d, want 100", event.Usage.InputTokens)
+	}
+}
+
+func TestOpenCodeBackendResolveOpenCodeModel(t *testing.T) {
+	backend := NewOpenCodeBackend(&OpenCodeConfig{Model: "dokproxy/gpt-5.4", Provider: "dokproxy"})
+	modelRef, modelString := backend.resolveOpenCodeModel("")
+	if modelRef == nil {
+		t.Fatal("expected model ref")
+	}
+	if modelRef.ProviderID != "dokproxy" || modelRef.ModelID != "gpt-5.4" {
+		t.Fatalf("unexpected model ref: %+v", *modelRef)
+	}
+	if modelString != "dokproxy/gpt-5.4" {
+		t.Fatalf("modelString = %q", modelString)
+	}
+}
+
+func TestOpenCodeBackendBuildMessagePayloads(t *testing.T) {
+	backend := NewOpenCodeBackend(&OpenCodeConfig{Model: "dokproxy/gpt-5.4", Provider: "dokproxy"})
+	payloads, err := backend.buildMessagePayloads(ExecuteOptions{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("buildMessagePayloads error = %v", err)
+	}
+	if len(payloads) != 2 {
+		t.Fatalf("payload count = %d, want 2", len(payloads))
+	}
+
+	modernJSON, _ := json.Marshal(payloads[0])
+	legacyJSON, _ := json.Marshal(payloads[1])
+	if !strings.Contains(string(modernJSON), `"model":{"providerID":"dokproxy","modelID":"gpt-5.4"}`) {
+		t.Fatalf("modern payload missing model object: %s", string(modernJSON))
+	}
+	if !strings.Contains(string(legacyJSON), `"model":"dokproxy/gpt-5.4"`) {
+		t.Fatalf("legacy payload missing model string: %s", string(legacyJSON))
+	}
+}
+
+func TestOpenCodeBackendSendMessageRetriesLegacyOnSchemaMismatch(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		payload := string(body)
+
+		switch requestCount.Load() {
+		case 1:
+			if !strings.Contains(payload, `"model":{"providerID":"dokproxy","modelID":"gpt-5.4"}`) {
+				t.Fatalf("first payload missing modern model object: %s", payload)
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":[{"expected":"string","path":["model"],"message":"Invalid input: expected string, received object"}]}`))
+		case 2:
+			if !strings.Contains(payload, `"model":"dokproxy/gpt-5.4"`) {
+				t.Fatalf("second payload missing legacy model string: %s", payload)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true,"output":"ok"}`))
+		default:
+			t.Fatalf("unexpected extra retry")
+		}
+	}))
+	defer server.Close()
+
+	backend := NewOpenCodeBackend(&OpenCodeConfig{ServerURL: server.URL, Model: "dokproxy/gpt-5.4", Provider: "dokproxy"})
+	result, err := backend.sendMessage(context.Background(), "sess-1", ExecuteOptions{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("sendMessage error = %v", err)
+	}
+	if !result.Success || result.Output != "ok" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if got := requestCount.Load(); got != 2 {
+		t.Fatalf("requestCount = %d, want 2", got)
+	}
+}
+
+func TestShouldRetryOpenCodeMessageLegacy(t *testing.T) {
+	if !shouldRetryOpenCodeMessageLegacy(`{"path":["model"],"message":"Invalid input: expected string, received object"}`) {
+		t.Fatal("expected retry for model schema mismatch")
+	}
+	if shouldRetryOpenCodeMessageLegacy(`{"error":"boom"}`) {
+		t.Fatal("unexpected retry for unrelated error")
 	}
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -72,7 +72,7 @@ func RunChecks(cfg *config.Config) *HealthReport {
 	}
 
 	report := &HealthReport{
-		Dependencies: checkDependenciesWithBackend(backendType),
+		Dependencies: checkDependenciesWithBackend(backendType, cfg),
 		Config:       checkConfig(cfg),
 		Features:     checkFeatures(cfg),
 		Projects:     len(cfg.Projects),
@@ -143,11 +143,11 @@ var backends = []backendInfo{
 // checkDependencies checks required system dependencies
 func checkDependencies() []Check {
 	// Use default backend type for backwards compatibility
-	return checkDependenciesWithBackend("claude-code")
+	return checkDependenciesWithBackend("claude-code", nil)
 }
 
 // checkDependenciesWithBackend checks dependencies including backend-aware checks
-func checkDependenciesWithBackend(activeBackendType string) []Check {
+func checkDependenciesWithBackend(activeBackendType string, cfg *config.Config) []Check {
 	checks := []Check{}
 
 	// Check Git first (always required)
@@ -185,7 +185,8 @@ func checkDependenciesWithBackend(activeBackendType string) []Check {
 	// Check all backends (active backend is required, others are optional)
 	for _, backend := range backends {
 		isActive := backend.backendType == activeBackendType
-		version := getCommandVersion(backend.command, backend.versionArgs...)
+		command, versionArgs := resolveBackendCommand(backend, activeBackendType, cfg)
+		version := getCommandVersion(command, versionArgs...)
 
 		if version != "" {
 			message := version
@@ -223,6 +224,37 @@ func checkDependenciesWithBackend(activeBackendType string) []Check {
 	}
 
 	return checks
+}
+
+func resolveBackendCommand(backend backendInfo, activeBackendType string, cfg *config.Config) (string, []string) {
+	command := backend.command
+	versionArgs := backend.versionArgs
+	if cfg == nil || cfg.Executor == nil || backend.backendType != activeBackendType {
+		return command, versionArgs
+	}
+
+	switch activeBackendType {
+	case "claude-code":
+		if cfg.Executor.ClaudeCode != nil && cfg.Executor.ClaudeCode.Command != "" {
+			command = cfg.Executor.ClaudeCode.Command
+		}
+	case "qwen-code":
+		if cfg.Executor.QwenCode != nil && cfg.Executor.QwenCode.Command != "" {
+			command = cfg.Executor.QwenCode.Command
+		}
+	case "opencode":
+		if cfg.Executor.OpenCode != nil && cfg.Executor.OpenCode.ServerCommand != "" {
+			parts := strings.Fields(cfg.Executor.OpenCode.ServerCommand)
+			if len(parts) > 0 {
+				command = parts[0]
+			}
+		}
+		// Modern OpenCode supports both `--version` and `version`. Prefer the
+		// flag form because wrapper scripts often special-case it.
+		versionArgs = []string{"--version"}
+	}
+
+	return command, versionArgs
 }
 
 // checkMacSleep checks if Mac sleep is disabled for always-on operation

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/slack"
 	"github.com/qf-studio/pilot/internal/adapters/telegram"
 	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/transcription"
 )
 
@@ -694,6 +696,56 @@ func TestCommandExists(t *testing.T) {
 	}
 }
 
+func TestResolveBackendCommand_OpenCodeUsesServerCommandBinaryAndVersionFlag(t *testing.T) {
+	backend := backendInfo{
+		name:        "opencode",
+		backendType: "opencode",
+		command:     "opencode",
+		versionArgs: []string{"version"},
+	}
+	cfg := &config.Config{
+		Executor: &executor.BackendConfig{
+			Type: "opencode",
+			OpenCode: &executor.OpenCodeConfig{
+				ServerCommand: "custom-opencode serve --hostname 127.0.0.1 --port 44096",
+			},
+		},
+	}
+
+	command, versionArgs := resolveBackendCommand(backend, "opencode", cfg)
+	if command != "custom-opencode" {
+		t.Fatalf("command = %q, want custom-opencode", command)
+	}
+	if !reflect.DeepEqual(versionArgs, []string{"--version"}) {
+		t.Fatalf("versionArgs = %#v, want %#v", versionArgs, []string{"--version"})
+	}
+}
+
+func TestResolveBackendCommand_NonActiveBackendKeepsDefaults(t *testing.T) {
+	backend := backendInfo{
+		name:        "opencode",
+		backendType: "opencode",
+		command:     "opencode",
+		versionArgs: []string{"version"},
+	}
+	cfg := &config.Config{
+		Executor: &executor.BackendConfig{
+			Type: "claude-code",
+			OpenCode: &executor.OpenCodeConfig{
+				ServerCommand: "custom-opencode serve",
+			},
+		},
+	}
+
+	command, versionArgs := resolveBackendCommand(backend, "claude-code", cfg)
+	if command != "opencode" {
+		t.Fatalf("command = %q, want opencode", command)
+	}
+	if !reflect.DeepEqual(versionArgs, []string{"version"}) {
+		t.Fatalf("versionArgs = %#v, want %#v", versionArgs, []string{"version"})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
@@ -709,10 +761,10 @@ func findCheck(checks []Check, name string) *Check {
 
 func TestCheckConfig_GitHubChecks(t *testing.T) {
 	tests := []struct {
-		name           string
-		cfg            *config.Config
-		wantCheckName  string
-		wantStatus     Status
+		name          string
+		cfg           *config.Config
+		wantCheckName string
+		wantStatus    Status
 	}{
 		{
 			name: "enabled no token no gh auth",
@@ -732,9 +784,9 @@ func TestCheckConfig_GitHubChecks(t *testing.T) {
 			cfg: &config.Config{
 				Adapters: &config.AdaptersConfig{
 					GitHub: &github.Config{
-						Enabled:  true,
-						Token:    "test-gh-token",
-						Polling:  &github.PollingConfig{Enabled: true},
+						Enabled: true,
+						Token:   "test-gh-token",
+						Polling: &github.PollingConfig{Enabled: true},
 					},
 				},
 			},


### PR DESCRIPTION
## Summary
- send modern OpenCode `/session/{id}/message` payloads with typed text parts and object-form models
- fall back to legacy string-model payloads only when server validation indicates an older schema
- add focused OpenCode backend tests for model normalization, payload generation, and retry behavior

## Verification
- `go test ./internal/executor/...`
- `go test ./...` (known baseline-unrelated failures remain in `desktop` git-graph tests on this clone)
- direct local OpenCode API check: modern payload accepted, legacy payload rejected with `path=["model"]`
- local smoke test advanced past previous immediate send failure; latest `GH-1` execution remains `running` instead of failing instantly after `OpenCode server ready`