### PR TITLE
GH-2409: fix(executor): OpenCode response parsing decodes wrong fields — silent empty Output

### DIFF
--- a/internal/executor/backend_opencode.go
+++ b/internal/executor/backend_opencode.go
@@ -247,18 +247,13 @@ func (b *OpenCodeBackend) sendMessage(ctx context.Context, sessionID string, opt
 			return nil, err
 		}
 	} else {
-		// Parse JSON response
-		var msgResult struct {
-			Success bool   `json:"success"`
-			Output  string `json:"output"`
-			Error   string `json:"error"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&msgResult); err != nil {
+		// OpenCode v1.4.x POST /session/:id/message returns application/json
+		// with the shape {info: AssistantMessage, parts: Part[]}, regardless of
+		// the Accept: text/event-stream request header. Parse that shape and
+		// project it onto BackendResult / BackendEvent. (GH-2409)
+		if err := b.parseAssistantResponse(resp.Body, opts, result); err != nil {
 			return nil, err
 		}
-		result.Success = msgResult.Success
-		result.Output = msgResult.Output
-		result.Error = msgResult.Error
 	}
 
 	// If no error set, mark as successful
@@ -267,6 +262,107 @@ func (b *OpenCodeBackend) sendMessage(ctx context.Context, sessionID string, opt
 	}
 
 	return result, nil
+}
+
+// parseAssistantResponse decodes the synchronous response from
+// POST /session/:id/message and populates result. The body shape comes from
+// OpenCode v1.4.6 (packages/opencode/src/server/instance/session.ts) and
+// looks like: {info: AssistantMessage, parts: Part[]}.
+//
+// Text parts are concatenated into result.Output. Non-text parts (tool, file,
+// agent, etc.) are surfaced through opts.EventHandler so the runner sees the
+// same event stream it would for a streaming backend. Token usage and model
+// metadata come from info.
+func (b *OpenCodeBackend) parseAssistantResponse(body io.Reader, opts ExecuteOptions, result *BackendResult) error {
+	var resp ocAssistantResponse
+	if err := json.NewDecoder(body).Decode(&resp); err != nil {
+		return fmt.Errorf("decode opencode response: %w", err)
+	}
+
+	// Model metadata: prefer providerID/modelID; fall back to model field.
+	if resp.Info.ModelID != "" {
+		if resp.Info.ProviderID != "" {
+			result.Model = resp.Info.ProviderID + "/" + resp.Info.ModelID
+		} else {
+			result.Model = resp.Info.ModelID
+		}
+	} else if resp.Info.Model != "" {
+		result.Model = resp.Info.Model
+	}
+
+	// Token usage. v1.4.x exposes tokens.{input,output,reasoning,cache.{read,write}}.
+	result.TokensInput += resp.Info.Tokens.Input
+	result.TokensOutput += resp.Info.Tokens.Output
+	result.CacheReadInputTokens += resp.Info.Tokens.Cache.Read
+	result.CacheCreationInputTokens += resp.Info.Tokens.Cache.Write
+
+	if resp.Info.SessionID != "" {
+		result.SessionID = resp.Info.SessionID
+	}
+
+	// If the assistant message carries an error indicator, propagate it.
+	if resp.Info.Error.Message != "" {
+		result.Error = resp.Info.Error.Message
+	} else if resp.Info.Error.Name != "" {
+		result.Error = resp.Info.Error.Name
+	}
+
+	var output strings.Builder
+	for _, part := range resp.Parts {
+		switch part.Type {
+		case "text":
+			output.WriteString(part.Text)
+			if opts.EventHandler != nil {
+				opts.EventHandler(BackendEvent{
+					Type:    EventTypeText,
+					Message: part.Text,
+					Raw:     part.Text,
+				})
+			}
+		case "tool":
+			if opts.EventHandler != nil {
+				opts.EventHandler(BackendEvent{
+					Type:      EventTypeToolUse,
+					ToolName:  part.Tool,
+					ToolInput: part.State.Input,
+					Message:   fmt.Sprintf("Using %s", part.Tool),
+				})
+				if part.State.Status == "completed" || part.State.Status == "error" {
+					ev := BackendEvent{
+						Type:       EventTypeToolResult,
+						ToolName:   part.Tool,
+						ToolResult: part.State.Output,
+						IsError:    part.State.Status == "error",
+					}
+					opts.EventHandler(ev)
+				}
+			}
+		case "step-start", "step-finish", "reasoning", "file", "agent", "snapshot":
+			if opts.EventHandler != nil {
+				opts.EventHandler(BackendEvent{
+					Type:    EventTypeProgress,
+					Message: part.Type,
+				})
+			}
+		}
+	}
+
+	result.Output = output.String()
+
+	// Synthesize a final result event so downstream consumers (alerts, logging)
+	// see a terminal event, mirroring the SSE path.
+	if opts.EventHandler != nil {
+		opts.EventHandler(BackendEvent{
+			Type:         EventTypeResult,
+			Message:      result.Output,
+			IsError:      result.Error != "",
+			TokensInput:  resp.Info.Tokens.Input,
+			TokensOutput: resp.Info.Tokens.Output,
+			Model:        result.Model,
+		})
+	}
+
+	return nil
 }
 
 // parseSSEStream parses Server-Sent Events from OpenCode.
@@ -414,6 +510,62 @@ type openCodeDelta struct {
 type openCodeUsage struct {
 	InputTokens  int64 `json:"input_tokens"`
 	OutputTokens int64 `json:"output_tokens"`
+}
+
+// ocAssistantResponse mirrors the response body of
+// POST /session/:sessionID/message in OpenCode v1.4.x:
+//
+//	{info: AssistantMessage, parts: Part[]}
+//
+// Field set is intentionally minimal — only what Pilot consumes. Unknown
+// fields are ignored by the JSON decoder.
+type ocAssistantResponse struct {
+	Info  ocAssistantInfo `json:"info"`
+	Parts []ocPart        `json:"parts"`
+}
+
+type ocAssistantInfo struct {
+	ID         string         `json:"id,omitempty"`
+	Role       string         `json:"role,omitempty"`
+	SessionID  string         `json:"sessionID,omitempty"`
+	ProviderID string         `json:"providerID,omitempty"`
+	ModelID    string         `json:"modelID,omitempty"`
+	Model      string         `json:"model,omitempty"` // legacy/fallback
+	Tokens     ocTokens       `json:"tokens"`
+	Cost       float64        `json:"cost,omitempty"`
+	Error      ocAssistantErr `json:"error,omitempty"`
+}
+
+type ocTokens struct {
+	Input     int64        `json:"input"`
+	Output    int64        `json:"output"`
+	Reasoning int64        `json:"reasoning,omitempty"`
+	Cache     ocCacheToken `json:"cache"`
+}
+
+type ocCacheToken struct {
+	Read  int64 `json:"read"`
+	Write int64 `json:"write"`
+}
+
+type ocAssistantErr struct {
+	Name    string `json:"name,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// ocPart covers the relevant union variants from MessageV2.Part. Only fields
+// Pilot uses are mapped; other types decode with zero values for unused fields.
+type ocPart struct {
+	Type  string      `json:"type"`
+	Text  string      `json:"text,omitempty"`
+	Tool  string      `json:"tool,omitempty"`
+	State ocPartState `json:"state,omitempty"`
+}
+
+type ocPartState struct {
+	Status string                 `json:"status,omitempty"`
+	Input  map[string]interface{} `json:"input,omitempty"`
+	Output string                 `json:"output,omitempty"`
 }
 
 // StopServer stops the managed OpenCode server if running.

--- a/internal/executor/backend_opencode_test.go
+++ b/internal/executor/backend_opencode_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -227,6 +228,131 @@ func TestOpenCodeBackendStopServer(t *testing.T) {
 	err := backend.StopServer()
 	if err != nil {
 		t.Errorf("StopServer() error = %v, want nil", err)
+	}
+}
+
+// TestOpenCodeBackendParseAssistantResponse verifies the JSON-shape parsing
+// for OpenCode v1.4.x's POST /session/:id/message response. Regression for
+// GH-2409 — the previous parser looked for {success,output,error}, none of
+// which exist on the actual response, so result.Output came back empty even
+// though the call succeeded.
+func TestOpenCodeBackendParseAssistantResponse(t *testing.T) {
+	backend := NewOpenCodeBackend(nil)
+
+	body := `{
+		"info": {
+			"id": "msg_1",
+			"role": "assistant",
+			"sessionID": "ses_1",
+			"providerID": "anthropic",
+			"modelID": "claude-sonnet-4",
+			"tokens": {
+				"input": 123,
+				"output": 45,
+				"reasoning": 0,
+				"cache": {"read": 7, "write": 8}
+			}
+		},
+		"parts": [
+			{"type": "text", "text": "Hello "},
+			{"type": "tool", "tool": "Read", "state": {"status": "completed", "input": {"file_path": "/x.go"}, "output": "ok"}},
+			{"type": "text", "text": "world"}
+		]
+	}`
+
+	var events []BackendEvent
+	opts := ExecuteOptions{
+		EventHandler: func(e BackendEvent) {
+			events = append(events, e)
+		},
+	}
+	result := &BackendResult{}
+
+	if err := backend.parseAssistantResponse(strings.NewReader(body), opts, result); err != nil {
+		t.Fatalf("parseAssistantResponse error = %v", err)
+	}
+
+	if result.Output != "Hello world" {
+		t.Errorf("Output = %q, want %q", result.Output, "Hello world")
+	}
+	if result.TokensInput != 123 {
+		t.Errorf("TokensInput = %d, want 123", result.TokensInput)
+	}
+	if result.TokensOutput != 45 {
+		t.Errorf("TokensOutput = %d, want 45", result.TokensOutput)
+	}
+	if result.CacheReadInputTokens != 7 {
+		t.Errorf("CacheReadInputTokens = %d, want 7", result.CacheReadInputTokens)
+	}
+	if result.CacheCreationInputTokens != 8 {
+		t.Errorf("CacheCreationInputTokens = %d, want 8", result.CacheCreationInputTokens)
+	}
+	if result.Model != "anthropic/claude-sonnet-4" {
+		t.Errorf("Model = %q, want anthropic/claude-sonnet-4", result.Model)
+	}
+	if result.SessionID != "ses_1" {
+		t.Errorf("SessionID = %q, want ses_1", result.SessionID)
+	}
+	if result.Error != "" {
+		t.Errorf("Error = %q, want empty", result.Error)
+	}
+
+	// Expect events: text, tool_use, tool_result, text, result.
+	wantTypes := []BackendEventType{
+		EventTypeText, EventTypeToolUse, EventTypeToolResult, EventTypeText, EventTypeResult,
+	}
+	if len(events) != len(wantTypes) {
+		t.Fatalf("event count = %d, want %d (events=%v)", len(events), len(wantTypes), events)
+	}
+	for i, et := range wantTypes {
+		if events[i].Type != et {
+			t.Errorf("event[%d].Type = %q, want %q", i, events[i].Type, et)
+		}
+	}
+
+	// Tool event should carry the tool name and input.
+	toolEv := events[1]
+	if toolEv.ToolName != "Read" {
+		t.Errorf("tool event ToolName = %q, want Read", toolEv.ToolName)
+	}
+	if toolEv.ToolInput["file_path"] != "/x.go" {
+		t.Errorf("tool event ToolInput[file_path] = %v, want /x.go", toolEv.ToolInput["file_path"])
+	}
+
+	// Final result event should carry the concatenated output.
+	finalEv := events[len(events)-1]
+	if finalEv.Message != "Hello world" {
+		t.Errorf("final event Message = %q, want %q", finalEv.Message, "Hello world")
+	}
+}
+
+func TestOpenCodeBackendParseAssistantResponseEmpty(t *testing.T) {
+	backend := NewOpenCodeBackend(nil)
+
+	// No parts at all — output should be empty but parse must succeed.
+	body := `{"info": {"id":"msg_2","tokens":{"input":1,"output":2,"cache":{"read":0,"write":0}}}, "parts": []}`
+	result := &BackendResult{}
+	if err := backend.parseAssistantResponse(strings.NewReader(body), ExecuteOptions{}, result); err != nil {
+		t.Fatalf("parseAssistantResponse error = %v", err)
+	}
+	if result.Output != "" {
+		t.Errorf("Output = %q, want empty", result.Output)
+	}
+	if result.TokensInput != 1 || result.TokensOutput != 2 {
+		t.Errorf("tokens = %d/%d, want 1/2", result.TokensInput, result.TokensOutput)
+	}
+}
+
+func TestOpenCodeBackendParseAssistantResponseError(t *testing.T) {
+	backend := NewOpenCodeBackend(nil)
+
+	body := `{"info": {"id":"msg_3","tokens":{"input":0,"output":0,"cache":{"read":0,"write":0}}, "error":{"name":"ProviderAuthError","message":"bad key"}}, "parts": []}`
+	result := &BackendResult{}
+	if err := backend.parseAssistantResponse(strings.NewReader(body), ExecuteOptions{}, result); err != nil {
+		t.Fatalf("parseAssistantResponse error = %v", err)
+	}
+	if result.Error != "bad key" {
+		t.Errorf("Error = %q, want %q", result.Error, "bad key")
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2409.

Closes #2409

## Changes

GitHub Issue #2409: fix(executor): OpenCode response parsing decodes wrong fields — silent empty Output

## Summary
After PR #2408 lands, the schema rejection at first send is gone, but `OpenCodeBackend.sendMessage` then mis-parses the success response. Pilot will see `Success: true` with empty `Output`, leading to no commit / empty PR / silent failure downstream.

## Evidence (verified against OpenCode v1.4.6 source)

`packages/opencode/src/server/instance/session.ts:854-895`:
```ts
.post("/:sessionID/message",
  describeRoute({
    responses: {
      200: { content: { "application/json": { schema: resolver(
        z.object({ info: MessageV2.Assistant, parts: MessageV2.Part.array() })
      ) } } },
    },
  }),
  ...
  async (c) => {
    c.status(200)
    c.header("Content-Type", "application/json")
    return stream(c, async (stream) => {
      const msg = await ...svc.prompt(...)
      stream.write(JSON.stringify(msg))
    })
  },
)
```

So the success response is:
- `Content-Type: application/json` (not `text/event-stream` — the `Accept: text/event-stream` header sent by Pilot is ignored)
- Body shape: `{info: MessageV2.Assistant, parts: MessageV2.Part[]}`

Pilot's current parse path (`internal/executor/backend_opencode.go:243-256`):
```go
} else {
    var msgResult struct {
        Success bool   `json:"success"`
        Output  string `json:"output"`
        Error   string `json:"error"`
    }
    json.NewDecoder(resp.Body).Decode(&msgResult)
    result.Success = msgResult.Success
    result.Output  = msgResult.Output
    result.Error   = msgResult.Error
}
if result.Error == "" { result.Success = true }
```

None of `success`/`output`/`error` exist on OpenCode v1.4.6's response. All three decode to zero values → `result.Output = \"\"` → final `Success = true` (because Error is empty).

## Impact
- Reporter of #2407 sees `running` rather than `failure` after PR #2408 → the HTTP call succeeds but Pilot extracts no useful content.
- Downstream: empty `Output`, no commit, autopilot sees nothing to push.

## Fix (sketch)
Map the actual response shape:
```go
type ocAssistantMessage struct {
    Info  ocAssistantInfo `json:\"info\"`
    Parts []ocPart        `json:\"parts\"`
}
type ocPart struct {
    Type string `json:\"type\"`
    Text string `json:\"text,omitempty\"`
    // tool, file, agent, subtask variants
}
```
Then concatenate text parts into `result.Output`, surface tool-use parts as `BackendEvent`s via `opts.EventHandler` (mimicking the streaming path), and pull token usage from `info`.

Alternative: switch to `POST /session/:sessionID/prompt_async` (returns 204 immediately) and consume the SSE event stream from `/event` for per-token deltas. That endpoint actually streams; the current synchronous `/message` endpoint never does despite the misleading `description: \"...streaming the AI response\"`.

## Repro (post #2408)
1. Configure Pilot with OpenCode 1.4.x backend.
2. Pick up a labeled GitHub issue.
3. Wait through OpenCode execution (will run for minutes).
4. Observe: HTTP 200 returned, but Pilot reports success with no commits / no PR content.

## References
- [OpenCode v1.4.6 message route](https://github.com/anomalyco/opencode/blob/v1.4.6/packages/opencode/src/server/instance/session.ts)
- [OpenCode v1.4.6 PromptInput / Assistant message types](https://github.com/anomalyco/opencode/blob/v1.4.6/packages/opencode/src/session/prompt.ts)
- Found while reviewing #2408 / #2407.