### PR TITLE
GH-2413: fix(executor): send OpenCode `model` as {providerID, modelID} object (re-do of closed #2408)

### DIFF
--- a/internal/executor/backend_opencode.go
+++ b/internal/executor/backend_opencode.go
@@ -210,8 +210,12 @@ func (b *OpenCodeBackend) sendMessage(ctx context.Context, sessionID string, opt
 		},
 	}
 
-	if b.config.Model != "" {
-		payload["model"] = b.config.Model
+	// OpenCode v1.4.x's Hono+Zod validator requires `model` to be either
+	// {providerID, modelID} or omitted. Sending a plain string fails with
+	// HTTP 400 "invalid_type" before the handler runs (GH-2413). See
+	// https://github.com/anomalyco/opencode/blob/v1.4.6/packages/opencode/src/session/prompt.ts
+	if ref := b.resolveModelRef(); ref != nil {
+		payload["model"] = ref
 	}
 
 	jsonData, err := json.Marshal(payload)
@@ -262,6 +266,39 @@ func (b *OpenCodeBackend) sendMessage(ctx context.Context, sessionID string, opt
 	}
 
 	return result, nil
+}
+
+// ocModelRef matches OpenCode v1.4.x's PromptInput.model schema:
+// {providerID, modelID}. Encoded as a JSON object.
+type ocModelRef struct {
+	ProviderID string `json:"providerID"`
+	ModelID    string `json:"modelID"`
+}
+
+// resolveModelRef builds the OpenCode model reference from config.
+// Returns nil when no model is configured, signalling the caller to omit
+// the field so the server falls back to its default model.
+//
+// Resolution rules:
+//   - "providerID/modelID" → split on first "/"
+//   - bare "modelID" + config.Provider → use config.Provider as providerID
+//   - bare "modelID" with no provider → empty providerID (server may reject;
+//     we still send what we have rather than silently dropping the model)
+func (b *OpenCodeBackend) resolveModelRef() *ocModelRef {
+	model := strings.TrimSpace(b.config.Model)
+	if model == "" {
+		return nil
+	}
+	if i := strings.Index(model, "/"); i > 0 && i < len(model)-1 {
+		return &ocModelRef{
+			ProviderID: model[:i],
+			ModelID:    model[i+1:],
+		}
+	}
+	return &ocModelRef{
+		ProviderID: strings.TrimSpace(b.config.Provider),
+		ModelID:    model,
+	}
 }
 
 // parseAssistantResponse decodes the synchronous response from

--- a/internal/executor/backend_opencode_test.go
+++ b/internal/executor/backend_opencode_test.go
@@ -1,8 +1,15 @@
 package executor
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewOpenCodeBackend(t *testing.T) {
@@ -353,6 +360,198 @@ func TestOpenCodeBackendParseAssistantResponseError(t *testing.T) {
 	}
 	if result.Error != "bad key" {
 		t.Errorf("Error = %q, want %q", result.Error, "bad key")
+	}
+}
+
+// TestOpenCodeBackendResolveModelRef verifies model resolution into the
+// {providerID, modelID} shape required by OpenCode v1.4.x (GH-2413).
+func TestOpenCodeBackendResolveModelRef(t *testing.T) {
+	tests := []struct {
+		name        string
+		model       string
+		provider    string
+		wantNil     bool
+		wantProv    string
+		wantModelID string
+	}{
+		{
+			name:        "providerID/modelID combined",
+			model:       "openai/gpt-5.4-mini",
+			provider:    "",
+			wantProv:    "openai",
+			wantModelID: "gpt-5.4-mini",
+		},
+		{
+			name:        "bare modelID with explicit provider",
+			model:       "gpt-5.4-mini",
+			provider:    "openai",
+			wantProv:    "openai",
+			wantModelID: "gpt-5.4-mini",
+		},
+		{
+			name:    "empty model returns nil (server default)",
+			model:   "",
+			wantNil: true,
+		},
+		{
+			name:        "anthropic/claude-sonnet-4 default",
+			model:       "anthropic/claude-sonnet-4",
+			wantProv:    "anthropic",
+			wantModelID: "claude-sonnet-4",
+		},
+		{
+			name:        "modelID with multiple slashes splits on first only",
+			model:       "openrouter/anthropic/claude-sonnet-4",
+			wantProv:    "openrouter",
+			wantModelID: "anthropic/claude-sonnet-4",
+		},
+		{
+			name:        "trailing slash treated as bare modelID",
+			model:       "openai/",
+			provider:    "fallback",
+			wantProv:    "fallback",
+			wantModelID: "openai/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &OpenCodeBackend{config: &OpenCodeConfig{
+				Model:    tt.model,
+				Provider: tt.provider,
+			}}
+			ref := b.resolveModelRef()
+			if tt.wantNil {
+				if ref != nil {
+					t.Fatalf("resolveModelRef() = %+v, want nil", ref)
+				}
+				return
+			}
+			if ref == nil {
+				t.Fatal("resolveModelRef() = nil, want non-nil")
+			}
+			if ref.ProviderID != tt.wantProv {
+				t.Errorf("ProviderID = %q, want %q", ref.ProviderID, tt.wantProv)
+			}
+			if ref.ModelID != tt.wantModelID {
+				t.Errorf("ModelID = %q, want %q", ref.ModelID, tt.wantModelID)
+			}
+		})
+	}
+}
+
+// TestOpenCodeBackendSendMessageModelObject verifies that sendMessage
+// serialises `model` as an object {providerID, modelID}, never a string
+// (GH-2413). Also checks `model` is omitted when no model is configured.
+func TestOpenCodeBackendSendMessageModelObject(t *testing.T) {
+	tests := []struct {
+		name      string
+		model     string
+		provider  string
+		wantOmit  bool
+		wantProv  string
+		wantModel string
+	}{
+		{
+			name:      "combined model serialises as object",
+			model:     "openai/gpt-5.4-mini",
+			wantProv:  "openai",
+			wantModel: "gpt-5.4-mini",
+		},
+		{
+			name:      "bare model + provider serialises as object",
+			model:     "gpt-5.4-mini",
+			provider:  "openai",
+			wantProv:  "openai",
+			wantModel: "gpt-5.4-mini",
+		},
+		{
+			name:     "empty model omits field",
+			model:    "",
+			wantOmit: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured map[string]interface{}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &captured)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"info":{"id":"m1","tokens":{"input":0,"output":0,"cache":{"read":0,"write":0}}},"parts":[{"type":"text","text":"ok"}]}`))
+			}))
+			defer srv.Close()
+
+			b := &OpenCodeBackend{
+				config: &OpenCodeConfig{
+					ServerURL: srv.URL,
+					Model:     tt.model,
+					Provider:  tt.provider,
+				},
+				httpClient: &http.Client{Timeout: 5 * time.Second},
+			}
+			b.log = NewOpenCodeBackend(nil).log
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if _, err := b.sendMessage(ctx, "ses_1", ExecuteOptions{Prompt: "hi"}); err != nil {
+				t.Fatalf("sendMessage error = %v", err)
+			}
+
+			modelField, present := captured["model"]
+			if tt.wantOmit {
+				if present {
+					t.Fatalf("expected model field omitted, got %v", modelField)
+				}
+				return
+			}
+			obj, ok := modelField.(map[string]interface{})
+			if !ok {
+				t.Fatalf("model field is not an object: %T = %v", modelField, modelField)
+			}
+			if obj["providerID"] != tt.wantProv {
+				t.Errorf("providerID = %v, want %q", obj["providerID"], tt.wantProv)
+			}
+			if obj["modelID"] != tt.wantModel {
+				t.Errorf("modelID = %v, want %q", obj["modelID"], tt.wantModel)
+			}
+		})
+	}
+}
+
+// TestOpenCodeBackendSendMessagePayloadShape verifies the full payload JSON
+// shape matches OpenCode v1.4.x's PromptInput schema (GH-2413).
+func TestOpenCodeBackendSendMessagePayloadShape(t *testing.T) {
+	var raw bytes.Buffer
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(&raw, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"info":{"id":"m1","tokens":{"input":0,"output":0,"cache":{"read":0,"write":0}}},"parts":[]}`))
+	}))
+	defer srv.Close()
+
+	b := &OpenCodeBackend{
+		config: &OpenCodeConfig{
+			ServerURL: srv.URL,
+			Model:     "anthropic/claude-sonnet-4",
+		},
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+	b.log = NewOpenCodeBackend(nil).log
+
+	if _, err := b.sendMessage(context.Background(), "ses_1", ExecuteOptions{Prompt: "hello"}); err != nil {
+		t.Fatalf("sendMessage error = %v", err)
+	}
+
+	// Reject the legacy string form.
+	if strings.Contains(raw.String(), `"model":"anthropic/claude-sonnet-4"`) {
+		t.Fatalf("payload still sends model as string: %s", raw.String())
+	}
+	// Require the object form.
+	if !strings.Contains(raw.String(), `"providerID":"anthropic"`) ||
+		!strings.Contains(raw.String(), `"modelID":"claude-sonnet-4"`) {
+		t.Fatalf("payload missing object-form model: %s", raw.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2413.

Closes #2413

## Changes

GitHub Issue #2413: fix(executor): send OpenCode `model` as {providerID, modelID} object (re-do of closed #2408)

## Summary
The OpenCode message schema fix from #2408 (closed) was not merged, but the downstream parsing fix from #2409 was. Net result: v2.100.2 still cannot send a message to OpenCode v1.4.x because Pilot serialises `model` as a plain string, which fails Hono's Zod validator before the handler runs.

#2407 is therefore unresolved: reporter will still hit `failed to send message: ...` immediately after `OpenCode server ready`.

## Evidence (verified against OpenCode v1.4.6 source)

`packages/opencode/src/session/prompt.ts:1717` (https://github.com/anomalyco/opencode/blob/v1.4.6/packages/opencode/src/session/prompt.ts):
```ts
export const PromptInput = z.object({
  ...
  model: z.object({ providerID: ProviderID.zod, modelID: ModelID.zod }).optional(),
  parts: z.array(z.discriminatedUnion("type", [...])),
})
```

Current main (`internal/executor/backend_opencode.go:213-215`):
```go
if b.config.Model != "" {
    payload["model"] = b.config.Model   // sent as string -> rejected
}
```

Server returns 400 with `{"success":false,"error":[{"code":"invalid_type","expected":"object","received":"string","path":["model"],...}],...}`. The handler never executes, no message is created — so the v2.100.2 response-parsing improvements never get a chance to run.

## Required change

In `internal/executor/backend_opencode.go::sendMessage`, build the payload with the modern object form:
```go
type modelRef struct {
    ProviderID string `json:"providerID"`
    ModelID    string `json:"modelID"`
}
```

Resolve from config:
- `executor.opencode.model: "openai/gpt-5.4-mini"` → split on `/` → `{providerID: "openai", modelID: "gpt-5.4-mini"}`
- `executor.opencode.model: "gpt-5.4-mini"` + `provider: "openai"` → `{providerID: "openai", modelID: "gpt-5.4-mini"}`
- Empty model → omit `model` from payload (server uses default)

`parts` is already correct: `[{type: "text", text: opts.Prompt}]` matches `MessageV2.TextPartInput`'s discriminator.

Optional: legacy fallback as in #2408. Recommended only if maintainers want to keep working with OpenCode <= 1.3.x; if not, drop it. The retry is safe (Hono validators run before any state mutation, so no LLM tokens charged on rejected payloads) but adds complexity.

## Acceptance
- `go test ./internal/executor/... -run OpenCode -v -count=1` passes
- New table-driven test covers: `provider/modelID` config, separate `provider` + `modelID` config, empty model
- Manual smoke test (or VCR-style http test) confirms the JSON payload contains `"model":{"providerID":"...","modelID":"..."}`, not a string

## References
- Closed predecessor PR: #2408 (verified safe in review at https://github.com/qf-studio/pilot/pull/2408)
- Reporter issue: #2407
- Companion fix that already shipped: #2409 (v2.100.2)
- OpenCode v1.4.6 prompt schema: https://github.com/anomalyco/opencode/blob/v1.4.6/packages/opencode/src/session/prompt.ts
- OpenCode v1.4.6 message route: https://github.com/anomalyco/opencode/blob/v1.4.6/packages/opencode/src/server/instance/session.ts

## Files
- `internal/executor/backend_opencode.go` (sendMessage payload construction)
- `internal/executor/backend_opencode_test.go` (new tests)