### PR TITLE
fix(executor): make opencode request timeout configurable

### DIFF
--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -593,6 +593,23 @@ type OpenCodeConfig struct {
 
 	// ServerCommand is the command to start the server (default: "opencode serve")
 	ServerCommand string `yaml:"server_command,omitempty"`
+
+	// RequestTimeout is the maximum time to wait for OpenCode HTTP responses.
+	// Applies to session creation, message send, and SSE response headers.
+	RequestTimeout string `yaml:"request_timeout,omitempty"`
+}
+
+// EffectiveRequestTimeout returns the OpenCode HTTP request timeout.
+// Falls back to 10m when empty or invalid.
+func (c *OpenCodeConfig) EffectiveRequestTimeout() time.Duration {
+	if c == nil || c.RequestTimeout == "" {
+		return 10 * time.Minute
+	}
+	d, err := time.ParseDuration(c.RequestTimeout)
+	if err != nil || d <= 0 {
+		return 10 * time.Minute
+	}
+	return d
 }
 
 // DefaultBackendConfig returns default backend configuration.
@@ -618,6 +635,7 @@ func DefaultBackendConfig() *BackendConfig {
 			Provider:        "anthropic",
 			AutoStartServer: true,
 			ServerCommand:   "opencode serve",
+			RequestTimeout:  "10m",
 		},
 		ModelRouting:     DefaultModelRoutingConfig(),
 		Timeout:          DefaultTimeoutConfig(),

--- a/internal/executor/backend_opencode.go
+++ b/internal/executor/backend_opencode.go
@@ -50,7 +50,7 @@ func NewOpenCodeBackend(config *OpenCodeConfig) *OpenCodeBackend {
 		config: config,
 		log:    logging.WithComponent("executor.opencode"),
 		httpClient: &http.Client{
-			Timeout: 10 * time.Minute, // Long timeout for AI operations
+			Timeout: config.EffectiveRequestTimeout(),
 		},
 	}
 }

--- a/internal/executor/backend_opencode_test.go
+++ b/internal/executor/backend_opencode_test.go
@@ -18,12 +18,14 @@ func TestNewOpenCodeBackend(t *testing.T) {
 		config          *OpenCodeConfig
 		expectServerURL string
 		expectModel     string
+		expectTimeout   string
 	}{
 		{
 			name:            "nil config uses defaults",
 			config:          nil,
 			expectServerURL: "http://127.0.0.1:4096",
 			expectModel:     "anthropic/claude-sonnet-4",
+			expectTimeout:   "10m0s",
 		},
 		{
 			name: "empty server URL uses default",
@@ -33,15 +35,18 @@ func TestNewOpenCodeBackend(t *testing.T) {
 			},
 			expectServerURL: "http://127.0.0.1:4096",
 			expectModel:     "custom-model",
+			expectTimeout:   "10m0s",
 		},
 		{
 			name: "custom config",
 			config: &OpenCodeConfig{
-				ServerURL: "http://localhost:5000",
-				Model:     "anthropic/claude-opus-4",
+				ServerURL:      "http://localhost:5000",
+				Model:          "anthropic/claude-opus-4",
+				RequestTimeout: "20m",
 			},
 			expectServerURL: "http://localhost:5000",
 			expectModel:     "anthropic/claude-opus-4",
+			expectTimeout:   "20m0s",
 		},
 		{
 			name: "empty model uses default",
@@ -51,6 +56,7 @@ func TestNewOpenCodeBackend(t *testing.T) {
 			},
 			expectServerURL: "http://localhost:4096",
 			expectModel:     "anthropic/claude-sonnet-4",
+			expectTimeout:   "10m0s",
 		},
 	}
 
@@ -65,6 +71,9 @@ func TestNewOpenCodeBackend(t *testing.T) {
 			}
 			if backend.config.Model != tt.expectModel {
 				t.Errorf("Model = %q, want %q", backend.config.Model, tt.expectModel)
+			}
+			if backend.httpClient.Timeout.String() != tt.expectTimeout {
+				t.Errorf("http timeout = %q, want %q", backend.httpClient.Timeout.String(), tt.expectTimeout)
 			}
 		})
 	}

--- a/internal/executor/backend_test.go
+++ b/internal/executor/backend_test.go
@@ -116,6 +116,7 @@ func TestOpenCodeConfig(t *testing.T) {
 		Provider:        "anthropic",
 		AutoStartServer: true,
 		ServerCommand:   "opencode serve --port 5000",
+		RequestTimeout:  "20m",
 	}
 
 	if config.ServerURL != "http://localhost:5000" {
@@ -126,6 +127,31 @@ func TestOpenCodeConfig(t *testing.T) {
 	}
 	if !config.AutoStartServer {
 		t.Error("AutoStartServer should be true")
+	}
+	if config.RequestTimeout != "20m" {
+		t.Errorf("RequestTimeout = %q, want 20m", config.RequestTimeout)
+	}
+}
+
+func TestOpenCodeConfigEffectiveRequestTimeout(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *OpenCodeConfig
+		want   string
+	}{
+		{name: "nil config fallback", config: nil, want: "10m0s"},
+		{name: "empty timeout fallback", config: &OpenCodeConfig{}, want: "10m0s"},
+		{name: "configured timeout used", config: &OpenCodeConfig{RequestTimeout: "20m"}, want: "20m0s"},
+		{name: "invalid timeout falls back", config: &OpenCodeConfig{RequestTimeout: "nope"}, want: "10m0s"},
+		{name: "zero timeout falls back", config: &OpenCodeConfig{RequestTimeout: "0s"}, want: "10m0s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.config.EffectiveRequestTimeout().String(); got != tt.want {
+				t.Fatalf("EffectiveRequestTimeout() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `executor.opencode.request_timeout` so OpenCode HTTP request lifetime is configurable
- fall back to 10m when unset or invalid to preserve current behavior
- cover timeout parsing and backend client wiring with focused tests

## Verification
- `go test ./internal/executor/...`

Closes #2410