### PR TITLE
GH-2423: fix(ci): docs deploy pipeline breaks every release — chained-trigger limitation

### DIFF
--- a/.github/workflows/docs-version-sync.yml
+++ b/.github/workflows/docs-version-sync.yml
@@ -46,6 +46,19 @@ jobs:
       - name: Run version sync script
         run: ./scripts/docs-version-sync.sh ${{ steps.version.outputs.VERSION }}
 
+      - name: Resolve token
+        id: token
+        env:
+          PILOT_DOCS_PAT: ${{ secrets.PILOT_DOCS_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "$PILOT_DOCS_PAT" ]; then
+            echo "token=$PILOT_DOCS_PAT" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::PILOT_DOCS_PAT not set — sync-docs.yml will not chain from the auto-merge"
+            echo "token=$GITHUB_TOKEN" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check for changes
         id: changes
         run: |
@@ -60,7 +73,7 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.token.outputs.token }}
           commit-message: "docs: sync version to ${{ steps.version.outputs.VERSION }}"
           title: "docs: sync version to ${{ steps.version.outputs.VERSION }}"
           body: |
@@ -79,7 +92,7 @@ jobs:
       - name: Enable auto-merge
         if: steps.changes.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           if [ -n "${{ steps.pr.outputs.pull-request-number }}" ]; then
             gh pr merge "${{ steps.pr.outputs.pull-request-number }}" --auto --squash

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/sync-docs.yml'
+  workflow_dispatch:
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2423.

Closes #2423

## Changes

GitHub Issue #2423: fix(ci): docs deploy pipeline breaks every release — chained-trigger limitation

## Summary
Each release silently fails to redeploy `pilot.quantflow.studio` because of the well-known GitHub Actions limitation: pushes performed via `secrets.GITHUB_TOKEN` do NOT trigger other `push`-event workflows.

Net effect: `docs-version-sync.yml` auto-merges its PR using `GITHUB_TOKEN` → `sync-docs.yml` (gated on `push: branches: [main], paths: docs/**`) does not fire → no GitLab content sync → no `prod-X.Y.Z-<ts>` tag → docs site stays on the previous version.

## Evidence
- v2.100.3 was released and PR #2422 (`docs: sync version to v2.100.3`) merged at 2026-04-27T09:33:57Z.
- `sync-docs.yml` last successful run was on 2026-04-18 (PR #2373 for v2.98.0). Nothing has fired since for any of v2.99.x / v2.100.x.
- `gh workflow run sync-docs.yml` returns `HTTP 422: Workflow does not have 'workflow_dispatch' trigger` — there is no manual escape hatch today.

## Required changes

### 1. `.github/workflows/sync-docs.yml`
Add `workflow_dispatch` so the deploy pipeline can be re-fired manually as a backstop:
```yaml
on:
  push:
    branches: [main]
    paths:
      - 'docs/**'
      - '.github/workflows/sync-docs.yml'
  workflow_dispatch:
```

### 2. `.github/workflows/docs-version-sync.yml`
Replace `secrets.GITHUB_TOKEN` with a PAT secret in **both** the create-PR step and the auto-merge step, so the resulting merge commit carries a token whose pushes DO trigger downstream workflows. Use a new secret name `PILOT_DOCS_PAT` (the secret will be created out-of-band; just wire the workflow to it). Both steps that need it:
- `Create Pull Request` (peter-evans/create-pull-request@v6) — change `token: \${{ secrets.GITHUB_TOKEN }}` → `token: \${{ secrets.PILOT_DOCS_PAT }}`
- `Enable auto-merge` step's `GH_TOKEN` env — change to `\${{ secrets.PILOT_DOCS_PAT }}`

If `PILOT_DOCS_PAT` is unavailable at runtime, fall back gracefully: keep the prior behavior of using `GITHUB_TOKEN` so the version-sync PR still gets created/merged (just won't trigger sync-docs); print a warning step output.

Pseudo-code for the fallback:
```yaml
- name: Resolve token
  id: token
  run: |
    if [ -n "\${{ secrets.PILOT_DOCS_PAT }}" ]; then
      echo "token=\${{ secrets.PILOT_DOCS_PAT }}" >> \$GITHUB_OUTPUT
    else
      echo "::warning::PILOT_DOCS_PAT not set — sync-docs.yml will not chain"
      echo "token=\${{ secrets.GITHUB_TOKEN }}" >> \$GITHUB_OUTPUT
    fi
```
Then reference `\${{ steps.token.outputs.token }}` in both downstream steps.

## Acceptance
- [ ] `sync-docs.yml` accepts `workflow_dispatch` events (verify with `gh workflow run sync-docs.yml`).
- [ ] `docs-version-sync.yml` uses the resolved token (PAT preferred, falls back to GITHUB_TOKEN with warning).
- [ ] Both workflows still pass `actionlint` (existing CI gate).
- [ ] No behavior change when PAT secret is absent — auto-merge still succeeds, just no chain.
- [ ] No new permissions added beyond what's already declared.

## Out of scope
- Creating the `PILOT_DOCS_PAT` secret — repo owner action; just wire the workflow to consume it.
- Backfilling `v2.99.0`–`v2.100.3` to the docs site. After this PR merges I'll manually run `gh workflow run sync-docs.yml` to push v2.100.3 to GitLab.

## References
- GitHub docs: ["events that don't trigger workflows"](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-a-workflow-from-a-workflow)
- Memory: `pilot.quantflow.studio` needs `prod-X.Y.Z` tag, docs commits don't auto-release.
- Prior incident: GH-2206 (closed 2026-04-18) — same root cause manifested with GoReleaser; this is the docs-side recurrence.

## Files
- `.github/workflows/sync-docs.yml`
- `.github/workflows/docs-version-sync.yml`

## Planned Steps (execute all in sequence)

1. **fix(ci): wire PILOT_DOCS_PAT with fallback + add workflow_dispatch to sync-docs** — Both files live in `.github/workflows/` (same directory) so this must be a single subtask to avoid merge conflicts. Changes: (a) In `.github/workflows/sync-docs.yml`, add `workflow_dispatch:` to the `on:` block alongside the existing `push:` trigger so the pipeline can be manually re-fired as a backstop. (b) In `.github/workflows/docs-version-sync.yml`, add a `Resolve token` step that prefers `secrets.PILOT_DOCS_PAT` and falls back to `secrets.GITHUB_TOKEN` with a `::warning::` annotation when the PAT is absent; reference `${{ steps.token.outputs.token }}` from both the `peter-evans/create-pull-request@v6` step (`token:` input) and the `Enable auto-merge` step (`GH_TOKEN` env). Verify both files still pass `actionlint`. No new permissions, no behavior change when PAT is missing.
