### PR TITLE
GH-2415: fix(executor): send X-OpenCode-Directory header in attached mode

### DIFF
--- a/.agent/tasks/gh-2415.md
+++ b/.agent/tasks/gh-2415.md
@@ -1,0 +1,30 @@
+# GH-2415
+
+**Created:** 2026-04-29
+
+## Problem
+
+GitHub Issue #2415: fix(executor): send X-OpenCode-Directory header in attached mode
+
+## Problem
+When Pilot talks to an attached OpenCode server over HTTP, it creates sessions in the server process cwd instead of the target project path.
+
+## Root Cause
+OpenCode attached mode resolves the project directory from the `x-opencode-directory` header or `directory` query parameter, not from the legacy JSON `path` field in the `POST /session` body.
+
+Verified against upstream OpenCode source:
+- `packages/sdk/js/src/v2/client.ts`
+- `packages/opencode/src/server/routes/instance/middleware.ts`
+
+## Impact
+Pilot can execute tasks against the wrong repository even though `ExecuteOptions.ProjectPath` is set correctly.
+
+## Proposed Fix
+Send `X-OpenCode-Directory: <urlencoded project path>` on both:
+- `POST /session`
+- `POST /session/:id/message`
+
+Add regression coverage to assert the header is present on both requests.
+
+## Acceptance Criteria
+

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-4040757811/pilot-bash-guard.sh"
+            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-435259103/pilot-bash-guard.sh"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-4040757811/pilot-stop-gate.sh"
+            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-435259103/pilot-stop-gate.sh"
           }
         ]
       }

--- a/internal/executor/backend_opencode.go
+++ b/internal/executor/backend_opencode.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os/exec"
 	"strings"
 	"sync"
@@ -174,6 +175,13 @@ func (b *OpenCodeBackend) createSession(ctx context.Context, projectPath string)
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// OpenCode attached mode resolves the project directory from the
+	// `x-opencode-directory` header (or `directory` query param), not from the
+	// JSON `path` field. Without it, sessions are created in the server's cwd
+	// rather than the target project. GH-2415.
+	if projectPath != "" {
+		req.Header.Set("X-OpenCode-Directory", url.QueryEscape(projectPath))
+	}
 
 	resp, err := b.httpClient.Do(req)
 	if err != nil {
@@ -232,6 +240,11 @@ func (b *OpenCodeBackend) sendMessage(ctx context.Context, sessionID string, opt
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "text/event-stream")
+	// See createSession: attached-mode directory resolution requires this
+	// header on the message endpoint too. GH-2415.
+	if opts.ProjectPath != "" {
+		req.Header.Set("X-OpenCode-Directory", url.QueryEscape(opts.ProjectPath))
+	}
 
 	resp, err := b.httpClient.Do(req)
 	if err != nil {

--- a/internal/executor/backend_opencode_test.go
+++ b/internal/executor/backend_opencode_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -552,6 +553,59 @@ func TestOpenCodeBackendSendMessagePayloadShape(t *testing.T) {
 	if !strings.Contains(raw.String(), `"providerID":"anthropic"`) ||
 		!strings.Contains(raw.String(), `"modelID":"claude-sonnet-4"`) {
 		t.Fatalf("payload missing object-form model: %s", raw.String())
+	}
+}
+
+// TestOpenCodeBackendDirectoryHeader verifies that both POST /session and
+// POST /session/:id/message send the X-OpenCode-Directory header so that
+// attached OpenCode servers create sessions in the target project path,
+// not in the server's cwd. GH-2415.
+func TestOpenCodeBackendDirectoryHeader(t *testing.T) {
+	const projectPath = "/tmp/some path/with spaces"
+	wantHeader := url.QueryEscape(projectPath)
+
+	var sessionHeader, messageHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/session":
+			sessionHeader = r.Header.Get("X-OpenCode-Directory")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"ses_1"}`))
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/session/"):
+			messageHeader = r.Header.Get("X-OpenCode-Directory")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"info":{"id":"m1","tokens":{"input":0,"output":0,"cache":{"read":0,"write":0}}},"parts":[{"type":"text","text":"ok"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	b := &OpenCodeBackend{
+		config: &OpenCodeConfig{
+			ServerURL: srv.URL,
+			Model:     "anthropic/claude-sonnet-4",
+		},
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+	b.log = NewOpenCodeBackend(nil).log
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	sessionID, err := b.createSession(ctx, projectPath)
+	if err != nil {
+		t.Fatalf("createSession error = %v", err)
+	}
+	if sessionHeader != wantHeader {
+		t.Errorf("createSession X-OpenCode-Directory = %q, want %q", sessionHeader, wantHeader)
+	}
+
+	if _, err := b.sendMessage(ctx, sessionID, ExecuteOptions{Prompt: "hi", ProjectPath: projectPath}); err != nil {
+		t.Fatalf("sendMessage error = %v", err)
+	}
+	if messageHeader != wantHeader {
+		t.Errorf("sendMessage X-OpenCode-Directory = %q, want %q", messageHeader, wantHeader)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2415.

Closes #2415

## Changes

GitHub Issue #2415: fix(executor): send X-OpenCode-Directory header in attached mode

## Problem
When Pilot talks to an attached OpenCode server over HTTP, it creates sessions in the server process cwd instead of the target project path.

## Root Cause
OpenCode attached mode resolves the project directory from the `x-opencode-directory` header or `directory` query parameter, not from the legacy JSON `path` field in the `POST /session` body.

Verified against upstream OpenCode source:
- `packages/sdk/js/src/v2/client.ts`
- `packages/opencode/src/server/routes/instance/middleware.ts`

## Impact
Pilot can execute tasks against the wrong repository even though `ExecuteOptions.ProjectPath` is set correctly.

## Proposed Fix
Send `X-OpenCode-Directory: <urlencoded project path>` on both:
- `POST /session`
- `POST /session/:id/message`

Add regression coverage to assert the header is present on both requests.