### PR TITLE
GH-2436: fix(docker): pin claude-code to 2.1.123 + use NodeSource Node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update && apt-get install -y --no-install-recommends \
     gh \
-    nodejs \
-    npm \
-    && npm install -g @anthropic-ai/claude-code \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g @anthropic-ai/claude-code@2.1.123 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2436.

Closes #2436

## Changes

GitHub Issue #2436: fix(docker): pin claude-code to 2.1.123 + use NodeSource Node 20

v2.101.0 Docker build failed ([run 24992556558](https://github.com/qf-studio/pilot/actions/runs/24992556558/job/73181442113)) because `Dockerfile:51` installs `nodejs` from Ubuntu jammy apt (Node v12.22.9), but `@anthropic-ai/claude-code` requires Node ≥18. Optional chaining in `install.cjs` throws `SyntaxError: Unexpected token '.'` on Node 12.

## Two coupled changes in `Dockerfile`

### 1. Replace apt-installed nodejs with NodeSource Node 20 LTS
- Drop `nodejs` and `npm` from the existing apt-get install block (line 51-52)
- Before `npm install -g`, add NodeSource setup:
  ```
  curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
  apt-get install -y --no-install-recommends nodejs
  ```
  (NodeSource bundles a current npm, no separate npm package needed)

### 2. Pin claude-code version
- Change line 53: `npm install -g @anthropic-ai/claude-code`
- To: `npm install -g @anthropic-ai/claude-code@2.1.123`

## Verification
- `docker build -t pilot:test .` succeeds locally
- `docker run --rm pilot:test claude --version` prints `2.1.123 (Claude Code)`
- After merge, retag or re-run the Docker workflow to publish the v2.101.x image

## Out of scope
- Doc snippets under `docs/content/**` (user-facing examples, leave unpinned)
- Helm chart (no Node baked in)