### PR TITLE
docs(content): sync to v2.102.2 — planning split, OpenCode attached, ExecuteOptions, version component

### DIFF
--- a/docs/components/current-version.tsx
+++ b/docs/components/current-version.tsx
@@ -1,0 +1,5 @@
+import { CURRENT_VERSION } from '../lib/version'
+
+export function CurrentVersion() {
+  return <>{CURRENT_VERSION}</>
+}

--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -586,7 +586,7 @@ Displays the current Pilot version and build time.
 ```bash
 pilot version
 # Output:
-# Pilot v2.56.0
+# Pilot v2.102.2
 # Built: 2026-03-01T10:30:00Z
 ```
 
@@ -2608,8 +2608,8 @@ pilot release --dry-run
 
 # Output:
 # Would create release:
-#   Current version: v2.56.0
-#   New version: v2.56.1
+#   Current version: v2.102.2
+#   New version: v2.102.3
 #   Bump type: patch
 #   Draft: false
 ```

--- a/docs/content/concepts/execution-backends.mdx
+++ b/docs/content/concepts/execution-backends.mdx
@@ -189,6 +189,35 @@ executor:
 - **Raw HTTP**: Errors are not classified (rate limit, API, timeout all appear as HTTP errors)
 - **SSE streaming**: Uses HTTP Server-Sent Events instead of JSON streaming
 
+### Attached Mode (multi-project / non-CWD execution)
+
+OpenCode runs as a long-lived HTTP server, so a single server instance can drive sessions across multiple project directories. To do that the server has to know **which** directory each request targets — its own `cwd` is not enough.
+
+Pilot sends the `X-OpenCode-Directory` header on the two endpoints that need it:
+
+- `POST /session` — directory the new session should attach to
+- `POST /session/:id/message` — directory the message executes against
+
+Without the header, OpenCode resolves sessions against the server process `cwd` and any tool calls (file reads, edits, shell commands) run in the wrong tree. Symptom: PRs land empty or commits target an unrelated repo. Fixed in [GH-2415](https://github.com/qf-studio/pilot/issues/2415) (v2.102.0).
+
+<Callout type="info">
+The header value is the URL-encoded absolute path. OpenCode also accepts a `directory=` query parameter; Pilot uses the header form. The legacy JSON `path` field on `POST /session` is no longer authoritative in OpenCode v1.4.x+.
+</Callout>
+
+When you run a single-project Pilot pointed at the project directory, attached mode is invisible — Pilot still sends the header, OpenCode resolves to the same path the server happens to be in, and behavior is identical to detached mode. The header is required, not optional, the moment you point one OpenCode server at multiple worktrees or run the server from a directory other than the project root.
+
+### Request Timeout
+
+OpenCode session creation and SSE response streaming go over HTTP, so they're bound by an explicit timeout. Default is **10 minutes** (the SSE phase frequently runs longer than a Claude Code subprocess; a 2-minute cap surfaces as spurious cancellations). Tune via `executor.opencode.request_timeout`:
+
+```yaml
+executor:
+  opencode:
+    request_timeout: "10m"   # default; raise for very long planning passes
+```
+
+The same timeout applies to session creation, message send, and SSE response headers. Tracked under [GH-2410](https://github.com/qf-studio/pilot/issues/2410) (v2.102.0) and [GH-2416](https://github.com/qf-studio/pilot/issues/2416) (v2.102.1).
+
 ### Strengths
 
 - ✅ Flexible server architecture (can be remote)

--- a/docs/content/concepts/model-routing.mdx
+++ b/docs/content/concepts/model-routing.mdx
@@ -105,6 +105,28 @@ Three phases alone is **not** epic — that's a normal implementation plan. The 
 4. Parent issue moves to `pilot-in-progress`
 5. The poller picks up subtasks sequentially
 
+## Planning vs Execution Model Split
+
+Pilot runs two distinct subprocesses per task: a **planning** pass that decomposes the issue and a sequence of **execution** passes that write the code. They have very different cost/quality trade-offs, so each gets its own model.
+
+| Phase | Default Model | Why |
+|-------|---------------|-----|
+| Planning (epic decomposition) | `claude-opus-4-7` | Stronger reasoning produces better subtask boundaries; runs once per epic |
+| Execution (every subtask, including `complex`) | `claude-sonnet-4-6` | Cheaper per token, near-Opus quality on focused implementation work |
+
+Planning runs once and emits a structured plan; execution runs many times per task across self-review, retry, and feedback loops. Reserving Opus for planning and pinning execution to Sonnet (including the `complex` complexity tier) cuts the per-task token spend by roughly **70%** versus running everything on Opus.
+
+```yaml
+executor:
+  planning:
+    model: "claude-opus-4-7"   # default; override per deployment
+  model_routing:
+    enabled: true
+    complex: "claude-sonnet-4-6"  # GH-2432: Opus reserved for planning
+```
+
+See [Configuration → Executor](/getting-started/configuration#executor) for the full key list and `executor.allowed_tools` / `executor.mcp_config_path` knobs that complement the split. Tracked under [GH-2432](https://github.com/qf-studio/pilot/issues/2432) (v2.100.5).
+
 ## Routing Tables
 
 ### Model Routing
@@ -116,10 +138,10 @@ Maps complexity to the AI model used for execution.
 | Trivial | `claude-haiku-4-5` | $0.80 / $4 per 1M tokens | Speed over depth — mechanical changes don't need reasoning |
 | Simple | `claude-sonnet-4-6` | $3 / $15 per 1M tokens | Near-Opus quality at 40% lower cost |
 | Medium | `claude-sonnet-4-6` | $3 / $15 per 1M tokens | Standard feature work, near-Opus quality |
-| Complex | `claude-opus-4-6` | $5 / $25 per 1M tokens | Architectural work gets the most capable model |
+| Complex | `claude-sonnet-4-6` | $3 / $15 per 1M tokens | Sonnet handles architectural work; Opus is reserved for the planning pass (GH-2432) |
 
 <Callout type="info">
-Sonnet 4.6 is the default for simple/medium tasks — near-Opus quality at 40% lower cost. Complex tasks use Opus 4.6 for maximum reasoning depth. Epic tasks are decomposed before execution, so each subtask routes independently.
+Sonnet 4.6 is the default across simple, medium, *and* complex execution tiers. Opus is invoked once per epic during the planning pass (`executor.planning.model`), not on the execution path. Epic tasks are decomposed before execution, so each subtask routes independently.
 </Callout>
 
 ### Timeout Routing
@@ -181,7 +203,7 @@ Beyond model and timeout, complexity drives execution behavior:
 
 ## Outcome-Based Escalation
 
-Starting in v2.56.0, Pilot tracks execution outcomes per model and automatically escalates to a more capable model when failure rates exceed a threshold.
+Pilot tracks execution outcomes per model and automatically escalates to a more capable model when failure rates exceed a threshold.
 
 ### How It Works
 
@@ -233,7 +255,7 @@ executor:
     trivial: "claude-haiku-4-5"     # fastest, cheapest
     simple: "claude-sonnet-4-6"    # near-Opus quality, 40% cheaper
     medium: "claude-sonnet-4-6"
-    complex: "claude-opus-4-6"
+    complex: "claude-sonnet-4-6"  # Opus is reserved for planning (see above)
 ```
 
 When `enabled: false` (default), all tasks use the backend's default model — no routing occurs.
@@ -292,7 +314,7 @@ executor:
     trivial: "claude-haiku-4-5"
     simple: "claude-sonnet-4-6"
     medium: "claude-sonnet-4-6"
-    complex: "claude-opus-4-6"
+    complex: "claude-sonnet-4-6"  # Opus is reserved for planning (see above)
     escalation:
       enabled: true
       threshold: 0.3

--- a/docs/content/deployment/desktop-app.mdx
+++ b/docs/content/deployment/desktop-app.mdx
@@ -183,10 +183,10 @@ desktop/build/bin/Pilot.app
 ### (Optional) Package as a zip
 
 ```bash
-make desktop-package VERSION=v2.56.0
+make desktop-package VERSION=v2.102.2
 ```
 
-Produces `bin/Pilot-macOS-v2.56.0.zip`.
+Produces `bin/Pilot-macOS-v2.102.2.zip`.
 
 </Steps>
 

--- a/docs/content/deployment/docker-helm.mdx
+++ b/docs/content/deployment/docker-helm.mdx
@@ -52,7 +52,7 @@ Pilot starts polling for issues labeled `pilot` on the configured repository wit
 docker pull ghcr.io/qf-studio/pilot:latest
 
 # Pin to a specific version (recommended for production)
-docker pull ghcr.io/qf-studio/pilot:v2.56.0
+docker pull ghcr.io/qf-studio/pilot:v2.102.2
 ```
 
 ### Build from Source
@@ -139,7 +139,7 @@ For production use with Telegram, Slack, and multiple adapters:
 ```yaml
 services:
   pilot:
-    image: ghcr.io/qf-studio/pilot:v2.56.0
+    image: ghcr.io/qf-studio/pilot:v2.102.2
     ports:
       - "9090:9090"
     environment:
@@ -252,7 +252,7 @@ helm install pilot ./helm/pilot \
 
 ```bash
 helm upgrade pilot ./helm/pilot --reuse-values \
-  --set image.tag=v2.56.0
+  --set image.tag=v2.102.2
 ```
 
 ### values.yaml Reference
@@ -261,7 +261,7 @@ helm upgrade pilot ./helm/pilot --reuse-values \
 # Image
 image:
   repository: ghcr.io/qf-studio/pilot
-  tag: v2.56.0           # pin to a specific version in production
+  tag: v2.102.2           # pin to a specific version in production
   pullPolicy: IfNotPresent
 
 # Replica count — always 1 (SQLite constraint)
@@ -338,7 +338,7 @@ podSecurityContext:
 
 ```bash
 # Change image tag
-helm upgrade pilot ./helm/pilot --set image.tag=v2.56.0
+helm upgrade pilot ./helm/pilot --set image.tag=v2.102.2
 
 # Enable ingress
 helm upgrade pilot ./helm/pilot \

--- a/docs/content/features/dashboard.mdx
+++ b/docs/content/features/dashboard.mdx
@@ -207,7 +207,7 @@ When a new Pilot version is detected, an orange notification appears:
 
 ```
 ╭─ ^ UPDATE ──────────────────────────────────────────────────────╮
-│  v2.55.0 -> v2.56.0 available                                   │
+│  v2.55.0 -> v2.102.2 available                                  │
 ╰─────────────────────────────────────────────────────────────────╯
                                                          u: upgrade
 ```
@@ -216,7 +216,7 @@ Press `u` to upgrade in-place. Progress is shown during download:
 
 ```
 ╭─ * UPGRADING ───────────────────────────────────────────────────╮
-│  Installing v2.56.0... [████████████░░░░░░] 65%                 │
+│  Installing v2.102.2... [████████████░░░░░░] 65%                │
 ╰─────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -288,6 +288,7 @@ executor:
     provider: "anthropic"
     auto_start_server: false
     server_command: "opencode serve"
+    request_timeout: "10m"
 ```
 
 </Tabs>
@@ -301,6 +302,31 @@ executor:
 | `opencode.provider` | string | `"anthropic"` | LLM provider name |
 | `opencode.auto_start_server` | bool | `true` | Auto-start OpenCode server if not running |
 | `opencode.server_command` | string | `"opencode serve"` | Command to start the server |
+| `opencode.request_timeout` | duration | `"10m"` | HTTP timeout for session creation, message send, and SSE response headers ([GH-2410](https://github.com/qf-studio/pilot/issues/2410)) |
+
+<Callout type="info">
+**Self-review timeout is backend-aware.** The self-review phase is capped at **10 minutes** for OpenCode and **2 minutes** for Claude Code / Qwen Code. OpenCode's SSE streaming legitimately runs slower than a Claude Code subprocess; a 2-minute cap cancels review while the backend is still working and surfaces as a false regression ([GH-2416](https://github.com/qf-studio/pilot/issues/2416)). The cap is not user-configurable today.
+</Callout>
+
+### Tool Restriction (per-subprocess token control)
+
+`executor.claude_code.allowed_tools` and `executor.claude_code.mcp_config_path` scope the toolbox each Claude Code subprocess can use. Both flow through to `ExecuteOptions.AllowedTools` / `ExecuteOptions.MCPConfigPath` and are applied to every backend call site (execution, self-review, retry, intent judge, feedback). Trimming the toolbox shaves the per-turn token cost — Claude Code replays the full tool definition list on every turn, and an unused MCP config is the single largest replayed payload.
+
+```yaml
+executor:
+  claude_code:
+    allowed_tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob", "Task"]
+    mcp_config_path: ""        # empty = no MCP servers loaded
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `claude_code.allowed_tools` | []string | `["Read","Write","Edit","Bash","Grep","Glob","Task"]` | Whitelist passed via `--allowedTools`. Excludes MCP and Web* tools by default to cut per-turn context bloat ([GH-2432](https://github.com/qf-studio/pilot/issues/2432)). |
+| `claude_code.mcp_config_path` | string | `""` | Path passed via `--mcp-config`. When empty, the subprocess loads **no** MCP servers. |
+
+<Callout type="warning">
+Empty `mcp_config_path` is the recommended default. Loading an MCP config you don't use can replay tens of thousands of tool-definition tokens on every turn. Only set this when a subprocess legitimately needs MCP-backed tools.
+</Callout>
 
 ### Hooks
 

--- a/docs/content/getting-started/installation.mdx
+++ b/docs/content/getting-started/installation.mdx
@@ -45,7 +45,7 @@ cp ./bin/pilot ~/.local/bin/pilot
 
 ```bash
 pilot --version
-# pilot version v2.56.0
+# pilot version v2.102.2
 ```
 
 Run the health check to verify all dependencies:

--- a/docs/content/getting-started/quickstart.mdx
+++ b/docs/content/getting-started/quickstart.mdx
@@ -38,7 +38,7 @@ Verify:
 
 ```bash
 pilot --version
-# pilot version v2.56.0
+# pilot version v2.102.2
 ```
 
 ### Run the Setup Wizard

--- a/docs/lib/version.ts
+++ b/docs/lib/version.ts
@@ -1,0 +1,3 @@
+// Single source of truth for the current Pilot release shown in docs prose.
+// Bump on every release tag (see GoReleaser hook follow-up — out of scope here).
+export const CURRENT_VERSION = "v2.102.2"

--- a/docs/mdx-components.tsx
+++ b/docs/mdx-components.tsx
@@ -1,1 +1,12 @@
-export { useMDXComponents } from 'nextra-theme-docs'
+import { useMDXComponents as getNextraComponents } from 'nextra-theme-docs'
+import { CurrentVersion } from './components/current-version'
+
+const sharedComponents = { CurrentVersion }
+
+export function useMDXComponents(components?: Record<string, unknown>) {
+  return {
+    ...getNextraComponents(),
+    ...sharedComponents,
+    ...components,
+  }
+}


### PR DESCRIPTION
## Summary

Brings `docs/` (Nextra at pilot.quantflow.studio) up to v2.102.2 in one bundled PR. Closes GH-2441.

- **Shared version component**: new `docs/lib/version.ts` + `<CurrentVersion/>` MDX component (registered in `mdx-components.tsx`) so docs prose has a single version source going forward.
- **Version pins**: 14 stale `v2.56.0` strings in code-fence examples (CLI output, docker/helm tags, desktop-package, dashboard hot-upgrade box) bumped to `v2.102.2`. Historical "Starting in v2.56.0" in model-routing rephrased.
- **Model-routing**: new "Planning vs Execution Model Split" section — `executor.planning.model = claude-opus-4-7` (planning), `claude-sonnet-4-6` everywhere on the execution path including `complex` (~70% per-task token cut). Routing Tables + yaml examples aligned. (GH-2432, v2.100.5)
- **Execution backends**: documented OpenCode attached mode, the `X-OpenCode-Directory` header on `POST /session` and `POST /session/:id/message`, and `executor.opencode.request_timeout` (default 10m). (GH-2415, GH-2410, v2.102.0/1)
- **Configuration**: added `opencode.request_timeout` row, callout on backend-aware self-review timeout (10m OpenCode / 2m Claude Code + Qwen), and a "Tool Restriction" section for `executor.claude_code.allowed_tools` / `mcp_config_path`. (GH-2416, GH-2432)

Out of scope (separate follow-ups): retry persistence labels in `integrations/github.mdx`, GoReleaser hook to auto-bump `docs/lib/version.ts` on tag push.

## Test plan

- [x] `cd docs && bun install && bun run build` — Compiled successfully, 66/66 static pages, 63 pages indexed by pagefind, no Nextra errors.
- [x] `grep -rn "v2\.56\.0" docs/content/` — zero hits.
- [x] Code cross-checks against `internal/executor/backend.go` (`PlanningConfig.Model = "claude-opus-4-7"`, `OpenCodeConfig.RequestTimeout` default `"10m"`, `DefaultModelRoutingConfig.Complex = "claude-sonnet-4-6"`), `internal/executor/backend_opencode.go` (`X-OpenCode-Directory` set on `createSession` + `sendMessage`), `internal/executor/runner.go` (`selfReviewTimeout()` returns 10m for OpenCode, 2m otherwise; `executionToolOptions` reads `ClaudeCode.AllowedTools` / `MCPConfigPath`).
- [ ] Spot-check rendered pages on pilot.quantflow.studio after docs deploy fires.