### PR TITLE
GH-2443: docs(integrations): document pilot-retry-1/2/exhausted labels

### DIFF
--- a/docs/content/integrations/github.mdx
+++ b/docs/content/integrations/github.mdx
@@ -180,6 +180,11 @@ Pilot applies labels to track issue status:
 | `pilot-done` | Applied after successful completion |
 | `pilot-failed` | Applied if execution fails |
 | `pilot-retry-ready` | PR closed without merge, ready for retry |
+| `pilot-retry-1` | Retry counter — first failed attempt recorded |
+| `pilot-retry-2` | Retry counter — second failed attempt recorded |
+| `pilot-retry-exhausted` | Retry budget consumed; blocks further retries until manually cleared |
+
+Each failed execution bumps the persistent retry counter (`pilot-retry-1` → `pilot-retry-2`). Once the budget is exhausted, Pilot applies `pilot-retry-exhausted` and stops picking up the issue. Remove that label manually to allow another attempt.
 
 ### Merge Methods
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2443.

Closes #2443

## Changes

GitHub Issue #2443: docs(integrations): document pilot-retry-1/2/exhausted labels

## Goal

Extend the retry labels table in `docs/content/integrations/github.mdx` (around line 182) to cover the persistent retry counter labels added in v2.100.5.

## Scope

**Edit** `docs/content/integrations/github.mdx`:

- Existing table currently lists only `pilot-retry-ready`.
- Add three rows for `pilot-retry-1`, `pilot-retry-2`, `pilot-retry-exhausted`.
- Brief explanation of the retry counter flow: each failure bumps the counter; `pilot-retry-exhausted` blocks further retries until manually cleared.

## Verification

- `cd docs && bun run dev` — page renders, table displays new rows cleanly.
- `grep -n "pilot-retry" docs/content/integrations/github.mdx` shows all four labels.

## Notes

Small, isolated docs change. No code touched.