### PR TITLE
chore(release): auto-bump docs/lib/version.ts on tag push (GH-2444)

### DIFF
--- a/.github/workflows/docs-version-sync.yml
+++ b/.github/workflows/docs-version-sync.yml
@@ -78,6 +78,7 @@ jobs:
             - `.agent/DEVELOPMENT-README.md`
             - `.agent/system/FEATURE-MATRIX.md`
             - `docs/app/layout.tsx` (navbar version)
+            - `docs/lib/version.ts` (`<CurrentVersion/>` source of truth)
 
             Created by docs-version-sync workflow.
           branch: docs/version-sync-${{ steps.version.outputs.VERSION }}

--- a/docs/lib/version.ts
+++ b/docs/lib/version.ts
@@ -1,3 +1,4 @@
 // Single source of truth for the current Pilot release shown in docs prose.
-// Bump on every release tag (see GoReleaser hook follow-up — out of scope here).
+// Auto-bumped by .github/workflows/docs-version-sync.yml on every v* tag push
+// via scripts/docs-version-sync.sh.
 export const CURRENT_VERSION = "v2.102.2"

--- a/scripts/docs-version-sync.sh
+++ b/scripts/docs-version-sync.sh
@@ -68,6 +68,20 @@ if [ -f "$LAYOUT_FILE" ]; then
     fi
 fi
 
+# Update docs/lib/version.ts (single source of truth for <CurrentVersion/>)
+VERSION_TS="docs/lib/version.ts"
+if [ -f "$VERSION_TS" ]; then
+    if grep -q 'CURRENT_VERSION = "v[0-9]*\.[0-9]*\.[0-9]*"' "$VERSION_TS"; then
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "s/CURRENT_VERSION = \"v[0-9]*\.[0-9]*\.[0-9]*\"/CURRENT_VERSION = \"${VERSION}\"/g" "$VERSION_TS"
+        else
+            sed -i "s/CURRENT_VERSION = \"v[0-9]*\.[0-9]*\.[0-9]*\"/CURRENT_VERSION = \"${VERSION}\"/g" "$VERSION_TS"
+        fi
+        echo "  Updated $VERSION_TS"
+        ((++updated))
+    fi
+fi
+
 if [ $updated -gt 0 ]; then
     echo "Version synced to $VERSION in $updated file(s)"
 else


### PR DESCRIPTION
Closes #2444.

## Approach — Option C

Extended the existing `Sync Docs Version` workflow (`.github/workflows/docs-version-sync.yml`) rather than adding a new workflow or GoReleaser hook. The workflow already triggers on `v*.*.*` tag push, runs `scripts/docs-version-sync.sh`, and opens an auto-merge PR with `[skip ci]`-equivalent flow. Adding `docs/lib/version.ts` to that script keeps everything in one place.

Why not Option A (GoReleaser hook)? GoReleaser amending the release commit fights with the existing PR-based sync flow that already updates two other files. Two mechanisms for the same job is worse than one.
Why not Option B (new workflow)? Pure duplication.

## Changes

- `scripts/docs-version-sync.sh` — sed-update `CURRENT_VERSION = "vX.Y.Z"` in `docs/lib/version.ts`.
- `.github/workflows/docs-version-sync.yml` — list the new file in the PR body.
- `docs/lib/version.ts` — comment now points at the automation path.

## Verification

Ran `bash scripts/docs-version-sync.sh v9.9.9` locally:
```
  Updated .agent/DEVELOPMENT-README.md
  Updated .agent/system/FEATURE-MATRIX.md
  Updated docs/app/layout.tsx
  Updated docs/lib/version.ts
Version synced to v9.9.9 in 4 file(s)
```

After the next `v*` tag push, the auto-PR opened by `docs-version-sync.yml` will include the bumped `docs/lib/version.ts`, and `<CurrentVersion/>` will render the new version once `Sync Docs to GitLab` runs.

## Test plan

- [ ] Next release tag triggers workflow and PR includes `docs/lib/version.ts` diff
- [ ] `<CurrentVersion/>` on docs site reflects new version after auto-merge + GitLab sync