### PR TITLE
GH-2450: fix(executor): preserve model_routing result for claude-code backend

### DIFF
--- a/internal/executor/gh2450_test.go
+++ b/internal/executor/gh2450_test.go
@@ -1,0 +1,75 @@
+package executor
+
+import "testing"
+
+// TestResolveSelectedModel_GH2450 covers the regression where setting
+// `default_model` clobbered `model_routing` for the Claude Code backend,
+// causing the routed model to be wiped to "" before reaching the backend.
+//
+// Cases:
+//   - (a) model_routing.simple set + CC backend → router model wins
+//   - (b) model_routing unset + CC backend     → empty (CC passthrough preserved)
+//   - (c) router empty + non-CC backend with default_model → default_model
+func TestResolveSelectedModel_GH2450(t *testing.T) {
+	// Force ComplexitySimple via a short description (word count < 10).
+	task := &Task{
+		ID:          "GH-2450-test",
+		Title:       "tiny",
+		Description: "one liner",
+	}
+
+	tests := []struct {
+		name    string
+		routing *ModelRoutingConfig
+		config  *BackendConfig
+		want    string
+	}{
+		{
+			name: "model_routing wins for CC backend",
+			routing: &ModelRoutingConfig{
+				Enabled: true,
+				Simple:  "claude-sonnet-4-6",
+				Medium:  "claude-sonnet-4-6",
+				Complex: "claude-opus-4-7",
+				Trivial: "claude-haiku-4-5",
+			},
+			config: &BackendConfig{
+				Type:         BackendTypeClaudeCode,
+				DefaultModel: "claude-opus-4-7",
+			},
+			want: "claude-sonnet-4-6",
+		},
+		{
+			name:    "model_routing unset + CC backend → passthrough",
+			routing: nil,
+			config: &BackendConfig{
+				Type:         BackendTypeClaudeCode,
+				DefaultModel: "claude-opus-4-7",
+			},
+			want: "",
+		},
+		{
+			name:    "non-CC backend falls back to default_model when router empty",
+			routing: nil,
+			config: &BackendConfig{
+				Type:         BackendTypeOpenCode,
+				DefaultModel: "claude-opus-4-7",
+			},
+			want: "claude-opus-4-7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Runner{
+				config:      tt.config,
+				modelRouter: NewModelRouter(tt.routing, nil),
+			}
+
+			got := r.resolveSelectedModel(task)
+			if got != tt.want {
+				t.Errorf("resolveSelectedModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -679,6 +679,26 @@ func (r *Runner) SetModelRouter(router *ModelRouter) {
 	r.modelRouter = router
 }
 
+// resolveSelectedModel returns the model name to pass to the backend for a task.
+// GH-2450: model_routing wins when configured. Only fall back to default_model
+// (or CC empty-passthrough) when the router returned an empty string. Setting
+// default_model previously clobbered routing for the Claude Code backend.
+func (r *Runner) resolveSelectedModel(task *Task) string {
+	model := r.modelRouter.SelectModel(task)
+	if model != "" {
+		return model
+	}
+	if r.config == nil || r.config.DefaultModel == "" {
+		return ""
+	}
+	if r.config.Type == BackendTypeClaudeCode {
+		// CC reads ANTHROPIC_MODEL / its own settings; pass empty to avoid
+		// overriding the user's CC-side configuration.
+		return ""
+	}
+	return r.config.DefaultModel
+}
+
 // SetParallelRunner sets the parallel runner for research phase execution (GH-217).
 // When set and enabled, medium/complex tasks run parallel research subagents
 // before the main implementation to gather codebase context.
@@ -1380,15 +1400,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		slog.Duration("timeout", timeout),
 	)
 
-	// Select model if routing is enabled
-	selectedModel := r.modelRouter.SelectModel(task)
-	if r.config != nil && r.config.DefaultModel != "" {
-		if r.config.Type == BackendTypeClaudeCode {
-			selectedModel = ""
-		} else {
-			selectedModel = r.config.DefaultModel
-		}
-	}
+	selectedModel := r.resolveSelectedModel(task)
 	if selectedModel != "" {
 		log = log.With(slog.String("routed_model", selectedModel))
 	}
@@ -3320,15 +3332,8 @@ func (r *Runner) runSelfReview(ctx context.Context, task *Task, state *progressS
 	reviewCtx, cancel := context.WithTimeout(ctx, r.selfReviewTimeout())
 	defer cancel()
 
-	// Select model and effort (use same routing as main execution)
-	selectedModel := r.modelRouter.SelectModel(task)
-	if r.config != nil && r.config.DefaultModel != "" {
-		if r.config.Type == BackendTypeClaudeCode {
-			selectedModel = ""
-		} else {
-			selectedModel = r.config.DefaultModel
-		}
-	}
+	// Select model and effort (use same routing as main execution).
+	selectedModel := r.resolveSelectedModel(task)
 	selectedEffort := r.modelRouter.SelectEffort(task)
 
 	// GH-1265: Determine if session resume is enabled and session ID is available


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2450.

Closes #2450

## Changes

Update both call sites in `internal/executor/runner.go` (lines 1384-1391 and 3324-3329) to only fall back to `default_model` / CC empty-passthrough when `r.modelRouter.SelectModel(task)` returns an empty string. When the router produces a non-empty model (i.e., `model_routing` is configured), use it directly instead of wiping it for `BackendTypeClaudeCode`. Add a unit test in `internal/executor/` covering: (a) `model_routing.simple: claude-sonnet-4-6` with CC backend → selected model is `claude-sonnet-4-6`; (b) `model_routing` unset with CC backend → selected model is empty (passthrough preserved); (c) non-CC backend with `default_model` set and router empty → falls back to `default_model`. Verify via `make test` and `make lint`. Acceptance: after merge and Pilot restart, a trivial task logs `model_name: claude-sonnet-4-6` in the `executions` SQLite table with Sonnet-priced cost.