### PR TITLE
GH-2450: fix(executor): preserve model_routing result for claude-code backend

### DIFF
--- a/internal/executor/model_routing.go
+++ b/internal/executor/model_routing.go
@@ -187,6 +187,29 @@ func (r *ModelRouter) GetTimeoutForComplexity(complexity Complexity) time.Durati
 	return duration
 }
 
+// resolveExecutionModel returns the model name to use for the executor's
+// main and self-review phases. It prefers a non-empty model_routing result
+// over default_model so explicit routing config is not clobbered by a
+// catch-all default_model (GH-2448/GH-2450). When routing is disabled or
+// returns empty, falls back to default_model — except for the claude-code
+// backend, which uses an empty passthrough so CC honors its own settings.
+func resolveExecutionModel(router *ModelRouter, cfg *BackendConfig, task *Task) string {
+	var routed string
+	if router != nil {
+		routed = router.SelectModel(task)
+	}
+	if routed != "" {
+		return routed
+	}
+	if cfg != nil && cfg.DefaultModel != "" {
+		if cfg.Type == BackendTypeClaudeCode {
+			return ""
+		}
+		return cfg.DefaultModel
+	}
+	return ""
+}
+
 // IsRoutingEnabled returns true if model routing is enabled.
 func (r *ModelRouter) IsRoutingEnabled() bool {
 	return r.modelConfig != nil && r.modelConfig.Enabled

--- a/internal/executor/model_routing_resolve_test.go
+++ b/internal/executor/model_routing_resolve_test.go
@@ -1,0 +1,70 @@
+package executor
+
+import "testing"
+
+// TestResolveExecutionModel_GH2450 covers the regression where default_model
+// clobbered model_routing results for the claude-code backend.
+func TestResolveExecutionModel_GH2450(t *testing.T) {
+	simpleTask := &Task{Description: "Add field to struct"}
+
+	tests := []struct {
+		name     string
+		router   *ModelRouter
+		cfg      *BackendConfig
+		task     *Task
+		expected string
+	}{
+		{
+			name: "model_routing wins over default_model on claude-code backend",
+			router: NewModelRouter(&ModelRoutingConfig{
+				Enabled: true,
+				Trivial: "claude-haiku",
+				Simple:  "claude-sonnet-4-6",
+				Medium:  "claude-sonnet-4-6",
+				Complex: "claude-opus",
+			}, nil),
+			cfg: &BackendConfig{
+				Type:         BackendTypeClaudeCode,
+				DefaultModel: "claude-opus-4-5",
+			},
+			task:     simpleTask,
+			expected: "claude-sonnet-4-6",
+		},
+		{
+			name:   "claude-code backend with routing disabled keeps empty passthrough",
+			router: NewModelRouter(&ModelRoutingConfig{Enabled: false}, nil),
+			cfg: &BackendConfig{
+				Type:         BackendTypeClaudeCode,
+				DefaultModel: "claude-opus-4-5",
+			},
+			task:     simpleTask,
+			expected: "",
+		},
+		{
+			name:   "non-CC backend falls back to default_model when router empty",
+			router: NewModelRouter(&ModelRoutingConfig{Enabled: false}, nil),
+			cfg: &BackendConfig{
+				Type:         "anthropic",
+				DefaultModel: "claude-opus-4-5",
+			},
+			task:     simpleTask,
+			expected: "claude-opus-4-5",
+		},
+		{
+			name:   "no config and disabled routing returns empty",
+			router: NewModelRouter(&ModelRoutingConfig{Enabled: false}, nil),
+			cfg:    nil,
+			task:   simpleTask,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveExecutionModel(tt.router, tt.cfg, tt.task)
+			if got != tt.expected {
+				t.Errorf("resolveExecutionModel() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1380,15 +1380,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		slog.Duration("timeout", timeout),
 	)
 
-	// Select model if routing is enabled
-	selectedModel := r.modelRouter.SelectModel(task)
-	if r.config != nil && r.config.DefaultModel != "" {
-		if r.config.Type == BackendTypeClaudeCode {
-			selectedModel = ""
-		} else {
-			selectedModel = r.config.DefaultModel
-		}
-	}
+	selectedModel := resolveExecutionModel(r.modelRouter, r.config, task)
 	if selectedModel != "" {
 		log = log.With(slog.String("routed_model", selectedModel))
 	}
@@ -3320,15 +3312,8 @@ func (r *Runner) runSelfReview(ctx context.Context, task *Task, state *progressS
 	reviewCtx, cancel := context.WithTimeout(ctx, r.selfReviewTimeout())
 	defer cancel()
 
-	// Select model and effort (use same routing as main execution)
-	selectedModel := r.modelRouter.SelectModel(task)
-	if r.config != nil && r.config.DefaultModel != "" {
-		if r.config.Type == BackendTypeClaudeCode {
-			selectedModel = ""
-		} else {
-			selectedModel = r.config.DefaultModel
-		}
-	}
+	// Select model and effort (use same routing as main execution).
+	selectedModel := resolveExecutionModel(r.modelRouter, r.config, task)
 	selectedEffort := r.modelRouter.SelectEffort(task)
 
 	// GH-1265: Determine if session resume is enabled and session ID is available


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2450.

Closes #2450

## Changes

GitHub Issue #2450: fix(executor): preserve model_routing result for claude-code backend

Parent: GH-2448

Update both call sites in `internal/executor/runner.go` (lines 1384-1391 and 3324-3329) to only fall back to `default_model` / CC empty-passthrough when `r.modelRouter.SelectModel(task)` returns an empty string. When the router produces a non-empty model (i.e., `model_routing` is configured), use it directly instead of wiping it for `BackendTypeClaudeCode`. Add a unit test in `internal/executor/` covering: (a) `model_routing.simple: claude-sonnet-4-6` with CC backend → selected model is `claude-sonnet-4-6`; (b) `model_routing` unset with CC backend → selected model is empty (passthrough preserved); (c) non-CC backend with `default_model` set and router empty → falls back to `default_model`. Verify via `make test` and `make lint`. Acceptance: after merge and Pilot restart, a trivial task logs `model_name: claude-sonnet-4-6` in the `executions` SQLite table with Sonnet-priced cost.