### PR TITLE
GH-2461: feat(executor): doc maintenance rule in generated CLAUDE.md

### DIFF
--- a/cmd/pilot/init_project.go
+++ b/cmd/pilot/init_project.go
@@ -296,6 +296,17 @@ func buildClaudeMD(data *initProjectData) string {
 		sb.WriteString("\n")
 	}
 
+	// Documentation maintenance rules
+	sb.WriteString("## Documentation Maintenance\n\n")
+	sb.WriteString("Keep `.agent/*.md` files lean. Alternative locations for long-lived content:\n\n")
+	sb.WriteString("- **Changelog / release notes** → `git log` or GitHub Releases\n")
+	sb.WriteString("- **Architectural decisions** → `.agent/system/` (one file per decision)\n")
+	sb.WriteString("- **Completed task history** → `.agent/tasks/archive/`\n")
+	sb.WriteString("- **Active task plans** → `.agent/tasks/` (remove when merged)\n\n")
+	sb.WriteString("Rules:\n\n")
+	sb.WriteString("- Do **not** append to `## Recent` blocks — replace the block content instead.\n")
+	sb.WriteString("- Do **not** let any `.agent/*.md` section grow append-only; prune or archive instead.\n\n")
+
 	return sb.String()
 }
 

--- a/cmd/pilot/init_project_test.go
+++ b/cmd/pilot/init_project_test.go
@@ -214,6 +214,24 @@ func TestBuildClaudeMD(t *testing.T) {
 			},
 			absent: []string{"## Quality Gates"},
 		},
+		{
+			name: "Documentation maintenance section always present",
+			data: &initProjectData{
+				ProjectName:  "myapp",
+				Template:     TemplateGo,
+				CommitFormat: "feat(scope): description",
+			},
+			contains: []string{
+				"## Documentation Maintenance",
+				"git log",
+				"GitHub Releases",
+				".agent/system/",
+				".agent/tasks/archive/",
+				".agent/tasks/",
+				"## Recent",
+				"append-only",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2461.

Closes #2461

## Changes

GitHub Issue #2461: feat(executor): doc maintenance rule in generated CLAUDE.md

## Problem
`.agent/DEVELOPMENT-README.md` in Pilot-managed projects can grow unbounded as interactive Claude sessions append release notes / changelogs out of habit. Pilot's own copy reached 941 lines before this fix.

## Fix
Add a "Documentation Maintenance" section to the CLAUDE.md generated by `pilot init`. Names the correct alternative locations so Claude doesn't default to appending to `.agent/DEVELOPMENT-README.md`.

## Acceptance criteria
- [ ] `cmd/pilot/init_project.go` `buildClaudeMD()` appends a new `## Documentation Maintenance` section before `return`.
- [ ] Section names: git log, GitHub releases, `.agent/tasks/archive/`, `.agent/system/` as alternative locations for changelogs / decisions / history.
- [ ] Rules: do not append to `## Recent` blocks (replace), do not let any `.agent/*.md` section grow append-only.
- [ ] `cmd/pilot/init_project_test.go` covers the new section content.
- [ ] `go test ./cmd/pilot/...` passes.

## Files
- `cmd/pilot/init_project.go` (line ~298)
- `cmd/pilot/init_project_test.go`

## Out of scope
- Trim of Pilot's existing `.agent/DEVELOPMENT-README.md` (separate issue).
- `pilot doctor` size guardrail (separate issue).