### PR TITLE
GH-2462: feat(doctor): warn on bloated .agent docs

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -290,6 +290,7 @@
 | Gateway HTTP | ✅ | gateway | `pilot start` | `gateway` | Internal server, wired in main.go |
 | Gateway WebSocket | ✅ | gateway | - | - | Session management active in gateway |
 | Health checks | ✅ | health | `pilot doctor` | - | System validation, 32 unit tests |
+| Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |

--- a/cmd/pilot/doctor.go
+++ b/cmd/pilot/doctor.go
@@ -131,6 +131,9 @@ Examples:
 			// Helpful next steps
 			fmt.Println("Run 'pilot setup' for interactive configuration wizard")
 
+			if report.HasErrors {
+				return fmt.Errorf("%d error(s) detected — fix them before running Pilot", errors)
+			}
 			return nil
 		},
 	}

--- a/docs/content/cli/_meta.js
+++ b/docs/content/cli/_meta.js
@@ -1,3 +1,4 @@
 export default {
-  commands: "Commands"
+  commands: "Commands",
+  doctor: "pilot doctor"
 }

--- a/docs/content/cli/doctor.mdx
+++ b/docs/content/cli/doctor.mdx
@@ -1,0 +1,95 @@
+# pilot doctor
+
+Run health checks on system dependencies, configuration, and features.
+
+```bash
+pilot doctor [flags]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-v`, `--verbose` | Show detailed output with fix suggestions |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All checks passed (warnings are non-fatal) |
+| `1` | One or more error-level checks failed |
+
+## Checks
+
+`pilot doctor` runs three categories of checks:
+
+### System Dependencies
+
+Verifies that required tools are installed and reachable in `PATH`:
+
+- **git** — required for all task execution
+- **gh** — GitHub CLI, needed for PR creation
+- **claude / qwen / opencode** — the active execution backend
+- **sleep** (macOS) — warns if system sleep is enabled, which may pause Pilot
+
+### Configuration
+
+Validates `~/.pilot/config.yaml`:
+
+- Config file exists
+- Telegram bot token present (if adapter enabled)
+- Slack bot token present (if adapter enabled)
+- At least one issue-source adapter is configured when projects are defined
+- GitHub token / `gh auth` reachable (if adapter enabled)
+- Daily brief has a cron schedule (if enabled)
+- Project paths resolve on disk
+
+#### Agent doc size
+
+`pilot doctor` also walks `.agent/**/*.md` in the current working directory and
+checks that documentation files have not grown unbounded.
+
+| Threshold | Behaviour |
+|-----------|-----------|
+| > 500 lines | Warning — `pilot doctor` exits `0` but prints `○` for the file |
+| > 1000 lines | Error — `pilot doctor` exits `1` |
+
+**Example output (verbose):**
+
+```
+○ .agent/DEVELOPMENT-README.md  641 lines (warn at: 500)
+  → Consider archiving sections of .agent/DEVELOPMENT-README.md
+```
+
+**Why it matters:** Navigator sessions append release notes and changelogs to
+`.agent/DEVELOPMENT-README.md` by default, causing unbounded growth that slows
+context loading and degrades plan quality.
+
+**Fix:** Archive older sections to `.agent/archive/` or split the file into
+focused topic documents. Keep the active index under 500 lines.
+
+### Features
+
+Checks optional feature availability based on config:
+
+- **Task Execution** — requires active backend + git
+- **Telegram** — requires bot token
+- **Images** — multimodal support (always available when backend is present)
+- **Voice** — requires `OPENAI_API_KEY` for Whisper transcription
+- **Briefs** — requires `orchestrator.daily_brief` config block
+- **Alerts** — requires `alerts.enabled: true`
+- **Memory** — requires `memory.cross_project: true`
+- **PRs** — requires `gh` CLI
+
+## Examples
+
+```bash
+# Quick check
+pilot doctor
+
+# Show fix suggestions
+pilot doctor --verbose
+
+# Use in CI (exits 1 on errors)
+pilot doctor || exit 1
+```

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -8,6 +8,7 @@ package health
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -63,6 +64,59 @@ type HealthReport struct {
 	HasWarnings  bool
 }
 
+// agentDocWarnLines is the line count at which a .agent/*.md file triggers a warning.
+const agentDocWarnLines = 500
+
+// agentDocFailLines is the line count at which a .agent/*.md file triggers an error.
+const agentDocFailLines = 1000
+
+// checkAgentDocSize walks agentDir for .md files and returns ConfigChecks for
+// files that exceed the warn or fail thresholds.
+func checkAgentDocSize(agentDir string) []ConfigCheck {
+	var checks []ConfigCheck
+
+	_ = filepath.WalkDir(agentDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Ext(path) != ".md" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		lineCount := strings.Count(string(data), "\n")
+		if len(data) > 0 && data[len(data)-1] != '\n' {
+			lineCount++
+		}
+		if lineCount <= agentDocWarnLines {
+			return nil
+		}
+
+		rel, _ := filepath.Rel(filepath.Dir(agentDir), path)
+		if rel == "" {
+			rel = path
+		}
+
+		if lineCount > agentDocFailLines {
+			checks = append(checks, ConfigCheck{
+				Name:    rel,
+				Status:  StatusError,
+				Message: fmt.Sprintf("%d lines (limit: %d)", lineCount, agentDocFailLines),
+				Fix:     fmt.Sprintf("Archive or trim %s to under %d lines", rel, agentDocFailLines),
+			})
+		} else {
+			checks = append(checks, ConfigCheck{
+				Name:    rel,
+				Status:  StatusWarning,
+				Message: fmt.Sprintf("%d lines (warn at: %d)", lineCount, agentDocWarnLines),
+				Fix:     fmt.Sprintf("Consider archiving sections of %s", rel),
+			})
+		}
+		return nil
+	})
+
+	return checks
+}
+
 // RunChecks performs all health checks based on config
 func RunChecks(cfg *config.Config) *HealthReport {
 	// Determine active backend type from config
@@ -71,9 +125,14 @@ func RunChecks(cfg *config.Config) *HealthReport {
 		backendType = cfg.Executor.Type
 	}
 
+	configChecks := checkConfig(cfg)
+	if cwd, err := os.Getwd(); err == nil {
+		configChecks = append(configChecks, checkAgentDocSize(filepath.Join(cwd, ".agent"))...)
+	}
+
 	report := &HealthReport{
 		Dependencies: checkDependenciesWithBackend(backendType),
-		Config:       checkConfig(cfg),
+		Config:       configChecks,
 		Features:     checkFeatures(cfg),
 		Projects:     len(cfg.Projects),
 	}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -865,3 +865,97 @@ func findFeature(features []FeatureStatus, name string) *FeatureStatus {
 	}
 	return nil
 }
+
+// ---------------------------------------------------------------------------
+// checkAgentDocSize
+// ---------------------------------------------------------------------------
+
+// makeLines builds a string with n newline-terminated lines of "x".
+func makeLines(n int) string {
+	return strings.Repeat("x\n", n)
+}
+
+func TestCheckAgentDocSize_CleanDir(t *testing.T) {
+	tmp := t.TempDir()
+	agentDir := filepath.Join(tmp, ".agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write a small file that should not trigger any check.
+	if err := os.WriteFile(filepath.Join(agentDir, "small.md"), []byte(makeLines(100)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	checks := checkAgentDocSize(agentDir)
+	if len(checks) != 0 {
+		t.Errorf("expected 0 checks for clean dir, got %d: %+v", len(checks), checks)
+	}
+}
+
+func TestCheckAgentDocSize_WarnFile(t *testing.T) {
+	tmp := t.TempDir()
+	agentDir := filepath.Join(tmp, ".agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// 600 lines — above warn threshold (500) but below fail threshold (1000).
+	if err := os.WriteFile(filepath.Join(agentDir, "big.md"), []byte(makeLines(600)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	checks := checkAgentDocSize(agentDir)
+	if len(checks) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(checks))
+	}
+	if checks[0].Status != StatusWarning {
+		t.Errorf("expected StatusWarning, got %v", checks[0].Status)
+	}
+}
+
+func TestCheckAgentDocSize_FailFile(t *testing.T) {
+	tmp := t.TempDir()
+	agentDir := filepath.Join(tmp, ".agent")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// 1100 lines — above fail threshold (1000).
+	if err := os.WriteFile(filepath.Join(agentDir, "bloated.md"), []byte(makeLines(1100)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	checks := checkAgentDocSize(agentDir)
+	if len(checks) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(checks))
+	}
+	if checks[0].Status != StatusError {
+		t.Errorf("expected StatusError, got %v", checks[0].Status)
+	}
+}
+
+func TestCheckAgentDocSize_MissingDir(t *testing.T) {
+	checks := checkAgentDocSize("/nonexistent/path/.agent")
+	if len(checks) != 0 {
+		t.Errorf("expected 0 checks for missing dir, got %d", len(checks))
+	}
+}
+
+func TestCheckAgentDocSize_SubdirFile(t *testing.T) {
+	tmp := t.TempDir()
+	agentDir := filepath.Join(tmp, ".agent")
+	subDir := filepath.Join(agentDir, "sops")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// 1100-line file in a subdirectory.
+	if err := os.WriteFile(filepath.Join(subDir, "deep.md"), []byte(makeLines(1100)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	checks := checkAgentDocSize(agentDir)
+	if len(checks) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(checks))
+	}
+	if checks[0].Status != StatusError {
+		t.Errorf("expected StatusError, got %v", checks[0].Status)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2462.

Closes #2462

## Changes

GitHub Issue #2462: feat(doctor): warn on bloated .agent docs

## Problem
There is no early-warning signal when `.agent/*.md` files grow unbounded. Pilot's own `.agent/DEVELOPMENT-README.md` reached 941 lines before drift was caught manually.

## Fix
Add a `checkAgentDocSize()` check to `pilot doctor`. Walks `.agent/**/*.md`, warns at >500 lines per file, exits non-zero at >1000 lines.

## Acceptance criteria
- [ ] New check `checkAgentDocSize()` in the existing `internal/doctor/` package, registered alongside other checks.
- [ ] Threshold: warn at 500 lines, fail at 1000 lines per file.
- [ ] Tests: clean dir passes, 600-line file warns (exit 0), 1100-line file fails (exit non-zero).
- [ ] Docs page in Nextra describing the check.
- [ ] `go test ./internal/doctor/...` passes.

## Files
- `internal/doctor/<checks file>` (locate existing check pattern)
- `internal/doctor/<checks test>`
- `docs/` (Nextra `pilot doctor` reference page)

## Out of scope
- Auto-archival logic (deferred — see future tracking issue).
- Trim of Pilot's existing `.agent/DEVELOPMENT-README.md` (depends on this issue + the doc-maintenance-rule issue both merging first).