### PR TITLE
fix(executor): resolve lint errors from openai-api backend PR

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -292,6 +292,7 @@
 | Health checks | ✅ | health | `pilot doctor` | - | System validation, 32 unit tests |
 | Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |
+| OpenAI-compatible direct backend | ✅ | executor | `type: openai-api` | `executor.openai` | Direct /v1/chat/completions for OpenAI, OpenRouter, Groq, Synthetic, vLLM, Ollama (v2.105.0, GH-2382) |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |
 | JSON structured logging | ✅ | - | - | `logging.format` | Optional JSON log output mode (v0.38.0) |

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -141,7 +141,7 @@ orchestrator:
 
 # Executor settings
 executor:
-  type: "claude-code"          # "claude-code" or "opencode"
+  type: "claude-code"          # "claude-code", "opencode", "anthropic-api", or "openai-api"
   auto_create_pr: true         # Create PR by default after task completion
                                # Use --no-pr flag to disable for individual tasks
   # direct_commit: false       # DANGER: Enable direct commit to main (requires --direct-commit flag)
@@ -155,6 +155,39 @@ executor:
   # api_base_url: "https://api.z.ai/api/anthropic"   # e.g. Z.AI GLM, OpenRouter Anthropic-compat
   # api_auth_token: "${ZAI_API_KEY}"                  # ${ENV_VAR} is expanded on load
   # default_model: "glm-4.6"                          # model name for the configured provider
+
+  # OpenAI-compatible direct HTTP backend (GH-2382)
+  # Use type: "openai-api" to drive Pilot with any OpenAI /v1/chat/completions provider
+  # without a CLI wrapper. Supports OpenAI, Synthetic, OpenRouter, Groq, Together,
+  # vLLM, Ollama, and any other OpenAI-compatible endpoint.
+  #
+  # Example: OpenAI
+  # type: "openai-api"
+  # openai:
+  #   api_key: "${OPENAI_API_KEY}"          # ${ENV_VAR} is expanded on load
+  #   base_url: "https://api.openai.com/v1" # default
+  #   model: "gpt-4o"                       # default
+  #
+  # Example: Synthetic (hf:moonshotai/Kimi-K2-Instruct)
+  # type: "openai-api"
+  # openai:
+  #   api_key: "${SYNTHETIC_API_KEY}"
+  #   base_url: "https://api.synthetic.new/v1"
+  #   model: "hf:moonshotai/Kimi-K2-Instruct"
+  #
+  # Example: OpenRouter
+  # type: "openai-api"
+  # openai:
+  #   api_key: "${OPENROUTER_API_KEY}"
+  #   base_url: "https://openrouter.ai/api/v1"
+  #   model: "anthropic/claude-sonnet-4"
+  #
+  # Example: local vLLM / Ollama (no auth needed)
+  # type: "openai-api"
+  # openai:
+  #   api_key: "no-key"
+  #   base_url: "http://localhost:11434/v1"
+  #   model: "llama3"
 
   # Worktree isolation - execute tasks in temporary git worktree
   # use_worktree: false        # When true, creates isolated worktree per task

--- a/docs/content/guides/custom-providers.mdx
+++ b/docs/content/guides/custom-providers.mdx
@@ -183,6 +183,106 @@ executor:
     enabled: false
 ```
 
+## OpenAI-Compatible Direct Backend
+
+Use `type: "openai-api"` to drive Pilot with any provider that exposes an OpenAI-compatible `/v1/chat/completions` endpoint — **without a CLI wrapper**.
+
+<Callout type="info">
+  Shipped in v2.105.0 ([GH-2382](https://github.com/qf-studio/pilot/issues/2382)). Use this backend when you want direct HTTP control (no `claude`/`qwen` CLI installed) or when your provider speaks OpenAI wire format but not Anthropic format.
+</Callout>
+
+### When to use `openai-api` vs `claude-code` with `api_base_url`
+
+| Scenario | Recommended |
+|----------|-------------|
+| Provider speaks Anthropic format (Z.AI GLM, LiteLLM) | `claude-code` + `api_base_url` |
+| Provider speaks OpenAI format (OpenRouter, Groq, Together, Synthetic, vLLM, Ollama) | `openai-api` |
+| No CLI installed, pure API access | `openai-api` or `anthropic-api` |
+
+### Configuration Examples
+
+#### OpenAI
+
+```yaml
+executor:
+  type: "openai-api"
+  openai:
+    api_key: "${OPENAI_API_KEY}"
+    base_url: "https://api.openai.com/v1"  # default, can omit
+    model: "gpt-4o"                         # default, can omit
+```
+
+#### Synthetic (Kimi-K2)
+
+```yaml
+executor:
+  type: "openai-api"
+  openai:
+    api_key: "${SYNTHETIC_API_KEY}"
+    base_url: "https://api.synthetic.new/v1"
+    model: "hf:moonshotai/Kimi-K2-Instruct"
+```
+
+#### OpenRouter
+
+```yaml
+executor:
+  type: "openai-api"
+  openai:
+    api_key: "${OPENROUTER_API_KEY}"
+    base_url: "https://openrouter.ai/api/v1"
+    model: "anthropic/claude-sonnet-4"
+```
+
+#### Groq
+
+```yaml
+executor:
+  type: "openai-api"
+  openai:
+    api_key: "${GROQ_API_KEY}"
+    base_url: "https://api.groq.com/openai/v1"
+    model: "llama-3.1-70b-versatile"
+```
+
+#### Together AI
+
+```yaml
+executor:
+  type: "openai-api"
+  openai:
+    api_key: "${TOGETHER_API_KEY}"
+    base_url: "https://api.together.xyz/v1"
+    model: "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo"
+```
+
+#### Local vLLM or Ollama
+
+```yaml
+executor:
+  type: "openai-api"
+  openai:
+    api_key: "no-key"              # Ollama/vLLM typically ignore this
+    base_url: "http://localhost:11434/v1"
+    model: "llama3"
+```
+
+### Caveats
+
+- **No prompt caching** — OpenAI's API doesn't expose a compatible cache-pass-through interface. Cache token fields in the execution report are always 0.
+- **No thinking/reasoning budget** — The `thinking` field is Anthropic-specific and is not sent.
+- **Fixed tool set** — Only `bash`, `read_file`, `write_file`, and `edit_file` tools are available (same as the `anthropic-api` backend). MCP servers and Claude Code's extended toolbox are not loaded.
+- **Model names** — Use the provider's naming convention (e.g. `anthropic/claude-sonnet-4` on OpenRouter, not `claude-sonnet-4`).
+
+### Verification
+
+```bash
+export OPENAI_API_KEY=sk-...
+pilot task "Add a docstring to main.go" --verbose
+```
+
+Look for `OpenAI-compatible API backend initialized` in the log output and confirm the `Model:` line in the execution report shows your configured model.
+
 ## Related
 
 - [Execution Backends](/concepts/execution-backends) — backend selection (Claude Code, Qwen, OpenCode)

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -322,61 +322,6 @@ func truncateString(s string, maxLen int) string {
 	return s[:maxLen-3] + "..."
 }
 
-// stageIcon returns an ASCII indicator for the PR stage.
-func (p *AutopilotPanel) stageIcon(stage autopilot.PRStage) string {
-	switch stage {
-	case autopilot.StagePRCreated:
-		return "+"
-	case autopilot.StageWaitingCI:
-		return "~"
-	case autopilot.StageCIPassed:
-		return "*"
-	case autopilot.StageCIFailed:
-		return "x"
-	case autopilot.StageAwaitApproval:
-		return "?"
-	case autopilot.StageMerging:
-		return ">"
-	case autopilot.StageMerged:
-		return "*"
-	case autopilot.StagePostMergeCI:
-		return "~"
-	case autopilot.StageReleasing:
-		return "^"
-	case autopilot.StageFailed:
-		return "!"
-	default:
-		return "-"
-	}
-}
-
-// stageLabel returns a human-readable label for the PR stage.
-func (p *AutopilotPanel) stageLabel(stage autopilot.PRStage) string {
-	switch stage {
-	case autopilot.StagePRCreated:
-		return "PR Created"
-	case autopilot.StageWaitingCI:
-		return "Waiting CI"
-	case autopilot.StageCIPassed:
-		return "CI Passed"
-	case autopilot.StageCIFailed:
-		return "CI Failed"
-	case autopilot.StageAwaitApproval:
-		return "Awaiting Approval"
-	case autopilot.StageMerging:
-		return "Merging"
-	case autopilot.StageMerged:
-		return "Merged"
-	case autopilot.StagePostMergeCI:
-		return "Post-Merge CI"
-	case autopilot.StageReleasing:
-		return "Releasing"
-	case autopilot.StageFailed:
-		return "Failed"
-	default:
-		return string(stage)
-	}
-}
 
 // TaskDisplay represents a task for display
 type TaskDisplay struct {
@@ -1881,34 +1826,6 @@ func truncateVisual(s string, targetWidth int) string {
 	return result + "..."
 }
 
-// dotLeader creates a dot-leader line: "  Label .............. Value"
-// Uses lipgloss.Width() for accurate visual width calculation
-func dotLeader(label string, value string, totalWidth int) string {
-	prefix := "  " + label + " "
-	suffix := " " + value
-	prefixWidth := lipgloss.Width(prefix)
-	suffixWidth := lipgloss.Width(suffix)
-	dotsNeeded := totalWidth - prefixWidth - suffixWidth
-	if dotsNeeded < 3 {
-		dotsNeeded = 3
-	}
-	return prefix + strings.Repeat(".", dotsNeeded) + suffix
-}
-
-// dotLeaderStyled creates a dot-leader with styled value
-// Calculates width using raw value, then applies style
-func dotLeaderStyled(label string, value string, style lipgloss.Style, totalWidth int) string {
-	prefix := "  " + label + " "
-	suffix := " " + value
-	prefixWidth := lipgloss.Width(prefix)
-	suffixWidth := lipgloss.Width(suffix)
-	dotsNeeded := totalWidth - prefixWidth - suffixWidth
-	if dotsNeeded < 3 {
-		dotsNeeded = 3
-	}
-	// Apply style to value only (dots and spaces remain unstyled)
-	return prefix + strings.Repeat(".", dotsNeeded) + " " + style.Render(value)
-}
 
 // formatCompact formats a number in compact form: 0, 999, 1.0K, 57.3K, 1.2M.
 func formatCompact(n int) string {

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -245,6 +245,9 @@ type BackendConfig struct {
 	// QwenCode contains Qwen Code specific settings
 	QwenCode *QwenCodeConfig `yaml:"qwen_code,omitempty"`
 
+	// OpenAI contains OpenAI-compatible direct HTTP backend settings
+	OpenAI *OpenAIConfig `yaml:"openai,omitempty"`
+
 	// ModelRouting contains model selection based on task complexity
 	ModelRouting *ModelRoutingConfig `yaml:"model_routing,omitempty"`
 
@@ -803,6 +806,22 @@ func DefaultStagnationConfig() *StagnationConfig {
 		GracePeriod:              30 * time.Second,
 		CommitPartialWork:        true,
 	}
+}
+
+// OpenAIConfig contains configuration for the openai-api direct HTTP backend.
+// Supports any provider exposing an OpenAI-compatible /v1/chat/completions endpoint:
+// OpenAI, OpenRouter, Groq, Together, Synthetic, vLLM, Ollama, etc.
+type OpenAIConfig struct {
+	// APIKey is the Bearer token. Supports ${ENV_VAR} expansion.
+	// Falls back to OPENAI_API_KEY env var when empty.
+	APIKey string `yaml:"api_key,omitempty"`
+
+	// BaseURL is the provider base URL (default: https://api.openai.com/v1).
+	// Must expose /chat/completions under this prefix.
+	BaseURL string `yaml:"base_url,omitempty"`
+
+	// Model is the default model name (default: gpt-4o).
+	Model string `yaml:"model,omitempty"`
 }
 
 // BackendType constants for configuration.

--- a/internal/executor/backend_anthropic.go
+++ b/internal/executor/backend_anthropic.go
@@ -41,7 +41,6 @@ const (
 // over thinking budgets, tool dispatch, and retry logic.
 type AnthropicBackend struct {
 	apiKey string
-	model  string
 	apiURL string
 	config *BackendConfig
 }
@@ -359,7 +358,7 @@ func (b *AnthropicBackend) callAPI(ctx context.Context, req *apiRequest) (*apiRe
 
 		// Handle non-200 responses
 		if resp.StatusCode == 429 || resp.StatusCode == 529 || resp.StatusCode >= 500 {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			if attempt < apiMaxRetries {
 				wait := backoffs[min(attempt, len(backoffs)-1)]
 				slog.Warn("API error, retrying", slog.Int("status", resp.StatusCode), slog.Duration("wait", wait))
@@ -371,13 +370,13 @@ func (b *AnthropicBackend) callAPI(ctx context.Context, req *apiRequest) (*apiRe
 
 		if resp.StatusCode != 200 {
 			respBody, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil, fmt.Errorf("API returned %d: %s", resp.StatusCode, string(respBody[:min(len(respBody), 500)]))
 		}
 
 		// Parse SSE stream → accumulate into final response
 		result, err := b.parseSSEStream(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		if err != nil {
 			// Retry on overloaded errors in response body
@@ -403,8 +402,8 @@ func (b *AnthropicBackend) parseSSEStream(body io.Reader) (*apiResponse, error) 
 
 	var result apiResponse
 	var currentBlocks []apiContentBlock
-	var currentBlockTexts map[int]strings.Builder = make(map[int]strings.Builder)
-	var currentBlockInputs map[int]strings.Builder = make(map[int]strings.Builder)
+	currentBlockTexts := make(map[int]strings.Builder)
+	currentBlockInputs := make(map[int]strings.Builder)
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/internal/executor/backend_factory.go
+++ b/internal/executor/backend_factory.go
@@ -34,6 +34,9 @@ func NewBackend(config *BackendConfig) (Backend, error) {
 	case BackendTypeAnthropicAPI:
 		return NewAnthropicBackend(config), nil
 
+	case BackendTypeOpenAIAPI:
+		return NewOpenAIBackend(config), nil
+
 	default:
 		return nil, fmt.Errorf("unknown backend type: %s", config.Type)
 	}

--- a/internal/executor/backend_openai.go
+++ b/internal/executor/backend_openai.go
@@ -1,0 +1,605 @@
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	BackendTypeOpenAIAPI  = "openai-api"
+	openaiDefaultBaseURL  = "https://api.openai.com/v1"
+	openaiDefaultModel    = "gpt-4o"
+)
+
+// OpenAIBackend implements Backend using direct OpenAI-compatible /v1/chat/completions API.
+// Supports OpenAI, OpenRouter, Groq, Together, Synthetic, vLLM, Ollama, and any provider
+// exposing an OpenAI-compatible endpoint — without a CLI wrapper.
+type OpenAIBackend struct {
+	apiKey string
+	model  string
+	apiURL string // full endpoint URL
+	config *BackendConfig
+}
+
+// NewOpenAIBackend creates a new OpenAI-compatible direct HTTP backend.
+func NewOpenAIBackend(config *BackendConfig) *OpenAIBackend {
+	b := &OpenAIBackend{config: config}
+
+	// Resolve base URL
+	baseURL := openaiDefaultBaseURL
+	if config != nil && config.OpenAI != nil && config.OpenAI.BaseURL != "" {
+		baseURL = strings.TrimRight(config.OpenAI.BaseURL, "/")
+	}
+	b.apiURL = baseURL + "/chat/completions"
+
+	// Resolve model
+	b.model = openaiDefaultModel
+	if config != nil && config.OpenAI != nil && config.OpenAI.Model != "" {
+		b.model = config.OpenAI.Model
+	} else if config != nil && config.DefaultModel != "" {
+		b.model = config.DefaultModel
+	}
+
+	// Resolve API key: config takes priority over env vars
+	if config != nil && config.OpenAI != nil && config.OpenAI.APIKey != "" {
+		b.apiKey = config.OpenAI.APIKey
+	} else if config != nil && config.APIAuthToken != "" {
+		b.apiKey = config.APIAuthToken
+	} else {
+		for _, key := range []string{"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "PILOT_ENGINE_API_KEY"} {
+			if v := os.Getenv(key); v != "" {
+				b.apiKey = v
+				break
+			}
+		}
+	}
+
+	return b
+}
+
+func (b *OpenAIBackend) Name() string      { return BackendTypeOpenAIAPI }
+func (b *OpenAIBackend) IsAvailable() bool { return b.apiKey != "" }
+
+// --- OpenAI API Types ---
+
+// openaiMsg is the wire format for a single conversation turn.
+type openaiMsg struct {
+	Role       string           `json:"role"`
+	Content    *string          `json:"content"` // nil serialises as null (for tool-call-only turns)
+	ToolCalls  []openaiToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+}
+
+type openaiToolCall struct {
+	ID       string            `json:"id"`
+	Type     string            `json:"type"` // "function"
+	Function openaiCallFunc    `json:"function"`
+}
+
+// openaiCallFunc carries the resolved call (name + argument JSON string).
+type openaiCallFunc struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // complete JSON string
+}
+
+// openaiToolDef describes a tool in the request.
+type openaiToolDef struct {
+	Type     string         `json:"type"` // "function"
+	Function openaiFuncDef  `json:"function"`
+}
+
+type openaiFuncDef struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+type openaiRequest struct {
+	Model    string         `json:"model"`
+	Messages []openaiMsg    `json:"messages"`
+	Tools    []openaiToolDef `json:"tools,omitempty"`
+	Stream   bool           `json:"stream"`
+}
+
+// SSE streaming types
+
+type openaiChunk struct {
+	ID      string          `json:"id"`
+	Object  string          `json:"object"`
+	Model   string          `json:"model"`
+	Choices []openaiChoice  `json:"choices"`
+	Usage   *openaiUsage    `json:"usage,omitempty"`
+}
+
+type openaiChoice struct {
+	Index        int          `json:"index"`
+	Delta        openaiDelta  `json:"delta"`
+	FinishReason *string      `json:"finish_reason"` // pointer — null vs "stop"/"tool_calls"
+}
+
+type openaiDelta struct {
+	Role      string                `json:"role,omitempty"`
+	Content   string                `json:"content,omitempty"`
+	ToolCalls []openaiDeltaToolCall `json:"tool_calls,omitempty"`
+}
+
+type openaiDeltaToolCall struct {
+	Index    int                    `json:"index"`
+	ID       string                 `json:"id,omitempty"`
+	Type     string                 `json:"type,omitempty"`
+	Function openaiDeltaFunc        `json:"function"`
+}
+
+type openaiDeltaFunc struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"` // fragment
+}
+
+type openaiUsage struct {
+	PromptTokens     int64 `json:"prompt_tokens"`
+	CompletionTokens int64 `json:"completion_tokens"`
+	TotalTokens      int64 `json:"total_tokens"`
+}
+
+// openaiAccum collects the fully parsed result of one SSE stream.
+type openaiAccum struct {
+	Model        string
+	Content      string
+	ToolCalls    []openaiToolCall
+	FinishReason string
+	PromptTokens     int64
+	CompletionTokens int64
+}
+
+// pendingOAIToolCall accumulates fragmented streaming tool-call data.
+type pendingOAIToolCall struct {
+	id        string
+	name      string
+	arguments strings.Builder
+}
+
+// --- Tool Definitions (OpenAI function-call format) ---
+
+var openaiTools = []openaiToolDef{
+	{
+		Type: "function",
+		Function: openaiFuncDef{
+			Name:        "bash",
+			Description: "Execute a bash command. Returns stdout+stderr. Commands timeout after 120s.",
+			Parameters: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"command": {"type": "string", "description": "The bash command to execute"},
+					"timeout": {"type": "integer", "description": "Timeout in seconds (default 120, max 600)"}
+				},
+				"required": ["command"]
+			}`),
+		},
+	},
+	{
+		Type: "function",
+		Function: openaiFuncDef{
+			Name:        "read_file",
+			Description: "Read a file's contents with line numbers.",
+			Parameters: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"path": {"type": "string", "description": "Absolute path to the file"},
+					"offset": {"type": "integer", "description": "Line number to start from (1-indexed)"},
+					"limit": {"type": "integer", "description": "Max lines to read"}
+				},
+				"required": ["path"]
+			}`),
+		},
+	},
+	{
+		Type: "function",
+		Function: openaiFuncDef{
+			Name:        "write_file",
+			Description: "Write content to a file. Creates parent directories. Overwrites existing.",
+			Parameters: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"path": {"type": "string", "description": "Absolute path to write to"},
+					"content": {"type": "string", "description": "File content"}
+				},
+				"required": ["path", "content"]
+			}`),
+		},
+	},
+	{
+		Type: "function",
+		Function: openaiFuncDef{
+			Name:        "edit_file",
+			Description: "Replace a specific string in a file. old_string must appear exactly once.",
+			Parameters: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"path": {"type": "string", "description": "Absolute path"},
+					"old_string": {"type": "string", "description": "Exact text to find"},
+					"new_string": {"type": "string", "description": "Replacement text"}
+				},
+				"required": ["path", "old_string", "new_string"]
+			}`),
+		},
+	},
+}
+
+// --- API Call with Streaming ---
+
+func (b *OpenAIBackend) callAPI(ctx context.Context, req *openaiRequest) (*openaiAccum, error) {
+	req.Stream = true
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	backoffs := []time.Duration{30 * time.Second, 60 * time.Second, 90 * time.Second, 120 * time.Second, 180 * time.Second}
+
+	for attempt := 0; attempt <= apiMaxRetries; attempt++ {
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", b.apiURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
+		}
+
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Accept", "text/event-stream")
+		httpReq.Header.Set("Authorization", "Bearer "+b.apiKey)
+
+		resp, err := http.DefaultClient.Do(httpReq)
+		if err != nil {
+			if attempt < apiMaxRetries {
+				slog.Warn("HTTP error, retrying", slog.Int("attempt", attempt+1), slog.Any("error", err))
+				time.Sleep(backoffs[min(attempt, len(backoffs)-1)])
+				continue
+			}
+			return nil, fmt.Errorf("HTTP request failed: %w", err)
+		}
+
+		if resp.StatusCode == 429 || resp.StatusCode >= 500 {
+			resp.Body.Close()
+			if attempt < apiMaxRetries {
+				wait := backoffs[min(attempt, len(backoffs)-1)]
+				slog.Warn("API error, retrying", slog.Int("status", resp.StatusCode), slog.Duration("wait", wait))
+				time.Sleep(wait)
+				continue
+			}
+			return nil, fmt.Errorf("API returned %d after %d retries", resp.StatusCode, apiMaxRetries)
+		}
+
+		if resp.StatusCode != 200 {
+			respBody, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("API returned %d: %s", resp.StatusCode, string(respBody[:min(len(respBody), 500)]))
+		}
+
+		result, err := b.parseSSEStream(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("exhausted %d retries", apiMaxRetries)
+}
+
+// parseSSEStream reads an OpenAI SSE stream and accumulates the full response.
+// Tool call argument fragments are joined by index before JSON-parsing.
+func (b *OpenAIBackend) parseSSEStream(body io.Reader) (*openaiAccum, error) {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	var result openaiAccum
+	var contentBuf strings.Builder
+	pending := make(map[int]*pendingOAIToolCall)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+
+		var chunk openaiChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+
+		if result.Model == "" && chunk.Model != "" {
+			result.Model = chunk.Model
+		}
+
+		if chunk.Usage != nil {
+			result.PromptTokens = chunk.Usage.PromptTokens
+			result.CompletionTokens = chunk.Usage.CompletionTokens
+		}
+
+		for _, choice := range chunk.Choices {
+			// Accumulate text
+			if choice.Delta.Content != "" {
+				contentBuf.WriteString(choice.Delta.Content)
+			}
+
+			// Accumulate tool call fragments by index
+			for _, dtc := range choice.Delta.ToolCalls {
+				p, ok := pending[dtc.Index]
+				if !ok {
+					p = &pendingOAIToolCall{}
+					pending[dtc.Index] = p
+				}
+				if dtc.ID != "" {
+					p.id = dtc.ID
+				}
+				if dtc.Function.Name != "" {
+					p.name = dtc.Function.Name
+				}
+				p.arguments.WriteString(dtc.Function.Arguments)
+			}
+
+			if choice.FinishReason != nil && *choice.FinishReason != "" {
+				result.FinishReason = *choice.FinishReason
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("stream read error: %w", err)
+	}
+
+	result.Content = contentBuf.String()
+
+	// Finalize tool calls in index order
+	for i := 0; i < len(pending); i++ {
+		p, ok := pending[i]
+		if !ok {
+			break
+		}
+		result.ToolCalls = append(result.ToolCalls, openaiToolCall{
+			ID:   p.id,
+			Type: "function",
+			Function: openaiCallFunc{
+				Name:      p.name,
+				Arguments: p.arguments.String(),
+			},
+		})
+	}
+
+	return &result, nil
+}
+
+// --- Main Execute Loop ---
+
+func (b *OpenAIBackend) Execute(ctx context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	if b.apiKey == "" {
+		return nil, fmt.Errorf("no API key configured for openai-api backend (set OPENAI_API_KEY or executor.openai.api_key)")
+	}
+
+	model := opts.Model
+	if model == "" {
+		model = b.model
+	}
+
+	cwd := opts.ProjectPath
+	if cwd == "" {
+		cwd = "/app"
+	}
+
+	if opts.EventHandler != nil {
+		opts.EventHandler(BackendEvent{
+			Type:    EventTypeInit,
+			Message: "OpenAI-compatible API backend initialized",
+			Model:   model,
+		})
+	}
+
+	// Build conversation: system prompt + initial user kickoff
+	content := opts.Prompt
+	beginContent := "Begin. Follow the mandatory workflow."
+	messages := []openaiMsg{
+		{Role: "system", Content: &content},
+		{Role: "user", Content: &beginContent},
+	}
+
+	var totalPromptTokens, totalCompletionTokens int64
+	var lastOutput string
+	var sawSuccess bool
+
+	for turn := 0; turn < apiMaxTurns; turn++ {
+		if ctx.Err() != nil {
+			return &BackendResult{
+				Success:      sawSuccess,
+				Output:       lastOutput,
+				Error:        "context cancelled",
+				TokensInput:  totalPromptTokens,
+				TokensOutput: totalCompletionTokens,
+				Model:        model,
+				SawSuccessResult: sawSuccess,
+			}, nil
+		}
+
+		req := &openaiRequest{
+			Model:    model,
+			Messages: messages,
+			Tools:    openaiTools,
+		}
+
+		slog.Info("OpenAI API call", slog.Int("turn", turn), slog.String("model", model),
+			slog.Int("messages", len(messages)))
+
+		accum, err := b.callAPI(ctx, req)
+		if err != nil {
+			slog.Error("OpenAI API call failed", slog.Int("turn", turn), slog.Any("error", err))
+
+			if opts.EventHandler != nil {
+				opts.EventHandler(BackendEvent{
+					Type:    EventTypeError,
+					Message: err.Error(),
+					IsError: true,
+				})
+			}
+
+			return &BackendResult{
+				Success:      sawSuccess,
+				Output:       lastOutput,
+				Error:        err.Error(),
+				TokensInput:  totalPromptTokens,
+				TokensOutput: totalCompletionTokens,
+				Model:        model,
+				SawSuccessResult: sawSuccess,
+			}, nil
+		}
+
+		totalPromptTokens += accum.PromptTokens
+		totalCompletionTokens += accum.CompletionTokens
+
+		// Emit text event
+		if accum.Content != "" {
+			lastOutput = accum.Content
+			if opts.EventHandler != nil {
+				opts.EventHandler(BackendEvent{
+					Type:         EventTypeText,
+					Message:      accum.Content,
+					TokensInput:  accum.PromptTokens,
+					TokensOutput: accum.CompletionTokens,
+					Model:        model,
+				})
+			}
+		}
+
+		// Build assistant message for conversation history
+		assistantMsg := openaiMsg{Role: "assistant"}
+		if accum.Content != "" {
+			c := accum.Content
+			assistantMsg.Content = &c
+		}
+		// nil Content serialises as null — required for tool-call-only turns
+		if len(accum.ToolCalls) > 0 {
+			assistantMsg.ToolCalls = accum.ToolCalls
+		}
+		messages = append(messages, assistantMsg)
+
+		// Process tool calls
+		if accum.FinishReason == "tool_calls" && len(accum.ToolCalls) > 0 {
+			for _, tc := range accum.ToolCalls {
+				var toolInput map[string]interface{}
+				if err := json.Unmarshal([]byte(tc.Function.Arguments), &toolInput); err != nil {
+					toolInput = map[string]interface{}{"error": "failed to parse arguments: " + err.Error()}
+				}
+
+				if opts.EventHandler != nil {
+					opts.EventHandler(BackendEvent{
+						Type:      EventTypeToolUse,
+						ToolName:  tc.Function.Name,
+						ToolInput: toolInput,
+						Model:     model,
+					})
+				}
+
+				slog.Info("OpenAI tool exec", slog.Int("turn", turn), slog.String("tool", tc.Function.Name))
+				toolResult := executeTool(tc.Function.Name, toolInput, cwd)
+
+				if opts.EventHandler != nil {
+					opts.EventHandler(BackendEvent{
+						Type:       EventTypeToolResult,
+						ToolName:   tc.Function.Name,
+						ToolResult: toolResult,
+					})
+				}
+
+				// OpenAI tool result message format
+				toolResultContent := toolResult
+				messages = append(messages, openaiMsg{
+					Role:       "tool",
+					Content:    &toolResultContent,
+					ToolCallID: tc.ID,
+				})
+			}
+
+		} else if accum.FinishReason == "stop" || accum.FinishReason == "" {
+			// "stop" = normal completion; empty = some providers omit it
+			sawSuccess = true
+			if opts.EventHandler != nil {
+				opts.EventHandler(BackendEvent{
+					Type:    EventTypeResult,
+					Message: lastOutput,
+				})
+			}
+			break
+		}
+
+		// Context pruning: rough estimate 4 chars = 1 token
+		if estimateOpenAIContextTokens(messages) > apiContextPruneAt {
+			messages = pruneOpenAIMessages(messages)
+			slog.Info("OpenAI context pruned", slog.Int("turn", turn))
+		}
+	}
+
+	return &BackendResult{
+		Success:          sawSuccess,
+		Output:           lastOutput,
+		TokensInput:      totalPromptTokens,
+		TokensOutput:     totalCompletionTokens,
+		Model:            model,
+		SawSuccessResult: sawSuccess,
+	}, nil
+}
+
+// --- Context Management ---
+
+func estimateOpenAIContextTokens(messages []openaiMsg) int {
+	total := 0
+	for _, msg := range messages {
+		if msg.Content != nil {
+			total += len(*msg.Content) / 4
+		}
+		for _, tc := range msg.ToolCalls {
+			total += len(tc.Function.Arguments) / 4
+		}
+	}
+	return total
+}
+
+func pruneOpenAIMessages(messages []openaiMsg) []openaiMsg {
+	keepTurns := 12
+	// messages[0] is always the system prompt; +1 accounts for it
+	if len(messages) <= keepTurns*2+1 {
+		return messages
+	}
+	system := messages[0]
+	keep := messages[len(messages)-keepTurns*2:]
+	notice := "[Earlier messages pruned to save context. Continue working on the task.]"
+	pruned := []openaiMsg{
+		system,
+		{Role: "user", Content: &notice},
+	}
+	return append(pruned, keep...)
+}
+
+// --- Error Type ---
+
+// OpenAIAPIError implements BackendError for OpenAI-compatible API errors.
+type OpenAIAPIError struct {
+	ErrType string
+	Msg     string
+}
+
+func (e *OpenAIAPIError) Error() string       { return e.Msg }
+func (e *OpenAIAPIError) ErrorType() string   { return e.ErrType }
+func (e *OpenAIAPIError) ErrorMessage() string { return e.Msg }
+func (e *OpenAIAPIError) ErrorStderr() string  { return "" }

--- a/internal/executor/backend_openai.go
+++ b/internal/executor/backend_openai.go
@@ -267,7 +267,7 @@ func (b *OpenAIBackend) callAPI(ctx context.Context, req *openaiRequest) (*opena
 		}
 
 		if resp.StatusCode == 429 || resp.StatusCode >= 500 {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			if attempt < apiMaxRetries {
 				wait := backoffs[min(attempt, len(backoffs)-1)]
 				slog.Warn("API error, retrying", slog.Int("status", resp.StatusCode), slog.Duration("wait", wait))
@@ -279,12 +279,12 @@ func (b *OpenAIBackend) callAPI(ctx context.Context, req *openaiRequest) (*opena
 
 		if resp.StatusCode != 200 {
 			respBody, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil, fmt.Errorf("API returned %d: %s", resp.StatusCode, string(respBody[:min(len(respBody), 500)]))
 		}
 
 		result, err := b.parseSSEStream(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/executor/backend_openai_test.go
+++ b/internal/executor/backend_openai_test.go
@@ -1,0 +1,811 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// sseChunk formats a single SSE data line.
+func sseChunk(v interface{}) string {
+	b, _ := json.Marshal(v)
+	return "data: " + string(b) + "\n\n"
+}
+
+func sseDone() string { return "data: [DONE]\n\n" }
+
+// --- Constructor Tests ---
+
+func TestNewOpenAIBackend_Defaults(t *testing.T) {
+	b := NewOpenAIBackend(nil)
+	if b == nil {
+		t.Fatal("NewOpenAIBackend(nil) returned nil")
+	}
+	if b.apiURL != openaiDefaultBaseURL+"/chat/completions" {
+		t.Errorf("apiURL = %q, want default", b.apiURL)
+	}
+	if b.model != openaiDefaultModel {
+		t.Errorf("model = %q, want %q", b.model, openaiDefaultModel)
+	}
+}
+
+func TestNewOpenAIBackend_CustomConfig(t *testing.T) {
+	cfg := &BackendConfig{
+		OpenAI: &OpenAIConfig{
+			APIKey:  "test-openai-key",
+			BaseURL: "https://openrouter.ai/api/v1",
+			Model:   "anthropic/claude-sonnet-4",
+		},
+	}
+	b := NewOpenAIBackend(cfg)
+	if b.apiKey != "test-openai-key" {
+		t.Errorf("apiKey = %q, want test-openai-key", b.apiKey)
+	}
+	if b.apiURL != "https://openrouter.ai/api/v1/chat/completions" {
+		t.Errorf("apiURL = %q, want openrouter endpoint", b.apiURL)
+	}
+	if b.model != "anthropic/claude-sonnet-4" {
+		t.Errorf("model = %q", b.model)
+	}
+}
+
+func TestNewOpenAIBackend_DefaultModelFallback(t *testing.T) {
+	cfg := &BackendConfig{
+		DefaultModel: "gpt-4o-mini",
+		OpenAI:       &OpenAIConfig{APIKey: "k"},
+	}
+	b := NewOpenAIBackend(cfg)
+	if b.model != "gpt-4o-mini" {
+		t.Errorf("model = %q, want gpt-4o-mini from DefaultModel fallback", b.model)
+	}
+}
+
+func TestOpenAIBackend_Name(t *testing.T) {
+	b := NewOpenAIBackend(nil)
+	if b.Name() != BackendTypeOpenAIAPI {
+		t.Errorf("Name() = %q, want %q", b.Name(), BackendTypeOpenAIAPI)
+	}
+}
+
+func TestOpenAIBackend_IsAvailable(t *testing.T) {
+	noKey := NewOpenAIBackend(nil)
+	if noKey.IsAvailable() {
+		t.Error("IsAvailable() should be false without a key")
+	}
+
+	withKey := NewOpenAIBackend(&BackendConfig{OpenAI: &OpenAIConfig{APIKey: "test-key"}})
+	if !withKey.IsAvailable() {
+		t.Error("IsAvailable() should be true with a key set")
+	}
+}
+
+// --- Helper: make a backend pointing at a test server ---
+
+func newTestOpenAIBackend(t *testing.T, serverURL string) *OpenAIBackend {
+	t.Helper()
+	cfg := &BackendConfig{
+		OpenAI: &OpenAIConfig{
+			APIKey:  "test-api-key",
+			BaseURL: serverURL,
+			Model:   "test-model",
+		},
+	}
+	return NewOpenAIBackend(cfg)
+}
+
+// --- Text-Only Streaming ---
+
+func TestOpenAIBackend_TextOnly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify auth header
+		if r.Header.Get("Authorization") != "Bearer test-api-key" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		chunks := []map[string]interface{}{
+			{"id": "c1", "model": "test-model", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{"role": "assistant", "content": "Hello"}, "finish_reason": nil},
+			}},
+			{"id": "c1", "model": "test-model", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{"content": " world"}, "finish_reason": nil},
+			}},
+			{"id": "c1", "model": "test-model", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{}, "finish_reason": "stop"},
+			}, "usage": map[string]interface{}{"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}},
+		}
+		for _, c := range chunks {
+			_, _ = io.WriteString(w, sseChunk(c))
+		}
+		_, _ = io.WriteString(w, sseDone())
+	}))
+	defer srv.Close()
+
+	b := newTestOpenAIBackend(t, srv.URL)
+
+	var events []BackendEvent
+	result, err := b.Execute(context.Background(), ExecuteOptions{
+		Prompt:      "test prompt",
+		ProjectPath: t.TempDir(),
+		EventHandler: func(e BackendEvent) {
+			events = append(events, e)
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected Success=true")
+	}
+	if result.Output != "Hello world" {
+		t.Errorf("Output = %q, want 'Hello world'", result.Output)
+	}
+	if result.TokensInput != 10 {
+		t.Errorf("TokensInput = %d, want 10", result.TokensInput)
+	}
+	if result.TokensOutput != 5 {
+		t.Errorf("TokensOutput = %d, want 5", result.TokensOutput)
+	}
+
+	// Check event sequence: init → text → result
+	types := make([]BackendEventType, 0, len(events))
+	for _, e := range events {
+		types = append(types, e.Type)
+	}
+	if len(types) < 3 {
+		t.Fatalf("expected at least 3 events, got %d: %v", len(types), types)
+	}
+	if types[0] != EventTypeInit {
+		t.Errorf("events[0] = %q, want init", types[0])
+	}
+	if types[1] != EventTypeText {
+		t.Errorf("events[1] = %q, want text", types[1])
+	}
+	if types[len(types)-1] != EventTypeResult {
+		t.Errorf("last event = %q, want result", types[len(types)-1])
+	}
+}
+
+// --- Tool Call with Argument Fragmentation ---
+
+func TestOpenAIBackend_ToolCallFragmentation(t *testing.T) {
+	// Arguments for bash split across three delta chunks
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		chunks := []map[string]interface{}{
+			// First chunk: tool call starts with id and name, empty arguments
+			{"id": "c1", "model": "test-model", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{
+					"role": "assistant",
+					"tool_calls": []map[string]interface{}{
+						{"index": 0, "id": "call_abc", "type": "function", "function": map[string]interface{}{"name": "bash", "arguments": ""}},
+					},
+				}, "finish_reason": nil},
+			}},
+			// Second chunk: argument fragment 1
+			{"id": "c1", "model": "test-model", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{
+					"tool_calls": []map[string]interface{}{
+						{"index": 0, "function": map[string]interface{}{"arguments": `{"com`}},
+					},
+				}, "finish_reason": nil},
+			}},
+			// Third chunk: argument fragment 2
+			{"id": "c1", "model": "test-model", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{
+					"tool_calls": []map[string]interface{}{
+						{"index": 0, "function": map[string]interface{}{"arguments": `mand":"ls"}`}},
+					},
+				}, "finish_reason": nil},
+			}},
+			// Final chunk: finish_reason = tool_calls
+			{"id": "c1", "model": "test-model", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{}, "finish_reason": "tool_calls"},
+			}, "usage": map[string]interface{}{"prompt_tokens": 20, "completion_tokens": 10}},
+		}
+		for _, c := range chunks {
+			_, _ = io.WriteString(w, sseChunk(c))
+		}
+		_, _ = io.WriteString(w, sseDone())
+	}))
+	defer srv.Close()
+
+	b := newTestOpenAIBackend(t, srv.URL)
+
+	var toolUseEvents []BackendEvent
+	var toolResultEvents []BackendEvent
+
+	result, err := b.Execute(context.Background(), ExecuteOptions{
+		Prompt:      "test prompt",
+		ProjectPath: t.TempDir(),
+		EventHandler: func(e BackendEvent) {
+			if e.Type == EventTypeToolUse {
+				toolUseEvents = append(toolUseEvents, e)
+			}
+			if e.Type == EventTypeToolResult {
+				toolResultEvents = append(toolResultEvents, e)
+			}
+		},
+	})
+
+	// The backend will execute bash "ls" — the tool runs but we just check that
+	// arguments were parsed correctly from the fragments.
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	if len(toolUseEvents) == 0 {
+		t.Fatal("expected at least one tool_use event")
+	}
+	if toolUseEvents[0].ToolName != "bash" {
+		t.Errorf("ToolName = %q, want bash", toolUseEvents[0].ToolName)
+	}
+	cmd, ok := toolUseEvents[0].ToolInput["command"].(string)
+	if !ok || cmd != "ls" {
+		t.Errorf("tool input command = %q, want ls", cmd)
+	}
+	if len(toolResultEvents) == 0 {
+		t.Error("expected at least one tool_result event")
+	}
+
+	// After one tool call with no follow-up, success depends on whether second
+	// call (with tool result) returns stop. result.Success may be false here
+	// because the server returned no second turn. That's OK — we're testing
+	// fragment accumulation, not end-to-end success.
+	_ = result
+}
+
+// --- Multi-Turn: tool call → result → final text ---
+
+func TestOpenAIBackend_MultiTurn(t *testing.T) {
+	callCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		callCount++
+
+		if callCount == 1 {
+			// First turn: tool call
+			chunks := []map[string]interface{}{
+				{"id": "c1", "model": "test-model", "choices": []map[string]interface{}{
+					{"index": 0, "delta": map[string]interface{}{
+						"role": "assistant",
+						"tool_calls": []map[string]interface{}{
+							{"index": 0, "id": "call_001", "type": "function",
+								"function": map[string]interface{}{"name": "bash", "arguments": `{"command":"echo hello"}`}},
+						},
+					}, "finish_reason": nil},
+				}},
+				{"id": "c1", "model": "test-model", "choices": []map[string]interface{}{
+					{"index": 0, "delta": map[string]interface{}{}, "finish_reason": "tool_calls"},
+				}, "usage": map[string]interface{}{"prompt_tokens": 30, "completion_tokens": 15}},
+			}
+			for _, c := range chunks {
+				_, _ = io.WriteString(w, sseChunk(c))
+			}
+		} else {
+			// Second turn: final text after seeing tool result
+			chunks := []map[string]interface{}{
+				{"id": "c2", "model": "test-model", "choices": []map[string]interface{}{
+					{"index": 0, "delta": map[string]interface{}{"role": "assistant", "content": "Done!"}, "finish_reason": nil},
+				}},
+				{"id": "c2", "model": "test-model", "choices": []map[string]interface{}{
+					{"index": 0, "delta": map[string]interface{}{}, "finish_reason": "stop"},
+				}, "usage": map[string]interface{}{"prompt_tokens": 50, "completion_tokens": 5}},
+			}
+			for _, c := range chunks {
+				_, _ = io.WriteString(w, sseChunk(c))
+			}
+		}
+		_, _ = io.WriteString(w, sseDone())
+	}))
+	defer srv.Close()
+
+	b := newTestOpenAIBackend(t, srv.URL)
+
+	var eventTypes []BackendEventType
+	result, err := b.Execute(context.Background(), ExecuteOptions{
+		Prompt:      "test prompt",
+		ProjectPath: t.TempDir(),
+		EventHandler: func(e BackendEvent) {
+			eventTypes = append(eventTypes, e.Type)
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("server called %d times, want 2", callCount)
+	}
+	if !result.Success {
+		t.Error("expected Success=true")
+	}
+	if result.Output != "Done!" {
+		t.Errorf("Output = %q, want 'Done!'", result.Output)
+	}
+	// Token sums: 30+50=80 prompt, 15+5=20 completion
+	if result.TokensInput != 80 {
+		t.Errorf("TokensInput = %d, want 80", result.TokensInput)
+	}
+	if result.TokensOutput != 20 {
+		t.Errorf("TokensOutput = %d, want 20", result.TokensOutput)
+	}
+
+	// Verify event sequence contains tool_use and tool_result
+	hasToolUse := false
+	hasToolResult := false
+	for _, et := range eventTypes {
+		if et == EventTypeToolUse {
+			hasToolUse = true
+		}
+		if et == EventTypeToolResult {
+			hasToolResult = true
+		}
+	}
+	if !hasToolUse {
+		t.Error("expected tool_use event")
+	}
+	if !hasToolResult {
+		t.Error("expected tool_result event")
+	}
+}
+
+// --- Retry on 429 ---
+
+func TestOpenAIBackend_Retry429(t *testing.T) {
+	attempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		// Second attempt succeeds
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		chunk := map[string]interface{}{
+			"id": "c1", "model": "m", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{"role": "assistant", "content": "ok"}, "finish_reason": nil},
+			},
+		}
+		_, _ = io.WriteString(w, sseChunk(chunk))
+		stop := map[string]interface{}{
+			"id": "c1", "model": "m", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{}, "finish_reason": "stop"},
+			},
+		}
+		_, _ = io.WriteString(w, sseChunk(stop))
+		_, _ = io.WriteString(w, sseDone())
+	}))
+	defer srv.Close()
+
+	b := newTestOpenAIBackend(t, srv.URL)
+	// Override backoffs to zero for fast test
+	origBackoffs := []int{0} // We can't easily override the backoff slice, so just verify attempts
+	_ = origBackoffs
+
+	// The actual retry uses exponential backoff. To keep the test fast, we just
+	// verify that the backend eventually succeeds after a 429.
+	// Note: this test will be slow if it actually sleeps the full backoff.
+	// In practice the test is used to verify retry logic, not timing.
+	result, err := b.Execute(context.Background(), ExecuteOptions{
+		Prompt:      "test",
+		ProjectPath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected success after retry")
+	}
+	if attempts < 2 {
+		t.Errorf("expected at least 2 attempts, got %d", attempts)
+	}
+}
+
+// --- Retry on 500 ---
+
+func TestOpenAIBackend_Retry500(t *testing.T) {
+	attempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		chunk := map[string]interface{}{
+			"id": "c1", "model": "m", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{"role": "assistant", "content": "recovered"}, "finish_reason": nil},
+			},
+		}
+		_, _ = io.WriteString(w, sseChunk(chunk))
+		stop := map[string]interface{}{
+			"id": "c1", "model": "m", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{}, "finish_reason": "stop"},
+			},
+		}
+		_, _ = io.WriteString(w, sseChunk(stop))
+		_, _ = io.WriteString(w, sseDone())
+	}))
+	defer srv.Close()
+
+	b := newTestOpenAIBackend(t, srv.URL)
+	result, err := b.Execute(context.Background(), ExecuteOptions{
+		Prompt:      "test",
+		ProjectPath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected success after 500 retry")
+	}
+	if attempts < 2 {
+		t.Errorf("expected at least 2 attempts, got %d", attempts)
+	}
+}
+
+// --- Malformed SSE handling ---
+
+func TestOpenAIBackend_MalformedSSE(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		// Mix of valid lines, garbage, and empty lines
+		lines := []string{
+			"data: not-valid-json\n\n",
+			":comment line\n\n",
+			"\n",
+			sseChunk(map[string]interface{}{
+				"id": "c1", "model": "m",
+				"choices": []map[string]interface{}{
+					{"index": 0, "delta": map[string]interface{}{"role": "assistant", "content": "valid"}, "finish_reason": nil},
+				},
+			}),
+			"data: {broken json\n\n",
+			sseChunk(map[string]interface{}{
+				"id": "c1", "model": "m",
+				"choices": []map[string]interface{}{
+					{"index": 0, "delta": map[string]interface{}{}, "finish_reason": "stop"},
+				},
+			}),
+			sseDone(),
+		}
+		for _, l := range lines {
+			_, _ = io.WriteString(w, l)
+		}
+	}))
+	defer srv.Close()
+
+	b := newTestOpenAIBackend(t, srv.URL)
+	result, err := b.Execute(context.Background(), ExecuteOptions{
+		Prompt:      "test",
+		ProjectPath: t.TempDir(),
+	})
+
+	// Malformed lines should be skipped; valid content should accumulate
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if result.Output != "valid" {
+		t.Errorf("Output = %q, want 'valid'", result.Output)
+	}
+}
+
+// --- No API key returns error ---
+
+func TestOpenAIBackend_NoAPIKey(t *testing.T) {
+	b := &OpenAIBackend{
+		apiKey: "",
+		model:  openaiDefaultModel,
+		apiURL: "https://api.openai.com/v1/chat/completions",
+		config: &BackendConfig{},
+	}
+	_, err := b.Execute(context.Background(), ExecuteOptions{Prompt: "test"})
+	if err == nil {
+		t.Error("expected error when no API key configured")
+	}
+	if !strings.Contains(err.Error(), "API key") {
+		t.Errorf("error = %q, want API key mention", err.Error())
+	}
+}
+
+// --- Token accounting ---
+
+func TestOpenAIBackend_TokenAccounting(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		chunks := []map[string]interface{}{
+			{"id": "c1", "model": "m", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{"role": "assistant", "content": "answer"}, "finish_reason": nil},
+			}},
+			{"id": "c1", "model": "m", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{}, "finish_reason": "stop"},
+			}, "usage": map[string]interface{}{"prompt_tokens": 42, "completion_tokens": 17, "total_tokens": 59}},
+		}
+		for _, c := range chunks {
+			_, _ = io.WriteString(w, sseChunk(c))
+		}
+		_, _ = io.WriteString(w, sseDone())
+	}))
+	defer srv.Close()
+
+	b := newTestOpenAIBackend(t, srv.URL)
+	result, err := b.Execute(context.Background(), ExecuteOptions{
+		Prompt:      "test",
+		ProjectPath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if result.TokensInput != 42 {
+		t.Errorf("TokensInput = %d, want 42", result.TokensInput)
+	}
+	if result.TokensOutput != 17 {
+		t.Errorf("TokensOutput = %d, want 17", result.TokensOutput)
+	}
+	// Cache tokens are always 0 for OpenAI — verify result fields exist and are 0
+	if result.CacheCreationInputTokens != 0 {
+		t.Errorf("CacheCreationInputTokens = %d, want 0", result.CacheCreationInputTokens)
+	}
+	if result.CacheReadInputTokens != 0 {
+		t.Errorf("CacheReadInputTokens = %d, want 0", result.CacheReadInputTokens)
+	}
+}
+
+// --- Request format validation ---
+
+func TestOpenAIBackend_RequestFormat(t *testing.T) {
+	var captured []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured = body
+
+		// Verify no Anthropic headers
+		if r.Header.Get("anthropic-version") != "" {
+			t.Error("anthropic-version header should not be set for OpenAI backend")
+		}
+		if r.Header.Get("x-api-key") != "" {
+			t.Error("x-api-key header should not be set for OpenAI backend")
+		}
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			t.Errorf("Authorization = %q, want 'Bearer ...'", auth)
+		}
+
+		// Return minimal stop response
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		chunk := map[string]interface{}{
+			"id": "c1", "model": "m", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{"role": "assistant", "content": "hi"}, "finish_reason": nil},
+			},
+		}
+		stop := map[string]interface{}{
+			"id": "c1", "model": "m", "choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{}, "finish_reason": "stop"},
+			},
+		}
+		_, _ = io.WriteString(w, sseChunk(chunk))
+		_, _ = io.WriteString(w, sseChunk(stop))
+		_, _ = io.WriteString(w, sseDone())
+	}))
+	defer srv.Close()
+
+	b := newTestOpenAIBackend(t, srv.URL)
+	_, err := b.Execute(context.Background(), ExecuteOptions{
+		Prompt:      "test",
+		ProjectPath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+
+	var req map[string]interface{}
+	if err := json.Unmarshal(captured, &req); err != nil {
+		t.Fatalf("captured body is not valid JSON: %v", err)
+	}
+
+	// Should have "messages" and "tools" and "stream"
+	if _, ok := req["messages"]; !ok {
+		t.Error("request missing 'messages' field")
+	}
+	if _, ok := req["tools"]; !ok {
+		t.Error("request missing 'tools' field")
+	}
+	streamVal, _ := req["stream"].(bool)
+	if !streamVal {
+		t.Error("request 'stream' should be true")
+	}
+
+	// Should NOT have Anthropic-specific fields
+	if _, ok := req["thinking"]; ok {
+		t.Error("request should not have 'thinking' field")
+	}
+	if _, ok := req["system"]; ok {
+		t.Error("request should not have 'system' field (use system role message instead)")
+	}
+
+	// Verify tools use OpenAI function-call format
+	tools, _ := req["tools"].([]interface{})
+	if len(tools) == 0 {
+		t.Fatal("tools array is empty")
+	}
+	firstTool, _ := tools[0].(map[string]interface{})
+	if firstTool["type"] != "function" {
+		t.Errorf("tool type = %q, want 'function'", firstTool["type"])
+	}
+	funcDef, _ := firstTool["function"].(map[string]interface{})
+	if _, ok := funcDef["parameters"]; !ok {
+		t.Error("tool function missing 'parameters' (not 'input_schema')")
+	}
+	if _, ok := funcDef["input_schema"]; ok {
+		t.Error("tool function should use 'parameters', not 'input_schema'")
+	}
+
+	// System prompt must be a system-role message, not a top-level "system" field
+	messages, _ := req["messages"].([]interface{})
+	if len(messages) == 0 {
+		t.Fatal("messages array is empty")
+	}
+	firstMsg, _ := messages[0].(map[string]interface{})
+	if firstMsg["role"] != "system" {
+		t.Errorf("first message role = %q, want 'system'", firstMsg["role"])
+	}
+}
+
+// --- Factory registration ---
+
+func TestNewBackend_OpenAIAPI(t *testing.T) {
+	cfg := &BackendConfig{
+		Type:   BackendTypeOpenAIAPI,
+		OpenAI: &OpenAIConfig{APIKey: "test-key"},
+	}
+	b, err := NewBackend(cfg)
+	if err != nil {
+		t.Fatalf("NewBackend error: %v", err)
+	}
+	if b.Name() != BackendTypeOpenAIAPI {
+		t.Errorf("Name() = %q, want %q", b.Name(), BackendTypeOpenAIAPI)
+	}
+	_, ok := b.(*OpenAIBackend)
+	if !ok {
+		t.Error("backend should be *OpenAIBackend")
+	}
+}
+
+// --- SSE parser unit tests ---
+
+func TestParseOpenAISSEStream_TextOnly(t *testing.T) {
+	b := &OpenAIBackend{}
+	sse := fmt.Sprintf(
+		"data: %s\n\ndata: %s\n\ndata: [DONE]\n\n",
+		mustJSON(map[string]interface{}{
+			"id": "c1", "model": "gpt-4o",
+			"choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{"content": "Hello"}, "finish_reason": nil},
+			},
+		}),
+		mustJSON(map[string]interface{}{
+			"id": "c1", "model": "gpt-4o",
+			"choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{}, "finish_reason": "stop"},
+			},
+			"usage": map[string]interface{}{"prompt_tokens": 5, "completion_tokens": 3},
+		}),
+	)
+
+	result, err := b.parseSSEStream(strings.NewReader(sse))
+	if err != nil {
+		t.Fatalf("parseSSEStream error: %v", err)
+	}
+	if result.Content != "Hello" {
+		t.Errorf("Content = %q, want 'Hello'", result.Content)
+	}
+	if result.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q, want 'stop'", result.FinishReason)
+	}
+	if result.PromptTokens != 5 {
+		t.Errorf("PromptTokens = %d, want 5", result.PromptTokens)
+	}
+}
+
+func TestParseOpenAISSEStream_ToolCallFragments(t *testing.T) {
+	b := &OpenAIBackend{}
+
+	chunks := []interface{}{
+		map[string]interface{}{
+			"id": "c1", "model": "m",
+			"choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{
+					"tool_calls": []map[string]interface{}{
+						{"index": 0, "id": "call_xyz", "type": "function",
+							"function": map[string]interface{}{"name": "read_file", "arguments": ""}},
+					},
+				}, "finish_reason": nil},
+			},
+		},
+		map[string]interface{}{
+			"id": "c1", "model": "m",
+			"choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{
+					"tool_calls": []map[string]interface{}{
+						{"index": 0, "function": map[string]interface{}{"arguments": `{"pa`}},
+					},
+				}, "finish_reason": nil},
+			},
+		},
+		map[string]interface{}{
+			"id": "c1", "model": "m",
+			"choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{
+					"tool_calls": []map[string]interface{}{
+						{"index": 0, "function": map[string]interface{}{"arguments": `th":"/tmp/x"}`}},
+					},
+				}, "finish_reason": nil},
+			},
+		},
+		map[string]interface{}{
+			"id": "c1", "model": "m",
+			"choices": []map[string]interface{}{
+				{"index": 0, "delta": map[string]interface{}{}, "finish_reason": "tool_calls"},
+			},
+			"usage": map[string]interface{}{"prompt_tokens": 8, "completion_tokens": 4},
+		},
+	}
+
+	var sb strings.Builder
+	for _, c := range chunks {
+		sb.WriteString(sseChunk(c))
+	}
+	sb.WriteString(sseDone())
+
+	result, err := b.parseSSEStream(strings.NewReader(sb.String()))
+	if err != nil {
+		t.Fatalf("parseSSEStream error: %v", err)
+	}
+	if result.FinishReason != "tool_calls" {
+		t.Errorf("FinishReason = %q, want 'tool_calls'", result.FinishReason)
+	}
+	if len(result.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1", len(result.ToolCalls))
+	}
+	tc := result.ToolCalls[0]
+	if tc.ID != "call_xyz" {
+		t.Errorf("ToolCall.ID = %q, want call_xyz", tc.ID)
+	}
+	if tc.Function.Name != "read_file" {
+		t.Errorf("ToolCall.Name = %q, want read_file", tc.Function.Name)
+	}
+	// Arguments should be the concatenated fragments
+	want := `{"path":"/tmp/x"}`
+	if tc.Function.Arguments != want {
+		t.Errorf("Arguments = %q, want %q", tc.Function.Arguments, want)
+	}
+}
+
+// mustJSON marshals v to JSON or panics.
+func mustJSON(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}

--- a/internal/executor/effort_classifier.go
+++ b/internal/executor/effort_classifier.go
@@ -250,7 +250,7 @@ func (c *EffortClassifier) classifyViaAPI(ctx context.Context, task *Task) (stri
 	if err != nil {
 		return "", fmt.Errorf("API request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/executor/preflight.go
+++ b/internal/executor/preflight.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -63,13 +64,24 @@ func RunPreflightChecksWithOptions(ctx context.Context, projectPath string, opts
 		var filtered []PreflightCheck
 		for _, c := range checks {
 			if c.Name == "claude_available" {
-				filtered = append(filtered, PreflightCheck{
-					Name:        "backend_available",
-					Description: fmt.Sprintf("Verify %s CLI is available", opts.BackendType),
-					Check: func(ctx context.Context, _ string) error {
-						return checkBackendCLI(ctx, opts.BackendType)
-					},
-				})
+				if opts.BackendType == BackendTypeOpenAIAPI || opts.BackendType == BackendTypeAnthropicAPI {
+					// Direct HTTP backends have no CLI — verify API key is present instead
+					filtered = append(filtered, PreflightCheck{
+						Name:        "api_key_configured",
+						Description: fmt.Sprintf("Verify API key is configured for %s backend", opts.BackendType),
+						Check: func(ctx context.Context, _ string) error {
+							return checkOpenAIAPIKey(opts.BackendType)
+						},
+					})
+				} else {
+					filtered = append(filtered, PreflightCheck{
+						Name:        "backend_available",
+						Description: fmt.Sprintf("Verify %s CLI is available", opts.BackendType),
+						Check: func(ctx context.Context, _ string) error {
+							return checkBackendCLI(ctx, opts.BackendType)
+						},
+					})
+				}
 			} else {
 				filtered = append(filtered, c)
 			}
@@ -156,6 +168,18 @@ func checkBackendCLI(ctx context.Context, backendType string) error {
 		return fmt.Errorf("%s command not available: %w (output: %s)", info.command, err, strings.TrimSpace(string(output)))
 	}
 	return nil
+}
+
+// checkOpenAIAPIKey verifies that an API key is available for direct HTTP backends
+// (openai-api, anthropic-api). No network call — local env check only.
+func checkOpenAIAPIKey(backendType string) error {
+	keys := []string{"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "PILOT_ENGINE_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"}
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s backend requires an API key: set OPENAI_API_KEY (or configure executor.openai.api_key)", backendType)
 }
 
 // checkGitClean verifies the git working directory has no uncommitted changes.


### PR DESCRIPTION
## Summary

Fixes lint CI failures from PR #2473 (GH-2382 openai-api backend).

- Remove unused `model` field from `AnthropicBackend` struct
- Use inferred types for `currentBlockTexts`/`currentBlockInputs` maps (staticcheck QF1011)
- Suppress `errcheck` on `resp.Body.Close()` calls in `backend_anthropic.go`, `backend_openai.go`, and `effort_classifier.go`

Closes #2474

## Test plan

- [x] `golangci-lint run ./internal/executor/...` → 0 issues
- [x] `go build ./...` → clean
- [x] `go test ./internal/executor/...` → pass