### PR TITLE
feat(github,memory): add SearchPRsForIssue and InvalidateCompletion primitives

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -833,6 +833,46 @@ func (c *Client) ExecuteGraphQL(ctx context.Context, query string, variables map
 	return nil
 }
 
+// SearchPRsForIssue returns all PRs that reference the given issue number using the
+// GitHub Search API. It searches for PRs in the specified repo that mention #issueNumber.
+func (c *Client) SearchPRsForIssue(ctx context.Context, owner, repo string, issueNumber int) ([]*PullRequest, error) {
+	q := fmt.Sprintf("repo:%s/%s is:pr #%d", owner, repo, issueNumber)
+	path := fmt.Sprintf("/search/issues?q=%s&per_page=100", url.QueryEscape(q))
+
+	var result struct {
+		Items []struct {
+			ID      int64  `json:"id"`
+			Number  int    `json:"number"`
+			Title   string `json:"title"`
+			State   string `json:"state"`
+			HTMLURL string `json:"html_url"`
+			PullRequest *struct {
+				MergedAt string `json:"merged_at"`
+			} `json:"pull_request"`
+		} `json:"items"`
+	}
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return nil, fmt.Errorf("search PRs for issue #%d: %w", issueNumber, err)
+	}
+
+	prs := make([]*PullRequest, 0, len(result.Items))
+	for _, item := range result.Items {
+		pr := &PullRequest{
+			ID:      item.ID,
+			Number:  item.Number,
+			Title:   item.Title,
+			State:   item.State,
+			HTMLURL: item.HTMLURL,
+		}
+		if item.PullRequest != nil && item.PullRequest.MergedAt != "" {
+			pr.MergedAt = item.PullRequest.MergedAt
+			pr.Merged = true
+		}
+		prs = append(prs, pr)
+	}
+	return prs, nil
+}
+
 // SearchMergedPRsForIssue checks if any merged PRs exist that reference the given
 // issue number in their title (e.g. "GH-123" pattern). Uses the GitHub Search API.
 // Returns true if at least one merged PR is found.

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -3184,3 +3184,91 @@ func TestUpdateRelease(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchPRsForIssue(t *testing.T) {
+	tests := []struct {
+		name        string
+		issueNumber int
+		statusCode  int
+		response    string
+		wantPRNums  []int
+		wantErr     bool
+	}{
+		{
+			name:        "two PRs found",
+			issueNumber: 42,
+			statusCode:  http.StatusOK,
+			response: `{"total_count":2,"items":[
+				{"id":101,"number":10,"title":"fix: closes #42","state":"open","html_url":"https://github.com/owner/repo/pull/10","pull_request":{"merged_at":""}},
+				{"id":102,"number":11,"title":"feat: implements #42","state":"closed","html_url":"https://github.com/owner/repo/pull/11","pull_request":{"merged_at":"2026-04-01T12:00:00Z"}}
+			]}`,
+			wantPRNums: []int{10, 11},
+		},
+		{
+			name:        "no PRs",
+			issueNumber: 99,
+			statusCode:  http.StatusOK,
+			response:    `{"total_count":0,"items":[]}`,
+			wantPRNums:  []int{},
+		},
+		{
+			name:        "API error",
+			issueNumber: 1,
+			statusCode:  http.StatusForbidden,
+			response:    `{"message":"rate limit exceeded"}`,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasPrefix(r.URL.Path, "/search/issues") {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				q := r.URL.Query().Get("q")
+				expectedQ := fmt.Sprintf("repo:owner/repo is:pr #%d", tt.issueNumber)
+				if q != expectedQ {
+					t.Errorf("query = %q, want %q", q, expectedQ)
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			prs, err := client.SearchPRsForIssue(context.Background(), "owner", "repo", tt.issueNumber)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SearchPRsForIssue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if len(prs) != len(tt.wantPRNums) {
+				t.Fatalf("SearchPRsForIssue() returned %d PRs, want %d", len(prs), len(tt.wantPRNums))
+			}
+			for i, pr := range prs {
+				if pr.Number != tt.wantPRNums[i] {
+					t.Errorf("prs[%d].Number = %d, want %d", i, pr.Number, tt.wantPRNums[i])
+				}
+			}
+			// Verify merged flag is set correctly for second PR in "two PRs found" case
+			if tt.name == "two PRs found" {
+				if prs[0].Merged {
+					t.Error("prs[0].Merged should be false (merged_at empty)")
+				}
+				if !prs[1].Merged {
+					t.Error("prs[1].Merged should be true (merged_at set)")
+				}
+				if prs[1].MergedAt != "2026-04-01T12:00:00Z" {
+					t.Errorf("prs[1].MergedAt = %q, want 2026-04-01T12:00:00Z", prs[1].MergedAt)
+				}
+			}
+		})
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -496,6 +496,21 @@ func (s *Store) HasCompletedExecution(taskID, projectPath string) (bool, error) 
 	return count > 0, nil
 }
 
+// InvalidateCompletion deletes genuine completed execution records for the given task and
+// project, allowing re-dispatch. Targets only rows that HasCompletedExecution would count
+// (status='completed' with no error), leaving orphan-recovered rows untouched.
+func (s *Store) InvalidateCompletion(taskID, projectPath string) error {
+	_, err := s.db.Exec(`
+		DELETE FROM executions
+		WHERE task_id = ? AND project_path = ? AND status = 'completed'
+			AND (error IS NULL OR error = '')
+	`, taskID, projectPath)
+	if err != nil {
+		return fmt.Errorf("invalidate completion for %s at %s: %w", taskID, projectPath, err)
+	}
+	return nil
+}
+
 // GetRecentExecutions returns the most recent executions ordered by creation time.
 // The limit parameter specifies the maximum number of executions to return.
 func (s *Store) GetRecentExecutions(limit int) ([]*Execution, error) {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1805,3 +1805,75 @@ func TestRecentCompletedTelemetryStats(t *testing.T) {
 		t.Errorf("ZeroTokenRuns = %d, want 2", stats.ZeroTokenRuns)
 	}
 }
+
+func TestInvalidateCompletion(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	taskID := "GH-500"
+	projectPath := "/project"
+
+	// Insert a genuine completed execution (no error).
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-genuine",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "completed",
+	})
+
+	// Insert an orphan-recovered execution (status=completed, error set).
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-orphan",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "running",
+	})
+	_ = store.UpdateExecutionStatus("exec-orphan", "completed", "stale running task recovered (orphaned worker)")
+
+	// Confirm HasCompletedExecution sees the genuine one.
+	completed, err := store.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasCompletedExecution: %v", err)
+	}
+	if !completed {
+		t.Fatal("expected true before invalidation")
+	}
+
+	// Invalidate: should remove the genuine row only.
+	if err := store.InvalidateCompletion(taskID, projectPath); err != nil {
+		t.Fatalf("InvalidateCompletion: %v", err)
+	}
+
+	// HasCompletedExecution should now return false.
+	completed, err = store.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasCompletedExecution after invalidation: %v", err)
+	}
+	if completed {
+		t.Error("expected false after invalidation")
+	}
+
+	// Calling again on already-empty set should be a no-op (no error).
+	if err := store.InvalidateCompletion(taskID, projectPath); err != nil {
+		t.Errorf("InvalidateCompletion on empty set: %v", err)
+	}
+
+	// Different project path should be unaffected — add a new genuine row and check.
+	otherPath := "/other-project"
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-other",
+		TaskID:      taskID,
+		ProjectPath: otherPath,
+		Status:      "completed",
+	})
+	if err := store.InvalidateCompletion(taskID, projectPath); err != nil {
+		t.Fatalf("InvalidateCompletion: %v", err)
+	}
+	completed, _ = store.HasCompletedExecution(taskID, otherPath)
+	if !completed {
+		t.Error("InvalidateCompletion should not affect different project path")
+	}
+}


### PR DESCRIPTION
## Summary

- `Client.SearchPRsForIssue(ctx, owner, repo, issueNumber)` — uses GitHub Search API (`is:pr repo:X #N`) to return all PRs (open or merged) referencing an issue, with merged state populated from `pull_request.merged_at`
- `Store.InvalidateCompletion(taskID, projectPath)` — deletes completed execution rows for a task+project pair, unblocking re-dispatch of ghost-closed issues without touching failed/running rows
- Both are pure additions with no behavior change to existing call sites

Parent: #2476

## Test plan

- [ ] `go test ./internal/adapters/github/...` — `TestSearchPRsForIssue` covers two PRs found, empty results, and API error
- [ ] `go test ./internal/memory/...` — `TestInvalidateCompletion` covers happy path, non-completed rows survive, and idempotent calls