### PR TITLE
fix(executor): verify PR observable before persisting completed (GH-2478)

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -307,6 +307,43 @@ func (c *Client) GetPullRequest(ctx context.Context, owner, repo string, number 
 	return &result, nil
 }
 
+// GetPRByURL fetches a pull request by its HTML URL.
+// Parses "https://github.com/owner/repo/pull/123" to extract owner, repo, and number,
+// then calls GetPullRequest. Returns (prNumber, error).
+func (c *Client) GetPRByURL(ctx context.Context, prURL string) (int, error) {
+	owner, repo, number, err := parsePRURL(prURL)
+	if err != nil {
+		return 0, fmt.Errorf("invalid PR URL %q: %w", prURL, err)
+	}
+	pr, err := c.GetPullRequest(ctx, owner, repo, number)
+	if err != nil {
+		return 0, fmt.Errorf("PR %s not observable: %w", prURL, err)
+	}
+	return pr.Number, nil
+}
+
+// parsePRURL extracts owner, repo, and PR number from a GitHub PR HTML URL.
+// Handles "https://github.com/owner/repo/pull/123" and enterprise GitHub.
+func parsePRURL(prURL string) (owner, repo string, number int, err error) {
+	if prURL == "" {
+		return "", "", 0, fmt.Errorf("empty URL")
+	}
+	// Strip query string and fragment
+	u, parseErr := url.Parse(prURL)
+	if parseErr != nil {
+		return "", "", 0, fmt.Errorf("malformed URL: %w", parseErr)
+	}
+	// Path: /owner/repo/pull/123[/...]
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 4 || parts[2] != "pull" {
+		return "", "", 0, fmt.Errorf("not a PR URL (expected /owner/repo/pull/N): %s", prURL)
+	}
+	if _, scanErr := fmt.Sscanf(parts[3], "%d", &number); scanErr != nil || number <= 0 {
+		return "", "", 0, fmt.Errorf("invalid PR number %q in URL", parts[3])
+	}
+	return parts[0], parts[1], number, nil
+}
+
 // ClosePullRequest closes a pull request without merging.
 // Used by autopilot to close failed PRs so the sequential poller can unblock.
 func (c *Client) ClosePullRequest(ctx context.Context, owner, repo string, number int) error {

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -3184,3 +3184,137 @@ func TestUpdateRelease(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePRURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		wantOwner  string
+		wantRepo   string
+		wantNumber int
+		wantErr    bool
+	}{
+		{
+			name:       "standard github PR",
+			url:        "https://github.com/owner/repo/pull/123",
+			wantOwner:  "owner",
+			wantRepo:   "repo",
+			wantNumber: 123,
+		},
+		{
+			name:       "github enterprise",
+			url:        "https://github.example.com/org/myrepo/pull/456",
+			wantOwner:  "org",
+			wantRepo:   "myrepo",
+			wantNumber: 456,
+		},
+		{
+			name:       "URL with trailing path",
+			url:        "https://github.com/owner/repo/pull/42/files",
+			wantOwner:  "owner",
+			wantRepo:   "repo",
+			wantNumber: 42,
+		},
+		{
+			name:    "empty URL",
+			url:     "",
+			wantErr: true,
+		},
+		{
+			name:    "issue URL not PR",
+			url:     "https://github.com/owner/repo/issues/123",
+			wantErr: true,
+		},
+		{
+			name:    "malformed URL",
+			url:     "not-a-url",
+			wantErr: true,
+		},
+		{
+			name:    "zero PR number",
+			url:     "https://github.com/owner/repo/pull/0",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, number, err := parsePRURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parsePRURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if owner != tt.wantOwner {
+					t.Errorf("owner = %q, want %q", owner, tt.wantOwner)
+				}
+				if repo != tt.wantRepo {
+					t.Errorf("repo = %q, want %q", repo, tt.wantRepo)
+				}
+				if number != tt.wantNumber {
+					t.Errorf("number = %d, want %d", number, tt.wantNumber)
+				}
+			}
+		})
+	}
+}
+
+func TestGetPRByURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		prURL      string
+		statusCode int
+		response   interface{}
+		wantNum    int
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			prURL:      "/owner/repo/pull/7",
+			statusCode: http.StatusOK,
+			response:   PullRequest{Number: 7, State: "open"},
+			wantNum:    7,
+		},
+		{
+			name:       "PR not found",
+			prURL:      "/owner/repo/pull/99",
+			statusCode: http.StatusNotFound,
+			response:   map[string]string{"message": "Not Found"},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				_, _ = fmt.Fprintf(w, "%s", mustJSON(tt.response))
+			}))
+			defer server.Close()
+
+			// Build a full URL using the test server
+			fullURL := server.URL + tt.prURL
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			num, err := client.GetPRByURL(context.Background(), fullURL)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetPRByURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && num != tt.wantNum {
+				t.Errorf("GetPRByURL() number = %d, want %d", num, tt.wantNum)
+			}
+		})
+	}
+}
+
+// mustJSON marshals v to JSON or panics.
+func mustJSON(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}

--- a/internal/executor/gh2478_test.go
+++ b/internal/executor/gh2478_test.go
@@ -1,0 +1,194 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// mockPRVerifier implements PRVerifier for testing.
+type mockPRVerifier struct {
+	returnErr error
+	returnNum int
+}
+
+func (m *mockPRVerifier) GetPRByURL(_ context.Context, _ string) (int, error) {
+	return m.returnNum, m.returnErr
+}
+
+// TestPRVerifier_Interface verifies that mockPRVerifier satisfies PRVerifier.
+func TestPRVerifier_Interface(t *testing.T) {
+	var _ PRVerifier = &mockPRVerifier{}
+}
+
+// TestSetPRVerifier_Wiring verifies that SetPRVerifier stores the verifier on the runner.
+func TestSetPRVerifier_Wiring(t *testing.T) {
+	r := NewRunner()
+	if r.prVerifier != nil {
+		t.Fatal("prVerifier should be nil before SetPRVerifier")
+	}
+	v := &mockPRVerifier{returnNum: 42}
+	r.SetPRVerifier(v)
+	if r.prVerifier == nil {
+		t.Fatal("prVerifier should be set after SetPRVerifier")
+	}
+	got, err := r.prVerifier.GetPRByURL(context.Background(), "https://github.com/o/r/pull/42")
+	if err != nil || got != 42 {
+		t.Errorf("GetPRByURL() = (%d, %v), want (42, nil)", got, err)
+	}
+}
+
+// TestDispatcher_EmptyPRURL_PersistedAsFailed verifies that when the runner signals
+// failure because PR creation returned an empty URL (GH-2478), the dispatcher
+// persists the execution row as "failed" — not "completed".
+//
+// The executeFunc simulates what runner.Execute now returns after the empty-URL guard:
+// Success=false with the canonical error message.
+func TestDispatcher_EmptyPRURL_PersistedAsFailed(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Simulate runner behaviour after GH-2478 fix: CreatePR returns ("", nil)
+	// so runner sets Success=false with the sentinel error.
+	execFn := func(_ context.Context, _ *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{
+			Success: false,
+			Error:   "PR creation reported success but returned empty URL",
+		}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	dispatcher := NewDispatcher(store, runner, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := dispatcher.Start(ctx); err != nil {
+		t.Fatalf("dispatcher.Start: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	task := &Task{
+		ID:          "GH-2478-empty-url",
+		Title:       "feat(test): verify empty PR URL persisted as failed",
+		Description: "Regression test for GH-2478",
+		ProjectPath: "/tmp/gh2478-test",
+		CreatePR:    true,
+		Branch:      "pilot/GH-2478-empty-url",
+	}
+
+	execID, err := dispatcher.QueueTask(ctx, task)
+	if err != nil {
+		t.Fatalf("QueueTask: %v", err)
+	}
+
+	// Poll until terminal status (failed or completed).
+	deadline := time.Now().Add(8 * time.Second)
+	var finalExec *memory.Execution
+	for time.Now().Before(deadline) {
+		exec, getErr := store.GetExecution(execID)
+		if getErr != nil {
+			t.Fatalf("GetExecution: %v", getErr)
+		}
+		if exec.Status == "failed" || exec.Status == "completed" {
+			finalExec = exec
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if finalExec == nil {
+		t.Fatal("execution never reached terminal state within deadline")
+	}
+	if finalExec.Status != "failed" {
+		t.Errorf("execution status = %q, want %q (GH-2478: empty PR URL must not be completed)",
+			finalExec.Status, "failed")
+	}
+}
+
+// TestDispatcher_PRVerifierFailure_PersistedAsFailed verifies that when the PRVerifier
+// cannot confirm the PR is observable, the dispatcher persists the row as "failed".
+func TestDispatcher_PRVerifierFailure_PersistedAsFailed(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	// Simulate runner behaviour when prVerifier.GetPRByURL returns an error.
+	execFn := func(_ context.Context, _ *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{
+			Success: false,
+			Error:   "PR created but not observable via API: 404 not found",
+		}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	dispatcher := NewDispatcher(store, runner, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := dispatcher.Start(ctx); err != nil {
+		t.Fatalf("dispatcher.Start: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	task := &Task{
+		ID:          "GH-2478-verify-fail",
+		Title:       "feat(test): verify unobservable PR persisted as failed",
+		Description: "Regression test for GH-2478",
+		ProjectPath: "/tmp/gh2478-verify-test",
+		CreatePR:    true,
+		Branch:      "pilot/GH-2478-verify-fail",
+	}
+
+	execID, err := dispatcher.QueueTask(ctx, task)
+	if err != nil {
+		t.Fatalf("QueueTask: %v", err)
+	}
+
+	deadline := time.Now().Add(8 * time.Second)
+	var finalExec *memory.Execution
+	for time.Now().Before(deadline) {
+		exec, getErr := store.GetExecution(execID)
+		if getErr != nil {
+			t.Fatalf("GetExecution: %v", getErr)
+		}
+		if exec.Status == "failed" || exec.Status == "completed" {
+			finalExec = exec
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if finalExec == nil {
+		t.Fatal("execution never reached terminal state within deadline")
+	}
+	if finalExec.Status != "failed" {
+		t.Errorf("execution status = %q, want %q (GH-2478: unobservable PR must not be completed)",
+			finalExec.Status, "failed")
+	}
+}
+
+// TestPRVerifier_MockSuccess verifies mock returns correct PR number on success path.
+func TestPRVerifier_MockSuccess(t *testing.T) {
+	v := &mockPRVerifier{returnNum: 99, returnErr: nil}
+	num, err := v.GetPRByURL(context.Background(), "https://github.com/o/r/pull/99")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if num != 99 {
+		t.Errorf("got PR number %d, want 99", num)
+	}
+}
+
+// TestPRVerifier_MockFailure verifies mock returns error on failure path.
+func TestPRVerifier_MockFailure(t *testing.T) {
+	sentinel := errors.New("PR not found")
+	v := &mockPRVerifier{returnErr: sentinel}
+	_, err := v.GetPRByURL(context.Background(), "https://github.com/o/r/pull/99")
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -324,6 +324,14 @@ type SubIssueLinker interface {
 	LinkSubIssue(ctx context.Context, owner, repo string, parentNum, childNum int) error
 }
 
+// PRVerifier confirms that a created pull/merge request is observable via the remote API.
+// When set, the runner calls GetPRByURL after PR creation; if the PR cannot be fetched,
+// the execution is marked failed instead of completed. GH-2478.
+// *github.Client satisfies this interface via its GetPRByURL method.
+type PRVerifier interface {
+	GetPRByURL(ctx context.Context, prURL string) (int, error)
+}
+
 // Runner executes development tasks using an AI backend (Claude Code, OpenCode, etc.).
 // It manages task lifecycle including branch creation, AI invocation,
 // progress tracking, PR creation, and execution recording. Runner is safe for
@@ -389,6 +397,9 @@ type Runner struct {
 	// GH-2363: Track consecutive title-rejection failures per issue so we stop
 	// retrying and post a helpful comment after the 2nd identical rejection.
 	titleRejections      *titleRejectionTracker
+	// GH-2478: Optional PR verifier — fetches the PR via API after creation to confirm
+	// it is observable before writing completed. Prevents ghost-completed rows.
+	prVerifier           PRVerifier
 }
 
 // NewRunner creates a new Runner instance with Claude Code backend by default.
@@ -782,6 +793,13 @@ func (r *Runner) SetPRCreator(creator PRCreator) {
 // (warn-level log only) — the text "Parent: GH-N" body marker remains as fallback.
 func (r *Runner) SetSubIssueLinker(linker SubIssueLinker) {
 	r.subIssueLinker = linker
+}
+
+// SetPRVerifier sets the verifier used to confirm a PR is observable via the remote API
+// after creation. When set, the runner calls GetPRByURL after each PR is created;
+// if the call fails, the execution is marked failed instead of completed (GH-2478).
+func (r *Runner) SetPRVerifier(v PRVerifier) {
+	r.prVerifier = v
 }
 
 // SetIntentJudge sets the intent judge for diff-vs-ticket alignment verification (GH-624).
@@ -2951,6 +2969,31 @@ The previous execution completed but made no code changes. This task requires ac
 					r.reportProgress(task.ID, "PR Failed", 100, result.Error)
 					return result, nil
 				}
+			}
+
+			// GH-2478: Guard against success-flag-true but empty URL (gh CLI quirk).
+			if prURL == "" {
+				result.Success = false
+				result.Error = "PR creation reported success but returned empty URL"
+				r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+				return result, nil
+			}
+
+			// GH-2478: Confirm the PR is observable via the API before marking completed.
+			if r.prVerifier != nil {
+				prNum, verErr := r.prVerifier.GetPRByURL(ctx, prURL)
+				if verErr != nil {
+					result.Success = false
+					result.Error = fmt.Sprintf("PR created but not observable via API: %v", verErr)
+					log.Warn("PR not observable after creation",
+						slog.String("task_id", task.ID),
+						slog.String("pr_url", prURL),
+						slog.Any("error", verErr),
+					)
+					r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+					return result, nil
+				}
+				log.Info("PR verified as observable", slog.String("pr_url", prURL), slog.Int("pr_number", prNum))
 			}
 
 			result.PRUrl = prURL


### PR DESCRIPTION
## Summary

- Adds an empty-URL guard after `CreatePR`: if the call returns `("", nil)`, sets `result.Success=false` so the dispatcher persists `failed` instead of `completed`
- Adds `PRVerifier` interface and `Runner.SetPRVerifier()` setter for wiring the GitHub client as a post-creation verifier
- Adds `GetPRByURL` to `github.Client` — parses the HTML URL, extracts owner/repo/number, then calls `GetPullRequest` to confirm the PR is observable via API

## Test plan

- [x] `TestPRVerifier_Interface` / `TestSetPRVerifier_Wiring` — interface and setter wiring
- [x] `TestDispatcher_EmptyPRURL_PersistedAsFailed` — dispatcher writes `failed` when runner signals failure (empty URL case)
- [x] `TestDispatcher_PRVerifierFailure_PersistedAsFailed` — dispatcher writes `failed` when PR not observable
- [x] `TestParsePRURL` — table-driven URL parsing for owner/repo/number extraction
- [x] `TestGetPRByURL` — happy path and 404 path on mock HTTP server
- [x] Build: `go build ./...` ✅
- [x] Lint: `make lint` → 0 issues ✅

Closes #2478
Parent: #2476