### PR TITLE
fix(executor): verify PR URL resolves before persisting completed status

### DIFF
--- a/internal/executor/gh2488_test.go
+++ b/internal/executor/gh2488_test.go
@@ -1,0 +1,84 @@
+package executor
+
+import (
+	"context"
+	"testing"
+)
+
+// mockPRVerifier is a test double for PRVerifier.
+type mockPRVerifier struct {
+	pr  *PRInfo
+	err error
+}
+
+func (m *mockPRVerifier) GetPRByURL(_ context.Context, _ string) (*PRInfo, error) {
+	return m.pr, m.err
+}
+
+// TestVerifyPRURL_EmptyURL covers case (a): createPR returned an empty URL.
+// The execution row must be failed.
+func TestVerifyPRURL_EmptyURL(t *testing.T) {
+	ctx := context.Background()
+	_, err := verifyPRURL(ctx, "", &mockPRVerifier{pr: &PRInfo{Number: 1, URL: "https://example.com/pull/1"}})
+	if err == nil {
+		t.Fatal("expected error for empty URL, got nil")
+	}
+}
+
+// TestVerifyPRURL_URLButLookupReturnsNil covers case (b): createPR returned a URL
+// but the remote lookup found no matching PR.
+func TestVerifyPRURL_URLButLookupReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	_, err := verifyPRURL(ctx, "https://github.com/owner/repo/pull/99", &mockPRVerifier{pr: nil})
+	if err == nil {
+		t.Fatal("expected error when PR lookup returns nil, got nil")
+	}
+}
+
+// TestVerifyPRURL_HappyPath covers case (c): createPR returned a URL and the
+// lookup confirmed the PR exists — the result must carry PRNumber and PRUrl.
+func TestVerifyPRURL_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	wantURL := "https://github.com/owner/repo/pull/42"
+	wantNum := 42
+
+	pr, err := verifyPRURL(ctx, wantURL, &mockPRVerifier{
+		pr: &PRInfo{Number: wantNum, URL: wantURL},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr == nil {
+		t.Fatal("expected PRInfo, got nil")
+	}
+	if pr.Number != wantNum {
+		t.Errorf("PRNumber = %d, want %d", pr.Number, wantNum)
+	}
+	if pr.URL != wantURL {
+		t.Errorf("PRUrl = %q, want %q", pr.URL, wantURL)
+	}
+}
+
+// TestVerifyPRURL_NilVerifier verifies that a nil verifier accepts any non-empty URL
+// without a remote call (used for non-GitHub adapters).
+func TestVerifyPRURL_NilVerifier(t *testing.T) {
+	ctx := context.Background()
+	url := "https://gitlab.com/owner/repo/-/merge_requests/7"
+
+	pr, err := verifyPRURL(ctx, url, nil)
+	if err != nil {
+		t.Fatalf("unexpected error with nil verifier: %v", err)
+	}
+	if pr == nil || pr.URL != url {
+		t.Errorf("expected PRInfo{URL:%q}, got %+v", url, pr)
+	}
+}
+
+// TestExecutionResult_PRNumberField verifies that PRNumber is wired into
+// ExecutionResult and defaults to zero (compile-time field check).
+func TestExecutionResult_PRNumberField(t *testing.T) {
+	r := &ExecutionResult{PRNumber: 5, PRUrl: "https://github.com/owner/repo/pull/5"}
+	if r.PRNumber != 5 {
+		t.Errorf("PRNumber = %d, want 5", r.PRNumber)
+	}
+}

--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -2,10 +2,53 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
 )
+
+// PRInfo holds the resolved fields of a pull/merge request.
+type PRInfo struct {
+	Number int
+	URL    string
+}
+
+// PRVerifier looks up a PR by URL and returns its resolved fields.
+// The interface exists so tests can inject a mock without calling the gh CLI.
+type PRVerifier interface {
+	GetPRByURL(ctx context.Context, url string) (*PRInfo, error)
+}
+
+// GetPRByURL fetches a PR by URL using the gh CLI.
+// Returns nil (no error) when the PR does not exist.
+func (g *GitOperations) GetPRByURL(ctx context.Context, url string) (*PRInfo, error) {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", url, "--json", "number,url")
+	cmd.Dir = g.projectPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		outputStr := strings.TrimSpace(string(output))
+		// gh exits non-zero when the PR is not found — treat as missing, not error
+		if strings.Contains(outputStr, "no pull requests found") ||
+			strings.Contains(outputStr, "Could not resolve") ||
+			strings.Contains(outputStr, "not found") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("gh pr view: %w: %s", err, output)
+	}
+
+	var data struct {
+		Number int    `json:"number"`
+		URL    string `json:"url"`
+	}
+	if jsonErr := json.Unmarshal(output, &data); jsonErr != nil {
+		return nil, fmt.Errorf("parse pr view output: %w", jsonErr)
+	}
+	if data.Number == 0 {
+		return nil, nil
+	}
+	return &PRInfo{Number: data.Number, URL: data.URL}, nil
+}
 
 // GitOperations handles git operations for tasks
 type GitOperations struct {

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -272,6 +272,9 @@ type ExecutionResult struct {
 	// guard and the runner has already posted a structured "how to fix" comment
 	// (GH-2363). Callers should skip their generic failure-comment path.
 	TitleRejected bool
+	// PRNumber is the numeric ID of the pull request created for this task (GH-2488).
+	// Populated only when CreatePR succeeded and the PR was verified via GetPRByURL.
+	PRNumber int
 }
 
 // ProgressCallback is a function called during execution with progress updates.
@@ -386,6 +389,8 @@ type Runner struct {
 	knowledgeGraph       KnowledgeGraphRecorder         // Optional knowledge graph for cross-project learnings
 	// GH-2256: Dry-run mode to suppress real gh CLI calls (issue close/comment)
 	dryRun               bool
+	// GH-2488: Optional PR verifier override; nil means use GitOperations.GetPRByURL.
+	prVerifier           PRVerifier
 	// GH-2363: Track consecutive title-rejection failures per issue so we stop
 	// retrying and post a helpful comment after the 2nd identical rejection.
 	titleRejections      *titleRejectionTracker
@@ -2939,6 +2944,15 @@ The previous execution completed but made no code changes. This task requires ac
 					r.reportProgress(task.ID, "MR Failed", 100, result.Error)
 					return result, nil
 				}
+				// GH-2488: verify URL is non-empty (no remote lookup for non-GitHub adapters)
+				mrInfo, verifyErr := verifyPRURL(ctx, prURL, nil)
+				if verifyErr != nil {
+					result.Success = false
+					result.Error = fmt.Sprintf("MR verification failed: %v", verifyErr)
+					r.reportProgress(task.ID, "MR Failed", 100, result.Error)
+					return result, nil
+				}
+				result.PRUrl = mrInfo.URL
 			} else {
 				// GitHub: use gh CLI with auto-close keyword
 				issueNum := strings.TrimPrefix(task.ID, "GH-")
@@ -2951,16 +2965,31 @@ The previous execution completed but made no code changes. This task requires ac
 					r.reportProgress(task.ID, "PR Failed", 100, result.Error)
 					return result, nil
 				}
+				// GH-2488: cross-check that the PR URL resolves to a real PR before
+				// recording status='completed'. Ghost-closes occur when gh reports a URL
+				// but no PR was actually created (e.g. extractPRURL parsing failures).
+				verifier := PRVerifier(git)
+				if r.prVerifier != nil {
+					verifier = r.prVerifier
+				}
+				pr, verifyErr := verifyPRURL(ctx, prURL, verifier)
+				if verifyErr != nil {
+					result.Success = false
+					result.Error = fmt.Sprintf("PR verification failed: %v", verifyErr)
+					r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+					return result, nil
+				}
+				result.PRUrl = pr.URL
+				result.PRNumber = pr.Number
 			}
 
-			result.PRUrl = prURL
-			log.Info("Pull request created", slog.String("pr_url", prURL))
-			r.reportProgress(task.ID, "Completed", 100, fmt.Sprintf("PR created: %s", prURL))
-			r.saveLogEntry(task.ID, "info", "PR created: "+prURL)
+			log.Info("Pull request created", slog.String("pr_url", result.PRUrl))
+			r.reportProgress(task.ID, "Completed", 100, fmt.Sprintf("PR created: %s", result.PRUrl))
+			r.saveLogEntry(task.ID, "info", "PR created: "+result.PRUrl)
 
 			// Update recording with PR info
 			if recorder != nil {
-				recorder.SetPRUrl(prURL)
+				recorder.SetPRUrl(result.PRUrl)
 			}
 		} else {
 			r.reportProgress(task.ID, "Completed", 100, "Task completed successfully")
@@ -3115,6 +3144,27 @@ The previous execution completed but made no code changes. This task requires ac
 
 	return result, nil
 }
+
+// verifyPRURL validates that a PR URL is non-empty and, when a verifier is provided,
+// that the PR actually exists on the remote. Returns the resolved PRInfo or an error.
+// Passing a nil verifier skips the remote lookup and accepts the URL at face value.
+func verifyPRURL(ctx context.Context, url string, verifier PRVerifier) (*PRInfo, error) {
+	if url == "" {
+		return nil, fmt.Errorf("PR creation returned empty URL")
+	}
+	if verifier == nil {
+		return &PRInfo{URL: url}, nil
+	}
+	pr, err := verifier.GetPRByURL(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("PR lookup failed: %w", err)
+	}
+	if pr == nil {
+		return nil, fmt.Errorf("PR not found at %s", url)
+	}
+	return pr, nil
+}
+
 // Cancel terminates a running task by killing its Claude Code process.
 // Returns an error if the task is not currently running.
 func (r *Runner) Cancel(taskID string) error {


### PR DESCRIPTION
## Summary

- Wraps the PR creation result: if `createPR` returns an empty URL, the task row is written with `status='failed'` and a descriptive reason
- If `createPR` returns a URL, `verifyPRURL` cross-checks via the `PRVerifier` interface (`GitOperations.GetPRByURL` via `gh pr view`)
- A nil PRVerifier accepts any non-empty URL (used for non-GitHub adapters where remote lookup is unavailable)
- Only persists `completed` when the PR is confirmed; records `PRNumber` and `PRURL` on `ExecutionResult`

Closes #2488
Parent: GH-2476

## Test plan

- [x] `TestVerifyPRURL_EmptyURL` → error returned, task status failed
- [x] `TestVerifyPRURL_URLButLookupReturnsNil` → error when lookup returns nil PR
- [x] `TestVerifyPRURL_HappyPath` → success with PRNumber and PRURL populated
- [x] `TestVerifyPRURL_NilVerifier` → nil verifier accepts non-empty URL
- [x] `go test ./internal/executor/...` — full suite passes
- [x] `go build ./...` — zero errors
- [x] `make lint` — 0 issues