### PR TITLE
fix(github): detect and self-heal ghost completions in poller guard

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -47,8 +47,10 @@ type TaskChecker interface {
 
 // ExecutionChecker verifies whether a completed execution exists for a task.
 // GH-2242: Prevents re-dispatch of completed tasks when pilot-done label is missing.
+// GH-2489: InvalidateCompletion enables the ghost-close self-healing path.
 type ExecutionChecker interface {
 	HasCompletedExecution(taskID, projectPath string) (bool, error)
+	InvalidateCompletion(taskID, projectPath string) error
 }
 
 // IssueResult is returned by the issue handler with PR information
@@ -912,6 +914,7 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 
 		// GH-2242: Before dispatching, check if we already have a completed execution.
 		// This prevents re-dispatch when pilot-done label failed to apply.
+		// GH-2489: Cross-check PR existence to detect and self-heal ghost completions.
 		if p.execChecker != nil {
 			taskID := fmt.Sprintf("GH-%d", issue.Number)
 			completed, err := p.execChecker.HasCompletedExecution(taskID, p.projectPath)
@@ -920,11 +923,28 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 					slog.Int("number", issue.Number),
 					slog.Any("error", err))
 			} else if completed {
-				p.logger.Info("Skipping re-dispatch — completed execution exists",
-					slog.Int("number", issue.Number),
-					slog.String("task_id", taskID))
-				p.markProcessed(issue.Number)
-				continue
+				// Verify a real PR exists — ghost-close leaves completed in DB with no PR.
+				prs, perr := p.client.SearchPRsForIssue(ctx, p.owner, p.repo, issue.Number)
+				if perr != nil {
+					p.logger.Warn("Failed to search PRs for ghost-close check — assuming completed",
+						slog.Int("issue", issue.Number),
+						slog.Any("error", perr))
+					p.markProcessed(issue.Number)
+					continue
+				}
+				if len(prs) == 0 {
+					p.logger.Warn("Ghost completion detected — execution marked completed but no PR exists, allowing re-dispatch",
+						slog.Int("issue", issue.Number),
+						slog.String("task_id", taskID))
+					_ = p.execChecker.InvalidateCompletion(taskID, p.projectPath)
+					// Fall through to dispatch
+				} else {
+					p.logger.Info("Skipping re-dispatch — completed execution exists",
+						slog.Int("number", issue.Number),
+						slog.String("task_id", taskID))
+					p.markProcessed(issue.Number)
+					continue
+				}
 			}
 		}
 

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2498,21 +2498,41 @@ func TestPoller_WithMaxRetryReadyRetries(t *testing.T) {
 
 // mockExecutionChecker implements ExecutionChecker for testing.
 type mockExecutionChecker struct {
-	completed map[string]bool // key: "taskID:projectPath"
+	completed    map[string]bool // key: "taskID:projectPath"
+	invalidated  []string        // records of InvalidateCompletion calls ("taskID:projectPath")
 }
 
 func (m *mockExecutionChecker) HasCompletedExecution(taskID, projectPath string) (bool, error) {
 	return m.completed[taskID+":"+projectPath], nil
 }
 
+func (m *mockExecutionChecker) InvalidateCompletion(taskID, projectPath string) error {
+	m.invalidated = append(m.invalidated, taskID+":"+projectPath)
+	delete(m.completed, taskID+":"+projectPath)
+	return nil
+}
+
 func TestPoller_SkipsCompletedExecution(t *testing.T) {
-	// GH-2242: Issue is open, no pilot-done label, but has completed execution — should NOT dispatch
+	// GH-2242 + GH-2489: Issue has completed execution AND a real PR exists — should NOT dispatch.
 	issues := []*Issue{
 		{Number: 42, Title: "Issue 42", Labels: []Label{{Name: "pilot"}}},
+	}
+	// Simulate a merged PR in the search response.
+	searchResp := map[string]interface{}{
+		"items": []map[string]interface{}{
+			{
+				"id": 1, "number": 10, "title": "Fix #42", "state": "closed", "html_url": "https://github.com/owner/repo/pull/10",
+				"pull_request": map[string]interface{}{"merged_at": "2026-05-01T10:00:00Z"},
+			},
+		},
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/search/issues" {
+			_ = json.NewEncoder(w).Encode(searchResp)
+			return
+		}
 		if strings.Contains(r.URL.Path, "/issues") {
 			_ = json.NewEncoder(w).Encode(issues)
 			return
@@ -2542,12 +2562,69 @@ func TestPoller_SkipsCompletedExecution(t *testing.T) {
 	poller.WaitForActive()
 
 	if got := atomic.LoadInt32(&callCount); got != 0 {
-		t.Errorf("callback called %d times, want 0 (completed execution should skip dispatch)", got)
+		t.Errorf("callback called %d times, want 0 (completed execution with real PR should skip dispatch)", got)
 	}
 
 	// Should be marked as processed
 	if !poller.IsProcessed(42) {
-		t.Error("completed issue should be marked as processed")
+		t.Error("completed issue with real PR should be marked as processed")
+	}
+	// InvalidateCompletion must NOT have been called — PR exists, not a ghost.
+	if len(execChecker.invalidated) != 0 {
+		t.Errorf("InvalidateCompletion called unexpectedly: %v", execChecker.invalidated)
+	}
+}
+
+func TestPoller_GhostCloseDetected_AllowsRedispatch(t *testing.T) {
+	// GH-2489: Issue has completed execution in DB but NO PR — ghost-close.
+	// The poller should invalidate the stale row and allow re-dispatch.
+	issues := []*Issue{
+		{Number: 55, Title: "Issue 55", Labels: []Label{{Name: "pilot"}}},
+	}
+	// Search returns empty — no PR was ever created.
+	emptySearch := map[string]interface{}{"items": []interface{}{}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/search/issues" {
+			_ = json.NewEncoder(w).Encode(emptySearch)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/issues") {
+			_ = json.NewEncoder(w).Encode(issues)
+			return
+		}
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	execChecker := &mockExecutionChecker{
+		completed: map[string]bool{
+			"GH-55:/project": true,
+		},
+	}
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithExecutionChecker(execChecker, "/project"),
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	// Ghost-close detected: issue should have been dispatched.
+	if got := atomic.LoadInt32(&callCount); got != 1 {
+		t.Errorf("callback called %d times, want 1 (ghost-close should allow re-dispatch)", got)
+	}
+	// InvalidateCompletion must have been called to clean up the stale row.
+	if len(execChecker.invalidated) == 0 {
+		t.Error("InvalidateCompletion was not called — ghost completion row not cleaned up")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extends `ExecutionChecker` interface with `InvalidateCompletion` so the poller can clean up stale completion rows automatically.
- In the GH-2242 dispatch guard, when `HasCompletedExecution` returns true, the poller now cross-checks PR existence via `SearchPRsForIssue` (added in Subtask 1 / 2eb2a15). If no PRs are found → ghost-close path: `InvalidateCompletion` is called and the issue is dispatched normally. If the search errors → safe fallback (assume completed, skip). If PRs exist → normal skip behavior.
- Fixes `TestPoller_SkipsCompletedExecution` to serve a correct search API response so the skip is for the right reason (PR exists). Adds `TestPoller_GhostCloseDetected_AllowsRedispatch` for the full ghost-close path.

Closes #2489. Subtask 2 of #2476.

## Test plan

- [x] `TestPoller_SkipsCompletedExecution` — completed execution + real PR → no dispatch, no invalidation
- [x] `TestPoller_GhostCloseDetected_AllowsRedispatch` — completed execution + no PR → invalidate + dispatch
- [x] `TestPoller_DispatchesWhenNoCompletedExecution` — no completed execution → dispatch as normal
- [x] Full `./internal/adapters/github/...` test suite passes (78s)
- [x] `go build ./...` clean