### PR TITLE
GH-2493: feat(github): add createPilotIssue chokepoint with conventional-title regex gate

### DIFF
--- a/internal/adapters/github/issue_create.go
+++ b/internal/adapters/github/issue_create.go
@@ -1,0 +1,24 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+)
+
+// conventionalCommitRE matches conventional commit titles per the spec used by Pilot.
+var conventionalCommitRE = regexp.MustCompile(`^(feat|fix|chore|refactor|test|docs|perf|build|ci|style)(\([^)]+\))?: .+$`)
+
+// createPilotIssue validates the title against the conventional-commits format and
+// creates a GitHub issue with the given labels. Returns an error if the title does
+// not match or if the API call fails.
+func createPilotIssue(ctx context.Context, c *Client, owner, repo, title, body string, labels []string) (*Issue, error) {
+	if !conventionalCommitRE.MatchString(title) {
+		return nil, fmt.Errorf("issue title %q does not match conventional-commits format (type(scope): description)", title)
+	}
+	return c.CreateIssue(ctx, owner, repo, &IssueInput{
+		Title:  title,
+		Body:   body,
+		Labels: labels,
+	})
+}

--- a/internal/adapters/github/issue_create_test.go
+++ b/internal/adapters/github/issue_create_test.go
@@ -1,0 +1,140 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+func TestConventionalCommitRE(t *testing.T) {
+	accept := []string{
+		"feat: add OAuth login",
+		"fix(auth): handle nil token",
+		"chore(deps): bump go to 1.22",
+		"refactor(executor): extract signal parser",
+		"test(gateway): add integration coverage",
+		"docs(readme): update quick-start",
+		"perf(db): add index on task_id",
+		"build(ci): upgrade golangci-lint",
+		"ci: run tests on pull_request",
+		"style(tui): align column headers",
+	}
+	for _, title := range accept {
+		if !conventionalCommitRE.MatchString(title) {
+			t.Errorf("expected ACCEPT for %q", title)
+		}
+	}
+
+	reject := []string{
+		"",
+		"Add OAuth login",
+		"feat add OAuth login",
+		"feat:",
+		"feat: ",
+		"unknown(scope): do something",
+		"Fix CI failure from PR #123",
+		"feat(: missing closing paren",
+		"FEAT: uppercase type",
+	}
+	for _, title := range reject {
+		if conventionalCommitRE.MatchString(title) {
+			t.Errorf("expected REJECT for %q", title)
+		}
+	}
+}
+
+func TestCreatePilotIssue_TitleValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		title   string
+		wantErr bool
+	}{
+		{"valid feat", "feat(github): add issue helper", false},
+		{"valid fix no scope", "fix: handle nil response", false},
+		{"invalid no type", "add issue helper", true},
+		{"invalid empty", "", true},
+		{"invalid uppercase", "FEAT: something", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Server only needed for non-error cases; validation fires before API call.
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				issue := Issue{Number: 1, Title: tt.title}
+				_, _ = w.Write(mustMarshal(issue))
+			}))
+			defer server.Close()
+
+			c := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			_, err := createPilotIssue(context.Background(), c, "owner", "repo", tt.title, "body", []string{"pilot"})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createPilotIssue(%q) error = %v, wantErr %v", tt.title, err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), "conventional-commits") {
+				t.Errorf("expected conventional-commits mention in error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestCreatePilotIssue_APIForwarding(t *testing.T) {
+	const wantTitle = "feat(github): add createPilotIssue helper"
+	const wantBody = "implements the validation primitive"
+
+	var gotTitle, gotBody string
+	var gotLabels []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/repos/owner/repo/issues" {
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		var input IssueInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		gotTitle = input.Title
+		gotBody = input.Body
+		gotLabels = input.Labels
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		issue := Issue{Number: 42, Title: input.Title, Body: input.Body}
+		_, _ = w.Write(mustMarshal(issue))
+	}))
+	defer server.Close()
+
+	c := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	issue, err := createPilotIssue(context.Background(), c, "owner", "repo", wantTitle, wantBody, []string{"pilot"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if issue.Number != 42 {
+		t.Errorf("issue.Number = %d, want 42", issue.Number)
+	}
+	if gotTitle != wantTitle {
+		t.Errorf("API received title %q, want %q", gotTitle, wantTitle)
+	}
+	if gotBody != wantBody {
+		t.Errorf("API received body %q, want %q", gotBody, wantBody)
+	}
+	if len(gotLabels) != 1 || gotLabels[0] != "pilot" {
+		t.Errorf("API received labels %v, want [pilot]", gotLabels)
+	}
+}
+
+func mustMarshal(v interface{}) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2493.

Closes #2493

## Changes

Create `internal/adapters/github/issue_create.go` exposing a single `createPilotIssue(ctx, repo, title, body, labels)` helper that validates the title against `^(feat|fix|chore|refactor|test|docs|perf|build|ci|style)(\([^)]+\))?: .+$` and returns an error on mismatch. Add unit tests covering accept/reject cases. This is a new file in a different package from the decomposer, has no dependencies on subsequent work, and provides the validation primitive the decomposer subtask will consume.