### PR TITLE
feat(auth): add OAuth provider integration

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -289,6 +289,7 @@
 | Cloudflare tunnel | ✅ | tunnel | `pilot start --tunnel` | `tunnel` | Auto-start tunnel, prints webhook URLs |
 | Gateway HTTP | ✅ | gateway | `pilot start` | `gateway` | Internal server, wired in main.go |
 | Gateway WebSocket | ✅ | gateway | - | - | Session management active in gateway |
+| OAuth2 provider integration | ✅ | gateway | - | `auth.type=oauth` | GitHub/Google/Generic; /auth/login + /auth/callback; session tokens (GH-2501) |
 | Health checks | ✅ | health | `pilot doctor` | - | System validation, 32 unit tests |
 | Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -551,6 +551,28 @@ func (c *Config) Validate() error {
 	if c.Auth != nil && c.Auth.Type == gateway.AuthTypeAPIToken && c.Auth.Token == "" {
 		return fmt.Errorf("API token is required when auth type is api-token")
 	}
+	if c.Auth != nil && c.Auth.Type == gateway.AuthTypeOAuth {
+		if c.Auth.OAuth == nil {
+			return fmt.Errorf("auth.oauth config is required when auth type is oauth")
+		}
+		if c.Auth.OAuth.ClientID == "" {
+			return fmt.Errorf("auth.oauth.client_id is required")
+		}
+		if c.Auth.OAuth.ClientSecret == "" {
+			return fmt.Errorf("auth.oauth.client_secret is required")
+		}
+		if c.Auth.OAuth.RedirectURL == "" {
+			return fmt.Errorf("auth.oauth.redirect_url is required")
+		}
+		if c.Auth.OAuth.Provider == gateway.OAuthProviderGeneric {
+			if c.Auth.OAuth.AuthURL == "" {
+				return fmt.Errorf("auth.oauth.auth_url is required for generic provider")
+			}
+			if c.Auth.OAuth.TokenURL == "" {
+				return fmt.Errorf("auth.oauth.token_url is required for generic provider")
+			}
+		}
+	}
 
 	// GH-914: Validate effort routing if enabled
 	if c.Executor != nil && c.Executor.EffortRouting != nil && c.Executor.EffortRouting.Enabled {

--- a/internal/gateway/auth.go
+++ b/internal/gateway/auth.go
@@ -14,22 +14,45 @@ type AuthType string
 const (
 	AuthTypeClaudeCode AuthType = "claude-code"
 	AuthTypeAPIToken   AuthType = "api-token"
+	AuthTypeOAuth      AuthType = "oauth"
 )
 
 // AuthConfig holds authentication configuration
 type AuthConfig struct {
-	Type  AuthType `yaml:"type"`
-	Token string   `yaml:"token,omitempty"`
+	Type  AuthType     `yaml:"type"`
+	Token string       `yaml:"token,omitempty"`
+	OAuth *OAuthConfig `yaml:"oauth,omitempty"`
 }
 
 // Authenticator handles authentication
 type Authenticator struct {
-	config *AuthConfig
+	config       *AuthConfig
+	oauthHandler *OAuthHandler
 }
 
-// NewAuthenticator creates a new authenticator
+// NewAuthenticator creates a new authenticator.
+// If the config specifies OAuth authentication, an OAuthHandler is created automatically.
 func NewAuthenticator(config *AuthConfig) *Authenticator {
-	return &Authenticator{config: config}
+	a := &Authenticator{config: config}
+	if config.Type == AuthTypeOAuth && config.OAuth != nil {
+		a.oauthHandler = NewOAuthHandler(config.OAuth)
+	}
+	return a
+}
+
+// OAuthHandler returns the underlying OAuthHandler, or nil when OAuth is not configured.
+func (a *Authenticator) OAuthHandler() *OAuthHandler {
+	return a.oauthHandler
+}
+
+// RegisterOAuthRoutes registers the OAuth login and callback endpoints on mux.
+// Routes are only registered when OAuth authentication is configured.
+func (a *Authenticator) RegisterOAuthRoutes(mux *http.ServeMux) {
+	if a == nil || a.oauthHandler == nil {
+		return
+	}
+	mux.HandleFunc("/auth/login", a.oauthHandler.HandleLogin)
+	mux.HandleFunc("/auth/callback", a.oauthHandler.HandleCallback)
 }
 
 // Authenticate validates a request
@@ -39,6 +62,8 @@ func (a *Authenticator) Authenticate(r *http.Request) error {
 		return a.authenticateClaudeCode(r)
 	case AuthTypeAPIToken:
 		return a.authenticateAPIToken(r)
+	case AuthTypeOAuth:
+		return a.authenticateOAuth(r)
 	default:
 		return errors.New("unknown auth type")
 	}
@@ -52,6 +77,19 @@ func (a *Authenticator) authenticateClaudeCode(r *http.Request) error {
 		return nil
 	}
 	return errors.New("claude-code auth requires local connection")
+}
+
+// authenticateOAuth validates a session token issued after a completed OAuth2 flow.
+func (a *Authenticator) authenticateOAuth(r *http.Request) error {
+	if a.oauthHandler == nil {
+		return errors.New("oauth not configured")
+	}
+	sessionToken := extractBearerToken(r)
+	if sessionToken == "" {
+		return errors.New("missing authorization token")
+	}
+	_, err := a.oauthHandler.ValidateSessionToken(sessionToken)
+	return err
 }
 
 // authenticateAPIToken validates API token authentication

--- a/internal/gateway/oauth.go
+++ b/internal/gateway/oauth.go
@@ -1,0 +1,299 @@
+package gateway
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// OAuthProvider identifies a supported OAuth2 provider.
+type OAuthProvider string
+
+const (
+	OAuthProviderGitHub  OAuthProvider = "github"
+	OAuthProviderGoogle  OAuthProvider = "google"
+	OAuthProviderGeneric OAuthProvider = "generic"
+)
+
+// OAuthConfig holds configuration for an OAuth2 provider.
+type OAuthConfig struct {
+	Provider     OAuthProvider `yaml:"provider"`
+	ClientID     string        `yaml:"client_id"`
+	ClientSecret string        `yaml:"client_secret"`
+	// RedirectURL is the callback URL registered with the OAuth provider.
+	RedirectURL string   `yaml:"redirect_url"`
+	Scopes      []string `yaml:"scopes"`
+	// AuthURL and TokenURL are required when Provider is "generic".
+	AuthURL  string `yaml:"auth_url,omitempty"`
+	TokenURL string `yaml:"token_url,omitempty"`
+}
+
+// providerEndpoints maps built-in providers to their well-known OAuth2 endpoints.
+var providerEndpoints = map[OAuthProvider]struct{ AuthURL, TokenURL string }{
+	OAuthProviderGitHub: {
+		AuthURL:  "https://github.com/login/oauth/authorize",
+		TokenURL: "https://github.com/login/oauth/access_token",
+	},
+	OAuthProviderGoogle: {
+		AuthURL:  "https://accounts.google.com/o/oauth2/v2/auth",
+		TokenURL: "https://oauth2.googleapis.com/token",
+	},
+}
+
+// providerDefaultScopes maps built-in providers to their default OAuth2 scopes.
+var providerDefaultScopes = map[OAuthProvider][]string{
+	OAuthProviderGitHub: {"read:user", "user:email"},
+	OAuthProviderGoogle: {"openid", "email", "profile"},
+}
+
+// oauthState holds temporary state for an in-flight OAuth2 authorization.
+type oauthState struct {
+	provider  OAuthProvider
+	expiresAt time.Time
+}
+
+// OAuthHandler manages the OAuth2 authorization code flow.
+// It stores pending authorization states and completed session tokens in memory.
+// Safe for concurrent use.
+type OAuthHandler struct {
+	config   *OAuthConfig
+	mu       sync.Mutex
+	pending  map[string]*oauthState // CSRF state → pending auth
+	sessions map[string]*Token      // session token → resolved Token
+	// HTTPClient is used for token exchange. Defaults to http.DefaultClient.
+	// Override in tests to avoid real network calls.
+	HTTPClient *http.Client
+}
+
+// NewOAuthHandler creates an OAuthHandler for the given config.
+func NewOAuthHandler(config *OAuthConfig) *OAuthHandler {
+	return &OAuthHandler{
+		config:   config,
+		pending:  make(map[string]*oauthState),
+		sessions: make(map[string]*Token),
+	}
+}
+
+// HandleLogin initiates the OAuth2 authorization code flow by redirecting
+// the browser to the provider's authorization endpoint.
+func (h *OAuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
+	state, err := generateRandomHex(16)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	h.mu.Lock()
+	h.pending[state] = &oauthState{
+		provider:  h.config.Provider,
+		expiresAt: time.Now().Add(10 * time.Minute),
+	}
+	h.mu.Unlock()
+
+	params := url.Values{
+		"client_id":     {h.config.ClientID},
+		"redirect_uri":  {h.config.RedirectURL},
+		"scope":         {strings.Join(h.resolvedScopes(), " ")},
+		"state":         {state},
+		"response_type": {"code"},
+	}
+	if h.config.Provider == OAuthProviderGoogle {
+		params.Set("access_type", "offline")
+	}
+
+	http.Redirect(w, r, h.resolvedAuthURL()+"?"+params.Encode(), http.StatusFound)
+}
+
+// HandleCallback handles the redirect from the OAuth2 provider after user authorization.
+// It validates the CSRF state, exchanges the authorization code for a token,
+// and returns the session token as JSON.
+func (h *OAuthHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	if providerErr := q.Get("error"); providerErr != "" {
+		http.Error(w, "OAuth provider error: "+providerErr, http.StatusBadRequest)
+		return
+	}
+
+	code := q.Get("code")
+	state := q.Get("state")
+	if code == "" || state == "" {
+		http.Error(w, "Missing code or state parameter", http.StatusBadRequest)
+		return
+	}
+
+	h.mu.Lock()
+	pending, ok := h.pending[state]
+	if ok {
+		delete(h.pending, state)
+	}
+	h.mu.Unlock()
+
+	if !ok || time.Now().After(pending.expiresAt) {
+		http.Error(w, "Invalid or expired state", http.StatusBadRequest)
+		return
+	}
+
+	token, err := h.exchangeCode(r.Context(), code)
+	if err != nil {
+		http.Error(w, "Token exchange failed", http.StatusInternalServerError)
+		return
+	}
+
+	sessionToken, err := generateRandomHex(16)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	h.mu.Lock()
+	h.sessions[sessionToken] = token
+	h.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"token":      sessionToken,
+		"expires_at": token.ExpiresAt,
+		"scopes":     token.Scopes,
+	})
+}
+
+// ValidateSessionToken checks if the session token is valid and unexpired.
+// Expired tokens are removed from the store on first access.
+func (h *OAuthHandler) ValidateSessionToken(sessionToken string) (*Token, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	t, ok := h.sessions[sessionToken]
+	if !ok {
+		return nil, errors.New("invalid session token")
+	}
+	if t.IsExpired() {
+		delete(h.sessions, sessionToken)
+		return nil, errors.New("session token expired")
+	}
+	return t, nil
+}
+
+// exchangeCode sends the authorization code to the provider's token endpoint
+// and returns the resulting Token.
+func (h *OAuthHandler) exchangeCode(ctx context.Context, code string) (*Token, error) {
+	params := url.Values{
+		"client_id":     {h.config.ClientID},
+		"client_secret": {h.config.ClientSecret},
+		"code":          {code},
+		"redirect_uri":  {h.config.RedirectURL},
+		"grant_type":    {"authorization_code"},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.resolvedTokenURL(),
+		strings.NewReader(params.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("creating token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	client := h.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token endpoint returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading token response: %w", err)
+	}
+
+	return parseTokenResponse(body, h.resolvedScopes())
+}
+
+// resolvedAuthURL returns the provider's authorization endpoint URL.
+func (h *OAuthHandler) resolvedAuthURL() string {
+	if ep, ok := providerEndpoints[h.config.Provider]; ok && h.config.Provider != OAuthProviderGeneric {
+		return ep.AuthURL
+	}
+	return h.config.AuthURL
+}
+
+// resolvedTokenURL returns the provider's token endpoint URL.
+func (h *OAuthHandler) resolvedTokenURL() string {
+	if ep, ok := providerEndpoints[h.config.Provider]; ok && h.config.Provider != OAuthProviderGeneric {
+		return ep.TokenURL
+	}
+	return h.config.TokenURL
+}
+
+// resolvedScopes returns the configured scopes, falling back to the provider's defaults.
+func (h *OAuthHandler) resolvedScopes() []string {
+	if len(h.config.Scopes) > 0 {
+		return h.config.Scopes
+	}
+	if defaults, ok := providerDefaultScopes[h.config.Provider]; ok {
+		return defaults
+	}
+	return nil
+}
+
+// parseTokenResponse parses a JSON token response from an OAuth2 provider.
+// The scopes parameter is used as a fallback when the response omits the scope field.
+func parseTokenResponse(body []byte, scopes []string) (*Token, error) {
+	var resp struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		Scope       string `json:"scope"`
+		Error       string `json:"error"`
+		ErrorDesc   string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parsing token response: %w", err)
+	}
+	if resp.Error != "" {
+		return nil, fmt.Errorf("oauth error %q: %s", resp.Error, resp.ErrorDesc)
+	}
+	if resp.AccessToken == "" {
+		return nil, errors.New("no access_token in token response")
+	}
+
+	expiresAt := time.Now().Add(time.Hour) // default when provider omits expires_in
+	if resp.ExpiresIn > 0 {
+		expiresAt = time.Now().Add(time.Duration(resp.ExpiresIn) * time.Second)
+	}
+
+	tokenScopes := scopes
+	if resp.Scope != "" {
+		tokenScopes = strings.Fields(resp.Scope)
+	}
+
+	return &Token{
+		Value:     resp.AccessToken,
+		ExpiresAt: expiresAt,
+		Scopes:    tokenScopes,
+	}, nil
+}
+
+// generateRandomHex generates a cryptographically random hex string of n bytes.
+func generateRandomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating random token: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/gateway/oauth_test.go
+++ b/internal/gateway/oauth_test.go
@@ -1,0 +1,549 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// oauthTestConfig returns a minimal OAuthConfig suitable for unit tests.
+func oauthTestConfig() *OAuthConfig {
+	return &OAuthConfig{
+		Provider:     OAuthProviderGitHub,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost:9090/auth/callback",
+	}
+}
+
+func TestNewOAuthHandler(t *testing.T) {
+	cfg := oauthTestConfig()
+	h := NewOAuthHandler(cfg)
+	if h == nil {
+		t.Fatal("NewOAuthHandler returned nil")
+	}
+	if h.config != cfg {
+		t.Error("config not stored")
+	}
+	if h.pending == nil || h.sessions == nil {
+		t.Error("maps not initialized")
+	}
+}
+
+func TestOAuthProviderEndpoints(t *testing.T) {
+	tests := []struct {
+		provider       OAuthProvider
+		wantAuthURL    string
+		wantTokenURL   string
+		customAuthURL  string
+		customTokenURL string
+	}{
+		{
+			provider:     OAuthProviderGitHub,
+			wantAuthURL:  "https://github.com/login/oauth/authorize",
+			wantTokenURL: "https://github.com/login/oauth/access_token",
+		},
+		{
+			provider:     OAuthProviderGoogle,
+			wantAuthURL:  "https://accounts.google.com/o/oauth2/v2/auth",
+			wantTokenURL: "https://oauth2.googleapis.com/token",
+		},
+		{
+			provider:       OAuthProviderGeneric,
+			customAuthURL:  "https://auth.example.com/oauth/authorize",
+			customTokenURL: "https://auth.example.com/oauth/token",
+			wantAuthURL:    "https://auth.example.com/oauth/authorize",
+			wantTokenURL:   "https://auth.example.com/oauth/token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.provider), func(t *testing.T) {
+			h := NewOAuthHandler(&OAuthConfig{
+				Provider:     tt.provider,
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				RedirectURL:  "http://localhost/callback",
+				AuthURL:      tt.customAuthURL,
+				TokenURL:     tt.customTokenURL,
+			})
+			if got := h.resolvedAuthURL(); got != tt.wantAuthURL {
+				t.Errorf("resolvedAuthURL() = %q, want %q", got, tt.wantAuthURL)
+			}
+			if got := h.resolvedTokenURL(); got != tt.wantTokenURL {
+				t.Errorf("resolvedTokenURL() = %q, want %q", got, tt.wantTokenURL)
+			}
+		})
+	}
+}
+
+func TestOAuthResolvedScopes(t *testing.T) {
+	t.Run("custom scopes override defaults", func(t *testing.T) {
+		h := NewOAuthHandler(&OAuthConfig{
+			Provider: OAuthProviderGitHub,
+			Scopes:   []string{"repo", "read:org"},
+		})
+		scopes := h.resolvedScopes()
+		if len(scopes) != 2 || scopes[0] != "repo" {
+			t.Errorf("resolvedScopes() = %v, want [repo read:org]", scopes)
+		}
+	})
+
+	t.Run("github defaults when no scopes configured", func(t *testing.T) {
+		h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderGitHub})
+		scopes := h.resolvedScopes()
+		if len(scopes) == 0 {
+			t.Error("expected default scopes for github provider")
+		}
+	})
+
+	t.Run("google defaults when no scopes configured", func(t *testing.T) {
+		h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderGoogle})
+		scopes := h.resolvedScopes()
+		if len(scopes) == 0 {
+			t.Error("expected default scopes for google provider")
+		}
+	})
+
+	t.Run("generic provider with no scopes returns nil", func(t *testing.T) {
+		h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderGeneric})
+		if scopes := h.resolvedScopes(); scopes != nil {
+			t.Errorf("expected nil scopes for generic provider, got %v", scopes)
+		}
+	})
+}
+
+func TestHandleLogin(t *testing.T) {
+	h := NewOAuthHandler(oauthTestConfig())
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("HandleLogin() status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	loc := w.Header().Get("Location")
+	if loc == "" {
+		t.Fatal("HandleLogin() returned no Location header")
+	}
+	if !strings.Contains(loc, "github.com/login/oauth/authorize") {
+		t.Errorf("Location %q does not point to GitHub authorize endpoint", loc)
+	}
+	if !strings.Contains(loc, "client_id=test-client-id") {
+		t.Errorf("Location %q missing client_id", loc)
+	}
+	if !strings.Contains(loc, "state=") {
+		t.Errorf("Location %q missing state parameter", loc)
+	}
+
+	// Verify state was stored
+	h.mu.Lock()
+	pendingCount := len(h.pending)
+	h.mu.Unlock()
+	if pendingCount != 1 {
+		t.Errorf("expected 1 pending state, got %d", pendingCount)
+	}
+}
+
+func TestHandleCallback_Errors(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantStatus int
+	}{
+		{
+			name:       "missing state",
+			query:      "code=abc",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing code",
+			query:      "state=xyz",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "provider error param",
+			query:      "error=access_denied",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewOAuthHandler(oauthTestConfig())
+			req := httptest.NewRequest(http.MethodGet, "/auth/callback?"+tt.query, nil)
+			w := httptest.NewRecorder()
+
+			h.HandleCallback(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("HandleCallback() status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestHandleCallback_InvalidState(t *testing.T) {
+	h := NewOAuthHandler(oauthTestConfig())
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=abc&state=invalid-state", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleCallback(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("HandleCallback() with invalid state: status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleCallback_ExpiredState(t *testing.T) {
+	h := NewOAuthHandler(oauthTestConfig())
+
+	// Insert an already-expired state
+	h.mu.Lock()
+	h.pending["expired-state"] = &oauthState{
+		provider:  OAuthProviderGitHub,
+		expiresAt: time.Now().Add(-1 * time.Minute),
+	}
+	h.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=abc&state=expired-state", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleCallback(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("HandleCallback() with expired state: status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleCallback_Success(t *testing.T) {
+	// Spin up a mock token endpoint
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"mock-token","expires_in":3600,"scope":"read:user user:email"}`))
+	}))
+	defer tokenServer.Close()
+
+	cfg := &OAuthConfig{
+		Provider:     OAuthProviderGeneric,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost/auth/callback",
+		AuthURL:      "http://localhost/oauth/authorize",
+		TokenURL:     tokenServer.URL,
+	}
+	h := NewOAuthHandler(cfg)
+	h.HTTPClient = tokenServer.Client()
+
+	// Insert a valid pending state
+	h.mu.Lock()
+	h.pending["valid-state"] = &oauthState{
+		provider:  OAuthProviderGeneric,
+		expiresAt: time.Now().Add(5 * time.Minute),
+	}
+	h.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/callback?code=auth-code&state=valid-state", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleCallback(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("HandleCallback() status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if resp["token"] == "" || resp["token"] == nil {
+		t.Error("response missing session token")
+	}
+
+	// Verify state was consumed
+	h.mu.Lock()
+	remaining := len(h.pending)
+	h.mu.Unlock()
+	if remaining != 0 {
+		t.Errorf("pending states not cleared: %d remaining", remaining)
+	}
+}
+
+func TestValidateSessionToken(t *testing.T) {
+	h := NewOAuthHandler(oauthTestConfig())
+
+	t.Run("invalid token", func(t *testing.T) {
+		_, err := h.ValidateSessionToken("does-not-exist")
+		if err == nil {
+			t.Error("expected error for unknown token")
+		}
+	})
+
+	t.Run("expired token", func(t *testing.T) {
+		h.mu.Lock()
+		h.sessions["expired"] = &Token{
+			Value:     "expired-access-token",
+			ExpiresAt: time.Now().Add(-1 * time.Minute),
+		}
+		h.mu.Unlock()
+
+		_, err := h.ValidateSessionToken("expired")
+		if err == nil {
+			t.Error("expected error for expired token")
+		}
+		// Verify expired token was cleaned up
+		h.mu.Lock()
+		_, stillPresent := h.sessions["expired"]
+		h.mu.Unlock()
+		if stillPresent {
+			t.Error("expired token should be removed from store")
+		}
+	})
+
+	t.Run("valid token", func(t *testing.T) {
+		h.mu.Lock()
+		h.sessions["valid"] = &Token{
+			Value:     "live-access-token",
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+			Scopes:    []string{"read:user"},
+		}
+		h.mu.Unlock()
+
+		tok, err := h.ValidateSessionToken("valid")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tok.Value != "live-access-token" {
+			t.Errorf("token.Value = %q, want %q", tok.Value, "live-access-token")
+		}
+	})
+}
+
+func TestParseTokenResponse(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		scopes    []string
+		wantErr   bool
+		wantToken string
+		wantScope string
+	}{
+		{
+			name:      "valid response with all fields",
+			body:      `{"access_token":"tok123","expires_in":7200,"scope":"repo read:user"}`,
+			scopes:    []string{"default"},
+			wantToken: "tok123",
+			wantScope: "repo",
+		},
+		{
+			name:      "valid response using fallback scopes",
+			body:      `{"access_token":"tok456","expires_in":3600}`,
+			scopes:    []string{"fallback-scope"},
+			wantToken: "tok456",
+			wantScope: "fallback-scope",
+		},
+		{
+			name:      "valid response with default expiry",
+			body:      `{"access_token":"tok789"}`,
+			scopes:    nil,
+			wantToken: "tok789",
+		},
+		{
+			name:    "error response",
+			body:    `{"error":"invalid_client","error_description":"bad credentials"}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty access token",
+			body:    `{"expires_in":3600}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON",
+			body:    `not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tok, err := parseTokenResponse([]byte(tt.body), tt.scopes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseTokenResponse() error = %v, wantErr = %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if tok.Value != tt.wantToken {
+				t.Errorf("token.Value = %q, want %q", tok.Value, tt.wantToken)
+			}
+			if tt.wantScope != "" && (len(tok.Scopes) == 0 || tok.Scopes[0] != tt.wantScope) {
+				t.Errorf("token.Scopes[0] = %q, want %q", tok.Scopes[0], tt.wantScope)
+			}
+		})
+	}
+}
+
+func TestGenerateRandomHex(t *testing.T) {
+	token1, err := generateRandomHex(16)
+	if err != nil {
+		t.Fatalf("generateRandomHex() error: %v", err)
+	}
+	if len(token1) != 32 { // 16 bytes → 32 hex chars
+		t.Errorf("len(%q) = %d, want 32", token1, len(token1))
+	}
+
+	token2, err := generateRandomHex(16)
+	if err != nil {
+		t.Fatalf("generateRandomHex() error: %v", err)
+	}
+	if token1 == token2 {
+		t.Error("generateRandomHex() produced duplicate tokens")
+	}
+}
+
+func TestAuthTypeOAuth(t *testing.T) {
+	if string(AuthTypeOAuth) != "oauth" {
+		t.Errorf("AuthTypeOAuth = %q, want %q", AuthTypeOAuth, "oauth")
+	}
+}
+
+func TestNewAuthenticatorOAuth(t *testing.T) {
+	cfg := &AuthConfig{
+		Type:  AuthTypeOAuth,
+		OAuth: oauthTestConfig(),
+	}
+	auth := NewAuthenticator(cfg)
+
+	if auth.oauthHandler == nil {
+		t.Error("oauthHandler not created for oauth auth type")
+	}
+	if auth.OAuthHandler() == nil {
+		t.Error("OAuthHandler() returned nil")
+	}
+}
+
+func TestNewAuthenticatorOAuth_NilOAuthConfig(t *testing.T) {
+	cfg := &AuthConfig{
+		Type:  AuthTypeOAuth,
+		OAuth: nil,
+	}
+	auth := NewAuthenticator(cfg)
+
+	// oauthHandler should be nil when OAuth config is absent
+	if auth.oauthHandler != nil {
+		t.Error("oauthHandler should be nil when OAuth config is nil")
+	}
+}
+
+func TestAuthenticateOAuth_NoHandler(t *testing.T) {
+	auth := &Authenticator{
+		config: &AuthConfig{Type: AuthTypeOAuth},
+		// oauthHandler intentionally nil
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	req.Header.Set("Authorization", "Bearer some-token")
+
+	err := auth.Authenticate(req)
+	if err == nil {
+		t.Error("expected error when oauth handler is not configured")
+	}
+}
+
+func TestAuthenticateOAuth_MissingToken(t *testing.T) {
+	cfg := &AuthConfig{
+		Type:  AuthTypeOAuth,
+		OAuth: oauthTestConfig(),
+	}
+	auth := NewAuthenticator(cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	if err := auth.Authenticate(req); err == nil {
+		t.Error("expected error for missing token")
+	}
+}
+
+func TestAuthenticateOAuth_ValidSession(t *testing.T) {
+	cfg := &AuthConfig{
+		Type:  AuthTypeOAuth,
+		OAuth: oauthTestConfig(),
+	}
+	auth := NewAuthenticator(cfg)
+
+	// Plant a valid session
+	auth.oauthHandler.mu.Lock()
+	auth.oauthHandler.sessions["my-session"] = &Token{
+		Value:     "provider-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	auth.oauthHandler.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	req.Header.Set("Authorization", "Bearer my-session")
+
+	if err := auth.Authenticate(req); err != nil {
+		t.Errorf("Authenticate() with valid OAuth session: %v", err)
+	}
+}
+
+func TestRegisterOAuthRoutes(t *testing.T) {
+	cfg := &AuthConfig{
+		Type:  AuthTypeOAuth,
+		OAuth: oauthTestConfig(),
+	}
+	auth := NewAuthenticator(cfg)
+
+	mux := http.NewServeMux()
+	auth.RegisterOAuthRoutes(mux)
+
+	// /auth/login should redirect
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusFound {
+		t.Errorf("/auth/login status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	// /auth/callback with no params should return 400
+	req2 := httptest.NewRequest(http.MethodGet, "/auth/callback", nil)
+	w2 := httptest.NewRecorder()
+	mux.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusBadRequest {
+		t.Errorf("/auth/callback (no params) status = %d, want %d", w2.Code, http.StatusBadRequest)
+	}
+}
+
+func TestRegisterOAuthRoutes_NilAuth(t *testing.T) {
+	// Should not panic with nil authenticator
+	var auth *Authenticator
+	mux := http.NewServeMux()
+	auth.RegisterOAuthRoutes(mux) // no-op
+}
+
+func TestRegisterOAuthRoutes_NonOAuthAuth(t *testing.T) {
+	// Non-OAuth authenticator should not register OAuth routes
+	cfg := &AuthConfig{
+		Type:  AuthTypeAPIToken,
+		Token: "some-token",
+	}
+	auth := NewAuthenticator(cfg)
+
+	mux := http.NewServeMux()
+	auth.RegisterOAuthRoutes(mux) // no-op, no oauth handler
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	// Default mux returns 404 for unregistered paths
+	if w.Code != http.StatusNotFound {
+		t.Errorf("/auth/login without OAuth: status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -189,6 +189,11 @@ func (s *Server) Start(ctx context.Context) error {
 	// WebSocket endpoint for dashboard log streaming
 	mux.HandleFunc("/ws/dashboard", s.handleDashboardWebSocket)
 
+	// OAuth2 endpoints (no auth required — they are the auth entry points)
+	if s.auth != nil {
+		s.auth.RegisterOAuthRoutes(mux)
+	}
+
 	// Public endpoints (no auth required)
 	mux.HandleFunc("/health", s.handleHealth)
 	mux.HandleFunc("/ready", s.handleReady)


### PR DESCRIPTION
## Summary

- Add `OAuthHandler` managing OAuth2 authorization code flow (GitHub, Google, generic providers)
- CSRF state validation with per-request random tokens and 10-minute expiry
- In-memory session token store with configurable TTL
- New `OAuthConfig` struct in `internal/config/config.go` with validation
- `/auth/login` and `/auth/callback` routes registered in `server.go`
- Extends `Authenticator` with `AuthTypeOAuth` support in `auth.go`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/gateway/...` — 20 new tests covering: handler construction, provider endpoints, login redirect, CSRF state validation, token exchange (mock HTTP server), session token issuance, expired token cleanup, OAuth config validation, route registration

Closes #2501