### PR TITLE
feat(auth): add OAuth session logout endpoint

### DIFF
--- a/internal/gateway/auth.go
+++ b/internal/gateway/auth.go
@@ -53,6 +53,7 @@ func (a *Authenticator) RegisterOAuthRoutes(mux *http.ServeMux) {
 	}
 	mux.HandleFunc("/auth/login", a.oauthHandler.HandleLogin)
 	mux.HandleFunc("/auth/callback", a.oauthHandler.HandleCallback)
+	mux.HandleFunc("/auth/logout", a.oauthHandler.HandleLogout)
 }
 
 // Authenticate validates a request

--- a/internal/gateway/oauth.go
+++ b/internal/gateway/oauth.go
@@ -166,6 +166,25 @@ func (h *OAuthHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// RevokeSession invalidates a previously-issued session token.
+// If the token does not exist, RevokeSession is a no-op.
+func (h *OAuthHandler) RevokeSession(sessionToken string) {
+	h.mu.Lock()
+	delete(h.sessions, sessionToken)
+	h.mu.Unlock()
+}
+
+// HandleLogout revokes the session token supplied in the Authorization header
+// and returns 204 No Content. If the token is missing or unknown the handler
+// still returns 204 to avoid leaking session existence information.
+func (h *OAuthHandler) HandleLogout(w http.ResponseWriter, r *http.Request) {
+	token := extractBearerToken(r)
+	if token != "" {
+		h.RevokeSession(token)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // ValidateSessionToken checks if the session token is valid and unexpired.
 // Expired tokens are removed from the store on first access.
 func (h *OAuthHandler) ValidateSessionToken(sessionToken string) (*Token, error) {

--- a/internal/gateway/oauth_test.go
+++ b/internal/gateway/oauth_test.go
@@ -410,6 +410,116 @@ func TestGenerateRandomHex(t *testing.T) {
 	}
 }
 
+func TestRevokeSession(t *testing.T) {
+	h := NewOAuthHandler(oauthTestConfig())
+
+	h.mu.Lock()
+	h.sessions["live-session"] = &Token{
+		Value:     "access-token",
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	h.mu.Unlock()
+
+	// Revoke the session
+	h.RevokeSession("live-session")
+
+	// Token must be gone
+	_, err := h.ValidateSessionToken("live-session")
+	if err == nil {
+		t.Error("expected error after RevokeSession, got nil")
+	}
+
+	// Revoking a non-existent token must not panic
+	h.RevokeSession("does-not-exist")
+}
+
+func TestHandleLogout(t *testing.T) {
+	t.Run("valid session is revoked and returns 204", func(t *testing.T) {
+		h := NewOAuthHandler(oauthTestConfig())
+
+		h.mu.Lock()
+		h.sessions["session-to-revoke"] = &Token{
+			Value:     "access-token",
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		}
+		h.mu.Unlock()
+
+		req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+		req.Header.Set("Authorization", "Bearer session-to-revoke")
+		w := httptest.NewRecorder()
+
+		h.HandleLogout(w, req)
+
+		if w.Code != http.StatusNoContent {
+			t.Errorf("HandleLogout() status = %d, want %d", w.Code, http.StatusNoContent)
+		}
+
+		// Session must be invalidated
+		_, err := h.ValidateSessionToken("session-to-revoke")
+		if err == nil {
+			t.Error("session should be invalid after logout")
+		}
+	})
+
+	t.Run("missing token still returns 204", func(t *testing.T) {
+		h := NewOAuthHandler(oauthTestConfig())
+		req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+		w := httptest.NewRecorder()
+
+		h.HandleLogout(w, req)
+
+		if w.Code != http.StatusNoContent {
+			t.Errorf("HandleLogout() without token: status = %d, want %d", w.Code, http.StatusNoContent)
+		}
+	})
+
+	t.Run("unknown token still returns 204", func(t *testing.T) {
+		h := NewOAuthHandler(oauthTestConfig())
+		req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+		req.Header.Set("Authorization", "Bearer unknown-token")
+		w := httptest.NewRecorder()
+
+		h.HandleLogout(w, req)
+
+		if w.Code != http.StatusNoContent {
+			t.Errorf("HandleLogout() with unknown token: status = %d, want %d", w.Code, http.StatusNoContent)
+		}
+	})
+}
+
+func TestRegisterOAuthRoutes_Logout(t *testing.T) {
+	cfg := &AuthConfig{
+		Type:  AuthTypeOAuth,
+		OAuth: oauthTestConfig(),
+	}
+	auth := NewAuthenticator(cfg)
+
+	// Plant a session to verify logout removes it
+	auth.oauthHandler.mu.Lock()
+	auth.oauthHandler.sessions["revoke-me"] = &Token{
+		Value:     "tok",
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	auth.oauthHandler.mu.Unlock()
+
+	mux := http.NewServeMux()
+	auth.RegisterOAuthRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer revoke-me")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("/auth/logout status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+
+	_, err := auth.oauthHandler.ValidateSessionToken("revoke-me")
+	if err == nil {
+		t.Error("session should be invalid after /auth/logout")
+	}
+}
+
 func TestAuthTypeOAuth(t *testing.T) {
 	if string(AuthTypeOAuth) != "oauth" {
 		t.Errorf("AuthTypeOAuth = %q, want %q", AuthTypeOAuth, "oauth")


### PR DESCRIPTION
## Summary

- Adds `RevokeSession(token string)` method to `OAuthHandler` for programmatic session invalidation
- Adds `HandleLogout` HTTP handler that extracts the bearer token and revokes the session, returning `204 No Content`
- Registers `/auth/logout` on the gateway mux alongside `/auth/login` and `/auth/callback`, completing the OAuth session lifecycle

Returns `204` regardless of whether the token exists to avoid leaking session-existence information.

## Test plan
- [x] `TestRevokeSession` — direct revocation removes token, no-op on missing token
- [x] `TestHandleLogout` — valid session revoked + 204; missing/unknown token → 204 (no info leak)
- [x] `TestRegisterOAuthRoutes_Logout` — end-to-end: route registered, session revoked via HTTP
- [x] Full `./internal/gateway/...` suite passes

Closes #2500