### PR TITLE
feat(auth): add OAuth logout endpoint

### DIFF
--- a/internal/gateway/auth.go
+++ b/internal/gateway/auth.go
@@ -53,6 +53,7 @@ func (a *Authenticator) RegisterOAuthRoutes(mux *http.ServeMux) {
 	}
 	mux.HandleFunc("/auth/login", a.oauthHandler.HandleLogin)
 	mux.HandleFunc("/auth/callback", a.oauthHandler.HandleCallback)
+	mux.HandleFunc("/auth/logout", a.oauthHandler.HandleLogout)
 }
 
 // Authenticate validates a request

--- a/internal/gateway/oauth.go
+++ b/internal/gateway/oauth.go
@@ -183,6 +183,42 @@ func (h *OAuthHandler) ValidateSessionToken(sessionToken string) (*Token, error)
 	return t, nil
 }
 
+// RevokeSessionToken removes a session token from the store, effectively logging out.
+// Returns an error if the token does not exist.
+func (h *OAuthHandler) RevokeSessionToken(sessionToken string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.sessions[sessionToken]; !ok {
+		return errors.New("session token not found")
+	}
+	delete(h.sessions, sessionToken)
+	return nil
+}
+
+// HandleLogout revokes the bearer session token presented in the Authorization header.
+func (h *OAuthHandler) HandleLogout(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	auth := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if len(auth) <= len(prefix) {
+		http.Error(w, "Missing authorization token", http.StatusBadRequest)
+		return
+	}
+	sessionToken := auth[len(prefix):]
+
+	if err := h.RevokeSessionToken(sessionToken); err != nil {
+		http.Error(w, "Invalid session token", http.StatusUnauthorized)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // exchangeCode sends the authorization code to the provider's token endpoint
 // and returns the resulting Token.
 func (h *OAuthHandler) exchangeCode(ctx context.Context, code string) (*Token, error) {

--- a/internal/gateway/oauth_test.go
+++ b/internal/gateway/oauth_test.go
@@ -547,3 +547,113 @@ func TestRegisterOAuthRoutes_NonOAuthAuth(t *testing.T) {
 		t.Errorf("/auth/login without OAuth: status = %d, want %d", w.Code, http.StatusNotFound)
 	}
 }
+
+func TestRevokeSessionToken(t *testing.T) {
+	h := NewOAuthHandler(oauthTestConfig())
+
+	// Seed a session token directly
+	h.mu.Lock()
+	h.sessions["valid-session"] = &Token{
+		Value:     "access-token",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	h.mu.Unlock()
+
+	t.Run("revokes existing token", func(t *testing.T) {
+		if err := h.RevokeSessionToken("valid-session"); err != nil {
+			t.Fatalf("RevokeSessionToken: unexpected error: %v", err)
+		}
+		_, err := h.ValidateSessionToken("valid-session")
+		if err == nil {
+			t.Error("token still valid after revocation")
+		}
+	})
+
+	t.Run("returns error for unknown token", func(t *testing.T) {
+		if err := h.RevokeSessionToken("does-not-exist"); err == nil {
+			t.Error("expected error for unknown token, got nil")
+		}
+	})
+}
+
+func TestHandleLogout(t *testing.T) {
+	h := NewOAuthHandler(oauthTestConfig())
+
+	// Seed a session token directly
+	h.mu.Lock()
+	h.sessions["my-session-token"] = &Token{
+		Value:     "access-token",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	h.mu.Unlock()
+
+	t.Run("POST with valid token returns 204", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+		req.Header.Set("Authorization", "Bearer my-session-token")
+		w := httptest.NewRecorder()
+		h.HandleLogout(w, req)
+		if w.Code != http.StatusNoContent {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusNoContent)
+		}
+		// Token must no longer validate
+		if _, err := h.ValidateSessionToken("my-session-token"); err == nil {
+			t.Error("token still valid after logout")
+		}
+	})
+
+	t.Run("POST with unknown token returns 401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+		req.Header.Set("Authorization", "Bearer unknown-token")
+		w := httptest.NewRecorder()
+		h.HandleLogout(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("POST with no token returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+		w := httptest.NewRecorder()
+		h.HandleLogout(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("GET method returns 405", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/auth/logout", nil)
+		req.Header.Set("Authorization", "Bearer some-token")
+		w := httptest.NewRecorder()
+		h.HandleLogout(w, req)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func TestRegisterOAuthRoutes_Logout(t *testing.T) {
+	cfg := &AuthConfig{
+		Type:  AuthTypeOAuth,
+		OAuth: oauthTestConfig(),
+	}
+	auth := NewAuthenticator(cfg)
+
+	// Seed a session token directly
+	auth.oauthHandler.mu.Lock()
+	auth.oauthHandler.sessions["logout-token"] = &Token{
+		Value:     "access-token",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	auth.oauthHandler.mu.Unlock()
+
+	mux := http.NewServeMux()
+	auth.RegisterOAuthRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer logout-token")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("/auth/logout status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `POST /auth/logout` endpoint to invalidate OAuth2 session tokens
- `OAuthHandler.RevokeSessionToken` removes the token from the in-memory store
- `OAuthHandler.HandleLogout` wraps it as an HTTP handler (204 / 400 / 401 / 405)
- Route registered alongside `/auth/login` and `/auth/callback` in `RegisterOAuthRoutes`

Completes GH-2502 (OAuth provider integration follow-up: logout flow).

## Test plan

- [x] `TestRevokeSessionToken` — revokes existing token, errors on unknown
- [x] `TestHandleLogout` — POST valid token → 204; unknown → 401; no token → 400; GET → 405
- [x] `TestRegisterOAuthRoutes_Logout` — end-to-end route registration
- [x] All existing gateway tests still pass