### PR TITLE
feat(auth): add GitLab OAuth provider integration

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -289,7 +289,7 @@
 | Cloudflare tunnel | ✅ | tunnel | `pilot start --tunnel` | `tunnel` | Auto-start tunnel, prints webhook URLs |
 | Gateway HTTP | ✅ | gateway | `pilot start` | `gateway` | Internal server, wired in main.go |
 | Gateway WebSocket | ✅ | gateway | - | - | Session management active in gateway |
-| OAuth2 provider integration | ✅ | gateway | - | `auth.type=oauth` | GitHub/Google/Generic; /auth/login + /auth/callback; session tokens (v2.109.0, GH-2498) |
+| OAuth2 provider integration | ✅ | gateway | - | `auth.type=oauth` | GitHub/Google/GitLab/Generic; /auth/login + /auth/callback; session tokens; GitLab self-hosted via AuthURL/TokenURL override (v2.110.0, GH-2506) |
 | Health checks | ✅ | health | `pilot doctor` | - | System validation, 32 unit tests |
 | Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -565,6 +565,59 @@ func TestValidate(t *testing.T) {
 			}(),
 			wantErr: false, // Nil auth is allowed
 		},
+		{
+			name: "OAuthGitLab",
+			config: func() *Config {
+				c := DefaultConfig()
+				c.Auth = &gateway.AuthConfig{
+					Type: gateway.AuthTypeOAuth,
+					OAuth: &gateway.OAuthConfig{
+						Provider:     gateway.OAuthProviderGitLab,
+						ClientID:     "gitlab-client-id",
+						ClientSecret: "gitlab-client-secret",
+						RedirectURL:  "http://localhost:9090/auth/callback",
+					},
+				}
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "OAuthGitLabSelfHosted",
+			config: func() *Config {
+				c := DefaultConfig()
+				c.Auth = &gateway.AuthConfig{
+					Type: gateway.AuthTypeOAuth,
+					OAuth: &gateway.OAuthConfig{
+						Provider:     gateway.OAuthProviderGitLab,
+						ClientID:     "gitlab-client-id",
+						ClientSecret: "gitlab-client-secret",
+						RedirectURL:  "http://localhost:9090/auth/callback",
+						AuthURL:      "https://gitlab.mycompany.com/oauth/authorize",
+						TokenURL:     "https://gitlab.mycompany.com/oauth/token",
+					},
+				}
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "OAuthMissingClientID",
+			config: func() *Config {
+				c := DefaultConfig()
+				c.Auth = &gateway.AuthConfig{
+					Type: gateway.AuthTypeOAuth,
+					OAuth: &gateway.OAuthConfig{
+						Provider:     gateway.OAuthProviderGitLab,
+						ClientSecret: "gitlab-client-secret",
+						RedirectURL:  "http://localhost:9090/auth/callback",
+					},
+				}
+				return c
+			}(),
+			wantErr:     true,
+			errContains: "client_id is required",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/gateway/oauth.go
+++ b/internal/gateway/oauth.go
@@ -21,6 +21,7 @@ type OAuthProvider string
 const (
 	OAuthProviderGitHub  OAuthProvider = "github"
 	OAuthProviderGoogle  OAuthProvider = "google"
+	OAuthProviderGitLab  OAuthProvider = "gitlab"
 	OAuthProviderGeneric OAuthProvider = "generic"
 )
 
@@ -38,6 +39,8 @@ type OAuthConfig struct {
 }
 
 // providerEndpoints maps built-in providers to their well-known OAuth2 endpoints.
+// For GitLab, these point to gitlab.com; self-hosted instances should use OAuthProviderGeneric
+// with custom AuthURL/TokenURL, or set AuthURL/TokenURL alongside Provider: "gitlab".
 var providerEndpoints = map[OAuthProvider]struct{ AuthURL, TokenURL string }{
 	OAuthProviderGitHub: {
 		AuthURL:  "https://github.com/login/oauth/authorize",
@@ -47,12 +50,17 @@ var providerEndpoints = map[OAuthProvider]struct{ AuthURL, TokenURL string }{
 		AuthURL:  "https://accounts.google.com/o/oauth2/v2/auth",
 		TokenURL: "https://oauth2.googleapis.com/token",
 	},
+	OAuthProviderGitLab: {
+		AuthURL:  "https://gitlab.com/oauth/authorize",
+		TokenURL: "https://gitlab.com/oauth/token",
+	},
 }
 
 // providerDefaultScopes maps built-in providers to their default OAuth2 scopes.
 var providerDefaultScopes = map[OAuthProvider][]string{
 	OAuthProviderGitHub: {"read:user", "user:email"},
 	OAuthProviderGoogle: {"openid", "email", "profile"},
+	OAuthProviderGitLab: {"read_user", "openid", "email"},
 }
 
 // oauthState holds temporary state for an in-flight OAuth2 authorization.
@@ -245,17 +253,29 @@ func (h *OAuthHandler) exchangeCode(ctx context.Context, code string) (*Token, e
 }
 
 // resolvedAuthURL returns the provider's authorization endpoint URL.
+// For built-in providers, custom AuthURL overrides the default (allows self-hosted GitLab).
 func (h *OAuthHandler) resolvedAuthURL() string {
-	if ep, ok := providerEndpoints[h.config.Provider]; ok && h.config.Provider != OAuthProviderGeneric {
-		return ep.AuthURL
+	if h.config.Provider != OAuthProviderGeneric {
+		if h.config.AuthURL != "" {
+			return h.config.AuthURL
+		}
+		if ep, ok := providerEndpoints[h.config.Provider]; ok {
+			return ep.AuthURL
+		}
 	}
 	return h.config.AuthURL
 }
 
 // resolvedTokenURL returns the provider's token endpoint URL.
+// For built-in providers, custom TokenURL overrides the default (allows self-hosted GitLab).
 func (h *OAuthHandler) resolvedTokenURL() string {
-	if ep, ok := providerEndpoints[h.config.Provider]; ok && h.config.Provider != OAuthProviderGeneric {
-		return ep.TokenURL
+	if h.config.Provider != OAuthProviderGeneric {
+		if h.config.TokenURL != "" {
+			return h.config.TokenURL
+		}
+		if ep, ok := providerEndpoints[h.config.Provider]; ok {
+			return ep.TokenURL
+		}
 	}
 	return h.config.TokenURL
 }

--- a/internal/gateway/oauth_test.go
+++ b/internal/gateway/oauth_test.go
@@ -52,6 +52,11 @@ func TestOAuthProviderEndpoints(t *testing.T) {
 			wantTokenURL: "https://oauth2.googleapis.com/token",
 		},
 		{
+			provider:     OAuthProviderGitLab,
+			wantAuthURL:  "https://gitlab.com/oauth/authorize",
+			wantTokenURL: "https://gitlab.com/oauth/token",
+		},
+		{
 			provider:       OAuthProviderGeneric,
 			customAuthURL:  "https://auth.example.com/oauth/authorize",
 			customTokenURL: "https://auth.example.com/oauth/token",
@@ -80,6 +85,26 @@ func TestOAuthProviderEndpoints(t *testing.T) {
 	}
 }
 
+func TestOAuthGitLabSelfHosted(t *testing.T) {
+	// Self-hosted GitLab overrides default gitlab.com endpoints via AuthURL/TokenURL.
+	customAuth := "https://gitlab.mycompany.com/oauth/authorize"
+	customToken := "https://gitlab.mycompany.com/oauth/token"
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderGitLab,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost/callback",
+		AuthURL:      customAuth,
+		TokenURL:     customToken,
+	})
+	if got := h.resolvedAuthURL(); got != customAuth {
+		t.Errorf("resolvedAuthURL() = %q, want %q (self-hosted override)", got, customAuth)
+	}
+	if got := h.resolvedTokenURL(); got != customToken {
+		t.Errorf("resolvedTokenURL() = %q, want %q (self-hosted override)", got, customToken)
+	}
+}
+
 func TestOAuthResolvedScopes(t *testing.T) {
 	t.Run("custom scopes override defaults", func(t *testing.T) {
 		h := NewOAuthHandler(&OAuthConfig{
@@ -105,6 +130,25 @@ func TestOAuthResolvedScopes(t *testing.T) {
 		scopes := h.resolvedScopes()
 		if len(scopes) == 0 {
 			t.Error("expected default scopes for google provider")
+		}
+	})
+
+	t.Run("gitlab defaults when no scopes configured", func(t *testing.T) {
+		h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderGitLab})
+		scopes := h.resolvedScopes()
+		if len(scopes) == 0 {
+			t.Error("expected default scopes for gitlab provider")
+		}
+		// Verify read_user is included as it's the primary GitLab scope
+		found := false
+		for _, s := range scopes {
+			if s == "read_user" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected read_user in gitlab default scopes, got %v", scopes)
 		}
 	})
 
@@ -148,6 +192,32 @@ func TestHandleLogin(t *testing.T) {
 	h.mu.Unlock()
 	if pendingCount != 1 {
 		t.Errorf("expected 1 pending state, got %d", pendingCount)
+	}
+}
+
+func TestHandleLogin_GitLab(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderGitLab,
+		ClientID:     "test-gitlab-client",
+		ClientSecret: "test-gitlab-secret",
+		RedirectURL:  "http://localhost:9090/auth/callback",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("HandleLogin(gitlab) status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "gitlab.com/oauth/authorize") {
+		t.Errorf("Location %q does not point to GitLab authorize endpoint", loc)
+	}
+	if !strings.Contains(loc, "client_id=test-gitlab-client") {
+		t.Errorf("Location %q missing client_id", loc)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `OAuthProviderGitLab` (`"gitlab"`) as a built-in OAuth2 provider alongside GitHub and Google
- Default endpoints: `https://gitlab.com/oauth/authorize` and `https://gitlab.com/oauth/token`
- Self-hosted GitLab instances override via `auth_url` / `token_url` config fields (no provider change needed)
- Default scopes: `read_user`, `openid`, `email`
- Config validation already allows GitLab without requiring custom URLs (same as GitHub/Google)

## Test plan

- [x] `TestOAuthProviderEndpoints/gitlab` — verifies correct gitlab.com endpoints
- [x] `TestOAuthGitLabSelfHosted` — verifies custom URL override for self-hosted instances
- [x] `TestOAuthResolvedScopes/gitlab_defaults_when_no_scopes_configured` — verifies `read_user` is in defaults
- [x] `TestHandleLogin_GitLab` — verifies login redirect points to gitlab.com
- [x] `TestValidate/OAuthGitLab` — config validates with GitLab provider
- [x] `TestValidate/OAuthGitLabSelfHosted` — config validates with self-hosted URLs
- [x] `TestValidate/OAuthMissingClientID` — config rejects missing client_id
- [x] Build: `go build ./...` passes
- [x] All gateway and config tests pass

Closes #2506