### PR TITLE
feat(auth): add Microsoft and Discord OAuth provider integration

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -289,7 +289,7 @@
 | Cloudflare tunnel | ✅ | tunnel | `pilot start --tunnel` | `tunnel` | Auto-start tunnel, prints webhook URLs |
 | Gateway HTTP | ✅ | gateway | `pilot start` | `gateway` | Internal server, wired in main.go |
 | Gateway WebSocket | ✅ | gateway | - | - | Session management active in gateway |
-| OAuth2 provider integration | ✅ | gateway | - | `auth.type=oauth` | GitHub/Google/GitLab/Generic; /auth/login + /auth/callback; session tokens; GitLab self-hosted via AuthURL/TokenURL override (v2.110.0, GH-2506) |
+| OAuth2 provider integration | ✅ | gateway | - | `auth.type=oauth` | GitHub/Google/GitLab/Microsoft/Discord/Generic; /auth/login + /auth/callback; session tokens; tenant-specific URL override for Microsoft (v2.112.0, GH-2516) |
 | Health checks | ✅ | health | `pilot doctor` | - | System validation, 32 unit tests |
 | Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |

--- a/internal/gateway/oauth.go
+++ b/internal/gateway/oauth.go
@@ -19,10 +19,12 @@ import (
 type OAuthProvider string
 
 const (
-	OAuthProviderGitHub  OAuthProvider = "github"
-	OAuthProviderGoogle  OAuthProvider = "google"
-	OAuthProviderGitLab  OAuthProvider = "gitlab"
-	OAuthProviderGeneric OAuthProvider = "generic"
+	OAuthProviderGitHub    OAuthProvider = "github"
+	OAuthProviderGoogle    OAuthProvider = "google"
+	OAuthProviderGitLab    OAuthProvider = "gitlab"
+	OAuthProviderMicrosoft OAuthProvider = "microsoft"
+	OAuthProviderDiscord   OAuthProvider = "discord"
+	OAuthProviderGeneric   OAuthProvider = "generic"
 )
 
 // OAuthConfig holds configuration for an OAuth2 provider.
@@ -41,6 +43,8 @@ type OAuthConfig struct {
 // providerEndpoints maps built-in providers to their well-known OAuth2 endpoints.
 // For GitLab, these point to gitlab.com; self-hosted instances should use OAuthProviderGeneric
 // with custom AuthURL/TokenURL, or set AuthURL/TokenURL alongside Provider: "gitlab".
+// For Microsoft, these use the "common" tenant; single-tenant apps should set AuthURL/TokenURL
+// with the specific tenant ID (e.g. https://login.microsoftonline.com/{tenant}/oauth2/v2.0/...).
 var providerEndpoints = map[OAuthProvider]struct{ AuthURL, TokenURL string }{
 	OAuthProviderGitHub: {
 		AuthURL:  "https://github.com/login/oauth/authorize",
@@ -54,13 +58,23 @@ var providerEndpoints = map[OAuthProvider]struct{ AuthURL, TokenURL string }{
 		AuthURL:  "https://gitlab.com/oauth/authorize",
 		TokenURL: "https://gitlab.com/oauth/token",
 	},
+	OAuthProviderMicrosoft: {
+		AuthURL:  "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+		TokenURL: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+	},
+	OAuthProviderDiscord: {
+		AuthURL:  "https://discord.com/api/oauth2/authorize",
+		TokenURL: "https://discord.com/api/oauth2/token",
+	},
 }
 
 // providerDefaultScopes maps built-in providers to their default OAuth2 scopes.
 var providerDefaultScopes = map[OAuthProvider][]string{
-	OAuthProviderGitHub: {"read:user", "user:email"},
-	OAuthProviderGoogle: {"openid", "email", "profile"},
-	OAuthProviderGitLab: {"read_user", "openid", "email"},
+	OAuthProviderGitHub:    {"read:user", "user:email"},
+	OAuthProviderGoogle:    {"openid", "email", "profile"},
+	OAuthProviderGitLab:    {"read_user", "openid", "email"},
+	OAuthProviderMicrosoft: {"openid", "email", "profile", "User.Read"},
+	OAuthProviderDiscord:   {"identify", "email"},
 }
 
 // oauthState holds temporary state for an in-flight OAuth2 authorization.
@@ -114,8 +128,11 @@ func (h *OAuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		"state":         {state},
 		"response_type": {"code"},
 	}
-	if h.config.Provider == OAuthProviderGoogle {
+	switch h.config.Provider {
+	case OAuthProviderGoogle:
 		params.Set("access_type", "offline")
+	case OAuthProviderDiscord:
+		params.Set("prompt", "consent")
 	}
 
 	http.Redirect(w, r, h.resolvedAuthURL()+"?"+params.Encode(), http.StatusFound)

--- a/internal/gateway/oauth_test.go
+++ b/internal/gateway/oauth_test.go
@@ -57,6 +57,23 @@ func TestOAuthProviderEndpoints(t *testing.T) {
 			wantTokenURL: "https://gitlab.com/oauth/token",
 		},
 		{
+			provider:     OAuthProviderMicrosoft,
+			wantAuthURL:  "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+			wantTokenURL: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+		},
+		{
+			provider:       OAuthProviderMicrosoft,
+			customAuthURL:  "https://login.microsoftonline.com/mytenant/oauth2/v2.0/authorize",
+			customTokenURL: "https://login.microsoftonline.com/mytenant/oauth2/v2.0/token",
+			wantAuthURL:    "https://login.microsoftonline.com/mytenant/oauth2/v2.0/authorize",
+			wantTokenURL:   "https://login.microsoftonline.com/mytenant/oauth2/v2.0/token",
+		},
+		{
+			provider:     OAuthProviderDiscord,
+			wantAuthURL:  "https://discord.com/api/oauth2/authorize",
+			wantTokenURL: "https://discord.com/api/oauth2/token",
+		},
+		{
 			provider:       OAuthProviderGeneric,
 			customAuthURL:  "https://auth.example.com/oauth/authorize",
 			customTokenURL: "https://auth.example.com/oauth/token",
@@ -152,6 +169,42 @@ func TestOAuthResolvedScopes(t *testing.T) {
 		}
 	})
 
+	t.Run("microsoft defaults when no scopes configured", func(t *testing.T) {
+		h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderMicrosoft})
+		scopes := h.resolvedScopes()
+		if len(scopes) == 0 {
+			t.Error("expected default scopes for microsoft provider")
+		}
+		found := false
+		for _, s := range scopes {
+			if s == "User.Read" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected User.Read in microsoft default scopes, got %v", scopes)
+		}
+	})
+
+	t.Run("discord defaults when no scopes configured", func(t *testing.T) {
+		h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderDiscord})
+		scopes := h.resolvedScopes()
+		if len(scopes) == 0 {
+			t.Error("expected default scopes for discord provider")
+		}
+		found := false
+		for _, s := range scopes {
+			if s == "identify" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected identify in discord default scopes, got %v", scopes)
+		}
+	})
+
 	t.Run("generic provider with no scopes returns nil", func(t *testing.T) {
 		h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderGeneric})
 		if scopes := h.resolvedScopes(); scopes != nil {
@@ -217,6 +270,83 @@ func TestHandleLogin_GitLab(t *testing.T) {
 		t.Errorf("Location %q does not point to GitLab authorize endpoint", loc)
 	}
 	if !strings.Contains(loc, "client_id=test-gitlab-client") {
+		t.Errorf("Location %q missing client_id", loc)
+	}
+}
+
+func TestHandleLogin_Microsoft(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderMicrosoft,
+		ClientID:     "test-ms-client",
+		ClientSecret: "test-ms-secret",
+		RedirectURL:  "http://localhost:9090/auth/callback",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("HandleLogin(microsoft) status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "login.microsoftonline.com/common/oauth2/v2.0/authorize") {
+		t.Errorf("Location %q does not point to Microsoft authorize endpoint", loc)
+	}
+	if !strings.Contains(loc, "client_id=test-ms-client") {
+		t.Errorf("Location %q missing client_id", loc)
+	}
+}
+
+func TestHandleLogin_MicrosoftTenantOverride(t *testing.T) {
+	tenantAuth := "https://login.microsoftonline.com/mytenant/oauth2/v2.0/authorize"
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderMicrosoft,
+		ClientID:     "test-ms-client",
+		ClientSecret: "test-ms-secret",
+		RedirectURL:  "http://localhost:9090/auth/callback",
+		AuthURL:      tenantAuth,
+		TokenURL:     "https://login.microsoftonline.com/mytenant/oauth2/v2.0/token",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	loc := w.Header().Get("Location")
+	if !strings.HasPrefix(loc, tenantAuth) {
+		t.Errorf("Location %q does not start with tenant-specific URL %q", loc, tenantAuth)
+	}
+}
+
+func TestHandleLogin_Discord(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderDiscord,
+		ClientID:     "test-discord-client",
+		ClientSecret: "test-discord-secret",
+		RedirectURL:  "http://localhost:9090/auth/callback",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("HandleLogin(discord) status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "discord.com/api/oauth2/authorize") {
+		t.Errorf("Location %q does not point to Discord authorize endpoint", loc)
+	}
+	if !strings.Contains(loc, "prompt=consent") {
+		t.Errorf("Location %q missing prompt=consent for Discord", loc)
+	}
+	if !strings.Contains(loc, "client_id=test-discord-client") {
 		t.Errorf("Location %q missing client_id", loc)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `OAuthProviderMicrosoft` and `OAuthProviderDiscord` as first-class OAuth2 providers in `internal/gateway/oauth.go`
- Microsoft uses `login.microsoftonline.com/common` multi-tenant endpoints; single-tenant apps can override via `auth_url`/`token_url` (same override mechanism as GitLab self-hosted)
- Discord adds `prompt=consent` to the login redirect so users explicitly re-authorize on each login
- Default scopes: Microsoft `[openid, email, profile, User.Read]`, Discord `[identify, email]`
- 4 new tests: endpoint resolution for both providers, Microsoft tenant URL override, Discord `prompt=consent` param

Closes #2516

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./internal/gateway/...` all pass (including 4 new test cases)
- [ ] `go test ./...` no regressions