### PR TITLE
feat(auth): add Bitbucket OAuth provider integration

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -10,9 +10,18 @@ gateway:
 
 # Authentication
 auth:
-  type: "claude-code"  # "claude-code" (local) or "api-token" (remote)
+  type: "claude-code"  # "claude-code" (local) or "api-token" (remote) or "oauth"
   # token: "sk-ant-..."  # Required if type is "api-token"
   # ANTHROPIC_API_KEY env var enables Claude API features (Haiku subtask parsing, etc.)
+  # OAuth2 — set type: "oauth" and configure the provider below.
+  # Supported providers: github, google, gitlab, microsoft, discord, bitbucket, generic
+  # oauth:
+  #   provider: "bitbucket"
+  #   client_id: "${BITBUCKET_CLIENT_ID}"
+  #   client_secret: "${BITBUCKET_CLIENT_SECRET}"
+  #   redirect_url: "http://localhost:9090/auth/callback"
+  #   # scopes: ["account", "email"]  # optional; defaults applied per provider
+  #   # AuthURL/TokenURL optional — override for Bitbucket Server/Data Center deployments
 
 # Adapters
 adapters:

--- a/internal/gateway/oauth.go
+++ b/internal/gateway/oauth.go
@@ -24,6 +24,7 @@ const (
 	OAuthProviderGitLab    OAuthProvider = "gitlab"
 	OAuthProviderMicrosoft OAuthProvider = "microsoft"
 	OAuthProviderDiscord   OAuthProvider = "discord"
+	OAuthProviderBitbucket OAuthProvider = "bitbucket"
 	OAuthProviderGeneric   OAuthProvider = "generic"
 )
 
@@ -45,6 +46,8 @@ type OAuthConfig struct {
 // with custom AuthURL/TokenURL, or set AuthURL/TokenURL alongside Provider: "gitlab".
 // For Microsoft, these use the "common" tenant; single-tenant apps should set AuthURL/TokenURL
 // with the specific tenant ID (e.g. https://login.microsoftonline.com/{tenant}/oauth2/v2.0/...).
+// For Bitbucket, these point to bitbucket.org (Bitbucket Cloud); Bitbucket Server/Data Center
+// deployments should set AuthURL/TokenURL alongside Provider: "bitbucket".
 var providerEndpoints = map[OAuthProvider]struct{ AuthURL, TokenURL string }{
 	OAuthProviderGitHub: {
 		AuthURL:  "https://github.com/login/oauth/authorize",
@@ -66,6 +69,10 @@ var providerEndpoints = map[OAuthProvider]struct{ AuthURL, TokenURL string }{
 		AuthURL:  "https://discord.com/api/oauth2/authorize",
 		TokenURL: "https://discord.com/api/oauth2/token",
 	},
+	OAuthProviderBitbucket: {
+		AuthURL:  "https://bitbucket.org/site/oauth2/authorize",
+		TokenURL: "https://bitbucket.org/site/oauth2/access_token",
+	},
 }
 
 // providerDefaultScopes maps built-in providers to their default OAuth2 scopes.
@@ -75,6 +82,7 @@ var providerDefaultScopes = map[OAuthProvider][]string{
 	OAuthProviderGitLab:    {"read_user", "openid", "email"},
 	OAuthProviderMicrosoft: {"openid", "email", "profile", "User.Read"},
 	OAuthProviderDiscord:   {"identify", "email"},
+	OAuthProviderBitbucket: {"account", "email"},
 }
 
 // oauthState holds temporary state for an in-flight OAuth2 authorization.

--- a/internal/gateway/oauth_test.go
+++ b/internal/gateway/oauth_test.go
@@ -74,6 +74,18 @@ func TestOAuthProviderEndpoints(t *testing.T) {
 			wantTokenURL: "https://discord.com/api/oauth2/token",
 		},
 		{
+			provider:     OAuthProviderBitbucket,
+			wantAuthURL:  "https://bitbucket.org/site/oauth2/authorize",
+			wantTokenURL: "https://bitbucket.org/site/oauth2/access_token",
+		},
+		{
+			provider:       OAuthProviderBitbucket,
+			customAuthURL:  "https://bitbucket.example.com/rest/oauth2/1.0/authorize",
+			customTokenURL: "https://bitbucket.example.com/rest/oauth2/1.0/token",
+			wantAuthURL:    "https://bitbucket.example.com/rest/oauth2/1.0/authorize",
+			wantTokenURL:   "https://bitbucket.example.com/rest/oauth2/1.0/token",
+		},
+		{
 			provider:       OAuthProviderGeneric,
 			customAuthURL:  "https://auth.example.com/oauth/authorize",
 			customTokenURL: "https://auth.example.com/oauth/token",
@@ -108,6 +120,26 @@ func TestOAuthGitLabSelfHosted(t *testing.T) {
 	customToken := "https://gitlab.mycompany.com/oauth/token"
 	h := NewOAuthHandler(&OAuthConfig{
 		Provider:     OAuthProviderGitLab,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost/callback",
+		AuthURL:      customAuth,
+		TokenURL:     customToken,
+	})
+	if got := h.resolvedAuthURL(); got != customAuth {
+		t.Errorf("resolvedAuthURL() = %q, want %q (self-hosted override)", got, customAuth)
+	}
+	if got := h.resolvedTokenURL(); got != customToken {
+		t.Errorf("resolvedTokenURL() = %q, want %q (self-hosted override)", got, customToken)
+	}
+}
+
+func TestOAuthBitbucketServerSelfHosted(t *testing.T) {
+	// Bitbucket Server/Data Center deployments override bitbucket.org endpoints via AuthURL/TokenURL.
+	customAuth := "https://bitbucket.mycompany.com/rest/oauth2/1.0/authorize"
+	customToken := "https://bitbucket.mycompany.com/rest/oauth2/1.0/token"
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderBitbucket,
 		ClientID:     "test-client-id",
 		ClientSecret: "test-client-secret",
 		RedirectURL:  "http://localhost/callback",
@@ -202,6 +234,24 @@ func TestOAuthResolvedScopes(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("expected identify in discord default scopes, got %v", scopes)
+		}
+	})
+
+	t.Run("bitbucket defaults when no scopes configured", func(t *testing.T) {
+		h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderBitbucket})
+		scopes := h.resolvedScopes()
+		if len(scopes) == 0 {
+			t.Error("expected default scopes for bitbucket provider")
+		}
+		found := false
+		for _, s := range scopes {
+			if s == "account" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected account in bitbucket default scopes, got %v", scopes)
 		}
 	})
 
@@ -348,6 +398,35 @@ func TestHandleLogin_Discord(t *testing.T) {
 	}
 	if !strings.Contains(loc, "client_id=test-discord-client") {
 		t.Errorf("Location %q missing client_id", loc)
+	}
+}
+
+func TestHandleLogin_Bitbucket(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderBitbucket,
+		ClientID:     "test-bitbucket-client",
+		ClientSecret: "test-bitbucket-secret",
+		RedirectURL:  "http://localhost:9090/auth/callback",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("HandleLogin(bitbucket) status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "bitbucket.org/site/oauth2/authorize") {
+		t.Errorf("Location %q does not point to Bitbucket authorize endpoint", loc)
+	}
+	if !strings.Contains(loc, "client_id=test-bitbucket-client") {
+		t.Errorf("Location %q missing client_id", loc)
+	}
+	if !strings.Contains(loc, "state=") {
+		t.Errorf("Location %q missing state parameter", loc)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `OAuthProviderBitbucket` ("bitbucket") constant to the OAuth provider list
- Adds Bitbucket Cloud endpoints: `https://bitbucket.org/site/oauth2/authorize` and `https://bitbucket.org/site/oauth2/access_token`
- Default scopes: `account`, `email` (standard Bitbucket Cloud user identity scopes)
- AuthURL/TokenURL can be overridden for Bitbucket Server/Data Center self-hosted deployments
- Documents Bitbucket as a supported provider in `configs/pilot.example.yaml`

## Test plan

- [x] `TestOAuthProviderEndpoints/bitbucket` — verifies Cloud endpoints
- [x] `TestOAuthProviderEndpoints/bitbucket#01` — verifies custom URL override (self-hosted)
- [x] `TestOAuthBitbucketServerSelfHosted` — verifies Bitbucket Server URL override
- [x] `TestOAuthResolvedScopes/bitbucket_defaults_when_no_scopes_configured` — verifies `account` scope default
- [x] `TestHandleLogin_Bitbucket` — verifies login redirect points to `bitbucket.org`
- [x] All existing gateway tests continue to pass

Closes #2513