### PR TITLE
feat(auth): add Slack and LinkedIn OAuth provider integration

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-05-04 (v2.53.0)
+**Last Updated:** 2026-05-03 (v2.53.0)
 
 ## Legend
 
@@ -289,7 +289,7 @@
 | Cloudflare tunnel | ✅ | tunnel | `pilot start --tunnel` | `tunnel` | Auto-start tunnel, prints webhook URLs |
 | Gateway HTTP | ✅ | gateway | `pilot start` | `gateway` | Internal server, wired in main.go |
 | Gateway WebSocket | ✅ | gateway | - | - | Session management active in gateway |
-| OAuth2 provider integration | ✅ | gateway | - | `auth.type=oauth` | GitHub/Google/GitLab/Microsoft/Discord/Generic; /auth/login + /auth/callback; session tokens; tenant-specific URL override for Microsoft (v2.112.0, GH-2516) |
+| OAuth2 provider integration | ✅ | gateway | - | `auth.type=oauth` | GitHub/Google/GitLab/Microsoft/Discord/Bitbucket/Slack/LinkedIn/Generic; /auth/login + /auth/callback; session tokens; tenant-specific URL override for Microsoft; Slack uses OpenID Connect v2 (v2.113.0, GH-2530) |
 | Health checks | ✅ | health | `pilot doctor` | - | System validation, 32 unit tests |
 | Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |

--- a/internal/gateway/oauth.go
+++ b/internal/gateway/oauth.go
@@ -25,6 +25,8 @@ const (
 	OAuthProviderMicrosoft OAuthProvider = "microsoft"
 	OAuthProviderDiscord   OAuthProvider = "discord"
 	OAuthProviderBitbucket OAuthProvider = "bitbucket"
+	OAuthProviderSlack     OAuthProvider = "slack"
+	OAuthProviderLinkedIn  OAuthProvider = "linkedin"
 	OAuthProviderGeneric   OAuthProvider = "generic"
 )
 
@@ -73,6 +75,17 @@ var providerEndpoints = map[OAuthProvider]struct{ AuthURL, TokenURL string }{
 		AuthURL:  "https://bitbucket.org/site/oauth2/authorize",
 		TokenURL: "https://bitbucket.org/site/oauth2/access_token",
 	},
+	// Slack uses OpenID Connect for "Sign in with Slack" (v2 API).
+	// Workspace-specific installations should use OAuthProviderGeneric with custom AuthURL/TokenURL.
+	OAuthProviderSlack: {
+		AuthURL:  "https://slack.com/openid/connect/authorize",
+		TokenURL: "https://slack.com/api/openid.connect.token",
+	},
+	// LinkedIn uses OpenID Connect for sign-in via the sign_in_with_linkedin_oidc scope.
+	OAuthProviderLinkedIn: {
+		AuthURL:  "https://www.linkedin.com/oauth/v2/authorization",
+		TokenURL: "https://www.linkedin.com/oauth/v2/accessToken",
+	},
 }
 
 // providerDefaultScopes maps built-in providers to their default OAuth2 scopes.
@@ -83,6 +96,8 @@ var providerDefaultScopes = map[OAuthProvider][]string{
 	OAuthProviderMicrosoft: {"openid", "email", "profile", "User.Read"},
 	OAuthProviderDiscord:   {"identify", "email"},
 	OAuthProviderBitbucket: {"account", "email"},
+	OAuthProviderSlack:     {"openid", "email", "profile"},
+	OAuthProviderLinkedIn:  {"openid", "email", "profile"},
 }
 
 // oauthState holds temporary state for an in-flight OAuth2 authorization.

--- a/internal/gateway/oauth_test.go
+++ b/internal/gateway/oauth_test.go
@@ -86,6 +86,16 @@ func TestOAuthProviderEndpoints(t *testing.T) {
 			wantTokenURL:   "https://bitbucket.example.com/rest/oauth2/1.0/token",
 		},
 		{
+			provider:     OAuthProviderSlack,
+			wantAuthURL:  "https://slack.com/openid/connect/authorize",
+			wantTokenURL: "https://slack.com/api/openid.connect.token",
+		},
+		{
+			provider:     OAuthProviderLinkedIn,
+			wantAuthURL:  "https://www.linkedin.com/oauth/v2/authorization",
+			wantTokenURL: "https://www.linkedin.com/oauth/v2/accessToken",
+		},
+		{
 			provider:       OAuthProviderGeneric,
 			customAuthURL:  "https://auth.example.com/oauth/authorize",
 			customTokenURL: "https://auth.example.com/oauth/token",
@@ -252,6 +262,42 @@ func TestOAuthResolvedScopes(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("expected account in bitbucket default scopes, got %v", scopes)
+		}
+	})
+
+	t.Run("slack defaults when no scopes configured", func(t *testing.T) {
+		h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderSlack})
+		scopes := h.resolvedScopes()
+		if len(scopes) == 0 {
+			t.Error("expected default scopes for slack provider")
+		}
+		found := false
+		for _, s := range scopes {
+			if s == "openid" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected openid in slack default scopes, got %v", scopes)
+		}
+	})
+
+	t.Run("linkedin defaults when no scopes configured", func(t *testing.T) {
+		h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderLinkedIn})
+		scopes := h.resolvedScopes()
+		if len(scopes) == 0 {
+			t.Error("expected default scopes for linkedin provider")
+		}
+		found := false
+		for _, s := range scopes {
+			if s == "openid" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected openid in linkedin default scopes, got %v", scopes)
 		}
 	})
 
@@ -423,6 +469,64 @@ func TestHandleLogin_Bitbucket(t *testing.T) {
 		t.Errorf("Location %q does not point to Bitbucket authorize endpoint", loc)
 	}
 	if !strings.Contains(loc, "client_id=test-bitbucket-client") {
+		t.Errorf("Location %q missing client_id", loc)
+	}
+	if !strings.Contains(loc, "state=") {
+		t.Errorf("Location %q missing state parameter", loc)
+	}
+}
+
+func TestHandleLogin_Slack(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderSlack,
+		ClientID:     "test-slack-client",
+		ClientSecret: "test-slack-secret",
+		RedirectURL:  "http://localhost:9090/auth/callback",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("HandleLogin(slack) status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "slack.com/openid/connect/authorize") {
+		t.Errorf("Location %q does not point to Slack authorize endpoint", loc)
+	}
+	if !strings.Contains(loc, "client_id=test-slack-client") {
+		t.Errorf("Location %q missing client_id", loc)
+	}
+	if !strings.Contains(loc, "state=") {
+		t.Errorf("Location %q missing state parameter", loc)
+	}
+}
+
+func TestHandleLogin_LinkedIn(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderLinkedIn,
+		ClientID:     "test-linkedin-client",
+		ClientSecret: "test-linkedin-secret",
+		RedirectURL:  "http://localhost:9090/auth/callback",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("HandleLogin(linkedin) status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "linkedin.com/oauth/v2/authorization") {
+		t.Errorf("Location %q does not point to LinkedIn authorize endpoint", loc)
+	}
+	if !strings.Contains(loc, "client_id=test-linkedin-client") {
 		t.Errorf("Location %q missing client_id", loc)
 	}
 	if !strings.Contains(loc, "state=") {


### PR DESCRIPTION
## Summary

- Add `OAuthProviderSlack` with OpenID Connect v2 endpoints (`slack.com/openid/connect/authorize` + `slack.com/api/openid.connect.token`)
- Add `OAuthProviderLinkedIn` with standard OAuth 2.0 v2 endpoints (`linkedin.com/oauth/v2/authorization` + `linkedin.com/oauth/v2/accessToken`)
- Both providers default to `openid`, `email`, `profile` scopes (consistent with Google/Microsoft)
- Custom `AuthURL`/`TokenURL` override supported for both (same pattern as other providers)

Closes #2530

## Test plan

- [x] `go build ./...` passes
- [x] `TestOAuthProviderEndpoints/slack` and `/linkedin` pass
- [x] `TestOAuthResolvedScopes/slack_defaults` and `/linkedin_defaults` pass
- [x] `TestHandleLogin_Slack` and `TestHandleLogin_LinkedIn` pass
- [x] Full `go test ./internal/gateway/...` passes