### PR TITLE
fix(ci): resolve CI failure from PR #2509

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -602,6 +602,40 @@ func TestValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "OAuthSlack",
+			config: func() *Config {
+				c := DefaultConfig()
+				c.Auth = &gateway.AuthConfig{
+					Type: gateway.AuthTypeOAuth,
+					OAuth: &gateway.OAuthConfig{
+						Provider:     gateway.OAuthProviderSlack,
+						ClientID:     "slack-client-id",
+						ClientSecret: "slack-client-secret",
+						RedirectURL:  "http://localhost:9090/auth/callback",
+					},
+				}
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "OAuthLinkedIn",
+			config: func() *Config {
+				c := DefaultConfig()
+				c.Auth = &gateway.AuthConfig{
+					Type: gateway.AuthTypeOAuth,
+					OAuth: &gateway.OAuthConfig{
+						Provider:     gateway.OAuthProviderLinkedIn,
+						ClientID:     "linkedin-client-id",
+						ClientSecret: "linkedin-client-secret",
+						RedirectURL:  "http://localhost:9090/auth/callback",
+					},
+				}
+				return c
+			}(),
+			wantErr: false,
+		},
+		{
 			name: "OAuthMissingClientID",
 			config: func() *Config {
 				c := DefaultConfig()


### PR DESCRIPTION
## Summary

- **Root cause**: `errcheck` lint violation in `internal/gateway/oauth.go` — `defer resp.Body.Close()` was not assigning the error return value, violating the globally-enabled `errcheck` linter rule
- **Fix**: Changed to `defer func() { _ = resp.Body.Close() }()` (applied in main via PR #2512)
- **Test coverage**: Added config validation tests for `OAuthProviderSlack` and `OAuthProviderLinkedIn` which were missing after those providers were added to the feature set

## Test plan

- [x] `make lint` → 0 issues
- [x] `go build ./...` → no errors
- [x] `go test ./internal/config/...` → all pass including new Slack/LinkedIn validation tests
- [x] `go test ./internal/gateway/...` → all pass

Closes #2511