### PR TITLE
feat(auth): add Facebook and Twitter OAuth provider integration

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -289,7 +289,7 @@
 | Cloudflare tunnel | ✅ | tunnel | `pilot start --tunnel` | `tunnel` | Auto-start tunnel, prints webhook URLs |
 | Gateway HTTP | ✅ | gateway | `pilot start` | `gateway` | Internal server, wired in main.go |
 | Gateway WebSocket | ✅ | gateway | - | - | Session management active in gateway |
-| OAuth2 provider integration | ✅ | gateway | - | `auth.type=oauth` | GitHub/Google/GitLab/Microsoft/Discord/Bitbucket/Slack/LinkedIn/Generic; /auth/login + /auth/callback; session tokens; tenant-specific URL override for Microsoft; Slack uses OpenID Connect v2 (v2.113.0, GH-2530) |
+| OAuth2 provider integration | ✅ | gateway | - | `auth.type=oauth` | GitHub/Google/GitLab/Microsoft/Discord/Bitbucket/Slack/LinkedIn/Facebook/Twitter/Generic; /auth/login + /auth/callback; session tokens; PKCE (S256) for Twitter; tenant override for Microsoft; Slack OpenID Connect v2 (v2.114.1, GH-2522) |
 | Health checks | ✅ | health | `pilot doctor` | - | System validation, 32 unit tests |
 | Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |

--- a/internal/gateway/oauth.go
+++ b/internal/gateway/oauth.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -27,6 +29,8 @@ const (
 	OAuthProviderBitbucket OAuthProvider = "bitbucket"
 	OAuthProviderSlack     OAuthProvider = "slack"
 	OAuthProviderLinkedIn  OAuthProvider = "linkedin"
+	OAuthProviderFacebook  OAuthProvider = "facebook"
+	OAuthProviderTwitter   OAuthProvider = "twitter"
 	OAuthProviderGeneric   OAuthProvider = "generic"
 )
 
@@ -86,6 +90,18 @@ var providerEndpoints = map[OAuthProvider]struct{ AuthURL, TokenURL string }{
 		AuthURL:  "https://www.linkedin.com/oauth/v2/authorization",
 		TokenURL: "https://www.linkedin.com/oauth/v2/accessToken",
 	},
+	// Facebook uses Graph API v19.0 for OAuth2 authorization.
+	// Apps targeting EU users may need to add the openid scope.
+	OAuthProviderFacebook: {
+		AuthURL:  "https://www.facebook.com/v19.0/dialog/oauth",
+		TokenURL: "https://graph.facebook.com/v19.0/oauth/access_token",
+	},
+	// Twitter uses OAuth 2.0 with PKCE for user authentication.
+	// The token endpoint issues short-lived access tokens and optionally refresh tokens.
+	OAuthProviderTwitter: {
+		AuthURL:  "https://twitter.com/i/oauth2/authorize",
+		TokenURL: "https://api.twitter.com/2/oauth2/token",
+	},
 }
 
 // providerDefaultScopes maps built-in providers to their default OAuth2 scopes.
@@ -98,12 +114,15 @@ var providerDefaultScopes = map[OAuthProvider][]string{
 	OAuthProviderBitbucket: {"account", "email"},
 	OAuthProviderSlack:     {"openid", "email", "profile"},
 	OAuthProviderLinkedIn:  {"openid", "email", "profile"},
+	OAuthProviderFacebook:  {"email", "public_profile"},
+	OAuthProviderTwitter:   {"users.read", "tweet.read"},
 }
 
 // oauthState holds temporary state for an in-flight OAuth2 authorization.
 type oauthState struct {
-	provider  OAuthProvider
-	expiresAt time.Time
+	provider     OAuthProvider
+	expiresAt    time.Time
+	codeVerifier string // non-empty when PKCE is used (e.g. Twitter)
 }
 
 // OAuthHandler manages the OAuth2 authorization code flow.
@@ -137,12 +156,10 @@ func (h *OAuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.mu.Lock()
-	h.pending[state] = &oauthState{
+	pending := &oauthState{
 		provider:  h.config.Provider,
 		expiresAt: time.Now().Add(10 * time.Minute),
 	}
-	h.mu.Unlock()
 
 	params := url.Values{
 		"client_id":     {h.config.ClientID},
@@ -156,7 +173,21 @@ func (h *OAuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		params.Set("access_type", "offline")
 	case OAuthProviderDiscord:
 		params.Set("prompt", "consent")
+	case OAuthProviderTwitter:
+		// Twitter OAuth 2.0 requires PKCE (S256 method).
+		verifier, challenge, pkceErr := generatePKCE()
+		if pkceErr != nil {
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		pending.codeVerifier = verifier
+		params.Set("code_challenge", challenge)
+		params.Set("code_challenge_method", "S256")
 	}
+
+	h.mu.Lock()
+	h.pending[state] = pending
+	h.mu.Unlock()
 
 	http.Redirect(w, r, h.resolvedAuthURL()+"?"+params.Encode(), http.StatusFound)
 }
@@ -190,7 +221,7 @@ func (h *OAuthHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := h.exchangeCode(r.Context(), code)
+	token, err := h.exchangeCode(r.Context(), code, pending.codeVerifier)
 	if err != nil {
 		http.Error(w, "Token exchange failed", http.StatusInternalServerError)
 		return
@@ -251,14 +282,17 @@ func (h *OAuthHandler) ValidateSessionToken(sessionToken string) (*Token, error)
 }
 
 // exchangeCode sends the authorization code to the provider's token endpoint
-// and returns the resulting Token.
-func (h *OAuthHandler) exchangeCode(ctx context.Context, code string) (*Token, error) {
+// and returns the resulting Token. codeVerifier is non-empty for PKCE flows (e.g. Twitter).
+func (h *OAuthHandler) exchangeCode(ctx context.Context, code, codeVerifier string) (*Token, error) {
 	params := url.Values{
 		"client_id":     {h.config.ClientID},
 		"client_secret": {h.config.ClientSecret},
 		"code":          {code},
 		"redirect_uri":  {h.config.RedirectURL},
 		"grant_type":    {"authorization_code"},
+	}
+	if codeVerifier != "" {
+		params.Set("code_verifier", codeVerifier)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.resolvedTokenURL(),
@@ -375,4 +409,17 @@ func generateRandomHex(n int) (string, error) {
 		return "", fmt.Errorf("generating random token: %w", err)
 	}
 	return hex.EncodeToString(b), nil
+}
+
+// generatePKCE generates a PKCE code_verifier and its S256 code_challenge.
+// Used for providers that require PKCE (e.g. Twitter OAuth 2.0).
+func generatePKCE() (verifier, challenge string, err error) {
+	b := make([]byte, 32)
+	if _, err = rand.Read(b); err != nil {
+		return "", "", fmt.Errorf("generating PKCE verifier: %w", err)
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(b)
+	h := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(h[:])
+	return verifier, challenge, nil
 }

--- a/internal/gateway/oauth_test.go
+++ b/internal/gateway/oauth_test.go
@@ -96,6 +96,16 @@ func TestOAuthProviderEndpoints(t *testing.T) {
 			wantTokenURL: "https://www.linkedin.com/oauth/v2/accessToken",
 		},
 		{
+			provider:     OAuthProviderFacebook,
+			wantAuthURL:  "https://www.facebook.com/v19.0/dialog/oauth",
+			wantTokenURL: "https://graph.facebook.com/v19.0/oauth/access_token",
+		},
+		{
+			provider:     OAuthProviderTwitter,
+			wantAuthURL:  "https://twitter.com/i/oauth2/authorize",
+			wantTokenURL: "https://api.twitter.com/2/oauth2/token",
+		},
+		{
 			provider:       OAuthProviderGeneric,
 			customAuthURL:  "https://auth.example.com/oauth/authorize",
 			customTokenURL: "https://auth.example.com/oauth/token",
@@ -812,7 +822,7 @@ func TestExchangeCode(t *testing.T) {
 			})
 			h.HTTPClient = srv.Client()
 
-			tok, err := h.exchangeCode(t.Context(), "auth-code")
+			tok, err := h.exchangeCode(t.Context(), "auth-code", "")
 			if tt.wantErr {
 				if err == nil {
 					t.Error("expected error, got nil")
@@ -1092,5 +1102,169 @@ func TestRegisterOAuthRoutes_NonOAuthAuth(t *testing.T) {
 	// Default mux returns 404 for unregistered paths
 	if w.Code != http.StatusNotFound {
 		t.Errorf("/auth/login without OAuth: status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandleLogin_Facebook(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderFacebook,
+		ClientID:     "test-facebook-client",
+		ClientSecret: "test-facebook-secret",
+		RedirectURL:  "http://localhost:9090/auth/callback",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("HandleLogin(facebook) status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "facebook.com/v19.0/dialog/oauth") {
+		t.Errorf("Location %q does not point to Facebook authorize endpoint", loc)
+	}
+	if !strings.Contains(loc, "client_id=test-facebook-client") {
+		t.Errorf("Location %q missing client_id", loc)
+	}
+	if !strings.Contains(loc, "state=") {
+		t.Errorf("Location %q missing state parameter", loc)
+	}
+}
+
+func TestHandleLogin_Twitter(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderTwitter,
+		ClientID:     "test-twitter-client",
+		ClientSecret: "test-twitter-secret",
+		RedirectURL:  "http://localhost:9090/auth/callback",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("HandleLogin(twitter) status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "twitter.com/i/oauth2/authorize") {
+		t.Errorf("Location %q does not point to Twitter authorize endpoint", loc)
+	}
+	if !strings.Contains(loc, "client_id=test-twitter-client") {
+		t.Errorf("Location %q missing client_id", loc)
+	}
+	if !strings.Contains(loc, "state=") {
+		t.Errorf("Location %q missing state parameter", loc)
+	}
+	if !strings.Contains(loc, "code_challenge=") {
+		t.Errorf("Location %q missing PKCE code_challenge for Twitter", loc)
+	}
+	if !strings.Contains(loc, "code_challenge_method=S256") {
+		t.Errorf("Location %q missing code_challenge_method=S256 for Twitter", loc)
+	}
+
+	// Verify state was stored with a code_verifier
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, s := range h.pending {
+		if s.codeVerifier == "" {
+			t.Error("Twitter pending state missing codeVerifier")
+		}
+	}
+}
+
+func TestOAuthProviderEndpoints_Facebook(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderFacebook,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost/callback",
+	})
+	if got := h.resolvedAuthURL(); got != "https://www.facebook.com/v19.0/dialog/oauth" {
+		t.Errorf("resolvedAuthURL() = %q, want Facebook authorize URL", got)
+	}
+	if got := h.resolvedTokenURL(); got != "https://graph.facebook.com/v19.0/oauth/access_token" {
+		t.Errorf("resolvedTokenURL() = %q, want Facebook token URL", got)
+	}
+}
+
+func TestOAuthProviderEndpoints_Twitter(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderTwitter,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost/callback",
+	})
+	if got := h.resolvedAuthURL(); got != "https://twitter.com/i/oauth2/authorize" {
+		t.Errorf("resolvedAuthURL() = %q, want Twitter authorize URL", got)
+	}
+	if got := h.resolvedTokenURL(); got != "https://api.twitter.com/2/oauth2/token" {
+		t.Errorf("resolvedTokenURL() = %q, want Twitter token URL", got)
+	}
+}
+
+func TestOAuthResolvedScopes_Facebook(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderFacebook})
+	scopes := h.resolvedScopes()
+	if len(scopes) == 0 {
+		t.Error("expected default scopes for facebook provider")
+	}
+	found := false
+	for _, s := range scopes {
+		if s == "email" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected email in facebook default scopes, got %v", scopes)
+	}
+}
+
+func TestOAuthResolvedScopes_Twitter(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderTwitter})
+	scopes := h.resolvedScopes()
+	if len(scopes) == 0 {
+		t.Error("expected default scopes for twitter provider")
+	}
+	found := false
+	for _, s := range scopes {
+		if s == "users.read" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected users.read in twitter default scopes, got %v", scopes)
+	}
+}
+
+func TestGeneratePKCE(t *testing.T) {
+	verifier, challenge, err := generatePKCE()
+	if err != nil {
+		t.Fatalf("generatePKCE() error: %v", err)
+	}
+	if verifier == "" {
+		t.Error("expected non-empty verifier")
+	}
+	if challenge == "" {
+		t.Error("expected non-empty challenge")
+	}
+	if verifier == challenge {
+		t.Error("verifier and challenge should differ")
+	}
+
+	// Two calls must produce distinct verifiers
+	v2, c2, err := generatePKCE()
+	if err != nil {
+		t.Fatalf("generatePKCE() second call error: %v", err)
+	}
+	if verifier == v2 || challenge == c2 {
+		t.Error("generatePKCE() produced duplicate values")
 	}
 }


### PR DESCRIPTION
## Summary

- Add `OAuthProviderFacebook` and `OAuthProviderTwitter` constants to the OAuth provider enum
- Register Facebook Graph API v19.0 endpoints and Twitter OAuth 2.0 endpoints in `providerEndpoints`
- Add default scopes: `email`, `public_profile` (Facebook) and `users.read`, `tweet.read` (Twitter)
- Implement PKCE (S256 method) for Twitter's mandatory code challenge requirement — generates verifier/challenge pair in `HandleLogin`, passes verifier through `oauthState.codeVerifier` to `exchangeCode`
- Add `generatePKCE` helper using `crypto/sha256` + `base64.RawURLEncoding`

## Test plan

- [ ] `TestHandleLogin_Facebook` — verifies redirect to Facebook authorize endpoint with correct client_id and state
- [ ] `TestHandleLogin_Twitter` — verifies redirect with PKCE `code_challenge` and `code_challenge_method=S256`, and that `codeVerifier` is stored in pending state
- [ ] `TestOAuthProviderEndpoints_Facebook` / `TestOAuthProviderEndpoints_Twitter` — verify resolved auth/token URLs
- [ ] `TestOAuthResolvedScopes_Facebook` / `TestOAuthResolvedScopes_Twitter` — verify default scope sets
- [ ] `TestGeneratePKCE` — verifies non-empty, distinct verifier/challenge pairs across calls
- [ ] `TestOAuthProviderEndpoints` table test covers Facebook and Twitter entries
- [ ] All gateway tests pass: `go test ./internal/gateway/...`

Closes #2522