### PR TITLE
feat(auth): add Apple and Spotify OAuth provider integration

### DIFF
--- a/internal/gateway/oauth.go
+++ b/internal/gateway/oauth.go
@@ -31,6 +31,8 @@ const (
 	OAuthProviderLinkedIn  OAuthProvider = "linkedin"
 	OAuthProviderFacebook  OAuthProvider = "facebook"
 	OAuthProviderTwitter   OAuthProvider = "twitter"
+	OAuthProviderApple     OAuthProvider = "apple"
+	OAuthProviderSpotify   OAuthProvider = "spotify"
 	OAuthProviderGeneric   OAuthProvider = "generic"
 )
 
@@ -102,6 +104,21 @@ var providerEndpoints = map[OAuthProvider]struct{ AuthURL, TokenURL string }{
 		AuthURL:  "https://twitter.com/i/oauth2/authorize",
 		TokenURL: "https://api.twitter.com/2/oauth2/token",
 	},
+	// Apple uses Sign in with Apple (SIWA) with OpenID Connect.
+	// Client secrets must be JWT-signed with an Apple private key; this provider handles
+	// the standard authorization redirect and token exchange steps only.
+	// Web flows that need the user's name/email in the first response should add
+	// response_mode=form_post via a custom AuthURL.
+	OAuthProviderApple: {
+		AuthURL:  "https://appleid.apple.com/auth/authorize",
+		TokenURL: "https://appleid.apple.com/auth/token",
+	},
+	// Spotify uses OAuth 2.0 with standard authorization code flow.
+	// Refresh tokens are long-lived; access tokens expire after 1 hour.
+	OAuthProviderSpotify: {
+		AuthURL:  "https://accounts.spotify.com/authorize",
+		TokenURL: "https://accounts.spotify.com/api/token",
+	},
 }
 
 // providerDefaultScopes maps built-in providers to their default OAuth2 scopes.
@@ -116,6 +133,8 @@ var providerDefaultScopes = map[OAuthProvider][]string{
 	OAuthProviderLinkedIn:  {"openid", "email", "profile"},
 	OAuthProviderFacebook:  {"email", "public_profile"},
 	OAuthProviderTwitter:   {"users.read", "tweet.read"},
+	OAuthProviderApple:     {"openid", "name", "email"},
+	OAuthProviderSpotify:   {"user-read-email", "user-read-private"},
 }
 
 // oauthState holds temporary state for an in-flight OAuth2 authorization.

--- a/internal/gateway/oauth_test.go
+++ b/internal/gateway/oauth_test.go
@@ -106,6 +106,16 @@ func TestOAuthProviderEndpoints(t *testing.T) {
 			wantTokenURL: "https://api.twitter.com/2/oauth2/token",
 		},
 		{
+			provider:     OAuthProviderApple,
+			wantAuthURL:  "https://appleid.apple.com/auth/authorize",
+			wantTokenURL: "https://appleid.apple.com/auth/token",
+		},
+		{
+			provider:     OAuthProviderSpotify,
+			wantAuthURL:  "https://accounts.spotify.com/authorize",
+			wantTokenURL: "https://accounts.spotify.com/api/token",
+		},
+		{
 			provider:       OAuthProviderGeneric,
 			customAuthURL:  "https://auth.example.com/oauth/authorize",
 			customTokenURL: "https://auth.example.com/oauth/token",
@@ -1242,6 +1252,166 @@ func TestOAuthResolvedScopes_Twitter(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected users.read in twitter default scopes, got %v", scopes)
+	}
+}
+
+func TestHandleLogin_Apple(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderApple,
+		ClientID:     "test-apple-client",
+		ClientSecret: "test-apple-secret",
+		RedirectURL:  "http://localhost:9090/auth/callback",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("HandleLogin(apple) status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "appleid.apple.com/auth/authorize") {
+		t.Errorf("Location %q does not point to Apple authorize endpoint", loc)
+	}
+	if !strings.Contains(loc, "client_id=test-apple-client") {
+		t.Errorf("Location %q missing client_id", loc)
+	}
+	if !strings.Contains(loc, "state=") {
+		t.Errorf("Location %q missing state parameter", loc)
+	}
+}
+
+func TestHandleLogin_Spotify(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderSpotify,
+		ClientID:     "test-spotify-client",
+		ClientSecret: "test-spotify-secret",
+		RedirectURL:  "http://localhost:9090/auth/callback",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/auth/login", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Errorf("HandleLogin(spotify) status = %d, want %d", w.Code, http.StatusFound)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "accounts.spotify.com/authorize") {
+		t.Errorf("Location %q does not point to Spotify authorize endpoint", loc)
+	}
+	if !strings.Contains(loc, "client_id=test-spotify-client") {
+		t.Errorf("Location %q missing client_id", loc)
+	}
+	if !strings.Contains(loc, "state=") {
+		t.Errorf("Location %q missing state parameter", loc)
+	}
+}
+
+func TestOAuthProviderEndpoints_Apple(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderApple,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost/callback",
+	})
+	if got := h.resolvedAuthURL(); got != "https://appleid.apple.com/auth/authorize" {
+		t.Errorf("resolvedAuthURL() = %q, want Apple authorize URL", got)
+	}
+	if got := h.resolvedTokenURL(); got != "https://appleid.apple.com/auth/token" {
+		t.Errorf("resolvedTokenURL() = %q, want Apple token URL", got)
+	}
+}
+
+func TestOAuthProviderEndpoints_Spotify(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{
+		Provider:     OAuthProviderSpotify,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost/callback",
+	})
+	if got := h.resolvedAuthURL(); got != "https://accounts.spotify.com/authorize" {
+		t.Errorf("resolvedAuthURL() = %q, want Spotify authorize URL", got)
+	}
+	if got := h.resolvedTokenURL(); got != "https://accounts.spotify.com/api/token" {
+		t.Errorf("resolvedTokenURL() = %q, want Spotify token URL", got)
+	}
+}
+
+func TestOAuthResolvedScopes_Apple(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderApple})
+	scopes := h.resolvedScopes()
+	if len(scopes) == 0 {
+		t.Error("expected default scopes for apple provider")
+	}
+	found := false
+	for _, s := range scopes {
+		if s == "email" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected email in apple default scopes, got %v", scopes)
+	}
+}
+
+func TestOAuthResolvedScopes_Spotify(t *testing.T) {
+	h := NewOAuthHandler(&OAuthConfig{Provider: OAuthProviderSpotify})
+	scopes := h.resolvedScopes()
+	if len(scopes) == 0 {
+		t.Error("expected default scopes for spotify provider")
+	}
+	found := false
+	for _, s := range scopes {
+		if s == "user-read-email" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected user-read-email in spotify default scopes, got %v", scopes)
+	}
+}
+
+func TestOAuthProviderEndpoints_TableAppleSpotify(t *testing.T) {
+	tests := []struct {
+		provider     OAuthProvider
+		wantAuthURL  string
+		wantTokenURL string
+	}{
+		{
+			provider:     OAuthProviderApple,
+			wantAuthURL:  "https://appleid.apple.com/auth/authorize",
+			wantTokenURL: "https://appleid.apple.com/auth/token",
+		},
+		{
+			provider:     OAuthProviderSpotify,
+			wantAuthURL:  "https://accounts.spotify.com/authorize",
+			wantTokenURL: "https://accounts.spotify.com/api/token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.provider), func(t *testing.T) {
+			h := NewOAuthHandler(&OAuthConfig{
+				Provider:     tt.provider,
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				RedirectURL:  "http://localhost/callback",
+			})
+			if got := h.resolvedAuthURL(); got != tt.wantAuthURL {
+				t.Errorf("resolvedAuthURL() = %q, want %q", got, tt.wantAuthURL)
+			}
+			if got := h.resolvedTokenURL(); got != tt.wantTokenURL {
+				t.Errorf("resolvedTokenURL() = %q, want %q", got, tt.wantTokenURL)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `OAuthProviderApple` and `OAuthProviderSpotify` constants to the OAuth provider set
- Register Sign in with Apple (SIWA) endpoints: `appleid.apple.com/auth/authorize` + `appleid.apple.com/auth/token`
- Register Spotify OAuth 2.0 endpoints: `accounts.spotify.com/authorize` + `accounts.spotify.com/api/token`
- Default scopes: `openid name email` (Apple), `user-read-email user-read-private` (Spotify)
- All new providers covered by tests: `HandleLogin`, endpoint resolution, and default scope assertions

Closes #2525

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/gateway/...` passes (all existing + new tests)
- [x] `TestHandleLogin_Apple` — redirect hits `appleid.apple.com/auth/authorize`
- [x] `TestHandleLogin_Spotify` — redirect hits `accounts.spotify.com/authorize`
- [x] `TestOAuthProviderEndpoints_Apple/Spotify` — URL resolution verified
- [x] `TestOAuthResolvedScopes_Apple/Spotify` — default scopes verified
- [x] `TestOAuthProviderEndpoints_TableAppleSpotify` — table test covers both providers