### PR TITLE
fix(upgrade): cherry-pick atomic binary replacement from PR #2465

### DIFF
--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -409,6 +409,55 @@ func (u *Upgrader) installBinary(downloadPath string) error {
 	return nil
 }
 
+// installToBinaryPath writes a new binary beside the current executable and
+// swaps it into place once the write completes. This avoids truncating a
+// running executable on Unix-like systems, which returns ETXTBSY.
+func (u *Upgrader) installToBinaryPath(write func(io.Writer) error) error {
+	dir := filepath.Dir(u.binaryPath)
+	tempFile, err := os.CreateTemp(dir, ".pilot-install-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp binary: %w", err)
+	}
+
+	tempPath := tempFile.Name()
+	closed := false
+	cleanup := true
+	defer func() {
+		if !closed {
+			_ = tempFile.Close()
+		}
+		if cleanup {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if err := tempFile.Chmod(0755); err != nil {
+		return fmt.Errorf("failed to set temp binary permissions: %w", err)
+	}
+
+	if err := write(tempFile); err != nil {
+		return err
+	}
+
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("failed to close binary: %w", err)
+	}
+	closed = true
+
+	if runtime.GOOS == "windows" {
+		if err := os.Remove(u.binaryPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove existing binary: %w", err)
+		}
+	}
+
+	if err := os.Rename(tempPath, u.binaryPath); err != nil {
+		return fmt.Errorf("failed to replace binary: %w", err)
+	}
+
+	cleanup = false
+	return nil
+}
+
 // isTarGz checks if a file is a gzipped tarball
 func (u *Upgrader) isTarGz(path string) bool {
 	f, err := os.Open(path)
@@ -471,24 +520,12 @@ func (u *Upgrader) installFromTarGz(tarPath string) error {
 		baseName := filepath.Base(header.Name)
 		if header.Typeflag == tar.TypeReg &&
 			(baseName == "pilot" || baseName == "pilot.exe") {
-
-			// Extract to binary path
-			out, err := os.OpenFile(u.binaryPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
-			if err != nil {
-				return fmt.Errorf("failed to create binary: %w", err)
-			}
-
-			_, copyErr := io.Copy(out, tr)
-			closeErr := out.Close()
-
-			if copyErr != nil {
-				return fmt.Errorf("failed to extract binary: %w", copyErr)
-			}
-			if closeErr != nil {
-				return fmt.Errorf("failed to close binary: %w", closeErr)
-			}
-
-			return nil
+			return u.installToBinaryPath(func(out io.Writer) error {
+				if _, err := io.Copy(out, tr); err != nil {
+					return fmt.Errorf("failed to extract binary: %w", err)
+				}
+				return nil
+			})
 		}
 	}
 }
@@ -513,25 +550,14 @@ func (u *Upgrader) installFromZip(zipPath string) error {
 			if err != nil {
 				return fmt.Errorf("failed to open zip entry: %w", err)
 			}
+			defer func() { _ = rc.Close() }()
 
-			out, err := os.OpenFile(u.binaryPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
-			if err != nil {
-				_ = rc.Close()
-				return fmt.Errorf("failed to create binary: %w", err)
-			}
-
-			_, copyErr := io.Copy(out, rc)
-			closeErr := out.Close()
-			_ = rc.Close()
-
-			if copyErr != nil {
-				return fmt.Errorf("failed to extract binary: %w", copyErr)
-			}
-			if closeErr != nil {
-				return fmt.Errorf("failed to close binary: %w", closeErr)
-			}
-
-			return nil
+			return u.installToBinaryPath(func(out io.Writer) error {
+				if _, err := io.Copy(out, rc); err != nil {
+					return fmt.Errorf("failed to extract binary: %w", err)
+				}
+				return nil
+			})
 		}
 	}
 
@@ -546,17 +572,12 @@ func (u *Upgrader) installDirectBinary(srcPath string) error {
 	}
 	defer func() { _ = src.Close() }()
 
-	dst, err := os.OpenFile(u.binaryPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
-	if err != nil {
-		return fmt.Errorf("failed to create binary: %w", err)
-	}
-	defer func() { _ = dst.Close() }()
-
-	if _, err := io.Copy(dst, src); err != nil {
-		return fmt.Errorf("failed to copy binary: %w", err)
-	}
-
-	return nil
+	return u.installToBinaryPath(func(dst io.Writer) error {
+		if _, err := io.Copy(dst, src); err != nil {
+			return fmt.Errorf("failed to copy binary: %w", err)
+		}
+		return nil
+	})
 }
 
 // compareVersions compares two semantic versions

--- a/internal/upgrade/upgrade_critical_test.go
+++ b/internal/upgrade/upgrade_critical_test.go
@@ -5,7 +5,9 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -427,6 +429,82 @@ func TestInstallDirectBinary_Success(t *testing.T) {
 	info, _ := os.Stat(binPath)
 	if info.Mode()&0755 != 0755 {
 		t.Errorf("permissions = %o, want 0755", info.Mode()&os.ModePerm)
+	}
+}
+
+func TestInstallDirectBinary_ReplacesExistingBinaryAtomically(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "downloaded")
+	binPath := filepath.Join(dir, "pilot")
+
+	if err := os.WriteFile(srcPath, []byte("new-binary"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binPath, []byte("old-binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	before, err := os.Stat(binPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	u := &Upgrader{binaryPath: binPath}
+	if err := u.installDirectBinary(srcPath); err != nil {
+		t.Fatalf("installDirectBinary() error = %v", err)
+	}
+
+	got, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatalf("failed to read installed binary: %v", err)
+	}
+	if string(got) != "new-binary" {
+		t.Errorf("content = %q, want %q", got, "new-binary")
+	}
+
+	after, err := os.Stat(binPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(before, after) {
+		t.Fatal("installDirectBinary() rewrote existing inode, want atomic replacement")
+	}
+}
+
+func TestInstallToBinaryPath_CleansUpTempOnWriterError(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "pilot")
+	if err := os.WriteFile(binPath, []byte("old-binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	u := &Upgrader{binaryPath: binPath}
+	errBoom := fmt.Errorf("boom")
+	err := u.installToBinaryPath(func(out io.Writer) error {
+		_, _ = out.Write([]byte("partial"))
+		return errBoom
+	})
+	if err == nil {
+		t.Fatal("installToBinaryPath() expected error, got nil")
+	}
+	if !errors.Is(err, errBoom) {
+		t.Fatalf("installToBinaryPath() error = %v, want wrapped %v", err, errBoom)
+	}
+
+	got, readErr := os.ReadFile(binPath)
+	if readErr != nil {
+		t.Fatalf("failed to read existing binary: %v", readErr)
+	}
+	if string(got) != "old-binary" {
+		t.Errorf("content = %q, want %q", got, "old-binary")
+	}
+
+	matches, globErr := filepath.Glob(filepath.Join(dir, ".pilot-install-*"))
+	if globErr != nil {
+		t.Fatalf("glob temp files: %v", globErr)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temp install files left behind: %v", matches)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Cherry-picks commit `d2e9250` from PR #2465 (community contribution by @myagizmaktav)
- Replaces truncate-in-place binary install with temp-file-write + atomic `os.Rename` pattern
- Fixes `ETXTBSY` on Linux when replacing a running executable during self-upgrade

## Changes
- `internal/upgrade/upgrade.go`: atomic rename-based replacement (+69/-48)
- `internal/upgrade/upgrade_critical_test.go`: two new tests (+78)

## Tests
- `TestInstallDirectBinary_ReplacesExistingBinaryAtomically` ✅
- `TestInstallToBinaryPath_CleansUpTempOnWriterError` ✅

Closes #2464
Co-authored-by: Mehmet Yağız Maktav <myagizmaktav@gmail.com>