### PR TITLE
GH-2564: fix(upgrade): detect truncated writes in installToBinaryPath

### DIFF
--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -441,6 +441,48 @@ func (u *Upgrader) isZip(path string) bool {
 	return buf[0] == 0x50 && buf[1] == 0x4b && buf[2] == 0x03 && buf[3] == 0x04
 }
 
+// installToBinaryPath atomically installs a new binary using a temp file and rename.
+// expectedSize is the expected byte count of the written content; pass 0 to skip the check.
+// write is called with an open file to receive the binary content.
+func (u *Upgrader) installToBinaryPath(expectedSize int64, write func(w io.Writer) error) error {
+	dir := filepath.Dir(u.binaryPath)
+	tmp, err := os.CreateTemp(dir, ".pilot-upgrade-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if err := tmp.Chmod(0755); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to chmod temp file: %w", err)
+	}
+
+	writeErr := write(tmp)
+	closeErr := tmp.Close()
+	if writeErr != nil {
+		return fmt.Errorf("failed to write binary: %w", writeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("failed to close temp file: %w", closeErr)
+	}
+
+	if expectedSize > 0 {
+		info, err := os.Stat(tmpName)
+		if err != nil {
+			return fmt.Errorf("failed to stat temp file: %w", err)
+		}
+		if info.Size() != expectedSize {
+			return fmt.Errorf("truncated write: expected %d bytes, got %d", expectedSize, info.Size())
+		}
+	}
+
+	if err := os.Rename(tmpName, u.binaryPath); err != nil {
+		return fmt.Errorf("failed to install binary: %w", err)
+	}
+	return nil
+}
+
 // installFromTarGz extracts and installs from a tarball
 func (u *Upgrader) installFromTarGz(tarPath string) error {
 	f, err := os.Open(tarPath)
@@ -472,23 +514,10 @@ func (u *Upgrader) installFromTarGz(tarPath string) error {
 		if header.Typeflag == tar.TypeReg &&
 			(baseName == "pilot" || baseName == "pilot.exe") {
 
-			// Extract to binary path
-			out, err := os.OpenFile(u.binaryPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
-			if err != nil {
-				return fmt.Errorf("failed to create binary: %w", err)
-			}
-
-			_, copyErr := io.Copy(out, tr)
-			closeErr := out.Close()
-
-			if copyErr != nil {
-				return fmt.Errorf("failed to extract binary: %w", copyErr)
-			}
-			if closeErr != nil {
-				return fmt.Errorf("failed to close binary: %w", closeErr)
-			}
-
-			return nil
+			return u.installToBinaryPath(header.Size, func(w io.Writer) error {
+				_, err := io.Copy(w, tr)
+				return err
+			})
 		}
 	}
 }
@@ -513,25 +542,12 @@ func (u *Upgrader) installFromZip(zipPath string) error {
 			if err != nil {
 				return fmt.Errorf("failed to open zip entry: %w", err)
 			}
+			defer func() { _ = rc.Close() }()
 
-			out, err := os.OpenFile(u.binaryPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
-			if err != nil {
-				_ = rc.Close()
-				return fmt.Errorf("failed to create binary: %w", err)
-			}
-
-			_, copyErr := io.Copy(out, rc)
-			closeErr := out.Close()
-			_ = rc.Close()
-
-			if copyErr != nil {
-				return fmt.Errorf("failed to extract binary: %w", copyErr)
-			}
-			if closeErr != nil {
-				return fmt.Errorf("failed to close binary: %w", closeErr)
-			}
-
-			return nil
+			return u.installToBinaryPath(int64(f.UncompressedSize64), func(w io.Writer) error {
+				_, err := io.Copy(w, rc)
+				return err
+			})
 		}
 	}
 
@@ -546,17 +562,15 @@ func (u *Upgrader) installDirectBinary(srcPath string) error {
 	}
 	defer func() { _ = src.Close() }()
 
-	dst, err := os.OpenFile(u.binaryPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	info, err := src.Stat()
 	if err != nil {
-		return fmt.Errorf("failed to create binary: %w", err)
-	}
-	defer func() { _ = dst.Close() }()
-
-	if _, err := io.Copy(dst, src); err != nil {
-		return fmt.Errorf("failed to copy binary: %w", err)
+		return fmt.Errorf("failed to stat source: %w", err)
 	}
 
-	return nil
+	return u.installToBinaryPath(info.Size(), func(w io.Writer) error {
+		_, err := io.Copy(w, src)
+		return err
+	})
 }
 
 // compareVersions compares two semantic versions

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -8,11 +8,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1390,6 +1392,71 @@ func TestUpgrader_installBinary_dispatch(t *testing.T) {
 		}
 		if string(got) != "plain" {
 			t.Errorf("Installed content = %q, want %q", string(got), "plain")
+		}
+	})
+}
+
+func TestUpgrader_installToBinaryPath_truncated(t *testing.T) {
+	tempDir := t.TempDir()
+	binaryPath := filepath.Join(tempDir, "pilot")
+	original := []byte("original-binary")
+	if err := os.WriteFile(binaryPath, original, 0755); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	u := &Upgrader{binaryPath: binaryPath}
+
+	t.Run("short write returns error and preserves original", func(t *testing.T) {
+		err := u.installToBinaryPath(100, func(w io.Writer) error {
+			_, err := w.Write([]byte("short"))
+			return err
+		})
+		if err == nil {
+			t.Fatal("installToBinaryPath() should return error for truncated write")
+		}
+		if !strings.Contains(err.Error(), "truncated write") {
+			t.Errorf("error should mention truncated write, got: %v", err)
+		}
+
+		// Original binary must be untouched
+		got, err2 := os.ReadFile(binaryPath)
+		if err2 != nil {
+			t.Fatalf("ReadFile error: %v", err2)
+		}
+		if string(got) != string(original) {
+			t.Errorf("binary was modified: got %q, want %q", string(got), string(original))
+		}
+
+		// Temp file must be cleaned up
+		entries, _ := filepath.Glob(filepath.Join(tempDir, ".pilot-upgrade-*"))
+		if len(entries) != 0 {
+			t.Errorf("temp file not cleaned up: %v", entries)
+		}
+	})
+
+	t.Run("exact size succeeds", func(t *testing.T) {
+		content := []byte("new-binary-content")
+		err := u.installToBinaryPath(int64(len(content)), func(w io.Writer) error {
+			_, err := w.Write(content)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("installToBinaryPath() error = %v", err)
+		}
+		got, _ := os.ReadFile(binaryPath)
+		if string(got) != string(content) {
+			t.Errorf("installed content = %q, want %q", string(got), string(content))
+		}
+	})
+
+	t.Run("zero expectedSize skips check", func(t *testing.T) {
+		content := []byte("any-size-binary")
+		err := u.installToBinaryPath(0, func(w io.Writer) error {
+			_, err := w.Write(content)
+			return err
+		})
+		if err != nil {
+			t.Fatalf("installToBinaryPath() with zero size error = %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2564.

Closes #2564

## Changes

GitHub Issue #2564: fix(upgrade): detect truncated writes in installToBinaryPath

After the atomic-replace fix lands (#2563 / closes #2464), `installToBinaryPath` in `internal/upgrade/upgrade.go` does not verify that the bytes written to the temp file match the expected source size. A degenerate or truncated `io.Reader` could result in a short binary being atomically renamed into place — a corrupted install with no error returned.

Pre-existing weakness (the old truncate-in-place code had it too). Worth fixing now that the install path is centralized through one helper.

**Depends on:** #2563 must merge first.

## Approach
- Pass expected size into `installToBinaryPath` where known:
  - tar header `Size` (in `installFromTarGz`)
  - zip `File.UncompressedSize64` (in `installFromZip`)
  - source file `Stat().Size()` (in `installDirectBinary`)
- After the write callback returns success, `Stat` the temp file and compare to expected size. Mismatch → return error → temp cleaned up by existing defer.
- For paths where size is not known up front (none currently), gracefully skip the check.

## Validation
- New unit test: writer that under-writes returns an error, original binary preserved, temp cleaned up.
- `go test ./internal/upgrade/...`
- `make lint`