### PR TITLE
feat(autopilot): scope-drift + size-floor escalation gates (#2584, #2585)

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -731,8 +731,10 @@ func (c *Client) ListPullRequestReviews(ctx context.Context, owner, repo string,
 
 // PRFile represents a file changed in a pull request.
 type PRFile struct {
-	Filename string `json:"filename"`
-	Status   string `json:"status"` // "added", "removed", "modified", "renamed"
+	Filename  string `json:"filename"`
+	Status    string `json:"status"` // "added", "removed", "modified", "renamed"
+	Additions int    `json:"additions"`
+	Deletions int    `json:"deletions"`
 }
 
 // ListPullRequestFiles returns the list of files changed in a pull request.

--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -51,8 +51,19 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 		"sha", ShortSHA(prState.HeadSHA),
 	)
 
-	// Check if approval required (prod only)
-	if m.requiresApproval(env) {
+	// GH-2584/GH-2585: structural escalation gates. Born from OAuth cascade #2.
+	// Force human approval for PRs that drift from their issue's scope OR
+	// exceed the size floor, regardless of env config.
+	requireApproval := m.requiresApproval(env)
+	if !requireApproval {
+		if reason := m.evaluateEscalationGates(ctx, prState); reason != "" {
+			m.log.Warn("escalation gate fired — forcing human approval despite env config",
+				"pr", prState.PRNumber, "reason", reason)
+			requireApproval = true
+		}
+	}
+
+	if requireApproval {
 		approved, err := m.requestApproval(ctx, prState)
 		if err != nil {
 			return fmt.Errorf("approval request failed: %w", err)
@@ -115,6 +126,35 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 	}
 
 	return nil
+}
+
+// evaluateEscalationGates runs the GH-2584/GH-2585 structural rails. Returns
+// the first reason that fires, or "" if none. A failure to fetch the issue or
+// PR files is treated as "abstain" (returns "") — these gates must never break
+// a working merge path on transient API errors. We log+continue.
+func (m *AutoMerger) evaluateEscalationGates(ctx context.Context, prState *PRState) string {
+	// Scope-drift gate (#2584) — only meaningful when an issue is linked.
+	if prState.IssueNumber > 0 && prState.PRTitle != "" {
+		issue, err := m.ghClient.GetIssue(ctx, m.owner, m.repo, prState.IssueNumber)
+		if err != nil {
+			m.log.Warn("scope-drift gate: GetIssue failed, abstaining",
+				"pr", prState.PRNumber, "issue", prState.IssueNumber, "error", err)
+		} else if reason := ScopeDriftReason(prState.PRTitle, issue.Title); reason != "" {
+			return reason
+		}
+	}
+
+	// Size-floor gate (#2585) — independent of issue link.
+	files, err := m.ghClient.ListPullRequestFiles(ctx, m.owner, m.repo, prState.PRNumber)
+	if err != nil {
+		m.log.Warn("size-floor gate: ListPullRequestFiles failed, abstaining",
+			"pr", prState.PRNumber, "error", err)
+		return ""
+	}
+	if reason := SizeFloorReason(files); reason != "" {
+		return reason
+	}
+	return ""
 }
 
 // requiresApproval checks if the active environment requires human approval before merge.

--- a/internal/autopilot/auto_merger_test.go
+++ b/internal/autopilot/auto_merger_test.go
@@ -206,6 +206,10 @@ func TestAutoMerger_MergePR_DevEnvironment(t *testing.T) {
 		case "/repos/owner/repo/pulls/42/reviews":
 			// Auto-review call
 			w.WriteHeader(http.StatusOK)
+		case "/repos/owner/repo/pulls/42/files":
+			// GH-2585: size-floor gate enumerates files. Return empty list.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
 		case "/repos/owner/repo/pulls/42/merge":
 			// Merge call
 			var body map[string]string

--- a/internal/autopilot/scope_guard.go
+++ b/internal/autopilot/scope_guard.go
@@ -1,0 +1,78 @@
+package autopilot
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+)
+
+// Born from OAuth cascade #2 (2026-05-04). Two structural rails to ensure that
+// a runaway executor cannot land code unsupervised even if env config drops
+// require_approval. Both gates only ESCALATE — they force human approval, they
+// never silently merge. They never relax an already-required approval.
+//
+// #2584 ScopeDriftReason: PR title type/scope must match the linked issue's.
+//   - Issue 'fix(upgrade): X' producing PR 'feat(auth): Y'  → blocked.
+//   - Same gate would have blocked PR #2572 (cascade #2 entry point).
+// #2585 SizeFloorReason: any PR > 200 net added lines escalates regardless of
+// env config. Cascade #2's contaminating PR was 512 LoC.
+
+var convCommitRE = regexp.MustCompile(`^([a-z]+)\(([a-z0-9_./-]+)\)\s*[!:]`)
+
+// extractTypeScope returns the conventional-commit type and scope from a title.
+// Returns ("", "") if the title doesn't match the conventional-commit prefix.
+// Example: "feat(auth): add OAuth" -> ("feat", "auth").
+func extractTypeScope(title string) (string, string) {
+	m := convCommitRE.FindStringSubmatch(title)
+	if m == nil {
+		return "", ""
+	}
+	return m[1], m[2]
+}
+
+// ScopeDriftReason returns a non-empty reason if the PR's conventional-commit
+// type or scope diverges from the linked issue's. Empty string = no drift
+// (or insufficient signal — both titles must have a conventional prefix).
+//
+// Closes the cascade-2 attack surface where a `fix(upgrade)` issue produced a
+// `feat(auth)` PR. We only escalate (force human approval), never block.
+func ScopeDriftReason(prTitle, issueTitle string) string {
+	if prTitle == "" || issueTitle == "" {
+		return ""
+	}
+	prType, prScope := extractTypeScope(prTitle)
+	issueType, issueScope := extractTypeScope(issueTitle)
+	// If either side has no conventional prefix, we can't compare — abstain.
+	if prType == "" || issueType == "" {
+		return ""
+	}
+	if prType != issueType {
+		return fmt.Sprintf("PR title type %q diverges from issue title type %q", prType, issueType)
+	}
+	if prScope != "" && issueScope != "" && prScope != issueScope {
+		return fmt.Sprintf("PR title scope %q diverges from issue title scope %q", prScope, issueScope)
+	}
+	return ""
+}
+
+// SizeFloorThreshold is the net-additions threshold above which a PR escalates
+// to human approval regardless of env config. Cascade #2's bad PR was 512 LoC;
+// 200 catches that with comfortable margin and only blocks PRs that genuinely
+// merit a second pair of eyes.
+const SizeFloorThreshold = 200
+
+// SizeFloorReason returns a non-empty reason if the PR's net additions exceed
+// SizeFloorThreshold. Pilot's median PR is well under 100 additions — anything
+// over 200 is large enough that auto-merge is too aggressive even on a passing
+// CI signal.
+func SizeFloorReason(files []*github.PRFile) string {
+	var net int
+	for _, f := range files {
+		net += f.Additions
+	}
+	if net > SizeFloorThreshold {
+		return fmt.Sprintf("PR adds %d net lines (> %d threshold)", net, SizeFloorThreshold)
+	}
+	return ""
+}

--- a/internal/autopilot/scope_guard_test.go
+++ b/internal/autopilot/scope_guard_test.go
@@ -1,0 +1,126 @@
+package autopilot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+)
+
+func TestExtractTypeScope(t *testing.T) {
+	cases := []struct {
+		title           string
+		wantType, wantS string
+	}{
+		{"feat(auth): add OAuth", "feat", "auth"},
+		{"fix(upgrade): cherry-pick atomic binary replacement", "fix", "upgrade"},
+		{"chore: bump deps", "", ""},                        // missing scope
+		{"refactor(internal/executor): clean", "refactor", "internal/executor"},
+		{"feat(auth)!: breaking change", "feat", "auth"},
+		{"random title", "", ""},
+		{"", "", ""},
+	}
+	for _, tc := range cases {
+		gotType, gotS := extractTypeScope(tc.title)
+		if gotType != tc.wantType || gotS != tc.wantS {
+			t.Errorf("extractTypeScope(%q) = (%q,%q), want (%q,%q)",
+				tc.title, gotType, gotS, tc.wantType, tc.wantS)
+		}
+	}
+}
+
+func TestScopeDriftReason(t *testing.T) {
+	cases := []struct {
+		name, prTitle, issueTitle string
+		wantContains              string // empty = expect no drift
+	}{
+		{
+			name:         "cascade-2 entry: type+scope mismatch",
+			prTitle:      "feat(auth): add OAuth provider integration",
+			issueTitle:   "fix(upgrade): cherry-pick atomic binary replacement",
+			wantContains: "type",
+		},
+		{
+			name:         "scope mismatch only",
+			prTitle:      "feat(memory): X",
+			issueTitle:   "feat(executor): Y",
+			wantContains: "scope",
+		},
+		{
+			name:       "matching prefix — no drift",
+			prTitle:    "fix(executor): tweak",
+			issueTitle: "fix(executor): broader description",
+		},
+		{
+			name:       "matching type, scope unset on issue side — abstain",
+			prTitle:    "fix(executor): X",
+			issueTitle: "fix: X",
+		},
+		{
+			name:       "PR has no conventional prefix — abstain (other validators handle title)",
+			prTitle:    "raw title",
+			issueTitle: "feat(auth): X",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ScopeDriftReason(tc.prTitle, tc.issueTitle)
+			if tc.wantContains == "" && got != "" {
+				t.Errorf("expected no drift, got %q", got)
+			}
+			if tc.wantContains != "" && !strings.Contains(got, tc.wantContains) {
+				t.Errorf("want reason containing %q, got %q", tc.wantContains, got)
+			}
+		})
+	}
+}
+
+func TestSizeFloorReason(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []*github.PRFile
+		want  bool // true if a reason is expected
+	}{
+		{
+			name: "small PR — no floor",
+			files: []*github.PRFile{
+				{Filename: "a.go", Status: "modified", Additions: 50, Deletions: 10},
+			},
+		},
+		{
+			name: "200 LoC exactly — no floor (strict >)",
+			files: []*github.PRFile{
+				{Filename: "a.go", Status: "modified", Additions: 200},
+			},
+		},
+		{
+			name: "201 LoC — floor fires",
+			files: []*github.PRFile{
+				{Filename: "a.go", Status: "modified", Additions: 201},
+			},
+			want: true,
+		},
+		{
+			name: "cascade-2 contaminating PR (~512 LoC)",
+			files: []*github.PRFile{
+				{Filename: "internal/gateway/oauth.go", Status: "added", Additions: 244},
+				{Filename: "internal/gateway/oauth_test.go", Status: "added", Additions: 240},
+				{Filename: "internal/gateway/server.go", Status: "modified", Additions: 24},
+				{Filename: "cmd/pilot/main.go", Status: "modified", Additions: 3},
+				{Filename: "internal/config/config.go", Status: "modified", Additions: 1},
+			},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SizeFloorReason(tc.files)
+			if tc.want && got == "" {
+				t.Errorf("expected size-floor to fire, got empty reason")
+			}
+			if !tc.want && got != "" {
+				t.Errorf("expected no size-floor fire, got %q", got)
+			}
+		})
+	}
+}

--- a/internal/executor/prompt_leak_test.go
+++ b/internal/executor/prompt_leak_test.go
@@ -1,0 +1,121 @@
+package executor
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestNoPromptLeakStrings is the cross-prompt invariant guard born from the
+// 2026-05-04 OAuth cascade #2 (#2559 recurrence). Cascade #1 fix (PR #2562)
+// only patched the planner prompt in epic.go and explicitly skipped
+// workflow.go on the (incorrect) reasoning that only the planner generates
+// subtask titles. The executor LLM also pattern-matched on the example, and
+// because the executor WRITES THE CODE, the second cascade was worse.
+//
+// This test scans EVERY raw string literal in every .go file under
+// internal/executor and internal/autopilot for known leak strings and the
+// "concrete commit-message-style example" regex family. ALL_CAPS placeholders
+// (e.g. `feat(SCOPE): IMPERATIVE_SUMMARY`) are explicitly allowed; only
+// plausible-looking lowercase examples are forbidden.
+//
+// Adding a new forbidden literal here is the third leg of the
+// prompt-leak-fix-checklist SOP (.agent/sops/integrations/prompt-leak-fix-checklist.md).
+func TestNoPromptLeakStrings(t *testing.T) {
+	roots := []string{
+		mustResolve(t, "."),                  // internal/executor
+		mustResolve(t, "../autopilot"),       // internal/autopilot
+	}
+
+	literalForbidden := []string{
+		"feat(auth): add OAuth provider integration",
+		"feat(auth): add OAuth session logout endpoint",
+		"feat(auth): add GitLab OAuth provider integration",
+		"feat(auth): add Microsoft and Discord OAuth provider integration",
+		"fix(api): handle nil response in webhook handler",
+		"chore(deps): upgrade go modules to latest",
+	}
+	// Conventional-commit-style example with a lowercase imperative verb.
+	// Matches "feat(auth): add ..." but NOT "feat(SCOPE): IMPERATIVE_SUMMARY"
+	// because the trailing token must start with [a-z].
+	concreteExample := regexp.MustCompile(`(?m)^\s*[-*]?\s*(feat|fix|chore|refactor|perf|docs|test|build|ci|style)\([a-z][a-z0-9_-]*\):\s+[a-z]`)
+
+	fset := token.NewFileSet()
+	scanned := 0
+
+	for _, root := range roots {
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if info.Name() == "testdata" || strings.HasPrefix(info.Name(), ".") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			scanned++
+
+			file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+
+			ast.Inspect(file, func(n ast.Node) bool {
+				lit, ok := n.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				val := lit.Value
+				// Only scan multi-line raw strings (backtick-delimited).
+				// Regular "..." strings are too small to host LLM prompts and
+				// would generate noise from short user-facing strings.
+				if !strings.HasPrefix(val, "`") || !strings.Contains(val, "\n") {
+					return true
+				}
+
+				rel, _ := filepath.Rel(root, path)
+				pos := fset.Position(lit.Pos())
+
+				for _, f := range literalForbidden {
+					if strings.Contains(val, f) {
+						t.Errorf("%s:%d: prompt-shaped literal contains forbidden concrete example %q (#2559/cascade-2 recurrence guard)", rel, pos.Line, f)
+					}
+				}
+				if m := concreteExample.FindString(val); m != "" {
+					t.Errorf("%s:%d: prompt-shaped literal contains concrete commit-message-style example %q — use ALL_CAPS placeholders (e.g. feat(SCOPE): IMPERATIVE_SUMMARY)", rel, pos.Line, strings.TrimSpace(m))
+				}
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+
+	if scanned == 0 {
+		t.Fatalf("scanned 0 files — roots misconfigured")
+	}
+	t.Logf("scanned %d .go files across %d roots", scanned, len(roots))
+}
+
+func mustResolve(t *testing.T, rel string) string {
+	t.Helper()
+	abs, err := filepath.Abs(rel)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", rel, err)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		t.Fatalf("stat %s: %v", abs, err)
+	}
+	return abs
+}


### PR DESCRIPTION
## Summary

Two structural rails to prevent a runaway executor from landing code unsupervised even if env config drops `require_approval`. Both gates only **escalate** — they force human approval on the existing approval pipeline; they never silently merge and never relax an already-required approval.

- **#2584 `ScopeDriftReason`**: PR title `type(scope):` must match the linked issue's. Issue `fix(upgrade): X` producing PR `feat(auth): Y` is escalated. Exact signature of cascade #2's entry PR (#2572).
- **#2585 `SizeFloorReason`**: any PR with > 200 net added lines escalates regardless of env config. Cascade #2's contaminating PR was 512 LoC; Pilot's median legit PR is well under 100.

## Implementation

- New `internal/autopilot/scope_guard.go` — `ScopeDriftReason(prTitle, issueTitle)` + `SizeFloorReason(files)` (both pure, table-tested).
- Wired into `(*AutoMerger).MergePR` via new `evaluateEscalationGates()`. Transient GitHub API failures abstain (log + continue) rather than break the merge path.
- Extended `github.PRFile` with `Additions`/`Deletions` (already returned by the Files API; backward-compatible).
- Updated `TestAutoMerger_MergePR_DevEnvironment` mock to handle the new `/files` call.

## Test plan

- [x] `go test ./internal/autopilot/...` passes including the cascade-2 reproduction (`TestSizeFloorReason/cascade-2_contaminating_PR`)
- [x] `go test ./...` green
- [x] `TestScopeDriftReason/cascade-2_entry:_type+scope_mismatch` reproduces the exact attack pattern
- [ ] CI green
- [ ] Smoke after merge: file a tiny non-auth issue, confirm Pilot's PR is auto-merged (gates abstain when issue+PR types match)
- [ ] Smoke 2: manually file a PR whose title type diverges from the issue → expect approval request

Closes #2584. Closes #2585. Companion to #2581 (root-cause fix), #2582 (revert), #2592 (invariant test).