### PR TITLE
GH-2587: fix(executor): disable extractParentTypeScope fallback when parent title comes from cascade artefact

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -545,11 +545,58 @@ func isPlaceholderSubtaskTitle(title string) bool {
 	return placeholderSubtaskTitleRE.MatchString(strings.TrimSpace(title))
 }
 
+// scopeKeywords returns body keywords that confirm a conventional-commit scope is legit.
+// Only covers scopes that have caused cascade contamination; all others return nil (always trusted).
+func scopeKeywords(scope string) []string {
+	switch scope {
+	case "auth":
+		return []string{"auth", "oauth", "login", "token", "session", "identity", "credential", "password", "jwt"}
+	default:
+		return nil
+	}
+}
+
+// extractScope pulls the scope name out of a conventional-commit prefix like "feat(auth):".
+// Returns "" when the prefix has no scope (e.g. "fix:").
+func extractScope(prefix string) string {
+	start := strings.Index(prefix, "(")
+	end := strings.Index(prefix, ")")
+	if start < 0 || end < 0 || end <= start+1 {
+		return ""
+	}
+	return prefix[start+1 : end]
+}
+
+// isCascadeArtefact returns true when the parent title carries a scoped prefix but
+// the parent body contains no keywords matching that scope — a signal that the title
+// was inherited from an unrelated earlier ticket (cascade-artefact pattern, GH-2587).
+func isCascadeArtefact(prefix, body string) bool {
+	scope := extractScope(prefix)
+	if scope == "" {
+		return false // no scope to verify
+	}
+	keywords := scopeKeywords(scope)
+	if keywords == nil {
+		return false // scope not in watchlist — trust it
+	}
+	bodyLower := strings.ToLower(body)
+	for _, kw := range keywords {
+		if strings.Contains(bodyLower, kw) {
+			return false // body confirms scope is legit
+		}
+	}
+	return true // title claims scope X but body never mentions X
+}
+
 // extractParentTypeScope returns the conventional-commit prefix (e.g. "feat(auth):") from
-// parentTitle. Falls back to "chore:" when the parent title is not in conventional-commit format.
-func extractParentTypeScope(parentTitle string) string {
+// parentTitle. Falls back to "chore:" when the parent title is not in conventional-commit format
+// or when the scoped prefix looks like a cascade artefact (GH-2587: title scope not reflected in body).
+func extractParentTypeScope(parentTitle, parentBody string) string {
 	m := parentTypeScopeRE.FindString(strings.TrimSpace(parentTitle))
 	if m == "" {
+		return "chore:"
+	}
+	if isCascadeArtefact(m, parentBody) {
 		return "chore:"
 	}
 	return m
@@ -558,8 +605,8 @@ func extractParentTypeScope(parentTitle string) string {
 // applyParentTypeScopeFallback rewrites the subtasks at invalidIdx using the parent's
 // conventional-commit prefix (Approach B). The result is guaranteed to satisfy
 // conventionalSubtaskTitleRE.
-func applyParentTypeScopeFallback(subtasks []PlannedSubtask, invalidIdx []int, parentTitle string) []PlannedSubtask {
-	prefix := extractParentTypeScope(parentTitle) // e.g. "feat(auth):"
+func applyParentTypeScopeFallback(subtasks []PlannedSubtask, invalidIdx []int, parentTitle, parentBody string) []PlannedSubtask {
+	prefix := extractParentTypeScope(parentTitle, parentBody) // e.g. "feat(auth):"
 	result := make([]PlannedSubtask, len(subtasks))
 	copy(result, subtasks)
 	for _, idx := range invalidIdx {
@@ -602,8 +649,10 @@ func validateAndFixSubtaskTitles(ctx context.Context, subtasks []PlannedSubtask,
 	}
 
 	parentTitle := ""
+	parentBody := ""
 	if parent != nil {
 		parentTitle = parent.Title
+		parentBody = parent.Description
 	}
 
 	// Attempt re-prompt via SubtaskParser API.
@@ -643,7 +692,7 @@ func validateAndFixSubtaskTitles(ctx context.Context, subtasks []PlannedSubtask,
 	}
 
 	// Approach B: inherit parent's type/scope for remaining invalid titles.
-	return applyParentTypeScopeFallback(subtasks, invalid, parentTitle)
+	return applyParentTypeScopeFallback(subtasks, invalid, parentTitle, parentBody)
 }
 
 // queryOpenSubIssues returns true when there are open GitHub issues that include
@@ -787,6 +836,7 @@ func (r *Runner) createSubIssuesViaAdapter(ctx context.Context, plan *EpicPlan) 
 				[]PlannedSubtask{{Title: title, Order: subtask.Order}},
 				[]int{0},
 				plan.ParentTask.Title,
+				plan.ParentTask.Description,
 			)[0].Title
 			r.log.Warn("Rejected invalid LLM subtask title; using conventional fallback",
 				"original_title", subtask.Title,
@@ -818,6 +868,7 @@ func (r *Runner) createSubIssuesViaAdapter(ctx context.Context, plan *EpicPlan) 
 				[]PlannedSubtask{{Title: title, Order: subtask.Order}},
 				[]int{0},
 				plan.ParentTask.Title,
+				plan.ParentTask.Description,
 			)[0].Title
 		}
 
@@ -884,15 +935,18 @@ func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, e
 			parentID := ""
 			parentProject := ""
 			parentTitle := ""
+			parentBody := ""
 			if plan.ParentTask != nil {
 				parentID = plan.ParentTask.ID
 				parentProject = plan.ParentTask.ProjectPath
 				parentTitle = plan.ParentTask.Title
+				parentBody = plan.ParentTask.Description
 			}
 			fallback := applyParentTypeScopeFallback(
 				[]PlannedSubtask{{Title: title, Order: subtask.Order}},
 				[]int{0},
 				parentTitle,
+				parentBody,
 			)[0].Title
 			r.log.Warn("Rejected invalid LLM subtask title; using conventional fallback",
 				"original_title", subtask.Title,
@@ -922,13 +976,16 @@ func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, e
 		// Catches titles that satisfy validateSubtaskTitle (action verb) but lack type prefix.
 		if !isConventionalSubtaskTitle(title) {
 			parentTitle := ""
+			parentBody := ""
 			if plan.ParentTask != nil {
 				parentTitle = plan.ParentTask.Title
+				parentBody = plan.ParentTask.Description
 			}
 			title = applyParentTypeScopeFallback(
 				[]PlannedSubtask{{Title: title, Order: subtask.Order}},
 				[]int{0},
 				parentTitle,
+				parentBody,
 			)[0].Title
 		}
 

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -1731,6 +1731,89 @@ func TestSyntheticSubtaskTitle(t *testing.T) {
 	})
 }
 
+// TestExtractParentTypeScope_CascadeArtefactGuard covers GH-2587: when the parent title
+// carries a scoped prefix (e.g. "feat(auth):") but the body has no matching keywords,
+// extractParentTypeScope must fall back to "chore:" to avoid cascade contamination.
+func TestExtractParentTypeScope_CascadeArtefactGuard(t *testing.T) {
+	tests := []struct {
+		name        string
+		parentTitle string
+		parentBody  string
+		wantPrefix  string
+	}{
+		{
+			// Case 1 (cascade-2 repro): GH-201 — dashboard ticket whose title coincidentally
+			// started with "feat(auth):" but body was entirely about UI, not auth.
+			name:        "cascade-2 repro: auth prefix with unrelated body returns chore",
+			parentTitle: "feat(auth): dashboard sparkline retro",
+			parentBody:  "add sparkline cards for cost panel — see attached design",
+			wantPrefix:  "chore:",
+		},
+		{
+			// Case 2 (legit auth feature): body mentions auth-related keywords.
+			name:        "legit auth feature: body mentions oauth returns feat(auth):",
+			parentTitle: "feat(auth): add OAuth provider integration",
+			parentBody:  "Implement OAuth login flow using GitHub provider tokens for session management",
+			wantPrefix:  "feat(auth):",
+		},
+		{
+			// Case 3 (no scope): title has no scope — scope check doesn't apply; prefix kept as-is.
+			name:        "no scope: fix: prefix preserved regardless of body",
+			parentTitle: "fix: timeout in retry path",
+			parentBody:  "the retry loop does not honour context cancellation",
+			wantPrefix:  "fix:",
+		},
+		{
+			// Additional: scope not in watchlist — always trusted.
+			name:        "executor scope not in watchlist: trusted",
+			parentTitle: "feat(executor): add stream-json parser",
+			parentBody:  "completely unrelated body about dashboard widgets",
+			wantPrefix:  "feat(executor):",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractParentTypeScope(tc.parentTitle, tc.parentBody)
+			if got != tc.wantPrefix {
+				t.Errorf("extractParentTypeScope(%q, ...) = %q, want %q", tc.parentTitle, got, tc.wantPrefix)
+			}
+		})
+	}
+}
+
+// TestApplyParentTypeScopeFallback_CascadeGuardEndToEnd verifies that the cascade-artefact
+// guard flows through applyParentTypeScopeFallback: subtasks with invalid titles under a
+// cascade-artefact parent must receive "chore:" not the contaminated scope.
+func TestApplyParentTypeScopeFallback_CascadeGuardEndToEnd(t *testing.T) {
+	subtasks := []PlannedSubtask{
+		{Title: "Subtask 1", Order: 1},
+		{Title: "fix: valid title already", Order: 2},
+		{Title: "Subtask 3", Order: 3},
+	}
+	invalid := []int{0, 2}
+
+	// Cascade-artefact parent: auth prefix but body is about dashboard sparklines.
+	result := applyParentTypeScopeFallback(subtasks, invalid, "feat(auth): dashboard sparkline retro", "add sparkline cards for cost panel")
+
+	for _, idx := range invalid {
+		if !isConventionalSubtaskTitle(result[idx].Title) {
+			t.Errorf("result[%d].Title %q is not conventional-commit format", idx, result[idx].Title)
+		}
+		if strings.HasPrefix(result[idx].Title, "feat(auth):") {
+			t.Errorf("result[%d].Title %q must not inherit cascade-artefact auth scope", idx, result[idx].Title)
+		}
+		if !strings.HasPrefix(result[idx].Title, "chore:") {
+			t.Errorf("result[%d].Title %q should use chore: fallback, not %q", idx, result[idx].Title, result[idx].Title[:strings.Index(result[idx].Title, " ")+1])
+		}
+	}
+
+	// Untouched slot must be preserved.
+	if result[1].Title != "fix: valid title already" {
+		t.Errorf("untouched subtask title changed: got %q", result[1].Title)
+	}
+}
+
 // TestCreateSubIssues_RejectsAnalysisTitle ensures the GH-2324 guard kicks in
 // end-to-end through the adapter path: an LLM analysis sentence must not reach
 // the tracker verbatim; a synthetic fallback is used instead.

--- a/internal/executor/subtask_cc_validation_test.go
+++ b/internal/executor/subtask_cc_validation_test.go
@@ -239,18 +239,20 @@ func TestIsPlaceholderSubtaskTitle(t *testing.T) {
 func TestExtractParentTypeScope(t *testing.T) {
 	tests := []struct {
 		parent string
+		body   string
 		want   string
 	}{
-		{"feat(auth): add OAuth", "feat(auth):"},
-		{"fix: resolve nil panic", "fix:"},
-		{"chore(deps): bump versions", "chore(deps):"},
-		{"Add some feature", "chore:"},    // not conventional → default
-		{"", "chore:"},                    // empty → default
+		// auth scope with body confirming oauth — legit, keep prefix.
+		{"feat(auth): add OAuth", "implement oauth login flow with token session management", "feat(auth):"},
+		{"fix: resolve nil panic", "retry loop panics on nil pointer", "fix:"},
+		{"chore(deps): bump versions", "update go modules to latest", "chore(deps):"},
+		{"Add some feature", "some body", "chore:"},    // not conventional → default
+		{"", "", "chore:"},                             // empty → default
 	}
 	for _, tt := range tests {
-		got := extractParentTypeScope(tt.parent)
+		got := extractParentTypeScope(tt.parent, tt.body)
 		if got != tt.want {
-			t.Errorf("extractParentTypeScope(%q) = %q, want %q", tt.parent, got, tt.want)
+			t.Errorf("extractParentTypeScope(%q, ...) = %q, want %q", tt.parent, got, tt.want)
 		}
 	}
 }
@@ -265,7 +267,7 @@ func TestApplyParentTypeScopeFallback(t *testing.T) {
 	parent := &Task{Title: "feat(api): add REST endpoints"}
 	invalidIdx := []int{0, 1} // only fix the first two
 
-	result := applyParentTypeScopeFallback(subtasks, invalidIdx, parent.Title)
+	result := applyParentTypeScopeFallback(subtasks, invalidIdx, parent.Title, parent.Description)
 
 	for i := range result[:2] {
 		if !conventionalSubtaskTitleRE.MatchString(result[i].Title) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2587.

Closes #2587

## Changes

GitHub Issue #2587: fix(executor): disable extractParentTypeScope fallback when parent title comes from cascade artefact

P1-NEW. `internal/executor/epic.go:550`. When parent issue title matches a known cascade pattern (e.g. starts with `feat(auth):` but body unrelated), do NOT inherit type/scope into sub-issue titles. Confirmed via #2580 inheriting from GH-201.

## Real-world hit
Cascade #2 (2026-05-04) sub-issue #2580 inherited `feat(auth):` prefix from parent GH-201 (a January 2026 dashboard ticket whose title coincidentally started with `feat(auth):` from an unrelated context). Body had nothing to do with auth. The `applyParentTypeScopeFallback` blindly applied the parent prefix, contributing to the cascade-2 contamination chain.

## Design

### Code locations
- `internal/executor/epic.go:548-556` — `extractParentTypeScope(parentTitle string)` (current behavior: regex-extract conventional prefix or fallback `chore:`)
- `internal/executor/epic.go:558-580+` — `applyParentTypeScopeFallback(...)` (caller — applies the prefix to invalid subtasks)

### Current behavior
`extractParentTypeScope` looks at title only. If parent title is `feat(auth): old dashboard work`, it returns `feat(auth):` regardless of what the parent body actually describes.

### Proposed fix
Add a body-relevance check in the fallback. New signature (one of):

```go
// Option A: extend extractor to accept body
func extractParentTypeScope(parentTitle, parentBody string) string {
    prefix := parentTypeScopeRE.FindString(strings.TrimSpace(parentTitle))
    if prefix == "" {
        return "chore:"
    }
    if isCascadeArtefact(prefix, parentBody) {
        return "chore:"  // safer default — don't inherit auth/feat from unrelated body
    }
    return prefix
}

func isCascadeArtefact(prefix, body string) bool {
    // Extract the type+scope (e.g. "auth" from "feat(auth):") and check
    // whether the body has at least one keyword corresponding to that scope.
    scope := extractScope(prefix)         // "auth", "executor", etc.
    if scope == "" {
        return false
    }
    keywords := scopeKeywords(scope)      // {"auth": ["auth", "oauth", "login", "token", "session", "identity"]}
    bodyLower := strings.ToLower(body)
    for _, kw := range keywords {
        if strings.Contains(bodyLower, kw) {
            return false  // body matches scope — legit
        }
    }
    return true  // title says scope X but body never mentions X — likely cascade artefact
}
```

`scopeKeywords` should at minimum cover `auth` (the cascade-2 culprit). Other scopes can default to "always trust" until they bite.

### Caller wiring
`applyParentTypeScopeFallback` at `epic.go:561` needs to receive `parentBody` from its caller. Trace upward — the planner has access to the parent issue body when fetching it; just thread it through.

## Acceptance

1. **New regression test** in `internal/executor/epic_test.go`:
   - **Case 1 (cascade-2 repro):** parent title = `feat(auth): dashboard sparkline retro` (the GH-201 pattern), parent body = `add sparkline cards for cost panel — see attached design`. Subtasks with empty/invalid titles → result MUST use `chore:` prefix, not `feat(auth):`.
   - **Case 2 (legit auth feature):** parent title = `feat(auth): add OAuth provider integration`, parent body = `Implement OAuth login flow using GitHub provider tokens for session management`. Subtasks → result keeps `feat(auth):` prefix.
   - **Case 3 (no scope):** parent title = `fix: timeout in retry path`, body irrelevant — keep `fix:` (no scope to verify).

2. **Cross-prompt invariant test (#2592) still passes** — this change adds new logic, does not introduce new prompt strings.

3. **No change to `applyParentTypeScopeFallback` signature** is acceptable IF `extractParentTypeScope` gets the body via a closure or struct field; goal is to keep the diff small.

## Constraints
- Keep diff under 200 LoC. Real code likely <50 LoC; tests will dominate.
- Do NOT add scope keywords beyond `auth` in this PR. Keyword expansion is a follow-up if/when other scopes bite.
- Do NOT touch `parentTypeScopeRE` regex — current title-side parsing is correct.
- Do NOT touch the cross-prompt invariant test (#2592).

## Refs
- `internal/executor/epic.go:548-556` — extractor
- `internal/executor/epic.go:558-580+` — caller
- Marker: `before-compact-2026-05-04-cascade-2-resolved-smoke-pending.md` (Agent C pointer)
- Sister fixes: #2592 (invariant test), #2594 (escalation gates), #2598 (fail-closed approval)

## Planned Steps (execute all in sequence)

1. **fix(executor): guard extractParentTypeScope against cascade-artefact parent titles** — Update `internal/executor/epic.go` to add a body-relevance check: extend `extractParentTypeScope` to accept `parentBody`, add `isCascadeArtefact` + `scopeKeywords` (covering `auth` only), and thread `parentBody` through `applyParentTypeScopeFallback` and its caller(s). When parent title carries a scope (e.g. `feat(auth):`) but the body contains no matching keywords, fall back to `chore:`. Add regression tests in `internal/executor/epic_test.go` covering the three acceptance cases (cascade-2 repro returning `chore:`, legit auth feature retaining `feat(auth):`, no-scope `fix:` preserved). Keep diff under 200 LoC; do not modify `parentTypeScopeRE` or the cross-prompt invariant test.
