### PR TITLE
GH-2619: feat(adapters): add structural spec-quality validator at issue dispatch

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -248,6 +248,18 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 
 	parts := strings.Split(sourceRepo, "/")
 
+	// GH-2619: Pre-dispatch spec quality gate — block issues whose bodies are too thin to execute.
+	if len(parts) == 2 {
+		parentResolver := func(parentNum int) (*github.Issue, error) {
+			return client.GetIssue(ctx, parts[0], parts[1], parentNum)
+		}
+		specResult := github.ValidateSpec(issue, parentResolver)
+		if !specResult.Valid && specResult.SkipReason == "" {
+			applySpecGuard(ctx, client, parts[0], parts[1], issue, specResult.FailureReasons)
+			return &github.IssueResult{Success: false}, nil
+		}
+	}
+
 	// Add pilot-in-progress label before execution begins
 	if len(parts) == 2 {
 		if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelInProgress}); err != nil {

--- a/cmd/pilot/handlers_spec_test.go
+++ b/cmd/pilot/handlers_spec_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// newSpecTestServer creates an httptest server that routes GitHub API calls for
+// issue 42 in owner/repo.  labelsAdded accumulates all labels posted to the
+// issue. commentsBody is returned for every GET /comments request.
+func newSpecTestServer(t *testing.T, commentsBody string, labelsAdded *[]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/issues/42/comments"):
+			_, _ = w.Write([]byte(commentsBody))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/issues/42/comments"):
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":1,"body":"ok"}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/issues/42/labels"):
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			*labelsAdded = append(*labelsAdded, body.Labels...)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	return srv
+}
+
+func hasLabel(labels []string, want string) bool {
+	for _, l := range labels {
+		if l == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestApplySpecGuard_FirstStrike: no existing marker comment → adds pilot-spec-incomplete.
+func TestApplySpecGuard_FirstStrike(t *testing.T) {
+	var labelsAdded []string
+	srv := newSpecTestServer(t, `[]`, &labelsAdded)
+	defer srv.Close()
+
+	client := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	issue := &github.Issue{Number: 42}
+	reasons := []string{"body too short (10 chars, need 100)"}
+
+	skipped := applySpecGuard(context.Background(), client, "owner", "repo", issue, reasons)
+	if !skipped {
+		t.Fatal("expected applySpecGuard to return true (skip dispatch)")
+	}
+	if !hasLabel(labelsAdded, github.LabelSpecIncomplete) {
+		t.Errorf("expected %s to be added, got %v", github.LabelSpecIncomplete, labelsAdded)
+	}
+	if hasLabel(labelsAdded, github.LabelBlocked) {
+		t.Errorf("expected %s NOT to be added on first strike, got %v", github.LabelBlocked, labelsAdded)
+	}
+}
+
+// TestApplySpecGuard_SecondStrike: marker comment present → adds pilot-blocked.
+func TestApplySpecGuard_SecondStrike(t *testing.T) {
+	markerComment := []map[string]interface{}{
+		{"id": 1, "body": github.SpecCommentMarker + "\n\nsome content"},
+	}
+	commentsJSON, _ := json.Marshal(markerComment)
+
+	var labelsAdded []string
+	srv := newSpecTestServer(t, string(commentsJSON), &labelsAdded)
+	defer srv.Close()
+
+	client := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	issue := &github.Issue{Number: 42}
+	reasons := []string{"body too short (10 chars, need 100)"}
+
+	skipped := applySpecGuard(context.Background(), client, "owner", "repo", issue, reasons)
+	if !skipped {
+		t.Fatal("expected applySpecGuard to return true (skip dispatch)")
+	}
+	if !hasLabel(labelsAdded, github.LabelBlocked) {
+		t.Errorf("expected %s to be added on second strike, got %v", github.LabelBlocked, labelsAdded)
+	}
+}
+
+// TestApplySpecGuard_NoExecRow: guard returns true, so the caller must not proceed to
+// execution.  We verify that applySpecGuard itself never writes an executions row —
+// it is the caller's responsibility to return early, which the handler does.
+func TestApplySpecGuard_SkippedWhenCommentListFails(t *testing.T) {
+	// Server returns 500 for comment listing → guard should not block dispatch.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+	issue := &github.Issue{Number: 42}
+	reasons := []string{"body too short"}
+
+	skipped := applySpecGuard(context.Background(), client, "owner", "repo", issue, reasons)
+	if skipped {
+		t.Error("expected applySpecGuard to return false (don't block) when comment listing fails")
+	}
+}

--- a/cmd/pilot/spec_guard.go
+++ b/cmd/pilot/spec_guard.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+)
+
+// applySpecGuard runs the two-strike spec validation gate for a GitHub issue.
+// Returns true when dispatch should be skipped (guard fired), false to proceed.
+//
+// First call with a failing issue adds pilot-spec-incomplete and posts a structured comment.
+// Subsequent call (comment marker already present) escalates to pilot-blocked.
+func applySpecGuard(ctx context.Context, client *github.Client, owner, repo string, issue *github.Issue, reasons []string) bool {
+	comments, err := client.ListIssueComments(ctx, owner, repo, issue.Number)
+	if err != nil {
+		slog.Warn("spec-guard: failed to list comments, skipping guard",
+			slog.Int("issue", issue.Number), slog.Any("error", err))
+		return false
+	}
+
+	markerFound := false
+	for _, c := range comments {
+		if strings.Contains(c.Body, github.SpecCommentMarker) {
+			markerFound = true
+			break
+		}
+	}
+
+	if !markerFound {
+		// First strike: warn and ask the author to improve the body.
+		if err := client.AddLabels(ctx, owner, repo, issue.Number, []string{github.LabelSpecIncomplete}); err != nil {
+			logGitHubAPIError("AddLabels[spec-incomplete]", owner, repo, issue.Number, err)
+		}
+		comment := buildSpecIncompleteComment(reasons)
+		if _, err := client.AddComment(ctx, owner, repo, issue.Number, comment); err != nil {
+			logGitHubAPIError("AddComment[spec-incomplete]", owner, repo, issue.Number, err)
+		}
+		slog.Warn("spec-guard: first strike — issue body too thin, dispatch skipped",
+			slog.Int("issue", issue.Number), slog.Any("reasons", reasons))
+	} else {
+		// Second strike: block the issue.
+		if err := client.AddLabels(ctx, owner, repo, issue.Number, []string{github.LabelBlocked}); err != nil {
+			logGitHubAPIError("AddLabels[blocked]", owner, repo, issue.Number, err)
+		}
+		slog.Warn("spec-guard: second strike — escalating to pilot-blocked",
+			slog.Int("issue", issue.Number))
+	}
+	return true
+}
+
+// buildSpecIncompleteComment renders the structured first-strike comment.
+func buildSpecIncompleteComment(reasons []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n\n", github.SpecCommentMarker)
+	fmt.Fprintf(&b, "⚠️ Pilot can't dispatch this issue: the spec body is too thin to execute against.\n\n")
+	fmt.Fprintf(&b, "**What failed:**\n")
+	for _, r := range reasons {
+		fmt.Fprintf(&b, "- %s\n", r)
+	}
+	fmt.Fprintf(&b, "\n**Suggested template:**\n\n")
+	fmt.Fprintf(&b, "```markdown\n")
+	fmt.Fprintf(&b, "## Context\n\n<!-- Describe what this changes and why -->\n\n")
+	fmt.Fprintf(&b, "## Acceptance\n\n- [ ] ...\n\n")
+	fmt.Fprintf(&b, "## Implementation\n\n<!-- Optional: describe the approach -->\n")
+	fmt.Fprintf(&b, "```\n\n")
+	fmt.Fprintf(&b, "To retry: edit the issue body, then remove the `%s` label.\n", github.LabelSpecIncomplete)
+	fmt.Fprintf(&b, "If `%s` was also added, remove that too.\n", github.LabelBlocked)
+	return b.String()
+}

--- a/internal/adapters/github/spec_validator.go
+++ b/internal/adapters/github/spec_validator.go
@@ -1,0 +1,85 @@
+package github
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// SpecCommentMarker is embedded in the first-strike comment to enable idempotency checks.
+const SpecCommentMarker = "<!-- pilot-spec-incomplete -->"
+
+const specMinBodyLen = 100
+
+var (
+	// parentOnlyRe matches a body that is solely a "Parent: GH-NNN" line.
+	parentOnlyRe = regexp.MustCompile(`(?i)^\s*Parent:\s*GH-\d+\s*$`)
+	// parentRefRe extracts the parent issue number from a Parent: GH-NNN line.
+	parentRefRe = regexp.MustCompile(`(?i)Parent:\s*GH-(\d+)`)
+	// autopilotMetaRe detects decomposer-generated sub-issues.
+	autopilotMetaRe = regexp.MustCompile(`<!--\s*autopilot-meta\s`)
+	// sectionHeaderRe requires at least one recognized structural section header.
+	sectionHeaderRe = regexp.MustCompile(`(?im)^##\s+(Acceptance|Implementation|Context|Background|Approach|Design|Refs)\b`)
+)
+
+// SpecValidationResult holds the outcome of ValidateSpec.
+type SpecValidationResult struct {
+	Valid          bool
+	FailureReasons []string // human-readable; e.g. "body too short (78 chars, need 100)"
+	SkipReason     string   // non-empty when the check was opted out
+}
+
+// ValidateSpec checks whether issue body is sufficiently specified for dispatch.
+// parentResolver, if non-nil, is called to fetch a parent issue by number when
+// evaluating decomposer-generated sub-issues.
+func ValidateSpec(issue *Issue, parentResolver func(int) (*Issue, error)) SpecValidationResult {
+	// Opt-out: pilot-skip-spec-check label bypasses all rules.
+	for _, l := range issue.Labels {
+		if l.Name == LabelSkipSpecCheck {
+			return SpecValidationResult{
+				Valid:      true,
+				SkipReason: fmt.Sprintf("opted out via %s label", LabelSkipSpecCheck),
+			}
+		}
+	}
+
+	body := strings.TrimSpace(issue.Body)
+
+	// Sub-issue with autopilot-meta marker: if parent is well-specced the child passes.
+	if parentResolver != nil && autopilotMetaRe.MatchString(issue.Body) {
+		if m := parentRefRe.FindStringSubmatch(issue.Body); len(m) > 1 {
+			var parentNum int
+			if _, err := fmt.Sscanf(m[1], "%d", &parentNum); err == nil && parentNum > 0 {
+				if parent, err := parentResolver(parentNum); err == nil {
+					parentResult := ValidateSpec(parent, nil)
+					if parentResult.Valid || parentResult.SkipReason != "" {
+						return SpecValidationResult{
+							Valid:      true,
+							SkipReason: fmt.Sprintf("parent GH-%d passes spec check", parentNum),
+						}
+					}
+				}
+			}
+		}
+	}
+
+	var reasons []string
+
+	if len(body) < specMinBodyLen {
+		reasons = append(reasons, fmt.Sprintf("body too short (%d chars, need %d)", len(body), specMinBodyLen))
+	}
+
+	if parentOnlyRe.MatchString(body) {
+		reasons = append(reasons, "body contains only a parent reference line")
+	}
+
+	if !sectionHeaderRe.MatchString(body) {
+		reasons = append(reasons,
+			"no structural section header (need one of: ## Acceptance, ## Implementation, ## Context, ## Background, ## Approach, ## Design, ## Refs)")
+	}
+
+	return SpecValidationResult{
+		Valid:          len(reasons) == 0,
+		FailureReasons: reasons,
+	}
+}

--- a/internal/adapters/github/spec_validator_test.go
+++ b/internal/adapters/github/spec_validator_test.go
@@ -1,0 +1,161 @@
+package github
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// validBody returns a body with a section header and >= 100 chars to pass all rules.
+func validBody() string {
+	return strings.Repeat("x", 60) + "\n\n## Acceptance\n\n- [ ] Does the thing correctly\n"
+}
+
+func TestValidateSpec_ValidBody(t *testing.T) {
+	issue := &Issue{
+		Number: 1,
+		Title:  "feat(foo): do something",
+		Body:   validBody(),
+	}
+	result := ValidateSpec(issue, nil)
+	if !result.Valid {
+		t.Errorf("expected Valid=true, got reasons=%v", result.FailureReasons)
+	}
+	if result.SkipReason != "" {
+		t.Errorf("expected no SkipReason, got %q", result.SkipReason)
+	}
+}
+
+func TestValidateSpec_BodyTooShort(t *testing.T) {
+	issue := &Issue{
+		Number: 2,
+		Title:  "cascade-2 repro",
+		Body:   "cascade-2 repro", // 15 chars — mirrors the real cascade-2 sub-issues
+	}
+	result := ValidateSpec(issue, nil)
+	if result.Valid {
+		t.Fatal("expected Valid=false for 15-char body")
+	}
+	foundShort := false
+	for _, r := range result.FailureReasons {
+		if strings.Contains(r, "body too short") {
+			foundShort = true
+		}
+	}
+	if !foundShort {
+		t.Errorf("expected 'body too short' reason, got %v", result.FailureReasons)
+	}
+}
+
+func TestValidateSpec_ParentOnlyBody(t *testing.T) {
+	issue := &Issue{
+		Number: 3,
+		Body:   "Parent: GH-201",
+	}
+	result := ValidateSpec(issue, nil)
+	if result.Valid {
+		t.Fatal("expected Valid=false for parent-only body")
+	}
+	foundParent := false
+	for _, r := range result.FailureReasons {
+		if strings.Contains(r, "parent reference") {
+			foundParent = true
+		}
+	}
+	if !foundParent {
+		t.Errorf("expected 'parent reference' reason, got %v", result.FailureReasons)
+	}
+}
+
+func TestValidateSpec_NoSectionHeader(t *testing.T) {
+	// 200 chars, no section header
+	body := strings.Repeat("This is a long body without any structural section header. ", 4)
+	issue := &Issue{
+		Number: 4,
+		Body:   body,
+	}
+	result := ValidateSpec(issue, nil)
+	if result.Valid {
+		t.Fatal("expected Valid=false for body without section header")
+	}
+	foundHeader := false
+	for _, r := range result.FailureReasons {
+		if strings.Contains(r, "structural section header") {
+			foundHeader = true
+		}
+	}
+	if !foundHeader {
+		t.Errorf("expected 'structural section header' reason, got %v", result.FailureReasons)
+	}
+}
+
+func TestValidateSpec_SkipLabelOptOut(t *testing.T) {
+	// Body fails all rules — but the skip label is present.
+	issue := &Issue{
+		Number: 5,
+		Body:   "too short",
+		Labels: []Label{{Name: LabelSkipSpecCheck}},
+	}
+	result := ValidateSpec(issue, nil)
+	if !result.Valid {
+		t.Errorf("expected Valid=true (opted out), got reasons=%v", result.FailureReasons)
+	}
+	if result.SkipReason == "" {
+		t.Error("expected non-empty SkipReason for opted-out issue")
+	}
+}
+
+func TestValidateSpec_SubIssueParentPasses(t *testing.T) {
+	// Child body is "see parent" (terse) but has autopilot-meta marker and the
+	// parent is well-specced → child should pass.
+	parentBody := validBody()
+	parentResolver := func(num int) (*Issue, error) {
+		if num == 201 {
+			return &Issue{Number: 201, Body: parentBody}, nil
+		}
+		return nil, errors.New("not found")
+	}
+
+	child := &Issue{
+		Number: 6,
+		Body:   "see parent\nParent: GH-201\n<!-- autopilot-meta branch:pilot/GH-200 pr:99 iteration:1 -->",
+	}
+	result := ValidateSpec(child, parentResolver)
+	if !result.Valid {
+		t.Errorf("expected Valid=true (parent passes), got reasons=%v", result.FailureReasons)
+	}
+	if !strings.Contains(result.SkipReason, "parent GH-201") {
+		t.Errorf("expected SkipReason to mention parent GH-201, got %q", result.SkipReason)
+	}
+}
+
+func TestValidateSpec_SubIssueParentFails(t *testing.T) {
+	// Child has autopilot-meta marker but parent also fails — child should fail.
+	parentResolver := func(num int) (*Issue, error) {
+		return &Issue{Number: num, Body: "too short"}, nil
+	}
+
+	child := &Issue{
+		Number: 7,
+		Body:   "see parent\nParent: GH-300\n<!-- autopilot-meta branch:pilot/GH-299 pr:88 iteration:1 -->",
+	}
+	result := ValidateSpec(child, parentResolver)
+	if result.Valid {
+		t.Error("expected Valid=false when both child and parent fail")
+	}
+}
+
+func TestValidateSpec_SectionHeaderVariants(t *testing.T) {
+	headers := []string{
+		"## Acceptance", "## Implementation", "## Context",
+		"## Background", "## Approach", "## Design", "## Refs",
+	}
+	for _, h := range headers {
+		body := strings.Repeat("x", 80) + "\n\n" + h + "\n\nsome content here and there\n"
+		issue := &Issue{Number: 8, Body: body}
+		result := ValidateSpec(issue, nil)
+		if !result.Valid {
+			t.Errorf("header %q should make body valid, got reasons=%v", h, result.FailureReasons)
+		}
+	}
+}

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -98,6 +98,8 @@ const (
 	LabelTitleRejected = "pilot-title-rejected" // GH-2363: title guard escalation; blocks auto-retry until human edits title
 	LabelSuperseded    = "pilot-superseded"     // GH-2402: sub-issue auto-closed because parent epic already shipped the work
 	LabelBlocked       = "pilot-blocked"        // GH-2402: deterministic failure that won't change between retries (e.g. non-conventional title)
+	LabelSpecIncomplete = "pilot-spec-incomplete" // GH-2619: issue body too thin to dispatch; first-strike warning
+	LabelSkipSpecCheck  = "pilot-skip-spec-check" // GH-2619: opt-out from spec quality gate (trivial micro-issues)
 
 	// GH-2432: Retry-counter labels persist retry state across `pilot start`
 	// restarts (the in-memory retryReadyCount map was lost on restart, letting


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2619.

Closes #2619

## Changes

GitHub Issue #2619: feat(adapters): add structural spec-quality validator at issue dispatch

P2. Add a structural spec-quality validator that gates Pilot dispatch BEFORE the executor runs. Refuses to dispatch issues whose bodies are too thin to execute against — the cascade-2 pattern was a vague title + empty body → executor improvises 512 LoC.

This complements the cascade-2 hardening rails (#2587, #2588, #2592, #2594, #2598) which all catch contamination AFTER execution starts. This catches it BEFORE.

## Real-world hit
Cascade-2 sub-issues (#2577, #2580) had body == title only (14 chars). Decomposer generated them as cascade artefacts. Existing rails caught the merge contamination but the executor still spent tokens improvising.

## Where to insert
**`cmd/pilot/handlers.go:248` — immediately before `client.AddLabels(..., LabelInProgress)`** in `handleGitHubIssueWithResult`. Mirror the existing cross-project guard at `handlers.go:178–190`: validate, on failure call `AddLabels` + `AddComment`, return early without creating an `executions` row.

## Validator rules (deterministic, structural — no LLM, no API)

A spec passes if **all** of these hold:

1. **Body length >= 100 chars** after trimming whitespace.
2. **Body is not solely a `Parent: GH-NNN` reference line.** Regex: body matches `^\s*Parent:\s*GH-\d+\s*$` → fail. Sub-issues with content beyond the parent ref pass.
3. **At least one structural section header** present, case-insensitive: `## Acceptance`, `## Implementation`, `## Context`, `## Background`, `## Approach`, `## Design`, `## Refs`. The `ExtractAcceptanceCriteria` regex pattern in `internal/adapters/github/converter.go:140` shows the parsing precedent.

A spec is **opted out** of the validator if it carries the label `pilot-skip-spec-check` (new label). Use case: trivial micro-issues like #2595 (`chore(memory)`, 1 LoC) where structural boilerplate is overhead.

## Failure mode (two-strike, matches title-rejection pattern)

- **First strike (issue first hits the validator):** Add `pilot-spec-incomplete` label (new). Post a single PR-style structured comment listing which rules failed + a copy-pasteable template body the author can use to fix it. Use HTML marker `<!-- pilot-spec-incomplete -->` for idempotency. Skip dispatch on this poll cycle.
- **Second strike (issue still fails on next poll, comment marker present):** Add `pilot-blocked` label (existing — `internal/executor/types.go:100`). The poller's existing `LabelBlocked` skip at `poller.go:617,828` then takes over. Author must fix body AND remove `pilot-blocked` to retry.

## Sub-issue handling

Decomposer-generated sub-issues are tagged with their generator metadata (`<!-- autopilot-meta branch:... pr:... iteration:N -->` per `feedback_loop.go:215`). For sub-issues without this marker, apply the same rules. For sub-issues that have it, the parent's body (resolved via the `Parent: GH-NNN` reference) is also checked — if the parent passes, the sub-issue passes regardless of length. This prevents legitimate decomposer sub-issues with terse bodies from being blocked when the parent is well-specced.

## Acceptance

1. **New file** `internal/adapters/github/spec_validator.go` exposing:
   ```go
   type SpecValidationResult struct {
       Valid         bool
       FailureReasons []string // human-readable; e.g. "body too short (78 chars, need 100)"
       SkipReason    string    // populated when skipped via opt-out label
   }
   func ValidateSpec(issue *Issue, parentResolver func(int) (*Issue, error)) SpecValidationResult
   ```
2. **Hook in `cmd/pilot/handlers.go:248`** — call `ValidateSpec`, on `!Valid && SkipReason==\"\"` apply two-strike logic, return early.
3. **New label constants** in `internal/executor/types.go`:
   - `LabelSpecIncomplete = \"pilot-spec-incomplete\"`
   - `LabelSkipSpecCheck = \"pilot-skip-spec-check\"`
4. **Idempotent comment** via `<!-- pilot-spec-incomplete -->` HTML marker (same pattern as #2598's idempotency).
5. **Tests** in new `internal/adapters/github/spec_validator_test.go`:
   - Valid: body with `## Acceptance` and >100 chars → pass.
   - Invalid: body == title (cascade-2 repro: 14-char body) → fail with reason \"body too short\".
   - Invalid: body == `Parent: GH-201` only → fail with reason \"only parent reference\".
   - Invalid: body 200 chars, no section header → fail with reason \"no structural section\".
   - Opted out: any failing body + `pilot-skip-spec-check` label → pass with `SkipReason`.
   - Sub-issue: child body \"see parent\" + parent body has `## Acceptance` → pass.
6. **Handler-level test** in new `cmd/pilot/handlers_spec_test.go`: first-strike applies `pilot-spec-incomplete`, second-strike applies `pilot-blocked`, both early-return without creating `executions` row.
7. **Update `permanentFailurePatterns`** at `internal/executor/runner.go:27–31` if the spec-validation error string flows through that path (review during implementation; may not be needed since the guard is at handler level, before runner).

## Constraints

- Keep diff under 200 LoC of net code (tests can exceed). The validator itself is <80 LoC; tests will dominate.
- **NO LLM calls.** No API calls. Pure regex + length + label inspection.
- Do NOT modify the cascade-2 rails (#2587, #2588, #2592, #2594, #2598).
- Do NOT modify the conventional-title validator (`title_rejection.go`) — that runs LATER, at PR-creation. This validator runs EARLIER.
- Do NOT auto-edit issue bodies. Comment only.
- The `LabelSkipSpecCheck` opt-out is intentional: a few legitimate issues (smoke tests, doc nudges) are too small for boilerplate.

## Risk surface

- `internal/adapters/github/poller_test.go:2854` (`TestPoller_CheckForNewIssues_SkipsBlockedIssues`) — unaffected since validator runs at handler layer, not poller. But add a parallel handler-level test.
- No `executions` rows created when guard fires (verified: handler returns before `:248` label-add and well before any execution-row write).
- Two new labels need creation in the repo. Document in PR description so user adds them via GH UI or `gh label create`.

## Refs

- Research findings (this session): handler insertion point, conventional-title validator pattern, `ExtractAcceptanceCriteria` regex, permanent-failure escalation chain.
- Memories: `incident_oauth_cascade_series.md`, `feedback_check_all_prompts_for_leaks.md`, `feedback_conventional_title_required.md`.
- Sister tickets: #2587, #2588, #2592, #2594, #2598 — all post-dispatch contamination guards. This is the pre-dispatch guard.