### PR TITLE
GH-2620: feat(dashboard): redesign autopilot card (variant A — pipeline-as-status)

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -116,49 +116,72 @@ var (
 				Foreground(lipgloss.Color("#d4a054")) // amber
 )
 
+// autopilotController is the subset of autopilot.Controller used by AutopilotPanel.
+// Defined as an interface so tests can inject fakes without a real Controller.
+type autopilotController interface {
+	GetActivePRs() []*autopilot.PRState
+	Config() *autopilot.Config
+	GetPRFailures(prNumber int) int
+}
+
 // AutopilotPanel displays autopilot status in the dashboard.
 type AutopilotPanel struct {
-	controller *autopilot.Controller
+	controller autopilotController
 	panelWidth int // dynamic panel width, set before View()
+	tick       int // increments per 1s animation tick, drives ◐ rotation
 }
 
 // NewAutopilotPanel creates an autopilot panel.
 func NewAutopilotPanel(controller *autopilot.Controller) *AutopilotPanel {
+	if controller == nil {
+		return &AutopilotPanel{controller: nil, panelWidth: panelTotalWidth}
+	}
 	return &AutopilotPanel{controller: controller, panelWidth: panelTotalWidth}
 }
 
-// View renders the autopilot panel content (GH-2455 avionics redesign).
-// Active PR: STATE/PR/AGE + CI/MERGE/RETRY gauges + pipeline rail.
-// Idle: compact single-line STATE IDLE indicator.
+// SetTick updates the animation tick counter (called from the parent model's tickMsg handler).
+func (p *AutopilotPanel) SetTick(t int) { p.tick = t }
+
+// View renders the autopilot panel (GH-2620 variant A redesign).
+// Compact layout: no empty-line padding rows.
+// Idle: 3 lines (border, content, border).
+// Active: 4 lines (+ PR identity + pipeline rail).
+// Failed: 5 lines (+ error reason on line 3).
 func (p *AutopilotPanel) View() string {
 	tw := p.panelWidth
 	if tw < panelTotalWidth {
 		tw = panelTotalWidth
 	}
+	inner := tw - 4 // content width: tw minus 2 borders and 2 padding spaces
 
 	if p.controller == nil {
-		return renderPanel("AUTOPILOT", "  Disabled", tw)
+		return p.buildCompactPanel(tw, "  Disabled")
 	}
 
 	prs := p.controller.GetActivePRs()
 	if len(prs) == 0 {
-		idle := "  " + labelStyle.Render("STATE") + "  " + dimStyle.Render("IDLE") + "  ─  no active PR"
-		return renderPanel("AUTOPILOT", idle, tw)
+		return p.buildCompactPanel(tw, "  "+dimStyle.Render("idle · no active PR"))
 	}
 
-	// Render first active PR with full detail; summarise additional PRs below.
 	pr := prs[0]
-	var content strings.Builder
 
-	// STATE / PR / AGE block
+	// Line 1: "  #NNNN  {title}{padding}{age}"
 	age := p.formatDuration(time.Since(pr.CreatedAt))
-	content.WriteString(fmt.Sprintf("  %s  %s    %s  #%d    %s  %s",
-		labelStyle.Render("STATE"), statusRunningStyle.Render(string(pr.Stage)),
-		labelStyle.Render("PR"), pr.PRNumber,
-		labelStyle.Render("AGE"), age))
-	content.WriteString("\n")
+	prefix1 := fmt.Sprintf("  #%d  ", pr.PRNumber)
+	prefix1Len := lipgloss.Width(prefix1)
+	ageLen := len(age)
+	titleMaxLen := inner - prefix1Len - ageLen - 1 // 1 space before age
+	if titleMaxLen < 5 {
+		titleMaxLen = 5
+	}
+	title := truncateString(pr.PRTitle, titleMaxLen)
+	pad1 := inner - prefix1Len - len(title) - ageLen
+	if pad1 < 1 {
+		pad1 = 1
+	}
+	line1 := prefix1 + title + strings.Repeat(" ", pad1) + age
 
-	// CI / MERGE / RETRY gauges
+	// Line 2: "  {rail}{padding}{N/M[ ⟲]}"
 	cfg := p.controller.Config()
 	maxFailures := cfg.MaxFailures
 	if maxFailures <= 0 {
@@ -166,76 +189,54 @@ func (p *AutopilotPanel) View() string {
 	}
 	failures := p.controller.GetPRFailures(pr.PRNumber)
 
-	ciPct := autopilotCIProgressPct(pr.CIStatus)
-	mergePct := 0
-	if pr.Stage == autopilot.StageMerging || pr.Stage == autopilot.StageMerged ||
-		pr.Stage == autopilot.StagePostMergeCI || pr.Stage == autopilot.StageReleasing {
-		mergePct = 100
+	rail := renderAutopilotRail(pr.Stage, pr.CIStatus, p.tick)
+
+	retryNum := fmt.Sprintf("%d/%d", failures, maxFailures)
+	var retryStr string
+	if failures > 0 {
+		retryStr = dimStyle.Render(retryNum) + " " + warningStyle.Render("⟲")
+	} else {
+		retryStr = dimStyle.Render(retryNum) + " "
 	}
-	retryPct := 0
-	if maxFailures > 0 {
-		retryPct = failures * 100 / maxFailures
+
+	pad2 := inner - 2 - lipgloss.Width(rail) - lipgloss.Width(retryStr)
+	if pad2 < 1 {
+		pad2 = 1
 	}
+	line2 := "  " + rail + strings.Repeat(" ", pad2) + retryStr
 
-	ciBar := renderAutopilotBar(ciPct, 8)
-	mergeBar := renderAutopilotBar(mergePct, 8)
-	retryBar := renderAutopilotBar(retryPct, 8)
+	lines := []string{line1, line2}
 
-	content.WriteString(fmt.Sprintf("  CI [%s]  MRG [%s]  RTY [%s] %d/%d",
-		ciBar, mergeBar, retryBar, failures, maxFailures))
-	content.WriteString("\n")
-
-	// Pipeline rail
-	content.WriteString("  " + renderAutopilotRail(pr.Stage))
-
-	// Error annotation if failed
+	// Line 3 (conditional): "  ↳ {truncated error}" — only on failure with message
 	if pr.Stage == autopilot.StageFailed && pr.Error != "" {
-		content.WriteString("\n")
-		content.WriteString("  " + statusFailedStyle.Render("!") + " " + truncateString(pr.Error, 55))
+		const errPrefix = "  ↳ "
+		errMax := inner - len(errPrefix)
+		if errMax < 5 {
+			errMax = 5
+		}
+		lines = append(lines, errPrefix+truncateString(pr.Error, errMax))
 	}
 
-	// Additional PRs count
+	// Overflow: additional active PRs
 	if len(prs) > 1 {
-		content.WriteString("\n")
-		content.WriteString(fmt.Sprintf("  + %d more PR(s)", len(prs)-1))
+		lines = append(lines, fmt.Sprintf("  + %d more PR(s)", len(prs)-1))
 	}
 
-	return renderPanel("AUTOPILOT", content.String(), tw)
+	return p.buildCompactPanel(tw, lines...)
 }
 
-// autopilotCIProgressPct maps CIStatus to a 0–100 progress percentage.
-func autopilotCIProgressPct(status autopilot.CIStatus) int {
-	switch status {
-	case autopilot.CIPending:
-		return 0
-	case autopilot.CIRunning:
-		return 50
-	case autopilot.CISuccess:
-		return 100
-	case autopilot.CIFailure:
-		return 0
+// buildCompactPanel renders a bordered panel without empty-line padding rows.
+// This produces exactly len(lines)+2 output lines (top border, content lines, bottom border).
+func (p *AutopilotPanel) buildCompactPanel(tw int, lines ...string) string {
+	var sb strings.Builder
+	sb.WriteString(buildTopBorder("AUTOPILOT", tw))
+	for _, line := range lines {
+		sb.WriteString("\n")
+		sb.WriteString(buildContentLine(line, tw))
 	}
-	return 0
-}
-
-// renderAutopilotBar renders a mini progress bar of the given width (in filled chars).
-// Uses █ for filled and ░ for empty, coloured with existing progress styles.
-func renderAutopilotBar(pct, barWidth int) string {
-	if pct < 0 {
-		pct = 0
-	}
-	if pct > 100 {
-		pct = 100
-	}
-	filled := barWidth * pct / 100
-	var b strings.Builder
-	if filled > 0 {
-		b.WriteString(progressBarStyle.Render(strings.Repeat("█", filled)))
-	}
-	if barWidth-filled > 0 {
-		b.WriteString(progressEmptyStyle.Render(strings.Repeat("░", barWidth-filled)))
-	}
-	return b.String()
+	sb.WriteString("\n")
+	sb.WriteString(buildBottomBorder(tw))
+	return sb.String()
 }
 
 // pipelineStagePosition maps a PRStage to its 0-based position in the 5-node rail.
@@ -258,34 +259,45 @@ func pipelineStagePosition(stage autopilot.PRStage) int {
 	return 0
 }
 
-// renderAutopilotRail renders the 5-node pipeline progress rail with a status
-// lamp before each node: ✓ (done, sage), ● (current, steel blue), ○ (pending,
-// dim slate). Connectors are plain dim "──" separators.
+// renderAutopilotRail renders the 5-node pipeline rail with glyph-per-node status.
+// Glyphs: ✓ done (sage), ◐◓◑◒ in-progress animated (steel blue), ○ pending (gray), ✗ failed (rose).
+// tick drives the spinner rotation; ciStatus allows the ci node to show ✗ independently of stage.
 // Format example for stage=releasing:
 //
-//	✓ ci-wait ── ✓ rebase ── ✓ merge ── ✓ tag ── ● release
-func renderAutopilotRail(stage autopilot.PRStage) string {
-	nodes := []string{"ci-wait", "rebase", "merge", "tag", "release"}
+//	✓ ci ── ✓ rebase ── ✓ merge ── ✓ tag ── ◐ release
+func renderAutopilotRail(stage autopilot.PRStage, ciStatus autopilot.CIStatus, tick int) string {
+	nodes := []string{"ci", "rebase", "merge", "tag", "release"}
+	spinner := []rune{'◐', '◓', '◑', '◒'}
 	pos := pipelineStagePosition(stage)
+
 	var sb strings.Builder
 	for i, name := range nodes {
-		var lamp, label string
-		var lampStyle, labelStyle lipgloss.Style
+		var glyph string
+		var glyphStyle, nameStyle lipgloss.Style
+
 		switch {
+		case i == 0 && ciStatus == autopilot.CIFailure:
+			// CI check failed — show ✗ on the ci node regardless of current stage
+			glyph = "✗"
+			glyphStyle, nameStyle = statusFailedStyle, statusFailedStyle
+		case stage == autopilot.StageFailed && i == pos:
+			// Pipeline failed at current position — show ✗
+			glyph = "✗"
+			glyphStyle, nameStyle = statusFailedStyle, statusFailedStyle
 		case i < pos:
-			lamp, lampStyle = "✓", statusCompletedStyle
-			labelStyle = statusCompletedStyle
+			glyph = "✓"
+			glyphStyle, nameStyle = statusCompletedStyle, statusCompletedStyle
 		case i == pos:
-			lamp, lampStyle = "●", statusRunningStyle
-			labelStyle = titleStyle
+			glyph = string(spinner[tick%4])
+			glyphStyle, nameStyle = statusRunningStyle, titleStyle
 		default:
-			lamp, lampStyle = "○", dimStyle
-			labelStyle = dimStyle
+			glyph = "○"
+			glyphStyle, nameStyle = dimStyle, dimStyle
 		}
-		label = name
-		sb.WriteString(lampStyle.Render(lamp))
+
+		sb.WriteString(glyphStyle.Render(glyph))
 		sb.WriteString(" ")
-		sb.WriteString(labelStyle.Render(label))
+		sb.WriteString(nameStyle.Render(name))
 		if i < len(nodes)-1 {
 			sb.WriteString(dimStyle.Render(" ── "))
 		}
@@ -999,6 +1011,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.sparklineTick = !m.sparklineTick
 		m.shimmerTick++
 		m.dbSyncTick++
+		if m.autopilotPanel != nil {
+			m.autopilotPanel.SetTick(m.autopilotPanel.tick + 1)
+		}
 		// GH-2248: Re-sync history and metrics from SQLite every 5 seconds
 		// so external DB changes (orphan cleanup, manual edits) are reflected.
 		if m.store != nil && m.dbSyncTick%5 == 0 {

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -1402,64 +1402,232 @@ func TestAutopilotPanelDisabled(t *testing.T) {
 }
 
 func TestRenderAutopilotRailPositions(t *testing.T) {
-	// New rail uses lamp-per-node: ✓ (done) / ● (current) / ○ (pending).
-	// Each rail has exactly one ● (the current stage), N done lamps, M pending lamps.
+	// Rail uses glyph-per-node: ✓ (done) / ◐◓◑◒ (current, animated) / ○ (pending) / ✗ (failed).
+	// Spinner index 0 → ◐ for the in-progress node.
 	tests := []struct {
 		stage    autopilot.PRStage
-		wantDone int // count of ✓
-		wantBull int // count of ● (always 1 for active stages)
-		wantPend int // count of ○
-		nodeName string
+		ciStatus autopilot.CIStatus
+		tick     int
+		wantDone int    // count of ✓
+		wantPend int    // count of ○
+		wantFail int    // count of ✗
+		nodeName string // must appear in rail
 	}{
-		{autopilot.StageWaitingCI, 0, 1, 4, "ci-wait"},
-		{autopilot.StageMerging, 2, 1, 2, "merge"},
-		{autopilot.StagePostMergeCI, 3, 1, 1, "tag"},
-		{autopilot.StageReleasing, 4, 1, 0, "release"},
+		{autopilot.StageWaitingCI, autopilot.CIPending, 0, 0, 4, 0, "ci"},
+		{autopilot.StageMerging, autopilot.CISuccess, 0, 2, 2, 0, "merge"},
+		{autopilot.StagePostMergeCI, autopilot.CISuccess, 0, 3, 1, 0, "tag"},
+		{autopilot.StageReleasing, autopilot.CISuccess, 0, 4, 0, 0, "release"},
+		// CI failure: ✗ on ci node
+		{autopilot.StageCIFailed, autopilot.CIFailure, 0, 0, 4, 1, "ci"},
+		// Pipeline failure (non-CI)
+		{autopilot.StageFailed, autopilot.CIPending, 0, 0, 4, 1, "ci"},
 	}
 
 	for _, tt := range tests {
 		t.Run(string(tt.stage), func(t *testing.T) {
-			out := renderAutopilotRail(tt.stage)
-			if got := strings.Count(out, "✓"); got != tt.wantDone {
-				t.Errorf("stage %s: ✓ count = %d, want %d (rail: %q)", tt.stage, got, tt.wantDone, out)
+			out := renderAutopilotRail(tt.stage, tt.ciStatus, tt.tick)
+			plain := stripANSI(out)
+			if got := strings.Count(plain, "✓"); got != tt.wantDone {
+				t.Errorf("stage %s: ✓ count = %d, want %d (rail: %q)", tt.stage, got, tt.wantDone, plain)
 			}
-			if got := strings.Count(out, "●"); got != tt.wantBull {
-				t.Errorf("stage %s: ● count = %d, want %d (rail: %q)", tt.stage, got, tt.wantBull, out)
+			if got := strings.Count(plain, "○"); got != tt.wantPend {
+				t.Errorf("stage %s: ○ count = %d, want %d (rail: %q)", tt.stage, got, tt.wantPend, plain)
 			}
-			if got := strings.Count(out, "○"); got != tt.wantPend {
-				t.Errorf("stage %s: ○ count = %d, want %d (rail: %q)", tt.stage, got, tt.wantPend, out)
+			if got := strings.Count(plain, "✗"); got != tt.wantFail {
+				t.Errorf("stage %s: ✗ count = %d, want %d (rail: %q)", tt.stage, got, tt.wantFail, plain)
 			}
-			if !strings.Contains(out, tt.nodeName) {
-				t.Errorf("stage %s: rail missing node %q", tt.stage, tt.nodeName)
+			if !strings.Contains(plain, tt.nodeName) {
+				t.Errorf("stage %s: rail missing node %q (rail: %q)", tt.stage, tt.nodeName, plain)
+			}
+			// Old glyph must not appear
+			if strings.Contains(plain, "●") {
+				t.Errorf("stage %s: rail contains deprecated ● glyph: %q", tt.stage, plain)
+			}
+			// No fake progress bars
+			if strings.Contains(plain, "[█") || strings.Contains(plain, "[░") {
+				t.Errorf("stage %s: rail contains fake progress bar chars: %q", tt.stage, plain)
 			}
 		})
 	}
 }
 
-func TestRenderAutopilotBar(t *testing.T) {
+func TestRenderAutopilotRailSpinner(t *testing.T) {
+	// Each tick value should produce a different spinner rune for the active node.
+	spinnerRunes := []string{"◐", "◓", "◑", "◒"}
+	for tick, want := range spinnerRunes {
+		out := renderAutopilotRail(autopilot.StageWaitingCI, autopilot.CIPending, tick)
+		plain := stripANSI(out)
+		if !strings.Contains(plain, want) {
+			t.Errorf("tick=%d: expected spinner rune %q not found in rail: %q", tick, want, plain)
+		}
+	}
+}
+
+// fakeAutopilotCtl implements autopilotController for testing without a real Controller.
+type fakeAutopilotCtl struct {
+	prs      []*autopilot.PRState
+	cfg      *autopilot.Config
+	failures map[int]int
+}
+
+func (f *fakeAutopilotCtl) GetActivePRs() []*autopilot.PRState { return f.prs }
+func (f *fakeAutopilotCtl) Config() *autopilot.Config          { return f.cfg }
+func (f *fakeAutopilotCtl) GetPRFailures(n int) int            { return f.failures[n] }
+
+func newFakeCtl(prs []*autopilot.PRState, maxFailures int, failures map[int]int) *fakeAutopilotCtl {
+	if failures == nil {
+		failures = map[int]int{}
+	}
+	return &fakeAutopilotCtl{
+		prs:      prs,
+		cfg:      &autopilot.Config{MaxFailures: maxFailures},
+		failures: failures,
+	}
+}
+
+func TestAutopilotPanelView_AllStates(t *testing.T) {
+	now := time.Now()
 	tests := []struct {
-		pct       int
-		barWidth  int
-		wantFull  int // count of filled █ chars
-		wantEmpty int
+		name        string
+		ctl         autopilotController
+		wantLines   int    // total output lines (borders included)
+		wantContain string // substring in plain text
+		wantAbsent  string // substring that must NOT appear
 	}{
-		{0, 8, 0, 8},
-		{50, 8, 4, 4},
-		{100, 8, 8, 0},
-		{100, 10, 10, 0},
+		{
+			name:        "disabled",
+			ctl:         nil,
+			wantLines:   3, // top border + content + bottom border
+			wantContain: "Disabled",
+		},
+		{
+			name:        "idle",
+			ctl:         newFakeCtl(nil, 3, nil),
+			wantLines:   3,
+			wantContain: "idle · no active PR",
+			wantAbsent:  "STATE",
+		},
+		{
+			name: "ci-running steady state",
+			ctl: newFakeCtl([]*autopilot.PRState{{
+				PRNumber:  2565,
+				PRTitle:   "fix(upgrade): atomic binary replacement",
+				Stage:     autopilot.StageWaitingCI,
+				CIStatus:  autopilot.CIRunning,
+				CreatedAt: now.Add(-90 * time.Second),
+			}}, 3, nil),
+			wantLines:   4, // border + line1 + line2 + border
+			wantContain: "#2565",
+			wantAbsent:  "[█",
+		},
+		{
+			name: "ci-failed with error",
+			ctl: newFakeCtl([]*autopilot.PRState{{
+				PRNumber:  2565,
+				PRTitle:   "fix(upgrade): atomic binary replacement",
+				Stage:     autopilot.StageFailed,
+				CIStatus:  autopilot.CIFailure,
+				Error:     "TestInstallToBinaryPath_Cleanup failed · linux-amd64",
+				CreatedAt: now.Add(-4 * time.Minute),
+			}}, 3, map[int]int{2565: 2}),
+			wantLines:   5, // border + line1 + line2 + line3(error) + border
+			wantContain: "↳",
+			wantAbsent:  "STATE",
+		},
+		{
+			name: "rebase in progress",
+			ctl: newFakeCtl([]*autopilot.PRState{{
+				PRNumber:  2565,
+				PRTitle:   "fix(upgrade): atomic binary replacement",
+				Stage:     autopilot.StageAwaitApproval,
+				CIStatus:  autopilot.CISuccess,
+				CreatedAt: now.Add(-3 * time.Minute),
+			}}, 3, nil),
+			wantLines:   4,
+			wantContain: "✓",
+			wantAbsent:  "[░",
+		},
+		{
+			name: "released",
+			ctl: newFakeCtl([]*autopilot.PRState{{
+				PRNumber:  2565,
+				PRTitle:   "fix(upgrade): atomic binary replacement",
+				Stage:     autopilot.StageReleasing,
+				CIStatus:  autopilot.CISuccess,
+				CreatedAt: now.Add(-10 * time.Minute),
+			}}, 3, nil),
+			wantLines:   4,
+			wantContain: "release",
+			wantAbsent:  "STATE",
+		},
+		{
+			name: "failed no error message",
+			ctl: newFakeCtl([]*autopilot.PRState{{
+				PRNumber:  2565,
+				PRTitle:   "fix(upgrade): atomic binary replacement",
+				Stage:     autopilot.StageFailed,
+				CIStatus:  autopilot.CIPending,
+				Error:     "",
+				CreatedAt: now.Add(-2 * time.Minute),
+			}}, 3, nil),
+			wantLines:   4, // no line 3 without error message
+			wantAbsent:  "↳",
+		},
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("%d%%", tt.pct), func(t *testing.T) {
-			out := renderAutopilotBar(tt.pct, tt.barWidth)
-			gotFull := strings.Count(out, "█")
-			gotEmpty := strings.Count(out, "░")
-			if gotFull != tt.wantFull {
-				t.Errorf("pct=%d barWidth=%d: █ count = %d, want %d", tt.pct, tt.barWidth, gotFull, tt.wantFull)
+		t.Run(tt.name, func(t *testing.T) {
+			p := &AutopilotPanel{
+				controller: tt.ctl,
+				panelWidth: panelTotalWidth,
+				tick:       0,
 			}
-			if gotEmpty != tt.wantEmpty {
-				t.Errorf("pct=%d barWidth=%d: ░ count = %d, want %d", tt.pct, tt.barWidth, gotEmpty, tt.wantEmpty)
+			out := p.View()
+			plain := stripANSI(out)
+			lines := strings.Split(out, "\n")
+
+			if len(lines) != tt.wantLines {
+				t.Errorf("line count = %d, want %d\noutput:\n%s", len(lines), tt.wantLines, plain)
+			}
+
+			if tt.wantContain != "" && !strings.Contains(plain, tt.wantContain) {
+				t.Errorf("output missing %q\nplain:\n%s", tt.wantContain, plain)
+			}
+			if tt.wantAbsent != "" && strings.Contains(plain, tt.wantAbsent) {
+				t.Errorf("output must not contain %q\nplain:\n%s", tt.wantAbsent, plain)
+			}
+
+			// No fake progress bars in any state
+			if strings.Contains(plain, "[█") || strings.Contains(plain, "[░") {
+				t.Errorf("output contains fake progress bar chars\nplain:\n%s", plain)
+			}
+
+			// Every line must be panelTotalWidth wide
+			for i, line := range lines {
+				w := lipgloss.Width(line)
+				if w != panelTotalWidth {
+					t.Errorf("line %d visual width = %d, want %d: %q", i, w, panelTotalWidth, line)
+				}
 			}
 		})
+	}
+}
+
+func TestAutopilotPanelTick_RotatesSpinner(t *testing.T) {
+	ctl := newFakeCtl([]*autopilot.PRState{{
+		PRNumber:  100,
+		PRTitle:   "test PR",
+		Stage:     autopilot.StageWaitingCI,
+		CIStatus:  autopilot.CIPending,
+		CreatedAt: time.Now(),
+	}}, 3, nil)
+
+	spinner := []string{"◐", "◓", "◑", "◒"}
+	for tick, want := range spinner {
+		p := &AutopilotPanel{controller: ctl, panelWidth: panelTotalWidth, tick: tick}
+		plain := stripANSI(p.View())
+		if !strings.Contains(plain, want) {
+			t.Errorf("tick=%d: spinner rune %q not found in output:\n%s", tick, want, plain)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2620.

Closes #2620

## Changes

GitHub Issue #2620: feat(dashboard): redesign autopilot card (variant A — pipeline-as-status)

Replace the current autopilot card (GH-2455 "avionics" layout) with a denser, honest variant. Three problems with current:

1. **Fake progress bars** CI/MRG/RTY — CI is binary, MRG is binary, RTY is a count. Rendering them as 8-slot fills is theatre.
2. **STATE field duplicates the pipeline rail** and can disagree with it.
3. **5 lines of card; only 3 carry signal.**

Full design doc: `.agent/tasks/autopilot-card-redesign.md` (319 lines, complete).

## Target — variant A

Steady state (waiting CI):
```
╭─ AUTOPILOT ─────────────────────────────────────────────────────╮
│  #2565  fix(upgrade): atomic binary replacement         1m42s   │
│  ◐ ci ── ○ rebase ── ○ merge ── ○ tag ── ○ release      0/3 ⟲   │
╰─────────────────────────────────────────────────────────────────╯
```

Failed (third line conditional, only on `Stage==Failed && Error != ""`):
```
╭─ AUTOPILOT ─────────────────────────────────────────────────────╮
│  #2565  fix(upgrade): atomic binary replacement         4m10s   │
│  ✗ ci ── ○ rebase ── ○ merge ── ○ tag ── ○ release      2/3 ⟲   │
│  ↳ TestInstallToBinaryPath_Cleanup failed · linux-amd64         │
╰─────────────────────────────────────────────────────────────────╯
```

Idle:
```
╭─ AUTOPILOT ─────────────────────────────────────────────────────╮
│  idle · no active PR                                            │
╰─────────────────────────────────────────────────────────────────╯
```

## Glyphs
- `✓` done — `statusCompletedStyle` (sage `#7ec699`)
- `◐` in progress, animated `◐◓◑◒` on 1s tick — `statusRunningStyle` (steel blue `#7eb8da`)
- `○` pending — `dimStyle` (mid gray `#8b949e`)
- `✗` failed — `statusFailedStyle` (dusty rose `#d48a8a`)
- `⟲` retry — `warningStyle` (amber `#d4a054`); suppress when retries == 0

All styles already exist in `internal/dashboard/tui.go:48-117`. **No new colors.**

## Files
- `internal/dashboard/tui.go` — rewrite `AutopilotPanel.View()` (130-204) and `renderAutopilotRail()` (267-294). Delete `autopilotCIProgressPct` (206-219) and `renderAutopilotBar` (221-239). Add `tick int` field + `SetTick(int)` to `AutopilotPanel`; wire from the parent model where `sparklineTick` toggles.
- `internal/dashboard/tui_test.go` — update `TestRenderAutopilotRailPositions`, add `TestAutopilotPanelView_AllStates` (table-driven), add `TestAutopilotPanelTick_RotatesSpinner`.

Reuse `pipelineStagePosition` (line 242) and `truncateString` (318) as-is. PR title via `pr.PRTitle` (already on the struct, see `auto_merger.go:91`).

## Forbidden
- Do NOT modify `internal/autopilot/*.go` — state machine unchanged.
- Do NOT touch other dashboard panels (TOKENS, COST, TASKS, HISTORY, queue, splash).
- Do NOT add new color constants.
- Do NOT add variant B (multi-PR table) — separate ticket if wanted.

## Acceptance
- 4-line card steady state; 5 lines on failure; 3 lines idle.
- No `[████░░░░]` anywhere in autopilot output.
- No `STATE` literal in autopilot output.
- `◐` rotates through `◐◓◑◒` on 1s tick.
- On `CIFailure`, `ci` stage renders `✗` and reason appears on line 3.
- All autopilot tests pass; new table-driven test covers every state branch.
- `make lint` clean.

## Verify
```
go build ./...
go test ./internal/dashboard/... -run Autopilot -v
make lint
```

## Refs
- Design doc: `.agent/tasks/autopilot-card-redesign.md` (already in repo, untracked at filing time — Pilot may want to commit/move it as part of this PR or in a follow-up cleanup).