### PR TITLE
GH-2626: fix(dashboard): autopilot card missing top/bottom padding rows breaks visual rhythm

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -143,10 +143,10 @@ func NewAutopilotPanel(controller *autopilot.Controller) *AutopilotPanel {
 func (p *AutopilotPanel) SetTick(t int) { p.tick = t }
 
 // View renders the autopilot panel (GH-2620 variant A redesign).
-// Compact layout: no empty-line padding rows.
-// Idle: 3 lines (border, content, border).
-// Active: 4 lines (+ PR identity + pipeline rail).
-// Failed: 5 lines (+ error reason on line 3).
+// Uses renderPanel so the card has the same 1-line top/bottom padding as QUEUE/HISTORY/LOGS.
+// Idle: 5 lines (border, empty, content, empty, border).
+// Active: 6 lines (+ PR identity + pipeline rail).
+// Failed: 7 lines (+ error reason on line 3).
 func (p *AutopilotPanel) View() string {
 	tw := p.panelWidth
 	if tw < panelTotalWidth {
@@ -155,12 +155,12 @@ func (p *AutopilotPanel) View() string {
 	inner := tw - 4 // content width: tw minus 2 borders and 2 padding spaces
 
 	if p.controller == nil {
-		return p.buildCompactPanel(tw, "  Disabled")
+		return renderPanel("AUTOPILOT", "  Disabled", tw)
 	}
 
 	prs := p.controller.GetActivePRs()
 	if len(prs) == 0 {
-		return p.buildCompactPanel(tw, "  "+dimStyle.Render("idle · no active PR"))
+		return renderPanel("AUTOPILOT", "  "+dimStyle.Render("idle · no active PR"), tw)
 	}
 
 	pr := prs[0]
@@ -222,21 +222,7 @@ func (p *AutopilotPanel) View() string {
 		lines = append(lines, fmt.Sprintf("  + %d more PR(s)", len(prs)-1))
 	}
 
-	return p.buildCompactPanel(tw, lines...)
-}
-
-// buildCompactPanel renders a bordered panel without empty-line padding rows.
-// This produces exactly len(lines)+2 output lines (top border, content lines, bottom border).
-func (p *AutopilotPanel) buildCompactPanel(tw int, lines ...string) string {
-	var sb strings.Builder
-	sb.WriteString(buildTopBorder("AUTOPILOT", tw))
-	for _, line := range lines {
-		sb.WriteString("\n")
-		sb.WriteString(buildContentLine(line, tw))
-	}
-	sb.WriteString("\n")
-	sb.WriteString(buildBottomBorder(tw))
-	return sb.String()
+	return renderPanel("AUTOPILOT", strings.Join(lines, "\n"), tw)
 }
 
 // pipelineStagePosition maps a PRStage to its 0-based position in the 5-node rail.

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -1497,13 +1497,13 @@ func TestAutopilotPanelView_AllStates(t *testing.T) {
 		{
 			name:        "disabled",
 			ctl:         nil,
-			wantLines:   3, // top border + content + bottom border
+			wantLines:   5, // top border + empty + content + empty + bottom border
 			wantContain: "Disabled",
 		},
 		{
 			name:        "idle",
 			ctl:         newFakeCtl(nil, 3, nil),
-			wantLines:   3,
+			wantLines:   5, // top border + empty + content + empty + bottom border
 			wantContain: "idle · no active PR",
 			wantAbsent:  "STATE",
 		},
@@ -1516,7 +1516,7 @@ func TestAutopilotPanelView_AllStates(t *testing.T) {
 				CIStatus:  autopilot.CIRunning,
 				CreatedAt: now.Add(-90 * time.Second),
 			}}, 3, nil),
-			wantLines:   4, // border + line1 + line2 + border
+			wantLines:   6, // border + empty + line1 + line2 + empty + border
 			wantContain: "#2565",
 			wantAbsent:  "[█",
 		},
@@ -1530,7 +1530,7 @@ func TestAutopilotPanelView_AllStates(t *testing.T) {
 				Error:     "TestInstallToBinaryPath_Cleanup failed · linux-amd64",
 				CreatedAt: now.Add(-4 * time.Minute),
 			}}, 3, map[int]int{2565: 2}),
-			wantLines:   5, // border + line1 + line2 + line3(error) + border
+			wantLines:   7, // border + empty + line1 + line2 + line3(error) + empty + border
 			wantContain: "↳",
 			wantAbsent:  "STATE",
 		},
@@ -1543,7 +1543,7 @@ func TestAutopilotPanelView_AllStates(t *testing.T) {
 				CIStatus:  autopilot.CISuccess,
 				CreatedAt: now.Add(-3 * time.Minute),
 			}}, 3, nil),
-			wantLines:   4,
+			wantLines:   6, // border + empty + line1 + line2 + empty + border
 			wantContain: "✓",
 			wantAbsent:  "[░",
 		},
@@ -1556,7 +1556,7 @@ func TestAutopilotPanelView_AllStates(t *testing.T) {
 				CIStatus:  autopilot.CISuccess,
 				CreatedAt: now.Add(-10 * time.Minute),
 			}}, 3, nil),
-			wantLines:   4,
+			wantLines:   6, // border + empty + line1 + line2 + empty + border
 			wantContain: "release",
 			wantAbsent:  "STATE",
 		},
@@ -1570,7 +1570,7 @@ func TestAutopilotPanelView_AllStates(t *testing.T) {
 				Error:     "",
 				CreatedAt: now.Add(-2 * time.Minute),
 			}}, 3, nil),
-			wantLines:   4, // no line 3 without error message
+			wantLines:   6, // border + empty + line1 + line2 + empty + border (no error line)
 			wantAbsent:  "↳",
 		},
 	}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2626.

Closes #2626

## Changes

GitHub Issue #2626: fix(dashboard): autopilot card missing top/bottom padding rows breaks visual rhythm

The new variant-A autopilot card (#2620, v2.118.0) renders without the 1-line top/bottom padding rows that every other panel (QUEUE, HISTORY, LOGS, EVAL) uses. The card visually clashes with its neighbours.

## Repro
Run \`pilot start --dashboard\`. Observe stack:

\`\`\`
╭─ QUEUE ───────────────────────────────────────────────────────────╮
│                                                                   │  ← top padding
│   No tasks in queue                                               │
│                                                                   │  ← bottom padding
╰───────────────────────────────────────────────────────────────────╯
╭─ AUTOPILOT ───────────────────────────────────────────────────────╮
│   idle · no active PR                                             │  ← NO padding ❌
╰───────────────────────────────────────────────────────────────────╯
╭─ HISTORY ─────────────────────────────────────────────────────────╮
│                                                                   │  ← top padding
│   + GH-2620  ...                                                  │
│                                                                   │  ← bottom padding
╰───────────────────────────────────────────────────────────────────╯
\`\`\`

## Root cause
\`internal/dashboard/tui.go:228\` — comment is explicit: \`"buildCompactPanel renders a bordered panel without empty-line padding rows."\` — that helper was introduced in #2624 specifically to skip padding for variant A's density goal. But the rest of the dashboard uses \`renderPanel\` at \`tui.go:1665\` which DOES add padding (callers at \`:2121, :2428, :2440, :2478, :2644\`).

The density goal is fine when the autopilot card is reviewed in isolation but breaks visual rhythm when stacked with other panels.

## Fix

**Switch \`AutopilotPanel.View()\` to use \`renderPanel\` instead of \`buildCompactPanel\`.** Single-line content paths (idle, disabled) become 3 visible content lines (top padding + content + bottom padding) — matching QUEUE/HISTORY/LOGS exactly. Multi-line active states become content_lines + 2.

Implementation:
1. Replace all four \`p.buildCompactPanel(...)\` call sites in \`tui.go\` (\`:158\`, \`:163\`, line ~218, line 225) with \`renderPanel("AUTOPILOT", content, tw)\` — joining the content lines with \`\\n\`.
2. Delete \`buildCompactPanel\` and its helper code.
3. Ensure existing tests still pass — the \`TestAutopilotPanelView_AllStates\` table-driven cases will need updated expected line counts.

## Acceptance
- AUTOPILOT card has 1 blank line at top and 1 blank line at bottom of its content area, matching QUEUE/HISTORY/LOGS.
- Idle state renders 3 content lines visible inside the border (was 1).
- Active steady state renders 4 content lines visible (was 2).
- Failed state renders 5 content lines visible (was 3).
- \`buildCompactPanel\` deleted; no other callers.
- All autopilot panel tests pass with updated line-count expectations.
- \`make lint\` clean.

## Constraints
- Keep diff under 100 LoC including tests — this is a small UX fix.
- Do NOT redesign the variant A glyphs/layout — only the panel-shell padding is wrong.
- Do NOT introduce a new third panel-renderer — converge on \`renderPanel\` only.
- Do NOT touch \`renderAutopilotRail\` or \`pipelineStagePosition\`.

## Refs
- v2.118.0 user-reported regression
- Sister: #2620 (variant A redesign — this PR fixes a small UX bug introduced there)
- \`internal/dashboard/tui.go:1665\` — \`renderPanel\` (the canonical panel shell)
- \`internal/dashboard/tui.go:228\` — \`buildCompactPanel\` (to be deleted)