### PR TITLE
chore(memory): add comment on PRState struct (GH-2630)

### DIFF
--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -424,7 +424,7 @@ func ShortSHA(sha string) string {
 	return sha[:7]
 }
 
-// PRState tracks a PR through the autopilot pipeline.
+// PRState tracks the lifecycle state of a pull request through the autopilot pipeline.
 type PRState struct {
 	// PRNumber is the GitHub PR number.
 	PRNumber int


### PR DESCRIPTION
## Summary
- Expanded the `PRState` doc comment to be more descriptive: "tracks the lifecycle state of a pull request through the autopilot pipeline."

## Purpose
Smoke test for Telegram pre-merge approval flow wiring (config block at `~/.pilot/config.yaml:472-485`).

Closes #2630