### PR TITLE
GH-2633: fix(approval): route Telegram pre-merge approval to approver DM, not adapter chat_id

### DIFF
--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -48,6 +48,7 @@ type TelegramHandler struct {
 type telegramPending struct {
 	Request    *Request
 	MessageID  int64
+	ChatID     string // resolved destination — may differ from h.chatID when approvers are set
 	ResponseCh chan *Response
 }
 
@@ -76,8 +77,14 @@ func (h *TelegramHandler) SendApprovalRequest(ctx context.Context, req *Request)
 	// Create inline keyboard with approve/reject buttons
 	keyboard := h.createApprovalKeyboard(req)
 
+	// Resolve destination: use first approver's chat_id when available
+	destChatID := h.chatID
+	if len(req.Approvers) > 0 {
+		destChatID = req.Approvers[0]
+	}
+
 	// Send message
-	resp, err := h.client.SendMessageWithKeyboard(ctx, h.chatID, text, "", keyboard)
+	resp, err := h.client.SendMessageWithKeyboard(ctx, destChatID, text, "", keyboard)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send Telegram message: %w", err)
 	}
@@ -92,12 +99,14 @@ func (h *TelegramHandler) SendApprovalRequest(ctx context.Context, req *Request)
 	h.pending[req.ID] = &telegramPending{
 		Request:    req,
 		MessageID:  messageID,
+		ChatID:     destChatID,
 		ResponseCh: responseCh,
 	}
 	h.mu.Unlock()
 
 	h.log.Debug("Sent approval request",
 		slog.String("request_id", req.ID),
+		slog.String("chat_id", destChatID),
 		slog.Int64("message_id", messageID))
 
 	return responseCh, nil
@@ -119,7 +128,7 @@ func (h *TelegramHandler) CancelRequest(ctx context.Context, requestID string) e
 	// Update message to show cancelled
 	if pending.MessageID != 0 {
 		text := h.formatCancelledMessage(pending.Request)
-		if err := h.client.EditMessage(ctx, h.chatID, pending.MessageID, text, ""); err != nil {
+		if err := h.client.EditMessage(ctx, pending.ChatID, pending.MessageID, text, ""); err != nil {
 			h.log.Warn("Failed to edit cancelled message", slog.Any("error", err))
 		}
 	}
@@ -171,7 +180,7 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 	// Update message to show result
 	if pending.MessageID != 0 {
 		text := h.formatResponseMessage(pending.Request, decision, username)
-		if err := h.client.EditMessage(ctx, h.chatID, pending.MessageID, text, ""); err != nil {
+		if err := h.client.EditMessage(ctx, pending.ChatID, pending.MessageID, text, ""); err != nil {
 			h.log.Warn("Failed to edit response message", slog.Any("error", err))
 		}
 	}

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -839,6 +839,94 @@ func TestTelegramHandler_HandleCallbackWithZeroMessageID(t *testing.T) {
 	}
 }
 
+// TestTelegramHandler_ApproverRouting verifies that the destination chat_id is
+// resolved from req.Approvers[0] when set, and falls back to the constructor
+// chat_id when the slice is empty.
+func TestTelegramHandler_ApproverRouting(t *testing.T) {
+	t.Run("uses approver chat_id when set", func(t *testing.T) {
+		client := &mockTelegramClient{}
+		handler := NewTelegramHandler(client, "constructor-chat")
+
+		req := &Request{
+			ID:        "req-approver",
+			TaskID:    "TASK-01",
+			Stage:     StagePreMerge,
+			Title:     "Test",
+			Approvers: []string{"99999"},
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		}
+
+		_, err := handler.SendApprovalRequest(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		msgs := client.getSentMessages()
+		if len(msgs) != 1 {
+			t.Fatalf("expected 1 message sent, got %d", len(msgs))
+		}
+		if msgs[0].ChatID != "99999" {
+			t.Errorf("expected chat_id '99999', got '%s'", msgs[0].ChatID)
+		}
+	})
+
+	t.Run("falls back to constructor chat_id when approvers empty", func(t *testing.T) {
+		client := &mockTelegramClient{}
+		handler := NewTelegramHandler(client, "constructor-chat")
+
+		req := &Request{
+			ID:        "req-no-approver",
+			TaskID:    "TASK-01",
+			Stage:     StagePreMerge,
+			Title:     "Test",
+			Approvers: []string{},
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		}
+
+		_, err := handler.SendApprovalRequest(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		msgs := client.getSentMessages()
+		if len(msgs) != 1 {
+			t.Fatalf("expected 1 message sent, got %d", len(msgs))
+		}
+		if msgs[0].ChatID != "constructor-chat" {
+			t.Errorf("expected chat_id 'constructor-chat', got '%s'", msgs[0].ChatID)
+		}
+	})
+
+	t.Run("edit after callback uses same chat_id as original send", func(t *testing.T) {
+		client := &mockTelegramClient{}
+		handler := NewTelegramHandler(client, "constructor-chat")
+
+		req := &Request{
+			ID:        "req-edit-routing",
+			TaskID:    "TASK-01",
+			Stage:     StagePreMerge,
+			Title:     "Test",
+			Approvers: []string{"99999"},
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		}
+
+		_, err := handler.SendApprovalRequest(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		handler.HandleCallback(context.Background(), "cb1", "approve:req-edit-routing", "user", "tester")
+
+		edited := client.getEditedMessages()
+		if len(edited) != 1 {
+			t.Fatalf("expected 1 edited message, got %d", len(edited))
+		}
+		if edited[0].ChatID != "99999" {
+			t.Errorf("expected edit chat_id '99999', got '%s'", edited[0].ChatID)
+		}
+	})
+}
+
 // containsString is a helper to check if a string contains a substring
 func containsString(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2633.

Closes #2633

## Changes

GitHub Issue #2633: fix(approval): route Telegram pre-merge approval to approver DM, not adapter chat_id

## Problem

`internal/approval/telegram.go:80` sends approval requests to a single `h.chatID` set at construction from `cfg.Adapters.Telegram.ChatID` (`cmd/pilot/main.go:423,1304`). That global chat_id is the adapter's default destination — not necessarily the approver. In production today the global chat_id (`-4502060100`) is unreachable ("chat not found") while approvers' DMs (e.g. `283716179`) work — briefs prove it. PR #2631 stuck at `awaiting_approval` 3/3 retries with `telegram API error: Bad Request: chat not found (code: 400)`.

## Acceptance

1. `TelegramHandler.SendApprovalRequest` (`internal/approval/telegram.go:70`) selects the destination chat_id at send-time as:
   ```
   if len(req.Approvers) > 0 { use req.Approvers[0] }
   else { fall back to h.chatID }
   ```
   Same selection logic applied in `EditMessage` paths (timeout edits, decision-confirmed edits) so edits go to the same chat the original message went to. Track the chosen chat_id in `telegramPending` so edits don't drift.

2. `Request.Approvers` is already populated from `approval.pre_merge.approvers` by `internal/approval/manager.go:143-144`. No config schema change required.

3. Behavior when `req.Approvers` is empty: keep existing fallback to `h.chatID` (preserves backward compat for callers that don't pass approvers).

4. Logs: include the resolved chat_id in the existing `Sent approval request` debug log so future debugging is one grep away.

## Tests

- Unit test in `internal/approval/telegram_test.go`: when `req.Approvers = ["99999"]`, mock client receives chat_id `"99999"`, NOT the constructor's chat_id.
- Unit test: when `req.Approvers = []`, mock client receives the constructor chat_id (fallback).
- Unit test: edit (timeout / decision update) uses the same chat_id as the original send.

## Constraints

- Single file scope: `internal/approval/telegram.go` + its test file. No changes to `cmd/pilot/main.go` wiring (constructor signature stays the same — fallback preserves it).
- Do NOT change Slack handler — out of scope.
- Do NOT change `Request` schema — `Approvers` already exists.
- No config migration. No new config keys.

## Refs

- `cmd/pilot/main.go:423` — handler construction, telegram path
- `cmd/pilot/main.go:1304` — handler construction, daemon path
- `internal/approval/telegram.go:80` — send site
- `internal/approval/manager.go:143-144` — Approvers populated from stage config
- `internal/approval/types.go:42` — `Request.Approvers` field
- `reference_approval_telegram_wiring.md` (memory)
- Failing PR: #2631 (smoke test from marker `before-compact-2026-05-05-cascade-2-shipped-approval-wired.md`)

## After-merge expectation

Daemon picks up new binary → autopilot retries pending approval for #2631 → approver `283716179` receives DM with Approve/Reject → tap → merge → tag → release. No config change needed.