### PR TITLE
GH-2638: fix(approval): deterministic handler selection via approval_source

### DIFF
--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -147,9 +147,23 @@ func (m *Manager) RequestApproval(ctx context.Context, req *Request) (*Response,
 	// Find available handler
 	m.mu.RLock()
 	var handler Handler
-	for _, h := range m.handlers {
-		handler = h // Use first available handler
-		break
+	if req.PreferredChannel != "" {
+		if h, ok := m.handlers[req.PreferredChannel]; ok {
+			handler = h
+		} else {
+			m.log.Warn("preferred approval channel not registered, falling back to first-available",
+				slog.String("preferred_channel", req.PreferredChannel),
+				slog.String("task_id", req.TaskID))
+			for _, h := range m.handlers {
+				handler = h
+				break
+			}
+		}
+	} else {
+		for _, h := range m.handlers {
+			handler = h
+			break
+		}
 	}
 	m.mu.RUnlock()
 

--- a/internal/approval/manager_test.go
+++ b/internal/approval/manager_test.go
@@ -731,6 +731,7 @@ func TestManager_MultipleHandlers(t *testing.T) {
 	m.RegisterHandler(handler1)
 	m.RegisterHandler(handler2)
 
+	// Unset PreferredChannel: first-available path — exactly one handler receives the request.
 	req := &Request{
 		ID:        "test-multi",
 		TaskID:    "TASK-01",
@@ -744,7 +745,6 @@ func TestManager_MultipleHandlers(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should use one of the handlers (implementation uses first available)
 	if resp.Decision != DecisionApproved {
 		t.Errorf("expected approved, got %s", resp.Decision)
 	}
@@ -753,6 +753,107 @@ func TestManager_MultipleHandlers(t *testing.T) {
 	totalSent := len(handler1.sentReqs) + len(handler2.sentReqs)
 	if totalSent != 1 {
 		t.Errorf("expected exactly 1 request sent to handlers, got %d", totalSent)
+	}
+}
+
+func TestManager_PreferredChannel_Deterministic(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreExecution.Enabled = true
+	config.PreExecution.Timeout = 500 * time.Millisecond
+
+	m := NewManager(config)
+
+	handler1 := &mockHandler{
+		name: "handler1",
+		respondWith: &Response{
+			RequestID:  "test-preferred",
+			Decision:   DecisionApproved,
+			ApprovedBy: "handler1-user",
+		},
+	}
+	handler2 := &mockHandler{
+		name: "handler2",
+		respondWith: &Response{
+			RequestID:  "test-preferred",
+			Decision:   DecisionApproved,
+			ApprovedBy: "handler2-user",
+		},
+	}
+
+	m.RegisterHandler(handler1)
+	m.RegisterHandler(handler2)
+
+	// Set PreferredChannel = "handler2": must use handler2, not handler1.
+	req := &Request{
+		ID:               "test-preferred",
+		TaskID:           "TASK-01",
+		Stage:            StagePreExecution,
+		Title:            "Test task",
+		PreferredChannel: "handler2",
+		CreatedAt:        time.Now(),
+	}
+
+	resp, err := m.RequestApproval(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Decision != DecisionApproved {
+		t.Errorf("expected approved, got %s", resp.Decision)
+	}
+
+	if len(handler2.sentReqs) != 1 {
+		t.Errorf("expected handler2 to receive the request, got %d", len(handler2.sentReqs))
+	}
+	if len(handler1.sentReqs) != 0 {
+		t.Errorf("expected handler1 to receive no requests, got %d", len(handler1.sentReqs))
+	}
+	if resp.ApprovedBy != "handler2-user" {
+		t.Errorf("expected handler2-user, got %s", resp.ApprovedBy)
+	}
+}
+
+func TestManager_PreferredChannel_FallbackWarning(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreExecution.Enabled = true
+	config.PreExecution.Timeout = 500 * time.Millisecond
+
+	m := NewManager(config)
+
+	handler1 := &mockHandler{
+		name: "handler1",
+		respondWith: &Response{
+			RequestID:  "test-fallback",
+			Decision:   DecisionApproved,
+			ApprovedBy: "handler1-user",
+		},
+	}
+	m.RegisterHandler(handler1)
+
+	// PreferredChannel names a handler that is not registered: must fall back to first-available.
+	req := &Request{
+		ID:               "test-fallback",
+		TaskID:           "TASK-01",
+		Stage:            StagePreExecution,
+		Title:            "Test task",
+		PreferredChannel: "nonexistent-channel",
+		CreatedAt:        time.Now(),
+	}
+
+	resp, err := m.RequestApproval(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Falls back to first-available handler and still completes.
+	if resp.Decision != DecisionApproved {
+		t.Errorf("expected approved via fallback, got %s", resp.Decision)
+	}
+
+	if len(handler1.sentReqs) != 1 {
+		t.Errorf("expected handler1 to receive the fallback request, got %d", len(handler1.sentReqs))
 	}
 }
 

--- a/internal/approval/types.go
+++ b/internal/approval/types.go
@@ -31,15 +31,16 @@ const (
 
 // Request represents an approval request
 type Request struct {
-	ID          string                 // Unique request identifier
-	TaskID      string                 // Associated task ID
-	Stage       Stage                  // Approval stage
-	Title       string                 // Short description
-	Description string                 // Detailed description
-	Metadata    map[string]interface{} // Additional context (PR URL, error details, etc.)
-	CreatedAt   time.Time              // When request was created
-	ExpiresAt   time.Time              // When request expires (timeout)
-	Approvers   []string               // Required approvers (user IDs, handles)
+	ID               string                 // Unique request identifier
+	TaskID           string                 // Associated task ID
+	Stage            Stage                  // Approval stage
+	Title            string                 // Short description
+	Description      string                 // Detailed description
+	Metadata         map[string]interface{} // Additional context (PR URL, error details, etc.)
+	CreatedAt        time.Time              // When request was created
+	ExpiresAt        time.Time              // When request expires (timeout)
+	Approvers        []string               // Required approvers (user IDs, handles)
+	PreferredChannel string                 `json:",omitempty"` // Preferred approval channel (e.g., "telegram", "slack"); falls back to first-available when unset or unregistered
 }
 
 // Response represents an approval response

--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -206,10 +206,11 @@ func (m *AutoMerger) requestApproval(ctx context.Context, prState *PRState) (boo
 	}
 
 	req := &approval.Request{
-		TaskID:      fmt.Sprintf("merge-pr-%d", prState.PRNumber),
-		Stage:       approval.StagePreMerge,
-		Title:       fmt.Sprintf("PR #%d Merge Approval", prState.PRNumber),
-		Description: fmt.Sprintf("Approve merge of PR #%d to production?", prState.PRNumber),
+		TaskID:           fmt.Sprintf("merge-pr-%d", prState.PRNumber),
+		Stage:            approval.StagePreMerge,
+		Title:            fmt.Sprintf("PR #%d Merge Approval", prState.PRNumber),
+		Description:      fmt.Sprintf("Approve merge of PR #%d to production?", prState.PRNumber),
+		PreferredChannel: string(m.config.ApprovalSource),
 		Metadata: map[string]interface{}{
 			"pr_url":    prState.PRURL,
 			"pr_number": prState.PRNumber,


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2638.

Closes #2638

## Changes

GitHub Issue #2638: fix(approval): deterministic handler selection via approval_source

## Context

`internal/approval/manager.go:148-153` selects the approval channel via Go map iteration with `break` after the first hit — non-deterministic. The autopilot config key `orchestrator.autopilot.approval_source` (`internal/autopilot/types.go:23-31`) is defined and documented but **never consulted by the Manager**. With Telegram + Slack both registered, behavior is random per process.

Plan doc: `.agent/tasks/TASK-26-approval-deterministic-handler.md`

## Acceptance

1. `internal/approval/types.go:33-43`: add `PreferredChannel string` (omitempty) to `Request`.
2. `internal/approval/manager.go:147-154`: when `req.PreferredChannel != ""`, look up `m.handlers[req.PreferredChannel]` first. On miss → log WARN ("preferred approval channel %q not registered, falling back to first-available") and fall through to existing loop. On hit → use that handler, skip the loop.
3. `internal/autopilot/auto_merger.go:208-218` (`requestApproval`): set `req.PreferredChannel = string(m.cfg.ApprovalSource)` when building the Request.
4. `internal/approval/manager_test.go:725-756`: update to assert deterministic selection when `PreferredChannel` is set; keep first-available assertion only for the unset path; add a fallback-warning test (preferred set but missing from handlers).

## Constraints

- No `approval.NewManager` signature change — plumbing flows through `Request`.
- No new config keys; `approval_source` already exists.
- Backward compatible: configs without `approval_source` set still hit the first-available loop.
- Single PR, no follow-ups.

## Tests

```bash
go test ./internal/approval/... -run TestManager -v
go test ./internal/approval/...
go vet ./internal/approval/... ./internal/autopilot/...
```

## Refs

- `internal/approval/manager.go:148-153` — non-deterministic loop
- `internal/autopilot/types.go:23-31` — `ApprovalSource` type definition
- `internal/autopilot/auto_merger.go:208-218` — Request construction site
- `internal/approval/types.go:33-43` — `Request` struct
- Plan: `.agent/tasks/TASK-26-approval-deterministic-handler.md`
- Memory: `reference_approval_telegram_wiring.md` documents the user-visible expectation that `approval_source` controls routing — this issue makes that documentation true.