### PR TITLE
GH-2641: feat(adapters/telegram): per-adapter approval-enabled config field

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -418,7 +418,8 @@ Examples:
 				approvalMgr := approval.NewManager(cfg.Approval)
 
 				// Register Telegram approval handler if enabled
-				if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.BotToken != "" {
+				if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.BotToken != "" &&
+					(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
 					tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 					tgApprovalHandler := approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgClient}, cfg.Adapters.Telegram.ChatID)
 					approvalMgr.RegisterHandler(tgApprovalHandler)
@@ -1299,7 +1300,8 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	approvalMgr := approval.NewManager(cfg.Approval)
 
 	// Register Telegram approval handler if enabled
-	if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.BotToken != "" {
+	if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.BotToken != "" &&
+		(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
 		tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 		tgApprovalHandler := approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgClient}, cfg.Adapters.Telegram.ChatID)
 		approvalMgr.RegisterHandler(tgApprovalHandler)

--- a/internal/adapters/telegram/notifier.go
+++ b/internal/adapters/telegram/notifier.go
@@ -20,6 +20,17 @@ type Config struct {
 	Transcription *transcription.Config `yaml:"transcription"`   // Voice message transcription config
 	RateLimit     *comms.RateLimitConfig `yaml:"rate_limit"`      // Rate limiting config (optional)
 	LLMClassifier *LLMClassifierConfig  `yaml:"llm_classifier"`  // LLM intent classification config (optional)
+	Approval      *ApprovalConfig       `yaml:"approval"`        // Approval-specific config (nil = enabled by default)
+}
+
+// ApprovalConfig holds Telegram approval-specific configuration
+type ApprovalConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+// DefaultApprovalConfig returns default Telegram approval configuration
+func DefaultApprovalConfig() *ApprovalConfig {
+	return &ApprovalConfig{Enabled: true}
 }
 
 // LLMClassifierConfig configures LLM-based intent classification

--- a/internal/adapters/telegram/notifier_test.go
+++ b/internal/adapters/telegram/notifier_test.go
@@ -394,6 +394,17 @@ func TestEscapeMarkdownNotifier(t *testing.T) {
 	}
 }
 
+// TestDefaultApprovalConfig asserts approval is enabled by default for back-compat
+func TestDefaultApprovalConfig(t *testing.T) {
+	cfg := DefaultApprovalConfig()
+	if cfg == nil {
+		t.Fatal("DefaultApprovalConfig returned nil")
+	}
+	if !cfg.Enabled {
+		t.Error("Enabled should be true by default")
+	}
+}
+
 // TestDefaultConfigPlainTextMode tests that PlainTextMode defaults to true
 func TestDefaultConfigPlainTextMode(t *testing.T) {
 	config := DefaultConfig()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2641.

Closes #2641

## Changes

GitHub Issue #2641: feat(adapters/telegram): per-adapter approval-enabled config field

## Context

Telegram approval handler registers whenever `Adapters.Telegram.Enabled && BotToken != ""` (`cmd/pilot/main.go:421` gateway, `cmd/pilot/main.go:1302` start). There's no way to keep Telegram on for briefs, voice, alerts while routing **approvals** through Slack or GitHub. Slack already has this granularity via `Adapters.Slack.Approval.Enabled` (`internal/adapters/slack/webhook.go:231-235`, gated at `cmd/pilot/main.go:428-439`). Telegram's adapter config (`internal/adapters/telegram/notifier.go:13-23`) lacks the parallel substruct.

Plan doc: `.agent/tasks/TASK-27-telegram-approval-config.md`

## Acceptance

1. `internal/adapters/telegram/notifier.go`: add
   - `type ApprovalConfig struct { Enabled bool \`yaml:"enabled"\` }`
   - `Approval *ApprovalConfig` field on `Config`
   - `DefaultApprovalConfig() *ApprovalConfig` returning `&ApprovalConfig{Enabled: true}`
2. `cmd/pilot/main.go:421` (gateway) and `cmd/pilot/main.go:1302` (start): extend the registration gate to
   `cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.BotToken != "" && (cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled)`.
   Nil substruct = back-compat = on.
3. Unit test: assert `DefaultApprovalConfig().Enabled == true` in `internal/adapters/telegram/notifier_test.go` (or adjacent test file).

## Constraints

- **Do not** change semantics of `adapters.telegram.enabled` — it still gates the whole adapter (briefs, alerts, voice, etc.). 30 unrelated read sites must remain untouched.
- Default for `Approval.Enabled` MUST be `true` (back-compat: existing configs continue to register the handler).
- Mirror Slack's pattern: struct in same file as `Config`, parallel naming.
- No new YAML schema doc updates required in this PR (low-risk feature, self-documenting via Slack symmetry).

## Tests

```bash
go test ./internal/adapters/telegram/... -run TestDefaultApprovalConfig -v
go test ./internal/adapters/telegram/...
go build ./cmd/pilot/...
go vet ./internal/adapters/telegram/... ./cmd/pilot/...
```

## Refs

- Slack pattern (mirror this): `internal/adapters/slack/webhook.go:231-235` + `cmd/pilot/main.go:428-439`
- Telegram registration sites: `cmd/pilot/main.go:421` and `cmd/pilot/main.go:1302`
- Plan: `.agent/tasks/TASK-27-telegram-approval-config.md`
- Depends on (logically): #2638 (deterministic handler selection) — without it, disabling Telegram approval doesn't reliably route to a different channel because Manager picks by Go map iteration. Pure config-shape work in this PR is independent and can ship first; behavior is only meaningful after #2638 lands.