### PR TITLE
GH-2642: feat(approval): wire GitHub PR-review approval handler

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -451,6 +451,19 @@ Examples:
 						parts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2)
 						if len(parts) == 2 {
 							ghClient := github.NewClient(ghToken)
+
+							// Register GitHub approval handler if enabled
+							if cfg.Adapters.GitHub.Approval != nil && cfg.Adapters.GitHub.Approval.Enabled {
+								pollInterval := cfg.Adapters.GitHub.Approval.PollInterval
+								if pollInterval == 0 {
+									pollInterval = 30 * time.Second
+								}
+								ghApprovalHandler := approval.NewGitHubHandler(ghClient, &approval.GitHubHandlerConfig{
+									Owner: parts[0], Repo: parts[1], PollInterval: pollInterval,
+								})
+								approvalMgr.RegisterHandler(ghApprovalHandler)
+							}
+
 							// GH-1870: Board sync option for gateway autopilot controller.
 							var gwBoardOpts []autopilot.ControllerOption
 							if cfg.Adapters.GitHub.ProjectBoard != nil && cfg.Adapters.GitHub.ProjectBoard.Enabled {
@@ -1353,6 +1366,20 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Repo != "" {
 				parts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2)
 				if len(parts) == 2 {
+					// Register GitHub approval handler if enabled
+					if cfg.Adapters.GitHub.Approval != nil && cfg.Adapters.GitHub.Approval.Enabled {
+						pollInterval := cfg.Adapters.GitHub.Approval.PollInterval
+						if pollInterval == 0 {
+							pollInterval = 30 * time.Second
+						}
+						ghApprovalHandler := approval.NewGitHubHandler(ghClient, &approval.GitHubHandlerConfig{
+							Owner: parts[0], Repo: parts[1], PollInterval: pollInterval,
+						})
+						approvalMgr.RegisterHandler(ghApprovalHandler)
+						logging.WithComponent("start").Info("registered GitHub approval handler",
+							slog.String("repo", cfg.Adapters.GitHub.Repo))
+					}
+
 					controller := autopilot.NewController(
 						cfg.Orchestrator.Autopilot,
 						ghClient,

--- a/internal/adapters/github/approval_config.go
+++ b/internal/adapters/github/approval_config.go
@@ -1,0 +1,14 @@
+package github
+
+import "time"
+
+// ApprovalConfig holds GitHub PR-review approval handler configuration.
+type ApprovalConfig struct {
+	Enabled      bool          `yaml:"enabled"`
+	PollInterval time.Duration `yaml:"poll_interval"`
+}
+
+// DefaultApprovalConfig returns a disabled GitHub approval config with a 30-second poll interval.
+func DefaultApprovalConfig() *ApprovalConfig {
+	return &ApprovalConfig{Enabled: false, PollInterval: 30 * time.Second}
+}

--- a/internal/adapters/github/approval_config_test.go
+++ b/internal/adapters/github/approval_config_test.go
@@ -1,0 +1,16 @@
+package github
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultApprovalConfig(t *testing.T) {
+	cfg := DefaultApprovalConfig()
+	if cfg.Enabled {
+		t.Error("expected Enabled=false")
+	}
+	if cfg.PollInterval != 30*time.Second {
+		t.Errorf("expected PollInterval=30s, got %v", cfg.PollInterval)
+	}
+}

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -13,6 +13,7 @@ type Config struct {
 	Polling           *PollingConfig           `yaml:"polling"`             // Polling configuration
 	StaleLabelCleanup *StaleLabelCleanupConfig `yaml:"stale_label_cleanup"` // Auto-cleanup stale labels
 	ProjectBoard      *ProjectBoardConfig      `yaml:"project_board"`       // GitHub Projects V2 board sync
+	Approval          *ApprovalConfig          `yaml:"approval"`            // GitHub PR-review approval handler
 }
 
 // PollingConfig holds GitHub polling settings


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2642.

Closes #2642

## Changes

GitHub Issue #2642: feat(approval): wire GitHub PR-review approval handler

## Context

The approval package already has a complete GitHub handler in `internal/approval/github.go` — `NewGitHubHandler`, `GitHubReviewClient` interface, polling loop, message formatter, and tests. But there is **no registration call site** in `cmd/pilot/main.go`. Today only Telegram and Slack are registered (lines 418-440 / 1299-1323). Operators cannot use GitHub PR review (Approve/Request Changes) as the approval mechanism even though the handler is shipped and tested.

Wiring it lets operators leave a normal PR review as the approval signal — no chat clients required, leverages the same UI used for code review.

Plan doc: `.agent/tasks/TASK-28-github-pr-review-approval-handler.md`

## Acceptance

1. New `github.ApprovalConfig` struct in `internal/adapters/github/approval_config.go`:
   ```go
   type ApprovalConfig struct {
       Enabled      bool          \`yaml:"enabled"\`
       PollInterval time.Duration \`yaml:"poll_interval"\`
   }
   func DefaultApprovalConfig() *ApprovalConfig {
       return &ApprovalConfig{Enabled: false, PollInterval: 30 * time.Second}
   }
   ```
2. Add `Approval *github.ApprovalConfig` field on the GitHub adapter Config struct in `internal/config/config.go` (mirror Slack).
3. `cmd/pilot/main.go` (both gateway block at 418-440 and start block at 1299-1323): register `approval.NewGitHubHandler` **inside the autopilot block** where `ghClient` and the owner/repo split already exist (avoids duplicate client construction). Gate:
   ```go
   if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Approval != nil && cfg.Adapters.GitHub.Approval.Enabled {
       pollInterval := cfg.Adapters.GitHub.Approval.PollInterval
       if pollInterval == 0 { pollInterval = 30 * time.Second }
       ghHandler := approval.NewGitHubHandler(ghClient, &approval.GitHubHandlerConfig{
           Owner: owner, Repo: repo, PollInterval: pollInterval,
       })
       approvalMgr.RegisterHandler(ghHandler)
   }
   ```
4. **Do NOT** create an adapter wrapper — `*github.Client` directly satisfies `approval.GitHubReviewClient` via `HasApprovalReview` (`internal/adapters/github/client.go:763`).
5. Unit test in `internal/adapters/github/approval_config_test.go` (new): assert `DefaultApprovalConfig()` returns `Enabled: false` and `PollInterval: 30s`.
6. Verify (no change required) that `auto_merger.go:requestApproval` already populates `req.Metadata["pr_number"]` at lines 213-217 — the GitHub handler reads this at `internal/approval/github.go:71-79`.

## Constraints

- **Default `Enabled: false`** — opt-in. Zero impact for current operators.
- **No wrapper adapter** — direct interface satisfaction; do not introduce a `githubApprovalAdapter` like Telegram has.
- **No changes to `auto_merger.go`** — Metadata is already populated.
- **No changes to `approval.NewManager` signature.**
- Single client instance: register inside the autopilot block, not above it.

## Tests

```bash
go test ./internal/approval/... -run TestGitHubHandler -v
go test ./internal/adapters/github/...
go build ./cmd/pilot/...
go vet ./cmd/pilot/... ./internal/approval/... ./internal/adapters/github/...
```

## Refs

- Existing handler (no changes): `internal/approval/github.go:14-79`, `internal/approval/github.go:106` (poll loop)
- Direct interface satisfaction: `internal/adapters/github/client.go:763` (`HasApprovalReview`)
- Slack pattern (mirror this for config shape): `internal/adapters/slack/webhook.go:231-235`, `cmd/pilot/main.go:428-439`
- Telegram pattern (also mirror — see TASK-27/#2641): same file
- Existing autopilot block in `cmd/pilot/main.go` where `ghClient` lives: search for `github.NewClient(ghToken)` near line 453 (gateway) and near line 1338 (start)
- Plan: `.agent/tasks/TASK-28-github-pr-review-approval-handler.md`

## Depends on

- #2638 (TASK-26: deterministic handler selection) — without it, registering a third handler makes the random map-iteration lottery strictly worse. Pure wiring in this PR is independent and can ship first; behavior is only useful after #2638 lands and the operator sets `approval_source: github-review`.