### PR TITLE
GH-2651: fix(adapters/telegram): wire approve/reject callback dispatch

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -332,6 +332,7 @@ Examples:
 			var gwAutopilotController *autopilot.Controller
 			var gwAutopilotStateStore *autopilot.StateStore
 			var gwAlertsEngine *alerts.Engine
+			var gwTgApprovalHandler *approval.TelegramHandler
 
 			if needsPollingInfra {
 				// Create shared runner with config (GH-956: enables worktree isolation)
@@ -421,8 +422,8 @@ Examples:
 				if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.BotToken != "" &&
 					(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
 					tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
-					tgApprovalHandler := approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgClient}, cfg.Adapters.Telegram.ChatID)
-					approvalMgr.RegisterHandler(tgApprovalHandler)
+					gwTgApprovalHandler = approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgClient}, cfg.Adapters.Telegram.ChatID)
+					approvalMgr.RegisterHandler(gwTgApprovalHandler)
 				}
 
 				// Register Slack approval handler if enabled
@@ -595,6 +596,10 @@ Examples:
 				// GH-634: Wire team member resolver for Telegram RBAC in gateway mode
 				if teamAdapter != nil {
 					pilotOpts = append(pilotOpts, pilot.WithTelegramMemberResolver(teamAdapter))
+				}
+				// GH-2651: Wire approval handler so approve:/reject: button taps are dispatched
+				if gwTgApprovalHandler != nil {
+					pilotOpts = append(pilotOpts, pilot.WithTelegramApprovalHandler(gwTgApprovalHandler))
 				}
 				logging.WithComponent("start").Info("Telegram polling enabled in gateway mode")
 			}
@@ -1313,11 +1318,13 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	approvalMgr := approval.NewManager(cfg.Approval)
 
 	// Register Telegram approval handler if enabled
+	var tgApprovalHandler telegram.ApprovalCallbackHandler
 	if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.BotToken != "" &&
 		(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
-		tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
-		tgApprovalHandler := approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgClient}, cfg.Adapters.Telegram.ChatID)
-		approvalMgr.RegisterHandler(tgApprovalHandler)
+		tgApprovalClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
+		tgApprovalHandlerImpl := approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgApprovalClient}, cfg.Adapters.Telegram.ChatID)
+		approvalMgr.RegisterHandler(tgApprovalHandlerImpl)
+		tgApprovalHandler = tgApprovalHandlerImpl
 		logging.WithComponent("start").Info("registered Telegram approval handler")
 	}
 
@@ -1725,13 +1732,14 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		})
 
 		tgConfig := &telegram.HandlerConfig{
-			Client:        tgClient,
-			CommsHandler:  tgCommsHandler,
-			ProjectPath:   projectPath,
-			Projects:      config.NewProjectSource(cfg),
-			AllowedIDs:    allowedIDs,
-			Transcription: cfg.Adapters.Telegram.Transcription,
-			Store:         store,
+			Client:          tgClient,
+			CommsHandler:    tgCommsHandler,
+			ProjectPath:     projectPath,
+			Projects:        config.NewProjectSource(cfg),
+			AllowedIDs:      allowedIDs,
+			Transcription:   cfg.Adapters.Telegram.Transcription,
+			Store:           store,
+			ApprovalHandler: tgApprovalHandler,
 		}
 		tgHandler = telegram.NewHandler(tgConfig, runner)
 

--- a/internal/adapters/telegram/handler.go
+++ b/internal/adapters/telegram/handler.go
@@ -45,6 +45,11 @@ func (a *MemberResolverAdapter) ResolveIdentity(senderID string) (string, error)
 	return a.Inner.ResolveTelegramIdentity(id, "")
 }
 
+// ApprovalCallbackHandler handles approve:/reject: inline-keyboard callbacks dispatched from Telegram.
+type ApprovalCallbackHandler interface {
+	HandleCallback(ctx context.Context, callbackID, data, userID, username string) bool
+}
+
 // PendingTask represents a task awaiting confirmation
 type PendingTask struct {
 	TaskID      string
@@ -81,6 +86,7 @@ type Handler struct {
 	plainTextMode    bool                   // Use plain text instead of Markdown
 	botUsername      string                 // Bot username for mention stripping (GH-2129)
 	commsHandler     *comms.Handler         // Shared message handler (GH-2143)
+	approvalHandler  ApprovalCallbackHandler // Routes approve:/reject: callbacks (GH-2651)
 }
 
 // HandlerConfig holds configuration for the Telegram handler
@@ -95,8 +101,9 @@ type HandlerConfig struct {
 	RateLimit      *comms.RateLimitConfig // Rate limiting config (optional)
 	LLMClassifier  *LLMClassifierConfig   // LLM intent classification config (optional)
 	MemberResolver MemberResolver         // Team member resolver for RBAC (optional, GH-634)
-	CommsHandler   *comms.Handler         // Shared message handler (optional, GH-2143)
-	Client         *Client                // Optional reuse of existing client
+	CommsHandler    *comms.Handler          // Shared message handler (optional, GH-2143)
+	Client          *Client                 // Optional reuse of existing client
+	ApprovalHandler ApprovalCallbackHandler // Routes approve:/reject: callbacks (optional, GH-2651)
 }
 
 // NewHandler creates a new Telegram message handler
@@ -121,15 +128,16 @@ func NewHandler(config *HandlerConfig, runner *executor.Runner) *Handler {
 	}
 
 	h := &Handler{
-		client:        client,
-		runner:        runner,
-		projects:      config.Projects,
-		projectPath:   projectPath,
-		allowedIDs:    allowedIDs,
-		stopCh:        make(chan struct{}),
-		store:         config.Store,
-		plainTextMode: config.PlainTextMode,
-		commsHandler:  config.CommsHandler,
+		client:          client,
+		runner:          runner,
+		projects:        config.Projects,
+		projectPath:     projectPath,
+		allowedIDs:      allowedIDs,
+		stopCh:          make(chan struct{}),
+		store:           config.Store,
+		plainTextMode:   config.PlainTextMode,
+		commsHandler:    config.CommsHandler,
+		approvalHandler: config.ApprovalHandler,
 	}
 
 	// Initialize command handler
@@ -417,6 +425,19 @@ func (h *Handler) handleCallback(ctx context.Context, callback *CallbackQuery) {
 		h.cmdHandler.HandleCallbackSwitch(ctx, chatID, projectName)
 	case data == "voice_check_status":
 		h.sendVoiceSetupPrompt(ctx, chatID)
+	case strings.HasPrefix(data, "approve:") || strings.HasPrefix(data, "reject:"):
+		if h.approvalHandler != nil {
+			userID := ""
+			username := ""
+			if callback.From != nil {
+				userID = strconv.FormatInt(callback.From.ID, 10)
+				username = callback.From.Username
+				if username == "" {
+					username = callback.From.FirstName
+				}
+			}
+			h.approvalHandler.HandleCallback(ctx, callback.ID, data, userID, username)
+		}
 	}
 }
 

--- a/internal/adapters/telegram/handler_test.go
+++ b/internal/adapters/telegram/handler_test.go
@@ -1556,6 +1556,114 @@ func TestActiveProjectUsedInTaskPaths(t *testing.T) {
 	}
 }
 
+// mockApprovalHandler records HandleCallback invocations for test assertions.
+type mockApprovalHandler struct {
+	calls []approvalCall
+	mu    sync.Mutex
+	ret   bool
+}
+
+type approvalCall struct {
+	callbackID string
+	data       string
+	userID     string
+	username   string
+}
+
+func (m *mockApprovalHandler) HandleCallback(_ context.Context, callbackID, data, userID, username string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, approvalCall{callbackID: callbackID, data: data, userID: userID, username: username})
+	return m.ret
+}
+
+// newCallbackTestHandler creates a Handler backed by a test HTTP server that accepts answerCallbackQuery.
+func newCallbackTestHandler(t *testing.T, approvalHandler ApprovalCallbackHandler) (*Handler, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	h := &Handler{
+		client:          NewClientWithBaseURL(testutil.FakeTelegramBotToken, srv.URL),
+		stopCh:          make(chan struct{}),
+		approvalHandler: approvalHandler,
+	}
+	return h, srv.Close
+}
+
+// TestHandleCallback_ApprovalCallbacks covers approve:, reject:, and nil-handler paths.
+func TestHandleCallback_ApprovalCallbacks(t *testing.T) {
+	makeCallback := func(id, data string, fromID int64, username, firstName string) *CallbackQuery {
+		cb := &CallbackQuery{
+			ID:   id,
+			Data: data,
+			Message: &Message{
+				Chat: &Chat{ID: 999},
+			},
+		}
+		if fromID != 0 || username != "" || firstName != "" {
+			cb.From = &User{ID: fromID, Username: username, FirstName: firstName}
+		}
+		return cb
+	}
+
+	t.Run("approve dispatches with correct args", func(t *testing.T) {
+		mock := &mockApprovalHandler{ret: true}
+		h, cleanup := newCallbackTestHandler(t, mock)
+		defer cleanup()
+
+		cb := makeCallback("cbid-1", "approve:req-abc", 42, "alice", "Alice")
+		h.handleCallback(context.Background(), cb)
+
+		mock.mu.Lock()
+		defer mock.mu.Unlock()
+		if len(mock.calls) != 1 {
+			t.Fatalf("HandleCallback called %d times, want 1", len(mock.calls))
+		}
+		got := mock.calls[0]
+		if got.callbackID != "cbid-1" {
+			t.Errorf("callbackID = %q, want cbid-1", got.callbackID)
+		}
+		if got.data != "approve:req-abc" {
+			t.Errorf("data = %q, want approve:req-abc", got.data)
+		}
+		if got.userID != "42" {
+			t.Errorf("userID = %q, want 42", got.userID)
+		}
+		if got.username != "alice" {
+			t.Errorf("username = %q, want alice", got.username)
+		}
+	})
+
+	t.Run("reject dispatches correctly", func(t *testing.T) {
+		mock := &mockApprovalHandler{ret: true}
+		h, cleanup := newCallbackTestHandler(t, mock)
+		defer cleanup()
+
+		cb := makeCallback("cbid-2", "reject:req-xyz", 99, "bob", "Bob")
+		h.handleCallback(context.Background(), cb)
+
+		mock.mu.Lock()
+		defer mock.mu.Unlock()
+		if len(mock.calls) != 1 {
+			t.Fatalf("HandleCallback called %d times, want 1", len(mock.calls))
+		}
+		if mock.calls[0].data != "reject:req-xyz" {
+			t.Errorf("data = %q, want reject:req-xyz", mock.calls[0].data)
+		}
+	})
+
+	t.Run("nil handler does not panic", func(t *testing.T) {
+		h, cleanup := newCallbackTestHandler(t, nil)
+		defer cleanup()
+
+		cb := makeCallback("cbid-3", "approve:req-nil", 0, "", "")
+		// Must not panic.
+		h.handleCallback(context.Background(), cb)
+	})
+}
+
 func TestStripBotMention(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -56,10 +56,11 @@ type Pilot struct {
 	slackClient            *slack.Client
 	slackInteractionWH     *slack.InteractionHandler
 	slackApprovalHdlr      *approval.SlackHandler
-	telegramClient         *telegram.Client
-	telegramHandler        *telegram.Handler       // Telegram polling handler (GH-349)
-	telegramRunner         *executor.Runner        // Runner for Telegram tasks (GH-349)
-	telegramMemberResolver telegram.MemberResolver // Team member resolver for Telegram RBAC (GH-634)
+	telegramClient          *telegram.Client
+	telegramHandler         *telegram.Handler               // Telegram polling handler (GH-349)
+	telegramRunner          *executor.Runner                // Runner for Telegram tasks (GH-349)
+	telegramMemberResolver  telegram.MemberResolver         // Team member resolver for Telegram RBAC (GH-634)
+	telegramApprovalHdlr    telegram.ApprovalCallbackHandler // Routes approve:/reject: callbacks (GH-2651)
 	slackHandler           *slack.Handler          // Slack Socket Mode handler (GH-652)
 	slackRunner            *executor.Runner        // Runner for Slack tasks (GH-652)
 	slackMemberResolver    slack.MemberResolver    // Team member resolver for Slack RBAC (GH-786)
@@ -134,6 +135,14 @@ func WithTelegramHandler(runner *executor.Runner, projectPath string) Option {
 func WithTelegramMemberResolver(resolver telegram.MemberResolver) Option {
 	return func(p *Pilot) {
 		p.telegramMemberResolver = resolver
+	}
+}
+
+// WithTelegramApprovalHandler wires an approval callback handler into the Telegram message handler (GH-2651).
+// When set, approve:/reject: button taps are dispatched to this handler instead of being silently dropped.
+func WithTelegramApprovalHandler(h telegram.ApprovalCallbackHandler) Option {
+	return func(p *Pilot) {
+		p.telegramApprovalHdlr = h
 	}
 }
 
@@ -572,13 +581,14 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 		})
 
 		p.telegramHandler = telegram.NewHandler(&telegram.HandlerConfig{
-			Client:        tgClient,
-			CommsHandler:  tgCommsHandler,
-			ProjectPath:   projectPath,
-			Projects:      config.NewProjectSource(cfg),
-			AllowedIDs:    allowedIDs,
-			Transcription: cfg.Adapters.Telegram.Transcription,
-			Store:         p.store,
+			Client:          tgClient,
+			CommsHandler:    tgCommsHandler,
+			ProjectPath:     projectPath,
+			Projects:        config.NewProjectSource(cfg),
+			AllowedIDs:      allowedIDs,
+			Transcription:   cfg.Adapters.Telegram.Transcription,
+			Store:           p.store,
+			ApprovalHandler: p.telegramApprovalHdlr,
 		}, p.telegramRunner)
 
 		if len(allowedIDs) == 0 {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2651.

Closes #2651

## Changes

In `internal/adapters/telegram/handler.go`, add an `ApprovalCallbackHandler` interface (single `HandleCallback(ctx, callbackID, data, userID, username) bool` method), add `approvalHandler` field on `Handler` and `ApprovalHandler` on `HandlerConfig`, wire it in `NewHandler`, and add a switch case in `handleCallback` for `approve:` / `reject:` prefixes that delegates to `h.approvalHandler.HandleCallback(...)` with a nil-safe guard. In `cmd/pilot/main.go` at both construction sites (~`:423` and `:1304`), build `tgApprovalHandler` before `tgConfig` and assign `tgConfig.ApprovalHandler = tgApprovalHandler` prior to `telegram.NewHandler(tgConfig, runner)`. Add unit tests in `internal/adapters/telegram/handler_test.go` covering: `approve:<id>` dispatches with correct args, `reject:<id>` dispatches correctly, and a nil handler does not panic. Verify `go build ./...` and `go vet ./...` are clean and existing `execute`/`cancel`/`switch_`/`voice_check_status` paths remain unchanged.