### PR TITLE
GH-2657: feat(memory): add approval_pending table and store methods

### DIFF
--- a/internal/memory/approval_store.go
+++ b/internal/memory/approval_store.go
@@ -1,0 +1,134 @@
+package memory
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// PendingApproval is a serialisable snapshot of an approval.Request persisted
+// to SQLite so it survives process restarts. Consumers convert to/from
+// approval.Request as needed; the memory package carries no approval import.
+type PendingApproval struct {
+	ID               string
+	TaskID           string
+	Stage            string
+	Title            string
+	Description      string
+	Metadata         map[string]interface{}
+	Approvers        []string
+	PreferredChannel string
+	CreatedAt        time.Time
+	ExpiresAt        time.Time
+}
+
+// InsertPendingApproval persists a new pending approval record.
+// Replaces any existing row with the same ID.
+func (s *Store) InsertPendingApproval(a *PendingApproval) error {
+	metaJSON, err := json.Marshal(a.Metadata)
+	if err != nil {
+		return fmt.Errorf("InsertPendingApproval: marshal metadata: %w", err)
+	}
+	approversJSON, err := json.Marshal(a.Approvers)
+	if err != nil {
+		return fmt.Errorf("InsertPendingApproval: marshal approvers: %w", err)
+	}
+	return s.withRetry("InsertPendingApproval", func() error {
+		_, err := s.db.Exec(`
+			INSERT INTO approval_pending
+				(id, task_id, stage, title, description, metadata, approvers, preferred_channel, created_at, expires_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				task_id           = excluded.task_id,
+				stage             = excluded.stage,
+				title             = excluded.title,
+				description       = excluded.description,
+				metadata          = excluded.metadata,
+				approvers         = excluded.approvers,
+				preferred_channel = excluded.preferred_channel,
+				created_at        = excluded.created_at,
+				expires_at        = excluded.expires_at
+		`,
+			a.ID, a.TaskID, a.Stage, a.Title, a.Description,
+			string(metaJSON), string(approversJSON), a.PreferredChannel,
+			a.CreatedAt, a.ExpiresAt,
+		)
+		return err
+	})
+}
+
+// DeletePendingApproval removes a pending approval by ID.
+func (s *Store) DeletePendingApproval(id string) error {
+	return s.withRetry("DeletePendingApproval", func() error {
+		_, err := s.db.Exec(`DELETE FROM approval_pending WHERE id = ?`, id)
+		return err
+	})
+}
+
+// LoadPendingApprovals returns all pending approval records, ordered by creation time ascending.
+func (s *Store) LoadPendingApprovals() ([]*PendingApproval, error) {
+	rows, err := s.db.Query(`
+		SELECT id, task_id, stage, title,
+			COALESCE(description, ''), COALESCE(metadata, ''),
+			COALESCE(approvers, ''), COALESCE(preferred_channel, ''),
+			created_at, expires_at
+		FROM approval_pending
+		ORDER BY created_at ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("LoadPendingApprovals: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*PendingApproval
+	for rows.Next() {
+		a, err := scanPendingApproval(rows)
+		if err != nil {
+			return nil, fmt.Errorf("LoadPendingApprovals: scan: %w", err)
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// PrunePendingApprovals deletes all approvals whose expires_at is before `cutoff`.
+// Returns the number of rows deleted.
+func (s *Store) PrunePendingApprovals(cutoff time.Time) (int64, error) {
+	var result sql.Result
+	err := s.withRetry("PrunePendingApprovals", func() error {
+		var execErr error
+		result, execErr = s.db.Exec(`DELETE FROM approval_pending WHERE expires_at < ?`, cutoff)
+		return execErr
+	})
+	if err != nil {
+		return 0, fmt.Errorf("PrunePendingApprovals: %w", err)
+	}
+	return result.RowsAffected()
+}
+
+// scanPendingApproval scans a single row from approval_pending.
+func scanPendingApproval(row interface {
+	Scan(...interface{}) error
+}) (*PendingApproval, error) {
+	var a PendingApproval
+	var metaJSON, approversJSON string
+	if err := row.Scan(
+		&a.ID, &a.TaskID, &a.Stage, &a.Title, &a.Description,
+		&metaJSON, &approversJSON, &a.PreferredChannel,
+		&a.CreatedAt, &a.ExpiresAt,
+	); err != nil {
+		return nil, err
+	}
+	if metaJSON != "" {
+		if err := json.Unmarshal([]byte(metaJSON), &a.Metadata); err != nil {
+			a.Metadata = nil
+		}
+	}
+	if approversJSON != "" {
+		if err := json.Unmarshal([]byte(approversJSON), &a.Approvers); err != nil {
+			a.Approvers = nil
+		}
+	}
+	return &a, nil
+}

--- a/internal/memory/approval_store_test.go
+++ b/internal/memory/approval_store_test.go
@@ -1,0 +1,216 @@
+package memory
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) (*Store, func()) {
+	t.Helper()
+	tmp, err := os.MkdirTemp("", "approval-store-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	s, err := NewStore(tmp)
+	if err != nil {
+		_ = os.RemoveAll(tmp)
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s, func() {
+		_ = s.Close()
+		_ = os.RemoveAll(tmp)
+	}
+}
+
+func TestInsertAndLoadPendingApproval(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	a := &PendingApproval{
+		ID:               "req-1",
+		TaskID:           "GH-100",
+		Stage:            "pre_merge",
+		Title:            "Approve merge",
+		Description:      "Please review",
+		Metadata:         map[string]interface{}{"pr_url": "https://github.com/org/repo/pull/1"},
+		Approvers:        []string{"alice", "bob"},
+		PreferredChannel: "telegram",
+		CreatedAt:        now,
+		ExpiresAt:        now.Add(24 * time.Hour),
+	}
+
+	if err := s.InsertPendingApproval(a); err != nil {
+		t.Fatalf("InsertPendingApproval: %v", err)
+	}
+
+	all, err := s.LoadPendingApprovals()
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(all))
+	}
+	got := all[0]
+
+	if got.ID != a.ID {
+		t.Errorf("ID: got %q, want %q", got.ID, a.ID)
+	}
+	if got.TaskID != a.TaskID {
+		t.Errorf("TaskID: got %q, want %q", got.TaskID, a.TaskID)
+	}
+	if got.Stage != a.Stage {
+		t.Errorf("Stage: got %q, want %q", got.Stage, a.Stage)
+	}
+	if got.Title != a.Title {
+		t.Errorf("Title: got %q, want %q", got.Title, a.Title)
+	}
+	if got.Description != a.Description {
+		t.Errorf("Description: got %q, want %q", got.Description, a.Description)
+	}
+	if got.PreferredChannel != a.PreferredChannel {
+		t.Errorf("PreferredChannel: got %q, want %q", got.PreferredChannel, a.PreferredChannel)
+	}
+	if len(got.Approvers) != 2 || got.Approvers[0] != "alice" || got.Approvers[1] != "bob" {
+		t.Errorf("Approvers: got %v, want %v", got.Approvers, a.Approvers)
+	}
+	if v, ok := got.Metadata["pr_url"].(string); !ok || v != "https://github.com/org/repo/pull/1" {
+		t.Errorf("Metadata pr_url: got %v", got.Metadata)
+	}
+}
+
+func TestInsertPendingApproval_Upsert(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	a := &PendingApproval{
+		ID: "req-upsert", TaskID: "GH-200", Stage: "pre_execution",
+		Title: "original", CreatedAt: now, ExpiresAt: now.Add(time.Hour),
+	}
+	if err := s.InsertPendingApproval(a); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+
+	a.Title = "updated"
+	if err := s.InsertPendingApproval(a); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	all, err := s.LoadPendingApprovals()
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 record after upsert, got %d", len(all))
+	}
+	if all[0].Title != "updated" {
+		t.Errorf("Title after upsert: got %q, want %q", all[0].Title, "updated")
+	}
+}
+
+func TestDeletePendingApproval(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	for i, id := range []string{"del-1", "del-2"} {
+		_ = s.InsertPendingApproval(&PendingApproval{
+			ID: id, TaskID: "GH-300", Stage: "pre_merge",
+			Title: "t", CreatedAt: now.Add(time.Duration(i) * time.Second),
+			ExpiresAt: now.Add(time.Hour),
+		})
+	}
+
+	if err := s.DeletePendingApproval("del-1"); err != nil {
+		t.Fatalf("DeletePendingApproval: %v", err)
+	}
+
+	all, err := s.LoadPendingApprovals()
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 record after delete, got %d", len(all))
+	}
+	if all[0].ID != "del-2" {
+		t.Errorf("expected del-2 to remain, got %q", all[0].ID)
+	}
+}
+
+func TestPrunePendingApprovals(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	past := now.Add(-2 * time.Hour)
+	future := now.Add(24 * time.Hour)
+
+	expired := &PendingApproval{
+		ID: "exp-1", TaskID: "GH-400", Stage: "pre_merge",
+		Title: "expired", CreatedAt: past, ExpiresAt: past.Add(time.Hour),
+	}
+	active := &PendingApproval{
+		ID: "act-1", TaskID: "GH-401", Stage: "pre_merge",
+		Title: "active", CreatedAt: now, ExpiresAt: future,
+	}
+
+	if err := s.InsertPendingApproval(expired); err != nil {
+		t.Fatalf("insert expired: %v", err)
+	}
+	if err := s.InsertPendingApproval(active); err != nil {
+		t.Fatalf("insert active: %v", err)
+	}
+
+	deleted, err := s.PrunePendingApprovals(now)
+	if err != nil {
+		t.Fatalf("PrunePendingApprovals: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 row deleted, got %d", deleted)
+	}
+
+	all, err := s.LoadPendingApprovals()
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals after prune: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 record remaining, got %d", len(all))
+	}
+	if all[0].ID != "act-1" {
+		t.Errorf("expected act-1 to remain, got %q", all[0].ID)
+	}
+}
+
+func TestPrunePendingApprovals_NoneExpired(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	_ = s.InsertPendingApproval(&PendingApproval{
+		ID: "future-1", TaskID: "GH-500", Stage: "pre_merge",
+		Title: "t", CreatedAt: now, ExpiresAt: now.Add(time.Hour),
+	})
+
+	deleted, err := s.PrunePendingApprovals(now.Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("PrunePendingApprovals: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("expected 0 rows deleted, got %d", deleted)
+	}
+}
+
+func TestLoadPendingApprovals_Empty(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	all, err := s.LoadPendingApprovals()
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals on empty store: %v", err)
+	}
+	if len(all) != 0 {
+		t.Errorf("expected 0 records, got %d", len(all))
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -299,6 +299,20 @@ func (s *Store) migrate() error {
 		`CREATE INDEX IF NOT EXISTS idx_eval_results_task ON eval_results(task_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_eval_results_model ON eval_results(model)`,
 		`CREATE INDEX IF NOT EXISTS idx_eval_results_created ON eval_results(created_at)`,
+		// Pending approval requests awaiting human decision (GH-2657)
+		`CREATE TABLE IF NOT EXISTS approval_pending (
+			id TEXT PRIMARY KEY,
+			task_id TEXT NOT NULL,
+			stage TEXT NOT NULL,
+			title TEXT NOT NULL,
+			description TEXT DEFAULT '',
+			metadata TEXT DEFAULT '',
+			approvers TEXT DEFAULT '',
+			preferred_channel TEXT DEFAULT '',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			expires_at DATETIME NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_approval_pending_expires ON approval_pending(expires_at)`,
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2657.

Closes #2657

## Changes

Add SQLite migration creating `approval_pending` table with index on `expires_at`. Implement `InsertPendingApproval`, `DeletePendingApproval`, `LoadPendingApprovals`, and `PrunePendingApprovals` in `internal/memory` (new `approval_store.go` or extension of `store.go`). Include round-trip and prune unit tests for the store layer. No consumers wired yet.