### PR TITLE
GH-2658: feat(approval): persist and rehydrate Telegram pending approvals

### DIFF
--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -9,7 +9,16 @@ import (
 	"time"
 
 	"github.com/qf-studio/pilot/internal/logging"
+	"github.com/qf-studio/pilot/internal/memory"
 )
+
+// PendingApprovalStore is the persistence contract consumed by TelegramHandler.
+// memory.Store satisfies this interface; callers may substitute a test double.
+type PendingApprovalStore interface {
+	InsertPendingApproval(ctx context.Context, p memory.PendingApproval) error
+	DeletePendingApproval(ctx context.Context, requestID string) error
+	LoadPendingApprovals(ctx context.Context) ([]memory.PendingApproval, error)
+}
 
 // TelegramClient defines the interface for Telegram operations
 // This allows the approval handler to use the existing Telegram client
@@ -40,6 +49,7 @@ type TelegramHandler struct {
 	client  TelegramClient
 	chatID  string
 	pending map[string]*telegramPending // requestID -> pending state
+	store   PendingApprovalStore        // optional; nil means in-memory only
 	mu      sync.RWMutex
 	log     *slog.Logger
 }
@@ -60,6 +70,53 @@ func NewTelegramHandler(client TelegramClient, chatID string) *TelegramHandler {
 		pending: make(map[string]*telegramPending),
 		log:     logging.WithComponent("approval.telegram"),
 	}
+}
+
+// WithStore attaches an optional persistence store. Returns the receiver so
+// it can be chained: approval.NewTelegramHandler(...).WithStore(memStore).
+func (h *TelegramHandler) WithStore(store PendingApprovalStore) *TelegramHandler {
+	h.store = store
+	return h
+}
+
+// Rehydrate loads non-expired rows from the store and re-populates the
+// in-memory pending map. Call once at startup after WithStore. Rows whose
+// ExpiresAt is in the past are skipped (caller should prune them separately).
+func (h *TelegramHandler) Rehydrate(ctx context.Context) error {
+	if h.store == nil {
+		return nil
+	}
+	rows, err := h.store.LoadPendingApprovals(ctx)
+	if err != nil {
+		return fmt.Errorf("rehydrate: load pending approvals: %w", err)
+	}
+	now := time.Now()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, row := range rows {
+		if row.ExpiresAt.Before(now) {
+			continue // expired; skip
+		}
+		req := &Request{
+			ID:          row.RequestID,
+			TaskID:      row.TaskID,
+			Stage:       Stage(row.Stage),
+			Title:       row.Title,
+			Description: row.Description,
+			Approvers:   row.Approvers,
+			Metadata:    row.Metadata,
+			ExpiresAt:   row.ExpiresAt,
+			CreatedAt:   row.CreatedAt,
+		}
+		h.pending[row.RequestID] = &telegramPending{
+			Request:    req,
+			MessageID:  row.MessageID,
+			ChatID:     row.ChatID,
+			ResponseCh: make(chan *Response, 1),
+		}
+	}
+	h.log.Info("Rehydrated pending approvals", slog.Int("count", len(h.pending)))
+	return nil
 }
 
 // Name returns the handler name
@@ -104,6 +161,26 @@ func (h *TelegramHandler) SendApprovalRequest(ctx context.Context, req *Request)
 	}
 	h.mu.Unlock()
 
+	// Persist to store best-effort: a failure here does not abort the request.
+	if h.store != nil {
+		p := memory.PendingApproval{
+			RequestID:   req.ID,
+			TaskID:      req.TaskID,
+			Stage:       string(req.Stage),
+			Title:       req.Title,
+			Description: req.Description,
+			ChatID:      destChatID,
+			MessageID:   messageID,
+			Approvers:   req.Approvers,
+			Metadata:    req.Metadata,
+			ExpiresAt:   req.ExpiresAt,
+			CreatedAt:   req.CreatedAt,
+		}
+		if err := h.store.InsertPendingApproval(ctx, p); err != nil {
+			h.log.Warn("Failed to persist pending approval", slog.String("request_id", req.ID), slog.Any("error", err))
+		}
+	}
+
 	h.log.Debug("Sent approval request",
 		slog.String("request_id", req.ID),
 		slog.String("chat_id", destChatID),
@@ -123,6 +200,13 @@ func (h *TelegramHandler) CancelRequest(ctx context.Context, requestID string) e
 
 	if !exists {
 		return nil
+	}
+
+	// Delete from store best-effort.
+	if h.store != nil {
+		if err := h.store.DeletePendingApproval(ctx, requestID); err != nil {
+			h.log.Warn("Failed to delete cancelled approval from store", slog.String("request_id", requestID), slog.Any("error", err))
+		}
 	}
 
 	// Update message to show cancelled
@@ -166,6 +250,13 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 	if !exists {
 		_ = h.client.AnswerCallback(ctx, callbackID, "Request expired or already processed")
 		return true
+	}
+
+	// Delete from store best-effort.
+	if h.store != nil {
+		if err := h.store.DeletePendingApproval(ctx, requestID); err != nil {
+			h.log.Warn("Failed to delete decided approval from store", slog.String("request_id", requestID), slog.Any("error", err))
+		}
 	}
 
 	// Answer callback

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 // mockTelegramClient implements TelegramClient for testing
@@ -925,6 +927,303 @@ func TestTelegramHandler_ApproverRouting(t *testing.T) {
 			t.Errorf("expected edit chat_id '99999', got '%s'", edited[0].ChatID)
 		}
 	})
+}
+
+// --- mock store for persistence tests ---
+
+type mockApprovalStore struct {
+	mu          sync.Mutex
+	rows        map[string]memory.PendingApproval
+	insertCalls []memory.PendingApproval
+	deleteCalls []string
+	insertErr   error
+	deleteErr   error
+}
+
+func newMockApprovalStore() *mockApprovalStore {
+	return &mockApprovalStore{rows: make(map[string]memory.PendingApproval)}
+}
+
+func (m *mockApprovalStore) InsertPendingApproval(_ context.Context, p memory.PendingApproval) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.insertErr != nil {
+		return m.insertErr
+	}
+	m.insertCalls = append(m.insertCalls, p)
+	m.rows[p.RequestID] = p
+	return nil
+}
+
+func (m *mockApprovalStore) DeletePendingApproval(_ context.Context, requestID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	m.deleteCalls = append(m.deleteCalls, requestID)
+	delete(m.rows, requestID)
+	return nil
+}
+
+func (m *mockApprovalStore) LoadPendingApprovals(_ context.Context) ([]memory.PendingApproval, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]memory.PendingApproval, 0, len(m.rows))
+	for _, r := range m.rows {
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+func (m *mockApprovalStore) inserts() []memory.PendingApproval {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]memory.PendingApproval, len(m.insertCalls))
+	copy(cp, m.insertCalls)
+	return cp
+}
+
+func (m *mockApprovalStore) deletes() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]string, len(m.deleteCalls))
+	copy(cp, m.deleteCalls)
+	return cp
+}
+
+// --- persistence tests ---
+
+func TestTelegramHandler_PersistsOnSend(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockApprovalStore()
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+
+	req := &Request{
+		ID:        "req-persist",
+		TaskID:    "TASK-42",
+		Stage:     StagePreMerge,
+		Title:     "Deploy",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	_, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	inserts := store.inserts()
+	if len(inserts) != 1 {
+		t.Fatalf("expected 1 InsertPendingApproval call, got %d", len(inserts))
+	}
+	if inserts[0].RequestID != "req-persist" {
+		t.Errorf("expected RequestID 'req-persist', got %q", inserts[0].RequestID)
+	}
+	if inserts[0].ChatID != "chat123" {
+		t.Errorf("expected ChatID 'chat123', got %q", inserts[0].ChatID)
+	}
+	if inserts[0].Stage != "pre_merge" {
+		t.Errorf("expected Stage 'pre_merge', got %q", inserts[0].Stage)
+	}
+}
+
+func TestTelegramHandler_PersistsOnSend_NoStore(t *testing.T) {
+	// Without a store, SendApprovalRequest must still succeed.
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123")
+
+	req := &Request{
+		ID:        "req-nostore",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	_, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error without store: %v", err)
+	}
+}
+
+func TestTelegramHandler_PersistsOnSend_StoreError(t *testing.T) {
+	// A store insert error must NOT fail SendApprovalRequest (best-effort).
+	client := &mockTelegramClient{}
+	store := newMockApprovalStore()
+	store.insertErr = errors.New("db unavailable")
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+
+	req := &Request{
+		ID:        "req-store-err",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	_, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected no error on best-effort persist failure, got: %v", err)
+	}
+}
+
+func TestTelegramHandler_DeletesOnApprove(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockApprovalStore()
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+
+	req := &Request{
+		ID:        "req-approve-del",
+		TaskID:    "TASK-01",
+		Stage:     StagePreMerge,
+		Title:     "Test",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	_, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	handler.HandleCallback(context.Background(), "cb1", "approve:req-approve-del", "user", "tester")
+
+	dels := store.deletes()
+	if len(dels) != 1 || dels[0] != "req-approve-del" {
+		t.Errorf("expected delete call for 'req-approve-del', got %v", dels)
+	}
+}
+
+func TestTelegramHandler_DeletesOnReject(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockApprovalStore()
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+
+	req := &Request{
+		ID:        "req-reject-del",
+		TaskID:    "TASK-01",
+		Stage:     StagePreMerge,
+		Title:     "Test",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	_, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	handler.HandleCallback(context.Background(), "cb1", "reject:req-reject-del", "user", "tester")
+
+	dels := store.deletes()
+	if len(dels) != 1 || dels[0] != "req-reject-del" {
+		t.Errorf("expected delete call for 'req-reject-del', got %v", dels)
+	}
+}
+
+func TestTelegramHandler_DeletesOnCancel(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockApprovalStore()
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+
+	req := &Request{
+		ID:        "req-cancel-del",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	_, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	if err := handler.CancelRequest(context.Background(), "req-cancel-del"); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+
+	dels := store.deletes()
+	if len(dels) != 1 || dels[0] != "req-cancel-del" {
+		t.Errorf("expected delete call for 'req-cancel-del', got %v", dels)
+	}
+}
+
+func TestTelegramHandler_Rehydrate_RestoresPending(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockApprovalStore()
+
+	// Pre-populate the store with a non-expired row.
+	_ = store.InsertPendingApproval(context.Background(), memory.PendingApproval{
+		RequestID: "req-rehydrate",
+		TaskID:    "TASK-99",
+		Stage:     "pre_merge",
+		Title:     "Rehydrated",
+		ChatID:    "chat-rehydrate",
+		MessageID: 42,
+		Approvers: []string{"user-1"},
+		ExpiresAt: time.Now().Add(time.Hour),
+		CreatedAt: time.Now().Add(-time.Minute),
+	})
+
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	if err := handler.Rehydrate(context.Background()); err != nil {
+		t.Fatalf("Rehydrate: %v", err)
+	}
+
+	// The pending map should be populated.
+	handler.mu.RLock()
+	_, exists := handler.pending["req-rehydrate"]
+	handler.mu.RUnlock()
+	if !exists {
+		t.Fatal("expected 'req-rehydrate' to be in pending map after Rehydrate")
+	}
+
+	// A tap on the restored entry must succeed (not return "expired").
+	handled := handler.HandleCallback(context.Background(), "cb-rehydrate", "approve:req-rehydrate", "user", "tester")
+	if !handled {
+		t.Error("expected callback to be handled for rehydrated entry")
+	}
+
+	cbs := client.getAnsweredCallbacks()
+	if len(cbs) == 0 {
+		t.Fatal("expected at least one answered callback")
+	}
+	if containsString(cbs[0].Text, "expired") {
+		t.Errorf("expected non-expired answer, got: %q", cbs[0].Text)
+	}
+}
+
+func TestTelegramHandler_Rehydrate_SkipsExpired(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockApprovalStore()
+
+	// Insert an already-expired row.
+	_ = store.InsertPendingApproval(context.Background(), memory.PendingApproval{
+		RequestID: "req-expired",
+		TaskID:    "TASK-old",
+		Stage:     "pre_merge",
+		Title:     "Old",
+		ChatID:    "chat-x",
+		MessageID: 1,
+		ExpiresAt: time.Now().Add(-time.Minute), // already expired
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+	})
+
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	if err := handler.Rehydrate(context.Background()); err != nil {
+		t.Fatalf("Rehydrate: %v", err)
+	}
+
+	handler.mu.RLock()
+	_, exists := handler.pending["req-expired"]
+	handler.mu.RUnlock()
+	if exists {
+		t.Error("expired entry should not be rehydrated into pending map")
+	}
+}
+
+func TestTelegramHandler_Rehydrate_NoStore(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123")
+
+	// Rehydrate without a store must be a no-op, not panic.
+	if err := handler.Rehydrate(context.Background()); err != nil {
+		t.Errorf("expected nil error without store, got: %v", err)
+	}
 }
 
 // containsString is a helper to check if a string contains a substring

--- a/internal/memory/approval_store.go
+++ b/internal/memory/approval_store.go
@@ -1,0 +1,145 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// PendingApproval is a row in the approval_pending table, capturing enough
+// state to reconstruct an in-flight Telegram approval after a daemon restart.
+type PendingApproval struct {
+	RequestID   string
+	TaskID      string
+	Stage       string
+	Title       string
+	Description string
+	ChatID      string
+	MessageID   int64
+	Approvers   []string
+	Metadata    map[string]interface{}
+	ExpiresAt   time.Time
+	CreatedAt   time.Time
+}
+
+// InsertPendingApproval persists a pending approval row. Replaces an existing
+// row with the same request_id (UPSERT), so re-sends after restart are safe.
+func (s *Store) InsertPendingApproval(ctx context.Context, p PendingApproval) error {
+	approversJSON, err := json.Marshal(p.Approvers)
+	if err != nil {
+		return fmt.Errorf("marshal approvers: %w", err)
+	}
+	metadataJSON, err := json.Marshal(p.Metadata)
+	if err != nil {
+		return fmt.Errorf("marshal metadata: %w", err)
+	}
+	return s.withRetry("InsertPendingApproval", func() error {
+		_, err := s.db.ExecContext(ctx, `
+			INSERT INTO approval_pending
+				(request_id, task_id, stage, title, description, chat_id, message_id,
+				 approvers, metadata, expires_at, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(request_id) DO UPDATE SET
+				task_id=excluded.task_id, stage=excluded.stage, title=excluded.title,
+				description=excluded.description, chat_id=excluded.chat_id,
+				message_id=excluded.message_id, approvers=excluded.approvers,
+				metadata=excluded.metadata, expires_at=excluded.expires_at`,
+			p.RequestID, p.TaskID, p.Stage, p.Title, p.Description,
+			p.ChatID, p.MessageID,
+			string(approversJSON), string(metadataJSON),
+			p.ExpiresAt.Unix(), p.CreatedAt.Unix(),
+		)
+		return err
+	})
+}
+
+// DeletePendingApproval removes the row for requestID. It is idempotent:
+// deleting a row that no longer exists is not an error.
+func (s *Store) DeletePendingApproval(ctx context.Context, requestID string) error {
+	return s.withRetry("DeletePendingApproval", func() error {
+		_, err := s.db.ExecContext(ctx,
+			`DELETE FROM approval_pending WHERE request_id = ?`, requestID)
+		return err
+	})
+}
+
+// LoadPendingApprovals returns all rows from approval_pending. Callers are
+// responsible for filtering expired entries (ExpiresAt < now).
+func (s *Store) LoadPendingApprovals(ctx context.Context) ([]PendingApproval, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT request_id, task_id, stage, title, description, chat_id, message_id,
+		       approvers, metadata, expires_at, created_at
+		FROM approval_pending
+		ORDER BY created_at ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("query approval_pending: %w", err)
+	}
+	defer rows.Close()
+
+	var result []PendingApproval
+	for rows.Next() {
+		var p PendingApproval
+		var approversJSON, metadataJSON string
+		var expiresUnix, createdUnix int64
+		if err := rows.Scan(
+			&p.RequestID, &p.TaskID, &p.Stage, &p.Title, &p.Description,
+			&p.ChatID, &p.MessageID,
+			&approversJSON, &metadataJSON,
+			&expiresUnix, &createdUnix,
+		); err != nil {
+			return nil, fmt.Errorf("scan approval_pending row: %w", err)
+		}
+		if err := json.Unmarshal([]byte(approversJSON), &p.Approvers); err != nil {
+			p.Approvers = nil
+		}
+		if metadataJSON != "" && metadataJSON != "null" {
+			if err := json.Unmarshal([]byte(metadataJSON), &p.Metadata); err != nil {
+				p.Metadata = nil
+			}
+		}
+		p.ExpiresAt = time.Unix(expiresUnix, 0)
+		p.CreatedAt = time.Unix(createdUnix, 0)
+		result = append(result, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating approval_pending rows: %w", err)
+	}
+	return result, nil
+}
+
+// PrunePendingApprovals deletes rows whose expires_at is before the given
+// time. Returns the number of rows deleted.
+func (s *Store) PrunePendingApprovals(ctx context.Context, before time.Time) (int, error) {
+	var n int64
+	err := s.withRetry("PrunePendingApprovals", func() error {
+		res, err := s.db.ExecContext(ctx,
+			`DELETE FROM approval_pending WHERE expires_at < ?`, before.Unix())
+		if err != nil {
+			return err
+		}
+		n, err = res.RowsAffected()
+		return err
+	})
+	if err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
+// approvalPendingMigration is the SQL that creates the approval_pending table.
+// It is referenced from store.go's migrate() slice.
+const approvalPendingMigration = `CREATE TABLE IF NOT EXISTS approval_pending (
+	request_id   TEXT PRIMARY KEY,
+	task_id      TEXT NOT NULL DEFAULT '',
+	stage        TEXT NOT NULL DEFAULT '',
+	title        TEXT NOT NULL DEFAULT '',
+	description  TEXT NOT NULL DEFAULT '',
+	chat_id      TEXT NOT NULL DEFAULT '',
+	message_id   INTEGER NOT NULL DEFAULT 0,
+	approvers    TEXT NOT NULL DEFAULT '[]',
+	metadata     TEXT,
+	expires_at   INTEGER NOT NULL,
+	created_at   INTEGER NOT NULL
+)`
+

--- a/internal/memory/approval_store_test.go
+++ b/internal/memory/approval_store_test.go
@@ -1,0 +1,225 @@
+package memory
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) (*Store, func()) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "pilot-approval-test-*")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		t.Fatalf("NewStore: %v", err)
+	}
+	return store, func() {
+		_ = store.Close()
+		_ = os.RemoveAll(tmpDir)
+	}
+}
+
+func samplePendingApproval(requestID string, expiresAt time.Time) PendingApproval {
+	return PendingApproval{
+		RequestID:   requestID,
+		TaskID:      "TASK-01",
+		Stage:       "pre_merge",
+		Title:       "Deploy to production",
+		Description: "merge PR #42",
+		ChatID:      "chat-123",
+		MessageID:   999,
+		Approvers:   []string{"user-1", "user-2"},
+		Metadata:    map[string]interface{}{"pr_url": "https://github.com/org/repo/pull/42"},
+		ExpiresAt:   expiresAt,
+		CreatedAt:   time.Now().Add(-time.Minute),
+	}
+}
+
+func TestInsertAndLoadPendingApproval(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	p := samplePendingApproval("req-1", time.Now().Add(time.Hour))
+
+	if err := store.InsertPendingApproval(ctx, p); err != nil {
+		t.Fatalf("InsertPendingApproval: %v", err)
+	}
+
+	rows, err := store.LoadPendingApprovals(ctx)
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+
+	got := rows[0]
+	if got.RequestID != p.RequestID {
+		t.Errorf("RequestID: want %q, got %q", p.RequestID, got.RequestID)
+	}
+	if got.TaskID != p.TaskID {
+		t.Errorf("TaskID: want %q, got %q", p.TaskID, got.TaskID)
+	}
+	if got.Stage != p.Stage {
+		t.Errorf("Stage: want %q, got %q", p.Stage, got.Stage)
+	}
+	if got.ChatID != p.ChatID {
+		t.Errorf("ChatID: want %q, got %q", p.ChatID, got.ChatID)
+	}
+	if got.MessageID != p.MessageID {
+		t.Errorf("MessageID: want %d, got %d", p.MessageID, got.MessageID)
+	}
+	if len(got.Approvers) != len(p.Approvers) {
+		t.Errorf("Approvers: want %v, got %v", p.Approvers, got.Approvers)
+	}
+	if got.Metadata["pr_url"] != p.Metadata["pr_url"] {
+		t.Errorf("Metadata pr_url: want %v, got %v", p.Metadata["pr_url"], got.Metadata["pr_url"])
+	}
+	// ExpiresAt round-trips through unix seconds
+	if got.ExpiresAt.Unix() != p.ExpiresAt.Unix() {
+		t.Errorf("ExpiresAt: want %v, got %v", p.ExpiresAt.Unix(), got.ExpiresAt.Unix())
+	}
+}
+
+func TestInsertPendingApproval_Upsert(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	p := samplePendingApproval("req-upsert", time.Now().Add(time.Hour))
+
+	if err := store.InsertPendingApproval(ctx, p); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+
+	// Update the message ID and re-insert (upsert).
+	p.MessageID = 12345
+	if err := store.InsertPendingApproval(ctx, p); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	rows, err := store.LoadPendingApprovals(ctx)
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row after upsert, got %d", len(rows))
+	}
+	if rows[0].MessageID != 12345 {
+		t.Errorf("expected updated MessageID 12345, got %d", rows[0].MessageID)
+	}
+}
+
+func TestDeletePendingApproval(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	p := samplePendingApproval("req-del", time.Now().Add(time.Hour))
+
+	if err := store.InsertPendingApproval(ctx, p); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := store.DeletePendingApproval(ctx, "req-del"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	rows, err := store.LoadPendingApprovals(ctx)
+	if err != nil {
+		t.Fatalf("load after delete: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows after delete, got %d", len(rows))
+	}
+}
+
+func TestDeletePendingApproval_Idempotent(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	// Deleting a nonexistent row must not return an error.
+	if err := store.DeletePendingApproval(ctx, "nonexistent"); err != nil {
+		t.Errorf("delete nonexistent: expected nil, got %v", err)
+	}
+}
+
+func TestPrunePendingApprovals(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now()
+
+	// Insert one expired and one active row.
+	expired := samplePendingApproval("req-expired", now.Add(-time.Minute))
+	active := samplePendingApproval("req-active", now.Add(time.Hour))
+
+	if err := store.InsertPendingApproval(ctx, expired); err != nil {
+		t.Fatalf("insert expired: %v", err)
+	}
+	if err := store.InsertPendingApproval(ctx, active); err != nil {
+		t.Fatalf("insert active: %v", err)
+	}
+
+	n, err := store.PrunePendingApprovals(ctx, now)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 pruned row, got %d", n)
+	}
+
+	rows, err := store.LoadPendingApprovals(ctx)
+	if err != nil {
+		t.Fatalf("load after prune: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 remaining row, got %d", len(rows))
+	}
+	if rows[0].RequestID != "req-active" {
+		t.Errorf("expected req-active to remain, got %q", rows[0].RequestID)
+	}
+}
+
+func TestLoadPendingApprovals_Empty(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	rows, err := store.LoadPendingApprovals(context.Background())
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals on empty table: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(rows))
+	}
+}
+
+func TestLoadPendingApprovals_NilMetadata(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	p := samplePendingApproval("req-nil-meta", time.Now().Add(time.Hour))
+	p.Metadata = nil
+
+	if err := store.InsertPendingApproval(ctx, p); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	rows, err := store.LoadPendingApprovals(ctx)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	// Nil metadata should not cause a panic.
+	_ = rows[0].Metadata
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -299,6 +299,9 @@ func (s *Store) migrate() error {
 		`CREATE INDEX IF NOT EXISTS idx_eval_results_task ON eval_results(task_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_eval_results_model ON eval_results(model)`,
 		`CREATE INDEX IF NOT EXISTS idx_eval_results_created ON eval_results(created_at)`,
+		// Pending approval requests for cross-restart durability (GH-2658)
+		approvalPendingMigration,
+		`CREATE INDEX IF NOT EXISTS idx_approval_pending_expires ON approval_pending(expires_at)`,
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2658.

Closes #2658

## Changes

In `internal/approval/telegram.go`, define a `PendingApprovalStore` interface matching the memory methods and add a `WithStore(store)` builder that keeps `NewTelegramHandler` signature back-compat. Make `SendApprovalRequest` persist alongside the in-memory insert (best-effort), and have the approve/reject decision path plus `CancelRequest` delete the row. Add a `Rehydrate(ctx)` method that loads rows on startup, skipping expired entries. Cover with tests: persist on send, delete on each terminal path, rehydrate restores entries (including a tap on a restored entry succeeding), and expired rows are skipped.