### PR TITLE
GH-2659: feat(cmd/pilot): wire approval store and rehydrate at startup

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -423,6 +423,12 @@ Examples:
 					(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
 					tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 					gwTgApprovalHandler = approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgClient}, cfg.Adapters.Telegram.ChatID)
+					if gwStore != nil {
+						gwTgApprovalHandler.WithStore(gwStore)
+						if rErr := gwTgApprovalHandler.Rehydrate(context.Background()); rErr != nil {
+							logging.WithComponent("approval").Warn("telegram approval rehydrate failed", slog.Any("error", rErr))
+						}
+					}
 					approvalMgr.RegisterHandler(gwTgApprovalHandler)
 				}
 
@@ -1319,10 +1325,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 
 	// Register Telegram approval handler if enabled
 	var tgApprovalHandler telegram.ApprovalCallbackHandler
+	var tgApprovalHandlerImpl *approval.TelegramHandler
 	if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.BotToken != "" &&
 		(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
 		tgApprovalClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
-		tgApprovalHandlerImpl := approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgApprovalClient}, cfg.Adapters.Telegram.ChatID)
+		tgApprovalHandlerImpl = approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgApprovalClient}, cfg.Adapters.Telegram.ChatID)
 		approvalMgr.RegisterHandler(tgApprovalHandlerImpl)
 		tgApprovalHandler = tgApprovalHandlerImpl
 		logging.WithComponent("start").Info("registered Telegram approval handler")
@@ -1439,6 +1446,14 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				_ = store.Close()
 			}
 		}()
+	}
+
+	// Attach persistence store and rehydrate pending approvals after restart.
+	if store != nil && tgApprovalHandlerImpl != nil {
+		tgApprovalHandlerImpl.WithStore(store)
+		if rErr := tgApprovalHandlerImpl.Rehydrate(ctx); rErr != nil {
+			logging.WithComponent("approval").Warn("telegram approval rehydrate failed", slog.Any("error", rErr))
+		}
 	}
 
 	// GH-726: Initialize autopilot state store for crash recovery

--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -9,7 +9,16 @@ import (
 	"time"
 
 	"github.com/qf-studio/pilot/internal/logging"
+	"github.com/qf-studio/pilot/internal/memory"
 )
+
+// PendingApprovalStore persists pending approval requests across restarts.
+// *memory.Store satisfies this interface directly.
+type PendingApprovalStore interface {
+	InsertPendingApproval(*memory.PendingApproval) error
+	DeletePendingApproval(id string) error
+	LoadPendingApprovals() ([]*memory.PendingApproval, error)
+}
 
 // TelegramClient defines the interface for Telegram operations
 // This allows the approval handler to use the existing Telegram client
@@ -42,6 +51,7 @@ type TelegramHandler struct {
 	pending map[string]*telegramPending // requestID -> pending state
 	mu      sync.RWMutex
 	log     *slog.Logger
+	store   PendingApprovalStore // optional; enables restart persistence
 }
 
 // telegramPending tracks a pending Telegram approval request
@@ -65,6 +75,66 @@ func NewTelegramHandler(client TelegramClient, chatID string) *TelegramHandler {
 // Name returns the handler name
 func (h *TelegramHandler) Name() string {
 	return "telegram"
+}
+
+// WithStore attaches a persistence store so pending approvals survive restarts.
+// Returns h to allow builder-style chaining after NewTelegramHandler.
+func (h *TelegramHandler) WithStore(store PendingApprovalStore) *TelegramHandler {
+	h.store = store
+	return h
+}
+
+// Rehydrate loads persisted pending approvals from the store and re-inserts them
+// into the in-memory map so that button taps that arrive after a restart are
+// processed rather than answered with "expired". Expired rows are pruned.
+// No-op when no store is attached.
+func (h *TelegramHandler) Rehydrate(ctx context.Context) error {
+	if h.store == nil {
+		return nil
+	}
+	rows, err := h.store.LoadPendingApprovals()
+	if err != nil {
+		return fmt.Errorf("rehydrate: load pending approvals: %w", err)
+	}
+	now := time.Now()
+	rehydrated := 0
+	for _, row := range rows {
+		if row.ExpiresAt.Before(now) {
+			_ = h.store.DeletePendingApproval(row.ID)
+			continue
+		}
+		req := &Request{
+			ID:               row.ID,
+			TaskID:           row.TaskID,
+			Stage:            Stage(row.Stage),
+			Title:            row.Title,
+			Description:      row.Description,
+			Metadata:         row.Metadata,
+			Approvers:        row.Approvers,
+			PreferredChannel: row.PreferredChannel,
+			CreatedAt:        row.CreatedAt,
+			ExpiresAt:        row.ExpiresAt,
+		}
+		destChatID := h.chatID
+		if len(req.Approvers) > 0 {
+			destChatID = req.Approvers[0]
+		}
+		responseCh := make(chan *Response, 1)
+		h.mu.Lock()
+		if _, exists := h.pending[req.ID]; !exists {
+			h.pending[req.ID] = &telegramPending{
+				Request:    req,
+				ChatID:     destChatID,
+				ResponseCh: responseCh,
+			}
+			rehydrated++
+		}
+		h.mu.Unlock()
+	}
+	if rehydrated > 0 {
+		h.log.Info("rehydrated pending approvals", slog.Int("count", rehydrated))
+	}
+	return nil
 }
 
 // SendApprovalRequest sends an approval request via Telegram
@@ -104,6 +174,25 @@ func (h *TelegramHandler) SendApprovalRequest(ctx context.Context, req *Request)
 	}
 	h.mu.Unlock()
 
+	// Best-effort persistence so the request survives a restart.
+	if h.store != nil {
+		row := &memory.PendingApproval{
+			ID:               req.ID,
+			TaskID:           req.TaskID,
+			Stage:            string(req.Stage),
+			Title:            req.Title,
+			Description:      req.Description,
+			Metadata:         req.Metadata,
+			Approvers:        req.Approvers,
+			PreferredChannel: req.PreferredChannel,
+			CreatedAt:        req.CreatedAt,
+			ExpiresAt:        req.ExpiresAt,
+		}
+		if err := h.store.InsertPendingApproval(row); err != nil {
+			h.log.Warn("failed to persist pending approval", slog.String("request_id", req.ID), slog.Any("error", err))
+		}
+	}
+
 	h.log.Debug("Sent approval request",
 		slog.String("request_id", req.ID),
 		slog.String("chat_id", destChatID),
@@ -123,6 +212,12 @@ func (h *TelegramHandler) CancelRequest(ctx context.Context, requestID string) e
 
 	if !exists {
 		return nil
+	}
+
+	if h.store != nil {
+		if err := h.store.DeletePendingApproval(requestID); err != nil {
+			h.log.Warn("failed to delete persisted approval on cancel", slog.String("request_id", requestID), slog.Any("error", err))
+		}
 	}
 
 	// Update message to show cancelled
@@ -166,6 +261,12 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 	if !exists {
 		_ = h.client.AnswerCallback(ctx, callbackID, "Request expired or already processed")
 		return true
+	}
+
+	if h.store != nil {
+		if err := h.store.DeletePendingApproval(requestID); err != nil {
+			h.log.Warn("failed to delete persisted approval on callback", slog.String("request_id", requestID), slog.Any("error", err))
+		}
 	}
 
 	// Answer callback

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 // mockTelegramClient implements TelegramClient for testing
@@ -925,6 +927,214 @@ func TestTelegramHandler_ApproverRouting(t *testing.T) {
 			t.Errorf("expected edit chat_id '99999', got '%s'", edited[0].ChatID)
 		}
 	})
+}
+
+// --- store tests ---
+
+// mockPendingStore is an in-memory PendingApprovalStore for unit tests.
+type mockPendingStore struct {
+	mu   sync.Mutex
+	rows map[string]*memory.PendingApproval
+	// per-call error injection
+	insertErr error
+	deleteErr error
+	loadErr   error
+}
+
+func newMockPendingStore() *mockPendingStore {
+	return &mockPendingStore{rows: make(map[string]*memory.PendingApproval)}
+}
+
+func (s *mockPendingStore) InsertPendingApproval(a *memory.PendingApproval) error {
+	if s.insertErr != nil {
+		return s.insertErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *a
+	s.rows[a.ID] = &cp
+	return nil
+}
+
+func (s *mockPendingStore) DeletePendingApproval(id string) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.rows, id)
+	return nil
+}
+
+func (s *mockPendingStore) LoadPendingApprovals() ([]*memory.PendingApproval, error) {
+	if s.loadErr != nil {
+		return nil, s.loadErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*memory.PendingApproval, 0, len(s.rows))
+	for _, r := range s.rows {
+		cp := *r
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (s *mockPendingStore) get(id string) *memory.PendingApproval {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rows[id]
+}
+
+func (s *mockPendingStore) len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.rows)
+}
+
+func TestTelegramHandler_WithStore_PersistOnSend(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockPendingStore()
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+
+	req := &Request{
+		ID: "persist-1", TaskID: "T-1", Stage: StagePreMerge,
+		Title: "Test", ExpiresAt: time.Now().Add(time.Hour),
+	}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if store.len() != 1 {
+		t.Fatalf("expected 1 persisted row, got %d", store.len())
+	}
+	row := store.get("persist-1")
+	if row == nil {
+		t.Fatal("expected row to be stored")
+	}
+	if row.TaskID != "T-1" {
+		t.Errorf("expected TaskID T-1, got %s", row.TaskID)
+	}
+}
+
+func TestTelegramHandler_WithStore_DeleteOnCallback(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockPendingStore()
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+
+	req := &Request{
+		ID: "del-cb-1", TaskID: "T-2", Stage: StagePreMerge,
+		Title: "Test", ExpiresAt: time.Now().Add(time.Hour),
+	}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if store.len() != 1 {
+		t.Fatal("expected 1 row after send")
+	}
+
+	handler.HandleCallback(context.Background(), "cb1", "approve:del-cb-1", "u", "user")
+
+	if store.len() != 0 {
+		t.Errorf("expected 0 rows after callback, got %d", store.len())
+	}
+}
+
+func TestTelegramHandler_WithStore_DeleteOnCancel(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockPendingStore()
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+
+	req := &Request{
+		ID: "del-cancel-1", TaskID: "T-3", Stage: StagePreMerge,
+		Title: "Test", ExpiresAt: time.Now().Add(time.Hour),
+	}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := handler.CancelRequest(context.Background(), "del-cancel-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if store.len() != 0 {
+		t.Errorf("expected 0 rows after cancel, got %d", store.len())
+	}
+}
+
+func TestTelegramHandler_Rehydrate_RestoреsNonExpired(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockPendingStore()
+
+	// Pre-populate store with one non-expired and one expired row.
+	future := time.Now().Add(time.Hour)
+	past := time.Now().Add(-time.Hour)
+	_ = store.InsertPendingApproval(&memory.PendingApproval{
+		ID: "live", TaskID: "T-live", Stage: "pre_merge",
+		Title: "Live", CreatedAt: time.Now(), ExpiresAt: future,
+	})
+	_ = store.InsertPendingApproval(&memory.PendingApproval{
+		ID: "dead", TaskID: "T-dead", Stage: "pre_merge",
+		Title: "Dead", CreatedAt: time.Now(), ExpiresAt: past,
+	})
+
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	if err := handler.Rehydrate(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handler.mu.RLock()
+	_, livePending := handler.pending["live"]
+	_, deadPending := handler.pending["dead"]
+	handler.mu.RUnlock()
+
+	if !livePending {
+		t.Error("expected non-expired approval to be rehydrated")
+	}
+	if deadPending {
+		t.Error("expected expired approval to NOT be rehydrated")
+	}
+	// Expired row should be pruned from store.
+	if store.get("dead") != nil {
+		t.Error("expected expired row to be deleted from store")
+	}
+}
+
+func TestTelegramHandler_Rehydrate_NoStore(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123")
+	// No store attached — Rehydrate should be a no-op.
+	if err := handler.Rehydrate(context.Background()); err != nil {
+		t.Fatalf("expected no error without store, got: %v", err)
+	}
+}
+
+func TestTelegramHandler_Rehydrate_CallbackWorksAfterRehydrate(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockPendingStore()
+	_ = store.InsertPendingApproval(&memory.PendingApproval{
+		ID: "rehy-cb", TaskID: "T-R", Stage: "pre_merge",
+		Title: "Rehydrated", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	if err := handler.Rehydrate(context.Background()); err != nil {
+		t.Fatalf("rehydrate error: %v", err)
+	}
+
+	// Simulate a button tap arriving after restart — should NOT answer "expired".
+	handled := handler.HandleCallback(context.Background(), "cb-r", "approve:rehy-cb", "u", "tester")
+	if !handled {
+		t.Error("expected callback to be handled")
+	}
+
+	cbs := client.getAnsweredCallbacks()
+	if len(cbs) == 0 {
+		t.Fatal("expected callback answer")
+	}
+	if containsString(cbs[0].Text, "expired") {
+		t.Errorf("expected non-expired answer, got: %s", cbs[0].Text)
+	}
 }
 
 // containsString is a helper to check if a string contains a substring


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2659.

Closes #2659

## Changes

At both `TelegramHandler` construction sites in `cmd/pilot/main.go` (~`:423` and `:1304`), chain `.WithStore(memoryStore)` and call `Rehydrate(ctx)` once after construction. Verify `go build ./...` and `go vet ./...` are clean and that a manual restart scenario (documented in PR description) recovers a pre-restart approval tap.