### PR TITLE
GH-2667: feat(autopilot/state): add approval decision fields and writer

### DIFF
--- a/internal/approval/types.go
+++ b/internal/approval/types.go
@@ -52,6 +52,15 @@ type Response struct {
 	RespondedAt time.Time // When response was given
 }
 
+// PRStateWriter is the storage interface used by the approval package to record
+// decisions back onto the execution (PR state) row. The memory.Store satisfies
+// this interface; callers may also provide test doubles.
+type PRStateWriter interface {
+	// SetApprovalDecision persists the approval decision for the execution
+	// linked to requestID. Returns sql.ErrNoRows if no matching execution exists.
+	SetApprovalDecision(ctx context.Context, requestID string, decision string, by string) error
+}
+
 // Handler is the interface for approval channel handlers
 // Each channel (Telegram, Slack, etc.) implements this interface
 type Handler interface {

--- a/internal/memory/pr_state_test.go
+++ b/internal/memory/pr_state_test.go
@@ -1,0 +1,132 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+)
+
+// seedExecution inserts a minimal execution row with the given ID and optional
+// approval_request_id. Uses newTestStore (defined in approval_store_test.go).
+func seedExecution(t *testing.T, s *Store, execID, approvalRequestID string) {
+	t.Helper()
+	exec := &Execution{
+		ID:                execID,
+		TaskID:            "GH-2667",
+		ProjectPath:       "/tmp/test-proj",
+		Status:            "running",
+		ApprovalRequestID: approvalRequestID,
+	}
+	if err := s.SaveExecution(exec); err != nil {
+		t.Fatalf("seedExecution: %v", err)
+	}
+}
+
+func TestSetApprovalDecision_RoundTrip(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const execID = "exec-approval-1"
+	const reqID = "req-abc"
+
+	seedExecution(t, s, execID, reqID)
+
+	before := time.Now().UTC().Truncate(time.Second)
+	if err := s.SetApprovalDecision(context.Background(), reqID, "approved", "alice"); err != nil {
+		t.Fatalf("SetApprovalDecision: %v", err)
+	}
+	after := time.Now().UTC().Add(time.Second)
+
+	exec, err := s.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+
+	if exec.ApprovalRequestID != reqID {
+		t.Errorf("ApprovalRequestID: got %q, want %q", exec.ApprovalRequestID, reqID)
+	}
+	if exec.ApprovalDecision != "approved" {
+		t.Errorf("ApprovalDecision: got %q, want %q", exec.ApprovalDecision, "approved")
+	}
+	if exec.ApprovalDecisionBy != "alice" {
+		t.Errorf("ApprovalDecisionBy: got %q, want %q", exec.ApprovalDecisionBy, "alice")
+	}
+	if exec.ApprovalDecisionAt == nil {
+		t.Fatal("ApprovalDecisionAt: expected non-nil")
+	}
+	if exec.ApprovalDecisionAt.Before(before) || exec.ApprovalDecisionAt.After(after) {
+		t.Errorf("ApprovalDecisionAt %v out of expected range [%v, %v]",
+			exec.ApprovalDecisionAt, before, after)
+	}
+}
+
+func TestSetApprovalDecision_Rejected(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	seedExecution(t, s, "exec-rej", "req-rej")
+
+	if err := s.SetApprovalDecision(context.Background(), "req-rej", "rejected", "bob"); err != nil {
+		t.Fatalf("SetApprovalDecision: %v", err)
+	}
+
+	exec, err := s.GetExecution("exec-rej")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.ApprovalDecision != "rejected" {
+		t.Errorf("ApprovalDecision: got %q, want rejected", exec.ApprovalDecision)
+	}
+	if exec.ApprovalDecisionBy != "bob" {
+		t.Errorf("ApprovalDecisionBy: got %q, want bob", exec.ApprovalDecisionBy)
+	}
+}
+
+func TestSetApprovalDecision_NoMatchingRow(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	err := s.SetApprovalDecision(context.Background(), "nonexistent-req", "approved", "system")
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows, got %v", err)
+	}
+}
+
+func TestApprovalRequestID_PersistedOnSave(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const execID = "exec-persist"
+	const reqID = "req-persist"
+	seedExecution(t, s, execID, reqID)
+
+	exec, err := s.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.ApprovalRequestID != reqID {
+		t.Errorf("ApprovalRequestID after save: got %q, want %q", exec.ApprovalRequestID, reqID)
+	}
+	// Decision fields should be zero until SetApprovalDecision is called.
+	if exec.ApprovalDecision != "" {
+		t.Errorf("ApprovalDecision should be empty before decision, got %q", exec.ApprovalDecision)
+	}
+	if exec.ApprovalDecisionAt != nil {
+		t.Errorf("ApprovalDecisionAt should be nil before decision")
+	}
+}
+
+func TestApprovalDecision_EmptyRequestID_NoRows(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	// Execution without an approval_request_id should not be matched.
+	seedExecution(t, s, "exec-no-req", "")
+
+	err := s.SetApprovalDecision(context.Background(), "", "approved", "system")
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows for empty requestID, got %v", err)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -313,6 +314,12 @@ func (s *Store) migrate() error {
 			expires_at DATETIME NOT NULL
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_approval_pending_expires ON approval_pending(expires_at)`,
+		// Approval decision columns on executions (GH-2667)
+		`ALTER TABLE executions ADD COLUMN approval_request_id TEXT DEFAULT ''`,
+		`ALTER TABLE executions ADD COLUMN approval_decision TEXT DEFAULT ''`,
+		`ALTER TABLE executions ADD COLUMN approval_decision_at DATETIME`,
+		`ALTER TABLE executions ADD COLUMN approval_decision_by TEXT DEFAULT ''`,
+		`CREATE INDEX IF NOT EXISTS idx_executions_approval_request ON executions(approval_request_id)`,
 	}
 
 	for _, migration := range migrations {
@@ -407,6 +414,11 @@ type Execution struct {
 	// GH-2326: persisted Task.Labels so label-driven gates (no-decompose, autopilot-fix, etc.)
 	// survive the dispatcher queue → worker round-trip.
 	TaskLabels []string
+	// Approval decision fields (GH-2667)
+	ApprovalRequestID  string
+	ApprovalDecision   string
+	ApprovalDecisionAt *time.Time
+	ApprovalDecisionBy string
 }
 
 // SaveExecution saves an execution record to the database.
@@ -421,12 +433,14 @@ func (s *Store) SaveExecution(exec *Execution) error {
 			INSERT INTO executions (id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, completed_at,
 				tokens_input, tokens_output, tokens_total, estimated_cost_usd, files_changed, lines_added, lines_removed, model_name,
 				task_title, task_description, task_branch, task_base_branch, task_create_pr, task_verbose,
-				task_source_adapter, task_source_issue_id, task_labels)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				task_source_adapter, task_source_issue_id, task_labels,
+				approval_request_id)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, exec.ID, exec.TaskID, exec.ProjectPath, exec.Status, exec.Output, exec.Error, exec.DurationMs, exec.PRUrl, exec.CommitSHA, exec.CompletedAt,
 			exec.TokensInput, exec.TokensOutput, exec.TokensTotal, exec.EstimatedCostUSD, exec.FilesChanged, exec.LinesAdded, exec.LinesRemoved, exec.ModelName,
 			exec.TaskTitle, exec.TaskDescription, exec.TaskBranch, exec.TaskBaseBranch, exec.TaskCreatePR, exec.TaskVerbose,
-			exec.TaskSourceAdapter, exec.TaskSourceIssueID, labelsJSON)
+			exec.TaskSourceAdapter, exec.TaskSourceIssueID, labelsJSON,
+			exec.ApprovalRequestID)
 		return err
 	})
 }
@@ -469,21 +483,29 @@ func (s *Store) GetExecution(id string) (*Execution, error) {
 			COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
 			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
 			COALESCE(task_source_adapter, ''), COALESCE(task_source_issue_id, ''),
-			COALESCE(task_labels, '')
+			COALESCE(task_labels, ''),
+			COALESCE(approval_request_id, ''), COALESCE(approval_decision, ''),
+			approval_decision_at,
+			COALESCE(approval_decision_by, '')
 		FROM executions WHERE id = ?
 	`, id)
 
 	var exec Execution
 	var completedAt sql.NullTime
+	var approvalDecisionAt sql.NullTime
 	var labelsJSON string
 	err := row.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &completedAt,
 		&exec.TokensInput, &exec.TokensOutput, &exec.TokensTotal, &exec.EstimatedCostUSD, &exec.FilesChanged, &exec.LinesAdded, &exec.LinesRemoved, &exec.ModelName,
 		&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose,
-		&exec.TaskSourceAdapter, &exec.TaskSourceIssueID, &labelsJSON)
+		&exec.TaskSourceAdapter, &exec.TaskSourceIssueID, &labelsJSON,
+		&exec.ApprovalRequestID, &exec.ApprovalDecision, &approvalDecisionAt, &exec.ApprovalDecisionBy)
 	if err != nil {
 		return nil, err
 	}
 	exec.TaskLabels = unmarshalLabels(labelsJSON)
+	if approvalDecisionAt.Valid {
+		exec.ApprovalDecisionAt = &approvalDecisionAt.Time
+	}
 
 	if completedAt.Valid {
 		exec.CompletedAt = &completedAt.Time
@@ -523,6 +545,35 @@ func (s *Store) InvalidateCompletion(taskID, projectPath string) error {
 		return fmt.Errorf("invalidate completion for %s at %s: %w", taskID, projectPath, err)
 	}
 	return nil
+}
+
+// SetApprovalDecision records an approval decision on the execution linked to requestID.
+// It sets approval_decision, approval_decision_at, and approval_decision_by on the row
+// whose approval_request_id matches. Returns sql.ErrNoRows if no matching row is found.
+func (s *Store) SetApprovalDecision(ctx context.Context, requestID string, decision string, by string) error {
+	if requestID == "" {
+		return sql.ErrNoRows
+	}
+	return s.withRetry("SetApprovalDecision", func() error {
+		result, err := s.db.ExecContext(ctx, `
+			UPDATE executions
+			SET approval_decision    = ?,
+			    approval_decision_at = CURRENT_TIMESTAMP,
+			    approval_decision_by = ?
+			WHERE approval_request_id = ?
+		`, decision, by, requestID)
+		if err != nil {
+			return fmt.Errorf("SetApprovalDecision: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("SetApprovalDecision rows affected: %w", err)
+		}
+		if rows == 0 {
+			return sql.ErrNoRows
+		}
+		return nil
+	})
 }
 
 // GetRecentExecutions returns the most recent executions ordered by creation time.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2667.

Closes #2667

## Changes

Extend PR state schema with `approval_request_id`, `approval_decision`, `approval_decision_at`, `approval_decision_by`. Add `SetApprovalDecision(ctx, requestID, decision, by)` method on the store and a `PRStateWriter` interface usable by the approval package. Include schema migration and unit tests for the new state field round-trips.