### PR TITLE
GH-2668: refactor(approval): replace channel API with submit + record decision

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -423,13 +423,13 @@ Examples:
 					(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
 					tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 					gwTgApprovalHandler = approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgClient}, cfg.Adapters.Telegram.ChatID)
+					approvalMgr.RegisterHandler(gwTgApprovalHandler) // wires RecordDecision recorder before Rehydrate
 					if gwStore != nil {
 						gwTgApprovalHandler.WithStore(gwStore)
 						if rErr := gwTgApprovalHandler.Rehydrate(context.Background()); rErr != nil {
 							logging.WithComponent("approval").Warn("telegram approval rehydrate failed", slog.Any("error", rErr))
 						}
 					}
-					approvalMgr.RegisterHandler(gwTgApprovalHandler)
 				}
 
 				// Register Slack approval handler if enabled

--- a/internal/approval/github.go
+++ b/internal/approval/github.go
@@ -28,10 +28,10 @@ type GitHubHandler struct {
 
 // githubPending tracks a pending GitHub approval request
 type githubPending struct {
-	Request    *Request
-	PRNumber   int
-	ResponseCh chan *Response
-	CancelFn   context.CancelFunc
+	Request  *Request
+	PRNumber int
+	recorder RecordDecisionFunc // called when PR is approved or changes requested
+	CancelFn context.CancelFunc // cancels the polling goroutine
 }
 
 // GitHubHandlerConfig holds configuration for the GitHub approval handler
@@ -63,31 +63,31 @@ func (h *GitHubHandler) Name() string {
 	return "github"
 }
 
-// SendApprovalRequest starts polling for PR approval reviews
-func (h *GitHubHandler) SendApprovalRequest(ctx context.Context, req *Request) (<-chan *Response, error) {
-	responseCh := make(chan *Response, 1)
+// setRecorder wires the manager's RecordDecision as the default recorder.
+// Called automatically by Manager.RegisterHandler. GitHub has no rehydrate path
+// so this is a no-op; recorder is always passed per-request via SendApprovalRequest.
+func (h *GitHubHandler) setRecorder(_ RecordDecisionFunc) {}
 
-	// Extract PR number from metadata
+// SendApprovalRequest starts polling for PR approval reviews (non-blocking).
+// recorder is called when the PR is approved or changes are requested.
+func (h *GitHubHandler) SendApprovalRequest(ctx context.Context, req *Request, recorder RecordDecisionFunc) error {
 	prNumber, ok := req.Metadata["pr_number"].(int)
 	if !ok {
-		// Try float64 (JSON unmarshaling)
 		if prFloat, ok := req.Metadata["pr_number"].(float64); ok {
 			prNumber = int(prFloat)
 		} else {
-			return nil, fmt.Errorf("pr_number missing from approval request metadata")
+			return fmt.Errorf("pr_number missing from approval request metadata")
 		}
 	}
 
-	// Create cancellable context for polling
 	pollCtx, cancelFn := context.WithCancel(ctx)
 
-	// Track pending request
 	h.mu.Lock()
 	h.pending[req.ID] = &githubPending{
-		Request:    req,
-		PRNumber:   prNumber,
-		ResponseCh: responseCh,
-		CancelFn:   cancelFn,
+		Request:  req,
+		PRNumber: prNumber,
+		recorder: recorder,
+		CancelFn: cancelFn,
 	}
 	h.mu.Unlock()
 
@@ -96,10 +96,9 @@ func (h *GitHubHandler) SendApprovalRequest(ctx context.Context, req *Request) (
 		slog.Int("pr_number", prNumber),
 		slog.Duration("poll_interval", h.pollInterval))
 
-	// Start polling goroutine
 	go h.pollForApproval(pollCtx, req.ID)
 
-	return responseCh, nil
+	return nil
 }
 
 // pollForApproval polls GitHub for approval reviews
@@ -107,7 +106,6 @@ func (h *GitHubHandler) pollForApproval(ctx context.Context, requestID string) {
 	ticker := time.NewTicker(h.pollInterval)
 	defer ticker.Stop()
 
-	// Check immediately first
 	if h.checkApproval(ctx, requestID) {
 		return
 	}
@@ -126,14 +124,14 @@ func (h *GitHubHandler) pollForApproval(ctx context.Context, requestID string) {
 	}
 }
 
-// checkApproval checks if the PR has been approved and sends response if so
+// checkApproval checks if the PR has been approved and calls recorder if so
 func (h *GitHubHandler) checkApproval(ctx context.Context, requestID string) bool {
 	h.mu.RLock()
 	pending, exists := h.pending[requestID]
 	h.mu.RUnlock()
 
 	if !exists {
-		return true // Request was cancelled/removed
+		return true
 	}
 
 	approved, approver, err := h.client.HasApprovalReview(ctx, h.owner, h.repo, pending.PRNumber)
@@ -151,24 +149,17 @@ func (h *GitHubHandler) checkApproval(ctx context.Context, requestID string) boo
 			slog.Int("pr_number", pending.PRNumber),
 			slog.String("approver", approver))
 
-		// Remove from pending
 		h.mu.Lock()
 		delete(h.pending, requestID)
 		h.mu.Unlock()
 
-		// Send response
-		response := &Response{
-			RequestID:   requestID,
-			Decision:    DecisionApproved,
-			ApprovedBy:  approver,
-			RespondedAt: time.Now(),
-		}
+		pending.CancelFn()
 
-		select {
-		case pending.ResponseCh <- response:
-		default:
+		if pending.recorder != nil {
+			if err := pending.recorder(ctx, requestID, DecisionApproved, approver); err != nil {
+				h.log.Warn("recorder call failed", slog.String("request_id", requestID), slog.Any("error", err))
+			}
 		}
-		close(pending.ResponseCh)
 
 		return true
 	}
@@ -176,7 +167,7 @@ func (h *GitHubHandler) checkApproval(ctx context.Context, requestID string) boo
 	return false
 }
 
-// CancelRequest cancels a pending approval request
+// CancelRequest cancels a pending approval request and stops polling
 func (h *GitHubHandler) CancelRequest(ctx context.Context, requestID string) error {
 	h.mu.Lock()
 	pending, exists := h.pending[requestID]
@@ -189,11 +180,7 @@ func (h *GitHubHandler) CancelRequest(ctx context.Context, requestID string) err
 		return nil
 	}
 
-	// Cancel polling
 	pending.CancelFn()
-
-	// Close response channel
-	close(pending.ResponseCh)
 
 	h.log.Debug("Cancelled GitHub approval request",
 		slog.String("request_id", requestID))
@@ -201,15 +188,13 @@ func (h *GitHubHandler) CancelRequest(ctx context.Context, requestID string) err
 	return nil
 }
 
-// HandleReviewEvent handles a GitHub pull_request_review webhook event
-// This provides instant response instead of waiting for poll
+// HandleReviewEvent handles a GitHub pull_request_review webhook event.
+// This provides instant response instead of waiting for poll.
 func (h *GitHubHandler) HandleReviewEvent(ctx context.Context, prNumber int, action, state, reviewer string) bool {
-	// Only process submitted reviews that are approvals
 	if action != "submitted" || state != "approved" {
 		return false
 	}
 
-	// Find pending request for this PR
 	h.mu.Lock()
 	var foundID string
 	var foundPending *githubPending
@@ -232,30 +217,20 @@ func (h *GitHubHandler) HandleReviewEvent(ctx context.Context, prNumber int, act
 		slog.Int("pr_number", prNumber),
 		slog.String("reviewer", reviewer))
 
-	// Cancel polling
 	foundPending.CancelFn()
 
-	// Send response
-	response := &Response{
-		RequestID:   foundID,
-		Decision:    DecisionApproved,
-		ApprovedBy:  reviewer,
-		RespondedAt: time.Now(),
+	if foundPending.recorder != nil {
+		if err := foundPending.recorder(ctx, foundID, DecisionApproved, reviewer); err != nil {
+			h.log.Warn("recorder call failed", slog.String("request_id", foundID), slog.Any("error", err))
+		}
 	}
-
-	select {
-	case foundPending.ResponseCh <- response:
-	default:
-	}
-	close(foundPending.ResponseCh)
 
 	return true
 }
 
-// HandleChangesRequestedEvent handles when changes are requested on a PR
-// This rejects the approval request
+// HandleChangesRequestedEvent handles when changes are requested on a PR.
+// This rejects the approval request.
 func (h *GitHubHandler) HandleChangesRequestedEvent(ctx context.Context, prNumber int, reviewer string) bool {
-	// Find pending request for this PR
 	h.mu.Lock()
 	var foundID string
 	var foundPending *githubPending
@@ -278,23 +253,13 @@ func (h *GitHubHandler) HandleChangesRequestedEvent(ctx context.Context, prNumbe
 		slog.Int("pr_number", prNumber),
 		slog.String("reviewer", reviewer))
 
-	// Cancel polling
 	foundPending.CancelFn()
 
-	// Send rejection response
-	response := &Response{
-		RequestID:   foundID,
-		Decision:    DecisionRejected,
-		ApprovedBy:  reviewer,
-		Comment:     "Changes requested",
-		RespondedAt: time.Now(),
+	if foundPending.recorder != nil {
+		if err := foundPending.recorder(ctx, foundID, DecisionRejected, reviewer); err != nil {
+			h.log.Warn("recorder call failed", slog.String("request_id", foundID), slog.Any("error", err))
+		}
 	}
-
-	select {
-	case foundPending.ResponseCh <- response:
-	default:
-	}
-	close(foundPending.ResponseCh)
 
 	return true
 }

--- a/internal/approval/github_test.go
+++ b/internal/approval/github_test.go
@@ -81,7 +81,7 @@ func TestGitHubHandler_SendApprovalRequest_MissingPRNumber(t *testing.T) {
 		Metadata: map[string]interface{}{}, // Missing pr_number
 	}
 
-	_, err := handler.SendApprovalRequest(context.Background(), req)
+	err := handler.SendApprovalRequest(context.Background(), req, nil)
 	if err == nil {
 		t.Error("expected error for missing pr_number")
 	}
@@ -108,14 +108,18 @@ func TestGitHubHandler_SendApprovalRequest_ImmediateApproval(t *testing.T) {
 		},
 	}
 
-	responseCh, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	respCh := make(chan *Response, 1)
+	recorder := func(_ context.Context, requestID string, decision Decision, by string) error {
+		respCh <- &Response{RequestID: requestID, Decision: decision, ApprovedBy: by, RespondedAt: time.Now()}
+		return nil
+	}
+	if err := handler.SendApprovalRequest(context.Background(), req, recorder); err != nil {
 		t.Fatalf("SendApprovalRequest failed: %v", err)
 	}
 
 	// Wait for response with timeout
 	select {
-	case resp := <-responseCh:
+	case resp := <-respCh:
 		if resp.Decision != DecisionApproved {
 			t.Errorf("response.Decision = %s, want approved", resp.Decision)
 		}
@@ -149,13 +153,17 @@ func TestGitHubHandler_SendApprovalRequest_PRNumberAsFloat64(t *testing.T) {
 		},
 	}
 
-	responseCh, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	respCh := make(chan *Response, 1)
+	recorder := func(_ context.Context, requestID string, decision Decision, by string) error {
+		respCh <- &Response{RequestID: requestID, Decision: decision, ApprovedBy: by, RespondedAt: time.Now()}
+		return nil
+	}
+	if err := handler.SendApprovalRequest(context.Background(), req, recorder); err != nil {
 		t.Fatalf("SendApprovalRequest failed: %v", err)
 	}
 
 	select {
-	case resp := <-responseCh:
+	case resp := <-respCh:
 		if resp.Decision != DecisionApproved {
 			t.Errorf("response.Decision = %s, want approved", resp.Decision)
 		}
@@ -184,25 +192,21 @@ func TestGitHubHandler_CancelRequest(t *testing.T) {
 		},
 	}
 
-	responseCh, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	if err := handler.SendApprovalRequest(context.Background(), req, nil); err != nil {
 		t.Fatalf("SendApprovalRequest failed: %v", err)
 	}
 
 	// Cancel the request
-	err = handler.CancelRequest(context.Background(), "test-cancel")
-	if err != nil {
+	if err := handler.CancelRequest(context.Background(), "test-cancel"); err != nil {
 		t.Fatalf("CancelRequest failed: %v", err)
 	}
 
-	// Channel should be closed
-	select {
-	case _, ok := <-responseCh:
-		if ok {
-			t.Error("expected channel to be closed after cancel")
-		}
-	case <-time.After(time.Second):
-		t.Error("timeout waiting for channel close")
+	// Pending should be cleared
+	handler.mu.RLock()
+	_, stillPending := handler.pending["test-cancel"]
+	handler.mu.RUnlock()
+	if stillPending {
+		t.Error("expected pending to be cleared after cancel")
 	}
 }
 
@@ -228,13 +232,16 @@ func TestGitHubHandler_HandleReviewEvent_Approved(t *testing.T) {
 	handler := NewGitHubHandler(client, cfg)
 
 	// Create a pending request
-	responseCh := make(chan *Response, 1)
+	respCh := make(chan *Response, 1)
 	_, cancel := context.WithCancel(context.Background())
 	handler.pending["test-webhook"] = &githubPending{
-		Request:    &Request{ID: "test-webhook"},
-		PRNumber:   42,
-		ResponseCh: responseCh,
-		CancelFn:   cancel,
+		Request:  &Request{ID: "test-webhook"},
+		PRNumber: 42,
+		recorder: func(_ context.Context, requestID string, decision Decision, by string) error {
+			respCh <- &Response{RequestID: requestID, Decision: decision, ApprovedBy: by, RespondedAt: time.Now()}
+			return nil
+		},
+		CancelFn: cancel,
 	}
 
 	// Simulate webhook event
@@ -245,7 +252,7 @@ func TestGitHubHandler_HandleReviewEvent_Approved(t *testing.T) {
 	}
 
 	select {
-	case resp := <-responseCh:
+	case resp := <-respCh:
 		if resp.Decision != DecisionApproved {
 			t.Errorf("response.Decision = %s, want approved", resp.Decision)
 		}
@@ -306,13 +313,16 @@ func TestGitHubHandler_HandleChangesRequestedEvent(t *testing.T) {
 	handler := NewGitHubHandler(client, cfg)
 
 	// Create a pending request
-	responseCh := make(chan *Response, 1)
+	respCh := make(chan *Response, 1)
 	_, cancel := context.WithCancel(context.Background())
 	handler.pending["test-changes"] = &githubPending{
-		Request:    &Request{ID: "test-changes"},
-		PRNumber:   42,
-		ResponseCh: responseCh,
-		CancelFn:   cancel,
+		Request:  &Request{ID: "test-changes"},
+		PRNumber: 42,
+		recorder: func(_ context.Context, requestID string, decision Decision, by string) error {
+			respCh <- &Response{RequestID: requestID, Decision: decision, ApprovedBy: by, RespondedAt: time.Now()}
+			return nil
+		},
+		CancelFn: cancel,
 	}
 
 	// Simulate changes requested event
@@ -323,7 +333,7 @@ func TestGitHubHandler_HandleChangesRequestedEvent(t *testing.T) {
 	}
 
 	select {
-	case resp := <-responseCh:
+	case resp := <-respCh:
 		if resp.Decision != DecisionRejected {
 			t.Errorf("response.Decision = %s, want rejected", resp.Decision)
 		}

--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -16,16 +16,24 @@ type Manager struct {
 	handlers      map[string]Handler // Channel name -> handler
 	pending       map[string]*pendingRequest
 	ruleEvaluator *RuleEvaluator
+	stateWriter   PRStateWriter // optional; nil OK
 	mu            sync.RWMutex
 	log           *slog.Logger
 }
 
-// pendingRequest tracks an active approval request
+// pendingRequest tracks an active approval request.
+// ResponseCh is set only on the RequestApproval (blocking-compat) path.
 type pendingRequest struct {
 	Request    *Request
-	ResponseCh chan *Response
 	Handler    Handler
+	ResponseCh chan *Response // non-nil when RequestApproval is waiting synchronously
 	CancelFn   context.CancelFunc
+}
+
+// recorderSetter is implemented by handlers that store the manager's recorder
+// as their default callback (used by Rehydrate and future handler-initiated flows).
+type recorderSetter interface {
+	setRecorder(RecordDecisionFunc)
 }
 
 // NewManager creates a new approval manager.
@@ -51,11 +59,23 @@ func NewManager(config *Config) *Manager {
 	return m
 }
 
-// RegisterHandler registers an approval handler for a channel
+// WithStateWriter attaches a PRStateWriter for persisting decisions.
+// Returns m to allow builder-style chaining.
+func (m *Manager) WithStateWriter(w PRStateWriter) *Manager {
+	m.stateWriter = w
+	return m
+}
+
+// RegisterHandler registers an approval handler for a channel.
+// If the handler implements recorderSetter, the manager's RecordDecision is
+// wired as its default recorder so Rehydrate can call back correctly.
 func (m *Manager) RegisterHandler(handler Handler) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.handlers[handler.Name()] = handler
+	if rs, ok := handler.(recorderSetter); ok {
+		rs.setRecorder(m.RecordDecision)
+	}
 	m.log.Debug("Registered approval handler", slog.String("channel", handler.Name()))
 }
 
@@ -96,19 +116,135 @@ func (m *Manager) ShouldRequireApproval(ruleCtx RuleContext) *Rule {
 	return m.ruleEvaluator.Evaluate(ruleCtx)
 }
 
-// RequestApproval sends an approval request and waits for response
-// Returns the decision and any error
-func (m *Manager) RequestApproval(ctx context.Context, req *Request) (*Response, error) {
+// SubmitApprovalRequest sends an approval request non-blocking and returns the
+// request ID. The manager calls RecordDecision when the user responds.
+func (m *Manager) SubmitApprovalRequest(ctx context.Context, req *Request) (string, error) {
 	if !m.IsStageEnabled(req.Stage) {
-		// Check rule-based triggers before auto-approving
 		if rule := m.checkRuleTriggers(req); rule != nil {
 			m.log.Info("Rule-triggered approval required",
 				slog.String("rule", rule.Name),
 				slog.String("task_id", req.TaskID),
 				slog.String("stage", string(req.Stage)))
-			// Fall through to normal approval flow
 		} else {
-			// Stage not enabled and no rule triggered, auto-approve
+			m.log.Debug("Auto-approving (stage disabled)",
+				slog.String("task_id", req.TaskID),
+				slog.String("stage", string(req.Stage)))
+			// For the non-blocking path, immediately record the auto-approval.
+			_ = m.RecordDecision(ctx, req.ID, DecisionApproved, "system")
+			return req.ID, nil
+		}
+	}
+
+	stageConfig := m.getStageConfig(req.Stage)
+	if stageConfig == nil {
+		stageConfig = &StageConfig{
+			Enabled:       false,
+			Timeout:       m.config.DefaultTimeout,
+			DefaultAction: m.config.DefaultAction,
+		}
+	}
+
+	timeout := stageConfig.Timeout
+	if timeout == 0 {
+		timeout = m.config.DefaultTimeout
+	}
+	req.ExpiresAt = time.Now().Add(timeout)
+
+	if len(req.Approvers) == 0 {
+		req.Approvers = stageConfig.Approvers
+	}
+
+	m.mu.RLock()
+	handler := m.selectHandler(req)
+	m.mu.RUnlock()
+
+	if handler == nil {
+		m.log.Warn("No approval handlers registered, using default action",
+			slog.String("task_id", req.TaskID),
+			slog.String("stage", string(req.Stage)),
+			slog.String("default_action", string(stageConfig.DefaultAction)))
+		_ = m.RecordDecision(ctx, req.ID, stageConfig.DefaultAction, "system")
+		return req.ID, nil
+	}
+
+	m.log.Info("Submitting approval request",
+		slog.String("request_id", req.ID),
+		slog.String("task_id", req.TaskID),
+		slog.String("stage", string(req.Stage)),
+		slog.String("channel", handler.Name()),
+		slog.Duration("timeout", timeout))
+
+	m.mu.Lock()
+	m.pending[req.ID] = &pendingRequest{
+		Request: req,
+		Handler: handler,
+	}
+	m.mu.Unlock()
+
+	if err := handler.SendApprovalRequest(ctx, req, m.RecordDecision); err != nil {
+		m.mu.Lock()
+		delete(m.pending, req.ID)
+		m.mu.Unlock()
+		return "", fmt.Errorf("failed to send approval request: %w", err)
+	}
+
+	return req.ID, nil
+}
+
+// RecordDecision records a user's approval decision.
+// It is the callback target for all handler implementations.
+// It writes the decision to the stateWriter (if set) and signals any
+// synchronous waiter from the RequestApproval compat path.
+func (m *Manager) RecordDecision(ctx context.Context, requestID string, decision Decision, by string) error {
+	m.mu.Lock()
+	pending, exists := m.pending[requestID]
+	if exists {
+		delete(m.pending, requestID)
+	}
+	m.mu.Unlock()
+
+	m.log.Info("approval decision recorded",
+		slog.String("request_id", requestID),
+		slog.String("decision", string(decision)),
+		slog.String("by", by))
+
+	// Signal synchronous waiter (RequestApproval blocking-compat path)
+	if pending != nil && pending.ResponseCh != nil {
+		response := &Response{
+			RequestID:   requestID,
+			Decision:    decision,
+			ApprovedBy:  by,
+			RespondedAt: time.Now(),
+		}
+		select {
+		case pending.ResponseCh <- response:
+		default:
+		}
+	}
+
+	// Persist to state — also handles rehydrated entries with no manager-side pending.
+	if m.stateWriter != nil {
+		if err := m.stateWriter.SetApprovalDecision(ctx, requestID, decision, by); err != nil {
+			m.log.Warn("RecordDecision: state write failed",
+				slog.String("request_id", requestID), slog.Any("error", err))
+			return fmt.Errorf("record decision: state write: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// RequestApproval sends an approval request and blocks until a response is
+// received or the context/timeout expires. Kept for backward compatibility
+// with callers that need synchronous approval (e.g., AutoMerger).
+func (m *Manager) RequestApproval(ctx context.Context, req *Request) (*Response, error) {
+	if !m.IsStageEnabled(req.Stage) {
+		if rule := m.checkRuleTriggers(req); rule != nil {
+			m.log.Info("Rule-triggered approval required",
+				slog.String("rule", rule.Name),
+				slog.String("task_id", req.TaskID),
+				slog.String("stage", string(req.Stage)))
+		} else {
 			m.log.Debug("Auto-approving (stage disabled)",
 				slog.String("task_id", req.TaskID),
 				slog.String("stage", string(req.Stage)))
@@ -122,7 +258,6 @@ func (m *Manager) RequestApproval(ctx context.Context, req *Request) (*Response,
 		}
 	}
 
-	// Get stage config (use defaults if rule-triggered but no stage config exists)
 	stageConfig := m.getStageConfig(req.Stage)
 	if stageConfig == nil {
 		stageConfig = &StageConfig{
@@ -132,43 +267,21 @@ func (m *Manager) RequestApproval(ctx context.Context, req *Request) (*Response,
 		}
 	}
 
-	// Set expiration based on stage timeout
 	timeout := stageConfig.Timeout
 	if timeout == 0 {
 		timeout = m.config.DefaultTimeout
 	}
 	req.ExpiresAt = time.Now().Add(timeout)
 
-	// Set approvers from config if not specified
 	if len(req.Approvers) == 0 {
 		req.Approvers = stageConfig.Approvers
 	}
 
-	// Find available handler
 	m.mu.RLock()
-	var handler Handler
-	if req.PreferredChannel != "" {
-		if h, ok := m.handlers[req.PreferredChannel]; ok {
-			handler = h
-		} else {
-			m.log.Warn("preferred approval channel not registered, falling back to first-available",
-				slog.String("preferred_channel", req.PreferredChannel),
-				slog.String("task_id", req.TaskID))
-			for _, h := range m.handlers {
-				handler = h
-				break
-			}
-		}
-	} else {
-		for _, h := range m.handlers {
-			handler = h
-			break
-		}
-	}
+	handler := m.selectHandler(req)
 	m.mu.RUnlock()
 
 	if handler == nil {
-		// No handlers registered - use default action
 		m.log.Warn("No approval handlers registered, using default action",
 			slog.String("task_id", req.TaskID),
 			slog.String("stage", string(req.Stage)),
@@ -189,22 +302,16 @@ func (m *Manager) RequestApproval(ctx context.Context, req *Request) (*Response,
 		slog.String("channel", handler.Name()),
 		slog.Duration("timeout", timeout))
 
-	// Create timeout context
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Send request through handler
-	responseCh, err := handler.SendApprovalRequest(timeoutCtx, req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send approval request: %w", err)
-	}
+	responseCh := make(chan *Response, 1)
 
-	// Track pending request
 	m.mu.Lock()
 	m.pending[req.ID] = &pendingRequest{
 		Request:    req,
-		ResponseCh: make(chan *Response, 1),
 		Handler:    handler,
+		ResponseCh: responseCh,
 		CancelFn:   cancel,
 	}
 	m.mu.Unlock()
@@ -215,7 +322,10 @@ func (m *Manager) RequestApproval(ctx context.Context, req *Request) (*Response,
 		m.mu.Unlock()
 	}()
 
-	// Wait for response or timeout
+	if err := handler.SendApprovalRequest(timeoutCtx, req, m.RecordDecision); err != nil {
+		return nil, fmt.Errorf("failed to send approval request: %w", err)
+	}
+
 	select {
 	case resp := <-responseCh:
 		m.log.Info("Approval response received",
@@ -225,13 +335,11 @@ func (m *Manager) RequestApproval(ctx context.Context, req *Request) (*Response,
 		return resp, nil
 
 	case <-timeoutCtx.Done():
-		// Timeout - use default action
 		m.log.Warn("Approval request timed out",
 			slog.String("request_id", req.ID),
 			slog.String("task_id", req.TaskID),
 			slog.String("default_action", string(stageConfig.DefaultAction)))
 
-		// Cancel the pending request
 		_ = handler.CancelRequest(ctx, req.ID)
 
 		return &Response{
@@ -242,6 +350,22 @@ func (m *Manager) RequestApproval(ctx context.Context, req *Request) (*Response,
 			RespondedAt: time.Now(),
 		}, nil
 	}
+}
+
+// selectHandler picks the handler for a request (must be called with m.mu held for reading).
+func (m *Manager) selectHandler(req *Request) Handler {
+	if req.PreferredChannel != "" {
+		if h, ok := m.handlers[req.PreferredChannel]; ok {
+			return h
+		}
+		m.log.Warn("preferred approval channel not registered, falling back to first-available",
+			slog.String("preferred_channel", req.PreferredChannel),
+			slog.String("task_id", req.TaskID))
+	}
+	for _, h := range m.handlers {
+		return h
+	}
+	return nil
 }
 
 // getStageConfig returns the configuration for a specific stage
@@ -265,7 +389,6 @@ func (m *Manager) checkRuleTriggers(req *Request) *Rule {
 		return nil
 	}
 
-	// Build rule context from request metadata
 	ruleCtx := RuleContext{
 		TaskID: req.TaskID,
 	}
@@ -294,7 +417,6 @@ func (m *Manager) checkRuleTriggers(req *Request) *Rule {
 		}
 	}
 
-	// Only evaluate rules for the request's stage
 	return m.ruleEvaluator.EvaluateForStage(ruleCtx, req.Stage)
 }
 
@@ -310,7 +432,9 @@ func (m *Manager) CancelPending(ctx context.Context, taskID string) {
 	m.mu.Unlock()
 
 	for _, pr := range toCancel {
-		pr.CancelFn()
+		if pr.CancelFn != nil {
+			pr.CancelFn()
+		}
 		_ = pr.Handler.CancelRequest(ctx, pr.Request.ID)
 		m.log.Debug("Cancelled pending approval",
 			slog.String("request_id", pr.Request.ID),

--- a/internal/approval/manager_test.go
+++ b/internal/approval/manager_test.go
@@ -21,18 +21,18 @@ func (m *mockHandler) Name() string {
 	return m.name
 }
 
-func (m *mockHandler) SendApprovalRequest(ctx context.Context, req *Request) (<-chan *Response, error) {
+func (m *mockHandler) SendApprovalRequest(ctx context.Context, req *Request, recorder RecordDecisionFunc) error {
 	m.mu.Lock()
 	m.sentReqs = append(m.sentReqs, req)
 	m.mu.Unlock()
-	ch := make(chan *Response, 1)
-	if m.respondWith != nil {
+	if m.respondWith != nil && recorder != nil {
+		resp := m.respondWith
 		go func() {
 			time.Sleep(10 * time.Millisecond) // Simulate async response
-			ch <- m.respondWith
+			_ = recorder(ctx, resp.RequestID, resp.Decision, resp.ApprovedBy)
 		}()
 	}
-	return ch, nil
+	return nil
 }
 
 func (m *mockHandler) CancelRequest(ctx context.Context, requestID string) error {
@@ -1363,5 +1363,263 @@ func TestManager_RuleTrigger_MultipleRules_FirstMatchWins(t *testing.T) {
 	}
 	if resp.Decision != DecisionApproved {
 		t.Errorf("expected approved, got %s", resp.Decision)
+	}
+}
+
+// --- Tests for SubmitApprovalRequest and RecordDecision ---
+
+// mockStateWriter captures SetApprovalDecision calls for assertions.
+type mockStateWriter struct {
+	mu      sync.Mutex
+	calls   []stateWriterCall
+	callErr error
+}
+
+type stateWriterCall struct {
+	requestID string
+	decision  Decision
+	by        string
+}
+
+func (w *mockStateWriter) SetApprovalDecision(_ context.Context, requestID string, d Decision, by string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.calls = append(w.calls, stateWriterCall{requestID: requestID, decision: d, by: by})
+	return w.callErr
+}
+
+func (w *mockStateWriter) getCalls() []stateWriterCall {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	result := make([]stateWriterCall, len(w.calls))
+	copy(result, w.calls)
+	return result
+}
+
+func TestManager_RecordDecision_WritesToStateWriter(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreMerge.Enabled = true
+	config.PreMerge.Timeout = time.Second
+
+	writer := &mockStateWriter{}
+	m := NewManager(config)
+	m.WithStateWriter(writer)
+
+	handler := &mockHandler{name: "test"}
+	m.RegisterHandler(handler)
+
+	req := &Request{
+		ID:        "rd-1",
+		TaskID:    "TASK-01",
+		Stage:     StagePreMerge,
+		Title:     "Test",
+		CreatedAt: time.Now(),
+	}
+
+	reqID, err := m.SubmitApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("SubmitApprovalRequest: %v", err)
+	}
+	if reqID != req.ID {
+		t.Errorf("expected req ID %q, got %q", req.ID, reqID)
+	}
+
+	if err := m.RecordDecision(context.Background(), req.ID, DecisionApproved, "alice"); err != nil {
+		t.Fatalf("RecordDecision: %v", err)
+	}
+
+	calls := writer.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 state write, got %d", len(calls))
+	}
+	if calls[0].requestID != req.ID {
+		t.Errorf("expected requestID %q, got %q", req.ID, calls[0].requestID)
+	}
+	if calls[0].decision != DecisionApproved {
+		t.Errorf("expected approved, got %s", calls[0].decision)
+	}
+	if calls[0].by != "alice" {
+		t.Errorf("expected by=alice, got %q", calls[0].by)
+	}
+}
+
+func TestManager_RecordDecision_NoStateWriter_NoError(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreMerge.Enabled = true
+	config.PreMerge.Timeout = time.Second
+
+	m := NewManager(config)
+
+	handler := &mockHandler{name: "test"}
+	m.RegisterHandler(handler)
+
+	req := &Request{
+		ID: "rd-nowriter", TaskID: "TASK-01", Stage: StagePreMerge,
+		Title: "Test", CreatedAt: time.Now(),
+	}
+
+	if _, err := m.SubmitApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("SubmitApprovalRequest: %v", err)
+	}
+
+	if err := m.RecordDecision(context.Background(), req.ID, DecisionRejected, "bob"); err != nil {
+		t.Errorf("unexpected error without state writer: %v", err)
+	}
+}
+
+func TestManager_RecordDecision_UnknownRequest_NoError(t *testing.T) {
+	// RecordDecision for a request not in manager pending should not error
+	// (handles rehydrated handler entries or double-call scenarios).
+	m := NewManager(nil)
+	if err := m.RecordDecision(context.Background(), "nonexistent", DecisionApproved, "system"); err != nil {
+		t.Errorf("unexpected error for unknown request: %v", err)
+	}
+}
+
+func TestManager_RecordDecision_StateWriteError_Propagates(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreMerge.Enabled = true
+	config.PreMerge.Timeout = time.Second
+
+	writer := &mockStateWriter{callErr: fmt.Errorf("db gone")}
+	m := NewManager(config)
+	m.WithStateWriter(writer)
+
+	handler := &mockHandler{name: "test"}
+	m.RegisterHandler(handler)
+
+	req := &Request{
+		ID: "rd-err", TaskID: "TASK-01", Stage: StagePreMerge,
+		Title: "Test", CreatedAt: time.Now(),
+	}
+
+	if _, err := m.SubmitApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("SubmitApprovalRequest: %v", err)
+	}
+
+	if err := m.RecordDecision(context.Background(), req.ID, DecisionApproved, "carol"); err == nil {
+		t.Error("expected error from state writer, got nil")
+	}
+}
+
+func TestManager_SubmitApprovalRequest_NonBlocking(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreExecution.Enabled = true
+	config.PreExecution.Timeout = 10 * time.Second
+
+	m := NewManager(config)
+
+	handler := &mockHandler{name: "test"} // no respondWith — never fires
+	m.RegisterHandler(handler)
+
+	req := &Request{
+		ID: "nb-1", TaskID: "TASK-01", Stage: StagePreExecution,
+		Title: "Test", CreatedAt: time.Now(),
+	}
+
+	start := time.Now()
+	reqID, err := m.SubmitApprovalRequest(context.Background(), req)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reqID != req.ID {
+		t.Errorf("expected %q, got %q", req.ID, reqID)
+	}
+	// Must return in well under 1 second (non-blocking)
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("SubmitApprovalRequest blocked for %v, expected non-blocking", elapsed)
+	}
+	if len(handler.sentReqs) != 1 {
+		t.Errorf("expected 1 request sent to handler, got %d", len(handler.sentReqs))
+	}
+}
+
+func TestManager_SubmitApprovalRequest_DisabledStage_AutoRecords(t *testing.T) {
+	config := DefaultConfig()
+	config.Enabled = true
+	// Stage disabled
+
+	writer := &mockStateWriter{}
+	m := NewManager(config)
+	m.WithStateWriter(writer)
+
+	req := &Request{
+		ID: "sub-auto", TaskID: "TASK-01", Stage: StagePreExecution,
+		Title: "Test", CreatedAt: time.Now(),
+	}
+
+	reqID, err := m.SubmitApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reqID != req.ID {
+		t.Errorf("expected %q, got %q", req.ID, reqID)
+	}
+
+	// Auto-approval should have been recorded via stateWriter
+	calls := writer.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 auto-approval state write, got %d", len(calls))
+	}
+	if calls[0].decision != DecisionApproved {
+		t.Errorf("expected auto-approved, got %s", calls[0].decision)
+	}
+}
+
+func TestManager_HandlerDispatch_RecorderWiredViaRegister(t *testing.T) {
+	// Verify that RecordDecision is called when a handler fires the recorder,
+	// and the decision is forwarded to the state writer.
+	config := DefaultConfig()
+	config.Enabled = true
+	config.PreExecution.Enabled = true
+	config.PreExecution.Timeout = time.Second
+
+	writer := &mockStateWriter{}
+	m := NewManager(config)
+	m.WithStateWriter(writer)
+
+	handler := &mockHandler{
+		name: "test",
+		respondWith: &Response{
+			RequestID:  "dispatch-1",
+			Decision:   DecisionApproved,
+			ApprovedBy: "dispatcher",
+		},
+	}
+	m.RegisterHandler(handler)
+
+	req := &Request{
+		ID: "dispatch-1", TaskID: "TASK-01", Stage: StagePreExecution,
+		Title: "Test", CreatedAt: time.Now(),
+	}
+
+	if _, err := m.SubmitApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("SubmitApprovalRequest: %v", err)
+	}
+
+	// Wait for async recorder call from mock handler
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if len(writer.getCalls()) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	calls := writer.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 state write from handler dispatch, got %d", len(calls))
+	}
+	if calls[0].decision != DecisionApproved {
+		t.Errorf("expected approved, got %s", calls[0].decision)
+	}
+	if calls[0].by != "dispatcher" {
+		t.Errorf("expected by=dispatcher, got %q", calls[0].by)
 	}
 }

--- a/internal/approval/slack.go
+++ b/internal/approval/slack.go
@@ -72,10 +72,10 @@ type SlackHandler struct {
 
 // slackPending tracks a pending Slack approval request
 type slackPending struct {
-	Request    *Request
-	TS         string // Slack message timestamp (used as message ID)
-	Channel    string
-	ResponseCh chan *Response
+	Request  *Request
+	TS       string             // Slack message timestamp (used as message ID)
+	Channel  string
+	recorder RecordDecisionFunc // called when user presses approve/reject
 }
 
 // NewSlackHandler creates a new Slack approval handler
@@ -93,33 +93,35 @@ func (h *SlackHandler) Name() string {
 	return "slack"
 }
 
-// SendApprovalRequest sends an approval request via Slack
-func (h *SlackHandler) SendApprovalRequest(ctx context.Context, req *Request) (<-chan *Response, error) {
-	responseCh := make(chan *Response, 1)
+// setRecorder wires the manager's RecordDecision as the default recorder.
+// Called automatically by Manager.RegisterHandler.
+func (h *SlackHandler) setRecorder(_ RecordDecisionFunc) {
+	// SlackHandler has no rehydrate path; recorder is always passed per-request
+	// via SendApprovalRequest. This satisfies the recorderSetter interface.
+}
 
-	// Build message blocks
+// SendApprovalRequest sends an approval request via Slack (non-blocking).
+// recorder is called when the user presses approve or reject.
+func (h *SlackHandler) SendApprovalRequest(ctx context.Context, req *Request, recorder RecordDecisionFunc) error {
 	blocks := h.buildApprovalBlocks(req)
 
-	// Create interactive message
 	msg := &SlackInteractiveMessage{
 		Channel: h.channel,
-		Text:    h.formatFallbackText(req), // Fallback for notifications
+		Text:    h.formatFallbackText(req),
 		Blocks:  blocks,
 	}
 
-	// Send message
 	resp, err := h.client.PostInteractiveMessage(ctx, msg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send Slack message: %w", err)
+		return fmt.Errorf("failed to send Slack message: %w", err)
 	}
 
-	// Track pending request
 	h.mu.Lock()
 	h.pending[req.ID] = &slackPending{
-		Request:    req,
-		TS:         resp.TS,
-		Channel:    resp.Channel,
-		ResponseCh: responseCh,
+		Request:  req,
+		TS:       resp.TS,
+		Channel:  resp.Channel,
+		recorder: recorder,
 	}
 	h.mu.Unlock()
 
@@ -127,7 +129,7 @@ func (h *SlackHandler) SendApprovalRequest(ctx context.Context, req *Request) (<
 		slog.String("request_id", req.ID),
 		slog.String("ts", resp.TS))
 
-	return responseCh, nil
+	return nil
 }
 
 // CancelRequest cancels a pending approval request
@@ -143,7 +145,6 @@ func (h *SlackHandler) CancelRequest(ctx context.Context, requestID string) erro
 		return nil
 	}
 
-	// Update message to show cancelled
 	if pending.TS != "" {
 		blocks := h.buildCancelledBlocks(pending.Request)
 		text := h.formatCancelledText(pending.Request)
@@ -152,16 +153,12 @@ func (h *SlackHandler) CancelRequest(ctx context.Context, requestID string) erro
 		}
 	}
 
-	// Close response channel
-	close(pending.ResponseCh)
-
 	return nil
 }
 
-// HandleInteraction processes a Slack interaction (button press)
-// This should be called by the Slack webhook handler when receiving interactions
+// HandleInteraction processes a Slack interaction (button press).
+// This should be called by the Slack webhook handler when receiving interactions.
 func (h *SlackHandler) HandleInteraction(ctx context.Context, actionID, value, userID, username, responseURL string) bool {
-	// Parse value: "approve:<requestID>" or "reject:<requestID>"
 	var decision Decision
 	var requestID string
 
@@ -172,7 +169,7 @@ func (h *SlackHandler) HandleInteraction(ctx context.Context, actionID, value, u
 		decision = DecisionRejected
 		requestID = value[7:]
 	} else {
-		return false // Not an approval action
+		return false
 	}
 
 	h.mu.Lock()
@@ -185,10 +182,9 @@ func (h *SlackHandler) HandleInteraction(ctx context.Context, actionID, value, u
 	if !exists {
 		h.log.Debug("Approval request not found or already processed",
 			slog.String("request_id", requestID))
-		return true // Still handled, just expired
+		return true
 	}
 
-	// Update message to show result
 	if pending.TS != "" {
 		blocks := h.buildResponseBlocks(pending.Request, decision, username)
 		text := h.formatResponseText(pending.Request, decision, username)
@@ -197,24 +193,17 @@ func (h *SlackHandler) HandleInteraction(ctx context.Context, actionID, value, u
 		}
 	}
 
-	// Send response
-	response := &Response{
-		RequestID:   requestID,
-		Decision:    decision,
-		ApprovedBy:  username,
-		RespondedAt: time.Now(),
-	}
-
-	select {
-	case pending.ResponseCh <- response:
-	default:
-	}
-	close(pending.ResponseCh)
-
 	h.log.Info("Approval interaction handled",
 		slog.String("request_id", requestID),
 		slog.String("decision", string(decision)),
 		slog.String("user", username))
+
+	// Notify manager via recorder.
+	if pending.recorder != nil {
+		if err := pending.recorder(ctx, requestID, decision, username); err != nil {
+			h.log.Warn("recorder call failed", slog.String("request_id", requestID), slog.Any("error", err))
+		}
+	}
 
 	return true
 }
@@ -238,7 +227,6 @@ func (h *SlackHandler) buildApprovalBlocks(req *Request) []interface{} {
 		stageLabel = "Approval Required"
 	}
 
-	// Header section
 	headerText := fmt.Sprintf("%s *%s*\n\n*Task:* `%s`\n*Title:* %s",
 		icon, stageLabel, req.TaskID, req.Title)
 
@@ -246,7 +234,6 @@ func (h *SlackHandler) buildApprovalBlocks(req *Request) []interface{} {
 		headerText += fmt.Sprintf("\n\n%s", truncateForSlack(req.Description, 500))
 	}
 
-	// Add metadata
 	if prURL, ok := req.Metadata["pr_url"].(string); ok && prURL != "" {
 		headerText += fmt.Sprintf("\n\n*PR:* <%s|View Pull Request>", prURL)
 	}
@@ -254,7 +241,6 @@ func (h *SlackHandler) buildApprovalBlocks(req *Request) []interface{} {
 		headerText += fmt.Sprintf("\n\n*Error:* ```%s```", truncateForSlack(errorMsg, 200))
 	}
 
-	// Add timeout info
 	timeLeft := time.Until(req.ExpiresAt).Round(time.Minute)
 	headerText += fmt.Sprintf("\n\n_Expires in: %s_", formatDuration(timeLeft))
 
@@ -268,7 +254,6 @@ func (h *SlackHandler) buildApprovalBlocks(req *Request) []interface{} {
 		},
 	}
 
-	// Add approval buttons
 	var approveText, rejectText string
 	switch req.Stage {
 	case StagePreExecution:

--- a/internal/approval/slack_test.go
+++ b/internal/approval/slack_test.go
@@ -62,12 +62,8 @@ func TestSlackHandler_SendApprovalRequest(t *testing.T) {
 				ExpiresAt:   time.Now().Add(time.Hour),
 			}
 
-			responseCh, err := handler.SendApprovalRequest(context.Background(), req)
-			if err != nil {
+			if err := handler.SendApprovalRequest(context.Background(), req, nil); err != nil {
 				t.Fatalf("unexpected error: %v", err)
-			}
-			if responseCh == nil {
-				t.Fatal("expected response channel")
 			}
 
 			if client.lastMessage == nil {
@@ -110,8 +106,12 @@ func TestSlackHandler_HandleInteraction_Approve(t *testing.T) {
 		ExpiresAt: time.Now().Add(time.Hour),
 	}
 
-	responseCh, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	respCh := make(chan *Response, 1)
+	recorder := func(_ context.Context, requestID string, decision Decision, by string) error {
+		respCh <- &Response{RequestID: requestID, Decision: decision, ApprovedBy: by, RespondedAt: time.Now()}
+		return nil
+	}
+	if err := handler.SendApprovalRequest(context.Background(), req, recorder); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -129,9 +129,9 @@ func TestSlackHandler_HandleInteraction_Approve(t *testing.T) {
 		t.Error("expected interaction to be handled")
 	}
 
-	// Check response was sent
+	// Check response via recorder
 	select {
-	case resp := <-responseCh:
+	case resp := <-respCh:
 		if resp.Decision != DecisionApproved {
 			t.Errorf("expected approved, got %v", resp.Decision)
 		}
@@ -155,8 +155,12 @@ func TestSlackHandler_HandleInteraction_Reject(t *testing.T) {
 		ExpiresAt: time.Now().Add(time.Hour),
 	}
 
-	responseCh, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	respCh := make(chan *Response, 1)
+	recorder := func(_ context.Context, requestID string, decision Decision, by string) error {
+		respCh <- &Response{RequestID: requestID, Decision: decision, ApprovedBy: by, RespondedAt: time.Now()}
+		return nil
+	}
+	if err := handler.SendApprovalRequest(context.Background(), req, recorder); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -175,7 +179,7 @@ func TestSlackHandler_HandleInteraction_Reject(t *testing.T) {
 	}
 
 	select {
-	case resp := <-responseCh:
+	case resp := <-respCh:
 		if resp.Decision != DecisionRejected {
 			t.Errorf("expected rejected, got %v", resp.Decision)
 		}
@@ -238,25 +242,21 @@ func TestSlackHandler_CancelRequest(t *testing.T) {
 		ExpiresAt: time.Now().Add(time.Hour),
 	}
 
-	responseCh, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	if err := handler.SendApprovalRequest(context.Background(), req, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Cancel the request
-	err = handler.CancelRequest(context.Background(), "test-cancel")
-	if err != nil {
+	if err := handler.CancelRequest(context.Background(), "test-cancel"); err != nil {
 		t.Fatalf("unexpected error cancelling: %v", err)
 	}
 
-	// Response channel should be closed
-	select {
-	case _, ok := <-responseCh:
-		if ok {
-			t.Error("expected channel to be closed")
-		}
-	case <-time.After(time.Second):
-		t.Error("timeout waiting for channel close")
+	// Verify pending is cleared
+	handler.mu.RLock()
+	_, stillPending := handler.pending["test-cancel"]
+	handler.mu.RUnlock()
+	if stillPending {
+		t.Error("expected pending to be cleared after cancel")
 	}
 }
 

--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -46,20 +46,21 @@ type MessageResult struct {
 
 // TelegramHandler handles approval requests via Telegram
 type TelegramHandler struct {
-	client  TelegramClient
-	chatID  string
-	pending map[string]*telegramPending // requestID -> pending state
-	mu      sync.RWMutex
-	log     *slog.Logger
-	store   PendingApprovalStore // optional; enables restart persistence
+	client   TelegramClient
+	chatID   string
+	pending  map[string]*telegramPending // requestID -> pending state
+	recorder RecordDecisionFunc          // default recorder wired by Manager.RegisterHandler
+	mu       sync.RWMutex
+	log      *slog.Logger
+	store    PendingApprovalStore // optional; enables restart persistence
 }
 
 // telegramPending tracks a pending Telegram approval request
 type telegramPending struct {
-	Request    *Request
-	MessageID  int64
-	ChatID     string // resolved destination — may differ from h.chatID when approvers are set
-	ResponseCh chan *Response
+	Request   *Request
+	MessageID int64
+	ChatID    string             // resolved destination — may differ from h.chatID when approvers are set
+	recorder  RecordDecisionFunc // called when user taps approve/reject
 }
 
 // NewTelegramHandler creates a new Telegram approval handler
@@ -82,6 +83,12 @@ func (h *TelegramHandler) Name() string {
 func (h *TelegramHandler) WithStore(store PendingApprovalStore) *TelegramHandler {
 	h.store = store
 	return h
+}
+
+// setRecorder wires the manager's RecordDecision as the default recorder used
+// by Rehydrate. Called automatically by Manager.RegisterHandler.
+func (h *TelegramHandler) setRecorder(recorder RecordDecisionFunc) {
+	h.recorder = recorder
 }
 
 // Rehydrate loads persisted pending approvals from the store and re-inserts them
@@ -119,13 +126,12 @@ func (h *TelegramHandler) Rehydrate(ctx context.Context) error {
 		if len(req.Approvers) > 0 {
 			destChatID = req.Approvers[0]
 		}
-		responseCh := make(chan *Response, 1)
 		h.mu.Lock()
 		if _, exists := h.pending[req.ID]; !exists {
 			h.pending[req.ID] = &telegramPending{
-				Request:    req,
-				ChatID:     destChatID,
-				ResponseCh: responseCh,
+				Request:  req,
+				ChatID:   destChatID,
+				recorder: h.recorder, // may be nil if RegisterHandler hasn't run yet
 			}
 			rehydrated++
 		}
@@ -137,29 +143,22 @@ func (h *TelegramHandler) Rehydrate(ctx context.Context) error {
 	return nil
 }
 
-// SendApprovalRequest sends an approval request via Telegram
-func (h *TelegramHandler) SendApprovalRequest(ctx context.Context, req *Request) (<-chan *Response, error) {
-	responseCh := make(chan *Response, 1)
-
-	// Format message based on stage
+// SendApprovalRequest sends an approval request via Telegram (non-blocking).
+// recorder is called when the user taps approve or reject.
+func (h *TelegramHandler) SendApprovalRequest(ctx context.Context, req *Request, recorder RecordDecisionFunc) error {
 	text := h.formatApprovalMessage(req)
-
-	// Create inline keyboard with approve/reject buttons
 	keyboard := h.createApprovalKeyboard(req)
 
-	// Resolve destination: use first approver's chat_id when available
 	destChatID := h.chatID
 	if len(req.Approvers) > 0 {
 		destChatID = req.Approvers[0]
 	}
 
-	// Send message
 	resp, err := h.client.SendMessageWithKeyboard(ctx, destChatID, text, "", keyboard)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send Telegram message: %w", err)
+		return fmt.Errorf("failed to send Telegram message: %w", err)
 	}
 
-	// Track pending request
 	var messageID int64
 	if resp != nil && resp.Result != nil {
 		messageID = resp.Result.MessageID
@@ -167,10 +166,10 @@ func (h *TelegramHandler) SendApprovalRequest(ctx context.Context, req *Request)
 
 	h.mu.Lock()
 	h.pending[req.ID] = &telegramPending{
-		Request:    req,
-		MessageID:  messageID,
-		ChatID:     destChatID,
-		ResponseCh: responseCh,
+		Request:   req,
+		MessageID: messageID,
+		ChatID:    destChatID,
+		recorder:  recorder,
 	}
 	h.mu.Unlock()
 
@@ -198,7 +197,7 @@ func (h *TelegramHandler) SendApprovalRequest(ctx context.Context, req *Request)
 		slog.String("chat_id", destChatID),
 		slog.Int64("message_id", messageID))
 
-	return responseCh, nil
+	return nil
 }
 
 // CancelRequest cancels a pending approval request
@@ -220,7 +219,6 @@ func (h *TelegramHandler) CancelRequest(ctx context.Context, requestID string) e
 		}
 	}
 
-	// Update message to show cancelled
 	if pending.MessageID != 0 {
 		text := h.formatCancelledMessage(pending.Request)
 		if err := h.client.EditMessage(ctx, pending.ChatID, pending.MessageID, text, ""); err != nil {
@@ -228,16 +226,12 @@ func (h *TelegramHandler) CancelRequest(ctx context.Context, requestID string) e
 		}
 	}
 
-	// Close response channel
-	close(pending.ResponseCh)
-
 	return nil
 }
 
-// HandleCallback processes a Telegram callback (button press)
-// This should be called by the main Telegram handler when receiving callbacks
+// HandleCallback processes a Telegram callback (button press).
+// This should be called by the main Telegram handler when receiving callbacks.
 func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, userID, username string) bool {
-	// Parse callback data: "approve:<requestID>" or "reject:<requestID>"
 	var decision Decision
 	var requestID string
 
@@ -248,7 +242,7 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 		decision = DecisionRejected
 		requestID = data[7:]
 	} else {
-		return false // Not an approval callback
+		return false
 	}
 
 	h.mu.Lock()
@@ -269,7 +263,6 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 		}
 	}
 
-	// Answer callback
 	var answerText string
 	if decision == DecisionApproved {
 		answerText = "Approved!"
@@ -278,7 +271,6 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 	}
 	_ = h.client.AnswerCallback(ctx, callbackID, answerText)
 
-	// Update message to show result
 	if pending.MessageID != 0 {
 		text := h.formatResponseMessage(pending.Request, decision, username)
 		if err := h.client.EditMessage(ctx, pending.ChatID, pending.MessageID, text, ""); err != nil {
@@ -286,24 +278,17 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 		}
 	}
 
-	// Send response
-	response := &Response{
-		RequestID:   requestID,
-		Decision:    decision,
-		ApprovedBy:  username,
-		RespondedAt: time.Now(),
-	}
-
-	select {
-	case pending.ResponseCh <- response:
-	default:
-	}
-	close(pending.ResponseCh)
-
 	h.log.Info("Approval callback handled",
 		slog.String("request_id", requestID),
 		slog.String("decision", string(decision)),
 		slog.String("user", username))
+
+	// Notify manager via recorder.
+	if pending.recorder != nil {
+		if err := pending.recorder(ctx, requestID, decision, username); err != nil {
+			h.log.Warn("recorder call failed", slog.String("request_id", requestID), slog.Any("error", err))
+		}
+	}
 
 	return true
 }
@@ -333,7 +318,6 @@ func (h *TelegramHandler) formatApprovalMessage(req *Request) string {
 		text += fmt.Sprintf("\n\n%s", truncateForTelegram(req.Description, 500))
 	}
 
-	// Add metadata
 	if prURL, ok := req.Metadata["pr_url"].(string); ok && prURL != "" {
 		text += fmt.Sprintf("\n\nPR: %s", prURL)
 	}
@@ -341,7 +325,6 @@ func (h *TelegramHandler) formatApprovalMessage(req *Request) string {
 		text += fmt.Sprintf("\n\nError: %s", truncateForTelegram(errorMsg, 200))
 	}
 
-	// Add timeout info
 	timeLeft := time.Until(req.ExpiresAt).Round(time.Minute)
 	text += fmt.Sprintf("\n\nExpires in: %s", formatDuration(timeLeft))
 

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -171,13 +171,8 @@ func TestTelegramHandler_SendApprovalRequest(t *testing.T) {
 				ExpiresAt: time.Now().Add(1 * time.Hour),
 			}
 
-			respCh, err := handler.SendApprovalRequest(context.Background(), req)
-			if err != nil {
+			if err := handler.SendApprovalRequest(context.Background(), req, nil); err != nil {
 				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if respCh == nil {
-				t.Fatal("expected non-nil response channel")
 			}
 
 			// Verify message was sent
@@ -225,8 +220,7 @@ func TestTelegramHandler_SendApprovalRequest_WithMetadata(t *testing.T) {
 		ExpiresAt: time.Now().Add(1 * time.Hour),
 	}
 
-	_, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	if err := handler.SendApprovalRequest(context.Background(), req, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -259,7 +253,7 @@ func TestTelegramHandler_SendApprovalRequest_Error(t *testing.T) {
 		ExpiresAt: time.Now().Add(1 * time.Hour),
 	}
 
-	_, err := handler.SendApprovalRequest(context.Background(), req)
+	err := handler.SendApprovalRequest(context.Background(), req, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -282,13 +276,12 @@ func TestTelegramHandler_CancelRequest(t *testing.T) {
 	}
 
 	// Send request first
-	_, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	if err := handler.SendApprovalRequest(context.Background(), req, nil); err != nil {
 		t.Fatalf("unexpected error sending request: %v", err)
 	}
 
 	// Now cancel it
-	err = handler.CancelRequest(context.Background(), "req-cancel")
+	err := handler.CancelRequest(context.Background(), "req-cancel")
 	if err != nil {
 		t.Fatalf("unexpected error cancelling: %v", err)
 	}
@@ -335,13 +328,12 @@ func TestTelegramHandler_CancelRequest_EditError(t *testing.T) {
 		ExpiresAt: time.Now().Add(1 * time.Hour),
 	}
 
-	_, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	if err := handler.SendApprovalRequest(context.Background(), req, nil); err != nil {
 		t.Fatalf("unexpected error sending request: %v", err)
 	}
 
 	// Cancel should not fail even if edit fails (just logs warning)
-	err = handler.CancelRequest(context.Background(), "req-edit-err")
+	err := handler.CancelRequest(context.Background(), "req-edit-err")
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -359,8 +351,12 @@ func TestTelegramHandler_HandleCallback_Approve(t *testing.T) {
 		ExpiresAt: time.Now().Add(1 * time.Hour),
 	}
 
-	respCh, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	respCh := make(chan *Response, 1)
+	recorder := func(_ context.Context, requestID string, decision Decision, by string) error {
+		respCh <- &Response{RequestID: requestID, Decision: decision, ApprovedBy: by, RespondedAt: time.Now()}
+		return nil
+	}
+	if err := handler.SendApprovalRequest(context.Background(), req, recorder); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -370,7 +366,7 @@ func TestTelegramHandler_HandleCallback_Approve(t *testing.T) {
 		t.Error("expected callback to be handled")
 	}
 
-	// Wait for response
+	// Wait for response via recorder
 	select {
 	case resp := <-respCh:
 		if resp == nil {
@@ -417,8 +413,12 @@ func TestTelegramHandler_HandleCallback_Reject(t *testing.T) {
 		ExpiresAt: time.Now().Add(1 * time.Hour),
 	}
 
-	respCh, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	respCh := make(chan *Response, 1)
+	recorder := func(_ context.Context, requestID string, decision Decision, by string) error {
+		respCh <- &Response{RequestID: requestID, Decision: decision, ApprovedBy: by, RespondedAt: time.Now()}
+		return nil
+	}
+	if err := handler.SendApprovalRequest(context.Background(), req, recorder); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -428,7 +428,7 @@ func TestTelegramHandler_HandleCallback_Reject(t *testing.T) {
 		t.Error("expected callback to be handled")
 	}
 
-	// Wait for response
+	// Wait for response via recorder
 	select {
 	case resp := <-respCh:
 		if resp == nil {
@@ -507,8 +507,12 @@ func TestTelegramHandler_HandleCallback_EditError(t *testing.T) {
 		ExpiresAt: time.Now().Add(1 * time.Hour),
 	}
 
-	respCh, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	respCh := make(chan *Response, 1)
+	recorder := func(_ context.Context, requestID string, decision Decision, by string) error {
+		respCh <- &Response{RequestID: requestID, Decision: decision, ApprovedBy: by, RespondedAt: time.Now()}
+		return nil
+	}
+	if err := handler.SendApprovalRequest(context.Background(), req, recorder); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -518,7 +522,7 @@ func TestTelegramHandler_HandleCallback_EditError(t *testing.T) {
 		t.Error("expected callback to be handled")
 	}
 
-	// Should still receive response
+	// Should still receive response via recorder
 	select {
 	case resp := <-respCh:
 		if resp.Decision != DecisionApproved {
@@ -760,12 +764,8 @@ func TestTelegramHandler_NilMessageResponse(t *testing.T) {
 	}
 
 	// Should handle gracefully even with message ID 0
-	respCh, err := handler.SendApprovalRequest(context.Background(), req)
-	if err != nil {
+	if err := handler.SendApprovalRequest(context.Background(), req, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if respCh == nil {
-		t.Fatal("expected non-nil response channel")
 	}
 }
 
@@ -782,8 +782,7 @@ func TestTelegramHandler_CancelWithZeroMessageID(t *testing.T) {
 			TaskID: "TASK-01",
 			Title:  "Test",
 		},
-		MessageID:  0, // Zero message ID
-		ResponseCh: make(chan *Response, 1),
+		MessageID: 0, // Zero message ID
 	}
 	handler.mu.Unlock()
 
@@ -813,8 +812,11 @@ func TestTelegramHandler_HandleCallbackWithZeroMessageID(t *testing.T) {
 			TaskID: "TASK-01",
 			Title:  "Test",
 		},
-		MessageID:  0,
-		ResponseCh: respCh,
+		MessageID: 0,
+		recorder: func(_ context.Context, requestID string, decision Decision, by string) error {
+			respCh <- &Response{RequestID: requestID, Decision: decision, ApprovedBy: by, RespondedAt: time.Now()}
+			return nil
+		},
 	}
 	handler.mu.Unlock()
 
@@ -824,7 +826,7 @@ func TestTelegramHandler_HandleCallbackWithZeroMessageID(t *testing.T) {
 		t.Error("expected callback to be handled")
 	}
 
-	// Should still receive response
+	// Should still receive response via recorder
 	select {
 	case resp := <-respCh:
 		if resp.Decision != DecisionApproved {
@@ -858,7 +860,7 @@ func TestTelegramHandler_ApproverRouting(t *testing.T) {
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 		}
 
-		_, err := handler.SendApprovalRequest(context.Background(), req)
+		err := handler.SendApprovalRequest(context.Background(), req, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -885,7 +887,7 @@ func TestTelegramHandler_ApproverRouting(t *testing.T) {
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 		}
 
-		_, err := handler.SendApprovalRequest(context.Background(), req)
+		err := handler.SendApprovalRequest(context.Background(), req, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -912,7 +914,7 @@ func TestTelegramHandler_ApproverRouting(t *testing.T) {
 			ExpiresAt: time.Now().Add(1 * time.Hour),
 		}
 
-		_, err := handler.SendApprovalRequest(context.Background(), req)
+		err := handler.SendApprovalRequest(context.Background(), req, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1001,7 +1003,7 @@ func TestTelegramHandler_WithStore_PersistOnSend(t *testing.T) {
 		ID: "persist-1", TaskID: "T-1", Stage: StagePreMerge,
 		Title: "Test", ExpiresAt: time.Now().Add(time.Hour),
 	}
-	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+	if err := handler.SendApprovalRequest(context.Background(), req, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1026,7 +1028,7 @@ func TestTelegramHandler_WithStore_DeleteOnCallback(t *testing.T) {
 		ID: "del-cb-1", TaskID: "T-2", Stage: StagePreMerge,
 		Title: "Test", ExpiresAt: time.Now().Add(time.Hour),
 	}
-	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+	if err := handler.SendApprovalRequest(context.Background(), req, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if store.len() != 1 {
@@ -1049,7 +1051,7 @@ func TestTelegramHandler_WithStore_DeleteOnCancel(t *testing.T) {
 		ID: "del-cancel-1", TaskID: "T-3", Stage: StagePreMerge,
 		Title: "Test", ExpiresAt: time.Now().Add(time.Hour),
 	}
-	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+	if err := handler.SendApprovalRequest(context.Background(), req, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/internal/approval/types.go
+++ b/internal/approval/types.go
@@ -52,12 +52,22 @@ type Response struct {
 	RespondedAt time.Time // When response was given
 }
 
+// RecordDecisionFunc is the callback that handlers invoke when a user responds.
+// The manager's RecordDecision method satisfies this signature.
+type RecordDecisionFunc func(ctx context.Context, requestID string, decision Decision, by string) error
+
+// PRStateWriter persists approval decisions to PR state.
+// autopilot.StateStore satisfies this interface.
+type PRStateWriter interface {
+	SetApprovalDecision(ctx context.Context, requestID string, d Decision, by string) error
+}
+
 // Handler is the interface for approval channel handlers
 // Each channel (Telegram, Slack, etc.) implements this interface
 type Handler interface {
-	// SendApprovalRequest sends an approval request to the channel
-	// Returns a channel that receives the response when user responds
-	SendApprovalRequest(ctx context.Context, req *Request) (<-chan *Response, error)
+	// SendApprovalRequest sends an approval request to the channel (non-blocking).
+	// recorder is called when the user responds via the channel.
+	SendApprovalRequest(ctx context.Context, req *Request, recorder RecordDecisionFunc) error
 
 	// CancelRequest cancels a pending approval request
 	CancelRequest(ctx context.Context, requestID string) error


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2668.

Closes #2668

## Changes

In `internal/approval/manager.go`, remove `RequestApproval(...) <-chan *Response` and introduce `SubmitApprovalRequest(ctx, req) (requestID string, error)` (non-blocking) plus `RecordDecision(ctx, requestID, decision, by)` that writes via the injected `PRStateWriter`. Update Telegram, Slack, and GitHub handlers in the same package (`approval/telegram.go`, `approval/slack.go`, `approval/github.go`) to call `RecordDecision` on tap instead of pushing to a channel. Add manager-level tests for `RecordDecision` writing to state and for handler dispatch.