### PR TITLE
GH-2669: refactor(autopilot/controller): non-blocking handleAwaitApproval with tick-time timeout

### DIFF
--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -23,7 +23,8 @@ type Manager struct {
 // pendingRequest tracks an active approval request
 type pendingRequest struct {
 	Request    *Request
-	ResponseCh chan *Response
+	ResponseCh chan *Response    // legacy: unused in non-blocking flow
+	HandlerCh  <-chan *Response  // actual channel from handler (used by CheckDecision)
 	Handler    Handler
 	CancelFn   context.CancelFunc
 }
@@ -310,8 +311,12 @@ func (m *Manager) CancelPending(ctx context.Context, taskID string) {
 	m.mu.Unlock()
 
 	for _, pr := range toCancel {
-		pr.CancelFn()
-		_ = pr.Handler.CancelRequest(ctx, pr.Request.ID)
+		if pr.CancelFn != nil {
+			pr.CancelFn()
+		}
+		if pr.Handler != nil {
+			_ = pr.Handler.CancelRequest(ctx, pr.Request.ID)
+		}
 		m.log.Debug("Cancelled pending approval",
 			slog.String("request_id", pr.Request.ID),
 			slog.String("task_id", taskID))
@@ -328,4 +333,156 @@ func (m *Manager) GetPendingRequests() []*Request {
 		requests = append(requests, pr.Request)
 	}
 	return requests
+}
+
+// SubmitApprovalRequest sends an approval request without blocking and returns
+// the assigned request ID. Callers use CheckDecision to poll for a response on
+// subsequent ticks instead of waiting on a channel.
+func (m *Manager) SubmitApprovalRequest(ctx context.Context, req *Request) (string, error) {
+	if req.ID == "" {
+		req.ID = fmt.Sprintf("req-%d", time.Now().UnixNano())
+	}
+	req.CreatedAt = time.Now()
+
+	stageEnabled := m.IsStageEnabled(req.Stage)
+	if !stageEnabled {
+		if rule := m.checkRuleTriggers(req); rule == nil {
+			// Stage disabled and no rule triggered: auto-approve immediately.
+			ch := make(chan *Response, 1)
+			ch <- &Response{
+				RequestID:   req.ID,
+				Decision:    DecisionApproved,
+				ApprovedBy:  "system",
+				Comment:     "Auto-approved: stage not enabled",
+				RespondedAt: time.Now(),
+			}
+			m.mu.Lock()
+			m.pending[req.ID] = &pendingRequest{Request: req, HandlerCh: ch}
+			m.mu.Unlock()
+			return req.ID, nil
+		}
+		// A rule triggered — fall through to normal approval flow.
+	}
+
+	stageConfig := m.getStageConfig(req.Stage)
+	if stageConfig == nil {
+		stageConfig = &StageConfig{
+			Timeout:       m.config.DefaultTimeout,
+			DefaultAction: m.config.DefaultAction,
+		}
+	}
+
+	timeout := stageConfig.Timeout
+	if timeout == 0 {
+		timeout = m.config.DefaultTimeout
+	}
+	req.ExpiresAt = time.Now().Add(timeout)
+	if len(req.Approvers) == 0 {
+		req.Approvers = stageConfig.Approvers
+	}
+
+	m.mu.RLock()
+	var handler Handler
+	if req.PreferredChannel != "" {
+		if h, ok := m.handlers[req.PreferredChannel]; ok {
+			handler = h
+		} else {
+			m.log.Warn("preferred approval channel not registered, falling back to first-available",
+				slog.String("preferred_channel", req.PreferredChannel),
+				slog.String("task_id", req.TaskID))
+			for _, h := range m.handlers {
+				handler = h
+				break
+			}
+		}
+	} else {
+		for _, h := range m.handlers {
+			handler = h
+			break
+		}
+	}
+	m.mu.RUnlock()
+
+	if handler == nil {
+		// No handlers registered — pre-fill with default action.
+		ch := make(chan *Response, 1)
+		ch <- &Response{
+			RequestID:   req.ID,
+			Decision:    stageConfig.DefaultAction,
+			ApprovedBy:  "system",
+			Comment:     "No approval handlers configured",
+			RespondedAt: time.Now(),
+		}
+		m.mu.Lock()
+		m.pending[req.ID] = &pendingRequest{Request: req, HandlerCh: ch}
+		m.mu.Unlock()
+		return req.ID, nil
+	}
+
+	handlerCh, err := handler.SendApprovalRequest(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send approval request: %w", err)
+	}
+
+	m.log.Info("Submitted approval request",
+		slog.String("request_id", req.ID),
+		slog.String("task_id", req.TaskID),
+		slog.String("stage", string(req.Stage)),
+		slog.String("channel", handler.Name()))
+
+	m.mu.Lock()
+	m.pending[req.ID] = &pendingRequest{
+		Request:   req,
+		HandlerCh: handlerCh,
+		Handler:   handler,
+	}
+	m.mu.Unlock()
+
+	return req.ID, nil
+}
+
+// CheckDecision does a non-blocking poll for a decision on a pending approval request.
+// Returns (response, true) if a decision has arrived; (nil, false) if still waiting.
+func (m *Manager) CheckDecision(requestID string) (*Response, bool) {
+	m.mu.RLock()
+	pr, ok := m.pending[requestID]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+
+	select {
+	case resp := <-pr.HandlerCh:
+		m.mu.Lock()
+		delete(m.pending, requestID)
+		m.mu.Unlock()
+		m.log.Info("CheckDecision: decision received",
+			slog.String("request_id", requestID),
+			slog.String("decision", string(resp.Decision)))
+		return resp, true
+	default:
+		return nil, false
+	}
+}
+
+// PreMergeTimeout returns the configured timeout for the pre-merge approval stage.
+func (m *Manager) PreMergeTimeout() time.Duration {
+	if m.config.PreMerge != nil && m.config.PreMerge.Timeout > 0 {
+		return m.config.PreMerge.Timeout
+	}
+	if m.config.DefaultTimeout > 0 {
+		return m.config.DefaultTimeout
+	}
+	return 24 * time.Hour
+}
+
+// PreMergeDefaultAction returns the configured default action for pre-merge timeout.
+func (m *Manager) PreMergeDefaultAction() Decision {
+	if m.config.PreMerge != nil && m.config.PreMerge.DefaultAction != "" {
+		return m.config.PreMerge.DefaultAction
+	}
+	if m.config.DefaultAction != "" {
+		return m.config.DefaultAction
+	}
+	return DecisionRejected
 }

--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/approval"
@@ -60,25 +61,30 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 		"sha", ShortSHA(prState.HeadSHA),
 	)
 
-	// GH-2584/GH-2585: structural escalation gates. Born from OAuth cascade #2.
-	// Force human approval for PRs that drift from their issue's scope OR
-	// exceed the size floor, regardless of env config.
-	requireApproval := m.requiresApproval(env)
-	if !requireApproval {
-		if reason := m.evaluateEscalationGates(ctx, prState); reason != "" {
-			m.log.Warn("escalation gate fired — forcing human approval despite env config",
-				"pr", prState.PRNumber, "reason", reason)
-			requireApproval = true
+	// ApprovalGranted is set by handleAwaitApproval (non-blocking flow) once the
+	// human has already approved via the three-path polling loop. Skip the blocking
+	// approval path entirely so handleMerging cannot stall processAllPRs.
+	if !prState.ApprovalGranted {
+		// GH-2584/GH-2585: structural escalation gates. Born from OAuth cascade #2.
+		// Force human approval for PRs that drift from their issue's scope OR
+		// exceed the size floor, regardless of env config.
+		requireApproval := m.requiresApproval(env)
+		if !requireApproval {
+			if reason := m.evaluateEscalationGates(ctx, prState); reason != "" {
+				m.log.Warn("escalation gate fired — forcing human approval despite env config",
+					"pr", prState.PRNumber, "reason", reason)
+				requireApproval = true
+			}
 		}
-	}
 
-	if requireApproval {
-		approved, err := m.requestApproval(ctx, prState)
-		if err != nil {
-			return fmt.Errorf("approval request failed: %w", err)
-		}
-		if !approved {
-			return fmt.Errorf("merge rejected: approval denied")
+		if requireApproval {
+			approved, err := m.requestApproval(ctx, prState)
+			if err != nil {
+				return fmt.Errorf("approval request failed: %w", err)
+			}
+			if !approved {
+				return fmt.Errorf("merge rejected: approval denied")
+			}
 		}
 	}
 
@@ -295,6 +301,77 @@ func (m *AutoMerger) CanMerge(ctx context.Context, prNumber int) (bool, string, 
 	}
 
 	return true, "", nil
+}
+
+// submitMergeApprovalRequest starts a non-blocking pre-merge approval request and
+// returns the request ID. The sentinel "auto-approved" is returned when the stage
+// is disabled and the environment does not require approval. Returns
+// ErrApprovalNotConfigured when the environment requires approval but the pre-merge
+// stage is disabled.
+func (m *AutoMerger) submitMergeApprovalRequest(ctx context.Context, prState *PRState) (string, error) {
+	if m.approvalMgr == nil {
+		return "", fmt.Errorf("approval manager not configured")
+	}
+
+	if !m.approvalMgr.IsStageEnabled(approval.StagePreMerge) {
+		if m.config.ResolvedEnv().RequireApproval {
+			m.log.Error("pre-merge approval stage not enabled in environment requiring approval",
+				"pr", prState.PRNumber, "env", m.config.EnvironmentName())
+			return "", fmt.Errorf("env %q: %w", m.config.EnvironmentName(), ErrApprovalNotConfigured)
+		}
+		// Stage not enabled and env does not require approval: auto-approve.
+		return "auto-approved", nil
+	}
+
+	req := &approval.Request{
+		ID:               fmt.Sprintf("merge-pr-%d-%d", prState.PRNumber, time.Now().UnixNano()),
+		TaskID:           fmt.Sprintf("merge-pr-%d", prState.PRNumber),
+		Stage:            approval.StagePreMerge,
+		Title:            fmt.Sprintf("PR #%d Merge Approval", prState.PRNumber),
+		Description:      fmt.Sprintf("Approve merge of PR #%d to production?", prState.PRNumber),
+		PreferredChannel: string(m.config.ApprovalSource),
+		Metadata: map[string]interface{}{
+			"pr_url":    prState.PRURL,
+			"pr_number": prState.PRNumber,
+			"head_sha":  prState.HeadSHA,
+		},
+	}
+
+	return m.approvalMgr.SubmitApprovalRequest(ctx, req)
+}
+
+// checkMergeApprovalDecision does a non-blocking check for a pre-merge approval decision.
+// The sentinel "auto-approved" immediately returns an approved response.
+func (m *AutoMerger) checkMergeApprovalDecision(requestID string) (*approval.Response, bool) {
+	if requestID == "auto-approved" {
+		return &approval.Response{
+			RequestID:   requestID,
+			Decision:    approval.DecisionApproved,
+			ApprovedBy:  "system",
+			Comment:     "Auto-approved: stage not enabled",
+			RespondedAt: time.Now(),
+		}, true
+	}
+	if m.approvalMgr == nil {
+		return nil, false
+	}
+	return m.approvalMgr.CheckDecision(requestID)
+}
+
+// mergeApprovalTimeout returns the configured timeout for the pre-merge stage.
+func (m *AutoMerger) mergeApprovalTimeout() time.Duration {
+	if m.approvalMgr == nil {
+		return 24 * time.Hour
+	}
+	return m.approvalMgr.PreMergeTimeout()
+}
+
+// mergeApprovalDefaultAction returns the configured default action on pre-merge timeout.
+func (m *AutoMerger) mergeApprovalDefaultAction() approval.Decision {
+	if m.approvalMgr == nil {
+		return approval.DecisionRejected
+	}
+	return m.approvalMgr.PreMergeDefaultAction()
 }
 
 // ShouldWaitForCI returns true if the environment requires CI to pass before merge.

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -955,43 +955,86 @@ func (c *Controller) hasChangesRequested(ctx context.Context, prState *PRState) 
 	return false
 }
 
-// handleAwaitApproval waits for human approval (prod only).
+// handleAwaitApproval implements a non-blocking three-path approval loop so that
+// processAllPRs is never starved by a single PR waiting for human input.
+//
+// Path 1 — no request yet: submit via the approval manager and return immediately.
+// Path 2 — request pending, no decision: check whether the configured timeout has
+// elapsed; if so apply the default action, otherwise stay in StageAwaitApproval.
+// Path 3 — decision recorded: advance to StageMerging (approved) or StageFailed.
 func (c *Controller) handleAwaitApproval(ctx context.Context, prState *PRState) error {
-	// This will block until approval received or timeout
-	err := c.autoMerger.MergePR(ctx, prState)
-	if err != nil {
-		if err.Error() == "merge rejected: approval denied" {
-			c.log.Info("merge approval denied", "pr", prState.PRNumber)
-			prState.Stage = StageFailed
-			return nil
+	// Path 1: submit the approval request (non-blocking).
+	if prState.ApprovalRequestID == "" {
+		reqID, err := c.autoMerger.submitMergeApprovalRequest(ctx, prState)
+		if err != nil {
+			if errors.Is(err, ErrApprovalNotConfigured) {
+				c.log.Error("approval misconfig: env requires approval but pre_merge stage is disabled",
+					"pr", prState.PRNumber,
+					"env", c.config.EnvironmentName(),
+				)
+				prState.Stage = StageFailed
+				prState.Error = fmt.Sprintf(
+					"approval-misconfig: env %q has require_approval=true but approval.pre_merge.enabled=false → deadlock until config fixed",
+					c.config.EnvironmentName(),
+				)
+				c.autoMerger.postMisconfigComment(ctx, prState)
+				c.metrics.RecordPRFailed()
+				return nil
+			}
+			return err
 		}
-		// Misconfig: env requires approval but approval.pre_merge is disabled.
-		// Fail closed — do NOT retry. Post a single explanatory comment and stop.
-		if errors.Is(err, ErrApprovalNotConfigured) {
-			c.log.Error("approval misconfig detected: env requires approval but pre_merge stage is disabled",
+		prState.ApprovalRequestID = reqID
+		prState.ApprovalRequestAt = time.Now()
+		c.log.Info("approval request submitted, awaiting decision",
+			"pr", prState.PRNumber,
+			"request_id", reqID,
+		)
+		return nil // stay in StageAwaitApproval
+	}
+
+	// Path 2: request already submitted — poll for a decision (non-blocking).
+	resp, decided := c.autoMerger.checkMergeApprovalDecision(prState.ApprovalRequestID)
+	if !decided {
+		timeout := c.autoMerger.mergeApprovalTimeout()
+		if !prState.ApprovalRequestAt.IsZero() && time.Since(prState.ApprovalRequestAt) >= timeout {
+			defaultAction := c.autoMerger.mergeApprovalDefaultAction()
+			c.log.Warn("pre-merge approval timed out, applying default action",
 				"pr", prState.PRNumber,
-				"env", c.config.EnvironmentName(),
+				"default_action", defaultAction,
+				"elapsed", time.Since(prState.ApprovalRequestAt).Round(time.Second),
 			)
-			prState.Stage = StageFailed
-			prState.Error = fmt.Sprintf(
-				"approval-misconfig: env %q has require_approval=true but approval.pre_merge.enabled=false → deadlock until config fixed",
-				c.config.EnvironmentName(),
-			)
-			c.autoMerger.postMisconfigComment(ctx, prState)
-			c.metrics.RecordPRFailed()
-			return nil
+			// Cancel the pending request so the handler goroutine can be cleaned up.
+			if c.approvalMgr != nil {
+				c.approvalMgr.CancelPending(ctx, fmt.Sprintf("merge-pr-%d", prState.PRNumber))
+			}
+			if defaultAction == approval.DecisionApproved {
+				prState.ApprovalGranted = true
+				prState.Stage = StageMerging
+			} else {
+				prState.Stage = StageFailed
+				prState.Error = "pre-merge approval timed out"
+				c.metrics.RecordPRFailed()
+			}
 		}
-		return err
-	}
-	prState.Stage = StageMerged
-
-	// Notify merge success after approval
-	if c.notifier != nil {
-		if err := c.notifier.NotifyMerged(ctx, prState); err != nil {
-			c.log.Warn("failed to send merge notification", "error", err)
-		}
+		// No timeout yet — stay in StageAwaitApproval until the next poll cycle.
+		return nil
 	}
 
+	// Path 3: decision received — advance or abort.
+	c.log.Info("pre-merge approval decision received",
+		"pr", prState.PRNumber,
+		"decision", resp.Decision,
+		"by", resp.ApprovedBy,
+	)
+	switch resp.Decision {
+	case approval.DecisionApproved:
+		prState.ApprovalGranted = true
+		prState.Stage = StageMerging
+	default:
+		prState.Stage = StageFailed
+		prState.Error = fmt.Sprintf("pre-merge approval %s by %s", resp.Decision, resp.ApprovedBy)
+		c.metrics.RecordPRFailed()
+	}
 	return nil
 }
 

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -4916,3 +4916,260 @@ func TestCIFixSizeGuard_APIError_FailOpen(t *testing.T) {
 		t.Error("fix issue MUST be created when ListPullRequestFiles fails (fail-open)")
 	}
 }
+
+// mockApprovalHandler is a controllable Handler for controller-level approval tests.
+type mockApprovalHandler struct {
+	name string
+	ch   chan *approval.Response
+}
+
+func newMockApprovalHandler(name string) *mockApprovalHandler {
+	return &mockApprovalHandler{name: name, ch: make(chan *approval.Response, 1)}
+}
+
+func (h *mockApprovalHandler) Name() string { return h.name }
+
+func (h *mockApprovalHandler) SendApprovalRequest(_ context.Context, _ *approval.Request) (<-chan *approval.Response, error) {
+	return h.ch, nil
+}
+
+func (h *mockApprovalHandler) CancelRequest(_ context.Context, _ string) error { return nil }
+
+func (h *mockApprovalHandler) sendDecision(resp *approval.Response) {
+	h.ch <- resp
+}
+
+// TestController_AwaitApproval_StaysInStageUntilDecision verifies that a PR in
+// StageAwaitApproval stays there across multiple ProcessPR calls while no decision
+// has been recorded, and advances to StageMerging once approval arrives.
+func TestController_AwaitApproval_StaysInStageUntilDecision(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return a simple PR for the merge attempt
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	handler := newMockApprovalHandler("test")
+
+	approvalCfg := approval.DefaultConfig()
+	approvalCfg.Enabled = true
+	approvalCfg.PreMerge = &approval.StageConfig{
+		Enabled:       true,
+		Timeout:       1 * time.Hour, // long timeout — won't fire in test
+		DefaultAction: approval.DecisionRejected,
+	}
+	mgr := approval.NewManager(approvalCfg)
+	mgr.RegisterHandler(handler)
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd // defaultEnvironments()["prod"].RequireApproval == true
+
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber: 77,
+		PRURL:    "https://github.com/owner/repo/pull/77",
+		HeadSHA:  "sha77",
+		Stage:    StageAwaitApproval,
+	}
+	c.mu.Lock()
+	c.activePRs[77] = prState
+	c.mu.Unlock()
+
+	ctx := context.Background()
+
+	// First call: submit the request, stay in StageAwaitApproval.
+	if err := c.handleAwaitApproval(ctx, prState); err != nil {
+		t.Fatalf("first handleAwaitApproval error: %v", err)
+	}
+	if prState.Stage != StageAwaitApproval {
+		t.Errorf("after first call: Stage = %s, want %s", prState.Stage, StageAwaitApproval)
+	}
+	if prState.ApprovalRequestID == "" {
+		t.Error("ApprovalRequestID should be set after first call")
+	}
+
+	// Second call (no decision yet): must still stay in StageAwaitApproval.
+	if err := c.handleAwaitApproval(ctx, prState); err != nil {
+		t.Fatalf("second handleAwaitApproval error: %v", err)
+	}
+	if prState.Stage != StageAwaitApproval {
+		t.Errorf("after second call (no decision): Stage = %s, want %s", prState.Stage, StageAwaitApproval)
+	}
+
+	// Inject an approval decision.
+	handler.sendDecision(&approval.Response{
+		RequestID:   prState.ApprovalRequestID,
+		Decision:    approval.DecisionApproved,
+		ApprovedBy:  "alice",
+		RespondedAt: time.Now(),
+	})
+
+	// Third call: decision is ready — must advance to StageMerging.
+	if err := c.handleAwaitApproval(ctx, prState); err != nil {
+		t.Fatalf("third handleAwaitApproval error: %v", err)
+	}
+	if prState.Stage != StageMerging {
+		t.Errorf("after approval: Stage = %s, want %s", prState.Stage, StageMerging)
+	}
+	if !prState.ApprovalGranted {
+		t.Error("ApprovalGranted should be true after approval")
+	}
+}
+
+// TestController_AwaitApproval_AppliesDefaultActionAtTimeout verifies that when
+// the configured timeout elapses without a decision, the default action is applied.
+func TestController_AwaitApproval_AppliesDefaultActionAtTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	handler := newMockApprovalHandler("test")
+
+	approvalCfg := approval.DefaultConfig()
+	approvalCfg.Enabled = true
+	approvalCfg.PreMerge = &approval.StageConfig{
+		Enabled:       true,
+		Timeout:       1 * time.Millisecond, // fires immediately
+		DefaultAction: approval.DecisionRejected,
+	}
+	mgr := approval.NewManager(approvalCfg)
+	mgr.RegisterHandler(handler)
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd
+
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:          88,
+		PRURL:             "https://github.com/owner/repo/pull/88",
+		HeadSHA:           "sha88",
+		Stage:             StageAwaitApproval,
+		ApprovalRequestID: "stale-req",
+		ApprovalRequestAt: time.Now().Add(-1 * time.Hour), // well past the 1ms timeout
+	}
+	c.mu.Lock()
+	c.activePRs[88] = prState
+	c.mu.Unlock()
+
+	ctx := context.Background()
+
+	if err := c.handleAwaitApproval(ctx, prState); err != nil {
+		t.Fatalf("handleAwaitApproval error: %v", err)
+	}
+
+	// Default action is DecisionRejected → StageFailed.
+	if prState.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s after timeout with default=rejected", prState.Stage, StageFailed)
+	}
+}
+
+// TestController_QueueNotStarved verifies that a PR stalled in StageAwaitApproval
+// (waiting for human input) does not block the processing of a second PR in the queue.
+func TestController_QueueNotStarved(t *testing.T) {
+	mergeCallCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/11":
+			_, _ = w.Write(mustJSON(t, map[string]interface{}{"number": 11, "state": "open"}))
+		case r.URL.Path == "/repos/owner/repo/pulls/22":
+			_, _ = w.Write(mustJSON(t, map[string]interface{}{"number": 22, "state": "open"}))
+		case r.URL.Path == "/repos/owner/repo/pulls/11/merge":
+			mergeCallCount++
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/repos/owner/repo/pulls/22/merge":
+			mergeCallCount++
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	// Handler for PR 11 never responds (simulates a pending human approval).
+	handler11 := newMockApprovalHandler("test")
+
+	approvalCfg := approval.DefaultConfig()
+	approvalCfg.Enabled = true
+	approvalCfg.PreMerge = &approval.StageConfig{
+		Enabled:       true,
+		Timeout:       1 * time.Hour, // long — won't fire
+		DefaultAction: approval.DecisionRejected,
+	}
+	mgr := approval.NewManager(approvalCfg)
+	mgr.RegisterHandler(handler11)
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd
+
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+
+	// PR 11: approval request already submitted, waiting for human (no decision).
+	pr11 := &PRState{
+		PRNumber:          11,
+		PRURL:             "https://github.com/owner/repo/pull/11",
+		HeadSHA:           "sha11",
+		Stage:             StageAwaitApproval,
+		ApprovalRequestID: "pending-req-11",
+		ApprovalRequestAt: time.Now(),
+	}
+	// PR 22: approval already granted, ready to merge.
+	pr22 := &PRState{
+		PRNumber:        22,
+		PRURL:           "https://github.com/owner/repo/pull/22",
+		HeadSHA:         "sha22",
+		Stage:           StageAwaitApproval,
+		ApprovalGranted: false,
+	}
+
+	c.mu.Lock()
+	c.activePRs[11] = pr11
+	c.activePRs[22] = pr22
+	c.mu.Unlock()
+
+	ctx := context.Background()
+
+	// Process PR 11: must return quickly (no decision → stay in StageAwaitApproval).
+	start := time.Now()
+	if err := c.handleAwaitApproval(ctx, pr11); err != nil {
+		t.Fatalf("handleAwaitApproval PR11 error: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("handleAwaitApproval blocked for %s; expected non-blocking (<200ms)", elapsed)
+	}
+	if pr11.Stage != StageAwaitApproval {
+		t.Errorf("PR11 stage = %s, want %s (should stay pending)", pr11.Stage, StageAwaitApproval)
+	}
+
+	// Process PR 22: first call submits the request and stays in StageAwaitApproval.
+	if err := c.handleAwaitApproval(ctx, pr22); err != nil {
+		t.Fatalf("handleAwaitApproval PR22 submit error: %v", err)
+	}
+	// Inject approval for PR 22.
+	handler11.sendDecision(&approval.Response{
+		RequestID:   pr22.ApprovalRequestID,
+		Decision:    approval.DecisionApproved,
+		ApprovedBy:  "bob",
+		RespondedAt: time.Now(),
+	})
+	// Second call: decision arrives, PR 22 must advance.
+	if err := c.handleAwaitApproval(ctx, pr22); err != nil {
+		t.Fatalf("handleAwaitApproval PR22 decision error: %v", err)
+	}
+	if pr22.Stage != StageMerging {
+		t.Errorf("PR22 stage = %s, want %s after approval", pr22.Stage, StageMerging)
+	}
+	// PR 11 must remain untouched.
+	if pr11.Stage != StageAwaitApproval {
+		t.Errorf("PR11 stage changed to %s; approval stall must not affect other PRs", pr11.Stage)
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -122,6 +122,10 @@ func (s *StateStore) migrate() error {
 			result TEXT DEFAULT '',
 			PRIMARY KEY (adapter, issue_id)
 		)`,
+		// GH-2669: Non-blocking approval fields for handleAwaitApproval three-path flow.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN approval_request_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE autopilot_pr_state ADD COLUMN approval_request_at DATETIME`,
+		`ALTER TABLE autopilot_pr_state ADD COLUMN approval_granted INTEGER NOT NULL DEFAULT 0`,
 	}
 
 	for _, m := range migrations {
@@ -143,8 +147,9 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at, updated_at,
-			release_version, release_bump_type, merge_notification_posted
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?)
+			release_version, release_bump_type, merge_notification_posted,
+			approval_request_id, approval_request_at, approval_granted
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -159,13 +164,17 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			updated_at = CURRENT_TIMESTAMP,
 			release_version = excluded.release_version,
 			release_bump_type = excluded.release_bump_type,
-			merge_notification_posted = excluded.merge_notification_posted
+			merge_notification_posted = excluded.merge_notification_posted,
+			approval_request_id = excluded.approval_request_id,
+			approval_request_at = excluded.approval_request_at,
+			approval_granted = excluded.approval_granted
 	`,
 		pr.PRNumber, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
 		nullTime(pr.LastChecked), nullTime(pr.CIWaitStartedAt),
 		pr.MergeAttempts, pr.Error, nullTime(pr.CreatedAt),
 		pr.ReleaseVersion, string(pr.ReleaseBumpType), pr.MergeNotificationPosted,
+		pr.ApprovalRequestID, nullTime(pr.ApprovalRequestAt), pr.ApprovalGranted,
 	)
 	return err
 }
@@ -177,7 +186,8 @@ func (s *StateStore) GetPRState(prNumber int) (*PRState, error) {
 		SELECT pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at,
-			release_version, release_bump_type, merge_notification_posted
+			release_version, release_bump_type, merge_notification_posted,
+			approval_request_id, approval_request_at, approval_granted
 		FROM autopilot_pr_state WHERE pr_number = ?
 	`, prNumber)
 
@@ -197,7 +207,8 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 		SELECT pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at,
-			release_version, release_bump_type, merge_notification_posted
+			release_version, release_bump_type, merge_notification_posted,
+			approval_request_id, approval_request_at, approval_granted
 		FROM autopilot_pr_state
 	`)
 	if err != nil {
@@ -208,7 +219,7 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 	var states []*PRState
 	for rows.Next() {
 		var pr PRState
-		var lastChecked, ciWaitStartedAt, createdAt sql.NullTime
+		var lastChecked, ciWaitStartedAt, createdAt, approvalRequestAt sql.NullTime
 		var stage, ciStatus, relBumpType string
 
 		if err := rows.Scan(
@@ -216,6 +227,7 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 			&stage, &ciStatus, &lastChecked, &ciWaitStartedAt,
 			&pr.MergeAttempts, &pr.Error, &createdAt,
 			&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
+			&pr.ApprovalRequestID, &approvalRequestAt, &pr.ApprovalGranted,
 		); err != nil {
 			return nil, err
 		}
@@ -231,6 +243,9 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 		}
 		if createdAt.Valid {
 			pr.CreatedAt = createdAt.Time
+		}
+		if approvalRequestAt.Valid {
+			pr.ApprovalRequestAt = approvalRequestAt.Time
 		}
 		states = append(states, &pr)
 	}
@@ -800,7 +815,7 @@ func (s *StateStore) PurgeTerminalPRStates(olderThan time.Duration) (int64, erro
 // scanPRState scans a single row into a PRState.
 func scanPRState(row *sql.Row) (*PRState, error) {
 	var pr PRState
-	var lastChecked, ciWaitStartedAt, createdAt sql.NullTime
+	var lastChecked, ciWaitStartedAt, createdAt, approvalRequestAt sql.NullTime
 	var stage, ciStatus, relBumpType string
 
 	err := row.Scan(
@@ -808,6 +823,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&stage, &ciStatus, &lastChecked, &ciWaitStartedAt,
 		&pr.MergeAttempts, &pr.Error, &createdAt,
 		&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
+		&pr.ApprovalRequestID, &approvalRequestAt, &pr.ApprovalGranted,
 	)
 	if err != nil {
 		return nil, err
@@ -824,6 +840,9 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 	}
 	if createdAt.Valid {
 		pr.CreatedAt = createdAt.Time
+	}
+	if approvalRequestAt.Valid {
+		pr.ApprovalRequestAt = approvalRequestAt.Time
 	}
 	return &pr, nil
 }

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -470,6 +470,15 @@ type PRState struct {
 	// posted to the linked issue. Prevents duplicate comments on state-machine
 	// re-entry for an already-merged PR (GH-2345).
 	MergeNotificationPosted bool
+	// ApprovalRequestID is the pending approval request ID used by the non-blocking
+	// handleAwaitApproval three-path flow. Empty means no request has been submitted yet.
+	ApprovalRequestID string
+	// ApprovalRequestAt is when the approval request was submitted, used to compare
+	// against the configured timeout without blocking processAllPRs.
+	ApprovalRequestAt time.Time
+	// ApprovalGranted is set to true once the pre-merge approval was explicitly given.
+	// handleMerging → MergePR skips re-requesting approval when this flag is set.
+	ApprovalGranted bool
 }
 
 // RepoOwnerAndName extracts the repository owner and name from the PR URL.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2669.

Closes #2669

## Changes

Rewrite `handleAwaitApproval` in `internal/autopilot/controller.go` to a non-blocking three-path flow (no request yet → submit + StageAwait; decision pending → check expiry vs. `now - request_at`; decision recorded → advance or abort). Remove `<-responseCh` and the blocking timeout select so `processAllPRs` can no longer be starved. Update existing controller tests and add `TestController_AwaitApproval_StaysInStageUntilDecision`, `TestController_AwaitApproval_AppliesDefaultActionAtTimeout`, and `TestController_QueueNotStarved` (two-PR queue, one stalled approval must not block the other).