### PR TITLE
GH-2685: refactor(autopilot/controller): wire handleAwaitApproval to async approval dispatch

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -340,7 +340,7 @@
 | Slack approval | ✅ | approval | - | `adapters.slack.approval` | Interactive messages, registered in main.go |
 | Telegram approval | ✅ | approval | - | - | Inline keyboards, registered in main.go |
 | Rule-based triggers | ✅ | approval | - | `approval.rules[]` | RuleEvaluator with 4 matchers wired into Manager (GH-636) |
-| Async dispatch | ✅ | approval | - | `approval.async_dispatch` | SubmitApprovalRequest + RecordDecision; coexists with blocking path (GH-2670) |
+| Non-blocking async approval | ✅ | autopilot | - | `approval.async_dispatch` | handleAwaitApproval tick-handler; PR-A stall no longer blocks PR-B (GH-2685) |
 
 ## Autopilot (v0.19.1+)
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -487,6 +487,9 @@ Examples:
 								parts[1],
 								gwBoardOpts...,
 							)
+							// GH-2685: wire the controller as the approval state writer so
+							// async approval decisions update the in-memory PRState.
+							approvalMgr.WithStateWriter(gwAutopilotController)
 						}
 					}
 				}
@@ -1433,6 +1436,16 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				)
 			}
 		}
+	}
+
+	// GH-2685: wire all controllers as the approval state writer so async approval
+	// decisions update the correct in-memory PRState across multi-repo deployments.
+	if len(autopilotControllers) > 0 {
+		var allControllers []*autopilot.Controller
+		for _, c := range autopilotControllers {
+			allControllers = append(allControllers, c)
+		}
+		approvalMgr.WithStateWriter(autopilot.NewMultiControllerStateWriter(allControllers...))
 	}
 
 	// Initialize memory store early for dashboard persistence (GH-367)

--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -485,6 +485,36 @@ func (m *Manager) SubmitApprovalRequest(ctx context.Context, req *Request) (stri
 	return req.ID, nil
 }
 
+// IsAsyncDispatch reports whether the non-blocking async dispatch path is enabled.
+func (m *Manager) IsAsyncDispatch() bool {
+	return m.config != nil && m.config.AsyncDispatch
+}
+
+// PreMergeTimeout returns the effective timeout for the pre-merge approval stage.
+func (m *Manager) PreMergeTimeout() time.Duration {
+	if m.config == nil {
+		return 24 * time.Hour
+	}
+	if m.config.PreMerge != nil && m.config.PreMerge.Timeout > 0 {
+		return m.config.PreMerge.Timeout
+	}
+	if m.config.DefaultTimeout > 0 {
+		return m.config.DefaultTimeout
+	}
+	return 24 * time.Hour
+}
+
+// PreMergeDefaultAction returns the default decision on timeout for the pre-merge stage.
+func (m *Manager) PreMergeDefaultAction() Decision {
+	if m.config == nil {
+		return DecisionRejected
+	}
+	if m.config.PreMerge != nil && m.config.PreMerge.DefaultAction != "" {
+		return m.config.PreMerge.DefaultAction
+	}
+	return m.config.DefaultAction
+}
+
 // RecordDecision records the outcome of a pending approval request.
 // It persists the decision via the state writer (if configured) and cancels
 // any background goroutine waiting on this request. Safe to call from

--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -72,6 +72,14 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 		}
 	}
 
+	// GH-2685: async dispatch path already obtained human approval on a prior tick.
+	// Skip the blocking requestApproval call so handleMerging is non-blocking.
+	if requireApproval && prState.ApprovalDecision == string(approval.DecisionApproved) {
+		m.log.Info("async approval already granted, skipping blocking request",
+			"pr", prState.PRNumber, "request_id", prState.ApprovalRequestID)
+		requireApproval = false
+	}
+
 	if requireApproval {
 		approved, err := m.requestApproval(ctx, prState)
 		if err != nil {

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -955,9 +955,131 @@ func (c *Controller) hasChangesRequested(ctx context.Context, prState *PRState) 
 	return false
 }
 
-// handleAwaitApproval waits for human approval (prod only).
+// handleAwaitApproval is a non-blocking tick handler for StageAwaitApproval.
+//
+// Tick 1 (no ApprovalRequestID): submits the request via SubmitApprovalRequest,
+// persists the returned ID + ApprovalRequestedAt, stays in StageAwaitApproval.
+//
+// Tick N with decision recorded: advances to StageMerging (approved) or
+// StageFailed (rejected/timeout).
+//
+// Tick N with no decision: checks wall-clock expiry against the stage timeout and
+// applies default_action when expired (belt-and-suspenders for post-restart cases).
+//
+// Legacy path (async_dispatch == false): delegates to the old blocking
+// autoMerger.MergePR call to preserve backward compatibility.
 func (c *Controller) handleAwaitApproval(ctx context.Context, prState *PRState) error {
-	// This will block until approval received or timeout
+	// Legacy blocking path — kept for one release cycle while async_dispatch rolls out.
+	if c.approvalMgr == nil || !c.approvalMgr.IsAsyncDispatch() {
+		return c.handleAwaitApprovalLegacy(ctx, prState)
+	}
+
+	// Path 1: submit request on first tick.
+	if prState.ApprovalRequestID == "" {
+		return c.submitAsyncApprovalRequest(ctx, prState)
+	}
+
+	// Path 2: decision already recorded — advance the state machine.
+	if prState.ApprovalDecision != "" {
+		return c.applyApprovalDecision(prState)
+	}
+
+	// Path 3: still waiting — check wall-clock expiry as a guard for post-restart
+	// cases where the background goroutine in SubmitApprovalRequest is gone.
+	timeout := c.approvalMgr.PreMergeTimeout()
+	if !prState.ApprovalRequestedAt.IsZero() && time.Since(prState.ApprovalRequestedAt) > timeout {
+		defaultAction := c.approvalMgr.PreMergeDefaultAction()
+		c.log.Warn("approval request expired in controller (post-restart guard)",
+			"pr", prState.PRNumber,
+			"request_id", prState.ApprovalRequestID,
+			"elapsed", time.Since(prState.ApprovalRequestedAt).Round(time.Second),
+			"default_action", defaultAction)
+		prState.ApprovalDecision = string(defaultAction)
+		return c.applyApprovalDecision(prState)
+	}
+
+	// Still waiting for user input — stay in StageAwaitApproval.
+	return nil
+}
+
+// submitAsyncApprovalRequest submits the first async approval request for a PR.
+func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PRState) error {
+	// Fail closed: if approval stage is not enabled, do NOT auto-approve when
+	// the env requires approval. Matches the legacy ErrApprovalNotConfigured behaviour.
+	if c.approvalMgr == nil || !c.approvalMgr.IsStageEnabled(approval.StagePreMerge) {
+		c.log.Error("approval misconfig: env requires approval but pre_merge.enabled=false",
+			"pr", prState.PRNumber, "env", c.config.EnvironmentName())
+		prState.Stage = StageFailed
+		prState.Error = fmt.Sprintf(
+			"approval-misconfig: env %q has require_approval=true but approval.pre_merge.enabled=false → deadlock until config fixed",
+			c.config.EnvironmentName(),
+		)
+		c.autoMerger.postMisconfigComment(ctx, prState)
+		c.metrics.RecordPRFailed()
+		return nil
+	}
+
+	taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
+	if prState.IssueNumber == 0 {
+		taskID = fmt.Sprintf("PR-%d", prState.PRNumber)
+	}
+	req := &approval.Request{
+		ID:     fmt.Sprintf("pr-%d-%d", prState.PRNumber, time.Now().UnixNano()),
+		TaskID: taskID,
+		Stage:  approval.StagePreMerge,
+		Title:  fmt.Sprintf("Merge approval for PR #%d", prState.PRNumber),
+		Metadata: map[string]interface{}{
+			"pr_url":    prState.PRURL,
+			"pr_title":  prState.PRTitle,
+			"pr_number": prState.PRNumber,
+		},
+	}
+
+	requestID, err := c.approvalMgr.SubmitApprovalRequest(ctx, req)
+	if err != nil {
+		return fmt.Errorf("submit approval request for PR %d: %w", prState.PRNumber, err)
+	}
+
+	prState.ApprovalRequestID = requestID
+	prState.ApprovalRequestedAt = time.Now()
+	// Stage intentionally stays at StageAwaitApproval.
+
+	if c.stateStore != nil {
+		if serr := c.stateStore.SavePRState(prState); serr != nil {
+			c.log.Warn("failed to persist approval request state", "pr", prState.PRNumber, "error", serr)
+		}
+	}
+
+	c.log.Info("async approval request submitted",
+		"pr", prState.PRNumber, "request_id", requestID)
+	return nil
+}
+
+// applyApprovalDecision advances the state machine based on the recorded decision.
+func (c *Controller) applyApprovalDecision(prState *PRState) error {
+	switch approval.Decision(prState.ApprovalDecision) {
+	case approval.DecisionApproved:
+		c.log.Info("approval granted — advancing to merging stage", "pr", prState.PRNumber)
+		prState.Stage = StageMerging
+	case approval.DecisionRejected, approval.DecisionTimeout:
+		c.log.Info("approval not granted — failing PR",
+			"pr", prState.PRNumber, "decision", prState.ApprovalDecision)
+		prState.Stage = StageFailed
+		prState.Error = fmt.Sprintf("merge rejected: approval %s", prState.ApprovalDecision)
+		c.metrics.RecordPRFailed()
+	default:
+		c.log.Warn("unknown approval decision — failing PR",
+			"pr", prState.PRNumber, "decision", prState.ApprovalDecision)
+		prState.Stage = StageFailed
+		prState.Error = fmt.Sprintf("unknown approval decision: %q", prState.ApprovalDecision)
+		c.metrics.RecordPRFailed()
+	}
+	return nil
+}
+
+// handleAwaitApprovalLegacy is the original blocking path, preserved for
+// async_dispatch=false deployments during the rollout window.
+func (c *Controller) handleAwaitApprovalLegacy(ctx context.Context, prState *PRState) error {
 	err := c.autoMerger.MergePR(ctx, prState)
 	if err != nil {
 		if err.Error() == "merge rejected: approval denied" {
@@ -985,13 +1107,38 @@ func (c *Controller) handleAwaitApproval(ctx context.Context, prState *PRState) 
 	}
 	prState.Stage = StageMerged
 
-	// Notify merge success after approval
 	if c.notifier != nil {
 		if err := c.notifier.NotifyMerged(ctx, prState); err != nil {
 			c.log.Warn("failed to send merge notification", "error", err)
 		}
 	}
 
+	return nil
+}
+
+// SetApprovalDecision implements approval.PRStateWriter. It finds the in-memory
+// PRState whose ApprovalRequestID matches and records the decision, then persists
+// via stateStore. Called by the approval.Manager's background goroutine when a
+// handler fires (e.g. Telegram button tap).
+func (c *Controller) SetApprovalDecision(_ context.Context, requestID string, decision string, by string) error {
+	if requestID == "" {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, pr := range c.activePRs {
+		if pr.ApprovalRequestID == requestID {
+			pr.ApprovalDecision = decision
+			if c.stateStore != nil {
+				_ = c.stateStore.SavePRState(pr)
+			}
+			c.log.Info("approval decision applied to PR state",
+				"pr", pr.PRNumber, "request_id", requestID,
+				"decision", decision, "by", by)
+			return nil
+		}
+	}
+	// requestID not found in this controller — normal in multi-repo deployments.
 	return nil
 }
 
@@ -2230,4 +2377,27 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 	// GH-2198: Close parent epic when all sub-issues are done (even if this one
 	// was closed without merge). maybeCloseParentIssue no-ops for non-sub-issues.
 	c.maybeCloseParentIssue(ctx, prState)
+}
+
+// MultiControllerStateWriter routes approval decisions to whichever controller
+// owns the matching ApprovalRequestID. Use this when multiple controllers share
+// a single approval.Manager (multi-repo deployments).
+type MultiControllerStateWriter struct {
+	controllers []*Controller
+}
+
+// NewMultiControllerStateWriter creates a writer that delegates SetApprovalDecision
+// to each controller in order, stopping at the first match.
+func NewMultiControllerStateWriter(controllers ...*Controller) *MultiControllerStateWriter {
+	return &MultiControllerStateWriter{controllers: controllers}
+}
+
+// SetApprovalDecision implements approval.PRStateWriter by trying each controller.
+func (w *MultiControllerStateWriter) SetApprovalDecision(ctx context.Context, requestID string, decision string, by string) error {
+	for _, c := range w.controllers {
+		if err := c.SetApprovalDecision(ctx, requestID, decision, by); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -4916,3 +4916,196 @@ func TestCIFixSizeGuard_APIError_FailOpen(t *testing.T) {
 		t.Error("fix issue MUST be created when ListPullRequestFiles fails (fail-open)")
 	}
 }
+
+// asyncApprovalManager returns an approval.Manager configured for async pre-merge approval.
+func asyncApprovalManager() *approval.Manager {
+	cfg := &approval.Config{
+		Enabled:        true,
+		AsyncDispatch:  true,
+		DefaultTimeout: 1 * time.Hour,
+		DefaultAction:  approval.DecisionRejected,
+		PreMerge: &approval.StageConfig{
+			Enabled:       true,
+			Timeout:       1 * time.Hour,
+			DefaultAction: approval.DecisionRejected,
+		},
+	}
+	return approval.NewManager(cfg)
+}
+
+// TestController_AwaitApproval_StaysInStageUntilDecision verifies that the
+// non-blocking handleAwaitApproval submits a request on the first tick and
+// stays in StageAwaitApproval until a decision is recorded.
+func TestController_AwaitApproval_StaysInStageUntilDecision(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd
+
+	mgr := asyncApprovalManager()
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+
+	// Plant a PR directly in StageAwaitApproval.
+	c.mu.Lock()
+	c.activePRs[42] = &PRState{
+		PRNumber:    42,
+		PRURL:       "https://github.com/owner/repo/pull/42",
+		PRTitle:     "feat: something",
+		IssueNumber: 10,
+		Stage:       StageAwaitApproval,
+	}
+	c.mu.Unlock()
+
+	ctx := context.Background()
+
+	// Tick 1: no ApprovalRequestID yet — should submit and stay in stage.
+	if err := c.ProcessPR(ctx, 42, nil); err != nil {
+		t.Fatalf("tick 1 error: %v", err)
+	}
+	pr, _ := c.GetPRState(42)
+	if pr.Stage != StageAwaitApproval {
+		t.Errorf("after tick 1: stage = %s, want %s", pr.Stage, StageAwaitApproval)
+	}
+	if pr.ApprovalRequestID == "" {
+		t.Error("after tick 1: ApprovalRequestID must be set")
+	}
+	if pr.ApprovalRequestedAt.IsZero() {
+		t.Error("after tick 1: ApprovalRequestedAt must be set")
+	}
+
+	// Tick 2: request submitted, no decision yet — should stay in stage.
+	if err := c.ProcessPR(ctx, 42, nil); err != nil {
+		t.Fatalf("tick 2 error: %v", err)
+	}
+	pr, _ = c.GetPRState(42)
+	if pr.Stage != StageAwaitApproval {
+		t.Errorf("after tick 2: stage = %s, want %s", pr.Stage, StageAwaitApproval)
+	}
+
+	// Record approval decision directly (simulating a Telegram callback).
+	_ = c.SetApprovalDecision(ctx, pr.ApprovalRequestID, string(approval.DecisionApproved), "testuser")
+
+	// Tick 3: decision recorded — should advance to StageMerging.
+	if err := c.ProcessPR(ctx, 42, nil); err != nil {
+		t.Fatalf("tick 3 error: %v", err)
+	}
+	pr, _ = c.GetPRState(42)
+	if pr.Stage != StageMerging {
+		t.Errorf("after approval tick: stage = %s, want %s", pr.Stage, StageMerging)
+	}
+}
+
+// TestController_AwaitApproval_AppliesDefaultActionAtTimeout verifies that when
+// ApprovalRequestedAt exceeds the stage timeout and no decision is recorded, the
+// controller applies the configured default_action.
+func TestController_AwaitApproval_AppliesDefaultActionAtTimeout(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd
+
+	// Short timeout so the test can simulate expiry without sleeping.
+	approvalCfg := &approval.Config{
+		Enabled:        true,
+		AsyncDispatch:  true,
+		DefaultTimeout: 1 * time.Millisecond,
+		DefaultAction:  approval.DecisionRejected,
+		PreMerge: &approval.StageConfig{
+			Enabled:       true,
+			Timeout:       1 * time.Millisecond,
+			DefaultAction: approval.DecisionRejected,
+		},
+	}
+	mgr := approval.NewManager(approvalCfg)
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+
+	// Plant a PR in StageAwaitApproval with a request already submitted but expired.
+	c.mu.Lock()
+	c.activePRs[42] = &PRState{
+		PRNumber:            42,
+		PRURL:               "https://github.com/owner/repo/pull/42",
+		IssueNumber:         10,
+		Stage:               StageAwaitApproval,
+		ApprovalRequestID:   "req-expired",
+		ApprovalRequestedAt: time.Now().Add(-2 * time.Hour), // well past timeout
+	}
+	c.mu.Unlock()
+
+	ctx := context.Background()
+
+	// Single tick: should detect expiry, apply default_action (rejected), set StageFailed.
+	if err := c.ProcessPR(ctx, 42, nil); err != nil {
+		t.Fatalf("tick error: %v", err)
+	}
+	pr, _ := c.GetPRState(42)
+	if pr.Stage != StageFailed {
+		t.Errorf("after timeout: stage = %s, want %s", pr.Stage, StageFailed)
+	}
+	if pr.ApprovalDecision != string(approval.DecisionRejected) {
+		t.Errorf("after timeout: decision = %q, want %q", pr.ApprovalDecision, approval.DecisionRejected)
+	}
+}
+
+// TestController_TwoPRQueue_StalledApprovalDoesNotBlockOther verifies that a PR
+// stalled in StageAwaitApproval does not prevent another PR from advancing through
+// earlier stages.
+func TestController_TwoPRQueue_StalledApprovalDoesNotBlockOther(t *testing.T) {
+	// Server returns success for any check-run or merge request.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "check-runs"):
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: "completed", Conclusion: "success"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	// Use stage env so PR-B can reach StageMerging without blocking on approval.
+	cfg.Environment = EnvStage
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 1 * time.Second
+	cfg.RequiredChecks = []string{"build"}
+
+	mgr := asyncApprovalManager()
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+
+	ctx := context.Background()
+
+	// PR-A: stalled in StageAwaitApproval with request already submitted.
+	c.mu.Lock()
+	c.activePRs[10] = &PRState{
+		PRNumber:            10,
+		PRURL:               "https://github.com/owner/repo/pull/10",
+		IssueNumber:         1,
+		HeadSHA:             "sha10",
+		Stage:               StageAwaitApproval,
+		ApprovalRequestID:   "req-stalled",
+		ApprovalRequestedAt: time.Now(),
+	}
+	c.mu.Unlock()
+
+	// PR-B: freshly created, will advance independently.
+	c.OnPRCreated(20, "https://github.com/owner/repo/pull/20", 2, "sha20", "pilot/GH-2", "")
+
+	// Tick both PRs — PR-A stays stalled, PR-B advances from StagePRCreated → StageWaitingCI.
+	_ = c.ProcessPR(ctx, 10, nil)
+	_ = c.ProcessPR(ctx, 20, nil)
+
+	prA, _ := c.GetPRState(10)
+	prB, _ := c.GetPRState(20)
+
+	if prA.Stage != StageAwaitApproval {
+		t.Errorf("PR-A should still be %s, got %s", StageAwaitApproval, prA.Stage)
+	}
+	if prB.Stage == StagePRCreated {
+		t.Errorf("PR-B should have advanced past %s (was blocked by PR-A)", StagePRCreated)
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -122,6 +122,11 @@ func (s *StateStore) migrate() error {
 			result TEXT DEFAULT '',
 			PRIMARY KEY (adapter, issue_id)
 		)`,
+		// GH-2685: Async approval state — persisted so crash-recovery can resume
+		// the non-blocking tick handler without re-submitting the request.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN approval_request_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE autopilot_pr_state ADD COLUMN approval_decision TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE autopilot_pr_state ADD COLUMN approval_requested_at DATETIME`,
 	}
 
 	for _, m := range migrations {
@@ -143,8 +148,9 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at, updated_at,
-			release_version, release_bump_type, merge_notification_posted
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?)
+			release_version, release_bump_type, merge_notification_posted,
+			approval_request_id, approval_decision, approval_requested_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -159,13 +165,17 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			updated_at = CURRENT_TIMESTAMP,
 			release_version = excluded.release_version,
 			release_bump_type = excluded.release_bump_type,
-			merge_notification_posted = excluded.merge_notification_posted
+			merge_notification_posted = excluded.merge_notification_posted,
+			approval_request_id = excluded.approval_request_id,
+			approval_decision = excluded.approval_decision,
+			approval_requested_at = excluded.approval_requested_at
 	`,
 		pr.PRNumber, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
 		nullTime(pr.LastChecked), nullTime(pr.CIWaitStartedAt),
 		pr.MergeAttempts, pr.Error, nullTime(pr.CreatedAt),
 		pr.ReleaseVersion, string(pr.ReleaseBumpType), pr.MergeNotificationPosted,
+		pr.ApprovalRequestID, pr.ApprovalDecision, nullTime(pr.ApprovalRequestedAt),
 	)
 	return err
 }
@@ -177,7 +187,8 @@ func (s *StateStore) GetPRState(prNumber int) (*PRState, error) {
 		SELECT pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at,
-			release_version, release_bump_type, merge_notification_posted
+			release_version, release_bump_type, merge_notification_posted,
+			approval_request_id, approval_decision, approval_requested_at
 		FROM autopilot_pr_state WHERE pr_number = ?
 	`, prNumber)
 
@@ -197,7 +208,8 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 		SELECT pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at,
-			release_version, release_bump_type, merge_notification_posted
+			release_version, release_bump_type, merge_notification_posted,
+			approval_request_id, approval_decision, approval_requested_at
 		FROM autopilot_pr_state
 	`)
 	if err != nil {
@@ -208,7 +220,7 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 	var states []*PRState
 	for rows.Next() {
 		var pr PRState
-		var lastChecked, ciWaitStartedAt, createdAt sql.NullTime
+		var lastChecked, ciWaitStartedAt, createdAt, approvalRequestedAt sql.NullTime
 		var stage, ciStatus, relBumpType string
 
 		if err := rows.Scan(
@@ -216,6 +228,7 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 			&stage, &ciStatus, &lastChecked, &ciWaitStartedAt,
 			&pr.MergeAttempts, &pr.Error, &createdAt,
 			&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
+			&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -231,6 +244,9 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 		}
 		if createdAt.Valid {
 			pr.CreatedAt = createdAt.Time
+		}
+		if approvalRequestedAt.Valid {
+			pr.ApprovalRequestedAt = approvalRequestedAt.Time
 		}
 		states = append(states, &pr)
 	}
@@ -800,7 +816,7 @@ func (s *StateStore) PurgeTerminalPRStates(olderThan time.Duration) (int64, erro
 // scanPRState scans a single row into a PRState.
 func scanPRState(row *sql.Row) (*PRState, error) {
 	var pr PRState
-	var lastChecked, ciWaitStartedAt, createdAt sql.NullTime
+	var lastChecked, ciWaitStartedAt, createdAt, approvalRequestedAt sql.NullTime
 	var stage, ciStatus, relBumpType string
 
 	err := row.Scan(
@@ -808,6 +824,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&stage, &ciStatus, &lastChecked, &ciWaitStartedAt,
 		&pr.MergeAttempts, &pr.Error, &createdAt,
 		&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
+		&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -824,6 +841,9 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 	}
 	if createdAt.Valid {
 		pr.CreatedAt = createdAt.Time
+	}
+	if approvalRequestedAt.Valid {
+		pr.ApprovalRequestedAt = approvalRequestedAt.Time
 	}
 	return &pr, nil
 }

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -470,6 +470,12 @@ type PRState struct {
 	// posted to the linked issue. Prevents duplicate comments on state-machine
 	// re-entry for an already-merged PR (GH-2345).
 	MergeNotificationPosted bool
+	// ApprovalRequestID holds the ID of the submitted async approval request (set on first tick in StageAwaitApproval).
+	ApprovalRequestID string
+	// ApprovalDecision holds the recorded async approval decision ("approved", "rejected", "timeout").
+	ApprovalDecision string
+	// ApprovalRequestedAt is when the async approval request was first submitted.
+	ApprovalRequestedAt time.Time
 }
 
 // RepoOwnerAndName extracts the repository owner and name from the PR URL.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2685.

Closes #2685

## Changes

Convert `internal/autopilot/controller.go:handleAwaitApproval` (lines 958-996) from the synchronous `MergePR`/`RequestApproval` blocking path to the non-blocking two-path tick handler using `Manager.SubmitApprovalRequest` and `prState.ApprovalDecision`. On first tick with no `ApprovalRequestID`, submit via `SubmitApprovalRequest`, persist the returned ID and `ApprovalRequestedAt`, and stay in `StageAwaitApproval`. On subsequent ticks, branch on `prState.ApprovalDecision`: `approved` advances to the merging stage, `rejected`/`expired` moves to `StageFailed`, and empty/`pending` checks `time.Since(ApprovalRequestedAt)` against the stage timeout (applying `default_action` on expiry) before returning to stay in stage. Preserve the existing `ErrApprovalNotConfigured` fail-closed behaviour. Verify `Manager.WithStateWriter(prStateWriter)` is wired at both Manager construction sites in `cmd/pilot/main.go` (~`:423` and `:1304`); add it if missing. Keep the legacy `RequestApproval` path reachable when `Config.AsyncDispatch == false` for safety. Validate with `go build ./...`, `go vet ./...`, existing approval tests, and a new two-PR queue test proving a stalled approval on PR-A does not block PR-B advancing through earlier stages.
(Single subtask: all changes live in `internal/autopilot/controller.go` plus minimal wiring in `cmd/pilot/main.go`. Per the single-package rule, splitting would cause merge conflicts.)