### PR TITLE
GH-2689: refactor(autopilot/controller): wire handleAwaitApproval to async approval dispatch

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -341,6 +341,7 @@
 | Telegram approval | ✅ | approval | - | - | Inline keyboards, registered in main.go |
 | Rule-based triggers | ✅ | approval | - | `approval.rules[]` | RuleEvaluator with 4 matchers wired into Manager (GH-636) |
 | Async dispatch | ✅ | approval | - | `approval.async_dispatch` | SubmitApprovalRequest + RecordDecision; coexists with blocking path (GH-2670) |
+| Async approval tick handler | ✅ | autopilot | v2.126.0 | `approval.async_dispatch` | handleAwaitApproval two-path tick: first tick submits, subsequent ticks poll decision; legacy sync path kept for async_dispatch=false (GH-2689) |
 
 ## Autopilot (v0.19.1+)
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -417,6 +417,10 @@ Examples:
 
 				// Create approval manager for autopilot
 				approvalMgr := approval.NewManager(cfg.Approval)
+				// GH-2689: wire state writer so async RecordDecision persists decisions.
+				if gwStore != nil {
+					approvalMgr.WithStateWriter(gwStore)
+				}
 
 				// Register Telegram approval handler if enabled
 				if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.BotToken != "" &&
@@ -1454,6 +1458,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		if rErr := tgApprovalHandlerImpl.Rehydrate(ctx); rErr != nil {
 			logging.WithComponent("approval").Warn("telegram approval rehydrate failed", slog.Any("error", rErr))
 		}
+	}
+
+	// GH-2689: wire state writer so async RecordDecision persists decisions.
+	if store != nil {
+		approvalMgr.WithStateWriter(store)
 	}
 
 	// GH-726: Initialize autopilot state store for crash recovery

--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -65,6 +65,13 @@ func (m *Manager) IsEnabled() bool {
 	return m.config != nil && m.config.Enabled
 }
 
+// IsAsyncDispatch returns true when non-blocking async approval dispatch is
+// configured (approval.async_dispatch = true, the default). When false, callers
+// should use the legacy blocking RequestApproval path instead.
+func (m *Manager) IsAsyncDispatch() bool {
+	return m.config == nil || m.config.AsyncDispatch
+}
+
 // IsStageEnabled checks if a specific stage requires approval
 func (m *Manager) IsStageEnabled(stage Stage) bool {
 	if !m.IsEnabled() {
@@ -483,6 +490,42 @@ func (m *Manager) SubmitApprovalRequest(ctx context.Context, req *Request) (stri
 		slog.Duration("timeout", timeout))
 
 	return req.ID, nil
+}
+
+// LookupDecision queries the state writer for the decision associated with
+// requestID. Returns "" if no decision has been recorded yet or if the state
+// writer does not implement DecisionReader. Safe to call from any goroutine.
+func (m *Manager) LookupDecision(ctx context.Context, requestID string) string {
+	dr, ok := m.stateWriter.(DecisionReader)
+	if !ok || dr == nil {
+		return ""
+	}
+	decision, err := dr.GetApprovalDecision(ctx, requestID)
+	if err != nil {
+		m.log.Warn("LookupDecision: read failed", slog.String("request_id", requestID), slog.Any("error", err))
+		return ""
+	}
+	return decision
+}
+
+// PreMergeTimeout returns the configured timeout for the pre_merge stage.
+// Falls back to DefaultTimeout when no stage-specific timeout is set.
+func (m *Manager) PreMergeTimeout() time.Duration {
+	if m.config.PreMerge != nil && m.config.PreMerge.Timeout > 0 {
+		return m.config.PreMerge.Timeout
+	}
+	if m.config.DefaultTimeout > 0 {
+		return m.config.DefaultTimeout
+	}
+	return 24 * time.Hour
+}
+
+// PreMergeDefaultAction returns the action to take when the pre_merge stage times out.
+func (m *Manager) PreMergeDefaultAction() Decision {
+	if m.config.PreMerge != nil && m.config.PreMerge.DefaultAction != "" {
+		return m.config.PreMerge.DefaultAction
+	}
+	return m.config.DefaultAction
 }
 
 // RecordDecision records the outcome of a pending approval request.

--- a/internal/approval/types.go
+++ b/internal/approval/types.go
@@ -61,6 +61,15 @@ type PRStateWriter interface {
 	SetApprovalDecision(ctx context.Context, requestID string, decision string, by string) error
 }
 
+// DecisionReader is an optional extension of PRStateWriter that allows callers
+// to read back a decision by request ID. memory.Store satisfies this interface.
+// Used by the autopilot controller to poll for async approval outcomes on each tick.
+type DecisionReader interface {
+	// GetApprovalDecision returns the stored approval decision for the given
+	// requestID. Returns ("", nil) if no decision has been recorded yet.
+	GetApprovalDecision(ctx context.Context, requestID string) (string, error)
+}
+
 // Handler is the interface for approval channel handlers
 // Each channel (Telegram, Slack, etc.) implements this interface
 type Handler interface {

--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -72,6 +72,16 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 		}
 	}
 
+	// GH-2689: async approval path records the decision on prState before
+	// advancing to StageMerging. Skip the blocking requestApproval when the
+	// controller has already obtained approval via SubmitApprovalRequest.
+	if requireApproval && prState.ApprovalDecision == string(approval.DecisionApproved) {
+		m.log.Info("MergePR: skipping approval check — already approved via async flow",
+			"pr", prState.PRNumber,
+		)
+		requireApproval = false
+	}
+
 	if requireApproval {
 		approved, err := m.requestApproval(ctx, prState)
 		if err != nil {

--- a/internal/autopilot/await_approval_test.go
+++ b/internal/autopilot/await_approval_test.go
@@ -1,0 +1,267 @@
+package autopilot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/approval"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// newAsyncController builds a minimal Controller configured for the async
+// approval path. approvalCfg may be nil (falls back to a default async config).
+func newAsyncController(t *testing.T, approvalCfg *approval.Config) *Controller {
+	t.Helper()
+	if approvalCfg == nil {
+		approvalCfg = &approval.Config{
+			Enabled:       true,
+			AsyncDispatch: true,
+			PreMerge: &approval.StageConfig{
+				Enabled:       true,
+				Timeout:       1 * time.Hour,
+				DefaultAction: approval.DecisionRejected,
+			},
+			DefaultTimeout: 1 * time.Hour,
+			DefaultAction:  approval.DecisionRejected,
+		}
+	}
+	cfg := DefaultConfig()
+	cfg.ApprovalTimeout = 1 * time.Hour
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	approvalMgr := approval.NewManager(approvalCfg)
+	return NewController(cfg, ghClient, approvalMgr, "owner", "repo")
+}
+
+// newPRStateAwaitingApproval returns a PRState positioned at StageAwaitApproval.
+func newPRStateAwaitingApproval(prNumber int) *PRState {
+	return &PRState{
+		PRNumber:  prNumber,
+		PRURL:     "https://github.com/owner/repo/pull/42",
+		Stage:     StageAwaitApproval,
+		HeadSHA:   "abc123",
+		CreatedAt: time.Now().Add(-5 * time.Minute),
+	}
+}
+
+// TestHandleAwaitApproval_TableDriven covers the async approval tick handler.
+func TestHandleAwaitApproval_TableDriven(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name            string
+		setupState      func(*PRState)
+		approvalCfg     *approval.Config
+		wantStage       PRStage
+		wantRequestID   bool // true = ApprovalRequestID should be non-empty after the call
+		wantDecision    string
+	}{
+		{
+			// (a) First tick: no request ID yet — submits and returns immediately
+			// staying in StageAwaitApproval with a populated ApprovalRequestID.
+			name: "first_tick_submits_request_without_blocking",
+			setupState: func(ps *PRState) {
+				// ApprovalRequestID intentionally left empty
+			},
+			approvalCfg: &approval.Config{
+				Enabled:       false, // stage disabled → SubmitApprovalRequest auto-approves
+				AsyncDispatch: true,
+				DefaultAction: approval.DecisionRejected,
+				PreMerge: &approval.StageConfig{
+					Enabled:       false,
+					DefaultAction: approval.DecisionRejected,
+				},
+			},
+			wantStage:     StageAwaitApproval,
+			wantRequestID: true,
+		},
+		{
+			// (b) Approved decision advances to StageMerging.
+			name: "approved_decision_advances_to_merging",
+			setupState: func(ps *PRState) {
+				ps.ApprovalRequestID = "req-approved"
+				ps.ApprovalRequestedAt = time.Now().Add(-10 * time.Minute)
+				ps.ApprovalDecision = string(approval.DecisionApproved)
+			},
+			wantStage: StageMerging,
+		},
+		{
+			// (c) Rejected decision transitions to StageFailed.
+			name: "rejected_decision_fails_stage",
+			setupState: func(ps *PRState) {
+				ps.ApprovalRequestID = "req-rejected"
+				ps.ApprovalRequestedAt = time.Now().Add(-10 * time.Minute)
+				ps.ApprovalDecision = string(approval.DecisionRejected)
+			},
+			wantStage: StageFailed,
+		},
+		{
+			// (c) Timeout decision string also transitions to StageFailed.
+			name: "timeout_decision_fails_stage",
+			setupState: func(ps *PRState) {
+				ps.ApprovalRequestID = "req-timeout"
+				ps.ApprovalRequestedAt = time.Now().Add(-10 * time.Minute)
+				ps.ApprovalDecision = string(approval.DecisionTimeout)
+			},
+			wantStage: StageFailed,
+		},
+		{
+			// (d) No decision yet but wall-clock timeout exceeded with
+			// default_action = rejected → StageFailed.
+			name: "tick_time_timeout_triggers_expiry_rejected_default",
+			setupState: func(ps *PRState) {
+				ps.ApprovalRequestID = "req-pending"
+				ps.ApprovalRequestedAt = time.Now().Add(-2 * time.Hour)
+				ps.ApprovalDecision = "" // still pending
+			},
+			approvalCfg: &approval.Config{
+				Enabled:       true,
+				AsyncDispatch: true,
+				DefaultAction: approval.DecisionRejected,
+				PreMerge: &approval.StageConfig{
+					Enabled:       true,
+					Timeout:       30 * time.Minute,
+					DefaultAction: approval.DecisionRejected,
+				},
+				DefaultTimeout: 30 * time.Minute,
+			},
+			wantStage: StageFailed,
+		},
+		{
+			// (d) No decision yet, timeout exceeded, default_action = approved → StageMerging.
+			name: "tick_time_timeout_triggers_expiry_approved_default",
+			setupState: func(ps *PRState) {
+				ps.ApprovalRequestID = "req-pending"
+				ps.ApprovalRequestedAt = time.Now().Add(-2 * time.Hour)
+				ps.ApprovalDecision = ""
+			},
+			approvalCfg: &approval.Config{
+				Enabled:       true,
+				AsyncDispatch: true,
+				DefaultAction: approval.DecisionApproved,
+				PreMerge: &approval.StageConfig{
+					Enabled:       true,
+					Timeout:       30 * time.Minute,
+					DefaultAction: approval.DecisionApproved,
+				},
+				DefaultTimeout: 30 * time.Minute,
+			},
+			wantStage: StageMerging,
+		},
+		{
+			// Pending within timeout window — stay in StageAwaitApproval.
+			name: "pending_within_timeout_stays_in_await",
+			setupState: func(ps *PRState) {
+				ps.ApprovalRequestID = "req-within-window"
+				ps.ApprovalRequestedAt = time.Now().Add(-5 * time.Minute)
+				ps.ApprovalDecision = ""
+			},
+			wantStage: StageAwaitApproval,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newAsyncController(t, tc.approvalCfg)
+
+			prState := newPRStateAwaitingApproval(42)
+			if tc.setupState != nil {
+				tc.setupState(prState)
+			}
+
+			if err := c.handleAwaitApproval(ctx, prState); err != nil {
+				t.Fatalf("handleAwaitApproval returned unexpected error: %v", err)
+			}
+
+			if prState.Stage != tc.wantStage {
+				t.Errorf("Stage = %q, want %q", prState.Stage, tc.wantStage)
+			}
+			if tc.wantRequestID && prState.ApprovalRequestID == "" {
+				t.Error("ApprovalRequestID should be non-empty after first tick")
+			}
+		})
+	}
+}
+
+// TestHandleAwaitApproval_TwoPRIndependence verifies that a stalled PR-A
+// waiting for approval does not block PR-B from advancing (test e).
+func TestHandleAwaitApproval_TwoPRIndependence(t *testing.T) {
+	ctx := context.Background()
+	c := newAsyncController(t, nil)
+
+	// PR-A: request submitted but no decision yet (still pending).
+	prA := newPRStateAwaitingApproval(10)
+	prA.ApprovalRequestID = "req-a-pending"
+	prA.ApprovalRequestedAt = time.Now().Add(-5 * time.Minute)
+	prA.ApprovalDecision = ""
+
+	// PR-B: already has an approved decision.
+	prB := newPRStateAwaitingApproval(20)
+	prB.ApprovalRequestID = "req-b-approved"
+	prB.ApprovalRequestedAt = time.Now().Add(-5 * time.Minute)
+	prB.ApprovalDecision = string(approval.DecisionApproved)
+
+	// Process A then B — neither call should block.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := c.handleAwaitApproval(ctx, prA); err != nil {
+			t.Errorf("prA: unexpected error: %v", err)
+		}
+		if err := c.handleAwaitApproval(ctx, prB); err != nil {
+			t.Errorf("prB: unexpected error: %v", err)
+		}
+	}()
+
+	select {
+	case <-done:
+		// Both calls returned without blocking — pass.
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleAwaitApproval blocked for more than 2 seconds — not non-blocking")
+	}
+
+	// PR-A should still be in StageAwaitApproval (pending, within timeout).
+	if prA.Stage != StageAwaitApproval {
+		t.Errorf("prA.Stage = %q, want %q (stalled PR should not advance)", prA.Stage, StageAwaitApproval)
+	}
+
+	// PR-B should have advanced to StageMerging.
+	if prB.Stage != StageMerging {
+		t.Errorf("prB.Stage = %q, want %q (approved PR should advance)", prB.Stage, StageMerging)
+	}
+}
+
+// TestHandleAwaitApproval_LegacySyncPath verifies that the legacy blocking path
+// is used when AsyncDispatch = false.
+func TestHandleAwaitApproval_LegacySyncPath(t *testing.T) {
+	ctx := context.Background()
+
+	// Build a controller with AsyncDispatch disabled. The autoMerger.MergePR path
+	// will be invoked. Since no env requires approval (EnvStage default), it should
+	// skip approval and try to merge — which fails due to no HTTP server. That's
+	// acceptable; we just need to confirm the legacy path is entered (i.e. no panic,
+	// and the function is not a no-op that returns nil without calling MergePR).
+	approvalCfg := &approval.Config{
+		Enabled:       false,
+		AsyncDispatch: false, // force legacy path
+		DefaultAction: approval.DecisionRejected,
+		PreMerge: &approval.StageConfig{
+			Enabled:       false,
+			DefaultAction: approval.DecisionRejected,
+		},
+	}
+	c := newAsyncController(t, approvalCfg)
+
+	prState := newPRStateAwaitingApproval(42)
+
+	// The legacy path calls autoMerger.MergePR which will attempt GitHub API
+	// calls and fail — that is expected. The important thing is that prState is
+	// not left in StageAwaitApproval without attempting the merge.
+	_ = c.handleAwaitApproval(ctx, prState)
+
+	// prState.ApprovalRequestID must remain empty (legacy path doesn't set it).
+	if prState.ApprovalRequestID != "" {
+		t.Errorf("legacy path should not set ApprovalRequestID, got %q", prState.ApprovalRequestID)
+	}
+}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -955,9 +955,112 @@ func (c *Controller) hasChangesRequested(ctx context.Context, prState *PRState) 
 	return false
 }
 
-// handleAwaitApproval waits for human approval (prod only).
+// handleAwaitApproval is a non-blocking tick handler for StageAwaitApproval.
+//
+// Async path (approval.async_dispatch = true, the default):
+//   - First tick: submit via Manager.SubmitApprovalRequest, persist the returned
+//     ID and timestamp on prState, return immediately (stays in StageAwaitApproval).
+//   - Subsequent ticks: refresh prState.ApprovalDecision from storage via
+//     Manager.LookupDecision, then branch:
+//     "approved"         → advance to StageMerging
+//     "rejected"/"timeout" → transition to StageFailed
+//     "" / "pending"     → check wall-clock timeout, apply default_action on expiry.
+//
+// Legacy sync path (approval.async_dispatch = false):
+//   - Delegates to handleAwaitApprovalSync (old blocking MergePR call) so that
+//     existing deployments can opt out for one release without code changes.
+//
+// ErrApprovalNotConfigured is always fail-closed regardless of dispatch mode.
 func (c *Controller) handleAwaitApproval(ctx context.Context, prState *PRState) error {
-	// This will block until approval received or timeout
+	// Use legacy blocking path when async dispatch is disabled or no manager.
+	if c.approvalMgr == nil || !c.approvalMgr.IsAsyncDispatch() {
+		return c.handleAwaitApprovalSync(ctx, prState)
+	}
+
+	// Misconfig guard: env requires approval but pre_merge stage is not enabled.
+	// Fail closed — do NOT retry or auto-approve. Post a single explanatory comment.
+	if c.config.ResolvedEnv().RequireApproval && !c.approvalMgr.IsStageEnabled(approval.StagePreMerge) {
+		c.log.Error("approval misconfig detected: env requires approval but pre_merge stage is disabled",
+			"pr", prState.PRNumber,
+			"env", c.config.EnvironmentName(),
+		)
+		prState.Stage = StageFailed
+		prState.Error = fmt.Sprintf(
+			"approval-misconfig: env %q has require_approval=true but approval.pre_merge.enabled=false → deadlock until config fixed",
+			c.config.EnvironmentName(),
+		)
+		c.autoMerger.postMisconfigComment(ctx, prState)
+		c.metrics.RecordPRFailed()
+		return nil
+	}
+
+	// First tick: submit the approval request and persist the returned ID.
+	if prState.ApprovalRequestID == "" {
+		reqID, err := c.submitApprovalRequest(ctx, prState)
+		if err != nil {
+			return fmt.Errorf("submit approval request: %w", err)
+		}
+		prState.ApprovalRequestID = reqID
+		prState.ApprovalRequestedAt = time.Now()
+		c.log.Info("async approval request submitted",
+			"pr", prState.PRNumber,
+			"request_id", reqID,
+		)
+		return nil // Stay in StageAwaitApproval; decision polled on next tick.
+	}
+
+	// Subsequent ticks: refresh decision from storage when still pending.
+	if prState.ApprovalDecision == "" {
+		if d := c.approvalMgr.LookupDecision(ctx, prState.ApprovalRequestID); d != "" {
+			prState.ApprovalDecision = d
+			c.log.Info("async approval decision refreshed",
+				"pr", prState.PRNumber,
+				"request_id", prState.ApprovalRequestID,
+				"decision", d,
+			)
+		}
+	}
+
+	// Branch on the current decision.
+	switch prState.ApprovalDecision {
+	case string(approval.DecisionApproved):
+		c.log.Info("approval granted, advancing to merging stage", "pr", prState.PRNumber)
+		prState.Stage = StageMerging
+
+	case string(approval.DecisionRejected), "expired", string(approval.DecisionTimeout):
+		c.log.Info("approval denied or timed out",
+			"pr", prState.PRNumber,
+			"decision", prState.ApprovalDecision,
+		)
+		prState.Stage = StageFailed
+		prState.Error = fmt.Sprintf("merge approval %s", prState.ApprovalDecision)
+
+	default:
+		// Decision still pending — check controller-side timeout.
+		timeout := c.approvalTimeout()
+		if !prState.ApprovalRequestedAt.IsZero() && time.Since(prState.ApprovalRequestedAt) > timeout {
+			defaultAction := c.approvalMgr.PreMergeDefaultAction()
+			c.log.Warn("approval request timed out at controller level, applying default action",
+				"pr", prState.PRNumber,
+				"waited", time.Since(prState.ApprovalRequestedAt),
+				"default_action", defaultAction,
+			)
+			if defaultAction == approval.DecisionApproved {
+				prState.Stage = StageMerging
+			} else {
+				prState.Stage = StageFailed
+				prState.Error = "approval timed out"
+			}
+		}
+		// else: still within timeout window — stay in StageAwaitApproval.
+	}
+	return nil
+}
+
+// handleAwaitApprovalSync is the legacy blocking path for StageAwaitApproval.
+// Used when approval.async_dispatch = false. Kept for one-release backward
+// compatibility; remove after the async path is validated in production.
+func (c *Controller) handleAwaitApprovalSync(ctx context.Context, prState *PRState) error {
 	err := c.autoMerger.MergePR(ctx, prState)
 	if err != nil {
 		if err.Error() == "merge rejected: approval denied" {
@@ -965,8 +1068,6 @@ func (c *Controller) handleAwaitApproval(ctx context.Context, prState *PRState) 
 			prState.Stage = StageFailed
 			return nil
 		}
-		// Misconfig: env requires approval but approval.pre_merge is disabled.
-		// Fail closed — do NOT retry. Post a single explanatory comment and stop.
 		if errors.Is(err, ErrApprovalNotConfigured) {
 			c.log.Error("approval misconfig detected: env requires approval but pre_merge stage is disabled",
 				"pr", prState.PRNumber,
@@ -985,14 +1086,43 @@ func (c *Controller) handleAwaitApproval(ctx context.Context, prState *PRState) 
 	}
 	prState.Stage = StageMerged
 
-	// Notify merge success after approval
 	if c.notifier != nil {
 		if err := c.notifier.NotifyMerged(ctx, prState); err != nil {
 			c.log.Warn("failed to send merge notification", "error", err)
 		}
 	}
-
 	return nil
+}
+
+// submitApprovalRequest builds and dispatches an async approval request for a PR.
+func (c *Controller) submitApprovalRequest(ctx context.Context, prState *PRState) (string, error) {
+	reqID := fmt.Sprintf("merge-pr-%d-%d", prState.PRNumber, time.Now().UnixNano())
+	req := &approval.Request{
+		ID:               reqID,
+		TaskID:           fmt.Sprintf("merge-pr-%d", prState.PRNumber),
+		Stage:            approval.StagePreMerge,
+		Title:            fmt.Sprintf("PR #%d Merge Approval", prState.PRNumber),
+		Description:      fmt.Sprintf("Approve merge of PR #%d to production?", prState.PRNumber),
+		PreferredChannel: string(c.config.ApprovalSource),
+		CreatedAt:        time.Now(),
+		Metadata: map[string]interface{}{
+			"pr_url":    prState.PRURL,
+			"pr_number": prState.PRNumber,
+			"head_sha":  prState.HeadSHA,
+		},
+	}
+	return c.approvalMgr.SubmitApprovalRequest(ctx, req)
+}
+
+// approvalTimeout returns the wall-clock timeout for controller-side expiry of
+// a pending approval request. Uses the autopilot-level ApprovalTimeout as an
+// outer bound; the approval manager's own goroutine applies the stage-level
+// timeout independently.
+func (c *Controller) approvalTimeout() time.Duration {
+	if c.config.ApprovalTimeout > 0 {
+		return c.config.ApprovalTimeout
+	}
+	return 1 * time.Hour
 }
 
 // handleMerging merges the PR.

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -62,6 +62,11 @@ func (s *StateStore) migrate() error {
 		// so re-entry into StageMerging (e.g. after crash recovery) does not
 		// emit duplicate "PR merged" comments on the linked issue.
 		`ALTER TABLE autopilot_pr_state ADD COLUMN merge_notification_posted INTEGER NOT NULL DEFAULT 0`,
+		// GH-2689: Async approval fields — persist request ID, timestamp, and
+		// decision so the non-blocking tick handler survives process restarts.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN approval_request_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE autopilot_pr_state ADD COLUMN approval_requested_at DATETIME`,
+		`ALTER TABLE autopilot_pr_state ADD COLUMN approval_decision TEXT NOT NULL DEFAULT ''`,
 		`CREATE TABLE IF NOT EXISTS autopilot_processed (
 			issue_number INTEGER PRIMARY KEY,
 			processed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -143,8 +148,9 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at, updated_at,
-			release_version, release_bump_type, merge_notification_posted
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?)
+			release_version, release_bump_type, merge_notification_posted,
+			approval_request_id, approval_requested_at, approval_decision
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -159,13 +165,17 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			updated_at = CURRENT_TIMESTAMP,
 			release_version = excluded.release_version,
 			release_bump_type = excluded.release_bump_type,
-			merge_notification_posted = excluded.merge_notification_posted
+			merge_notification_posted = excluded.merge_notification_posted,
+			approval_request_id = excluded.approval_request_id,
+			approval_requested_at = excluded.approval_requested_at,
+			approval_decision = excluded.approval_decision
 	`,
 		pr.PRNumber, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
 		nullTime(pr.LastChecked), nullTime(pr.CIWaitStartedAt),
 		pr.MergeAttempts, pr.Error, nullTime(pr.CreatedAt),
 		pr.ReleaseVersion, string(pr.ReleaseBumpType), pr.MergeNotificationPosted,
+		pr.ApprovalRequestID, nullTime(pr.ApprovalRequestedAt), pr.ApprovalDecision,
 	)
 	return err
 }
@@ -177,7 +187,9 @@ func (s *StateStore) GetPRState(prNumber int) (*PRState, error) {
 		SELECT pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at,
-			release_version, release_bump_type, merge_notification_posted
+			release_version, release_bump_type, merge_notification_posted,
+			COALESCE(approval_request_id, ''), approval_requested_at,
+			COALESCE(approval_decision, '')
 		FROM autopilot_pr_state WHERE pr_number = ?
 	`, prNumber)
 
@@ -197,7 +209,9 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 		SELECT pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at,
-			release_version, release_bump_type, merge_notification_posted
+			release_version, release_bump_type, merge_notification_posted,
+			COALESCE(approval_request_id, ''), approval_requested_at,
+			COALESCE(approval_decision, '')
 		FROM autopilot_pr_state
 	`)
 	if err != nil {
@@ -208,7 +222,7 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 	var states []*PRState
 	for rows.Next() {
 		var pr PRState
-		var lastChecked, ciWaitStartedAt, createdAt sql.NullTime
+		var lastChecked, ciWaitStartedAt, createdAt, approvalRequestedAt sql.NullTime
 		var stage, ciStatus, relBumpType string
 
 		if err := rows.Scan(
@@ -216,6 +230,7 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 			&stage, &ciStatus, &lastChecked, &ciWaitStartedAt,
 			&pr.MergeAttempts, &pr.Error, &createdAt,
 			&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
+			&pr.ApprovalRequestID, &approvalRequestedAt, &pr.ApprovalDecision,
 		); err != nil {
 			return nil, err
 		}
@@ -231,6 +246,9 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 		}
 		if createdAt.Valid {
 			pr.CreatedAt = createdAt.Time
+		}
+		if approvalRequestedAt.Valid {
+			pr.ApprovalRequestedAt = approvalRequestedAt.Time
 		}
 		states = append(states, &pr)
 	}
@@ -800,7 +818,7 @@ func (s *StateStore) PurgeTerminalPRStates(olderThan time.Duration) (int64, erro
 // scanPRState scans a single row into a PRState.
 func scanPRState(row *sql.Row) (*PRState, error) {
 	var pr PRState
-	var lastChecked, ciWaitStartedAt, createdAt sql.NullTime
+	var lastChecked, ciWaitStartedAt, createdAt, approvalRequestedAt sql.NullTime
 	var stage, ciStatus, relBumpType string
 
 	err := row.Scan(
@@ -808,6 +826,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&stage, &ciStatus, &lastChecked, &ciWaitStartedAt,
 		&pr.MergeAttempts, &pr.Error, &createdAt,
 		&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
+		&pr.ApprovalRequestID, &approvalRequestedAt, &pr.ApprovalDecision,
 	)
 	if err != nil {
 		return nil, err
@@ -824,6 +843,9 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 	}
 	if createdAt.Valid {
 		pr.CreatedAt = createdAt.Time
+	}
+	if approvalRequestedAt.Valid {
+		pr.ApprovalRequestedAt = approvalRequestedAt.Time
 	}
 	return &pr, nil
 }

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -470,6 +470,19 @@ type PRState struct {
 	// posted to the linked issue. Prevents duplicate comments on state-machine
 	// re-entry for an already-merged PR (GH-2345).
 	MergeNotificationPosted bool
+
+	// ApprovalRequestID is the ID returned by Manager.SubmitApprovalRequest on
+	// the first tick of StageAwaitApproval. Non-empty signals that a request has
+	// already been submitted so subsequent ticks poll for the decision instead of
+	// re-submitting.
+	ApprovalRequestID string
+	// ApprovalRequestedAt is when the approval request was first submitted.
+	// Used for controller-side timeout calculation in the async path.
+	ApprovalRequestedAt time.Time
+	// ApprovalDecision is the outcome recorded by Manager.RecordDecision / the
+	// background goroutine: "approved", "rejected", or "timeout".
+	// Empty means the decision is still pending.
+	ApprovalDecision string
 }
 
 // RepoOwnerAndName extracts the repository owner and name from the PR URL.

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -576,6 +576,30 @@ func (s *Store) SetApprovalDecision(ctx context.Context, requestID string, decis
 	})
 }
 
+// GetApprovalDecision returns the stored approval decision for the given requestID.
+// Returns ("", nil) when no decision has been recorded yet (row exists but
+// approval_decision is empty). Returns ("", sql.ErrNoRows) if no execution row
+// matches the requestID.
+func (s *Store) GetApprovalDecision(ctx context.Context, requestID string) (string, error) {
+	if requestID == "" {
+		return "", nil
+	}
+	var decision string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COALESCE(approval_decision, '')
+		FROM executions
+		WHERE approval_request_id = ?
+		LIMIT 1
+	`, requestID).Scan(&decision)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("GetApprovalDecision: %w", err)
+	}
+	return decision, nil
+}
+
 // GetRecentExecutions returns the most recent executions ordered by creation time.
 // The limit parameter specifies the maximum number of executions to return.
 func (s *Store) GetRecentExecutions(limit int) ([]*Execution, error) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2689.

Closes #2689

## Changes

Convert `internal/autopilot/controller.go:958-996` `handleAwaitApproval` from the synchronous `autoMerger.MergePR` → `Manager.RequestApproval` blocking path to a non-blocking two-path tick handler using the v2.125.0 async API. First tick submits via `Manager.SubmitApprovalRequest(ctx, req)`, persists the returned `ApprovalRequestID` and `ApprovalRequestedAt` on `PRState`, and returns immediately staying in `StageAwaitApproval`. Subsequent ticks branch on `prState.ApprovalDecision`: `approved` advances to the existing post-approval stage (e.g. `StageMerging`), `rejected`/`expired` transitions to `StageFailed`, empty/`pending` checks `time.Since(ApprovalRequestedAt) > c.approvalTimeout(prState)` and applies the stage's `default_action` on timeout. Preserve the existing `ErrApprovalNotConfigured` fail-closed branch. Verify `Manager.WithStateWriter(prStateWriter)` is wired at both construction sites in `cmd/pilot/main.go` (~`:423` and `~:1304`); add it if missing. Keep the legacy `RequestApproval` path reachable when `Config.AsyncDispatch == false` for one-release safety. Add a table-driven test in `internal/autopilot/` covering: (a) first-tick submission populates request ID without blocking, (b) approved decision advances stage, (c) rejected/expired fails stage, (d) tick-time timeout triggers expiry + default_action, (e) two-PR scenario where stalled PR-A does not block PR-B from progressing in `processAllPRs`. Verify `go build ./...` and `go vet ./...` are clean.