### PR TITLE
GH-2690: fix(memory/approval): InsertPendingApproval stores zero-value timestamps, breaking rehydrate

### DIFF
--- a/internal/memory/approval_store.go
+++ b/internal/memory/approval_store.go
@@ -25,7 +25,14 @@ type PendingApproval struct {
 
 // InsertPendingApproval persists a new pending approval record.
 // Replaces any existing row with the same ID.
+// CreatedAt defaults to now when zero; ExpiresAt must be set by the caller (schema NOT NULL).
 func (s *Store) InsertPendingApproval(a *PendingApproval) error {
+	if a.CreatedAt.IsZero() {
+		a.CreatedAt = time.Now().UTC()
+	}
+	if a.ExpiresAt.IsZero() {
+		return fmt.Errorf("InsertPendingApproval: ExpiresAt must be set (id=%s)", a.ID)
+	}
 	metaJSON, err := json.Marshal(a.Metadata)
 	if err != nil {
 		return fmt.Errorf("InsertPendingApproval: marshal metadata: %w", err)
@@ -47,7 +54,6 @@ func (s *Store) InsertPendingApproval(a *PendingApproval) error {
 				metadata          = excluded.metadata,
 				approvers         = excluded.approvers,
 				preferred_channel = excluded.preferred_channel,
-				created_at        = excluded.created_at,
 				expires_at        = excluded.expires_at
 		`,
 			a.ID, a.TaskID, a.Stage, a.Title, a.Description,

--- a/internal/memory/approval_store_test.go
+++ b/internal/memory/approval_store_test.go
@@ -214,3 +214,91 @@ func TestLoadPendingApprovals_Empty(t *testing.T) {
 		t.Errorf("expected 0 records, got %d", len(all))
 	}
 }
+
+func TestInsertPendingApproval_DefaultsCreatedAt(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	before := time.Now().UTC().Add(-time.Second)
+	a := &PendingApproval{
+		ID:        "zero-created",
+		TaskID:    "GH-600",
+		Stage:     "pre_merge",
+		Title:     "t",
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+		// CreatedAt deliberately zero
+	}
+	if err := s.InsertPendingApproval(a); err != nil {
+		t.Fatalf("InsertPendingApproval: %v", err)
+	}
+
+	all, err := s.LoadPendingApprovals()
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(all))
+	}
+	if all[0].CreatedAt.IsZero() {
+		t.Error("CreatedAt should not be zero after insert")
+	}
+	if all[0].CreatedAt.Before(before) {
+		t.Errorf("CreatedAt %v is before test start %v", all[0].CreatedAt, before)
+	}
+}
+
+func TestInsertPendingApproval_ZeroExpiresAtReturnsError(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	a := &PendingApproval{
+		ID:     "zero-expires",
+		TaskID: "GH-601",
+		Stage:  "pre_merge",
+		Title:  "t",
+		// ExpiresAt deliberately zero
+	}
+	err := s.InsertPendingApproval(a)
+	if err == nil {
+		t.Fatal("expected error for zero ExpiresAt, got nil")
+	}
+}
+
+func TestInsertPendingApproval_UpsertPreservesCreatedAt(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+
+	original := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	a := &PendingApproval{
+		ID:        "freeze-created",
+		TaskID:    "GH-602",
+		Stage:     "pre_merge",
+		Title:     "original",
+		CreatedAt: original,
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+	}
+	if err := s.InsertPendingApproval(a); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+
+	// Re-insert with a different CreatedAt — UPSERT must not overwrite the stored value.
+	a.Title = "updated"
+	a.CreatedAt = time.Now().UTC()
+	if err := s.InsertPendingApproval(a); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	all, err := s.LoadPendingApprovals()
+	if err != nil {
+		t.Fatalf("LoadPendingApprovals: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 record after upsert, got %d", len(all))
+	}
+	if !all[0].CreatedAt.Equal(original) {
+		t.Errorf("CreatedAt changed on upsert: got %v, want %v", all[0].CreatedAt, original)
+	}
+	if all[0].Title != "updated" {
+		t.Errorf("Title not updated: got %q", all[0].Title)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2690.

Closes #2690

## Changes

GitHub Issue #2690: fix(memory/approval): InsertPendingApproval stores zero-value timestamps, breaking rehydrate

## Context

`internal/memory/approval_store.go:28-58` — `InsertPendingApproval` binds `a.CreatedAt, a.ExpiresAt` directly to the INSERT statement. When a caller passes a `*PendingApproval` with zero-value time fields (e.g., a struct constructed without explicit timestamps), the bind serialises Go's zero `time.Time` and stores blanks/garbage. The schema's `created_at DATETIME DEFAULT CURRENT_TIMESTAMP` is **bypassed** because the INSERT explicitly provides a value.

The UPSERT clause compounds it:

```sql
ON CONFLICT(id) DO UPDATE SET
    created_at = excluded.created_at,
    expires_at = excluded.expires_at
```

A re-insert (or rehydrate-then-persist round trip) overwrites previously-good timestamps with the new zero values.

## Observed cost

Verified live on 2026-05-05: after the daemon hot-upgraded to v2.125.0 (PID 6257, started 18:40:31), an active `merge-pr-2688` row in `approval_pending` had:

```
| id | task_id        | stage     | sent | expires |
|    | merge-pr-2688  | pre_merge |      |         |
```

(blank `created_at` and `expires_at`). The orphaned row could not be pruned by `PrunePendingApprovals(cutoff)` because `expires_at < cutoff` is undefined for the bad value, leaving stale rows behind indefinitely. This compounded the daemon-restart approval-tap loss for PR #2688 (the user clicked Merge → tap was dispatched → no goroutine waiting in the new daemon → row not deleted; manual `gh pr merge` was the workaround).

The empty `id` field in the listing above also suggests the row was inserted with zero-value PK, which would explain why subsequent inserts hit the UPSERT path silently.

## Reproduction

```go
a := &PendingApproval{
    ID:     "test-1",
    TaskID: "merge-pr-9999",
    Stage:  "pre_merge",
    Title:  "test",
    // CreatedAt, ExpiresAt deliberately not set
}
_ = store.InsertPendingApproval(a)
```

Then:
```bash
sqlite3 pilot.db "SELECT id, task_id, created_at, expires_at FROM approval_pending"
# expects sane values; gets blanks
```

## Implementation

Two-part fix:

**1. Defensive default in Go** (`internal/memory/approval_store.go:28+`):

```go
func (s *Store) InsertPendingApproval(a *PendingApproval) error {
    if a.CreatedAt.IsZero() {
        a.CreatedAt = time.Now().UTC()
    }
    if a.ExpiresAt.IsZero() {
        // Caller MUST set ExpiresAt; this is a fail-loud guard.
        return fmt.Errorf("InsertPendingApproval: ExpiresAt must be set (id=%s)", a.ID)
    }
    // ... existing marshal + Exec
}
```

`ExpiresAt` is `NOT NULL` per schema, so a zero value is a logic bug — fail loud rather than store junk.

**2. Don't overwrite immutable timestamps on UPSERT** (`approval_store.go:42-51`):

`created_at` should never change once a row exists. Drop it from the UPDATE clause:

```sql
ON CONFLICT(id) DO UPDATE SET
    task_id           = excluded.task_id,
    stage             = excluded.stage,
    title             = excluded.title,
    description       = excluded.description,
    metadata          = excluded.metadata,
    approvers         = excluded.approvers,
    preferred_channel = excluded.preferred_channel,
    expires_at        = excluded.expires_at   -- still mutable (timeout extension)
    -- created_at intentionally omitted
```

## Acceptance

- [ ] `InsertPendingApproval` defaults `CreatedAt` to `time.Now().UTC()` when zero
- [ ] `InsertPendingApproval` returns error when `ExpiresAt` is zero (fail-loud)
- [ ] UPSERT clause does NOT update `created_at` on conflict
- [ ] Unit test: insert with zero `CreatedAt` → row has non-zero timestamp
- [ ] Unit test: insert with zero `ExpiresAt` → returns error
- [ ] Unit test: UPSERT preserves original `created_at` across re-inserts
- [ ] Existing `LoadPendingApprovals`/`PrunePendingApprovals` tests still pass (the prune index `idx_approval_pending_expires` is unaffected)
- [ ] `go build ./...` + `go vet ./...` clean
- [ ] Conventional PR title: `fix(memory/approval): default CreatedAt and freeze it on UPSERT (GH-<this-issue>)`

## Out of scope

- Audit other persistence layers (`executions`, etc.) for the same pattern — file as separate issue if found.
- Rehydrate path needs to handle existing zero-value rows gracefully (skip-or-log) — likely handled by the fail-loud `ExpiresAt` guard in `Rehydrate`, but verify and add a test.

## References

- `internal/memory/approval_store.go:28-58` — buggy INSERT
- `internal/memory/store.go:304` — schema with DEFAULT CURRENT_TIMESTAMP that's being bypassed
- v2.122.0 (commit 24f54ea0) — original storage layer
- v2.123.0 (commit 69d98489) — rehydrate wiring
- Live observation: PR #2688 approval tap lost across daemon restart, blank-timestamp row left orphaned

## Planned Steps (execute all in sequence)

1. **fix(memory/approval): default CreatedAt and freeze it on UPSERT** — In `internal/memory/approval_store.go`, update `InsertPendingApproval` to default `a.CreatedAt` to `time.Now().UTC()` when zero, return a fail-loud error when `a.ExpiresAt` is zero (since schema requires NOT NULL), and remove `created_at` from the `ON CONFLICT(id) DO UPDATE SET` clause so it's never overwritten on re-insert (keeping `expires_at` mutable for timeout extensions). Add unit tests in the same package covering: (a) zero `CreatedAt` → row has non-zero timestamp, (b) zero `ExpiresAt` → returns error, (c) UPSERT preserves original `created_at` across re-inserts. Verify `LoadPendingApprovals` / `PrunePendingApprovals` tests still pass and that `Rehydrate` handles the new error path gracefully (add a test if needed). Ensure `go build ./...` and `go vet ./...` are clean.
