### PR TITLE
GH-2700: chore(approval): document decision retrieval in SubmitApprovalRequest doc comment

### DIFF
--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -345,6 +345,10 @@ func (m *Manager) WithStateWriter(w PRStateWriter) *Manager {
 // (called externally, e.g. from a Telegram callback) or by the background
 // goroutine when the handler's response channel fires.
 //
+// Decision retrieval: RecordDecision persists the outcome to the executions
+// table via PRStateWriter. Callers should poll PRState.ApprovalDecision on
+// subsequent ticks rather than awaiting a channel (see controller.handleAwaitApproval).
+//
 // This is the async counterpart to RequestApproval. Both coexist; the
 // config.async_dispatch flag indicates which path callers should prefer.
 func (m *Manager) SubmitApprovalRequest(ctx context.Context, req *Request) (string, error) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2700.

Closes #2700

## Changes

GitHub Issue #2700: chore(approval): document decision retrieval in SubmitApprovalRequest doc comment

## Context

`Manager.SubmitApprovalRequest` in `internal/approval/manager.go:342-350` documents that the call is non-blocking and that decisions are recorded externally via `RecordDecision`. It does **not** document how callers retrieve the decision after submission.

Today, callers must read `PRStateWriter` / `executions.approval_decision` on a subsequent tick (see `controller.handleAwaitApproval`). This convention is not discoverable from the doc comment.

## Acceptance Criteria

- Extend the doc comment on `SubmitApprovalRequest` (manager.go:342) with 1-2 lines explaining that the decision is persisted by `RecordDecision` to the `executions` table via `PRStateWriter`, and that callers should poll `PRState.ApprovalDecision` rather than awaiting a channel.
- No behavior change. No new types or functions.
- `make test` passes.
- `make lint` passes.

## Out of Scope

- Refactoring `RecordDecision` or `PRStateWriter`.
- Removing the legacy blocking `RequestApproval` path (separate cleanup task).

## Notes

This is a smoke-test task to verify v2.128.0's async approval pipeline end-to-end (Telegram callback → RecordDecision → PRStateWriter → controller advance → merge → release). Doc-only Go change exercises the full pipeline without behavior risk.