### PR TITLE
GH-2707: fix(dashboard,memory): TUI live cost uses actual model + filter zero-token rows from aggregations

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -2297,8 +2297,8 @@ func runDashboardMode(p *pilot.Pilot, cfg *config.Config, gwProgram *tea.Program
 			program.Send(dashboard.AddLog(logMsg)())
 		})
 
-		gwRunner.AddTokenCallback("dashboard", func(taskID string, inputTokens, outputTokens int64) {
-			program.Send(dashboard.UpdateTokens(int(inputTokens), int(outputTokens))())
+		gwRunner.AddTokenCallback("dashboard", func(taskID string, inputTokens, outputTokens int64, modelName string) {
+			program.Send(dashboard.UpdateTokens(int(inputTokens), int(outputTokens), modelName)())
 		})
 	}
 
@@ -2323,8 +2323,8 @@ func runDashboardMode(p *pilot.Pilot, cfg *config.Config, gwProgram *tea.Program
 	})
 
 	// Register token usage callback for dashboard updates (GH-156 fix)
-	p.OnToken("dashboard", func(taskID string, inputTokens, outputTokens int64) {
-		program.Send(dashboard.UpdateTokens(int(inputTokens), int(outputTokens))())
+	p.OnToken("dashboard", func(taskID string, inputTokens, outputTokens int64, modelName string) {
+		program.Send(dashboard.UpdateTokens(int(inputTokens), int(outputTokens), modelName)())
 	})
 
 	// Periodic refresh to catch any missed updates

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1688,8 +1688,8 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		})
 
 		// Wire token usage updates to dashboard (GH-156 fix)
-		runner.AddTokenCallback("dashboard", func(taskID string, inputTokens, outputTokens int64) {
-			program.Send(dashboard.UpdateTokens(int(inputTokens), int(outputTokens))())
+		runner.AddTokenCallback("dashboard", func(taskID string, inputTokens, outputTokens int64, modelName string) {
+			program.Send(dashboard.UpdateTokens(int(inputTokens), int(outputTokens), modelName)())
 		})
 	}
 

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -340,6 +340,7 @@ type TokenUsage struct {
 	InputTokens  int
 	OutputTokens int
 	TotalTokens  int
+	Model        string // model that produced these tokens; empty until first stream event
 }
 
 // CompletedTask represents a finished task for history
@@ -1055,10 +1056,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.metricsCard.InputTokens += inputDelta
 		m.metricsCard.OutputTokens += outputDelta
 		m.metricsCard.TotalTokens += inputDelta + outputDelta
+		costModel := msg.Model
+		if costModel == "" {
+			costModel = memory.DefaultModel
+		}
 		m.metricsCard.TotalCostUSD += memory.EstimateCost(
 			int64(inputDelta),
 			int64(outputDelta),
-			memory.DefaultModel,
+			costModel,
 		)
 		if m.metricsCard.TotalTasks > 0 {
 			m.metricsCard.CostPerTask = m.metricsCard.TotalCostUSD / float64(m.metricsCard.TotalTasks)
@@ -2654,13 +2659,16 @@ func AddLog(log string) tea.Cmd {
 	}
 }
 
-// UpdateTokens sends updated token usage to the TUI
-func UpdateTokens(input, output int) tea.Cmd {
+// UpdateTokens sends updated token usage to the TUI.
+// model is the model name that produced the tokens; may be empty before the first
+// stream event, in which case the handler falls back to memory.DefaultModel.
+func UpdateTokens(input, output int, model string) tea.Cmd {
 	return func() tea.Msg {
 		return updateTokensMsg(TokenUsage{
 			InputTokens:  input,
 			OutputTokens: output,
 			TotalTokens:  input + output,
+			Model:        model,
 		})
 	}
 }

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -1631,3 +1631,40 @@ func TestAutopilotPanelTick_RotatesSpinner(t *testing.T) {
 		}
 	}
 }
+
+func TestUpdateTokens_ModelAwareCost(t *testing.T) {
+	m := NewModel("test")
+
+	// Sonnet pricing: $3/M input, $15/M output
+	// 1M input + 1M output = $3 + $15 = $18
+	updated, _ := m.Update(updateTokensMsg{InputTokens: 1_000_000, OutputTokens: 1_000_000, TotalTokens: 2_000_000, Model: "claude-sonnet-4-6"})
+	sonnetModel := updated.(Model)
+	wantSonnet := memory.EstimateCost(1_000_000, 1_000_000, "claude-sonnet-4-6")
+	if sonnetModel.metricsCard.TotalCostUSD != wantSonnet {
+		t.Errorf("Sonnet cost = %.4f, want %.4f", sonnetModel.metricsCard.TotalCostUSD, wantSonnet)
+	}
+
+	// Opus pricing: $5/M input, $25/M output = $30 for same token count
+	m2 := NewModel("test")
+	updated2, _ := m2.Update(updateTokensMsg{InputTokens: 1_000_000, OutputTokens: 1_000_000, TotalTokens: 2_000_000, Model: "claude-opus-4-6"})
+	opusModel := updated2.(Model)
+	wantOpus := memory.EstimateCost(1_000_000, 1_000_000, "claude-opus-4-6")
+	if opusModel.metricsCard.TotalCostUSD != wantOpus {
+		t.Errorf("Opus cost = %.4f, want %.4f", opusModel.metricsCard.TotalCostUSD, wantOpus)
+	}
+
+	// Sonnet cost must be less than Opus cost for the same token count
+	if wantSonnet >= wantOpus {
+		t.Errorf("expected Sonnet ($%.4f) < Opus ($%.4f)", wantSonnet, wantOpus)
+	}
+}
+
+func TestUpdateTokens_EmptyModelFallsBackToDefault(t *testing.T) {
+	m := NewModel("test")
+	updated, _ := m.Update(updateTokensMsg{InputTokens: 100_000, OutputTokens: 50_000, TotalTokens: 150_000, Model: ""})
+	model := updated.(Model)
+	want := memory.EstimateCost(100_000, 50_000, memory.DefaultModel)
+	if model.metricsCard.TotalCostUSD != want {
+		t.Errorf("cost with empty model = %.6f, want %.6f (DefaultModel=%s)", model.metricsCard.TotalCostUSD, want, memory.DefaultModel)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -280,8 +280,9 @@ type ExecutionResult struct {
 type ProgressCallback func(taskID string, phase string, progress int, message string)
 
 // TokenCallback is a function called during execution with token usage updates.
-// It receives the task ID, input tokens, and output tokens.
-type TokenCallback func(taskID string, inputTokens, outputTokens int64)
+// It receives the task ID, input tokens, output tokens, and the model name (may be empty
+// before the first stream event arrives — callers should fall back to a default).
+type TokenCallback func(taskID string, inputTokens, outputTokens int64, modelName string)
 
 // TokenLimitCallback is called during execution with per-event token deltas.
 // It returns true if execution should continue, false if the per-task token/duration
@@ -1024,11 +1025,11 @@ func (r *Runner) RemoveTokenCallback(name string) {
 }
 
 // reportTokens sends token usage updates to all registered callbacks.
-func (r *Runner) reportTokens(taskID string, inputTokens, outputTokens int64) {
+func (r *Runner) reportTokens(taskID string, inputTokens, outputTokens int64, modelName string) {
 	r.tokenMu.RLock()
 	defer r.tokenMu.RUnlock()
 	for _, cb := range r.tokenCallbacks {
-		cb(taskID, inputTokens, outputTokens)
+		cb(taskID, inputTokens, outputTokens, modelName)
 	}
 }
 
@@ -3491,6 +3492,10 @@ func (r *Runner) parseStreamEvent(taskID, line string, state *progressState) (st
 		return event.Result, ""
 	}
 
+	// Capture model name before reporting tokens so the callback receives the correct model.
+	if event.Model != "" && state.modelName == "" {
+		state.modelName = event.Model
+	}
 	// Track usage from any event with usage info
 	if event.Usage != nil {
 		state.tokensInput += event.Usage.InputTokens
@@ -3498,10 +3503,7 @@ func (r *Runner) parseStreamEvent(taskID, line string, state *progressState) (st
 		state.cacheCreationInputTokens += event.Usage.CacheCreationInputTokens
 		state.cacheReadInputTokens += event.Usage.CacheReadInputTokens
 		// Report token usage to callbacks (e.g., dashboard)
-		r.reportTokens(taskID, state.tokensInput, state.tokensOutput)
-	}
-	if event.Model != "" && state.modelName == "" {
-		state.modelName = event.Model
+		r.reportTokens(taskID, state.tokensInput, state.tokensOutput, state.modelName)
 	}
 
 	return "", ""
@@ -3521,7 +3523,7 @@ func (r *Runner) processBackendEvent(taskID string, event BackendEvent, state *p
 
 	// Report token usage to callbacks (e.g., dashboard)
 	if event.TokensInput > 0 || event.TokensOutput > 0 {
-		r.reportTokens(taskID, state.tokensInput, state.tokensOutput)
+		r.reportTokens(taskID, state.tokensInput, state.tokensOutput, state.modelName)
 	}
 
 	// GH-539: Check per-task token/duration limit on each event

--- a/internal/memory/metrics.go
+++ b/internal/memory/metrics.go
@@ -296,7 +296,7 @@ func (s *Store) GetMetricsSummary(query MetricsQuery) (*MetricsSummary, error) {
 // GetDailyMetrics returns metrics aggregated by day
 func (s *Store) GetDailyMetrics(query MetricsQuery) ([]*DailyMetrics, error) {
 	var args []interface{}
-	whereClause := "WHERE created_at >= ? AND created_at < ?"
+	whereClause := "WHERE created_at >= ? AND created_at < ? AND tokens_total > 0"
 	args = append(args, query.Start, query.End)
 
 	if len(query.Projects) > 0 {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1586,6 +1586,8 @@ type LifetimeTokens struct {
 
 // GetLifetimeTokens returns cumulative token usage and cost across all executions.
 // Unlike session-scoped data, this survives restarts by querying the executions table directly.
+// Rows with zero tokens (dispatcher queue rows, early-failure rows) are excluded so they
+// don't dilute per-task averages.
 func (s *Store) GetLifetimeTokens() (*LifetimeTokens, error) {
 	row := s.db.QueryRow(`
 		SELECT
@@ -1594,6 +1596,7 @@ func (s *Store) GetLifetimeTokens() (*LifetimeTokens, error) {
 			COALESCE(SUM(tokens_total), 0),
 			COALESCE(SUM(estimated_cost_usd), 0)
 		FROM executions
+		WHERE tokens_total > 0
 	`)
 
 	var lt LifetimeTokens

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1877,3 +1877,74 @@ func TestInvalidateCompletion(t *testing.T) {
 		t.Error("InvalidateCompletion should not affect different project path")
 	}
 }
+
+func TestGetLifetimeTokens_ExcludesZeroTokenRows(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Row with real tokens
+	if err := store.SaveExecution(&Execution{ID: "exec-real", TaskID: "T-1", ProjectPath: "/p", Status: "completed"}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	if err := store.SaveExecutionMetrics(&ExecutionMetrics{ExecutionID: "exec-real", TokensInput: 5000, TokensOutput: 2000, TokensTotal: 7000, EstimatedCostUSD: 0.50}); err != nil {
+		t.Fatalf("SaveExecutionMetrics: %v", err)
+	}
+
+	// Dispatcher queue / early-failure row with zero tokens
+	if err := store.SaveExecution(&Execution{ID: "exec-zero", TaskID: "T-2", ProjectPath: "/p", Status: "failed"}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	lt, err := store.GetLifetimeTokens()
+	if err != nil {
+		t.Fatalf("GetLifetimeTokens: %v", err)
+	}
+	if lt.TotalTokens != 7000 {
+		t.Errorf("TotalTokens = %d, want 7000 (zero-token row must be excluded)", lt.TotalTokens)
+	}
+	if lt.TotalCostUSD != 0.50 {
+		t.Errorf("TotalCostUSD = %.4f, want 0.5000", lt.TotalCostUSD)
+	}
+}
+
+func TestGetDailyMetrics_ExcludesZeroTokenRows(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().UTC()
+	yesterday := now.Add(-24 * time.Hour)
+
+	// Real execution
+	if err := store.SaveExecution(&Execution{ID: "dm-real", TaskID: "T-1", ProjectPath: "/p", Status: "completed", CreatedAt: yesterday}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	if err := store.SaveExecutionMetrics(&ExecutionMetrics{ExecutionID: "dm-real", TokensInput: 3000, TokensOutput: 1000, TokensTotal: 4000, EstimatedCostUSD: 0.30}); err != nil {
+		t.Fatalf("SaveExecutionMetrics: %v", err)
+	}
+
+	// Zero-token row (same day) — should not appear in daily metrics
+	if err := store.SaveExecution(&Execution{ID: "dm-zero", TaskID: "T-2", ProjectPath: "/p", Status: "failed", CreatedAt: yesterday}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	q := MetricsQuery{Start: yesterday.Add(-time.Hour), End: now.Add(time.Hour)}
+	days, err := store.GetDailyMetrics(q)
+	if err != nil {
+		t.Fatalf("GetDailyMetrics: %v", err)
+	}
+	if len(days) == 0 {
+		t.Fatal("GetDailyMetrics: want at least 1 day row")
+	}
+	// Only the real execution should be counted
+	if days[0].ExecutionCount != 1 {
+		t.Errorf("ExecutionCount = %d, want 1 (zero-token row must be excluded)", days[0].ExecutionCount)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -299,7 +299,7 @@ func (o *Orchestrator) OnCompletion(callback func(taskID, prURL string, success 
 }
 
 // OnToken registers a callback for token usage updates on the underlying runner.
-func (o *Orchestrator) OnToken(name string, callback func(taskID string, inputTokens, outputTokens int64)) {
+func (o *Orchestrator) OnToken(name string, callback func(taskID string, inputTokens, outputTokens int64, modelName string)) {
 	o.runner.AddTokenCallback(name, callback)
 }
 

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -1014,7 +1014,7 @@ func (p *Pilot) OnProgress(callback func(taskID, phase string, progress int, mes
 }
 
 // OnToken registers a callback for token usage updates
-func (p *Pilot) OnToken(name string, callback func(taskID string, inputTokens, outputTokens int64)) {
+func (p *Pilot) OnToken(name string, callback func(taskID string, inputTokens, outputTokens int64, modelName string)) {
 	p.orchestrator.OnToken(name, callback)
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2707.

Closes #2707

## Changes

GitHub Issue #2707: fix(dashboard,memory): TUI live cost uses actual model + filter zero-token rows from aggregations

## Context

User switched execution from Opus to Sonnet but isn't seeing the expected cost drop in the dashboard.

**Investigation confirms cost IS dropping in the DB** (Opus 4.6 avg \$2.10/exec → Sonnet \$0.65/exec, 3.2× reduction), but two surface bugs hide the win:

1. **TUI live cost card hardcodes Opus pricing** at `internal/dashboard/tui.go:1061` regardless of the actual model running. During Sonnet sessions, this overstates cost ~67% in the live dashboard view.
2. **266 of 550 recent rows in `executions` have empty `model_name` and \$0 cost** — dispatcher queue/decomposed rows + early-failure rows. They don't inflate dollar totals (cost is \$0) but dilute per-task averages.

## Scope

**In scope (this PR):**
1. Fix TUI live-delta cost computation to use the actual model name from stream events.
2. Filter cost aggregation queries (`GetLifetimeTokens`, `GetDailyMetrics`) to exclude zero-token rows.

**Out of scope (file separately):**
- Persist `cache_creation_input_tokens` / `cache_read_input_tokens` columns to `executions` (cache tokens dominate cost 5–10× but are computed-only, never persisted, never surfaced).

---

## Fix 1 — TUI Live-Delta Uses Actual Model

### Root cause

Token callback signature carries no model info. The model is captured in `progressState.modelName` from stream events at `runner.go:3503-3505` and `3518-3520` but never propagated.

- `internal/executor/runner.go:1026-1033` — \`reportTokens(taskID, inputTokens, outputTokens int64)\`
- \`internal/dashboard/tui.go:339-343\` — \`TokenUsage{InputTokens, OutputTokens, TotalTokens}\` — no model field
- \`internal/dashboard/tui.go:2657-2666\` — \`UpdateTokens(input, output int)\` cmd
- \`internal/dashboard/tui.go:1058-1062\` — handler hardcodes \`memory.DefaultModel\`

### Implementation

| File | Change |
|---|---|
| \`internal/executor/runner.go\` | Extend \`tokenCallback\` type and \`reportTokens\` to include \`modelName string\`. Pass \`state.modelName\` from call sites at \`runner.go:3501\` and \`runner.go:3524\`. |
| \`internal/executor/runner.go\` | Update \`AddTokenCallback\` / \`OnToken\` signatures. |
| \`internal/dashboard/tui.go\` | Add \`Model string\` to \`TokenUsage\` struct. |
| \`internal/dashboard/tui.go\` | Update \`UpdateTokens(input, output int, model string)\` cmd. |
| \`internal/dashboard/tui.go:1061\` | Replace \`memory.DefaultModel\` with \`msg.Model\` (fall back to \`memory.DefaultModel\` when empty — first delta before stream events arrive). |
| \`cmd/pilot/main.go:1690-1693\` and \`cmd/pilot/commands.go:2325-2328\` | Update callback closures to forward \`model\` to \`dashboard.UpdateTokens\`. |

### Reuses

- \`memory.EstimateCost(input, output int64, model string)\` at \`internal/memory/metrics.go:133\` — already model-aware.
- \`progressState.modelName\` field — already populated.

### Edge case

When the first stream event hasn't arrived yet, \`state.modelName\` is empty. Fall back to \`memory.DefaultModel\` (preserves current behavior). On subsequent deltas the model will be populated and accurate.

---

## Fix 2 — Filter Aggregations to Real Executions

### Root cause

- \`internal/memory/store.go:1587-1604\` (\`GetLifetimeTokens\`) sums across ALL rows including dispatcher queue rows (\`internal/executor/dispatcher.go:327-343\` and \`385-401\`) and early-failure rows.
- \`internal/memory/metrics.go:314-331\` (\`GetDailyMetrics\`) — same.

### Implementation

| File | Change |
|---|---|
| \`internal/memory/store.go:1587-1604\` | Add \`WHERE tokens_total > 0\` to \`GetLifetimeTokens\`. |
| \`internal/memory/metrics.go:314-331\` | Same filter on \`GetDailyMetrics\`. |
| \`internal/memory/metrics.go:99-160\` | Audit \`ExecutionCount\` denominator (cost-per-task) — match the same filter. |

### Why \`tokens_total > 0\` and not \`status='completed'\`

Some completed runs legitimately have \$0 cost (LocalMode no-ops). Filtering on \`tokens_total > 0\` is the cleanest signal for "actually consumed Anthropic tokens".

---

## Verification

\`\`\`bash
make fmt && make lint && make test
go test ./internal/memory/... -run EstimateCost -v
go test ./internal/executor/... -run estimateCostWithCache -v
\`\`\`

**End-to-end (live TUI):**
1. \`make build\` and run \`./bin/pilot start --dashboard --github\`.
2. Confirm Sonnet selected in \`~/.pilot/config.yaml\`.
3. Dispatch a small issue. Live deltas should accumulate at Sonnet rates (~\$3/M input, \$15/M output), not Opus rates.
4. Cross-check post-completion:
   \`\`\`bash
   sqlite3 ~/.pilot/data/pilot.db \\
     "SELECT task_id, model_name, tokens_input, tokens_output, estimated_cost_usd \\
      FROM executions ORDER BY created_at DESC LIMIT 1;"
   \`\`\`

**End-to-end (filtered aggregation):**
\`\`\`bash
sqlite3 ~/.pilot/data/pilot.db \\
  "SELECT COUNT(*), SUM(estimated_cost_usd) FROM executions WHERE tokens_total > 0;"
\`\`\`
Should match the lifetime totals shown in the TUI cost card after restart.

**Regression:** confirm no double-counting after TUI restart — \`tui.go:583-591\` overwrites \`metricsCard.TotalCostUSD\` from DB on hydrate, so deltas only apply to current session (preserved).

---

## Effort

- Fix 1: ~80 LOC across 4 files + 1 unit test (callback signature ripples through 2 call sites).
- Fix 2: ~4 LOC across 2 files + 2 unit tests.
- Total: ~1 small PR.