### PR TITLE
GH-2712: fix(approval): persist approval_request_id and decision to executions table

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-05-06 (v2.53.0)
+**Last Updated:** 2026-05-05 (v2.53.0)
 
 ## Legend
 
@@ -341,6 +341,7 @@
 | Telegram approval | ✅ | approval | - | - | Inline keyboards, registered in main.go |
 | Rule-based triggers | ✅ | approval | - | `approval.rules[]` | RuleEvaluator with 4 matchers wired into Manager (GH-636) |
 | Non-blocking async approval | ✅ | autopilot | - | `approval.async_dispatch` | handleAwaitApproval tick-handler; PR-A stall no longer blocks PR-B (GH-2685) |
+| Approval persistence in executions | ✅ | autopilot/memory | - | - | approval_request_id + decision written to executions table (GH-2712) |
 
 ## Autopilot (v0.19.1+)
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -496,6 +496,8 @@ Examples:
 
 				// GH-726: Initialize autopilot state store for gateway mode
 				if gwStore != nil && gwAutopilotController != nil {
+					gwAutopilotController.SetMemoryStore(gwStore)
+
 					var gwStoreErr error
 					gwAutopilotStateStore, gwStoreErr = autopilot.NewStateStore(gwStore.DB())
 					if gwStoreErr != nil {
@@ -1472,6 +1474,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	// GH-726: Initialize autopilot state store for crash recovery
 	var autopilotStateStore *autopilot.StateStore
 	if store != nil && len(autopilotControllers) > 0 {
+		// GH-2712: Wire memory store for approval_request_id / approval_decision persistence.
+		for _, controller := range autopilotControllers {
+			controller.SetMemoryStore(store)
+		}
+
 		var storeErr error
 		autopilotStateStore, storeErr = autopilot.NewStateStore(store.DB())
 		if storeErr != nil {

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2,6 +2,7 @@ package autopilot
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -15,6 +16,13 @@ import (
 	"github.com/qf-studio/pilot/internal/approval"
 	"github.com/qf-studio/pilot/internal/memory"
 )
+
+// approvalPersister is the subset of memory.Store used for approval persistence
+// in the executions table.
+type approvalPersister interface {
+	SetApprovalRequestID(ctx context.Context, taskID, requestID string) error
+	SetApprovalDecision(ctx context.Context, requestID, decision, by string) error
+}
 
 // iterationRe matches the iteration field in autopilot-meta comments.
 var iterationRe = regexp.MustCompile(`<!-- autopilot-meta.*?iteration:(\d+).*?-->`)
@@ -104,6 +112,14 @@ func WithProjectBoardSync(bs *github.ProjectBoardSync, doneStatus, failStatus st
 	}
 }
 
+// WithMemoryStore wires an execution-level approval persister so that
+// approval_request_id and approval_decision are written to the executions table.
+func WithMemoryStore(s *memory.Store) ControllerOption {
+	return func(c *Controller) {
+		c.memoryStore = s
+	}
+}
+
 // Controller orchestrates the autopilot loop for PR processing.
 // It manages the state machine: PR created → CI check → merge → post-merge CI → feedback loop.
 type Controller struct {
@@ -134,6 +150,9 @@ type Controller struct {
 
 	// Eval store for capturing eval tasks from merged PRs (optional, nil = eval disabled)
 	evalStore EvalStore
+
+	// Execution-level approval persistence (optional, nil = audit trail disabled)
+	memoryStore approvalPersister
 
 	// Per-PR circuit breaker: each PR has independent failure tracking.
 	// A failure on one PR does not block other PRs.
@@ -223,6 +242,12 @@ func (c *Controller) SetLearningLoop(loop *memory.LearningLoop) {
 // SetEvalStore sets the eval store for capturing eval tasks from merged PRs.
 func (c *Controller) SetEvalStore(store EvalStore) {
 	c.evalStore = store
+}
+
+// SetMemoryStore wires an execution-level approval persister so that
+// approval_request_id and approval_decision are written to the executions table.
+func (c *Controller) SetMemoryStore(s *memory.Store) {
+	c.memoryStore = s
 }
 
 // SetReleaseSummaryGenerator sets the LLM release summary generator.
@@ -1050,6 +1075,13 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 		}
 	}
 
+	if c.memoryStore != nil {
+		if merr := c.memoryStore.SetApprovalRequestID(ctx, taskID, requestID); merr != nil {
+			c.log.Warn("failed to persist approval_request_id to executions",
+				"pr", prState.PRNumber, "task_id", taskID, "error", merr)
+		}
+	}
+
 	c.log.Info("async approval request submitted",
 		"pr", prState.PRNumber, "request_id", requestID)
 	return nil
@@ -1120,7 +1152,7 @@ func (c *Controller) handleAwaitApprovalLegacy(ctx context.Context, prState *PRS
 // PRState whose ApprovalRequestID matches and records the decision, then persists
 // via stateStore. Called by the approval.Manager's background goroutine when a
 // handler fires (e.g. Telegram button tap).
-func (c *Controller) SetApprovalDecision(_ context.Context, requestID string, decision string, by string) error {
+func (c *Controller) SetApprovalDecision(ctx context.Context, requestID string, decision string, by string) error {
 	if requestID == "" {
 		return nil
 	}
@@ -1131,6 +1163,12 @@ func (c *Controller) SetApprovalDecision(_ context.Context, requestID string, de
 			pr.ApprovalDecision = decision
 			if c.stateStore != nil {
 				_ = c.stateStore.SavePRState(pr)
+			}
+			if c.memoryStore != nil {
+				if merr := c.memoryStore.SetApprovalDecision(ctx, requestID, decision, by); merr != nil && !errors.Is(merr, sql.ErrNoRows) {
+					c.log.Warn("failed to persist approval decision to executions",
+						"pr", pr.PRNumber, "request_id", requestID, "error", merr)
+				}
 			}
 			c.log.Info("approval decision applied to PR state",
 				"pr", pr.PRNumber, "request_id", requestID,

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -5109,3 +5109,88 @@ func TestController_TwoPRQueue_StalledApprovalDoesNotBlockOther(t *testing.T) {
 		t.Errorf("PR-B should have advanced past %s (was blocked by PR-A)", StagePRCreated)
 	}
 }
+
+// mockApprovalPersister records calls to SetApprovalRequestID and SetApprovalDecision
+// so tests can verify that the controller wires through to the memory store.
+type mockApprovalPersister struct {
+	requestIDCalls []struct{ taskID, requestID string }
+	decisionCalls  []struct{ requestID, decision, by string }
+}
+
+func (m *mockApprovalPersister) SetApprovalRequestID(_ context.Context, taskID, requestID string) error {
+	m.requestIDCalls = append(m.requestIDCalls, struct{ taskID, requestID string }{taskID, requestID})
+	return nil
+}
+
+func (m *mockApprovalPersister) SetApprovalDecision(_ context.Context, requestID, decision, by string) error {
+	m.decisionCalls = append(m.decisionCalls, struct{ requestID, decision, by string }{requestID, decision, by})
+	return nil
+}
+
+// TestController_SetApprovalDecision_PersistsToMemoryStore verifies that
+// Controller.SetApprovalDecision updates in-memory PRState AND calls the
+// injected approvalPersister (executions table write path).
+func TestController_SetApprovalDecision_PersistsToMemoryStore(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	mgr := approval.NewManager(nil)
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+
+	mock := &mockApprovalPersister{}
+	c.memoryStore = mock
+
+	c.mu.Lock()
+	c.activePRs[99] = &PRState{
+		PRNumber:          99,
+		IssueNumber:       10,
+		ApprovalRequestID: "req-test-123",
+	}
+	c.mu.Unlock()
+
+	ctx := context.Background()
+	if err := c.SetApprovalDecision(ctx, "req-test-123", "approved", "reviewer"); err != nil {
+		t.Fatalf("SetApprovalDecision: %v", err)
+	}
+
+	// In-memory state updated.
+	pr, ok := c.GetPRState(99)
+	if !ok {
+		t.Fatal("PR state not found")
+	}
+	if pr.ApprovalDecision != "approved" {
+		t.Errorf("in-memory ApprovalDecision = %q, want %q", pr.ApprovalDecision, "approved")
+	}
+
+	// Memory store called with correct args.
+	if len(mock.decisionCalls) != 1 {
+		t.Fatalf("expected 1 SetApprovalDecision call, got %d", len(mock.decisionCalls))
+	}
+	call := mock.decisionCalls[0]
+	if call.requestID != "req-test-123" || call.decision != "approved" || call.by != "reviewer" {
+		t.Errorf("unexpected call args: %+v", call)
+	}
+}
+
+// TestController_SetApprovalDecision_NoStoreNoPanic verifies that the controller
+// works correctly when no memory store is wired (nil-safe).
+func TestController_SetApprovalDecision_NoStoreNoPanic(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	c := NewController(DefaultConfig(), ghClient, approval.NewManager(nil), "owner", "repo")
+
+	c.mu.Lock()
+	c.activePRs[1] = &PRState{
+		PRNumber:          1,
+		ApprovalRequestID: "req-nil-store",
+	}
+	c.mu.Unlock()
+
+	// Should not panic with nil memoryStore.
+	err := c.SetApprovalDecision(context.Background(), "req-nil-store", "approved", "bot")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	pr, _ := c.GetPRState(1)
+	if pr.ApprovalDecision != "approved" {
+		t.Errorf("in-memory decision not set: %q", pr.ApprovalDecision)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -576,6 +576,39 @@ func (s *Store) SetApprovalDecision(ctx context.Context, requestID string, decis
 	})
 }
 
+// SetApprovalRequestID records the approval request ID on the most-recent execution
+// row for the given task. Must be called after SubmitApprovalRequest succeeds so
+// that SetApprovalDecision's WHERE clause can later match the row.
+// Returns sql.ErrNoRows when no execution row exists for taskID yet.
+func (s *Store) SetApprovalRequestID(ctx context.Context, taskID, requestID string) error {
+	if taskID == "" || requestID == "" {
+		return nil
+	}
+	return s.withRetry("SetApprovalRequestID", func() error {
+		result, err := s.db.ExecContext(ctx, `
+			UPDATE executions
+			SET approval_request_id = ?
+			WHERE id = (
+				SELECT id FROM executions
+				WHERE task_id = ?
+				ORDER BY created_at DESC
+				LIMIT 1
+			)
+		`, requestID, taskID)
+		if err != nil {
+			return fmt.Errorf("SetApprovalRequestID: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("SetApprovalRequestID rows affected: %w", err)
+		}
+		if rows == 0 {
+			return sql.ErrNoRows
+		}
+		return nil
+	})
+}
+
 // GetRecentExecutions returns the most recent executions ordered by creation time.
 // The limit parameter specifies the maximum number of executions to return.
 func (s *Store) GetRecentExecutions(limit int) ([]*Execution, error) {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2,6 +2,9 @@ package memory
 
 import (
 	"bytes"
+	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -1395,6 +1398,65 @@ func TestStore_ConnectionPoolSettings(t *testing.T) {
 	// MaxOpenConns should be 1
 	if stats.MaxOpenConnections != 1 {
 		t.Errorf("MaxOpenConnections = %d, want 1", stats.MaxOpenConnections)
+	}
+}
+
+func TestStore_SetApprovalRequestID_HappyPath(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+
+	exec := &Execution{
+		ID:          "exec-approval-1",
+		TaskID:      "GH-999",
+		ProjectPath: "/proj",
+		Status:      "completed",
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	if err := store.SetApprovalRequestID(ctx, "GH-999", "req-abc"); err != nil {
+		t.Fatalf("SetApprovalRequestID: %v", err)
+	}
+
+	// Verify via SetApprovalDecision — it matches on approval_request_id.
+	if err := store.SetApprovalDecision(ctx, "req-abc", "approved", "tester"); err != nil {
+		t.Fatalf("SetApprovalDecision after SetApprovalRequestID: %v", err)
+	}
+
+	got, err := store.GetExecution("exec-approval-1")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if got.ApprovalRequestID != "req-abc" {
+		t.Errorf("ApprovalRequestID = %q, want %q", got.ApprovalRequestID, "req-abc")
+	}
+	if got.ApprovalDecision != "approved" {
+		t.Errorf("ApprovalDecision = %q, want %q", got.ApprovalDecision, "approved")
+	}
+	if got.ApprovalDecisionBy != "tester" {
+		t.Errorf("ApprovalDecisionBy = %q, want %q", got.ApprovalDecisionBy, "tester")
+	}
+}
+
+func TestStore_SetApprovalRequestID_ZeroRowCase(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	ctx := context.Background()
+
+	// No execution row exists for this task.
+	err = store.SetApprovalRequestID(ctx, "GH-000", "req-xyz")
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows for missing task, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2712.

Closes #2712

## Changes

GitHub Issue #2712: fix(approval): persist approval_request_id and decision to executions table

## Context

The `executions` table has approval columns added in v2.124.0:
- `approval_request_id`
- `approval_decision`, `approval_decision_at`, `approval_decision_by`

**These columns are never populated.** Verified live on 2026-05-06:

```sql
SELECT count(*) FROM executions
WHERE approval_request_id != '' OR approval_decision != '';
-- 0 rows (across all-time executions)
```

Two missing wires cause this:

### Wire 1: `approval_request_id` is never written to executions after submission

`internal/memory/store.go:437` only binds `approval_request_id` during the initial INSERT, which happens when Pilot picks up the issue — *before* any approval flow exists. After `SubmitApprovalRequest` returns its ID, no code UPDATEs the column. So `Store.SetApprovalDecision`'s `WHERE approval_request_id = ?` matches zero rows.

### Wire 2: Controller.SetApprovalDecision doesn't call Store.SetApprovalDecision

`internal/autopilot/controller.go:1119-1143` (the `PRStateWriter` impl invoked by `approval.Manager.RecordDecision`) updates in-memory `pr.ApprovalDecision` and `stateStore.SavePRState(pr)` — but never touches the `executions` table.

### Concrete impact

- Smoke-test PRs #2702 (GH-2700) and #2704 (GH-2703) both completed the async approval flow successfully (merge fired). Both `executions.approval_decision` columns remain empty.
- Auto-release did not fire after either merge → v2.128.1 had to be hand-tagged. Likely root cause: any release-trigger consumer reading persisted approval state finds nothing.
- Restart resilience for dashboards/audits is broken — SQLite has no record of approvals.

## Acceptance Criteria

1. **New `Store.SetApprovalRequestID(ctx, taskID, requestID string) error`** in `internal/memory/store.go` updating the most-recent active `executions` row matching `task_id` (using existing `withRetry` pattern).
2. **Controller calls `SetApprovalRequestID`** after `SubmitApprovalRequest` succeeds (`controller.go:~1038`). Controller gains an optional `memoryStore` field + `WithMemoryStore` `ControllerOption`. Wire it in `cmd/pilot/...` at startup.
3. **`Controller.SetApprovalDecision`** (controller.go:1119) calls `c.memoryStore.SetApprovalDecision(ctx, requestID, decision, by)` after the in-memory update; `sql.ErrNoRows` is a warning, not a hard error.
4. **Unit tests** cover:
   - `Store.SetApprovalRequestID` happy path + zero-row case
   - `Controller.SetApprovalDecision` writes to both in-memory state and the (mock) memory store
5. **Existing tests pass** (`make test`). No new import cycles.
6. **No regression in approval flow latency** — wire is non-blocking from caller's perspective.

## Out of Scope

- Removing the legacy blocking `RequestApproval` path (separate task)
- Schema changes (columns already exist)
- Backfilling historic rows

## Implementation Plan

Full plan with phases, file lists, and decision rationale: `.agent/tasks/TASK-33-approval-decision-executions-persist.md`

## Verification (after merge)

```bash
# File a tiny Pilot issue, tap Approve in TG, then:
sqlite3 ~/.pilot/data/pilot.db \
  "SELECT task_id, approval_request_id, approval_decision, approval_decision_by \
   FROM executions WHERE task_id = 'GH-NNN';"
# Expect: all four columns populated
```

## Notes

- Per memory `pattern_hot_upgrade_bootstrap.md`: the running daemon predates the fix; the first hot-upgrade may need hand-tagging once.
- Natural follow-up to TASK-29/30/31. Closes the loop on observable async approval pipeline.