### PR TITLE
GH-2716: fix(autopilot): initialize Releaser from resolvedRelease() (env-scoped config)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -193,9 +193,10 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 	c.autoMerger = NewAutoMerger(ghClient, approvalMgr, c.ciMonitor, owner, repo, cfg)
 	c.feedbackLoop = NewFeedbackLoop(ghClient, owner, repo, cfg)
 
-	// Initialize releaser if release config exists
-	if cfg.Release != nil && cfg.Release.Enabled {
-		c.releaser = NewReleaser(ghClient, owner, repo, cfg.Release)
+	// Initialize releaser from resolved release config (env-scoped wins over global).
+	// Mirrors resolvedRelease() so construction matches runtime decision path.
+	if relCfg := resolveRelease(cfg); relCfg != nil && relCfg.Enabled {
+		c.releaser = NewReleaser(ghClient, owner, repo, relCfg)
 	}
 
 	// Initialize deployer if post-merge config exists
@@ -1542,13 +1543,19 @@ func (c *Controller) getMainBranchSHA(ctx context.Context) (string, error) {
 	return branch.SHA(), nil
 }
 
+// resolveRelease is a package-level helper used during construction (before Controller
+// exists) and by the resolvedRelease method below. Env-scoped config wins over global.
+func resolveRelease(cfg *Config) *ReleaseConfig {
+	if env := cfg.ResolvedEnv(); env != nil && env.Release != nil {
+		return env.Release
+	}
+	return cfg.Release
+}
+
 // resolvedRelease returns the effective release config, preferring per-environment
 // config over global. Returns nil if neither is set.
 func (c *Controller) resolvedRelease() *ReleaseConfig {
-	if env := c.config.ResolvedEnv(); env != nil && env.Release != nil {
-		return env.Release
-	}
-	return c.config.Release
+	return resolveRelease(c.config)
 }
 
 // shouldTriggerRelease returns true if auto-release is configured.

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -43,6 +43,66 @@ func TestNewController(t *testing.T) {
 	}
 }
 
+func TestNewController_ReleaserInit(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+
+	enabledRelease := &ReleaseConfig{Enabled: true, Trigger: "on_merge"}
+	disabledRelease := &ReleaseConfig{Enabled: false}
+
+	tests := []struct {
+		name           string
+		globalRelease  *ReleaseConfig
+		envRelease     *ReleaseConfig
+		wantReleaser   bool
+	}{
+		{
+			name:          "global only enabled",
+			globalRelease: enabledRelease,
+			envRelease:    nil,
+			wantReleaser:  true,
+		},
+		{
+			name:          "env only enabled",
+			globalRelease: nil,
+			envRelease:    enabledRelease,
+			wantReleaser:  true,
+		},
+		{
+			name:          "both set — env wins (enabled)",
+			globalRelease: disabledRelease,
+			envRelease:    enabledRelease,
+			wantReleaser:  true,
+		},
+		{
+			name:          "neither set",
+			globalRelease: nil,
+			envRelease:    nil,
+			wantReleaser:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Release = tt.globalRelease
+			if tt.envRelease != nil {
+				envCfg := &EnvironmentConfig{Release: tt.envRelease}
+				cfg.activeEnvName = "test"
+				cfg.activeEnvConfig = envCfg
+			}
+
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			if tt.wantReleaser && c.releaser == nil {
+				t.Errorf("releaser should be non-nil")
+			}
+			if !tt.wantReleaser && c.releaser != nil {
+				t.Errorf("releaser should be nil")
+			}
+		})
+	}
+}
+
 func TestController_OnPRCreated(t *testing.T) {
 	ghClient := github.NewClient(testutil.FakeGitHubToken)
 	cfg := DefaultConfig()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2716.

Closes #2716

## Changes

GitHub Issue #2716: fix(autopilot): initialize Releaser from resolvedRelease() (env-scoped config)

## Context

At \`internal/autopilot/controller.go:197-199\`:

\`\`\`go
if cfg.Release != nil && cfg.Release.Enabled {
    c.releaser = NewReleaser(ghClient, owner, repo, cfg.Release)
}
\`\`\`

But at runtime, \`resolvedRelease()\` (line 1547-1551) prefers \`env.Release\` over global. If a user sets release config ONLY under \`environments.<env>.release\` (no global \`release:\` block), \`shouldTriggerRelease()\` returns true (env config resolves) but \`c.releaser == nil\` (initialized from absent global). \`handleReleasing\` (line 1524) returns \"releaser not configured, skipping release\" and the release silently dies.

Currently masked because \`~/.pilot/config.yaml\` has both global and env-scoped release blocks with identical content.

## Acceptance Criteria

1. \`c.releaser\` is non-nil when EITHER global \`cfg.Release\` OR \`env.Release\` is enabled.
2. If both are set, env-scoped config wins (matches \`resolvedRelease()\` semantics — env first, fallback global).
3. New table-driven test covers: global-only, env-only, both, neither.
4. No regression in existing tests.
5. \`make test\` and \`make lint\` pass.

## Out of Scope

- Refactoring \`resolvedRelease()\` itself.
- Other env-scoped-vs-global config mismatches (separate audit).

## Implementation Plan

\`.agent/tasks/TASK-34-releaser-from-resolved-release.md\`

## Notes

- Latent bug discovered during v2.128.2 post-mortem audit (gap 1 of 5).
- Low active impact (configs align today), high future blast radius.