### PR TITLE
GH-2717: refactor(autopilot): non-blocking handlePostMergeCI (mirror handleWaitingCI)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1481,34 +1481,71 @@ func (c *Controller) maybeCloseParentIssue(ctx context.Context, prState *PRState
 	}
 }
 
-// handlePostMergeCI monitors deployment/post-merge checks.
+// handlePostMergeCI monitors deployment/post-merge checks (non-blocking).
+// Each tick calls CheckCI once and either advances the stage or returns to wait
+// for the next tick, mirroring the pattern used by handleWaitingCI.
 func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) error {
-	// Get merge commit SHA from main branch
-	// For now, use head SHA - in production, should get actual merge commit
-	mainSHA, err := c.getMainBranchSHA(ctx)
-	if err != nil {
-		c.log.Warn("failed to get main branch SHA, using head SHA", "error", err)
-		mainSHA = prState.HeadSHA
-	}
-
-	status, err := c.ciMonitor.WaitForCI(ctx, mainSHA)
-	if err != nil {
-		return err
-	}
-
-	if status == CIFailure {
-		c.log.Warn("post-merge CI failed", "pr", prState.PRNumber)
-		failedChecks, _ := c.ciMonitor.GetFailedChecks(ctx, mainSHA)
-		// GH-1567: Fetch CI error logs for post-merge failures too
-		ciLogs := c.ciMonitor.GetFailedCheckLogs(ctx, mainSHA, 2000)
-		// Post-merge failures start a new lineage (iteration 1), not part of pre-merge cascade
-		issueNum, err := c.feedbackLoop.CreateFailureIssue(ctx, prState, FailureCIPostMerge, failedChecks, ciLogs, 1)
+	// Capture main branch SHA on first entry; persisted so daemon restarts resume
+	// monitoring the same commit rather than picking up a newer one.
+	if prState.PostMergeSHA == "" {
+		sha, err := c.getMainBranchSHA(ctx)
 		if err != nil {
-			c.log.Error("failed to create post-merge fix issue", "error", err)
+			c.log.Warn("failed to get main branch SHA, using head SHA", "error", err)
+			sha = prState.HeadSHA
+		}
+		prState.PostMergeSHA = sha
+	}
+
+	// Start the CI timer on first tick.
+	if prState.PostMergeCIStartedAt.IsZero() {
+		prState.PostMergeCIStartedAt = time.Now()
+	}
+
+	// Enforce timeout using same logic as handleWaitingCI.
+	ciTimeout := c.config.CIWaitTimeout
+	envCITimeout := c.config.ResolvedEnv().CITimeout
+	if envCITimeout > 0 && (ciTimeout == 0 || envCITimeout < ciTimeout) {
+		ciTimeout = envCITimeout
+	}
+	if time.Since(prState.PostMergeCIStartedAt) > ciTimeout {
+		c.log.Warn("post-merge CI timeout", "pr", prState.PRNumber, "waited", time.Since(prState.PostMergeCIStartedAt))
+		prState.Stage = StageFailed
+		prState.Error = fmt.Sprintf("post-merge CI timeout after %v", ciTimeout)
+		return nil
+	}
+
+	mainSHA := prState.PostMergeSHA
+	status, err := c.ciMonitor.CheckCI(ctx, mainSHA)
+	if err != nil {
+		// Transient API error — log and retry next tick without failing the PR.
+		c.log.Warn("post-merge CI status check failed", "pr", prState.PRNumber, "sha", ShortSHA(mainSHA), "error", err)
+		return nil
+	}
+
+	prState.CIStatus = status
+	prState.LastChecked = time.Now()
+
+	switch status {
+	case CISuccess:
+		c.log.Info("post-merge CI passed", "pr", prState.PRNumber, "sha", ShortSHA(mainSHA))
+		if c.shouldTriggerRelease() {
+			prState.Stage = StageReleasing
+			return nil
+		}
+		c.removePR(prState.PRNumber)
+
+	case CIFailure:
+		c.log.Warn("post-merge CI failed", "pr", prState.PRNumber, "sha", ShortSHA(mainSHA))
+		failedChecks, _ := c.ciMonitor.GetFailedChecks(ctx, mainSHA)
+		// GH-1567: Fetch CI error logs for post-merge failures too.
+		ciLogs := c.ciMonitor.GetFailedCheckLogs(ctx, mainSHA, 2000)
+		// Post-merge failures start a new lineage (iteration 1), not part of pre-merge cascade.
+		issueNum, issueErr := c.feedbackLoop.CreateFailureIssue(ctx, prState, FailureCIPostMerge, failedChecks, ciLogs, 1)
+		if issueErr != nil {
+			c.log.Error("failed to create post-merge fix issue", "error", issueErr)
 		} else {
 			c.log.Info("created fix issue for post-merge CI failure", "pr", prState.PRNumber, "issue", issueNum)
 		}
-
 		// GH-1964/GH-1979: Learn from post-merge CI failure patterns (self-improvement).
 		// Guard: skip learning when CI logs are empty/whitespace (nothing to extract).
 		if c.learningLoop != nil && strings.TrimSpace(ciLogs) != "" {
@@ -1517,19 +1554,13 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 				c.log.Warn("Failed to learn from post-merge CI failure", slog.Any("error", learnErr))
 			}
 		}
-
 		c.removePR(prState.PRNumber)
-		return nil
+
+	default:
+		// CIPending or CIRunning — stay in StagePostMergeCI and wait for next tick.
+		c.log.Debug("post-merge CI still running", "pr", prState.PRNumber, "sha", ShortSHA(mainSHA), "status", status)
 	}
 
-	// CI passed - check if we should release
-	if c.shouldTriggerRelease() {
-		prState.Stage = StageReleasing
-		return nil
-	}
-
-	c.log.Info("post-merge CI passed", "pr", prState.PRNumber)
-	c.removePR(prState.PRNumber)
 	return nil
 }
 

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -3467,6 +3467,218 @@ func TestHandlePostMergeCI_LearnsFromCIFailure(t *testing.T) {
 	}
 }
 
+// TestHandlePostMergeCI_NonBlocking verifies that handlePostMergeCI does not block
+// the tick loop: pending CI returns nil and stays in StagePostMergeCI, success
+// advances to StageReleasing (when release is configured) or removes the PR,
+// and a daemon restart resumes from the persisted PostMergeSHA. (GH-2717)
+func TestHandlePostMergeCI_NonBlocking(t *testing.T) {
+	tests := []struct {
+		name          string
+		checkStatus   string
+		checkConc     string
+		releaseEnabled bool
+		wantStage     PRStage
+		wantRemoved   bool
+	}{
+		{
+			name:        "pending stays in stage",
+			checkStatus: "in_progress",
+			wantStage:   StagePostMergeCI,
+			wantRemoved: false,
+		},
+		{
+			name:          "success without release removes PR",
+			checkStatus:   "completed",
+			checkConc:     "success",
+			releaseEnabled: false,
+			wantRemoved:   true,
+		},
+		{
+			name:          "success with release advances to StageReleasing",
+			checkStatus:   "completed",
+			checkConc:     "success",
+			releaseEnabled: true,
+			wantStage:     StageReleasing,
+			wantRemoved:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/owner/repo/branches/main":
+					resp := map[string]interface{}{
+						"commit": map[string]string{"sha": "mainsha42"},
+					}
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(mustJSON(t, resp))
+				case "/repos/owner/repo/commits/mainsha42/check-runs":
+					resp := github.CheckRunsResponse{
+						TotalCount: 1,
+						CheckRuns: []github.CheckRun{
+							{Name: "ci", Status: tt.checkStatus, Conclusion: tt.checkConc},
+						},
+					}
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(mustJSON(t, resp))
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.Environment = EnvDev
+			cfg.CIPollInterval = 10 * time.Millisecond
+			cfg.CIWaitTimeout = 5 * time.Second
+			if tt.releaseEnabled {
+				cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge"}
+			}
+
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			prState := &PRState{
+				PRNumber: 77,
+				Stage:    StagePostMergeCI,
+			}
+
+			err := c.handlePostMergeCI(context.Background(), prState)
+			if err != nil {
+				t.Fatalf("handlePostMergeCI returned error: %v", err)
+			}
+
+			if tt.wantRemoved {
+				// PR should have been removed from tracking.
+				c.mu.RLock()
+				_, stillTracked := c.activePRs[77]
+				c.mu.RUnlock()
+				if stillTracked {
+					t.Error("expected PR to be removed but it is still tracked")
+				}
+			} else {
+				if prState.Stage != tt.wantStage {
+					t.Errorf("stage = %s, want %s", prState.Stage, tt.wantStage)
+				}
+			}
+
+			// PostMergeSHA must be populated after first call.
+			if prState.PostMergeSHA == "" {
+				t.Error("PostMergeSHA should be set after first tick")
+			}
+		})
+	}
+}
+
+// TestHandlePostMergeCI_RestartResumesSHA verifies that if PostMergeSHA is already
+// set (simulating a daemon restart with persisted state), handlePostMergeCI does not
+// fetch a new SHA and continues monitoring the original commit. (GH-2717)
+func TestHandlePostMergeCI_RestartResumesSHA(t *testing.T) {
+	branchFetched := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/branches/main":
+			branchFetched = true
+			resp := map[string]interface{}{
+				"commit": map[string]string{"sha": "newsha99"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		case "/repos/owner/repo/commits/originalsha/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "ci", Status: "in_progress"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.CIWaitTimeout = 5 * time.Minute
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Simulate persisted state from before restart (started 30s ago, well within timeout).
+	prState := &PRState{
+		PRNumber:             88,
+		Stage:                StagePostMergeCI,
+		PostMergeSHA:         "originalsha",
+		PostMergeCIStartedAt: time.Now().Add(-30 * time.Second),
+	}
+
+	err := c.handlePostMergeCI(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("handlePostMergeCI returned error: %v", err)
+	}
+
+	if branchFetched {
+		t.Error("branch SHA should NOT be fetched when PostMergeSHA is already set")
+	}
+	if prState.PostMergeSHA != "originalsha" {
+		t.Errorf("PostMergeSHA changed to %q, want %q", prState.PostMergeSHA, "originalsha")
+	}
+	if prState.Stage != StagePostMergeCI {
+		t.Errorf("stage = %s, want %s (CI still running)", prState.Stage, StagePostMergeCI)
+	}
+}
+
+// TestHandlePostMergeCI_Timeout verifies that a long-running post-merge CI
+// eventually times out and transitions to StageFailed. (GH-2717)
+func TestHandlePostMergeCI_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/tsha/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "ci", Status: "in_progress"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.CIWaitTimeout = 1 * time.Millisecond
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Started well in the past to trigger immediate timeout.
+	prState := &PRState{
+		PRNumber:             99,
+		Stage:                StagePostMergeCI,
+		PostMergeSHA:         "tsha",
+		PostMergeCIStartedAt: time.Now().Add(-10 * time.Minute),
+	}
+
+	err := c.handlePostMergeCI(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("handlePostMergeCI returned error: %v", err)
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("stage = %s, want %s after timeout", prState.Stage, StageFailed)
+	}
+	if prState.Error == "" {
+		t.Error("expected Error to be set on timeout")
+	}
+}
+
 // TestHandleCIFailed_EmptyLogs_SkipsLearning verifies that handleCIFailed skips
 // LearnFromCIFailure when CI logs are empty or whitespace-only (GH-1979).
 // TestHandleCIFailed_EmptyLogs_SkipsLearning verifies that handleCIFailed skips

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -127,6 +127,10 @@ func (s *StateStore) migrate() error {
 		`ALTER TABLE autopilot_pr_state ADD COLUMN approval_request_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE autopilot_pr_state ADD COLUMN approval_decision TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE autopilot_pr_state ADD COLUMN approval_requested_at DATETIME`,
+		// GH-2717: Non-blocking post-merge CI — persist SHA and start time so
+		// daemon restarts resume monitoring the same commit without re-fetching.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN post_merge_sha TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE autopilot_pr_state ADD COLUMN post_merge_ci_started_at DATETIME`,
 	}
 
 	for _, m := range migrations {
@@ -149,8 +153,9 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at, updated_at,
 			release_version, release_bump_type, merge_notification_posted,
-			approval_request_id, approval_decision, approval_requested_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?)
+			approval_request_id, approval_decision, approval_requested_at,
+			post_merge_sha, post_merge_ci_started_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -168,7 +173,9 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			merge_notification_posted = excluded.merge_notification_posted,
 			approval_request_id = excluded.approval_request_id,
 			approval_decision = excluded.approval_decision,
-			approval_requested_at = excluded.approval_requested_at
+			approval_requested_at = excluded.approval_requested_at,
+			post_merge_sha = excluded.post_merge_sha,
+			post_merge_ci_started_at = excluded.post_merge_ci_started_at
 	`,
 		pr.PRNumber, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
@@ -176,6 +183,7 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 		pr.MergeAttempts, pr.Error, nullTime(pr.CreatedAt),
 		pr.ReleaseVersion, string(pr.ReleaseBumpType), pr.MergeNotificationPosted,
 		pr.ApprovalRequestID, pr.ApprovalDecision, nullTime(pr.ApprovalRequestedAt),
+		pr.PostMergeSHA, nullTime(pr.PostMergeCIStartedAt),
 	)
 	return err
 }
@@ -188,7 +196,8 @@ func (s *StateStore) GetPRState(prNumber int) (*PRState, error) {
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at,
 			release_version, release_bump_type, merge_notification_posted,
-			approval_request_id, approval_decision, approval_requested_at
+			approval_request_id, approval_decision, approval_requested_at,
+			post_merge_sha, post_merge_ci_started_at
 		FROM autopilot_pr_state WHERE pr_number = ?
 	`, prNumber)
 
@@ -209,7 +218,8 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at,
 			release_version, release_bump_type, merge_notification_posted,
-			approval_request_id, approval_decision, approval_requested_at
+			approval_request_id, approval_decision, approval_requested_at,
+			post_merge_sha, post_merge_ci_started_at
 		FROM autopilot_pr_state
 	`)
 	if err != nil {
@@ -220,7 +230,7 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 	var states []*PRState
 	for rows.Next() {
 		var pr PRState
-		var lastChecked, ciWaitStartedAt, createdAt, approvalRequestedAt sql.NullTime
+		var lastChecked, ciWaitStartedAt, createdAt, approvalRequestedAt, postMergeCIStartedAt sql.NullTime
 		var stage, ciStatus, relBumpType string
 
 		if err := rows.Scan(
@@ -229,6 +239,7 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 			&pr.MergeAttempts, &pr.Error, &createdAt,
 			&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
 			&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
+			&pr.PostMergeSHA, &postMergeCIStartedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -247,6 +258,9 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 		}
 		if approvalRequestedAt.Valid {
 			pr.ApprovalRequestedAt = approvalRequestedAt.Time
+		}
+		if postMergeCIStartedAt.Valid {
+			pr.PostMergeCIStartedAt = postMergeCIStartedAt.Time
 		}
 		states = append(states, &pr)
 	}
@@ -816,7 +830,7 @@ func (s *StateStore) PurgeTerminalPRStates(olderThan time.Duration) (int64, erro
 // scanPRState scans a single row into a PRState.
 func scanPRState(row *sql.Row) (*PRState, error) {
 	var pr PRState
-	var lastChecked, ciWaitStartedAt, createdAt, approvalRequestedAt sql.NullTime
+	var lastChecked, ciWaitStartedAt, createdAt, approvalRequestedAt, postMergeCIStartedAt sql.NullTime
 	var stage, ciStatus, relBumpType string
 
 	err := row.Scan(
@@ -825,6 +839,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&pr.MergeAttempts, &pr.Error, &createdAt,
 		&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
 		&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
+		&pr.PostMergeSHA, &postMergeCIStartedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -844,6 +859,9 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 	}
 	if approvalRequestedAt.Valid {
 		pr.ApprovalRequestedAt = approvalRequestedAt.Time
+	}
+	if postMergeCIStartedAt.Valid {
+		pr.PostMergeCIStartedAt = postMergeCIStartedAt.Time
 	}
 	return &pr, nil
 }

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -476,6 +476,11 @@ type PRState struct {
 	ApprovalDecision string
 	// ApprovalRequestedAt is when the async approval request was first submitted.
 	ApprovalRequestedAt time.Time
+	// PostMergeSHA is the main branch SHA captured on first entry to StagePostMergeCI.
+	// Persisted so a daemon restart resumes monitoring the same commit.
+	PostMergeSHA string
+	// PostMergeCIStartedAt is when StagePostMergeCI monitoring began (for timeout tracking).
+	PostMergeCIStartedAt time.Time
 }
 
 // RepoOwnerAndName extracts the repository owner and name from the PR URL.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2717.

Closes #2717

## Changes

GitHub Issue #2717: refactor(autopilot): non-blocking handlePostMergeCI (mirror handleWaitingCI)

## Context

\`handlePostMergeCI\` calls \`ciMonitor.WaitForCI(ctx, mainSHA)\` which polls in a loop for up to 30 minutes (\`internal/autopilot/ci_monitor.go:93-121\`). This blocks the entire \`processAllPRs\` sequential loop in \`controller.go:2241-2280\`. While one PR's post-merge CI is being awaited, no other PR ticks.

\`handleWaitingCI\` (pre-merge) was already refactored to use non-blocking \`CheckCI\` + tick-driven polling. \`handlePostMergeCI\` was missed during that refactor.

In current production with \`ci_checks.mode: auto\` + 1m grace period, the auto-mode path usually resolves in ~2 minutes, masking the issue. But if \`required_checks\` are configured or CI takes longer, this deadlocks the controller.

## Acceptance Criteria

1. \`handlePostMergeCI\` does not block the tick for more than a few hundred ms.
2. Stage transitions:
   - CI success → \`StageReleasing\` (or \`removePR\` if no release configured)
   - CI failure → \`StageFailed\`
   - CI pending → return nil; stay in \`StagePostMergeCI\` for next tick
3. Restart mid-poll resumes correctly from persisted prState (grace-period tracking persists).
4. Existing post-merge CI tests still pass; new test covers non-blocking transitions including restart.
5. \`make test\` and \`make lint\` pass.

## Out of Scope

- Changes to \`handleWaitingCI\` (already correct).
- Changes to \`ciMonitor.WaitForCI\` itself (kept for any non-tick callers; just unused by post-merge path).
- Tick interval tuning.

## Implementation Plan

\`.agent/tasks/TASK-35-nonblocking-post-merge-ci.md\`

## Notes

- Discovered during v2.128.2 post-mortem audit (gap 2 of 5). Architectural smell, not the cause of the recent hand-tag streak (that was the zero-timestamp Rehydrate-pruning bug, fixed in v2.128.0).
- Mirrors the pattern already proven in \`handleWaitingCI\`.