### PR TITLE
GH-2718: chore(.agent): add post-mortem note for v2.126-v2.128.2 hand-tag streak

### DIFF
--- a/.agent/system/OPERATIONAL-ISSUES.md
+++ b/.agent/system/OPERATIONAL-ISSUES.md
@@ -53,3 +53,47 @@ Enable `claude_code.disable_navigator_for_epic: true` when:
 
 Leave it off by default — Navigator context materially improves success
 rate on smaller tasks.
+
+## v2.126–v2.128.2 Hand-Tag Streak (5 consecutive releases)
+
+**Symptom**: Auto-release did not fire after merge for v2.126.0, v2.127.0,
+v2.128.0, v2.128.1, and v2.128.2. Each release required manual
+`git tag vX.Y.Z && git push origin vX.Y.Z`.
+
+**Root cause**: `approval_pending` rows were inserted with a zero
+`CreatedAt` timestamp. On daemon restart, `Rehydrate` pruned those rows
+(treated as expired), leaving the in-memory pending map empty. When the
+Telegram user tapped Approve, the handler returned "request not found" and
+the decision was lost — the approval gate never resolved, so the autopilot
+release step stalled.
+
+**Fix**: PR #2694 (shipped in v2.128.0) sets a default `CreatedAt = NOW()`
+and freezes the value on UPSERT so it is never overwritten by a zero.
+
+**Why v2.128.0/1/2 still needed hand-tagging after the fix**: classic
+hot-upgrade bootstrap. The running daemon predated the fix; until it
+self-upgraded and restarted with the new binary, newly inserted rows still
+used the old (zero-timestamp) code path. Once the upgraded daemon was live,
+the first subsequent approval-gated PR should auto-release without
+intervention.
+
+**Latent gaps tracked separately**:
+- Gap 1 — Releaser init from env-scoped config: GH-2716 (fix in v2.128.3)
+- Gap 2 — Blocking post-merge CI: GH-2717 (fix in v2.128.3)
+
+**Smoke-test**: GH-2718 (this doc change) is the third approval-gated PR
+after v2.128.2. Its merge verifies:
+1. `executions.approval_decision` columns now populate (TASK-33 / #2694).
+2. Auto-release fires for v2.129.0 without hand-tagging.
+
+Post-merge, confirm with:
+```sql
+SELECT task_id, approval_request_id, approval_decision, approval_decision_by
+FROM executions WHERE task_id = 'GH-2718';
+-- Expect: all four columns populated
+```
+Then check whether v2.129.0 (or next) tagged automatically.
+
+See also: memory pattern `bug_telegram_approval_callback_unwired.md`
+(resolved v2.121.0→v2.126.0) and memory entry
+`pattern_approval_chat_id_bootstrap.md`.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2718.

Closes #2718

## Changes

GitHub Issue #2718: chore(.agent): add post-mortem note for v2.126-v2.128.2 hand-tag streak

## Context

Add a brief post-mortem entry to \`.agent/system/OPERATIONAL-ISSUES.md\` (or create the file if it doesn't have a section for this) documenting:

- 5 consecutive releases (v2.126.0, v2.127.0, v2.128.0, v2.128.1, v2.128.2) required hand-tagging because auto-release didn't fire after merge.
- Root cause: zero-timestamp \`approval_pending\` rows pruned by \`Rehydrate\` after daemon restart → in-memory pending map empty → user tap returned \"request not found\" → decision lost.
- Fixed by #2694 (v2.128.0): default \`CreatedAt\`, freeze on UPSERT.
- Why v2.128.0/1/2 still needed hand-tagging despite the fix being in main: classic hot-upgrade bootstrap (the running daemon predated the fix; once it hot-upgraded, the next approval-gated PR should auto-release without intervention).
- Latent gaps 1 (releaser init) and 2 (blocking post-merge CI) tracked separately as GH-2716 / GH-2717.

## Acceptance Criteria

- One section/paragraph appended to \`.agent/system/OPERATIONAL-ISSUES.md\` (or create the file).
- Cross-link to the bug pattern memory file (\`.agent/memory/bug_approval_pending_zero_timestamps.md\` if present).
- No code changes.
- This issue serves as the **third smoke-test of the async approval pipeline post-v2.128.2** — its own merge verifies that:
  1. \`executions.approval_decision\` columns now populate (TASK-33)
  2. Auto-release fires without hand-tagging (Gap 4 truly closed)

After merge, verify:

\`\`\`sql
SELECT task_id, approval_request_id, approval_decision, approval_decision_by
FROM executions WHERE task_id = 'GH-NNNN';
-- Expect: all four columns populated
\`\`\`

And check: did v2.129.0 (or whatever) auto-tag, or did it require hand-tagging?

## Out of Scope

- Code changes
- Other ops doc cleanup