### PR TITLE
feat(executor): title auto-rewrite fallback when label heuristic misses

### DIFF
--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -380,6 +380,43 @@ func (g *GitOperations) DeleteBranch(ctx context.Context, branchName string) err
 	return nil
 }
 
+// GitDiff holds numstat output from `git diff --numstat origin/main...HEAD`.
+type GitDiff struct {
+	// Files is the list of changed file paths.
+	Files []string
+	// Added is the total number of inserted lines across all changed files.
+	Added int
+	// Removed is the total number of deleted lines across all changed files.
+	Removed int
+}
+
+// GetDiffStats returns line-level diff statistics between origin/baseBranch and HEAD.
+// Uses three-dot notation so only commits on the current branch are counted.
+func (g *GitOperations) GetDiffStats(ctx context.Context, baseBranch string) (GitDiff, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--numstat", "origin/"+baseBranch+"...HEAD")
+	cmd.Dir = g.projectPath
+	output, err := cmd.Output()
+	if err != nil {
+		return GitDiff{}, fmt.Errorf("git diff --numstat failed: %w", err)
+	}
+
+	var diff GitDiff
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line == "" {
+			continue
+		}
+		var added, removed int
+		var path string
+		if _, scanErr := fmt.Sscanf(line, "%d %d %s", &added, &removed, &path); scanErr != nil {
+			continue
+		}
+		diff.Files = append(diff.Files, path)
+		diff.Added += added
+		diff.Removed += removed
+	}
+	return diff, nil
+}
+
 // RemoteBranchExists checks if a branch exists on the remote (origin).
 // GH-1389: Used to verify if push actually succeeded despite worktree chdir errors.
 func (g *GitOperations) RemoteBranchExists(ctx context.Context, branchName string) bool {

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -25,8 +25,6 @@ import (
 // failures which won't change between retries (e.g. invalid issue title).
 // GH-2402: terminal-classify these so the poller stops the retry loop.
 var permanentFailurePatterns = []string{
-	"title is not a conventional commit",
-	"could not auto-correct",
 	"PR creation refused",
 }
 
@@ -2884,8 +2882,9 @@ The previous execution completed but made no code changes. This task requires ac
 
 			// GH-2325: ensure the subject passed through to the PR (and the squash
 			// commit on main) is a conventional commit. Falls back to a
-			// label-derived prefix; aborts if neither applies.
-			normalizedTitle, titleErr := normalizeTitle(task.Title, task.Labels)
+			// label-derived prefix, then diff heuristic (GH-2735).
+			diffStats, _ := git.GetDiffStats(ctx, baseBranch)
+			normalizedTitle, titleErr := normalizeTitle(task.Title, task.Labels, diffStats)
 			if titleErr != nil {
 				result.Success = false
 				result.Error = fmt.Sprintf("PR creation refused: %v", titleErr)

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3379,7 +3379,8 @@ func TestIsPermanentFailure(t *testing.T) {
 		{"transient network error", "connection refused: dial tcp", false},
 		{"rate limit hit", "rate limit exceeded, retry after 60s", false},
 		{"non-conventional title", "PR creation refused: title is not a conventional commit: 'Implement test thing'", true},
-		{"could not auto-correct title", "title is invalid: could not auto-correct to a conventional commit", true},
+		// GH-2735: "could not auto-correct" removed from permanentFailurePatterns; normalizeTitle now always produces a valid title.
+		{"could not auto-correct title", "title is invalid: could not auto-correct to a conventional commit", false},
 		{"PR creation refused (catch-all)", "PR creation refused: some reason", true},
 		{"random failure", "no_changes: Claude completed but made no code changes", false},
 	}

--- a/internal/executor/subtask_cc_validation_test.go
+++ b/internal/executor/subtask_cc_validation_test.go
@@ -342,10 +342,11 @@ func TestAutoCorrector_Unaffected(t *testing.T) {
 		{"fix(api): handle nil", nil, false, "fix(api):"},
 		{"feat: add login", nil, false, "feat:"},
 		{"Add login feature", []string{"enhancement"}, false, "feat:"},
-		{"this is unrecognizable", nil, true, ""},
+		// GH-2735: diff fallback now produces "chore:" instead of erroring.
+		{"this is unrecognizable", nil, false, "chore:"},
 	}
 	for _, tt := range tests {
-		got, err := normalizeTitle(tt.title, tt.labels)
+		got, err := normalizeTitle(tt.title, tt.labels, GitDiff{})
 		if (err != nil) != tt.wantErr {
 			t.Errorf("normalizeTitle(%q) error = %v, wantErr %v", tt.title, err, tt.wantErr)
 			continue

--- a/internal/executor/title.go
+++ b/internal/executor/title.go
@@ -3,8 +3,10 @@ package executor
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode"
 )
 
 // conventionalCommitRegex matches titles in the form:
@@ -80,19 +82,147 @@ func autoPrefixTitle(title string, labels []string) (string, bool) {
 	return trimmed, false
 }
 
-// normalizeTitle returns a conventional-commit title derived from title and
-// labels. If title already conforms it is returned as-is. Otherwise auto-prefix
-// is attempted from labels. If neither succeeds the result wraps
-// ErrNonConventionalTitle so callers can abort PR creation.
-func normalizeTitle(title string, labels []string) (string, error) {
+// inferConventionalPrefix derives a conventional commit type from file-level
+// diff stats and issue labels. First-match-wins across the priority order
+// defined in the acceptance criteria (GH-2735).
+func inferConventionalPrefix(diff GitDiff, labels []string) string {
+	files := diff.Files
+
+	if len(files) > 0 {
+		if allFilesMatch(files, func(f string) bool {
+			ext := strings.ToLower(filepath.Ext(f))
+			base := strings.ToLower(filepath.Base(f))
+			return ext == ".md" || ext == ".mdx" || base == "readme" || base == "readme.md" || base == "readme.mdx"
+		}) {
+			return "docs"
+		}
+
+		if allFilesMatch(files, func(f string) bool {
+			base := filepath.Base(f)
+			return strings.HasSuffix(base, "_test.go") ||
+				strings.HasSuffix(base, "_test.ts") ||
+				strings.Contains(base, ".test.")
+		}) {
+			return "test"
+		}
+	}
+
+	for _, label := range labels {
+		key := strings.ToLower(strings.TrimSpace(label))
+		if prefix, ok := labelPrefixMap[key]; ok {
+			return prefix
+		}
+	}
+
+	if len(files) > 0 {
+		if allFilesMatch(files, func(f string) bool {
+			return strings.HasPrefix(f, ".github/workflows/") ||
+				strings.HasPrefix(f, ".gitlab-ci") ||
+				f == ".gitlab-ci.yml"
+		}) {
+			return "ci"
+		}
+
+		buildFiles := map[string]bool{
+			"dockerfile": true, "makefile": true, "go.mod": true, "go.sum": true,
+			"package.json": true, "package-lock.json": true,
+		}
+		if allFilesMatch(files, func(f string) bool {
+			return buildFiles[strings.ToLower(filepath.Base(f))]
+		}) {
+			return "build"
+		}
+
+		total := diff.Added + diff.Removed
+		if total > 0 && hasCodeFile(files) {
+			if diff.Added >= 2*diff.Removed {
+				return "feat"
+			}
+			ratio := float64(abs(diff.Added-diff.Removed)) / float64(total)
+			if ratio < 0.2 {
+				return "refactor"
+			}
+		}
+	}
+
+	return "chore"
+}
+
+func allFilesMatch(files []string, pred func(string) bool) bool {
+	if len(files) == 0 {
+		return false
+	}
+	for _, f := range files {
+		if !pred(f) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasCodeFile(files []string) bool {
+	nonCodeExts := map[string]bool{".md": true, ".mdx": true, ".txt": true, ".json": true, ".yaml": true, ".yml": true}
+	for _, f := range files {
+		ext := strings.ToLower(filepath.Ext(f))
+		if !nonCodeExts[ext] {
+			return true
+		}
+	}
+	return false
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+// normalizeTitle returns a conventional-commit title derived from title, labels,
+// and diff stats. If title already conforms it is returned as-is. Otherwise
+// auto-prefix is attempted from labels, then from the diff heuristic.
+// Only errors on empty title.
+func normalizeTitle(title string, labels []string, diff GitDiff) (string, error) {
 	trimmed := strings.TrimSpace(title)
+	if trimmed == "" {
+		return "", fmt.Errorf("%w: empty title", ErrNonConventionalTitle)
+	}
+
+	// Strip leading issue-id prefix (e.g. "GH-2735: ") before trying to normalize.
+	subject := issuePrefixRegex.ReplaceAllString(trimmed, "")
+	// Lowercase first word of subject for consistency.
+	subject = lowercaseFirst(subject)
+	// Truncate to 72 chars.
+	subject = truncateTitle(subject, 72)
+
+	// 1. Already a valid conventional commit — return as-is (preserving original casing/prefix).
 	if err := validatePRTitle(trimmed); err == nil {
 		return trimmed, nil
 	}
-	if prefixed, ok := autoPrefixTitle(trimmed, labels); ok {
+
+	// 2. Label-derived prefix.
+	if prefixed, ok := autoPrefixTitle(subject, labels); ok {
 		if err := validatePRTitle(prefixed); err == nil {
 			return prefixed, nil
 		}
 	}
+
+	// 3. Diff-derived prefix (last-ditch fallback, GH-2735).
+	prefix := inferConventionalPrefix(diff, labels)
+	candidate := prefix + ": " + subject
+	if err := validatePRTitle(candidate); err == nil {
+		return candidate, nil
+	}
+
 	return trimmed, fmt.Errorf("%w: could not auto-correct %q", ErrNonConventionalTitle, truncateTitle(trimmed, 80))
+}
+
+// lowercaseFirst lowercases the first rune of s, leaving the rest unchanged.
+func lowercaseFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	runes := []rune(s)
+	runes[0] = unicode.ToLower(runes[0])
+	return string(runes)
 }

--- a/internal/executor/title_test.go
+++ b/internal/executor/title_test.go
@@ -84,6 +84,7 @@ func TestNormalizeTitle(t *testing.T) {
 		name    string
 		title   string
 		labels  []string
+		diff    GitDiff
 		want    string
 		wantErr bool
 	}{
@@ -105,16 +106,53 @@ func TestNormalizeTitle(t *testing.T) {
 			want:   "feat: add rate limiting",
 		},
 		{
-			name:    "non-conventional with no useful labels aborts",
-			title:   "add rate limiting",
-			labels:  []string{"pilot", "triage"},
-			wantErr: true,
+			name:   "label-miss + diff fallback produces chore",
+			title:  "add rate limiting",
+			labels: []string{"pilot", "triage"},
+			diff:   GitDiff{},
+			want:   "chore: add rate limiting",
 		},
 		{
-			name:    "analysis-style title aborts",
-			title:   `Dispatcher recoverStaleTasks() already marks orphans as "failed"`,
-			labels:  []string{"pilot"},
-			wantErr: true,
+			name:   "diff fallback: all md files → docs",
+			title:  "update README",
+			labels: []string{"pilot"},
+			diff:   GitDiff{Files: []string{"README.md", "docs/guide.md"}},
+			want:   "docs: update README",
+		},
+		{
+			name:   "diff fallback: all test files → test",
+			title:  "add coverage for parser",
+			labels: []string{"pilot"},
+			diff:   GitDiff{Files: []string{"internal/foo/bar_test.go"}},
+			want:   "test: add coverage for parser",
+		},
+		{
+			name:   "diff fallback: ci files → ci",
+			title:  "add lint step",
+			labels: []string{"pilot"},
+			diff:   GitDiff{Files: []string{".github/workflows/ci.yml"}},
+			want:   "ci: add lint step",
+		},
+		{
+			name:   "diff fallback: build files → build",
+			title:  "bump go version",
+			labels: []string{"pilot"},
+			diff:   GitDiff{Files: []string{"go.mod", "go.sum"}},
+			want:   "build: bump go version",
+		},
+		{
+			name:   "diff fallback: large net addition → feat",
+			title:  "add new dashboard widget",
+			labels: []string{"pilot"},
+			diff:   GitDiff{Files: []string{"internal/dashboard/widget.go"}, Added: 200, Removed: 10},
+			want:   "feat: add new dashboard widget",
+		},
+		{
+			name:   "diff fallback: balanced changes → refactor",
+			title:  "reorganise approval flow",
+			labels: []string{"pilot"},
+			diff:   GitDiff{Files: []string{"internal/executor/runner.go"}, Added: 50, Removed: 48},
+			want:   "refactor: reorganise approval flow",
 		},
 		{
 			name:    "empty title aborts",
@@ -126,7 +164,7 @@ func TestNormalizeTitle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := normalizeTitle(tt.title, tt.labels)
+			got, err := normalizeTitle(tt.title, tt.labels, tt.diff)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got %q", got)
@@ -139,7 +177,7 @@ func TestNormalizeTitle(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if got != tt.want {
+			if tt.want != "" && got != tt.want {
 				t.Fatalf("got %q, want %q", got, tt.want)
 			}
 			// Result must itself validate.
@@ -147,6 +185,116 @@ func TestNormalizeTitle(t *testing.T) {
 				t.Fatalf("normalized title failed validation: %v", verr)
 			}
 		})
+	}
+}
+
+func TestInferConventionalPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		diff   GitDiff
+		labels []string
+		want   string
+	}{
+		{
+			name: "all md files → docs",
+			diff: GitDiff{Files: []string{"README.md", "docs/api.md"}},
+			want: "docs",
+		},
+		{
+			name: "mdx files → docs",
+			diff: GitDiff{Files: []string{"docs/index.mdx"}},
+			want: "docs",
+		},
+		{
+			name: "all _test.go → test",
+			diff: GitDiff{Files: []string{"internal/foo/bar_test.go"}},
+			want: "test",
+		},
+		{
+			name: "all .test. files → test",
+			diff: GitDiff{Files: []string{"src/component.test.ts"}},
+			want: "test",
+		},
+		{
+			name:   "label match overrides nothing (md files win first)",
+			diff:   GitDiff{Files: []string{"docs/guide.md"}},
+			labels: []string{"bug"},
+			want:   "docs",
+		},
+		{
+			name:   "label match when no file heuristic hits",
+			diff:   GitDiff{Files: []string{"internal/foo/bar.go", "internal/baz/quux.go"}, Added: 5, Removed: 5},
+			labels: []string{"enhancement"},
+			want:   "feat",
+		},
+		{
+			name: "ci workflow → ci",
+			diff: GitDiff{Files: []string{".github/workflows/test.yml"}},
+			want: "ci",
+		},
+		{
+			name: "gitlab ci → ci",
+			diff: GitDiff{Files: []string{".gitlab-ci.yml"}},
+			want: "ci",
+		},
+		{
+			name: "build files → build",
+			diff: GitDiff{Files: []string{"go.mod", "go.sum"}},
+			want: "build",
+		},
+		{
+			name: "Makefile → build",
+			diff: GitDiff{Files: []string{"Makefile"}},
+			want: "build",
+		},
+		{
+			name: "large net addition with code → feat",
+			diff: GitDiff{Files: []string{"internal/foo/widget.go"}, Added: 100, Removed: 2},
+			want: "feat",
+		},
+		{
+			name: "balanced change with code → refactor",
+			diff: GitDiff{Files: []string{"internal/foo/runner.go"}, Added: 50, Removed: 48},
+			want: "refactor",
+		},
+		{
+			name: "empty diff → chore",
+			diff: GitDiff{},
+			want: "chore",
+		},
+		{
+			name:   "no useful label, no files → chore",
+			diff:   GitDiff{},
+			labels: []string{"pilot"},
+			want:   "chore",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferConventionalPrefix(tt.diff, tt.labels)
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPermanentFailure_TitleStringsNoLongerMatch(t *testing.T) {
+	// GH-2735: these were removed from permanentFailurePatterns because
+	// normalizeTitle now falls back to diff heuristics instead of erroring.
+	removed := []string{
+		"title is not a conventional commit",
+		"could not auto-correct",
+	}
+	for _, s := range removed {
+		if IsPermanentFailure(s) {
+			t.Errorf("IsPermanentFailure(%q) = true; expected false after GH-2735 removal", s)
+		}
+	}
+	// Broader umbrella pattern must still match.
+	if !IsPermanentFailure("PR creation refused: some reason") {
+		t.Error("IsPermanentFailure should still match 'PR creation refused'")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `inferConventionalPrefix(diff GitDiff, labels []string) string` in `internal/executor/title.go` — first-match-wins heuristic across docs/test/label/ci/build/feat/refactor/chore
- `normalizeTitle` now accepts `GitDiff` and uses the diff heuristic as last-ditch fallback; only errors on empty title (never on non-empty)
- Adds `GetDiffStats(ctx, baseBranch) (GitDiff, error)` to `GitOperations` in `internal/executor/git.go`
- Removes `"title is not a conventional commit"` and `"could not auto-correct"` from `permanentFailurePatterns`; `"PR creation refused"` umbrella kept
- Updates call site in `runner.go:2888` to pass diff stats

## Test plan
- [ ] Table-driven `TestInferConventionalPrefix` covers all heuristic branches (docs, test, ci, build, feat, refactor, chore)
- [ ] `TestNormalizeTitle` covers valid passthrough, label-path, label-miss+diff-fallback, empty-title error
- [ ] `TestIsPermanentFailure_TitleStringsNoLongerMatch` regression: title strings no longer trigger permanent failure
- [ ] `TestIsPermanentFailure/could_not_auto-correct_title` updated to expect `false`
- [ ] `TestAutoCorrector_Unaffected` updated: "this is unrecognizable" now produces `chore:` prefix
- [ ] `make test`, `make lint`, `make build` all pass

Closes #2735