### PR TITLE
fix(executor): no-commits-to-PR guard before gh pr create

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1344,6 +1344,16 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						}
 					}
 
+					// GH-2743: no-commits guard for epic PR path.
+					if guardCount, _ := epicGit.CountNewCommits(ctx, baseBranch); guardCount == 0 {
+						r.log.Warn("Epic branch has no commits vs base, skipping PR creation",
+							slog.String("task_id", task.ID),
+							slog.String("base_branch", baseBranch),
+						)
+						r.reportProgress(task.ID, "PR Skipped", 97, "epic branch has no commits relative to base")
+						return epicResult, nil
+					}
+
 					// Create PR with GitHub auto-close keyword
 					epicIssueNum := strings.TrimPrefix(task.ID, "GH-")
 					prBody := fmt.Sprintf("## Summary\n\nAutomated PR created by Pilot for epic task %s.\n\nCloses #%s\n\n## Changes\n\n%s", task.ID, epicIssueNum, task.Description)

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2820,6 +2820,28 @@ The previous execution completed but made no code changes. This task requires ac
 			// Create PR if requested and we have commits
 			r.reportProgress(task.ID, "Creating PR", 96, "Pushing branch...")
 
+			// Determine base branch before the no-commits guard.
+			baseBranch := task.BaseBranch
+			if baseBranch == "" {
+				baseBranch, _ = git.GetDefaultBranch(ctx)
+				if baseBranch == "" {
+					baseBranch = "main"
+				}
+			}
+
+			// GH-2743: pre-CreatePR no-commits guard.
+			// The no-commit check at ~line 2151 only runs when result.Success==true.
+			// If the initial execution fails, that check is bypassed and gh pr create
+			// receives an empty branch, producing "No commits between main and <branch>".
+			if guardCount, _ := git.CountNewCommits(ctx, baseBranch); guardCount == 0 {
+				result.Success = false
+				result.Error = "no_changes: branch has no commits relative to base (PR guard)"
+				if backendResult != nil {
+					backendResult.ErrorType = string(ErrorTypeNoChanges)
+				}
+				r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+				return result, nil
+			}
 
 			// Pre-push lint gate (GH-1376)
 			if r.config != nil && r.config.PrePushLint != nil && *r.config.PrePushLint {
@@ -2870,15 +2892,6 @@ The previous execution completed but made no code changes. This task requires ac
 			}
 
 			r.reportProgress(task.ID, "Creating PR", 98, "Creating pull request...")
-
-			// Determine base branch
-			baseBranch := task.BaseBranch
-			if baseBranch == "" {
-				baseBranch, _ = git.GetDefaultBranch(ctx)
-				if baseBranch == "" {
-					baseBranch = "main"
-				}
-			}
 
 			// GH-2325: ensure the subject passed through to the PR (and the squash
 			// commit on main) is a conventional commit. Falls back to a

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3513,6 +3513,7 @@ func TestRunner_PRCreate_EmptyBranch_TriggersRetry(t *testing.T) {
 	}
 	runner := NewRunnerWithBackend(backend)
 	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
 	runner.config = &BackendConfig{SkipSelfReview: true}
 
 	task := &Task{
@@ -3558,6 +3559,7 @@ func TestRunner_PRCreate_HasCommits_ProceedsToCreate(t *testing.T) {
 	}
 	runner := NewRunnerWithBackend(backend)
 	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
 	runner.config = &BackendConfig{SkipSelfReview: true}
 
 	task := &Task{

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3439,3 +3439,150 @@ func TestRunnerFallbackModelName(t *testing.T) {
 		})
 	}
 }
+
+// mockFixedBackend returns a fixed BackendResult for every Execute call and tracks count.
+type mockFixedBackend struct {
+	mu        sync.Mutex
+	result    *BackendResult
+	execCount int
+}
+
+func (m *mockFixedBackend) Name() string     { return "mock-fixed" }
+func (m *mockFixedBackend) IsAvailable() bool { return true }
+func (m *mockFixedBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.execCount++
+	return m.result, nil
+}
+
+// setupPRGuardRepo creates a temp git repo with an initial commit on main and
+// checks out the given branch. If addCommit is true, one additional commit is
+// added on the branch (simulating real work).
+func setupPRGuardRepo(t *testing.T, branch string, addCommit bool) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir, err := os.MkdirTemp("", "pilot-pr-guard-*")
+	if err != nil {
+		t.Fatalf("setupPRGuardRepo: MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init")
+	run("config", "user.email", "test@pilot.local")
+	run("config", "user.name", "Pilot Test")
+
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("setupPRGuardRepo: WriteFile: %v", err)
+	}
+	run("add", ".")
+	run("commit", "-m", "initial commit")
+	run("checkout", "-b", branch)
+
+	if addCommit {
+		if err := os.WriteFile(filepath.Join(dir, "change.go"), []byte("package main\n"), 0644); err != nil {
+			t.Fatalf("setupPRGuardRepo: WriteFile change.go: %v", err)
+		}
+		run("add", ".")
+		run("commit", "-m", "fix(executor): implement change")
+	}
+	return dir
+}
+
+// TestRunner_PRCreate_EmptyBranch_TriggersRetry verifies that when a branch has
+// no commits relative to base, the no-commit retry path fires and gh pr create is
+// never reached. The backend succeeds but makes no git commits, so the guard at
+// ~line 2151 detects this, retries once, and returns no_changes when still empty.
+func TestRunner_PRCreate_EmptyBranch_TriggersRetry(t *testing.T) {
+	const branch = "pilot/GH-9999"
+	dir := setupPRGuardRepo(t, branch, false) // no additional commits
+
+	// Backend always succeeds but makes no git commits.
+	backend := &mockFixedBackend{
+		result: &BackendResult{Success: true, Output: "analysis complete"},
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	task := &Task{
+		ID:          "GH-9999",
+		Title:       "fix(executor): no-commits guard test",
+		Description: "Verify retry fires on empty branch and CreatePR is not called",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    true,
+	}
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if result.Success {
+		t.Error("Expected failure, got success")
+	}
+	if !strings.HasPrefix(result.Error, "no_changes:") {
+		t.Errorf("Expected no_changes error (retry path), got: %q", result.Error)
+	}
+	// Backend called twice: initial execution + no-commit retry (GH-916).
+	// CreatePR is not called because the retry path returns early.
+	backend.mu.Lock()
+	count := backend.execCount
+	backend.mu.Unlock()
+	if count != 2 {
+		t.Errorf("Expected backend called 2 times (initial + retry), got %d", count)
+	}
+}
+
+// TestRunner_PRCreate_HasCommits_ProceedsToCreate verifies the GH-2743 guard
+// does NOT fire when the branch has commits, allowing PR creation to proceed past
+// the guard. Execution reaches the push step (which fails without a remote),
+// confirming the guard was not the source of failure.
+func TestRunner_PRCreate_HasCommits_ProceedsToCreate(t *testing.T) {
+	const branch = "pilot/GH-9998"
+	dir := setupPRGuardRepo(t, branch, true) // one commit on branch
+
+	// Backend always succeeds; the pre-made commit satisfies the no-commit check.
+	backend := &mockFixedBackend{
+		result: &BackendResult{Success: true, Output: "implementation complete"},
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	task := &Task{
+		ID:          "GH-9998",
+		Title:       "fix(executor): no-commits guard test with commits",
+		Description: "Verify guard passes and execution proceeds toward CreatePR",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    true,
+	}
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if result.Success {
+		t.Error("Expected failure (push has no remote), got success")
+	}
+	// Guard must NOT have fired — error must come from push or PR creation, not the guard.
+	if strings.HasPrefix(result.Error, "no_changes:") {
+		t.Errorf("Guard fired unexpectedly on branch with commits: %q", result.Error)
+	}
+	// Error comes from the push step (no remote configured), proving execution
+	// proceeded past both the no-commit check and the GH-2743 guard.
+	if !strings.HasPrefix(result.Error, "push failed:") {
+		t.Errorf("Expected push failed error (guard passed), got: %q", result.Error)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a pre-CreatePR guard that checks branch commit count before calling `gh pr create`, preventing the `GraphQL: No commits between main and <branch>` failure (~4 of 25 Sonnet 4.6 production failures)
- Adds the same guard to the epic PR creation path (parity fix)
- Fixes CI: adds `skipPreflightChecks = true` to the two new tests so they don't fail on environments without the `claude` binary

## Root Cause (CI failure)

`TestRunner_PRCreate_EmptyBranch_TriggersRetry` and `TestRunner_PRCreate_HasCommits_ProceedsToCreate` call `Execute()`, which runs the `claude_available` preflight check first. In CI (no `claude` binary), this check fails before the guard logic under test is reached.

Fix: set `runner.skipPreflightChecks = true`, consistent with all other `Execute()`-level tests in the file.

## Test plan
- [x] `TestRunner_PRCreate_EmptyBranch_TriggersRetry` — passes locally
- [x] `TestRunner_PRCreate_HasCommits_ProceedsToCreate` — passes locally
- [x] Full `./internal/executor/...` test suite — passes locally