### PR TITLE
feat(executor): DECLINED-with-reason structured output (partial — recovers GH-2753/2754 ghost-close)

### DIFF
--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -158,6 +159,19 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 				execErr = fmt.Errorf("failed waiting for execution: %w", waitErr)
 			} else if exec.Status == "failed" {
 				execErr = fmt.Errorf("execution failed: %s", exec.Error)
+			} else if exec.Status == "declined" {
+				// GH-2754: propagate declined state so adapter handlers can apply
+				// pilot-needs-clarification instead of pilot-failed.
+				declinedReason := strings.TrimPrefix(exec.Error, "declined: ")
+				result = &executor.ExecutionResult{
+					TaskID:         task.ID,
+					Success:        false,
+					Output:         exec.Output,
+					Error:          exec.Error,
+					Declined:       true,
+					DeclinedReason: declinedReason,
+					Duration:       time.Duration(exec.DurationMs) * time.Millisecond,
+				}
 			} else {
 				result = &executor.ExecutionResult{
 					TaskID:    task.ID,

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -380,6 +380,17 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 					logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
 				}
 			}
+		} else if hr.Result != nil && hr.Result.Declined {
+			// GH-2754: model explicitly declined — apply needs-clarification label
+			// instead of pilot-failed so the poller doesn't auto-retry.
+			if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelNeedsClari}); err != nil {
+				logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
+			}
+			syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Failed)
+			comment := fmt.Sprintf("🤔 **Pilot needs clarification**\n\n**Reason**: %s\n\n_The model determined this task cannot be implemented as specified. Please clarify the requirements and remove the `pilot-needs-clarification` label to retry._", hr.Result.DeclinedReason)
+			if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
+				logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
+			}
 		} else if hr.Result != nil {
 			// GH-2363: Title-guard escalation already posted its own structured
 			// comment and added pilot-failed + pilot-title-rejected. Skip the

--- a/internal/adapters/github/notifier.go
+++ b/internal/adapters/github/notifier.go
@@ -129,6 +129,22 @@ func (n *Notifier) NotifyTaskFailed(ctx context.Context, owner, repo string, iss
 	return nil
 }
 
+// NotifyTaskDeclined posts a comment and applies the pilot-needs-clarification
+// label when the model explicitly declined the task as unactionable. GH-2754.
+func (n *Notifier) NotifyTaskDeclined(ctx context.Context, owner, repo string, issueNum int, reason string) error {
+	if err := n.client.RemoveLabel(ctx, owner, repo, issueNum, LabelInProgress); err != nil {
+		_ = err // label may not exist
+	}
+	if err := n.client.AddLabels(ctx, owner, repo, issueNum, []string{LabelNeedsClari}); err != nil {
+		return fmt.Errorf("failed to add needs-clarification label: %w", err)
+	}
+	comment := fmt.Sprintf("🤔 **Pilot needs clarification**\n\n**Reason**: %s\n\n_The model determined this task cannot be implemented as specified. Please clarify the requirements and remove the `pilot-needs-clarification` label to retry._", reason)
+	if _, err := n.client.AddComment(ctx, owner, repo, issueNum, comment); err != nil {
+		return fmt.Errorf("failed to add declined comment: %w", err)
+	}
+	return nil
+}
+
 // LinkPR adds a comment linking the created PR
 func (n *Notifier) LinkPR(ctx context.Context, owner, repo string, issueNum int, prNumber int, prURL string) error {
 	comment := fmt.Sprintf("🔗 **Pull Request Created**: #%d\n\n%s\n\n_This PR implements the changes for this issue._", prNumber, prURL)

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -99,8 +99,9 @@ const (
 	LabelTitleRejected = "pilot-title-rejected" // GH-2363: title guard escalation; blocks auto-retry until human edits title
 	LabelSuperseded    = "pilot-superseded"     // GH-2402: sub-issue auto-closed because parent epic already shipped the work
 	LabelBlocked       = "pilot-blocked"        // GH-2402: deterministic failure that won't change between retries (e.g. non-conventional title)
-	LabelSpecIncomplete = "pilot-spec-incomplete" // GH-2619: issue body too thin to dispatch; first-strike warning
-	LabelSkipSpecCheck  = "pilot-skip-spec-check" // GH-2619: opt-out from spec quality gate (trivial micro-issues)
+	LabelSpecIncomplete = "pilot-spec-incomplete"         // GH-2619: issue body too thin to dispatch; first-strike warning
+	LabelSkipSpecCheck  = "pilot-skip-spec-check"         // GH-2619: opt-out from spec quality gate (trivial micro-issues)
+	LabelNeedsClari     = "pilot-needs-clarification"     // GH-2754: model declined task as unactionable; human must clarify
 
 	// GH-2432: Retry-counter labels persist retry state across `pilot start`
 	// restarts (the in-memory retryReadyCount map was lost on restart, letting

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -67,6 +67,10 @@ const (
 	// a refusal or "task already done" response. The final assistant message holds
 	// the refusal reason. GH-2328.
 	ErrorTypeNoChanges ClaudeCodeErrorType = "no_changes"
+	// ErrorTypeDeclined indicates the model explicitly signalled DECLINED:<reason>
+	// in its output, meaning the task is unactionable and needs clarification.
+	// GH-2754: separates intentional declines from silent no-change failures.
+	ErrorTypeDeclined ClaudeCodeErrorType = "declined"
 	// ErrorTypeUnknown indicates an unclassified error
 	ErrorTypeUnknown ClaudeCodeErrorType = "unknown"
 )

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -484,7 +484,7 @@ func (d *Dispatcher) WaitForExecution(ctx context.Context, execID string, pollIn
 
 			// Check if terminal state
 			switch exec.Status {
-			case "completed", "failed", "cancelled":
+			case "completed", "failed", "cancelled", "declined":
 				return exec, nil
 			}
 		}
@@ -668,16 +668,28 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			// Emit progress callback for task failed
 			w.runner.EmitProgress(exec.TaskID, "Failed", 100, fmt.Sprintf("Execution error: %s", truncateForLog(execErr.Error(), 60)))
 		} else if !result.Success {
-			w.log.Warn("Task completed with failure",
-				slog.String("task_id", exec.TaskID),
-				slog.String("error", result.Error),
-				slog.Duration("duration", duration),
-			)
-			if err := w.store.UpdateExecutionStatus(exec.ID, "failed", result.Error); err != nil {
-				w.log.Error("Failed to update status to failed", slog.Any("error", err))
+			if result.Declined {
+				// GH-2754: model explicitly declined the task as unactionable.
+				w.log.Info("Task declined by model",
+					slog.String("task_id", exec.TaskID),
+					slog.String("reason", result.DeclinedReason),
+					slog.Duration("duration", duration),
+				)
+				if err := w.store.UpdateExecutionStatus(exec.ID, "declined", result.Error); err != nil {
+					w.log.Error("Failed to update status to declined", slog.Any("error", err))
+				}
+				w.runner.EmitProgress(exec.TaskID, "Declined", 100, fmt.Sprintf("Task declined: %s", truncateForLog(result.DeclinedReason, 60)))
+			} else {
+				w.log.Warn("Task completed with failure",
+					slog.String("task_id", exec.TaskID),
+					slog.String("error", result.Error),
+					slog.Duration("duration", duration),
+				)
+				if err := w.store.UpdateExecutionStatus(exec.ID, "failed", result.Error); err != nil {
+					w.log.Error("Failed to update status to failed", slog.Any("error", err))
+				}
+				w.runner.EmitProgress(exec.TaskID, "Failed", 100, fmt.Sprintf("Task failed: %s", truncateForLog(result.Error, 60)))
 			}
-			// Emit progress callback for task failed
-			w.runner.EmitProgress(exec.TaskID, "Failed", 100, fmt.Sprintf("Task failed: %s", truncateForLog(result.Error, 60)))
 		} else {
 			w.log.Info("Task completed successfully",
 				slog.String("task_id", exec.TaskID),

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -42,6 +43,22 @@ func IsPermanentFailure(errStr string) bool {
 		}
 	}
 	return false
+}
+
+// declinedLineRe matches a DECLINED:<reason> marker that the model may emit
+// to signal the task is unactionable. GH-2754.
+var declinedLineRe = regexp.MustCompile(`(?m)^DECLINED:\s*(.+?)\s*$`)
+
+// parseDeclinedReason scans the last 20 lines of text for a DECLINED:<reason>
+// marker. Returns the reason and true when found. The last match wins so the
+// model can revise mid-response.
+func parseDeclinedReason(text string) (string, bool) {
+	matches := declinedLineRe.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return "", false
+	}
+	last := matches[len(matches)-1]
+	return last[1], true
 }
 
 // StreamEvent represents a Claude Code stream-json event
@@ -270,6 +287,12 @@ type ExecutionResult struct {
 	// guard and the runner has already posted a structured "how to fix" comment
 	// (GH-2363). Callers should skip their generic failure-comment path.
 	TitleRejected bool
+	// Declined indicates the model explicitly signalled DECLINED:<reason>,
+	// meaning it judged the task unactionable. Callers should apply the
+	// pilot-needs-clarification label instead of pilot-failed. GH-2754.
+	Declined bool
+	// DeclinedReason is the model-provided explanation from the DECLINED marker.
+	DeclinedReason string
 }
 
 // ProgressCallback is a function called during execution with progress updates.
@@ -2180,18 +2203,32 @@ retrySucceeded:
 				)
 				r.reportProgress(task.ID, "Retry", 91, "No commits detected, retrying...")
 
-				// Build retry prompt with explicit instruction
+				// Build retry prompt with explicit instruction.
+				// GH-2754: offer DECLINED as structured output so the model can
+				// signal unactionable tasks instead of silently producing no commits.
 				retryPrompt := fmt.Sprintf(`## Retry: No Changes Detected
 
-The previous execution completed but made no code changes. This task requires actual implementation.
+The previous execution completed but made no code changes.
 
 **Original Task:** %s
 
-**Instructions:**
-1. Read the task requirements carefully
-2. Implement the required changes
-3. Create at least one commit with your changes
-4. Do NOT just analyze or plan - actually write and commit code
+You have two valid paths:
+
+**Path A — Implement**: If the task is actionable, implement the required changes
+and create at least one commit. Do NOT just analyze or plan — write and commit code.
+
+**Path B — Decline**: If the task is genuinely unactionable (ambiguous, out of scope,
+requires missing context, contradicts existing code, or is already done), end your
+response with EXACTLY this line as the last non-empty line:
+
+    DECLINED: <concise reason in one sentence>
+
+Examples of valid declines:
+- DECLINED: Issue asks to remove a feature that does not exist in this codebase.
+- DECLINED: Requirements are contradictory — cannot both add and remove the cache layer.
+- DECLINED: Task requires credentials not available in this environment.
+
+Do NOT emit DECLINED if the task is implementable, even if difficult.
 
 %s`, task.Title, task.Description)
 
@@ -2245,6 +2282,44 @@ The previous execution completed but made no code changes. This task requires ac
 							refusal = strings.TrimSpace(retryResult.LastAssistantText)
 						}
 					}
+
+					// GH-2754: check for explicit DECLINED marker before falling
+					// back to the generic no_changes failure path.
+					if reason, ok := parseDeclinedReason(refusal); ok {
+						result.Declined = true
+						result.DeclinedReason = reason
+						result.Error = fmt.Sprintf("declined: %s", reason)
+						if backendResult != nil {
+							backendResult.ErrorType = string(ErrorTypeDeclined)
+						}
+						log.Info("Task declined by model",
+							slog.String("task_id", task.ID),
+							slog.String("reason", reason),
+						)
+						r.reportProgress(task.ID, "Declined", 100, fmt.Sprintf("Task declined: %s", reason))
+						r.persistBackendDiagnostics(task.ID, backendResult)
+						r.emitAlertEvent(AlertEvent{
+							Type:      AlertEventTypeTaskFailed,
+							TaskID:    task.ID,
+							TaskTitle: task.Title,
+							Project:   task.ProjectPath,
+							Error:     result.Error,
+							Metadata: map[string]string{
+								"reason":          "declined",
+								"declined_reason": reason,
+							},
+							Timestamp: time.Now(),
+						})
+						if recorder != nil {
+							recorder.SetModel(result.ModelName)
+							recorder.SetNavigator(state.hasNavigator)
+							if finErr := recorder.Finish("declined"); finErr != nil {
+								log.Warn("Failed to finish recording", slog.Any("error", finErr))
+							}
+						}
+						return result, nil
+					}
+
 					if refusal != "" {
 						result.Error = fmt.Sprintf("no_changes: Claude completed but made no code changes after retry — %s", refusal)
 					} else {

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3394,6 +3394,38 @@ func TestIsPermanentFailure(t *testing.T) {
 	}
 }
 
+// TestParseDeclinedReason verifies that parseDeclinedReason correctly
+// extracts DECLINED:<reason> markers from model output. GH-2754.
+func TestParseDeclinedReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		text       string
+		wantReason string
+		wantOK     bool
+	}{
+		{"empty string", "", "", false},
+		{"no marker", "I have implemented the changes and committed them.", "", false},
+		{"marker at end", "Looked at the code.\nDECLINED: Feature does not exist in this codebase.", "Feature does not exist in this codebase.", true},
+		{"marker with extra whitespace", "Some text.\nDECLINED:   trailing spaces   \nmore text", "trailing spaces", true},
+		{"marker mid-text (last wins)", "DECLINED: first reason\nSome implementation.\nDECLINED: revised reason", "revised reason", true},
+		{"partial word not matched", "I declined to do this.", "", false},
+		{"lowercase declined not matched", "declined: not a structured signal", "", false},
+		{"marker alone", "DECLINED: requires credentials not in this environment", "requires credentials not in this environment", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, ok := parseDeclinedReason(tt.text)
+			if ok != tt.wantOK {
+				t.Errorf("parseDeclinedReason(%q) ok = %v, want %v", tt.text, ok, tt.wantOK)
+			}
+			if reason != tt.wantReason {
+				t.Errorf("parseDeclinedReason(%q) reason = %q, want %q", tt.text, reason, tt.wantReason)
+			}
+		})
+	}
+}
+
 // TestRunnerFallbackModelName verifies that the telemetry fallback model name
 // reflects the configured backend, not a hardcoded default. GH-2428.
 func TestRunnerFallbackModelName(t *testing.T) {

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3620,3 +3620,117 @@ func TestRunner_PRCreate_HasCommits_ProceedsToCreate(t *testing.T) {
 		t.Errorf("Expected push failed error (guard passed), got: %q", result.Error)
 	}
 }
+
+// mockSequentialBackend returns results from a slice in order, cycling on the
+// last entry when the list is exhausted. Used to simulate first-exec vs retry.
+type mockSequentialBackend struct {
+	mu      sync.Mutex
+	results []*BackendResult
+	idx     int
+}
+
+func (m *mockSequentialBackend) Name() string      { return "mock-sequential" }
+func (m *mockSequentialBackend) IsAvailable() bool { return true }
+func (m *mockSequentialBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r := m.results[m.idx]
+	if m.idx < len(m.results)-1 {
+		m.idx++
+	}
+	return r, nil
+}
+
+// TestRunner_DECLINED_Path verifies that when the retry backend response contains
+// a DECLINED:<reason> marker, the runner sets result.Declined=true and
+// result.DeclinedReason without falling through to the generic no_changes error.
+// GH-2754.
+func TestRunner_DECLINED_Path(t *testing.T) {
+	const branch = "pilot/GH-7777"
+	dir := setupPRGuardRepo(t, branch, false) // no commits → triggers retry
+
+	const declinedMsg = "DECLINED: Feature does not exist in this codebase."
+	backend := &mockSequentialBackend{
+		results: []*BackendResult{
+			// First call: succeeds but commits nothing.
+			{Success: true, Output: "analysis complete"},
+			// Retry call: model signals decline.
+			{Success: true, Output: "", LastAssistantText: declinedMsg},
+		},
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	task := &Task{
+		ID:          "GH-7777",
+		Title:       "fix(executor): declined path test",
+		Description: "Verify DECLINED marker propagates to result",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    true,
+	}
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Error("Expected result.Success=false on declined task")
+	}
+	if !result.Declined {
+		t.Error("Expected result.Declined=true, got false")
+	}
+	const wantReason = "Feature does not exist in this codebase."
+	if result.DeclinedReason != wantReason {
+		t.Errorf("result.DeclinedReason = %q, want %q", result.DeclinedReason, wantReason)
+	}
+	if !strings.HasPrefix(result.Error, "declined:") {
+		t.Errorf("result.Error should start with 'declined:', got %q", result.Error)
+	}
+}
+
+// TestRunner_NoChanges_NoDecline verifies that when the retry response contains
+// no DECLINED marker, the runner falls through to the generic no_changes error
+// and leaves result.Declined=false. GH-2754.
+func TestRunner_NoChanges_NoDecline(t *testing.T) {
+	const branch = "pilot/GH-7776"
+	dir := setupPRGuardRepo(t, branch, false) // no commits → triggers retry
+
+	backend := &mockSequentialBackend{
+		results: []*BackendResult{
+			// First call: succeeds but commits nothing.
+			{Success: true, Output: "analysis complete"},
+			// Retry call: plain refusal without DECLINED marker.
+			{Success: true, Output: "", LastAssistantText: "I analyzed the code but could not determine what to change."},
+		},
+	}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	task := &Task{
+		ID:          "GH-7776",
+		Title:       "fix(executor): no-decline fallthrough test",
+		Description: "Verify no_changes error when DECLINED marker absent",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    true,
+	}
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Error("Expected result.Success=false on no-changes task")
+	}
+	if result.Declined {
+		t.Error("Expected result.Declined=false when no DECLINED marker present")
+	}
+	if !strings.HasPrefix(result.Error, "no_changes:") {
+		t.Errorf("Expected no_changes error, got %q", result.Error)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1022,7 +1022,7 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 	}
 
 	// Set completed_at for terminal states
-	if status == "completed" || status == "failed" || status == "cancelled" {
+	if status == "completed" || status == "failed" || status == "cancelled" || status == "declined" {
 		return s.withRetry("UpdateExecutionStatus", func() error {
 			_, err := s.db.Exec(`
 				UPDATE executions


### PR DESCRIPTION
## Salvage from ghost-close

Recovers commits stranded in this repo's object DB after Pilot's epic decomposer split GH-2753 → GH-2754 → 3 subtask sessions. Subtasks 1+2 committed locally in a worktree; subtask 3 did not commit; the worktree was cleaned up before push, leaving both issues marked \`pilot-done\` with no PR. See post-mortem in the linked issue.

Closes #2753 (partial — see follow-up below)
Closes #2754

## What this ships (subtasks 1+2)

- \`internal/executor/runner.go\` — \`declinedRegex\` + \`parseDeclinedReason\` helper, retry prompt rewritten to offer implement-or-DECLINED with examples and anti-abuse caveat, \`Declined\`/\`DeclinedReason\` fields on \`ExecutionResult\`, branched post-retry to short-circuit failure escalation when DECLINED is parsed
- \`internal/executor/runner_test.go\` — table-driven \`TestParseDeclinedReason\` + DECLINED-path / no-decline integration tests
- \`internal/executor/backend_claudecode.go\` — \`ErrorTypeDeclined\` constant
- \`internal/executor/dispatcher.go\` — handle declined case in dispatch result
- \`internal/memory/store.go\` — accept \`declined\` as a terminal status
- \`cmd/pilot/handler_common.go\` — reconstruct \`ExecutionResult\` with \`Declined=true\` from dispatcher
- \`cmd/pilot/handlers.go\` — handle declined branch in GitHub issue handler
- \`internal/adapters/github/types.go\` — \`LabelNeedsClari\` constant
- \`internal/adapters/github/notifier.go\` — \`NotifyTaskDeclined\` for label + comment

Stat: +299 / -20 across 9 files. Build, lint, and tests passed in the original worktree.

## What's NOT in this PR (will file as follow-up)

- Poller skip-on-label: \`internal/adapters/github/poller.go\` — \`pilot-needs-clarification\` should join \`pilot-failed\` in the blocking-label set
- Dashboard \`declined\` count alongside \`completed\`/\`failed\`
- One-paragraph docs entry under \`docs/content/features/\`

## Verification

- CI must pass on this branch
- Manual smoke after merge: file an intentionally-ambiguous Pilot issue, expect Sonnet to return \`DECLINED:\` and the issue to receive \`pilot-needs-clarification\` label

## Notes

P3 of the Sonnet success-rate plan (\`~/.claude/plans/use-nav-research-prepare-delegated-dragon.md\`). Prior shipped in this arc: P1 (v2.130.0 title rewrite), P2 (v2.130.1 no-commits guard).

Decomposition behaviour during this run is itself a regression worth investigating — the original GH-2753 explicitly requested single-Pilot-issue + single-AC framing per memory \`bug_decomposer_no_meta_marker.md\` / \`bug_pilot_ghost_closes.md\`.