### PR TITLE
GH-2768: chore(executor): wire DECLINED follow-up — poller skip + dashboard count + docs

### DIFF
--- a/.agent/DEVELOPMENT-README.md
+++ b/.agent/DEVELOPMENT-README.md
@@ -118,7 +118,7 @@ Disable via config: `executor.navigator.auto_init: false`
 
 ## Current State
 
-**Current Version:** v2.130.1 | **322 features working**
+**Current Version:** v2.130.0 | **322 features working**
 
 **Recent (v2.103.0 → v2.103.1, Apr 30 2026):**
 - `feat(dashboard)`: avionics-style TUI redesign — splash boot screen, compact 3-row banner with version/env/model stack/adapter chips, autopilot panel rework with CI/MERGE/RETRY gauges + 5-node pipeline rail (GH-2454, GH-2455, PR #2456 → v2.103.0)

--- a/.agent/tasks/TASK-30-approval-pending-sqlite-persistence.md
+++ b/.agent/tasks/TASK-30-approval-pending-sqlite-persistence.md
@@ -1,0 +1,137 @@
+# TASK-30: Persist pending approval requests in SQLite
+
+**Status:** Planned
+**Priority:** P1 (UX correctness — restarts lose in-flight approvals)
+**Type:** Feature (durability)
+**Effort:** M (~80 LoC + migration + tests)
+
+## Problem
+
+`*approval.TelegramHandler.pending` (`internal/approval/telegram.go:42`) is
+an in-memory `map[string]*pendingRequest` keyed by request ID. When the
+daemon restarts (hot-upgrade or crash):
+
+1. `pending` is empty.
+2. The Telegram message and inline keyboard from before the restart still
+   sit in the user's chat.
+3. User taps Approve / Reject — `HandleCallback` cannot find the request →
+   returns "Request expired or already processed" (the actual message in
+   `approval/telegram.go`).
+4. Stage release that triggered the approval already has its blocking
+   `<-responseCh` orphaned in `manager.requestApproval`; that waits 24h
+   then defaults to `rejected`.
+
+This pairs badly with TASK-29's tactical dispatch fix: now taps reach the
+handler — but only for the current process lifetime. Hot-upgrades happen
+routinely (every release).
+
+## Fix Shape
+
+Add an `approval_pending` table to the SQLite store; persist on
+`SendApprovalRequest`, delete on decision/cancel/timeout; rehydrate the
+`pending` map on `NewTelegramHandler` startup.
+
+### Schema (new migration)
+
+```sql
+CREATE TABLE IF NOT EXISTS approval_pending (
+    request_id    TEXT PRIMARY KEY,
+    pr_number     INTEGER NOT NULL,
+    repo          TEXT NOT NULL,
+    stage         TEXT NOT NULL,
+    chat_id       TEXT NOT NULL,
+    message_id    INTEGER NOT NULL,
+    approvers     TEXT NOT NULL,         -- JSON array of approver IDs
+    requested_by  TEXT,
+    metadata      TEXT,                  -- JSON blob (Request.Metadata)
+    expires_at    INTEGER NOT NULL,      -- unix seconds
+    created_at    INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_approval_pending_expires ON approval_pending(expires_at);
+```
+
+Place migration in whichever migration mechanism `internal/memory/store.go`
+uses (verify pattern from existing tables). Use Go-side migration if no
+formal migrator exists.
+
+### Code changes
+
+**1. `internal/memory/store.go`** (or new `approval_store.go`)
+- `InsertPendingApproval(ctx, p PendingApproval) error`
+- `DeletePendingApproval(ctx, requestID string) error`
+- `LoadPendingApprovals(ctx) ([]PendingApproval, error)` — used at startup
+- `PrunePendingApprovals(ctx, before time.Time) (int, error)` — drops expired rows; called periodically
+
+**2. `internal/approval/telegram.go`**
+- Add optional `store PendingApprovalStore` interface field to `TelegramHandler`:
+  ```go
+  type PendingApprovalStore interface {
+      InsertPendingApproval(ctx context.Context, p PendingApproval) error
+      DeletePendingApproval(ctx context.Context, requestID string) error
+      LoadPendingApprovals(ctx context.Context) ([]PendingApproval, error)
+  }
+  ```
+- `NewTelegramHandler(client, chatID)` keeps existing signature; add
+  `WithStore(store PendingApprovalStore)` builder method to keep the
+  constructor backward-compatible.
+- In `SendApprovalRequest`: after inserting into `pending` map, also
+  `store.InsertPendingApproval` (best-effort; log on error, don't fail
+  the request).
+- In `HandleCallback` decision branch: `store.DeletePendingApproval`
+  alongside `delete(h.pending, ...)`.
+- In `CancelRequest`: same delete-from-store.
+- Add `Rehydrate(ctx)` method called once at startup: loads rows,
+  populates `pending` map. Skip rows where `expires_at < now` (caller
+  prunes those).
+- Note: response channels on rehydrated requests must be reconstructed —
+  there is no caller blocking on them post-restart, so the channel can be
+  a buffered channel that nobody reads. This is the bridge to TASK-31
+  (callback-driven stage advance) which removes the blocker entirely.
+
+**3. `cmd/pilot/main.go`**
+- Both construction sites (`:423`, `:1304`):
+  ```go
+  tgApprovalHandler := approval.NewTelegramHandler(...).WithStore(memoryStore)
+  if err := tgApprovalHandler.Rehydrate(ctx); err != nil {
+      logger.Warn("approval rehydrate failed", "err", err)
+  }
+  ```
+
+### Tests
+
+- `TestTelegramHandler_PersistsOnSend` — `SendApprovalRequest` calls `InsertPendingApproval`
+- `TestTelegramHandler_DeletesOnApprove` / `OnReject` / `OnCancel`
+- `TestTelegramHandler_Rehydrate_RestoresPending` — preload store, construct handler, verify `pending` populated, `HandleCallback` succeeds for restored entry
+- `TestTelegramHandler_Rehydrate_SkipsExpired` — past expiry rows ignored
+- Store layer: insert/delete/load round-trip + prune
+
+### Verification
+
+- `go test ./internal/memory/... ./internal/approval/...`
+- `go build ./...`
+- Manual smoke: trigger approval → hot-upgrade daemon → tap button → PR advances (currently fails post-restart with "Request expired")
+
+## Out of scope
+
+- Callback-driven stage advance (separate task): see TASK-31.
+- Slack/GitHub handler persistence — file as further follow-ups if needed.
+
+## Acceptance Criteria
+
+- [ ] `approval_pending` table created via migration
+- [ ] `SendApprovalRequest` persists row
+- [ ] Decision / cancel deletes row
+- [ ] `Rehydrate` repopulates `pending` map at startup; skips expired
+- [ ] After daemon restart, tap on pre-restart Telegram message succeeds
+- [ ] `WithStore` is optional — handler still works without it (in-memory only)
+- [ ] Tests cover persist / delete / rehydrate / expired-skip
+- [ ] `go build ./...` + `go vet ./...` clean
+- [ ] Conventional PR title: `feat(approval): persist pending approvals in SQLite (GH-NNNN)`
+
+## References
+
+- `internal/approval/telegram.go:38-150` — `TelegramHandler` shape
+- `internal/approval/manager.go:205-213` — blocking `<-responseCh` (will be replaced in TASK-31)
+- Memory: `bug_telegram_approval_callback_unwired.md` § "Outstanding follow-ups"
+- TASK-29 (archived) — tactical dispatch fix that this depends on

--- a/.agent/tasks/TASK-31-approval-callback-driven-stage-advance.md
+++ b/.agent/tasks/TASK-31-approval-callback-driven-stage-advance.md
@@ -1,0 +1,144 @@
+# TASK-31: Replace blocking approval receive with callback-driven stage advance
+
+**Status:** Planned (depends on TASK-30 landing first)
+**Priority:** P1 (queue starvation under stalled approvals)
+**Type:** Architectural refactor
+**Effort:** L (~150-250 LoC + careful tests)
+
+## Problem
+
+`internal/approval/manager.go:requestApproval` returns a `<-chan *Response`,
+and the caller (`autopilot/controller.go:handleAwaitApproval`) does
+`<-responseCh` — a hard block up to the configured timeout (24h default).
+
+`processAllPRs` (`controller.go:2059-2114`) is a sequential `for _, pr :=
+range prs` loop. Every other PR — earlier-stage, post-merge, anything —
+waits behind the blocked one. A single user who doesn't tap the approval
+button starves the entire queue for 24h.
+
+The intended UX is asynchronous: approval message goes out → user taps
+sometime later → that tap should drive the stage forward independently of
+the controller loop's cadence.
+
+## Fix Shape
+
+Make approval truly asynchronous: persist decision into PR state on tap;
+have the controller's normal tick check `await_approval` PRs against PR
+state and advance when a decision is recorded. Remove the blocking
+receive.
+
+### Design
+
+**State machine addition** — PR state already has stage tracking; add:
+- `approval_request_id` (the request submitted)
+- `approval_decision` (pending|approved|rejected|expired)
+- `approval_decision_at` (timestamp)
+- `approval_decision_by` (user ID)
+
+**Two paths converge into the controller tick:**
+
+1. **Submission path** (`handleAwaitApproval`):
+   - If PR has no `approval_request_id` yet → call
+     `manager.SubmitApprovalRequest(...)` (new, non-blocking; returns
+     `requestID`, no channel) → store on PR state → return
+     `StageAwait` (stay in stage, controller will recheck next tick).
+   - If PR has `approval_request_id` and decision is still `pending` →
+     check expiry; if expired, mark `expired` and apply `default_action`.
+     Otherwise return `StageAwait`.
+   - If decision is `approved` → advance stage. If `rejected`/`expired`
+     w/ default_action=reject → close/abort PR per existing logic.
+
+2. **Decision path** (`approval.TelegramHandler.HandleCallback` and Slack/GitHub equivalents):
+   - On approve / reject tap → manager looks up the request, writes the
+     decision into PR state via injected `PRStateWriter` interface, then
+     deletes from pending. **No channel send.** Returns immediately.
+
+**Manager interface change:**
+```go
+type PRStateWriter interface {
+    SetApprovalDecision(ctx context.Context, requestID string, d Decision, by string) error
+}
+```
+Inject into `Manager` at construction. Each handler is given a callback
+that the manager wires up, OR each handler calls back into the manager
+which routes to the writer.
+
+**Backward-compat note:** drop the `<-chan *Response` API entirely; no
+external consumers besides controller. Single-PR migration.
+
+### Code changes
+
+**1. `internal/autopilot/state.go`** (or wherever PR state lives)
+- Add fields to PR state struct + persistence
+- Add `SetApprovalDecision` method on the store
+
+**2. `internal/approval/manager.go`**
+- Replace `RequestApproval(ctx, req) (<-chan *Response, error)` with
+  `SubmitApprovalRequest(ctx, req) (requestID string, error)`
+- Replace internal handler dispatch to use new non-blocking signature on handlers
+- Add `RecordDecision(ctx, requestID, decision, by)` — handlers call this
+  on tap; manager writes via injected `PRStateWriter`
+
+**3. `internal/approval/telegram.go` / `slack.go` / `github.go`**
+- `HandleCallback` (and Slack/GH equivalents) → on decision call
+  `manager.RecordDecision(ctx, requestID, decision, userID)` instead of
+  pushing to a channel.
+
+**4. `internal/autopilot/controller.go`**
+- `handleAwaitApproval` becomes non-blocking — the two-path logic above.
+- Remove `<-responseCh` and timeout select.
+- Approval timeout is now checked at tick time against
+  `approval_decision_at == 0 && now - request_at > timeout`; controller
+  applies `default_action`.
+
+### Tests
+
+- `TestController_AwaitApproval_StaysInStageUntilDecision` — first tick
+  submits, second tick (no decision) stays, third tick (after manual
+  decision write) advances.
+- `TestManager_RecordDecision_WritesToState` — stub writer, verify call.
+- `TestController_AwaitApproval_AppliesDefaultActionAtTimeout`
+- `TestController_QueueNotStarved` — two PRs both at await_approval; one
+  gets a decision, the other waits; verify the decided PR advances on the
+  next tick without the second blocking it. (The whole point.)
+- Migration tests for state schema additions.
+
+### Migration / rollout
+
+- This is a single load-bearing change to a critical path (release
+  pipeline). Strongly prefer:
+  - Land behind a config flag `approval.async_dispatch: true` (default
+    `true` after a release of bake time).
+  - Keep both code paths for one release cycle, then remove the blocking
+    path.
+- Coordinate with TASK-30 landing first so persisted approvals exist for
+  rehydration on restart — without TASK-30, an in-flight async approval
+  is lost on restart and PR sits indefinitely. (TASK-30 is the safety net.)
+
+### Verification
+
+- All existing approval tests pass under new manager surface.
+- Manual smoke: open two stage releases simultaneously → tap approve on
+  the second one → it advances while the first still waits → tap approve
+  on the first → it advances. (Currently impossible.)
+- 24h timeout still applied via tick-time check.
+
+## Acceptance Criteria
+
+- [ ] `Manager.RequestApproval` channel API removed; `SubmitApprovalRequest` + `RecordDecision` in place
+- [ ] `handleAwaitApproval` non-blocking; PR stays in `await_approval` stage until state shows decision
+- [ ] Telegram, Slack, GitHub handlers all call `manager.RecordDecision` on tap
+- [ ] Approval timeout enforced at tick time, not via blocking select
+- [ ] Two-PR queue test: stalled approval on one PR does NOT block the other
+- [ ] All existing approval tests updated and green
+- [ ] `go build ./...` + `go vet ./...` clean
+- [ ] Conventional PR title: `refactor(approval): callback-driven stage advance, remove blocking receive (GH-NNNN)`
+
+## References
+
+- `internal/approval/manager.go:205-213` — current blocking `<-responseCh`
+- `internal/autopilot/controller.go:2059-2114` — sequential `processAllPRs`
+- `internal/autopilot/controller.go:handleAwaitApproval` — current blocking caller
+- TASK-29 (archived) — dispatch wiring this depends on
+- TASK-30 — SQLite persistence (recommended to land first)
+- Memory: `bug_telegram_approval_callback_unwired.md` § "Outstanding follow-ups"

--- a/.agent/tasks/TASK-32-docs-async-approval-diagram.md
+++ b/.agent/tasks/TASK-32-docs-async-approval-diagram.md
@@ -1,0 +1,143 @@
+# TASK-32: Docs — Async Approval Flow + Mermaid Diagram
+
+**Status**: 🚧 In Progress
+**Created**: 2026-05-05
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**:
+The async pre-merge approval pipeline shipped in v2.121.0–v2.128.0 (TASK-26 through TASK-31) is fully working end-to-end (verified live via PR #2702 smoke-test on 2026-05-05). However, `docs/content/features/approval-workflows.mdx` (241 lines) does not yet describe:
+- The async dispatch path (Manager.SubmitApprovalRequest → Telegram callback → RecordDecision → PRStateWriter → controller advance)
+- Daemon-restart resilience (approval_pending SQLite table rehydrates on startup)
+- The `approval.async_dispatch` config knob (default true in v2.125+)
+
+Users reading the docs see only the legacy synchronous behavior.
+
+**Goal**:
+Update `approval-workflows.mdx` with a new section that documents the async flow and includes a Mermaid sequence diagram. Cross-link from `features/telegram.mdx`.
+
+**Success Criteria**:
+- [ ] New "How async approval works" section in `approval-workflows.mdx`
+- [ ] Mermaid sequence diagram renders in Nextra v4 build
+- [ ] `approval.async_dispatch` config knob documented
+- [ ] Daemon-restart resilience explained (approval_pending table)
+- [ ] One-line "see also" link added to `features/telegram.mdx`
+- [ ] `cd docs && pnpm build` succeeds without errors
+- [ ] No behavior change (docs only)
+
+---
+
+## Implementation Plan
+
+### Phase 1: Add async-flow section with Mermaid diagram
+**Goal**: Document the v2.121–v2.128 pipeline visually.
+
+**Tasks**:
+- [ ] Insert new section in `docs/content/features/approval-workflows.mdx` (placement: after the existing pre-merge section, before the FAQ/troubleshooting if any)
+- [ ] Mermaid sequence diagram covering:
+  - Controller → `Manager.SubmitApprovalRequest(ctx, req)` returns request ID immediately
+  - Manager dispatches Telegram message with `approve:<id>` / `reject:<id>` callback_data buttons
+  - User taps button → `tgApprovalHandler.HandleCallback` parses prefix
+  - Handler calls `Manager.RecordDecision(id, decision, by)`
+  - `RecordDecision` → `PRStateWriter.SetApprovalDecision` writes `executions.approval_decision`
+  - On next controller tick, `controller.handleAwaitApproval` reads `prState.ApprovalDecision`, advances stage
+  - Merge → tag → release pipeline
+- [ ] Prose surrounding the diagram explaining each step in 1-2 sentences
+
+**Files**:
+- `docs/content/features/approval-workflows.mdx` — new section + diagram
+
+### Phase 2: Daemon-restart resilience callout
+**Goal**: Explain why taps survive a daemon restart.
+
+**Tasks**:
+- [ ] Subsection or callout box noting:
+  - `approval_pending` SQLite table persists pending requests across restarts (v2.122)
+  - On startup, the daemon rehydrates the in-memory map from this table (v2.123)
+  - Result: an Approve tap lands correctly even if the daemon was restarted between the prompt and the tap
+
+**Files**:
+- `docs/content/features/approval-workflows.mdx`
+
+### Phase 3: Config documentation
+**Goal**: Surface the `approval.async_dispatch` knob.
+
+**Tasks**:
+- [ ] Document `approval.async_dispatch` (bool, default `true` since v2.125)
+- [ ] Note that the legacy blocking path (`Manager.RequestApproval` channel) is preserved for one release of bake time, then will be removed (TASK-31 follow-up)
+
+**Files**:
+- `docs/content/features/approval-workflows.mdx`
+
+### Phase 4: Cross-link from telegram.mdx
+**Goal**: Discoverability from the Telegram adapter page.
+
+**Tasks**:
+- [ ] Add a one-line "See also" pointing to the new approval-workflows section, somewhere near the existing approval/callback content in `docs/content/features/telegram.mdx`
+
+**Files**:
+- `docs/content/features/telegram.mdx`
+
+---
+
+## Technical Decisions
+
+| Decision | Options Considered | Chosen | Reasoning |
+|----------|-------------------|--------|-----------|
+| Diagram format | Mermaid, ASCII art, image | Mermaid | Nextra v4 supports it natively; renders cleanly; editable in plain markdown |
+| Diagram type | sequenceDiagram, flowchart | sequenceDiagram | Async approval is inherently temporal (ordered actor messages); sequence is the natural fit |
+| Page placement | New page vs append to existing | Append section | Single discoverable doc avoids fragmentation; existing page already has 241 lines of relevant context |
+| Legacy path mention | Hide vs document as deprecated | Document with deprecation note | Honest about transition; user-visible config (`async_dispatch`) requires it |
+
+---
+
+## Dependencies
+
+**Requires**:
+- [x] Async approval pipeline merged (TASK-26 → TASK-31, all done as of v2.128.0)
+- [x] Smoke-test verification (PR #2702, 2026-05-05)
+
+**Blocks**:
+- Future cleanup PR removing legacy `RequestApproval` path (will reference these docs)
+
+---
+
+## Verify
+
+```bash
+cd docs
+pnpm install
+pnpm build
+# Expected: build succeeds, no Mermaid render errors, new section visible in output
+```
+
+Manual verification:
+- Inspect built HTML for Mermaid diagram presence
+- Cross-check that all named symbols (SubmitApprovalRequest, RecordDecision, PRStateWriter, etc.) match current code in `internal/approval/manager.go` and `internal/autopilot/state/`
+
+---
+
+## Done
+
+- [ ] `approval-workflows.mdx` contains "How async approval works" section
+- [ ] Mermaid `sequenceDiagram` block renders without errors
+- [ ] `approval.async_dispatch` config knob documented
+- [ ] Daemon-restart resilience subsection present
+- [ ] `telegram.mdx` cross-link added
+- [ ] `cd docs && pnpm build` succeeds
+- [ ] PR opened, CI green, approved, merged, released
+
+---
+
+## Notes
+
+- Public docs site: Nextra v4 at `pilot.quantflow.studio` (per CLAUDE.md, this is authoritative for product behavior)
+- Docs deploy pipeline: `v*` tag → docs-version-sync → GitLab `prod-*` (see `.agent/memory/reference_docs_deploy_pipeline.md`)
+- This task exercises the docs-deploy pipeline as a side effect, providing additional validation beyond the Go-only PR #2702.
+
+---
+
+**Last Updated**: 2026-05-05

--- a/.agent/tasks/TASK-33-approval-decision-executions-persist.md
+++ b/.agent/tasks/TASK-33-approval-decision-executions-persist.md
@@ -1,0 +1,153 @@
+# TASK-33: Persist Approval Decision to executions Table
+
+**Status**: 🚧 In Progress
+**Created**: 2026-05-06
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**:
+The `executions` table has columns for approval persistence (added v2.124.0):
+- `approval_request_id` (line 437 of `internal/memory/store.go` — bound during INSERT only)
+- `approval_decision`, `approval_decision_at`, `approval_decision_by` (updated by `Store.SetApprovalDecision`, line 553)
+
+**These columns are never populated for any execution.** Live verification on 2026-05-06:
+
+```sql
+SELECT count(*) FROM executions
+WHERE approval_request_id != '' OR approval_decision != '';
+-- 0 rows (out of all-time executions)
+```
+
+Two missing wires cause this:
+
+1. **`approval_request_id` is never written to the execution row.** The execution row is INSERTed when Pilot picks up the issue, *before* the approval flow runs. Nothing UPDATEs `executions.approval_request_id` after `SubmitApprovalRequest` returns its ID. So even if the writer fired, `Store.SetApprovalDecision`'s `WHERE approval_request_id = ?` matches zero rows.
+
+2. **`Controller.SetApprovalDecision` (the `PRStateWriter` impl, `controller.go:1119-1143`) does not call `Store.SetApprovalDecision`.** It updates the in-memory `pr.ApprovalDecision` and saves PRState via `stateStore.SavePRState(pr)`, but never touches the `executions` table.
+
+**Concrete impact (verified 2026-05-06):**
+- Smoke-test PRs #2702 (GH-2700) and #2704 (GH-2703) both merged successfully via the async approval flow. Both `executions.approval_decision` columns remain empty.
+- Releases for both did NOT auto-fire — v2.128.1 had to be hand-tagged. Likely root cause: any release-trigger consumer keying off persisted decision sees nothing was decided. (To confirm during implementation.)
+- Dashboards / audits / restart-resilience scenarios that re-read SQLite see no record of approvals.
+
+**Goal**:
+Wire both missing connections so that:
+1. After `SubmitApprovalRequest` succeeds, the request ID is persisted to the corresponding `executions.approval_request_id` row.
+2. `Controller.SetApprovalDecision` (and `MultiControllerStateWriter.SetApprovalDecision`) also calls `Store.SetApprovalDecision` so `approval_decision`, `approval_decision_at`, `approval_decision_by` get populated.
+
+**Success Criteria**:
+- [ ] After a smoke-test PR completes the approval flow, `SELECT * FROM executions WHERE task_id = '<id>'` shows non-empty `approval_request_id`, `approval_decision`, `approval_decision_at`, `approval_decision_by`.
+- [ ] Existing tests still pass (`make test`).
+- [ ] No regression in approval flow timing (still non-blocking).
+- [ ] No new cross-package import cycles.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Persist `approval_request_id` after SubmitApprovalRequest
+**Goal**: Make `executions.approval_request_id` discoverable for later UPDATEs.
+
+**Tasks**:
+- [ ] Add `Store.SetApprovalRequestID(ctx, taskID, requestID string) error` in `internal/memory/store.go`. Uses `withRetry` pattern. Updates the most recent non-completed (or most recent overall — TBD) `executions` row matching `task_id = ?` and `approval_request_id = ''`.
+- [ ] In `Controller` or `approval.Manager` (decide which), call `SetApprovalRequestID(taskID, requestID)` immediately after `SubmitApprovalRequest` returns successfully. The task ID is already in `req.TaskID`. Plumbing: prefer the call site in `controller.go:1038` (`requestID, err := c.approvalMgr.SubmitApprovalRequest(ctx, req)` — `c` already owns or can own the memory store).
+
+**Files**:
+- `internal/memory/store.go` — new `SetApprovalRequestID` method
+- `internal/autopilot/controller.go` — call site after line 1038
+- (Optional) `internal/autopilot/controller.go` — Controller may need a new optional `memoryStore` field; thread it via a `WithMemoryStore` `ControllerOption` to keep the constructor stable.
+- `internal/memory/store_test.go` — unit test for the new method (matching existing patterns)
+- `cmd/pilot/...` — wire memory store into the controller at startup (verify no new circular deps)
+
+### Phase 2: Persist decision in Controller.SetApprovalDecision
+**Goal**: When the writer fires, also UPDATE the executions table.
+
+**Tasks**:
+- [ ] In `Controller.SetApprovalDecision` (`controller.go:1119`), after the in-memory update succeeds, call `c.memoryStore.SetApprovalDecision(ctx, requestID, decision, by)` if `memoryStore != nil`. Treat `sql.ErrNoRows` as a warning (log + continue) rather than a hard error — keeps the in-memory path resilient if Phase 1 missed a row.
+- [ ] Same wiring in `MultiControllerStateWriter.SetApprovalDecision` (`controller.go:2395-2401`) IF that path is the one Manager uses; otherwise just the per-Controller path is fine.
+
+**Files**:
+- `internal/autopilot/controller.go` — modify `SetApprovalDecision`
+- `internal/autopilot/controller_test.go` — extend or add test asserting Store call
+
+### Phase 3: Verification & Tests
+**Goal**: Lock in the fix with tests; verify against running daemon.
+
+**Tasks**:
+- [ ] Unit test: feed a fake `*memory.Store` to a Controller, call `SetApprovalDecision`, assert the row in executions is updated.
+- [ ] Integration test (if existing patterns support it): full path from `SubmitApprovalRequest` → simulated tap → `RecordDecision` → both in-memory PRState and SQLite row updated.
+- [ ] After merge, repeat live smoke-test (file a tiny Pilot issue, watch SQLite columns populate after approval tap).
+
+**Files**:
+- `internal/autopilot/controller_test.go`
+- `internal/memory/store_test.go`
+
+---
+
+## Technical Decisions
+
+| Decision | Options Considered | Chosen | Reasoning |
+|----------|-------------------|--------|-----------|
+| Where to call `SetApprovalRequestID` | (A) Inside `approval.Manager.SubmitApprovalRequest`; (B) at the controller call site after the function returns | **B** | Manager package shouldn't depend on `memory` (clean layering). Controller already owns autopilot orchestration and is the natural seam. |
+| Where `Controller` gets `memoryStore` | (A) New field + ControllerOption; (B) Pass on every call; (C) Re-use existing `stateStore` as composite | **A** | Keeps PRState persistence (`stateStore`) and execution persistence (`memoryStore`) separate concerns. Optional via Option pattern preserves backward compat. |
+| Failure behavior on no matching row | Hard error vs warning | Warning + continue | In-memory path is the source of truth for the merge decision. SQLite persistence is for audits and downstream consumers; a missed row shouldn't deadlock the merge. |
+| Update `request_id` for: most-recent row vs. all matching rows | most-recent vs broad | Most recent non-completed match | Multiple historic execution rows for the same `task_id` exist (retries, reruns); only the active one should be tagged. |
+
+---
+
+## Dependencies
+
+**Requires**:
+- [x] v2.124.0 columns already in schema
+- [x] v2.121–v2.128 async dispatch chain working in-memory
+
+**Blocks**:
+- Reliable post-merge auto-release (likely depends on persisted decision; will validate during implementation)
+- Restart-resilience audits / dashboards reading approval state
+
+---
+
+## Verify
+
+```bash
+# Unit + integration tests
+make test ./internal/autopilot/... ./internal/memory/...
+
+# Lint
+make lint
+
+# Build
+make build
+
+# After deploy: live verify
+# 1. File a tiny Pilot issue
+# 2. Tap Approve in TG when prompted
+# 3. sqlite3 ~/.pilot/data/pilot.db \
+#      "SELECT task_id, approval_request_id, approval_decision, approval_decision_by \
+#       FROM executions WHERE task_id = 'GH-NNN';"
+#    Expect: all four columns populated
+```
+
+---
+
+## Done
+
+- [ ] `executions.approval_request_id` is populated after `SubmitApprovalRequest` for the active execution row
+- [ ] `executions.approval_decision`, `_at`, `_by` are populated after `RecordDecision` fires
+- [ ] Unit tests cover both wires
+- [ ] No regression in approval flow latency or merge correctness
+- [ ] PR opened, CI green, approved, merged, released
+
+---
+
+## Notes
+
+- v2.128.1 was the third hand-tagged release this week (after v2.126/127/128). If this fix unblocks auto-release, it eliminates a recurring operational burden.
+- Per memory `pattern_hot_upgrade_bootstrap.md`: the persistence fixes via hot upgrade trigger their own bug once. Be aware that the first PR merging this fix may itself need hand-tagging because the running daemon predates the fix.
+- This task is the natural follow-up to TASK-29/30/31 (the trifecta). Together, they make the async approval pipeline fully observable.
+
+---
+
+**Last Updated**: 2026-05-06

--- a/.agent/tasks/TASK-34-releaser-from-resolved-release.md
+++ b/.agent/tasks/TASK-34-releaser-from-resolved-release.md
@@ -1,0 +1,76 @@
+# TASK-34: Initialize Releaser from `resolvedRelease()` (Gap 1)
+
+**Status**: 🚧 In Progress
+**Created**: 2026-05-06
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**:
+At `internal/autopilot/controller.go:197-199`, the `Releaser` is constructed from the global `cfg.Release` only:
+
+```go
+if cfg.Release != nil && cfg.Release.Enabled {
+    c.releaser = NewReleaser(ghClient, owner, repo, cfg.Release)
+}
+```
+
+But at runtime, `resolvedRelease()` (line 1547-1551) prefers `env.Release` over global. If a user ever sets release config ONLY under `environments.<env>.release` and removes the global `release:` block, `shouldTriggerRelease()` returns `true` (resolves env config) but `c.releaser == nil` (initialized from absent global). `handleReleasing` then returns early at line 1524 ("releaser not configured, skipping release") and the release never fires — silently.
+
+Today, `~/.pilot/config.yaml` has both global and env-scoped release blocks with identical content, so the latent bug is masked.
+
+**Goal**:
+Initialize `c.releaser` from `resolvedRelease()` so the construction path matches the runtime decision path.
+
+**Success Criteria**:
+- [ ] `c.releaser` is non-nil when EITHER global `cfg.Release` or `env.Release` is enabled
+- [ ] If both are set, the env-scoped one wins (matches `resolvedRelease()` semantics)
+- [ ] No regression in existing tests
+- [ ] New test case covering the env-only-release scenario
+
+---
+
+## Implementation Plan
+
+### Phase 1: Refactor releaser initialization
+**Tasks**:
+- [ ] At `controller.go:197`, replace the direct `cfg.Release` check with a call that mirrors `resolvedRelease()`. Construction is in `NewController`, before the Controller struct is populated, so a small inline helper or duplicating the resolve logic is fine.
+- [ ] Ensure resolution uses `cfg.ResolvedEnv()` to get the env block, falls back to global.
+
+**Files**:
+- `internal/autopilot/controller.go` — modify NewController
+
+### Phase 2: Test
+**Tasks**:
+- [ ] Add table-driven test in `controller_test.go` covering: global only, env only, both set, neither set.
+
+**Files**:
+- `internal/autopilot/controller_test.go`
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|----------|---------|--------|-----------|
+| Resolution helper | Inline duplicate / extract package func / call cfg method | Extract or reuse cfg-level helper if one exists | DRY; resolvedRelease is currently a Controller method using c.config — refactor to a Config method or a free function so it works pre-Controller |
+
+---
+
+## Verify
+
+```bash
+make test ./internal/autopilot/...
+make lint
+```
+
+---
+
+## Done
+
+- [ ] `Releaser` initialized from resolved (env || global) release config
+- [ ] Tests cover all 4 combinations
+- [ ] No regression
+EOF

--- a/.agent/tasks/TASK-35-nonblocking-post-merge-ci.md
+++ b/.agent/tasks/TASK-35-nonblocking-post-merge-ci.md
@@ -1,0 +1,73 @@
+# TASK-35: Non-Blocking handlePostMergeCI (Gap 2)
+
+**Status**: 🚧 In Progress
+**Created**: 2026-05-06
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**:
+`handlePostMergeCI` calls `ciMonitor.WaitForCI(ctx, mainSHA)` which polls in a loop for up to 30 minutes (`internal/autopilot/ci_monitor.go:93-121`). This blocks the entire `processAllPRs` sequential loop in `controller.go:2241-2280`. While the post-merge CI of one PR is being awaited, no other PR ticks. If the daemon restarts mid-block, the goroutine is killed and `StagePostMergeCI` is restored — but the new tick uses a fresh `mainSHA` lookup which may point to a different commit (e.g., docs-version-sync ran in between).
+
+`handleWaitingCI` (pre-merge) was already refactored to use non-blocking `CheckCI` and tick-driven polling. `handlePostMergeCI` was missed.
+
+In current production with `ci_checks.mode: auto` + `discovery_grace_period: 1m`, the auto-mode grace path usually resolves in ~2 minutes, masking the architectural issue. But if `required_checks` are configured or CI takes longer, this can deadlock the controller.
+
+**Goal**:
+Port `handlePostMergeCI` to the same non-blocking pattern as `handleWaitingCI`: each tick calls `CheckCI` and either advances the stage or returns to wait for the next tick.
+
+**Success Criteria**:
+- [ ] `handlePostMergeCI` does not block the tick loop for more than a few hundred ms
+- [ ] Stage transitions: `StagePostMergeCI` → `StageReleasing` (success) | `StageFailed` (CI fail) | stays in `StagePostMergeCI` (pending, wait next tick)
+- [ ] Restart mid-poll resumes correctly from persisted prState
+- [ ] Existing post-merge CI tests pass; new test covers the non-blocking transition
+
+---
+
+## Implementation Plan
+
+### Phase 1: Refactor handlePostMergeCI
+**Tasks**:
+- [ ] Replace `WaitForCI` call with `CheckCI`
+- [ ] Map result to stage transition: success → release path; pending → return nil (next tick); failure → StageFailed
+- [ ] Use prState fields to track post-merge SHA / first-seen timestamp to enforce grace period across ticks (mirror handleWaitingCI's approach)
+
+**Files**:
+- `internal/autopilot/controller.go` (handlePostMergeCI ~line 1487)
+- `internal/autopilot/state_store.go` if new prState fields needed
+
+### Phase 2: Tests
+**Tasks**:
+- [ ] Table-driven tests for each transition (success, failure, pending, grace-period expiry, daemon restart mid-poll)
+
+**Files**:
+- `internal/autopilot/controller_test.go`
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|----------|---------|--------|-----------|
+| Grace period tracking | new prState field vs in-memory only | new prState field | survives restart; matches existing pre-merge pattern |
+| Backoff between ticks | rely on tick interval (existing) | rely on tick interval | simpler; tick interval is already configurable |
+
+---
+
+## Verify
+
+```bash
+make test ./internal/autopilot/...
+make lint
+```
+
+---
+
+## Done
+
+- [ ] handlePostMergeCI is non-blocking (no internal poll loop)
+- [ ] Tests pass including restart scenarios
+- [ ] Other PRs' ticks not starved during a long post-merge CI wait
+EOF

--- a/.agent/tasks/TASK-36-remove-legacy-blocking-approval.md
+++ b/.agent/tasks/TASK-36-remove-legacy-blocking-approval.md
@@ -1,0 +1,138 @@
+# TASK-36: Remove Legacy Blocking RequestApproval Path
+
+**Status**: 🚧 In Progress
+**Created**: 2026-05-06
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**:
+The async approval pipeline (TASK-29/30/31, v2.121.0–v2.128.0) shipped behind `Config.AsyncDispatch` (default `true`). The legacy blocking `Manager.RequestApproval` path was kept "for one release cycle while async_dispatch rolls out" (per controller.go:998). With v2.128.4 in production and async verified live across 3 smoke-test PRs (2026-05-06), the bake time has elapsed.
+
+The legacy path is now dead weight. It also has architectural risks:
+- Blocks the sequential `processAllPRs` tick loop for up to 24h on `<-responseCh` waiting (the original cause of `bug_telegram_approval_callback_unwired`)
+- Diverges from the audited path — bug fixes to async (TASK-33 executions persistence) don't apply
+- `auto_merger.go:233` still calls the blocking `RequestApproval` from `MergePR`, meaning prod-env merges may hit the legacy path even when `AsyncDispatch=true`. Worth verifying during implementation.
+
+**Goal**:
+Delete the legacy `RequestApproval` blocking path. The async path becomes the only path; `AsyncDispatch` config knob is removed.
+
+**Success Criteria**:
+- [ ] `Manager.RequestApproval` removed from `internal/approval/manager.go`
+- [ ] `Manager.IsAsyncDispatch` removed (always implicitly true)
+- [ ] `Config.AsyncDispatch` field removed from `internal/approval/types.go`
+- [ ] `Controller.handleAwaitApprovalLegacy` removed from `internal/autopilot/controller.go`
+- [ ] Legacy fallback at `controller.go:999-1000` removed (the `if !IsAsyncDispatch ... handleAwaitApprovalLegacy` branch)
+- [ ] `auto_merger.go:233` migrated to async path: call `SubmitApprovalRequest` and wait for the decision via state writer / next tick (consistent with how the controller does it)
+- [ ] All tests for legacy path removed; remaining tests still pass
+- [ ] No references to `AsyncDispatch` in any config or yaml docs (grep clean)
+- [ ] `make test`, `make lint`, `make build` all pass
+
+---
+
+## Implementation Plan
+
+### Phase 1: Migrate auto_merger.go to async path
+**Goal**: Eliminate the only non-controller caller of `RequestApproval`.
+
+**Tasks**:
+- [ ] Replace `m.approvalMgr.RequestApproval(ctx, req)` at `auto_merger.go:233` with `SubmitApprovalRequest` + read decision from `prState` on subsequent invocation OR refactor the merge flow so `MergePR` is called only after the controller's stage machine has set `prState.ApprovalDecision`. Likely cleaner: remove the in-line approval call from `MergePR` entirely; the controller's `handleAwaitApproval` is the single approval gate, and `MergePR` should only run for PRs that have `prState.ApprovalDecision == approved` (or env-disabled-approval).
+- [ ] Update `auto_merger_test.go` cases that exercise approval inside `MergePR`.
+
+**Files**:
+- `internal/autopilot/auto_merger.go`
+- `internal/autopilot/auto_merger_test.go`
+
+### Phase 2: Remove legacy path from approval package
+**Tasks**:
+- [ ] Delete `Manager.RequestApproval` (`manager.go:100-...`)
+- [ ] Delete `Manager.IsAsyncDispatch` (`manager.go:492-494`)
+- [ ] Delete `Config.AsyncDispatch` field (`types.go:82-87`); remove default-true setting in `DefaultConfig` (line 141)
+- [ ] Update package docs/comments referencing legacy path
+
+**Files**:
+- `internal/approval/manager.go`
+- `internal/approval/types.go`
+- `internal/approval/manager_test.go`
+
+### Phase 3: Remove legacy path from controller
+**Tasks**:
+- [ ] Delete `Controller.handleAwaitApprovalLegacy` (`controller.go:1113-...`)
+- [ ] Delete the legacy fallback branch at `controller.go:998-1000`
+- [ ] Update `handleAwaitApproval` doc comment to drop legacy mentions
+
+**Files**:
+- `internal/autopilot/controller.go`
+- `internal/autopilot/controller_test.go`
+
+### Phase 4: Sweep & docs
+**Tasks**:
+- [ ] `grep -rn "async_dispatch\|AsyncDispatch\|RequestApproval\|handleAwaitApprovalLegacy" --include="*.go" --include="*.yaml" --include="*.mdx"` should return only history docs (e.g. `.agent/.context-markers/`) — no live code references.
+- [ ] Update `~/.pilot/config.example.yaml` if it documents `async_dispatch` (user's local config doesn't need editing — extra keys are ignored).
+- [ ] Update `docs/content/features/approval-workflows.mdx` (the page added in v2.128.4 era): remove the `async_dispatch` config knob section since the option no longer exists.
+
+**Files**:
+- `docs/content/features/approval-workflows.mdx`
+- Any example yaml in repo
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|----------|---------|--------|-----------|
+| Approval call site for prod-env merges | Keep in `auto_merger.MergePR` (sync) / move to controller stage machine (async) | Move to controller stage machine | Single approval gate; consistent with non-prod async flow; eliminates code duplication |
+| Removal vs deprecation | Mark deprecated then remove next release / hard-remove now | Hard-remove now | One release of bake time per TASK-31 has elapsed; live-verified in 3 smoke-tests; deprecation adds noise without value |
+| Backward compat for users with `async_dispatch: false` in config | Keep config field as no-op / hard-remove | Hard-remove (extra YAML keys are ignored by Go decoder) | Forcing migration is fine; the option was always documented as transitional |
+
+---
+
+## Dependencies
+
+**Requires**:
+- [x] Async path verified live (TASK-33 / v2.128.4)
+- [x] One release of bake time (v2.121.0 → v2.128.4 = ~24h, exceeds the 1-release commitment)
+
+**Blocks**: None
+
+---
+
+## Verify
+
+```bash
+make test
+make lint
+make build
+
+# Confirm no live references remain
+grep -rn "async_dispatch\|AsyncDispatch\|RequestApproval\|handleAwaitApprovalLegacy" \
+  --include="*.go" --include="*.yaml" --include="*.mdx" \
+  internal/ docs/ cmd/ | grep -v "\.agent/" | grep -v archive
+# Expect: no matches in production code
+```
+
+After deploy: file a smoke-test approval-gated PR; verify pipeline still works exactly as before (because the async path is unchanged).
+
+---
+
+## Done
+
+- [ ] All five legacy symbols removed (RequestApproval, IsAsyncDispatch, AsyncDispatch, handleAwaitApprovalLegacy, fallback branch)
+- [ ] auto_merger no longer calls RequestApproval
+- [ ] All tests pass
+- [ ] grep sweep clean
+- [ ] PR opened, CI green, approved, merged, released
+
+---
+
+## Notes
+
+- Per memory `pattern_burst_auto_release_starvation.md`: ship this on its own (don't burst-merge with other PRs) to avoid auto-release skip until v2.128.4 hot-upgrade is confirmed across the controller path.
+- Net LoC change estimated -150 to -250 (counting tests).
+- This is the final cleanup of the trifecta arc that started with TASK-26 (deterministic handler selection) and ended with TASK-35 (non-blocking post-merge CI).
+
+---
+
+**Last Updated**: 2026-05-06

--- a/.agent/tasks/TASK-37-approval-persist-observability.md
+++ b/.agent/tasks/TASK-37-approval-persist-observability.md
@@ -1,0 +1,97 @@
+# TASK-37: Observability for Approval Persistence Misses (Gap 5)
+
+**Status**: 🚧 In Progress
+**Created**: 2026-05-06
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**:
+`Store.SetApprovalRequestID` (`internal/memory/store.go:583-609`) returns `sql.ErrNoRows` when the UPDATE matches zero rows. The caller treats it as a warning + continue — correct for resilience, but it leaves no observable signal if the audit trail is silently lost.
+
+Same pattern in `Store.SetApprovalDecision` (`store.go:553-577`).
+
+Verified live on 2026-05-06: the happy path works (TASK-33 / v2.128.2). The zero-row case is rare but unmonitored. If a future change introduces a race or task_id format drift, we'd discover it via missing audit rows after the fact — exactly the postmortem cost we want to avoid.
+
+**Goal**:
+Add minimal observability so a zero-row persist failure is visible without failing the merge flow.
+
+**Success Criteria**:
+- [ ] Prometheus counter (or existing metrics infra) increments on zero-row persist for both `SetApprovalRequestID` and `SetApprovalDecision`
+- [ ] Log line includes `task_id` AND `request_id` so an operator can correlate
+- [ ] No regression in approval flow latency or merge correctness
+- [ ] Existing tests pass; one new test asserts the counter increments on the zero-row path
+
+---
+
+## Implementation Plan
+
+### Phase 1: Add metric
+**Tasks**:
+- [ ] Add a Prometheus counter (or whatever metrics package the codebase uses — check `internal/metrics/` or `internal/gateway/prometheus*.go`) named `pilot_approval_persist_misses_total` with a `kind` label (`request_id` | `decision`).
+- [ ] Wire the increment from the call sites: when the caller logs the warning for zero-row case, also bump the counter.
+
+**Files**:
+- `internal/metrics/...` or wherever the existing counter conventions live
+- `internal/autopilot/controller.go` (the call sites for both Set methods)
+
+### Phase 2: Improve log structure
+**Tasks**:
+- [ ] Ensure both warning logs include structured fields: `task_id`, `request_id`, the operation name, and decision (where applicable).
+- [ ] Match the slog patterns used elsewhere in the file.
+
+**Files**:
+- `internal/autopilot/controller.go`
+
+### Phase 3: Test
+**Tasks**:
+- [ ] Unit test: feed a controller a memory store with no matching execution row, call the writer, assert metric incremented and log emitted.
+
+**Files**:
+- `internal/autopilot/controller_test.go`
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|----------|---------|--------|-----------|
+| Metric name | `pilot_approval_persist_misses_total` vs split per method | single counter w/ label | Lower cardinality, easier to alert on |
+| Severity of zero-row | Warning vs Error | Warning + counter | Audit trail miss does not block merge; alerting is via metric, not log level |
+| Where to increment | Inside Store methods vs at caller | At caller | Keeps Store package free of metrics deps; matches existing conventions |
+
+---
+
+## Verify
+
+```bash
+make test ./internal/autopilot/...
+make lint
+make build
+
+# Operationally (after deploy): confirm metric appears
+curl -s localhost:<metrics-port>/metrics | grep pilot_approval_persist_misses
+```
+
+---
+
+## Done
+
+- [ ] Counter added and wired
+- [ ] Log lines structured with task_id + request_id
+- [ ] Test passes
+- [ ] No regression
+
+---
+
+## Notes
+
+- Low priority polish; not a release/merge blocker.
+- Closes the observability gap identified in the v2.128.2 audit (Gap 5 of 5).
+- The other 4 gaps are now closed: Gap 1 (TASK-34/v2.128.3), Gap 2 (TASK-35/v2.128.4), Gap 3 (TASK-33/v2.128.2 verified live), Gap 4 (resolved by #2694/v2.128.0 zero-timestamp fix).
+
+---
+
+**Last Updated**: 2026-05-06

--- a/.agent/tasks/TASK-38-title-autorewrite-fallback.md
+++ b/.agent/tasks/TASK-38-title-autorewrite-fallback.md
@@ -1,0 +1,150 @@
+# TASK-38: Title Auto-Rewrite Fallback (P1 of Sonnet success-rate plan)
+
+**Status**: 🚧 In Progress
+**Created**: 2026-05-06
+**Assignee**: Pilot
+
+---
+
+## Context
+
+5 of 25 Sonnet 4.6 failures (20%) are `PR creation refused: title is not a conventional commit: could not auto-correct ...`. Today `normalizeTitle()` (`internal/executor/title.go:87-98`) returns an error and the executor classifies the run as a permanent failure — even though we have all the info needed (the diff + labels) to generate a valid title.
+
+Goal: extend `normalizeTitle()` with a diff-based fallback so a non-conventional title auto-rewrites instead of failing the run. Recover ~5 wins (~3.5pp success-rate bump).
+
+This is P1 of the larger plan in `.agent/.context-markers/.active`-adjacent doc `~/.claude/plans/use-nav-research-prepare-delegated-dragon.md`.
+
+## Success Criteria
+
+- [ ] `normalizeTitle()` returns a valid conventional-commit title for any input, never an error (when called with a non-empty title and access to a diff)
+- [ ] New helper `inferConventionalPrefix(diff GitDiff, labels []string) string` chooses prefix from file paths and net line counts
+- [ ] Title-related entries removed from `permanentFailurePatterns` (`internal/executor/runner.go:27-31`)
+- [ ] All existing tests pass; new table-driven tests cover all heuristic branches
+- [ ] No regression — titles that already conform still pass through unchanged
+
+---
+
+## Implementation Plan
+
+### Phase 1: Diff-based prefix heuristic
+
+Add `inferConventionalPrefix(diff, labels) string` near `autoPrefixTitle()` in `title.go`.
+
+Heuristic rules (apply in order, first match wins):
+
+1. All changed files match `*.md` or `*.mdx` → `docs`
+2. All changed files match `*_test.go` or `*_test.ts` or `*.test.*` → `test`
+3. Any label in `labelPrefixMap` matches → use that (delegate to `autoPrefixTitle`)
+4. Files only under `.github/workflows/` or `.gitlab-ci.yml` → `ci`
+5. Files only under `Dockerfile`, `Makefile`, `go.mod`, `go.sum`, `package.json`, `package-lock.json` → `build`
+6. Net diff added > removed by ≥2x AND any code file changed → `feat`
+7. Net diff close to zero (`abs(added - removed) / total < 0.2`) AND code file changed → `refactor`
+8. Otherwise → `chore`
+
+### Phase 2: Wire into `normalizeTitle()`
+
+Modify `normalizeTitle()` to accept a third arg (or use a builder/options pattern) for the diff. Cleanest: change signature to `normalizeTitle(title string, labels []string, diff GitDiff) (string, error)`.
+
+- If `validatePRTitle(title)` passes → return as-is
+- Else if `autoPrefixTitle(title, labels)` returns valid → return that (existing behavior)
+- Else `prefix := inferConventionalPrefix(diff, labels); return prefix + ": " + truncated_subject, nil`
+- Subject normalization: strip leading `GH-NNNN: `, truncate to 72 chars, lowercase first word
+- Only return error for truly unrecoverable cases (empty title, no diff)
+
+### Phase 3: Update callers
+
+`internal/executor/runner.go:2888` is the single call site. It already has access to git and the working tree — pass a `GitDiff` snapshot computed from `git diff --numstat origin/main...HEAD`.
+
+If a `GitDiff` type doesn't exist, define a minimal one:
+
+```go
+type GitDiff struct {
+    Files       []GitDiffFile
+    LinesAdded  int
+    LinesRemoved int
+}
+
+type GitDiffFile struct {
+    Path         string
+    LinesAdded   int
+    LinesRemoved int
+}
+```
+
+Add `git.GetDiffStats(ctx, baseBranch) (GitDiff, error)` in `internal/executor/git.go` if not present.
+
+### Phase 4: Drop title patterns from permanent-failure list
+
+`internal/executor/runner.go:27-31` — remove:
+- `"title is not a conventional commit"`
+- `"could not auto-correct"`
+
+Keep `"PR creation refused"` (broader umbrella for other refusal cases).
+
+### Phase 5: Tests
+
+`internal/executor/title_test.go` — new cases:
+
+- `inferConventionalPrefix`: docs-only, test-only, ci-only, build-only, feat (heavy additions), refactor (net-zero), chore (default)
+- `normalizeTitle` with diff: valid title (passthrough), label-only path (existing behavior preserved), label-miss + diff-based fallback (new), truncation of long subject
+- Regression test: empty title still errors
+
+`internal/executor/git_test.go` (or wherever `git.go` tests live) — `GetDiffStats` smoke test if added.
+
+`internal/executor/runner_test.go` — `IsPermanentFailure` no longer matches title-related strings.
+
+---
+
+## Out of Scope
+
+- Changes to the `validatePRTitle` regex
+- Removing `IsPermanentFailure` mechanism — only its title entries
+- Smarter subject summarization (LLM-generated subject) — heuristic is enough for P1
+- Touching the no-commits guard or no-changes retry (those are P2/P3)
+
+---
+
+## Verify
+
+```bash
+make test ./internal/executor/...
+make lint
+make build
+
+# After deploy: file a Pilot issue with a deliberately non-conventional title
+# (no `feat:`/`fix:`/etc prefix; no helpful labels) and confirm Pilot
+# auto-rewrites and ships rather than failing
+```
+
+Post-merge metric:
+
+```sql
+SELECT COUNT(*) FROM executions
+WHERE model_name='claude-sonnet-4-6'
+  AND created_at > '<merge-date>'
+  AND error LIKE '%conventional commit%';
+-- Expect: 0
+```
+
+---
+
+## Done
+
+- [ ] `inferConventionalPrefix` implemented with heuristic table
+- [ ] `normalizeTitle` extended; signature change propagated
+- [ ] `git.GetDiffStats` exists (existing or new)
+- [ ] Title patterns dropped from `permanentFailurePatterns`
+- [ ] All test branches covered
+- [ ] PR opened, CI green, approved, auto-merged, auto-released
+
+---
+
+## Notes
+
+- Single Pilot issue. ~80 LoC including tests.
+- Smallest, lowest-risk item in the success-rate plan; chosen to ship first to confirm `pattern_burst_auto_release_starvation.md` fix is holding under normal cadence.
+- Plan reference: `~/.claude/plans/use-nav-research-prepare-delegated-dragon.md`
+
+---
+
+**Last Updated**: 2026-05-06

--- a/.agent/tasks/TASK-39-no-commits-guard.md
+++ b/.agent/tasks/TASK-39-no-commits-guard.md
@@ -1,0 +1,138 @@
+# TASK-39: No-Commits-to-PR Guard (P2 of Sonnet success-rate plan)
+
+**Status**: 🚧 In Progress
+**Created**: 2026-05-06
+**Assignee**: Pilot
+
+---
+
+## Context
+
+4 of 25 Sonnet 4.6 failures (16%) are `PR creation failed: ... GraphQL: No commits between main and <branch>`. The executor calls `git.CreatePR()` (which shells out to `gh pr create`) without first checking that the branch contains commits vs the base. The gh CLI errors out and the run fails.
+
+Today's existing "no-changes" retry logic at `internal/executor/runner.go:2162-2188` already does the right thing — it detects empty branches via `git.CountNewCommits()` and re-prompts Claude — but that check only runs in one specific code path. Other paths reach `git.CreatePR` (line 2951) without the guard, so an empty branch leaks through to gh CLI.
+
+Goal: ensure every path to `git.CreatePR` is gated by `git.CountNewCommits() > 0`, and reuse the existing retry block when zero. Recovers ~4 wins (~2.8pp success-rate bump).
+
+This is P2 of `~/.claude/plans/use-nav-research-prepare-delegated-dragon.md`. P1 (TASK-38, v2.130.0) shipped 2026-05-06.
+
+## Success Criteria
+
+- [ ] Pre-`git.CreatePR` guard verifies the branch has commits relative to the base
+- [ ] When commits == 0, the existing retry block (runner.go:2162-2253) is invoked instead of attempting PR creation
+- [ ] No regression on the existing retry path
+- [ ] New test exercising the empty-branch case
+- [ ] `make test` / `make lint` / `make build` pass
+
+---
+
+## Implementation Plan
+
+### Phase 1: Locate every call to `git.CreatePR`
+
+Single call site is at `internal/executor/runner.go:2951` for the GitHub-default path. The non-GitHub adapter path uses `r.prCreator.CreatePR(...)` at line 2939.
+
+Confirm during implementation:
+```bash
+grep -rn "\.CreatePR(\|prCreator.CreatePR" internal/executor/ --include="*.go" | grep -v _test.go
+```
+
+### Phase 2: Insert guard before PR create
+
+In `runner.go`, between the post-push step (line 2838) and the title-validation/PR-create block (lines 2888-2951), insert:
+
+```go
+commitCount, countErr := git.CountNewCommits(ctx, baseBranch)
+if countErr != nil {
+    log.Warn("count commits before PR create failed", ...)
+} else if commitCount == 0 {
+    // Reuse existing retry block (runner.go:2162-2253).
+    // Refactor that block into a helper `retryNoChanges(...)` if needed
+    // and call it here.
+    ...
+}
+```
+
+If the lines 2162-2253 block is in-line and not currently a helper, factor it into a method:
+
+```go
+func (r *Runner) retryNoChanges(
+    ctx context.Context,
+    log *slog.Logger,
+    task *Task,
+    state *executionState,
+    backendResult *BackendResult,
+    baseBranch string,
+    selectedModel, watchdogTimeout, ...
+) (commitCount int, retryResult *BackendResult, retryErr error)
+```
+
+This keeps the new guard's body small (call → check → return-or-continue) and removes duplication.
+
+### Phase 3: Tests
+
+New test in `runner_test.go`:
+
+- `TestRunner_PRCreate_EmptyBranch_TriggersRetry`:
+  - Mock backend returns success but no diff
+  - Mock `git.CountNewCommits` returns 0
+  - Assert: `git.CreatePR` is NOT called; retry path fires
+  - Assert: error message classifies as `no_changes` if retry also fails
+
+- `TestRunner_PRCreate_HasCommits_ProceedsToCreate`:
+  - Mock returns 1+ commits
+  - Assert: `git.CreatePR` IS called
+
+If the existing tests already mock the backend at this layer, reuse the same scaffolding. If they don't, add the minimum mock.
+
+---
+
+## Out of Scope
+
+- Schema changes
+- Touching the retry-prompt content (P3 will rewrite it)
+- Pre-flight intent judge (P4)
+- Effort-routing wiring (P5)
+- New error classifications
+
+---
+
+## Verify
+
+```bash
+make test ./internal/executor/...
+make lint
+make build
+```
+
+Post-merge metric:
+
+```sql
+SELECT COUNT(*) FROM executions
+WHERE model_name='claude-sonnet-4-6'
+  AND created_at > '<merge-date>'
+  AND error LIKE '%No commits between%';
+-- Expect: 0
+```
+
+---
+
+## Done
+
+- [ ] Guard placed before every `CreatePR` call (GitHub path + adapter path)
+- [ ] Existing retry block reused via helper or in-line check
+- [ ] New tests pass
+- [ ] PR opened, CI green, approved, auto-merged, auto-released
+
+---
+
+## Notes
+
+- Single Pilot issue. ~40 LoC including tests.
+- Reuses `git.CountNewCommits()` (already invoked at line 2162) and the existing retry block (lines 2162-2253).
+- Per `pattern_burst_auto_release_starvation.md`: ship alone after P1 has merged + auto-released.
+- Plan reference: `~/.claude/plans/use-nav-research-prepare-delegated-dragon.md` (P2 of 5)
+
+---
+
+**Last Updated**: 2026-05-06

--- a/.agent/tasks/TASK-40-declined-structured-output.md
+++ b/.agent/tasks/TASK-40-declined-structured-output.md
@@ -1,0 +1,215 @@
+# TASK-40: DECLINED-with-Reason Structured Output (P3 of Sonnet success-rate plan)
+
+**Status**: 🚧 In Progress
+**Created**: 2026-05-07
+**Assignee**: Pilot
+
+---
+
+## Context
+
+14 of 25 Sonnet 4.6 failures (56%) are "Claude completed but made no code changes after retry". Today's retry prompt at `internal/executor/runner.go:2176-2188` says "implement or don't bother" with no path for Sonnet to signal "I genuinely cannot, here's why". So the 14 failures collapse together: half are correct judgements (issue is unactionable) and half are model giving up too early.
+
+Goal: rewrite the retry prompt to require structured output. After retry, Sonnet must either commit code OR end its message with `DECLINED: <one-line reason>`. The DECLINED case becomes a structured human-handoff (label issue `pilot-needs-clarification`, post comment with reason, exit with new status `declined`) — not a failure. Convert ~half of the 14 no-changes "failures" into a deliberate human-in-the-loop signal and cleanly distinguish model error from genuine ambiguity.
+
+This is P3 of `~/.claude/plans/use-nav-research-prepare-delegated-dragon.md`.
+P1 (TASK-38, GH-2735) shipped as v2.130.0.
+P2 (TASK-39, GH-2743) shipped as v2.130.1.
+
+## Success Criteria
+
+- [ ] Retry prompt at `runner.go:2176-2188` rewritten to instruct Sonnet that on retry, it must either commit code or end with `DECLINED: <reason>`
+- [ ] Helper `parseDeclinedReason(text string) (string, bool)` parses the DECLINED line out of the final assistant message
+- [ ] When DECLINED is present and no commits exist after retry: execution exits with status `declined`, the GitHub issue gets the `pilot-needs-clarification` label and a comment containing the reason
+- [ ] When DECLINED is absent and no commits exist: existing failure behaviour preserved
+- [ ] GH poller skips re-dispatching issues with `pilot-needs-clarification` label until label removed
+- [ ] Dashboard counts include a `declined` bucket alongside `completed`/`failed`
+- [ ] All existing tests pass; new tests cover parse, declined-path, label flow
+- [ ] `make test`, `make lint`, `make build` pass
+
+---
+
+## Implementation Plan
+
+### Phase 1: Parse helper
+
+In `internal/executor/runner.go`, add near the top (next to `IsPermanentFailure`):
+
+```go
+// declinedRegex matches the structured DECLINED line at the end of an assistant
+// message. The reason is captured group 1, trimmed of whitespace.
+var declinedRegex = regexp.MustCompile(`(?m)^DECLINED:\s*(.+?)\s*$`)
+
+// parseDeclinedReason returns the reason and true if the assistant text ends
+// with a DECLINED line. Falls back to scanning the last 8 non-empty lines so a
+// terminal whitespace blob doesn't hide the marker.
+func parseDeclinedReason(text string) (string, bool) {
+    if text == "" {
+        return "", false
+    }
+    // ... parse and return
+}
+```
+
+Tests in `runner_test.go`: empty, no marker, marker mid-text, marker at end, multiline reason (only first line captured), trailing whitespace, multiple DECLINED lines (last one wins).
+
+### Phase 2: Rewrite retry prompt
+
+`runner.go:2176-2188`. Replace the current `retryPrompt` with one that explicitly offers two outcomes. Keep it short:
+
+```
+## Retry: No Changes Detected
+
+Your previous run completed but made no code changes. This task requires
+either an actual implementation or a structured decline.
+
+**Original Task:** %s
+
+You MUST do exactly ONE of the following:
+
+1. Read the task carefully, implement the required changes, and create at
+   least one commit. Do NOT just analyze or plan — actually write and
+   commit code.
+
+2. If the task cannot be implemented as stated (ambiguous scope, missing
+   info, conflicting acceptance criteria, blocked by external dependency),
+   end your final message with a single line:
+
+       DECLINED: <one-line reason>
+
+   Examples:
+       DECLINED: issue body does not specify which file to modify
+       DECLINED: acceptance criteria conflict — needs human clarification
+       DECLINED: requires API credentials not available in env
+
+Do NOT use DECLINED to avoid hard work. Use it only when implementation
+is genuinely blocked.
+
+%s
+```
+
+### Phase 3: Branch on parse after retry
+
+`runner.go:2228-2253` — when `commitCount == 0` after retry, parse the assistant text first:
+
+```go
+refusal := ""
+if backendResult != nil {
+    refusal = strings.TrimSpace(backendResult.LastAssistantText)
+    if retryResult != nil && strings.TrimSpace(retryResult.LastAssistantText) != "" {
+        refusal = strings.TrimSpace(retryResult.LastAssistantText)
+    }
+}
+
+if reason, ok := parseDeclinedReason(refusal); ok {
+    // Structured decline — not a failure.
+    result.Success = false
+    result.Declined = true        // NEW field on Result
+    result.DeclinedReason = reason
+    if backendResult != nil {
+        backendResult.ErrorType = string(ErrorTypeDeclined) // NEW
+    }
+    log.Info("task declined by executor with reason",
+        slog.String("task_id", task.ID),
+        slog.String("reason", reason),
+    )
+    r.reportProgress(task.ID, "Declined", 100, "Declined: " + reason)
+    // ... return early; let caller post comment + label
+} else {
+    // Existing failure behaviour preserved.
+}
+```
+
+Add `Declined bool` and `DeclinedReason string` to whichever Result type runner returns (likely `Result` in the same file or `internal/executor/types.go`).
+
+Add `ErrorTypeDeclined ErrorType = "declined"` near other ErrorType constants.
+
+### Phase 4: GitHub label + comment on decline
+
+The runner already has access to a GH client for PR creation. After a decline:
+- Post a comment on the source issue: a markdown block with the reason, who declined (model name), and a hint that removing `pilot-needs-clarification` will allow re-dispatch
+- Add label `pilot-needs-clarification` to the issue
+- Remove `pilot-in-progress` if present
+
+Locate the existing label-management helpers in `internal/adapters/github/`. If not present, add a small helper.
+
+### Phase 5: Poller skip-on-label
+
+`internal/adapters/github/poller.go:660,877,916` — already check existing labels for blocking states. Add `pilot-needs-clarification` to the blocking set so the poller doesn't re-dispatch a declined issue until a human removes the label.
+
+Pattern to mirror: how `pilot-failed` is treated. Search `pilot-failed` to find the exact set.
+
+### Phase 6: Dashboard `declined` count
+
+`internal/dashboard/...` — find where `completed`/`failed` counters are computed and add a `declined` parallel counter sourced from `executions.status='declined'`.
+
+If status is computed from a fixed list, extend the list. Schema check: `internal/memory/store.go` — confirm `executions.status` has no CHECK constraint blocking new values. If it does, add `declined` to the allow-list.
+
+### Phase 7: Tests
+
+- `runner_test.go`: `parseDeclinedReason` table-driven; `TestRunner_DECLINED_Path` (mock retry returns DECLINED, assert status=declined, label applied, no failure escalation); `TestRunner_NoChanges_NoDecline` (retry without DECLINED still fails as today)
+- `poller_test.go`: assert `pilot-needs-clarification` skips dispatch
+- Dashboard test (if any test infra) for the new counter
+
+### Phase 8: Documentation
+
+- Update `docs/content/features/...` with one paragraph describing the new behavior + label
+- Mention the `pilot-needs-clarification` label in the user-facing runbook
+
+---
+
+## Out of Scope
+
+- Pre-flight intent judge (P4)
+- Effort routing (P5)
+- Retry budget tuning beyond DECLINED path
+- Slack/Telegram notification for declines (could be follow-up)
+- Auto-clarification flow that asks the user follow-up questions (out of scope for v1)
+
+---
+
+## Verify
+
+```bash
+make test ./internal/executor/... ./internal/memory/... ./internal/adapters/github/...
+make lint
+make build
+```
+
+Post-merge production verification (after the next batch of issues):
+
+```sql
+-- Expect: a non-zero declined count if any issues were genuinely ambiguous
+SELECT status, COUNT(*) FROM executions
+WHERE model_name='claude-sonnet-4-6'
+  AND created_at > '<merge-date>'
+GROUP BY status;
+```
+
+Manual verification: file an intentionally-ambiguous Pilot issue (e.g., "improve the thing"). Confirm Sonnet returns DECLINED, the issue gets `pilot-needs-clarification`, and the poller skips it on the next tick.
+
+---
+
+## Done
+
+- [ ] `parseDeclinedReason` implemented + tested
+- [ ] Retry prompt rewritten with explicit DECLINED option
+- [ ] Result type extended; ErrorTypeDeclined added
+- [ ] Label + comment posted on decline
+- [ ] Poller skips `pilot-needs-clarification`
+- [ ] Dashboard shows declined count
+- [ ] Docs updated
+- [ ] PR opened, CI green, auto-merged, auto-released
+
+---
+
+## Notes
+
+- ~150 LoC including tests, dashboard wiring, label flow.
+- **Single Pilot issue with a single AC list** — to avoid epic decomposition. Per memory `bug_decomposer_no_meta_marker.md` and `bug_pilot_ghost_closes.md`, decomposed multi-PR work has higher failure surface.
+- Per `pattern_burst_auto_release_starvation.md`: ship alone (no concurrent Pilot issues filed).
+- Master plan: `~/.claude/plans/use-nav-research-prepare-delegated-dragon.md` (P3 of 5)
+
+---
+
+**Last Updated**: 2026-05-07

--- a/.agent/tasks/TASK-41-declined-followup.md
+++ b/.agent/tasks/TASK-41-declined-followup.md
@@ -1,0 +1,67 @@
+# TASK-41: Declined Pipeline Follow-Up (P3 cleanup)
+
+**Status**: 🚧 In Progress
+**Created**: 2026-05-07
+**Assignee**: Pilot
+
+---
+
+## Context
+
+PR #2767 (salvage of ghost-closed GH-2753/GH-2754) ships the core DECLINED pipeline (parseDeclinedReason, retry prompt, Result fields, dispatcher wiring, GitHub label notifier). Three small loose ends from P3 didn't make it into the salvage and are tracked here.
+
+Plan ref: `~/.claude/plans/use-nav-research-prepare-delegated-dragon.md` (P3 of 5, cleanup)
+
+## Success Criteria (single AC list — DO NOT decompose)
+
+- [ ] Poller skip-on-label: in `internal/adapters/github/poller.go`, add `pilot-needs-clarification` to the same blocking-label set used for `pilot-failed`. Cover both `checkForNewIssues` and `findOldestUnprocessedIssue` (parallel + sequential modes). Mirror the existing pattern exactly.
+- [ ] Test: `TestPoller_SkipsNeedsClarification` in `internal/adapters/github/poller_test.go`, mirroring whatever test covers `pilot-failed`.
+- [ ] Dashboard: in `internal/dashboard/...`, add a `declined` counter alongside `completed`/`failed`, sourced from `executions.status='declined'`. Find the existing counter wiring and extend it minimally — no UI redesign.
+- [ ] Docs: one paragraph appended to `docs/content/features/...` (the relevant features page; pick the same page the original retry/approval flow is documented in) describing the new DECLINED behaviour and the `pilot-needs-clarification` label.
+- [ ] `make test`, `make lint`, `make build` pass.
+
+---
+
+## Out of Scope
+
+- Refactoring anything PR #2767 already shipped
+- Changing the DECLINED parser, retry prompt, or label name
+- Slack/Telegram notifications for declines (separate Pilot issue if needed)
+- Auto-clarification follow-up flow
+
+---
+
+## Implementation Plan
+
+Three small additions, sequential. ~50 LoC total.
+
+1. **Poller guard.** Search `pilot-failed` in `internal/adapters/github/poller.go`. Add `pilot-needs-clarification` to the same set. Mirror tests.
+2. **Dashboard counter.** Find the `completed`/`failed` aggregation. Add `declined`. Render alongside.
+3. **Docs.** One paragraph. Cross-link from the approval / retry section on the same page.
+
+No changes to runner.go, dispatcher.go, or any package PR #2767 already touched.
+
+---
+
+## Verify
+
+```bash
+make test ./internal/adapters/github/... ./internal/dashboard/...
+make lint
+make build
+
+# After deploy: file an intentionally ambiguous Pilot issue.
+# Expect: Sonnet returns DECLINED, label applied, poller skips on next tick.
+```
+
+---
+
+## Notes
+
+- ~50 LoC, single PR, deliberately small to avoid decomposition triggering again.
+- DO NOT split into subtasks. The three changes are independent but tiny — keep as one commit.
+- Master plan: `~/.claude/plans/use-nav-research-prepare-delegated-dragon.md`
+
+---
+
+**Last Updated**: 2026-05-07

--- a/.agent/tasks/archive/TASK-25-stale-recovery-queue-drain-fix.md
+++ b/.agent/tasks/archive/TASK-25-stale-recovery-queue-drain-fix.md
@@ -1,0 +1,133 @@
+# TASK-25: Fix Stale Recovery Killing Queued Tasks
+
+**Status**: 📋 Planned
+**Created**: 2026-04-17
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**: The dispatcher's `recoverStaleTasks()` runs every 5 minutes and marks all queued tasks older than 5 minutes as failed. When `runner.Execute()` blocks for 10-20 minutes (GLM-5.1, complex tasks), tasks queued behind it age past the `StaleQueuedThreshold` and get nuked — even though the worker is actively processing the queue. The worker eventually finishes, loops back to `GetQueuedTasksForProject()`, finds nothing, and the queued tasks are lost.
+
+**Timeline**:
+1. Task A queued → worker starts, `processing=true`, `runner.Execute` blocks (10-20 min)
+2. Tasks B, C queued → sit in `queued` status waiting for A to finish
+3. 5 minutes pass → `recoverStaleTasks()` runs
+4. `GetStaleQueuedExecutions(5min)` returns B and C (no project filter)
+5. B and C marked failed — "stale queued task recovered (no worker picked up)"
+6. Task A finishes → `processQueue` loops back, `GetQueuedTasksForProject` returns empty
+7. B and C are lost
+
+**Goal**: Before marking a stale queued task as failed, check if the project has an active worker currently processing (`processing == true`). If so, skip it — the worker will get to it.
+
+**Success Criteria**:
+- [ ] Queued tasks behind a busy worker are NOT marked failed by stale recovery
+- [ ] Stale recovery still fails tasks for projects with no worker or idle worker (genuinely stuck)
+- [ ] `isWorkerProcessing()` helper uses RLock (no blocking of queue ops)
+- [ ] Tests cover active worker, idle worker, and no-worker scenarios
+- [ ] Build succeeds, tests pass
+
+---
+
+## Implementation Plan
+
+### Phase 1: Add `isWorkerProcessing` helper
+**Goal**: Thread-safe check for active worker processing state.
+
+**Tasks**:
+- [ ] Add `isWorkerProcessing(projectPath string) bool` method on `Dispatcher`
+- [ ] Uses `d.mu.RLock()` — safe from stale recovery loop
+- [ ] Returns `worker.processing.Load()` for project, `false` if no worker
+
+**Files**:
+- `internal/executor/dispatcher.go` — Add method near `GetWorkerStatus()` (line ~374)
+
+### Phase 2: Guard stale-queued loop
+**Goal**: Skip tasks for projects with actively processing workers.
+
+**Tasks**:
+- [ ] In `recoverStaleTasks()` stale-queued loop, add guard after orphan-completed check
+- [ ] Log at Debug level when skipping
+- [ ] Continue to next task if `isWorkerProcessing()` returns `true`
+
+**Files**:
+- `internal/executor/dispatcher.go` — Add guard in loop (line ~211)
+
+### Phase 3: Tests
+**Goal**: Verify skip behavior for active/idle/no worker scenarios.
+
+**Tasks**:
+- [ ] `TestRecoverStaleTasks_SkipsActiveWorker` — active worker skips, no-worker fails
+- [ ] `TestRecoverStaleTasks_IdleWorkerStillFails` — idle worker fails task
+
+**Files**:
+- `internal/executor/dispatcher_test.go` — Add 2 new test functions
+
+---
+
+## Technical Decisions
+
+| Decision | Options Considered | Chosen | Reasoning |
+|----------|-------------------|--------|-----------|
+| Skip mechanism | Increase threshold, worker-aware check, hybrid | Worker-aware check | Targeted fix, keeps 5-min timeout for genuinely stuck tasks |
+| Locking | Lock, RLock, atomic-only | RLock + atomic | Safe read without blocking `ensureWorker` |
+| Log level | Info, Debug, Warn | Debug | Skip is expected behavior, not a concern |
+
+---
+
+## Edge Cases
+
+| Scenario | `isWorkerProcessing` | Result |
+|----------|---------------------|--------|
+| Active worker, long task running | `true` | Skip (correct) |
+| Worker idle, task stuck in queue | `false` | Fail (correct) |
+| No worker for project | `false` | Fail (correct) |
+| Worker crashes between check and next tick | `false` on next tick | Fail on next tick (correct) |
+| Dispatcher just started, no workers yet | `false` | Fail (correct) |
+
+---
+
+## Files to Modify
+
+| File | Change | Lines |
+|------|--------|-------|
+| `internal/executor/dispatcher.go` | Add `isWorkerProcessing()` | ~8 lines |
+| `internal/executor/dispatcher.go` | Add guard in `recoverStaleTasks()` | ~8 lines |
+| `internal/executor/dispatcher_test.go` | `TestRecoverStaleTasks_SkipsActiveWorker` | ~50 lines |
+| `internal/executor/dispatcher_test.go` | `TestRecoverStaleTasks_IdleWorkerStillFails` | ~35 lines |
+
+---
+
+## Dependencies
+
+**Requires**:
+- None
+
+**Blocks**:
+- Reliable long-running task execution (GLM-5.1, complex tasks)
+
+---
+
+## Verify
+
+```bash
+go test ./internal/executor/ -run TestRecoverStale -v
+go test ./internal/executor/ -v
+make build
+```
+
+---
+
+## Done
+
+- [ ] `isWorkerProcessing()` method exists and uses RLock
+- [ ] Guard added in `recoverStaleTasks()` stale-queued loop
+- [ ] `TestRecoverStaleTasks_SkipsActiveWorker` passes
+- [ ] `TestRecoverStaleTasks_IdleWorkerStillFails` passes
+- [ ] `make build` succeeds
+- [ ] All tests pass
+
+---
+
+**Last Updated**: 2026-04-17

--- a/.agent/tasks/archive/TASK-26-approval-deterministic-handler.md
+++ b/.agent/tasks/archive/TASK-26-approval-deterministic-handler.md
@@ -1,0 +1,129 @@
+# TASK-26: Deterministic approval handler selection via approval_source
+
+**Status**: ✅ Completed
+**Created**: 2026-05-05
+**Completed**: 2026-05-05 (PR #2640, shipped in v2.118.2)
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**:
+`internal/approval/manager.go:148-153` selects the approval channel via Go map iteration with `break` after the first hit. Map iteration order is non-deterministic in Go, so with Telegram + Slack both registered the handler that fires is random per process. The autopilot config key `orchestrator.autopilot.approval_source` (`internal/autopilot/types.go:23-31`) is defined and documented in user memory (`reference_approval_telegram_wiring.md`) but is **never consulted by the Manager** — it is a no-op today.
+
+**Goal**:
+Make handler selection deterministic by routing the autopilot's `approval_source` config through to the Manager via the existing `approval.Request` boundary, with graceful fallback to the existing first-available behavior when the preferred channel isn't registered.
+
+**Success Criteria**:
+- [ ] With `approval_source: telegram` and Slack also registered, every approval send goes to Telegram across restarts.
+- [ ] With `approval_source` unset, behavior matches today (first-available; tests still pass).
+- [ ] When `approval_source: slack` is set but the Slack handler is not registered, autopilot logs a WARN and falls back to first-available — does not deadlock.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Plumb PreferredChannel through Request
+**Goal**: Carry channel preference from autopilot caller to approval Manager without changing constructor signatures.
+
+**Tasks**:
+- [ ] Add `PreferredChannel string` (omitempty) field to `approval.Request`.
+- [ ] In `auto_merger.go:requestApproval`, set `req.PreferredChannel = string(m.cfg.ApprovalSource)` when building the Request.
+
+**Files**:
+- `internal/approval/types.go:33-43` — add field to `Request` struct.
+- `internal/autopilot/auto_merger.go:208-218` — set the field when constructing the Request.
+
+### Phase 2: Deterministic lookup in Manager
+**Goal**: Use the new field to pick the handler, with graceful fallback.
+
+**Tasks**:
+- [ ] In `manager.go:147-154`, when `req.PreferredChannel != ""`, look up `m.handlers[req.PreferredChannel]`.
+- [ ] On miss, emit a WARN log (`"preferred approval channel %q not registered, falling back to first-available"`) and fall through to existing loop.
+- [ ] On hit, use that handler directly; skip the fallback loop.
+
+**Files**:
+- `internal/approval/manager.go:147-154` — preferred-channel lookup before existing loop.
+
+### Phase 3: Tests
+**Goal**: Lock in the new behavior, document the fallback path.
+
+**Tasks**:
+- [ ] Update `internal/approval/manager_test.go:725-756` (existing multi-handler test) — assert that when `PreferredChannel` is set, the named handler receives the request and others do NOT.
+- [ ] Keep the existing first-available assertion for the path where `PreferredChannel` is unset (rename test to clarify scope).
+- [ ] Add a fallback-warning test: `PreferredChannel: "slack"` but only Telegram registered → warning logged, Telegram receives request, no error.
+
+**Files**:
+- `internal/approval/manager_test.go:725-756` — update + extend.
+
+---
+
+## Technical Decisions
+
+| Decision | Options Considered | Chosen | Reasoning |
+|----------|-------------------|--------|-----------|
+| Where to plumb `approval_source` | (a) into `approval.Config` via `NewManager(cfg, source)`; (b) via `Request.PreferredChannel`; (c) read autopilot config inside Manager | (b) Request.PreferredChannel | Keeps autopilot-specific concern in the autopilot package; no constructor signature change; Request is already caller-built; per-request override possible if ever needed. |
+| Fallback on miss | (a) hard fail; (b) graceful WARN + first-available | (b) graceful | Avoids deadlock when config drifts (e.g. operator sets `approval_source: github-review` before wiring the GitHub handler). Deadlocks are the single worst failure mode for this surface area — see incident_oauth_cascade_series. |
+| Default when `approval_source` unset | (a) error; (b) preserve first-available | (b) preserve | Backward compatibility for configs without `approval_source` set. |
+
+---
+
+## Dependencies
+
+**Requires**:
+- [ ] None — independent change.
+
+**Blocks**:
+- [ ] TASK-27 (per-channel Telegram approval flag) — only meaningful if handler selection is deterministic; otherwise a Telegram-disable can be silently overridden by map iteration.
+- [ ] TASK-28 (wire GitHub PR-review handler) — must land after this so `approval_source: github-review` actually routes correctly when a third handler is present.
+
+---
+
+## Verify
+
+```bash
+# Unit tests
+go test ./internal/approval/... -run TestManager -v
+
+# Full approval package
+go test ./internal/approval/...
+
+# Vet + lint
+go vet ./internal/approval/... ./internal/autopilot/...
+golangci-lint run ./internal/approval/... ./internal/autopilot/...
+```
+
+---
+
+## Done
+
+- [ ] `approval.Request.PreferredChannel` field exists, omitempty-tagged.
+- [ ] `manager.go` consults `PreferredChannel` before falling through; WARN log on miss.
+- [ ] `auto_merger.go:requestApproval` sets the field from `m.cfg.ApprovalSource`.
+- [ ] Unit tests cover: deterministic match, fallback-warning, no-preference (legacy first-available).
+- [ ] All existing approval tests still pass.
+- [ ] No new config keys; no constructor signature changes.
+
+---
+
+## Notes
+
+- `manager_test.go:747` has an existing comment "implementation uses first available" and asserts `totalSent == 1`. That assertion stays valid for the no-preference path; new test covers the with-preference path.
+- This task does not change `approval.NewManager` signature. Plumbing flows entirely through `Request`.
+- Memory `reference_approval_telegram_wiring.md` claims `approval_source` controls routing — that documentation is currently aspirational; this task makes it true.
+
+---
+
+## Completion Checklist
+
+- [ ] Implementation finished
+- [ ] Tests written and passing
+- [ ] No regressions in existing tests
+- [ ] PR opened with conventional title `fix(approval): deterministic handler selection via approval_source`
+- [ ] Linked to GitHub issue (filled in below after issue creation)
+
+---
+
+**GitHub Issue**: [#2638](https://github.com/qf-studio/pilot/issues/2638)
+**Last Updated**: 2026-05-05

--- a/.agent/tasks/archive/TASK-27-telegram-approval-config.md
+++ b/.agent/tasks/archive/TASK-27-telegram-approval-config.md
@@ -1,0 +1,137 @@
+# TASK-27: Per-adapter approval-enabled config field for Telegram
+
+**Status**: ✅ Completed
+**Created**: 2026-05-05
+**Completed**: 2026-05-05 (PR #2644, shipped in v2.119.0 — `feat:` triggered minor bump)
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**:
+The Telegram approval handler registers whenever `Adapters.Telegram.Enabled && BotToken != ""` (`cmd/pilot/main.go:421` gateway path, `cmd/pilot/main.go:1302` start path). There is no way to keep Telegram on for briefs, voice, status messages, alerts while routing **approvals** through Slack or GitHub. Slack already has this granularity via `Adapters.Slack.Approval.Enabled` (`internal/adapters/slack/webhook.go:231-235`, gated at `cmd/pilot/main.go:428-439`). Telegram's adapter config (`internal/adapters/telegram/notifier.go:13-23`) has no `Approval` substruct.
+
+**Goal**:
+Add a Slack-parallel `Adapters.Telegram.Approval.Enabled` config field so the operator can disable Telegram approval registration without disabling the adapter entirely. Default `Enabled: true` for back-compat — existing configs continue to behave identically.
+
+**Success Criteria**:
+- [ ] Setting `adapters.telegram.approval.enabled: false` skips Telegram approval handler registration on both gateway and start paths.
+- [ ] Omitting `adapters.telegram.approval` (back-compat) registers the handler exactly as today.
+- [ ] No unrelated `adapters.telegram.enabled` semantics change — the 30 read sites of that field are untouched.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Config struct
+**Goal**: Mirror Slack's pattern in the Telegram adapter package.
+
+**Tasks**:
+- [ ] Add `ApprovalConfig{Enabled bool}` struct in `internal/adapters/telegram/notifier.go` (or a sibling file if cleaner — match Slack's location pattern).
+- [ ] Add `Approval *ApprovalConfig` field to `telegram.Config`.
+- [ ] Add `DefaultApprovalConfig() *ApprovalConfig` returning `&ApprovalConfig{Enabled: true}`.
+
+**Files**:
+- `internal/adapters/telegram/notifier.go:13-23` — extend `Config`, add `ApprovalConfig` + `DefaultApprovalConfig()`.
+
+### Phase 2: Wire the gate
+**Goal**: Use the new config at registration sites.
+
+**Tasks**:
+- [ ] Update `cmd/pilot/main.go:421` (gateway path): gate becomes
+  `cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.BotToken != "" && (cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled)`.
+  Nil-check preserves back-compat — configs without the substruct register the handler as before.
+- [ ] Update `cmd/pilot/main.go:1302` (start path) identically.
+
+**Files**:
+- `cmd/pilot/main.go:421` — gateway-mode gate.
+- `cmd/pilot/main.go:1302` — start-mode gate.
+
+### Phase 3: Test
+**Goal**: Lock in default behavior.
+
+**Tasks**:
+- [ ] Add a unit test in `internal/adapters/telegram/notifier_test.go` (or matching test file) asserting `DefaultApprovalConfig().Enabled == true`.
+- [ ] No test required for the registration gate itself (config-shape change), but if a `_test.go` already covers Config defaults, extend it.
+
+**Files**:
+- `internal/adapters/telegram/notifier_test.go` (or adjacent) — default assertion.
+
+---
+
+## Technical Decisions
+
+| Decision | Options Considered | Chosen | Reasoning |
+|----------|-------------------|--------|-----------|
+| Default for `Approval.Enabled` | (a) false (opt-in); (b) true (opt-out) | (b) true | Back-compat: existing configs without the substruct must continue to register the handler. Setting opt-in would silently break every prod operator on upgrade. |
+| Where to put the struct | (a) `notifier.go` next to `Config`; (b) new `approval_config.go` file | (a) | Slack's `ApprovalConfig` lives next to its `Config` in `webhook.go`; mirroring keeps grep-discoverability. |
+| Nil substruct semantics | (a) treat as disabled; (b) treat as enabled | (b) | Matches the "default true" decision. Nil pointer = use defaults = enabled. |
+
+---
+
+## Dependencies
+
+**Requires**:
+- [ ] **TASK-26 (#2638)** — deterministic handler selection. Without it, disabling Telegram approval may not actually route to Slack/GitHub deterministically because the Manager picks via Go map iteration; with only one handler registered the point is moot, but the use case for this task is "two handlers, prefer one" which only works after TASK-26.
+
+**Blocks**:
+- [ ] None directly. TASK-28 (GitHub PR-review handler) is independent but combines well with this once both land.
+
+---
+
+## Verify
+
+```bash
+# Test the new default
+go test ./internal/adapters/telegram/... -run TestDefaultApprovalConfig -v
+
+# Full adapter package
+go test ./internal/adapters/telegram/...
+
+# Build + vet
+go build ./cmd/pilot/...
+go vet ./internal/adapters/telegram/... ./cmd/pilot/...
+```
+
+Manual smoke (after merge + hot-upgrade):
+1. Add `adapters.telegram.approval.enabled: false` to `~/.pilot/config.yaml`.
+2. Ensure Slack approval is enabled with `approval_source: slack` (depends on TASK-26).
+3. Trigger a pre-merge approval on a stage PR.
+4. Expect Slack message, no Telegram message.
+5. Remove the substruct (back-compat) → next approval lands on Telegram again.
+
+---
+
+## Done
+
+- [ ] `telegram.ApprovalConfig` struct exists with `Enabled bool`.
+- [ ] `telegram.Config.Approval *ApprovalConfig` field added.
+- [ ] `DefaultApprovalConfig()` returns `Enabled: true`.
+- [ ] Both registration sites (`main.go:421`, `main.go:1302`) gated on the new field with nil = back-compat = on.
+- [ ] Unit test for default value passes.
+- [ ] No regressions in existing telegram adapter tests.
+- [ ] No changes to the 30 unrelated read sites of `Adapters.Telegram.Enabled`.
+
+---
+
+## Notes
+
+- This is a config-shape addition. Operators with existing configs are unaffected (nil substruct preserves current behavior).
+- Once landed, the user-facing knob is `adapters.telegram.approval.enabled: false` — same syntax as Slack.
+- Wider plan: combined with TASK-26 (deterministic selection) and TASK-28 (GitHub PR-review handler), the operator gets a coherent matrix where each channel is independently switchable and `approval_source` deterministically picks among the registered ones.
+
+---
+
+## Completion Checklist
+
+- [ ] Implementation finished
+- [ ] Tests written and passing
+- [ ] No regressions in existing tests
+- [ ] PR opened with conventional title `feat(adapters/telegram): per-adapter approval-enabled config field`
+- [ ] Linked to GitHub issue (filled in below after issue creation)
+
+---
+
+**GitHub Issue**: [#2641](https://github.com/qf-studio/pilot/issues/2641)
+**Last Updated**: 2026-05-05

--- a/.agent/tasks/archive/TASK-28-github-pr-review-approval-handler.md
+++ b/.agent/tasks/archive/TASK-28-github-pr-review-approval-handler.md
@@ -1,0 +1,167 @@
+# TASK-28: Wire GitHub PR-review approval handler
+
+**Status**: ✅ Completed
+**Created**: 2026-05-05
+**Completed**: 2026-05-05 (PR #2646, shipped in v2.118.3)
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**:
+The approval package already has a complete GitHub handler implementation in `internal/approval/github.go`:
+- `NewGitHubHandler(client GitHubReviewClient, cfg *GitHubHandlerConfig) *GitHubHandler` (line 45)
+- `GitHubReviewClient` interface with `HasApprovalReview(ctx, owner, repo, number)` (lines 14-16)
+- Polling loop in `pollForApproval` (line 106)
+- Message formatter
+- Tests in `internal/approval/github_test.go`
+
+But **there is no registration call site** in `cmd/pilot/main.go`. The block at lines 418-440 (gateway) and 1299-1323 (start) only registers Telegram and Slack. Operators who want to use GitHub PR review (Approve/Request Changes on the PR) as the approval mechanism cannot — even though the entire handler is sitting in the codebase ready to use.
+
+**Goal**:
+Wire `NewGitHubHandler` into both registration sites with an opt-in config flag (`Adapters.GitHub.Approval.Enabled`, default `false`). Once enabled, operators can leave a PR review as the approval signal — no chat clients required, no DM gymnastics, leverages the same UI used for normal code review.
+
+**Success Criteria**:
+- [ ] Setting `adapters.github.approval.enabled: true` registers the GitHub handler at startup.
+- [ ] Default `Enabled: false` — zero impact for current users.
+- [ ] When registered alongside Telegram/Slack with `approval_source: github-review` (depends on TASK-26), GitHub handler is selected deterministically.
+- [ ] No new wrapper adapter — `*github.Client` satisfies `GitHubReviewClient` directly via `HasApprovalReview` (`internal/adapters/github/client.go:763`).
+
+---
+
+## Implementation Plan
+
+### Phase 1: Config struct
+**Goal**: Add an opt-in config field, parallel to Slack and (post-TASK-27) Telegram.
+
+**Tasks**:
+- [ ] Add `ApprovalConfig{Enabled bool, PollInterval time.Duration}` struct in `internal/adapters/github/` (new file `approval_config.go`, or alongside existing config — match the Slack location pattern).
+- [ ] Default constructor: `Enabled: false, PollInterval: 30 * time.Second`.
+- [ ] Add `Approval *ApprovalConfig` field to the GitHub adapter Config struct in `internal/config/config.go` (mirror `Slack.Approval`).
+
+**Files**:
+- `internal/adapters/github/approval_config.go` (new) — struct + default constructor.
+- `internal/config/config.go` — add `Approval *github.ApprovalConfig` field on GitHub adapter struct.
+
+### Phase 2: Wire the registration sites
+**Goal**: Register `NewGitHubHandler` on both gateway and start paths when enabled.
+
+**Tasks**:
+- [ ] Inspect `cmd/pilot/main.go:418-440` (gateway) — locate the existing `ghClient := github.NewClient(ghToken)` instantiation (current approx line 453, *after* approval block). Either:
+  - **Option A**: Move the GitHub handler registration to live inside the autopilot block where `ghClient` and the owner/repo split already exist. Cleanest, avoids duplicate client construction.
+  - **Option B**: Hoist `ghClient` + `parts := strings.Split(cfg.Adapters.GitHub.Repo, "/")` above the approval block. More refactor-y.
+  - Choose Option A (less churn, single client instance).
+- [ ] Same treatment for `cmd/pilot/main.go:1299-1323` (start path).
+- [ ] Registration code:
+  ```go
+  if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Approval != nil && cfg.Adapters.GitHub.Approval.Enabled {
+      pollInterval := cfg.Adapters.GitHub.Approval.PollInterval
+      if pollInterval == 0 {
+          pollInterval = 30 * time.Second
+      }
+      ghHandler := approval.NewGitHubHandler(ghClient, &approval.GitHubHandlerConfig{
+          Owner:        owner,
+          Repo:         repo,
+          PollInterval: pollInterval,
+      })
+      approvalMgr.RegisterHandler(ghHandler)
+  }
+  ```
+
+**Files**:
+- `cmd/pilot/main.go:418-440` — gateway-mode registration.
+- `cmd/pilot/main.go:1299-1323` — start-mode registration.
+
+### Phase 3: Test
+**Goal**: Lock in default config + handler construction.
+
+**Tasks**:
+- [ ] In `internal/approval/github_test.go`, ensure `NewGitHubHandler` is exercised with a stub `GitHubReviewClient` and verify the handler's `Name()` returns the expected string for Manager lookup (alignment with TASK-26's `PreferredChannel` lookup key).
+- [ ] Add a config-default test asserting `github.DefaultApprovalConfig().Enabled == false` and `PollInterval == 30s`.
+- [ ] If a `cmd/pilot/main_test.go` integration smoke exists, extend it; otherwise skip — wiring is config-shape work and the unit-test surface is already covered.
+
+**Files**:
+- `internal/approval/github_test.go` — assert handler `Name()` and `NewGitHubHandler` happy path (extend existing tests if present).
+- `internal/adapters/github/approval_config_test.go` (new) — default-constructor assertions.
+
+---
+
+## Technical Decisions
+
+| Decision | Options Considered | Chosen | Reasoning |
+|----------|-------------------|--------|-----------|
+| Default for `Approval.Enabled` | (a) true (opt-out); (b) false (opt-in) | (b) false | Slack uses opt-in (`Slack.Approval.Enabled` defaults effectively to false unless set). Telegram (TASK-27) defaults true for back-compat because it was always-on before. GitHub has *never* been wired — no back-compat to preserve, opt-in is correct. |
+| Where to register in main.go | (a) standalone block above autopilot; (b) inside autopilot block where `ghClient` exists | (b) inside autopilot block | Avoids constructing a second `ghClient`; keeps GitHub-specific concerns colocated with autopilot setup; less diff churn. |
+| Need for adapter wrapper | (a) wrapper struct mirroring `telegramApprovalAdapter`; (b) use `*github.Client` directly | (b) direct | `*github.Client` already satisfies `approval.GitHubReviewClient` via `HasApprovalReview` (`internal/adapters/github/client.go:763`). No interface mismatch, no wrapper required. Saves ~30 LoC vs Telegram/Slack patterns. |
+| Default `PollInterval` | (a) 15s aggressive; (b) 30s balanced; (c) 60s conservative | (b) 30s | Matches existing GitHub poller default in `cfg.Adapters.GitHub.Polling.Interval`. Acceptable latency for an approval-required prod environment; adjustable via config. |
+
+---
+
+## Dependencies
+
+**Requires**:
+- [ ] **TASK-26 (#2638)** — deterministic handler selection. Without it, registering a third handler (alongside Telegram + Slack) makes the random map-iteration lottery strictly worse (1-in-3 instead of 1-in-2). With TASK-26, `approval_source: github-review` deterministically routes to this handler.
+
+**Blocks**:
+- [ ] None.
+
+**Related**:
+- TASK-27 (#2641) — Telegram per-adapter approval flag. Independent change but together they form a coherent matrix: each channel has its own enable/disable, and `approval_source` picks among the registered ones deterministically.
+
+---
+
+## Verify
+
+```bash
+# Test the new handler wiring
+go test ./internal/approval/... -run TestGitHubHandler -v
+go test ./internal/adapters/github/...
+
+# Build + vet the registration changes
+go build ./cmd/pilot/...
+go vet ./cmd/pilot/... ./internal/approval/... ./internal/adapters/github/...
+```
+
+Manual smoke (after merge + hot-upgrade, requires TASK-26):
+1. Set `adapters.github.approval.enabled: true` in `~/.pilot/config.yaml`.
+2. Set `orchestrator.autopilot.approval_source: github-review`.
+3. Optionally set `adapters.telegram.approval.enabled: false` (post-TASK-27) to avoid registering Telegram.
+4. Trigger a stage PR. Expect: autopilot pauses at pre-merge, polls for an approving review on the PR.
+5. Open the PR in GitHub UI, click **Approve** in the Review menu.
+6. Within `PollInterval`, autopilot detects the review and proceeds to merge.
+
+---
+
+## Done
+
+- [ ] `github.ApprovalConfig{Enabled bool, PollInterval time.Duration}` struct exists with default `Enabled: false, PollInterval: 30s`.
+- [ ] `cfg.Adapters.GitHub.Approval` field plumbed in `internal/config/config.go`.
+- [ ] Both registration sites (`cmd/pilot/main.go` gateway + start) call `approval.NewGitHubHandler` when enabled, using the existing `ghClient` (no duplicate client construction).
+- [ ] Unit tests cover handler construction + default config values.
+- [ ] No changes to `auto_merger.go:requestApproval` (verified `Metadata["pr_number"]` is already set at lines 213-217).
+- [ ] No new dependencies; no wrapper adapter; no `approval.NewManager` signature change.
+
+---
+
+## Notes
+
+- The handler is fully implemented in `internal/approval/github.go` — this task is purely wiring + config, no new approval logic.
+- `auto_merger.go:requestApproval` (lines 208-218) already populates `req.Metadata["pr_number"]`. The GitHub handler reads this at `internal/approval/github.go:71-79` to know which PR to poll. No changes needed there.
+- Compose TASK-26 + TASK-27 + this task and the final UX is: operator sets `approval_source: github-review`, handler is deterministic, no chat client needed, just review the PR.
+- Possible follow-up (NOT in scope): allow per-environment approval source (`stage` → Slack, `prod` → GitHub-review). Would require threading `ApprovalSource` through `EnvironmentConfig`. File separately if desired.
+
+---
+
+## Completion Checklist
+
+- [ ] Implementation finished
+- [ ] Tests written and passing
+- [ ] No regressions in existing approval or github adapter tests
+- [ ] PR opened with conventional title `feat(approval): wire GitHub PR-review approval handler`
+- [ ] Linked to GitHub issue (filled in below after issue creation)
+
+---
+
+**GitHub Issue**: [#2642](https://github.com/qf-studio/pilot/issues/2642)
+**Last Updated**: 2026-05-05

--- a/.agent/tasks/archive/TASK-29-telegram-approval-callback-dispatch.md
+++ b/.agent/tasks/archive/TASK-29-telegram-approval-callback-dispatch.md
@@ -1,0 +1,190 @@
+# TASK-29: Wire Telegram approve/reject callback dispatch
+
+**Status:** Planned
+**Priority:** P0 (blocks pre-merge approval re-enable)
+**Type:** Bug fix (Day-1 wiring gap)
+**Effort:** S (~25 LoC + test)
+
+## Problem
+
+`internal/adapters/telegram/handler.go:handleCallback` (lines 372-421) only
+handles `execute`, `cancel`, `switch_*`, `voice_check_status`. There is **no
+case** for callbacks with the `approve:` or `reject:` prefix.
+
+`*approval.TelegramHandler` (defined at `internal/approval/telegram.go:38`)
+exposes `HandleCallback(ctx, callbackID, data, userID, username) bool` which
+parses `approve:<requestID>` / `reject:<requestID>` correctly — but this
+object is constructed at `cmd/pilot/main.go:423` and `:1304`, registered
+with the approval manager, and **never injected into the telegram poller**.
+
+Result: every approval button tap is acknowledged by `AnswerCallback`
+(loading spinner clears — illusion of success) then falls through the
+switch default and is silently dropped. `<-responseCh` in
+`internal/approval/manager.go:205-213` then blocks for 24h, and
+`processAllPRs` (`controller.go:2059-2114`) is sequential, so one stuck PR
+starves the entire queue.
+
+This was the actual mechanism behind every "I clicked Merge but nothing
+happened" episode. Manual `gh pr merge` (handled by
+`controller.checkExternalMergeOrClose`) is the current workaround.
+
+References:
+- Memory: `bug_telegram_approval_callback_unwired.md` (full RCA)
+- Memory: `pattern_approval_chat_id_bootstrap.md` (bootstrap deadlock)
+- `.agent/system/OPERATIONAL-ISSUES.md` "Telegram Pre-Merge Approval Dispatch Unwired (2026-05-05)"
+- TASK-26 / TASK-27 / TASK-28 (archived) — approval architecture context
+
+## Fix Shape (tactical)
+
+Inject the existing `*approval.TelegramHandler` into `telegram.Handler` at
+construction, then route `approve:`/`reject:` callbacks to it.
+
+### Changes
+
+**1. `internal/adapters/telegram/handler.go`**
+
+- Add interface for the approval handler (avoid hard dep on approval pkg if
+  it would create a cycle — approval defines `TelegramClient` itself, so
+  direct import should be safe; verify):
+
+```go
+// ApprovalCallbackHandler dispatches approve:/reject: callbacks.
+// Implemented by *approval.TelegramHandler.
+type ApprovalCallbackHandler interface {
+    HandleCallback(ctx context.Context, callbackID, data, userID, username string) bool
+}
+```
+
+- Add field to `Handler`:
+  ```go
+  approvalHandler ApprovalCallbackHandler
+  ```
+
+- Add field to `HandlerConfig`:
+  ```go
+  ApprovalHandler ApprovalCallbackHandler
+  ```
+
+- Wire in `NewHandler`:
+  ```go
+  approvalHandler: config.ApprovalHandler,
+  ```
+
+- Add case in `handleCallback` switch (before existing cases — avoids
+  fall-through; after the `AnswerCallback` is fine because the approval
+  handler will edit the message itself):
+
+  ```go
+  case strings.HasPrefix(data, "approve:") || strings.HasPrefix(data, "reject:"):
+      if h.approvalHandler == nil {
+          return
+      }
+      userID := ""
+      username := ""
+      if callback.From != nil {
+          userID = strconv.FormatInt(callback.From.ID, 10)
+          username = callback.From.Username
+          if username == "" {
+              username = callback.From.FirstName
+          }
+      }
+      h.approvalHandler.HandleCallback(ctx, callback.ID, data, userID, username)
+  ```
+
+  Note: the existing `_ = h.client.AnswerCallback(...)` at line 382 already
+  fires for all callbacks, which is fine — `approval.TelegramHandler.HandleCallback`
+  edits the message via `EditMessage` separately. (Verify against `approval/telegram.go:144+` — current code calls `client.EditMessage` post-decision; the early `AnswerCallback` is harmless.)
+
+**2. `cmd/pilot/main.go`**
+
+Both construction sites need updating. Currently:
+```go
+tgApprovalHandler := approval.NewTelegramHandler(&telegramApprovalAdapter{...}, ...)
+approvalMgr.RegisterHandler(tgApprovalHandler)
+// ... later ...
+tgHandler = telegram.NewHandler(tgConfig, runner)
+```
+
+Change to: construct `tgApprovalHandler` BEFORE `tgConfig`, then pass via
+config:
+```go
+tgConfig.ApprovalHandler = tgApprovalHandler
+tgHandler = telegram.NewHandler(tgConfig, runner)
+```
+
+Both call sites at `main.go:423` and `:1304` need this re-ordering. Check
+which `main.go:1707` site (`telegram.NewHandler(...)`) corresponds to which
+construction site — the `start` command flow is the load-bearing one.
+
+**3. Unit test — `internal/adapters/telegram/handler_test.go`**
+
+```go
+func TestHandleCallback_ApproveRejectDispatches(t *testing.T) {
+    var called bool
+    var gotCallbackID, gotData, gotUserID string
+    fakeApproval := &fakeApprovalHandler{
+        fn: func(ctx context.Context, callbackID, data, userID, username string) bool {
+            called = true
+            gotCallbackID = callbackID
+            gotData = data
+            gotUserID = userID
+            return true
+        },
+    }
+    h := &Handler{
+        client:          newFakeClient(),
+        approvalHandler: fakeApproval,
+    }
+    cb := &CallbackQuery{
+        ID:      "cb-1",
+        Data:    "approve:req-42",
+        Message: &Message{Chat: Chat{ID: 1}},
+        From:    &User{ID: 99, Username: "alice"},
+    }
+    h.handleCallback(context.Background(), cb)
+
+    if !called {
+        t.Fatal("approve: callback should dispatch to ApprovalCallbackHandler")
+    }
+    if gotCallbackID != "cb-1" || gotData != "approve:req-42" || gotUserID != "99" {
+        t.Errorf("unexpected args: cb=%q data=%q uid=%q", gotCallbackID, gotData, gotUserID)
+    }
+}
+```
+
+Plus a parallel `reject:` case and a `nil approvalHandler` no-panic case.
+
+## Verification
+
+- `go test ./internal/adapters/telegram/... -run Approve`
+- `go build ./...`
+- `go vet ./...`
+- Manual smoke (operator post-merge): re-enable `approval.pre_merge.enabled` + `release.environments.stage.require_approval` in `~/.pilot/config.yaml`, trigger a stage release, tap Approve, verify PR advances within 60s.
+
+## Out of scope (separate tasks)
+
+- **M:** Persist pending approval requests in SQLite (`approval_pending`
+  table); rehydrate `tgApprovalHandler.pending` on restart so taps on
+  pre-restart messages don't return "Request expired or already
+  processed".
+- **L:** Replace blocking `<-responseCh` in `requestApproval` with
+  callback-driven stage advance — handler writes decision to PR state on
+  tap, next controller tick picks up; eliminates 24h queue starvation.
+
+## Re-enable checklist (post-merge of this PR)
+
+After PR is merged + smoke-tested, follow `.agent/system/OPERATIONAL-ISSUES.md`:
+1. `~/.pilot/config.yaml` line 481: `approval.pre_merge.enabled: true`
+2. `~/.pilot/config.yaml` line 185: `release.environments.stage.require_approval: true`
+3. `pilot upgrade` (or hot-upgrade if daemon supports) to picked-up version
+4. Smoke-test a stage release end-to-end before considering closed.
+
+## Acceptance Criteria
+
+- [ ] `approve:<id>` callback in `handleCallback` dispatched to `ApprovalCallbackHandler.HandleCallback`
+- [ ] `reject:<id>` callback dispatched the same way
+- [ ] `nil` approval handler is a no-op (no panic)
+- [ ] Unit tests pass for approve, reject, nil-handler cases
+- [ ] `cmd/pilot/main.go` injects `tgApprovalHandler` into `tgConfig` at both construction sites
+- [ ] Existing `execute`/`cancel`/`switch_`/`voice_check_status` callbacks still work (no regressions)
+- [ ] PR title is conventional: `fix(adapters/telegram): wire approve/reject callback dispatch (GH-NNNN)`

--- a/.agent/tasks/autopilot-card-redesign.md
+++ b/.agent/tasks/autopilot-card-redesign.md
@@ -1,0 +1,319 @@
+# Autopilot Card Redesign — Variant A
+
+**Status**: 🚧 Ready to file
+**Created**: 2026-05-04
+**Execution**: Sonnet 4.6 via Pilot
+**Target file**: `internal/dashboard/tui.go`
+
+---
+
+## Context
+
+**Problem.** Current autopilot card (GH-2455 "avionics") wastes 5 lines on 3 lines of signal:
+
+```
+╭─ AUTOPILOT ───────────────────────────────────────────────────────╮
+│                                                                   │
+│   STATE  ci_passed    PR  #2565    AGE  1m                        │
+│   CI [████████]  MRG [░░░░░░░░]  RTY [░░░░░░░░] 0/3               │
+│   ● ci-wait ── ○ rebase ── ○ merge ── ○ tag ── ○ release          │
+│                                                                   │
+╰───────────────────────────────────────────────────────────────────╯
+```
+
+Three problems:
+1. **Fake progress bars.** CI is binary (pending/running/success/failure), MRG is binary (merged/not), RTY is a count not a percentage. Rendering them as 8-slot fills is theatre.
+2. **STATE field duplicates the pipeline rail.** `ci_passed` text + `● ci-wait` dots = same info, two places, inconsistent (text says passed, dot says current).
+3. **Wasted vertical space.** Two padding rows at top and bottom.
+
+**Goal.** Replace with Variant A: PR identity on line 1, pipeline-as-status on line 2, conditional failure reason on line 3 only when relevant. Idle state collapses to one line.
+
+---
+
+## Target Layouts
+
+**Steady state — waiting on CI:**
+```
+╭─ AUTOPILOT ─────────────────────────────────────────────────────╮
+│  #2565  fix(upgrade): atomic binary replacement         1m42s   │
+│  ◐ ci ── ○ rebase ── ○ merge ── ○ tag ── ○ release      0/3 ⟲   │
+╰─────────────────────────────────────────────────────────────────╯
+```
+
+**CI failed, mid-retry (3rd line conditional):**
+```
+╭─ AUTOPILOT ─────────────────────────────────────────────────────╮
+│  #2565  fix(upgrade): atomic binary replacement         4m10s   │
+│  ✗ ci ── ○ rebase ── ○ merge ── ○ tag ── ○ release      2/3 ⟲   │
+│  ↳ TestInstallToBinaryPath_Cleanup failed · linux-amd64         │
+╰─────────────────────────────────────────────────────────────────╯
+```
+
+**Mid-pipeline (rebasing, CI already green):**
+```
+╭─ AUTOPILOT ─────────────────────────────────────────────────────╮
+│  #2565  fix(upgrade): atomic binary replacement         3m08s   │
+│  ✓ ci ── ◐ rebase ── ○ merge ── ○ tag ── ○ release      0/3 ⟲   │
+╰─────────────────────────────────────────────────────────────────╯
+```
+
+**Idle:**
+```
+╭─ AUTOPILOT ─────────────────────────────────────────────────────╮
+│  idle · no active PR                                            │
+╰─────────────────────────────────────────────────────────────────╯
+```
+
+---
+
+## Glyph + Color Spec
+
+| Glyph | Meaning | Style (existing) | Color |
+|---|---|---|---|
+| `✓` | stage done | `statusCompletedStyle` | sage green `#7ec699` |
+| `◐` | stage in progress (rotates) | `statusRunningStyle` | steel blue `#7eb8da` |
+| `○` | stage pending | `dimStyle` | mid gray `#8b949e` |
+| `✗` | stage failed | `statusFailedStyle` | dusty rose `#d48a8a` |
+| `⟲` | retry indicator | `warningStyle` | amber `#d4a054` |
+
+Animation: `◐` rotates `◐ → ◓ → ◑ → ◒ → ◐` on each 1s tick. Reuse the existing tick that drives `sparklineTick` (see `internal/dashboard/tui.go:398`). Pass tick into `AutopilotPanel` via a setter or struct field bumped from the parent `tea.Tick` handler.
+
+---
+
+## Files to Modify
+
+| File | What |
+|---|---|
+| `internal/dashboard/tui.go` | Rewrite `AutopilotPanel.View()` (lines 130–204), `renderAutopilotRail()` (267–294). Delete `autopilotCIProgressPct()`, `renderAutopilotBar()`, and progress-bar usage (206–239). Add 1s tick field + setter on `AutopilotPanel`. |
+| `internal/dashboard/tui_test.go` | Update `TestRenderAutopilotRailPositions` and any other autopilot tests for new glyphs/format. Add table-driven test covering: idle, ci-running, ci-failed, mid-pipeline, released. |
+| caller in `internal/dashboard/tui.go` (parent model) | Wire animation tick into `autopilotPanel` (search for `sparklineTick` toggling — same place increments autopilot tick). |
+
+**Untouched:**
+- `internal/autopilot/*.go` — state machine stays exactly as-is. Only the rendering changes.
+- All other panels (TOKENS, COST, TASKS, HISTORY, queue, etc.).
+- `pipelineStagePosition()` (line 242) — reuse as-is for stage→index mapping.
+
+---
+
+## Implementation Steps
+
+### Step 1 — Add tick field for `◐` rotation
+Add to `AutopilotPanel` struct (line 120):
+```go
+type AutopilotPanel struct {
+    controller *autopilot.Controller
+    panelWidth int
+    tick       int // increments per 1s animation tick, drives ◐ rotation
+}
+```
+Add setter `SetTick(int)`. Wire from parent model where `sparklineTick` toggles.
+
+### Step 2 — Rewrite `View()` (lines 130–204)
+Three rendering branches:
+
+**A. Disabled** (controller nil) — keep current `"  Disabled"` content.
+**B. Idle** (no active PRs) — single line `"  idle · no active PR"` using `dimStyle`. (Optional enhancement: append last-release info if accessible cheaply.)
+**C. Active PR** — two or three lines:
+
+```
+  #{PRNumber}  {truncatedTitle}{padding}{age}
+  {rail}{padding}{retries}/{maxFailures} ⟲
+  ↳ {truncatedError}                              ← only if Stage == Failed && Error != ""
+```
+
+Width budget (inner = 65 chars):
+- Line 1: `  #NNNN  ` (9) + title (truncated to 47) + ` ` + age right-padded to 6 = 65
+- Line 2: rail (~50 visible chars without ANSI) + padding + retries (`0/3 ⟲` = 5) = 65
+- Line 3 (failure): `  ↳ ` (4) + truncated error (≤61) = 65
+
+Use `lipgloss.Width()` for ANSI-safe length, or strip ANSI when computing padding. Existing helper pattern: see `renderPanel`.
+
+### Step 3 — Rewrite `renderAutopilotRail(stage, ciStatus, tick)`
+Drop the lamp-then-label approach, switch to glyph-then-stage-name:
+
+```go
+nodes := []string{"ci", "rebase", "merge", "tag", "release"}
+spinner := []rune{'◐', '◓', '◑', '◒'}
+pos := pipelineStagePosition(stage)
+
+for i, name := range nodes {
+    var glyph rune
+    var glyphStyle, labelStyle lipgloss.Style
+    switch {
+    case i == 0 && ciStatus == autopilot.CIFailure:
+        glyph, glyphStyle, labelStyle = '✗', statusFailedStyle, statusFailedStyle
+    case i < pos:
+        glyph, glyphStyle, labelStyle = '✓', statusCompletedStyle, statusCompletedStyle
+    case i == pos:
+        glyph = spinner[tick%4]
+        glyphStyle, labelStyle = statusRunningStyle, titleStyle
+    default:
+        glyph, glyphStyle, labelStyle = '○', dimStyle, dimStyle
+    }
+    // append glyph + " " + name + (" ── " if not last)
+}
+```
+
+Important: `pipelineStagePosition` already maps `StageFailed → 0`. The `✗` override on the failed CI stage is correct only when `ciStatus == CIFailure`. For other failure modes (e.g. rebase failed), the `✗` should land on the actual failed stage — but the current state machine collapses all failures to `StageFailed`. **Out of scope to fix.** For now: render `✗` on stage 0 only when CI failed; otherwise on `StageFailed` render `✗` at position 0 with error line 3 carrying the detail.
+
+### Step 4 — Title source
+PR struct exposes `PRTitle` (see `internal/autopilot/auto_merger.go:91`). Use directly. Truncate with the existing `truncateString` helper (line 318) to fit the width budget.
+
+### Step 5 — Retries
+Reuse `cfg.MaxFailures` and `controller.GetPRFailures(pr.PRNumber)` exactly as today (lines 162–167). Render as `{n}/{max} ⟲` with the count in `dimStyle` and the `⟲` in `warningStyle`. Suppress the `⟲` glyph when `n == 0` (replace with a space) to avoid noise on healthy runs.
+
+### Step 6 — Multi-PR overflow
+Keep current behaviour (`+ N more PR(s)`) on its own line if `len(prs) > 1`. Variant B (one-row-per-PR) is **out of scope** for this ticket.
+
+### Step 7 — Delete dead code
+Remove `autopilotCIProgressPct` (206–219) and `renderAutopilotBar` (221–239) once nothing references them. Verify with `grep -r renderAutopilotBar internal/`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Card height: 4 lines (border + content + border) when idle; 4 when active steady-state; 5 when failed.
+- [ ] No `[████░░░░]`-style progress bars anywhere in autopilot output.
+- [ ] No `STATE` literal text anywhere in autopilot output.
+- [ ] Stage glyphs render correct color per spec table.
+- [ ] `◐` rotates through `◐◓◑◒` once per second when a stage is in progress.
+- [ ] On `CIFailure`, the `ci` stage renders `✗` in dusty rose; failure reason appears on line 3, prefixed with `↳`, truncated to fit.
+- [ ] Idle state is exactly one content line.
+- [ ] All existing autopilot tests pass after updates.
+- [ ] New table-driven test covers: disabled, idle, ci-running, ci-failed, rebase-in-progress, merged, released, failed-with-error.
+- [ ] `make lint` clean.
+
+---
+
+## Test Approach
+
+Extend `internal/dashboard/tui_test.go`:
+
+1. **Update** `TestRenderAutopilotRailPositions` — assert new glyph set (`✓ ◐ ○ ✗`), new stage labels (`ci` not `ci-wait`), and that `tick` parameter rotates the in-progress glyph.
+2. **Add** `TestAutopilotPanelView_AllStates` — table-driven, one row per state. Build a fake `*autopilot.Controller` (or mock the minimum surface) and assert the rendered output:
+   - Contains the expected glyph for the current stage
+   - Does NOT contain `[█` or `[░` (no fake bars)
+   - Does NOT contain `STATE`
+   - Width of every line == `panelTotalWidth`
+   - Failure state contains `↳ ` prefix and the error substring
+3. **Add** `TestAutopilotPanelTick_RotatesSpinner` — call `View()` 4 times incrementing tick, assert all 4 spinner runes appear.
+
+---
+
+## Forbidden Actions
+
+- ❌ Do **not** modify `internal/autopilot/*.go` — state machine stays as-is.
+- ❌ Do **not** touch other dashboard panels (TOKENS, COST, TASKS, HISTORY, queue, splash).
+- ❌ Do **not** add new color constants — every required style already exists in `tui.go:48–117`.
+- ❌ Do **not** introduce variant B (multi-PR table) — separate ticket if wanted.
+- ❌ Do **not** change `pipelineStagePosition()` mapping.
+- ❌ Do **not** add new dependencies.
+
+---
+
+## Verify
+
+```bash
+go build ./...
+go test ./internal/dashboard/... -run Autopilot -v
+make lint
+```
+
+Manual smoke (after merge):
+```bash
+make build && ./bin/pilot dashboard
+```
+Trigger a Pilot task, watch the autopilot card cycle through states.
+
+---
+
+## Issue Body Ready to File
+
+```
+Title: feat(dashboard): redesign autopilot card (variant A — pipeline-as-status)
+
+Body:
+Replace the current autopilot card (GH-2455 "avionics" layout) with a denser,
+honest variant. Three problems with current:
+
+1. Fake progress bars CI/MRG/RTY — CI is binary, MRG is binary, RTY is a count.
+   Rendering them as 8-slot fills is theatre.
+2. STATE field duplicates the pipeline rail and can disagree with it.
+3. 5 lines of card; only 3 carry signal.
+
+## Target — variant A
+
+Steady state (waiting CI):
+```
+╭─ AUTOPILOT ─────────────────────────────────────────────────────╮
+│  #2565  fix(upgrade): atomic binary replacement         1m42s   │
+│  ◐ ci ── ○ rebase ── ○ merge ── ○ tag ── ○ release      0/3 ⟲   │
+╰─────────────────────────────────────────────────────────────────╯
+```
+
+Failed (third line conditional, only on Stage==Failed && Error != ""):
+```
+╭─ AUTOPILOT ─────────────────────────────────────────────────────╮
+│  #2565  fix(upgrade): atomic binary replacement         4m10s   │
+│  ✗ ci ── ○ rebase ── ○ merge ── ○ tag ── ○ release      2/3 ⟲   │
+│  ↳ TestInstallToBinaryPath_Cleanup failed · linux-amd64         │
+╰─────────────────────────────────────────────────────────────────╯
+```
+
+Idle:
+```
+╭─ AUTOPILOT ─────────────────────────────────────────────────────╮
+│  idle · no active PR                                            │
+╰─────────────────────────────────────────────────────────────────╯
+```
+
+## Glyphs
+- `✓` done — `statusCompletedStyle` (sage `#7ec699`)
+- `◐` in progress, animated `◐◓◑◒` on 1s tick — `statusRunningStyle` (steel blue `#7eb8da`)
+- `○` pending — `dimStyle` (mid gray `#8b949e`)
+- `✗` failed — `statusFailedStyle` (dusty rose `#d48a8a`)
+- `⟲` retry — `warningStyle` (amber `#d4a054`); suppress when retries == 0
+
+All styles already exist in `internal/dashboard/tui.go:48-117`. No new colors.
+
+## Files
+- `internal/dashboard/tui.go` — rewrite `AutopilotPanel.View()` (130-204) and
+  `renderAutopilotRail()` (267-294). Delete `autopilotCIProgressPct` (206-219)
+  and `renderAutopilotBar` (221-239). Add `tick int` field + `SetTick(int)` to
+  `AutopilotPanel`; wire from the parent model where `sparklineTick` toggles.
+- `internal/dashboard/tui_test.go` — update `TestRenderAutopilotRailPositions`,
+  add `TestAutopilotPanelView_AllStates` (table-driven), add
+  `TestAutopilotPanelTick_RotatesSpinner`.
+
+Reuse `pipelineStagePosition` (line 242) and `truncateString` (318) as-is.
+PR title via `pr.PRTitle` (already on the struct, see auto_merger.go:91).
+
+## Forbidden
+- Do NOT modify `internal/autopilot/*.go` — state machine unchanged.
+- Do NOT touch other dashboard panels.
+- Do NOT add new color constants.
+- Do NOT add variant B (multi-PR table) — separate ticket if wanted.
+
+## Acceptance
+- 4-line card steady state; 5 lines on failure; 3 lines idle.
+- No `[████░░░░]` anywhere in autopilot output.
+- No `STATE` literal in autopilot output.
+- ◐ rotates through ◐◓◑◒ on 1s tick.
+- On CIFailure, `ci` stage renders `✗` and reason appears on line 3.
+- All autopilot tests pass; new table-driven test covers every state branch.
+- `make lint` clean.
+
+## Verify
+```
+go build ./...
+go test ./internal/dashboard/... -run Autopilot -v
+make lint
+```
+```
+
+---
+
+## Notes
+
+- Plan doc lives at `.agent/tasks/autopilot-card-redesign.md`. Once filed, rename to `.agent/tasks/gh-NNNN.md` to match repo convention.
+- If Pilot picks Sonnet 4.6 vs Opus, this is medium-effort scoped work — fits Sonnet's wheelhouse. Routing should pick Sonnet by default; no override needed.

--- a/.agent/tasks/gh-2768.md
+++ b/.agent/tasks/gh-2768.md
@@ -1,0 +1,45 @@
+# GH-2768
+
+**Created:** 2026-05-07
+
+## Problem
+
+GitHub Issue #2768: chore(executor): wire DECLINED follow-up — poller skip + dashboard count + docs
+
+## Context
+
+PR #2767 ships the core DECLINED pipeline (parser + retry prompt + Result fields + dispatcher + GitHub label notifier). Three small loose ends from the original P3 plan didn't make it into the salvage:
+
+1. Poller skip on \`pilot-needs-clarification\` label
+2. Dashboard \`declined\` counter
+3. One-paragraph docs entry
+
+This is the explicit cleanup ticket. Single AC list. **DO NOT DECOMPOSE.** ~50 LoC total.
+
+## Acceptance Criteria
+
+1. **Poller guard.** In \`internal/adapters/github/poller.go\`, add \`pilot-needs-clarification\` to the same blocking-label set used for \`pilot-failed\`. Cover both \`checkForNewIssues\` AND \`findOldestUnprocessedIssue\`. Mirror the existing pattern exactly — do NOT introduce a new mechanism.
+2. **Test.** \`TestPoller_SkipsNeedsClarification\` in \`internal/adapters/github/poller_test.go\`, mirroring whatever test covers \`pilot-failed\` skip.
+3. **Dashboard counter.** In \`internal/dashboard/...\`, find the existing \`completed\`/\`failed\` aggregation and add \`declined\` (sourced from \`executions.status='declined'\`). Render alongside. Minimal change — no UI redesign.
+4. **Docs.** One paragraph appended to \`docs/content/features/...\` (find the page that documents retry/no-changes behaviour and add adjacent to it). Mention DECLINED, the \`pilot-needs-clarification\` label, and that removing the label re-enables dispatch.
+5. \`make test\`, \`make lint\`, \`make build\` pass.
+
+## Out of Scope
+
+- Refactoring anything PR #2767 already shipped
+- Changing the DECLINED parser, retry prompt, or label name
+- Slack/Telegram notifications for declines
+- Auto-clarification follow-up flow
+
+## Implementation Plan
+
+\`.agent/tasks/TASK-41-declined-followup.md\`
+
+## Notes
+
+- **Single Pilot issue, single commit, NO DECOMPOSITION.** Carries the \`no-decompose\` label as defense.
+- Per memory \`bug_decomposer_no_meta_marker.md\` and \`bug_pilot_ghost_closes.md\`: previous P3 attempt (GH-2753) ghost-closed when decomposition kicked in. This issue is sized small enough that decomposition shouldn't trigger.
+- Master plan: \`~/.claude/plans/use-nav-research-prepare-delegated-dragon.md\`
+
+## Acceptance Criteria
+

--- a/.agent/tasks/q-1778013288.md
+++ b/.agent/tasks/q-1778013288.md
@@ -1,0 +1,15 @@
+# Q-1778013288
+
+**Created:** 2026-05-05
+
+## Problem
+
+Answer this question about the codebase. DO NOT make any changes, only read and analyze.
+
+Question: What’s in the queue at the moment?
+
+IMPORTANT: Be concise. Limit your exploration to 5-10 files max. Provide a brief, direct answer.
+If the question is too broad, ask for clarification instead of exploring everything.
+
+## Acceptance Criteria
+

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,17 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-435259103/pilot-bash-guard.sh"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-435259103/pilot-stop-gate.sh"
+            "command": "/var/folders/_8/nnsxrdhn46x08pb886hrggv00000gn/T/pilot-hooks-2587742524/pilot-bash-guard.sh"
           }
         ]
       }

--- a/docs/content/features/self-healing.mdx
+++ b/docs/content/features/self-healing.mdx
@@ -144,6 +144,10 @@ These three mechanisms work together to create a closed-loop system:
 └─────────────────────────────────────────────────────────────┘
 ```
 
+## DECLINED: Unactionable Task Handling
+
+When Pilot determines that an issue cannot be implemented as written — for example, it contradicts the codebase design, references missing context, or is too ambiguous to act on safely — the executor emits a DECLINED result instead of creating a partial or broken PR. Pilot adds the `pilot-needs-clarification` label to the issue and posts a comment explaining what information is needed. The GitHub poller treats `pilot-needs-clarification` as a permanent skip: the issue will not be dispatched again until a human removes the label. Once removed, the issue re-enters the normal dispatch queue on the next poll cycle.
+
 ## Related Features
 
 - [Autopilot](/features/autopilot) — CI monitoring and auto-merge

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -618,6 +618,11 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 			continue
 		}
 
+		// GH-2768: Skip issues declined as unactionable. Remove the label to re-enable dispatch.
+		if HasLabel(issue, LabelNeedsClarification) {
+			continue
+		}
+
 		// GH-2402: Auto-close sub-issues whose parent epic already shipped.
 		if p.skipSupersededByParent(ctx, issue) {
 			continue
@@ -826,6 +831,11 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 		// GH-2402: Skip permanently-blocked issues. The user must remove
 		// the pilot-blocked label to retry (e.g. after fixing a non-conventional title).
 		if HasLabel(issue, LabelBlocked) {
+			continue
+		}
+
+		// GH-2768: Skip issues declined as unactionable. Remove the label to re-enable dispatch.
+		if HasLabel(issue, LabelNeedsClarification) {
 			continue
 		}
 

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2280,6 +2280,62 @@ func TestPoller_AutoRetryFailedIssue_ParallelMode_LimitReached(t *testing.T) {
 	}
 }
 
+// GH-2768: Skip issues with pilot-needs-clarification label
+
+func TestPoller_SkipsNeedsClarification(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		// Has pilot-needs-clarification — should be skipped until label is removed
+		{Number: 42, State: "open", Title: "Declined issue", Labels: []Label{{Name: "pilot"}, {Name: LabelNeedsClarification}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, State: "open", Title: "Available issue", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	// Test findOldestUnprocessedIssue skips #42
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil {
+		t.Fatal("issue should not be nil — #43 should be picked")
+	}
+	if issue.Number != 43 {
+		t.Errorf("findOldestUnprocessedIssue: got issue #%d, want #43 (should skip #42 with pilot-needs-clarification)", issue.Number)
+	}
+
+	// Test checkForNewIssues (parallel mode) also skips #42
+	var processedIssues []*Issue
+	var mu sync.Mutex
+	poller2, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, iss *Issue) error {
+			mu.Lock()
+			processedIssues = append(processedIssues, iss)
+			mu.Unlock()
+			return nil
+		}),
+	)
+	poller2.checkForNewIssues(context.Background())
+	poller2.WaitForActive()
+
+	mu.Lock()
+	got := processedIssues
+	mu.Unlock()
+	if len(got) != 1 {
+		t.Fatalf("checkForNewIssues: dispatched %d issues, want 1", len(got))
+	}
+	if got[0].Number != 43 {
+		t.Errorf("checkForNewIssues: dispatched issue #%d, want #43", got[0].Number)
+	}
+}
+
 // GH-2276: Auto-retry issues with pilot-retry-ready (PR closed without merge)
 
 func TestPoller_AutoRetryRetryReadyIssue_FirstRetry(t *testing.T) {

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -99,8 +99,9 @@ const (
 	LabelTitleRejected = "pilot-title-rejected" // GH-2363: title guard escalation; blocks auto-retry until human edits title
 	LabelSuperseded    = "pilot-superseded"     // GH-2402: sub-issue auto-closed because parent epic already shipped the work
 	LabelBlocked       = "pilot-blocked"        // GH-2402: deterministic failure that won't change between retries (e.g. non-conventional title)
-	LabelSpecIncomplete = "pilot-spec-incomplete" // GH-2619: issue body too thin to dispatch; first-strike warning
-	LabelSkipSpecCheck  = "pilot-skip-spec-check" // GH-2619: opt-out from spec quality gate (trivial micro-issues)
+	LabelNeedsClarification = "pilot-needs-clarification" // GH-2768: executor declined task as unactionable; blocks dispatch until label removed
+	LabelSpecIncomplete     = "pilot-spec-incomplete"     // GH-2619: issue body too thin to dispatch; first-strike warning
+	LabelSkipSpecCheck      = "pilot-skip-spec-check"     // GH-2619: opt-out from spec quality gate (trivial micro-issues)
 
 	// GH-2432: Retry-counter labels persist retry state across `pilot start`
 	// restarts (the in-memory retryReadyCount map was lost on restart, letting

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -38,7 +38,7 @@ var sparkBlocks = []rune{' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '
 type MetricsCardData struct {
 	TotalTokens, InputTokens, OutputTokens int
 	TotalCostUSD, CostPerTask              float64
-	TotalTasks, Succeeded, Failed          int
+	TotalTasks, Succeeded, Failed, Declined int
 	TokenHistory                           []int64   // 7 days
 	CostHistory                            []float64 // 7 days
 	TaskHistory                            []int     // 7 days
@@ -600,6 +600,7 @@ func (m *Model) hydrateFromStore() {
 		m.metricsCard.TotalTasks = taskCounts.Total
 		m.metricsCard.Succeeded = taskCounts.Succeeded
 		m.metricsCard.Failed = taskCounts.Failed
+		m.metricsCard.Declined = taskCounts.Declined
 	}
 
 	// Populate history panel from recent executions (most recent 5)
@@ -874,6 +875,7 @@ func storeRefreshCmd(store *memory.Store) tea.Cmd {
 			msg.metricsCard.TotalTasks = taskCounts.Total
 			msg.metricsCard.Succeeded = taskCounts.Succeeded
 			msg.metricsCard.Failed = taskCounts.Failed
+			msg.metricsCard.Declined = taskCounts.Declined
 		}
 
 		if msg.metricsCard.TotalTasks > 0 {
@@ -2032,7 +2034,11 @@ func (m Model) renderTaskCard(cw int) string {
 	ciw := cw - 6
 	value := fmt.Sprintf("%d", len(m.tasks))
 	detail1 := statusCompletedStyle.Render(fmt.Sprintf("✓ %d succeeded", m.metricsCard.Succeeded))
-	detail2 := statusFailedStyle.Render(fmt.Sprintf("✗ %d failed", m.metricsCard.Failed))
+	declinedSuffix := ""
+	if m.metricsCard.Declined > 0 {
+		declinedSuffix = fmt.Sprintf(" (%d declined)", m.metricsCard.Declined)
+	}
+	detail2 := statusFailedStyle.Render(fmt.Sprintf("✗ %d failed%s", m.metricsCard.Failed, declinedSuffix))
 
 	// Convert int history to float64
 	floats := make([]float64, len(m.metricsCard.TaskHistory))

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1639,11 +1639,12 @@ func (s *Store) GetLifetimeTokens() (*LifetimeTokens, error) {
 	return &lt, nil
 }
 
-// LifetimeTaskCounts holds cumulative succeeded/failed counts from all executions.
+// LifetimeTaskCounts holds cumulative succeeded/failed/declined counts from all executions.
 type LifetimeTaskCounts struct {
 	Total     int
 	Succeeded int
 	Failed    int
+	Declined  int
 }
 
 // GetLifetimeTaskCounts returns cumulative task counts across all executions.
@@ -1653,12 +1654,13 @@ func (s *Store) GetLifetimeTaskCounts() (*LifetimeTaskCounts, error) {
 		SELECT
 			COUNT(*),
 			COALESCE(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0)
+			COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN status = 'declined' THEN 1 ELSE 0 END), 0)
 		FROM executions
 	`)
 
 	var tc LifetimeTaskCounts
-	if err := row.Scan(&tc.Total, &tc.Succeeded, &tc.Failed); err != nil {
+	if err := row.Scan(&tc.Total, &tc.Succeeded, &tc.Failed, &tc.Declined); err != nil {
 		return nil, fmt.Errorf("failed to get lifetime task counts: %w", err)
 	}
 	return &tc, nil


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2768.

Closes #2768

## Changes

GitHub Issue #2768: chore(executor): wire DECLINED follow-up — poller skip + dashboard count + docs

## Context

PR #2767 ships the core DECLINED pipeline (parser + retry prompt + Result fields + dispatcher + GitHub label notifier). Three small loose ends from the original P3 plan didn't make it into the salvage:

1. Poller skip on \`pilot-needs-clarification\` label
2. Dashboard \`declined\` counter
3. One-paragraph docs entry

This is the explicit cleanup ticket. Single AC list. **DO NOT DECOMPOSE.** ~50 LoC total.

## Acceptance Criteria

1. **Poller guard.** In \`internal/adapters/github/poller.go\`, add \`pilot-needs-clarification\` to the same blocking-label set used for \`pilot-failed\`. Cover both \`checkForNewIssues\` AND \`findOldestUnprocessedIssue\`. Mirror the existing pattern exactly — do NOT introduce a new mechanism.
2. **Test.** \`TestPoller_SkipsNeedsClarification\` in \`internal/adapters/github/poller_test.go\`, mirroring whatever test covers \`pilot-failed\` skip.
3. **Dashboard counter.** In \`internal/dashboard/...\`, find the existing \`completed\`/\`failed\` aggregation and add \`declined\` (sourced from \`executions.status='declined'\`). Render alongside. Minimal change — no UI redesign.
4. **Docs.** One paragraph appended to \`docs/content/features/...\` (find the page that documents retry/no-changes behaviour and add adjacent to it). Mention DECLINED, the \`pilot-needs-clarification\` label, and that removing the label re-enables dispatch.
5. \`make test\`, \`make lint\`, \`make build\` pass.

## Out of Scope

- Refactoring anything PR #2767 already shipped
- Changing the DECLINED parser, retry prompt, or label name
- Slack/Telegram notifications for declines
- Auto-clarification follow-up flow

## Implementation Plan

\`.agent/tasks/TASK-41-declined-followup.md\`

## Notes

- **Single Pilot issue, single commit, NO DECOMPOSITION.** Carries the \`no-decompose\` label as defense.
- Per memory \`bug_decomposer_no_meta_marker.md\` and \`bug_pilot_ghost_closes.md\`: previous P3 attempt (GH-2753) ghost-closed when decomposition kicked in. This issue is sized small enough that decomposition shouldn't trigger.
- Master plan: \`~/.claude/plans/use-nav-research-prepare-delegated-dragon.md\`