### PR TITLE
GH-2777: feat(executor): DECLINED-with-reason structured output for unactionable tasks

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -57,6 +57,7 @@
 | LLM classifier gate fix | ✅ | executor | - | - | Word count gate conditional on classifier type (v2.10.0, GH-1728) |
 | Execution mode auto-switch | ✅ | executor | - | - | Scope-based auto parallel/sequential via union-find (v2.25.0) |
 | Pattern compliance check | ✅ | executor | - | - | Self-review validates learned patterns from memory (v2.43.0, GH-1941) |
+| DECLINED structured output | ✅ | executor | - | - | Explicit DECLINED:<reason> marker; adds pilot-needs-clarification, avoids pilot-failed (v2.131.0, GH-2777) |
 | Self-review pattern extraction | ✅ | executor | - | - | Extract new patterns from self-review results and store (v2.44.0, GH-1955) |
 | Case-insensitive label matching | ✅ | executor | - | - | `Pilot` and `pilot` labels treated identically (v0.33.3) |
 | Commit SHA git fallback | ✅ | executor | - | - | Recover SHA via git log when output parsing misses it (v0.23.3) |

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -386,6 +386,25 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 			// generic failure-comment path to avoid duplicate noise.
 			if hr.Result.TitleRejected {
 				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Failed)
+			} else if hr.Result.Declined {
+				// GH-2777: Claude explicitly declined the task as unactionable.
+				// Add pilot-needs-clarification instead of pilot-failed so the poller
+				// blocks without incrementing the retry counter.
+				if err := client.RemoveLabel(ctx, parts[0], parts[1], issue.Number, github.LabelInProgress); err != nil {
+					slog.Debug("pilot-in-progress removal (declined)", "issue", issue.Number, "error", err)
+				}
+				if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelNeedsClarification}); err != nil {
+					logGitHubAPIError("AddLabels(needs-clarification)", parts[0], parts[1], issue.Number, err)
+				}
+				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Failed)
+				reason := hr.Result.DeclinedReason
+				if reason == "" {
+					reason = "task could not be implemented as specified"
+				}
+				comment := fmt.Sprintf("🤔 **Pilot needs clarification before implementing this task**\n\n**Reason**: %s\n\nTo resume, clarify the requirements and remove the `%s` label.", reason, github.LabelNeedsClarification)
+				if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
+					logGitHubAPIError("AddComment(declined)", parts[0], parts[1], issue.Number, err)
+				}
 			} else {
 				// result exists but Success is false - mark as failed
 				// GH-2402: Use pilot-blocked for deterministic failures so we don't retry.

--- a/docs/content/features/github.mdx
+++ b/docs/content/features/github.mdx
@@ -75,6 +75,27 @@ When Pilot completes a task:
 | `pilot` | Queue for execution |
 | `pilot:urgent` | Process before other tasks |
 | `pilot:hold` | Skip this issue |
+| `pilot-needs-clarification` | Task was declined as unactionable; blocks dispatch until removed |
+
+## Declined Tasks
+
+When Pilot determines a task cannot be implemented as specified — because the requirements are ambiguous, the feature already exists, or the necessary context is unavailable — it explicitly declines rather than silently producing no changes.
+
+**What happens:**
+
+1. Pilot adds the `pilot-needs-clarification` label and removes `pilot-in-progress`
+2. A comment is posted explaining the reason
+3. The issue is not marked as failed; it stays open
+
+**To resume:** Clarify the requirements in the issue body, then remove the `pilot-needs-clarification` label. Pilot will re-pick the issue on the next poll cycle.
+
+**Example decline comment:**
+
+> 🤔 **Pilot needs clarification before implementing this task**
+>
+> **Reason**: The authentication module requested already exists in `internal/auth/jwt.go`.
+>
+> To resume, clarify the requirements and remove the `pilot-needs-clarification` label.
 
 ## Webhooks (Advanced)
 

--- a/internal/adapters/github/notifier.go
+++ b/internal/adapters/github/notifier.go
@@ -129,6 +129,25 @@ func (n *Notifier) NotifyTaskFailed(ctx context.Context, owner, repo string, iss
 	return nil
 }
 
+// NotifyTaskDeclined posts a comment and swaps labels when Claude declined the task
+// as unactionable (GH-2777). Adds pilot-needs-clarification, removes pilot-in-progress.
+func (n *Notifier) NotifyTaskDeclined(ctx context.Context, owner, repo string, issueNum int, reason string) error {
+	if err := n.client.RemoveLabel(ctx, owner, repo, issueNum, LabelInProgress); err != nil {
+		_ = err // best-effort
+	}
+
+	if err := n.client.AddLabels(ctx, owner, repo, issueNum, []string{LabelNeedsClarification}); err != nil {
+		return fmt.Errorf("failed to add needs-clarification label: %w", err)
+	}
+
+	comment := fmt.Sprintf("🤔 **Pilot needs clarification before implementing this task**\n\n**Reason**: %s\n\nTo resume, clarify the requirements and remove the `%s` label.", reason, LabelNeedsClarification)
+	if _, err := n.client.AddComment(ctx, owner, repo, issueNum, comment); err != nil {
+		return fmt.Errorf("failed to add declined comment: %w", err)
+	}
+
+	return nil
+}
+
 // LinkPR adds a comment linking the created PR
 func (n *Notifier) LinkPR(ctx context.Context, owner, repo string, issueNum int, prNumber int, prURL string) error {
 	comment := fmt.Sprintf("🔗 **Pull Request Created**: #%d\n\n%s\n\n_This PR implements the changes for this issue._", prNumber, prURL)

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -67,6 +67,9 @@ const (
 	// a refusal or "task already done" response. The final assistant message holds
 	// the refusal reason. GH-2328.
 	ErrorTypeNoChanges ClaudeCodeErrorType = "no_changes"
+	// ErrorTypeDeclined indicates Claude explicitly declined the task as unactionable,
+	// emitting a structured DECLINED:<reason> marker in its response. GH-2777.
+	ErrorTypeDeclined ClaudeCodeErrorType = "declined"
 	// ErrorTypeUnknown indicates an unclassified error
 	ErrorTypeUnknown ClaudeCodeErrorType = "unknown"
 )

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -270,6 +270,12 @@ type ExecutionResult struct {
 	// guard and the runner has already posted a structured "how to fix" comment
 	// (GH-2363). Callers should skip their generic failure-comment path.
 	TitleRejected bool
+	// Declined is true when Claude explicitly refused the task as unactionable,
+	// emitting a DECLINED:<reason> marker in its response (GH-2777).
+	// When true, callers should add pilot-needs-clarification instead of pilot-failed.
+	Declined bool
+	// DeclinedReason is the human-readable reason Claude provided for the decline.
+	DeclinedReason string
 }
 
 // ProgressCallback is a function called during execution with progress updates.
@@ -941,6 +947,26 @@ func truncateDiagnostic(s string, max int) string {
 		return s
 	}
 	return s[:max] + "\n[...truncated]"
+}
+
+// parseDeclinedReason extracts the reason from a DECLINED:<reason> marker
+// emitted by Claude when a task is explicitly unactionable. Returns the reason
+// and true if found, or ("", false) if no marker is present. GH-2777.
+func parseDeclinedReason(text string) (string, bool) {
+	const marker = "DECLINED:"
+	idx := strings.Index(text, marker)
+	if idx == -1 {
+		return "", false
+	}
+	reason := strings.TrimSpace(text[idx+len(marker):])
+	// Trim to the first newline so we don't swallow prose that follows.
+	if nl := strings.Index(reason, "\n"); nl != -1 {
+		reason = strings.TrimSpace(reason[:nl])
+	}
+	if reason == "" {
+		return "", false
+	}
+	return reason, true
 }
 
 // persistBackendDiagnostics writes the backend's stderr, error type, and final
@@ -2180,20 +2206,33 @@ retrySucceeded:
 				)
 				r.reportProgress(task.ID, "Retry", 91, "No commits detected, retrying...")
 
-				// Build retry prompt with explicit instruction
+				// Build retry prompt with explicit instruction.
+				// GH-2777: Offer DECLINED:<reason> as an escape hatch so Claude can
+				// signal that a task is genuinely unactionable rather than silently
+				// producing no output. The DECLINED path avoids the pilot-failed label
+				// and adds pilot-needs-clarification instead.
 				retryPrompt := fmt.Sprintf(`## Retry: No Changes Detected
 
-The previous execution completed but made no code changes. This task requires actual implementation.
+The previous execution completed but made no code changes.
 
 **Original Task:** %s
 
-**Instructions:**
-1. Read the task requirements carefully
-2. Implement the required changes
-3. Create at least one commit with your changes
-4. Do NOT just analyze or plan - actually write and commit code
+%s
 
-%s`, task.Title, task.Description)
+**You have two options:**
+
+**Option A — Implement:** If this task is actionable, implement the required changes and create at least one git commit. Do NOT just analyze or plan — actually write and commit code.
+
+**Option B — Decline:** If this task is genuinely unactionable (e.g. the requirements are ambiguous, the requested feature already exists, or it would require information you don't have), output exactly one line in this format and nothing else after it:
+
+  DECLINED:<concise reason — one sentence>
+
+Examples of valid DECLINED lines:
+  DECLINED: The authentication module requested already exists in internal/auth/jwt.go.
+  DECLINED: The issue asks to "improve performance" without specifying which endpoint or metric.
+  DECLINED: This requires production database credentials that are not available in this environment.
+
+Only use DECLINED if implementation is truly impossible or undefined. Do not decline due to difficulty alone.`, task.Title, task.Description)
 
 				// Execute retry
 				noopRetryAllowed, noopRetryMCP := r.executionToolOptions()
@@ -2235,16 +2274,46 @@ The previous execution completed but made no code changes. This task requires ac
 				commitCount, _ = git.CountNewCommits(ctx, baseBranch)
 				if commitCount == 0 {
 					result.Success = false
-					// GH-2328: classify this as ErrorTypeNoChanges and carry the
-					// final assistant message so the failure comment surfaces the
-					// refusal reason instead of a generic "no changes" string.
+
+					// GH-2777: Collect the last assistant text from the retry response
+					// so we can check for an explicit DECLINED marker first.
 					refusal := ""
 					if backendResult != nil {
 						refusal = strings.TrimSpace(backendResult.LastAssistantText)
-						if retryResult != nil && strings.TrimSpace(retryResult.LastAssistantText) != "" {
-							refusal = strings.TrimSpace(retryResult.LastAssistantText)
-						}
 					}
+					if retryResult != nil && strings.TrimSpace(retryResult.LastAssistantText) != "" {
+						refusal = strings.TrimSpace(retryResult.LastAssistantText)
+					}
+
+					// GH-2777: Check for an explicit DECLINED:<reason> marker before
+					// classifying as a generic no_changes failure. DECLINED avoids
+					// pilot-failed and instead adds pilot-needs-clarification.
+					if declinedReason, ok := parseDeclinedReason(refusal); ok {
+						result.Declined = true
+						result.DeclinedReason = declinedReason
+						if backendResult != nil {
+							backendResult.ErrorType = string(ErrorTypeDeclined)
+						}
+						log.Warn("Task declined by executor",
+							slog.String("task_id", task.ID),
+							slog.String("reason", declinedReason),
+						)
+						r.reportProgress(task.ID, "Declined", 100, "Task declined: "+declinedReason)
+						r.persistBackendDiagnostics(task.ID, backendResult)
+
+						if recorder != nil {
+							recorder.SetModel(result.ModelName)
+							recorder.SetNavigator(state.hasNavigator)
+							if finErr := recorder.Finish("declined"); finErr != nil {
+								log.Warn("Failed to finish recording", slog.Any("error", finErr))
+							}
+						}
+						return result, nil
+					}
+
+					// GH-2328: classify this as ErrorTypeNoChanges and carry the
+					// final assistant message so the failure comment surfaces the
+					// refusal reason instead of a generic "no changes" string.
 					if refusal != "" {
 						result.Error = fmt.Sprintf("no_changes: Claude completed but made no code changes after retry — %s", refusal)
 					} else {
@@ -3162,7 +3231,9 @@ func (r *Runner) recordLearning(ctx context.Context, task *Task, result *Executi
 		return
 	}
 	statusStr := "completed"
-	if !result.Success {
+	if result.Declined {
+		statusStr = "declined"
+	} else if !result.Success {
 		statusStr = "failed"
 	}
 	exec := &memory.Execution{

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3588,3 +3588,185 @@ func TestRunner_PRCreate_HasCommits_ProceedsToCreate(t *testing.T) {
 		t.Errorf("Expected push failed error (guard passed), got: %q", result.Error)
 	}
 }
+
+// TestParseDeclinedReason verifies the DECLINED:<reason> marker extraction. GH-2777.
+func TestParseDeclinedReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantReason string
+		wantFound  bool
+	}{
+		{
+			name:       "simple marker",
+			input:      "DECLINED: The module already exists in internal/auth/jwt.go.",
+			wantReason: "The module already exists in internal/auth/jwt.go.",
+			wantFound:  true,
+		},
+		{
+			name:       "marker with leading prose",
+			input:      "I analyzed the codebase.\nDECLINED: Requirements are too vague to implement safely.",
+			wantReason: "Requirements are too vague to implement safely.",
+			wantFound:  true,
+		},
+		{
+			name:       "marker followed by trailing prose",
+			input:      "DECLINED: Feature already exists.\n\nHere is more detail about why...",
+			wantReason: "Feature already exists.",
+			wantFound:  true,
+		},
+		{
+			name:      "no marker — implementation text",
+			input:     "I implemented the feature in internal/foo/bar.go and committed it.",
+			wantFound: false,
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			wantFound: false,
+		},
+		{
+			name:      "marker with empty reason",
+			input:     "DECLINED:",
+			wantFound: false,
+		},
+		{
+			name:      "marker with only whitespace reason",
+			input:     "DECLINED:   ",
+			wantFound: false,
+		},
+		{
+			name:       "marker without space after colon",
+			input:      "DECLINED:needs-clarification",
+			wantReason: "needs-clarification",
+			wantFound:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, found := parseDeclinedReason(tt.input)
+			if found != tt.wantFound {
+				t.Errorf("parseDeclinedReason(%q) found=%v, want %v", tt.input, found, tt.wantFound)
+			}
+			if found && reason != tt.wantReason {
+				t.Errorf("parseDeclinedReason(%q) reason=%q, want %q", tt.input, reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// mockSequentialBackend returns different results per call index. GH-2777.
+type mockSequentialBackend struct {
+	mu      sync.Mutex
+	results []*BackendResult
+	idx     int
+}
+
+func (m *mockSequentialBackend) Name() string     { return "mock-sequential" }
+func (m *mockSequentialBackend) IsAvailable() bool { return true }
+func (m *mockSequentialBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.idx >= len(m.results) {
+		return m.results[len(m.results)-1], nil
+	}
+	r := m.results[m.idx]
+	m.idx++
+	return r, nil
+}
+
+// TestRunner_DECLINED_Path verifies that when the retry result contains a
+// DECLINED:<reason> marker, result.Declined is set to true and no failure
+// escalation occurs (success=false but Declined=true, not a generic no_changes). GH-2777.
+func TestRunner_DECLINED_Path(t *testing.T) {
+	const branch = "pilot/GH-7777"
+	dir := setupPRGuardRepo(t, branch, false) // no commits — triggers no-commit retry
+
+	backend := &mockSequentialBackend{
+		results: []*BackendResult{
+			// First call: successful but no commits
+			{Success: true, Output: "analysis complete"},
+			// Second call (retry): returns DECLINED marker
+			{Success: true, Output: "I reviewed the task.", LastAssistantText: "DECLINED: The feature requested already exists in internal/auth/handler.go."},
+		},
+	}
+
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	task := &Task{
+		ID:          "GH-7777",
+		Title:       "feat(auth): add JWT handler",
+		Description: "Add JWT authentication handler",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    true,
+	}
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if result.Success {
+		t.Error("Expected Success=false for declined task")
+	}
+	if !result.Declined {
+		t.Error("Expected result.Declined=true, got false")
+	}
+	if result.DeclinedReason == "" {
+		t.Error("Expected non-empty DeclinedReason")
+	}
+	if !strings.Contains(result.DeclinedReason, "already exists") {
+		t.Errorf("DeclinedReason %q does not contain expected text", result.DeclinedReason)
+	}
+	// Must NOT be classified as no_changes
+	if strings.HasPrefix(result.Error, "no_changes:") {
+		t.Errorf("Declined task should not have no_changes error, got: %q", result.Error)
+	}
+}
+
+// TestRunner_NoChanges_NoDecline verifies that when the retry response contains
+// no DECLINED marker, the path falls through to the standard no_changes error. GH-2777.
+func TestRunner_NoChanges_NoDecline(t *testing.T) {
+	const branch = "pilot/GH-7778"
+	dir := setupPRGuardRepo(t, branch, false) // no commits
+
+	backend := &mockSequentialBackend{
+		results: []*BackendResult{
+			{Success: true, Output: "analysis complete"},
+			// Retry produces no commits and no DECLINED marker
+			{Success: true, Output: "I reviewed the code but found nothing to change.", LastAssistantText: "The codebase looks good as-is."},
+		},
+	}
+
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	task := &Task{
+		ID:          "GH-7778",
+		Title:       "fix(executor): update handler",
+		Description: "Update the handler logic",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    true,
+	}
+
+	result, err := runner.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if result.Success {
+		t.Error("Expected failure, got success")
+	}
+	if result.Declined {
+		t.Error("result.Declined should be false when no DECLINED marker present")
+	}
+	if !strings.HasPrefix(result.Error, "no_changes:") {
+		t.Errorf("Expected no_changes error, got: %q", result.Error)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1022,7 +1022,7 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 	}
 
 	// Set completed_at for terminal states
-	if status == "completed" || status == "failed" || status == "cancelled" {
+	if status == "completed" || status == "failed" || status == "cancelled" || status == "declined" {
 		return s.withRetry("UpdateExecutionStatus", func() error {
 			_, err := s.db.Exec(`
 				UPDATE executions


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2777.

Closes #2777

## Changes

GitHub Issue #2777: feat(executor): DECLINED-with-reason structured output for unactionable tasks

<!--autopilot-meta
parent: GH-2753
inherited-spec: true
-->

Parent: GH-2753

Implement the full DECLINED path end-to-end as a single unit per the task's explicit "keep as single issue" directive. Add `parseDeclinedReason` helper and `ErrorTypeDeclined` constant in `internal/executor/runner.go`, rewrite the retry prompt at lines 2176-2188 to offer implement-or-DECLINED outcomes with examples, branch on parse at lines 2228-2253 to set `result.Declined`/`result.DeclinedReason` and status `declined` without failure escalation, extend the Result type with the new fields, wire GitHub-side label flow (`pilot-needs-clarification` add, `pilot-in-progress` remove, comment with reason + clarification hint) in the executor's GitHub integration path, add `pilot-needs-clarification` to the blocking-label set in `internal/adapters/github/poller.go`, surface a `declined` count in the dashboard alongside completed/failed, verify the `executions.status` schema accepts `declined` (extending the allow-list if needed), add table-driven tests for `parseDeclinedReason`, `TestRunner_DECLINED_Path`, `TestRunner_NoChanges_NoDecline`, and a poller skip-on-label test, document the new behavior in `docs/content/features/...`, and ensure `make test`, `make lint`, `make build` pass. Splitting this would fragment runner.go edits across parallel subtasks and risks the cascade patterns flagged in the linked bug notes; the entire change is ~150 LoC and stays cohesive as one PR.