### PR TITLE
fix(executor): decomposer respects prose intent (single AC, do not decompose)

### DIFF
--- a/internal/executor/decompose.go
+++ b/internal/executor/decompose.go
@@ -55,6 +55,30 @@ const NoDecomposeLabel = "no-decompose"
 // to bypass epic planning and decomposition (GH-1687).
 const NoPlanKeyword = "[no-plan]"
 
+// noDecomposePhrases are precompiled patterns that signal a task must not be split.
+// Matched against lowercased title + description (GH-2783).
+var noDecomposePhrases = []*regexp.Regexp{
+	regexp.MustCompile(`single ac list`),
+	regexp.MustCompile(`do not decompose`),
+	regexp.MustCompile(`do not split`),
+	regexp.MustCompile(`single pilot issue`),
+	regexp.MustCompile(`keep as .+ single`),
+	regexp.MustCompile(`splitting this would`),
+	regexp.MustCompile(`<!--\s*pilot:no-decompose\s*-->`),
+}
+
+// HasNoDecomposePhrase returns true when the task title or description contains
+// prose that signals the task must not be split into subtasks (GH-2783).
+func HasNoDecomposePhrase(task *Task) bool {
+	haystack := strings.ToLower(task.Title + " " + task.Description)
+	for _, re := range noDecomposePhrases {
+		if re.MatchString(haystack) {
+			return true
+		}
+	}
+	return false
+}
+
 // TaskDecomposer handles breaking complex tasks into smaller subtasks.
 type TaskDecomposer struct {
 	config     *DecomposeConfig

--- a/internal/executor/decompose_test.go
+++ b/internal/executor/decompose_test.go
@@ -676,6 +676,62 @@ improving the overall design.`,
 	}
 }
 
+func TestHasNoDecomposePhrase(t *testing.T) {
+	tests := []struct {
+		name     string
+		title    string
+		body     string
+		expected bool
+	}{
+		// Each canonical phrase in body → true
+		{name: "single AC list in body", body: "This is a single AC list for the task.", expected: true},
+		{name: "do not decompose in body", body: "Please do not decompose this issue.", expected: true},
+		{name: "do not split in body", body: "do not split this task.", expected: true},
+		{name: "single Pilot issue in body", body: "This is a single Pilot issue.", expected: true},
+		{name: "keep as ... single in body", body: "Keep as one single task.", expected: true},
+		{name: "splitting this would in body", body: "Splitting this would fragment the changes.", expected: true},
+		{name: "HTML marker in body", body: "<!-- pilot:no-decompose -->", expected: true},
+		// Each canonical phrase in title → true
+		{name: "do not decompose in title", title: "do not decompose this", expected: true},
+		{name: "do not split in title", title: "do not split this", expected: true},
+		{name: "single Pilot issue in title", title: "single Pilot issue with multiple steps", expected: true},
+		{name: "splitting this would in title", title: "splitting this would break things", expected: true},
+		// Mixed-case → true
+		{name: "mixed case single AC list", body: "This has a Single AC List of criteria.", expected: true},
+		{name: "mixed case do not decompose", body: "DO NOT DECOMPOSE this task.", expected: true},
+		{name: "mixed case HTML marker", body: "<!-- Pilot:No-Decompose -->", expected: true},
+		// HTML marker with extra whitespace → true
+		{name: "HTML marker with spaces", body: "<!--  pilot:no-decompose  -->", expected: true},
+		// Phrase as unrelated substring → false
+		{name: "single word only", body: "This is a single change to a file.", expected: false},
+		{name: "split without do not", body: "We should split this into modules.", expected: false},
+		{name: "pilot issue without single", body: "This is a pilot issue for adding auth.", expected: false},
+		{name: "keep without single", body: "Keep as is without further changes.", expected: false},
+		// Empty → false
+		{name: "empty body", title: "", body: "", expected: false},
+		// Genuine multi-scope body without opt-out → false
+		{
+			name:     "genuine multi-scope body",
+			title:    "Refactor auth and payments",
+			body:     "Update internal/auth/handler.go and internal/payments/service.go to use the new middleware.",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &Task{
+				Title:       tt.title,
+				Description: tt.body,
+			}
+			got := HasNoDecomposePhrase(task)
+			if got != tt.expected {
+				t.Errorf("HasNoDecomposePhrase() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestBuildSubtaskDescription(t *testing.T) {
 	parent := &Task{
 		ID:    "GH-150",

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1221,6 +1221,9 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	if !hasNoDecompose && HasNoPlanKeyword(task) {
 		hasNoDecompose = true
 	}
+	if !hasNoDecompose && HasNoDecomposePhrase(task) {
+		hasNoDecompose = true
+	}
 
 	// GH-1588: Diagnostic logging for epic detection
 	r.log.Info("Epic detection check",


### PR DESCRIPTION
## Summary

- Adds `HasNoDecomposePhrase(*Task) bool` to `internal/executor/decompose.go` with 7 precompiled regexp patterns matched against lowercased title + description
- Wires the new helper into `runner.go` after the existing `HasNoPlanKeyword` check so issues containing explicit anti-split prose skip epic decomposition
- Adds 21 table-driven tests covering all canonical phrases, mixed-case, HTML marker, negative cases, and multi-scope bodies

Fixes the empirically observed failure from GH-2777 where a body containing *"Splitting this would fragment runner.go edits across parallel subtasks"* caused the decomposer to split the issue into 3 subtasks despite the clear prose intent.

## Test plan

- [ ] `TestHasNoDecomposePhrase` — 21 subtests, all pass
- [ ] Full executor suite passes (`go test ./internal/executor/...`)
- [ ] `make lint` — 0 issues
- [ ] `make build` — clean

Closes #2783