### PR TITLE
feat(executor): pre-flight intent judge — reject vague/conflicting/stale issues before execution

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-05-07 (v2.53.0)
+**Last Updated:** 2026-05-06 (v2.53.0)
 
 ## Legend
 
@@ -19,7 +19,6 @@
 |---------|--------|---------|-------------|------------|-------|
 | Task execution | ✅ | executor | `pilot task` | - | Claude Code subprocess |
 | Branch creation | ✅ | executor | `--no-branch` disables | - | Auto `pilot/TASK-XXX` |
-| Scoped commit staging | ✅ | executor | - | - | Excludes `.agent/`, `.claude/`, lock files etc. from auto-stage (GH-2797, v2.131.3) |
 | PR creation | ✅ | executor | `--create-pr` | - | Via `gh pr create` |
 | Progress display | ✅ | executor | - | - | Lipgloss visual bar |
 | Navigator detection | ✅ | executor | - | - | Auto-prefix if `.agent/` exists |
@@ -29,6 +28,7 @@
 | Task dispatcher | ✅ | executor | - | - | Per-project queue (GH-46) |
 | Sequential execution | ✅ | executor | `--sequential` | `orchestrator.execution.mode` | Wait for PR merge before next issue |
 | Self-review | ✅ | executor | - | - | Auto code review before PR push (v0.13.0) |
+| Pre-flight intent judge | ✅ | executor/github | - | `executor.pre_flight_judge.enabled` | Haiku evaluates issue before dispatch; rejects vague/question/conflicting/stale/out-of-scope issues (v2.132.0, GH-2802) |
 | Auto build gate | ✅ | executor | - | - | Minimal build gate when none configured (v0.13.0) |
 | Epic decomposition | ✅ | executor | - | `decompose.enabled` | PlanEpic + CreateSubIssues for complex tasks (v0.20.2) |
 | Epic scope guard | ✅ | executor | - | - | Consolidate single-package epics to prevent conflict cascade (v1.0.11) |

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -760,6 +760,19 @@ Examples:
 						pollerOpts = append(pollerOpts, github.WithExecutionChecker(gwStore, projectPath))
 					}
 
+					// GH-2802: Wire pre-flight judge when enabled
+					if cfg.Executor != nil && cfg.Executor.PreFlightJudge != nil && cfg.Executor.PreFlightJudge.Enabled {
+						apiKey := cfg.Executor.PreFlightJudge.APIKey
+						if apiKey == "" {
+							apiKey = os.Getenv("ANTHROPIC_API_KEY")
+						}
+						pfJudge := executor.NewIntentJudge(apiKey)
+						pollerOpts = append(pollerOpts, github.WithPreFlightJudge(preFlightJudgeShim{judge: pfJudge}))
+						if gwStore != nil {
+							pollerOpts = append(pollerOpts, github.WithExecutionSaver(storeExecutionSaver{store: gwStore}))
+						}
+					}
+
 					// Create rate limit retry scheduler
 					repoParts := strings.Split(cfg.Adapters.GitHub.Repo, "/")
 					if len(repoParts) != 2 {
@@ -2075,6 +2088,19 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					pollerOpts = append(pollerOpts, github.WithExecutionChecker(store, projPath))
 				}
 
+				// GH-2802: Wire pre-flight judge when enabled
+				if cfg.Executor != nil && cfg.Executor.PreFlightJudge != nil && cfg.Executor.PreFlightJudge.Enabled {
+					apiKey := cfg.Executor.PreFlightJudge.APIKey
+					if apiKey == "" {
+						apiKey = os.Getenv("ANTHROPIC_API_KEY")
+					}
+					pfJudge := executor.NewIntentJudge(apiKey)
+					pollerOpts = append(pollerOpts, github.WithPreFlightJudge(preFlightJudgeShim{judge: pfJudge}))
+					if store != nil {
+						pollerOpts = append(pollerOpts, github.WithExecutionSaver(storeExecutionSaver{store: store}))
+					}
+				}
+
 				// Capture variables for closures
 				sourceRepo := repoFullName
 				projPathCapture := projPath
@@ -2724,6 +2750,44 @@ func (s storeTaskChecker) IsTaskQueued(taskID string) bool {
 		return false // Don't block retry on DB errors
 	}
 	return queued
+}
+
+// preFlightJudgeShim adapts *executor.IntentJudge to the github.PreFlightJudger interface.
+// GH-2802: Keeps the poller package decoupled from the executor package.
+type preFlightJudgeShim struct {
+	judge *executor.IntentJudge
+}
+
+func (s preFlightJudgeShim) JudgeIssue(ctx context.Context, title, body, repoContext string) (github.Verdict, error) {
+	v, err := s.judge.JudgeIssue(ctx, title, body, repoContext)
+	if err != nil {
+		return github.Verdict{}, err
+	}
+	return github.Verdict{
+		Accepted:   !v.IsRejection(),
+		Decision:   string(v.Decision),
+		Reason:     v.Reason,
+		Confidence: v.Confidence,
+	}, nil
+}
+
+// storeExecutionSaver adapts *memory.Store to the github.ExecutionSaver interface.
+// GH-2802: Persists pre-flight rejection records for observability.
+type storeExecutionSaver struct {
+	store *memory.Store
+}
+
+func (s storeExecutionSaver) SaveDeclinedExecution(taskID, projectPath, status, reason string) error {
+	now := time.Now()
+	return s.store.SaveExecution(&memory.Execution{
+		ID:          fmt.Sprintf("%s-preflight-%d", taskID, now.UnixNano()),
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      status,
+		Error:       reason,
+		CreatedAt:   now,
+		CompletedAt: &now,
+	})
 }
 
 // countGitHubRepos counts unique GitHub repos from the default config and project-level entries.

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -51,6 +51,28 @@ type ExecutionChecker interface {
 	HasCompletedExecution(taskID, projectPath string) (bool, error)
 }
 
+// Verdict is the poller-side result of a pre-flight judgment.
+// Mirrors executor.PreFlightVerdict but keeps the poller decoupled from the executor
+// package to avoid import cycles.
+type Verdict struct {
+	Accepted   bool
+	Decision   string
+	Reason     string
+	Confidence float64
+}
+
+// PreFlightJudger evaluates issues before dispatch to avoid burning worker slots on
+// vague, ambiguous, or otherwise unactionable issues (GH-2802).
+// Implemented by a shim in cmd/pilot/main.go that wraps *executor.IntentJudge.
+type PreFlightJudger interface {
+	JudgeIssue(ctx context.Context, title, body, repoContext string) (Verdict, error)
+}
+
+// ExecutionSaver persists pre-flight rejection records for observability.
+type ExecutionSaver interface {
+	SaveDeclinedExecution(taskID, projectPath, status, reason string) error
+}
+
 // IssueResult is returned by the issue handler with PR information
 type IssueResult struct {
 	Success    bool
@@ -121,6 +143,11 @@ type Poller struct {
 	// when pilot-done label failed to apply.
 	execChecker ExecutionChecker
 	projectPath string
+
+	// GH-2802: Pre-flight judge evaluates issues before dispatch.
+	// nil means disabled (config flag executor.pre_flight_judge.enabled=false).
+	preFlightJudge PreFlightJudger
+	execSaver      ExecutionSaver
 }
 
 // PollerOption configures a Poller
@@ -241,6 +268,21 @@ func WithMaxConcurrent(n int) PollerOption {
 			n = 1
 		}
 		p.maxConcurrent = n
+	}
+}
+
+// WithPreFlightJudge sets the pre-flight issue quality judge (GH-2802).
+// Pass nil to disable (same as not calling this option).
+func WithPreFlightJudge(judge PreFlightJudger) PollerOption {
+	return func(p *Poller) {
+		p.preFlightJudge = judge
+	}
+}
+
+// WithExecutionSaver sets the store used to persist pre-flight rejection records.
+func WithExecutionSaver(saver ExecutionSaver) PollerOption {
+	return func(p *Poller) {
+		p.execSaver = saver
 	}
 }
 
@@ -437,6 +479,23 @@ func (p *Poller) startSequential(ctx context.Context) {
 			slog.Int("number", issue.Number),
 			slog.String("title", issue.Title),
 		)
+
+		// GH-2802: Pre-flight judge — evaluate issue quality before burning a worker slot.
+		if p.preFlightJudge != nil {
+			verdict, pfErr := p.preFlightJudge.JudgeIssue(ctx, issue.Title, issue.Body, "")
+			if pfErr != nil {
+				p.logger.Warn("pre-flight judge error (fail-open)",
+					slog.Int("issue", issue.Number),
+					slog.Any("error", pfErr))
+			} else if !verdict.Accepted {
+				p.logger.Info("pre-flight rejected issue",
+					slog.Int("issue", issue.Number),
+					slog.String("decision", verdict.Decision),
+					slog.String("reason", verdict.Reason))
+				p.handlePreFlightReject(ctx, issue, verdict)
+				continue // skip dispatch; label removal re-triggers on next poll
+			}
+		}
 
 		result, err := p.processIssueSequential(ctx, issue)
 		if err != nil {
@@ -984,6 +1043,23 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 			)
 		}
 
+		// GH-2802: Pre-flight judge — evaluate issue quality before burning a worker slot.
+		if p.preFlightJudge != nil {
+			verdict, pfErr := p.preFlightJudge.JudgeIssue(ctx, issue.Title, issue.Body, "")
+			if pfErr != nil {
+				p.logger.Warn("pre-flight judge error (fail-open)",
+					slog.Int("issue", issue.Number),
+					slog.Any("error", pfErr))
+			} else if !verdict.Accepted {
+				p.logger.Info("pre-flight rejected issue",
+					slog.Int("issue", issue.Number),
+					slog.String("decision", verdict.Decision),
+					slog.String("reason", verdict.Reason))
+				p.handlePreFlightReject(ctx, issue, verdict)
+				continue // skip markProcessed so label removal re-triggers dispatch
+			}
+		}
+
 		// Mark processed immediately to prevent duplicate dispatch on next tick
 		p.markProcessed(issue.Number)
 
@@ -1074,6 +1150,44 @@ func (p *Poller) unmarkProcessed(number int) {
 	if p.processedStore != nil {
 		if err := p.processedStore.UnmarkIssueProcessed(number); err != nil {
 			p.logger.Warn("Failed to unmark processed issue", slog.Int("issue", number), slog.Any("error", err))
+		}
+	}
+}
+
+// handlePreFlightReject handles an issue rejected by the pre-flight judge (GH-2802):
+//   - adds pilot-needs-clarification label so the issue is filtered on subsequent polls
+//   - posts a comment explaining the decision and how to re-trigger
+//   - saves a declined-preflight execution record if an ExecutionSaver is wired
+//
+// The caller must NOT call markProcessed after this so that label removal re-triggers dispatch.
+func (p *Poller) handlePreFlightReject(ctx context.Context, issue *Issue, verdict Verdict) {
+	taskID := fmt.Sprintf("GH-%d", issue.Number)
+
+	if err := p.client.AddLabels(ctx, p.owner, p.repo, issue.Number, []string{LabelNeedsClarification}); err != nil {
+		p.logger.Warn("pre-flight: failed to add needs-clarification label",
+			slog.Int("issue", issue.Number),
+			slog.Any("error", err))
+	}
+
+	comment := fmt.Sprintf(
+		"**Pre-flight check declined this issue.**\n\n"+
+			"**Decision:** `%s`\n"+
+			"**Reason:** %s\n"+
+			"**Confidence:** %.0f%%\n\n"+
+			"To re-trigger: edit the issue to address the above, then remove the `%s` label.",
+		verdict.Decision, verdict.Reason, verdict.Confidence*100, LabelNeedsClarification,
+	)
+	if _, err := p.client.AddComment(ctx, p.owner, p.repo, issue.Number, comment); err != nil {
+		p.logger.Warn("pre-flight: failed to post rejection comment",
+			slog.Int("issue", issue.Number),
+			slog.Any("error", err))
+	}
+
+	if p.execSaver != nil {
+		if err := p.execSaver.SaveDeclinedExecution(taskID, p.projectPath, "declined-preflight", verdict.Reason); err != nil {
+			p.logger.Warn("pre-flight: failed to save execution record",
+				slog.Int("issue", issue.Number),
+				slog.Any("error", err))
 		}
 	}
 }

--- a/internal/adapters/github/poller_preflight_test.go
+++ b/internal/adapters/github/poller_preflight_test.go
@@ -1,0 +1,372 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// mockPreFlightJudger is a test double for PreFlightJudger.
+type mockPreFlightJudger struct {
+	verdict Verdict
+	err     error
+	calls   int32
+}
+
+func (m *mockPreFlightJudger) JudgeIssue(_ context.Context, _, _, _ string) (Verdict, error) {
+	atomic.AddInt32(&m.calls, 1)
+	return m.verdict, m.err
+}
+
+// mockExecutionSaver records SaveDeclinedExecution calls.
+type mockExecutionSaver struct {
+	mu   sync.Mutex
+	rows []savedRow
+}
+
+type savedRow struct {
+	taskID      string
+	projectPath string
+	status      string
+	reason      string
+}
+
+func (m *mockExecutionSaver) SaveDeclinedExecution(taskID, projectPath, status, reason string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rows = append(m.rows, savedRow{taskID: taskID, projectPath: projectPath, status: status, reason: reason})
+	return nil
+}
+
+// newTestPollerServer returns a minimal httptest.Server serving a single issue
+// and captures labels/comments added to it.
+type pollerTestServer struct {
+	server        *httptest.Server
+	mu            sync.Mutex
+	labelsAdded   []string
+	commentsAdded []string
+}
+
+func newPollerTestServer(t *testing.T, issues []*Issue) *pollerTestServer {
+	t.Helper()
+	pts := &pollerTestServer{}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/repos/test/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = fmt.Fprint(w, "[")
+			for i, iss := range issues {
+				if i > 0 {
+					_, _ = fmt.Fprint(w, ",")
+				}
+				_ = json.NewEncoder(w).Encode(iss)
+			}
+			_, _ = fmt.Fprint(w, "]")
+		}
+	})
+
+	for _, iss := range issues {
+		num := iss.Number
+		path := fmt.Sprintf("/repos/test/repo/issues/%d", num)
+		mux.HandleFunc(path+"/labels", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				var body struct {
+					Labels []string `json:"labels"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				pts.mu.Lock()
+				pts.labelsAdded = append(pts.labelsAdded, body.Labels...)
+				pts.mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprint(w, "[]")
+			}
+		})
+		mux.HandleFunc(path+"/comments", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				var body struct {
+					Body string `json:"body"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				pts.mu.Lock()
+				pts.commentsAdded = append(pts.commentsAdded, body.Body)
+				pts.mu.Unlock()
+				_, _ = fmt.Fprint(w, `{"id":1,"body":"ok"}`)
+			}
+		})
+		// Single issue GET (label refresh)
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			for _, iss2 := range issues {
+				if iss2.Number == num {
+					_ = json.NewEncoder(w).Encode(iss2)
+					return
+				}
+			}
+			w.WriteHeader(http.StatusNotFound)
+		})
+	}
+
+	pts.server = httptest.NewServer(mux)
+	return pts
+}
+
+func (pts *pollerTestServer) Close() { pts.server.Close() }
+
+// TestPoller_PreFlight_AcceptVerdictDispatches verifies that an accept verdict dispatches as today.
+func TestPoller_PreFlight_AcceptVerdictDispatches(t *testing.T) {
+	issue := &Issue{
+		Number:    42,
+		Title:     "feat: add login button",
+		Body:      "Add a login button to the nav header.",
+		State:     "open",
+		Labels:    []Label{{Name: "pilot"}},
+		CreatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	pts := newPollerTestServer(t, []*Issue{issue})
+	defer pts.Close()
+
+	judger := &mockPreFlightJudger{verdict: Verdict{Accepted: true, Decision: "accept", Confidence: 0.9}}
+	var dispatched int32
+	poller, err := NewPoller(
+		NewClientWithBaseURL("test-token", pts.server.URL),
+		"test/repo", "pilot", 50*time.Millisecond,
+		WithOnIssue(func(_ context.Context, iss *Issue) error {
+			atomic.AddInt32(&dispatched, 1)
+			return nil
+		}),
+		WithPreFlightJudge(judger),
+		WithMaxConcurrent(1),
+	)
+	if err != nil {
+		t.Fatalf("NewPoller: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	go poller.Start(ctx)
+	<-ctx.Done()
+
+	if atomic.LoadInt32(&dispatched) == 0 {
+		t.Error("expected issue to be dispatched when verdict is accept")
+	}
+	pts.mu.Lock()
+	defer pts.mu.Unlock()
+	if len(pts.labelsAdded) > 0 {
+		t.Errorf("expected no labels added on accept, got %v", pts.labelsAdded)
+	}
+}
+
+// TestPoller_PreFlight_RejectVerdictAddsLabelAndComment verifies that a reject verdict:
+// - adds pilot-needs-clarification label
+// - posts a comment
+// - does NOT dispatch the issue
+func TestPoller_PreFlight_RejectVerdictAddsLabelAndComment(t *testing.T) {
+	issue := &Issue{
+		Number:    43,
+		Title:     "??",
+		Body:      "",
+		State:     "open",
+		Labels:    []Label{{Name: "pilot"}},
+		CreatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	pts := newPollerTestServer(t, []*Issue{issue})
+	defer pts.Close()
+
+	judger := &mockPreFlightJudger{verdict: Verdict{
+		Accepted:   false,
+		Decision:   "reject_vague",
+		Reason:     "Issue title is too vague.",
+		Confidence: 0.92,
+	}}
+	saver := &mockExecutionSaver{}
+	var dispatched int32
+
+	poller, err := NewPoller(
+		NewClientWithBaseURL("test-token", pts.server.URL),
+		"test/repo", "pilot", 50*time.Millisecond,
+		WithOnIssue(func(_ context.Context, iss *Issue) error {
+			atomic.AddInt32(&dispatched, 1)
+			return nil
+		}),
+		WithPreFlightJudge(judger),
+		WithExecutionSaver(saver),
+		WithMaxConcurrent(1),
+	)
+	if err != nil {
+		t.Fatalf("NewPoller: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	go poller.Start(ctx)
+	<-ctx.Done()
+
+	if atomic.LoadInt32(&dispatched) > 0 {
+		t.Error("expected issue NOT to be dispatched on reject verdict")
+	}
+
+	pts.mu.Lock()
+	labelsAdded := pts.labelsAdded
+	commentsAdded := pts.commentsAdded
+	pts.mu.Unlock()
+
+	hasLabel := false
+	for _, l := range labelsAdded {
+		if l == LabelNeedsClarification {
+			hasLabel = true
+		}
+	}
+	if !hasLabel {
+		t.Errorf("expected %q label to be added, got: %v", LabelNeedsClarification, labelsAdded)
+	}
+	if len(commentsAdded) == 0 {
+		t.Error("expected a comment to be posted")
+	}
+
+	saver.mu.Lock()
+	defer saver.mu.Unlock()
+	if len(saver.rows) == 0 {
+		t.Error("expected an execution row to be saved")
+	}
+	if saver.rows[0].status != "declined-preflight" {
+		t.Errorf("expected status 'declined-preflight', got %q", saver.rows[0].status)
+	}
+}
+
+// TestPoller_PreFlight_JudgeError_FailOpen verifies that a judge error does not block dispatch.
+func TestPoller_PreFlight_JudgeError_FailOpen(t *testing.T) {
+	issue := &Issue{
+		Number:    44,
+		Title:     "feat: add feature",
+		Body:      "Add a feature.",
+		State:     "open",
+		Labels:    []Label{{Name: "pilot"}},
+		CreatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	pts := newPollerTestServer(t, []*Issue{issue})
+	defer pts.Close()
+
+	judger := &mockPreFlightJudger{err: fmt.Errorf("judge API unavailable")}
+	var dispatched int32
+
+	poller, err := NewPoller(
+		NewClientWithBaseURL("test-token", pts.server.URL),
+		"test/repo", "pilot", 50*time.Millisecond,
+		WithOnIssue(func(_ context.Context, iss *Issue) error {
+			atomic.AddInt32(&dispatched, 1)
+			return nil
+		}),
+		WithPreFlightJudge(judger),
+		WithMaxConcurrent(1),
+	)
+	if err != nil {
+		t.Fatalf("NewPoller: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	go poller.Start(ctx)
+	<-ctx.Done()
+
+	if atomic.LoadInt32(&dispatched) == 0 {
+		t.Error("expected issue to be dispatched (fail-open) when judge returns error")
+	}
+}
+
+// TestPoller_PreFlight_NilJudge_ExistingBehavior verifies that nil judge preserves existing behavior.
+func TestPoller_PreFlight_NilJudge_ExistingBehavior(t *testing.T) {
+	issue := &Issue{
+		Number:    45,
+		Title:     "feat: add feature",
+		Body:      "Add a feature.",
+		State:     "open",
+		Labels:    []Label{{Name: "pilot"}},
+		CreatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	pts := newPollerTestServer(t, []*Issue{issue})
+	defer pts.Close()
+
+	var dispatched int32
+
+	// No WithPreFlightJudge — nil judge
+	poller, err := NewPoller(
+		NewClientWithBaseURL("test-token", pts.server.URL),
+		"test/repo", "pilot", 50*time.Millisecond,
+		WithOnIssue(func(_ context.Context, iss *Issue) error {
+			atomic.AddInt32(&dispatched, 1)
+			return nil
+		}),
+		WithMaxConcurrent(1),
+	)
+	if err != nil {
+		t.Fatalf("NewPoller: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	go poller.Start(ctx)
+	<-ctx.Done()
+
+	if atomic.LoadInt32(&dispatched) == 0 {
+		t.Error("expected issue to be dispatched when pre-flight judge is disabled (nil)")
+	}
+}
+
+// TestPoller_PreFlight_RejectSkipsMarkProcessed verifies that label removal allows re-dispatch.
+// After rejection the issue should NOT be in the processed map, so removing
+// LabelNeedsClarification allows the next poll to dispatch it.
+func TestPoller_PreFlight_RejectSkipsMarkProcessed(t *testing.T) {
+	issue := &Issue{
+		Number:    46,
+		Title:     "??",
+		Body:      "",
+		State:     "open",
+		Labels:    []Label{{Name: "pilot"}},
+		CreatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	pts := newPollerTestServer(t, []*Issue{issue})
+	defer pts.Close()
+
+	callCount := int32(0)
+	judger := &mockPreFlightJudger{verdict: Verdict{
+		Accepted: false,
+		Decision: "reject_vague",
+		Reason:   "Vague.",
+	}}
+
+	poller, err := NewPoller(
+		NewClientWithBaseURL("test-token", pts.server.URL),
+		"test/repo", "pilot", 50*time.Millisecond,
+		WithOnIssue(func(_ context.Context, iss *Issue) error { return nil }),
+		WithPreFlightJudge(judger),
+		WithMaxConcurrent(1),
+	)
+	if err != nil {
+		t.Fatalf("NewPoller: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	go poller.Start(ctx)
+	<-ctx.Done()
+
+	calls := atomic.LoadInt32(&judger.calls)
+	atomic.StoreInt32(&callCount, calls)
+
+	// Issue should NOT be in the processed map (so removal of label allows retry)
+	poller.mu.RLock()
+	_, inProcessed := poller.processed[issue.Number]
+	poller.mu.RUnlock()
+
+	if inProcessed {
+		t.Error("rejected issue should NOT be in the processed map (so label removal re-triggers)")
+	}
+	if callCount == 0 {
+		t.Error("expected pre-flight judge to be called at least once")
+	}
+}

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -266,6 +266,11 @@ type BackendConfig struct {
 	// IntentJudge contains intent alignment settings for diff-vs-ticket verification
 	IntentJudge *IntentJudgeConfig `yaml:"intent_judge,omitempty"`
 
+	// PreFlightJudge contains pre-flight issue quality judge settings (GH-2802).
+	// When enabled, each issue is evaluated by Haiku before dispatch; vague/question/
+	// conflicting/stale/out-of-scope issues are declined without burning a worker slot.
+	PreFlightJudge *PreFlightJudgeConfig `yaml:"pre_flight_judge,omitempty"`
+
 	// Navigator contains Navigator auto-init settings
 	Navigator *NavigatorConfig `yaml:"navigator,omitempty"`
 
@@ -537,6 +542,25 @@ func DefaultIntentJudgeConfig() *IntentJudgeConfig {
 		Model:        "claude-haiku-4-5-20251001",
 		MaxDiffChars: 8000,
 	}
+}
+
+// PreFlightJudgeConfig configures the pre-flight issue quality judge (GH-2802).
+// When enabled, Haiku evaluates each issue before dispatch and declines
+// vague/question/conflicting/stale/out-of-scope issues without burning a worker slot.
+//
+// Example YAML configuration:
+//
+//	executor:
+//	  pre_flight_judge:
+//	    enabled: true
+//	    api_key: "${ANTHROPIC_API_KEY}"
+type PreFlightJudgeConfig struct {
+	// Enabled controls whether the pre-flight judge runs before dispatch. Default: false.
+	Enabled bool `yaml:"enabled"`
+
+	// APIKey is the Anthropic API key for the pre-flight judge.
+	// Falls back to ANTHROPIC_API_KEY env var when empty.
+	APIKey string `yaml:"api_key,omitempty"`
 }
 
 // ClaudeCodeConfig contains Claude Code backend configuration.

--- a/internal/executor/intent_judge.go
+++ b/internal/executor/intent_judge.go
@@ -51,12 +51,56 @@ func newIntentJudgeWithURL(apiKey, url string) *IntentJudge {
 	return j
 }
 
+// PreFlightDecision is the decision returned by the pre-flight intent judge.
+type PreFlightDecision string
+
+const (
+	PreFlightAccept           PreFlightDecision = "accept"
+	PreFlightRejectQuestion   PreFlightDecision = "reject_question"
+	PreFlightRejectVague      PreFlightDecision = "reject_vague"
+	PreFlightRejectConflicting PreFlightDecision = "reject_conflicting"
+	PreFlightRejectStale      PreFlightDecision = "reject_stale"
+	PreFlightRejectOutOfScope PreFlightDecision = "reject_out_of_scope"
+)
+
+// PreFlightVerdict is the result of a pre-flight issue evaluation.
+type PreFlightVerdict struct {
+	Decision   PreFlightDecision
+	Reason     string
+	Confidence float64
+}
+
+// IsRejection returns true if the verdict indicates the issue should be rejected.
+func (v *PreFlightVerdict) IsRejection() bool {
+	return v.Decision != PreFlightAccept
+}
+
 var (
 	verdictPassRegex    = regexp.MustCompile(`VERDICT:\s*PASS`)
 	verdictFailRegex    = regexp.MustCompile(`VERDICT:\s*FAIL`)
 	confidenceRegex     = regexp.MustCompile(`CONFIDENCE:\s*([0-9]*\.?[0-9]+)`)
 	maxDiffCharsDefault = 8000
+
+	preflightDecisionRegex   = regexp.MustCompile(`DECISION:\s*(\S+)`)
+	preflightReasonRegex     = regexp.MustCompile(`REASON:\s*(.+)`)
+	preflightConfidenceRegex = regexp.MustCompile(`CONFIDENCE:\s*([0-9]*\.?[0-9]+)`)
+	maxPreflightBodyChars    = 4000
 )
+
+const preflightJudgeSystemPrompt = `You are a pre-flight issue quality judge. Evaluate whether a GitHub issue is actionable for an autonomous AI developer.
+
+Classify the issue as exactly one of:
+- accept: clear, specific, implementable request with enough context
+- reject_question: issue is asking a question rather than requesting implementation
+- reject_vague: too vague or ambiguous to implement without further clarification
+- reject_conflicting: contains contradictory requirements that cannot all be satisfied
+- reject_stale: describes something already done or clearly outdated
+- reject_out_of_scope: outside the repository's purpose or requires unavailable external resources
+
+Output exactly:
+DECISION: <classification>
+REASON: <one sentence explanation>
+CONFIDENCE: <0.0-1.0>`
 
 const intentJudgeSystemPrompt = `You are a code review judge. Compare the git diff against the original issue title and description. Determine if the diff implements what was requested.
 
@@ -126,6 +170,94 @@ func (j *IntentJudge) Judge(ctx context.Context, issueTitle, issueBody, diff str
 	}
 
 	return parseJudgeResponse(apiResp.Content[0].Text)
+}
+
+// JudgeIssue evaluates whether a GitHub issue is actionable before dispatching to a worker.
+// Returns a PreFlightVerdict with decision, reason, and confidence.
+// Empty body is treated as vague (returns reject_vague, not an error).
+// Body is truncated to maxPreflightBodyChars before sending.
+func (j *IntentJudge) JudgeIssue(ctx context.Context, title, body, repoContext string) (*PreFlightVerdict, error) {
+	if len(body) > maxPreflightBodyChars {
+		body = body[:maxPreflightBodyChars] + "\n...[truncated]"
+	}
+
+	userContent := fmt.Sprintf("## Issue Title\n%s\n\n## Issue Description\n%s", title, body)
+	if repoContext != "" {
+		userContent += fmt.Sprintf("\n\n## Repository Context\n%s", repoContext)
+	}
+
+	reqBody := haikuRequest{
+		Model:     j.model,
+		MaxTokens: 256,
+		System:    preflightJudgeSystemPrompt,
+		Messages: []haikuMessage{
+			{Role: "user", Content: userContent},
+		},
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, j.apiURL, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", j.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := j.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	var apiResp haikuResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	if len(apiResp.Content) == 0 || apiResp.Content[0].Text == "" {
+		return nil, fmt.Errorf("empty response from API")
+	}
+
+	return parsePreFlightResponse(apiResp.Content[0].Text)
+}
+
+// parsePreFlightResponse extracts decision, reason, and confidence from the pre-flight judge's response.
+func parsePreFlightResponse(text string) (*PreFlightVerdict, error) {
+	verdict := &PreFlightVerdict{}
+
+	m := preflightDecisionRegex.FindStringSubmatch(text)
+	if len(m) < 2 {
+		return nil, fmt.Errorf("no DECISION signal found in response")
+	}
+	decision := PreFlightDecision(strings.ToLower(strings.TrimSpace(m[1])))
+	switch decision {
+	case PreFlightAccept, PreFlightRejectQuestion, PreFlightRejectVague,
+		PreFlightRejectConflicting, PreFlightRejectStale, PreFlightRejectOutOfScope:
+		verdict.Decision = decision
+	default:
+		return nil, fmt.Errorf("unknown DECISION value: %q", m[1])
+	}
+
+	if rm := preflightReasonRegex.FindStringSubmatch(text); len(rm) >= 2 {
+		verdict.Reason = strings.TrimSpace(rm[1])
+	}
+
+	if cm := preflightConfidenceRegex.FindStringSubmatch(text); len(cm) >= 2 {
+		if c, err := strconv.ParseFloat(cm[1], 64); err == nil {
+			verdict.Confidence = c
+		}
+	}
+
+	return verdict, nil
 }
 
 // parseJudgeResponse extracts verdict, reason, and confidence from the judge's response.

--- a/internal/executor/intent_judge_test.go
+++ b/internal/executor/intent_judge_test.go
@@ -192,6 +192,192 @@ func TestIntentJudge_IncompleteMultiFileChanges(t *testing.T) {
 	}
 }
 
+// --- Pre-flight judge tests (GH-2802) ---
+
+func TestJudgeIssue_Accept(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"text":"DECISION: accept\nREASON: Clear and specific implementation request.\nCONFIDENCE: 0.95"}]}`)
+	}))
+	defer server.Close()
+
+	judge := newIntentJudgeWithURL("fake-api-key", server.URL)
+	v, err := judge.JudgeIssue(context.Background(), "Add login button", "Add a login button to the header nav", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Decision != PreFlightAccept {
+		t.Errorf("expected accept, got %q", v.Decision)
+	}
+	if v.IsRejection() {
+		t.Error("IsRejection() should be false for accept")
+	}
+	if v.Confidence != 0.95 {
+		t.Errorf("expected confidence 0.95, got %f", v.Confidence)
+	}
+}
+
+func TestJudgeIssue_RejectQuestion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"text":"DECISION: reject_question\nREASON: Issue asks a question rather than requesting implementation.\nCONFIDENCE: 0.88"}]}`)
+	}))
+	defer server.Close()
+
+	judge := newIntentJudgeWithURL("fake-api-key", server.URL)
+	v, err := judge.JudgeIssue(context.Background(), "How does auth work?", "Can you explain the auth flow?", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Decision != PreFlightRejectQuestion {
+		t.Errorf("expected reject_question, got %q", v.Decision)
+	}
+	if !v.IsRejection() {
+		t.Error("IsRejection() should be true for reject_question")
+	}
+}
+
+func TestJudgeIssue_RejectVague(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"text":"DECISION: reject_vague\nREASON: Issue body is too vague to implement.\nCONFIDENCE: 0.90"}]}`)
+	}))
+	defer server.Close()
+
+	judge := newIntentJudgeWithURL("fake-api-key", server.URL)
+	v, err := judge.JudgeIssue(context.Background(), "Fix it", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Decision != PreFlightRejectVague {
+		t.Errorf("expected reject_vague, got %q", v.Decision)
+	}
+	if !v.IsRejection() {
+		t.Error("IsRejection() should be true for reject_vague")
+	}
+}
+
+func TestJudgeIssue_AllDecisionConstants(t *testing.T) {
+	decisions := []PreFlightDecision{
+		PreFlightAccept,
+		PreFlightRejectQuestion,
+		PreFlightRejectVague,
+		PreFlightRejectConflicting,
+		PreFlightRejectStale,
+		PreFlightRejectOutOfScope,
+	}
+	for _, dec := range decisions {
+		dec := dec
+		t.Run(string(dec), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"content":[{"text":"DECISION: %s\nREASON: Test reason.\nCONFIDENCE: 0.85"}]}`, dec)
+			}))
+			defer server.Close()
+
+			judge := newIntentJudgeWithURL("fake-api-key", server.URL)
+			v, err := judge.JudgeIssue(context.Background(), "title", "body", "")
+			if err != nil {
+				t.Fatalf("unexpected error for decision %q: %v", dec, err)
+			}
+			if v.Decision != dec {
+				t.Errorf("expected %q, got %q", dec, v.Decision)
+			}
+		})
+	}
+}
+
+func TestJudgeIssue_EmptyBodyReturnsVague(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"text":"DECISION: reject_vague\nREASON: No description provided.\nCONFIDENCE: 0.95"}]}`)
+	}))
+	defer server.Close()
+
+	judge := newIntentJudgeWithURL("fake-api-key", server.URL)
+	v, err := judge.JudgeIssue(context.Background(), "title", "", "")
+	if err != nil {
+		t.Fatalf("empty body should not return error, got: %v", err)
+	}
+	if v.Decision != PreFlightRejectVague {
+		t.Errorf("expected reject_vague for empty body, got %q", v.Decision)
+	}
+}
+
+func TestJudgeIssue_HTTP500Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	judge := newIntentJudgeWithURL("fake-api-key", server.URL)
+	_, err := judge.JudgeIssue(context.Background(), "title", "body", "")
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected error to mention status 500, got: %v", err)
+	}
+}
+
+func TestJudgeIssue_MalformedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"text":"This looks fine to me."}]}`)
+	}))
+	defer server.Close()
+
+	judge := newIntentJudgeWithURL("fake-api-key", server.URL)
+	_, err := judge.JudgeIssue(context.Background(), "title", "body", "")
+	if err == nil {
+		t.Fatal("expected error for malformed response missing DECISION")
+	}
+	if !strings.Contains(err.Error(), "DECISION") {
+		t.Errorf("expected error about missing DECISION, got: %v", err)
+	}
+}
+
+func TestJudgeIssue_BodyTruncation(t *testing.T) {
+	var receivedContent string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req haikuRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err == nil && len(req.Messages) > 0 {
+			receivedContent = req.Messages[0].Content
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"text":"DECISION: accept\nREASON: Looks good.\nCONFIDENCE: 0.9"}]}`)
+	}))
+	defer server.Close()
+
+	largeBody := strings.Repeat("x", 5000) // > maxPreflightBodyChars (4000)
+
+	judge := newIntentJudgeWithURL("fake-api-key", server.URL)
+	_, err := judge.JudgeIssue(context.Background(), "title", largeBody, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(receivedContent, "...[truncated]") {
+		t.Error("expected body to be truncated")
+	}
+}
+
+func TestJudgeIssue_ConfidenceParsed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"content":[{"text":"DECISION: accept\nREASON: Good issue.\nCONFIDENCE: 0.85"}]}`)
+	}))
+	defer server.Close()
+
+	judge := newIntentJudgeWithURL("fake-api-key", server.URL)
+	v, err := judge.JudgeIssue(context.Background(), "title", "body", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Confidence != 0.85 {
+		t.Errorf("expected confidence 0.85, got %f", v.Confidence)
+	}
+}
+
 // TestIntentJudge_SingleBackendPass tests that single-backend issues pass when only one backend is modified (GH-1321)
 func TestIntentJudge_SingleBackendPass(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Adds a Haiku-powered pre-flight judge at the poller boundary that evaluates each `pilot`-labeled issue before a worker slot is allocated. Vague, question, conflicting, stale, or out-of-scope issues are declined with a comment and label instead of burning $2-8 in execution cost.

- Adds `PreFlightDecision` type with 6 constants and `PreFlightVerdict` struct (with `IsRejection()`) to `internal/executor/intent_judge.go`
- `IntentJudge.JudgeIssue()` method using existing Haiku HTTP plumbing; body truncated at 4000 chars
- `PreFlightJudger` interface + `Verdict` struct in poller package (keeps poller decoupled from executor to avoid import cycles)
- `ExecutionSaver` interface for persisting `declined-preflight` execution rows
- `handlePreFlightReject`: adds `pilot-needs-clarification`, posts explanatory comment, saves execution row
- Pre-flight check wired in both `checkForNewIssues` (parallel/auto mode) and `startSequential`; **fail-open** on judge error; skips `markProcessed` on rejection so label removal re-triggers dispatch
- `PreFlightJudgeConfig` in `BackendConfig` (`executor.pre_flight_judge.enabled` / `executor.pre_flight_judge.api_key`)
- `preFlightJudgeShim` + `storeExecutionSaver` adapters wired in both `NewPoller` call sites in `cmd/pilot/main.go`

**Default: `Enabled: false`** (opt-in behind config flag). Enable with:

```yaml
executor:
  pre_flight_judge:
    enabled: true
    api_key: "${ANTHROPIC_API_KEY}"
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/executor/...` — 8 new `TestJudgeIssue_*` tests pass
- [x] `go test ./internal/adapters/github/...` — 5 new `TestPoller_PreFlight_*` tests pass
- [x] `make lint` — 0 issues
- [ ] E2e: enable flag, submit vague issue — expect `pilot-needs-clarification` label + comment within one poll cycle
- [ ] E2e: remove label after editing issue — expect normal dispatch on next poll

Closes #2802