### PR TITLE
fix(upgrade): detect truncated writes in installToBinaryPath

### DIFF
--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -412,7 +412,9 @@ func (u *Upgrader) installBinary(downloadPath string) error {
 // installToBinaryPath writes a new binary beside the current executable and
 // swaps it into place once the write completes. This avoids truncating a
 // running executable on Unix-like systems, which returns ETXTBSY.
-func (u *Upgrader) installToBinaryPath(write func(io.Writer) error) error {
+// expectedSize is the number of bytes the write callback must produce; pass 0
+// to skip the check (no caller currently needs this).
+func (u *Upgrader) installToBinaryPath(write func(io.Writer) error, expectedSize int64) error {
 	dir := filepath.Dir(u.binaryPath)
 	tempFile, err := os.CreateTemp(dir, ".pilot-install-*")
 	if err != nil {
@@ -443,6 +445,16 @@ func (u *Upgrader) installToBinaryPath(write func(io.Writer) error) error {
 		return fmt.Errorf("failed to close binary: %w", err)
 	}
 	closed = true
+
+	if expectedSize > 0 {
+		fi, err := os.Stat(tempPath)
+		if err != nil {
+			return fmt.Errorf("failed to stat written binary: %w", err)
+		}
+		if fi.Size() != expectedSize {
+			return fmt.Errorf("truncated write: wrote %d bytes, expected %d", fi.Size(), expectedSize)
+		}
+	}
 
 	if runtime.GOOS == "windows" {
 		if err := os.Remove(u.binaryPath); err != nil && !os.IsNotExist(err) {
@@ -525,7 +537,7 @@ func (u *Upgrader) installFromTarGz(tarPath string) error {
 					return fmt.Errorf("failed to extract binary: %w", err)
 				}
 				return nil
-			})
+			}, header.Size)
 		}
 	}
 }
@@ -557,7 +569,7 @@ func (u *Upgrader) installFromZip(zipPath string) error {
 					return fmt.Errorf("failed to extract binary: %w", err)
 				}
 				return nil
-			})
+			}, int64(f.UncompressedSize64))
 		}
 	}
 
@@ -572,12 +584,17 @@ func (u *Upgrader) installDirectBinary(srcPath string) error {
 	}
 	defer func() { _ = src.Close() }()
 
+	srcInfo, err := src.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat source binary: %w", err)
+	}
+
 	return u.installToBinaryPath(func(dst io.Writer) error {
 		if _, err := io.Copy(dst, src); err != nil {
 			return fmt.Errorf("failed to copy binary: %w", err)
 		}
 		return nil
-	})
+	}, srcInfo.Size())
 }
 
 // compareVersions compares two semantic versions

--- a/internal/upgrade/upgrade_critical_test.go
+++ b/internal/upgrade/upgrade_critical_test.go
@@ -483,7 +483,7 @@ func TestInstallToBinaryPath_CleansUpTempOnWriterError(t *testing.T) {
 	err := u.installToBinaryPath(func(out io.Writer) error {
 		_, _ = out.Write([]byte("partial"))
 		return errBoom
-	})
+	}, 0)
 	if err == nil {
 		t.Fatal("installToBinaryPath() expected error, got nil")
 	}
@@ -499,6 +499,41 @@ func TestInstallToBinaryPath_CleansUpTempOnWriterError(t *testing.T) {
 		t.Errorf("content = %q, want %q", got, "old-binary")
 	}
 
+	matches, globErr := filepath.Glob(filepath.Join(dir, ".pilot-install-*"))
+	if globErr != nil {
+		t.Fatalf("glob temp files: %v", globErr)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temp install files left behind: %v", matches)
+	}
+}
+
+func TestInstallToBinaryPath_TruncatedWrite(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "pilot")
+	if err := os.WriteFile(binPath, []byte("original-binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	u := &Upgrader{binaryPath: binPath}
+	err := u.installToBinaryPath(func(out io.Writer) error {
+		_, _ = out.Write([]byte("short"))
+		return nil
+	}, 100)
+	if err == nil {
+		t.Fatal("installToBinaryPath() expected error for truncated write, got nil")
+	}
+
+	// Original binary must be preserved.
+	got, readErr := os.ReadFile(binPath)
+	if readErr != nil {
+		t.Fatalf("failed to read existing binary: %v", readErr)
+	}
+	if string(got) != "original-binary" {
+		t.Errorf("content = %q, want %q", got, "original-binary")
+	}
+
+	// Temp file must be cleaned up.
 	matches, globErr := filepath.Glob(filepath.Join(dir, ".pilot-install-*"))
 	if globErr != nil {
 		t.Fatalf("glob temp files: %v", globErr)


### PR DESCRIPTION
## Summary
- Added `expectedSize int64` parameter to `installToBinaryPath`; callers pass the size from the tar header, zip `UncompressedSize64`, or source file `Stat`
- After the write callback returns successfully, stat the temp file and return an error if size mismatches — temp is cleaned up by existing defer
- Added `TestInstallToBinaryPath_TruncatedWrite` verifying error is returned, original binary preserved, and temp files cleaned up

## Test plan
- [ ] `go test ./internal/upgrade/...` — all pass
- [ ] `make lint` — 0 issues
- [ ] New test `TestInstallToBinaryPath_TruncatedWrite` covers the truncated-write path end-to-end

Closes #2564