### PR TITLE
GH-2829: fix(gateway): wire Prometheus /metrics endpoint to autopilot metrics source

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -965,6 +965,7 @@ Examples:
 			// GH-1585: Wire autopilot provider to gateway so /api/v1/autopilot returns live PR data
 			if gwAutopilotController != nil {
 				p.Gateway().SetAutopilotProvider(&autopilotProviderAdapter{controller: gwAutopilotController})
+				p.Gateway().SetMetricsSource(gwAutopilotController.Metrics())
 
 				// GH-2080: Wire PR review events to autopilot controller
 				p.SetOnPRReview(func(ctx context.Context, prNumber int, action, state, reviewer string, repo *github.Repository) error {
@@ -1624,6 +1625,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		gwServer := gateway.NewServer(cfg.Gateway)
 		if autopilotController != nil {
 			gwServer.SetAutopilotProvider(&autopilotProviderAdapter{controller: autopilotController})
+			gwServer.SetMetricsSource(autopilotController.Metrics())
 		}
 
 		// GH-2080: Wire PR review webhook events to autopilot controller in polling mode

--- a/internal/gateway/prometheus_test.go
+++ b/internal/gateway/prometheus_test.go
@@ -2,6 +2,8 @@ package gateway
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -227,4 +229,51 @@ func TestFormatLabels(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMetricsEndpointWiring verifies that /metrics returns Prometheus text when
+// SetMetricsSource is called, and the fallback response when it is not.
+func TestMetricsEndpointWiring(t *testing.T) {
+	t.Run("with metrics source returns 200 and pilot counters", func(t *testing.T) {
+		srv := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+		m := autopilot.NewMetrics()
+		m.RecordIssueProcessed("success")
+		srv.SetMetricsSource(m)
+
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		w := httptest.NewRecorder()
+		srv.handleMetrics(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+		body := w.Body.String()
+		for _, want := range []string{
+			"pilot_issues_processed_total",
+			"pilot_prs_merged_total",
+			"pilot_prs_failed_total",
+			"pilot_prs_conflicting_total",
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("body missing %q", want)
+			}
+		}
+	})
+
+	t.Run("without metrics source returns 503 fallback", func(t *testing.T) {
+		srv := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+
+		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+		w := httptest.NewRecorder()
+		srv.handleMetrics(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503, got %d", resp.StatusCode)
+		}
+		if !strings.Contains(w.Body.String(), "Metrics not configured") {
+			t.Errorf("expected 'Metrics not configured' in body, got: %s", w.Body.String())
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2829.

Closes #2829

## Changes

GitHub Issue #2829: fix(gateway): wire Prometheus /metrics endpoint to autopilot metrics source

## Problem

Gateway registers `GET /metrics` and ships a fully-implemented `PrometheusExporter`, but the endpoint returns the literal string **`Metrics not configured`** because `cmd/pilot/main.go` never calls `gwServer.SetMetricsSource(...)`. Result: Prometheus scraping is impossible against a running Pilot daemon.

Verified live (2026-05-08): `curl http://localhost:9091/metrics` against a running daemon returns `Metrics not configured`.

## Goal

Make `/metrics` return Prometheus text-format counters/histograms backed by the autopilot `Metrics` instance, so a standard Prometheus scrape job works against a running Pilot with zero extra config.

## Acceptance Criteria

- [ ] `curl http://<gateway-host>:<port>/metrics` returns `200` with body containing `pilot_issues_processed_total`, `pilot_prs_merged_total`, `pilot_prs_failed_total`, `pilot_prs_conflicting_total`, and existing histograms.
- [ ] Wiring added at **both** gateway-startup paths in `cmd/pilot/main.go`.
- [ ] Wiring test in `internal/gateway/prometheus_test.go` locks the behavior down (so a future refactor can't silently regress).
- [ ] `make test` and `make lint` pass.
- [ ] No new dependencies, no config changes.

## Implementation

`*autopilot.Metrics` already satisfies the `gateway.MetricsSource` interface (`Snapshot()` + `HistogramSnapshot()`), so no adapter is needed.

### Change 1 — `cmd/pilot/main.go:1605`

Inside the `if !noGateway && cfg.Gateway != nil { ... }` block, right after the existing `gwServer.SetAutopilotProvider(...)` call, add:

```go
if autopilotController != nil {
    gwServer.SetAutopilotProvider(&autopilotProviderAdapter{controller: autopilotController})
    gwServer.SetMetricsSource(autopilotController.Metrics()) // <-- NEW
}
```

### Change 2 — `cmd/pilot/main.go:946`

The other code path that wires `SetAutopilotProvider`:

```go
p.Gateway().SetAutopilotProvider(&autopilotProviderAdapter{controller: gwAutopilotController})
p.Gateway().SetMetricsSource(gwAutopilotController.Metrics()) // <-- NEW
```

(Match the existing nil-guard for `gwAutopilotController`.)

### Change 3 — Wiring test in `internal/gateway/prometheus_test.go`

Add two test cases:

1. **Positive**: Construct `gateway.NewServer(...)`, call `SetMetricsSource(...)` with a stub or real `autopilot.NewMetrics()`, hit `/metrics` via `httptest`, assert `200` + body contains `pilot_issues_processed_total`.
2. **Negative**: Server with **no** `SetMetricsSource` call → assert `/metrics` still returns the existing `Metrics not configured` fallback (locks current behavior so we notice when it changes).

## Verify

```bash
make test
make lint

# After release + pilot upgrade, on a running daemon:
curl -s http://localhost:9091/metrics | head -40
# Expect Prometheus text-format with pilot_* metrics.
```

## References

- Plan: `.agent/tasks/TASK-52-prometheus-metrics-wiring.md`
- `gateway.MetricsSource` interface: `internal/gateway/prometheus.go:17`
- `*autopilot.Metrics`: `internal/autopilot/metrics.go:183` (`Snapshot`), `:277` (`HistogramSnapshot`)
- `/metrics` handler: `internal/gateway/server.go:760`
- `SetMetricsSource`: `internal/gateway/server.go:271`