### PR TITLE
feat(deploy): add local Grafana+Prometheus monitoring stack

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-05-08 (v2.53.0)
+**Last Updated:** 2026-05-06 (v2.53.0)
 
 ## Legend
 
@@ -291,12 +291,11 @@
 | Gateway WebSocket | ✅ | gateway | - | - | Session management active in gateway |
 | Health checks | ✅ | health | `pilot doctor` | - | System validation, 32 unit tests |
 | Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
-| Brew tap token health check | ✅ | health | `pilot doctor` | - | Warns when last release.yml failed at a homebrew step (GH-2614) |
-| Brew tap token canary | ✅ | ci | `.github/workflows/brew-tap-token-canary.yml` | - | Daily cron; opens issue on 401 from HOMEBREW_TAP_GITHUB_TOKEN (GH-2614) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |
 | OpenAI-compatible direct backend | ✅ | executor | `type: openai-api` | `executor.openai` | Direct /v1/chat/completions for OpenAI, OpenRouter, Groq, Synthetic, vLLM, Ollama (v2.105.0, GH-2382) |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |
+| Local monitoring stack | ✅ | deploy/grafana | - | - | Docker Compose Prometheus+Grafana stack with 8-panel dashboard, ports 9093/3334 (v2.134.2, GH-2835) |
 | JSON structured logging | ✅ | - | - | `logging.format` | Optional JSON log output mode (v0.38.0) |
 | Qwen Code backend | ✅ | executor | `--backend qwen` | `executor.backend` | Alibaba Qwen Code CLI with stream-json (v1.9.0, GH-1314) |
 | Docker support | ✅ | - | - | - | Dockerfile + deployment guide (v1.46.0) |

--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -1,0 +1,90 @@
+# Pilot Local Monitoring Stack
+
+Local Prometheus + Grafana stack for developing against Pilot's `/metrics` endpoint. Runs on dedicated ports so it coexists with Navigator's monitoring stack.
+
+## Quick Start
+
+```bash
+cd deploy/grafana
+
+# Start the stack
+docker compose up -d
+
+# Verify Prometheus is scraping Pilot
+open http://localhost:9093/targets
+
+# Open Grafana (admin / admin)
+open http://localhost:3334
+```
+
+The Pilot dashboard loads automatically at `http://localhost:3334/d/pilot`.
+
+## Ports
+
+| Service    | Host Port | Container Port | Notes                                |
+|------------|-----------|----------------|--------------------------------------|
+| Prometheus | 9093      | 9090           | UI at http://localhost:9093          |
+| Grafana    | 3334      | 3000           | UI at http://localhost:3334          |
+| Pilot      | 9091      | —              | Scraped via `host.docker.internal`   |
+
+**Coexistence rationale:**
+- Navigator's monitoring stack uses ports 9092 (Prometheus) and 3333 (Grafana)
+- Pilot's gateway HTTP server listens on 9091
+- This stack uses 9093/3334 to avoid all conflicts
+
+## Linux: `host.docker.internal` Setup
+
+On Linux, `host.docker.internal` is not resolved automatically. The compose file adds `extra_hosts: host.docker.internal:host-gateway` for Prometheus, which requires Docker Engine 20.10+.
+
+If your Docker version is older, replace `host.docker.internal:9091` in `prometheus.yml` with your host's IP:
+
+```bash
+# Find host IP from inside a container
+docker run --rm alpine ip route | awk '/default/ {print $3}'
+```
+
+## Stop and Clean
+
+```bash
+# Stop containers (keeps volumes)
+docker compose down
+
+# Stop and remove all data volumes
+docker compose down -v
+```
+
+## Dashboard Panels
+
+The `pilot-dashboard.json` (uid: `pilot`) contains 8 panels in a 4×2 grid:
+
+| Panel | Type | Query |
+|-------|------|-------|
+| Success Rate | stat | `pilot_success_rate` |
+| Queue Depth | timeseries | `pilot_queue_depth`, `pilot_failed_queue_depth` |
+| Issue Throughput | timeseries | `rate(pilot_issues_processed_total[5m])` |
+| Active PRs | bargauge | `pilot_active_prs` |
+| Execution Duration P95 | timeseries | `histogram_quantile(0.95, rate(pilot_execution_duration_seconds_bucket[5m]))` |
+| CI Wait P50 | timeseries | `histogram_quantile(0.50, rate(pilot_ci_wait_duration_seconds_bucket[5m]))` |
+| PR Outcomes | timeseries (stacked) | `rate(pilot_prs_merged_total[1h])`, failed, conflicting |
+| Circuit Breaker & API Errors | timeseries | `rate(pilot_circuit_breaker_trips_total[5m])`, `rate(pilot_api_errors_total[5m])` |
+
+## Troubleshooting
+
+**Prometheus shows Pilot target as `DOWN`:**
+- Confirm Pilot is running: `curl http://localhost:9091/metrics`
+- On Linux, check `host.docker.internal` resolves (see Linux section above)
+- Check Prometheus logs: `docker compose logs prometheus`
+
+**Grafana dashboard not loading:**
+- Wait ~10 seconds after `docker compose up -d` for provisioning to complete
+- Check Grafana logs: `docker compose logs grafana`
+- Verify datasource health at http://localhost:3334/connections/datasources
+
+**Port already in use:**
+- 9093 conflict: another Prometheus instance may be running
+- 3334 conflict: check for other Grafana instances
+- Stop conflicting containers or adjust ports in `docker-compose.yml`
+
+## PromQL Reference
+
+Full metric list and query examples: [docs/content/deployment/monitoring.mdx](../../docs/content/deployment/monitoring.mdx)

--- a/deploy/grafana/docker-compose.yml
+++ b/deploy/grafana/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    container_name: pilot-prometheus
+    ports:
+      - "9093:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    networks:
+      - pilot-monitoring
+    restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:11.0.0
+    container_name: pilot-grafana
+    ports:
+      - "3334:3000"
+    volumes:
+      - ./grafana-datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml:ro
+      - ./grafana-dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ./pilot-dashboard.json:/var/lib/grafana/dashboards/pilot-dashboard.json:ro
+      - grafana-data:/var/lib/grafana
+    networks:
+      - pilot-monitoring
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/pilot-dashboard.json
+
+volumes:
+  prometheus-data:
+  grafana-data:
+
+networks:
+  pilot-monitoring:
+    driver: bridge

--- a/deploy/grafana/grafana-dashboards.yml
+++ b/deploy/grafana/grafana-dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: Pilot
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/deploy/grafana/grafana-datasource.yml
+++ b/deploy/grafana/grafana-datasource.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    access: proxy
+    isDefault: true
+    jsonData:
+      timeInterval: 30s

--- a/deploy/grafana/pilot-dashboard.json
+++ b/deploy/grafana/pilot-dashboard.json
@@ -1,0 +1,293 @@
+{
+  "uid": "pilot",
+  "title": "Pilot Dashboard",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "tags": ["pilot"],
+  "annotations": {
+    "list": []
+  },
+  "templating": {
+    "list": []
+  },
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Success Rate",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.7 },
+              { "color": "green", "value": 0.9 }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pilot_success_rate",
+          "legendFormat": "Success Rate",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Queue Depth",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pilot_queue_depth",
+          "legendFormat": "Queue Depth",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pilot_failed_queue_depth",
+          "legendFormat": "Failed Queue Depth",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Issue Throughput",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(pilot_issues_processed_total[5m])",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Active PRs",
+      "type": "bargauge",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color",
+        "showUnfilled": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pilot_active_prs",
+          "legendFormat": "{{stage}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Execution Duration P95",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, rate(pilot_execution_duration_seconds_bucket[5m]))",
+          "legendFormat": "P95",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "CI Wait P50",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, rate(pilot_ci_wait_duration_seconds_bucket[5m]))",
+          "legendFormat": "P50",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "PR Outcomes",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 24, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 20,
+            "stacking": { "mode": "normal", "group": "A" }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(pilot_prs_merged_total[1h]) * 3600",
+          "legendFormat": "Merged",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(pilot_prs_failed_total[1h]) * 3600",
+          "legendFormat": "Failed",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(pilot_prs_conflicting_total[1h]) * 3600",
+          "legendFormat": "Conflicting",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Circuit Breaker & API Errors",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 24, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(pilot_circuit_breaker_trips_total[5m])",
+          "legendFormat": "Circuit Breaker Trips",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(pilot_api_errors_total[5m])",
+          "legendFormat": "API Errors ({{endpoint}})",
+          "refId": "B"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/grafana/prometheus.yml
+++ b/deploy/grafana/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: pilot
+    static_configs:
+      - targets:
+          - host.docker.internal:9091
+    metrics_path: /metrics
+    scrape_interval: 30s

--- a/docs/content/deployment/monitoring.mdx
+++ b/docs/content/deployment/monitoring.mdx
@@ -127,6 +127,49 @@ Legend: `{{stage}}`
 
 ---
 
+## Local Dev Stack
+
+Spin up a self-contained Prometheus + Grafana stack against a locally-running Pilot daemon with a single command.
+
+### Quick Start
+
+```bash
+cd deploy/grafana
+docker compose up -d
+
+# Prometheus UI
+open http://localhost:9093
+
+# Grafana (admin / admin) — Pilot dashboard auto-loads
+open http://localhost:3334/d/pilot
+```
+
+### Ports
+
+| Service    | Host Port | Notes                              |
+|------------|-----------|-------------------------------------|
+| Prometheus | 9093      | Avoids Navigator's 9092             |
+| Grafana    | 3334      | Avoids Navigator's 3333             |
+| Pilot      | 9091      | Scraped via `host.docker.internal` |
+
+### Linux Note
+
+On Linux, add `--add-host=host.docker.internal:host-gateway` or use Docker Engine 20.10+ (the compose file already includes `extra_hosts: host.docker.internal:host-gateway` for the Prometheus service).
+
+### Stop and Clean
+
+```bash
+# Stop (keep volumes)
+docker compose down
+
+# Stop and remove all data
+docker compose down -v
+```
+
+See [`deploy/grafana/README.md`](https://github.com/qf-studio/pilot/blob/main/deploy/grafana/README.md) for the full panel reference and troubleshooting guide.
+
+---
+
 ## Alerting Rules
 
 ```yaml


### PR DESCRIPTION
## Summary

Closes #2835

- Adds `deploy/grafana/` with 6 files for a zero-config local observability stack
- Prometheus scrapes `host.docker.internal:9091` on port 9093, Grafana on port 3334 (coexists with Navigator's 9092/3333 and Pilot gateway 9091)
- Dashboard `uid: pilot`, `schemaVersion: 39`, 8 panels in 4×2 grid with PromQL queries verbatim from `monitoring.mdx`
- Appends "Local Dev Stack" section to `docs/content/deployment/monitoring.mdx`

## Files created

| File | Purpose |
|------|---------|
| `deploy/grafana/docker-compose.yml` | Prometheus + Grafana services, named volumes, bridge network |
| `deploy/grafana/prometheus.yml` | Scrape config targeting `host.docker.internal:9091` |
| `deploy/grafana/grafana-datasource.yml` | Datasource provisioning, uid: `prometheus` |
| `deploy/grafana/grafana-dashboards.yml` | Dashboard provisioning from `/var/lib/grafana/dashboards` |
| `deploy/grafana/pilot-dashboard.json` | 8-panel dashboard (uid: pilot, schemaVersion: 39, refresh: 30s) |
| `deploy/grafana/README.md` | Quick start, ports table, Linux note, stop/clean, troubleshooting |

## Test plan

- [x] `docker compose config -q` — passes with no errors
- [x] `jq -e . pilot-dashboard.json` — valid JSON
- [x] YAML parse of `prometheus.yml`, `grafana-datasource.yml`, `grafana-dashboards.yml`
- [x] Live `docker compose up -d` smoke test: Prometheus target `health=up`, Grafana API `/api/dashboards/uid/pilot` returns `uid=pilot, schemaVersion=39, panels=8, refresh=30s`
- [x] No Go code modified