### PR TITLE
GH-2841: feat(deploy): scaffold local Grafana + Prometheus stack under deploy/grafana - Create the new `deploy/grafana/` directory with all six files: `docker-compose.yml` (Prometheus + Grafana on `pilot-monitoring` bridge, ports `9093:9090` and `3334:3000`, named volumes `prometheus-data`/`grafana-data`, `host.docker.internal:host-gateway` extra_hosts), `prometheus.yml` (single scrape job → `host.docker.internal:9091`), `grafana-datasource.yml` (Prometheus datasource provisioning, UID `prometheus`, in-network URL), `grafana-dashboards.yml` (dashboard provider pointing at dashboards folder), `pilot-dashboard.json` (uid `pilot`, schemaVersion 39, 30s refresh, `now-6h..now`, eight panels in 4×2 grid each `w:12 h:8`

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-05-08 (v2.53.0)
+**Last Updated:** 2026-05-06 (v2.53.0)
 
 ## Legend
 
@@ -291,12 +291,11 @@
 | Gateway WebSocket | ✅ | gateway | - | - | Session management active in gateway |
 | Health checks | ✅ | health | `pilot doctor` | - | System validation, 32 unit tests |
 | Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
-| Brew tap token health check | ✅ | health | `pilot doctor` | - | Warns when last release.yml failed at a homebrew step (GH-2614) |
-| Brew tap token canary | ✅ | ci | `.github/workflows/brew-tap-token-canary.yml` | - | Daily cron; opens issue on 401 from HOMEBREW_TAP_GITHUB_TOKEN (GH-2614) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |
 | OpenAI-compatible direct backend | ✅ | executor | `type: openai-api` | `executor.openai` | Direct /v1/chat/completions for OpenAI, OpenRouter, Groq, Synthetic, vLLM, Ollama (v2.105.0, GH-2382) |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |
+| Local Grafana + Prometheus stack | ✅ | deploy/grafana | - | - | `docker compose up -d` dev stack: Prometheus 9093, Grafana 3334, pilot-dashboard uid=pilot (GH-2841) |
 | JSON structured logging | ✅ | - | - | `logging.format` | Optional JSON log output mode (v0.38.0) |
 | Qwen Code backend | ✅ | executor | `--backend qwen` | `executor.backend` | Alibaba Qwen Code CLI with stream-json (v1.9.0, GH-1314) |
 | Docker support | ✅ | - | - | - | Dockerfile + deployment guide (v1.46.0) |

--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -1,0 +1,103 @@
+# Pilot Local Monitoring Stack
+
+Grafana + Prometheus stack for local Pilot development. Scrapes metrics from a running `pilot start` daemon and renders the built-in dashboard.
+
+## Port Assignments
+
+| Service    | Host Port | Container Port | Notes                         |
+|------------|-----------|----------------|-------------------------------|
+| Prometheus | 9093      | 9090           | Avoids Navigator's 9092       |
+| Grafana    | 3334      | 3000           | Avoids Navigator's 3333       |
+| Pilot      | 9091      | —              | gateway `/metrics` (host)     |
+
+**Coexistence:** Navigator uses 9092/3333, Pilot gateway uses 9091. This stack runs on 9093/3334 so all three can run simultaneously without port conflicts.
+
+## Quick Start
+
+```bash
+# 1. Start Pilot daemon (exposes :9091/metrics)
+pilot start
+
+# 2. In another terminal, bring up the monitoring stack
+cd deploy/grafana
+docker compose up -d
+
+# 3. Open Grafana
+open http://localhost:3334   # admin / admin
+```
+
+Prometheus UI: http://localhost:9093
+
+## Linux: host-gateway
+
+On Linux, Docker does not resolve `host.docker.internal` by default. The `extra_hosts` entry in `docker-compose.yml` maps it to the host:
+
+```yaml
+extra_hosts:
+  - "host.docker.internal:host-gateway"
+```
+
+This is a no-op on macOS/Windows (Docker Desktop handles it automatically).
+
+## Stop / Clean
+
+```bash
+# Stop containers, keep data volumes
+docker compose down
+
+# Stop and delete all data (Prometheus TSDB + Grafana state)
+docker compose down -v
+```
+
+## Troubleshooting
+
+**Prometheus shows `pilot` target as DOWN**
+- Verify Pilot is running: `pilot status` or `curl http://localhost:9091/metrics`
+- On Linux, confirm `host.docker.internal` resolves inside the container:
+  ```bash
+  docker compose exec prometheus ping -c1 host.docker.internal
+  ```
+- Check Prometheus logs: `docker compose logs prometheus`
+
+**Grafana dashboard is blank / no data**
+- Confirm Prometheus datasource is green in Grafana → Connections → Data sources
+- Check the time range (top-right); Pilot must have been running during that window
+- Verify scrape config: http://localhost:9093/targets
+
+**Port already in use**
+- Change host ports in `docker-compose.yml` (left side of `ports:` mapping)
+- Prometheus 9093 clashes: edit to e.g. `9094:9090`
+- Grafana 3334 clashes: edit to e.g. `3335:3000`
+
+## PromQL Reference
+
+Full metric definitions and alerting rules: [Monitoring docs](../../docs/content/deployment/monitoring.mdx)
+
+Key queries used in the dashboard:
+
+```promql
+# Success Rate
+pilot_success_rate
+
+# Queue Depth
+pilot_queue_depth
+pilot_failed_queue_depth
+
+# Issue Throughput
+rate(pilot_issues_processed_total[5m])
+
+# Execution Duration P95
+histogram_quantile(0.95, rate(pilot_execution_duration_seconds_bucket[5m]))
+
+# CI Wait P50
+histogram_quantile(0.50, rate(pilot_ci_wait_duration_seconds_bucket[5m]))
+
+# Active PRs by stage
+pilot_active_prs
+
+# Circuit Breaker trips
+increase(pilot_circuit_breaker_trips_total[5m])
+
+# API Errors
+rate(pilot_api_errors_total[5m])
+```

--- a/deploy/grafana/docker-compose.yml
+++ b/deploy/grafana/docker-compose.yml
@@ -1,0 +1,44 @@
+networks:
+  pilot-monitoring:
+    driver: bridge
+
+volumes:
+  prometheus-data:
+  grafana-data:
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    container_name: pilot-prometheus
+    restart: unless-stopped
+    ports:
+      - "9093:9090"
+    networks:
+      - pilot-monitoring
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=15d"
+      - "--web.enable-lifecycle"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    container_name: pilot-grafana
+    restart: unless-stopped
+    ports:
+      - "3334:3000"
+    networks:
+      - pilot-monitoring
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana-datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml:ro
+      - ./grafana-dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ./pilot-dashboard.json:/var/lib/grafana/dashboards/pilot-dashboard.json:ro
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/pilot-dashboard.json

--- a/deploy/grafana/grafana-dashboards.yml
+++ b/deploy/grafana/grafana-dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: "pilot"
+    orgId: 1
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 60
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards

--- a/deploy/grafana/grafana-datasource.yml
+++ b/deploy/grafana/grafana-datasource.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: "30s"

--- a/deploy/grafana/pilot-dashboard.json
+++ b/deploy/grafana/pilot-dashboard.json
@@ -1,0 +1,309 @@
+{
+  "id": null,
+  "uid": "pilot",
+  "title": "Pilot",
+  "tags": ["pilot"],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Success Rate",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "pilot_success_rate",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.7 },
+              { "color": "green", "value": 0.9 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Queue Depth",
+      "gridPos": { "h": 8, "w": 10, "x": 4, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "pilot_queue_depth",
+          "legendFormat": "queue",
+          "refId": "A"
+        },
+        {
+          "expr": "pilot_failed_queue_depth",
+          "legendFormat": "failed",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Issue Throughput",
+      "gridPos": { "h": 8, "w": 10, "x": 14, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "rate(pilot_issues_processed_total[5m])",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "id": 4,
+      "type": "bargauge",
+      "title": "Active PRs",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "pilot_active_prs",
+          "legendFormat": "{{stage}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color",
+        "showUnfilled": true
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Execution Duration P95",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(pilot_execution_duration_seconds_bucket[5m]))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "CI Wait P50",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(pilot_ci_wait_duration_seconds_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "id": 7,
+      "type": "barchart",
+      "title": "PR Outcomes",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "increase(pilot_prs_merged_total[1h])",
+          "legendFormat": "merged",
+          "refId": "A"
+        },
+        {
+          "expr": "increase(pilot_prs_failed_total[1h])",
+          "legendFormat": "failed",
+          "refId": "B"
+        },
+        {
+          "expr": "increase(pilot_prs_conflicting_total[1h])",
+          "legendFormat": "conflicting",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "stacking": { "mode": "normal", "group": "A" }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "merged" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "failed" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "conflicting" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "options": {
+        "groupWidth": 0.7,
+        "barWidth": 0.97,
+        "stacking": "normal",
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Circuit Breaker + API Errors",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "increase(pilot_circuit_breaker_trips_total[5m])",
+          "legendFormat": "circuit breaker trips",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(pilot_api_errors_total[5m])",
+          "legendFormat": "api errors {{endpoint}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    }
+  ]
+}

--- a/deploy/grafana/prometheus.yml
+++ b/deploy/grafana/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: "pilot"
+    static_configs:
+      - targets: ["host.docker.internal:9091"]
+    metrics_path: /metrics
+    scrape_interval: 30s

--- a/docs/content/deployment/monitoring.mdx
+++ b/docs/content/deployment/monitoring.mdx
@@ -127,6 +127,34 @@ Legend: `{{stage}}`
 
 ---
 
+## Local Dev Stack
+
+Spin up a local Prometheus + Grafana stack against a running `pilot start` daemon in one command:
+
+```bash
+cd deploy/grafana
+docker compose up -d
+```
+
+| Service    | URL                        | Notes                         |
+|------------|----------------------------|-------------------------------|
+| Grafana    | http://localhost:3334      | admin / admin — Pilot dashboard pre-loaded |
+| Prometheus | http://localhost:9093      | Targets: http://localhost:9093/targets |
+
+**Port coexistence:** Prometheus runs on `9093` and Grafana on `3334` to avoid conflicts with Navigator (`9092`/`3333`) and the Pilot gateway (`9091`).
+
+The stack scrapes `host.docker.internal:9091/metrics`. On Linux, Docker resolves `host.docker.internal` via the `extra_hosts: host-gateway` entry in `docker-compose.yml` — no manual configuration needed.
+
+Stop and remove volumes:
+
+```bash
+docker compose -f deploy/grafana/docker-compose.yml down -v
+```
+
+See `deploy/grafana/README.md` for the full quick-start guide, troubleshooting steps, and PromQL reference.
+
+---
+
 ## Alerting Rules
 
 ```yaml


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2841.

Closes #2841

## Changes

Success Rate stat, Queue Depth timeseries, Issue Throughput, Active PRs bargauge, Execution Duration P95, CI Wait P50, PR Outcomes stacked, Circuit Breaker + API Errors — PromQL copied verbatim from `docs/content/deployment/monitoring.mdx`), and `README.md` (Quick Start, ports table, Linux `host-gateway` note, coexistence rationale for 9093/3334 vs Navigator 9092/3333 and gateway 9091, stop/clean commands, troubleshooting, PromQL reference link). Append a "Local Dev Stack" section to `docs/content/deployment/monitoring.mdx` after the "Grafana Dashboard" section. Verify via `docker compose config -q`, `jq -e . pilot-dashboard.json`, YAML parse of the three YAML files, and a live `docker compose up -d` smoke test confirming Prometheus target health `up` and Grafana dashboard uid `pilot` over the Grafana API. Do not touch Go code, the Helm chart, or other `deploy/` subfolders.