### PR TITLE
GH-2845: feat(memory): add LatestAutopilotMetrics query for snapshot restoration - In `internal/memory/store.go`, implement `LatestAutopilotMetrics() (*AutopilotMetricsRow, error)` that runs `SELECT ... FROM autopilot_metrics ORDER BY snapshot_at DESC LIMIT 1` and returns the row (or `nil, nil` when the table is empty

### DIFF
--- a/internal/memory/latest_autopilot_metrics_test.go
+++ b/internal/memory/latest_autopilot_metrics_test.go
@@ -1,0 +1,65 @@
+package memory
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLatestAutopilotMetrics(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	t.Run("empty table returns nil", func(t *testing.T) {
+		row, err := store.LatestAutopilotMetrics()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if row != nil {
+			t.Fatalf("expected nil, got %+v", row)
+		}
+	})
+
+	t.Run("returns newer snapshot after two inserts", func(t *testing.T) {
+		older := &AutopilotMetricsRow{
+			SnapshotAt:    time.Now().Add(-10 * time.Minute),
+			IssuesSuccess: 5,
+			PRsMerged:     3,
+		}
+		newer := &AutopilotMetricsRow{
+			SnapshotAt:    time.Now(),
+			IssuesSuccess: 12,
+			PRsMerged:     7,
+		}
+
+		if err := store.SaveAutopilotMetrics(older); err != nil {
+			t.Fatalf("SaveAutopilotMetrics (older): %v", err)
+		}
+		if err := store.SaveAutopilotMetrics(newer); err != nil {
+			t.Fatalf("SaveAutopilotMetrics (newer): %v", err)
+		}
+
+		got, err := store.LatestAutopilotMetrics()
+		if err != nil {
+			t.Fatalf("LatestAutopilotMetrics: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected a row, got nil")
+		}
+		if got.IssuesSuccess != newer.IssuesSuccess {
+			t.Errorf("IssuesSuccess: got %d, want %d", got.IssuesSuccess, newer.IssuesSuccess)
+		}
+		if got.PRsMerged != newer.PRsMerged {
+			t.Errorf("PRsMerged: got %d, want %d", got.PRsMerged, newer.PRsMerged)
+		}
+	})
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1773,6 +1773,33 @@ func (s *Store) GetRecentAutopilotMetrics(limit int) ([]*AutopilotMetricsRow, er
 	return result, rows.Err()
 }
 
+// LatestAutopilotMetrics returns the most recent persisted snapshot, or (nil, nil) if none.
+func (s *Store) LatestAutopilotMetrics() (*AutopilotMetricsRow, error) {
+	row := s.db.QueryRow(`
+		SELECT id, snapshot_at, issues_success, issues_failed, issues_rate_limited,
+			prs_merged, prs_failed, prs_conflicting, circuit_breaker_trips,
+			api_errors_total, api_error_rate, queue_depth, failed_queue_depth,
+			active_prs, success_rate, avg_ci_wait_ms, avg_merge_time_ms, avg_execution_ms
+		FROM autopilot_metrics
+		ORDER BY snapshot_at DESC
+		LIMIT 1
+	`)
+	r := &AutopilotMetricsRow{}
+	err := row.Scan(
+		&r.ID, &r.SnapshotAt, &r.IssuesSuccess, &r.IssuesFailed, &r.IssuesRateLimited,
+		&r.PRsMerged, &r.PRsFailed, &r.PRsConflicting, &r.CircuitBreakerTrips,
+		&r.APIErrorsTotal, &r.APIErrorRate, &r.QueueDepth, &r.FailedQueueDepth,
+		&r.ActivePRs, &r.SuccessRate, &r.AvgCIWaitMs, &r.AvgMergeTimeMs, &r.AvgExecutionMs,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan latest autopilot metrics: %w", err)
+	}
+	return r, nil
+}
+
 // PruneAutopilotMetrics deletes snapshots older than the given duration.
 func (s *Store) PruneAutopilotMetrics(olderThan time.Duration) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2845.

Closes #2845

## Changes

not an error). Mirror the column scan order used by `SaveAutopilotMetrics`. Add a unit test in `internal/memory/` covering: empty table returns `(nil, nil)`; after inserting two rows, the newer `snapshot_at` is returned. This must land first so the autopilot subtask has a real method to call.