### PR TITLE
GH-2846: feat(autopilot): restore Prometheus metrics from SQLite snapshot on daemon start - In `internal/autopilot/metrics.go`, add `RestoreFromRow(row *memory.AutopilotMetricsRow)` that takes the mutex and copies the snapshot fields per the spec (IssuesProcessed success/failed/rate_limited, PRsMerged, PRsFailed, PRsConflicting, CircuitBreakerTrips). Skip histograms and the per-endpoint APIErrors map. In `internal/autopilot/metrics_persister.go`, call `mp.store.LatestAutopilotMetrics()` once at the top of `Run()` before the ticker loop; on success+non-nil, invoke `RestoreFromRow` and log at info; on error or nil, log at debug and continue with zero state

### DIFF
--- a/internal/autopilot/metrics.go
+++ b/internal/autopilot/metrics.go
@@ -3,6 +3,8 @@ package autopilot
 import (
 	"sync"
 	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 // Metrics collects autopilot operational metrics.
@@ -51,6 +53,24 @@ func NewMetrics() *Metrics {
 		apiErrorTimes:      make([]time.Time, 0, 100),
 		maxSamples:         1000,
 	}
+}
+
+// RestoreFromRow rehydrates counters from a persisted snapshot row.
+// Histograms are NOT restored — they are a rolling window and stale samples
+// would give misleading quantiles. Gauges (queue depth, active PRs) are also
+// skipped because they are re-populated on the first poll cycle.
+func (m *Metrics) RestoreFromRow(row *memory.AutopilotMetricsRow) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.IssuesProcessed["success"] = int64(row.IssuesSuccess)
+	m.IssuesProcessed["failed"] = int64(row.IssuesFailed)
+	m.IssuesProcessed["rate_limited"] = int64(row.IssuesRateLimited)
+	m.PRsMerged = int64(row.PRsMerged)
+	m.PRsFailed = int64(row.PRsFailed)
+	m.PRsConflicting = int64(row.PRsConflicting)
+	m.CircuitBreakerTrips = int64(row.CircuitBreakerTrips)
+	// APIErrors map[endpoint]int64 is not persisted per-endpoint; skip restoration.
+	// SuccessRate is a derived gauge recomputed by Snapshot().
 }
 
 // --- Counter increments ---

--- a/internal/autopilot/metrics_persister.go
+++ b/internal/autopilot/metrics_persister.go
@@ -29,11 +29,20 @@ func NewMetricsPersister(controller *Controller, store *memory.Store) *MetricsPe
 	}
 }
 
-// Run starts the persister loop.
+// Run starts the persister loop. On startup it attempts to restore the latest
+// persisted snapshot into Metrics. Restoration is best-effort: failures are
+// logged at debug level and the daemon proceeds with zero-state counters.
 func (mp *MetricsPersister) Run(ctx context.Context) {
 	if mp.store == nil {
 		mp.log.Debug("no store configured, metrics persistence disabled")
 		return
+	}
+
+	if row, err := mp.store.LatestAutopilotMetrics(); err != nil {
+		mp.log.Debug("could not load metrics snapshot for restore", slog.Any("error", err))
+	} else if row != nil {
+		mp.controller.Metrics().RestoreFromRow(row)
+		mp.log.Info("restored autopilot metrics from snapshot", slog.Time("snapshot_at", row.SnapshotAt))
 	}
 
 	ticker := time.NewTicker(mp.interval)

--- a/internal/autopilot/metrics_persister_test.go
+++ b/internal/autopilot/metrics_persister_test.go
@@ -1,0 +1,143 @@
+package autopilot
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// newTestStore creates a temp-dir Store for integration tests.
+func newTestStore(t *testing.T) (*memory.Store, func()) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "metrics-persister-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		t.Fatalf("failed to create store: %v", err)
+	}
+	return store, func() {
+		_ = store.Close()
+		_ = os.RemoveAll(tmpDir)
+	}
+}
+
+// newTestPersister returns a MetricsPersister backed by a stub controller that
+// holds the given *Metrics so tests can inspect the result of RestoreFromRow.
+func newTestPersister(m *Metrics, store *memory.Store) *MetricsPersister {
+	ctrl := &Controller{metrics: m}
+	return &MetricsPersister{
+		controller: ctrl,
+		store:      store,
+		interval:   time.Hour, // large — we don't want ticks to fire in tests
+		retention:  7 * 24 * time.Hour,
+		log:        slog.Default(),
+	}
+}
+
+// TestMetricsPersister_RestoreFromStore_OneRow seeds a store with one snapshot row
+// and verifies that Run() populates Metrics before any tick fires.
+func TestMetricsPersister_RestoreFromStore_OneRow(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	seed := &memory.AutopilotMetricsRow{
+		SnapshotAt:          time.Now().Add(-10 * time.Minute),
+		IssuesSuccess:       20,
+		IssuesFailed:        4,
+		IssuesRateLimited:   2,
+		PRsMerged:           8,
+		PRsFailed:           1,
+		PRsConflicting:      3,
+		CircuitBreakerTrips: 6,
+	}
+	if err := store.SaveAutopilotMetrics(seed); err != nil {
+		t.Fatalf("SaveAutopilotMetrics: %v", err)
+	}
+
+	m := NewMetrics()
+	mp := newTestPersister(m, store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately so the ticker loop exits right away
+
+	mp.Run(ctx)
+
+	snap := m.Snapshot()
+	if snap.IssuesProcessed["success"] != 20 {
+		t.Errorf("IssuesProcessed[success]: want 20, got %d", snap.IssuesProcessed["success"])
+	}
+	if snap.IssuesProcessed["failed"] != 4 {
+		t.Errorf("IssuesProcessed[failed]: want 4, got %d", snap.IssuesProcessed["failed"])
+	}
+	if snap.PRsMerged != 8 {
+		t.Errorf("PRsMerged: want 8, got %d", snap.PRsMerged)
+	}
+	if snap.CircuitBreakerTrips != 6 {
+		t.Errorf("CircuitBreakerTrips: want 6, got %d", snap.CircuitBreakerTrips)
+	}
+}
+
+// TestMetricsPersister_RestoreFromStore_Empty verifies that an empty store leaves
+// all counters at zero and does not return an error.
+func TestMetricsPersister_RestoreFromStore_Empty(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	m := NewMetrics()
+	mp := newTestPersister(m, store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Must not panic or log a fatal error; counters stay zero.
+	mp.Run(ctx)
+
+	snap := m.Snapshot()
+	if snap.TotalIssuesProcessed() != 0 {
+		t.Errorf("expected zero counters, got total %d", snap.TotalIssuesProcessed())
+	}
+	if snap.PRsMerged != 0 {
+		t.Errorf("expected PRsMerged 0, got %d", snap.PRsMerged)
+	}
+}
+
+// TestMetricsPersister_RestoreFromStore_LatestRow seeds two rows and confirms
+// that the newer snapshot is the one restored.
+func TestMetricsPersister_RestoreFromStore_LatestRow(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	older := &memory.AutopilotMetricsRow{
+		SnapshotAt:    time.Now().Add(-20 * time.Minute),
+		IssuesSuccess: 5,
+	}
+	newer := &memory.AutopilotMetricsRow{
+		SnapshotAt:    time.Now().Add(-5 * time.Minute),
+		IssuesSuccess: 99,
+	}
+	if err := store.SaveAutopilotMetrics(older); err != nil {
+		t.Fatalf("SaveAutopilotMetrics(older): %v", err)
+	}
+	if err := store.SaveAutopilotMetrics(newer); err != nil {
+		t.Fatalf("SaveAutopilotMetrics(newer): %v", err)
+	}
+
+	m := NewMetrics()
+	mp := newTestPersister(m, store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	mp.Run(ctx)
+
+	snap := m.Snapshot()
+	if snap.IssuesProcessed["success"] != 99 {
+		t.Errorf("expected newest snapshot (99), got %d", snap.IssuesProcessed["success"])
+	}
+}

--- a/internal/autopilot/metrics_test.go
+++ b/internal/autopilot/metrics_test.go
@@ -3,6 +3,8 @@ package autopilot
 import (
 	"testing"
 	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 func TestNewMetrics(t *testing.T) {
@@ -175,6 +177,62 @@ func TestSnapshotIsolation(t *testing.T) {
 	snap2 := m.Snapshot()
 	if snap2.PRsMerged != 2 {
 		t.Errorf("new snapshot should reflect mutation, expected 2, got %d", snap2.PRsMerged)
+	}
+}
+
+func TestRestoreFromRow(t *testing.T) {
+	m := NewMetrics()
+	row := &memory.AutopilotMetricsRow{
+		IssuesSuccess:       10,
+		IssuesFailed:        3,
+		IssuesRateLimited:   1,
+		PRsMerged:           7,
+		PRsFailed:           2,
+		PRsConflicting:      4,
+		CircuitBreakerTrips: 5,
+	}
+	m.RestoreFromRow(row)
+	snap := m.Snapshot()
+
+	if snap.IssuesProcessed["success"] != 10 {
+		t.Errorf("IssuesProcessed[success]: want 10, got %d", snap.IssuesProcessed["success"])
+	}
+	if snap.IssuesProcessed["failed"] != 3 {
+		t.Errorf("IssuesProcessed[failed]: want 3, got %d", snap.IssuesProcessed["failed"])
+	}
+	if snap.IssuesProcessed["rate_limited"] != 1 {
+		t.Errorf("IssuesProcessed[rate_limited]: want 1, got %d", snap.IssuesProcessed["rate_limited"])
+	}
+	if snap.PRsMerged != 7 {
+		t.Errorf("PRsMerged: want 7, got %d", snap.PRsMerged)
+	}
+	if snap.PRsFailed != 2 {
+		t.Errorf("PRsFailed: want 2, got %d", snap.PRsFailed)
+	}
+	if snap.PRsConflicting != 4 {
+		t.Errorf("PRsConflicting: want 4, got %d", snap.PRsConflicting)
+	}
+	if snap.CircuitBreakerTrips != 5 {
+		t.Errorf("CircuitBreakerTrips: want 5, got %d", snap.CircuitBreakerTrips)
+	}
+}
+
+func TestRestoreFromRowThenIncrement(t *testing.T) {
+	m := NewMetrics()
+	row := &memory.AutopilotMetricsRow{
+		IssuesSuccess: 10,
+		PRsMerged:     7,
+	}
+	m.RestoreFromRow(row)
+	m.RecordIssueProcessed("success")
+	m.RecordPRMerged()
+
+	snap := m.Snapshot()
+	if snap.IssuesProcessed["success"] != 11 {
+		t.Errorf("IssuesProcessed[success] after increment: want 11, got %d", snap.IssuesProcessed["success"])
+	}
+	if snap.PRsMerged != 8 {
+		t.Errorf("PRsMerged after increment: want 8, got %d", snap.PRsMerged)
 	}
 }
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1773,6 +1773,33 @@ func (s *Store) GetRecentAutopilotMetrics(limit int) ([]*AutopilotMetricsRow, er
 	return result, rows.Err()
 }
 
+// LatestAutopilotMetrics returns the most recent persisted snapshot, or nil if the table is empty.
+func (s *Store) LatestAutopilotMetrics() (*AutopilotMetricsRow, error) {
+	row := s.db.QueryRow(`
+		SELECT id, snapshot_at, issues_success, issues_failed, issues_rate_limited,
+			prs_merged, prs_failed, prs_conflicting, circuit_breaker_trips,
+			api_errors_total, api_error_rate, queue_depth, failed_queue_depth,
+			active_prs, success_rate, avg_ci_wait_ms, avg_merge_time_ms, avg_execution_ms
+		FROM autopilot_metrics
+		ORDER BY snapshot_at DESC
+		LIMIT 1
+	`)
+	r := &AutopilotMetricsRow{}
+	err := row.Scan(
+		&r.ID, &r.SnapshotAt, &r.IssuesSuccess, &r.IssuesFailed, &r.IssuesRateLimited,
+		&r.PRsMerged, &r.PRsFailed, &r.PRsConflicting, &r.CircuitBreakerTrips,
+		&r.APIErrorsTotal, &r.APIErrorRate, &r.QueueDepth, &r.FailedQueueDepth,
+		&r.ActivePRs, &r.SuccessRate, &r.AvgCIWaitMs, &r.AvgMergeTimeMs, &r.AvgExecutionMs,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query latest autopilot metrics: %w", err)
+	}
+	return r, nil
+}
+
 // PruneAutopilotMetrics deletes snapshots older than the given duration.
 func (s *Store) PruneAutopilotMetrics(olderThan time.Duration) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2127,3 +2127,65 @@ func TestEffortLevelColumns_RoundTrip(t *testing.T) {
 		t.Errorf("after update: ComplexityLevel = %q, want %q", got2.ComplexityLevel, "complex")
 	}
 }
+
+func TestLatestAutopilotMetrics_Empty(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "latest-metrics-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	row, err := store.LatestAutopilotMetrics()
+	if err != nil {
+		t.Fatalf("LatestAutopilotMetrics on empty table returned error: %v", err)
+	}
+	if row != nil {
+		t.Fatalf("expected nil row on empty table, got %+v", row)
+	}
+}
+
+func TestLatestAutopilotMetrics_ReturnsNewest(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "latest-metrics-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	older := &AutopilotMetricsRow{
+		SnapshotAt:    time.Now().Add(-10 * time.Minute),
+		IssuesSuccess: 3,
+	}
+	newer := &AutopilotMetricsRow{
+		SnapshotAt:    time.Now().Add(-1 * time.Minute),
+		IssuesSuccess: 42,
+	}
+	if err := store.SaveAutopilotMetrics(older); err != nil {
+		t.Fatalf("SaveAutopilotMetrics(older): %v", err)
+	}
+	if err := store.SaveAutopilotMetrics(newer); err != nil {
+		t.Fatalf("SaveAutopilotMetrics(newer): %v", err)
+	}
+
+	row, err := store.LatestAutopilotMetrics()
+	if err != nil {
+		t.Fatalf("LatestAutopilotMetrics: %v", err)
+	}
+	if row == nil {
+		t.Fatal("expected non-nil row, got nil")
+	}
+	if row.IssuesSuccess != 42 {
+		t.Errorf("IssuesSuccess: want 42, got %d", row.IssuesSuccess)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2846.

Closes #2846

## Changes

never fail-fatal. Tests: unit test `RestoreFromRow` populates every counter from a row; unit test that incrementing after restore yields `row + 1`; integration test using a real `Store` seeded with one row asserts `Snapshot()` reflects it before any tick fires; integration test with an empty store leaves counters at zero with no error. Verify with `make test`, `make lint`, and the end-to-end curl/sqlite check from the task spec.