### PR TITLE
GH-2853: feat(autopilot): add token/cost/execution counter fields to Metrics

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-05-08 (v2.53.0)
+**Last Updated:** 2026-05-06 (v2.53.0)
 
 ## Legend
 
@@ -295,7 +295,7 @@
 | OpenAI-compatible direct backend | ✅ | executor | `type: openai-api` | `executor.openai` | Direct /v1/chat/completions for OpenAI, OpenRouter, Groq, Synthetic, vLLM, Ollama (v2.105.0, GH-2382) |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |
-| Local monitoring stack | ✅ | deploy/grafana | - | - | Docker Compose Prometheus+Grafana stack with 8-panel dashboard, ports 9093/3334 (v2.134.2, GH-2835) |
+| Token/cost/execution metrics | ✅ | autopilot | - | - | `TokensConsumed`, `ExecutionCostUSD`, `ExecutionsByResult` counters with per-model keying (v2.136.1, GH-2853) |
 | JSON structured logging | ✅ | - | - | `logging.format` | Optional JSON log output mode (v0.38.0) |
 | Qwen Code backend | ✅ | executor | `--backend qwen` | `executor.backend` | Alibaba Qwen Code CLI with stream-json (v1.9.0, GH-1314) |
 | Docker support | ✅ | - | - | - | Dockerfile + deployment guide (v1.46.0) |

--- a/internal/autopilot/metrics.go
+++ b/internal/autopilot/metrics.go
@@ -5,20 +5,35 @@ import (
 	"time"
 )
 
+// tokenKey identifies a token bucket by model and direction (input/output/cache_read/etc).
+type tokenKey struct {
+	Model     string
+	Direction string
+}
+
+// execKey identifies an execution bucket by model and result (success/failed/etc).
+type execKey struct {
+	Model  string
+	Result string
+}
+
 // Metrics collects autopilot operational metrics.
 // All methods are goroutine-safe.
 type Metrics struct {
 	mu sync.RWMutex
 
 	// Counters
-	IssuesProcessed       map[string]int64 // result → count (success, failed, rate_limited)
+	IssuesProcessed       map[string]int64    // result → count (success, failed, rate_limited)
 	PRsMerged             int64
 	PRsFailed             int64
 	PRsConflicting        int64
 	CircuitBreakerTrips   int64
-	APIErrors             map[string]int64 // endpoint → count
-	LabelCleanups         map[string]int64 // label → count
-	ApprovalPersistMisses map[string]int64 // kind → count (request_id, decision)
+	APIErrors             map[string]int64    // endpoint → count
+	LabelCleanups         map[string]int64    // label → count
+	ApprovalPersistMisses map[string]int64    // kind → count (request_id, decision)
+	TokensConsumed        map[tokenKey]int64  // {model,direction} → token count
+	ExecutionCostUSD      map[string]float64  // model → cumulative USD cost
+	ExecutionsByResult    map[execKey]int64   // {model,result} → execution count
 
 	// Gauges (point-in-time values)
 	ActivePRsByStage map[PRStage]int
@@ -44,12 +59,15 @@ func NewMetrics() *Metrics {
 		APIErrors:             make(map[string]int64),
 		LabelCleanups:         make(map[string]int64),
 		ApprovalPersistMisses: make(map[string]int64),
-		ActivePRsByStage:   make(map[PRStage]int),
-		PRTimeToMerge:      make([]time.Duration, 0, 100),
-		CIWaitDurations:    make([]time.Duration, 0, 100),
-		ExecutionDurations: make([]time.Duration, 0, 100),
-		apiErrorTimes:      make([]time.Time, 0, 100),
-		maxSamples:         1000,
+		TokensConsumed:        make(map[tokenKey]int64),
+		ExecutionCostUSD:      make(map[string]float64),
+		ExecutionsByResult:    make(map[execKey]int64),
+		ActivePRsByStage:      make(map[PRStage]int),
+		PRTimeToMerge:         make([]time.Duration, 0, 100),
+		CIWaitDurations:       make([]time.Duration, 0, 100),
+		ExecutionDurations:    make([]time.Duration, 0, 100),
+		apiErrorTimes:         make([]time.Time, 0, 100),
+		maxSamples:            1000,
 	}
 }
 
@@ -115,6 +133,27 @@ func (m *Metrics) RecordApprovalPersistMiss(kind string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.ApprovalPersistMisses[kind]++
+}
+
+// RecordTokens adds n tokens to the {model, direction} bucket.
+func (m *Metrics) RecordTokens(model, direction string, n int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.TokensConsumed[tokenKey{Model: model, Direction: direction}] += n
+}
+
+// RecordCost adds costUSD to the per-model cumulative cost.
+func (m *Metrics) RecordCost(model string, costUSD float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ExecutionCostUSD[model] += costUSD
+}
+
+// RecordExecution increments the {model, result} execution counter.
+func (m *Metrics) RecordExecution(model, result string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ExecutionsByResult[execKey{Model: model, Result: result}]++
 }
 
 // --- Gauge updates ---
@@ -193,15 +232,18 @@ func (m *Metrics) Snapshot() MetricsSnapshot {
 		APIErrors:             copyStringIntMap(m.APIErrors),
 		LabelCleanups:         copyStringIntMap(m.LabelCleanups),
 		ApprovalPersistMisses: copyStringIntMap(m.ApprovalPersistMisses),
+		TokensConsumed:        copyTokenKeyMap(m.TokensConsumed),
+		ExecutionCostUSD:      copyStringFloatMap(m.ExecutionCostUSD),
+		ExecutionsByResult:    copyExecKeyMap(m.ExecutionsByResult),
 		ActivePRsByStage:      copyStageIntMap(m.ActivePRsByStage),
-		QueueDepth:           m.QueueDepth,
-		FailedQueueDepth:     m.FailedQueueDepth,
-		TotalActivePRs:       sumStageMap(m.ActivePRsByStage),
-		AvgPRTimeToMerge:     avgDuration(m.PRTimeToMerge),
-		AvgCIWaitDuration:    avgDuration(m.CIWaitDurations),
-		AvgExecutionDuration: avgDuration(m.ExecutionDurations),
-		APIErrorRate:         m.apiErrorRate(),
-		SnapshotAt:           time.Now(),
+		QueueDepth:            m.QueueDepth,
+		FailedQueueDepth:      m.FailedQueueDepth,
+		TotalActivePRs:        sumStageMap(m.ActivePRsByStage),
+		AvgPRTimeToMerge:      avgDuration(m.PRTimeToMerge),
+		AvgCIWaitDuration:     avgDuration(m.CIWaitDurations),
+		AvgExecutionDuration:  avgDuration(m.ExecutionDurations),
+		APIErrorRate:          m.apiErrorRate(),
+		SnapshotAt:            time.Now(),
 	}
 
 	// Calculate success rate
@@ -240,6 +282,9 @@ type MetricsSnapshot struct {
 	APIErrors             map[string]int64
 	LabelCleanups         map[string]int64
 	ApprovalPersistMisses map[string]int64
+	TokensConsumed        map[tokenKey]int64
+	ExecutionCostUSD      map[string]float64
+	ExecutionsByResult    map[execKey]int64
 
 	// Gauges
 	ActivePRsByStage map[PRStage]int
@@ -329,4 +374,28 @@ func avgDuration(samples []time.Duration) time.Duration {
 		sum += d
 	}
 	return sum / time.Duration(len(samples))
+}
+
+func copyTokenKeyMap(src map[tokenKey]int64) map[tokenKey]int64 {
+	dst := make(map[tokenKey]int64, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func copyStringFloatMap(src map[string]float64) map[string]float64 {
+	dst := make(map[string]float64, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func copyExecKeyMap(src map[execKey]int64) map[execKey]int64 {
+	dst := make(map[execKey]int64, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }

--- a/internal/autopilot/metrics_test.go
+++ b/internal/autopilot/metrics_test.go
@@ -178,6 +178,165 @@ func TestSnapshotIsolation(t *testing.T) {
 	}
 }
 
+func TestRecordTokens(t *testing.T) {
+	m := NewMetrics()
+
+	m.RecordTokens("claude-sonnet-4-5", "input", 500)
+	m.RecordTokens("claude-sonnet-4-5", "input", 300)
+	m.RecordTokens("claude-sonnet-4-5", "output", 200)
+	m.RecordTokens("claude-opus-4-5", "input", 100)
+
+	snap := m.Snapshot()
+
+	k1 := tokenKey{Model: "claude-sonnet-4-5", Direction: "input"}
+	if snap.TokensConsumed[k1] != 800 {
+		t.Errorf("expected 800 input tokens for sonnet, got %d", snap.TokensConsumed[k1])
+	}
+	k2 := tokenKey{Model: "claude-sonnet-4-5", Direction: "output"}
+	if snap.TokensConsumed[k2] != 200 {
+		t.Errorf("expected 200 output tokens for sonnet, got %d", snap.TokensConsumed[k2])
+	}
+	k3 := tokenKey{Model: "claude-opus-4-5", Direction: "input"}
+	if snap.TokensConsumed[k3] != 100 {
+		t.Errorf("expected 100 input tokens for opus, got %d", snap.TokensConsumed[k3])
+	}
+}
+
+func TestRecordCost(t *testing.T) {
+	m := NewMetrics()
+
+	m.RecordCost("claude-sonnet-4-5", 0.01)
+	m.RecordCost("claude-sonnet-4-5", 0.02)
+	m.RecordCost("claude-opus-4-5", 0.05)
+
+	snap := m.Snapshot()
+
+	const epsilon = 1e-9
+	if diff := snap.ExecutionCostUSD["claude-sonnet-4-5"] - 0.03; diff > epsilon || diff < -epsilon {
+		t.Errorf("expected sonnet cost 0.03, got %f", snap.ExecutionCostUSD["claude-sonnet-4-5"])
+	}
+	if diff := snap.ExecutionCostUSD["claude-opus-4-5"] - 0.05; diff > epsilon || diff < -epsilon {
+		t.Errorf("expected opus cost 0.05, got %f", snap.ExecutionCostUSD["claude-opus-4-5"])
+	}
+}
+
+func TestRecordExecution(t *testing.T) {
+	m := NewMetrics()
+
+	m.RecordExecution("claude-sonnet-4-5", "success")
+	m.RecordExecution("claude-sonnet-4-5", "success")
+	m.RecordExecution("claude-sonnet-4-5", "failed")
+	m.RecordExecution("claude-opus-4-5", "success")
+
+	snap := m.Snapshot()
+
+	k1 := execKey{Model: "claude-sonnet-4-5", Result: "success"}
+	if snap.ExecutionsByResult[k1] != 2 {
+		t.Errorf("expected 2 sonnet successes, got %d", snap.ExecutionsByResult[k1])
+	}
+	k2 := execKey{Model: "claude-sonnet-4-5", Result: "failed"}
+	if snap.ExecutionsByResult[k2] != 1 {
+		t.Errorf("expected 1 sonnet failure, got %d", snap.ExecutionsByResult[k2])
+	}
+	k3 := execKey{Model: "claude-opus-4-5", Result: "success"}
+	if snap.ExecutionsByResult[k3] != 1 {
+		t.Errorf("expected 1 opus success, got %d", snap.ExecutionsByResult[k3])
+	}
+}
+
+func TestSnapshotIsolationNewMaps(t *testing.T) {
+	m := NewMetrics()
+	m.RecordTokens("model-a", "input", 100)
+	m.RecordCost("model-a", 0.01)
+	m.RecordExecution("model-a", "success")
+
+	snap := m.Snapshot()
+
+	// Mutate after snapshot
+	m.RecordTokens("model-a", "input", 900)
+	m.RecordCost("model-a", 0.99)
+	m.RecordExecution("model-a", "success")
+
+	tk := tokenKey{Model: "model-a", Direction: "input"}
+	if snap.TokensConsumed[tk] != 100 {
+		t.Errorf("snapshot TokensConsumed should be isolated; expected 100, got %d", snap.TokensConsumed[tk])
+	}
+	const epsilon = 1e-9
+	if diff := snap.ExecutionCostUSD["model-a"] - 0.01; diff > epsilon || diff < -epsilon {
+		t.Errorf("snapshot ExecutionCostUSD should be isolated; expected 0.01, got %f", snap.ExecutionCostUSD["model-a"])
+	}
+	ek := execKey{Model: "model-a", Result: "success"}
+	if snap.ExecutionsByResult[ek] != 1 {
+		t.Errorf("snapshot ExecutionsByResult should be isolated; expected 1, got %d", snap.ExecutionsByResult[ek])
+	}
+
+	snap2 := m.Snapshot()
+	if snap2.TokensConsumed[tk] != 1000 {
+		t.Errorf("new snapshot should reflect mutations; expected 1000, got %d", snap2.TokensConsumed[tk])
+	}
+}
+
+func TestRecordTokensRace(t *testing.T) {
+	m := NewMetrics()
+	done := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				m.RecordTokens("model", "input", 1)
+				_ = m.Snapshot()
+			}
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+	snap := m.Snapshot()
+	tk := tokenKey{Model: "model", Direction: "input"}
+	if snap.TokensConsumed[tk] != 1000 {
+		t.Errorf("expected 1000 tokens after concurrent writes, got %d", snap.TokensConsumed[tk])
+	}
+}
+
+func TestRecordCostRace(t *testing.T) {
+	m := NewMetrics()
+	done := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				m.RecordCost("model", 0.001)
+				_ = m.Snapshot()
+			}
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}
+
+func TestRecordExecutionRace(t *testing.T) {
+	m := NewMetrics()
+	done := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				m.RecordExecution("model", "success")
+				_ = m.Snapshot()
+			}
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+	snap := m.Snapshot()
+	ek := execKey{Model: "model", Result: "success"}
+	if snap.ExecutionsByResult[ek] != 1000 {
+		t.Errorf("expected 1000 executions after concurrent writes, got %d", snap.ExecutionsByResult[ek])
+	}
+}
+
 func TestUpdateActivePRsReset(t *testing.T) {
 	m := NewMetrics()
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2853.

Closes #2853

## Changes

In `internal/autopilot/metrics.go`, add `TokensConsumed map[tokenKey]int64`, `ExecutionCostUSD map[string]float64`, and `ExecutionsByResult map[execKey]int64` fields with `tokenKey{Model,Direction}` and `execKey{Model,Result}` types. Implement `RecordTokens`, `RecordCost`, and `RecordExecution` methods (mutex-guarded like existing fields). Extend `MetricsSnapshot` with read-only copies and update `Snapshot()` to deep-copy the new maps. Add unit tests in `internal/autopilot/metrics_test.go` covering each Record method, snapshot isolation, and `-race` safety.