### PR TITLE
GH-2867: fix(executor): refuse CreateSubIssues for closed parents

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -583,6 +583,21 @@ var parentTypeScopeRE = regexp.MustCompile(
 // referencing the parent already exist, preventing duplicate batch creation.
 var ErrSubIssuesAlreadyExist = errors.New("open sub-issues already exist for this parent")
 
+// ErrParentDone is returned by CreateSubIssues when the parent task is already
+// closed or skipped, so spawning sub-issues would be wasteful (GH-2867).
+var ErrParentDone = errors.New("parent task is already done; refusing to create sub-issues")
+
+// isParentDone reports whether a task should be treated as done based on its
+// labels (pilot-done, pilot-skip) or its state (closed, merged).
+func isParentDone(t *Task) bool {
+	for _, label := range t.Labels {
+		if label == "pilot-done" || label == "pilot-skip" {
+			return true
+		}
+	}
+	return t.State == "closed" || t.State == "merged"
+}
+
 // isConventionalSubtaskTitle reports whether title is in conventional-commits format.
 func isConventionalSubtaskTitle(title string) bool {
 	return conventionalSubtaskTitleRE.MatchString(strings.TrimSpace(title))
@@ -743,14 +758,16 @@ func validateAndFixSubtaskTitles(ctx context.Context, subtasks []PlannedSubtask,
 	return applyParentTypeScopeFallback(subtasks, invalid, parentTitle, parentBody)
 }
 
-// queryOpenSubIssues returns true when there are open GitHub issues that include
-// "Parent: <parentID>" in their body. Used by CreateSubIssues as a dedup guard.
+// queryRecentSubIssues returns true when there are open or recently-closed GitHub
+// issues (created within the last 24 hours) that include "Parent: <parentID>" in
+// their body. Used by CreateSubIssues as a dedup guard (GH-2867).
 // Non-fatal: if the gh CLI call fails the check returns (false, nil) to allow creation.
-func queryOpenSubIssues(ctx context.Context, dir, parentID string) (bool, error) {
+func queryRecentSubIssues(ctx context.Context, dir, parentID string) (bool, error) {
+	since := time.Now().UTC().Add(-24 * time.Hour).Format("2006-01-02T15:04:05Z")
 	args := []string{
 		"issue", "list",
-		"--state", "open",
-		"--search", fmt.Sprintf("\"Parent: %s\" in:body", parentID),
+		"--state", "all",
+		"--search", fmt.Sprintf("\"Parent: %s\" in:body created:>=%s", parentID, since),
 		"--json", "number",
 		"--limit", "3",
 	}
@@ -816,12 +833,22 @@ func (r *Runner) CreateSubIssues(ctx context.Context, plan *EpicPlan, executionP
 		return nil, fmt.Errorf("plan has no subtasks to create issues from")
 	}
 
-	// Dedup guard: skip creation if open sub-issues referencing this parent already exist.
-	// Uses an injectable checker so tests can control the result without spawning gh CLI.
 	if plan.ParentTask != nil {
+		// GH-2867: refuse to spawn sub-issues for a parent that is already done.
+		if isParentDone(plan.ParentTask) {
+			r.log.Info("Skipping sub-issue creation: parent is already done",
+				"parent_id", plan.ParentTask.ID,
+				"state", plan.ParentTask.State,
+				"labels", plan.ParentTask.Labels,
+			)
+			return nil, ErrParentDone
+		}
+
+		// Dedup guard: skip creation if recent sub-issues referencing this parent already exist.
+		// Uses an injectable checker so tests can control the result without spawning gh CLI.
 		checker := r.openSubIssueCheck
 		if checker == nil {
-			checker = queryOpenSubIssues
+			checker = queryRecentSubIssues
 		}
 		if exists, _ := checker(ctx, executionPath, plan.ParentTask.ID); exists {
 			r.log.Info("Skipping sub-issue creation: open children already exist",

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2150,3 +2150,67 @@ func TestCreateSubIssuesViaAdapter_PropagatesParentLabels(t *testing.T) {
 		t.Errorf("CreateIssue labels = %v, want %v", gotLabels, wantLabels)
 	}
 }
+
+// TestCreateSubIssues_RefusesClosedParent verifies that CreateSubIssues returns
+// ErrParentDone when the parent task carries a terminal label or closed state.
+func TestCreateSubIssues_RefusesClosedParent(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels []string
+		state  string
+	}{
+		{name: "pilot-done label", labels: []string{"pilot-done"}},
+		{name: "pilot-skip label", labels: []string{"pilot-skip"}},
+		{name: "closed state", state: "closed"},
+		{name: "merged state", state: "merged"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRunner()
+			r.dryRun = true
+			r.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) {
+				return false, nil // dedup guard must not be reached
+			}
+			plan := &EpicPlan{
+				ParentTask: &Task{
+					ID:     "GH-999",
+					Title:  "feat(scope): some epic",
+					Labels: tc.labels,
+					State:  tc.state,
+				},
+				Subtasks: []PlannedSubtask{
+					{Order: 1, Title: "feat(scope): sub-task one"},
+				},
+			}
+			_, err := r.CreateSubIssues(context.Background(), plan, "")
+			if err != ErrParentDone {
+				t.Errorf("expected ErrParentDone, got %v", err)
+			}
+		})
+	}
+}
+
+// TestCreateSubIssues_RefusesRecentlyClosedSiblings verifies that CreateSubIssues returns
+// ErrSubIssuesAlreadyExist when the injectable checker reports a recent sibling exists,
+// even when the parent itself is open.
+func TestCreateSubIssues_RefusesRecentlyClosedSiblings(t *testing.T) {
+	r := NewRunner()
+	r.dryRun = true
+	r.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) {
+		return true, nil // simulate a recently-closed sibling
+	}
+	plan := &EpicPlan{
+		ParentTask: &Task{
+			ID:    "GH-1000",
+			Title: "feat(scope): another epic",
+			State: "open",
+		},
+		Subtasks: []PlannedSubtask{
+			{Order: 1, Title: "feat(scope): sub-task one"},
+		},
+	}
+	_, err := r.CreateSubIssues(context.Background(), plan, "")
+	if err != ErrSubIssuesAlreadyExist {
+		t.Errorf("expected ErrSubIssuesAlreadyExist, got %v", err)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -187,6 +187,9 @@ type Task struct {
 	// When true, BuildPrompt skips Navigator detection and uses a focused
 	// problem-solving prompt suitable for local execution.
 	LocalMode bool
+	// State is the current issue state in the source adapter (GH-2867).
+	// Examples: "open", "closed", "merged"
+	State string
 }
 
 // QualityGateResult represents the result of a single quality gate check.
@@ -398,8 +401,8 @@ type Runner struct {
 	// GH-2363: Track consecutive title-rejection failures per issue so we stop
 	// retrying and post a helpful comment after the 2nd identical rejection.
 	titleRejections      *titleRejectionTracker
-	// openSubIssueCheck detects whether open sub-issues for a parent already exist.
-	// Injectable for testing; defaults to queryOpenSubIssues (gh CLI).
+	// openSubIssueCheck detects whether recent sub-issues for a parent already exist.
+	// Injectable for testing; defaults to queryRecentSubIssues (gh CLI).
 	openSubIssueCheck func(ctx context.Context, dir, parentID string) (bool, error)
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2867.

Closes #2867

## Changes

In `internal/executor/`, add `isParentDone(t *Task) bool` helper checking labels (`pilot-done`, `pilot-skip`) and state (`closed`, `merged`); thread `Task.State` through `types.go` if missing. Gate `CreateSubIssues` at `epic.go:811` to return an error when the parent is done. Rename `queryOpenSubIssues` → `queryRecentSubIssues` at `epic.go:746` to search `--state all` with `created:>=<now-24h>` and treat any open or recently-closed sibling as a duplicate. Add `TestCreateSubIssues_RefusesClosedParent` and `TestCreateSubIssues_RefusesRecentlyClosedSiblings` in `epic_test.go`. Verify via `make test`, `make lint`, and the two targeted `go test -run` invocations from the acceptance criteria.