### PR TITLE
GH-2855: feat(gateway): expose token/cost/execution counters on /metrics

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-05-08 (v2.53.0)
+**Last Updated:** 2026-05-06 (v2.53.0)
 
 ## Legend
 
@@ -295,7 +295,7 @@
 | OpenAI-compatible direct backend | ✅ | executor | `type: openai-api` | `executor.openai` | Direct /v1/chat/completions for OpenAI, OpenRouter, Groq, Synthetic, vLLM, Ollama (v2.105.0, GH-2382) |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |
-| Token/cost/execution metrics | ✅ | autopilot | - | - | `TokensConsumed`, `ExecutionCostUSD`, `ExecutionsByResult` counters with per-model keying (v2.136.1, GH-2853) |
+| Prometheus token/cost/execution counters | ✅ | gateway | - | - | `pilot_tokens_consumed_total`, `pilot_execution_cost_usd_total`, `pilot_executions_total` wired from executor (v2.138.0, GH-2855) |
 | JSON structured logging | ✅ | - | - | `logging.format` | Optional JSON log output mode (v0.38.0) |
 | Qwen Code backend | ✅ | executor | `--backend qwen` | `executor.backend` | Alibaba Qwen Code CLI with stream-json (v1.9.0, GH-1314) |
 | Docker support | ✅ | - | - | - | Dockerfile + deployment guide (v1.46.0) |

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -966,6 +966,10 @@ Examples:
 			if gwAutopilotController != nil {
 				p.Gateway().SetAutopilotProvider(&autopilotProviderAdapter{controller: gwAutopilotController})
 				p.Gateway().SetMetricsSource(gwAutopilotController.Metrics())
+				// GH-2855: wire token/cost/execution counters into executor
+				if gwRunner != nil {
+					gwRunner.SetMetricsRecorder(gwAutopilotController.Metrics())
+				}
 
 				// GH-2080: Wire PR review events to autopilot controller
 				p.SetOnPRReview(func(ctx context.Context, prNumber int, action, state, reviewer string, repo *github.Repository) error {
@@ -1626,6 +1630,8 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		if autopilotController != nil {
 			gwServer.SetAutopilotProvider(&autopilotProviderAdapter{controller: autopilotController})
 			gwServer.SetMetricsSource(autopilotController.Metrics())
+			// GH-2855: wire token/cost/execution counters into executor
+			runner.SetMetricsRecorder(autopilotController.Metrics())
 		}
 
 		// GH-2080: Wire PR review webhook events to autopilot controller in polling mode

--- a/internal/executor/metrics_recorder.go
+++ b/internal/executor/metrics_recorder.go
@@ -1,0 +1,9 @@
+package executor
+
+// MetricsRecorder accepts per-execution telemetry from the runner.
+// The interface is satisfied by *autopilot.Metrics without importing the autopilot package.
+type MetricsRecorder interface {
+	RecordTokens(model, direction string, n int64)
+	RecordCost(model string, costUSD float64)
+	RecordExecution(model, result string)
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -401,6 +401,8 @@ type Runner struct {
 	// openSubIssueCheck detects whether open sub-issues for a parent already exist.
 	// Injectable for testing; defaults to queryOpenSubIssues (gh CLI).
 	openSubIssueCheck func(ctx context.Context, dir, parentID string) (bool, error)
+	// GH-2855: Prometheus counters for tokens, cost, and executions.
+	metricsRecorder MetricsRecorder
 }
 
 // NewRunner creates a new Runner instance with Claude Code backend by default.
@@ -835,6 +837,11 @@ func (r *Runner) SetLogStore(store *memory.Store) {
 // SetLearningLoop sets the learning loop for post-execution pattern learning.
 func (r *Runner) SetLearningLoop(loop LearningRecorder) {
 	r.learningLoop = loop
+}
+
+// SetMetricsRecorder wires the Prometheus metrics recorder for token/cost/execution counters (GH-2855).
+func (r *Runner) SetMetricsRecorder(rec MetricsRecorder) {
+	r.metricsRecorder = rec
 }
 
 // SetPatternContext sets the pattern context for pre-execution pattern injection.
@@ -2124,6 +2131,25 @@ retrySucceeded:
 	}
 	// Estimate cost based on token usage (including research tokens) with cache-aware pricing (GH-2164)
 	result.EstimatedCostUSD = estimateCostWithCache(result.TokensInput+result.ResearchTokens, result.TokensOutput, result.CacheCreationInputTokens, result.CacheReadInputTokens, result.ModelName)
+
+	// Emit Prometheus counters for token usage, cost, and execution outcome (GH-2855).
+	if r.metricsRecorder != nil {
+		model := result.ModelName
+		r.metricsRecorder.RecordTokens(model, "input", result.TokensInput+result.ResearchTokens)
+		r.metricsRecorder.RecordTokens(model, "output", result.TokensOutput)
+		if result.CacheCreationInputTokens > 0 {
+			r.metricsRecorder.RecordTokens(model, "cache_creation", result.CacheCreationInputTokens)
+		}
+		if result.CacheReadInputTokens > 0 {
+			r.metricsRecorder.RecordTokens(model, "cache_read", result.CacheReadInputTokens)
+		}
+		r.metricsRecorder.RecordCost(model, result.EstimatedCostUSD)
+		outcomeLabel := "success"
+		if !result.Success {
+			outcomeLabel = "failed"
+		}
+		r.metricsRecorder.RecordExecution(model, outcomeLabel)
+	}
 
 	if !result.Success {
 		log.Error("Task execution failed",

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3823,3 +3823,95 @@ func TestExecute_PopulatesEffortAndComplexityOnResult(t *testing.T) {
 		t.Error("result.EffortLevel is empty; want a non-empty effort string (routing was enabled)")
 	}
 }
+
+// fakeMetricsRecorder captures calls to the MetricsRecorder interface for assertions.
+type fakeMetricsRecorder struct {
+	mu         sync.Mutex
+	tokenCalls []struct{ model, direction string; n int64 }
+	costCalls  []struct{ model string; costUSD float64 }
+	execCalls  []struct{ model, result string }
+}
+
+func (f *fakeMetricsRecorder) RecordTokens(model, direction string, n int64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.tokenCalls = append(f.tokenCalls, struct{ model, direction string; n int64 }{model, direction, n})
+}
+
+func (f *fakeMetricsRecorder) RecordCost(model string, costUSD float64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.costCalls = append(f.costCalls, struct{ model string; costUSD float64 }{model, costUSD})
+}
+
+func (f *fakeMetricsRecorder) RecordExecution(model, result string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.execCalls = append(f.execCalls, struct{ model, result string }{model, result})
+}
+
+// TestMetricsRecorder_CalledOncePerExecution verifies that SetMetricsRecorder
+// wires the recorder and that all three Record methods are called exactly once
+// per execution (GH-2855).
+func TestMetricsRecorder_CalledOncePerExecution(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	const branch = "pilot/GH-test-metrics"
+	dir := setupPRGuardRepo(t, branch, true) // adds a real commit so no-commit guard doesn't fire
+
+	backend := &mockFixedBackend{
+		result: &BackendResult{
+			Success:      true,
+			Output:       "done",
+			TokensInput:  500,
+			TokensOutput: 150,
+			Model:        "claude-sonnet-test",
+		},
+	}
+
+	rec := &fakeMetricsRecorder{}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	runner.SetMetricsRecorder(rec)
+
+	task := &Task{
+		ID:          "GH-test-metrics",
+		Title:       "test metrics recording",
+		Description: "verify recorder is called",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    false,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Execute() not successful: %s", result.Error)
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	if len(rec.execCalls) != 1 {
+		t.Errorf("RecordExecution called %d times, want exactly 1", len(rec.execCalls))
+	} else if rec.execCalls[0].result != "success" {
+		t.Errorf("RecordExecution result = %q, want %q", rec.execCalls[0].result, "success")
+	}
+
+	if len(rec.costCalls) != 1 {
+		t.Errorf("RecordCost called %d times, want exactly 1", len(rec.costCalls))
+	}
+
+	if len(rec.tokenCalls) == 0 {
+		t.Error("RecordTokens not called; want at least one call for input tokens")
+	}
+}

--- a/internal/gateway/prometheus.go
+++ b/internal/gateway/prometheus.go
@@ -91,6 +91,27 @@ func (e *PrometheusExporter) WritePrometheus(w io.Writer) error {
 		}
 	}
 
+	// pilot_tokens_consumed_total
+	writeHelp(w, "pilot_tokens_consumed_total", "Total tokens consumed by model and direction")
+	writeType(w, "pilot_tokens_consumed_total", "counter")
+	for k, v := range snap.TokensConsumed {
+		writeCounter(w, "pilot_tokens_consumed_total", v, "model", k.Model, "direction", k.Direction)
+	}
+
+	// pilot_execution_cost_usd_total
+	writeHelp(w, "pilot_execution_cost_usd_total", "Total execution cost in USD by model")
+	writeType(w, "pilot_execution_cost_usd_total", "counter")
+	for model, cost := range snap.ExecutionCostUSD {
+		writeFloatCounter(w, "pilot_execution_cost_usd_total", cost, "model", model)
+	}
+
+	// pilot_executions_total
+	writeHelp(w, "pilot_executions_total", "Total executions by model and result")
+	writeType(w, "pilot_executions_total", "counter")
+	for k, v := range snap.ExecutionsByResult {
+		writeCounter(w, "pilot_executions_total", v, "model", k.Model, "result", k.Result)
+	}
+
 	// --- Gauges ---
 
 	// pilot_queue_depth
@@ -166,6 +187,16 @@ func writeCounter(w io.Writer, name string, value int64, labelPairs ...string) {
 	}
 	labels := formatLabels(labelPairs)
 	_, _ = fmt.Fprintf(w, "%s{%s} %d\n", name, labels, value)
+}
+
+// writeFloatCounter writes a counter metric line with a float64 value.
+func writeFloatCounter(w io.Writer, name string, value float64, labelPairs ...string) {
+	if len(labelPairs) == 0 {
+		_, _ = fmt.Fprintf(w, "%s %g\n", name, value)
+		return
+	}
+	labels := formatLabels(labelPairs)
+	_, _ = fmt.Fprintf(w, "%s{%s} %g\n", name, labels, value)
 }
 
 // writeGauge writes a gauge metric line.

--- a/internal/gateway/prometheus_test.go
+++ b/internal/gateway/prometheus_test.go
@@ -187,6 +187,40 @@ func TestPrometheusExporter_WritePrometheus(t *testing.T) {
 	}
 }
 
+func TestPrometheusExporter_TokenCostExecutionMetrics(t *testing.T) {
+	m := autopilot.NewMetrics()
+	m.RecordTokens("claude-sonnet-4-5", "input", 1000)
+	m.RecordTokens("claude-sonnet-4-5", "output", 250)
+	m.RecordCost("claude-sonnet-4-5", 0.005)
+	m.RecordExecution("claude-sonnet-4-5", "success")
+	m.RecordExecution("claude-sonnet-4-5", "failed")
+
+	exporter := NewPrometheusExporter(m)
+	var buf bytes.Buffer
+	if err := exporter.WritePrometheus(&buf); err != nil {
+		t.Fatalf("WritePrometheus() error = %v", err)
+	}
+	output := buf.String()
+
+	for _, want := range []string{
+		"# HELP pilot_tokens_consumed_total Total tokens consumed by model and direction",
+		"# TYPE pilot_tokens_consumed_total counter",
+		`pilot_tokens_consumed_total{model="claude-sonnet-4-5",direction="input"} 1000`,
+		`pilot_tokens_consumed_total{model="claude-sonnet-4-5",direction="output"} 250`,
+		"# HELP pilot_execution_cost_usd_total Total execution cost in USD by model",
+		"# TYPE pilot_execution_cost_usd_total counter",
+		`pilot_execution_cost_usd_total{model="claude-sonnet-4-5"} 0.005`,
+		"# HELP pilot_executions_total Total executions by model and result",
+		"# TYPE pilot_executions_total counter",
+		`pilot_executions_total{model="claude-sonnet-4-5",result="success"} 1`,
+		`pilot_executions_total{model="claude-sonnet-4-5",result="failed"} 1`,
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("Output missing expected string: %q\nGot:\n%s", want, output)
+		}
+	}
+}
+
 func TestEscapeLabel(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2855.

Closes #2855

## Changes

GitHub Issue #2855: feat(gateway): expose token/cost/execution counters on /metrics

<!--autopilot-meta
parent: GH-2837
inherited-spec: true
-->

Parent: GH-2837

In `internal/gateway/prometheus.go`, add three metric blocks emitting `pilot_tokens_consumed_total{model,direction}`, `pilot_execution_cost_usd_total{model}`, and `pilot_executions_total{model,result}` from the new snapshot fields. Add a `writeFloatCounter` helper if existing writers are int64-only. Wire the autopilot `Metrics` instance as the executor's `MetricsRecorder` at daemon startup (the call site that already shares the metrics object with the gateway). Extend `internal/gateway/prometheus_test.go` to assert exact text format for all three new blocks.