### PR TITLE
GH-2883: fix(executor): fix(executor): treat ErrSubIssuesAlreadyExist as recovery, not failure

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -229,6 +229,9 @@ type CreatedIssue struct {
 
 	// Subtask is the planned subtask this issue was created from
 	Subtask PlannedSubtask
+
+	// State is "open" or "closed"; populated by recoverExistingSubIssues (GH-2883).
+	State string
 }
 
 // numberedListRegex matches numbered patterns: "1. ", "1) ", "Step 1:", "Phase 1:", "**1.", etc.
@@ -785,6 +788,63 @@ func queryRecentSubIssues(ctx context.Context, dir, parentID string) (bool, erro
 		return false, nil
 	}
 	return len(issues) > 0, nil
+}
+
+// recoverExistingSubIssues queries GitHub for all issues (open or closed) that
+// reference the given parentID in their body, and returns them as CreatedIssue
+// with the State field populated. Used by the runner when CreateSubIssues returns
+// ErrSubIssuesAlreadyExist so execution can resume rather than fail (GH-2883).
+func recoverExistingSubIssues(ctx context.Context, dir, parentID string) ([]CreatedIssue, error) {
+	args := []string{
+		"issue", "list",
+		"--state", "all",
+		"--search", fmt.Sprintf("\"Parent: %s\" in:body", parentID),
+		"--json", "number,url,title,state",
+		"--limit", "100",
+	}
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("gh issue list failed: %w", err)
+	}
+	var items []struct {
+		Number int    `json:"number"`
+		URL    string `json:"url"`
+		Title  string `json:"title"`
+		State  string `json:"state"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &items); err != nil {
+		return nil, fmt.Errorf("parse gh output: %w", err)
+	}
+	issues := make([]CreatedIssue, 0, len(items))
+	for _, item := range items {
+		issues = append(issues, CreatedIssue{
+			Number:     item.Number,
+			Identifier: strconv.Itoa(item.Number),
+			URL:        item.URL,
+			State:      item.State,
+			Subtask:    PlannedSubtask{Title: item.Title},
+		})
+	}
+	return issues, nil
+}
+
+// allChildrenDone returns true when every issue in the slice has State "closed".
+// An empty slice returns false so callers don't treat a recovery miss as done.
+func allChildrenDone(issues []CreatedIssue) bool {
+	if len(issues) == 0 {
+		return false
+	}
+	for _, iss := range issues {
+		if iss.State != "closed" {
+			return false
+		}
+	}
+	return true
 }
 
 // issueNumberRegex extracts the issue number from a GitHub issue URL.

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2214,3 +2214,114 @@ func TestCreateSubIssues_RefusesRecentlyClosedSiblings(t *testing.T) {
 		t.Errorf("expected ErrSubIssuesAlreadyExist, got %v", err)
 	}
 }
+
+// TestRunner_Execute_EpicRecoversExistingSubIssues verifies that when CreateSubIssues
+// returns ErrSubIssuesAlreadyExist and all recovered children are closed, Execute
+// returns a success no-op without invoking ExecuteSubIssues (GH-2883).
+func TestRunner_Execute_EpicRecoversExistingSubIssues(t *testing.T) {
+	r := newTestRunnerWithExecFunc(func(_ context.Context, _ *Task) (*ExecutionResult, error) {
+		t.Error("ExecuteSubIssues must NOT be called when all children are closed")
+		return &ExecutionResult{Success: true}, nil
+	})
+	r.skipPreflightChecks = true
+
+	// Make CreateSubIssues return ErrSubIssuesAlreadyExist.
+	r.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) {
+		return true, nil
+	}
+
+	// Inject recovery that returns all-closed children.
+	r.recoverSubIssuesFn = func(_ context.Context, _, _ string) ([]CreatedIssue, error) {
+		return []CreatedIssue{
+			{Number: 101, Identifier: "101", State: "closed", Subtask: PlannedSubtask{Title: "feat(scope): sub one"}},
+			{Number: 102, Identifier: "102", State: "closed", Subtask: PlannedSubtask{Title: "feat(scope): sub two"}},
+		}, nil
+	}
+
+	// Inject PlanEpic so the test doesn't shell out to Claude Code.
+	r.planEpicFn = func(_ context.Context, task *Task, _ string) (*EpicPlan, error) {
+		return &EpicPlan{
+			ParentTask: task,
+			Subtasks: []PlannedSubtask{
+				{Order: 1, Title: "feat(auth): migrate database schema", Description: "internal/auth/schema.go"},
+				{Order: 2, Title: "feat(billing): expose payment endpoint", Description: "internal/billing/handler.go"},
+			},
+		}, nil
+	}
+
+	task := &Task{
+		ID:    "GH-2883",
+		Title: "[epic] recover existing sub-issues",
+		Labels: []string{"epic"},
+	}
+
+	result, err := r.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("expected success result, got %+v", result)
+	}
+	if !result.IsEpic {
+		t.Error("expected IsEpic=true")
+	}
+}
+
+// TestRunner_Execute_EpicRecoversThenExecutesOpenChildren verifies that when
+// CreateSubIssues returns ErrSubIssuesAlreadyExist and some recovered children
+// are still open, Execute calls ExecuteSubIssues with only the open ones (GH-2883).
+func TestRunner_Execute_EpicRecoversThenExecutesOpenChildren(t *testing.T) {
+	var executedIDs []string
+
+	r := newTestRunnerWithExecFunc(func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		executedIDs = append(executedIDs, task.ID)
+		return &ExecutionResult{TaskID: task.ID, Success: true}, nil
+	})
+	r.skipPreflightChecks = true
+
+	// Make CreateSubIssues return ErrSubIssuesAlreadyExist.
+	r.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) {
+		return true, nil
+	}
+
+	// Inject recovery: one closed, one open.
+	r.recoverSubIssuesFn = func(_ context.Context, _, _ string) ([]CreatedIssue, error) {
+		return []CreatedIssue{
+			{Number: 201, Identifier: "201", State: "closed", Subtask: PlannedSubtask{Title: "feat(scope): sub closed"}},
+			{Number: 202, Identifier: "202", State: "open", Subtask: PlannedSubtask{Title: "feat(scope): sub open"}},
+		}, nil
+	}
+
+	// Inject PlanEpic so the test doesn't shell out to Claude Code.
+	r.planEpicFn = func(_ context.Context, task *Task, _ string) (*EpicPlan, error) {
+		return &EpicPlan{
+			ParentTask: task,
+			Subtasks: []PlannedSubtask{
+				{Order: 1, Title: "feat(auth): migrate database schema", Description: "internal/auth/schema.go"},
+				{Order: 2, Title: "feat(billing): expose payment endpoint", Description: "internal/billing/handler.go"},
+			},
+		}, nil
+	}
+
+	task := &Task{
+		ID:    "GH-2883",
+		Title: "[epic] recover then execute open children",
+		Labels: []string{"epic"},
+	}
+
+	result, err := r.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("expected success result, got %+v", result)
+	}
+
+	// Only the open child (GH-202) should have been executed.
+	if len(executedIDs) != 1 {
+		t.Fatalf("expected 1 ExecuteSubIssues call, got %d: %v", len(executedIDs), executedIDs)
+	}
+	if executedIDs[0] != "GH-202" {
+		t.Errorf("expected GH-202 to be executed, got %q", executedIDs[0])
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -404,6 +405,11 @@ type Runner struct {
 	// openSubIssueCheck detects whether recent sub-issues for a parent already exist.
 	// Injectable for testing; defaults to queryRecentSubIssues (gh CLI).
 	openSubIssueCheck func(ctx context.Context, dir, parentID string) (bool, error)
+	// recoverSubIssuesFn lists existing sub-issues for a parent and returns them as CreatedIssue.
+	// Injectable for testing; defaults to recoverExistingSubIssues (gh CLI) (GH-2883).
+	recoverSubIssuesFn func(ctx context.Context, dir, parentID string) ([]CreatedIssue, error)
+	// planEpicFn overrides PlanEpic for testing so tests don't need a real Claude binary.
+	planEpicFn func(ctx context.Context, task *Task, executionPath string) (*EpicPlan, error)
 	// GH-2855: Prometheus counters for tokens, cost, and executions.
 	metricsRecorder MetricsRecorder
 }
@@ -1284,7 +1290,11 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		)
 		r.reportProgress(task.ID, "Planning", 10, "Running epic planning...")
 
-		plan, err := r.PlanEpic(ctx, task, executionPath)
+		planFn := r.planEpicFn
+		if planFn == nil {
+			planFn = r.PlanEpic
+		}
+		plan, err := planFn(ctx, task, executionPath)
 		if err != nil {
 			// GH-1687: Planning failure is non-fatal — fall through to direct execution
 			r.log.Warn("Epic planning failed, falling back to direct execution",
@@ -1321,14 +1331,58 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 
 			issues, err := r.CreateSubIssues(ctx, plan, executionPath)
 			if err != nil {
-				return &ExecutionResult{
-					TaskID:   task.ID,
-					Success:  false,
-					Error:    fmt.Sprintf("failed to create sub-issues: %v", err),
-					Duration: time.Since(start),
-					IsEpic:   true,
-					EpicPlan: plan,
-				}, nil
+				if errors.Is(err, ErrSubIssuesAlreadyExist) {
+					// GH-2883: sub-issues were already created — recover them instead of failing.
+					r.log.Info("Sub-issues already exist, recovering open children",
+						slog.String("task_id", task.ID),
+					)
+					recoverer := r.recoverSubIssuesFn
+					if recoverer == nil {
+						recoverer = recoverExistingSubIssues
+					}
+					recovered, recoverErr := recoverer(ctx, executionPath, task.ID)
+					if recoverErr != nil {
+						return &ExecutionResult{
+							TaskID:   task.ID,
+							Success:  false,
+							Error:    fmt.Sprintf("failed to recover sub-issues: %v", recoverErr),
+							Duration: time.Since(start),
+							IsEpic:   true,
+							EpicPlan: plan,
+						}, nil
+					}
+					if allChildrenDone(recovered) {
+						r.log.Info("All sub-issues already closed, returning no-op success",
+							slog.String("task_id", task.ID),
+						)
+						return &ExecutionResult{
+							TaskID:    task.ID,
+							Success:   true,
+							Output:    fmt.Sprintf("Epic already completed: all %d sub-issues are closed", len(recovered)),
+							Duration:  time.Since(start),
+							IsEpic:    true,
+							EpicPlan:  plan,
+							ModelName: r.fallbackModelName(),
+						}, nil
+					}
+					// Filter to open children only, then fall through to ExecuteSubIssues.
+					var openIssues []CreatedIssue
+					for _, iss := range recovered {
+						if iss.State != "closed" {
+							openIssues = append(openIssues, iss)
+						}
+					}
+					issues = openIssues
+				} else {
+					return &ExecutionResult{
+						TaskID:   task.ID,
+						Success:  false,
+						Error:    fmt.Sprintf("failed to create sub-issues: %v", err),
+						Duration: time.Since(start),
+						IsEpic:   true,
+						EpicPlan: plan,
+					}, nil
+				}
 			}
 
 			r.reportProgress(task.ID, "Executing", 50, fmt.Sprintf("Executing %d sub-issues sequentially...", len(issues)))


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2883.

Closes #2883

## Changes

GitHub Issue #2883: fix(executor): fix(executor): treat ErrSubIssuesAlreadyExist as recovery, not failure

<!--autopilot-meta
parent: GH-2882
inherited-spec: true
-->

Parent: GH-2882

In `internal/executor/epic.go`, add a `recoverExistingSubIssues` helper that lists children matching `"Parent: <id>" in:body` via `gh issue list` and reconstructs `[]CreatedIssue` (adding a `State string` field to `CreatedIssue` so `allChildrenDone` can inspect it). In `internal/executor/runner.go:1293-1303`, branch on `errors.Is(err, ErrSubIssuesAlreadyExist)`: log the recovery, call the new helper, return a no-op success `ExecutionResult` when `allChildrenDone(issues)` is true, otherwise fall through to `ExecuteSubIssues` with the recovered open children. Add an `allChildrenDone` helper alongside it. Add two regression tests in `internal/executor/runner_test.go` (or `epic_test.go`): `TestRunner_Execute_EpicRecoversExistingSubIssues` (all children closed → success no-op, `ExecuteSubIssues` NOT called) and `TestRunner_Execute_EpicRecoversThenExecutesOpenChildren` (open children → `ExecuteSubIssues` IS called with recovered list). Inject the recovery path via a test seam (e.g., a `recoverSubIssuesFn` field on `Runner`) so the tests don't shell out to `gh`. Verify with `make test`, `make lint`, and the two `go test -run` invocations from the task description.