### PR TITLE
GH-2931: fix(executor): migrate SubtaskParser to claude subprocess

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -520,15 +520,16 @@ func NewRunnerWithConfig(config *BackendConfig) (*Runner, error) {
 		}
 	}
 
-	// Initialize Haiku subtask parser; nil if ANTHROPIC_API_KEY unset (GH-501)
-	runner.subtaskParser = NewSubtaskParser(runner.log)
-	if runner.subtaskParser != nil && config != nil {
-		if config.DefaultModel != "" {
-			runner.subtaskParser.model = config.DefaultModel
+	// Initialize subprocess-based subtask parser; nil if claude binary missing (GH-2931)
+	{
+		claudeCmd := ""
+		if config != nil && config.ClaudeCode != nil {
+			claudeCmd = config.ClaudeCode.Command
 		}
-		if config.APIBaseURL != "" {
-			runner.subtaskParser.baseURL = config.ResolveAPIBaseURL()
+		if claudeCmd == "" {
+			claudeCmd = "claude"
 		}
+		runner.subtaskParser = NewSubtaskParser(claudeCmd, runner.log)
 	}
 
 	// Initialize intent judge for diff-vs-ticket alignment (GH-624, GH-2817)

--- a/internal/executor/subtask_cc_validation_test.go
+++ b/internal/executor/subtask_cc_validation_test.go
@@ -2,9 +2,7 @@ package executor
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -61,23 +59,13 @@ func TestValidateAndFixSubtaskTitles_PlaceholderFallback(t *testing.T) {
 }
 
 // TestValidateAndFixSubtaskTitles_RepromptSucceeds verifies that a SubtaskParser
-// re-prompt can fix non-conventional titles via the LLM before Approach B is needed.
+// re-prompt can fix non-conventional titles via the subprocess before Approach B is needed.
 func TestValidateAndFixSubtaskTitles_RepromptSucceeds(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := map[string]interface{}{
-			"content": []map[string]interface{}{
-				{
-					"type": "text",
-					"text": `{"subtasks": [{"order": 1, "title": "feat(auth): add OAuth integration"}, {"order": 2, "title": "fix(api): handle nil response"}]}`,
-				},
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte(`{"subtasks": [{"order": 1, "title": "feat(auth): add OAuth integration"}, {"order": 2, "title": "fix(api): handle nil response"}]}`), nil
+	}
 
-	parser := newSubtaskParserWithURL("test-api-key", server.URL, nil)
+	parser := newSubtaskParserWithRunner(runner, nil)
 
 	subtasks := []PlannedSubtask{
 		{Order: 1, Title: "Add OAuth integration"},  // not conventional
@@ -95,22 +83,21 @@ func TestValidateAndFixSubtaskTitles_RepromptSucceeds(t *testing.T) {
 			t.Errorf("subtask %d title %q: expected conventional-commit format after re-prompt", i+1, st.Title)
 		}
 	}
-	// Verify these are the API-returned titles, not Approach B fallbacks
+	// Verify these are the subprocess-returned titles, not Approach B fallbacks
 	if result[0].Title != "feat(auth): add OAuth integration" {
 		t.Errorf("subtask 1 title = %q; want re-prompt result", result[0].Title)
 	}
 }
 
 // TestValidateAndFixSubtaskTitles_ParentInheritanceFallback verifies Approach B:
-// when the LLM re-prompt fails (server 500), the parent's type/scope is inherited
+// when the subprocess re-prompt fails, the parent's type/scope is inherited
 // and the resulting title is valid conventional-commit format.
 func TestValidateAndFixSubtaskTitles_ParentInheritanceFallback(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("subprocess error")
+	}
 
-	parser := newSubtaskParserWithURL("test-api-key", server.URL, nil)
+	parser := newSubtaskParserWithRunner(runner, nil)
 
 	subtasks := []PlannedSubtask{
 		{Order: 1, Title: "GH-100: Subtask 1"}, // placeholder
@@ -281,23 +268,13 @@ func TestApplyParentTypeScopeFallback(t *testing.T) {
 }
 
 // TestReformatTitles_SubtaskParser verifies that ReformatTitles correctly parses
-// the LLM response and updates titles by order.
+// the subprocess response and updates titles by order.
 func TestReformatTitles_SubtaskParser(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := map[string]interface{}{
-			"content": []map[string]interface{}{
-				{
-					"type": "text",
-					"text": `{"subtasks": [{"order": 1, "title": "feat(db): add migration"}, {"order": 2, "title": "chore(api): wire endpoint"}]}`,
-				},
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte(`{"subtasks": [{"order": 1, "title": "feat(db): add migration"}, {"order": 2, "title": "chore(api): wire endpoint"}]}`), nil
+	}
 
-	parser := newSubtaskParserWithURL("test-api-key", server.URL, nil)
+	parser := newSubtaskParserWithRunner(runner, nil)
 
 	subtasks := []PlannedSubtask{
 		{Order: 1, Title: "Add migration", Description: "Create user table"},

--- a/internal/executor/subtask_parser.go
+++ b/internal/executor/subtask_parser.go
@@ -1,57 +1,66 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"net/http"
-	"os"
+	"os/exec"
 	"strings"
 	"time"
 )
 
-// SubtaskParser extracts subtasks from planning output using the Anthropic Haiku API.
+const subtaskParseSystemPrompt = `Extract subtasks from this planning output as JSON. Return ONLY a JSON object with a "subtasks" array. Each subtask must have: "order" (integer), "title" (string), "description" (string).
+
+Example response:
+{"subtasks": [{"order": 1, "title": "Set up database", "description": "Create tables and migrations"}, {"order": 2, "title": "Add API endpoints", "description": "REST endpoints for CRUD operations"}]}`
+
+const subtaskReformatSystemPrompt = `Reformat subtask titles to conventional-commits format. Use the parent task title as context for type and scope. Return ONLY a JSON object with a "subtasks" array. Each subtask must have "order" (integer) and "title" (string) in conventional-commits format (type(scope): description).`
+
+// SubtaskParser extracts subtasks from planning output using the claude subprocess.
 // Part of the epic planning pipeline: PlanEpic → parseSubtasksWithFallback → SubtaskParser.
-// When the API is unavailable or fails, parseSubtasksWithFallback falls back to
+// When the binary is unavailable or fails, parseSubtasksWithFallback falls back to
 // regex-based parseSubtasks() in epic.go.
 type SubtaskParser struct {
-	apiKey     string
-	baseURL    string // Base URL for API (default: https://api.anthropic.com)
-	httpClient *http.Client
-	model      string
-	log        *slog.Logger
+	claudeCmd string
+	model     string
+	timeout   time.Duration
+	log       *slog.Logger
+	cmdRunner func(ctx context.Context, args ...string) ([]byte, error)
 }
 
-// NewSubtaskParser creates a SubtaskParser using the ANTHROPIC_API_KEY env var.
-// Returns nil if the API key is not set (caller should use regex fallback).
-func NewSubtaskParser(log *slog.Logger) *SubtaskParser {
-	apiKey := os.Getenv("ANTHROPIC_API_KEY")
-	if apiKey == "" {
+// NewSubtaskParser creates a SubtaskParser using the claude subprocess.
+// Returns nil if the claude binary is not found on PATH (caller should use regex fallback).
+func NewSubtaskParser(claudeCmd string, log *slog.Logger) *SubtaskParser {
+	if claudeCmd == "" {
+		claudeCmd = "claude"
+	}
+	if _, err := exec.LookPath(claudeCmd); err != nil {
 		return nil
 	}
-	return &SubtaskParser{
-		apiKey:  apiKey,
-		baseURL: "https://api.anthropic.com",
-		httpClient: &http.Client{
-			Timeout: 10 * time.Second,
-		},
-		model: "claude-haiku-4-5-20251001",
-		log:   log,
+	p := &SubtaskParser{
+		claudeCmd: claudeCmd,
+		model:     "claude-haiku-4-5-20251001",
+		timeout:   30 * time.Second,
+		log:       log,
 	}
+	p.cmdRunner = p.defaultCmdRunner
+	return p
 }
 
-// newSubtaskParserWithURL creates a SubtaskParser with a custom base URL (for testing).
-func newSubtaskParserWithURL(apiKey, baseURL string, log *slog.Logger) *SubtaskParser {
+func (p *SubtaskParser) defaultCmdRunner(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, p.claudeCmd, args...)
+	return cmd.Output()
+}
+
+// newSubtaskParserWithRunner creates a SubtaskParser with a custom command runner for testing.
+func newSubtaskParserWithRunner(runner func(ctx context.Context, args ...string) ([]byte, error), log *slog.Logger) *SubtaskParser {
 	return &SubtaskParser{
-		apiKey:  apiKey,
-		baseURL: baseURL,
-		httpClient: &http.Client{
-			Timeout: 10 * time.Second,
-		},
-		model: "claude-haiku-4-5-20251001",
-		log:   log,
+		claudeCmd: "claude",
+		model:     "claude-haiku-4-5-20251001",
+		timeout:   30 * time.Second,
+		log:       log,
+		cmdRunner: runner,
 	}
 }
 
@@ -62,85 +71,48 @@ type subtaskJSON struct {
 	Description string `json:"description"`
 }
 
-// subtasksResponse wraps the array of subtasks in the API response.
+// subtasksResponse wraps the array of subtasks in the response.
 type subtasksResponse struct {
 	Subtasks []subtaskJSON `json:"subtasks"`
 }
 
-// Parse sends the planning output to Haiku for structured extraction.
-// Returns the extracted subtasks or an error if the API call fails.
+// stripCodeFence removes markdown code fence wrappers from LLM text output.
+func stripCodeFence(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "```json")
+	s = strings.TrimPrefix(s, "```")
+	s = strings.TrimSuffix(s, "```")
+	return strings.TrimSpace(s)
+}
+
+// Parse sends the planning output to the claude subprocess for structured extraction.
+// Returns the extracted subtasks or an error if the subprocess fails or output is unparseable.
 func (p *SubtaskParser) Parse(ctx context.Context, output string) ([]PlannedSubtask, error) {
 	if p == nil {
 		return nil, fmt.Errorf("subtask parser is nil")
 	}
 
-	systemPrompt := `Extract subtasks from this planning output as JSON. Return ONLY a JSON object with a "subtasks" array. Each subtask must have: "order" (integer), "title" (string), "description" (string).
+	prompt := fmt.Sprintf("%s\n\n---\n\n%s", subtaskParseSystemPrompt, output)
 
-Example response:
-{"subtasks": [{"order": 1, "title": "Set up database", "description": "Create tables and migrations"}, {"order": 2, "title": "Add API endpoints", "description": "REST endpoints for CRUD operations"}]}`
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
 
-	requestBody := map[string]interface{}{
-		"model":      p.model,
-		"max_tokens": 4096,
-		"system":     systemPrompt,
-		"messages": []map[string]string{
-			{
-				"role":    "user",
-				"content": output,
-			},
-		},
-	}
-
-	jsonBody, err := json.Marshal(requestBody)
+	raw, err := p.cmdRunner(ctx, "--print", "-p", prompt, "--model", p.model, "--output-format", "text")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, fmt.Errorf("claude subprocess failed: %w", err)
 	}
 
-	url := p.baseURL + "/v1/messages"
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
+	text := stripCodeFence(string(raw))
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", p.apiKey)
-	req.Header.Set("anthropic-version", "2023-06-01")
-
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("API request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
-	}
-
-	// Parse the Anthropic API response envelope
-	var apiResp struct {
-		Content []struct {
-			Text string `json:"text"`
-		} `json:"content"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	if len(apiResp.Content) == 0 {
-		return nil, fmt.Errorf("empty response from API")
-	}
-
-	// Parse the JSON subtasks from the response text
 	var parsed subtasksResponse
-	if err := json.Unmarshal([]byte(apiResp.Content[0].Text), &parsed); err != nil {
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
 		return nil, fmt.Errorf("failed to parse subtasks JSON: %w", err)
 	}
 
 	if len(parsed.Subtasks) == 0 {
-		return nil, fmt.Errorf("no subtasks in API response")
+		return nil, fmt.Errorf("no subtasks in response")
 	}
 
-	// Convert to PlannedSubtask slice
 	result := make([]PlannedSubtask, len(parsed.Subtasks))
 	for i, s := range parsed.Subtasks {
 		result[i] = PlannedSubtask{
@@ -153,10 +125,10 @@ Example response:
 	return result, nil
 }
 
-// ReformatTitles sends a batch of subtask titles to the LLM and asks it to rewrite
+// ReformatTitles sends a batch of subtask titles to the claude subprocess and asks it to rewrite
 // them in conventional-commits format. parentTitle provides type/scope context.
 // Only the titles are updated; Order and Description are preserved from the input.
-// Returns an error when the parser is nil, the API call fails, or the response is empty.
+// Returns an error when the parser is nil, the subprocess fails, or the response is empty.
 func (p *SubtaskParser) ReformatTitles(ctx context.Context, parentTitle string, subtasks []PlannedSubtask) ([]PlannedSubtask, error) {
 	if p == nil {
 		return nil, fmt.Errorf("subtask parser is nil")
@@ -173,53 +145,17 @@ func (p *SubtaskParser) ReformatTitles(ctx context.Context, parentTitle string, 
 		parentTitle, sb.String(),
 	)
 
-	systemPrompt := `Reformat subtask titles to conventional-commits format. Use the parent task title as context for type and scope. Return ONLY a JSON object with a "subtasks" array. Each subtask must have "order" (integer) and "title" (string) in conventional-commits format (type(scope): description).`
+	prompt := fmt.Sprintf("%s\n\n---\n\n%s", subtaskReformatSystemPrompt, userMsg)
 
-	requestBody := map[string]interface{}{
-		"model":      p.model,
-		"max_tokens": 1024,
-		"system":     systemPrompt,
-		"messages": []map[string]string{
-			{"role": "user", "content": userMsg},
-		},
-	}
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
 
-	jsonBody, err := json.Marshal(requestBody)
+	raw, err := p.cmdRunner(ctx, "--print", "-p", prompt, "--model", p.model, "--output-format", "text")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, fmt.Errorf("claude subprocess failed: %w", err)
 	}
 
-	url := p.baseURL + "/v1/messages"
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", p.apiKey)
-	req.Header.Set("anthropic-version", "2023-06-01")
-
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("API request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
-	}
-
-	var apiResp struct {
-		Content []struct {
-			Text string `json:"text"`
-		} `json:"content"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
-	}
-	if len(apiResp.Content) == 0 {
-		return nil, fmt.Errorf("empty response from API")
-	}
+	text := stripCodeFence(string(raw))
 
 	var parsed struct {
 		Subtasks []struct {
@@ -227,7 +163,7 @@ func (p *SubtaskParser) ReformatTitles(ctx context.Context, parentTitle string, 
 			Title string `json:"title"`
 		} `json:"subtasks"`
 	}
-	if err := json.Unmarshal([]byte(apiResp.Content[0].Text), &parsed); err != nil {
+	if err := json.Unmarshal([]byte(text), &parsed); err != nil {
 		return nil, fmt.Errorf("failed to parse reformatted titles JSON: %w", err)
 	}
 	if len(parsed.Subtasks) == 0 {
@@ -251,19 +187,19 @@ func (p *SubtaskParser) ReformatTitles(ctx context.Context, parentTitle string, 
 }
 
 // parseSubtasksWithFallback is the primary entry point for subtask extraction.
-// Tries Haiku structured extraction first (SubtaskParser.Parse), then falls back
-// to regex-based parseSubtasks() in epic.go if the API is unavailable or fails.
+// Tries claude subprocess structured extraction first (SubtaskParser.Parse), then falls back
+// to regex-based parseSubtasks() in epic.go if the subprocess is unavailable or fails.
 func parseSubtasksWithFallback(parser *SubtaskParser, output string) []PlannedSubtask {
 	if parser != nil {
 		subtasks, err := parser.Parse(context.Background(), output)
 		if err == nil && len(subtasks) > 0 {
 			if parser.log != nil {
-				parser.log.Debug("Subtasks extracted via Haiku API", "count", len(subtasks))
+				parser.log.Debug("Subtasks extracted via claude subprocess", "count", len(subtasks))
 			}
 			return subtasks
 		}
 		if parser.log != nil {
-			parser.log.Warn("Haiku subtask extraction failed, falling back to regex", "error", err)
+			parser.log.Warn("claude subtask extraction failed, falling back to regex", "error", err)
 		}
 	}
 

--- a/internal/executor/subtask_parser_test.go
+++ b/internal/executor/subtask_parser_test.go
@@ -2,12 +2,11 @@ package executor
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 	"log/slog"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 )
 
 // samplePlanningOutput is realistic Claude --print output used across tests.
@@ -19,37 +18,12 @@ const samplePlanningOutput = `Based on the codebase analysis, here is the implem
 **4. Add frontend settings page** - React component with form controls bound to the API`
 
 func TestSubtaskParserParse_HappyPath(t *testing.T) {
-	// Mock Haiku endpoint returns structured JSON
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/messages" {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		if r.Header.Get("x-api-key") != "test-api-key" {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		if r.Header.Get("anthropic-version") != "2023-06-01" {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-
-		// Return structured subtasks via Anthropic API response format
-		resp := map[string]interface{}{
-			"content": []map[string]interface{}{
-				{
-					"type": "text",
-					"text": `{"subtasks": [{"order": 1, "title": "Add database migration", "description": "Create new table for user preferences"}, {"order": 2, "title": "Implement repository layer", "description": "Add CRUD methods for user preferences"}, {"order": 3, "title": "Create API endpoints", "description": "REST endpoints for reading and updating"}, {"order": 4, "title": "Add frontend settings page", "description": "React component with form controls"}]}`,
-				},
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte(`{"subtasks": [{"order": 1, "title": "Add database migration", "description": "Create new table for user preferences"}, {"order": 2, "title": "Implement repository layer", "description": "Add CRUD methods for user preferences"}, {"order": 3, "title": "Create API endpoints", "description": "REST endpoints for reading and updating"}, {"order": 4, "title": "Add frontend settings page", "description": "React component with form controls"}]}`), nil
+	}
 
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	parser := newSubtaskParserWithURL("test-api-key", server.URL, log)
+	parser := newSubtaskParserWithRunner(runner, log)
 
 	subtasks, err := parser.Parse(context.Background(), samplePlanningOutput)
 	if err != nil {
@@ -60,7 +34,6 @@ func TestSubtaskParserParse_HappyPath(t *testing.T) {
 		t.Fatalf("expected 4 subtasks, got %d", len(subtasks))
 	}
 
-	// Verify structured extraction
 	expected := []struct {
 		order int
 		title string
@@ -84,65 +57,41 @@ func TestSubtaskParserParse_HappyPath(t *testing.T) {
 	}
 }
 
-func TestSubtaskParserParse_APIError(t *testing.T) {
-	// Mock Haiku endpoint returns 500
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
+func TestSubtaskParserParse_SubprocessError(t *testing.T) {
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("subprocess exited with code 1")
+	}
 
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	parser := newSubtaskParserWithURL("test-api-key", server.URL, log)
+	parser := newSubtaskParserWithRunner(runner, log)
 
 	_, err := parser.Parse(context.Background(), samplePlanningOutput)
 	if err == nil {
-		t.Fatal("expected error from 500 response, got nil")
+		t.Fatal("expected error from subprocess failure, got nil")
 	}
 }
 
-func TestSubtaskParserParse_InvalidJSON(t *testing.T) {
-	// Mock returns 200 but with non-JSON text content
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := map[string]interface{}{
-			"content": []map[string]interface{}{
-				{
-					"type": "text",
-					"text": "This is not JSON at all",
-				},
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
+func TestSubtaskParserParse_MalformedJSON(t *testing.T) {
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("This is not JSON at all"), nil
+	}
 
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	parser := newSubtaskParserWithURL("test-api-key", server.URL, log)
+	parser := newSubtaskParserWithRunner(runner, log)
 
 	_, err := parser.Parse(context.Background(), samplePlanningOutput)
 	if err == nil {
-		t.Fatal("expected error from invalid JSON response, got nil")
+		t.Fatal("expected error from malformed JSON response, got nil")
 	}
 }
 
 func TestSubtaskParserParse_EmptySubtasks(t *testing.T) {
-	// Mock returns valid JSON but empty subtasks array
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := map[string]interface{}{
-			"content": []map[string]interface{}{
-				{
-					"type": "text",
-					"text": `{"subtasks": []}`,
-				},
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte(`{"subtasks": []}`), nil
+	}
 
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	parser := newSubtaskParserWithURL("test-api-key", server.URL, log)
+	parser := newSubtaskParserWithRunner(runner, log)
 
 	_, err := parser.Parse(context.Background(), samplePlanningOutput)
 	if err == nil {
@@ -158,49 +107,90 @@ func TestSubtaskParserParse_NilParser(t *testing.T) {
 	}
 }
 
-func TestParseSubtasksWithFallback_HaikuSucceeds(t *testing.T) {
-	// When Haiku API succeeds, its structured results are used
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := map[string]interface{}{
-			"content": []map[string]interface{}{
-				{
-					"type": "text",
-					"text": `{"subtasks": [{"order": 1, "title": "API-extracted task one", "description": "From Haiku"}, {"order": 2, "title": "API-extracted task two", "description": "From Haiku"}]}`,
-				},
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
+func TestSubtaskParserParse_CodeFenceStripping(t *testing.T) {
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		// Simulate claude wrapping JSON in a code fence
+		return []byte("```json\n{\"subtasks\": [{\"order\": 1, \"title\": \"feat(db): add migration\", \"description\": \"Create schema\"}]}\n```"), nil
+	}
 
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	parser := newSubtaskParserWithURL("test-api-key", server.URL, log)
+	parser := newSubtaskParserWithRunner(runner, log)
+
+	subtasks, err := parser.Parse(context.Background(), samplePlanningOutput)
+	if err != nil {
+		t.Fatalf("expected code fence to be stripped, got error: %v", err)
+	}
+	if len(subtasks) != 1 {
+		t.Fatalf("expected 1 subtask, got %d", len(subtasks))
+	}
+	if subtasks[0].Title != "feat(db): add migration" {
+		t.Errorf("subtask title = %q, want %q", subtasks[0].Title, "feat(db): add migration")
+	}
+}
+
+func TestSubtaskParserParse_Timeout(t *testing.T) {
+	runner := func(ctx context.Context, args ...string) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	parser := newSubtaskParserWithRunner(runner, log)
+	parser.timeout = 5 * time.Millisecond // very short timeout to trigger quickly
+
+	_, err := parser.Parse(context.Background(), samplePlanningOutput)
+	if err == nil {
+		t.Fatal("expected error from timeout, got nil")
+	}
+}
+
+func TestSubtaskParserParse_ContextCancelled(t *testing.T) {
+	runner := func(ctx context.Context, args ...string) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	parser := newSubtaskParserWithRunner(runner, log)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := parser.Parse(ctx, samplePlanningOutput)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+}
+
+func TestParseSubtasksWithFallback_SubprocessSucceeds(t *testing.T) {
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte(`{"subtasks": [{"order": 1, "title": "API-extracted task one", "description": "From subprocess"}, {"order": 2, "title": "API-extracted task two", "description": "From subprocess"}]}`), nil
+	}
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	parser := newSubtaskParserWithRunner(runner, log)
 
 	subtasks := parseSubtasksWithFallback(parser, samplePlanningOutput)
 
 	if len(subtasks) != 2 {
-		t.Fatalf("expected 2 subtasks from Haiku, got %d", len(subtasks))
+		t.Fatalf("expected 2 subtasks from subprocess, got %d", len(subtasks))
 	}
 
-	// Verify these are from the API (unique titles), not regex
 	if subtasks[0].Title != "API-extracted task one" {
-		t.Errorf("subtask 0 title = %q, want %q (should be from API, not regex)", subtasks[0].Title, "API-extracted task one")
+		t.Errorf("subtask 0 title = %q, want %q (should be from subprocess, not regex)", subtasks[0].Title, "API-extracted task one")
 	}
 	if subtasks[1].Title != "API-extracted task two" {
-		t.Errorf("subtask 1 title = %q, want %q (should be from API, not regex)", subtasks[1].Title, "API-extracted task two")
+		t.Errorf("subtask 1 title = %q, want %q (should be from subprocess, not regex)", subtasks[1].Title, "API-extracted task two")
 	}
 }
 
-func TestParseSubtasksWithFallback_HaikuFails_FallsBackToRegex(t *testing.T) {
-	// When Haiku API returns 500, fallback to regex parsing
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
+func TestParseSubtasksWithFallback_SubprocessError_FallsBackToRegex(t *testing.T) {
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("subprocess error")
+	}
 
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	parser := newSubtaskParserWithURL("test-api-key", server.URL, log)
+	parser := newSubtaskParserWithRunner(runner, log)
 
 	subtasks := parseSubtasksWithFallback(parser, samplePlanningOutput)
 
@@ -209,7 +199,6 @@ func TestParseSubtasksWithFallback_HaikuFails_FallsBackToRegex(t *testing.T) {
 		t.Fatalf("expected 4 subtasks from regex fallback, got %d", len(subtasks))
 	}
 
-	// Verify these are from regex (titles parsed from the bold-wrapped output)
 	if subtasks[0].Title != "Add database migration" {
 		t.Errorf("subtask 0 title = %q, want %q (should be from regex fallback)", subtasks[0].Title, "Add database migration")
 	}
@@ -219,7 +208,6 @@ func TestParseSubtasksWithFallback_HaikuFails_FallsBackToRegex(t *testing.T) {
 }
 
 func TestParseSubtasksWithFallback_NilParser_FallsBackToRegex(t *testing.T) {
-	// When parser is nil (no API key), regex is used directly
 	subtasks := parseSubtasksWithFallback(nil, samplePlanningOutput)
 
 	if len(subtasks) != 4 {
@@ -231,24 +219,13 @@ func TestParseSubtasksWithFallback_NilParser_FallsBackToRegex(t *testing.T) {
 	}
 }
 
-func TestParseSubtasksWithFallback_HaikuReturnsInvalidJSON_FallsBackToRegex(t *testing.T) {
-	// When Haiku returns invalid JSON, fallback to regex
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := map[string]interface{}{
-			"content": []map[string]interface{}{
-				{
-					"type": "text",
-					"text": "not valid json",
-				},
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
+func TestParseSubtasksWithFallback_MalformedJSON_FallsBackToRegex(t *testing.T) {
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte("not valid json"), nil
+	}
 
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	parser := newSubtaskParserWithURL("test-api-key", server.URL, log)
+	parser := newSubtaskParserWithRunner(runner, log)
 
 	subtasks := parseSubtasksWithFallback(parser, samplePlanningOutput)
 
@@ -257,24 +234,13 @@ func TestParseSubtasksWithFallback_HaikuReturnsInvalidJSON_FallsBackToRegex(t *t
 	}
 }
 
-func TestParseSubtasksWithFallback_HaikuReturnsEmptySubtasks_FallsBackToRegex(t *testing.T) {
-	// When Haiku returns empty subtasks array, fallback to regex
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := map[string]interface{}{
-			"content": []map[string]interface{}{
-				{
-					"type": "text",
-					"text": `{"subtasks": []}`,
-				},
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
+func TestParseSubtasksWithFallback_EmptySubtasks_FallsBackToRegex(t *testing.T) {
+	runner := func(_ context.Context, args ...string) ([]byte, error) {
+		return []byte(`{"subtasks": []}`), nil
+	}
 
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	parser := newSubtaskParserWithURL("test-api-key", server.URL, log)
+	parser := newSubtaskParserWithRunner(runner, log)
 
 	subtasks := parseSubtasksWithFallback(parser, samplePlanningOutput)
 
@@ -283,39 +249,10 @@ func TestParseSubtasksWithFallback_HaikuReturnsEmptySubtasks_FallsBackToRegex(t 
 	}
 }
 
-func TestNewSubtaskParser_NoAPIKey(t *testing.T) {
-	// Temporarily unset the env var
-	original := os.Getenv("ANTHROPIC_API_KEY")
-	_ = os.Unsetenv("ANTHROPIC_API_KEY")
-	defer func() {
-		if original != "" {
-			_ = os.Setenv("ANTHROPIC_API_KEY", original)
-		}
-	}()
-
+func TestNewSubtaskParser_BinaryMissing(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	parser := NewSubtaskParser(log)
+	parser := NewSubtaskParser("this-binary-does-not-exist-on-path-xyz-abc", log)
 	if parser != nil {
-		t.Error("expected nil parser when ANTHROPIC_API_KEY is not set")
-	}
-}
-
-func TestSubtaskParserParse_ContextCancelled(t *testing.T) {
-	// Mock server that blocks (simulating slow response)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Wait for context cancellation
-		<-r.Context().Done()
-	}))
-	defer server.Close()
-
-	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	parser := newSubtaskParserWithURL("test-api-key", server.URL, log)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately
-
-	_, err := parser.Parse(ctx, samplePlanningOutput)
-	if err == nil {
-		t.Fatal("expected error from cancelled context, got nil")
+		t.Error("expected nil parser when binary is not found on PATH")
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2931.

Closes #2931

## Changes

GitHub Issue #2931: fix(executor): migrate SubtaskParser to claude subprocess

<!--autopilot-meta
parent: GH-2930
inherited-spec: true
-->

Parent: GH-2930

Refactor `internal/executor/subtask_parser.go` to replace the HTTP-based Anthropic API client with the `claude` subprocess pattern established by `EffortClassifier` (TASK-47). Replace `apiKey`/`baseURL`/`httpClient` fields with `claudeCmd`, `model`, `timeout`, `log`, and an injectable `cmdRunner func(ctx, args...) ([]byte, error)`. Both `Parse` and `ReformatTitles` invoke `cmdRunner(ctx, "--print", "-p", prompt, "--model", model, "--output-format", "text")`; move system prompts to package-level constants. `NewSubtaskParser(claudeCmd, log)` becomes the only public constructor and returns `nil` when the `claude` binary is missing on PATH (preserving the nil-fallback contract relied upon by `parseSubtasksWithFallback`). Update the single call site at `internal/executor/runner.go:526` to pass `cfg.ClaudeCode.Command`. Migrate every existing test in `subtask_parser_test.go` and `subtask_cc_validation_test.go` from `httptest.NewServer` + `newSubtaskParserWithURL` to a `newSubtaskParserWithRunner` mock pattern; delete `newSubtaskParserWithURL`. Add new cases for: malformed JSON, empty subtasks slice, subprocess error propagation, timeout handling, JSON codefence stripping, regex fallback when subprocess errors, and binary-missing nil return. Verify no remaining `os.Getenv("ANTHROPIC_API_KEY")` reads or HTTP fields exist in `subtask_parser.go`. Confirm `make test`, `make lint`, and `make build` all pass without `ANTHROPIC_API_KEY` set.