### PR TITLE
GH-2943: feat(autopilot): wire RecordIssueProcessed at terminal controller paths

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-05-08 (v2.53.0)
+**Last Updated:** 2026-05-06 (v2.53.0)
 
 ## Legend
 
@@ -295,6 +295,7 @@
 | OpenAI-compatible direct backend | ✅ | executor | `type: openai-api` | `executor.openai` | Direct /v1/chat/completions for OpenAI, OpenRouter, Groq, Synthetic, vLLM, Ollama (v2.105.0, GH-2382) |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |
+| Issue processed metrics | ✅ | autopilot | - | - | RecordIssueProcessed(success/failed/rate_limited) at terminal outcomes (GH-2943) |
 | JSON structured logging | ✅ | - | - | `logging.format` | Optional JSON log output mode (v0.38.0) |
 | Qwen Code backend | ✅ | executor | `--backend qwen` | `executor.backend` | Alibaba Qwen Code CLI with stream-json (v1.9.0, GH-1314) |
 | Docker support | ✅ | - | - | - | Dockerfile + deployment guide (v1.46.0) |
@@ -399,7 +400,6 @@
 | Decompose on retry | ✅ | executor | - | `retry.decompose_on_kill` | Retry via decomposition when task killed (signal:killed) (v2.10.0, GH-1729) |
 | Conventional sub-issue titles | ✅ | executor | - | - | CC-format enforced on subtask titles: re-prompt → Approach B fallback → creation guard (GH-2494) |
 | Sub-issue dedup guard | ✅ | executor | - | - | CreateSubIssues skips if open children referencing parent already exist (GH-2494) |
-| Epic sub-issue recovery | ✅ | executor | - | - | On ErrSubIssuesAlreadyExist: recover existing children; no-op if all closed, execute open ones (GH-2883) |
 | createPilotIssue chokepoint | ✅ | adapters/github, autopilot | - | - | All Pilot-internal issue creation validated through CreatePilotIssue CC gate (GH-2494) |
 
 ## Test Coverage

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -761,6 +761,11 @@ Examples:
 						pollerOpts = append(pollerOpts, github.WithExecutionChecker(gwStore, projectPath))
 					}
 
+					// Wire issue metrics recorder for rate-limit tracking.
+					if gwAutopilotController != nil {
+						pollerOpts = append(pollerOpts, github.WithIssueMetricsRecorder(gwAutopilotController.Metrics()))
+					}
+
 					// GH-2802: Wire pre-flight judge when enabled (GH-2817: uses CC subprocess, no API key)
 					if cfg.Executor != nil && cfg.Executor.PreFlightJudge != nil && cfg.Executor.PreFlightJudge.Enabled {
 						claudeCmd := ""
@@ -2102,6 +2107,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				// GH-2242: Wire execution checker to prevent re-dispatch of completed tasks
 				if store != nil {
 					pollerOpts = append(pollerOpts, github.WithExecutionChecker(store, projPath))
+				}
+
+				// Wire issue metrics recorder for rate-limit tracking.
+				if controller != nil {
+					pollerOpts = append(pollerOpts, github.WithIssueMetricsRecorder(controller.Metrics()))
 				}
 
 				// GH-2802: Wire pre-flight judge when enabled (GH-2817: uses CC subprocess, no API key)

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -73,6 +73,12 @@ type ExecutionSaver interface {
 	SaveDeclinedExecution(taskID, projectPath, status, reason string) error
 }
 
+// IssueMetricsRecorder records issue processing outcomes.
+// Implemented by *autopilot.Metrics; kept as an interface here to avoid circular imports.
+type IssueMetricsRecorder interface {
+	RecordIssueProcessed(result string)
+}
+
 // IssueResult is returned by the issue handler with PR information
 type IssueResult struct {
 	Success    bool
@@ -148,6 +154,9 @@ type Poller struct {
 	// nil means disabled (config flag executor.pre_flight_judge.enabled=false).
 	preFlightJudge PreFlightJudger
 	execSaver      ExecutionSaver
+
+	// metricsRecorder records issue processing outcomes (optional).
+	metricsRecorder IssueMetricsRecorder
 }
 
 // PollerOption configures a Poller
@@ -283,6 +292,14 @@ func WithPreFlightJudge(judge PreFlightJudger) PollerOption {
 func WithExecutionSaver(saver ExecutionSaver) PollerOption {
 	return func(p *Poller) {
 		p.execSaver = saver
+	}
+}
+
+// WithIssueMetricsRecorder sets the recorder for issue processing outcomes.
+// Pass nil to disable (same as not calling this option).
+func WithIssueMetricsRecorder(rec IssueMetricsRecorder) PollerOption {
+	return func(p *Poller) {
+		p.metricsRecorder = rec
 	}
 }
 
@@ -527,6 +544,9 @@ func (p *Poller) startSequential(ctx context.Context) {
 						slog.Time("retry_at", rlInfo.ResetTime.Add(5*time.Minute)),
 						slog.String("reset_time", rlInfo.ResetTimeFormatted()),
 					)
+					if p.metricsRecorder != nil {
+						p.metricsRecorder.RecordIssueProcessed("rate_limited")
+					}
 					// Don't mark as processed - will retry via scheduler
 					continue
 				}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -756,6 +756,7 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 			prState.Stage = StageFailed
 			prState.Error = fmt.Sprintf("CI fix iteration limit reached (%d/%d): stopping cascade to prevent infinite loop", iteration, c.config.MaxCIFixIterations)
 			c.metrics.RecordPRFailed()
+			c.metrics.RecordIssueProcessed("failed")
 			return nil
 		}
 	}
@@ -783,6 +784,7 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 				prState.Stage = StageFailed
 				prState.Error = fmt.Sprintf("CI fix size guard: PR has %d additions, over limit %d (likely cascade contamination — escalate to human)", netAdditions, c.config.MaxCIFixPRSize)
 				c.metrics.RecordPRFailed()
+				c.metrics.RecordIssueProcessed("failed")
 				return nil
 			}
 		}
@@ -881,6 +883,7 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 			prState.Stage = StageFailed
 			prState.Error = fmt.Sprintf("review feedback iteration limit reached (%d/%d)", iteration, c.config.ReviewFeedback.MaxIterations)
 			c.metrics.RecordPRFailed()
+			c.metrics.RecordIssueProcessed("failed")
 			return nil
 		}
 	}
@@ -1033,6 +1036,7 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 		)
 		c.autoMerger.postMisconfigComment(ctx, prState)
 		c.metrics.RecordPRFailed()
+		c.metrics.RecordIssueProcessed("failed")
 		return nil
 	}
 
@@ -1095,12 +1099,14 @@ func (c *Controller) applyApprovalDecision(prState *PRState) error {
 		prState.Stage = StageFailed
 		prState.Error = fmt.Sprintf("merge rejected: approval %s", prState.ApprovalDecision)
 		c.metrics.RecordPRFailed()
+		c.metrics.RecordIssueProcessed("failed")
 	default:
 		c.log.Warn("unknown approval decision — failing PR",
 			"pr", prState.PRNumber, "decision", prState.ApprovalDecision)
 		prState.Stage = StageFailed
 		prState.Error = fmt.Sprintf("unknown approval decision: %q", prState.ApprovalDecision)
 		c.metrics.RecordPRFailed()
+		c.metrics.RecordIssueProcessed("failed")
 	}
 	return nil
 }
@@ -1177,6 +1183,7 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 	c.log.Info("PR merged successfully", "pr", prState.PRNumber)
 	prState.Stage = StageMerged
 	c.metrics.RecordPRMerged()
+	c.metrics.RecordIssueProcessed("success")
 	c.metrics.RecordPRTimeToMerge(time.Since(prState.CreatedAt))
 
 	// GH-1015: Add pilot-done label after successful merge (not at PR creation)

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -5541,3 +5541,101 @@ func TestController_SetApprovalDecision_NoStoreNoPanic(t *testing.T) {
 		t.Errorf("in-memory decision not set: %q", pr.ApprovalDecision)
 	}
 }
+
+// TestController_IssuesProcessed_Success verifies that RecordIssueProcessed("success")
+// is called when a PR merges successfully.
+func TestController_IssuesProcessed_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/mergesha1/check-runs":
+			_, _ = w.Write(mustJSON(t, github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "build", Status: "completed", Conclusion: "success"}},
+			}))
+		case r.URL.Path == "/repos/owner/repo/pulls/42/merge" && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, map[string]interface{}{
+				"sha": "merged1", "merged": true, "message": "Pull Request successfully merged",
+			}))
+		case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == http.MethodGet:
+			_, _ = w.Write(mustJSON(t, github.PullRequest{
+				Number: 42, State: "open",
+				Head: github.PRRef{Ref: "pilot/GH-10", SHA: "mergesha1"},
+			}))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoReview = false
+	cfg.RequiredChecks = []string{"build"}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "mergesha1", "pilot/GH-10", "")
+	pr, _ := c.GetPRState(42)
+	pr.Stage = StageMerging
+
+	if err := c.ProcessPR(context.Background(), 42, nil); err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	snap := c.metrics.Snapshot()
+	if snap.IssuesProcessed["success"] != 1 {
+		t.Errorf("IssuesProcessed[success] = %d, want 1", snap.IssuesProcessed["success"])
+	}
+	if snap.IssuesProcessed["failed"] != 0 {
+		t.Errorf("IssuesProcessed[failed] = %d, want 0", snap.IssuesProcessed["failed"])
+	}
+}
+
+// TestController_IssuesProcessed_TerminalFailure verifies that RecordIssueProcessed("failed")
+// is called when a PR hits the CI fix iteration limit (terminal failure path).
+func TestController_IssuesProcessed_TerminalFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/failsha1/check-runs":
+			_, _ = w.Write(mustJSON(t, github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "build", Status: "completed", Conclusion: "failure"}},
+			}))
+		case r.URL.Path == "/repos/owner/repo/issues/20" && r.Method == http.MethodGet:
+			// iteration:3 >= MaxCIFixIterations(3) → terminal stop
+			_, _ = w.Write(mustJSON(t, github.Issue{
+				Number: 20,
+				Body:   "Fix CI failures.\n\n<!-- autopilot-meta branch:pilot/GH-20 pr:55 iteration:3 -->\n",
+			}))
+		case r.URL.Path == "/repos/owner/repo/pulls/55" && r.Method == http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.MaxCIFixIterations = 3
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.OnPRCreated(55, "https://github.com/owner/repo/pull/55", 20, "failsha1", "pilot/GH-20", "")
+	pr, _ := c.GetPRState(55)
+	pr.Stage = StageCIFailed
+
+	if err := c.ProcessPR(context.Background(), 55, nil); err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	snap := c.metrics.Snapshot()
+	if snap.IssuesProcessed["failed"] != 1 {
+		t.Errorf("IssuesProcessed[failed] = %d, want 1", snap.IssuesProcessed["failed"])
+	}
+	if snap.IssuesProcessed["success"] != 0 {
+		t.Errorf("IssuesProcessed[success] = %d, want 0", snap.IssuesProcessed["success"])
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2943.

Closes #2943

## Changes

In internal/autopilot/controller.go, add RecordIssueProcessed("success") next to the existing RecordPRMerged call at line 1179. Audit each RecordPRFailed site (lines 758, 785, 836, 883, 943, 1035, 1097, 1103) and add RecordIssueProcessed("failed") only at terminal failure points (auto-merge abandoned, max retries exhausted, unrecoverable conflict) — skip mid-flight failures that still have retry budget. Locate the 429/rate-limit park path and add RecordIssueProcessed("rate_limited") there. Extend internal/autopilot/controller_test.go with table-driven cases asserting metrics.IssuesProcessed["success"] == 1 on happy path and metrics.IssuesProcessed["failed"] == 1 on terminal failure. Verify make test ./internal/autopilot/... and make lint.