### PR TITLE
fix(executor): close GH-201 spurious-dispatch loop (state propagation + live fallback)

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -244,6 +244,11 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 		// GH-2290: honor project.default_branch / branch_from so branching and PR target
 		// follow the configured integration branch (e.g. `dev` in main → dev → feature).
 		BaseBranch: cfg.FindProjectByRepo(sourceRepo).ResolveBaseBranch(),
+		// Propagate parent state so isParentDone() can refuse sub-issue creation
+		// when the daemon re-dispatches a closed/merged parent. Without this, an
+		// empty State + empty Labels combo bypasses the gate at epic.go and
+		// permits spurious sub-issue spawning (GH-201 OAuth dispatch loop).
+		State: issue.State,
 	}
 
 	parts := strings.Split(sourceRepo, "/")

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 )
 
@@ -595,13 +596,85 @@ var ErrParentDone = errors.New("parent task is already done; refusing to create 
 
 // isParentDone reports whether a task should be treated as done based on its
 // labels (pilot-done, pilot-skip) or its state (closed, merged).
+//
+// Defensive fallback: when both State and Labels are empty AND the task ID
+// looks like a GitHub issue ("GH-N"), this function shells out to `gh issue
+// view` to fetch the live state. This catches stale dispatcher rows and
+// upstream constructors that drop those fields — the GH-201 spurious
+// dispatch loop on 2026-05-08 spawned 70+ OAuth sub-issues this way.
+// Non-fatal on lookup error: returns the original (empty-fields → false)
+// decision so this never blocks legitimate dispatches.
+//
+// Tests can override this var to assert the fallback path or to keep the
+// production default no-op when constructing tasks with deterministic GH-* IDs.
+var isParentDoneLiveFallback = func(taskID, dir string) bool {
+	// Never shell out during `go test` — tests override this var explicitly
+	// when they want to exercise the fallback path.
+	if testing.Testing() {
+		return false
+	}
+	return queryParentDoneViaGitHub(taskID, dir)
+}
+
 func isParentDone(t *Task) bool {
+	if t == nil {
+		return false
+	}
 	for _, label := range t.Labels {
 		if label == "pilot-done" || label == "pilot-skip" {
 			return true
 		}
 	}
-	return t.State == "closed" || t.State == "merged"
+	if t.State == "closed" || t.State == "merged" {
+		return true
+	}
+	if t.State == "" && len(t.Labels) == 0 && strings.HasPrefix(t.ID, "GH-") {
+		if isParentDoneLiveFallback(t.ID, t.ProjectPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// queryParentDoneViaGitHub returns true when the GitHub issue identified by
+// taskID ("GH-N") is closed/merged or carries pilot-done / pilot-skip labels.
+// Non-fatal: any subprocess or parse error returns false so the caller falls
+// back to the default decision.
+func queryParentDoneViaGitHub(taskID, dir string) bool {
+	issueNum := strings.TrimPrefix(taskID, "GH-")
+	if issueNum == "" || issueNum == taskID {
+		return false
+	}
+	args := []string{"issue", "view", issueNum, "--json", "state,labels"}
+	cmd := exec.Command("gh", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	var resp struct {
+		State  string `json:"state"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		return false
+	}
+	state := strings.ToLower(strings.TrimSpace(resp.State))
+	if state == "closed" || state == "merged" {
+		return true
+	}
+	for _, l := range resp.Labels {
+		switch strings.ToLower(strings.TrimSpace(l.Name)) {
+		case "pilot-done", "pilot-skip":
+			return true
+		}
+	}
+	return false
 }
 
 // isConventionalSubtaskTitle reports whether title is in conventional-commits format.

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -254,7 +254,7 @@ func TestBuildPlanningPrompt(t *testing.T) {
 		"Implement user authentication",
 		"Add login, logout, and session management",
 		"Output Format",
-		"Single-Package Splits",       // GH-1265: anti-cascade instruction
+		"Single-Package Splits",         // GH-1265: anti-cascade instruction
 		"NEVER split work that belongs", // GH-1265: footer reminder
 	}
 
@@ -1446,9 +1446,9 @@ func TestCreatedIssue_IdentifierField(t *testing.T) {
 
 // mockSubIssueLinker records LinkSubIssue calls for test assertions.
 type mockSubIssueLinker struct {
-	mu     sync.Mutex
-	Calls  []mockLinkSubIssueCall
-	ErrFn  func(owner, repo string, parentNum, childNum int) error // optional error injection
+	mu    sync.Mutex
+	Calls []mockLinkSubIssueCall
+	ErrFn func(owner, repo string, parentNum, childNum int) error // optional error injection
 }
 
 type mockLinkSubIssueCall struct {
@@ -1974,9 +1974,9 @@ func TestCreateSubIssuesViaAdapter_InjectsAutopilotMetaMarker(t *testing.T) {
 
 func TestFilterPropagatableLabels(t *testing.T) {
 	tests := []struct {
-		name   string
-		input  []string
-		want   []string
+		name  string
+		input []string
+		want  []string
 	}{
 		{
 			name:  "empty input",
@@ -2212,6 +2212,84 @@ func TestCreateSubIssues_RefusesRecentlyClosedSiblings(t *testing.T) {
 	_, err := r.CreateSubIssues(context.Background(), plan, "")
 	if err != ErrSubIssuesAlreadyExist {
 		t.Errorf("expected ErrSubIssuesAlreadyExist, got %v", err)
+	}
+}
+
+// TestIsParentDone_LiveFallback exercises the GH-201 defensive path: when
+// State and Labels are both empty but the task ID looks like a GitHub issue,
+// isParentDone consults a live lookup. Without this fallback, stale dispatcher
+// rows that drop State/Labels bypass the gate and spawn spurious sub-issues
+// (the 2026-05-08 GH-201 OAuth incident, 70+ dupes).
+func TestIsParentDone_LiveFallback(t *testing.T) {
+	cases := []struct {
+		name           string
+		task           *Task
+		fallbackResult bool
+		fallbackCalled bool
+		want           bool
+	}{
+		{
+			name:           "empty fields + GH- id + live says done",
+			task:           &Task{ID: "GH-201"},
+			fallbackResult: true,
+			fallbackCalled: true,
+			want:           true,
+		},
+		{
+			name:           "empty fields + GH- id + live says open",
+			task:           &Task{ID: "GH-201"},
+			fallbackResult: false,
+			fallbackCalled: true,
+			want:           false,
+		},
+		{
+			name:           "non-GH id skips fallback",
+			task:           &Task{ID: "LIN-42"},
+			fallbackResult: true,
+			fallbackCalled: false,
+			want:           false,
+		},
+		{
+			name:           "populated state skips fallback",
+			task:           &Task{ID: "GH-201", State: "open"},
+			fallbackResult: true,
+			fallbackCalled: false,
+			want:           false,
+		},
+		{
+			name:           "populated labels skip fallback",
+			task:           &Task{ID: "GH-201", Labels: []string{"area:executor"}},
+			fallbackResult: true,
+			fallbackCalled: false,
+			want:           false,
+		},
+		{
+			name: "terminal label still wins without fallback",
+			task: &Task{ID: "GH-201", Labels: []string{"pilot-done"}},
+			// fallback should not be reached when a terminal label is present
+			fallbackResult: false,
+			fallbackCalled: false,
+			want:           true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			orig := isParentDoneLiveFallback
+			isParentDoneLiveFallback = func(taskID, dir string) bool {
+				called = true
+				return tc.fallbackResult
+			}
+			t.Cleanup(func() { isParentDoneLiveFallback = orig })
+
+			got := isParentDone(tc.task)
+			if got != tc.want {
+				t.Errorf("isParentDone = %v, want %v", got, tc.want)
+			}
+			if called != tc.fallbackCalled {
+				t.Errorf("fallback called = %v, want %v", called, tc.fallbackCalled)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the GH-201 spurious-dispatch loop that produced 70+ OAuth-titled sub-issues today. The TASK-50 `isParentDone` gate is reachable but receives a `Task` with empty `State` and empty `Labels`, so it returns `false` and the gate is bypassed.

Two fixes:

- **`cmd/pilot/handlers.go`** — propagate `issue.State` into the `Task` struct (was being dropped when the handler built the task from a GitHub issue).
- **`internal/executor/epic.go`** — defensive live fallback in `isParentDone`: when `State` and `Labels` are both empty AND the task ID has the `GH-` prefix, shell out to `gh issue view` to fetch the live state. Catches the dispatcher-restore path (executions schema has no `task_state` column) and any future caller that drops the fields. Disabled under `go test`; overrideable.

Why both: the handler fix covers fresh dispatches; the live fallback is the belt-and-suspenders for the `dispatcher.go:639` worker reconstruction path, where a Task is rebuilt from the persisted execution row that does not carry State.

## Why we need both

The 70+ OAuth dupes today were spawned **after** TASK-50 fix shipped in v2.139.0+. The fix was correct in code but never fired because every `Task` reaching `isParentDone` had empty State/Labels. Verified live: post-restart on v2.140.0/v2.141.1, dupes continued. Diagnosis below.

| Layer | Why it bypassed the gate |
|---|---|
| `cmd/pilot/handlers.go:232` | Builds Task from `*github.Issue` but never sets `State` |
| `internal/executor/dispatcher.go:639` | Reconstructs Task from `Execution` row; schema has no `task_state` column; `task_labels` is empty for pre-migration rows |
| `internal/executor/epic.go:598` (`isParentDone`) | Returned `false` whenever State and Labels both empty — exactly the input both upstream paths produce |

## Test plan

- [x] `make test` (full executor + cmd/pilot + gateway + autopilot suites pass on the worktree)
- [x] `make lint` equivalent (`golangci-lint run`, `gofmt -l`, `go vet`) — 0 issues
- [x] New: `TestIsParentDone_LiveFallback` — 6 sub-cases covering all guard combinations
- [x] Existing: `TestCreateSubIssues_RefusesClosedParent` — still passes (4 sub-cases)
- [x] Existing: `TestCreateSubIssues_SkipsWhenChildrenExist` — still passes (regression target — this test broke during my first iteration when the fallback fired against a real closed issue; the `testing.Testing()` no-op default fixes it)

## Verify post-merge

```bash
# After release + pilot upgrade + clean daemon restart:
gh issue list --state all --search "OAuth provider integration created:>=$(date -u +%Y-%m-%dT%H:%M:%SZ)" --json number
# Expect zero new dupes for 1h+ soak.
```

## References

- Plan / RCA: `.agent/tasks/TASK-50-gh201-spurious-dispatch-rca.md`
- Predecessor (gate code): TASK-50 / PR #2872 / commit `0f1829a8`
- Sentinel issue: #2866 (close after this lands and 2h soak passes)
- Manual workaround used today: closed #2837 to break a `pilot-failed` retry loop (separate bug, addressed by TASK-56)