### PR TITLE
GH-2944: feat(executor): record execution duration in runner

### DIFF
--- a/internal/executor/metrics_recorder.go
+++ b/internal/executor/metrics_recorder.go
@@ -1,9 +1,12 @@
 package executor
 
+import "time"
+
 // MetricsRecorder accepts per-execution telemetry from the runner.
 // The interface is satisfied by *autopilot.Metrics without importing the autopilot package.
 type MetricsRecorder interface {
 	RecordTokens(model, direction string, n int64)
 	RecordCost(model string, costUSD float64)
 	RecordExecution(model, result string)
+	RecordExecutionDuration(d time.Duration)
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1112,6 +1112,11 @@ func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, err
 // This prevents recursive worktree creation in sub-issues and decomposed tasks.
 func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktree bool) (*ExecutionResult, error) {
 	start := time.Now()
+	defer func() {
+		if r.metricsRecorder != nil {
+			r.metricsRecorder.RecordExecutionDuration(time.Since(start))
+		}
+	}()
 
 	// Signal monitor that execution is actually starting (queued→running transition)
 	if r.monitor != nil {

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3826,10 +3826,11 @@ func TestExecute_PopulatesEffortAndComplexityOnResult(t *testing.T) {
 
 // fakeMetricsRecorder captures calls to the MetricsRecorder interface for assertions.
 type fakeMetricsRecorder struct {
-	mu         sync.Mutex
-	tokenCalls []struct{ model, direction string; n int64 }
-	costCalls  []struct{ model string; costUSD float64 }
-	execCalls  []struct{ model, result string }
+	mu            sync.Mutex
+	tokenCalls    []struct{ model, direction string; n int64 }
+	costCalls     []struct{ model string; costUSD float64 }
+	execCalls     []struct{ model, result string }
+	durationCalls []time.Duration
 }
 
 func (f *fakeMetricsRecorder) RecordTokens(model, direction string, n int64) {
@@ -3848,6 +3849,12 @@ func (f *fakeMetricsRecorder) RecordExecution(model, result string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.execCalls = append(f.execCalls, struct{ model, result string }{model, result})
+}
+
+func (f *fakeMetricsRecorder) RecordExecutionDuration(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.durationCalls = append(f.durationCalls, d)
 }
 
 // TestMetricsRecorder_CalledOncePerExecution verifies that SetMetricsRecorder
@@ -3913,5 +3920,11 @@ func TestMetricsRecorder_CalledOncePerExecution(t *testing.T) {
 
 	if len(rec.tokenCalls) == 0 {
 		t.Error("RecordTokens not called; want at least one call for input tokens")
+	}
+
+	if len(rec.durationCalls) != 1 {
+		t.Errorf("RecordExecutionDuration called %d times, want exactly 1", len(rec.durationCalls))
+	} else if rec.durationCalls[0] <= 0 {
+		t.Errorf("RecordExecutionDuration got %v, want positive duration", rec.durationCalls[0])
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2944.

Closes #2944

## Changes

GitHub Issue #2944: feat(executor): record execution duration in runner

<!--autopilot-meta
parent: GH-2941
inherited-spec: true
-->

Parent: GH-2941

In internal/executor/runner.go, extend the MetricsRecorder interface to add RecordExecutionDuration(d time.Duration) (the method already exists on *autopilot.Metrics at metrics.go:264, so no autopilot change is required). In Runner.Execute(), the start := time.Now() is already captured; add a single defer near the top that calls r.metricsRecorder.RecordExecutionDuration(time.Since(start)) (nil-guarded) so every return path is covered DRY. Update internal/executor/runner_test.go with a fake recorder asserting a sample is recorded after one execution. Verify make test ./internal/executor/... and make lint.