### PR TITLE
GH-2963: feat(deploy): add token/cost/executions panels to Pilot Grafana dashboard

### DIFF
--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -55,18 +55,22 @@ docker compose down -v
 
 ## Dashboard Panels
 
-The `pilot-dashboard.json` (uid: `pilot`) contains 8 panels in a 4×2 grid:
+The `pilot-dashboard.json` (uid: `pilot`) contains 12 panels across 5 rows (y=0..32):
 
-| Panel | Type | Query |
-|-------|------|-------|
-| Success Rate | stat | `pilot_success_rate` |
-| Queue Depth | timeseries | `pilot_queue_depth`, `pilot_failed_queue_depth` |
-| Issue Throughput | timeseries | `rate(pilot_issues_processed_total[5m])` |
-| Active PRs | bargauge | `pilot_active_prs` |
-| Execution Duration P95 | timeseries | `histogram_quantile(0.95, rate(pilot_execution_duration_seconds_bucket[5m]))` |
-| CI Wait P50 | timeseries | `histogram_quantile(0.50, rate(pilot_ci_wait_duration_seconds_bucket[5m]))` |
-| PR Outcomes | timeseries (stacked) | `rate(pilot_prs_merged_total[1h])`, failed, conflicting |
-| Circuit Breaker & API Errors | timeseries | `rate(pilot_circuit_breaker_trips_total[5m])`, `rate(pilot_api_errors_total[5m])` |
+| # | Panel | Type | PromQL |
+|---|-------|------|--------|
+| 1 | Success Rate | stat | `pilot_success_rate` |
+| 2 | Queue Depth | timeseries | `pilot_queue_depth`, `pilot_failed_queue_depth` |
+| 3 | Issue Throughput | timeseries | `rate(pilot_issues_processed_total[5m])` |
+| 4 | Active PRs | bargauge | `pilot_active_prs` |
+| 5 | Execution Duration P95 | timeseries | `histogram_quantile(0.95, rate(pilot_execution_duration_seconds_bucket[5m]))` |
+| 6 | CI Wait P50 | timeseries | `histogram_quantile(0.50, rate(pilot_ci_wait_duration_seconds_bucket[5m]))` |
+| 7 | PR Outcomes | timeseries (stacked) | `rate(pilot_prs_merged_total[1h])`, failed, conflicting |
+| 8 | Circuit Breaker & API Errors | timeseries | `rate(pilot_circuit_breaker_trips_total[5m])`, `rate(pilot_api_errors_total[5m])` |
+| 9 | Tokens/5m | timeseries (stacked area) | `rate(pilot_tokens_consumed_total[5m])` legend `{{model}}/{{direction}}` |
+| 10 | Cumulative Cost (USD) | stat | `sum(pilot_execution_cost_usd_total)` |
+| 11 | Cost/hour | timeseries | `rate(pilot_execution_cost_usd_total[5m]) * 3600` legend `{{model}}` |
+| 12 | Executions by Result | bargauge | `pilot_executions_total` legend `{{model}}/{{result}}` |
 
 ## Troubleshooting
 

--- a/deploy/grafana/pilot-dashboard.json
+++ b/deploy/grafana/pilot-dashboard.json
@@ -288,6 +288,148 @@
           "refId": "B"
         }
       ]
+    },
+    {
+      "id": 9,
+      "title": "Tokens/5m",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 32, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 20,
+            "stacking": { "mode": "normal", "group": "A" }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(pilot_tokens_consumed_total[5m])",
+          "legendFormat": "{{model}}/{{direction}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Cumulative Cost (USD)",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 32, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "mappings": [],
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(pilot_execution_cost_usd_total)",
+          "legendFormat": "Total Cost",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "title": "Cost/hour",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 32, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "USD/hour"
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(pilot_execution_cost_usd_total[5m]) * 3600",
+          "legendFormat": "{{model}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "title": "Executions by Result",
+      "type": "bargauge",
+      "gridPos": { "x": 18, "y": 32, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color",
+        "showUnfilled": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pilot_executions_total",
+          "legendFormat": "{{model}}/{{result}}",
+          "refId": "A"
+        }
+      ]
     }
   ]
 }

--- a/docs/content/deployment/monitoring.mdx
+++ b/docs/content/deployment/monitoring.mdx
@@ -125,6 +125,30 @@ pilot_active_prs
 ```
 Legend: `{{stage}}`
 
+**8. Token Consumption Rate (per model and direction)**
+```promql
+rate(pilot_tokens_consumed_total[5m])
+```
+Legend: `{{model}}/{{direction}}` — stacked area, unit: short
+
+**9. Cumulative Execution Cost**
+```promql
+sum(pilot_execution_cost_usd_total)
+```
+Unit: currencyUSD, decimals: 4. Thresholds: green < $1, yellow < $10, red ≥ $10.
+
+**10. Cost per Hour (by model)**
+```promql
+rate(pilot_execution_cost_usd_total[5m]) * 3600
+```
+Legend: `{{model}}` — unit: currencyUSD, axis label: USD/hour
+
+**11. Executions by Result**
+```promql
+pilot_executions_total
+```
+Legend: `{{model}}/{{result}}` — bargauge showing cumulative execution counts split by model and outcome.
+
 ---
 
 ## Local Dev Stack


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2963.

Closes #2963

## Changes

Append four new panels (ids 9–12) to deploy/grafana/pilot-dashboard.json at gridPos.y=32, w=6 h=8 each: (9) Tokens/5m timeseries with rate(pilot_tokens_consumed_total[5m]) legend {{model}}/{{direction}} stacked area unit short; (10) Cumulative Cost (USD) stat with sum(pilot_execution_cost_usd_total) unit currencyUSD decimals 4 thresholds green<$1/yellow<$10/red≥$10; (11) Cost/hour timeseries with rate(pilot_execution_cost_usd_total[5m])*3600 legend {{model}} unit currencyUSD axis label USD/hour; (12) Executions by Result bargauge with pilot_executions_total legend {{model}}/{{result}} unit short. Every new panel must set datasource:{type:prometheus,uid:prometheus}. Do not modify existing 8 panels. Add Panels section to deploy/grafana/README.md listing all 12 panels with PromQL. Append four PromQL examples to docs/content/deployment/monitoring.mdx. Verify with jq -e . deploy/grafana/pilot-dashboard.json, docker compose config -q, and curl confirm panels length >= 12.