### PR TITLE
GH-2969: feat(github): add SearchOpenPilotIssuesWithSubIssues GraphQL method

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -1039,3 +1039,54 @@ func (c *Client) GetOpenSubIssueCount(ctx context.Context, owner, repo string, p
 	}
 	return openCount, true, nil
 }
+
+// SearchOpenPilotIssuesWithSubIssues returns issue numbers for open issues labeled "pilot"
+// in the given repo that have at least one sub-issue (subIssuesSummary.total > 0).
+// limit controls the maximum number of issues fetched from the API via the GraphQL first argument.
+func (c *Client) SearchOpenPilotIssuesWithSubIssues(ctx context.Context, owner, repo string, limit int) ([]int, error) {
+	const query = `query($owner: String!, $repo: String!, $first: Int!) {
+		repository(owner: $owner, name: $repo) {
+			issues(first: $first, states: [OPEN], labels: ["pilot"]) {
+				nodes {
+					number
+					subIssuesSummary {
+						total
+						completed
+					}
+				}
+			}
+		}
+	}`
+
+	var result struct {
+		Repository struct {
+			Issues struct {
+				Nodes []struct {
+					Number           int `json:"number"`
+					SubIssuesSummary struct {
+						Total     int `json:"total"`
+						Completed int `json:"completed"`
+					} `json:"subIssuesSummary"`
+				} `json:"nodes"`
+			} `json:"issues"`
+		} `json:"repository"`
+	}
+
+	variables := map[string]interface{}{
+		"owner": owner,
+		"repo":  repo,
+		"first": limit,
+	}
+
+	if err := c.ExecuteGraphQL(ctx, query, variables, &result); err != nil {
+		return nil, fmt.Errorf("search pilot issues with sub-issues for %s/%s: %w", owner, repo, err)
+	}
+
+	var numbers []int
+	for _, node := range result.Repository.Issues.Nodes {
+		if node.SubIssuesSummary.Total > 0 {
+			numbers = append(numbers, node.Number)
+		}
+	}
+	return numbers, nil
+}

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -3130,6 +3130,124 @@ func TestGetOpenSubIssueCount(t *testing.T) {
 	}
 }
 
+func TestSearchOpenPilotIssuesWithSubIssues(t *testing.T) {
+	tests := []struct {
+		name            string
+		graphqlResponse string
+		graphqlStatus   int
+		limit           int
+		wantNumbers     []int
+		wantErr         bool
+		errContains     string
+	}{
+		{
+			name:  "returns issues with sub-issues",
+			limit: 10,
+			graphqlResponse: `{"data":{"repository":{"issues":{"nodes":[
+				{"number":1,"subIssuesSummary":{"total":3,"completed":1}},
+				{"number":2,"subIssuesSummary":{"total":0,"completed":0}},
+				{"number":3,"subIssuesSummary":{"total":2,"completed":2}}
+			]}}}}`,
+			graphqlStatus: http.StatusOK,
+			wantNumbers:   []int{1, 3},
+		},
+		{
+			name:  "empty results when no sub-issues",
+			limit: 10,
+			graphqlResponse: `{"data":{"repository":{"issues":{"nodes":[
+				{"number":5,"subIssuesSummary":{"total":0,"completed":0}},
+				{"number":6,"subIssuesSummary":{"total":0,"completed":0}}
+			]}}}}`,
+			graphqlStatus: http.StatusOK,
+			wantNumbers:   nil,
+		},
+		{
+			name:            "empty results when no issues",
+			limit:           10,
+			graphqlResponse: `{"data":{"repository":{"issues":{"nodes":[]}}}}`,
+			graphqlStatus:   http.StatusOK,
+			wantNumbers:     nil,
+		},
+		{
+			name:  "limit truncation applied to API request",
+			limit: 2,
+			graphqlResponse: `{"data":{"repository":{"issues":{"nodes":[
+				{"number":10,"subIssuesSummary":{"total":1,"completed":0}},
+				{"number":11,"subIssuesSummary":{"total":4,"completed":2}}
+			]}}}}`,
+			graphqlStatus: http.StatusOK,
+			wantNumbers:   []int{10, 11},
+		},
+		{
+			name:            "API error propagation",
+			limit:           10,
+			graphqlResponse: `{"data":null,"errors":[{"message":"could not resolve repository"}]}`,
+			graphqlStatus:   http.StatusOK,
+			wantErr:         true,
+			errContains:     "search pilot issues with sub-issues",
+		},
+		{
+			name:          "HTTP error propagation",
+			limit:         10,
+			graphqlStatus: http.StatusInternalServerError,
+			graphqlResponse: `internal error`,
+			wantErr:         true,
+			errContains:     "search pilot issues with sub-issues",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedFirst int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/graphql" && r.Method == http.MethodPost {
+					var req GraphQLRequest
+					if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+						if v, ok := req.Variables["first"]; ok {
+							switch n := v.(type) {
+							case float64:
+								capturedFirst = int(n)
+							}
+						}
+					}
+					w.WriteHeader(tt.graphqlStatus)
+					_, _ = w.Write([]byte(tt.graphqlResponse))
+					return
+				}
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			numbers, err := client.SearchOpenPilotIssuesWithSubIssues(context.Background(), "owner", "repo", tt.limit)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SearchOpenPilotIssuesWithSubIssues() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %q, want containing %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if !tt.wantErr && capturedFirst != tt.limit {
+				t.Errorf("GraphQL first = %d, want %d (limit not forwarded)", capturedFirst, tt.limit)
+			}
+			if len(numbers) != len(tt.wantNumbers) {
+				t.Errorf("SearchOpenPilotIssuesWithSubIssues() = %v, want %v", numbers, tt.wantNumbers)
+				return
+			}
+			for i, n := range numbers {
+				if n != tt.wantNumbers[i] {
+					t.Errorf("numbers[%d] = %d, want %d", i, n, tt.wantNumbers[i])
+				}
+			}
+		})
+	}
+}
+
 func TestUpdateRelease(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2969.

Closes #2969

## Changes

Add a new method on the GitHub client that runs a GraphQL query using the `subIssuesSummary` field (`{total, completed}`) to return open issues with the `pilot` label that have `total > 0` sub-issues, bounded by a `limit` parameter. Signature: `SearchOpenPilotIssuesWithSubIssues(ctx context.Context, owner, repo string, limit int) ([]int, error)`. Include unit tests with mocked GraphQL responses covering: results returned, empty results, limit truncation, API error propagation. This is a pure read-only addition with no callers yet — safe to land independently.