### PR TITLE
GH-2970: fix(autopilot): parent-close recovery sweep and pilot-blocked cleanup

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -1039,3 +1039,52 @@ func (c *Client) GetOpenSubIssueCount(ctx context.Context, owner, repo string, p
 	}
 	return openCount, true, nil
 }
+
+// SearchOpenPilotIssuesWithSubIssues returns issue numbers of open issues with
+// the "pilot" label that have at least one native sub-issue link (total > 0).
+// Used by Controller.recoverStaleParentIssues for the startup recovery sweep.
+// Results are bounded by limit.
+func (c *Client) SearchOpenPilotIssuesWithSubIssues(ctx context.Context, owner, repo string, limit int) ([]int, error) {
+	// GraphQL: search for open pilot-labelled issues; include subIssuesSummary
+	// so we can filter to those with ≥1 sub-issue without N+1 round-trips.
+	const query = `query($q: String!, $limit: Int!) {
+		search(query: $q, type: ISSUE, first: $limit) {
+			nodes {
+				... on Issue {
+					number
+					subIssuesSummary {
+						total
+					}
+				}
+			}
+		}
+	}`
+
+	variables := map[string]interface{}{
+		"q":     fmt.Sprintf("repo:%s/%s label:pilot state:open", owner, repo),
+		"limit": limit,
+	}
+
+	var result struct {
+		Search struct {
+			Nodes []struct {
+				Number            int `json:"number"`
+				SubIssuesSummary  struct {
+					Total int `json:"total"`
+				} `json:"subIssuesSummary"`
+			} `json:"nodes"`
+		} `json:"search"`
+	}
+
+	if err := c.ExecuteGraphQL(ctx, query, variables, &result); err != nil {
+		return nil, fmt.Errorf("SearchOpenPilotIssuesWithSubIssues %s/%s: %w", owner, repo, err)
+	}
+
+	var issues []int
+	for _, n := range result.Search.Nodes {
+		if n.SubIssuesSummary.Total > 0 {
+			issues = append(issues, n.Number)
+		}
+	}
+	return issues, nil
+}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1392,6 +1392,7 @@ func (c *Controller) handleMerged(ctx context.Context, prState *PRState) error {
 // All errors are logged as warnings without blocking the merge flow.
 func (c *Controller) maybeCloseParentIssue(ctx context.Context, prState *PRState) {
 	if prState.IssueNumber == 0 {
+		c.log.Info("maybeCloseParentIssue: no issue number, skipping")
 		return
 	}
 
@@ -1404,54 +1405,111 @@ func (c *Controller) maybeCloseParentIssue(ctx context.Context, prState *PRState
 
 	parentNum := github.ParseParentIssueNumber(issue.Body)
 	if parentNum == 0 {
+		c.log.Info("maybeCloseParentIssue: no parent reference found", slog.Int("issue", prState.IssueNumber))
 		return
 	}
+
+	c.log.Info("maybeCloseParentIssue: evaluating",
+		slog.Int("sub_issue", prState.IssueNumber),
+		slog.Int("parent", parentNum))
 
 	// Check how many sibling sub-issues are still open.
 	// Tier 1: try native GitHub sub-issues GraphQL API (more reliable, works even without text patterns).
 	// Tier 2: fall back to text search when native links are absent (legacy repos use body "Parent: GH-N" only).
-	openCount, hasNativeLinks, err := c.ghClient.GetOpenSubIssueCount(ctx, c.owner, c.repo, parentNum)
-	if err != nil || !hasNativeLinks {
-		if err != nil {
-			c.log.Warn("maybeCloseParentIssue: native sub-issue count failed, falling back to search", slog.Int("parent", parentNum), slog.Any("error", err))
+	openCount, hasNativeLinks, tier1Err := c.ghClient.GetOpenSubIssueCount(ctx, c.owner, c.repo, parentNum)
+	if tier1Err != nil || !hasNativeLinks {
+		if tier1Err != nil {
+			c.log.Warn("maybeCloseParentIssue: native sub-issue count failed, falling back to search",
+				slog.Int("parent", parentNum),
+				slog.Bool("had_native_links", hasNativeLinks),
+				slog.Any("tier1_err", tier1Err))
 		} else {
 			c.log.Debug("maybeCloseParentIssue: no native sub-issue links, falling back to search", slog.Int("parent", parentNum))
 		}
-		openCount, err = c.ghClient.SearchOpenSubIssues(ctx, c.owner, c.repo, parentNum)
-		if err != nil {
-			c.log.Warn("maybeCloseParentIssue: failed to search open sub-issues", slog.Int("parent", parentNum), slog.Any("error", err))
+		var tier2Err error
+		openCount, tier2Err = c.ghClient.SearchOpenSubIssues(ctx, c.owner, c.repo, parentNum)
+		if tier2Err != nil {
+			c.log.Warn("maybeCloseParentIssue: failed to search open sub-issues",
+				slog.Int("parent", parentNum),
+				slog.Any("tier1_err", tier1Err),
+				slog.Any("tier2_err", tier2Err))
 			return
 		}
 	}
+
+	c.log.Info("maybeCloseParentIssue: sub-issue count resolved",
+		slog.Int("parent", parentNum),
+		slog.Int("open", openCount),
+		slog.Bool("via_native_links", hasNativeLinks))
 
 	if openCount > 0 {
 		c.log.Info("maybeCloseParentIssue: siblings still open", slog.Int("parent", parentNum), slog.Int("open", openCount))
 		return
 	}
 
-	// All sub-issues closed — close the parent.
-	c.log.Info("maybeCloseParentIssue: all sub-issues done, closing parent", slog.Int("parent", parentNum))
+	c.closeParentNow(ctx, parentNum)
+}
+
+// closeParentNow adds pilot-done, removes stale labels, posts a summary comment,
+// and closes the parent issue. Called by both maybeCloseParentIssue (per-merge)
+// and recoverStaleParentIssues (startup sweep) once openCount == 0 is confirmed.
+func (c *Controller) closeParentNow(ctx context.Context, parentNum int) {
+	c.log.Info("closeParentNow: closing parent", slog.Int("parent", parentNum))
 
 	// Label cleanup: add pilot-done, remove stale labels.
 	if err := c.ghClient.AddLabels(ctx, c.owner, c.repo, parentNum, []string{"pilot-done"}); err != nil {
-		c.log.Warn("maybeCloseParentIssue: failed to add pilot-done label", slog.Int("parent", parentNum), slog.Any("error", err))
+		c.log.Warn("closeParentNow: failed to add pilot-done label", slog.Int("parent", parentNum), slog.Any("error", err))
 	}
-	for _, stale := range []string{"pilot-failed", "pilot-in-progress"} {
+	for _, stale := range []string{"pilot-failed", "pilot-in-progress", "pilot-blocked"} {
 		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, parentNum, stale); err != nil {
-			c.log.Warn("maybeCloseParentIssue: failed to remove label", slog.String("label", stale), slog.Int("parent", parentNum), slog.Any("error", err))
+			c.log.Warn("closeParentNow: failed to remove label", slog.String("label", stale), slog.Int("parent", parentNum), slog.Any("error", err))
 		}
 	}
 
 	// Post summary comment.
 	comment := fmt.Sprintf("All sub-issues for GH-%d are complete. Closing parent issue automatically.", parentNum)
 	if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, parentNum, comment); err != nil {
-		c.log.Warn("maybeCloseParentIssue: failed to post comment", slog.Int("parent", parentNum), slog.Any("error", err))
+		c.log.Warn("closeParentNow: failed to post comment", slog.Int("parent", parentNum), slog.Any("error", err))
 	}
 
 	// Close the parent issue.
 	if err := c.ghClient.UpdateIssueState(ctx, c.owner, c.repo, parentNum, "closed"); err != nil {
-		c.log.Warn("maybeCloseParentIssue: failed to close parent issue", slog.Int("parent", parentNum), slog.Any("error", err))
+		c.log.Warn("closeParentNow: failed to close parent issue", slog.Int("parent", parentNum), slog.Any("error", err))
 	}
+}
+
+// recoverStaleParentIssues scans for parent issues stuck OPEN after all sub-issues
+// closed, and closes them. Runs once at daemon startup for eventual consistency.
+// Bounded to 50 issues per run; continues per-item on errors.
+func (c *Controller) recoverStaleParentIssues(ctx context.Context) {
+	const maxRecover = 50
+
+	candidates, err := c.ghClient.SearchOpenPilotIssuesWithSubIssues(ctx, c.owner, c.repo, maxRecover+1)
+	if err != nil {
+		c.log.Warn("recoverStaleParentIssues: search failed", slog.Any("error", err))
+		return
+	}
+	if len(candidates) > maxRecover {
+		c.log.Info("recoverStaleParentIssues: truncated to max",
+			slog.Int("found", len(candidates)),
+			slog.Int("max", maxRecover))
+		candidates = candidates[:maxRecover]
+	}
+
+	closed := 0
+	for _, parentNum := range candidates {
+		openCount, _, err := c.ghClient.GetOpenSubIssueCount(ctx, c.owner, c.repo, parentNum)
+		if err != nil {
+			c.log.Warn("recoverStaleParentIssues: count failed", slog.Int("parent", parentNum), slog.Any("error", err))
+			continue
+		}
+		if openCount > 0 {
+			continue
+		}
+		c.closeParentNow(ctx, parentNum)
+		closed++
+	}
+	c.log.Info("recoverStaleParentIssues: done", slog.Int("closed", closed))
 }
 
 // handlePostMergeCI monitors deployment/post-merge checks (non-blocking).
@@ -2193,6 +2251,10 @@ func (c *Controller) Run(ctx context.Context) error {
 		"auto_merge", c.config.AutoMerge,
 		"release_enabled", c.resolvedRelease() != nil && c.resolvedRelease().Enabled,
 	)
+
+	// Startup sweep: close parent issues whose sub-issues all completed but
+	// parent was never auto-closed (race or transient error at merge time).
+	c.recoverStaleParentIssues(ctx)
 
 	// Dynamic poll interval settings
 	basePollInterval := c.config.CIPollInterval

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -5639,3 +5639,343 @@ func TestController_IssuesProcessed_TerminalFailure(t *testing.T) {
 		t.Errorf("IssuesProcessed[success] = %d, want 0", snap.IssuesProcessed["success"])
 	}
 }
+
+// graphqlSearchResponse builds a GraphQL search result with the given issue nodes
+// in the format expected by SearchOpenPilotIssuesWithSubIssues.
+func graphqlSearchResponse(nodes []map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"data": map[string]interface{}{
+			"search": map[string]interface{}{
+				"nodes": nodes,
+			},
+		},
+	}
+}
+
+// graphqlSubIssuesResponse builds a GraphQL node result with sub-issues in the
+// format expected by GetOpenSubIssueCount.
+func graphqlSubIssuesResponse(totalCount int, states []string) map[string]interface{} {
+	nodes := make([]map[string]string, len(states))
+	for i, s := range states {
+		nodes[i] = map[string]string{"state": s}
+	}
+	return map[string]interface{}{
+		"data": map[string]interface{}{
+			"node": map[string]interface{}{
+				"subIssues": map[string]interface{}{
+					"totalCount": totalCount,
+					"nodes":      nodes,
+				},
+			},
+		},
+	}
+}
+
+// TestMaybeCloseParentIssue_RemovesPilotBlocked verifies that pilot-blocked is
+// removed alongside pilot-failed and pilot-in-progress when a parent is closed.
+func TestMaybeCloseParentIssue_RemovesPilotBlocked(t *testing.T) {
+	var removeLabelCalls []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/10" && r.Method == http.MethodGet:
+			issue := github.Issue{Number: 10, Body: "Fix\n\nParent: GH-5\n", State: "closed"}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(issue)
+
+		case r.URL.Path == "/repos/owner/repo/issues/5" && r.Method == http.MethodGet:
+			// Return node_id so GetOpenSubIssueCount can proceed.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"node_id":"I_parent_node","number":5}`))
+
+		case r.URL.Path == "/graphql" && r.Method == http.MethodPost:
+			// All sub-issues closed (native path).
+			resp := graphqlSubIssuesResponse(2, []string{"CLOSED", "CLOSED"})
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/issues/5/labels" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/5/labels/") && r.Method == http.MethodDelete:
+			label := strings.TrimPrefix(r.URL.Path, "/repos/owner/repo/issues/5/labels/")
+			removeLabelCalls = append(removeLabelCalls, label)
+			w.WriteHeader(http.StatusOK)
+
+		case r.URL.Path == "/repos/owner/repo/issues/5/comments" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":1}`))
+
+		case r.URL.Path == "/repos/owner/repo/issues/5" && r.Method == http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+	prState := &PRState{PRNumber: 42, IssueNumber: 10}
+
+	c.maybeCloseParentIssue(context.Background(), prState)
+
+	for _, want := range []string{"pilot-failed", "pilot-in-progress", "pilot-blocked"} {
+		found := false
+		for _, got := range removeLabelCalls {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected label %q to be removed, removeLabelCalls = %v", want, removeLabelCalls)
+		}
+	}
+}
+
+// TestRecoverStaleParentIssues_ClosesOrphanedParent verifies that the startup
+// sweep closes a parent whose sub-issues are all done.
+func TestRecoverStaleParentIssues_ClosesOrphanedParent(t *testing.T) {
+	closeCalled := false
+	graphqlCallCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/graphql" && r.Method == http.MethodPost {
+			graphqlCallCount++
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			q, _ := req["query"].(string)
+
+			if strings.Contains(q, "search(") {
+				// SearchOpenPilotIssuesWithSubIssues: return one candidate (issue 5).
+				resp := graphqlSearchResponse([]map[string]interface{}{
+					{"number": 5, "subIssuesSummary": map[string]interface{}{"total": 2}},
+				})
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+			// GetOpenSubIssueCount: parent 5 has no open sub-issues.
+			resp := graphqlSubIssuesResponse(2, []string{"CLOSED", "CLOSED"})
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/5" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"node_id":"I_parent_node","number":5}`))
+
+		case r.URL.Path == "/repos/owner/repo/issues/5/labels" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/5/labels/") && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+
+		case r.URL.Path == "/repos/owner/repo/issues/5/comments" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":1}`))
+
+		case r.URL.Path == "/repos/owner/repo/issues/5" && r.Method == http.MethodPatch:
+			closeCalled = true
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	c.recoverStaleParentIssues(context.Background())
+
+	if !closeCalled {
+		t.Error("expected orphaned parent issue to be closed, but PATCH was not called")
+	}
+}
+
+// TestRecoverStaleParentIssues_SkipsParentWithOpenSiblings verifies that the
+// sweep does not close a parent that still has open sub-issues.
+func TestRecoverStaleParentIssues_SkipsParentWithOpenSiblings(t *testing.T) {
+	closeCalled := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/graphql" && r.Method == http.MethodPost {
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			q, _ := req["query"].(string)
+
+			if strings.Contains(q, "search(") {
+				resp := graphqlSearchResponse([]map[string]interface{}{
+					{"number": 5, "subIssuesSummary": map[string]interface{}{"total": 2}},
+				})
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+			// GetOpenSubIssueCount: one sub-issue is still OPEN.
+			resp := graphqlSubIssuesResponse(2, []string{"OPEN", "CLOSED"})
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/5" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"node_id":"I_parent_node","number":5}`))
+
+		case r.URL.Path == "/repos/owner/repo/issues/5" && r.Method == http.MethodPatch:
+			closeCalled = true
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	c.recoverStaleParentIssues(context.Background())
+
+	if closeCalled {
+		t.Error("expected parent with open siblings to be skipped, but PATCH was called")
+	}
+}
+
+// TestRecoverStaleParentIssues_NoOpWhenNoSubIssues verifies that the sweep skips
+// issues returned by search but having zero sub-issues in the summary.
+func TestRecoverStaleParentIssues_NoOpWhenNoSubIssues(t *testing.T) {
+	closeCalled := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/graphql" && r.Method == http.MethodPost {
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			q, _ := req["query"].(string)
+
+			if strings.Contains(q, "search(") {
+				// Return an issue with total=0 — SearchOpenPilotIssuesWithSubIssues
+				// filters it out before calling GetOpenSubIssueCount.
+				resp := graphqlSearchResponse([]map[string]interface{}{
+					{"number": 5, "subIssuesSummary": map[string]interface{}{"total": 0}},
+				})
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+			// Should not be reached, but return empty to be safe.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(graphqlSubIssuesResponse(0, nil))
+			return
+		}
+
+		if r.URL.Path == "/repos/owner/repo/issues/5" && r.Method == http.MethodPatch {
+			closeCalled = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	c.recoverStaleParentIssues(context.Background())
+
+	if closeCalled {
+		t.Error("expected no-op for issue with no sub-issues, but PATCH was called")
+	}
+}
+
+// TestRecoverStaleParentIssues_TruncatesAt50 verifies that the sweep caps at 50
+// candidates and logs an Info message when more are available.
+func TestRecoverStaleParentIssues_TruncatesAt50(t *testing.T) {
+	const maxRecover = 50
+	patchCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/graphql" && r.Method == http.MethodPost {
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			q, _ := req["query"].(string)
+
+			if strings.Contains(q, "search(") {
+				// Return maxRecover+1 candidates so truncation kicks in.
+				nodes := make([]map[string]interface{}, maxRecover+1)
+				for i := range nodes {
+					nodes[i] = map[string]interface{}{
+						"number":           i + 100,
+						"subIssuesSummary": map[string]interface{}{"total": 1},
+					}
+				}
+				resp := graphqlSearchResponse(nodes)
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+			// GetOpenSubIssueCount for each candidate: no open sub-issues.
+			resp := graphqlSubIssuesResponse(1, []string{"CLOSED"})
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		// GetIssueNodeID REST call for each candidate.
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/") {
+			num := strings.TrimPrefix(r.URL.Path, "/repos/owner/repo/issues/")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"node_id":"I_node_` + num + `","number":` + num + `}`))
+			return
+		}
+
+		// Label add for each candidate.
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/labels") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+			return
+		}
+
+		// Label remove for each candidate.
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/labels/") {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// Comment for each candidate.
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/comments") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":1}`))
+			return
+		}
+
+		// PATCH = close issue.
+		if r.Method == http.MethodPatch {
+			patchCalls++
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	c.recoverStaleParentIssues(context.Background())
+
+	if patchCalls != maxRecover {
+		t.Errorf("expected exactly %d PATCH calls (truncated at max), got %d", maxRecover, patchCalls)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2970.

Closes #2970

## Changes

All controller-side work in `internal/autopilot/controller.go` and `controller_test.go`: Add `"pilot-blocked"` to the stale-label cleanup list at `controller.go:1439` alongside `pilot-failed` and `pilot-in-progress`. Extract lines 1432-1454 of `maybeCloseParentIssue` into a private `closeParentNow` helper used by both the per-merge path and the new sweep. Replace silent `Warn` returns in `maybeCloseParentIssue` with structured `Info`/`Warn` logs at each decision branch (no behavior change). Add `Controller.recoverStaleParentIssues(ctx)` that calls `SearchOpenPilotIssuesWithSubIssues` (limit 50), iterates candidates, calls `GetOpenSubIssueCount`, and invokes `closeParentNow` when count is 0. Bounded to 50, continues per-item on errors (matches `recoverStaleTasks` pattern), logs `recoverStaleParentIssues: done closed=N`. Wire the sweep into `Controller.Start(ctx)` after `c.recoverStaleTasks()`. Table-driven tests: `pilot-blocked` in RemoveLabel call; sweep closes orphaned parent; sweep skips parent with open siblings; sweep no-op when no sub-issues; sweep truncates at 50 with Info log. Verify with `go test ./internal/autopilot/... -v`, `make lint`, `make build`. Depends on subtask 1 for `SearchOpenPilotIssuesWithSubIssues` to exist.