### PR TITLE
GH-2981: fix(autopilot): record merge metrics for externally-merged PRs

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-05-09 (v2.53.0)
+**Last Updated:** 2026-05-06 (v2.53.0)
 
 ## Legend
 
@@ -295,7 +295,7 @@
 | OpenAI-compatible direct backend | ✅ | executor | `type: openai-api` | `executor.openai` | Direct /v1/chat/completions for OpenAI, OpenRouter, Groq, Synthetic, vLLM, Ollama (v2.105.0, GH-2382) |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |
-| Issue processed metrics | ✅ | autopilot | - | - | RecordIssueProcessed(success/failed/rate_limited) at terminal outcomes (GH-2943) |
+| External-merge metrics | ✅ | autopilot | - | - | Record PRsMerged/IssuesProcessed/PRTimeToMerge for externally-merged PRs via scanner (v2.147.0, GH-2981) |
 | JSON structured logging | ✅ | - | - | `logging.format` | Optional JSON log output mode (v0.38.0) |
 | Qwen Code backend | ✅ | executor | `--backend qwen` | `executor.backend` | Alibaba Qwen Code CLI with stream-json (v1.9.0, GH-1314) |
 | Docker support | ✅ | - | - | - | Dockerfile + deployment guide (v1.46.0) |

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1182,9 +1182,7 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 
 	c.log.Info("PR merged successfully", "pr", prState.PRNumber)
 	prState.Stage = StageMerged
-	c.metrics.RecordPRMerged()
-	c.metrics.RecordIssueProcessed("success")
-	c.metrics.RecordPRTimeToMerge(time.Since(prState.CreatedAt))
+	c.recordMergeSuccess(prState)
 
 	// GH-1015: Add pilot-done label after successful merge (not at PR creation)
 	// This prevents false positives where PRs are closed without merging
@@ -2004,6 +2002,16 @@ func (c *Controller) Metrics() *Metrics {
 	return c.metrics
 }
 
+// recordMergeSuccess fires the three merge-success metrics counters.
+// Skips the time-to-merge histogram if prState.CreatedAt is zero (defensive).
+func (c *Controller) recordMergeSuccess(prState *PRState) {
+	c.metrics.RecordPRMerged()
+	c.metrics.RecordIssueProcessed("success")
+	if !prState.CreatedAt.IsZero() {
+		c.metrics.RecordPRTimeToMerge(time.Since(prState.CreatedAt))
+	}
+}
+
 // GetLastProgressAt returns the timestamp of the last PR state transition.
 // Used by MetricsAlerter for deadlock detection (GH-849).
 func (c *Controller) GetLastProgressAt() time.Time {
@@ -2206,6 +2214,21 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			EnvironmentName: c.config.EnvironmentName(),
 			PRTitle:         pr.Title,
 			TargetBranch:    pr.Base.Ref,
+		}
+
+		// Record merge metrics for externally-merged PRs that we haven't seen
+		// before. If a prior row already exists at StageReleasing or StageMerged
+		// this is a re-discovery on a subsequent scan tick — skip to stay idempotent.
+		if c.stateStore != nil {
+			prior, err := c.stateStore.GetPRState(pr.Number)
+			if err != nil {
+				c.log.Warn("failed to check prior PR state for metrics", "pr", pr.Number, "error", err)
+			} else if prior == nil {
+				c.recordMergeSuccess(prState)
+			}
+		} else {
+			// No state store — fire on first (and only) in-memory encounter.
+			c.recordMergeSuccess(prState)
 		}
 
 		// Register and trigger release

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -5912,3 +5912,82 @@ func TestController_IssuesProcessed_TerminalFailure(t *testing.T) {
 		t.Errorf("IssuesProcessed[success] = %d, want 0", snap.IssuesProcessed["success"])
 	}
 }
+
+// TestController_ScanRecentlyMergedPRs_RecordsMetrics verifies that
+// ScanRecentlyMergedPRs fires merge metrics on first discovery (GH-2981)
+// and is idempotent on subsequent scans.
+func TestController_ScanRecentlyMergedPRs_RecordsMetrics(t *testing.T) {
+	recentMergedAt := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+
+	pilotPR := github.PullRequest{
+		Number:         77,
+		Head:           github.PRRef{Ref: "pilot/GH-300", SHA: "sha77"},
+		Base:           github.PRRef{Ref: "main"},
+		HTMLURL:        "https://github.com/owner/repo/pull/77",
+		Title:          "feat(api): new endpoint",
+		Merged:         true,
+		MergedAt:       recentMergedAt,
+		MergeCommitSHA: "merge-sha-77",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{&pilotPR})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/releases"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{
+		Enabled:   true,
+		Trigger:   "on_merge",
+		TagPrefix: "v",
+	}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	store := newTestStateStore(t)
+	c.SetStateStore(store)
+
+	// First scan: PR not in state store → metrics must be recorded.
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("first ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	snap := c.metrics.Snapshot()
+	if snap.PRsMerged != 1 {
+		t.Errorf("after first scan: PRsMerged = %d, want 1", snap.PRsMerged)
+	}
+	if snap.IssuesProcessed["success"] != 1 {
+		t.Errorf("after first scan: IssuesProcessed[success] = %d, want 1", snap.IssuesProcessed["success"])
+	}
+	hist := c.metrics.HistogramSnapshot()
+	if len(hist.PRTimeToMerge) != 1 {
+		t.Errorf("after first scan: PRTimeToMerge samples = %d, want 1", len(hist.PRTimeToMerge))
+	}
+
+	// Second scan: PR is now in state store at StageReleasing → counts must not change.
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("second ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	snap2 := c.metrics.Snapshot()
+	if snap2.PRsMerged != 1 {
+		t.Errorf("after second scan (idempotency): PRsMerged = %d, want 1", snap2.PRsMerged)
+	}
+	if snap2.IssuesProcessed["success"] != 1 {
+		t.Errorf("after second scan (idempotency): IssuesProcessed[success] = %d, want 1", snap2.IssuesProcessed["success"])
+	}
+	hist2 := c.metrics.HistogramSnapshot()
+	if len(hist2.PRTimeToMerge) != 1 {
+		t.Errorf("after second scan (idempotency): PRTimeToMerge samples = %d, want 1", len(hist2.PRTimeToMerge))
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-2981.

Closes #2981

## Changes

GitHub Issue #2981: fix(autopilot): record merge metrics for externally-merged PRs

## Problem

Pilot's Prometheus counters for issues processed, PRs merged, and PR time-to-merge are all stuck at 0 despite real merges happening.

Verified on v2.146.1 (2026-05-09):

```
pilot_issues_processed_total{result="success"} = 0
pilot_prs_merged_total = 0
pilot_pr_time_to_merge_seconds_count = 0
pilot_success_rate = 0
```

Despite #2959, #2962, #2966 merging earlier today and 1369 completed executions in `executions` SQLite table over the daemon's lifetime.

## Root cause

`RecordPRMerged()` / `RecordIssueProcessed("success")` / `RecordPRTimeToMerge()` are only called from `internal/autopilot/controller.go:1185-1187` inside `handleMerging()`, which runs ONLY when autopilot performs the merge itself via `MergePR()`.

In `--env stage` mode GitHub Actions auto-merge handles the merge after CI passes. Autopilot's `MergePR()` is never called → `handleMerging()` never runs → recorders never fire.

`ScanRecentlyMergedPRs()` (controller.go:2096-2229) already polls GitHub for externally-merged Pilot PRs on a ticker, but assigns `Stage=StageReleasing` to discovered rows, skipping the `StageMerged` handler entirely. So the safety net exists for release pipelining but not for metrics.

## Acceptance criteria

1. New helper `Controller.recordMergeSuccess(prState *PRState)` in `internal/autopilot/controller.go` that fires:
   - `c.metrics.RecordPRMerged()`
   - `c.metrics.RecordIssueProcessed("success")`
   - `c.metrics.RecordPRTimeToMerge(time.Since(prState.CreatedAt))` (skip if `prState.CreatedAt.IsZero()` — defensive)

2. Replace lines 1185-1187 in `handleMerging()` with a call to the new helper. Behavior unchanged for autopilot-merged PRs.

3. In `ScanRecentlyMergedPRs()`, before persisting newly-discovered externally-merged PR via `SavePRState()`:
   - Check if a prior PRState row exists for that PR number via `c.stateStore.GetPRState(prNumber)`.
   - If no prior row exists, call `c.recordMergeSuccess(prState)` before saving (first-time discovery = real merge event).
   - If prior row exists already at `StageReleasing` or `StageMerged`, do NOT call recorder (idempotency guard — scan runs every ~15min and may re-discover the same PR).

4. Unit test in `internal/autopilot/controller_test.go`:
   - Setup: fake `ghClient` returning a closed+merged PR on a `pilot/GH-NNN` branch that is NOT in `state_store`.
   - Inject a counting `*Metrics` instance.
   - Call `ScanRecentlyMergedPRs(ctx)`.
   - Assert: `metrics.PRsMerged == 1`, `metrics.IssuesProcessed["success"] == 1`, `len(metrics.PRTimeToMerge) == 1`.
   - Run `ScanRecentlyMergedPRs(ctx)` a second time → counts unchanged (idempotency).

5. No regression in existing `handleMerging` test coverage — recorders still fire exactly once per autopilot-driven merge.

## Out of scope

- Why `autopilot_pr_state` has only 14 historical rows (separate issue: `OnPRCreated` may not be wired for stage-mode PR creation). The fix above closes the metrics gap regardless via the scanner safety net.
- Token / cost / execution-duration recorders — those are wired via `MetricsRecorder` interface in the executor and live on a different path. Verify separately after this fix lands.

## Files to change

- `internal/autopilot/controller.go` — extract helper, add scanner call (~25 lines added)
- `internal/autopilot/controller_test.go` — new test (~80 lines)

## References

- Inventory: ScanRecentlyMergedPRs at controller.go:2096-2229
- Existing call site: controller.go:1185-1187
- State store: internal/autopilot/state_store.go:149-189