### PR TITLE
fix(autopilot): hoist merge-metric recorder before scanner skip gates

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -142,6 +142,11 @@ type Controller struct {
 	activePRs map[int]*PRState
 	mu        sync.RWMutex
 
+	// Merge-metric idempotency: tracks PR numbers we've already recorded
+	// merge-success metrics for, so handleMerging + ScanRecentlyMergedPRs
+	// can both call recordMergeSuccess without double-counting.
+	recordedMerges map[int]bool
+
 	// Persistent state store (optional, nil = in-memory only)
 	stateStore *StateStore
 
@@ -183,6 +188,7 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 		owner:          owner,
 		repo:           repo,
 		activePRs:      make(map[int]*PRState),
+		recordedMerges: make(map[int]bool),
 		prFailures:     make(map[int]*prFailureState),
 		lastProgressAt: time.Now(), // Initialize to now to avoid false alarm on startup
 		metrics:        NewMetrics(),
@@ -2002,9 +2008,20 @@ func (c *Controller) Metrics() *Metrics {
 	return c.metrics
 }
 
-// recordMergeSuccess fires the three merge-success metrics counters.
+// recordMergeSuccess fires the three merge-success metrics counters exactly
+// once per PR number per daemon lifetime. Safe to call from any path that
+// observes a Pilot PR transitioning to merged (handleMerging for
+// autopilot-driven merges, ScanRecentlyMergedPRs for externally-merged PRs).
 // Skips the time-to-merge histogram if prState.CreatedAt is zero (defensive).
 func (c *Controller) recordMergeSuccess(prState *PRState) {
+	c.mu.Lock()
+	if c.recordedMerges[prState.PRNumber] {
+		c.mu.Unlock()
+		return
+	}
+	c.recordedMerges[prState.PRNumber] = true
+	c.mu.Unlock()
+
 	c.metrics.RecordPRMerged()
 	c.metrics.RecordIssueProcessed("success")
 	if !prState.CreatedAt.IsZero() {
@@ -2171,6 +2188,26 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			continue
 		}
 
+		// Extract issue number from branch name (optional)
+		var issueNum int
+		if strings.HasPrefix(pr.Head.Ref, "pilot/GH-") {
+			_, _ = fmt.Sscanf(pr.Head.Ref, "pilot/GH-%d", &issueNum)
+		}
+
+		// Record merge metrics BEFORE the activePRs/release-exists skip gates
+		// below — those gates exist to avoid duplicate release triggering, but
+		// the metric must fire on every discovered merged Pilot PR regardless
+		// of whether a release tag already exists or whether autopilot tracked
+		// the PR through creation. recordMergeSuccess is idempotent via
+		// recordedMerges so handleMerging + scanner can both call it.
+		// Use pr.CreatedAt for a meaningful time-to-merge sample; fall back to
+		// mergedAt so the histogram still records on PRs missing CreatedAt.
+		createdAt, _ := time.Parse(time.RFC3339, pr.CreatedAt)
+		if createdAt.IsZero() {
+			createdAt = mergedAt
+		}
+		c.recordMergeSuccess(&PRState{PRNumber: pr.Number, CreatedAt: createdAt})
+
 		// Skip if already tracked in activePRs (avoid duplicate processing)
 		c.mu.RLock()
 		_, alreadyTracked := c.activePRs[pr.Number]
@@ -2186,12 +2223,6 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 				"merge_sha", ShortSHA(pr.MergeCommitSHA),
 			)
 			continue
-		}
-
-		// Extract issue number from branch name (optional)
-		var issueNum int
-		if strings.HasPrefix(pr.Head.Ref, "pilot/GH-") {
-			_, _ = fmt.Sscanf(pr.Head.Ref, "pilot/GH-%d", &issueNum)
 		}
 
 		c.log.Info("found merged Pilot PR needing release",
@@ -2214,21 +2245,6 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			EnvironmentName: c.config.EnvironmentName(),
 			PRTitle:         pr.Title,
 			TargetBranch:    pr.Base.Ref,
-		}
-
-		// Record merge metrics for externally-merged PRs that we haven't seen
-		// before. If a prior row already exists at StageReleasing or StageMerged
-		// this is a re-discovery on a subsequent scan tick — skip to stay idempotent.
-		if c.stateStore != nil {
-			prior, err := c.stateStore.GetPRState(pr.Number)
-			if err != nil {
-				c.log.Warn("failed to check prior PR state for metrics", "pr", pr.Number, "error", err)
-			} else if prior == nil {
-				c.recordMergeSuccess(prState)
-			}
-		} else {
-			// No state store — fire on first (and only) in-memory encounter.
-			c.recordMergeSuccess(prState)
 		}
 
 		// Register and trigger release

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -5991,3 +5991,129 @@ func TestController_ScanRecentlyMergedPRs_RecordsMetrics(t *testing.T) {
 		t.Errorf("after second scan (idempotency): PRTimeToMerge samples = %d, want 1", len(hist2.PRTimeToMerge))
 	}
 }
+
+// TestController_ScanRecentlyMergedPRs_RecordsMetricsDespiteExistingRelease
+// reproduces the bug where Pilot's own self-release pipeline always tags every
+// merge within ~1min, so by the time the ~5-15min scanner tick runs the
+// "release already exists" gate at line 2186 skips the PR before metrics
+// fire. The recorder must fire BEFORE the gate so counters move in
+// stage-mode auto-merge.
+func TestController_ScanRecentlyMergedPRs_RecordsMetricsDespiteExistingRelease(t *testing.T) {
+	recentMergedAt := time.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339)
+	recentCreatedAt := time.Now().Add(-12 * time.Minute).UTC().Format(time.RFC3339)
+	mergeSHA := "merge-sha-99"
+
+	pilotPR := github.PullRequest{
+		Number:         99,
+		Head:           github.PRRef{Ref: "pilot/GH-501", SHA: "headsha99"},
+		Base:           github.PRRef{Ref: "main"},
+		HTMLURL:        "https://github.com/owner/repo/pull/99",
+		Title:          "feat(api): another endpoint",
+		Merged:         true,
+		CreatedAt:      recentCreatedAt,
+		MergedAt:       recentMergedAt,
+		MergeCommitSHA: mergeSHA,
+	}
+
+	// Release already exists for the merge SHA (Pilot's self-shipping pattern).
+	existingRelease := github.Release{
+		TagName:         "v9.9.9",
+		TargetCommitish: mergeSHA,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{&pilotPR})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/releases"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Release{&existingRelease})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{
+		Enabled:   true,
+		Trigger:   "on_merge",
+		TagPrefix: "v",
+	}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	store := newTestStateStore(t)
+	c.SetStateStore(store)
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("first ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	snap := c.metrics.Snapshot()
+	if snap.PRsMerged != 1 {
+		t.Errorf("PRsMerged = %d, want 1 (recorder must fire even when release tag exists)", snap.PRsMerged)
+	}
+	if snap.IssuesProcessed["success"] != 1 {
+		t.Errorf("IssuesProcessed[success] = %d, want 1", snap.IssuesProcessed["success"])
+	}
+	hist := c.metrics.HistogramSnapshot()
+	if len(hist.PRTimeToMerge) != 1 {
+		t.Errorf("PRTimeToMerge samples = %d, want 1", len(hist.PRTimeToMerge))
+	}
+
+	// Verify release-exists gate still suppresses release triggering: PR should
+	// NOT have been added to activePRs (would happen if scanner proceeded past
+	// the gate).
+	c.mu.RLock()
+	_, tracked := c.activePRs[99]
+	c.mu.RUnlock()
+	if tracked {
+		t.Error("PR 99 was added to activePRs; release-exists gate should still suppress release triggering")
+	}
+
+	// Second scan: counts unchanged (idempotency).
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("second ScanRecentlyMergedPRs() error = %v", err)
+	}
+	snap2 := c.metrics.Snapshot()
+	if snap2.PRsMerged != 1 {
+		t.Errorf("after second scan: PRsMerged = %d, want 1 (idempotent)", snap2.PRsMerged)
+	}
+}
+
+// TestController_RecordMergeSuccess_Idempotency verifies recordMergeSuccess
+// fires exactly once per PR number even when called multiple times from
+// different code paths (e.g. handleMerging + ScanRecentlyMergedPRs both
+// observing the same PR).
+func TestController_RecordMergeSuccess_Idempotency(t *testing.T) {
+	c := NewController(DefaultConfig(), nil, nil, "owner", "repo")
+
+	createdAt := time.Now().Add(-10 * time.Minute)
+	prState := &PRState{PRNumber: 42, CreatedAt: createdAt}
+
+	c.recordMergeSuccess(prState)
+	c.recordMergeSuccess(prState)
+	c.recordMergeSuccess(prState)
+
+	snap := c.metrics.Snapshot()
+	if snap.PRsMerged != 1 {
+		t.Errorf("PRsMerged = %d after 3 calls, want 1", snap.PRsMerged)
+	}
+	if snap.IssuesProcessed["success"] != 1 {
+		t.Errorf("IssuesProcessed[success] = %d after 3 calls, want 1", snap.IssuesProcessed["success"])
+	}
+	hist := c.metrics.HistogramSnapshot()
+	if len(hist.PRTimeToMerge) != 1 {
+		t.Errorf("PRTimeToMerge samples = %d after 3 calls, want 1", len(hist.PRTimeToMerge))
+	}
+
+	// Different PR number → fires independently.
+	c.recordMergeSuccess(&PRState{PRNumber: 43, CreatedAt: createdAt})
+	snap2 := c.metrics.Snapshot()
+	if snap2.PRsMerged != 2 {
+		t.Errorf("PRsMerged = %d after second PR, want 2", snap2.PRsMerged)
+	}
+}


### PR DESCRIPTION
## Summary

- TASK-59 (v2.146.2) placed the merge-metric recorder AFTER three skip gates in `ScanRecentlyMergedPRs`. Pilot's self-release pipeline tags every merge within ~1min, so the next scanner tick (every 5-15min) always hits the "release already exists" gate before the recorder fires. Counters stay at 0 forever.
- Hoist `recordMergeSuccess` to run immediately after merged+window filters, before any skip gates. The gates exist to avoid duplicate release triggering — they should not gate observability.
- Move idempotency from per-call `stateStore.GetPRState` lookups to an in-memory `recordedMerges map[int]bool` on Controller, protected by the existing mu. `recordMergeSuccess` now check-and-sets internally, so `handleMerging` + scanner can both call it freely.
- Use `pr.CreatedAt` (parsed RFC3339) for a meaningful time-to-merge sample, fall back to `mergedAt` when missing.

## Test plan
- [x] `go test ./internal/autopilot/... -count=1` (43s, all pass)
- [x] `go vet ./internal/autopilot/...`
- [x] `make lint` → 0 issues
- [x] New: `TestController_ScanRecentlyMergedPRs_RecordsMetricsDespiteExistingRelease` reproduces the bug (PR + release tag → old code skipped, new code records)
- [x] New: `TestController_RecordMergeSuccess_Idempotency` (three calls → counts of 1; different PR → counts independently)
- [x] Existing `TestController_ScanRecentlyMergedPRs_RecordsMetrics` (TASK-59 test) still passes — new code path matches expectations
- [ ] Post-merge live verification: after next stage-mode merge, `curl :9091/metrics | grep pilot_prs_merged_total` should flip 0 → 1 within ~15min (scanner tick cadence)