### PR TITLE
GH-3002: chore(observability): redesign Grafana dashboard with accurate queries and missing panels

### DIFF
--- a/deploy/grafana/pilot-dashboard.json
+++ b/deploy/grafana/pilot-dashboard.json
@@ -1,8 +1,8 @@
 {
   "uid": "pilot",
-  "title": "Pilot Dashboard",
+  "title": "Pilot Pipeline",
   "schemaVersion": 39,
-  "version": 1,
+  "version": 2,
   "refresh": "30s",
   "time": {
     "from": "now-6h",
@@ -21,9 +21,9 @@
   "panels": [
     {
       "id": 1,
-      "title": "Success Rate",
+      "title": "Success Rate (1h)",
       "type": "stat",
-      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "options": {
         "reduceOptions": {
@@ -34,31 +34,30 @@
         "orientation": "auto",
         "textMode": "auto",
         "colorMode": "background",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto"
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "percentunit",
+          "unit": "percent",
+          "decimals": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               { "color": "red", "value": null },
-              { "color": "yellow", "value": 0.7 },
-              { "color": "green", "value": 0.9 }
+              { "color": "yellow", "value": 50 },
+              { "color": "green", "value": 80 }
             ]
           },
           "mappings": [],
-          "color": {
-            "mode": "thresholds"
-          }
+          "color": { "mode": "thresholds" }
         },
         "overrides": []
       },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "pilot_success_rate",
+          "expr": "(sum(increase(pilot_executions_total{result=\"success\"}[1h])) or vector(0)) / clamp_min(sum(increase(pilot_executions_total[1h])), 1) * 100",
           "legendFormat": "Success Rate",
           "refId": "A"
         }
@@ -66,67 +65,52 @@
     },
     {
       "id": 2,
-      "title": "Queue Depth",
-      "type": "timeseries",
-      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "title": "Active PRs",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom" }
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
       },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "color": { "mode": "palette-classic" }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "mappings": [],
+          "color": { "mode": "thresholds" }
         },
         "overrides": []
       },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "pilot_queue_depth",
-          "legendFormat": "Queue Depth",
+          "expr": "pilot_active_prs_total",
+          "legendFormat": "Active PRs",
           "refId": "A"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "pilot_failed_queue_depth",
-          "legendFormat": "Failed Queue Depth",
-          "refId": "B"
         }
       ]
     },
     {
       "id": 3,
-      "title": "Issue Throughput",
-      "type": "timeseries",
-      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "options": {
-        "tooltip": { "mode": "multi", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom" }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "reqps",
-          "color": { "mode": "palette-classic" }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "rate(pilot_issues_processed_total[5m])",
-          "legendFormat": "{{result}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "id": 4,
-      "title": "Active PRs",
-      "type": "bargauge",
-      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "title": "Queue Depth",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "options": {
         "reduceOptions": {
@@ -135,14 +119,14 @@
           "values": false
         },
         "orientation": "horizontal",
-        "displayMode": "gradient",
-        "valueMode": "color",
-        "showUnfilled": true
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
       },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "color": { "mode": "palette-classic" },
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -150,180 +134,42 @@
               { "color": "yellow", "value": 5 },
               { "color": "red", "value": 10 }
             ]
+          },
+          "mappings": [],
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Failed" },
+            "properties": [
+              {
+                "id": "color",
+                "value": { "fixedColor": "red", "mode": "fixed" }
+              }
+            ]
           }
-        },
-        "overrides": []
+        ]
       },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "pilot_active_prs",
-          "legendFormat": "{{stage}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "id": 5,
-      "title": "Execution Duration P95",
-      "type": "timeseries",
-      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "options": {
-        "tooltip": { "mode": "single", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom" }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "color": { "mode": "palette-classic" }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "histogram_quantile(0.95, rate(pilot_execution_duration_seconds_bucket[5m]))",
-          "legendFormat": "P95",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "id": 6,
-      "title": "CI Wait P50",
-      "type": "timeseries",
-      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "options": {
-        "tooltip": { "mode": "single", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom" }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "color": { "mode": "palette-classic" }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "histogram_quantile(0.50, rate(pilot_ci_wait_duration_seconds_bucket[5m]))",
-          "legendFormat": "P50",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "id": 7,
-      "title": "PR Outcomes",
-      "type": "timeseries",
-      "gridPos": { "x": 0, "y": 24, "w": 12, "h": 8 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "options": {
-        "tooltip": { "mode": "multi", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom" }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "reqps",
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "fillOpacity": 20,
-            "stacking": { "mode": "normal", "group": "A" }
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "rate(pilot_prs_merged_total[1h]) * 3600",
-          "legendFormat": "Merged",
+          "expr": "pilot_queue_depth",
+          "legendFormat": "Active",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "rate(pilot_prs_failed_total[1h]) * 3600",
+          "expr": "pilot_failed_queue_depth",
           "legendFormat": "Failed",
           "refId": "B"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "rate(pilot_prs_conflicting_total[1h]) * 3600",
-          "legendFormat": "Conflicting",
-          "refId": "C"
         }
       ]
     },
     {
-      "id": 8,
-      "title": "Circuit Breaker & API Errors",
-      "type": "timeseries",
-      "gridPos": { "x": 12, "y": 24, "w": 12, "h": 8 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "options": {
-        "tooltip": { "mode": "multi", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom" }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": { "mode": "palette-classic" }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "rate(pilot_circuit_breaker_trips_total[5m])",
-          "legendFormat": "Circuit Breaker Trips",
-          "refId": "A"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "rate(pilot_api_errors_total[5m])",
-          "legendFormat": "API Errors ({{endpoint}})",
-          "refId": "B"
-        }
-      ]
-    },
-    {
-      "id": 9,
-      "title": "Tokens/5m",
-      "type": "timeseries",
-      "gridPos": { "x": 0, "y": 32, "w": 6, "h": 8 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "options": {
-        "tooltip": { "mode": "multi", "sort": "none" },
-        "legend": { "displayMode": "list", "placement": "bottom" }
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "fillOpacity": 20,
-            "stacking": { "mode": "normal", "group": "A" }
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "rate(pilot_tokens_consumed_total[5m])",
-          "legendFormat": "{{model}}/{{direction}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "id": 10,
-      "title": "Cumulative Cost (USD)",
+      "id": 4,
+      "title": "Cost (last 1h)",
       "type": "stat",
-      "gridPos": { "x": 6, "y": 32, "w": 6, "h": 8 },
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "options": {
         "reduceOptions": {
@@ -340,13 +186,13 @@
       "fieldConfig": {
         "defaults": {
           "unit": "currencyUSD",
-          "decimals": 4,
+          "decimals": 2,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               { "color": "green", "value": null },
               { "color": "yellow", "value": 1 },
-              { "color": "red", "value": 10 }
+              { "color": "red", "value": 5 }
             ]
           },
           "mappings": [],
@@ -357,17 +203,301 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(pilot_execution_cost_usd_total)",
-          "legendFormat": "Total Cost",
+          "expr": "sum(increase(pilot_execution_cost_usd_total[1h]))",
+          "legendFormat": "Cost/1h",
           "refId": "A"
         }
       ]
     },
     {
-      "id": 11,
-      "title": "Cost/hour",
+      "id": 5,
+      "title": "PR Time-to-Merge",
       "type": "timeseries",
-      "gridPos": { "x": 12, "y": 32, "w": 6, "h": 8 },
+      "gridPos": { "x": 0, "y": 4, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, sum(rate(pilot_pr_time_to_merge_seconds_bucket[15m])) by (le))",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(pilot_pr_time_to_merge_seconds_bucket[15m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Execution Duration",
+      "type": "timeseries",
+      "gridPos": { "x": 6, "y": 4, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, sum(rate(pilot_execution_duration_seconds_bucket[15m])) by (le))",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(pilot_execution_duration_seconds_bucket[15m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "CI Wait Duration",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 4, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, sum(rate(pilot_ci_wait_duration_seconds_bucket[15m])) by (le))",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(pilot_ci_wait_duration_seconds_bucket[15m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Active PRs by Stage",
+      "type": "timeseries",
+      "gridPos": { "x": 18, "y": 4, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 20,
+            "stacking": { "mode": "normal", "group": "A" }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "pilot_active_prs",
+          "legendFormat": "{{stage}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Executions / Hour",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 12, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 20,
+            "stacking": { "mode": "normal", "group": "A" }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (result) (increase(pilot_executions_total[1h]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "PR Outcomes / Hour",
+      "type": "timeseries",
+      "gridPos": { "x": 6, "y": 12, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 20,
+            "stacking": { "mode": "normal", "group": "A" }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(pilot_prs_merged_total[1h])",
+          "legendFormat": "Merged",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(pilot_prs_failed_total[1h])",
+          "legendFormat": "Failed",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(pilot_prs_conflicting_total[1h])",
+          "legendFormat": "Conflicting",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "title": "API Errors / Hour",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 12, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (endpoint) (increase(pilot_api_errors_total[1h]))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "title": "Circuit Breaker Trips / Hour",
+      "type": "timeseries",
+      "gridPos": { "x": 18, "y": 12, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "fixedColor": "orange", "mode": "fixed" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(pilot_circuit_breaker_trips_total[1h])",
+          "legendFormat": "Trips/hr",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "title": "Cumulative Cost (USD)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 20, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2,
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(pilot_execution_cost_usd_total)",
+          "legendFormat": "Total",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "title": "Cost / Hour by Model",
+      "type": "timeseries",
+      "gridPos": { "x": 6, "y": 20, "w": 6, "h": 8 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "options": {
         "tooltip": { "mode": "multi", "sort": "none" },
@@ -376,9 +506,11 @@
       "fieldConfig": {
         "defaults": {
           "unit": "currencyUSD",
+          "decimals": 2,
           "color": { "mode": "palette-classic" },
           "custom": {
-            "axisLabel": "USD/hour"
+            "fillOpacity": 20,
+            "stacking": { "mode": "normal", "group": "A" }
           }
         },
         "overrides": []
@@ -386,28 +518,51 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "rate(pilot_execution_cost_usd_total[5m]) * 3600",
+          "expr": "sum by (model) (increase(pilot_execution_cost_usd_total[1h]))",
           "legendFormat": "{{model}}",
           "refId": "A"
         }
       ]
     },
     {
-      "id": 12,
-      "title": "Executions by Result",
-      "type": "bargauge",
-      "gridPos": { "x": 18, "y": 32, "w": 6, "h": 8 },
+      "id": 15,
+      "title": "Tokens / 5m by Model",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 20, "w": 6, "h": 8 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "options": {
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 20,
+            "stacking": { "mode": "normal", "group": "A" }
+          }
         },
-        "orientation": "horizontal",
-        "displayMode": "gradient",
-        "valueMode": "color",
-        "showUnfilled": true
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (model, direction) (increase(pilot_tokens_consumed_total[5m]))",
+          "legendFormat": "{{model}}/{{direction}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "title": "Approval Persist Misses",
+      "type": "timeseries",
+      "gridPos": { "x": 18, "y": 20, "w": 6, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
       },
       "fieldConfig": {
         "defaults": {
@@ -416,8 +571,12 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null }
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
             ]
+          },
+          "custom": {
+            "thresholdsStyle": { "mode": "area" }
           }
         },
         "overrides": []
@@ -425,8 +584,8 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "pilot_executions_total",
-          "legendFormat": "{{model}}/{{result}}",
+          "expr": "sum by (kind) (increase(pilot_approval_persist_misses_total[1h]))",
+          "legendFormat": "{{kind}}",
           "refId": "A"
         }
       ]


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3002.

Closes #3002

## Changes

GitHub Issue #3002: chore(observability): redesign Grafana dashboard with accurate queries and missing panels

## Context

The Grafana dashboard at `deploy/grafana/pilot-dashboard.json` is operationally uninformative in its current form. Concrete defects observed on a live daemon (v2.146.3) with 3 successful executions and $7.83 cumulative cost over the last 6h:

1. **Success Rate panel shows 0% (red)** despite 3 successful executions visible in `Executions by Result`. The query is `pilot_success_rate`, a server-side gauge in `internal/gateway/prometheus.go:144-147` that reads `snap.SuccessRate`. The gauge is unreliable — replace with a PromQL-computed ratio that uses the per-result counter directly.
2. **Rate-based panels appear empty.** `Issue Throughput`, `PR Outcomes`, `Circuit Breaker`, etc. use `rate(...[5m])` with auto-scaled `req/s` units. Pilot operates at roughly 1 issue per 30 min ≈ 0.0005 req/s, which is invisible on a 0–100 req/s axis. Switch all rate panels to `increase(...[1h])` with `count/hour` units; log Y-axis where bursts dominate.
3. **`Active PRs` shows "No data".** The `pilot_active_prs{stage}` gauge depends on `Controller.OnPRCreated` populating `autopilot_pr_state`, which is the active gap tracked by #2999. Until #2999 lands, also surface `pilot_active_prs_total` as a fallback single-stat so this row is never blank.
4. **`Cumulative Cost (USD)` is a giant single-stat** that clips ("$7.8313" → "$7.8313" cut). Replace with a sparkline + value to 2 decimals.
5. **Missing operationally useful metrics.** The exporter at `internal/gateway/prometheus.go:152-167` exposes three histograms; only two have panels:
   - `pilot_pr_time_to_merge_seconds` — **not displayed anywhere**. This is the headline product metric.
   - `pilot_execution_duration_seconds` — P95 only; add P50 for distribution shape
   - `pilot_ci_wait_duration_seconds` — P50 only; add P95
6. **Missing health metrics:** `pilot_approval_persist_misses_total{kind}` (alarming when nonzero — exposed at `prometheus.go:82-92`) has no panel.
7. **Failed Queue Depth is buried** as a secondary series under Queue Depth despite being a distinct signal.

## Approach

Rewrite `deploy/grafana/pilot-dashboard.json` end-to-end. Single file, no Go code, no metric exporter changes. Use a 4×3 panel grid:

- **Row 1 — At-a-glance stats (single-stats, ~6h window):** Active PRs total, Queue Depth (split: active + failed), Executions last 1h (stacked breakdown success/failed/rate_limited), Cost last 1h (2 decimals).
- **Row 2 — Performance histograms (P50 + P95):** PR time-to-merge, Execution duration, CI wait, Active PRs by stage (stacked time-series).
- **Row 3 — Volume per hour (stacked area):** Executions/hr by result, PR outcomes/hr by outcome, API errors/hr by endpoint, Circuit breaker trips/hr.
- **Row 4 — Cost / tokens / health:** Cumulative cost (line, not stat), Cost/hour by model, Tokens by model + direction, Approval persist misses by kind.

## Implementation

**File:** `deploy/grafana/pilot-dashboard.json` (only file touched)

**Query reference (use these verbatim, then build the panel JSON around them):**

| Panel | PromQL |
|---|---|
| Success rate (1h window) | `(sum(increase(pilot_executions_total{result="success"}[1h])) or vector(0)) / clamp_min(sum(increase(pilot_executions_total[1h])), 1) * 100` (unit: percent, thresholds 0–50 red, 50–80 yellow, 80–100 green) |
| Active PRs total | `pilot_active_prs_total` |
| Active PRs by stage | `pilot_active_prs` (legend: `{{stage}}`, stacked) |
| Queue depth | `pilot_queue_depth` and `pilot_failed_queue_depth` (two series, different colors) |
| Executions last 1h | `sum by (result) (increase(pilot_executions_total[1h]))` (stat panel, calc: last, multi-row breakdown) |
| Cost last 1h | `sum(increase(pilot_execution_cost_usd_total[1h]))` (unit: currency USD, 2 decimals) |
| PR time-to-merge P50 | `histogram_quantile(0.50, sum(rate(pilot_pr_time_to_merge_seconds_bucket[15m])) by (le))` (unit: seconds → grafana auto-formats to min/hr) |
| PR time-to-merge P95 | `histogram_quantile(0.95, sum(rate(pilot_pr_time_to_merge_seconds_bucket[15m])) by (le))` |
| Execution duration P50/P95 | same shape against `pilot_execution_duration_seconds_bucket` |
| CI wait P50/P95 | same shape against `pilot_ci_wait_duration_seconds_bucket` |
| Executions/hr by result | `sum by (result) (increase(pilot_executions_total[1h]))` (time-series, stacked area, unit: short) |
| PR outcomes/hr | `increase(pilot_prs_merged_total[1h])`, `_failed_total`, `_conflicting_total` (three series, stacked) |
| API errors/hr by endpoint | `sum by (endpoint) (increase(pilot_api_errors_total[1h]))` |
| Circuit breaker trips/hr | `increase(pilot_circuit_breaker_trips_total[1h])` |
| Cumulative cost | `sum(pilot_execution_cost_usd_total)` (time-series, area, unit: currency USD) |
| Cost/hour by model | `sum by (model) (increase(pilot_execution_cost_usd_total[1h]))` (stacked) |
| Tokens by model+direction | `sum by (model, direction) (increase(pilot_tokens_consumed_total[5m]))` (legend: `{{model}}/{{direction}}`) |
| Approval persist misses | `sum by (kind) (increase(pilot_approval_persist_misses_total[1h]))` (unit: short, threshold: any value > 0 → red) |

**Units & axis conventions to apply:**
- All rate/volume panels: `count/hour`, not `req/s`. Use Grafana unit `short` with a `/h` suffix, OR switch to `increase(...[1h])` so the raw number is already counts/hour.
- All histogram-quantile panels: leave unit as `s` (seconds) — Grafana formats to min/hr automatically.
- Cost panels: unit `currencyUSD`, decimals=2, no fluid font scaling beyond what fits the panel.
- Y-axis on volume panels: keep linear (most bursts are within a single order of magnitude); switch to log only if the panel proves cramped.

**Layout:** 4 rows × 3 columns, 24-grid Grafana layout. Single-stats in row 1 are 8 grid units wide each (8+8+8); panels in rows 2–4 are 8 wide each. Heights: row 1 = 4 units (compact stats), rows 2–4 = 8 units.

**Dashboard metadata:**
- Title: `Pilot Pipeline` (keep)
- Default time range: `now-6h` (keep)
- Refresh: `30s` (keep)
- Datasource UID: keep whatever is currently in the JSON

**Verify the change:**

```bash
# JSON well-formed
jq . deploy/grafana/pilot-dashboard.json > /dev/null

# Reload Grafana provisioner
cd deploy/grafana && docker-compose restart grafana

# Visit http://localhost:3334 and confirm:
#  - Success Rate panel reads from PromQL ratio (not pilot_success_rate gauge)
#  - All rate panels show counts (not req/s)
#  - PR time-to-merge panel exists with P50 and P95
#  - Approval persist misses panel exists
```

No application code touched. No metric exporter changes. No tests added (this is dashboard config).

## Acceptance

- [ ] `deploy/grafana/pilot-dashboard.json` rewritten with the 4×3 grid above
- [ ] All 16 panels use the PromQL queries from the table verbatim
- [ ] Success Rate panel no longer uses the broken `pilot_success_rate` gauge
- [ ] PR time-to-merge panel exists with both P50 and P95 series
- [ ] Approval persist misses panel exists with threshold coloring
- [ ] Active PRs has both a single-stat (total) and a by-stage stacked panel
- [ ] No rate-per-second units on any panel; all volume panels show counts/hour
- [ ] Cost single-stat formatted to 2 decimals with `currencyUSD` unit
- [ ] `jq .` validates the JSON cleanly
- [ ] No Go files modified, no tests added or changed
- [ ] No changes outside `deploy/grafana/`

## Refs

- Exporter: `internal/gateway/prometheus.go` (metric inventory above is canonical — do not invent new metric names)
- Current dashboard: `deploy/grafana/pilot-dashboard.json` (replace, do not append)
- Companion issue: #2999 (OnPRCreated instrumentation — populates `pilot_active_prs` for this dashboard)
- Memory pattern: `pattern_observability_before_gates.md`

---

<!-- pilot-execution-mode: single-shot, no-decompose -->

**To the executor:** This is a single JSON file rewrite (~300–500 lines of dashboard JSON). Do NOT decompose — there is no useful split point. Sibling task #2999 today went sideways under decomposition (#2988 crash + #2991 OOM); keep this one tight, single PR, dashboard JSON only.
