### PR TITLE
GH-3006: fix(observability): emit zero for absent stages in pilot_active_prs gauge export

### DIFF
--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -388,6 +388,25 @@ const (
 	StageFailed PRStage = "failed"
 )
 
+// AllPRStages returns every defined PRStage value. Used by the Prometheus exporter
+// to emit zero-values for stages absent from the current snapshot, preventing
+// Prometheus's 5-min lookback from holding stale non-zero values.
+func AllPRStages() []PRStage {
+	return []PRStage{
+		StagePRCreated,
+		StageWaitingCI,
+		StageCIPassed,
+		StageCIFailed,
+		StageAwaitApproval,
+		StageMerging,
+		StageMerged,
+		StagePostMergeCI,
+		StageReleasing,
+		StageReviewRequested,
+		StageFailed,
+	}
+}
+
 // CIStatus represents the current CI check state.
 type CIStatus string
 

--- a/internal/gateway/prometheus.go
+++ b/internal/gateway/prometheus.go
@@ -130,6 +130,15 @@ func (e *PrometheusExporter) WritePrometheus(w io.Writer) error {
 	for stage, count := range snap.ActivePRsByStage {
 		writeGaugeLabeled(w, "pilot_active_prs", float64(count), "stage", string(stage))
 	}
+	// Emit zero for every defined stage not present in the snapshot so that
+	// Prometheus's 5-min lookback does not hold stale non-zero values after a
+	// stage transition. Mirrors the pattern at lines 41-46 (pilot_issues_processed_total)
+	// and lines 88-92 (pilot_approval_persist_misses_total).
+	for _, stage := range autopilot.AllPRStages() {
+		if _, exists := snap.ActivePRsByStage[stage]; !exists {
+			writeGaugeLabeled(w, "pilot_active_prs", 0, "stage", string(stage))
+		}
+	}
 
 	// pilot_active_prs_total
 	writeHelp(w, "pilot_active_prs_total", "Total number of active PRs")

--- a/internal/gateway/prometheus_test.go
+++ b/internal/gateway/prometheus_test.go
@@ -123,6 +123,26 @@ func TestPrometheusExporter_WritePrometheus(t *testing.T) {
 			},
 		},
 		{
+			name: "absent stages emitted as zero",
+			source: &mockMetricsSource{
+				snapshot: autopilot.MetricsSnapshot{
+					IssuesProcessed: make(map[string]int64),
+					APIErrors:       make(map[string]int64),
+					LabelCleanups:   make(map[string]int64),
+					ActivePRsByStage: map[autopilot.PRStage]int{
+						autopilot.StageCIPassed: 1,
+					},
+				},
+				histogramSnapshot: autopilot.HistogramData{},
+			},
+			contains: []string{
+				`pilot_active_prs{stage="ci_passed"} 1`,
+				`pilot_active_prs{stage="waiting_ci"} 0`,
+				`pilot_active_prs{stage="merging"} 0`,
+				`pilot_active_prs{stage="merged"} 0`,
+			},
+		},
+		{
 			name: "histogram with samples",
 			source: &mockMetricsSource{
 				snapshot: autopilot.MetricsSnapshot{


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3006.

Closes #3006

## Changes

GitHub Issue #3006: fix(observability): emit zero for absent stages in pilot_active_prs gauge export

## Context

The Prometheus gauge `pilot_active_prs{stage}` shows all 4 transit stages at value `1` simultaneously for a single PR (observed live on the Grafana dashboard with one PR in flight: `waiting_ci=1`, `ci_passed=1`, `merging=1`, `merged=1`). A PR can only be in one autopilot stage at a time, so this looks like a controller-side leak — but it isn't.

A `navigator-research` pass (2026-05-11) ruled out three hypotheses and identified the actual mechanism:

1. **Not an in-memory leak.** `UpdateActivePRs` at `internal/autopilot/metrics.go:168-177` resets `m.ActivePRsByStage = make(...)` on every poll, then increments per current `pr.Stage`. The map is keyed by `prNumber` (`controller.go:142`), one entry per PR. `TestUpdateActivePRsReset` (`metrics_test.go:340-362`) verifies stale stages drop to 0 in the snapshot.
2. **Not a SQL query bug.** `ActivePRsByStage` is built purely from the in-memory `c.activePRs` map; SQLite is not read for this metric.
3. **Not multi-row per PR.** `state_store` upserts a single row per PR keyed by PR number.

**Actual root cause: Prometheus textfile staleness on dynamic labels combined with exporter incompleteness.**

`internal/gateway/prometheus.go:127-132` only emits `pilot_active_prs{stage=X}` for stages **present** in the snapshot map. When a PR transitions `waiting_ci → ci_passed`, the next scrape contains a `ci_passed` line but **no `waiting_ci` line**. Prometheus does NOT auto-zero a disappearing series — its default lookback (5 min) holds the last scraped value alive. A fast pipeline (`waiting_ci → ci_passed → merging → merged` inside 5 min) legitimately shows all four stages at `=1` in queries until the lookback window expires.

**Proof the fix template already exists in this file.** Two other metrics explicitly emit zero values for absent label-values:
- `pilot_issues_processed_total` at `prometheus.go:41-46` — pre-emits `0` for `success`/`failed`/`rate_limited`
- `pilot_approval_persist_misses_total` at `prometheus.go:88-92` — pre-emits `0` for `request_id`/`decision`

The `pilot_active_prs` block at `prometheus.go:127-132` simply skipped that pattern. The fix is to apply the same idiom to a third gauge.

## Approach

Add a post-loop sweep that emits `pilot_active_prs{stage=X} 0` for every defined `PRStage` not present in `snap.ActivePRsByStage`. Mirrors the existing pattern at lines 41-46 and 88-92. No controller, metrics, or state-store changes.

Stage constants are defined at `internal/autopilot/types.go:367-388`. The exporter needs an authoritative list. Pick one of:

- **Option A (preferred):** add `AllPRStages() []PRStage` accessor in `types.go` returning the canonical slice. Keeps the source of truth in one place; future stages added there auto-propagate to the exporter.
- **Option B:** hardcode the slice in `prometheus.go`. Faster to write, drifts silently when new stages are added.

Use Option A unless `types.go` is package-private and adding an exported helper requires churn elsewhere — it isn't, both files are in package-different packages and a public accessor is the natural shape.

## Implementation

**File 1:** `internal/autopilot/types.go` — add an `AllPRStages()` accessor returning every value in the `PRStage` enum (look at the existing `const (...)` block at `types.go:367-388` and enumerate). Single function, ~12 lines.

**File 2:** `internal/gateway/prometheus.go:127-132` — after the existing range loop, add a sweep emitting zeros for missing stages. Verbatim shape (do not change the existing loop):

```go
// pilot_active_prs
writeHelp(w, "pilot_active_prs", "Number of active PRs by stage")
writeType(w, "pilot_active_prs", "gauge")
for stage, count := range snap.ActivePRsByStage {
    writeGaugeLabeled(w, "pilot_active_prs", float64(count), "stage", string(stage))
}
// Ensure every defined stage appears in each scrape so disappearing series
// are explicitly zeroed (matches the pattern used for pilot_issues_processed_total
// at lines 41-46 and pilot_approval_persist_misses_total at lines 88-92).
for _, stage := range autopilot.AllPRStages() {
    if _, exists := snap.ActivePRsByStage[stage]; !exists {
        writeGaugeLabeled(w, "pilot_active_prs", 0, "stage", string(stage))
    }
}
```

**File 3:** `internal/gateway/prometheus_test.go` — add a table case that snapshots with `{StageCIPassed: 1}` only, then asserts the rendered output contains both:
- `pilot_active_prs{stage="ci_passed"} 1`
- `pilot_active_prs{stage="waiting_ci"} 0` (or any other defined stage, asserting at least one absent stage is emitted as zero)

Existing tests at `prometheus_test.go:39-132` already exercise the exporter end-to-end — add the new case alongside them; no new test infrastructure required.

**Verification:**

```bash
go build ./...
go test ./internal/gateway/... ./internal/autopilot/...
make lint
```

After merge, restart the daemon and watch the dashboard: within one scrape interval, stages that no PR currently occupies should read `0`, and only the stage holding the live PR should read `1`.

## Acceptance

- [ ] `internal/autopilot/types.go` exports `AllPRStages() []PRStage` returning every value from the `PRStage` const block
- [ ] `internal/gateway/prometheus.go` post-loop sweep emits `0` for missing stages, idiomatically matching lines 41-46 and 88-92
- [ ] `internal/gateway/prometheus_test.go` asserts at least one absent stage is emitted as `pilot_active_prs{stage="..."} 0` in the rendered output
- [ ] `go build ./...` passes
- [ ] `go test ./internal/gateway/... ./internal/autopilot/...` passes
- [ ] `make lint` clean
- [ ] No changes to `controller.go`, `metrics.go`, `state_store.go`, or any other autopilot/state-machine code — this is exporter completeness only
- [ ] PR body includes a one-line explanation of the Prometheus lookback mechanism and a reference to the existing pattern at `prometheus.go:41-46`

## Refs

- Exporter site: `internal/gateway/prometheus.go:127-132`
- Pattern templates already in the same file: `prometheus.go:41-46`, `prometheus.go:88-92`
- Stage constants: `internal/autopilot/types.go:367-388`
- Snapshot computation: `internal/autopilot/metrics.go:168-177`, `metrics.go:244`
- Controller (no change needed — verified clean): `internal/autopilot/controller.go:1815-1823, 2336-2339`
- Test surface to extend: `internal/gateway/prometheus_test.go:39-132`
- Companion: PR #3000 (OnPRCreated instrumentation, just merged) and #3002 (dashboard redesign, in flight)

---

<!-- pilot-execution-mode: single-shot, no-decompose -->

**To the executor:** This is intentionally small (one accessor + ~5 lines in the exporter + one test case). Do NOT decompose — there is no useful split point. Two adjacent issues today (#2999, #3002) demonstrated that decomposing fixes of this size triggered the OOM/crash cascade. Ship as a single focused PR.
