### PR TITLE
GH-3014: docs(autopilot): document OnPRCreated gate semantics in poller.go

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -580,6 +580,7 @@ func (p *Poller) startSequential(ctx context.Context) {
 			)
 		}
 		// Notify autopilot controller of new PR (if callback registered)
+		// Gate: PRNumber > 0 implies executor surfaced a valid PR URL via runner.go:3151. Empty PRUrl (no-commits guard, push-fail, title-rejection) leaves PRNumber=0 and we silently skip — see TASK-60 for the upstream chain.
 		if result != nil && result.PRNumber > 0 && p.OnPRCreated != nil {
 			p.logger.Info("Notifying autopilot of PR creation",
 				slog.Int("pr_number", result.PRNumber),
@@ -1165,6 +1166,7 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 					)
 				}
 				// Notify autopilot controller of new PR
+				// Gate: PRNumber > 0 implies executor surfaced a valid PR URL via runner.go:3151. Empty PRUrl (no-commits guard, push-fail, title-rejection) leaves PRNumber=0 and we silently skip — see TASK-60 for the upstream chain.
 				if result != nil && result.PRNumber > 0 && p.OnPRCreated != nil {
 					p.logger.Info("Notifying autopilot of PR creation (parallel path)",
 						slog.Int("pr_number", result.PRNumber),


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3014.

Closes #3014

## Changes

GitHub Issue #3014: docs(autopilot): document OnPRCreated gate semantics in poller.go

## Context

TASK-60 Phase 1 investigation (2026-05-11) traced why `autopilot_pr_state` rows stopped being written for stage-mode merges. Root cause: the `OnPRCreated` gate at `internal/adapters/github/poller.go:589` (sequential) and `:1174` (parallel) requires `result.PRNumber > 0`, but the executor surfaces `result.PRUrl == ""` in some path, leaving `PRNumber == 0`. The wires are correct; the upstream chain (runner.go:3151 → handler_common.go:250) is the suspect.

The gate semantics are non-obvious from the read site. Future readers will repeat the spelunk. Document the gate inline.

## Implementation

Add **one** `//` comment line immediately above EACH of the two `OnPRCreated` gates in `internal/adapters/github/poller.go` (sequential path ~line 589, parallel path ~line 1174). Both comments must be **verbatim**:

```
// Gate: PRNumber > 0 implies executor surfaced a valid PR URL via runner.go:3151. Empty PRUrl (no-commits guard, push-fail, title-rejection) leaves PRNumber=0 and we silently skip — see TASK-60 for the upstream chain.
```

That is the entire change. Two new comment lines. Zero code/behavior modification.

## Constraints

- **Do NOT decompose** this issue. It's a literal two-line documentation edit. A single-phase implementation. No tests, no refactor, no extras.
- Conventional commit title: `docs(autopilot): document OnPRCreated gate semantics in poller.go`.
- Touch exactly one file: `internal/adapters/github/poller.go`.

## Acceptance

- [ ] Both `OnPRCreated` gates in `poller.go` have the verbatim comment line directly above
- [ ] `git diff --stat origin/main...HEAD` shows exactly `internal/adapters/github/poller.go | 2 ++` (or similar — only that file, only additions)
- [ ] `make build` and `make lint` clean
- [ ] No other files modified

<!-- autopilot-meta no-decompose: true -->