### PR TITLE
feat(executor): refuse sub-issue creation on unmanaged repos

### DIFF
--- a/.agent/sops/integrations/repo-allowlist-guardrail.md
+++ b/.agent/sops/integrations/repo-allowlist-guardrail.md
@@ -1,0 +1,132 @@
+# SOP: Repo allowlist guardrail (TASK-286 / GH-3027)
+
+> **When to read this:** you see `sub-issue guardrail rejected target repo`
+> in Pilot logs, or `ErrRepoNotInConfig` surfaced in a task error.
+
+## What it does
+
+Before Pilot's epic decomposer shells out to `gh issue create` (or even
+`gh issue list` for the dedup check), it resolves the worktree's `origin`
+remote to `owner/repo` and refuses to proceed unless that pair matches a
+project in the user's `~/.pilot/config.yaml`.
+
+Filed after the 2026-05-20 incident on the upstream `qf-studio/pilot`,
+where an external user's misconfigured Pilot fired 6 duplicate sub-issues
+(#3021–#3026) before the decomposer ran out of subtasks.
+
+Chokepoint: `internal/executor/repo_guardrail.go::ValidateTargetRepo`,
+invoked from `internal/executor/epic.go::CreateSubIssues` before any `gh`
+call. Wired onto the Runner via `cmd/pilot/repo_allowlist.go`.
+
+## Symptom
+
+Pilot logs one of:
+
+```
+ERROR sub-issue guardrail rejected target repo
+  owner=qf-studio repo=pilot execution_path=...
+  error="target repo is not in user's configured project list: qf-studio/pilot not in configured projects [alice/site]"
+```
+
+or:
+
+```
+ERROR sub-issue guardrail: could not resolve origin remote
+  execution_path=... error="no origin remote found: ..."
+```
+
+The task fails with an error wrapping `executor.ErrRepoNotInConfig`
+(or `ErrNoOriginRemote`).
+
+## Diagnosis checklist
+
+1. **Confirm the target repo is what you expect.**
+   ```sh
+   git -C <executionPath> remote get-url origin
+   ```
+   The output's `owner/repo` is what Pilot resolved. If it surprises you
+   (e.g. it's the upstream rather than your fork), the bug is in your
+   `~/.pilot/config.yaml` or local clone, not in Pilot.
+
+2. **List configured projects.**
+   ```sh
+   yq '.projects[] | "\(.github.owner)/\(.github.repo) -> \(.path)"' \
+     ~/.pilot/config.yaml
+   ```
+   Each `owner/repo` listed here is allowed. If the rejected pair isn't
+   here, that's the immediate cause.
+
+3. **Check for projectPath drift.**
+   The guardrail also rejects "right repo, wrong working tree" — i.e.
+   the configured project's `path` does not match the directory Pilot
+   is executing in. This usually means you have a fork in a different
+   path than the project entry expects.
+
+## Fix paths
+
+**Most common — user pointed Pilot at the wrong repo:**
+
+```yaml
+# ~/.pilot/config.yaml
+projects:
+  - name: my-fork
+    path: /Users/me/projects/my-fork
+    github:
+      owner: my-username     # ← was previously upstream owner
+      repo:  pilot-fork      # ← was previously upstream repo
+```
+
+Re-run; the guardrail will accept.
+
+**Ad-hoc one-off (testing, recovery, debugging):**
+
+```sh
+PILOT_ALLOW_UNMANAGED_REPO=1 pilot run ...
+```
+
+The bypass always logs a WARN with the resolved owner/repo so the action
+remains visible in dashboards and the daemon log:
+
+```
+WARN PILOT_ALLOW_UNMANAGED_REPO=1 bypassed repo allowlist
+  component=executor.repo_guardrail
+  owner=... repo=... project_path=... configured_repos=...
+```
+
+Never set this in `~/.pilot/config.yaml` or a long-lived shell env —
+it disables the safety net.
+
+**Library/SDK use (no allowlist wired):**
+
+If you're calling `executor.NewRunnerWithConfig` directly and didn't
+plumb a `RepoAllowlist`, you'll see:
+
+```
+WARN sub-issue guardrail skipped: no RepoAllowlist configured on Runner;
+  production callers must invoke Runner.SetRepoAllowlist
+```
+
+In production this means cmd/pilot's wiring regressed — fix the
+construction site. In a one-off script, either wire one or accept the
+WARN (the call falls through to the existing `gh` error path, same as
+pre-guardrail).
+
+## What was wrong before this guardrail
+
+`internal/executor/epic.go::createSubIssuesViaGitHub` ran
+`exec.CommandContext(ctx, "gh", "issue", "create", ...)` with
+`cmd.Dir = executionPath` and **no `owner/repo` validation**. `gh`
+infers the target from the directory's `origin` remote, with no
+cross-check against the user's configured projects. A misconfigured
+worktree silently became a write-target for sub-issues.
+
+A partial guard at `internal/executor/runner.go::ValidateRepoProjectMatch`
+existed for the parent task but did not apply to the sub-issue creation
+path.
+
+## Related
+
+- Incident comment: `qf-studio/pilot#3021#issuecomment-4508477616`
+- Task plan: `.agent/tasks/TASK-286-guardrail-external-repo-issue-create.md`
+- Pattern memory: `.agent/knowledge/memories/patterns/pattern_target_repo_validation.md` *(write after merge)*
+- Pitfall memory: `.agent/knowledge/memories/pitfalls/pitfall_external_repo_issue_create.md` *(write after merge)*

--- a/.agent/tasks/TASK-286-guardrail-external-repo-issue-create.md
+++ b/.agent/tasks/TASK-286-guardrail-external-repo-issue-create.md
@@ -1,6 +1,6 @@
 # TASK-286: Guardrail — refuse issue creation on repos outside the user's project list
 
-**Status**: in-progress (handed off to Pilot as [#3027](https://github.com/qf-studio/pilot/issues/3027))
+**Status**: implemented in [feat/task-286-repo-guardrail](https://github.com/qf-studio/pilot/tree/feat/task-286-repo-guardrail), pending PR review (closes [#3027](https://github.com/qf-studio/pilot/issues/3027))
 **Priority**: P1 (data-integrity / reputation)
 **Estimated Effort**: S (3-4 person-hours)
 **Risk Level**: Low (additive validation; opt-out via env var for power users)

--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -435,6 +435,9 @@ Examples:
 				if runnerErr != nil {
 					return fmt.Errorf("failed to create runner for dry-run: %w", runnerErr)
 				}
+				// TASK-286 / GH-3027: harmless on the dry-run path (no gh calls),
+				// but kept for consistency so the wiring is uniform across sites.
+				runner.SetRepoAllowlist(newConfigRepoAllowlist(dryRunCfg))
 				prompt := runner.BuildPrompt(task, task.ProjectPath)
 				fmt.Println(prompt)
 				fmt.Println("─────────────────────────────────────")
@@ -578,6 +581,8 @@ Examples:
 			if runnerErr != nil {
 				return fmt.Errorf("failed to create executor runner: %w", runnerErr)
 			}
+			// TASK-286 / GH-3027: refuse sub-issue creation on unmanaged repos.
+			runner.SetRepoAllowlist(newConfigRepoAllowlist(cfg))
 
 			// GH-962: Clean up orphaned worktree directories from previous crashed executions
 			if cfg.Executor != nil && cfg.Executor.UseWorktree {
@@ -1089,6 +1094,8 @@ Examples:
 				if runnerErr != nil {
 					return fmt.Errorf("failed to create runner for dry-run: %w", runnerErr)
 				}
+				// TASK-286 / GH-3027: harmless on the dry-run path (no gh calls).
+				runner.SetRepoAllowlist(newConfigRepoAllowlist(cfg))
 				prompt := runner.BuildPrompt(task, task.ProjectPath)
 				fmt.Println("Prompt:")
 				fmt.Println("─────────────────────────────────────")
@@ -1108,6 +1115,8 @@ Examples:
 			if runnerErr != nil {
 				return fmt.Errorf("failed to create executor runner: %w", runnerErr)
 			}
+			// TASK-286 / GH-3027: refuse sub-issue creation on unmanaged repos.
+			runner.SetRepoAllowlist(newConfigRepoAllowlist(cfg))
 
 			// GH-962: Clean up orphaned worktree directories from previous crashed executions
 			if cfg.Executor != nil && cfg.Executor.UseWorktree {

--- a/cmd/pilot/interactive.go
+++ b/cmd/pilot/interactive.go
@@ -173,6 +173,8 @@ func interactiveNewTask(cfg *config.Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create runner: %w", err)
 	}
+	// TASK-286 / GH-3027: refuse sub-issue creation on unmanaged repos.
+	runner.SetRepoAllowlist(newConfigRepoAllowlist(cfg))
 	progress := executor.NewProgressDisplay(task.ID, taskDesc, true)
 
 	// Suppress slog progress output when visual display is active

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -342,6 +342,8 @@ Examples:
 				if runnerErr != nil {
 					return fmt.Errorf("failed to create executor runner: %w", runnerErr)
 				}
+				// TASK-286 / GH-3027: refuse sub-issue creation on unmanaged repos.
+				gwRunner.SetRepoAllowlist(newConfigRepoAllowlist(cfg))
 
 				// Set up quality gates on runner if configured
 				if cfg.Quality != nil && cfg.Quality.Enabled {
@@ -1326,6 +1328,8 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	if err != nil {
 		return fmt.Errorf("failed to create executor runner: %w", err)
 	}
+	// TASK-286 / GH-3027: refuse sub-issue creation on unmanaged repos.
+	runner.SetRepoAllowlist(newConfigRepoAllowlist(cfg))
 
 	// Set up quality gates if configured (GH-207)
 	if cfg.Quality != nil && cfg.Quality.Enabled {

--- a/cmd/pilot/repo_allowlist.go
+++ b/cmd/pilot/repo_allowlist.go
@@ -1,0 +1,73 @@
+// repo_allowlist.go — TASK-286 / GH-3027
+//
+// Concrete adapter implementing executor.RepoAllowlist over *config.Config.
+// Lives in cmd/pilot/ (not internal/executor/) so the executor package
+// remains decoupled from the top-level config types — the same reason
+// FindProjectByRepo is only invoked from cmd/pilot in the existing codebase.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/executor"
+)
+
+// configRepoAllowlist adapts *config.Config to the
+// executor.RepoAllowlist interface used by the sub-issue creation
+// guardrail.
+type configRepoAllowlist struct {
+	cfg *config.Config
+}
+
+// newConfigRepoAllowlist constructs an allowlist backed by cfg. cfg must
+// not be nil; pass nil to Runner.SetRepoAllowlist if you genuinely want to
+// disable the allowlist (the guardrail will then refuse without
+// PILOT_ALLOW_UNMANAGED_REPO=1).
+func newConfigRepoAllowlist(cfg *config.Config) executor.RepoAllowlist {
+	if cfg == nil {
+		return nil
+	}
+	return &configRepoAllowlist{cfg: cfg}
+}
+
+// RepoIsAllowed implements executor.RepoAllowlist.
+//
+// A repo is allowed if some configured project matches both:
+//   - GitHub owner+repo (case-sensitive match against ProjectGitHubConfig)
+//   - When projectPath is non-empty, the matched project's filesystem Path
+//     equals projectPath. This blocks the "right repo, wrong working tree"
+//     misconfiguration class.
+func (a *configRepoAllowlist) RepoIsAllowed(owner, repo, projectPath string) bool {
+	if a == nil || a.cfg == nil {
+		return false
+	}
+	match := a.cfg.FindProjectByRepo(fmt.Sprintf("%s/%s", owner, repo))
+	if match == nil {
+		return false
+	}
+	if projectPath == "" {
+		return true
+	}
+	return match.Path == projectPath
+}
+
+// ConfiguredRepos returns all configured "owner/repo" pairs. Used only for
+// error and log messages.
+func (a *configRepoAllowlist) ConfiguredRepos() []string {
+	if a == nil || a.cfg == nil {
+		return nil
+	}
+	out := make([]string, 0, len(a.cfg.Projects))
+	for _, p := range a.cfg.Projects {
+		if p == nil || p.GitHub == nil {
+			continue
+		}
+		if p.GitHub.Owner == "" || p.GitHub.Repo == "" {
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s/%s", p.GitHub.Owner, p.GitHub.Repo))
+	}
+	return out
+}

--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -1747,6 +1747,30 @@ memory:
 | `projects[].github.repo` | string | — | GitHub repository name |
 | `default_project` | string | — | Name of the project used when none is specified |
 
+**Repo allowlist guardrail**
+
+Pilot refuses to create GitHub issues (including sub-issues from the epic
+decomposer) on repositories that are **not** listed under `projects[]`.
+The check resolves the worktree's `origin` remote to `owner/repo` and
+matches against every configured `projects[].github.owner` /
+`projects[].github.repo` pair.
+
+This closed a 2026-05-20 incident where a misconfigured external user
+accidentally created 6 duplicate sub-issues on the upstream
+`qf-studio/pilot` repo. See SOP
+`.agent/sops/integrations/repo-allowlist-guardrail.md` for the diagnosis
+runbook.
+
+**Bypass for ad-hoc one-off use:**
+
+```sh
+PILOT_ALLOW_UNMANAGED_REPO=1 pilot run ...
+```
+
+The bypass always emits a `WARN` log line naming the resolved owner/repo
+so the action is visible in dashboards and the daemon log. Never set
+this in your shell profile — it disables the safety net.
+
 **Memory**
 
 | Field | Type | Default | Description |

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -975,17 +975,54 @@ func (r *Runner) CreateSubIssues(ctx context.Context, plan *EpicPlan, executionP
 		return nil, fmt.Errorf("plan has no subtasks to create issues from")
 	}
 
-	if plan.ParentTask != nil {
+	if plan.ParentTask != nil && isParentDone(plan.ParentTask) {
 		// GH-2867: refuse to spawn sub-issues for a parent that is already done.
-		if isParentDone(plan.ParentTask) {
-			r.log.Info("Skipping sub-issue creation: parent is already done",
-				"parent_id", plan.ParentTask.ID,
-				"state", plan.ParentTask.State,
-				"labels", plan.ParentTask.Labels,
-			)
-			return nil, ErrParentDone
-		}
+		r.log.Info("Skipping sub-issue creation: parent is already done",
+			"parent_id", plan.ParentTask.ID,
+			"state", plan.ParentTask.State,
+			"labels", plan.ParentTask.Labels,
+		)
+		return nil, ErrParentDone
+	}
 
+	// GH-1471: pick the creation backend up front. The adapter path is
+	// non-GitHub (Linear, Jira, …) and uses its own per-adapter auth, so
+	// the repo allowlist guardrail below is skipped for that branch.
+	useAdapterCreator := r.subIssueCreator != nil &&
+		plan.ParentTask != nil &&
+		plan.ParentTask.SourceAdapter != "" &&
+		plan.ParentTask.SourceAdapter != "github"
+
+	// TASK-286 / GH-3027: guardrail must run BEFORE queryRecentSubIssues
+	// because that helper also shells out to `gh` against the worktree's
+	// inferred origin remote. Without this ordering, a misconfigured Pilot
+	// would still leak `gh issue list` calls to an unmanaged repo even if
+	// no sub-issue was created. Only enforced when a RepoAllowlist has been
+	// wired onto the Runner; production callers do this in cmd/pilot via
+	// SetRepoAllowlist(newConfigRepoAllowlist(cfg)).
+	if !useAdapterCreator && r.repoAllowlist != nil && executionPath != "" {
+		owner, repo, remoteErr := resolveGitRemote(ctx, executionPath)
+		if remoteErr != nil {
+			r.log.Error("sub-issue guardrail: could not resolve origin remote",
+				"execution_path", executionPath, "error", remoteErr)
+			if err := ValidateTargetRepo(r.repoAllowlist, "", "", executionPath); err != nil {
+				return nil, fmt.Errorf("sub-issue guardrail (no origin remote at %s): %w", executionPath, err)
+			}
+		} else if err := ValidateTargetRepo(r.repoAllowlist, owner, repo, executionPath); err != nil {
+			r.log.Error("sub-issue guardrail rejected target repo",
+				"owner", owner, "repo", repo,
+				"execution_path", executionPath, "error", err)
+			return nil, fmt.Errorf("sub-issue guardrail: %w", err)
+		} else {
+			r.log.Debug("sub-issue guardrail passed",
+				"owner", owner, "repo", repo, "execution_path", executionPath)
+		}
+	} else if !useAdapterCreator && r.repoAllowlist == nil {
+		r.log.Warn("sub-issue guardrail skipped: no RepoAllowlist configured on Runner; production callers must invoke Runner.SetRepoAllowlist",
+			"execution_path", executionPath)
+	}
+
+	if plan.ParentTask != nil {
 		// Dedup guard: skip creation if recent sub-issues referencing this parent already exist.
 		// Uses an injectable checker so tests can control the result without spawning gh CLI.
 		checker := r.openSubIssueCheck
@@ -999,13 +1036,6 @@ func (r *Runner) CreateSubIssues(ctx context.Context, plan *EpicPlan, executionP
 			return nil, ErrSubIssuesAlreadyExist
 		}
 	}
-
-	// GH-1471: Check if we should use the SubIssueCreator interface
-	// Conditions: non-nil creator AND non-empty SourceAdapter AND not "github"
-	useAdapterCreator := r.subIssueCreator != nil &&
-		plan.ParentTask != nil &&
-		plan.ParentTask.SourceAdapter != "" &&
-		plan.ParentTask.SourceAdapter != "github"
 
 	if useAdapterCreator {
 		return r.createSubIssuesViaAdapter(ctx, plan)
@@ -1126,6 +1156,9 @@ func (r *Runner) createSubIssuesViaAdapter(ctx context.Context, plan *EpicPlan) 
 
 // createSubIssuesViaGitHub creates sub-issues using the gh CLI.
 // This is the original implementation and fallback path.
+//
+// The TASK-286 / GH-3027 repo guardrail runs one level up in CreateSubIssues
+// (it must fire before queryRecentSubIssues, which also shells out to gh).
 func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, executionPath string) ([]CreatedIssue, error) {
 	var created []CreatedIssue
 

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -2424,5 +2425,153 @@ func TestRunner_Execute_EpicRecoversThenExecutesOpenChildren(t *testing.T) {
 		if id == "GH-20" {
 			t.Errorf("closed child GH-20 should not have been executed")
 		}
+	}
+}
+
+
+// staticAllowlist is a test helper that allows a fixed set of "owner/repo"
+// pairs. projectPath comparison is ignored (tests don't need that dimension).
+type staticAllowlist struct {
+	repos []string // "owner/repo"
+}
+
+func (s *staticAllowlist) RepoIsAllowed(owner, repo, projectPath string) bool {
+	want := owner + "/" + repo
+	for _, r := range s.repos {
+		if r == want {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *staticAllowlist) ConfiguredRepos() []string { return s.repos }
+
+// TestCreateSubIssuesViaGitHub_GuardrailAllowsConfiguredRepo verifies the
+// TASK-286 / GH-3027 guardrail: when a RepoAllowlist is wired AND the
+// worktree's origin remote resolves to a configured repo, the gh CLI call
+// proceeds normally.
+func TestCreateSubIssuesViaGitHub_GuardrailAllowsConfiguredRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	worktree := t.TempDir()
+	runGitForGuardrail(t, worktree, "init", "-q")
+	runGitForGuardrail(t, worktree, "remote", "add", "origin", "https://github.com/qf-studio/pilot.git")
+
+	fakeBin := t.TempDir()
+	script := filepath.Join(fakeBin, "gh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho https://github.com/qf-studio/pilot/issues/9999\n"), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+os.Getenv("PATH"))
+
+	runner := NewRunner()
+	runner.SetRepoAllowlist(&staticAllowlist{repos: []string{"qf-studio/pilot"}})
+
+	plan := &EpicPlan{
+		ParentTask: &Task{ID: "GH-42"},
+		Subtasks: []PlannedSubtask{
+			{Title: "feat(guardrail): allow happy path", Description: "ok", Order: 1},
+		},
+	}
+
+	created, err := runner.CreateSubIssues(context.Background(), plan, worktree)
+	if err != nil {
+		t.Fatalf("guardrail unexpectedly blocked configured repo: %v", err)
+	}
+	if len(created) != 1 {
+		t.Fatalf("expected 1 created issue, got %d", len(created))
+	}
+}
+
+// TestCreateSubIssuesViaGitHub_GuardrailBlocksUnmanagedRepo proves the
+// incident-driving path is now closed: when the worktree's origin remote is
+// NOT in the user's configured projects, no `gh issue create` call is fired
+// and the error wraps ErrRepoNotInConfig.
+//
+// Without this guardrail, an external user pointing his Pilot at
+// `qf-studio/pilot` created 6 dupes (#3021-#3026) on 2026-05-20.
+func TestCreateSubIssuesViaGitHub_GuardrailBlocksUnmanagedRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	worktree := t.TempDir()
+	runGitForGuardrail(t, worktree, "init", "-q")
+	runGitForGuardrail(t, worktree, "remote", "add", "origin", "https://github.com/qf-studio/pilot.git")
+
+	// A `gh` shim that records its invocation. If the guardrail does its job,
+	// this file must not exist after CreateSubIssues returns.
+	callMarker := filepath.Join(t.TempDir(), "gh_was_called")
+	fakeBin := t.TempDir()
+	script := filepath.Join(fakeBin, "gh")
+	scriptBody := fmt.Sprintf("#!/bin/sh\ntouch %q\necho https://example/issues/0\n", callMarker)
+	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+os.Getenv("PATH"))
+	t.Setenv(envBypassRepoAllowlist, "") // belt-and-braces: no stray bypass
+
+	runner := NewRunner()
+	runner.SetRepoAllowlist(&staticAllowlist{repos: []string{"alice/site"}}) // qf-studio/pilot intentionally missing
+
+	plan := &EpicPlan{
+		ParentTask: &Task{ID: "GH-42"},
+		Subtasks: []PlannedSubtask{
+			{Title: "feat(guardrail): should not run", Description: "blocked", Order: 1},
+		},
+	}
+
+	_, err := runner.CreateSubIssues(context.Background(), plan, worktree)
+	if err == nil {
+		t.Fatal("expected guardrail to block unmanaged repo, got nil error")
+	}
+	if !errors.Is(err, ErrRepoNotInConfig) {
+		t.Fatalf("error %v should wrap ErrRepoNotInConfig", err)
+	}
+	if _, statErr := os.Stat(callMarker); statErr == nil {
+		t.Errorf("guardrail did not fire before `gh issue create`: marker %s exists", callMarker)
+	}
+}
+
+// TestCreateSubIssuesViaGitHub_GuardrailBypassEnvVar documents that the
+// PILOT_ALLOW_UNMANAGED_REPO=1 env var lets the call proceed even when the
+// repo is not in the allowlist. The bypass logs a WARN inside
+// ValidateTargetRepo; here we verify behavior (no error + gh fires).
+func TestCreateSubIssuesViaGitHub_GuardrailBypassEnvVar(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	worktree := t.TempDir()
+	runGitForGuardrail(t, worktree, "init", "-q")
+	runGitForGuardrail(t, worktree, "remote", "add", "origin", "https://github.com/qf-studio/pilot.git")
+
+	fakeBin := t.TempDir()
+	script := filepath.Join(fakeBin, "gh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho https://example/issues/1\n"), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+os.Getenv("PATH"))
+	t.Setenv(envBypassRepoAllowlist, "1")
+
+	runner := NewRunner()
+	runner.SetRepoAllowlist(&staticAllowlist{repos: []string{"alice/site"}})
+
+	plan := &EpicPlan{
+		ParentTask: &Task{ID: "GH-42"},
+		Subtasks: []PlannedSubtask{
+			{Title: "feat(guardrail): bypass should proceed", Description: "ok via env", Order: 1},
+		},
+	}
+
+	created, err := runner.CreateSubIssues(context.Background(), plan, worktree)
+	if err != nil {
+		t.Fatalf("PILOT_ALLOW_UNMANAGED_REPO=1 should let the call proceed: %v", err)
+	}
+	if len(created) != 1 {
+		t.Fatalf("expected 1 issue created via bypass, got %d", len(created))
 	}
 }

--- a/internal/executor/repo_guardrail.go
+++ b/internal/executor/repo_guardrail.go
@@ -1,0 +1,184 @@
+// Package executor — TASK-286 / GH-3027
+//
+// Guardrail that refuses to create GitHub issues on repositories that are not
+// in the user's configured project list. Closes the incident on 2026-05-20
+// where an external Pilot user accidentally pointed his daemon at the upstream
+// `qf-studio/pilot` repo and the epic decomposer fired 6 duplicate sub-issues
+// (#3021-#3026). The decomposer at internal/executor/epic.go shelled out
+// `gh issue create` with `cmd.Dir` set to the worktree path; `gh` infers
+// owner/repo from the directory's origin remote, with no cross-check that
+// the repo is one Pilot is supposed to write to.
+//
+// This file defines the chokepoint. Callers must hold a RepoAllowlist
+// (concrete implementation lives in cmd/pilot/ to keep the executor
+// decoupled from the top-level config types).
+//
+// Bypass: PILOT_ALLOW_UNMANAGED_REPO=1 (logs WARN with the resolved repo).
+
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// envBypassRepoAllowlist is the documented opt-out for the guardrail. When set
+// to "1" the guardrail logs a WARN with the resolved owner/repo and returns
+// nil, allowing the call to proceed. Intended for ad-hoc CLI invocations
+// against repos that are not registered as Pilot projects; never the default.
+const envBypassRepoAllowlist = "PILOT_ALLOW_UNMANAGED_REPO"
+
+// ErrRepoNotInConfig is the sentinel returned when the resolved (owner, repo)
+// pair does not match any project in the user's configured allowlist.
+var ErrRepoNotInConfig = errors.New("target repo is not in user's configured project list")
+
+// ErrNoOriginRemote is the sentinel returned when resolveGitRemote cannot
+// determine an origin remote for the given working directory, or when the
+// URL cannot be parsed into owner/repo.
+var ErrNoOriginRemote = errors.New("no origin remote found")
+
+// RepoAllowlist is the minimum surface ValidateTargetRepo needs to decide
+// whether a (owner, repo, projectPath) tuple corresponds to a Pilot-managed
+// project. Implementations live outside the executor package (typically
+// wrapping *config.Config) so the executor stays decoupled from concrete
+// configuration types and so the guardrail is trivial to unit-test.
+type RepoAllowlist interface {
+	// RepoIsAllowed reports whether (owner, repo) is configured for some
+	// project. When projectPath is non-empty the match must also align with
+	// that project's filesystem Path so a misconfigured executionPath cannot
+	// inherit another project's git context.
+	RepoIsAllowed(owner, repo, projectPath string) bool
+
+	// ConfiguredRepos returns the set of "owner/repo" strings the user has
+	// configured. Used only for error and log messages — must not include
+	// secrets.
+	ConfiguredRepos() []string
+}
+
+// ValidateTargetRepo returns nil iff (owner, repo) is allowed by the
+// supplied allowlist for projectPath. On rejection it returns a wrapped
+// ErrRepoNotInConfig. The PILOT_ALLOW_UNMANAGED_REPO=1 env var is honored as
+// a documented bypass; the bypass path always logs a WARN naming the
+// resolved repo so the action is visible in dashboards and audit logs.
+//
+// allow == nil is treated as "no allowlist plumbed" — the function refuses
+// unless the bypass env var is set. This makes the safe default loud rather
+// than silent if a code path forgets to set the allowlist on the Runner.
+func ValidateTargetRepo(allow RepoAllowlist, owner, repo, projectPath string) error {
+	if owner == "" || repo == "" {
+		return fmt.Errorf("%w: empty owner or repo", ErrRepoNotInConfig)
+	}
+
+	if allow != nil && allow.RepoIsAllowed(owner, repo, projectPath) {
+		return nil
+	}
+
+	if os.Getenv(envBypassRepoAllowlist) == "1" {
+		configured := ""
+		if allow != nil {
+			configured = strings.Join(allow.ConfiguredRepos(), ",")
+		}
+		slog.Warn("PILOT_ALLOW_UNMANAGED_REPO=1 bypassed repo allowlist",
+			"component", "executor.repo_guardrail",
+			"owner", owner,
+			"repo", repo,
+			"project_path", projectPath,
+			"configured_repos", configured,
+		)
+		return nil
+	}
+
+	if allow == nil {
+		return fmt.Errorf("%w: no allowlist configured (set %s=1 to bypass for ad-hoc use)",
+			ErrRepoNotInConfig, envBypassRepoAllowlist)
+	}
+
+	return fmt.Errorf("%w: %s/%s not in configured projects [%s]",
+		ErrRepoNotInConfig, owner, repo, strings.Join(allow.ConfiguredRepos(), ","))
+}
+
+// resolveGitRemote returns the (owner, repo) parsed from the `origin` remote
+// of the git working tree at dir. Supports the three URL forms produced by
+// `git remote get-url`:
+//
+//	HTTPS:    https://github.com/owner/repo[.git]
+//	SSH:      git@github.com:owner/repo[.git]
+//	ssh://:   ssh://git@github.com/owner/repo[.git]
+//
+// Returns ErrNoOriginRemote if the directory has no remote or the URL
+// cannot be parsed. ctx is used to bound the underlying `git` invocation.
+func resolveGitRemote(ctx context.Context, dir string) (string, string, error) {
+	if dir == "" {
+		return "", "", fmt.Errorf("%w: empty directory", ErrNoOriginRemote)
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("%w: git remote get-url origin: %v", ErrNoOriginRemote, err)
+	}
+	return parseGitHubRemoteURL(strings.TrimSpace(string(out)))
+}
+
+// parseGitHubRemoteURL parses one of the standard GitHub remote URL forms
+// and returns (owner, repo). The .git suffix is stripped. Trailing slashes
+// are tolerated. Returns ErrNoOriginRemote when the URL does not parse.
+//
+// The parser is intentionally conservative — it does NOT attempt to
+// normalize hosts (e.g. github.enterprise.example.com); the only invariant
+// is that the URL ends in "<owner>/<repo>" (with optional .git). For
+// non-GitHub remotes the returned (owner, repo) is still meaningful and the
+// allowlist check above will reject it if the user has not configured that
+// remote as a project.
+func parseGitHubRemoteURL(url string) (string, string, error) {
+	if url == "" {
+		return "", "", fmt.Errorf("%w: empty url", ErrNoOriginRemote)
+	}
+
+	s := strings.TrimSuffix(url, ".git")
+	s = strings.TrimRight(s, "/")
+
+	// SSH "scp-like" form: git@host:owner/repo
+	// Distinguishable from URL forms by the presence of `:` without `//`.
+	if !strings.Contains(s, "://") && strings.Contains(s, "@") && strings.Contains(s, ":") {
+		colon := strings.Index(s, ":")
+		if colon >= 0 && colon < len(s)-1 {
+			return splitOwnerRepo(s[colon+1:], url)
+		}
+	}
+
+	// URL forms: https://host/owner/repo or ssh://user@host/owner/repo
+	if i := strings.Index(s, "://"); i >= 0 {
+		rest := s[i+3:]
+		// Drop optional user@ prefix.
+		if at := strings.Index(rest, "@"); at >= 0 {
+			rest = rest[at+1:]
+		}
+		// Drop host (up to first slash).
+		if slash := strings.Index(rest, "/"); slash >= 0 {
+			return splitOwnerRepo(rest[slash+1:], url)
+		}
+	}
+
+	// Bare "owner/repo" fallback (uncommon, but tolerable).
+	return splitOwnerRepo(s, url)
+}
+
+// splitOwnerRepo enforces that path == "owner/repo" with non-empty parts.
+// The original URL is included in error messages to aid debugging.
+func splitOwnerRepo(path, originalURL string) (string, string, error) {
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("%w: expected owner/repo in %q", ErrNoOriginRemote, originalURL)
+	}
+	owner := parts[len(parts)-2]
+	repo := parts[len(parts)-1]
+	if owner == "" || repo == "" {
+		return "", "", fmt.Errorf("%w: empty owner or repo in %q", ErrNoOriginRemote, originalURL)
+	}
+	return owner, repo, nil
+}

--- a/internal/executor/repo_guardrail_test.go
+++ b/internal/executor/repo_guardrail_test.go
@@ -1,0 +1,288 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeAllowlist is a hand-rolled RepoAllowlist for tests so we don't pull in
+// the real config types. Each entry maps "owner/repo" → projectPath.
+type fakeAllowlist struct {
+	repos map[string]string // ownerRepo → projectPath
+}
+
+func (f *fakeAllowlist) RepoIsAllowed(owner, repo, projectPath string) bool {
+	want, ok := f.repos[owner+"/"+repo]
+	if !ok {
+		return false
+	}
+	if projectPath == "" {
+		return true
+	}
+	return want == projectPath
+}
+
+func (f *fakeAllowlist) ConfiguredRepos() []string {
+	out := make([]string, 0, len(f.repos))
+	for k := range f.repos {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestParseGitHubRemoteURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{"https with .git", "https://github.com/qf-studio/pilot.git", "qf-studio", "pilot", false},
+		{"https without .git", "https://github.com/qf-studio/pilot", "qf-studio", "pilot", false},
+		{"https with trailing slash", "https://github.com/qf-studio/pilot/", "qf-studio", "pilot", false},
+		{"ssh scp-like with .git", "git@github.com:qf-studio/pilot.git", "qf-studio", "pilot", false},
+		{"ssh scp-like without .git", "git@github.com:qf-studio/pilot", "qf-studio", "pilot", false},
+		{"ssh url form", "ssh://git@github.com/qf-studio/pilot.git", "qf-studio", "pilot", false},
+		{"http insecure", "http://github.com/qf-studio/pilot.git", "qf-studio", "pilot", false},
+		{"enterprise host", "https://github.enterprise.example.com/team/svc.git", "team", "svc", false},
+		{"bare owner/repo", "qf-studio/pilot", "qf-studio", "pilot", false},
+		{"empty url", "", "", "", true},
+		{"missing repo", "https://github.com/qf-studio", "", "", true},
+		{"trailing slash only", "https://github.com/qf-studio/", "", "", true},
+		{"scp form missing repo", "git@github.com:qf-studio", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, err := parseGitHubRemoteURL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseGitHubRemoteURL(%q) want error, got owner=%q repo=%q", tt.url, owner, repo)
+				}
+				if !errors.Is(err, ErrNoOriginRemote) {
+					t.Fatalf("error %v should wrap ErrNoOriginRemote", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseGitHubRemoteURL(%q) unexpected error: %v", tt.url, err)
+			}
+			if owner != tt.wantOwner || repo != tt.wantRepo {
+				t.Errorf("parseGitHubRemoteURL(%q) = (%q,%q), want (%q,%q)",
+					tt.url, owner, repo, tt.wantOwner, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestValidateTargetRepo(t *testing.T) {
+	// Ensure bypass env var is clear for tests that don't set it.
+	t.Setenv(envBypassRepoAllowlist, "")
+
+	allow := &fakeAllowlist{repos: map[string]string{
+		"qf-studio/pilot": "/Users/me/projects/pilot",
+		"alice/site":      "/Users/me/projects/site",
+	}}
+
+	tests := []struct {
+		name        string
+		allow       RepoAllowlist
+		owner       string
+		repo        string
+		projectPath string
+		bypass      string
+		wantErr     error // nil = success, otherwise sentinel to match with errors.Is
+	}{
+		{
+			name:        "happy_path_repo_and_projectPath_match",
+			allow:       allow,
+			owner:       "qf-studio",
+			repo:        "pilot",
+			projectPath: "/Users/me/projects/pilot",
+		},
+		{
+			name:        "happy_path_repo_match_empty_projectPath",
+			allow:       allow,
+			owner:       "qf-studio",
+			repo:        "pilot",
+			projectPath: "",
+		},
+		{
+			name:        "reject_unconfigured_repo",
+			allow:       allow,
+			owner:       "tenlisboa",
+			repo:        "pilot-fork",
+			projectPath: "/tmp/whatever",
+			wantErr:     ErrRepoNotInConfig,
+		},
+		{
+			name:        "reject_repo_match_but_projectPath_mismatch",
+			allow:       allow,
+			owner:       "qf-studio",
+			repo:        "pilot",
+			projectPath: "/Users/me/projects/site", // configured for alice/site, not qf-studio/pilot
+			wantErr:     ErrRepoNotInConfig,
+		},
+		{
+			name:    "reject_empty_owner",
+			allow:   allow,
+			owner:   "",
+			repo:    "pilot",
+			wantErr: ErrRepoNotInConfig,
+		},
+		{
+			name:    "reject_empty_repo",
+			allow:   allow,
+			owner:   "qf-studio",
+			repo:    "",
+			wantErr: ErrRepoNotInConfig,
+		},
+		{
+			name:    "reject_nil_allowlist_no_bypass",
+			allow:   nil,
+			owner:   "qf-studio",
+			repo:    "pilot",
+			wantErr: ErrRepoNotInConfig,
+		},
+		{
+			name:   "bypass_via_env_var_with_allowlist",
+			allow:  allow,
+			owner:  "tenlisboa",
+			repo:   "pilot-fork",
+			bypass: "1",
+		},
+		{
+			name:   "bypass_via_env_var_with_nil_allowlist",
+			allow:  nil,
+			owner:  "qf-studio",
+			repo:   "pilot",
+			bypass: "1",
+		},
+		{
+			name:   "bypass_set_to_0_is_NOT_a_bypass",
+			allow:  allow,
+			owner:  "tenlisboa",
+			repo:   "pilot-fork",
+			bypass: "0",
+			wantErr: ErrRepoNotInConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envBypassRepoAllowlist, tt.bypass)
+			err := ValidateTargetRepo(tt.allow, tt.owner, tt.repo, tt.projectPath)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("ValidateTargetRepo unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateTargetRepo want error wrapping %v, got nil", tt.wantErr)
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("ValidateTargetRepo error %v does not wrap %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestResolveGitRemote exercises the actual git invocation end-to-end. We
+// initialize a throwaway repo in a temp dir and configure an origin remote.
+// Skipped if git is not on PATH (highly unlikely in CI, but defensive).
+func TestResolveGitRemote(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	tests := []struct {
+		name      string
+		remoteURL string
+		wantOwner string
+		wantRepo  string
+	}{
+		{"https", "https://github.com/qf-studio/pilot.git", "qf-studio", "pilot"},
+		{"ssh", "git@github.com:qf-studio/pilot.git", "qf-studio", "pilot"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			runGitForGuardrail(t, dir, "init", "-q")
+			runGitForGuardrail(t, dir, "remote", "add", "origin", tt.remoteURL)
+
+			owner, repo, err := resolveGitRemote(context.Background(), dir)
+			if err != nil {
+				t.Fatalf("resolveGitRemote: %v", err)
+			}
+			if owner != tt.wantOwner || repo != tt.wantRepo {
+				t.Errorf("got (%q,%q), want (%q,%q)", owner, repo, tt.wantOwner, tt.wantRepo)
+			}
+		})
+	}
+
+	t.Run("no_remote_returns_sentinel", func(t *testing.T) {
+		dir := t.TempDir()
+		runGitForGuardrail(t, dir, "init", "-q")
+		_, _, err := resolveGitRemote(context.Background(), dir)
+		if err == nil {
+			t.Fatal("want error for dir with no origin remote, got nil")
+		}
+		if !errors.Is(err, ErrNoOriginRemote) {
+			t.Fatalf("err %v should wrap ErrNoOriginRemote", err)
+		}
+	})
+
+	t.Run("empty_dir_returns_sentinel", func(t *testing.T) {
+		_, _, err := resolveGitRemote(context.Background(), "")
+		if err == nil {
+			t.Fatal("want error for empty dir, got nil")
+		}
+		if !errors.Is(err, ErrNoOriginRemote) {
+			t.Fatalf("err %v should wrap ErrNoOriginRemote", err)
+		}
+	})
+
+	t.Run("nonexistent_dir_returns_sentinel", func(t *testing.T) {
+		_, _, err := resolveGitRemote(context.Background(), filepath.Join(os.TempDir(), "definitely-does-not-exist-pilot-test"))
+		if err == nil {
+			t.Fatal("want error for missing dir, got nil")
+		}
+		if !errors.Is(err, ErrNoOriginRemote) {
+			t.Fatalf("err %v should wrap ErrNoOriginRemote", err)
+		}
+		// Sanity: the underlying git error mentions the dir.
+		if !strings.Contains(err.Error(), "git") {
+			t.Errorf("error message should mention git: %v", err)
+		}
+	})
+}
+
+// runGitForGuardrail is the test helper used by repo_guardrail_test.go to
+// shell out git. Named distinctly from runGit in runner_git_test.go to avoid
+// a duplicate-declaration build error within the package.
+func runGitForGuardrail(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		// Suppress system/global gitconfig so the test is hermetic.
+		"GIT_CONFIG_NOSYSTEM=1",
+		"HOME="+t.TempDir(),
+		"XDG_CONFIG_HOME="+t.TempDir(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -412,6 +412,21 @@ type Runner struct {
 	planEpicFn func(ctx context.Context, task *Task, executionPath string) (*EpicPlan, error)
 	// GH-2855: Prometheus counters for tokens, cost, and executions.
 	metricsRecorder MetricsRecorder
+	// GH-3027 / TASK-286: Allowlist used to refuse `gh issue create` calls on
+	// repos that are not in the user's configured project list. Set via
+	// SetRepoAllowlist at construction time by cmd/pilot. When nil the
+	// guardrail logs a one-shot WARN and (without PILOT_ALLOW_UNMANAGED_REPO=1)
+	// refuses to create sub-issues — safe default for newly-wired call paths.
+	repoAllowlist RepoAllowlist
+}
+
+// SetRepoAllowlist injects the allowlist used by the sub-issue creation
+// guardrail (TASK-286 / GH-3027). cmd/pilot wires this from the top-level
+// *config.Config so the executor stays decoupled from concrete config types.
+// Passing nil disables the allowlist (the guardrail then refuses unless
+// PILOT_ALLOW_UNMANAGED_REPO=1 is set, which logs a WARN).
+func (r *Runner) SetRepoAllowlist(allow RepoAllowlist) {
+	r.repoAllowlist = allow
 }
 
 // NewRunner creates a new Runner instance with Claude Code backend by default.


### PR DESCRIPTION
Closes #3027 — implements [TASK-286](../blob/feat/task-286-repo-guardrail/.agent/tasks/TASK-286-guardrail-external-repo-issue-create.md).

## Summary

- New chokepoint `internal/executor/repo_guardrail.go::ValidateTargetRepo` rejects `gh issue create` calls targeting a repo not in the user's configured `projects[]`.
- Guardrail runs inside `CreateSubIssues` **before** `queryRecentSubIssues` so the dedup-check `gh issue list` call is also blocked when the resolved repo is unmanaged.
- `Runner.SetRepoAllowlist` wired at every `NewRunnerWithConfig` site in `cmd/pilot/` (7 sites); a concrete `configRepoAllowlist` adapter in `cmd/pilot/repo_allowlist.go` keeps the executor decoupled from `*config.Config`.
- `PILOT_ALLOW_UNMANAGED_REPO=1` documented bypass for ad-hoc/recovery use; always logs `WARN` naming the resolved repo.

## Why

On 2026-05-20 external user @tenlisboa accidentally pointed his Pilot at the upstream `qf-studio/pilot` repo. The epic decomposer fired 6 duplicate sub-issues (#3021–#3026, all closed as dupes). Diagnosis comment: #3021. Before this PR, `internal/executor/epic.go:1218` ran `exec.CommandContext(ctx, "gh", "issue", "create", ...)` with `cmd.Dir = executionPath` and zero owner/repo validation — `gh` inferred the target from the directory's origin remote with no allowlist cross-check.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/executor/ ./internal/adapters/github/ ./cmd/pilot/ ./internal/wiring/` — all green (the executor suite re-runs the existing 1.6k-line `epic_test.go` plus 3 new integration tests)
- [x] Unit tests for `parseGitHubRemoteURL` (HTTPS, SSH scp form, ssh:// URL, trailing slashes, enterprise host, bare `owner/repo`, error cases)
- [x] Unit tests for `ValidateTargetRepo` (allow / deny / empty / nil-allowlist / bypass on / bypass off)
- [x] Unit tests for `resolveGitRemote` using a real `git init` + temp dir (https, ssh, no-remote, missing dir)
- [x] Integration tests in `epic_test.go` with a fake `gh` shim + real git worktree:
  - guardrail allows configured repo → gh called → issue created
  - guardrail blocks unmanaged repo → `ErrRepoNotInConfig` + gh **not** called (call-marker file confirms no shell-out happened)
  - `PILOT_ALLOW_UNMANAGED_REPO=1` lets the call proceed
- [x] Existing `TestCreateSubIssues_*` tests (5 of them) continue to pass — they construct Runners without an allowlist and get the WARN-and-fall-through path

Optional manual checks for reviewers:

- [ ] `make test` (full suite — should already be green based on the targeted runs)
- [ ] Set up a worktree pointed at any repo not in your `~/.pilot/config.yaml`, run `pilot run` with an epic-shaped issue. Expect `ErrRepoNotInConfig` and no GitHub-side side-effects.
- [ ] Same, but with `PILOT_ALLOW_UNMANAGED_REPO=1` — expect creation to proceed with a `WARN` log line.

## Scope cut

Defense-in-depth at `internal/adapters/github/issue_create.go::CreatePilotIssue` is **not** in this PR. The actual incident vector was the epic sub-issue path covered here. The two `feedback_loop.go` call sites would benefit from the same check; tracked as a small follow-up (will file once this lands).

## Refs

- Incident: #3021–#3026 (closed as dupes)
- Diagnosis comment: #3021#issuecomment-4508477616
- Task plan: `.agent/tasks/TASK-286-guardrail-external-repo-issue-create.md`
- SOP: `.agent/sops/integrations/repo-allowlist-guardrail.md`