### PR TITLE
feat(executor): harden Claude Code subprocess against OOM-kills

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -37,6 +37,9 @@
 | Navigator auto-init | ✅ | executor | - | `executor.navigator.auto_init` | Auto-creates .agent/ on first task execution (v0.33.16) |
 | Preflight checks | ✅ | executor | - | - | Claude available, git clean, git repo validation (v0.48.0) |
 | Smart retry | ✅ | executor | - | - | Error-type-specific retry with exponential backoff (v0.51.0) |
+| OOM smart-retry | ✅ | executor | - | `executor.retry.oom_killed` | Retry OOM-killed subprocess once after 10s (GH-3028, v2.147.0) |
+| RSS telemetry | ✅ | executor | - | `executor.subprocess_limits` | Peak/final RSS sampled per execution; stored in DB + shown in history (GH-3028, v2.147.0) |
+| Subprocess memory cap | ✅ | executor | - | `executor.subprocess_limits.enabled` | RLIMIT_AS via prlimit64 on Linux (default off; tune after RSS baseline) (GH-3028, v2.147.0) |
 | Acceptance criteria | ✅ | executor | - | - | Extract from issue body, include in prompts (v0.51.0) |
 | Worktree isolation | ✅ | executor | - | `executor.use_worktree` | Execute in git worktree, allows uncommitted changes (v0.53.2) |
 | Signal parser v2 | ✅ | executor | - | - | JSON pilot-signal blocks with validation (v0.56.0) |

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -225,7 +225,20 @@ executor:
   #     max_attempts: 2           # Retry once
   #     extend_timeout: true      # Use 1.5x original timeout on retry
   #     timeout_multiplier: 1.5
+  #   oom_killed:                 # OOM-killed subprocess (exit 137/139) (GH-3028)
+  #     max_attempts: 2           # Retry once — most OOM tasks succeed on a clean retry
+  #     initial_backoff: 10s      # flat backoff; OOM is not time-sensitive
+  #     backoff_multiplier: 1.0
   # Note: invalid_config errors always fail fast (no retry)
+
+  # Subprocess memory limits + RSS telemetry (GH-3028)
+  # RSS sampler runs on every execution (Linux: /proc/<pid>/status, macOS: ps).
+  # Memory cap (Enabled=true) applies RLIMIT_AS on Linux only; macOS degrades to
+  # telemetry-only. Collect one week of peak_rss_mb data before enabling the cap.
+  # subprocess_limits:
+  #   enabled: false              # flip to true after tuning max_rss_mb
+  #   max_rss_mb: 4096            # virtual address space cap in MiB (Linux only)
+  #   sample_interval_sec: 10     # how often to poll RSS
 
   # Stagnation detection (GH-925) - detect and recover from stuck tasks
   # stagnation:

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/wailsapp/wails/v2 v2.11.0
+	golang.org/x/sys v0.40.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.44.3
 )
@@ -60,7 +61,6 @@ require (
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.35.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -354,6 +354,9 @@ type CompletedTask struct {
 	TotalSubs   int      // Total number of sub-issues (epic tracking)
 	DoneSubs    int      // Number of completed sub-issues (epic tracking)
 	IsEpic      bool     // Whether this task was decomposed into sub-issues
+	// PeakRSSMB is the peak subprocess RSS in MiB from the RSS sampler. GH-3028.
+	// Zero when the sampler had no data (pre-3028 executions, non-Linux/darwin).
+	PeakRSSMB int
 }
 
 // UpdateInfo contains information about an available update
@@ -621,6 +624,7 @@ func (m *Model) hydrateFromStore() {
 			Status:      status,
 			Duration:    fmt.Sprintf("%dms", exec.DurationMs),
 			CompletedAt: completedAt,
+			PeakRSSMB:   exec.PeakRSSMB,
 		})
 	}
 
@@ -854,6 +858,7 @@ func storeRefreshCmd(store *memory.Store) tea.Cmd {
 				Status:      status,
 				Duration:    fmt.Sprintf("%dms", exec.DurationMs),
 				CompletedAt: completedAt,
+				PeakRSSMB:   exec.PeakRSSMB,
 			})
 		}
 
@@ -2476,18 +2481,43 @@ func (m Model) renderHistory() string {
 // renderStandaloneLine renders a standalone (non-epic) task line.
 // Layout: "  + GH-156  Title...                                    2m ago"
 // indent(2) + icon(1) + space(1) + id(7) + space(2) + title + space(2) + timeAgo(8) = iw
+// When PeakRSSMB > 0 (GH-3028), an RSS indicator ("4.2G") is appended after the time.
 func renderStandaloneLine(task CompletedTask, iw int) string {
-	titleWidth := iw - 23
 	icon, style := statusIconStyle(task.Status)
 	timeAgoStr := formatTimeAgo(task.CompletedAt)
+
+	var rssStr string
+	if task.PeakRSSMB > 0 {
+		rssStr = fmt.Sprintf(" %s", formatRSSMB(task.PeakRSSMB))
+	}
+
+	// Reserve space: indent(2)+icon(1)+sp(1)+id(7)+sp(2)+sp(2)+time(8)+rss = 23+len(rssStr)
+	titleWidth := iw - 23 - len(rssStr)
+	if titleWidth < 10 {
+		titleWidth = 10
+	}
 	titleStr := padOrTruncate(task.Title, titleWidth)
 
-	return fmt.Sprintf("  %s %-7s  %s  %8s",
+	return fmt.Sprintf("  %s %-7s  %s  %8s%s",
 		style.Render(icon),
 		task.ID,
 		titleStr,
 		dimStyle.Render(timeAgoStr),
+		dimStyle.Render(rssStr),
 	)
+}
+
+// formatRSSMB formats a RSS value in MiB as a compact human-readable string.
+// 512 → "512M", 2048 → "2.0G", 10240 → "10G".
+func formatRSSMB(mb int) string {
+	if mb < 1024 {
+		return fmt.Sprintf("%dM", mb)
+	}
+	gb := float64(mb) / 1024.0
+	if gb < 10 {
+		return fmt.Sprintf("%.1fG", gb)
+	}
+	return fmt.Sprintf("%.0fG", gb)
 }
 
 // renderActiveEpicLine renders the parent line for an active epic.

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -210,6 +210,13 @@ type BackendResult struct {
 	// ErrorType classifies the failure (rate_limit, api_error, oom_killed,
 	// session_not_found, timeout, invalid_config, unknown). GH-2328.
 	ErrorType string
+
+	// PeakRSSMB is the peak resident set size of the subprocess in MiB. GH-3028.
+	// Zero when RSS sampling is unavailable (non-Linux/darwin platforms).
+	PeakRSSMB int
+
+	// FinalRSSMB is the RSS at subprocess exit. GH-3028.
+	FinalRSSMB int
 }
 
 // BackendConfig contains configuration for executor backends.
@@ -306,6 +313,11 @@ type BackendConfig struct {
 
 	// Stagnation contains stagnation detection settings (GH-925)
 	Stagnation *StagnationConfig `yaml:"stagnation,omitempty"`
+
+	// SubprocessLimits controls memory caps and RSS telemetry for the Claude Code
+	// subprocess. Enabled=false by default; flip after collecting a baseline week of
+	// peak_rss_mb data to choose a safe cap. GH-3028.
+	SubprocessLimits *SubprocessLimitsConfig `yaml:"subprocess_limits,omitempty"`
 
 	// Simplification contains code simplification settings (GH-995)
 	// When enabled, Pilot auto-simplifies code after implementation for clarity.
@@ -729,6 +741,7 @@ func DefaultBackendConfig() *BackendConfig {
 		Retry:            DefaultRetryConfig(),
 		Stagnation:       DefaultStagnationConfig(),
 		Simplification:   DefaultSimplifyConfig(),
+		SubprocessLimits: DefaultSubprocessLimitsConfig(),
 	}
 }
 
@@ -847,6 +860,41 @@ type OpenAIConfig struct {
 
 	// Model is the default model name (default: gpt-4o).
 	Model string `yaml:"model,omitempty"`
+}
+
+// SubprocessLimitsConfig controls RSS telemetry and optional memory cap for the
+// Claude Code subprocess. GH-3028.
+//
+// Example YAML configuration:
+//
+//	executor:
+//	  subprocess_limits:
+//	    enabled: false           # flip to true after one baseline bench cycle
+//	    max_rss_mb: 4096         # cap at 4 GiB virtual address space (Linux only)
+//	    sample_interval_sec: 10  # how often to poll /proc/<pid>/status
+type SubprocessLimitsConfig struct {
+	// Enabled controls whether RLIMIT_AS is applied to the subprocess.
+	// Default: false. Flip to true after collecting a baseline week of peak_rss_mb
+	// data to choose a safe cap (recommended: p99 × 1.5).
+	Enabled bool `yaml:"enabled"`
+
+	// MaxRSSMB is the virtual address space limit in MiB applied via RLIMIT_AS on Linux.
+	// Ignored when Enabled=false or on non-Linux platforms.
+	// Default: 4096 (4 GiB).
+	MaxRSSMB int `yaml:"max_rss_mb,omitempty"`
+
+	// SampleIntervalSec controls how often (in seconds) the RSS sampler polls the subprocess.
+	// Default: 10.
+	SampleIntervalSec int `yaml:"sample_interval_sec,omitempty"`
+}
+
+// DefaultSubprocessLimitsConfig returns safe defaults: telemetry on, cap off.
+func DefaultSubprocessLimitsConfig() *SubprocessLimitsConfig {
+	return &SubprocessLimitsConfig{
+		Enabled:           false,
+		MaxRSSMB:          4096,
+		SampleIntervalSec: 10,
+	}
 }
 
 // BackendType constants for configuration.

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -224,6 +224,9 @@ type ClaudeCodeBackend struct {
 	apiBaseURL   string
 	apiAuthToken string
 	defaultModel string
+
+	// subprocessLimits configures RSS telemetry and optional RLIMIT_AS cap. GH-3028.
+	subprocessLimits *SubprocessLimitsConfig
 }
 
 // NewClaudeCodeBackend creates a new Claude Code backend.
@@ -244,6 +247,12 @@ func NewClaudeCodeBackend(config *ClaudeCodeConfig) *ClaudeCodeBackend {
 // SetHeartbeatTimeout sets a custom heartbeat timeout for this backend.
 func (b *ClaudeCodeBackend) SetHeartbeatTimeout(d time.Duration) {
 	b.heartbeatTimeout = d
+}
+
+// SetSubprocessLimits configures RSS telemetry and optional memory cap for the
+// Claude Code subprocess. GH-3028.
+func (b *ClaudeCodeBackend) SetSubprocessLimits(cfg *SubprocessLimitsConfig) {
+	b.subprocessLimits = cfg
 }
 
 // SetProviderEnv configures provider-routing env vars injected into the
@@ -419,6 +428,17 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 		return nil, fmt.Errorf("failed to start Claude Code: %w", err)
 	}
 	b.log.Debug("Claude Code started", slog.Int("pid", cmd.Process.Pid))
+
+	// GH-3028: apply RSS cap (Linux: RLIMIT_AS via prlimit64; darwin/other: no-op).
+	applyResourceLimits(cmd.Process.Pid, b.subprocessLimits)
+
+	// GH-3028: start RSS sampler — collects peak/final RSS for telemetry.
+	sampleInterval := 10 * time.Second
+	if b.subprocessLimits != nil && b.subprocessLimits.SampleIntervalSec > 0 {
+		sampleInterval = time.Duration(b.subprocessLimits.SampleIntervalSec) * time.Second
+	}
+	rssSamplerCtx, cancelRSSSampler := context.WithCancel(context.Background())
+	rssCh := StartRSSSampler(rssSamplerCtx, cmd.Process.Pid, sampleInterval)
 
 	// Track results
 	result := &BackendResult{}
@@ -650,6 +670,19 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 	// Wait for command to complete
 	err = cmd.Wait()
 	close(cmdDone) // Signal that command is done
+
+	// GH-3028: collect RSS sample (cancelling the sampler goroutine triggers final read).
+	cancelRSSSampler()
+	if rssSample, ok := <-rssCh; ok {
+		result.PeakRSSMB = rssSample.PeakMB
+		result.FinalRSSMB = rssSample.FinalMB
+		if rssSample.PeakMB > 0 {
+			b.log.Debug("Subprocess RSS telemetry",
+				slog.Int("peak_rss_mb", rssSample.PeakMB),
+				slog.Int("final_rss_mb", rssSample.FinalMB),
+			)
+		}
+	}
 
 	if err != nil {
 		// GH-2107: If a successful result event was seen before the process exited with

--- a/internal/executor/backend_factory.go
+++ b/internal/executor/backend_factory.go
@@ -21,6 +21,8 @@ func NewBackend(config *BackendConfig) (Backend, error) {
 		// subprocess env so users don't need to also edit
 		// ~/.claude/settings.json.
 		b.SetProviderEnv(config.APIBaseURL, config.APIAuthToken, config.DefaultModel)
+		// GH-3028: wire RSS telemetry + optional memory cap.
+		b.SetSubprocessLimits(config.SubprocessLimits)
 		return b, nil
 
 	case BackendTypeOpenCode:

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -718,6 +718,8 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 				LinesAdded:       result.LinesAdded,
 				LinesRemoved:     result.LinesRemoved,
 				ModelName:        result.ModelName,
+				PeakRSSMB:        result.PeakRSSMB,
+				FinalRSSMB:       result.FinalRSSMB,
 			}); err != nil {
 				w.log.Error("Failed to save execution metrics", slog.Any("error", err))
 			}

--- a/internal/executor/resource_limits_darwin.go
+++ b/internal/executor/resource_limits_darwin.go
@@ -1,0 +1,27 @@
+//go:build darwin
+
+package executor
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/qf-studio/pilot/internal/logging"
+)
+
+var darwinLimitWarnOnce sync.Once
+
+// applyResourceLimits is best-effort on macOS: prlimit64 is a Linux-only syscall
+// and macOS RLIMIT_AS support is unreliable. We log a one-time warning and degrade
+// to telemetry-only mode (RSS sampler still runs).
+func applyResourceLimits(pid int, cfg *SubprocessLimitsConfig) {
+	if cfg == nil || !cfg.Enabled || cfg.MaxRSSMB <= 0 {
+		return
+	}
+	darwinLimitWarnOnce.Do(func() {
+		logging.WithComponent("executor.resource_limits").Warn(
+			"subprocess_limits.enabled=true but memory cap is not supported on macOS; running in telemetry-only mode",
+			slog.Int("max_rss_mb", cfg.MaxRSSMB),
+		)
+	})
+}

--- a/internal/executor/resource_limits_linux.go
+++ b/internal/executor/resource_limits_linux.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+package executor
+
+import (
+	"log/slog"
+
+	"github.com/qf-studio/pilot/internal/logging"
+	"golang.org/x/sys/unix"
+)
+
+// applyResourceLimits calls prlimit64 on an already-started subprocess to cap its
+// virtual address space. Must be called after cmd.Start() when pid is valid.
+// RLIMIT_AS limits virtual address space; exceeding it causes malloc/mmap to return
+// ENOMEM, producing a clean exit rather than a kernel SIGKILL with no stderr.
+func applyResourceLimits(pid int, cfg *SubprocessLimitsConfig) {
+	if cfg == nil || !cfg.Enabled || cfg.MaxRSSMB <= 0 {
+		return
+	}
+
+	log := logging.WithComponent("executor.resource_limits")
+	maxBytes := uint64(cfg.MaxRSSMB) * 1024 * 1024
+	lim := unix.Rlimit{Cur: maxBytes, Max: maxBytes}
+
+	if err := unix.Prlimit(pid, unix.RLIMIT_AS, &lim, nil); err != nil {
+		log.Warn("Failed to apply RLIMIT_AS to subprocess (telemetry-only mode)",
+			slog.Int("pid", pid),
+			slog.Int("max_rss_mb", cfg.MaxRSSMB),
+			slog.Any("error", err),
+		)
+		return
+	}
+
+	log.Debug("Applied RLIMIT_AS to subprocess",
+		slog.Int("pid", pid),
+		slog.Int("max_rss_mb", cfg.MaxRSSMB),
+	)
+}

--- a/internal/executor/resource_limits_other.go
+++ b/internal/executor/resource_limits_other.go
@@ -1,0 +1,6 @@
+//go:build !linux && !darwin
+
+package executor
+
+// applyResourceLimits is a no-op on unsupported platforms.
+func applyResourceLimits(_ int, _ *SubprocessLimitsConfig) {}

--- a/internal/executor/retry.go
+++ b/internal/executor/retry.go
@@ -46,6 +46,10 @@ type RetryStrategy struct {
 //	      max_attempts: 2
 //	      extend_timeout: true
 //	      timeout_multiplier: 1.5
+//	    oom_killed:
+//	      max_attempts: 2
+//	      initial_backoff: 10s
+//	      backoff_multiplier: 1.0
 type RetryConfig struct {
 	// Enabled controls whether smart retry is active
 	Enabled bool `yaml:"enabled"`
@@ -58,6 +62,11 @@ type RetryConfig struct {
 
 	// Timeout strategy for timeout errors (retry with extended timeout)
 	Timeout *RetryStrategy `yaml:"timeout,omitempty"`
+
+	// OOMKilled strategy for OOM-killed subprocess errors. GH-3028.
+	// Retry once after 10s — GH-22/sub-43 proved the task itself is small;
+	// the waste is in over-reading context on the first attempt.
+	OOMKilled *RetryStrategy `yaml:"oom_killed,omitempty"`
 
 	// DecomposeOnKill enables automatic decomposition when execution is killed
 	// (OOM, signal:killed, timeout). Instead of plain retry, the task is decomposed
@@ -86,6 +95,11 @@ func DefaultRetryConfig() *RetryConfig {
 			MaxAttempts:       2, // Retry once
 			ExtendTimeout:     true,
 			TimeoutMultiplier: 1.5,
+		},
+		OOMKilled: &RetryStrategy{
+			MaxAttempts:       2,    // Retry once — GH-22/sub-43 succeeded in 33s on first retry
+			InitialBackoff:    10 * time.Second,
+			BackoffMultiplier: 1.0, // flat backoff; OOM is not time-sensitive
 		},
 	}
 }
@@ -153,6 +167,11 @@ func (r *Retrier) Evaluate(err error, attempt int, originalTimeout time.Duration
 	case "timeout":
 		strategy = r.config.Timeout
 		errorName = "timeout"
+	case "oom_killed":
+		// GH-3028: OOM retry — subprocess killed by kernel or our own limiter.
+		// GH-22/sub-43 proved a clean retry succeeded in 33s; don't decompose first.
+		strategy = r.config.OOMKilled
+		errorName = "oom_killed"
 	case "invalid_config":
 		// Invalid config should never be retried - fail fast
 		return RetryDecision{

--- a/internal/executor/retry_test.go
+++ b/internal/executor/retry_test.go
@@ -186,6 +186,65 @@ func TestRetrier_Sleep_Success(t *testing.T) {
 	}
 }
 
+func TestRetrier_Evaluate_OOMKilled_RetryOnce(t *testing.T) {
+	config := &RetryConfig{
+		Enabled: true,
+		OOMKilled: &RetryStrategy{
+			MaxAttempts:       2,
+			InitialBackoff:    10 * time.Second,
+			BackoffMultiplier: 1.0,
+		},
+	}
+	retrier := NewRetrier(config)
+	err := &ClaudeCodeError{Type: ErrorTypeOOM, Message: "Process killed by SIGKILL (exit code 137)"}
+
+	// First attempt should retry with 10s backoff
+	decision := retrier.Evaluate(err, 0, 10*time.Minute)
+	if !decision.ShouldRetry {
+		t.Error("Expected ShouldRetry=true for first OOM attempt")
+	}
+	if decision.BackoffDuration != 10*time.Second {
+		t.Errorf("Expected 10s backoff, got %v", decision.BackoffDuration)
+	}
+}
+
+func TestRetrier_Evaluate_OOMKilled_GiveUpAfterMax(t *testing.T) {
+	config := &RetryConfig{
+		Enabled: true,
+		OOMKilled: &RetryStrategy{
+			MaxAttempts:       2,
+			InitialBackoff:    10 * time.Second,
+			BackoffMultiplier: 1.0,
+		},
+	}
+	retrier := NewRetrier(config)
+	err := &ClaudeCodeError{Type: ErrorTypeOOM, Message: "Process killed by SIGKILL (exit code 137)"}
+
+	// Second attempt (attempt=2) should NOT retry — max reached
+	decision := retrier.Evaluate(err, 2, 10*time.Minute)
+	if decision.ShouldRetry {
+		t.Error("Expected ShouldRetry=false after max OOM attempts")
+	}
+}
+
+func TestRetrier_Evaluate_OOMKilled_NotRetriedWhenNoStrategy(t *testing.T) {
+	// Retry config without OOMKilled strategy = no retry for OOM
+	config := &RetryConfig{
+		Enabled: true,
+		RateLimit: &RetryStrategy{
+			MaxAttempts: 3,
+		},
+		// OOMKilled intentionally omitted
+	}
+	retrier := NewRetrier(config)
+	err := &ClaudeCodeError{Type: ErrorTypeOOM, Message: "oom"}
+
+	decision := retrier.Evaluate(err, 0, 10*time.Minute)
+	if decision.ShouldRetry {
+		t.Error("Expected ShouldRetry=false when OOMKilled strategy is not configured")
+	}
+}
+
 func TestDefaultRetryConfig(t *testing.T) {
 	config := DefaultRetryConfig()
 
@@ -200,5 +259,11 @@ func TestDefaultRetryConfig(t *testing.T) {
 	}
 	if config.Timeout == nil {
 		t.Error("Expected Timeout to be configured")
+	}
+	if config.OOMKilled == nil {
+		t.Error("Expected OOMKilled to be configured")
+	}
+	if config.OOMKilled.MaxAttempts != 2 {
+		t.Errorf("Expected OOMKilled.MaxAttempts=2, got %d", config.OOMKilled.MaxAttempts)
 	}
 }

--- a/internal/executor/rss_sampler.go
+++ b/internal/executor/rss_sampler.go
@@ -1,0 +1,41 @@
+package executor
+
+import (
+	"context"
+	"time"
+)
+
+// RSSSample holds peak and final RSS readings from a subprocess.
+type RSSSample struct {
+	PeakMB  int
+	FinalMB int
+}
+
+// StartRSSSampler polls the subprocess RSS every interval until ctx is cancelled,
+// then returns the peak and final readings.  Implementations are split by OS:
+// rss_sampler_linux.go reads /proc/<pid>/status; rss_sampler_darwin.go uses
+// `ps -o rss=`; rss_sampler_other.go is a no-op that always returns zero.
+func StartRSSSampler(ctx context.Context, pid int, interval time.Duration) <-chan RSSSample {
+	ch := make(chan RSSSample, 1)
+	go func() {
+		var peak int
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				final := readRSSMB(pid)
+				if final > peak {
+					peak = final
+				}
+				ch <- RSSSample{PeakMB: peak, FinalMB: final}
+				return
+			case <-ticker.C:
+				if rss := readRSSMB(pid); rss > peak {
+					peak = rss
+				}
+			}
+		}
+	}()
+	return ch
+}

--- a/internal/executor/rss_sampler_darwin.go
+++ b/internal/executor/rss_sampler_darwin.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package executor
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// readRSSMB reads the RSS for pid using `ps -o rss= -p <pid>` and returns MB.
+// Returns 0 if the process has exited or ps fails.
+func readRSSMB(pid int) int {
+	out, err := exec.Command("ps", "-o", "rss=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0
+	}
+	kb, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0
+	}
+	return kb / 1024
+}

--- a/internal/executor/rss_sampler_linux.go
+++ b/internal/executor/rss_sampler_linux.go
@@ -1,0 +1,37 @@
+//go:build linux
+
+package executor
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// readRSSMB reads the VmRSS field from /proc/<pid>/status and returns MB.
+// Returns 0 if the file cannot be read (process may have exited).
+func readRSSMB(pid int) int {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "VmRSS:") {
+			// Format: "VmRSS:\t   12345 kB"
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				kb, err := strconv.Atoi(fields[1])
+				if err == nil {
+					return kb / 1024
+				}
+			}
+		}
+	}
+	return 0
+}

--- a/internal/executor/rss_sampler_other.go
+++ b/internal/executor/rss_sampler_other.go
@@ -1,0 +1,6 @@
+//go:build !linux && !darwin
+
+package executor
+
+// readRSSMB returns 0 on unsupported platforms.
+func readRSSMB(_ int) int { return 0 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -284,6 +284,11 @@ type ExecutionResult struct {
 	Declined bool
 	// DeclinedReason is the human-readable reason Claude provided for the decline.
 	DeclinedReason string
+	// PeakRSSMB is the peak subprocess RSS in MiB collected by the RSS sampler. GH-3028.
+	// Zero on non-Linux/darwin platforms or when the sampler had no data.
+	PeakRSSMB int
+	// FinalRSSMB is the subprocess RSS at exit. GH-3028.
+	FinalRSSMB int
 }
 
 // ProgressCallback is a function called during execution with progress updates.
@@ -2124,6 +2129,9 @@ retrySucceeded:
 	result.TokensOutput = backendResult.TokensOutput
 	result.TokensTotal = backendResult.TokensInput + backendResult.TokensOutput
 	result.ModelName = backendResult.Model
+	// GH-3028: propagate RSS telemetry from backend to execution result.
+	result.PeakRSSMB = backendResult.PeakRSSMB
+	result.FinalRSSMB = backendResult.FinalRSSMB
 
 	// Track research phase tokens (GH-217)
 	if researchResult != nil {

--- a/internal/memory/metrics.go
+++ b/internal/memory/metrics.go
@@ -18,6 +18,9 @@ type ExecutionMetrics struct {
 	LinesAdded       int
 	LinesRemoved     int
 	ModelName        string
+	// GH-3028: RSS telemetry — zero on non-Linux/darwin or before Step 1 deploy.
+	PeakRSSMB  int
+	FinalRSSMB int
 }
 
 // MetricsQuery holds parameters for querying metrics
@@ -209,11 +212,15 @@ func (s *Store) SaveExecutionMetrics(metrics *ExecutionMetrics) error {
 				files_changed = ?,
 				lines_added = ?,
 				lines_removed = ?,
-				model_name = ?
+				model_name = ?,
+				peak_rss_mb = ?,
+				final_rss_mb = ?
 			WHERE id = ?
 		`, metrics.TokensInput, metrics.TokensOutput, metrics.TokensTotal,
 			metrics.EstimatedCostUSD, metrics.FilesChanged, metrics.LinesAdded,
-			metrics.LinesRemoved, metrics.ModelName, metrics.ExecutionID)
+			metrics.LinesRemoved, metrics.ModelName,
+			metrics.PeakRSSMB, metrics.FinalRSSMB,
+			metrics.ExecutionID)
 		return err
 	})
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -327,6 +327,9 @@ func (s *Store) migrate() error {
 		`ALTER TABLE autopilot_metrics ADD COLUMN tokens_consumed_json TEXT DEFAULT '{}'`,
 		`ALTER TABLE autopilot_metrics ADD COLUMN execution_cost_usd_json TEXT DEFAULT '{}'`,
 		`ALTER TABLE autopilot_metrics ADD COLUMN executions_by_result_json TEXT DEFAULT '{}'`,
+		// GH-3028: RSS telemetry — peak and final resident set size for subprocess OOM diagnostics.
+		`ALTER TABLE executions ADD COLUMN peak_rss_mb INTEGER DEFAULT 0`,
+		`ALTER TABLE executions ADD COLUMN final_rss_mb INTEGER DEFAULT 0`,
 	}
 
 	for _, migration := range migrations {
@@ -429,6 +432,9 @@ type Execution struct {
 	ApprovalDecision   string
 	ApprovalDecisionAt *time.Time
 	ApprovalDecisionBy string
+	// GH-3028: RSS telemetry
+	PeakRSSMB  int
+	FinalRSSMB int
 }
 
 // SaveExecution saves an execution record to the database.
@@ -627,7 +633,8 @@ func (s *Store) GetRecentExecutions(limit int) ([]*Execution, error) {
 	rows, err := s.db.Query(`
 		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at,
 			COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
-			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0)
+			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
+			COALESCE(peak_rss_mb, 0), COALESCE(final_rss_mb, 0)
 		FROM executions ORDER BY created_at DESC LIMIT ?
 	`, limit)
 	if err != nil {
@@ -640,7 +647,8 @@ func (s *Store) GetRecentExecutions(limit int) ([]*Execution, error) {
 		var exec Execution
 		var completedAt sql.NullTime
 		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &completedAt,
-			&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose); err != nil {
+			&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose,
+			&exec.PeakRSSMB, &exec.FinalRSSMB); err != nil {
 			return nil, err
 		}
 		if completedAt.Valid {


### PR DESCRIPTION
Closes #3028

## Summary

Three-layer hardening for the recurring `exit code 137` SIGKILL pattern (3 incidents in 24h, all during RESEARCH phase, ~30 min/day wasted):

### Step 1 — RSS Telemetry (always on, no behavior change)
- `rss_sampler.go` + OS-split impls poll subprocess RSS every 10s
  - Linux: `/proc/<pid>/status` (VmRSS field)
  - macOS: `ps -o rss=`
  - other: no-op
- `PeakRSSMB` / `FinalRSSMB` flow through `BackendResult` → `ExecutionResult` → `memory.ExecutionMetrics` → two new DB columns (`peak_rss_mb`, `final_rss_mb`, auto-migrated with `DEFAULT 0`)
- Dashboard history panel shows compact RSS indicator (`4.2G`) after the time-ago stamp

### Step 2 — OOM Smart-Retry (deterministic, observable)
- `retry.go`: new `OOMKilled *RetryStrategy`; `Retrier.Evaluate` handles `"oom_killed"` → retry once after 10s flat backoff
- `DefaultRetryConfig` pre-wires `OOMKilled{MaxAttempts:2, InitialBackoff:10s}` (takes effect when `retry.enabled: true`)
- 3 new table tests: retry-once, give-up-after-max, no-retry-when-strategy-absent

### Step 3 — Memory Cap (Linux only, default off)
- `resource_limits_linux.go`: `unix.Prlimit(pid, RLIMIT_AS, lim)` after `cmd.Start()` → clean ENOMEM instead of kernel SIGKILL
- `resource_limits_darwin.go`: one-time WARN log, degrades to telemetry-only
- `resource_limits_other.go`: no-op stub
- New `SubprocessLimitsConfig{Enabled, MaxRSSMB=4096, SampleIntervalSec=10}` on `BackendConfig`; default `Enabled=false` — flip after one baseline bench cycle

`golang.org/x/sys` promoted from indirect → direct dependency.

## Test plan
- [ ] `go test ./internal/executor/...` — all pass including 3 new OOM retry tests
- [ ] `go test ./internal/memory/...` — DB migration + metrics save pass
- [ ] `go test ./internal/dashboard/...` — dashboard rendering unchanged
- [ ] `go build ./...` — clean build on darwin (resource_limits_darwin.go no-op path)
- [ ] After deploy: verify `peak_rss_mb > 0` in executions table for Linux runs
- [ ] Manually trigger OOM (or inject `oom_killed` error) with `retry.enabled: true` and confirm retry appears in logs as `attempt=0 max_attempts=2`