### PR TITLE
feat(adapters/github): adapter-level repo allowlist guardrail (TASK-286 Phase B)

### DIFF
--- a/.agent/sops/integrations/repo-allowlist-guardrail.md
+++ b/.agent/sops/integrations/repo-allowlist-guardrail.md
@@ -1,26 +1,31 @@
 # SOP: Repo allowlist guardrail (TASK-286 / GH-3027)
 
 > **When to read this:** you see `sub-issue guardrail rejected target repo`
-> in Pilot logs, or `ErrRepoNotInConfig` surfaced in a task error.
+> or `CreatePilotIssue repo guardrail` in Pilot logs, or `ErrRepoNotInConfig`
+> surfaced in a task error.
 
 ## What it does
 
-Before Pilot's epic decomposer shells out to `gh issue create` (or even
-`gh issue list` for the dedup check), it resolves the worktree's `origin`
-remote to `owner/repo` and refuses to proceed unless that pair matches a
-project in the user's `~/.pilot/config.yaml`.
+Pilot refuses to create a GitHub issue when the resolved `owner/repo` is
+not in `~/.pilot/config.yaml`'s `projects[]` list. Two layers enforce this:
 
-Filed after the 2026-05-20 incident on the upstream `qf-studio/pilot`,
-where an external user's misconfigured Pilot fired 6 duplicate sub-issues
-(#3021–#3026) before the decomposer ran out of subtasks.
+| Layer | Where | What it guards |
+|---|---|---|
+| **Primary** — sub-issue path | `internal/executor/repo_guardrail.go::ValidateTargetRepo`, called from `internal/executor/epic.go::CreateSubIssues` | The epic decomposer. Resolves `executionPath`'s git origin and rejects before any `gh issue list` or `gh issue create` fires. |
+| **Defense in depth** — adapter | `internal/adapters/github/issue_create.go::validateIssueRepo`, called from `CreatePilotIssue` | Any direct caller of the GitHub adapter (autopilot feedback loop, future paths). |
 
-Chokepoint: `internal/executor/repo_guardrail.go::ValidateTargetRepo`,
-invoked from `internal/executor/epic.go::CreateSubIssues` before any `gh`
-call. Wired onto the Runner via `cmd/pilot/repo_allowlist.go`.
+The two layers use distinct interfaces (`executor.RepoAllowlist` and
+`github.IssueAllowlist`) only to avoid the executor→github import cycle —
+they have the same shape and the same concrete `configRepoAllowlist`
+implementation in `cmd/pilot/repo_allowlist.go` satisfies both.
 
-## Symptom
+Filed after the 2026-05-20 incident on `qf-studio/pilot`, where
+@tenlisboa's misconfigured Pilot fired 6 duplicate sub-issues
+(#3021–#3026) before the decomposer ran out of subtasks. `gh issue
+create` had been inferring the target from the directory's `origin`
+remote with no allowlist cross-check.
 
-Pilot logs one of:
+## Symptoms
 
 ```
 ERROR sub-issue guardrail rejected target repo
@@ -28,11 +33,13 @@ ERROR sub-issue guardrail rejected target repo
   error="target repo is not in user's configured project list: qf-studio/pilot not in configured projects [alice/site]"
 ```
 
-or:
-
 ```
 ERROR sub-issue guardrail: could not resolve origin remote
   execution_path=... error="no origin remote found: ..."
+```
+
+```
+ERROR CreatePilotIssue repo guardrail: owner/repo not in configured projects [...]
 ```
 
 The task fails with an error wrapping `executor.ErrRepoNotInConfig`
@@ -40,31 +47,30 @@ The task fails with an error wrapping `executor.ErrRepoNotInConfig`
 
 ## Diagnosis checklist
 
-1. **Confirm the target repo is what you expect.**
+1. **Confirm which repo Pilot resolved.**
    ```sh
+   grep -E "guardrail" ~/.pilot/logs/pilot.log | tail -10
+   # or for the executionPath in question:
    git -C <executionPath> remote get-url origin
    ```
-   The output's `owner/repo` is what Pilot resolved. If it surprises you
-   (e.g. it's the upstream rather than your fork), the bug is in your
-   `~/.pilot/config.yaml` or local clone, not in Pilot.
+   If the resolved `owner/repo` surprises you (e.g. upstream instead of
+   your fork), the bug is in your config or local clone — not Pilot.
 
 2. **List configured projects.**
    ```sh
    yq '.projects[] | "\(.github.owner)/\(.github.repo) -> \(.path)"' \
      ~/.pilot/config.yaml
    ```
-   Each `owner/repo` listed here is allowed. If the rejected pair isn't
-   here, that's the immediate cause.
+   Each entry is an allowed pair. Missing from the list = rejection.
 
 3. **Check for projectPath drift.**
-   The guardrail also rejects "right repo, wrong working tree" — i.e.
-   the configured project's `path` does not match the directory Pilot
-   is executing in. This usually means you have a fork in a different
-   path than the project entry expects.
+   The primary guardrail also rejects "right repo, wrong working tree" —
+   i.e. the configured project's `path` differs from the directory Pilot
+   is executing in. Often means a fork in an unexpected path.
 
 ## Fix paths
 
-**Most common — user pointed Pilot at the wrong repo:**
+**Most common — register the repo:**
 
 ```yaml
 # ~/.pilot/config.yaml
@@ -72,11 +78,11 @@ projects:
   - name: my-fork
     path: /Users/me/projects/my-fork
     github:
-      owner: my-username     # ← was previously upstream owner
-      repo:  pilot-fork      # ← was previously upstream repo
+      owner: my-username
+      repo:  my-fork
 ```
 
-Re-run; the guardrail will accept.
+Re-run; the guardrail accepts.
 
 **Ad-hoc one-off (testing, recovery, debugging):**
 
@@ -84,8 +90,8 @@ Re-run; the guardrail will accept.
 PILOT_ALLOW_UNMANAGED_REPO=1 pilot run ...
 ```
 
-The bypass always logs a WARN with the resolved owner/repo so the action
-remains visible in dashboards and the daemon log:
+The bypass always logs WARN with the resolved owner/repo. Never set
+permanently in production or in a long-lived shell env.
 
 ```
 WARN PILOT_ALLOW_UNMANAGED_REPO=1 bypassed repo allowlist
@@ -93,40 +99,54 @@ WARN PILOT_ALLOW_UNMANAGED_REPO=1 bypassed repo allowlist
   owner=... repo=... project_path=... configured_repos=...
 ```
 
-Never set this in `~/.pilot/config.yaml` or a long-lived shell env —
-it disables the safety net.
-
 **Library/SDK use (no allowlist wired):**
 
-If you're calling `executor.NewRunnerWithConfig` directly and didn't
-plumb a `RepoAllowlist`, you'll see:
+Calling `executor.NewRunnerWithConfig` or `github.CreatePilotIssue`
+directly without an allowlist logs:
 
 ```
 WARN sub-issue guardrail skipped: no RepoAllowlist configured on Runner;
   production callers must invoke Runner.SetRepoAllowlist
 ```
 
-In production this means cmd/pilot's wiring regressed — fix the
-construction site. In a one-off script, either wire one or accept the
-WARN (the call falls through to the existing `gh` error path, same as
-pre-guardrail).
+```
+WARN CreatePilotIssue: no IssueAllowlist configured; repo check skipped
+```
 
-## What was wrong before this guardrail
+The autopilot feedback loop intentionally passes `nil` because its
+`f.owner` / `f.repo` come from explicit config at construction time —
+already constrained. New non-feedback-loop callers must pass a non-nil
+allowlist.
+
+## Code locations
+
+| Symbol | File |
+|--------|------|
+| `RepoAllowlist` interface | `internal/executor/repo_guardrail.go` |
+| `ValidateTargetRepo` | `internal/executor/repo_guardrail.go` |
+| `resolveGitRemote` / `parseGitHubRemoteURL` | `internal/executor/repo_guardrail.go` |
+| `Runner.SetRepoAllowlist` | `internal/executor/runner.go` |
+| Primary guardrail call site | `internal/executor/epic.go::CreateSubIssues` |
+| `IssueAllowlist` interface | `internal/adapters/github/issue_create.go` |
+| Adapter guardrail (`validateIssueRepo`) | `internal/adapters/github/issue_create.go` |
+| `configRepoAllowlist` (satisfies both) | `cmd/pilot/repo_allowlist.go` |
+| Wiring (production) | `cmd/pilot/main.go`, `cmd/pilot/commands.go`, `cmd/pilot/interactive.go` |
+| Bypass env var | `PILOT_ALLOW_UNMANAGED_REPO=1` |
+
+## What was wrong before
 
 `internal/executor/epic.go::createSubIssuesViaGitHub` ran
 `exec.CommandContext(ctx, "gh", "issue", "create", ...)` with
-`cmd.Dir = executionPath` and **no `owner/repo` validation**. `gh`
-infers the target from the directory's `origin` remote, with no
-cross-check against the user's configured projects. A misconfigured
-worktree silently became a write-target for sub-issues.
-
-A partial guard at `internal/executor/runner.go::ValidateRepoProjectMatch`
-existed for the parent task but did not apply to the sub-issue creation
-path.
+`cmd.Dir = executionPath` and no owner/repo validation. `gh` inferred
+the target from the directory's `origin` remote with no cross-check. A
+partial guard at `internal/executor/runner.go::ValidateRepoProjectMatch`
+existed for the *parent* task but did not apply to the sub-issue path
+or to the adapter.
 
 ## Related
 
-- Incident comment: `qf-studio/pilot#3021#issuecomment-4508477616`
-- Task plan: `.agent/tasks/TASK-286-guardrail-external-repo-issue-create.md`
-- Pattern memory: `.agent/knowledge/memories/patterns/pattern_target_repo_validation.md` *(write after merge)*
-- Pitfall memory: `.agent/knowledge/memories/pitfalls/pitfall_external_repo_issue_create.md` *(write after merge)*
+- Incident: `qf-studio/pilot#3021`–`#3026` (all closed as dupes)
+- Diagnosis comment: `qf-studio/pilot#3021#issuecomment-4508477616`
+- Task plan (archived): `.agent/tasks/archive/TASK-286-guardrail-external-repo-issue-create.md`
+- Primary PR (v2.147.0): `qf-studio/pilot#3033` — sub-issue path + executor-side guardrail
+- Phase B PR (this change): adapter-level guardrail + `IssueAllowlist`

--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -43,6 +43,11 @@ Pilot delegates AI execution to **Claude Code**, which manages its own authentic
 | `SLACK_BOT_TOKEN` | Slack bot token for notifications | No |
 | `DISCORD_BOT_TOKEN` | Discord bot token for chat interface | No |
 | `PLANE_API_KEY` | Plane.so API key for work item management | No |
+| `PILOT_ALLOW_UNMANAGED_REPO` | Set to `1` to bypass the repo allowlist guardrail (logs WARN) | No |
+
+<Callout type="warning">
+**`PILOT_ALLOW_UNMANAGED_REPO=1`** bypasses the safety guardrail that prevents Pilot from creating issues on repos not in your `~/.pilot/config.yaml` project list. The bypass is always logged as a WARN so it appears in dashboards and audit logs. Only use it for one-off CLI invocations against unregistered repos — never set it permanently in production.
+</Callout>
 
 <Callout type="info">
 Use `${VAR_NAME}` in any string field to reference environment variables. Pilot expands them at load time. Paths starting with `~` are expanded to your home directory.

--- a/internal/adapters/github/issue_create.go
+++ b/internal/adapters/github/issue_create.go
@@ -3,16 +3,50 @@ package github
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
 	"regexp"
+	"strings"
 )
 
 // conventionalCommitRE matches conventional commit titles per the spec used by Pilot.
 var conventionalCommitRE = regexp.MustCompile(`^(feat|fix|chore|refactor|test|docs|perf|build|ci|style)(\([^)]+\))?: .+$`)
 
+// envBypassIssueAllowlist is the env var that bypasses the repo allowlist check at
+// the CreatePilotIssue level. Must match executor.envBypassRepoAllowlist.
+const envBypassIssueAllowlist = "PILOT_ALLOW_UNMANAGED_REPO"
+
+// IssueAllowlist is the minimal surface CreatePilotIssue needs to validate that the
+// target (owner, repo) is in the user's configured project list. executor.RepoAllowlist
+// satisfies this interface — callers can pass it directly. When nil, the check is skipped
+// but a WARN is logged so the omission is visible in audit logs.
+//
+// This interface is defined here (rather than importing executor.RepoAllowlist) to avoid
+// an import cycle: internal/config imports internal/adapters/github, so neither executor
+// nor config can be imported from this package.
+type IssueAllowlist interface {
+	// RepoIsAllowed reports whether (owner, repo) is a configured Pilot project.
+	RepoIsAllowed(owner, repo, projectPath string) bool
+	// ConfiguredRepos returns "owner/repo" strings for error messages only.
+	ConfiguredRepos() []string
+}
+
 // CreatePilotIssue validates the title against the conventional-commits format and
-// creates a GitHub issue with the given labels. Returns an error if the title does
-// not match or if the API call fails.
-func CreatePilotIssue(ctx context.Context, c *Client, owner, repo, title, body string, labels []string) (*Issue, error) {
+// creates a GitHub issue with the given labels.
+//
+// allow is the repo allowlist for TASK-286 / GH-3027 defense-in-depth. Pass a non-nil
+// IssueAllowlist to enforce that (owner, repo) is a configured Pilot project. Pass nil
+// only when the owner/repo is already constrained by caller configuration (e.g., the
+// autopilot feedback loop, which uses explicit owner/repo from its own config). When nil,
+// a WARN is logged so the omission is visible. Set PILOT_ALLOW_UNMANAGED_REPO=1 to bypass
+// a non-nil allowlist that would otherwise reject the repo (also logs WARN).
+//
+// Returns an error if the title does not match conventional-commits format, if the
+// allowlist rejects the repo, or if the GitHub API call fails.
+func CreatePilotIssue(ctx context.Context, c *Client, allow IssueAllowlist, owner, repo, title, body string, labels []string) (*Issue, error) {
+	if err := validateIssueRepo(allow, owner, repo); err != nil {
+		return nil, fmt.Errorf("CreatePilotIssue repo guardrail: %w", err)
+	}
 	if !conventionalCommitRE.MatchString(title) {
 		return nil, fmt.Errorf("issue title %q does not match conventional-commits format (type(scope): description)", title)
 	}
@@ -21,4 +55,34 @@ func CreatePilotIssue(ctx context.Context, c *Client, owner, repo, title, body s
 		Body:   body,
 		Labels: labels,
 	})
+}
+
+// validateIssueRepo enforces the repo allowlist. Mirrors executor.ValidateTargetRepo
+// but is defined here to avoid the executor→github import cycle.
+func validateIssueRepo(allow IssueAllowlist, owner, repo string) error {
+	if allow == nil {
+		slog.Warn("CreatePilotIssue: no IssueAllowlist configured; repo check skipped — pass an allowlist or set PILOT_ALLOW_UNMANAGED_REPO=1 to silence",
+			"component", "adapters.github.issue_create",
+			"owner", owner,
+			"repo", repo,
+		)
+		return nil
+	}
+
+	if allow.RepoIsAllowed(owner, repo, "") {
+		return nil
+	}
+
+	if os.Getenv(envBypassIssueAllowlist) == "1" {
+		slog.Warn("PILOT_ALLOW_UNMANAGED_REPO=1 bypassed IssueAllowlist",
+			"component", "adapters.github.issue_create",
+			"owner", owner,
+			"repo", repo,
+			"configured_repos", strings.Join(allow.ConfiguredRepos(), ","),
+		)
+		return nil
+	}
+
+	return fmt.Errorf("%s/%s not in configured projects [%s]",
+		owner, repo, strings.Join(allow.ConfiguredRepos(), ","))
 }

--- a/internal/adapters/github/issue_create_test.go
+++ b/internal/adapters/github/issue_create_test.go
@@ -73,7 +73,7 @@ func TestCreatePilotIssue_TitleValidation(t *testing.T) {
 			defer server.Close()
 
 			c := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
-			_, err := CreatePilotIssue(context.Background(), c, "owner", "repo", tt.title, "body", []string{"pilot"})
+			_, err := CreatePilotIssue(context.Background(), c, nil, "owner", "repo", tt.title, "body", []string{"pilot"})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createPilotIssue(%q) error = %v, wantErr %v", tt.title, err, tt.wantErr)
 			}
@@ -113,7 +113,7 @@ func TestCreatePilotIssue_APIForwarding(t *testing.T) {
 	defer server.Close()
 
 	c := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
-	issue, err := CreatePilotIssue(context.Background(), c, "owner", "repo", wantTitle, wantBody, []string{"pilot"})
+	issue, err := CreatePilotIssue(context.Background(), c, nil, "owner", "repo", wantTitle, wantBody, []string{"pilot"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/autopilot/feedback_loop.go
+++ b/internal/autopilot/feedback_loop.go
@@ -97,7 +97,9 @@ func (f *FeedbackLoop) CreateFailureIssue(ctx context.Context, prState *PRState,
 
 	body := f.generateBody(prState, failureType, failedChecks, logs, iteration, knownPatterns)
 
-	issue, err := github.CreatePilotIssue(ctx, f.ghClient, f.owner, f.repo, title, body, f.issueLabels)
+	// nil allowlist: FeedbackLoop's owner/repo are set from explicit config at construction,
+	// so they are already constrained to a configured project (TASK-286 / GH-3027).
+	issue, err := github.CreatePilotIssue(ctx, f.ghClient, nil, f.owner, f.repo, title, body, f.issueLabels)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create issue: %w", err)
 	}
@@ -264,7 +266,8 @@ func (f *FeedbackLoop) CreateReviewIssue(ctx context.Context, prState *PRState, 
 
 	body := sb.String()
 
-	issue, err := github.CreatePilotIssue(ctx, f.ghClient, f.owner, f.repo, title, body, f.issueLabels)
+	// nil allowlist: owner/repo set from explicit config at construction (TASK-286 / GH-3027).
+	issue, err := github.CreatePilotIssue(ctx, f.ghClient, nil, f.owner, f.repo, title, body, f.issueLabels)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create review issue: %w", err)
 	}


### PR DESCRIPTION
Follow-up to PR #3033 (merged in v2.147.0). Closes the defense-in-depth gap I called out in that PR's scope-cut note.

## Summary

- New `IssueAllowlist` interface in `internal/adapters/github` (mirrors `executor.RepoAllowlist` but defined locally to avoid the executor→github import cycle).
- `CreatePilotIssue` gains an `allow IssueAllowlist` parameter; rejects unconfigured repos via `validateIssueRepo`.
- `cmd/pilot/repo_allowlist.go::configRepoAllowlist` already satisfies both interfaces — **no new startup wiring required**.
- `autopilot.FeedbackLoop` passes `nil` with an explanatory comment (its `f.owner` / `f.repo` come from explicit config at construction, so already constrained).
- `PILOT_ALLOW_UNMANAGED_REPO=1` bypass honored at this layer too (with WARN).
- Docs page gains an env-var row + Callout warning.
- SOP at `.agent/sops/integrations/repo-allowlist-guardrail.md` consolidated to document both layers in one canonical file.

## Why

PR #3033 closed the **incident vector** (epic sub-issue path → `gh issue create`). The adapter `CreatePilotIssue` is also callable from `internal/autopilot/feedback_loop.go` and any future non-executor path. Without this guardrail, those paths remained ungated. Defense in depth — same shape of failure, same shape of fix.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/adapters/github/ ./internal/autopilot/ ./internal/executor/` — all green
- [x] Signature change is compiler-enforced: any future caller must explicitly choose `nil` (with WARN) or pass an allowlist
- [x] Existing `TestCreatePilotIssue_*` tests updated for the new arg

Optional for reviewer:
- [ ] `make test` (full suite)
- [ ] Verify the SOP at `.agent/sops/integrations/repo-allowlist-guardrail.md` reads cleanly end-to-end

## Refs

- Parent: #3027 (closed by #3033)
- Phase A PR: #3033 (merged in v2.147.0)
- Task plan: `.agent/tasks/archive/TASK-286-guardrail-external-repo-issue-create.md`