### PR TITLE
fix(autopilot): warn when startup gates silently disable autopilot

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1403,6 +1403,15 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				ghToken = os.Getenv("GITHUB_TOKEN")
 			}
 		}
+		if ghToken == "" {
+			// GH-3050: surface silent autopilot disable when token is missing.
+			// Without this warning, --env=<...> appears accepted but autopilot
+			// never starts because controller creation is skipped here.
+			logging.WithComponent("autopilot").Warn(
+				"autopilot enabled but no GitHub token resolved — autopilot will not start (set adapters.github.token or GITHUB_TOKEN)",
+				slog.String("env", string(cfg.Orchestrator.Autopilot.Environment)),
+			)
+		}
 		if ghToken != "" {
 			ghClient := github.NewClient(ghToken)
 
@@ -2260,6 +2269,14 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			if len(ghPollers) == 0 {
 				logging.WithComponent("github").Warn("GitHub polling enabled but no repos configured — set adapters.github.repo or add project-level github.owner/github.repo",
 					slog.Int("pollers", 0))
+				// GH-3050: surface second silent autopilot gate. Controllers
+				// were created but will not Start because there are no pollers.
+				if len(autopilotControllers) > 0 {
+					logging.WithComponent("autopilot").Warn(
+						"autopilot controllers created but no GitHub pollers configured — autopilot will not start",
+						slog.Int("controllers", len(autopilotControllers)),
+					)
+				}
 			}
 
 			if len(ghPollers) > 0 {


### PR DESCRIPTION
## Summary

`pilot start --env=stage` (or `dev`/`prod`) silently no-oped in environments without a resolved GitHub token. The flag was accepted, `Autopilot.Enabled = true` was set in memory, but two later gates skipped controller creation and start with no log output.

## Root cause

Two silent gates in `runPollingMode`:

- **`cmd/pilot/main.go:1406`** — `if ghToken != ""`. When `adapters.github.token` and `GITHUB_TOKEN` are both empty, the entire controller-creation block is skipped. No `else`, no log.
- **`cmd/pilot/main.go:2265`** — `if len(ghPollers) > 0`. Even if controllers exist, `controller.Start(ctx)` and `c.Run(ctx)` only run when at least one GitHub poller was created. If polling setup failed earlier, autopilot never starts.

User-visible effect: flag accepted → no errors → autopilot never runs. Restart "fixes" it only if the token resolves on the next process start.

## Fix

Add a `logging.WithComponent("autopilot").Warn(...)` at each gate's failure branch.

- Logging-only. Zero behavior change on the happy path.
- Build + vet clean.
- +17 lines, 1 file.

## Test plan
- [ ] Build: `make build` succeeds
- [ ] Smoke: `pilot start --env=stage` with `GITHUB_TOKEN` unset → expect WARN `"autopilot enabled but no GitHub token resolved"`
- [ ] Smoke: `pilot start --env=stage` with token set but `adapters.github.repo` empty → expect WARN `"autopilot controllers created but no GitHub pollers configured"`
- [ ] Smoke: happy path (`--env=stage` with token + repo) → no new warnings, normal startup logs