### PR TITLE
fix(executor): allow worktrees of configured projects in repo allowlist

### DIFF
--- a/cmd/pilot/repo_allowlist.go
+++ b/cmd/pilot/repo_allowlist.go
@@ -8,7 +8,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/executor"
@@ -36,9 +41,17 @@ func newConfigRepoAllowlist(cfg *config.Config) executor.RepoAllowlist {
 //
 // A repo is allowed if some configured project matches both:
 //   - GitHub owner+repo (case-sensitive match against ProjectGitHubConfig)
-//   - When projectPath is non-empty, the matched project's filesystem Path
-//     equals projectPath. This blocks the "right repo, wrong working tree"
-//     misconfiguration class.
+//   - When projectPath is non-empty, projectPath either equals the matched
+//     project's filesystem Path OR is a git worktree of it (shares the same
+//     git common-dir). The worktree case is the common path in production:
+//     Pilot creates ephemeral worktrees under /tmp/pilot-worktree-* for
+//     each task (see internal/executor/worktree.go), and the original
+//     strict equality check rejected all of them. GH-3050 follow-up.
+//
+// The "right repo, wrong working tree" guard is preserved: an unrelated
+// clone of the same upstream repo at a different path will fail BOTH the
+// equality check and the worktree check (its git common-dir is its own
+// .git, not the configured project's).
 func (a *configRepoAllowlist) RepoIsAllowed(owner, repo, projectPath string) bool {
 	if a == nil || a.cfg == nil {
 		return false
@@ -47,10 +60,43 @@ func (a *configRepoAllowlist) RepoIsAllowed(owner, repo, projectPath string) boo
 	if match == nil {
 		return false
 	}
-	if projectPath == "" {
+	if projectPath == "" || match.Path == projectPath {
 		return true
 	}
-	return match.Path == projectPath
+	return isWorktreeOf(projectPath, match.Path)
+}
+
+// isWorktreeOf reports whether worktreePath is a git worktree whose common
+// .git directory belongs to projectPath. Uses `git rev-parse
+// --git-common-dir`, which returns the canonical .git location shared by
+// all worktrees of a repository. A 2s context bounds the git call.
+//
+// Returns false (deny) on any error — git missing, path not a repo,
+// timeout. The guardrail prefers false negatives (reject worktree) over
+// false positives (allow unmanaged repo).
+func isWorktreeOf(worktreePath, projectPath string) bool {
+	if worktreePath == "" || projectPath == "" {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "-C", worktreePath, "rev-parse", "--git-common-dir").Output()
+	if err != nil {
+		return false
+	}
+	commonDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(worktreePath, commonDir)
+	}
+	commonDir, err = filepath.EvalSymlinks(commonDir)
+	if err != nil {
+		return false
+	}
+	expected, err := filepath.EvalSymlinks(filepath.Join(projectPath, ".git"))
+	if err != nil {
+		return false
+	}
+	return commonDir == expected
 }
 
 // ConfiguredRepos returns all configured "owner/repo" pairs. Used only for

--- a/cmd/pilot/repo_allowlist_test.go
+++ b/cmd/pilot/repo_allowlist_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/config"
+)
+
+// TestRepoIsAllowed_WorktreeAcceptance verifies GH-3050 follow-up: a git
+// worktree of a configured project must be accepted by the allowlist.
+// Reproduces the production failure path where Pilot creates ephemeral
+// worktrees under /tmp/pilot-worktree-* and the strict path-equality
+// check rejected every task before this fix.
+func TestRepoIsAllowed_WorktreeAcceptance(t *testing.T) {
+	tmp := t.TempDir()
+	mainRepo := filepath.Join(tmp, "main")
+	worktree := filepath.Join(tmp, "worktree")
+	unrelated := filepath.Join(tmp, "unrelated-clone")
+
+	mustGit(t, "", "init", "-q", mainRepo)
+	mustGit(t, mainRepo, "commit", "--allow-empty", "-m", "init", "-q")
+	mustGit(t, mainRepo, "worktree", "add", "--detach", "-q", worktree, "HEAD")
+
+	// Unrelated clone of the same upstream URL — must NOT be allowed.
+	mustGit(t, "", "init", "-q", unrelated)
+	mustGit(t, unrelated, "commit", "--allow-empty", "-m", "init", "-q")
+
+	allow := &configRepoAllowlist{cfg: &config.Config{
+		Projects: []*config.ProjectConfig{{
+			Name: "demo",
+			Path: mainRepo,
+			GitHub: &config.ProjectGitHubConfig{
+				Owner: "octo",
+				Repo:  "demo",
+			},
+		}},
+	}}
+
+	tests := []struct {
+		name        string
+		projectPath string
+		want        bool
+	}{
+		{"empty path", "", true},
+		{"configured path", mainRepo, true},
+		{"worktree of configured path", worktree, true},
+		{"unrelated repo at different path", unrelated, false},
+		{"nonexistent path", filepath.Join(tmp, "ghost"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allow.RepoIsAllowed("octo", "demo", tt.projectPath)
+			if got != tt.want {
+				t.Errorf("RepoIsAllowed(octo, demo, %q) = %v, want %v", tt.projectPath, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRepoIsAllowed_RepoMismatchAlwaysRejected ensures the worktree check
+// does not weaken the owner/repo guard: a worktree of project A must not
+// be accepted as project B.
+func TestRepoIsAllowed_RepoMismatchAlwaysRejected(t *testing.T) {
+	tmp := t.TempDir()
+	mainRepo := filepath.Join(tmp, "main")
+	mustGit(t, "", "init", "-q", mainRepo)
+	mustGit(t, mainRepo, "commit", "--allow-empty", "-m", "init", "-q")
+
+	allow := &configRepoAllowlist{cfg: &config.Config{
+		Projects: []*config.ProjectConfig{{
+			Name: "demo",
+			Path: mainRepo,
+			GitHub: &config.ProjectGitHubConfig{
+				Owner: "octo",
+				Repo:  "demo",
+			},
+		}},
+	}}
+
+	if allow.RepoIsAllowed("other-owner", "other-repo", mainRepo) {
+		t.Fatal("allowlist must reject mismatched owner/repo even at configured path")
+	}
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = append(cmd.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}


### PR DESCRIPTION
## Summary

v2.149.0's repo allowlist (TASK-286 Phase B / #3047) rejected every epic decomposition because the strict path-equality check at `cmd/pilot/repo_allowlist.go:53` does not recognize git worktrees as members of the configured project.

Pilot's executor creates an ephemeral worktree per task under `/tmp/pilot-worktree-*` (`internal/executor/worktree.go:86`). That worktree path never equals `cfg.Projects[i].Path`, so `RepoIsAllowed` returned `false` and the sub-issue guardrail at `internal/executor/epic.go:1011` aborted:

```
sub-issue guardrail: target repo is not in user's configured project list:
qf-studio/gitnation-companion not in configured projects
[qf-studio/pilot,…,qf-studio/gitnation-companion]
```

Note: the repo IS in the configured list. The check fails only on the path.

## Fix

`RepoIsAllowed` now also accepts the worktree case: it runs `git rev-parse --git-common-dir` against the candidate path and accepts if the resolved common `.git` directory matches the configured project's `.git`. The original strict equality remains the fast path; symlinks are resolved on both sides to handle macOS `/tmp` → `/private/tmp`.

The "right repo, wrong working tree" defense from TASK-286 is preserved: an unrelated clone of the same upstream repo at a different path has its own `.git` directory, so the common-dir comparison rejects it. The test suite asserts this explicitly.

## Test plan
- [x] `go test ./cmd/pilot/ -run TestRepoIsAllowed` — all subcases pass
- [x] `go build ./cmd/pilot/` — clean
- [x] `go vet ./cmd/pilot/` — clean
- [ ] Smoke after release: re-run a failed Pilot task (e.g. gitnation-companion GH-21) → epic decomposition proceeds past the guardrail