### PR TITLE
fix(executor): empty-set guard + suppress epic-complete false-failure (v2.149.3)

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -1159,7 +1159,10 @@ Examples:
 			}
 
 			// Validate deliverables - execution succeeded but did it produce anything?
-			if result.CommitSHA == "" && result.PRUrl == "" {
+			// GH-3053: skip for epic-parent results. The parent legitimately
+			// produces no commit/PR when sub-issues handle the work; flagging
+			// it as failed mislabels the issue and posts a misleading comment.
+			if !result.IsEpic && result.CommitSHA == "" && result.PRUrl == "" {
 				// No commits and no PR - mark as failed
 				if err := client.AddLabels(ctx, owner, repoName, int(issueNum), []string{"pilot-failed"}); err != nil {
 					logGitHubAPIError("AddLabels", owner, repoName, int(issueNum), err)

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -335,8 +335,9 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				logGitHubAPIError("AddComment", parts[0], parts[1], issue.Number, err)
 			}
 		} else if hr.Result != nil && hr.Result.Success {
-			// Validate deliverables before marking as done
-			if hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" {
+			// Validate deliverables before marking as done.
+			// GH-3053: skip for epic-parent results — sub-issues handle the work.
+			if !hr.Result.IsEpic && hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" {
 				// No commits and no PR - mark as failed
 				if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelFailed}); err != nil {
 					logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
@@ -501,7 +502,7 @@ func handleLinearIssueWithResult(ctx context.Context, cfg *config.Config, client
 		}
 	} else if hr.Result != nil && hr.Result.Success {
 		// Validate deliverables before marking as done
-		if hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" {
+		if !hr.Result.IsEpic && hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" { // GH-3053
 			comment := fmt.Sprintf("⚠️ Pilot execution completed but no changes were made.\n\n**Duration:** %s\n**Branch:** `%s`\n\nNo commits or PR were created. The task may need clarification or manual intervention.",
 				hr.Result.Duration, branchName)
 			if err := client.AddComment(ctx, issue.ID, comment); err != nil {
@@ -607,7 +608,7 @@ func handleJiraIssueWithResult(ctx context.Context, cfg *config.Config, client *
 		}
 	} else if hr.Result != nil && hr.Result.Success {
 		// Validate deliverables before marking as done
-		if hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" {
+		if !hr.Result.IsEpic && hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" { // GH-3053
 			comment := fmt.Sprintf("⚠️ Pilot execution completed but no changes were made.\n\nDuration: %s\nBranch: %s\n\nNo commits or PR were created. The task may need clarification or manual intervention.",
 				hr.Result.Duration, branchName)
 			if _, err := client.AddComment(ctx, issue.Key, comment); err != nil {
@@ -754,7 +755,7 @@ func handleAsanaTaskWithResult(ctx context.Context, cfg *config.Config, client *
 		}
 	} else if hr.Result != nil && hr.Result.Success {
 		// Validate deliverables before marking as done
-		if hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" {
+		if !hr.Result.IsEpic && hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" { // GH-3053
 			comment := fmt.Sprintf("⚠️ Pilot execution completed but no changes were made.\n\nDuration: %s\nBranch: %s\n\nNo commits or PR were created. The task may need clarification or manual intervention.",
 				hr.Result.Duration, branchName)
 			if _, err := client.AddComment(ctx, task.GID, comment); err != nil {
@@ -988,7 +989,7 @@ func handlePlaneIssueWithResult(ctx context.Context, cfg *config.Config, client 
 			)
 		}
 	} else if hr.Result != nil && hr.Result.Success {
-		if hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" {
+		if !hr.Result.IsEpic && hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" { // GH-3053
 			comment := fmt.Sprintf("<p>⚠️ Pilot execution completed but no changes were made.</p><p>Duration: %s<br>Branch: <code>%s</code></p><p>No commits or PR were created. The task may need clarification or manual intervention.</p>",
 				hr.Result.Duration, branchName)
 			if err := client.AddComment(ctx, workspaceSlug, projectID, issue.ID, comment); err != nil {
@@ -1095,7 +1096,7 @@ func handleGitLabIssueWithResult(ctx context.Context, cfg *config.Config, client
 			)
 		}
 	} else if hr.Result != nil && hr.Result.Success {
-		if hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" {
+		if !hr.Result.IsEpic && hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" { // GH-3053
 			note := fmt.Sprintf("⚠️ Pilot execution completed but no changes were made.\n\nDuration: %s\nBranch: %s\n\nNo commits or MR were created. The task may need clarification or manual intervention.",
 				hr.Result.Duration, branchName)
 			if _, err := client.AddIssueNote(ctx, issue.IID, note); err != nil {
@@ -1206,7 +1207,7 @@ func handleAzureDevOpsWorkItemWithResult(ctx context.Context, cfg *config.Config
 				)
 			}
 		} else if hr.Result != nil && hr.Result.Success {
-			if hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" {
+			if !hr.Result.IsEpic && hr.Result.CommitSHA == "" && hr.Result.PRUrl == "" { // GH-3053
 				if err := notifier.NotifyTaskFailed(ctx, wi.ID, "Execution completed but no changes were made"); err != nil {
 					logging.WithComponent("azuredevops").Warn("Failed to notify no-changes",
 						slog.Int("work_item_id", wi.ID),

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -921,6 +921,14 @@ func recoverExistingSubIssues(ctx context.Context, dir, parentID string) ([]Crea
 
 // allChildrenDone reports whether every issue in the slice is in a non-open state.
 func allChildrenDone(issues []CreatedIssue) bool {
+	// GH-3053: empty slice must not vacuously satisfy "all done". A
+	// recoverExistingSubIssues call that returns zero issues (gh search
+	// hiccup, no sub-issues created yet, network blip) would otherwise
+	// trip the false epic-complete path in runner.go: empty → true →
+	// "All sub-issues already completed (100%)" → exit without work.
+	if len(issues) == 0 {
+		return false
+	}
 	for _, iss := range issues {
 		if strings.ToLower(iss.State) == "open" {
 			return false

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -16,6 +16,34 @@ import (
 	"time"
 )
 
+// TestAllChildrenDone covers GH-3053: empty slice must NOT vacuously satisfy
+// "all done". The original implementation returned true for the empty case,
+// causing recoverExistingSubIssues failures (network blip, gh search hiccup,
+// no sub-issues yet) to be silently interpreted as "epic complete" — leading
+// to the false 100% completion log + exit-without-work on the parent issue.
+func TestAllChildrenDone(t *testing.T) {
+	tests := []struct {
+		name   string
+		issues []CreatedIssue
+		want   bool
+	}{
+		{"empty slice: not done", nil, false},
+		{"empty slice literal: not done", []CreatedIssue{}, false},
+		{"single open: not done", []CreatedIssue{{State: "open"}}, false},
+		{"single closed: done", []CreatedIssue{{State: "closed"}}, true},
+		{"mixed open+closed: not done", []CreatedIssue{{State: "closed"}, {State: "open"}}, false},
+		{"all closed: done", []CreatedIssue{{State: "closed"}, {State: "CLOSED"}}, true},
+		{"case-insensitive open detection", []CreatedIssue{{State: "OPEN"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := allChildrenDone(tt.issues); got != tt.want {
+				t.Errorf("allChildrenDone(%v) = %v, want %v", tt.issues, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseSubtasks(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Two defensive fixes hardening Pilot for the GitNation workshop demo tomorrow. Both surfaced live during the 2026-05-21 debug session.

### 1. `allChildrenDone(empty) = true` vacuous-truth bug

`internal/executor/epic.go:923` — the function returns \`true\` for an empty slice, which causes the recovery path at `runner.go:1380` to misreport `"All sub-issues already completed (100%)"` and exit without any work whenever `recoverExistingSubIssues` returns zero items (search hiccup, no sub-issues yet, network blip).

Fix: short-circuit `len(issues) == 0` to `false`.

### 2. False `pilot-failed` label + "no changes were made" comment for epic parents

`cmd/pilot/handlers.go` (7 sites) + `cmd/pilot/commands.go:1165` post a failure label + comment whenever `result.CommitSHA == "" && result.PRUrl == ""`. But epic-parent results legitimately produce no commit/PR — sub-issues handle the work (see `runner.go:1386,1409,1426,1440` where `IsEpic: true` is set). This mislabels the parent and posts a misleading "needs clarification" comment for behavior that's actually correct.

Fix: guard each site with `!result.IsEpic` (or `!hr.Result.IsEpic`). One-token additions per site.

## Diff size
- 50 LOC across 4 files
- One new test: `TestAllChildrenDone` with 7 subcases
- No new logs, no new dependencies, no API changes
- Happy path (single-task implementer producing commits) unchanged

## Out of scope
The `sql: no rows in result set` waiter race observed once during the same session is **intentionally not addressed**. Root cause unknown, too risky to investigate 12 hours before the workshop.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/executor/ -run TestAllChildrenDone\` — 7/7 subcases pass
- [x] \`go test ./internal/executor/ ./cmd/pilot/\` full suites green
- [ ] Smoke: dry-run a throwaway epic ticket on \`--env stage\` after release; confirm no false ⚠️ comment on the parent and no \`pilot-failed\` label applied to epic parents