### PR TITLE
fix(quality): default parallel gates to false (TASK-289)

### DIFF
--- a/.agent/sops/quality/parallel-gate-cache-race.md
+++ b/.agent/sops/quality/parallel-gate-cache-race.md
@@ -1,0 +1,76 @@
+# SOP: Quality gate parallel execution — shared cache race
+
+**Status:** Active · **Created:** 2026-05-25 · **Related:** TASK-289
+
+## Symptom
+
+`pilot start` reports intermittent quality-gate failures: `make build` fails with
+"file already exists" errors in `~/.cache/go-build`, or `make lint` exits with
+"failed to acquire lock on .golangci-lint.cache". Re-running the gate succeeds
+without code changes. Most visible during back-to-back task execution.
+
+The 2026-05-21 workshop run hit 11 spurious failures in 3 hours.
+
+## Root cause
+
+`internal/quality/runner.go:62-83` runs all configured gates as goroutines when
+`quality.parallel: true`. The three default gates (`make build`, `make test`,
+`make lint`) all invoke the Go toolchain, which serializes access to:
+
+- `~/.cache/go-build` — Go's build cache (file-level locks)
+- `~/.cache/golangci-lint` — golangci-lint cache (process-level lock at
+  `~/.cache/golangci-lint/.golangci-lint.cache.lock`)
+
+Two `go build` invocations in flight will deadlock or fail with "input file
+appears to be modified" if both try to write the same cached artifact.
+
+## Resolution (current default)
+
+Per **TASK-289**, the project default for `quality.parallel` is now `false`
+(sequential execution). Gates run one at a time:
+
+```yaml
+# ~/.pilot/config.yaml
+quality:
+  enabled: true
+  # parallel: false  # default; no need to set explicitly
+  gates: [...]
+```
+
+This eliminates the race at the cost of total gate wall time (≈3× for the
+default 3 gates, typically still <5min for the workshop-sized projects).
+
+## When to opt back into parallel
+
+Set `quality.parallel: true` ONLY if you have isolated caches per gate. The
+common patterns:
+
+1. **Per-gate `GOCACHE`** — set `GOCACHE=$(mktemp -d)` in the gate's `command`
+   string so each goroutine writes to its own build cache.
+2. **Per-gate `GOLANGCI_LINT_CACHE`** — same idea for the lint cache.
+3. **Container-per-gate** — wrap each `command` in `docker run ...` so the
+   cache lives in the container scratch.
+
+Until one of these ships as a Pilot feature (Wave 4+ candidate per audit
+2026-05-25 §3.7), prefer the sequential default.
+
+## How to verify the default is active
+
+```bash
+$ ./bin/pilot config show | grep -A1 quality:
+quality:
+  enabled: true
+
+$ ./bin/pilot start  # observe logs
+INFO Starting quality gate checks gate_count=3 mode=sequential
+```
+
+If `mode=parallel` shows without an explicit `parallel: true` in the config,
+something is overriding the default — file an issue.
+
+## References
+
+- `internal/quality/types.go` — `IsParallel()` and the default
+- `internal/quality/runner.go:62-83` — execution branch
+- TASK-289 — the flip itself
+- Audit 2026-05-25 §2 Action #5, §3.7 P1, §3.3 P1

--- a/internal/quality/runner_test.go
+++ b/internal/quality/runner_test.go
@@ -758,8 +758,11 @@ func TestShouldRetry_ActionWarn(t *testing.T) {
 func TestRunner_RunAll_ParallelExecution(t *testing.T) {
 	// Each gate sleeps for 100ms. In parallel, total time should be ~100ms.
 	// In sequential, total time would be ~300ms.
+	// TASK-289: parallel default flipped to false, so this test must opt in explicitly.
+	parallelTrue := true
 	config := &Config{
-		Enabled: true,
+		Enabled:  true,
+		Parallel: &parallelTrue,
 		Gates: []*Gate{
 			{Name: "gate1", Type: GateCustom, Command: "sleep 0.1", Required: true, Timeout: 5 * time.Second},
 			{Name: "gate2", Type: GateCustom, Command: "sleep 0.1", Required: true, Timeout: 5 * time.Second},
@@ -815,12 +818,13 @@ func TestRunner_RunAll_SequentialExecution(t *testing.T) {
 }
 
 func TestConfig_IsParallel(t *testing.T) {
+	// TASK-289: nil now defaults to false (was true) — see SOP parallel-gate-cache-race.
 	tests := []struct {
 		name     string
 		parallel *bool
 		expected bool
 	}{
-		{name: "nil defaults to true", parallel: nil, expected: true},
+		{name: "nil defaults to false (TASK-289)", parallel: nil, expected: false},
 		{name: "explicit true", parallel: boolPtr(true), expected: true},
 		{name: "explicit false", parallel: boolPtr(false), expected: false},
 	}
@@ -832,6 +836,42 @@ func TestConfig_IsParallel(t *testing.T) {
 				t.Errorf("IsParallel() = %v, want %v", got, tt.expected)
 			}
 		})
+	}
+}
+
+// TestRunner_RunAll_DefaultsToSequential asserts that a Config with no explicit
+// Parallel setting runs gates sequentially. TASK-289: prevents regression of the
+// 2026-05-21 workshop incident where 11 spurious quality-gate failures hit in 3h
+// due to concurrent gates racing on ~/.cache/go-build and ~/.cache/golangci-lint.
+func TestRunner_RunAll_DefaultsToSequential(t *testing.T) {
+	// Each gate sleeps for 50ms. Sequential: ~150ms; parallel would be ~50ms.
+	// No Parallel field set → must default to sequential.
+	config := &Config{
+		Enabled: true,
+		Gates: []*Gate{
+			{Name: "gate1", Type: GateCustom, Command: "sleep 0.05", Required: true, Timeout: 5 * time.Second},
+			{Name: "gate2", Type: GateCustom, Command: "sleep 0.05", Required: true, Timeout: 5 * time.Second},
+			{Name: "gate3", Type: GateCustom, Command: "sleep 0.05", Required: true, Timeout: 5 * time.Second},
+		},
+	}
+
+	if config.IsParallel() {
+		t.Fatal("Config with nil Parallel must default to sequential (TASK-289)")
+	}
+
+	runner := NewRunner(config, "/tmp")
+	start := time.Now()
+	results, err := runner.RunAll(context.Background(), "default-sequential-test")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !results.AllPassed {
+		t.Error("expected all gates to pass")
+	}
+	if elapsed < 140*time.Millisecond {
+		t.Errorf("expected sequential (default) execution to take at least 140ms, took %v", elapsed)
 	}
 }
 

--- a/internal/quality/types.go
+++ b/internal/quality/types.go
@@ -123,16 +123,20 @@ func (cr *CheckResults) GetFailedGates() []*Result {
 // Config holds quality gates configuration
 type Config struct {
 	Enabled   bool          `yaml:"enabled" json:"enabled"`
-	Parallel  *bool         `yaml:"parallel" json:"parallel"` // Run gates in parallel (default: true)
+	Parallel  *bool         `yaml:"parallel" json:"parallel"` // Run gates in parallel (default: false; see TASK-289 / SOP parallel-gate-cache-race)
 	Gates     []*Gate       `yaml:"gates" json:"gates"`
 	OnFailure FailureConfig `yaml:"on_failure" json:"on_failure"`
 }
 
 // IsParallel returns whether gates should run in parallel.
-// Defaults to true if not explicitly set.
+//
+// Defaults to false: concurrent `make build` / `make test` / `make lint` race on the
+// shared `~/.cache/go-build` and `~/.cache/golangci-lint` caches, producing spurious
+// gate failures (see .agent/sops/quality/parallel-gate-cache-race.md and TASK-289).
+// Set `quality.parallel: true` explicitly only when per-gate cache isolation is in place.
 func (c *Config) IsParallel() bool {
 	if c.Parallel == nil {
-		return true // Default to parallel execution
+		return false // Default to sequential — avoids shared-cache races (TASK-289)
 	}
 	return *c.Parallel
 }


### PR DESCRIPTION
## Summary

- Flip `quality.parallel` default from `true` → `false` to eliminate the race on shared `~/.cache/go-build` and `~/.cache/golangci-lint` that caused 11 spurious gate failures in 3h during the 2026-05-21 workshop.
- Users with isolated per-gate caches can still opt in via explicit `quality.parallel: true`.
- New SOP `.agent/sops/quality/parallel-gate-cache-race.md` documents the race + opt-in conditions.

## Test plan

- [x] \`go test ./internal/quality/\` — passes (\`TestConfig_IsParallel\`, \`TestRunner_RunAll_DefaultsToSequential\`, \`TestRunner_RunAll_ParallelExecution\` with explicit opt-in, \`TestRunner_RunAll_SequentialExecution\`)
- [ ] Manual smoke: \`pilot start\` shows \`mode=sequential\` in quality-gate log line by default
- [ ] No regression on Pilot's own CI (post-merge)

Wave 1 of the 2026-05-25 audit plan. Audit ref: §2 Action #5, §3.7 P1, §3.3 P1.