### PR TITLE
fix(config): write ~/.pilot/config.yaml with mode 0600 (TASK-290)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -482,19 +482,36 @@ func Load(path string) (*Config, error) {
 
 // Save writes the configuration to a YAML file at the given path.
 // It creates the parent directory if it does not exist.
+//
+// TASK-290: file mode is 0600 and parent dir is 0700 because the config
+// contains GitHub PAT, Linear API key, Slack bot token, and (optionally)
+// Anthropic API key — none of which should be world- or group-readable.
+// If a config already exists on disk with looser perms, this Save call will
+// tighten them on the next write (existing 0644 files are rewritten 0600).
 func Save(config *Config, path string) error {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
+
+	// If the directory already existed with looser perms (e.g. an older
+	// install left ~/.pilot at 0755), tighten it. Ignore errors — best effort.
+	_ = os.Chmod(dir, 0700)
 
 	data, err := yaml.Marshal(config)
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
+	}
+
+	// os.WriteFile does NOT change permissions of an existing file — it only
+	// applies the mode on create. Explicit Chmod ensures we tighten perms even
+	// when a previous version of Pilot left the file at 0644 on disk.
+	if err := os.Chmod(path, 0600); err != nil {
+		return fmt.Errorf("failed to chmod config to 0600: %w", err)
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -1454,5 +1455,72 @@ projects:
 	}
 	if len(proj.TeamReviewers) != 1 || proj.TeamReviewers[0] != "backend-team" {
 		t.Errorf("TeamReviewers = %v, want [backend-team]", proj.TeamReviewers)
+	}
+}
+
+// TestSave_PermissionsAre0600 asserts that Save() writes the config file
+// with 0600 permissions and its parent directory with 0700 — required
+// because the file stores GitHub PAT, Linear API key, Slack bot token,
+// and (optionally) Anthropic API key. TASK-290.
+//
+// Skipped on Windows where Unix file modes don't apply.
+func TestSave_PermissionsAre0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permissions are not enforced on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, ".pilot")
+	configPath := filepath.Join(configDir, "config.yaml")
+
+	cfg := &Config{Version: "1.0"}
+	if err := Save(cfg, configPath); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	fileInfo, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("Stat config file failed: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0600 {
+		t.Errorf("config file mode = %o, want 0600", got)
+	}
+
+	dirInfo, err := os.Stat(configDir)
+	if err != nil {
+		t.Fatalf("Stat config dir failed: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0700 {
+		t.Errorf("config dir mode = %o, want 0700", got)
+	}
+}
+
+// TestSave_TightensExistingLoosePerms asserts that Save() rewrites a file
+// that previously existed with 0644 down to 0600. Covers the migration path
+// for users upgrading past TASK-290 with an existing 0644 config on disk.
+func TestSave_TightensExistingLoosePerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permissions are not enforced on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Pre-seed file at 0644 (the old default).
+	if err := os.WriteFile(configPath, []byte("version: \"1.0\"\n"), 0644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	cfg := &Config{Version: "1.0"}
+	if err := Save(cfg, configPath); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("Stat after Save failed: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Errorf("config file mode after rewrite = %o, want 0600", got)
 	}
 }


### PR DESCRIPTION
## Summary

- \`config.Save()\` previously wrote \`~/.pilot/config.yaml\` with mode \`0644\`, leaving the GitHub PAT, Linear API key, Slack bot token, and (optionally) Anthropic API key world-readable on shared workstations.
- File mode tightened to \`0600\`; parent dir to \`0700\`.
- Explicit \`os.Chmod\` after \`os.WriteFile\` so existing \`0644\` configs on disk are tightened on the next save (\`os.WriteFile\` only applies its mode on file creation, not on rewrite).

## Test plan

- [x] \`go test ./internal/config/\` — passes (\`TestSave_PermissionsAre0600\`, \`TestSave_TightensExistingLoosePerms\`)
- [ ] Manual: \`pilot config set foo bar && ls -la ~/.pilot/config.yaml\` shows \`-rw-------\`
- [ ] Verify on a workstation with an existing 0644 config — next save tightens it

Wave 1 of the 2026-05-25 audit plan. Audit ref: §2 Action #8, §3.7 P1.

## Out of scope

- Encryption at rest (separate, much larger effort)
- Migrating existing on-disk configs without a new save — relies on next \`Save()\` call to tighten