### PR TITLE
fix(autopilot): getMainBranchSHA reads ResolvedEnv().Branch (TASK-291)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1584,12 +1584,37 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 }
 
 // getMainBranchSHA returns the current SHA of the main branch.
+//
+// TASK-291: previously hardcoded "main" — this silently broke post-merge CI
+// monitoring on repos defaulting to develop/master/trunk (releases could fire
+// before main-branch CI completed). Now reads ResolvedEnv().Branch and falls
+// back to literal "main" with a WARN log when no environment branch is set.
 func (c *Controller) getMainBranchSHA(ctx context.Context) (string, error) {
-	branch, err := c.ghClient.GetBranch(ctx, c.owner, c.repo, "main")
+	branchName := c.resolveMainBranchName()
+	branch, err := c.ghClient.GetBranch(ctx, c.owner, c.repo, branchName)
 	if err != nil {
 		return "", err
 	}
 	return branch.SHA(), nil
+}
+
+// resolveMainBranchName returns the branch name post-merge CI should track.
+// Preference order:
+//  1. c.config.ResolvedEnv().Branch — the per-environment branch (prod=main, stage=develop, etc.)
+//  2. Literal "main" with a WARN log — last-resort fallback so we never block a release on an empty branch name.
+//
+// A broader fallback through ProjectConfig (BranchFrom/DefaultBranch) would
+// require wiring the pilot global Config into autopilot.Controller — deferred
+// to a follow-up; not needed for the workshop-scope incident this fix targets.
+func (c *Controller) resolveMainBranchName() string {
+	if env := c.config.ResolvedEnv(); env != nil && env.Branch != "" {
+		return env.Branch
+	}
+	c.log.Warn("resolveMainBranchName: no environment branch configured, falling back to literal \"main\" — set environments.<env>.branch to silence this warning",
+		"owner", c.owner,
+		"repo", c.repo,
+	)
+	return "main"
 }
 
 // resolveRelease is a package-level helper used during construction (before Controller

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6117,3 +6117,65 @@ func TestController_RecordMergeSuccess_Idempotency(t *testing.T) {
 		t.Errorf("PRsMerged = %d after second PR, want 2", snap2.PRsMerged)
 	}
 }
+
+// TestGetMainBranchSHA_RespectsResolvedEnv asserts that getMainBranchSHA reads
+// the branch name from c.config.ResolvedEnv().Branch instead of the previously
+// hardcoded "main" literal. TASK-291: prevents the regression where develop /
+// master / trunk default repos silently failed post-merge CI monitoring.
+//
+// Each sub-test installs a different EnvironmentConfig and asserts that the
+// GitHub branch endpoint received the matching branch name in its path.
+func TestGetMainBranchSHA_RespectsResolvedEnv(t *testing.T) {
+	tests := []struct {
+		name           string
+		envBranch      string
+		wantBranchPath string // suffix of the URL path we expect GH to receive
+	}{
+		{name: "branch=main", envBranch: "main", wantBranchPath: "/branches/main"},
+		{name: "branch=develop", envBranch: "develop", wantBranchPath: "/branches/develop"},
+		{name: "branch=master", envBranch: "master", wantBranchPath: "/branches/master"},
+		{name: "branch=trunk", envBranch: "trunk", wantBranchPath: "/branches/trunk"},
+		{name: "empty branch falls back to main", envBranch: "", wantBranchPath: "/branches/main"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestedPath string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.Contains(r.URL.Path, "/branches/") {
+					requestedPath = r.URL.Path
+					resp := github.Branch{
+						Name:   strings.TrimPrefix(r.URL.Path, "/repos/owner/repo/branches/"),
+						Commit: github.BranchCommit{SHA: "deadbeef"},
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			// Install per-test environment directly via unexported fields (same-package access).
+			// Mirrors the pattern at TestNewController_ReleaserInit.
+			cfg.activeEnvName = "test-env"
+			cfg.activeEnvConfig = &EnvironmentConfig{Branch: tt.envBranch}
+
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			sha, err := c.getMainBranchSHA(context.Background())
+			if err != nil {
+				t.Fatalf("getMainBranchSHA error: %v", err)
+			}
+			if sha != "deadbeef" {
+				t.Errorf("sha = %q, want deadbeef", sha)
+			}
+			if !strings.HasSuffix(requestedPath, tt.wantBranchPath) {
+				t.Errorf("requested path %q does not end with %q", requestedPath, tt.wantBranchPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- \`getMainBranchSHA\` previously hardcoded \`GetBranch(ctx, owner, repo, "main")\`. Repos defaulting to \`develop\` / \`master\` / \`trunk\` silently failed post-merge CI monitoring; releases could fire before the real default branch's CI completed.
- Now reads \`c.config.ResolvedEnv().Branch\` via a new \`resolveMainBranchName()\` helper.
- Last-resort fallback: literal \`"main"\` + WARN log when no environment branch is configured (so we never block a release on an empty branch name).

## Test plan

- [x] \`go test ./internal/autopilot/\` — passes (\`TestGetMainBranchSHA_RespectsResolvedEnv\` covering main/develop/master/trunk + empty fallback, via httptest-recorded GH branch URL)
- [ ] Manual smoke: trigger a merge on a develop-default secondary repo, observe post-merge CI fires correctly

Wave 1 of the 2026-05-25 audit plan. Audit ref: §2 Action #9, §3.7 P1.

## Out of scope

- Releaser's similar frozen-config issue (audit §3.7 P1) — separate fix, Wave 4+.
- Broader \`ProjectConfig.BranchFrom\` / \`DefaultBranch\` fallback — would require wiring the pilot global Config into \`autopilot.Controller\`. Deferred.