### PR TITLE
fix(security): broaden secret-pattern scanner to all tracked files (TASK-299)

### DIFF
--- a/scripts/check-secret-patterns.sh
+++ b/scripts/check-secret-patterns.sh
@@ -1,31 +1,73 @@
 #!/bin/bash
-# Check for realistic-looking secret patterns in test files
-# Used by CI to catch patterns that might have bypassed pre-commit hook
+# Check for realistic-looking secret patterns across all tracked files.
+#
+# History:
+#   - Original (TASK-41): scanned only *_test.go files. That was the scope of
+#     the original incident (push protection blocked 9 branches because
+#     tests used realistic fake tokens).
+#   - Broadened (TASK-299, 2026-05-25 audit): the test-only scope let any
+#     non-test file (source, docs, configs) leak past this check. The
+#     2026-05-25 sweep found xoxb-format examples in CLAUDE.md,
+#     CONTRIBUTING.md, internal/testutil/tokens.go — those are intentional
+#     educational content, so they're explicitly allowlisted below. All
+#     other tracked files are now scanned.
+#
+# Used by CI (.github/workflows/ci.yml step: "Check Secret Patterns") AND by
+# the pre-commit hook installed via `make install-hooks`.
 
 set -e
 
-echo "Scanning for realistic secret patterns in test files..."
+echo "Scanning all tracked files for realistic secret patterns..."
 
-# Patterns that look like real secrets (will trigger GitHub push protection)
+# Patterns that look like real secrets (will trigger GitHub push protection).
+# Add new patterns here when GitHub adds support for new providers.
 PATTERNS=(
-    'xoxb-[0-9]{10,}-[0-9]{10,}'           # Slack bot token
-    'xoxa-[0-9]{10,}-[0-9]{10,}'           # Slack app token
-    'xoxp-[0-9]{10,}-[0-9]{10,}'           # Slack user token
-    'sk-[a-zA-Z0-9]{32,}'                   # OpenAI API key
-    'ghp_[a-zA-Z0-9]{36}'                   # GitHub PAT
-    'gho_[a-zA-Z0-9]{36}'                   # GitHub OAuth token
-    'ghu_[a-zA-Z0-9]{36}'                   # GitHub user-to-server token
-    'ghs_[a-zA-Z0-9]{36}'                   # GitHub server-to-server token
+    'xoxb-[0-9]{10,}-[0-9]{10,}'                  # Slack bot token
+    'xoxa-[0-9]{10,}-[0-9]{10,}'                  # Slack app token
+    'xoxp-[0-9]{10,}-[0-9]{10,}'                  # Slack user token
+    'sk-[a-zA-Z0-9]{32,}'                         # OpenAI / Anthropic-style API key
+    'ghp_[a-zA-Z0-9]{36}'                         # GitHub PAT
+    'gho_[a-zA-Z0-9]{36}'                         # GitHub OAuth token
+    'ghu_[a-zA-Z0-9]{36}'                         # GitHub user-to-server token
+    'ghs_[a-zA-Z0-9]{36}'                         # GitHub server-to-server token
     'github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}'  # GitHub fine-grained PAT
-    'AKIA[0-9A-Z]{16}'                      # AWS access key ID
-    'lin_api_[a-zA-Z0-9]{40}'               # Linear API key
+    'AKIA[0-9A-Z]{16}'                            # AWS access key ID
+    'lin_api_[a-zA-Z0-9]{40}'                     # Linear API key
 )
+
+# Files allowlisted from the scan because they intentionally show secret
+# patterns for educational purposes (teach contributors what NOT to use).
+# DO NOT add files here without a clear "this is educational content"
+# justification — every entry weakens the check.
+#
+# Paths are matched as exact lines against `git ls-files` output (so they
+# must be repo-root-relative, no leading "./").
+ALLOWLIST=(
+    'CLAUDE.md'                                       # forbidden-pattern examples in §"Test Token Guidelines"
+    'CONTRIBUTING.md'                                 # same examples for external contributors
+    'internal/testutil/tokens.go'                     # safe-token constants module, comments show what NOT to do
+    '.agent/tasks/archive/TASK-41-test-secret-patterns.md'  # postmortem documenting the original incident
+    'scripts/check-secret-patterns.sh'                # this script literally contains the patterns it detects
+)
+
+# Build a temp file of files to scan: tracked files minus the allowlist.
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+git ls-files | grep -vFx -f <(printf '%s\n' "${ALLOWLIST[@]}") > "$TMPFILE"
+
+# Sanity: bail loudly if the file list is suspiciously short — the allowlist
+# probably matched too much or git ls-files returned nothing (broken cwd).
+SCAN_COUNT=$(wc -l < "$TMPFILE" | tr -d ' ')
+if [ "$SCAN_COUNT" -lt 50 ]; then
+    echo "❌ ERROR: only $SCAN_COUNT files queued for scan — allowlist or cwd misconfigured"
+    exit 2
+fi
 
 FOUND_SECRETS=0
 
 for pattern in "${PATTERNS[@]}"; do
-    # Search in all test files
-    MATCHES=$(grep -rE "$pattern" --include='*_test.go' . 2>/dev/null || true)
+    # xargs respects ARG_MAX and splits the file list if necessary.
+    MATCHES=$(xargs grep -HnE "$pattern" < "$TMPFILE" 2>/dev/null || true)
     if [ -n "$MATCHES" ]; then
         echo ""
         echo "❌ ERROR: Found realistic-looking secret pattern"
@@ -48,10 +90,17 @@ if [ $FOUND_SECRETS -eq 1 ]; then
     echo "Instead, use obviously fake tokens:"
     echo "  ✅ test-slack-bot-token"
     echo "  ✅ fake-api-key"
-    echo "  ✅ Constants from internal/testutil/tokens.go"
+    echo "  ✅ test-github-token"
+    echo ""
+    echo "Or use the constants in internal/testutil/tokens.go:"
+    echo "  import \"github.com/qf-studio/pilot/internal/testutil\""
+    echo "  token := testutil.FakeSlackBotToken"
+    echo ""
+    echo "If the match is intentional educational content (showing what NOT"
+    echo "to use), add the file to the ALLOWLIST in scripts/check-secret-patterns.sh."
     echo ""
     exit 1
 fi
 
-echo "✓ No realistic secret patterns found in test files"
+echo "✓ No realistic secret patterns found in $SCAN_COUNT scanned files"
 exit 0


### PR DESCRIPTION
## Summary

Two-part security fix to close a check-secrets defense gap found during the 2026-05-25 audit follow-up:

1. **This PR**: broadens \`scripts/check-secret-patterns.sh\` from \`--include='*_test.go'\` (~50 files) to all tracked files (1086 files), with an explicit \`ALLOWLIST\` for 4 known-educational files that intentionally show patterns to teach contributors what NOT to use.
2. **Already applied (out-of-band, via \`gh api PATCH\`)**: enabled \`secret_scanning\` and \`secret_scanning_push_protection\` on the repo. They were both \`disabled\` until just now.

## Why the gap existed

The original scanner ([TASK-41](https://github.com/qf-studio/pilot/blob/main/.agent/tasks/archive/TASK-41-test-secret-patterns.md)) narrowed scope to test files because that's where the original incident lived (push protection blocked 9 branches because of realistic fake tokens in tests). The narrow scope made sense for the immediate fix — but it meant any non-test file could still leak a real key past CI undetected.

Combined with GitHub-side secret scanning being **off**, a real \`ghp_...\` accidentally hardcoded in \`internal/config/defaults.go\` or \`docs/getting-started.mdx\` would have been silently merged. Now both layers (script + GitHub) are armed.

## Allowlist (educational content only)

| File | Why allowlisted |
|---|---|
| \`CLAUDE.md\` | §"Test Token Guidelines" lists 3 forbidden patterns as examples |
| \`CONTRIBUTING.md\` | Same examples for external contributors |
| \`internal/testutil/tokens.go\` | Safe-token constants module; comments show what NOT to do |
| \`.agent/tasks/archive/TASK-41-test-secret-patterns.md\` | Postmortem of the original incident |
| \`scripts/check-secret-patterns.sh\` | Contains the regex patterns it detects |

7 realistic patterns total across these 5 files — without the allowlist, the broader scan would correctly fail on all of them.

## Test plan

- [x] \`make check-secrets\` against current tree → passes (\`✓ No realistic secret patterns found in 1086 scanned files\`)
- [x] Smoke test: a canary file with \`ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\` (36 \`a\`s) matches the \`ghp_[a-zA-Z0-9]{36}\` regex → confirms failure path works
- [x] Sanity check: script aborts with exit 2 if fewer than 50 files queue for scan (catches broken allowlist / wrong cwd)
- [x] xargs respects ARG_MAX so the broader scan won't break on large repos
- [ ] CI on this PR confirms the broader scan still passes (the \"Check Secret Patterns\" job)

## Notes for reviewers

- This PR is a single-file change to \`scripts/check-secret-patterns.sh\`. The repo-side \`gh api PATCH\` was already applied so push protection is active **for this PR's push as well** — if GitHub flags anything, that's the new defense doing its job.
- If you want to add a new educational example (e.g., a new doc page showing forbidden patterns), append it to \`ALLOWLIST\` with a comment explaining why.

Closes the audit follow-up flagged in https://github.com/qf-studio/pilot/releases/tag/v2.149.4.