### PR TITLE
feat(metrics): poller skip-by-reason counters (TASK-293)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -299,6 +299,7 @@
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |
 | External-merge metrics | ✅ | autopilot | - | - | Record PRsMerged/IssuesProcessed/PRTimeToMerge for externally-merged PRs via scanner (v2.147.0, GH-2981) |
+| Poller skip-by-reason counters | ✅ | gateway/adapters | - | - | `pilot_poller_skipped_total{repo,reason}`, `pilot_poller_dispatched_total{repo}`, `pilot_poller_deferred_scope_overlap_total{repo}` for GitHub/GitLab/Azure (v2.149.6, GH-3064) |
 | JSON structured logging | ✅ | - | - | `logging.format` | Optional JSON log output mode (v0.38.0) |
 | Qwen Code backend | ✅ | executor | `--backend qwen` | `executor.backend` | Alibaba Qwen Code CLI with stream-json (v1.9.0, GH-1314) |
 | Docker support | ✅ | - | - | - | Dockerfile + deployment guide (v1.46.0) |

--- a/internal/adapters/azuredevops/poller.go
+++ b/internal/adapters/azuredevops/poller.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/adapters/skipreason"
 	"github.com/qf-studio/pilot/internal/logging"
 )
 
@@ -31,6 +32,13 @@ type WorkItemResult struct {
 	HeadSHA    string // Head commit SHA of the PR
 	BranchName string // Head branch name (e.g. "pilot/GH-123")
 	Error      error
+}
+
+// PollerMetricsRecorder records per-repo poller skip/dispatch counters.
+// Implemented by *autopilot.Metrics; kept as interface to avoid circular imports.
+type PollerMetricsRecorder interface {
+	RecordPollerSkipped(repo, reason string)
+	RecordPollerDispatched(repo string)
 }
 
 // ProcessedStore persists which Azure DevOps work items have been processed across restarts.
@@ -76,6 +84,11 @@ type Poller struct {
 	activeWg      sync.WaitGroup
 	stopping      atomic.Bool
 	wgMu          sync.Mutex // protects stopping + activeWg Add/Wait coordination
+
+	// pollerMetrics records per-repo skip/dispatch counters (optional).
+	pollerMetrics PollerMetricsRecorder
+	// repoKeyStr identifies this project in Prometheus labels.
+	repoKeyStr string
 }
 
 // PollerOption configures a Poller
@@ -148,6 +161,14 @@ func WithMaxConcurrent(n int) PollerOption {
 			n = 1
 		}
 		p.maxConcurrent = n
+	}
+}
+
+// WithPollerMetricsRecorder sets the recorder for per-repo poller skip/dispatch counters.
+func WithPollerMetricsRecorder(rec PollerMetricsRecorder, repoKey string) PollerOption {
+	return func(p *Poller) {
+		p.pollerMetrics = rec
+		p.repoKeyStr = repoKey
 	}
 }
 
@@ -517,11 +538,24 @@ func (p *Poller) checkForNewWorkItems(ctx context.Context) {
 		p.mu.RUnlock()
 
 		if processed {
+			if p.pollerMetrics != nil {
+				p.pollerMetrics.RecordPollerSkipped(p.repoKeyStr, skipreason.ReasonProcessedGrace)
+			}
 			continue
 		}
 
 		// Skip if has in-progress, done, or failed tag
 		if p.hasStatusTag(wi) {
+			if p.pollerMetrics != nil {
+				switch {
+				case HasTag(wi, TagInProgress):
+					p.pollerMetrics.RecordPollerSkipped(p.repoKeyStr, skipreason.ReasonInProgress)
+				case HasTag(wi, TagDone):
+					p.pollerMetrics.RecordPollerSkipped(p.repoKeyStr, skipreason.ReasonDone)
+				default:
+					p.pollerMetrics.RecordPollerSkipped(p.repoKeyStr, skipreason.ReasonFailedSkip)
+				}
+			}
 			p.markProcessed(wi.ID)
 			continue
 		}
@@ -540,6 +574,9 @@ func (p *Poller) checkForNewWorkItems(ctx context.Context) {
 			slog.Int("id", wi.ID),
 			slog.String("title", wi.GetTitle()),
 		)
+		if p.pollerMetrics != nil {
+			p.pollerMetrics.RecordPollerDispatched(p.repoKeyStr)
+		}
 
 		// Use mutex to coordinate stopping flag check with WaitGroup Add
 		p.wgMu.Lock()

--- a/internal/adapters/azuredevops/poller_test.go
+++ b/internal/adapters/azuredevops/poller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -456,5 +457,136 @@ func TestPollerWithProcessedStore(t *testing.T) {
 	// Verify it was removed from store
 	if store.processed[100] {
 		t.Error("expected work item 100 to be removed from store")
+	}
+}
+
+// mockPollerMetrics satisfies PollerMetricsRecorder for Azure DevOps poller tests.
+type mockPollerMetrics struct {
+	mu         sync.Mutex
+	skipped    map[string]int64
+	dispatched int64
+}
+
+func newMockPollerMetrics() *mockPollerMetrics {
+	return &mockPollerMetrics{skipped: make(map[string]int64)}
+}
+
+func (m *mockPollerMetrics) RecordPollerSkipped(_, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.skipped[reason]++
+}
+
+func (m *mockPollerMetrics) RecordPollerDispatched(_ string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dispatched++
+}
+
+func makeAzureTestServer(t *testing.T, wi *WorkItem) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			// WIQL query → return one work item reference
+			_ = json.NewEncoder(w).Encode(WIQLQueryResult{
+				WorkItems: []WIQLWorkItemRef{{ID: wi.ID}},
+			})
+		} else {
+			// Batch GET → return the work item
+			resp := struct {
+				Count int         `json:"count"`
+				Value []*WorkItem `json:"value"`
+			}{Count: 1, Value: []*WorkItem{wi}}
+			_ = json.NewEncoder(w).Encode(resp)
+		}
+	}))
+}
+
+func TestPoller_SkipMetric_IncrementsByReason(t *testing.T) {
+	tests := []struct {
+		name         string
+		tags         string
+		preProcessed bool
+		wantReason   string
+		wantSkipped  int64
+		wantDispatch int64
+	}{
+		{
+			name:         "already processed → ReasonProcessedGrace",
+			tags:         "pilot",
+			preProcessed: true,
+			wantReason:   "processed_grace",
+			wantSkipped:  1,
+		},
+		{
+			name:        "in_progress tag → ReasonInProgress",
+			tags:        "pilot; " + TagInProgress,
+			wantReason:  "in_progress",
+			wantSkipped: 1,
+		},
+		{
+			name:        "done tag → ReasonDone",
+			tags:        "pilot; " + TagDone,
+			wantReason:  "done",
+			wantSkipped: 1,
+		},
+		{
+			name:        "failed tag → ReasonFailedSkip",
+			tags:        "pilot; " + TagFailed,
+			wantReason:  "failed_skip",
+			wantSkipped: 1,
+		},
+		{
+			name:         "clean work item → dispatch counter",
+			tags:         "pilot",
+			wantDispatch: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wi := &WorkItem{
+				ID: 1,
+				Fields: map[string]interface{}{
+					"System.Title":       "Test Work Item",
+					"System.CreatedDate": "2024-01-01T10:00:00Z",
+					"System.Tags":        tt.tags,
+				},
+			}
+			server := makeAzureTestServer(t, wi)
+			defer server.Close()
+
+			rec := newMockPollerMetrics()
+			client := NewClientWithBaseURL(testutil.FakeAzureDevOpsPAT, "org", "project", server.URL)
+			poller := NewPoller(client, "pilot", 30*time.Second,
+				WithPollerMetricsRecorder(rec, "org/project"),
+				WithOnWorkItem(func(_ context.Context, _ *WorkItem) error { return nil }),
+			)
+
+			if tt.preProcessed {
+				poller.markProcessed(wi.ID)
+			}
+
+			poller.checkForNewWorkItems(context.Background())
+			poller.WaitForActive()
+
+			if tt.wantSkipped > 0 {
+				rec.mu.Lock()
+				got := rec.skipped[tt.wantReason]
+				rec.mu.Unlock()
+				if got != tt.wantSkipped {
+					t.Errorf("skipped[%q] = %d, want %d", tt.wantReason, got, tt.wantSkipped)
+				}
+			}
+			if tt.wantDispatch > 0 {
+				rec.mu.Lock()
+				got := rec.dispatched
+				rec.mu.Unlock()
+				if got != tt.wantDispatch {
+					t.Errorf("dispatched = %d, want %d", got, tt.wantDispatch)
+				}
+			}
+		})
 	}
 }

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/adapters/skipreason"
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/text"
@@ -77,6 +78,14 @@ type ExecutionSaver interface {
 // Implemented by *autopilot.Metrics; kept as an interface here to avoid circular imports.
 type IssueMetricsRecorder interface {
 	RecordIssueProcessed(result string)
+}
+
+// PollerMetricsRecorder records per-repo poller skip/dispatch counters.
+// Implemented by *autopilot.Metrics; kept as interface to avoid circular imports.
+type PollerMetricsRecorder interface {
+	RecordPollerSkipped(repo, reason string)
+	RecordPollerDispatched(repo string)
+	RecordPollerDeferredScopeOverlap(repo string)
 }
 
 // IssueResult is returned by the issue handler with PR information
@@ -157,6 +166,8 @@ type Poller struct {
 
 	// metricsRecorder records issue processing outcomes (optional).
 	metricsRecorder IssueMetricsRecorder
+	// pollerMetrics records per-repo skip/dispatch counters (optional).
+	pollerMetrics PollerMetricsRecorder
 }
 
 // PollerOption configures a Poller
@@ -300,6 +311,14 @@ func WithExecutionSaver(saver ExecutionSaver) PollerOption {
 func WithIssueMetricsRecorder(rec IssueMetricsRecorder) PollerOption {
 	return func(p *Poller) {
 		p.metricsRecorder = rec
+	}
+}
+
+// WithPollerMetricsRecorder sets the recorder for per-repo poller skip/dispatch counters.
+// Pass nil to disable (same as not calling this option).
+func WithPollerMetricsRecorder(rec PollerMetricsRecorder) PollerOption {
+	return func(p *Poller) {
+		p.pollerMetrics = rec
 	}
 }
 
@@ -924,28 +943,33 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 
 		// Skip if already in progress
 		if HasLabel(issue, LabelInProgress) {
+			p.recordSkip(skipreason.ReasonInProgress)
 			continue
 		}
 
 		// GH-2402: Skip permanently-blocked issues. The user must remove
 		// the pilot-blocked label to retry (e.g. after fixing a non-conventional title).
 		if HasLabel(issue, LabelBlocked) {
+			p.recordSkip(skipreason.ReasonBlocked)
 			continue
 		}
 
 		// GH-2768: Skip issues declined as unactionable. Remove the label to re-enable dispatch.
 		if HasLabel(issue, LabelNeedsClarification) {
+			p.recordSkip(skipreason.ReasonNeedsClarification)
 			continue
 		}
 
 		// GH-2402: Auto-close sub-issues whose parent epic already shipped.
 		if p.skipSupersededByParent(ctx, issue) {
+			p.recordSkip(skipreason.ReasonSuperseded)
 			continue
 		}
 
 		// GH-2176: Auto-retry issues stuck with pilot-failed (no pilot-done)
 		if HasLabel(issue, LabelFailed) {
 			if !p.shouldRetryFailedIssue(ctx, issue) {
+				p.recordSkip(skipreason.ReasonFailedSkip)
 				continue
 			}
 			// Label removed, fall through to candidate selection
@@ -954,6 +978,7 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 		// GH-2276: Auto-retry issues with pilot-retry-ready (PR closed without merge)
 		if HasLabel(issue, LabelRetryReady) {
 			if !p.shouldRetryRetryReadyIssue(ctx, issue) {
+				p.recordSkip(skipreason.ReasonRetryReadySkip)
 				continue
 			}
 			// Label removed, fall through to candidate selection
@@ -961,6 +986,7 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 
 		// Skip and mark done issues as permanently processed
 		if HasLabel(issue, LabelDone) {
+			p.recordSkip(skipreason.ReasonDone)
 			p.markProcessed(issue.Number)
 			continue
 		}
@@ -978,6 +1004,7 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 					slog.Int("number", issue.Number),
 					slog.Duration("elapsed", time.Since(processedAt)),
 					slog.Duration("grace_period", p.retryGracePeriod))
+				p.recordSkip(skipreason.ReasonProcessedGrace)
 				continue
 			}
 
@@ -988,6 +1015,7 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 					p.logger.Debug("Issue still queued/in-progress, skipping retry",
 						slog.Int("number", issue.Number),
 						slog.String("task_id", taskID))
+					p.recordSkip(skipreason.ReasonInProgress)
 					continue
 				}
 			}
@@ -1007,6 +1035,7 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 
 			// GH-1983: Before retrying, check if merged PRs already exist
 			if p.hasMergedWork(ctx, issue) {
+				p.recordSkip(skipreason.ReasonDone)
 				continue
 			}
 		}
@@ -1016,6 +1045,7 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 			p.logger.Debug("Skipping issue with pending dependencies in parallel mode",
 				slog.Int("number", issue.Number),
 			)
+			p.recordSkip(skipreason.ReasonBlocked)
 			continue
 		}
 
@@ -1032,6 +1062,7 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 				p.logger.Info("Skipping re-dispatch — completed execution exists",
 					slog.Int("number", issue.Number),
 					slog.String("task_id", taskID))
+				p.recordSkip(skipreason.ReasonCompletedExecution)
 				p.markProcessed(issue.Number)
 				continue
 			}
@@ -1057,6 +1088,9 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 					slog.Int("number", deferred.Number),
 					slog.Int("dispatched", group[0].Number),
 				)
+				if p.pollerMetrics != nil {
+					p.pollerMetrics.RecordPollerDeferredScopeOverlap(p.repoKey())
+				}
 			}
 		}
 	}
@@ -1073,6 +1107,11 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 					slog.Bool("done", HasLabel(fresh, LabelDone)),
 					slog.Bool("in_progress", HasLabel(fresh, LabelInProgress)),
 				)
+				if HasLabel(fresh, LabelDone) {
+					p.recordSkip(skipreason.ReasonDone)
+				} else {
+					p.recordSkip(skipreason.ReasonInProgress)
+				}
 				p.markProcessed(issue.Number)
 				continue
 			}
@@ -1114,6 +1153,9 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 			slog.Int("number", issue.Number),
 			slog.String("title", issue.Title),
 		)
+		if p.pollerMetrics != nil {
+			p.pollerMetrics.RecordPollerDispatched(p.repoKey())
+		}
 
 		// Use mutex to coordinate stopping flag check with WaitGroup Add
 		p.wgMu.Lock()
@@ -1192,6 +1234,18 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 }
 
 // markProcessed marks an issue as processed with the current timestamp
+// repoKey returns "owner/repo" as the Prometheus label value for this poller.
+func (p *Poller) repoKey() string {
+	return p.owner + "/" + p.repo
+}
+
+// recordSkip increments the poller skip counter when pollerMetrics is wired.
+func (p *Poller) recordSkip(reason string) {
+	if p.pollerMetrics != nil {
+		p.pollerMetrics.RecordPollerSkipped(p.repoKey(), reason)
+	}
+}
+
 func (p *Poller) markProcessed(number int) {
 	p.mu.Lock()
 	p.processed[number] = time.Now()

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2938,3 +2938,118 @@ func TestPoller_CheckForNewIssues_SkipsBlockedIssues(t *testing.T) {
 		t.Errorf("dispatched %d times, want 0 (pilot-blocked must skip)", got)
 	}
 }
+
+// mockPollerMetrics captures calls to the PollerMetricsRecorder interface for testing.
+type mockPollerMetrics struct {
+	mu                    sync.Mutex
+	skipped               map[string]int64 // reason → count
+	dispatched            int64
+	deferredScopeOverlap  int64
+}
+
+func newMockPollerMetrics() *mockPollerMetrics {
+	return &mockPollerMetrics{skipped: make(map[string]int64)}
+}
+
+func (m *mockPollerMetrics) RecordPollerSkipped(_, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.skipped[reason]++
+}
+
+func (m *mockPollerMetrics) RecordPollerDispatched(_ string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dispatched++
+}
+
+func (m *mockPollerMetrics) RecordPollerDeferredScopeOverlap(_ string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deferredScopeOverlap++
+}
+
+func (m *mockPollerMetrics) getSkipped(reason string) int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.skipped[reason]
+}
+
+func TestPoller_SkipMetric_IncrementsByReason(t *testing.T) {
+	tests := []struct {
+		name         string
+		issue        *Issue
+		wantReason   string
+		wantSkipped  int64
+		wantDispatch int64
+	}{
+		{
+			name:        "in_progress label → ReasonInProgress",
+			issue:       &Issue{Number: 1, Title: "T", Labels: []Label{{Name: "pilot"}, {Name: LabelInProgress}}},
+			wantReason:  "in_progress",
+			wantSkipped: 1,
+		},
+		{
+			name:        "blocked label → ReasonBlocked",
+			issue:       &Issue{Number: 1, Title: "T", Labels: []Label{{Name: "pilot"}, {Name: LabelBlocked}}},
+			wantReason:  "blocked",
+			wantSkipped: 1,
+		},
+		{
+			name:        "needs_clarification label → ReasonNeedsClarification",
+			issue:       &Issue{Number: 1, Title: "T", Labels: []Label{{Name: "pilot"}, {Name: LabelNeedsClarification}}},
+			wantReason:  "needs_clarification",
+			wantSkipped: 1,
+		},
+		{
+			name:        "done label → ReasonDone",
+			issue:       &Issue{Number: 1, Title: "T", Labels: []Label{{Name: "pilot"}, {Name: LabelDone}}},
+			wantReason:  "done",
+			wantSkipped: 1,
+		},
+		{
+			name:         "clean issue → dispatch counter",
+			issue:        &Issue{Number: 1, Title: "T", Labels: []Label{{Name: "pilot"}}},
+			wantDispatch: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				// Serve the issue as both list and single-object responses.
+				if strings.Contains(r.URL.Path, "/issues/") {
+					_ = json.NewEncoder(w).Encode(tt.issue)
+				} else {
+					_ = json.NewEncoder(w).Encode([]*Issue{tt.issue})
+				}
+			}))
+			defer server.Close()
+
+			rec := newMockPollerMetrics()
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+				WithPollerMetricsRecorder(rec),
+				WithOnIssue(func(_ context.Context, _ *Issue) error { return nil }),
+			)
+
+			poller.checkForNewIssues(context.Background())
+			poller.WaitForActive()
+
+			if tt.wantSkipped > 0 {
+				if got := rec.getSkipped(tt.wantReason); got != tt.wantSkipped {
+					t.Errorf("skipped[%q] = %d, want %d", tt.wantReason, got, tt.wantSkipped)
+				}
+			}
+			if tt.wantDispatch > 0 {
+				rec.mu.Lock()
+				got := rec.dispatched
+				rec.mu.Unlock()
+				if got != tt.wantDispatch {
+					t.Errorf("dispatched = %d, want %d", got, tt.wantDispatch)
+				}
+			}
+		})
+	}
+}

--- a/internal/adapters/gitlab/poller.go
+++ b/internal/adapters/gitlab/poller.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/adapters/skipreason"
 	"github.com/qf-studio/pilot/internal/logging"
 )
 
@@ -31,6 +32,13 @@ type IssueResult struct {
 	HeadSHA    string // Head commit SHA of the MR
 	BranchName string // Head branch name (e.g. "pilot/GH-123")
 	Error      error
+}
+
+// PollerMetricsRecorder records per-repo poller skip/dispatch counters.
+// Implemented by *autopilot.Metrics; kept as interface to avoid circular imports.
+type PollerMetricsRecorder interface {
+	RecordPollerSkipped(repo, reason string)
+	RecordPollerDispatched(repo string)
 }
 
 // ProcessedStore persists which GitLab issues have been processed across restarts.
@@ -73,6 +81,11 @@ type Poller struct {
 	activeWg      sync.WaitGroup
 	stopping      atomic.Bool
 	wgMu          sync.Mutex // protects stopping + activeWg Add/Wait coordination
+
+	// pollerMetrics records per-repo skip/dispatch counters (optional).
+	pollerMetrics PollerMetricsRecorder
+	// repoKeyStr identifies this repo/project in Prometheus labels.
+	repoKeyStr string
 }
 
 // PollerOption configures a Poller
@@ -138,6 +151,14 @@ func WithMaxConcurrent(n int) PollerOption {
 			n = 1
 		}
 		p.maxConcurrent = n
+	}
+}
+
+// WithPollerMetricsRecorder sets the recorder for per-repo poller skip/dispatch counters.
+func WithPollerMetricsRecorder(rec PollerMetricsRecorder, repoKey string) PollerOption {
+	return func(p *Poller) {
+		p.pollerMetrics = rec
+		p.repoKeyStr = repoKey
 	}
 }
 
@@ -507,11 +528,24 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 		p.mu.RUnlock()
 
 		if processed {
+			if p.pollerMetrics != nil {
+				p.pollerMetrics.RecordPollerSkipped(p.repoKeyStr, skipreason.ReasonProcessedGrace)
+			}
 			continue
 		}
 
 		// Skip if has in-progress, done, or failed label
 		if p.hasStatusLabel(issue) {
+			if p.pollerMetrics != nil {
+				switch {
+				case HasLabel(issue, LabelInProgress):
+					p.pollerMetrics.RecordPollerSkipped(p.repoKeyStr, skipreason.ReasonInProgress)
+				case HasLabel(issue, LabelDone):
+					p.pollerMetrics.RecordPollerSkipped(p.repoKeyStr, skipreason.ReasonDone)
+				default:
+					p.pollerMetrics.RecordPollerSkipped(p.repoKeyStr, skipreason.ReasonFailedSkip)
+				}
+			}
 			p.markProcessed(issue.IID)
 			continue
 		}
@@ -530,6 +564,9 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 			slog.Int("iid", issue.IID),
 			slog.String("title", issue.Title),
 		)
+		if p.pollerMetrics != nil {
+			p.pollerMetrics.RecordPollerDispatched(p.repoKeyStr)
+		}
 
 		// Use mutex to coordinate stopping flag check with WaitGroup Add
 		p.wgMu.Lock()

--- a/internal/adapters/gitlab/poller_test.go
+++ b/internal/adapters/gitlab/poller_test.go
@@ -1,6 +1,11 @@
 package gitlab
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 )
@@ -390,5 +395,111 @@ func TestPollerWithProcessedStore(t *testing.T) {
 	// Verify it was removed from store
 	if store.processed[100] {
 		t.Error("expected issue 100 to be removed from store")
+	}
+}
+
+// mockPollerMetrics satisfies PollerMetricsRecorder for GitLab poller tests.
+type mockPollerMetrics struct {
+	mu         sync.Mutex
+	skipped    map[string]int64
+	dispatched int64
+}
+
+func newMockPollerMetrics() *mockPollerMetrics {
+	return &mockPollerMetrics{skipped: make(map[string]int64)}
+}
+
+func (m *mockPollerMetrics) RecordPollerSkipped(_, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.skipped[reason]++
+}
+
+func (m *mockPollerMetrics) RecordPollerDispatched(_ string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dispatched++
+}
+
+func TestPoller_SkipMetric_IncrementsByReason(t *testing.T) {
+	tests := []struct {
+		name         string
+		issue        *Issue
+		wantReason   string
+		wantSkipped  int64
+		wantDispatch int64
+	}{
+		{
+			name:        "already processed → ReasonProcessedGrace",
+			issue:       &Issue{IID: 1, Title: "T", Labels: []string{"pilot"}},
+			wantReason:  "processed_grace",
+			wantSkipped: 1,
+			// Issue will be pre-marked in the test below
+		},
+		{
+			name:        "in_progress label → ReasonInProgress",
+			issue:       &Issue{IID: 2, Title: "T", Labels: []string{"pilot", LabelInProgress}},
+			wantReason:  "in_progress",
+			wantSkipped: 1,
+		},
+		{
+			name:        "done label → ReasonDone",
+			issue:       &Issue{IID: 3, Title: "T", Labels: []string{"pilot", LabelDone}},
+			wantReason:  "done",
+			wantSkipped: 1,
+		},
+		{
+			name:        "failed label → ReasonFailedSkip",
+			issue:       &Issue{IID: 4, Title: "T", Labels: []string{"pilot", LabelFailed}},
+			wantReason:  "failed_skip",
+			wantSkipped: 1,
+		},
+		{
+			name:         "clean issue → dispatch counter",
+			issue:        &Issue{IID: 5, Title: "T", Labels: []string{"pilot"}},
+			wantDispatch: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode([]*Issue{tt.issue})
+			}))
+			defer server.Close()
+
+			rec := newMockPollerMetrics()
+			client := NewClientWithBaseURL("test-token", "ns/proj", server.URL)
+			poller := NewPoller(client, "pilot", 30*time.Second,
+				WithPollerMetricsRecorder(rec, "ns/proj"),
+				WithOnIssue(func(_ context.Context, _ *Issue) error { return nil }),
+			)
+
+			// Pre-mark for the "already processed" test case
+			if tt.wantReason == "processed_grace" {
+				poller.markProcessed(tt.issue.IID)
+			}
+
+			poller.checkForNewIssues(context.Background())
+			poller.WaitForActive()
+
+			if tt.wantSkipped > 0 {
+				rec.mu.Lock()
+				got := rec.skipped[tt.wantReason]
+				rec.mu.Unlock()
+				if got != tt.wantSkipped {
+					t.Errorf("skipped[%q] = %d, want %d", tt.wantReason, got, tt.wantSkipped)
+				}
+			}
+			if tt.wantDispatch > 0 {
+				rec.mu.Lock()
+				got := rec.dispatched
+				rec.mu.Unlock()
+				if got != tt.wantDispatch {
+					t.Errorf("dispatched = %d, want %d", got, tt.wantDispatch)
+				}
+			}
+		})
 	}
 }

--- a/internal/adapters/skipreason/skipreason.go
+++ b/internal/adapters/skipreason/skipreason.go
@@ -1,0 +1,16 @@
+// Package skipreason defines shared constants for poller dispatch-skip label values.
+// All three pollers (GitHub, GitLab, Azure DevOps) use these constants so that
+// the pilot_poller_skipped_total{reason} label is consistent across adapters.
+package skipreason
+
+const (
+	ReasonInProgress         = "in_progress"
+	ReasonDone               = "done"
+	ReasonBlocked            = "blocked"
+	ReasonNeedsClarification = "needs_clarification"
+	ReasonSuperseded         = "superseded"
+	ReasonFailedSkip         = "failed_skip"
+	ReasonRetryReadySkip     = "retry_ready_skip"
+	ReasonProcessedGrace     = "processed_grace"
+	ReasonCompletedExecution = "completed_execution"
+)

--- a/internal/autopilot/metrics.go
+++ b/internal/autopilot/metrics.go
@@ -41,6 +41,11 @@ type Metrics struct {
 	ExecutionCostUSD   map[string]float64 // model → cumulative USD cost
 	ExecutionsByResult map[execKey]int64  // {model,result} → execution count
 
+	// Poller counters (GH-3064): per-repo skip/dispatch visibility
+	PollerSkipped              map[string]map[string]int64 // repo → reason → count
+	PollerDispatched           map[string]int64             // repo → count
+	PollerDeferredScopeOverlap map[string]int64             // repo → count
+
 	// Gauges (point-in-time values)
 	ActivePRsByStage map[PRStage]int
 	QueueDepth       int // issues with `pilot` label, no `pilot-in-progress`
@@ -61,19 +66,22 @@ type Metrics struct {
 // NewMetrics creates a new Metrics instance.
 func NewMetrics() *Metrics {
 	return &Metrics{
-		IssuesProcessed:       make(map[string]int64),
-		APIErrors:             make(map[string]int64),
-		LabelCleanups:         make(map[string]int64),
-		ApprovalPersistMisses: make(map[string]int64),
-		TokensConsumed:        make(map[tokenKey]int64),
-		ExecutionCostUSD:      make(map[string]float64),
-		ExecutionsByResult:    make(map[execKey]int64),
-		ActivePRsByStage:      make(map[PRStage]int),
-		PRTimeToMerge:         make([]time.Duration, 0, 100),
-		CIWaitDurations:       make([]time.Duration, 0, 100),
-		ExecutionDurations:    make([]time.Duration, 0, 100),
-		apiErrorTimes:         make([]time.Time, 0, 100),
-		maxSamples:            1000,
+		IssuesProcessed:            make(map[string]int64),
+		APIErrors:                  make(map[string]int64),
+		LabelCleanups:              make(map[string]int64),
+		ApprovalPersistMisses:      make(map[string]int64),
+		TokensConsumed:             make(map[tokenKey]int64),
+		ExecutionCostUSD:           make(map[string]float64),
+		ExecutionsByResult:         make(map[execKey]int64),
+		PollerSkipped:              make(map[string]map[string]int64),
+		PollerDispatched:           make(map[string]int64),
+		PollerDeferredScopeOverlap: make(map[string]int64),
+		ActivePRsByStage:           make(map[PRStage]int),
+		PRTimeToMerge:              make([]time.Duration, 0, 100),
+		CIWaitDurations:            make([]time.Duration, 0, 100),
+		ExecutionDurations:         make([]time.Duration, 0, 100),
+		apiErrorTimes:              make([]time.Time, 0, 100),
+		maxSamples:                 1000,
 	}
 }
 
@@ -162,6 +170,30 @@ func (m *Metrics) RecordExecution(model, result string) {
 	m.ExecutionsByResult[execKey{Model: model, Result: result}]++
 }
 
+// RecordPollerSkipped increments the skip counter for the given repo and reason.
+func (m *Metrics) RecordPollerSkipped(repo, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.PollerSkipped[repo] == nil {
+		m.PollerSkipped[repo] = make(map[string]int64)
+	}
+	m.PollerSkipped[repo][reason]++
+}
+
+// RecordPollerDispatched increments the dispatched counter for the given repo.
+func (m *Metrics) RecordPollerDispatched(repo string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PollerDispatched[repo]++
+}
+
+// RecordPollerDeferredScopeOverlap increments the scope-overlap deferral counter for the given repo.
+func (m *Metrics) RecordPollerDeferredScopeOverlap(repo string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PollerDeferredScopeOverlap[repo]++
+}
+
 // --- Gauge updates ---
 
 // UpdateActivePRs recalculates active PR counts by stage from a snapshot.
@@ -238,10 +270,13 @@ func (m *Metrics) Snapshot() MetricsSnapshot {
 		APIErrors:             copyStringIntMap(m.APIErrors),
 		LabelCleanups:         copyStringIntMap(m.LabelCleanups),
 		ApprovalPersistMisses: copyStringIntMap(m.ApprovalPersistMisses),
-		TokensConsumed:        copyTokenKeyMap(m.TokensConsumed),
-		ExecutionCostUSD:      copyStringFloatMap(m.ExecutionCostUSD),
-		ExecutionsByResult:    copyExecKeyMap(m.ExecutionsByResult),
-		ActivePRsByStage:      copyStageIntMap(m.ActivePRsByStage),
+		TokensConsumed:             copyTokenKeyMap(m.TokensConsumed),
+		ExecutionCostUSD:           copyStringFloatMap(m.ExecutionCostUSD),
+		ExecutionsByResult:         copyExecKeyMap(m.ExecutionsByResult),
+		PollerSkipped:              copyRepoReasonMap(m.PollerSkipped),
+		PollerDispatched:           copyStringIntMap(m.PollerDispatched),
+		PollerDeferredScopeOverlap: copyStringIntMap(m.PollerDeferredScopeOverlap),
+		ActivePRsByStage:           copyStageIntMap(m.ActivePRsByStage),
 		QueueDepth:            m.QueueDepth,
 		FailedQueueDepth:      m.FailedQueueDepth,
 		TotalActivePRs:        sumStageMap(m.ActivePRsByStage),
@@ -291,6 +326,11 @@ type MetricsSnapshot struct {
 	TokensConsumed        map[tokenKey]int64
 	ExecutionCostUSD      map[string]float64
 	ExecutionsByResult    map[execKey]int64
+
+	// Poller counters
+	PollerSkipped              map[string]map[string]int64
+	PollerDispatched           map[string]int64
+	PollerDeferredScopeOverlap map[string]int64
 
 	// Gauges
 	ActivePRsByStage map[PRStage]int
@@ -402,6 +442,17 @@ func copyExecKeyMap(src map[execKey]int64) map[execKey]int64 {
 	dst := make(map[execKey]int64, len(src))
 	for k, v := range src {
 		dst[k] = v
+	}
+	return dst
+}
+
+func copyRepoReasonMap(src map[string]map[string]int64) map[string]map[string]int64 {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]map[string]int64, len(src))
+	for repo, reasons := range src {
+		dst[repo] = copyStringIntMap(reasons)
 	}
 	return dst
 }

--- a/internal/gateway/prometheus.go
+++ b/internal/gateway/prometheus.go
@@ -112,6 +112,29 @@ func (e *PrometheusExporter) WritePrometheus(w io.Writer) error {
 		writeCounter(w, "pilot_executions_total", v, "model", k.Model, "result", k.Result)
 	}
 
+	// pilot_poller_skipped_total
+	writeHelp(w, "pilot_poller_skipped_total", "Total poller dispatch skips by repo and reason")
+	writeType(w, "pilot_poller_skipped_total", "counter")
+	for repo, reasons := range snap.PollerSkipped {
+		for reason, count := range reasons {
+			writeCounter(w, "pilot_poller_skipped_total", count, "repo", repo, "reason", reason)
+		}
+	}
+
+	// pilot_poller_dispatched_total
+	writeHelp(w, "pilot_poller_dispatched_total", "Total issues dispatched by repo")
+	writeType(w, "pilot_poller_dispatched_total", "counter")
+	for repo, count := range snap.PollerDispatched {
+		writeCounter(w, "pilot_poller_dispatched_total", count, "repo", repo)
+	}
+
+	// pilot_poller_deferred_scope_overlap_total
+	writeHelp(w, "pilot_poller_deferred_scope_overlap_total", "Total issues deferred due to overlapping scope by repo")
+	writeType(w, "pilot_poller_deferred_scope_overlap_total", "counter")
+	for repo, count := range snap.PollerDeferredScopeOverlap {
+		writeCounter(w, "pilot_poller_deferred_scope_overlap_total", count, "repo", repo)
+	}
+
 	// --- Gauges ---
 
 	// pilot_queue_depth


### PR DESCRIPTION
## Summary

- Adds `pilot_poller_skipped_total{repo,reason}`, `pilot_poller_dispatched_total{repo}`, and `pilot_poller_deferred_scope_overlap_total{repo}` Prometheus counters
- New `internal/adapters/skipreason` package with 9 shared reason constants (`in_progress`, `done`, `blocked`, `needs_clarification`, `superseded`, `failed_skip`, `retry_ready_skip`, `processed_grace`, `completed_execution`)
- Wires all skip branches in the GitHub poller's parallel `checkForNewIssues` path (Phase 1 candidates + Phase 2 scope-deferral + Phase 3 fresh-label re-check + dispatch counter)
- Wires GitLab and Azure DevOps pollers' simpler processed/status-label branches and dispatch points

Fixes the silent dispatch-loss visibility gap that caused the 2026-05-21 GH-21/22/26 5-hour incident.

## Test plan

- [x] `go build ./...` passes with zero errors
- [x] `go vet ./...` passes
- [x] `TestPoller_SkipMetric_IncrementsByReason` table-driven tests pass for GitHub, GitLab, and Azure DevOps pollers (covers each reason constant)
- [x] All existing poller tests pass (`./internal/adapters/github/...`, `./internal/adapters/gitlab/...`, `./internal/adapters/azuredevops/...`)
- [ ] Manual: run `pilot start` against a mixed-state repo, confirm distribution across `reason` labels in `/metrics` endpoint

Closes #3064