### PR TITLE
feat(github): move WithRetry into doRequest + wire RecordAPIError (TASK-294, GH-3065)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -691,6 +691,9 @@ Examples:
 
 				if token != "" && cfg.Adapters.GitHub.Repo != "" {
 					client := github.NewClient(token)
+					if gwAutopilotController != nil {
+						client.SetMetricsRecorder(gwAutopilotController.Metrics())
+					}
 					label := cfg.Adapters.GitHub.Polling.Label
 					if label == "" {
 						label = cfg.Adapters.GitHub.PilotLabel
@@ -1455,6 +1458,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					)
 					autopilotControllers[cfg.Adapters.GitHub.Repo] = controller
 					autopilotController = controller // Default for backwards compat
+					ghClient.SetMetricsRecorder(controller.Metrics())
 				}
 			}
 
@@ -1661,6 +1665,9 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			}
 			if token != "" {
 				ghClient := github.NewClient(token)
+				if autopilotController != nil {
+					ghClient.SetMetricsRecorder(autopilotController.Metrics())
+				}
 				ghWH := github.NewWebhookHandler(ghClient, cfg.Adapters.GitHub.WebhookSecret, cfg.Adapters.GitHub.PilotLabel)
 				ghWH.OnPRReview(func(ctx context.Context, prNumber int, action, state, reviewer string, repo *github.Repository) error {
 					if action == "submitted" {
@@ -2048,6 +2055,9 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 
 		if token != "" {
 			client := github.NewClient(token)
+			if autopilotController != nil {
+				client.SetMetricsRecorder(autopilotController.Metrics())
+			}
 			label := cfg.Adapters.GitHub.Polling.Label
 			if label == "" {
 				label = cfg.Adapters.GitHub.PilotLabel

--- a/internal/adapters/github/cleanup_test.go
+++ b/internal/adapters/github/cleanup_test.go
@@ -143,7 +143,7 @@ func TestCleaner_Cleanup_NoIssues(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled:   true,
 		Interval:  30 * time.Minute,
@@ -205,7 +205,7 @@ func TestCleaner_Cleanup_StaleIssuesRemoved(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled:   true,
 		Interval:  30 * time.Minute,
@@ -263,7 +263,7 @@ func TestCleaner_Cleanup_RecentIssuesSkipped(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled:   true,
 		Interval:  30 * time.Minute,
@@ -326,7 +326,7 @@ func TestCleaner_Cleanup_ActiveExecutionsSkipped(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled:   true,
 		Interval:  30 * time.Minute,
@@ -352,7 +352,7 @@ func TestCleaner_Cleanup_APIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled:   true,
 		Interval:  30 * time.Minute,
@@ -375,7 +375,7 @@ func TestCleaner_StartStop(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled:   true,
 		Interval:  50 * time.Millisecond,
@@ -416,7 +416,7 @@ func TestCleaner_Stop(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled:   true,
 		Interval:  50 * time.Millisecond,
@@ -457,7 +457,7 @@ func TestCleaner_DoubleStart(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled:   true,
 		Interval:  100 * time.Millisecond,
@@ -553,7 +553,7 @@ func TestCleaner_Cleanup_StaleFailedLabelsRemoved(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled:         true,
 		Interval:        30 * time.Minute,
@@ -635,7 +635,7 @@ func TestCleaner_Cleanup_StaleBlockedLabelsRemoved(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled:         true,
 		Interval:        30 * time.Minute,
@@ -703,7 +703,7 @@ func TestCleaner_Cleanup_RecentFailedIssuesSkipped(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled:         true,
 		Interval:        30 * time.Minute,
@@ -802,7 +802,7 @@ func TestCleaner_Cleanup_ClosedInProgressIssueCleaned(t *testing.T) {
 	defer server.Close()
 
 	var callbackIssue int
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled:   true,
 		Interval:  30 * time.Minute,
@@ -868,7 +868,7 @@ func TestCleaner_Cleanup_ClosedInProgressWithActiveExecutionSkipped(t *testing.T
 	defer server.Close()
 
 	callbackFired := false
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled: true, Interval: 30 * time.Minute, Threshold: 1 * time.Hour,
 	}, WithOnInProgressCleaned(func(int) { callbackFired = true }))
@@ -923,7 +923,7 @@ func TestCleaner_StartupRecover_StuckIssueUnlabeled(t *testing.T) {
 	defer server.Close()
 
 	var callbackIssue int
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled: true, Interval: 30 * time.Minute, Threshold: 1 * time.Hour,
 	}, WithOnStartupRecovered(func(n int) { callbackIssue = n }))
@@ -988,7 +988,7 @@ func TestCleaner_StartupRecover_LiveExecutionSkipped(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled: true, Interval: 30 * time.Minute, Threshold: 1 * time.Hour,
 	})
@@ -1058,7 +1058,7 @@ func TestCleaner_StartupRecover_StaleExecutionStripped(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled: true, Interval: 30 * time.Minute, Threshold: 1 * time.Hour,
 	})
@@ -1091,7 +1091,7 @@ func TestCleaner_StartupRecover_NoIssues(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	cleaner, _ := NewCleaner(client, store, "owner/repo", &StaleLabelCleanupConfig{
 		Enabled: true, Interval: 30 * time.Minute, Threshold: 1 * time.Hour,
 	})

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -34,33 +34,74 @@ type GraphQLError struct {
 	Message string `json:"message"`
 }
 
+// MetricsRecorder records API error events for observability.
+type MetricsRecorder interface {
+	RecordAPIError(endpoint string)
+}
+
+// ClientOption configures a Client.
+type ClientOption func(*Client)
+
+// WithMetricsRecorder sets the metrics recorder for API error tracking.
+func WithMetricsRecorder(m MetricsRecorder) ClientOption {
+	return func(c *Client) {
+		c.metricsRecorder = m
+	}
+}
+
+// WithRetryOptions overrides the default retry configuration.
+// Useful in tests to reduce delays.
+func WithRetryOptions(opts RetryOptions) ClientOption {
+	return func(c *Client) {
+		c.retryOpts = opts
+	}
+}
+
 // Client is a GitHub API client
 type Client struct {
-	token      string
-	httpClient *http.Client
-	baseURL    string // For testing - defaults to githubAPIURL
+	token           string
+	httpClient      *http.Client
+	baseURL         string // For testing - defaults to githubAPIURL
+	metricsRecorder MetricsRecorder
+	retryOpts       RetryOptions
 }
 
 // NewClient creates a new GitHub client
-func NewClient(token string) *Client {
-	return &Client{
+func NewClient(token string, opts ...ClientOption) *Client {
+	c := &Client{
 		token:   token,
 		baseURL: githubAPIURL,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
+		retryOpts: DefaultRetryOptions(),
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // NewClientWithBaseURL creates a new GitHub client with a custom base URL (for testing)
-func NewClientWithBaseURL(token, baseURL string) *Client {
-	return &Client{
+func NewClientWithBaseURL(token, baseURL string, opts ...ClientOption) *Client {
+	c := &Client{
 		token:   token,
 		baseURL: baseURL,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
+		retryOpts: DefaultRetryOptions(),
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// SetMetricsRecorder sets the metrics recorder after construction.
+// Must only be called during initialization before concurrent use.
+func (c *Client) SetMetricsRecorder(m MetricsRecorder) {
+	c.metricsRecorder = m
 }
 
 // Issue represents a GitHub issue
@@ -116,51 +157,106 @@ type Comment struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// doRequest performs an HTTP request to the GitHub API
+// doRequest performs an HTTP request to the GitHub API with automatic retry on 429/5xx.
+// Body marshaling happens once; the retry closure creates a fresh reader per attempt.
+// RecordAPIError is called when a retryable error exhausts all retries.
 func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}, result interface{}) error {
-	var bodyReader io.Reader
+	var bodyBytes []byte
 	if body != nil {
-		bodyBytes, err := json.Marshal(body)
+		var err error
+		bodyBytes, err = json.Marshal(body)
 		if err != nil {
 			return fmt.Errorf("failed to marshal request body: %w", err)
 		}
-		bodyReader = bytes.NewReader(bodyBytes)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
+	endpointLabel := normalizePathLabel(path)
 
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
+	err := WithRetryVoid(ctx, func() error {
+		var bodyReader io.Reader
+		if bodyBytes != nil {
+			bodyReader = bytes.NewReader(bodyBytes)
+		}
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
+		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
-	}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		if bodyBytes != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
-	}
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to execute request: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
 
-	if result != nil && len(respBody) > 0 {
-		if err := json.Unmarshal(respBody, result); err != nil {
-			return fmt.Errorf("failed to parse response: %w", err)
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response: %w", err)
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+		}
+
+		if result != nil && len(respBody) > 0 {
+			if err := json.Unmarshal(respBody, result); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+		}
+
+		return nil
+	}, c.retryOpts)
+
+	// Record metric only for retryable errors (429/5xx/network) — not business-logic 4xx.
+	if err != nil && c.metricsRecorder != nil && isRetryableError(err) {
+		c.metricsRecorder.RecordAPIError(endpointLabel)
+	}
+	return err
+}
+
+// normalizePathLabel derives a stable label from a URL path for Prometheus metrics.
+// Numeric segments become :id; 40-char hex segments (SHAs) become :sha.
+func normalizePathLabel(path string) string {
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		path = path[:i]
+	}
+	parts := strings.Split(path, "/")
+	for i, p := range parts {
+		if isAllDigits(p) {
+			parts[i] = ":id"
+		} else if len(p) == 40 && isAllHex(p) {
+			parts[i] = ":sha"
 		}
 	}
+	return strings.Join(parts, "/")
+}
 
-	return nil
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isAllHex(s string) bool {
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
 }
 
 // GetIssue fetches an issue by owner, repo, and number
@@ -185,47 +281,39 @@ func (c *Client) ListIssueComments(ctx context.Context, owner, repo string, numb
 
 // AddComment adds a comment to an issue
 func (c *Client) AddComment(ctx context.Context, owner, repo string, number int, body string) (*Comment, error) {
-	return WithRetry(ctx, func() (*Comment, error) {
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
-		reqBody := map[string]string{"body": body}
-		var comment Comment
-		if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &comment); err != nil {
-			return nil, err
-		}
-		return &comment, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
+	reqBody := map[string]string{"body": body}
+	var comment Comment
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &comment); err != nil {
+		return nil, err
+	}
+	return &comment, nil
 }
 
 // AddLabels adds labels to an issue
 func (c *Client) AddLabels(ctx context.Context, owner, repo string, number int, labels []string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, number)
-		reqBody := map[string][]string{"labels": labels}
-		return c.doRequest(ctx, http.MethodPost, path, reqBody, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, number)
+	reqBody := map[string][]string{"labels": labels}
+	return c.doRequest(ctx, http.MethodPost, path, reqBody, nil)
 }
 
 // RemoveLabel removes a label from an issue
 func (c *Client) RemoveLabel(ctx context.Context, owner, repo string, number int, label string) error {
-	return WithRetryVoid(ctx, func() error {
-		// GitHub API is case-sensitive for label names in URL path, normalize to lowercase
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%s", owner, repo, number, strings.ToLower(label))
-		err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
-		// 404 is OK - label might not exist
-		if err != nil && err.Error() != "API error (status 404): " {
-			return err
-		}
-		return nil
-	}, DefaultRetryOptions())
+	// GitHub API is case-sensitive for label names in URL path, normalize to lowercase
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%s", owner, repo, number, strings.ToLower(label))
+	err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
+	// 404 is OK - label might not exist
+	if err != nil && err.Error() != "API error (status 404): " {
+		return err
+	}
+	return nil
 }
 
 // UpdateIssueState updates an issue's state (open/closed)
 func (c *Client) UpdateIssueState(ctx context.Context, owner, repo string, number int, state string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d", owner, repo, number)
-		reqBody := map[string]string{"state": state}
-		return c.doRequest(ctx, http.MethodPatch, path, reqBody, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d", owner, repo, number)
+	reqBody := map[string]string{"state": state}
+	return c.doRequest(ctx, http.MethodPatch, path, reqBody, nil)
 }
 
 // GetRepository fetches repository info
@@ -241,51 +329,43 @@ func (c *Client) GetRepository(ctx context.Context, owner, repo string) (*Reposi
 // CreateCommitStatus creates a status for a specific commit SHA
 // The context parameter allows multiple statuses per commit (e.g., "ci/build", "pilot/execution")
 func (c *Client) CreateCommitStatus(ctx context.Context, owner, repo, sha string, status *CommitStatus) (*CommitStatus, error) {
-	return WithRetry(ctx, func() (*CommitStatus, error) {
-		path := fmt.Sprintf("/repos/%s/%s/statuses/%s", owner, repo, sha)
-		var result CommitStatus
-		if err := c.doRequest(ctx, http.MethodPost, path, status, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/statuses/%s", owner, repo, sha)
+	var result CommitStatus
+	if err := c.doRequest(ctx, http.MethodPost, path, status, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // CreateCheckRun creates a check run for the GitHub Checks API
 // Requires a GitHub App token with checks:write permission
 func (c *Client) CreateCheckRun(ctx context.Context, owner, repo string, checkRun *CheckRun) (*CheckRun, error) {
-	return WithRetry(ctx, func() (*CheckRun, error) {
-		path := fmt.Sprintf("/repos/%s/%s/check-runs", owner, repo)
-		var result CheckRun
-		if err := c.doRequest(ctx, http.MethodPost, path, checkRun, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/check-runs", owner, repo)
+	var result CheckRun
+	if err := c.doRequest(ctx, http.MethodPost, path, checkRun, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // UpdateCheckRun updates an existing check run
 func (c *Client) UpdateCheckRun(ctx context.Context, owner, repo string, checkRunID int64, checkRun *CheckRun) (*CheckRun, error) {
-	return WithRetry(ctx, func() (*CheckRun, error) {
-		path := fmt.Sprintf("/repos/%s/%s/check-runs/%d", owner, repo, checkRunID)
-		var result CheckRun
-		if err := c.doRequest(ctx, http.MethodPatch, path, checkRun, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/check-runs/%d", owner, repo, checkRunID)
+	var result CheckRun
+	if err := c.doRequest(ctx, http.MethodPatch, path, checkRun, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // CreatePullRequest creates a new pull request
 func (c *Client) CreatePullRequest(ctx context.Context, owner, repo string, input *PullRequestInput) (*PullRequest, error) {
-	return WithRetry(ctx, func() (*PullRequest, error) {
-		path := fmt.Sprintf("/repos/%s/%s/pulls", owner, repo)
-		var result PullRequest
-		if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/pulls", owner, repo)
+	var result PullRequest
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // RequestReviewers requests reviewers for a pull request.
@@ -294,17 +374,15 @@ func (c *Client) RequestReviewers(ctx context.Context, owner, repo string, numbe
 	if len(reviewers) == 0 && len(teamReviewers) == 0 {
 		return nil
 	}
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, number)
-		body := map[string][]string{}
-		if len(reviewers) > 0 {
-			body["reviewers"] = reviewers
-		}
-		if len(teamReviewers) > 0 {
-			body["team_reviewers"] = teamReviewers
-		}
-		return c.doRequest(ctx, http.MethodPost, path, body, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, number)
+	body := map[string][]string{}
+	if len(reviewers) > 0 {
+		body["reviewers"] = reviewers
+	}
+	if len(teamReviewers) > 0 {
+		body["team_reviewers"] = teamReviewers
+	}
+	return c.doRequest(ctx, http.MethodPost, path, body, nil)
 }
 
 // GetPullRequest fetches a pull request by number
@@ -320,26 +398,22 @@ func (c *Client) GetPullRequest(ctx context.Context, owner, repo string, number 
 // ClosePullRequest closes a pull request without merging.
 // Used by autopilot to close failed PRs so the sequential poller can unblock.
 func (c *Client) ClosePullRequest(ctx context.Context, owner, repo string, number int) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number)
-		payload := map[string]string{"state": "closed"}
-		return c.doRequest(ctx, http.MethodPatch, path, payload, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number)
+	payload := map[string]string{"state": "closed"}
+	return c.doRequest(ctx, http.MethodPatch, path, payload, nil)
 }
 
 // AddPRComment adds a comment to a pull request (issue comment API)
 // For review comments on specific lines, use CreatePRReviewComment instead
 func (c *Client) AddPRComment(ctx context.Context, owner, repo string, number int, body string) (*PRComment, error) {
-	return WithRetry(ctx, func() (*PRComment, error) {
-		// PRs use the issues API for general comments
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
-		reqBody := map[string]string{"body": body}
-		var result PRComment
-		if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	// PRs use the issues API for general comments
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
+	reqBody := map[string]string{"body": body}
+	var result PRComment
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // ListIssues lists issues for a repository with optional filters
@@ -413,18 +487,16 @@ func HasLabel(issue *Issue, labelName string) bool {
 // method can be "merge", "squash", or "rebase" (use MergeMethod* constants)
 // commitTitle is optional - if empty, GitHub uses the default
 func (c *Client) MergePullRequest(ctx context.Context, owner, repo string, number int, method, commitTitle string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, number)
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, number)
 
-		body := map[string]string{
-			"merge_method": method,
-		}
-		if commitTitle != "" {
-			body["commit_title"] = commitTitle
-		}
+	body := map[string]string{
+		"merge_method": method,
+	}
+	if commitTitle != "" {
+		body["commit_title"] = commitTitle
+	}
 
-		return c.doRequest(ctx, http.MethodPut, path, body, nil)
-	}, DefaultRetryOptions())
+	return c.doRequest(ctx, http.MethodPut, path, body, nil)
 }
 
 // GetCombinedStatus gets combined status for a commit SHA
@@ -456,18 +528,16 @@ func (c *Client) ListCheckRuns(ctx context.Context, owner, repo, sha string) (*C
 // ApprovePullRequest creates an approval review on a PR
 // body is the optional review comment
 func (c *Client) ApprovePullRequest(ctx context.Context, owner, repo string, number int, body string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, number)
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, number)
 
-		payload := map[string]string{
-			"event": ReviewEventApprove,
-		}
-		if body != "" {
-			payload["body"] = body
-		}
+	payload := map[string]string{
+		"event": ReviewEventApprove,
+	}
+	if body != "" {
+		payload["body"] = body
+	}
 
-		return c.doRequest(ctx, http.MethodPost, path, payload, nil)
-	}, DefaultRetryOptions())
+	return c.doRequest(ctx, http.MethodPost, path, payload, nil)
 }
 
 // IssueInput is the input for creating a new issue
@@ -479,14 +549,12 @@ type IssueInput struct {
 
 // CreateIssue creates a new issue in a repository
 func (c *Client) CreateIssue(ctx context.Context, owner, repo string, input *IssueInput) (*Issue, error) {
-	return WithRetry(ctx, func() (*Issue, error) {
-		path := fmt.Sprintf("/repos/%s/%s/issues", owner, repo)
-		var issue Issue
-		if err := c.doRequest(ctx, http.MethodPost, path, input, &issue); err != nil {
-			return nil, err
-		}
-		return &issue, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/issues", owner, repo)
+	var issue Issue
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &issue); err != nil {
+		return nil, err
+	}
+	return &issue, nil
 }
 
 // GetBranch fetches information about a branch
@@ -512,28 +580,24 @@ func (c *Client) ListPullRequests(ctx context.Context, owner, repo, state string
 
 // CreateRelease creates a new release
 func (c *Client) CreateRelease(ctx context.Context, owner, repo string, input *ReleaseInput) (*Release, error) {
-	return WithRetry(ctx, func() (*Release, error) {
-		path := fmt.Sprintf("/repos/%s/%s/releases", owner, repo)
-		var result Release
-		if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/releases", owner, repo)
+	var result Release
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // CreateGitTag creates a lightweight git tag via the GitHub API.
 // This creates only the tag ref, not a GitHub Release — letting GoReleaser
 // handle the full release creation with binary assets on tag push.
 func (c *Client) CreateGitTag(ctx context.Context, owner, repo, tag, sha string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo)
-		body := map[string]string{
-			"ref": "refs/tags/" + tag,
-			"sha": sha,
-		}
-		return c.doRequest(ctx, http.MethodPost, path, body, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo)
+	body := map[string]string{
+		"ref": "refs/tags/" + tag,
+		"sha": sha,
+	}
+	return c.doRequest(ctx, http.MethodPost, path, body, nil)
 }
 
 // GetLatestRelease gets the latest published release
@@ -567,14 +631,12 @@ func (c *Client) GetReleaseByTag(ctx context.Context, owner, repo, tag string) (
 
 // UpdateRelease updates an existing release (e.g. to enrich the body with a summary).
 func (c *Client) UpdateRelease(ctx context.Context, owner, repo string, releaseID int64, input *ReleaseInput) (*Release, error) {
-	return WithRetry(ctx, func() (*Release, error) {
-		path := fmt.Sprintf("/repos/%s/%s/releases/%d", owner, repo, releaseID)
-		var result Release
-		if err := c.doRequest(ctx, http.MethodPatch, path, input, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/releases/%d", owner, repo, releaseID)
+	var result Release
+	if err := c.doRequest(ctx, http.MethodPatch, path, input, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // ListReleases lists releases for a repository (newest first)
@@ -690,43 +752,39 @@ func isUnprocessableError(err error) bool {
 // Uses PATCH /repos/{owner}/{repo}/git/refs/heads/{branch} with force=true.
 // If the ref does not exist, falls back to creating it via POST.
 func (c *Client) UpdateRef(ctx context.Context, owner, repo, branch, sha string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, url.PathEscape(branch))
-		body := map[string]interface{}{
-			"sha":   sha,
-			"force": true,
+	path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, url.PathEscape(branch))
+	body := map[string]interface{}{
+		"sha":   sha,
+		"force": true,
+	}
+	err := c.doRequest(ctx, http.MethodPatch, path, body, nil)
+	if err == nil {
+		return nil
+	}
+	// If the ref doesn't exist yet, create it
+	if isUnprocessableError(err) || isNotFoundError(err) {
+		createPath := fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo)
+		createBody := map[string]string{
+			"ref": "refs/heads/" + branch,
+			"sha": sha,
 		}
-		err := c.doRequest(ctx, http.MethodPatch, path, body, nil)
-		if err == nil {
-			return nil
-		}
-		// If the ref doesn't exist yet, create it
-		if isUnprocessableError(err) || isNotFoundError(err) {
-			createPath := fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo)
-			createBody := map[string]string{
-				"ref": "refs/heads/" + branch,
-				"sha": sha,
-			}
-			return c.doRequest(ctx, http.MethodPost, createPath, createBody, nil)
-		}
-		return err
-	}, DefaultRetryOptions())
+		return c.doRequest(ctx, http.MethodPost, createPath, createBody, nil)
+	}
+	return err
 }
 
 // DeleteBranch deletes a branch from the repository.
 // GitHub API: DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}
 // Returns nil on success, or if the branch was already deleted (404/422).
 func (c *Client) DeleteBranch(ctx context.Context, owner, repo, branch string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, url.PathEscape(branch))
-		err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
-		// 404 = branch doesn't exist, 422 = branch already deleted
-		// Both are success cases for cleanup
-		if isNotFoundError(err) || isUnprocessableError(err) {
-			return nil
-		}
-		return err
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, url.PathEscape(branch))
+	err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
+	// 404 = branch doesn't exist, 422 = branch already deleted
+	// Both are success cases for cleanup
+	if isNotFoundError(err) || isUnprocessableError(err) {
+		return nil
+	}
+	return err
 }
 
 // ListPullRequestReviews lists all reviews for a pull request
@@ -940,11 +998,9 @@ func (c *Client) SearchOpenSubIssues(ctx context.Context, owner, repo string, pa
 // Uses GitHub API: PUT /repos/{owner}/{repo}/pulls/{number}/update-branch
 // Returns nil on success, error if the branch cannot be automatically updated (true conflict).
 func (c *Client) UpdatePullRequestBranch(ctx context.Context, owner, repo string, number int) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/update-branch", owner, repo, number)
-		body := map[string]interface{}{}
-		return c.doRequest(ctx, http.MethodPut, path, body, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/update-branch", owner, repo, number)
+	body := map[string]interface{}{}
+	return c.doRequest(ctx, http.MethodPut, path, body, nil)
 }
 
 // GetIssueNodeID fetches the GraphQL node ID for a given issue number via the REST API.

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -96,7 +96,7 @@ func TestGetIssue(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			issue, err := client.GetIssue(context.Background(), "owner", "repo", 42)
 
 			if (err != nil) != tt.wantErr {
@@ -161,7 +161,7 @@ func TestAddComment(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			comment, err := client.AddComment(context.Background(), "owner", "repo", 42, tt.commentBody)
 
 			if (err != nil) != tt.wantErr {
@@ -222,7 +222,7 @@ func TestAddLabels(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			err := client.AddLabels(context.Background(), "owner", "repo", 42, tt.labels)
 
 			if (err != nil) != tt.wantErr {
@@ -274,7 +274,7 @@ func TestRemoveLabel(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			err := client.RemoveLabel(context.Background(), "owner", "repo", 42, tt.label)
 
 			if (err != nil) != tt.wantErr {
@@ -293,7 +293,7 @@ func TestRemoveLabel_NormalizesToLowercase(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	_ = client.RemoveLabel(context.Background(), "owner", "repo", 42, "Pilot-Failed")
 
 	expectedPath := "/repos/owner/repo/issues/42/labels/pilot-failed"
@@ -349,7 +349,7 @@ func TestUpdateIssueState(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			err := client.UpdateIssueState(context.Background(), "owner", "repo", 42, tt.state)
 
 			if (err != nil) != tt.wantErr {
@@ -397,7 +397,7 @@ func TestGetRepository(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			repo, err := client.GetRepository(context.Background(), "owner", "repo")
 
 			if (err != nil) != tt.wantErr {
@@ -486,7 +486,7 @@ func TestCreateCommitStatus(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			result, err := client.CreateCommitStatus(context.Background(), "owner", "repo", "abc123def", tt.status)
 
 			if (err != nil) != tt.wantErr {
@@ -565,7 +565,7 @@ func TestCreateCheckRun(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			result, err := client.CreateCheckRun(context.Background(), "owner", "repo", tt.checkRun)
 
 			if (err != nil) != tt.wantErr {
@@ -642,7 +642,7 @@ func TestUpdateCheckRun(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			result, err := client.UpdateCheckRun(context.Background(), "owner", "repo", tt.checkRunID, tt.checkRun)
 
 			if (err != nil) != tt.wantErr {
@@ -732,7 +732,7 @@ func TestCreatePullRequest(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			result, err := client.CreatePullRequest(context.Background(), "owner", "repo", tt.input)
 
 			if (err != nil) != tt.wantErr {
@@ -793,7 +793,7 @@ func TestGetPullRequest(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			result, err := client.GetPullRequest(context.Background(), "owner", "repo", 42)
 
 			if (err != nil) != tt.wantErr {
@@ -838,7 +838,7 @@ func TestClosePullRequest(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			err := client.ClosePullRequest(context.Background(), "owner", "repo", 42)
 
 			if (err != nil) != tt.wantErr {
@@ -901,7 +901,7 @@ func TestAddPRComment(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			result, err := client.AddPRComment(context.Background(), "owner", "repo", 42, tt.commentBody)
 
 			if (err != nil) != tt.wantErr {
@@ -1002,7 +1002,7 @@ func TestListIssues(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			issues, err := client.ListIssues(context.Background(), "owner", "repo", tt.opts)
 
 			if (err != nil) != tt.wantErr {
@@ -1032,7 +1032,7 @@ func TestListIssues_LabelsFilteredCaseInsensitively(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	issues, err := client.ListIssues(context.Background(), "owner", "repo", &ListIssuesOptions{
 		Labels: []string{"Pilot"}, // Request with mixed case
 	})
@@ -1187,7 +1187,8 @@ func TestDoRequest_ErrorHandling(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			// Use fast retry opts so retryable status codes (500) don't slow down the test.
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(fastRetryOpts()))
 			_, err := client.GetIssue(context.Background(), "owner", "repo", 1)
 
 			if (err != nil) != tt.wantErr {
@@ -1207,7 +1208,7 @@ func TestDoRequest_InvalidJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	_, err := client.GetIssue(context.Background(), "owner", "repo", 1)
 
 	if err == nil {
@@ -1427,7 +1428,7 @@ func TestMergePullRequest(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			err := client.MergePullRequest(context.Background(), "owner", "repo", 42, tt.method, tt.commitTitle)
 
 			if (err != nil) != tt.wantErr {
@@ -1524,7 +1525,7 @@ func TestGetCombinedStatus(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			status, err := client.GetCombinedStatus(context.Background(), "owner", "repo", "abc123def456")
 
 			if (err != nil) != tt.wantErr {
@@ -1609,7 +1610,7 @@ func TestListCheckRuns(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			result, err := client.ListCheckRuns(context.Background(), "owner", "repo", "abc123def456")
 
 			if (err != nil) != tt.wantErr {
@@ -1691,7 +1692,7 @@ func TestApprovePullRequest(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			err := client.ApprovePullRequest(context.Background(), "owner", "repo", 42, tt.body)
 
 			if (err != nil) != tt.wantErr {
@@ -1802,7 +1803,7 @@ func TestListPullRequestReviews(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			reviews, err := client.ListPullRequestReviews(context.Background(), "owner", "repo", 42)
 
 			if (err != nil) != tt.wantErr {
@@ -1902,7 +1903,7 @@ func TestHasApprovalReview(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			approved, approver, err := client.HasApprovalReview(context.Background(), "owner", "repo", 42)
 
 			if (err != nil) != tt.wantErr {
@@ -1989,7 +1990,7 @@ func TestRequestReviewers(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			err := client.RequestReviewers(context.Background(), "owner", "repo", 42, tt.reviewers, tt.teamReviewers)
 
 			if (err != nil) != tt.wantErr {
@@ -2089,7 +2090,7 @@ func TestListPullRequests(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			prs, err := client.ListPullRequests(context.Background(), "owner", "repo", tt.state)
 
 			if (err != nil) != tt.wantErr {
@@ -2174,7 +2175,7 @@ func TestGetTagForSHA(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			tagName, err := client.GetTagForSHA(context.Background(), "owner", "repo", tt.sha)
 
 			if (err != nil) != tt.wantErr {
@@ -2238,7 +2239,7 @@ func TestDeleteBranch(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			err := client.DeleteBranch(context.Background(), "owner", "repo", tt.branch)
 
 			if (err != nil) != tt.wantErr {
@@ -2335,7 +2336,7 @@ func TestGetJobLogs(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			logs, err := client.GetJobLogs(context.Background(), "owner", "repo", 123)
 
 			if tt.wantErr {
@@ -2420,7 +2421,7 @@ func TestGetPullRequestComments(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			comments, err := client.GetPullRequestComments(context.Background(), "owner", "repo", 10)
 
 			if (err != nil) != tt.wantErr {
@@ -2491,7 +2492,7 @@ func TestUpdatePullRequestBranch(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			err := client.UpdatePullRequestBranch(context.Background(), "owner", "repo", 42)
 
 			if (err != nil) != tt.wantErr {
@@ -2577,7 +2578,7 @@ func TestExecuteGraphQL(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 			if tt.name == "nil result ignores data" {
 				err := client.ExecuteGraphQL(context.Background(), tt.query, tt.variables, nil)
@@ -2663,7 +2664,7 @@ func TestSearchMergedPRsForIssue(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			found, err := client.SearchMergedPRsForIssue(context.Background(), "owner", "repo", tt.issueNumber)
 
 			if (err != nil) != tt.wantErr {
@@ -2734,7 +2735,7 @@ func TestFindMergedPRByBranch(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			found, err := client.FindMergedPRByBranch(context.Background(), "owner", "repo", tt.branch)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FindMergedPRByBranch() error = %v, wantErr %v", err, tt.wantErr)
@@ -2797,7 +2798,7 @@ func TestSearchOpenSubIssues(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			count, err := client.SearchOpenSubIssues(context.Background(), "owner", "repo", tt.parentNum)
 
 			if (err != nil) != tt.wantErr {
@@ -2860,7 +2861,7 @@ func TestGetReleaseByTag(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			release, err := client.GetReleaseByTag(context.Background(), "owner", "repo", "v1.0.0")
 
 			if (err != nil) != tt.wantErr {
@@ -2919,7 +2920,7 @@ func TestGetIssueNodeID(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			nodeID, err := client.GetIssueNodeID(context.Background(), "owner", "repo", 42)
 
 			if (err != nil) != tt.wantErr {
@@ -3017,7 +3018,7 @@ func TestLinkSubIssue(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			err := client.LinkSubIssue(context.Background(), "owner", "repo", 10, 20)
 
 			if (err != nil) != tt.wantErr {
@@ -3107,7 +3108,7 @@ func TestGetOpenSubIssueCount(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			count, hasNative, err := client.GetOpenSubIssueCount(context.Background(), "owner", "repo", 50)
 
 			if (err != nil) != tt.wantErr {
@@ -3219,7 +3220,7 @@ func TestSearchOpenPilotIssuesWithSubIssues(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			numbers, err := client.SearchOpenPilotIssuesWithSubIssues(context.Background(), "owner", "repo", tt.limit)
 
 			if (err != nil) != tt.wantErr {
@@ -3282,7 +3283,7 @@ func TestUpdateRelease(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			release, err := client.UpdateRelease(context.Background(), "owner", "repo", 123, &ReleaseInput{
 				Body: "enriched changelog",
 			})
@@ -3356,7 +3357,7 @@ func TestSearchPRsForIssue(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			prs, err := client.SearchPRsForIssue(context.Background(), "owner", "repo", tt.issueNumber)
 
 			if (err != nil) != tt.wantErr {
@@ -3388,5 +3389,152 @@ func TestSearchPRsForIssue(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// fastRetryOpts returns retry options with minimal delays for unit tests.
+func fastRetryOpts() RetryOptions {
+	return RetryOptions{MaxRetries: 2, BaseDelay: time.Millisecond, MaxDelay: time.Millisecond}
+}
+
+// stubMetricsRecorder counts RecordAPIError calls.
+type stubMetricsRecorder struct {
+	calls    int
+	endpoint string
+}
+
+func (s *stubMetricsRecorder) RecordAPIError(endpoint string) {
+	s.calls++
+	s.endpoint = endpoint
+}
+
+func TestDoRequest_RetriesOn429(t *testing.T) {
+	attempt := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt++
+		if attempt == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"message":"rate limited"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"number":1}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(fastRetryOpts()))
+	var result struct{ Number int `json:"number"` }
+	err := client.doRequest(context.Background(), http.MethodGet, "/repos/o/r/issues/1", nil, &result)
+	if err != nil {
+		t.Fatalf("expected success after retry, got: %v", err)
+	}
+	if attempt != 2 {
+		t.Errorf("expected 2 attempts, got %d", attempt)
+	}
+}
+
+func TestDoRequest_RetriesOn5xx(t *testing.T) {
+	attempt := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt++
+		if attempt == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"message":"service unavailable"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"number":2}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(fastRetryOpts()))
+	var result struct{ Number int `json:"number"` }
+	err := client.doRequest(context.Background(), http.MethodGet, "/repos/o/r/issues/2", nil, &result)
+	if err != nil {
+		t.Fatalf("expected success after retry, got: %v", err)
+	}
+	if attempt != 2 {
+		t.Errorf("expected 2 attempts, got %d", attempt)
+	}
+}
+
+func TestDoRequest_RecordsAPIErrorOnRetryableExhausted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"message":"service unavailable"}`))
+	}))
+	defer server.Close()
+
+	rec := &stubMetricsRecorder{}
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL,
+		WithRetryOptions(fastRetryOpts()),
+		WithMetricsRecorder(rec),
+	)
+	err := client.doRequest(context.Background(), http.MethodGet, "/repos/o/r/issues/42", nil, nil)
+	if err == nil {
+		t.Fatal("expected error after exhausted retries")
+	}
+	if rec.calls != 1 {
+		t.Errorf("RecordAPIError called %d times, want 1", rec.calls)
+	}
+	if rec.endpoint != "/repos/o/r/issues/:id" {
+		t.Errorf("RecordAPIError endpoint = %q, want /repos/o/r/issues/:id", rec.endpoint)
+	}
+}
+
+func TestDoRequest_NoRetryOn4xx(t *testing.T) {
+	attempt := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt++
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(fastRetryOpts()))
+	err := client.doRequest(context.Background(), http.MethodGet, "/repos/o/r/issues/99", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if attempt != 1 {
+		t.Errorf("expected exactly 1 attempt for 404, got %d", attempt)
+	}
+}
+
+func TestDoRequest_NoMetricRecordedFor4xx(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	rec := &stubMetricsRecorder{}
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL,
+		WithRetryOptions(fastRetryOpts()),
+		WithMetricsRecorder(rec),
+	)
+	_ = client.doRequest(context.Background(), http.MethodGet, "/repos/o/r/issues/1", nil, nil)
+	if rec.calls != 0 {
+		t.Errorf("RecordAPIError should not be called for 404, got %d calls", rec.calls)
+	}
+}
+
+func TestNormalizePathLabel(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/repos/owner/repo/issues/42", "/repos/owner/repo/issues/:id"},
+		{"/repos/owner/repo/pulls/123/merge", "/repos/owner/repo/pulls/:id/merge"},
+		{"/repos/owner/repo/commits/abc123456789012345678901234567890123456a/status", "/repos/owner/repo/commits/:sha/status"},
+		{"/repos/owner/repo/releases?per_page=10", "/repos/owner/repo/releases"},
+		{"/repos/owner/repo/issues", "/repos/owner/repo/issues"},
+		{"/repos/owner/repo/check-runs/987654", "/repos/owner/repo/check-runs/:id"},
+	}
+	for _, tt := range tests {
+		got := normalizePathLabel(tt.path)
+		if got != tt.want {
+			t.Errorf("normalizePathLabel(%q) = %q, want %q", tt.path, got, tt.want)
+		}
 	}
 }

--- a/internal/adapters/github/gh2432_test.go
+++ b/internal/adapters/github/gh2432_test.go
@@ -50,7 +50,7 @@ func TestPoller_RetryLabel_FirstAttemptAddsRetry1(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithRetryGracePeriod(0))
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -108,7 +108,7 @@ func TestPoller_RetryLabel_Retry2EscalatesToExhausted(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithRetryGracePeriod(0))
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -148,7 +148,7 @@ func TestPoller_RetryLabel_ExhaustedIsTerminal(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithRetryGracePeriod(0))
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())

--- a/internal/adapters/github/issue_create_test.go
+++ b/internal/adapters/github/issue_create_test.go
@@ -72,7 +72,7 @@ func TestCreatePilotIssue_TitleValidation(t *testing.T) {
 			}))
 			defer server.Close()
 
-			c := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			c := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			_, err := CreatePilotIssue(context.Background(), c, nil, "owner", "repo", tt.title, "body", []string{"pilot"})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createPilotIssue(%q) error = %v, wantErr %v", tt.title, err, tt.wantErr)
@@ -112,7 +112,7 @@ func TestCreatePilotIssue_APIForwarding(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	issue, err := CreatePilotIssue(context.Background(), c, nil, "owner", "repo", wantTitle, wantBody, []string{"pilot"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/adapters/github/merger_test.go
+++ b/internal/adapters/github/merger_test.go
@@ -59,7 +59,7 @@ func TestMergeWaiter_WaitForMerge_AlreadyMerged(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	waiter := NewMergeWaiter(client, "owner", "repo", &MergeWaiterConfig{
 		PollInterval: 10 * time.Millisecond,
 		Timeout:      1 * time.Second,
@@ -95,7 +95,7 @@ func TestMergeWaiter_WaitForMerge_ClosedWithoutMerge(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	waiter := NewMergeWaiter(client, "owner", "repo", &MergeWaiterConfig{
 		PollInterval: 10 * time.Millisecond,
 		Timeout:      1 * time.Second,
@@ -130,7 +130,7 @@ func TestMergeWaiter_WaitForMerge_Conflicting(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	waiter := NewMergeWaiter(client, "owner", "repo", &MergeWaiterConfig{
 		PollInterval: 10 * time.Millisecond,
 		Timeout:      1 * time.Second,
@@ -163,7 +163,7 @@ func TestMergeWaiter_WaitForMerge_Timeout(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	waiter := NewMergeWaiter(client, "owner", "repo", &MergeWaiterConfig{
 		PollInterval: 10 * time.Millisecond,
 		Timeout:      50 * time.Millisecond,
@@ -199,7 +199,7 @@ func TestMergeWaiter_WaitForMerge_ContextCancelled(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	waiter := NewMergeWaiter(client, "owner", "repo", &MergeWaiterConfig{
 		PollInterval: 50 * time.Millisecond,
 		Timeout:      10 * time.Second, // Long timeout
@@ -248,7 +248,7 @@ func TestMergeWaiter_WaitForMerge_EventuallyMerges(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	waiter := NewMergeWaiter(client, "owner", "repo", &MergeWaiterConfig{
 		PollInterval: 10 * time.Millisecond,
 		Timeout:      1 * time.Second,
@@ -293,7 +293,7 @@ func TestMergeWaiter_WaitWithCallback(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	waiter := NewMergeWaiter(client, "owner", "repo", &MergeWaiterConfig{
 		PollInterval: 10 * time.Millisecond,
 		Timeout:      1 * time.Second,

--- a/internal/adapters/github/notifier_test.go
+++ b/internal/adapters/github/notifier_test.go
@@ -98,7 +98,7 @@ func TestNotifyTaskStarted(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			notifier := NewNotifier(client, "pilot")
 
 			err := notifier.NotifyTaskStarted(context.Background(), "owner", "repo", 42, "TASK-123")
@@ -202,7 +202,7 @@ func TestNotifyProgress(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			notifier := NewNotifier(client, "pilot")
 
 			err := notifier.NotifyProgress(context.Background(), "owner", "repo", 42, tt.phase, tt.details)
@@ -339,7 +339,7 @@ func TestNotifyTaskCompleted(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			notifier := NewNotifier(client, "pilot")
 
 			err := notifier.NotifyTaskCompleted(context.Background(), "owner", "repo", 42, tt.prURL, tt.summary)
@@ -437,7 +437,7 @@ func TestNotifyTaskFailed(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			notifier := NewNotifier(client, "pilot")
 
 			err := notifier.NotifyTaskFailed(context.Background(), "owner", "repo", 42, tt.reason)
@@ -501,7 +501,7 @@ func TestLinkPR(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			notifier := NewNotifier(client, "pilot")
 
 			err := notifier.LinkPR(context.Background(), "owner", "repo", 1, tt.prNumber, tt.prURL)
@@ -544,7 +544,7 @@ func TestNotifyProgress_PhaseEmojis(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			notifier := NewNotifier(client, "pilot")
 
 			err := notifier.NotifyProgress(context.Background(), "owner", "repo", 42, p.phase, "details")

--- a/internal/adapters/github/poller_skip_metrics_test.go
+++ b/internal/adapters/github/poller_skip_metrics_test.go
@@ -117,7 +117,7 @@ func TestPoller_SkipMetric_IncrementsByReason(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			m := newFakePollerMetrics()
 
 			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -171,7 +171,7 @@ func TestPoller_ScopeOverlapDeferral_IncrementsMetric(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	m := newFakePollerMetrics()
 
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -206,7 +206,7 @@ func TestPoller_NoMetrics_NoPanic(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	// No WithPollerMetrics — pollerMetrics is nil
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithOnIssue(func(ctx context.Context, issue *Issue) error { return nil }),

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -350,7 +350,7 @@ func TestPoller_CheckForNewIssues(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 			processedIssues := []*Issue{}
 			var mu sync.Mutex
@@ -387,7 +387,7 @@ func TestPoller_CheckForNewIssues_APIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	callbackCalled := false
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -417,7 +417,7 @@ func TestPoller_CheckForNewIssues_CallbackError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var callCount int32
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -456,7 +456,7 @@ func TestPoller_CheckForNewIssues_NoCallback(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	// Create poller without callback
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
@@ -485,7 +485,7 @@ func TestPoller_CheckForNewIssues_SkipsAlreadyProcessed(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var callCount int32
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -522,7 +522,7 @@ func TestPoller_CheckForNewIssues_AllowsRetryWhenLabelsRemoved(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var callCount int32
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -585,7 +585,7 @@ func TestPoller_Start_InitialCheck(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	callbackCalled := make(chan struct{}, 1)
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 1*time.Hour, // Long interval
@@ -739,7 +739,7 @@ func TestPoller_FindOldestUnprocessedIssue(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -768,7 +768,7 @@ func TestPoller_FindOldestUnprocessedIssue_SkipsProcessedWithDoneLabel(t *testin
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -797,7 +797,7 @@ func TestPoller_FindOldestUnprocessedIssue_AllowsRetryWhenFailedLabelRemoved(t *
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithRetryGracePeriod(0), // GH-2201: disable grace period for test
 	)
@@ -836,7 +836,7 @@ func TestPoller_FindOldestUnprocessedIssue_SkipsInProgress(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -859,7 +859,7 @@ func TestPoller_FindOldestUnprocessedIssue_ReturnsNilWhenEmpty(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -938,7 +938,7 @@ func TestPoller_StartSequential_ProcessesOneAtATime(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	processedOrder := []int{}
 	var mu sync.Mutex
@@ -1111,7 +1111,7 @@ func TestPoller_HasPendingDependencies(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 			issue := &Issue{Number: 1, Body: tt.issueBody}
@@ -1130,7 +1130,7 @@ func TestPoller_HasPendingDependencies_APIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue := &Issue{Number: 1, Body: "Depends on: #100"}
@@ -1164,7 +1164,7 @@ func TestPoller_FindOldestUnprocessedIssue_SkipsPendingDependencies(t *testing.T
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -1203,7 +1203,7 @@ func TestPoller_FindOldestUnprocessedIssue_PicksClosedDependency(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -1242,7 +1242,7 @@ func TestPoller_FindOldestUnprocessedIssue_AllDepsOpen(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -1293,7 +1293,7 @@ func TestPoller_RecoverOrphanedIssues(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	// Call recovery directly
@@ -1317,7 +1317,7 @@ func TestPoller_RecoverOrphanedIssues_NoOrphanedIssues(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	// Should not panic or error with empty result
@@ -1331,7 +1331,7 @@ func TestPoller_RecoverOrphanedIssues_APIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	// Should not panic - errors are logged but not returned
@@ -1426,7 +1426,7 @@ func TestPoller_OverlapGrouping_AllOverlap(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var dispatched []int
 	var mu sync.Mutex
@@ -1467,7 +1467,7 @@ func TestPoller_OverlapGrouping_NoOverlap(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var callCount int32
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -1502,7 +1502,7 @@ func TestPoller_OverlapGrouping_MixedGroups(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var dispatched []int
 	var mu sync.Mutex
@@ -1555,7 +1555,7 @@ func TestPoller_AutoMode_NonOverlapping(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var callCount int32
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -1590,7 +1590,7 @@ func TestPoller_AutoMode_OverlappingDispatchesOldestOnly(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var dispatched []int
 	var mu sync.Mutex
@@ -1656,7 +1656,7 @@ func TestPoller_HasMergedWork(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 			issue := &Issue{Number: 42, Title: "Test issue"}
@@ -1682,7 +1682,7 @@ func TestPoller_HasMergedWork_APIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue := &Issue{Number: 42, Title: "Test issue"}
@@ -1712,7 +1712,7 @@ func TestPoller_CheckForNewIssues_SkipsRetryWithMergedPRs(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var callCount int32
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -1758,7 +1758,7 @@ func TestPoller_FindOldestUnprocessedIssue_SkipsRetryWithMergedPRs(t *testing.T)
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithExecutionMode(ExecutionModeSequential),
 		WithRetryGracePeriod(0), // GH-2201: disable grace period for test
@@ -1790,7 +1790,7 @@ func TestPoller_CheckForNewIssues_SkipsPullRequests(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var dispatched []int
 	var mu sync.Mutex
@@ -1835,7 +1835,7 @@ func TestPoller_FindOldestUnprocessedIssue_SkipsPullRequests(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -1872,7 +1872,7 @@ func TestPoller_SkipsRecentlyProcessed(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var callCount int32
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -1910,7 +1910,7 @@ func TestPoller_AllowsRetryAfterGrace(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var callCount int32
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -1945,7 +1945,7 @@ func TestPoller_SkipsQueuedTask(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	checker := &mockTaskChecker{queued: map[string]bool{"GH-42": true}}
 
@@ -1986,7 +1986,7 @@ func TestPoller_AllowsRetryCompletedTask(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	checker := &mockTaskChecker{queued: map[string]bool{}} // Not queued
 
@@ -2071,7 +2071,7 @@ func TestPoller_AutoRetryFailedIssue_FirstFailure(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithRetryGracePeriod(0),
 	)
@@ -2112,7 +2112,7 @@ func TestPoller_AutoRetryFailedIssue_RetryLimitReached(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithMaxFailedRetries(3),
 	)
@@ -2148,7 +2148,7 @@ func TestPoller_AutoRetryFailedIssue_SkipsDoneIssues(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -2177,7 +2177,7 @@ func TestPoller_AutoRetryFailedIssue_SkipsClosedIssues(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -2214,7 +2214,7 @@ func TestPoller_AutoRetryFailedIssue_ParallelMode(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var processedIssues []*Issue
 	var mu sync.Mutex
@@ -2256,7 +2256,7 @@ func TestPoller_AutoRetryFailedIssue_ParallelMode_LimitReached(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var processedCount atomic.Int32
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
@@ -2296,7 +2296,7 @@ func TestPoller_SkipsNeedsClarification(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	// Test findOldestUnprocessedIssue skips #42
@@ -2363,7 +2363,7 @@ func TestPoller_AutoRetryRetryReadyIssue_FirstRetry(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithRetryGracePeriod(0),
 	)
@@ -2407,7 +2407,7 @@ func TestPoller_AutoRetryRetryReadyIssue_RetryLimitReached(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithMaxRetryReadyRetries(3),
 	)
@@ -2438,7 +2438,7 @@ func TestPoller_AutoRetryRetryReadyIssue_SkipsDoneIssues(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -2467,7 +2467,7 @@ func TestPoller_AutoRetryRetryReadyIssue_SkipsClosedIssues(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
@@ -2504,7 +2504,7 @@ func TestPoller_AutoRetryRetryReadyIssue_ParallelMode(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var processedIssues []*Issue
 	var mu sync.Mutex
@@ -2577,7 +2577,7 @@ func TestPoller_SkipsCompletedExecution(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	execChecker := &mockExecutionChecker{
 		completed: map[string]bool{
@@ -2623,7 +2623,7 @@ func TestPoller_DispatchesWhenNoCompletedExecution(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	execChecker := &mockExecutionChecker{
 		completed: map[string]bool{}, // No completed executions
@@ -2673,7 +2673,7 @@ func TestPoller_HasMergedWork_SearchLag_BranchFallback(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue := &Issue{Number: 42, Title: "Test issue"}
@@ -2703,7 +2703,7 @@ func TestPoller_HasMergedWork_NoMerges_NoFallbackBlock(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue := &Issue{Number: 42, Title: "Test issue"}
@@ -2743,7 +2743,7 @@ func TestPoller_CheckForNewIssues_StaleSnapshot_RefreshesLabels(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithOnIssue(func(ctx context.Context, issue *Issue) error {
 			atomic.AddInt32(&dispatches, 1)
@@ -2826,7 +2826,7 @@ func TestPoller_CheckForNewIssues_SkipsSupersededByParent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithOnIssue(func(ctx context.Context, issue *Issue) error {
 			atomic.AddInt32(&dispatches, 1)
@@ -2892,7 +2892,7 @@ func TestPoller_CheckForNewIssues_DoesNotSupersedeWhenParentNotDone(t *testing.T
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithOnIssue(func(ctx context.Context, issue *Issue) error {
 			atomic.AddInt32(&dispatches, 1)
@@ -2924,7 +2924,7 @@ func TestPoller_CheckForNewIssues_SkipsBlockedIssues(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
 		WithOnIssue(func(ctx context.Context, issue *Issue) error {
 			atomic.AddInt32(&dispatches, 1)

--- a/internal/adapters/github/project_board_test.go
+++ b/internal/adapters/github/project_board_test.go
@@ -97,7 +97,7 @@ func TestUpdateProjectItemStatus_FullFlow(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
 		Enabled:       true,
 		ProjectNumber: 5,
@@ -142,7 +142,7 @@ func TestUpdateProjectItemStatus_CachesIDs(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
 		Enabled:       true,
 		ProjectNumber: 1,
@@ -224,7 +224,7 @@ func TestResolveProjectID_OrgFirstUserFallback(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			pbs := &ProjectBoardSync{
 				client: client,
 				config: &ProjectBoardConfig{ProjectNumber: 3},
@@ -266,7 +266,7 @@ func TestUpdateProjectItemStatus_IssueNotInProject(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
 		Enabled:       true,
 		ProjectNumber: 1,
@@ -300,7 +300,7 @@ func TestUpdateProjectItemStatus_StatusNotFound(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
 		Enabled:       true,
 		ProjectNumber: 1,
@@ -343,7 +343,7 @@ func TestUpdateProjectItemStatus_CaseInsensitiveMatch(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
 		Enabled:       true,
 		ProjectNumber: 1,
@@ -364,7 +364,7 @@ func TestUpdateProjectItemStatus_GraphQLError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
 		Enabled:       true,
 		ProjectNumber: 1,
@@ -405,7 +405,7 @@ func TestEnsureResolved_ConcurrentAccess(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	pbs := &ProjectBoardSync{
 		client: client,
 		config: &ProjectBoardConfig{ProjectNumber: 1, StatusField: "Status"},
@@ -435,7 +435,7 @@ func TestExecuteGraphQL_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	var result map[string]string
 	err := client.ExecuteGraphQL(context.Background(), `{ test }`, nil, &result)
@@ -454,7 +454,7 @@ func TestExecuteGraphQL_GraphQLErrors(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	err := client.ExecuteGraphQL(context.Background(), `{ test }`, nil, nil)
 	if err == nil {
@@ -472,7 +472,7 @@ func TestExecuteGraphQL_HTTPError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 
 	err := client.ExecuteGraphQL(context.Background(), `{ test }`, nil, nil)
 	if err == nil {
@@ -501,7 +501,7 @@ func TestResolveFieldAndOptions_DefaultFieldName(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	pbs := &ProjectBoardSync{
 		client:    client,
 		config:    &ProjectBoardConfig{StatusField: ""}, // empty — should default to "Status"

--- a/internal/adapters/github/retry.go
+++ b/internal/adapters/github/retry.go
@@ -52,9 +52,13 @@ func WithRetry[T any](ctx context.Context, op func() (T, error), opts RetryOptio
 			delay = opts.MaxDelay
 		}
 
-		// Check for Retry-After header in rate limit errors
+		// Check for Retry-After header in rate limit errors, but cap by MaxDelay
 		if retryAfter := extractRetryAfter(lastErr); retryAfter > 0 {
-			delay = retryAfter
+			if opts.MaxDelay > 0 && retryAfter > opts.MaxDelay {
+				delay = opts.MaxDelay
+			} else {
+				delay = retryAfter
+			}
 		}
 
 		// Wait with context cancellation support

--- a/internal/adapters/github/webhook_test.go
+++ b/internal/adapters/github/webhook_test.go
@@ -273,7 +273,7 @@ func TestHandleIssueOpened(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			handler := NewWebhookHandler(client, "", "pilot")
 
 			processed := false
@@ -409,7 +409,7 @@ func TestHandleIssueLabeled(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 			handler := NewWebhookHandler(client, "", "pilot")
 
 			processed := false
@@ -445,7 +445,7 @@ func TestHandleIssueLabeled_CustomLabel(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	handler := NewWebhookHandler(client, "", "ai-assist") // Custom pilot label
 
 	processed := false
@@ -508,7 +508,7 @@ func TestProcessIssue_CallbackError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	handler := NewWebhookHandler(client, "", "pilot")
 
 	expectedErr := errors.New("callback error")
@@ -570,7 +570,7 @@ func TestProcessIssue_NoCallback(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	handler := NewWebhookHandler(client, "", "pilot")
 	// No callback set
 
@@ -617,7 +617,7 @@ func TestProcessIssue_APIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL, WithRetryOptions(RetryOptions{MaxRetries: 0}))
 	handler := NewWebhookHandler(client, "", "pilot")
 
 	handler.OnIssue(func(ctx context.Context, issue *Issue, repo *Repository) error {


### PR DESCRIPTION
## Summary

- Moves retry logic from 20 individual call-site `WithRetry`/`WithRetryVoid` wrappers into `doRequest` — all 51 GitHub client methods now retry 429/5xx automatically, including previously unprotected endpoints (`GetPullRequest`, `GetCombinedStatus`, `ListIssues`, etc.)
- Adds `MetricsRecorder` interface + `WithMetricsRecorder` `ClientOption`; wires `RecordAPIError` in `doRequest` when retries are exhausted for 429/5xx (not for 4xx business errors)
- Adds `WithRetryOptions` `ClientOption` for injectable retry config (used by tests to avoid slow delays)
- Caps `extractRetryAfter` delay by `RetryOptions.MaxDelay` so test opts with short `MaxDelay` are honoured even for 429 responses
- Wires `SetMetricsRecorder` at 4 GitHub client creation sites in `cmd/pilot/main.go`
- 5 new tests: retry on 429, retry on 5xx, `RecordAPIError` after exhaustion, no-retry on 4xx, path label normalization

## Test plan

- [x] `go build ./...` — clean
- [x] `go test github.com/qf-studio/pilot/internal/adapters/github` — passes in ~4s
- [x] `go test github.com/qf-studio/pilot/cmd/pilot/...` — passes
- [x] All new `TestDoRequest_*` and `TestNormalizePathLabel` tests pass
- [ ] Manual: induce a 429; confirm retry in logs and `pilot_api_errors_total{endpoint="..."}` increments in `/metrics`

Closes GH-3065 · TASK-294