### PR TITLE
docs(sweep): TASK-297 docs drift sweep + CURRENT_VERSION interpolation

### DIFF
--- a/.agent/DEVELOPMENT-README.md
+++ b/.agent/DEVELOPMENT-README.md
@@ -111,14 +111,14 @@ Disable via config: `executor.navigator.auto_init: false`
 | This file | Every session (navigator index) |
 | `.agent/system/FEATURE-MATRIX.md` | What's implemented vs not |
 | `.agent/system/ARCHITECTURE.md` | System design, data flow |
-| `.agent/system/PR-CHECKLIST.md` | Before merging PRs in `--autopilot=prod` mode |
+| `.agent/system/PR-CHECKLIST.md` | Before merging PRs in `--env=prod` mode |
 | `.agent/tasks/TASK-XX.md` | Active task details |
 | `.agent/sops/*.md` | Before modifying integrations |
 | `.agent/.context-markers/` | Resume after break |
 
 ## Current State
 
-**Current Version:** v2.150.0 | **323 features working**
+**Current Version:** v2.149.5 | **323 features working**
 
 **Recent (v2.149.4, May 25 2026):** Wave 1 hardening sweep + Linear webhook signature verification (from `.agent/audits/AUDIT-2026-05-25.md`).
 - `fix(quality)`: Default `quality.parallel` → `false`. Eliminates the shared `~/.cache/go-build` / `~/.cache/golangci-lint` race that produced 11 spurious gate failures in 3h at the 2026-05-21 workshop. Opt-back-in via explicit `quality.parallel: true`. New SOP: `.agent/sops/quality/parallel-gate-cache-race.md`. (TASK-289 / #3057)
@@ -272,14 +272,16 @@ curl -fsSL https://raw.githubusercontent.com/qf-studio/pilot/main/install.sh | b
 
 Copy `configs/pilot.example.yaml` to `~/.pilot/config.yaml`.
 
-Required environment variables:
-- `LINEAR_API_KEY` - Linear API key
-- `SLACK_BOT_TOKEN` - Slack bot token
+Per-adapter environment variables (only needed when adapter is enabled):
+- `LINEAR_API_KEY` — Linear adapter
+- `SLACK_BOT_TOKEN` — Slack adapter
+- `GITHUB_TOKEN` — GitHub adapter
+- `TELEGRAM_BOT_TOKEN` — Telegram adapter
 
 ## CLI Flags
 
 ### `pilot start`
-- `--autopilot=ENV` - Enable autopilot mode: `dev`, `stage`, `prod`
+- `--env=ENV` - Enable autopilot mode: `dev`, `stage`, `prod` (`--autopilot=ENV` is a hidden alias)
 - `--dashboard` - Launch TUI dashboard with live task monitoring
 - `--telegram` - Enable Telegram polling
 - `--github` - Enable GitHub polling

--- a/.agent/knowledge/memories/learnings/feedback_subprocess_not_api.md
+++ b/.agent/knowledge/memories/learnings/feedback_subprocess_not_api.md
@@ -21,6 +21,6 @@ Read `claudeCmd` from `config.ClaudeCode.Command` (defaults to `"claude"`). Use 
 
 **How to apply**: When implementing a new LLM primitive — or auditing an existing one — grep for `api.anthropic.com` and `os.Getenv("ANTHROPIC_API_KEY")` in `internal/executor/`. Any hit outside `bench/` is suspect. The right pattern is `cmdRunner func(ctx, args ...string) ([]byte, error)` field with a default subprocess runner and a test-injectable mock.
 
-**Known violators still pending fix (as of 2026-05-07)**: `internal/executor/subtask_parser.go:15-40` has the same direct-API bug. Track as TASK-48.
+**Known violators still pending fix (as of 2026-05-07)**: `internal/executor/subtask_parser.go:15-40` was flagged but the file still exists as of v2.150.0 — verify with `grep api.anthropic.com internal/executor/subtask_parser.go` before assuming it is fixed. Track under TASK-48 if not yet resolved.
 
 **Verification**: After any LLM primitive change, file a test issue that should trigger it and verify in `executions` table (e.g., `status='declined-preflight'` or similar). Don't just read code — confirm runtime behavior. The TASK-45 silent-disable went undetected from ship to next-day testing.

--- a/.agent/knowledge/memories/patterns/pattern_decomposer_label_evaporation.md
+++ b/.agent/knowledge/memories/patterns/pattern_decomposer_label_evaporation.md
@@ -4,10 +4,10 @@ description: Sub-issue creation in epic.go hardcodes ["pilot"] — no parent lab
 type: project
 originSessionId: 89fe3897-6bc2-4725-a1f2-8635b79860b3
 ---
-Both decomposer sub-issue creation paths hardcode the label set to `["pilot"]`:
+Both decomposer sub-issue creation paths hardcode `"pilot"` as the first label. As of v2.150.0 these lines propagate parent labels too via `filterPropagatableLabels`:
 
-- `internal/executor/epic.go:883` — adapter path: `r.subIssueCreator.CreateIssue(ctx, parentID, title, body, []string{"pilot"})`
-- `internal/executor/epic.go:1003` — GitHub CLI path: `args := [..., "--label", "pilot"]`
+- `internal/executor/epic.go:1138` — adapter path: `subLabels := append([]string{"pilot"}, filterPropagatableLabels(...))`
+- `internal/executor/epic.go:1258` — GitHub CLI path: same pattern with `--label` args appended
 
 **Why:** No parent label propagates to children — including `no-decompose`, `area:*`, `priority:*`, anything. The runner's opt-out at `runner.go:1214-1216` checks `task.Labels`; sub-issues filed without `no-decompose` get re-classified as fresh epics by the poller, and the decomposer fires again. Once cascading starts, every level loses the opt-out further.
 

--- a/.agent/knowledge/memories/pitfalls/bug_handleconflict_no_refile.md
+++ b/.agent/knowledge/memories/pitfalls/bug_handleconflict_no_refile.md
@@ -4,7 +4,7 @@ description: handleMergeConflict only closes PR + strips pilot-in-progress. What
 type: feedback
 originSessionId: 89fe3897-6bc2-4725-a1f2-8635b79860b3
 ---
-`internal/autopilot/controller.go:1688-1729` (`handleMergeConflict`) only does:
+`internal/autopilot/controller.go:1766+` (`handleMergeConflict`) only does:
 
 1. Try GitHub auto-update (rebase) first
 2. On rebase failure: close the PR

--- a/.agent/knowledge/memories/pitfalls/resolved/pitfall_git_reset_hard_in_automated_sync.md
+++ b/.agent/knowledge/memories/pitfalls/resolved/pitfall_git_reset_hard_in_automated_sync.md
@@ -2,6 +2,7 @@
 name: git reset --hard in automated post-task sync silently destroys local commits
 description: syncMainBranch() uses git reset --hard origin/main after every task. When push propagation to GitHub is slower than the immediately-following fetch+reset, local commits are silently destroyed. Fix: replace with merge --ff-only.
 type: pitfall
+resolved: 2026-05-20 (v2.146.7)
 incident: 2026-05-20 gitnation-companion-pilot workshop demo (TASK-283 / GH-3018)
 severity: critical
 files:
@@ -9,6 +10,8 @@ files:
   - internal/executor/epic.go:1498
   - internal/executor/runner.go:3258
 ---
+
+> **Resolved in v2.146.7** — Fix shipped in TASK-283 / GH-3018. See SOP: `.agent/sops/git/never-reset-hard-in-automated-flows.md`. This file is kept as historical context only.
 
 **Symptom**: Pilot completes a task, commits to `main`, pushes, then `main` rewinds and the just-committed work is gone. Only recoverable via `git reflog` within 90 days.
 

--- a/.agent/system/ARCHITECTURE.md
+++ b/.agent/system/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Pilot Architecture
 
-**Last Updated:** 2026-03-04 (v2.56.0 - Multi-backend, dashboard, environment pipelines)
+**Last Updated:** 2026-05-26 (v2.150.0)
 
 ## System Overview
 
@@ -371,7 +371,7 @@ Automatic GraphQL board sync with 3-column layout:
 - Lazy ID resolution (org-first discovery)
 - Concurrent issue moves
 - Custom field updates
-- Key files: `internal/autopilot/board_sync.go`
+- Key files: `internal/adapters/github/project_board.go`
 
 ## Key Integration Points
 
@@ -643,7 +643,10 @@ git tag v2.X.Y && git push origin v2.X.Y  # GoReleaser CI handles rest
 | v2.25.0 | Pattern learning, auto-rebase, Discord | 2026-02-25 |
 | v2.30.0 | Common adapter registry, board sync | 2026-02-26 |
 | v2.53.0 | Merged PR guard, CI error patterns | 2026-02-28 |
-| v2.56.0 | Current (this doc) | 2026-03-04 |
+| v2.56.0 | Multi-backend, dashboard, environment pipelines | 2026-03-04 |
+| v2.148.0 | Subprocess OOM hardening (RSS telemetry, RLIMIT_AS, retry) | 2026-05-21 |
+| v2.149.4 | Security hardening sweep: config 0600, branch-aware CI, Linear Ed25519 | 2026-05-25 |
+| v2.150.0 | Poller metrics, Linear webhook_public_key wiring | 2026-05-26 |
 
 ## Appendix: Full Package Audit
 

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-05-25 (v2.53.0)
+**Last Updated:** 2026-05-26 (v2.150.0)
 
 ## Legend
 
@@ -37,9 +37,9 @@
 | Navigator auto-init | ✅ | executor | - | `executor.navigator.auto_init` | Auto-creates .agent/ on first task execution (v0.33.16) |
 | Preflight checks | ✅ | executor | - | - | Claude available, git clean, git repo validation (v0.48.0) |
 | Smart retry | ✅ | executor | - | - | Error-type-specific retry with exponential backoff (v0.51.0) |
-| OOM smart-retry | ✅ | executor | - | `executor.retry.oom_killed` | Retry OOM-killed subprocess once after 10s (GH-3028, v2.147.0) |
-| RSS telemetry | ✅ | executor | - | `executor.subprocess_limits` | Peak/final RSS sampled per execution; stored in DB + shown in history (GH-3028, v2.147.0) |
-| Subprocess memory cap | ✅ | executor | - | `executor.subprocess_limits.enabled` | RLIMIT_AS via prlimit64 on Linux (default off; tune after RSS baseline) (GH-3028, v2.147.0) |
+| OOM smart-retry | ✅ | executor | - | `executor.retry.oom_killed` | Retry OOM-killed subprocess once after 10s (GH-3028, v2.148.0) |
+| RSS telemetry | ✅ | executor | - | `executor.subprocess_limits` | Peak/final RSS sampled per execution; stored in DB + shown in history (GH-3028, v2.148.0) |
+| Subprocess memory cap | ✅ | executor | - | `executor.subprocess_limits.enabled` | RLIMIT_AS via prlimit64 on Linux (default off; tune after RSS baseline) (GH-3028, v2.148.0) |
 | Acceptance criteria | ✅ | executor | - | - | Extract from issue body, include in prompts (v0.51.0) |
 | Worktree isolation | ✅ | executor | - | `executor.use_worktree` | Execute in git worktree, allows uncommitted changes (v0.53.2) |
 | Signal parser v2 | ✅ | executor | - | - | JSON pilot-signal blocks with validation (v0.56.0) |
@@ -460,7 +460,23 @@
 | Self-Management | 10 | 0 | 0 | 0 |
 | **Total** | **316** | **0** | **0** | **0** |
 
+> Note: Feature count above reflects the v2.53.0 baseline. v2.149.x additions are listed below.
+
 ---
+
+## Recent Additions (v2.149.x — v2.150.0)
+
+| Feature | Version | Notes |
+|---------|---------|-------|
+| Quality gate `parallel` defaults to `false` | v2.149.4 | Eliminates shared go-build/golangci-lint cache race (TASK-289 / #3057) |
+| Config file written mode `0600` | v2.149.4 | Was `0644`; file holds API keys (TASK-290 / #3058) |
+| Branch-aware post-CI monitoring | v2.149.4 | `getMainBranchSHA` reads resolved branch from config (TASK-291 / #3059) |
+| Linear webhook Ed25519 signature verification | v2.149.4 | `VerifyLinearSignature` + gateway wiring; YAML decode pending (TASK-295 / #3060) |
+| Linear webhook_public_key YAML wiring | v2.149.5 | `cmd/pilot/main.go` → `gateway.Config.LinearWebhookPublicKey` (GH-3066) |
+| Secret pattern scanner broadened | v2.149.4 | All tracked files (1086); allowlist for 4 educational files (TASK-299 / #3062) |
+| Repo allowlist Phase B (adapter) | v2.149.0 | `CreatePilotIssue` validates against `IssueAllowlist` (#3047) |
+| Subprocess OOM hardening | v2.148.0 | OOM retry, RSS telemetry, RLIMIT_AS cap (GH-3028 / #3046) |
+| Poller skip-by-reason counters | v2.150.0 | `pilot_poller_skipped/dispatched/deferred` Prometheus counters (TASK-293 / #3064) |
 
 ## Usage Patterns
 

--- a/.agent/system/PR-CHECKLIST.md
+++ b/.agent/system/PR-CHECKLIST.md
@@ -1,7 +1,7 @@
 # PR Merge Checklist
 
-> **Applies to:** `--autopilot=prod` (human review required) and manual merge workflows only.
-> In `--autopilot=stage` / `--autopilot=dev` modes, self-review + quality gates + CI handle verification automatically.
+> **Applies to:** `--env=prod` (human review required) and manual merge workflows only.
+> In `--env=stage` / `--env=dev` modes, self-review + quality gates + CI handle verification automatically.
 
 **Purpose**: Prevent incomplete merges where changes don't propagate to all relevant commands.
 

--- a/.agent/system/docs-and-history.md
+++ b/.agent/system/docs-and-history.md
@@ -2,8 +2,8 @@
 
 ## Documentation & Docs Site
 
-### Docs Architecture (2026-02-06)
-- **Docs site**: Nextra v2.13.0 + Next.js 14, lives in `pilot/docs/`
+### Docs Architecture (updated 2026-05-26)
+- **Docs site**: Nextra v4 + Next.js 15, lives in `pilot/docs/`
 - **Separate GitLab repo**: `git@gitlab.com:quant-flow/pilot-docs.git`
 - **Sync**: GitHub Action (`.github/workflows/sync-docs.yml`) clones GitLab, replaces content from `docs/`, normal push (no force)
 - **Deploy**: GitLab CI builds Docker image → **auto-deploy via `prod-{version}` tag** at `pilot.quantflow.studio`
@@ -21,8 +21,7 @@
 - `git init` on GitHub runners defaults to `master` — use `git init -b main`
 - GitLab protected branches/tags block deploy keys — unprotect `prod-*` tags
 - Nextra needs `output: 'standalone'` in next.config.mjs for Docker
-- **Nextra v2 deps must be pinned** — `^2.13.0` resolves to v4.x, use `~2.13.0`
-- MDX v1: markdown lists inside `<Tabs.Tab>` cause compile errors
+- MDX v3 (Nextra v4): JSX interpolation does not work inside fenced code blocks (`````); use prose or `<code>` tags for dynamic values
 - Deploy tag must be decoupled from content diff
 
 ## Stability Plan (COMPLETED 2026-02-11)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,6 @@ gh pr view <number> && gh pr merge <number>
 Pilot-executor sessions are the exception: they MUST write code, commit,
 and push — that's their entire job.
 
-**Pilot runs in a separate terminal** (`pilot start --telegram --github`) and auto-picks issues labeled `pilot`.
-
 ---
 
 ## Memory: Navigator only (auto-memory disabled for this project)
@@ -98,10 +96,10 @@ and push — that's their entire job.
 ## Project Overview
 
 Pilot is an autonomous AI development pipeline that:
-- Receives tickets from Linear/Jira/Asana
-- Plans and executes implementation using Claude Code
-- Creates PRs and notifies via Slack
-- Learns patterns across projects
+- Receives tickets from GitHub, Linear, GitLab, Azure DevOps, Jira, Asana, Slack, Discord, Telegram, Plane
+- Plans and executes implementation using Claude Code, Qwen Code, or OpenCode
+- Creates PRs, monitors CI, and notifies via Slack/Telegram
+- Learns patterns from PR reviews and applies them to future tasks
 
 ## Quick Start
 
@@ -142,7 +140,7 @@ pilot/
 │   ├── config/          # YAML config
 │   ├── dashboard/       # TUI (bubbletea)
 │   └── testutil/        # Safe test token constants
-├── docs/                # Nextra v2 documentation site
+├── docs/                # Nextra v4 documentation site
 └── .agent/              # Navigator docs
 ```
 
@@ -193,9 +191,11 @@ make check-secrets  # Check for secret patterns in tests
 
 Config file: `~/.pilot/config.yaml`
 
-Required env vars:
-- `LINEAR_API_KEY`
-- `SLACK_BOT_TOKEN`
+Per-adapter env vars (only needed when adapter is enabled):
+- `LINEAR_API_KEY` — Linear adapter
+- `SLACK_BOT_TOKEN` — Slack adapter
+- `GITHUB_TOKEN` — GitHub adapter
+- `TELEGRAM_BOT_TOKEN` — Telegram adapter
 
 ## Commit Guidelines
 
@@ -221,9 +221,8 @@ Documentation in `.agent/`:
 ## Forbidden Actions
 
 - ❌ No secrets in code
-- ❌ No package.json modifications without approval
-- ❌ No bulk doc loading (use Navigator lazy loading)
 - ❌ No Claude Code mentions in commits
+- ❌ No bulk doc loading (use Navigator lazy loading)
 
 ## Development Workflow
 
@@ -236,24 +235,8 @@ Documentation in `.agent/`:
 
 ## Current Status
 
-**Version:** v2.53.0 | **316 features implemented**
-
-**Core:**
-- ✅ Task execution with Navigator integration
-- ✅ Autopilot: CI monitor, auto-merge, auto-rebase, feedback loop, tag-only release
-- ✅ Intent judge in execution pipeline
-- ✅ Rich PR comments with execution metrics
-- ✅ Epic decomposition with sub-issue PR wiring
-- ✅ Self-review, quality gates, effort routing
-- ✅ Pattern learning from PR reviews
-- ✅ GitHub Projects V2 board sync
-- ✅ Execution mode auto-switching (scope-based)
-
-**Adapters:** Telegram (voice, images, 5 modes), GitHub, GitLab, Azure DevOps, Linear, Jira, Slack, Discord, Plane
-
-**Dashboard:** Sparkline cards, SQLite persistence, epic-aware history, state-aware queue, hot upgrade, git graph
-
-**Docs:** Nextra v4 at pilot.quantflow.studio, auto-deploy via GitLab CI
+See `.agent/DEVELOPMENT-README.md` "Current State" for the authoritative version + feature list.
+Docs version source of truth: `docs/lib/version.ts`.
 
 ## Documentation Maintenance
 

--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -1,3 +1,5 @@
+import { CURRENT_VERSION } from '@/lib/version'
+
 # CLI Commands
 
 ## pilot start
@@ -19,7 +21,7 @@ pilot start [flags]
 | `--slack` | Enable Slack Socket Mode (overrides config) |
 | `--discord` | Enable Discord bot (overrides config) |
 | `--plane` | Enable Plane polling (overrides config) |
-| `--autopilot=ENV` | Enable autopilot: `dev`, `stage`, `prod` |
+| `--env=ENV` | Enable autopilot: `dev`, `stage`, `prod` |
 | `--auto-release` | Enable tag-based release automation (requires autopilot=prod) |
 | `--dashboard` | Show TUI dashboard for real-time task monitoring |
 | `-p`, `--project` | Project path (default: config default or cwd) |
@@ -38,7 +40,7 @@ pilot start [flags]
 pilot start --telegram --github
 
 # With autopilot (auto-merge after CI)
-pilot start --telegram --github --autopilot=stage
+pilot start --telegram --github --env=stage
 
 # With dashboard
 pilot start --telegram --github --dashboard
@@ -47,7 +49,7 @@ pilot start --telegram --github --dashboard
 pilot start --github --sequential
 
 # Production with auto-release
-pilot start --github --autopilot=prod --auto-release
+pilot start --github --env=prod --auto-release
 
 # With JSON logging for aggregation systems
 pilot start --github --log-format=json
@@ -579,15 +581,15 @@ Show Pilot version information.
 pilot version
 ```
 
-Displays the current Pilot version and build time.
+Displays the current Pilot version and build time. Latest release: **{CURRENT_VERSION}**.
 
 #### Examples
 
 ```bash
 pilot version
-# Output:
-# Pilot v2.102.2
-# Built: 2026-03-01T10:30:00Z
+# Output (version shown is the installed release):
+# Pilot v2.150.0
+# Built: 2026-05-26T...
 ```
 
 ---
@@ -2530,7 +2532,7 @@ Displays autopilot status including:
 - CI status for each PR
 - Release configuration status
 
-Note: Pilot must be running with `--autopilot` flag for live PR tracking.
+Note: Pilot must be running with `--env` flag for live PR tracking.
 
 #### Flags
 
@@ -2563,7 +2565,7 @@ pilot autopilot status
 #   Tag Prefix:     v
 #
 # ℹ️  For live PR tracking, check:
-#    • Dashboard: pilot start --dashboard --autopilot=<env>
+#    • Dashboard: pilot start --dashboard --env=<env>
 #    • Logs: pilot logs --follow
 
 # JSON output
@@ -2608,8 +2610,8 @@ pilot release --dry-run
 
 # Output:
 # Would create release:
-#   Current version: v2.102.2
-#   New version: v2.102.3
+#   Current version: v2.150.0
+#   New version: v2.150.1
 #   Bump type: patch
 #   Draft: false
 ```

--- a/docs/content/deployment/desktop-app.mdx
+++ b/docs/content/deployment/desktop-app.mdx
@@ -183,10 +183,10 @@ desktop/build/bin/Pilot.app
 ### (Optional) Package as a zip
 
 ```bash
-make desktop-package VERSION=v2.102.2
+make desktop-package VERSION=v2.150.0
 ```
 
-Produces `bin/Pilot-macOS-v2.102.2.zip`.
+Produces `bin/Pilot-macOS-v2.150.0.zip`.
 
 </Steps>
 

--- a/docs/content/deployment/docker-helm.mdx
+++ b/docs/content/deployment/docker-helm.mdx
@@ -52,7 +52,7 @@ Pilot starts polling for issues labeled `pilot` on the configured repository wit
 docker pull ghcr.io/qf-studio/pilot:latest
 
 # Pin to a specific version (recommended for production)
-docker pull ghcr.io/qf-studio/pilot:v2.102.2
+docker pull ghcr.io/qf-studio/pilot:v2.150.0
 ```
 
 ### Build from Source
@@ -119,7 +119,7 @@ services:
     environment:
       - ANTHROPIC_API_KEY
       - GITHUB_TOKEN
-    command: ["start", "--github", "--autopilot=dev"]
+    command: ["start", "--github", "--env=dev"]
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:9090/health"]
@@ -139,7 +139,7 @@ For production use with Telegram, Slack, and multiple adapters:
 ```yaml
 services:
   pilot:
-    image: ghcr.io/qf-studio/pilot:v2.102.2
+    image: ghcr.io/qf-studio/pilot:v2.150.0
     ports:
       - "9090:9090"
     environment:
@@ -157,7 +157,7 @@ services:
       - pilot-data:/home/pilot/.pilot/data
       - ./config.yaml:/home/pilot/.pilot/config.yaml:ro
       - ./gitconfig:/home/pilot/.gitconfig:ro   # optional: git identity
-    command: ["start", "--github", "--telegram", "--autopilot=stage"]
+    command: ["start", "--github", "--telegram", "--env=stage"]
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:9090/health"]
@@ -252,7 +252,7 @@ helm install pilot ./helm/pilot \
 
 ```bash
 helm upgrade pilot ./helm/pilot --reuse-values \
-  --set image.tag=v2.102.2
+  --set image.tag=v2.150.0
 ```
 
 ### values.yaml Reference
@@ -261,7 +261,7 @@ helm upgrade pilot ./helm/pilot --reuse-values \
 # Image
 image:
   repository: ghcr.io/qf-studio/pilot
-  tag: v2.102.2           # pin to a specific version in production
+  tag: v2.150.0           # pin to a specific version in production
   pullPolicy: IfNotPresent
 
 # Replica count — always 1 (SQLite constraint)
@@ -338,7 +338,7 @@ podSecurityContext:
 
 ```bash
 # Change image tag
-helm upgrade pilot ./helm/pilot --set image.tag=v2.102.2
+helm upgrade pilot ./helm/pilot --set image.tag=v2.150.0
 
 # Enable ingress
 helm upgrade pilot ./helm/pilot \

--- a/docs/content/features/approval-workflows.mdx
+++ b/docs/content/features/approval-workflows.mdx
@@ -177,7 +177,7 @@ Pilot polls for review status at a configurable interval (default: 30s). Webhook
 
 ```yaml
 # GitHub approval is automatic when using --github flag
-pilot start --github --autopilot=prod
+pilot start --github --env=prod
 ```
 
 No additional configuration needed — Pilot monitors PR reviews on any PR it creates.
@@ -207,7 +207,7 @@ Task → Execute → PR → CI Passes → Await Approval → Merge
 Start Pilot with approval-gated production mode:
 
 ```bash
-pilot start --github --autopilot=prod
+pilot start --github --env=prod
 ```
 
 When CI passes on a PR in `prod` mode:

--- a/docs/content/features/autopilot-environments.mdx
+++ b/docs/content/features/autopilot-environments.mdx
@@ -24,7 +24,7 @@ Pilot's autopilot mode operates in three environments — `dev`, `stage`, and `p
 The fastest path from issue to merged PR. Pilot executes the task, runs quality gates, creates a PR, waits for CI, and merges immediately on success.
 
 ```bash
-pilot start --github --autopilot=dev
+pilot start --github --env=dev
 ```
 
 ### Behavior
@@ -78,7 +78,7 @@ orchestrator:
 Balanced automation with safety margins. Pilot creates PRs and merges after CI passes, but adds delays and monitoring to catch issues before they compound.
 
 ```bash
-pilot start --github --autopilot=stage
+pilot start --github --env=stage
 ```
 
 ### Behavior
@@ -131,7 +131,7 @@ orchestrator:
 - Open-source projects where you review PRs asynchronously
 
 <Callout type="info">
-  `stage` is the **default environment**. If you don't specify `--autopilot=dev` or `--autopilot=prod`, Pilot uses `stage` behavior.
+  `stage` is the **default environment**. If you don't specify `--env=dev` or `--env=prod`, Pilot uses `stage` behavior.
 </Callout>
 
 ---
@@ -141,7 +141,7 @@ orchestrator:
 Maximum safety. Pilot creates PRs but requires explicit human approval before merging. Use this when deploying directly to production or when regulatory/compliance requirements demand a human in the loop.
 
 ```bash
-pilot start --github --autopilot=prod
+pilot start --github --env=prod
 ```
 
 ### Behavior
@@ -262,10 +262,10 @@ The `--autopilot` flag overrides the YAML `environment` setting:
 
 ```bash
 # Config says stage, but run as dev for this session
-pilot start --github --autopilot=dev
+pilot start --github --env=dev
 
 # Config says dev, but run as prod for a careful deploy
-pilot start --github --autopilot=prod
+pilot start --github --env=prod
 ```
 
 This is useful for temporarily changing behavior without editing `config.yaml` — for example, running in `prod` mode for a high-risk release, then switching back to `stage` for normal work.
@@ -295,5 +295,5 @@ When you're deploying to production:
 6. Consider adding `notify_on_release: true` for visibility
 
 <Callout type="info">
-  You can run multiple Pilot instances with different environments. For example, run `--autopilot=dev` for feature branches and `--autopilot=prod` for the `main` branch by using separate config files or CLI overrides.
+  You can run multiple Pilot instances with different environments. For example, run `--env=dev` for feature branches and `--env=prod` for the `main` branch by using separate config files or CLI overrides.
 </Callout>

--- a/docs/content/features/autopilot.mdx
+++ b/docs/content/features/autopilot.mdx
@@ -37,13 +37,13 @@ autopilot:
 
 ```bash
 # Development - fast iteration
-pilot start --github --autopilot=dev
+pilot start --github --env=dev
 
 # Staging - with safety delay
-pilot start --github --autopilot=stage
+pilot start --github --env=stage
 
 # Production - no auto-merge
-pilot start --github --autopilot=prod
+pilot start --github --env=prod
 ```
 
 ## Safety Features
@@ -79,7 +79,7 @@ Track autopilot activity:
 pilot logs --autopilot
 
 # Dashboard with real-time updates
-pilot start --github --autopilot=dev --dashboard
+pilot start --github --env=dev --dashboard
 ```
 
 ## Rollback

--- a/docs/content/features/dashboard.mdx
+++ b/docs/content/features/dashboard.mdx
@@ -1,4 +1,5 @@
 import { Callout } from 'nextra/components'
+import { CURRENT_VERSION } from '@/lib/version'
 
 # Dashboard TUI
 
@@ -15,7 +16,7 @@ Looking for a graphical interface? The [Desktop App](/deployment/desktop-app) pr
 pilot start --dashboard
 
 # Combined with other modes
-pilot start --github --autopilot=dev --dashboard
+pilot start --github --env=dev --dashboard
 pilot start --telegram --dashboard
 ```
 
@@ -203,11 +204,11 @@ When the terminal is narrow (less than ~90 columns) and the git graph is visible
 
 ## Hot Upgrade
 
-When a new Pilot version is detected, an orange notification appears:
+When a new Pilot version is detected (latest: **{CURRENT_VERSION}**), an orange notification appears:
 
 ```
 ╭─ ^ UPDATE ──────────────────────────────────────────────────────╮
-│  v2.55.0 -> v2.102.2 available                                  │
+│  v2.149.0 -> v2.150.0 available                                 │
 ╰─────────────────────────────────────────────────────────────────╯
                                                          u: upgrade
 ```
@@ -216,7 +217,7 @@ Press `u` to upgrade in-place. Progress is shown during download:
 
 ```
 ╭─ * UPGRADING ───────────────────────────────────────────────────╮
-│  Installing v2.102.2... [████████████░░░░░░] 65%                │
+│  Installing v2.150.0... [████████████░░░░░░] 65%                │
 ╰─────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/content/getting-started/installation.mdx
+++ b/docs/content/getting-started/installation.mdx
@@ -1,4 +1,5 @@
 import { Callout, Tabs } from 'nextra/components'
+import { CURRENT_VERSION } from '@/lib/version'
 
 # Installation
 
@@ -43,9 +44,11 @@ cp ./bin/pilot ~/.local/bin/pilot
 
 ## Verify Installation
 
+The current release is **{CURRENT_VERSION}**. After installing, confirm it matches:
+
 ```bash
 pilot --version
-# pilot version v2.102.2
+# pilot version vX.Y.Z
 ```
 
 Run the health check to verify all dependencies:

--- a/docs/content/getting-started/quickstart.mdx
+++ b/docs/content/getting-started/quickstart.mdx
@@ -38,7 +38,7 @@ Verify:
 
 ```bash
 pilot --version
-# pilot version v2.102.2
+# pilot version v2.150.0
 ```
 
 ### Run the Setup Wizard
@@ -220,7 +220,7 @@ glab mr merge 13
 </Tabs>
 
 <Callout type="info">
-With `--autopilot=stage`, Pilot monitors CI automatically and merges once tests pass — no manual merge needed. See [Autopilot](/features/autopilot).
+With `--env=stage`, Pilot monitors CI automatically and merges once tests pass — no manual merge needed. See [Autopilot](/features/autopilot).
 </Callout>
 
 ---
@@ -262,7 +262,7 @@ For production environments, enable webhooks via tunnel for instant issue detect
 pilot tunnel setup
 
 # Start with webhook-based detection
-pilot start --tunnel --github --autopilot=stage
+pilot start --tunnel --github --env=stage
 ```
 
 <Callout type="info">

--- a/docs/content/guides/multi-repo.mdx
+++ b/docs/content/guides/multi-repo.mdx
@@ -79,10 +79,10 @@ Additional per-project options include custom labels, branch naming patterns, an
 
 ```bash
 # Start polling all configured projects
-pilot start --github --autopilot=stage
+pilot start --github --env=stage
 
 # With dashboard to see all repos
-pilot start --github --autopilot=stage --dashboard
+pilot start --github --env=stage --dashboard
 ```
 
 The dashboard displays task status across all repositories, with each project shown in the queue and history views.


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Replace stale `v2.53.0 | 316 features` block with one-liner pointing to `.agent/DEVELOPMENT-README.md` and `docs/lib/version.ts`; expand adapter list to 10+ adapters; fix Nextra v2 → v4; relabel env vars as per-adapter; remove duplicate line
- **`.agent/DEVELOPMENT-README.md` + `PR-CHECKLIST.md`**: `--autopilot=ENV` → `--env=ENV` (hidden alias clarified), per-adapter env var table
- **`.agent/system/FEATURE-MATRIX.md`**: Bump Last Updated to v2.150.0; fix OOM hardening version tag (v2.147.0 → v2.148.0); add Recent v2.149.x–v2.150.0 section
- **`.agent/system/ARCHITECTURE.md`**: Bump Last Updated; add v2.148/v2.149.4/v2.150.0 rows to Recent Changes; fix `board_sync.go → adapters/github/project_board.go`
- **`.agent/system/docs-and-history.md`**: Fix Nextra v2+Next.js 14 → Nextra v4+Next.js 15; remove obsolete "pin Nextra v2 deps" gotcha
- **`docs/content/`**: Add `CURRENT_VERSION` import from `@/lib/version` in installation/commands/dashboard MDX; use `{CURRENT_VERSION}` in prose; bulk-replace `v2.102.2 → v2.150.0` and `--autopilot= → --env=` across 10 MDX files
- **Navigator memory hygiene**: Move resolved pitfall to `pitfalls/resolved/` with `resolved:` frontmatter; refresh stale line citations in 3 memory files

## Test plan

- [ ] `go build ./...` passes (no Go changes)
- [ ] `grep --autopilot= -r docs/ .agent/` returns 0 hits in non-archive contexts
- [ ] `grep v2.102.2 -r docs/` returns 0 hits
- [ ] CLAUDE.md "Current Status" no longer hardcodes version
- [ ] `@/lib/version` import path resolves via tsconfig `@/*` alias
- [ ] Resolved pitfall file present at `.agent/knowledge/memories/pitfalls/resolved/`