### PR TITLE
feat(executor): ghost-SHA guard — fail closed when commit_sha is on base branch

### DIFF
--- a/internal/executor/git_freshness.go
+++ b/internal/executor/git_freshness.go
@@ -1,0 +1,32 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// commitSHAIsNew returns true iff sha is NOT an ancestor of origin/<baseBranch>.
+// A SHA that is already on the base branch is a parent SHA — proof the executor
+// made no new commit. Returns false (with no error) for an empty sha.
+//
+// Exit semantics of git merge-base --is-ancestor:
+//
+//	0 = sha IS an ancestor → already on base → not new
+//	1 = sha is NOT an ancestor → new commit
+//	other = error (e.g. unknown ref)
+func commitSHAIsNew(ctx context.Context, repoPath, sha, baseBranch string) (bool, error) {
+	if sha == "" {
+		return false, nil
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath,
+		"merge-base", "--is-ancestor", sha, "origin/"+baseBranch)
+	err := cmd.Run()
+	if err == nil {
+		return false, nil // SHA is ancestor of origin/baseBranch — not a new commit
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+		return true, nil // SHA is NOT an ancestor — it is a genuinely new commit
+	}
+	return false, fmt.Errorf("merge-base check: %w", err)
+}

--- a/internal/executor/git_freshness_test.go
+++ b/internal/executor/git_freshness_test.go
@@ -1,0 +1,122 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// setupFreshnessTestRepo creates a bare origin and a working clone with one commit
+// on main (pushed to origin) and returns (workDir, mainSHA).
+func setupFreshnessTestRepo(t *testing.T) (workDir string, mainSHA string) {
+	t.Helper()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	ctx := context.Background()
+
+	// Create bare repo simulating origin.
+	originDir := t.TempDir()
+	if out, err := exec.CommandContext(ctx, "git", "init", "--bare", originDir).CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v: %s", err, out)
+	}
+
+	// Create working repo.
+	workDir = t.TempDir()
+	run := func(args ...string) string {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = workDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return string(out)
+	}
+
+	run("init")
+	run("config", "user.email", "test@pilot.test")
+	run("config", "user.name", "Pilot Test")
+	run("remote", "add", "origin", originDir)
+
+	// Initial commit on main.
+	if err := os.WriteFile(filepath.Join(workDir, "base.txt"), []byte("base"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "initial commit")
+	run("push", "-u", "origin", "main")
+
+	// Fetch to update remote-tracking refs (refs/remotes/origin/main).
+	run("fetch", "origin")
+
+	mainSHA = trimNL(run("rev-parse", "HEAD"))
+	return workDir, mainSHA
+}
+
+func trimNL(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+func TestCommitSHAIsNew_EmptySHA(t *testing.T) {
+	ctx := context.Background()
+	isNew, err := commitSHAIsNew(ctx, t.TempDir(), "", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isNew {
+		t.Error("empty SHA should not be considered new")
+	}
+}
+
+func TestCommitSHAIsNew_SHAOnMain(t *testing.T) {
+	workDir, mainSHA := setupFreshnessTestRepo(t)
+	ctx := context.Background()
+
+	isNew, err := commitSHAIsNew(ctx, workDir, mainSHA, "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isNew {
+		t.Errorf("SHA already on origin/main should not be new (got isNew=true), sha=%s", mainSHA[:7])
+	}
+}
+
+func TestCommitSHAIsNew_SHAOnFeatureBranch(t *testing.T) {
+	workDir, _ := setupFreshnessTestRepo(t)
+	ctx := context.Background()
+
+	run := func(args ...string) string {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = workDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return string(out)
+	}
+
+	// Create a feature branch with a new commit.
+	run("checkout", "-b", "feature/test")
+	if err := os.WriteFile(filepath.Join(workDir, "feature.txt"), []byte("feature"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "feature commit")
+
+	featureSHA := trimNL(run("rev-parse", "HEAD"))
+
+	isNew, err := commitSHAIsNew(ctx, workDir, featureSHA, "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isNew {
+		t.Errorf("SHA on feature branch should be new (got isNew=false), sha=%s", featureSHA[:7])
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2202,6 +2202,30 @@ retrySucceeded:
 		}
 	}
 
+	// GH-3112: Ghost-SHA guard — fail closed when the harvested SHA is already on
+	// the base branch. This means Claude made no new commit; the SHA is the parent
+	// (base branch tip) that was HEAD at worktree creation time.
+	if result.CommitSHA != "" && result.Success {
+		ghostBase := task.BaseBranch
+		if ghostBase == "" {
+			if db, _ := git.GetDefaultBranch(ctx); db != "" {
+				ghostBase = db
+			} else {
+				ghostBase = "main"
+			}
+		}
+		if isNew, checkErr := commitSHAIsNew(ctx, executionPath, result.CommitSHA, ghostBase); checkErr == nil && !isNew {
+			log.Warn("ghost-SHA detected: harvested SHA is already on base branch — no new commit",
+				slog.String("task_id", task.ID),
+				slog.String("sha", result.CommitSHA[:min(7, len(result.CommitSHA))]),
+				slog.String("base", ghostBase),
+			)
+			result.CommitSHA = ""
+			result.Success = false
+			result.Error = "no new commit produced — worktree HEAD matches base branch parent"
+		}
+	}
+
 	// Fill in additional metrics from state
 	result.FilesChanged = state.filesWrite
 	result.CacheCreationInputTokens = state.cacheCreationInputTokens
@@ -3086,6 +3110,20 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					)
 				}
 				result.CommitSHA = pushedSHA
+				// GH-3112: Defense in depth — re-validate after push.
+				// The pre-push guard should catch ghost SHAs earlier, but re-check
+				// here in case fetch state was stale at the first check.
+				if isNew, checkErr := commitSHAIsNew(ctx, executionPath, result.CommitSHA, baseBranch); checkErr == nil && !isNew {
+					log.Warn("ghost-SHA detected post-push: pushed SHA is already on base branch",
+						slog.String("task_id", task.ID),
+						slog.String("sha", result.CommitSHA[:min(7, len(result.CommitSHA))]),
+						slog.String("base", baseBranch),
+					)
+					result.CommitSHA = ""
+					result.Success = false
+					result.Error = "no new commit produced — post-push HEAD matches base branch parent"
+					return result, nil
+				}
 			} else if pushErr != nil {
 				log.Warn("Failed to get pushed HEAD SHA, using tracked SHA",
 					slog.String("task_id", task.ID),

--- a/internal/executor/task_shipped.go
+++ b/internal/executor/task_shipped.go
@@ -7,6 +7,11 @@ import "github.com/qf-studio/pilot/internal/memory"
 // Epic-parent rows (status=completed, no deliverable) correctly return false — sub-issues own the work.
 // This predicate mirrors the SQL filter in HasCompletedExecution; the cross-site invariant test
 // in internal/integration ensures both always agree.
+//
+// Variant 4 (ghost-SHA) risk: if CommitSHA is set but PRUrl is empty, the SHA may be a parent
+// SHA that was never a new commit. The upstream ghost-SHA guard in runner.go (GH-3112) clears
+// CommitSHA before recording, so a ghost SHA should never reach this predicate. PRUrl is the
+// stronger signal when both are present.
 func IsTaskShipped(row memory.Execution) bool {
 	if row.Status != "completed" {
 		return false

--- a/internal/executor/task_shipped_test.go
+++ b/internal/executor/task_shipped_test.go
@@ -57,6 +57,19 @@ func TestIsTaskShipped(t *testing.T) {
 			row:  memory.Execution{Status: "completed", Error: "stale running task recovered", CommitSHA: "abc123"},
 			want: true,
 		},
+		{
+			// GH-3112: ghost-SHA scenario — the upstream guard in runner.go clears CommitSHA
+			// before the row is recorded, so a completed row with no deliverables is correctly
+			// treated as not-shipped (epic-parent pattern). PRUrl is the stronger signal.
+			name: "completed with no deliverables (ghost-SHA cleared upstream)",
+			row:  memory.Execution{Status: "completed"},
+			want: false,
+		},
+		{
+			name: "completed with pr_url only (strongest signal)",
+			row:  memory.Execution{Status: "completed", PRUrl: "https://github.com/x/y/pull/99"},
+			want: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- **Problem:** Executor recorded the parent SHA (base branch tip) as `CommitSHA` when Claude finished without making a new commit. `IsTaskShipped` returned true, triggering issue close + `pilot-done` label with no PR or branch — work permanently lost. Two confirmed incidents (issues #3090 and #3100, ~1h10m lost each).
- **Fix:** New `commitSHAIsNew()` helper (`git merge-base --is-ancestor`) detects ghost SHAs and clears `CommitSHA` / sets `Success=false` before the row is recorded.
- **Defense in depth:** Second check after push in case remote-tracking refs were stale at first check.

## Files

- `internal/executor/git_freshness.go` — new `commitSHAIsNew()` predicate
- `internal/executor/git_freshness_test.go` — 3 cases: empty SHA, SHA on main, SHA on feature branch
- `internal/executor/runner.go` — two guard sites (post-SHA-capture, post-push)
- `internal/executor/task_shipped.go` — documents Variant 4 ghost-SHA risk in comment
- `internal/executor/task_shipped_test.go` — adds ghost-SHA-cleared-upstream case

## Test plan

- [ ] `go build ./...` passes ✓
- [ ] `go test ./internal/executor/` passes (96s) ✓
- [ ] `TestCommitSHAIsNew_*` all green ✓
- [ ] Pre-PR verification: HEAD not ancestor of origin/main, commit visible in log ✓

Closes #3112