### PR TITLE
feat(autopilot): PR reconciliation loop + ListPullRequests pagination (TASK-302)

### DIFF
--- a/.agent/sops/autopilot/orphan-pr-recovery.md
+++ b/.agent/sops/autopilot/orphan-pr-recovery.md
@@ -1,0 +1,74 @@
+# SOP: Autopilot Orphan PR Recovery
+
+**Category:** Autopilot reliability  
+**Implemented:** 2026-05-26  
+**Source incident:** PR #3107 (TASK-298-redo) invisible to autopilot for ~40 min
+
+---
+
+## What is an orphan PR?
+
+A Pilot PR (branch `pilot/GH-*`) that exists on GitHub but is not tracked in `autopilot_pr_state`. Autopilot cannot advance, merge, or release an orphan — it is invisible to all processing loops.
+
+---
+
+## Automatic recovery (since TASK-302)
+
+`Controller.startReconciler` runs every 60 seconds alongside the main processing loop. It lists all open PRs and registers any `pilot/GH-*` branch PR not yet in `activePRs`. No manual intervention is needed for transient misses.
+
+**Metric to watch:** `pilot_autopilot_orphan_pr_registered_total{trigger="reconciler"}`  
+A sustained spike (>0 per hour) means `OnPRCreated` is consistently missing fires — investigate the root cause below.
+
+---
+
+## Detection query
+
+```bash
+# Find pilot/ PRs not tracked in autopilot_pr_state
+PILOT_PRS=$(gh pr list --state open --search "head:pilot/" --json number --jq '.[].number')
+TRACKED=$(sqlite3 ~/.pilot/data/pilot.db \
+  "SELECT pr_number FROM autopilot_pr_state WHERE stage NOT IN ('failed','merged')")
+comm -23 <(echo "$PILOT_PRS" | sort) <(echo "$TRACKED" | sort)
+```
+
+An empty result means no orphans. Any numbers printed are orphan PR numbers.
+
+---
+
+## Known orphan causes
+
+| # | Root cause | Signal |
+|---|---|---|
+| 1 | Executor returns `pr_url=""` (post-create verification failed) | `executor` log: `pr_url=''` despite PR existing |
+| 2 | `ListPullRequests` pagination cap (fixed in TASK-302: now 100/page) | Repos with >30 open PRs at startup |
+| 3 | `OnPRCreated` callback gate at `poller.go:596` filters `PRNumber==0` | Poller log: `skipping pr_number=0` |
+| 4 | Daemon restart between PR create and `OnPRCreated` fire | Reconciler logs `registering orphan PR` on first tick post-restart |
+
+---
+
+## Manual recovery (if reconciler is disabled or pre-TASK-302)
+
+```bash
+# 1. Identify orphan PR number and issue number from branch name
+gh pr view <PR_NUMBER>   # e.g. branch = pilot/GH-100 → issue 100
+
+# 2. Force registration via sqlite directly (emergency only)
+sqlite3 ~/.pilot/data/pilot.db <<SQL
+INSERT OR REPLACE INTO autopilot_pr_state
+  (pr_number, pr_url, issue_number, branch_name, head_sha, stage, ci_status, created_at)
+VALUES
+  (<PR>, '<URL>', <ISSUE>, 'pilot/GH-<ISSUE>', '<SHA>', 'pr_created', 'pending', datetime('now'));
+SQL
+
+# 3. Restart daemon — RestoreState will pick it up
+pilot start
+```
+
+---
+
+## Escalation
+
+If `reconciler` metric stays elevated (>3 orphans/hour) after daemon restart:
+1. Check executor logs for `pr_url=''` patterns — likely TASK-300 ghost-SHA issue
+2. Check poller logs for `skipping pr_number=0` — fix executor to always return PR number
+3. File issue with `pilot` label referencing this SOP

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -96,6 +96,7 @@
 | CI-specific error matchers | ✅ | memory | - | - | Add CI-specific error matchers to PatternExtractor (v2.47.0, PR #1973) |
 | CI pattern confidence boost | ✅ | memory | - | - | Confidence boosting for recurring CI patterns (v2.48.0, PR #1975) |
 | CI log learning pipeline | ✅ | autopilot | - | - | Wire CI log learning into autopilot controller and feedback loop (v2.50.0, PR #1977) |
+| Autopilot orphan PR reconciler | ✅ | autopilot | - | - | 60s reconciliation loop registers pilot/ PRs missed by OnPRCreated; ListPullRequests paginated to 100/page (v2.153.0, GH-3113, TASK-302) |
 | Expanded pattern extractors (11 categories) | ✅ | memory | - | - | Added API design, concurrency, config wiring, test patterns, performance, security matchers (v2.54.0, GH-1989) |
 
 ## Input Adapters

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -499,15 +499,27 @@ func (c *Client) GetBranch(ctx context.Context, owner, repo, branch string) (*Br
 	return &result, nil
 }
 
-// ListPullRequests lists pull requests for a repository
-// state can be "open", "closed", or "all"
+// ListPullRequests lists pull requests for a repository.
+// state can be "open", "closed", or "all".
+// Results are paginated at 100 per page (GitHub default is 30). A safety cap
+// of 50 pages (5 000 PRs) prevents runaway loops on very large repos.
 func (c *Client) ListPullRequests(ctx context.Context, owner, repo, state string) ([]*PullRequest, error) {
-	path := fmt.Sprintf("/repos/%s/%s/pulls?state=%s", owner, repo, state)
-	var result []*PullRequest
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
-		return nil, err
+	const perPage = 100
+	const maxPages = 50
+
+	var all []*PullRequest
+	for page := 1; page <= maxPages; page++ {
+		path := fmt.Sprintf("/repos/%s/%s/pulls?state=%s&per_page=%d&page=%d", owner, repo, state, perPage, page)
+		var batch []*PullRequest
+		if err := c.doRequest(ctx, http.MethodGet, path, nil, &batch); err != nil {
+			return nil, err
+		}
+		all = append(all, batch...)
+		if len(batch) < perPage {
+			break
+		}
 	}
-	return result, nil
+	return all, nil
 }
 
 // CreateRelease creates a new release

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -3390,3 +3390,82 @@ func TestSearchPRsForIssue(t *testing.T) {
 		})
 	}
 }
+
+// TestListPullRequests_Pagination verifies that ListPullRequests fetches
+// multiple pages when a page returns the full per_page count.
+func TestListPullRequests_Pagination(t *testing.T) {
+	// Build two pages: page 1 has 100 PRs, page 2 has 3 PRs.
+	page1 := make([]*PullRequest, 100)
+	for i := range page1 {
+		n := i + 1
+		page1[i] = &PullRequest{
+			Number:  n,
+			HTMLURL: fmt.Sprintf("https://github.com/owner/repo/pull/%d", n),
+			Head:    PRRef{Ref: fmt.Sprintf("pilot/GH-%d", n), SHA: "sha"},
+		}
+	}
+	page2 := []*PullRequest{
+		{Number: 101, HTMLURL: "url101", Head: PRRef{Ref: "pilot/GH-101", SHA: "sha"}},
+		{Number: 102, HTMLURL: "url102", Head: PRRef{Ref: "pilot/GH-102", SHA: "sha"}},
+		{Number: 103, HTMLURL: "url103", Head: PRRef{Ref: "pilot/GH-103", SHA: "sha"}},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/pulls" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		q := r.URL.Query()
+		pageParam := q.Get("page")
+		perPage := q.Get("per_page")
+		if perPage != "100" {
+			t.Errorf("per_page = %q, want 100", perPage)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if pageParam == "2" {
+			_ = json.NewEncoder(w).Encode(page2)
+		} else {
+			_ = json.NewEncoder(w).Encode(page1)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	prs, err := client.ListPullRequests(context.Background(), "owner", "repo", "open")
+	if err != nil {
+		t.Fatalf("ListPullRequests() error = %v", err)
+	}
+	if len(prs) != 103 {
+		t.Errorf("got %d PRs, want 103", len(prs))
+	}
+}
+
+// TestListPullRequests_SinglePage verifies that a response shorter than
+// per_page stops pagination after one request.
+func TestListPullRequests_SinglePage(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		prs := []*PullRequest{
+			{Number: 1, HTMLURL: "url1", Head: PRRef{Ref: "pilot/GH-1", SHA: "sha"}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(prs)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	prs, err := client.ListPullRequests(context.Background(), "owner", "repo", "open")
+	if err != nil {
+		t.Fatalf("ListPullRequests() error = %v", err)
+	}
+	if len(prs) != 1 {
+		t.Errorf("got %d PRs, want 1", len(prs))
+	}
+	if calls != 1 {
+		t.Errorf("server called %d times, want 1 (single page should stop)", calls)
+	}
+}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2133,11 +2133,66 @@ func (c *Controller) ScanExistingPRs(ctx context.Context) error {
 
 		// Register PR via existing mechanism
 		c.OnPRCreated(pr.Number, pr.HTMLURL, issueNum, pr.Head.SHA, pr.Head.Ref, "")
+		c.metrics.RecordOrphanPRRegistered("startup_scan")
 		restored++
 	}
 
 	c.log.Info("completed PR scan", "restored", restored, "env", c.config.EnvironmentName())
 	return nil
+}
+
+// startReconciler runs a periodic loop that calls reconcileOrphanPRs once per
+// minute. It is launched as a goroutine by Run and exits when ctx is cancelled.
+func (c *Controller) startReconciler(ctx context.Context) {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.reconcileOrphanPRs(ctx)
+		}
+	}
+}
+
+// reconcileOrphanPRs lists all open pilot/ PRs and registers any that are not
+// currently tracked in activePRs. A PR is orphaned when OnPRCreated was never
+// fired — e.g. the executor returned pr_url="" or the poller gate filtered it.
+// The function is idempotent and safe to call concurrently with processAllPRs.
+func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
+	prs, err := c.ghClient.ListPullRequests(ctx, c.owner, c.repo, "open")
+	if err != nil {
+		c.log.Warn("reconciler: failed to list open PRs", "error", err)
+		return
+	}
+
+	for _, pr := range prs {
+		if !strings.HasPrefix(pr.Head.Ref, "pilot/GH-") {
+			continue
+		}
+
+		c.mu.RLock()
+		_, tracked := c.activePRs[pr.Number]
+		c.mu.RUnlock()
+		if tracked {
+			continue
+		}
+
+		var issueNum int
+		if _, err := fmt.Sscanf(pr.Head.Ref, "pilot/GH-%d", &issueNum); err != nil {
+			c.log.Warn("reconciler: failed to parse branch name", "branch", pr.Head.Ref, "error", err)
+			continue
+		}
+
+		c.log.Warn("reconciler: registering orphan PR",
+			"pr", pr.Number,
+			"branch", pr.Head.Ref,
+			"issue", issueNum,
+		)
+		c.OnPRCreated(pr.Number, pr.HTMLURL, issueNum, pr.Head.SHA, pr.Head.Ref, "")
+		c.metrics.RecordOrphanPRRegistered("reconciler")
+	}
 }
 
 // ScanRecentlyMergedPRs scans for Pilot PRs that were merged externally.
@@ -2305,6 +2360,9 @@ func (c *Controller) Run(ctx context.Context) error {
 	fastPollInterval := 10 * time.Second
 	idlePollInterval := 60 * time.Second
 	currentInterval := basePollInterval
+
+	// GH-3113: Periodic reconciliation loop — registers orphan PRs that OnPRCreated missed.
+	go c.startReconciler(ctx)
 
 	// GH-2251: Periodic scan for externally-merged PRs.
 	// Use half the scan window as the interval so merges are detected well within the window.

--- a/internal/autopilot/controller_reconciler_test.go
+++ b/internal/autopilot/controller_reconciler_test.go
@@ -1,0 +1,162 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestController_ReconcileOrphanPRs_RegistersOrphan verifies that a pilot/ PR
+// not yet in activePRs is registered after one reconciler tick.
+func TestController_ReconcileOrphanPRs_RegistersOrphan(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls" {
+			prs := []*github.PullRequest{
+				{
+					Number:  42,
+					HTMLURL: "https://github.com/owner/repo/pull/42",
+					Head:    github.PRRef{Ref: "pilot/GH-100", SHA: "abc1234"},
+					Base:    github.PRRef{Ref: "main"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// activePRs is empty — PR 42 is an orphan
+	c.reconcileOrphanPRs(context.Background())
+
+	pr, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("reconciler did not register orphan PR 42")
+	}
+	if pr.IssueNumber != 100 {
+		t.Errorf("IssueNumber = %d, want 100", pr.IssueNumber)
+	}
+	if pr.BranchName != "pilot/GH-100" {
+		t.Errorf("BranchName = %q, want pilot/GH-100", pr.BranchName)
+	}
+
+	// Metric should be incremented
+	snap := c.metrics.Snapshot()
+	if snap.OrphanPRsRegistered["reconciler"] != 1 {
+		t.Errorf("OrphanPRsRegistered[reconciler] = %d, want 1", snap.OrphanPRsRegistered["reconciler"])
+	}
+}
+
+// TestController_ReconcileOrphanPRs_SkipsTracked verifies that already-tracked
+// PRs are not re-registered (no duplicate entry, no metric increment).
+func TestController_ReconcileOrphanPRs_SkipsTracked(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls" {
+			prs := []*github.PullRequest{
+				{
+					Number:  42,
+					HTMLURL: "https://github.com/owner/repo/pull/42",
+					Head:    github.PRRef{Ref: "pilot/GH-100", SHA: "abc1234"},
+					Base:    github.PRRef{Ref: "main"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Pre-populate activePRs so PR 42 is already tracked
+	c.mu.Lock()
+	c.activePRs[42] = &PRState{
+		PRNumber:    42,
+		IssueNumber: 100,
+		BranchName:  "pilot/GH-100",
+		HeadSHA:     "abc1234",
+		Stage:       StageWaitingCI,
+	}
+	c.mu.Unlock()
+
+	c.reconcileOrphanPRs(context.Background())
+
+	// Metric should NOT be incremented
+	snap := c.metrics.Snapshot()
+	if snap.OrphanPRsRegistered["reconciler"] != 0 {
+		t.Errorf("OrphanPRsRegistered[reconciler] = %d, want 0 (tracked PR should not be re-registered)", snap.OrphanPRsRegistered["reconciler"])
+	}
+
+	// Stage should be unchanged
+	pr, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("PR 42 missing from activePRs")
+	}
+	if pr.Stage != StageWaitingCI {
+		t.Errorf("Stage = %v, want StageWaitingCI (reconciler should not clobber tracked state)", pr.Stage)
+	}
+}
+
+// TestController_ReconcileOrphanPRs_NonPilotBranchSkipped verifies that PRs
+// with branches that do not match pilot/GH-* are ignored.
+func TestController_ReconcileOrphanPRs_NonPilotBranchSkipped(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls" {
+			prs := []*github.PullRequest{
+				{Number: 10, HTMLURL: "url", Head: github.PRRef{Ref: "feature/my-feature", SHA: "sha1"}},
+				{Number: 11, HTMLURL: "url", Head: github.PRRef{Ref: "fix/some-bug", SHA: "sha2"}},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	c.reconcileOrphanPRs(context.Background())
+
+	prs := c.GetActivePRs()
+	if len(prs) != 0 {
+		t.Errorf("expected 0 registered PRs, got %d", len(prs))
+	}
+}
+
+// TestController_ReconcileOrphanPRs_APIError verifies that an API error is
+// handled gracefully (no panic, no registration).
+func TestController_ReconcileOrphanPRs_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Should not panic
+	c.reconcileOrphanPRs(context.Background())
+
+	prs := c.GetActivePRs()
+	if len(prs) != 0 {
+		t.Errorf("expected 0 registered PRs on API error, got %d", len(prs))
+	}
+}

--- a/internal/autopilot/metrics.go
+++ b/internal/autopilot/metrics.go
@@ -52,6 +52,11 @@ type Metrics struct {
 	PollerDispatched           map[string]int64        // repo → dispatch count
 	PollerDeferredScopeOverlap map[string]int64        // repo → deferred-scope-overlap count
 
+	// Orphan PR registration counters (GH-3113, TASK-302)
+	// trigger is "reconciler" or "startup_scan".
+	// Sustained spikes indicate OnPRCreated is missing fires.
+	OrphanPRsRegistered map[string]int64 // trigger → count
+
 	// Gauges (point-in-time values)
 	ActivePRsByStage map[PRStage]int
 	QueueDepth       int // issues with `pilot` label, no `pilot-in-progress`
@@ -82,6 +87,7 @@ func NewMetrics() *Metrics {
 		PollerSkipped:              make(map[pollerSkipKey]int64),
 		PollerDispatched:           make(map[string]int64),
 		PollerDeferredScopeOverlap: make(map[string]int64),
+		OrphanPRsRegistered:        make(map[string]int64),
 		ActivePRsByStage:           make(map[PRStage]int),
 		PRTimeToMerge:         make([]time.Duration, 0, 100),
 		CIWaitDurations:       make([]time.Duration, 0, 100),
@@ -119,6 +125,14 @@ func (m *Metrics) RecordPollerDeferredScopeOverlap(repo string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.PollerDeferredScopeOverlap[repo]++
+}
+
+// RecordOrphanPRRegistered increments the orphan-PR registration counter.
+// trigger is "reconciler" (periodic loop) or "startup_scan" (ScanExistingPRs).
+func (m *Metrics) RecordOrphanPRRegistered(trigger string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.OrphanPRsRegistered[trigger]++
 }
 
 // RecordPRMerged increments the merged PR counter.
@@ -279,6 +293,7 @@ func (m *Metrics) Snapshot() MetricsSnapshot {
 		PollerSkipped:              copyPollerSkipKeyMap(m.PollerSkipped),
 		PollerDispatched:           copyStringIntMap(m.PollerDispatched),
 		PollerDeferredScopeOverlap: copyStringIntMap(m.PollerDeferredScopeOverlap),
+		OrphanPRsRegistered:        copyStringIntMap(m.OrphanPRsRegistered),
 		ActivePRsByStage:           copyStageIntMap(m.ActivePRsByStage),
 		QueueDepth:            m.QueueDepth,
 		FailedQueueDepth:      m.FailedQueueDepth,
@@ -334,6 +349,9 @@ type MetricsSnapshot struct {
 	PollerSkipped              map[pollerSkipKey]int64
 	PollerDispatched           map[string]int64
 	PollerDeferredScopeOverlap map[string]int64
+
+	// Orphan PR registration (TASK-302)
+	OrphanPRsRegistered map[string]int64 // trigger → count
 
 	// Gauges
 	ActivePRsByStage map[PRStage]int


### PR DESCRIPTION
## Summary

- Adds `startReconciler` goroutine in `Controller.Run` that ticks every 60s and calls `reconcileOrphanPRs` — registers any open `pilot/GH-*` PR not in `activePRs` via the existing `OnPRCreated` path
- Paginates `ListPullRequests` to 100/page (up from GitHub's 30 default), eliminating the startup scan cap that silently dropped PRs on repos with >30 open pilot/ branches
- Adds `OrphanPRsRegistered{trigger}` counter metric — sustained spikes signal `OnPRCreated` is consistently missing fires

## Root cause fixed

PR #3107 (TASK-298-redo) was invisible to autopilot for ~40 min until daemon restart. Executor recorded `pr_url=''` despite the PR existing; `OnPRCreated` never fired. No periodic recovery existed.

## Files changed

- `internal/autopilot/controller.go` — `startReconciler` + `reconcileOrphanPRs` + wired into `Run`; `ScanExistingPRs` now records `startup_scan` metric
- `internal/autopilot/metrics.go` — `OrphanPRsRegistered map[string]int64` + `RecordOrphanPRRegistered`
- `internal/adapters/github/client.go` — `ListPullRequests` paginated (100/page, 50-page safety cap)
- `internal/autopilot/controller_reconciler_test.go` — 4 new unit tests
- `internal/adapters/github/client_test.go` — 2 pagination tests
- `.agent/sops/autopilot/orphan-pr-recovery.md` — runbook with detection query and escalation path

## Test plan

- [x] `TestController_ReconcileOrphanPRs_RegistersOrphan` — orphan PR gets registered, metric incremented
- [x] `TestController_ReconcileOrphanPRs_SkipsTracked` — already-tracked PR not re-registered, stage preserved
- [x] `TestController_ReconcileOrphanPRs_NonPilotBranchSkipped` — non-pilot branches ignored
- [x] `TestController_ReconcileOrphanPRs_APIError` — API failure handled gracefully
- [x] `TestListPullRequests_Pagination` — 103 PRs across 2 pages fetched correctly
- [x] `TestListPullRequests_SinglePage` — single short page stops after one request
- [x] Full autopilot package: `go test ./internal/autopilot/...` — PASS
- [x] Full github adapter package: `go test ./internal/adapters/github/...` — PASS
- [x] `go build ./...` — clean

Closes #3113