### PR TITLE
refactor(github): centralize retry in doRequest + cap Retry-After (GH-3114)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -96,7 +96,6 @@
 | CI-specific error matchers | ✅ | memory | - | - | Add CI-specific error matchers to PatternExtractor (v2.47.0, PR #1973) |
 | CI pattern confidence boost | ✅ | memory | - | - | Confidence boosting for recurring CI patterns (v2.48.0, PR #1975) |
 | CI log learning pipeline | ✅ | autopilot | - | - | Wire CI log learning into autopilot controller and feedback loop (v2.50.0, PR #1977) |
-| Autopilot orphan PR reconciler | ✅ | autopilot | - | - | 60s reconciliation loop registers pilot/ PRs missed by OnPRCreated; ListPullRequests paginated to 100/page (v2.153.0, GH-3113, TASK-302) |
 | Expanded pattern extractors (11 categories) | ✅ | memory | - | - | Added API design, concurrency, config wiring, test patterns, performance, security matchers (v2.54.0, GH-1989) |
 
 ## Input Adapters
@@ -564,7 +563,7 @@ quality:
 | Feature | Version | Package | Notes |
 |---------|---------|---------|-------|
 | Poller skip-by-reason counters | v2.150.0 | adapters/github | `pilot_poller_skipped/dispatched/deferred` Prometheus counters (TASK-293 / GH-3064) |
-| `WithRetry` centralized in `doRequest` | v2.150.0 | adapters/github | All GitHub client methods now get retry; `RecordAPIError` wired (TASK-294 / GH-3065) |
+| `WithRetry` centralized in `doRequest` | v2.152.0 | adapters/github | All 51 GitHub client methods get uniform retry via `doRequest`; Retry-After capped at MaxDelay (TASK-294-redo / GH-3114) |
 | Linear webhook Ed25519 verification | v2.149.4 | gateway + adapters/linear | `VerifyLinearSignature`; YAML wiring added in v2.151.0 (TASK-295 / GH-3060, GH-3066) |
 | `quality.parallel` defaults to `false` | v2.149.4 | executor | Eliminates shared build-cache race (TASK-289 / GH-3057) |
 | Config file mode 0600 | v2.149.4 | config | `~/.pilot/config.yaml` world-readable fixed (TASK-290 / GH-3058) |

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -38,25 +38,29 @@ type GraphQLError struct {
 type Client struct {
 	token      string
 	httpClient *http.Client
-	baseURL    string // For testing - defaults to githubAPIURL
+	baseURL    string       // For testing - defaults to githubAPIURL
+	retryOpts  RetryOptions // Retry config for doRequest; overridable in tests
 }
 
 // NewClient creates a new GitHub client
 func NewClient(token string) *Client {
 	return &Client{
-		token:   token,
-		baseURL: githubAPIURL,
+		token:     token,
+		baseURL:   githubAPIURL,
+		retryOpts: DefaultRetryOptions(),
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
 	}
 }
 
-// NewClientWithBaseURL creates a new GitHub client with a custom base URL (for testing)
+// NewClientWithBaseURL creates a new GitHub client with a custom base URL (for testing).
+// Retry is disabled by default so unit tests fail fast; set client.retryOpts to enable.
 func NewClientWithBaseURL(token, baseURL string) *Client {
 	return &Client{
-		token:   token,
-		baseURL: baseURL,
+		token:     token,
+		baseURL:   baseURL,
+		retryOpts: RetryOptions{MaxRetries: 0},
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
@@ -116,51 +120,60 @@ type Comment struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// doRequest performs an HTTP request to the GitHub API
+// doRequest performs an HTTP request to the GitHub API with automatic retry on
+// transient errors (429, 5xx, network failures). The request body is buffered
+// once before the retry loop so it can be replayed on each attempt.
 func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}, result interface{}) error {
-	var bodyReader io.Reader
+	var bodyBytes []byte
 	if body != nil {
-		bodyBytes, err := json.Marshal(body)
+		var err error
+		bodyBytes, err = json.Marshal(body)
 		if err != nil {
 			return fmt.Errorf("failed to marshal request body: %w", err)
 		}
-		bodyReader = bytes.NewReader(bodyBytes)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
-	}
-
-	if result != nil && len(respBody) > 0 {
-		if err := json.Unmarshal(respBody, result); err != nil {
-			return fmt.Errorf("failed to parse response: %w", err)
+	return WithRetryVoid(ctx, func() error {
+		var bodyReader io.Reader
+		if bodyBytes != nil {
+			bodyReader = bytes.NewReader(bodyBytes)
 		}
-	}
 
-	return nil
+		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		if bodyBytes != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to execute request: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response: %w", err)
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+		}
+
+		if result != nil && len(respBody) > 0 {
+			if err := json.Unmarshal(respBody, result); err != nil {
+				return fmt.Errorf("failed to parse response: %w", err)
+			}
+		}
+
+		return nil
+	}, c.retryOpts)
 }
 
 // GetIssue fetches an issue by owner, repo, and number
@@ -185,47 +198,39 @@ func (c *Client) ListIssueComments(ctx context.Context, owner, repo string, numb
 
 // AddComment adds a comment to an issue
 func (c *Client) AddComment(ctx context.Context, owner, repo string, number int, body string) (*Comment, error) {
-	return WithRetry(ctx, func() (*Comment, error) {
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
-		reqBody := map[string]string{"body": body}
-		var comment Comment
-		if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &comment); err != nil {
-			return nil, err
-		}
-		return &comment, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
+	reqBody := map[string]string{"body": body}
+	var comment Comment
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &comment); err != nil {
+		return nil, err
+	}
+	return &comment, nil
 }
 
 // AddLabels adds labels to an issue
 func (c *Client) AddLabels(ctx context.Context, owner, repo string, number int, labels []string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, number)
-		reqBody := map[string][]string{"labels": labels}
-		return c.doRequest(ctx, http.MethodPost, path, reqBody, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, number)
+	reqBody := map[string][]string{"labels": labels}
+	return c.doRequest(ctx, http.MethodPost, path, reqBody, nil)
 }
 
 // RemoveLabel removes a label from an issue
 func (c *Client) RemoveLabel(ctx context.Context, owner, repo string, number int, label string) error {
-	return WithRetryVoid(ctx, func() error {
-		// GitHub API is case-sensitive for label names in URL path, normalize to lowercase
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%s", owner, repo, number, strings.ToLower(label))
-		err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
-		// 404 is OK - label might not exist
-		if err != nil && err.Error() != "API error (status 404): " {
-			return err
-		}
-		return nil
-	}, DefaultRetryOptions())
+	// GitHub API is case-sensitive for label names in URL path, normalize to lowercase
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%s", owner, repo, number, strings.ToLower(label))
+	err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
+	// 404 is OK - label might not exist
+	if err != nil && err.Error() != "API error (status 404): " {
+		return err
+	}
+	return nil
 }
 
 // UpdateIssueState updates an issue's state (open/closed)
 func (c *Client) UpdateIssueState(ctx context.Context, owner, repo string, number int, state string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d", owner, repo, number)
-		reqBody := map[string]string{"state": state}
-		return c.doRequest(ctx, http.MethodPatch, path, reqBody, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d", owner, repo, number)
+	reqBody := map[string]string{"state": state}
+	return c.doRequest(ctx, http.MethodPatch, path, reqBody, nil)
 }
 
 // GetRepository fetches repository info
@@ -241,51 +246,43 @@ func (c *Client) GetRepository(ctx context.Context, owner, repo string) (*Reposi
 // CreateCommitStatus creates a status for a specific commit SHA
 // The context parameter allows multiple statuses per commit (e.g., "ci/build", "pilot/execution")
 func (c *Client) CreateCommitStatus(ctx context.Context, owner, repo, sha string, status *CommitStatus) (*CommitStatus, error) {
-	return WithRetry(ctx, func() (*CommitStatus, error) {
-		path := fmt.Sprintf("/repos/%s/%s/statuses/%s", owner, repo, sha)
-		var result CommitStatus
-		if err := c.doRequest(ctx, http.MethodPost, path, status, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/statuses/%s", owner, repo, sha)
+	var result CommitStatus
+	if err := c.doRequest(ctx, http.MethodPost, path, status, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // CreateCheckRun creates a check run for the GitHub Checks API
 // Requires a GitHub App token with checks:write permission
 func (c *Client) CreateCheckRun(ctx context.Context, owner, repo string, checkRun *CheckRun) (*CheckRun, error) {
-	return WithRetry(ctx, func() (*CheckRun, error) {
-		path := fmt.Sprintf("/repos/%s/%s/check-runs", owner, repo)
-		var result CheckRun
-		if err := c.doRequest(ctx, http.MethodPost, path, checkRun, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/check-runs", owner, repo)
+	var result CheckRun
+	if err := c.doRequest(ctx, http.MethodPost, path, checkRun, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // UpdateCheckRun updates an existing check run
 func (c *Client) UpdateCheckRun(ctx context.Context, owner, repo string, checkRunID int64, checkRun *CheckRun) (*CheckRun, error) {
-	return WithRetry(ctx, func() (*CheckRun, error) {
-		path := fmt.Sprintf("/repos/%s/%s/check-runs/%d", owner, repo, checkRunID)
-		var result CheckRun
-		if err := c.doRequest(ctx, http.MethodPatch, path, checkRun, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/check-runs/%d", owner, repo, checkRunID)
+	var result CheckRun
+	if err := c.doRequest(ctx, http.MethodPatch, path, checkRun, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // CreatePullRequest creates a new pull request
 func (c *Client) CreatePullRequest(ctx context.Context, owner, repo string, input *PullRequestInput) (*PullRequest, error) {
-	return WithRetry(ctx, func() (*PullRequest, error) {
-		path := fmt.Sprintf("/repos/%s/%s/pulls", owner, repo)
-		var result PullRequest
-		if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/pulls", owner, repo)
+	var result PullRequest
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // RequestReviewers requests reviewers for a pull request.
@@ -294,17 +291,15 @@ func (c *Client) RequestReviewers(ctx context.Context, owner, repo string, numbe
 	if len(reviewers) == 0 && len(teamReviewers) == 0 {
 		return nil
 	}
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, number)
-		body := map[string][]string{}
-		if len(reviewers) > 0 {
-			body["reviewers"] = reviewers
-		}
-		if len(teamReviewers) > 0 {
-			body["team_reviewers"] = teamReviewers
-		}
-		return c.doRequest(ctx, http.MethodPost, path, body, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, number)
+	body := map[string][]string{}
+	if len(reviewers) > 0 {
+		body["reviewers"] = reviewers
+	}
+	if len(teamReviewers) > 0 {
+		body["team_reviewers"] = teamReviewers
+	}
+	return c.doRequest(ctx, http.MethodPost, path, body, nil)
 }
 
 // GetPullRequest fetches a pull request by number
@@ -320,26 +315,22 @@ func (c *Client) GetPullRequest(ctx context.Context, owner, repo string, number 
 // ClosePullRequest closes a pull request without merging.
 // Used by autopilot to close failed PRs so the sequential poller can unblock.
 func (c *Client) ClosePullRequest(ctx context.Context, owner, repo string, number int) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number)
-		payload := map[string]string{"state": "closed"}
-		return c.doRequest(ctx, http.MethodPatch, path, payload, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number)
+	payload := map[string]string{"state": "closed"}
+	return c.doRequest(ctx, http.MethodPatch, path, payload, nil)
 }
 
 // AddPRComment adds a comment to a pull request (issue comment API)
 // For review comments on specific lines, use CreatePRReviewComment instead
 func (c *Client) AddPRComment(ctx context.Context, owner, repo string, number int, body string) (*PRComment, error) {
-	return WithRetry(ctx, func() (*PRComment, error) {
-		// PRs use the issues API for general comments
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
-		reqBody := map[string]string{"body": body}
-		var result PRComment
-		if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	// PRs use the issues API for general comments
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
+	reqBody := map[string]string{"body": body}
+	var result PRComment
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // ListIssues lists issues for a repository with optional filters
@@ -413,18 +404,16 @@ func HasLabel(issue *Issue, labelName string) bool {
 // method can be "merge", "squash", or "rebase" (use MergeMethod* constants)
 // commitTitle is optional - if empty, GitHub uses the default
 func (c *Client) MergePullRequest(ctx context.Context, owner, repo string, number int, method, commitTitle string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, number)
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, number)
 
-		body := map[string]string{
-			"merge_method": method,
-		}
-		if commitTitle != "" {
-			body["commit_title"] = commitTitle
-		}
+	body := map[string]string{
+		"merge_method": method,
+	}
+	if commitTitle != "" {
+		body["commit_title"] = commitTitle
+	}
 
-		return c.doRequest(ctx, http.MethodPut, path, body, nil)
-	}, DefaultRetryOptions())
+	return c.doRequest(ctx, http.MethodPut, path, body, nil)
 }
 
 // GetCombinedStatus gets combined status for a commit SHA
@@ -456,18 +445,16 @@ func (c *Client) ListCheckRuns(ctx context.Context, owner, repo, sha string) (*C
 // ApprovePullRequest creates an approval review on a PR
 // body is the optional review comment
 func (c *Client) ApprovePullRequest(ctx context.Context, owner, repo string, number int, body string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, number)
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, number)
 
-		payload := map[string]string{
-			"event": ReviewEventApprove,
-		}
-		if body != "" {
-			payload["body"] = body
-		}
+	payload := map[string]string{
+		"event": ReviewEventApprove,
+	}
+	if body != "" {
+		payload["body"] = body
+	}
 
-		return c.doRequest(ctx, http.MethodPost, path, payload, nil)
-	}, DefaultRetryOptions())
+	return c.doRequest(ctx, http.MethodPost, path, payload, nil)
 }
 
 // IssueInput is the input for creating a new issue
@@ -479,14 +466,12 @@ type IssueInput struct {
 
 // CreateIssue creates a new issue in a repository
 func (c *Client) CreateIssue(ctx context.Context, owner, repo string, input *IssueInput) (*Issue, error) {
-	return WithRetry(ctx, func() (*Issue, error) {
-		path := fmt.Sprintf("/repos/%s/%s/issues", owner, repo)
-		var issue Issue
-		if err := c.doRequest(ctx, http.MethodPost, path, input, &issue); err != nil {
-			return nil, err
-		}
-		return &issue, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/issues", owner, repo)
+	var issue Issue
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &issue); err != nil {
+		return nil, err
+	}
+	return &issue, nil
 }
 
 // GetBranch fetches information about a branch
@@ -524,28 +509,24 @@ func (c *Client) ListPullRequests(ctx context.Context, owner, repo, state string
 
 // CreateRelease creates a new release
 func (c *Client) CreateRelease(ctx context.Context, owner, repo string, input *ReleaseInput) (*Release, error) {
-	return WithRetry(ctx, func() (*Release, error) {
-		path := fmt.Sprintf("/repos/%s/%s/releases", owner, repo)
-		var result Release
-		if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/releases", owner, repo)
+	var result Release
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // CreateGitTag creates a lightweight git tag via the GitHub API.
 // This creates only the tag ref, not a GitHub Release — letting GoReleaser
 // handle the full release creation with binary assets on tag push.
 func (c *Client) CreateGitTag(ctx context.Context, owner, repo, tag, sha string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo)
-		body := map[string]string{
-			"ref": "refs/tags/" + tag,
-			"sha": sha,
-		}
-		return c.doRequest(ctx, http.MethodPost, path, body, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo)
+	body := map[string]string{
+		"ref": "refs/tags/" + tag,
+		"sha": sha,
+	}
+	return c.doRequest(ctx, http.MethodPost, path, body, nil)
 }
 
 // GetLatestRelease gets the latest published release
@@ -579,14 +560,12 @@ func (c *Client) GetReleaseByTag(ctx context.Context, owner, repo, tag string) (
 
 // UpdateRelease updates an existing release (e.g. to enrich the body with a summary).
 func (c *Client) UpdateRelease(ctx context.Context, owner, repo string, releaseID int64, input *ReleaseInput) (*Release, error) {
-	return WithRetry(ctx, func() (*Release, error) {
-		path := fmt.Sprintf("/repos/%s/%s/releases/%d", owner, repo, releaseID)
-		var result Release
-		if err := c.doRequest(ctx, http.MethodPatch, path, input, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/releases/%d", owner, repo, releaseID)
+	var result Release
+	if err := c.doRequest(ctx, http.MethodPatch, path, input, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // ListReleases lists releases for a repository (newest first)
@@ -702,43 +681,39 @@ func isUnprocessableError(err error) bool {
 // Uses PATCH /repos/{owner}/{repo}/git/refs/heads/{branch} with force=true.
 // If the ref does not exist, falls back to creating it via POST.
 func (c *Client) UpdateRef(ctx context.Context, owner, repo, branch, sha string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, url.PathEscape(branch))
-		body := map[string]interface{}{
-			"sha":   sha,
-			"force": true,
+	path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, url.PathEscape(branch))
+	body := map[string]interface{}{
+		"sha":   sha,
+		"force": true,
+	}
+	err := c.doRequest(ctx, http.MethodPatch, path, body, nil)
+	if err == nil {
+		return nil
+	}
+	// If the ref doesn't exist yet, create it
+	if isUnprocessableError(err) || isNotFoundError(err) {
+		createPath := fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo)
+		createBody := map[string]string{
+			"ref": "refs/heads/" + branch,
+			"sha": sha,
 		}
-		err := c.doRequest(ctx, http.MethodPatch, path, body, nil)
-		if err == nil {
-			return nil
-		}
-		// If the ref doesn't exist yet, create it
-		if isUnprocessableError(err) || isNotFoundError(err) {
-			createPath := fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo)
-			createBody := map[string]string{
-				"ref": "refs/heads/" + branch,
-				"sha": sha,
-			}
-			return c.doRequest(ctx, http.MethodPost, createPath, createBody, nil)
-		}
-		return err
-	}, DefaultRetryOptions())
+		return c.doRequest(ctx, http.MethodPost, createPath, createBody, nil)
+	}
+	return err
 }
 
 // DeleteBranch deletes a branch from the repository.
 // GitHub API: DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}
 // Returns nil on success, or if the branch was already deleted (404/422).
 func (c *Client) DeleteBranch(ctx context.Context, owner, repo, branch string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, url.PathEscape(branch))
-		err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
-		// 404 = branch doesn't exist, 422 = branch already deleted
-		// Both are success cases for cleanup
-		if isNotFoundError(err) || isUnprocessableError(err) {
-			return nil
-		}
-		return err
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, url.PathEscape(branch))
+	err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
+	// 404 = branch doesn't exist, 422 = branch already deleted
+	// Both are success cases for cleanup
+	if isNotFoundError(err) || isUnprocessableError(err) {
+		return nil
+	}
+	return err
 }
 
 // ListPullRequestReviews lists all reviews for a pull request
@@ -952,11 +927,9 @@ func (c *Client) SearchOpenSubIssues(ctx context.Context, owner, repo string, pa
 // Uses GitHub API: PUT /repos/{owner}/{repo}/pulls/{number}/update-branch
 // Returns nil on success, error if the branch cannot be automatically updated (true conflict).
 func (c *Client) UpdatePullRequestBranch(ctx context.Context, owner, repo string, number int) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/update-branch", owner, repo, number)
-		body := map[string]interface{}{}
-		return c.doRequest(ctx, http.MethodPut, path, body, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/update-branch", owner, repo, number)
+	body := map[string]interface{}{}
+	return c.doRequest(ctx, http.MethodPut, path, body, nil)
 }
 
 // GetIssueNodeID fetches the GraphQL node ID for a given issue number via the REST API.

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -3467,5 +3468,99 @@ func TestListPullRequests_SinglePage(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Errorf("server called %d times, want 1 (single page should stop)", calls)
+	}
+}
+
+// TestDoRequest_RetryOn429 verifies that doRequest retries once on 429 and succeeds.
+func TestDoRequest_RetryOn429(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("rate limited"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(Issue{Number: 1})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	// Use fast retry so the test doesn't sleep for 1s
+	client.retryOpts = RetryOptions{MaxRetries: 3, BaseDelay: 1 * time.Millisecond, MaxDelay: 10 * time.Millisecond}
+
+	var issue Issue
+	err := client.doRequest(context.Background(), "GET", "/repos/owner/repo/issues/1", nil, &issue)
+	if err != nil {
+		t.Fatalf("doRequest() error = %v, want nil", err)
+	}
+	if calls != 2 {
+		t.Errorf("server called %d times, want 2 (1 initial + 1 retry)", calls)
+	}
+	if issue.Number != 1 {
+		t.Errorf("issue.Number = %d, want 1", issue.Number)
+	}
+}
+
+// TestDoRequest_NoRetryOn404 verifies that doRequest does not retry non-retriable errors.
+func TestDoRequest_NoRetryOn404(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not found"))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client.retryOpts = RetryOptions{MaxRetries: 3, BaseDelay: 1 * time.Millisecond, MaxDelay: 10 * time.Millisecond}
+
+	err := client.doRequest(context.Background(), "GET", "/repos/owner/repo/issues/999", nil, nil)
+	if err == nil {
+		t.Fatal("doRequest() expected error for 404, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("server called %d times, want 1 (no retry on 404)", calls)
+	}
+}
+
+// TestDoRequest_ReplayBodyOnRetry verifies that POST body is replayed correctly on retry.
+func TestDoRequest_ReplayBodyOnRetry(t *testing.T) {
+	calls := 0
+	var receivedBodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		buf := new(strings.Builder)
+		_, _ = io.Copy(buf, r.Body)
+		receivedBodies = append(receivedBodies, buf.String())
+		if calls == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(Comment{ID: 42, Body: "hello"})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client.retryOpts = RetryOptions{MaxRetries: 3, BaseDelay: 1 * time.Millisecond, MaxDelay: 10 * time.Millisecond}
+
+	var comment Comment
+	err := client.doRequest(context.Background(), "POST", "/repos/owner/repo/issues/1/comments",
+		map[string]string{"body": "hello"}, &comment)
+	if err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("server called %d times, want 2", calls)
+	}
+	// Both attempts should have sent the same body
+	for i, body := range receivedBodies {
+		if !strings.Contains(body, "hello") {
+			t.Errorf("attempt %d body %q does not contain 'hello'", i+1, body)
+		}
 	}
 }

--- a/internal/adapters/github/retry.go
+++ b/internal/adapters/github/retry.go
@@ -52,8 +52,12 @@ func WithRetry[T any](ctx context.Context, op func() (T, error), opts RetryOptio
 			delay = opts.MaxDelay
 		}
 
-		// Check for Retry-After header in rate limit errors
+		// Check for Retry-After header in rate limit errors; cap at MaxDelay so
+		// a runaway "Retry-After: 3600" can't stall the worker for an hour.
 		if retryAfter := extractRetryAfter(lastErr); retryAfter > 0 {
+			if retryAfter > opts.MaxDelay {
+				retryAfter = opts.MaxDelay
+			}
 			delay = retryAfter
 		}
 

--- a/internal/adapters/github/retry_test.go
+++ b/internal/adapters/github/retry_test.go
@@ -265,6 +265,33 @@ func TestWithRetry_ExponentialBackoff(t *testing.T) {
 	}
 }
 
+func TestWithRetry_RetryAfterCappedAtMaxDelay(t *testing.T) {
+	// extractRetryAfter returns 60s for a plain 429 error; with MaxDelay=10ms the cap kicks in.
+	start := time.Now()
+	calls := 0
+	_, _ = WithRetry(context.Background(), func() (string, error) {
+		calls++
+		if calls == 1 {
+			return "", errors.New("API error (status 429): rate limited")
+		}
+		return "ok", nil
+	}, RetryOptions{
+		MaxRetries: 3,
+		BaseDelay:  1 * time.Millisecond,
+		MaxDelay:   10 * time.Millisecond,
+	})
+	elapsed := time.Since(start)
+
+	// Without cap: extractRetryAfter returns 60s for a raw 429 → would block for 60s.
+	// With cap at 10ms: delay ≤ 10ms, so elapsed should be well under 1s.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("Retry-After was not capped: elapsed %v (expected <500ms)", elapsed)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls, got %d", calls)
+	}
+}
+
 func TestWithRetry_MaxDelayRespected(t *testing.T) {
 	calls := 0
 	lastCall := time.Now()


### PR DESCRIPTION
## Summary

- **Moved `WithRetryVoid` into `doRequest`** so all 51 GitHub client methods get uniform 429/5xx/network retry without per-method wrappers. Previously only 20 of 51 methods were wrapped — `GetPullRequest`, `GetCombinedStatus`, `ListIssues`, etc. would fail hard on rate-limit hits.
- **Removed 20 per-method `WithRetry`/`WithRetryVoid` wrappers** to eliminate double-retry now that `doRequest` handles it.
- **Added `retryOpts` field to `Client`** — `NewClient` uses `DefaultRetryOptions()` (production default); `NewClientWithBaseURL` defaults to `MaxRetries:0` so unit tests remain fast; tests that verify retry behavior set `client.retryOpts` explicitly.
- **Capped `Retry-After` at `opts.MaxDelay`** in `WithRetry` to prevent a runaway `Retry-After: 3600` header from stalling a worker goroutine for an hour.

## Test plan

- [ ] `go test ./internal/adapters/github/...` — all pass (including 3 new retry-specific tests)
- [ ] `go test ./internal/...` — no regressions across all internal packages
- [ ] `go build ./...` — clean build
- [ ] `TestDoRequest_RetryOn429` — mock returns 429 once, then 200; asserts 2 server calls, no error
- [ ] `TestDoRequest_NoRetryOn404` — mock always returns 404; asserts exactly 1 call
- [ ] `TestDoRequest_ReplayBodyOnRetry` — POST body replayed correctly on 503 → 201 retry
- [ ] `TestWithRetry_RetryAfterCappedAtMaxDelay` — 429 with 60s Retry-After capped to 10ms MaxDelay; elapsed < 500ms

Closes #3114