### PR TITLE
refactor(github): move WithRetry into doRequest, cap Retry-After (TASK-294)

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -38,7 +38,8 @@ type GraphQLError struct {
 type Client struct {
 	token      string
 	httpClient *http.Client
-	baseURL    string // For testing - defaults to githubAPIURL
+	baseURL    string        // For testing - defaults to githubAPIURL
+	retryOpts  *RetryOptions // nil uses DefaultRetryOptions(); settable in tests for fast retry
 }
 
 // NewClient creates a new GitHub client
@@ -52,14 +53,18 @@ func NewClient(token string) *Client {
 	}
 }
 
-// NewClientWithBaseURL creates a new GitHub client with a custom base URL (for testing)
+// NewClientWithBaseURL creates a new GitHub client with a custom base URL.
+// Intended for use in tests: sets MaxRetries=0 so tests that mock error
+// responses return immediately without sleeping through retry back-off.
 func NewClientWithBaseURL(token, baseURL string) *Client {
+	noRetry := RetryOptions{MaxRetries: 0}
 	return &Client{
 		token:   token,
 		baseURL: baseURL,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
+		retryOpts: &noRetry,
 	}
 }
 
@@ -116,42 +121,63 @@ type Comment struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// doRequest performs an HTTP request to the GitHub API
+// doRequest performs an HTTP request to the GitHub API with automatic retry on
+// transient errors (429, 5xx, network). Retry behavior is governed by
+// DefaultRetryOptions (3 retries, exponential back-off, Retry-After cap).
 func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}, result interface{}) error {
-	var bodyReader io.Reader
+	var bodyBytes []byte
 	if body != nil {
-		bodyBytes, err := json.Marshal(body)
+		var err error
+		bodyBytes, err = json.Marshal(body)
 		if err != nil {
 			return fmt.Errorf("failed to marshal request body: %w", err)
 		}
-		bodyReader = bytes.NewReader(bodyBytes)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+	retryOpts := DefaultRetryOptions()
+	if c.retryOpts != nil {
+		retryOpts = *c.retryOpts
 	}
 
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
+	var respBody []byte
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
+	if err := WithRetryVoid(ctx, func() error {
+		var bodyReader io.Reader
+		if bodyBytes != nil {
+			bodyReader = bytes.NewReader(bodyBytes)
+		}
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response: %w", err)
-	}
+		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		if bodyBytes != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to execute request: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		var readErr error
+		respBody, readErr = io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("failed to read response: %w", readErr)
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+		}
+
+		return nil
+	}, retryOpts); err != nil {
+		return err
 	}
 
 	if result != nil && len(respBody) > 0 {
@@ -185,47 +211,39 @@ func (c *Client) ListIssueComments(ctx context.Context, owner, repo string, numb
 
 // AddComment adds a comment to an issue
 func (c *Client) AddComment(ctx context.Context, owner, repo string, number int, body string) (*Comment, error) {
-	return WithRetry(ctx, func() (*Comment, error) {
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
-		reqBody := map[string]string{"body": body}
-		var comment Comment
-		if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &comment); err != nil {
-			return nil, err
-		}
-		return &comment, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
+	reqBody := map[string]string{"body": body}
+	var comment Comment
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &comment); err != nil {
+		return nil, err
+	}
+	return &comment, nil
 }
 
 // AddLabels adds labels to an issue
 func (c *Client) AddLabels(ctx context.Context, owner, repo string, number int, labels []string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, number)
-		reqBody := map[string][]string{"labels": labels}
-		return c.doRequest(ctx, http.MethodPost, path, reqBody, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels", owner, repo, number)
+	reqBody := map[string][]string{"labels": labels}
+	return c.doRequest(ctx, http.MethodPost, path, reqBody, nil)
 }
 
 // RemoveLabel removes a label from an issue
 func (c *Client) RemoveLabel(ctx context.Context, owner, repo string, number int, label string) error {
-	return WithRetryVoid(ctx, func() error {
-		// GitHub API is case-sensitive for label names in URL path, normalize to lowercase
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%s", owner, repo, number, strings.ToLower(label))
-		err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
-		// 404 is OK - label might not exist
-		if err != nil && err.Error() != "API error (status 404): " {
-			return err
-		}
-		return nil
-	}, DefaultRetryOptions())
+	// GitHub API is case-sensitive for label names in URL path, normalize to lowercase
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%s", owner, repo, number, strings.ToLower(label))
+	err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
+	// 404 is OK - label might not exist
+	if err != nil && err.Error() != "API error (status 404): " {
+		return err
+	}
+	return nil
 }
 
 // UpdateIssueState updates an issue's state (open/closed)
 func (c *Client) UpdateIssueState(ctx context.Context, owner, repo string, number int, state string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d", owner, repo, number)
-		reqBody := map[string]string{"state": state}
-		return c.doRequest(ctx, http.MethodPatch, path, reqBody, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d", owner, repo, number)
+	reqBody := map[string]string{"state": state}
+	return c.doRequest(ctx, http.MethodPatch, path, reqBody, nil)
 }
 
 // GetRepository fetches repository info
@@ -241,51 +259,43 @@ func (c *Client) GetRepository(ctx context.Context, owner, repo string) (*Reposi
 // CreateCommitStatus creates a status for a specific commit SHA
 // The context parameter allows multiple statuses per commit (e.g., "ci/build", "pilot/execution")
 func (c *Client) CreateCommitStatus(ctx context.Context, owner, repo, sha string, status *CommitStatus) (*CommitStatus, error) {
-	return WithRetry(ctx, func() (*CommitStatus, error) {
-		path := fmt.Sprintf("/repos/%s/%s/statuses/%s", owner, repo, sha)
-		var result CommitStatus
-		if err := c.doRequest(ctx, http.MethodPost, path, status, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/statuses/%s", owner, repo, sha)
+	var result CommitStatus
+	if err := c.doRequest(ctx, http.MethodPost, path, status, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // CreateCheckRun creates a check run for the GitHub Checks API
 // Requires a GitHub App token with checks:write permission
 func (c *Client) CreateCheckRun(ctx context.Context, owner, repo string, checkRun *CheckRun) (*CheckRun, error) {
-	return WithRetry(ctx, func() (*CheckRun, error) {
-		path := fmt.Sprintf("/repos/%s/%s/check-runs", owner, repo)
-		var result CheckRun
-		if err := c.doRequest(ctx, http.MethodPost, path, checkRun, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/check-runs", owner, repo)
+	var result CheckRun
+	if err := c.doRequest(ctx, http.MethodPost, path, checkRun, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // UpdateCheckRun updates an existing check run
 func (c *Client) UpdateCheckRun(ctx context.Context, owner, repo string, checkRunID int64, checkRun *CheckRun) (*CheckRun, error) {
-	return WithRetry(ctx, func() (*CheckRun, error) {
-		path := fmt.Sprintf("/repos/%s/%s/check-runs/%d", owner, repo, checkRunID)
-		var result CheckRun
-		if err := c.doRequest(ctx, http.MethodPatch, path, checkRun, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/check-runs/%d", owner, repo, checkRunID)
+	var result CheckRun
+	if err := c.doRequest(ctx, http.MethodPatch, path, checkRun, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // CreatePullRequest creates a new pull request
 func (c *Client) CreatePullRequest(ctx context.Context, owner, repo string, input *PullRequestInput) (*PullRequest, error) {
-	return WithRetry(ctx, func() (*PullRequest, error) {
-		path := fmt.Sprintf("/repos/%s/%s/pulls", owner, repo)
-		var result PullRequest
-		if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/pulls", owner, repo)
+	var result PullRequest
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // RequestReviewers requests reviewers for a pull request.
@@ -294,17 +304,15 @@ func (c *Client) RequestReviewers(ctx context.Context, owner, repo string, numbe
 	if len(reviewers) == 0 && len(teamReviewers) == 0 {
 		return nil
 	}
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, number)
-		body := map[string][]string{}
-		if len(reviewers) > 0 {
-			body["reviewers"] = reviewers
-		}
-		if len(teamReviewers) > 0 {
-			body["team_reviewers"] = teamReviewers
-		}
-		return c.doRequest(ctx, http.MethodPost, path, body, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", owner, repo, number)
+	body := map[string][]string{}
+	if len(reviewers) > 0 {
+		body["reviewers"] = reviewers
+	}
+	if len(teamReviewers) > 0 {
+		body["team_reviewers"] = teamReviewers
+	}
+	return c.doRequest(ctx, http.MethodPost, path, body, nil)
 }
 
 // GetPullRequest fetches a pull request by number
@@ -320,26 +328,22 @@ func (c *Client) GetPullRequest(ctx context.Context, owner, repo string, number 
 // ClosePullRequest closes a pull request without merging.
 // Used by autopilot to close failed PRs so the sequential poller can unblock.
 func (c *Client) ClosePullRequest(ctx context.Context, owner, repo string, number int) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number)
-		payload := map[string]string{"state": "closed"}
-		return c.doRequest(ctx, http.MethodPatch, path, payload, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number)
+	payload := map[string]string{"state": "closed"}
+	return c.doRequest(ctx, http.MethodPatch, path, payload, nil)
 }
 
 // AddPRComment adds a comment to a pull request (issue comment API)
 // For review comments on specific lines, use CreatePRReviewComment instead
 func (c *Client) AddPRComment(ctx context.Context, owner, repo string, number int, body string) (*PRComment, error) {
-	return WithRetry(ctx, func() (*PRComment, error) {
-		// PRs use the issues API for general comments
-		path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
-		reqBody := map[string]string{"body": body}
-		var result PRComment
-		if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	// PRs use the issues API for general comments
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
+	reqBody := map[string]string{"body": body}
+	var result PRComment
+	if err := c.doRequest(ctx, http.MethodPost, path, reqBody, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // ListIssues lists issues for a repository with optional filters
@@ -413,18 +417,16 @@ func HasLabel(issue *Issue, labelName string) bool {
 // method can be "merge", "squash", or "rebase" (use MergeMethod* constants)
 // commitTitle is optional - if empty, GitHub uses the default
 func (c *Client) MergePullRequest(ctx context.Context, owner, repo string, number int, method, commitTitle string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, number)
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", owner, repo, number)
 
-		body := map[string]string{
-			"merge_method": method,
-		}
-		if commitTitle != "" {
-			body["commit_title"] = commitTitle
-		}
+	body := map[string]string{
+		"merge_method": method,
+	}
+	if commitTitle != "" {
+		body["commit_title"] = commitTitle
+	}
 
-		return c.doRequest(ctx, http.MethodPut, path, body, nil)
-	}, DefaultRetryOptions())
+	return c.doRequest(ctx, http.MethodPut, path, body, nil)
 }
 
 // GetCombinedStatus gets combined status for a commit SHA
@@ -456,18 +458,16 @@ func (c *Client) ListCheckRuns(ctx context.Context, owner, repo, sha string) (*C
 // ApprovePullRequest creates an approval review on a PR
 // body is the optional review comment
 func (c *Client) ApprovePullRequest(ctx context.Context, owner, repo string, number int, body string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, number)
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, number)
 
-		payload := map[string]string{
-			"event": ReviewEventApprove,
-		}
-		if body != "" {
-			payload["body"] = body
-		}
+	payload := map[string]string{
+		"event": ReviewEventApprove,
+	}
+	if body != "" {
+		payload["body"] = body
+	}
 
-		return c.doRequest(ctx, http.MethodPost, path, payload, nil)
-	}, DefaultRetryOptions())
+	return c.doRequest(ctx, http.MethodPost, path, payload, nil)
 }
 
 // IssueInput is the input for creating a new issue
@@ -479,14 +479,12 @@ type IssueInput struct {
 
 // CreateIssue creates a new issue in a repository
 func (c *Client) CreateIssue(ctx context.Context, owner, repo string, input *IssueInput) (*Issue, error) {
-	return WithRetry(ctx, func() (*Issue, error) {
-		path := fmt.Sprintf("/repos/%s/%s/issues", owner, repo)
-		var issue Issue
-		if err := c.doRequest(ctx, http.MethodPost, path, input, &issue); err != nil {
-			return nil, err
-		}
-		return &issue, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/issues", owner, repo)
+	var issue Issue
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &issue); err != nil {
+		return nil, err
+	}
+	return &issue, nil
 }
 
 // GetBranch fetches information about a branch
@@ -524,28 +522,24 @@ func (c *Client) ListPullRequests(ctx context.Context, owner, repo, state string
 
 // CreateRelease creates a new release
 func (c *Client) CreateRelease(ctx context.Context, owner, repo string, input *ReleaseInput) (*Release, error) {
-	return WithRetry(ctx, func() (*Release, error) {
-		path := fmt.Sprintf("/repos/%s/%s/releases", owner, repo)
-		var result Release
-		if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/releases", owner, repo)
+	var result Release
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // CreateGitTag creates a lightweight git tag via the GitHub API.
 // This creates only the tag ref, not a GitHub Release — letting GoReleaser
 // handle the full release creation with binary assets on tag push.
 func (c *Client) CreateGitTag(ctx context.Context, owner, repo, tag, sha string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo)
-		body := map[string]string{
-			"ref": "refs/tags/" + tag,
-			"sha": sha,
-		}
-		return c.doRequest(ctx, http.MethodPost, path, body, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo)
+	body := map[string]string{
+		"ref": "refs/tags/" + tag,
+		"sha": sha,
+	}
+	return c.doRequest(ctx, http.MethodPost, path, body, nil)
 }
 
 // GetLatestRelease gets the latest published release
@@ -579,14 +573,12 @@ func (c *Client) GetReleaseByTag(ctx context.Context, owner, repo, tag string) (
 
 // UpdateRelease updates an existing release (e.g. to enrich the body with a summary).
 func (c *Client) UpdateRelease(ctx context.Context, owner, repo string, releaseID int64, input *ReleaseInput) (*Release, error) {
-	return WithRetry(ctx, func() (*Release, error) {
-		path := fmt.Sprintf("/repos/%s/%s/releases/%d", owner, repo, releaseID)
-		var result Release
-		if err := c.doRequest(ctx, http.MethodPatch, path, input, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/releases/%d", owner, repo, releaseID)
+	var result Release
+	if err := c.doRequest(ctx, http.MethodPatch, path, input, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // ListReleases lists releases for a repository (newest first)
@@ -702,43 +694,39 @@ func isUnprocessableError(err error) bool {
 // Uses PATCH /repos/{owner}/{repo}/git/refs/heads/{branch} with force=true.
 // If the ref does not exist, falls back to creating it via POST.
 func (c *Client) UpdateRef(ctx context.Context, owner, repo, branch, sha string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, url.PathEscape(branch))
-		body := map[string]interface{}{
-			"sha":   sha,
-			"force": true,
+	path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, url.PathEscape(branch))
+	body := map[string]interface{}{
+		"sha":   sha,
+		"force": true,
+	}
+	err := c.doRequest(ctx, http.MethodPatch, path, body, nil)
+	if err == nil {
+		return nil
+	}
+	// If the ref doesn't exist yet, create it
+	if isUnprocessableError(err) || isNotFoundError(err) {
+		createPath := fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo)
+		createBody := map[string]string{
+			"ref": "refs/heads/" + branch,
+			"sha": sha,
 		}
-		err := c.doRequest(ctx, http.MethodPatch, path, body, nil)
-		if err == nil {
-			return nil
-		}
-		// If the ref doesn't exist yet, create it
-		if isUnprocessableError(err) || isNotFoundError(err) {
-			createPath := fmt.Sprintf("/repos/%s/%s/git/refs", owner, repo)
-			createBody := map[string]string{
-				"ref": "refs/heads/" + branch,
-				"sha": sha,
-			}
-			return c.doRequest(ctx, http.MethodPost, createPath, createBody, nil)
-		}
-		return err
-	}, DefaultRetryOptions())
+		return c.doRequest(ctx, http.MethodPost, createPath, createBody, nil)
+	}
+	return err
 }
 
 // DeleteBranch deletes a branch from the repository.
 // GitHub API: DELETE /repos/{owner}/{repo}/git/refs/heads/{branch}
 // Returns nil on success, or if the branch was already deleted (404/422).
 func (c *Client) DeleteBranch(ctx context.Context, owner, repo, branch string) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, url.PathEscape(branch))
-		err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
-		// 404 = branch doesn't exist, 422 = branch already deleted
-		// Both are success cases for cleanup
-		if isNotFoundError(err) || isUnprocessableError(err) {
-			return nil
-		}
-		return err
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", owner, repo, url.PathEscape(branch))
+	err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
+	// 404 = branch doesn't exist, 422 = branch already deleted
+	// Both are success cases for cleanup
+	if isNotFoundError(err) || isUnprocessableError(err) {
+		return nil
+	}
+	return err
 }
 
 // ListPullRequestReviews lists all reviews for a pull request
@@ -952,11 +940,9 @@ func (c *Client) SearchOpenSubIssues(ctx context.Context, owner, repo string, pa
 // Uses GitHub API: PUT /repos/{owner}/{repo}/pulls/{number}/update-branch
 // Returns nil on success, error if the branch cannot be automatically updated (true conflict).
 func (c *Client) UpdatePullRequestBranch(ctx context.Context, owner, repo string, number int) error {
-	return WithRetryVoid(ctx, func() error {
-		path := fmt.Sprintf("/repos/%s/%s/pulls/%d/update-branch", owner, repo, number)
-		body := map[string]interface{}{}
-		return c.doRequest(ctx, http.MethodPut, path, body, nil)
-	}, DefaultRetryOptions())
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/update-branch", owner, repo, number)
+	body := map[string]interface{}{}
+	return c.doRequest(ctx, http.MethodPut, path, body, nil)
 }
 
 // GetIssueNodeID fetches the GraphQL node ID for a given issue number via the REST API.

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -3469,3 +3469,78 @@ func TestListPullRequests_SinglePage(t *testing.T) {
 		t.Errorf("server called %d times, want 1 (single page should stop)", calls)
 	}
 }
+
+// fastRetryOpts returns retry options suitable for tests: no real sleeping.
+func fastRetryOpts(maxRetries int) RetryOptions {
+	return RetryOptions{
+		MaxRetries: maxRetries,
+		BaseDelay:  1 * time.Millisecond,
+		MaxDelay:   5 * time.Millisecond,
+	}
+}
+
+// TestDoRequest_RetryOn429 verifies that doRequest automatically retries on 429
+// and succeeds when the server eventually returns 200.
+func TestDoRequest_RetryOn429(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"message":"rate limited"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"number":42,"title":"Test"}`))
+	}))
+	defer server.Close()
+
+	opts := fastRetryOpts(3)
+	client := &Client{
+		token:      testutil.FakeGitHubToken,
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		retryOpts:  &opts,
+	}
+
+	issue, err := client.GetIssue(context.Background(), "owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("GetIssue() unexpected error after retry: %v", err)
+	}
+	if issue.Number != 42 {
+		t.Errorf("issue.Number = %d, want 42", issue.Number)
+	}
+	if calls != 2 {
+		t.Errorf("server called %d times, want 2 (1 rate-limit + 1 success)", calls)
+	}
+}
+
+// TestDoRequest_ExhaustsRetries verifies that doRequest returns an error after
+// all retries are exhausted on persistent 429.
+func TestDoRequest_ExhaustsRetries(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"rate limited"}`))
+	}))
+	defer server.Close()
+
+	opts := fastRetryOpts(2)
+	client := &Client{
+		token:      testutil.FakeGitHubToken,
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		retryOpts:  &opts,
+	}
+
+	_, err := client.GetIssue(context.Background(), "owner", "repo", 42)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	// 1 initial + 2 retries = 3 total calls
+	if calls != 3 {
+		t.Errorf("server called %d times, want 3 (1 initial + 2 retries)", calls)
+	}
+}

--- a/internal/adapters/github/retry.go
+++ b/internal/adapters/github/retry.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"log/slog"
 	"regexp"
 	"strconv"
 	"strings"
@@ -52,10 +53,20 @@ func WithRetry[T any](ctx context.Context, op func() (T, error), opts RetryOptio
 			delay = opts.MaxDelay
 		}
 
-		// Check for Retry-After header in rate limit errors
+		// Check for Retry-After header in rate limit errors; cap at MaxDelay.
 		if retryAfter := extractRetryAfter(lastErr); retryAfter > 0 {
 			delay = retryAfter
+			if delay > opts.MaxDelay {
+				delay = opts.MaxDelay
+			}
 		}
+
+		slog.Warn("github API request retrying",
+			"attempt", attempt+1,
+			"max_retries", opts.MaxRetries,
+			"delay_ms", delay.Milliseconds(),
+			"error", lastErr,
+		)
 
 		// Wait with context cancellation support
 		select {

--- a/internal/adapters/github/retry_test.go
+++ b/internal/adapters/github/retry_test.go
@@ -227,6 +227,36 @@ func TestDefaultRetryOptions(t *testing.T) {
 	}
 }
 
+// TestWithRetry_RetryAfterCappedAtMaxDelay verifies that a Retry-After value
+// larger than MaxDelay is capped rather than honored verbatim.
+func TestWithRetry_RetryAfterCappedAtMaxDelay(t *testing.T) {
+	calls := 0
+	start := time.Now()
+
+	_, _ = WithRetry(context.Background(), func() (string, error) {
+		calls++
+		if calls == 1 {
+			// Error message that triggers extractRetryAfter to return 999s
+			return "", errors.New("API error (status 429): rate limited, retry after 999 seconds")
+		}
+		return "ok", nil
+	}, RetryOptions{
+		MaxRetries: 3,
+		BaseDelay:  1 * time.Millisecond,
+		MaxDelay:   10 * time.Millisecond, // cap at 10ms, not 999s
+	})
+
+	elapsed := time.Since(start)
+	// If Retry-After 999s was honored without cap, this would sleep ~999s.
+	// With cap at 10ms, the total should be well under 1s.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("Retry-After was not capped: elapsed %v, expected <500ms", elapsed)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls, got %d", calls)
+	}
+}
+
 func TestWithRetry_ExponentialBackoff(t *testing.T) {
 	// Test that delays increase exponentially (approximately)
 	delays := []time.Duration{}


### PR DESCRIPTION
## Summary

- **Step 1 (doRequest retry)**: Moved retry logic from 20 per-method `WithRetry`/`WithRetryVoid` wrappers into `doRequest`. Every GitHub API call now gets uniform retry on 429/5xx/network errors. The 31 methods that previously had no retry coverage (e.g. `GetPullRequest`, `GetCombinedStatus`, `ListIssues`) are now protected.
- **Step 2 (observability)**: Added `slog.Warn` in `WithRetry` that logs on each retry attempt with `attempt`, `max_retries`, `delay_ms`, and `error` fields.
- **Step 3 (cleanup)**: Removed outer `WithRetry`/`WithRetryVoid` wrappers from all 20 methods that had them — `doRequest` handles it now.
- **Step 4 (Retry-After cap)**: `extractRetryAfter` values are now capped at `MaxDelay` so a runaway `Retry-After: 3600` can't stall a worker for an hour.
- **Test isolation**: `NewClientWithBaseURL` (test-only constructor) sets `MaxRetries=0` so existing mock-server tests fail fast without sleeping through back-off. Production `NewClient` keeps real retry defaults.

## Test plan

- [x] `TestDoRequest_RetryOn429` — server returns 429 once then 200; asserts 1 retry, no error
- [x] `TestDoRequest_ExhaustsRetries` — server always returns 429; asserts 3 total calls, error returned
- [x] `TestWithRetry_RetryAfterCappedAtMaxDelay` — error claims `Retry-After: 999s`, MaxDelay=10ms; asserts elapsed < 500ms
- [x] All 263 existing github adapter tests pass (`go test ./internal/adapters/github/... -timeout 120s`)
- [x] Full suite passes (`go test ./...`)
- [x] `make lint` — 0 issues

Closes #3114