### PR TITLE
GH-3136: fix(upgrade): surface codesign errors and add pre-exec smoke test

### DIFF
--- a/internal/upgrade/hot_test.go
+++ b/internal/upgrade/hot_test.go
@@ -23,10 +23,11 @@ func newTestHotUpgrader(t *testing.T, tc TaskChecker) (*HotUpgrader, string) {
 	statePath := filepath.Join(dir, "upgrade-state.json")
 
 	u := &Upgrader{
-		currentVersion: "1.0.0",
-		httpClient:     &http.Client{Timeout: 5 * time.Second},
-		binaryPath:     binPath,
-		backupPath:     binPath + BackupSuffix,
+		currentVersion:      "1.0.0",
+		httpClient:          &http.Client{Timeout: 5 * time.Second},
+		binaryPath:          binPath,
+		backupPath:          binPath + BackupSuffix,
+		prepareForExecution: func(string) error { return nil },
 	}
 
 	graceful := &GracefulUpgrader{

--- a/internal/upgrade/restart.go
+++ b/internal/upgrade/restart.go
@@ -6,10 +6,27 @@
 package upgrade
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"syscall"
+	"time"
 )
+
+// runSmokeTest verifies the new binary starts cleanly before we exec into it.
+// Overridable in tests.
+var runSmokeTest = func(binaryPath string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := exec.CommandContext(ctx, binaryPath, "--version").Run(); err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("timed out after 5s: %w", ctx.Err())
+		}
+		return err
+	}
+	return nil
+}
 
 // RestartWithNewBinary replaces the current process with the new binary.
 // This uses syscall.Exec which replaces the current process in-place,
@@ -46,6 +63,11 @@ func RestartWithNewBinary(binaryPath string, args []string, previousVersion stri
 	// Add previous version for upgrade notification
 	if previousVersion != "" {
 		env = append(env, fmt.Sprintf("PILOT_PREVIOUS_VERSION=%s", previousVersion))
+	}
+
+	// Verify the new binary boots before replacing the process.
+	if err := runSmokeTest(binaryPath); err != nil {
+		return fmt.Errorf("pre-exec smoke test failed: %w", err)
 	}
 
 	// Replace current process with the new binary

--- a/internal/upgrade/restart_smoke_test.go
+++ b/internal/upgrade/restart_smoke_test.go
@@ -1,0 +1,57 @@
+//go:build !windows
+
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunSmokeTest covers the pre-exec smoke test added in GH-3136.
+// Uses shell scripts as stand-ins for real binaries so CI does not need a
+// compiled Pilot binary.
+func TestRunSmokeTest(t *testing.T) {
+	tests := []struct {
+		name       string
+		script     string
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:    "happy path — exits zero",
+			script:  "#!/bin/sh\necho v1.0.0\nexit 0\n",
+			wantErr: false,
+		},
+		{
+			name:    "smoke test non-zero exit",
+			script:  "#!/bin/sh\nexit 1\n",
+			wantErr: true,
+		},
+		{
+			name:       "smoke test timeout",
+			script:     "#!/bin/sh\nsleep 10\n",
+			wantErr:    true,
+			wantErrMsg: "timed out",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			bin := filepath.Join(dir, "pilot")
+			if err := os.WriteFile(bin, []byte(tt.script), 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			err := runSmokeTest(bin)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("runSmokeTest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErrMsg != "" && err != nil && !strings.Contains(err.Error(), tt.wantErrMsg) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrMsg)
+			}
+		})
+	}
+}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -61,10 +61,11 @@ type VersionInfo struct {
 
 // Upgrader handles version checking and self-update
 type Upgrader struct {
-	currentVersion string
-	httpClient     *http.Client
-	binaryPath     string
-	backupPath     string
+	currentVersion      string
+	httpClient          *http.Client
+	binaryPath          string
+	backupPath          string
+	prepareForExecution func(string) error // injectable for testing; defaults to PrepareForExecution
 }
 
 // NewUpgrader creates a new Upgrader instance
@@ -93,10 +94,11 @@ func NewUpgrader(currentVersion string) (*Upgrader, error) {
 	}
 
 	return &Upgrader{
-		currentVersion: currentVersion,
-		httpClient:     &http.Client{Timeout: DefaultTimeout},
-		binaryPath:     resolvedPath,
-		backupPath:     resolvedPath + BackupSuffix,
+		currentVersion:      currentVersion,
+		httpClient:          &http.Client{Timeout: DefaultTimeout},
+		binaryPath:          resolvedPath,
+		backupPath:          resolvedPath + BackupSuffix,
+		prepareForExecution: PrepareForExecution,
 	}, nil
 }
 
@@ -402,9 +404,16 @@ func (u *Upgrader) installBinary(downloadPath string) error {
 		return err
 	}
 
-	// Prepare binary for execution (removes quarantine, signs on macOS)
-	// Errors are non-fatal - binary may still work
-	_ = PrepareForExecution(u.binaryPath)
+	// On Darwin, a codesign failure means Gatekeeper will kill the binary on
+	// first launch — surface it so callers can transition to UpgradeStateFailed.
+	prepare := PrepareForExecution
+	if u.prepareForExecution != nil {
+		prepare = u.prepareForExecution
+	}
+	if err := prepare(u.binaryPath); err != nil {
+		return fmt.Errorf("codesign failed — macOS Gatekeeper may block this binary "+
+			"(run: xattr -d com.apple.quarantine %s): %w", u.binaryPath, err)
+	}
 
 	return nil
 }

--- a/internal/upgrade/upgrade_codesign_test.go
+++ b/internal/upgrade/upgrade_codesign_test.go
@@ -1,0 +1,58 @@
+package upgrade
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInstallBinary_PrepareForExecution covers the codesign error-propagation path
+// added in GH-3136: a non-zero codesign exit must surface a Gatekeeper-aware error.
+func TestInstallBinary_PrepareForExecution(t *testing.T) {
+	tests := []struct {
+		name        string
+		prepareErr  error
+		wantErr     bool
+		wantErrMsg  string
+	}{
+		{
+			name:       "happy path — codesign succeeds",
+			prepareErr: nil,
+			wantErr:    false,
+		},
+		{
+			name:       "codesign non-zero exit",
+			prepareErr: errors.New("exit status 1"),
+			wantErr:    true,
+			wantErrMsg: "Gatekeeper",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			binaryPath := filepath.Join(dir, "pilot")
+			downloadPath := filepath.Join(dir, "download")
+
+			if err := os.WriteFile(downloadPath, []byte("fake binary"), 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			u := &Upgrader{
+				binaryPath:          binaryPath,
+				backupPath:          binaryPath + BackupSuffix,
+				prepareForExecution: func(string) error { return tt.prepareErr },
+			}
+
+			err := u.installBinary(downloadPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("installBinary() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErrMsg != "" && err != nil && !strings.Contains(err.Error(), tt.wantErrMsg) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrMsg)
+			}
+		})
+	}
+}

--- a/internal/upgrade/upgrade_critical_test.go
+++ b/internal/upgrade/upgrade_critical_test.go
@@ -221,7 +221,7 @@ func TestInstallBinary_DirectBinary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	u := &Upgrader{binaryPath: binPath}
+	u := &Upgrader{binaryPath: binPath, prepareForExecution: func(string) error { return nil }}
 	if err := u.installBinary(srcPath); err != nil {
 		t.Fatalf("installBinary() error = %v", err)
 	}
@@ -244,7 +244,7 @@ func TestInstallBinary_TarGz(t *testing.T) {
 
 	createTestTarGz(t, tarPath, "pilot", []byte("tar-binary-content"))
 
-	u := &Upgrader{binaryPath: binPath}
+	u := &Upgrader{binaryPath: binPath, prepareForExecution: func(string) error { return nil }}
 	if err := u.installBinary(tarPath); err != nil {
 		t.Fatalf("installBinary() error = %v", err)
 	}
@@ -787,10 +787,11 @@ func TestUpgrade_EndToEnd(t *testing.T) {
 	defer server.Close()
 
 	u := &Upgrader{
-		currentVersion: "1.0.0",
-		httpClient:     server.Client(),
-		binaryPath:     binPath,
-		backupPath:     backupPath,
+		currentVersion:      "1.0.0",
+		httpClient:          server.Client(),
+		binaryPath:          binPath,
+		backupPath:          backupPath,
+		prepareForExecution: func(string) error { return nil },
 	}
 
 	release := &Release{
@@ -866,10 +867,11 @@ func TestUpgrade_WithTarGzAsset(t *testing.T) {
 	defer server.Close()
 
 	u := &Upgrader{
-		currentVersion: "1.0.0",
-		httpClient:     server.Client(),
-		binaryPath:     binPath,
-		backupPath:     backupPath,
+		currentVersion:      "1.0.0",
+		httpClient:          server.Client(),
+		binaryPath:          binPath,
+		backupPath:          backupPath,
+		prepareForExecution: func(string) error { return nil },
 	}
 
 	tarName := fmt.Sprintf("pilot-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3136.

Closes #3136

## Changes

In internal/upgrade/upgrade.go, replace swallowed PrepareForExecution error at upgrade.go:407 with explicit handling that wraps codesign failures in a Darwin-specific Gatekeeper-aware message and propagates the error so the orchestrator transitions to UpgradeStateFailed with a non-empty upgradeMessage. In internal/upgrade/restart.go, add a 5s pre-exec smoke test (exec.CommandContext binaryPath --version) immediately before syscall.Exec; on non-zero exit or timeout return a wrapped error instead of proceeding. Keep Windows code path untouched. Add table-driven unit tests covering: codesign non-zero exit, smoke test non-zero exit, smoke test timeout, and happy path. Verifiable by go test ./internal/upgrade/...