### PR TITLE
GH-3137: fix(dashboard): render upgrade progress, completion, and failure states honestly

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -2745,14 +2745,21 @@ func (m Model) renderUpdateNotification() string {
 		title = "* UPGRADING"
 		bar := m.renderProgressBar(m.upgradeProgress, 30)
 		content.WriteString(fmt.Sprintf("  Installing %s... %s %d%%", m.updateInfo.LatestVersion, bar, m.upgradeProgress))
+		if m.upgradeMessage != "" {
+			content.WriteString("\n  " + m.upgradeMessage)
+		}
 
 	case UpgradeStateComplete:
 		title = "+ UPGRADED"
-		content.WriteString(fmt.Sprintf("  Now running %s - Restarting...", m.updateInfo.LatestVersion))
+		content.WriteString(fmt.Sprintf("  Upgrade to %s installed — restart Pilot manually to apply.", m.updateInfo.LatestVersion))
 
 	case UpgradeStateFailed:
 		title = "! UPGRADE FAILED"
-		content.WriteString("  " + m.upgradeError)
+		if m.upgradeError != "" {
+			content.WriteString("  " + m.upgradeError)
+		} else {
+			content.WriteString("  " + m.upgradeMessage)
+		}
 
 	default:
 		return ""

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -1668,3 +1668,77 @@ func TestUpdateTokens_EmptyModelFallsBackToDefault(t *testing.T) {
 		t.Errorf("cost with empty model = %.6f, want %.6f (DefaultModel=%s)", model.metricsCard.TotalCostUSD, want, memory.DefaultModel)
 	}
 }
+
+func newUpgradeModel(t *testing.T) Model {
+	t.Helper()
+	m := NewModel("v2.100.0")
+	m.width = 120
+	m.height = 40
+	// Seed update info so renderUpdateNotification can reference version strings.
+	updated, _ := m.Update(updateAvailableMsg{
+		CurrentVersion: "v2.100.0",
+		LatestVersion:  "v2.101.0",
+	})
+	return updated.(Model)
+}
+
+func TestUpgradeRender_InProgressShowsMessage(t *testing.T) {
+	m := newUpgradeModel(t)
+
+	// Transition to InProgress with a status message.
+	updated, _ := m.Update(upgradeProgressMsg{Progress: 50, Message: "Downloading..."})
+	model := updated.(Model)
+	model.upgradeState = UpgradeStateInProgress
+
+	out := model.renderUpdateNotification()
+	if !strings.Contains(out, "Downloading...") {
+		t.Errorf("InProgress render missing upgradeMessage; got:\n%s", out)
+	}
+}
+
+func TestUpgradeRender_InProgress_NoMessageNoExtraLine(t *testing.T) {
+	m := newUpgradeModel(t)
+
+	updated, _ := m.Update(upgradeProgressMsg{Progress: 30, Message: ""})
+	model := updated.(Model)
+	model.upgradeState = UpgradeStateInProgress
+
+	out := model.renderUpdateNotification()
+	if strings.Contains(out, "\n  \n") {
+		t.Errorf("InProgress render should not add blank line when upgradeMessage is empty; got:\n%s", out)
+	}
+}
+
+func TestUpgradeRender_CompleteNoRestarting(t *testing.T) {
+	m := newUpgradeModel(t)
+
+	updated, _ := m.Update(upgradeCompleteMsg{Success: true})
+	model := updated.(Model)
+
+	out := model.renderUpdateNotification()
+	if strings.Contains(out, "Restarting") {
+		t.Errorf("Complete render must not claim a restart happened; got:\n%s", out)
+	}
+	if !strings.Contains(out, "restart Pilot manually") {
+		t.Errorf("Complete render should instruct manual restart; got:\n%s", out)
+	}
+	if !strings.Contains(out, "v2.101.0") {
+		t.Errorf("Complete render should include the new version; got:\n%s", out)
+	}
+}
+
+func TestUpgradeRender_FailedShowsError(t *testing.T) {
+	m := newUpgradeModel(t)
+
+	errMsg := "Gatekeeper rejected the binary"
+	updated, _ := m.Update(upgradeCompleteMsg{Success: false, Error: errMsg})
+	model := updated.(Model)
+
+	out := model.renderUpdateNotification()
+	if !strings.Contains(out, errMsg) {
+		t.Errorf("Failed render should show the Gatekeeper-aware error; got:\n%s", out)
+	}
+	if strings.Contains(out, "Restarting") {
+		t.Errorf("Failed render must not contain 'Restarting'; got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3137.

Closes #3137

## Changes

GitHub Issue #3137: fix(dashboard): render upgrade progress, completion, and failure states honestly

<!--autopilot-meta
parent: GH-3118
inherited-spec: true
-->

Parent: GH-3118

In internal/dashboard/tui.go lines ~2735-2755: for UpgradeStateInProgress append m.upgradeMessage when non-empty; for UpgradeStateComplete replace misleading 'Now running X - Restarting...' with 'Upgrade to <version> installed — restart Pilot manually to apply.'; for UpgradeStateFailed clear stale Installing/100% progress text and render m.upgradeMessage with the Gatekeeper-aware text from subtask 1. Add state-transition tests driving InProgress→Failed and InProgress→Complete asserting correct rendered output and absence of 'Restarting...' when no restart occurred. Verifiable by go test ./internal/dashboard/... and manual repro per issue verification steps.