### PR TITLE
GH-3125: feat: workspace lifecycle hooks (after_create/before_run/after_run/before_r...

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -572,3 +572,4 @@ quality:
 | `safeGo()` panic-recovery wrapper | v2.150.x | executor + adapters | All goroutine spawns wrapped (TASK-292) |
 | `IsTaskShipped` predicate | v2.151.x | autopilot | Cross-site invariant preventing double-dispatch (TASK-296 / GH-3091) |
 | Ghost-SHA guard | v2.151.x | executor | Fail-closed when commit_sha already on base branch (TASK-300 / GH-3099) |
+| Workspace lifecycle hooks | v2.154.x | executor/workflow | `after_create`/`before_run`/`after_run`/`before_remove` hooks from `.pilot/workflow.yaml`; abort-on-failure for setup hooks; `setup_failed` DB status (TASK-305 / GH-3125) |

--- a/.pilot/workflow.yaml
+++ b/.pilot/workflow.yaml
@@ -1,0 +1,18 @@
+# Pilot's per-repo workflow configuration (TASK-304/305).
+# Pilot reads this file from the target repo at the start of each run.
+#
+# hooks: lifecycle hooks executed around each worktree session (TASK-305).
+#   after_create  — runs after the worktree is created (bootstrap: deps, tools)
+#   before_run    — runs just before the AI agent starts (env warmup)
+#   after_run     — runs after the AI agent finishes (artifact snapshot)
+#   before_remove — runs just before the worktree is destroyed (log archive)
+#
+#   Each hook is a shell snippet (or list) executed via: bash -lc "<script>"
+#   Available env vars: PILOT_TASK_ID, PILOT_BRANCH, PILOT_ISSUE_URL, PILOT_WORKTREE
+#
+# timeout_sec: per-hook timeout in seconds (default 300).
+
+hooks:
+  after_create:
+    - "go build ./... 2>&1 | head -20 || true"
+  timeout_sec: 300

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -682,13 +682,20 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			// Emit progress callback for task failed
 			w.runner.EmitProgress(exec.TaskID, "Failed", 100, fmt.Sprintf("Execution error: %s", truncateForLog(execErr.Error(), 60)))
 		} else if !result.Success {
+			// TASK-305: lifecycle hook aborts use "setup_failed" status so the dashboard
+			// and history can distinguish infra failures from code-quality failures.
+			status := "failed"
+			if result.SetupFailed {
+				status = "setup_failed"
+			}
 			w.log.Warn("Task completed with failure",
 				slog.String("task_id", exec.TaskID),
+				slog.String("status", status),
 				slog.String("error", result.Error),
 				slog.Duration("duration", duration),
 			)
-			if err := w.store.UpdateExecutionStatus(exec.ID, "failed", result.Error); err != nil {
-				w.log.Error("Failed to update status to failed", slog.Any("error", err))
+			if err := w.store.UpdateExecutionStatus(exec.ID, status, result.Error); err != nil {
+				w.log.Error("Failed to update execution status", slog.Any("error", err))
 			}
 			// Emit progress callback for task failed
 			w.runner.EmitProgress(exec.TaskID, "Failed", 100, fmt.Sprintf("Task failed: %s", truncateForLog(result.Error, 60)))

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/executor/workflow"
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/quality"
@@ -292,6 +293,9 @@ type ExecutionResult struct {
 	PeakRSSMB int
 	// FinalRSSMB is the subprocess RSS at exit. GH-3028.
 	FinalRSSMB int
+	// SetupFailed is true when a lifecycle hook (after_create or before_run) aborted
+	// the run. Callers should persist status="setup_failed" instead of "failed". TASK-305.
+	SetupFailed bool
 }
 
 // ProgressCallback is a function called during execution with progress updates.
@@ -1183,6 +1187,10 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	executionPath := task.ProjectPath
 	var cleanupWorktree func()
 
+	// TASK-305: lifecycleHooks is populated after executionPath is finalized.
+	// The before_remove defer captures this variable by reference.
+	var lifecycleHooks *workflow.WorkflowHooks
+
 	// Debug: log worktree condition state
 	r.log.Info("Worktree condition check",
 		slog.Bool("allowWorktree", allowWorktree),
@@ -1254,9 +1262,51 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		r.reportProgress(task.ID, "Worktree", 2, "Worktree ready")
 	}
 
+	// TASK-305: before_remove runs just before teardown — always, whether or not a
+	// worktree is in use. The defer fires before cleanupWorktree (LIFO order) because
+	// it is registered first. lifecycleHooks is populated below; nil means no-op.
+	defer func() {
+		if lifecycleHooks != nil {
+			hookCtx, hookCancel := context.WithTimeout(context.Background(), lifecycleHooks.Timeout())
+			defer hookCancel()
+			if hookErr := workflow.RunHook(hookCtx, "before_remove", lifecycleHooks,
+				buildHookEnv(task, executionPath), executionPath, r.log); hookErr != nil {
+				r.log.Warn("before_remove hook failed (non-fatal)",
+					slog.String("task_id", task.ID),
+					slog.Any("error", hookErr),
+				)
+			}
+		}
+	}()
+
 	// Ensure worktree cleanup on exit (handles panic, early return, success)
 	if cleanupWorktree != nil {
 		defer cleanupWorktree()
+	}
+
+	// TASK-305: Load .pilot/workflow.yaml hooks from the execution directory, then
+	// run after_create (abort on failure with setup_failed status).
+	if wh, loadErr := workflow.Load(executionPath); loadErr != nil {
+		r.log.Warn("Failed to load .pilot/workflow.yaml hooks (non-fatal)",
+			slog.String("task_id", task.ID),
+			slog.Any("error", loadErr),
+		)
+	} else if wh != nil {
+		lifecycleHooks = wh
+		r.reportProgress(task.ID, "Setup", 2, "Running after_create hook...")
+		if hookErr := workflow.RunHook(ctx, "after_create", lifecycleHooks,
+			buildHookEnv(task, executionPath), executionPath, r.log); hookErr != nil {
+			r.log.Error("after_create hook failed, aborting run",
+				slog.String("task_id", task.ID),
+				slog.Any("error", hookErr),
+			)
+			return &ExecutionResult{
+				TaskID:      task.ID,
+				Success:     false,
+				SetupFailed: true,
+				Error:       fmt.Sprintf("after_create hook failed: %v", hookErr),
+			}, fmt.Errorf("after_create hook: %w", hookErr)
+		}
 	}
 
 	// GH-915: Run pre-flight checks to catch environmental issues early
@@ -1797,6 +1847,24 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		stallCancel = func() {}
 	}
 
+	// TASK-305: before_run hook — abort on failure with setup_failed status.
+	if lifecycleHooks != nil {
+		r.reportProgress(task.ID, "Setup", 3, "Running before_run hook...")
+		if hookErr := workflow.RunHook(ctx, "before_run", lifecycleHooks,
+			buildHookEnv(task, executionPath), executionPath, r.log); hookErr != nil {
+			r.log.Error("before_run hook failed, aborting run",
+				slog.String("task_id", task.ID),
+				slog.Any("error", hookErr),
+			)
+			return &ExecutionResult{
+				TaskID:      task.ID,
+				Success:     false,
+				SetupFailed: true,
+				Error:       fmt.Sprintf("before_run hook failed: %v", hookErr),
+			}, fmt.Errorf("before_run hook: %w", hookErr)
+		}
+	}
+
 	// Execute via backend with watchdog (GH-882)
 	// Watchdog kills subprocess after 2x timeout as a safety net for processes
 	// that ignore context cancellation.
@@ -1855,6 +1923,20 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	// Stop stall watchdog and release stall context resources.
 	close(stallDone)
 	stallCancel()
+
+	// TASK-305: after_run hook — best-effort; failure logs a warning but does not
+	// change the run's success status (artifact snapshot / cleanup should not fail the task).
+	if lifecycleHooks != nil {
+		hookCtx, hookCancel := context.WithTimeout(context.Background(), lifecycleHooks.Timeout())
+		if hookErr := workflow.RunHook(hookCtx, "after_run", lifecycleHooks,
+			buildHookEnv(task, executionPath), executionPath, r.log); hookErr != nil {
+			r.log.Warn("after_run hook failed (non-fatal)",
+				slog.String("task_id", task.ID),
+				slog.Any("error", hookErr),
+			)
+		}
+		hookCancel()
+	}
 
 	// Transfer stallDetected flag to progressState for post-Execute checks.
 	if stallDetectedFlag.Load() {
@@ -4646,4 +4728,18 @@ func (r *Runner) getPostExecutionSummary(ctx context.Context) (*PostExecutionSum
 	}
 
 	return &summary, nil
+}
+
+// buildHookEnv constructs the PILOT_* environment variables for lifecycle hooks. TASK-305.
+func buildHookEnv(task *Task, worktreePath string) workflow.HookEnv {
+	issueURL := ""
+	if task.SourceAdapter == "github" && task.SourceRepo != "" && task.SourceIssueID != "" {
+		issueURL = "https://github.com/" + task.SourceRepo + "/issues/" + task.SourceIssueID
+	}
+	return workflow.HookEnv{
+		TaskID:   task.ID,
+		Branch:   task.Branch,
+		IssueURL: issueURL,
+		Worktree: worktreePath,
+	}
 }

--- a/internal/executor/workflow/hooks.go
+++ b/internal/executor/workflow/hooks.go
@@ -1,0 +1,184 @@
+// Package workflow provides support for per-repo .pilot/workflow.yaml lifecycle hooks.
+//
+// Hooks allow target repos to inject project-specific shell scripts at four lifecycle
+// points: after_create, before_run, after_run, and before_remove.
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultHookTimeout is the per-hook execution timeout when none is configured.
+const DefaultHookTimeout = 300 * time.Second
+
+// WorkflowHooks configures the four lifecycle hook points from .pilot/workflow.yaml.
+// Each field is a list of shell snippets executed sequentially via bash -lc.
+type WorkflowHooks struct {
+	AfterCreate  StringOrSlice `yaml:"after_create"`
+	BeforeRun    StringOrSlice `yaml:"before_run"`
+	AfterRun     StringOrSlice `yaml:"after_run"`
+	BeforeRemove StringOrSlice `yaml:"before_remove"`
+	// TimeoutSec is the per-hook timeout in seconds. Default: 300.
+	TimeoutSec int `yaml:"timeout_sec"`
+}
+
+// StringOrSlice unmarshals a YAML value that can be either a string or a list of strings.
+type StringOrSlice []string
+
+// UnmarshalYAML handles both scalar ("echo hello") and sequence forms.
+func (s *StringOrSlice) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		if value.Value != "" {
+			*s = []string{value.Value}
+		}
+		return nil
+	case yaml.SequenceNode:
+		var ss []string
+		if err := value.Decode(&ss); err != nil {
+			return err
+		}
+		*s = ss
+		return nil
+	default:
+		return fmt.Errorf("workflow hooks: expected string or sequence, got %v", value.Kind)
+	}
+}
+
+// Timeout returns the effective per-hook timeout.
+func (h *WorkflowHooks) Timeout() time.Duration {
+	if h == nil || h.TimeoutSec <= 0 {
+		return DefaultHookTimeout
+	}
+	return time.Duration(h.TimeoutSec) * time.Second
+}
+
+// Scripts returns the shell snippets configured for hookName.
+// Valid names: "after_create", "before_run", "after_run", "before_remove".
+func (h *WorkflowHooks) Scripts(hookName string) []string {
+	if h == nil {
+		return nil
+	}
+	switch hookName {
+	case "after_create":
+		return []string(h.AfterCreate)
+	case "before_run":
+		return []string(h.BeforeRun)
+	case "after_run":
+		return []string(h.AfterRun)
+	case "before_remove":
+		return []string(h.BeforeRemove)
+	}
+	return nil
+}
+
+// workflowFile is the minimal YAML structure of .pilot/workflow.yaml needed for hooks.
+// TASK-304 will add the full schema (agent overrides, policy, prompt body).
+type workflowFile struct {
+	Hooks *WorkflowHooks `yaml:"hooks"`
+}
+
+// Load reads .pilot/workflow.yaml from repoPath and returns its hooks block.
+// Returns nil (not an error) when the file does not exist or has no hooks block.
+func Load(repoPath string) (*WorkflowHooks, error) {
+	path := filepath.Join(repoPath, ".pilot", "workflow.yaml")
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var wf workflowFile
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	return wf.Hooks, nil
+}
+
+// HookEnv carries the pilot-specific environment variables injected into every hook.
+type HookEnv struct {
+	TaskID   string // $PILOT_TASK_ID
+	Branch   string // $PILOT_BRANCH
+	IssueURL string // $PILOT_ISSUE_URL
+	Worktree string // $PILOT_WORKTREE
+}
+
+// RunHook executes all scripts configured for hookName, in declaration order.
+// Each script runs as: bash -lc "<script>" in dir.
+// Returns an error on the first failing script; remaining scripts are skipped.
+func RunHook(ctx context.Context, hookName string, hooks *WorkflowHooks, env HookEnv, dir string, log *slog.Logger) error {
+	scripts := hooks.Scripts(hookName)
+	if len(scripts) == 0 {
+		return nil
+	}
+
+	timeout := hooks.Timeout()
+	for i, script := range scripts {
+		if err := runScript(ctx, hookName, i, script, timeout, env, dir, log); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runScript executes a single hook script and streams its output to log.
+func runScript(ctx context.Context, hookName string, idx int, script string, timeout time.Duration, env HookEnv, dir string, log *slog.Logger) error {
+	hookCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(hookCtx, "bash", "-lc", script)
+	cmd.Dir = dir
+	// Inherit process environment so PATH, HOME, and shell configs are available.
+	cmd.Env = append(os.Environ(),
+		"PILOT_TASK_ID="+env.TaskID,
+		"PILOT_BRANCH="+env.Branch,
+		"PILOT_ISSUE_URL="+env.IssueURL,
+		"PILOT_WORKTREE="+env.Worktree,
+	)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	log.Info("Running lifecycle hook",
+		slog.String("hook", hookName),
+		slog.Int("script_index", idx),
+		slog.String("dir", dir),
+	)
+
+	runErr := cmd.Run()
+	output := out.String()
+
+	if output != "" {
+		log.Info("Hook output",
+			slog.String("hook", hookName),
+			slog.Int("script_index", idx),
+			slog.String("output", output),
+		)
+	}
+
+	if runErr != nil {
+		if hookCtx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("hook %s[%d] timed out after %v", hookName, idx, timeout)
+		}
+		return fmt.Errorf("hook %s[%d] failed: %w\noutput: %s", hookName, idx, runErr, output)
+	}
+
+	log.Info("Hook completed",
+		slog.String("hook", hookName),
+		slog.Int("script_index", idx),
+	)
+	return nil
+}

--- a/internal/executor/workflow/hooks_test.go
+++ b/internal/executor/workflow/hooks_test.go
@@ -1,0 +1,265 @@
+package workflow_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/executor/workflow"
+)
+
+func TestRunHook_Success(t *testing.T) {
+	dir := t.TempDir()
+	hooks := &workflow.WorkflowHooks{}
+	hooks.AfterCreate = workflow.StringOrSlice([]string{"echo hello"})
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	err := workflow.RunHook(context.Background(), "after_create", hooks, workflow.HookEnv{
+		TaskID:  "T-1",
+		Branch:  "pilot/GH-1",
+		Worktree: dir,
+	}, dir, log)
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+}
+
+func TestRunHook_Failure(t *testing.T) {
+	dir := t.TempDir()
+	hooks := &workflow.WorkflowHooks{}
+	hooks.BeforeRun = workflow.StringOrSlice([]string{"exit 1"})
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	err := workflow.RunHook(context.Background(), "before_run", hooks, workflow.HookEnv{}, dir, log)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "before_run[0] failed") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRunHook_Timeout(t *testing.T) {
+	dir := t.TempDir()
+	hooks := &workflow.WorkflowHooks{TimeoutSec: 1}
+	hooks.AfterCreate = workflow.StringOrSlice([]string{"sleep 10"})
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	start := time.Now()
+	err := workflow.RunHook(context.Background(), "after_create", hooks, workflow.HookEnv{}, dir, log)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected timeout in error, got: %v", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("timeout took too long: %v", elapsed)
+	}
+}
+
+func TestRunHook_EnvVars(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "env_out.txt")
+
+	hooks := &workflow.WorkflowHooks{}
+	hooks.AfterCreate = workflow.StringOrSlice([]string{
+		"echo $PILOT_TASK_ID $PILOT_BRANCH $PILOT_WORKTREE > " + outFile,
+	})
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	env := workflow.HookEnv{
+		TaskID:   "GH-42",
+		Branch:   "pilot/GH-42",
+		Worktree: dir,
+	}
+	if err := workflow.RunHook(context.Background(), "after_create", hooks, env, dir, log); err != nil {
+		t.Fatalf("hook failed: %v", err)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	output := strings.TrimSpace(string(data))
+	if !strings.Contains(output, "GH-42") {
+		t.Errorf("PILOT_TASK_ID not found in output: %q", output)
+	}
+	if !strings.Contains(output, "pilot/GH-42") {
+		t.Errorf("PILOT_BRANCH not found in output: %q", output)
+	}
+}
+
+func TestRunHook_MultipleScripts(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "order.txt")
+
+	hooks := &workflow.WorkflowHooks{}
+	hooks.AfterCreate = workflow.StringOrSlice([]string{
+		"echo first >> " + outFile,
+		"echo second >> " + outFile,
+	})
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	if err := workflow.RunHook(context.Background(), "after_create", hooks, workflow.HookEnv{}, dir, log); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 || lines[0] != "first" || lines[1] != "second" {
+		t.Errorf("unexpected output order: %v", lines)
+	}
+}
+
+func TestRunHook_StopsOnFirstFailure(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "reached.txt")
+
+	hooks := &workflow.WorkflowHooks{}
+	hooks.BeforeRun = workflow.StringOrSlice([]string{
+		"exit 1",
+		"echo reached > " + outFile,
+	})
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	err := workflow.RunHook(context.Background(), "before_run", hooks, workflow.HookEnv{}, dir, log)
+	if err == nil {
+		t.Fatal("expected error from first script")
+	}
+
+	if _, statErr := os.Stat(outFile); !os.IsNotExist(statErr) {
+		t.Error("second script ran despite first failure")
+	}
+}
+
+func TestRunHook_NoScripts(t *testing.T) {
+	dir := t.TempDir()
+	hooks := &workflow.WorkflowHooks{} // no hooks configured
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	if err := workflow.RunHook(context.Background(), "after_create", hooks, workflow.HookEnv{}, dir, log); err != nil {
+		t.Fatalf("expected nil for empty hooks, got: %v", err)
+	}
+}
+
+func TestRunHook_NilHooks(t *testing.T) {
+	dir := t.TempDir()
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	if err := workflow.RunHook(context.Background(), "after_create", nil, workflow.HookEnv{}, dir, log); err != nil {
+		t.Fatalf("expected nil for nil hooks, got: %v", err)
+	}
+}
+
+func TestLoad_FileNotExist(t *testing.T) {
+	dir := t.TempDir()
+	hooks, err := workflow.Load(dir)
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got: %v", err)
+	}
+	if hooks != nil {
+		t.Fatalf("expected nil hooks for missing file, got: %+v", hooks)
+	}
+}
+
+func TestLoad_ParseHooks(t *testing.T) {
+	dir := t.TempDir()
+	pilotDir := filepath.Join(dir, ".pilot")
+	if err := os.MkdirAll(pilotDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	yaml := `
+hooks:
+  after_create:
+    - "mise install"
+    - "npm ci"
+  before_run: "echo warming"
+  timeout_sec: 120
+`
+	if err := os.WriteFile(filepath.Join(pilotDir, "workflow.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hooks, err := workflow.Load(dir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if hooks == nil {
+		t.Fatal("expected non-nil hooks")
+	}
+
+	ac := hooks.Scripts("after_create")
+	if len(ac) != 2 || ac[0] != "mise install" || ac[1] != "npm ci" {
+		t.Errorf("after_create: want [mise install, npm ci], got %v", ac)
+	}
+
+	br := hooks.Scripts("before_run")
+	if len(br) != 1 || br[0] != "echo warming" {
+		t.Errorf("before_run: want [echo warming], got %v", br)
+	}
+
+	if hooks.Timeout() != 120*time.Second {
+		t.Errorf("timeout: want 120s, got %v", hooks.Timeout())
+	}
+}
+
+func TestLoad_NoHooksBlock(t *testing.T) {
+	dir := t.TempDir()
+	pilotDir := filepath.Join(dir, ".pilot")
+	if err := os.MkdirAll(pilotDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// workflow.yaml with no hooks block (future TASK-304 fields only)
+	yaml := `
+version: 1
+agent:
+  max_turns: 20
+`
+	if err := os.WriteFile(filepath.Join(pilotDir, "workflow.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hooks, err := workflow.Load(dir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if hooks != nil {
+		t.Fatalf("expected nil hooks when block absent, got: %+v", hooks)
+	}
+}
+
+func TestStringOrSlice_UnmarshalSingle(t *testing.T) {
+	dir := t.TempDir()
+	pilotDir := filepath.Join(dir, ".pilot")
+	if err := os.MkdirAll(pilotDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	yaml := "hooks:\n  after_create: \"mise install\"\n"
+	if err := os.WriteFile(filepath.Join(pilotDir, "workflow.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hooks, err := workflow.Load(dir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if hooks == nil {
+		t.Fatal("expected hooks")
+	}
+	ac := hooks.Scripts("after_create")
+	if len(ac) != 1 || ac[0] != "mise install" {
+		t.Errorf("want [mise install], got %v", ac)
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3125.

Closes #3125

## Changes

GitHub Issue #3125: TASK-305: Workspace lifecycle hooks (after_create/before_run/after_run/before_remove)

**Severity**: P2 — Wave 5
**Job (JTD)**: J2 Hand-off
**Effort**: M (~4h)
**Depends on**: TASK-304
**Plan**: `.agent/tasks/TASK-305-workspace-lifecycle-hooks.md`

## Summary
Four shell-script hook points executed by Pilot around each session, declared in `.pilot/workflow.yaml` `hooks:` block:
- `after_create` — bootstrap (mise install, fetch submodules)
- `before_run` — env warmup
- `after_run` — artifact snapshot
- `before_remove` — log archive

Borrowed from OpenAI Symphony's workspace lifecycle hooks.

## Why
Per-project bootstrap and cleanup is hardcoded today. Hooks let customers inject project-specific lifecycle steps without forking Pilot.

## Acceptance criteria
- Hooks execute as `bash -lc "<script>"` in worktree dir
- `after_create` / `before_run` failure aborts run (`setup_failed` status)
- `after_run` / `before_remove` failures log warnings, don't change run status
- Per-hook timeout (default 300s)
- Env vars available: `PILOT_TASK_ID`, `PILOT_BRANCH`, `PILOT_ISSUE_URL`, `PILOT_WORKTREE`
- Stdout/stderr captured to executor logs

Full plan in `.agent/tasks/TASK-305-workspace-lifecycle-hooks.md`.