### PR TITLE
fix(autopilot): gate pilot-done + issue close on PR merge, not PR creation

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -23,7 +23,6 @@
 | Progress display | ✅ | executor | - | - | Lipgloss visual bar |
 | Navigator detection | ✅ | executor | - | - | Auto-prefix if `.agent/` exists |
 | AGENTS.md loading | ✅ | executor | - | - | LoadAgentsFile reads project AGENTS.md (v0.24.1) |
-| Per-repo workflow override | ✅ | executor/workflow | - | `.pilot/workflow.yaml` | YAML front-matter + Markdown prompt appendix; overrides agent.max_turns, agent.reasoning_effort, policy.* (TASK-304, v2.153.2) |
 | Dry run mode | ✅ | executor | `--dry-run` | - | Show prompt only |
 | Verbose output | ✅ | executor | `--verbose` | - | Stream raw JSON |
 | Task dispatcher | ✅ | executor | - | - | Per-project queue (GH-46) |
@@ -573,3 +572,4 @@ quality:
 | `safeGo()` panic-recovery wrapper | v2.150.x | executor + adapters | All goroutine spawns wrapped (TASK-292) |
 | `IsTaskShipped` predicate | v2.151.x | autopilot | Cross-site invariant preventing double-dispatch (TASK-296 / GH-3091) |
 | Ghost-SHA guard | v2.151.x | executor | Fail-closed when commit_sha already on base branch (TASK-300 / GH-3099) |
+| Gate pilot-done on merge | v2.155.x | autopilot + cmd/pilot | pilot-done + issue close deferred to PR merge; handleMergeConflict re-adds pilot label + guards pilot-done (TASK-301 / GH-3139) |

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -351,13 +351,10 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				// Update issueResult to reflect failure
 				issueResult.Success = false
 			} else {
-				// Has deliverables — add pilot-done immediately to close label gap
-				// GH-1350: Prevents parallel poller re-dispatch race during the window
-				// between execution complete and autopilot merge handler
-				// GH-1015: Autopilot also adds pilot-done after merge (idempotent)
-				if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelDone}); err != nil {
-					logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
-				}
+				// Has deliverables — PR created, awaiting merge.
+				// GH-3139/TASK-301: pilot-done + issue close are deferred to merge
+				// (handleMerging in autopilot) so a later merge conflict cannot
+				// ghost-close the issue before any code reaches main.
 				// GH-1869: Move to Review column when PR is created
 				if hr.PRNumber > 0 {
 					syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Review)
@@ -365,7 +362,6 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 					// GH-2099: Auto-assign PR reviewers from project config
 					requestReviewersFromConfig(ctx, cfg, client, sourceRepo, parts[0], parts[1], hr.PRNumber)
 				}
-				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Done) // GH-1853
 
 				// GH-1302/GH-2402: Clean up stale pilot-failed label from prior failed attempt.
 				// Removed unconditionally — the in-memory `issue` object is the snapshot
@@ -374,11 +370,6 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				if err := client.RemoveLabel(ctx, parts[0], parts[1], issue.Number, github.LabelFailed); err != nil {
 					// 404 is expected if label doesn't exist — log at debug level
 					slog.Debug("pilot-failed label cleanup", "issue", issue.Number, "error", err)
-				}
-
-				// Close the issue so dependent issues can proceed
-				if err := client.UpdateIssueState(ctx, parts[0], parts[1], issue.Number, "closed"); err != nil {
-					logGitHubAPIError("UpdateIssueState", parts[0], parts[1], issue.Number, err)
 				}
 
 				comment := buildExecutionComment(hr.Result, branchName)

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -92,6 +92,7 @@ const (
 
 // Label names used by Pilot
 const (
+	LabelPilot              = "pilot"
 	LabelInProgress         = "pilot-in-progress"
 	LabelDone               = "pilot-done"
 	LabelFailed             = "pilot-failed"

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1794,10 +1794,20 @@ func (c *Controller) handleMergeConflict(ctx context.Context, prState *PRState) 
 		c.log.Warn("failed to close conflicting PR", "pr", prState.PRNumber, "error", err)
 	}
 
-	// Remove pilot-in-progress label from the issue so poller can re-pick it
+	// Restore issue to dispatch-ready state after conflict.
+	// GH-3139/TASK-301: issue must remain OPEN with pilot label so the poller
+	// can re-dispatch. Do NOT close the issue or add pilot-done here.
 	if prState.IssueNumber > 0 {
 		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelInProgress); err != nil {
 			c.log.Warn("failed to remove in-progress label", "issue", prState.IssueNumber, "error", err)
+		}
+		// Re-add pilot label so poller can pick up the issue on the next cycle.
+		if err := c.ghClient.AddLabels(ctx, c.owner, c.repo, prState.IssueNumber, []string{github.LabelPilot}); err != nil {
+			c.log.Warn("failed to re-add pilot label on conflict", "issue", prState.IssueNumber, "error", err)
+		}
+		// Guard: remove pilot-done if somehow present — prevents ghost-close.
+		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelDone); err != nil {
+			c.log.Debug("pilot-done cleanup on conflict (may not exist)", "issue", prState.IssueNumber, "error", err)
 		}
 	}
 

--- a/internal/autopilot/controller_merge_test.go
+++ b/internal/autopilot/controller_merge_test.go
@@ -1,0 +1,232 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestController_MergeConflict_IssueNotGhostClosed verifies that when autopilot
+// detects a merge conflict and closes the PR, the associated issue is NOT closed
+// and pilot-done is NOT added. The issue must stay open for re-dispatch.
+// GH-3139 / TASK-301.
+func TestController_MergeConflict_IssueNotGhostClosed(t *testing.T) {
+	var (
+		pilotDoneAdded   bool
+		pilotLabelAdded  bool
+		pilotDoneRemoved bool
+		issueClosed      bool
+		prClosed         bool
+		inProgressRemoved bool
+	)
+
+	mergeable := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/55" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:         55,
+				Head:           github.PRRef{SHA: "sha55"},
+				Mergeable:      &mergeable,
+				MergeableState: "dirty",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/55/update-branch" && r.Method == http.MethodPut:
+			// Auto-rebase fails → true conflict path
+			w.WriteHeader(http.StatusUnprocessableEntity)
+
+		case r.URL.Path == "/repos/owner/repo/issues/55/comments" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.PRComment{ID: 1})
+
+		case r.URL.Path == "/repos/owner/repo/pulls/55" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+
+		case r.URL.Path == "/repos/owner/repo/issues/20/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for _, l := range body["labels"] {
+				if l == github.LabelDone {
+					pilotDoneAdded = true
+				}
+				if l == github.LabelPilot {
+					pilotLabelAdded = true
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+
+		case r.URL.Path == "/repos/owner/repo/issues/20/labels/pilot-in-progress" && r.Method == http.MethodDelete:
+			inProgressRemoved = true
+			w.WriteHeader(http.StatusOK)
+
+		case r.URL.Path == "/repos/owner/repo/issues/20/labels/pilot-done" && r.Method == http.MethodDelete:
+			pilotDoneRemoved = true
+			w.WriteHeader(http.StatusOK)
+
+		case r.URL.Path == "/repos/owner/repo/issues/20" && r.Method == http.MethodPatch:
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["state"] == "closed" {
+				issueClosed = true
+			}
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	c.activePRs[55] = &PRState{
+		PRNumber:    55,
+		PRURL:       "https://github.com/owner/repo/pull/55",
+		IssueNumber: 20,
+		BranchName:  "pilot/GH-20",
+		HeadSHA:     "sha55",
+		Stage:       StageWaitingCI,
+		CIStatus:    CIPending,
+		CIWaitStartedAt: time.Now(),
+		CreatedAt:   time.Now(),
+	}
+	c.mu.Unlock()
+
+	err := c.ProcessPR(context.Background(), 55, nil)
+	if err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	pr, _ := c.GetPRState(55)
+	if pr.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", pr.Stage, StageFailed)
+	}
+	if !prClosed {
+		t.Error("conflicting PR should have been closed")
+	}
+	if !inProgressRemoved {
+		t.Error("pilot-in-progress should be removed from issue")
+	}
+	if pilotDoneAdded {
+		t.Error("pilot-done must NOT be added on conflict — ghost-close guard (GH-3139)")
+	}
+	if issueClosed {
+		t.Error("issue must NOT be closed on conflict — ghost-close guard (GH-3139)")
+	}
+	if !pilotLabelAdded {
+		t.Error("pilot label should be re-added to issue for re-dispatch")
+	}
+	if !pilotDoneRemoved {
+		t.Error("pilot-done cleanup should be attempted on conflict (may be 404 — that is OK)")
+	}
+}
+
+// TestController_HandleMerging_ClosesIssueWithPilotDone verifies that when a PR
+// is successfully merged, the associated issue is closed and pilot-done is added.
+// GH-3139 / TASK-301: this is the only path that should close the issue.
+func TestController_HandleMerging_ClosesIssueWithPilotDone(t *testing.T) {
+	var (
+		pilotDoneAdded  bool
+		issueClosed     bool
+		inProgRemoved   bool
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/sha99/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/99/merge" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+
+		case r.URL.Path == "/repos/owner/repo/issues/30/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for _, l := range body["labels"] {
+				if l == github.LabelDone {
+					pilotDoneAdded = true
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+
+		case r.URL.Path == "/repos/owner/repo/issues/30/labels/pilot-in-progress" && r.Method == http.MethodDelete:
+			inProgRemoved = true
+			w.WriteHeader(http.StatusOK)
+
+		case r.URL.Path == "/repos/owner/repo/issues/30" && r.Method == http.MethodPatch:
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["state"] == "closed" {
+				issueClosed = true
+			}
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoMerge = true
+	cfg.AutoReview = false
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	c.activePRs[99] = &PRState{
+		PRNumber:    99,
+		PRURL:       "https://github.com/owner/repo/pull/99",
+		IssueNumber: 30,
+		BranchName:  "pilot/GH-30",
+		HeadSHA:     "sha99",
+		Stage:       StageMerging,
+		CreatedAt:   time.Now(),
+	}
+	c.mu.Unlock()
+
+	if err := c.ProcessPR(context.Background(), 99, nil); err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	pr, _ := c.GetPRState(99)
+	if pr.Stage != StageMerged {
+		t.Errorf("Stage = %s, want %s", pr.Stage, StageMerged)
+	}
+	if !pilotDoneAdded {
+		t.Error("pilot-done must be added after successful merge")
+	}
+	if !issueClosed {
+		t.Error("issue must be closed after successful merge")
+	}
+	if !inProgRemoved {
+		t.Error("pilot-in-progress should be removed after merge")
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause:** `handlers.go` eagerly added `pilot-done` and closed the issue at PR-creation time. When autopilot later detected a merge conflict and closed the PR unmerged, the issue stayed closed with `pilot-done` — code never landed on main, but Pilot won't re-dispatch a closed+done issue (ghost-close, variant 5).
- **Fix:** Remove `AddLabels(pilot-done)` and `UpdateIssueState(closed)` from the `handlers.go` "has deliverables" branch. These operations now happen exclusively in `handleMerging` on successful merge (already present since GH-1015).
- **Conflict path hardened:** `handleMergeConflict` now re-adds the `pilot` label for re-dispatch and guards against stale `pilot-done` being present.

## Changes

| File | What changed |
|------|-------------|
| `cmd/pilot/handlers.go` | Removed eager `pilot-done` add and issue close at PR creation |
| `internal/autopilot/controller.go` | `handleMergeConflict` re-adds `pilot` label + removes `pilot-done` if present |
| `internal/adapters/github/types.go` | Added `LabelPilot = "pilot"` constant |
| `internal/autopilot/controller_merge_test.go` | New tests for conflict (issue stays open) and merge (issue closes) |

## Test plan

- [x] `TestController_MergeConflict_IssueNotGhostClosed` — conflict path: PR closed, issue OPEN, no `pilot-done`, `pilot` label re-added
- [x] `TestController_HandleMerging_ClosesIssueWithPilotDone` — merge path: issue closed, `pilot-done` added
- [x] All existing `TestController_ProcessPR_MergeConflict_*` tests still pass
- [x] Full `./internal/autopilot/...` and `./cmd/pilot/...` suites pass

Closes #3139