### PR TITLE
GH-3139: feat: gate `pilot-done` + issue close on PR merge, not PR creation

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -23,7 +23,6 @@
 | Progress display | ✅ | executor | - | - | Lipgloss visual bar |
 | Navigator detection | ✅ | executor | - | - | Auto-prefix if `.agent/` exists |
 | AGENTS.md loading | ✅ | executor | - | - | LoadAgentsFile reads project AGENTS.md (v0.24.1) |
-| Per-repo workflow override | ✅ | executor/workflow | - | `.pilot/workflow.yaml` | YAML front-matter + Markdown prompt appendix; overrides agent.max_turns, agent.reasoning_effort, policy.* (TASK-304, v2.153.2) |
 | Dry run mode | ✅ | executor | `--dry-run` | - | Show prompt only |
 | Verbose output | ✅ | executor | `--verbose` | - | Stream raw JSON |
 | Task dispatcher | ✅ | executor | - | - | Per-project queue (GH-46) |
@@ -573,3 +572,4 @@ quality:
 | `safeGo()` panic-recovery wrapper | v2.150.x | executor + adapters | All goroutine spawns wrapped (TASK-292) |
 | `IsTaskShipped` predicate | v2.151.x | autopilot | Cross-site invariant preventing double-dispatch (TASK-296 / GH-3091) |
 | Ghost-SHA guard | v2.151.x | executor | Fail-closed when commit_sha already on base branch (TASK-300 / GH-3099) |
+| Gate pilot-done on merge | v2.155.x | autopilot + cmd/pilot | pilot-done + issue close deferred to PR merge; handleMergeConflict re-adds pilot label + guards pilot-done (TASK-301 / GH-3139) |

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -351,13 +351,10 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				// Update issueResult to reflect failure
 				issueResult.Success = false
 			} else {
-				// Has deliverables — add pilot-done immediately to close label gap
-				// GH-1350: Prevents parallel poller re-dispatch race during the window
-				// between execution complete and autopilot merge handler
-				// GH-1015: Autopilot also adds pilot-done after merge (idempotent)
-				if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelDone}); err != nil {
-					logGitHubAPIError("AddLabels", parts[0], parts[1], issue.Number, err)
-				}
+				// Has deliverables — PR created, awaiting merge.
+				// GH-3139/TASK-301: pilot-done + issue close are deferred to merge
+				// (handleMerging in autopilot) so a later merge conflict cannot
+				// ghost-close the issue before any code reaches main.
 				// GH-1869: Move to Review column when PR is created
 				if hr.PRNumber > 0 {
 					syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Review)
@@ -365,7 +362,6 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 					// GH-2099: Auto-assign PR reviewers from project config
 					requestReviewersFromConfig(ctx, cfg, client, sourceRepo, parts[0], parts[1], hr.PRNumber)
 				}
-				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Done) // GH-1853
 
 				// GH-1302/GH-2402: Clean up stale pilot-failed label from prior failed attempt.
 				// Removed unconditionally — the in-memory `issue` object is the snapshot
@@ -374,11 +370,6 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				if err := client.RemoveLabel(ctx, parts[0], parts[1], issue.Number, github.LabelFailed); err != nil {
 					// 404 is expected if label doesn't exist — log at debug level
 					slog.Debug("pilot-failed label cleanup", "issue", issue.Number, "error", err)
-				}
-
-				// Close the issue so dependent issues can proceed
-				if err := client.UpdateIssueState(ctx, parts[0], parts[1], issue.Number, "closed"); err != nil {
-					logGitHubAPIError("UpdateIssueState", parts[0], parts[1], issue.Number, err)
 				}
 
 				comment := buildExecutionComment(hr.Result, branchName)

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -92,6 +92,7 @@ const (
 
 // Label names used by Pilot
 const (
+	LabelPilot              = "pilot"
 	LabelInProgress         = "pilot-in-progress"
 	LabelDone               = "pilot-done"
 	LabelFailed             = "pilot-failed"

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1794,10 +1794,20 @@ func (c *Controller) handleMergeConflict(ctx context.Context, prState *PRState) 
 		c.log.Warn("failed to close conflicting PR", "pr", prState.PRNumber, "error", err)
 	}
 
-	// Remove pilot-in-progress label from the issue so poller can re-pick it
+	// Restore issue to dispatch-ready state after conflict.
+	// GH-3139/TASK-301: issue must remain OPEN with pilot label so the poller
+	// can re-dispatch. Do NOT close the issue or add pilot-done here.
 	if prState.IssueNumber > 0 {
 		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelInProgress); err != nil {
 			c.log.Warn("failed to remove in-progress label", "issue", prState.IssueNumber, "error", err)
+		}
+		// Re-add pilot label so poller can pick up the issue on the next cycle.
+		if err := c.ghClient.AddLabels(ctx, c.owner, c.repo, prState.IssueNumber, []string{github.LabelPilot}); err != nil {
+			c.log.Warn("failed to re-add pilot label on conflict", "issue", prState.IssueNumber, "error", err)
+		}
+		// Guard: remove pilot-done if somehow present — prevents ghost-close.
+		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelDone); err != nil {
+			c.log.Debug("pilot-done cleanup on conflict (may not exist)", "issue", prState.IssueNumber, "error", err)
 		}
 	}
 

--- a/internal/autopilot/controller_merge_test.go
+++ b/internal/autopilot/controller_merge_test.go
@@ -1,0 +1,232 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestController_MergeConflict_IssueNotGhostClosed verifies that when autopilot
+// detects a merge conflict and closes the PR, the associated issue is NOT closed
+// and pilot-done is NOT added. The issue must stay open for re-dispatch.
+// GH-3139 / TASK-301.
+func TestController_MergeConflict_IssueNotGhostClosed(t *testing.T) {
+	var (
+		pilotDoneAdded   bool
+		pilotLabelAdded  bool
+		pilotDoneRemoved bool
+		issueClosed      bool
+		prClosed         bool
+		inProgressRemoved bool
+	)
+
+	mergeable := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/55" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:         55,
+				Head:           github.PRRef{SHA: "sha55"},
+				Mergeable:      &mergeable,
+				MergeableState: "dirty",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/55/update-branch" && r.Method == http.MethodPut:
+			// Auto-rebase fails → true conflict path
+			w.WriteHeader(http.StatusUnprocessableEntity)
+
+		case r.URL.Path == "/repos/owner/repo/issues/55/comments" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.PRComment{ID: 1})
+
+		case r.URL.Path == "/repos/owner/repo/pulls/55" && r.Method == http.MethodPatch:
+			prClosed = true
+			w.WriteHeader(http.StatusOK)
+
+		case r.URL.Path == "/repos/owner/repo/issues/20/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for _, l := range body["labels"] {
+				if l == github.LabelDone {
+					pilotDoneAdded = true
+				}
+				if l == github.LabelPilot {
+					pilotLabelAdded = true
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+
+		case r.URL.Path == "/repos/owner/repo/issues/20/labels/pilot-in-progress" && r.Method == http.MethodDelete:
+			inProgressRemoved = true
+			w.WriteHeader(http.StatusOK)
+
+		case r.URL.Path == "/repos/owner/repo/issues/20/labels/pilot-done" && r.Method == http.MethodDelete:
+			pilotDoneRemoved = true
+			w.WriteHeader(http.StatusOK)
+
+		case r.URL.Path == "/repos/owner/repo/issues/20" && r.Method == http.MethodPatch:
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["state"] == "closed" {
+				issueClosed = true
+			}
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	c.activePRs[55] = &PRState{
+		PRNumber:    55,
+		PRURL:       "https://github.com/owner/repo/pull/55",
+		IssueNumber: 20,
+		BranchName:  "pilot/GH-20",
+		HeadSHA:     "sha55",
+		Stage:       StageWaitingCI,
+		CIStatus:    CIPending,
+		CIWaitStartedAt: time.Now(),
+		CreatedAt:   time.Now(),
+	}
+	c.mu.Unlock()
+
+	err := c.ProcessPR(context.Background(), 55, nil)
+	if err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	pr, _ := c.GetPRState(55)
+	if pr.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", pr.Stage, StageFailed)
+	}
+	if !prClosed {
+		t.Error("conflicting PR should have been closed")
+	}
+	if !inProgressRemoved {
+		t.Error("pilot-in-progress should be removed from issue")
+	}
+	if pilotDoneAdded {
+		t.Error("pilot-done must NOT be added on conflict — ghost-close guard (GH-3139)")
+	}
+	if issueClosed {
+		t.Error("issue must NOT be closed on conflict — ghost-close guard (GH-3139)")
+	}
+	if !pilotLabelAdded {
+		t.Error("pilot label should be re-added to issue for re-dispatch")
+	}
+	if !pilotDoneRemoved {
+		t.Error("pilot-done cleanup should be attempted on conflict (may be 404 — that is OK)")
+	}
+}
+
+// TestController_HandleMerging_ClosesIssueWithPilotDone verifies that when a PR
+// is successfully merged, the associated issue is closed and pilot-done is added.
+// GH-3139 / TASK-301: this is the only path that should close the issue.
+func TestController_HandleMerging_ClosesIssueWithPilotDone(t *testing.T) {
+	var (
+		pilotDoneAdded  bool
+		issueClosed     bool
+		inProgRemoved   bool
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/sha99/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/99/merge" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"mergedSHA","merged":true,"message":"merged"}`))
+
+		case r.URL.Path == "/repos/owner/repo/issues/30/labels" && r.Method == http.MethodPost:
+			var body map[string][]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for _, l := range body["labels"] {
+				if l == github.LabelDone {
+					pilotDoneAdded = true
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{})
+
+		case r.URL.Path == "/repos/owner/repo/issues/30/labels/pilot-in-progress" && r.Method == http.MethodDelete:
+			inProgRemoved = true
+			w.WriteHeader(http.StatusOK)
+
+		case r.URL.Path == "/repos/owner/repo/issues/30" && r.Method == http.MethodPatch:
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["state"] == "closed" {
+				issueClosed = true
+			}
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoMerge = true
+	cfg.AutoReview = false
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	c.activePRs[99] = &PRState{
+		PRNumber:    99,
+		PRURL:       "https://github.com/owner/repo/pull/99",
+		IssueNumber: 30,
+		BranchName:  "pilot/GH-30",
+		HeadSHA:     "sha99",
+		Stage:       StageMerging,
+		CreatedAt:   time.Now(),
+	}
+	c.mu.Unlock()
+
+	if err := c.ProcessPR(context.Background(), 99, nil); err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	pr, _ := c.GetPRState(99)
+	if pr.Stage != StageMerged {
+		t.Errorf("Stage = %s, want %s", pr.Stage, StageMerged)
+	}
+	if !pilotDoneAdded {
+		t.Error("pilot-done must be added after successful merge")
+	}
+	if !issueClosed {
+		t.Error("issue must be closed after successful merge")
+	}
+	if !inProgRemoved {
+		t.Error("pilot-in-progress should be removed after merge")
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3139.

Closes #3139

## Changes

GitHub Issue #3139: TASK-301: Gate `pilot-done` + issue close on PR merge, not PR creation

## Wave 4 · Effort: M (~4h) · Severity: P1

**Source:** ghost-close incident 2026-05-26 (Variant 5 in \`.agent/knowledge/memories/pitfalls/bug_pilot_ghost_closes.md\`). Recurred today on PR #3116 (TASK-300) — the fix for ghost-SHA was itself ghost-closed by this exact bug.

## Problem

\`pilot-done\` label and issue closure fire eagerly at \`cmd/pilot/handlers.go:354-382\` when \`IsResultShipped(result)\` returns true at PR-creation time. This is BEFORE merge.

When autopilot later detects a merge conflict at \`internal/autopilot/controller.go:1766-1806\` (\`handleMergeConflict\`):
- Line 1787: posts conflict comment
- Line 1793: closes the **PR**
- Line 1799: removes \`pilot-in-progress\` from the **issue**
- **Does NOT remove \`pilot-done\`, does NOT reopen issue**

Steady-state outcome: issue closed with \`pilot-done\`, PR closed without merge, code never on main. Pilot worker won't re-pick because issue is in CLOSED+pilot-done state.

**Today's recurrence (PR #3116, TASK-300):** CI test failed legitimately, PR closed unmerged → issue #3112 still went to \`pilot-done\` despite no merge. Required manual reopen + redo as fresh issue #3126.

## Approach (Option A — preferred, structural)

### Step 1 — Find merge-success handler (~30 min)

Grep \`internal/autopilot/controller.go\` for \`MergedAt\`, \`IsMerged\`, \`removePR\`. Identify where successful merges are observed in the poll loop (likely near \`handleMerging\` or in \`checkExternalMergeOrClose\`).

### Step 2 — Move label/close logic (~60 min)

Extract helper \`markIssueShipped(issue, prURL)\` that adds \`pilot-done\` + closes the issue. Call from merge-success handler ONLY. Remove eager call in \`handlers.go:354-382\` — keep only \`pilot-in-progress\` removal there.

### Step 3 — Update conflict path (~30 min)

\`handleMergeConflict\` (\`controller.go:1766-1806\`) keeps \`pilot\` label on issue, re-adds it if missing. Does NOT touch issue's open/closed state — issue stays open for re-dispatch.

### Step 4 — Tests (~90 min)

- Unit: \`markIssueShipped\` adds label + closes (mock GitHub)
- Integration: simulate PR-open → conflict-detected → assert issue stays OPEN with \`pilot\` label, no \`pilot-done\`
- Integration: simulate PR-open → merged → assert issue closes with \`pilot-done\`

### Step 5 — Backfill recovery doc (~15 min)

Document \`bin/pilot ghost-recovery\` operator command or manual gh script for existing ghost-closed issues (pattern already in \`bug_pilot_ghost_closes.md\` \"How to recover\" section).

## Option B (conservative, leaves the race intact)

Less invasive: in \`handleMergeConflict\` line 1799, add:
\`\`\`go
gh.RemoveLabel(issue, \"pilot-done\")
gh.AddLabel(issue, \"pilot\")
gh.ReopenIssue(issue)  // only if .State == closed
\`\`\`

Less correct but smaller change surface. Use ONLY if Option A is blocked by complexity.

## Files

- \`cmd/pilot/handlers.go\` (remove eager close at 354-382)
- \`internal/autopilot/controller.go\` (merge-success path adds \`pilot-done\` + close; merge-conflict path preserves \`pilot\` label)
- New: \`internal/autopilot/controller_merge_test.go\` (or extend existing)

## Coordination with TASK-300

Both TASK-300 and TASK-301 must land for the ghost-close cycle to close completely. TASK-300 prevents the *parent-SHA* ghost; TASK-301 prevents the *post-creation-conflict* ghost. Either alone leaves a vulnerable variant.

## Pre-PR verification (Pilot, MUST run)

\`\`\`bash
git rev-parse HEAD                                       # NOT on origin/main
git merge-base --is-ancestor HEAD origin/main; echo \$?    # prints 1
git log --oneline origin/main..HEAD                       # shows your commits
go test ./internal/autopilot/... ./cmd/pilot/... -count=1 -v   # all PASS
\`\`\`

## Out of scope

- Per-task-file lock against docs-version-sync (separate enhancement)
- Backfill of existing ghost-closed issues (operational, not code)

Full plan: \`.agent/tasks/TASK-301-autopilot-done-on-merge.md\`