### PR TITLE
fix(executor): ghost-SHA guard + IsTaskShipped hardening (TASK-300)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -571,5 +571,4 @@ quality:
 | Repo allowlist Phase B | v2.149.0 | adapters/github | `CreatePilotIssue` validates against allowlist (GH-3047) |
 | `safeGo()` panic-recovery wrapper | v2.150.x | executor + adapters | All goroutine spawns wrapped (TASK-292) |
 | `IsTaskShipped` predicate | v2.151.x | autopilot | Cross-site invariant preventing double-dispatch (TASK-296 / GH-3091) |
-| Ghost-SHA guard | v2.151.x | executor | Fail-closed when commit_sha already on base branch (TASK-300 / GH-3099) |
-| Gate pilot-done on merge | v2.155.x | autopilot + cmd/pilot | pilot-done + issue close deferred to PR merge; handleMergeConflict re-adds pilot label + guards pilot-done (TASK-301 / GH-3139) |
+| Ghost-SHA guard | v2.155.x | executor | `commitSHAIsNew` blocks parent-SHA ghost-closes; `IsTaskShipped` requires error="" for SHA-only trust; orphan-recovery divergence resolved (TASK-300 / GH-3126) |

--- a/internal/executor/git_freshness.go
+++ b/internal/executor/git_freshness.go
@@ -1,0 +1,27 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// commitSHAIsNew returns true iff sha exists in the repo AND is NOT an ancestor of
+// origin/<baseBranch>. A SHA already reachable from the base branch is a parent SHA —
+// proof the executor made no new commit. Returns false (not new) on empty sha.
+func commitSHAIsNew(ctx context.Context, repoPath, sha, baseBranch string) (bool, error) {
+	if sha == "" {
+		return false, nil
+	}
+	// `git merge-base --is-ancestor SHA origin/BASE` exits 0 when SHA is an ancestor of BASE.
+	// We want the opposite: exit 1 means SHA is NOT an ancestor — it's a fresh commit.
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "merge-base", "--is-ancestor", sha, "origin/"+baseBranch)
+	err := cmd.Run()
+	if err == nil {
+		return false, nil // exit 0: SHA is ancestor of base — parent SHA, not fresh
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+		return true, nil // exit 1: SHA is not ancestor — fresh commit
+	}
+	return false, fmt.Errorf("merge-base check failed: %w", err)
+}

--- a/internal/executor/git_freshness_test.go
+++ b/internal/executor/git_freshness_test.go
@@ -1,0 +1,89 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupFreshnessRepo creates a git repo with an initial commit on `main` and a bare
+// remote, then pushes main so origin/main exists as a remote-tracking ref.
+// Returns (repoDir, bareDir).
+func setupFreshnessRepo(t *testing.T) (string, string) {
+	t.Helper()
+
+	bareDir := t.TempDir()
+	runGit(t, bareDir, "init", "--bare", "-b", "main")
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-b", "main")
+	runGit(t, repoDir, "config", "user.email", "test@test.com")
+	runGit(t, repoDir, "config", "user.name", "Test User")
+	runGit(t, repoDir, "commit", "--allow-empty", "-m", "initial")
+	runGit(t, repoDir, "remote", "add", "origin", bareDir)
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+
+	return repoDir, bareDir
+}
+
+func TestCommitSHAIsNew(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty SHA returns false", func(t *testing.T) {
+		repoDir, _ := setupFreshnessRepo(t)
+		isNew, err := commitSHAIsNew(ctx, repoDir, "", "main")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if isNew {
+			t.Error("expected false for empty SHA, got true")
+		}
+	})
+
+	t.Run("SHA already on main returns false (ghost-SHA pattern)", func(t *testing.T) {
+		repoDir, _ := setupFreshnessRepo(t)
+		sha := gitOutput(t, repoDir, "rev-parse", "HEAD")
+		sha = sha[:len(sha)-1] // trim trailing newline from gitOutput
+		if len(sha) > 0 && sha[len(sha)-1] == '\n' {
+			sha = sha[:len(sha)-1]
+		}
+		isNew, err := commitSHAIsNew(ctx, repoDir, sha, "main")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if isNew {
+			t.Errorf("expected false for SHA %s already on main, got true", sha[:7])
+		}
+	})
+
+	t.Run("SHA on feature branch ahead of main returns true", func(t *testing.T) {
+		repoDir, _ := setupFreshnessRepo(t)
+
+		runGit(t, repoDir, "checkout", "-b", "feat/new-work")
+		featureFile := filepath.Join(repoDir, "work.txt")
+		if err := os.WriteFile(featureFile, []byte("new work"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, repoDir, "add", "work.txt")
+		runGit(t, repoDir, "commit", "-m", "feat: new work")
+
+		sha := gitOutput(t, repoDir, "rev-parse", "HEAD")
+		sha = sha[:len(sha)-1]
+		isNew, err := commitSHAIsNew(ctx, repoDir, sha, "main")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !isNew {
+			t.Errorf("expected true for SHA %s on feature branch ahead of main, got false", sha[:7])
+		}
+	})
+
+	t.Run("non-existent SHA returns error", func(t *testing.T) {
+		repoDir, _ := setupFreshnessRepo(t)
+		_, err := commitSHAIsNew(ctx, repoDir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "main")
+		if err == nil {
+			t.Error("expected error for non-existent SHA, got nil")
+		}
+	})
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2318,6 +2318,38 @@ retrySucceeded:
 		}
 	}
 
+	// GH-3126: Ghost-SHA guard — reject SHAs that are already on the base branch.
+	// When Claude makes no new commit, git log returns the parent (pre-execution) SHA.
+	// Recording that as CommitSHA causes IsTaskShipped to return true on a no-op run,
+	// triggering pilot-done + issue close with no actual work delivered.
+	// Fail open on check errors (e.g. no origin configured in test repos): only reject
+	// when the check conclusively shows the SHA is already on origin/<base>.
+	if result.CommitSHA != "" && result.Success {
+		ghostBase := task.BaseBranch
+		if ghostBase == "" {
+			ghostBase, _ = git.GetDefaultBranch(ctx)
+			if ghostBase == "" {
+				ghostBase = "main"
+			}
+		}
+		if isNew, checkErr := commitSHAIsNew(ctx, executionPath, result.CommitSHA, ghostBase); checkErr != nil {
+			log.Warn("executor: ghost-SHA check skipped (will not block)",
+				slog.String("task_id", task.ID),
+				slog.String("sha", result.CommitSHA[:min(7, len(result.CommitSHA))]),
+				slog.Any("error", checkErr),
+			)
+		} else if !isNew {
+			log.Warn("executor: harvested SHA is already on base branch — no new commit",
+				slog.String("task_id", task.ID),
+				slog.String("sha", result.CommitSHA[:min(7, len(result.CommitSHA))]),
+				slog.String("base", ghostBase),
+			)
+			result.CommitSHA = ""
+			result.Success = false
+			result.Error = "no new commit produced — worktree HEAD matches base branch parent"
+		}
+	}
+
 	// Fill in additional metrics from state
 	result.FilesChanged = state.filesWrite
 	result.CacheCreationInputTokens = state.cacheCreationInputTokens
@@ -3207,6 +3239,31 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					slog.String("task_id", task.ID),
 					slog.Any("error", pushErr),
 				)
+			}
+
+			// GH-3126: Defense-in-depth ghost-SHA guard after push.
+			// The pre-push guard above clears parent SHAs, but re-check here since
+			// post-push SHA is the authoritative value that flows into autopilot CI polling.
+			// Fail open on errors (missing origin ref) — only block on conclusive stale result.
+			if result.CommitSHA != "" {
+				if isNew, checkErr := commitSHAIsNew(ctx, executionPath, result.CommitSHA, baseBranch); checkErr != nil {
+					log.Warn("executor: post-push ghost-SHA check skipped (will not block)",
+						slog.String("task_id", task.ID),
+						slog.String("sha", result.CommitSHA[:min(7, len(result.CommitSHA))]),
+						slog.Any("error", checkErr),
+					)
+				} else if !isNew {
+					log.Warn("executor: post-push SHA is already on base branch — aborting PR creation",
+						slog.String("task_id", task.ID),
+						slog.String("sha", result.CommitSHA[:min(7, len(result.CommitSHA))]),
+						slog.String("base", baseBranch),
+					)
+					result.CommitSHA = ""
+					result.Success = false
+					result.Error = "no new commit produced — post-push SHA matches base branch"
+					r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+					return result, nil
+				}
 			}
 
 			r.reportProgress(task.ID, "Creating PR", 98, "Creating pull request...")

--- a/internal/executor/task_completion_invariant_test.go
+++ b/internal/executor/task_completion_invariant_test.go
@@ -65,16 +65,15 @@ func TestTaskCompletionInvariant(t *testing.T) {
 			wantShipped: false,
 		},
 		{
-			// Orphan-recovery row: status=completed with error, and a commit. HasCompletedExecution
-			// excludes error!='' rows (GH-2315), so it returns false. IsTaskShipped ignores the
-			// error field — it only checks status+deliverables. These diverge intentionally:
-			// the SQL guard is for dispatch decisions (conservative), the Go predicate is for
-			// post-flight label checks. This case is documented here so future maintainers
-			// know the divergence is expected, not a bug.
-			// Skipped from the invariant loop — see comment below.
-			name:        "orphan-recovery (known divergence, not in invariant loop)",
+			// GH-3126: orphan-recovery rows are no longer a divergence between IsTaskShipped and
+			// HasCompletedExecution. Both now return false for error!='' rows without a pr_url:
+			// - HasCompletedExecution SQL excludes error!='' (GH-2315 guard)
+			// - IsTaskShipped requires error=='' for CommitSHA-only trust (GH-3126 hardening)
+			// This closes the ghost-SHA ghost-close variant where a parent SHA was accepted as proof
+			// of shipped work.
+			name:        "orphan-recovery: completed with error and commit_sha only (not shipped)",
 			exec:        memory.Execution{ID: "inv-7", TaskID: "GH-999", ProjectPath: "/proj", Status: "completed", Error: "stale running task recovered", CommitSHA: "xyz"},
-			wantShipped: true, // IsTaskShipped returns true; HasCompletedExecution returns false
+			wantShipped: false,
 		},
 	}
 
@@ -84,15 +83,8 @@ func TestTaskCompletionInvariant(t *testing.T) {
 		}
 	}
 
-	// Invariant check: for each non-divergence row, IsTaskShipped and HasCompletedExecution must agree.
+	// Invariant check: IsTaskShipped and HasCompletedExecution must agree on every row.
 	for _, tc := range rows {
-		if tc.exec.ID == "inv-7" {
-			// Known intentional divergence: orphan-recovery rows with deliverables.
-			// IsTaskShipped=true, HasCompletedExecution=false (excludes error!='').
-			// Verified separately below.
-			continue
-		}
-
 		t.Run(tc.name, func(t *testing.T) {
 			goResult := IsTaskShipped(tc.exec)
 			sqlResult, err := store.HasCompletedExecution(tc.exec.TaskID, tc.exec.ProjectPath)
@@ -112,20 +104,4 @@ func TestTaskCompletionInvariant(t *testing.T) {
 			}
 		})
 	}
-
-	// Verify the known divergence for orphan-recovery rows.
-	t.Run("orphan-recovery divergence is expected", func(t *testing.T) {
-		orphan := rows[len(rows)-1].exec
-		goResult := IsTaskShipped(orphan)
-		sqlResult, err := store.HasCompletedExecution(orphan.TaskID, orphan.ProjectPath)
-		if err != nil {
-			t.Fatalf("HasCompletedExecution: %v", err)
-		}
-		if !goResult {
-			t.Errorf("IsTaskShipped should be true for completed+deliverable row (ignores error field), got false")
-		}
-		if sqlResult {
-			t.Errorf("HasCompletedExecution should be false for error!='' row (GH-2315 guard), got true")
-		}
-	})
 }

--- a/internal/executor/task_shipped.go
+++ b/internal/executor/task_shipped.go
@@ -1,15 +1,27 @@
 package executor
 
-import "github.com/qf-studio/pilot/internal/memory"
+import (
+	"log/slog"
 
-// IsTaskShipped reports whether an execution row represents real shipped work:
-// status must be "completed" AND at least one deliverable (commit_sha or pr_url) must be set.
-// Epic-parent rows (status=completed, no deliverable) correctly return false — sub-issues own the work.
-// This predicate mirrors the SQL filter in HasCompletedExecution; the cross-site invariant test
-// in internal/integration ensures both always agree.
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// IsTaskShipped reports whether an execution row represents real shipped work.
+// PRUrl is the primary signal — it proves a PR was opened against the remote.
+// CommitSHA alone is accepted for backwards-compat (direct-commit workflows) but
+// logs a warning because it can be a parent SHA if the ghost-SHA guard was bypassed.
+// Epic-parent rows (status=completed, no deliverable) correctly return false.
 func IsTaskShipped(row memory.Execution) bool {
 	if row.Status != "completed" {
 		return false
 	}
-	return row.CommitSHA != "" || row.PRUrl != ""
+	if row.PRUrl != "" {
+		return true
+	}
+	if row.CommitSHA != "" && row.Error == "" {
+		slog.Warn("IsTaskShipped: trusting CommitSHA without PRUrl — verify freshness",
+			"sha", row.CommitSHA)
+		return true
+	}
+	return false
 }

--- a/internal/executor/task_shipped_test.go
+++ b/internal/executor/task_shipped_test.go
@@ -13,18 +13,18 @@ func TestIsTaskShipped(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "completed with commit_sha",
-			row:  memory.Execution{Status: "completed", CommitSHA: "abc123"},
-			want: true,
-		},
-		{
-			name: "completed with pr_url",
+			name: "completed with pr_url (primary signal)",
 			row:  memory.Execution{Status: "completed", PRUrl: "https://github.com/x/y/pull/1"},
 			want: true,
 		},
 		{
 			name: "completed with both commit_sha and pr_url",
 			row:  memory.Execution{Status: "completed", CommitSHA: "abc123", PRUrl: "https://github.com/x/y/pull/1"},
+			want: true,
+		},
+		{
+			name: "completed with commit_sha only and no error (backwards-compat direct-commit path)",
+			row:  memory.Execution{Status: "completed", CommitSHA: "abc123"},
 			want: true,
 		},
 		{
@@ -53,8 +53,19 @@ func TestIsTaskShipped(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "completed with error and commit_sha (orphan recovery)",
+			// GH-3126: orphan-recovery rows have a non-empty Error field.
+			// IsTaskShipped now requires Error=="" for CommitSHA-only trust — consistent with
+			// HasCompletedExecution SQL which also excludes error!='' rows. Previously these
+			// two sites diverged; now both return false, eliminating the known divergence.
+			name: "completed with error and commit_sha but no pr_url (orphan recovery — not shipped)",
 			row:  memory.Execution{Status: "completed", Error: "stale running task recovered", CommitSHA: "abc123"},
+			want: false,
+		},
+		{
+			// A row with both pr_url and an error IS still considered shipped: the PR was created,
+			// the error may be from a post-PR step (e.g. comment failed). PRUrl is the primary signal.
+			name: "completed with error and pr_url (PR created despite error)",
+			row:  memory.Execution{Status: "completed", Error: "comment failed", PRUrl: "https://github.com/x/y/pull/2"},
 			want: true,
 		},
 	}


### PR DESCRIPTION
## Summary

- **`internal/executor/git_freshness.go`** — new `commitSHAIsNew` helper: runs `git merge-base --is-ancestor SHA origin/<base>` to detect when the captured commit SHA is already reachable from the base branch (parent-SHA ghost pattern that caused #3090 ghost-close)
- **`internal/executor/runner.go`** — two guard sites (pre-push and post-push); fail-open on git errors (no remote configured) but block conclusively stale SHAs with `result.Success = false`
- **`internal/executor/task_shipped.go`** — `IsTaskShipped` now requires `Error == ""` for CommitSHA-only trust, making it consistent with `HasCompletedExecution` SQL; orphan-recovery divergence eliminated
- **`internal/executor/git_freshness_test.go`** — corrected test fixture: `git init -b main` + `--allow-empty` initial commit + push to bare remote before testing ancestor checks (fixes the "src refspec main does not match any" failure from the original #3112)

## Test plan

- [ ] `go test ./internal/executor/... -run TestCommitSHAIsNew -count=1 -v` — all 4 sub-tests pass
- [ ] `go test ./internal/executor/... -run TestIsTaskShipped -count=1 -v` — all 10 sub-tests pass
- [ ] `go test ./internal/executor/... -run TestTaskCompletionInvariant -count=1 -v` — all 7 sub-tests pass, no divergence sub-test (it was removed since orphan-recovery no longer diverges)
- [ ] `go test ./internal/executor/... -count=1` — full suite passes

Closes #3126