### PR TITLE
fix(bench): prevent OAuth token leak in Harbor submission artifacts

### DIFF
--- a/pilot-bench/pilot_agent/agent.py
+++ b/pilot-bench/pilot_agent/agent.py
@@ -247,12 +247,19 @@ VERIFICATION PROTOCOL (mandatory before finishing):
                 fcntl.flock(lock, fcntl.LOCK_UN)
 
     def _build_env(self) -> dict[str, str]:
-        """Collect auth environment variables."""
+        """Collect non-secret env vars to pass to the agent subprocess.
+
+        WARNING: keys here are serialized verbatim into Harbor's
+        config.json / result.json (AgentConfig.env is a plain dict with
+        no masking) and end up in committed/published submission
+        artifacts. NEVER add auth tokens here. The subprocess inherits
+        ambient secrets (ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN,
+        CLAUDE_CODE_OAUTH_TOKEN) automatically — they just must not be
+        captured into this serialized dict.
+        """
         env: dict[str, str] = {}
         for key in [
-            "ANTHROPIC_API_KEY",
-            "PILOT_ENGINE_API_KEY",
-            "CLAUDE_CODE_OAUTH_TOKEN",
+            "PILOT_ENGINE_API_KEY",  # non-secret routing key, safe to record
         ]:
             if key in os.environ:
                 env[key] = os.environ[key]


### PR DESCRIPTION
## Summary

Harbor serializes `AgentConfig.env` verbatim into committed `config.json` / `result.json` submission artifacts. Three keys were being captured into that serialized dict — `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, and `PILOT_ENGINE_API_KEY` — meaning OAuth/API tokens were being published to public benchmark submissions.

This commit restricts `_build_env` to non-secret routing keys only (just `PILOT_ENGINE_API_KEY`, which is a router identifier, not a credential) and adds a prominent WARNING in the docstring explaining the constraint. The subprocess still inherits ambient secrets via process env — they just must not be captured into the serialized config dict.

## Reconciliation context

This is the original commit `4e518eef` from the now-abandoned `feat/custom-engine` branch, cherry-picked onto main during Wave 4 reconciliation. Salvaged because the underlying bug is still present on main.

## Test plan
- [ ] Run a Harbor submission and inspect generated `config.json` — verify no `ANTHROPIC_*` / `*OAUTH*` keys are present in `env`
- [ ] Confirm the subprocess still has access to `ANTHROPIC_API_KEY` via process env (inheritance still works)