### PR TITLE
docs(.agent/drafts): preserve Wave 5 engine + hooks drafts for Pilot

### DIFF
--- a/.agent/drafts/README.md
+++ b/.agent/drafts/README.md
@@ -1,0 +1,16 @@
+# Drafts — for Pilot pickup
+
+Half-baked code dropped here during Wave 4/5 reconciliation. **Don't import — these compile against an older codebase and need adaptation before they're useful.**
+
+Each subdirectory corresponds to a GH issue that hands the work to Pilot. The issue references the drafts as starting points so Pilot doesn't reimplement from scratch.
+
+## Conventions
+
+- `task-NNN-slug/` per draft, named after the task ID
+- Include the task doc (`TASK-NNN-*.md`) alongside the code so context travels with it
+- Once Pilot ships the real implementation, **delete the corresponding subdirectory** in the same PR that lands the code
+
+## Current contents
+
+- `task-312-engine/` — Go OpenRouter execution engine. ~33KB. All non-smoke tests pass standalone; needs `backend_factory.go` wire-up (~5 LOC) for `TestBackendFactory_RegistersOpenRouter` to pass.
+- `task-305-hooks/` — workflow lifecycle hook execution. Compile-breaks against current `internal/executor/workflow/workflow.go` because `HookConfig` fields are now `interface{}` on main and `HookValue` type was never landed. Needs adaptation: define `HookValue`, write a normalizer from `interface{}`, wire `RunHook`.

--- a/.agent/drafts/task-305-hooks/hooks.go
+++ b/.agent/drafts/task-305-hooks/hooks.go
@@ -1,0 +1,66 @@
+// Package workflow — lifecycle hook execution. TASK-305.
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// DefaultHookTimeout is the per-hook timeout when none is configured.
+const DefaultHookTimeout = 300 * time.Second
+
+// RunHook executes the scripts in scripts sequentially via bash -lc in dir.
+// env entries (KEY=VALUE) are appended to the inherited process environment.
+// logFn receives combined stdout/stderr per script execution; may be nil.
+// Returns the first non-zero-exit error; remaining scripts are not executed.
+// A nil/empty scripts slice is a no-op.
+func RunHook(ctx context.Context, name string, scripts HookValue, dir string, env []string, timeout time.Duration, logFn func(string)) error {
+	if len(scripts) == 0 {
+		return nil
+	}
+	if timeout <= 0 {
+		timeout = DefaultHookTimeout
+	}
+	for i, script := range scripts {
+		if script == "" {
+			continue
+		}
+		hookCtx, cancel := context.WithTimeout(ctx, timeout)
+		err := execScript(hookCtx, name, i, script, dir, env, logFn)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("hook %s[%d]: %w", name, i, err)
+		}
+	}
+	return nil
+}
+
+// BuildHookEnv returns the standard env vars injected into every hook process.
+func BuildHookEnv(taskID, branch, issueURL, worktreePath string) []string {
+	return []string{
+		"PILOT_TASK_ID=" + taskID,
+		"PILOT_BRANCH=" + branch,
+		"PILOT_ISSUE_URL=" + issueURL,
+		"PILOT_WORKTREE=" + worktreePath,
+	}
+}
+
+func execScript(ctx context.Context, name string, idx int, script, dir string, env []string, logFn func(string)) error {
+	cmd := exec.CommandContext(ctx, "bash", "-lc", script)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), env...)
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	err := cmd.Run()
+	if output := buf.String(); output != "" && logFn != nil {
+		logFn(fmt.Sprintf("[hook:%s] %s", name, output))
+	}
+	return err
+}

--- a/.agent/drafts/task-305-hooks/hooks_test.go
+++ b/.agent/drafts/task-305-hooks/hooks_test.go
@@ -1,0 +1,132 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunHook_Empty(t *testing.T) {
+	err := RunHook(context.Background(), "after_create", nil, t.TempDir(), nil, 0, nil)
+	if err != nil {
+		t.Fatalf("expected nil for empty scripts, got %v", err)
+	}
+}
+
+func TestRunHook_SingleScript(t *testing.T) {
+	dir := t.TempDir()
+	var logs []string
+	err := RunHook(context.Background(), "after_create",
+		HookValue{"echo hello"},
+		dir, nil, DefaultHookTimeout,
+		func(s string) { logs = append(logs, s) },
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(logs) == 0 || !strings.Contains(logs[0], "hello") {
+		t.Errorf("expected log with 'hello', got %v", logs)
+	}
+}
+
+func TestRunHook_ListScripts(t *testing.T) {
+	dir := t.TempDir()
+	var logs []string
+	err := RunHook(context.Background(), "before_run",
+		HookValue{"echo first", "echo second"},
+		dir, nil, DefaultHookTimeout,
+		func(s string) { logs = append(logs, s) },
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	combined := strings.Join(logs, "\n")
+	if !strings.Contains(combined, "first") || !strings.Contains(combined, "second") {
+		t.Errorf("expected both outputs, got %v", logs)
+	}
+}
+
+func TestRunHook_FailureAbortsEarly(t *testing.T) {
+	dir := t.TempDir()
+	ran := false
+	err := RunHook(context.Background(), "after_create",
+		HookValue{"exit 1", "echo should-not-run"},
+		dir, nil, DefaultHookTimeout,
+		func(s string) { ran = ran || strings.Contains(s, "should-not-run") },
+	)
+	if err == nil {
+		t.Fatal("expected error for exit 1, got nil")
+	}
+	if ran {
+		t.Error("second script should not have run after first failed")
+	}
+}
+
+func TestRunHook_EnvVars(t *testing.T) {
+	dir := t.TempDir()
+	var logs []string
+	env := BuildHookEnv("GH-42", "pilot/GH-42", "https://example.com/issues/42", dir)
+	err := RunHook(context.Background(), "before_run",
+		HookValue{"echo TASK=$PILOT_TASK_ID BRANCH=$PILOT_BRANCH"},
+		dir, env, DefaultHookTimeout,
+		func(s string) { logs = append(logs, s) },
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	combined := strings.Join(logs, "\n")
+	if !strings.Contains(combined, "GH-42") || !strings.Contains(combined, "pilot/GH-42") {
+		t.Errorf("expected env vars in output, got %v", logs)
+	}
+}
+
+func TestRunHook_Timeout(t *testing.T) {
+	dir := t.TempDir()
+	err := RunHook(context.Background(), "after_create",
+		HookValue{"sleep 10"},
+		dir, nil, 50*time.Millisecond, nil,
+	)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+func TestHookValue_UnmarshalYAML_String(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".pilot/workflow.yaml", `---
+version: 1
+hooks:
+  after_create: "mise install"
+---
+`)
+	wf, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(wf.Hooks.AfterCreate) != 1 || wf.Hooks.AfterCreate[0] != "mise install" {
+		t.Errorf("expected [mise install], got %v", wf.Hooks.AfterCreate)
+	}
+}
+
+func TestHookValue_UnmarshalYAML_List(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".pilot/workflow.yaml", `---
+version: 1
+hooks:
+  before_run:
+    - mise install
+    - npm ci
+---
+`)
+	wf, err := Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(wf.Hooks.BeforeRun) != 2 {
+		t.Fatalf("expected 2 scripts, got %d: %v", len(wf.Hooks.BeforeRun), wf.Hooks.BeforeRun)
+	}
+	if wf.Hooks.BeforeRun[0] != "mise install" || wf.Hooks.BeforeRun[1] != "npm ci" {
+		t.Errorf("unexpected scripts: %v", wf.Hooks.BeforeRun)
+	}
+}

--- a/.agent/drafts/task-312-engine/TASK-312-engine-go-openrouter.md
+++ b/.agent/drafts/task-312-engine/TASK-312-engine-go-openrouter.md
@@ -1,0 +1,138 @@
+# TASK-312: `engine.go` — OpenRouter-only execution engine
+
+**Status**: ✅ complete — engine.go + tests landed, smoke verified against live OR
+**Branch**: `feat/custom-engine`
+**Created**: 2026-05-26
+**Completed**: 2026-05-26
+**Depends on**: TASK-310 (spike findings → `system/openrouter-quirks.md`)
+**Blocks**: backend deletes, bench wiring, factory collapse
+
+## Outcome
+
+- `internal/executor/engine.go` (~700 LOC) — new Backend implementation targeting `openrouter.ai/api/v1/chat/completions`
+- `internal/executor/engine_test.go` (~500 LOC, 22 tests) — full coverage of construction, factory wiring, SSE parsing (incl. parallel tool calls + stream errors), HTTP retry on 429 with backoff override, end-to-end via `httptest.Server`, tool dispatch, smoke gated by `OPENROUTER_API_KEY`
+- `BackendTypeOpenRouter = "openrouter"` registered in `backend_factory.go` (additive — existing backends untouched in this PR per the agreed phasing)
+- Live smoke against OR pool key: ✅ HTTP+SSE round-trip, cost reported, `cache_read=0` (confirms spike finding on non-BYOK path)
+- All existing executor tests still green (`ok  internal/executor  99.596s`)
+
+## Key implementation details
+- Cache_control on system content block with `ttl:"1h"`
+- No default `provider.order` (preserves OR sticky cache routing)
+- `reasoning: {effort}` field, progressive: high for first 8 turns, medium after; opts.Effort overrides
+- One-time WARN log if `cached_tokens` stays 0 for 5+ turns (nudge for BYOK setup)
+- Exit fast on 402 (credit cap) with `ErrorType: "api_error"`
+- Tools: bash, read_file, write_file, edit_file — ported from `backend_anthropic.go` with `engine*` prefix to avoid package-local collision (will rename cleanly in TASK-315 when old backends are deleted)
+
+## Follow-ups
+- TASK-313 — port claw-code `bash_validation` (6 submodules) into `engineExecBash`
+- TASK-314 — port claw-code `file_ops` guards into `engineExecReadFile`/`WriteFile`/`EditFile`
+- TASK-315 — delete `backend_claudecode.go`, `backend_opencode.go`, `backend_qwencode.go`, `backend_openai.go`, `backend_anthropic.go`; collapse factory; rename `engine*` helpers to clean names
+- TASK-316 — bench wiring: strip CC install, flip `_build_config` to `openrouter`
+- TASK-317 — delete Python `engine.py`
+- TASK-318 — memory updates (`feedback_subprocess_not_api.md`, `bench_cost_safety.md`)
+
+---
+
+## Goal
+
+Single Pilot execution engine that talks to OpenRouter's `/api/v1/chat/completions`. One auth surface (`OPENROUTER_API_KEY`), multi-provider model access via slugs, OpenAI-shape API for maximum compatibility.
+
+This becomes Pilot's only Backend — current `claude-code`, `opencode`, `qwencode`, `openai-api`, `anthropic-api` all get deleted in follow-up tasks.
+
+## Scope of this task
+
+**In scope:**
+- New file `internal/executor/engine.go` implementing `Backend` interface against OR
+- Register `BackendTypeOpenRouter = "openrouter"` in `backend_factory.go` (additive — existing backends untouched in this PR)
+- Unit tests for the engine (HTTP fixtures, no live OR calls)
+- One smoke test against live OR gated by `OPENROUTER_API_KEY` env var (skip in CI)
+- Update `BackendConfig` with `OpenRouterConfig` sub-struct (API key resolution, attribution headers, optional `provider` overrides)
+
+**Out of scope (follow-ups):**
+- Deleting other backends (TASK-315)
+- Collapsing factory (TASK-315)
+- Bench wiring (TASK-316)
+- Python `engine.py` deletion (TASK-317)
+- Memory updates (TASK-318)
+
+## Implementation outline
+
+### Endpoint and request shape
+- `POST https://openrouter.ai/api/v1/chat/completions`
+- Headers: `Authorization: Bearer $OPENROUTER_API_KEY`, `Content-Type: application/json`, `HTTP-Referer: https://github.com/qf-studio/pilot`, `X-OpenRouter-Title: pilot`
+- Body: OpenAI-shape with the OR-specific extensions:
+  - `model: <slug>` (e.g. `anthropic/claude-opus-4.7`)
+  - `messages: [{role, content: [{type, text, cache_control?}]}]`
+  - `tools: [{type:"function", function:{name, description, parameters}}]` (no cache_control on tool wrappers — see quirks doc)
+  - `reasoning: {effort: "low"|"medium"|"high"}` for thinking
+  - `stream: true`
+  - `usage: {include: true}`
+  - **NO `provider.order` by default** (preserves sticky routing for cache)
+
+### Engine loop
+Mirror the proven semantics from existing `backend_anthropic.go` and Python `engine.py`:
+- Max 60 turns
+- Progressive reasoning effort: high for first 8 turns, medium after (mapped from previous `thinkingHigh/Low` budgets)
+- Tool dispatch: `bash`, `read_file`, `write_file`, `edit_file` (port from `backend_anthropic.go` for now; claw-code bash_validation + file_ops guards come in TASK-313/314)
+- Tool output cap: 50KB
+- Context prune at ~150K tokens
+- 5× retry with exp backoff (30/60/90/120/180s) on 429/529/5xx
+- Honor `metadata.retry_after_seconds` and `Retry-After` headers on 429
+
+### Cost capture
+- Read `usage.cost` from final response (non-stream) or final streaming chunk
+- Optionally `GET /api/v1/generation?id=<gen_id>` for detailed cost reconciliation
+
+### Cache strategy
+- Place `cache_control: {type:"ephemeral", ttl:"1h"}` on:
+  - The system message content block
+  - The last cacheable content block in `messages` (auto-mode pattern from OR docs)
+- Detect engagement via `usage.prompt_tokens_details.cached_tokens > 0`
+- Log a one-time INFO-level message if cached_tokens stays 0 across 5+ turns (suggests user hasn't set up BYOK and pool path isn't caching for them — surface as nudge later)
+
+### Streaming SSE parsing
+- Skip `: OPENROUTER PROCESSING` heartbeat comments
+- Parse `data: {...}` lines, reassemble `choices[0].delta` into final message
+- Terminate on `data: [DONE]`
+- Capture `usage` from the chunk that carries it (last data chunk, by convention)
+
+### Model routing config
+
+`BackendConfig.OpenRouter` carries:
+```go
+type OpenRouterConfig struct {
+    APIKey            string            // explicit override; falls back to env
+    BaseURL           string            // default https://openrouter.ai/api/v1
+    AttributionURL   string            // HTTP-Referer header
+    AttributionTitle string            // X-OpenRouter-Title header
+    DefaultModel     string            // fallback slug if router returns empty
+    ProviderOrder    []string          // optional, advanced override (disables sticky cache)
+    AllowFallbacks   *bool             // optional
+    Effort           string            // override for progressive (default: progressive)
+}
+```
+
+Existing `ModelRouting` in BackendConfig maps complexity → slug. Reuses Pilot's `EffortClassifier` and `ModelRouter`.
+
+## Acceptance
+
+- `go build ./...` clean
+- `go test ./internal/executor/...` clean (mock-based)
+- `OPENROUTER_API_KEY=... go test -run TestEngineSmoke ./internal/executor/` exits 0 against live OR (manual run, gated)
+- Engine reaches "SPIKE OK" round-trip in <10s on default model
+- 3-turn tool-using loop completes without panic; `usage.cached_tokens` ≥ 0 observed; total cost printed to log
+- File size ≤ ~900 LOC including header + tests
+
+## Sequencing
+
+After this lands, immediate follow-ups:
+- TASK-313 — port claw-code `bash_validation` (6 submodules) into the engine's `bash` tool
+- TASK-314 — port claw-code `file_ops` guards into `read_file`/`write_file`/`edit_file`
+- TASK-315 — delete `backend_claudecode.go`, `backend_opencode.go`, `backend_qwencode.go`, `backend_openai.go`, `backend_anthropic.go`; collapse factory switch
+- TASK-316 — bench: strip CC install from `install-pilot-agent.sh.j2`, flip `agent.py._build_config` to `engine`
+- TASK-317 — delete Python `pilot-bench/pilot_agent/engine.py`
+- TASK-318 — supersede `feedback_subprocess_not_api.md` and `bench_cost_safety.md` memories; write new decision memory
+
+---
+
+**Last updated**: 2026-05-26

--- a/.agent/drafts/task-312-engine/engine.go
+++ b/.agent/drafts/task-312-engine/engine.go
@@ -1,0 +1,1025 @@
+// Package executor: engine.go — Pilot's single execution engine, targeting
+// OpenRouter's OpenAI-compatible /chat/completions endpoint.
+//
+// Architecture (see .agent/system/openrouter-quirks.md for rationale):
+//   - Single auth surface: OPENROUTER_API_KEY
+//   - Multi-provider model access via slugs (anthropic/*, openai/*, google/*, ...)
+//   - OpenAI-shape request/response — tools, streaming, usage, all standardized
+//   - Anthropic cache_control sent on content blocks; engages with ttl:"1h" when
+//     the upstream path honors it (BYOK or sticky routing)
+//   - Reasoning: {effort} field instead of Anthropic's thinking.budget_tokens —
+//     OR maps to upstream-specific format on the wire
+//
+// This replaces backend_anthropic.go (delete in TASK-315) plus every other
+// backend in factory.go. The Engine type is the only Backend Pilot ships.
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// BackendTypeOpenRouter is the factory key for the OpenRouter engine.
+	BackendTypeOpenRouter = "openrouter"
+
+	openRouterDefaultBaseURL = "https://openrouter.ai/api/v1"
+	openRouterChatPath       = "/chat/completions"
+
+	// Default attribution headers (OR uses these for app leaderboards + analytics).
+	openRouterDefaultReferer = "https://github.com/qf-studio/pilot"
+	openRouterDefaultTitle   = "pilot"
+
+	// Default model when neither opts.Model nor BackendConfig overrides supply one.
+	openRouterDefaultModel = "anthropic/claude-opus-4.7"
+
+	// Engine loop limits.
+	engineMaxTurns       = 60
+	engineBashTimeout    = 120     // seconds per bash command
+	engineMaxRetries     = 5       // API retry attempts
+	engineOutputCap      = 50000   // bytes, engineTruncate tool output to prevent context bloat
+	engineContextPruneAt = 150000  // estimated tokens before pruning
+	engineMaxOutputToksDefault = 12000 // default max_tokens cap in chat completion request
+	engineCacheTTL       = "1h"    // long TTL for agent loops that idle on tool waits
+
+	// Effort levels map to OR's `reasoning.effort` field (low|medium|high).
+	engineEffortLow    = "low"
+	engineEffortMedium = "medium"
+	engineEffortHigh   = "high"
+)
+
+// engineRetryBackoffs is the exponential backoff schedule for 429/529/5xx.
+var engineRetryBackoffs = []time.Duration{
+	30 * time.Second,
+	60 * time.Second,
+	90 * time.Second,
+	120 * time.Second,
+	180 * time.Second,
+}
+
+// Engine is Pilot's single Backend implementation. It speaks to OpenRouter
+// over HTTPS, streams SSE responses, runs a tool-use loop, and reports cost
+// via OR's `usage.cost` field.
+type Engine struct {
+	apiKey         string
+	baseURL        string
+	referer        string
+	title          string
+	config         *BackendConfig
+	httpClient     *http.Client
+	maxOutputToks  int // override for engineMaxOutputToksDefault; 0 = use default
+}
+
+// NewEngine constructs an Engine from BackendConfig. The OPENROUTER_API_KEY
+// environment variable is the primary credential source; BackendConfig.APIAuthToken
+// is honored as a config-level override (useful for testing).
+func NewEngine(config *BackendConfig) *Engine {
+	e := &Engine{
+		config:     config,
+		baseURL:    openRouterDefaultBaseURL,
+		referer:    openRouterDefaultReferer,
+		title:      openRouterDefaultTitle,
+		httpClient: &http.Client{Timeout: 0}, // No timeout — streams can run long
+	}
+
+	// Override base URL from config (e.g. testing against a mock).
+	if config != nil && config.APIBaseURL != "" {
+		e.baseURL = strings.TrimRight(config.APIBaseURL, "/")
+	}
+
+	// Resolve API key. Priority: explicit config token → env var.
+	if config != nil && config.APIAuthToken != "" {
+		e.apiKey = config.APIAuthToken
+	}
+	if e.apiKey == "" {
+		e.apiKey = os.Getenv("OPENROUTER_API_KEY")
+	}
+
+	return e
+}
+
+// Name returns the backend type identifier.
+func (e *Engine) Name() string { return BackendTypeOpenRouter }
+
+// IsAvailable reports whether the engine has the credentials to make a call.
+func (e *Engine) IsAvailable() bool { return e.apiKey != "" }
+
+// --- OpenRouter request/response types (OpenAI /chat/completions shape) ---
+
+// orContentBlock is a content item inside a message. OR accepts content as
+// either a string (`content: "..."`) or an array of these blocks. Using the
+// block form lets us attach cache_control to specific blocks.
+type orContentBlock struct {
+	Type         string          `json:"type"`                    // "text" | "image_url" (we use text only)
+	Text         string          `json:"text,omitempty"`
+	CacheControl *orCacheControl `json:"cache_control,omitempty"` // Anthropic passthrough
+}
+
+// orCacheControl is the cache breakpoint marker that flows through OR to
+// Anthropic. ttl: "1h" extends the default 5m cache for agent loops.
+type orCacheControl struct {
+	Type string `json:"type"`          // "ephemeral"
+	TTL  string `json:"ttl,omitempty"` // "1h" recommended for agent loops
+}
+
+// orMessage represents one message in the conversation. Content is
+// json.RawMessage so we can emit either a string or a []orContentBlock.
+type orMessage struct {
+	Role       string          `json:"role"` // "system" | "user" | "assistant" | "tool"
+	Content    json.RawMessage `json:"content,omitempty"`
+	ToolCalls  []orToolCall    `json:"tool_calls,omitempty"`
+	ToolCallID string          `json:"tool_call_id,omitempty"`
+	Name       string          `json:"name,omitempty"`
+}
+
+// orToolDef is the OpenAI function-calling tool definition shape.
+type orToolDef struct {
+	Type     string         `json:"type"` // always "function"
+	Function orFunctionSpec `json:"function"`
+}
+
+type orFunctionSpec struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+// orToolCall is a tool invocation the model produced. ID flows through OR
+// preserving Anthropic's native `toolu_*` identifier when the upstream is
+// Anthropic.
+type orToolCall struct {
+	ID       string         `json:"id"`
+	Type     string         `json:"type"`            // "function"
+	Function orFunctionCall `json:"function"`
+	Index    int            `json:"index,omitempty"` // streaming delta order
+}
+
+type orFunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // JSON-encoded args (OpenAI convention)
+}
+
+// orReasoning is OR's normalized reasoning/thinking field. For Anthropic
+// upstreams this maps to thinking.budget_tokens on the wire.
+type orReasoning struct {
+	Effort string `json:"effort,omitempty"` // "low" | "medium" | "high"
+}
+
+// orProvider lets callers pin or constrain provider routing. By default we
+// leave this nil — setting `provider.order` disables OR's sticky cache
+// routing, so we only override when there's a specific reason.
+type orProvider struct {
+	Order             []string `json:"order,omitempty"`
+	AllowFallbacks    *bool    `json:"allow_fallbacks,omitempty"`
+	RequireParameters bool     `json:"require_parameters,omitempty"`
+}
+
+// orUsageInclude opts into detailed usage reporting in responses.
+type orUsageInclude struct {
+	Include bool `json:"include"`
+}
+
+// orRequest is the body of a /chat/completions call.
+type orRequest struct {
+	Model      string          `json:"model"`
+	MaxTokens  int             `json:"max_tokens,omitempty"`
+	Messages   []orMessage     `json:"messages"`
+	Tools      []orToolDef     `json:"tools,omitempty"`
+	ToolChoice string          `json:"tool_choice,omitempty"`
+	Stream     bool            `json:"stream"`
+	Reasoning  *orReasoning    `json:"reasoning,omitempty"`
+	Provider   *orProvider     `json:"provider,omitempty"`
+	Usage      *orUsageInclude `json:"usage,omitempty"`
+}
+
+// orChoice is one completion option from the response.
+type orChoice struct {
+	Index              int                `json:"index"`
+	Message            *orResponseMessage `json:"message,omitempty"` // non-streaming
+	Delta              *orResponseMessage `json:"delta,omitempty"`   // streaming
+	FinishReason       string             `json:"finish_reason,omitempty"`
+	NativeFinishReason string             `json:"native_finish_reason,omitempty"`
+}
+
+type orResponseMessage struct {
+	Role      string       `json:"role,omitempty"`
+	Content   string       `json:"content,omitempty"`
+	Refusal   string       `json:"refusal,omitempty"`
+	Reasoning string       `json:"reasoning,omitempty"`
+	ToolCalls []orToolCall `json:"tool_calls,omitempty"`
+}
+
+// orPromptTokensDetails carries cache hit/miss counters. cached_tokens > 0
+// indicates the prompt cache engaged.
+type orPromptTokensDetails struct {
+	CachedTokens     int64 `json:"cached_tokens"`
+	CacheWriteTokens int64 `json:"cache_write_tokens"`
+}
+
+type orCompletionTokensDetails struct {
+	ReasoningTokens int64 `json:"reasoning_tokens"`
+}
+
+type orUsage struct {
+	PromptTokens            int64                      `json:"prompt_tokens"`
+	CompletionTokens        int64                      `json:"completion_tokens"`
+	TotalTokens             int64                      `json:"total_tokens"`
+	Cost                    float64                    `json:"cost"`
+	IsByok                  bool                       `json:"is_byok"`
+	PromptTokensDetails     *orPromptTokensDetails     `json:"prompt_tokens_details,omitempty"`
+	CompletionTokensDetails *orCompletionTokensDetails `json:"completion_tokens_details,omitempty"`
+}
+
+type orErrorBody struct {
+	Code     int             `json:"code"`
+	Message  string          `json:"message"`
+	Metadata json.RawMessage `json:"metadata,omitempty"`
+}
+
+// orResponse is the assembled response after non-streaming or end-of-stream.
+type orResponse struct {
+	ID       string       `json:"id"`
+	Object   string       `json:"object"`
+	Model    string       `json:"model"`
+	Provider string       `json:"provider"`
+	Choices  []orChoice   `json:"choices"`
+	Usage    orUsage      `json:"usage"`
+	Error    *orErrorBody `json:"error,omitempty"`
+}
+
+// --- Tool definitions ---
+
+var engineTools = []orToolDef{
+	{
+		Type: "function",
+		Function: orFunctionSpec{
+			Name:        "bash",
+			Description: "Execute a bash command. Returns stdout+stderr combined. Commands timeout after 120s by default. Use for running code, installing packages, checking files, running tests.",
+			Parameters: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"command": {"type": "string", "description": "The bash command to execute"},
+					"timeout": {"type": "integer", "description": "Timeout in seconds (default 120, max 600)"}
+				},
+				"required": ["command"]
+			}`),
+		},
+	},
+	{
+		Type: "function",
+		Function: orFunctionSpec{
+			Name:        "read_file",
+			Description: "Read a file's contents and return with line numbers prepended (e.g. '  42 | line content'). Supports offset/limit for partial reads.",
+			Parameters: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"path": {"type": "string", "description": "Absolute path to the file"},
+					"offset": {"type": "integer", "description": "Line number to start from (1-indexed)"},
+					"limit": {"type": "integer", "description": "Max lines to read"}
+				},
+				"required": ["path"]
+			}`),
+		},
+	},
+	{
+		Type: "function",
+		Function: orFunctionSpec{
+			Name:        "write_file",
+			Description: "Write content to a file. Creates parent directories if needed. Overwrites existing files. Use for creating new files or complete rewrites.",
+			Parameters: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"path": {"type": "string", "description": "Absolute path to write to"},
+					"content": {"type": "string", "description": "File content"}
+				},
+				"required": ["path", "content"]
+			}`),
+		},
+	},
+	{
+		Type: "function",
+		Function: orFunctionSpec{
+			Name:        "edit_file",
+			Description: "Replace a specific string in a file. The old_string must appear exactly once. More precise than write_file for small changes.",
+			Parameters: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"path": {"type": "string", "description": "Absolute path"},
+					"old_string": {"type": "string", "description": "Exact text to find (must appear exactly once)"},
+					"new_string": {"type": "string", "description": "Replacement text"}
+				},
+				"required": ["path", "old_string", "new_string"]
+			}`),
+		},
+	},
+}
+
+// --- Tool execution ---
+
+func engineExecBash(command string, timeout int, cwd string) string {
+	if timeout <= 0 || timeout > 600 {
+		timeout = engineBashTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", "-c", command)
+	cmd.Dir = cwd
+	out, err := cmd.CombinedOutput()
+
+	output := string(out)
+	if len(output) > engineOutputCap {
+		half := engineOutputCap / 2
+		output = output[:half] + "\n\n... [truncated] ...\n\n" + output[len(output)-half:]
+	}
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Sprintf("%s\n[TIMEOUT after %ds — command killed]", output, timeout)
+	}
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return fmt.Sprintf("%s\n[exit code: %d]", output, exitErr.ExitCode())
+		}
+		return fmt.Sprintf("%s\n[ERROR: %v]", output, err)
+	}
+	return output
+}
+
+func engineExecReadFile(path string, offset, limit int) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Sprintf("[File not found: %s]", path)
+	}
+	if len(data) > 500000 {
+		return fmt.Sprintf("[File too large: %d bytes. Use bash: head -100 %s]", len(data), path)
+	}
+	lines := strings.Split(string(data), "\n")
+	if offset > 0 && offset <= len(lines) {
+		lines = lines[offset-1:]
+	}
+	if limit > 0 && limit < len(lines) {
+		lines = lines[:limit]
+	}
+	startLine := 1
+	if offset > 0 {
+		startLine = offset
+	}
+	var sb strings.Builder
+	for i, line := range lines {
+		fmt.Fprintf(&sb, "%4d | %s\n", startLine+i, line)
+	}
+	return sb.String()
+}
+
+func engineExecWriteFile(path, content string) string {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Sprintf("[ERROR creating dirs: %v]", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return fmt.Sprintf("[ERROR writing %s: %v]", path, err)
+	}
+	return fmt.Sprintf("[Wrote %d bytes to %s]", len(content), path)
+}
+
+func engineExecEditFile(path, oldStr, newStr string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Sprintf("[File not found: %s]", path)
+	}
+	content := string(data)
+	count := strings.Count(content, oldStr)
+	if count == 0 {
+		return fmt.Sprintf("[old_string not found in %s — read the file first to get exact text]", path)
+	}
+	if count > 1 {
+		return fmt.Sprintf("[old_string appears %d times in %s — provide more context to make it unique]", count, path)
+	}
+	newContent := strings.Replace(content, oldStr, newStr, 1)
+	if err := os.WriteFile(path, []byte(newContent), 0644); err != nil {
+		return fmt.Sprintf("[ERROR writing %s: %v]", path, err)
+	}
+	return fmt.Sprintf("[Edited %s: replaced %d chars with %d chars]", path, len(oldStr), len(newStr))
+}
+
+// engineDispatchTool routes a tool call to the right executor. Returns the
+// string result that gets sent back as a tool_result message.
+func engineDispatchTool(name string, args map[string]interface{}, cwd string) string {
+	switch name {
+	case "bash":
+		cmd, _ := args["command"].(string)
+		timeout := engineBashTimeout
+		if t, ok := args["timeout"].(float64); ok {
+			timeout = int(t)
+		}
+		return engineExecBash(cmd, timeout, cwd)
+	case "read_file":
+		path, _ := args["path"].(string)
+		offset, _ := args["offset"].(float64)
+		limit, _ := args["limit"].(float64)
+		return engineExecReadFile(path, int(offset), int(limit))
+	case "write_file":
+		path, _ := args["path"].(string)
+		content, _ := args["content"].(string)
+		return engineExecWriteFile(path, content)
+	case "edit_file":
+		path, _ := args["path"].(string)
+		oldStr, _ := args["old_string"].(string)
+		newStr, _ := args["new_string"].(string)
+		return engineExecEditFile(path, oldStr, newStr)
+	default:
+		return fmt.Sprintf("[Unknown tool: %s]", name)
+	}
+}
+
+// --- HTTP call with retry + SSE parsing ---
+
+// callAPI POSTs the request and parses the SSE stream into a unified response.
+// Retries on 429/529/5xx with exponential backoff.
+func (e *Engine) callAPI(ctx context.Context, req *orRequest) (*orResponse, error) {
+	req.Stream = true
+	if req.Usage == nil {
+		req.Usage = &orUsageInclude{Include: true}
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := e.baseURL + openRouterChatPath
+
+	for attempt := 0; attempt <= engineMaxRetries; attempt++ {
+		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("create request: %w", err)
+		}
+
+		httpReq.Header.Set("Authorization", "Bearer "+e.apiKey)
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Accept", "text/event-stream")
+		if e.referer != "" {
+			httpReq.Header.Set("HTTP-Referer", e.referer)
+		}
+		if e.title != "" {
+			httpReq.Header.Set("X-OpenRouter-Title", e.title)
+		}
+
+		resp, err := e.httpClient.Do(httpReq)
+		if err != nil {
+			if attempt < engineMaxRetries {
+				wait := engineRetryBackoffs[min(attempt, len(engineRetryBackoffs)-1)]
+				slog.Warn("engine: HTTP error, retrying",
+					slog.Int("attempt", attempt+1), slog.Duration("wait", wait), slog.Any("error", err))
+				time.Sleep(wait)
+				continue
+			}
+			return nil, fmt.Errorf("HTTP request failed after %d retries: %w", engineMaxRetries, err)
+		}
+
+		// Retry on 429/529/5xx.
+		if resp.StatusCode == 429 || resp.StatusCode == 529 || resp.StatusCode >= 500 {
+			respBody, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if attempt < engineMaxRetries {
+				wait := engineRetryBackoffs[min(attempt, len(engineRetryBackoffs)-1)]
+				// Honor retry_after_seconds from OR's 429 error body if present.
+				if resp.StatusCode == 429 {
+					if ra := extractRetryAfter(respBody); ra > 0 {
+						wait = time.Duration(ra) * time.Second
+					}
+				}
+				slog.Warn("engine: API error, retrying",
+					slog.Int("status", resp.StatusCode), slog.Duration("wait", wait))
+				time.Sleep(wait)
+				continue
+			}
+			return nil, fmt.Errorf("API returned %d after %d retries: %s", resp.StatusCode, engineMaxRetries, engineTruncate(string(respBody), 500))
+		}
+
+		if resp.StatusCode != 200 {
+			respBody, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("API returned %d: %s", resp.StatusCode, engineTruncate(string(respBody), 500))
+		}
+
+		result, err := e.parseSSEStream(resp.Body)
+		_ = resp.Body.Close()
+
+		if err != nil {
+			// Some upstreams emit overloaded errors in the SSE stream body even at HTTP 200.
+			if strings.Contains(strings.ToLower(err.Error()), "overloaded") && attempt < engineMaxRetries {
+				wait := engineRetryBackoffs[min(attempt, len(engineRetryBackoffs)-1)]
+				slog.Warn("engine: overloaded in stream, retrying", slog.Duration("wait", wait))
+				time.Sleep(wait)
+				continue
+			}
+			return nil, err
+		}
+
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("exhausted %d retries", engineMaxRetries)
+}
+
+// extractRetryAfter looks for OR's `metadata.retry_after_seconds` in a 429 body.
+// Returns 0 if not parseable.
+func extractRetryAfter(body []byte) int {
+	var envelope struct {
+		Error struct {
+			Metadata struct {
+				RetryAfter int `json:"retry_after_seconds"`
+			} `json:"metadata"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return 0
+	}
+	return envelope.Error.Metadata.RetryAfter
+}
+
+func engineTruncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+// parseSSEStream reads OR's SSE event stream and accumulates the final
+// orResponse. Skips `: OPENROUTER PROCESSING` heartbeats. Terminates on
+// `data: [DONE]`. The final data chunk carries the usage block.
+func (e *Engine) parseSSEStream(body io.Reader) (*orResponse, error) {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // 1MB line buffer
+
+	result := &orResponse{}
+	// Accumulate delta content per choice index.
+	contentBuilders := make(map[int]*strings.Builder)
+	// Accumulate tool-call argument JSON per (choice, tool-call) index.
+	toolCallArgBuilders := make(map[string]*strings.Builder) // key: "choice:index"
+	toolCallMeta := make(map[string]*orToolCall)             // key: "choice:index"
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Skip blank lines and OR heartbeat comments.
+		if line == "" || strings.HasPrefix(line, ":") {
+			continue
+		}
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+
+		var chunk orResponse
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			// Some chunks (especially errors) may not parse cleanly; skip.
+			continue
+		}
+
+		// Error in stream body (HTTP 200, error inside JSON).
+		if chunk.Error != nil && chunk.Error.Message != "" {
+			return nil, fmt.Errorf("stream error: %s", chunk.Error.Message)
+		}
+
+		// Capture top-level metadata from the first chunk that has them.
+		if chunk.ID != "" && result.ID == "" {
+			result.ID = chunk.ID
+		}
+		if chunk.Model != "" && result.Model == "" {
+			result.Model = chunk.Model
+		}
+		if chunk.Provider != "" && result.Provider == "" {
+			result.Provider = chunk.Provider
+		}
+
+		for _, choice := range chunk.Choices {
+			idx := choice.Index
+			// Ensure result.Choices is grown to fit this index.
+			for len(result.Choices) <= idx {
+				result.Choices = append(result.Choices, orChoice{Index: len(result.Choices)})
+			}
+			rc := &result.Choices[idx]
+
+			if choice.FinishReason != "" {
+				rc.FinishReason = choice.FinishReason
+			}
+			if choice.NativeFinishReason != "" {
+				rc.NativeFinishReason = choice.NativeFinishReason
+			}
+
+			if choice.Delta == nil {
+				continue
+			}
+
+			// Accumulate text content.
+			if choice.Delta.Content != "" {
+				cb, ok := contentBuilders[idx]
+				if !ok {
+					cb = &strings.Builder{}
+					contentBuilders[idx] = cb
+				}
+				cb.WriteString(choice.Delta.Content)
+			}
+
+			// Accumulate tool calls.
+			for _, tc := range choice.Delta.ToolCalls {
+				key := fmt.Sprintf("%d:%d", idx, tc.Index)
+				meta, ok := toolCallMeta[key]
+				if !ok {
+					meta = &orToolCall{Index: tc.Index, Type: "function"}
+					toolCallMeta[key] = meta
+					toolCallArgBuilders[key] = &strings.Builder{}
+				}
+				if tc.ID != "" {
+					meta.ID = tc.ID
+				}
+				if tc.Type != "" {
+					meta.Type = tc.Type
+				}
+				if tc.Function.Name != "" {
+					meta.Function.Name = tc.Function.Name
+				}
+				if tc.Function.Arguments != "" {
+					toolCallArgBuilders[key].WriteString(tc.Function.Arguments)
+				}
+			}
+		}
+
+		// Final usage block comes on the last data chunk (OR convention).
+		if chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 || chunk.Usage.Cost > 0 {
+			result.Usage = chunk.Usage
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("stream read error: %w", err)
+	}
+
+	// Materialize each choice's final message from the accumulated deltas.
+	for i := range result.Choices {
+		msg := &orResponseMessage{Role: "assistant"}
+		if cb, ok := contentBuilders[i]; ok {
+			msg.Content = cb.String()
+		}
+		// Walk our tool-call map in index order to keep the result deterministic.
+		for key, meta := range toolCallMeta {
+			var ci, ti int
+			if _, err := fmt.Sscanf(key, "%d:%d", &ci, &ti); err != nil || ci != i {
+				continue
+			}
+			tc := *meta
+			if ab, ok := toolCallArgBuilders[key]; ok {
+				tc.Function.Arguments = ab.String()
+			}
+			msg.ToolCalls = append(msg.ToolCalls, tc)
+		}
+		result.Choices[i].Message = msg
+	}
+
+	return result, nil
+}
+
+// --- Engine Execute loop ---
+
+// Execute runs the agent loop against OpenRouter. Streams BackendEvents to
+// the caller's handler. Returns a BackendResult with final tokens, cost,
+// success state.
+func (e *Engine) Execute(ctx context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	if e.apiKey == "" {
+		return nil, fmt.Errorf("engine: no OPENROUTER_API_KEY configured")
+	}
+
+	model := opts.Model
+	if model == "" {
+		if e.config != nil && e.config.DefaultModel != "" {
+			model = e.config.DefaultModel
+		} else {
+			model = openRouterDefaultModel
+		}
+	}
+
+	cwd := opts.ProjectPath
+	if cwd == "" {
+		cwd = "/app"
+	}
+
+	if opts.EventHandler != nil {
+		opts.EventHandler(BackendEvent{
+			Type:    EventTypeInit,
+			Message: "OpenRouter engine initialized",
+			Model:   model,
+		})
+	}
+
+	// Initial messages: system carries the prompt with cache_control; user
+	// kicks off the loop. cache_control on the system block lets a properly
+	// configured upstream cache the entire prompt prefix.
+	systemBlocks := []orContentBlock{
+		{
+			Type:         "text",
+			Text:         opts.Prompt,
+			CacheControl: &orCacheControl{Type: "ephemeral", TTL: engineCacheTTL},
+		},
+	}
+	systemContent, _ := json.Marshal(systemBlocks)
+	userContent, _ := json.Marshal("Begin. Follow the mandatory workflow.")
+
+	messages := []orMessage{
+		{Role: "system", Content: systemContent},
+		{Role: "user", Content: userContent},
+	}
+
+	var (
+		totalInputTokens  int64
+		totalOutputTokens int64
+		totalCacheRead    int64
+		totalCacheWrite   int64
+		totalCost         float64
+		lastOutput        string
+		sawSuccess        bool
+		cachedTokensZeros int // count turns with cached=0; warn after threshold
+	)
+
+	for turn := 0; turn < engineMaxTurns; turn++ {
+		if ctx.Err() != nil {
+			return &BackendResult{
+				Success:                  sawSuccess,
+				Output:                   lastOutput,
+				Error:                    "context cancelled",
+				TokensInput:              totalInputTokens,
+				TokensOutput:             totalOutputTokens,
+				CacheReadInputTokens:     totalCacheRead,
+				CacheCreationInputTokens: totalCacheWrite,
+				Model:                    model,
+				SawSuccessResult:         sawSuccess,
+			}, nil
+		}
+
+		// Context pruning by rough token estimate.
+		if engineEstimateTokens(messages) > engineContextPruneAt {
+			messages = enginePruneMessages(messages)
+			slog.Info("engine: context pruned", slog.Int("turn", turn))
+		}
+
+		// Progressive effort: high for first 8 turns, medium after. Overridden
+		// by opts.Effort.
+		effort := engineEffortHigh
+		if turn >= 8 {
+			effort = engineEffortMedium
+		}
+		switch opts.Effort {
+		case "low":
+			effort = engineEffortLow
+		case "medium":
+			effort = engineEffortMedium
+		case "high", "max":
+			effort = engineEffortHigh
+		}
+
+		maxToks := e.maxOutputToks
+		if maxToks <= 0 {
+			maxToks = engineMaxOutputToksDefault
+		}
+
+		req := &orRequest{
+			Model:     model,
+			MaxTokens: maxToks,
+			Messages:  messages,
+			Tools:     engineTools,
+			Reasoning: &orReasoning{Effort: effort},
+		}
+
+		slog.Info("engine: API call",
+			slog.Int("turn", turn),
+			slog.String("model", model),
+			slog.String("effort", effort),
+			slog.Int("messages", len(messages)))
+
+		response, err := e.callAPI(ctx, req)
+		if err != nil {
+			slog.Error("engine: API call failed", slog.Int("turn", turn), slog.Any("error", err))
+			if opts.EventHandler != nil {
+				opts.EventHandler(BackendEvent{Type: EventTypeError, Message: err.Error(), IsError: true})
+			}
+			return &BackendResult{
+				Success:                  sawSuccess,
+				Output:                   lastOutput,
+				Error:                    err.Error(),
+				TokensInput:              totalInputTokens,
+				TokensOutput:             totalOutputTokens,
+				CacheReadInputTokens:     totalCacheRead,
+				CacheCreationInputTokens: totalCacheWrite,
+				Model:                    model,
+				SawSuccessResult:         sawSuccess,
+				ErrorType:                "api_error",
+			}, nil
+		}
+
+		// Accounting.
+		totalInputTokens += response.Usage.PromptTokens
+		totalOutputTokens += response.Usage.CompletionTokens
+		totalCost += response.Usage.Cost
+		if response.Usage.PromptTokensDetails != nil {
+			totalCacheRead += response.Usage.PromptTokensDetails.CachedTokens
+			totalCacheWrite += response.Usage.PromptTokensDetails.CacheWriteTokens
+			if response.Usage.PromptTokensDetails.CachedTokens == 0 {
+				cachedTokensZeros++
+			} else {
+				cachedTokensZeros = 0
+			}
+		}
+
+		// One-time nudge if cache never engages (suggests user hasn't set up
+		// BYOK or pool path doesn't cache for them).
+		if cachedTokensZeros == 5 {
+			slog.Warn("engine: prompt cache has not engaged after 5 turns; consider adding an Anthropic key under OpenRouter Integrations for cache passthrough",
+				slog.String("model", model))
+		}
+
+		if len(response.Choices) == 0 {
+			err := fmt.Errorf("engine: empty choices in response (id=%s)", response.ID)
+			if opts.EventHandler != nil {
+				opts.EventHandler(BackendEvent{Type: EventTypeError, Message: err.Error(), IsError: true})
+			}
+			return &BackendResult{
+				Success:          sawSuccess,
+				Output:           lastOutput,
+				Error:            err.Error(),
+				TokensInput:      totalInputTokens,
+				TokensOutput:     totalOutputTokens,
+				Model:            model,
+				SawSuccessResult: sawSuccess,
+				ErrorType:        "api_error",
+			}, nil
+		}
+
+		choice := response.Choices[0]
+		msg := choice.Message
+		if msg == nil {
+			msg = &orResponseMessage{Role: "assistant"}
+		}
+
+		// Emit text event for the assistant's prose.
+		if msg.Content != "" {
+			lastOutput = msg.Content
+			if opts.EventHandler != nil {
+				opts.EventHandler(BackendEvent{
+					Type:                 EventTypeText,
+					Message:              msg.Content,
+					TokensInput:          response.Usage.PromptTokens,
+					TokensOutput:         response.Usage.CompletionTokens,
+					CacheReadInputTokens: cacheReadFromUsage(response.Usage),
+					Model:                model,
+				})
+			}
+		}
+
+		// Append the assistant message to history.
+		assistantMsg := orMessage{Role: "assistant"}
+		if msg.Content != "" {
+			c, _ := json.Marshal(msg.Content)
+			assistantMsg.Content = c
+		}
+		if len(msg.ToolCalls) > 0 {
+			assistantMsg.ToolCalls = msg.ToolCalls
+		}
+		messages = append(messages, assistantMsg)
+
+		// Tool calls? Execute them and append tool messages.
+		if choice.FinishReason == "tool_calls" && len(msg.ToolCalls) > 0 {
+			for _, tc := range msg.ToolCalls {
+				var args map[string]interface{}
+				if tc.Function.Arguments != "" {
+					_ = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+				}
+				if args == nil {
+					args = map[string]interface{}{}
+				}
+
+				if opts.EventHandler != nil {
+					opts.EventHandler(BackendEvent{
+						Type:      EventTypeToolUse,
+						ToolName:  tc.Function.Name,
+						ToolInput: args,
+						Model:     model,
+					})
+				}
+
+				slog.Info("engine: tool exec",
+					slog.Int("turn", turn),
+					slog.String("tool", tc.Function.Name))
+
+				result := engineDispatchTool(tc.Function.Name, args, cwd)
+
+				if opts.EventHandler != nil {
+					opts.EventHandler(BackendEvent{
+						Type:       EventTypeToolResult,
+						ToolName:   tc.Function.Name,
+						ToolResult: result,
+					})
+				}
+
+				toolContent, _ := json.Marshal(result)
+				messages = append(messages, orMessage{
+					Role:       "tool",
+					ToolCallID: tc.ID,
+					Name:       tc.Function.Name,
+					Content:    toolContent,
+				})
+			}
+			continue // next turn
+		}
+
+		// finish_reason: "stop" (or anything other than tool_calls) → done
+		sawSuccess = true
+		if opts.EventHandler != nil {
+			opts.EventHandler(BackendEvent{Type: EventTypeResult, Message: lastOutput})
+		}
+		break
+	}
+
+	slog.Info("engine: done",
+		slog.Bool("success", sawSuccess),
+		slog.Int64("tokens_in", totalInputTokens),
+		slog.Int64("tokens_out", totalOutputTokens),
+		slog.Int64("cache_read", totalCacheRead),
+		slog.Int64("cache_write", totalCacheWrite),
+		slog.Float64("cost_usd", totalCost),
+		slog.String("model", model))
+
+	return &BackendResult{
+		Success:                  sawSuccess,
+		Output:                   lastOutput,
+		TokensInput:              totalInputTokens,
+		TokensOutput:             totalOutputTokens,
+		CacheReadInputTokens:     totalCacheRead,
+		CacheCreationInputTokens: totalCacheWrite,
+		Model:                    model,
+		SawSuccessResult:         sawSuccess,
+	}, nil
+}
+
+func cacheReadFromUsage(u orUsage) int64 {
+	if u.PromptTokensDetails == nil {
+		return 0
+	}
+	return u.PromptTokensDetails.CachedTokens
+}
+
+// --- Context management ---
+
+func engineEstimateTokens(messages []orMessage) int {
+	total := 0
+	for _, m := range messages {
+		total += len(m.Content) / 4
+		for _, tc := range m.ToolCalls {
+			total += len(tc.Function.Arguments) / 4
+			total += len(tc.Function.Name) / 4
+		}
+	}
+	return total
+}
+
+func enginePruneMessages(messages []orMessage) []orMessage {
+	keepTurns := 12
+	if len(messages) <= keepTurns*2 {
+		return messages
+	}
+	first := messages[0]
+	keep := messages[len(messages)-keepTurns*2:]
+	prunedMarker, _ := json.Marshal("[Earlier messages pruned to save context. Continue working on the task.]")
+	pruned := []orMessage{
+		first,
+		{Role: "user", Content: prunedMarker},
+	}
+	return append(pruned, keep...)
+}
+
+// --- Error type ---
+
+// EngineError implements BackendError for engine failures.
+type EngineError struct {
+	ErrType string
+	Msg     string
+}
+
+func (e *EngineError) Error() string        { return e.Msg }
+func (e *EngineError) ErrorType() string    { return e.ErrType }
+func (e *EngineError) ErrorMessage() string { return e.Msg }
+func (e *EngineError) ErrorStderr() string  { return "" }

--- a/.agent/drafts/task-312-engine/engine_test.go
+++ b/.agent/drafts/task-312-engine/engine_test.go
@@ -1,0 +1,557 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- Construction / configuration ---
+
+func TestNewEngine_PicksUpEnvKey(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+	e := NewEngine(&BackendConfig{})
+	if !e.IsAvailable() {
+		t.Fatal("engine should be available with env key")
+	}
+	if e.Name() != BackendTypeOpenRouter {
+		t.Fatalf("Name() = %q, want %q", e.Name(), BackendTypeOpenRouter)
+	}
+}
+
+func TestNewEngine_ConfigTokenOverridesEnv(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "sk-or-v1-env")
+	e := NewEngine(&BackendConfig{APIAuthToken: "sk-or-v1-config"})
+	if e.apiKey != "sk-or-v1-config" {
+		t.Fatalf("apiKey = %q, want config-supplied value", e.apiKey)
+	}
+}
+
+func TestNewEngine_MissingKey(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "")
+	e := NewEngine(&BackendConfig{})
+	if e.IsAvailable() {
+		t.Fatal("engine should not be available without any key")
+	}
+}
+
+func TestNewEngine_CustomBaseURL(t *testing.T) {
+	e := NewEngine(&BackendConfig{APIBaseURL: "http://localhost:9999/api/v1/"})
+	if e.baseURL != "http://localhost:9999/api/v1" {
+		t.Fatalf("baseURL = %q, want trailing slash trimmed", e.baseURL)
+	}
+}
+
+// --- Factory wiring ---
+
+func TestBackendFactory_RegistersOpenRouter(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+	backend, err := NewBackend(&BackendConfig{Type: BackendTypeOpenRouter})
+	if err != nil {
+		t.Fatalf("NewBackend(openrouter) failed: %v", err)
+	}
+	if _, ok := backend.(*Engine); !ok {
+		t.Fatalf("expected *Engine, got %T", backend)
+	}
+	if backend.Name() != BackendTypeOpenRouter {
+		t.Fatalf("Name() = %q, want %q", backend.Name(), BackendTypeOpenRouter)
+	}
+}
+
+// --- Retry-after extraction ---
+
+func TestExtractRetryAfter(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"message": "rate limited",
+			"metadata": {"retry_after_seconds": 12, "provider_name": "Anthropic"}
+		}
+	}`)
+	if got := extractRetryAfter(body); got != 12 {
+		t.Fatalf("extractRetryAfter = %d, want 12", got)
+	}
+
+	// Malformed → 0
+	if got := extractRetryAfter([]byte(`not json`)); got != 0 {
+		t.Fatalf("extractRetryAfter(garbage) = %d, want 0", got)
+	}
+
+	// Missing field → 0
+	if got := extractRetryAfter([]byte(`{"error":{"code":429}}`)); got != 0 {
+		t.Fatalf("extractRetryAfter(no metadata) = %d, want 0", got)
+	}
+}
+
+func TestEngineTruncate(t *testing.T) {
+	if engineTruncate("short", 100) != "short" {
+		t.Fatal("short string should not be truncated")
+	}
+	if got := engineTruncate("hello world", 5); got != "hello..." {
+		t.Fatalf("engineTruncate = %q, want %q", got, "hello...")
+	}
+}
+
+// --- Tool execution ---
+
+func TestEngineExecBash_Simple(t *testing.T) {
+	got := engineExecBash("echo hello", 5, t.TempDir())
+	if !strings.Contains(got, "hello") {
+		t.Fatalf("expected 'hello' in output, got: %q", got)
+	}
+}
+
+func TestEngineExecBash_Timeout(t *testing.T) {
+	got := engineExecBash("sleep 2", 1, t.TempDir())
+	if !strings.Contains(got, "TIMEOUT") {
+		t.Fatalf("expected TIMEOUT marker, got: %q", got)
+	}
+}
+
+func TestEngineExecBash_OutputCap(t *testing.T) {
+	// Generate >engineOutputCap bytes via python (portable, deterministic).
+	big := engineExecBash(`python3 -c "import sys; sys.stdout.write('x'*60000)"`, 10, t.TempDir())
+	if len(big) > engineOutputCap+500 { // small slack for the truncation marker
+		t.Fatalf("output not capped: %d bytes", len(big))
+	}
+	if !strings.Contains(big, "truncated") {
+		t.Fatalf("expected 'truncated' marker (output len=%d)", len(big))
+	}
+}
+
+func TestEngineExecWriteReadFile(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/test.txt"
+	wr := engineExecWriteFile(path, "hello\nworld\n")
+	if !strings.Contains(wr, "Wrote") {
+		t.Fatalf("write failed: %q", wr)
+	}
+	rd := engineExecReadFile(path, 0, 0)
+	if !strings.Contains(rd, "hello") || !strings.Contains(rd, "world") {
+		t.Fatalf("read content unexpected: %q", rd)
+	}
+	if !strings.Contains(rd, "   1 |") {
+		t.Fatalf("expected line numbering, got: %q", rd)
+	}
+}
+
+func TestEngineExecEditFile(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/test.txt"
+	_ = engineExecWriteFile(path, "alpha\nbeta\ngamma\n")
+
+	ok := engineExecEditFile(path, "beta", "BETA")
+	if !strings.Contains(ok, "Edited") {
+		t.Fatalf("edit failed: %q", ok)
+	}
+	content, _ := os.ReadFile(path)
+	if !strings.Contains(string(content), "BETA") {
+		t.Fatalf("edit did not apply: %q", content)
+	}
+
+	notFound := engineExecEditFile(path, "zzznotpresent", "x")
+	if !strings.Contains(notFound, "not found") {
+		t.Fatalf("missing-string case: %q", notFound)
+	}
+
+	ambiguous := engineExecEditFile(path, "a", "X")
+	if !strings.Contains(ambiguous, "times") {
+		t.Fatalf("ambiguous-match case: %q", ambiguous)
+	}
+}
+
+func TestEngineDispatchTool_UnknownTool(t *testing.T) {
+	got := engineDispatchTool("nonexistent", map[string]interface{}{}, t.TempDir())
+	if !strings.Contains(got, "Unknown tool") {
+		t.Fatalf("unknown tool: %q", got)
+	}
+}
+
+// --- SSE parsing ---
+
+func TestParseSSEStream_SimpleCompletion(t *testing.T) {
+	stream := strings.Join([]string{
+		`: OPENROUTER PROCESSING`, // heartbeat — must be skipped
+		``,
+		`data: {"id":"gen-1","model":"anthropic/claude-opus-4.7","provider":"Anthropic","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello "}}]}`,
+		``,
+		`data: {"id":"gen-1","model":"anthropic/claude-opus-4.7","provider":"Anthropic","choices":[{"index":0,"delta":{"content":"world"}}]}`,
+		``,
+		`data: {"id":"gen-1","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop","native_finish_reason":"end_turn"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"cost":0.0001}}`,
+		``,
+		`data: [DONE]`,
+	}, "\n") + "\n"
+
+	e := &Engine{}
+	resp, err := e.parseSSEStream(strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("parseSSEStream: %v", err)
+	}
+	if resp.ID != "gen-1" {
+		t.Fatalf("ID = %q, want gen-1", resp.ID)
+	}
+	if resp.Model != "anthropic/claude-opus-4.7" {
+		t.Fatalf("Model = %q", resp.Model)
+	}
+	if resp.Provider != "Anthropic" {
+		t.Fatalf("Provider = %q", resp.Provider)
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("got %d choices", len(resp.Choices))
+	}
+	c := resp.Choices[0]
+	if c.Message == nil || c.Message.Content != "Hello world" {
+		t.Fatalf("Message.Content = %q", c.Message.Content)
+	}
+	if c.FinishReason != "stop" {
+		t.Fatalf("FinishReason = %q", c.FinishReason)
+	}
+	if c.NativeFinishReason != "end_turn" {
+		t.Fatalf("NativeFinishReason = %q", c.NativeFinishReason)
+	}
+	if resp.Usage.PromptTokens != 10 || resp.Usage.CompletionTokens != 5 || resp.Usage.Cost != 0.0001 {
+		t.Fatalf("usage mismatch: %+v", resp.Usage)
+	}
+}
+
+func TestParseSSEStream_ToolCall(t *testing.T) {
+	stream := strings.Join([]string{
+		`data: {"id":"gen-2","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"toolu_01","type":"function","function":{"name":"bash"}}]}}]}`,
+		``,
+		`data: {"id":"gen-2","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"command\":\""}}]}}]}`,
+		``,
+		`data: {"id":"gen-2","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ls /tmp\"}"}}]}}]}`,
+		``,
+		`data: {"id":"gen-2","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls","native_finish_reason":"tool_use"}]}`,
+		``,
+		`data: [DONE]`,
+	}, "\n") + "\n"
+
+	e := &Engine{}
+	resp, err := e.parseSSEStream(strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("parseSSEStream: %v", err)
+	}
+	if len(resp.Choices) != 1 || resp.Choices[0].Message == nil {
+		t.Fatalf("no message")
+	}
+	msg := resp.Choices[0].Message
+	if len(msg.ToolCalls) != 1 {
+		t.Fatalf("got %d tool_calls", len(msg.ToolCalls))
+	}
+	tc := msg.ToolCalls[0]
+	if tc.ID != "toolu_01" {
+		t.Fatalf("ToolCall.ID = %q", tc.ID)
+	}
+	if tc.Function.Name != "bash" {
+		t.Fatalf("Function.Name = %q", tc.Function.Name)
+	}
+	if tc.Function.Arguments != `{"command":"ls /tmp"}` {
+		t.Fatalf("Arguments = %q", tc.Function.Arguments)
+	}
+	if resp.Choices[0].FinishReason != "tool_calls" {
+		t.Fatalf("FinishReason = %q", resp.Choices[0].FinishReason)
+	}
+}
+
+func TestParseSSEStream_ParallelToolCalls(t *testing.T) {
+	stream := strings.Join([]string{
+		`data: {"id":"gen-3","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[` +
+			`{"index":0,"id":"toolu_a","type":"function","function":{"name":"bash","arguments":"{\"command\":\"a\"}"}},` +
+			`{"index":1,"id":"toolu_b","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"/b\"}"}}` +
+			`]},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+	}, "\n") + "\n"
+
+	e := &Engine{}
+	resp, err := e.parseSSEStream(strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("parseSSEStream: %v", err)
+	}
+	msg := resp.Choices[0].Message
+	if len(msg.ToolCalls) != 2 {
+		t.Fatalf("got %d tool_calls, want 2", len(msg.ToolCalls))
+	}
+	names := []string{msg.ToolCalls[0].Function.Name, msg.ToolCalls[1].Function.Name}
+	bothPresent := (names[0] == "bash" || names[0] == "read_file") &&
+		(names[1] == "bash" || names[1] == "read_file") &&
+		names[0] != names[1]
+	if !bothPresent {
+		t.Fatalf("unexpected tool names: %v", names)
+	}
+}
+
+func TestParseSSEStream_ErrorInStream(t *testing.T) {
+	stream := `data: {"id":"gen-x","error":{"code":529,"message":"upstream overloaded"}}` + "\n"
+	e := &Engine{}
+	_, err := e.parseSSEStream(strings.NewReader(stream))
+	if err == nil || !strings.Contains(err.Error(), "overloaded") {
+		t.Fatalf("expected overloaded error, got: %v", err)
+	}
+}
+
+// --- End-to-end against a mock OR server ---
+
+func TestExecute_HappyPath_NoTools(t *testing.T) {
+	var seenAuth string
+	var seenReferer string
+	var seenTitle string
+	var seenBody orRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != openRouterChatPath {
+			http.NotFound(w, r)
+			return
+		}
+		seenAuth = r.Header.Get("Authorization")
+		seenReferer = r.Header.Get("HTTP-Referer")
+		seenTitle = r.Header.Get("X-OpenRouter-Title")
+
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &seenBody)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		// Single chunk: assistant content + finish_reason: stop + usage.
+		_, _ = fmt.Fprintf(w, "data: %s\n\n",
+			`{"id":"gen-mock","model":"anthropic/claude-opus-4.7","provider":"Anthropic","choices":[{"index":0,"delta":{"role":"assistant","content":"PONG"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4,"cost":0.00005,"prompt_tokens_details":{"cached_tokens":0,"cache_write_tokens":0}}}`)
+		_, _ = fmt.Fprintf(w, "data: [DONE]\n")
+	}))
+	defer srv.Close()
+
+	e := NewEngine(&BackendConfig{
+		APIAuthToken: "sk-or-v1-mock",
+		APIBaseURL:   srv.URL,
+	})
+
+	var events []BackendEvent
+	res, err := e.Execute(context.Background(), ExecuteOptions{
+		Prompt:       "Reply PONG",
+		ProjectPath:  t.TempDir(),
+		EventHandler: func(ev BackendEvent) { events = append(events, ev) },
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if !res.Success {
+		t.Fatal("expected Success=true")
+	}
+	if res.Output != "PONG" {
+		t.Fatalf("Output = %q, want PONG", res.Output)
+	}
+	if res.TokensInput != 3 || res.TokensOutput != 1 {
+		t.Fatalf("tokens = (%d,%d), want (3,1)", res.TokensInput, res.TokensOutput)
+	}
+
+	// Headers
+	if seenAuth != "Bearer sk-or-v1-mock" {
+		t.Fatalf("Authorization = %q", seenAuth)
+	}
+	if seenReferer != openRouterDefaultReferer {
+		t.Fatalf("Referer = %q", seenReferer)
+	}
+	if seenTitle != openRouterDefaultTitle {
+		t.Fatalf("Title = %q", seenTitle)
+	}
+
+	// Request body sanity
+	if !seenBody.Stream {
+		t.Fatal("expected stream: true")
+	}
+	if seenBody.Usage == nil || !seenBody.Usage.Include {
+		t.Fatal("expected usage.include: true")
+	}
+	if seenBody.Reasoning == nil || seenBody.Reasoning.Effort != engineEffortHigh {
+		t.Fatalf("Reasoning = %+v", seenBody.Reasoning)
+	}
+	if seenBody.Provider != nil {
+		t.Fatalf("Provider should be nil by default (preserves sticky routing), got: %+v", seenBody.Provider)
+	}
+	if len(seenBody.Tools) != 4 {
+		t.Fatalf("got %d tools, want 4 (bash,read,write,edit)", len(seenBody.Tools))
+	}
+	if len(seenBody.Messages) < 2 || seenBody.Messages[0].Role != "system" {
+		t.Fatal("expected system message first")
+	}
+	// system content should contain cache_control with ttl:1h
+	if !strings.Contains(string(seenBody.Messages[0].Content), `"cache_control"`) {
+		t.Fatalf("system message missing cache_control: %s", seenBody.Messages[0].Content)
+	}
+	if !strings.Contains(string(seenBody.Messages[0].Content), `"ttl":"1h"`) {
+		t.Fatalf("system message missing ttl:1h: %s", seenBody.Messages[0].Content)
+	}
+
+	// Events
+	var sawInit, sawText, sawResult bool
+	for _, ev := range events {
+		switch ev.Type {
+		case EventTypeInit:
+			sawInit = true
+		case EventTypeText:
+			sawText = true
+		case EventTypeResult:
+			sawResult = true
+		}
+	}
+	if !sawInit || !sawText || !sawResult {
+		t.Fatalf("missing events: init=%v text=%v result=%v", sawInit, sawText, sawResult)
+	}
+}
+
+func TestExecute_ToolLoop(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		if calls == 1 {
+			// Turn 1: model wants to bash 'echo HI'
+			_, _ = fmt.Fprintf(w, "data: %s\n\n",
+				`{"id":"g1","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"toolu_x","type":"function","function":{"name":"bash","arguments":"{\"command\":\"echo HI\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":50,"completion_tokens":20,"cost":0.001}}`)
+		} else {
+			// Turn 2: model says done
+			_, _ = fmt.Fprintf(w, "data: %s\n\n",
+				`{"id":"g2","choices":[{"index":0,"delta":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":60,"completion_tokens":2,"cost":0.0005}}`)
+		}
+		_, _ = fmt.Fprintf(w, "data: [DONE]\n")
+	}))
+	defer srv.Close()
+
+	e := NewEngine(&BackendConfig{
+		APIAuthToken: "sk-or-v1-mock",
+		APIBaseURL:   srv.URL,
+	})
+
+	var toolEvents []BackendEvent
+	res, err := e.Execute(context.Background(), ExecuteOptions{
+		Prompt:      "do a thing",
+		ProjectPath: t.TempDir(),
+		EventHandler: func(ev BackendEvent) {
+			if ev.Type == EventTypeToolUse || ev.Type == EventTypeToolResult {
+				toolEvents = append(toolEvents, ev)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 API calls, got %d", calls)
+	}
+	if !res.Success {
+		t.Fatal("expected Success=true")
+	}
+	if res.Output != "OK" {
+		t.Fatalf("Output = %q, want OK", res.Output)
+	}
+	if res.TokensInput != 110 || res.TokensOutput != 22 {
+		t.Fatalf("aggregated tokens wrong: in=%d out=%d", res.TokensInput, res.TokensOutput)
+	}
+	if len(toolEvents) != 2 { // one ToolUse, one ToolResult
+		t.Fatalf("got %d tool events, want 2", len(toolEvents))
+	}
+	if toolEvents[0].ToolName != "bash" {
+		t.Fatalf("ToolName = %q", toolEvents[0].ToolName)
+	}
+	if !strings.Contains(toolEvents[1].ToolResult, "HI") {
+		t.Fatalf("tool result missing 'HI': %q", toolEvents[1].ToolResult)
+	}
+}
+
+func TestExecute_RetryOn429(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(429)
+			// Embed retry_after_seconds:0 so the test doesn't actually wait.
+			_, _ = w.Write([]byte(`{"error":{"code":429,"message":"rate limited","metadata":{"retry_after_seconds":0}}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n",
+			`{"id":"g","choices":[{"index":0,"delta":{"role":"assistant","content":"recovered"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+		_, _ = fmt.Fprintf(w, "data: [DONE]\n")
+	}))
+	defer srv.Close()
+
+	// Override backoffs to zero for the test (avoid 30s sleep).
+	originalBackoffs := engineRetryBackoffs
+	engineRetryBackoffs = []time.Duration{0}
+	defer func() { engineRetryBackoffs = originalBackoffs }()
+
+	e := NewEngine(&BackendConfig{
+		APIAuthToken: "sk-or-v1-mock",
+		APIBaseURL:   srv.URL,
+	})
+
+	res, err := e.Execute(context.Background(), ExecuteOptions{
+		Prompt:      "p",
+		ProjectPath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls (429 + recovery), got %d", calls)
+	}
+	if !res.Success || res.Output != "recovered" {
+		t.Fatalf("res = %+v", res)
+	}
+}
+
+func TestExecute_NoAPIKey(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "")
+	e := NewEngine(&BackendConfig{})
+	_, err := e.Execute(context.Background(), ExecuteOptions{Prompt: "x", ProjectPath: t.TempDir()})
+	if err == nil {
+		t.Fatal("expected error when no key")
+	}
+	if !strings.Contains(err.Error(), "OPENROUTER_API_KEY") {
+		t.Fatalf("error should mention OPENROUTER_API_KEY, got: %v", err)
+	}
+}
+
+// --- Live smoke test, gated by env var ---
+// Run with: OPENROUTER_API_KEY=... go test -run TestEngineSmoke ./internal/executor/ -v
+
+func TestEngineSmoke(t *testing.T) {
+	key := os.Getenv("OPENROUTER_API_KEY")
+	if key == "" {
+		t.Skip("smoke test requires OPENROUTER_API_KEY")
+	}
+
+	e := NewEngine(&BackendConfig{})
+	// Cheapest possible call: Haiku + tight max_tokens. Lets a credit-limited
+	// key (a few cents) still validate the full request/response loop.
+	e.maxOutputToks = 200
+
+	res, err := e.Execute(context.Background(), ExecuteOptions{
+		Prompt:      "You are a test assistant. Reply with exactly: SMOKE OK. Do not use any tools.",
+		ProjectPath: t.TempDir(),
+		Model:       "anthropic/claude-haiku-4.5",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !res.Success {
+		// 402 (credit cap) is a real-world result, not a code bug. The fact that
+		// we got a structured error back means auth/headers/parsing all worked.
+		if strings.Contains(res.Error, "402") || strings.Contains(res.Error, "credits") {
+			t.Skipf("OR key out of credit (engine round-trip otherwise OK): %s", res.Error)
+		}
+		t.Fatalf("smoke failed: %+v", res)
+	}
+	t.Logf("smoke ok: output=%q tokens=(%d,%d)", res.Output, res.TokensInput, res.TokensOutput)
+}


### PR DESCRIPTION
## Summary

Park two half-baked WIP artifacts under \`.agent/drafts/\` so Pilot can pick them up via dedicated GH issues rather than re-implementing from scratch:

- **task-312-engine/** — Go OpenRouter execution engine (33KB, 22 tests pass standalone, needs \`backend_factory.go\` wire-up to integrate)
- **task-305-hooks/** — workflow lifecycle hooks (compile-breaks against current \`internal/executor/workflow/\` since \`HookConfig\` fields are now \`interface{}\`)

\`README.md\` documents the convention: each draft is deleted in the same PR that lands the real implementation.

## Reconciliation context

Surfaced during Wave 4 reconciliation. Most other "uncommitted" artifacts turned out to be stale predecessors of already-shipped main code:
- TASK-294 → shipped via fa2d8045
- TASK-301 → shipped via ea80c3c7
- TASK-302 → shipped via 90d78419
- TASK-304 → shipped via ba268fc3
- TASK-300 ghost-SHA guard → shipped via 5384ddc2 (PR #3193, made PR #3189 redundant — closed)
- \`internal/metrics/metrics.go\` → orphan with no callers (discarded)

Only these two were legit half-baked work worth preserving.

## Test plan
- [ ] Docs-only — no tests
- [ ] Reviewer confirms \`drafts/README.md\` convention is clear