### PR TITLE
feat(workflow): TASK-305 lifecycle hooks — after_create, before_run, after_run, before_remove

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -51,6 +51,8 @@
 | Claude Code hooks v2 | ✅ | executor | - | - | Matcher-based hook format for CC 2.1.42+ (v1.14.0, GH-1366) |
 | Claude Code hooks v3 | ✅ | executor | - | - | Regex matcher string, Stop hooks no matcher field (v1.50.0) |
 | Stale hook cleanup | ✅ | executor | - | - | Cleanup on startup regardless of hooks config (v2.10.1, GH-1749) |
+| Per-repo workflow.yaml | ✅ | executor/workflow | - | - | `.pilot/workflow.yaml` overrides max_turns, reasoning_effort, policy, appends prompt (TASK-304, GH-3203) |
+| Workflow lifecycle hooks | ✅ | executor/workflow | - | - | `after_create`, `before_run`, `after_run`, `before_remove` bash scripts in `.pilot/workflow.yaml` (TASK-305, GH-3203) |
 | Pre-push lint gate | ✅ | executor | - | - | Run golangci-lint before creating PRs (v1.15.0, GH-1376) |
 | Navigator context bridge | ✅ | executor | - | - | Load project context (key files, components) into execution prompt (v1.18.0, GH-1387) |
 | Navigator docs auto-update | ✅ | executor | - | - | Auto-update feature matrix + knowledge capture post-execution (v1.19.0, GH-1388) |
@@ -563,7 +565,7 @@ quality:
 | Feature | Version | Package | Notes |
 |---------|---------|---------|-------|
 | Poller skip-by-reason counters | v2.150.0 | adapters/github | `pilot_poller_skipped/dispatched/deferred` Prometheus counters (TASK-293 / GH-3064) |
-| `WithRetry` centralized in `doRequest` | v2.152.0 | adapters/github | All 51 GitHub client methods get uniform retry via `doRequest`; Retry-After capped at MaxDelay (TASK-294-redo / GH-3114) |
+| `WithRetry` centralized in `doRequest` | v2.150.0 | adapters/github | All GitHub client methods now get retry; `RecordAPIError` wired (TASK-294 / GH-3065) |
 | Linear webhook Ed25519 verification | v2.149.4 | gateway + adapters/linear | `VerifyLinearSignature`; YAML wiring added in v2.151.0 (TASK-295 / GH-3060, GH-3066) |
 | `quality.parallel` defaults to `false` | v2.149.4 | executor | Eliminates shared build-cache race (TASK-289 / GH-3057) |
 | Config file mode 0600 | v2.149.4 | config | `~/.pilot/config.yaml` world-readable fixed (TASK-290 / GH-3058) |
@@ -571,4 +573,4 @@ quality:
 | Repo allowlist Phase B | v2.149.0 | adapters/github | `CreatePilotIssue` validates against allowlist (GH-3047) |
 | `safeGo()` panic-recovery wrapper | v2.150.x | executor + adapters | All goroutine spawns wrapped (TASK-292) |
 | `IsTaskShipped` predicate | v2.151.x | autopilot | Cross-site invariant preventing double-dispatch (TASK-296 / GH-3091) |
-| Ghost-SHA guard | v2.155.x | executor | `commitSHAIsNew` blocks parent-SHA ghost-closes; `IsTaskShipped` requires error="" for SHA-only trust; orphan-recovery divergence resolved (TASK-300 / GH-3126) |
+| Ghost-SHA guard | v2.151.x | executor | Fail-closed when commit_sha already on base branch (TASK-300 / GH-3099) |

--- a/.agent/tasks/gh-3203.md
+++ b/.agent/tasks/gh-3203.md
@@ -1,0 +1,56 @@
+# GH-3203
+
+**Created:** 2026-05-27
+
+## Problem
+
+GitHub Issue #3203: TASK-305: workflow lifecycle hooks — adapt draft to main's HookConfig API
+
+## Task
+
+Pick up the draft \`hooks.go\` + \`hooks_test.go\` from \`.agent/drafts/task-305-hooks/\` and adapt them to compile against main's current \`internal/executor/workflow/workflow.go\`.
+
+## Draft contents
+
+- \`.agent/drafts/task-305-hooks/hooks.go\` (~66 LOC) — \`RunHook(ctx, name, scripts HookValue, dir, env, timeout, logFn)\` executes scripts sequentially via \`bash -lc\`, per-hook timeout, returns first error
+- \`.agent/drafts/task-305-hooks/hooks_test.go\` (~132 LOC) — covers nil/empty, sequential exec, timeout, env passthrough, first-failure-stops-rest
+
+## Why it doesn't compile as-is
+
+\`workflow.go\` on main (shipped via TASK-304 / ba268fc3) declares:
+
+\`\`\`go
+type HookConfig struct {
+    AfterCreate  interface{} \`yaml:"after_create,omitempty"\`
+    BeforeRun    interface{} \`yaml:"before_run,omitempty"\`
+    AfterRun     interface{} \`yaml:"after_run,omitempty"\`
+    BeforeRemove interface{} \`yaml:"before_remove,omitempty"\`
+}
+// Hooks is parsed but not executed in this version (TASK-305).
+\`\`\`
+
+The draft assumes a named \`HookValue\` type (likely \`[]string\` from YAML, normalized from \`interface{}\`). That type doesn't exist on main yet.
+
+## Scope of this issue
+
+1. Move \`hooks.go\` + \`hooks_test.go\` from \`.agent/drafts/task-305-hooks/\` to \`internal/executor/workflow/\`
+2. Delete \`.agent/drafts/task-305-hooks/\` in the same commit
+3. Define \`HookValue\` (likely \`[]string\`) in \`workflow.go\` or \`hooks.go\`
+4. Add a normalizer: convert \`HookConfig.{AfterCreate,BeforeRun,AfterRun,BeforeRemove} interface{}\` → \`HookValue\`. YAML can deliver these as \`nil\`, a single string, or a list of strings — all three must work.
+5. Make \`hooks_test.go\` build + pass (the test also references a \`writeFile\` helper that needs to be added)
+6. Wire \`RunHook\` calls into the executor lifecycle (after_create, before_run, after_run, before_remove) — verify with an integration test if practical
+7. Add per-hook timeout knob to \`AgentOverrides\` (or accept the \`DefaultHookTimeout = 300s\` from the draft)
+
+## Acceptance
+
+- \`go build ./...\` clean
+- \`go test ./internal/executor/workflow/...\` clean
+- Sample \`.pilot/workflow.yaml\` with a \`hooks:\` section actually runs the scripts when triggered
+- \`.agent/drafts/task-305-hooks/\` directory removed in same commit
+
+## Context
+
+Original draft was written against an older version of \`workflow.go\` (lower-case constants, typed \`HookValue\` field). That older code never landed; main's shipped version (ba268fc3) chose \`interface{}\` for the hook fields, deferring typing to TASK-305. This issue is TASK-305.
+
+## Acceptance Criteria
+

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1255,9 +1255,16 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		r.reportProgress(task.ID, "Worktree", 2, "Worktree ready")
 	}
 
-	// Ensure worktree cleanup on exit (handles panic, early return, success)
+	// Ensure worktree cleanup on exit (handles panic, early return, success).
+	// before_remove hook fires just before worktree teardown (TASK-305).
+	var beforeRemoveHookFn func()
 	if cleanupWorktree != nil {
-		defer cleanupWorktree()
+		defer func() {
+			if beforeRemoveHookFn != nil {
+				beforeRemoveHookFn()
+			}
+			cleanupWorktree()
+		}()
 	}
 
 	// GH-915: Run pre-flight checks to catch environmental issues early
@@ -1702,6 +1709,20 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		workflowMaxTurns = repoWorkflow.Agent.MaxTurns
 	}
 
+	// TASK-305: fire after_create and wire before_remove now that the workflow is loaded.
+	var hookEnv []string
+	if repoWorkflow != nil {
+		hookEnv = append(os.Environ(), "PILOT_TASK_ID="+task.ID)
+		runWorkflowHook(ctx, "after_create", repoWorkflow.Hooks.AfterCreate, executionPath, hookEnv, log)
+		if len(repoWorkflow.Hooks.BeforeRemove) > 0 {
+			scripts := repoWorkflow.Hooks.BeforeRemove
+			env := hookEnv
+			beforeRemoveHookFn = func() {
+				runWorkflowHook(context.Background(), "before_remove", scripts, executionPath, env, log)
+			}
+		}
+	}
+
 	// Build the prompt
 	prompt := r.BuildPrompt(task, executionPath)
 
@@ -1827,6 +1848,11 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	// Execute via backend with watchdog (GH-882)
 	// Watchdog kills subprocess after 2x timeout as a safety net for processes
 	// that ignore context cancellation.
+	// TASK-305: before_run hook fires just before agent execution.
+	if repoWorkflow != nil {
+		runWorkflowHook(ctx, "before_run", repoWorkflow.Hooks.BeforeRun, executionPath, hookEnv, log)
+	}
+
 	watchdogTimeout := 2 * timeout
 	allowedTools, mcpConfigPath := r.executionToolOptions()
 	backendResult, err := r.backend.Execute(stallExecutionCtx, ExecuteOptions{
@@ -1883,6 +1909,11 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	// Stop stall watchdog and release stall context resources.
 	close(stallDone)
 	stallCancel()
+
+	// TASK-305: after_run hook fires as soon as the agent finishes (success or error).
+	if repoWorkflow != nil {
+		runWorkflowHook(ctx, "after_run", repoWorkflow.Hooks.AfterRun, executionPath, hookEnv, log)
+	}
 
 	// Transfer stallDetected flag to progressState for post-Execute checks.
 	if stallDetectedFlag.Load() {
@@ -4731,4 +4762,18 @@ func (r *Runner) getPostExecutionSummary(ctx context.Context) (*PostExecutionSum
 	}
 
 	return &summary, nil
+}
+
+// runWorkflowHook executes a workflow lifecycle hook, logging output and warning on failure.
+// It is a no-op when scripts is empty.
+func runWorkflowHook(ctx context.Context, name string, scripts workflow.HookValue, dir string, env []string, log *slog.Logger) {
+	if len(scripts) == 0 {
+		return
+	}
+	logFn := func(output string) {
+		log.Info("hook output", slog.String("hook", name), slog.String("output", strings.TrimSpace(output)))
+	}
+	if err := workflow.RunHook(ctx, name, scripts, dir, env, 0, logFn); err != nil {
+		log.Warn("workflow hook failed", slog.String("hook", name), slog.Any("error", err))
+	}
 }

--- a/internal/executor/workflow/hooks.go
+++ b/internal/executor/workflow/hooks.go
@@ -1,0 +1,75 @@
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultHookTimeout is the per-script timeout applied when the caller passes 0.
+const DefaultHookTimeout = 5 * time.Minute
+
+// HookValue is an ordered list of shell scripts executed sequentially for one lifecycle event.
+// YAML accepts: null/omit (no-op), a single string, or a list of strings — all normalised here.
+type HookValue []string
+
+// UnmarshalYAML allows a HookValue field to accept null, a single string, or a sequence.
+func (h *HookValue) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		if value.Tag == "!!null" || value.Value == "" {
+			*h = nil
+			return nil
+		}
+		*h = HookValue{value.Value}
+	case yaml.SequenceNode:
+		var ss []string
+		if err := value.Decode(&ss); err != nil {
+			return fmt.Errorf("hook: decode sequence: %w", err)
+		}
+		*h = ss
+	default:
+		return fmt.Errorf("hook: unsupported YAML type %s", value.Tag)
+	}
+	return nil
+}
+
+// RunHook executes each script in scripts sequentially via bash -lc.
+// It stops and returns the first error; subsequent scripts are skipped.
+// timeout applies per-script; 0 uses DefaultHookTimeout.
+// logFn, if non-nil, receives combined stdout+stderr from each script.
+func RunHook(ctx context.Context, name string, scripts HookValue, dir string, env []string, timeout time.Duration, logFn func(string)) error {
+	if len(scripts) == 0 {
+		return nil
+	}
+	if timeout <= 0 {
+		timeout = DefaultHookTimeout
+	}
+	for i, script := range scripts {
+		hctx, cancel := context.WithTimeout(ctx, timeout)
+		out, err := runScript(hctx, script, dir, env)
+		cancel()
+		if logFn != nil && len(out) > 0 {
+			logFn(string(out))
+		}
+		if err != nil {
+			return fmt.Errorf("hook %s[%d]: %w", name, i, err)
+		}
+	}
+	return nil
+}
+
+func runScript(ctx context.Context, script, dir string, env []string) ([]byte, error) {
+	var buf bytes.Buffer
+	cmd := exec.CommandContext(ctx, "bash", "-lc", script)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.Bytes(), err
+}

--- a/internal/executor/workflow/hooks_test.go
+++ b/internal/executor/workflow/hooks_test.go
@@ -1,0 +1,145 @@
+package workflow_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/executor/workflow"
+)
+
+// writeFile creates a file with content under dir and returns its path.
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("writeFile %s: %v", name, err)
+	}
+	return p
+}
+
+func TestRunHook_Nil(t *testing.T) {
+	err := workflow.RunHook(context.Background(), "after_create", nil, t.TempDir(), os.Environ(), 0, nil)
+	if err != nil {
+		t.Fatalf("nil scripts: unexpected error %v", err)
+	}
+}
+
+func TestRunHook_Empty(t *testing.T) {
+	err := workflow.RunHook(context.Background(), "after_create", workflow.HookValue{}, t.TempDir(), os.Environ(), 0, nil)
+	if err != nil {
+		t.Fatalf("empty scripts: unexpected error %v", err)
+	}
+}
+
+func TestRunHook_Sequential(t *testing.T) {
+	dir := t.TempDir()
+	log := writeFile(t, dir, "log.txt", "")
+	scripts := workflow.HookValue{
+		fmt.Sprintf("echo first >> %s", log),
+		fmt.Sprintf("echo second >> %s", log),
+		fmt.Sprintf("echo third >> %s", log),
+	}
+	if err := workflow.RunHook(context.Background(), "test", scripts, dir, os.Environ(), 0, nil); err != nil {
+		t.Fatalf("RunHook: %v", err)
+	}
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	got := strings.TrimSpace(string(data))
+	if want := "first\nsecond\nthird"; got != want {
+		t.Errorf("execution order:\ngot  %q\nwant %q", got, want)
+	}
+}
+
+func TestRunHook_Timeout(t *testing.T) {
+	dir := t.TempDir()
+	err := workflow.RunHook(context.Background(), "test", workflow.HookValue{"sleep 30"}, dir, os.Environ(), 50*time.Millisecond, nil)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+func TestRunHook_EnvPassthrough(t *testing.T) {
+	dir := t.TempDir()
+	out := writeFile(t, dir, "env.txt", "")
+	env := append(os.Environ(), "PILOT_HOOK_TEST=hello_hooks")
+	scripts := workflow.HookValue{fmt.Sprintf("echo $PILOT_HOOK_TEST > %s", out)}
+	if err := workflow.RunHook(context.Background(), "test", scripts, dir, env, 0, nil); err != nil {
+		t.Fatalf("RunHook: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "hello_hooks" {
+		t.Errorf("env var: got %q, want %q", got, "hello_hooks")
+	}
+}
+
+func TestRunHook_FirstFailureStopsRest(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "sentinel")
+	scripts := workflow.HookValue{
+		"exit 1",
+		fmt.Sprintf("touch %s", sentinel),
+	}
+	if err := workflow.RunHook(context.Background(), "test", scripts, dir, os.Environ(), 0, nil); err == nil {
+		t.Fatal("expected error from failing script")
+	}
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Error("second script ran after first failure")
+	}
+}
+
+func TestRunHook_LogFn(t *testing.T) {
+	dir := t.TempDir()
+	var captured []string
+	logFn := func(s string) { captured = append(captured, s) }
+	if err := workflow.RunHook(context.Background(), "test", workflow.HookValue{"echo pilot_hook_output"}, dir, os.Environ(), 0, logFn); err != nil {
+		t.Fatalf("RunHook: %v", err)
+	}
+	if len(captured) == 0 {
+		t.Fatal("logFn was never called")
+	}
+	if combined := strings.Join(captured, ""); !strings.Contains(combined, "pilot_hook_output") {
+		t.Errorf("logFn output %q missing expected string", combined)
+	}
+}
+
+func TestHookValue_YAML(t *testing.T) {
+	dir := t.TempDir()
+	writeWorkflow(t, dir, `---
+version: 1
+hooks:
+  after_create: echo hello
+  before_run:
+    - echo step1
+    - echo step2
+  after_run: null
+---
+`)
+	w, err := workflow.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if w == nil {
+		t.Fatal("expected non-nil Workflow")
+	}
+	if got := len(w.Hooks.AfterCreate); got != 1 {
+		t.Errorf("AfterCreate: len=%d, want 1", got)
+	} else if w.Hooks.AfterCreate[0] != "echo hello" {
+		t.Errorf("AfterCreate[0]: got %q, want %q", w.Hooks.AfterCreate[0], "echo hello")
+	}
+	if got := len(w.Hooks.BeforeRun); got != 2 {
+		t.Errorf("BeforeRun: len=%d, want 2", got)
+	}
+	if w.Hooks.AfterRun != nil {
+		t.Errorf("AfterRun: expected nil, got %v", w.Hooks.AfterRun)
+	}
+}

--- a/internal/executor/workflow/workflow.go
+++ b/internal/executor/workflow/workflow.go
@@ -45,13 +45,13 @@ type PolicyOverrides struct {
 	PRTemplate string `yaml:"pr_template,omitempty"`
 }
 
-// HookConfig holds hook definitions. Parsed for forward-compatibility;
-// hook execution is implemented in TASK-305.
+// HookConfig holds lifecycle hook scripts for the workflow.
+// Each field accepts null, a single string, or a list of strings in YAML.
 type HookConfig struct {
-	AfterCreate  interface{} `yaml:"after_create,omitempty"`
-	BeforeRun    interface{} `yaml:"before_run,omitempty"`
-	AfterRun     interface{} `yaml:"after_run,omitempty"`
-	BeforeRemove interface{} `yaml:"before_remove,omitempty"`
+	AfterCreate  HookValue `yaml:"after_create,omitempty"`
+	BeforeRun    HookValue `yaml:"before_run,omitempty"`
+	AfterRun     HookValue `yaml:"after_run,omitempty"`
+	BeforeRemove HookValue `yaml:"before_remove,omitempty"`
 }
 
 // Workflow is the parsed representation of .pilot/workflow.yaml.
@@ -65,7 +65,7 @@ type Workflow struct {
 	// Policy contains policy fields exposed to the prompt.
 	Policy PolicyOverrides `yaml:"policy,omitempty"`
 
-	// Hooks is parsed but not executed in this version (TASK-305).
+	// Hooks defines lifecycle scripts executed at specific points in the task lifecycle.
 	Hooks HookConfig `yaml:"hooks,omitempty"`
 
 	// PromptAppendix is the Markdown body after the closing --- delimiter.


### PR DESCRIPTION
## Summary

- **New `HookValue` type** (`[]string`) in `internal/executor/workflow/hooks.go` with a `yaml.Unmarshaler` that accepts null, a single string, or a list of strings
- **`RunHook`** executes scripts sequentially via `bash -lc`; enforces per-script timeout (default 5 min); stops on first error; streams combined stdout+stderr to caller's `logFn`
- **`HookConfig` updated** — fields changed from `interface{}` to `HookValue` in `workflow.go`
- **Executor wiring** in `runner.go`:
  - `after_create` fires after workflow is loaded (environment is ready, before prompt build)
  - `before_run` fires immediately before `r.backend.Execute`
  - `after_run` fires as soon as the agent finishes (success or error)
  - `before_remove` fires via deferred closure just before worktree teardown
- **8 new tests** covering nil/empty no-op, sequential order, timeout, env passthrough, first-failure-stops-rest, logFn output, and YAML unmarshaling edge cases

Closes #3203

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/executor/workflow/...` — all 8 new hook tests pass
- [x] `go test ./internal/executor/...` — full executor suite passes (96s)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues