### PR TITLE
docs(.agent/memories): session 2026-05-27 feedback + pitfall learnings

### DIFF
--- a/.agent/knowledge/memories/learnings/feedback_check_state_before_designing.md
+++ b/.agent/knowledge/memories/learnings/feedback_check_state_before_designing.md
@@ -1,0 +1,16 @@
+---
+name: check-state-before-designing
+description: When asked to design a recurring check, monitor, or workflow, FIRST run the check once and look at the result. If the result is empty/trivial, lead with that fact, not with the design.
+type: feedback
+---
+
+When the user asks to design a recurring check, monitor, polling loop, or similar workflow, **run the check once first and look at the actual result**. Then decide whether the workflow is even worth building.
+
+**Why:** Stated on 2026-05-27. User asked about setting up a recurring Pilot queue check. I'd already run the queries earlier in the session and seen the queue was empty (0 open PRs, all Wave 4 shipped, daemon down). Instead of leading with "queue is empty, loop is pointless," I produced paragraphs of loop-body design — work generated for a non-problem. User had to push back twice.
+
+**How to apply:**
+
+- Before describing what a recurring check would *do*, run the check once and report the current result
+- If the result is empty / trivial / "nothing happening," lead with that. Don't proceed to design unless asked
+- Treat "design me a monitor" as "tell me whether monitoring is needed right now" first, design second
+- Apply the same to any "let's automate X" request — check whether X is happening at all before automating it

--- a/.agent/knowledge/memories/learnings/feedback_no_apologies_just_working_project.md
+++ b/.agent/knowledge/memories/learnings/feedback_no_apologies_just_working_project.md
@@ -1,0 +1,17 @@
+---
+name: no-apologies-just-working-project
+description: User does not want apologies or reassurance. User wants a perfectly working project. Verify build/tests after every change, never leave the project broken, no apology theater.
+type: feedback
+---
+
+User does not want apologies or reassurance language. **The deliverable is a perfectly working project.**
+
+**Why:** Stated explicitly on 2026-05-27 after I broke the build with an unverified wipe and responded with apologies. Apologies don't undo damage; verification before/after each change does.
+
+**How to apply:**
+
+- After any change to the project, run `go build ./...` (and tests where relevant) and confirm exit 0 before reporting done
+- Never leave the working tree, main repo, or any branch in a broken state — if a change breaks something, fix it or revert it before yielding control
+- Skip "sorry", "apologies", "my mistake" framing. State the technical fact (what broke, what fixed it) and move on
+- Verify pre-conditions before destructive ops (pwd, branch, status, build) — don't trust the picture from earlier in the session
+- If something breaks, the priority is restoration + verification, not explanation

--- a/.agent/knowledge/memories/learnings/feedback_use_worktree_for_reconciliation.md
+++ b/.agent/knowledge/memories/learnings/feedback_use_worktree_for_reconciliation.md
@@ -1,0 +1,15 @@
+---
+name: use-worktree-for-multi-branch-work
+description: For reconciliation, branch splits, or any multi-branch work in the Pilot repo, create a fresh git worktree under .claude/worktrees/ — don't operate on a checked-out feature branch in the main repo
+type: feedback
+---
+
+For reconciliation, branch splits, or any work that touches multiple branches in the Pilot repo, **work in a fresh git worktree under `.claude/worktrees/`** — don't operate from the main repo's checked-out feature branch.
+
+**Why:** The main repo's working tree may be hosting another agent's in-flight work, or be on a feature branch you'd disturb by switching/stashing. The Pilot project uses worktrees as the standard isolation pattern — `git worktree list` typically shows `.claude/worktrees/<name>` worktrees for active Claude sessions, and the executor itself runs in worktrees per `pilot/GH-*` branches.
+
+**How to apply:**
+- Before any non-trivial multi-branch session, run `git worktree list`
+- Create one with `git worktree add -b <branch-name> .claude/worktrees/<slug> <base-ref>`
+- Move work-in-progress into the new worktree (stash + pop, or copy files via patch)
+- Leave the main repo's working tree alone

--- a/.agent/knowledge/memories/pitfalls/pitfall_verify_branch_before_destructive_ops.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_verify_branch_before_destructive_ops.md
@@ -1,0 +1,22 @@
+---
+name: verify-branch-and-working-tree-before-destructive-ops
+description: Before ANY destructive op (rm, git checkout HEAD --, branch delete, wipe) in the Pilot main repo, run pwd + git status + git rev-parse HEAD and READ the output. The main repo working tree often holds in-progress work from other sessions.
+type: pitfall
+---
+
+Before ANY destructive op in the Pilot main repo (`rm`, `git checkout HEAD -- <file>`, `git stash drop`, branch deletes, wipes), **stop and verify** what's actually there. Required pre-flight:
+
+1. `pwd` — confirm you're in the directory you think you're in
+2. `git rev-parse --abbrev-ref HEAD` — confirm the branch
+3. `git status --short -uall` — confirm what's modified AND what's untracked
+4. **READ the output**. Don't skim. The main repo's working tree often hosts in-progress work made outside the current session — from other Claude agents, from offline manual edits, from Pilot executor sessions.
+
+**Why:** During a Wave 4 reconciliation session (2026-05-27), I (Claude) wiped 14 untracked files from the main repo to "clean up duplicates" — but `backend_factory.go` and `runner.go` had **tracked** modifications from another session that depended on those untracked files (engine.go, workflow/*). Wipe broke the build. User had to intervene angrily. Recovery was only possible because a tar backup was made earlier.
+
+**How to apply:**
+
+- For any destructive op on the main repo, prefer `git stash push -u -m "<context>"` over `rm` so the action is reversible
+- If files appear "duplicate" with another branch/PR, that does NOT mean they're disposable — they may be the source dependencies of tracked-file modifications you haven't noticed yet
+- Always run a `go build ./...` before AND after touching the working tree to catch breakage immediately
+- Prefer working in a `.claude/worktrees/<name>` worktree over operating on the main repo — leaves main repo's in-flight state alone
+- If you discover unexpected tracked modifications mid-session (files that weren't M at session start), STOP. Don't proceed with cleanup until you've inspected the diff and understood whose work it is


### PR DESCRIPTION
## Summary

Four operational learnings captured during the Wave 4 reconciliation session, routed to Navigator memory per project CLAUDE.md (auto-memory deprecated for new writes).

| File | Type | What it captures |
|---|---|---|
| \`feedback_use_worktree_for_reconciliation\` | learning | Use \`.claude/worktrees/\` for multi-branch work, not the main repo's checked-out feature branch |
| \`feedback_no_apologies_just_working_project\` | learning | Verify build/tests after every change; lead with technical fact, not reassurance |
| \`feedback_check_state_before_designing\` | learning | Run a check once before designing a recurring monitor; don't manufacture work |
| \`pitfall_verify_branch_before_destructive_ops\` | pitfall | \`pwd\` + \`git status\` + READ output before any \`rm\` / \`checkout --\` / branch delete |

## Test plan
- [ ] Docs-only PR — no tests