### PR TITLE
fix(autopilot): replace releasedCommits map with GetTagForSHA in scanner (TASK-314)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2235,21 +2235,6 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 
 	c.log.Debug("found closed PRs", "total", len(prs))
 
-	// Get recent releases to check for existing releases
-	releases, err := c.ghClient.ListReleases(ctx, c.owner, c.repo, 20)
-	if err != nil {
-		c.log.Warn("failed to list releases, continuing without release check", "error", err)
-		releases = nil
-	}
-
-	// Build set of release target commits for quick lookup
-	releasedCommits := make(map[string]bool)
-	for _, rel := range releases {
-		if rel.TargetCommitish != "" {
-			releasedCommits[rel.TargetCommitish] = true
-		}
-	}
-
 	cutoff := time.Now().Add(-scanWindow)
 	triggered := 0
 
@@ -2306,13 +2291,26 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			continue
 		}
 
-		// Skip if release already exists for this merge commit
-		if pr.MergeCommitSHA != "" && releasedCommits[pr.MergeCommitSHA] {
-			c.log.Debug("skipping PR: release already exists",
-				"pr", pr.Number,
-				"merge_sha", ShortSHA(pr.MergeCommitSHA),
-			)
-			continue
+		// Skip if this merge commit already has a release tag.
+		// GitHub releases set target_commitish to the branch ref ("main"), not the merge
+		// SHA, so the former map-based check was unreliable. GetTagForSHA (same primitive
+		// handleReleasing uses) is the reliable check.
+		if pr.MergeCommitSHA != "" {
+			existingTag, tagErr := c.ghClient.GetTagForSHA(ctx, c.owner, c.repo, pr.MergeCommitSHA)
+			if tagErr != nil {
+				c.log.Warn("failed to check existing tag for PR, will track to be safe",
+					"pr", pr.Number,
+					"merge_sha", ShortSHA(pr.MergeCommitSHA),
+					"error", tagErr,
+				)
+			} else if existingTag != "" {
+				c.log.Debug("skipping PR: merge commit already tagged",
+					"pr", pr.Number,
+					"merge_sha", ShortSHA(pr.MergeCommitSHA),
+					"tag", existingTag,
+				)
+				continue
+			}
 		}
 
 		c.log.Info("found merged Pilot PR needing release",

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -5995,9 +5995,8 @@ func TestController_ScanRecentlyMergedPRs_RecordsMetrics(t *testing.T) {
 // TestController_ScanRecentlyMergedPRs_RecordsMetricsDespiteExistingRelease
 // reproduces the bug where Pilot's own self-release pipeline always tags every
 // merge within ~1min, so by the time the ~5-15min scanner tick runs the
-// "release already exists" gate at line 2186 skips the PR before metrics
-// fire. The recorder must fire BEFORE the gate so counters move in
-// stage-mode auto-merge.
+// "already tagged" gate skips the PR before metrics fire. The recorder must
+// fire BEFORE the gate so counters move in stage-mode auto-merge.
 func TestController_ScanRecentlyMergedPRs_RecordsMetricsDespiteExistingRelease(t *testing.T) {
 	recentMergedAt := time.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339)
 	recentCreatedAt := time.Now().Add(-12 * time.Minute).UTC().Format(time.RFC3339)
@@ -6015,20 +6014,19 @@ func TestController_ScanRecentlyMergedPRs_RecordsMetricsDespiteExistingRelease(t
 		MergeCommitSHA: mergeSHA,
 	}
 
-	// Release already exists for the merge SHA (Pilot's self-shipping pattern).
-	existingRelease := github.Release{
-		TagName:         "v9.9.9",
-		TargetCommitish: mergeSHA,
-	}
+	// Tag already exists at the merge SHA (Pilot's self-shipping pattern).
+	existingTag := github.Tag{Name: "v9.9.9", Commit: struct {
+		SHA string `json:"sha"`
+	}{SHA: mergeSHA}}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode([]*github.PullRequest{&pilotPR})
-		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/releases"):
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/tags"):
 			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode([]*github.Release{&existingRelease})
+			_ = json.NewEncoder(w).Encode([]*github.Tag{&existingTag})
 		default:
 			w.WriteHeader(http.StatusOK)
 		}
@@ -6081,6 +6079,135 @@ func TestController_ScanRecentlyMergedPRs_RecordsMetricsDespiteExistingRelease(t
 	snap2 := c.metrics.Snapshot()
 	if snap2.PRsMerged != 1 {
 		t.Errorf("after second scan: PRsMerged = %d, want 1 (idempotent)", snap2.PRsMerged)
+	}
+}
+
+// TestController_ScanRecentlyMergedPRs_SkipsTaggedMergeCommit reproduces GH-3218:
+// releases have target_commitish="main" (branch ref, not SHA), so the former
+// releasedCommits map lookup was never matching. The scanner must skip PRs whose
+// merge commit has a release tag regardless of target_commitish.
+func TestController_ScanRecentlyMergedPRs_SkipsTaggedMergeCommit(t *testing.T) {
+	recentMergedAt := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	mergeSHA := "abc123def456"
+
+	pilotPR := github.PullRequest{
+		Number:         55,
+		Head:           github.PRRef{Ref: "pilot/GH-200", SHA: "headsha55"},
+		Base:           github.PRRef{Ref: "main"},
+		HTMLURL:        "https://github.com/owner/repo/pull/55",
+		Title:          "feat(api): endpoint",
+		Merged:         true,
+		MergedAt:       recentMergedAt,
+		MergeCommitSHA: mergeSHA,
+	}
+
+	// Tag exists at the merge SHA. target_commitish is "main" (branch ref, not SHA),
+	// which was the broken key in the old releasedCommits map.
+	tagAtMergeSHA := github.Tag{Name: "v1.2.3", Commit: struct {
+		SHA string `json:"sha"`
+	}{SHA: mergeSHA}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{&pilotPR})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/tags"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Tag{&tagAtMergeSHA})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{
+		Enabled:   true,
+		Trigger:   "on_merge",
+		TagPrefix: "v",
+	}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	store := newTestStateStore(t)
+	c.SetStateStore(store)
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	c.mu.RLock()
+	_, tracked := c.activePRs[55]
+	c.mu.RUnlock()
+	if tracked {
+		t.Error("PR 55 was added to activePRs; scanner must skip PRs whose merge commit is already tagged")
+	}
+}
+
+// TestController_ScanRecentlyMergedPRs_TracksOrphanMerge verifies that a PR
+// merged externally with NO release tag is still picked up by the scanner
+// (orphan-merge recovery must keep working after the GH-3218 fix).
+func TestController_ScanRecentlyMergedPRs_TracksOrphanMerge(t *testing.T) {
+	recentMergedAt := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	mergeSHA := "deadbeef1234"
+
+	pilotPR := github.PullRequest{
+		Number:         66,
+		Head:           github.PRRef{Ref: "pilot/GH-300", SHA: "headsha66"},
+		Base:           github.PRRef{Ref: "main"},
+		HTMLURL:        "https://github.com/owner/repo/pull/66",
+		Title:          "fix(db): leak",
+		Merged:         true,
+		MergedAt:       recentMergedAt,
+		MergeCommitSHA: mergeSHA,
+	}
+
+	// Tags endpoint returns a tag for a DIFFERENT SHA — merge commit has no tag yet.
+	unrelatedTag := github.Tag{Name: "v0.0.1", Commit: struct {
+		SHA string `json:"sha"`
+	}{SHA: "ffffffffffffffffffffffffffffffffffffffff"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{&pilotPR})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/tags"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Tag{&unrelatedTag})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{
+		Enabled:   true,
+		Trigger:   "on_merge",
+		TagPrefix: "v",
+	}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	store := newTestStateStore(t)
+	c.SetStateStore(store)
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	c.mu.RLock()
+	pr, tracked := c.activePRs[66]
+	c.mu.RUnlock()
+	if !tracked {
+		t.Fatal("PR 66 was not added to activePRs; orphan-merge recovery must still pick up untagged PRs")
+	}
+	if pr.Stage != StageReleasing {
+		t.Errorf("PR 66 stage = %v, want StageReleasing", pr.Stage)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `ScanRecentlyMergedPRs` was building `releasedCommits` keyed by `release.TargetCommitish` but looking it up by `pr.MergeCommitSHA`. GoReleaser sets `target_commitish` to the branch ref (`"main"`), not the merge SHA, so the lookup never matched — released PRs were re-added to `activePRs` with `StageReleasing` on every cycle (root cause of the 5h48m dashboard stuck-at-release symptom on 2026-05-27).
- Replace the `ListReleases` round-trip + map with a per-PR `GetTagForSHA(ctx, owner, repo, pr.MergeCommitSHA)` call — the same primitive `handleReleasing` already trusts. On lookup error, fall through to track the PR safely.
- Add `TestController_ScanRecentlyMergedPRs_SkipsTaggedMergeCommit` (regression test) and `TestController_ScanRecentlyMergedPRs_TracksOrphanMerge` (orphan-merge recovery guard). Update `RecordsMetricsDespiteExistingRelease` to mock `/tags` instead of `/releases`.

## Test plan

- [ ] `go test ./internal/autopilot/ -run TestController_ScanRecentlyMergedPRs` — all subtests pass
- [ ] `go test ./internal/autopilot/` — full suite passes
- [ ] `golangci-lint run --new-from-rev=origin/main ./internal/autopilot/...` — 0 issues
- [ ] Live: ship a Pilot PR, wait through one scan cycle (≤15m), AUTOPILOT panel returns to idle

Closes #3218