### PR TITLE
fix(autopilot): handle GetTagForSHA error + duplicate-tag in handleReleasing (TASK-316)

### DIFF
--- a/.agent/.nav-config.json
+++ b/.agent/.nav-config.json
@@ -13,7 +13,7 @@
   "auto_update": {
     "enabled": true,
     "check_interval_hours": 1,
-    "last_check": "2026-05-26T13:20:15.189723"
+    "last_check": "2026-05-28T10:14:00.112889"
   },
   "loop_mode": {
     "enabled": false,

--- a/.agent/tasks/TASK-316-handle-releasing-tag-lookup-error-handling.md
+++ b/.agent/tasks/TASK-316-handle-releasing-tag-lookup-error-handling.md
@@ -1,0 +1,143 @@
+---
+name: task-316-handle-releasing-tag-lookup-error-handling
+description: P1 — Defense-in-depth fix for handleReleasing GetTagForSHA error fallthrough that can cause infinite re-tag-attempt loops
+metadata:
+  type: task
+  priority: P1
+  area: autopilot
+---
+
+# TASK-316: `handleReleasing` fallthrough on `GetTagForSHA` error
+
+**Status**: 🚧 Open
+**Created**: 2026-05-27
+**Priority**: P1 (defense-in-depth — the loop only triggers if TASK-314 isn't fixed, but the bug is real and worth hardening)
+**Area**: `internal/autopilot/controller.go`
+
+---
+
+## Context
+
+**Problem**:
+`handleReleasing` (controller.go:1659–1671) calls `GetTagForSHA` to short-circuit re-releasing an already-tagged commit. On error, it logs a warning and **falls through** to `CreateTagForRepo`. If the tag actually exists (we just couldn't see it), the create call fails with "tag already exists" or similar, the function returns an error, and the PR remains in `activePRs` at `Stage=StageReleasing` — re-entered every poll cycle, retrying forever.
+
+```go
+existingTag, err := c.ghClient.GetTagForSHA(ctx, owner, repo, prState.HeadSHA)
+if err != nil {
+    c.log.Warn("failed to check existing tags", "error", err)
+    // Continue anyway - worst case we get a duplicate tag error  ← incorrect comment
+} else if existingTag != "" {
+    c.removePR(prState.PRNumber)
+    return nil
+}
+```
+
+The "worst case duplicate tag error" comment is wrong: a duplicate-tag error from `CreateTagForRepo` propagates up as a returned `error`, which means `removePR` is never called and the PR sticks. This is the second of two compounding bugs that caused the 2026-05-27 stuck-`StageReleasing` dashboard symptom (TASK-314 is the primary; this is defense-in-depth).
+
+**Goal**:
+On `GetTagForSHA` error, retry next poll (return the error) rather than blindly continuing to `CreateTagForRepo`. Optionally: when `CreateTagForRepo` itself fails with a duplicate/conflict error, classify that as "already released" and `removePR`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] When `GetTagForSHA` returns an error, `handleReleasing` returns the error (retry next poll) instead of falling through to `CreateTagForRepo`
+- [ ] When `CreateTagForRepo` returns a duplicate-tag / 422-conflict error, `handleReleasing` treats it as success (the tag exists), calls `removePR`, returns nil
+- [ ] Unit tests for both paths: (a) `GetTagForSHA` errors → no tag-create attempted, returns error; (b) `CreateTagForRepo` returns duplicate-tag error → `removePR` called, returns nil
+- [ ] Existing tests pass (especially the race-condition guard at lines 1655–1670 for rapid-fire merges)
+
+---
+
+## Implementation
+
+### Path 1: Treat `GetTagForSHA` errors as transient
+
+```go
+existingTag, err := c.ghClient.GetTagForSHA(ctx, owner, repo, prState.HeadSHA)
+if err != nil {
+    return fmt.Errorf("failed to check existing tags for PR #%d: %w", prState.PRNumber, err)
+}
+if existingTag != "" {
+    c.log.Info("commit already tagged, skipping release",
+        "pr", prState.PRNumber,
+        "sha", ShortSHA(prState.HeadSHA),
+        "tag", existingTag,
+    )
+    c.removePR(prState.PRNumber)
+    return nil
+}
+```
+
+### Path 2: Classify duplicate-tag as success in `CreateTagForRepo` error handling
+
+After `CreateTagForRepo` call (line 1709–1712), inspect the error. If it's a duplicate-tag / 422-conflict:
+
+```go
+tagName, err := c.releaser.CreateTagForRepo(ctx, owner, repo, prState, newVersion)
+if err != nil {
+    if isDuplicateTagError(err) {
+        c.log.Info("tag already exists at HEAD SHA — treating as released",
+            "pr", prState.PRNumber,
+            "sha", ShortSHA(prState.HeadSHA),
+        )
+        c.removePR(prState.PRNumber)
+        return nil
+    }
+    return fmt.Errorf("failed to create tag: %w", err)
+}
+```
+
+`isDuplicateTagError` should detect both GitHub's 422 "Reference already exists" and any wrapper-level conflict signal. Keep the predicate narrow — don't swallow generic 422s.
+
+### Files
+
+- `internal/autopilot/controller.go:1659–1712` — change fallthrough behavior + add duplicate-tag classifier
+- `internal/autopilot/release.go` (or wherever `CreateTagForRepo` lives) — may need to surface a typed error
+- `internal/autopilot/controller_test.go` — add unit tests for both branches
+
+---
+
+## Out of Scope
+
+- The scanner re-add loop itself — fixed by TASK-314
+- Adding a global circuit breaker for "PR has been in StageReleasing > N minutes, force-remove" — interesting follow-up, separate issue
+- Telegram/Slack notification changes — orthogonal
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Recommended | Reasoning |
+|---|---|---|---|
+| `GetTagForSHA` error policy | Fall through (today), retry (return err), assume-no-tag | Return err / retry | Existing tag is a release-critical invariant; better to retry than to attempt a duplicate create |
+| Duplicate-tag classification | New typed error, string-match, HTTP status check | Typed error from release client | Avoids string-match brittleness; lets test cover the path cleanly |
+
+---
+
+## Verify
+
+```bash
+go test ./internal/autopilot/ -run TestHandleReleasing -v
+```
+
+Manual: inject a `GetTagForSHA` failure (e.g. GitHub 5xx) via a fake — verify PR stays at StageReleasing for ONE poll cycle (returning error) and is cleared on the next successful call, instead of looping on duplicate-tag forever.
+
+---
+
+## Done
+
+- [ ] Both unit tests added and green
+- [ ] `handleReleasing` no longer attempts `CreateTagForRepo` after a `GetTagForSHA` error
+- [ ] Duplicate-tag from `CreateTagForRepo` is non-fatal and clears the PR
+
+---
+
+## Refs
+
+- Sibling fix: TASK-314 (primary cause of the 2026-05-27 stuck-release dashboard)
+- Code: `internal/autopilot/controller.go:1659–1712`
+- Investigation transcript: this session (2026-05-27)
+
+---
+
+**Last Updated**: 2026-05-27

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1658,9 +1658,14 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	// is already tagged (by an earlier release) and skip.
 	existingTag, err := c.ghClient.GetTagForSHA(ctx, owner, repo, prState.HeadSHA)
 	if err != nil {
-		c.log.Warn("failed to check existing tags", "error", err)
-		// Continue anyway - worst case we get a duplicate tag error
-	} else if existingTag != "" {
+		// Transient lookup failure: do NOT fall through to CreateTagForRepo. If a
+		// tag already exists but we couldn't see it, the create call fails with
+		// "Reference already exists", returns an error, and the PR stays in
+		// StageReleasing forever (re-tried every poll). Return the error so this
+		// PR is retried cleanly on the next poll once the lookup recovers. (TASK-316)
+		return fmt.Errorf("failed to check existing tags for PR #%d: %w", prState.PRNumber, err)
+	}
+	if existingTag != "" {
 		c.log.Info("commit already tagged, skipping release",
 			"pr", prState.PRNumber,
 			"sha", ShortSHA(prState.HeadSHA),
@@ -1708,6 +1713,18 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	// Create git tag in the correct repo
 	tagName, err := c.releaser.CreateTagForRepo(ctx, owner, repo, prState, newVersion)
 	if err != nil {
+		// A duplicate-tag error means the commit is already released (e.g. a
+		// racing PR tagged it, or our GetTagForSHA check raced the create).
+		// Treat it as success so the PR drains from activePRs instead of
+		// looping forever on a tag it can never re-create. (TASK-316)
+		if isDuplicateTagError(err) {
+			c.log.Info("tag already exists at HEAD SHA — treating as released",
+				"pr", prState.PRNumber,
+				"sha", ShortSHA(prState.HeadSHA),
+			)
+			c.removePR(prState.PRNumber)
+			return nil
+		}
 		return fmt.Errorf("failed to create tag: %w", err)
 	}
 
@@ -1742,6 +1759,18 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 
 	c.removePR(prState.PRNumber)
 	return nil
+}
+
+// isDuplicateTagError reports whether err indicates the git tag already exists.
+// GitHub returns HTTP 422 with body {"message":"Reference already exists"} when
+// POSTing /git/refs for a ref that is already present. The predicate is kept
+// deliberately narrow — it matches the "already exists" signal, not generic 422s
+// (e.g. validation failures), so we never swallow a real release failure. (TASK-316)
+func isDuplicateTagError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "already exists")
 }
 
 // isMergeConflict returns true if the PR has merge conflicts.

--- a/internal/autopilot/controller_releasing_test.go
+++ b/internal/autopilot/controller_releasing_test.go
@@ -1,0 +1,158 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+func TestIsDuplicateTagError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{
+			name: "github 422 reference already exists",
+			err:  errors.New(`API error (status 422): {"message":"Reference already exists"}`),
+			want: true,
+		},
+		{
+			name: "uppercase variant",
+			err:  errors.New("failed to create tag v1.2.3: Reference Already Exists"),
+			want: true,
+		},
+		{
+			name: "generic 422 validation failure is not swallowed",
+			err:  errors.New(`API error (status 422): {"message":"Validation Failed"}`),
+			want: false,
+		},
+		{
+			name: "transient 500 is not duplicate",
+			err:  errors.New("API error (status 500): internal server error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDuplicateTagError(tt.err); got != tt.want {
+				t.Errorf("isDuplicateTagError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// newReleasingController builds a controller wired to a test GitHub server with
+// auto-release enabled, ready to exercise handleReleasing.
+func newReleasingController(t *testing.T, serverURL string) *Controller {
+	t.Helper()
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, serverURL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.Release = &ReleaseConfig{
+		Enabled:         true,
+		Trigger:         "on_merge",
+		TagPrefix:       "v",
+		NotifyOnRelease: false,
+		GenerateSummary: false,
+	}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	if c.releaser == nil {
+		t.Fatal("releaser not initialized — check ReleaseConfig wiring")
+	}
+	return c
+}
+
+// TestHandleReleasing_GetTagForSHAError verifies that a tag-lookup failure makes
+// handleReleasing return an error (retry next poll) WITHOUT attempting to create
+// a tag and WITHOUT removing the PR from tracking. (TASK-316, path 1)
+func TestHandleReleasing_GetTagForSHAError(t *testing.T) {
+	createCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+			// GetTagForSHA lookup fails transiently.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"server error"}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
+			createCalled = true
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := newReleasingController(t, server.URL)
+	prState := &PRState{PRNumber: 100, HeadSHA: "deadbeef", Stage: StageReleasing}
+	c.mu.Lock()
+	c.activePRs[100] = prState
+	c.mu.Unlock()
+
+	err := c.handleReleasing(context.Background(), prState)
+	if err == nil {
+		t.Fatal("expected error when GetTagForSHA fails, got nil")
+	}
+	if createCalled {
+		t.Error("CreateGitTag must NOT be called after a tag-lookup failure")
+	}
+	c.mu.RLock()
+	_, stillTracked := c.activePRs[100]
+	c.mu.RUnlock()
+	if !stillTracked {
+		t.Error("PR must remain tracked for retry after a lookup failure")
+	}
+}
+
+// TestHandleReleasing_DuplicateTagTreatedAsReleased verifies that a duplicate-tag
+// error from CreateGitTag is treated as success: the PR is removed from tracking
+// and handleReleasing returns nil instead of looping forever. (TASK-316, path 2)
+func TestHandleReleasing_DuplicateTagTreatedAsReleased(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+			// No existing tag visible for this SHA.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.0.0"})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/commits"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat: add a thing")})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
+			// Tag already exists (racing release tagged this commit first).
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"Reference already exists"}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := newReleasingController(t, server.URL)
+	prState := &PRState{PRNumber: 101, HeadSHA: "cafebabe", Stage: StageReleasing}
+	c.mu.Lock()
+	c.activePRs[101] = prState
+	c.mu.Unlock()
+
+	err := c.handleReleasing(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("duplicate-tag error should be treated as released, got error: %v", err)
+	}
+	c.mu.RLock()
+	_, stillTracked := c.activePRs[101]
+	c.mu.RUnlock()
+	if stillTracked {
+		t.Error("PR must be removed from tracking once the tag is confirmed to exist")
+	}
+}


### PR DESCRIPTION
Closes #3219

## Summary

`handleReleasing` treated a `GetTagForSHA` lookup error as non-fatal and fell through to `CreateTagForRepo`. When a tag already existed but the lookup errored, the create call failed with `Reference already exists`, the function returned that error, and the PR stayed in `StageReleasing` forever — re-tried every poll cycle.

Two fixes:
- **GetTagForSHA error → retry**: return the error instead of falling through, so the PR is re-processed cleanly next poll instead of attempting a tag it can never re-create.
- **Duplicate-tag → treat as released**: `CreateTagForRepo` duplicate-tag errors are classified via a narrow `isDuplicateTagError` predicate (matches `already exists`, not generic 422s) and treated as success — `removePR` + return nil — so the PR drains from `activePRs`.

Sibling to TASK-314 (#3220), which fixed the scanner re-add loop. Together they resolve the 2026-05-27 stuck-`StageReleasing` dashboard symptom (PRs #3205/#3208/#3210/#3212 pinned at `◐ release` for hours after their releases had already shipped).

Implemented directly because Pilot's executor failed to produce a commit on #3219 across 6 attempts (`no new commit produced — worktree HEAD matches base branch parent`).

## Test plan

- [x] `TestIsDuplicateTagError` — predicate matches `already exists`, rejects generic 422 / 500
- [x] `TestHandleReleasing_GetTagForSHAError` — lookup failure returns error, no tag created, PR stays tracked
- [x] `TestHandleReleasing_DuplicateTagTreatedAsReleased` — duplicate-tag returns nil, PR removed from tracking
- [x] Full `internal/autopilot` package suite green
- [x] `golangci-lint` 0 issues, `go vet` clean, `gofmt` clean