### PR TITLE
fix(upgrade): smoke test uses `version` subcommand, not unsupported --version flag

### DIFF
--- a/internal/upgrade/restart.go
+++ b/internal/upgrade/restart.go
@@ -19,7 +19,10 @@ import (
 var runSmokeTest = func(binaryPath string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := exec.CommandContext(ctx, binaryPath, "--version").Run(); err != nil {
+	// Use the `version` subcommand, not a `--version` flag: pilot's root
+	// command does not register a --version flag, so the flag form exits
+	// non-zero ("unknown flag") and would fail every hot upgrade (GH-3222).
+	if err := exec.CommandContext(ctx, binaryPath, "version").Run(); err != nil {
 		if ctx.Err() != nil {
 			return fmt.Errorf("timed out after 5s: %w", ctx.Err())
 		}

--- a/internal/upgrade/restart_smoke_test.go
+++ b/internal/upgrade/restart_smoke_test.go
@@ -55,3 +55,26 @@ func TestRunSmokeTest(t *testing.T) {
 		})
 	}
 }
+
+// TestRunSmokeTest_UsesVersionSubcommand is a regression guard for GH-3222.
+// pilot exposes a `version` subcommand but no `--version` flag; the latter
+// exits non-zero ("unknown flag"). This fake mimics that contract: it accepts
+// `version` and rejects `--version`. The real runSmokeTest must invoke the
+// form pilot actually supports, or every hot upgrade fails at the smoke test.
+func TestRunSmokeTest_UsesVersionSubcommand(t *testing.T) {
+	// Mimics pilot's cobra CLI: `version` → exit 0, any unknown flag → exit 1.
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"version\" ]; then echo 'Pilot 9.9.9'; exit 0; fi\n" +
+		"echo \"Error: unknown flag: $1\" >&2; exit 1\n"
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "pilot")
+	if err := os.WriteFile(bin, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runSmokeTest(bin); err != nil {
+		t.Errorf("runSmokeTest() must invoke the `version` subcommand that pilot "+
+			"supports; got error = %v (likely still using the unsupported --version flag)", err)
+	}
+}


### PR DESCRIPTION
## Summary

- The TASK-303 pre-exec smoke test invoked `pilot --version` (flag), but pilot's root command registers **no** `--version` flag — the flag form exits non-zero (`unknown flag: --version`), so the smoke test failed on **every** hot upgrade and `syscall.Exec` was never reached.
- Fix: invoke the `version` **subcommand** that pilot actually implements (`restart.go:22`).
- Add `TestRunSmokeTest_UsesVersionSubcommand` regression guard. The prior smoke tests used arg-agnostic shell scripts, so they never exercised the `--version` vs `version` distinction.

## Why Pilot couldn't self-fix this

Filed via #3222 with the exact one-line change, but Pilot's executor produced **no commit on 3 attempts** ("no new commit produced — worktree HEAD matches base branch parent" — the TASK-300 ghost-SHA guard correctly failing closed). The likely cause: `--version` *looks* correct (standard for most CLIs), so the executor's model talked itself out of the edit. Tracked separately. Fixed manually here to unblock the P0.

## Verification

```
$ go test ./internal/upgrade/ -run SmokeTest -count=1 -v
--- PASS: TestRunSmokeTest (4 subtests)
--- PASS: TestRunSmokeTest_UsesVersionSubcommand
```

Live binary confirms the contract:
- `pilot --version` → `Error: unknown flag: --version`, exit 1
- `pilot version` → `Pilot 2.159.2`, exit 0

## ⚠️ Deployment note (chicken-and-egg)

This fix lives inside the broken upgrade path. The currently-installed binary still runs the old `--version` smoke test, so **this cannot be hot-deployed via `u`** — it must ship via one manual reinstall of the release containing it. After that single manual install, `u` works for good. (See `.agent/knowledge/memories/patterns/pattern_hot_upgrade_bootstrap.md`.)

## Test plan

- [x] `go test ./internal/upgrade/...` green (incl. new regression guard)
- [x] `gofmt` / `go vet` clean
- [ ] CI green
- [ ] Manual: build release, manually reinstall, then press `u` on next release → in-place restart succeeds

Fixes #3222