### PR TITLE
fix(ci): harden docs-sync Close-previous step against gh --search regression

### DIFF
--- a/.github/workflows/docs-version-sync.yml
+++ b/.github/workflows/docs-version-sync.yml
@@ -34,12 +34,14 @@ jobs:
           fi
 
       - name: Close previous version-sync PRs
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr list --state open --search "docs: sync version to" --json number,headRefName --jq '.[]' | while read -r line; do
-            pr_num=$(echo "$line" | jq -r '.number')
-            branch=$(echo "$line" | jq -r '.headRefName')
+          set +e
+          gh pr list --state open --search '"docs: sync version to" in:title' \
+            --json number --jq '.[].number' | while read -r pr_num; do
+            [ -n "$pr_num" ] || continue
             gh pr close "$pr_num" --comment "Superseded by ${{ steps.version.outputs.VERSION }}" --delete-branch || true
           done
 


### PR DESCRIPTION
## Problem

`docs/lib/version.ts` drifted (stuck at v2.159.2 while latest release is v2.159.3). The **Sync Docs Version** workflow fails deterministically in the *Close previous version-sync PRs* step:

```
tag is not a valid choice for the --state flag, and it might cause issues with the --search flag.
gh: To pass exact search terms wrap them with quotes
Process completed with exit code 1
```

A newer `gh` CLI on the GitHub runner now rejects the unquoted multi-word `--search "docs: sync version to"`. Under `bash -e` the non-zero exit aborts the whole job **before** the version-bump/PR steps run, so the sync never happens.

## Fix

- Quote the search phrase and scope to `in:title`.
- Iterate over PR numbers only (drop the `headRefName` jq dance).
- `set +e` + `continue-on-error: true` so a close-previous hiccup can never block the actual sync again.

## After merge

Re-dispatch for v2.159.3 to catch `version.ts` up.