### PR TITLE
docs: sync version to v2.159.3

### DIFF
--- a/.agent/DEVELOPMENT-README.md
+++ b/.agent/DEVELOPMENT-README.md
@@ -118,7 +118,7 @@ Disable via config: `executor.navigator.auto_init: false`
 
 ## Current State
 
-**Current Version:** v2.159.2 | full status in `.agent/system/FEATURE-MATRIX.md`
+**Current Version:** v2.159.3 | full status in `.agent/system/FEATURE-MATRIX.md`
 
 **Recent (v2.159.3, May 28 2026):** Hot-upgrade subsystem repair + autopilot release-pipeline reliability.
 - `fix(upgrade)`: Pre-exec smoke test invoked `pilot --version` (a flag the root cobra command never registers → exit 1), so it failed **every** hot upgrade before `syscall.Exec`. Switched to the `version` subcommand pilot actually implements, plus a regression guard (`TestRunSmokeTest_UsesVersionSubcommand`) using a fake that mimics the real CLI — prior tests used arg-agnostic scripts and missed it. Chicken-and-egg: the fix lives inside the path it repairs, so it required one manual reinstall to land. (GH-3222 / #3223). Pitfall: `.agent/knowledge/memories/pitfalls/bug_smoke_test_wrong_cli_contract.md`. Executor's inability to self-fix this one-liner (it second-guessed the obvious-looking `--version`) tracked in GH-3224.

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-05-28 (v2.151.0)
+**Last Updated:** 2026-05-29 (v2.151.0)
 
 ## Legend
 

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -45,7 +45,7 @@ export default async function RootLayout({
               logo={
                 <span style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
                   <img src="/logo.svg" alt="Pilot" height={24} style={{ height: 24, width: 'auto', alignSelf: 'center' }} />
-                  <span style={{ fontSize: '0.5em', opacity: 0.5, fontWeight: 400 }}>v2.159.2</span>
+                  <span style={{ fontSize: '0.5em', opacity: 0.5, fontWeight: 400 }}>v2.159.3</span>
                 </span>
               }
               projectLink="https://github.com/qf-studio/pilot"

--- a/docs/lib/version.ts
+++ b/docs/lib/version.ts
@@ -1,4 +1,4 @@
 // Single source of truth for the current Pilot release shown in docs prose.
 // Auto-bumped by .github/workflows/docs-version-sync.yml on every v* tag push
 // via scripts/docs-version-sync.sh.
-export const CURRENT_VERSION = "v2.159.2"
+export const CURRENT_VERSION = "v2.159.3"


### PR DESCRIPTION
Catches docs version refs up to the latest release (`version.ts` was stuck at v2.159.2, README at v2.155.2).

**Why manual:** the automated *Sync Docs Version* workflow can't do this — its `Create Pull Request` step fails at `git push` with `403 Permission to qf-studio/pilot.git denied to alekspetrov`. The `PILOT_DOCS_PAT` token authenticates but lacks **Contents: write** on qf-studio/pilot, so it cannot push the sync branch. Re-scope the PAT to fix the automation; this PR unblocks the current drift.

Files (via `scripts/docs-version-sync.sh v2.159.3`):
- `docs/lib/version.ts` v2.159.2 → v2.159.3
- `.agent/DEVELOPMENT-README.md` v2.155.2 → v2.159.3
- `docs/app/layout.tsx` navbar version

Related: #3226 (workflow hardening, merged).