### PR TITLE
fix(executor): defeat false-negative no-op on evidence-backed specs (GH-3224)

### DIFF
--- a/.agent/tasks/TASK-320-executor-false-negative-noop-fix.md
+++ b/.agent/tasks/TASK-320-executor-false-negative-noop-fix.md
@@ -1,0 +1,122 @@
+# TASK-320: Executor false-negative no-op fix (evidence-backed specs)
+
+**Status:** 🟡 in review — Layer A + B1 shipped (PR on `fix/task-320-executor-noop-guard`); Layer B2 deferred — **MANUAL** (Pilot cannot fix its own execution guard)
+**Priority:** P1 — systemic; blocks/poisons every explicit-spec task (GH-3222, GH-3228 class)
+**Repo:** `qf-studio/pilot`
+**Area:** `internal/executor/`
+**Source bug:** GH-3224 (auto-filed). Instances: GH-3222 (`--version` one-liner, fixed manually in #3223), GH-3228 (board-as-source, 4× no-op).
+
+---
+
+## Why manual (not Pilot)
+
+This is a fix **to the executor's own no-op behavior**. Handing it to Pilot is
+chicken-and-egg: the bug being fixed is exactly what makes Pilot exit without
+editing on explicit specs. It also edits Pilot's execution guard — high blast
+radius, must be human-reviewed. Implement directly, open PR for review.
+
+---
+
+## Problem
+
+The executor's model reads existing code, judges it "looks correct," and exits
+with **zero edits** — overriding an explicit, evidence-backed spec with its prior.
+The TASK-300 ghost-SHA guard catches the result (`HEAD == base parent`) but:
+1. only **after** the wasted run, and
+2. (bug) emits an **empty error string** — `execution failed:` with no message
+   (observed on studio-sdk #4/#5 re-dispatch and implied on GH-3228).
+
+Deterministic: same no-op on all retries. A P0 one-liner with a perfect spec
+(exact file, line, before/after, proof current code is wrong) still could not be
+executed autonomously.
+
+---
+
+## Goal
+
+Make the executor honor evidence-backed specs over its prior, and when it still
+no-ops, fail loudly and recover once — never silently.
+
+---
+
+## Implementation (3 layers)
+
+### Layer A — prevent (prompt directive)
+Inject into the executor task/system prompt:
+> If the issue specifies an explicit change (file + line + before/after) with
+> evidence the current code is wrong, you MUST apply it even if the existing code
+> looks correct — your general knowledge does not override the spec's verified
+> claim. If you conclude no change is genuinely needed, emit an explicit
+> `NO-OP RATIONALE: <file:line> <reason>` block instead of exiting silently.
+
+> **Scope shipped in first PR:** Layer A (prompt directive) + Layer B1 (terminal
+> classification of the no-op so the poller stops the 4×-identical-retry burn and
+> labels `pilot-blocked`). **Layer B2 (in-executor escalated re-invocation) is
+> DEFERRED** — `executeWithOptions` is a ~1700-line critical function with existing
+> self-review retry machinery (`runner.go:2843`); bolting a second backend
+> re-invocation onto the ghost-SHA guard duplicates SHA-harvest + ghost-check +
+> metrics logic and risks regressing the executor's core path. It needs a
+> structured retry-loop refactor, tracked as a follow-up. Layer A alone addresses
+> the GH-3222/GH-3228 root cause; B1 stops the wasted retries.
+
+### Layer B1 — classify the no-op as terminal (SHIPPED)
+- `runner.go`: added `"no new commit produced"` to `permanentFailurePatterns`
+  (both ghost-SHA messages share that prefix). `IsPermanentFailure` now returns
+  true → poller applies `pilot-blocked` (not `pilot-failed`), ending identical
+  retries. The guard messages at `runner.go:2380`/`:3294` are already descriptive
+  (no empty-error on this path).
+
+### Layer B2 — recover (escalated single retry on no-op) — DEFERRED
+At the ghost-SHA guard failure branch (HEAD == base parent):
+1. **Fix the empty-error bug first** — always format a descriptive message, e.g.
+   `no new commit produced — worktree HEAD matches base branch parent (issue %s)`.
+   Never emit `execution failed:` with an empty tail.
+2. Re-invoke the executor **once** with an escalation preamble:
+   *"Your previous run made ZERO edits but this task requires a change. Re-read the
+   explicit instruction and apply it. Do not exit without editing or without a
+   NO-OP RATIONALE."*
+3. If the retry still no-ops → fail with the descriptive error and auto-comment the
+   `NO-OP RATIONALE` (if produced) so a human sees *why* the model refused.
+
+### Layer C — observability (optional, low cost)
+Counter/log for no-op-on-explicit-spec so the rate is visible (mirrors TASK-293
+poller skip-reason counters pattern).
+
+---
+
+## Acceptance criteria
+
+- [ ] No-op (HEAD == base parent) never produces an empty `execution failed:`
+      message — always a descriptive, actionable string naming the issue.
+- [ ] On no-op, the executor retries exactly once with the escalation preamble
+      before failing.
+- [ ] Prompt directive present in the executor template; covered by a prompt-
+      assembly test.
+- [ ] A regression test simulating an explicit-spec issue asserts the executor
+      either edits or emits `NO-OP RATIONALE` (never silent exit).
+- [ ] `make test` + `make lint` green.
+
+## Out of scope
+- Changing the ghost-SHA guard's correctness (it is right to reject empty commits).
+- Model/router changes.
+
+---
+
+## Critical files (to locate during implementation)
+- `internal/executor/` — ghost-SHA / TASK-300 guard site (the `no new commit
+  produced — worktree HEAD matches base branch parent` string is the anchor:
+  `grep -rn "no new commit produced" internal/`).
+- Executor prompt template assembly (where the task prompt is built).
+
+## Verification
+```bash
+grep -rn "no new commit produced" internal/   # find the guard
+make test && make lint
+go test ./internal/executor/ -run 'NoOp|GhostSHA|Prompt' -v
+```
+
+---
+
+## Refs
+- GH-3224 (root-cause report), GH-3222/#3223 (first instance + manual fix),
+  GH-3228 / TASK-317 (second instance — unblocked once this ships).

--- a/internal/executor/prompt_builder.go
+++ b/internal/executor/prompt_builder.go
@@ -41,6 +41,27 @@ const ExecutorPromptHeader = "[PILOT-EXEC]\n" +
 	"to create a GitHub issue, do not defer. Write code, run build and tests via " +
 	"the stop-gate hook, and complete the task.\n\n"
 
+// EvidenceBackedSpecDirective combats the false-negative no-op (GH-3224):
+// the model reads existing code, judges it "looks correct," and exits without
+// editing — overriding an explicit, evidence-backed spec with its prior
+// knowledge (e.g. GH-3222: "--version" looks like the standard flag, so the
+// edit was skipped despite proof the current code was wrong). The executor's
+// ghost-SHA guard then rejects the run as "no new commit produced." This
+// directive instructs the model to honor the spec over its prior, and to make
+// any silent no-op explicit instead.
+const EvidenceBackedSpecDirective = "## NON-NEGOTIABLE: implement evidence-backed changes\n\n" +
+	"If the task specifies an explicit change (a file, a line, a before/after, or " +
+	"evidence that the current code is wrong), you MUST apply it even if the " +
+	"existing code looks correct. Your general knowledge does NOT override the " +
+	"task's specific, verified claim — the spec was written with proof you may not " +
+	"infer from reading the code alone.\n\n" +
+	"If the task asks you to CREATE a new file, verify it does not already exist " +
+	"(e.g. `ls <path>`), then create it. A sibling or similarly-named existing " +
+	"file is a pattern to mirror, NOT evidence the task is done.\n\n" +
+	"If, after analysis, you conclude no change is genuinely needed, you MUST emit " +
+	"an explicit `NO-OP RATIONALE: <file:line> <reason>` block explaining why, " +
+	"rather than exiting silently. A silent no-op is treated as a task failure.\n\n"
+
 // BuildPrompt constructs the prompt for Claude Code execution.
 // executionPath may differ from task.ProjectPath when using worktree isolation.
 func (r *Runner) BuildPrompt(task *Task, executionPath string) (prompt string) {
@@ -59,6 +80,11 @@ func (r *Runner) BuildPrompt(task *Task, executionPath string) (prompt string) {
 	// session and any project CLAUDE.md can skip Navigator-only "don't write
 	// code" rules explicitly, without relying on CWD or prompt-prefix sniffing.
 	sb.WriteString(ExecutorPromptHeader)
+
+	// GH-3224: defeat the false-negative no-op for evidence-backed specs.
+	// Injected here so it covers both the Navigator and non-Navigator execution
+	// paths below (image/local-mode early returns above are out of scope).
+	sb.WriteString(EvidenceBackedSpecDirective)
 
 	// GH-2103: LocalMode takes priority over Navigator detection.
 	// Sandbox environments with .agent/ dirs would hijack the prompt to Navigator path,

--- a/internal/executor/prompt_builder_test.go
+++ b/internal/executor/prompt_builder_test.go
@@ -487,6 +487,49 @@ func TestBuildPromptContainsErrcheckGuidance(t *testing.T) {
 	}
 }
 
+// GH-3224: every executor prompt must carry the evidence-backed-spec directive
+// so the model does not silently no-op on explicit changes that "look correct."
+func TestBuildPromptContainsEvidenceBackedSpecDirective(t *testing.T) {
+	runner := NewRunner()
+
+	cases := []struct {
+		name string
+		task *Task
+	}{
+		{
+			name: "navigator path",
+			task: &Task{ID: "GH-3224", Title: "fix no-op", Description: "Change line 22", Branch: "pilot/GH-3224"},
+		},
+		{
+			name: "with acceptance criteria",
+			task: &Task{ID: "GH-3224", Title: "fix no-op", Description: "Create new file", AcceptanceCriteria: []string{"file exists"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := os.MkdirTemp("", "pilot-test-noop")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer func() { _ = os.RemoveAll(tempDir) }()
+			tc.task.ProjectPath = tempDir
+
+			prompt := runner.BuildPrompt(tc.task, tempDir)
+
+			for _, want := range []string{
+				"NON-NEGOTIABLE",
+				"evidence-backed",
+				"NO-OP RATIONALE",
+			} {
+				if !strings.Contains(prompt, want) {
+					t.Errorf("BuildPrompt missing %q from EvidenceBackedSpecDirective", want)
+				}
+			}
+		})
+	}
+}
+
 func TestBuildSelfReviewPromptContainsLintCheck(t *testing.T) {
 	runner := NewRunner()
 	task := &Task{

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -29,6 +29,13 @@ import (
 // GH-2402: terminal-classify these so the poller stops the retry loop.
 var permanentFailurePatterns = []string{
 	"PR creation refused",
+	// GH-3224: a no-op run (ghost-SHA guard tripped — both the worktree-HEAD and
+	// post-push variants begin with this prefix) is deterministic: retrying the
+	// identical prompt reproduces it (observed 4× on GH-3228). Classify terminal
+	// so the poller labels pilot-blocked instead of burning cycles on pilot-failed
+	// retries. A human (or a re-dispatch carrying the EvidenceBackedSpecDirective)
+	// resolves it.
+	"no new commit produced",
 }
 
 // IsPermanentFailure reports whether an error message represents a

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3383,6 +3383,9 @@ func TestIsPermanentFailure(t *testing.T) {
 		{"could not auto-correct title", "title is invalid: could not auto-correct to a conventional commit", false},
 		{"PR creation refused (catch-all)", "PR creation refused: some reason", true},
 		{"random failure", "no_changes: Claude completed but made no code changes", false},
+		// GH-3224: no-op runs (ghost-SHA guard) are deterministic — terminal.
+		{"no-op worktree HEAD", "no new commit produced — worktree HEAD matches base branch parent", true},
+		{"no-op post-push SHA", "no new commit produced — post-push SHA matches base branch", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem (GH-3224)

The executor reads existing code, judges it "looks correct," and exits **without editing** — overriding an explicit, evidence-backed spec with its prior knowledge. The ghost-SHA guard then rejects the run as `no new commit produced — worktree HEAD matches base branch parent`, and the poller retries the identical prompt.

Confirmed instances:
- **GH-3222** — a P0 one-liner (`"--version"` → `"version"`, exact file+line+proof) no-op'd 3× (fixed manually in #3223).
- **GH-3228** — board-as-source; the executor saw the existing `project_board.go` write path, judged the work done, and no-op'd **4× identically**.

## Fix (this PR: Layer A + B1)

**Layer A — prevent.** New `EvidenceBackedSpecDirective` injected into every executor prompt (`prompt_builder.go`, after the exec header → covers Navigator + non-Navigator paths):
- honor an explicit/evidence-backed spec over the model's prior, even if the code "looks correct";
- verify-before-create for new files (a similarly-named existing file is a pattern to mirror, not proof of completion);
- emit an explicit `NO-OP RATIONALE: <file:line> <reason>` instead of exiting silently.

**Layer B1 — stop the retry burn.** `"no new commit produced"` added to `permanentFailurePatterns` (`runner.go`). Both ghost-SHA messages share that prefix, so `IsPermanentFailure` now returns true → the poller applies `pilot-blocked` instead of looping on identical `pilot-failed` retries.

## Deferred (follow-up, see TASK-320)

**Layer B2** (in-executor escalated single re-invocation on no-op) is intentionally **not** in this PR. `executeWithOptions` is a ~1700-line critical path with existing self-review retry machinery (`runner.go:2843`); adding a second backend re-invocation at the ghost-SHA guard duplicates SHA-harvest + ghost-check + metrics and risks regressing the core path. It needs a structured retry-loop refactor. Layer A addresses the root cause; B1 stops the wasted cycles.

## Tests
- `TestBuildPromptContainsEvidenceBackedSpecDirective` — navigator + acceptance-criteria paths.
- `TestIsPermanentFailure` — added both no-op variants (worktree-HEAD, post-push).
- `make test` (full `internal/executor` suite, 96s) + `make lint` (0 issues) green.

## Why manual (not Pilot)
This fixes the executor's own no-op behavior — handing it to Pilot is chicken-and-egg, and it edits the execution guard (high blast radius). Implemented directly for human review.

Refs: GH-3224 (root cause), GH-3222/#3223 (first instance), GH-3228/TASK-317 (second instance, unblocked by Layer A).