### PR TITLE
docs: GH Projects full-loop plan + worktree discipline

### DIFF
--- a/.agent/sops/config/github-token-architecture.md
+++ b/.agent/sops/config/github-token-architecture.md
@@ -1,0 +1,79 @@
+# SOP: GitHub token architecture for Pilot (multi-project)
+
+**Category:** config
+**Created:** 2026-05-29
+**Applies to:** local Pilot runs against multiple GitHub repos + the pilot-repo CI
+
+## Problem this prevents
+
+Pilot uses **one global GitHub token** for *all* configured projects, and the
+`--project` flag does **not** scope the pollers. A token scoped to a single repo
+(e.g. a fine-grained PAT) therefore breaks every other project's poller with
+401/403. This was learned the hard way wiring up `qf-studio/studio-sdk`.
+
+### Evidence in code
+- `internal/config/config.go:200` — `ProjectGitHubConfig` has only `Owner`/`Repo`,
+  **no per-project token field**. One global `adapters.github.token` serves all.
+- `cmd/pilot/main.go:2235` — poller loop is `for _, proj := range cfg.Projects`
+  (all projects). `--project` only sets the executor cwd (`main.go:215`), it does
+  **not** filter this loop.
+- Token resolution falls back to `os.Getenv("GITHUB_TOKEN")` in many sites
+  (`main.go:1403/1660/2046`, `commands.go:991/2473`).
+
+## The rule
+
+The global `adapters.github.token` must be able to access **every** repo across
+**every** configured project — which often spans multiple owners (personal +
+org). Only a **classic PAT** can span owners; a fine-grained PAT is locked to a
+single resource owner.
+
+## Canonical setup (3 tokens, clean separation)
+
+| Token | Type | Home | Scope | Serves |
+|---|---|---|---|---|
+| `pilot-local` | **classic** | `~/.pilot/config.yaml` → `adapters.github.token` | `repo`, `read:org`, `project` | all local Pilot work, all projects, all owners |
+| `pilot-docs-pat` | fine-grained | `PILOT_DOCS_PAT` Actions secret (pilot repo) | Contents RW + Pull requests RW on pilot | docs auto-merge **chaining** (`docs-version-sync.yml`) |
+| `qf-studio-homebrew-tap` | classic | `HOMEBREW_TAP_GITHUB_TOKEN` Actions secret | tap write | release pipeline (brew tap) |
+
+- `project` scope on `pilot-local` is included now so **board-as-source**
+  (TASK-317 / GH-3228 `FindIssuesFromProject`) works without re-issuing.
+- For org repos under SSO: after creating the classic token, **Configure SSO →
+  Authorize** for the org. Membership being granted is not enough; the *token*
+  must be authorized.
+
+## Why PILOT_DOCS_PAT is a PAT, not GITHUB_TOKEN
+
+`docs-version-sync.yml:73` uses `secrets.PILOT_DOCS_PAT || secrets.GITHUB_TOKEN`.
+A PAT is required only for the **chained** workflow: merges made with the default
+`GITHUB_TOKEN` cannot trigger a follow-on workflow run. Without the PAT, docs sync
+still works; you just lose the chain step.
+
+## Verify a token without printing it
+
+```python
+# python3 - reads adapters.github.token, prints only HTTP status + scopes
+import yaml, os, urllib.request, subprocess
+cfg = yaml.safe_load(open(os.path.expanduser("~/.pilot/config.yaml")))
+tok = cfg["adapters"]["github"]["token"]
+if tok.startswith("${"): tok = os.environ[tok[2:-1]]
+for repo in ["qf-studio/pilot","alekspetrov/navigator","qf-studio/studio-sdk"]:
+    code = subprocess.run(["curl","-s","-o","/dev/null","-w","%{http_code}",
+        "-H",f"Authorization: Bearer {tok}",
+        f"https://api.github.com/repos/{repo}"],capture_output=True,text=True).stdout
+    print(repo, code)
+req = urllib.request.Request("https://api.github.com/user",
+    headers={"Authorization":f"Bearer {tok}"})
+print("scopes:", urllib.request.urlopen(req).headers.get("x-oauth-scopes"))
+```
+
+Expected: every repo `200`, scopes include `repo, read:org, project`.
+
+## Gotchas
+
+- A PAT whose one-time value you didn't copy is **unrecoverable** — revoke and
+  recreate; it can't be read back out of an Actions secret either.
+- Fine-grained PAT permissions reset the form when you change the resource owner.
+- Set Actions secrets via `gh secret set NAME -R owner/repo` (interactive paste,
+  no shell-history exposure) rather than the web UI.
+- Revoke order: create + verify replacements **first**, revoke stale tokens
+  **last**, to avoid locking out a running Pilot.

--- a/.agent/tasks/TASK-319-gh-projects-full-loop.md
+++ b/.agent/tasks/TASK-319-gh-projects-full-loop.md
@@ -1,10 +1,52 @@
 # TASK-319: GitHub Projects V2 — full board-driven lifecycle loop
 
-**Status:** planned (ready to decompose into PR-sized issues for Pilot)
+**Status:** planned — Option B locked; board-setup + issue drafts ready; execution gated on #3228 merge
 **Priority:** P1 — completes the board-as-source-of-truth roadmap (Studio SDK)
 **Repo:** `qf-studio/pilot` (code) — drives `qf-studio/studio-sdk` work via `qf-studio/projects/1`
 **Depends on:** #3228 / TASK-317 (`FindIssuesFromProject`, read path) — must merge first
-**Decisions (2026-05-29):** full lifecycle loop · Studio SDK board only · fine-grained PAT for auth
+**Decisions (2026-05-29):** **full 5-state loop (Option B)** · Studio SDK board only · the `ghp_` PAT in `~/.pilot/config.yaml` (scopes `project, read:org, repo`) is the board token
+
+## Locked status mapping (Option B — 5 columns)
+
+Board today has 3 columns (`Todo | In Progress | Done`); Option B adds **In Review** + **Blocked**.
+
+| Column | Color | Pilot event | Source/Write |
+|---|---|---|---|
+| Todo | GREEN | queued work | `source_status` (read, #3228) |
+| In Progress | YELLOW | issue picked up / executing | write on dispatch (PR-1) |
+| In Review | ORANGE | PR opened | write on `OnPRCreated` (PR-2) |
+| Done | PURPLE | PR merged | write on merge (exists) |
+| Blocked | RED | exec-fail / CI-fail | write on failure (PR-2) |
+
+```yaml
+# configs/pilot.example.yaml — full board-driven block
+adapters:
+  github:
+    repo: qf-studio/studio-sdk
+    project_board:
+      enabled: true
+      project_number: 1
+      status_field: Status
+      source_enabled: true     # from #3228 — pull work FROM the board
+      source_status: "Todo"
+      statuses:
+        in_progress: "In Progress"
+        review: "In Review"
+        done: "Done"
+        failed: "Blocked"
+```
+
+## Board setup (do once, before go-live)
+
+**Recommended — web UI (zero risk):** open https://github.com/orgs/qf-studio/projects/1
+→ Status field settings → add two options: **In Review** (orange, place between In Progress and Done) and **Blocked** (red, last). Preserves all 10 existing items.
+
+**Alternative — GraphQL (⚠ caveat):** `updateProjectV2Field` rewrites the whole option
+set and can detach items from columns. If used, pass ALL options (existing + new) in
+the desired order. Field ID `PVTSSF_lADOD34yzs4BZIGzzhUJB8o`, project ID
+`PVT_kwDOD34yzs4BZIGz`. Existing: Todo(GREEN,"This item hasn't been started"),
+In Progress(YELLOW,"This is actively being worked on"), Done(PURPLE,"This has been completed").
+Prefer the UI unless scripting board provisioning.
 
 ---
 
@@ -119,10 +161,27 @@ Fine-grained PAT (chosen). Document in an SOP (`.agent/sops/integrations/`):
 - [ ] `make test` + `make lint` green.
 - [ ] SOP for the fine-grained PAT exists.
 
-## Open items (need from you)
+## Pre-execution checklist (prep state 2026-05-29)
 
-1. **Actual column names** on `qf-studio/projects/1` (Todo / In Progress / In Review / Done / Blocked?) — I can't read the board (no `read:project`). Needed for the config example + status mappings.
-2. **Token separation** — one GitHub token for everything, or a dedicated `GITHUB_PROJECT_TOKEN` for board ops? (Lean: one PAT with all needed scopes; revisit only if least-privilege separation is wanted.)
+- [x] Decisions locked: Option B (5-state), Studio SDK board only, PAT identified
+- [x] Board read confirmed via `ghp_` PAT (`project` scope present)
+- [x] Status mapping + config block finalized (see top of doc)
+- [x] PR-sized issue drafts ready (see "Execution-ready issues" below)
+- [ ] **#3228 merged** (read path) — user tracking, will signal
+- [ ] **Board columns added**: In Review (orange) + Blocked (red) — web UI, see "Board setup"
+- [ ] **Board hygiene**: move stale CLOSED #6 from In Progress → Done; Todo currently empty (no queued work yet)
+- [ ] File the 4 issues into `qf-studio/pilot`, drop into the board's Todo column once sourcing is live
+
+**Token note:** the dev `gh` CLI uses a keyring token (`gho_`) lacking project scope. For direct `gh project ...` use `gh auth refresh -s read:project,project`, or `export GH_TOKEN=<ghp_ PAT>`. Pilot itself reads the `ghp_` PAT from config, so the daemon is unaffected.
+
+## Execution-ready issues (file once #3228 lands + columns added)
+
+Each becomes a `pilot`-labeled issue in `qf-studio/pilot`. Sequencing per the diagram below.
+
+1. **`feat(github): move board card to In Progress on issue pickup`** — workstream B / PR-1. Add `WithBoardSync` poller option; on accepted dispatch call `UpdateProjectItemStatus(nodeID, statuses.InProgress)`; node ID from `Issue.NodeID` (board read) or `GetIssueNodeID` fallback; no-op when board disabled/nodeID empty. Tests: fake GraphQL transport.
+2. **`feat(autopilot): move card to In Review on PR open + Blocked on failure`** — workstream C+D / PR-2. In `OnPRCreated` write `statuses.Review`; extend failure handling (exec-fail + CI-fail) to write `statuses.Failed`; extend `WithProjectBoardSync` to carry InProgress/Review (backward-compatible). Tests for both transitions.
+3. **`feat(github): board-sync idempotency + off-board/cross-repo safety`** — workstream E / PR-3. `UpdateProjectItemStatus` no-ops if already in target column; skip (debug-log) when item not on board; tolerate cross-repo items; document full block in `pilot.example.yaml`. Tests for short-circuit + off-board skip.
+4. **`docs(sops): fine-grained PAT + board provisioning runbook`** — workstream F / PR-4. SOP under `.agent/sops/integrations/`: PAT scopes (Projects R/W, Issues R/W), board column setup, config block, go-live checklist.
 
 ## Sequencing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,32 @@ When in doubt, look at the incoming prompt: if it hands you a specific
 task with file paths and expected outputs, implement it. If it's a human
 asking open-ended questions about the project, plan via Navigator.
 
+## ⚠️ Git & Worktree Discipline (ALL sessions)
+
+Multiple sessions (interactive terminals, Claude Code sessions, and the
+Pilot daemon) operate on this repo **concurrently**. Running `git checkout`
+in the shared repo root rips the branch out from under every other session
+— this has repeatedly left the root on a stranger's PR branch with orphaned
+uncommitted changes and a graveyard of stashes.
+
+**Rules:**
+
+- ❌ **NEVER `git checkout <branch>` / `git switch` in the repo root**
+  (`/Users/.../startups/pilot`). Keep the root pinned to `main`; treat it as
+  reference + build-from-main only.
+- ✅ **Do all branch work in your own worktree.** Interactive Claude sessions:
+  use the worktree flow (sessions land in `.claude/worktrees/<name>`). The
+  Pilot daemon already isolates via `pilot-worktree-GH-*` — leave those alone.
+- ✅ Base worktrees on `origin/main` (fresh), not on whatever the root
+  happens to be pointing at.
+- ✅ Commit in your worktree branch; push it; open a PR. Never pile unrelated
+  work onto someone else's branch/PR.
+- ❌ Do not `git stash pop` blindly in the root — a pathspec-limited stash or
+  a worktree is safer when other sessions may have uncommitted work there.
+- If you find the root on a non-`main` branch with uncommitted changes you
+  did not make, **STOP** — that's another session's work. Don't checkout,
+  don't reset, don't commit it. Flag it.
+
 ## ⚠️ WORKFLOW: Navigator + Pilot Pipeline (interactive sessions only)
 
 **If this is an interactive dev session**, use Navigator to plan and Pilot
@@ -228,6 +254,7 @@ Documentation in `.agent/`:
 - ❌ No package.json modifications without approval
 - ❌ No bulk doc loading (use Navigator lazy loading)
 - ❌ No Claude Code mentions in commits
+- ❌ No `git checkout`/`git switch` in the repo root — work in a worktree (see "Git & Worktree Discipline")
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary
- **TASK-319** — plan to migrate Pilot work sourcing onto the Studio SDK GitHub Projects V2 board (`qf-studio/projects/1`). Full 5-state lifecycle loop (Todo → In Progress → In Review → Done, → Blocked on failure): status mappings, config block, board-setup steps, 4 PR-sized issue drafts, pre-execution checklist. Gated on #3228 (read path).
- **SOP** `github-token-architecture.md` — one global GitHub token spans all projects; `--project` does not scope pollers, so a single-repo PAT breaks other projects' pollers.
- **CLAUDE.md** — new "Git & Worktree Discipline" section: never `git checkout` in the repo root (it thrashes concurrent sessions); do all branch work in a worktree based on `origin/main`.

## Context
Docs/planning only — no code changes. Separated onto its own branch to keep PR #3230 (executor no-op fix) clean.

## Test plan
- [x] Pre-commit secret scan passed
- [ ] Docs review