### PR TITLE
fix(handlers): suppress empty-error failure comments (GH-3239)

### DIFF
--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -157,7 +157,7 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 			if waitErr != nil {
 				execErr = fmt.Errorf("failed waiting for execution: %w", waitErr)
 			} else if exec.Status == "failed" {
-				execErr = fmt.Errorf("execution failed: %s", exec.Error)
+				execErr = fmt.Errorf("execution failed: %s", execFailureMsg(exec.Error))
 			} else {
 				result = &executor.ExecutionResult{
 					TaskID:    task.ID,
@@ -271,4 +271,14 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	}
 
 	return hr, execErr
+}
+
+// execFailureMsg returns the error detail for a failed dispatcher execution.
+// When exec.Error is empty (the executor failed silently), a descriptive default
+// is substituted so callers never build a bare "execution failed: " comment.
+func execFailureMsg(execError string) string {
+	if execError == "" {
+		return "executor reported failure without providing an error message"
+	}
+	return execError
 }

--- a/cmd/pilot/handler_common_test.go
+++ b/cmd/pilot/handler_common_test.go
@@ -174,6 +174,28 @@ func TestAdapterSpecificPRNumberExtraction(t *testing.T) {
 	}
 }
 
+// TestExecFailureMsg_EmptyBody asserts that an empty exec.Error is replaced with a
+// descriptive default, so no bare "execution failed:" comment body is produced.
+func TestExecFailureMsg_EmptyBody(t *testing.T) {
+	got := execFailureMsg("")
+	if got == "" {
+		t.Fatal("expected non-empty default message for empty exec error")
+	}
+	// Verify the full comment body would not be bare.
+	full := "execution failed: " + got
+	if strings.HasSuffix(full, ": ") {
+		t.Errorf("bare failure comment produced for empty exec error: %q", full)
+	}
+}
+
+// TestExecFailureMsg_NonEmptyPassthrough verifies that a non-empty error string is passed through unchanged.
+func TestExecFailureMsg_NonEmptyPassthrough(t *testing.T) {
+	in := "build failed: undefined reference to foo"
+	if got := execFailureMsg(in); got != in {
+		t.Errorf("expected passthrough %q, got %q", in, got)
+	}
+}
+
 // TestHandleIssueGeneric_NilEnforcer verifies that nil enforcer skips budget check
 // and proceeds. Because runner is also nil, it should fail at execution.
 func TestHandleIssueGeneric_NilEnforcer(t *testing.T) {


### PR DESCRIPTION
## Summary

- In `cmd/pilot/handler_common.go:160`, when `exec.Status == "failed"` and `exec.Error == ""`, the old code formatted `fmt.Errorf("execution failed: %s", exec.Error)` producing a bare `"execution failed: "` comment body
- Extracted `execFailureMsg(execError string) string` helper that substitutes `"executor reported failure without providing an error message"` when the error is empty
- Added two unit tests: `TestExecFailureMsg_EmptyBody` and `TestExecFailureMsg_NonEmptyPassthrough`

## Test plan

- [ ] `make test` passes (all packages green)
- [ ] `make lint` reports 0 issues
- [ ] `TestExecFailureMsg_EmptyBody` asserts no bare `"execution failed: "` comment is produced for an empty exec error
- [ ] `TestExecFailureMsg_NonEmptyPassthrough` asserts non-empty errors are passed through unchanged

Closes #3239