### PR TITLE
fix(github): exclude closed issues from board source

### DIFF
--- a/internal/adapters/github/project_source.go
+++ b/internal/adapters/github/project_source.go
@@ -130,6 +130,9 @@ func (s *ProjectBoardSource) FindIssuesFromProject(ctx context.Context, statusCo
 			if strings.ToLower(c.Repository.NameWithOwner) != targetRepo {
 				continue // cross-repo filter
 			}
+			if strings.ToUpper(c.State) != "OPEN" {
+				continue // skip closed/merged issues
+			}
 			if !strings.EqualFold(node.FieldValueByName.Name, statusColumn) {
 				continue // wrong status column
 			}

--- a/internal/adapters/github/project_source_test.go
+++ b/internal/adapters/github/project_source_test.go
@@ -217,6 +217,49 @@ func TestFindIssuesFromProject_LabelHydration(t *testing.T) {
 	}
 }
 
+func TestFindIssuesFromProject_ClosedIssueExclusion(t *testing.T) {
+	cases := []struct {
+		name        string
+		state       string
+		wantInclude bool
+	}{
+		{"open uppercase", "OPEN", true},
+		{"open lowercase", "open", true},
+		{"closed", "CLOSED", false},
+		{"closed lowercase", "closed", false},
+		{"merged", "MERGED", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := fakeProjectSourceServer(t, []string{
+				orgProjectResp("PVT_closed"),
+				itemsResp([]map[string]interface{}{
+					issueNode(42, "I_42", "Some issue", "", tc.state, "org/repo", "Todo"),
+				}, false, ""),
+			})
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			src := NewProjectBoardSource(client, &ProjectBoardConfig{
+				ProjectNumber: 99,
+				StatusField:   "Status",
+			}, "org", "repo")
+
+			issues, err := src.FindIssuesFromProject(context.Background(), "Todo")
+			if err != nil {
+				t.Fatalf("FindIssuesFromProject() error = %v", err)
+			}
+			if tc.wantInclude && len(issues) != 1 {
+				t.Errorf("state=%q: expected issue to be included, got %d issues", tc.state, len(issues))
+			}
+			if !tc.wantInclude && len(issues) != 0 {
+				t.Errorf("state=%q: expected issue to be excluded, got %d issues", tc.state, len(issues))
+			}
+		})
+	}
+}
+
 func TestFindIssuesFromProject_DraftIssuesSkipped(t *testing.T) {
 	server := fakeProjectSourceServer(t, []string{
 		orgProjectResp("PVT_draft"),


### PR DESCRIPTION
Fixes #3241

## Summary
- `FindIssuesFromProject` now skips nodes where `strings.ToUpper(c.State) != "OPEN"`, matching the label path's `State: StateOpen` behavior
- Added `TestFindIssuesFromProject_ClosedIssueExclusion` — table-driven test covering OPEN (upper/lower), CLOSED (upper/lower), and MERGED states

## Test plan
- [x] `make test` passes
- [x] `make lint` passes (0 issues)
- [x] All 5 subtests in new test function pass