### PR TITLE
fix(executor): dedup epic sub-issues from poller re-dispatch (GH-3240)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2350,6 +2350,14 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					runner.SetOnSubIssuePRCreated(autopilotController.OnPRCreated)
 				}
 
+				// GH-3240: mark epic-created sub-issues as processed in all pollers so
+				// findOldestUnprocessedIssue does not re-dispatch them.
+				runner.SetSubIssuePollerSkip(func(n int) {
+					for _, p := range ghPollers {
+						p.MarkProcessed(n)
+					}
+				})
+
 				// Wire sub-issue merge-wait so epic sub-issues block until their PR merges (GH-2179)
 				if waitForMerge && cfg.Adapters.GitHub.Repo != "" {
 					parts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2)

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -1379,6 +1379,12 @@ func (p *Poller) Reset() {
 	p.mu.Unlock()
 }
 
+// MarkProcessed marks an issue as processed so findOldestUnprocessedIssue skips it.
+// Called by the executor after epic sub-issues are created to prevent re-dispatch (GH-3240).
+func (p *Poller) MarkProcessed(number int) {
+	p.markProcessed(number)
+}
+
 // ClearProcessed removes a single issue from the processed map.
 // Used by the stale label cleaner when removing pilot-failed labels
 // to allow the issue to be retried without restarting Pilot.

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1293,6 +1293,12 @@ func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, e
 			Subtask:    subtask,
 		})
 
+		// GH-3240: pre-mark in the poller so the sub-issue is not re-dispatched
+		// on the next poll cycle (the epic will execute it directly via ExecuteSubIssues).
+		if r.subIssuePollerSkip != nil && issueNumber > 0 {
+			r.subIssuePollerSkip(issueNumber)
+		}
+
 		// Track order → issue number for dependency resolution (GH-1794)
 		orderToIssueNumber[subtask.Order] = issueNumber
 

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2603,3 +2603,70 @@ func TestCreateSubIssuesViaGitHub_GuardrailBypassEnvVar(t *testing.T) {
 		t.Fatalf("expected 1 issue created via bypass, got %d", len(created))
 	}
 }
+
+// TestCreateSubIssues_PollerSkipCalledForGitHubIssues verifies GH-3240: after
+// createSubIssuesViaGitHub creates each sub-issue, it must call the
+// SubIssuePollerSkipFn callback with the issue number so the poller marks it
+// as processed and does not re-dispatch it on the next poll cycle.
+func TestCreateSubIssues_PollerSkipCalledForGitHubIssues(t *testing.T) {
+	// Fake "gh" binary that returns successive issue URLs.
+	fakeBin := t.TempDir()
+	script := filepath.Join(fakeBin, "gh")
+	scriptContent := "#!/bin/sh\n" +
+		// Each call prints the next issue number (101, 102, …) by counting invocations
+		// via a temp counter file, then emits a valid GitHub issue URL.
+		`COUNT_FILE="` + filepath.Join(t.TempDir(), "count") + `"
+if [ -f "$COUNT_FILE" ]; then
+  N=$(cat "$COUNT_FILE")
+else
+  N=100
+fi
+N=$((N+1))
+echo $N > "$COUNT_FILE"
+echo "https://github.com/owner/repo/issues/$N"
+`
+	if err := os.WriteFile(script, []byte(scriptContent), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+
+	runner := NewRunner()
+
+	var mu sync.Mutex
+	var skipped []int
+	runner.SetSubIssuePollerSkip(func(n int) {
+		mu.Lock()
+		skipped = append(skipped, n)
+		mu.Unlock()
+	})
+
+	plan := &EpicPlan{
+		ParentTask: &Task{ID: "GH-99"},
+		Subtasks: []PlannedSubtask{
+			{Title: "feat(sub): first subtask", Description: "First", Order: 1},
+			{Title: "feat(sub): second subtask", Description: "Second", Order: 2},
+		},
+	}
+
+	created, err := runner.CreateSubIssues(context.Background(), plan, t.TempDir())
+	if err != nil {
+		t.Fatalf("CreateSubIssues failed: %v", err)
+	}
+	if len(created) != 2 {
+		t.Fatalf("expected 2 created issues, got %d", len(created))
+	}
+
+	mu.Lock()
+	got := append([]int(nil), skipped...)
+	mu.Unlock()
+
+	if len(got) != 2 {
+		t.Fatalf("SubIssuePollerSkipFn called %d times, want 2; skipped=%v", len(got), got)
+	}
+	for i, issue := range created {
+		if got[i] != issue.Number {
+			t.Errorf("skipped[%d] = %d, want %d (issue.Number)", i, got[i], issue.Number)
+		}
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -326,6 +326,10 @@ type SubIssuePRCallback func(prNumber int, prURL string, issueNumber int, headSH
 // to enforce sequential ordering: sub-issue N+1 only starts after sub-issue N is merged.
 type SubIssueMergeWaitFn func(ctx context.Context, prNumber int) error
 
+// SubIssuePollerSkipFn is called with each newly-created GitHub sub-issue number so the
+// poller marks it as already-processed and does not re-dispatch it (GH-3240).
+type SubIssuePollerSkipFn func(issueNumber int)
+
 // SubIssueCreator is an interface for creating sub-issues in external issue trackers.
 // Adapters like Linear, Jira, GitLab, and Azure DevOps can implement this interface
 // to allow epic decomposition to create sub-issues in the source tracker rather than GitHub.
@@ -381,6 +385,7 @@ type Runner struct {
 	tokenLimitCheck       TokenLimitCallback                                              // Optional per-task token/duration limit check (GH-539)
 	onSubIssuePRCreated   SubIssuePRCallback                                              // Optional callback when a sub-issue PR is created (GH-596)
 	subIssueMergeWait     SubIssueMergeWaitFn                                             // Optional fn to block between sub-issues until PR is merged (GH-2178)
+	subIssuePollerSkip    SubIssuePollerSkipFn                                            // GH-3240: marks sub-issues in poller so they aren't re-dispatched
 	intentJudge           *IntentJudge                                                    // Optional intent judge for diff-vs-ticket alignment (GH-624)
 	teamChecker           TeamChecker                                                     // Optional team RBAC checker (GH-633)
 	executeFunc           func(ctx context.Context, task *Task) (*ExecutionResult, error) // Internal override for testing
@@ -829,6 +834,12 @@ func (r *Runner) SetSubIssueMergeWait(fn SubIssueMergeWaitFn) {
 
 // HasSubIssueMergeWait reports whether a merge-wait function is wired.
 func (r *Runner) HasSubIssueMergeWait() bool { return r.subIssueMergeWait != nil }
+
+// SetSubIssuePollerSkip wires the callback that marks a newly-created GitHub
+// sub-issue as already-processed in the poller so it is not re-dispatched (GH-3240).
+func (r *Runner) SetSubIssuePollerSkip(fn SubIssuePollerSkipFn) {
+	r.subIssuePollerSkip = fn
+}
 
 // SetSubIssueCreator sets the creator for sub-issues in external issue trackers (GH-1471).
 // When set and the task's SourceAdapter is non-GitHub, CreateSubIssues will dispatch


### PR DESCRIPTION
## Summary

- Adds `Poller.MarkProcessed` (public) — wraps the existing private `markProcessed` so external callers can mark issues processed
- Adds `SubIssuePollerSkipFn` type + `subIssuePollerSkip` field + `SetSubIssuePollerSkip` setter to `Runner`
- In `createSubIssuesViaGitHub`, calls the callback immediately after each GitHub sub-issue is created (before the poller's next tick can see it)
- Wires the callback in `cmd/pilot/main.go` alongside the existing `SetOnSubIssuePRCreated` and `SetSubIssueMergeWait` wiring
- Adds `TestCreateSubIssues_PollerSkipCalledForGitHubIssues` — regression test proving the callback fires for each created sub-issue

## Test plan

- [ ] `make test` passes
- [ ] `go test ./internal/executor/... -run TestCreateSubIssues_PollerSkipCalledForGitHubIssues -v` — PASS
- [ ] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues

Closes #3240