### PR TITLE
feat(autopilot): wire GH Projects V2 board transitions for PR-created and exec-failure (GH-3260)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -480,7 +480,7 @@ Examples:
 							if cfg.Adapters.GitHub.ProjectBoard != nil && cfg.Adapters.GitHub.ProjectBoard.Enabled {
 								bs := github.NewProjectBoardSync(ghClient, cfg.Adapters.GitHub.ProjectBoard, parts[0])
 								statuses := cfg.Adapters.GitHub.ProjectBoard.GetStatuses()
-								gwBoardOpts = append(gwBoardOpts, autopilot.WithProjectBoardSync(bs, statuses.Done, statuses.Failed))
+								gwBoardOpts = append(gwBoardOpts, autopilot.WithProjectBoardSync(bs, statuses.Done, statuses.Failed, statuses.Review, statuses.InProgress))
 							}
 							gwAutopilotController = autopilot.NewController(
 								cfg.Orchestrator.Autopilot,
@@ -1430,7 +1430,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				}
 				bs := github.NewProjectBoardSync(ghClient, cfg.Adapters.GitHub.ProjectBoard, owner)
 				statuses := cfg.Adapters.GitHub.ProjectBoard.GetStatuses()
-				autopilotBoardOpts = append(autopilotBoardOpts, autopilot.WithProjectBoardSync(bs, statuses.Done, statuses.Failed))
+				autopilotBoardOpts = append(autopilotBoardOpts, autopilot.WithProjectBoardSync(bs, statuses.Done, statuses.Failed, statuses.Review, statuses.InProgress))
 			}
 
 			// Create controller for default repo (adapters.github.repo)

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -24,6 +24,12 @@ type approvalPersister interface {
 	SetApprovalDecision(ctx context.Context, requestID, decision, by string) error
 }
 
+// projectBoardSyncer abstracts GitHub Projects V2 board status updates.
+// *github.ProjectBoardSync implements this interface; tests substitute a mock.
+type projectBoardSyncer interface {
+	UpdateProjectItemStatus(ctx context.Context, issueNodeID string, statusName string) error
+}
+
 // iterationRe matches the iteration field in autopilot-meta comments.
 var iterationRe = regexp.MustCompile(`<!-- autopilot-meta.*?iteration:(\d+).*?-->`)
 
@@ -103,12 +109,15 @@ type EvalStore interface {
 type ControllerOption func(*Controller)
 
 // WithProjectBoardSync wires a GitHub Projects V2 board sync into the controller.
-// doneStatus is the board column name for merged PRs; failStatus for CI failures (may be empty).
-func WithProjectBoardSync(bs *github.ProjectBoardSync, doneStatus, failStatus string) ControllerOption {
+// doneStatus: merged PRs; failStatus: CI/exec failures; reviewStatus: PR created (In Progress → Review);
+// inProgressStatus: reserved for future use (wired for symmetry, not yet emitted).
+func WithProjectBoardSync(bs *github.ProjectBoardSync, doneStatus, failStatus, reviewStatus, inProgressStatus string) ControllerOption {
 	return func(c *Controller) {
 		c.boardSync = bs
 		c.doneStatus = doneStatus
 		c.failStatus = failStatus
+		c.reviewStatus = reviewStatus
+		c.inProgressStatus = inProgressStatus
 	}
 }
 
@@ -131,12 +140,14 @@ type Controller struct {
 	feedbackLoop *FeedbackLoop
 	releaser     *Releaser
 	deployer     *Deployer
-	notifier     Notifier
-	monitor      TaskMonitor // GH-1336: sync dashboard state on merge
-	boardSync    *github.ProjectBoardSync
-	doneStatus   string
-	failStatus   string
-	log          *slog.Logger
+	notifier         Notifier
+	monitor          TaskMonitor // GH-1336: sync dashboard state on merge
+	boardSync        projectBoardSyncer
+	doneStatus       string
+	failStatus       string
+	reviewStatus     string // GH-3260: board column for PR-created (In Progress → Review)
+	inProgressStatus string // GH-3260: reserved for symmetry; not yet emitted
+	log              *slog.Logger
 
 	// State tracking
 	activePRs map[int]*PRState
@@ -353,8 +364,6 @@ func (c *Controller) RestoreState() (int, error) {
 // OnPRCreated registers a new PR for autopilot processing.
 func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, headSHA string, branchName string, issueNodeID string) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	prState := &PRState{
 		PRNumber:        prNumber,
 		PRURL:           prURL,
@@ -368,8 +377,9 @@ func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, he
 		IssueNodeID:     issueNodeID,
 	}
 	c.activePRs[prNumber] = prState
+	c.mu.Unlock()
 
-	// Persist to SQLite (outside lock is fine, persist is idempotent)
+	// Persist to SQLite (idempotent, safe outside lock)
 	c.persistPRState(prState)
 
 	c.log.Info("PR registered for autopilot",
@@ -381,6 +391,14 @@ func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, he
 		"stage", StagePRCreated,
 		"env", c.config.EnvironmentName(),
 	)
+
+	// GH-3260: Sync board card to "In Review" column when PR is created (In Progress → Review).
+	// Board sync is a non-critical side-effect; failure is logged but does not block registration.
+	if c.boardSync != nil && issueNodeID != "" && c.reviewStatus != "" {
+		if err := c.boardSync.UpdateProjectItemStatus(context.Background(), issueNodeID, c.reviewStatus); err != nil {
+			c.log.Warn("board sync on PR created failed", "pr", prNumber, "error", err)
+		}
+	}
 }
 
 // OnReviewRequested handles PR review events from GitHub webhooks.
@@ -759,6 +777,13 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 				c.log.Warn("failed to close failed PR", "pr", prState.PRNumber, "error", err)
 			}
 
+			// GH-3260: Sync board card to "Blocked/Failed" column on execution failure (iteration limit).
+			if c.boardSync != nil && prState.IssueNodeID != "" && c.failStatus != "" {
+				if err := c.boardSync.UpdateProjectItemStatus(ctx, prState.IssueNodeID, c.failStatus); err != nil {
+					c.log.Warn("board sync on exec failure (iteration limit) failed", "pr", prState.PRNumber, "error", err)
+				}
+			}
+
 			prState.Stage = StageFailed
 			prState.Error = fmt.Sprintf("CI fix iteration limit reached (%d/%d): stopping cascade to prevent infinite loop", iteration, c.config.MaxCIFixIterations)
 			c.metrics.RecordPRFailed()
@@ -786,6 +811,12 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 				if err := c.ghClient.ClosePullRequest(ctx, c.owner, c.repo, prState.PRNumber); err != nil {
 					c.log.Warn("CI fix size guard: failed to close oversized failed PR",
 						"pr", prState.PRNumber, "error", err)
+				}
+				// GH-3260: Sync board card to "Blocked/Failed" column on execution failure (size guard).
+				if c.boardSync != nil && prState.IssueNodeID != "" && c.failStatus != "" {
+					if err := c.boardSync.UpdateProjectItemStatus(ctx, prState.IssueNodeID, c.failStatus); err != nil {
+						c.log.Warn("board sync on exec failure (size guard) failed", "pr", prState.PRNumber, "error", err)
+					}
 				}
 				prState.Stage = StageFailed
 				prState.Error = fmt.Sprintf("CI fix size guard: PR has %d additions, over limit %d (likely cascade contamination — escalate to human)", netAdditions, c.config.MaxCIFixPRSize)

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6306,3 +6306,271 @@ func TestGetMainBranchSHA_RespectsResolvedEnv(t *testing.T) {
 		})
 	}
 }
+
+// --- Board/Project/Status/Review/Block tests (GH-3260) ---
+
+// mockBoardSyncer is a test double for projectBoardSyncer.
+type mockBoardSyncer struct {
+	calls []boardSyncCall
+	err   error // if non-nil, returned from UpdateProjectItemStatus
+}
+
+type boardSyncCall struct {
+	issueNodeID string
+	statusName  string
+}
+
+func (m *mockBoardSyncer) UpdateProjectItemStatus(_ context.Context, issueNodeID, statusName string) error {
+	m.calls = append(m.calls, boardSyncCall{issueNodeID: issueNodeID, statusName: statusName})
+	return m.err
+}
+
+// TestController_WithProjectBoardSync_AllStatuses verifies that WithProjectBoardSync
+// stores all four status strings and wires the boardSync field.
+func TestController_WithProjectBoardSync_AllStatuses(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	mock := &mockBoardSyncer{}
+	opt := withBoardSyncerForTest(mock, "Done", "Failed", "In Review", "In Dev")
+
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo", opt)
+
+	if c.boardSync == nil {
+		t.Fatal("boardSync should be set")
+	}
+	if c.doneStatus != "Done" {
+		t.Errorf("doneStatus = %q, want %q", c.doneStatus, "Done")
+	}
+	if c.failStatus != "Failed" {
+		t.Errorf("failStatus = %q, want %q", c.failStatus, "Failed")
+	}
+	if c.reviewStatus != "In Review" {
+		t.Errorf("reviewStatus = %q, want %q", c.reviewStatus, "In Review")
+	}
+	if c.inProgressStatus != "In Dev" {
+		t.Errorf("inProgressStatus = %q, want %q", c.inProgressStatus, "In Dev")
+	}
+}
+
+// withBoardSyncerForTest is a ControllerOption that injects a mockBoardSyncer
+// (bypasses the *github.ProjectBoardSync type constraint of WithProjectBoardSync).
+func withBoardSyncerForTest(bs projectBoardSyncer, done, fail, review, inProgress string) ControllerOption {
+	return func(c *Controller) {
+		c.boardSync = bs
+		c.doneStatus = done
+		c.failStatus = fail
+		c.reviewStatus = review
+		c.inProgressStatus = inProgress
+	}
+}
+
+// TestController_OnPRCreated_BoardSyncReview verifies that OnPRCreated triggers a
+// board sync to reviewStatus when a non-empty IssueNodeID is present.
+func TestController_OnPRCreated_BoardSyncReview(t *testing.T) {
+	tests := []struct {
+		name         string
+		issueNodeID  string
+		reviewStatus string
+		wantCalls    int
+		wantStatus   string
+	}{
+		{
+			name:         "syncs to reviewStatus when nodeID and status set",
+			issueNodeID:  "IssueNodeID_abc",
+			reviewStatus: "In Review",
+			wantCalls:    1,
+			wantStatus:   "In Review",
+		},
+		{
+			name:         "no sync when issueNodeID is empty",
+			issueNodeID:  "",
+			reviewStatus: "In Review",
+			wantCalls:    0,
+		},
+		{
+			name:         "no sync when reviewStatus is empty",
+			issueNodeID:  "IssueNodeID_abc",
+			reviewStatus: "",
+			wantCalls:    0,
+		},
+		{
+			name:         "no sync when both empty",
+			issueNodeID:  "",
+			reviewStatus: "",
+			wantCalls:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockBoardSyncer{}
+			opt := withBoardSyncerForTest(mock, "Done", "Failed", tt.reviewStatus, "")
+			c := NewController(DefaultConfig(), github.NewClient(testutil.FakeGitHubToken), nil, "owner", "repo", opt)
+
+			c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", tt.issueNodeID)
+
+			if len(mock.calls) != tt.wantCalls {
+				t.Fatalf("board sync calls = %d, want %d", len(mock.calls), tt.wantCalls)
+			}
+			if tt.wantCalls > 0 {
+				got := mock.calls[0]
+				if got.issueNodeID != tt.issueNodeID {
+					t.Errorf("issueNodeID = %q, want %q", got.issueNodeID, tt.issueNodeID)
+				}
+				if got.statusName != tt.wantStatus {
+					t.Errorf("statusName = %q, want %q", got.statusName, tt.wantStatus)
+				}
+			}
+		})
+	}
+}
+
+// TestController_OnPRCreated_BoardSync_NoBoardSync is a regression guard that verifies
+// OnPRCreated does not panic or error when no board sync is configured.
+func TestController_OnPRCreated_BoardSync_NoBoardSync(t *testing.T) {
+	c := NewController(DefaultConfig(), github.NewClient(testutil.FakeGitHubToken), nil, "owner", "repo")
+	// Should not panic.
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", "IssueNodeID_abc")
+	if _, ok := c.GetPRState(42); !ok {
+		t.Fatal("PR should be registered even without board sync")
+	}
+}
+
+// TestController_handleCIFailed_BoardSync_IterationLimit verifies that the
+// iteration-limit execution-failure path syncs the board to failStatus.
+func TestController_handleCIFailed_BoardSync_IterationLimit(t *testing.T) {
+	const issueNodeID = "IssueNodeID_iter"
+
+	tests := []struct {
+		name       string
+		failStatus string
+		wantCalls  int
+	}{
+		{
+			name:       "syncs to failStatus at iteration limit",
+			failStatus: "Blocked",
+			wantCalls:  1,
+		},
+		{
+			name:       "no sync when failStatus is empty",
+			failStatus: "",
+			wantCalls:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockBoardSyncer{}
+
+			// Build a test HTTP server that serves the GitHub API calls made by handleCIFailed.
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/issues/"):
+					// Return an issue body with iteration counter at the limit.
+					_, _ = fmt.Fprintf(w, `{"number":10,"body":"<!-- autopilot-meta iteration:%d -->"}`, 3)
+				case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/pulls/"):
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.MaxCIFixIterations = 3 // iteration = 3 >= MaxCIFixIterations = 3 → limit hit
+
+			opt := withBoardSyncerForTest(mock, "Done", tt.failStatus, "In Review", "")
+			c := NewController(cfg, ghClient, nil, "owner", "repo", opt)
+
+			prState := &PRState{
+				PRNumber:    42,
+				IssueNumber: 10,
+				IssueNodeID: issueNodeID,
+				HeadSHA:     "abc123",
+				BranchName:  "pilot/GH-10",
+			}
+
+			err := c.handleCIFailed(context.Background(), prState)
+			if err != nil {
+				t.Fatalf("handleCIFailed returned unexpected error: %v", err)
+			}
+			if prState.Stage != StageFailed {
+				t.Errorf("Stage = %s, want %s", prState.Stage, StageFailed)
+			}
+
+			if len(mock.calls) != tt.wantCalls {
+				t.Fatalf("board sync calls = %d, want %d (calls: %+v)", len(mock.calls), tt.wantCalls, mock.calls)
+			}
+			if tt.wantCalls > 0 {
+				got := mock.calls[0]
+				if got.issueNodeID != issueNodeID {
+					t.Errorf("issueNodeID = %q, want %q", got.issueNodeID, issueNodeID)
+				}
+				if got.statusName != tt.failStatus {
+					t.Errorf("statusName = %q, want %q", got.statusName, tt.failStatus)
+				}
+			}
+		})
+	}
+}
+
+// TestController_handleCIFailed_BoardSync_Regression_NormalPath is a regression guard
+// that verifies the existing normal CI failure board sync (non-iteration-limit) still fires.
+func TestController_handleCIFailed_BoardSync_Regression_NormalPath(t *testing.T) {
+	const issueNodeID = "IssueNodeID_normal"
+	mock := &mockBoardSyncer{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/issues/") && !strings.Contains(r.URL.Path, "/comments"):
+			// Iteration = 0 → below any limit
+			_, _ = fmt.Fprintf(w, `{"number":10,"body":"no-meta"}`)
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/issues"):
+			// CreateFailureIssue creates a new issue
+			_, _ = fmt.Fprintf(w, `{"number":99}`)
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/check-runs"):
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
+			_, _ = fmt.Fprintf(w, `{"check_runs":[]}`)
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/"):
+			_, _ = fmt.Fprintf(w, `{"number":42,"state":"open"}`)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.MaxCIFixIterations = 5 // below limit
+
+	opt := withBoardSyncerForTest(mock, "Done", "Blocked", "In Review", "")
+	c := NewController(cfg, ghClient, nil, "owner", "repo", opt)
+
+	prState := &PRState{
+		PRNumber:    42,
+		IssueNumber: 10,
+		IssueNodeID: issueNodeID,
+		HeadSHA:     "abc123",
+		BranchName:  "pilot/GH-10",
+	}
+
+	// handleCIFailed should reach the normal path and fire board sync with failStatus.
+	_ = c.handleCIFailed(context.Background(), prState)
+
+	// The normal path fires one board sync call with failStatus.
+	found := false
+	for _, call := range mock.calls {
+		if call.issueNodeID == issueNodeID && call.statusName == "Blocked" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected board sync call with issueNodeID=%q statusName=%q, got calls: %+v",
+			issueNodeID, "Blocked", mock.calls)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `projectBoardSyncer` interface so tests can inject a mock without a live GitHub GraphQL API
- Extends `WithProjectBoardSync` to accept `reviewStatus` and `inProgressStatus` (symmetry with `doneStatus`/`failStatus`)
- `OnPRCreated`: syncs the project board card to `reviewStatus` after registering the PR (In Progress → Review transition)
- `handleCIFailed` iteration-limit path: syncs board to `failStatus` before `StageFailed` — closes the gap where the card would stay stuck on "In Review" after cascade stop
- `handleCIFailed` size-guard path: same guard for the oversized-PR failure path
- Updates both `WithProjectBoardSync` call sites in `cmd/pilot/main.go` (`statuses.Review`, `statuses.InProgress`)

## Test plan

- [ ] `go test ./internal/autopilot/ -run 'Board|Project|Status|Review|Block' -v` — all new tests pass
- [ ] `go test ./...` — zero regressions
- [ ] `golangci-lint run --new-from-rev=origin/main ./...` — zero issues