### PR TITLE
feat(autopilot): add WithBoardSync option and wire InProgress at both call sites (GH-3253)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -481,6 +481,7 @@ Examples:
 								bs := github.NewProjectBoardSync(ghClient, cfg.Adapters.GitHub.ProjectBoard, parts[0])
 								statuses := cfg.Adapters.GitHub.ProjectBoard.GetStatuses()
 								gwBoardOpts = append(gwBoardOpts, autopilot.WithProjectBoardSync(bs, statuses.Done, statuses.Failed))
+								gwBoardOpts = append(gwBoardOpts, autopilot.WithBoardSync(bs, statuses.InProgress))
 							}
 							gwAutopilotController = autopilot.NewController(
 								cfg.Orchestrator.Autopilot,
@@ -1431,6 +1432,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				bs := github.NewProjectBoardSync(ghClient, cfg.Adapters.GitHub.ProjectBoard, owner)
 				statuses := cfg.Adapters.GitHub.ProjectBoard.GetStatuses()
 				autopilotBoardOpts = append(autopilotBoardOpts, autopilot.WithProjectBoardSync(bs, statuses.Done, statuses.Failed))
+				autopilotBoardOpts = append(autopilotBoardOpts, autopilot.WithBoardSync(bs, statuses.InProgress))
 			}
 
 			// Create controller for default repo (adapters.github.repo)

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -112,6 +112,17 @@ func WithProjectBoardSync(bs *github.ProjectBoardSync, doneStatus, failStatus st
 	}
 }
 
+// WithBoardSync wires a GitHub Projects V2 board sync and the "In Progress"
+// column name into the controller. The inProgressStatus field is reserved for
+// future transitions (e.g. marking an issue as In Progress when execution begins);
+// it no-ops when empty, so callers in label-mode need not provide a value.
+func WithBoardSync(bs *github.ProjectBoardSync, inProgressStatus string) ControllerOption {
+	return func(c *Controller) {
+		c.boardSync = bs
+		c.inProgressStatus = inProgressStatus
+	}
+}
+
 // WithMemoryStore wires an execution-level approval persister so that
 // approval_request_id and approval_decision are written to the executions table.
 func WithMemoryStore(s *memory.Store) ControllerOption {
@@ -133,10 +144,11 @@ type Controller struct {
 	deployer     *Deployer
 	notifier     Notifier
 	monitor      TaskMonitor // GH-1336: sync dashboard state on merge
-	boardSync    *github.ProjectBoardSync
-	doneStatus   string
-	failStatus   string
-	log          *slog.Logger
+	boardSync        *github.ProjectBoardSync
+	doneStatus       string
+	failStatus       string
+	inProgressStatus string // GH-3253: reserved for future In Progress transition
+	log              *slog.Logger
 
 	// State tracking
 	activePRs map[int]*PRState


### PR DESCRIPTION
## Summary

- Add `WithBoardSync(bs *github.ProjectBoardSync, inProgressStatus string)` as a new `ControllerOption` in `internal/autopilot/controller.go`
- Add `inProgressStatus string` field to `Controller` struct (reserved for future In Progress board transition; not yet emitted)
- Wire `autopilot.WithBoardSync(bs, statuses.InProgress)` at both existing `WithProjectBoardSync` call sites in `cmd/pilot/main.go`:
  - Gateway-mode (~line 483)
  - Start-mode (~line 1433)

No behavior change: the option no-ops when `inProgressStatus` is empty, so label-mode is unaffected.

Closes #3253

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/autopilot/... ./cmd/pilot/...` — all pass
- [x] `make test` — all packages pass, no failures
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues