### PR TITLE
feat(github): add WithBoardSync poller option and in-progress write-back (GH-3252)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -132,6 +132,7 @@
 | Jira/Asana autopilot wire | ✅ | adapters | - | - | OnPRCreated + HeadSHA/BranchName for Jira + Asana (v1.19.0, GH-1397) |
 | GitHub Projects V2 Board | ✅ | adapters/github | - | `adapters.github.project_board` | GraphQL board sync: Review/Done/Failed columns (v2.30.0, PR #1863) |
 | GitHub Projects V2 Board Source | ✅ | adapters/github | - | `adapters.github.project_board.source_enabled` | Pull work FROM a board column (FindIssuesFromProject); opt-in via source_enabled/source_status (GH-3228) |
+| GitHub Projects V2 In-Progress write-back | ✅ | adapters/github | - | wired via `WithBoardSync` | Moves issue card to In Progress on confirmed dispatch; `WithBoardSync(bs, status)` poller option; node-ID from issue or REST fallback (GH-3252) |
 | Common Adapter Registry | ✅ | adapters | - | - | Unified Adapter interface, generic ProcessedStore table (v2.30.0, PR #1845) |
 | Linear workspace mode | ✅ | adapters/linear | - | `adapters.linear.projects` | Project-scoped routing via project_ids mapping for multi-project setups |
 | Plane.so state transitions | ✅ | adapters/plane | - | - | State transitions and PR comments on Plane.so issues (v2.25.0, PR #1843) |

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -166,6 +166,11 @@ type Poller struct {
 	// projectBoardSource sources candidates from a Projects V2 board column (GH-3228).
 	// When non-nil, replaces label-based ListIssues in findOldestUnprocessedIssue.
 	projectBoardSource *ProjectBoardSource
+
+	// boardSync moves the issue card to inProgressStatus on confirmed dispatch (GH-3252).
+	// nil or empty inProgressStatus disables the write-back, keeping label-mode identical.
+	boardSync        *ProjectBoardSync
+	inProgressStatus string
 }
 
 // PollerOption configures a Poller
@@ -325,6 +330,15 @@ func WithPollerMetrics(rec skipreason.PollerMetricsRecorder) PollerOption {
 func WithProjectBoardSource(src *ProjectBoardSource) PollerOption {
 	return func(p *Poller) {
 		p.projectBoardSource = src
+	}
+}
+
+// WithBoardSync configures the poller to move the issue card to inProgressStatus on the
+// Projects V2 board after confirmed dispatch. No-op when bs is nil or inProgressStatus is "".
+func WithBoardSync(bs *ProjectBoardSync, inProgressStatus string) PollerOption {
+	return func(p *Poller) {
+		p.boardSync = bs
+		p.inProgressStatus = inProgressStatus
 	}
 }
 
@@ -540,6 +554,9 @@ func (p *Poller) startSequential(ctx context.Context) {
 				continue // skip dispatch; label removal re-triggers on next poll
 			}
 		}
+
+		// Board sync: move card to in-progress on confirmed dispatch (GH-3252).
+		p.syncBoardStatusInProgress(ctx, issue)
 
 		result, err := p.processIssueSequential(ctx, issue)
 		if err != nil {
@@ -966,6 +983,35 @@ func (p *Poller) recordDeferredScopeOverlap() {
 	}
 }
 
+// syncBoardStatusInProgress moves the issue card to the configured in-progress status
+// on the Projects V2 board. Called once after confirmed dispatch, before execution starts.
+// Logs errors but does not fail the dispatch — board sync is best-effort.
+// No-op when boardSync is nil or inProgressStatus is empty.
+func (p *Poller) syncBoardStatusInProgress(ctx context.Context, issue *Issue) {
+	if p.boardSync == nil || p.inProgressStatus == "" {
+		return
+	}
+
+	nodeID := issue.NodeID
+	if nodeID == "" {
+		var err error
+		nodeID, err = p.client.GetIssueNodeID(ctx, p.owner, p.repo, issue.Number)
+		if err != nil {
+			p.logger.Warn("board sync: failed to resolve issue node ID",
+				slog.Int("issue", issue.Number),
+				slog.Any("error", err))
+			return
+		}
+	}
+
+	if err := p.boardSync.UpdateProjectItemStatus(ctx, nodeID, p.inProgressStatus); err != nil {
+		p.logger.Warn("board sync: failed to update project item status",
+			slog.Int("issue", issue.Number),
+			slog.String("status", p.inProgressStatus),
+			slog.Any("error", err))
+	}
+}
+
 // checkForNewIssues fetches issues and dispatches new ones concurrently (parallel mode)
 func (p *Poller) checkForNewIssues(ctx context.Context) {
 	issues, err := p.client.ListIssues(ctx, p.owner, p.repo, &ListIssuesOptions{
@@ -1207,6 +1253,9 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 		go func(issue *Issue) {
 			defer p.activeWg.Done()
 			defer func() { <-p.semaphore }() // release slot
+
+			// Board sync: move card to in-progress on confirmed dispatch (GH-3252).
+			p.syncBoardStatusInProgress(ctx, issue)
 
 			if p.onIssueWithResult != nil {
 				result, err := p.onIssueWithResult(ctx, issue)

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2938,3 +2938,229 @@ func TestPoller_CheckForNewIssues_SkipsBlockedIssues(t *testing.T) {
 		t.Errorf("dispatched %d times, want 0 (pilot-blocked must skip)", got)
 	}
 }
+
+// --- GH-3252: WithBoardSync write-back tests ---
+
+// boardSyncTestServer creates an httptest.Server that handles the full set of calls
+// made during a board-sync dispatch cycle:
+//   - GET /repos/owner/repo/issues   → returns issues
+//   - GET /repos/owner/repo/issues/N → returns freshIssue (used for label refresh and GetIssueNodeID fallback)
+//   - POST /graphql                  → serves ProjectBoardSync GraphQL; counts mutations via mutationCount
+func boardSyncTestServer(t *testing.T, issues []*Issue, freshIssue *Issue, mutationCount *atomic.Int32, capturedNodeID *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode(issues)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/1":
+			_ = json.NewEncoder(w).Encode(freshIssue)
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			var req GraphQLRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode graphql request: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			var resp string
+			switch {
+			case strings.Contains(req.Query, "organization"):
+				resp = `{"data":{"organization":{"projectV2":{"id":"PVT_org1"}}}}`
+			case strings.Contains(req.Query, "field(name:"):
+				resp = `{"data":{"node":{"field":{"id":"PVTSSF_f1","options":[{"id":"OPT_inprog","name":"In Progress"},{"id":"OPT_done","name":"Done"}]}}}}`
+			case strings.Contains(req.Query, "projectItems"):
+				if capturedNodeID != nil {
+					if id, ok := req.Variables["issueID"].(string); ok {
+						*capturedNodeID = id
+					}
+				}
+				resp = `{"data":{"node":{"projectItems":{"nodes":[{"id":"PVTI_item1","project":{"id":"PVT_org1"}}]}}}}`
+			case strings.Contains(req.Query, "updateProjectV2ItemFieldValue"):
+				mutationCount.Add(1)
+				resp = `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_item1"}}}}`
+			default:
+				t.Errorf("unexpected graphql query: %s", req.Query)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+}
+
+// newBoardSyncForTest creates a ProjectBoardSync backed by the given client.
+func newBoardSyncForTest(client *Client) *ProjectBoardSync {
+	return NewProjectBoardSync(client, &ProjectBoardConfig{
+		Enabled:       true,
+		ProjectNumber: 1,
+		StatusField:   "Status",
+	}, "owner")
+}
+
+func TestPollerBoardSync_PickupTriggersExactlyOneCall(t *testing.T) {
+	issue := &Issue{
+		Number: 1, Title: "feat: board test", NodeID: "I_node1",
+		Labels: []Label{{Name: "pilot"}},
+	}
+	var mutCount atomic.Int32
+	server := boardSyncTestServer(t, []*Issue{issue}, issue, &mutCount, nil)
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	bs := newBoardSyncForTest(client)
+
+	var dispatched int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithBoardSync(bs, "In Progress"),
+		WithOnIssueWithResult(func(ctx context.Context, i *Issue) (*IssueResult, error) {
+			atomic.AddInt32(&dispatched, 1)
+			return &IssueResult{Success: true, PRNumber: 1, PRURL: "https://github.com/owner/repo/pull/1"}, nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&dispatched); got != 1 {
+		t.Fatalf("handler called %d times, want 1", got)
+	}
+	if got := mutCount.Load(); got != 1 {
+		t.Errorf("UpdateProjectItemStatus called %d times, want exactly 1", got)
+	}
+}
+
+func TestPollerBoardSync_NilBoardSync(t *testing.T) {
+	issue := &Issue{
+		Number: 1, Title: "no board", NodeID: "I_node1",
+		Labels: []Label{{Name: "pilot"}},
+	}
+	var mutCount atomic.Int32
+	server := boardSyncTestServer(t, []*Issue{issue}, issue, &mutCount, nil)
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	// WithBoardSync not called — boardSync remains nil.
+	var dispatched int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssueWithResult(func(ctx context.Context, i *Issue) (*IssueResult, error) {
+			atomic.AddInt32(&dispatched, 1)
+			return &IssueResult{Success: true, PRNumber: 1}, nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&dispatched); got != 1 {
+		t.Fatalf("handler called %d times, want 1", got)
+	}
+	if got := mutCount.Load(); got != 0 {
+		t.Errorf("mutation called %d times, want 0 (boardSync is nil)", got)
+	}
+}
+
+func TestPollerBoardSync_EmptyInProgressStatus(t *testing.T) {
+	issue := &Issue{
+		Number: 1, Title: "no status", NodeID: "I_node1",
+		Labels: []Label{{Name: "pilot"}},
+	}
+	var mutCount atomic.Int32
+	server := boardSyncTestServer(t, []*Issue{issue}, issue, &mutCount, nil)
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	bs := newBoardSyncForTest(client)
+
+	var dispatched int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithBoardSync(bs, ""), // empty status — must be no-op
+		WithOnIssueWithResult(func(ctx context.Context, i *Issue) (*IssueResult, error) {
+			atomic.AddInt32(&dispatched, 1)
+			return &IssueResult{Success: true, PRNumber: 1}, nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&dispatched); got != 1 {
+		t.Fatalf("handler called %d times, want 1", got)
+	}
+	if got := mutCount.Load(); got != 0 {
+		t.Errorf("mutation called %d times, want 0 (inProgressStatus is empty)", got)
+	}
+}
+
+func TestPollerBoardSync_NodeIDFromIssue(t *testing.T) {
+	// Issue already has NodeID — GetIssueNodeID fallback must NOT be called.
+	issue := &Issue{
+		Number: 1, Title: "has node id", NodeID: "I_direct_node",
+		Labels: []Label{{Name: "pilot"}},
+	}
+	var capturedNodeID string
+	var mutCount atomic.Int32
+	server := boardSyncTestServer(t, []*Issue{issue}, issue, &mutCount, &capturedNodeID)
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	bs := newBoardSyncForTest(client)
+
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithBoardSync(bs, "In Progress"),
+		WithOnIssueWithResult(func(ctx context.Context, i *Issue) (*IssueResult, error) {
+			return &IssueResult{Success: true, PRNumber: 1}, nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if mutCount.Load() != 1 {
+		t.Fatalf("mutation called %d times, want 1", mutCount.Load())
+	}
+	if capturedNodeID != "I_direct_node" {
+		t.Errorf("GraphQL used nodeID %q, want %q (should use issue.NodeID directly)", capturedNodeID, "I_direct_node")
+	}
+}
+
+func TestPollerBoardSync_NodeIDFallback(t *testing.T) {
+	// Issue returned by ListIssues has empty NodeID — must fall back to GetIssueNodeID.
+	issueNoNodeID := &Issue{
+		Number: 1, Title: "no node id", NodeID: "",
+		Labels: []Label{{Name: "pilot"}},
+	}
+	// GetIssueNodeID and fresh-label-check both use GET /repos/.../issues/1.
+	// Return the same issue but WITH a node_id so GetIssueNodeID can resolve it.
+	freshIssueWithNodeID := &Issue{
+		Number: 1, Title: "no node id", NodeID: "I_fallback_node",
+		Labels: []Label{{Name: "pilot"}},
+	}
+	var capturedNodeID string
+	var mutCount atomic.Int32
+	server := boardSyncTestServer(t, []*Issue{issueNoNodeID}, freshIssueWithNodeID, &mutCount, &capturedNodeID)
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	bs := newBoardSyncForTest(client)
+
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithBoardSync(bs, "In Progress"),
+		WithOnIssueWithResult(func(ctx context.Context, i *Issue) (*IssueResult, error) {
+			return &IssueResult{Success: true, PRNumber: 1}, nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if mutCount.Load() != 1 {
+		t.Fatalf("mutation called %d times, want 1", mutCount.Load())
+	}
+	if capturedNodeID != "I_fallback_node" {
+		t.Errorf("GraphQL used nodeID %q, want %q (should use GetIssueNodeID fallback)", capturedNodeID, "I_fallback_node")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `WithBoardSync(bs *ProjectBoardSync, inProgressStatus string)` poller option in `internal/adapters/github/poller.go`
- On confirmed dispatch (after pre-flight acceptance, never on rejection), calls `boardSync.UpdateProjectItemStatus(ctx, nodeID, inProgressStatus)` exactly once to move the board card to the in-progress column
- Node-ID resolution: uses `issue.NodeID` when present, falls back to `GetIssueNodeID(owner, repo, number)` via REST API
- Entire write-back is a strict no-op when `boardSync == nil` or `inProgressStatus == ""` — label-mode default unchanged
- Wired at both dispatch sites: goroutine start in `checkForNewIssues` (parallel/auto modes) and before `processIssueSequential` (sequential mode)

## Test plan

- [ ] `TestPollerBoardSync_PickupTriggersExactlyOneCall` — confirms exactly 1 `UpdateProjectItemStatus` call on acceptance
- [ ] `TestPollerBoardSync_NilBoardSync` — no-op when boardSync is nil
- [ ] `TestPollerBoardSync_EmptyInProgressStatus` — no-op when inProgressStatus is ""
- [ ] `TestPollerBoardSync_NodeIDFromIssue` — uses `issue.NodeID` directly (no REST fallback)
- [ ] `TestPollerBoardSync_NodeIDFallback` — falls back to `GetIssueNodeID` when NodeID is empty

All tests pass: `go test ./internal/adapters/github/ -run 'Poller|Board|Dispatch' -v`