### PR TITLE
fix(poller): consult hasMergedWork on fresh candidates + add merged-work guard to sequential mode (GH-3269)

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -847,6 +847,30 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 			}
 		}
 
+		// GH-3269: Fresh candidates (never processed / post-unmark) bypass the
+		// retry block above, so apply the merged-work guard unconditionally for them.
+		if !processed && p.hasMergedWork(ctx, issue) {
+			continue
+		}
+
+		// GH-3269: Mirror the parallel-mode HasCompletedExecution guard — prevents
+		// re-dispatch when the pilot-done label failed to apply after execution.
+		if p.execChecker != nil {
+			taskID := fmt.Sprintf("GH-%d", issue.Number)
+			completed, err := p.execChecker.HasCompletedExecution(taskID, p.projectPath)
+			if err != nil {
+				p.logger.Warn("Failed to check execution status",
+					slog.Int("number", issue.Number),
+					slog.Any("error", err))
+			} else if completed {
+				p.logger.Info("Skipping re-dispatch — completed execution exists",
+					slog.Int("number", issue.Number),
+					slog.String("task_id", taskID))
+				p.markProcessed(issue.Number)
+				continue
+			}
+		}
+
 		candidates = append(candidates, issue)
 	}
 

--- a/internal/adapters/github/poller_gh3269_test.go
+++ b/internal/adapters/github/poller_gh3269_test.go
@@ -1,0 +1,194 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestPoller_Sequential_FreshCandidate_MergedWorkGuard covers GH-3269 fix 1:
+// hasMergedWork must be consulted for fresh (never-processed) candidates in
+// sequential mode, not only inside the retry/restart branches.
+func TestPoller_Sequential_FreshCandidate_MergedWorkGuard(t *testing.T) {
+	tests := []struct {
+		name        string
+		searchCount int  // total_count returned by /search/issues
+		wantNil     bool // should findOldestUnprocessedIssue return nil?
+		wantLabeled bool // should pilot-done label be added?
+		wantMarked  bool // should issue be marked processed?
+	}{
+		{
+			name:        "fresh candidate with merged PR is skipped",
+			searchCount: 1,
+			wantNil:     true,
+			wantLabeled: true,
+			wantMarked:  true,
+		},
+		{
+			name:        "fresh candidate with no merged PR dispatches normally",
+			searchCount: 0,
+			wantNil:     false,
+			wantLabeled: false,
+			wantMarked:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &Issue{
+				Number:    55,
+				Title:     "GH-55 fresh feature",
+				State:     "open",
+				Labels:    []Label{{Name: "pilot"}},
+				CreatedAt: time.Now().Add(-1 * time.Hour),
+			}
+
+			var labeled atomic.Bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.URL.Path == "/search/issues":
+					_, _ = fmt.Fprintf(w, `{"total_count":%d}`, tt.searchCount)
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/issues/55/labels"):
+					labeled.Store(true)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("[]"))
+				case r.Method == http.MethodDelete:
+					// pilot-failed cleanup inside hasMergedWork
+					w.WriteHeader(http.StatusOK)
+				default:
+					_ = json.NewEncoder(w).Encode([]*Issue{issue})
+				}
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+			got, err := poller.findOldestUnprocessedIssue(context.Background())
+			if err != nil {
+				t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+			}
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("got issue #%d, want nil (should be skipped due to merged PR)", got.Number)
+				}
+			} else {
+				if got == nil {
+					t.Fatal("got nil, want issue (should dispatch fresh candidate with no merged PR)")
+				}
+				if got.Number != 55 {
+					t.Errorf("got issue #%d, want #55", got.Number)
+				}
+			}
+
+			if labeled.Load() != tt.wantLabeled {
+				t.Errorf("pilot-done label added = %v, want %v", labeled.Load(), tt.wantLabeled)
+			}
+
+			if tt.wantMarked && !poller.IsProcessed(55) {
+				t.Error("issue should be marked processed when merged work found")
+			}
+			if !tt.wantMarked && poller.IsProcessed(55) {
+				t.Error("issue should not be marked processed when no merged work")
+			}
+		})
+	}
+}
+
+// TestPoller_Sequential_FreshCandidate_CompletedExecutionGuard covers GH-3269 fix 2:
+// HasCompletedExecution must be checked in sequential mode (findOldestUnprocessedIssue),
+// mirroring the guard that already exists in parallel mode (checkForNewIssues).
+func TestPoller_Sequential_FreshCandidate_CompletedExecutionGuard(t *testing.T) {
+	tests := []struct {
+		name       string
+		completed  bool // does execChecker report completed execution?
+		wantNil    bool // should findOldestUnprocessedIssue return nil?
+		wantMarked bool
+	}{
+		{
+			name:       "completed execution blocks dispatch",
+			completed:  true,
+			wantNil:    true,
+			wantMarked: true,
+		},
+		{
+			name:       "no completed execution allows dispatch",
+			completed:  false,
+			wantNil:    false,
+			wantMarked: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &Issue{
+				Number:    77,
+				Title:     "GH-77 fresh issue",
+				State:     "open",
+				Labels:    []Label{{Name: "pilot"}},
+				CreatedAt: time.Now().Add(-1 * time.Hour),
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/search/issues":
+					// No merged PRs — let execChecker guard run.
+					_, _ = w.Write([]byte(`{"total_count":0}`))
+				case "/repos/owner/repo/pulls":
+					_, _ = w.Write([]byte(`[]`))
+				default:
+					_ = json.NewEncoder(w).Encode([]*Issue{issue})
+				}
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+			execChecker := &mockExecutionChecker{
+				completed: map[string]bool{
+					"GH-77:/project": tt.completed,
+				},
+			}
+
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+				WithExecutionChecker(execChecker, "/project"),
+			)
+
+			got, err := poller.findOldestUnprocessedIssue(context.Background())
+			if err != nil {
+				t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+			}
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("got issue #%d, want nil (completed execution should block dispatch)", got.Number)
+				}
+			} else {
+				if got == nil {
+					t.Fatal("got nil, want issue (no completed execution should allow dispatch)")
+				}
+				if got.Number != 77 {
+					t.Errorf("got issue #%d, want #77", got.Number)
+				}
+			}
+
+			if tt.wantMarked && !poller.IsProcessed(77) {
+				t.Error("issue should be marked processed after completed-execution skip")
+			}
+			if !tt.wantMarked && poller.IsProcessed(77) {
+				t.Error("issue should not be marked processed when dispatched normally")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Fix 1 (sequential mode, merged-work guard):** Fresh candidates in `findOldestUnprocessedIssue` bypassed `hasMergedWork` because the check only fired inside the `if processed {}` retry block. Added an unconditional `!processed && p.hasMergedWork(ctx, issue)` check after the retry block so issues with already-merged PRs are skipped pre-dispatch regardless of processing history.
- **Fix 2 (sequential mode, completed-execution guard):** Mirrored the `HasCompletedExecution` guard from `checkForNewIssues` (parallel mode) into `findOldestUnprocessedIssue` (sequential mode). Previously absent, this prevented re-dispatch when `pilot-done` label failed to apply after a completed execution.
- **Tests:** Table-driven tests for both fixes in `poller_gh3269_test.go` covering all four cases (merged/no-merged × sequential modes; completed/no-completed execution × sequential modes).

## Test plan

- [ ] `make test` passes (4 new tests, 0 regressions in github adapter suite)
- [ ] `golangci-lint run --new-from-rev=origin/main ./internal/adapters/github/...` — 0 issues
- [ ] `make build` — zero errors
- [ ] Fresh issue with merged PR → `findOldestUnprocessedIssue` returns nil + adds `pilot-done` label
- [ ] Fresh issue with no merged PR → dispatched normally
- [ ] Fresh issue with completed execution → `findOldestUnprocessedIssue` returns nil + marks processed
- [ ] Fresh issue with no completed execution → dispatched normally

Closes #3269
Part of TASK-321 (PR 2 of 4)