### PR TITLE
fix(cmd/pilot): wire WithBoardSync — complete Todo→In Progress board write-back (TASK-319)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -842,6 +842,10 @@ Examples:
 					if cfg.Adapters.GitHub.ProjectBoard != nil && cfg.Adapters.GitHub.ProjectBoard.SourceEnabled {
 						boardSrc := github.NewProjectBoardSource(client, cfg.Adapters.GitHub.ProjectBoard, repoOwner, repoName)
 						pollerOpts = append(pollerOpts, github.WithProjectBoardSource(boardSrc))
+						// TASK-319: complete the loop — move the card Todo→In Progress on
+						// confirmed pickup. WithBoardSync is a no-op when InProgress is "".
+						boardWB := github.NewProjectBoardSync(client, cfg.Adapters.GitHub.ProjectBoard, repoOwner)
+						pollerOpts = append(pollerOpts, github.WithBoardSync(boardWB, cfg.Adapters.GitHub.ProjectBoard.GetStatuses().InProgress))
 					}
 
 					// GH-392: Configure with actual issue processing callbacks (same as polling mode)
@@ -2202,6 +2206,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					repoFullName == cfg.Adapters.GitHub.Repo {
 					boardSrc := github.NewProjectBoardSource(client, cfg.Adapters.GitHub.ProjectBoard, repoOwner, repoName)
 					pollerOpts = append(pollerOpts, github.WithProjectBoardSource(boardSrc))
+					// TASK-319: complete the loop — move the card Todo→In Progress on
+					// confirmed pickup. WithBoardSync is a no-op when InProgress is "".
+					boardWB := github.NewProjectBoardSync(client, cfg.Adapters.GitHub.ProjectBoard, repoOwner)
+					pollerOpts = append(pollerOpts, github.WithBoardSync(boardWB, cfg.Adapters.GitHub.ProjectBoard.GetStatuses().InProgress))
 				}
 
 				// Configure based on execution mode


### PR DESCRIPTION
## Summary

`WithBoardSync` (the poller's Todo→In Progress write-back, GH-3252/#3267) is merged but was **never wired at either `NewPoller` site** in `cmd/pilot/main.go` — so at runtime the poller's `boardSync` was always nil and `syncBoardStatusInProgress` (poller.go:559/:1258) short-circuited. The Todo→In Progress transition on pickup was dead code.

The controller's board transitions (Done/Failed/Review, GH-3260/#3263) are wired and work; the controller's `inProgressStatus` is explicitly **"reserved; not yet emitted"** (controller.go:113/:149) — so the poller is the *only* intended emitter of Todo→In Progress.

This closes the gap left when #3253's PR #3266 was closed unmerged.

## Change

8 lines: extend the two existing `SourceEnabled` blocks (main.go gateway-mode ~842, start-mode ~2200) to also append `github.WithBoardSync(NewProjectBoardSync(...), GetStatuses().InProgress)`.

- Gated on `SourceEnabled` (same as the board *source*) → every picked issue came from the board, so its card is guaranteed present; no stray item lookups.
- No-op when the InProgress status is `""` (WithBoardSync guard, poller.go:991) — label-mode behavior unchanged.

## Verification

- `go build ./cmd/pilot/` ✅
- `gofmt -l` clean, `go vet ./cmd/pilot/` ✅
- `go test ./internal/adapters/github/` ✅ — `WithBoardSync` behavior (fires on pickup; nil/empty = no-op) already covered by `poller_test.go:2942+` (GH-3252).
- No new unit test: main.go's poller assembly isn't unit-testable without extracting a helper; the wired behavior is covered above.

## Result

Completes the board-driven loop: **Todo → In Progress → In Review → Done / Blocked**.

Refs TASK-319. Closes #3253.