### PR TITLE
feat(github): board-sync idempotency + off-board/cross-repo safety (TASK-319 PR-3)

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -47,16 +47,20 @@ adapters:
       enabled: true
       interval: 30s
       label: "pilot"
-    # GitHub Projects V2 board integration
+    # GitHub Projects V2 board integration — full board-driven lifecycle loop.
+    # When source_enabled is true, the board (not the pilot label) is the source of
+    # truth: cards flow Todo -> In Progress -> In Review -> Done, and -> Blocked on
+    # failure. All transitions no-op safely when the board is disabled, the issue is
+    # off-board, or the card is already in the target column (idempotent).
     # project_board:
     #   enabled: true                  # Sync issue status to the board (write path)
     #   project_number: 1              # Project number from the board URL
     #   status_field: "Status"         # Name of the single-select status field
     #   statuses:
-    #     in_progress: "In Progress"
-    #     review: "In Review"
-    #     done: "Done"
-    #     failed: "Blocked"
+    #     in_progress: "In Progress"   # written on issue pickup
+    #     review: "In Review"          # written on PR open
+    #     done: "Done"                 # written on PR merge
+    #     failed: "Blocked"            # written on exec / CI failure
     #   source_enabled: false          # Pull work FROM the board instead of by label
     #   source_status: "Todo"          # Board column to source issues from (default "Todo")
 

--- a/internal/adapters/github/project_board.go
+++ b/internal/adapters/github/project_board.go
@@ -28,9 +28,19 @@ const (
   }
 }`
 
-	queryIssueProjectItems = `query($issueID: ID!) {
+	queryIssueProjectItems = `query($issueID: ID!, $fieldName: String!) {
   node(id: $issueID) {
-    ... on Issue { projectItems(first: 20) { nodes { id project { id } } } }
+    ... on Issue {
+      projectItems(first: 20) {
+        nodes {
+          id
+          project { id }
+          fieldValueByName(name: $fieldName) {
+            ... on ProjectV2ItemFieldSingleSelectValue { optionId }
+          }
+        }
+      }
+    }
   }
 }`
 
@@ -80,6 +90,10 @@ type (
 					Project struct {
 						ID string `json:"id"`
 					} `json:"project"`
+					// FieldValueByName is the item's current Status option; null/empty when unset.
+					FieldValueByName struct {
+						OptionID string `json:"optionId"`
+					} `json:"fieldValueByName"`
 				} `json:"nodes"`
 			} `json:"projectItems"`
 		} `json:"node"`
@@ -129,12 +143,23 @@ func (p *ProjectBoardSync) UpdateProjectItemStatus(ctx context.Context, issueNod
 		return nil
 	}
 
-	itemID, err := p.getIssueProjectItemID(ctx, issueNodeID)
+	itemID, currentOptionID, err := p.getIssueProjectItem(ctx, issueNodeID)
 	if err != nil {
 		return fmt.Errorf("get issue project item: %w", err)
 	}
 	if itemID == "" {
-		slog.Warn("issue not found in project board", "issue_node_id", issueNodeID, "project_id", p.projectID)
+		// Off-board item (org-level boards span repos; not every issue is added).
+		// Skip silently — never hard-fail the lifecycle on a missing card.
+		slog.Debug("issue not on project board; skipping status update",
+			"issue_node_id", issueNodeID, "project_id", p.projectID, "status", statusName)
+		return nil
+	}
+
+	// Idempotency: skip the write (and its GraphQL call) when the card is already
+	// in the target column. Avoids board thrash on repeated transitions.
+	if currentOptionID == optionID {
+		slog.Debug("project card already in target status; skipping update",
+			"issue_node_id", issueNodeID, "status", statusName)
 		return nil
 	}
 
@@ -210,12 +235,17 @@ func (p *ProjectBoardSync) resolveProjectID(ctx context.Context) (string, error)
 	return resolveProjectID(ctx, p.client, p.owner, p.config.ProjectNumber)
 }
 
+// statusFieldName returns the configured Status field name, defaulting to "Status".
+func (p *ProjectBoardSync) statusFieldName() string {
+	if p.config.StatusField != "" {
+		return p.config.StatusField
+	}
+	return "Status"
+}
+
 // resolveFieldAndOptions fetches the Status field ID and all option name→ID mappings.
 func (p *ProjectBoardSync) resolveFieldAndOptions(ctx context.Context) (string, map[string]string, error) {
-	fieldName := p.config.StatusField
-	if fieldName == "" {
-		fieldName = "Status"
-	}
+	fieldName := p.statusFieldName()
 
 	vars := map[string]interface{}{
 		"projectID": p.projectID,
@@ -239,25 +269,28 @@ func (p *ProjectBoardSync) resolveFieldAndOptions(ctx context.Context) (string, 
 	return resp.Node.Field.ID, optionIDs, nil
 }
 
-// getIssueProjectItemID finds the project item ID for the given issue in this project.
-// Returns "" if the issue is not in the project.
-func (p *ProjectBoardSync) getIssueProjectItemID(ctx context.Context, issueNodeID string) (string, error) {
+// getIssueProjectItem finds the project item for the given issue in this project,
+// returning the item ID and its current Status option ID. Matching is by project ID,
+// so it tolerates org-level boards spanning multiple repos. Returns ("", "", nil) when
+// the issue is not on this board.
+func (p *ProjectBoardSync) getIssueProjectItem(ctx context.Context, issueNodeID string) (itemID, currentOptionID string, err error) {
 	vars := map[string]interface{}{
-		"issueID": issueNodeID,
+		"issueID":   issueNodeID,
+		"fieldName": p.statusFieldName(),
 	}
 
 	var resp issueProjectItemsResponse
 	if err := p.client.ExecuteGraphQL(ctx, queryIssueProjectItems, vars, &resp); err != nil {
-		return "", fmt.Errorf("query issue project items: %w", err)
+		return "", "", fmt.Errorf("query issue project items: %w", err)
 	}
 
 	for _, item := range resp.Node.ProjectItems.Nodes {
 		if item.Project.ID == p.projectID {
-			return item.ID, nil
+			return item.ID, item.FieldValueByName.OptionID, nil
 		}
 	}
 
-	return "", nil
+	return "", "", nil
 }
 
 // setItemFieldValue calls the updateProjectV2ItemFieldValue mutation.

--- a/internal/adapters/github/project_board_test.go
+++ b/internal/adapters/github/project_board_test.go
@@ -380,6 +380,99 @@ func TestUpdateProjectItemStatus_GraphQLError(t *testing.T) {
 	}
 }
 
+func TestUpdateProjectItemStatus_AlreadyInTargetStatus(t *testing.T) {
+	var updateCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		var resp string
+		switch {
+		case strings.Contains(req.Query, "organization"):
+			resp = `{"data":{"organization":{"projectV2":{"id":"PVT_p1"}}}}`
+		case strings.Contains(req.Query, "field(name:"):
+			resp = `{"data":{"node":{"field":{"id":"PVTSSF_f1","options":[{"id":"OPT_done","name":"Done"}]}}}}`
+		case strings.Contains(req.Query, "projectItems"):
+			// Card already sits in the target column (OPT_done).
+			resp = `{"data":{"node":{"projectItems":{"nodes":[{"id":"PVTI_i1","project":{"id":"PVT_p1"},"fieldValueByName":{"optionId":"OPT_done"}}]}}}}`
+		case strings.Contains(req.Query, "updateProjectV2ItemFieldValue"):
+			updateCalled = true
+			resp = `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_i1"}}}}`
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
+		Enabled:       true,
+		ProjectNumber: 1,
+		StatusField:   "Status",
+	}, "testorg")
+
+	err := pbs.UpdateProjectItemStatus(context.Background(), "ISSUE_1", "Done")
+	if err != nil {
+		t.Fatalf("UpdateProjectItemStatus() error = %v", err)
+	}
+	if updateCalled {
+		t.Error("expected no field-update mutation when card is already in target status")
+	}
+}
+
+func TestUpdateProjectItemStatus_DifferentStatusWritesUpdate(t *testing.T) {
+	var updateCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req GraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		var resp string
+		switch {
+		case strings.Contains(req.Query, "organization"):
+			resp = `{"data":{"organization":{"projectV2":{"id":"PVT_p1"}}}}`
+		case strings.Contains(req.Query, "field(name:"):
+			resp = `{"data":{"node":{"field":{"id":"PVTSSF_f1","options":[{"id":"OPT_todo","name":"Todo"},{"id":"OPT_done","name":"Done"}]}}}}`
+		case strings.Contains(req.Query, "projectItems"):
+			// Card currently in Todo; target is Done — should write.
+			resp = `{"data":{"node":{"projectItems":{"nodes":[{"id":"PVTI_i1","project":{"id":"PVT_p1"},"fieldValueByName":{"optionId":"OPT_todo"}}]}}}}`
+		case strings.Contains(req.Query, "updateProjectV2ItemFieldValue"):
+			updateCalled = true
+			if req.Variables["optionID"] != "OPT_done" {
+				t.Errorf("expected optionID OPT_done, got %v", req.Variables["optionID"])
+			}
+			resp = `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_i1"}}}}`
+		default:
+			t.Fatalf("unexpected query: %s", req.Query)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	pbs := NewProjectBoardSync(client, &ProjectBoardConfig{
+		Enabled:       true,
+		ProjectNumber: 1,
+		StatusField:   "Status",
+	}, "testorg")
+
+	err := pbs.UpdateProjectItemStatus(context.Background(), "ISSUE_1", "Done")
+	if err != nil {
+		t.Fatalf("UpdateProjectItemStatus() error = %v", err)
+	}
+	if !updateCalled {
+		t.Error("expected a field-update mutation when card is in a different status")
+	}
+}
+
 func TestEnsureResolved_ConcurrentAccess(t *testing.T) {
 	var resolveCount atomic.Int32
 


### PR DESCRIPTION
## Summary

Completes **TASK-319 PR-3** — the last code piece of the GH Projects V2 board-driven loop. PR-1 (#3267 + wiring #3273), PR-2 (#3263), and PR-4 SOP (#3261) have landed; this adds the safety/idempotency layer.

## Changes

- **Idempotency:** `UpdateProjectItemStatus` now reads the card's current Status option in the *same* `projectItems` query (via `fieldValueByName`) and short-circuits when the card is already in the target column. No redundant mutation, no board thrash, no wasted GraphQL call.
- **Off-board skip:** items not on the board (org-level boards span repos; not every issue is added) are skipped with a **debug** log instead of a warn — the lifecycle never hard-fails on a missing card.
- **Cross-repo:** tolerated inherently — item matching is by **project ID**, not repo. Documented; no behavior change needed.
- **Config:** `configs/pilot.example.yaml` now documents the full board-driven block (Todo→In Progress→In Review→Done / Blocked) with per-status comments.

## Verification

- `go build ./internal/adapters/github/` ✅
- `gofmt -l` clean, `go vet` ✅
- `go test ./internal/adapters/github/` ✅ — adds:
  - `TestUpdateProjectItemStatus_AlreadyInTargetStatus` — asserts **no** mutation fires
  - `TestUpdateProjectItemStatus_DifferentStatusWritesUpdate` — asserts the mutation fires with the right option
  - Existing fake servers omit `fieldValueByName` → unmarshal to empty current-status (≠ target) → keep passing.

## Result

All four TASK-319 PRs now complete. Remaining work is **operational** (web-UI board column setup + filing issues), tracked in the task doc.

Refs TASK-319.