### PR TITLE
fix(handlers): treat already-merged no-op as done, not pilot-blocked (TASK-321 PR-1)

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -48,6 +48,25 @@ func logGitHubAPIError(operation string, owner, repo string, issueNum int, err e
 	}
 }
 
+// noOpErrorMarker is the shared prefix of the executor's ghost-SHA guard errors
+// ("no new commit produced — …", both the worktree-HEAD and post-push variants).
+// TASK-321: used to recognize an ambiguous no-op that may actually be already-merged work.
+const noOpErrorMarker = "no new commit produced"
+
+// issueAlreadyMerged reports whether a merged PR already exists for the issue,
+// using the same Search + branch-lookup strategy as the poller's pre-dispatch
+// guard (Search API has ~30s indexing lag, so we supplement with a strongly-
+// consistent branch lookup). Read-only — labeling/closing is the caller's job.
+// TASK-321: distinguishes a re-dispatch of shipped work from a genuine no-op.
+func issueAlreadyMerged(ctx context.Context, client *github.Client, owner, repo string, issueNumber int) bool {
+	if found, err := client.SearchMergedPRsForIssue(ctx, owner, repo, issueNumber); err == nil && found {
+		return true
+	}
+	branch := fmt.Sprintf("pilot/GH-%d", issueNumber)
+	found, err := client.FindMergedPRByBranch(ctx, owner, repo, branch)
+	return err == nil && found
+}
+
 // requestReviewersFromConfig looks up the project config for the given sourceRepo
 // and requests PR reviewers if configured. Errors are logged but not propagated.
 func requestReviewersFromConfig(ctx context.Context, cfg *config.Config, client *github.Client, sourceRepo, owner, repo string, prNumber int) {
@@ -402,6 +421,28 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
 					logGitHubAPIError("AddComment(declined)", parts[0], parts[1], issue.Number, err)
 				}
+			} else if hr.Result.Error != "" && strings.Contains(hr.Result.Error, noOpErrorMarker) &&
+				issueAlreadyMerged(ctx, client, parts[0], parts[1], issue.Number) {
+				// TASK-321: a "no new commit produced" no-op is ambiguous — it can mean
+				// the work was ALREADY merged to main (a re-dispatch of a shipped issue),
+				// not a genuine failure. When a merged PR already exists for this issue,
+				// the correct outcome is done+closed, NOT pilot-blocked. (A genuine
+				// no-op with no merged PR falls through to the blocked path below.)
+				if err := client.AddLabels(ctx, parts[0], parts[1], issue.Number, []string{github.LabelDone}); err != nil {
+					logGitHubAPIError("AddLabels(done)", parts[0], parts[1], issue.Number, err)
+				}
+				if err := client.RemoveLabel(ctx, parts[0], parts[1], issue.Number, github.LabelBlocked); err != nil {
+					slog.Debug("pilot-blocked cleanup (already-merged)", "issue", issue.Number, "error", err)
+				}
+				syncBoardStatus(ctx, boardSync, issue.NodeID, boardStatuses.Done)
+				if err := client.UpdateIssueState(ctx, parts[0], parts[1], issue.Number, "closed"); err != nil {
+					logGitHubAPIError("UpdateIssueState(closed)", parts[0], parts[1], issue.Number, err)
+				}
+				comment := "✅ No new commit was produced because the work for this issue is **already merged to `main`**. This was a re-dispatch of completed work, not a failure — closing as done. (TASK-321)"
+				if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
+					logGitHubAPIError("AddComment(already-merged)", parts[0], parts[1], issue.Number, err)
+				}
+				issueResult.Success = true
 			} else {
 				// result exists but Success is false - mark as failed
 				// GH-2402: Use pilot-blocked for deterministic failures so we don't retry.

--- a/cmd/pilot/handlers_already_merged_test.go
+++ b/cmd/pilot/handlers_already_merged_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TASK-321: issueAlreadyMerged distinguishes a re-dispatch of shipped work
+// (merged PR exists) from a genuine no-op (none), so the handler can close the
+// issue as done instead of mislabeling completed work pilot-blocked.
+func TestIssueAlreadyMerged(t *testing.T) {
+	tests := []struct {
+		name        string
+		searchCount string // total_count returned by /search/issues
+		branchPRs   string // JSON array returned by /repos/.../pulls
+		want        bool
+	}{
+		{
+			name:        "search finds merged PR",
+			searchCount: `{"total_count":1}`,
+			branchPRs:   `[]`,
+			want:        true,
+		},
+		{
+			name:        "search misses but branch lookup finds merged PR (Search API lag)",
+			searchCount: `{"total_count":0}`,
+			branchPRs:   `[{"merged_at":"2026-05-29T18:00:00Z"}]`,
+			want:        true,
+		},
+		{
+			name:        "genuine no-op — no merged PR anywhere",
+			searchCount: `{"total_count":0}`,
+			branchPRs:   `[]`,
+			want:        false,
+		},
+		{
+			name:        "branch PR exists but is not merged",
+			searchCount: `{"total_count":0}`,
+			branchPRs:   `[{"merged_at":"","merged":false}]`,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/search/issues"):
+					_, _ = w.Write([]byte(tt.searchCount))
+				case strings.Contains(r.URL.Path, "/pulls"):
+					_, _ = w.Write([]byte(tt.branchPRs))
+				default:
+					http.Error(w, "unexpected path: "+r.URL.Path, http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			client := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			got := issueAlreadyMerged(context.Background(), client, "owner", "repo", 3260)
+			if got != tt.want {
+				t.Errorf("issueAlreadyMerged() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The executor's ghost-SHA guard emits `no new commit produced` for two indistinguishable cases:
- **(a)** a genuine no-op (model made no edit), and
- **(b)** a **re-dispatch of an issue whose PR already merged** to main — the worktree (built from origin/main) already contains the change, so no new commit is possible.

Case (b) was mislabeled `pilot-blocked` — **completed work shown as failed**. This is the phantom-failure cluster observed 2026-05-29 (GH-3238/3240/3243/3260: PRs merged, issues marked blocked).

## Fix

In the result-failure branch of `handleGitHubIssueWithResult` (handlers.go), when the error is the no-op marker **and** a merged PR already exists for the issue, close it as `pilot-done` + move the board card to **Done** instead of `pilot-blocked`. Detection mirrors the poller's pre-dispatch guard: Search API + strongly-consistent branch lookup (`pilot/GH-N`) to defeat the ~30s Search indexing lag.

A genuine no-op with **no** merged PR still falls through to `pilot-blocked` — **GH-3230 behavior preserved**.

### Design note
The merged-PR query lives in the **handler** (where the GitHub client already is), leaving the 1700-line `executeWithOptions` untouched — per TASK-321's risk note about editing the executor core.

## Scope / not in scope
- ✅ Direct re-dispatch of a shipped issue → done.
- ❌ Genuine model false-negative *refusal* (model reads code, wrongly concludes 'nothing to do', no PR exists) — that's TASK-320 Layer B2 (escalated re-invocation), still deferred. This PR does **not** change that path; such cases correctly remain `pilot-blocked`.
- ❌ Epic-wrapped sub-issue no-ops (`sub-issue X failed: …` via execErr) — covered by the PR-2/PR-3 dedup work.

## Verification
- `go build ./cmd/pilot/` ✅ · `gofmt` clean · `go vet` ✅
- New `TestIssueAlreadyMerged`: search-hit, branch-lookup fallback (Search lag), genuine-no-op, unmerged-PR — all pass.
- Full `go test ./cmd/pilot/` ✅.

Refs TASK-321. Part 1 of 4 (PR-2/3 poller idempotency to follow; PR-4 = #3271).