### PR TITLE
GH-3270: fix(poller): retain adapter_processed marker on permanent/no-op failure (TASK-321 PR-3)

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -297,14 +297,20 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 	// when execution actually begins, enabling accurate queued→running dashboard transitions.
 	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
 
-	// Build the issue result
+	// Build the issue result. GH-3270: when the outer error is nil but the executor
+	// recorded a failure string (e.g. "no new commit produced"), surface it as the
+	// IssueResult.Error so the poller can call IsPermanentFailure on it.
+	issueErr := hr.Error
+	if issueErr == nil && hr.Result != nil && hr.Result.Error != "" {
+		issueErr = fmt.Errorf("%s", hr.Result.Error)
+	}
 	issueResult := &github.IssueResult{
 		Success:    hr.Success,
 		BranchName: hr.BranchName,
 		PRNumber:   hr.PRNumber,
 		PRURL:      hr.PRURL,
 		HeadSHA:    hr.HeadSHA,
-		Error:      hr.Error,
+		Error:      issueErr,
 	}
 
 	// Post-execution: label management, close issue, add rich execution comment

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -1293,12 +1293,22 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 					return
 				}
 
-				// GH-2176: Unmark if execution failed without creating a PR
+				// GH-2176: Unmark if execution failed without creating a PR (unless permanent).
+				// GH-3270: Permanent/no-op failures already carry pilot-blocked; retaining the
+				// durable row is defense-in-depth so a daemon restart cannot re-dispatch until
+				// the human removes pilot-blocked (which clears the mark via the retry path).
 				if result != nil && !result.Success && result.PRNumber == 0 {
-					p.logger.Info("Execution failed without PR, unmarking for retry",
-						slog.Int("number", issue.Number),
-					)
-					p.unmarkProcessed(issue.Number)
+					if result.Error != nil && executor.IsPermanentFailure(result.Error.Error()) {
+						p.logger.Info("Permanent failure — retaining adapter_processed marker",
+							slog.Int("number", issue.Number),
+							slog.String("error", result.Error.Error()),
+						)
+					} else {
+						p.logger.Info("Execution failed without PR, unmarking for retry",
+							slog.Int("number", issue.Number),
+						)
+						p.unmarkProcessed(issue.Number)
+					}
 				}
 
 				// Diagnostic: surface why OnPRCreated may not fire (GH-2999 Phase 1)

--- a/internal/adapters/github/poller_gh3270_test.go
+++ b/internal/adapters/github/poller_gh3270_test.go
@@ -1,0 +1,156 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// gh3270ProcessedStore is a minimal ProcessedStore for GH-3270 tests that
+// tracks Mark/Unmark call counts so we can assert durable-marker retention.
+type gh3270ProcessedStore struct {
+	mu          sync.Mutex
+	marked      map[string]bool
+	unmarkCalls int
+}
+
+func newGH3270Store() *gh3270ProcessedStore {
+	return &gh3270ProcessedStore{marked: make(map[string]bool)}
+}
+
+func (s *gh3270ProcessedStore) Mark(source, repo, issueID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.marked[issueID] = true
+	return nil
+}
+
+func (s *gh3270ProcessedStore) Unmark(source, repo, issueID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.marked, issueID)
+	s.unmarkCalls++
+	return nil
+}
+
+func (s *gh3270ProcessedStore) IsProcessed(source, repo, issueID string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.marked[issueID], nil
+}
+
+func (s *gh3270ProcessedStore) Load(source, repo string) (map[string]time.Time, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make(map[string]time.Time)
+	for k := range s.marked {
+		result[k] = time.Now()
+	}
+	return result, nil
+}
+
+// TestPoller_UnmarkProcessed_PermanentFailureRetainsMarker covers GH-3270:
+// when onIssueWithResult returns a permanent failure (Success=false, PRNumber=0,
+// Error contains a permanent-failure pattern), the durable adapter_processed row
+// must NOT be deleted so a daemon restart cannot re-dispatch the issue.
+// A retriable failure (same shape but non-permanent error) MUST still unmark.
+func TestPoller_UnmarkProcessed_PermanentFailureRetainsMarker(t *testing.T) {
+	tests := []struct {
+		name         string
+		resultErr    error  // error returned by onIssueWithResult
+		wantMarked   bool   // should the durable row still be present after dispatch?
+		wantUnmarks  int    // expected Unmark() call count
+	}{
+		{
+			name:        "permanent failure (no new commit produced) retains marker",
+			resultErr:   errors.New("no new commit produced — worktree HEAD matches base branch parent"),
+			wantMarked:  true,
+			wantUnmarks: 0,
+		},
+		{
+			name:        "retriable failure unmarks for retry",
+			resultErr:   errors.New("tests failed unexpectedly"),
+			wantMarked:  false,
+			wantUnmarks: 1,
+		},
+		{
+			name:        "nil error (no-commit, no error string) unmarks",
+			resultErr:   nil,
+			wantMarked:  false,
+			wantUnmarks: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &Issue{
+				Number:    42,
+				Title:     "GH-42 fix something",
+				State:     "open",
+				Labels:    []Label{{Name: "pilot"}},
+				CreatedAt: time.Now().Add(-1 * time.Hour),
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/search/issues":
+					_, _ = fmt.Fprintf(w, `{"total_count":0}`)
+				default:
+					_ = json.NewEncoder(w).Encode([]*Issue{issue})
+				}
+			}))
+			defer server.Close()
+
+			store := newGH3270Store()
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+			dispatched := make(chan struct{})
+			poller, err := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+				WithOnIssueWithResult(func(ctx context.Context, i *Issue) (*IssueResult, error) {
+					defer close(dispatched)
+					return &IssueResult{
+						Success:  false,
+						PRNumber: 0,
+						Error:    tt.resultErr,
+					}, nil
+				}),
+				WithProcessedStore(store),
+				WithMaxConcurrent(1),
+			)
+			if err != nil {
+				t.Fatalf("NewPoller() error = %v", err)
+			}
+
+			poller.checkForNewIssues(context.Background())
+
+			// Wait for the dispatched goroutine to finish (callback + unmark).
+			select {
+			case <-dispatched:
+			case <-time.After(3 * time.Second):
+				t.Fatal("timed out waiting for dispatch goroutine")
+			}
+			poller.activeWg.Wait()
+
+			store.mu.Lock()
+			gotMarked := store.marked["42"]
+			gotUnmarks := store.unmarkCalls
+			store.mu.Unlock()
+
+			if gotMarked != tt.wantMarked {
+				t.Errorf("store.marked[42] = %v, want %v", gotMarked, tt.wantMarked)
+			}
+			if gotUnmarks != tt.wantUnmarks {
+				t.Errorf("Unmark() calls = %d, want %d", gotUnmarks, tt.wantUnmarks)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3270.

Closes #3270

## Changes

GitHub Issue #3270: fix(poller): retain adapter_processed marker on permanent/no-op failure (TASK-321 PR-3)

## Problem (TASK-321, PR-3 of 4)

On a no-op/permanent failure the poller deletes the durable dedup row, so a daemon restart re-dispatches already-shipped work → `no new commit produced` → `pilot-blocked`.

## Root cause (verified on main)

When execution returns `!result.Success && result.PRNumber==0`, the poller calls `unmarkProcessed(issue.Number)` (`internal/adapters/github/poller.go:1224-1228`), which DELETEs from `adapter_processed` (`internal/autopilot/state_store.go:320`). Correct for a *retriable* failure, wrong for a *permanent* one: the issue is `pilot-blocked` but on restart the marker is gone and it looks fresh again.

## Scope

- In the unmark path (`poller.go:1224`), do NOT `unmarkProcessed` when the failure is permanent (use `executor.IsPermanentFailure(result.Error)`). Retain the durable marker as defense-in-depth.
- Keep unmark for genuinely retriable failures.

## Out of scope

- PR-1 (executor success path), PR-2 (fresh-candidate guard), PR-4 (timing window).

## Acceptance criteria

- [ ] After a permanent/no-op failure, the `adapter_processed` row is retained; a simulated restart does not re-dispatch the issue.
- [ ] A retriable failure still unmarks and is retried as before.
- [ ] Table-driven test for both branches. `make test` + `make lint` green.
- [ ] Conventional commit title; no Claude Code mention.

Touches `internal/adapters/github/poller.go` (shared with PR-2) and `internal/autopilot/state_store.go`.