### PR TITLE
fix(docs): disable Next image optimizer to stop runtime cache bloat

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -4,4 +4,11 @@ const withNextra = nextra({})
 
 export default withNextra({
   output: 'standalone',
+  // Docs ship static, pre-sized assets — the on-server image optimizer adds no
+  // value but writes optimized variants to .next/cache/images, which is bind-
+  // mounted to a persistent host volume in prod (docker-compose.prod.yml) and
+  // grows unbounded, exhausting disk. Disable it so the runtime cache stays flat.
+  images: {
+    unoptimized: true,
+  },
 })


### PR DESCRIPTION
## Problem

The docs site (`pilot.quantflow.studio`) runs as a self-hosted container (GitLab CI → `docs/.gitlab-ci.yml`, deployed via `docs/docker-compose.prod.yml`). The prod compose bind-mounts a **persistent host volume** into the Next.js runtime cache:

```yaml
volumes:
  - /data/quantflow/pilot_cache:/app/.next/cache
```

`next.config.mjs` leaves Next's **on-server image optimizer enabled** (the default). At runtime the optimizer writes optimized image variants to `.next/cache/images`, which lands on that persistent volume and **grows unbounded** — exhausting disk on the docs host.

## Fix

Set `images.unoptimized: true`. Docs assets are static and pre-sized, so the optimizer adds no value here. The runtime cache stays flat.

```js
export default withNextra({
  output: 'standalone',
  images: { unoptimized: true },
})
```

## Scope / what this does NOT fix

This bounds the **runtime host-volume** cache only. Two operational items remain (no repo change, need infra access):

1. **Reclaim the already-bloated host volume** — on the docs host:
   `du -sh /data/quantflow/pilot_cache` then clear stale image cache and restart the container.
2. **GitLab Container Registry retention** — `prod-*` tags + untagged `:main` layers accumulate forever. Add a project cleanup policy (keep N most recent, expire untagged).

## Test

- `cd docs && bun run build` succeeds with `output: standalone`.
- After deploy, `.next/cache/images` no longer accumulates on the volume.