### PR TITLE
fix(executor): run retries in the worktree, not task.ProjectPath (TASK-323)

### DIFF
--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2194,7 +2194,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						smartAllowed, smartMCP := r.executionToolOptions()
 						retryResult, retryErr := r.backend.Execute(retryCtx, ExecuteOptions{
 							Prompt:          prompt,
-							ProjectPath:     task.ProjectPath,
+							ProjectPath:     executionPath, // TASK-323: retry in the worktree, not the user's real repo
 							Verbose:         task.Verbose,
 							Model:           selectedModel,
 							Effort:          selectedEffort,
@@ -2558,7 +2558,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				noopRetryAllowed, noopRetryMCP := r.executionToolOptions()
 				retryResult, retryErr := r.backend.Execute(ctx, ExecuteOptions{
 					Prompt:          retryPrompt,
-					ProjectPath:     task.ProjectPath,
+					ProjectPath:     executionPath, // TASK-323: retry in the worktree so CountNewCommits can see its commits
 					Verbose:         task.Verbose,
 					Model:           selectedModel,
 					Effort:          selectedEffort,

--- a/internal/executor/runner_retry_worktree_test.go
+++ b/internal/executor/runner_retry_worktree_test.go
@@ -1,0 +1,91 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// retryPathRecordingBackend records the ProjectPath of every Execute call so a
+// test can assert which working tree a retry ran in. It always reports success
+// but never creates a commit, which forces the runner's no-commit retry path.
+type retryPathRecordingBackend struct {
+	mu           sync.Mutex
+	projectPaths []string
+}
+
+func (b *retryPathRecordingBackend) Name() string      { return "retry-path-recording" }
+func (b *retryPathRecordingBackend) IsAvailable() bool { return true }
+
+func (b *retryPathRecordingBackend) Execute(ctx context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	b.mu.Lock()
+	b.projectPaths = append(b.projectPaths, opts.ProjectPath)
+	b.mu.Unlock()
+	return &BackendResult{Success: true, Output: "no changes made"}, nil
+}
+
+func (b *retryPathRecordingBackend) paths() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]string, len(b.projectPaths))
+	copy(out, b.projectPaths)
+	return out
+}
+
+// TestRunner_NoCommitRetry_RunsInWorktree is the TASK-323 regression guard.
+//
+// Before the fix both retry paths passed ProjectPath: task.ProjectPath, so a
+// retry executed against the user's real repository instead of the isolated
+// worktree — defeating worktree isolation AND guaranteeing the post-retry
+// CountNewCommits (which inspects the worktree) always saw zero commits, so the
+// retry could never clear a no_changes failure. With the fix the retry runs in
+// the worktree (executionPath).
+func TestRunner_NoCommitRetry_RunsInWorktree(t *testing.T) {
+	localRepo, remoteRepo := setupTestRepoWithRemote(t)
+	defer func() { _ = os.RemoveAll(localRepo) }()
+	defer func() { _ = os.RemoveAll(remoteRepo) }()
+
+	backend := &retryPathRecordingBackend{}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{UseWorktree: true} // enable worktree isolation
+	runner.SetSkipPreflightChecks(true)               // mock backend: skip env preflight
+	runner.SetRecordingEnabled(false)
+
+	task := &Task{
+		ID:          "GH-323",
+		Title:       "force a no-commit retry in worktree mode",
+		Description: "the backend never commits, so the no-commit retry fires",
+		ProjectPath: localRepo,
+		Branch:      "pilot/GH-323", // Branch + CreatePR + !DirectCommit → worktree + no-commit retry
+		CreatePR:    true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Result is a no_changes failure (no commits ever produced) — we only care
+	// about which path the retry executed in.
+	_, _ = runner.Execute(ctx, task)
+
+	paths := backend.paths()
+	if len(paths) < 2 {
+		t.Fatalf("expected >=2 backend calls (initial + no-commit retry), got %d: %v", len(paths), paths)
+	}
+
+	// The initial execution must run in the worktree (existing GH-936 guarantee).
+	if !strings.Contains(paths[0], "pilot-worktree-") {
+		t.Errorf("initial execution ProjectPath %q should be the isolated worktree", paths[0])
+	}
+
+	// TASK-323: the retry must ALSO run in the worktree, not task.ProjectPath.
+	retryPath := paths[len(paths)-1]
+	if retryPath == task.ProjectPath {
+		t.Errorf("retry ran in task.ProjectPath %q; it must run in the worktree", task.ProjectPath)
+	}
+	if !strings.Contains(retryPath, "pilot-worktree-") {
+		t.Errorf("retry ProjectPath %q should be the isolated worktree (contain 'pilot-worktree-')", retryPath)
+	}
+}


### PR DESCRIPTION
## TASK-322 critical #1 — Wave 0 (manual)

Both retry paths in `runner.go` passed `ProjectPath: task.ProjectPath` instead of the `executionPath` worktree that the primary execution (`:1878`) and all post-exec commit checks (`NewGitOperations(executionPath)`, `:1612`) use.

With worktrees enabled (the default for any `Branch != "" && !DirectCommit` task) this made retries:
1. **Dangerous** — run in the user's real repo working tree, defeating GH-936 worktree isolation;
2. **Ineffective** — the post-retry `CountNewCommits` inspects the worktree the retry never touched, so it always reported 0 commits → the no-commit retry was structurally incapable of clearing a `no_changes` failure.

### Change
- `runner.go:2197` (smart retry) and `:2561` (no-commit retry): `task.ProjectPath` → `executionPath`.
- New `runner_retry_worktree_test.go`: drives a real worktree-mode execution with a recording backend that never commits, asserts the retry's `ExecuteOptions.ProjectPath` is the `pilot-worktree-*` path. **Verified to FAIL before the fix** (retry ran in `task.ProjectPath`) and PASS after.

### Verification
- `go build ./...` ✅ · `go vet ./internal/executor/` ✅ · `go test ./internal/executor/` ✅
- Negative test confirmed the guard catches the regression.

> Manual delivery (not Pilot) — Pilot must not edit its own execution core. See `.agent/tasks/TASK-323-retry-path-worktree.md`.