### PR TITLE
fix(poller): fresh-candidate hasMergedWork guard in parallel mode (TASK-321 PR-4)

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -1155,6 +1155,16 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 			}
 		}
 
+		// GH-3269 / TASK-321 PR-4: Fresh candidates (never processed / post-unmark)
+		// bypass the retry block above, so apply the merged-work guard
+		// unconditionally for them — mirrors the sequential
+		// findOldestUnprocessedIssue guard and prevents phantom
+		// "no new commit produced" redispatch in parallel mode.
+		if !processed && p.hasMergedWork(ctx, issue) {
+			p.recordSkip(skipreason.ReasonHasMergedWork)
+			continue
+		}
+
 		// Skip issues with pending dependencies
 		if p.hasPendingDependencies(ctx, issue) {
 			p.logger.Debug("Skipping issue with pending dependencies in parallel mode",

--- a/internal/adapters/github/poller_task321_pr4_test.go
+++ b/internal/adapters/github/poller_task321_pr4_test.go
@@ -1,0 +1,98 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestPoller_Parallel_FreshCandidate_MergedWorkGuard is the TASK-321 PR-4 regression
+// guard. GH-3269 added the fresh-candidate hasMergedWork guard to the sequential path
+// (findOldestUnprocessedIssue) but not to the parallel path (checkForNewIssues), where
+// hasMergedWork was only consulted inside the `if processed {}` retry block. A fresh,
+// never-processed issue whose PR already merged would therefore be dispatched in
+// parallel mode (the production default for concurrency>1), producing the phantom
+// "no new commit produced" failure TASK-321 set out to eliminate.
+//
+// This mirrors TestPoller_Sequential_FreshCandidate_MergedWorkGuard for checkForNewIssues.
+func TestPoller_Parallel_FreshCandidate_MergedWorkGuard(t *testing.T) {
+	tests := []struct {
+		name         string
+		searchCount  int  // total_count returned by /search/issues
+		wantDispatch bool // should checkForNewIssues dispatch the fresh issue?
+	}{
+		{
+			name:         "fresh candidate with merged PR is NOT dispatched",
+			searchCount:  1,
+			wantDispatch: false,
+		},
+		{
+			name:         "fresh candidate with no merged PR dispatches normally",
+			searchCount:  0,
+			wantDispatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &Issue{
+				Number:    55,
+				Title:     "GH-55 fresh feature",
+				State:     "open",
+				Labels:    []Label{{Name: "pilot"}},
+				CreatedAt: time.Now().Add(-1 * time.Hour),
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.URL.Path == "/search/issues":
+					// hasMergedWork → SearchMergedPRsForIssue
+					_, _ = fmt.Fprintf(w, `{"total_count":%d}`, tt.searchCount)
+				case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pulls"):
+					// hasMergedWork → FindMergedPRByBranch (no merged branch)
+					_, _ = w.Write([]byte("[]"))
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/issues/55/labels"):
+					// hasMergedWork → AddLabels(pilot-done) on the merged path
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("[]"))
+				case r.Method == http.MethodDelete:
+					// pilot-failed cleanup inside hasMergedWork
+					w.WriteHeader(http.StatusOK)
+				default:
+					// ListIssues snapshot (and the Phase-3 single-issue refresh, which
+					// tolerates a decode miss and proceeds with the snapshot).
+					_ = json.NewEncoder(w).Encode([]*Issue{issue})
+				}
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+			var dispatched55 atomic.Bool
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+				WithOnIssue(func(ctx context.Context, iss *Issue) error {
+					if iss.Number == 55 {
+						dispatched55.Store(true)
+					}
+					return nil
+				}),
+			)
+
+			poller.checkForNewIssues(context.Background())
+			poller.WaitForActive()
+
+			if got := dispatched55.Load(); got != tt.wantDispatch {
+				t.Errorf("dispatched #55 = %v, want %v (merged-work guard must skip fresh already-merged candidates in parallel mode)", got, tt.wantDispatch)
+			}
+		})
+	}
+}

--- a/stress/memory_test.go
+++ b/stress/memory_test.go
@@ -179,6 +179,18 @@ func TestMemory_ProcessedMapGrowth(t *testing.T) {
 				return
 			}
 		}
+		// TASK-321 PR-4: parallel checkForNewIssues now runs the fresh-candidate
+		// merged-work guard, which probes /search/issues + /pulls per candidate.
+		// Answer "no merged work" cheaply so the guard is a fast no-op — otherwise
+		// it would decode the 1000-element list per issue and starve the 30s poll.
+		if strings.HasPrefix(r.URL.Path, "/search/issues") {
+			_, _ = w.Write([]byte(`{"total_count":0,"items":[]}`))
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/pulls") {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
 		n := atomic.AddInt64(&pollCount, 1)
 		if n <= 2 {
 			// Call 1: recoverOrphanedIssues, Call 2: first checkForNewIssues


### PR DESCRIPTION
Closes #3291 (Pilot hit its own no-op false-negative on this one — taken over manually).

## TASK-322 high — TASK-321 fold

GH-3269 (`f3c48fa7`) added the fresh-candidate merged-work guard to the **sequential** path (`findOldestUnprocessedIssue:852`) but not the **parallel** path (`checkForNewIssues`), where `hasMergedWork` was only consulted inside the `if processed {}` retry block. A fresh, never-processed issue whose PR already merged (daemon restart, or after `unmarkProcessed` dropped the durable row on a failed no-op) was therefore dispatched in parallel mode — the production default for concurrency>1 — producing the phantom `no new commit produced` failure TASK-321 set out to eliminate. The fix corrected sequential mode but inverted rather than removed the asymmetry.

### Change
- `poller.go` `checkForNewIssues`: add `if !processed && p.hasMergedWork(ctx, issue) { recordSkip(ReasonHasMergedWork); continue }` after the retry block, mirroring sequential `:852`.
- New `poller_task321_pr4_test.go`: `TestPoller_Parallel_FreshCandidate_MergedWorkGuard` drives `checkForNewIssues` + `WaitForActive`, asserts a fresh already-merged issue is **not** dispatched (and a non-merged one is). **Verified to FAIL before the fix.**

### Verification
`go build ./...` ✅ · `go vet ./internal/adapters/github/` ✅ · `go test ./internal/adapters/github/` ✅