### PR TITLE
fix(autopilot): guard *PRState fields with a per-PR mutex (TASK-324)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -280,6 +280,13 @@ func (c *Controller) SetReleaseSummaryGenerator(gen *ReleaseSummaryGenerator) {
 }
 
 // persistPRState saves a PR state to the store if available.
+//
+// TASK-324 concurrency contract: this method is LOCK-FREE with respect to the
+// per-PR mutex. The CALLER MUST hold prState.mu (so the fields read by
+// stateStore.SavePRState are stable) — OR the prState must not yet be published in
+// c.activePRs (e.g. freshly constructed). It must NOT take prState.mu itself: every
+// caller that holds the live pointer already owns prState.mu, and re-locking would
+// deadlock (Go's sync.Mutex is non-reentrant).
 func (c *Controller) persistPRState(prState *PRState) {
 	if c.stateStore == nil {
 		return
@@ -392,8 +399,14 @@ func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, he
 	c.activePRs[prNumber] = prState
 	c.mu.Unlock()
 
-	// Persist to SQLite (idempotent, safe outside lock)
+	// Persist to SQLite (idempotent, safe outside lock).
+	// TASK-324: prState is now published in activePRs, so a concurrent ProcessPR or
+	// webhook could already hold a reference. Take prState.mu for the persist to honor
+	// the persistPRState contract (caller holds prState.mu). c.mu is already released,
+	// so the prState.mu→c.mu ordering invariant holds.
+	prState.mu.Lock()
 	c.persistPRState(prState)
+	prState.mu.Unlock()
 
 	c.log.Info("PR registered for autopilot",
 		"pr", prNumber,
@@ -448,17 +461,19 @@ func (c *Controller) OnReviewRequested(prNumber int, action, state, reviewer str
 		return
 	}
 
+	// TASK-324: guard the read of prState.Stage (for the log), the Stage write, and
+	// the persist under the per-PR mutex. The pointer was fetched under c.mu above and
+	// c.mu has since been released, so taking prState.mu here keeps the no-deadlock
+	// invariant (prState.mu before c.mu, never the reverse).
+	prState.mu.Lock()
 	c.log.Warn("Changes requested on PR, transitioning to review_requested stage",
 		"pr", prNumber,
 		"reviewer", reviewer,
 		"current_stage", prState.Stage,
 	)
-
-	c.mu.Lock()
 	prState.Stage = StageReviewRequested
-	c.mu.Unlock()
-
 	c.persistPRState(prState)
+	prState.mu.Unlock()
 }
 
 // ProcessPR processes a single PR through the state machine.
@@ -472,6 +487,16 @@ func (c *Controller) ProcessPR(ctx context.Context, prNumber int, ghPR *github.P
 	if !ok {
 		return fmt.Errorf("PR %d not tracked", prNumber)
 	}
+
+	// TASK-324: hold the per-PR mutex for the entire processing body. This single
+	// lock covers all 11 handleX(prState) handlers, the inline PRTitle/TargetBranch/
+	// Error writes, and the persistPRState call, serialising the main loop against
+	// webhook writers (OnReviewRequested, SetApprovalDecision) on the same PR.
+	// Lock ordering: we hold prState.mu and may take c.mu below (isPRCircuitOpen,
+	// recordPRFailure/resetPRFailures, the lastProgressAt update, removePR via
+	// handlers). Never the reverse — see the no-deadlock invariant on PRState.
+	prState.mu.Lock()
+	defer prState.mu.Unlock()
 
 	// Per-PR circuit breaker check
 	if c.isPRCircuitOpen(prNumber) {
@@ -1169,34 +1194,53 @@ func (c *Controller) SetApprovalDecision(ctx context.Context, requestID string, 
 	if requestID == "" {
 		return nil
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
+
+	// TASK-324: collect the live pointers under c.mu, then RELEASE c.mu before taking
+	// any prState.mu (no-deadlock invariant: prState.mu before c.mu, never reverse).
+	// ApprovalRequestID is written under prState.mu (submitAsyncApprovalRequest), so we
+	// also read it under prState.mu to find the match.
+	c.mu.RLock()
+	live := make([]*PRState, 0, len(c.activePRs))
 	for _, pr := range c.activePRs {
-		if pr.ApprovalRequestID == requestID {
-			pr.ApprovalDecision = decision
-			if c.stateStore != nil {
-				_ = c.stateStore.SavePRState(pr)
-			}
-			if c.memoryStore != nil {
-				if merr := c.memoryStore.SetApprovalDecision(ctx, requestID, decision, by); merr != nil {
-					taskIDStr := fmt.Sprintf("GH-%d", pr.IssueNumber)
-					if errors.Is(merr, sql.ErrNoRows) {
-						c.log.Warn("failed to persist approval decision to executions (no matching row)",
-							"pr", pr.PRNumber, "task_id", taskIDStr, "request_id", requestID,
-							"op", "SetApprovalDecision", "decision", decision, "error", merr)
-						c.metrics.RecordApprovalPersistMiss("decision")
-					} else {
-						c.log.Warn("failed to persist approval decision to executions",
-							"pr", pr.PRNumber, "task_id", taskIDStr, "request_id", requestID,
-							"op", "SetApprovalDecision", "decision", decision, "error", merr)
-					}
+		live = append(live, pr)
+	}
+	c.mu.RUnlock()
+
+	for _, pr := range live {
+		pr.mu.Lock()
+		if pr.ApprovalRequestID != requestID {
+			pr.mu.Unlock()
+			continue
+		}
+		pr.ApprovalDecision = decision
+		if c.stateStore != nil {
+			_ = c.stateStore.SavePRState(pr)
+		}
+		prNumber := pr.PRNumber
+		issueNumber := pr.IssueNumber
+		pr.mu.Unlock()
+
+		// memoryStore persistence is keyed by requestID, not by the live PRState
+		// fields, so it is safe (and preferable) to run it outside prState.mu.
+		if c.memoryStore != nil {
+			if merr := c.memoryStore.SetApprovalDecision(ctx, requestID, decision, by); merr != nil {
+				taskIDStr := fmt.Sprintf("GH-%d", issueNumber)
+				if errors.Is(merr, sql.ErrNoRows) {
+					c.log.Warn("failed to persist approval decision to executions (no matching row)",
+						"pr", prNumber, "task_id", taskIDStr, "request_id", requestID,
+						"op", "SetApprovalDecision", "decision", decision, "error", merr)
+					c.metrics.RecordApprovalPersistMiss("decision")
+				} else {
+					c.log.Warn("failed to persist approval decision to executions",
+						"pr", prNumber, "task_id", taskIDStr, "request_id", requestID,
+						"op", "SetApprovalDecision", "decision", decision, "error", merr)
 				}
 			}
-			c.log.Info("approval decision applied to PR state",
-				"pr", pr.PRNumber, "request_id", requestID,
-				"decision", decision, "by", by)
-			return nil
 		}
+		c.log.Info("approval decision applied to PR state",
+			"pr", prNumber, "request_id", requestID,
+			"decision", decision, "by", by)
+		return nil
 	}
 	// requestID not found in this controller — normal in multi-repo deployments.
 	return nil
@@ -1925,14 +1969,31 @@ func (c *Controller) removePR(prNumber int) {
 	c.log.Info("PR removed from tracking", "pr", prNumber)
 }
 
-// GetActivePRs returns all tracked PRs.
+// GetActivePRs returns detached snapshots of all tracked PRs.
+//
+// TASK-324: each returned *PRState is a field-by-field copy taken under that PR's
+// own mu (via snapshot()), so every read-only consumer (metrics.UpdateActivePRs,
+// metrics_alerter, dashboard/tui, gateway/server, cmd/pilot/adapters) is race-free
+// for free and can never observe a torn write. The returned pointers are NOT the
+// live map entries; callers that must mutate state (e.g. processAllPRs) re-fetch the
+// live pointer by PRNumber under c.mu and take that pr.mu themselves.
+//
+// Lock ordering: we collect the live pointers under c.mu.RLock, RELEASE c.mu, then
+// take each pr.mu to snapshot. This preserves the no-deadlock invariant (never hold
+// c.mu while acquiring a prState.mu).
 func (c *Controller) GetActivePRs() []*PRState {
 	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	prs := make([]*PRState, 0, len(c.activePRs))
+	live := make([]*PRState, 0, len(c.activePRs))
 	for _, pr := range c.activePRs {
-		prs = append(prs, pr)
+		live = append(live, pr)
+	}
+	c.mu.RUnlock()
+
+	prs := make([]*PRState, 0, len(live))
+	for _, pr := range live {
+		pr.mu.Lock()
+		prs = append(prs, pr.snapshot())
+		pr.mu.Unlock()
 	}
 	return prs
 }
@@ -2418,7 +2479,12 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 		c.mu.Lock()
 		c.activePRs[pr.Number] = prState
 		c.mu.Unlock()
+		// prState is now published in activePRs, so a concurrent ProcessPR or
+		// webhook could already hold the pointer — persist under prState.mu per
+		// the caller-holds-the-lock contract (mirrors OnPRCreated).
+		prState.mu.Lock()
 		c.persistPRState(prState)
+		prState.mu.Unlock()
 
 		triggered++
 	}
@@ -2514,16 +2580,27 @@ func (c *Controller) processAllPRs(ctx context.Context) {
 
 	c.log.Info("processing active PRs", "count", len(prs))
 
-	for _, pr := range prs {
+	for _, snap := range prs {
 		select {
 		case <-ctx.Done():
 			return
 		default:
 			c.log.Debug("checking PR",
-				"pr", pr.PRNumber,
-				"stage", pr.Stage,
-				"ci_status", pr.CIStatus,
+				"pr", snap.PRNumber,
+				"stage", snap.Stage,
+				"ci_status", snap.CIStatus,
 			)
+
+			// TASK-324: `snap` is a detached snapshot from GetActivePRs. Re-fetch the
+			// LIVE pointer by number so the pre-ProcessPR mutations below (and
+			// checkExternalMergeOrClose) operate on the shared state under its mutex.
+			c.mu.RLock()
+			pr, ok := c.activePRs[snap.PRNumber]
+			c.mu.RUnlock()
+			if !ok {
+				// PR was removed between snapshot and now — skip.
+				continue
+			}
 
 			// Fetch PR once, use twice - cache to avoid redundant API calls
 			ghPR, err := c.ghClient.GetPullRequest(ctx, c.owner, c.repo, pr.PRNumber)
@@ -2532,8 +2609,15 @@ func (c *Controller) processAllPRs(ctx context.Context) {
 				continue
 			}
 
-			// Check if PR was merged/closed externally before processing
-			if c.checkExternalMergeOrClose(ctx, pr, ghPR) {
+			// TASK-324: hold pr.mu around the external-merge/close check and the
+			// polling-mode changes-requested read-modify-write + persist. Release it
+			// BEFORE calling ProcessPR, which re-acquires pr.mu for its whole body
+			// (Go's sync.Mutex is non-reentrant). Lock ordering preserved: pr.mu is
+			// taken before any c.mu that checkExternalMergeOrClose→removePR acquires.
+			pr.mu.Lock()
+			externallyResolved := c.checkExternalMergeOrClose(ctx, pr, ghPR)
+			if externallyResolved {
+				pr.mu.Unlock()
 				continue
 			}
 
@@ -2546,12 +2630,11 @@ func (c *Controller) processAllPRs(ctx context.Context) {
 						"pr", pr.PRNumber,
 						"stage", pr.Stage,
 					)
-					c.mu.Lock()
 					pr.Stage = StageReviewRequested
-					c.mu.Unlock()
 					c.persistPRState(pr)
 				}
 			}
+			pr.mu.Unlock()
 
 			if err := c.ProcessPR(ctx, pr.PRNumber, ghPR); err != nil {
 				// Error already logged in ProcessPR

--- a/internal/autopilot/controller_prstate_race_test.go
+++ b/internal/autopilot/controller_prstate_race_test.go
@@ -1,0 +1,179 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/approval"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// legalPRStages is the set of every defined PRStage. The concurrent-driver test
+// asserts the final Stage is one of these (i.e. never a torn/garbage value).
+func legalPRStages() map[PRStage]bool {
+	out := make(map[PRStage]bool)
+	for _, s := range AllPRStages() {
+		out[s] = true
+	}
+	return out
+}
+
+// TestController_PRStateRace_Concurrent is a -race regression test for TASK-324.
+//
+// It drives, concurrently and on the SAME tracked PR:
+//   - a ProcessPR loop (the main state-machine leg: 11 handlers + inline writes +
+//     persist, all under prState.mu),
+//   - OnReviewRequested (webhook leg: writes prState.Stage),
+//   - SetApprovalDecision (approval-callback leg: writes prState.ApprovalDecision),
+//   - GetActivePRs (read-only consumers: snapshot under prState.mu).
+//
+// Before the fix these legs mutate/read *PRState fields from different goroutines
+// with only c.mu guarding the map (never the struct), which `go test -race` flags
+// as a data race. With the per-PR mutex in place the run is clean and the final
+// Stage is always a legal value.
+//
+// NEGATIVE CHECK: commenting out the `prState.mu.Lock()` in ProcessPR makes this
+// test report a DATA RACE under -race (verified during implementation).
+func TestController_PRStateRace_Concurrent(t *testing.T) {
+	// Permissive mock GitHub: GetPullRequest returns an open, clean (non-conflicting)
+	// PR so the state machine keeps churning; reviews are empty; everything else 200.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/pulls/42":
+			mergeable := true
+			resp := github.PullRequest{
+				Number:         42,
+				Title:          "feat: race target",
+				State:          "open",
+				Merged:         false,
+				Mergeable:      &mergeable,
+				MergeableState: "clean",
+				HTMLURL:        "https://github.com/owner/repo/pull/42",
+				Head:           github.PRRef{SHA: "abc1234", Ref: "pilot/GH-10"},
+				Base:           github.PRRef{Ref: "main"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/commits/abc1234/check-runs":
+			// CI still in progress → keeps the PR in StageWaitingCI, mutating fields
+			// (HeadSHA refresh, CIStatus, LastChecked) on each ProcessPR tick.
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: "in_progress", Conclusion: ""},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/pulls/42/reviews":
+			// No reviews — hasChangesRequested / handleReviewRequested see an empty list.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			// AddLabels, RemoveLabel, UpdateIssueState, AddComment, ClosePullRequest,
+			// DeleteBranch, merge, issue creation, etc. all succeed harmlessly.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd // prod → approval path is reachable
+	cfg.AutoReview = false
+	cfg.CIPollInterval = time.Millisecond
+	cfg.CIWaitTimeout = time.Hour    // don't time out CI mid-test
+	cfg.MaxFailures = 1 << 30        // keep the per-PR circuit breaker from tripping
+	cfg.ReviewFeedback = &ReviewFeedbackConfig{Enabled: true, MaxIterations: 1 << 30}
+
+	mgr := approval.NewManager(&approval.Config{
+		Enabled:        true,
+		DefaultTimeout: time.Hour,
+		DefaultAction:  approval.DecisionRejected,
+		PreMerge: &approval.StageConfig{
+			Enabled:       true,
+			Timeout:       time.Hour,
+			DefaultAction: approval.DecisionRejected,
+		},
+	})
+
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+
+	// Track exactly one PR; seed an approval request id so SetApprovalDecision has a
+	// live target without depending on ordering with the submit path.
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc1234", "pilot/GH-10", "")
+	c.mu.RLock()
+	seed := c.activePRs[42]
+	c.mu.RUnlock()
+	seed.mu.Lock()
+	seed.ApprovalRequestID = "req-race-42"
+	seed.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	const iterations = 400
+	var wg sync.WaitGroup
+
+	// Leg 1: ProcessPR loop (main state-machine writer).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// Ignore errors — the goal is concurrent field access, not a clean run.
+			_ = c.ProcessPR(ctx, 42, nil)
+		}
+	}()
+
+	// Leg 2: OnReviewRequested (webhook writer of prState.Stage).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			c.OnReviewRequested(42, "submitted", "changes_requested", "human-reviewer")
+		}
+	}()
+
+	// Leg 3: SetApprovalDecision (approval-callback writer of prState.ApprovalDecision).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = c.SetApprovalDecision(ctx, "req-race-42", string(approval.DecisionApproved), "human-approver")
+		}
+	}()
+
+	// Leg 4: GetActivePRs (read-only snapshot consumer).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			for _, snap := range c.GetActivePRs() {
+				_ = snap.Stage // read a field off the detached snapshot
+			}
+		}
+	}()
+
+	wg.Wait()
+	cancel()
+
+	// Final assertion: read via a detached snapshot (race-free) and verify the Stage
+	// is a legal value (never torn). The PR may or may not still be tracked depending
+	// on which terminal transition the ProcessPR loop landed on last.
+	legal := legalPRStages()
+	for _, snap := range c.GetActivePRs() {
+		if snap.PRNumber != 42 {
+			continue
+		}
+		if !legal[snap.Stage] {
+			t.Fatalf("PR 42 ended in illegal/torn stage %q", snap.Stage)
+		}
+	}
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -3,6 +3,7 @@ package autopilot
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -444,7 +445,20 @@ func ShortSHA(sha string) string {
 }
 
 // PRState tracks the lifecycle state of a pull request through the autopilot pipeline.
+//
+// Concurrency: a live *PRState stored in Controller.activePRs is shared across the
+// main processing loop and webhook goroutines. The embedded mu guards every field
+// below. Holders of the live pointer MUST take mu before reading/writing fields
+// (see TASK-324). The no-deadlock invariant is: always acquire PRState.mu BEFORE
+// Controller.mu, never the reverse.
+//
+// Because PRState now contains a sync.Mutex, a populated value must never be
+// copied (go vet copylocks). Use snapshot() to hand a detached, lock-free copy to
+// read-only consumers. state_store.go constructs a fresh zero-value `var pr PRState`
+// before populating it, which is fine.
 type PRState struct {
+	// mu guards all fields below for the live pointer held in Controller.activePRs.
+	mu sync.Mutex
 	// PRNumber is the GitHub PR number.
 	PRNumber int
 	// PRURL is the full URL to the PR.
@@ -500,6 +514,49 @@ type PRState struct {
 	PostMergeSHA string
 	// PostMergeCIStartedAt is when StagePostMergeCI monitoring began (for timeout tracking).
 	PostMergeCIStartedAt time.Time
+}
+
+// snapshot returns a detached, field-by-field copy of the PRState with a fresh
+// (zero-value) mutex. The caller MUST hold ps.mu while calling this so the read of
+// every field is race-free; the returned *PRState is independent of the live one
+// and safe to hand to read-only consumers (metrics, dashboard, gateway) without any
+// lock. It deliberately does NOT use `cp := *ps`, which would copy the mutex and
+// trip go vet copylocks.
+func (ps *PRState) snapshot() *PRState {
+	cp := &PRState{
+		PRNumber:                ps.PRNumber,
+		PRURL:                   ps.PRURL,
+		IssueNumber:             ps.IssueNumber,
+		BranchName:              ps.BranchName,
+		HeadSHA:                 ps.HeadSHA,
+		Stage:                   ps.Stage,
+		CIStatus:                ps.CIStatus,
+		LastChecked:             ps.LastChecked,
+		CIWaitStartedAt:         ps.CIWaitStartedAt,
+		MergeAttempts:           ps.MergeAttempts,
+		Error:                   ps.Error,
+		CreatedAt:               ps.CreatedAt,
+		ReleaseVersion:          ps.ReleaseVersion,
+		ReleaseBumpType:         ps.ReleaseBumpType,
+		ConsecutiveAPIFailures:  ps.ConsecutiveAPIFailures,
+		EnvironmentName:         ps.EnvironmentName,
+		PRTitle:                 ps.PRTitle,
+		TargetBranch:            ps.TargetBranch,
+		IssueNodeID:             ps.IssueNodeID,
+		MergeNotificationPosted: ps.MergeNotificationPosted,
+		ApprovalRequestID:       ps.ApprovalRequestID,
+		ApprovalDecision:        ps.ApprovalDecision,
+		ApprovalRequestedAt:     ps.ApprovalRequestedAt,
+		PostMergeSHA:            ps.PostMergeSHA,
+		PostMergeCIStartedAt:    ps.PostMergeCIStartedAt,
+	}
+	// DiscoveredChecks is a slice — copy the backing array so consumers can't
+	// mutate the live PR's slice through the snapshot.
+	if ps.DiscoveredChecks != nil {
+		cp.DiscoveredChecks = make([]string, len(ps.DiscoveredChecks))
+		copy(cp.DiscoveredChecks, ps.DiscoveredChecks)
+	}
+	return cp
 }
 
 // RepoOwnerAndName extracts the repository owner and name from the PR URL.


### PR DESCRIPTION
## TASK-322 critical #3 (+ high) — Wave 0 (manual, workflow-verified)

`Controller` handed **live `*PRState` pointers** to six consumers across four goroutines (main loop, reconciler, `metrics_alerter` ticker, dashboard TUI, gateway HTTP) while webhook handlers mutated the same fields — a genuine `-race` data race that could drive the merge state machine down the wrong branch (a webhook flipping a mid-`StageMerging` PR to `StageReviewRequested`; torn `Stage` reads).

### Design
- Embedded `sync.Mutex` on `PRState`; **`ProcessPR` holds it across its whole body** → one lock covers all 11 stage handlers + inline writes + persist.
- **`GetActivePRs` returns detached `snapshot()` copies** (built under each PR's mutex) → every read-only consumer (metrics, metrics_alerter, dashboard, gateway) is race-free with zero per-consumer edits.
- `processAllPRs` uses snapshots for metrics/iteration, re-fetches the **live** pointer under the mutex for mutation.
- Webhook writers (`OnReviewRequested`, `OnPRCreated`, `SetApprovalDecision`) + `ScanRecentlyMergedPRs` publish-then-persist all guarded. `persistPRState` stays lock-free (caller-holds contract).
- **No-deadlock invariant:** always `PRState.mu` **before** `Controller.mu`, never the reverse.

### Verification
- `go build ./...` ✅ · `go vet ./internal/autopilot/...` (copylocks-clean) ✅ · `go test -race ./internal/autopilot/...` ✅ · downstream `dashboard`/`gateway`/`cmd/pilot` `-race` ✅
- New `TestController_PRStateRace_Concurrent` drives 4 concurrent legs on one PR; **verified to fail with DATA RACE when ProcessPR's lock is removed**, green when restored.

### How this was built
Implemented by one agent in a worktree, then **adversarially verified by four parallel reviewers** (deadlock/lock-ordering, race-coverage, behavior-preservation, copylocks/vet). Two independently flagged one residual unguarded persist in `ScanRecentlyMergedPRs` — fixed (mirrors `OnPRCreated`) and re-verified `-race` green.

> Manual delivery (not Pilot) — Pilot must not edit its own concurrency core. Plan: `.agent/tasks/TASK-324-prstate-race.md`.