### PR TITLE
fix(executor): ctx-aware retry backoff + in-stream overloaded detection (TASK-329)

### DIFF
--- a/internal/executor/backend_anthropic.go
+++ b/internal/executor/backend_anthropic.go
@@ -40,9 +40,10 @@ const (
 // Replaces Claude Code CLI subprocess with HTTP streaming, giving full control
 // over thinking budgets, tool dispatch, and retry logic.
 type AnthropicBackend struct {
-	apiKey string
-	apiURL string
-	config *BackendConfig
+	apiKey     string
+	apiURL     string
+	config     *BackendConfig
+	retryWaits []time.Duration // nil = use hardcoded defaults; overridden in tests
 }
 
 // NewAnthropicBackend creates a new direct API backend.
@@ -325,7 +326,10 @@ func (b *AnthropicBackend) callAPI(ctx context.Context, req *apiRequest) (*apiRe
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	backoffs := []time.Duration{30 * time.Second, 60 * time.Second, 90 * time.Second, 120 * time.Second, 180 * time.Second}
+	backoffs := b.retryWaits
+	if backoffs == nil {
+		backoffs = []time.Duration{30 * time.Second, 60 * time.Second, 90 * time.Second, 120 * time.Second, 180 * time.Second}
+	}
 
 	for attempt := 0; attempt <= apiMaxRetries; attempt++ {
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", b.apiURL, bytes.NewReader(body))
@@ -350,7 +354,11 @@ func (b *AnthropicBackend) callAPI(ctx context.Context, req *apiRequest) (*apiRe
 		if err != nil {
 			if attempt < apiMaxRetries {
 				slog.Warn("HTTP error, retrying", slog.Int("attempt", attempt+1), slog.Any("error", err))
-				time.Sleep(backoffs[min(attempt, len(backoffs)-1)])
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(backoffs[min(attempt, len(backoffs)-1)]):
+				}
 				continue
 			}
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
@@ -362,7 +370,11 @@ func (b *AnthropicBackend) callAPI(ctx context.Context, req *apiRequest) (*apiRe
 			if attempt < apiMaxRetries {
 				wait := backoffs[min(attempt, len(backoffs)-1)]
 				slog.Warn("API error, retrying", slog.Int("status", resp.StatusCode), slog.Duration("wait", wait))
-				time.Sleep(wait)
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(wait):
+				}
 				continue
 			}
 			return nil, fmt.Errorf("API returned %d after %d retries", resp.StatusCode, apiMaxRetries)
@@ -383,7 +395,11 @@ func (b *AnthropicBackend) callAPI(ctx context.Context, req *apiRequest) (*apiRe
 			if strings.Contains(err.Error(), "overloaded") && attempt < apiMaxRetries {
 				wait := backoffs[min(attempt, len(backoffs)-1)]
 				slog.Warn("Overloaded in response, retrying", slog.Duration("wait", wait))
-				time.Sleep(wait)
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(wait):
+				}
 				continue
 			}
 			return nil, err

--- a/internal/executor/backend_anthropic.go
+++ b/internal/executor/backend_anthropic.go
@@ -138,6 +138,10 @@ type sseEvent struct {
 	Delta        *sseDelta        `json:"delta,omitempty"`
 	Message      *apiResponse     `json:"message,omitempty"`
 	Usage        *apiUsage        `json:"usage,omitempty"`
+	// Error carries the nested {"error": {...}} of an in-stream "error" event.
+	// Without it, marshaling the event drops the detail and retry classification
+	// (callAPI checks for "overloaded") cannot see an in-stream overloaded_error.
+	Error *apiError `json:"error,omitempty"`
 }
 
 type sseDelta struct {
@@ -499,7 +503,17 @@ func (b *AnthropicBackend) parseSSEStream(body io.Reader) (*apiResponse, error) 
 			// Final event
 
 		case "error":
-			// Error in stream
+			// Error in stream. Surface the inner error type/message so the retry
+			// classification in callAPI (Contains "overloaded") works for in-stream
+			// errors, not just HTTP-status ones — otherwise an overloaded_error
+			// delivered mid-stream is returned immediately instead of retried.
+			if event.Error != nil {
+				detail := strings.TrimSpace(event.Error.Type + ": " + event.Error.Message)
+				if strings.Contains(strings.ToLower(detail), "overloaded") {
+					return nil, fmt.Errorf("overloaded: %s", detail)
+				}
+				return nil, fmt.Errorf("stream error: %s", detail)
+			}
 			errData, _ := json.Marshal(event)
 			return nil, fmt.Errorf("stream error: %s", string(errData))
 		}

--- a/internal/executor/backend_anthropic_test.go
+++ b/internal/executor/backend_anthropic_test.go
@@ -1,0 +1,269 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- Constructor Tests ---
+
+func TestNewAnthropicBackend_Defaults(t *testing.T) {
+	b := NewAnthropicBackend(nil)
+	if b == nil {
+		t.Fatal("NewAnthropicBackend(nil) returned nil")
+	}
+	if b.apiURL != anthropicAPIURL {
+		t.Errorf("apiURL = %q, want default %q", b.apiURL, anthropicAPIURL)
+	}
+}
+
+func TestNewAnthropicBackend_CustomBaseURL(t *testing.T) {
+	cfg := &BackendConfig{
+		APIBaseURL: "https://proxy.example.com",
+	}
+	b := NewAnthropicBackend(cfg)
+	if b.apiURL != "https://proxy.example.com/v1/messages" {
+		t.Errorf("apiURL = %q, want proxy endpoint", b.apiURL)
+	}
+}
+
+func TestAnthropicBackend_Name(t *testing.T) {
+	b := NewAnthropicBackend(nil)
+	if b.Name() != BackendTypeAnthropicAPI {
+		t.Errorf("Name() = %q, want %q", b.Name(), BackendTypeAnthropicAPI)
+	}
+}
+
+func TestAnthropicBackend_IsAvailable(t *testing.T) {
+	noKey := NewAnthropicBackend(nil)
+	if noKey.IsAvailable() {
+		t.Error("IsAvailable() should be false without a key")
+	}
+}
+
+// --- Helper: build a test backend pointing at a local server ---
+
+func newTestAnthropicBackend(t *testing.T, serverURL string) *AnthropicBackend {
+	t.Helper()
+	b := &AnthropicBackend{
+		apiKey: "test-anthropic-key",
+		apiURL: serverURL + "/v1/messages",
+		config: &BackendConfig{},
+		// Inject zero-duration backoffs so retry tests are instant.
+		retryWaits: []time.Duration{0, 0, 0, 0, 0},
+	}
+	return b
+}
+
+// anthropicSSEStop returns a minimal SSE stream that ends cleanly.
+func anthropicSSEStop() string {
+	return strings.Join([]string{
+		`data: {"type":"message_start","message":{"id":"msg1","type":"message","role":"assistant","model":"claude-opus-4-6","usage":{"input_tokens":10,"output_tokens":0}}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"done"}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n\n")
+}
+
+// --- Retry on 429 ---
+
+func TestAnthropicBackend_Retry429(t *testing.T) {
+	attempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, anthropicSSEStop())
+	}))
+	defer srv.Close()
+
+	b := newTestAnthropicBackend(t, srv.URL)
+
+	req := &apiRequest{
+		Model:     "claude-opus-4-6",
+		MaxTokens: 100,
+		Messages:  []apiMessage{{Role: "user", Content: "hi"}},
+	}
+	result, err := b.callAPI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("callAPI error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if attempts < 2 {
+		t.Errorf("expected at least 2 attempts, got %d", attempts)
+	}
+}
+
+// --- Retry on 500 ---
+
+func TestAnthropicBackend_Retry500(t *testing.T) {
+	attempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, anthropicSSEStop())
+	}))
+	defer srv.Close()
+
+	b := newTestAnthropicBackend(t, srv.URL)
+
+	req := &apiRequest{
+		Model:     "claude-opus-4-6",
+		MaxTokens: 100,
+		Messages:  []apiMessage{{Role: "user", Content: "hi"}},
+	}
+	result, err := b.callAPI(context.Background(), req)
+	if err != nil {
+		t.Fatalf("callAPI error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if attempts < 2 {
+		t.Errorf("expected at least 2 attempts, got %d", attempts)
+	}
+}
+
+// --- Context cancellation during 429 backoff ---
+//
+// Verifies that when ctx is cancelled while callAPI is waiting between retries,
+// the function returns ctx.Err() promptly instead of sleeping the full backoff.
+
+func TestAnthropicBackend_CtxCancelDuring429Backoff(t *testing.T) {
+	// Use a real backoff long enough that if the select falls through to
+	// time.After, the test would time out (5s >> test budget).
+	longWait := 5 * time.Second
+
+	readyCh := make(chan struct{}) // server signals it sent 429
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		// Signal that the 429 has been written so the test can cancel ctx.
+		select {
+		case readyCh <- struct{}{}:
+		default:
+		}
+	}))
+	defer srv.Close()
+
+	b := &AnthropicBackend{
+		apiKey:     "test-key",
+		apiURL:     srv.URL + "/v1/messages",
+		config:     &BackendConfig{},
+		retryWaits: []time.Duration{longWait, longWait, longWait, longWait, longWait},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel the context once the server has responded with 429.
+	go func() {
+		<-readyCh
+		cancel()
+	}()
+
+	start := time.Now()
+	req := &apiRequest{
+		Model:     "claude-opus-4-6",
+		MaxTokens: 100,
+		Messages:  []apiMessage{{Role: "user", Content: "hi"}},
+	}
+	_, err := b.callAPI(ctx, req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error on context cancellation, got nil")
+	}
+	if err != context.Canceled {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+	// Must return well before the 5s backoff.
+	if elapsed >= longWait {
+		t.Errorf("callAPI took %v, want << %v (backoff not honouring ctx)", elapsed, longWait)
+	}
+}
+
+// --- Context cancellation during overloaded-error backoff ---
+
+func TestAnthropicBackend_CtxCancelDuringOverloadedBackoff(t *testing.T) {
+	longWait := 5 * time.Second
+
+	readyCh := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Return an overloaded error event in the stream body.
+		_, _ = io.WriteString(w, "data: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"overloaded\"}}\n\n")
+		select {
+		case readyCh <- struct{}{}:
+		default:
+		}
+	}))
+	defer srv.Close()
+
+	b := &AnthropicBackend{
+		apiKey:     "test-key",
+		apiURL:     srv.URL + "/v1/messages",
+		config:     &BackendConfig{},
+		retryWaits: []time.Duration{longWait, longWait, longWait, longWait, longWait},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-readyCh
+		cancel()
+	}()
+
+	start := time.Now()
+	req := &apiRequest{
+		Model:     "claude-opus-4-6",
+		MaxTokens: 100,
+		Messages:  []apiMessage{{Role: "user", Content: "hi"}},
+	}
+	_, err := b.callAPI(ctx, req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error on context cancellation, got nil")
+	}
+	if err != context.Canceled {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+	if elapsed >= longWait {
+		t.Errorf("callAPI took %v, want << %v (backoff not honouring ctx)", elapsed, longWait)
+	}
+}
+
+// --- No API key returns error ---
+
+func TestAnthropicBackend_NoAPIKey(t *testing.T) {
+	b := &AnthropicBackend{
+		apiKey: "",
+		apiURL: anthropicAPIURL,
+		config: &BackendConfig{},
+	}
+	_, err := b.Execute(context.Background(), ExecuteOptions{Prompt: "test"})
+	if err == nil {
+		t.Error("expected error when no API key configured")
+	}
+	if !strings.Contains(err.Error(), "API key") {
+		t.Errorf("error = %q, want API key mention", err.Error())
+	}
+}

--- a/internal/executor/backend_openai.go
+++ b/internal/executor/backend_openai.go
@@ -24,10 +24,11 @@ const (
 // Supports OpenAI, OpenRouter, Groq, Together, Synthetic, vLLM, Ollama, and any provider
 // exposing an OpenAI-compatible endpoint — without a CLI wrapper.
 type OpenAIBackend struct {
-	apiKey string
-	model  string
-	apiURL string // full endpoint URL
-	config *BackendConfig
+	apiKey     string
+	model      string
+	apiURL     string // full endpoint URL
+	config     *BackendConfig
+	retryWaits []time.Duration // nil = use hardcoded defaults; overridden in tests
 }
 
 // NewOpenAIBackend creates a new OpenAI-compatible direct HTTP backend.
@@ -244,7 +245,10 @@ func (b *OpenAIBackend) callAPI(ctx context.Context, req *openaiRequest) (*opena
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	backoffs := []time.Duration{30 * time.Second, 60 * time.Second, 90 * time.Second, 120 * time.Second, 180 * time.Second}
+	backoffs := b.retryWaits
+	if backoffs == nil {
+		backoffs = []time.Duration{30 * time.Second, 60 * time.Second, 90 * time.Second, 120 * time.Second, 180 * time.Second}
+	}
 
 	for attempt := 0; attempt <= apiMaxRetries; attempt++ {
 		httpReq, err := http.NewRequestWithContext(ctx, "POST", b.apiURL, bytes.NewReader(body))
@@ -260,7 +264,11 @@ func (b *OpenAIBackend) callAPI(ctx context.Context, req *openaiRequest) (*opena
 		if err != nil {
 			if attempt < apiMaxRetries {
 				slog.Warn("HTTP error, retrying", slog.Int("attempt", attempt+1), slog.Any("error", err))
-				time.Sleep(backoffs[min(attempt, len(backoffs)-1)])
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(backoffs[min(attempt, len(backoffs)-1)]):
+				}
 				continue
 			}
 			return nil, fmt.Errorf("HTTP request failed: %w", err)
@@ -271,7 +279,11 @@ func (b *OpenAIBackend) callAPI(ctx context.Context, req *openaiRequest) (*opena
 			if attempt < apiMaxRetries {
 				wait := backoffs[min(attempt, len(backoffs)-1)]
 				slog.Warn("API error, retrying", slog.Int("status", resp.StatusCode), slog.Duration("wait", wait))
-				time.Sleep(wait)
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(wait):
+				}
 				continue
 			}
 			return nil, fmt.Errorf("API returned %d after %d retries", resp.StatusCode, apiMaxRetries)

--- a/internal/executor/backend_openai_test.go
+++ b/internal/executor/backend_openai_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // sseChunk formats a single SSE data line.
@@ -95,7 +96,10 @@ func newTestOpenAIBackend(t *testing.T, serverURL string) *OpenAIBackend {
 			Model:   "test-model",
 		},
 	}
-	return NewOpenAIBackend(cfg)
+	b := NewOpenAIBackend(cfg)
+	// Inject zero-duration backoffs so retry tests are instant.
+	b.retryWaits = []time.Duration{0, 0, 0, 0, 0}
+	return b
 }
 
 // --- Text-Only Streaming ---
@@ -392,14 +396,9 @@ func TestOpenAIBackend_Retry429(t *testing.T) {
 	defer srv.Close()
 
 	b := newTestOpenAIBackend(t, srv.URL)
-	// Override backoffs to zero for fast test
-	origBackoffs := []int{0} // We can't easily override the backoff slice, so just verify attempts
-	_ = origBackoffs
+	// Inject zero-duration backoffs so the retry is instant.
+	b.retryWaits = []time.Duration{0, 0, 0, 0, 0}
 
-	// The actual retry uses exponential backoff. To keep the test fast, we just
-	// verify that the backend eventually succeeds after a 429.
-	// Note: this test will be slow if it actually sleeps the full backoff.
-	// In practice the test is used to verify retry logic, not timing.
 	result, err := b.Execute(context.Background(), ExecuteOptions{
 		Prompt:      "test",
 		ProjectPath: t.TempDir(),
@@ -414,6 +413,60 @@ func TestOpenAIBackend_Retry429(t *testing.T) {
 		t.Errorf("expected at least 2 attempts, got %d", attempts)
 	}
 }
+
+// --- Context cancellation during 429 backoff ---
+//
+// Verifies that cancelling ctx while callAPI is waiting between retries returns
+// ctx.Err() promptly — not after the full backoff duration.
+
+func TestOpenAIBackend_CtxCancelDuring429Backoff(t *testing.T) {
+	longWait := 5 * time.Second
+
+	readyCh := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		select {
+		case readyCh <- struct{}{}:
+		default:
+		}
+	}))
+	defer srv.Close()
+
+	b := &OpenAIBackend{
+		apiKey:     "test-key",
+		model:      "test-model",
+		apiURL:     srv.URL + "/chat/completions",
+		config:     &BackendConfig{},
+		retryWaits: []time.Duration{longWait, longWait, longWait, longWait, longWait},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-readyCh
+		cancel()
+	}()
+
+	start := time.Now()
+	req := &openaiRequest{
+		Model:    "test-model",
+		Messages: []openaiMsg{{Role: "user", Content: strPtr("hi")}},
+	}
+	_, err := b.callAPI(ctx, req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error on context cancellation, got nil")
+	}
+	if err != context.Canceled {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+	if elapsed >= longWait {
+		t.Errorf("callAPI took %v, want << %v (backoff not honouring ctx)", elapsed, longWait)
+	}
+}
+
+// strPtr returns a pointer to s; used in test message construction.
+func strPtr(s string) *string { return &s }
 
 // --- Retry on 500 ---
 


### PR DESCRIPTION
Closes #3302. Supersedes #3311 (closed after its CI failed on the test below).

Pilot implemented TASK-329 (replace `time.Sleep` with a ctx-aware `select` in the Anthropic/OpenAI retry backoffs) in #3311, but its own regression test `TestAnthropicBackend_CtxCancelDuringOverloadedBackoff` failed: an `overloaded_error` delivered as an **in-stream SSE event** was returned as `stream error: {"type":"error"}` instead of being retried, so the ctx-cancel-during-backoff path was never exercised.

**Root cause (fixed here):** `sseEvent` had no `Error` field, so marshaling the in-stream `error` event dropped the nested `{"error":{"type":"overloaded_error"}}` — the `Contains(err,"overloaded")` retry classification missed it. Added `sseEvent.Error` and made the `case "error"` handler surface the inner type/message, so in-stream overloaded events enter the backoff (and the ctx-cancel path) like HTTP-status overloads.

### Verification
- `go build ./...` ✅ · `go vet ./internal/executor/` ✅
- `TestAnthropicBackend_CtxCancelDuringOverloadedBackoff` ✅ (was failing) · `TestOpenAIBackend_CtxCancelDuring429Backoff` ✅
- `go test ./internal/executor/` ✅

Contains Pilot's original TASK-329 commit + the one-commit fix. Audit: TASK-322 §high (API backend retry backoff).