### PR TITLE
test(executor): lock IsTaskShipped/HasCompletedExecution invariant for {pr_url, error} row (TASK-334)

### DIFF
--- a/internal/executor/task_completion_invariant_test.go
+++ b/internal/executor/task_completion_invariant_test.go
@@ -75,6 +75,14 @@ func TestTaskCompletionInvariant(t *testing.T) {
 			exec:        memory.Execution{ID: "inv-7", TaskID: "GH-999", ProjectPath: "/proj", Status: "completed", Error: "stale running task recovered", CommitSHA: "xyz"},
 			wantShipped: false,
 		},
+		{
+			// TASK-334: the {pr_url, error} combination must NOT be treated as shipped by either
+			// site. HasCompletedExecution SQL excludes error!='' unconditionally; IsTaskShipped
+			// must agree. Without this row the agreement was unverified and could silently regress.
+			name:        "TASK-334: completed with pr_url AND error (both sites must agree: not shipped)",
+			exec:        memory.Execution{ID: "inv-8", TaskID: "GH-334", ProjectPath: "/proj", Status: "completed", PRUrl: "https://github.com/x/y/pull/3", Error: "post-PR comment failed"},
+			wantShipped: false,
+		},
 	}
 
 	for i, tc := range rows {

--- a/internal/executor/task_shipped.go
+++ b/internal/executor/task_shipped.go
@@ -7,7 +7,9 @@ import (
 )
 
 // IsTaskShipped reports whether an execution row represents real shipped work.
-// PRUrl is the primary signal — it proves a PR was opened against the remote.
+// PRUrl is the primary signal — it proves a PR was opened against the remote, but only
+// when the row has no error (mirrors the HasCompletedExecution SQL which excludes error!=''
+// rows unconditionally, preventing the two sites from diverging on the {pr_url, error} case).
 // CommitSHA alone is accepted for backwards-compat (direct-commit workflows) but
 // logs a warning because it can be a parent SHA if the ghost-SHA guard was bypassed.
 // Epic-parent rows (status=completed, no deliverable) correctly return false.
@@ -15,7 +17,7 @@ func IsTaskShipped(row memory.Execution) bool {
 	if row.Status != "completed" {
 		return false
 	}
-	if row.PRUrl != "" {
+	if row.PRUrl != "" && row.Error == "" {
 		return true
 	}
 	if row.CommitSHA != "" && row.Error == "" {

--- a/internal/executor/task_shipped_test.go
+++ b/internal/executor/task_shipped_test.go
@@ -62,11 +62,14 @@ func TestIsTaskShipped(t *testing.T) {
 			want: false,
 		},
 		{
-			// A row with both pr_url and an error IS still considered shipped: the PR was created,
-			// the error may be from a post-PR step (e.g. comment failed). PRUrl is the primary signal.
-			name: "completed with error and pr_url (PR created despite error)",
+			// TASK-334: rows with pr_url AND a non-empty error are NOT shipped.
+			// HasCompletedExecution SQL excludes error!='' unconditionally; IsTaskShipped must
+			// agree to prevent invariant divergence. The error may indicate a partial failure
+			// (e.g. comment failed after PR creation), but the cross-site invariant takes
+			// precedence — callers that need finer-grained distinction must query pr_url directly.
+			name: "completed with error and pr_url (error present — not shipped, TASK-334)",
 			row:  memory.Execution{Status: "completed", Error: "comment failed", PRUrl: "https://github.com/x/y/pull/2"},
-			want: true,
+			want: false,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `IsTaskShipped` was returning `true` for `{status=completed, pr_url!='', error!=''}` while `HasCompletedExecution` SQL returned `false` — the two sites disagreed on this case.
- **Fix**: Added `&& row.Error == ""` guard to the `PRUrl` branch in `IsTaskShipped` (same pattern as the existing `CommitSHA` branch), aligning it with the SQL's `error IS NULL OR error = ''` filter.
- **Test added**: New row `TASK-334: completed with pr_url AND error → not shipped` in `TestTaskCompletionInvariant` asserts both sites agree. Will catch any future regression at either site.
- **Unit test updated**: Existing `task_shipped_test.go` case "completed with error and pr_url" flipped from `want: true` → `want: false` to match the corrected behaviour.

## Test plan

- [x] `go build ./...` — passes
- [x] `go test -v -run "TestIsTaskShipped|TestTaskCompletionInvariant" ./internal/executor/...` — all 18 subtests pass
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/executor/...` — 0 issues

Closes #3307