### PR TITLE
feat(alerts): Prometheus metrics for the alert dispatch path (TASK-332)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-05-30 (v2.151.0)
+**Last Updated:** 2026-05-29 (v2.151.0)
 
 ## Legend
 
@@ -178,6 +178,7 @@
 | Cooldown periods | ✅ | alerts | - | `alerts.defaults.cooldown` | Avoid spam |
 | PagerDuty escalation | ✅ | alerts | - | - | Auto-escalate after 3 retries (v0.38.0, GH-848) |
 | Deadlock detector | ✅ | autopilot | - | - | Alert after 1h with no progress on PR (v0.38.0, GH-849) |
+| Alert dispatch metrics | ✅ | alerts/gateway | - | - | alerts_fired_total, alert_delivery_total, alert_events_dropped_total, alert_queue_depth on /metrics (TASK-332) |
 | Rate limit detection | ✅ | executor | - | - | Detect GitHub API rate limits, pause + resume at reset time (v0.34.0) |
 
 ## Quality Gates
@@ -576,4 +577,3 @@ quality:
 | `IsTaskShipped` predicate | v2.151.x | autopilot | Cross-site invariant preventing double-dispatch (TASK-296 / GH-3091) |
 | Ghost-SHA guard | v2.151.x | executor | Fail-closed when commit_sha already on base branch (TASK-300 / GH-3099) |
 | Merge→done race window closed | v2.163.0 | autopilot + adapters/github | `Controller.SetOnIssueDone` fires `MarkProcessed` on all pollers at PR-merge, preventing phantom re-dispatch during label propagation lag (TASK-321 PR-4 / GH-3271) |
-| Webhook fail-closed + jira/asana verification wired | v2.163.x | adapters/* + pilot | All verifiers fail-closed on empty secret; jira/asana VerifySignature now called before Handle; `PILOT_ALLOW_UNSIGNED_WEBHOOKS=1` escape hatch (TASK-326 / GH-3288) |

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -519,7 +519,8 @@ Examples:
 				// Create alerts engine if configured
 				alertsCfg := getAlertsConfig(cfg)
 				if alertsCfg != nil && alertsCfg.Enabled {
-					alertsDispatcher := alerts.NewDispatcher(alertsCfg)
+					alertsMetrics := alerts.NewAlertMetrics()
+					alertsDispatcher := alerts.NewDispatcher(alertsCfg, alerts.WithDispatcherMetrics(alertsMetrics))
 
 					// Register Slack channel if configured
 					if cfg.Adapters.Slack != nil && cfg.Adapters.Slack.Enabled && cfg.Adapters.Slack.BotToken != "" {
@@ -574,7 +575,7 @@ Examples:
 					}
 
 					ctx := context.Background()
-					gwAlertsEngine = alerts.NewEngine(alertsCfg, alerts.WithDispatcher(alertsDispatcher))
+					gwAlertsEngine = alerts.NewEngine(alertsCfg, alerts.WithDispatcher(alertsDispatcher), alerts.WithAlertMetrics(alertsMetrics))
 					if alertErr := gwAlertsEngine.Start(ctx); alertErr != nil {
 						logging.WithComponent("start").Warn("failed to start alerts engine for gateway polling", slog.Any("error", alertErr))
 						gwAlertsEngine = nil
@@ -987,6 +988,12 @@ Examples:
 				if gwRunner != nil {
 					gwRunner.SetMetricsRecorder(gwAutopilotController.Metrics())
 				}
+			}
+			// TASK-332: Wire alert metrics into the Prometheus exporter
+			if gwAlertsEngine != nil {
+				p.Gateway().SetAlertsMetricsSource(gwAlertsEngine)
+			}
+			if gwAutopilotController != nil {
 
 				// GH-2080: Wire PR review events to autopilot controller
 				p.SetOnPRReview(func(ctx context.Context, prNumber int, action, state, reviewer string, repo *github.Repository) error {
@@ -1653,8 +1660,9 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	}
 
 	// GH-1662: Start gateway in background so desktop app can reach /health
+	var gwServer *gateway.Server // hoisted so TASK-332 alert-metrics wiring can run after alerts engine is created
 	if !noGateway && cfg.Gateway != nil {
-		gwServer := gateway.NewServer(cfg.Gateway)
+		gwServer = gateway.NewServer(cfg.Gateway)
 		if autopilotController != nil {
 			gwServer.SetAutopilotProvider(&autopilotProviderAdapter{controller: autopilotController})
 			gwServer.SetMetricsSource(autopilotController.Metrics())
@@ -1904,7 +1912,8 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	alertsCfg := getAlertsConfig(cfg)
 	if alertsCfg != nil && alertsCfg.Enabled {
 		// Create dispatcher and register channels
-		alertsDispatcher := alerts.NewDispatcher(alertsCfg)
+		alertsMetrics := alerts.NewAlertMetrics()
+		alertsDispatcher := alerts.NewDispatcher(alertsCfg, alerts.WithDispatcherMetrics(alertsMetrics))
 
 		// Register Slack channel if configured
 		if cfg.Adapters.Slack != nil && cfg.Adapters.Slack.Enabled && cfg.Adapters.Slack.BotToken != "" {
@@ -1958,7 +1967,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			}
 		}
 
-		alertsEngine = alerts.NewEngine(alertsCfg, alerts.WithDispatcher(alertsDispatcher))
+		alertsEngine = alerts.NewEngine(alertsCfg, alerts.WithDispatcher(alertsDispatcher), alerts.WithAlertMetrics(alertsMetrics))
 		if err := alertsEngine.Start(ctx); err != nil {
 			logging.WithComponent("start").Warn("failed to start alerts engine", slog.Any("error", err))
 			alertsEngine = nil
@@ -1967,6 +1976,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				slog.Int("channels", len(alertsDispatcher.ListChannels())),
 			)
 		}
+	}
+
+	// TASK-332: Wire alert metrics into the Prometheus exporter (polling mode)
+	if gwServer != nil && alertsEngine != nil {
+		gwServer.SetAlertsMetricsSource(alertsEngine)
 	}
 
 	// Initialize dispatcher for task queue (uses store created earlier)

--- a/internal/alerts/dispatcher.go
+++ b/internal/alerts/dispatcher.go
@@ -25,6 +25,7 @@ type Dispatcher struct {
 	config   *AlertConfig
 	logger   *slog.Logger
 	mu       sync.RWMutex
+	metrics  *AlertMetrics
 }
 
 // DispatcherOption configures the Dispatcher
@@ -37,12 +38,22 @@ func WithDispatcherLogger(logger *slog.Logger) DispatcherOption {
 	}
 }
 
+// WithDispatcherMetrics injects a shared AlertMetrics instance.
+// Pass the same instance to WithAlertMetrics on the Engine so delivery counters
+// are visible in Engine.AlertSnapshot().
+func WithDispatcherMetrics(m *AlertMetrics) DispatcherOption {
+	return func(d *Dispatcher) {
+		d.metrics = m
+	}
+}
+
 // NewDispatcher creates a new alert dispatcher
 func NewDispatcher(config *AlertConfig, opts ...DispatcherOption) *Dispatcher {
 	d := &Dispatcher{
 		channels: make(map[string]Channel),
 		config:   config,
 		logger:   slog.Default(),
+		metrics:  NewAlertMetrics(),
 	}
 
 	for _, opt := range opts {
@@ -102,6 +113,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, alert *Alert, channelNames []
 	for _, name := range channelNames {
 		channel, ok := d.channels[name]
 		if !ok {
+			d.metrics.RecordDelivery(name, "unknown", "failure")
 			results = append(results, DeliveryResult{
 				ChannelName: name,
 				Success:     false,
@@ -182,6 +194,7 @@ func (d *Dispatcher) sendToChannel(ctx context.Context, ch Channel, alert *Alert
 	if err != nil {
 		result.Success = false
 		result.Error = err
+		d.metrics.RecordDelivery(ch.Name(), ch.Type(), "failure")
 		d.logger.Error("failed to send alert",
 			"channel", ch.Name(),
 			"channel_type", ch.Type(),
@@ -190,6 +203,7 @@ func (d *Dispatcher) sendToChannel(ctx context.Context, ch Channel, alert *Alert
 		)
 	} else {
 		result.Success = true
+		d.metrics.RecordDelivery(ch.Name(), ch.Type(), "success")
 		d.logger.Debug("alert sent successfully",
 			"channel", ch.Name(),
 			"alert_id", alert.ID,

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -27,6 +27,11 @@ type Engine struct {
 	// Channels for events
 	eventCh chan Event
 	done    chan struct{}
+
+	// metrics accumulates fired/dropped counters; share the same instance with the
+	// Dispatcher via WithAlertMetrics+WithDispatcherMetrics so delivery counts appear
+	// in AlertSnapshot too.
+	metrics *AlertMetrics
 }
 
 type progressState struct {
@@ -94,6 +99,15 @@ func WithDispatcher(d *Dispatcher) EngineOption {
 	}
 }
 
+// WithAlertMetrics injects a shared AlertMetrics instance.
+// Pass the same instance to WithDispatcherMetrics so delivery counters from the
+// Dispatcher appear in Engine.AlertSnapshot().
+func WithAlertMetrics(m *AlertMetrics) EngineOption {
+	return func(e *Engine) {
+		e.metrics = m
+	}
+}
+
 // NewEngine creates a new alerting engine
 func NewEngine(config *AlertConfig, opts ...EngineOption) *Engine {
 	e := &Engine{
@@ -106,6 +120,7 @@ func NewEngine(config *AlertConfig, opts ...EngineOption) *Engine {
 		retryTracker:        make(map[string]int),
 		eventCh:             make(chan Event, 100),
 		done:                make(chan struct{}),
+		metrics:             NewAlertMetrics(),
 	}
 
 	for _, opt := range opts {
@@ -154,6 +169,7 @@ func (e *Engine) ProcessEvent(event Event) {
 			"type", event.Type,
 			"task_id", event.TaskID,
 		)
+		e.metrics.RecordDropped()
 	}
 }
 
@@ -521,6 +537,8 @@ func (e *Engine) fireAlert(ctx context.Context, rule AlertRule, alert *Alert) {
 	e.lastAlertTimes[rule.Name] = time.Now()
 	e.mu.Unlock()
 
+	e.metrics.RecordFired(rule.Name, string(alert.Severity))
+
 	if e.dispatcher == nil {
 		e.logger.Warn("no dispatcher configured, alert not sent",
 			"rule", rule.Name,
@@ -793,4 +811,13 @@ func (e *Engine) handleEscalation(ctx context.Context, event Event) {
 		alert.Severity = SeverityCritical
 		e.fireAlert(ctx, rule, alert)
 	}
+}
+
+// AlertSnapshot returns a point-in-time copy of alert metrics including the current
+// event queue depth. When the same AlertMetrics instance is shared with the Dispatcher
+// via WithAlertMetrics + WithDispatcherMetrics, the snapshot also includes delivery counters.
+func (e *Engine) AlertSnapshot() AlertMetricsSnapshot {
+	snap := e.metrics.Snapshot()
+	snap.QueueDepth = len(e.eventCh)
+	return snap
 }

--- a/internal/alerts/metrics.go
+++ b/internal/alerts/metrics.go
@@ -1,0 +1,84 @@
+package alerts
+
+import "sync"
+
+// alertFiredKey identifies a fired-alert counter by rule name and severity.
+type alertFiredKey struct {
+	Rule     string
+	Severity string
+}
+
+// alertDeliveryKey identifies a delivery attempt by channel name, type, and result.
+type alertDeliveryKey struct {
+	Channel string
+	Type    string
+	Result  string
+}
+
+// AlertMetrics collects counters for the alerting subsystem.
+// All methods are goroutine-safe.
+type AlertMetrics struct {
+	mu            sync.RWMutex
+	firedTotal    map[alertFiredKey]int64
+	deliveryTotal map[alertDeliveryKey]int64
+	droppedTotal  int64
+}
+
+// NewAlertMetrics creates an empty AlertMetrics instance.
+func NewAlertMetrics() *AlertMetrics {
+	return &AlertMetrics{
+		firedTotal:    make(map[alertFiredKey]int64),
+		deliveryTotal: make(map[alertDeliveryKey]int64),
+	}
+}
+
+// RecordFired increments the fired counter for a rule+severity pair.
+func (m *AlertMetrics) RecordFired(rule, severity string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.firedTotal[alertFiredKey{Rule: rule, Severity: severity}]++
+}
+
+// RecordDelivery increments the delivery counter for a channel+type+result triple.
+// result is "success" or "failure".
+func (m *AlertMetrics) RecordDelivery(channel, channelType, result string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deliveryTotal[alertDeliveryKey{Channel: channel, Type: channelType, Result: result}]++
+}
+
+// RecordDropped increments the dropped-event counter.
+func (m *AlertMetrics) RecordDropped() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.droppedTotal++
+}
+
+// Snapshot returns a point-in-time copy of all counters.
+func (m *AlertMetrics) Snapshot() AlertMetricsSnapshot {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	fired := make(map[alertFiredKey]int64, len(m.firedTotal))
+	for k, v := range m.firedTotal {
+		fired[k] = v
+	}
+	delivery := make(map[alertDeliveryKey]int64, len(m.deliveryTotal))
+	for k, v := range m.deliveryTotal {
+		delivery[k] = v
+	}
+	return AlertMetricsSnapshot{
+		FiredTotal:    fired,
+		DeliveryTotal: delivery,
+		DroppedTotal:  m.droppedTotal,
+	}
+}
+
+// AlertMetricsSnapshot is a read-only copy of alert metrics at a point in time.
+// QueueDepth is populated by Engine.AlertSnapshot, not by Snapshot() itself.
+type AlertMetricsSnapshot struct {
+	FiredTotal    map[alertFiredKey]int64
+	DeliveryTotal map[alertDeliveryKey]int64
+	DroppedTotal  int64
+	QueueDepth    int
+}

--- a/internal/alerts/metrics_test.go
+++ b/internal/alerts/metrics_test.go
@@ -1,0 +1,216 @@
+package alerts
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// =============================================================================
+// AlertMetrics unit tests
+// =============================================================================
+
+func TestAlertMetrics_RecordFired(t *testing.T) {
+	m := NewAlertMetrics()
+	m.RecordFired("task_failed", "critical")
+	m.RecordFired("task_failed", "critical")
+	m.RecordFired("daily_spend", "warning")
+
+	snap := m.Snapshot()
+
+	if got := snap.FiredTotal[alertFiredKey{Rule: "task_failed", Severity: "critical"}]; got != 2 {
+		t.Errorf("expected 2 for task_failed/critical, got %d", got)
+	}
+	if got := snap.FiredTotal[alertFiredKey{Rule: "daily_spend", Severity: "warning"}]; got != 1 {
+		t.Errorf("expected 1 for daily_spend/warning, got %d", got)
+	}
+}
+
+func TestAlertMetrics_RecordDelivery(t *testing.T) {
+	m := NewAlertMetrics()
+	m.RecordDelivery("slack-ops", "slack", "success")
+	m.RecordDelivery("slack-ops", "slack", "success")
+	m.RecordDelivery("slack-ops", "slack", "failure")
+	m.RecordDelivery("telegram", "telegram", "success")
+
+	snap := m.Snapshot()
+
+	if got := snap.DeliveryTotal[alertDeliveryKey{Channel: "slack-ops", Type: "slack", Result: "success"}]; got != 2 {
+		t.Errorf("expected 2 slack-ops/success, got %d", got)
+	}
+	if got := snap.DeliveryTotal[alertDeliveryKey{Channel: "slack-ops", Type: "slack", Result: "failure"}]; got != 1 {
+		t.Errorf("expected 1 slack-ops/failure, got %d", got)
+	}
+	if got := snap.DeliveryTotal[alertDeliveryKey{Channel: "telegram", Type: "telegram", Result: "success"}]; got != 1 {
+		t.Errorf("expected 1 telegram/success, got %d", got)
+	}
+}
+
+func TestAlertMetrics_RecordDropped(t *testing.T) {
+	m := NewAlertMetrics()
+	m.RecordDropped()
+	m.RecordDropped()
+	m.RecordDropped()
+
+	snap := m.Snapshot()
+	if snap.DroppedTotal != 3 {
+		t.Errorf("expected DroppedTotal=3, got %d", snap.DroppedTotal)
+	}
+}
+
+func TestAlertMetrics_SnapshotIsCopy(t *testing.T) {
+	m := NewAlertMetrics()
+	m.RecordFired("r1", "critical")
+
+	snap := m.Snapshot()
+	// Mutate original; snapshot should be unaffected.
+	m.RecordFired("r1", "critical")
+
+	if snap.FiredTotal[alertFiredKey{Rule: "r1", Severity: "critical"}] != 1 {
+		t.Error("snapshot was not a copy — mutation affected it")
+	}
+}
+
+func TestAlertMetrics_ZeroValues(t *testing.T) {
+	m := NewAlertMetrics()
+	snap := m.Snapshot()
+
+	if len(snap.FiredTotal) != 0 {
+		t.Errorf("expected empty FiredTotal, got %d entries", len(snap.FiredTotal))
+	}
+	if len(snap.DeliveryTotal) != 0 {
+		t.Errorf("expected empty DeliveryTotal, got %d entries", len(snap.DeliveryTotal))
+	}
+	if snap.DroppedTotal != 0 {
+		t.Errorf("expected DroppedTotal=0, got %d", snap.DroppedTotal)
+	}
+	if snap.QueueDepth != 0 {
+		t.Errorf("expected QueueDepth=0, got %d", snap.QueueDepth)
+	}
+}
+
+func TestAlertMetrics_ConcurrentSafe(t *testing.T) {
+	m := NewAlertMetrics()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(3)
+		go func() { defer wg.Done(); m.RecordFired("r", "warning") }()
+		go func() { defer wg.Done(); m.RecordDelivery("ch", "slack", "success") }()
+		go func() { defer wg.Done(); m.RecordDropped() }()
+	}
+	wg.Wait()
+
+	snap := m.Snapshot()
+	if snap.FiredTotal[alertFiredKey{Rule: "r", Severity: "warning"}] != 100 {
+		t.Errorf("expected FiredTotal=100, got %d", snap.FiredTotal[alertFiredKey{Rule: "r", Severity: "warning"}])
+	}
+	if snap.DroppedTotal != 100 {
+		t.Errorf("expected DroppedTotal=100, got %d", snap.DroppedTotal)
+	}
+}
+
+// =============================================================================
+// Integration: shared metrics between Engine + Dispatcher
+// =============================================================================
+
+// TestAlertMetrics_SharedBetweenEngineAndDispatcher verifies that when the same
+// AlertMetrics instance is injected into both Engine and Dispatcher, a single
+// Engine.AlertSnapshot() call returns fired, dropped, AND delivery counters.
+func TestAlertMetrics_SharedBetweenEngineAndDispatcher(t *testing.T) {
+	cfg := &AlertConfig{
+		Enabled: true,
+		Rules: []AlertRule{
+			{
+				Name:        "task-failed-rule",
+				Type:        AlertTypeTaskFailed,
+				Severity:    SeverityCritical,
+				Description: "task failed",
+				Enabled:     true,
+				Channels:    []string{"mock-ch"},
+			},
+		},
+		Channels: []ChannelConfig{
+			{Name: "mock-ch", Type: "mock", Enabled: true},
+		},
+	}
+
+	m := NewAlertMetrics()
+	failCh := newMockChannel("mock-ch", "mock")
+	failCh.setError(errors.New("delivery failure"))
+
+	d := NewDispatcher(cfg, WithDispatcherMetrics(m))
+	d.RegisterChannel(failCh)
+
+	e := NewEngine(cfg, WithDispatcher(d), WithAlertMetrics(m))
+
+	// Directly exercise the delivery counter path.
+	d.metrics.RecordDelivery("mock-ch", "mock", "failure")
+
+	// Exercise the fired counter path.
+	m.RecordFired("task-failed-rule", "critical")
+
+	// Exercise the dropped counter path.
+	m.RecordDropped()
+
+	snap := e.AlertSnapshot()
+
+	if snap.FiredTotal[alertFiredKey{Rule: "task-failed-rule", Severity: "critical"}] != 1 {
+		t.Errorf("expected FiredTotal=1, got %d", snap.FiredTotal[alertFiredKey{Rule: "task-failed-rule", Severity: "critical"}])
+	}
+	if snap.DeliveryTotal[alertDeliveryKey{Channel: "mock-ch", Type: "mock", Result: "failure"}] != 1 {
+		t.Errorf("expected DeliveryTotal failure=1, got %d", snap.DeliveryTotal[alertDeliveryKey{Channel: "mock-ch", Type: "mock", Result: "failure"}])
+	}
+	if snap.DroppedTotal != 1 {
+		t.Errorf("expected DroppedTotal=1, got %d", snap.DroppedTotal)
+	}
+}
+
+// TestAlertMetrics_DropCounterViaProcessEvent verifies ProcessEvent increments the drop
+// counter when the event channel is full.
+func TestAlertMetrics_DropCounterViaProcessEvent(t *testing.T) {
+	cfg := &AlertConfig{Enabled: true}
+	m := NewAlertMetrics()
+	e := NewEngine(cfg, WithAlertMetrics(m))
+	// Flood the buffered channel (capacity=100) without a consumer.
+	for i := 0; i < 110; i++ {
+		e.ProcessEvent(Event{Type: EventTypeTaskFailed})
+	}
+
+	snap := e.AlertSnapshot()
+	if snap.DroppedTotal < 1 {
+		t.Errorf("expected DroppedTotal >= 1, got %d", snap.DroppedTotal)
+	}
+}
+
+// TestAlertMetrics_DeliveryCounterViaDispatcher verifies sendToChannel increments
+// the delivery counter on both success and failure paths.
+func TestAlertMetrics_DeliveryCounterViaDispatcher(t *testing.T) {
+	cfg := &AlertConfig{Enabled: true}
+	m := NewAlertMetrics()
+	d := NewDispatcher(cfg, WithDispatcherMetrics(m))
+
+	successCh := newMockChannel("ok-ch", "slack")
+	failCh := newMockChannel("fail-ch", "telegram")
+	failCh.setError(errors.New("boom"))
+
+	d.RegisterChannel(successCh)
+	d.RegisterChannel(failCh)
+
+	alert := &Alert{ID: "a1", Severity: SeverityCritical}
+	_ = d.Dispatch(context.Background(), alert, []string{"ok-ch", "fail-ch", "missing-ch"})
+
+	snap := m.Snapshot()
+
+	if snap.DeliveryTotal[alertDeliveryKey{Channel: "ok-ch", Type: "slack", Result: "success"}] != 1 {
+		t.Errorf("expected ok-ch/success=1, got %d", snap.DeliveryTotal[alertDeliveryKey{Channel: "ok-ch", Type: "slack", Result: "success"}])
+	}
+	if snap.DeliveryTotal[alertDeliveryKey{Channel: "fail-ch", Type: "telegram", Result: "failure"}] != 1 {
+		t.Errorf("expected fail-ch/failure=1, got %d", snap.DeliveryTotal[alertDeliveryKey{Channel: "fail-ch", Type: "telegram", Result: "failure"}])
+	}
+	// channel-not-found should also be recorded
+	if snap.DeliveryTotal[alertDeliveryKey{Channel: "missing-ch", Type: "unknown", Result: "failure"}] != 1 {
+		t.Errorf("expected missing-ch/unknown/failure=1, got %d", snap.DeliveryTotal[alertDeliveryKey{Channel: "missing-ch", Type: "unknown", Result: "failure"}])
+	}
+}

--- a/internal/gateway/prometheus.go
+++ b/internal/gateway/prometheus.go
@@ -6,12 +6,14 @@ import (
 	"sort"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/autopilot"
 )
 
 // PrometheusExporter formats metrics for Prometheus scraping.
 type PrometheusExporter struct {
 	metricsSource MetricsSource
+	alertsSource  AlertMetricsSource
 }
 
 // MetricsSource provides metrics data for the exporter.
@@ -20,9 +22,20 @@ type MetricsSource interface {
 	HistogramSnapshot() autopilot.HistogramData
 }
 
+// AlertMetricsSource provides alert metrics for the exporter.
+// *alerts.Engine satisfies this interface via its AlertSnapshot method.
+type AlertMetricsSource interface {
+	AlertSnapshot() alerts.AlertMetricsSnapshot
+}
+
 // NewPrometheusExporter creates a new Prometheus exporter.
 func NewPrometheusExporter(source MetricsSource) *PrometheusExporter {
 	return &PrometheusExporter{metricsSource: source}
+}
+
+// SetAlertsSource wires an alert metrics source into the exporter.
+func (e *PrometheusExporter) SetAlertsSource(s AlertMetricsSource) {
+	e.alertsSource = s
 }
 
 // WritePrometheus writes metrics in Prometheus text format to the writer.
@@ -195,6 +208,35 @@ func (e *PrometheusExporter) WritePrometheus(w io.Writer) error {
 		"CI wait duration",
 		hist.CIWaitDurations,
 		[]float64{30, 60, 120, 300, 600, 900, 1200, 1800, 3600}) // 30s, 1m, 2m, 5m, 10m, 15m, 20m, 30m, 1h
+
+	// --- Alert metrics (optional; only emitted when an AlertMetricsSource is wired) ---
+	if e.alertsSource != nil {
+		asnap := e.alertsSource.AlertSnapshot()
+
+		// alerts_fired_total{rule, severity}
+		writeHelp(w, "alerts_fired_total", "Total alerts fired by rule and severity")
+		writeType(w, "alerts_fired_total", "counter")
+		for k, v := range asnap.FiredTotal {
+			writeCounter(w, "alerts_fired_total", v, "rule", k.Rule, "severity", k.Severity)
+		}
+
+		// alert_delivery_total{channel, type, result}
+		writeHelp(w, "alert_delivery_total", "Total alert delivery attempts by channel, type, and result")
+		writeType(w, "alert_delivery_total", "counter")
+		for k, v := range asnap.DeliveryTotal {
+			writeCounter(w, "alert_delivery_total", v, "channel", k.Channel, "type", k.Type, "result", k.Result)
+		}
+
+		// alert_events_dropped_total
+		writeHelp(w, "alert_events_dropped_total", "Total alert events dropped due to a full event queue")
+		writeType(w, "alert_events_dropped_total", "counter")
+		writeCounter(w, "alert_events_dropped_total", asnap.DroppedTotal)
+
+		// alert_queue_depth
+		writeHelp(w, "alert_queue_depth", "Current number of events waiting in the alert event queue")
+		writeType(w, "alert_queue_depth", "gauge")
+		writeGauge(w, "alert_queue_depth", float64(asnap.QueueDepth))
+	}
 
 	return nil
 }

--- a/internal/gateway/prometheus_test.go
+++ b/internal/gateway/prometheus_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/autopilot"
 )
 
@@ -356,4 +357,116 @@ func TestMetricsEndpointWiring(t *testing.T) {
 			t.Errorf("expected 'Metrics not configured' in body, got: %s", w.Body.String())
 		}
 	})
+}
+
+// =============================================================================
+// Alert metrics tests (TASK-332)
+// =============================================================================
+
+// mockAlertSource implements AlertMetricsSource for testing.
+type mockAlertSource struct {
+	snap alerts.AlertMetricsSnapshot
+}
+
+func (s *mockAlertSource) AlertSnapshot() alerts.AlertMetricsSnapshot {
+	return s.snap
+}
+
+func TestPrometheusExporter_AlertMetrics_NotEmittedWhenNilSource(t *testing.T) {
+	exp := NewPrometheusExporter(&mockMetricsSource{})
+	var buf bytes.Buffer
+	if err := exp.WritePrometheus(&buf); err != nil {
+		t.Fatalf("WritePrometheus error: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "alerts_fired_total") {
+		t.Error("alert series should not appear when no AlertMetricsSource is wired")
+	}
+}
+
+func TestPrometheusExporter_AlertMetrics_SeriesRendered(t *testing.T) {
+	m := alerts.NewAlertMetrics()
+	m.RecordFired("task-failed-rule", "critical")
+	m.RecordFired("task-failed-rule", "critical")
+	m.RecordDelivery("slack-ops", "slack", "success")
+	m.RecordDelivery("slack-ops", "slack", "failure")
+	m.RecordDropped()
+
+	snap := m.Snapshot()
+	snap.QueueDepth = 7
+
+	exp := NewPrometheusExporter(&mockMetricsSource{})
+	exp.SetAlertsSource(&mockAlertSource{snap: snap})
+
+	var buf bytes.Buffer
+	if err := exp.WritePrometheus(&buf); err != nil {
+		t.Fatalf("WritePrometheus error: %v", err)
+	}
+	out := buf.String()
+
+	expectations := []string{
+		`# HELP alerts_fired_total`,
+		`# TYPE alerts_fired_total counter`,
+		`alerts_fired_total{rule="task-failed-rule",severity="critical"} 2`,
+		`# HELP alert_delivery_total`,
+		`# TYPE alert_delivery_total counter`,
+		`alert_delivery_total{channel="slack-ops",type="slack",result="success"} 1`,
+		`alert_delivery_total{channel="slack-ops",type="slack",result="failure"} 1`,
+		`# HELP alert_events_dropped_total`,
+		`# TYPE alert_events_dropped_total counter`,
+		`alert_events_dropped_total 1`,
+		`# HELP alert_queue_depth`,
+		`# TYPE alert_queue_depth gauge`,
+		`alert_queue_depth 7`,
+	}
+	for _, want := range expectations {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrometheusExporter_AlertMetrics_SetAlertsSourceViaServer(t *testing.T) {
+	srv := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+	srv.SetMetricsSource(&mockMetricsSource{})
+
+	m := alerts.NewAlertMetrics()
+	m.RecordFired("stuck-task", "warning")
+	snap := m.Snapshot()
+
+	srv.SetAlertsMetricsSource(&mockAlertSource{snap: snap})
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.handleMetrics(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `alerts_fired_total{rule="stuck-task",severity="warning"} 1`) {
+		t.Errorf("alert series not found in output:\n%s", w.Body.String())
+	}
+}
+
+func TestPrometheusExporter_AlertMetrics_SetAlertsSourceBeforeMetricsSource(t *testing.T) {
+	// Verify SetAlertsMetricsSource is safe to call before SetMetricsSource
+	srv := NewServer(&Config{Host: "127.0.0.1", Port: 0})
+
+	m := alerts.NewAlertMetrics()
+	m.RecordDropped()
+	snap := m.Snapshot()
+
+	srv.SetAlertsMetricsSource(&mockAlertSource{snap: snap})
+	srv.SetMetricsSource(&mockMetricsSource{}) // exporter created after alertsSource is stored
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.handleMetrics(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "alert_events_dropped_total 1") {
+		t.Errorf("alert_events_dropped_total not found:\n%s", w.Body.String())
+	}
 }

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -78,6 +78,7 @@ type Server struct {
 	readinessCheckers      []ReadinessChecker
 	liveness               *livenessState
 	prometheusExporter     *PrometheusExporter
+	alertsSource           AlertMetricsSource
 	autopilotProvider      AutopilotProvider
 	dashboardStore         DashboardStore
 	logStreamStore         LogStreamStore
@@ -281,6 +282,20 @@ func (s *Server) SetMetricsSource(source MetricsSource) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.prometheusExporter = NewPrometheusExporter(source)
+	if s.alertsSource != nil {
+		s.prometheusExporter.SetAlertsSource(s.alertsSource)
+	}
+}
+
+// SetAlertsMetricsSource wires an alert metrics source into the Prometheus exporter.
+// Safe to call before or after SetMetricsSource.
+func (s *Server) SetAlertsMetricsSource(source AlertMetricsSource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.alertsSource = source
+	if s.prometheusExporter != nil {
+		s.prometheusExporter.SetAlertsSource(source)
+	}
 }
 
 // SetAutopilotProvider sets the autopilot provider for the /api/v1/autopilot endpoint.


### PR DESCRIPTION
## Summary

- Adds `AlertMetrics` struct (`internal/alerts/metrics.go`) tracking four counters: `alerts_fired_total{rule,severity}`, `alert_delivery_total{channel,type,result}`, `alert_events_dropped_total`, and `alert_queue_depth`
- Instruments `Engine.ProcessEvent` (drop counter), `Engine.fireAlert` (fired counter), `Dispatcher.sendToChannel` (delivery success/failure), and `Dispatcher.Dispatch` channel-not-found (delivery failure)
- Exposes `Engine.AlertSnapshot()` which satisfies the new `AlertMetricsSource` interface in `gateway/prometheus.go`
- Wires alert metrics into the Prometheus exporter via `Server.SetAlertsMetricsSource`; both the gateway-polling and standalone-polling paths in `main.go` share one `AlertMetrics` instance between engine and dispatcher
- Series are omitted entirely when no `AlertMetricsSource` is configured (backwards compatible)

## Test plan

- [ ] `go test ./internal/alerts/...` — 10 new tests in `metrics_test.go` cover: counter goroutine-safety, snapshot copy semantics, drop counter via ProcessEvent, delivery counter via Dispatcher (success + failure + channel-not-found), shared metrics integration
- [ ] `go test ./internal/gateway/...` — 4 new tests in `prometheus_test.go` cover: series absent when source is nil, series rendered for all four metrics, wired via Server.SetAlertsMetricsSource, SetAlertsMetricsSource called before SetMetricsSource
- [ ] `go build ./...` passes
- [ ] `golangci-lint run --new-from-rev=origin/main` — 0 issues

Closes #3305