### PR TITLE
feat(autopilot): wire scope-drift/size-floor merge-escalation gates (TASK-325)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -742,13 +742,49 @@ func (c *Controller) handleWaitingCI(ctx context.Context, prState *PRState, ghPR
 	return nil
 }
 
-// handleCIPassed proceeds to merge (with approval if required by environment config).
+// handleCIPassed proceeds to merge (with approval if required by environment config
+// or by the scope-drift / size-floor defense-in-depth rails).
 func (c *Controller) handleCIPassed(ctx context.Context, prState *PRState) error {
 	c.log.Info("handleCIPassed: CI passed, determining next stage",
 		"pr", prState.PRNumber,
 		"env", c.config.EnvironmentName(),
 		"auto_merge", c.config.AutoMerge,
 	)
+
+	// Defense-in-depth: scope-drift and size-floor gates escalate to human approval
+	// regardless of env RequireApproval config. Born from OAuth cascade #2
+	// (#2572/#2584/#2585): a runaway executor must not land oversized or scope-drifting
+	// code unsupervised even when env config drops require_approval.
+	var escalateReason string
+	files, listErr := c.ghClient.ListPullRequestFiles(ctx, c.owner, c.repo, prState.PRNumber)
+	if listErr != nil {
+		c.log.Warn("handleCIPassed: ListPullRequestFiles failed, skipping size-floor gate (fail-open)",
+			"pr", prState.PRNumber, "error", listErr)
+	} else if reason := SizeFloorReason(files); reason != "" {
+		escalateReason = reason
+	}
+
+	if escalateReason == "" && prState.IssueNumber > 0 {
+		issue, issueErr := c.ghClient.GetIssue(ctx, c.owner, c.repo, prState.IssueNumber)
+		if issueErr != nil {
+			c.log.Warn("handleCIPassed: GetIssue failed, skipping scope-drift gate (fail-open)",
+				"pr", prState.PRNumber, "issue", prState.IssueNumber, "error", issueErr)
+		} else if reason := ScopeDriftReason(prState.PRTitle, issue.Title); reason != "" {
+			escalateReason = reason
+		}
+	}
+
+	if escalateReason != "" {
+		c.log.Warn("merge gate escalated: requiring human approval",
+			"pr", prState.PRNumber, "reason", escalateReason)
+		prState.Stage = StageAwaitApproval
+		if c.notifier != nil {
+			if err := c.notifier.NotifyApprovalRequired(ctx, prState); err != nil {
+				c.log.Warn("failed to send approval notification", "error", err)
+			}
+		}
+		return nil
+	}
 
 	if c.config.ResolvedEnv().RequireApproval {
 		c.log.Info("awaiting approval before merge", "pr", prState.PRNumber)
@@ -837,7 +873,7 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 		if err != nil {
 			c.log.Warn("CI fix size guard: ListPullRequestFiles failed, skipping guard (fail-open)",
 				"pr", prState.PRNumber, "error", err)
-			// Fall through — belt-and-suspenders: merge-time SizeFloor (#2594) still catches it.
+			// Fall through — belt-and-suspenders: merge-time SizeFloor gate in handleCIPassed catches it.
 		} else {
 			netAdditions := 0
 			for _, f := range files {

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6574,3 +6574,128 @@ func TestController_handleCIFailed_BoardSync_Regression_NormalPath(t *testing.T)
 			issueNodeID, "Blocked", mock.calls)
 	}
 }
+
+// TestHandleCIPassed_SizeFloorEscalation verifies that a PR exceeding the size
+// floor (300 net additions > 200 threshold) is routed to StageAwaitApproval even
+// when RequireApproval is false.
+func TestHandleCIPassed_SizeFloorEscalation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls/77/files" && r.Method == http.MethodGet {
+			files := []*github.PRFile{
+				{Filename: "a.go", Status: "modified", Additions: 300},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, files))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev // RequireApproval = false
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	prState := &PRState{
+		PRNumber: 77,
+		PRTitle:  "fix(auth): fix bug",
+		Stage:    StageCIPassed,
+	}
+
+	if err := c.handleCIPassed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIPassed returned unexpected error: %v", err)
+	}
+	if prState.Stage != StageAwaitApproval {
+		t.Errorf("expected StageAwaitApproval for oversized PR, got %v", prState.Stage)
+	}
+}
+
+// TestHandleCIPassed_ScopeDriftEscalation verifies that a PR whose conventional-
+// commit type diverges from the linked issue's title is routed to StageAwaitApproval
+// even when RequireApproval is false.
+func TestHandleCIPassed_ScopeDriftEscalation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/78/files" && r.Method == http.MethodGet:
+			// Small PR — size floor should not fire.
+			files := []*github.PRFile{
+				{Filename: "a.go", Status: "modified", Additions: 10},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, files))
+		case r.URL.Path == "/repos/owner/repo/issues/50" && r.Method == http.MethodGet:
+			resp := github.Issue{Number: 50, Title: "fix(auth): fix login bug"}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev // RequireApproval = false
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	prState := &PRState{
+		PRNumber:    78,
+		IssueNumber: 50,
+		// feat type diverges from the fix issue title — scope drift gate fires.
+		PRTitle: "feat(auth): add OAuth",
+		Stage:   StageCIPassed,
+	}
+
+	if err := c.handleCIPassed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIPassed returned unexpected error: %v", err)
+	}
+	if prState.Stage != StageAwaitApproval {
+		t.Errorf("expected StageAwaitApproval for scope-drifting PR, got %v", prState.Stage)
+	}
+}
+
+// TestHandleCIPassed_SmallInScopePRMerges verifies that a small, in-scope PR with
+// RequireApproval=false proceeds to StageMerging (no false positives from the gates).
+func TestHandleCIPassed_SmallInScopePRMerges(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/79/files" && r.Method == http.MethodGet:
+			files := []*github.PRFile{
+				{Filename: "a.go", Status: "modified", Additions: 50},
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, files))
+		case r.URL.Path == "/repos/owner/repo/issues/51" && r.Method == http.MethodGet:
+			resp := github.Issue{Number: 51, Title: "fix(auth): fix login bug"}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(mustJSON(t, resp))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev // RequireApproval = false
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	prState := &PRState{
+		PRNumber:    79,
+		IssueNumber: 51,
+		// Same type+scope as the issue — no drift.
+		PRTitle: "fix(auth): fix login bug",
+		Stage:   StageCIPassed,
+	}
+
+	if err := c.handleCIPassed(context.Background(), prState); err != nil {
+		t.Fatalf("handleCIPassed returned unexpected error: %v", err)
+	}
+	if prState.Stage != StageMerging {
+		t.Errorf("expected StageMerging for small in-scope PR, got %v", prState.Stage)
+	}
+}


### PR DESCRIPTION
## Summary

- `ScopeDriftReason` and `SizeFloorReason` (born from OAuth cascade #2) were defined in `scope_guard.go` but had **zero production callers**, leaving the cascade-2 attack surface open whenever `require_approval` was not set.
- `handleCIPassed` now calls both gates before the env-config branch. If either fires, the PR is forced to `StageAwaitApproval` **regardless of env config**.
- Fails open on API errors (transient GitHub outage never blocks a merge unnecessarily).
- Fixes the false "belt-and-suspenders" comment in `handleCIFailed` that claimed `SizeFloor` was wired at merge time.

## Test plan

- [ ] `TestHandleCIPassed_SizeFloorEscalation` — 300 net-LoC PR → `StageAwaitApproval` (not `StageMerging`)
- [ ] `TestHandleCIPassed_ScopeDriftEscalation` — feat-PR linked to a fix-issue → `StageAwaitApproval`
- [ ] `TestHandleCIPassed_SmallInScopePRMerges` — small, in-scope PR with `RequireApproval=false` → `StageMerging` (no false positives)
- [ ] Full `internal/autopilot` test suite: all 6576 lines pass with no regressions
- [ ] `golangci-lint run --new-from-rev=origin/main ./internal/autopilot/...` → 0 issues