### PR TITLE
fix(alerts): honor context + enforce STARTTLS in SMTP sender (TASK-331)

### DIFF
--- a/internal/alerts/smtp.go
+++ b/internal/alerts/smtp.go
@@ -2,7 +2,9 @@ package alerts
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
 	"net/smtp"
 	"strings"
 )
@@ -14,21 +16,45 @@ type SMTPSender struct {
 	from     string
 	username string
 	password string
+
+	// allowInsecure permits delivery to a server that does not advertise
+	// STARTTLS. It defaults to false, so credentials and alert bodies are never
+	// sent in cleartext unless an operator explicitly opts in for a trusted
+	// internal relay. (Set via SetAllowInsecure.)
+	allowInsecure bool
+	// tlsConfig is used for the STARTTLS upgrade. Defaults to verifying the
+	// server certificate against host. Overridable for tests via SetTLSConfig.
+	tlsConfig *tls.Config
 }
 
 // NewSMTPSender creates a new SMTP email sender.
 func NewSMTPSender(host string, port int, from, username, password string) *SMTPSender {
 	return &SMTPSender{
-		host:     host,
-		port:     port,
-		from:     from,
-		username: username,
-		password: password,
+		host:      host,
+		port:      port,
+		from:      from,
+		username:  username,
+		password:  password,
+		tlsConfig: &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12},
 	}
 }
 
+// SetAllowInsecure permits sending without STARTTLS (trusted internal relays).
+// Off by default; turning it on re-enables cleartext transmission.
+func (s *SMTPSender) SetAllowInsecure(allow bool) { s.allowInsecure = allow }
+
+// SetTLSConfig overrides the STARTTLS client config.
+func (s *SMTPSender) SetTLSConfig(cfg *tls.Config) { s.tlsConfig = cfg }
+
 // Send sends an HTML email via SMTP.
-func (s *SMTPSender) Send(_ context.Context, to []string, subject, htmlBody string) error {
+//
+// TASK-331: it honors ctx (so the dispatcher's per-channel timeout is enforced
+// and a wedged mail server cannot block the dispatch worker indefinitely) and
+// prefers STARTTLS, refusing to transmit credentials/alert bodies in cleartext
+// unless allowInsecure is set. The previous implementation used
+// net/smtp.SendMail, which ignored the context (raw TCP, no deadline) and would
+// silently fall back to plaintext on port 25.
+func (s *SMTPSender) Send(ctx context.Context, to []string, subject, htmlBody string) error {
 	addr := fmt.Sprintf("%s:%d", s.host, s.port)
 
 	// Build MIME message
@@ -41,10 +67,65 @@ func (s *SMTPSender) Send(_ context.Context, to []string, subject, htmlBody stri
 	msg.WriteString("\r\n")
 	msg.WriteString(htmlBody)
 
-	var auth smtp.Auth
-	if s.username != "" {
-		auth = smtp.PlainAuth("", s.username, s.password, s.host)
+	// Context-aware dial: aborts if ctx is cancelled/expires before connect.
+	dialer := net.Dialer{}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return fmt.Errorf("smtp dial %s: %w", addr, err)
+	}
+	// Propagate the context deadline to the connection so the SMTP conversation
+	// (greeting, EHLO, STARTTLS, AUTH, DATA) also fails fast instead of blocking
+	// on OS-level TCP timeouts when the server stalls mid-exchange.
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
 	}
 
-	return smtp.SendMail(addr, auth, s.from, to, []byte(msg.String()))
+	client, err := smtp.NewClient(conn, s.host)
+	if err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("smtp new client: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	// Prefer STARTTLS; refuse cleartext unless explicitly allowed.
+	if ok, _ := client.Extension("STARTTLS"); ok {
+		cfg := s.tlsConfig
+		if cfg == nil {
+			cfg = &tls.Config{ServerName: s.host, MinVersion: tls.VersionTLS12}
+		}
+		if err := client.StartTLS(cfg); err != nil {
+			return fmt.Errorf("smtp starttls: %w", err)
+		}
+	} else if !s.allowInsecure {
+		return fmt.Errorf("smtp server %s does not advertise STARTTLS; refusing to send in cleartext (enable allowInsecure for trusted relays)", s.host)
+	}
+
+	if s.username != "" {
+		if err := client.Auth(smtp.PlainAuth("", s.username, s.password, s.host)); err != nil {
+			return fmt.Errorf("smtp auth: %w", err)
+		}
+	}
+
+	if err := client.Mail(s.from); err != nil {
+		return fmt.Errorf("smtp mail from %s: %w", s.from, err)
+	}
+	for _, rcpt := range to {
+		if err := client.Rcpt(rcpt); err != nil {
+			return fmt.Errorf("smtp rcpt %s: %w", rcpt, err)
+		}
+	}
+
+	w, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("smtp data: %w", err)
+	}
+	if _, err := w.Write([]byte(msg.String())); err != nil {
+		_ = w.Close()
+		return fmt.Errorf("smtp write body: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("smtp data close: %w", err)
+	}
+
+	return client.Quit()
 }

--- a/internal/alerts/smtp_test.go
+++ b/internal/alerts/smtp_test.go
@@ -3,8 +3,10 @@ package alerts
 import (
 	"context"
 	"net"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // =============================================================================
@@ -145,6 +147,7 @@ func TestSMTPSender_Send_WithFakeServer(t *testing.T) {
 	}
 
 	s := NewSMTPSender(host, port, "from@example.com", "", "")
+	s.SetAllowInsecure(true) // plaintext fake server: exercise protocol behavior
 
 	err := s.Send(
 		context.Background(),
@@ -185,6 +188,7 @@ func TestSMTPSender_Send_MultipleRecipients(t *testing.T) {
 	}
 
 	s := NewSMTPSender(host, port, "from@example.com", "", "")
+	s.SetAllowInsecure(true) // plaintext fake server
 
 	err := s.Send(
 		context.Background(),
@@ -213,6 +217,7 @@ func TestSMTPSender_Send_MIMEHeaders(t *testing.T) {
 	}
 
 	s := NewSMTPSender(host, port, "alerts@pilot.dev", "", "")
+	s.SetAllowInsecure(true) // plaintext fake server
 
 	err := s.Send(
 		context.Background(),
@@ -238,6 +243,65 @@ func TestSMTPSender_ImplementsEmailSender(t *testing.T) {
 	var _ EmailSender = (*SMTPSender)(nil)
 }
 
+// TASK-331: by default (allowInsecure=false) a server that does not advertise
+// STARTTLS must be refused rather than sent to in cleartext.
+func TestSMTPSender_Send_RefusesCleartextByDefault(t *testing.T) {
+	addr, _, cleanup := fakeSMTPServer(t) // plaintext fake server, no STARTTLS
+	defer cleanup()
+
+	host, portStr, _ := net.SplitHostPort(addr)
+	port, _ := strconv.Atoi(portStr)
+
+	s := NewSMTPSender(host, port, "from@example.com", "user", "pass") // allowInsecure defaults to false
+
+	err := s.Send(context.Background(), []string{"to@example.com"}, "Test", "<h1>Hi</h1>")
+	if err == nil {
+		t.Fatal("expected Send to refuse a non-STARTTLS server by default")
+	}
+	if !strings.Contains(err.Error(), "STARTTLS") {
+		t.Errorf("expected a STARTTLS-refusal error, got: %v", err)
+	}
+}
+
+// TASK-331: Send must honor the context deadline so a wedged server cannot block
+// the dispatch worker past the dispatcher's per-channel timeout.
+func TestSMTPSender_Send_HonorsContextDeadline(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	// Accept the connection but never send the SMTP greeting — the client read
+	// must time out at the context deadline rather than hanging.
+	go func() {
+		conn, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		time.Sleep(3 * time.Second)
+		_ = conn.Close()
+	}()
+
+	host, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+	s := NewSMTPSender(host, port, "from@example.com", "", "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err = s.Send(ctx, []string{"to@example.com"}, "Test", "<h1>Hi</h1>")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from a stalled server")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("Send did not honor the context deadline; took %v (want well under 2s)", elapsed)
+	}
+}
+
 // =============================================================================
 // Integration with EmailChannel
 // =============================================================================
@@ -253,6 +317,7 @@ func TestSMTPSender_WithEmailChannel(t *testing.T) {
 	}
 
 	sender := NewSMTPSender(host, port, "alerts@pilot.dev", "", "")
+	sender.SetAllowInsecure(true) // plaintext fake server
 
 	config := &EmailChannelConfig{
 		To:      []string{"admin@example.com"},


### PR DESCRIPTION
Closes #3304. **Manual implementation** — Pilot stalled on this 4× (`no agent event >3m`): implementing/testing the SMTP timeout fix runs the very blocking SMTP path the task fixes, hanging its own agent past the watchdog.

## TASK-322 §high (SMTP discards context) + §medium (plaintext)
`SMTPSender.Send` ignored its context and used `net/smtp.SendMail` (raw TCP, no deadline, silent plaintext fallback). A wedged mail server could block the dispatch worker minutes past the dispatcher's 30s timeout; credentials/alert bodies could transit in cleartext.

### Change
- `DialContext` + propagate the ctx deadline to the conn, then run the SMTP conversation manually (greeting/EHLO/STARTTLS/AUTH/MAIL/RCPT/DATA) so the whole exchange fails fast on a stall.
- **Prefer STARTTLS; refuse cleartext by default** — fail when the server doesn't advertise STARTTLS unless `allowInsecure` is explicitly set for a trusted internal relay (fail-closed escape-hatch, mirrors TASK-326's webhook pattern).
- New tests: `RefusesCleartextByDefault` and `HonorsContextDeadline` (returns at the 300ms deadline, not the 3s stall). Existing protocol tests opt into `allowInsecure` against the plaintext fake server.

### Verification
`go build ./...` ✅ · `go vet ./internal/alerts/` ✅ · `go test ./internal/alerts/` ✅