### PR TITLE
fix(gateway): preserve raw webhook body for jira/asana body-HMAC (TASK-333)

### DIFF
--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -660,14 +660,24 @@ func (s *Server) handleJiraWebhook(w http.ResponseWriter, r *http.Request) {
 	// Jira may send signature in header (if configured)
 	signature := r.Header.Get("X-Hub-Signature")
 
+	// Read the raw body once. Body-HMAC verification (TASK-333) must run over
+	// the exact bytes Jira signed; decoding into a map and re-marshaling would
+	// not reproduce them. Decode from the buffered bytes after stashing them.
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Failed to read request body", http.StatusBadRequest)
+		return
+	}
+
 	var payload map[string]interface{}
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+	if err := json.Unmarshal(body, &payload); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
 
 	// Add metadata to payload for handler
 	payload["_signature"] = signature
+	payload["_raw_body"] = string(body)
 
 	webhookEvent, _ := payload["webhookEvent"].(string)
 	logging.WithComponent("gateway").Info("Received Jira webhook", slog.String("event", webhookEvent))
@@ -725,14 +735,24 @@ func (s *Server) handleAsanaWebhook(w http.ResponseWriter, r *http.Request) {
 	// Asana sends signature in X-Hook-Signature header
 	signature := r.Header.Get("X-Hook-Signature")
 
+	// Read the raw body once. Body-HMAC verification (TASK-333) must run over
+	// the exact bytes Asana signed; decoding into a map and re-marshaling would
+	// not reproduce them. Decode from the buffered bytes after stashing them.
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Failed to read request body", http.StatusBadRequest)
+		return
+	}
+
 	var payload map[string]interface{}
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+	if err := json.Unmarshal(body, &payload); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
 
 	// Add metadata to payload for handler
 	payload["_signature"] = signature
+	payload["_raw_body"] = string(body)
 
 	logging.WithComponent("gateway").Info("Received Asana webhook")
 

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -948,6 +948,81 @@ func TestJiraWebhookTableDriven(t *testing.T) {
 	}
 }
 
+// TestJiraWebhookPreservesRawBody asserts the gateway buffers the exact request
+// body into payload["_raw_body"] (TASK-333) so downstream body-HMAC verification
+// runs over the bytes Jira signed, and that JSON still decodes from the buffer.
+func TestJiraWebhookPreservesRawBody(t *testing.T) {
+	config := &Config{Host: "127.0.0.1", Port: 9090}
+	server := NewServer(config)
+
+	var captured map[string]interface{}
+	server.Router().RegisterWebhookHandler("jira", func(payload map[string]interface{}) {
+		captured = payload
+	})
+
+	// Non-canonical formatting (whitespace + key order) that json.Marshal would
+	// not reproduce — proves the raw bytes are preserved verbatim.
+	rawBody := `{ "webhookEvent":  "jira:issue_created", "issue": {"key":"PROJ-9"} }`
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/jira", strings.NewReader(rawBody))
+	req.Header.Set("X-Hub-Signature", "sha256=deadbeef")
+	w := httptest.NewRecorder()
+
+	server.handleJiraWebhook(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if captured == nil {
+		t.Fatal("webhook was not routed to the registered handler")
+	}
+	if got := captured["_raw_body"]; got != rawBody {
+		t.Errorf("_raw_body = %q, want exact request body %q", got, rawBody)
+	}
+	if got := captured["_signature"]; got != "sha256=deadbeef" {
+		t.Errorf("_signature = %q, want propagated header", got)
+	}
+	// JSON still decoded from the buffered bytes.
+	if got := captured["webhookEvent"]; got != "jira:issue_created" {
+		t.Errorf("decoded webhookEvent = %q, want jira:issue_created", got)
+	}
+}
+
+// TestAsanaWebhookPreservesRawBody asserts the gateway buffers the exact request
+// body into payload["_raw_body"] (TASK-333) for body-HMAC verification, and that
+// JSON still decodes from the buffer.
+func TestAsanaWebhookPreservesRawBody(t *testing.T) {
+	config := &Config{Host: "127.0.0.1", Port: 9090}
+	server := NewServer(config)
+
+	var captured map[string]interface{}
+	server.Router().RegisterWebhookHandler("asana", func(payload map[string]interface{}) {
+		captured = payload
+	})
+
+	rawBody := `{ "events":  [ {"action":"changed"} ] }`
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/asana", strings.NewReader(rawBody))
+	req.Header.Set("X-Hook-Signature", "abc123")
+	w := httptest.NewRecorder()
+
+	server.handleAsanaWebhook(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if captured == nil {
+		t.Fatal("webhook was not routed to the registered handler")
+	}
+	if got := captured["_raw_body"]; got != rawBody {
+		t.Errorf("_raw_body = %q, want exact request body %q", got, rawBody)
+	}
+	if got := captured["_signature"]; got != "abc123" {
+		t.Errorf("_signature = %q, want propagated header", got)
+	}
+	if _, ok := captured["events"]; !ok {
+		t.Error("decoded payload missing 'events' — JSON did not decode from buffer")
+	}
+}
+
 func TestLinearWebhookTableDriven(t *testing.T) {
 	config := &Config{Host: "127.0.0.1", Port: 9090}
 	server := NewServer(config)

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/qf-studio/pilot/internal/adapters/asana"
@@ -474,15 +473,11 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 	if p.jiraWH != nil {
 		p.gateway.Router().RegisterWebhookHandler("jira", func(payload map[string]interface{}) {
 			signature, _ := payload["_signature"].(string)
-			// TODO(F2): The gateway currently JSON-decodes before calling handlers, so
-			// VerifySignature runs on re-marshaled bytes that may differ from the original
-			// body. This is best-effort verification until raw-body preservation is added.
-			sigBytes, err := marshalWebhookPayload(payload)
-			if err != nil {
-				logging.WithComponent("pilot").Error("Failed to marshal Jira payload for signature check", slog.Any("error", err))
-				return
-			}
-			if !p.jiraWH.VerifySignature(sigBytes, signature) {
+			// TASK-333: verify the HMAC over the exact raw request body the gateway
+			// buffered, not a re-marshaled map (which would not reproduce the bytes
+			// Jira signed).
+			rawBody, _ := payload["_raw_body"].(string)
+			if !p.jiraWH.VerifySignature([]byte(rawBody), signature) {
 				logging.WithComponent("pilot").Warn("Jira webhook signature verification failed")
 				return
 			}
@@ -525,15 +520,11 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 	if p.asanaWH != nil {
 		p.gateway.Router().RegisterWebhookHandler("asana", func(payload map[string]interface{}) {
 			signature, _ := payload["_signature"].(string)
-			// TODO(F2): The gateway currently JSON-decodes before calling handlers, so
-			// VerifySignature runs on re-marshaled bytes that may differ from the original
-			// body. This is best-effort verification until raw-body preservation is added.
-			sigBytes, err := marshalWebhookPayload(payload)
-			if err != nil {
-				logging.WithComponent("pilot").Error("Failed to marshal Asana payload for signature check", slog.Any("error", err))
-				return
-			}
-			if !p.asanaWH.VerifySignature(sigBytes, signature) {
+			// TASK-333: verify the HMAC over the exact raw request body the gateway
+			// buffered, not a re-marshaled map (which would not reproduce the bytes
+			// Asana signed).
+			rawBody, _ := payload["_raw_body"].(string)
+			if !p.asanaWH.VerifySignature([]byte(rawBody), signature) {
 				logging.WithComponent("pilot").Warn("Asana webhook signature verification failed")
 				return
 			}
@@ -1541,17 +1532,4 @@ func (p *Pilot) convertAlertsConfig(cfg *config.AlertsConfig) *alerts.AlertConfi
 	}
 
 	return alerts.FromConfigAlerts(cfg.Enabled, channels, rules, defaults)
-}
-
-// marshalWebhookPayload marshals a gateway payload map to JSON, excluding internal
-// metadata keys (prefixed with "_") injected by the gateway layer. Used to produce
-// canonical bytes for HMAC verification before signature material is mixed in.
-func marshalWebhookPayload(payload map[string]interface{}) ([]byte, error) {
-	filtered := make(map[string]interface{}, len(payload))
-	for k, v := range payload {
-		if !strings.HasPrefix(k, "_") {
-			filtered[k] = v
-		}
-	}
-	return json.Marshal(filtered)
 }

--- a/internal/pilot/webhook_handlers_test.go
+++ b/internal/pilot/webhook_handlers_test.go
@@ -22,8 +22,9 @@ func computeTestHMAC(secret string, payload []byte) string {
 	return hex.EncodeToString(mac.Sum(nil))
 }
 
-// TestJiraWebhookSignatureGating asserts that Handle is NOT reached when the
-// signature is invalid — mirroring pilot.go's registered jira handler.
+// TestJiraWebhookSignatureGating asserts that Handle is gated on a body-HMAC
+// computed over the exact raw request body the gateway buffered (TASK-333),
+// mirroring pilot.go's registered jira handler.
 func TestJiraWebhookSignatureGating(t *testing.T) {
 	router := gateway.NewRouter()
 	wh := jira.NewWebhookHandler(nil, testutil.FakeWebhookSecret, "pilot")
@@ -35,42 +36,59 @@ func TestJiraWebhookSignatureGating(t *testing.T) {
 	})
 
 	ctx := context.Background()
+	// Mirror pilot.go: verify over payload["_raw_body"], not a re-marshaled map.
 	router.RegisterWebhookHandler("jira", func(payload map[string]interface{}) {
 		signature, _ := payload["_signature"].(string)
-		sigBytes, err := marshalWebhookPayload(payload)
-		if err != nil {
-			return
-		}
-		if !wh.VerifySignature(sigBytes, signature) {
+		rawBody, _ := payload["_raw_body"].(string)
+		if !wh.VerifySignature([]byte(rawBody), signature) {
 			return
 		}
 		_ = wh.Handle(ctx, payload)
 	})
 
+	// Non-canonical body (whitespace + key order json.Marshal would not
+	// reproduce). The pre-TASK-333 re-marshal path would reject a valid HMAC
+	// over these bytes; raw-body verification accepts it.
+	rawBody := `{ "webhookEvent":  "jira:issue_updated", "issue": {"key":"PROJ-1"} }`
+	validSig := computeTestHMAC(testutil.FakeWebhookSecret, []byte(rawBody))
+
 	t.Run("bad signature blocks Handle", func(t *testing.T) {
+		handleCalled = false
 		router.HandleWebhook("jira", map[string]interface{}{
-			"_signature":   "bad-signature",
-			"webhookEvent": "jira:issue_created",
+			"_signature": "bad-signature",
+			"_raw_body":  rawBody,
 		})
 		if handleCalled {
 			t.Error("Handle must not be called when signature is invalid")
 		}
 	})
 
-	t.Run("valid signature reaches Handle", func(t *testing.T) {
-		// Build the payload that pilot's marshalWebhookPayload will see (no _ keys).
-		inner := map[string]interface{}{"webhookEvent": "jira:issue_updated"}
-		innerBytes, _ := json.Marshal(inner)
-		sig := computeTestHMAC(testutil.FakeWebhookSecret, innerBytes)
-
+	t.Run("tampered body blocks Handle", func(t *testing.T) {
 		handleCalled = false
 		router.HandleWebhook("jira", map[string]interface{}{
-			"_signature":   sig,
-			"webhookEvent": "jira:issue_updated",
+			"_signature": validSig,
+			"_raw_body":  rawBody + " ", // mutated after signing
 		})
-		// Handle is reached (event type is unsupported so onIssue won't fire, but
-		// Handle itself returns nil without error — the gate was passed).
-		_ = handleCalled // gate check: no panic / early return from the handler
+		if handleCalled {
+			t.Error("Handle must not be called when the body was tampered after signing")
+		}
+	})
+
+	t.Run("valid body-HMAC over raw bytes passes the gate", func(t *testing.T) {
+		// The whole point of TASK-333: an HMAC over the exact raw bytes passes.
+		if !wh.VerifySignature([]byte(rawBody), validSig) {
+			t.Fatal("valid HMAC over the raw body must pass — TASK-333 regression")
+		}
+		// Decode the buffered bytes into the routed map exactly as server.go does,
+		// then route. issue_updated with no changelog returns before any client
+		// call, so this asserts the gate passed without panicking.
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(rawBody), &payload); err != nil {
+			t.Fatalf("raw body must decode: %v", err)
+		}
+		payload["_signature"] = validSig
+		payload["_raw_body"] = rawBody
+		router.HandleWebhook("jira", payload)
 	})
 }
 
@@ -87,13 +105,11 @@ func TestAsanaWebhookSignatureGating(t *testing.T) {
 	})
 
 	ctx := context.Background()
+	// Mirror pilot.go: verify over payload["_raw_body"], not a re-marshaled map.
 	router.RegisterWebhookHandler("asana", func(payload map[string]interface{}) {
 		signature, _ := payload["_signature"].(string)
-		sigBytes, err := marshalWebhookPayload(payload)
-		if err != nil {
-			return
-		}
-		if !wh.VerifySignature(sigBytes, signature) {
+		rawBody, _ := payload["_raw_body"].(string)
+		if !wh.VerifySignature([]byte(rawBody), signature) {
 			return
 		}
 		payloadBytes, err := json.Marshal(payload)
@@ -107,14 +123,43 @@ func TestAsanaWebhookSignatureGating(t *testing.T) {
 		_ = wh.Handle(ctx, &wp)
 	})
 
+	// Non-canonical body whose re-marshaling would differ from the raw bytes.
+	rawBody := `{ "events": [] }`
+	validSig := computeTestHMAC(testutil.FakeAsanaWebhookSecret, []byte(rawBody))
+
 	t.Run("bad signature blocks Handle", func(t *testing.T) {
+		handleCalled = false
 		router.HandleWebhook("asana", map[string]interface{}{
 			"_signature": "bad-signature",
-			"events":     []interface{}{},
+			"_raw_body":  rawBody,
 		})
 		if handleCalled {
 			t.Error("Handle must not be called when signature is invalid")
 		}
+	})
+
+	t.Run("tampered body blocks Handle", func(t *testing.T) {
+		handleCalled = false
+		router.HandleWebhook("asana", map[string]interface{}{
+			"_signature": validSig,
+			"_raw_body":  rawBody + " ", // mutated after signing
+		})
+		if handleCalled {
+			t.Error("Handle must not be called when the body was tampered after signing")
+		}
+	})
+
+	t.Run("valid body-HMAC over raw bytes passes the gate", func(t *testing.T) {
+		if !wh.VerifySignature([]byte(rawBody), validSig) {
+			t.Fatal("valid HMAC over the raw body must pass — TASK-333 regression")
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(rawBody), &payload); err != nil {
+			t.Fatalf("raw body must decode: %v", err)
+		}
+		payload["_signature"] = validSig
+		payload["_raw_body"] = rawBody
+		router.HandleWebhook("asana", payload) // gate passed; empty events → no callback
 	})
 }
 


### PR DESCRIPTION
## What

Closes the structural gap that made true body-HMAC verification impossible for the **jira** and **asana** webhook paths.

The gateway decoded their request bodies with `json.NewDecoder(r.Body)` **before** any handler ran, destroying the raw bytes a body-HMAC needs. `VerifySignature` then ran over **re-marshaled** bytes (`marshalWebhookPayload`) that may not reproduce what the provider signed (key order, whitespace) — best-effort at best, flagged in-code as `TODO(F2)`.

## How

Mirror the existing **Plane** handler pattern:

- **`internal/gateway/server.go`** — `handleJiraWebhook` / `handleAsanaWebhook` now `io.ReadAll` the body once, `json.Unmarshal` from the buffer, and stash `payload["_raw_body"]`.
- **`internal/pilot/pilot.go`** — the registered jira/asana handlers verify `VerifySignature([]byte(rawBody), signature)` over the exact raw bytes. Removed the now-dead `marshalWebhookPayload` helper + its `strings` import and the `TODO(F2)` comments.
- **gitlab / azuredevops** left unchanged — they use header-token / basic-auth (`X-Gitlab-Token`, basic auth), not body-HMAC.

## Tests

- `gateway`: `TestJiraWebhookPreservesRawBody` / `TestAsanaWebhookPreservesRawBody` — `_raw_body` equals the exact (non-canonical) request bytes and JSON still decodes from the buffer.
- `pilot`: `TestJira/AsanaWebhookSignatureGating` rewritten to true body-HMAC — valid HMAC over raw bytes passes; bad signature and **tampered body** block `Handle`. Green under `-race`.
- Full suite green; `golangci-lint` 0 issues.

Builds on TASK-326 (#3295). Audit ref: TASK-322.