### PR TITLE
fix(autopilot): fall back to commit-status API when check-runs is empty (TASK-335)

### DIFF
--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -154,7 +154,7 @@ func (m *CIMonitor) checkStatus(ctx context.Context, sha string) (CIStatus, erro
 
 	// Auto mode: use discovered checks with exclusions and grace period
 	if m.ciChecks != nil && m.ciChecks.Mode == "auto" {
-		return m.checkAutoDiscoveredRuns(sha, checkRuns)
+		return m.checkAutoDiscoveredRuns(ctx, sha, checkRuns)
 	}
 
 	// Manual mode: If no required checks configured, check all runs
@@ -208,8 +208,9 @@ func (m *CIMonitor) checkAllRuns(checkRuns *github.CheckRunsResponse) CIStatus {
 }
 
 // checkAutoDiscoveredRuns checks CI status in auto mode with exclusion filtering.
-// It waits during the grace period if no checks are found yet.
-func (m *CIMonitor) checkAutoDiscoveredRuns(sha string, checkRuns *github.CheckRunsResponse) (CIStatus, error) {
+// It waits during the grace period if no checks are found yet, then falls back
+// to the commit-status API before treating a SHA as having no CI configured.
+func (m *CIMonitor) checkAutoDiscoveredRuns(ctx context.Context, sha string, checkRuns *github.CheckRunsResponse) (CIStatus, error) {
 	// Filter checks by exclusion patterns
 	var filteredRuns []github.CheckRun
 	for _, run := range checkRuns.CheckRuns {
@@ -245,12 +246,25 @@ func (m *CIMonitor) checkAutoDiscoveredRuns(sha string, checkRuns *github.CheckR
 			return CIPending, nil
 		}
 
-		// Grace period expired with no checks - treat as success (no CI configured)
-		m.log.Info("grace period expired with no CI checks, treating as success",
+		// Grace period expired with no check runs — query commit-status API before
+		// concluding that no CI is configured. Providers like CircleCI, Jenkins,
+		// Travis, and Buildkite report exclusively via the statuses API.
+		combined, err := m.ghClient.GetCombinedStatus(ctx, m.owner, m.repo, sha)
+		if err != nil {
+			m.log.Warn("grace period expired; combined-status lookup failed, treating as no CI",
+				"sha", ShortSHA(sha),
+				"error", err,
+			)
+			return CISuccess, nil
+		}
+		status := m.mapCombinedStatus(combined)
+		m.log.Info("grace period expired with no check runs; using commit-status API",
 			"sha", ShortSHA(sha),
-			"grace_period", m.ciChecks.DiscoveryGracePeriod,
+			"combined_state", combined.State,
+			"total_count", combined.TotalCount,
+			"status", status,
 		)
-		return CISuccess, nil
+		return status, nil
 	}
 
 	// Clear discovery start since we found checks
@@ -279,6 +293,22 @@ func (m *CIMonitor) checkAutoDiscoveredRuns(sha string, checkRuns *github.CheckR
 		return CIPending, nil
 	}
 	return CISuccess, nil
+}
+
+// mapCombinedStatus converts a GitHub combined commit-status response into CIStatus.
+// TotalCount==0 means no status contexts exist → genuine no-CI repo → CISuccess.
+func (m *CIMonitor) mapCombinedStatus(combined *github.CombinedStatus) CIStatus {
+	if combined.TotalCount == 0 {
+		return CISuccess
+	}
+	switch combined.State {
+	case github.StatusFailure, github.StatusError:
+		return CIFailure
+	case github.StatusPending:
+		return CIPending
+	default:
+		return CISuccess
+	}
 }
 
 // matchesExclude checks if a check name matches any exclusion pattern.

--- a/internal/autopilot/ci_monitor_test.go
+++ b/internal/autopilot/ci_monitor_test.go
@@ -967,13 +967,21 @@ func TestCIMonitor_AutoDiscovery_GracePeriod(t *testing.T) {
 
 func TestCIMonitor_AutoDiscovery_GracePeriodExpired(t *testing.T) {
 	// Test that auto mode returns success if grace period expires with no checks
+	// and no commit statuses (genuine no-CI repo).
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := github.CheckRunsResponse{
-			TotalCount: 0,
-			CheckRuns:  []github.CheckRun{},
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/abc1234/check-runs":
+			resp := github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/commits/abc1234/status":
+			// No commit statuses → genuine no-CI repo
+			resp := github.CombinedStatus{State: github.StatusPending, TotalCount: 0, Statuses: []github.CommitStatus{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusNotFound)
 		}
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -1180,6 +1188,159 @@ func TestCIMonitor_GetFailedCheckLogs(t *testing.T) {
 			t.Errorf("expected empty logs when no failed checks, got %q", logs)
 		}
 	})
+}
+
+// TestCIMonitor_CommitStatusFallback tests the fallback to the GitHub commit-status
+// API when check-runs returns empty. Providers like CircleCI, Jenkins, and Travis
+// use the statuses API exclusively, so empty check-runs must not auto-approve.
+func TestCIMonitor_CommitStatusFallback(t *testing.T) {
+	tests := []struct {
+		name           string
+		combinedState  string
+		totalCount     int
+		wantStatus     CIStatus
+	}{
+		{
+			name:          "failing combined status → CIFailure",
+			combinedState: github.StatusFailure,
+			totalCount:    1,
+			wantStatus:    CIFailure,
+		},
+		{
+			name:          "error combined status → CIFailure",
+			combinedState: github.StatusError,
+			totalCount:    1,
+			wantStatus:    CIFailure,
+		},
+		{
+			name:          "pending combined status → CIPending",
+			combinedState: github.StatusPending,
+			totalCount:    1,
+			wantStatus:    CIPending,
+		},
+		{
+			name:          "empty combined statuses (TotalCount=0) → CISuccess",
+			combinedState: github.StatusPending, // GitHub returns "pending" with no statuses
+			totalCount:    0,
+			wantStatus:    CISuccess,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/owner/repo/commits/abc1234/check-runs":
+					resp := github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+				case "/repos/owner/repo/commits/abc1234/status":
+					resp := github.CombinedStatus{
+						State:      tt.combinedState,
+						TotalCount: tt.totalCount,
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.RequiredChecks = nil
+			cfg.CIChecks = &CIChecksConfig{
+				Mode:                 "auto",
+				DiscoveryGracePeriod: 20 * time.Millisecond,
+			}
+			monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+			// First call starts grace period
+			firstStatus, _ := monitor.CheckCI(context.Background(), "abc1234")
+			if firstStatus != CIPending {
+				t.Errorf("first CheckCI() = %s, want %s", firstStatus, CIPending)
+			}
+
+			// Wait for grace period to expire
+			time.Sleep(30 * time.Millisecond)
+
+			// Second call: grace period expired, fallback to commit-status API
+			status, err := monitor.CheckCI(context.Background(), "abc1234")
+			if err != nil {
+				t.Fatalf("CheckCI() error = %v", err)
+			}
+			if status != tt.wantStatus {
+				t.Errorf("CheckCI() after grace period = %s, want %s", status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestCIMonitor_CommitStatusFallback_APIError(t *testing.T) {
+	// When GetCombinedStatus fails, treat as no CI configured (success).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/abc1234/check-runs":
+			resp := github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/commits/abc1234/status":
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.RequiredChecks = nil
+	cfg.CIChecks = &CIChecksConfig{
+		Mode:                 "auto",
+		DiscoveryGracePeriod: 20 * time.Millisecond,
+	}
+	monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+	// Start grace period
+	_, _ = monitor.CheckCI(context.Background(), "abc1234")
+	time.Sleep(30 * time.Millisecond)
+
+	// After grace period, status API fails → treat as no CI (success)
+	status, err := monitor.CheckCI(context.Background(), "abc1234")
+	if err != nil {
+		t.Fatalf("CheckCI() error = %v", err)
+	}
+	if status != CISuccess {
+		t.Errorf("CheckCI() on status API error = %s, want %s (degrade gracefully)", status, CISuccess)
+	}
+}
+
+func TestCIMonitor_MapCombinedStatus(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+	tests := []struct {
+		name       string
+		combined   *github.CombinedStatus
+		wantStatus CIStatus
+	}{
+		{"failure state", &github.CombinedStatus{State: github.StatusFailure, TotalCount: 2}, CIFailure},
+		{"error state", &github.CombinedStatus{State: github.StatusError, TotalCount: 1}, CIFailure},
+		{"pending state", &github.CombinedStatus{State: github.StatusPending, TotalCount: 1}, CIPending},
+		{"success state", &github.CombinedStatus{State: github.StatusSuccess, TotalCount: 2}, CISuccess},
+		{"zero total count (no statuses)", &github.CombinedStatus{State: github.StatusPending, TotalCount: 0}, CISuccess},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := monitor.mapCombinedStatus(tt.combined)
+			if got != tt.wantStatus {
+				t.Errorf("mapCombinedStatus(%+v) = %s, want %s", tt.combined, got, tt.wantStatus)
+			}
+		})
+	}
 }
 
 func contains(s, substr string) bool {


### PR DESCRIPTION
## Summary

- **Root cause (B3):** `checkAutoDiscoveredRuns` only queried the GitHub Check Runs API. After the grace period expired with no check-run results, it immediately returned `CISuccess` — silently approving PRs with no CI verification. Providers like CircleCI, Jenkins, Travis, and Buildkite report exclusively via the commit-status API, which was never consulted.
- **Fix:** Before the grace-period "no CI configured" fallback, query `GetCombinedStatus`. Map the combined state: `failure`/`error` → `CIFailure`, `pending` → `CIPending`. Only when `TotalCount == 0` (zero status contexts) treat the repo as genuinely CI-free and return `CISuccess`.
- **Error-safe:** if `GetCombinedStatus` itself fails, log a warning and degrade to the original behaviour (CISuccess), avoiding blocking on transient API errors.

## Files changed

- `internal/autopilot/ci_monitor.go` — `checkAutoDiscoveredRuns` now takes `ctx`, calls `GetCombinedStatus` on empty check-runs after grace period; new `mapCombinedStatus` helper.
- `internal/autopilot/ci_monitor_test.go` — updated `GracePeriodExpired` test to serve both endpoints explicitly; added `TestCIMonitor_CommitStatusFallback` (4 subtests), `TestCIMonitor_CommitStatusFallback_APIError`, and `TestCIMonitor_MapCombinedStatus`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/autopilot/... -count=1` — all pass (40+ existing + 6 new)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] Empty check-runs + failing combined status → `CIFailure` ✓
- [x] Empty check-runs + empty combined statuses (TotalCount=0) → `CISuccess` ✓
- [x] Empty check-runs + pending combined status → `CIPending` ✓
- [x] `GetCombinedStatus` API error → degrades to `CISuccess` (no regression) ✓

Closes #3326 · Audit ref: TASK-322 B3