### PR TITLE
feat(autopilot): cap merge retries at MaxMergeAttempts and escalate (TASK-336)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1307,6 +1307,35 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 			return c.handleMergeConflict(ctx, prState)
 		}
 
+		// B5 (TASK-336): Hard cap on non-conflict merge retries. The circuit breaker
+		// (MaxFailures) auto-resets after FailureResetTimeout, so without this cap a
+		// PR blocked by branch-protection or a stuck status check retries indefinitely.
+		// Once MergeAttempts reaches MaxMergeAttempts the failure is terminal and a
+		// human must intervene.
+		if prState.MergeAttempts >= c.config.MaxMergeAttempts {
+			errMsg := fmt.Sprintf("merge failed after %d/%d attempts: %v — manual intervention required",
+				prState.MergeAttempts, c.config.MaxMergeAttempts, err)
+			c.log.Error("handleMerging: merge attempt cap reached — escalating to StageFailed",
+				"pr", prState.PRNumber,
+				"attempts", prState.MergeAttempts,
+				"max", c.config.MaxMergeAttempts,
+				"error", err,
+			)
+			if prState.IssueNumber > 0 {
+				comment := fmt.Sprintf(
+					"⚠️ **Merge escalation**: PR #%d failed to merge after %d attempts.\n\nLast error: `%v`\n\nManual intervention is required — no further automatic retries will be made.",
+					prState.PRNumber, prState.MergeAttempts, err)
+				if _, cerr := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); cerr != nil {
+					c.log.Warn("failed to post merge escalation comment", "issue", prState.IssueNumber, "error", cerr)
+				}
+			}
+			prState.Stage = StageFailed
+			prState.Error = errMsg
+			c.metrics.RecordPRFailed()
+			c.metrics.RecordIssueProcessed("failed")
+			return nil
+		}
+
 		return fmt.Errorf("merge attempt %d failed: %w", prState.MergeAttempts, err)
 	}
 

--- a/internal/autopilot/controller_merge_test.go
+++ b/internal/autopilot/controller_merge_test.go
@@ -301,3 +301,154 @@ func TestController_HandleMerging_CallsOnIssueDone(t *testing.T) {
 		t.Errorf("onIssueDone called with %v, want [55]", doneCalled)
 	}
 }
+
+// TestController_HandleMerging_MergeAttemptCapEscalates verifies that when a PR
+// reaches MaxMergeAttempts on a non-conflict merge failure it transitions to
+// StageFailed (never retried) and posts an escalation comment on the issue.
+// TASK-336 / B5.
+func TestController_HandleMerging_MergeAttemptCapEscalates(t *testing.T) {
+	var (
+		escalationCommentPosted bool
+		prFetched               bool
+	)
+
+	mergeable := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/88/merge" && r.Method == http.MethodPost:
+			// Simulate a persistent non-conflict merge failure (e.g. branch-protection).
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			_, _ = w.Write([]byte(`{"message":"405 Method Not Allowed"}`))
+
+		case r.URL.Path == "/repos/owner/repo/pulls/88" && r.Method == http.MethodGet:
+			prFetched = true
+			resp := github.PullRequest{
+				Number:         88,
+				Head:           github.PRRef{SHA: "sha88"},
+				Mergeable:      &mergeable,
+				MergeableState: "clean",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/issues/40/comments" && r.Method == http.MethodPost:
+			escalationCommentPosted = true
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.PRComment{ID: 1})
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.MaxMergeAttempts = 3
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	// MergeAttempts is 2; handleMerging will increment to 3 == MaxMergeAttempts → cap fires.
+	c.activePRs[88] = &PRState{
+		PRNumber:      88,
+		PRURL:         "https://github.com/owner/repo/pull/88",
+		IssueNumber:   40,
+		BranchName:    "pilot/GH-40",
+		HeadSHA:       "sha88",
+		Stage:         StageMerging,
+		MergeAttempts: 2,
+		CreatedAt:     time.Now(),
+	}
+	c.mu.Unlock()
+
+	err := c.ProcessPR(context.Background(), 88, nil)
+	if err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	pr, ok := c.GetPRState(88)
+	if !ok {
+		t.Fatal("PR 88 not found in activePRs")
+	}
+	if pr.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s", pr.Stage, StageFailed)
+	}
+	if pr.MergeAttempts != 3 {
+		t.Errorf("MergeAttempts = %d, want 3", pr.MergeAttempts)
+	}
+	if !prFetched {
+		t.Error("GetPullRequest should have been called to check for conflict")
+	}
+	if !escalationCommentPosted {
+		t.Error("escalation comment should have been posted on the issue")
+	}
+}
+
+// TestController_HandleMerging_BelowCapReturnsRetryableError verifies that a merge
+// failure when MergeAttempts is still below MaxMergeAttempts returns a retryable
+// error (Stage stays StageMerging) rather than transitioning to StageFailed.
+// TASK-336 / B5.
+func TestController_HandleMerging_BelowCapReturnsRetryableError(t *testing.T) {
+	mergeable := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/66/merge" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			_, _ = w.Write([]byte(`{"message":"405 Method Not Allowed"}`))
+
+		case r.URL.Path == "/repos/owner/repo/pulls/66" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:         66,
+				Head:           github.PRRef{SHA: "sha66"},
+				Mergeable:      &mergeable,
+				MergeableState: "clean",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.MaxMergeAttempts = 5
+	cfg.MaxFailures = 100 // disable circuit breaker for this test
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	// MergeAttempts is 1; handleMerging will increment to 2 < MaxMergeAttempts(5) → retryable.
+	c.activePRs[66] = &PRState{
+		PRNumber:      66,
+		PRURL:         "https://github.com/owner/repo/pull/66",
+		IssueNumber:   0,
+		BranchName:    "pilot/GH-66",
+		HeadSHA:       "sha66",
+		Stage:         StageMerging,
+		MergeAttempts: 1,
+		CreatedAt:     time.Now(),
+	}
+	c.mu.Unlock()
+
+	err := c.ProcessPR(context.Background(), 66, nil)
+	if err == nil {
+		t.Fatal("ProcessPR should have returned an error for a below-cap merge failure")
+	}
+
+	pr, ok := c.GetPRState(66)
+	if !ok {
+		t.Fatal("PR 66 not found in activePRs")
+	}
+	if pr.Stage != StageMerging {
+		t.Errorf("Stage = %s, want %s (below-cap failure must stay retryable)", pr.Stage, StageMerging)
+	}
+	if pr.MergeAttempts != 2 {
+		t.Errorf("MergeAttempts = %d, want 2", pr.MergeAttempts)
+	}
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -147,6 +147,11 @@ type Config struct {
 	FailureResetTimeout time.Duration `yaml:"failure_reset_timeout"`
 	// MaxMergesPerHour limits merge rate to prevent runaway automation.
 	MaxMergesPerHour int `yaml:"max_merges_per_hour"`
+	// MaxMergeAttempts is the hard cap on non-conflict merge retries before the PR
+	// is transitioned to StageFailed and escalated to a human. The circuit breaker
+	// (MaxFailures) provides transient backoff; this cap makes persistent failures
+	// terminal so they don't loop indefinitely. Default: 5.
+	MaxMergeAttempts int `yaml:"max_merge_attempts"`
 	// ApprovalTimeout is how long to wait for human approval in prod.
 	ApprovalTimeout time.Duration `yaml:"approval_timeout"`
 
@@ -320,6 +325,7 @@ func DefaultConfig() *Config {
 		MaxCIFixPRSize:      200,
 		FailureResetTimeout: 30 * time.Minute,
 		MaxMergesPerHour:    10,
+		MaxMergeAttempts:    5,
 		ApprovalTimeout:     1 * time.Hour,
 		Release:             nil, // Disabled by default
 		MergedPRScanWindow:  30 * time.Minute,


### PR DESCRIPTION
## Summary

- Adds `MaxMergeAttempts int` config field (default 5, `yaml:"max_merge_attempts"`) to `Config` in `types.go`
- In `handleMerging`: after a non-conflict merge failure, checks `prState.MergeAttempts >= c.config.MaxMergeAttempts`; if at cap, transitions to `StageFailed`, posts an escalation comment on the linked issue, records metrics, and returns `nil` (terminal)
- Below the cap, the existing retryable error is returned so the circuit breaker still provides transient backoff
- Two focused tests cover the cap-reached (→ `StageFailed` + comment) and below-cap (→ retryable error, stage stays `StageMerging`) paths

## Problem fixed (TASK-322 audit finding B5)

`handleMerging` incremented `MergeAttempts` but never compared it to any limit. The per-PR circuit breaker (`MaxFailures`) auto-resets after 30 min, so a PR blocked by branch-protection or a stuck required check would cycle: fail ~3×, breaker opens, 30 min later auto-resets, repeat — burning API quota with no human-actionable failure.

## Test plan
- [ ] `TestController_HandleMerging_MergeAttemptCapEscalates` — reaches cap → `StageFailed` + escalation comment posted
- [ ] `TestController_HandleMerging_BelowCapReturnsRetryableError` — below cap → retryable error, stage stays `StageMerging`
- [ ] All existing merge tests still pass (`go test ./internal/autopilot/... -timeout 120s`)
- [ ] `go build ./...` clean
- [ ] `golangci-lint run --new-from-rev=origin/main ./internal/autopilot/...` → 0 issues