### PR TITLE
feat(github): add retry wrapper to ExecuteGraphQL (TASK-339)

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -837,6 +837,9 @@ func (c *Client) GetPullRequestComments(ctx context.Context, owner, repo string,
 // ExecuteGraphQL executes a GitHub GraphQL query or mutation.
 // Posts to baseURL+"/graphql" (testable via NewClientWithBaseURL).
 // result is unmarshalled from response.data if non-nil.
+// Transient transport errors (5xx, network) and GraphQL-level rate limits
+// (HTTP 200 + RATE_LIMITED / "was submitted too quickly") are retried via
+// c.retryOpts, matching the behaviour of doRequest.
 func (c *Client) ExecuteGraphQL(ctx context.Context, query string, variables map[string]interface{}, result interface{}) error {
 	reqBody := GraphQLRequest{Query: query, Variables: variables}
 	bodyBytes, err := json.Marshal(reqBody)
@@ -845,44 +848,47 @@ func (c *Client) ExecuteGraphQL(ctx context.Context, query string, variables map
 	}
 
 	endpoint := c.baseURL + "/graphql"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return fmt.Errorf("create graphql request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("graphql request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("read graphql response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("graphql API error (status %d): %s", resp.StatusCode, string(respBody))
-	}
-
-	var gqlResp GraphQLResponse
-	if err := json.Unmarshal(respBody, &gqlResp); err != nil {
-		return fmt.Errorf("parse graphql response: %w", err)
-	}
-
-	if len(gqlResp.Errors) > 0 {
-		return fmt.Errorf("graphql error: %s", gqlResp.Errors[0].Message)
-	}
-
-	if result != nil && len(gqlResp.Data) > 0 {
-		if err := json.Unmarshal(gqlResp.Data, result); err != nil {
-			return fmt.Errorf("unmarshal graphql data: %w", err)
+	return WithRetryVoid(ctx, func() error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
+		if err != nil {
+			return fmt.Errorf("create graphql request: %w", err)
 		}
-	}
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Content-Type", "application/json")
 
-	return nil
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("graphql request failed: %w", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("read graphql response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("graphql API error (status %d): %s", resp.StatusCode, string(respBody))
+		}
+
+		var gqlResp GraphQLResponse
+		if err := json.Unmarshal(respBody, &gqlResp); err != nil {
+			return fmt.Errorf("parse graphql response: %w", err)
+		}
+
+		if len(gqlResp.Errors) > 0 {
+			return fmt.Errorf("graphql error: %s", gqlResp.Errors[0].Message)
+		}
+
+		if result != nil && len(gqlResp.Data) > 0 {
+			if err := json.Unmarshal(gqlResp.Data, result); err != nil {
+				return fmt.Errorf("unmarshal graphql data: %w", err)
+			}
+		}
+
+		return nil
+	}, c.retryOpts)
 }
 
 // SearchPRsForIssue returns all PRs that reference the given issue number using the

--- a/internal/adapters/github/graphql_retry_test.go
+++ b/internal/adapters/github/graphql_retry_test.go
@@ -1,0 +1,193 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// fastRetryOpts returns retry options with minimal delays so tests run quickly.
+func fastRetryOpts() RetryOptions {
+	return RetryOptions{
+		MaxRetries: 3,
+		BaseDelay:  1 * time.Millisecond,
+		MaxDelay:   5 * time.Millisecond,
+	}
+}
+
+// TestExecuteGraphQL_RetryOn502 verifies that a transient 502 on the first
+// attempt is retried and the second (successful) response is returned.
+func TestExecuteGraphQL_RetryOn502(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("bad gateway"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"login":"testuser"}}}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client.retryOpts = fastRetryOpts()
+
+	var result struct {
+		Viewer struct {
+			Login string `json:"login"`
+		} `json:"viewer"`
+	}
+	err := client.ExecuteGraphQL(context.Background(), `{ viewer { login } }`, nil, &result)
+	if err != nil {
+		t.Fatalf("expected success after retry, got: %v", err)
+	}
+	if result.Viewer.Login != "testuser" {
+		t.Errorf("login = %q, want %q", result.Viewer.Login, "testuser")
+	}
+	if calls.Load() != 2 {
+		t.Errorf("expected 2 calls (1 fail + 1 retry), got %d", calls.Load())
+	}
+}
+
+// TestExecuteGraphQL_RetryOnRateLimited verifies that an HTTP 200 response
+// with a RATE_LIMITED GraphQL error is retried and ultimately succeeds.
+func TestExecuteGraphQL_RetryOnRateLimited(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			// HTTP 200 with GraphQL-level rate limit error
+			resp := GraphQLResponse{
+				Errors: []GraphQLError{{Message: "RATE_LIMITED"}},
+			}
+			body, _ := json.Marshal(resp)
+			_, _ = w.Write(body)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"login":"testuser"}}}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client.retryOpts = fastRetryOpts()
+
+	var result struct {
+		Viewer struct {
+			Login string `json:"login"`
+		} `json:"viewer"`
+	}
+	err := client.ExecuteGraphQL(context.Background(), `{ viewer { login } }`, nil, &result)
+	if err != nil {
+		t.Fatalf("expected success after RATE_LIMITED retry, got: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("expected 2 calls (RATE_LIMITED + retry), got %d", calls.Load())
+	}
+}
+
+// TestExecuteGraphQL_RetryOnSubmittedTooQuickly verifies that the "was submitted
+// too quickly" GraphQL error message is treated as retryable.
+func TestExecuteGraphQL_RetryOnSubmittedTooQuickly(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			resp := GraphQLResponse{
+				Errors: []GraphQLError{{Message: "was submitted too quickly"}},
+			}
+			body, _ := json.Marshal(resp)
+			_, _ = w.Write(body)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"login":"testuser"}}}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client.retryOpts = fastRetryOpts()
+
+	var result struct {
+		Viewer struct {
+			Login string `json:"login"`
+		} `json:"viewer"`
+	}
+	err := client.ExecuteGraphQL(context.Background(), `{ viewer { login } }`, nil, &result)
+	if err != nil {
+		t.Fatalf("expected success after 'submitted too quickly' retry, got: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("expected 2 calls, got %d", calls.Load())
+	}
+}
+
+// TestExecuteGraphQL_ContextCancellation verifies that context cancellation
+// aborts the retry loop without waiting for the full retry budget.
+func TestExecuteGraphQL_ContextCancellation(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("unavailable"))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	client.retryOpts = RetryOptions{
+		MaxRetries: 10,
+		BaseDelay:  50 * time.Millisecond, // long enough for cancel to fire
+		MaxDelay:   100 * time.Millisecond,
+	}
+
+	// Cancel after first failure.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+
+	err := client.ExecuteGraphQL(ctx, `{ viewer { login } }`, nil, nil)
+	if err == nil {
+		t.Fatal("expected error after context cancellation")
+	}
+
+	// Should have made at most 2 calls before the cancel fires.
+	if calls.Load() > 2 {
+		t.Errorf("expected ≤2 calls before cancellation, got %d", calls.Load())
+	}
+}
+
+// TestIsRetryableError_GraphQLRateLimit verifies the predicate recognises
+// GraphQL-level rate limit messages as retryable.
+func TestIsRetryableError_GraphQLRateLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		msg       string
+		retryable bool
+	}{
+		{"RATE_LIMITED", "graphql error: RATE_LIMITED", true},
+		{"was submitted too quickly", "graphql error: was submitted too quickly", true},
+		{"non-retryable graphql error", "graphql error: FORBIDDEN", false},
+		{"unrelated error", "some other problem", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetryableError(errors.New(tt.msg))
+			if got != tt.retryable {
+				t.Errorf("isRetryableError(%q) = %v, want %v", tt.msg, got, tt.retryable)
+			}
+		})
+	}
+}

--- a/internal/adapters/github/retry.go
+++ b/internal/adapters/github/retry.go
@@ -122,6 +122,12 @@ func isRetryableError(err error) bool {
 		}
 	}
 
+	// GraphQL rate limit errors: HTTP 200 but error body signals rate-limiting.
+	// GitHub Projects V2 returns these as GraphQL errors rather than HTTP 429.
+	if strings.Contains(errStr, "RATE_LIMITED") || strings.Contains(errStr, "was submitted too quickly") {
+		return true
+	}
+
 	// Check for network errors (these don't have HTTP status)
 	networkErrors := []string{
 		"connection refused",


### PR DESCRIPTION
## Summary

- **`ExecuteGraphQL`** (previously a bare `httpClient.Do`) is now wrapped in `WithRetryVoid(ctx, …, c.retryOpts)`, mirroring the pattern used by `doRequest`. Transient 5xx / network failures on any Projects V2 operation (project-ID resolution, field/option resolution, board-source pagination, board write-backs) now retry instead of aborting with the first blip.
- **`isRetryableError`** extended to recognise GraphQL-level rate-limit messages (`RATE_LIMITED`, `"was submitted too quickly"`) returned as HTTP 200 + GraphQL error body — GitHub Projects V2 uses these instead of HTTP 429.
- **Tests** (`graphql_retry_test.go`): 502→success retry; `RATE_LIMITED` retry; `"was submitted too quickly"` retry; context-cancellation aborts promptly; `isRetryableError` predicate table for the new cases.

## Test plan

- [x] `go build ./...` — zero errors
- [x] `go test ./internal/adapters/github/... -count=1` — all pass (4.2s)
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/adapters/github/...` — 0 issues
- [x] All 5 new tests pass covering every acceptance criterion from the task spec

Closes #3330