### PR TITLE
fix(github): populate CreatedAt from board GraphQL query (TASK-340)

### DIFF
--- a/internal/adapters/github/project_source.go
+++ b/internal/adapters/github/project_source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 )
 
 const queryProjectBoardItems = `query($projectID: ID!, $statusField: String!, $cursor: String) {
@@ -20,6 +21,7 @@ const queryProjectBoardItems = `query($projectID: ID!, $statusField: String!, $c
               title
               body
               state
+              createdAt
               labels(first: 30) { nodes { name } }
               repository { nameWithOwner }
             }
@@ -48,12 +50,13 @@ type projectBoardItemsResponse struct {
 
 type projectBoardItemNode struct {
 	Content struct {
-		Number     int    `json:"number"`
-		ID         string `json:"id"`
-		Title      string `json:"title"`
-		Body       string `json:"body"`
-		State      string `json:"state"`
-		Labels     struct {
+		Number    int    `json:"number"`
+		ID        string `json:"id"`
+		Title     string `json:"title"`
+		Body      string `json:"body"`
+		State     string `json:"state"`
+		CreatedAt string `json:"createdAt"`
+		Labels    struct {
 			Nodes []struct {
 				Name string `json:"name"`
 			} `json:"nodes"`
@@ -142,13 +145,21 @@ func (s *ProjectBoardSource) FindIssuesFromProject(ctx context.Context, statusCo
 				labels[i] = Label{Name: l.Name}
 			}
 
+			var createdAt time.Time
+			if c.CreatedAt != "" {
+				if t, err := time.Parse(time.RFC3339, c.CreatedAt); err == nil {
+					createdAt = t
+				}
+			}
+
 			issues = append(issues, &Issue{
-				NodeID: c.ID,
-				Number: c.Number,
-				Title:  c.Title,
-				Body:   c.Body,
-				State:  strings.ToLower(c.State),
-				Labels: labels,
+				NodeID:    c.ID,
+				Number:    c.Number,
+				Title:     c.Title,
+				Body:      c.Body,
+				State:     strings.ToLower(c.State),
+				Labels:    labels,
+				CreatedAt: createdAt,
 			})
 		}
 

--- a/internal/adapters/github/project_source_test.go
+++ b/internal/adapters/github/project_source_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/testutil"
 )
@@ -75,6 +77,13 @@ func issueNode(number int, nodeID, title, body, state, repo, status string, labe
 			"name": status,
 		},
 	}
+}
+
+// issueNodeWithCreatedAt is like issueNode but includes a createdAt RFC3339 timestamp.
+func issueNodeWithCreatedAt(number int, nodeID, title, body, state, repo, status, createdAt string, labelNames ...string) map[string]interface{} {
+	node := issueNode(number, nodeID, title, body, state, repo, status, labelNames...)
+	node["content"].(map[string]interface{})["createdAt"] = createdAt
+	return node
 }
 
 // draftNode builds a non-issue item (number=0, no content fields set).
@@ -349,6 +358,89 @@ func TestFindIssuesFromProject_CachesProjectID(t *testing.T) {
 	}
 	if resolveCount != 1 {
 		t.Errorf("expected project ID resolved once, got %d", resolveCount)
+	}
+}
+
+func TestFindIssuesFromProject_CreatedAtPopulated(t *testing.T) {
+	ts := "2024-03-15T10:30:00Z"
+	server := fakeProjectSourceServer(t, []string{
+		orgProjectResp("PVT_cat"),
+		itemsResp([]map[string]interface{}{
+			issueNodeWithCreatedAt(50, "I_50", "With time", "", "OPEN", "org/repo", "Todo", ts),
+			issueNode(51, "I_51", "No time", "", "OPEN", "org/repo", "Todo"),
+		}, false, ""),
+	})
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	src := NewProjectBoardSource(client, &ProjectBoardConfig{
+		ProjectNumber: 10,
+		StatusField:   "Status",
+	}, "org", "repo")
+
+	issues, err := src.FindIssuesFromProject(context.Background(), "Todo")
+	if err != nil {
+		t.Fatalf("FindIssuesFromProject() error = %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+
+	want, _ := time.Parse(time.RFC3339, ts)
+	if !issues[0].CreatedAt.Equal(want) {
+		t.Errorf("issue #50 CreatedAt = %v, want %v", issues[0].CreatedAt, want)
+	}
+	if !issues[1].CreatedAt.IsZero() {
+		t.Errorf("issue #51 CreatedAt should be zero (no createdAt in response), got %v", issues[1].CreatedAt)
+	}
+}
+
+func TestFindIssuesFromProject_OldestFirstOrdering(t *testing.T) {
+	older := "2024-01-01T00:00:00Z"
+	newer := "2024-06-01T00:00:00Z"
+
+	// GraphQL returns newer first (board insertion order).
+	server := fakeProjectSourceServer(t, []string{
+		orgProjectResp("PVT_order"),
+		itemsResp([]map[string]interface{}{
+			issueNodeWithCreatedAt(200, "I_200", "Newer", "", "OPEN", "org/repo", "Todo", newer),
+			issueNodeWithCreatedAt(100, "I_100", "Older", "", "OPEN", "org/repo", "Todo", older),
+		}, false, ""),
+	})
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	src := NewProjectBoardSource(client, &ProjectBoardConfig{
+		ProjectNumber: 11,
+		StatusField:   "Status",
+	}, "org", "repo")
+
+	issues, err := src.FindIssuesFromProject(context.Background(), "Todo")
+	if err != nil {
+		t.Fatalf("FindIssuesFromProject() error = %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+
+	olderTime, _ := time.Parse(time.RFC3339, older)
+	newerTime, _ := time.Parse(time.RFC3339, newer)
+
+	// Both CreatedAt fields must be populated so the poller's oldest-first sort works.
+	// GraphQL returns them in board/insertion order (#200 then #100); verify timestamps match.
+	if !issues[0].CreatedAt.Equal(newerTime) {
+		t.Errorf("issues[0] (#200) CreatedAt = %v, want newer (%v)", issues[0].CreatedAt, newerTime)
+	}
+	if !issues[1].CreatedAt.Equal(olderTime) {
+		t.Errorf("issues[1] (#100) CreatedAt = %v, want older (%v)", issues[1].CreatedAt, olderTime)
+	}
+
+	// Applying the same sort the poller uses gives oldest-first order.
+	sort.Slice(issues, func(i, j int) bool {
+		return issues[i].CreatedAt.Before(issues[j].CreatedAt)
+	})
+	if issues[0].Number != 100 || issues[1].Number != 200 {
+		t.Errorf("oldest-first sort: expected [100, 200], got [%d, %d]", issues[0].Number, issues[1].Number)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `createdAt` to the `... on Issue` inline fragment in `queryProjectBoardItems` so the GitHub GraphQL API returns the field
- Adds `CreatedAt string` to `projectBoardItemNode.Content` for JSON decoding
- Parses the RFC3339 timestamp and sets `Issue.CreatedAt` in `FindIssuesFromProject`

Without this fix, every board-sourced candidate had `CreatedAt == zero`, making `sort.Slice` a no-op and violating the FIFO dispatch contract in `findOldestUnprocessedIssue`.

Closes #3331

## Test plan
- [x] `TestFindIssuesFromProject_CreatedAtPopulated` — verifies `CreatedAt` is parsed correctly for issues with `createdAt` in the response and remains zero for issues without
- [x] `TestFindIssuesFromProject_OldestFirstOrdering` — verifies both timestamps are populated, and that applying the same `sort.Slice` the poller uses gives oldest-first order
- [x] All existing `TestFindIssuesFromProject_*` tests still pass
- [x] `go build ./...` clean, `golangci-lint` 0 issues