### PR TITLE
fix(github): honor project board source in parallel/auto poll mode (TASK-338)

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -732,25 +732,33 @@ func (p *Poller) startSequential(ctx context.Context) {
 
 // findOldestUnprocessedIssue finds the oldest issue with the pilot label
 // that hasn't been processed yet and has no pending dependencies.
-// When projectBoardSource is set, candidates are fetched from the board column
-// instead of by label; all downstream filters remain identical.
-func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error) {
-	var issues []*Issue
-	var err error
-
+// fetchCandidates returns the raw candidate issues for this poll cycle. When a
+// projectBoardSource is configured it sources from the board column (GH-3228);
+// otherwise it lists open issues by label. This is the single source-selection
+// point used by BOTH dispatch paths — findOldestUnprocessedIssue (sequential)
+// and checkForNewIssues (parallel/auto) — so the board source is honored
+// regardless of execution mode (TASK-338). Previously only the sequential path
+// consulted the board source, so source_enabled + mode:parallel silently
+// reverted to label polling.
+func (p *Poller) fetchCandidates(ctx context.Context) ([]*Issue, error) {
 	if p.projectBoardSource != nil {
 		sourceStatus := p.projectBoardSource.config.SourceStatus
 		if sourceStatus == "" {
 			sourceStatus = "Todo"
 		}
-		issues, err = p.projectBoardSource.FindIssuesFromProject(ctx, sourceStatus)
-	} else {
-		issues, err = p.client.ListIssues(ctx, p.owner, p.repo, &ListIssuesOptions{
-			Labels: []string{p.label},
-			State:  StateOpen,
-			Sort:   "created", // Sort by creation date to get oldest first
-		})
+		return p.projectBoardSource.FindIssuesFromProject(ctx, sourceStatus)
 	}
+	return p.client.ListIssues(ctx, p.owner, p.repo, &ListIssuesOptions{
+		Labels: []string{p.label},
+		State:  StateOpen,
+		Sort:   "created", // oldest first
+	})
+}
+
+// When projectBoardSource is set, candidates are fetched from the board column
+// instead of by label; all downstream filters remain identical.
+func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error) {
+	issues, err := p.fetchCandidates(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1038,11 +1046,7 @@ func (p *Poller) syncBoardStatusInProgress(ctx context.Context, issue *Issue) {
 
 // checkForNewIssues fetches issues and dispatches new ones concurrently (parallel mode)
 func (p *Poller) checkForNewIssues(ctx context.Context) {
-	issues, err := p.client.ListIssues(ctx, p.owner, p.repo, &ListIssuesOptions{
-		Labels: []string{p.label},
-		State:  StateOpen,
-		Sort:   "created",
-	})
+	issues, err := p.fetchCandidates(ctx)
 	if err != nil {
 		p.logger.Warn("Failed to fetch issues", slog.Any("error", err))
 		return

--- a/internal/adapters/github/poller_task338_test.go
+++ b/internal/adapters/github/poller_task338_test.go
@@ -1,0 +1,111 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestPoller_Parallel_UsesBoardSource asserts that checkForNewIssues (the
+// parallel/auto dispatch path) sources candidates from the project board when a
+// projectBoardSource is configured, instead of falling back to the REST issues
+// API. Before TASK-338 only the sequential path consulted the board source, so
+// source_enabled + mode:parallel silently reverted to label polling.
+func TestPoller_Parallel_UsesBoardSource(t *testing.T) {
+	var graphqlHits, restIssuesHits atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/graphql":
+			graphqlHits.Add(1)
+			// Return an empty board column — enough to prove the board source was
+			// queried without dragging in downstream dispatch/API calls.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[]}}}}`))
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues"):
+			restIssuesHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	src := NewProjectBoardSource(client, &ProjectBoardConfig{
+		ProjectNumber: 1,
+		StatusField:   "Status",
+		SourceStatus:  "Todo",
+		SourceEnabled: true,
+	}, "owner", "repo")
+	// Pre-seed the project node ID so ensureProjectID skips the resolver query.
+	src.projectID = "PVT_test"
+
+	poller, err := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithProjectBoardSource(src))
+	if err != nil {
+		t.Fatalf("NewPoller() error = %v", err)
+	}
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if graphqlHits.Load() == 0 {
+		t.Error("checkForNewIssues did not query the project board (GraphQL endpoint never hit)")
+	}
+	if restIssuesHits.Load() != 0 {
+		t.Errorf("checkForNewIssues fell back to the REST issues API (%d hits) instead of the board source", restIssuesHits.Load())
+	}
+}
+
+// TestPoller_fetchCandidates_LabelModeUnchanged asserts that without a
+// projectBoardSource the helper still lists issues by label via the REST API,
+// preserving the default (non-board) behavior.
+func TestPoller_fetchCandidates_LabelModeUnchanged(t *testing.T) {
+	var graphqlHits, restIssuesHits atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/graphql":
+			graphqlHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{}}`))
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues"):
+			restIssuesHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, err := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+	if err != nil {
+		t.Fatalf("NewPoller() error = %v", err)
+	}
+
+	issues, err := poller.fetchCandidates(context.Background())
+	if err != nil {
+		t.Fatalf("fetchCandidates() error = %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("expected 0 issues, got %d", len(issues))
+	}
+	if restIssuesHits.Load() == 0 {
+		t.Error("fetchCandidates did not use the REST issues API in label mode")
+	}
+	if graphqlHits.Load() != 0 {
+		t.Errorf("fetchCandidates hit the board GraphQL endpoint (%d) in label mode", graphqlHits.Load())
+	}
+}


### PR DESCRIPTION
## Context
Closes #3329. `checkForNewIssues` (parallel/auto dispatch path) called `ListIssues` by label unconditionally and never consulted `projectBoardSource` — only the sequential `findOldestUnprocessedIssue` did. So `source_enabled` + `mode:parallel` (the production default for concurrency>1) silently reverted to label polling, ignoring the board column.

## Approach
Extract the source-selection into a single `fetchCandidates(ctx)` helper — board source when configured, else `ListIssues` by label — and call it from **both** `checkForNewIssues` and `findOldestUnprocessedIssue`. DRY single selection point.

## Acceptance
- [x] `checkForNewIssues` queries the board GraphQL endpoint and **never** the REST issues API when a board source is set.
- [x] Label mode still uses REST (unchanged behavior).
- [x] Full `internal/adapters/github` suite green; gofmt/vet clean.

Taken manually — Pilot no-op'd this issue (no branch produced). Audit TASK-322 finding C2 · task doc `.agent/tasks/TASK-338-board-source-parallel-mode.md`.