### PR TITLE
fix(alerts): decouple dispatch from event loop + enforce SuppressDuplicates (TASK-337)

### DIFF
--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,9 +25,26 @@ type Engine struct {
 	alertHistory        []AlertHistory
 	retryTracker        map[string]int // source (issue/PR) -> consecutive failure count (GH-848)
 
-	// Channels for events
-	eventCh chan Event
-	done    chan struct{}
+	// Channels for events. priorityCh carries high-severity events
+	// (escalation / OOM / budget / security) on a dedicated buffer so a flood of
+	// ordinary task events filling eventCh cannot starve a critical alert (E1).
+	eventCh    chan Event
+	priorityCh chan Event
+	done       chan struct{}
+
+	// dispatchCh feeds a single background delivery worker. fireAlert enqueues
+	// here instead of calling Dispatch inline, so a slow/hung channel can never
+	// block the event loop (E1). Sequential delivery keeps ordering and adds no
+	// new concurrency. dispatchWG tracks in-flight deliveries for WaitForDispatch.
+	dispatchCh chan dispatchJob
+	dispatchWG sync.WaitGroup
+	// started is set once Start() launches the dispatch worker. Before that
+	// (direct callers / tests) fireAlert delivers inline so behavior is synchronous.
+	started atomic.Bool
+
+	// recentAlerts deduplicates identical alerts ({rule|source|message}) within
+	// duplicateSuppressTTL when config.Defaults.SuppressDuplicates is set (E5).
+	recentAlerts map[string]time.Time
 
 	// metrics accumulates fired/dropped counters; share the same instance with the
 	// Dispatcher via WithAlertMetrics+WithDispatcherMetrics so delivery counts appear
@@ -82,6 +100,23 @@ const (
 	EventTypeOOMKilled EventType = "oom_killed"
 )
 
+const (
+	// dispatchBacklog bounds the delivery queue feeding the dispatch worker (E1).
+	// When the worker is stuck on a hung channel and the backlog fills, further
+	// deliveries are dropped with a counter rather than blocking the event loop.
+	dispatchBacklog = 256
+	// duplicateSuppressTTL is the window within which an identical alert
+	// ({rule|source|message}) is suppressed when SuppressDuplicates is enabled (E5).
+	duplicateSuppressTTL = 5 * time.Minute
+)
+
+// dispatchJob is a queued alert delivery handled by the dispatch worker (E1).
+type dispatchJob struct {
+	rule     AlertRule
+	alert    *Alert
+	channels []string
+}
+
 // EngineOption configures the Engine
 type EngineOption func(*Engine)
 
@@ -119,7 +154,10 @@ func NewEngine(config *AlertConfig, opts ...EngineOption) *Engine {
 		alertHistory:        make([]AlertHistory, 0),
 		retryTracker:        make(map[string]int),
 		eventCh:             make(chan Event, 100),
+		priorityCh:          make(chan Event, 100),
 		done:                make(chan struct{}),
+		dispatchCh:          make(chan dispatchJob, dispatchBacklog),
+		recentAlerts:        make(map[string]time.Time),
 		metrics:             NewAlertMetrics(),
 	}
 
@@ -145,10 +183,37 @@ func (e *Engine) Start(ctx context.Context) error {
 	// Start event processor
 	go e.processEvents(ctx)
 
+	// Start the delivery worker that drains dispatchCh (E1).
+	go e.dispatchWorker(ctx)
+
 	// Start stuck task checker
 	go e.checkStuckTasks(ctx)
 
+	e.started.Store(true)
+
 	return nil
+}
+
+// dispatchWorker drains queued deliveries sequentially so channel I/O never
+// blocks the event loop (E1).
+func (e *Engine) dispatchWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-e.done:
+			return
+		case job := <-e.dispatchCh:
+			e.dispatchAndRecord(ctx, job.rule, job.alert, job.channels)
+			e.dispatchWG.Done()
+		}
+	}
+}
+
+// WaitForDispatch blocks until all enqueued alert deliveries have completed.
+// Useful for graceful shutdown and for deterministic tests.
+func (e *Engine) WaitForDispatch() {
+	e.dispatchWG.Wait()
 }
 
 // Stop stops the alerting engine
@@ -156,9 +221,26 @@ func (e *Engine) Stop() {
 	close(e.done)
 }
 
-// ProcessEvent adds an event to the processing queue
+// ProcessEvent adds an event to the processing queue. High-severity events
+// (escalation / OOM / budget / security) go on a dedicated priority queue so a
+// flood of ordinary events that fills eventCh cannot drop them (E1).
 func (e *Engine) ProcessEvent(event Event) {
 	if !e.config.Enabled {
+		return
+	}
+
+	if isHighPriorityEvent(event.Type) {
+		select {
+		case e.priorityCh <- event:
+		default:
+			// The priority queue is independent of eventCh, so this only happens
+			// under a sustained critical-event storm. Log loudly and count it.
+			e.logger.Error("CRITICAL alert event dropped — priority queue full",
+				"type", event.Type,
+				"task_id", event.TaskID,
+			)
+			e.metrics.RecordDropped()
+		}
 		return
 	}
 
@@ -173,14 +255,39 @@ func (e *Engine) ProcessEvent(event Event) {
 	}
 }
 
-// processEvents processes incoming events
+// isHighPriorityEvent reports whether an event must not be lost under load.
+func isHighPriorityEvent(t EventType) bool {
+	switch t {
+	case EventTypeEscalation, EventTypeOOMKilled, EventTypeBudgetExceeded, EventTypeSecurityEvent:
+		return true
+	default:
+		return false
+	}
+}
+
+// processEvents processes incoming events. The priority queue is drained ahead
+// of the normal queue so critical alerts are handled first under load.
 func (e *Engine) processEvents(ctx context.Context) {
 	for {
+		// Fast path: always prefer a pending priority event.
 		select {
 		case <-ctx.Done():
 			return
 		case <-e.done:
 			return
+		case event := <-e.priorityCh:
+			e.handleEvent(ctx, event)
+			continue
+		default:
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-e.done:
+			return
+		case event := <-e.priorityCh:
+			e.handleEvent(ctx, event)
 		case event := <-e.eventCh:
 			e.handleEvent(ctx, event)
 		}
@@ -531,10 +638,30 @@ func (e *Engine) createEscalationAlert(rule AlertRule, event Event, source strin
 	}
 }
 
-// fireAlert sends an alert through configured channels
+// fireAlert sends an alert through configured channels. Delivery is handed to a
+// bounded background goroutine so a slow/hung channel cannot block the event
+// loop (E1); identical alerts are suppressed within a TTL window (E5).
 func (e *Engine) fireAlert(ctx context.Context, rule AlertRule, alert *Alert) {
+	now := time.Now()
+
 	e.mu.Lock()
-	e.lastAlertTimes[rule.Name] = time.Now()
+	// E5: suppress identical alerts ({rule|source|message}) within the TTL window.
+	if e.config.Defaults.SuppressDuplicates {
+		key := dedupeKey(rule.Name, alert.Source, alert.Message)
+		if last, ok := e.recentAlerts[key]; ok && now.Sub(last) < duplicateSuppressTTL {
+			e.mu.Unlock()
+			e.metrics.RecordDropped()
+			e.logger.Debug("duplicate alert suppressed",
+				"rule", rule.Name,
+				"source", alert.Source,
+				"alert_id", alert.ID,
+			)
+			return
+		}
+		e.recentAlerts[key] = now
+		e.pruneRecentAlertsLocked(now)
+	}
+	e.lastAlertTimes[rule.Name] = now
 	e.mu.Unlock()
 
 	e.metrics.RecordFired(rule.Name, string(alert.Severity))
@@ -558,6 +685,30 @@ func (e *Engine) fireAlert(ctx context.Context, rule AlertRule, alert *Alert) {
 		}
 	}
 
+	// E1: once running, hand delivery to the background worker so a slow/hung
+	// channel can never block the event loop. Before Start() (direct callers /
+	// tests) deliver inline so the path stays synchronous.
+	if !e.started.Load() {
+		e.dispatchAndRecord(ctx, rule, alert, channels)
+		return
+	}
+	e.dispatchWG.Add(1)
+	select {
+	case e.dispatchCh <- dispatchJob{rule: rule, alert: alert, channels: channels}:
+	default:
+		e.dispatchWG.Done()
+		e.metrics.RecordDropped()
+		e.logger.Warn("alert dispatch backlog full, dropping delivery",
+			"rule", rule.Name,
+			"alert_id", alert.ID,
+			"severity", alert.Severity,
+		)
+	}
+}
+
+// dispatchAndRecord delivers an alert to its channels and records delivery
+// history. Runs in its own goroutine, bounded by dispatchSem (E1).
+func (e *Engine) dispatchAndRecord(ctx context.Context, rule AlertRule, alert *Alert, channels []string) {
 	results := e.dispatcher.Dispatch(ctx, alert, channels)
 
 	// Track delivery history
@@ -593,6 +744,21 @@ func (e *Engine) fireAlert(ctx context.Context, rule AlertRule, alert *Alert) {
 		"severity", alert.Severity,
 		"delivered_to", deliveredTo,
 	)
+}
+
+// dedupeKey builds the suppression key for an alert (E5).
+func dedupeKey(rule, source, message string) string {
+	return rule + "|" + source + "|" + message
+}
+
+// pruneRecentAlertsLocked removes dedupe entries older than the TTL.
+// The caller must hold e.mu.
+func (e *Engine) pruneRecentAlertsLocked(now time.Time) {
+	for k, t := range e.recentAlerts {
+		if now.Sub(t) >= duplicateSuppressTTL {
+			delete(e.recentAlerts, k)
+		}
+	}
 }
 
 func (e *Engine) channelAcceptsSeverity(ch ChannelConfig, severity Severity) bool {

--- a/internal/alerts/engine_task337_test.go
+++ b/internal/alerts/engine_task337_test.go
@@ -1,0 +1,167 @@
+package alerts
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockingChannel blocks in Send until release is closed (with a 2s safety
+// timeout so it can never hang the suite). Used to prove a hung channel cannot
+// block the event loop (E1 / TASK-337).
+type blockingChannel struct {
+	name    string
+	release chan struct{}
+	mu      sync.Mutex
+	count   int
+}
+
+func (b *blockingChannel) Name() string { return b.name }
+func (b *blockingChannel) Type() string { return "webhook" }
+func (b *blockingChannel) Send(ctx context.Context, _ *Alert) error {
+	b.mu.Lock()
+	b.count++
+	b.mu.Unlock()
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second): // safety: never hang the test suite
+	}
+	return nil
+}
+
+func mkTask337Engine(t *testing.T, suppress bool, ch Channel) *Engine {
+	t.Helper()
+	config := &AlertConfig{
+		Enabled:  true,
+		Channels: []ChannelConfig{{Name: ch.Name(), Type: ch.Type(), Enabled: true}},
+		Rules: []AlertRule{{
+			Name: "task_failed", Type: AlertTypeTaskFailed, Severity: SeverityWarning,
+			Enabled: true, Channels: []string{ch.Name()},
+		}},
+		Defaults: AlertDefaults{SuppressDuplicates: suppress},
+	}
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(ch)
+	return NewEngine(config, WithDispatcher(dispatcher))
+}
+
+// TestFireAlert_SuppressDuplicates verifies that identical {rule|source|message}
+// alerts are coalesced within the TTL window when SuppressDuplicates is set (E5).
+func TestFireAlert_SuppressDuplicates(t *testing.T) {
+	mock := newMockChannel("mock", "webhook")
+	engine := mkTask337Engine(t, true, mock)
+	rule := engine.config.Rules[0]
+	ctx := context.Background()
+
+	mk := func(id, src, msg string) *Alert {
+		return &Alert{ID: id, Type: AlertTypeTaskFailed, Severity: SeverityWarning, Source: src, Message: msg, CreatedAt: time.Now()}
+	}
+
+	// engine not Started → fireAlert delivers inline (synchronous).
+	engine.fireAlert(ctx, rule, mk("1", "task:X", "boom"))  // delivered
+	engine.fireAlert(ctx, rule, mk("2", "task:X", "boom"))  // duplicate → suppressed
+	engine.fireAlert(ctx, rule, mk("3", "task:X", "other")) // distinct message → delivered
+	engine.fireAlert(ctx, rule, mk("4", "task:Y", "boom"))  // distinct source → delivered
+
+	if got := len(mock.getAlerts()); got != 3 {
+		t.Fatalf("expected 3 delivered (1 duplicate suppressed), got %d", got)
+	}
+	if engine.metrics.Snapshot().DroppedTotal != 1 {
+		t.Errorf("expected 1 suppressed alert counted as dropped, got %d", engine.metrics.Snapshot().DroppedTotal)
+	}
+}
+
+// TestFireAlert_SuppressDuplicatesDisabled verifies identical alerts all fire
+// when the feature is off (preserving prior behavior).
+func TestFireAlert_SuppressDuplicatesDisabled(t *testing.T) {
+	mock := newMockChannel("mock", "webhook")
+	engine := mkTask337Engine(t, false, mock)
+	rule := engine.config.Rules[0]
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		engine.fireAlert(ctx, rule, &Alert{ID: fmt.Sprintf("%d", i), Type: AlertTypeTaskFailed, Severity: SeverityWarning, Source: "task:X", Message: "boom", CreatedAt: time.Now()})
+	}
+	if got := len(mock.getAlerts()); got != 3 {
+		t.Fatalf("expected 3 delivered with suppression off, got %d", got)
+	}
+}
+
+// TestProcessEvent_PriorityQueueNotStarvedByFlood verifies that a flood of
+// ordinary events filling eventCh does not cause critical events to be dropped —
+// they ride the independent priority queue (E1).
+func TestProcessEvent_PriorityQueueNotStarvedByFlood(t *testing.T) {
+	engine := NewEngine(&AlertConfig{Enabled: true}) // not Started → nothing drains the queues
+
+	// Overflow eventCh (cap 100) with ordinary events.
+	for i := 0; i < 150; i++ {
+		engine.ProcessEvent(Event{Type: EventTypeTaskProgress, TaskID: fmt.Sprintf("t%d", i)})
+	}
+
+	// A critical escalation event must still be queued (separate buffer).
+	engine.ProcessEvent(Event{Type: EventTypeEscalation, TaskID: "crit"})
+
+	if len(engine.priorityCh) == 0 {
+		t.Fatal("escalation event was not enqueued on the priority queue despite eventCh flood")
+	}
+	if engine.metrics.Snapshot().DroppedTotal == 0 {
+		t.Error("expected overflowed ordinary events to be counted as dropped")
+	}
+}
+
+// TestProcessEvents_HungChannelDoesNotBlockEventLoop verifies that a wedged
+// channel delivery (held in the dispatch worker) does not stall the event loop:
+// subsequent events are still processed (E1).
+func TestProcessEvents_HungChannelDoesNotBlockEventLoop(t *testing.T) {
+	release := make(chan struct{})
+	bc := &blockingChannel{name: "blocking", release: release}
+	engine := mkTask337Engine(t, false, bc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = engine.Start(ctx)
+	defer engine.Stop()
+
+	// Fire an alert routed to the hung channel → the dispatch worker blocks on Send.
+	engine.ProcessEvent(Event{Type: EventTypeTaskFailed, TaskID: "A", Project: "p", Error: "boom", Timestamp: time.Now()})
+
+	// While the worker is wedged, the event loop must keep processing: a later
+	// task_started must update engine state within a short bound.
+	engine.ProcessEvent(Event{Type: EventTypeTaskStarted, TaskID: "B", Timestamp: time.Now()})
+
+	processed := false
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		engine.mu.RLock()
+		_, processed = engine.taskLastProgress["B"]
+		engine.mu.RUnlock()
+		if processed {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	close(release) // unblock the wedged delivery before cleanup
+	if !processed {
+		t.Fatal("event loop blocked: task_started for B was not processed while a channel was hung")
+	}
+	engine.WaitForDispatch()
+}
+
+func TestIsHighPriorityEvent(t *testing.T) {
+	high := []EventType{EventTypeEscalation, EventTypeOOMKilled, EventTypeBudgetExceeded, EventTypeSecurityEvent}
+	for _, et := range high {
+		if !isHighPriorityEvent(et) {
+			t.Errorf("%s should be high priority", et)
+		}
+	}
+	normal := []EventType{EventTypeTaskStarted, EventTypeTaskProgress, EventTypeTaskCompleted, EventTypeTaskFailed, EventTypeCostUpdate, EventTypeAutopilotMetrics}
+	for _, et := range normal {
+		if isHighPriorityEvent(et) {
+			t.Errorf("%s should not be high priority", et)
+		}
+	}
+}

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -2723,6 +2723,7 @@ func TestHandleEvalRegression(t *testing.T) {
 		}
 
 		engine.handleEvalRegression(ctx, event)
+		engine.WaitForDispatch()
 
 		mock.mu.Lock()
 		defer mock.mu.Unlock()
@@ -2760,6 +2761,7 @@ func TestHandleEvalRegression(t *testing.T) {
 		}
 
 		engine.handleEvalRegression(ctx, event)
+		engine.WaitForDispatch()
 
 		mock.mu.Lock()
 		defer mock.mu.Unlock()


### PR DESCRIPTION
## Context
Closes #3328. Two `internal/alerts/engine.go` findings (combined — same file):
- **E1** — `processEvents` runs one goroutine; `handleEvent` → `fireAlert` → `dispatcher.Dispatch` blocked inline (`wg.Wait`, 30s/channel). One hung channel stalled **all** alerting for up to 30s/alert, and `eventCh` overflow dropped events indiscriminately — including escalation/OOM criticals.
- **E5** — `AlertDefaults.SuppressDuplicates` was plumbed + defaulted `true` but never read; `task_failed` ships `Cooldown:0`, so a flapping task flooded channels.

## Approach
**E1**
- Single background **dispatch worker** drains a bounded `dispatchCh`; `fireAlert` enqueues instead of delivering inline → the event loop never blocks on channel I/O. Sequential delivery = no new concurrency; backlog overflow drops with a counter. A `started` flag keeps delivery **inline/synchronous before `Start()`** (direct callers/tests), so existing semantics are preserved.
- Independent **`priorityCh`** for escalation/OOM/budget/security so an ordinary-event flood can't starve criticals; loop drains priority first.
- `WaitForDispatch()` drains in-flight deliveries (graceful shutdown + deterministic tests).

**E5** — suppress identical `{rule|source|message}` alerts within a 5m TTL when enabled; suppressed alerts counted via metrics.

## Acceptance
- [x] A hung channel does not block the event loop (subsequent events still processed) — bounded, self-releasing test.
- [x] Priority queue survives an `eventCh` flood; overflowed ordinary events counted as dropped.
- [x] `SuppressDuplicates=true` → identical alert fires once; distinct source/message fire separately; off → all fire.
- [x] Full `internal/alerts` suite green under `-race`; gofmt/vet clean.

Taken manually — Pilot no-op'd this issue (hang-adjacent; no branch produced). Audit TASK-322 E1+E5 · task doc `.agent/tasks/TASK-337-alert-loop-decouple-suppress-dupes.md`.