### PR TITLE
fix(github): no-op re-dispatch with an open PR is awaiting-merge, not pilot-blocked (TASK-341)

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -67,6 +67,32 @@ func issueAlreadyMerged(ctx context.Context, client *github.Client, owner, repo 
 	return err == nil && found
 }
 
+// issueHasOpenPR reports whether an OPEN pilot PR already exists for the issue.
+// Counterpart to issueAlreadyMerged for the awaiting-merge window: pilot-done +
+// issue close are deferred to merge time (GH-3139/TASK-301), so between PR
+// creation and merge a re-dispatch finds the work already on the pilot/GH-N
+// branch and produces a "no new commit produced" no-op even though a healthy PR
+// is open. TASK-341: used to classify that no-op as awaiting-merge rather than
+// pilot-blocked. Branch lookup is strongly consistent (no Search API lag); the
+// Search fallback catches PRs whose head deviates from the pilot/GH-N convention.
+// Read-only.
+func issueHasOpenPR(ctx context.Context, client *github.Client, owner, repo string, issueNumber int) bool {
+	branch := fmt.Sprintf("pilot/GH-%d", issueNumber)
+	if found, err := client.FindOpenPRByBranch(ctx, owner, repo, branch); err == nil && found {
+		return true
+	}
+	prs, err := client.SearchPRsForIssue(ctx, owner, repo, issueNumber)
+	if err != nil {
+		return false
+	}
+	for _, pr := range prs {
+		if pr.State == "open" && !pr.Merged {
+			return true
+		}
+	}
+	return false
+}
+
 // requestReviewersFromConfig looks up the project config for the given sourceRepo
 // and requests PR reviewers if configured. Errors are logged but not propagated.
 func requestReviewersFromConfig(ctx context.Context, cfg *config.Config, client *github.Client, sourceRepo, owner, repo string, prNumber int) {
@@ -449,6 +475,28 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 					logGitHubAPIError("AddComment(already-merged)", parts[0], parts[1], issue.Number, err)
 				}
 				issueResult.Success = true
+			} else if hr.Result.Error != "" && strings.Contains(hr.Result.Error, noOpErrorMarker) &&
+				issueHasOpenPR(ctx, client, parts[0], parts[1], issue.Number) {
+				// TASK-341: a "no new commit produced" no-op with an OPEN pilot PR is
+				// the awaiting-merge window — pilot-done + close are deferred to merge
+				// time (GH-3139/TASK-301), so a re-dispatch finds the work already on
+				// the branch and produces this no-op even though a healthy PR is open.
+				// This is a redundant re-dispatch of shipped work, NOT a failure: leave
+				// it for the autopilot merge flow and do NOT add pilot-blocked. (The
+				// already-merged case is handled by the branch above; a genuine no-op
+				// with neither a merged nor an open PR falls through to the blocked
+				// path below.) No comment is posted — the run can repeat before merge
+				// and we must not spam the issue.
+				slog.Info("no-op re-dispatch with open PR — awaiting merge, not blocked (TASK-341)",
+					slog.Int("issue", issue.Number),
+				)
+				// Defense-in-depth: clear a stale pilot-blocked from a prior phantom
+				// classification so the open PR is not held out of the merge flow.
+				if err := client.RemoveLabel(ctx, parts[0], parts[1], issue.Number, github.LabelBlocked); err != nil {
+					slog.Debug("pilot-blocked cleanup (awaiting-merge)", "issue", issue.Number, "error", err)
+				}
+				// issueResult.Success stays false (no new deliverable this run), but no
+				// failure/blocked label is applied — the open PR is the deliverable.
 			} else {
 				// result exists but Success is false - mark as failed
 				// GH-2402: Use pilot-blocked for deterministic failures so we don't retry.

--- a/cmd/pilot/handlers_open_pr_test.go
+++ b/cmd/pilot/handlers_open_pr_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TASK-341: issueHasOpenPR detects the awaiting-merge window (PR created but not
+// yet merged) so a "no new commit produced" no-op re-dispatch is classified as
+// awaiting-merge instead of being mislabeled pilot-blocked. It is the open-PR
+// counterpart to issueAlreadyMerged (TASK-321).
+func TestIssueHasOpenPR(t *testing.T) {
+	tests := []struct {
+		name        string
+		branchPRs   string // JSON array returned by /repos/.../pulls?state=open (FindOpenPRByBranch)
+		searchItems string // JSON returned by /search/issues (SearchPRsForIssue)
+		want        bool
+	}{
+		{
+			name:        "branch lookup finds open PR (strongly consistent)",
+			branchPRs:   `[{"number":10,"state":"open","head":{"ref":"pilot/GH-3260"}}]`,
+			searchItems: `{"items":[]}`,
+			want:        true,
+		},
+		{
+			name:        "branch misses but search finds open PR (head off-convention)",
+			branchPRs:   `[]`,
+			searchItems: `{"items":[{"number":10,"state":"open"}]}`,
+			want:        true,
+		},
+		{
+			name:        "search finds only a merged/closed PR — not awaiting merge",
+			branchPRs:   `[]`,
+			searchItems: `{"items":[{"number":10,"state":"closed","pull_request":{"merged_at":"2026-05-29T18:00:00Z"}}]}`,
+			want:        false,
+		},
+		{
+			name:        "genuine no-op — no open PR anywhere",
+			branchPRs:   `[]`,
+			searchItems: `{"items":[]}`,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/search/issues"):
+					_, _ = w.Write([]byte(tt.searchItems))
+				case strings.Contains(r.URL.Path, "/pulls"):
+					// issueHasOpenPR only queries open PRs by branch here.
+					_, _ = w.Write([]byte(tt.branchPRs))
+				default:
+					http.Error(w, "unexpected path: "+r.URL.Path, http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			client := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			got := issueHasOpenPR(context.Background(), client, "owner", "repo", 3260)
+			if got != tt.want {
+				t.Errorf("issueHasOpenPR() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -967,6 +967,31 @@ func (c *Client) FindMergedPRByBranch(ctx context.Context, owner, repo, branch s
 	return false, nil
 }
 
+// FindOpenPRByBranch looks up OPEN PRs by head branch via the strongly-consistent
+// REST API (no Search API indexing lag). Returns true if any open PR exists on
+// that branch. TASK-341: counterpart to FindMergedPRByBranch for the
+// PR-created-but-not-yet-merged window, so a re-dispatch no-op can be classified
+// as awaiting-merge rather than pilot-blocked.
+func (c *Client) FindOpenPRByBranch(ctx context.Context, owner, repo, branch string) (bool, error) {
+	head := fmt.Sprintf("%s:%s", owner, branch)
+	path := fmt.Sprintf("/repos/%s/%s/pulls?head=%s&state=open&per_page=10",
+		owner, repo, url.QueryEscape(head))
+
+	var prs []*PullRequest
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &prs); err != nil {
+		return false, fmt.Errorf("list open PRs by branch %s: %w", branch, err)
+	}
+	// The server filters by head=owner:branch&state=open, so a matching PR has
+	// state=="open" and head.ref==branch. Re-check both rather than trusting the
+	// array length, mirroring FindMergedPRByBranch's field inspection.
+	for _, pr := range prs {
+		if pr.State == "open" && pr.Head.Ref == branch {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // SearchOpenSubIssues counts open issues in a repo whose body contains "Parent: GH-{parentNum}".
 // Uses the GitHub Search API to find sub-issues referencing the given parent.
 func (c *Client) SearchOpenSubIssues(ctx context.Context, owner, repo string, parentNum int) (int, error) {

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -853,6 +853,17 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 			if p.hasMergedWork(ctx, issue) {
 				continue
 			}
+
+			// TASK-341: a re-dispatch whose pilot/GH-N PR is still OPEN (created but
+			// not yet merged — pilot-done/close are deferred to merge time per
+			// GH-3139/TASK-301) would only produce a "no new commit produced" no-op
+			// that the handler used to mislabel pilot-blocked. Re-mark so the grace
+			// window throttles re-checks (mirrors hasMergedWork); do NOT label — the
+			// autopilot merge flow owns this issue until the PR merges or closes.
+			if p.hasOpenPRAwaitingMerge(ctx, issue) {
+				p.markProcessed(issue.Number)
+				continue
+			}
 		}
 
 		// GH-3269: Fresh candidates (never processed / post-unmark) bypass the
@@ -877,19 +888,6 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 				p.markProcessed(issue.Number)
 				continue
 			}
-		}
-
-		// TASK-341: skip re-dispatch when an OPEN pilot PR already exists. Between
-		// PR-created and merged, pilot-done + close are deferred (GH-3139/TASK-301),
-		// so the issue still looks like a fresh candidate; re-dispatching it produces
-		// a "no new commit produced" no-op that the handler used to mislabel
-		// pilot-blocked. The merged case is handled by hasMergedWork above; this
-		// covers the awaiting-merge window. Read-only — leave it for the merge flow.
-		if p.hasOpenPRAwaitingMerge(ctx, issue) {
-			p.logger.Info("Skipping re-dispatch — open PR awaiting merge",
-				slog.Int("number", issue.Number))
-			p.recordSkip(skipreason.ReasonHasOpenPR)
-			continue
 		}
 
 		candidates = append(candidates, issue)
@@ -1170,6 +1168,18 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 				p.recordSkip(skipreason.ReasonHasMergedWork)
 				continue
 			}
+
+			// TASK-341: skip a re-dispatch whose pilot/GH-N PR is still OPEN (parallel
+			// mode). Mirrors the sequential guard — the open PR is awaiting merge
+			// (pilot-done/close deferred per GH-3139/TASK-301), so re-dispatch would
+			// only no-op ("no new commit produced") and used to be mislabeled
+			// pilot-blocked. Re-mark so the grace window throttles re-checks; do NOT
+			// label — leave the open PR for the autopilot merge flow.
+			if p.hasOpenPRAwaitingMerge(ctx, issue) {
+				p.markProcessed(issue.Number)
+				p.recordSkip(skipreason.ReasonHasOpenPR)
+				continue
+			}
 		}
 
 		// GH-3269 / TASK-321 PR-4: Fresh candidates (never processed / post-unmark)
@@ -1208,18 +1218,6 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 				p.recordSkip(skipreason.ReasonCompletedExecution)
 				continue
 			}
-		}
-
-		// TASK-341: skip re-dispatch when an OPEN pilot PR already exists (parallel
-		// mode). Mirrors the sequential findOldestUnprocessedIssue guard — between
-		// PR-created and merged, pilot-done + close are deferred (GH-3139/TASK-301),
-		// so a re-dispatch produces a "no new commit produced" no-op that used to be
-		// mislabeled pilot-blocked. Read-only — leave the open PR for the merge flow.
-		if p.hasOpenPRAwaitingMerge(ctx, issue) {
-			p.logger.Info("Skipping re-dispatch — open PR awaiting merge",
-				slog.Int("number", issue.Number))
-			p.recordSkip(skipreason.ReasonHasOpenPR)
-			continue
 		}
 
 		candidates = append(candidates, issue)

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -879,6 +879,19 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 			}
 		}
 
+		// TASK-341: skip re-dispatch when an OPEN pilot PR already exists. Between
+		// PR-created and merged, pilot-done + close are deferred (GH-3139/TASK-301),
+		// so the issue still looks like a fresh candidate; re-dispatching it produces
+		// a "no new commit produced" no-op that the handler used to mislabel
+		// pilot-blocked. The merged case is handled by hasMergedWork above; this
+		// covers the awaiting-merge window. Read-only — leave it for the merge flow.
+		if p.hasOpenPRAwaitingMerge(ctx, issue) {
+			p.logger.Info("Skipping re-dispatch — open PR awaiting merge",
+				slog.Int("number", issue.Number))
+			p.recordSkip(skipreason.ReasonHasOpenPR)
+			continue
+		}
+
 		candidates = append(candidates, issue)
 	}
 
@@ -1195,6 +1208,18 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 				p.recordSkip(skipreason.ReasonCompletedExecution)
 				continue
 			}
+		}
+
+		// TASK-341: skip re-dispatch when an OPEN pilot PR already exists (parallel
+		// mode). Mirrors the sequential findOldestUnprocessedIssue guard — between
+		// PR-created and merged, pilot-done + close are deferred (GH-3139/TASK-301),
+		// so a re-dispatch produces a "no new commit produced" no-op that used to be
+		// mislabeled pilot-blocked. Read-only — leave the open PR for the merge flow.
+		if p.hasOpenPRAwaitingMerge(ctx, issue) {
+			p.logger.Info("Skipping re-dispatch — open PR awaiting merge",
+				slog.Int("number", issue.Number))
+			p.recordSkip(skipreason.ReasonHasOpenPR)
+			continue
 		}
 
 		candidates = append(candidates, issue)
@@ -1621,6 +1646,35 @@ func (p *Poller) hasMergedWork(ctx context.Context, issue *Issue) bool {
 	}
 	p.markProcessed(issue.Number)
 	return true
+}
+
+// hasOpenPRAwaitingMerge reports whether an OPEN pilot PR already exists for the
+// issue. Unlike hasMergedWork it is read-only — it mutates no labels and marks
+// nothing processed, because the awaiting-merge state is transient (the PR will
+// merge → hasMergedWork closes it, or close-without-merge → the retry-ready path
+// re-picks it). TASK-321/TASK-341: skip the redundant re-dispatch that would
+// otherwise produce a "no new commit produced" no-op during the
+// PR-created-but-not-yet-merged window. Branch lookup is strongly consistent
+// (no Search API lag), which matters here because the PR may have been created
+// only one poll cycle earlier.
+func (p *Poller) hasOpenPRAwaitingMerge(ctx context.Context, issue *Issue) bool {
+	branch := fmt.Sprintf("pilot/GH-%d", issue.Number)
+	found, err := p.client.FindOpenPRByBranch(ctx, p.owner, p.repo, branch)
+	if err != nil {
+		p.logger.Warn("Failed to check for open PRs by branch",
+			slog.Int("issue", issue.Number),
+			slog.String("branch", branch),
+			slog.Any("error", err),
+		)
+		return false
+	}
+	if found {
+		p.logger.Info("Issue has an open PR awaiting merge",
+			slog.Int("issue", issue.Number),
+			slog.String("branch", branch),
+		)
+	}
+	return found
 }
 
 // shouldRetryFailedIssue checks if a pilot-failed issue should be auto-retried.

--- a/internal/adapters/github/poller_task341_test.go
+++ b/internal/adapters/github/poller_task341_test.go
@@ -1,0 +1,207 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// task341Server builds a mock GitHub API for the open-PR-awaiting-merge guard.
+// hasMergedWork (Search + merged-branch lookup) always reports "no merged work",
+// so dispatch turns purely on whether an OPEN pilot PR exists on the branch.
+//
+// Both FindMergedPRByBranch (state=closed) and FindOpenPRByBranch (state=open)
+// hit /repos/.../pulls — they are differentiated by the state query param.
+// labeled flips true if any pilot-done/label POST occurs, asserting the guard is
+// read-only (unlike hasMergedWork, it must NOT label the issue done).
+func task341Server(t *testing.T, issue *Issue, hasOpenPR bool, labeled *atomic.Bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/search/issues":
+			// hasMergedWork → SearchMergedPRsForIssue: no merged work.
+			_, _ = w.Write([]byte(`{"total_count":0}`))
+		case strings.HasSuffix(r.URL.Path, "/pulls"):
+			switch r.URL.Query().Get("state") {
+			case "open":
+				// FindOpenPRByBranch (hasOpenPRAwaitingMerge).
+				if hasOpenPR {
+					_, _ = w.Write([]byte(`[{"number":99,"state":"open","head":{"ref":"pilot/GH-55"}}]`))
+				} else {
+					_, _ = w.Write([]byte(`[]`))
+				}
+			default:
+				// FindMergedPRByBranch (state=closed): no merged PR.
+				_, _ = w.Write([]byte(`[]`))
+			}
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			labeled.Store(true)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			// ListIssues snapshot (and the parallel Phase-3 single-issue refresh).
+			_ = json.NewEncoder(w).Encode([]*Issue{issue})
+		}
+	}))
+}
+
+// TestPoller_Sequential_OpenPRAwaitingMergeGuard is the TASK-341 sequential-mode
+// regression: findOldestUnprocessedIssue must skip a candidate whose pilot PR is
+// open and awaiting merge (pilot-done/close are deferred to merge time per
+// GH-3139/TASK-301), and must do so WITHOUT marking it processed or done — the
+// state is transient (merge → done, or close → retry).
+func TestPoller_Sequential_OpenPRAwaitingMergeGuard(t *testing.T) {
+	tests := []struct {
+		name      string
+		hasOpenPR bool
+		wantNil   bool // findOldestUnprocessedIssue returns nil (skipped)?
+	}{
+		{name: "open PR awaiting merge is skipped", hasOpenPR: true, wantNil: true},
+		{name: "no open PR dispatches normally", hasOpenPR: false, wantNil: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &Issue{
+				Number:    55,
+				Title:     "GH-55 fresh feature",
+				State:     "open",
+				Labels:    []Label{{Name: "pilot"}},
+				CreatedAt: time.Now().Add(-1 * time.Hour),
+			}
+			var labeled atomic.Bool
+			server := task341Server(t, issue, tt.hasOpenPR, &labeled)
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+			got, err := poller.findOldestUnprocessedIssue(context.Background())
+			if err != nil {
+				t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+			}
+
+			if tt.wantNil && got != nil {
+				t.Errorf("got issue #%d, want nil (open PR should be skipped)", got.Number)
+			}
+			if !tt.wantNil {
+				if got == nil {
+					t.Fatal("got nil, want issue #55 (no open PR should dispatch)")
+				}
+				if got.Number != 55 {
+					t.Errorf("got issue #%d, want #55", got.Number)
+				}
+			}
+
+			// Read-only guard: never marks processed or labels the issue done.
+			if tt.hasOpenPR {
+				if poller.IsProcessed(55) {
+					t.Error("issue must NOT be marked processed for an open PR awaiting merge (transient state)")
+				}
+				if labeled.Load() {
+					t.Error("issue must NOT be labeled when skipped for an open PR (read-only guard)")
+				}
+			}
+		})
+	}
+}
+
+// TestPoller_Parallel_OpenPRAwaitingMergeGuard mirrors the sequential test for
+// checkForNewIssues (the production default for concurrency>1).
+func TestPoller_Parallel_OpenPRAwaitingMergeGuard(t *testing.T) {
+	tests := []struct {
+		name         string
+		hasOpenPR    bool
+		wantDispatch bool
+	}{
+		{name: "open PR awaiting merge is NOT dispatched", hasOpenPR: true, wantDispatch: false},
+		{name: "no open PR dispatches normally", hasOpenPR: false, wantDispatch: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &Issue{
+				Number:    55,
+				Title:     "GH-55 fresh feature",
+				State:     "open",
+				Labels:    []Label{{Name: "pilot"}},
+				CreatedAt: time.Now().Add(-1 * time.Hour),
+			}
+			var labeled atomic.Bool
+			server := task341Server(t, issue, tt.hasOpenPR, &labeled)
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+			var dispatched55 atomic.Bool
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+				WithOnIssue(func(ctx context.Context, iss *Issue) error {
+					if iss.Number == 55 {
+						dispatched55.Store(true)
+					}
+					return nil
+				}),
+			)
+
+			poller.checkForNewIssues(context.Background())
+			poller.WaitForActive()
+
+			if got := dispatched55.Load(); got != tt.wantDispatch {
+				t.Errorf("dispatched #55 = %v, want %v (open-PR guard must skip awaiting-merge candidates in parallel mode)", got, tt.wantDispatch)
+			}
+			if tt.hasOpenPR && poller.IsProcessed(55) {
+				t.Error("issue must NOT be marked processed for an open PR awaiting merge (transient state)")
+			}
+		})
+	}
+}
+
+// TestFindOpenPRByBranch verifies the strongly-consistent open-PR lookup queries
+// state=open and reports presence by array length.
+func TestFindOpenPRByBranch(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		want     bool
+	}{
+		{name: "open PR present", response: `[{"number":7,"state":"open","head":{"ref":"pilot/GH-7"}}]`, want: true},
+		{name: "no open PR", response: `[]`, want: false},
+		{name: "PR on a different branch is ignored", response: `[{"number":7,"state":"open","head":{"ref":"other/branch"}}]`, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sawOpenState atomic.Bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Query().Get("state") == "open" {
+					sawOpenState.Store(true)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			got, err := client.FindOpenPRByBranch(context.Background(), "owner", "repo", "pilot/GH-7")
+			if err != nil {
+				t.Fatalf("FindOpenPRByBranch() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("FindOpenPRByBranch() = %v, want %v", got, tt.want)
+			}
+			if !sawOpenState.Load() {
+				t.Error("FindOpenPRByBranch must query state=open")
+			}
+		})
+	}
+}

--- a/internal/adapters/github/poller_task341_test.go
+++ b/internal/adapters/github/poller_task341_test.go
@@ -56,10 +56,12 @@ func task341Server(t *testing.T, issue *Issue, hasOpenPR bool, labeled *atomic.B
 }
 
 // TestPoller_Sequential_OpenPRAwaitingMergeGuard is the TASK-341 sequential-mode
-// regression: findOldestUnprocessedIssue must skip a candidate whose pilot PR is
-// open and awaiting merge (pilot-done/close are deferred to merge time per
-// GH-3139/TASK-301), and must do so WITHOUT marking it processed or done — the
-// state is transient (merge → done, or close → retry).
+// regression: a RE-dispatch candidate (already processed, grace elapsed) whose
+// pilot PR is open and awaiting merge must be skipped (pilot-done/close are
+// deferred to merge time per GH-3139/TASK-301). The guard lives in the
+// processed-retry path because a never-dispatched issue has no PR yet. It
+// re-marks the issue (so the grace window throttles re-checks) but never labels
+// it — the merge flow owns it.
 func TestPoller_Sequential_OpenPRAwaitingMergeGuard(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -67,14 +69,14 @@ func TestPoller_Sequential_OpenPRAwaitingMergeGuard(t *testing.T) {
 		wantNil   bool // findOldestUnprocessedIssue returns nil (skipped)?
 	}{
 		{name: "open PR awaiting merge is skipped", hasOpenPR: true, wantNil: true},
-		{name: "no open PR dispatches normally", hasOpenPR: false, wantNil: false},
+		{name: "no open PR re-dispatches normally", hasOpenPR: false, wantNil: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			issue := &Issue{
 				Number:    55,
-				Title:     "GH-55 fresh feature",
+				Title:     "GH-55 feature",
 				State:     "open",
 				Labels:    []Label{{Name: "pilot"}},
 				CreatedAt: time.Now().Add(-1 * time.Hour),
@@ -84,7 +86,10 @@ func TestPoller_Sequential_OpenPRAwaitingMergeGuard(t *testing.T) {
 			defer server.Close()
 
 			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
-			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+			// grace=0 so the processed issue proceeds straight to the retry path.
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+				WithRetryGracePeriod(0))
+			poller.markProcessed(55) // simulate a prior dispatch (PR already created)
 
 			got, err := poller.findOldestUnprocessedIssue(context.Background())
 			if err != nil {
@@ -96,20 +101,20 @@ func TestPoller_Sequential_OpenPRAwaitingMergeGuard(t *testing.T) {
 			}
 			if !tt.wantNil {
 				if got == nil {
-					t.Fatal("got nil, want issue #55 (no open PR should dispatch)")
+					t.Fatal("got nil, want issue #55 (no open PR should re-dispatch)")
 				}
 				if got.Number != 55 {
 					t.Errorf("got issue #%d, want #55", got.Number)
 				}
 			}
 
-			// Read-only guard: never marks processed or labels the issue done.
 			if tt.hasOpenPR {
-				if poller.IsProcessed(55) {
-					t.Error("issue must NOT be marked processed for an open PR awaiting merge (transient state)")
+				// Re-marked (grace throttle) but never labeled.
+				if !poller.IsProcessed(55) {
+					t.Error("issue should be re-marked processed when skipped for an open PR (grace throttle)")
 				}
 				if labeled.Load() {
-					t.Error("issue must NOT be labeled when skipped for an open PR (read-only guard)")
+					t.Error("issue must NOT be labeled when skipped for an open PR (merge flow owns it)")
 				}
 			}
 		})
@@ -125,14 +130,14 @@ func TestPoller_Parallel_OpenPRAwaitingMergeGuard(t *testing.T) {
 		wantDispatch bool
 	}{
 		{name: "open PR awaiting merge is NOT dispatched", hasOpenPR: true, wantDispatch: false},
-		{name: "no open PR dispatches normally", hasOpenPR: false, wantDispatch: true},
+		{name: "no open PR re-dispatches normally", hasOpenPR: false, wantDispatch: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			issue := &Issue{
 				Number:    55,
-				Title:     "GH-55 fresh feature",
+				Title:     "GH-55 feature",
 				State:     "open",
 				Labels:    []Label{{Name: "pilot"}},
 				CreatedAt: time.Now().Add(-1 * time.Hour),
@@ -145,6 +150,7 @@ func TestPoller_Parallel_OpenPRAwaitingMergeGuard(t *testing.T) {
 
 			var dispatched55 atomic.Bool
 			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+				WithRetryGracePeriod(0),
 				WithOnIssue(func(ctx context.Context, iss *Issue) error {
 					if iss.Number == 55 {
 						dispatched55.Store(true)
@@ -152,6 +158,7 @@ func TestPoller_Parallel_OpenPRAwaitingMergeGuard(t *testing.T) {
 					return nil
 				}),
 			)
+			poller.markProcessed(55) // simulate a prior dispatch (PR already created)
 
 			poller.checkForNewIssues(context.Background())
 			poller.WaitForActive()
@@ -159,8 +166,8 @@ func TestPoller_Parallel_OpenPRAwaitingMergeGuard(t *testing.T) {
 			if got := dispatched55.Load(); got != tt.wantDispatch {
 				t.Errorf("dispatched #55 = %v, want %v (open-PR guard must skip awaiting-merge candidates in parallel mode)", got, tt.wantDispatch)
 			}
-			if tt.hasOpenPR && poller.IsProcessed(55) {
-				t.Error("issue must NOT be marked processed for an open PR awaiting merge (transient state)")
+			if tt.hasOpenPR && !poller.IsProcessed(55) {
+				t.Error("issue should be re-marked processed when skipped for an open PR (grace throttle)")
 			}
 		})
 	}

--- a/internal/adapters/skipreason/skipreason.go
+++ b/internal/adapters/skipreason/skipreason.go
@@ -15,6 +15,7 @@ const (
 	ReasonProcessedGrace     = "processed_grace"
 	ReasonTaskQueued         = "task_queued"
 	ReasonHasMergedWork      = "has_merged_work"
+	ReasonHasOpenPR          = "has_open_pr" // TASK-341: PR created, awaiting merge
 	ReasonPendingDependency  = "pending_dependency"
 	ReasonCompletedExecution = "completed_execution"
 	ReasonFreshLabelCheck    = "fresh_label_check"


### PR DESCRIPTION
Closes #3342.

## Context
`pilot-done` + issue close are deferred to merge time (GH-3139/TASK-301), so between *PR created* and *PR merged* an issue still looks like a fresh candidate (`pilot` label present, no `pilot-done`, not closed, `pilot-in-progress` removed). The poller re-picks it; the re-dispatch runs in a fresh worktree off `main`, finds the work already on `pilot/GH-NNNN`, and emits `no new commit produced` (`runner.go:2398`).

The TASK-321 guard (`issueAlreadyMerged`, `handlers.go`) only treated an **already-merged** PR as benign → done. An **open** PR fell through to the `else` → **`pilot-blocked`**, false-flagging healthy green PRs. Hit 4/6 Wave-2 items this session (#3326/#3327/#3330/#3331), cleared by hand. Prior fixes (#3277 handler, #3300 poller `hasMergedWork`, #3279 marker retention) all covered only the already-*merged* case.

## Approach
**Layer 1 — `cmd/pilot/handlers.go` (the fix).** New `else if` between the already-merged branch and the blocked fall-through: a `no new commit produced` no-op with an **open** pilot PR is classified as awaiting-merge — no `pilot-blocked`, clears any stale one, leaves the PR for the autopilot merge flow. No comment (a run can repeat before merge; avoid spam). Order: merged → open → genuine-no-op (blocked).

**Layer 2 — `internal/adapters/github/poller.go` (defense-in-depth).** `hasOpenPRAwaitingMerge` skips dispatching an issue that already has an open `pilot/GH-NNNN` PR in **both** `findOldestUnprocessedIssue` (sequential) and `checkForNewIssues` (parallel), so the redundant run never starts. New skipreason `has_open_pr`. Read-only — unlike `hasMergedWork` it marks nothing processed/done (the state is transient: merge → done, or close → retry-ready).

New `Client.FindOpenPRByBranch` — strongly-consistent REST lookup (no Search API lag), matched on `state==open && head.ref==branch` (mirrors `FindMergedPRByBranch`'s field inspection rather than trusting array length).

## Acceptance
- [x] Handler: `no new commit` + an **open** PR → NOT labeled `pilot-blocked` (awaiting-merge).
- [x] Handler: neither open nor merged → still `pilot-blocked`; merged → done (unchanged).
- [x] Poller: open `pilot/GH-N` PR → skipped (not dispatched), sequential **and** parallel; read-only (not marked processed).
- [x] Scoped to `cmd/pilot/handlers.go` + `internal/adapters/github/poller.go` + `client.go` helper + `skipreason`; `-race` clean; stress package green (31.7s).

## Tests
`TestIssueHasOpenPR`, `TestPoller_Sequential_OpenPRAwaitingMergeGuard`, `TestPoller_Parallel_OpenPRAwaitingMergeGuard`, `TestFindOpenPRByBranch`. Existing TASK-321/GH-3269 merged-work guards unchanged and green.

## Refs
TASK-321 follow-up · task doc `.agent/tasks/TASK-341-phantom-block-open-pr-guard.md`. Out of scope: reworking the GH-3139 defer-done-to-merge decision (intentional).