### PR TITLE
fix(memory): memory-store integrity cluster — D3/D5/D6/D7

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -97,12 +97,13 @@ type TaskMonitor interface {
 // EvalStore persists eval tasks extracted from merged PRs.
 type EvalStore interface {
 	SaveEvalTask(task *memory.EvalTask) error
-	// UpdateExecutionStatusByTaskID updates execution status by task ID.
+	// UpdateExecutionStatusByTaskID updates execution status by task ID and project path.
 	// Used to mark failed executions as completed when the PR is merged.
-	UpdateExecutionStatusByTaskID(taskID, status string) error
+	UpdateExecutionStatusByTaskID(taskID, projectPath, status string) error
 	// SelfHealExecutionAfterMerge promotes failed rows to completed and
-	// stamps the PR URL after a successful merge. GH-2402.
-	SelfHealExecutionAfterMerge(taskID, prURL string) error
+	// stamps the PR URL after a successful merge. projectPath scopes the update
+	// to prevent cross-repo clobbering. GH-2402.
+	SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) error
 }
 
 // ControllerOption is a functional option for Controller configuration.
@@ -1393,7 +1394,8 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 		// merged via parent, etc.).
 		if c.evalStore != nil {
 			taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
-			if err := c.evalStore.SelfHealExecutionAfterMerge(taskID, prState.PRURL); err != nil {
+			projectPath := c.owner + "/" + c.repo
+			if err := c.evalStore.SelfHealExecutionAfterMerge(taskID, projectPath, prState.PRURL); err != nil {
 				c.log.Warn("failed to self-heal execution on merge",
 					"task_id", taskID, "error", err)
 			}

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -533,6 +533,9 @@ func TestController_HandleMerging_SelfHealsExecution(t *testing.T) {
 	if got.TaskID != "GH-99" {
 		t.Errorf("self-heal task ID = %q, want GH-99", got.TaskID)
 	}
+	if got.ProjectPath != "owner/repo" {
+		t.Errorf("self-heal project path = %q, want owner/repo", got.ProjectPath)
+	}
 	if got.PRURL != "https://github.com/owner/repo/pull/42" {
 		t.Errorf("self-heal PR URL = %q, want PR URL", got.PRURL)
 	}
@@ -3838,13 +3841,15 @@ type mockEvalStore struct {
 }
 
 type selfHealCall struct {
-	TaskID string
-	PRURL  string
+	TaskID      string
+	ProjectPath string
+	PRURL       string
 }
 
 type updateStatusCall struct {
-	TaskID string
-	Status string
+	TaskID      string
+	ProjectPath string
+	Status      string
 }
 
 func (m *mockEvalStore) SaveEvalTask(task *memory.EvalTask) error {
@@ -3852,13 +3857,13 @@ func (m *mockEvalStore) SaveEvalTask(task *memory.EvalTask) error {
 	return nil
 }
 
-func (m *mockEvalStore) UpdateExecutionStatusByTaskID(taskID, status string) error {
-	m.updateStatus = append(m.updateStatus, updateStatusCall{TaskID: taskID, Status: status})
+func (m *mockEvalStore) UpdateExecutionStatusByTaskID(taskID, projectPath, status string) error {
+	m.updateStatus = append(m.updateStatus, updateStatusCall{TaskID: taskID, ProjectPath: projectPath, Status: status})
 	return nil
 }
 
-func (m *mockEvalStore) SelfHealExecutionAfterMerge(taskID, prURL string) error {
-	m.selfHealed = append(m.selfHealed, selfHealCall{TaskID: taskID, PRURL: prURL})
+func (m *mockEvalStore) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) error {
+	m.selfHealed = append(m.selfHealed, selfHealCall{TaskID: taskID, ProjectPath: projectPath, PRURL: prURL})
 	return nil
 }
 

--- a/internal/autopilot/metrics_persister.go
+++ b/internal/autopilot/metrics_persister.go
@@ -108,4 +108,11 @@ func (mp *MetricsPersister) prune() {
 	} else if deleted > 0 {
 		mp.log.Debug("pruned old autopilot metrics", slog.Int64("deleted", deleted))
 	}
+
+	deletedLogs, err := mp.store.PruneExecutionLogs(mp.retention)
+	if err != nil {
+		mp.log.Warn("failed to prune execution logs", slog.Any("error", err))
+	} else if deletedLogs > 0 {
+		mp.log.Debug("pruned old execution logs", slog.Int64("deleted", deletedLogs))
+	}
 }

--- a/internal/memory/knowledge.go
+++ b/internal/memory/knowledge.go
@@ -271,6 +271,9 @@ func (k *KnowledgeStore) GetMemoryStats() (*MemoryStats, error) {
 		}
 		stats.ByType[memType] = count
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return stats, nil
 }

--- a/internal/memory/metering.go
+++ b/internal/memory/metering.go
@@ -335,6 +335,9 @@ func (s *Store) GetDailyUsage(query UsageQuery) ([]*DailyUsage, error) {
 			du.ComputeCost = cost
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	// Convert to slice
 	var result []*DailyUsage
@@ -394,7 +397,7 @@ func (s *Store) GetUsageByProject(query UsageQuery) ([]*ProjectUsage, error) {
 		result = append(result, &pu)
 	}
 
-	return result, nil
+	return result, rows.Err()
 }
 
 // ProjectUsage represents usage for a single project
@@ -460,7 +463,7 @@ func (s *Store) GetUsageEvents(query UsageQuery, limit int) ([]*UsageEvent, erro
 		events = append(events, &e)
 	}
 
-	return events, nil
+	return events, rows.Err()
 }
 
 // UsageThreshold defines an alert threshold for usage

--- a/internal/memory/metrics.go
+++ b/internal/memory/metrics.go
@@ -364,7 +364,7 @@ func (s *Store) GetDailyMetrics(query MetricsQuery) ([]*DailyMetrics, error) {
 		metrics = append(metrics, &m)
 	}
 
-	return metrics, nil
+	return metrics, rows.Err()
 }
 
 // GetProjectMetrics returns metrics aggregated by project
@@ -429,7 +429,7 @@ func (s *Store) GetProjectMetrics(query MetricsQuery) ([]*ProjectMetrics, error)
 		metrics = append(metrics, &m)
 	}
 
-	return metrics, nil
+	return metrics, rows.Err()
 }
 
 // GetFailureReasons returns breakdown of failure reasons
@@ -477,7 +477,7 @@ func (s *Store) GetFailureReasons(query MetricsQuery, limit int) ([]*FailureReas
 		reasons = append(reasons, &r)
 	}
 
-	return reasons, nil
+	return reasons, rows.Err()
 }
 
 // GetPeakUsageHours returns execution counts by hour of day
@@ -521,7 +521,7 @@ func (s *Store) GetPeakUsageHours(query MetricsQuery) (map[int]int, error) {
 		hours[hour] = count
 	}
 
-	return hours, nil
+	return hours, rows.Err()
 }
 
 // ExportMetrics exports execution data for external analytics
@@ -612,7 +612,7 @@ func (s *Store) ExportMetrics(query MetricsQuery) ([]*ExportedExecution, error) 
 		exports = append(exports, &e)
 	}
 
-	return exports, nil
+	return exports, rows.Err()
 }
 
 // ExportedExecution represents an execution record for export

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -668,7 +668,7 @@ func (s *Store) GetRecentExecutions(limit int) ([]*Execution, error) {
 		executions = append(executions, &exec)
 	}
 
-	return executions, nil
+	return executions, rows.Err()
 }
 
 // Pattern represents a learned pattern from project executions.
@@ -738,7 +738,7 @@ func (s *Store) GetPatterns(projectPath string) ([]*Pattern, error) {
 		patterns = append(patterns, &p)
 	}
 
-	return patterns, nil
+	return patterns, rows.Err()
 }
 
 // Project represents a registered project in Pilot.
@@ -822,7 +822,7 @@ func (s *Store) GetAllProjects() ([]*Project, error) {
 		projects = append(projects, &p)
 	}
 
-	return projects, nil
+	return projects, rows.Err()
 }
 
 // BriefQuery holds parameters for querying execution data within a time period.
@@ -884,7 +884,7 @@ func (s *Store) GetExecutionsInPeriod(query BriefQuery) ([]*Execution, error) {
 		executions = append(executions, &exec)
 	}
 
-	return executions, nil
+	return executions, rows.Err()
 }
 
 // GetActiveExecutions retrieves all executions with status "running".
@@ -913,7 +913,7 @@ func (s *Store) GetActiveExecutions() ([]*Execution, error) {
 		executions = append(executions, &exec)
 	}
 
-	return executions, nil
+	return executions, rows.Err()
 }
 
 // GetBriefMetrics calculates aggregate metrics for a time period including
@@ -1001,7 +1001,7 @@ func (s *Store) GetQueuedTasks(limit int) ([]*Execution, error) {
 		executions = append(executions, &exec)
 	}
 
-	return executions, nil
+	return executions, rows.Err()
 }
 
 // GetQueuedTasksForProject returns queued/pending tasks for a specific project.
@@ -1041,7 +1041,7 @@ func (s *Store) GetQueuedTasksForProject(projectPath string, limit int) ([]*Exec
 		executions = append(executions, &exec)
 	}
 
-	return executions, nil
+	return executions, rows.Err()
 }
 
 // UpdateExecutionStatus updates the status of an execution record.
@@ -1075,33 +1075,37 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 }
 
 // UpdateExecutionStatusByTaskID updates the status of the most recent execution
-// for a given task ID. Used by autopilot to mark failed executions as completed
-// when the PR is merged externally.
-func (s *Store) UpdateExecutionStatusByTaskID(taskID, status string) error {
+// for a given task ID and project path. Used by autopilot to mark failed
+// executions as completed when the PR is merged externally.
+// The projectPath scope prevents cross-project clobbering when the same task ID
+// appears in multiple repos.
+func (s *Store) UpdateExecutionStatusByTaskID(taskID, projectPath, status string) error {
 	return s.withRetry("UpdateExecutionStatusByTaskID", func() error {
 		_, err := s.db.Exec(`
 			UPDATE executions
 			SET status = ?, completed_at = CURRENT_TIMESTAMP
-			WHERE task_id = ? AND status = 'failed'
-		`, status, taskID)
+			WHERE task_id = ? AND project_path = ? AND status = 'failed'
+		`, status, taskID, projectPath)
 		return err
 	})
 }
 
 // SelfHealExecutionAfterMerge promotes any "failed" rows for the given task ID
-// to "completed" and stamps the PR URL so the dashboard reflects the merged
-// outcome. Used when autopilot observes a merge for an issue whose previous
-// execution row was recorded as failed (e.g. user-pushed commits, sub-issue
-// shipped via parent epic). GH-2402.
-func (s *Store) SelfHealExecutionAfterMerge(taskID, prURL string) error {
+// and project path to "completed" and stamps the PR URL so the dashboard
+// reflects the merged outcome. Used when autopilot observes a merge for an
+// issue whose previous execution row was recorded as failed (e.g. user-pushed
+// commits, sub-issue shipped via parent epic). GH-2402.
+// The projectPath scope prevents cross-project clobbering when the same task ID
+// appears in multiple repos.
+func (s *Store) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) error {
 	return s.withRetry("SelfHealExecutionAfterMerge", func() error {
 		_, err := s.db.Exec(`
 			UPDATE executions
 			SET status = 'completed',
 				completed_at = CURRENT_TIMESTAMP,
 				pr_url = CASE WHEN ? <> '' THEN ? ELSE pr_url END
-			WHERE task_id = ? AND status = 'failed'
-		`, prURL, prURL, taskID)
+			WHERE task_id = ? AND project_path = ? AND status = 'failed'
+		`, prURL, prURL, taskID, projectPath)
 		return err
 	})
 }
@@ -1160,7 +1164,7 @@ func (s *Store) GetStaleRunningExecutions(staleDuration time.Duration) ([]*Execu
 		executions = append(executions, &exec)
 	}
 
-	return executions, nil
+	return executions, rows.Err()
 }
 
 // GetStaleQueuedExecutions returns executions that have been in "queued" status
@@ -1191,7 +1195,7 @@ func (s *Store) GetStaleQueuedExecutions(staleDuration time.Duration) ([]*Execut
 		executions = append(executions, &exec)
 	}
 
-	return executions, nil
+	return executions, rows.Err()
 }
 
 // DeleteExecution removes an execution row by ID. Used to clean up orphan rows
@@ -1382,7 +1386,7 @@ func (s *Store) scanCrossPatterns(rows *sql.Rows) ([]*CrossPattern, error) {
 		}
 		patterns = append(patterns, &p)
 	}
-	return patterns, nil
+	return patterns, rows.Err()
 }
 
 // LinkPatternToProject creates or updates a relationship between a pattern and a project.
@@ -1422,61 +1426,59 @@ func (s *Store) GetProjectsForPattern(patternID string) ([]*PatternProjectLink, 
 		}
 		links = append(links, &link)
 	}
-	return links, nil
+	return links, rows.Err()
 }
 
 // RecordPatternFeedback records feedback when a pattern is applied during an execution.
 // Based on the outcome ("success", "failure", or "neutral"), it adjusts the pattern's
 // confidence score and updates project-level success/failure counts.
+// All three writes (insert feedback, update confidence, update project link) run
+// in a single transaction so a partial failure cannot leave the tables inconsistent.
 func (s *Store) RecordPatternFeedback(feedback *PatternFeedback) error {
-	err := s.withRetry("RecordPatternFeedback", func() error {
-		result, err := s.db.Exec(`
+	return s.withRetry("RecordPatternFeedback", func() error {
+		tx, err := s.db.BeginTx(context.Background(), nil)
+		if err != nil {
+			return fmt.Errorf("begin tx: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		result, err := tx.Exec(`
 			INSERT INTO pattern_feedback (pattern_id, execution_id, project_path, outcome, confidence_delta)
 			VALUES (?, ?, ?, ?, ?)
 		`, feedback.PatternID, feedback.ExecutionID, feedback.ProjectPath, feedback.Outcome, feedback.ConfidenceDelta)
 		if err != nil {
 			return err
 		}
-
 		id, _ := result.LastInsertId()
 		feedback.ID = id
-		return nil
-	})
-	if err != nil {
-		return err
-	}
 
-	// Update pattern confidence and project link based on outcome
-	switch feedback.Outcome {
-	case "success":
-		_ = s.withRetry("RecordPatternFeedback:updateConfidence", func() error {
-			_, err := s.db.Exec(`
+		switch feedback.Outcome {
+		case "success":
+			if _, err := tx.Exec(`
 				UPDATE cross_patterns SET confidence = min(0.95, max(0.1, confidence + ?)) WHERE id = ?
-			`, feedback.ConfidenceDelta, feedback.PatternID)
-			return err
-		})
-		_ = s.withRetry("RecordPatternFeedback:updateSuccess", func() error {
-			_, err := s.db.Exec(`
+			`, feedback.ConfidenceDelta, feedback.PatternID); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(`
 				UPDATE pattern_projects SET success_count = success_count + 1 WHERE pattern_id = ? AND project_path = ?
-			`, feedback.PatternID, feedback.ProjectPath)
-			return err
-		})
-	case "failure":
-		_ = s.withRetry("RecordPatternFeedback:updateConfidence", func() error {
-			_, err := s.db.Exec(`
+			`, feedback.PatternID, feedback.ProjectPath); err != nil {
+				return err
+			}
+		case "failure":
+			if _, err := tx.Exec(`
 				UPDATE cross_patterns SET confidence = max(0.1, min(0.95, confidence - ?)) WHERE id = ?
-			`, feedback.ConfidenceDelta, feedback.PatternID)
-			return err
-		})
-		_ = s.withRetry("RecordPatternFeedback:updateFailure", func() error {
-			_, err := s.db.Exec(`
+			`, feedback.ConfidenceDelta, feedback.PatternID); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(`
 				UPDATE pattern_projects SET failure_count = failure_count + 1 WHERE pattern_id = ? AND project_path = ?
-			`, feedback.PatternID, feedback.ProjectPath)
-			return err
-		})
-	}
+			`, feedback.PatternID, feedback.ProjectPath); err != nil {
+				return err
+			}
+		}
 
-	return nil
+		return tx.Commit()
+	})
 }
 
 // SearchCrossPatterns searches patterns by title, description, or context using substring matching.
@@ -1545,6 +1547,9 @@ func (s *Store) GetCrossPatternStats() (*CrossPatternStats, error) {
 			return nil, err
 		}
 		stats.ByType[pType] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	// Get project count
@@ -1844,6 +1849,30 @@ func (s *Store) LatestAutopilotMetrics() (*AutopilotMetricsRow, error) {
 	r.ExecutionCostUSD = unmarshalStringFloatMap(costJSON.String)
 	r.ExecutionsByResult = unmarshalStringIntMap(execsJSON.String)
 	return r, nil
+}
+
+// PruneExecutionLogs deletes execution log entries older than the given duration.
+// Returns the number of rows deleted. Runs a WAL checkpoint after a large
+// prune (>1000 rows) to reclaim disk space promptly.
+func (s *Store) PruneExecutionLogs(olderThan time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-olderThan)
+	var result sql.Result
+	err := s.withRetry("PruneExecutionLogs", func() error {
+		var execErr error
+		result, execErr = s.db.Exec(`DELETE FROM execution_logs WHERE timestamp < ?`, cutoff)
+		return execErr
+	})
+	if err != nil {
+		return 0, err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	if n > 1000 {
+		_, _ = s.db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`)
+	}
+	return n, nil
 }
 
 // PruneAutopilotMetrics deletes snapshots older than the given duration.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1776,7 +1776,7 @@ func TestUpdateExecutionStatusByTaskID_UpdatesFailedToCompleted(t *testing.T) {
 		Error:       "quality gate failed",
 	})
 
-	if err := store.UpdateExecutionStatusByTaskID("GH-100", "completed"); err != nil {
+	if err := store.UpdateExecutionStatusByTaskID("GH-100", "/tmp/proj", "completed"); err != nil {
 		t.Fatalf("UpdateExecutionStatusByTaskID failed: %v", err)
 	}
 
@@ -1806,7 +1806,7 @@ func TestUpdateExecutionStatusByTaskID_SkipsNonFailed(t *testing.T) {
 		Status:      "completed",
 	})
 
-	if err := store.UpdateExecutionStatusByTaskID("GH-200", "completed"); err != nil {
+	if err := store.UpdateExecutionStatusByTaskID("GH-200", "/tmp/proj", "completed"); err != nil {
 		t.Fatalf("UpdateExecutionStatusByTaskID failed: %v", err)
 	}
 
@@ -1825,8 +1825,65 @@ func TestUpdateExecutionStatusByTaskID_NoMatchingTask(t *testing.T) {
 	defer func() { _ = store.Close() }()
 
 	// Should not error even with no matching rows
-	if err := store.UpdateExecutionStatusByTaskID("GH-999", "completed"); err != nil {
+	if err := store.UpdateExecutionStatusByTaskID("GH-999", "/tmp/proj", "completed"); err != nil {
 		t.Fatalf("expected no error for non-existent task, got: %v", err)
+	}
+}
+
+// TestUpdateExecutionStatusByTaskID_ScopedToProject verifies that updating by task ID
+// only affects rows matching the given project path (D3 regression).
+func TestUpdateExecutionStatusByTaskID_ScopedToProject(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Same task ID, different projects
+	_ = store.SaveExecution(&Execution{ID: "exec-a", TaskID: "GH-300", ProjectPath: "/proj/a", Status: "failed"})
+	_ = store.SaveExecution(&Execution{ID: "exec-b", TaskID: "GH-300", ProjectPath: "/proj/b", Status: "failed"})
+
+	// Only heal project a
+	if err := store.UpdateExecutionStatusByTaskID("GH-300", "/proj/a", "completed"); err != nil {
+		t.Fatalf("UpdateExecutionStatusByTaskID: %v", err)
+	}
+
+	execA, _ := store.GetExecution("exec-a")
+	if execA.Status != "completed" {
+		t.Errorf("exec-a: expected 'completed', got %q", execA.Status)
+	}
+	execB, _ := store.GetExecution("exec-b")
+	if execB.Status != "failed" {
+		t.Errorf("exec-b: expected 'failed' (unaffected), got %q", execB.Status)
+	}
+}
+
+// TestSelfHealExecutionAfterMerge_ScopedToProject verifies that self-heal only
+// promotes rows matching the given project path (D3 regression).
+func TestSelfHealExecutionAfterMerge_ScopedToProject(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "heal-a", TaskID: "GH-400", ProjectPath: "/proj/a", Status: "failed"})
+	_ = store.SaveExecution(&Execution{ID: "heal-b", TaskID: "GH-400", ProjectPath: "/proj/b", Status: "failed"})
+
+	if err := store.SelfHealExecutionAfterMerge("GH-400", "/proj/a", "https://github.com/org/repo/pull/1"); err != nil {
+		t.Fatalf("SelfHealExecutionAfterMerge: %v", err)
+	}
+
+	execA, _ := store.GetExecution("heal-a")
+	if execA.Status != "completed" {
+		t.Errorf("heal-a: expected 'completed', got %q", execA.Status)
+	}
+	if execA.PRUrl != "https://github.com/org/repo/pull/1" {
+		t.Errorf("heal-a: expected pr_url to be stamped, got %q", execA.PRUrl)
+	}
+	execB, _ := store.GetExecution("heal-b")
+	if execB.Status != "failed" {
+		t.Errorf("heal-b: expected 'failed' (unaffected), got %q", execB.Status)
 	}
 }
 
@@ -2144,5 +2201,118 @@ func TestEffortLevelColumns_RoundTrip(t *testing.T) {
 	}
 	if got2.ComplexityLevel != "complex" {
 		t.Errorf("after update: ComplexityLevel = %q, want %q", got2.ComplexityLevel, "complex")
+	}
+}
+
+// TestPruneExecutionLogs verifies D5: deletes logs older than the cutoff and
+// leaves newer ones untouched.
+func TestPruneExecutionLogs(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	old := time.Now().Add(-2 * time.Hour)
+	recent := time.Now().Add(-10 * time.Minute)
+
+	// Insert two old entries and one recent entry directly.
+	_, err = store.db.Exec(`INSERT INTO execution_logs (timestamp, level, message, component) VALUES (?, 'info', 'old1', 'test')`, old)
+	if err != nil {
+		t.Fatalf("insert old1: %v", err)
+	}
+	_, err = store.db.Exec(`INSERT INTO execution_logs (timestamp, level, message, component) VALUES (?, 'info', 'old2', 'test')`, old)
+	if err != nil {
+		t.Fatalf("insert old2: %v", err)
+	}
+	_, err = store.db.Exec(`INSERT INTO execution_logs (timestamp, level, message, component) VALUES (?, 'info', 'recent', 'test')`, recent)
+	if err != nil {
+		t.Fatalf("insert recent: %v", err)
+	}
+
+	deleted, err := store.PruneExecutionLogs(time.Hour)
+	if err != nil {
+		t.Fatalf("PruneExecutionLogs: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("deleted = %d, want 2", deleted)
+	}
+
+	var count int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM execution_logs`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("remaining rows = %d, want 1", count)
+	}
+}
+
+// TestRecordPatternFeedback_TransactionAtomicity verifies D6: all three writes
+// inside RecordPatternFeedback succeed together — the feedback row, the
+// confidence update, and the project-link update.
+func TestRecordPatternFeedback_TransactionAtomicity(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Prerequisites: a cross pattern and a project link must exist for the
+	// confidence/link UPDATE statements to match rows.
+	pattern := &CrossPattern{
+		ID:          "pat-tx-1",
+		Type:        "code",
+		Title:       "test pattern",
+		Description: "desc",
+		Confidence:  0.5,
+		Occurrences: 1,
+		Scope:       "org",
+	}
+	if err := store.SaveCrossPattern(pattern); err != nil {
+		t.Fatalf("SaveCrossPattern: %v", err)
+	}
+	if err := store.LinkPatternToProject("pat-tx-1", "/proj/tx"); err != nil {
+		t.Fatalf("LinkPatternToProject: %v", err)
+	}
+	// Seed an execution row so the FK constraint on pattern_feedback is satisfied.
+	if err := store.SaveExecution(&Execution{ID: "exec-tx-1", TaskID: "GH-TX", ProjectPath: "/proj/tx", Status: "completed"}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	fb := &PatternFeedback{
+		PatternID:       "pat-tx-1",
+		ExecutionID:     "exec-tx-1",
+		ProjectPath:     "/proj/tx",
+		Outcome:         "success",
+		ConfidenceDelta: 0.1,
+	}
+	if err := store.RecordPatternFeedback(fb); err != nil {
+		t.Fatalf("RecordPatternFeedback: %v", err)
+	}
+	if fb.ID == 0 {
+		t.Error("expected feedback ID to be set after insert")
+	}
+
+	// Confidence should have increased.
+	updated, err := store.GetCrossPattern("pat-tx-1")
+	if err != nil {
+		t.Fatalf("GetCrossPattern: %v", err)
+	}
+	if updated.Confidence <= 0.5 {
+		t.Errorf("confidence = %.3f, want > 0.5", updated.Confidence)
+	}
+
+	// Project link success_count should be 1.
+	links, err := store.GetProjectsForPattern("pat-tx-1")
+	if err != nil {
+		t.Fatalf("GetProjectsForPattern: %v", err)
+	}
+	if len(links) == 0 || links[0].SuccessCount != 1 {
+		t.Errorf("success_count = %d, want 1", func() int {
+			if len(links) > 0 {
+				return links[0].SuccessCount
+			}
+			return -1
+		}())
 	}
 }


### PR DESCRIPTION
## Summary

- **D3** — `UpdateExecutionStatusByTaskID` and `SelfHealExecutionAfterMerge` now require `projectPath` in addition to `taskID`, adding `AND project_path = ?` to both WHERE clauses. Prevents cross-repo clobbering when the same GH-NNN task ID appears in multiple repos. Updates `EvalStore` interface, controller callers, and mock; adds regression tests.
- **D5** — New `PruneExecutionLogs(olderThan time.Duration) (int64, error)` mirrors `PruneAutopilotMetrics`; runs a WAL `TRUNCATE` checkpoint after large prunes (>1000 rows). Wired into `MetricsPersister.prune()` on the same 5-minute cycle.
- **D6** — `RecordPatternFeedback` now wraps all three DB writes (INSERT feedback, UPDATE confidence, UPDATE project link) in a single `BeginTx` transaction. Errors are propagated instead of silently discarded.
- **D7** — Added `rows.Err()` checks after every `for rows.Next()` loop in `store.go` (13 functions), `metrics.go` (5 functions), `metering.go` (3 functions), and `knowledge.go` (1 function). Already-correct files (`eval.go`, `knowledge.go scanMemories`) untouched.

## Test plan

- [ ] `go test ./internal/memory/...` — all tests green including 4 new tests (D3 scoping regression ×2, D5 prune, D6 atomicity)
- [ ] `go test ./internal/autopilot/...` — self-heal and handle-merged tests pass with updated projectPath assertions
- [ ] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [ ] `go build ./...` — clean