### PR TITLE
fix(logging): serialize cleanOldLogs — prevent concurrent cleanup races (E6)

### DIFF
--- a/internal/logging/rotation.go
+++ b/internal/logging/rotation.go
@@ -20,6 +20,7 @@ type rotatingWriter struct {
 	maxBackups int
 
 	mu          sync.Mutex
+	cleanMu     sync.Mutex // serializes cleanOldLogs; TryLock skips redundant concurrent spawns
 	file        *os.File
 	currentSize int64
 }
@@ -144,9 +145,23 @@ func (w *rotatingWriter) rotate() error {
 }
 
 // cleanOldLogs removes old backup files.
+// At most one invocation runs at a time; concurrent spawns are skipped via TryLock.
 func (w *rotatingWriter) cleanOldLogs() {
-	dir := filepath.Dir(w.filename)
-	base := filepath.Base(w.filename)
+	// Skip if a cleanup is already in progress.
+	if !w.cleanMu.TryLock() {
+		return
+	}
+	defer w.cleanMu.Unlock()
+
+	// Snapshot config fields under the writer lock to avoid a race with Write/rotate.
+	w.mu.Lock()
+	filename := w.filename
+	maxAge := w.maxAge
+	maxBackups := w.maxBackups
+	w.mu.Unlock()
+
+	dir := filepath.Dir(filename)
+	base := filepath.Base(filename)
 	ext := filepath.Ext(base)
 	prefix := strings.TrimSuffix(base, ext)
 
@@ -165,7 +180,7 @@ func (w *rotatingWriter) cleanOldLogs() {
 
 	now := time.Now()
 	for _, match := range matches {
-		if match == w.filename {
+		if match == filename {
 			continue
 		}
 		info, err := os.Stat(match)
@@ -173,8 +188,8 @@ func (w *rotatingWriter) cleanOldLogs() {
 			continue
 		}
 
-		// Skip if too old
-		if now.Sub(info.ModTime()) > w.maxAge {
+		// Remove files older than maxAge.
+		if now.Sub(info.ModTime()) > maxAge {
 			_ = os.Remove(match)
 			continue
 		}
@@ -182,13 +197,13 @@ func (w *rotatingWriter) cleanOldLogs() {
 		files = append(files, fileInfo{path: match, modTime: info.ModTime()})
 	}
 
-	// Sort by mod time, oldest first
+	// Sort by mod time, oldest first.
 	sort.Slice(files, func(i, j int) bool {
 		return files[i].modTime.Before(files[j].modTime)
 	})
 
-	// Remove excess backups
-	for len(files) > w.maxBackups {
+	// Remove excess backups beyond maxBackups.
+	for len(files) > maxBackups {
 		_ = os.Remove(files[0].path)
 		files = files[1:]
 	}

--- a/internal/logging/rotation_test.go
+++ b/internal/logging/rotation_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -426,5 +427,61 @@ func TestRotatingWriterMaxBackups(t *testing.T) {
 	// MaxBackups is 1, so at most 1 backup should exist (might be cleaned up)
 	if len(matches) > 1 {
 		t.Errorf("expected at most 1 backup file, found %d: %v", len(matches), matches)
+	}
+}
+
+// TestCleanOldLogsConcurrency verifies that concurrent rotations do not race on
+// cleanOldLogs and never delete the active log file.  Run with -race to catch
+// data races introduced by the fix regression.
+func TestCleanOldLogsConcurrency(t *testing.T) {
+	tmpDir := t.TempDir()
+	logFile := filepath.Join(tmpDir, "test.log")
+
+	cfg := &RotationConfig{
+		MaxSize:    "100B",
+		MaxAge:     "1d",
+		MaxBackups: 2,
+	}
+
+	writer, err := newRotatingWriter(logFile, cfg)
+	if err != nil {
+		t.Fatalf("failed to create rotating writer: %v", err)
+	}
+
+	rw := writer.(*rotatingWriter)
+	defer func() { _ = rw.Close() }()
+
+	// Drive many concurrent writes to trigger parallel rotation+cleanup paths.
+	const goroutines = 10
+	const writesPerGoroutine = 20
+	msg := strings.Repeat("x", 60) + "\n"
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < writesPerGoroutine; j++ {
+				_, _ = rw.Write([]byte(msg))
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Allow any in-flight cleanup to finish.
+	time.Sleep(50 * time.Millisecond)
+
+	// The active log file must not have been deleted by cleanup.
+	if _, statErr := os.Stat(logFile); os.IsNotExist(statErr) {
+		t.Error("active log file was deleted by cleanOldLogs")
+	}
+
+	// Backup count must not exceed maxBackups.
+	matches, err := filepath.Glob(filepath.Join(tmpDir, "test.*.log"))
+	if err != nil {
+		t.Fatalf("failed to glob backup files: %v", err)
+	}
+	if len(matches) > cfg.MaxBackups {
+		t.Errorf("expected at most %d backup files, found %d: %v", cfg.MaxBackups, len(matches), matches)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `cleanMu sync.Mutex` to `rotatingWriter`; `cleanOldLogs` calls `TryLock` so redundant concurrent spawns return immediately without doing any filesystem work.
- Snapshot `filename`, `maxAge`, `maxBackups` under `w.mu` at the top of `cleanOldLogs`, eliminating the data race with concurrent `Write`/`rotate` calls that was previously accessing those fields unlocked.
- Add `TestCleanOldLogsConcurrency`: 10 goroutines × 20 writes with a 100-byte rotation threshold drives parallel rotation+cleanup paths; asserts no race (verified with `-race`), active log file not deleted, backup count within limit.

Closes #3351

## Test plan

- [x] `go test -race ./internal/logging/...` — all pass, no data race reported
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/logging/...` — 0 issues
- [x] `go build ./...` — clean