### PR TITLE
fix(autopilot): self-heal merged work — project_path scope + scan + parent (TASK-352)

### DIFF
--- a/.agent/tasks/TASK-352-selfheal-projectpath-scan-parent.md
+++ b/.agent/tasks/TASK-352-selfheal-projectpath-scan-parent.md
@@ -1,0 +1,67 @@
+# TASK-352: self-heal is broken — dashboard shows merged work as `failed`
+
+**Status:** in progress (MANUAL — autopilot-core, self-modifying) · **Created:** 2026-06-01 · **Found via:** TASK-322 Wave 3 watch loop (dashboard QUEUE showed GH-3344/3353/3349 as `✗ failed` after they shipped as v2.166.2).
+
+## Context
+
+The dashboard QUEUE renders the `executions` table `Status` column verbatim
+(`internal/dashboard/tui.go:614,848`, fed by `GetRecentExecutions`) with **no** reconciliation
+against GitHub issue-closed / PR-merged state. A row flips `failed → completed` only via
+`SelfHealExecutionAfterMerge`. Three compounding bugs leave shipped work showing `failed`:
+
+- **Bug 0 — D3 regression (PR #3354, merged 2026-06-01).** D3 scoped self-heal with
+  `WHERE task_id=? AND project_path=? AND status='failed'`, and the controller passes
+  `projectPath := c.owner + "/" + c.repo` (`qf-studio/pilot`). But `executions.project_path` stores
+  the **absolute filesystem path** (`/Users/.../pilot` — set at `runner.go:1878 ProjectPath: executionPath`;
+  confirmed in the live DB: `~/.pilot/data/pilot.db`). The two never match → self-heal updates **zero
+  rows on every merge path**, controller-driven included. D3's intent (prevent cross-repo clobber) was
+  right; the discriminator value was wrong.
+- **Bug 1 — `ScanRecentlyMergedPRs` never self-heals.** `controller.go:2417` is the only catch-all for
+  PRs merged outside the controller (`gh pr merge`, GitHub UI — which is exactly how the Wave-3 watch
+  loop merges). It records merge metrics and injects the PR at `StageReleasing` to trigger a release,
+  but never calls `SelfHealExecutionAfterMerge`. So manual/UI merges never heal.
+- **Bug 2 — parent task never heals.** Self-heal keys on `GH-<merged PR's issue number>`. Pilot
+  decomposes a parent issue into a sub-issue (parent GH-3344 → sub GH-3353; the PR is `pilot/GH-3353`).
+  Healing GH-3353 never touches the parent GH-3344's no-op `failed` row, which has no PR of its own.
+
+Not the TASK-321/341 phantom-block bug — that's the GitHub-label/dispatch layer (working: these issues
+did not redispatch-loop). This is the executions/self-heal layer, untouched by those fixes.
+
+## Approach
+
+All in `internal/autopilot/controller.go` + `internal/memory/store.go` (autopilot core → MANUAL, like M1/M2).
+
+1. **Bug 0 — correct discriminator.** Add `projectPath string` field + `WithProjectPath(path)` option to
+   the controller (functional-option pattern, backward-compatible — tests/unset → empty). Thread the
+   filesystem `projectPath` at the 3 `NewController` call sites in `cmd/pilot/main.go` (485/1465/1487 —
+   it is already in scope, already passed to `WithExecutionChecker`). Make
+   `SelfHealExecutionAfterMerge` tolerate empty projectPath:
+   `WHERE task_id=? AND status='failed' AND (? = '' OR project_path = ?)` — keeps D3 cross-repo scoping
+   when the path is known (production), reverts to task_id-only legacy match when empty (safe single-repo).
+2. **Bug 1 + 2 — `selfHealForPR(ctx, issueNum, prURL)` helper.** Promotes the issue's failed rows AND,
+   if the issue body matches `(?i)Parent:\s*GH-(\d+)` (same ref as `epic.go`), the parent's rows.
+   Resolve parent via `c.ghClient.GetIssue` (already used in 6+ handlers; concrete client, httptest-tested).
+   - Replace the inline self-heal block at `controller.go:~1398` with `c.selfHealForPR(...)`.
+   - Add a `c.selfHealForPR(ctx, issueNum, pr.HTMLURL)` call in `ScanRecentlyMergedPRs` right after
+     `recordMergeSuccess` (fires regardless of the release-tag skip gates), guarded by `issueNum != 0`.
+3. **Backfill (operational, one-time).** The current stale rows (GH-3344/3353/3349/etc.) are past the
+   30-min scan window and the daemon runs an older binary, so the code fix won't retroactively heal them.
+   `UPDATE executions SET status='completed' WHERE task_id IN (...shipped...) AND status='failed'` after
+   the merged Wave-3 task IDs are confirmed shipped.
+
+## Acceptance
+
+- [ ] `SelfHealExecutionAfterMerge` heals rows whose `project_path` is the filesystem path (Bug 0); test with a realistic fs-path row asserts the row flips to `completed`.
+- [ ] Empty projectPath falls back to task_id-only match (legacy behavior preserved); existing controller tests stay green.
+- [ ] `ScanRecentlyMergedPRs` self-heals a discovered externally-merged PR's execution row (Bug 1); test asserts a `failed` row → `completed` after a scan over a merged `pilot/GH-N` PR.
+- [ ] A sub-issue PR merge heals the parent task too (Bug 2); test: sub-issue body has `Parent: GH-<n>`, merge heals both `GH-<sub>` and `GH-<n>`.
+- [ ] `WithProjectPath` wired at all 3 `NewController` call sites in `main.go`.
+- [ ] `make build` + `make test` (autopilot, memory) green; `make lint` clean.
+- [ ] Stale Wave-3 rows backfilled so the dashboard QUEUE no longer shows shipped work as `failed`.
+
+## Refs
+
+- Watch-loop discovery thread (this session); roadmap `.agent/tasks/TASK-322-remediation-roadmap.md`
+- Regression source: D3 in PR #3354 (TASK-343)
+- Files: `internal/autopilot/controller.go` (1398 merge path, 2417 scan, NewController 200), `internal/memory/store.go` (`SelfHealExecutionAfterMerge`), `cmd/pilot/main.go` (485/1465/1487), parent ref `internal/executor/epic.go:1075`
+- Prior self-heal history: GH-2279 / GH-2402 (merge self-heal), GH-2251 (`ScanRecentlyMergedPRs`)

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -482,6 +482,9 @@ Examples:
 								statuses := cfg.Adapters.GitHub.ProjectBoard.GetStatuses()
 								gwBoardOpts = append(gwBoardOpts, autopilot.WithProjectBoardSync(bs, statuses.Done, statuses.Failed, statuses.Review, statuses.InProgress))
 							}
+							// TASK-352: scope self-heal to the project's fs path (matches
+							// executions.project_path) so merged work flips failed→completed.
+							gwBoardOpts = append(gwBoardOpts, autopilot.WithProjectPath(projectPath))
 							gwAutopilotController = autopilot.NewController(
 								cfg.Orchestrator.Autopilot,
 								ghClient,
@@ -1462,13 +1465,16 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 							slog.String("repo", cfg.Adapters.GitHub.Repo))
 					}
 
+					// TASK-352: scope self-heal to the project's fs path. Fresh slice so
+					// the per-project loop below does not alias this controller's option.
+					ctrlOpts := append(append([]autopilot.ControllerOption{}, autopilotBoardOpts...), autopilot.WithProjectPath(projectPath))
 					controller := autopilot.NewController(
 						cfg.Orchestrator.Autopilot,
 						ghClient,
 						approvalMgr,
 						parts[0],
 						parts[1],
-						autopilotBoardOpts...,
+						ctrlOpts...,
 					)
 					autopilotControllers[cfg.Adapters.GitHub.Repo] = controller
 					autopilotController = controller // Default for backwards compat
@@ -1484,13 +1490,16 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				if _, exists := autopilotControllers[repoFullName]; exists {
 					continue // Skip duplicates
 				}
+				// TASK-352: scope self-heal to this project's fs path (matches
+				// executions.project_path). Fresh slice to avoid aliasing the shared opts.
+				ctrlOpts := append(append([]autopilot.ControllerOption{}, autopilotBoardOpts...), autopilot.WithProjectPath(proj.Path))
 				controller := autopilot.NewController(
 					cfg.Orchestrator.Autopilot,
 					ghClient,
 					approvalMgr,
 					proj.GitHub.Owner,
 					proj.GitHub.Repo,
-					autopilotBoardOpts...,
+					ctrlOpts...,
 				)
 				autopilotControllers[repoFullName] = controller
 				logging.WithComponent("autopilot").Info("created controller for project",

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -130,17 +130,28 @@ func WithMemoryStore(s *memory.Store) ControllerOption {
 	}
 }
 
+// WithProjectPath sets the filesystem project path used to scope execution
+// self-heal (SelfHealExecutionAfterMerge) to this project's rows. It MUST match
+// the value the executor stored in executions.project_path — an absolute fs path
+// (e.g. /Users/me/proj), NOT owner/repo. Empty falls back to task_id-only match.
+// TASK-352.
+func WithProjectPath(path string) ControllerOption {
+	return func(c *Controller) {
+		c.projectPath = path
+	}
+}
+
 // Controller orchestrates the autopilot loop for PR processing.
 // It manages the state machine: PR created → CI check → merge → post-merge CI → feedback loop.
 type Controller struct {
-	config       *Config
-	ghClient     *github.Client
-	approvalMgr  *approval.Manager
-	ciMonitor    *CIMonitor
-	autoMerger   *AutoMerger
-	feedbackLoop *FeedbackLoop
-	releaser     *Releaser
-	deployer     *Deployer
+	config           *Config
+	ghClient         *github.Client
+	approvalMgr      *approval.Manager
+	ciMonitor        *CIMonitor
+	autoMerger       *AutoMerger
+	feedbackLoop     *FeedbackLoop
+	releaser         *Releaser
+	deployer         *Deployer
 	notifier         Notifier
 	monitor          TaskMonitor // GH-1336: sync dashboard state on merge
 	boardSync        projectBoardSyncer
@@ -190,6 +201,11 @@ type Controller struct {
 	owner string
 	repo  string
 
+	// projectPath is the absolute filesystem path the executor stored in
+	// executions.project_path. Used to scope self-heal to this project's rows.
+	// Empty = match by task_id only (single-repo / tests). TASK-352.
+	projectPath string
+
 	// GH-3271: called after a PR merges and pilot-done is applied so pollers
 	// can immediately re-mark the issue as processed, closing the merge→done
 	// race window before label propagation catches up.
@@ -232,6 +248,51 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 	}
 
 	return c
+}
+
+// parentIssueRe extracts a parent issue number from a sub-issue body line like
+// "Parent: GH-3344" — the convention epic.go writes when decomposing an issue
+// into sub-issues. TASK-352.
+var parentIssueRe = regexp.MustCompile(`(?i)Parent:\s*GH-(\d+)`)
+
+// selfHealForPR promotes any prior "failed" execution rows for the merged PR's
+// issue — and its parent epic, if it is a sub-issue — to "completed", stamping the
+// PR URL so the dashboard reflects the merged outcome. Safe to call from any merge
+// path (controller-driven handleMerging or the externally-merged scan). No-op when
+// the eval store is unset or issueNum is zero. TASK-352.
+func (c *Controller) selfHealForPR(ctx context.Context, issueNum int, prURL string) {
+	if c.evalStore == nil || issueNum == 0 {
+		return
+	}
+	c.selfHealTask(fmt.Sprintf("GH-%d", issueNum), prURL)
+	// Pilot decomposes a parent issue into sub-issues; only the sub-issue's PR
+	// merges, so the parent's no-op "failed" row would never heal otherwise.
+	if parent := c.resolveParentIssue(ctx, issueNum); parent != 0 && parent != issueNum {
+		c.selfHealTask(fmt.Sprintf("GH-%d", parent), prURL)
+	}
+}
+
+// selfHealTask runs SelfHealExecutionAfterMerge for one task ID, scoped to this
+// controller's project path (empty = task_id-only match). TASK-352.
+func (c *Controller) selfHealTask(taskID, prURL string) {
+	if err := c.evalStore.SelfHealExecutionAfterMerge(taskID, c.projectPath, prURL); err != nil {
+		c.log.Warn("failed to self-heal execution on merge", "task_id", taskID, "error", err)
+	}
+}
+
+// resolveParentIssue returns the parent issue number for a sub-issue by parsing
+// the "Parent: GH-N" line epic.go writes into sub-issue bodies, or 0 if the issue
+// has no parent or cannot be fetched (best-effort, fail-open). TASK-352.
+func (c *Controller) resolveParentIssue(ctx context.Context, issueNum int) int {
+	issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, issueNum)
+	if err != nil || issue == nil {
+		return 0
+	}
+	if m := parentIssueRe.FindStringSubmatch(issue.Body); len(m) == 2 {
+		n, _ := strconv.Atoi(m[1])
+		return n
+	}
+	return 0
 }
 
 // SetNotifier sets the notifier for autopilot events.
@@ -1388,18 +1449,11 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 			c.log.Debug("updated monitor state to completed", "task", taskID, "pr", prState.PRNumber)
 		}
 
-		// GH-2279/GH-2402: Self-heal execution record on merge. Promotes any prior
-		// "failed" row to "completed" and stamps the PR URL so the dashboard
-		// reflects the merged outcome (handles user-pushed commits, sub-issues
-		// merged via parent, etc.).
-		if c.evalStore != nil {
-			taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
-			projectPath := c.owner + "/" + c.repo
-			if err := c.evalStore.SelfHealExecutionAfterMerge(taskID, projectPath, prState.PRURL); err != nil {
-				c.log.Warn("failed to self-heal execution on merge",
-					"task_id", taskID, "error", err)
-			}
-		}
+		// GH-2279/GH-2402 + TASK-352: Self-heal execution records on merge.
+		// Promotes prior "failed" rows (for the issue AND its parent epic) to
+		// "completed" and stamps the PR URL so the dashboard reflects the merged
+		// outcome (handles user-pushed commits, sub-issues merged via parent, etc.).
+		c.selfHealForPR(ctx, prState.IssueNumber, prState.PRURL)
 
 		// GH-1870: Sync board card to "Done" column on merge
 		if c.boardSync != nil && prState.IssueNodeID != "" {
@@ -2489,6 +2543,13 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			createdAt = mergedAt
 		}
 		c.recordMergeSuccess(&PRState{PRNumber: pr.Number, CreatedAt: createdAt})
+
+		// TASK-352: Self-heal execution records for externally-merged PRs (gh pr
+		// merge / GitHub UI). These never pass through handleMerging, so their
+		// "failed" rows would otherwise never flip to "completed". Like
+		// recordMergeSuccess above, this fires before the release-tag/activePRs skip
+		// gates because the heal must happen on every discovered merged Pilot PR.
+		c.selfHealForPR(ctx, issueNum, pr.HTMLURL)
 
 		// Skip if already tracked in activePRs (avoid duplicate processing)
 		c.mu.RLock()

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -508,7 +508,9 @@ func TestController_HandleMerging_SelfHealsExecution(t *testing.T) {
 	cfg.AutoReview = false
 	cfg.RequiredChecks = []string{"build"}
 
-	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	// TASK-352: scope self-heal to the project's filesystem path (the value the
+	// executor stores in executions.project_path), NOT owner/repo.
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath("/proj/pilot"))
 	evalMock := &mockEvalStore{}
 	c.SetEvalStore(evalMock)
 
@@ -526,6 +528,8 @@ func TestController_HandleMerging_SelfHealsExecution(t *testing.T) {
 		t.Fatalf("ProcessPR returned unexpected error: %v", err)
 	}
 
+	// IssueNumber 99 has no "Parent: GH-N" body (default {} response), so exactly
+	// one self-heal call (the issue itself, no parent).
 	if len(evalMock.selfHealed) != 1 {
 		t.Fatalf("expected 1 self-heal call, got %d", len(evalMock.selfHealed))
 	}
@@ -533,8 +537,8 @@ func TestController_HandleMerging_SelfHealsExecution(t *testing.T) {
 	if got.TaskID != "GH-99" {
 		t.Errorf("self-heal task ID = %q, want GH-99", got.TaskID)
 	}
-	if got.ProjectPath != "owner/repo" {
-		t.Errorf("self-heal project path = %q, want owner/repo", got.ProjectPath)
+	if got.ProjectPath != "/proj/pilot" {
+		t.Errorf("self-heal project path = %q, want /proj/pilot (fs path, not owner/repo)", got.ProjectPath)
 	}
 	if got.PRURL != "https://github.com/owner/repo/pull/42" {
 		t.Errorf("self-heal PR URL = %q, want PR URL", got.PRURL)
@@ -543,6 +547,72 @@ func TestController_HandleMerging_SelfHealsExecution(t *testing.T) {
 	// supersedes it so we don't write stale rows without the PR URL.
 	if len(evalMock.updateStatus) != 0 {
 		t.Errorf("expected 0 UpdateExecutionStatusByTaskID calls (self-heal replaces it), got %d", len(evalMock.updateStatus))
+	}
+}
+
+// TASK-352: An externally-merged Pilot PR (gh pr merge / GitHub UI) never passes
+// through handleMerging, so ScanRecentlyMergedPRs must self-heal its execution
+// record (Bug 1) AND, when the PR is for a sub-issue, its parent epic's record
+// (Bug 2) — both scoped to the controller's filesystem project path.
+func TestController_ScanRecentlyMergedPRs_SelfHeals(t *testing.T) {
+	mergedAt := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	pr := github.PullRequest{
+		Number:         55,
+		Head:           github.PRRef{Ref: "pilot/GH-3353", SHA: "sha55"},
+		Base:           github.PRRef{Ref: "main"},
+		HTMLURL:        "https://github.com/owner/repo/pull/55",
+		Title:          "fix(memory): integrity cluster",
+		Merged:         true,
+		MergedAt:       mergedAt,
+		MergeCommitSHA: "merge-sha-55",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{&pr})
+		case r.URL.Path == "/repos/owner/repo/issues/3353":
+			// Sub-issue body carries the "Parent: GH-N" line epic.go writes.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{
+				Body: "<!--autopilot-meta\nparent: GH-3344\n-->\n\nParent: GH-3344\n\nwork",
+			})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", TagPrefix: "v"}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo", WithProjectPath("/proj/pilot"))
+	evalMock := &mockEvalStore{}
+	c.SetEvalStore(evalMock)
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs: %v", err)
+	}
+
+	healed := map[string]bool{}
+	for _, h := range evalMock.selfHealed {
+		healed[h.TaskID] = true
+		if h.ProjectPath != "/proj/pilot" {
+			t.Errorf("self-heal %s: ProjectPath = %q, want /proj/pilot", h.TaskID, h.ProjectPath)
+		}
+		if h.PRURL != pr.HTMLURL {
+			t.Errorf("self-heal %s: PRURL = %q, want %q", h.TaskID, h.PRURL, pr.HTMLURL)
+		}
+	}
+	if !healed["GH-3353"] {
+		t.Errorf("Bug 1: expected self-heal for the merged sub-issue GH-3353; got %+v", evalMock.selfHealed)
+	}
+	if !healed["GH-3344"] {
+		t.Errorf("Bug 2: expected self-heal for the parent epic GH-3344; got %+v", evalMock.selfHealed)
 	}
 }
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1091,12 +1091,18 @@ func (s *Store) UpdateExecutionStatusByTaskID(taskID, projectPath, status string
 }
 
 // SelfHealExecutionAfterMerge promotes any "failed" rows for the given task ID
-// and project path to "completed" and stamps the PR URL so the dashboard
+// (scoped to projectPath) to "completed" and stamps the PR URL so the dashboard
 // reflects the merged outcome. Used when autopilot observes a merge for an
 // issue whose previous execution row was recorded as failed (e.g. user-pushed
 // commits, sub-issue shipped via parent epic). GH-2402.
-// The projectPath scope prevents cross-project clobbering when the same task ID
-// appears in multiple repos.
+//
+// projectPath MUST be the same value the executor stored in executions.project_path
+// — an absolute filesystem path (e.g. /Users/me/proj), NOT an owner/repo slug. The
+// scope prevents cross-project clobbering when the same task ID (GH-N is only unique
+// per repo) appears in multiple repos. When projectPath is empty the scope is
+// dropped and rows match by task_id alone (legacy single-repo behavior); this also
+// guards against a caller passing the wrong discriminator silently healing nothing.
+// TASK-352.
 func (s *Store) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) error {
 	return s.withRetry("SelfHealExecutionAfterMerge", func() error {
 		_, err := s.db.Exec(`
@@ -1104,8 +1110,8 @@ func (s *Store) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) e
 			SET status = 'completed',
 				completed_at = CURRENT_TIMESTAMP,
 				pr_url = CASE WHEN ? <> '' THEN ? ELSE pr_url END
-			WHERE task_id = ? AND project_path = ? AND status = 'failed'
-		`, prURL, prURL, taskID, projectPath)
+			WHERE task_id = ? AND status = 'failed' AND (? = '' OR project_path = ?)
+		`, prURL, prURL, taskID, projectPath, projectPath)
 		return err
 	})
 }

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1887,6 +1887,32 @@ func TestSelfHealExecutionAfterMerge_ScopedToProject(t *testing.T) {
 	}
 }
 
+// TestSelfHealExecutionAfterMerge_EmptyProjectPath verifies that an empty
+// projectPath falls back to task_id-only matching (legacy single-repo behavior),
+// so a caller that cannot supply the discriminator still heals every matching row
+// rather than silently matching nothing. TASK-352.
+func TestSelfHealExecutionAfterMerge_EmptyProjectPath(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "e1", TaskID: "GH-500", ProjectPath: "/proj/a", Status: "failed"})
+	_ = store.SaveExecution(&Execution{ID: "e2", TaskID: "GH-500", ProjectPath: "/proj/b", Status: "failed"})
+
+	if err := store.SelfHealExecutionAfterMerge("GH-500", "", "https://github.com/org/repo/pull/9"); err != nil {
+		t.Fatalf("SelfHealExecutionAfterMerge: %v", err)
+	}
+
+	for _, id := range []string{"e1", "e2"} {
+		ex, _ := store.GetExecution(id)
+		if ex.Status != "completed" {
+			t.Errorf("%s: expected 'completed' with empty projectPath fallback, got %q", id, ex.Status)
+		}
+	}
+}
+
 // TestRecentCompletedTelemetryStats verifies the zero-token telemetry gap
 // query: rows are filtered to completed runs with a real commit, and rows
 // without commit_sha (e.g. epic orchestrators) are excluded so they don't


### PR DESCRIPTION
## Context

The dashboard QUEUE renders the `executions` table `status` verbatim (`dashboard/tui.go:614,848`) with no reconciliation against GitHub state. A row flips `failed → completed` only via `SelfHealExecutionAfterMerge`. Found via the TASK-322 Wave-3 watch loop: GH-3344/3353/3349 showed `✗ failed` after shipping as v2.166.2.

Three compounding bugs:

- **Bug 0 — regression from #3354/D3 (urgent).** D3 scoped self-heal with `WHERE project_path = ?` and the controller passed `c.owner+"/"+c.repo` (`qf-studio/pilot`). But `executions.project_path` stores the **absolute filesystem path** (`/Users/.../pilot`; confirmed in the live DB). → self-heal matched **zero rows on every merge path** since #3354.
- **Bug 1.** `ScanRecentlyMergedPRs` — the only catch-all for `gh pr merge`/UI merges (how the watch loop merges) — triggered release+metrics but never called self-heal.
- **Bug 2.** Self-heal keys on the merged PR's issue (= sub-issue `GH-3353`); the parent `GH-3344`'s no-op row was never healed.

## Approach

- `WithProjectPath` option → controller passes the real fs path (matches `executions.project_path`); wired at all 3 `NewController` sites in `main.go`.
- `SelfHealExecutionAfterMerge` tolerates empty projectPath (`(? = '' OR project_path = ?)`) — keeps D3 cross-repo scoping when known, reverts to task_id-only when unset (so a wrong/missing discriminator can't silently heal nothing).
- `selfHealForPR()` helper heals the issue **and** its parent (regex `Parent:\s*GH-(\d+)`, same convention as `epic.go`), called from both the merge path and the scan.
- No dashboard change — healed rows render correctly.

## Tests

- `store`: empty-projectPath fallback heals all matching rows; existing fs-path scoping test unchanged.
- `autopilot`: merge path scopes to the fs path (not owner/repo); `ScanRecentlyMergedPRs` self-heals a sub-issue **and** its parent.
- `make build` + `go vet` + full `autopilot`/`memory` suites green; `golangci-lint` 0 issues.

## Notes

- Manual (not Pilot-dispatched): autopilot self-heal core → self-modifying, per the M1/M2 precedent.
- **Backfill pending:** current stale rows (GH-3344/3353/3349 etc.) are past the 30-min scan window and the daemon runs an older binary, so this won't retroactively heal them — a one-time `UPDATE` will clear the display after merge.
- Plan: `.agent/tasks/TASK-352-selfheal-projectpath-scan-parent.md`