### PR TITLE
fix(executor): derive stall-watchdog tick interval from stallTimeout (A3, TASK-344)

### DIFF
--- a/internal/executor/watchdog.go
+++ b/internal/executor/watchdog.go
@@ -9,10 +9,30 @@ import (
 
 const defaultStallWatchdogInterval = 30 * time.Second
 
-// runStallWatchdog ticks every watchdogInterval and cancels stallCancel if no
-// backend event has been seen for longer than stallTimeout. Sets stallDetected
-// before canceling so callers can distinguish a stall from other cancellations.
-// Returns when done is closed (i.e., the execution has ended).
+// minStallWatchdogInterval floors the derived tick interval so a tiny configured
+// stall timeout can't spin the watchdog hot.
+const minStallWatchdogInterval = time.Second
+
+// watchdogTickInterval derives the watchdog poll interval from stallTimeout so a
+// small configured timeout is actually honored (detection latency ≈ one tick).
+// It is min(defaultStallWatchdogInterval, stallTimeout/3), floored at
+// minStallWatchdogInterval. TASK-344.
+func watchdogTickInterval(stallTimeout time.Duration) time.Duration {
+	interval := defaultStallWatchdogInterval
+	if third := stallTimeout / 3; third < interval {
+		interval = third
+	}
+	if interval < minStallWatchdogInterval {
+		interval = minStallWatchdogInterval
+	}
+	return interval
+}
+
+// runStallWatchdog ticks at an interval derived from stallTimeout
+// (watchdogTickInterval: min(30s, stallTimeout/3), floored at 1s) and cancels
+// stallCancel if no backend event has been seen for longer than stallTimeout.
+// Sets stallDetected before canceling so callers can distinguish a stall from
+// other cancellations. Returns when done is closed (i.e., the execution has ended).
 func (r *Runner) runStallWatchdog(
 	taskID string,
 	lastEventAt *atomic.Int64,
@@ -21,7 +41,7 @@ func (r *Runner) runStallWatchdog(
 	done <-chan struct{},
 	stallCancel context.CancelFunc,
 ) {
-	ticker := time.NewTicker(defaultStallWatchdogInterval)
+	ticker := time.NewTicker(watchdogTickInterval(stallTimeout))
 	defer ticker.Stop()
 	for {
 		select {

--- a/internal/executor/watchdog_test.go
+++ b/internal/executor/watchdog_test.go
@@ -9,6 +9,28 @@ import (
 	"time"
 )
 
+// TestWatchdogTickInterval verifies the tick interval is derived from stallTimeout
+// (min(30s, stallTimeout/3), floored at 1s) so small timeouts are honored. TASK-344.
+func TestWatchdogTickInterval(t *testing.T) {
+	tests := []struct {
+		name         string
+		stallTimeout time.Duration
+		want         time.Duration
+	}{
+		{"sub-30s honored", 9 * time.Second, 3 * time.Second},
+		{"floored at 1s", 900 * time.Millisecond, time.Second},
+		{"large caps at default", 90 * time.Second, defaultStallWatchdogInterval},
+		{"default boundary", 90 * time.Second, 30 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := watchdogTickInterval(tt.stallTimeout); got != tt.want {
+				t.Errorf("watchdogTickInterval(%v) = %v, want %v", tt.stallTimeout, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestStallWatchdog_FiresOnIdle verifies the watchdog cancels the context
 // when no event is received within stallTimeout.
 func TestStallWatchdog_FiresOnIdle(t *testing.T) {


### PR DESCRIPTION
## Context
TASK-322 Wave-3 A3 (#3345). `runStallWatchdog` ticked at a hardcoded `defaultStallWatchdogInterval` (30s), ignoring the configured `stallTimeout` — so a sub-30s timeout had ≥30s detection latency and the doc comment referenced a non-existent `watchdogInterval`.

## Approach
`watchdogTickInterval(stallTimeout) = min(30s, stallTimeout/3)`, floored at 1s. Fix the doc comment.

## Acceptance
- [x] interval derived from stallTimeout; 9s→3s, large→30s cap, tiny→1s floor (table test)
- [x] doc comment corrected
- [x] `internal/executor` tests green

## Refs
Task: TASK-344.