### PR TITLE
fix(autopilot): debounce CIFailure — only fail when no check is pending (B4, TASK-345)

### DIFF
--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -198,7 +198,10 @@ func (m *CIMonitor) checkAllRuns(checkRuns *github.CheckRunsResponse) CIStatus {
 		}
 	}
 
-	if hasFailure {
+	// B4 (TASK-345): only declare failure once no check is still pending — a
+	// fail-fast matrix leg or flaky check can report failure before siblings
+	// finish; wait (CIPending) so the suite completes / flaky checks auto-rerun.
+	if hasFailure && !hasPending {
 		return CIFailure
 	}
 	if hasPending {
@@ -286,7 +289,10 @@ func (m *CIMonitor) checkAutoDiscoveredRuns(ctx context.Context, sha string, che
 		}
 	}
 
-	if hasFailure {
+	// B4 (TASK-345): only declare failure once no check is still pending — a
+	// fail-fast matrix leg or flaky check can report failure before siblings
+	// finish; wait (CIPending) so the suite completes / flaky checks auto-rerun.
+	if hasFailure && !hasPending {
 		return CIFailure, nil
 	}
 	if hasPending {
@@ -345,7 +351,10 @@ func (m *CIMonitor) aggregateStatus(statuses map[string]CIStatus) CIStatus {
 		}
 	}
 
-	if hasFailure {
+	// B4 (TASK-345): only declare failure once no check is still pending — a
+	// fail-fast matrix leg or flaky check can report failure before siblings
+	// finish; wait (CIPending) so the suite completes / flaky checks auto-rerun.
+	if hasFailure && !hasPending {
 		return CIFailure
 	}
 	if hasPending {

--- a/internal/autopilot/ci_monitor_test.go
+++ b/internal/autopilot/ci_monitor_test.go
@@ -12,6 +12,37 @@ import (
 	"github.com/qf-studio/pilot/internal/testutil"
 )
 
+// TestCIAggregation_PendingBeatsFailure_B4 verifies the B4 debounce (TASK-345):
+// a failure alongside a still-pending check yields CIPending (wait), not a
+// premature CIFailure; a failure with all siblings terminal yields CIFailure.
+func TestCIAggregation_PendingBeatsFailure_B4(t *testing.T) {
+	m := &CIMonitor{}
+
+	// aggregateStatus (map-based)
+	if got := m.aggregateStatus(map[string]CIStatus{"a": CIFailure, "b": CIPending}); got != CIPending {
+		t.Errorf("aggregateStatus failure+pending = %v, want CIPending", got)
+	}
+	if got := m.aggregateStatus(map[string]CIStatus{"a": CIFailure, "b": CISuccess}); got != CIFailure {
+		t.Errorf("aggregateStatus failure+success = %v, want CIFailure", got)
+	}
+
+	// checkAllRuns (CheckRunsResponse-based)
+	failPending := &github.CheckRunsResponse{TotalCount: 2, CheckRuns: []github.CheckRun{
+		{Name: "a", Status: github.CheckRunCompleted, Conclusion: github.ConclusionFailure},
+		{Name: "b", Status: github.CheckRunInProgress},
+	}}
+	if got := m.checkAllRuns(failPending); got != CIPending {
+		t.Errorf("checkAllRuns failed+in_progress = %v, want CIPending", got)
+	}
+	failDone := &github.CheckRunsResponse{TotalCount: 2, CheckRuns: []github.CheckRun{
+		{Name: "a", Status: github.CheckRunCompleted, Conclusion: github.ConclusionFailure},
+		{Name: "b", Status: github.CheckRunCompleted, Conclusion: github.ConclusionSuccess},
+	}}
+	if got := m.checkAllRuns(failDone); got != CIFailure {
+		t.Errorf("checkAllRuns failed+success = %v, want CIFailure", got)
+	}
+}
+
 func TestNewCIMonitor(t *testing.T) {
 	ghClient := github.NewClient(testutil.FakeGitHubToken)
 	cfg := DefaultConfig()
@@ -545,8 +576,15 @@ func TestCIMonitor_AggregateStatus(t *testing.T) {
 			want:     CIPending,
 		},
 		{
-			name:     "failure takes precedence over pending",
+			// B4 (TASK-345): a failure while a sibling is still pending must NOT
+			// declare CIFailure — wait for the suite to finish (premature-close fix).
+			name:     "pending defers failure (B4 debounce)",
 			statuses: map[string]CIStatus{"build": CIFailure, "test": CIPending},
+			want:     CIPending,
+		},
+		{
+			name:     "failure with all siblings terminal",
+			statuses: map[string]CIStatus{"build": CIFailure, "test": CISuccess},
 			want:     CIFailure,
 		},
 		{
@@ -1195,10 +1233,10 @@ func TestCIMonitor_GetFailedCheckLogs(t *testing.T) {
 // use the statuses API exclusively, so empty check-runs must not auto-approve.
 func TestCIMonitor_CommitStatusFallback(t *testing.T) {
 	tests := []struct {
-		name           string
-		combinedState  string
-		totalCount     int
-		wantStatus     CIStatus
+		name          string
+		combinedState string
+		totalCount    int
+		wantStatus    CIStatus
 	}{
 		{
 			name:          "failing combined status → CIFailure",


### PR DESCRIPTION
## Context
TASK-322 Wave-3 B4 (#3346). `hasFailure` took precedence over `hasPending` in `checkAllRuns`/`checkAutoDiscoveredRuns`/`aggregateStatus` → one fail-fast matrix leg or flaky check declared CIFailure → premature PR close + fix cascade while siblings were still running.

## Approach
Declare CIFailure only when `hasFailure && !hasPending`; otherwise CIPending so the suite finishes and flaky checks auto-rerun. Applied to all 3 aggregation sites.

## Acceptance
- [x] failed + in_progress → CIPending; failed + all-terminal → CIFailure (new + updated table tests)
- [x] full `internal/autopilot` suite green

## Refs
Task: TASK-345. Directly mitigates the flaky-`briefs` → phantom-CI-fix cascade seen on D4 (#3358/#3359).