### PR TITLE
fix(github): paginate ListIssues (per_page=100) so candidates aren't truncated (C6, TASK-346)

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -390,9 +390,10 @@ func (c *Client) AddPRComment(ctx context.Context, owner, repo string, number in
 // Note: Labels are filtered case-insensitively in Go code after fetching,
 // because GitHub API label queries are case-sensitive.
 func (c *Client) ListIssues(ctx context.Context, owner, repo string, opts *ListIssuesOptions) ([]*Issue, error) {
-	path := fmt.Sprintf("/repos/%s/%s/issues?", owner, repo)
+	const perPage = 100
+	const maxPages = 50
 
-	// Build query parameters
+	// Build query parameters (pagination is added per-page below).
 	// Note: We intentionally skip passing labels to the API because GitHub's
 	// label query is case-sensitive. Instead, we filter in code after fetching.
 	params := []string{}
@@ -409,17 +410,25 @@ func (c *Client) ListIssues(ctx context.Context, owner, repo string, opts *ListI
 			params = append(params, "since="+opts.Since.Format(time.RFC3339))
 		}
 	}
+	baseQuery := strings.Join(params, "&")
 
-	for i, p := range params {
-		if i > 0 {
-			path += "&"
-		}
-		path += p
-	}
-
+	// Paginate (GitHub defaults to 30/page, caps at 100). Without this the
+	// candidate set was silently truncated to the first ~30 issues, breaking the
+	// oldest-first dispatch contract on repos with more open issues. TASK-346 (C6).
 	var issues []*Issue
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &issues); err != nil {
-		return nil, err
+	for page := 1; page <= maxPages; page++ {
+		path := fmt.Sprintf("/repos/%s/%s/issues?per_page=%d&page=%d", owner, repo, perPage, page)
+		if baseQuery != "" {
+			path += "&" + baseQuery
+		}
+		var batch []*Issue
+		if err := c.doRequest(ctx, http.MethodGet, path, nil, &batch); err != nil {
+			return nil, err
+		}
+		issues = append(issues, batch...)
+		if len(batch) < perPage {
+			break
+		}
 	}
 
 	// Filter by labels case-insensitively

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -1060,6 +1060,50 @@ func TestListIssues_LabelsFilteredCaseInsensitively(t *testing.T) {
 	}
 }
 
+// TestListIssues_Paginates verifies C6 (TASK-346): ListIssues requests per_page=100
+// and follows pages until a short page, returning the full set (not just the first ~30).
+func TestListIssues_Paginates(t *testing.T) {
+	var perPageSeen string
+	var pageRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pageRequests++
+		perPageSeen = r.URL.Query().Get("per_page")
+		var batch []*Issue
+		switch r.URL.Query().Get("page") {
+		case "1":
+			batch = make([]*Issue, 100) // full page → keep paging
+			for i := range batch {
+				batch[i] = &Issue{Number: i + 1}
+			}
+		case "2":
+			batch = make([]*Issue, 15) // short page → stop
+			for i := range batch {
+				batch[i] = &Issue{Number: 101 + i}
+			}
+		default:
+			batch = []*Issue{}
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(batch)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	issues, err := client.ListIssues(context.Background(), "owner", "repo", nil)
+	if err != nil {
+		t.Fatalf("ListIssues() error = %v", err)
+	}
+	if len(issues) != 115 {
+		t.Errorf("expected 115 issues across 2 pages, got %d", len(issues))
+	}
+	if perPageSeen != "100" {
+		t.Errorf("expected per_page=100, got %q", perPageSeen)
+	}
+	if pageRequests != 2 {
+		t.Errorf("expected 2 page requests (100 + short 15 stops paging), got %d", pageRequests)
+	}
+}
+
 func TestHasLabel(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Context
TASK-322 Wave-3 C6 (#3347). `ListIssues` fetched a single default page (~30 issues, GitHub default), silently truncating the poller's candidate universe and breaking the oldest-first dispatch contract on repos with >30 open issues.

## Approach
Request `per_page=100` and follow `page=N` until a short page returns (mirrors `ListPullRequests`). Label filtering still applied to the full accumulated set.

## Acceptance
- [x] per_page=100 + pagination; 100+15 → 115 issues in 2 requests (test)
- [x] existing ListIssues/label-filter tests green
- [x] fix lives in client.go, not poller.go (no per-candidate API calls → no stress-test starvation)

## Refs
Task: TASK-346.