### PR TITLE
fix(github): CreatePilotIssue repo allowlist fails closed on nil (C7, TASK-347)

### DIFF
--- a/internal/adapters/github/issue_create.go
+++ b/internal/adapters/github/issue_create.go
@@ -31,15 +31,28 @@ type IssueAllowlist interface {
 	ConfiguredRepos() []string
 }
 
+// allowAllIssueRepos is an IssueAllowlist that permits any (owner, repo). Use it
+// at call sites where owner/repo are already constrained by explicit config (e.g.
+// the autopilot feedback loop) so the intent is encoded at the call site rather
+// than relying on a permissive nil default. TASK-347.
+type allowAllIssueRepos struct{}
+
+func (allowAllIssueRepos) RepoIsAllowed(string, string, string) bool { return true }
+func (allowAllIssueRepos) ConfiguredRepos() []string                 { return []string{"*"} }
+
+// AllowAllIssueRepos returns an IssueAllowlist that permits any repo, for callers
+// whose target is already constrained by their own configuration. TASK-347.
+func AllowAllIssueRepos() IssueAllowlist { return allowAllIssueRepos{} }
+
 // CreatePilotIssue validates the title against the conventional-commits format and
 // creates a GitHub issue with the given labels.
 //
 // allow is the repo allowlist for TASK-286 / GH-3027 defense-in-depth. Pass a non-nil
-// IssueAllowlist to enforce that (owner, repo) is a configured Pilot project. Pass nil
-// only when the owner/repo is already constrained by caller configuration (e.g., the
-// autopilot feedback loop, which uses explicit owner/repo from its own config). When nil,
-// a WARN is logged so the omission is visible. Set PILOT_ALLOW_UNMANAGED_REPO=1 to bypass
-// a non-nil allowlist that would otherwise reject the repo (also logs WARN).
+// IssueAllowlist to enforce that (owner, repo) is a configured Pilot project. A nil
+// allowlist now FAILS CLOSED (TASK-347) to match executor.ValidateTargetRepo — for a
+// caller whose owner/repo is already constrained by its own config, pass
+// AllowAllIssueRepos() to encode that intent. Set PILOT_ALLOW_UNMANAGED_REPO=1 to bypass
+// (covers both the nil case and a non-nil allowlist that would otherwise reject the repo).
 //
 // Returns an error if the title does not match conventional-commits format, if the
 // allowlist rejects the repo, or if the GitHub API call fails.
@@ -60,20 +73,30 @@ func CreatePilotIssue(ctx context.Context, c *Client, allow IssueAllowlist, owne
 // validateIssueRepo enforces the repo allowlist. Mirrors executor.ValidateTargetRepo
 // but is defined here to avoid the executor→github import cycle.
 func validateIssueRepo(allow IssueAllowlist, owner, repo string) error {
+	bypass := os.Getenv(envBypassIssueAllowlist) == "1"
+
 	if allow == nil {
-		slog.Warn("CreatePilotIssue: no IssueAllowlist configured; repo check skipped — pass an allowlist or set PILOT_ALLOW_UNMANAGED_REPO=1 to silence",
-			"component", "adapters.github.issue_create",
-			"owner", owner,
-			"repo", repo,
-		)
-		return nil
+		// C7 (TASK-347): fail closed to match executor.ValidateTargetRepo — a future
+		// caller that forgets to wire an allowlist must not silently get zero
+		// enforcement (the GH-3027 cross-repo-leak class). Known-safe callers pass
+		// AllowAllIssueRepos() to encode "intentionally unrestricted" explicitly.
+		if bypass {
+			slog.Warn("CreatePilotIssue: no IssueAllowlist configured; PILOT_ALLOW_UNMANAGED_REPO=1 bypassed the repo check",
+				"component", "adapters.github.issue_create",
+				"owner", owner,
+				"repo", repo,
+			)
+			return nil
+		}
+		return fmt.Errorf("no IssueAllowlist configured for %s/%s — pass an allowlist (or AllowAllIssueRepos()) or set %s=1",
+			owner, repo, envBypassIssueAllowlist)
 	}
 
 	if allow.RepoIsAllowed(owner, repo, "") {
 		return nil
 	}
 
-	if os.Getenv(envBypassIssueAllowlist) == "1" {
+	if bypass {
 		slog.Warn("PILOT_ALLOW_UNMANAGED_REPO=1 bypassed IssueAllowlist",
 			"component", "adapters.github.issue_create",
 			"owner", owner,

--- a/internal/adapters/github/issue_create_test.go
+++ b/internal/adapters/github/issue_create_test.go
@@ -11,6 +11,36 @@ import (
 	"github.com/qf-studio/pilot/internal/testutil"
 )
 
+type fakeIssueAllowlist struct{ allowed bool }
+
+func (f fakeIssueAllowlist) RepoIsAllowed(string, string, string) bool { return f.allowed }
+func (f fakeIssueAllowlist) ConfiguredRepos() []string                 { return []string{"owner/allowed"} }
+
+// TestValidateIssueRepo_FailClosed_C7 verifies C7 (TASK-347): a nil allowlist fails
+// closed (unless PILOT_ALLOW_UNMANAGED_REPO=1); the AllowAllIssueRepos sentinel and a
+// matching allowlist pass; a non-matching allowlist errors — matching executor's default.
+func TestValidateIssueRepo_FailClosed_C7(t *testing.T) {
+	if err := validateIssueRepo(nil, "owner", "repo"); err == nil {
+		t.Error("nil allowlist must fail closed, got nil error")
+	}
+
+	t.Setenv(envBypassIssueAllowlist, "1")
+	if err := validateIssueRepo(nil, "owner", "repo"); err != nil {
+		t.Errorf("nil allowlist + bypass env should pass, got %v", err)
+	}
+	t.Setenv(envBypassIssueAllowlist, "") // disable bypass for the rest
+
+	if err := validateIssueRepo(AllowAllIssueRepos(), "owner", "repo"); err != nil {
+		t.Errorf("AllowAllIssueRepos should pass, got %v", err)
+	}
+	if err := validateIssueRepo(fakeIssueAllowlist{allowed: true}, "owner", "repo"); err != nil {
+		t.Errorf("allowed repo should pass, got %v", err)
+	}
+	if err := validateIssueRepo(fakeIssueAllowlist{allowed: false}, "owner", "repo"); err == nil {
+		t.Error("disallowed repo must error")
+	}
+}
+
 func TestConventionalCommitRE(t *testing.T) {
 	accept := []string{
 		"feat: add OAuth login",
@@ -73,7 +103,7 @@ func TestCreatePilotIssue_TitleValidation(t *testing.T) {
 			defer server.Close()
 
 			c := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
-			_, err := CreatePilotIssue(context.Background(), c, nil, "owner", "repo", tt.title, "body", []string{"pilot"})
+			_, err := CreatePilotIssue(context.Background(), c, AllowAllIssueRepos(), "owner", "repo", tt.title, "body", []string{"pilot"})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createPilotIssue(%q) error = %v, wantErr %v", tt.title, err, tt.wantErr)
 			}
@@ -113,7 +143,7 @@ func TestCreatePilotIssue_APIForwarding(t *testing.T) {
 	defer server.Close()
 
 	c := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
-	issue, err := CreatePilotIssue(context.Background(), c, nil, "owner", "repo", wantTitle, wantBody, []string{"pilot"})
+	issue, err := CreatePilotIssue(context.Background(), c, AllowAllIssueRepos(), "owner", "repo", wantTitle, wantBody, []string{"pilot"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/autopilot/feedback_loop.go
+++ b/internal/autopilot/feedback_loop.go
@@ -97,9 +97,10 @@ func (f *FeedbackLoop) CreateFailureIssue(ctx context.Context, prState *PRState,
 
 	body := f.generateBody(prState, failureType, failedChecks, logs, iteration, knownPatterns)
 
-	// nil allowlist: FeedbackLoop's owner/repo are set from explicit config at construction,
-	// so they are already constrained to a configured project (TASK-286 / GH-3027).
-	issue, err := github.CreatePilotIssue(ctx, f.ghClient, nil, f.owner, f.repo, title, body, f.issueLabels)
+	// AllowAllIssueRepos: FeedbackLoop's owner/repo are set from explicit config at
+	// construction, so they're already constrained to a configured project. The
+	// explicit sentinel encodes that intent (vs a nil-means-skip default). TASK-286 / GH-3027 / TASK-347.
+	issue, err := github.CreatePilotIssue(ctx, f.ghClient, github.AllowAllIssueRepos(), f.owner, f.repo, title, body, f.issueLabels)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create issue: %w", err)
 	}
@@ -266,8 +267,9 @@ func (f *FeedbackLoop) CreateReviewIssue(ctx context.Context, prState *PRState, 
 
 	body := sb.String()
 
-	// nil allowlist: owner/repo set from explicit config at construction (TASK-286 / GH-3027).
-	issue, err := github.CreatePilotIssue(ctx, f.ghClient, nil, f.owner, f.repo, title, body, f.issueLabels)
+	// AllowAllIssueRepos: owner/repo set from explicit config at construction; explicit
+	// sentinel encodes intent vs a nil-means-skip default (TASK-286 / GH-3027 / TASK-347).
+	issue, err := github.CreatePilotIssue(ctx, f.ghClient, github.AllowAllIssueRepos(), f.owner, f.repo, title, body, f.issueLabels)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create review issue: %w", err)
 	}


### PR DESCRIPTION
## Context
TASK-322 Wave-3 C7 (#3348). `validateIssueRepo` treated `allow==nil` as ALLOW (WARN+skip) — the opposite of `executor.ValidateTargetRepo`'s fail-closed default. A future direct caller that forgot to wire an allowlist got zero enforcement (the GH-3027 cross-repo-leak class this guard exists to prevent).

## Approach
nil now fails closed (errors) unless `PILOT_ALLOW_UNMANAGED_REPO=1`. Added an `AllowAllIssueRepos()` sentinel and used it at the two known-safe `feedback_loop` callers so the intent is encoded at the call site rather than relying on a permissive nil default.

## Acceptance
- [x] nil → error; nil+env → ok; AllowAllIssueRepos → ok; allowed → ok; disallowed → error (table test)
- [x] feedback_loop callers pass AllowAllIssueRepos(); doc comment corrected
- [x] github + autopilot build/tests green

## Refs
Task: TASK-347. Twin of executor.ValidateTargetRepo (repo_guardrail.go).