### PR TITLE
test: fix flaky CI — pagination-aware stress mocks + bounded waits + briefs panic guard (TASK-353)

### DIFF
--- a/.agent/tasks/TASK-353-flaky-ci-tests.md
+++ b/.agent/tasks/TASK-353-flaky-ci-tests.md
@@ -1,0 +1,42 @@
+# TASK-353: stop the flaky-CI noise — stress pagination-mock + bounded waits + briefs panic guard
+
+**Status:** in progress (MANUAL, test-only) · **Created:** 2026-06-01 · **Found via:** TASK-322 Wave-3 manual batch — the `stress` + `briefs` packages reded CI across all 6 fix PRs + reruns, generating a flood of failure emails.
+
+## Context
+
+Two test issues spammed CI during the Wave-3 batch:
+
+1. **`stress` package — broken by C6 (TASK-346), not just flaky.** C6 made `ListIssues`
+   paginate (`per_page=100&page=N` until a short page). All 4 stress mocks in
+   `stress/memory_test.go` return the full 1000-issue list for **every** request, so
+   post-C6 `ListIssues` loops to `maxPages=50` (≈50k items/poll) and the poll starves →
+   the unbounded wait loop `for processedCount < numIssues { sleep }` hangs to the
+   **600s whole-package timeout**, failing the entire CI run. Verified locally:
+   `TestMemory_ProcessedMapGrowth` processed 0/1000 in 25s post-C6; 0.79s after the mock fix.
+2. **`briefs` package — rare SQLite timing flake + a panic.** `TestGeneratorWithProjectFilter`
+   used non-fatal `t.Errorf` on `len(brief.Completed) != 1` then indexed `brief.Completed[0]`
+   → `panic: index out of range [0] with length 0` on the rare flake. (DB is already isolated
+   via `os.MkdirTemp`; the "got 0" timing flake is rare — 10/10 locally — and per
+   `learning_flaky_briefs_generator_test` is "rerun, don't chase".)
+
+## Approach (test-only)
+
+1. **stress:** make all 4 mocks pagination-aware — full list on `page=1`, empty `[]` on
+   `page>=2` so `ListIssues` pagination terminates. Add a `waitForProcessed(t, get, want, timeout)`
+   helper that bounds the busy-wait and `t.Fatalf`s on deadline instead of hanging to 600s
+   (converts any future starvation into a fast, localized failure that doesn't sink the whole run).
+2. **briefs:** change the `len(brief.Completed) != 1` check to `t.Fatalf` so the rare flake
+   fails cleanly instead of panicking on the `[0]` access.
+
+## Acceptance
+
+- [x] `go test ./stress/` green and fast (no 600s timeout); `TestMemory_ProcessedMapGrowth` ~1s
+- [x] all 4 stress mocks return `[]` for `page>=2`; busy-waits bounded with a deadline
+- [x] `briefs` index-out-of-range panic guarded (Fatalf before `[0]`)
+- [ ] CI green on the PR (whole-repo `-race`)
+
+## Refs
+
+- Regression source: C6 / PR #3369 (TASK-346) pagination
+- `learning_flaky_briefs_generator_test`, TASK-342 kickoff gate #5 (stress starvation)
+- Files: `stress/memory_test.go`, `internal/briefs/generator_test.go`

--- a/internal/briefs/generator_test.go
+++ b/internal/briefs/generator_test.go
@@ -207,9 +207,11 @@ func TestGeneratorWithProjectFilter(t *testing.T) {
 		t.Fatalf("failed to generate brief: %v", err)
 	}
 
-	// Should only have alpha project
+	// Should only have alpha project. Fatalf (not Errorf) so the rare SQLite timing
+	// flake that yields 0 rows fails cleanly here instead of panicking on Completed[0]
+	// below (the "index out of range [0]" red). TASK-353 / learning_flaky_briefs_generator_test.
 	if len(brief.Completed) != 1 {
-		t.Errorf("expected 1 completed task (filtered), got %d", len(brief.Completed))
+		t.Fatalf("expected 1 completed task (filtered), got %d", len(brief.Completed))
 	}
 
 	if brief.Completed[0].ProjectPath != "/project/alpha" {

--- a/stress/memory_test.go
+++ b/stress/memory_test.go
@@ -17,6 +17,21 @@ import (
 	"github.com/qf-studio/pilot/internal/testutil"
 )
 
+// waitForProcessed busy-waits until get() reaches want, failing fast with a clear
+// message when timeout elapses instead of hanging until the whole-package test
+// timeout (600s). The unbounded version of this loop made these stress tests red
+// CI on unrelated PRs whenever dispatch was slow under load. TASK-353.
+func waitForProcessed(t *testing.T, get func() int64, want int64, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for get() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after %v waiting for processed count: got %d, want %d", timeout, get(), want)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
 // TestMemory_NoUnboundedGrowth verifies memory doesn't grow unbounded during processing.
 func TestMemory_NoUnboundedGrowth(t *testing.T) {
 	if testing.Short() {
@@ -53,6 +68,12 @@ func TestMemory_NoUnboundedGrowth(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		// C6/TASK-346: paginate-aware mock — full list on page 1, empty after, so
+		// ListIssues pagination terminates instead of looping to maxPages. TASK-353.
+		if p := r.URL.Query().Get("page"); p != "" && p != "1" {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
 		_ = json.NewEncoder(w).Encode(issues)
 	}))
 	defer server.Close()
@@ -101,9 +122,7 @@ func TestMemory_NoUnboundedGrowth(t *testing.T) {
 	}()
 
 	// Wait for processing
-	for atomic.LoadInt64(&processedCount) < int64(numIssues) {
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForProcessed(t, func() int64 { return atomic.LoadInt64(&processedCount) }, int64(numIssues), 25*time.Second)
 
 	close(done)
 	cancel()
@@ -191,6 +210,14 @@ func TestMemory_ProcessedMapGrowth(t *testing.T) {
 			_, _ = w.Write([]byte(`[]`))
 			return
 		}
+		// C6/TASK-346: ListIssues now paginates (per_page=100&page=N). Return the
+		// full list only on page 1 and an empty page after, so pagination terminates;
+		// otherwise the mock would return 1000 per page up to maxPages (50k items),
+		// starving the poll. TASK-353.
+		if p := r.URL.Query().Get("page"); p != "" && p != "1" {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
 		n := atomic.AddInt64(&pollCount, 1)
 		if n <= 2 {
 			// Call 1: recoverOrphanedIssues, Call 2: first checkForNewIssues
@@ -225,9 +252,7 @@ func TestMemory_ProcessedMapGrowth(t *testing.T) {
 	go poller.Start(ctx)
 
 	// Wait for all to be processed
-	for atomic.LoadInt64(&processedCount) < int64(numIssues) {
-		time.Sleep(50 * time.Millisecond)
-	}
+	waitForProcessed(t, func() int64 { return atomic.LoadInt64(&processedCount) }, int64(numIssues), 25*time.Second)
 
 	cancel()
 	poller.WaitForActive()
@@ -277,6 +302,12 @@ func TestMemory_LargePayloads(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		// C6/TASK-346: paginate-aware mock — full list on page 1, empty after, so
+		// ListIssues pagination terminates instead of looping to maxPages. TASK-353.
+		if p := r.URL.Query().Get("page"); p != "" && p != "1" {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
 		_ = json.NewEncoder(w).Encode(issues)
 	}))
 	defer server.Close()
@@ -366,6 +397,11 @@ func TestMemory_RepeatedStartStop(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
+			// C6/TASK-346: paginate-aware mock — full list on page 1, empty after.
+			if p := r.URL.Query().Get("page"); p != "" && p != "1" {
+				_, _ = w.Write([]byte(`[]`))
+				return
+			}
 			_ = json.NewEncoder(w).Encode(issues)
 		}))
 


### PR DESCRIPTION
## Context
The Wave-3 batch flooded CI with failure emails from two test packages — **mostly a real regression, not just flake**:
- **`stress`**: C6 (#3369, TASK-346) made `ListIssues` paginate. All 4 mocks in `stress/memory_test.go` return the full 1000-issue list for *every* request, so post-C6 `ListIssues` loops to `maxPages=50` (~50k items/poll), the poll starves, and the unbounded `for processedCount < numIssues { sleep }` wait hangs to the **600s package timeout** → whole CI run fails. (Verified: `TestMemory_ProcessedMapGrowth` did 0/1000 in 25s post-C6; 0.8s after this fix.)
- **`briefs`**: `TestGeneratorWithProjectFilter` used non-fatal `Errorf` on the length check then indexed `Completed[0]` → `panic: index out of range` on the rare SQLite timing flake.

## Approach (test-only)
- All 4 stress mocks paginate-aware: full list on `page=1`, `[]` on `page>=2` so pagination terminates.
- `waitForProcessed(t, get, want, timeout)` helper bounds the busy-waits → fast `Fatalf` on deadline instead of a 600s hang that sinks the whole run.
- briefs: `Fatalf` before `Completed[0]` so the rare flake fails cleanly, not via panic.

## Acceptance
- [x] `go test ./stress/` fast + green (no 600s timeout)
- [x] `go test ./internal/briefs/` green (10× locally)
- [x] mocks return `[]` for page>=2; waits bounded; briefs panic guarded

## Refs
Regression source: C6 / #3369. Task: TASK-353. Related: learning_flaky_briefs_generator_test, TASK-342 gate #5.