### PR TITLE
fix(autopilot): reap stale 'releasing' rows + DB-aware scanner skip gate (B3/B4, TASK-309)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2559,6 +2559,28 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			continue
 		}
 
+		// B3 (TASK-309): activePRs is in-memory only. After a daemon restart a PR
+		// can be persisted at stage='releasing' yet be absent from activePRs, so the
+		// in-memory gate above would re-register and re-trigger the release on every
+		// scan. Consult the persistent state: if a recent 'releasing' row exists, the
+		// release is already in flight — skip it. Stale rows (age past
+		// releasingStaleThreshold) are intentionally NOT skipped so a genuinely
+		// wedged release can be re-driven.
+		if c.stateStore != nil {
+			if age, found, err := c.stateStore.PersistedReleasingAge(pr.Number); err != nil {
+				c.log.Warn("failed to check persisted releasing state, will track to be safe",
+					"pr", pr.Number,
+					"error", err,
+				)
+			} else if found && age < releasingStaleThreshold {
+				c.log.Debug("skipping PR: release already in flight (persisted at releasing)",
+					"pr", pr.Number,
+					"age", age,
+				)
+				continue
+			}
+		}
+
 		// Skip if this merge commit already has a release tag.
 		// GitHub releases set target_commitish to the branch ref ("main"), not the merge
 		// SHA, so the former map-based check was unreliable. GetTagForSHA (same primitive

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -616,6 +616,87 @@ func TestController_ScanRecentlyMergedPRs_SelfHeals(t *testing.T) {
 	}
 }
 
+// B3 (TASK-309): a PR persisted at stage='releasing' but absent from the in-memory
+// activePRs map (e.g. after a daemon restart) must not be re-registered by the
+// scanner while the release is fresh. A 'releasing' row stuck past
+// releasingStaleThreshold is re-driven so a wedged release can recover.
+func TestController_ScanRecentlyMergedPRs_SkipsPersistedReleasing(t *testing.T) {
+	mergedAt := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	pr := github.PullRequest{
+		Number:         77,
+		Head:           github.PRRef{Ref: "pilot/GH-770", SHA: "sha77"},
+		Base:           github.PRRef{Ref: "main"},
+		HTMLURL:        "https://github.com/owner/repo/pull/77",
+		Title:          "fix(api): retry",
+		Merged:         true,
+		MergedAt:       mergedAt,
+		MergeCommitSHA: "merge-sha-77",
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{&pr})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		}
+	}))
+	defer server.Close()
+
+	newScanController := func(t *testing.T) (*Controller, *StateStore) {
+		t.Helper()
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		cfg := DefaultConfig()
+		cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", TagPrefix: "v"}
+		cfg.MergedPRScanWindow = 30 * time.Minute
+		c := NewController(cfg, ghClient, nil, "owner", "repo")
+		store := newTestStateStore(t)
+		c.SetStateStore(store)
+		return c, store
+	}
+
+	isTracked := func(c *Controller, prNumber int) bool {
+		for _, p := range c.GetActivePRs() {
+			if p.PRNumber == prNumber {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("fresh persisted releasing row is skipped", func(t *testing.T) {
+		c, store := newScanController(t)
+		if err := store.SavePRState(&PRState{PRNumber: 77, BranchName: "pilot/GH-770", Stage: StageReleasing, CreatedAt: time.Now()}); err != nil {
+			t.Fatalf("SavePRState: %v", err)
+		}
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs: %v", err)
+		}
+		if isTracked(c, 77) {
+			t.Error("PR 77 was re-registered despite a fresh persisted releasing row; B3 skip gate did not fire")
+		}
+	})
+
+	t.Run("stale persisted releasing row is re-driven", func(t *testing.T) {
+		c, store := newScanController(t)
+		if err := store.SavePRState(&PRState{PRNumber: 77, BranchName: "pilot/GH-770", Stage: StageReleasing, CreatedAt: time.Now()}); err != nil {
+			t.Fatalf("SavePRState: %v", err)
+		}
+		if _, err := store.db.Exec(
+			`UPDATE autopilot_pr_state SET updated_at = datetime('now', '-2 hours') WHERE pr_number = ?`, 77,
+		); err != nil {
+			t.Fatalf("backdate: %v", err)
+		}
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs: %v", err)
+		}
+		if !isTracked(c, 77) {
+			t.Error("PR 77 was not re-driven despite a stale persisted releasing row; wedged release cannot recover")
+		}
+	})
+}
+
 func TestController_CircuitBreaker(t *testing.T) {
 	// Test per-PR circuit breaker trips after max failures for that specific PR
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -2,6 +2,7 @@ package autopilot
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -443,18 +444,64 @@ func (s *StateStore) LoadAllPRFailures() (map[int]*prFailureState, error) {
 	return failures, nil
 }
 
-// PurgeTerminalPRStates removes PR states in terminal stages (failed, merged+removed).
-// This is for housekeeping — active PRs are never purged.
+// releasingStaleThreshold bounds how long a PR row may sit at stage='releasing'
+// before it is treated as wedged. 'releasing' is not a terminal stage, but a row
+// stuck past this threshold indicates a release that never completed (B4/TASK-309).
+// Shared by PurgeTerminalPRStates (B4 housekeeping purge) and the scanner skip
+// gate (B3, PersistedReleasingAge) so both agree on what "stale" means.
+const releasingStaleThreshold = 30 * time.Minute
+
+// PurgeTerminalPRStates removes housekeeping-eligible PR state rows: terminal
+// 'failed' rows older than olderThan, plus 'releasing' rows untouched for longer
+// than releasingStaleThreshold. A 'releasing' row is not strictly terminal, but
+// one stuck past the threshold is a wedged release (B4/TASK-309) — purging it is a
+// safety net so the row cannot live forever and suppress re-discovery by
+// ScanRecentlyMergedPRs. Active PRs (fresh rows, other stages) are never purged.
 func (s *StateStore) PurgeTerminalPRStates(olderThan time.Duration) (int64, error) {
-	cutoff := time.Now().Add(-olderThan)
+	// updated_at is written as CURRENT_TIMESTAMP (SQLite UTC), so the cutoffs must
+	// be evaluated against SQLite's own UTC clock — binding a Go (local) time.Time
+	// here mis-compares by the host's tz offset. <= keeps the olderThan=0 degenerate
+	// case ("purge all terminal rows now") reaping same-second rows.
 	result, err := s.db.Exec(`
 		DELETE FROM autopilot_pr_state
-		WHERE stage IN ('failed') AND updated_at < ?
-	`, cutoff)
+		WHERE (stage = 'failed'    AND updated_at <= datetime('now', ?))
+		   OR (stage = 'releasing' AND updated_at <= datetime('now', ?))
+	`,
+		fmt.Sprintf("-%d seconds", int64(olderThan.Seconds())),
+		fmt.Sprintf("-%d seconds", int64(releasingStaleThreshold.Seconds())),
+	)
 	if err != nil {
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+// PersistedReleasingAge reports the age (time since last update) of a persisted PR
+// row at stage='releasing'. found is false when no row exists for prNumber or the
+// row is in a different stage. The scanner uses this (B3/TASK-309) to skip
+// re-registering a release that is already in flight in the state store but absent
+// from the in-memory activePRs map (e.g. after a daemon restart), without relying
+// on the in-memory map alone. Returning the age (rather than a bool) lets the
+// caller ignore genuinely wedged rows so they can be re-driven.
+func (s *StateStore) PersistedReleasingAge(prNumber int) (age time.Duration, found bool, err error) {
+	var stage string
+	var updatedAt sql.NullTime
+	row := s.db.QueryRow(`SELECT stage, updated_at FROM autopilot_pr_state WHERE pr_number = ?`, prNumber)
+	if scanErr := row.Scan(&stage, &updatedAt); scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, scanErr
+	}
+	if PRStage(stage) != StageReleasing {
+		return 0, false, nil
+	}
+	if !updatedAt.Valid {
+		// Row exists at 'releasing' but has no timestamp (should not happen given
+		// the CURRENT_TIMESTAMP default); treat as wedged so it is not skipped.
+		return releasingStaleThreshold, true, nil
+	}
+	return time.Since(updatedAt.Time), true, nil
 }
 
 // scanPRState scans a single row into a PRState.

--- a/internal/autopilot/state_store_test.go
+++ b/internal/autopilot/state_store_test.go
@@ -342,6 +342,96 @@ func TestStateStore_PurgeTerminalPRStates(t *testing.T) {
 	}
 }
 
+// B4 (TASK-309): PurgeTerminalPRStates also reaps 'releasing' rows stuck past
+// releasingStaleThreshold, while leaving fresh releases-in-flight alone.
+func TestStateStore_PurgeTerminalPRStates_Releasing(t *testing.T) {
+	store := newTestStateStore(t)
+
+	freshReleasing := &PRState{
+		PRNumber:   1,
+		BranchName: "pilot/GH-1",
+		Stage:      StageReleasing,
+		CreatedAt:  time.Now(),
+	}
+	staleReleasing := &PRState{
+		PRNumber:   2,
+		BranchName: "pilot/GH-2",
+		Stage:      StageReleasing,
+		CreatedAt:  time.Now(),
+	}
+	for _, pr := range []*PRState{freshReleasing, staleReleasing} {
+		if err := store.SavePRState(pr); err != nil {
+			t.Fatalf("SavePRState(%d): %v", pr.PRNumber, err)
+		}
+	}
+	// Backdate PR 2 well past the 30-min staleness threshold.
+	if _, err := store.db.Exec(
+		`UPDATE autopilot_pr_state SET updated_at = datetime('now', '-2 hours') WHERE pr_number = ?`, 2,
+	); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	// A large olderThan keeps any 'failed' row out of scope, so the only eligible
+	// row is the stale 'releasing' one (reaped on its own 30-min threshold).
+	purged, err := store.PurgeTerminalPRStates(24 * time.Hour)
+	if err != nil {
+		t.Fatalf("PurgeTerminalPRStates: %v", err)
+	}
+	if purged != 1 {
+		t.Errorf("purged = %d, want 1 (only the stale releasing row)", purged)
+	}
+
+	states, _ := store.LoadAllPRStates()
+	if len(states) != 1 || states[0].PRNumber != 1 {
+		t.Errorf("remaining states = %+v, want only the fresh releasing PR 1", states)
+	}
+}
+
+// B3 (TASK-309): PersistedReleasingAge reports whether a PR already has a release
+// in flight in the state store, and how stale that row is.
+func TestStateStore_PersistedReleasingAge(t *testing.T) {
+	store := newTestStateStore(t)
+
+	// (a) no row → not found.
+	if _, found, err := store.PersistedReleasingAge(99); err != nil || found {
+		t.Errorf("missing row: got found=%v err=%v, want found=false err=nil", found, err)
+	}
+
+	// (b) non-releasing stage → not found.
+	if err := store.SavePRState(&PRState{PRNumber: 10, BranchName: "pilot/GH-10", Stage: StageWaitingCI, CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SavePRState(waiting): %v", err)
+	}
+	if _, found, err := store.PersistedReleasingAge(10); err != nil || found {
+		t.Errorf("non-releasing row: got found=%v err=%v, want found=false", found, err)
+	}
+
+	// (c) fresh releasing row → found, age below threshold.
+	if err := store.SavePRState(&PRState{PRNumber: 20, BranchName: "pilot/GH-20", Stage: StageReleasing, CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SavePRState(releasing): %v", err)
+	}
+	age, found, err := store.PersistedReleasingAge(20)
+	if err != nil || !found {
+		t.Fatalf("fresh releasing: got found=%v err=%v, want found=true", found, err)
+	}
+	if age >= releasingStaleThreshold {
+		t.Errorf("fresh releasing age = %v, want < %v", age, releasingStaleThreshold)
+	}
+
+	// (d) stale releasing row → found, age above threshold.
+	if _, err := store.db.Exec(
+		`UPDATE autopilot_pr_state SET updated_at = datetime('now', '-2 hours') WHERE pr_number = ?`, 20,
+	); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+	age, found, err = store.PersistedReleasingAge(20)
+	if err != nil || !found {
+		t.Fatalf("stale releasing: got found=%v err=%v, want found=true", found, err)
+	}
+	if age < releasingStaleThreshold {
+		t.Errorf("stale releasing age = %v, want >= %v", age, releasingStaleThreshold)
+	}
+}
+
 func TestController_RestoreState(t *testing.T) {
 	store := newTestStateStore(t)
 


### PR DESCRIPTION
Closes #3188.

## Context — the acute P1 was already fixed on `main`

#3188 (TASK-309) catalogued 4 interacting bugs that left PRs stuck at `releasing`. Re-verifying against current `main`:

| Bug | Status before this PR |
|---|---|
| **B1** — `checkExternalMergeOrClose` ejected merged PRs before `handleReleasing` ran (*the actual "stuck for hours" cause*) | ✅ **already fixed** — transitions to `StageReleasing` then returns `false` to let `handleReleasing` run |
| **B2** — `handleReleasing` froze forever on error | 🟡 **mitigated** by TASK-316 (`e77a94bf`): transient-retry + dup-tag classification |
| **B3** — scanner re-registers from a memory-only skip gate | 🔴 LIVE → **fixed here** |
| **B4** — `releasing` rows immortal in the state store | 🔴 LIVE → **fixed here** |

This PR lands the two remaining (defense-in-depth) bugs, B3 and B4.

## B4 — `PurgeTerminalPRStates` reaps stale `releasing` rows
- Broadened from `stage='failed'` only to also purge `stage='releasing'` rows untouched past a 30-min `releasingStaleThreshold`, so a wedged release row can't live forever and suppress re-discovery.
- **Also fixes a latent timezone bug**: `updated_at` is written as `CURRENT_TIMESTAMP` (UTC) but the cutoff bound a *local* `time.Time`, mis-comparing by the host's tz offset (on an ahead-of-UTC host, fresh rows compared as "old"). Now compares against SQLite's own `datetime('now', ?)`; `<=` keeps the `olderThan=0` degenerate case working.

## B3 — DB-aware scanner skip gate
- `ScanRecentlyMergedPRs`'s skip gate consulted only the in-memory `activePRs` map. A PR persisted at `stage='releasing'` but absent from `activePRs` (e.g. after a daemon restart) was re-registered and re-triggered on **every** scan.
- New `StateStore.PersistedReleasingAge(prNumber)` (a targeted `SELECT stage, updated_at` — no change to the shared scan hot-path) lets the scanner **skip a fresh persisted release** while still **re-driving genuinely wedged (stale) ones**. Self-contained: does not depend on B4's purge being wired.

## Out of scope (per issue)
- **B2 attempt-cap/backoff budget** + `pilot_autopilot_releasing_retry_total` metric — low value now that TASK-316 stopped the freeze; can be filed separately if observed in practice.

## Tests
- `TestStateStore_PurgeTerminalPRStates_Releasing` — stale `releasing` purged, fresh kept (B4)
- `TestStateStore_PersistedReleasingAge` — missing / non-releasing / fresh / stale (B3 data layer)
- `TestController_ScanRecentlyMergedPRs_SkipsPersistedReleasing` — fresh row skipped, stale row re-driven (B3 integration)

`go test ./internal/autopilot/...` green · `-race` green · `golangci-lint` 0 issues · `go build ./...` clean.

> Manual (not Pilot): touches the autopilot auto-merge/concurrency core, per the standing manual/Pilot split.