### PR TITLE
chore(build): make release tag-only so it stops colliding with goreleaser CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,13 +159,21 @@ auto-fix:
 gate:
 	@./scripts/pre-push-gate.sh
 
-# Release - creates tag, builds, packages, and publishes to GitHub
-# Usage: make release V=0.14.6 NOTES="Release notes here"
+# Release - creates and pushes the version tag. CI is the sole publisher.
+# Usage: make release V=0.14.6
+#
+# Tag-only by design: the tag push triggers .github/workflows/release.yml
+# (goreleaser), which builds the binaries and publishes the GitHub release,
+# the Homebrew tap, and Docker images; release-desktop.yml ships the desktop
+# bundles. Do NOT create the GitHub release or upload assets here — a local
+# `gh release create` races goreleaser and makes it fail with 422
+# "asset already_exists", which also skips the Homebrew formula publish.
+# (That broke v2.166.6's Release run; v2.166.0–166.5 shipped clean as tag-only.)
 release:
 ifndef V
-	$(error V is required. Usage: make release V=0.14.6 NOTES="Release notes")
+	$(error V is required. Usage: make release V=0.14.6)
 endif
-	@echo "🚀 Creating release v$(V)..."
+	@echo "🚀 Releasing v$(V)..."
 	@if [ -n "$$(git status --porcelain)" ]; then \
 		echo "❌ Error: Working directory not clean. Commit or stash changes first."; \
 		exit 1; \
@@ -177,19 +185,9 @@ endif
 	@echo "📌 Creating and pushing git tag v$(V)..."
 	git tag v$(V)
 	git push origin v$(V)
-	@echo "🔨 Building and packaging binaries..."
-	$(MAKE) package VERSION=v$(V)
-	@echo "📦 Creating GitHub release..."
-	gh release create v$(V) \
-		bin/$(BINARY_NAME)-darwin-amd64.tar.gz \
-		bin/$(BINARY_NAME)-darwin-arm64.tar.gz \
-		bin/$(BINARY_NAME)-linux-amd64.tar.gz \
-		bin/$(BINARY_NAME)-linux-arm64.tar.gz \
-		bin/checksums.txt \
-		--title "pilot v$(V)" \
-		--notes "$(if $(NOTES),$(NOTES),Release v$(V))"
-	@echo "✅ Released v$(V)"
-	@echo "   Run 'pilot upgrade' to update"
+	@echo "✅ Tag v$(V) pushed. CI (goreleaser) now builds binaries and publishes"
+	@echo "   the GitHub release, Homebrew tap, and Docker/Desktop bundles."
+	@echo "   Track it: gh run list --workflow=Release"
 
 # Build Docker image for standalone Pilot
 docker-build:


### PR DESCRIPTION
## Problem
`make release` (used to cut **v2.166.6**) did a local `make package` + `gh release create`. The same tag push also triggers the goreleaser workflow (`.github/workflows/release.yml`), which rebuilt the binaries and tried to upload them to the **same** release → `422 Validation Failed [already_exists]` on every asset → goreleaser **exit 1**, which skipped the **Homebrew formula publish** (the tap was stranded at v2.166.5 until fixed by hand).

Prior releases (v2.166.0–166.5) shipped clean because they were cut **tag-only** — goreleaser was the sole publisher.

## Fix
`make release V=X.Y.Z` now only **creates and pushes the tag**, then lets CI publish everything:
- `release.yml` (goreleaser) → binaries + GitHub release + Homebrew tap + Docker
- `release-desktop.yml` → desktop bundles

Dropped the local `make package` + `gh release create` steps and the now-unused `NOTES` var (goreleaser generates the changelog from commits).

## Verify
`make -n release V=9.9.9` → emits only `git tag` + `git push` (guards intact); no `gh release create` / `make package`.

No Go code touched; build-tooling only.