### PR TITLE
fix(executor): stop epic decomposition from discarding child work (TASK-356)

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1506,6 +1506,27 @@ func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []Cr
 			return fmt.Errorf("sub-issue %s failed: %s", issueRef, result.Error)
 		}
 
+		// TASK-356 #1: work-loss guard. A sub-issue runs with CreatePR=true, so a
+		// successful child MUST yield a PR. When it instead reports success with real
+		// commits (CommitSHA set) but no PR (empty PRUrl), its work is stranded in a
+		// worktree that cleanup will discard — the failure mode that silently lost 26
+		// minutes of a real port (studio-sdk #17). Refuse to close the issue or report
+		// epic success: fail loud so the child issue stays OPEN for recovery/retry
+		// instead of the work vanishing behind a false "completed" record.
+		if result.PRUrl == "" && result.CommitSHA != "" {
+			shortSHA := result.CommitSHA[:min(7, len(result.CommitSHA))]
+			warnMsg := fmt.Sprintf("⚠️ %d/%d produced commits (%s) but no PR — work not delivered; leaving issue open for retry: %s",
+				i+1, total, shortSHA, issue.Subtask.Title)
+			_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, warnMsg)
+			r.log.Error("sub-issue committed work but produced no PR — refusing to discard",
+				"parent_id", parent.ID,
+				"sub_issue", issueRef,
+				"commit_sha", shortSHA,
+				"branch", subTask.Branch,
+			)
+			return fmt.Errorf("sub-issue %s committed work (sha %s) but produced no PR — work would be lost, halting epic", issueRef, shortSHA)
+		}
+
 		// Register sub-issue PR with autopilot controller (GH-596)
 		// Note: PR callback uses int issueNumber for GitHub compatibility
 		if result.PRUrl != "" && r.onSubIssuePRCreated != nil {

--- a/internal/executor/epic_sequential_test.go
+++ b/internal/executor/epic_sequential_test.go
@@ -235,15 +235,19 @@ func TestSequentialEpicFlow(t *testing.T) {
 			},
 		},
 		{
-			name:         "sub-issue succeeds but no PR URL - callback skipped",
+			// TASK-356 #1: a child commits real work but produces no PR — its work is
+			// stranded in a worktree cleanup will discard. The work-loss guard halts the
+			// epic loudly so the issue stays open for recovery, rather than silently
+			// closing it and marching on (which lost the studio-sdk #17 port).
+			name:         "sub-issue commits but no PR URL - work-loss guard halts epic",
 			numSubIssues: 2,
 			resultFn: func(idx int, task *Task) (*ExecutionResult, error) {
 				if idx == 0 {
-					// First sub-issue: success but no PR (docs-only change)
+					// First sub-issue: committed work but PR creation never landed.
 					return &ExecutionResult{
 						TaskID:    task.ID,
 						Success:   true,
-						Output:    "docs updated",
+						Output:    "committed but no PR",
 						PRUrl:     "",
 						CommitSHA: "sha-docs",
 					}, nil
@@ -256,13 +260,12 @@ func TestSequentialEpicFlow(t *testing.T) {
 					CommitSHA: "sha-code",
 				}, nil
 			},
-			wantErr:             false,
-			wantExecCount:       2,
-			wantPRCallbackCount: 1, // Only second sub-issue triggers callback
-			wantPRNumbers:       []int{500},
+			wantErr:             true,
+			wantErrContains:     "no PR",
+			wantExecCount:       1, // halts after the first child; second never runs
+			wantPRCallbackCount: 0, // callback never fires for a PR-less child
 			wantBranches: []string{
 				"pilot/GH-100",
-				"pilot/GH-101",
 			},
 		},
 	}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1491,11 +1491,6 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						)
 						// Don't fail the epic — sub-issues may have their own PRs
 					} else {
-						// Get commit SHA
-						if sha, shaErr := epicGit.GetCurrentCommitSHA(ctx); shaErr == nil && sha != "" {
-							epicResult.CommitSHA = sha
-						}
-
 						// Determine base branch
 						baseBranch := task.BaseBranch
 						if baseBranch == "" {
@@ -1506,6 +1501,11 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						}
 
 						// GH-2743: no-commits guard for epic PR path.
+						// TASK-356 #1: harvest CommitSHA ONLY after this guard passes. The epic
+						// parent runs in an orchestrator-only worktree whose HEAD == base HEAD,
+						// so reading the SHA before the guard recorded that foreign base SHA as
+						// the epic's CommitSHA — making a no-deliverable epic look "completed"
+						// (a false-positive no-op that hid the loss of the child's real work).
 						if guardCount, _ := epicGit.CountNewCommits(ctx, baseBranch); guardCount == 0 {
 							r.log.Warn("Epic branch has no commits vs base, skipping PR creation",
 								slog.String("task_id", task.ID),
@@ -1513,6 +1513,12 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 							)
 							r.reportProgress(task.ID, "PR Skipped", 97, "epic branch has no commits relative to base")
 							return epicResult, nil
+						}
+
+						// Parent branch carries real commits — safe to record its HEAD as the
+						// epic's deliverable SHA (it is no longer the foreign base SHA).
+						if sha, shaErr := epicGit.GetCurrentCommitSHA(ctx); shaErr == nil && sha != "" {
+							epicResult.CommitSHA = sha
 						}
 
 						// Create PR with GitHub auto-close keyword

--- a/internal/executor/sub_issue_callback_test.go
+++ b/internal/executor/sub_issue_callback_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -171,15 +172,19 @@ func TestExecuteSubIssues_NilCallbackNoPanic(t *testing.T) {
 	}
 }
 
-func TestExecuteSubIssues_CallbackNotFiredOnNoPRUrl(t *testing.T) {
-	// Execution succeeds but no PR URL (e.g., CreatePR was false or PR creation failed)
+// TASK-356 #1: epic sub-issues run with CreatePR=true, so a successful child that
+// reports real commits but NO PR URL means its work is stranded in a worktree that
+// cleanup will discard (the studio-sdk #17 work-loss). ExecuteSubIssues must fail
+// loud — not silently close the issue and report epic success — so the child issue
+// stays open for recovery. The PR callback must not fire either.
+func TestExecuteSubIssues_WorkLossGuard_CommitsButNoPR(t *testing.T) {
 	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
 		return &ExecutionResult{
 			TaskID:    task.ID,
 			Success:   true,
 			Output:    "done",
-			PRUrl:     "", // No PR
-			CommitSHA: "abc123",
+			PRUrl:     "",          // PR creation failed / never happened
+			CommitSHA: "abc123def", // ...but real work WAS committed
 		}, nil
 	}
 
@@ -204,10 +209,52 @@ func TestExecuteSubIssues_CallbackNotFiredOnNoPRUrl(t *testing.T) {
 	}
 
 	err := runner.ExecuteSubIssues(context.Background(), parent, issues, parent.ProjectPath, "")
-	if err != nil {
-		t.Fatalf("ExecuteSubIssues returned error: %v", err)
+	if err == nil {
+		t.Fatal("expected work-loss guard error when a sub-issue commits but produces no PR, got nil")
+	}
+	if !strings.Contains(err.Error(), "no PR") {
+		t.Errorf("error should explain the missing PR / work loss, got: %v", err)
+	}
+	if callbackFired {
+		t.Error("callback should not fire when PRUrl is empty")
+	}
+}
+
+// TASK-356 #1 (counterpart): a child that legitimately produced no commits AND no
+// PR is benign — the ghost-SHA guard would already have failed a real no-op, so an
+// empty CommitSHA here means there is simply nothing to lose. The work-loss guard
+// must NOT fire (it keys on commits-without-delivery), and the callback stays silent.
+func TestExecuteSubIssues_NoCommitsNoPR_NoGuard(t *testing.T) {
+	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{
+			TaskID:    task.ID,
+			Success:   true,
+			Output:    "no changes needed",
+			PRUrl:     "",
+			CommitSHA: "", // no work committed → nothing to lose
+		}, nil
 	}
 
+	runner := newTestRunnerWithExecFunc(execFn)
+
+	callbackFired := false
+	runner.SetOnSubIssuePRCreated(func(prNumber int, prURL string, issueNumber int, commitSHA, branchName string, issueNodeID string) {
+		callbackFired = true
+	})
+
+	parent := &Task{ID: "GH-71", Title: "[epic] No-op child"}
+	issues := []CreatedIssue{
+		{
+			Number:  31,
+			URL:     "https://github.com/owner/repo/issues/31",
+			Subtask: PlannedSubtask{Title: "No-op task", Description: "desc", Order: 1},
+		},
+	}
+
+	err := runner.ExecuteSubIssues(context.Background(), parent, issues, parent.ProjectPath, "")
+	if err != nil {
+		t.Fatalf("benign no-commits/no-PR child must not trip the work-loss guard: %v", err)
+	}
 	if callbackFired {
 		t.Error("callback should not fire when PRUrl is empty")
 	}


### PR DESCRIPTION
## Problem (TASK-356 #1, P1)

Epic auto-decomposition **silently lost completed child work** and recorded a false `completed` no-op against a foreign SHA.

Observed (studio-sdk #16 → child #17):
1. Parent epic #16 dispatched with an **empty orchestrator worktree** (`pilot/GH-16`).
2. Child #17 executed the real port in its **own** worktree (`pilot/GH-17`) — ~7 files over 26 min.
3. Child #17 was **closed with no merge**, branch **never pushed**, worktree reset.
4. Parent #16 recorded `status=completed`, `commit_sha=<base HEAD>` (foreign), 0 files, no PR. **26 min of work — gone.**

## Root cause

Two independent defects:

1. **`ExecuteSubIssues` (`epic.go`)** only checked `result.Success`. A child runs with `CreatePR=true`, so a successful child that produced real commits but **no PR URL** (PR creation failed) had its work stranded in a worktree that cleanup discards — yet the loop closed the child issue and reported epic success.
2. **Epic finalization (`runner.go`)** read the parent branch `CommitSHA` **before** the no-commits guard. The orchestrator-only parent worktree's `HEAD == base HEAD`, so it recorded the **foreign base SHA** as the epic deliverable — masking the lost work as shipped.

## Fix

- **`epic.go`** — work-loss guard: when a child reports `Success && CommitSHA != "" && PRUrl == ""`, fail loud and halt the epic, leaving the child issue **open for recovery** instead of silently closing it. (Truly empty children are already failed upstream by the ghost-SHA guard, so this keys precisely on *committed-but-undelivered* work.)
- **`runner.go`** — harvest the parent `CommitSHA` **only after** the no-commits guard passes, so a no-deliverable epic never records a foreign SHA.

## Tests

- `TestExecuteSubIssues_WorkLossGuard_CommitsButNoPR` — guard fires (error) on commits-without-PR; callback never fires.
- `TestExecuteSubIssues_NoCommitsNoPR_NoGuard` — benign no-commits/no-PR child still passes.
- `TestSequentialEpicFlow` — the former "no PR URL → callback skipped" case updated to the corrected contract (halts, work-loss error).
- Full `internal/executor` package green.

## Notes

- This is a **manual** pilot-core fix (Pilot cannot fix its own execution guard — Wave 0 / TASK-320 B2 precedent).
- Does **not** yet recover the stranded branch automatically (fix direction (a)); it converts silent loss into a loud, recoverable failure + removes the false-positive completion. The `no-decompose` label remains the reliable escape hatch.

Closes TASK-356 #1.