### PR TITLE
fix(autopilot): board write-back for externally-merged PRs (TASK-356 #2)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2551,6 +2551,26 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 		// gates because the heal must happen on every discovered merged Pilot PR.
 		c.selfHealForPR(ctx, issueNum, pr.HTMLURL)
 
+		// TASK-356 #2: board write-back for externally-merged PRs. Large PRs that
+		// hit the stage approval-misconfig (require_approval=true + approval disabled)
+		// are merged manually (`gh pr merge` / GitHub UI) and never pass through
+		// handleMerging, so their board card stays stuck "In Review". Move it to Done
+		// here, mirroring the on-merge write-back in handleMerging. Like
+		// recordMergeSuccess/selfHealForPR above, this fires on every discovered merged
+		// Pilot PR (before the release-tag/activePRs skip gates). The scanner only runs
+		// when on_merge release is enabled (see shouldTriggerRelease at the top), so
+		// fully decoupling board sync from release is a follow-up. UpdateProjectItemStatus
+		// is idempotent and silently skips issues that aren't on the board.
+		if c.boardSync != nil && c.doneStatus != "" && issueNum > 0 {
+			if nodeID, nodeErr := c.ghClient.GetIssueNodeID(ctx, c.owner, c.repo, issueNum); nodeErr != nil {
+				c.log.Warn("board sync on external merge: failed to resolve issue node id",
+					"pr", pr.Number, "issue", issueNum, "error", nodeErr)
+			} else if err := c.boardSync.UpdateProjectItemStatus(ctx, nodeID, c.doneStatus); err != nil {
+				c.log.Warn("board sync on external merge failed",
+					"pr", pr.Number, "issue", issueNum, "error", err)
+			}
+		}
+
 		// Skip if already tracked in activePRs (avoid duplicate processing)
 		c.mu.RLock()
 		_, alreadyTracked := c.activePRs[pr.Number]

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6148,6 +6148,66 @@ func TestController_ScanRecentlyMergedPRs_RecordsMetrics(t *testing.T) {
 	}
 }
 
+// TestController_ScanRecentlyMergedPRs_BoardWriteBack verifies TASK-356 #2: an
+// externally-merged Pilot PR (manual `gh pr merge`, never through handleMerging)
+// still has its board card moved to Done by the scanner. Large PRs blocked by the
+// stage approval-misconfig are merged manually, so without this the card stays
+// stuck "In Review".
+func TestController_ScanRecentlyMergedPRs_BoardWriteBack(t *testing.T) {
+	recentMergedAt := time.Now().Add(-3 * time.Minute).UTC().Format(time.RFC3339)
+
+	pilotPR := github.PullRequest{
+		Number:         123,
+		Head:           github.PRRef{Ref: "pilot/GH-456", SHA: "headsha123"},
+		Base:           github.PRRef{Ref: "main"},
+		HTMLURL:        "https://github.com/owner/repo/pull/123",
+		Title:          "feat: big change merged manually",
+		Merged:         true,
+		MergedAt:       recentMergedAt,
+		MergeCommitSHA: "merge-sha-123",
+	}
+
+	const issueNodeID = "I_kwDOissue456"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{&pilotPR})
+		case r.URL.Path == "/repos/owner/repo/issues/456":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"node_id": issueNodeID})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", TagPrefix: "v"}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	mock := &mockBoardSyncer{}
+	c := NewController(cfg, ghClient, nil, "owner", "repo",
+		withBoardSyncerForTest(mock, "Done", "Failed", "In Review", "In Dev"))
+	c.SetStateStore(newTestStateStore(t))
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	if len(mock.calls) != 1 {
+		t.Fatalf("board sync calls = %d, want 1 (externally-merged PR card should move to Done)", len(mock.calls))
+	}
+	if mock.calls[0].issueNodeID != issueNodeID {
+		t.Errorf("board sync issueNodeID = %q, want %q", mock.calls[0].issueNodeID, issueNodeID)
+	}
+	if mock.calls[0].statusName != "Done" {
+		t.Errorf("board sync statusName = %q, want %q", mock.calls[0].statusName, "Done")
+	}
+}
+
 // TestController_ScanRecentlyMergedPRs_RecordsMetricsDespiteExistingRelease
 // reproduces the bug where Pilot's own self-release pipeline always tags every
 // merge within ~1min, so by the time the ~5-15min scanner tick runs the


### PR DESCRIPTION
## Problem (TASK-356 #2)

Large PRs that escalate to approval hit the **stage approval-misconfig** (`environments.stage.require_approval: true` while `approval.enabled: false`) — the autopilot posts `🚧 Merge blocked: approval not wired` and never auto-merges. The operator merges them manually (`gh pr merge` / GitHub UI).

A manually/externally-merged PR **never passes through `handleMerging`**, so the on-merge board write-back (`controller.go` GH-1870) never fires → the board card stays stuck **"In Review"** even though the issue is closed `pilot-done`. Every manual merge then needs a manual "→ Done" move.

## Fix

`ScanRecentlyMergedPRs` already reconciles externally-merged Pilot PRs (records merge metrics, self-heals execution rows). It now **also moves the board card to Done**:

- Resolve the issue node ID via `GetIssueNodeID(owner, repo, issueNum)`.
- Call `boardSync.UpdateProjectItemStatus(nodeID, doneStatus)` — idempotent, silently skips off-board issues.
- Placed alongside `recordMergeSuccess` / `selfHealForPR`, **before** the release-tag / activePRs skip gates, so it fires on every discovered merged Pilot PR (covers PRs autopilot tracked through creation but that were merged manually).
- Nil-guarded (`boardSync != nil && doneStatus != "" && issueNum > 0`) — no behavior change when board sync isn't configured.

## Known limitation

The scanner only runs when **on_merge release is enabled** (`shouldTriggerRelease`), so board sync for external merges is currently coupled to release being on (same as the existing `selfHealForPR` in this scan). Fully decoupling board sync from release is a follow-up.

## Not addressed here (TASK-356)

- **#2 part A** ("degrade the approval gate") — intentionally **not** changed: auto-merging around a deliberately-set `require_approval: true` is a policy decision; the right resolution is wiring approval or fixing the config. The health check already flags `approval-misconfig`.
- **#3** (autopilot adds no-status PR cards) — **not our code**: PR cards are auto-added by a GitHub Project workflow (no `addProjectV2Item` in the repo). Fix is a project-settings change (disable auto-add), not a repo change.

## Tests

`TestController_ScanRecentlyMergedPRs_BoardWriteBack` — externally-merged PR → card moved to Done with the resolved node ID. Full `internal/autopilot` package green.

Refs TASK-356 #2.