### PR TITLE
fix(autopilot): decouple board write-back from on_merge release (TASK-356 #2 follow-up)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2471,9 +2471,16 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 // autopilot (e.g. via `gh pr merge` or the GitHub UI).
 // Called on startup and periodically from the Run loop.
 func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
-	// Skip if auto-release is not enabled
-	if !c.shouldTriggerRelease() {
-		c.log.Debug("skipping merged PR scan: auto-release not enabled")
+	// TASK-356 #2 (decouple): the scan reconciles externally-merged Pilot PRs —
+	// release triggering, merge metrics, execution-row self-heal, AND board
+	// write-back. Run it whenever EITHER auto-release OR board sync is enabled, so
+	// a board-sourced (non-releasing) setup still gets its cards moved to Done on a
+	// manual merge. The release-triggering tail below is separately gated on
+	// releaseEnabled so nothing tries to tag a release when release is off.
+	releaseEnabled := c.shouldTriggerRelease()
+	boardEnabled := c.boardSync != nil && c.doneStatus != ""
+	if !releaseEnabled && !boardEnabled {
+		c.log.Debug("skipping merged PR scan: neither auto-release nor board sync enabled")
 		return nil
 	}
 
@@ -2557,11 +2564,10 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 		// handleMerging, so their board card stays stuck "In Review". Move it to Done
 		// here, mirroring the on-merge write-back in handleMerging. Like
 		// recordMergeSuccess/selfHealForPR above, this fires on every discovered merged
-		// Pilot PR (before the release-tag/activePRs skip gates). The scanner only runs
-		// when on_merge release is enabled (see shouldTriggerRelease at the top), so
-		// fully decoupling board sync from release is a follow-up. UpdateProjectItemStatus
-		// is idempotent and silently skips issues that aren't on the board.
-		if c.boardSync != nil && c.doneStatus != "" && issueNum > 0 {
+		// Pilot PR (before the release-tag/activePRs skip gates) and is independent of
+		// whether release is enabled. UpdateProjectItemStatus is idempotent and silently
+		// skips issues that aren't on the board.
+		if boardEnabled && issueNum > 0 {
 			if nodeID, nodeErr := c.ghClient.GetIssueNodeID(ctx, c.owner, c.repo, issueNum); nodeErr != nil {
 				c.log.Warn("board sync on external merge: failed to resolve issue node id",
 					"pr", pr.Number, "issue", issueNum, "error", nodeErr)
@@ -2569,6 +2575,12 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 				c.log.Warn("board sync on external merge failed",
 					"pr", pr.Number, "issue", issueNum, "error", err)
 			}
+		}
+
+		// Everything below is release-triggering machinery — skip it entirely when
+		// release is disabled (the scan may be running for board sync alone).
+		if !releaseEnabled {
+			continue
 		}
 
 		// Skip if already tracked in activePRs (avoid duplicate processing)

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6208,6 +6208,70 @@ func TestController_ScanRecentlyMergedPRs_BoardWriteBack(t *testing.T) {
 	}
 }
 
+// TestController_ScanRecentlyMergedPRs_BoardWriteBack_NoRelease verifies TASK-356 #2
+// (decouple): board write-back fires even when on_merge release is DISABLED, and the
+// release-triggering tail is skipped (PR not added to activePRs). A board-sourced,
+// non-releasing setup must still move a manually-merged PR's card to Done.
+func TestController_ScanRecentlyMergedPRs_BoardWriteBack_NoRelease(t *testing.T) {
+	recentMergedAt := time.Now().Add(-3 * time.Minute).UTC().Format(time.RFC3339)
+
+	pilotPR := github.PullRequest{
+		Number:         321,
+		Head:           github.PRRef{Ref: "pilot/GH-654", SHA: "headsha321"},
+		Base:           github.PRRef{Ref: "main"},
+		HTMLURL:        "https://github.com/owner/repo/pull/321",
+		Title:          "feat: merged manually, release off",
+		Merged:         true,
+		MergedAt:       recentMergedAt,
+		MergeCommitSHA: "merge-sha-321",
+	}
+
+	const issueNodeID = "I_kwDOissue654"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{&pilotPR})
+		case r.URL.Path == "/repos/owner/repo/issues/654":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"node_id": issueNodeID})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: false} // release OFF
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	mock := &mockBoardSyncer{}
+	c := NewController(cfg, ghClient, nil, "owner", "repo",
+		withBoardSyncerForTest(mock, "Done", "Failed", "In Review", "In Dev"))
+	c.SetStateStore(newTestStateStore(t))
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	if len(mock.calls) != 1 {
+		t.Fatalf("board sync calls = %d, want 1 (card should move to Done even with release off)", len(mock.calls))
+	}
+	if mock.calls[0].issueNodeID != issueNodeID || mock.calls[0].statusName != "Done" {
+		t.Errorf("board sync call = %+v, want {%q, Done}", mock.calls[0], issueNodeID)
+	}
+
+	// Release tail must be skipped: PR not registered for release triggering.
+	c.mu.RLock()
+	_, tracked := c.activePRs[321]
+	c.mu.RUnlock()
+	if tracked {
+		t.Error("PR 321 was added to activePRs; release tail must be skipped when release is disabled")
+	}
+}
+
 // TestController_ScanRecentlyMergedPRs_RecordsMetricsDespiteExistingRelease
 // reproduces the bug where Pilot's own self-release pipeline always tags every
 // merge within ~1min, so by the time the ~5-15min scanner tick runs the


### PR DESCRIPTION
## Follow-up to TASK-356 #2 (PR #3391)

The board write-back for externally-merged PRs landed inside `ScanRecentlyMergedPRs`, which **early-returned unless on_merge release was enabled**. So board sync (and the existing self-heal / merge-metrics reconciliation) only ran in releasing setups — a board-sourced, non-releasing project would still leave a manually-merged card stuck **"In Review"**.

## Fix

- Run the scan when **either** auto-release **or** board sync is enabled (`releaseEnabled || boardEnabled`).
- Separately gate the **release-triggering tail** on `releaseEnabled` (`if !releaseEnabled { continue }`) so nothing tries to tag a release when release is off.
- Board write-back, `recordMergeSuccess`, and `selfHealForPR` now run for every discovered merged Pilot PR independent of release config.

## Tests

- `TestController_ScanRecentlyMergedPRs_BoardWriteBack_NoRelease` — release **off** + board sync on → card moved to Done, and the PR is **not** registered for release triggering (release tail skipped).
- Existing scanner/board tests unchanged & green; full `internal/autopilot` package green.

Closes the "decouple board sync from on_merge release" follow-up on TASK-356.