### PR TITLE
fix(dashboard): accurate QUEUE 'failed' count via outcome classification (TASK-358)

### DIFF
--- a/.agent/tasks/TASK-358-dashboard-failed-count-classification.md
+++ b/.agent/tasks/TASK-358-dashboard-failed-count-classification.md
@@ -1,0 +1,53 @@
+# TASK-358: Dashboard "failed" count inflated by misclassified outcomes
+
+**Status:** 🟢 implemented (PR on `fix/dashboard-failed-classification`) · 2026-06-02
+**Refs:** [[TASK-320]] (executor false-negative no-op) · [[TASK-321]] (phantom blocked on already-merged) · [[TASK-355]] (board-sourced no-op false positive)
+
+## Symptom
+
+QUEUE card showed `✗ 784 failed` — far higher than real failures. Reported: "many
+showed failed but were done correctly."
+
+## Root cause
+
+Not a display bug — a **write-path classification bug**.
+
+- `dispatcher.go` collapsed *every* `result.Success == false` outcome into
+  `status = "failed"`: declined, no-op ("no new commit produced" / `no_changes`),
+  stalled, and budget-capped runs all became "failed".
+- `GetLifetimeTaskCounts()` then `SUM(CASE WHEN status='failed')` — so the card
+  counted all of them as failures.
+- `result.Declined` was never honored by the dispatcher, so even explicit declines
+  inflated the count.
+
+## Fix
+
+**Layer A — classify at the write path (forward):**
+- `ExecutionResult.Outcome` field; set at terminal points (budget/stalled/declined/no_op).
+- `TerminalStatus(result)` in `runner.go`: Success→`completed`, Declined→`declined`,
+  Outcome tag → `no_op`/`stalled`, else error-signature fallback, else `failed`.
+- `dispatcher.go` writes the classified status (+ phase label) instead of blanket `failed`.
+- `UpdateExecutionStatus` treats `no_op` as terminal (stamps `completed_at`).
+- Heal-on-merge scope (`UpdateExecutionStatusByTaskID`, `SelfHealExecutionAfterMerge`)
+  broadened to `status IN ('failed','no_op','stalled')` so reclassified rows still
+  promote to `completed` when their PR lands.
+
+**Layer B — backfill existing rows:**
+- `reclassifyLegacyOutcomes()` runs in `migrate()` (idempotent): reclassifies
+  historical `failed` rows by deterministic error signature into `no_op`/`stalled`.
+  Genuine failures (no signature) stay `failed`.
+
+**Dashboard:** `Failed` now counts genuine failures only; `NoOp`/`Stalled`/`Declined`
+shown as a muted ` (N no-op · M stalled · K declined)` suffix so numbers reconcile.
+
+## Known limitations
+
+- Declined rows can't be backfilled — decline reason was never persisted to
+  `executions.error` (only to backend diagnostics). Forward-only.
+- Rows where work merged but was recorded as a *generic* failure (no no-op signature)
+  are healed at merge-time via the broadened self-heal, not by the backfill.
+
+## Tests
+
+- `executor/terminal_status_test.go` — `TerminalStatus` / `terminalPhaseLabel` tables.
+- `memory/reclassify_outcomes_test.go` — backfill correctness, idempotency, no-op self-heal.

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -39,6 +39,7 @@ type MetricsCardData struct {
 	TotalTokens, InputTokens, OutputTokens  int
 	TotalCostUSD, CostPerTask               float64
 	TotalTasks, Succeeded, Failed, Declined int
+	NoOp, Stalled                           int       // TASK-358: non-failure terminal outcomes
 	TokenHistory                            []int64   // 7 days
 	CostHistory                             []float64 // 7 days
 	TaskHistory                             []int     // 7 days
@@ -603,6 +604,8 @@ func (m *Model) hydrateFromStore() {
 		m.metricsCard.Succeeded = taskCounts.Succeeded
 		m.metricsCard.Failed = taskCounts.Failed
 		m.metricsCard.Declined = taskCounts.Declined
+		m.metricsCard.NoOp = taskCounts.NoOp
+		m.metricsCard.Stalled = taskCounts.Stalled
 	}
 
 	// Populate history panel from recent executions (most recent 5)
@@ -880,6 +883,8 @@ func storeRefreshCmd(store *memory.Store) tea.Cmd {
 			msg.metricsCard.Succeeded = taskCounts.Succeeded
 			msg.metricsCard.Failed = taskCounts.Failed
 			msg.metricsCard.Declined = taskCounts.Declined
+			msg.metricsCard.NoOp = taskCounts.NoOp
+			msg.metricsCard.Stalled = taskCounts.Stalled
 		}
 
 		if msg.metricsCard.TotalTasks > 0 {
@@ -2031,17 +2036,39 @@ func (m Model) renderCostCard(cw int) string {
 	return buildMiniCard("cost", value, detail1, detail2, spark, cw)
 }
 
+// nonFailureSuffix builds the muted " (N no-op · M stalled · K declined)" suffix
+// for the QUEUE card, omitting any zero buckets. Returns "" when all are zero.
+// TASK-358: these are non-failure terminal outcomes split out of "failed".
+func nonFailureSuffix(c MetricsCardData) string {
+	var parts []string
+	if c.NoOp > 0 {
+		parts = append(parts, fmt.Sprintf("%d no-op", c.NoOp))
+	}
+	if c.Stalled > 0 {
+		parts = append(parts, fmt.Sprintf("%d stalled", c.Stalled))
+	}
+	if c.Declined > 0 {
+		parts = append(parts, fmt.Sprintf("%d declined", c.Declined))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, " · ") + ")"
+}
+
 // renderTaskCard renders the QUEUE mini-card with the given card width.
 // Value shows current queue depth (pending + running), not lifetime totals.
 func (m Model) renderTaskCard(cw int) string {
 	ciw := cw - 6
 	value := fmt.Sprintf("%d", len(m.tasks))
 	detail1 := statusCompletedStyle.Render(fmt.Sprintf("✓ %d succeeded", m.metricsCard.Succeeded))
-	declinedSuffix := ""
-	if m.metricsCard.Declined > 0 {
-		declinedSuffix = fmt.Sprintf(" (%d declined)", m.metricsCard.Declined)
+	// TASK-358: "failed" counts genuine failures only. Non-failure terminal
+	// outcomes (no-op / stalled / declined) are shown as a muted suffix so the
+	// numbers reconcile and a no-op is no longer miscounted as a failure.
+	detail2 := statusFailedStyle.Render(fmt.Sprintf("✗ %d failed", m.metricsCard.Failed))
+	if suffix := nonFailureSuffix(m.metricsCard); suffix != "" {
+		detail2 += statusPendingStyle.Render(suffix)
 	}
-	detail2 := statusFailedStyle.Render(fmt.Sprintf("✗ %d failed%s", m.metricsCard.Failed, declinedSuffix))
 
 	// Convert int history to float64
 	floats := make([]float64, len(m.metricsCard.TaskHistory))
@@ -2617,6 +2644,10 @@ func statusIconStyle(status string) (string, lipgloss.Style) {
 		return "x", statusFailedStyle
 	case "stalled":
 		return "~", statusFailedStyle
+	case "no_op":
+		return "=", statusPendingStyle // TASK-358: no-change run, not a failure
+	case "declined":
+		return "-", statusPendingStyle // TASK-358: agent declined as unactionable
 	case "running":
 		return "~", statusRunningStyle
 	default:

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -682,16 +682,23 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			// Emit progress callback for task failed
 			w.runner.EmitProgress(exec.TaskID, "Failed", 100, fmt.Sprintf("Execution error: %s", truncateForLog(execErr.Error(), 60)))
 		} else if !result.Success {
-			w.log.Warn("Task completed with failure",
+			// TASK-358: classify the terminal outcome instead of collapsing every
+			// non-success into "failed". declined / no-op / stalled get their own
+			// status so the dashboard's "failed" count reflects genuine failures.
+			status := TerminalStatus(result)
+			w.log.Warn("Task ended without success",
 				slog.String("task_id", exec.TaskID),
+				slog.String("status", status),
 				slog.String("error", result.Error),
 				slog.Duration("duration", duration),
 			)
-			if err := w.store.UpdateExecutionStatus(exec.ID, "failed", result.Error); err != nil {
-				w.log.Error("Failed to update status to failed", slog.Any("error", err))
+			if err := w.store.UpdateExecutionStatus(exec.ID, status, result.Error); err != nil {
+				w.log.Error("Failed to update execution status",
+					slog.String("status", status), slog.Any("error", err))
 			}
-			// Emit progress callback for task failed
-			w.runner.EmitProgress(exec.TaskID, "Failed", 100, fmt.Sprintf("Task failed: %s", truncateForLog(result.Error, 60)))
+			// Emit progress callback with a phase that matches the classified outcome.
+			w.runner.EmitProgress(exec.TaskID, terminalPhaseLabel(status), 100,
+				fmt.Sprintf("%s: %s", status, truncateForLog(result.Error, 60)))
 		} else {
 			w.log.Info("Task completed successfully",
 				slog.String("task_id", exec.TaskID),
@@ -766,4 +773,19 @@ func truncateForLog(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen-3] + "..."
+}
+
+// terminalPhaseLabel maps a classified execution status to the human-readable
+// progress phase shown in the dashboard. TASK-358.
+func terminalPhaseLabel(status string) string {
+	switch status {
+	case "no_op":
+		return "No-op"
+	case "stalled":
+		return "Stalled"
+	case "declined":
+		return "Declined"
+	default:
+		return "Failed"
+	}
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -54,6 +54,60 @@ func IsPermanentFailure(errStr string) bool {
 	return false
 }
 
+// noOpErrorSignatures are deterministic error-message fragments the runner writes
+// when an execution produced no code change for a *non-failure* reason — the work
+// was already present on the base branch (TASK-321 phantom no-op), or the agent
+// completed but made no edits. These are not code failures and must not inflate
+// the dashboard's "failed" count. Used as a fallback when Outcome was not set
+// explicitly (e.g. older rows, or terminal paths that pre-date Outcome). TASK-358.
+var noOpErrorSignatures = []string{
+	"no new commit produced",      // ghost-SHA guard: HEAD/post-push SHA matches base
+	"no_changes",                  // agent completed but made no edits
+	"no commits relative to base", // PR guard: empty branch
+}
+
+// stalledErrorSignatures mark an execution that ran out of budget or stalled —
+// an incomplete run, not a code failure.
+var stalledErrorSignatures = []string{
+	"session stalled",
+	"budget limit exceeded",
+}
+
+// TerminalStatus maps a finished ExecutionResult to the status persisted in the
+// executions table. It exists so the dashboard's "failed" count reflects genuine
+// failures only: declined / no-op / stalled outcomes get their own status instead
+// of collapsing into "failed", which historically inflated the QUEUE card. TASK-358.
+//
+// Precedence: Success → Declined flag → explicit Outcome tag → error-signature
+// fallback → "failed". A genuine failure (compile/test error, crash) has none of
+// the non-failure signals and correctly falls through to "failed".
+func TerminalStatus(result *ExecutionResult) string {
+	if result == nil {
+		return "failed"
+	}
+	if result.Success {
+		return "completed"
+	}
+	if result.Declined {
+		return "declined"
+	}
+	switch result.Outcome {
+	case "declined":
+		return "declined"
+	case "no_op", "no_commits":
+		return "no_op"
+	case "stalled", "budget_exceeded":
+		return "stalled"
+	}
+	if containsAny(result.Error, noOpErrorSignatures) {
+		return "no_op"
+	}
+	if containsAny(result.Error, stalledErrorSignatures) {
+		return "stalled"
+	}
+	return "failed"
+}
+
 // StreamEvent represents a Claude Code stream-json event
 type StreamEvent struct {
 	Type          string          `json:"type"`
@@ -295,6 +349,11 @@ type ExecutionResult struct {
 	Declined bool
 	// DeclinedReason is the human-readable reason Claude provided for the decline.
 	DeclinedReason string
+	// Outcome is a fine-grained terminal classification ("declined", "no_op",
+	// "no_commits", "stalled", "budget_exceeded") used by the dispatcher to pick
+	// the persisted execution status instead of collapsing every !Success result
+	// into "failed". Empty means "classify from Success/Declined/Error". TASK-358.
+	Outcome string
 	// PeakRSSMB is the peak subprocess RSS in MiB collected by the RSS sampler. GH-3028.
 	// Zero on non-Linux/darwin platforms or when the sampler had no data.
 	PeakRSSMB int
@@ -1853,9 +1912,9 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 
 	// TASK-308: Stall detection — track last event time and spawn a watchdog.
 	var (
-		lastEventAt   atomic.Int64
+		lastEventAt       atomic.Int64
 		stallDetectedFlag atomic.Bool
-		stallDone     = make(chan struct{})
+		stallDone         = make(chan struct{})
 	)
 	lastEventAt.Store(time.Now().UnixNano())
 	stallTimeout := r.effectiveStallTimeout()
@@ -1886,7 +1945,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		Model:           selectedModel,
 		Effort:          selectedEffort,
 		MaxTurns:        workflowMaxTurns, // TASK-304: per-repo .pilot/workflow.yaml override
-		FromPR:          task.FromPR, // GH-1267: session resumption from PR context
+		FromPR:          task.FromPR,      // GH-1267: session resumption from PR context
 		WatchdogTimeout: watchdogTimeout,
 		AllowedTools:    allowedTools,
 		MCPConfigPath:   mcpConfigPath,
@@ -1959,6 +2018,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 
 		// GH-539: Check if this was a per-task budget limit breach
 		if state.budgetExceeded {
+			result.Outcome = "budget_exceeded" // TASK-358: not a code failure
 			result.Error = fmt.Sprintf("per-task budget limit exceeded: %s", state.budgetReason)
 			result.TokensInput = state.tokensInput
 			result.TokensOutput = state.tokensOutput
@@ -2006,6 +2066,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 
 		// TASK-308: Check if this was a stall (no event activity for stall_timeout).
 		if state.stallDetected {
+			result.Outcome = "stalled" // TASK-358: incomplete run, not a code failure
 			result.Error = fmt.Sprintf("session stalled: no agent event for >%v", stallTimeout)
 			result.TokensInput = state.tokensInput
 			result.TokensOutput = state.tokensOutput
@@ -2033,9 +2094,9 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				Project:   task.ProjectPath,
 				Error:     result.Error,
 				Metadata: map[string]string{
-					"reason":       "stalled",
+					"reason":        "stalled",
 					"stall_timeout": stallTimeout.String(),
-					"duration_ms":  fmt.Sprintf("%d", duration.Milliseconds()),
+					"duration_ms":   fmt.Sprintf("%d", duration.Milliseconds()),
 				},
 				Timestamp: time.Now(),
 			})
@@ -2617,6 +2678,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					if declinedReason, ok := parseDeclinedReason(refusal); ok {
 						result.Declined = true
 						result.DeclinedReason = declinedReason
+						result.Outcome = "declined" // TASK-358
 						if backendResult != nil {
 							backendResult.ErrorType = string(ErrorTypeDeclined)
 						}
@@ -2640,6 +2702,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					// GH-2328: classify this as ErrorTypeNoChanges and carry the
 					// final assistant message so the failure comment surfaces the
 					// refusal reason instead of a generic "no changes" string.
+					result.Outcome = "no_op" // TASK-358: no edits made, not a code failure
 					if refusal != "" {
 						result.Error = fmt.Sprintf("no_changes: Claude completed but made no code changes after retry — %s", refusal)
 					} else {

--- a/internal/executor/terminal_status_test.go
+++ b/internal/executor/terminal_status_test.go
@@ -1,0 +1,86 @@
+package executor
+
+import "testing"
+
+// TestTerminalStatus verifies the dispatcher classifier maps execution outcomes
+// to the right persisted status so the dashboard's "failed" count reflects
+// genuine failures only (TASK-358).
+func TestTerminalStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *ExecutionResult
+		want   string
+	}{
+		{"nil result", nil, "failed"},
+		{"success", &ExecutionResult{Success: true}, "completed"},
+		{"declined flag", &ExecutionResult{Declined: true}, "declined"},
+		{"declined outcome", &ExecutionResult{Outcome: "declined"}, "declined"},
+		{"no_op outcome", &ExecutionResult{Outcome: "no_op"}, "no_op"},
+		{"no_commits outcome", &ExecutionResult{Outcome: "no_commits"}, "no_op"},
+		{"stalled outcome", &ExecutionResult{Outcome: "stalled"}, "stalled"},
+		{"budget_exceeded outcome", &ExecutionResult{Outcome: "budget_exceeded"}, "stalled"},
+		{
+			"no-op via error signature (phantom no-op, work already on base)",
+			&ExecutionResult{Error: "no new commit produced — post-push SHA matches base branch"},
+			"no_op",
+		},
+		{
+			"no-op via no_changes signature",
+			&ExecutionResult{Error: "no_changes: Claude completed but made no code changes after retry"},
+			"no_op",
+		},
+		{
+			"no-op via empty-branch PR guard",
+			&ExecutionResult{Error: "no_changes: branch has no commits relative to base (PR guard)"},
+			"no_op",
+		},
+		{
+			"stalled via error signature",
+			&ExecutionResult{Error: "session stalled: no agent event for >10m0s"},
+			"stalled",
+		},
+		{
+			"budget via error signature",
+			&ExecutionResult{Error: "per-task budget limit exceeded: tokens"},
+			"stalled",
+		},
+		{
+			"genuine failure falls through",
+			&ExecutionResult{Error: "go build: undefined: Foo"},
+			"failed",
+		},
+		{
+			"empty non-success is a failure",
+			&ExecutionResult{},
+			"failed",
+		},
+		{
+			"explicit Outcome wins over a misleading error string",
+			&ExecutionResult{Outcome: "stalled", Error: "no new commit produced"},
+			"stalled",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TerminalStatus(tt.result); got != tt.want {
+				t.Errorf("TerminalStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTerminalPhaseLabel verifies the dashboard progress phase matches the status.
+func TestTerminalPhaseLabel(t *testing.T) {
+	cases := map[string]string{
+		"no_op":    "No-op",
+		"stalled":  "Stalled",
+		"declined": "Declined",
+		"failed":   "Failed",
+		"anything": "Failed",
+	}
+	for status, want := range cases {
+		if got := terminalPhaseLabel(status); got != want {
+			t.Errorf("terminalPhaseLabel(%q) = %q, want %q", status, got, want)
+		}
+	}
+}

--- a/internal/memory/reclassify_outcomes_test.go
+++ b/internal/memory/reclassify_outcomes_test.go
@@ -1,0 +1,132 @@
+package memory
+
+import (
+	"os"
+	"testing"
+)
+
+// TestReclassifyLegacyOutcomes verifies the one-time backfill (TASK-358) moves
+// historically-misclassified 'failed' rows into their true terminal outcome
+// (no_op / stalled) while leaving genuine failures untouched, and that the fix
+// is reflected in GetLifetimeTaskCounts.
+func TestReclassifyLegacyOutcomes(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-reclassify-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// All inserted as the legacy collapsed status='failed'.
+	seed := []Execution{
+		{ID: "e1", TaskID: "GH-1", ProjectPath: "/p", Status: "failed", Error: "no new commit produced — post-push SHA matches base branch"},
+		{ID: "e2", TaskID: "GH-2", ProjectPath: "/p", Status: "failed", Error: "no_changes: Claude completed but made no code changes after retry"},
+		{ID: "e3", TaskID: "GH-3", ProjectPath: "/p", Status: "failed", Error: "no_changes: branch has no commits relative to base (PR guard)"},
+		{ID: "e4", TaskID: "GH-4", ProjectPath: "/p", Status: "failed", Error: "session stalled: no agent event for >10m0s"},
+		{ID: "e5", TaskID: "GH-5", ProjectPath: "/p", Status: "failed", Error: "per-task budget limit exceeded: tokens"},
+		{ID: "e6", TaskID: "GH-6", ProjectPath: "/p", Status: "failed", Error: "go build: undefined: Foo"}, // genuine failure
+		{ID: "e7", TaskID: "GH-7", ProjectPath: "/p", Status: "completed"},                                 // untouched
+	}
+	for i := range seed {
+		if err := store.SaveExecution(&seed[i]); err != nil {
+			t.Fatalf("SaveExecution(%s) failed: %v", seed[i].ID, err)
+		}
+	}
+
+	if err := store.reclassifyLegacyOutcomes(); err != nil {
+		t.Fatalf("reclassifyLegacyOutcomes failed: %v", err)
+	}
+
+	wantStatus := map[string]string{
+		"e1": "no_op",
+		"e2": "no_op",
+		"e3": "no_op",
+		"e4": "stalled",
+		"e5": "stalled",
+		"e6": "failed",    // genuine failure stays failed
+		"e7": "completed", // untouched
+	}
+	for id, want := range wantStatus {
+		got, err := store.GetExecution(id)
+		if err != nil {
+			t.Fatalf("GetExecution(%s): %v", id, err)
+		}
+		if got.Status != want {
+			t.Errorf("%s status = %q, want %q", id, got.Status, want)
+		}
+	}
+
+	counts, err := store.GetLifetimeTaskCounts()
+	if err != nil {
+		t.Fatalf("GetLifetimeTaskCounts: %v", err)
+	}
+	if counts.Failed != 1 {
+		t.Errorf("Failed = %d, want 1 (only the genuine build failure)", counts.Failed)
+	}
+	if counts.NoOp != 3 {
+		t.Errorf("NoOp = %d, want 3", counts.NoOp)
+	}
+	if counts.Stalled != 2 {
+		t.Errorf("Stalled = %d, want 2", counts.Stalled)
+	}
+	if counts.Succeeded != 1 {
+		t.Errorf("Succeeded = %d, want 1", counts.Succeeded)
+	}
+	if counts.Total != len(seed) {
+		t.Errorf("Total = %d, want %d", counts.Total, len(seed))
+	}
+}
+
+// TestReclassifyLegacyOutcomesIdempotent verifies re-running the backfill makes
+// no further changes (it runs on every startup via migrate()).
+func TestReclassifyLegacyOutcomesIdempotent(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-reclassify-idem-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "e1", TaskID: "GH-1", ProjectPath: "/p", Status: "failed", Error: "no new commit produced"})
+
+	for i := 0; i < 3; i++ {
+		if err := store.reclassifyLegacyOutcomes(); err != nil {
+			t.Fatalf("pass %d: %v", i, err)
+		}
+	}
+	got, _ := store.GetExecution("e1")
+	if got.Status != "no_op" {
+		t.Errorf("status = %q, want no_op after repeated runs", got.Status)
+	}
+}
+
+// TestSelfHealPromotesNoOp verifies that a row the dispatcher now classifies as a
+// no-op (rather than failed) still heals to completed when its PR is observed
+// merged — the heal scope was broadened in TASK-358.
+func TestSelfHealPromotesNoOp(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-heal-noop-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "e1", TaskID: "GH-9", ProjectPath: "/p", Status: "no_op", Error: "no new commit produced"})
+
+	if err := store.SelfHealExecutionAfterMerge("GH-9", "/p", "https://github.com/o/r/pull/9"); err != nil {
+		t.Fatalf("SelfHealExecutionAfterMerge: %v", err)
+	}
+	got, _ := store.GetExecution("e1")
+	if got.Status != "completed" {
+		t.Errorf("status = %q, want completed", got.Status)
+	}
+	if got.PRUrl != "https://github.com/o/r/pull/9" {
+		t.Errorf("PRUrl = %q, want the merged PR url", got.PRUrl)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -347,6 +347,46 @@ func (s *Store) migrate() error {
 		}
 	}
 
+	// TASK-358: correct historically-misclassified outcomes (declined/no-op/stalled
+	// that were collapsed into status='failed' before the dispatcher classified them).
+	if err := s.reclassifyLegacyOutcomes(); err != nil {
+		return fmt.Errorf("reclassify legacy outcomes: %w", err)
+	}
+
+	return nil
+}
+
+// reclassifyLegacyOutcomes corrects executions that the dispatcher previously
+// recorded as status='failed' when they were actually non-failure terminal
+// outcomes — a no-op (the work was already on base, or the agent made no edits)
+// or a stalled/budget-capped run. Before TASK-358 every !Success result collapsed
+// into "failed", inflating the dashboard's QUEUE "failed" count.
+//
+// Classification uses the deterministic error signatures the runner writes, so it
+// only touches rows it can positively identify; genuine failures (compile/test
+// errors, crashes) carry none of these signatures and are left as "failed".
+// Idempotent: after the first pass no 'failed' row matches, so re-running on every
+// startup is a cheap, indexed no-op. Declined rows cannot be recovered here
+// because the decline reason was never persisted to executions.error.
+func (s *Store) reclassifyLegacyOutcomes() error {
+	stmts := []string{
+		`UPDATE executions SET status = 'no_op'
+		 WHERE status = 'failed' AND (
+			error LIKE '%no new commit produced%' OR
+			error LIKE '%no_changes%' OR
+			error LIKE '%no commits relative to base%'
+		 )`,
+		`UPDATE executions SET status = 'stalled'
+		 WHERE status = 'failed' AND (
+			error LIKE '%session stalled%' OR
+			error LIKE '%budget limit exceeded%'
+		 )`,
+	}
+	for _, stmt := range stmts {
+		if _, err := s.db.Exec(stmt); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -1053,7 +1093,7 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 	}
 
 	// Set completed_at for terminal states
-	if status == "completed" || status == "failed" || status == "cancelled" || status == "declined" || status == "stalled" {
+	if status == "completed" || status == "failed" || status == "cancelled" || status == "declined" || status == "stalled" || status == "no_op" {
 		return s.withRetry("UpdateExecutionStatus", func() error {
 			_, err := s.db.Exec(`
 				UPDATE executions
@@ -1079,22 +1119,27 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 // executions as completed when the PR is merged externally.
 // The projectPath scope prevents cross-project clobbering when the same task ID
 // appears in multiple repos.
+//
+// TASK-358: the source scope is the non-success set ('failed', 'no_op', 'stalled')
+// rather than 'failed' alone, so an execution the dispatcher now classifies as a
+// no-op/stalled outcome still heals to the merged status when its PR lands.
 func (s *Store) UpdateExecutionStatusByTaskID(taskID, projectPath, status string) error {
 	return s.withRetry("UpdateExecutionStatusByTaskID", func() error {
 		_, err := s.db.Exec(`
 			UPDATE executions
 			SET status = ?, completed_at = CURRENT_TIMESTAMP
-			WHERE task_id = ? AND project_path = ? AND status = 'failed'
+			WHERE task_id = ? AND project_path = ? AND status IN ('failed', 'no_op', 'stalled')
 		`, status, taskID, projectPath)
 		return err
 	})
 }
 
-// SelfHealExecutionAfterMerge promotes any "failed" rows for the given task ID
-// (scoped to projectPath) to "completed" and stamps the PR URL so the dashboard
-// reflects the merged outcome. Used when autopilot observes a merge for an
-// issue whose previous execution row was recorded as failed (e.g. user-pushed
-// commits, sub-issue shipped via parent epic). GH-2402.
+// SelfHealExecutionAfterMerge promotes any non-success row ("failed", "no_op",
+// "stalled" — TASK-358) for the given task ID (scoped to projectPath) to
+// "completed" and stamps the PR URL so the dashboard reflects the merged outcome.
+// Used when autopilot observes a merge for an issue whose previous execution row
+// was recorded as a non-success (e.g. user-pushed commits, sub-issue shipped via
+// parent epic, or a phantom no-op whose work was already on base). GH-2402.
 //
 // projectPath MUST be the same value the executor stored in executions.project_path
 // — an absolute filesystem path (e.g. /Users/me/proj), NOT an owner/repo slug. The
@@ -1110,7 +1155,7 @@ func (s *Store) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) e
 			SET status = 'completed',
 				completed_at = CURRENT_TIMESTAMP,
 				pr_url = CASE WHEN ? <> '' THEN ? ELSE pr_url END
-			WHERE task_id = ? AND status = 'failed' AND (? = '' OR project_path = ?)
+			WHERE task_id = ? AND status IN ('failed', 'no_op', 'stalled') AND (? = '' OR project_path = ?)
 		`, prURL, prURL, taskID, projectPath, projectPath)
 		return err
 	})
@@ -1694,12 +1739,17 @@ func (s *Store) GetLifetimeTokens() (*LifetimeTokens, error) {
 	return &lt, nil
 }
 
-// LifetimeTaskCounts holds cumulative succeeded/failed/declined counts from all executions.
+// LifetimeTaskCounts holds cumulative outcome counts from all executions.
+// TASK-358: Failed counts genuine failures only; non-failure terminal outcomes
+// (no-op, stalled, declined) are broken out separately so the dashboard does not
+// inflate the failed count by lumping them in.
 type LifetimeTaskCounts struct {
 	Total     int
 	Succeeded int
 	Failed    int
 	Declined  int
+	NoOp      int
+	Stalled   int
 }
 
 // GetLifetimeTaskCounts returns cumulative task counts across all executions.
@@ -1710,12 +1760,14 @@ func (s *Store) GetLifetimeTaskCounts() (*LifetimeTaskCounts, error) {
 			COUNT(*),
 			COALESCE(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN status = 'declined' THEN 1 ELSE 0 END), 0)
+			COALESCE(SUM(CASE WHEN status = 'declined' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN status = 'no_op' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN status = 'stalled' THEN 1 ELSE 0 END), 0)
 		FROM executions
 	`)
 
 	var tc LifetimeTaskCounts
-	if err := row.Scan(&tc.Total, &tc.Succeeded, &tc.Failed, &tc.Declined); err != nil {
+	if err := row.Scan(&tc.Total, &tc.Succeeded, &tc.Failed, &tc.Declined, &tc.NoOp, &tc.Stalled); err != nil {
 		return nil, fmt.Errorf("failed to get lifetime task counts: %w", err)
 	}
 	return &tc, nil


### PR DESCRIPTION
## Problem

The QUEUE card showed `✗ 784 failed` — far more than real failures. Reported symptom: *"many showed failed but were done correctly."*

This is **not a display bug**. The dashboard count was honest; the data was wrong.

`dispatcher.go` collapsed *every* `result.Success == false` outcome into `status = "failed"`:
- **declined** (agent refused as unactionable — `result.Declined` was never even honored)
- **no-op** (`no new commit produced` / `no_changes` — incl. TASK-321 phantom no-ops where the work was already on base / already merged)
- **stalled** and **budget-capped** runs

`GetLifetimeTaskCounts()` then summed `status='failed'`, so all of them inflated the card.

## Fix

### Layer A — classify at the write path (forward)
- Add `ExecutionResult.Outcome`; set at the terminal points (budget / stalled / declined / no-op).
- `TerminalStatus(result)` classifier: `Success→completed`, `Declined→declined`, `Outcome` tag → `no_op`/`stalled`, deterministic error-signature fallback, else `failed`. Genuine failures (compile/test errors) carry no non-failure signal and stay `failed`.
- `dispatcher.go` writes the classified status + a matching progress phase label.
- `UpdateExecutionStatus` treats `no_op` as terminal (stamps `completed_at`).
- **Heal-on-merge scope broadened** to `status IN ('failed','no_op','stalled')` in `UpdateExecutionStatusByTaskID` + `SelfHealExecutionAfterMerge`, so a reclassified row still promotes to `completed` when its PR lands later.

### Layer B — backfill existing rows
- `reclassifyLegacyOutcomes()` runs in `migrate()` (idempotent, indexed): reclassifies historical `failed` rows into `no_op`/`stalled` by the deterministic error signatures the runner writes. Genuine failures stay `failed`.

### Dashboard
- `Failed` now counts genuine failures only. `NoOp`/`Stalled`/`Declined` surface as a muted ` (N no-op · M stalled · K declined)` suffix so the numbers reconcile.

## Safety
Swept every reader of `status='failed'`: metrics queries become more accurate (no-op excluded from failure breakdowns); autopilot's `stage='failed'` is the PR state machine (different column, untouched); no retry/redispatch logic branches on `executions.status`.

## Known limitations
- Declined rows can't be backfilled (decline reason was never persisted to `executions.error`). Forward-only.
- Generic failures whose work later merged are healed at merge-time via the broadened self-heal, not by the signature backfill.

## Tests
- `executor/terminal_status_test.go` — `TerminalStatus` / `terminalPhaseLabel` tables (incl. phantom no-op, genuine failure, explicit-outcome-wins).
- `memory/reclassify_outcomes_test.go` — backfill correctness, idempotency, no-op self-heal.
- Full `executor` / `memory` / `dashboard` suites pass; `gofmt`/`go vet` clean.