### PR TITLE
fix(dashboard): widen outcome classification to production reality (infra/skipped/rate-limited) — TASK-358

### DIFF
--- a/.agent/tasks/TASK-358-dashboard-failed-count-classification.md
+++ b/.agent/tasks/TASK-358-dashboard-failed-count-classification.md
@@ -1,12 +1,31 @@
 # TASK-358: Dashboard "failed" count inflated by misclassified outcomes
 
-**Status:** 🟢 implemented (PR on `fix/dashboard-failed-classification`) · 2026-06-02
+**Status:** 🟢 shipped in two PRs · 2026-06-02
+- #3401 (`fix/dashboard-failed-classification`) — mechanism: classifier + 2 buckets (`no_op`, `stalled`) + backfill.
+- #2 (`fix/dashboard-outcome-buckets`) — widen to production reality: 3 more buckets (`infra`, `skipped`, `rate_limited`), real-DB-validated.
+
 **Refs:** [[TASK-320]] (executor false-negative no-op) · [[TASK-321]] (phantom blocked on already-merged) · [[TASK-355]] (board-sourced no-op false positive)
 
 ## Symptom
 
 QUEUE card showed `✗ 784 failed` — far higher than real failures. Reported: "many
 showed failed but were done correctly."
+
+## Production breakdown (real DB, 2026-06-02)
+
+The 784 "failed" rows, simulated through the final classifier precedence:
+
+| bucket | n | meaning |
+|---|---:|---|
+| **failed** | **234** | genuine: quality gates, planning, title-refused, unknown exit-1 |
+| infra | 305 | OOM/SIGKILL + push/PR/worktree/branch — Pilot couldn't run/land it |
+| no_op | 120 | work already on base / no edits (TASK-321 phantom no-ops) |
+| skipped | 81 | stale-queued (no worker) + context-canceled |
+| rate_limited | 34 | provider quota hit (transient) |
+| stalled | 10 | watchdog stall / budget cap |
+
+Conservation verified: 234+305+120+81+34+10 = 784. Product call: infra is its own
+bucket (not "failed"); unknown/exit-1 stays "failed" (conservative).
 
 ## Root cause
 
@@ -25,27 +44,33 @@ Not a display bug — a **write-path classification bug**.
 **Layer A — classify at the write path (forward):**
 - `ExecutionResult.Outcome` field; set at terminal points (budget/stalled/declined/no_op).
 - `TerminalStatus(result)` in `runner.go`: Success→`completed`, Declined→`declined`,
-  Outcome tag → `no_op`/`stalled`, else error-signature fallback, else `failed`.
-- `dispatcher.go` writes the classified status (+ phase label) instead of blanket `failed`.
-- `UpdateExecutionStatus` treats `no_op` as terminal (stamps `completed_at`).
+  explicit Outcome tag, then an **ordered error-signature table** (no_op → rate_limited
+  → skipped → stalled → infra), else `failed`. Order = precedence (most "not a failure"
+  wins). Signature lists kept in sync with the backfill SQL.
+- `dispatcher.go` writes the classified status (+ matching phase label) instead of blanket `failed`.
+- `UpdateExecutionStatus` treats all non-failure outcomes as terminal (stamps `completed_at`).
 - Heal-on-merge scope (`UpdateExecutionStatusByTaskID`, `SelfHealExecutionAfterMerge`)
-  broadened to `status IN ('failed','no_op','stalled')` so reclassified rows still
-  promote to `completed` when their PR lands.
+  broadened to `status IN ('failed','no_op','stalled','rate_limited','infra','skipped')`
+  so reclassified rows still promote to `completed` when their PR lands.
 
 **Layer B — backfill existing rows:**
-- `reclassifyLegacyOutcomes()` runs in `migrate()` (idempotent): reclassifies
-  historical `failed` rows by deterministic error signature into `no_op`/`stalled`.
-  Genuine failures (no signature) stay `failed`.
+- `reclassifyLegacyOutcomes()` runs in `migrate()` (idempotent): ordered UPDATEs,
+  each guarded by `status='failed'`, reclassify historical rows by deterministic
+  error signature. Genuine failures (no signature) stay `failed`.
 
-**Dashboard:** `Failed` now counts genuine failures only; `NoOp`/`Stalled`/`Declined`
-shown as a muted ` (N no-op · M stalled · K declined)` suffix so numbers reconcile.
+**Dashboard:** `Failed` counts genuine failures only; the rest show as a muted
+breakdown suffix ` (N no-op · M infra · K skipped · …)`, omitting zero buckets and
+truncating after the headline on narrow cards. `LifetimeTaskCounts.NonFailure()`
+aggregates them.
 
 ## Known limitations
 
 - Declined rows can't be backfilled — decline reason was never persisted to
   `executions.error` (only to backend diagnostics). Forward-only.
-- Rows where work merged but was recorded as a *generic* failure (no no-op signature)
-  are healed at merge-time via the broadened self-heal, not by the backfill.
+- `infra` is a judgment bucket: a push/PR failure *might* mean the work never landed.
+  The broadened heal-on-merge promotes any such row to `completed` if its PR later merges.
+- Pre-existing `declined-preflight` (10) and `canceled` (3) statuses are left as-is
+  (already excluded from `failed`); not surfaced in the card breakdown.
 
 ## Tests
 

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -39,10 +39,11 @@ type MetricsCardData struct {
 	TotalTokens, InputTokens, OutputTokens  int
 	TotalCostUSD, CostPerTask               float64
 	TotalTasks, Succeeded, Failed, Declined int
-	NoOp, Stalled                           int       // TASK-358: non-failure terminal outcomes
-	TokenHistory                            []int64   // 7 days
-	CostHistory                             []float64 // 7 days
-	TaskHistory                             []int     // 7 days
+	// TASK-358: non-failure terminal outcomes, split out of "failed".
+	NoOp, Stalled, RateLimited, Infra, Skipped int
+	TokenHistory                               []int64   // 7 days
+	CostHistory                                []float64 // 7 days
+	TaskHistory                                []int     // 7 days
 }
 
 // Styles (muted terminal aesthetic)
@@ -606,6 +607,9 @@ func (m *Model) hydrateFromStore() {
 		m.metricsCard.Declined = taskCounts.Declined
 		m.metricsCard.NoOp = taskCounts.NoOp
 		m.metricsCard.Stalled = taskCounts.Stalled
+		m.metricsCard.RateLimited = taskCounts.RateLimited
+		m.metricsCard.Infra = taskCounts.Infra
+		m.metricsCard.Skipped = taskCounts.Skipped
 	}
 
 	// Populate history panel from recent executions (most recent 5)
@@ -885,6 +889,9 @@ func storeRefreshCmd(store *memory.Store) tea.Cmd {
 			msg.metricsCard.Declined = taskCounts.Declined
 			msg.metricsCard.NoOp = taskCounts.NoOp
 			msg.metricsCard.Stalled = taskCounts.Stalled
+			msg.metricsCard.RateLimited = taskCounts.RateLimited
+			msg.metricsCard.Infra = taskCounts.Infra
+			msg.metricsCard.Skipped = taskCounts.Skipped
 		}
 
 		if msg.metricsCard.TotalTasks > 0 {
@@ -2036,19 +2043,28 @@ func (m Model) renderCostCard(cw int) string {
 	return buildMiniCard("cost", value, detail1, detail2, spark, cw)
 }
 
-// nonFailureSuffix builds the muted " (N no-op · M stalled · K declined)" suffix
+// nonFailureSuffix builds the muted " (N no-op · M infra · …)" breakdown suffix
 // for the QUEUE card, omitting any zero buckets. Returns "" when all are zero.
-// TASK-358: these are non-failure terminal outcomes split out of "failed".
+// On narrow cards the line truncates after the "✗ N failed" headline, which is
+// always preserved. TASK-358: these are non-failure terminal outcomes split out
+// of "failed".
 func nonFailureSuffix(c MetricsCardData) string {
+	buckets := []struct {
+		n     int
+		label string
+	}{
+		{c.NoOp, "no-op"},
+		{c.Infra, "infra"},
+		{c.Skipped, "skipped"},
+		{c.RateLimited, "rate-limited"},
+		{c.Stalled, "stalled"},
+		{c.Declined, "declined"},
+	}
 	var parts []string
-	if c.NoOp > 0 {
-		parts = append(parts, fmt.Sprintf("%d no-op", c.NoOp))
-	}
-	if c.Stalled > 0 {
-		parts = append(parts, fmt.Sprintf("%d stalled", c.Stalled))
-	}
-	if c.Declined > 0 {
-		parts = append(parts, fmt.Sprintf("%d declined", c.Declined))
+	for _, b := range buckets {
+		if b.n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", b.n, b.label))
+		}
 	}
 	if len(parts) == 0 {
 		return ""
@@ -2648,6 +2664,12 @@ func statusIconStyle(status string) (string, lipgloss.Style) {
 		return "=", statusPendingStyle // TASK-358: no-change run, not a failure
 	case "declined":
 		return "-", statusPendingStyle // TASK-358: agent declined as unactionable
+	case "rate_limited":
+		return "%", statusPendingStyle // TASK-358: provider quota hit, transient
+	case "infra":
+		return "!", statusPendingStyle // TASK-358: plumbing/resource failure, not the work
+	case "skipped":
+		return ".", statusPendingStyle // TASK-358: never ran / cancelled
 	case "running":
 		return "~", statusRunningStyle
 	default:

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -54,33 +54,77 @@ func IsPermanentFailure(errStr string) bool {
 	return false
 }
 
-// noOpErrorSignatures are deterministic error-message fragments the runner writes
-// when an execution produced no code change for a *non-failure* reason — the work
-// was already present on the base branch (TASK-321 phantom no-op), or the agent
-// completed but made no edits. These are not code failures and must not inflate
-// the dashboard's "failed" count. Used as a fallback when Outcome was not set
-// explicitly (e.g. older rows, or terminal paths that pre-date Outcome). TASK-358.
-var noOpErrorSignatures = []string{
-	"no new commit produced",      // ghost-SHA guard: HEAD/post-push SHA matches base
-	"no_changes",                  // agent completed but made no edits
-	"no commits relative to base", // PR guard: empty branch
-}
+// Non-failure terminal-outcome signatures. The dispatcher classifies an execution
+// by the deterministic fragments the runner (or its subprocess) writes to
+// result.Error, so the dashboard's "failed" count reflects genuine task failures
+// only. Matching is case-insensitive (see containsAny). Evaluation order in
+// outcomeClassifiers is significant. TASK-358.
+var (
+	// noOp: the agent produced no code change for a non-failure reason — the work
+	// was already on the base branch (TASK-321 phantom no-op) or it made no edits.
+	noOpErrorSignatures = []string{
+		"no new commit produced",      // ghost-SHA guard: HEAD/post-push SHA matches base
+		"no commits relative to base", // PR guard: empty branch
+		"no_changes",                  // tagged no-change run
+		"made no code changes",        // legacy no-change message (lacks the "no_changes:" prefix)
+	}
+	// rateLimited: provider/model quota was hit — transient, not a failure.
+	rateLimitedSignatures = []string{
+		"hit your limit",
+		"rate limit",
+		"usage limit",
+	}
+	// skipped: the task never really executed — no worker picked it up, or the run
+	// was cancelled (shutdown / context canceled).
+	skippedSignatures = []string{
+		"stale queued task recovered",
+		"context canceled",
+		"context cancelled",
+	}
+	// stalled: an incomplete run — watchdog stall or per-task budget cap.
+	stalledErrorSignatures = []string{
+		"session stalled",
+		"budget limit exceeded",
+	}
+	// infra: operational/plumbing failure — the agent's work may be fine but Pilot
+	// could not run or land it (resource kill, push/PR/worktree/branch failure).
+	infraErrorSignatures = []string{
+		"oom_killed",
+		"exit code 137",
+		"sigkill",
+		"signal: killed",
+		"push failed",
+		"pr creation failed", // distinct from "PR creation refused" (a genuine title-guard failure)
+		"worktree creation failed",
+		"create/switch branch",
+		"branch switch failed",
+	}
+)
 
-// stalledErrorSignatures mark an execution that ran out of budget or stalled —
-// an incomplete run, not a code failure.
-var stalledErrorSignatures = []string{
-	"session stalled",
-	"budget limit exceeded",
+// outcomeClassifiers is the ordered fallback table used when result.Outcome was
+// not set explicitly (older rows, or terminal paths that pre-date Outcome). First
+// match wins, so the most "this isn't a failure" signal (no-op) is checked before
+// the most failure-like (infra). TASK-358.
+var outcomeClassifiers = []struct {
+	status     string
+	signatures []string
+}{
+	{"no_op", noOpErrorSignatures},
+	{"rate_limited", rateLimitedSignatures},
+	{"skipped", skippedSignatures},
+	{"stalled", stalledErrorSignatures},
+	{"infra", infraErrorSignatures},
 }
 
 // TerminalStatus maps a finished ExecutionResult to the status persisted in the
-// executions table. It exists so the dashboard's "failed" count reflects genuine
-// failures only: declined / no-op / stalled outcomes get their own status instead
-// of collapsing into "failed", which historically inflated the QUEUE card. TASK-358.
+// executions table so the dashboard's "failed" count reflects genuine task
+// failures only. Non-failure outcomes (no-op / rate-limited / skipped / stalled /
+// infra / declined) get their own status instead of collapsing into "failed",
+// which historically inflated the QUEUE card. TASK-358.
 //
-// Precedence: Success → Declined flag → explicit Outcome tag → error-signature
-// fallback → "failed". A genuine failure (compile/test error, crash) has none of
-// the non-failure signals and correctly falls through to "failed".
+// Precedence: Success → Declined → explicit Outcome tag → ordered error-signature
+// table → "failed". A genuine failure (quality gates, planning, unknown exit) has
+// none of the non-failure signals and correctly falls through to "failed".
 func TerminalStatus(result *ExecutionResult) string {
 	if result == nil {
 		return "failed"
@@ -98,12 +142,17 @@ func TerminalStatus(result *ExecutionResult) string {
 		return "no_op"
 	case "stalled", "budget_exceeded":
 		return "stalled"
+	case "rate_limited":
+		return "rate_limited"
+	case "infra":
+		return "infra"
+	case "skipped":
+		return "skipped"
 	}
-	if containsAny(result.Error, noOpErrorSignatures) {
-		return "no_op"
-	}
-	if containsAny(result.Error, stalledErrorSignatures) {
-		return "stalled"
+	for _, c := range outcomeClassifiers {
+		if containsAny(result.Error, c.signatures) {
+			return c.status
+		}
 	}
 	return "failed"
 }

--- a/internal/executor/terminal_status_test.go
+++ b/internal/executor/terminal_status_test.go
@@ -19,6 +19,9 @@ func TestTerminalStatus(t *testing.T) {
 		{"no_commits outcome", &ExecutionResult{Outcome: "no_commits"}, "no_op"},
 		{"stalled outcome", &ExecutionResult{Outcome: "stalled"}, "stalled"},
 		{"budget_exceeded outcome", &ExecutionResult{Outcome: "budget_exceeded"}, "stalled"},
+		{"rate_limited outcome", &ExecutionResult{Outcome: "rate_limited"}, "rate_limited"},
+		{"infra outcome", &ExecutionResult{Outcome: "infra"}, "infra"},
+		{"skipped outcome", &ExecutionResult{Outcome: "skipped"}, "skipped"},
 		{
 			"no-op via error signature (phantom no-op, work already on base)",
 			&ExecutionResult{Error: "no new commit produced — post-push SHA matches base branch"},
@@ -27,6 +30,11 @@ func TestTerminalStatus(t *testing.T) {
 		{
 			"no-op via no_changes signature",
 			&ExecutionResult{Error: "no_changes: Claude completed but made no code changes after retry"},
+			"no_op",
+		},
+		{
+			"no-op via legacy 'made no code changes' (no prefix)",
+			&ExecutionResult{Error: "Claude completed but made no code changes after retry"},
 			"no_op",
 		},
 		{
@@ -45,6 +53,56 @@ func TestTerminalStatus(t *testing.T) {
 			"stalled",
 		},
 		{
+			"rate-limited via error signature",
+			&ExecutionResult{Error: "You've hit your limit · resets 3pm (Europe/Podgorica)"},
+			"rate_limited",
+		},
+		{
+			"infra via OOM kill",
+			&ExecutionResult{Error: "oom_killed: Process killed by SIGKILL (exit code 137)"},
+			"infra",
+		},
+		{
+			"infra via signal killed",
+			&ExecutionResult{Error: "unknown: signal: killed"},
+			"infra",
+		},
+		{
+			"infra via push failure",
+			&ExecutionResult{Error: "push failed: failed to push: exit status 1: To https://github.com/o/r"},
+			"infra",
+		},
+		{
+			"infra via PR creation failure",
+			&ExecutionResult{Error: "PR creation failed: failed to create PR: exit status 1"},
+			"infra",
+		},
+		{
+			"skipped via stale-queued",
+			&ExecutionResult{Error: "stale queued task recovered (no worker picked up)"},
+			"skipped",
+		},
+		{
+			"skipped via context canceled",
+			&ExecutionResult{Error: "failed to start Claude Code: context canceled"},
+			"skipped",
+		},
+		{
+			"PR creation REFUSED (title guard) stays a genuine failure",
+			&ExecutionResult{Error: "PR creation refused: title is not a conventional commit"},
+			"failed",
+		},
+		{
+			"quality gates failure stays failed",
+			&ExecutionResult{Error: "quality gates failed after 2 auto-retries"},
+			"failed",
+		},
+		{
+			"unknown exit status stays failed",
+			&ExecutionResult{Error: "unknown: exit status 1"},
+			"failed",
+		},
+		{
 			"genuine failure falls through",
 			&ExecutionResult{Error: "go build: undefined: Foo"},
 			"failed",
@@ -58,6 +116,11 @@ func TestTerminalStatus(t *testing.T) {
 			"explicit Outcome wins over a misleading error string",
 			&ExecutionResult{Outcome: "stalled", Error: "no new commit produced"},
 			"stalled",
+		},
+		{
+			"no-op precedence beats infra when both signatures present",
+			&ExecutionResult{Error: "no new commit produced; push failed"},
+			"no_op",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/memory/reclassify_outcomes_test.go
+++ b/internal/memory/reclassify_outcomes_test.go
@@ -19,15 +19,32 @@ func TestReclassifyLegacyOutcomes(t *testing.T) {
 	}
 	defer func() { _ = store.Close() }()
 
-	// All inserted as the legacy collapsed status='failed'.
+	// All inserted as the legacy collapsed status='failed', one row per real-world
+	// error signature observed in production (TASK-358 categorization).
 	seed := []Execution{
+		// no-op
 		{ID: "e1", TaskID: "GH-1", ProjectPath: "/p", Status: "failed", Error: "no new commit produced — post-push SHA matches base branch"},
 		{ID: "e2", TaskID: "GH-2", ProjectPath: "/p", Status: "failed", Error: "no_changes: Claude completed but made no code changes after retry"},
 		{ID: "e3", TaskID: "GH-3", ProjectPath: "/p", Status: "failed", Error: "no_changes: branch has no commits relative to base (PR guard)"},
+		{ID: "e3b", TaskID: "GH-3b", ProjectPath: "/p", Status: "failed", Error: "Claude completed but made no code changes after retry"}, // legacy, no prefix
+		// stalled
 		{ID: "e4", TaskID: "GH-4", ProjectPath: "/p", Status: "failed", Error: "session stalled: no agent event for >10m0s"},
 		{ID: "e5", TaskID: "GH-5", ProjectPath: "/p", Status: "failed", Error: "per-task budget limit exceeded: tokens"},
-		{ID: "e6", TaskID: "GH-6", ProjectPath: "/p", Status: "failed", Error: "go build: undefined: Foo"}, // genuine failure
-		{ID: "e7", TaskID: "GH-7", ProjectPath: "/p", Status: "completed"},                                 // untouched
+		// rate-limited
+		{ID: "e8", TaskID: "GH-8", ProjectPath: "/p", Status: "failed", Error: "You've hit your limit · resets 3pm (Europe/Podgorica)"},
+		// skipped
+		{ID: "e9", TaskID: "GH-9", ProjectPath: "/p", Status: "failed", Error: "stale queued task recovered (no worker picked up)"},
+		{ID: "e10", TaskID: "GH-10", ProjectPath: "/p", Status: "failed", Error: "failed to start Claude Code: context canceled"},
+		// infra
+		{ID: "e11", TaskID: "GH-11", ProjectPath: "/p", Status: "failed", Error: "oom_killed: Process killed by SIGKILL (exit code 137)"},
+		{ID: "e12", TaskID: "GH-12", ProjectPath: "/p", Status: "failed", Error: "push failed: failed to push: exit status 1"},
+		{ID: "e13", TaskID: "GH-13", ProjectPath: "/p", Status: "failed", Error: "PR creation failed: failed to create PR: exit status 1"},
+		// genuine failures (stay failed)
+		{ID: "e6", TaskID: "GH-6", ProjectPath: "/p", Status: "failed", Error: "go build: undefined: Foo"},
+		{ID: "e14", TaskID: "GH-14", ProjectPath: "/p", Status: "failed", Error: "PR creation refused: title is not a conventional commit"},
+		{ID: "e15", TaskID: "GH-15", ProjectPath: "/p", Status: "failed", Error: "unknown: exit status 1"},
+		// untouched
+		{ID: "e7", TaskID: "GH-7", ProjectPath: "/p", Status: "completed"},
 	}
 	for i := range seed {
 		if err := store.SaveExecution(&seed[i]); err != nil {
@@ -40,12 +57,12 @@ func TestReclassifyLegacyOutcomes(t *testing.T) {
 	}
 
 	wantStatus := map[string]string{
-		"e1": "no_op",
-		"e2": "no_op",
-		"e3": "no_op",
-		"e4": "stalled",
-		"e5": "stalled",
-		"e6": "failed",    // genuine failure stays failed
+		"e1": "no_op", "e2": "no_op", "e3": "no_op", "e3b": "no_op",
+		"e4": "stalled", "e5": "stalled",
+		"e8": "rate_limited",
+		"e9": "skipped", "e10": "skipped",
+		"e11": "infra", "e12": "infra", "e13": "infra",
+		"e6": "failed", "e14": "failed", "e15": "failed", // genuine failures stay failed
 		"e7": "completed", // untouched
 	}
 	for id, want := range wantStatus {
@@ -62,21 +79,20 @@ func TestReclassifyLegacyOutcomes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetLifetimeTaskCounts: %v", err)
 	}
-	if counts.Failed != 1 {
-		t.Errorf("Failed = %d, want 1 (only the genuine build failure)", counts.Failed)
+	assertCount := func(name string, got, want int) {
+		if got != want {
+			t.Errorf("%s = %d, want %d", name, got, want)
+		}
 	}
-	if counts.NoOp != 3 {
-		t.Errorf("NoOp = %d, want 3", counts.NoOp)
-	}
-	if counts.Stalled != 2 {
-		t.Errorf("Stalled = %d, want 2", counts.Stalled)
-	}
-	if counts.Succeeded != 1 {
-		t.Errorf("Succeeded = %d, want 1", counts.Succeeded)
-	}
-	if counts.Total != len(seed) {
-		t.Errorf("Total = %d, want %d", counts.Total, len(seed))
-	}
+	assertCount("Failed", counts.Failed, 3) // build error, title-refused, unknown exit
+	assertCount("NoOp", counts.NoOp, 4)
+	assertCount("Stalled", counts.Stalled, 2)
+	assertCount("RateLimited", counts.RateLimited, 1)
+	assertCount("Skipped", counts.Skipped, 2)
+	assertCount("Infra", counts.Infra, 3)
+	assertCount("Succeeded", counts.Succeeded, 1)
+	assertCount("Total", counts.Total, len(seed))
+	assertCount("NonFailure", counts.NonFailure(), 12)
 }
 
 // TestReclassifyLegacyOutcomesIdempotent verifies re-running the backfill makes

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -358,28 +358,59 @@ func (s *Store) migrate() error {
 
 // reclassifyLegacyOutcomes corrects executions that the dispatcher previously
 // recorded as status='failed' when they were actually non-failure terminal
-// outcomes — a no-op (the work was already on base, or the agent made no edits)
-// or a stalled/budget-capped run. Before TASK-358 every !Success result collapsed
-// into "failed", inflating the dashboard's QUEUE "failed" count.
+// outcomes — no-op (work already on base / no edits), rate-limited, skipped
+// (never ran / cancelled), stalled/budget, or infra/plumbing (resource kill,
+// push/PR/worktree/branch). Before TASK-358 every !Success result collapsed into
+// "failed", inflating the dashboard's QUEUE "failed" count.
 //
+// Each UPDATE is guarded by status='failed' and the statements run in the same
+// precedence order as TerminalStatus (no-op first, infra last) so a row matching
+// more than one signature lands in the most "this isn't a failure" bucket.
 // Classification uses the deterministic error signatures the runner writes, so it
-// only touches rows it can positively identify; genuine failures (compile/test
-// errors, crashes) carry none of these signatures and are left as "failed".
-// Idempotent: after the first pass no 'failed' row matches, so re-running on every
-// startup is a cheap, indexed no-op. Declined rows cannot be recovered here
-// because the decline reason was never persisted to executions.error.
+// only touches rows it can positively identify; genuine failures (quality gates,
+// planning, unknown exit-1) carry none of these signatures and are left as
+// "failed". Idempotent: after the first pass no 'failed' row matches, so running
+// on every startup is a cheap, indexed no-op. Declined rows cannot be recovered
+// here because the decline reason was never persisted to executions.error.
+//
+// Keep the LIKE patterns in sync with the signature lists in executor/runner.go.
 func (s *Store) reclassifyLegacyOutcomes() error {
 	stmts := []string{
 		`UPDATE executions SET status = 'no_op'
 		 WHERE status = 'failed' AND (
 			error LIKE '%no new commit produced%' OR
+			error LIKE '%no commits relative to base%' OR
 			error LIKE '%no_changes%' OR
-			error LIKE '%no commits relative to base%'
+			error LIKE '%made no code changes%'
+		 )`,
+		`UPDATE executions SET status = 'rate_limited'
+		 WHERE status = 'failed' AND (
+			error LIKE '%hit your limit%' OR
+			error LIKE '%rate limit%' OR
+			error LIKE '%usage limit%'
+		 )`,
+		`UPDATE executions SET status = 'skipped'
+		 WHERE status = 'failed' AND (
+			error LIKE '%stale queued task recovered%' OR
+			error LIKE '%context canceled%' OR
+			error LIKE '%context cancelled%'
 		 )`,
 		`UPDATE executions SET status = 'stalled'
 		 WHERE status = 'failed' AND (
 			error LIKE '%session stalled%' OR
 			error LIKE '%budget limit exceeded%'
+		 )`,
+		`UPDATE executions SET status = 'infra'
+		 WHERE status = 'failed' AND (
+			error LIKE '%oom_killed%' OR
+			error LIKE '%exit code 137%' OR
+			error LIKE '%SIGKILL%' OR
+			error LIKE '%signal: killed%' OR
+			error LIKE '%push failed%' OR
+			error LIKE '%PR creation failed%' OR
+			error LIKE '%worktree creation failed%' OR
+			error LIKE '%create/switch branch%' OR
+			error LIKE '%branch switch failed%'
 		 )`,
 	}
 	for _, stmt := range stmts {
@@ -1093,7 +1124,7 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 	}
 
 	// Set completed_at for terminal states
-	if status == "completed" || status == "failed" || status == "cancelled" || status == "declined" || status == "stalled" || status == "no_op" {
+	if status == "completed" || status == "failed" || status == "cancelled" || status == "declined" || status == "stalled" || status == "no_op" || status == "rate_limited" || status == "infra" || status == "skipped" {
 		return s.withRetry("UpdateExecutionStatus", func() error {
 			_, err := s.db.Exec(`
 				UPDATE executions
@@ -1128,7 +1159,7 @@ func (s *Store) UpdateExecutionStatusByTaskID(taskID, projectPath, status string
 		_, err := s.db.Exec(`
 			UPDATE executions
 			SET status = ?, completed_at = CURRENT_TIMESTAMP
-			WHERE task_id = ? AND project_path = ? AND status IN ('failed', 'no_op', 'stalled')
+			WHERE task_id = ? AND project_path = ? AND status IN ('failed', 'no_op', 'stalled', 'rate_limited', 'infra', 'skipped')
 		`, status, taskID, projectPath)
 		return err
 	})
@@ -1155,7 +1186,7 @@ func (s *Store) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) e
 			SET status = 'completed',
 				completed_at = CURRENT_TIMESTAMP,
 				pr_url = CASE WHEN ? <> '' THEN ? ELSE pr_url END
-			WHERE task_id = ? AND status IN ('failed', 'no_op', 'stalled') AND (? = '' OR project_path = ?)
+			WHERE task_id = ? AND status IN ('failed', 'no_op', 'stalled', 'rate_limited', 'infra', 'skipped') AND (? = '' OR project_path = ?)
 		`, prURL, prURL, taskID, projectPath, projectPath)
 		return err
 	})
@@ -1740,16 +1771,25 @@ func (s *Store) GetLifetimeTokens() (*LifetimeTokens, error) {
 }
 
 // LifetimeTaskCounts holds cumulative outcome counts from all executions.
-// TASK-358: Failed counts genuine failures only; non-failure terminal outcomes
-// (no-op, stalled, declined) are broken out separately so the dashboard does not
-// inflate the failed count by lumping them in.
+// TASK-358: Failed counts genuine task failures only; non-failure terminal
+// outcomes (no-op, stalled, declined, rate-limited, infra, skipped) are broken
+// out separately so the dashboard does not inflate the failed count.
 type LifetimeTaskCounts struct {
-	Total     int
-	Succeeded int
-	Failed    int
-	Declined  int
-	NoOp      int
-	Stalled   int
+	Total       int
+	Succeeded   int
+	Failed      int
+	Declined    int
+	NoOp        int
+	Stalled     int
+	RateLimited int
+	Infra       int
+	Skipped     int
+}
+
+// NonFailure returns the total of all non-failure terminal outcomes (everything
+// that is neither succeeded nor a genuine failure). TASK-358.
+func (c LifetimeTaskCounts) NonFailure() int {
+	return c.NoOp + c.Stalled + c.Declined + c.RateLimited + c.Infra + c.Skipped
 }
 
 // GetLifetimeTaskCounts returns cumulative task counts across all executions.
@@ -1762,12 +1802,16 @@ func (s *Store) GetLifetimeTaskCounts() (*LifetimeTaskCounts, error) {
 			COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN status = 'declined' THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN status = 'no_op' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN status = 'stalled' THEN 1 ELSE 0 END), 0)
+			COALESCE(SUM(CASE WHEN status = 'stalled' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN status = 'rate_limited' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN status = 'infra' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END), 0)
 		FROM executions
 	`)
 
 	var tc LifetimeTaskCounts
-	if err := row.Scan(&tc.Total, &tc.Succeeded, &tc.Failed, &tc.Declined, &tc.NoOp, &tc.Stalled); err != nil {
+	if err := row.Scan(&tc.Total, &tc.Succeeded, &tc.Failed, &tc.Declined, &tc.NoOp, &tc.Stalled,
+		&tc.RateLimited, &tc.Infra, &tc.Skipped); err != nil {
 		return nil, fmt.Errorf("failed to get lifetime task counts: %w", err)
 	}
 	return &tc, nil


### PR DESCRIPTION
Follow-up to #3401. That PR fixed the *mechanism* (distinct statuses + classifier + idempotent backfill) but its signature set caught only **66 of 784** `failed` rows. Categorizing the live DB showed the inflation is dominated by buckets it didn't cover.

## Production breakdown (real DB) — 784 `failed` simulated through the final classifier

| status | n | nature |
|---|---:|---|
| **failed** | **234** | genuine: quality gates, planning, title-refused, unknown exit-1 |
| infra | 305 | OOM/SIGKILL + push/PR/worktree/branch — Pilot couldn't run/land it |
| no_op | 120 | work already on base / no edits (TASK-321 phantom no-ops) |
| skipped | 81 | stale-queued (no worker) + context-canceled |
| rate_limited | 34 | provider quota hit (transient) |
| stalled | 10 | watchdog stall / budget cap |

Conservation: 234+305+120+81+34+10 = 784 ✓.

## Changes

- **Classifier** (`runner.go`): replace the two ad-hoc checks with an **ordered signature table** — `no_op → rate_limited → skipped → stalled → infra → failed`. First match wins, so the most "not a failure" signal beats the most failure-like. Explicit `result.Outcome` tags still take precedence.
- **Three new statuses**: `infra`, `skipped`, `rate_limited` (added to terminal-state list, counts query, `LifetimeTaskCounts`, heal-on-merge scope).
- **Backfill** (`reclassifyLegacyOutcomes`): ordered UPDATEs mirroring classifier precedence, each guarded by `status='failed'`. LIKE patterns kept in sync with the Go signatures.
- **Dashboard**: full non-failure breakdown suffix ` (120 no-op · 305 infra · 81 skipped · 34 rate-limited · 10 stalled)`, omitting zeros, truncating after the `✗ N failed` headline on narrow cards. Adds `NonFailure()` aggregate + status-icon cases.

## Product decisions baked in
- **infra is its own bucket**, not `failed` (the agent's work may be fine; plumbing/resources failed). Heal-on-merge promotes any infra row to `completed` if its PR later merges.
- **`PR creation refused`** (title guard) stays `failed` — distinct string from infra's `PR creation failed`.
- **Unknown / `exit status 1`** (114) stays `failed` (conservative — don't hide real failures).

## Validation
- Read-only simulation against the production DB matches the table above exactly.
- Tests: classifier table covers all six buckets + precedence + the genuine-failure cases that must stay `failed`; backfill test seeds one row per real signature and asserts every bucket count + `NonFailure()`.
- `gofmt`/`go vet` clean; `executor`/`memory`/`dashboard` suites pass.

After merge + daemon restart, the idempotent backfill corrects the existing rows: **failed 784 → 234**.