### PR TITLE
fix(dashboard): QUEUE 'failed' line blanked by overflowing breakdown suffix (TASK-358)

### DIFF
--- a/internal/dashboard/task_card_test.go
+++ b/internal/dashboard/task_card_test.go
@@ -1,0 +1,67 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TestRenderTaskCard_NarrowDoesNotBlankFailed reproduces the v2.166.10 bug: with
+// all non-failure buckets populated, the breakdown suffix overflowed the narrow
+// mini-card and truncation of the styled multi-segment string blanked the whole
+// "failed" line. The headline must always remain visible. TASK-358.
+func TestRenderTaskCard_NarrowDoesNotBlankFailed(t *testing.T) {
+	m := NewModel("test")
+	m.metricsCard = MetricsCardData{
+		Succeeded: 1508, Failed: 234,
+		NoOp: 120, Infra: 305, Skipped: 81, RateLimited: 34, Stalled: 10,
+	}
+
+	out := m.renderTaskCard(23) // real-world narrow card width (ciw = 17)
+
+	if !strings.Contains(out, "234 failed") {
+		t.Errorf("narrow card dropped the failed headline; got:\n%s", out)
+	}
+	if !strings.Contains(out, "1508 succeeded") {
+		t.Errorf("narrow card dropped the succeeded line; got:\n%s", out)
+	}
+	// Every rendered line must fit the card width exactly (no overflow / blanking).
+	for _, line := range strings.Split(out, "\n") {
+		if w := lipgloss.Width(line); w != 23 {
+			t.Errorf("line width = %d, want 23: %q", w, line)
+		}
+	}
+}
+
+// TestRenderTaskCard_WideShowsBreakdown verifies the breakdown suffix appears when
+// the card is wide enough to hold it.
+func TestRenderTaskCard_WideShowsBreakdown(t *testing.T) {
+	m := NewModel("test")
+	m.metricsCard = MetricsCardData{Succeeded: 1508, Failed: 234, NoOp: 120, Infra: 305}
+
+	out := m.renderTaskCard(90) // wide card: suffix fits
+
+	for _, want := range []string{"234 failed", "120 no-op", "305 infra"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("wide card missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestTruncateVisualStyled verifies ANSI-aware truncation: a styled string longer
+// than the target keeps its leading visible text and respects the visible width
+// budget instead of breaking mid-escape.
+func TestTruncateVisualStyled(t *testing.T) {
+	styled := statusFailedStyle.Render("✗ 234 failed") +
+		statusPendingStyle.Render(" (120 no-op · 305 infra · 81 skipped)")
+
+	out := truncateVisual(styled, 17)
+
+	if w := lipgloss.Width(out); w > 17 {
+		t.Errorf("visible width = %d, want <= 17", w)
+	}
+	if !strings.Contains(out, "234 failed") {
+		t.Errorf("truncation dropped leading visible text; got %q", out)
+	}
+}

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -1829,10 +1829,27 @@ func truncateVisual(s string, targetWidth int) string {
 		return strings.Repeat(".", targetWidth)
 	}
 
-	// We need to truncate to targetWidth-3 and add "..."
+	// We need to truncate to targetWidth-3 and add "...".
+	// ANSI escape sequences (e.g. lipgloss color codes) are copied through with
+	// zero visible width — counting their bytes as visible (the old behavior) made
+	// styled strings break mid-escape and render blank. A CSI sequence starts at
+	// ESC (0x1b) and ends at a byte in 0x40–0x7e.
 	result := ""
 	width := 0
+	inEsc := false
 	for _, r := range s {
+		if inEsc {
+			result += string(r)
+			if r >= 0x40 && r <= 0x7e {
+				inEsc = false
+			}
+			continue
+		}
+		if r == 0x1b {
+			inEsc = true
+			result += string(r)
+			continue
+		}
 		runeWidth := lipgloss.Width(string(r))
 		if width+runeWidth > targetWidth-3 {
 			break
@@ -2079,11 +2096,18 @@ func (m Model) renderTaskCard(cw int) string {
 	value := fmt.Sprintf("%d", len(m.tasks))
 	detail1 := statusCompletedStyle.Render(fmt.Sprintf("✓ %d succeeded", m.metricsCard.Succeeded))
 	// TASK-358: "failed" counts genuine failures only. Non-failure terminal
-	// outcomes (no-op / stalled / declined) are shown as a muted suffix so the
-	// numbers reconcile and a no-op is no longer miscounted as a failure.
+	// outcomes (no-op / infra / …) are shown as a muted suffix so the numbers
+	// reconcile and a no-op is no longer miscounted as a failure. Only append the
+	// suffix when the whole line fits the card — otherwise show just the headline.
+	// The breakdown is wider than a mini-card on narrow terminals, and truncating
+	// a styled multi-segment string blanks the line (the empty "failed" row seen
+	// on v2.166.10).
 	detail2 := statusFailedStyle.Render(fmt.Sprintf("✗ %d failed", m.metricsCard.Failed))
 	if suffix := nonFailureSuffix(m.metricsCard); suffix != "" {
-		detail2 += statusPendingStyle.Render(suffix)
+		withSuffix := detail2 + statusPendingStyle.Render(suffix)
+		if lipgloss.Width(withSuffix) <= ciw {
+			detail2 = withSuffix
+		}
 	}
 
 	// Convert int history to float64


### PR DESCRIPTION
## Bug (v2.166.10)
After installing v2.166.10 the QUEUE card showed **no failed line at all** — succeeded rendered, the failed row was blank and the card border was corrupted:
```
│  ✓ 1508 succeeded   │
│  │
```
Data was correct (DB = 234 failed); this is a pure render bug.

## Root cause
The TASK-358 breakdown suffix `✗ N failed (120 no-op · 305 infra · 81 skipped · …)` is ~75 chars — far wider than a mini-card's ~17-char inner width. `miniCardContentLine` → `truncateVisual` then truncated the **styled** multi-segment string, but `truncateVisual` iterated rune-by-rune counting ANSI escape bytes (`\x1b[38;5;…m`) as visible width. It broke mid-escape and emitted a fragment that renders blank. Latent all along; only triggered now because the suffix was the first detail line wide enough to need truncation.

## Fix
- **`renderTaskCard`**: append the breakdown only when the full styled line fits (`lipgloss.Width(withSuffix) <= ciw`); otherwise show just `✗ N failed`. Wide terminals still show the breakdown; narrow ones show the (correct) headline.
- **`truncateVisual`**: made ANSI-aware — escape sequences (ESC … 0x40–0x7e) are copied through with zero visible width instead of being counted. Fixes the corruption for *any* styled overflow, not just this card.

## Tests
- `TestRenderTaskCard_NarrowDoesNotBlankFailed` — reproduces the bug: at card width 23 the failed + succeeded lines are present and **every line is exactly 23 wide** (would fail on the old code).
- `TestRenderTaskCard_WideShowsBreakdown` — breakdown appears when it fits.
- `TestTruncateVisualStyled` — styled input truncates within the visible budget and keeps leading text.
- `gofmt`/`go vet` clean; full `dashboard` suite passes.