### PR TITLE
perf(docs): cache + compression + security headers

### DIFF
--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -8,7 +8,19 @@ services:
       - "traefik.http.routers.pilot-docs.rule=Host(`pilot.quantflow.studio`)"
       - "traefik.http.routers.pilot-docs.entrypoints=websecure"
       - "traefik.http.routers.pilot-docs.tls=true"
+      - "traefik.http.routers.pilot-docs.middlewares=docs-compress,docs-secheaders"
       - "traefik.docker.network=balancer"
+      # gzip compression — Traefik v2.11 (brotli requires v3.x; upgrade tracked in #3380)
+      - "traefik.http.middlewares.docs-compress.compress=true"
+      # security headers
+      - "traefik.http.middlewares.docs-secheaders.headers.stsSeconds=63072000"
+      - "traefik.http.middlewares.docs-secheaders.headers.stsIncludeSubdomains=true"
+      - "traefik.http.middlewares.docs-secheaders.headers.contentTypeNosniff=true"
+      - "traefik.http.middlewares.docs-secheaders.headers.referrerPolicy=strict-origin-when-cross-origin"
+      - "traefik.http.middlewares.docs-secheaders.headers.permissionsPolicy=geolocation=(), microphone=(), camera=(), payment=()"
+      # CSP in report-only mode — Nextra v4 inlines styles so 'unsafe-inline' is required;
+      # harden to nonces/hashes in a follow-up once the report stream is clean.
+      - "traefik.http.middlewares.docs-secheaders.headers.contentSecurityPolicyReportOnly=default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' data:; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     expose:
       - 3000
     networks:

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -4,11 +4,45 @@ const withNextra = nextra({})
 
 export default withNextra({
   output: 'standalone',
+  poweredByHeader: false,
+  // Compression is handled by the Traefik compress middleware; standalone
+  // server.js does not honour this flag anyway (Next.js self-hosting docs §2.5).
+  compress: false,
   // Docs ship static, pre-sized assets — the on-server image optimizer adds no
   // value but writes optimized variants to .next/cache/images, which is bind-
   // mounted to a persistent host volume in prod (docker-compose.prod.yml) and
   // grows unbounded, exhausting disk. Disable it so the runtime cache stays flat.
   images: {
     unoptimized: true,
+  },
+  async headers() {
+    return [
+      {
+        // All routes except /_next/static (immutable, content-hashed by Next)
+        // and favicon paths: force browser revalidation on every visit.
+        // ETag already set by Next saves the body on unchanged pages (→ 304).
+        // Image/font rules below override Cache-Control for those asset types.
+        source: '/((?!_next/static|_next/image|favicon).*)',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=0, must-revalidate' },
+        ],
+      },
+      {
+        // Public images and fonts: one-week browser cache + 1-day SWR.
+        // Overrides the must-revalidate rule above for these file types.
+        source: '/:all*(svg|png|jpg|jpeg|gif|webp|avif|ico|woff2?)',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=604800, stale-while-revalidate=86400' },
+        ],
+      },
+      {
+        // Favicons: cache aggressively — browsers refetch them on every tab
+        // open without a long TTL. Overrides the ico match from the rule above.
+        source: '/favicon.ico',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=31536000' },
+        ],
+      },
+    ]
   },
 })


### PR DESCRIPTION
Closes #3414

## Summary

- **`docs/next.config.mjs`** — `headers()` cache rules, `poweredByHeader: false`, `compress: false`
- **`docs/docker-compose.prod.yml`** — Traefik gzip + security-headers middlewares chained on `pilot-docs` router

## Changes in detail

### Layer 1 — `next.config.mjs`

| Rule | Pattern | Cache-Control |
|---|---|---|
| HTML routes | `/((?!_next/static\|_next/image\|favicon).*)` | `public, max-age=0, must-revalidate` |
| Public images / fonts | `/:all*(svg\|png\|jpg\|jpeg\|gif\|webp\|avif\|ico\|woff2?)` | `public, max-age=604800, stale-while-revalidate=86400` |
| Favicon | `/favicon.ico` | `public, max-age=31536000` |

`/_next/static/**` left untouched — Next.js already sets `immutable` and blocks overrides.

`poweredByHeader: false` removes the `x-powered-by: Next.js` info leak.  
`compress: false` is explicit: standalone `server.js` ignores this flag anyway; Traefik handles compression.

### Layer 2 — `docker-compose.prod.yml`

Two new Traefik middlewares, chained on `pilot-docs` router:

**`docs-compress`** — gzip (Traefik v2.11; brotli requires v3.x, tracked in #3380)

**`docs-secheaders`**:
| Header | Value |
|---|---|
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `geolocation=(), microphone=(), camera=(), payment=()` |
| `Content-Security-Policy-Report-Only` | `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' data:; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'` |

CSP ships in **report-only** mode — Nextra v4 inlines styles so `'unsafe-inline'` is required; enforce and harden to nonces in a follow-up once the report stream is clean.

## Pre-deploy probe baseline (pilot.quantflow.studio, 2026-06-03)

| Probe | Before | Expected after |
|---|---|---|
| 1. Compression | (none) | `content-encoding: gzip` |
| 2. HTML Cache-Control | `s-maxage=31536000` | `public, max-age=0, must-revalidate` |
| 3. Logo.svg Cache-Control | `public, max-age=0` | `public, max-age=604800, stale-while-revalidate=86400` |
| 4. Security headers | (none) | HSTS + X-Content-Type-Options + Referrer-Policy + Permissions-Policy + CSP-RO |
| 5. Favicon status | HTTP 404 | addressed in GH-3413 a11y PR |
| 6. x-powered-by | `Next.js` | suppressed |
| 7. OG image Cache-Control | `public, max-age=0` | `public, max-age=604800, stale-while-revalidate=86400` |

## Verification (post-deploy)

```bash
# 1. compression
curl -sSI -H 'Accept-Encoding: gzip,br' https://pilot.quantflow.studio/ | grep -i content-encoding

# 2. HTML cache
curl -sSI https://pilot.quantflow.studio/ | grep -i cache-control

# 3. public asset cache
curl -sSI https://pilot.quantflow.studio/logo.svg | grep -i cache-control

# 4. security headers
curl -sSI https://pilot.quantflow.studio/ | grep -iE 'strict-transport|content-security|x-content-type|referrer-policy|permissions-policy'

# 5. favicon (post GH-3413)
curl -sSI https://pilot.quantflow.studio/favicon.ico | head -1

# 6. x-powered-by suppressed
curl -sSI https://pilot.quantflow.studio/ | grep -i powered || echo "suppressed ✓"

# 7. OG image cache
curl -sSI https://pilot.quantflow.studio/pilot-preview.png | grep -i cache-control

# Lighthouse desktop (target: Performance 100, LCP < 1.2s)
npx lighthouse https://pilot.quantflow.studio/ --preset=desktop --quiet --chrome-flags="--headless"
```

## ⚠️ Merge order

**Must merge after GH-3413** (a11y Lighthouse-100 PR) so the performance delta from compression and cache headers is measurable in isolation.