### PR TITLE
hotfix(docs): qualify Traefik middleware refs with @docker (prod 404)

### DIFF
--- a/docs/docker-compose.prod.yml
+++ b/docs/docker-compose.prod.yml
@@ -8,7 +8,7 @@ services:
       - "traefik.http.routers.pilot-docs.rule=Host(`pilot.quantflow.studio`)"
       - "traefik.http.routers.pilot-docs.entrypoints=websecure"
       - "traefik.http.routers.pilot-docs.tls=true"
-      - "traefik.http.routers.pilot-docs.middlewares=docs-compress,docs-secheaders"
+      - "traefik.http.routers.pilot-docs.middlewares=docs-compress@docker,docs-secheaders@docker"
       - "traefik.docker.network=balancer"
       # gzip compression — Traefik v2.11 (brotli requires v3.x; upgrade tracked in #3380)
       - "traefik.http.middlewares.docs-compress.compress=true"
@@ -20,7 +20,9 @@ services:
       - "traefik.http.middlewares.docs-secheaders.headers.permissionsPolicy=geolocation=(), microphone=(), camera=(), payment=()"
       # CSP in report-only mode — Nextra v4 inlines styles so 'unsafe-inline' is required;
       # harden to nonces/hashes in a follow-up once the report stream is clean.
-      - "traefik.http.middlewares.docs-secheaders.headers.contentSecurityPolicyReportOnly=default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' data:; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+      # NOTE: Traefik v2.11 has no native `contentSecurityPolicyReportOnly` field — use
+      # customResponseHeaders to set the header verbatim (silent no-op otherwise).
+      - "traefik.http.middlewares.docs-secheaders.headers.customResponseHeaders.Content-Security-Policy-Report-Only=default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' data:; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     expose:
       - 3000
     networks:


### PR DESCRIPTION
**Production fix — pilot.quantflow.studio is currently HTTP/2 404.**

PR #3415 (cache/compression/security headers) introduced two label bugs in `docs/docker-compose.prod.yml`:

## Bug 1 — Outage cause
Router middleware reference used bare names:
\`\`\`yaml
middlewares=docs-compress,docs-secheaders
\`\`\`
With multiple Traefik providers configured on the host (Docker labels + the file provider), same-provider middleware names need the \`@docker\` suffix. Without it, Traefik can't resolve them → the router becomes unsatisfiable → the host falls through to the catch-all 404.

Live evidence (probed 2026-06-03 ~10:31 UTC after PR #3415 deploy):
\`\`\`
$ curl -sSIL -H 'Accept-Encoding: gzip,br' https://pilot.quantflow.studio/
HTTP/2 404
content-type: text/plain; charset=utf-8
x-content-type-options: nosniff      ← Go stdlib auto-sets this on http.Error, NOT from our middleware
content-length: 19
\`\`\`
None of the expected headers (HSTS, Referrer-Policy, Permissions-Policy, CSP-Report-Only, Content-Encoding) appear, and the body is the literal \`404 page not found\`.

## Bug 2 — Silently inert
\`contentSecurityPolicyReportOnly\` is not a Traefik v2.11 native headers field — it sets nothing. Switch to \`customResponseHeaders.Content-Security-Policy-Report-Only\` so the header is actually emitted.

## Diff
\`\`\`diff
-      - \"traefik.http.routers.pilot-docs.middlewares=docs-compress,docs-secheaders\"
+      - \"traefik.http.routers.pilot-docs.middlewares=docs-compress@docker,docs-secheaders@docker\"
…
-      - \"traefik.http.middlewares.docs-secheaders.headers.contentSecurityPolicyReportOnly=…\"
+      - \"traefik.http.middlewares.docs-secheaders.headers.customResponseHeaders.Content-Security-Policy-Report-Only=…\"
\`\`\`

## Verify after merge + sync-docs deploy

\`\`\`bash
curl -sSI -H 'Accept-Encoding: gzip,br' https://pilot.quantflow.studio/ | head -20
# Expect:
#   HTTP/2 200
#   content-encoding: gzip
#   cache-control: public, max-age=0, must-revalidate
#   strict-transport-security: max-age=63072000; includeSubDomains
#   x-content-type-options: nosniff
#   referrer-policy: strict-origin-when-cross-origin
#   permissions-policy: geolocation=(), microphone=(), camera=(), payment=()
#   content-security-policy-report-only: default-src 'self'; …
\`\`\`

## Pattern memory (file as Navigator pitfall after merge)
Traefik multi-provider middleware references **must** be \`@<provider>\`-qualified at the router side; bare names silently break routing in mixed setups. Same risk class as the trailing-slash gotcha. Mention in \`.agent/system/docs-cache-and-lighthouse.md\`.