### PR TITLE
pilot-fix(autopilot): guard notifyExternalClose against human recovery PRs (GH-3417)

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -940,6 +940,50 @@ func (c *Client) SearchPRsForIssue(ctx context.Context, owner, repo string, issu
 	return prs, nil
 }
 
+// SearchOpenPRsForIssue returns open PRs that reference the given issue number.
+// The returned PullRequest values include the User (author) field so callers can
+// distinguish Pilot-bot PRs from human recovery PRs.
+func (c *Client) SearchOpenPRsForIssue(ctx context.Context, owner, repo string, issueNumber int) ([]*PullRequest, error) {
+	q := fmt.Sprintf("repo:%s/%s is:pr is:open #%d", owner, repo, issueNumber)
+	path := fmt.Sprintf("/search/issues?q=%s&per_page=100", url.QueryEscape(q))
+
+	var result struct {
+		Items []struct {
+			ID      int64  `json:"id"`
+			Number  int    `json:"number"`
+			Title   string `json:"title"`
+			State   string `json:"state"`
+			HTMLURL string `json:"html_url"`
+			User    *User  `json:"user"`
+		} `json:"items"`
+	}
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return nil, fmt.Errorf("search open PRs for issue #%d: %w", issueNumber, err)
+	}
+
+	prs := make([]*PullRequest, 0, len(result.Items))
+	for _, item := range result.Items {
+		prs = append(prs, &PullRequest{
+			ID:      item.ID,
+			Number:  item.Number,
+			Title:   item.Title,
+			State:   item.State,
+			HTMLURL: item.HTMLURL,
+			User:    item.User,
+		})
+	}
+	return prs, nil
+}
+
+// GetAuthenticatedUser returns the GitHub user associated with the current token.
+func (c *Client) GetAuthenticatedUser(ctx context.Context) (*User, error) {
+	var user User
+	if err := c.doRequest(ctx, http.MethodGet, "/user", nil, &user); err != nil {
+		return nil, fmt.Errorf("get authenticated user: %w", err)
+	}
+	return &user, nil
+}
+
 // SearchMergedPRsForIssue checks if any merged PRs exist that reference the given
 // issue number in their title (e.g. "GH-123" pattern). Uses the GitHub Search API.
 // Returns true if at least one merged PR is found.

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -242,6 +242,7 @@ type PullRequest struct {
 	CreatedAt      string `json:"created_at,omitempty"`
 	UpdatedAt      string `json:"updated_at,omitempty"`
 	MergedAt       string `json:"merged_at,omitempty"`
+	User           *User  `json:"user,omitempty"` // PR author (populated by search results and GetPullRequest)
 }
 
 // PullRequestInput is used for creating pull requests

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -210,6 +210,10 @@ type Controller struct {
 	// can immediately re-mark the issue as processed, closing the merge→done
 	// race window before label propagation catches up.
 	onIssueDone func(issueNumber int)
+
+	// cachedBotLogin holds the authenticated GitHub login for the Pilot token.
+	// Populated lazily by getBotLogin; protected by mu. GH-3417.
+	cachedBotLogin string
 }
 
 // NewController creates an autopilot controller with all required components.
@@ -2903,6 +2907,28 @@ func (c *Controller) notifyExternalMerge(ctx context.Context, prState *PRState) 
 	}
 }
 
+// getBotLogin returns the authenticated GitHub login of the Pilot token.
+// The value is resolved lazily on first call and then cached. Returns "" when the
+// login cannot be determined; callers must skip the human-recovery-PR guard in that case.
+func (c *Controller) getBotLogin(ctx context.Context) string {
+	c.mu.RLock()
+	login := c.cachedBotLogin
+	c.mu.RUnlock()
+	if login != "" {
+		return login
+	}
+
+	user, err := c.ghClient.GetAuthenticatedUser(ctx)
+	if err != nil {
+		c.log.Debug("could not fetch authenticated user login for bot-guard", "error", err)
+		return ""
+	}
+	c.mu.Lock()
+	c.cachedBotLogin = user.Login
+	c.mu.Unlock()
+	return user.Login
+}
+
 // notifyExternalClose sends notification when a PR is closed externally without merge.
 // GH-1015: Marks the issue as pilot-retry-ready so it can be re-picked by the poller.
 func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) {
@@ -2923,6 +2949,27 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 			c.log.Info("skipping pilot-retry-ready: issue already pilot-done", "issue", prState.IssueNumber, "pr", prState.PRNumber)
 			c.maybeCloseParentIssue(ctx, prState)
 			return
+		}
+
+		// GH-3417: Skip pilot-retry-ready when a human recovery PR is already open
+		// for this issue. Re-dispatching via retry-ready would overwrite the human's
+		// branch (git checkout -B in worktree.go). Guard only fires when we can
+		// resolve the bot's own login; if the lookup fails, fall through to the
+		// existing retry-ready behaviour (safe default).
+		if botLogin := c.getBotLogin(ctx); botLogin != "" {
+			prs, searchErr := c.ghClient.SearchOpenPRsForIssue(ctx, c.owner, c.repo, prState.IssueNumber)
+			if searchErr == nil {
+				for _, pr := range prs {
+					if pr.User != nil && pr.User.Login != botLogin {
+						c.log.Info("skipping pilot-retry-ready: human recovery PR already open",
+							"issue", prState.IssueNumber,
+							"recovery_pr", pr.HTMLURL,
+							"author", pr.User.Login)
+						c.maybeCloseParentIssue(ctx, prState)
+						return
+					}
+				}
+			}
 		}
 
 		if err := c.ghClient.AddLabels(ctx, c.owner, c.repo, prState.IssueNumber, []string{github.LabelRetryReady}); err != nil {

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -5020,6 +5020,133 @@ func TestNotifyExternalClose_SkipsRetryReadyWhenDone(t *testing.T) {
 	}
 }
 
+// GH-3417: notifyExternalClose must not stamp pilot-retry-ready when a human
+// recovery PR is already open for the issue. Re-dispatching would overwrite
+// the human's branch via git checkout -B in the worktree.
+func TestNotifyExternalClose_SkipsRetryReadyForHumanRecoveryPR(t *testing.T) {
+	const botLogin = "pilot-bot"
+
+	tests := []struct {
+		name            string
+		openPRs         []github.PullRequest // PRs returned by SearchOpenPRsForIssue
+		wantRetryAdded  bool
+		wantSkipLogged  bool // expect the "human recovery PR" log path
+	}{
+		{
+			name:           "no open PRs — retry-ready applied",
+			openPRs:        nil,
+			wantRetryAdded: true,
+		},
+		{
+			name: "human PR open — retry-ready skipped",
+			openPRs: []github.PullRequest{
+				{
+					Number:  99,
+					State:   "open",
+					HTMLURL: "https://github.com/owner/repo/pull/99",
+					User:    &github.User{Login: "alice"},
+				},
+			},
+			wantRetryAdded: false,
+			wantSkipLogged: true,
+		},
+		{
+			name: "only bot PR open — retry-ready applied",
+			openPRs: []github.PullRequest{
+				{
+					Number:  100,
+					State:   "open",
+					HTMLURL: "https://github.com/owner/repo/pull/100",
+					User:    &github.User{Login: botLogin},
+				},
+			},
+			wantRetryAdded: true,
+		},
+		{
+			name: "mixed: bot PR and human PR — retry-ready skipped",
+			openPRs: []github.PullRequest{
+				{Number: 100, State: "open", HTMLURL: "https://github.com/owner/repo/pull/100", User: &github.User{Login: botLogin}},
+				{Number: 101, State: "open", HTMLURL: "https://github.com/owner/repo/pull/101", User: &github.User{Login: "bob"}},
+			},
+			wantRetryAdded: false,
+			wantSkipLogged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var retryReadyAdded bool
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/user" && r.Method == http.MethodGet:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"login":"` + botLogin + `","id":1}`))
+
+				case r.URL.Path == "/repos/owner/repo/issues/10" && r.Method == http.MethodGet:
+					issue := github.Issue{Number: 10, State: "open", Labels: []github.Label{}}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(issue)
+
+				case strings.HasPrefix(r.URL.Path, "/search/issues") && r.Method == http.MethodGet:
+					// SearchOpenPRsForIssue — return the configured open PRs.
+					items := make([]map[string]interface{}, 0, len(tt.openPRs))
+					for _, pr := range tt.openPRs {
+						item := map[string]interface{}{
+							"id":       pr.Number,
+							"number":   pr.Number,
+							"title":    pr.Title,
+							"state":    pr.State,
+							"html_url": pr.HTMLURL,
+						}
+						if pr.User != nil {
+							item["user"] = map[string]interface{}{"login": pr.User.Login, "id": 0}
+						}
+						items = append(items, item)
+					}
+					resp := map[string]interface{}{
+						"total_count": len(items),
+						"items":       items,
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+
+				case r.URL.Path == "/repos/owner/repo/issues/10/labels" && r.Method == http.MethodPost:
+					var body struct {
+						Labels []string `json:"labels"`
+					}
+					_ = json.NewDecoder(r.Body).Decode(&body)
+					for _, l := range body.Labels {
+						if l == github.LabelRetryReady {
+							retryReadyAdded = true
+						}
+					}
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("[]"))
+
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/10/labels/") && r.Method == http.MethodDelete:
+					w.WriteHeader(http.StatusOK)
+
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			prState := &PRState{PRNumber: 42, IssueNumber: 10}
+			c.notifyExternalClose(context.Background(), prState)
+
+			if retryReadyAdded != tt.wantRetryAdded {
+				t.Errorf("pilot-retry-ready added = %v, want %v", retryReadyAdded, tt.wantRetryAdded)
+			}
+		})
+	}
+}
+
 // GH-2251: Test that ScanRecentlyMergedPRs discovers externally-merged PRs
 // and skips those already tracked.
 func TestController_ScanRecentlyMergedPRs(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Root cause (Shape B / TASK-359 Layer 2a):** `notifyExternalClose` applied `pilot-retry-ready` whenever a Pilot PR was closed without merge, with no check for human recovery PRs. Re-dispatch would overwrite a human's branch via `git checkout -B` in `worktree.go`.
- **Fix:** Before stamping `pilot-retry-ready`, resolve the bot's own GitHub login (lazily cached) and query open PRs that reference the issue. If any PR is authored by someone other than the bot, skip the label and log the recovery PR URL + author.
- **Fallback safety:** If the bot-login lookup fails (e.g., offline tests, bad token), the guard is silently bypassed and existing retry-ready behaviour is preserved.

## Changes

| File | What |
|---|---|
| `internal/adapters/github/types.go` | Add `User *User` to `PullRequest` struct |
| `internal/adapters/github/client.go` | Add `SearchOpenPRsForIssue` (open PRs + author) and `GetAuthenticatedUser` |
| `internal/autopilot/controller.go` | Add `getBotLogin` helper (lazy-cached, mutex-guarded), wire guard into `notifyExternalClose` |
| `internal/autopilot/controller_test.go` | Table-driven test: no PRs, human PR, bot-only PR, mixed |

## Test plan

- [ ] `go test ./internal/autopilot/... ./internal/adapters/github/...` — all pass
- [ ] `golangci-lint run --new-from-rev=origin/main ./internal/autopilot/... ./internal/adapters/github/...` — 0 issues
- [ ] `TestNotifyExternalClose_SkipsRetryReadyForHumanRecoveryPR` covers all 4 cases (no PRs, human PR, bot-only PR, mixed)
- [ ] Existing `TestNotifyExternalClose_MaybeCloseParent` and `TestNotifyExternalClose_SkipsRetryReadyWhenDone` still pass unmodified

Refs: GH-3417, TASK-359 Layer 2a