### PR TITLE
pilot-fix(autopilot): ungate ScanRecentlyMergedPRs (GH-3419, TASK-359 Layer 3a)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2471,18 +2471,12 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 // autopilot (e.g. via `gh pr merge` or the GitHub UI).
 // Called on startup and periodically from the Run loop.
 func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
-	// TASK-356 #2 (decouple): the scan reconciles externally-merged Pilot PRs —
-	// release triggering, merge metrics, execution-row self-heal, AND board
-	// write-back. Run it whenever EITHER auto-release OR board sync is enabled, so
-	// a board-sourced (non-releasing) setup still gets its cards moved to Done on a
-	// manual merge. The release-triggering tail below is separately gated on
-	// releaseEnabled so nothing tries to tag a release when release is off.
+	// Run the scan unconditionally — it covers self-heal + merge metrics even when
+	// neither auto-release nor board sync is enabled (e.g. a plain GH-issue-source
+	// deployment). Internal gates below handle release-trigger and board-writeback
+	// per-mode; both are idempotent so duplicate calls are safe.
 	releaseEnabled := c.shouldTriggerRelease()
 	boardEnabled := c.boardSync != nil && c.doneStatus != ""
-	if !releaseEnabled && !boardEnabled {
-		c.log.Debug("skipping merged PR scan: neither auto-release nor board sync enabled")
-		return nil
-	}
 
 	scanWindow := c.config.MergedPRScanWindow
 	if scanWindow == 0 {

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6491,6 +6491,140 @@ func TestController_ScanRecentlyMergedPRs_TracksOrphanMerge(t *testing.T) {
 	}
 }
 
+// TestController_ScanRecentlyMergedPRs_FlagMatrix verifies GH-3419: the scan
+// runs unconditionally across all {release, board} flag combinations. Self-heal
+// fires in every case; release triggering and board write-back are gated
+// internally per-mode.
+func TestController_ScanRecentlyMergedPRs_FlagMatrix(t *testing.T) {
+	recentMergedAt := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	const (
+		prNum       = 77
+		issueNum    = 400
+		issueNodeID = "I_kwDOissue400"
+	)
+	pilotPR := github.PullRequest{
+		Number:         prNum,
+		Head:           github.PRRef{Ref: fmt.Sprintf("pilot/GH-%d", issueNum), SHA: "headsha77"},
+		Base:           github.PRRef{Ref: "main"},
+		HTMLURL:        fmt.Sprintf("https://github.com/owner/repo/pull/%d", prNum),
+		Title:          "feat: matrix test PR",
+		Merged:         true,
+		MergedAt:       recentMergedAt,
+		MergeCommitSHA: "merge-sha-77",
+	}
+
+	tests := []struct {
+		name           string
+		releaseEnabled bool
+		boardEnabled   bool
+		wantSelfHeal   bool
+		wantActivePR   bool // PR registered for release
+		wantBoardCalls int
+	}{
+		{
+			name:           "off,off: scan still runs self-heal, no release, no board",
+			releaseEnabled: false,
+			boardEnabled:   false,
+			wantSelfHeal:   true,
+			wantActivePR:   false,
+			wantBoardCalls: 0,
+		},
+		{
+			name:           "off,on: no release but board write-back fires",
+			releaseEnabled: false,
+			boardEnabled:   true,
+			wantSelfHeal:   true,
+			wantActivePR:   false,
+			wantBoardCalls: 1,
+		},
+		{
+			name:           "on,off: release triggered, no board",
+			releaseEnabled: true,
+			boardEnabled:   false,
+			wantSelfHeal:   true,
+			wantActivePR:   true,
+			wantBoardCalls: 0,
+		},
+		{
+			name:           "on,on: release triggered AND board write-back fires",
+			releaseEnabled: true,
+			boardEnabled:   true,
+			wantSelfHeal:   true,
+			wantActivePR:   true,
+			wantBoardCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode([]*github.PullRequest{&pilotPR})
+				case r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", issueNum):
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(map[string]string{"node_id": issueNodeID})
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/tags"):
+					// No tags for merge SHA — PR triggers release when enabled.
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("[]"))
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			if tt.releaseEnabled {
+				cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", TagPrefix: "v"}
+			} else {
+				cfg.Release = &ReleaseConfig{Enabled: false}
+			}
+			cfg.MergedPRScanWindow = 30 * time.Minute
+
+			var opts []ControllerOption
+			var boardMock *mockBoardSyncer
+			if tt.boardEnabled {
+				boardMock = &mockBoardSyncer{}
+				opts = append(opts, withBoardSyncerForTest(boardMock, "Done", "Failed", "In Review", "In Dev"))
+			}
+
+			c := NewController(cfg, ghClient, nil, "owner", "repo", opts...)
+			c.SetStateStore(newTestStateStore(t))
+			evalMock := &mockEvalStore{}
+			c.SetEvalStore(evalMock)
+
+			if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+				t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+			}
+
+			// Self-heal must fire in every flag combination.
+			if got, want := len(evalMock.selfHealed) > 0, tt.wantSelfHeal; got != want {
+				t.Errorf("selfHealed entries = %d (healed=%v), want %v", len(evalMock.selfHealed), got, want)
+			}
+
+			// Release-trigger: PR registered in activePRs only when release is enabled.
+			c.mu.RLock()
+			_, tracked := c.activePRs[prNum]
+			c.mu.RUnlock()
+			if tracked != tt.wantActivePR {
+				t.Errorf("activePRs[%d] tracked = %v, want %v", prNum, tracked, tt.wantActivePR)
+			}
+
+			// Board write-back: called only when board is enabled.
+			var boardCalls int
+			if boardMock != nil {
+				boardCalls = len(boardMock.calls)
+			}
+			if boardCalls != tt.wantBoardCalls {
+				t.Errorf("board sync calls = %d, want %d", boardCalls, tt.wantBoardCalls)
+			}
+		})
+	}
+}
+
 // TestController_RecordMergeSuccess_Idempotency verifies recordMergeSuccess
 // fires exactly once per PR number even when called multiple times from
 // different code paths (e.g. handleMerging + ScanRecentlyMergedPRs both


### PR DESCRIPTION
## Summary

- Removes the early-return gate in `ScanRecentlyMergedPRs` that required `releaseEnabled || boardEnabled` before running any scan logic.
- The scan now runs unconditionally: `selfHealForPR` and `recordMergeSuccess` fire even in plain GH-issue-source deployments with neither auto-release nor board sync configured.
- Internal gates already handle release-trigger (`if !releaseEnabled { continue }` at line 2582) and board-writeback (`if boardEnabled && issueNum > 0` at line 2570) per-mode — no behavior change for existing setups.

## Changes

- `internal/autopilot/controller.go`: Remove 4-line early-return gate; update comment to reflect unconditional semantics.
- `internal/autopilot/controller_test.go`: Add `TestController_ScanRecentlyMergedPRs_FlagMatrix` covering all four `{release,board}` flag matrices: `(off,off)`, `(off,on)`, `(on,off)`, `(on,on)`.

## Test plan

- [x] `TestController_ScanRecentlyMergedPRs_FlagMatrix` — all 4 flag combinations pass
- [x] Full `internal/autopilot` suite clean (1.75s)
- [x] `golangci-lint --new-from-rev=origin/main` — 0 issues
- [x] `go build ./...` — clean

Closes #3419