### PR TITLE
pilot-fix(poller): invalidate completion on pilot-retry-ready dispatch (GH-3418)

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -51,6 +51,9 @@ type TaskChecker interface {
 // GH-2242: Prevents re-dispatch of completed tasks when pilot-done label is missing.
 type ExecutionChecker interface {
 	HasCompletedExecution(taskID, projectPath string) (bool, error)
+	// InvalidateCompletion deletes stale completed execution records so a
+	// retry-ready re-dispatch is not silently no-op'd (GH-3418).
+	InvalidateCompletion(taskID, projectPath string) error
 }
 
 // Verdict is the poller-side result of a pre-flight judgment.
@@ -1850,6 +1853,19 @@ func (p *Poller) shouldRetryRetryReadyIssue(ctx context.Context, issue *Issue) b
 	p.mu.Lock()
 	p.retryReadyCount[issue.Number]++
 	p.mu.Unlock()
+
+	// GH-3418: Delete any stale completed execution row so HasCompletedExecution
+	// doesn't cause the re-dispatch to silently no-op. Must happen before
+	// ClearProcessed so the issue can actually reach the dispatch gate.
+	if p.execChecker != nil {
+		taskID := fmt.Sprintf("GH-%d", issue.Number)
+		if err := p.execChecker.InvalidateCompletion(taskID, p.projectPath); err != nil {
+			p.logger.Warn("InvalidateCompletion failed on retry-ready re-dispatch — proceeding",
+				slog.String("task_id", taskID),
+				slog.Any("error", err),
+			)
+		}
+	}
 
 	// Clear from processed map so the issue can be re-picked
 	p.ClearProcessed(issue.Number)

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2554,11 +2554,19 @@ func TestPoller_WithMaxRetryReadyRetries(t *testing.T) {
 
 // mockExecutionChecker implements ExecutionChecker for testing.
 type mockExecutionChecker struct {
-	completed map[string]bool // key: "taskID:projectPath"
+	completed   map[string]bool // key: "taskID:projectPath"
+	invalidated []string        // keys passed to InvalidateCompletion, in order
 }
 
 func (m *mockExecutionChecker) HasCompletedExecution(taskID, projectPath string) (bool, error) {
 	return m.completed[taskID+":"+projectPath], nil
+}
+
+func (m *mockExecutionChecker) InvalidateCompletion(taskID, projectPath string) error {
+	key := taskID + ":" + projectPath
+	m.invalidated = append(m.invalidated, key)
+	delete(m.completed, key)
+	return nil
 }
 
 func TestPoller_SkipsCompletedExecution(t *testing.T) {
@@ -2643,6 +2651,66 @@ func TestPoller_DispatchesWhenNoCompletedExecution(t *testing.T) {
 
 	if got := atomic.LoadInt32(&callCount); got != 1 {
 		t.Errorf("callback called %d times, want 1 (should dispatch when no completed execution)", got)
+	}
+}
+
+// GH-3418: pilot-retry-ready re-dispatch must invalidate any stale completed
+// execution row, otherwise HasCompletedExecution silently no-ops the re-dispatch.
+func TestPoller_RetryReady_InvalidatesCompletedExecution(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Retry-ready with completed row",
+			Labels: []Label{{Name: "pilot"}, {Name: LabelRetryReady}},
+			CreatedAt: now.Add(-1 * time.Hour)},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/search/issues" {
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	// Seed: issue has a prior completed execution row.
+	execChecker := &mockExecutionChecker{
+		completed: map[string]bool{
+			"GH-42:/project": true,
+		},
+	}
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithRetryGracePeriod(0),
+		WithExecutionChecker(execChecker, "/project"),
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	// InvalidateCompletion must have been called for the re-dispatched issue.
+	if len(execChecker.invalidated) == 0 {
+		t.Fatal("InvalidateCompletion was not called — stale completed row would block re-dispatch")
+	}
+	if execChecker.invalidated[0] != "GH-42:/project" {
+		t.Errorf("InvalidateCompletion called with %q, want %q", execChecker.invalidated[0], "GH-42:/project")
+	}
+
+	// After invalidation the completed map is empty, so dispatch must proceed.
+	if got := atomic.LoadInt32(&callCount); got != 1 {
+		t.Errorf("OnIssue called %d times, want 1 (retry-ready should re-dispatch after invalidation)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extends `ExecutionChecker` interface with `InvalidateCompletion(taskID, projectPath string) error`
- Calls `InvalidateCompletion` in `shouldRetryRetryReadyIssue` before `ClearProcessed`, removing stale `completed` execution rows that caused silent no-op re-dispatches
- `*memory.Store` already implements the method (from TASK-296); no store changes needed

**Root cause fixed:** when an issue was re-labeled `pilot-retry-ready`, the poller cleared the in-memory processed marker but left the prior `status='completed'` + `commit_sha` row intact. The dispatch gate (`HasCompletedExecution`) then matched that row and re-marked the issue processed without executing — infinite skip loop.

## Test plan

- [x] `TestPoller_RetryReady_InvalidatesCompletedExecution` — seeds completed row, triggers retry-ready, asserts `InvalidateCompletion` called and `OnIssue` fires
- [x] All existing `TestPoller_AutoRetryRetryReadyIssue_*` tests pass unchanged
- [x] `TestPoller_SkipsCompletedExecution` / `TestPoller_DispatchesWhenNoCompletedExecution` unaffected
- [x] `go build ./...` clean
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues

Closes #3418