### PR TITLE
fix(ci): force Node.js 24 for lint job to resolve golangci-lint-action 502 (GH-3430)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- `golangci-lint-action@v7` runs on Node.js 20, deprecated by GitHub Actions (forced upgrade to Node.js 24 on 2026-06-16)
- Prior CI run on PR #3429 failed with `Unexpected HTTP response: 502` in the lint job
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` to the lint job to opt into Node.js 24 early

## Test plan

- [ ] CI lint job passes on this PR
- [ ] No golangci-lint issues introduced (lint is clean locally)

Closes #3430