### PR TITLE
pilot-fix(poller): hasMergedWork DB fallback for Search API lag (TASK-359 Layer 3b)

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -1620,7 +1620,24 @@ func (p *Poller) hasMergedWork(ctx context.Context, issue *Issue) bool {
 			return false
 		}
 		if !branchFound {
-			return false
+			// GH-3420 / TASK-359 Layer 3b: DB fallback — no Search API indexing lag.
+			// A completed execution row with a deliverable (commit_sha or pr_url) is
+			// strong evidence work shipped, even when the ~30s Search window is open.
+			// Skip for pilot-retry-ready: that label means the prior execution's PR was
+			// closed without merge, so the completed row is stale. shouldRetryRetryReadyIssue
+			// invalidates it explicitly before re-dispatch.
+			if p.execChecker != nil && !HasLabel(issue, LabelRetryReady) {
+				taskID := fmt.Sprintf("GH-%d", issue.Number)
+				if completed, cerr := p.execChecker.HasCompletedExecution(taskID, p.projectPath); cerr == nil && completed {
+					p.logger.Debug("hasMergedWork: DB fallback hit — execution previously completed",
+						slog.String("task_id", taskID))
+					// fall through to mark-as-done below
+				} else {
+					return false
+				}
+			} else {
+				return false
+			}
 		}
 		p.logger.Info("Merged PR found via branch lookup (Search API lag)",
 			slog.Int("issue", issue.Number),

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2780,6 +2780,70 @@ func TestPoller_HasMergedWork_NoMerges_NoFallbackBlock(t *testing.T) {
 	}
 }
 
+// GH-3420 / TASK-359 Layer 3b: Search API empty + branch REST empty + completed DB row → true.
+func TestPoller_HasMergedWork_DBFallback_CompletedRow(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+		case "/repos/owner/repo/pulls":
+			_, _ = w.Write([]byte(`[]`))
+		case "/repos/owner/repo/issues/42/labels":
+			if r.Method == http.MethodPost {
+				w.WriteHeader(http.StatusOK)
+			}
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	execChecker := &mockExecutionChecker{
+		completed: map[string]bool{
+			"GH-42:/project": true,
+		},
+	}
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithExecutionChecker(execChecker, "/project"),
+	)
+
+	issue := &Issue{Number: 42, Title: "Test issue"}
+	if !poller.hasMergedWork(context.Background(), issue) {
+		t.Error("hasMergedWork() should return true when DB has completed row (even with Search + branch empty)")
+	}
+}
+
+// GH-3420: Search empty + branch empty + no DB row → false (no regression).
+func TestPoller_HasMergedWork_DBFallback_NoRow(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+		case "/repos/owner/repo/pulls":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	execChecker := &mockExecutionChecker{
+		completed: map[string]bool{}, // no rows
+	}
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithExecutionChecker(execChecker, "/project"),
+	)
+
+	issue := &Issue{Number: 42, Title: "Test issue"}
+	if poller.hasMergedWork(context.Background(), issue) {
+		t.Error("hasMergedWork() should return false when Search, branch, and DB all return empty")
+	}
+}
+
 // GH-2341: Fresh label fetch before dispatch blocks re-dispatch when the
 // ListIssues snapshot is stale and pilot-done was added in between.
 func TestPoller_CheckForNewIssues_StaleSnapshot_RefreshesLabels(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds a local DB fallback to `hasMergedWork` that queries `HasCompletedExecution` after both GitHub Search and `FindMergedPRByBranch` return empty — eliminating the ~30s Search API indexing window where a just-merged PR could trigger re-dispatch.
- Skips the DB fallback for `pilot-retry-ready` issues: that label means the prior PR was closed without merge, so the completed row is stale; `shouldRetryRetryReadyIssue` handles invalidation explicitly.
- Two new tests: `TestPoller_HasMergedWork_DBFallback_CompletedRow` (positive) and `TestPoller_HasMergedWork_DBFallback_NoRow` (negative).

## Test plan

- [x] `TestPoller_HasMergedWork_DBFallback_CompletedRow` — Search empty + branch empty + DB hit → returns true
- [x] `TestPoller_HasMergedWork_DBFallback_NoRow` — Search empty + branch empty + no DB row → returns false
- [x] `TestPoller_RetryReady_InvalidatesCompletedExecution` — retry-ready path unaffected (still calls `InvalidateCompletion`)
- [x] `make test` clean (all packages)
- [x] `make lint` clean (0 issues)