### PR TITLE
fix(executor): unify epic finalization error contract (TASK-359 Layer 1)

### DIFF
--- a/.agent/tasks/TASK-359-daemon-finalization-hardening.md
+++ b/.agent/tasks/TASK-359-daemon-finalization-hardening.md
@@ -1,6 +1,31 @@
 # TASK-359: Daemon finalization hardening — close Shapes A/B/C
 
-**Status:** 🟡 partial (3/4 Pilot-eligible layers SHIPPED in v2.166.13–14; Layer 1 still MANUAL; #3420 status TBD). Updated 2026-06-03 after origin/main moved.
+**Status:** 🟢 boundary fixes COMPLETE (4/4 Pilot-eligible layers shipped, v2.166.13–16). **Layer 1 IMPLEMENTED (MANUAL)** on `fix/task-359-layer1-finalize` (2026-06-03) — see "Layer 1 — as built" below. Updated 2026-06-03.
+
+---
+
+## Layer 1 — as built (`fix/task-359-layer1-finalize`, 2026-06-03)
+
+Implemented as a **focused hardening of the epic finalization path** (not a full
+direct-path extraction). A `navigator-research` pass refuted two of the original
+plan's assumptions and flagged a third as high-risk; the build follows the
+evidence:
+
+| Original step | Finding | As built |
+|---|---|---|
+| 4 — `git.FindMergedPRByBranch` on `GitOperations` | **REFUTED** — that method is on `*github.Client`; the executor holds no github client | Added a new `GitOperations.FindMergedPRByBranch(ctx, branch)` shelling `gh pr list --head <branch> --state merged --json url` (same `gh` dependency `CreatePR` already uses) + pure `parseFirstPRURL` helper |
+| 1–2 — extract direct path into `finalizeExecution(ctx,task,path,result,isEpic)` | **PARTIAL** — epic block lacks `git`/`log`/`recorder`/`backendResult` in scope; full extraction needs 4 extra params and rewires the daemon's hot path | New `Runner.finalizeEpicBranchPR(ctx, task, git, result)` gives the **epic** path the direct path's error contract. Direct path (`runner.go:~3336`, already correct) left untouched — lower regression risk |
+| 7 — tighten `HasCompletedExecution` to require `pr_url` | **REFUTED** — breaks direct-commit-to-main rows (commit_sha set, pr_url='') and violates `TestTaskCompletionInvariant` | **Deferred.** Layer 1's invariant prevents the empty-PR `completed` row from ever being written, so the OR-clause is no longer reachable for the bug. SQL/schema left unchanged (defense-in-depth follow-up only) |
+
+**What changed:**
+- `internal/executor/runner.go` — new `finalizeEpicBranchPR` method; epic block (`~runner.go:1589`) now routes through it. Reordered to **guard → push → harvest → idempotency → CreatePR → invariant** (matches the direct path). Push fail / PR-create fail now set `result.Success=false` instead of warn+continue (Shape A). Pre-create `FindMergedPRByBranch` short-circuit (Shape C). Invariant: `task.CreatePR && PRUrl=="" ⇒ Success=false`.
+- `internal/executor/git.go` — `FindMergedPRByBranch` + `parseFirstPRURL`.
+- `internal/memory/store.go` — `MarkExecutionCompleted(id, prURL, commitSHA, durationMs)`: one atomic `UPDATE` (status + result fields) replacing the non-atomic two-call write.
+- `internal/executor/dispatcher.go` — completion write (`~:708`) now calls `MarkExecutionCompleted`.
+
+**Tests (green):** `TestFinalizeEpicBranchPR_PushFailIsFailure` (Shape A), `TestFinalizeEpicBranchPR_NoCommitsIsCleanSuccess` (reordered guard), `TestParseFirstPRURL`, `TestMarkExecutionCompleted{,_EmptyPRUrl}`. `go test ./internal/executor/ ./internal/memory/`, `go vet`, `gofmt`, and `golangci-lint` all clean.
+
+**Not in this PR (follow-ups):** direct-path GH-3126 ghost-SHA guard parity for the epic path; the step-7 `is_direct_commit` column (defense-in-depth); full single-`finalizeExecution` unification (Option ii) if/when the direct path is next refactored.
 **Priority:** P1 — drove ~70% of finalization failures in the studio-sdk extraction; #1 item on Pilot's own roadmap per `pilot-known-bugs` memory
 **Repo:** `qf-studio/pilot`
 **Area:** `internal/executor/`, `internal/autopilot/`, `internal/adapters/github/`, `internal/memory/`

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -705,12 +705,11 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 				slog.Duration("duration", duration),
 				slog.String("pr_url", result.PRUrl),
 			)
-			if err := w.store.UpdateExecutionStatus(exec.ID, "completed"); err != nil {
-				w.log.Error("Failed to update status to completed", slog.Any("error", err))
-			}
-			// Update result fields (PR URL, commit SHA, duration)
-			if err := w.store.UpdateExecutionResult(exec.ID, result.PRUrl, result.CommitSHA, duration.Milliseconds()); err != nil {
-				w.log.Error("Failed to update execution result", slog.Any("error", err))
+			// TASK-359 Layer 1: one atomic write (status + result fields) instead of
+			// UpdateExecutionStatus("completed") then UpdateExecutionResult — the gap
+			// between those two could leave a 'completed' row with an empty pr_url.
+			if err := w.store.MarkExecutionCompleted(exec.ID, result.PRUrl, result.CommitSHA, duration.Milliseconds()); err != nil {
+				w.log.Error("Failed to mark execution completed", slog.Any("error", err))
 			}
 			// Emit progress callback for task completed
 			msg := fmt.Sprintf("Completed in %s", duration.Round(time.Second))

--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -236,6 +237,42 @@ func extractPRURL(text string) string {
 		}
 	}
 	return ""
+}
+
+// FindMergedPRByBranch returns the URL of a merged PR whose head is branch, or
+// "" if none exists. TASK-359 Layer 1 (Shape C): lets the executor skip opening
+// a duplicate PR for work that is already merged. It uses the gh CLI — the same
+// dependency CreatePR already relies on — so the executor needs no github.Client
+// wiring (the merge-detection API lives only on *github.Client).
+func (g *GitOperations) FindMergedPRByBranch(ctx context.Context, branch string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "list",
+		"--head", branch,
+		"--state", "merged",
+		"--json", "url",
+		"--limit", "1",
+	)
+	cmd.Dir = g.projectPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to list merged PRs for %s: %w: %s", branch, err, output)
+	}
+	return parseFirstPRURL(output), nil
+}
+
+// parseFirstPRURL extracts the first "url" field from `gh pr list --json url`
+// output (a JSON array like [{"url":"https://github.com/o/r/pull/1"}]). Returns
+// "" for an empty array or unparseable input.
+func parseFirstPRURL(jsonOutput []byte) string {
+	var prs []struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(jsonOutput, &prs); err != nil {
+		return ""
+	}
+	if len(prs) == 0 {
+		return ""
+	}
+	return prs[0].URL
 }
 
 // GetCurrentBranch returns the current branch name

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1264,6 +1264,118 @@ func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, err
 	return r.executeWithOptions(ctx, task, true)
 }
 
+// finalizeEpicBranchPR runs the epic parent's push → PR-create finalization with
+// the SAME error contract as the direct path (executeWithOptions ~runner.go:3336):
+// any non-recoverable failure sets result.Success=false (Shape A), and an
+// already-merged branch short-circuits PR creation (Shape C). TASK-359 Layer 1.
+//
+// Before TASK-359 this logic was inline and warn-only: a push or PR-create
+// failure logged a warning and continued, leaving epicResult.Success=true. The
+// dispatcher then wrote a "completed" row with an empty pr_url and the issue was
+// stranded open.
+//
+// Ordering mirrors the direct path: the no-commits guard runs BEFORE push, so an
+// epic whose deliverables shipped via child PRs (empty parent branch) is a clean
+// success, while a parent branch carrying real commits MUST push and PR
+// successfully or the epic is reported as failed.
+func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult) {
+	// Determine base branch before the no-commits guard.
+	baseBranch := task.BaseBranch
+	if baseBranch == "" {
+		baseBranch, _ = git.GetDefaultBranch(ctx)
+		if baseBranch == "" {
+			baseBranch = "main"
+		}
+	}
+
+	// GH-2743 / TASK-356 #1: no-commits guard. An orchestrator-only epic worktree
+	// whose HEAD == base HEAD produced no parent-branch deliverable (work, if any,
+	// shipped via child PRs). Skipping PR creation here is a legitimate success —
+	// and we must NOT harvest the (foreign base) SHA in that case.
+	if guardCount, _ := git.CountNewCommits(ctx, baseBranch); guardCount == 0 {
+		r.log.Warn("Epic branch has no commits vs base, skipping PR creation",
+			slog.String("task_id", task.ID),
+			slog.String("base_branch", baseBranch),
+		)
+		r.reportProgress(task.ID, "PR Skipped", 97, "epic branch has no commits relative to base")
+		return
+	}
+
+	r.reportProgress(task.ID, "Creating PR", 96, "Pushing epic branch...")
+
+	// Push the parent branch. TASK-359: a real deliverable that fails to push is a
+	// failure, not an advisory warning (was warn+continue pre-TASK-359 — Shape A).
+	if err := git.Push(ctx, task.Branch); err != nil {
+		// GH-1389: a worktree push may report a chdir error even though the data
+		// reached the remote. Treat the branch existing on the remote as success.
+		if git.RemoteBranchExists(ctx, task.Branch) {
+			r.log.Warn("Epic push reported error but branch exists on remote, continuing",
+				slog.String("task_id", task.ID),
+				slog.String("branch", task.Branch),
+				slog.Any("error", err),
+			)
+		} else {
+			result.Success = false
+			result.Error = fmt.Sprintf("epic branch push failed: %v", err)
+			r.log.Warn("Epic branch push failed",
+				slog.String("task_id", task.ID),
+				slog.String("branch", task.Branch),
+				slog.Any("error", err),
+			)
+			r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+			return
+		}
+	}
+
+	// Parent branch carries real commits — safe to record its HEAD as the epic's
+	// deliverable SHA (no longer the foreign base SHA). TASK-356 #1.
+	if sha, shaErr := git.GetCurrentCommitSHA(ctx); shaErr == nil && sha != "" {
+		result.CommitSHA = sha
+	}
+
+	// TASK-359 Layer 1 (Shape C): if this branch's work is already merged, do not
+	// open a duplicate PR. Record the existing merged PR's URL and finish.
+	if mergedURL, mergedErr := git.FindMergedPRByBranch(ctx, task.Branch); mergedErr == nil && mergedURL != "" {
+		result.PRUrl = mergedURL
+		r.log.Info("Epic branch already merged, skipping duplicate PR",
+			slog.String("task_id", task.ID),
+			slog.String("pr_url", mergedURL),
+		)
+		r.reportProgress(task.ID, "Complete", 100, "epic work already merged")
+		return
+	}
+
+	// Create the parent PR with a GitHub auto-close keyword.
+	epicIssueNum := strings.TrimPrefix(task.ID, "GH-")
+	prBody := fmt.Sprintf("## Summary\n\nAutomated PR created by Pilot for epic task %s.\n\nCloses #%s\n\n## Changes\n\n%s", task.ID, epicIssueNum, task.Description)
+	epicPRTitle := fmt.Sprintf("%s: %s", task.ID, task.Title)
+	prURL, prErr := git.CreatePR(ctx, epicPRTitle, prBody, baseBranch)
+	if prErr != nil {
+		result.Success = false
+		result.Error = fmt.Sprintf("epic PR creation failed: %v", prErr)
+		r.log.Warn("Epic PR creation failed",
+			slog.String("task_id", task.ID),
+			slog.Any("error", prErr),
+		)
+		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		return
+	}
+	result.PRUrl = prURL
+	r.log.Info("Epic PR created", slog.String("pr_url", prURL))
+
+	// TASK-359 Layer 1 invariant: a PR-mode task that finished without a PR URL is
+	// NOT a success (the direct path enforces the same). Guards against CreatePR
+	// returning a non-error empty URL.
+	if task.CreatePR && result.PRUrl == "" {
+		result.Success = false
+		result.Error = "epic finalize produced no PR URL"
+		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		return
+	}
+
+	r.reportProgress(task.ID, "Complete", 100, "Epic completed successfully")
+}
+
 // executeWithOptions is the internal implementation that allows controlling worktree creation.
 // When allowWorktree is false, it skips worktree creation even if configured.
 // This prevents recursive worktree creation in sub-issues and decomposed tasks.
@@ -1587,66 +1699,16 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				}
 
 				if task.CreatePR && task.Branch != "" {
-					epicGit := NewGitOperations(executionPath)
-
-					r.reportProgress(task.ID, "Creating PR", 96, "Pushing epic branch...")
-
-					if err := epicGit.Push(ctx, task.Branch); err != nil {
-						r.log.Warn("Epic branch push failed",
-							slog.String("task_id", task.ID),
-							slog.String("branch", task.Branch),
-							slog.Any("error", err),
-						)
-						// Don't fail the epic — sub-issues may have their own PRs
-					} else {
-						// Determine base branch
-						baseBranch := task.BaseBranch
-						if baseBranch == "" {
-							baseBranch, _ = epicGit.GetDefaultBranch(ctx)
-							if baseBranch == "" {
-								baseBranch = "main"
-							}
-						}
-
-						// GH-2743: no-commits guard for epic PR path.
-						// TASK-356 #1: harvest CommitSHA ONLY after this guard passes. The epic
-						// parent runs in an orchestrator-only worktree whose HEAD == base HEAD,
-						// so reading the SHA before the guard recorded that foreign base SHA as
-						// the epic's CommitSHA — making a no-deliverable epic look "completed"
-						// (a false-positive no-op that hid the loss of the child's real work).
-						if guardCount, _ := epicGit.CountNewCommits(ctx, baseBranch); guardCount == 0 {
-							r.log.Warn("Epic branch has no commits vs base, skipping PR creation",
-								slog.String("task_id", task.ID),
-								slog.String("base_branch", baseBranch),
-							)
-							r.reportProgress(task.ID, "PR Skipped", 97, "epic branch has no commits relative to base")
-							return epicResult, nil
-						}
-
-						// Parent branch carries real commits — safe to record its HEAD as the
-						// epic's deliverable SHA (it is no longer the foreign base SHA).
-						if sha, shaErr := epicGit.GetCurrentCommitSHA(ctx); shaErr == nil && sha != "" {
-							epicResult.CommitSHA = sha
-						}
-
-						// Create PR with GitHub auto-close keyword
-						epicIssueNum := strings.TrimPrefix(task.ID, "GH-")
-						prBody := fmt.Sprintf("## Summary\n\nAutomated PR created by Pilot for epic task %s.\n\nCloses #%s\n\n## Changes\n\n%s", task.ID, epicIssueNum, task.Description)
-						epicPRTitle := fmt.Sprintf("%s: %s", task.ID, task.Title)
-						prURL, prErr := epicGit.CreatePR(ctx, epicPRTitle, prBody, baseBranch)
-						if prErr != nil {
-							r.log.Warn("Epic PR creation failed",
-								slog.String("task_id", task.ID),
-								slog.Any("error", prErr),
-							)
-						} else {
-							epicResult.PRUrl = prURL
-							r.log.Info("Epic PR created", slog.String("pr_url", prURL))
-						}
-					}
+					// TASK-359 Layer 1: route epic finalization through the same error
+					// contract as the direct path (executeWithOptions ~runner.go:3336).
+					// A failed push or PR-create now sets epicResult.Success=false
+					// instead of warn-and-continue, so a stranded epic is never recorded
+					// as a "completed" row with an empty PR (Shape A). A pre-create
+					// merged-work check avoids opening a duplicate PR (Shape C).
+					r.finalizeEpicBranchPR(ctx, task, NewGitOperations(executionPath), epicResult)
+				} else {
+					r.reportProgress(task.ID, "Complete", 100, "Epic completed successfully")
 				}
-
-				r.reportProgress(task.ID, "Complete", 100, "Epic completed successfully")
 				return epicResult, nil
 			}
 		} // else: plan succeeded

--- a/internal/executor/runner_task359_test.go
+++ b/internal/executor/runner_task359_test.go
@@ -1,0 +1,112 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newSilentRunnerTask359() *Runner {
+	return &Runner{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+// initRepoWithCommitTask359 creates a git repo on `main` with one commit and
+// returns its path. No remote is configured, so pushes will fail — which is the
+// point for the push-failure contract test.
+func initRepoWithCommitTask359(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("init\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "initial")
+	return dir
+}
+
+// TestFinalizeEpicBranchPR_PushFailIsFailure is the Shape A regression guard:
+// a parent branch with real commits that fails to push (no reachable remote)
+// MUST mark the epic as failed — not warn-and-continue with Success=true.
+func TestFinalizeEpicBranchPR_PushFailIsFailure(t *testing.T) {
+	dir := initRepoWithCommitTask359(t)
+	runGit(t, dir, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("work\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runGit(t, dir, "add", "f.txt")
+	runGit(t, dir, "commit", "-m", "feature work")
+
+	r := newSilentRunnerTask359()
+	result := &ExecutionResult{TaskID: "GH-1", Success: true, IsEpic: true}
+	task := &Task{ID: "GH-1", Title: "feat: add f", Description: "d", Branch: "feature", BaseBranch: "main", CreatePR: true}
+
+	r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result)
+
+	if result.Success {
+		t.Error("expected Success=false when epic push fails with no remote")
+	}
+	if !strings.Contains(result.Error, "push failed") {
+		t.Errorf("expected push-failed error, got %q", result.Error)
+	}
+	if result.PRUrl != "" {
+		t.Errorf("expected no PR URL on push failure, got %q", result.PRUrl)
+	}
+}
+
+// TestFinalizeEpicBranchPR_NoCommitsIsCleanSuccess verifies the reordered
+// guard: a parent branch with no commits vs base (deliverables shipped via
+// child PRs) is a legitimate success — PR creation is skipped, Success is left
+// untouched, and no foreign SHA is harvested.
+func TestFinalizeEpicBranchPR_NoCommitsIsCleanSuccess(t *testing.T) {
+	dir := initRepoWithCommitTask359(t)
+
+	r := newSilentRunnerTask359()
+	result := &ExecutionResult{TaskID: "GH-2", Success: true, IsEpic: true}
+	task := &Task{ID: "GH-2", Title: "epic", Description: "d", Branch: "main", BaseBranch: "main", CreatePR: true}
+
+	r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result)
+
+	if !result.Success {
+		t.Errorf("expected Success=true for empty parent branch, error=%q", result.Error)
+	}
+	if result.PRUrl != "" {
+		t.Errorf("expected no PR URL, got %q", result.PRUrl)
+	}
+	if result.Error != "" {
+		t.Errorf("expected no error, got %q", result.Error)
+	}
+	if result.CommitSHA != "" {
+		t.Errorf("expected no harvested SHA when guard skips, got %q", result.CommitSHA)
+	}
+}
+
+// TestParseFirstPRURL covers the gh-list JSON parser used by
+// GitOperations.FindMergedPRByBranch (Shape C idempotency).
+func TestParseFirstPRURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"merged PR", `[{"url":"https://github.com/o/r/pull/12"}]`, "https://github.com/o/r/pull/12"},
+		{"empty array", `[]`, ""},
+		{"two entries takes first", `[{"url":"https://github.com/o/r/pull/1"},{"url":"https://github.com/o/r/pull/2"}]`, "https://github.com/o/r/pull/1"},
+		{"garbage", `not json`, ""},
+		{"empty string", ``, ""},
+		{"null", `null`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseFirstPRURL([]byte(tt.in)); got != tt.want {
+				t.Errorf("parseFirstPRURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1205,6 +1205,27 @@ func (s *Store) UpdateExecutionResult(id string, prURL, commitSHA string, durati
 	})
 }
 
+// MarkExecutionCompleted atomically marks an execution completed with its result
+// fields in a single UPDATE. TASK-359 Layer 1: replaces the prior two-call
+// sequence (UpdateExecutionStatus("completed") then UpdateExecutionResult) whose
+// non-atomic gap could leave a 'completed' row with an empty pr_url if the
+// process died between the writes — a row HasCompletedExecution then accepted via
+// its OR-clause, stranding the issue. A single SQLite UPDATE is atomic.
+func (s *Store) MarkExecutionCompleted(id, prURL, commitSHA string, durationMs int64) error {
+	return s.withRetry("MarkExecutionCompleted", func() error {
+		_, err := s.db.Exec(`
+			UPDATE executions
+			SET status = 'completed',
+				pr_url = ?,
+				commit_sha = ?,
+				duration_ms = ?,
+				completed_at = CURRENT_TIMESTAMP
+			WHERE id = ?
+		`, prURL, commitSHA, durationMs, id)
+		return err
+	})
+}
+
 // UpdateExecutionEffort records the resolved effort and complexity levels for a completed execution.
 // Called after execution finishes so cost-by-tier queries can group rows by tier.
 func (s *Store) UpdateExecutionEffort(id, effortLevel, complexityLevel string) error {

--- a/internal/memory/store_task359_test.go
+++ b/internal/memory/store_task359_test.go
@@ -1,0 +1,98 @@
+package memory
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMarkExecutionCompleted verifies the TASK-359 Layer 1 atomic completion
+// write: status, pr_url, commit_sha, and duration_ms are all set in a single
+// UPDATE, and the row is then accepted by HasCompletedExecution.
+func TestMarkExecutionCompleted(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Seed a running execution (no deliverable yet).
+	if err := store.SaveExecution(&Execution{
+		ID:          "exec-1",
+		TaskID:      "GH-100",
+		ProjectPath: "/project",
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	const (
+		prURL = "https://github.com/o/r/pull/7"
+		sha   = "deadbeef"
+		dur   = int64(4321)
+	)
+	if err := store.MarkExecutionCompleted("exec-1", prURL, sha, dur); err != nil {
+		t.Fatalf("MarkExecutionCompleted failed: %v", err)
+	}
+
+	// All four columns must be set in the single write.
+	var (
+		gotStatus, gotPR, gotSHA string
+		gotDur                   int64
+	)
+	row := store.db.QueryRow(
+		`SELECT status, pr_url, commit_sha, duration_ms FROM executions WHERE id = ?`, "exec-1")
+	if err := row.Scan(&gotStatus, &gotPR, &gotSHA, &gotDur); err != nil {
+		t.Fatalf("scan row: %v", err)
+	}
+	if gotStatus != "completed" {
+		t.Errorf("status = %q, want completed", gotStatus)
+	}
+	if gotPR != prURL {
+		t.Errorf("pr_url = %q, want %q", gotPR, prURL)
+	}
+	if gotSHA != sha {
+		t.Errorf("commit_sha = %q, want %q", gotSHA, sha)
+	}
+	if gotDur != dur {
+		t.Errorf("duration_ms = %d, want %d", gotDur, dur)
+	}
+
+	// And it must be recognized as a genuine completion.
+	completed, err := store.HasCompletedExecution("GH-100", "/project")
+	if err != nil {
+		t.Fatalf("HasCompletedExecution failed: %v", err)
+	}
+	if !completed {
+		t.Error("expected HasCompletedExecution=true after MarkExecutionCompleted")
+	}
+}
+
+// TestMarkExecutionCompleted_EmptyPRUrl documents that the atomic write itself
+// does not enforce the PR-URL invariant — that guard lives in the executor's
+// finalize path (TASK-359 Layer 1). A direct-commit completion (commit_sha set,
+// pr_url empty) is still a valid completed row.
+func TestMarkExecutionCompleted_EmptyPRUrl(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-direct",
+		TaskID:      "GH-101",
+		ProjectPath: "/project",
+		Status:      "running",
+	})
+	if err := store.MarkExecutionCompleted("exec-direct", "", "abc123", 10); err != nil {
+		t.Fatalf("MarkExecutionCompleted failed: %v", err)
+	}
+
+	completed, _ := store.HasCompletedExecution("GH-101", "/project")
+	if !completed {
+		t.Error("direct-commit completion (commit_sha set, no pr_url) should still count as completed")
+	}
+}


### PR DESCRIPTION
## TASK-359 Layer 1 — unify epic finalization error contract

**Manual PR — do NOT hand to Pilot.** The daemon runs the exact finalization
path being changed here; same rationale as TASK-320 Layer B2. Human review +
manual merge only.

### Problem

`executor.Runner` had **two finalization paths with divergent error contracts**:

| Path | Push fail | PR-create fail | Returned `Success` |
|---|---|---|---|
| Direct | `Success=false`, return | `Success=false`, return | correct |
| **Epic** | `log.Warn` + continue | `log.Warn` + continue | **always `true`** |

Consequences observed in stage rollouts this cycle:
- **Shape A** — stranded `completed` execution rows with empty `pr_url` (epic pushed but never PR'd, yet reported success).
- **Shape C** — duplicate PR created on already-merged work.
- Non-atomic completion write: dispatcher did `UpdateExecutionStatus("completed")` then a separate `UpdateExecutionResult(...)`, so a crash between them left a half-written row.

### Fix

- **`internal/executor/runner.go`** — new `Runner.finalizeEpicBranchPR(ctx, task, git, result)`. Epic block now routes through it, ordered **guard → push → harvest → idempotency → CreatePR → invariant** (mirrors the direct path). Push / PR-create failures now set `result.Success = false` (was warn-and-continue). Invariant: `task.CreatePR && result.PRUrl == "" ⇒ Success=false`.
- **`internal/executor/git.go`** — `GitOperations.FindMergedPRByBranch(ctx, branch)` (shells `gh pr list --head <b> --state merged --json url`) + pure `parseFirstPRURL`. Pre-create short-circuit closes **Shape C** at the source.
- **`internal/memory/store.go`** — `MarkExecutionCompleted(id, prURL, commitSHA, durationMs)`: single atomic `UPDATE` (pattern: `SelfHealExecutionAfterMerge`).
- **`internal/executor/dispatcher.go`** — completion write now calls `MarkExecutionCompleted` (replaces the two non-atomic calls).

### Evidence-based deviations from the original 7-step spec

1. `FindMergedPRByBranch` was **not** on `GitOperations` (it lived on `*github.Client`) → added a `gh`-CLI helper to `GitOperations`.
2. Full direct-path *extraction* (Step 2) would need 4 extra params and rewire the daemon hot path for **no correctness gain** → took the **mirror** approach: kept the (already-correct) direct path intact, added a matching-contract epic finalizer. Lower regression risk, same single-error-contract outcome.
3. Step 7 (tighten `HasCompletedExecution` to require `pr_url`) **deferred** — it breaks direct-commit-to-main rows and `TestTaskCompletionInvariant`. Layer 1's new invariant + atomic write already prevent the bad row **at the source**. Tracked as a defense-in-depth follow-up (`is_direct_commit` column).

### Verification (all green, post-rebase onto current `main`)

- `go build ./...` ✓
- `go test ./internal/executor/... ./internal/memory/...` ✓
- `go vet` ✓ · `gofmt -l` clean ✓ · `golangci-lint run` → 0 issues ✓
- New tests: `TestFinalizeEpicBranchPR_{PushFailIsFailure,NoCommitsIsCleanSuccess}`, `TestParseFirstPRURL`, `TestMarkExecutionCompleted{,_EmptyPRUrl}`.
- Existing `TestTaskCompletionInvariant` + `TestIsTaskShipped` still pass (`HasCompletedExecution` untouched).

Refs: TASK-359 (Layer 1), supersedes the dispatch-idempotency / no-op-guard symptom in TASK-321.
