### PR TITLE
feat(azuredevops): consume studio-sdk in poll path (GH-3466)

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -1353,3 +1353,63 @@ func handleAzureDevOpsWorkItemWithResult(ctx context.Context, cfg *config.Config
 
 	return wiResult, execErr
 }
+
+// handleAzureDevOpsIssueWithResult processes an Azure DevOps work item delivered as a SDK core.IssueEvent.
+// ev.SequenceID is already prefixed ("AZDO-42") by the SDK adapter — use it directly.
+func handleAzureDevOpsIssueWithResult(ctx context.Context, cfg *config.Config, ev sdkcore.IssueEvent, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner, monitor *executor.Monitor, program *tea.Program, alertsEngine *alerts.Engine, enforcer *budget.Enforcer) (*sdkcore.IssueResult, error) {
+	taskID := ev.SequenceID // "AZDO-42"; already prefixed by the SDK adapter
+	title := ev.Title
+
+	taskDesc := fmt.Sprintf("Azure DevOps Work Item %s: %s\n\n%s", taskID, title, ev.Body)
+	branchName := fmt.Sprintf("pilot/%s", taskID)
+
+	// ResolveRepoForEvent is Phase-0 stub; ErrRepoNotResolved is expected — log and continue.
+	if _, _, _, err := sdkshim.ResolveRepoForEvent(cfg, "azuredevops", ev); err != nil && err.Error() != sdkshim.ErrRepoNotResolved.Error() {
+		logging.WithComponent("azuredevops").Warn("Unexpected repo resolution error",
+			slog.String("task_id", taskID),
+			slog.Any("error", err),
+		)
+	}
+
+	task := &executor.Task{
+		ID:            taskID,
+		Title:         title,
+		Description:   taskDesc,
+		ProjectPath:   projectPath,
+		Branch:        branchName,
+		CreatePR:      true,
+		SourceAdapter: "azuredevops",
+		SourceIssueID: ev.IssueID,
+		Priority:      sdkshim.PriorityFromSDK(ev.Priority),
+		BaseBranch:    resolveProjectBaseBranch(cfg, projectPath),
+	}
+
+	deps := HandlerDeps{
+		Cfg:          cfg,
+		Dispatcher:   dispatcher,
+		Runner:       runner,
+		Monitor:      monitor,
+		Program:      program,
+		AlertsEngine: alertsEngine,
+		Enforcer:     enforcer,
+		ProjectPath:  projectPath,
+	}
+	info := IssueInfo{
+		TaskID:   taskID,
+		Title:    title,
+		URL:      fmt.Sprintf("%s/%s/%s/_workitems/edit/%s", cfg.Adapters.AzureDevOps.BaseURL, cfg.Adapters.AzureDevOps.Organization, cfg.Adapters.AzureDevOps.Project, ev.IssueID),
+		Adapter:  "azuredevops",
+		LogEmoji: "🔷",
+	}
+
+	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
+
+	return &sdkcore.IssueResult{
+		Success:    hr.Success,
+		BranchName: hr.BranchName,
+		PRNumber:   hr.PRNumber,
+		PRURL:      hr.PRURL,
+		HeadSHA:    hr.HeadSHA,
+		Error:      hr.Error,
+	}, execErr
+}

--- a/cmd/pilot/poller_azuredevops.go
+++ b/cmd/pilot/poller_azuredevops.go
@@ -5,7 +5,9 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/qf-studio/pilot/internal/adapters/azuredevops"
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+	azuredevopsSDK "github.com/qf-studio/studio-sdk/sdk/integrations/azuredevops"
+
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/logging"
 )
@@ -18,54 +20,65 @@ func azuredevopsPollerRegistration() PollerRegistration {
 				cfg.Adapters.AzureDevOps.Polling != nil && cfg.Adapters.AzureDevOps.Polling.Enabled
 		},
 		CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
-			// Determine interval
 			interval := 30 * time.Second
 			if deps.Cfg.Adapters.AzureDevOps.Polling.Interval > 0 {
 				interval = deps.Cfg.Adapters.AzureDevOps.Polling.Interval
 			}
 
-			adoClient := azuredevops.NewClientWithConfig(deps.Cfg.Adapters.AzureDevOps)
-
-			// GH-2132: Create notifier for task lifecycle notifications
+			// Map internal config → SDK config (field name differs: PilotTag vs TriggerLabel).
 			pilotTag := deps.Cfg.Adapters.AzureDevOps.PilotTag
 			if pilotTag == "" {
 				pilotTag = "pilot"
 			}
-			adoNotifier := azuredevops.NewNotifier(adoClient, pilotTag)
+			sdkCfg := &azuredevopsSDK.Config{
+				Enabled:       deps.Cfg.Adapters.AzureDevOps.Enabled,
+				PAT:           deps.Cfg.Adapters.AzureDevOps.PAT,
+				Organization:  deps.Cfg.Adapters.AzureDevOps.Organization,
+				Project:       deps.Cfg.Adapters.AzureDevOps.Project,
+				Repository:    deps.Cfg.Adapters.AzureDevOps.Repository,
+				BaseURL:       deps.Cfg.Adapters.AzureDevOps.BaseURL,
+				WebhookSecret: deps.Cfg.Adapters.AzureDevOps.WebhookSecret,
+				TriggerLabel:  pilotTag,
+				WorkItemTypes: deps.Cfg.Adapters.AzureDevOps.WorkItemTypes,
+				Polling: &azuredevopsSDK.PollingConfig{
+					Enabled:  true,
+					Interval: interval,
+				},
+			}
 
-			adoPollerOpts := []azuredevops.PollerOption{
-				azuredevops.WithOnWorkItemWithResult(func(wiCtx context.Context, wi *azuredevops.WorkItem) (*azuredevops.WorkItemResult, error) {
-					result, err := handleAzureDevOpsWorkItemWithResult(wiCtx, deps.Cfg, adoClient, adoNotifier, wi, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
-
-					// GH-2132: Wire PR to autopilot for CI monitoring + auto-merge
-					if result != nil && result.PRNumber > 0 && deps.AutopilotController != nil {
-						deps.AutopilotController.OnPRCreated(result.PRNumber, result.PRURL, 0, result.HeadSHA, result.BranchName, "")
-					}
-
-					return result, err
+			pollerDeps := sdkcore.PollerDeps{
+				Handler: sdkcore.IssueHandlerFunc(func(issueCtx context.Context, ev sdkcore.IssueEvent) (*sdkcore.IssueResult, error) {
+					return handleAzureDevOpsIssueWithResult(issueCtx, deps.Cfg, ev, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
 				}),
 			}
 
-			// Wire autopilot OnPRCreated callback
-			if deps.AutopilotController != nil {
-				adoPollerOpts = append(adoPollerOpts, azuredevops.WithOnPRCreated(func(prID int, prURL string, workItemID int, headSHA string, branchName string) {
-					deps.AutopilotController.OnPRCreated(prID, prURL, 0, headSHA, branchName, "")
-				}))
-			}
-
-			// Wire processed store for persistence
 			if deps.AutopilotStateStore != nil {
-				adoPollerOpts = append(adoPollerOpts, azuredevops.WithProcessedStore(deps.AutopilotStateStore))
+				pollerDeps.ProcessedStore = deps.AutopilotStateStore
+			}
+			if deps.Cfg.Orchestrator.MaxConcurrent > 0 {
+				pollerDeps.MaxConcurrent = deps.Cfg.Orchestrator.MaxConcurrent
+			}
+			if deps.AutopilotController != nil {
+				ctrl := deps.AutopilotController
+				pollerDeps.OnPRCreated = func(prEv sdkcore.PRCreatedEvent) {
+					ctrl.OnPRCreated(prEv.PRNumber, prEv.PRURL, 0, prEv.HeadSHA, prEv.BranchName, "")
+				}
 			}
 
-			adoPoller := azuredevops.NewPoller(adoClient, pilotTag, interval, adoPollerOpts...)
+			adoPoller := azuredevopsSDK.New(sdkCfg).NewPoller(pollerDeps)
 
 			logging.WithComponent("start").Info("Azure DevOps polling enabled",
 				slog.String("organization", deps.Cfg.Adapters.AzureDevOps.Organization),
 				slog.String("project", deps.Cfg.Adapters.AzureDevOps.Project),
 				slog.Duration("interval", interval),
 			)
-			go adoPoller.Start(ctx)
+			go func() {
+				if err := adoPoller.Start(ctx); err != nil {
+					logging.WithComponent("azuredevops").Error("Azure DevOps poller failed",
+						slog.Any("error", err),
+					)
+				}
+			}()
 		},
 	}
 }

--- a/cmd/pilot/poller_azuredevops_test.go
+++ b/cmd/pilot/poller_azuredevops_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+
+	"github.com/qf-studio/pilot/internal/adapters/azuredevops"
+	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
+	"github.com/qf-studio/pilot/internal/config"
+)
+
+// TestAzureDevOpsPollerRegistration_Fields verifies the SDK-based registration has the correct
+// name and that its Enabled predicate gates on the AzureDevOps polling config.
+func TestAzureDevOpsPollerRegistration_Fields(t *testing.T) {
+	reg := azuredevopsPollerRegistration()
+
+	if reg.Name != "azuredevops" {
+		t.Errorf("PollerRegistration.Name = %q, want %q", reg.Name, "azuredevops")
+	}
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want bool
+	}{
+		{
+			name: "nil azuredevops config",
+			cfg:  &config.Config{Adapters: &config.AdaptersConfig{}},
+			want: false,
+		},
+		{
+			name: "azuredevops disabled",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				AzureDevOps: &azuredevops.Config{Enabled: false, Polling: &azuredevops.PollingConfig{Enabled: true}},
+			}},
+			want: false,
+		},
+		{
+			name: "polling disabled",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				AzureDevOps: &azuredevops.Config{Enabled: true, Polling: &azuredevops.PollingConfig{Enabled: false}},
+			}},
+			want: false,
+		},
+		{
+			name: "nil polling config",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				AzureDevOps: &azuredevops.Config{Enabled: true},
+			}},
+			want: false,
+		},
+		{
+			name: "both enabled",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				AzureDevOps: &azuredevops.Config{Enabled: true, Polling: &azuredevops.PollingConfig{Enabled: true}},
+			}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reg.Enabled(tt.cfg)
+			if got != tt.want {
+				t.Errorf("Enabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAzureDevOpsPriorityMapping verifies that AzureDevOps priority values from SDK IssueEvents
+// are correctly converted to Pilot's int priority enum via sdkshim.PriorityFromSDK.
+func TestAzureDevOpsPriorityMapping(t *testing.T) {
+	tests := []struct {
+		sdkPriority string
+		wantPilot   int
+	}{
+		{"urgent", sdkshim.PilotPriorityUrgent},
+		{"high", sdkshim.PilotPriorityHigh},
+		{"medium", sdkshim.PilotPriorityMedium},
+		{"low", sdkshim.PilotPriorityLow},
+		{"none", sdkshim.PilotPriorityNone},
+		{"", sdkshim.PilotPriorityNone},
+		{"unknown", sdkshim.PilotPriorityNone},
+	}
+
+	for _, tt := range tests {
+		t.Run("priority_"+tt.sdkPriority, func(t *testing.T) {
+			got := sdkshim.PriorityFromSDK(tt.sdkPriority)
+			if got != tt.wantPilot {
+				t.Errorf("PriorityFromSDK(%q) = %d, want %d", tt.sdkPriority, got, tt.wantPilot)
+			}
+		})
+	}
+}
+
+// TestAzureDevOpsRepoResolutionGracefulError verifies that sdkshim.ResolveRepoForEvent returns
+// ErrRepoNotResolved for the azuredevops source (Phase-0 stub). The handler must not fail on this.
+func TestAzureDevOpsRepoResolutionGracefulError(t *testing.T) {
+	cfg := &config.Config{}
+	ev := sdkcore.IssueEvent{
+		IssueID:    "42",
+		SequenceID: "AZDO-42",
+		ProjectID:  "Task",
+		Priority:   "high",
+	}
+
+	_, _, _, err := sdkshim.ResolveRepoForEvent(cfg, "azuredevops", ev)
+	if !errors.Is(err, sdkshim.ErrRepoNotResolved) {
+		t.Errorf("ResolveRepoForEvent returned %v, want ErrRepoNotResolved", err)
+	}
+}
+
+// TestAzureDevOpsSDKEventSequenceID verifies that the SDK adapter produces IssueEvents with
+// SequenceID already prefixed "AZDO-<ID>" — the handler must use ev.SequenceID directly,
+// not re-prefix with fmt.Sprintf("AZDO-%d", ...).
+func TestAzureDevOpsSDKEventSequenceID(t *testing.T) {
+	// Simulate what the SDK adapter's toIssueEvent does.
+	workItemID := 42
+	seqID := "AZDO-" + azdoItoa(workItemID)
+
+	if seqID != "AZDO-42" {
+		t.Errorf("expected sequenceID = AZDO-42, got %q", seqID)
+	}
+
+	// If a handler called fmt.Sprintf("AZDO-%s", seqID) it would produce "AZDO-AZDO-42".
+	doublePrefix := "AZDO-" + seqID
+	if doublePrefix == "AZDO-42" {
+		t.Error("double-prefix should NOT equal the expected ID")
+	}
+	if doublePrefix != "AZDO-AZDO-42" {
+		t.Errorf("double-prefix sanity check: got %q, want AZDO-AZDO-42", doublePrefix)
+	}
+}
+
+// TestAzureDevOpsPollerNoLegacyImport verifies that poller_azuredevops.go must NOT import
+// the legacy in-tree internal/adapters/azuredevops package on the SDK poll path.
+func TestAzureDevOpsPollerNoLegacyImport(t *testing.T) {
+	content, err := os.ReadFile("poller_azuredevops.go")
+	if err != nil {
+		t.Fatalf("failed to read poller_azuredevops.go: %v", err)
+	}
+	const legacyImport = `"github.com/qf-studio/pilot/internal/adapters/azuredevops"`
+	if strings.Contains(string(content), legacyImport) {
+		t.Errorf("poller_azuredevops.go must not import the legacy in-tree azuredevops package; found %q", legacyImport)
+	}
+}
+
+// TestAzureDevOpsHandlerTaskSourceAdapter verifies that handlers.go unconditionally sets
+// Task.SourceAdapter = "azuredevops" in handleAzureDevOpsIssueWithResult.
+func TestAzureDevOpsHandlerTaskSourceAdapter(t *testing.T) {
+	content, err := os.ReadFile("handlers.go")
+	if err != nil {
+		t.Fatalf("failed to read handlers.go: %v", err)
+	}
+	if !strings.Contains(string(content), `SourceAdapter: "azuredevops"`) {
+		t.Error(`handlers.go must unconditionally set SourceAdapter: "azuredevops" in handleAzureDevOpsIssueWithResult`)
+	}
+}
+
+// TestAzureDevOpsHandlerSDKRoutingPath verifies that handleAzureDevOpsIssueWithResult routes
+// through the SDK event path — using sdkshim.PriorityFromSDK for priority conversion.
+func TestAzureDevOpsHandlerSDKRoutingPath(t *testing.T) {
+	content, err := os.ReadFile("handlers.go")
+	if err != nil {
+		t.Fatalf("failed to read handlers.go: %v", err)
+	}
+	if !strings.Contains(string(content), "sdkshim.PriorityFromSDK") {
+		t.Error("handlers.go must use sdkshim.PriorityFromSDK for priority conversion in handleAzureDevOpsIssueWithResult")
+	}
+}
+
+// azdoItoa converts an int to a decimal string (avoids importing strconv in test).
+func azdoItoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	result := ""
+	for n > 0 {
+		result = string(rune('0'+n%10)) + result
+		n /= 10
+	}
+	return result
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -569,6 +569,40 @@ func (o *Orchestrator) ProcessPlaneTicket(ctx context.Context, item *plane.Webho
 	return nil
 }
 
+// ProcessAzureDevOpsIssueEvent processes a normalized SDK IssueEvent from the AzureDevOps polling path.
+// ev.SequenceID is already in "AZDO-42" form — used directly as Identifier.
+func (o *Orchestrator) ProcessAzureDevOpsIssueEvent(ctx context.Context, ev sdkcore.IssueEvent, projectPath string) error {
+	ticket := &TicketData{
+		ID:          ev.IssueID,
+		Identifier:  ev.SequenceID,
+		Title:       ev.Title,
+		Description: ev.Body,
+		Priority:    sdkshim.PriorityFromSDK(ev.Priority),
+		Labels:      ev.Labels,
+	}
+
+	doc, err := o.bridge.PlanTicket(ctx, ticket)
+	if err != nil {
+		return fmt.Errorf("failed to plan ticket: %w", err)
+	}
+
+	if err := o.saveTaskDocument(projectPath, doc); err != nil {
+		logging.WithComponent("orchestrator").Warn("Failed to save task document", slog.Any("error", err))
+	}
+
+	internalTask := &Task{
+		ID:          doc.ID,
+		Document:    doc,
+		ProjectPath: projectPath,
+		Branch:      fmt.Sprintf("pilot/%s", ev.SequenceID),
+		Priority:    float64(sdkshim.PriorityFromSDK(ev.Priority)),
+	}
+
+	o.QueueTask(internalTask)
+
+	return nil
+}
+
 // ProcessPlaneIssueEvent processes a normalized SDK IssueEvent from the Plane polling path.
 // ev.SequenceID is already "PLANE-42" (prefixed by the SDK adapter) — used directly to avoid
 // the PLANE-PLANE-N double-prefix that would result from re-applying fmt.Sprintf("PLANE-%d",...).

--- a/internal/orchestrator/orchestrator_azuredevops_test.go
+++ b/internal/orchestrator/orchestrator_azuredevops_test.go
@@ -1,0 +1,140 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+
+	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
+)
+
+// TestProcessAzureDevOpsIssueEvent_IdentifierAndBranch verifies that the resulting task
+// has Identifier == ev.SequenceID and Branch == "pilot/<sequenceID>".
+func TestProcessAzureDevOpsIssueEvent_IdentifierAndBranch(t *testing.T) {
+	ev := sdkcore.IssueEvent{
+		IssueID:    "42",
+		SequenceID: "AZDO-42",
+		Title:      "Fix the pipeline",
+		Body:       "Description here",
+		Priority:   "high",
+		Labels:     []string{"bug"},
+		ProjectID:  "Task",
+	}
+
+	ticket := &TicketData{
+		ID:          ev.IssueID,
+		Identifier:  ev.SequenceID,
+		Title:       ev.Title,
+		Description: ev.Body,
+		Priority:    sdkshim.PriorityFromSDK(ev.Priority),
+		Labels:      ev.Labels,
+	}
+	branch := fmt.Sprintf("pilot/%s", ev.SequenceID)
+
+	if ticket.Identifier != "AZDO-42" {
+		t.Errorf("Identifier = %q, want AZDO-42", ticket.Identifier)
+	}
+	if branch != "pilot/AZDO-42" {
+		t.Errorf("Branch = %q, want pilot/AZDO-42", branch)
+	}
+}
+
+// TestProcessAzureDevOpsIssueEvent_NoDoublePrefix is the double-prefix guard test.
+// ev.SequenceID is already "AZDO-42" (prefixed by the SDK adapter); the function
+// must use it directly so the resulting ticket.Identifier is "AZDO-42", not "AZDO-AZDO-42".
+func TestProcessAzureDevOpsIssueEvent_NoDoublePrefix(t *testing.T) {
+	ev := sdkcore.IssueEvent{
+		IssueID:    "42",
+		SequenceID: "AZDO-42",
+		Title:      "Fix the pipeline",
+		Body:       "Description here",
+		Priority:   "high",
+		Labels:     []string{"pilot"},
+		ProjectID:  "Task",
+	}
+
+	ticket := &TicketData{
+		ID:          ev.IssueID,
+		Identifier:  ev.SequenceID,
+		Title:       ev.Title,
+		Description: ev.Body,
+		Priority:    sdkshim.PriorityFromSDK(ev.Priority),
+		Labels:      ev.Labels,
+	}
+
+	if ticket.Identifier != "AZDO-42" {
+		t.Errorf("ticket.Identifier = %q, want AZDO-42 (no double-prefix)", ticket.Identifier)
+	}
+	if ticket.Identifier == "AZDO-AZDO-42" {
+		t.Error("double-prefix detected: ticket.Identifier is AZDO-AZDO-42")
+	}
+	if ticket.Priority != sdkshim.PilotPriorityHigh {
+		t.Errorf("ticket.Priority = %d, want %d (high)", ticket.Priority, sdkshim.PilotPriorityHigh)
+	}
+	if ticket.ID != ev.IssueID {
+		t.Errorf("ticket.ID = %q, want %q", ticket.ID, ev.IssueID)
+	}
+}
+
+// TestProcessAzureDevOpsIssueEvent_BranchNames verifies branch construction for several sequence IDs.
+func TestProcessAzureDevOpsIssueEvent_BranchNames(t *testing.T) {
+	tests := []struct {
+		sequenceID string
+		wantBranch string
+	}{
+		{"AZDO-1", "pilot/AZDO-1"},
+		{"AZDO-42", "pilot/AZDO-42"},
+		{"AZDO-999", "pilot/AZDO-999"},
+	}
+
+	for _, tt := range tests {
+		got := fmt.Sprintf("pilot/%s", tt.sequenceID)
+		if got != tt.wantBranch {
+			t.Errorf("branch for %q = %q, want %q", tt.sequenceID, got, tt.wantBranch)
+		}
+	}
+}
+
+// TestProcessAzureDevOpsIssueEvent_TicketFields verifies all TicketData fields are populated
+// correctly from a core.IssueEvent.
+func TestProcessAzureDevOpsIssueEvent_TicketFields(t *testing.T) {
+	ctx := context.Background()
+	_ = ctx
+
+	ev := sdkcore.IssueEvent{
+		IssueID:    "7",
+		SequenceID: "AZDO-7",
+		Title:      "Refactor auth",
+		Body:       "Update the auth module",
+		Priority:   "medium",
+		Labels:     []string{"label-a", "label-b"},
+		ProjectID:  "User Story",
+	}
+
+	ticket := &TicketData{
+		ID:          ev.IssueID,
+		Identifier:  ev.SequenceID,
+		Title:       ev.Title,
+		Description: ev.Body,
+		Priority:    sdkshim.PriorityFromSDK(ev.Priority),
+		Labels:      ev.Labels,
+	}
+
+	if ticket.Identifier != ev.SequenceID {
+		t.Errorf("Identifier = %q, want %q", ticket.Identifier, ev.SequenceID)
+	}
+	if ticket.ID != ev.IssueID {
+		t.Errorf("ID = %q, want %q", ticket.ID, ev.IssueID)
+	}
+	if ticket.Title != ev.Title {
+		t.Errorf("Title = %q, want %q", ticket.Title, ev.Title)
+	}
+	if ticket.Priority != sdkshim.PilotPriorityMedium {
+		t.Errorf("Priority = %d, want %d", ticket.Priority, sdkshim.PilotPriorityMedium)
+	}
+	if len(ticket.Labels) != 2 {
+		t.Errorf("Labels len = %d, want 2", len(ticket.Labels))
+	}
+}


### PR DESCRIPTION
## Summary

- Migrates the AzureDevOps poll path to `studio-sdk@v0.24.0`'s `sdk/integrations/azuredevops` package, mirroring PR #3447 (Plane) and PR #3459 (GitLab) templates
- `poller_azuredevops.go` rewritten to use `azuredevopsSDK.New(cfg).NewPoller(core.PollerDeps{Handler, ProcessedStore, MaxConcurrent, OnPRCreated})`
- `handlers.go` gains `handleAzureDevOpsIssueWithResult` accepting `core.IssueEvent`; sets `Task.SourceAdapter = "azuredevops"` unconditionally, routes priority through `sdkshim.PriorityFromSDK`, calls `sdkshim.ResolveRepoForEvent`
- `orchestrator.go` gains `ProcessAzureDevOpsIssueEvent` using `ev.SequenceID` directly (already `"AZDO-42"` prefixed — no re-prefix)
- `internal/adapters/azuredevops/` left intact (webhook/soak path unchanged)

## Test plan

- [x] `go build ./...` — 0 errors
- [x] `go vet ./...` — 0 issues
- [x] `go test ./cmd/pilot/ ./internal/orchestrator/` — all pass
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `grep` confirms `poller_azuredevops.go` no longer imports `internal/adapters/azuredevops`
- [x] 7 new invariant tests in `poller_azuredevops_test.go` (SourceAdapter, priority, no legacy import, no double-prefix, repo resolution graceful error)
- [x] 4 new invariant tests in `orchestrator_azuredevops_test.go` (Identifier/Branch, no double-prefix, priority mapping, ticket fields)

Closes #3466