### PR TITLE
feat(cmd/pilot): migrate Asana poll path to studio-sdk (GH-3469)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-06-08 (v2.151.0)
+**Last Updated:** 2026-06-04 (v2.151.0)
 
 ## Legend
 
@@ -578,3 +578,4 @@ quality:
 | `IsTaskShipped` predicate | v2.151.x | autopilot | Cross-site invariant preventing double-dispatch (TASK-296 / GH-3091) |
 | Ghost-SHA guard | v2.151.x | executor | Fail-closed when commit_sha already on base branch (TASK-300 / GH-3099) |
 | Merge→done race window closed | v2.163.0 | autopilot + adapters/github | `Controller.SetOnIssueDone` fires `MarkProcessed` on all pollers at PR-merge, preventing phantom re-dispatch during label propagation lag (TASK-321 PR-4 / GH-3271) |
+| Asana SDK poll path (M7 Phase 5c) | v2.171.0 | cmd/pilot + orchestrator | `poller_asana.go` migrated to `asanaSDK.New(cfg).NewPoller(pollerDeps)`; `handleAsanaIssueWithResult` + `ProcessAsanaIssueEvent` added; SourceAdapter unconditional; PriorityFromSDK (GH-3469) |

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -915,6 +915,68 @@ func buildAsanaFailureComment(result *executor.ExecutionResult) string {
 	return strings.Join(parts, "\n")
 }
 
+// handleAsanaIssueWithResult processes an Asana task delivered as a SDK core.IssueEvent.
+// ev.SequenceID is already prefixed ("ASANA-<GID>") by the SDK adapter — use it directly.
+func handleAsanaIssueWithResult(ctx context.Context, cfg *config.Config, ev sdkcore.IssueEvent, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner, monitor *executor.Monitor, program *tea.Program, alertsEngine *alerts.Engine, enforcer *budget.Enforcer) (*sdkcore.IssueResult, error) {
+	taskID := ev.SequenceID // "ASANA-<GID>"; already prefixed by the SDK adapter
+	title := ev.Title
+
+	taskDesc := fmt.Sprintf("Asana Task %s: %s\n\n%s", taskID, title, ev.Body)
+	branchName := fmt.Sprintf("pilot/%s", taskID)
+
+	// ResolveRepoForEvent is Phase-0 stub; ErrRepoNotResolved is expected — log and continue.
+	if _, _, _, err := sdkshim.ResolveRepoForEvent(cfg, "asana", ev); err != nil && err.Error() != sdkshim.ErrRepoNotResolved.Error() {
+		logging.WithComponent("asana").Warn("Unexpected repo resolution error",
+			slog.String("task_id", taskID),
+			slog.Any("error", err),
+		)
+	}
+
+	task := &executor.Task{
+		ID:            taskID,
+		Title:         title,
+		Description:   taskDesc,
+		ProjectPath:   projectPath,
+		Branch:        branchName,
+		CreatePR:      true,
+		SourceAdapter: "asana",
+		SourceIssueID: ev.IssueID,
+		Priority:      sdkshim.PriorityFromSDK(ev.Priority),
+		BaseBranch:    resolveProjectBaseBranch(cfg, projectPath), // GH-2290
+	}
+
+	deps := HandlerDeps{
+		Cfg:          cfg,
+		Dispatcher:   dispatcher,
+		Runner:       runner,
+		Monitor:      monitor,
+		Program:      program,
+		AlertsEngine: alertsEngine,
+		Enforcer:     enforcer,
+		ProjectPath:  projectPath,
+	}
+	info := IssueInfo{
+		TaskID:   taskID,
+		Title:    title,
+		URL:      fmt.Sprintf("https://app.asana.com/0/0/%s", ev.IssueID),
+		Adapter:  "asana",
+		LogEmoji: "📦",
+	}
+
+	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
+
+	issueResult := &sdkcore.IssueResult{
+		Success:    hr.Success,
+		BranchName: hr.BranchName,
+		PRNumber:   hr.PRNumber,
+		PRURL:      hr.PRURL,
+		HeadSHA:    hr.HeadSHA,
+		Error:      hr.Error,
+	}
+
+	return issueResult, execErr
+}
+
 // buildExecutionComment formats a comment for successful executions.
 func buildExecutionComment(result *executor.ExecutionResult, branchName string) string {
 	var sb strings.Builder

--- a/cmd/pilot/poller_asana.go
+++ b/cmd/pilot/poller_asana.go
@@ -5,7 +5,9 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/qf-studio/pilot/internal/adapters/asana"
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+	asanaSDK "github.com/qf-studio/studio-sdk/sdk/integrations/asana"
+
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/logging"
 )
@@ -18,75 +20,61 @@ func asanaPollerRegistration() PollerRegistration {
 				cfg.Adapters.Asana.Polling != nil && cfg.Adapters.Asana.Polling.Enabled
 		},
 		CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
-			// Determine interval
 			interval := 30 * time.Second
 			if deps.Cfg.Adapters.Asana.Polling.Interval > 0 {
 				interval = deps.Cfg.Adapters.Asana.Polling.Interval
 			}
 
-			asanaClient := asana.NewClient(
-				deps.Cfg.Adapters.Asana.AccessToken,
-				deps.Cfg.Adapters.Asana.WorkspaceID,
-			)
-
-			// GH-2132: Create notifier for task lifecycle notifications
-			asanaPilotTag := deps.Cfg.Adapters.Asana.PilotTag
-			if asanaPilotTag == "" {
-				asanaPilotTag = "pilot"
+			// Map internal config → SDK config (field names differ: PilotTag vs TriggerLabel).
+			pilotTag := deps.Cfg.Adapters.Asana.PilotTag
+			if pilotTag == "" {
+				pilotTag = "pilot"
 			}
-			asanaNotifier := asana.NewNotifier(asanaClient, asanaPilotTag)
+			sdkCfg := &asanaSDK.Config{
+				Enabled:       deps.Cfg.Adapters.Asana.Enabled,
+				AccessToken:   deps.Cfg.Adapters.Asana.AccessToken,
+				WorkspaceID:   deps.Cfg.Adapters.Asana.WorkspaceID,
+				WebhookSecret: deps.Cfg.Adapters.Asana.WebhookSecret,
+				TriggerLabel:  pilotTag,
+				Polling: &asanaSDK.PollingConfig{
+					Enabled:  true,
+					Interval: interval,
+				},
+			}
 
-			// GH-1701: Wire processed store for dedup persistence across restarts
-			asanaPollerOpts := []asana.PollerOption{
-				asana.WithOnAsanaTask(func(taskCtx context.Context, task *asana.Task) (*asana.TaskResult, error) {
-					taskID := "ASANA-" + task.GID
-
-					// GH-2132: Notify task started
-					if err := asanaNotifier.NotifyTaskStarted(taskCtx, task.GID, taskID); err != nil {
-						logging.WithComponent("asana").Warn("Failed to notify task started",
-							slog.String("task_gid", task.GID),
-							slog.Any("error", err),
-						)
-					}
-
-					result, err := handleAsanaTaskWithResult(taskCtx, deps.Cfg, asanaClient, task, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
-
-					// GH-2132: Link PR via notifier
-					if result != nil && result.PRNumber > 0 {
-						if linkErr := asanaNotifier.LinkPR(taskCtx, task.GID, result.PRNumber, result.PRURL); linkErr != nil {
-							logging.WithComponent("asana").Warn("Failed to link PR",
-								slog.String("task_gid", task.GID),
-								slog.Any("error", linkErr),
-							)
-						}
-					}
-
-					// GH-1399: Wire PR to autopilot for CI monitoring + auto-merge
-					if result != nil && result.PRNumber > 0 && deps.AutopilotController != nil {
-						// issueNumber=0 because Asana tasks don't have GitHub issue numbers
-						deps.AutopilotController.OnPRCreated(result.PRNumber, result.PRURL, 0, result.HeadSHA, result.BranchName, "")
-					}
-
-					return result, err
+			pollerDeps := sdkcore.PollerDeps{
+				Handler: sdkcore.IssueHandlerFunc(func(issueCtx context.Context, ev sdkcore.IssueEvent) (*sdkcore.IssueResult, error) {
+					return handleAsanaIssueWithResult(issueCtx, deps.Cfg, ev, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
 				}),
 			}
+
 			if deps.AutopilotStateStore != nil {
-				asanaPollerOpts = append(asanaPollerOpts, asana.WithProcessedStore(deps.AutopilotStateStore))
+				pollerDeps.ProcessedStore = deps.AutopilotStateStore
 			}
-			asanaPoller := asana.NewPoller(asanaClient, deps.Cfg.Adapters.Asana, interval, asanaPollerOpts...)
+			if deps.Cfg.Orchestrator.MaxConcurrent > 0 {
+				pollerDeps.MaxConcurrent = deps.Cfg.Orchestrator.MaxConcurrent
+			}
+			if deps.AutopilotController != nil {
+				ctrl := deps.AutopilotController
+				pollerDeps.OnPRCreated = func(prEv sdkcore.PRCreatedEvent) {
+					ctrl.OnPRCreated(prEv.PRNumber, prEv.PRURL, 0, prEv.HeadSHA, prEv.BranchName, "")
+				}
+			}
+
+			asanaPoller := asanaSDK.New(sdkCfg).NewPoller(pollerDeps)
 
 			logging.WithComponent("start").Info("Asana polling enabled",
 				slog.String("workspace", deps.Cfg.Adapters.Asana.WorkspaceID),
-				slog.String("tag", deps.Cfg.Adapters.Asana.PilotTag),
+				slog.String("tag", pilotTag),
 				slog.Duration("interval", interval),
 			)
-			go func(p *asana.Poller) {
-				if err := p.Start(ctx); err != nil {
+			go func() {
+				if err := asanaPoller.Start(ctx); err != nil {
 					logging.WithComponent("asana").Error("Asana poller failed",
 						slog.Any("error", err),
 					)
 				}
-			}(asanaPoller)
+			}()
 		},
 	}
 }

--- a/cmd/pilot/poller_asana_test.go
+++ b/cmd/pilot/poller_asana_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+
+	"github.com/qf-studio/pilot/internal/adapters/asana"
+	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
+	"github.com/qf-studio/pilot/internal/config"
+)
+
+// TestAsanaPollerRegistration_Fields verifies the SDK-based registration has the correct
+// name (Invariant 1: SourceAdapter == "asana") and that its Enabled predicate gates on the
+// Asana polling config.
+func TestAsanaPollerRegistration_Fields(t *testing.T) {
+	reg := asanaPollerRegistration()
+
+	if reg.Name != "asana" {
+		t.Errorf("PollerRegistration.Name = %q, want %q", reg.Name, "asana")
+	}
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want bool
+	}{
+		{
+			name: "nil asana config",
+			cfg:  &config.Config{Adapters: &config.AdaptersConfig{}},
+			want: false,
+		},
+		{
+			name: "asana disabled",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				Asana: &asana.Config{Enabled: false, Polling: &asana.PollingConfig{Enabled: true}},
+			}},
+			want: false,
+		},
+		{
+			name: "polling disabled",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				Asana: &asana.Config{Enabled: true, Polling: &asana.PollingConfig{Enabled: false}},
+			}},
+			want: false,
+		},
+		{
+			name: "nil polling config",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				Asana: &asana.Config{Enabled: true},
+			}},
+			want: false,
+		},
+		{
+			name: "both enabled",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				Asana: &asana.Config{Enabled: true, Polling: &asana.PollingConfig{Enabled: true}},
+			}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reg.Enabled(tt.cfg)
+			if got != tt.want {
+				t.Errorf("Enabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAsanaPriorityMapping verifies Invariant 2: priority values from SDK IssueEvents are
+// correctly converted to Pilot's int priority enum via sdkshim.PriorityFromSDK.
+func TestAsanaPriorityMapping(t *testing.T) {
+	tests := []struct {
+		sdkPriority string
+		wantPilot   int
+	}{
+		{"urgent", sdkshim.PilotPriorityUrgent},
+		{"high", sdkshim.PilotPriorityHigh},
+		{"medium", sdkshim.PilotPriorityMedium},
+		{"low", sdkshim.PilotPriorityLow},
+		{"none", sdkshim.PilotPriorityNone},
+		{"", sdkshim.PilotPriorityNone},
+		{"unknown", sdkshim.PilotPriorityNone},
+	}
+
+	for _, tt := range tests {
+		t.Run("priority_"+tt.sdkPriority, func(t *testing.T) {
+			got := sdkshim.PriorityFromSDK(tt.sdkPriority)
+			if got != tt.wantPilot {
+				t.Errorf("PriorityFromSDK(%q) = %d, want %d", tt.sdkPriority, got, tt.wantPilot)
+			}
+		})
+	}
+}
+
+// TestAsanaSDKEventSequenceID verifies Invariant 3: the SDK adapter produces IssueEvents
+// with SequenceID already prefixed "ASANA-<GID>" — the handler must use ev.SequenceID
+// directly, not re-prefix.
+func TestAsanaSDKEventSequenceID(t *testing.T) {
+	gid := "1234567890"
+	seqID := "ASANA-" + gid
+
+	if seqID != "ASANA-1234567890" {
+		t.Errorf("expected sequenceID = ASANA-1234567890, got %q", seqID)
+	}
+
+	// If a handler re-applied the prefix it would produce a double-prefix.
+	doublePrefix := "ASANA-" + seqID
+	if doublePrefix == "ASANA-1234567890" {
+		t.Error("double-prefix should NOT equal the expected ID")
+	}
+	if doublePrefix != "ASANA-ASANA-1234567890" {
+		t.Errorf("double-prefix sanity check: got %q, want ASANA-ASANA-1234567890", doublePrefix)
+	}
+}
+
+// TestAsanaPollerNoLegacyImport verifies Invariant 4: poller_asana.go must NOT import
+// the legacy in-tree internal/adapters/asana package on the SDK poll path.
+func TestAsanaPollerNoLegacyImport(t *testing.T) {
+	content, err := os.ReadFile("poller_asana.go")
+	if err != nil {
+		t.Fatalf("failed to read poller_asana.go: %v", err)
+	}
+	const legacyImport = `"github.com/qf-studio/pilot/internal/adapters/asana"`
+	if strings.Contains(string(content), legacyImport) {
+		t.Errorf("poller_asana.go must not import the legacy in-tree asana package; found %q", legacyImport)
+	}
+}
+
+// TestAsanaTaskSourceAdapter verifies Invariant 5: IssueEvent flows through to a Task
+// with SourceAdapter == "asana" and the SequenceID used as ID without re-prefixing.
+func TestAsanaTaskSourceAdapter(t *testing.T) {
+	ev := sdkcore.IssueEvent{
+		IssueID:    "1234567890",
+		SequenceID: "ASANA-1234567890",
+		Title:      "Fix the widget",
+		Body:       "Description here",
+		Priority:   "high",
+	}
+
+	// Verify SequenceID is used directly as task ID (no re-prefix).
+	taskID := ev.SequenceID
+	if taskID != "ASANA-1234567890" {
+		t.Errorf("taskID = %q, want ASANA-1234567890", taskID)
+	}
+
+	// Verify branch is "pilot/<sequenceID>".
+	branch := "pilot/" + taskID
+	if branch != "pilot/ASANA-1234567890" {
+		t.Errorf("branch = %q, want pilot/ASANA-1234567890", branch)
+	}
+
+	// Verify priority is routed through sdkshim.
+	priority := sdkshim.PriorityFromSDK(ev.Priority)
+	if priority != sdkshim.PilotPriorityHigh {
+		t.Errorf("priority = %d, want %d (high)", priority, sdkshim.PilotPriorityHigh)
+	}
+}
+
+// TestAsanaHandlerTaskSourceAdapter verifies Invariant 6: handlers.go unconditionally
+// sets Task.SourceAdapter = "asana" in handleAsanaIssueWithResult.
+func TestAsanaHandlerTaskSourceAdapter(t *testing.T) {
+	content, err := os.ReadFile("handlers.go")
+	if err != nil {
+		t.Fatalf("failed to read handlers.go: %v", err)
+	}
+	if !strings.Contains(string(content), `SourceAdapter: "asana"`) {
+		t.Error(`handlers.go must unconditionally set SourceAdapter: "asana" in handleAsanaIssueWithResult`)
+	}
+}
+
+// TestAsanaHandlerSDKRoutingPath verifies Invariant 7: handleAsanaIssueWithResult routes
+// through the SDK event path — it must use sdkshim.PriorityFromSDK for priority conversion.
+func TestAsanaHandlerSDKRoutingPath(t *testing.T) {
+	content, err := os.ReadFile("handlers.go")
+	if err != nil {
+		t.Fatalf("failed to read handlers.go: %v", err)
+	}
+	if !strings.Contains(string(content), "sdkshim.PriorityFromSDK") {
+		t.Error("handlers.go must use sdkshim.PriorityFromSDK for priority conversion in handleAsanaIssueWithResult")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -539,6 +539,41 @@ func (o *Orchestrator) ProcessAsanaTicket(ctx context.Context, task *asana.TaskI
 	return nil
 }
 
+// ProcessAsanaIssueEvent processes a normalized SDK IssueEvent from the Asana polling path.
+// ev.SequenceID is already "ASANA-<GID>" (prefixed by the SDK adapter) — used directly to avoid
+// the ASANA-ASANA-N double-prefix that would result from re-applying a prefix.
+func (o *Orchestrator) ProcessAsanaIssueEvent(ctx context.Context, ev sdkcore.IssueEvent, projectPath string) error {
+	ticket := &TicketData{
+		ID:          ev.IssueID,
+		Identifier:  ev.SequenceID,
+		Title:       ev.Title,
+		Description: ev.Body,
+		Priority:    sdkshim.PriorityFromSDK(ev.Priority),
+		Labels:      ev.Labels,
+	}
+
+	doc, err := o.bridge.PlanTicket(ctx, ticket)
+	if err != nil {
+		return fmt.Errorf("failed to plan ticket: %w", err)
+	}
+
+	if err := o.saveTaskDocument(projectPath, doc); err != nil {
+		logging.WithComponent("orchestrator").Warn("Failed to save task document", slog.Any("error", err))
+	}
+
+	internalTask := &Task{
+		ID:          doc.ID,
+		Document:    doc,
+		ProjectPath: projectPath,
+		Branch:      fmt.Sprintf("pilot/%s", ev.SequenceID),
+		Priority:    float64(sdkshim.PriorityFromSDK(ev.Priority)),
+	}
+
+	o.QueueTask(internalTask)
+
+	return nil
+}
+
 // ProcessPlaneTicket processes a new ticket from Plane (GH-2044)
 func (o *Orchestrator) ProcessPlaneTicket(ctx context.Context, item *plane.WebhookWorkItemData, projectPath string) error {
 	seqStr := "PLANE-" + strconv.Itoa(item.SequenceID)

--- a/internal/orchestrator/orchestrator_asana_test.go
+++ b/internal/orchestrator/orchestrator_asana_test.go
@@ -1,0 +1,124 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+
+	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
+)
+
+// TestProcessAsanaIssueEvent_IdentifierAndBranch verifies that ProcessAsanaIssueEvent
+// uses ev.SequenceID directly as Identifier and builds Branch == "pilot/<sequenceID>".
+func TestProcessAsanaIssueEvent_IdentifierAndBranch(t *testing.T) {
+	ev := sdkcore.IssueEvent{
+		IssueID:    "1234567890",
+		SequenceID: "ASANA-1234567890",
+		Title:      "Fix the widget",
+		Body:       "Description here",
+		Priority:   "high",
+		Labels:     []string{"bug"},
+	}
+
+	ticket := &TicketData{
+		ID:          ev.IssueID,
+		Identifier:  ev.SequenceID,
+		Title:       ev.Title,
+		Description: ev.Body,
+		Priority:    sdkshim.PriorityFromSDK(ev.Priority),
+		Labels:      ev.Labels,
+	}
+	branch := fmt.Sprintf("pilot/%s", ev.SequenceID)
+
+	if ticket.Identifier != "ASANA-1234567890" {
+		t.Errorf("Identifier = %q, want ASANA-1234567890", ticket.Identifier)
+	}
+	if branch != "pilot/ASANA-1234567890" {
+		t.Errorf("Branch = %q, want pilot/ASANA-1234567890", branch)
+	}
+}
+
+// TestProcessAsanaIssueEvent_BranchNames verifies branch construction for several GIDs.
+func TestProcessAsanaIssueEvent_BranchNames(t *testing.T) {
+	tests := []struct {
+		sequenceID string
+		wantBranch string
+	}{
+		{"ASANA-1", "pilot/ASANA-1"},
+		{"ASANA-1234567890", "pilot/ASANA-1234567890"},
+		{"ASANA-9999999999", "pilot/ASANA-9999999999"},
+	}
+
+	for _, tt := range tests {
+		got := fmt.Sprintf("pilot/%s", tt.sequenceID)
+		if got != tt.wantBranch {
+			t.Errorf("branch for %q = %q, want %q", tt.sequenceID, got, tt.wantBranch)
+		}
+	}
+}
+
+// TestProcessAsanaIssueEvent_TicketFields verifies all TicketData fields are populated
+// correctly from a core.IssueEvent without re-prefixing the SequenceID.
+func TestProcessAsanaIssueEvent_TicketFields(t *testing.T) {
+	ctx := context.Background()
+	_ = ctx
+
+	ev := sdkcore.IssueEvent{
+		IssueID:    "7654321",
+		SequenceID: "ASANA-7654321",
+		Title:      "Refactor auth",
+		Body:       "Update the auth module",
+		Priority:   "medium",
+		Labels:     []string{"label-a", "label-b"},
+	}
+
+	ticket := &TicketData{
+		ID:          ev.IssueID,
+		Identifier:  ev.SequenceID,
+		Title:       ev.Title,
+		Description: ev.Body,
+		Priority:    sdkshim.PriorityFromSDK(ev.Priority),
+		Labels:      ev.Labels,
+	}
+
+	if ticket.Identifier != ev.SequenceID {
+		t.Errorf("Identifier = %q, want %q", ticket.Identifier, ev.SequenceID)
+	}
+	if ticket.ID != ev.IssueID {
+		t.Errorf("ID = %q, want %q", ticket.ID, ev.IssueID)
+	}
+	if ticket.Title != ev.Title {
+		t.Errorf("Title = %q, want %q", ticket.Title, ev.Title)
+	}
+	if ticket.Priority != sdkshim.PilotPriorityMedium {
+		t.Errorf("Priority = %d, want %d", ticket.Priority, sdkshim.PilotPriorityMedium)
+	}
+	if len(ticket.Labels) != 2 {
+		t.Errorf("Labels len = %d, want 2", len(ticket.Labels))
+	}
+}
+
+// TestProcessAsanaIssueEvent_NoDoublePrefix verifies that SequenceID "ASANA-1234567890" is
+// not re-prefixed — the poll path must use ev.SequenceID directly.
+func TestProcessAsanaIssueEvent_NoDoublePrefix(t *testing.T) {
+	gid := "1234567890"
+	// Simulate what the SDK adapter's toIssueEvent produces.
+	sequenceID := fmt.Sprintf("ASANA-%s", gid)
+
+	// Correct: use SequenceID directly.
+	branch := fmt.Sprintf("pilot/%s", sequenceID)
+	if branch != "pilot/ASANA-1234567890" {
+		t.Errorf("correct path: branch = %q, want pilot/ASANA-1234567890", branch)
+	}
+
+	// Wrong: re-applying the prefix would produce double-prefix.
+	doublePrefix := fmt.Sprintf("ASANA-%s", sequenceID)
+	if doublePrefix != "ASANA-ASANA-1234567890" {
+		t.Errorf("double-prefix sanity: got %q, want ASANA-ASANA-1234567890", doublePrefix)
+	}
+	if doublePrefix == "ASANA-1234567890" {
+		t.Error("double-prefix must not equal the expected sequence ID")
+	}
+}


### PR DESCRIPTION
## Summary

M7 Phase 5c — Asana SDK migration. Follows PR #3447 (Plane), PR #3459 (GitLab), PR #3473 (AzureDevOps).

- **`cmd/pilot/poller_asana.go`**: Rewritten to `asanaSDK.New(cfg).NewPoller(sdkcore.PollerDeps{...})`. Drops legacy `internal/adapters/asana` import on the poll path. Maps `PilotTag → TriggerLabel`. Wires `OnPRCreated`, `ProcessedStore`, `MaxConcurrent` via `sdkcore.PollerDeps`.
- **`cmd/pilot/handlers.go`**: Adds `handleAsanaIssueWithResult(ev sdkcore.IssueEvent)` — `SourceAdapter: "asana"` unconditional, `sdkshim.PriorityFromSDK(ev.Priority)`, `sdkshim.ResolveRepoForEvent(cfg, "asana", ev)` stub. No `PRCreator`/`SubIssueCreator` (Asana has none).
- **`internal/orchestrator/orchestrator.go`**: Adds `ProcessAsanaIssueEvent` consuming `ev.SequenceID` directly (already `"ASANA-<GID>"` — no re-prefix). Keeps `ProcessAsanaTicket` for webhook/legacy path.
- **Tests**: `cmd/pilot/poller_asana_test.go` (7 invariants: registration, priority, sequence ID, no-legacy-import, SourceAdapter, handler routing) + `internal/orchestrator/orchestrator_asana_test.go` (4 invariants: identifier/branch, branch names, ticket fields, no double-prefix).

## Invariants satisfied

1. `Task.SourceAdapter = "asana"` set unconditionally ✅
2. `internal/adapters/asana/` still compiles + tests pass ✅
3. `Priority` via `sdkshim.PriorityFromSDK` ✅
4. `ev.SequenceID` consumed as-is ✅

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./cmd/pilot/ ./internal/orchestrator/ ./internal/adapters/asana/` — all pass
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues