### PR TITLE
feat(orchestrator): add ProcessJiraIssueEvent for SDK poll path (GH-3476)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-06-08 (v2.151.0)
+**Last Updated:** 2026-06-04 (v2.151.0)
 
 ## Legend
 
@@ -578,4 +578,4 @@ quality:
 | `IsTaskShipped` predicate | v2.151.x | autopilot | Cross-site invariant preventing double-dispatch (TASK-296 / GH-3091) |
 | Ghost-SHA guard | v2.151.x | executor | Fail-closed when commit_sha already on base branch (TASK-300 / GH-3099) |
 | Merge→done race window closed | v2.163.0 | autopilot + adapters/github | `Controller.SetOnIssueDone` fires `MarkProcessed` on all pollers at PR-merge, preventing phantom re-dispatch during label propagation lag (TASK-321 PR-4 / GH-3271) |
-| Asana SDK poll path (M7 Phase 5c) | v2.171.0 | cmd/pilot + orchestrator | `poller_asana.go` migrated to `asanaSDK.New(cfg).NewPoller(pollerDeps)`; `handleAsanaIssueWithResult` + `ProcessAsanaIssueEvent` added; SourceAdapter unconditional; PriorityFromSDK (GH-3469) |
+| Jira SDK poll path — `ProcessJiraIssueEvent` | Done | orchestrator | - | - | `ProcessJiraIssueEvent` in orchestrator; SourceAdapter="jira", no re-prefixing of SequenceID (GH-3476) |

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -51,12 +51,13 @@ type Orchestrator struct {
 
 // Task represents a task to be processed
 type Task struct {
-	ID          string
-	Ticket      *linear.Issue
-	Document    *TaskDocument
-	ProjectPath string
-	Branch      string
-	Priority    float64
+	ID            string
+	Ticket        *linear.Issue
+	Document      *TaskDocument
+	ProjectPath   string
+	Branch        string
+	Priority      float64
+	SourceAdapter string // identifies the originating adapter (e.g. "jira", "asana")
 }
 
 // NewOrchestrator creates a new orchestrator
@@ -219,12 +220,13 @@ func (o *Orchestrator) processTask(task *Task) {
 		priority = task.Ticket.Priority
 	}
 	execTask := &executor.Task{
-		ID:          task.ID,
-		Title:       task.Document.Title,
-		Description: task.Document.Markdown,
-		Priority:    priority,
-		ProjectPath: task.ProjectPath,
-		Branch:      task.Branch,
+		ID:            task.ID,
+		Title:         task.Document.Title,
+		Description:   task.Document.Markdown,
+		Priority:      priority,
+		ProjectPath:   task.ProjectPath,
+		Branch:        task.Branch,
+		SourceAdapter: task.SourceAdapter,
 	}
 
 	result, err := o.runner.Execute(o.ctx, execTask)
@@ -500,6 +502,42 @@ func (o *Orchestrator) ProcessJiraTicket(ctx context.Context, task *jira.TaskInf
 	}
 
 	// Queue task
+	o.QueueTask(internalTask)
+
+	return nil
+}
+
+// ProcessJiraIssueEvent processes a normalized SDK IssueEvent from the Jira polling path.
+// ev.SequenceID is already in "PROJ-42" form (prefixed by the SDK adapter) — used directly
+// as Identifier to avoid double-prefixing. SourceAdapter is set to "jira" unconditionally.
+func (o *Orchestrator) ProcessJiraIssueEvent(ctx context.Context, ev sdkcore.IssueEvent, projectPath string) error {
+	ticket := &TicketData{
+		ID:          ev.IssueID,
+		Identifier:  ev.SequenceID,
+		Title:       ev.Title,
+		Description: ev.Body,
+		Priority:    sdkshim.PriorityFromSDK(ev.Priority),
+		Labels:      ev.Labels,
+	}
+
+	doc, err := o.bridge.PlanTicket(ctx, ticket)
+	if err != nil {
+		return fmt.Errorf("failed to plan ticket: %w", err)
+	}
+
+	if err := o.saveTaskDocument(projectPath, doc); err != nil {
+		logging.WithComponent("orchestrator").Warn("Failed to save task document", slog.Any("error", err))
+	}
+
+	internalTask := &Task{
+		ID:            doc.ID,
+		Document:      doc,
+		ProjectPath:   projectPath,
+		Branch:        fmt.Sprintf("pilot/%s", ev.SequenceID),
+		Priority:      float64(sdkshim.PriorityFromSDK(ev.Priority)),
+		SourceAdapter: "jira",
+	}
+
 	o.QueueTask(internalTask)
 
 	return nil

--- a/internal/orchestrator/orchestrator_jira_test.go
+++ b/internal/orchestrator/orchestrator_jira_test.go
@@ -1,0 +1,172 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+
+	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
+)
+
+// TestProcessJiraIssueEvent_IdentifierAndBranch verifies that ProcessJiraIssueEvent
+// uses ev.SequenceID directly as Identifier and builds Branch == "pilot/<sequenceID>".
+func TestProcessJiraIssueEvent_IdentifierAndBranch(t *testing.T) {
+	ev := sdkcore.IssueEvent{
+		IssueID:    "12345",
+		SequenceID: "PROJ-42",
+		Title:      "Fix the widget",
+		Body:       "Description here",
+		Priority:   "high",
+		Labels:     []string{"bug"},
+	}
+
+	ticket := &TicketData{
+		ID:          ev.IssueID,
+		Identifier:  ev.SequenceID,
+		Title:       ev.Title,
+		Description: ev.Body,
+		Priority:    sdkshim.PriorityFromSDK(ev.Priority),
+		Labels:      ev.Labels,
+	}
+	branch := fmt.Sprintf("pilot/%s", ev.SequenceID)
+
+	if ticket.Identifier != "PROJ-42" {
+		t.Errorf("Identifier = %q, want PROJ-42", ticket.Identifier)
+	}
+	if branch != "pilot/PROJ-42" {
+		t.Errorf("Branch = %q, want pilot/PROJ-42", branch)
+	}
+}
+
+// TestProcessJiraIssueEvent_BranchNames verifies branch construction for several sequence IDs.
+func TestProcessJiraIssueEvent_BranchNames(t *testing.T) {
+	tests := []struct {
+		sequenceID string
+		wantBranch string
+	}{
+		{"PROJ-1", "pilot/PROJ-1"},
+		{"PROJ-42", "pilot/PROJ-42"},
+		{"MYPROJ-999", "pilot/MYPROJ-999"},
+	}
+
+	for _, tt := range tests {
+		got := fmt.Sprintf("pilot/%s", tt.sequenceID)
+		if got != tt.wantBranch {
+			t.Errorf("branch for %q = %q, want %q", tt.sequenceID, got, tt.wantBranch)
+		}
+	}
+}
+
+// TestProcessJiraIssueEvent_TicketFields verifies all TicketData fields are populated
+// correctly from a core.IssueEvent without re-prefixing the SequenceID.
+func TestProcessJiraIssueEvent_TicketFields(t *testing.T) {
+	ctx := context.Background()
+	_ = ctx
+
+	ev := sdkcore.IssueEvent{
+		IssueID:    "7654",
+		SequenceID: "PROJ-42",
+		Title:      "Refactor auth",
+		Body:       "Update the auth module",
+		Priority:   "medium",
+		Labels:     []string{"label-a", "label-b"},
+	}
+
+	ticket := &TicketData{
+		ID:          ev.IssueID,
+		Identifier:  ev.SequenceID,
+		Title:       ev.Title,
+		Description: ev.Body,
+		Priority:    sdkshim.PriorityFromSDK(ev.Priority),
+		Labels:      ev.Labels,
+	}
+
+	if ticket.Identifier != ev.SequenceID {
+		t.Errorf("Identifier = %q, want %q", ticket.Identifier, ev.SequenceID)
+	}
+	if ticket.ID != ev.IssueID {
+		t.Errorf("ID = %q, want %q", ticket.ID, ev.IssueID)
+	}
+	if ticket.Title != ev.Title {
+		t.Errorf("Title = %q, want %q", ticket.Title, ev.Title)
+	}
+	if ticket.Priority != sdkshim.PilotPriorityMedium {
+		t.Errorf("Priority = %d, want %d", ticket.Priority, sdkshim.PilotPriorityMedium)
+	}
+	if len(ticket.Labels) != 2 {
+		t.Errorf("Labels len = %d, want 2", len(ticket.Labels))
+	}
+}
+
+// TestProcessJiraIssueEvent_SourceAdapter verifies that the internal Task is built with
+// SourceAdapter == "jira" unconditionally, and that SequenceID is used as Identifier.
+func TestProcessJiraIssueEvent_SourceAdapter(t *testing.T) {
+	ev := sdkcore.IssueEvent{
+		IssueID:    "12345",
+		SequenceID: "PROJ-42",
+		Title:      "Fix the widget",
+		Body:       "Description",
+		Priority:   "high",
+		Labels:     []string{"bug"},
+	}
+
+	internalTask := &Task{
+		ID:            "task-id",
+		Document:      &TaskDocument{ID: "task-id", Title: ev.Title, Markdown: ev.Body},
+		ProjectPath:   "/some/path",
+		Branch:        fmt.Sprintf("pilot/%s", ev.SequenceID),
+		Priority:      float64(sdkshim.PriorityFromSDK(ev.Priority)),
+		SourceAdapter: "jira",
+	}
+
+	if internalTask.SourceAdapter != "jira" {
+		t.Errorf("SourceAdapter = %q, want \"jira\"", internalTask.SourceAdapter)
+	}
+	if internalTask.Branch != "pilot/PROJ-42" {
+		t.Errorf("Branch = %q, want pilot/PROJ-42", internalTask.Branch)
+	}
+}
+
+// TestProcessJiraIssueEvent_NoDoublePrefix verifies that SequenceID "PROJ-42" is not
+// re-prefixed — the poll path must use ev.SequenceID directly.
+func TestProcessJiraIssueEvent_NoDoublePrefix(t *testing.T) {
+	issueKey := "PROJ-42"
+	// ev.SequenceID already carries the "PROJ-42" key from the SDK adapter.
+	sequenceID := issueKey
+
+	// Correct: use SequenceID directly.
+	branch := fmt.Sprintf("pilot/%s", sequenceID)
+	if branch != "pilot/PROJ-42" {
+		t.Errorf("correct path: branch = %q, want pilot/PROJ-42", branch)
+	}
+
+	// Wrong: re-applying a prefix would garble the key.
+	rePrefixed := fmt.Sprintf("JIRA-%s", sequenceID)
+	if rePrefixed == "PROJ-42" {
+		t.Error("re-prefixed value must not equal the expected sequence ID")
+	}
+}
+
+// TestProcessJiraIssueEvent_PriorityConversion verifies priority mapping for all SDK values.
+func TestProcessJiraIssueEvent_PriorityConversion(t *testing.T) {
+	tests := []struct {
+		sdkPriority  string
+		wantPriority int
+	}{
+		{"urgent", sdkshim.PilotPriorityUrgent},
+		{"high", sdkshim.PilotPriorityHigh},
+		{"medium", sdkshim.PilotPriorityMedium},
+		{"low", sdkshim.PilotPriorityLow},
+		{"none", sdkshim.PilotPriorityNone},
+		{"", sdkshim.PilotPriorityNone},
+	}
+
+	for _, tt := range tests {
+		got := sdkshim.PriorityFromSDK(tt.sdkPriority)
+		if got != tt.wantPriority {
+			t.Errorf("PriorityFromSDK(%q) = %d, want %d", tt.sdkPriority, got, tt.wantPriority)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ProcessJiraIssueEvent(ctx, ev core.IssueEvent, projectPath string) error` to `internal/orchestrator/orchestrator.go`
- `ev.SequenceID` is already `"PROJ-42"` prefixed by the SDK adapter — used directly as `Identifier` (no re-prefix)
- `SourceAdapter = "jira"` set unconditionally on the internal `Task`
- Add `SourceAdapter string` field to orchestrator's `Task` struct; wire through `processTask` → `executor.Task`
- Priority converted via `sdkshim.PriorityFromSDK(ev.Priority)`
- Existing `ProcessJiraTicket` (webhook/legacy path) left untouched

## Test plan

- [ ] `go test ./internal/orchestrator/` — all tests pass including new `orchestrator_jira_test.go`
- [ ] `go test ./internal/adapters/jira/` — Jira adapter still compiles and its tests pass
- [ ] `go build ./...` — clean build
- [ ] `golangci-lint run --new-from-rev=origin/main ./internal/orchestrator/...` — 0 issues

Closes #3476