### PR TITLE
feat(adapters/slack): migrate Slack chat to studio-sdk bridge (GH-3471)

### DIFF
--- a/.agent/tasks/gh-3471.md
+++ b/.agent/tasks/gh-3471.md
@@ -1,0 +1,62 @@
+# GH-3471
+
+**Created:** 2026-06-08
+
+## Problem
+
+GitHub Issue #3471: M7 Phase 7: Slack chat — consume studio-sdk chat contract (single PR)
+
+## M7 Phase 7 (Slack chat) — consume `studio-sdk` chat contract (single PR)
+
+Slack chat shim. Simpler than Telegram (no local command parser to delete).
+
+## Refs
+1. **Phase 6 Telegram PR** (recently filed at GH-3470 once it merges) — primary reference
+2. `.agent/research/2026-06-03-m7-integration-plan.md`:
+   - §0.5 chat contract
+   - §1.4 Slack: 232 LOC handler.go, **no local command handler** (Slack already defers to `comms.detectIntent`)
+   - §3 chat shim verdict — same as Telegram
+3. `internal/adapters/sdkshim/chat.go`, `outbound.go` — Phase 0 scaffold
+
+```bash
+go doc github.com/qf-studio/studio-sdk/sdk/integrations/slack
+```
+
+## Scope — IN
+
+### Wire the chat bridge
+- **`cmd/pilot/main.go`** (~main.go:2535 region) — replace `slackHandler.StartListening(ctx)` with `slackSDK.New(cfg).NewChatBridge(core.ChatDeps{HandleMessage: pilotChatHandler})` and `bridge.Start(ctx)`.
+- **`internal/adapters/slack/handler.go`** — `HandleMessage(ctx, ev core.MessageEvent)` closure → `sdkshim.MessageEventToIncomingMessage(ev, "slack", senderIDConverter)` → `comms.Handler.HandleMessage`. Slack sender IDs are already strings — converter is a no-op.
+- **Outbound** — same as Telegram, use `sdkshim.MessengerToBridge`.
+- **MemberResolverAdapter** wiring — keep functional; resolve identity from `ev.Sender.Identity`.
+
+### What stays
+- `internal/adapters/slack/messenger.go`, `notifier.go`, `formatter.go`, `users.go` — host-domain, untouched.
+- `slack/handler.go` itself — heavily updated but not deleted (formatting + ack paths stay).
+
+### Replace per-platform ack
+- HTTP 200 ack on callback → `bridge.Ack(ev.CallbackID)`.
+
+### Tests
+- `internal/adapters/slack/handler_test.go` — shim path for `Action: "message" / "command" / "callback"`.
+
+## Scope — OUT
+- ❌ Do NOT delete `internal/adapters/slack/`.
+- ❌ Do NOT touch Telegram or Discord.
+- ❌ Do NOT touch tracker code.
+
+## Invariants
+1. `sdkshim.MessageEventToIncomingMessage` used at the entry.
+2. Outbound preserves all 4 `comms.Messenger` methods.
+3. `MemberResolverAdapter` wiring keeps working (Slack RBAC).
+4. Approval flow (`adapters.slack.approval` config) still functional.
+
+## Acceptance
+Same as Phase 6.
+
+## Sequencing
+After Telegram. Mirrors the same shim pattern.
+
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -23,8 +23,11 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/adapters/linear"
 	"github.com/qf-studio/pilot/internal/adapters/plane"
+	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
 	"github.com/qf-studio/pilot/internal/adapters/slack"
 	"github.com/qf-studio/pilot/internal/adapters/telegram"
+	sdkCore "github.com/qf-studio/studio-sdk/sdk/core"
+	sdkSlack "github.com/qf-studio/studio-sdk/sdk/integrations/slack"
 	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/approval"
 	"github.com/qf-studio/pilot/internal/autopilot"
@@ -2502,19 +2505,32 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	}
 
 	// Start Slack Socket Mode if enabled (GH-652: wire into polling mode)
-	var slackHandler *slack.Handler
 	if cfg.Adapters.Slack != nil && cfg.Adapters.Slack.Enabled && cfg.Adapters.Slack.SocketMode &&
 		cfg.Adapters.Slack.AppToken != "" && cfg.Adapters.Slack.BotToken != "" {
-		slackClient := slack.NewClient(cfg.Adapters.Slack.BotToken)
-		slackMessenger := slack.NewMessenger(slackClient)
 
 		var slackMemberResolver comms.MemberResolver
 		if teamAdapter != nil {
 			slackMemberResolver = &slack.MemberResolverAdapter{Inner: teamAdapter}
 		}
 
+		// slackChatHandler is the pilotChatHandler: it shims SDK events into
+		// comms.IncomingMessage and forwards them to slackCommsHandler.
+		// SetCommsHandler is called after the bridge messenger is created to
+		// break the bridge ↔ Messenger circular dependency.
+		slackChatHandler := slack.NewHandler(&slack.HandlerConfig{
+			AllowedChannels: cfg.Adapters.Slack.AllowedChannels,
+			AllowedUsers:    cfg.Adapters.Slack.AllowedUsers,
+		})
+
+		slackBridge := sdkSlack.New(sdkSlack.Config{
+			AppToken:        cfg.Adapters.Slack.AppToken,
+			BotToken:        cfg.Adapters.Slack.BotToken,
+			AllowedChannels: cfg.Adapters.Slack.AllowedChannels,
+			AllowedUsers:    cfg.Adapters.Slack.AllowedUsers,
+		}, nil).NewChatBridge(sdkCore.ChatDeps{Handler: slackChatHandler})
+
 		slackCommsHandler := comms.NewHandler(&comms.HandlerConfig{
-			Messenger:      slackMessenger,
+			Messenger:      sdkshim.MessengerToBridge(slackBridge),
 			Runner:         runner,
 			Projects:       config.NewSlackProjectSource(cfg),
 			ProjectPath:    projectPath,
@@ -2522,17 +2538,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			Store:          store,
 			TaskIDPrefix:   "SLACK",
 		})
-
-		slackHandler = slack.NewHandler(&slack.HandlerConfig{
-			AppToken:        cfg.Adapters.Slack.AppToken,
-			Client:          slackClient,
-			CommsHandler:    slackCommsHandler,
-			AllowedChannels: cfg.Adapters.Slack.AllowedChannels,
-			AllowedUsers:    cfg.Adapters.Slack.AllowedUsers,
-		})
+		slackChatHandler.SetCommsHandler(slackCommsHandler)
 
 		go func() {
-			if err := slackHandler.StartListening(ctx); err != nil {
+			if err := slackBridge.Start(ctx); err != nil {
 				logging.WithComponent("slack").Error("Slack Socket Mode error", slog.Any("error", err))
 			}
 		}()

--- a/internal/adapters/sdkshim/bridge_messenger.go
+++ b/internal/adapters/sdkshim/bridge_messenger.go
@@ -1,0 +1,152 @@
+package sdkshim
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/qf-studio/pilot/internal/comms"
+	"github.com/qf-studio/studio-sdk/sdk/core"
+)
+
+// Compile-time assertion that bridgeMessenger implements comms.Messenger.
+var _ comms.Messenger = (*bridgeMessenger)(nil)
+
+// bridgeMessenger adapts a core.ChatBridge to comms.Messenger so that
+// comms.Handler can delegate outbound calls to the SDK bridge.
+type bridgeMessenger struct {
+	bridge core.ChatBridge
+}
+
+// MessengerToBridge wraps a core.ChatBridge as a comms.Messenger. All
+// outbound calls are delegated to the bridge's Send / Edit / Ack methods.
+func MessengerToBridge(b core.ChatBridge) comms.Messenger {
+	return &bridgeMessenger{bridge: b}
+}
+
+func (m *bridgeMessenger) SendText(ctx context.Context, contextID, text string) error {
+	_, err := m.bridge.Send(ctx, core.OutboundMessage{
+		ChannelID: contextID,
+		Text:      text,
+	})
+	return err
+}
+
+// SendConfirmation posts a confirmation prompt with Execute / Cancel buttons.
+// The button ActionID and Data are both set to "execute" / "cancel" so that
+// the SDK bridge callback event delivers ev.Data == "execute" and the sdkshim
+// maps it to comms.IncomingMessage.ActionID without normalization.
+func (m *bridgeMessenger) SendConfirmation(ctx context.Context, contextID, threadID, taskID, desc, project string) (string, error) {
+	text := fmt.Sprintf("*Task %s*\n\n%s", taskID, desc)
+	if project != "" {
+		text = fmt.Sprintf("*Task %s* · _%s_\n\n%s", taskID, project, desc)
+	}
+	ref, err := m.bridge.Send(ctx, core.OutboundMessage{
+		ChannelID: contextID,
+		ThreadID:  threadID,
+		Text:      text,
+		Buttons: []core.Button{
+			{Label: "Execute ✅", ActionID: "execute", Data: "execute"},
+			{Label: "Cancel ❌", ActionID: "cancel", Data: "cancel"},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("send confirmation: %w", err)
+	}
+	return MessageRefToString(ref), nil
+}
+
+// SendProgress updates the existing progress message when messageRef is set,
+// or posts a new one when it is empty (first call in an execution).
+func (m *bridgeMessenger) SendProgress(ctx context.Context, contextID, messageRef, taskID, phase string, progress int, detail string) (string, error) {
+	text := fmt.Sprintf("⚙️ *%s* · %s %d%%\n%s", taskID, phase, progress, detail)
+	ref := MessageRefFromString(messageRef)
+	if ref.MessageID != "" {
+		if err := m.bridge.Edit(ctx, core.MessageRef{
+			ChannelID: contextID,
+			MessageID: ref.MessageID,
+			ThreadID:  ref.ThreadID,
+		}, text); err != nil {
+			return messageRef, fmt.Errorf("update progress: %w", err)
+		}
+		return messageRef, nil
+	}
+	newRef, err := m.bridge.Send(ctx, core.OutboundMessage{
+		ChannelID: contextID,
+		Text:      text,
+	})
+	if err != nil {
+		return "", fmt.Errorf("send progress: %w", err)
+	}
+	return MessageRefToString(newRef), nil
+}
+
+func (m *bridgeMessenger) SendResult(ctx context.Context, contextID, threadID, taskID string, success bool, output, prURL string) error {
+	status := "✅"
+	if !success {
+		status = "❌"
+	}
+	text := fmt.Sprintf("%s *Task %s completed*", status, taskID)
+	if prURL != "" {
+		text += fmt.Sprintf("\n<%s|View PR>", prURL)
+	}
+	if output != "" {
+		text += "\n\n" + output
+	}
+	_, err := m.bridge.Send(ctx, core.OutboundMessage{
+		ChannelID: contextID,
+		ThreadID:  threadID,
+		Text:      text,
+	})
+	return err
+}
+
+func (m *bridgeMessenger) SendChunked(ctx context.Context, contextID, threadID, content, prefix string) error {
+	chunks := bridgeSplitChunks(content, m.MaxMessageLength())
+	for i, chunk := range chunks {
+		text := chunk
+		if prefix != "" && i == 0 {
+			text = prefix + "\n\n" + chunk
+		}
+		if _, err := m.bridge.Send(ctx, core.OutboundMessage{
+			ChannelID: contextID,
+			ThreadID:  threadID,
+			Text:      text,
+		}); err != nil {
+			return fmt.Errorf("send chunk %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func (m *bridgeMessenger) AcknowledgeCallback(ctx context.Context, callbackID string) error {
+	return m.bridge.Ack(ctx, callbackID)
+}
+
+func (m *bridgeMessenger) MaxMessageLength() int {
+	return 3800
+}
+
+// bridgeSplitChunks splits s into chunks of at most maxLen bytes, preferring
+// newline boundaries. Empty input returns a single empty-string chunk so
+// callers always have at least one message to send.
+func bridgeSplitChunks(s string, maxLen int) []string {
+	if len(s) == 0 {
+		return []string{""}
+	}
+	var chunks []string
+	for len(s) > maxLen {
+		idx := maxLen
+		for idx > 0 && s[idx-1] != '\n' {
+			idx--
+		}
+		if idx == 0 {
+			idx = maxLen
+		}
+		chunks = append(chunks, s[:idx])
+		s = s[idx:]
+	}
+	if s != "" {
+		chunks = append(chunks, s)
+	}
+	return chunks
+}

--- a/internal/adapters/slack/handler.go
+++ b/internal/adapters/slack/handler.go
@@ -10,7 +10,15 @@ import (
 
 	"github.com/qf-studio/pilot/internal/comms"
 	"github.com/qf-studio/pilot/internal/logging"
+	"github.com/qf-studio/studio-sdk/sdk/core"
 )
+
+// commsHandlerIface is the subset of *comms.Handler that Handler calls.
+// Using an interface allows test doubles without a full comms stack.
+type commsHandlerIface interface {
+	HandleMessage(ctx context.Context, msg *comms.IncomingMessage)
+	CleanupLoop(ctx context.Context)
+}
 
 // MemberResolver resolves a Slack user to a team member ID for RBAC (GH-786).
 // Decoupled from teams package to avoid import cycles.
@@ -34,10 +42,10 @@ func (a *MemberResolverAdapter) ResolveIdentity(senderID string) (string, error)
 // Delegates intent detection and task lifecycle to the shared comms.Handler (GH-2143).
 type Handler struct {
 	socketClient    *SocketModeClient
-	apiClient       *Client         // Kept for client access; Messenger wraps this
-	commsHandler    *comms.Handler  // Shared message handler for intent dispatch + task execution
-	allowedChannels map[string]bool // Allowed channel IDs for security
-	allowedUsers    map[string]bool // Allowed user IDs for security
+	apiClient       *Client          // Kept for client access; Messenger wraps this
+	commsHandler    commsHandlerIface // Shared message handler for intent dispatch + task execution
+	allowedChannels map[string]bool   // Allowed channel IDs for security
+	allowedUsers    map[string]bool   // Allowed user IDs for security
 	stopCh          chan struct{}
 	wg              sync.WaitGroup
 	log             *slog.Logger
@@ -79,10 +87,16 @@ func NewHandler(config *HandlerConfig) *Handler {
 		apiClient = NewClient(config.BotToken)
 	}
 
+	// Store as interface only when non-nil to avoid a non-nil interface holding a nil pointer.
+	var commsH commsHandlerIface
+	if config.CommsHandler != nil {
+		commsH = config.CommsHandler
+	}
+
 	return &Handler{
 		socketClient:    NewSocketModeClient(config.AppToken),
 		apiClient:       apiClient,
-		commsHandler:    config.CommsHandler,
+		commsHandler:    commsH,
 		allowedChannels: allowedChannels,
 		allowedUsers:    allowedUsers,
 		stopCh:          make(chan struct{}),
@@ -202,6 +216,42 @@ func (h *Handler) isAllowed(channelID, userID string) bool {
 	}
 
 	return false
+}
+
+// HandleMessage implements core.MessageHandler. It converts the normalized SDK
+// event to comms.IncomingMessage and delegates to the shared comms.Handler.
+// Slack sender IDs are already strings so no conversion is needed.
+//
+// The conversion mirrors sdkshim.MessageEventToIncomingMessage; it is inlined
+// here to avoid the sdkshim → config → slack → sdkshim import cycle.
+func (h *Handler) HandleMessage(ctx context.Context, ev core.MessageEvent) error {
+	msg := &comms.IncomingMessage{
+		ContextID:  ev.ChannelID,
+		SenderID:   ev.Sender.UserID,
+		SenderName: ev.Sender.DisplayName,
+		Text:       ev.Text,
+		ThreadID:   ev.ThreadID,
+		Platform:   "slack",
+		RawEvent:   &ev,
+	}
+	if ev.Action == "callback" {
+		msg.IsCallback = true
+		msg.CallbackID = ev.CallbackID
+		// ev.Data carries the button Data payload; bridgeMessenger.SendConfirmation
+		// sets Data=="execute"/"cancel" so comms.Handler can route directly.
+		msg.ActionID = ev.Data
+	}
+	if h.commsHandler != nil {
+		h.commsHandler.HandleMessage(ctx, msg)
+	}
+	return nil
+}
+
+// SetCommsHandler wires the shared comms handler after construction. Used
+// when the bridge messenger must be created before the comms handler, avoiding
+// the chicken-and-egg dependency between the bridge and its Messenger.
+func (h *Handler) SetCommsHandler(ch *comms.Handler) {
+	h.commsHandler = ch
 }
 
 // HandleCallback processes button clicks from interactive messages.

--- a/internal/adapters/slack/handler_test.go
+++ b/internal/adapters/slack/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/qf-studio/pilot/internal/comms"
+	"github.com/qf-studio/studio-sdk/sdk/core"
 )
 
 func TestNewHandler(t *testing.T) {
@@ -159,6 +160,133 @@ func (m *mockMemberResolver) ResolveSlackIdentity(slackUserID, email string) (st
 		return "", nil
 	}
 	return m.mappings[slackUserID], nil
+}
+
+// mockCommsHandler records HandleMessage calls for shim path tests.
+type mockCommsHandler struct {
+	got []*comms.IncomingMessage
+}
+
+func (m *mockCommsHandler) HandleMessage(_ context.Context, msg *comms.IncomingMessage) {
+	m.got = append(m.got, msg)
+}
+
+func (m *mockCommsHandler) CleanupLoop(_ context.Context) {}
+
+func TestHandler_HandleMessage_MessageAction(t *testing.T) {
+	mock := &mockCommsHandler{}
+	h := NewHandler(&HandlerConfig{
+		AppToken: "xapp-test-token",
+		BotToken: "xoxb-test-token",
+	})
+	h.commsHandler = mock
+
+	ev := core.MessageEvent{
+		Action:    "message",
+		ChannelID: "C123",
+		ThreadID:  "T456",
+		Text:      "deploy the app",
+		Sender:    core.Identity{UserID: "U789"},
+	}
+
+	if err := h.HandleMessage(context.Background(), ev); err != nil {
+		t.Fatalf("HandleMessage() error = %v", err)
+	}
+	if len(mock.got) != 1 {
+		t.Fatalf("HandleMessage() delivered %d messages, want 1", len(mock.got))
+	}
+	got := mock.got[0]
+	if got.ContextID != "C123" {
+		t.Errorf("ContextID = %q, want C123", got.ContextID)
+	}
+	if got.SenderID != "U789" {
+		t.Errorf("SenderID = %q, want U789", got.SenderID)
+	}
+	if got.Text != "deploy the app" {
+		t.Errorf("Text = %q, want %q", got.Text, "deploy the app")
+	}
+	if got.Platform != "slack" {
+		t.Errorf("Platform = %q, want slack", got.Platform)
+	}
+	if got.IsCallback {
+		t.Error("IsCallback should be false for message action")
+	}
+}
+
+func TestHandler_HandleMessage_CommandAction(t *testing.T) {
+	mock := &mockCommsHandler{}
+	h := NewHandler(&HandlerConfig{
+		AppToken: "xapp-test-token",
+		BotToken: "xoxb-test-token",
+	})
+	h.commsHandler = mock
+
+	ev := core.MessageEvent{
+		Action:    "command",
+		ChannelID: "C123",
+		Command:   "/status",
+		Sender:    core.Identity{UserID: "U789"},
+	}
+
+	if err := h.HandleMessage(context.Background(), ev); err != nil {
+		t.Fatalf("HandleMessage() error = %v", err)
+	}
+	if len(mock.got) != 1 {
+		t.Fatalf("HandleMessage() delivered %d messages, want 1", len(mock.got))
+	}
+	got := mock.got[0]
+	if got.Platform != "slack" {
+		t.Errorf("Platform = %q, want slack", got.Platform)
+	}
+	if got.IsCallback {
+		t.Error("IsCallback should be false for command action")
+	}
+}
+
+func TestHandler_HandleMessage_CallbackAction(t *testing.T) {
+	mock := &mockCommsHandler{}
+	h := NewHandler(&HandlerConfig{
+		AppToken: "xapp-test-token",
+		BotToken: "xoxb-test-token",
+	})
+	h.commsHandler = mock
+
+	ev := core.MessageEvent{
+		Action:     "callback",
+		ChannelID:  "C123",
+		CallbackID: "execute",
+		Data:       "execute",
+		Sender:     core.Identity{UserID: "U789"},
+	}
+
+	if err := h.HandleMessage(context.Background(), ev); err != nil {
+		t.Fatalf("HandleMessage() error = %v", err)
+	}
+	if len(mock.got) != 1 {
+		t.Fatalf("HandleMessage() delivered %d messages, want 1", len(mock.got))
+	}
+	got := mock.got[0]
+	if !got.IsCallback {
+		t.Error("IsCallback should be true for callback action")
+	}
+	if got.ActionID != "execute" {
+		t.Errorf("ActionID = %q, want execute", got.ActionID)
+	}
+	if got.CallbackID != "execute" {
+		t.Errorf("CallbackID = %q, want execute", got.CallbackID)
+	}
+}
+
+func TestHandler_HandleMessage_NilCommsHandler(t *testing.T) {
+	h := NewHandler(&HandlerConfig{
+		AppToken: "xapp-test-token",
+		BotToken: "xoxb-test-token",
+	})
+	// commsHandler is nil — HandleMessage must not panic.
+	ev := core.MessageEvent{Action: "message", Text: "hello", ChannelID: "C1"}
+	if err := h.HandleMessage(context.Background(), ev); err != nil {
+		t.Fatalf("HandleMessage() with nil commsHandler error = %v", err)
+	}
 }
 
 func TestRateLimiter(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `sdkshim.MessengerToBridge` — wraps `core.ChatBridge` as `comms.Messenger` (outbound via `Send`/`Edit`/`Ack`)
- Replaces `slackHandler.StartListening` in `main.go` with `sdkSlack.New(cfg).NewChatBridge(deps).Start(ctx)`
- Adds `slack.Handler.HandleMessage(ctx, core.MessageEvent) error` to satisfy `core.MessageHandler`; inlined conversion avoids the `sdkshim→config→slack→sdkshim` import cycle
- Adds `SetCommsHandler` for post-construction wiring (breaks bridge ↔ Messenger circular dep)
- Tests: shim path for `Action: message / command / callback`

## Invariants checked

1. `comms.Messenger` interface fully implemented by `bridgeMessenger` (compile-time assertion)
2. `MemberResolverAdapter` wiring unchanged — `ev.Sender.UserID` flows as `SenderID`
3. Callback routing: `SendConfirmation` buttons use `ActionID/Data="execute"/"cancel"`, so `comms.Handler` receives the correct `ActionID` without normalization
4. `messenger.go`, `notifier.go`, `formatter.go`, `users.go` untouched

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go test ./internal/adapters/sdkshim/... ./internal/adapters/slack/...` — passes
- [ ] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues