### PR TITLE
feat(telegram): implement studio-sdk chat contract on Handler (GH-3470)

### DIFF
--- a/internal/adapters/telegram/sdk_chat.go
+++ b/internal/adapters/telegram/sdk_chat.go
@@ -1,0 +1,66 @@
+package telegram
+
+import (
+	"context"
+
+	"github.com/qf-studio/pilot/internal/comms"
+	"github.com/qf-studio/studio-sdk/sdk/core"
+)
+
+// Handler implements the studio-sdk chat contract (core.MessageHandler) so the
+// Telegram poll path can be driven by the SDK chat bridge instead of the local
+// long-poll loop (M7 Phase 6, GH-3470). The bridge calls HandleMessage for each
+// normalized inbound event; Pilot's existing photo/voice handling stays on the
+// host-side path and fills ImagePath/VoiceText there — only inbound text flows
+// through this shim.
+var _ core.MessageHandler = (*Handler)(nil)
+
+// messageEventToIncoming converts a normalized SDK chat event into Pilot's
+// comms.IncomingMessage.
+//
+// The conversion mirrors sdkshim.MessageEventToIncomingMessage but is inlined
+// here: telegram → sdkshim → config → telegram is an import cycle (config.go
+// imports the telegram package), so telegram cannot import sdkshim. The Slack
+// adapter inlines the same conversion for the identical reason — see
+// slack/handler.go HandleMessage.
+//
+// Telegram sender IDs arrive from sdk/integrations/telegram as a stringified
+// int64, and Telegram's MemberResolver consumes them as strings, so the SDK
+// UserID is used as-is (pass-through).
+func messageEventToIncoming(ev core.MessageEvent) *comms.IncomingMessage {
+	msg := &comms.IncomingMessage{
+		ContextID:  ev.ChannelID,
+		SenderID:   ev.Sender.UserID,
+		SenderName: ev.Sender.DisplayName,
+		Text:       ev.Text,
+		ThreadID:   ev.ThreadID,
+		Platform:   "telegram",
+		RawEvent:   &ev,
+	}
+	if ev.Action == "callback" {
+		msg.IsCallback = true
+		msg.CallbackID = ev.CallbackID
+		// ev.Data carries the button payload (e.g. "approve:TASK123"); comms
+		// routes it via ActionID. Per-platform normalization (execute/cancel)
+		// happens inside comms.Handler.
+		msg.ActionID = ev.Data
+	}
+	return msg
+}
+
+// HandleMessage implements core.MessageHandler. It converts the normalized SDK
+// event to comms.IncomingMessage and delegates to the shared comms.Handler,
+// matching the Slack/Discord chat-contract adapters.
+func (h *Handler) HandleMessage(ctx context.Context, ev core.MessageEvent) error {
+	if h.commsHandler != nil {
+		h.commsHandler.HandleMessage(ctx, messageEventToIncoming(ev))
+	}
+	return nil
+}
+
+// SetCommsHandler wires the shared comms handler after construction. Used when
+// the bridge messenger must be created before the comms handler, avoiding the
+// chicken-and-egg dependency between the bridge and its Messenger.
+func (h *Handler) SetCommsHandler(ch *comms.Handler) {
+	h.commsHandler = ch
+}

--- a/internal/adapters/telegram/sdk_chat_test.go
+++ b/internal/adapters/telegram/sdk_chat_test.go
@@ -1,0 +1,78 @@
+package telegram
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qf-studio/studio-sdk/sdk/core"
+)
+
+func TestMessageEventToIncoming_Message(t *testing.T) {
+	ev := core.MessageEvent{
+		Action:    "message",
+		ChannelID: "12345",
+		ThreadID:  "67",
+		Text:      "deploy the api",
+		Sender:    core.Identity{UserID: "999", DisplayName: "alice"},
+	}
+
+	msg := messageEventToIncoming(ev)
+
+	if msg.Platform != "telegram" {
+		t.Errorf("Platform = %q, want telegram", msg.Platform)
+	}
+	if msg.ContextID != "12345" {
+		t.Errorf("ContextID = %q, want 12345", msg.ContextID)
+	}
+	if msg.SenderID != "999" {
+		t.Errorf("SenderID = %q, want 999 (pass-through)", msg.SenderID)
+	}
+	if msg.SenderName != "alice" {
+		t.Errorf("SenderName = %q, want alice", msg.SenderName)
+	}
+	if msg.Text != "deploy the api" {
+		t.Errorf("Text = %q, want %q", msg.Text, "deploy the api")
+	}
+	if msg.ThreadID != "67" {
+		t.Errorf("ThreadID = %q, want 67", msg.ThreadID)
+	}
+	if msg.IsCallback {
+		t.Error("IsCallback = true, want false for a plain message")
+	}
+	if msg.RawEvent == nil {
+		t.Error("RawEvent = nil, want the SDK event")
+	}
+}
+
+func TestMessageEventToIncoming_Callback(t *testing.T) {
+	ev := core.MessageEvent{
+		Action:     "callback",
+		ChannelID:  "12345",
+		CallbackID: "cb-abc",
+		Data:       "approve:TASK123",
+		Sender:     core.Identity{UserID: "999", DisplayName: "alice"},
+	}
+
+	msg := messageEventToIncoming(ev)
+
+	if !msg.IsCallback {
+		t.Error("IsCallback = false, want true for a callback event")
+	}
+	if msg.CallbackID != "cb-abc" {
+		t.Errorf("CallbackID = %q, want cb-abc", msg.CallbackID)
+	}
+	if msg.ActionID != "approve:TASK123" {
+		t.Errorf("ActionID = %q, want approve:TASK123 (from ev.Data)", msg.ActionID)
+	}
+}
+
+// HandleMessage must satisfy core.MessageHandler and be safe when the comms
+// handler has not been wired yet (e.g. bridge created before SetCommsHandler).
+func TestHandleMessage_NilCommsHandlerIsSafe(t *testing.T) {
+	var _ core.MessageHandler = (*Handler)(nil)
+
+	h := &Handler{} // commsHandler nil
+	if err := h.HandleMessage(context.Background(), core.MessageEvent{Action: "message", Text: "hi"}); err != nil {
+		t.Errorf("HandleMessage with nil commsHandler returned err = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## M7 Phase 6 (Telegram chat) — part 1: SDK chat-contract conformance

Closes #3470 (Phase 6 part 1). Telegram's `Handler` now implements the studio-sdk
chat contract (`core.MessageHandler`), so it can be driven by the SDK chat bridge
the same way the shipped Slack (#3471) and Discord (#3490) adapters are.

### What this PR does
- `internal/adapters/telegram/sdk_chat.go`:
  - `HandleMessage(ctx, core.MessageEvent) error` — converts a normalized SDK
    event to `comms.IncomingMessage` and routes through the shared `comms.Handler`.
  - `SetCommsHandler(*comms.Handler)` — breaks the bridge ↔ Messenger init cycle.
  - `var _ core.MessageHandler = (*Handler)(nil)` compile-time conformance.
- `internal/adapters/telegram/sdk_chat_test.go` — message + callback mapping and
  nil-comms-handler safety.

### Evidence-based deviations from the issue spec
1. **Inlined conversion** instead of `sdkshim.MessageEventToIncomingMessage`:
   `telegram → sdkshim → config → telegram` is an import cycle (`config.go`
   imports the telegram package). `slack/handler.go` inlines the identical
   conversion for the same reason. Invariant #2 as written is infeasible.
2. **Corrected SDK API**: the issue's wiring snippet used
   `telegramSDK.New(cfg)` / `core.ChatDeps{HandleMessage:}`, which do not compile
   against studio-sdk v0.24.0. The real API is `New(cfg, logger)` /
   `core.ChatDeps{Handler:}` (verified against the shipped Slack wiring). This
   stale snippet is what made the autonomous runs fail at `go build` (exit 1).

### Deliberately deferred (follow-up, after soak)
Per the issue's own **Scope — OUT** ("delete `commands.go` only after soak"),
this PR does **not** yet:
- cut `cmd/pilot/main.go` over from the gateway long-poll path to the SDK bridge,
- delete `commands.go` (~620 LOC),
- rewire `telegram_notifier.go`.

Those touch the **live daemon control plane** and are split out to keep this
change safe and reviewable. The handler-level contract conformance here is the
prerequisite and mirrors the Slack handler change exactly.

### Verification
- `go build ./...`, `go vet ./internal/adapters/telegram/` — clean
- `go test ./internal/adapters/telegram/` — ok (full package, no regressions)
- `golangci-lint run ./internal/adapters/telegram/` — 0 issues
- `gofmt -l` — clean