### PR TITLE
fix(poller): periodic stranded-issue sweep for orphaned pilot-in-progress (TASK-354)

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -102,8 +102,13 @@ type Poller struct {
 	label     string
 	interval  time.Duration
 	processed map[int]time.Time
-	mu        sync.RWMutex
-	onIssue   func(ctx context.Context, issue *Issue) error
+	// inFlight tracks issues whose dispatch goroutine is currently executing
+	// (set for the lifetime of the goroutine, including label finalization).
+	// TASK-354: the periodic stranded-issue sweep skips in-flight issues so a
+	// live execution is never disturbed.
+	inFlight map[int]struct{}
+	mu       sync.RWMutex
+	onIssue  func(ctx context.Context, issue *Issue) error
 	// onIssueWithResult is called for sequential mode, returns PR info
 	onIssueWithResult func(ctx context.Context, issue *Issue) (*IssueResult, error)
 	// OnPRCreated is called when a PR is created after issue processing
@@ -135,6 +140,11 @@ type Poller struct {
 	// When a processed issue's status labels are removed, the poller waits this duration
 	// before allowing retry. Default: 5 minutes.
 	retryGracePeriod time.Duration
+
+	// TASK-354: interval for the periodic stranded-issue sweep that clears
+	// pilot-in-progress from issues whose execution goroutine has ended without
+	// a terminal transition (mid-session orphan recovery). Default: 10 minutes.
+	strandSweepInterval time.Duration
 
 	// GH-2201: TaskChecker verifies whether an issue is still queued/in-progress
 	// before allowing retry after the grace period expires.
@@ -359,12 +369,14 @@ func NewPoller(client *Client, repo string, label string, interval time.Duration
 		label:                label,
 		interval:             interval,
 		processed:            make(map[int]time.Time),
+		inFlight:             make(map[int]struct{}),
 		logger:               logging.WithComponent("github-poller"),
 		executionMode:        ExecutionModeAuto, // Default matches config.DefaultExecutionConfig()
 		waitForMerge:         true,
 		prPollInterval:       30 * time.Second,
 		prTimeout:            1 * time.Hour,
-		retryGracePeriod:     5 * time.Minute, // GH-2201: default grace period
+		retryGracePeriod:     5 * time.Minute,  // GH-2201: default grace period
+		strandSweepInterval:  10 * time.Minute, // TASK-354: default stranded-issue sweep cadence
 		failedRetryCount:     make(map[int]int),
 		maxFailedRetries:     3, // GH-2176: default max retries for pilot-failed issues
 		retryReadyCount:      make(map[int]int),
@@ -469,6 +481,82 @@ func (p *Poller) recoverOrphanedIssues(ctx context.Context) {
 	}
 }
 
+// markInFlight records that issue's dispatch goroutine is executing. Held for the
+// goroutine's lifetime (including label finalization) so sweepStrandedIssues never
+// disturbs a live execution. TASK-354.
+func (p *Poller) markInFlight(number int) {
+	p.mu.Lock()
+	p.inFlight[number] = struct{}{}
+	p.mu.Unlock()
+}
+
+// unmarkInFlight clears the in-flight marker once the dispatch goroutine returns.
+func (p *Poller) unmarkInFlight(number int) {
+	p.mu.Lock()
+	delete(p.inFlight, number)
+	p.mu.Unlock()
+}
+
+// isInFlight reports whether issue's dispatch goroutine is currently executing.
+func (p *Poller) isInFlight(number int) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	_, ok := p.inFlight[number]
+	return ok
+}
+
+// sweepStrandedIssues clears pilot-in-progress from issues whose execution
+// goroutine has ended without performing a terminal transition. Unlike
+// recoverOrphanedIssues (which runs once at startup), this runs periodically so a
+// mid-session strand — e.g. a no_op/terminal path that failed to remove the label
+// (TASK-354) — self-heals without a daemon restart.
+//
+// Safety:
+//   - Issues currently in-flight are skipped, so a live execution is never touched
+//     (the in-progress label is added inside the dispatch goroutine, which is
+//     marked in-flight, so the label can only exist for a live or already-finished
+//     run).
+//   - When a terminal label (blocked/done/failed) is already present alongside
+//     pilot-in-progress, the strand is a contradictory leftover: the label is
+//     cleaned up but the issue is NOT re-armed (no unmarkProcessed), so a
+//     deterministically-failing issue does not re-dispatch on a loop.
+//   - Otherwise (in-progress only, goroutine gone — e.g. a crash mid-run) the issue
+//     is re-armed for pickup, mirroring recoverOrphanedIssues.
+func (p *Poller) sweepStrandedIssues(ctx context.Context) {
+	issues, err := p.client.ListIssues(ctx, p.owner, p.repo, &ListIssuesOptions{
+		Labels: []string{p.label, LabelInProgress},
+		State:  StateOpen,
+	})
+	if err != nil {
+		p.logger.Warn("Stranded-issue sweep: list failed", slog.Any("error", err))
+		return
+	}
+
+	for _, issue := range issues {
+		if p.isInFlight(issue.Number) {
+			continue // live execution — leave it alone
+		}
+		if err := p.client.RemoveLabel(ctx, p.owner, p.repo, issue.Number, LabelInProgress); err != nil {
+			p.logger.Warn("Stranded-issue sweep: failed to remove in-progress label",
+				slog.Int("number", issue.Number),
+				slog.Any("error", err),
+			)
+			continue
+		}
+
+		terminal := HasLabel(issue, LabelBlocked) || HasLabel(issue, LabelDone) || HasLabel(issue, LabelFailed)
+		if !terminal {
+			// Pure orphan (crash mid-run): re-arm for pickup.
+			p.unmarkProcessed(issue.Number)
+		}
+		p.logger.Info("Swept stranded in-progress issue",
+			slog.Int("number", issue.Number),
+			slog.String("title", issue.Title),
+			slog.Bool("rearmed", !terminal),
+		)
+	}
+}
+
 // startParallel runs concurrent issue execution with a semaphore limiter.
 // Used by both "parallel" and "auto" modes. In "auto" mode, checkForNewIssues
 // applies the scope-overlap guard so that overlapping issues are held back.
@@ -484,6 +572,14 @@ func (p *Poller) startParallel(ctx context.Context) {
 	ticker := time.NewTicker(p.interval)
 	defer ticker.Stop()
 
+	// TASK-354: periodic stranded-issue sweep (mid-session orphan recovery).
+	sweepInterval := p.strandSweepInterval
+	if sweepInterval <= 0 {
+		sweepInterval = 10 * time.Minute
+	}
+	sweepTicker := time.NewTicker(sweepInterval)
+	defer sweepTicker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -496,6 +592,8 @@ func (p *Poller) startParallel(ctx context.Context) {
 			return
 		case <-ticker.C:
 			p.checkForNewIssues(ctx)
+		case <-sweepTicker.C:
+			p.sweepStrandedIssues(ctx)
 		}
 	}
 }
@@ -1317,6 +1415,11 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 		go func(issue *Issue) {
 			defer p.activeWg.Done()
 			defer func() { <-p.semaphore }() // release slot
+
+			// TASK-354: mark in-flight for the whole execution (incl. label
+			// finalization) so the stranded-issue sweep never touches a live run.
+			p.markInFlight(issue.Number)
+			defer p.unmarkInFlight(issue.Number)
 
 			// Board sync: move card to in-progress on confirmed dispatch (GH-3252).
 			p.syncBoardStatusInProgress(ctx, issue)

--- a/internal/adapters/github/poller_sweep_test.go
+++ b/internal/adapters/github/poller_sweep_test.go
@@ -1,0 +1,123 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// sweepTestServer returns an httptest server that serves the given issues for
+// GET /issues and records pilot-in-progress DELETEs into removed.
+func sweepTestServer(t *testing.T, issues []*Issue, removed *[]int, mu *sync.Mutex) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.Path == "/repos/owner/repo/issues" {
+				_ = json.NewEncoder(w).Encode(issues)
+			}
+		case http.MethodDelete:
+			// Path: /repos/owner/repo/issues/{n}/labels/pilot-in-progress
+			var n int
+			if _, err := fmt.Sscanf(r.URL.Path, "/repos/owner/repo/issues/%d/labels/"+LabelInProgress, &n); err == nil {
+				mu.Lock()
+				*removed = append(*removed, n)
+				mu.Unlock()
+			}
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+}
+
+// TASK-354: a stranded in-progress issue (goroutine gone, no terminal label) is
+// swept — label removed AND re-armed for pickup.
+func TestPoller_SweepStranded_RemovesAndRearms(t *testing.T) {
+	issues := []*Issue{
+		{Number: 123, Title: "Stranded", Labels: []Label{{Name: "pilot"}, {Name: LabelInProgress}}},
+	}
+	removed := []int{}
+	var mu sync.Mutex
+	server := sweepTestServer(t, issues, &removed, &mu)
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+	poller.markProcessed(123) // simulate retained marker from a no_op
+
+	poller.sweepStrandedIssues(context.Background())
+
+	mu.Lock()
+	gotRemoved := append([]int(nil), removed...)
+	mu.Unlock()
+	if len(gotRemoved) != 1 || gotRemoved[0] != 123 {
+		t.Fatalf("expected pilot-in-progress removed from #123, got %v", gotRemoved)
+	}
+	poller.mu.RLock()
+	_, stillProcessed := poller.processed[123]
+	poller.mu.RUnlock()
+	if stillProcessed {
+		t.Error("expected #123 to be re-armed (unmarkProcessed) when no terminal label present")
+	}
+}
+
+// TASK-354: an in-flight issue is never swept (live execution protected).
+func TestPoller_SweepStranded_SkipsInFlight(t *testing.T) {
+	issues := []*Issue{
+		{Number: 123, Title: "Running", Labels: []Label{{Name: "pilot"}, {Name: LabelInProgress}}},
+	}
+	removed := []int{}
+	var mu sync.Mutex
+	server := sweepTestServer(t, issues, &removed, &mu)
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+	poller.markInFlight(123) // live execution
+
+	poller.sweepStrandedIssues(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(removed) != 0 {
+		t.Errorf("expected no label removal for in-flight issue, got %v", removed)
+	}
+}
+
+// TASK-354: an in-progress + terminal-label contradiction is cleaned up (label
+// removed) but NOT re-armed — a deterministically-failed issue must not re-loop.
+func TestPoller_SweepStranded_TerminalLabelNoRearm(t *testing.T) {
+	issues := []*Issue{
+		{Number: 123, Title: "Blocked leftover", Labels: []Label{{Name: "pilot"}, {Name: LabelInProgress}, {Name: LabelBlocked}}},
+	}
+	removed := []int{}
+	var mu sync.Mutex
+	server := sweepTestServer(t, issues, &removed, &mu)
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+	poller.markProcessed(123)
+
+	poller.sweepStrandedIssues(context.Background())
+
+	mu.Lock()
+	gotRemoved := append([]int(nil), removed...)
+	mu.Unlock()
+	if len(gotRemoved) != 1 || gotRemoved[0] != 123 {
+		t.Fatalf("expected pilot-in-progress cleaned up on #123, got %v", gotRemoved)
+	}
+	poller.mu.RLock()
+	_, stillProcessed := poller.processed[123]
+	poller.mu.RUnlock()
+	if !stillProcessed {
+		t.Error("expected #123 to stay processed (no re-arm) when a terminal label is present")
+	}
+}


### PR DESCRIPTION
## TASK-354 — mid-session orphan recovery for stranded `pilot-in-progress`

`recoverOrphanedIssues` runs **only at daemon startup** (`poller.go` `Start`). A
`pilot-in-progress` label stranded *after* startup is permanent until the next
restart, because the poller hard-skips in-progress issues (`poller.go:1078`) and
never re-evaluates them. This is what froze **GH-3470** for an hour after a no_op
execution failed to perform its terminal label transition.

### Fix
A periodic sweep (`sweepStrandedIssues`, default **10m**, parallel/auto mode)
that clears `pilot-in-progress` from issues whose execution goroutine has ended:

- **`inFlight` set** — marked for the dispatch goroutine's full lifetime
  (including `onIssueWithResult` label finalization). The in-progress label is
  only ever added *inside* that goroutine, so gating the sweep on `inFlight`
  means a live execution is never touched.
- **Terminal-label contradiction** (`in-progress` + `blocked`/`done`/`failed`) →
  clean up the stale `in-progress` but do **not** re-arm, so a
  deterministically-failing issue can't re-dispatch on a loop.
- **Pure orphan** (`in-progress` only, goroutine gone — e.g. a crash mid-run) →
  re-arm for pickup, mirroring startup recovery.

### Scope
- Parallel/auto mode only (what the daemon runs). Sequential mode keeps existing
  startup-only recovery.
- Pairs with the TASK-320 no_op finalization fix (separate PR): once a no_op
  reliably applies `pilot-blocked`, the sweep's terminal-label branch handles it
  with zero re-dispatch.

### Verification
- `go build ./...`, `go vet ./internal/adapters/github/` — clean
- `go test ./internal/adapters/github/` — ok (full package)
- `golangci-lint run ./internal/adapters/github/` — 0 issues
- New tests: remove+rearm, in-flight skip, terminal-label cleanup-no-rearm