### PR TITLE
fix(executor): tolerate no-op subtasks in decomposed tasks + escalated retry (TASK-320 B2)

### DIFF
--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -128,6 +128,23 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 		}
 
 		if !subtaskResult.Success {
+			// TASK-320 B2: a subtask that produced no commit (analysis, verification,
+			// or a change already present on the branch) is NOT a task failure. The
+			// ghost-SHA guard flags every no-commit run as !Success, which previously
+			// aborted the whole decomposed task on the FIRST such subtask (the
+			// "subtask 1/5 failed: no new commit produced" freeze, GH-3470/GH-3228).
+			// Aggregate its cost and continue; the task only no-ops if NO subtask
+			// delivers a commit, checked after the loop.
+			if isNoOpResult(subtaskResult) {
+				aggregateSubtaskCost(aggregateResult, subtaskResult)
+				r.log.Info("Subtask produced no commit; continuing decomposition (TASK-320 B2)",
+					slog.String("subtask_id", subtask.ID),
+					slog.Int("index", subtaskNum),
+					slog.Int("total", totalSubtasks),
+					slog.String("reason", subtaskResult.Error),
+				)
+				continue
+			}
 			r.log.Warn("Subtask failed",
 				slog.String("subtask_id", subtask.ID),
 				slog.String("error", subtaskResult.Error),
@@ -169,6 +186,15 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 			slog.Int("index", subtaskNum),
 			slog.Int("total", totalSubtasks),
 		)
+	}
+
+	// TASK-320 B2: every subtask ran without a hard error, but none delivered a
+	// commit — the decomposed task is a genuine no-op. Escalate the final subtask
+	// once with the evidence-backed directive before declaring a terminal no-op,
+	// so a model that silently refused an explicit spec gets one firm re-prompt.
+	// Never surface an empty error string for this path (acceptance: descriptive).
+	if aggregateResult.Success && aggregateResult.CommitSHA == "" && aggregateResult.PRUrl == "" && len(subtasks) > 0 {
+		r.escalateDecomposedNoOp(ctx, parentTask, subtasks, executionPath, aggregateResult)
 	}
 
 	aggregateResult.Duration = time.Since(start)
@@ -229,4 +255,81 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 	}
 
 	return aggregateResult, nil
+}
+
+// isNoOpResult reports whether a subtask result is a no-commit no-op (analysis,
+// verification, or a change already present) rather than a real failure. The
+// ghost-SHA guard marks every no-commit run as !Success; this distinguishes the
+// benign case from a genuine error so a decomposed task is not aborted by an
+// early non-delivering subtask. TASK-320 B2.
+func isNoOpResult(res *ExecutionResult) bool {
+	if res == nil || res.Success {
+		return false
+	}
+	return res.Outcome == "no_op" || containsAny(res.Error, noOpErrorSignatures)
+}
+
+// aggregateSubtaskCost folds a subtask's token/research usage into the aggregate.
+// Cost accrues even for no-op subtasks (the model still ran); commit/PR/quality
+// are aggregated separately, only on delivery.
+func aggregateSubtaskCost(agg, sub *ExecutionResult) {
+	agg.TokensInput += sub.TokensInput
+	agg.TokensOutput += sub.TokensOutput
+	agg.TokensTotal += sub.TokensTotal
+	agg.CacheCreationInputTokens += sub.CacheCreationInputTokens
+	agg.CacheReadInputTokens += sub.CacheReadInputTokens
+	agg.ResearchTokens += sub.ResearchTokens
+	if sub.ModelName != "" {
+		agg.ModelName = sub.ModelName
+	}
+}
+
+// escalateDecomposedNoOp re-runs the final subtask exactly once with the
+// evidence-backed directive when the whole decomposed task delivered no commit.
+// On recovery it folds the commit/PR into agg; otherwise it sets a descriptive
+// terminal no-op error (never empty). TASK-320 B2.
+//
+// This lives at the decomposition layer — it re-invokes executeWithOptions rather
+// than duplicating the ghost-SHA/SHA-harvest logic inside that ~1700-line function
+// (the in-executor variant the task doc flagged as needing a structured refactor).
+func (r *Runner) escalateDecomposedNoOp(ctx context.Context, parentTask *Task, subtasks []*Task, executionPath string, agg *ExecutionResult) {
+	final := subtasks[len(subtasks)-1]
+
+	escalated := *final // shallow copy; only value fields below are mutated
+	escalated.Branch = ""
+	escalated.ProjectPath = executionPath
+	escalated.Description = final.Description + "\n\n" + EvidenceBackedSpecDirective
+
+	r.log.Warn("Decomposed task produced no commit; escalating final subtask once (TASK-320 B2)",
+		slog.String("parent_id", parentTask.ID),
+		slog.String("subtask_id", final.ID),
+	)
+
+	savedDecomposer := r.decomposer
+	r.decomposer = nil
+	retryResult, err := r.executeWithOptions(ctx, &escalated, false)
+	r.decomposer = savedDecomposer
+
+	if err == nil && retryResult != nil && retryResult.Success && retryResult.CommitSHA != "" {
+		aggregateSubtaskCost(agg, retryResult)
+		agg.CommitSHA = retryResult.CommitSHA
+		agg.PRUrl = retryResult.PRUrl
+		agg.FilesChanged += retryResult.FilesChanged
+		agg.LinesAdded += retryResult.LinesAdded
+		agg.LinesRemoved += retryResult.LinesRemoved
+		if retryResult.QualityGates != nil {
+			agg.QualityGates = retryResult.QualityGates
+		}
+		r.log.Info("Escalated retry recovered the no-op (TASK-320 B2)",
+			slog.String("parent_id", parentTask.ID),
+			slog.String("commit_sha", retryResult.CommitSHA),
+		)
+		return
+	}
+
+	if retryResult != nil {
+		aggregateSubtaskCost(agg, retryResult)
+	}
+	agg.Success = false
+	agg.Error = fmt.Sprintf("no new commit produced — all %d subtask(s) were no-ops after one escalated retry (task %s)", len(subtasks), parentTask.ID)
 }

--- a/internal/executor/runner_decompose_noop_test.go
+++ b/internal/executor/runner_decompose_noop_test.go
@@ -1,0 +1,79 @@
+package executor
+
+import "testing"
+
+func TestIsNoOpResult(t *testing.T) {
+	tests := []struct {
+		name string
+		res  *ExecutionResult
+		want bool
+	}{
+		{"nil", nil, false},
+		{"success is never no-op", &ExecutionResult{Success: true}, false},
+		{
+			"ghost-SHA worktree no-op",
+			&ExecutionResult{Success: false, Error: "no new commit produced — worktree HEAD matches base branch parent"},
+			true,
+		},
+		{
+			"ghost-SHA post-push no-op",
+			&ExecutionResult{Success: false, Error: "no new commit produced — post-push SHA matches base branch"},
+			true,
+		},
+		{
+			"wrapped subtask no-op still detected (substring)",
+			&ExecutionResult{Success: false, Error: "subtask 1/5 failed: no new commit produced — worktree HEAD matches base branch parent"},
+			true,
+		},
+		{
+			"explicit no_op outcome",
+			&ExecutionResult{Success: false, Outcome: "no_op", Error: "made no code changes"},
+			true,
+		},
+		{
+			"real failure is NOT a no-op",
+			&ExecutionResult{Success: false, Error: "PR creation refused: title rejected"},
+			false,
+		},
+		{
+			"build failure is NOT a no-op",
+			&ExecutionResult{Success: false, Error: "execution failed: exit status 1"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNoOpResult(tt.res); got != tt.want {
+				t.Errorf("isNoOpResult() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAggregateSubtaskCost(t *testing.T) {
+	agg := &ExecutionResult{TokensInput: 100, TokensOutput: 10}
+	sub := &ExecutionResult{
+		TokensInput:              50,
+		TokensOutput:             5,
+		TokensTotal:              55,
+		CacheReadInputTokens:     20,
+		CacheCreationInputTokens: 3,
+		ResearchTokens:           7,
+		ModelName:                "claude-opus-4-8",
+	}
+	aggregateSubtaskCost(agg, sub)
+
+	if agg.TokensInput != 150 || agg.TokensOutput != 15 || agg.TokensTotal != 55 {
+		t.Errorf("token aggregation wrong: in=%d out=%d total=%d", agg.TokensInput, agg.TokensOutput, agg.TokensTotal)
+	}
+	if agg.CacheReadInputTokens != 20 || agg.ResearchTokens != 7 {
+		t.Errorf("cache/research aggregation wrong: cacheRead=%d research=%d", agg.CacheReadInputTokens, agg.ResearchTokens)
+	}
+	if agg.ModelName != "claude-opus-4-8" {
+		t.Errorf("ModelName = %q, want claude-opus-4-8", agg.ModelName)
+	}
+	// Cost helper must not fabricate a commit/delivery from a no-op subtask.
+	if agg.CommitSHA != "" || agg.PRUrl != "" {
+		t.Errorf("aggregateSubtaskCost must not set CommitSHA/PRUrl, got sha=%q pr=%q", agg.CommitSHA, agg.PRUrl)
+	}
+}


### PR DESCRIPTION
## TASK-320 B2 — decomposed-task no-op tolerance + escalated retry

`executeDecomposedTask` aborted the whole task the moment **any** subtask returned
`!Success`. The ghost-SHA guard marks every no-commit run as `!Success`, so a
non-delivering subtask (analysis, verification, "confirm X already holds", or a
change already on the branch) failed the entire task as
`subtask 1/5 failed: no new commit produced`. This is exactly why **GH-3470**
no_op'd deterministically on every dispatch.

### Fix (all in `internal/executor/runner_decompose.go`)
- **`isNoOpResult`** — distinguishes a no-commit no-op (`Outcome=="no_op"` or a
  `noOpErrorSignatures` match) from a real failure (`PR creation refused`, build
  error). Only real errors abort the loop now; a no-op subtask has its cost
  aggregated and the loop **continues**.
- The decomposed task no-ops **only when no subtask delivers a commit** (checked
  after the loop) — not on the first non-delivering step.
- **`escalateDecomposedNoOp`** — on a genuine whole-task no-op, re-runs the final
  subtask **exactly once** with `EvidenceBackedSpecDirective` (Layer A) appended.
  On recovery it folds in the commit/PR; otherwise it sets a **descriptive**
  terminal error naming the task (never the empty `execution failed:` string —
  acceptance criterion). The message keeps the `no new commit produced` prefix so
  `IsPermanentFailure` still classifies it terminal (Layer B1) → poller applies
  `pilot-blocked`.

### Why the decomposition layer (not in-executor)
The task doc deferred Layer B2 because bolting a second backend re-invocation onto
the ~1700-line `executeWithOptions` "duplicates SHA-harvest + ghost-check + metrics
logic and risks regressing the executor's core path." Doing the escalation at the
decomposition layer (re-invoking `executeWithOptions`) sidesteps that entirely — no
core-path changes.

### Verification
- `go build ./...`, `go vet ./internal/executor/` — clean
- `go test ./internal/executor/` — ok (full package, no regressions)
- `golangci-lint run ./internal/executor/` — 0 issues
- New tests: `isNoOpResult` classification table, `aggregateSubtaskCost`

### Pairs with
TASK-354 (#3495, merged) — once a no_op reliably applies `pilot-blocked` here, the
poller's stranded-issue sweep cleans up `pilot-in-progress` with zero re-dispatch.