### PR TITLE
feat(telegram): opt-in studio-sdk chat bridge for inbound (GH-3470 Phase 6)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -26,8 +26,6 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
 	"github.com/qf-studio/pilot/internal/adapters/slack"
 	"github.com/qf-studio/pilot/internal/adapters/telegram"
-	sdkCore "github.com/qf-studio/studio-sdk/sdk/core"
-	sdkSlack "github.com/qf-studio/studio-sdk/sdk/integrations/slack"
 	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/approval"
 	"github.com/qf-studio/pilot/internal/autopilot"
@@ -47,6 +45,9 @@ import (
 	"github.com/qf-studio/pilot/internal/teams"
 	"github.com/qf-studio/pilot/internal/tunnel"
 	"github.com/qf-studio/pilot/internal/upgrade"
+	sdkCore "github.com/qf-studio/studio-sdk/sdk/core"
+	sdkSlack "github.com/qf-studio/studio-sdk/sdk/integrations/slack"
+	sdkTelegram "github.com/qf-studio/studio-sdk/sdk/integrations/telegram"
 )
 
 var (
@@ -2496,12 +2497,36 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	}
 	StartAdapterPollers(ctx, pollingDeps, adapterPollerRegistrations())
 
-	// Start Telegram polling if enabled
+	// Start Telegram inbound if enabled.
 	if tgHandler != nil {
-		if !dashboardMode {
-			fmt.Println("📱 Telegram polling started")
+		if cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.SDKBridge {
+			// M7 Phase 6 (GH-3470), opt-in: drive inbound through the studio-sdk
+			// chat bridge instead of the local long-poll loop. tgHandler implements
+			// core.MessageHandler (telegram/sdk_chat.go) and routes through the same
+			// comms.Handler, so command + intent handling is unchanged. Outbound
+			// stays on the existing messenger, and commands.go + the host-side
+			// photo/voice paths are untouched — the full cutover (delete commands.go,
+			// rewire the notifier) is a soak-gated follow-up. Default off: when
+			// sdk_bridge is unset the original StartPolling path runs verbatim.
+			tgBridge := sdkTelegram.New(sdkTelegram.Config{
+				BotToken:   cfg.Adapters.Telegram.BotToken,
+				AllowedIDs: cfg.Adapters.Telegram.AllowedIDs,
+			}, nil).NewChatBridge(sdkCore.ChatDeps{Handler: tgHandler})
+			if !dashboardMode {
+				fmt.Println("📱 Telegram SDK chat bridge started")
+			}
+			logging.WithComponent("start").Info("Telegram studio-sdk chat bridge started (sdk_bridge=true)")
+			go func() {
+				if err := tgBridge.Start(ctx); err != nil {
+					logging.WithComponent("telegram").Error("Telegram SDK bridge error", slog.Any("error", err))
+				}
+			}()
+		} else {
+			if !dashboardMode {
+				fmt.Println("📱 Telegram polling started")
+			}
+			tgHandler.StartPolling(ctx)
 		}
-		tgHandler.StartPolling(ctx)
 	}
 
 	// Start Slack Socket Mode if enabled (GH-652: wire into polling mode)

--- a/internal/adapters/telegram/notifier.go
+++ b/internal/adapters/telegram/notifier.go
@@ -15,6 +15,7 @@ type Config struct {
 	BotToken      string                 `yaml:"bot_token"`
 	ChatID        string                 `yaml:"chat_id"`
 	Polling       bool                   `yaml:"polling"`         // Enable inbound polling
+	SDKBridge     bool                   `yaml:"sdk_bridge"`      // GH-3470: drive inbound via the studio-sdk chat bridge instead of the local long-poll loop (opt-in; default off)
 	AllowedIDs    []int64                `yaml:"allowed_ids"`     // User/chat IDs allowed to send tasks
 	PlainTextMode bool                   `yaml:"plain_text_mode"` // Use plain text instead of Markdown (default: true for messaging apps)
 	Transcription *transcription.Config  `yaml:"transcription"`   // Voice message transcription config

--- a/internal/adapters/telegram/sdk_bridge_test.go
+++ b/internal/adapters/telegram/sdk_bridge_test.go
@@ -1,0 +1,32 @@
+package telegram
+
+import (
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	sdkCore "github.com/qf-studio/studio-sdk/sdk/core"
+	sdkTelegram "github.com/qf-studio/studio-sdk/sdk/integrations/telegram"
+)
+
+// The studio-sdk chat bridge must accept *telegram.Handler as its
+// core.MessageHandler — this is the exact wiring cmd/pilot/main.go performs when
+// sdk_bridge is enabled (GH-3470 Phase 6). Guards against an SDK API drift that
+// would only otherwise surface at daemon start.
+func TestSDKChatBridge_AcceptsHandler(t *testing.T) {
+	h := &Handler{} // zero value: HandleMessage tolerates a nil comms handler
+	bridge := sdkTelegram.New(sdkTelegram.Config{
+		BotToken: testutil.FakeTelegramBotToken,
+	}, nil).NewChatBridge(sdkCore.ChatDeps{Handler: h})
+	if bridge == nil {
+		t.Fatal("NewChatBridge returned nil for a valid *Handler")
+	}
+}
+
+// sdk_bridge must default off so existing deployments keep the long-poll path
+// (non-breaking opt-in).
+func TestConfig_SDKBridgeDefaultsOff(t *testing.T) {
+	var c Config
+	if c.SDKBridge {
+		t.Error("Config.SDKBridge should default to false (non-breaking)")
+	}
+}


### PR DESCRIPTION
## GH-3470 Phase 6 — phased Telegram SDK bridge (opt-in)

Builds on #3494 (handler-level `core.MessageHandler` conformance). This wires the
studio-sdk chat bridge into `cmd/pilot/main.go` **behind a default-off config
flag**, so Telegram inbound can run on the SDK contract without disturbing the
live control plane.

### What this does
- **`telegram.Config.SDKBridge`** (`yaml: sdk_bridge`), default `false`.
- **`cmd/pilot/main.go`** — when `sdk_bridge: true`, inbound starts via
  `sdkTelegram.New(cfg, nil).NewChatBridge(core.ChatDeps{Handler: tgHandler})`
  instead of `tgHandler.StartPolling(ctx)`. `tgHandler` already implements
  `core.MessageHandler` (#3494) and routes through the **same** `comms.Handler`,
  so command/intent handling is identical. When the flag is unset, the original
  `StartPolling` path runs **verbatim** — fully non-breaking.

### Deliberately phased (matches the issue's Scope-OUT: "delete commands.go after soak")
Untouched in this PR:
- `commands.go` (~620 LOC) — still drives the local command/callback path.
- `telegram_notifier.go` — the autopilot notify path is unchanged.
- Outbound messenger + host-side photo/voice handling.
- The gateway-mode `WithTelegramHandler` start path.

Known limitation while on the bridge: inbound flows as text only (photo/voice
host enrichment isn't on the bridge path yet) — acceptable for an opt-in soak
flag. The full cutover is a follow-up once this soaks.

### Verification
- `go build ./...`, `go vet ./cmd/pilot/ ./internal/adapters/telegram/` — clean
- `go test ./internal/adapters/telegram/` — ok (full package)
- New tests: bridge accepts `*Handler` as `core.MessageHandler`; `sdk_bridge`
  defaults off
- Note: local `make lint` reports 7 pre-existing `unused` funcs in
  `cmd/pilot/handlers.go` (Asana/Jira/Azure, present on `main`, unrelated to this
  change). CI's golangci-lint version does not flag them (lint passed on the
  current `main` HEAD).