### PR TITLE
docs: revert version.ts to v2.177.0 (remove spurious v2.178.0)

### DIFF
--- a/docs/lib/version.ts
+++ b/docs/lib/version.ts
@@ -1,4 +1,4 @@
 // Single source of truth for the current Pilot release shown in docs prose.
 // Auto-bumped by .github/workflows/docs-version-sync.yml on every v* tag push
 // via scripts/docs-version-sync.sh.
-export const CURRENT_VERSION = "v2.178.0"
+export const CURRENT_VERSION = "v2.177.0"


### PR DESCRIPTION
Reverts the `version.ts` auto-bump from #3500.

**Why:** the autopilot controller adopted the four manually-merged PRs
(#3494/#3495/#3497/#3498) as orphan PRs and ran `handleReleasing` per PR. It cut
**v2.178.0 at #3494's merge commit `4f8abd0f`**, which is an *ancestor* of
v2.177.0 (main HEAD `a417b768`) — a strict subset wrongly labeled higher and
marked "Latest", which also auto-bumped `version.ts` (#3500).

The spurious `v2.178.0` release + tag have been deleted, so `v2.177.0` is the
correct latest. This PR restores `version.ts` to `v2.177.0`.

Root cause was operational (hand-merging pilot PRs + a single manual tag while the
daemon was live); a follow-up will harden `handleReleasing` to treat a HeadSHA
that is an ancestor of an existing release tag as already-released.