### PR TITLE
docs(nav): record manual-merge spurious-release pitfall (mem-028)

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updated": "2026-06-04",
+  "updated": "2026-06-09",
   "nodes": {
     "concepts": {
       "pilot-architecture": {
@@ -120,6 +120,18 @@
         "description": "Per-execution git worktree isolation",
         "related": [
           "executor"
+        ]
+      },
+      "autopilot-release": {
+        "label": "Autopilot Release Pipeline",
+        "description": "Controller stages CI->merge->tag->release; reconcileOrphanPRs adopts open pilot/ PRs; handleReleasing cuts a per-PR release at HeadSHA with exact-SHA tag dedup.",
+        "files": [
+          "internal/autopilot/controller.go:1861",
+          "internal/autopilot/controller.go:2434"
+        ],
+        "related": [
+          "orchestrator",
+          "gateway"
         ]
       }
     },
@@ -500,6 +512,20 @@
         "confidence": 0.95,
         "created": "2026-06-04",
         "file": ".agent/knowledge/memories/learnings/learn_task359_layer1_shipped.md"
+      },
+      "mem-028": {
+        "type": "pitfall",
+        "summary": "Hand-merging a pilot/GH-* PR while the daemon runs makes the autopilot reconciler adopt it and cut a spurious per-PR release at the PR's own commit (exact-SHA dedup misses a tag on a descendant commit). 2026-06-09: manual v2.177.0 tag at #3498 -> controller cut v2.178.0 at #3494's ancestor commit, wrongly 'Latest'. Use fix/feat branch names or stop the daemon before hand-merging.",
+        "incident": "2026-06-09: manually merged #3494/95/97/98 + one manual v2.177.0 tag; only #3494 (pilot/ branch) was adopted; controller released it as spurious v2.178.0 (ancestor of v2.177.0). Cleaned up: deleted v2.178.0 release+tag, reverted version.ts (PR #3502).",
+        "severity": "high",
+        "concepts": [
+          "autopilot-release",
+          "orchestrator",
+          "worktree"
+        ],
+        "memory_file": ".agent/knowledge/memories/pitfalls/bug_manual_merge_spurious_release.md",
+        "created": "2026-06-09",
+        "confidence": 1.0
       }
     }
   },
@@ -663,6 +689,16 @@
       "from": "TASK-359",
       "to": "TASK-321",
       "type": "supersedes"
+    },
+    {
+      "from": "mem-028",
+      "to": "autopilot-release",
+      "type": "concerns"
+    },
+    {
+      "from": "mem-028",
+      "to": "orchestrator",
+      "type": "concerns"
     }
   ]
 }

--- a/.agent/knowledge/memories/pitfalls/bug_manual_merge_spurious_release.md
+++ b/.agent/knowledge/memories/pitfalls/bug_manual_merge_spurious_release.md
@@ -1,0 +1,18 @@
+---
+name: Hand-merging pilot/ PRs while the daemon runs → spurious per-PR releases
+description: The autopilot reconciler (reconcileOrphanPRs) adopts any open pilot/-prefixed PR; after merge, handleReleasing cuts a release per adopted PR at that PR's own commit. Its dedup is exact-SHA (GetTagForSHA(HeadSHA)), so a manual merge + single manual tag on a different (descendant) commit makes it cut an extra, lower-content release labeled higher. Hit 2026-06-09: manual v2.177.0 tag at #3498's merge commit → controller cut spurious v2.178.0 at #3494's ancestor commit, wrongly "Latest".
+type: pitfall
+---
+When you hand-merge a `pilot/GH-*`-branch PR with `gh pr merge` while the Pilot daemon is running, the autopilot controller will **re-release it on its own** — even though you already merged (and maybe released) it. Symptom: an extra GitHub release/tag appears at a commit that is an **ancestor** of your intended release, marked "Latest" despite containing **less** than the real head; `version.ts` auto-bumps to the wrong (higher) version via the `docs-version-sync` workflow.
+
+**Why:** `internal/autopilot/controller.go` `reconcileOrphanPRs` (~:2434) lists all **open `pilot/`-prefixed** PRs every reconcile tick and adopts any not already tracked via `OnPRCreated`. Once adopted and merged, the PR walks to `StageReleasing`, and `handleReleasing` (~:1861) cuts a release **per PR at `prState.HeadSHA`**. The dedup guard is exact-SHA: `GetTagForSHA(ctx, owner, repo, prState.HeadSHA)` (~:1878). If a tag exists at the PR's *own* commit it skips; otherwise it bumps and tags. So tagging a **descendant** commit (e.g. the squash-merge of a later PR) does **not** dedup an earlier adopted PR — it gets its own release.
+
+**Why (the 2026-06-09 incident):** I manually merged #3494/#3495/#3497/#3498 and cut **one** manual tag `v2.177.0` at `origin/main` (= #3498's merge commit `a417b768`). Only #3494's branch was `pilot/GH-3470-manual` (the others were `fix/…`/`feat/…`), so **only #3494 was adopted**. The controller cut **`v2.178.0` at #3494's merge commit `4f8abd0f`** — an ancestor of v2.177.0 — making "Latest" a strict subset (missing the TASK-354/TASK-320/bridge fixes) and bumping `version.ts` to v2.178.0 (PR #3500). It then wedged at `active_prs=1`, "going nowhere" on the release stage.
+
+**How to apply:**
+- **Prefer letting the daemon merge `pilot/GH-*` PRs.** If you must hand-merge while it runs, either (a) stop the daemon first, or (b) use a non-`pilot/` branch name (`fix/…`, `feat/…`) — those are NOT adopted by `reconcileOrphanPRs`.
+- Symptom to watch: a release tag/`version.ts` at a version higher than your intended one, "Latest" pointing at an **ancestor** of `main` HEAD. Verify with `git merge-base --is-ancestor <spurious-sha> <main-head-sha>`.
+- Cleanup: stop the daemon → `gh release delete <vX> --yes` + `git push origin :refs/tags/<vX>` → revert `version.ts` via a `fix/…`-branch PR → restart (clean: reconciler finds no open `pilot/` PRs, in-memory `active_prs` resets).
+- Recovery is safe to do with the daemon **stopped** only — if it's live, it re-creates the tag the moment `GetTagForSHA` returns empty.
+
+**Latent code weakness (follow-up):** `handleReleasing`'s dedup should treat a `HeadSHA` that is an **ancestor of any existing release tag** as already-released (not just exact-SHA). Today an adopted-but-already-shipped PR gets a redundant release. See [[bug_goreleaser_cancellation]] for other release-stage edge cases.


### PR DESCRIPTION
Navigator memory: a pitfall capturing today's autopilot spurious-release incident (v2.178.0). Hand-merging a `pilot/GH-*`-branch PR while the daemon runs makes `reconcileOrphanPRs` adopt it and `handleReleasing` cut a redundant per-PR release at the PR's own (ancestor) commit, because the dedup is exact-SHA. Adds the pitfall file + indexes it as mem-028 with a new `autopilot-release` concept. Docs-only.