### PR TITLE
fix(autopilot): dedup releases when commit is an ancestor of an existing tag

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -687,6 +687,22 @@ func (c *Client) CompareCommits(ctx context.Context, owner, repo, base, head str
 	return result.Commits, nil
 }
 
+// CompareStatus returns GitHub's relationship of head to base for base...head:
+// one of "ahead", "behind", "identical", or "diverged". It is the cheapest way
+// to ask "is base an ancestor of head?" — base...head is "ahead" when head
+// contains base plus more commits, and "identical" when they are the same
+// commit. Used to detect a commit already covered by an existing release tag.
+func (c *Client) CompareStatus(ctx context.Context, owner, repo, base, head string) (string, error) {
+	path := fmt.Sprintf("/repos/%s/%s/compare/%s...%s", owner, repo, base, head)
+	var result struct {
+		Status string `json:"status"`
+	}
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &result); err != nil {
+		return "", err
+	}
+	return result.Status, nil
+}
+
 // GetJobLogs fetches the logs for a GitHub Actions job (check run).
 // Uses GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs which returns
 // a 302 redirect to a log download URL. Returns the raw log text.

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1857,6 +1857,40 @@ func (c *Controller) shouldTriggerRelease() bool {
 	return rel != nil && rel.Enabled && rel.Trigger == "on_merge"
 }
 
+// tagCoveringCommit returns the name of an existing release tag that already
+// covers sha, or "" if none does. A tag "covers" sha when sha is the tag's
+// commit (exact match) OR sha is an ancestor of the tag's commit — i.e. the
+// commit was already shipped inside a later release. This is a superset of
+// GetTagForSHA's exact-match dedup and guards handleReleasing against cutting a
+// redundant, lower-content release for already-released work.
+//
+// The ancestor probe uses the compare API (base=sha, head=tag): "ahead" means
+// the tag contains sha plus more commits, "identical" means same commit —
+// either way sha is covered. Any lookup error is propagated so the caller
+// retries on the next poll rather than tagging on uncertain state (TASK-316).
+func (c *Controller) tagCoveringCommit(ctx context.Context, owner, repo, sha string) (string, error) {
+	// 10 most recent tags: a redundant release only happens when sha is an
+	// ancestor of a recent tag (the current release line), so a bounded list
+	// keeps the compare-call fan-out small.
+	tags, err := c.ghClient.ListTags(ctx, owner, repo, 10)
+	if err != nil {
+		return "", err
+	}
+	for _, tag := range tags {
+		if tag.Commit.SHA == sha {
+			return tag.Name, nil
+		}
+		status, err := c.ghClient.CompareStatus(ctx, owner, repo, sha, tag.Commit.SHA)
+		if err != nil {
+			return "", err
+		}
+		if status == "ahead" || status == "identical" {
+			return tag.Name, nil
+		}
+	}
+	return "", nil
+}
+
 // handleReleasing creates a release after successful merge and CI.
 func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) error {
 	if c.releaser == nil {
@@ -1871,11 +1905,16 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	// correct repo to avoid stuck-forever releasing state.
 	owner, repo := prState.RepoOwnerAndName(c.owner, c.repo)
 
-	// Race condition guard: Check if this commit already has a tag.
+	// Race condition guard: Check if this commit is already covered by a tag.
 	// When multiple PRs merge rapidly, each triggers handleReleasing but only
-	// the first should create a tag. Subsequent PRs will see their merge commit
-	// is already tagged (by an earlier release) and skip.
-	existingTag, err := c.ghClient.GetTagForSHA(ctx, owner, repo, prState.HeadSHA)
+	// the first should create a tag. Subsequent PRs see their commit is already
+	// covered (by an earlier release) and skip. "Covered" means either the
+	// commit is tagged exactly, OR it is an ANCESTOR of an existing release
+	// tag's commit — e.g. it was already shipped inside a later squash-merge or
+	// a manual tag on a descendant commit. Without the ancestor check we cut a
+	// redundant, lower-content release for already-shipped work (the spurious
+	// v2.178.0 incident: #3494's commit was an ancestor of v2.177.0).
+	existingTag, err := c.tagCoveringCommit(ctx, owner, repo, prState.HeadSHA)
 	if err != nil {
 		// Transient lookup failure: do NOT fall through to CreateTagForRepo. If a
 		// tag already exists but we couldn't see it, the create call fails with
@@ -1885,7 +1924,7 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		return fmt.Errorf("failed to check existing tags for PR #%d: %w", prState.PRNumber, err)
 	}
 	if existingTag != "" {
-		c.log.Info("commit already tagged, skipping release",
+		c.log.Info("commit already covered by existing tag, skipping release",
 			"pr", prState.PRNumber,
 			"sha", ShortSHA(prState.HeadSHA),
 			"tag", existingTag,

--- a/internal/autopilot/controller_releasing_test.go
+++ b/internal/autopilot/controller_releasing_test.go
@@ -156,3 +156,98 @@ func TestHandleReleasing_DuplicateTagTreatedAsReleased(t *testing.T) {
 		t.Error("PR must be removed from tracking once the tag is confirmed to exist")
 	}
 }
+
+// tagAt builds a github.Tag pointing a tag name at a commit SHA. It avoids
+// spelling out the anonymous Commit struct literal at each call site.
+func tagAt(name, sha string) github.Tag {
+	tag := github.Tag{Name: name}
+	tag.Commit.SHA = sha
+	return tag
+}
+
+// TestHandleReleasing_AncestorTagDedup verifies handleReleasing treats a PR
+// whose HeadSHA is already covered by an existing tag — tagged exactly, or an
+// ANCESTOR of a tag's commit — as already released: the PR drains from
+// activePRs WITHOUT cutting a new tag. Only a genuinely uncovered commit
+// (diverged/behind the existing tags) proceeds to a release. This guards the
+// spurious-v2.178.0 case where an ancestor commit cut a redundant release.
+func TestHandleReleasing_AncestorTagDedup(t *testing.T) {
+	const headSHA = "headsha000"
+	tests := []struct {
+		name          string
+		tags          []github.Tag
+		compareStatus string // status the compare API returns for headSHA...tagSHA
+		wantTagCreate bool   // expect POST /git/refs (a new release tag)
+		wantTracked   bool   // expect the PR still tracked afterward
+	}{
+		{
+			name:          "exact SHA match skips release",
+			tags:          []github.Tag{tagAt("v2.0.0", headSHA)},
+			wantTagCreate: false,
+			wantTracked:   false,
+		},
+		{
+			name: "ancestor of existing tag skips release",
+			tags: []github.Tag{tagAt("v2.0.0", "descendantsha")},
+			// base=headSHA...head=tagSHA is "ahead": the tag contains headSHA
+			// plus more commits, so headSHA is already shipped inside the tag.
+			compareStatus: "ahead",
+			wantTagCreate: false,
+			wantTracked:   false,
+		},
+		{
+			name:          "diverged commit cuts a release",
+			tags:          []github.Tag{tagAt("v2.0.0", "unrelatedsha")},
+			compareStatus: "diverged",
+			wantTagCreate: true,
+			wantTracked:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tagCreated := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(tt.tags)
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(map[string]string{"status": tt.compareStatus})
+				case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/releases/latest"):
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(github.Release{TagName: "v2.0.0"})
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/commits"):
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat: add a thing")})
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
+					tagCreated = true
+					w.WriteHeader(http.StatusCreated)
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			c := newReleasingController(t, server.URL)
+			prState := &PRState{PRNumber: 200, HeadSHA: headSHA, Stage: StageReleasing}
+			c.mu.Lock()
+			c.activePRs[200] = prState
+			c.mu.Unlock()
+
+			if err := c.handleReleasing(context.Background(), prState); err != nil {
+				t.Fatalf("handleReleasing returned error: %v", err)
+			}
+			if tagCreated != tt.wantTagCreate {
+				t.Errorf("tag created = %v, want %v", tagCreated, tt.wantTagCreate)
+			}
+			c.mu.RLock()
+			_, tracked := c.activePRs[200]
+			c.mu.RUnlock()
+			if tracked != tt.wantTracked {
+				t.Errorf("PR tracked = %v, want %v", tracked, tt.wantTracked)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`handleReleasing` dedups with an **exact-SHA** check (`GetTagForSHA` at `internal/autopilot/controller.go`). When a PR's `HeadSHA` is an **ancestor** of an existing release tag's commit — already shipped inside a later squash-merge, or a manual tag on a descendant commit — it does **not** dedup and cuts a **redundant, lower-content release**.

Root cause of this session's spurious `v2.178.0` incident: #3494's commit was an ancestor of `v2.177.0`, so the reconciler cut a second tag at the older commit.

## Fix

- New `tagCoveringCommit(ctx, owner, repo, sha)` on the controller: a tag "covers" a commit when it's the tag's commit (exact match) **or** the commit is an ancestor of the tag's commit. Superset of the old exact-match dedup.
- Ancestor probe via a new `github.Client.CompareStatus(base, head)` — wraps the compare API and returns `ahead`/`behind`/`identical`/`diverged`. `base=sha...head=tag` is `ahead` (tag contains sha + more) or `identical` ⇒ covered.
- On match the PR drains from `activePRs` **without** creating a tag. Lookup errors are propagated so the PR retries on the next poll rather than tagging on uncertain state (consistent with TASK-316).
- Bounded to the 10 most recent tags to keep the compare fan-out small.

## Tests

`TestHandleReleasing_AncestorTagDedup` (table-driven):
- exact-SHA match → skip release, PR drained, no tag created
- ancestor match (`compare` = `ahead`) → skip release, PR drained, no tag created
- diverged commit → cuts a release (tag created)

Existing `TestHandleReleasing_GetTagForSHAError` / `_DuplicateTagTreatedAsReleased` still pass (lookup-failure + duplicate-tag paths unchanged).

## Verification

- `go test -race ./internal/... ./cmd/...` — green
- `golangci-lint run ./internal/autopilot/... ./internal/adapters/github/...` — 0 issues
  (the 7 repo-wide `unused` findings in `cmd/pilot/handlers.go` are pre-existing on `main`, unrelated)