### PR TITLE
fix(spec-guard): write board Failed status on spec-block

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -307,7 +307,11 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 		}
 		specResult := github.ValidateSpec(issue, parentResolver)
 		if !specResult.Valid && specResult.SkipReason == "" {
-			applySpecGuard(ctx, client, parts[0], parts[1], issue, specResult.FailureReasons)
+			var specBoardSync projectBoardSyncer
+			if boardSync != nil {
+				specBoardSync = boardSync
+			}
+			applySpecGuard(ctx, client, parts[0], parts[1], issue, specResult.FailureReasons, specBoardSync, cfg.Adapters.GitHub.ProjectBoard.GetStatuses().Failed)
 			return &github.IssueResult{Success: false}, nil
 		}
 	}

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -307,7 +307,7 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 		}
 		specResult := github.ValidateSpec(issue, parentResolver)
 		if !specResult.Valid && specResult.SkipReason == "" {
-			applySpecGuard(ctx, client, parts[0], parts[1], issue, specResult.FailureReasons)
+			applySpecGuard(ctx, client, parts[0], parts[1], issue, specResult.FailureReasons, boardSync, cfg.Adapters.GitHub.ProjectBoard.GetStatuses().Failed)
 			return &github.IssueResult{Success: false}, nil
 		}
 	}

--- a/cmd/pilot/handlers_spec_test.go
+++ b/cmd/pilot/handlers_spec_test.go
@@ -59,7 +59,7 @@ func TestApplySpecGuard_FirstStrike(t *testing.T) {
 	issue := &github.Issue{Number: 42}
 	reasons := []string{"body too short (10 chars, need 100)"}
 
-	skipped := applySpecGuard(context.Background(), client, "owner", "repo", issue, reasons)
+	skipped := applySpecGuard(context.Background(), client, "owner", "repo", issue, reasons, nil, "")
 	if !skipped {
 		t.Fatal("expected applySpecGuard to return true (skip dispatch)")
 	}
@@ -86,7 +86,7 @@ func TestApplySpecGuard_SecondStrike(t *testing.T) {
 	issue := &github.Issue{Number: 42}
 	reasons := []string{"body too short (10 chars, need 100)"}
 
-	skipped := applySpecGuard(context.Background(), client, "owner", "repo", issue, reasons)
+	skipped := applySpecGuard(context.Background(), client, "owner", "repo", issue, reasons, nil, "")
 	if !skipped {
 		t.Fatal("expected applySpecGuard to return true (skip dispatch)")
 	}
@@ -110,7 +110,7 @@ func TestApplySpecGuard_SkippedWhenCommentListFails(t *testing.T) {
 	issue := &github.Issue{Number: 42}
 	reasons := []string{"body too short"}
 
-	skipped := applySpecGuard(context.Background(), client, "owner", "repo", issue, reasons)
+	skipped := applySpecGuard(context.Background(), client, "owner", "repo", issue, reasons, nil, "")
 	if skipped {
 		t.Error("expected applySpecGuard to return false (don't block) when comment listing fails")
 	}

--- a/cmd/pilot/spec_guard.go
+++ b/cmd/pilot/spec_guard.go
@@ -9,12 +9,18 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/github"
 )
 
+// projectBoardSyncer abstracts board-status writes so applySpecGuard can be tested without a real GitHub client.
+type projectBoardSyncer interface {
+	UpdateProjectItemStatus(ctx context.Context, nodeID string, status string) error
+}
+
 // applySpecGuard runs the two-strike spec validation gate for a GitHub issue.
 // Returns true when dispatch should be skipped (guard fired), false to proceed.
 //
 // First call with a failing issue adds pilot-spec-incomplete and posts a structured comment.
 // Subsequent call (comment marker already present) escalates to pilot-blocked.
-func applySpecGuard(ctx context.Context, client *github.Client, owner, repo string, issue *github.Issue, reasons []string) bool {
+// boardSync and failedStatus are optional: when non-nil/non-empty the issue card is moved to the Failed column.
+func applySpecGuard(ctx context.Context, client *github.Client, owner, repo string, issue *github.Issue, reasons []string, boardSync projectBoardSyncer, failedStatus string) bool {
 	comments, err := client.ListIssueComments(ctx, owner, repo, issue.Number)
 	if err != nil {
 		slog.Warn("spec-guard: failed to list comments, skipping guard",
@@ -49,6 +55,14 @@ func applySpecGuard(ctx context.Context, client *github.Client, owner, repo stri
 		slog.Warn("spec-guard: second strike — escalating to pilot-blocked",
 			slog.Int("issue", issue.Number))
 	}
+
+	if boardSync != nil && issue.NodeID != "" && failedStatus != "" {
+		if err := boardSync.UpdateProjectItemStatus(ctx, issue.NodeID, failedStatus); err != nil {
+			slog.Warn("spec-guard: board sync failed",
+				slog.Int("issue", issue.Number), slog.Any("error", err))
+		}
+	}
+
 	return true
 }
 

--- a/cmd/pilot/spec_guard.go
+++ b/cmd/pilot/spec_guard.go
@@ -9,12 +9,19 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/github"
 )
 
+// projectBoardSyncer is satisfied by *github.ProjectBoardSync.
+type projectBoardSyncer interface {
+	UpdateProjectItemStatus(ctx context.Context, issueNodeID string, statusName string) error
+}
+
 // applySpecGuard runs the two-strike spec validation gate for a GitHub issue.
 // Returns true when dispatch should be skipped (guard fired), false to proceed.
 //
 // First call with a failing issue adds pilot-spec-incomplete and posts a structured comment.
 // Subsequent call (comment marker already present) escalates to pilot-blocked.
-func applySpecGuard(ctx context.Context, client *github.Client, owner, repo string, issue *github.Issue, reasons []string) bool {
+// When boardSync is non-nil, issue.NodeID is non-empty, and failedStatus is non-empty,
+// the issue's project board card is moved to failedStatus after the label work.
+func applySpecGuard(ctx context.Context, client *github.Client, owner, repo string, issue *github.Issue, reasons []string, boardSync projectBoardSyncer, failedStatus string) bool {
 	comments, err := client.ListIssueComments(ctx, owner, repo, issue.Number)
 	if err != nil {
 		slog.Warn("spec-guard: failed to list comments, skipping guard",
@@ -49,6 +56,14 @@ func applySpecGuard(ctx context.Context, client *github.Client, owner, repo stri
 		slog.Warn("spec-guard: second strike — escalating to pilot-blocked",
 			slog.Int("issue", issue.Number))
 	}
+
+	if boardSync != nil && issue.NodeID != "" && failedStatus != "" {
+		if err := boardSync.UpdateProjectItemStatus(ctx, issue.NodeID, failedStatus); err != nil {
+			slog.Warn("spec-guard: board sync failed",
+				slog.Int("issue", issue.Number), slog.Any("error", err))
+		}
+	}
+
 	return true
 }
 

--- a/cmd/pilot/spec_guard_test.go
+++ b/cmd/pilot/spec_guard_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// mockBoardSyncer is a test double for projectBoardSyncer.
+type mockBoardSyncer struct {
+	called    bool
+	nodeID    string
+	status    string
+	returnErr error
+}
+
+func (m *mockBoardSyncer) UpdateProjectItemStatus(_ context.Context, nodeID, status string) error {
+	m.called = true
+	m.nodeID = nodeID
+	m.status = status
+	return m.returnErr
+}
+
+func TestApplySpecGuard_BoardSync(t *testing.T) {
+	tests := []struct {
+		name          string
+		boardSync     projectBoardSyncer
+		nodeID        string
+		failedStatus  string
+		boardCallWant bool
+		wantNodeID    string
+		wantStatus    string
+	}{
+		{
+			name:          "happy-path write",
+			boardSync:     &mockBoardSyncer{},
+			nodeID:        "NODE_42",
+			failedStatus:  "Failed",
+			boardCallWant: true,
+			wantNodeID:    "NODE_42",
+			wantStatus:    "Failed",
+		},
+		{
+			name:          "nil syncer skip",
+			boardSync:     nil,
+			nodeID:        "NODE_42",
+			failedStatus:  "Failed",
+			boardCallWant: false,
+		},
+		{
+			name:          "empty NodeID skip",
+			boardSync:     &mockBoardSyncer{},
+			nodeID:        "",
+			failedStatus:  "Failed",
+			boardCallWant: false,
+		},
+		{
+			name:          "empty failedStatus skip",
+			boardSync:     &mockBoardSyncer{},
+			nodeID:        "NODE_42",
+			failedStatus:  "",
+			boardCallWant: false,
+		},
+		{
+			name:          "transport-error swallow",
+			boardSync:     &mockBoardSyncer{returnErr: errors.New("graphql: timeout")},
+			nodeID:        "NODE_42",
+			failedStatus:  "Failed",
+			boardCallWant: true,
+			wantNodeID:    "NODE_42",
+			wantStatus:    "Failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var labelsAdded []string
+			srv := newSpecTestServer(t, `[]`, &labelsAdded)
+			defer srv.Close()
+
+			client := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+			issue := &github.Issue{Number: 42, NodeID: tc.nodeID}
+
+			result := applySpecGuard(
+				context.Background(), client, "owner", "repo",
+				issue, []string{"body too short"},
+				tc.boardSync, tc.failedStatus,
+			)
+
+			if !result {
+				t.Fatal("expected applySpecGuard to return true (guard fired)")
+			}
+
+			// For nil syncer, there is no mock to inspect.
+			if tc.boardSync == nil {
+				return
+			}
+			mock, ok := tc.boardSync.(*mockBoardSyncer)
+			if !ok {
+				return
+			}
+			if mock.called != tc.boardCallWant {
+				t.Errorf("UpdateProjectItemStatus called=%v, want %v", mock.called, tc.boardCallWant)
+			}
+			if tc.boardCallWant {
+				if mock.nodeID != tc.wantNodeID {
+					t.Errorf("nodeID=%q, want %q", mock.nodeID, tc.wantNodeID)
+				}
+				if mock.status != tc.wantStatus {
+					t.Errorf("status=%q, want %q", mock.status, tc.wantStatus)
+				}
+			}
+		})
+	}
+}

--- a/cmd/pilot/spec_guard_test.go
+++ b/cmd/pilot/spec_guard_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// stubBoardSyncer is a minimal projectBoardSyncer for testing.
+type stubBoardSyncer struct {
+	err      error
+	calls    []string // accumulated nodeID+status pairs, joined as "nodeID:status"
+}
+
+func (s *stubBoardSyncer) UpdateProjectItemStatus(_ context.Context, nodeID, status string) error {
+	s.calls = append(s.calls, nodeID+":"+status)
+	return s.err
+}
+
+// newSpecGuardServer returns a minimal HTTP server that satisfies the GitHub API
+// calls made by applySpecGuard: list comments (returns empty list) and accept
+// POST label / comment requests without error.
+func newSpecGuardServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments"):
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":1,"body":"ok"}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+}
+
+func TestApplySpecGuard_BoardSync(t *testing.T) {
+	cases := []struct {
+		name         string
+		nodeID       string
+		failedStatus string
+		syncer       *stubBoardSyncer // nil means pass nil interface
+		wantCalls    int              // expected number of UpdateProjectItemStatus calls
+		wantErr      bool             // syncer.err set to non-nil
+	}{
+		{
+			name:         "happy-path write",
+			nodeID:       "I_node1",
+			failedStatus: "Failed",
+			syncer:       &stubBoardSyncer{},
+			wantCalls:    1,
+		},
+		{
+			name:         "nil syncer skip",
+			nodeID:       "I_node1",
+			failedStatus: "Failed",
+			syncer:       nil,
+			wantCalls:    0,
+		},
+		{
+			name:         "empty NodeID skip",
+			nodeID:       "",
+			failedStatus: "Failed",
+			syncer:       &stubBoardSyncer{},
+			wantCalls:    0,
+		},
+		{
+			name:         "empty failedStatus skip",
+			nodeID:       "I_node1",
+			failedStatus: "",
+			syncer:       &stubBoardSyncer{},
+			wantCalls:    0,
+		},
+		{
+			name:         "transport-error swallow",
+			nodeID:       "I_node1",
+			failedStatus: "Failed",
+			syncer:       &stubBoardSyncer{err: errors.New("network timeout")},
+			wantCalls:    1,
+			wantErr:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newSpecGuardServer(t)
+			defer srv.Close()
+
+			client := github.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+			issue := &github.Issue{Number: 42, NodeID: tc.nodeID}
+
+			var syncer projectBoardSyncer
+			if tc.syncer != nil {
+				syncer = tc.syncer
+			}
+
+			got := applySpecGuard(context.Background(), client, "owner", "repo", issue, []string{"thin body"}, syncer, tc.failedStatus)
+			if !got {
+				t.Fatal("applySpecGuard returned false (no-skip); expected true")
+			}
+
+			if tc.syncer == nil {
+				return
+			}
+			if len(tc.syncer.calls) != tc.wantCalls {
+				t.Errorf("UpdateProjectItemStatus called %d times, want %d", len(tc.syncer.calls), tc.wantCalls)
+			}
+			if tc.wantCalls > 0 && len(tc.syncer.calls) > 0 {
+				want := tc.nodeID + ":" + tc.failedStatus
+				if tc.syncer.calls[0] != want {
+					t.Errorf("UpdateProjectItemStatus called with %q, want %q", tc.syncer.calls[0], want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Extends `applySpecGuard()` in `cmd/pilot/spec_guard.go` with a locally-defined `projectBoardSyncer` interface and two new params: `boardSync projectBoardSyncer` and `failedStatus string`
- After label work (both first- and second-strike paths), moves the issue card to `failedStatus` when all three guards pass: `boardSync != nil && issue.NodeID != "" && failedStatus != ""`; transport errors are log-and-swallowed via `slog.Warn`
- Updates the call site in `handlers.go` with a nil-safe interface conversion before passing to `applySpecGuard`
- Adds `spec_guard_test.go` with 5 table-driven cases: happy-path write, nil syncer skip, empty NodeID skip, empty failedStatus skip, transport-error swallow

## Test plan

- [ ] `make build` passes
- [ ] `make test` passes (all `TestApplySpecGuard_*` cases green)
- [ ] `make lint` reports 0 issues