### PR TITLE
feat(gateway): scope dashboard HTTP API to daemon project path

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -2256,7 +2256,7 @@ func checkForUpdates() {
 }
 
 // runDashboardMode runs the TUI dashboard with live task updates
-func runDashboardMode(p *pilot.Pilot, cfg *config.Config, gwProgram *tea.Program, gwMonitor *executor.Monitor, gwRunner *executor.Runner) error {
+func runDashboardMode(p *pilot.Pilot, cfg *config.Config, gwProgram *tea.Program, gwMonitor *executor.Monitor, gwRunner *executor.Runner, projectPath string) error {
 	// Suppress slog output to prevent corrupting TUI display (GH-164)
 	logging.Suppress()
 	p.SuppressProgressLogs(true)
@@ -2284,6 +2284,15 @@ func runDashboardMode(p *pilot.Pilot, cfg *config.Config, gwProgram *tea.Program
 			allStates = append(allStates, gwMonitor.GetAll()...)
 		}
 		allStates = append(allStates, p.GetTaskStates()...)
+		if projectPath != "" {
+			filtered := allStates[:0]
+			for _, s := range allStates {
+				if s.ProjectPath == projectPath {
+					filtered = append(filtered, s)
+				}
+			}
+			allStates = filtered
+		}
 		return convertTaskStatesToDisplay(allStates)
 	}
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1016,6 +1016,7 @@ Examples:
 				p.Gateway().SetDashboardStore(gwStore)
 				p.Gateway().SetLogStreamStore(gwStore)
 			}
+			p.Gateway().SetDashboardProjectPath("") // GH-3515: subtask 3 wires real project path
 
 			// GH-1633: Wire git graph fetcher to gateway so /api/v1/gitgraph returns live git data
 			p.Gateway().SetGitGraphFetcher(func(path string, limit int) interface{} {
@@ -1711,6 +1712,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			gwServer.SetDashboardStore(store)
 			gwServer.SetLogStreamStore(store)
 		}
+		gwServer.SetDashboardProjectPath("") // GH-3515: subtask 3 wires real project path
 		gwServer.SetGitGraphFetcher(func(path string, limit int) interface{} {
 			return dashboard.FetchGitGraph(path, limit)
 		})

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1016,7 +1016,7 @@ Examples:
 				p.Gateway().SetDashboardStore(gwStore)
 				p.Gateway().SetLogStreamStore(gwStore)
 			}
-			p.Gateway().SetDashboardProjectPath("") // GH-3515: subtask 3 wires real project path
+			p.Gateway().SetDashboardProjectPath(projectPath)
 
 			// GH-1633: Wire git graph fetcher to gateway so /api/v1/gitgraph returns live git data
 			p.Gateway().SetGitGraphFetcher(func(path string, limit int) interface{} {
@@ -1092,7 +1092,7 @@ Examples:
 			if dashboardMode {
 				// GH-2291: Pass adapter poller infrastructure so the dashboard
 				// merges task states from both adapter pollers and gateway webhooks.
-				return runDashboardMode(p, cfg, gwProgram, gwMonitor, gwRunner)
+				return runDashboardMode(p, cfg, gwProgram, gwMonitor, gwRunner, projectPath)
 			}
 
 			// Show startup banner (headless mode)
@@ -1712,7 +1712,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			gwServer.SetDashboardStore(store)
 			gwServer.SetLogStreamStore(store)
 		}
-		gwServer.SetDashboardProjectPath("") // GH-3515: subtask 3 wires real project path
+		gwServer.SetDashboardProjectPath(projectPath)
 		gwServer.SetGitGraphFetcher(func(path string, limit int) interface{} {
 			return dashboard.FetchGitGraph(path, limit)
 		})

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -71,12 +71,12 @@ func (a *App) GetMetrics() DashboardMetrics {
 		return DashboardMetrics{}
 	}
 
-	lt, err := a.store.GetLifetimeTokens()
+	lt, err := a.store.GetLifetimeTokens("")
 	if err != nil {
 		lt = &memory.LifetimeTokens{}
 	}
 
-	tc, err := a.store.GetLifetimeTaskCounts()
+	tc, err := a.store.GetLifetimeTaskCounts("")
 	if err != nil {
 		tc = &memory.LifetimeTaskCounts{}
 	}
@@ -128,7 +128,7 @@ func (a *App) GetQueueTasks() []QueueTask {
 		return nil
 	}
 
-	execs, err := a.store.GetRecentExecutions(50)
+	execs, err := a.store.GetRecentExecutions(50, "")
 	if err != nil {
 		return nil
 	}
@@ -183,7 +183,7 @@ func (a *App) GetHistory(limit int) []HistoryEntry {
 		limit = 5
 	}
 
-	execs, err := a.store.GetRecentExecutions(limit)
+	execs, err := a.store.GetRecentExecutions(limit, "")
 	if err != nil {
 		return nil
 	}

--- a/internal/adapters/telegram/commands.go
+++ b/internal/adapters/telegram/commands.go
@@ -415,7 +415,7 @@ func (c *CommandHandler) handleHistory(ctx context.Context, chatID string) {
 		return
 	}
 
-	executions, err := c.store.GetRecentExecutions(10)
+	executions, err := c.store.GetRecentExecutions(10, "")
 	if err != nil {
 		_, _ = c.handler.client.SendMessage(ctx, chatID, "❌ Failed to fetch history", "")
 		return

--- a/internal/comms/commands.go
+++ b/internal/comms/commands.go
@@ -379,7 +379,7 @@ func (c *CommandHandler) handleHistory(ctx context.Context, contextID string) {
 		return
 	}
 
-	executions, err := c.store.GetRecentExecutions(10)
+	executions, err := c.store.GetRecentExecutions(10, "")
 	if err != nil {
 		_ = c.messenger.SendText(ctx, contextID, "❌ Failed to fetch history")
 		return

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -577,7 +577,7 @@ func (m *Model) hydrateFromStore() {
 	}
 
 	// Load recent executions as completed tasks
-	executions, err := m.store.GetRecentExecutions(20)
+	executions, err := m.store.GetRecentExecutions(20, "")
 	if err != nil {
 		slog.Warn("failed to load recent executions", slog.Any("error", err))
 		return
@@ -585,7 +585,7 @@ func (m *Model) hydrateFromStore() {
 
 	// Initialize metrics card from lifetime execution data (survives restarts).
 	// Session tokens only track the current process; executions table has the real totals.
-	lifetime, err := m.store.GetLifetimeTokens()
+	lifetime, err := m.store.GetLifetimeTokens("")
 	if err != nil {
 		slog.Warn("failed to load lifetime tokens", slog.Any("error", err))
 	} else {
@@ -597,7 +597,7 @@ func (m *Model) hydrateFromStore() {
 
 	// Initialize task counts from lifetime data (survives restarts).
 	// Previous code sampled from GetRecentExecutions(20), showing only last 20 results.
-	taskCounts, err := m.store.GetLifetimeTaskCounts()
+	taskCounts, err := m.store.GetLifetimeTaskCounts("")
 	if err != nil {
 		slog.Warn("failed to load lifetime task counts", slog.Any("error", err))
 	} else {
@@ -842,7 +842,7 @@ func storeRefreshCmd(store *memory.Store) tea.Cmd {
 	return func() tea.Msg {
 		msg := storeRefreshMsg{}
 
-		executions, err := store.GetRecentExecutions(20)
+		executions, err := store.GetRecentExecutions(20, "")
 		if err != nil {
 			slog.Warn("store refresh: failed to load executions", slog.Any("error", err))
 			return msg
@@ -869,7 +869,7 @@ func storeRefreshCmd(store *memory.Store) tea.Cmd {
 			})
 		}
 
-		lifetime, err := store.GetLifetimeTokens()
+		lifetime, err := store.GetLifetimeTokens("")
 		if err != nil {
 			slog.Warn("store refresh: failed to load lifetime tokens", slog.Any("error", err))
 		} else {
@@ -879,7 +879,7 @@ func storeRefreshCmd(store *memory.Store) tea.Cmd {
 			msg.metricsCard.TotalCostUSD = lifetime.TotalCostUSD
 		}
 
-		taskCounts, err := store.GetLifetimeTaskCounts()
+		taskCounts, err := store.GetLifetimeTaskCounts("")
 		if err != nil {
 			slog.Warn("store refresh: failed to load task counts", slog.Any("error", err))
 		} else {

--- a/internal/gateway/dashboard.go
+++ b/internal/gateway/dashboard.go
@@ -18,10 +18,10 @@ type GitGraphFetcher func(projectPath string, limit int) interface{}
 
 // DashboardStore provides read access to execution and metrics data for the dashboard API.
 type DashboardStore interface {
-	GetLifetimeTokens() (*memory.LifetimeTokens, error)
-	GetLifetimeTaskCounts() (*memory.LifetimeTaskCounts, error)
+	GetLifetimeTokens(projectPath string) (*memory.LifetimeTokens, error)
+	GetLifetimeTaskCounts(projectPath string) (*memory.LifetimeTaskCounts, error)
 	GetDailyMetrics(query memory.MetricsQuery) ([]*memory.DailyMetrics, error)
-	GetRecentExecutions(limit int) ([]*memory.Execution, error)
+	GetRecentExecutions(limit int, projectPath string) ([]*memory.Execution, error)
 	GetQueuedTasks(limit int) ([]*memory.Execution, error)
 	GetActiveExecutions() ([]*memory.Execution, error)
 	GetRecentLogs(limit int) ([]*memory.LogEntry, error)
@@ -32,6 +32,14 @@ func (s *Server) SetDashboardStore(store DashboardStore) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.dashboardStore = store
+}
+
+// SetDashboardProjectPath scopes the dashboard metrics, queue, and history endpoints
+// to a single project directory. Pass "" to aggregate across all projects (daemon default).
+func (s *Server) SetDashboardProjectPath(path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dashboardProjectPath = path
 }
 
 // --- JSON response types (mirrors desktop/types.go) ---
@@ -89,6 +97,7 @@ func (s *Server) handleDashboardMetrics(w http.ResponseWriter, r *http.Request) 
 
 	s.mu.RLock()
 	store := s.dashboardStore
+	projectPath := s.dashboardProjectPath
 	s.mu.RUnlock()
 
 	if store == nil {
@@ -96,12 +105,12 @@ func (s *Server) handleDashboardMetrics(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	lt, err := store.GetLifetimeTokens()
+	lt, err := store.GetLifetimeTokens(projectPath)
 	if err != nil {
 		lt = &memory.LifetimeTokens{}
 	}
 
-	tc, err := store.GetLifetimeTaskCounts()
+	tc, err := store.GetLifetimeTaskCounts(projectPath)
 	if err != nil {
 		tc = &memory.LifetimeTaskCounts{}
 	}
@@ -155,6 +164,7 @@ func (s *Server) handleDashboardQueue(w http.ResponseWriter, r *http.Request) {
 
 	s.mu.RLock()
 	store := s.dashboardStore
+	projectPath := s.dashboardProjectPath
 	s.mu.RUnlock()
 
 	if store == nil {
@@ -162,7 +172,7 @@ func (s *Server) handleDashboardQueue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	execs, err := store.GetRecentExecutions(50)
+	execs, err := store.GetRecentExecutions(50, projectPath)
 	if err != nil {
 		http.Error(w, "failed to fetch queue", http.StatusInternalServerError)
 		return
@@ -202,6 +212,7 @@ func (s *Server) handleDashboardHistory(w http.ResponseWriter, r *http.Request) 
 
 	s.mu.RLock()
 	store := s.dashboardStore
+	projectPath := s.dashboardProjectPath
 	s.mu.RUnlock()
 
 	if store == nil {
@@ -216,7 +227,7 @@ func (s *Server) handleDashboardHistory(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	execs, err := store.GetRecentExecutions(limit)
+	execs, err := store.GetRecentExecutions(limit, projectPath)
 	if err != nil {
 		http.Error(w, "failed to fetch history", http.StatusInternalServerError)
 		return

--- a/internal/gateway/dashboard_test.go
+++ b/internal/gateway/dashboard_test.go
@@ -19,13 +19,20 @@ type mockDashboardStore struct {
 	queuedTasks    []*memory.Execution
 	activeExecs    []*memory.Execution
 	logEntries     []*memory.LogEntry
+
+	// Capture last projectPath arg passed to each scoped method.
+	gotTokensPath     string
+	gotTaskCountsPath string
+	gotExecsPaths     []string // appended on each GetRecentExecutions call
 }
 
-func (m *mockDashboardStore) GetLifetimeTokens() (*memory.LifetimeTokens, error) {
+func (m *mockDashboardStore) GetLifetimeTokens(projectPath string) (*memory.LifetimeTokens, error) {
+	m.gotTokensPath = projectPath
 	return m.lifetimeTokens, nil
 }
 
-func (m *mockDashboardStore) GetLifetimeTaskCounts() (*memory.LifetimeTaskCounts, error) {
+func (m *mockDashboardStore) GetLifetimeTaskCounts(projectPath string) (*memory.LifetimeTaskCounts, error) {
+	m.gotTaskCountsPath = projectPath
 	return m.taskCounts, nil
 }
 
@@ -33,7 +40,8 @@ func (m *mockDashboardStore) GetDailyMetrics(_ memory.MetricsQuery) ([]*memory.D
 	return m.dailyMetrics, nil
 }
 
-func (m *mockDashboardStore) GetRecentExecutions(_ int) ([]*memory.Execution, error) {
+func (m *mockDashboardStore) GetRecentExecutions(_ int, projectPath string) ([]*memory.Execution, error) {
+	m.gotExecsPaths = append(m.gotExecsPaths, projectPath)
 	return m.executions, nil
 }
 
@@ -590,6 +598,61 @@ func TestDashboardIssueURL(t *testing.T) {
 		got := dashboardIssueURL(tt.input)
 		if got != tt.expected {
 			t.Errorf("dashboardIssueURL(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+// TestDashboardProjectPathScoping verifies that SetDashboardProjectPath propagates
+// the configured path to all four store call sites across the three affected endpoints.
+func TestDashboardProjectPathScoping(t *testing.T) {
+	const wantPath = "/opt/projects/myrepo"
+
+	store := &mockDashboardStore{
+		lifetimeTokens: &memory.LifetimeTokens{},
+		taskCounts:     &memory.LifetimeTaskCounts{},
+		executions:     []*memory.Execution{},
+	}
+
+	s := newTestServerWithDashboard(store)
+	s.SetDashboardProjectPath(wantPath)
+
+	// Hit /api/v1/metrics — calls GetLifetimeTokens + GetLifetimeTaskCounts.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/metrics", nil)
+	w := httptest.NewRecorder()
+	s.handleDashboardMetrics(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("metrics: expected 200, got %d", w.Code)
+	}
+	if store.gotTokensPath != wantPath {
+		t.Errorf("metrics: GetLifetimeTokens got projectPath %q, want %q", store.gotTokensPath, wantPath)
+	}
+	if store.gotTaskCountsPath != wantPath {
+		t.Errorf("metrics: GetLifetimeTaskCounts got projectPath %q, want %q", store.gotTaskCountsPath, wantPath)
+	}
+
+	// Hit /api/v1/queue — calls GetRecentExecutions once.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/queue", nil)
+	w = httptest.NewRecorder()
+	s.handleDashboardQueue(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("queue: expected 200, got %d", w.Code)
+	}
+
+	// Hit /api/v1/history — calls GetRecentExecutions again.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/history", nil)
+	w = httptest.NewRecorder()
+	s.handleDashboardHistory(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("history: expected 200, got %d", w.Code)
+	}
+
+	// Both queue and history should have forwarded wantPath.
+	if len(store.gotExecsPaths) != 2 {
+		t.Fatalf("expected 2 GetRecentExecutions calls, got %d", len(store.gotExecsPaths))
+	}
+	for i, got := range store.gotExecsPaths {
+		if got != wantPath {
+			t.Errorf("GetRecentExecutions call %d: projectPath %q, want %q", i, got, wantPath)
 		}
 	}
 }

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -81,6 +81,7 @@ type Server struct {
 	alertsSource           AlertMetricsSource
 	autopilotProvider      AutopilotProvider
 	dashboardStore         DashboardStore
+	dashboardProjectPath   string          // Project path filter for dashboard metrics/queue/history APIs ("" = all projects)
 	logStreamStore         LogStreamStore
 	gitGraphPath           string          // Project path for git graph API (defaults to ".")
 	gitGraphFetcher        GitGraphFetcher // Injected to avoid import cycle with internal/dashboard

--- a/internal/memory/reclassify_outcomes_test.go
+++ b/internal/memory/reclassify_outcomes_test.go
@@ -75,7 +75,7 @@ func TestReclassifyLegacyOutcomes(t *testing.T) {
 		}
 	}
 
-	counts, err := store.GetLifetimeTaskCounts()
+	counts, err := store.GetLifetimeTaskCounts("")
 	if err != nil {
 		t.Fatalf("GetLifetimeTaskCounts: %v", err)
 	}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -711,14 +711,21 @@ func (s *Store) SetApprovalRequestID(ctx context.Context, taskID, requestID stri
 
 // GetRecentExecutions returns the most recent executions ordered by creation time.
 // The limit parameter specifies the maximum number of executions to return.
-func (s *Store) GetRecentExecutions(limit int) ([]*Execution, error) {
-	rows, err := s.db.Query(`
+// If projectPath is non-empty, only executions for that project are returned.
+func (s *Store) GetRecentExecutions(limit int, projectPath string) ([]*Execution, error) {
+	const base = `
 		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at,
 			COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
 			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
 			COALESCE(peak_rss_mb, 0), COALESCE(final_rss_mb, 0)
-		FROM executions ORDER BY created_at DESC LIMIT ?
-	`, limit)
+		FROM executions`
+	var rows *sql.Rows
+	var err error
+	if projectPath != "" {
+		rows, err = s.db.Query(base+` WHERE project_path = ? ORDER BY created_at DESC LIMIT ?`, projectPath, limit)
+	} else {
+		rows, err = s.db.Query(base+` ORDER BY created_at DESC LIMIT ?`, limit)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -1773,16 +1780,22 @@ type LifetimeTokens struct {
 // Unlike session-scoped data, this survives restarts by querying the executions table directly.
 // Rows with zero tokens (dispatcher queue rows, early-failure rows) are excluded so they
 // don't dilute per-task averages.
-func (s *Store) GetLifetimeTokens() (*LifetimeTokens, error) {
-	row := s.db.QueryRow(`
+// If projectPath is non-empty, only executions for that project are counted.
+func (s *Store) GetLifetimeTokens(projectPath string) (*LifetimeTokens, error) {
+	q := `
 		SELECT
 			COALESCE(SUM(tokens_input), 0),
 			COALESCE(SUM(tokens_output), 0),
 			COALESCE(SUM(tokens_total), 0),
 			COALESCE(SUM(estimated_cost_usd), 0)
 		FROM executions
-		WHERE tokens_total > 0
-	`)
+		WHERE tokens_total > 0`
+	var row *sql.Row
+	if projectPath != "" {
+		row = s.db.QueryRow(q+` AND project_path = ?`, projectPath)
+	} else {
+		row = s.db.QueryRow(q)
+	}
 
 	var lt LifetimeTokens
 	if err := row.Scan(&lt.InputTokens, &lt.OutputTokens, &lt.TotalTokens, &lt.TotalCostUSD); err != nil {
@@ -1815,8 +1828,9 @@ func (c LifetimeTaskCounts) NonFailure() int {
 
 // GetLifetimeTaskCounts returns cumulative task counts across all executions.
 // Parallels GetLifetimeTokens — survives restarts by querying executions table directly.
-func (s *Store) GetLifetimeTaskCounts() (*LifetimeTaskCounts, error) {
-	row := s.db.QueryRow(`
+// If projectPath is non-empty, only executions for that project are counted.
+func (s *Store) GetLifetimeTaskCounts(projectPath string) (*LifetimeTaskCounts, error) {
+	const cols = `
 		SELECT
 			COUNT(*),
 			COALESCE(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END), 0),
@@ -1827,8 +1841,13 @@ func (s *Store) GetLifetimeTaskCounts() (*LifetimeTaskCounts, error) {
 			COALESCE(SUM(CASE WHEN status = 'rate_limited' THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN status = 'infra' THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END), 0)
-		FROM executions
-	`)
+		FROM executions`
+	var row *sql.Row
+	if projectPath != "" {
+		row = s.db.QueryRow(cols+` WHERE project_path = ?`, projectPath)
+	} else {
+		row = s.db.QueryRow(cols)
+	}
 
 	var tc LifetimeTaskCounts
 	if err := row.Scan(&tc.Total, &tc.Succeeded, &tc.Failed, &tc.Declined, &tc.NoOp, &tc.Stalled,

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -93,7 +93,7 @@ func TestGetRecentExecutions(t *testing.T) {
 		_ = store.SaveExecution(exec)
 	}
 
-	recent, err := store.GetRecentExecutions(3)
+	recent, err := store.GetRecentExecutions(3, "")
 	if err != nil {
 		t.Fatalf("GetRecentExecutions failed: %v", err)
 	}
@@ -776,7 +776,7 @@ func TestGetExecutionsInPeriod(t *testing.T) {
 	})
 
 	// Verify the executions were created
-	allExecs, _ := store.GetRecentExecutions(100)
+	allExecs, _ := store.GetRecentExecutions(100, "")
 	t.Logf("Total executions in DB: %d", len(allExecs))
 
 	tests := []struct {
@@ -1016,7 +1016,7 @@ func TestGetLifetimeTokens(t *testing.T) {
 	defer func() { _ = store.Close() }()
 
 	// Empty table should return zeros
-	lt, err := store.GetLifetimeTokens()
+	lt, err := store.GetLifetimeTokens("")
 	if err != nil {
 		t.Fatalf("GetLifetimeTokens (empty): %v", err)
 	}
@@ -1055,7 +1055,7 @@ func TestGetLifetimeTokens(t *testing.T) {
 		}
 	}
 
-	lt, err = store.GetLifetimeTokens()
+	lt, err = store.GetLifetimeTokens("")
 	if err != nil {
 		t.Fatalf("GetLifetimeTokens: %v", err)
 	}
@@ -1089,7 +1089,7 @@ func TestGetLifetimeTaskCounts(t *testing.T) {
 	defer func() { _ = store.Close() }()
 
 	// Empty table should return zeros
-	tc, err := store.GetLifetimeTaskCounts()
+	tc, err := store.GetLifetimeTaskCounts("")
 	if err != nil {
 		t.Fatalf("GetLifetimeTaskCounts (empty): %v", err)
 	}
@@ -1119,7 +1119,7 @@ func TestGetLifetimeTaskCounts(t *testing.T) {
 		}
 	}
 
-	tc, err = store.GetLifetimeTaskCounts()
+	tc, err = store.GetLifetimeTaskCounts("")
 	if err != nil {
 		t.Fatalf("GetLifetimeTaskCounts: %v", err)
 	}
@@ -2063,7 +2063,7 @@ func TestGetLifetimeTokens_ExcludesZeroTokenRows(t *testing.T) {
 		t.Fatalf("SaveExecution: %v", err)
 	}
 
-	lt, err := store.GetLifetimeTokens()
+	lt, err := store.GetLifetimeTokens("")
 	if err != nil {
 		t.Fatalf("GetLifetimeTokens: %v", err)
 	}
@@ -2072,6 +2072,18 @@ func TestGetLifetimeTokens_ExcludesZeroTokenRows(t *testing.T) {
 	}
 	if lt.TotalCostUSD != 0.50 {
 		t.Errorf("TotalCostUSD = %.4f, want 0.5000", lt.TotalCostUSD)
+	}
+
+	// Project-scoped filter must also exclude zero-token rows.
+	ltScoped, err := store.GetLifetimeTokens("/p")
+	if err != nil {
+		t.Fatalf("GetLifetimeTokens(/p): %v", err)
+	}
+	if ltScoped.TotalTokens != 7000 {
+		t.Errorf("scoped TotalTokens = %d, want 7000 (zero-token row must be excluded under filter)", ltScoped.TotalTokens)
+	}
+	if ltScoped.TotalCostUSD != 0.50 {
+		t.Errorf("scoped TotalCostUSD = %.4f, want 0.5000", ltScoped.TotalCostUSD)
 	}
 }
 
@@ -2340,5 +2352,209 @@ func TestRecordPatternFeedback_TransactionAtomicity(t *testing.T) {
 			}
 			return -1
 		}())
+	}
+}
+
+func TestGetRecentExecutions_ProjectFilter(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const pathA = "/project/alpha"
+	const pathB = "/project/beta"
+
+	fixture := []struct {
+		id   string
+		path string
+	}{
+		{"pf-exec-a1", pathA},
+		{"pf-exec-a2", pathA},
+		{"pf-exec-a3", pathA},
+		{"pf-exec-b1", pathB},
+		{"pf-exec-b2", pathB},
+	}
+	for _, f := range fixture {
+		if err := store.SaveExecution(&Execution{
+			ID:          f.id,
+			TaskID:      "TASK-" + f.id,
+			ProjectPath: f.path,
+			Status:      "completed",
+		}); err != nil {
+			t.Fatalf("SaveExecution %s: %v", f.id, err)
+		}
+	}
+
+	all, err := store.GetRecentExecutions(100, "")
+	if err != nil {
+		t.Fatalf("GetRecentExecutions (all): %v", err)
+	}
+	if len(all) != 5 {
+		t.Errorf("unfiltered: got %d, want 5", len(all))
+	}
+
+	forA, err := store.GetRecentExecutions(100, pathA)
+	if err != nil {
+		t.Fatalf("GetRecentExecutions (pathA): %v", err)
+	}
+	if len(forA) != 3 {
+		t.Errorf("filter=%s: got %d, want 3", pathA, len(forA))
+	}
+	for _, e := range forA {
+		if e.ProjectPath != pathA {
+			t.Errorf("unexpected ProjectPath %q in filtered results", e.ProjectPath)
+		}
+	}
+
+	forB, err := store.GetRecentExecutions(100, pathB)
+	if err != nil {
+		t.Fatalf("GetRecentExecutions (pathB): %v", err)
+	}
+	if len(forB) != 2 {
+		t.Errorf("filter=%s: got %d, want 2", pathB, len(forB))
+	}
+}
+
+func TestGetLifetimeTokens_ProjectFilter(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const pathA = "/project/alpha"
+	const pathB = "/project/beta"
+
+	saveWithTokens := func(id, path string, input, output int64, cost float64) {
+		t.Helper()
+		if err := store.SaveExecution(&Execution{
+			ID: id, TaskID: "TASK-" + id, ProjectPath: path, Status: "completed",
+		}); err != nil {
+			t.Fatalf("SaveExecution %s: %v", id, err)
+		}
+		if err := store.SaveExecutionMetrics(&ExecutionMetrics{
+			ExecutionID:      id,
+			TokensInput:      input,
+			TokensOutput:     output,
+			TokensTotal:      input + output,
+			EstimatedCostUSD: cost,
+		}); err != nil {
+			t.Fatalf("SaveExecutionMetrics %s: %v", id, err)
+		}
+	}
+
+	saveWithTokens("lt-pf-a1", pathA, 1000, 500, 0.10)
+	saveWithTokens("lt-pf-a2", pathA, 2000, 1000, 0.20)
+	saveWithTokens("lt-pf-b1", pathB, 500, 250, 0.05)
+
+	approxEqual := func(a, b float64) bool {
+		diff := a - b
+		if diff < 0 {
+			diff = -diff
+		}
+		return diff < 1e-9
+	}
+
+	ltA, err := store.GetLifetimeTokens(pathA)
+	if err != nil {
+		t.Fatalf("GetLifetimeTokens(pathA): %v", err)
+	}
+	if ltA.TotalTokens != 4500 {
+		t.Errorf("pathA TotalTokens = %d, want 4500", ltA.TotalTokens)
+	}
+	if !approxEqual(ltA.TotalCostUSD, 0.30) {
+		t.Errorf("pathA TotalCostUSD = %.10f, want ~0.30", ltA.TotalCostUSD)
+	}
+
+	ltB, err := store.GetLifetimeTokens(pathB)
+	if err != nil {
+		t.Fatalf("GetLifetimeTokens(pathB): %v", err)
+	}
+	if ltB.TotalTokens != 750 {
+		t.Errorf("pathB TotalTokens = %d, want 750", ltB.TotalTokens)
+	}
+
+	ltAll, err := store.GetLifetimeTokens("")
+	if err != nil {
+		t.Fatalf("GetLifetimeTokens(all): %v", err)
+	}
+	if ltAll.TotalTokens != 5250 {
+		t.Errorf("unfiltered TotalTokens = %d, want 5250", ltAll.TotalTokens)
+	}
+}
+
+func TestGetLifetimeTaskCounts_ProjectFilter(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const pathA = "/project/alpha"
+	const pathB = "/project/beta"
+
+	fixture := []struct {
+		id     string
+		path   string
+		status string
+	}{
+		{"tc-pf-a1", pathA, "completed"},
+		{"tc-pf-a2", pathA, "completed"},
+		{"tc-pf-a3", pathA, "failed"},
+		{"tc-pf-b1", pathB, "completed"},
+		{"tc-pf-b2", pathB, "no_op"},
+	}
+	for _, f := range fixture {
+		if err := store.SaveExecution(&Execution{
+			ID:          f.id,
+			TaskID:      "TASK-" + f.id,
+			ProjectPath: f.path,
+			Status:      f.status,
+		}); err != nil {
+			t.Fatalf("SaveExecution %s: %v", f.id, err)
+		}
+	}
+
+	tcA, err := store.GetLifetimeTaskCounts(pathA)
+	if err != nil {
+		t.Fatalf("GetLifetimeTaskCounts(pathA): %v", err)
+	}
+	if tcA.Total != 3 {
+		t.Errorf("pathA Total = %d, want 3", tcA.Total)
+	}
+	if tcA.Succeeded != 2 {
+		t.Errorf("pathA Succeeded = %d, want 2", tcA.Succeeded)
+	}
+	if tcA.Failed != 1 {
+		t.Errorf("pathA Failed = %d, want 1", tcA.Failed)
+	}
+
+	tcB, err := store.GetLifetimeTaskCounts(pathB)
+	if err != nil {
+		t.Fatalf("GetLifetimeTaskCounts(pathB): %v", err)
+	}
+	if tcB.Total != 2 {
+		t.Errorf("pathB Total = %d, want 2", tcB.Total)
+	}
+	if tcB.Succeeded != 1 {
+		t.Errorf("pathB Succeeded = %d, want 1", tcB.Succeeded)
+	}
+	if tcB.NoOp != 1 {
+		t.Errorf("pathB NoOp = %d, want 1", tcB.NoOp)
+	}
+	if tcB.Failed != 0 {
+		t.Errorf("pathB Failed = %d, want 0", tcB.Failed)
+	}
+
+	tcAll, err := store.GetLifetimeTaskCounts("")
+	if err != nil {
+		t.Fatalf("GetLifetimeTaskCounts(all): %v", err)
+	}
+	if tcAll.Total != 5 {
+		t.Errorf("unfiltered Total = %d, want 5", tcAll.Total)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `dashboardProjectPath string` field to `internal/gateway.Server` with a `SetDashboardProjectPath` setter
- All three dashboard handlers (`handleDashboardMetrics`, `handleDashboardQueue`, `handleDashboardHistory`) now forward the configured path to the four store call sites: `GetLifetimeTokens`, `GetLifetimeTaskCounts`, and `GetRecentExecutions` (×2)
- `cmd/pilot` wires `""` at both call sites for now — subtask 3 will supply the real project path
- New `TestDashboardProjectPathScoping` asserts all four call sites propagate a non-empty path correctly

## Dependencies

Includes cherry-picked GH-3514 (prerequisite: `projectPath` arg on memory store methods). Depends on GH-3514 merging first or can be merged on top.

## Test plan

- [ ] `go test ./internal/gateway/...` — all tests pass including `TestDashboardProjectPathScoping`
- [ ] `go test ./internal/memory/...` — no regressions
- [ ] `go build ./...` — clean build
- [ ] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues

Closes #3515