### PR TITLE
feat(cmd-pilot): thread resolved projectPath into dashboard mode (GH-3516)

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -2256,7 +2256,7 @@ func checkForUpdates() {
 }
 
 // runDashboardMode runs the TUI dashboard with live task updates
-func runDashboardMode(p *pilot.Pilot, cfg *config.Config, gwProgram *tea.Program, gwMonitor *executor.Monitor, gwRunner *executor.Runner) error {
+func runDashboardMode(p *pilot.Pilot, cfg *config.Config, gwProgram *tea.Program, gwMonitor *executor.Monitor, gwRunner *executor.Runner, projectPath string) error {
 	// Suppress slog output to prevent corrupting TUI display (GH-164)
 	logging.Suppress()
 	p.SuppressProgressLogs(true)
@@ -2284,6 +2284,15 @@ func runDashboardMode(p *pilot.Pilot, cfg *config.Config, gwProgram *tea.Program
 			allStates = append(allStates, gwMonitor.GetAll()...)
 		}
 		allStates = append(allStates, p.GetTaskStates()...)
+		if projectPath != "" {
+			filtered := allStates[:0]
+			for _, s := range allStates {
+				if s.ProjectPath == projectPath {
+					filtered = append(filtered, s)
+				}
+			}
+			allStates = filtered
+		}
 		return convertTaskStatesToDisplay(allStates)
 	}
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1016,7 +1016,7 @@ Examples:
 				p.Gateway().SetDashboardStore(gwStore)
 				p.Gateway().SetLogStreamStore(gwStore)
 			}
-			p.Gateway().SetDashboardProjectPath("") // GH-3515: subtask 3 wires real project path
+			p.Gateway().SetDashboardProjectPath(projectPath)
 
 			// GH-1633: Wire git graph fetcher to gateway so /api/v1/gitgraph returns live git data
 			p.Gateway().SetGitGraphFetcher(func(path string, limit int) interface{} {
@@ -1092,7 +1092,7 @@ Examples:
 			if dashboardMode {
 				// GH-2291: Pass adapter poller infrastructure so the dashboard
 				// merges task states from both adapter pollers and gateway webhooks.
-				return runDashboardMode(p, cfg, gwProgram, gwMonitor, gwRunner)
+				return runDashboardMode(p, cfg, gwProgram, gwMonitor, gwRunner, projectPath)
 			}
 
 			// Show startup banner (headless mode)
@@ -1712,7 +1712,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			gwServer.SetDashboardStore(store)
 			gwServer.SetLogStreamStore(store)
 		}
-		gwServer.SetDashboardProjectPath("") // GH-3515: subtask 3 wires real project path
+		gwServer.SetDashboardProjectPath(projectPath)
 		gwServer.SetGitGraphFetcher(func(path string, limit int) interface{} {
 			return dashboard.FetchGitGraph(path, limit)
 		})


### PR DESCRIPTION
## Summary

- Adds `projectPath string` param to `runDashboardMode` in `cmd/pilot/commands.go`
- Filters `collectTasks` in-flight states by `s.ProjectPath == projectPath` when non-empty, scoping the TUI task list to the active project
- Replaces the `""` placeholders from GH-3515 with the real resolved `projectPath` in both `p.Gateway().SetDashboardProjectPath` (gateway mode) and `gwServer.SetDashboardProjectPath` (polling mode)
- Passes `projectPath` to the `runDashboardMode` call site

Depends on GH-3514 + GH-3515 (merged via `origin/pilot/GH-3515` base).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./cmd/pilot/... ./internal/gateway/... ./internal/memory/...` — all pass
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues