### PR TITLE
fix(autopilot): verify decomposed work before closing parents or superseding children

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -2028,6 +2028,29 @@ func (p *Poller) skipSupersededByParent(ctx context.Context, issue *Issue) bool 
 		return false
 	}
 
+	// GH-3513 incident: pilot-done on the parent proves only that the parent
+	// ISSUE was closed, not that this child's work merged — premature parent
+	// closes (partial native sub-issue links) otherwise cascade into discarding
+	// live work. An open pilot/GH-N PR for this child is direct evidence its
+	// implementation is still in flight; never supersede over it. Fail open on
+	// lookup errors for the same reason as the parent GET above.
+	branch := fmt.Sprintf("pilot/GH-%d", issue.Number)
+	if openPR, perr := p.client.FindOpenPRByBranch(ctx, p.owner, p.repo, branch); perr != nil {
+		p.logger.Warn("Failed to check for open PR before superseding, falling through to normal dispatch",
+			slog.Int("issue", issue.Number),
+			slog.String("branch", branch),
+			slog.Any("error", perr),
+		)
+		return false
+	} else if openPR {
+		p.logger.Info("Not superseding sub-issue: open PR exists for its branch",
+			slog.Int("issue", issue.Number),
+			slog.Int("parent", parentNum),
+			slog.String("branch", branch),
+		)
+		return false
+	}
+
 	p.logger.Info("Auto-closing sub-issue: parent epic already shipped",
 		slog.Int("issue", issue.Number),
 		slog.Int("parent", parentNum),

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2660,7 +2660,7 @@ func TestPoller_RetryReady_InvalidatesCompletedExecution(t *testing.T) {
 	now := time.Now()
 	issues := []*Issue{
 		{Number: 42, State: "open", Title: "Retry-ready with completed row",
-			Labels: []Label{{Name: "pilot"}, {Name: LabelRetryReady}},
+			Labels:    []Label{{Name: "pilot"}, {Name: LabelRetryReady}},
 			CreatedAt: now.Add(-1 * time.Hour)},
 	}
 
@@ -3036,6 +3036,71 @@ func TestPoller_CheckForNewIssues_DoesNotSupersedeWhenParentNotDone(t *testing.T
 
 	if got := atomic.LoadInt32(&dispatches); got != 1 {
 		t.Errorf("dispatched %d times, want 1 (parent closed but not done — should dispatch)", got)
+	}
+}
+
+// GH-3513: A sub-issue with an OPEN pilot/GH-N PR must never be superseded,
+// even when the parent is closed + pilot-done — the open PR is direct evidence
+// its implementation is still in flight (the parent close may be premature).
+func TestPoller_CheckForNewIssues_DoesNotSupersedeWithOpenPR(t *testing.T) {
+	subIssue := &Issue{
+		Number: 202,
+		Title:  "Sub-issue with live PR",
+		Body:   "Parent: GH-102\n\nSome work.",
+		State:  "open",
+		Labels: []Label{{Name: "pilot"}},
+	}
+	parent := &Issue{
+		Number: 102,
+		Title:  "Epic",
+		State:  "closed",
+		Labels: []Label{{Name: "pilot"}, {Name: LabelDone}},
+	}
+	openPR := &PullRequest{
+		Number: 900,
+		State:  "open",
+		Head:   PRRef{Ref: "pilot/GH-202"},
+	}
+
+	var (
+		dispatches  int32
+		closedIssue int32
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode([]*Issue{subIssue})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/102":
+			_ = json.NewEncoder(w).Encode(parent)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/202":
+			_ = json.NewEncoder(w).Encode(subIssue)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/pulls":
+			_ = json.NewEncoder(w).Encode([]*PullRequest{openPR})
+		case r.Method == http.MethodPatch && r.URL.Path == "/repos/owner/repo/issues/202":
+			atomic.AddInt32(&closedIssue, 1)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&dispatches, 1)
+			return nil
+		}),
+	)
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&closedIssue); got != 0 {
+		t.Errorf("sub-issue was closed %d times, want 0 (open PR must veto supersession)", got)
+	}
+	if got := atomic.LoadInt32(&dispatches); got != 1 {
+		t.Errorf("dispatched %d times, want 1 (open PR means work in flight — fall through to dispatch)", got)
 	}
 }
 

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1630,21 +1630,10 @@ func (c *Controller) maybeCloseParentIssue(ctx context.Context, prState *PRState
 		return
 	}
 
-	// Check how many sibling sub-issues are still open.
-	// Tier 1: try native GitHub sub-issues GraphQL API (more reliable, works even without text patterns).
-	// Tier 2: fall back to text search when native links are absent (legacy repos use body "Parent: GH-N" only).
-	openCount, hasNativeLinks, err := c.ghClient.GetOpenSubIssueCount(ctx, c.owner, c.repo, parentNum)
-	if err != nil || !hasNativeLinks {
-		if err != nil {
-			c.log.Warn("maybeCloseParentIssue: native sub-issue count failed, falling back to search", slog.Int("parent", parentNum), slog.Any("error", err))
-		} else {
-			c.log.Debug("maybeCloseParentIssue: no native sub-issue links, falling back to search", slog.Int("parent", parentNum))
-		}
-		openCount, err = c.ghClient.SearchOpenSubIssues(ctx, c.owner, c.repo, parentNum)
-		if err != nil {
-			c.log.Warn("maybeCloseParentIssue: failed to search open sub-issues", slog.Int("parent", parentNum), slog.Any("error", err))
-			return
-		}
+	openCount, err := c.openSubIssueCount(ctx, parentNum)
+	if err != nil {
+		c.log.Warn("maybeCloseParentIssue: failed to count open sub-issues", slog.Int("parent", parentNum), slog.Any("error", err))
+		return
 	}
 
 	if openCount > 0 {
@@ -1653,6 +1642,45 @@ func (c *Controller) maybeCloseParentIssue(ctx context.Context, prState *PRState
 	}
 
 	c.closeParentNow(ctx, parentNum)
+}
+
+// openSubIssueCount returns the number of open sub-issues for a parent,
+// combining both lookup tiers:
+//   - Tier 1: native GitHub sub-issues GraphQL API (works even without text patterns).
+//   - Tier 2: text search for body "Parent: GH-N" references.
+//
+// GH-3513 incident: LinkSubIssue is non-fatal at creation time, so the native
+// link set can cover only a SUBSET of children. A native count of 0 then looks
+// like "all done" while unlinked siblings are still open — the parent gets
+// closed prematurely and the poller later supersedes the live children.
+// Therefore a native count of 0 is never trusted alone: it must be confirmed
+// by the text search before the caller may close the parent. The max of both
+// tiers is returned.
+func (c *Controller) openSubIssueCount(ctx context.Context, parentNum int) (int, error) {
+	nativeCount, hasNativeLinks, err := c.ghClient.GetOpenSubIssueCount(ctx, c.owner, c.repo, parentNum)
+	if err != nil || !hasNativeLinks {
+		if err != nil {
+			c.log.Warn("openSubIssueCount: native sub-issue count failed, falling back to search", slog.Int("parent", parentNum), slog.Any("error", err))
+		} else {
+			c.log.Debug("openSubIssueCount: no native sub-issue links, falling back to search", slog.Int("parent", parentNum))
+		}
+		return c.ghClient.SearchOpenSubIssues(ctx, c.owner, c.repo, parentNum)
+	}
+
+	if nativeCount > 0 {
+		return nativeCount, nil
+	}
+
+	// Native says 0 — cross-check text search to catch unlinked open siblings.
+	textCount, err := c.ghClient.SearchOpenSubIssues(ctx, c.owner, c.repo, parentNum)
+	if err != nil {
+		return 0, fmt.Errorf("native count is 0 but confirmation search failed: %w", err)
+	}
+	if textCount > 0 {
+		c.log.Info("openSubIssueCount: native links report 0 open but text search found unlinked open siblings, deferring close",
+			slog.Int("parent", parentNum), slog.Int("text_open", textCount))
+	}
+	return textCount, nil
 }
 
 // closeParentNow adds pilot-done, removes stale labels, posts a summary comment,
@@ -1699,7 +1727,7 @@ func (c *Controller) recoverStaleParentIssues(ctx context.Context) {
 
 	closed := 0
 	for _, parentNum := range candidates {
-		openCount, _, err := c.ghClient.GetOpenSubIssueCount(ctx, c.owner, c.repo, parentNum)
+		openCount, err := c.openSubIssueCount(ctx, parentNum)
 		if err != nil {
 			c.log.Warn("recoverStaleParentIssues: failed to count sub-issues", slog.Int("parent", parentNum), slog.Any("error", err))
 			continue

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -4580,9 +4580,11 @@ func TestMaybeCloseParentIssue(t *testing.T) {
 
 func TestRecoverStaleParentIssues(t *testing.T) {
 	type parentCandidate struct {
-		num      int
-		openSubs int // open sub-issue count from GetOpenSubIssueCount
-		subErr   bool
+		num          int
+		openSubs     int  // open sub-issue count from GetOpenSubIssueCount (native links)
+		subErr       bool // native GraphQL count fails
+		textOpenSubs int  // open sub-issue count from SearchOpenSubIssues (text search)
+		textErr      bool // text search fails
 	}
 
 	tests := []struct {
@@ -4615,10 +4617,34 @@ func TestRecoverStaleParentIssues(t *testing.T) {
 		{
 			name: "continues on per-item error, closes others",
 			candidates: []parentCandidate{
-				{num: 100, subErr: true},
+				{num: 100, subErr: true, textErr: true},
 				{num: 200, openSubs: 0},
 			},
 			wantClosed:  []int{200},
+			wantSkipped: []int{100},
+		},
+		{
+			name: "native count error falls back to text search, skips when siblings open",
+			candidates: []parentCandidate{
+				{num: 100, subErr: true, textOpenSubs: 1},
+			},
+			wantSkipped: []int{100},
+		},
+		{
+			// GH-3513 regression: LinkSubIssue partially failed, so native links
+			// cover only closed children (native open = 0) while unlinked siblings
+			// are still open. The text-search cross-check must veto the close.
+			name: "native 0 vetoed by text search finding unlinked open siblings",
+			candidates: []parentCandidate{
+				{num: 100, openSubs: 0, textOpenSubs: 2},
+			},
+			wantSkipped: []int{100},
+		},
+		{
+			name: "native 0 with failing confirmation search defers close",
+			candidates: []parentCandidate{
+				{num: 100, openSubs: 0, textErr: true},
+			},
 			wantSkipped: []int{100},
 		},
 		{
@@ -4740,6 +4766,19 @@ func TestRecoverStaleParentIssues(t *testing.T) {
 					_, _ = fmt.Sscanf(path, "%d", &num)
 					closedParents[num] = true
 					w.WriteHeader(http.StatusOK)
+
+				case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+					// SearchOpenSubIssues — parent number is embedded in the q param
+					// as `"Parent: GH-<num>"`.
+					var num int
+					_, _ = fmt.Sscanf(r.URL.Query().Get("q"), `repo:owner/repo "Parent: GH-%d"`, &num)
+					cand, ok := candidateMap[num]
+					if !ok || cand.textErr {
+						w.WriteHeader(http.StatusBadGateway)
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+					_, _ = fmt.Fprintf(w, `{"total_count":%d}`, cand.textOpenSubs)
 
 				default:
 					w.WriteHeader(http.StatusOK)
@@ -5027,10 +5066,10 @@ func TestNotifyExternalClose_SkipsRetryReadyForHumanRecoveryPR(t *testing.T) {
 	const botLogin = "pilot-bot"
 
 	tests := []struct {
-		name            string
-		openPRs         []github.PullRequest // PRs returned by SearchOpenPRsForIssue
-		wantRetryAdded  bool
-		wantSkipLogged  bool // expect the "human recovery PR" log path
+		name           string
+		openPRs        []github.PullRequest // PRs returned by SearchOpenPRsForIssue
+		wantRetryAdded bool
+		wantSkipLogged bool // expect the "human recovery PR" log path
 	}{
 		{
 			name:           "no open PRs — retry-ready applied",

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1071,9 +1071,7 @@ func (r *Runner) createSubIssuesViaAdapter(ctx context.Context, plan *EpicPlan) 
 		// Build the issue body
 		body := subtask.Description
 		if plan.ParentTask.ID != "" {
-			// GH-2695: mirror the GitHub path — inject autopilot-meta marker for parity.
-			body = fmt.Sprintf("<!--autopilot-meta\nparent: %s\ninherited-spec: true\n-->\n\nParent: %s\n\n%s",
-				plan.ParentTask.ID, plan.ParentTask.ID, body)
+			body = subIssueBody(plan.ParentTask.ID, body)
 		}
 
 		// Wire DependsOn annotations into the body (GH-1794)
@@ -1162,6 +1160,33 @@ func (r *Runner) createSubIssuesViaAdapter(ctx context.Context, plan *EpicPlan) 
 	return created, nil
 }
 
+// subIssueBody assembles a decomposer-generated sub-issue body: the
+// autopilot-meta marker (GH-2695, lets spec_validator's inherited-spec bailout
+// recognise the issue), the parent reference, the subtask's planned slice, and
+// a scope fence.
+//
+// The fence exists because of the GH-3513 incident: executors that see
+// "Parent: GH-N" fetch the parent issue and treat its full spec as their task,
+// so every sibling re-implements the entire feature and the redundant PRs
+// collide. The fence pins the executor to this subtask's slice.
+func subIssueBody(parentID, description string) string {
+	return fmt.Sprintf(`<!--autopilot-meta
+parent: %[1]s
+inherited-spec: true
+-->
+
+Parent: %[1]s
+
+%[2]s
+
+## Scope fence
+
+Implement ONLY the slice described above. The parent issue %[1]s is decomposed
+into sibling sub-issues that cover the rest of its spec — consult the parent
+for context, but do NOT implement parts of it that fall outside this subtask.`,
+		parentID, description)
+}
+
 // createSubIssuesViaGitHub creates sub-issues using the gh CLI.
 // This is the original implementation and fallback path.
 //
@@ -1177,11 +1202,7 @@ func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, e
 		// Build the issue body
 		body := subtask.Description
 		if plan.ParentTask != nil && plan.ParentTask.ID != "" {
-			// GH-2695: inject autopilot-meta marker so spec_validator's inherited-spec
-			// bailout path recognises this as a decomposer-generated sub-issue and skips
-			// the full spec check, delegating to the parent's validation result instead.
-			body = fmt.Sprintf("<!--autopilot-meta\nparent: %s\ninherited-spec: true\n-->\n\nParent: %s\n\n%s",
-				plan.ParentTask.ID, plan.ParentTask.ID, body)
+			body = subIssueBody(plan.ParentTask.ID, body)
 		}
 
 		// Wire DependsOn annotations into the body (GH-1794)

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -1956,6 +1956,33 @@ func TestCreateSubIssuesViaGitHub_InjectsAutopilotMetaMarker(t *testing.T) {
 	if !strings.Contains(body, "\n\nParent: GH-42\n\n") {
 		t.Errorf("human-readable parent prose missing from body; body = %q", body)
 	}
+
+	// GH-3513: the scope fence must pin the executor to this subtask's slice so
+	// it doesn't re-implement the full parent spec.
+	if !strings.Contains(body, "## Scope fence") {
+		t.Errorf("scope fence section missing from body; body = %q", body)
+	}
+	if !strings.Contains(body, "Implement ONLY the slice described above") {
+		t.Errorf("scope fence constraint missing from body; body = %q", body)
+	}
+}
+
+// subIssueBody must keep the subtask description ABOVE the scope fence and
+// reference the parent ID inside the fence text.
+func TestSubIssueBody_ScopeFence(t *testing.T) {
+	body := subIssueBody("GH-99", "Add the projectPath filter to the store layer.")
+
+	descIdx := strings.Index(body, "Add the projectPath filter")
+	fenceIdx := strings.Index(body, "## Scope fence")
+	if descIdx == -1 || fenceIdx == -1 {
+		t.Fatalf("body missing description (%d) or fence (%d); body = %q", descIdx, fenceIdx, body)
+	}
+	if descIdx > fenceIdx {
+		t.Errorf("description must precede the scope fence; body = %q", body)
+	}
+	if !strings.Contains(body[fenceIdx:], "GH-99") {
+		t.Errorf("fence must name the parent issue; body = %q", body)
+	}
 }
 
 // TestCreateSubIssuesViaAdapter_InjectsAutopilotMetaMarker verifies parity with the
@@ -2455,7 +2482,6 @@ func TestRunner_Execute_EpicRecoversThenExecutesOpenChildren(t *testing.T) {
 		}
 	}
 }
-
 
 // staticAllowlist is a test helper that allows a fixed set of "owner/repo"
 // pairs. projectPath comparison is ignored (tests don't need that dimension).


### PR DESCRIPTION
## Problem (GH-3513 incident, 2026-06-09)

A decomposed epic (#3513) was closed `pilot-done` after a single fragment PR merged. The poller then auto-closed the remaining children as *"parent epic already shipped this work"* — orphaning their complete, CI-green PRs (#3519, #3523). Every issue read done/superseded while `main` had none of the feature.

Failure chain: partial native sub-issue linking (`LinkSubIssue` is non-fatal) → `GetOpenSubIssueCount` saw only the linked subset → first merged child produced open-count 0 → parent closed `pilot-done` with no PR-merge verification → `skipSupersededByParent` trusted the label and discarded the live children.

## Fixes (one per chain link)

1. **`openSubIssueCount()` (controller)** — a native count of 0 is never trusted alone; it must be confirmed by the `"Parent: GH-N"` text search before a parent may close. Max of both tiers wins. Applied to `maybeCloseParentIssue` and `recoverStaleParentIssues` (same flaw, now shared helper).
2. **`skipSupersededByParent()` (poller)** — an open `pilot/GH-N` PR for the child vetoes supersession; fail-open on lookup errors (consistent with the existing parent-GET behavior).
3. **`subIssueBody()` (executor)** — decomposer-created sub-issues get a scope fence so executors implement only their slice instead of re-implementing the full parent spec they fetch via the `Parent: GH-N` reference. (This is what produced three redundant 12-file PRs.)

## Tests

- `TestRecoverStaleParentIssues`: 4 new cases incl. the GH-3513 regression (native 0 vetoed by text search finding unlinked open siblings).
- `TestPoller_CheckForNewIssues_DoesNotSupersedeWithOpenPR`: open PR blocks supersession, dispatch falls through.
- `TestSubIssueBody_ScopeFence` + fence assertions in the existing marker-injection test.

`go test` on the 3 packages: ok · `golangci-lint`: 0 issues.

⚠️ Manual fix — Pilot cannot safely repair its own decomposition/finalization logic (same rationale as TASK-320 B2). Do not hand off to the daemon.