### PR TITLE
feat(memory): add project_path to eval_tasks schema and filter (GH-3536)

### DIFF
--- a/cmd/pilot/eval.go
+++ b/cmd/pilot/eval.go
@@ -33,9 +33,10 @@ func newEvalCmd() *cobra.Command {
 
 func newEvalRunCmd() *cobra.Command {
 	var (
-		repo  string
-		model string
-		limit int
+		repo    string
+		project string
+		model   string
+		limit   int
 	)
 
 	cmd := &cobra.Command{
@@ -55,8 +56,9 @@ Selects tasks by repository, optionally overriding the model used.`,
 			defer cleanup()
 
 			tasks, err := store.ListEvalTasks(memory.EvalTaskFilter{
-				Repo:  repo,
-				Limit: limit,
+				Repo:        repo,
+				ProjectPath: project,
+				Limit:       limit,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to load eval tasks: %w", err)
@@ -99,6 +101,7 @@ Selects tasks by repository, optionally overriding the model used.`,
 	}
 
 	cmd.Flags().StringVar(&repo, "repo", "", "Repository (owner/name) to evaluate")
+	cmd.Flags().StringVar(&project, "project", "", "Filter by project path")
 	cmd.Flags().StringVar(&model, "model", "", "Model to use for evaluation (default: config model)")
 	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of tasks to run")
 
@@ -108,6 +111,7 @@ Selects tasks by repository, optionally overriding the model used.`,
 func newEvalListCmd() *cobra.Command {
 	var (
 		repo        string
+		project     string
 		limit       int
 		successOnly bool
 		failedOnly  bool
@@ -126,6 +130,7 @@ func newEvalListCmd() *cobra.Command {
 
 			tasks, err := store.ListEvalTasks(memory.EvalTaskFilter{
 				Repo:        repo,
+				ProjectPath: project,
 				SuccessOnly: successOnly,
 				FailedOnly:  failedOnly,
 				Limit:       limit,
@@ -165,6 +170,7 @@ func newEvalListCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&repo, "repo", "", "Filter by repository (owner/name)")
+	cmd.Flags().StringVar(&project, "project", "", "Filter by project path")
 	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of tasks to show")
 	cmd.Flags().BoolVar(&successOnly, "success", false, "Show only successful tasks")
 	cmd.Flags().BoolVar(&failedOnly, "failed", false, "Show only failed tasks")
@@ -173,7 +179,10 @@ func newEvalListCmd() *cobra.Command {
 }
 
 func newEvalStatsCmd() *cobra.Command {
-	var repo string
+	var (
+		repo    string
+		project string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "stats",
@@ -188,8 +197,9 @@ Shows per-repository breakdown and overall statistics.`,
 			defer cleanup()
 
 			tasks, err := store.ListEvalTasks(memory.EvalTaskFilter{
-				Repo:  repo,
-				Limit: 10000,
+				Repo:        repo,
+				ProjectPath: project,
+				Limit:       10000,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to load eval tasks: %w", err)
@@ -206,6 +216,7 @@ Shows per-repository breakdown and overall statistics.`,
 	}
 
 	cmd.Flags().StringVar(&repo, "repo", "", "Filter by repository (owner/name)")
+	cmd.Flags().StringVar(&project, "project", "", "Filter by project path")
 
 	return cmd
 }

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1571,6 +1571,7 @@ func (c *Controller) handleMerged(ctx context.Context, prState *PRState) error {
 					IssueTitle:   issue.Title,
 					Repo:         fmt.Sprintf("%s/%s", c.owner, c.repo),
 					FilesChanged: filenames,
+					ProjectPath:  c.projectPath,
 				})
 				if saveErr := c.evalStore.SaveEvalTask(evalTask); saveErr != nil {
 					c.log.Warn("Failed to save eval task", slog.Any("error", saveErr))

--- a/internal/memory/eval.go
+++ b/internal/memory/eval.go
@@ -16,6 +16,7 @@ type EvalTask struct {
 	IssueNumber  int            `json:"issue_number"`
 	IssueTitle   string         `json:"issue_title"`
 	Repo         string         `json:"repo"`
+	ProjectPath  string         `json:"project_path,omitempty"`
 	Success      bool           `json:"success"`
 	PassCriteria []PassCriteria `json:"pass_criteria,omitempty"`
 	FilesChanged []string       `json:"files_changed,omitempty"`
@@ -41,6 +42,7 @@ type EvalInput struct {
 	IssueNumber  int
 	IssueTitle   string
 	FilesChanged []string
+	ProjectPath  string
 }
 
 // EvalGateResult is a quality gate outcome, mirroring executor.QualityGateResult.
@@ -69,6 +71,7 @@ func ExtractEvalTask(in EvalInput) *EvalTask {
 		IssueNumber:  in.IssueNumber,
 		IssueTitle:   in.IssueTitle,
 		Repo:         in.Repo,
+		ProjectPath:  in.ProjectPath,
 		Success:      in.Success,
 		PassCriteria: criteria,
 		FilesChanged: in.FilesChanged,
@@ -90,16 +93,17 @@ func (s *Store) SaveEvalTask(task *EvalTask) error {
 
 	return s.withRetry("SaveEvalTask", func() error {
 		_, err := s.db.Exec(`
-			INSERT INTO eval_tasks (id, execution_id, issue_number, issue_title, repo, success, pass_criteria, files_changed, duration_ms)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			INSERT INTO eval_tasks (id, execution_id, issue_number, issue_title, repo, success, pass_criteria, files_changed, duration_ms, project_path)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(repo, issue_number) DO UPDATE SET
 				execution_id = excluded.execution_id,
 				success = excluded.success,
 				pass_criteria = excluded.pass_criteria,
 				files_changed = excluded.files_changed,
-				duration_ms = excluded.duration_ms
+				duration_ms = excluded.duration_ms,
+				project_path = excluded.project_path
 		`, task.ID, task.ExecutionID, task.IssueNumber, task.IssueTitle, task.Repo, task.Success,
-			string(criteriaJSON), string(filesJSON), task.DurationMs)
+			string(criteriaJSON), string(filesJSON), task.DurationMs, task.ProjectPath)
 		return err
 	})
 }
@@ -238,6 +242,7 @@ func (s *Store) GetEvalStats(runID string) ([]*EvalStats, error) {
 type EvalTaskFilter struct {
 	Repo        string
 	ExecutionID string // Filter by execution_id (used as eval run identifier)
+	ProjectPath string // Filter by project path; empty returns all projects
 	SuccessOnly bool
 	FailedOnly  bool
 	Limit       int
@@ -256,6 +261,10 @@ func (s *Store) ListEvalTasks(filter EvalTaskFilter) ([]*EvalTask, error) {
 		conditions = append(conditions, "execution_id = ?")
 		args = append(args, filter.ExecutionID)
 	}
+	if filter.ProjectPath != "" {
+		conditions = append(conditions, "project_path = ?")
+		args = append(args, filter.ProjectPath)
+	}
 	if filter.SuccessOnly {
 		conditions = append(conditions, "success = 1")
 	}
@@ -263,7 +272,7 @@ func (s *Store) ListEvalTasks(filter EvalTaskFilter) ([]*EvalTask, error) {
 		conditions = append(conditions, "success = 0")
 	}
 
-	query := "SELECT id, execution_id, issue_number, issue_title, repo, success, pass_criteria, files_changed, duration_ms, created_at FROM eval_tasks"
+	query := "SELECT id, execution_id, issue_number, issue_title, repo, success, pass_criteria, files_changed, duration_ms, project_path, created_at FROM eval_tasks"
 	if len(conditions) > 0 {
 		query += " WHERE " + strings.Join(conditions, " AND ")
 	}
@@ -286,7 +295,7 @@ func (s *Store) ListEvalTasks(filter EvalTaskFilter) ([]*EvalTask, error) {
 		var t EvalTask
 		var criteriaJSON, filesJSON string
 		if err := rows.Scan(&t.ID, &t.ExecutionID, &t.IssueNumber, &t.IssueTitle, &t.Repo,
-			&t.Success, &criteriaJSON, &filesJSON, &t.DurationMs, &t.CreatedAt); err != nil {
+			&t.Success, &criteriaJSON, &filesJSON, &t.DurationMs, &t.ProjectPath, &t.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan eval_task: %w", err)
 		}
 		if criteriaJSON != "" {

--- a/internal/memory/eval_test.go
+++ b/internal/memory/eval_test.go
@@ -291,6 +291,83 @@ func TestSaveEvalTaskDuplicatePrevention(t *testing.T) {
 	}
 }
 
+func TestListEvalTasksProjectPathFilter(t *testing.T) {
+	store, cleanup := newTestStoreForEval(t)
+	defer cleanup()
+
+	taskA1 := &EvalTask{
+		ID: "eval-proj-a1", ExecutionID: "exec-pa1", IssueNumber: 101,
+		IssueTitle: "Alpha Feature 1", Repo: "org/repo",
+		ProjectPath: "/projects/alpha", Success: true, DurationMs: 1000,
+	}
+	taskA2 := &EvalTask{
+		ID: "eval-proj-a2", ExecutionID: "exec-pa2", IssueNumber: 102,
+		IssueTitle: "Alpha Feature 2", Repo: "org/repo",
+		ProjectPath: "/projects/alpha", Success: false, DurationMs: 2000,
+	}
+	taskB1 := &EvalTask{
+		ID: "eval-proj-b1", ExecutionID: "exec-pb1", IssueNumber: 201,
+		IssueTitle: "Beta Feature 1", Repo: "org/other",
+		ProjectPath: "/projects/beta", Success: true, DurationMs: 500,
+	}
+
+	for _, task := range []*EvalTask{taskA1, taskA2, taskB1} {
+		if err := store.SaveEvalTask(task); err != nil {
+			t.Fatalf("SaveEvalTask(%s): %v", task.ID, err)
+		}
+	}
+
+	// ProjectPath "A" returns only A's rows.
+	alphaRows, err := store.ListEvalTasks(EvalTaskFilter{ProjectPath: "/projects/alpha"})
+	if err != nil {
+		t.Fatalf("ListEvalTasks alpha: %v", err)
+	}
+	if len(alphaRows) != 2 {
+		t.Errorf("alpha: got %d tasks, want 2", len(alphaRows))
+	}
+	for _, row := range alphaRows {
+		if row.ProjectPath != "/projects/alpha" {
+			t.Errorf("expected ProjectPath=/projects/alpha, got %q", row.ProjectPath)
+		}
+	}
+
+	// ProjectPath "B" returns only B's rows.
+	betaRows, err := store.ListEvalTasks(EvalTaskFilter{ProjectPath: "/projects/beta"})
+	if err != nil {
+		t.Fatalf("ListEvalTasks beta: %v", err)
+	}
+	if len(betaRows) != 1 {
+		t.Fatalf("beta: got %d tasks, want 1", len(betaRows))
+	}
+	if betaRows[0].ID != "eval-proj-b1" {
+		t.Errorf("beta[0].ID = %q, want eval-proj-b1", betaRows[0].ID)
+	}
+	if betaRows[0].ProjectPath != "/projects/beta" {
+		t.Errorf("beta[0].ProjectPath = %q, want /projects/beta", betaRows[0].ProjectPath)
+	}
+
+	// Empty ProjectPath returns all rows.
+	allRows, err := store.ListEvalTasks(EvalTaskFilter{})
+	if err != nil {
+		t.Fatalf("ListEvalTasks all: %v", err)
+	}
+	if len(allRows) != 3 {
+		t.Errorf("all: got %d tasks, want 3", len(allRows))
+	}
+
+	// ProjectPath + SuccessOnly intersection.
+	alphaSuccess, err := store.ListEvalTasks(EvalTaskFilter{ProjectPath: "/projects/alpha", SuccessOnly: true})
+	if err != nil {
+		t.Fatalf("ListEvalTasks alpha+success: %v", err)
+	}
+	if len(alphaSuccess) != 1 {
+		t.Fatalf("alpha+success: got %d tasks, want 1", len(alphaSuccess))
+	}
+	if alphaSuccess[0].ID != "eval-proj-a1" {
+		t.Errorf("alpha+success[0].ID = %q, want eval-proj-a1", alphaSuccess[0].ID)
+	}
+}
+
 func TestEvalTaskPassCriteriaRoundTrip(t *testing.T) {
 	store, cleanup := newTestStoreForEval(t)
 	defer cleanup()

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -282,6 +282,7 @@ func (s *Store) migrate() error {
 			pass_criteria TEXT,
 			files_changed TEXT,
 			duration_ms INTEGER DEFAULT 0,
+			project_path TEXT DEFAULT '',
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			UNIQUE(repo, issue_number)
 		)`,
@@ -332,6 +333,8 @@ func (s *Store) migrate() error {
 		// GH-3028: RSS telemetry — peak and final resident set size for subprocess OOM diagnostics.
 		`ALTER TABLE executions ADD COLUMN peak_rss_mb INTEGER DEFAULT 0`,
 		`ALTER TABLE executions ADD COLUMN final_rss_mb INTEGER DEFAULT 0`,
+		// GH-3536: project scoping for eval tasks
+		`ALTER TABLE eval_tasks ADD COLUMN project_path TEXT DEFAULT ''`,
 	}
 
 	for _, migration := range migrations {


### PR DESCRIPTION
## Summary

- Adds `project_path TEXT DEFAULT ''` to the `eval_tasks` CREATE TABLE and as an inline ALTER TABLE migration so existing databases pick up the column on next startup
- Extends `EvalTask` and `EvalInput` structs with a `ProjectPath` field; `SaveEvalTask` writes it, `ListEvalTasks` filters by it when non-empty
- Autopilot controller passes `c.projectPath` when capturing eval tasks from merged PRs
- Adds optional `--project` flag to `pilot eval run`, `pilot eval list`, and `pilot eval stats`

## Eval mode scope

Eval tasks span multiple projects by default. When `--project` (or `EvalTaskFilter.ProjectPath`) is set to a non-empty path, only rows for that project are returned. Passing an empty string returns all projects, preserving existing behaviour byte-for-byte.

## Test plan

- [x] `TestListEvalTasksProjectPathFilter` — multi-project fixture: `ProjectPath: "/projects/alpha"` returns only 2 alpha rows; `ProjectPath: "/projects/beta"` returns 1 beta row; empty filter returns all 3; `ProjectPath + SuccessOnly` intersection works
- [x] All existing eval tests pass (`TestSaveAndListEvalTasks`, `TestSaveEvalTaskDuplicatePrevention`, `TestEvalTaskPassCriteriaRoundTrip`)
- [x] `make test` — all packages green
- [x] `golangci-lint run --new-from-rev=origin/main` — 0 issues