### PR TITLE
feat(cli): wire --dashboard-scope flag to dashboard + gateway (GH-3534)

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -2255,6 +2255,16 @@ func checkForUpdates() {
 	}
 }
 
+// scopedProjectPath maps the --dashboard-scope flag value to the project path
+// used for metrics filtering. "all" returns "" (no filter); anything else
+// (including the default "project" and the empty string) returns projectPath.
+func scopedProjectPath(scope, projectPath string) string {
+	if scope == "all" {
+		return ""
+	}
+	return projectPath
+}
+
 // runDashboardMode runs the TUI dashboard with live task updates
 func runDashboardMode(p *pilot.Pilot, cfg *config.Config, gwProgram *tea.Program, gwMonitor *executor.Monitor, gwRunner *executor.Runner, projectPath string) error {
 	// Suppress slog output to prevent corrupting TUI display (GH-164)

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -133,7 +133,8 @@ func newStartCmd() *cobra.Command {
 		enableTunnel bool   // Enable public tunnel (Cloudflare/ngrok)
 		teamID       string // Optional team ID for scoping execution
 		teamMember   string // Member email for project access scoping
-		logFormat    string // Log output format: text or json (GH-847)
+		logFormat      string // Log output format: text or json (GH-847)
+		dashboardScope string // Dashboard metrics scope: "project" (default) or "all" (GH-3534)
 	)
 
 	cmd := &cobra.Command{
@@ -229,6 +230,11 @@ Examples:
 			if strings.HasPrefix(projectPath, "~") {
 				home, _ := os.UserHomeDir()
 				projectPath = strings.Replace(projectPath, "~", home, 1)
+			}
+
+			// Validate --dashboard-scope (GH-3534)
+			if dashboardScope != "project" && dashboardScope != "all" {
+				return fmt.Errorf("invalid --dashboard-scope %q: must be one of [project, all]", dashboardScope)
 			}
 
 			// Clean stale pilot hooks on startup (GH-1883)
@@ -1016,7 +1022,7 @@ Examples:
 				p.Gateway().SetDashboardStore(gwStore)
 				p.Gateway().SetLogStreamStore(gwStore)
 			}
-			p.Gateway().SetDashboardProjectPath(projectPath)
+			p.Gateway().SetDashboardProjectPath(scopedProjectPath(dashboardScope, projectPath))
 
 			// GH-1633: Wire git graph fetcher to gateway so /api/v1/gitgraph returns live git data
 			p.Gateway().SetGitGraphFetcher(func(path string, limit int) interface{} {
@@ -1092,7 +1098,7 @@ Examples:
 			if dashboardMode {
 				// GH-2291: Pass adapter poller infrastructure so the dashboard
 				// merges task states from both adapter pollers and gateway webhooks.
-				return runDashboardMode(p, cfg, gwProgram, gwMonitor, gwRunner, projectPath)
+				return runDashboardMode(p, cfg, gwProgram, gwMonitor, gwRunner, scopedProjectPath(dashboardScope, projectPath))
 			}
 
 			// Show startup banner (headless mode)
@@ -1191,6 +1197,7 @@ Examples:
 	}
 
 	cmd.Flags().BoolVar(&dashboardMode, "dashboard", false, "Show TUI dashboard for real-time task monitoring")
+	cmd.Flags().StringVar(&dashboardScope, "dashboard-scope", "project", "Scope dashboard metrics: project (current project only) or all (all projects)")
 	cmd.Flags().StringVarP(&projectPath, "project", "p", "", "Project path (default: config default or cwd)")
 	cmd.Flags().BoolVar(&replace, "replace", false, "Kill existing bot instance before starting")
 	cmd.Flags().BoolVar(&noGateway, "no-gateway", false, "Run polling adapters only (no HTTP gateway)")

--- a/cmd/pilot/scope_test.go
+++ b/cmd/pilot/scope_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+func TestScopedProjectPath(t *testing.T) {
+	const path = "/home/user/myproject"
+	tests := []struct {
+		scope string
+		want  string
+	}{
+		{"project", path},
+		{"all", ""},
+		{"", path},
+	}
+	for _, tt := range tests {
+		got := scopedProjectPath(tt.scope, path)
+		if got != tt.want {
+			t.Errorf("scopedProjectPath(%q, %q) = %q, want %q", tt.scope, path, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `--dashboard-scope` flag to `pilot start` (default `"project"`, accepts `project|all`)
- Validate the flag at startup; invalid value exits non-zero with a clear error message
- Extract `scopedProjectPath(scope, projectPath string) string` helper in `commands.go`
- Wire the helper at the two gateway call sites: `SetDashboardProjectPath` and `runDashboardMode`
- Add table-driven unit test (`TestScopedProjectPath`) covering `scope=project`, `scope=all`, and `scope=""`

Closes #3534. Part of GH-3530.

## Test plan

- [ ] `go test ./cmd/pilot/... -run TestScopedProjectPath` passes
- [ ] `go build ./...` passes with zero errors
- [ ] `golangci-lint run --new-from-rev=origin/main ./...` reports 0 issues
- [ ] `pilot start --dashboard-scope=bogus` exits non-zero with `invalid --dashboard-scope "bogus": must be one of [project, all]`
- [ ] `pilot start --dashboard-scope=all --dashboard` shows lifetime metrics across all projects
- [ ] Default behavior unchanged (no `--dashboard-scope` flag → scoped to current project)