### PR TITLE
docs(landing): remove Terminal-Bench claims and fix copy-page mobile overflow

### DIFF
--- a/docs/content/concepts/why-pilot.mdx
+++ b/docs/content/concepts/why-pilot.mdx
@@ -17,11 +17,7 @@ Era 1: Human writes code → AI suggests completions
 Era 2: Human writes ticket → AI ships the PR
 ```
 
-Pilot is built for Era 2 — and the benchmarks prove it.
-
-<Callout type="info">
-**#1 on Terminal-Bench 2.0** — Pilot scored 82% across 445 real-world software engineering tasks, ranking first on the global leaderboard for autonomous coding agents. [View the leaderboard →](https://huggingface.co/datasets/harborframework/terminal-bench-2-leaderboard)
-</Callout>
+Pilot is built for Era 2.
 
 <Callout type="info">
 This is not about replacing engineers. It's about removing engineers from work that doesn't need their judgment — CRUD endpoints, test coverage, documentation updates, bug fixes with clear repro steps.
@@ -75,7 +71,7 @@ Running Claude Code directly with a `CLAUDE.md` file works for one-off tasks. Bu
                        ASSISTIVE
 ```
 
-Pilot occupies a unique quadrant: **autonomous and self-hosted**. No other tool in the market combines ticket-driven autonomous execution with full self-hosting capability. Pilot is also the **#1 ranked agent on Terminal-Bench 2.0**, the industry standard benchmark for autonomous coding tools.
+Pilot occupies a unique quadrant: **autonomous and self-hosted**. No other tool in the market combines ticket-driven autonomous execution with full self-hosting capability.
 
 - **Top-left (Pilot):** Autonomous execution on your own infrastructure. Your code never leaves your environment. Full control over the AI pipeline.
 - **Top-right (Devin, Factory):** Autonomous but cloud-locked. You trust a third party with source code access and CI credentials.
@@ -162,7 +158,6 @@ Trivial tickets cost cents and complete in seconds. Complex tickets get the reas
 
 | Capability | Pilot | Cursor | Copilot | Devin | DIY Claude Code |
 |-----------|-------|--------|---------|-------|-----------------|
-| **Terminal-Bench 2.0** | ✅ #1 (82%) | ❌ N/A | ❌ N/A | ❌ Not ranked | ❌ N/A |
 | **Autonomous execution** | ✅ Ticket → PR | ❌ | ❌ | ✅ | ⚠️ Manual |
 | **Ticket integration** | ✅ GitHub, Linear, Jira, Asana | ❌ | ⚠️ Partial | ✅ | ❌ |
 | **Codebase context** | ✅ Built-in (deep) | ⚠️ File-level | ⚠️ File-level | ⚠️ Proprietary | ⚠️ Manual CLAUDE.md |

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -1,3 +1,7 @@
+---
+copyPage: false
+---
+
 ```
    ██████╗ ██╗██╗      ██████╗ ████████╗
    ██╔══██╗██║██║     ██╔═══██╗╚══██╔══╝
@@ -8,8 +12,6 @@
 ```
 
 **AI that ships your tickets while you focus on architecture.**
-
-**#1 on [Terminal-Bench 2.0](https://huggingface.co/datasets/harborframework/terminal-bench-2-leaderboard) — the global benchmark for autonomous coding agents.** 82% pass rate across 445 real-world software tasks.
 
 Pilot is an autonomous development pipeline with **260+ features** production-ready. It picks up tickets from GitHub Issues, GitLab Issues, Linear, Jira, Asana, Plane, or Discord — plans the implementation using your codebase context, writes code with Claude Code, runs quality gates, and opens a pull request. You review and merge.
 


### PR DESCRIPTION
## Summary

- Removes all Terminal-Bench 2.0 ranking claims from `docs/content/index.mdx` (the #1 line) and `docs/content/concepts/why-pilot.mdx` (intro callout, quadrant caption, feature comparison row). Guard verified: `grep -ri "terminal-bench|leaderboard" docs/content/` returns 0 hits.
- Adds `copyPage: false` frontmatter to `docs/content/index.mdx` to disable the Nextra v4 copy-page split-button on the landing route only, preventing horizontal overflow at 375px. Interior pages are unaffected (verified via `nextra/dist/server/schemas.js` — `copyPage` is a per-page opt-out).

Closes #3554

## Test plan

- [ ] `grep -ri "terminal-bench\|leaderboard" docs/content/` returns 0 hits
- [ ] Docs build succeeds (`cd docs && npm run build`)
- [ ] Landing page (`/`) shows no copy-page button at 375px width
- [ ] Interior pages (e.g. `/getting-started/prerequisites`) still show copy-page button
- [ ] No horizontal overflow at 375px on `/`
- [ ] `layout.tsx` a11y backfill Script (lines 62-67) untouched