### PR TITLE
fix(autopilot): harden release stage — retry cap, reachability guard, tag pagination (GH-3558)

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -651,15 +651,23 @@ func (c *Client) ListTags(ctx context.Context, owner, repo string, perPage int) 
 }
 
 // GetTagForSHA returns the tag name if a tag exists at the given SHA, or empty string if none.
-// Used to detect if a commit has already been tagged (race condition prevention).
+// Paginates exhaustively (100 per page) so that repos with more than 20 tags are not
+// silently missed — a 20-tag window caused false "not found" results in large repos. (GH-3558)
 func (c *Client) GetTagForSHA(ctx context.Context, owner, repo, sha string) (string, error) {
-	tags, err := c.ListTags(ctx, owner, repo, 20)
-	if err != nil {
-		return "", err
-	}
-	for _, tag := range tags {
-		if tag.Commit.SHA == sha {
-			return tag.Name, nil
+	const perPage = 100
+	for page := 1; ; page++ {
+		path := fmt.Sprintf("/repos/%s/%s/tags?per_page=%d&page=%d", owner, repo, perPage, page)
+		var batch []*Tag
+		if err := c.doRequest(ctx, http.MethodGet, path, nil, &batch); err != nil {
+			return "", err
+		}
+		for _, tag := range batch {
+			if tag.Commit.SHA == sha {
+				return tag.Name, nil
+			}
+		}
+		if len(batch) < perPage {
+			break
 		}
 	}
 	return "", nil

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -651,11 +651,12 @@ func (c *Client) ListTags(ctx context.Context, owner, repo string, perPage int) 
 }
 
 // GetTagForSHA returns the tag name if a tag exists at the given SHA, or empty string if none.
-// Paginates exhaustively (100 per page) so that repos with more than 20 tags are not
-// silently missed — a 20-tag window caused false "not found" results in large repos. (GH-3558)
+// Paginates exhaustively (100 per page, up to 50 pages = 5 000 tags) so a SHA beyond the
+// first 20 newest tags is still found. Used to detect if a commit has already been tagged.
 func (c *Client) GetTagForSHA(ctx context.Context, owner, repo, sha string) (string, error) {
 	const perPage = 100
-	for page := 1; ; page++ {
+	const maxPages = 50
+	for page := 1; page <= maxPages; page++ {
 		path := fmt.Sprintf("/repos/%s/%s/tags?per_page=%d&page=%d", owner, repo, perPage, page)
 		var batch []*Tag
 		if err := c.doRequest(ctx, http.MethodGet, path, nil, &batch); err != nil {

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -3769,3 +3769,74 @@ func TestDoRequest_ReplayBodyOnRetry(t *testing.T) {
 		}
 	}
 }
+
+// TestGetTagForSHA_ExhaustivePagination verifies that GetTagForSHA finds a tag
+// whose SHA sits beyond the first page of results (i.e. would have been missed
+// by the old ListTags(...,20) window). The test serves three pages of tags —
+// page 1 and 2 return 100 tags each, page 3 returns the target tag plus a
+// sentinel tag — and asserts the correct tag name is returned. GH-3558.
+func TestGetTagForSHA_ExhaustivePagination(t *testing.T) {
+	const targetSHA = "deeplypaginatedsha"
+	const targetTag = "v0.99.0"
+
+	// Build a full page of dummy tags (none match targetSHA).
+	makePage := func(n int, prefix string) []Tag {
+		tags := make([]Tag, n)
+		for i := range tags {
+			tags[i] = Tag{Name: fmt.Sprintf("%s-tag-%d", prefix, i)}
+			tags[i].Commit.SHA = fmt.Sprintf("%s-sha-%d", prefix, i)
+		}
+		return tags
+	}
+
+	page1 := makePage(100, "p1")
+	page2 := makePage(100, "p2")
+	// Page 3: target tag + one filler (fewer than 100 → last page).
+	targetTagObj := Tag{Name: targetTag}
+	targetTagObj.Commit.SHA = targetSHA
+	page3 := []Tag{targetTagObj, {Name: "extra"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pageParam := r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		switch pageParam {
+		case "1":
+			_ = json.NewEncoder(w).Encode(page1)
+		case "2":
+			_ = json.NewEncoder(w).Encode(page2)
+		default:
+			_ = json.NewEncoder(w).Encode(page3)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	got, err := client.GetTagForSHA(context.Background(), "owner", "repo", targetSHA)
+	if err != nil {
+		t.Fatalf("GetTagForSHA() error = %v", err)
+	}
+	if got != targetTag {
+		t.Errorf("GetTagForSHA() = %q, want %q", got, targetTag)
+	}
+}
+
+// TestGetTagForSHA_NotFound verifies that GetTagForSHA returns empty string
+// when no tag matches, scanning all pages to exhaustion. GH-3558.
+func TestGetTagForSHA_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return a single page with one tag whose SHA does not match.
+		tag := Tag{Name: "v1.0.0"}
+		tag.Commit.SHA = "othershaabc"
+		_, _ = w.Write([]byte(`[{"name":"v1.0.0","commit":{"sha":"othershaabc"}}]`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	got, err := client.GetTagForSHA(context.Background(), "owner", "repo", "notpresentsha")
+	if err != nil {
+		t.Fatalf("GetTagForSHA() error = %v", err)
+	}
+	if got != "" {
+		t.Errorf("GetTagForSHA() = %q, want empty string when SHA not found", got)
+	}
+}

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -2234,6 +2234,79 @@ func TestGetTagForSHA(t *testing.T) {
 	}
 }
 
+// TestGetTagForSHA_Paginated verifies that GetTagForSHA paginates exhaustively and
+// finds a tag that is NOT in the first page (i.e. beyond the old 20-tag window).
+func TestGetTagForSHA_Paginated(t *testing.T) {
+	const targetSHA = "targetsha001"
+	const targetTag = "v5.0.42-target"
+
+	// Page 1: 100 tags, none matching targetSHA.
+	page1 := make([]*Tag, 100)
+	for i := range page1 {
+		page1[i] = &Tag{Name: fmt.Sprintf("v5.0.%d", i)}
+		page1[i].Commit.SHA = fmt.Sprintf("bulksha%03d", i)
+	}
+	// Page 2: 50 tags; targetSHA is at position 7.
+	page2 := make([]*Tag, 50)
+	for i := range page2 {
+		page2[i] = &Tag{Name: fmt.Sprintf("v5.1.%d", i)}
+		page2[i].Commit.SHA = fmt.Sprintf("page2sha%03d", i)
+	}
+	page2[7].Commit.SHA = targetSHA
+	page2[7].Name = targetTag
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasPrefix(r.URL.Path, "/repos/owner/repo/tags") {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		page := r.URL.Query().Get("page")
+		w.WriteHeader(http.StatusOK)
+		if page == "2" {
+			_ = json.NewEncoder(w).Encode(page2)
+		} else {
+			_ = json.NewEncoder(w).Encode(page1)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	tag, err := client.GetTagForSHA(context.Background(), "owner", "repo", targetSHA)
+	if err != nil {
+		t.Fatalf("GetTagForSHA() error = %v", err)
+	}
+	if tag != targetTag {
+		t.Errorf("GetTagForSHA() = %q, want %q", tag, targetTag)
+	}
+}
+
+// TestGetTagForSHA_NotFoundAfterFullScan verifies that GetTagForSHA returns empty
+// string (no error) when the SHA does not appear in any page.
+func TestGetTagForSHA_NotFoundAfterFullScan(t *testing.T) {
+	// Single page with 10 tags, none matching.
+	tags := make([]*Tag, 10)
+	for i := range tags {
+		tags[i] = &Tag{Name: fmt.Sprintf("v6.0.%d", i)}
+		tags[i].Commit.SHA = fmt.Sprintf("other%03d", i)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(tags)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	tag, err := client.GetTagForSHA(context.Background(), "owner", "repo", "notpresent")
+	if err != nil {
+		t.Fatalf("GetTagForSHA() unexpected error: %v", err)
+	}
+	if tag != "" {
+		t.Errorf("GetTagForSHA() = %q, want empty string when SHA not found", tag)
+	}
+}
+
 func TestDeleteBranch(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -3820,23 +3893,3 @@ func TestGetTagForSHA_ExhaustivePagination(t *testing.T) {
 	}
 }
 
-// TestGetTagForSHA_NotFound verifies that GetTagForSHA returns empty string
-// when no tag matches, scanning all pages to exhaustion. GH-3558.
-func TestGetTagForSHA_NotFound(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Return a single page with one tag whose SHA does not match.
-		tag := Tag{Name: "v1.0.0"}
-		tag.Commit.SHA = "othershaabc"
-		_, _ = w.Write([]byte(`[{"name":"v1.0.0","commit":{"sha":"othershaabc"}}]`))
-	}))
-	defer server.Close()
-
-	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
-	got, err := client.GetTagForSHA(context.Background(), "owner", "repo", "notpresentsha")
-	if err != nil {
-		t.Fatalf("GetTagForSHA() error = %v", err)
-	}
-	if got != "" {
-		t.Errorf("GetTagForSHA() = %q, want empty string when SHA not found", got)
-	}
-}

--- a/internal/adapters/github/get_tag_for_sha_test.go
+++ b/internal/adapters/github/get_tag_for_sha_test.go
@@ -1,0 +1,142 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// makeTag builds a Tag with the given name and commit SHA.
+func makeTag(name, sha string) *Tag {
+	t := &Tag{Name: name}
+	t.Commit.SHA = sha
+	return t
+}
+
+// TestGetTagForSHA_OldTagBeyond20 verifies that GetTagForSHA finds a tag even
+// when it lives beyond the first 20 entries — the window previously used. (GH-3558)
+func TestGetTagForSHA_OldTagBeyond20(t *testing.T) {
+	const targetSHA = "sha-at-position-25"
+	const perPage = 100
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		page := 1
+		if p := r.URL.Query().Get("page"); p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &page)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch page {
+		case 1:
+			// First page: 100 tags, none at targetSHA.
+			tags := make([]*Tag, perPage)
+			for i := range tags {
+				tags[i] = makeTag(fmt.Sprintf("v1.0.%d", i), fmt.Sprintf("sha-%d", i))
+			}
+			_ = json.NewEncoder(w).Encode(tags)
+		case 2:
+			// Second page: 25 tags, the last one is targetSHA.
+			tags := make([]*Tag, 25)
+			for i := range tags {
+				sha := fmt.Sprintf("sha-page2-%d", i)
+				if i == 24 {
+					sha = targetSHA
+				}
+				tags[i] = makeTag(fmt.Sprintf("v2.0.%d", i), sha)
+			}
+			_ = json.NewEncoder(w).Encode(tags)
+		default:
+			_ = json.NewEncoder(w).Encode([]*Tag{})
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	tag, err := client.GetTagForSHA(context.Background(), "owner", "repo", targetSHA)
+	if err != nil {
+		t.Fatalf("GetTagForSHA returned error: %v", err)
+	}
+	if tag == "" {
+		t.Fatal("expected tag name, got empty string — old 20-tag window bug may still be present")
+	}
+	if tag != "v2.0.24" {
+		t.Errorf("tag = %q, want %q", tag, "v2.0.24")
+	}
+}
+
+// TestGetTagForSHA_NotFound verifies that GetTagForSHA returns an empty string
+// and no error when no tag points to the given SHA.
+func TestGetTagForSHA_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Return a page with tags none of which match the queried SHA.
+		tags := []*Tag{
+			makeTag("v1.0.0", "some-other-sha"),
+			makeTag("v1.0.1", "another-sha"),
+		}
+		_ = json.NewEncoder(w).Encode(tags)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	tag, err := client.GetTagForSHA(context.Background(), "owner", "repo", "missing-sha")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "" {
+		t.Errorf("expected empty string for missing SHA, got %q", tag)
+	}
+}
+
+// TestGetTagForSHA_PaginatesUntilFound verifies that GetTagForSHA stops paginating
+// as soon as a match is found (does not fetch extra pages).
+func TestGetTagForSHA_PaginatesUntilFound(t *testing.T) {
+	const targetSHA = "target-sha"
+	const perPage = 100
+	pagesRequested := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		pagesRequested++
+
+		page := 1
+		if p := r.URL.Query().Get("page"); p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &page)
+		}
+
+		if page == 1 {
+			// Full page — no match, forces a second request.
+			tags := make([]*Tag, perPage)
+			for i := range tags {
+				tags[i] = makeTag(fmt.Sprintf("v1.%d.0", i), fmt.Sprintf("sha-%d", i))
+			}
+			_ = json.NewEncoder(w).Encode(tags)
+			return
+		}
+		// Second page contains the target (first element).
+		_ = json.NewEncoder(w).Encode([]*Tag{makeTag("v2.0.0", targetSHA)})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	tag, err := client.GetTagForSHA(context.Background(), "owner", "repo", targetSHA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "v2.0.0" {
+		t.Errorf("tag = %q, want %q", tag, "v2.0.0")
+	}
+	if pagesRequested != 2 {
+		t.Errorf("pages requested = %d, want 2", pagesRequested)
+	}
+}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -30,17 +30,6 @@ type projectBoardSyncer interface {
 	UpdateProjectItemStatus(ctx context.Context, issueNodeID string, statusName string) error
 }
 
-// maxReleasingAttempts is the hard cap on handleReleasing retries before the PR
-// transitions to StageFailed. Prevents StageReleasing from looping indefinitely
-// when transient API failures (tag lookup, commit fetch) persist across many polls.
-// At the default 30 s poll interval this allows ~10 minutes of retrying. (GH-3558)
-const maxReleasingAttempts = 20
-
-// maxReleasingDuration is the wall-clock cap on time spent in StageReleasing from the
-// first tagging attempt. Complements maxReleasingAttempts for cases where the daemon
-// restarts (resetting the count) but the underlying issue persists. (GH-3558)
-const maxReleasingDuration = 30 * time.Minute
-
 // iterationRe matches the iteration field in autopilot-meta comments.
 var iterationRe = regexp.MustCompile(`<!-- autopilot-meta.*?iteration:(\d+).*?-->`)
 
@@ -1933,15 +1922,17 @@ func (c *Controller) tagCoveringCommit(ctx context.Context, owner, repo, sha str
 
 // handleReleasing creates a release after successful merge and CI.
 func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) error {
-	prState.ReleasingAttempts++
-	if prState.ReleasingFirstAt.IsZero() {
-		prState.ReleasingFirstAt = time.Now()
-	}
-
 	if c.releaser == nil {
 		c.log.Debug("releaser not configured, skipping release", "pr", prState.PRNumber)
 		c.removePR(prState.PRNumber)
 		return nil
+	}
+
+	// Track attempt count for retry cap. Drain paths (tag already exists) never
+	// reach the cap — only persistent error loops do.
+	prState.ReleasingAttempts++
+	if prState.ReleasingFirstAt.IsZero() {
+		prState.ReleasingFirstAt = time.Now()
 	}
 
 	// Resolve the actual repo owner/name from the PR URL.
@@ -1949,40 +1940,6 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	// than c.owner/c.repo (the pilot repo). All release API calls must target the
 	// correct repo to avoid stuck-forever releasing state.
 	owner, repo := prState.RepoOwnerAndName(c.owner, c.repo)
-
-	// Refresh HeadSHA to the merge commit SHA. For squash-merged PRs the PR branch
-	// head is NOT on the default branch; tagging it would place the tag on a commit
-	// unreachable from main. Best-effort: if the fetch fails we proceed with the
-	// existing SHA (the reachability guard below is gated on a successful refresh). (GH-3558)
-	headSHARefreshed := false
-	if ghPR, fetchErr := c.ghClient.GetPullRequest(ctx, owner, repo, prState.PRNumber); fetchErr == nil && ghPR.MergeCommitSHA != "" {
-		if ghPR.MergeCommitSHA != prState.HeadSHA {
-			c.log.Debug("handleReleasing: refreshed HeadSHA to merge commit",
-				"pr", prState.PRNumber,
-				"old", ShortSHA(prState.HeadSHA),
-				"new", ShortSHA(ghPR.MergeCommitSHA),
-			)
-			prState.HeadSHA = ghPR.MergeCommitSHA
-		}
-		headSHARefreshed = true
-	}
-
-	// Fast-path drain: if a published GitHub Release already exists for HeadSHA,
-	// we are done — avoid any further API calls and drain the PR. This guards the
-	// retry-loop case where a prior Pilot instance (or a human) already released
-	// the commit. Uses the fixed exhaustive GetTagForSHA. (GH-3558)
-	if tag, tagErr := c.ghClient.GetTagForSHA(ctx, owner, repo, prState.HeadSHA); tagErr == nil && tag != "" {
-		if rel, relErr := c.ghClient.GetReleaseByTag(ctx, owner, repo, tag); relErr == nil && rel != nil && rel.ID != 0 && !rel.Draft {
-			c.log.Info("published release already exists for HeadSHA, draining",
-				"pr", prState.PRNumber,
-				"sha", ShortSHA(prState.HeadSHA),
-				"tag", tag,
-				"release_url", rel.HTMLURL,
-			)
-			c.removePR(prState.PRNumber)
-			return nil
-		}
-	}
 
 	// Race condition guard: Check if this commit is already covered by a tag.
 	// When multiple PRs merge rapidly, each triggers handleReleasing but only
@@ -2000,7 +1957,7 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		// "Reference already exists", returns an error, and the PR stays in
 		// StageReleasing forever (re-tried every poll). Return the error so this
 		// PR is retried cleanly on the next poll once the lookup recovers. (TASK-316)
-		return c.releasingErrorOrFail(ctx, prState,
+		return c.checkReleasingRetryOrEscalate(ctx, prState,
 			fmt.Errorf("failed to check existing tags for PR #%d: %w", prState.PRNumber, err))
 	}
 	if existingTag != "" {
@@ -2013,42 +1970,31 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		return nil
 	}
 
-	// Reachability guard: refuse to tag a SHA that is not reachable from the
-	// default branch. A diverged or "behind" status means the commit was never
-	// actually merged into the release branch — tagging it would publish the wrong
-	// content. Only applied when HeadSHA was successfully refreshed to the merge
-	// commit SHA above; the branch-head SHA would falsely fail for squash merges. (GH-3558)
-	if headSHARefreshed {
-		defaultBranch := c.resolveMainBranchName()
-		reachStatus, reachErr := c.ghClient.CompareStatus(ctx, owner, repo, prState.HeadSHA, defaultBranch)
-		if reachErr != nil {
-			return c.releasingErrorOrFail(ctx, prState,
-				fmt.Errorf("reachability check failed for PR #%d: %w", prState.PRNumber, reachErr))
-		}
-		if reachStatus != "ahead" && reachStatus != "identical" {
-			errMsg := fmt.Sprintf(
-				"refusing to release PR #%d: HeadSHA %s is not reachable from %s (compare status: %s) — manual intervention required",
-				prState.PRNumber, ShortSHA(prState.HeadSHA), defaultBranch, reachStatus)
-			c.log.Error("handleReleasing: SHA not reachable from default branch — escalating to StageFailed",
-				"pr", prState.PRNumber,
-				"sha", ShortSHA(prState.HeadSHA),
-				"branch", defaultBranch,
-				"status", reachStatus,
-			)
-			if prState.IssueNumber > 0 {
-				comment := fmt.Sprintf(
-					"⚠️ **Release blocked**: PR #%d HeadSHA `%s` is not reachable from `%s` (compare status: `%s`).\n\nThis usually means the PR was not actually merged into the release branch. Manual intervention is required.",
-					prState.PRNumber, ShortSHA(prState.HeadSHA), defaultBranch, reachStatus)
-				if _, cerr := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); cerr != nil {
-					c.log.Warn("failed to post reachability failure comment", "issue", prState.IssueNumber, "error", cerr)
-				}
-			}
-			prState.Stage = StageFailed
-			prState.Error = errMsg
-			c.metrics.RecordPRFailed()
-			c.metrics.RecordIssueProcessed("failed")
-			return nil
-		}
+	// Published-release guard: tagCoveringCommit uses a bounded window of 10 tags.
+	// This exhaustive lookup (paginates all tags) catches the case where the SHA
+	// was tagged more than 10 releases ago and treats it as already released.
+	exactTag, err := c.ghClient.GetTagForSHA(ctx, owner, repo, prState.HeadSHA)
+	if err != nil {
+		return c.checkReleasingRetryOrEscalate(ctx, prState,
+			fmt.Errorf("failed to check published release for PR #%d: %w", prState.PRNumber, err))
+	}
+	if exactTag != "" {
+		c.log.Info("commit already tagged (exact match in full tag history) — treating as released",
+			"pr", prState.PRNumber,
+			"sha", ShortSHA(prState.HeadSHA),
+			"tag", exactTag,
+		)
+		c.removePR(prState.PRNumber)
+		return nil
+	}
+
+	// Reachability guard: refuse to tag a commit that is not reachable from the
+	// default branch. A diverged SHA (e.g. from a force-push or a PR merged to a
+	// non-main branch) can never be released from main; failing immediately avoids
+	// unbounded retries on a permanently unreleasable commit.
+	if reachErr := c.guardReleaseSHAReachable(ctx, owner, repo, prState); reachErr != nil {
+		c.escalateReleasingFailed(ctx, prState, reachErr.Error())
+		return nil
 	}
 
 	// Get current version from the target repo
@@ -2061,7 +2007,8 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	// Get PR commits for bump detection
 	commits, err := c.ghClient.GetPRCommits(ctx, owner, repo, prState.PRNumber)
 	if err != nil {
-		return c.releasingErrorOrFail(ctx, prState, fmt.Errorf("failed to get PR commits: %w", err))
+		return c.checkReleasingRetryOrEscalate(ctx, prState,
+			fmt.Errorf("failed to get PR commits: %w", err))
 	}
 
 	// Detect bump type from commits
@@ -2101,7 +2048,8 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 			c.removePR(prState.PRNumber)
 			return nil
 		}
-		return c.releasingErrorOrFail(ctx, prState, fmt.Errorf("failed to create tag: %w", err))
+		return c.checkReleasingRetryOrEscalate(ctx, prState,
+			fmt.Errorf("failed to create tag: %w", err))
 	}
 
 	releaseURL := fmt.Sprintf("https://github.com/%s/%s/releases/tag/%s", owner, repo, tagName)
@@ -2149,41 +2097,81 @@ func isDuplicateTagError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "already exists")
 }
 
-// releasingErrorOrFail returns causeErr if the PR is still within the retry cap, or
-// escalates to StageFailed once maxReleasingAttempts or maxReleasingDuration is reached.
-// The transition to StageFailed posts a GitHub issue comment (if linked) and records
-// failure metrics. It always returns nil on escalation so the caller's error path is
-// suppressed and ProcessPR treats the state change as a clean (non-retried) transition.
-// maxReleasingDuration guards against the restart-and-reset scenario where the attempt
-// counter resets but the underlying issue persists. (GH-3558)
-func (c *Controller) releasingErrorOrFail(ctx context.Context, prState *PRState, causeErr error) error {
-	elapsed := time.Since(prState.ReleasingFirstAt)
-	if prState.ReleasingAttempts < maxReleasingAttempts && elapsed < maxReleasingDuration {
-		return causeErr
+// checkReleasingRetryOrEscalate returns nil (transitioning prState to StageFailed) when
+// ReleasingAttempts has reached MaxReleasingAttempts; otherwise returns err so the caller
+// retries on the next poll.
+func (c *Controller) checkReleasingRetryOrEscalate(ctx context.Context, prState *PRState, err error) error {
+	if prState.ReleasingAttempts >= c.config.MaxReleasingAttempts {
+		msg := fmt.Sprintf("release failed after %d/%d attempts: %v — manual intervention required",
+			prState.ReleasingAttempts, c.config.MaxReleasingAttempts, err)
+		c.escalateReleasingFailed(ctx, prState, msg)
+		return nil
 	}
-	errMsg := fmt.Sprintf("release failed after %d/%d attempts (%.0fm elapsed): %v — manual intervention required",
-		prState.ReleasingAttempts, maxReleasingAttempts, elapsed.Minutes(), causeErr)
-	c.log.Error("handleReleasing: cap reached — escalating to StageFailed",
+	return err
+}
+
+// escalateReleasingFailed transitions a PR to StageFailed, posts a GitHub comment on the
+// linked issue, and records metrics. Used for both the retry cap and the reachability guard.
+func (c *Controller) escalateReleasingFailed(ctx context.Context, prState *PRState, reason string) {
+	c.log.Error("handleReleasing: escalating to StageFailed",
 		"pr", prState.PRNumber,
+		"sha", ShortSHA(prState.HeadSHA),
 		"attempts", prState.ReleasingAttempts,
-		"max_attempts", maxReleasingAttempts,
-		"elapsed", elapsed.Round(time.Second),
-		"max_duration", maxReleasingDuration,
-		"error", causeErr,
+		"reason", reason,
 	)
 	if prState.IssueNumber > 0 {
 		comment := fmt.Sprintf(
-			"⚠️ **Release escalation**: PR #%d failed to release after %d attempts (%.0f min elapsed).\n\nLast error: `%v`\n\nManual intervention is required — no further automatic retries will be made.",
-			prState.PRNumber, prState.ReleasingAttempts, elapsed.Minutes(), causeErr)
+			"⚠️ **Release escalation**: PR #%d failed to release.\n\nReason: `%v`\n\nManual intervention is required — no further automatic retries will be made.",
+			prState.PRNumber, reason)
 		if _, cerr := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); cerr != nil {
 			c.log.Warn("failed to post release escalation comment", "issue", prState.IssueNumber, "error", cerr)
 		}
 	}
 	prState.Stage = StageFailed
-	prState.Error = errMsg
+	prState.Error = reason
 	c.metrics.RecordPRFailed()
 	c.metrics.RecordIssueProcessed("failed")
-	return nil
+}
+
+// guardReleaseSHAReachable verifies that prState.HeadSHA is reachable from the default
+// branch of the target repo before creating a release tag. A diverged SHA (from a
+// force-push or a PR merged to a non-main branch) cannot be released from main and would
+// loop forever without this guard. Fails open (returns nil) on transient API errors so
+// a temporary outage doesn't block a valid release.
+func (c *Controller) guardReleaseSHAReachable(ctx context.Context, owner, repo string, prState *PRState) error {
+	branchName := c.resolveMainBranchName()
+	branch, err := c.ghClient.GetBranch(ctx, owner, repo, branchName)
+	if err != nil {
+		// Transient — skip the guard rather than blocking a valid release.
+		c.log.Warn("reachability guard: could not fetch default branch, skipping check",
+			"pr", prState.PRNumber,
+			"branch", branchName,
+			"error", err,
+		)
+		return nil
+	}
+	mainSHA := branch.SHA()
+
+	// Compare base=HeadSHA, head=mainSHA:
+	//   "ahead"     → mainSHA contains HeadSHA as ancestor → reachable ✓
+	//   "identical" → same commit → reachable ✓
+	//   "behind"    → HeadSHA has commits main doesn't → not reachable from main ✗
+	//   "diverged"  → both have exclusive commits → not reachable ✗
+	status, err := c.ghClient.CompareStatus(ctx, owner, repo, prState.HeadSHA, mainSHA)
+	if err != nil {
+		// Transient — skip the guard.
+		c.log.Warn("reachability guard: CompareStatus failed, skipping check",
+			"pr", prState.PRNumber,
+			"sha", ShortSHA(prState.HeadSHA),
+			"error", err,
+		)
+		return nil
+	}
+	if status == "ahead" || status == "identical" {
+		return nil
+	}
+	return fmt.Errorf("SHA %s is not reachable from %s (compare status: %q) — SHA may be from a diverged or force-pushed branch",
+		ShortSHA(prState.HeadSHA), branchName, status)
 }
 
 // isMergeConflict returns true if the PR has merge conflicts.

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -30,6 +30,17 @@ type projectBoardSyncer interface {
 	UpdateProjectItemStatus(ctx context.Context, issueNodeID string, statusName string) error
 }
 
+// maxReleasingAttempts is the hard cap on handleReleasing retries before the PR
+// transitions to StageFailed. Prevents StageReleasing from looping indefinitely
+// when transient API failures (tag lookup, commit fetch) persist across many polls.
+// At the default 30 s poll interval this allows ~10 minutes of retrying. (GH-3558)
+const maxReleasingAttempts = 20
+
+// maxReleasingDuration is the wall-clock cap on time spent in StageReleasing from the
+// first tagging attempt. Complements maxReleasingAttempts for cases where the daemon
+// restarts (resetting the count) but the underlying issue persists. (GH-3558)
+const maxReleasingDuration = 30 * time.Minute
+
 // iterationRe matches the iteration field in autopilot-meta comments.
 var iterationRe = regexp.MustCompile(`<!-- autopilot-meta.*?iteration:(\d+).*?-->`)
 
@@ -1922,6 +1933,11 @@ func (c *Controller) tagCoveringCommit(ctx context.Context, owner, repo, sha str
 
 // handleReleasing creates a release after successful merge and CI.
 func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) error {
+	prState.ReleasingAttempts++
+	if prState.ReleasingFirstAt.IsZero() {
+		prState.ReleasingFirstAt = time.Now()
+	}
+
 	if c.releaser == nil {
 		c.log.Debug("releaser not configured, skipping release", "pr", prState.PRNumber)
 		c.removePR(prState.PRNumber)
@@ -1933,6 +1949,40 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	// than c.owner/c.repo (the pilot repo). All release API calls must target the
 	// correct repo to avoid stuck-forever releasing state.
 	owner, repo := prState.RepoOwnerAndName(c.owner, c.repo)
+
+	// Refresh HeadSHA to the merge commit SHA. For squash-merged PRs the PR branch
+	// head is NOT on the default branch; tagging it would place the tag on a commit
+	// unreachable from main. Best-effort: if the fetch fails we proceed with the
+	// existing SHA (the reachability guard below is gated on a successful refresh). (GH-3558)
+	headSHARefreshed := false
+	if ghPR, fetchErr := c.ghClient.GetPullRequest(ctx, owner, repo, prState.PRNumber); fetchErr == nil && ghPR.MergeCommitSHA != "" {
+		if ghPR.MergeCommitSHA != prState.HeadSHA {
+			c.log.Debug("handleReleasing: refreshed HeadSHA to merge commit",
+				"pr", prState.PRNumber,
+				"old", ShortSHA(prState.HeadSHA),
+				"new", ShortSHA(ghPR.MergeCommitSHA),
+			)
+			prState.HeadSHA = ghPR.MergeCommitSHA
+		}
+		headSHARefreshed = true
+	}
+
+	// Fast-path drain: if a published GitHub Release already exists for HeadSHA,
+	// we are done — avoid any further API calls and drain the PR. This guards the
+	// retry-loop case where a prior Pilot instance (or a human) already released
+	// the commit. Uses the fixed exhaustive GetTagForSHA. (GH-3558)
+	if tag, tagErr := c.ghClient.GetTagForSHA(ctx, owner, repo, prState.HeadSHA); tagErr == nil && tag != "" {
+		if rel, relErr := c.ghClient.GetReleaseByTag(ctx, owner, repo, tag); relErr == nil && rel != nil && rel.ID != 0 && !rel.Draft {
+			c.log.Info("published release already exists for HeadSHA, draining",
+				"pr", prState.PRNumber,
+				"sha", ShortSHA(prState.HeadSHA),
+				"tag", tag,
+				"release_url", rel.HTMLURL,
+			)
+			c.removePR(prState.PRNumber)
+			return nil
+		}
+	}
 
 	// Race condition guard: Check if this commit is already covered by a tag.
 	// When multiple PRs merge rapidly, each triggers handleReleasing but only
@@ -1950,7 +2000,8 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		// "Reference already exists", returns an error, and the PR stays in
 		// StageReleasing forever (re-tried every poll). Return the error so this
 		// PR is retried cleanly on the next poll once the lookup recovers. (TASK-316)
-		return fmt.Errorf("failed to check existing tags for PR #%d: %w", prState.PRNumber, err)
+		return c.releasingErrorOrFail(ctx, prState,
+			fmt.Errorf("failed to check existing tags for PR #%d: %w", prState.PRNumber, err))
 	}
 	if existingTag != "" {
 		c.log.Info("commit already covered by existing tag, skipping release",
@@ -1960,6 +2011,44 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		)
 		c.removePR(prState.PRNumber)
 		return nil
+	}
+
+	// Reachability guard: refuse to tag a SHA that is not reachable from the
+	// default branch. A diverged or "behind" status means the commit was never
+	// actually merged into the release branch — tagging it would publish the wrong
+	// content. Only applied when HeadSHA was successfully refreshed to the merge
+	// commit SHA above; the branch-head SHA would falsely fail for squash merges. (GH-3558)
+	if headSHARefreshed {
+		defaultBranch := c.resolveMainBranchName()
+		reachStatus, reachErr := c.ghClient.CompareStatus(ctx, owner, repo, prState.HeadSHA, defaultBranch)
+		if reachErr != nil {
+			return c.releasingErrorOrFail(ctx, prState,
+				fmt.Errorf("reachability check failed for PR #%d: %w", prState.PRNumber, reachErr))
+		}
+		if reachStatus != "ahead" && reachStatus != "identical" {
+			errMsg := fmt.Sprintf(
+				"refusing to release PR #%d: HeadSHA %s is not reachable from %s (compare status: %s) — manual intervention required",
+				prState.PRNumber, ShortSHA(prState.HeadSHA), defaultBranch, reachStatus)
+			c.log.Error("handleReleasing: SHA not reachable from default branch — escalating to StageFailed",
+				"pr", prState.PRNumber,
+				"sha", ShortSHA(prState.HeadSHA),
+				"branch", defaultBranch,
+				"status", reachStatus,
+			)
+			if prState.IssueNumber > 0 {
+				comment := fmt.Sprintf(
+					"⚠️ **Release blocked**: PR #%d HeadSHA `%s` is not reachable from `%s` (compare status: `%s`).\n\nThis usually means the PR was not actually merged into the release branch. Manual intervention is required.",
+					prState.PRNumber, ShortSHA(prState.HeadSHA), defaultBranch, reachStatus)
+				if _, cerr := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); cerr != nil {
+					c.log.Warn("failed to post reachability failure comment", "issue", prState.IssueNumber, "error", cerr)
+				}
+			}
+			prState.Stage = StageFailed
+			prState.Error = errMsg
+			c.metrics.RecordPRFailed()
+			c.metrics.RecordIssueProcessed("failed")
+			return nil
+		}
 	}
 
 	// Get current version from the target repo
@@ -1972,7 +2061,7 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	// Get PR commits for bump detection
 	commits, err := c.ghClient.GetPRCommits(ctx, owner, repo, prState.PRNumber)
 	if err != nil {
-		return fmt.Errorf("failed to get PR commits: %w", err)
+		return c.releasingErrorOrFail(ctx, prState, fmt.Errorf("failed to get PR commits: %w", err))
 	}
 
 	// Detect bump type from commits
@@ -2012,7 +2101,7 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 			c.removePR(prState.PRNumber)
 			return nil
 		}
-		return fmt.Errorf("failed to create tag: %w", err)
+		return c.releasingErrorOrFail(ctx, prState, fmt.Errorf("failed to create tag: %w", err))
 	}
 
 	releaseURL := fmt.Sprintf("https://github.com/%s/%s/releases/tag/%s", owner, repo, tagName)
@@ -2058,6 +2147,43 @@ func isDuplicateTagError(err error) bool {
 		return false
 	}
 	return strings.Contains(strings.ToLower(err.Error()), "already exists")
+}
+
+// releasingErrorOrFail returns causeErr if the PR is still within the retry cap, or
+// escalates to StageFailed once maxReleasingAttempts or maxReleasingDuration is reached.
+// The transition to StageFailed posts a GitHub issue comment (if linked) and records
+// failure metrics. It always returns nil on escalation so the caller's error path is
+// suppressed and ProcessPR treats the state change as a clean (non-retried) transition.
+// maxReleasingDuration guards against the restart-and-reset scenario where the attempt
+// counter resets but the underlying issue persists. (GH-3558)
+func (c *Controller) releasingErrorOrFail(ctx context.Context, prState *PRState, causeErr error) error {
+	elapsed := time.Since(prState.ReleasingFirstAt)
+	if prState.ReleasingAttempts < maxReleasingAttempts && elapsed < maxReleasingDuration {
+		return causeErr
+	}
+	errMsg := fmt.Sprintf("release failed after %d/%d attempts (%.0fm elapsed): %v — manual intervention required",
+		prState.ReleasingAttempts, maxReleasingAttempts, elapsed.Minutes(), causeErr)
+	c.log.Error("handleReleasing: cap reached — escalating to StageFailed",
+		"pr", prState.PRNumber,
+		"attempts", prState.ReleasingAttempts,
+		"max_attempts", maxReleasingAttempts,
+		"elapsed", elapsed.Round(time.Second),
+		"max_duration", maxReleasingDuration,
+		"error", causeErr,
+	)
+	if prState.IssueNumber > 0 {
+		comment := fmt.Sprintf(
+			"⚠️ **Release escalation**: PR #%d failed to release after %d attempts (%.0f min elapsed).\n\nLast error: `%v`\n\nManual intervention is required — no further automatic retries will be made.",
+			prState.PRNumber, prState.ReleasingAttempts, elapsed.Minutes(), causeErr)
+		if _, cerr := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); cerr != nil {
+			c.log.Warn("failed to post release escalation comment", "issue", prState.IssueNumber, "error", cerr)
+		}
+	}
+	prState.Stage = StageFailed
+	prState.Error = errMsg
+	c.metrics.RecordPRFailed()
+	c.metrics.RecordIssueProcessed("failed")
+	return nil
 }
 
 // isMergeConflict returns true if the PR has merge conflicts.

--- a/internal/autopilot/controller_releasing_test.go
+++ b/internal/autopilot/controller_releasing_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/testutil"
@@ -130,6 +130,16 @@ func TestHandleReleasing_DuplicateTagTreatedAsReleased(t *testing.T) {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/commits"):
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat: add a thing")})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/branches/"):
+			// Reachability guard: return a branch so CompareStatus is called.
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"name": "main",
+				"commit": map[string]string{"sha": "mainsha101"},
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+			// Reachability guard: HeadSHA is reachable from main.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ahead"})
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
 			// Tag already exists (racing release tagged this commit first).
 			w.WriteHeader(http.StatusUnprocessableEntity)
@@ -166,171 +176,6 @@ func tagAt(name, sha string) github.Tag {
 	return tag
 }
 
-// TestHandleReleasing_AlreadyPublishedReleaseDrains verifies that when a published
-// GitHub Release already exists for HeadSHA, handleReleasing drains the PR without
-// creating a new tag. This is the fast-path "existing published release" drain. (GH-3558)
-func TestHandleReleasing_AlreadyPublishedReleaseDrains(t *testing.T) {
-	const headSHA = "mergecommitabc"
-	const tagName = "v3.1.0"
-	tagCreateCalled := false
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/"):
-			// Return a merged PR with MergeCommitSHA == headSHA.
-			_ = json.NewEncoder(w).Encode(github.PullRequest{
-				Number:         300,
-				MergeCommitSHA: headSHA,
-				Merged:         true,
-			})
-		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
-			// GetTagForSHA exhaustive search finds the tag.
-			tags := []github.Tag{tagAt(tagName, headSHA)}
-			_ = json.NewEncoder(w).Encode(tags)
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
-			// A published release already exists for this tag.
-			_ = json.NewEncoder(w).Encode(github.Release{
-				ID:      12345,
-				TagName: tagName,
-				Draft:   false,
-				HTMLURL: "https://github.com/owner/repo/releases/tag/" + tagName,
-			})
-		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
-			tagCreateCalled = true
-			w.WriteHeader(http.StatusCreated)
-		default:
-			w.WriteHeader(http.StatusOK)
-		}
-	}))
-	defer server.Close()
-
-	c := newReleasingController(t, server.URL)
-	prState := &PRState{PRNumber: 300, HeadSHA: headSHA, Stage: StageReleasing}
-	c.mu.Lock()
-	c.activePRs[300] = prState
-	c.mu.Unlock()
-
-	err := c.handleReleasing(context.Background(), prState)
-	if err != nil {
-		t.Fatalf("expected nil error when published release exists, got: %v", err)
-	}
-	if tagCreateCalled {
-		t.Error("CreateGitTag must NOT be called when a published release already exists")
-	}
-	c.mu.RLock()
-	_, stillTracked := c.activePRs[300]
-	c.mu.RUnlock()
-	if stillTracked {
-		t.Error("PR must be drained when published release exists")
-	}
-}
-
-// TestHandleReleasing_RetryCapEscalatesStageFailed verifies that once
-// ReleasingAttempts reaches maxReleasingAttempts, a transient tag-lookup error
-// causes StageFailed (not another retry). (GH-3558)
-func TestHandleReleasing_RetryCapEscalatesStageFailed(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/"):
-			// Return a merged PR with MergeCommitSHA so HeadSHA refresh succeeds.
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(github.PullRequest{
-				Number:         301,
-				MergeCommitSHA: "sha301",
-				Merged:         true,
-			})
-		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
-			// Simulate a persistent transient failure on tag lookup.
-			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = w.Write([]byte(`{"message":"server error"}`))
-		default:
-			w.WriteHeader(http.StatusOK)
-		}
-	}))
-	defer server.Close()
-
-	c := newReleasingController(t, server.URL)
-	prState := &PRState{
-		PRNumber:          301,
-		HeadSHA:           "sha301",
-		Stage:             StageReleasing,
-		ReleasingAttempts: maxReleasingAttempts - 1, // one more attempt will hit the cap
-	}
-	c.mu.Lock()
-	c.activePRs[301] = prState
-	c.mu.Unlock()
-
-	err := c.handleReleasing(context.Background(), prState)
-	if err != nil {
-		t.Fatalf("expected nil error on cap escalation, got: %v", err)
-	}
-	if prState.Stage != StageFailed {
-		t.Errorf("stage = %v, want StageFailed", prState.Stage)
-	}
-	if prState.Error == "" {
-		t.Error("prState.Error must be set on StageFailed escalation")
-	}
-	// StageFailed keeps the PR in activePRs (terminal but visible for observability),
-	// consistent with how handleMerging handles its attempt cap.
-	c.mu.RLock()
-	tracked, ok := c.activePRs[301]
-	c.mu.RUnlock()
-	if !ok || tracked == nil {
-		t.Error("PR should remain in activePRs (in StageFailed state) for observability")
-	}
-}
-
-// TestHandleReleasing_DivergedSHARefused verifies that a HeadSHA which is not
-// reachable from the default branch (compare status "diverged") causes StageFailed
-// rather than tagging a commit that was never actually merged. (GH-3558)
-func TestHandleReleasing_DivergedSHARefused(t *testing.T) {
-	const mergeCommit = "divergedcommit"
-	tagCreateCalled := false
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/"):
-			_ = json.NewEncoder(w).Encode(github.PullRequest{
-				Number:         302,
-				MergeCommitSHA: mergeCommit,
-				Merged:         true,
-			})
-		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
-			// No existing tag for this SHA.
-			_ = json.NewEncoder(w).Encode([]github.Tag{})
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
-			// The compare of mergeCommit against the default branch returns "diverged"
-			// — the commit is not on the default branch.
-			_ = json.NewEncoder(w).Encode(map[string]string{"status": "diverged"})
-		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
-			tagCreateCalled = true
-			w.WriteHeader(http.StatusCreated)
-		default:
-			w.WriteHeader(http.StatusOK)
-		}
-	}))
-	defer server.Close()
-
-	c := newReleasingController(t, server.URL)
-	prState := &PRState{PRNumber: 302, HeadSHA: "original-head", Stage: StageReleasing}
-	c.mu.Lock()
-	c.activePRs[302] = prState
-	c.mu.Unlock()
-
-	err := c.handleReleasing(context.Background(), prState)
-	if err != nil {
-		t.Fatalf("expected nil error on reachability failure, got: %v", err)
-	}
-	if tagCreateCalled {
-		t.Error("CreateGitTag must NOT be called for an unreachable SHA")
-	}
-	if prState.Stage != StageFailed {
-		t.Errorf("stage = %v, want StageFailed", prState.Stage)
-	}
-}
-
 // TestHandleReleasing_AncestorTagDedup verifies handleReleasing treats a PR
 // whose HeadSHA is already covered by an existing tag — tagged exactly, or an
 // ANCESTOR of a tag's commit — as already released: the PR drains from
@@ -339,6 +184,7 @@ func TestHandleReleasing_DivergedSHARefused(t *testing.T) {
 // spurious-v2.178.0 case where an ancestor commit cut a redundant release.
 func TestHandleReleasing_AncestorTagDedup(t *testing.T) {
 	const headSHA = "headsha000"
+	const mainBranchSHA = "mainsha200" // fixed SHA served by the branch endpoint
 	tests := []struct {
 		name          string
 		tags          []github.Tag
@@ -362,8 +208,10 @@ func TestHandleReleasing_AncestorTagDedup(t *testing.T) {
 			wantTracked:   false,
 		},
 		{
-			name:          "diverged commit cuts a release",
-			tags:          []github.Tag{tagAt("v2.0.0", "unrelatedsha")},
+			name: "diverged commit cuts a release",
+			tags: []github.Tag{tagAt("v2.0.0", "unrelatedsha")},
+			// tagCoveringCommit compare: headSHA...tagSHA → diverged (not covered by tag)
+			// reachability guard compare: headSHA...mainBranchSHA → handled separately → ahead
 			compareStatus: "diverged",
 			wantTagCreate: true,
 			wantTracked:   false,
@@ -378,9 +226,22 @@ func TestHandleReleasing_AncestorTagDedup(t *testing.T) {
 				case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
 					w.WriteHeader(http.StatusOK)
 					_ = json.NewEncoder(w).Encode(tt.tags)
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/branches/"):
+					// Reachability guard: return a fixed main branch SHA.
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"name": "main",
+						"commit": map[string]string{"sha": mainBranchSHA},
+					})
 				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+					// Reachability guard compare (headSHA...mainBranchSHA) always returns
+					// "ahead" so the guard passes. tagCoveringCommit compare
+					// (headSHA...tagSHA) returns tt.compareStatus to exercise the dedup.
+					status := tt.compareStatus
+					if strings.HasSuffix(r.URL.Path, mainBranchSHA) {
+						status = "ahead"
+					}
 					w.WriteHeader(http.StatusOK)
-					_ = json.NewEncoder(w).Encode(map[string]string{"status": tt.compareStatus})
+					_ = json.NewEncoder(w).Encode(map[string]string{"status": status})
 				case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/releases/latest"):
 					w.WriteHeader(http.StatusOK)
 					_ = json.NewEncoder(w).Encode(github.Release{TagName: "v2.0.0"})
@@ -418,18 +279,42 @@ func TestHandleReleasing_AncestorTagDedup(t *testing.T) {
 	}
 }
 
-// TestHandleReleasing_DurationCapStageFailed verifies that a PR stuck in
-// StageReleasing longer than maxReleasingDuration escalates to StageFailed via
-// releasingErrorOrFail even if the attempt count is below maxReleasingAttempts.
-// This guards the daemon-restart scenario where the attempt counter resets but the
-// underlying API failure persists. GH-3558.
-func TestHandleReleasing_DurationCapStageFailed(t *testing.T) {
+// TestHandleReleasing_ExhaustiveTagDrain verifies that a PR whose HeadSHA is tagged
+// beyond position 10 (outside tagCoveringCommit's bounded window) is still drained
+// as "already released" via the exhaustive GetTagForSHA pagination path.
+func TestHandleReleasing_ExhaustiveTagDrain(t *testing.T) {
+	const headSHA = "oldsha001"
+	// Build a page of 10 tags that don't match headSHA (simulates tagCoveringCommit's window).
+	coveringTags := make([]github.Tag, 10)
+	for i := range coveringTags {
+		coveringTags[i] = tagAt(fmt.Sprintf("v3.0.%d", i), fmt.Sprintf("othersha%03d", i))
+	}
+	// Build a per_page=100 batch where headSHA appears at position 42.
+	exhaustiveTags := make([]*github.Tag, 100)
+	for i := range exhaustiveTags {
+		t2 := &github.Tag{Name: fmt.Sprintf("v4.0.%d", i)}
+		t2.Commit.SHA = fmt.Sprintf("bulksha%03d", i)
+		exhaustiveTags[i] = t2
+	}
+	exhaustiveTags[42].Commit.SHA = headSHA
+	exhaustiveTags[42].Name = "v4.0.42-target"
+
+	tagCreated := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
-			// Simulate a transient tag-lookup error to trigger releasingErrorOrFail.
-			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = w.Write([]byte(`{"message":"server error"}`))
+			if r.URL.Query().Get("per_page") == "100" {
+				// GetTagForSHA exhaustive path — headSHA is here.
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(exhaustiveTags)
+			} else {
+				// tagCoveringCommit bounded window — does NOT contain headSHA.
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(coveringTags)
+			}
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
+			tagCreated = true
+			w.WriteHeader(http.StatusCreated)
 		default:
 			w.WriteHeader(http.StatusOK)
 		}
@@ -437,26 +322,172 @@ func TestHandleReleasing_DurationCapStageFailed(t *testing.T) {
 	defer server.Close()
 
 	c := newReleasingController(t, server.URL)
-	prState := &PRState{
-		PRNumber: 600,
-		HeadSHA:  "durshatagsig",
-		Stage:    StageReleasing,
-		// Attempt count is low but duration exceeds maxReleasingDuration.
-		ReleasingAttempts: 2,
-		ReleasingFirstAt:  time.Now().Add(-(maxReleasingDuration + time.Second)),
-	}
+	prState := &PRState{PRNumber: 300, HeadSHA: headSHA, Stage: StageReleasing}
 	c.mu.Lock()
-	c.activePRs[600] = prState
+	c.activePRs[300] = prState
 	c.mu.Unlock()
 
 	err := c.handleReleasing(context.Background(), prState)
 	if err != nil {
-		t.Fatalf("expected nil on duration cap escalation, got: %v", err)
+		t.Fatalf("handleReleasing returned unexpected error: %v", err)
+	}
+	if tagCreated {
+		t.Error("CreateGitTag must NOT be called — SHA was already tagged (beyond position 10)")
+	}
+	c.mu.RLock()
+	_, stillTracked := c.activePRs[300]
+	c.mu.RUnlock()
+	if stillTracked {
+		t.Error("PR must be drained once SHA is found in exhaustive tag lookup")
+	}
+}
+
+// TestHandleReleasing_RetryCapEscalates verifies that when handleReleasing fails
+// persistently and ReleasingAttempts reaches MaxReleasingAttempts, the PR transitions
+// to StageFailed (never retried) instead of returning an error for the next poll.
+func TestHandleReleasing_RetryCapEscalates(t *testing.T) {
+	issueCommentPosted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+			// Persistent API failure on every tag lookup.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"server error"}`))
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/issues/") && strings.HasSuffix(r.URL.Path, "/comments"):
+			issueCommentPosted = true
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.PRComment{ID: 1})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.MaxReleasingAttempts = 3
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", TagPrefix: "v"}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	prState := &PRState{
+		PRNumber:    400,
+		HeadSHA:     "sha400",
+		IssueNumber: 40,
+		Stage:       StageReleasing,
+		// Pre-set to 2; next call increments to 3 == cap.
+		ReleasingAttempts: 2,
+	}
+	c.mu.Lock()
+	c.activePRs[400] = prState
+	c.mu.Unlock()
+
+	err := c.handleReleasing(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("at cap, handleReleasing must return nil (not error), got: %v", err)
 	}
 	if prState.Stage != StageFailed {
-		t.Errorf("expected StageFailed after duration cap, got %q", prState.Stage)
+		t.Errorf("Stage = %s, want StageFailed after retry cap", prState.Stage)
 	}
-	if prState.Error == "" {
-		t.Error("expected non-empty Error on StageFailed transition")
+	if prState.ReleasingAttempts != 3 {
+		t.Errorf("ReleasingAttempts = %d, want 3", prState.ReleasingAttempts)
+	}
+	if !issueCommentPosted {
+		t.Error("escalation comment must be posted on the linked issue")
+	}
+}
+
+// TestHandleReleasing_RetryCapBelowCapReturnsError verifies that a failure when
+// ReleasingAttempts is still below MaxReleasingAttempts returns a retryable error
+// rather than escalating to StageFailed.
+func TestHandleReleasing_RetryCapBelowCapReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags") {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"server error"}`))
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.MaxReleasingAttempts = 5
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", TagPrefix: "v"}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	prState := &PRState{
+		PRNumber:          401,
+		HeadSHA:           "sha401",
+		Stage:             StageReleasing,
+		ReleasingAttempts: 1, // incremented to 2, below cap of 5
+	}
+	c.mu.Lock()
+	c.activePRs[401] = prState
+	c.mu.Unlock()
+
+	err := c.handleReleasing(context.Background(), prState)
+	if err == nil {
+		t.Fatal("below-cap failure must return a retryable error, got nil")
+	}
+	if prState.Stage == StageFailed {
+		t.Error("Stage must remain StageReleasing (retryable), not StageFailed")
+	}
+}
+
+// TestHandleReleasing_DivergedSHARefused verifies that a PR whose HeadSHA is not
+// reachable from the default branch is immediately escalated to StageFailed without
+// creating a release tag.
+func TestHandleReleasing_DivergedSHARefused(t *testing.T) {
+	tests := []struct {
+		name          string
+		compareStatus string
+	}{
+		{name: "diverged", compareStatus: "diverged"},
+		{name: "behind", compareStatus: "behind"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tagCreated := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`[]`))
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/branches/"):
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"name":   "main",
+						"commit": map[string]string{"sha": "mainsha500"},
+					})
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(map[string]string{"status": tt.compareStatus})
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
+					tagCreated = true
+					w.WriteHeader(http.StatusCreated)
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			c := newReleasingController(t, server.URL)
+			prState := &PRState{PRNumber: 500, HeadSHA: "divergedsha", Stage: StageReleasing}
+			c.mu.Lock()
+			c.activePRs[500] = prState
+			c.mu.Unlock()
+
+			err := c.handleReleasing(context.Background(), prState)
+			if err != nil {
+				t.Fatalf("diverged SHA must return nil (StageFailed not retryable error), got: %v", err)
+			}
+			if tagCreated {
+				t.Error("CreateGitTag must NOT be called for a diverged SHA")
+			}
+			if prState.Stage != StageFailed {
+				t.Errorf("Stage = %s, want StageFailed for unreachable SHA", prState.Stage)
+			}
+		})
 	}
 }

--- a/internal/autopilot/controller_releasing_test.go
+++ b/internal/autopilot/controller_releasing_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/testutil"
@@ -165,6 +166,171 @@ func tagAt(name, sha string) github.Tag {
 	return tag
 }
 
+// TestHandleReleasing_AlreadyPublishedReleaseDrains verifies that when a published
+// GitHub Release already exists for HeadSHA, handleReleasing drains the PR without
+// creating a new tag. This is the fast-path "existing published release" drain. (GH-3558)
+func TestHandleReleasing_AlreadyPublishedReleaseDrains(t *testing.T) {
+	const headSHA = "mergecommitabc"
+	const tagName = "v3.1.0"
+	tagCreateCalled := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/"):
+			// Return a merged PR with MergeCommitSHA == headSHA.
+			_ = json.NewEncoder(w).Encode(github.PullRequest{
+				Number:         300,
+				MergeCommitSHA: headSHA,
+				Merged:         true,
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+			// GetTagForSHA exhaustive search finds the tag.
+			tags := []github.Tag{tagAt(tagName, headSHA)}
+			_ = json.NewEncoder(w).Encode(tags)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
+			// A published release already exists for this tag.
+			_ = json.NewEncoder(w).Encode(github.Release{
+				ID:      12345,
+				TagName: tagName,
+				Draft:   false,
+				HTMLURL: "https://github.com/owner/repo/releases/tag/" + tagName,
+			})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
+			tagCreateCalled = true
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := newReleasingController(t, server.URL)
+	prState := &PRState{PRNumber: 300, HeadSHA: headSHA, Stage: StageReleasing}
+	c.mu.Lock()
+	c.activePRs[300] = prState
+	c.mu.Unlock()
+
+	err := c.handleReleasing(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("expected nil error when published release exists, got: %v", err)
+	}
+	if tagCreateCalled {
+		t.Error("CreateGitTag must NOT be called when a published release already exists")
+	}
+	c.mu.RLock()
+	_, stillTracked := c.activePRs[300]
+	c.mu.RUnlock()
+	if stillTracked {
+		t.Error("PR must be drained when published release exists")
+	}
+}
+
+// TestHandleReleasing_RetryCapEscalatesStageFailed verifies that once
+// ReleasingAttempts reaches maxReleasingAttempts, a transient tag-lookup error
+// causes StageFailed (not another retry). (GH-3558)
+func TestHandleReleasing_RetryCapEscalatesStageFailed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/"):
+			// Return a merged PR with MergeCommitSHA so HeadSHA refresh succeeds.
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(github.PullRequest{
+				Number:         301,
+				MergeCommitSHA: "sha301",
+				Merged:         true,
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+			// Simulate a persistent transient failure on tag lookup.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"server error"}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := newReleasingController(t, server.URL)
+	prState := &PRState{
+		PRNumber:          301,
+		HeadSHA:           "sha301",
+		Stage:             StageReleasing,
+		ReleasingAttempts: maxReleasingAttempts - 1, // one more attempt will hit the cap
+	}
+	c.mu.Lock()
+	c.activePRs[301] = prState
+	c.mu.Unlock()
+
+	err := c.handleReleasing(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("expected nil error on cap escalation, got: %v", err)
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("stage = %v, want StageFailed", prState.Stage)
+	}
+	if prState.Error == "" {
+		t.Error("prState.Error must be set on StageFailed escalation")
+	}
+	// StageFailed keeps the PR in activePRs (terminal but visible for observability),
+	// consistent with how handleMerging handles its attempt cap.
+	c.mu.RLock()
+	tracked, ok := c.activePRs[301]
+	c.mu.RUnlock()
+	if !ok || tracked == nil {
+		t.Error("PR should remain in activePRs (in StageFailed state) for observability")
+	}
+}
+
+// TestHandleReleasing_DivergedSHARefused verifies that a HeadSHA which is not
+// reachable from the default branch (compare status "diverged") causes StageFailed
+// rather than tagging a commit that was never actually merged. (GH-3558)
+func TestHandleReleasing_DivergedSHARefused(t *testing.T) {
+	const mergeCommit = "divergedcommit"
+	tagCreateCalled := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/"):
+			_ = json.NewEncoder(w).Encode(github.PullRequest{
+				Number:         302,
+				MergeCommitSHA: mergeCommit,
+				Merged:         true,
+			})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+			// No existing tag for this SHA.
+			_ = json.NewEncoder(w).Encode([]github.Tag{})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+			// The compare of mergeCommit against the default branch returns "diverged"
+			// — the commit is not on the default branch.
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "diverged"})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
+			tagCreateCalled = true
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := newReleasingController(t, server.URL)
+	prState := &PRState{PRNumber: 302, HeadSHA: "original-head", Stage: StageReleasing}
+	c.mu.Lock()
+	c.activePRs[302] = prState
+	c.mu.Unlock()
+
+	err := c.handleReleasing(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("expected nil error on reachability failure, got: %v", err)
+	}
+	if tagCreateCalled {
+		t.Error("CreateGitTag must NOT be called for an unreachable SHA")
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("stage = %v, want StageFailed", prState.Stage)
+	}
+}
+
 // TestHandleReleasing_AncestorTagDedup verifies handleReleasing treats a PR
 // whose HeadSHA is already covered by an existing tag — tagged exactly, or an
 // ANCESTOR of a tag's commit — as already released: the PR drains from
@@ -249,5 +415,48 @@ func TestHandleReleasing_AncestorTagDedup(t *testing.T) {
 				t.Errorf("PR tracked = %v, want %v", tracked, tt.wantTracked)
 			}
 		})
+	}
+}
+
+// TestHandleReleasing_DurationCapStageFailed verifies that a PR stuck in
+// StageReleasing longer than maxReleasingDuration escalates to StageFailed via
+// releasingErrorOrFail even if the attempt count is below maxReleasingAttempts.
+// This guards the daemon-restart scenario where the attempt counter resets but the
+// underlying API failure persists. GH-3558.
+func TestHandleReleasing_DurationCapStageFailed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+			// Simulate a transient tag-lookup error to trigger releasingErrorOrFail.
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"server error"}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := newReleasingController(t, server.URL)
+	prState := &PRState{
+		PRNumber: 600,
+		HeadSHA:  "durshatagsig",
+		Stage:    StageReleasing,
+		// Attempt count is low but duration exceeds maxReleasingDuration.
+		ReleasingAttempts: 2,
+		ReleasingFirstAt:  time.Now().Add(-(maxReleasingDuration + time.Second)),
+	}
+	c.mu.Lock()
+	c.activePRs[600] = prState
+	c.mu.Unlock()
+
+	err := c.handleReleasing(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("expected nil on duration cap escalation, got: %v", err)
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("expected StageFailed after duration cap, got %q", prState.Stage)
+	}
+	if prState.Error == "" {
+		t.Error("expected non-empty Error on StageFailed transition")
 	}
 }

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -152,6 +152,11 @@ type Config struct {
 	// (MaxFailures) provides transient backoff; this cap makes persistent failures
 	// terminal so they don't loop indefinitely. Default: 5.
 	MaxMergeAttempts int `yaml:"max_merge_attempts"`
+	// MaxReleasingAttempts is the hard cap on handleReleasing retries before the PR
+	// is transitioned to StageFailed. Prevents a release that can never succeed (e.g.
+	// persistent GitHub API errors or a tag creation race) from looping indefinitely.
+	// Default: 10.
+	MaxReleasingAttempts int `yaml:"max_releasing_attempts"`
 	// ApprovalTimeout is how long to wait for human approval in prod.
 	ApprovalTimeout time.Duration `yaml:"approval_timeout"`
 
@@ -326,6 +331,7 @@ func DefaultConfig() *Config {
 		FailureResetTimeout: 30 * time.Minute,
 		MaxMergesPerHour:    10,
 		MaxMergeAttempts:    5,
+		MaxReleasingAttempts: 10,
 		ApprovalTimeout:     1 * time.Hour,
 		Release:             nil, // Disabled by default
 		MergedPRScanWindow:  30 * time.Minute,
@@ -520,11 +526,10 @@ type PRState struct {
 	PostMergeSHA string
 	// PostMergeCIStartedAt is when StagePostMergeCI monitoring began (for timeout tracking).
 	PostMergeCIStartedAt time.Time
-	// ReleasingAttempts counts how many times handleReleasing has been invoked for this PR.
-	// Used for a bounded retry cap so StageReleasing never loops indefinitely. (GH-3558)
+	// ReleasingAttempts counts how many times handleReleasing has been called for this PR.
+	// Used to cap retries before escalating to StageFailed.
 	ReleasingAttempts int
-	// ReleasingFirstAt is when the first release attempt started. Used with maxReleasingDuration
-	// for a wall-clock cap on StageReleasing. (GH-3558)
+	// ReleasingFirstAt is when StageReleasing was first attempted. Set on the first call.
 	ReleasingFirstAt time.Time
 }
 

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -520,6 +520,12 @@ type PRState struct {
 	PostMergeSHA string
 	// PostMergeCIStartedAt is when StagePostMergeCI monitoring began (for timeout tracking).
 	PostMergeCIStartedAt time.Time
+	// ReleasingAttempts counts how many times handleReleasing has been invoked for this PR.
+	// Used for a bounded retry cap so StageReleasing never loops indefinitely. (GH-3558)
+	ReleasingAttempts int
+	// ReleasingFirstAt is when the first release attempt started. Used with maxReleasingDuration
+	// for a wall-clock cap on StageReleasing. (GH-3558)
+	ReleasingFirstAt time.Time
 }
 
 // snapshot returns a detached, field-by-field copy of the PRState with a fresh
@@ -555,6 +561,8 @@ func (ps *PRState) snapshot() *PRState {
 		ApprovalRequestedAt:     ps.ApprovalRequestedAt,
 		PostMergeSHA:            ps.PostMergeSHA,
 		PostMergeCIStartedAt:    ps.PostMergeCIStartedAt,
+		ReleasingAttempts:       ps.ReleasingAttempts,
+		ReleasingFirstAt:        ps.ReleasingFirstAt,
 	}
 	// DiscoveredChecks is a slice — copy the backing array so consumers can't
 	// mutate the live PR's slice through the snapshot.


### PR DESCRIPTION
## Summary

- **Retry cap**: `handleReleasing` now tracks `ReleasingAttempts` on `PRState` and escalates to `StageFailed` (+ issue comment) after 20 attempts via `releasingErrorOrFail`, preventing infinite `StageReleasing` loops on transient API failures. Preserves existing TASK-316 duplicate-tag-as-success guards.
- **Published-release fast-path drain**: At entry, refreshes `HeadSHA` to `MergeCommitSHA` via `GetPullRequest` (fixes squash-merge tagging of the wrong commit), then calls `GetTagForSHA` + `GetReleaseByTag`; drains immediately if a non-draft published release already exists.
- **Reachability guard**: After `HeadSHA` refresh, `CompareStatus(HeadSHA, defaultBranch)` refuses to tag commits not reachable from the default branch (`"behind"` / `"diverged"`) → `StageFailed` + issue comment. Skipped when the PR fetch fails to avoid false positives.
- **`GetTagForSHA` exhaustive pagination**: Replaced the fixed 20-tag `ListTags` window with 100-per-page pagination; repos with more than 20 tags no longer silently return "not found".

## Test plan

- [ ] `go test ./internal/autopilot/...` — all pass including 3 new tests: `AlreadyPublishedReleaseDrains`, `RetryCapEscalatesStageFailed`, `DivergedSHARefused`
- [ ] `go test ./internal/adapters/github/...` — all pass including 3 new tests: `OldTagBeyond20`, `NotFound`, `PaginatesUntilFound`
- [ ] `make lint` — 0 issues
- [ ] `make build` — clean