### PR TITLE
fix(autopilot): decomposition integrity wave 2 — verified closes, evidence-based supersession, junk-child guards

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -95,6 +95,22 @@ func issueHasOpenPR(ctx context.Context, client *github.Client, owner, repo stri
 	return false
 }
 
+// issueHasOpenChildren reports whether the issue is a decomposed parent with
+// open sub-issues, using the same two-tier strategy as the autopilot's
+// count-verified close path: native sub-issue links first, text search for
+// "Parent: GH-N" bodies as fallback/cross-check. A native count of 0 is never
+// trusted alone (LinkSubIssue is non-fatal, so native links can cover only a
+// subset of children — the GH-3513 incident). Fail-open returns false so leaf
+// issues keep their existing treatment on transient API errors. Read-only.
+func issueHasOpenChildren(ctx context.Context, client *github.Client, owner, repo string, issueNumber int) bool {
+	native, hasNativeLinks, err := client.GetOpenSubIssueCount(ctx, owner, repo, issueNumber)
+	if err == nil && hasNativeLinks && native > 0 {
+		return true
+	}
+	text, terr := client.SearchOpenSubIssues(ctx, owner, repo, issueNumber)
+	return terr == nil && text > 0
+}
+
 // requestReviewersFromConfig looks up the project config for the given sourceRepo
 // and requests PR reviewers if configured. Errors are logged but not propagated.
 func requestReviewersFromConfig(ctx context.Context, cfg *config.Config, client *github.Client, sourceRepo, owner, repo string, prNumber int) {
@@ -370,6 +386,20 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 			logGitHubAPIError("RemoveLabel", parts[0], parts[1], issue.Number, err)
 		}
 
+		// GH-3513 wave 2: a re-dispatch of an already-completed parent hits the
+		// ErrParentDone guard. That is a benign skip, not a failure — the parent
+		// is already closed + pilot-done. Stacking pilot-failed on top (and
+		// posting a ❌ comment) produced contradictory issue states on #3513 and
+		// #3546. Success=true so the poller marks it processed instead of
+		// re-dispatch-looping.
+		if (execErr != nil && executor.IsParentDoneSkip(execErr.Error())) ||
+			(hr.Result != nil && executor.IsParentDoneSkip(hr.Result.Error)) {
+			slog.Info("re-dispatch of completed parent hit ErrParentDone — benign skip, no labels/comments",
+				slog.Int("issue", issue.Number))
+			issueResult.Success = true
+			return issueResult, nil
+		}
+
 		// GH-1853: Resolve board statuses once for all paths (nil-safe via GetStatuses)
 		boardStatuses := cfg.Adapters.GitHub.ProjectBoard.GetStatuses()
 
@@ -458,6 +488,20 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				comment := fmt.Sprintf("🤔 **Pilot needs clarification before implementing this task**\n\n**Reason**: %s\n\nTo resume, clarify the requirements and remove the `%s` label.", reason, github.LabelNeedsClarification)
 				if _, err := client.AddComment(ctx, parts[0], parts[1], issue.Number, comment); err != nil {
 					logGitHubAPIError("AddComment(declined)", parts[0], parts[1], issue.Number, err)
+				}
+			} else if hr.Result.Error != "" && strings.Contains(hr.Result.Error, noOpErrorMarker) &&
+				issueHasOpenChildren(ctx, client, parts[0], parts[1], issue.Number) {
+				// GH-3513 wave 2: a no-op on a DECOMPOSED PARENT with open children
+				// must not be classified by the already-merged branch below — the
+				// parent's own epic PR (or a child's PR matching the search) makes
+				// issueAlreadyMerged true while sibling slices are still unshipped,
+				// which closed parents prematurely. Leave the parent open; the
+				// autopilot's count-verified path closes it when the last child
+				// ships. No labels, no comment (re-dispatches can repeat).
+				slog.Info("no-op re-dispatch of decomposed parent with open children — deferring close to count-verified path",
+					slog.Int("issue", issue.Number))
+				if err := client.RemoveLabel(ctx, parts[0], parts[1], issue.Number, github.LabelBlocked); err != nil {
+					slog.Debug("pilot-blocked cleanup (open-children)", "issue", issue.Number, "error", err)
 				}
 			} else if hr.Result.Error != "" && strings.Contains(hr.Result.Error, noOpErrorMarker) &&
 				issueAlreadyMerged(ctx, client, parts[0], parts[1], issue.Number) {

--- a/cmd/pilot/handlers_already_merged_test.go
+++ b/cmd/pilot/handlers_already_merged_test.go
@@ -70,3 +70,65 @@ func TestIssueAlreadyMerged(t *testing.T) {
 		})
 	}
 }
+
+// GH-3513 wave 2: issueHasOpenChildren gates the already-merged close path —
+// a decomposed parent with open children must not be closed by a no-op
+// re-dispatch even when a merged PR matches the search.
+func TestIssueHasOpenChildren(t *testing.T) {
+	tests := []struct {
+		name      string
+		graphql   string // /graphql response (GetOpenSubIssueCount)
+		textCount string // /search/issues response (SearchOpenSubIssues)
+		want      bool
+	}{
+		{
+			name:      "native links report open children",
+			graphql:   `{"data":{"node":{"subIssues":{"totalCount":2,"nodes":[{"state":"OPEN"},{"state":"CLOSED"}]}}}}`,
+			textCount: `{"total_count":0}`,
+			want:      true,
+		},
+		{
+			name:      "native 0 but text search finds unlinked open children",
+			graphql:   `{"data":{"node":{"subIssues":{"totalCount":1,"nodes":[{"state":"CLOSED"}]}}}}`,
+			textCount: `{"total_count":1}`,
+			want:      true,
+		},
+		{
+			name:      "no children anywhere",
+			graphql:   `{"data":{"node":{"subIssues":{"totalCount":0,"nodes":[]}}}}`,
+			textCount: `{"total_count":0}`,
+			want:      false,
+		},
+		{
+			name:      "both lookups fail — fail open (leaf treatment)",
+			graphql:   `not json`,
+			textCount: `not json`,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.URL.Path == "/graphql":
+					_, _ = w.Write([]byte(tt.graphql))
+				case strings.HasPrefix(r.URL.Path, "/search/issues"):
+					_, _ = w.Write([]byte(tt.textCount))
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/"):
+					_, _ = w.Write([]byte(`{"node_id":"node_77","number":77}`))
+				default:
+					http.Error(w, "unexpected path: "+r.URL.Path, http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			client := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			got := issueHasOpenChildren(context.Background(), client, "owner", "repo", 77)
+			if got != tt.want {
+				t.Errorf("issueHasOpenChildren() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -2051,6 +2051,37 @@ func (p *Poller) skipSupersededByParent(ctx context.Context, issue *Issue) bool 
 		return false
 	}
 
+	// GH-3513 wave 2 (#3537): the open-PR veto above cannot protect a child
+	// that has not created its PR yet. Require POSITIVE evidence this child's
+	// own slice shipped — a merged PR on its branch or a completed execution
+	// row — before discarding it. A prematurely-closed parent must never
+	// cascade into closing children whose work never landed. Fail open on
+	// lookup errors (dispatch rather than lose work).
+	merged, merr := p.client.FindMergedPRByBranch(ctx, p.owner, p.repo, branch)
+	if merr != nil {
+		p.logger.Warn("Failed to check for merged PR before superseding, falling through to normal dispatch",
+			slog.Int("issue", issue.Number),
+			slog.String("branch", branch),
+			slog.Any("error", merr),
+		)
+		return false
+	}
+	completed := false
+	if !merged && p.execChecker != nil {
+		taskID := fmt.Sprintf("GH-%d", issue.Number)
+		if c, cerr := p.execChecker.HasCompletedExecution(taskID, p.projectPath); cerr == nil {
+			completed = c
+		}
+	}
+	if !merged && !completed {
+		p.logger.Info("Not superseding sub-issue: parent is done but child has no evidence of shipped work — dispatching",
+			slog.Int("issue", issue.Number),
+			slog.Int("parent", parentNum),
+			slog.String("branch", branch),
+		)
+		return false
+	}
+
 	p.logger.Info("Auto-closing sub-issue: parent epic already shipped",
 		slog.Int("issue", issue.Number),
 		slog.Int("parent", parentNum),

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2925,6 +2925,16 @@ func TestPoller_CheckForNewIssues_SkipsSupersededByParent(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(parent)
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/200":
 			_ = json.NewEncoder(w).Encode(subIssue)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/pulls" &&
+			r.URL.Query().Get("state") == "closed":
+			// Wave 2: supersession now requires positive evidence the child's own
+			// slice shipped — give it a merged PR on pilot/GH-200.
+			_ = json.NewEncoder(w).Encode([]*PullRequest{{
+				Number: 900,
+				State:  "closed",
+				Merged: true,
+				Head:   PRRef{Ref: "pilot/GH-200"},
+			}})
 		case r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/issues/200/comments":
 			var payload struct {
 				Body string `json:"body"`
@@ -3417,5 +3427,150 @@ func TestPoller_MergeDoneWindow_MarkProcessedAfterGrace(t *testing.T) {
 
 	if got := callCount.Load(); got != 0 {
 		t.Errorf("dispatch callback called %d times, want 0 — MarkProcessed should prevent re-dispatch in merge→done window", got)
+	}
+}
+
+// GH-3513 wave 2 (#3537): a child with NO PR and NO completed execution must
+// not be superseded even when the parent is closed + pilot-done — the parent
+// close may be premature and the child's slice never shipped. It must fall
+// through to normal dispatch.
+func TestPoller_CheckForNewIssues_DoesNotSupersedeChildWithoutShippedEvidence(t *testing.T) {
+	subIssue := &Issue{
+		Number: 203,
+		Title:  "Sub-issue with no PR yet",
+		Body:   "Parent: GH-103\n\nUnshipped slice.",
+		State:  "open",
+		Labels: []Label{{Name: "pilot"}},
+	}
+	parent := &Issue{
+		Number: 103,
+		Title:  "Epic",
+		State:  "closed",
+		Labels: []Label{{Name: "pilot"}, {Name: LabelDone}},
+	}
+
+	var (
+		dispatches  int32
+		closedIssue int32
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode([]*Issue{subIssue})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/103":
+			_ = json.NewEncoder(w).Encode(parent)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/203":
+			_ = json.NewEncoder(w).Encode(subIssue)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/pulls":
+			// No PRs on the child's branch — open or merged.
+			_ = json.NewEncoder(w).Encode([]*PullRequest{})
+		case r.Method == http.MethodPatch && r.URL.Path == "/repos/owner/repo/issues/203":
+			atomic.AddInt32(&closedIssue, 1)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&dispatches, 1)
+			return nil
+		}),
+	)
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&closedIssue); got != 0 {
+		t.Errorf("sub-issue closed %d times, want 0 (no shipped evidence — must not supersede)", got)
+	}
+	if got := atomic.LoadInt32(&dispatches); got != 1 {
+		t.Errorf("dispatched %d times, want 1 (child must dispatch when its slice never shipped)", got)
+	}
+}
+
+// GH-3513 wave 2: a completed execution row is valid evidence the child's
+// slice shipped — supersession may proceed.
+func TestPoller_CheckForNewIssues_SupersedesChildWithCompletedExecution(t *testing.T) {
+	subIssue := &Issue{
+		Number: 204,
+		Title:  "Sub-issue shipped via execution row",
+		Body:   "Parent: GH-104\n\nShipped slice.",
+		State:  "open",
+		Labels: []Label{{Name: "pilot"}},
+	}
+	parent := &Issue{
+		Number: 104,
+		Title:  "Epic",
+		State:  "closed",
+		Labels: []Label{{Name: "pilot"}, {Name: LabelDone}},
+	}
+
+	var (
+		dispatches  int32
+		closedIssue int32
+		gotLabelsMu sync.Mutex
+		gotLabels   []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode([]*Issue{subIssue})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/104":
+			_ = json.NewEncoder(w).Encode(parent)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/204":
+			_ = json.NewEncoder(w).Encode(subIssue)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/pulls":
+			_ = json.NewEncoder(w).Encode([]*PullRequest{}) // no PRs at all
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/issues/204/labels":
+			var payload struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			gotLabelsMu.Lock()
+			gotLabels = append(gotLabels, payload.Labels...)
+			gotLabelsMu.Unlock()
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPatch && r.URL.Path == "/repos/owner/repo/issues/204":
+			atomic.AddInt32(&closedIssue, 1)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	checker := &mockExecutionChecker{completed: map[string]bool{"GH-204:/proj/p": true}}
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithExecutionChecker(checker, "/proj/p"),
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&dispatches, 1)
+			return nil
+		}),
+	)
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&closedIssue); got != 1 {
+		t.Errorf("sub-issue closed %d times, want 1 (completed execution = shipped evidence)", got)
+	}
+	if got := atomic.LoadInt32(&dispatches); got != 0 {
+		t.Errorf("dispatched %d times, want 0 (superseded)", got)
+	}
+	gotLabelsMu.Lock()
+	defer gotLabelsMu.Unlock()
+	found := false
+	for _, l := range gotLabels {
+		if l == LabelSuperseded {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected pilot-superseded label, got %v", gotLabels)
 	}
 }

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -271,7 +271,23 @@ func (c *Controller) selfHealForPR(ctx context.Context, issueNum int, prURL stri
 	c.selfHealTask(fmt.Sprintf("GH-%d", issueNum), prURL)
 	// Pilot decomposes a parent issue into sub-issues; only the sub-issue's PR
 	// merges, so the parent's no-op "failed" row would never heal otherwise.
+	// GH-3513/GH-3530: heal the parent ONLY once all its children are closed —
+	// healing on the first child's merge stamped that child's PR URL on the
+	// parent's row and marked it "completed", which woke a hung WaitForExecution
+	// with a false success and fed HasCompletedExecution dispatch-skips while
+	// sibling slices were still unshipped.
 	if parent := c.resolveParentIssue(ctx, issueNum); parent != 0 && parent != issueNum {
+		open, err := c.openSubIssueCount(ctx, parent)
+		if err != nil {
+			c.log.Warn("selfHealForPR: sub-issue count failed — not healing parent row",
+				"parent", parent, "child", issueNum, "error", err)
+			return
+		}
+		if open > 0 {
+			c.log.Info("selfHealForPR: parent has open children — not healing parent row",
+				"parent", parent, "child", issueNum, "open", open)
+			return
+		}
 		c.selfHealTask(fmt.Sprintf("GH-%d", parent), prURL)
 	}
 }
@@ -1349,6 +1365,28 @@ func (c *Controller) SetApprovalDecision(ctx context.Context, requestID string, 
 }
 
 // handleMerging merges the PR.
+// shouldDeferIssueClose reports whether the merged PR's issue is a decomposed
+// parent that still has open children. GH-3513/GH-3530 incidents: a child's PR
+// mis-registered under the parent's issue number made handleMerging close the
+// parent + pilot-done while siblings were open and unshipped. Decomposed
+// parents must only be closed by the count-verified path (maybeCloseParentIssue
+// / recoverStaleParentIssues). Fail-open on count errors so leaf issues keep
+// closing on transient API failures.
+func (c *Controller) shouldDeferIssueClose(ctx context.Context, issueNum, prNum int) bool {
+	open, err := c.openSubIssueCount(ctx, issueNum)
+	if err != nil {
+		c.log.Warn("shouldDeferIssueClose: sub-issue count failed — proceeding with close",
+			"issue", issueNum, "pr", prNum, "error", err)
+		return false
+	}
+	if open > 0 {
+		c.log.Info("handleMerging: issue is a decomposed parent with open children — deferring close to count-verified path",
+			"issue", issueNum, "open", open, "pr", prNum)
+		return true
+	}
+	return false
+}
+
 func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error {
 	prState.MergeAttempts++
 
@@ -1411,7 +1449,7 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 
 	// GH-1015: Add pilot-done label after successful merge (not at PR creation)
 	// This prevents false positives where PRs are closed without merging
-	if prState.IssueNumber > 0 {
+	if prState.IssueNumber > 0 && !c.shouldDeferIssueClose(ctx, prState.IssueNumber, prState.PRNumber) {
 		// GH-3271: mark issue processed in all pollers before any label updates so
 		// a poll tick that fires during the merge→pilot-done propagation window
 		// cannot re-dispatch the issue (phantom pilot-blocked).

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -578,6 +578,19 @@ func TestController_ScanRecentlyMergedPRs_SelfHeals(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(github.Issue{
 				Body: "<!--autopilot-meta\nparent: GH-3344\n-->\n\nParent: GH-3344\n\nwork",
 			})
+		case r.URL.Path == "/repos/owner/repo/issues/3344":
+			// GetIssueNodeID lookup for the parent's open-children gate (wave 2).
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"node_id":"node_3344","number":3344}`))
+		case r.URL.Path == "/graphql" && r.Method == http.MethodPost:
+			// openSubIssueCount: the only child (GH-3353) is closed → open count 0,
+			// so the parent heal is allowed (preserves the TASK-352 scenario).
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"node":{"subIssues":{"totalCount":1,"nodes":[{"state":"CLOSED"}]}}}}`))
+		case r.URL.Path == "/search/issues":
+			// Wave-1 cross-check: native 0 must be confirmed by text search.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"total_count":0}`))
 		default:
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("[]"))
@@ -7277,5 +7290,155 @@ func TestHandleCIPassed_SmallInScopePRMerges(t *testing.T) {
 	}
 	if prState.Stage != StageMerging {
 		t.Errorf("expected StageMerging for small in-scope PR, got %v", prState.Stage)
+	}
+}
+
+// GH-3513 wave 2: a merged PR registered under a DECOMPOSED PARENT's issue
+// number must not close the parent while children are open — only the
+// count-verified path may close decomposed parents.
+func TestShouldDeferIssueClose(t *testing.T) {
+	tests := []struct {
+		name      string
+		graphqlOK bool   // false → GraphQL count errors
+		openSubs  int    // open children from native links (totalCount = openSubs+1)
+		textCount string // /search/issues total_count JSON
+		want      bool
+	}{
+		{name: "open children defer the close", graphqlOK: true, openSubs: 2, want: true},
+		{name: "leaf issue (no children) closes", graphqlOK: true, openSubs: 0, textCount: `{"total_count":0}`, want: false},
+		{name: "native 0 but text search finds unlinked open children", graphqlOK: true, openSubs: 0, textCount: `{"total_count":1}`, want: true},
+		{name: "count error fails open (close proceeds)", graphqlOK: false, textCount: `bad`, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.URL.Path == "/graphql" && r.Method == http.MethodPost:
+					if !tt.graphqlOK {
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte(`{"errors":[{"message":"boom"}]}`))
+						return
+					}
+					states := make([]map[string]string, tt.openSubs)
+					for i := range states {
+						states[i] = map[string]string{"state": "OPEN"}
+					}
+					resp := map[string]interface{}{
+						"data": map[string]interface{}{
+							"node": map[string]interface{}{
+								"subIssues": map[string]interface{}{
+									"totalCount": tt.openSubs + 1,
+									"nodes":      states,
+								},
+							},
+						},
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+				case r.URL.Path == "/search/issues":
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(tt.textCount))
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/"):
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"node_id":"node_77","number":77}`))
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+			if got := c.shouldDeferIssueClose(context.Background(), 77, 42); got != tt.want {
+				t.Errorf("shouldDeferIssueClose() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// GH-3513 wave 2: selfHealForPR must not promote a decomposed parent's
+// execution row (stamping a child's PR URL) while siblings are still open —
+// that false "completed" row woke hung handlers and fed dispatch-skips.
+func TestSelfHealForPR_ParentGate(t *testing.T) {
+	tests := []struct {
+		name       string
+		openSubs   int
+		graphqlOK  bool
+		searchJSON string
+		wantHealed []string
+	}{
+		{name: "open siblings: only the child heals", openSubs: 1, graphqlOK: true, searchJSON: `{"total_count":0}`, wantHealed: []string{"GH-50"}},
+		{name: "last child merged: parent heals too", openSubs: 0, graphqlOK: true, searchJSON: `{"total_count":0}`, wantHealed: []string{"GH-50", "GH-40"}},
+		{name: "count error: parent heal skipped (fail closed)", graphqlOK: false, searchJSON: `not json`, wantHealed: []string{"GH-50"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.URL.Path == "/repos/owner/repo/issues/50":
+					// Child body carries the parent reference.
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"number":50,"body":"Parent: GH-40\n\nwork","node_id":"node_50"}`))
+				case r.URL.Path == "/repos/owner/repo/issues/40":
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"number":40,"body":"epic","node_id":"node_40"}`))
+				case r.URL.Path == "/graphql" && r.Method == http.MethodPost:
+					if !tt.graphqlOK {
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte(`{"errors":[{"message":"boom"}]}`))
+						return
+					}
+					states := make([]map[string]string, tt.openSubs)
+					for i := range states {
+						states[i] = map[string]string{"state": "OPEN"}
+					}
+					resp := map[string]interface{}{
+						"data": map[string]interface{}{
+							"node": map[string]interface{}{
+								"subIssues": map[string]interface{}{
+									"totalCount": tt.openSubs + 1,
+									"nodes":      states,
+								},
+							},
+						},
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+				case r.URL.Path == "/search/issues":
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(tt.searchJSON))
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo", WithProjectPath("/proj/p"))
+			evalMock := &mockEvalStore{}
+			c.SetEvalStore(evalMock)
+
+			c.selfHealForPR(context.Background(), 50, "https://github.com/owner/repo/pull/9")
+
+			var got []string
+			for _, h := range evalMock.selfHealed {
+				got = append(got, h.TaskID)
+			}
+			if len(got) != len(tt.wantHealed) {
+				t.Fatalf("healed %v, want %v", got, tt.wantHealed)
+			}
+			for i := range got {
+				if got[i] != tt.wantHealed[i] {
+					t.Errorf("healed[%d] = %s, want %s", i, got[i], tt.wantHealed[i])
+				}
+			}
+		})
 	}
 }

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -496,9 +496,15 @@ func (d *Dispatcher) WaitForExecution(ctx context.Context, execID string, pollIn
 				return nil, fmt.Errorf("failed to get execution: %w", err)
 			}
 
-			// Check if terminal state
+			// Check if terminal state. The TASK-358 classified worker outcomes
+			// (no_op, declined, skipped, stalled, rate_limited, infra) are terminal
+			// too: treating them as in-flight left this loop hanging until something
+			// else mutated the row — in the GH-3513/GH-3530 incidents a child PR
+			// merge self-healed the PARENT's row to completed with the child's PR
+			// URL, and the woken handler reported a false "✅ Pilot completed!".
 			switch exec.Status {
-			case "completed", "failed", "cancelled":
+			case "completed", "failed", "cancelled",
+				"declined", "no_op", "rate_limited", "skipped", "stalled", "infra":
 				return exec, nil
 			}
 		}

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -961,3 +961,40 @@ func TestQueueTask_AfterRecovery(t *testing.T) {
 		t.Error("expected non-empty execution ID")
 	}
 }
+
+// GH-3513 wave 2: every TASK-358 classified worker outcome must be terminal for
+// WaitForExecution. Treating them as in-flight left the handler hanging until a
+// later self-heal mutated the row — in the GH-3530 incident a child PR merge
+// promoted the PARENT's row to completed with the child's PR URL, and the woken
+// handler reported a false "✅ Pilot completed!".
+func TestWaitForExecution_ClassifiedOutcomesAreTerminal(t *testing.T) {
+	statuses := []string{"completed", "failed", "cancelled", "declined", "no_op", "rate_limited", "skipped", "stalled", "infra"}
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	dispatcher := NewDispatcher(store, NewRunner(), nil)
+
+	for _, status := range statuses {
+		t.Run(status, func(t *testing.T) {
+			execID := "exec-" + status
+			if err := store.SaveExecution(&memory.Execution{
+				ID:          execID,
+				TaskID:      "GH-1",
+				ProjectPath: "/tmp/p",
+				Status:      status,
+			}); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			exec, err := dispatcher.WaitForExecution(ctx, execID, 10*time.Millisecond)
+			if err != nil {
+				t.Fatalf("WaitForExecution(%s) returned error (hang→timeout?): %v", status, err)
+			}
+			if exec.Status != status {
+				t.Errorf("WaitForExecution(%s) returned status %q", status, exec.Status)
+			}
+		})
+	}
+}

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -594,6 +594,16 @@ var ErrSubIssuesAlreadyExist = errors.New("open sub-issues already exist for thi
 // closed or skipped, so spawning sub-issues would be wasteful (GH-2867).
 var ErrParentDone = errors.New("parent task is already done; refusing to create sub-issues")
 
+// IsParentDoneSkip reports whether an execution error string stems from the
+// ErrParentDone guard. The error crosses process/DB boundaries as wrapped text
+// ("execution failed: failed to create sub-issues: ..."), so substring matching
+// is the only reliable detection. GH-3513 wave 2: callers treat this as a
+// benign skip — the parent is already closed + pilot-done — instead of a
+// failure that stacks pilot-failed on top.
+func IsParentDoneSkip(errStr string) bool {
+	return strings.Contains(errStr, ErrParentDone.Error())
+}
+
 // isParentDone reports whether a task should be treated as done based on its
 // labels (pilot-done, pilot-skip) or its state (closed, merged).
 //
@@ -1043,6 +1053,34 @@ func (r *Runner) CreateSubIssues(ctx context.Context, plan *EpicPlan, executionP
 			)
 			return nil, ErrSubIssuesAlreadyExist
 		}
+	}
+
+	// GH-3513 wave 2 (#3538/#3553): drop subtasks whose Description is empty —
+	// they produce junk sub-issues whose body is just the autopilot-meta marker
+	// and a scope fence wrapping nothing. Title validation already exists
+	// (validateSubtaskTitle); this is its Description counterpart, applied once
+	// here so both creator paths (adapter + gh CLI) are covered. Runs AFTER the
+	// dedup guard so recovery of already-created children is never blocked by
+	// plan quality. The plan is rebuilt rather than mutated so the caller's
+	// copy stays intact.
+	valid := make([]PlannedSubtask, 0, len(plan.Subtasks))
+	for _, st := range plan.Subtasks {
+		if strings.TrimSpace(st.Description) == "" {
+			parentID := ""
+			if plan.ParentTask != nil {
+				parentID = plan.ParentTask.ID
+			}
+			r.log.Warn("Skipping subtask with empty description",
+				"title", st.Title, "order", st.Order, "parent", parentID)
+			continue
+		}
+		valid = append(valid, st)
+	}
+	if len(valid) == 0 {
+		return nil, fmt.Errorf("decomposition produced %d subtasks but none had a description — refusing to create empty sub-issues", len(plan.Subtasks))
+	}
+	if len(valid) < len(plan.Subtasks) {
+		plan = &EpicPlan{ParentTask: plan.ParentTask, Subtasks: valid, TotalEffort: plan.TotalEffort, PlanOutput: plan.PlanOutput}
 	}
 
 	if useAdapterCreator {

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2696,3 +2696,139 @@ echo "https://github.com/owner/repo/issues/$N"
 		}
 	}
 }
+
+// GH-3513 wave 2 (#3538/#3553): subtasks with empty descriptions produce junk
+// sub-issues (body = meta marker + scope fence wrapping nothing) and must be
+// dropped at creation time.
+func TestCreateSubIssues_SkipsEmptyDescriptionSubtasks(t *testing.T) {
+	runner := NewRunner()
+	runner.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) { return false, nil }
+	mock := &mockSubIssueCreator{
+		Returns: []mockCreateIssueReturn{
+			{Identifier: "APP-101", URL: "https://linear.app/test/issue/APP-101"},
+			{Identifier: "APP-102", URL: "https://linear.app/test/issue/APP-102"},
+		},
+	}
+	runner.SetSubIssueCreator(mock)
+
+	plan := &EpicPlan{
+		ParentTask: &Task{ID: "APP-100", SourceAdapter: "linear", SourceIssueID: "APP-100"},
+		Subtasks: []PlannedSubtask{
+			{Title: "feat(linear): real slice one", Description: "Do first thing", Order: 1},
+			{Title: "feat(linear): hallucinated empty slice", Description: "   \n\t", Order: 2},
+			{Title: "feat(linear): real slice two", Description: "Do second thing", Order: 3},
+		},
+	}
+
+	created, err := runner.CreateSubIssues(context.Background(), plan, "")
+	if err != nil {
+		t.Fatalf("CreateSubIssues failed: %v", err)
+	}
+	if len(created) != 2 {
+		t.Fatalf("expected 2 created issues (empty-description subtask dropped), got %d", len(created))
+	}
+	if len(mock.Called) != 2 {
+		t.Fatalf("expected 2 creator calls, got %d", len(mock.Called))
+	}
+	for _, call := range mock.Called {
+		if strings.Contains(call.Title, "hallucinated") {
+			t.Errorf("empty-description subtask reached the creator: %q", call.Title)
+		}
+	}
+	// The caller's plan must not be mutated.
+	if len(plan.Subtasks) != 3 {
+		t.Errorf("caller's plan was mutated: %d subtasks, want 3", len(plan.Subtasks))
+	}
+}
+
+func TestCreateSubIssues_FailsWhenAllDescriptionsEmpty(t *testing.T) {
+	runner := NewRunner()
+	runner.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) { return false, nil }
+	mock := &mockSubIssueCreator{}
+	runner.SetSubIssueCreator(mock)
+
+	plan := &EpicPlan{
+		ParentTask: &Task{ID: "APP-100", SourceAdapter: "linear", SourceIssueID: "APP-100"},
+		Subtasks: []PlannedSubtask{
+			{Title: "feat(linear): empty one", Description: "", Order: 1},
+			{Title: "feat(linear): empty two", Description: "  ", Order: 2},
+		},
+	}
+
+	_, err := runner.CreateSubIssues(context.Background(), plan, "")
+	if err == nil {
+		t.Fatal("expected error when all subtask descriptions are empty")
+	}
+	if !strings.Contains(err.Error(), "refusing to create empty sub-issues") {
+		t.Errorf("error %q does not mention empty sub-issues", err.Error())
+	}
+	if len(mock.Called) != 0 {
+		t.Errorf("creator was called %d times, want 0", len(mock.Called))
+	}
+}
+
+// GH-3513 wave 2 (#3538/#3553): a plan whose ParentTask diverges from the
+// dispatched task must never create sub-issues — children were observed
+// claiming "parent: GH-201" while unrelated epics ran.
+func TestRunner_Execute_EpicRejectsForeignParentPlan(t *testing.T) {
+	r := NewRunner()
+	r.skipPreflightChecks = true
+	r.dryRun = true
+
+	checkerCalled := false
+	r.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) {
+		checkerCalled = true
+		return false, nil
+	}
+
+	// planEpicFn returns a plan for a DIFFERENT parent (GH-201) than the
+	// dispatched task (GH-9000); multi-package descriptions so decomposition
+	// is attempted rather than consolidated.
+	r.planEpicFn = func(_ context.Context, _ *Task, _ string) (*EpicPlan, error) {
+		return &EpicPlan{
+			ParentTask: &Task{ID: "GH-201"},
+			Subtasks: []PlannedSubtask{
+				{Order: 1, Title: "feat(gateway): add websocket handler", Description: "Implement upgrade handler in internal/gateway/server.go"},
+				{Order: 2, Title: "feat(adapters): add telegram bot", Description: "Wire bot client in internal/adapters/telegram/bot.go"},
+			},
+		}, nil
+	}
+
+	task := &Task{
+		ID:    "GH-9000",
+		Title: "[epic] foreign parent plan rejection test",
+	}
+
+	result, err := r.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+	if result == nil || result.Success {
+		t.Fatalf("expected failed result for foreign-parent plan, got: %+v", result)
+	}
+	if !strings.Contains(result.Error, "does not match dispatched task") {
+		t.Errorf("result error %q does not mention parent mismatch", result.Error)
+	}
+	if checkerCalled {
+		t.Error("sub-issue creation machinery was reached despite parent mismatch")
+	}
+}
+
+// GH-3513 wave 2: IsParentDoneSkip must detect the ErrParentDone guard through
+// the wrapped text it acquires crossing the runner/dispatcher/DB boundaries.
+func TestIsParentDoneSkip(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{ErrParentDone.Error(), true},
+		{"execution failed: failed to create sub-issues: parent task is already done; refusing to create sub-issues", true},
+		{"failed to create sub-issues: something else", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsParentDoneSkip(tt.in); got != tt.want {
+			t.Errorf("IsParentDoneSkip(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1629,6 +1629,30 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 			} else {
 				// Multi-package epic: safe to create separate GitHub issues
 
+				// GH-3513 wave 2 (#3538/#3553): refuse to create sub-issues from a
+				// plan whose ParentTask diverges from the dispatched task — children
+				// were observed claiming "parent: GH-201" while unrelated epics ran.
+				// CreateSubIssues' only production caller is here, so this assertion
+				// is equivalent to an entry guard with zero signature churn.
+				if plan.ParentTask == nil || plan.ParentTask.ID != task.ID {
+					planParent := "<nil>"
+					if plan.ParentTask != nil {
+						planParent = plan.ParentTask.ID
+					}
+					r.log.Error("epic plan parent mismatch — refusing sub-issue creation",
+						slog.String("dispatched", task.ID),
+						slog.String("plan_parent", planParent),
+					)
+					return &ExecutionResult{
+						TaskID:   task.ID,
+						Success:  false,
+						IsEpic:   true,
+						EpicPlan: plan,
+						Error:    fmt.Sprintf("epic plan parent %q does not match dispatched task %q — refusing sub-issue creation", planParent, task.ID),
+						Duration: time.Since(start),
+					}, nil
+				}
+
 				// GH-412: Create sub-issues from the plan
 				r.reportProgress(task.ID, "Creating Issues", 40, "Creating GitHub sub-issues...")
 


### PR DESCRIPTION
## Context

Wave 1 (#3527, v2.183.0) hardened the parent-close *counting* path. Live decomposition runs since (GH-3530, GH-3535→#3537/#3538, GH-3546, #3553) exposed four remaining defects. Full incident analysis in `.agent/tasks/TASK-361-autopilot-decomposition-integrity.md`.

**Root cause of the worst defect, now pinned:** `WaitForExecution` treated the TASK-358 classified worker statuses (`no_op`, `skipped`, …) as in-flight, hanging the handler indefinitely. When a child's PR later merged, `selfHealForPR` (TASK-352) promoted the **parent's** execution row to `completed` and stamped the **child's** PR URL on it. The woken handler posted a false "✅ Pilot completed! Duration 0s" with the child's PR, and `handleMerging` closed the parent + `pilot-done` while sibling slices were unshipped.

## Fixes

| # | Defect | Fix |
|---|---|---|
| 1a | handler hangs on classified outcomes | `WaitForExecution`: all TASK-358 statuses are terminal |
| 1b | parent closed via mis-registered child PR | `handleMerging`: `shouldDeferIssueClose` — skip close/done/comment when the issue has open children (reuses wave-1 `openSubIssueCount` cross-check); fail-open for leaf issues |
| 1c | child merge stamps parent row | `selfHealForPR`: heal parent only when last child merged; fail-closed on count errors |
| 1d | TASK-321 already-merged path closes decomposed parents | `issueHasOpenChildren` gate before close+done |
| 2 | supersession kills PR-less children (#3537) | `skipSupersededByParent`: require positive evidence the child's own slice shipped (merged `pilot/GH-N` PR or completed execution row); otherwise dispatch |
| 3 | hallucinated/empty children (#3538, #3553) | drop empty-description subtasks (error when ALL empty, after the dedup guard so recovery never blocks); runner refuses plans whose `ParentTask` ≠ dispatched task |
| 4 | `pilot-failed` stacked on `pilot-done` | `ErrParentDone` re-dispatch = benign skip (`IsParentDoneSkip`): no labels, no ❌ comment, marks processed |

**Invariant after this PR:** decomposed parents are closed ONLY by the controller's count-verified path (`maybeCloseParentIssue` / `recoverStaleParentIssues`).

## Tests

13 new tests across 4 packages (terminal-status table, defer-close table incl. the GH-3513 native-0-vetoed-by-text case, self-heal parent gate, no-evidence dispatch + completed-execution supersede, empty-description filter, foreign-parent rejection, `IsParentDoneSkip`, `issueHasOpenChildren` table). 3 existing tests updated where wave-2 semantics intentionally changed scenarios (each now models the evidence it relied on implicitly).

`go build` ✓ · 4 packages `ok` · `golangci-lint`: only the 7 pre-existing `unused` findings in untouched Jira/Asana/ADO handlers (present on clean main — verified via stash).

## Risks (from the plan)

- Autopilot disabled → decomposed parents linger open until the next daemon start (`recoverStaleParentIssues` backstop). Pre-existing gap, now explicit.
- `openSubIssueCount` adds 1-2 API calls per merge; fail-open preserves leaf-issue closes.
- 1a changes handler timing for all adapters (classified no-ops return promptly instead of hanging) — strictly better.
- Fix 2 trade-off: a child whose slice shipped without a branch-PR/execution row dispatches once and no-ops — acceptable per "never lose work".

⚠️ **MANUAL fix** — Pilot must not modify its own completion logic (TASK-320 B2 rationale). Do not hand to the daemon; hand-merge + manual release like #3527.