### PR TITLE
fix(executor): harvest commit SHA from worktree git, not daemon-CWD LLM summary

### DIFF
--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -114,8 +114,8 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 }
 
 // postMisconfigComment posts a single explanatory comment on the PR when
-// approval is required by the environment but not enabled in config.
-// Idempotent: skips posting if the marker comment already exists.
+// approval is required (by an escalation gate or the environment) but not
+// enabled in config. Idempotent: skips posting if the marker comment exists.
 func (m *AutoMerger) postMisconfigComment(ctx context.Context, prState *PRState) {
 	existing, err := m.ghClient.ListIssueComments(ctx, m.owner, m.repo, prState.PRNumber)
 	if err != nil {
@@ -130,16 +130,21 @@ func (m *AutoMerger) postMisconfigComment(ctx context.Context, prState *PRState)
 		}
 	}
 
-	envName := m.config.EnvironmentName()
+	// GH-3569: name the actual escalation trigger (size-floor / scope-drift /
+	// env require_approval) instead of always blaming require_approval.
+	reason := prState.EscalationReason
+	if reason == "" {
+		reason = fmt.Sprintf("environments.%s.require_approval=true", m.config.EnvironmentName())
+	}
 	body := fmt.Sprintf(`%s
 🚧 **Merge blocked: approval not wired**
 
-Environment `+"`%s`"+` requires pre-merge approval (`+"`environments.%s.require_approval: true`"+`) but the approval system is disabled (`+"`approval.enabled: false`"+` and/or `+"`approval.pre_merge.enabled: false`"+`).
+This PR requires pre-merge approval (**%s**) but the approval system is disabled (`+"`approval.enabled: false`"+` and/or `+"`approval.pre_merge.enabled: false`"+`).
 
 To unblock: either enable approval in `+"`~/.pilot/config.yaml`"+` (set `+"`approval.enabled: true`"+` + `+"`approval.pre_merge.enabled: true`"+` + add an approver), or merge manually with `+"`gh pr merge %d`"+`.
 
 Tracked in #2598.`,
-		misconfigCommentMarker, envName, envName, prState.PRNumber)
+		misconfigCommentMarker, reason, prState.PRNumber)
 
 	if _, postErr := m.ghClient.AddPRComment(ctx, m.owner, m.repo, prState.PRNumber, body); postErr != nil {
 		m.log.Warn("postMisconfigComment: failed to post PR comment",

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -860,6 +860,10 @@ func (c *Controller) handleCIPassed(ctx context.Context, prState *PRState) error
 		c.log.Warn("merge gate escalated: requiring human approval",
 			"pr", prState.PRNumber, "reason", escalateReason)
 		prState.Stage = StageAwaitApproval
+		// GH-3569: record WHY this PR awaits approval so downstream reporting
+		// (misconfig error, PR comment) names the actual trigger instead of
+		// blaming env require_approval.
+		prState.EscalationReason = escalateReason
 		if c.notifier != nil {
 			if err := c.notifier.NotifyApprovalRequired(ctx, prState); err != nil {
 				c.log.Warn("failed to send approval notification", "error", err)
@@ -871,6 +875,7 @@ func (c *Controller) handleCIPassed(ctx context.Context, prState *PRState) error
 	if c.config.ResolvedEnv().RequireApproval {
 		c.log.Info("awaiting approval before merge", "pr", prState.PRNumber)
 		prState.Stage = StageAwaitApproval
+		prState.EscalationReason = fmt.Sprintf("environments.%s.require_approval=true", c.config.EnvironmentName())
 
 		// Notify approval required
 		if c.notifier != nil {
@@ -1218,14 +1223,22 @@ func (c *Controller) handleAwaitApproval(ctx context.Context, prState *PRState) 
 
 // submitAsyncApprovalRequest submits the first async approval request for a PR.
 func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PRState) error {
-	// Fail closed: if approval stage is not enabled, do NOT auto-approve when the env requires approval.
+	// Fail closed: if approval stage is not enabled, do NOT auto-approve when approval is required.
 	if c.approvalMgr == nil || !c.approvalMgr.IsStageEnabled(approval.StagePreMerge) {
-		c.log.Error("approval misconfig: env requires approval but pre_merge.enabled=false",
-			"pr", prState.PRNumber, "env", c.config.EnvironmentName())
+		// GH-3569: PRs reach StageAwaitApproval via three paths (size-floor gate,
+		// scope-drift gate, env require_approval). The old hardcoded message
+		// blamed require_approval=true even when the env had it false and a
+		// defense-in-depth gate did the escalating — observed on PR #3559.
+		reason := prState.EscalationReason
+		if reason == "" {
+			reason = fmt.Sprintf("environments.%s.require_approval=true", c.config.EnvironmentName())
+		}
+		c.log.Error("approval misconfig: approval required but pre_merge.enabled=false",
+			"pr", prState.PRNumber, "env", c.config.EnvironmentName(), "escalation_reason", reason)
 		prState.Stage = StageFailed
 		prState.Error = fmt.Sprintf(
-			"approval-misconfig: env %q has require_approval=true but approval.pre_merge.enabled=false → deadlock until config fixed",
-			c.config.EnvironmentName(),
+			"approval-misconfig: PR requires approval (%s) but approval.pre_merge.enabled=false → deadlock until config fixed",
+			reason,
 		)
 		c.autoMerger.postMisconfigComment(ctx, prState)
 		c.metrics.RecordPRFailed()

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -7169,13 +7169,13 @@ func TestController_handleCIFailed_BoardSync_Regression_NormalPath(t *testing.T)
 }
 
 // TestHandleCIPassed_SizeFloorEscalation verifies that a PR exceeding the size
-// floor (300 net additions > 200 threshold) is routed to StageAwaitApproval even
+// floor (600 net additions > 500 threshold) is routed to StageAwaitApproval even
 // when RequireApproval is false.
 func TestHandleCIPassed_SizeFloorEscalation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/repos/owner/repo/pulls/77/files" && r.Method == http.MethodGet {
 			files := []*github.PRFile{
-				{Filename: "a.go", Status: "modified", Additions: 300},
+				{Filename: "a.go", Status: "modified", Additions: 600},
 			}
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(mustJSON(t, files))

--- a/internal/autopilot/escalation_reason_test.go
+++ b/internal/autopilot/escalation_reason_test.go
@@ -1,0 +1,170 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// GH-3569: the misconfig error must name the ACTUAL escalation trigger
+// (size-floor gate, scope-drift gate, or env require_approval) — the old
+// hardcoded message blamed require_approval=true even when the env had it
+// false and a defense-in-depth gate did the escalating (observed on PR #3559).
+func TestSubmitAsyncApprovalRequest_MisconfigErrorText(t *testing.T) {
+	tests := []struct {
+		name             string
+		escalationReason string
+		wantInError      string
+	}{
+		{
+			name:             "size-floor gate reason is reported verbatim",
+			escalationReason: "PR adds 656 net lines (> 500 threshold)",
+			wantInError:      "PR adds 656 net lines (> 500 threshold)",
+		},
+		{
+			name:             "scope-drift gate reason is reported verbatim",
+			escalationReason: `PR title type "feat" diverges from issue title type "fix"`,
+			wantInError:      `PR title type "feat" diverges from issue title type "fix"`,
+		},
+		{
+			name:             "env require_approval reason is reported verbatim",
+			escalationReason: "environments.prod.require_approval=true",
+			wantInError:      "environments.prod.require_approval=true",
+		},
+		{
+			name:             "zero-value falls back to env-based wording",
+			escalationReason: "",
+			wantInError:      "require_approval=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("[]"))
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.Environment = EnvStage
+			// approvalMgr nil → IsStageEnabled false → misconfig branch.
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			prState := &PRState{
+				PRNumber:         90,
+				Stage:            StageAwaitApproval,
+				EscalationReason: tt.escalationReason,
+			}
+
+			if err := c.submitAsyncApprovalRequest(context.Background(), prState); err != nil {
+				t.Fatalf("submitAsyncApprovalRequest returned error: %v", err)
+			}
+			if prState.Stage != StageFailed {
+				t.Errorf("Stage = %v, want StageFailed", prState.Stage)
+			}
+			if !strings.Contains(prState.Error, tt.wantInError) {
+				t.Errorf("Error %q does not contain %q", prState.Error, tt.wantInError)
+			}
+			if tt.escalationReason != "" && !strings.Contains(prState.Error, tt.escalationReason) {
+				t.Errorf("Error %q must carry the escalation reason %q", prState.Error, tt.escalationReason)
+			}
+		})
+	}
+}
+
+// GH-3569: handleCIPassed must record why the PR entered StageAwaitApproval.
+func TestHandleCIPassed_SetsEscalationReason(t *testing.T) {
+	tests := []struct {
+		name         string
+		additions    int
+		requireAppr  bool
+		wantInReason string
+	}{
+		{name: "size-floor gate stamps its reason", additions: SizeFloorThreshold + 1, wantInReason: "net lines"},
+		{name: "env require_approval stamps env wording", additions: 1, requireAppr: true, wantInReason: "require_approval=true"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/files") && r.Method == http.MethodGet {
+					files := []*github.PRFile{{Filename: "a.go", Status: "modified", Additions: tt.additions}}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(files)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("{}"))
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.Environment = EnvDev
+			if tt.requireAppr {
+				cfg.activeEnvName = "dev"
+				cfg.activeEnvConfig = &EnvironmentConfig{Branch: "main", RequireApproval: true}
+			}
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			prState := &PRState{PRNumber: 91, PRTitle: "fix(auth): fix bug", Stage: StageCIPassed}
+			if err := c.handleCIPassed(context.Background(), prState); err != nil {
+				t.Fatalf("handleCIPassed: %v", err)
+			}
+			if prState.Stage != StageAwaitApproval {
+				t.Fatalf("Stage = %v, want StageAwaitApproval", prState.Stage)
+			}
+			if !strings.Contains(prState.EscalationReason, tt.wantInReason) {
+				t.Errorf("EscalationReason %q does not contain %q", prState.EscalationReason, tt.wantInReason)
+			}
+		})
+	}
+}
+
+// GH-3569: the misconfig PR comment names the actual escalation reason.
+func TestPostMisconfigComment_NamesEscalationReason(t *testing.T) {
+	var postedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			var payload struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			postedBody = payload.Body
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":1}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", DefaultConfig())
+	prState := &PRState{
+		PRNumber:         92,
+		EscalationReason: "PR adds 656 net lines (> 500 threshold)",
+	}
+
+	merger.postMisconfigComment(context.Background(), prState)
+
+	if !strings.Contains(postedBody, "PR adds 656 net lines") {
+		t.Errorf("comment body does not name the escalation reason: %q", postedBody)
+	}
+	if strings.Contains(postedBody, "require_approval: true") {
+		t.Errorf("comment body still blames require_approval despite a gate reason: %q", postedBody)
+	}
+}

--- a/internal/autopilot/scope_guard.go
+++ b/internal/autopilot/scope_guard.go
@@ -57,15 +57,16 @@ func ScopeDriftReason(prTitle, issueTitle string) string {
 }
 
 // SizeFloorThreshold is the net-additions threshold above which a PR escalates
-// to human approval regardless of env config. Cascade #2's bad PR was 512 LoC;
-// 200 catches that with comfortable margin and only blocks PRs that genuinely
-// merit a second pair of eyes.
-const SizeFloorThreshold = 200
+// to human approval regardless of env config. Cascade #2's bad PR was 512 LoC.
+// GH-3570: raised from 200 to 500 — routine well-scoped Pilot PRs with tests
+// (e.g. #3559 at +656) tripped the old floor; 500 still catches the cascade-2
+// class while sparing ordinary multi-file fixes.
+const SizeFloorThreshold = 500
 
 // SizeFloorReason returns a non-empty reason if the PR's net additions exceed
 // SizeFloorThreshold. Pilot's median PR is well under 100 additions — anything
-// over 200 is large enough that auto-merge is too aggressive even on a passing
-// CI signal.
+// over the floor is large enough that auto-merge is too aggressive even on a
+// passing CI signal.
 func SizeFloorReason(files []*github.PRFile) string {
 	var net int
 	for _, f := range files {

--- a/internal/autopilot/scope_guard_test.go
+++ b/internal/autopilot/scope_guard_test.go
@@ -88,17 +88,24 @@ func TestSizeFloorReason(t *testing.T) {
 			},
 		},
 		{
-			name: "200 LoC exactly — no floor (strict >)",
+			name: "500 LoC exactly — no floor (strict >)",
 			files: []*github.PRFile{
-				{Filename: "a.go", Status: "modified", Additions: 200},
+				{Filename: "a.go", Status: "modified", Additions: 500},
 			},
 		},
 		{
-			name: "201 LoC — floor fires",
+			name: "501 LoC — floor fires",
 			files: []*github.PRFile{
-				{Filename: "a.go", Status: "modified", Additions: 201},
+				{Filename: "a.go", Status: "modified", Additions: 501},
 			},
 			want: true,
+		},
+		{
+			name: "routine multi-file fix with tests (#3559 class, ~450) — no floor",
+			files: []*github.PRFile{
+				{Filename: "internal/autopilot/controller.go", Status: "modified", Additions: 110},
+				{Filename: "internal/autopilot/controller_test.go", Status: "modified", Additions: 340},
+			},
 		},
 		{
 			name: "cascade-2 contaminating PR (~512 LoC)",

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -322,20 +322,20 @@ func DefaultConfig() *Config {
 			Enabled:       true,
 			MaxIterations: 3,
 		},
-		AutoCreateIssues:    true,
-		IssueLabels:         []string{"pilot", "autopilot-fix"},
-		NotifyOnFailure:     true,
-		MaxFailures:         3,
-		MaxCIFixIterations:  3,
-		MaxCIFixPRSize:      200,
-		FailureResetTimeout: 30 * time.Minute,
-		MaxMergesPerHour:    10,
-		MaxMergeAttempts:    5,
+		AutoCreateIssues:     true,
+		IssueLabels:          []string{"pilot", "autopilot-fix"},
+		NotifyOnFailure:      true,
+		MaxFailures:          3,
+		MaxCIFixIterations:   3,
+		MaxCIFixPRSize:       200,
+		FailureResetTimeout:  30 * time.Minute,
+		MaxMergesPerHour:     10,
+		MaxMergeAttempts:     5,
 		MaxReleasingAttempts: 10,
-		ApprovalTimeout:     1 * time.Hour,
-		Release:             nil, // Disabled by default
-		MergedPRScanWindow:  30 * time.Minute,
-		Environments:        defaultEnvironments(),
+		ApprovalTimeout:      1 * time.Hour,
+		Release:              nil, // Disabled by default
+		MergedPRScanWindow:   30 * time.Minute,
+		Environments:         defaultEnvironments(),
 	}
 }
 
@@ -531,6 +531,11 @@ type PRState struct {
 	ReleasingAttempts int
 	// ReleasingFirstAt is when StageReleasing was first attempted. Set on the first call.
 	ReleasingFirstAt time.Time
+	// EscalationReason records why the PR entered StageAwaitApproval (size-floor
+	// gate, scope-drift gate, or env require_approval) so misconfig reporting
+	// names the actual trigger (GH-3569). In-memory only; lost on restart, which
+	// degrades to the env-based fallback wording.
+	EscalationReason string
 }
 
 // snapshot returns a detached, field-by-field copy of the PRState with a fresh
@@ -568,6 +573,7 @@ func (ps *PRState) snapshot() *PRState {
 		PostMergeCIStartedAt:    ps.PostMergeCIStartedAt,
 		ReleasingAttempts:       ps.ReleasingAttempts,
 		ReleasingFirstAt:        ps.ReleasingFirstAt,
+		EscalationReason:        ps.EscalationReason,
 	}
 	// DiscoveredChecks is a slice — copy the backing array so consumers can't
 	// mutate the live PR's slice through the snapshot.

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2544,29 +2544,15 @@ retrySucceeded:
 		result.CommitSHA = state.commitSHAs[len(state.commitSHAs)-1] // Use last commit
 	}
 
-	// Post-execution summary via structured output (GH-1264)
-	// This replaces brittle regex parsing with reliable --json-schema output
-	if result.CommitSHA == "" && result.Success && r.config != nil && r.config.ClaudeCode != nil && r.config.ClaudeCode.UseStructuredOutput {
-		if summary, summaryErr := r.getPostExecutionSummary(ctx); summaryErr == nil {
-			if summary.CommitSHA != "" {
-				result.CommitSHA = summary.CommitSHA
-				log.Info("CommitSHA extracted via post-execution summary",
-					slog.String("task_id", task.ID),
-					slog.String("sha", summary.CommitSHA[:min(7, len(summary.CommitSHA))]),
-					slog.String("branch", summary.BranchName),
-				)
-			}
-		} else {
-			log.Debug("post-execution summary failed, falling back to git",
-				slog.String("task_id", task.ID),
-				slog.Any("error", summaryErr),
-			)
-		}
-	}
-
-	// Fallback: if output parsing missed the commit SHA, ask git directly.
-	// This handles cases where Claude's git commit output format doesn't match
-	// the extractCommitSHA() pattern (e.g. different flags, localized output).
+	// GH-3569/GH-3570 incident (TASK-320/TASK-355 root cause): harvest the SHA
+	// from git in the worktree BEFORE asking an LLM. The structured-output
+	// summary used to run first and, lacking cmd.Dir, executed `git log` in the
+	// daemon's CWD — reporting the daemon repo's HEAD as "the commit". When that
+	// HEAD was an ancestor of origin/main the ghost guard below discarded the
+	// worker's real commit as a no-op; when the daemon CWD was a different repo
+	// entirely, the foreign SHA failed the ancestor check open and was recorded
+	// as a wrong-repo "completed" SHA. Git in the worktree is deterministic and
+	// authoritative; the LLM summary is a last resort only.
 	if result.CommitSHA == "" && task.Branch != "" && result.Success {
 		baseBranch := task.BaseBranch
 		if baseBranch == "" {
@@ -2584,6 +2570,27 @@ retrySucceeded:
 				)
 				result.CommitSHA = sha
 			}
+		}
+	}
+
+	// Post-execution summary via structured output (GH-1264) — last resort when
+	// both stream parsing and the worktree git harvest came up empty. Pinned to
+	// executionPath so its git commands run in the worktree, never the daemon CWD.
+	if result.CommitSHA == "" && result.Success && r.config != nil && r.config.ClaudeCode != nil && r.config.ClaudeCode.UseStructuredOutput {
+		if summary, summaryErr := r.getPostExecutionSummary(ctx, executionPath); summaryErr == nil {
+			if summary.CommitSHA != "" {
+				result.CommitSHA = summary.CommitSHA
+				log.Info("CommitSHA extracted via post-execution summary",
+					slog.String("task_id", task.ID),
+					slog.String("sha", summary.CommitSHA[:min(7, len(summary.CommitSHA))]),
+					slog.String("branch", summary.BranchName),
+				)
+			}
+		} else {
+			log.Debug("post-execution summary failed",
+				slog.String("task_id", task.ID),
+				slog.Any("error", summaryErr),
+			)
 		}
 	}
 
@@ -4966,7 +4973,10 @@ type PostExecutionSummary struct {
 
 // getPostExecutionSummary runs a structured output query to extract git state information.
 // This replaces brittle regex parsing of git output with reliable --json-schema extraction.
-func (r *Runner) getPostExecutionSummary(ctx context.Context) (*PostExecutionSummary, error) {
+// dir pins the subprocess working directory to the execution worktree: without it the
+// git commands in the prompt ran in the daemon's CWD and reported the wrong repo's HEAD
+// (GH-3569/GH-3570 incident — false no-ops and wrong-repo completed SHAs).
+func (r *Runner) getPostExecutionSummary(ctx context.Context, dir string) (*PostExecutionSummary, error) {
 	if r.config == nil || r.config.ClaudeCode == nil {
 		return nil, fmt.Errorf("claude code backend not configured")
 	}
@@ -4985,6 +4995,7 @@ func (r *Runner) getPostExecutionSummary(ctx context.Context) (*PostExecutionSum
 		"--output-format", "json",
 		"--json-schema", PostExecutionSummarySchema,
 	)
+	cmd.Dir = dir
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/executor/runner_post_execution_summary_test.go
+++ b/internal/executor/runner_post_execution_summary_test.go
@@ -1,0 +1,48 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// GH-3569/GH-3570 incident: getPostExecutionSummary spawned the claude CLI
+// without cmd.Dir, so its git commands ran in the daemon's CWD and reported the
+// wrong repo's HEAD as the commit SHA — turning real worker commits into
+// ghost-guard no-ops (TASK-320) or recording wrong-repo SHAs as completed
+// (TASK-355). The fake claude script below echoes its own working directory as
+// the commit_sha, proving the subprocess runs in the directory the caller pins.
+func TestGetPostExecutionSummary_RunsInGivenDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake command not portable to windows")
+	}
+
+	dir := t.TempDir()
+	scriptDir := t.TempDir()
+	script := filepath.Join(scriptDir, "fake-claude")
+	// Emit the claude --output-format json wrapper with the CWD as commit_sha.
+	content := `#!/bin/sh
+printf '{"result":"ok","structured_output":{"branch_name":"b","commit_sha":"%s","files_changed":[],"summary":"s"}}' "$(pwd)"
+`
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+
+	r := NewRunner()
+	r.config = &BackendConfig{
+		ClaudeCode: &ClaudeCodeConfig{Command: script, UseStructuredOutput: true},
+	}
+
+	summary, err := r.getPostExecutionSummary(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("getPostExecutionSummary: %v", err)
+	}
+	// macOS TempDir paths may resolve through /private symlinks — compare resolved paths.
+	wantDir, _ := filepath.EvalSymlinks(dir)
+	gotDir, _ := filepath.EvalSymlinks(summary.CommitSHA)
+	if gotDir != wantDir {
+		t.Errorf("summary subprocess ran in %q, want pinned dir %q", summary.CommitSHA, dir)
+	}
+}


### PR DESCRIPTION
## Root cause (TASK-320 false no-ops + TASK-355 wrong-repo SHAs — one bug)

`getPostExecutionSummary` spawned the `claude` CLI **without `cmd.Dir`** — its `git log --oneline -1` ran in the **daemon's CWD**, not the execution worktree, and reported that repo's HEAD as "the commit SHA". Two failure modes, both observed live:

1. **Daemon CWD = pilot root (pinned to main)** → reported SHA is an ancestor of `origin/main` → ghost guard (GH-3126) discards the worker's real, hook-passing commit as `no_op` ("no new commit produced"). 4/4 deterministic on #3569/#3570 (workers committed `ecdf5017`-class commits that were destroyed with the worktree). #3558's work survived only because the worker pushed + created the PR in-session before the executor misjudged it.
2. **Daemon CWD = different repo** → foreign SHA → `merge-base` errors → guard fails open → execution recorded `completed` with a wrong-repo SHA (the TASK-355 family).

## Fixes

- **runner.go**: deterministic git harvest in the worktree (`CountNewCommits` + `GetCurrentCommitSHA`, already worktree-bound) now runs **before** the LLM summary; the summary is a last resort and is **pinned via `cmd.Dir = executionPath`**.
- **GH-3569**: `PRState.EscalationReason` records why a PR awaits approval (size-floor / scope-drift / env require_approval); the misconfig error, log line, and PR comment now name the actual trigger instead of always blaming `require_approval=true`. In-memory only (restart degrades to env-based fallback wording — acceptable).
- **GH-3570**: `SizeFloorThreshold` 200 → 500 net added lines (constant only; routine multi-file fixes with tests no longer escalate; cascade-2 class at 512 still caught).

## Tests

- `TestGetPostExecutionSummary_RunsInGivenDir` — fake `claude` script echoes its CWD as commit_sha, proving dir pinning.
- `TestSubmitAsyncApprovalRequest_MisconfigErrorText` — 4-path table (size-floor / scope-drift / env / zero-value fallback).
- `TestHandleCIPassed_SetsEscalationReason`, `TestPostMisconfigComment_NamesEscalationReason`.
- Size-floor boundary tests moved to 500/501 + a #3559-class (~450) no-fire case.

`go test ./internal/autopilot/... ./internal/executor/... ./cmd/...` ok · `golangci-lint` 0 issues · gofmt clean.

## Route

MANUAL (TASK-320 B2 rationale — Pilot cannot fix its own execution guard; it literally could not ship #3569/#3570 because of this bug).

Closes #3569. Closes #3570.

Refs: TASK-320, TASK-355, TASK-361.