### PR TITLE
fix(executor): retry in worktree, failure-aware gate feedback, dry-run guard on issue creation

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1231,6 +1231,16 @@ for context, but do NOT implement parts of it that fall outside this subtask.`,
 // The TASK-286 / GH-3027 repo guardrail runs one level up in CreateSubIssues
 // (it must fire before queryRecentSubIssues, which also shells out to gh).
 func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, executionPath string) ([]CreatedIssue, error) {
+	// GH-3579: dry-run must short-circuit BEFORE any gh invocation. Previously
+	// only the progress/close paths honored dryRun, so tests that set it still
+	// fired live `gh issue create` on machines with an authed gh — the source
+	// of the GH-201 fixture ghost issues (#3562-64, #3576).
+	if r.dryRun {
+		r.log.Info("dry-run: skipping createSubIssuesViaGitHub",
+			"subtasks", len(plan.Subtasks))
+		return nil, nil
+	}
+
 	var created []CreatedIssue
 
 	// Map subtask order → created GitHub issue number for dependency annotation (GH-1794)

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -893,12 +893,15 @@ func TestPlanEpicDefaultCommand(t *testing.T) {
 		modelRouter:       NewModelRouter(nil, nil),
 	}
 
-	// Use a short timeout so it doesn't hang if "claude" binary exists
+	// GH-3579: isolate PATH so the default "claude" command can never resolve.
+	// This test previously spawned a LIVE claude session (with the real
+	// decomposition prompt) on any machine where claude was installed.
+	t.Setenv("PATH", t.TempDir())
+
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	_, err = runner2.PlanEpic(ctx, task, task.ProjectPath)
-	// We expect either an error (binary not found) or timeout (binary exists but hangs)
 	if err == nil {
 		t.Fatal("PlanEpic with nil config should still attempt to run")
 	}
@@ -1196,6 +1199,7 @@ func TestCreateSubIssues_FallsBackToGitHubWhenNoAdapter(t *testing.T) {
 	// This test verifies the dispatch logic chooses GitHub path when SourceAdapter is empty.
 	// We test this by verifying the mock is NOT called, regardless of gh CLI outcome.
 	runner := NewRunner()
+	runner.dryRun = true // GH-3579: never let tests reach a live gh
 
 	mock := &mockSubIssueCreator{
 		Returns: []mockCreateIssueReturn{
@@ -1230,6 +1234,7 @@ func TestCreateSubIssues_FallsBackToGitHubWhenAdapterIsGitHub(t *testing.T) {
 	// This test verifies the dispatch logic chooses GitHub path when SourceAdapter is "github".
 	// We test this by verifying the mock is NOT called, regardless of gh CLI outcome.
 	runner := NewRunner()
+	runner.dryRun = true // GH-3579: never let tests reach a live gh
 
 	mock := &mockSubIssueCreator{
 		Returns: []mockCreateIssueReturn{
@@ -1265,6 +1270,7 @@ func TestCreateSubIssues_FallsBackToGitHubWhenNoCreator(t *testing.T) {
 	// This test verifies that when SubIssueCreator is nil, even with a non-GitHub
 	// SourceAdapter, we fall back to the GitHub path (and don't panic).
 	runner := NewRunner()
+	runner.dryRun = true // GH-3579: never let tests reach a live gh
 	// SubIssueCreator not set
 
 	plan := &EpicPlan{
@@ -1279,16 +1285,16 @@ func TestCreateSubIssues_FallsBackToGitHubWhenNoCreator(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	// Run in a non-existent directory to ensure gh CLI fails
-	_, err := runner.CreateSubIssues(ctx, plan, "/nonexistent/path")
-
-	// Should get an error from gh CLI, not from a nil creator panic
-	if err == nil {
-		t.Skip("gh CLI succeeded unexpectedly (test requires gh CLI to fail in non-repo dir)")
+	// GH-3579: with dryRun set, reaching the GitHub path returns (nil, nil)
+	// before any gh invocation. The assertion is that the nil creator falls
+	// through to the GitHub path without panicking — a non-nil error here
+	// would mean dispatch went somewhere else.
+	created, err := runner.CreateSubIssues(ctx, plan, "/nonexistent/path")
+	if err != nil {
+		t.Errorf("expected dry-run GitHub fallback to return nil error, got: %v", err)
 	}
-	// Verify it's a gh CLI error, not a nil pointer
-	if !strings.Contains(err.Error(), "failed to create issue") {
-		t.Errorf("Expected gh CLI error, got: %v", err)
+	if created != nil {
+		t.Errorf("expected no issues created in dry-run, got: %v", created)
 	}
 }
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -3091,7 +3091,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					feedbackAllowed, feedbackMCP := r.executionToolOptions()
 					retryResult, retryErr := r.backend.Execute(ctx, ExecuteOptions{
 						Prompt:        retryPrompt,
-						ProjectPath:   task.ProjectPath,
+						ProjectPath:   executionPath, // GH-3577: retry in the worktree, not the daemon's repo root
 						Verbose:       task.Verbose,
 						Model:         selectedModel,
 						Effort:        selectedEffort,
@@ -3370,7 +3370,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					intentAllowed, intentMCP := r.executionToolOptions()
 					_, retryErr := r.backend.Execute(ctx, ExecuteOptions{
 						Prompt:        retryPrompt,
-						ProjectPath:   task.ProjectPath,
+						ProjectPath:   executionPath, // GH-3577: retry in the worktree, not the daemon's repo root
 						Verbose:       task.Verbose,
 						Model:         selectedModel,
 						Effort:        selectedEffort,

--- a/internal/executor/runner_retry_worktree_test.go
+++ b/internal/executor/runner_retry_worktree_test.go
@@ -2,7 +2,10 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -87,5 +90,100 @@ func TestRunner_NoCommitRetry_RunsInWorktree(t *testing.T) {
 	}
 	if !strings.Contains(retryPath, "pilot-worktree-") {
 		t.Errorf("retry ProjectPath %q should be the isolated worktree (contain 'pilot-worktree-')", retryPath)
+	}
+}
+
+// commitAndRecordBackend records the ProjectPath of every Execute call and
+// creates a real commit in that path, so the runner proceeds past the
+// no-commit checks into the quality-gate loop.
+type commitAndRecordBackend struct {
+	retryPathRecordingBackend
+	commits int
+}
+
+func (b *commitAndRecordBackend) Execute(ctx context.Context, opts ExecuteOptions) (*BackendResult, error) {
+	b.mu.Lock()
+	b.projectPaths = append(b.projectPaths, opts.ProjectPath)
+	b.commits++
+	n := b.commits
+	b.mu.Unlock()
+
+	fname := filepath.Join(opts.ProjectPath, fmt.Sprintf("change_%d.txt", n))
+	if err := os.WriteFile(fname, []byte("x"), 0o644); err != nil {
+		return nil, err
+	}
+	for _, args := range [][]string{{"add", "."}, {"commit", "-m", fmt.Sprintf("change %d", n)}} {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = opts.ProjectPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	return &BackendResult{Success: true, Output: "done"}, nil
+}
+
+// failingQualityChecker always fails with ShouldRetry so the quality-gate
+// retry path fires.
+type failingQualityChecker struct{}
+
+func (c *failingQualityChecker) Check(_ context.Context) (*QualityOutcome, error) {
+	return &QualityOutcome{
+		Passed:        false,
+		ShouldRetry:   true,
+		RetryFeedback: "synthetic gate failure",
+		Attempt:       1,
+	}, nil
+}
+
+// TestRunner_QualityRetry_RunsInWorktree is the GH-3577 regression guard.
+//
+// Before the fix the quality-gate retry (and intent retry) passed
+// ProjectPath: task.ProjectPath — the daemon's repo root — so retry workers
+// executed outside the isolated worktree. Their fixes were invisible to the
+// gate loop re-testing the worktree, making quality retries structurally
+// unable to succeed, and the retry sessions ran loose in the user's real repo
+// (the GH-3573 incident: a retry reimplemented the whole task in a foreign
+// .claude/worktrees branch while gates kept failing against the worktree).
+func TestRunner_QualityRetry_RunsInWorktree(t *testing.T) {
+	localRepo, remoteRepo := setupTestRepoWithRemote(t)
+	defer func() { _ = os.RemoveAll(localRepo) }()
+	defer func() { _ = os.RemoveAll(remoteRepo) }()
+
+	backend := &commitAndRecordBackend{}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{UseWorktree: true} // enable worktree isolation
+	runner.SetSkipPreflightChecks(true)
+	runner.SetRecordingEnabled(false)
+	runner.SetQualityCheckerFactory(func(taskID, projectPath string) QualityChecker {
+		return &failingQualityChecker{}
+	})
+
+	task := &Task{
+		ID:          "GH-3577",
+		Title:       "force a quality-gate retry in worktree mode",
+		Description: "gates always fail, so the quality retry fires",
+		ProjectPath: localRepo,
+		Branch:      "pilot/GH-3577",
+		CreatePR:    true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// The task fails (gates never pass) — we only care which path every
+	// backend invocation, including the quality retries, executed in.
+	_, _ = runner.Execute(ctx, task)
+
+	paths := backend.paths()
+	if len(paths) < 2 {
+		t.Fatalf("expected >=2 backend calls (initial + quality retry), got %d: %v", len(paths), paths)
+	}
+	for i, p := range paths {
+		if p == task.ProjectPath {
+			t.Errorf("backend call %d ran in task.ProjectPath %q; it must run in the worktree", i, p)
+		}
+		if !strings.Contains(p, "pilot-worktree-") {
+			t.Errorf("backend call %d ProjectPath %q should be the isolated worktree (contain 'pilot-worktree-')", i, p)
+		}
 	}
 }

--- a/internal/quality/runner.go
+++ b/internal/quality/runner.go
@@ -327,20 +327,65 @@ func FormatErrorFeedback(results *CheckResults) string {
 
 		sb.WriteString(fmt.Sprintf("### %s Gate (FAILED)\n\n", result.GateName))
 		sb.WriteString("**Error Output:**\n```\n")
-
-		// Truncate output if too long
-		output := result.Output
-		maxLen := 2000
-		if len(output) > maxLen {
-			output = output[:maxLen] + "\n... (truncated)"
-		}
-		sb.WriteString(output)
+		sb.WriteString(extractFailureOutput(result.Output, 2000))
 		sb.WriteString("\n```\n\n")
 	}
 
 	sb.WriteString("Please fix these issues and ensure all quality gates pass.\n")
 
 	return sb.String()
+}
+
+// failureMarkerRE matches lines that carry the actual failure in gate output:
+// go test verdicts, race reports, panics, build/lint diagnostics.
+var failureMarkerRE = regexp.MustCompile(`^\s*(--- FAIL|FAIL\b|panic:|WARNING: DATA RACE|Error:|# )|\.go:\d+(:\d+)?: |race detected`)
+
+// extractFailureOutput reduces gate output to its failure-relevant portion.
+// go test prints failures and summaries AFTER potentially thousands of PASS
+// lines, so a head truncation hands the retry worker nothing but noise
+// (GH-3578). Lines matching failure markers are kept with trailing context;
+// when nothing matches, the tail is kept — that's where tools print summaries.
+func extractFailureOutput(output string, maxLen int) string {
+	if len(output) <= maxLen {
+		return output
+	}
+
+	lines := strings.Split(output, "\n")
+	const contextAfter = 6
+	keep := make([]bool, len(lines))
+	matched := false
+	for i, line := range lines {
+		if failureMarkerRE.MatchString(line) {
+			matched = true
+			for j := i; j < len(lines) && j <= i+contextAfter; j++ {
+				keep[j] = true
+			}
+		}
+	}
+
+	if !matched {
+		return "... (head truncated)\n" + output[len(output)-maxLen:]
+	}
+
+	var sb strings.Builder
+	skipping := false
+	for i, line := range lines {
+		if !keep[i] {
+			skipping = true
+			continue
+		}
+		if skipping {
+			sb.WriteString("...\n")
+			skipping = false
+		}
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+		if sb.Len() >= maxLen {
+			sb.WriteString("... (truncated)")
+			break
+		}
+	}
+	return strings.TrimRight(sb.String(), "\n")
 }
 
 // ShouldRetry determines if gates should be retried with Claude

--- a/internal/quality/runner_test.go
+++ b/internal/quality/runner_test.go
@@ -631,6 +631,44 @@ func TestFormatErrorFeedback_TruncatesLongOutput(t *testing.T) {
 	}
 }
 
+func TestExtractFailureOutput_ShortPassthrough(t *testing.T) {
+	out := extractFailureOutput("--- FAIL: TestX\nshort output", 2000)
+	if out != "--- FAIL: TestX\nshort output" {
+		t.Errorf("short output must pass through unchanged, got %q", out)
+	}
+}
+
+func TestExtractFailureOutput_KeepsFailureLinesBeyondHead(t *testing.T) {
+	// 3000+ bytes of PASS noise followed by the actual failure — the old head
+	// truncation dropped everything that mattered (GH-3578).
+	noise := strings.Repeat("=== RUN   TestSomething\n--- PASS: TestSomething (0.01s)\n", 60)
+	failure := "--- FAIL: TestSafeGo_IncrementsCounter (0.05s)\n    safego_test.go:42: WARNING: DATA RACE\nFAIL\tgithub.com/qf-studio/pilot/internal/logging\t0.123s"
+	out := extractFailureOutput(noise+failure, 2000)
+
+	if !strings.Contains(out, "--- FAIL: TestSafeGo_IncrementsCounter") {
+		t.Errorf("extracted output must contain the FAIL line, got %q", out)
+	}
+	if !strings.Contains(out, "DATA RACE") {
+		t.Errorf("extracted output must contain the race report, got %q", out)
+	}
+	if strings.Count(out, "--- PASS") > 10 {
+		t.Errorf("extracted output should drop PASS noise, got %d PASS lines", strings.Count(out, "--- PASS"))
+	}
+}
+
+func TestExtractFailureOutput_TailFallbackWhenNoMarkers(t *testing.T) {
+	head := strings.Repeat("a", 2500)
+	tail := "the real summary lives at the end"
+	out := extractFailureOutput(head+"\n"+tail, 2000)
+
+	if !strings.Contains(out, tail) {
+		t.Errorf("tail fallback must keep the end of the output, got %q", out[:80])
+	}
+	if !strings.Contains(out, "head truncated") {
+		t.Error("tail fallback must carry a truncation notice")
+	}
+}
+
 func TestFormatErrorFeedback_NoFailedGates(t *testing.T) {
 	results := &CheckResults{
 		TaskID:    "all-passed",


### PR DESCRIPTION
Closes #3577
Closes #3578
Closes #3579

## Summary

Three MANUAL fixes for the retry machinery, root-caused from the GH-3573 incident:

1. **Retry CWD (#3577)** — quality-gate retry (`runner.go`) and intent retry re-invoked the backend with `ProjectPath: task.ProjectPath` (daemon repo root) instead of `executionPath` (task worktree). TASK-323 fixed the two sibling paths; these two were missed. Consequence: retry workers executed in the user's interactive repo, their fixes were invisible to the gate loop re-testing the worktree, and quality retries could never succeed under worktree isolation.
2. **Feedback truncation (#3578)** — `FormatErrorFeedback` head-truncated gate output at 2000 bytes; `go test` prints failures after the PASS noise, so both GH-3573 retry prompts contained zero information about the actual failure (a data race). New `extractFailureOutput` keeps failure-marker lines (`--- FAIL`, `DATA RACE`, `panic:`, build/lint diagnostics) with trailing context; tail-truncation fallback when no markers match.
3. **Live-fire tests (#3579)** — `createSubIssuesViaGitHub` had no `dryRun` guard, so tests that set `dryRun` still fired real `gh issue create` — the source of the GH-201 fixture ghost issues (#3562–64, #3576). Guard added before any gh invocation; GitHub-fallback tests now set `dryRun`; `TestPlanEpicDefaultCommand` isolates `PATH` so the default `claude` command can never spawn a live session.

## Verification

- `make lint` — 0 issues
- `make test` (`go test -v -race ./...`) — exit 0
- New regression `TestRunner_QualityRetry_RunsInWorktree` **verified to fail with the fix reverted**
- Full-suite run observed to spawn **zero** claude sessions and create **zero** GitHub objects (previously: one live claude spawn per run + ghost issues when run pre-wave-2)