### PR TITLE
feat(executor): add sanitizeSubtaskDescription (GH-3584)

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -21,6 +21,19 @@ import (
 // "fix:", "feat(scope):", "chore(epic):" at the start of a title.
 var conventionalCommitPrefixRegex = regexp.MustCompile(`^(?i)(fix|feat|chore|docs|test|refactor|style|perf|ci|build|revert)(\([^)]+\))?:`)
 
+// parentLineRegex matches model-emitted "Parent: GH-NNN" / "Parent: #NNN" lines.
+// These are stripped from subtask descriptions by sanitizeSubtaskDescription before
+// subIssueBody stamps its own programmatic Parent: line, preventing duplicates.
+var parentLineRegex = regexp.MustCompile(`(?im)^\s*Parent:\s*(?:GH-|#)?\d+\s*$`)
+
+// autopilotMetaBlockRegex matches <!--autopilot-meta ... --> comment blocks (multiline).
+// Stripped from model-emitted descriptions so subIssueBody can stamp its own clean block.
+var autopilotMetaBlockRegex = regexp.MustCompile(`(?s)<!--autopilot-meta\b.*?-->`)
+
+// blankLineRunRegex matches three or more consecutive newlines (used to collapse gaps
+// left by sanitizeSubtaskDescription after removing lines/blocks).
+var blankLineRunRegex = regexp.MustCompile(`\n{3,}`)
+
 // subtaskActionVerbs is the allow-list of first words that identify a subtask
 // title as an action item (vs LLM analysis/prose). Kept intentionally broad to
 // cover normal engineering verbs without admitting analysis sentences.
@@ -1107,7 +1120,7 @@ func (r *Runner) createSubIssuesViaAdapter(ctx context.Context, plan *EpicPlan) 
 
 	for _, subtask := range plan.Subtasks {
 		// Build the issue body
-		body := subtask.Description
+		body := sanitizeSubtaskDescription(subtask.Description)
 		if plan.ParentTask.ID != "" {
 			body = subIssueBody(plan.ParentTask.ID, body)
 		}
@@ -1225,6 +1238,19 @@ for context, but do NOT implement parts of it that fall outside this subtask.`,
 		parentID, description)
 }
 
+// sanitizeSubtaskDescription strips model-emitted noise from a subtask description
+// before it is embedded into a sub-issue body via subIssueBody. Specifically:
+//   - <!--autopilot-meta ... --> blocks are removed (subIssueBody stamps its own)
+//   - "Parent: GH-NNN" / "Parent: #NNN" lines are removed (same reason)
+//
+// Runs of 3+ newlines left by removals are collapsed to a single blank line.
+func sanitizeSubtaskDescription(description string) string {
+	description = autopilotMetaBlockRegex.ReplaceAllString(description, "")
+	description = parentLineRegex.ReplaceAllString(description, "")
+	description = blankLineRunRegex.ReplaceAllString(description, "\n\n")
+	return strings.TrimSpace(description)
+}
+
 // createSubIssuesViaGitHub creates sub-issues using the gh CLI.
 // This is the original implementation and fallback path.
 //
@@ -1248,7 +1274,7 @@ func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, e
 
 	for _, subtask := range plan.Subtasks {
 		// Build the issue body
-		body := subtask.Description
+		body := sanitizeSubtaskDescription(subtask.Description)
 		if plan.ParentTask != nil && plan.ParentTask.ID != "" {
 			body = subIssueBody(plan.ParentTask.ID, body)
 		}

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2838,3 +2838,90 @@ func TestIsParentDoneSkip(t *testing.T) {
 		}
 	}
 }
+
+// TestSanitizeSubtaskDescription verifies that model-emitted Parent: lines and
+// <!--autopilot-meta ... --> blocks are stripped from subtask descriptions before
+// they are embedded into sub-issue bodies.
+func TestSanitizeSubtaskDescription(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain description unchanged",
+			input: "Add rate limiting to the API endpoints",
+			want:  "Add rate limiting to the API endpoints",
+		},
+		{
+			name:  "strips bare Parent: GH-NNN line",
+			input: "Parent: GH-123\n\nAdd rate limiting to the API endpoints",
+			want:  "Add rate limiting to the API endpoints",
+		},
+		{
+			name:  "strips Parent: #NNN variant",
+			input: "Parent: #456\n\nFix the login bug",
+			want:  "Fix the login bug",
+		},
+		{
+			name:  "strips Parent: NNN (no prefix)",
+			input: "Some description\n\nParent: 789\n\nMore text",
+			want:  "Some description\n\nMore text",
+		},
+		{
+			name:  "case-insensitive: PARENT:",
+			input: "PARENT: GH-42\n\nDo the thing",
+			want:  "Do the thing",
+		},
+		{
+			name:  "strips autopilot-meta single-line block",
+			input: "<!--autopilot-meta parent: GH-1 inherited-spec: true -->\n\nDo the thing",
+			want:  "Do the thing",
+		},
+		{
+			name: "strips autopilot-meta multiline block",
+			input: `<!--autopilot-meta
+parent: GH-100
+inherited-spec: true
+-->
+
+Do the thing`,
+			want: "Do the thing",
+		},
+		{
+			name: "strips both autopilot-meta block and Parent: line",
+			input: `<!--autopilot-meta
+parent: GH-200
+inherited-spec: true
+-->
+
+Parent: GH-200
+
+Implement the feature`,
+			want: "Implement the feature",
+		},
+		{
+			name:  "collapses extra blank lines after stripping",
+			input: "First paragraph\n\nParent: GH-1\n\n\n\nSecond paragraph",
+			want:  "First paragraph\n\nSecond paragraph",
+		},
+		{
+			name:  "empty description stays empty",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "leading/trailing whitespace trimmed",
+			input: "\n\nParent: GH-5\n\nSome work\n\n",
+			want:  "Some work",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeSubtaskDescription(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeSubtaskDescription(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `sanitizeSubtaskDescription(description string) string` in `internal/executor/epic.go`
- Strips `Parent: GH-NNN` / `Parent: #NNN` lines (case-insensitive) using `parentLineRegex`
- Removes `<!--autopilot-meta ... -->` blocks (multiline) using `autopilotMetaBlockRegex`
- Collapses 3+ consecutive newlines left by removals via `blankLineRunRegex`
- Wired at both `createSubIssuesViaAdapter` and `createSubIssuesViaGitHub` before `subIssueBody` is called, preventing duplicate `Parent:` lines and stale meta blocks in sub-issue bodies

## Test plan

- [ ] `TestSanitizeSubtaskDescription` — 11 table-driven cases covering all strip patterns, case-insensitivity, blank-line collapse, and passthrough of clean descriptions
- [ ] `go test ./internal/executor/... -short` passes (33s, no regressions)
- [ ] `golangci-lint run --new-from-rev=origin/main ./internal/executor/...` — 0 issues