### PR TITLE
GH-3587: chore(decomposer): verify sanitizer behavior and commit

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1208,6 +1208,7 @@ func (r *Runner) createSubIssuesViaAdapter(ctx context.Context, plan *EpicPlan) 
 // so every sibling re-implements the entire feature and the redundant PRs
 // collide. The fence pins the executor to this subtask's slice.
 func subIssueBody(parentID, description string) string {
+	description = sanitizeSubtaskDescription(description)
 	return fmt.Sprintf(`<!--autopilot-meta
 parent: %[1]s
 inherited-spec: true
@@ -1223,6 +1224,30 @@ Implement ONLY the slice described above. The parent issue %[1]s is decomposed
 into sibling sub-issues that cover the rest of its spec — consult the parent
 for context, but do NOT implement parts of it that fall outside this subtask.`,
 		parentID, description)
+}
+
+// sanitizeSubtaskDescription removes parent-reference artefacts that the
+// decomposing LLM may have echoed into a subtask description.
+//
+// Strips:
+//   - <!--autopilot-meta ... --> HTML comment blocks (subIssueBody re-stamps
+//     the correct one programmatically)
+//   - Bare "Parent: GH-N" / "Parent: #N" lines (subIssueBody re-stamps the
+//     correct programmatic reference)
+//
+// Without this, a model-emitted Parent: pointing at the wrong issue number
+// would survive into the final body and cause ParseParentIssueNumber to
+// return a stale or foreign parent — breaking epic grouping and the
+// inherited-spec bailout.
+var (
+	sanitizeMetaBlockRe  = regexp.MustCompile(`(?s)<!--autopilot-meta.*?-->`)
+	sanitizeParentLineRe = regexp.MustCompile(`(?m)^Parent:\s*(?:GH-|#)\d+[^\n]*\n?`)
+)
+
+func sanitizeSubtaskDescription(description string) string {
+	description = sanitizeMetaBlockRe.ReplaceAllString(description, "")
+	description = sanitizeParentLineRe.ReplaceAllString(description, "")
+	return strings.TrimSpace(description)
 }
 
 // createSubIssuesViaGitHub creates sub-issues using the gh CLI.

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2820,6 +2820,122 @@ func TestRunner_Execute_EpicRejectsForeignParentPlan(t *testing.T) {
 	}
 }
 
+// TestSanitizeSubtaskDescription verifies that model-emitted parent artefacts
+// are stripped before the description is embedded in a sub-issue body (TASK-364
+// Hole 4).
+func TestSanitizeSubtaskDescription(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "clean description unchanged",
+			in:   "Implement the store layer.",
+			want: "Implement the store layer.",
+		},
+		{
+			name: "strips bare Parent: GH- line",
+			in:   "Parent: GH-201\n\nImplement the store layer.",
+			want: "Implement the store layer.",
+		},
+		{
+			name: "strips bare Parent: # line",
+			in:   "Parent: #201\n\nImplement the store layer.",
+			want: "Implement the store layer.",
+		},
+		{
+			name: "strips multiline autopilot-meta block",
+			in:   "<!--autopilot-meta\nparent: GH-999\ninherited-spec: true\n-->\n\nImplement the store layer.",
+			want: "Implement the store layer.",
+		},
+		{
+			name: "strips inline autopilot-meta block",
+			in:   "<!--autopilot-meta parent: GH-999 -->\n\nImplement the store layer.",
+			want: "Implement the store layer.",
+		},
+		{
+			name: "strips both meta block and bare Parent line",
+			in:   "<!--autopilot-meta\nparent: GH-999\n-->\n\nParent: GH-999\n\nImplement the store layer.",
+			want: "Implement the store layer.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeSubtaskDescription(tt.in)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSubIssueBody_ExactlyOneParentLine verifies that subIssueBody produces
+// exactly one programmatic Parent: line even when the input description
+// contains model-emitted parent references.
+func TestSubIssueBody_ExactlyOneParentLine(t *testing.T) {
+	parentLineRe := regexp.MustCompile(`(?m)^Parent:\s*GH-\d+`)
+
+	tests := []struct {
+		name        string
+		parentID    string
+		description string
+	}{
+		{
+			name:        "description with bare Parent: line claiming wrong parent",
+			parentID:    "GH-300",
+			description: "Parent: GH-201\n\nImplement the store layer.",
+		},
+		{
+			name:        "description with autopilot-meta block claiming wrong parent",
+			parentID:    "GH-300",
+			description: "<!--autopilot-meta\nparent: GH-999\ninherited-spec: true\n-->\n\nImplement the store layer.",
+		},
+		{
+			name:        "clean description",
+			parentID:    "GH-300",
+			description: "Implement the store layer.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := subIssueBody(tt.parentID, tt.description)
+
+			matches := parentLineRe.FindAllString(body, -1)
+			if len(matches) != 1 {
+				t.Errorf("expected exactly 1 Parent: line, got %d; body = %q", len(matches), body)
+				return
+			}
+			if !strings.Contains(matches[0], tt.parentID) {
+				t.Errorf("Parent: line references wrong parent; got %q, want %q in it", matches[0], tt.parentID)
+			}
+			if !strings.Contains(body, "Implement the store layer.") {
+				t.Errorf("body missing description content; body = %q", body)
+			}
+		})
+	}
+}
+
+// TestSubIssueBody_ParseParentExtractsCorrectParent verifies that the
+// parentRefRegex (mirroring github.ParseParentIssueNumber) extracts the
+// programmatic parent even when the description contained a conflicting
+// model-emitted reference.
+func TestSubIssueBody_ParseParentExtractsCorrectParent(t *testing.T) {
+	parentRefRe := regexp.MustCompile(`(?m)^Parent:\s*(?:GH-|#)(\d+)`)
+
+	description := "Parent: GH-201\n\nImplement the store layer."
+	body := subIssueBody("GH-300", description)
+
+	matches := parentRefRe.FindStringSubmatch(body)
+	if len(matches) < 2 {
+		t.Fatalf("no Parent: reference found in body; body = %q", body)
+	}
+	if matches[1] != "300" {
+		t.Errorf("ParseParentIssueNumber equivalent returns %s, want 300; body = %q", matches[1], body)
+	}
+}
+
 // GH-3513 wave 2: IsParentDoneSkip must detect the ErrParentDone guard through
 // the wrapped text it acquires crossing the runner/dispatcher/DB boundaries.
 func TestIsParentDoneSkip(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3587.

Closes #3587

## Changes

Run make test and make lint to confirm clean. Commit as fix(executor): sanitize model-emitted parent refs in subtask bodies TASK-364.