### PR TITLE
fix(executor): rehydrate recovered sub-issues and refuse empty-description execution

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -897,7 +897,7 @@ func recoverExistingSubIssues(ctx context.Context, dir, parentID string) ([]Crea
 		"issue", "list",
 		"--state", "all",
 		"--search", fmt.Sprintf("\"Parent: %s\" in:body", parentID),
-		"--json", "number,url,state",
+		"--json", "number,url,state,title,body",
 		"--limit", "50",
 	}
 	cmd := exec.CommandContext(ctx, "gh", args...)
@@ -913,6 +913,8 @@ func recoverExistingSubIssues(ctx context.Context, dir, parentID string) ([]Crea
 		Number int    `json:"number"`
 		URL    string `json:"url"`
 		State  string `json:"state"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
 		return nil, nil
@@ -924,6 +926,10 @@ func recoverExistingSubIssues(ctx context.Context, dir, parentID string) ([]Crea
 			Identifier: strconv.Itoa(r.Number),
 			URL:        r.URL,
 			State:      r.State,
+			Subtask: PlannedSubtask{
+				Title:       r.Title,
+				Description: r.Body,
+			},
 		})
 	}
 	return out, nil
@@ -1536,6 +1542,20 @@ func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []Cr
 			// Fallback (shouldn't happen)
 			taskID = "unknown"
 			issueRef = "unknown"
+		}
+
+		// Refuse to dispatch a child with no task description — a recovered child
+		// whose Subtask was never rehydrated would produce an empty-prompt run.
+		if strings.TrimSpace(issue.Subtask.Description) == "" {
+			r.log.Error("sub-issue has no task description — skipping to avoid empty-prompt run",
+				"parent_id", parent.ID,
+				"sub_issue", issueRef,
+			)
+			skipNote := "recovered child has no task description — manual dispatch needed"
+			_ = r.UpdateIssueProgress(ctx, projectPath, issueRef, skipNote)
+			_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID,
+				fmt.Sprintf("⚠️ Skipped sub-issue #%s: no task description (manual dispatch needed)", issueRef))
+			continue
 		}
 
 		// Update parent with current progress

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -2440,10 +2441,13 @@ func TestRunner_Execute_EpicRecoversThenExecutesOpenChildren(t *testing.T) {
 	}
 
 	// Mix of open and closed children — only the open one should be executed.
+	// GH-3583: Subtask must be populated so the empty-description guard doesn't skip.
 	r.recoverSubIssuesFn = func(_ context.Context, _, _ string) ([]CreatedIssue, error) {
 		return []CreatedIssue{
-			{Number: 20, Identifier: "20", URL: "https://github.com/o/r/issues/20", State: "closed"},
-			{Number: 21, Identifier: "21", URL: "https://github.com/o/r/issues/21", State: "open"},
+			{Number: 20, Identifier: "20", URL: "https://github.com/o/r/issues/20", State: "closed",
+				Subtask: PlannedSubtask{Title: "feat(gateway): add websocket handler", Description: "Implement upgrade handler in internal/gateway/server.go"}},
+			{Number: 21, Identifier: "21", URL: "https://github.com/o/r/issues/21", State: "open",
+				Subtask: PlannedSubtask{Title: "feat(adapters): add telegram bot", Description: "Wire bot client in internal/adapters/telegram/bot.go"}},
 		}, nil
 	}
 
@@ -2947,5 +2951,180 @@ func TestSubIssueBody_ParseParentReturnsRealParent(t *testing.T) {
 					num, tc.wantNum, m[0])
 			}
 		})
+	}
+}
+
+// writeFakeGhJSON writes a fake "gh" binary to fakeBin that prints jsonPayload
+// to stdout. Returns the path to the script.
+func writeFakeGhJSON(t *testing.T, fakeBin string, jsonPayload []byte) {
+	t.Helper()
+	jsonFile := filepath.Join(fakeBin, "response.json")
+	if err := os.WriteFile(jsonFile, jsonPayload, 0o644); err != nil {
+		t.Fatalf("write json file: %v", err)
+	}
+	script := filepath.Join(fakeBin, "gh")
+	if err := os.WriteFile(script, []byte(fmt.Sprintf("#!/bin/sh\ncat %s\n", jsonFile)), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+}
+
+// TestRecoverExistingSubIssues_PopulatesSubtask verifies that after a daemon
+// restart, recovered sub-issues have non-empty Subtask.Title and
+// Subtask.Description sourced from the GitHub issue JSON (GH-3583).
+func TestRecoverExistingSubIssues_PopulatesSubtask(t *testing.T) {
+	tests := []struct {
+		name             string
+		issueTitle       string
+		issueBody        string
+		wantTitleContain string
+		wantDescContain  string
+	}{
+		{
+			name:             "full subIssueBody wrapper",
+			issueTitle:       "feat(auth): implement JWT service",
+			issueBody:        subIssueBody("GH-100", "Implement JWT tokens and refresh flow."),
+			wantTitleContain: "JWT service",
+			wantDescContain:  "Implement JWT tokens",
+		},
+		{
+			name:             "plain body without wrapper",
+			issueTitle:       "fix: handle nil pointer in handler",
+			issueBody:        "Fix the nil pointer dereference in the request handler.",
+			wantTitleContain: "nil pointer",
+			wantDescContain:  "nil pointer dereference",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeBin := t.TempDir()
+			raw := []map[string]interface{}{
+				{
+					"number": 42,
+					"url":    "https://github.com/owner/repo/issues/42",
+					"state":  "open",
+					"title":  tt.issueTitle,
+					"body":   tt.issueBody,
+				},
+			}
+			jsonPayload, err := json.Marshal(raw)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			writeFakeGhJSON(t, fakeBin, jsonPayload)
+			origPATH := os.Getenv("PATH")
+			t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+
+			issues, err := recoverExistingSubIssues(context.Background(), "", "GH-100")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(issues) != 1 {
+				t.Fatalf("expected 1 issue, got %d", len(issues))
+			}
+			got := issues[0]
+			if got.Subtask.Title == "" {
+				t.Error("Subtask.Title must not be empty after recovery")
+			}
+			if !strings.Contains(got.Subtask.Title, tt.wantTitleContain) {
+				t.Errorf("Subtask.Title = %q, want it to contain %q", got.Subtask.Title, tt.wantTitleContain)
+			}
+			if got.Subtask.Description == "" {
+				t.Error("Subtask.Description must not be empty after recovery")
+			}
+			if !strings.Contains(got.Subtask.Description, tt.wantDescContain) {
+				t.Errorf("Subtask.Description does not contain %q; got: %q", tt.wantDescContain, got.Subtask.Description)
+			}
+		})
+	}
+}
+
+// TestExecuteSubIssues_SkipsEmptyDescription verifies that a recovered child
+// with an empty Subtask.Description is skipped — backend Execute is never
+// called for it — rather than launching a doomed empty-prompt run (GH-3583).
+func TestExecuteSubIssues_SkipsEmptyDescription(t *testing.T) {
+	var execCalled bool
+	runner := newTestRunnerWithExecFunc(func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		execCalled = true
+		return &ExecutionResult{Success: true, PRUrl: "https://github.com/owner/repo/pull/1"}, nil
+	})
+
+	issues := []CreatedIssue{
+		{
+			Number: 55,
+			URL:    "https://github.com/owner/repo/issues/55",
+			Subtask: PlannedSubtask{
+				Title:       "feat: something",
+				Description: "", // empty — simulates unhydrated recovery
+			},
+		},
+	}
+	parent := &Task{ID: "GH-50", Title: "[epic] parent"}
+
+	err := runner.ExecuteSubIssues(context.Background(), parent, issues, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if execCalled {
+		t.Error("backend Execute must NOT be called for an empty-description child")
+	}
+}
+
+// TestRecoveryToExecutionPath_RehydratesDescription is a regression test for
+// the GH-3558 incident shape: a recovered child that previously executed with
+// an empty prompt must now carry the real issue body text through to the Task
+// passed to the backend.
+func TestRecoveryToExecutionPath_RehydratesDescription(t *testing.T) {
+	realDesc := "Add rate limiting middleware to all API endpoints using token bucket algorithm."
+	issueBody := subIssueBody("GH-200", realDesc)
+
+	// Build fake gh binary.
+	fakeBin := t.TempDir()
+	raw := []map[string]interface{}{
+		{
+			"number": 77,
+			"url":    "https://github.com/owner/repo/issues/77",
+			"state":  "open",
+			"title":  "feat(api): add rate limiting",
+			"body":   issueBody,
+		},
+	}
+	jsonPayload, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	writeFakeGhJSON(t, fakeBin, jsonPayload)
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+origPATH)
+
+	// Recover sub-issues as the daemon would after restart.
+	recovered, err := recoverExistingSubIssues(context.Background(), "", "GH-200")
+	if err != nil {
+		t.Fatalf("recoverExistingSubIssues: %v", err)
+	}
+	if len(recovered) != 1 {
+		t.Fatalf("expected 1 recovered issue, got %d", len(recovered))
+	}
+
+	// Execute the recovered child and capture the Task passed to the backend.
+	var capturedDesc string
+	runner := newTestRunnerWithExecFunc(func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		capturedDesc = task.Description
+		return &ExecutionResult{
+			Success: true,
+			PRUrl:   "https://github.com/owner/repo/pull/99",
+		}, nil
+	})
+
+	parent := &Task{ID: "GH-200", Title: "[epic] add API rate limiting"}
+	if err := runner.ExecuteSubIssues(context.Background(), parent, recovered, "", ""); err != nil {
+		t.Fatalf("ExecuteSubIssues: %v", err)
+	}
+
+	if capturedDesc == "" {
+		t.Fatal("Task.Description passed to backend must not be empty after recovery")
+	}
+	if !strings.Contains(capturedDesc, realDesc) {
+		t.Errorf("Task.Description does not contain the real issue body text\ngot:  %q\nwant it to contain: %q",
+			capturedDesc, realDesc)
 	}
 }

--- a/internal/executor/epic_worktree_integration_test.go
+++ b/internal/executor/epic_worktree_integration_test.go
@@ -175,8 +175,8 @@ func TestEpicWorktreeIsolation_ExecuteWithOptionsTracking(t *testing.T) {
 
 	// Test scenario: Execute sub-issues like epic.go does
 	subIssues := []CreatedIssue{
-		{Number: 100, Subtask: PlannedSubtask{Title: "Task 1", Order: 1}},
-		{Number: 101, Subtask: PlannedSubtask{Title: "Task 2", Order: 2}},
+		{Number: 100, Subtask: PlannedSubtask{Title: "Task 1", Description: "First task description", Order: 1}},
+		{Number: 101, Subtask: PlannedSubtask{Title: "Task 2", Description: "Second task description", Order: 2}},
 	}
 
 	parent := &Task{
@@ -346,9 +346,9 @@ func TestNoRecursiveWorktreeInDecomposedTasks(t *testing.T) {
 
 	// Execute sub-issues
 	subIssues := []CreatedIssue{
-		{Number: 300, Subtask: PlannedSubtask{Title: "Decomposed 1", Order: 1}},
-		{Number: 301, Subtask: PlannedSubtask{Title: "Decomposed 2", Order: 2}},
-		{Number: 302, Subtask: PlannedSubtask{Title: "Decomposed 3", Order: 3}},
+		{Number: 300, Subtask: PlannedSubtask{Title: "Decomposed 1", Description: "Decomposed task 1", Order: 1}},
+		{Number: 301, Subtask: PlannedSubtask{Title: "Decomposed 2", Description: "Decomposed task 2", Order: 2}},
+		{Number: 302, Subtask: PlannedSubtask{Title: "Decomposed 3", Description: "Decomposed task 3", Order: 3}},
 	}
 
 	parent := &Task{
@@ -436,7 +436,7 @@ func TestWorktreeIsolationWithNavigatorCopy(t *testing.T) {
 	}
 
 	subIssues := []CreatedIssue{
-		{Number: 400, Subtask: PlannedSubtask{Title: "Nav test", Order: 1}},
+		{Number: 400, Subtask: PlannedSubtask{Title: "Nav test", Description: "Navigator copy test task", Order: 1}},
 	}
 
 	parent := &Task{

--- a/internal/executor/sub_issue_callback_test.go
+++ b/internal/executor/sub_issue_callback_test.go
@@ -299,8 +299,8 @@ func TestExecuteSubIssues_CallbackNotFiredOnFailure(t *testing.T) {
 	}
 
 	issues := []CreatedIssue{
-		{Number: 40, Subtask: PlannedSubtask{Title: "Good task", Order: 1}},
-		{Number: 41, Subtask: PlannedSubtask{Title: "Bad task", Order: 2}},
+		{Number: 40, Subtask: PlannedSubtask{Title: "Good task", Description: "Good task description", Order: 1}},
+		{Number: 41, Subtask: PlannedSubtask{Title: "Bad task", Description: "Bad task description", Order: 2}},
 	}
 
 	err := runner.ExecuteSubIssues(context.Background(), parent, issues, parent.ProjectPath, "")
@@ -335,7 +335,7 @@ func TestExecuteSubIssues_CallbackNotFiredOnExecError(t *testing.T) {
 
 	parent := &Task{ID: "GH-90", Title: "[epic] Exec error"}
 	issues := []CreatedIssue{
-		{Number: 50, Subtask: PlannedSubtask{Title: "Task", Order: 1}},
+		{Number: 50, Subtask: PlannedSubtask{Title: "Task", Description: "Task description", Order: 1}},
 	}
 
 	err := runner.ExecuteSubIssues(context.Background(), parent, issues, parent.ProjectPath, "")


### PR DESCRIPTION
## Summary

- **Rehydrate:** `recoverExistingSubIssues` now requests `title,body` in the `gh issue list --json` call and populates `CreatedIssue.Subtask.Title`/`.Description` from them. Previously, all recovered children had a zero-value `Subtask`, causing workers to receive a prompt with nothing to implement.
- **Refuse empty:** `ExecuteSubIssues` now guards against empty `Subtask.Description` before dispatching — logs an error, posts a comment on the child ("recovered child has no task description — manual dispatch needed"), and skips the child via `continue`. This prevents the doomed empty-prompt run (3 wasted Claude runs on #3558, 2026-06-10).

Fixes the GH-3558 live incident shape (root cause: recovery path in `epic.go:895–929` never read `title`/`body` from gh output).

## Test plan

- [ ] `TestRecoverExistingSubIssues_PopulatesSubtask` — fake `gh` binary returns JSON with title+body; recovered issue carries non-empty `Subtask.Title`/`Description`
- [ ] `TestExecuteSubIssues_SkipsEmptyDescription` — child with empty description is skipped, backend `Execute` never called
- [ ] `TestRecoveryToExecutionPath_RehydratesDescription` — full regression: recovery → execution, `Task.Description` passed to backend contains the real issue body text
- [ ] Existing tests updated to include `Subtask.Description` (4 test files), reflecting the new invariant that dispatched children must have a description
- [ ] `make test` and `make lint` clean