### PR TITLE
fix(decomposer): tighten sanitizeParentLineRe to spec — case-insensitive, optional prefix, leading whitespace (GH-3584)

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1263,7 +1263,7 @@ for context, but do NOT implement parts of it that fall outside this subtask.`,
 // inherited-spec bailout.
 var (
 	sanitizeMetaBlockRe  = regexp.MustCompile(`(?s)<!--autopilot-meta.*?-->`)
-	sanitizeParentLineRe = regexp.MustCompile(`(?m)^Parent:\s*(?:GH-|#)\d+[^\n]*\n?`)
+	sanitizeParentLineRe = regexp.MustCompile(`(?im)^\s*Parent:\s*(?:GH-|#)?\d+\s*$`)
 )
 
 func sanitizeSubtaskDescription(description string) string {

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2863,6 +2863,21 @@ func TestSanitizeSubtaskDescription(t *testing.T) {
 			in:   "<!--autopilot-meta\nparent: GH-999\n-->\n\nParent: GH-999\n\nImplement the store layer.",
 			want: "Implement the store layer.",
 		},
+		{
+			name: "strips lowercase parent line (case-insensitive)",
+			in:   "parent: GH-201\n\nImplement the store layer.",
+			want: "Implement the store layer.",
+		},
+		{
+			name: "strips indented Parent line",
+			in:   "  Parent: GH-201\n\nImplement the store layer.",
+			want: "Implement the store layer.",
+		},
+		{
+			name: "strips bare Parent with no GH-/# prefix",
+			in:   "Parent: 201\n\nImplement the store layer.",
+			want: "Implement the store layer.",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes `sanitizeParentLineRe` in `internal/executor/epic.go` to match the GH-3584 spec exactly
- Old regex: `(?m)^Parent:\s*(?:GH-|#)\d+[^\n]*\n?` — missing case flag, leading whitespace, optional prefix
- New regex: `(?im)^\s*Parent:\s*(?:GH-|#)?\d+\s*$` — adds `(?i)`, `\s*` prefix, `?` on the GH-/#  group, `\s*$` end

Closes #3588 (earlier PR had the correct implementation but diverged from main before `e8aaf627`/`425b270f` landed).

## Test plan

- [x] 3 new table-driven cases in `TestSanitizeSubtaskDescription` covering the previously-untested edge cases: lowercase `parent:`, indented `  Parent:`, and bare `Parent: 201` without a GH-/# prefix
- [x] All 9 cases pass: `go test ./internal/executor/... -run TestSanitizeSubtaskDescription`
- [x] Full executor suite passes: `go test ./internal/executor/...` (30s, 0 regressions)
- [x] Build clean: `go build ./...`