### PR TITLE
fix(executor): machine-check standalone prose; ignore context-cited paths in scope guard

### DIFF
--- a/internal/executor/complexity.go
+++ b/internal/executor/complexity.go
@@ -121,8 +121,9 @@ func DetectComplexity(task *Task) Complexity {
 
 	// Check epic patterns first (these are too large for single execution)
 	if detectEpic(task.Title, task.Description, combined) {
-		// Defense-in-depth: no-decompose label prevents epic classification (GH-1568)
-		if HasLabel(task, NoDecomposeLabel) {
+		// Defense-in-depth: no-decompose label prevents epic classification (GH-1568);
+		// standalone prose like "must NOT be decomposed" gates identically (GH-3597)
+		if HasLabel(task, NoDecomposeLabel) || HasNoDecomposePhrase(task) {
 			return ComplexityComplex
 		}
 		return ComplexityEpic

--- a/internal/executor/decompose.go
+++ b/internal/executor/decompose.go
@@ -64,6 +64,12 @@ var noDecomposePhrases = []*regexp.Regexp{
 	regexp.MustCompile(`single pilot issue`),
 	regexp.MustCompile(`keep as .+ single`),
 	regexp.MustCompile(`splitting this would`),
+	// GH-3597: "must NOT be decomposed" — the way humans actually write it —
+	// reached only the planner LLM advisorily; #3582 split into 4 sub-issues
+	// despite opening with exactly this phrasing.
+	regexp.MustCompile(`(must|should) not be (decomposed|split)`),
+	regexp.MustCompile(`is a standalone task`),
+	regexp.MustCompile(`as a single pr\b`),
 	regexp.MustCompile(`<!--\s*pilot:no-decompose\s*-->`),
 }
 
@@ -134,6 +140,15 @@ func (d *TaskDecomposer) DecomposeWithContext(ctx context.Context, task *Task) *
 		}
 	}
 
+	// GH-3597: standalone prose gates exactly like the label
+	if HasNoDecomposePhrase(task) {
+		return &DecomposeResult{
+			Decomposed: false,
+			Subtasks:   []*Task{task},
+			Reason:     "skipped: no-decompose phrase in title/description",
+		}
+	}
+
 	// GH-727: Use LLM classifier if available, otherwise fall back to heuristic
 	var complexity Complexity
 	if d.classifier != nil {
@@ -193,6 +208,15 @@ func (d *TaskDecomposer) DecomposeForRetry(ctx context.Context, task *Task) *Dec
 			Decomposed: false,
 			Subtasks:   []*Task{task},
 			Reason:     "skipped: no-decompose label (even on retry)",
+		}
+	}
+
+	// GH-3597: standalone prose gates exactly like the label, even on retry
+	if HasNoDecomposePhrase(task) {
+		return &DecomposeResult{
+			Decomposed: false,
+			Subtasks:   []*Task{task},
+			Reason:     "skipped: no-decompose phrase (even on retry)",
 		}
 	}
 

--- a/internal/executor/decompose_test.go
+++ b/internal/executor/decompose_test.go
@@ -691,6 +691,13 @@ func TestHasNoDecomposePhrase(t *testing.T) {
 		{name: "keep as ... single in body", body: "Keep as one single task.", expected: true},
 		{name: "splitting this would in body", body: "Splitting this would fragment the changes.", expected: true},
 		{name: "HTML marker in body", body: "<!-- pilot:no-decompose -->", expected: true},
+		// GH-3597: standalone prose variants (the #3582 incident phrasing)
+		{name: "must not be decomposed", body: "It must NOT be decomposed into sub-issues.", expected: true},
+		{name: "must not be split", body: "This task must not be split.", expected: true},
+		{name: "should not be decomposed", body: "The work should not be decomposed further.", expected: true},
+		{name: "should not be split", body: "This should not be split across PRs.", expected: true},
+		{name: "is a standalone task", body: "This is a standalone task covering one package.", expected: true},
+		{name: "as a single PR", body: "Implement it as a single PR.", expected: true},
 		// Each canonical phrase in title → true
 		{name: "do not decompose in title", title: "do not decompose this", expected: true},
 		{name: "do not split in title", title: "do not split this", expected: true},
@@ -705,6 +712,8 @@ func TestHasNoDecomposePhrase(t *testing.T) {
 		// Phrase as unrelated substring → false
 		{name: "single word only", body: "This is a single change to a file.", expected: false},
 		{name: "split without do not", body: "We should split this into modules.", expected: false},
+		{name: "standalone without task context", body: "Build a standalone binary for darwin.", expected: false},
+		{name: "single PR mention without 'as a'", body: "The last single PR touched this file.", expected: false},
 		{name: "pilot issue without single", body: "This is a pilot issue for adding auth.", expected: false},
 		{name: "keep without single", body: "Keep as is without further changes.", expected: false},
 		// Empty → false
@@ -729,6 +738,79 @@ func TestHasNoDecomposePhrase(t *testing.T) {
 				t.Errorf("HasNoDecomposePhrase() = %v, want %v", got, tt.expected)
 			}
 		})
+	}
+}
+
+// gh3582BodyExcerpt reproduces the decision-relevant content of issue #3582
+// verbatim (markdown/backticks stripped): the standalone-prose opener that was
+// never machine-checked, a context citation of a foreign package (grouping.go),
+// and work scoped entirely to internal/executor/. The daemon split this task
+// into 4 sub-issues — the GH-3597 incident.
+const gh3582BodyExcerpt = "This is a standalone task. It must NOT be decomposed into sub-issues. Implement it as a single PR.\n\n" +
+	"## Problem\n\n" +
+	"subIssueBody() (internal/executor/epic.go, ~line 1210) stamps the Parent: reference and autopilot-meta block programmatically — but the model-written subtask description it embeds is NOT sanitized. When the planner LLM emits its own Parent: GH-N line, the assembled body carries TWO parent claims:\n\n" +
+	"- ParseParentIssueNumber (internal/adapters/github/grouping.go:38, regex ^Parent:\\s*(?:GH-|#)(\\d+)) can resolve the wrong one,\n" +
+	"- recovery searches (queryRecentSubIssues, recoverExistingSubIssues in epic.go) match the child into a FOREIGN epic's recovery set → cross-epic contamination.\n\n" +
+	"## Fix\n\n" +
+	"In internal/executor/epic.go:\n\n" +
+	"1. Add sanitizeSubtaskDescription(description string) string that removes parent lines and autopilot-meta blocks from model-supplied descriptions.\n" +
+	"2. Call it on the description at BOTH body-assembly call sites of subIssueBody(...).\n\n" +
+	"## Tests (table-driven, internal/executor/epic_test.go)\n\n" +
+	"- description containing Parent: GH-201 → assembled body contains exactly ONE Parent: line\n"
+
+// TestGH3582StandaloneBody_NeverDecomposes is the GH-3597 acceptance test:
+// re-filing #3582's body (prose only — no label, no HTML marker) must classify
+// as single-task execution at every gate.
+func TestGH3582StandaloneBody_NeverDecomposes(t *testing.T) {
+	task := &Task{
+		ID:          "GH-3582",
+		Title:       "Sanitize model-emitted parent refs in subtask bodies",
+		Description: gh3582BodyExcerpt,
+	}
+
+	if !HasNoDecomposePhrase(task) {
+		t.Fatal("expected standalone prose to match noDecomposePhrases")
+	}
+	if c := DetectComplexity(task); c == ComplexityEpic {
+		t.Errorf("DetectComplexity() = %v, want non-epic for standalone-prose body", c)
+	}
+
+	decomposer := NewTaskDecomposer(&DecomposeConfig{
+		Enabled:       true,
+		MinComplexity: "complex",
+		MaxSubtasks:   5,
+	})
+	result := decomposer.Decompose(task)
+	if result.Decomposed {
+		t.Errorf("Decompose() split a standalone-prose task: %s", result.Reason)
+	}
+	if result.Reason != "skipped: no-decompose phrase in title/description" {
+		t.Errorf("Unexpected reason: %q", result.Reason)
+	}
+}
+
+func TestDecomposeForRetry_RespectsNoDecomposePhrase(t *testing.T) {
+	decomposer := NewTaskDecomposer(&DecomposeConfig{
+		Enabled:     true,
+		MaxSubtasks: 5,
+	})
+
+	task := &Task{
+		ID:    "GH-3582",
+		Title: "Implement auth system",
+		Description: `This must not be split.
+1. Add user model
+2. Add login endpoint
+3. Add session middleware`,
+	}
+
+	result := decomposer.DecomposeForRetry(nil, task)
+
+	if result.Decomposed {
+		t.Error("Expected DecomposeForRetry to respect no-decompose phrase")
+	}
+	if result.Reason != "skipped: no-decompose phrase (even on retry)" {
+		t.Errorf("Unexpected reason: %q", result.Reason)
 	}
 }
 

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -390,25 +390,32 @@ func consolidateEpicPlan(originalDesc string, subtasks []PlannedSubtask) string 
 // would cause merge conflicts because each sub-issue branches from main independently.
 //
 // Detection strategy:
-// 1. Extract all file paths mentioned across subtask titles and descriptions
+// 1. Extract file paths from subtask titles and descriptions — they define the
+//    actual work scope. Paths cited only in the parent description are context
+//    (e.g. code being defended against) and must not flip the verdict (GH-3597:
+//    #3582 cited grouping.go as context while all work was in internal/executor/,
+//    which bypassed this guard and caused a 4-way split of a single-PR task).
 // 2. Compute unique parent directories
-// 3. If only 1 directory (or 0 files found), consider it single-package scope
+// 3. If only 1 directory → single-package scope. If subtasks cite no paths,
+//    fall back to the parent description, then to the title heuristic.
 //
 // GH-1265: This prevents the "serial conflict cascade" bug where N sub-issues
 // all touching cmd/pilot/ create N branches from main, each redeclaring shared types.
 func isSinglePackageScope(subtasks []PlannedSubtask, taskDescription string) bool {
-	// Collect all text to scan for file references
-	var allText strings.Builder
-	allText.WriteString(taskDescription)
-	allText.WriteString("\n")
+	var subtaskText strings.Builder
 	for _, st := range subtasks {
-		allText.WriteString(st.Title)
-		allText.WriteString("\n")
-		allText.WriteString(st.Description)
-		allText.WriteString("\n")
+		subtaskText.WriteString(st.Title)
+		subtaskText.WriteString("\n")
+		subtaskText.WriteString(st.Description)
+		subtaskText.WriteString("\n")
 	}
 
-	dirs := extractUniqueDirectories(allText.String())
+	dirs := extractUniqueDirectories(subtaskText.String())
+
+	// Subtasks cite no paths — fall back to the parent description (GH-1265 behavior)
+	if len(dirs) == 0 {
+		dirs = extractUniqueDirectories(taskDescription)
+	}
 
 	// If we found file references and they all point to 1 directory → single package
 	if len(dirs) == 1 {

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -387,6 +387,30 @@ func TestIsSinglePackageScope(t *testing.T) {
 			description: "Cross-cutting change",
 			expected:    false,
 		},
+		{
+			// GH-3597: #3582 cited internal/adapters/github/grouping.go:38 as
+			// context (the parser being defended against) while every subtask's
+			// work was in internal/executor/ — the union of description+subtask
+			// paths saw 2 directories and bypassed the guard, splitting a
+			// single-PR task into 4 sub-issues.
+			name: "context-cited foreign path in parent description does not flip verdict (GH-3597)",
+			subtasks: []PlannedSubtask{
+				{Title: "Add sanitizeSubtaskDescription helper", Description: "Add the sanitizer in internal/executor/epic.go"},
+				{Title: "Wire sanitizer into body assembly", Description: "Call it at both subIssueBody call sites in internal/executor/epic.go"},
+				{Title: "Add table-driven tests", Description: "Cover parent-line and meta-block removal in internal/executor/epic_test.go"},
+			},
+			description: "Defend against ParseParentIssueNumber (internal/adapters/github/grouping.go:38) resolving a model-emitted parent claim. All work is in internal/executor/epic.go.",
+			expected:    true,
+		},
+		{
+			name: "subtasks genuinely span packages regardless of description",
+			subtasks: []PlannedSubtask{
+				{Title: "Update store", Description: "Modify internal/memory/store.go"},
+				{Title: "Update server", Description: "Modify internal/gateway/server.go"},
+			},
+			description: "Per the spec, persistence work lives in internal/memory/store.go.",
+			expected:    false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #3597 (MANUAL fix — decomposition machinery, TASK-320 B2 rationale).

## What

Two of the three stacked causes from the GH-3582 incident:

**(a) Honor the prose.** `noDecomposePhrases` (GH-2783) lacked the phrasing humans actually write — #3582 opened with "It must NOT be decomposed into sub-issues" and matched nothing. Added:

- `(must|should) not be (decomposed|split)`
- `is a standalone task`
- `as a single pr\b`

and wired `HasNoDecomposePhrase` into every gate where the label is checked: `Decompose()`, `DecomposeForRetry()` (decompose.go), and the epic downgrade in `DetectComplexity` (complexity.go:124). Prose is now equivalent to the `no-decompose` label. The runner epic gate (runner.go:1574) already consulted it.

**(c) Don't count context citations.** `isSinglePackageScope` (epic.go) unioned parent-description paths with subtask paths, so #3582's context citation of `internal/adapters/github/grouping.go:38` flipped a single-package plan (all work in `internal/executor/`) to multi-package → 4 sub-issues. The verdict is now driven by subtask-cited paths; the parent description is only consulted when subtasks cite no paths (preserving GH-1265 behavior, confirmed by the existing "files in description only" test case).

Fix direction **(b)** (planner self-contradiction collapse) intentionally not included — (a) alone gates the #3582 class at three layers before planning even starts.

## Acceptance (from the issue)

> Re-filing #3582's exact body (prose, no label/marker) classifies as single-task execution — zero sub-issues created.

`TestGH3582StandaloneBody_NeverDecomposes` asserts this with a verbatim excerpt of #3582's body: prose matches, `DetectComplexity` ≠ epic, `Decompose()` refuses. `TestIsSinglePackageScope` gains the context-cited-path case plus a genuine multi-package counter-case.

## Verification

- `make test-short` — ok (full `internal/executor` package also green un-short)
- `make lint` — 0 issues

Once merged, the interim "label every standalone issue `no-decompose`" rule can be retired.