### PR TITLE
fix(upgrade): two-phase hot-upgrade state + boot verification + durable dashboard logging

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -198,6 +198,37 @@ Examples:
 				}
 			}
 
+			// GH-3600: in dashboard mode daemon logs must not hit the terminal,
+			// but discarding them hid a failed hot restart entirely — redirect to
+			// a rotating file instead (logging.dashboard_log; "off" = old discard
+			// behavior). Must run BEFORE runner/gateway creation (GH-190/GH-351:
+			// components cache their logger) and before the reconciliation below
+			// so its outcome is durably logged.
+			if dashboardMode {
+				setupDashboardLogging(cfg)
+			}
+
+			// GH-3600: verify whether a pending upgrade actually took effect —
+			// the running version vs the state file is the ground truth; the
+			// PILOT_RESTARTED marker only tells how the restart happened.
+			bootReconcile, _ := upgrade.ReconcileBootState(version, "")
+			switch bootReconcile.Outcome {
+			case upgrade.BootUpgradeVerified:
+				via := "manual restart"
+				if bootReconcile.HotExec {
+					via = "hot restart"
+				}
+				logging.WithComponent("upgrade").Info("upgrade verified complete",
+					"from", bootReconcile.PreviousVersion,
+					"to", bootReconcile.NewVersion,
+					"via", via)
+			case upgrade.BootRestartFailed:
+				logging.WithComponent("upgrade").Error("previous upgrade did NOT take effect — still running old version",
+					"running", version,
+					"expected", bootReconcile.NewVersion,
+					"error", bootReconcile.RestartError)
+			}
+
 			// GH-879: Log config reload on hot upgrade
 			// After syscall.Exec, the new binary starts fresh and re-reads config from disk
 			if os.Getenv("PILOT_RESTARTED") == "1" {
@@ -294,7 +325,7 @@ Examples:
 
 			hasPollingAdapter := hasTelegram || hasGithubPolling
 			if noGateway || hasPollingAdapter {
-				return runPollingMode(cmd, cfg, projectPath, replace, dashboardMode, noGateway)
+				return runPollingMode(cmd, cfg, projectPath, replace, dashboardMode, noGateway, bootReconcile)
 			}
 
 			// Full daemon mode with gateway
@@ -302,10 +333,8 @@ Examples:
 				return fmt.Errorf("invalid config: %w", err)
 			}
 
-			// Suppress logging in dashboard mode BEFORE initialization (GH-351)
-			if dashboardMode {
-				logging.Suppress()
-			}
+			// Dashboard-mode log redirect already happened above (GH-3600),
+			// before initialization (GH-351 ordering preserved).
 
 			// Build Pilot options for gateway mode (GH-349)
 			var pilotOpts []pilot.Option
@@ -1330,10 +1359,36 @@ func applyTeamOverrides(cfg *config.Config, cmd *cobra.Command, teamID, teamMemb
 	}
 }
 
+// setupDashboardLogging redirects daemon logs to a rotating file in TUI
+// dashboard mode (GH-3600) so upgrade/restart failures stay diagnosable.
+// logging.dashboard_log config: "" = default ~/.pilot/logs/daemon.log,
+// "off" = discard (pre-GH-3600 behavior), anything else = custom path.
+// Falls back to Suppress on error — an unwritable log path must not corrupt
+// the TUI.
+func setupDashboardLogging(cfg *config.Config) {
+	path := logging.DefaultDaemonLogPath()
+	var rotation *logging.RotationConfig
+	if cfg.Logging != nil {
+		if cfg.Logging.DashboardLog == "off" {
+			logging.Suppress()
+			return
+		}
+		if cfg.Logging.DashboardLog != "" {
+			path = cfg.Logging.DashboardLog
+		}
+		rotation = cfg.Logging.Rotation
+	}
+	if err := logging.RedirectToFile(path, rotation); err != nil {
+		logging.Suppress()
+	}
+}
+
 // runPollingMode runs lightweight polling-only mode.
 // When noGateway is false, the HTTP gateway starts in the background so the
 // desktop app (and any other client hitting /health) can reach the daemon.
-func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, replace, dashboardMode, noGateway bool) error {
+// bootReconcile carries the GH-3600 upgrade verification outcome for the
+// dashboard to surface; may be nil.
+func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, replace, dashboardMode, noGateway bool, bootReconcile *upgrade.BootReconcileResult) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1349,11 +1404,9 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		cfg.Adapters.Slack.SocketMode = false
 	}
 
-	// Suppress logging BEFORE creating runner in dashboard mode (GH-190)
-	// Runner caches its logger at creation time, so suppression must happen first
-	if dashboardMode {
-		logging.Suppress()
-	}
+	// Dashboard-mode log redirect already happened in the start command before
+	// this call (GH-3600), which preserves the GH-190 ordering: the runner
+	// below caches its logger at creation time, so the redirect must precede it.
 
 	// Create runner with config (GH-956: enables worktree isolation, decomposer, model routing)
 	runner, err := executor.NewRunnerWithConfig(cfg.Executor)
@@ -2808,9 +2861,25 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				program.Send(dashboard.AddLog("🎮 Discord gateway enabled")())
 			}
 
-			// Check for restart marker (set by hot upgrade)
-			// GH-879: Config is automatically reloaded because syscall.Exec starts a fresh process
-			if os.Getenv("PILOT_RESTARTED") == "1" {
+			// GH-3600: surface upgrade verification — running version vs the
+			// state file is the ground truth, not the env marker alone.
+			// GH-879: config is reloaded automatically because exec starts a
+			// fresh process.
+			switch {
+			case bootReconcile != nil && bootReconcile.Outcome == upgrade.BootUpgradeVerified:
+				via := "manual restart"
+				if bootReconcile.HotExec {
+					via = "hot restart, config reloaded"
+				}
+				program.Send(dashboard.AddLog(fmt.Sprintf("✅ Upgrade complete: %s → %s (%s)",
+					bootReconcile.PreviousVersion, bootReconcile.NewVersion, via))())
+			case bootReconcile != nil && bootReconcile.Outcome == upgrade.BootRestartFailed:
+				// Drives the sticky "! UPGRADE FAILED" panel.
+				program.Send(dashboard.NotifyUpgradeComplete(false, fmt.Sprintf(
+					"Upgrade to %s did not take effect — still running %s. See ~/.pilot/logs/daemon.log",
+					bootReconcile.NewVersion, version))())
+			case os.Getenv("PILOT_RESTARTED") == "1":
+				// Legacy: restart marker without a reconcilable state file
 				prevVersion := os.Getenv("PILOT_PREVIOUS_VERSION")
 				if prevVersion != "" {
 					program.Send(dashboard.AddLog(fmt.Sprintf("✅ Upgraded from %s to %s (config reloaded)", prevVersion, version))())

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -2859,6 +2859,9 @@ func (m Model) renderUpdateNotification() string {
 		} else {
 			content.WriteString("  " + m.upgradeMessage)
 		}
+		// GH-3600: a failed upgrade means the old binary is still running —
+		// say so explicitly and point at the durable log.
+		content.WriteString(fmt.Sprintf("\n  Daemon still running %s — see ~/.pilot/logs/daemon.log", m.version))
 
 	default:
 		return ""

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sync"
 )
 
@@ -39,6 +40,12 @@ type Config struct {
 	Format   string          `yaml:"format"`   // json, text
 	Output   string          `yaml:"output"`   // stdout, stderr, or file path
 	Rotation *RotationConfig `yaml:"rotation"` // Log rotation settings
+
+	// DashboardLog controls where daemon logs go in TUI dashboard mode, where
+	// terminal output would corrupt the display (GH-3600). "" = default file
+	// (~/.pilot/logs/daemon.log), "off" = discard (pre-GH-3600 behavior),
+	// anything else = custom file path.
+	DashboardLog string `yaml:"dashboard_log"`
 }
 
 // RotationConfig holds log rotation settings.
@@ -101,6 +108,38 @@ func Suppress() {
 
 	// Also set the global slog default to suppress any direct slog.Info() calls
 	slog.SetDefault(discardLogger)
+}
+
+// DefaultDaemonLogPath returns the default dashboard-mode log file,
+// ~/.pilot/logs/daemon.log.
+func DefaultDaemonLogPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".pilot", "logs", "daemon.log")
+}
+
+// RedirectToFile sends the global logger AND slog's default to a rotating
+// file. Used in TUI dashboard mode instead of Suppress so daemon events —
+// upgrade/restart failures in particular (GH-3600) — stay diagnosable.
+// Process-global via slog.SetDefault: only call from dashboard-mode startup,
+// never from library code.
+func RedirectToFile(path string, rotation *RotationConfig) error {
+	writer, err := newRotatingWriter(path, rotation)
+	if err != nil {
+		return err
+	}
+
+	fileLogger := slog.New(slog.NewTextHandler(writer, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	loggerMu.Lock()
+	defaultLogger = fileLogger
+	loggerMu.Unlock()
+
+	// Bare slog.Info()/slog.Error() calls (e.g. internal/upgrade) must land in
+	// the file too.
+	slog.SetDefault(fileLogger)
+	return nil
 }
 
 // parseLevel converts a string level to slog.Level.

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -641,3 +641,50 @@ func TestLogLevelsWithArguments(t *testing.T) {
 		}
 	}
 }
+
+// GH-3600: dashboard mode redirects logs to a file instead of discarding them
+// so upgrade/restart failures stay diagnosable.
+func TestRedirectToFile(t *testing.T) {
+	origDefault := slog.Default()
+	loggerMu.RLock()
+	origPackage := defaultLogger
+	loggerMu.RUnlock()
+	defer func() {
+		slog.SetDefault(origDefault)
+		loggerMu.Lock()
+		defaultLogger = origPackage
+		loggerMu.Unlock()
+	}()
+
+	path := filepath.Join(t.TempDir(), "logs", "daemon.log")
+	if err := RedirectToFile(path, nil); err != nil {
+		t.Fatalf("RedirectToFile() error = %v", err)
+	}
+
+	// Both bare slog (used by internal/upgrade) and the package logger must land in the file.
+	slog.Info("bare slog message")
+	Logger().Info("package logger message")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	for _, want := range []string{"bare slog message", "package logger message"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("log file missing %q; got:\n%s", want, data)
+		}
+	}
+}
+
+func TestRedirectToFile_InvalidPath(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Parent "directory" is a regular file — MkdirAll must fail.
+	if err := RedirectToFile(filepath.Join(blocker, "daemon.log"), nil); err == nil {
+		t.Error("RedirectToFile() expected error for unwritable path")
+	}
+}

--- a/internal/upgrade/graceful.go
+++ b/internal/upgrade/graceful.go
@@ -49,6 +49,12 @@ type UpgradeOptions struct {
 
 	// OnProgress callback for progress updates
 	OnProgress func(pct int, msg string)
+
+	// MarkAwaitingRestart records the install as awaiting_restart instead of
+	// completed (GH-3600). The hot path sets it because a process restart is
+	// still expected after install; the CLI path leaves it false — there,
+	// "completed" correctly means install done with no restart expected (GH-272).
+	MarkAwaitingRestart bool
 }
 
 // DefaultUpgradeOptions returns default upgrade options
@@ -115,8 +121,14 @@ func (g *GracefulUpgrader) PerformUpgrade(ctx context.Context, release *Release,
 		return err
 	}
 
-	// Mark completed
-	state.MarkCompleted()
+	// Mark completed — or awaiting_restart when the caller still has a process
+	// restart ahead (GH-3600: a hot upgrade whose exec fails must never read
+	// as completed on disk).
+	if opts.MarkAwaitingRestart {
+		state.MarkAwaitingRestart()
+	} else {
+		state.MarkCompleted()
+	}
 	if err := state.Save(g.statePath); err != nil {
 		return fmt.Errorf("failed to save completion state: %w", err)
 	}

--- a/internal/upgrade/graceful_test.go
+++ b/internal/upgrade/graceful_test.go
@@ -110,6 +110,53 @@ func TestGracefulUpgrader_PerformUpgrade_NoTasks(t *testing.T) {
 	}
 }
 
+// GH-3600: the hot path expects a restart after install — state must read
+// awaiting_restart, never completed, until boot reconciliation verifies it.
+func TestGracefulUpgrader_PerformUpgrade_MarkAwaitingRestart(t *testing.T) {
+	tc := &mockTaskChecker{}
+	g, dir := newTestGracefulUpgrader(t, tc)
+
+	newBinary := []byte("new-binary-v2")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(newBinary)
+	}))
+	defer server.Close()
+
+	g.upgrader.httpClient = server.Client()
+
+	release := &Release{
+		TagName: "v2.0.0",
+		Assets: []Asset{
+			{
+				Name:               fmt.Sprintf("pilot-%s-%s", runtime.GOOS, runtime.GOARCH),
+				BrowserDownloadURL: server.URL + "/pilot",
+				Size:               int64(len(newBinary)),
+			},
+		},
+	}
+
+	opts := &UpgradeOptions{
+		WaitForTasks:        false,
+		Force:               true,
+		MarkAwaitingRestart: true,
+	}
+
+	if err := g.PerformUpgrade(context.Background(), release, opts); err != nil {
+		t.Fatalf("PerformUpgrade() error = %v", err)
+	}
+
+	state, err := LoadState(filepath.Join(dir, "upgrade-state.json"))
+	if err != nil || state == nil {
+		t.Fatalf("LoadState() = %v, %v", state, err)
+	}
+	if state.Status != StatusAwaitingRestart {
+		t.Errorf("state.Status = %q, want %q", state.Status, StatusAwaitingRestart)
+	}
+	if !state.UpgradeCompleted.IsZero() {
+		t.Error("UpgradeCompleted should stay zero until boot reconciliation promotes the state")
+	}
+}
+
 func TestGracefulUpgrader_PerformUpgrade_DefaultOpts(t *testing.T) {
 	tc := &mockTaskChecker{}
 	g, _ := newTestGracefulUpgrader(t, tc)

--- a/internal/upgrade/hot.go
+++ b/internal/upgrade/hot.go
@@ -104,6 +104,10 @@ func (h *HotUpgrader) PerformHotUpgrade(ctx context.Context, release *Release, c
 	upgradeOpts := &UpgradeOptions{
 		WaitForTasks: false, // Already handled above
 		Force:        true,  // Skip task check in graceful upgrader
+		// GH-3600: a restart is still ahead (exec below, or a manual restart on
+		// Windows) — state must read awaiting_restart, not completed, until the
+		// restarted process verifies the running version at boot.
+		MarkAwaitingRestart: true,
 		OnProgress: func(pct int, msg string) {
 			// Scale from 25-90%
 			scaledPct := 25 + (pct * 65 / 100)
@@ -116,7 +120,7 @@ func (h *HotUpgrader) PerformHotUpgrade(ctx context.Context, release *Release, c
 	}
 
 	// Step 4: Restart if supported, otherwise notify user
-	if !CanHotRestart() {
+	if !canHotRestart() {
 		progress(100, "Upgrade installed! Please restart Pilot manually.")
 		slog.Info("upgrade installed, manual restart required (Windows)",
 			slog.String("previous_version", currentVersion),
@@ -143,12 +147,27 @@ func (h *HotUpgrader) PerformHotUpgrade(ctx context.Context, release *Release, c
 
 	// Step 5: Exec into new binary (this never returns on success)
 	if err := RestartWithNewBinary(binaryPath, args, currentVersion); err != nil {
+		// GH-3600: persist the failure — without this the state file keeps
+		// claiming the upgrade landed while the old binary is still running.
+		if st, lerr := LoadState(h.graceful.statePath); lerr == nil && st != nil {
+			st.MarkRestartFailed(err)
+			_ = st.Save(h.graceful.statePath)
+		}
+		slog.Error("hot restart FAILED — daemon still running previous version",
+			slog.String("running_version", currentVersion),
+			slog.String("installed_version", release.TagName),
+			slog.Any("error", err),
+		)
 		return fmt.Errorf("restart failed: %w", err)
 	}
 
 	// This line is never reached on success
 	return nil
 }
+
+// canHotRestart is an overridable seam (mirrors runSmokeTest) so tests can
+// exercise the manual-restart branch on any platform.
+var canHotRestart = CanHotRestart
 
 // GetUpgrader returns the underlying Upgrader for version checks
 func (h *HotUpgrader) GetUpgrader() *Upgrader {

--- a/internal/upgrade/hot_test.go
+++ b/internal/upgrade/hot_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -89,6 +90,95 @@ func TestHotUpgrader_PerformHotUpgrade_DefaultConfig(t *testing.T) {
 	// as the "binary" is not a real executable
 	if err != nil {
 		t.Logf("PerformHotUpgrade() error (expected in test): %v", err)
+	}
+}
+
+// GH-3600: a failed exec must leave durable evidence — restart_failed with the
+// error in the state file, never a state that reads like success.
+func TestHotUpgrader_PerformHotUpgrade_ExecFailurePersisted(t *testing.T) {
+	tc := &NoOpTaskChecker{}
+	h, dir := newTestHotUpgrader(t, tc)
+
+	newBinary := []byte("hot-upgraded-binary")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(newBinary)
+	}))
+	defer server.Close()
+
+	h.graceful.upgrader.httpClient = server.Client()
+
+	release := &Release{
+		TagName: "v2.0.0",
+		Assets: []Asset{
+			{
+				Name:               fmt.Sprintf("pilot-%s-%s", runtime.GOOS, runtime.GOARCH),
+				BrowserDownloadURL: server.URL + "/pilot",
+				Size:               int64(len(newBinary)),
+			},
+		},
+	}
+
+	// Fail the restart deterministically before syscall.Exec can run.
+	origSmoke := runSmokeTest
+	runSmokeTest = func(string) error { return fmt.Errorf("smoke test exploded") }
+	defer func() { runSmokeTest = origSmoke }()
+
+	err := h.PerformHotUpgrade(context.Background(), release, nil)
+	if err == nil || !strings.Contains(err.Error(), "restart failed") {
+		t.Fatalf("PerformHotUpgrade() error = %v, want wrapped restart failure", err)
+	}
+
+	state, lerr := LoadState(filepath.Join(dir, "upgrade-state.json"))
+	if lerr != nil || state == nil {
+		t.Fatalf("LoadState() = %v, %v", state, lerr)
+	}
+	if state.Status != StatusRestartFailed {
+		t.Errorf("state.Status = %q, want %q", state.Status, StatusRestartFailed)
+	}
+	if !strings.Contains(state.Error, "smoke test exploded") {
+		t.Errorf("state.Error = %q, want the exec failure recorded", state.Error)
+	}
+}
+
+// GH-3600: platforms without hot restart (Windows) install and return — state
+// must stay awaiting_restart so the manual restart reconciles at next boot.
+func TestHotUpgrader_PerformHotUpgrade_NoHotRestart_AwaitingRestart(t *testing.T) {
+	tc := &NoOpTaskChecker{}
+	h, dir := newTestHotUpgrader(t, tc)
+
+	newBinary := []byte("hot-upgraded-binary")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(newBinary)
+	}))
+	defer server.Close()
+
+	h.graceful.upgrader.httpClient = server.Client()
+
+	release := &Release{
+		TagName: "v2.0.0",
+		Assets: []Asset{
+			{
+				Name:               fmt.Sprintf("pilot-%s-%s", runtime.GOOS, runtime.GOARCH),
+				BrowserDownloadURL: server.URL + "/pilot",
+				Size:               int64(len(newBinary)),
+			},
+		},
+	}
+
+	origCan := canHotRestart
+	canHotRestart = func() bool { return false }
+	defer func() { canHotRestart = origCan }()
+
+	if err := h.PerformHotUpgrade(context.Background(), release, nil); err != nil {
+		t.Fatalf("PerformHotUpgrade() error = %v", err)
+	}
+
+	state, lerr := LoadState(filepath.Join(dir, "upgrade-state.json"))
+	if lerr != nil || state == nil {
+		t.Fatalf("LoadState() = %v, %v", state, lerr)
+	}
+	if state.Status != StatusAwaitingRestart {
+		t.Errorf("state.Status = %q, want %q", state.Status, StatusAwaitingRestart)
 	}
 }
 

--- a/internal/upgrade/reconcile.go
+++ b/internal/upgrade/reconcile.go
@@ -1,0 +1,97 @@
+// Package upgrade: boot-time reconciliation of the two-phase upgrade state
+// (GH-3600). A hot upgrade writes awaiting_restart before exec'ing; only the
+// restarted process can prove the upgrade took effect, by comparing its own
+// compiled version against the state's NewVersion. The running version is the
+// ground truth — it covers hot exec, manual restarts, and Windows alike; the
+// PILOT_RESTARTED env marker only distinguishes how the restart happened.
+package upgrade
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// BootOutcome classifies what boot-time reconciliation found.
+type BootOutcome int
+
+const (
+	// BootNoAction — no state file, no reconcilable status, or load error.
+	BootNoAction BootOutcome = iota
+
+	// BootUpgradeVerified — the running version matches the installed one;
+	// state promoted to completed and cleaned up.
+	BootUpgradeVerified
+
+	// BootRestartFailed — state expected a new version but this process runs
+	// a different one: the previous restart never took effect.
+	BootRestartFailed
+)
+
+// BootReconcileResult reports the reconciliation outcome for logging/UI.
+type BootReconcileResult struct {
+	Outcome         BootOutcome
+	PreviousVersion string
+	NewVersion      string
+
+	// RestartError carries the persisted exec failure, if one was recorded.
+	RestartError string
+
+	// HotExec is true when this process was started via the hot-upgrade exec
+	// (PILOT_RESTARTED=1) rather than a manual restart. Phrasing only.
+	HotExec bool
+}
+
+// ReconcileBootState verifies a pending upgrade against the running version.
+// It never fails startup: any load/parse problem degrades to BootNoAction.
+func ReconcileBootState(runningVersion, statePath string) (*BootReconcileResult, error) {
+	result := &BootReconcileResult{
+		Outcome: BootNoAction,
+		HotExec: os.Getenv("PILOT_RESTARTED") == "1",
+	}
+
+	state, err := LoadState(statePath)
+	if err != nil {
+		slog.Warn("upgrade state unreadable at boot, skipping reconciliation", slog.Any("error", err))
+		return result, nil
+	}
+	if state == nil || !state.NeedsBootReconcile() {
+		// Covers legacy "completed" files (CLI upgrades, pre-GH-3600 hot
+		// upgrades) and failed/rolled_back, which belong to the rollback domain.
+		return result, nil
+	}
+
+	result.PreviousVersion = state.PreviousVersion
+	result.NewVersion = state.NewVersion
+	result.RestartError = state.Error
+
+	// Exact equality after trimming the v prefix (same normalization as
+	// CheckVersion). Equality is the question here — semver ordering would
+	// mangle dev builds.
+	if strings.TrimPrefix(runningVersion, "v") == strings.TrimPrefix(state.NewVersion, "v") {
+		// Promote and clean up. Small intentional duplication of
+		// GracefulUpgrader.CleanupState — constructing an upgrader at boot
+		// (os.Executable lookups) is not worth it here.
+		state.MarkCompleted()
+		_ = state.Save(statePath)
+		if state.BackupPath != "" {
+			_ = os.Remove(state.BackupPath)
+		}
+		_ = ClearState(statePath)
+
+		result.Outcome = BootUpgradeVerified
+		return result, nil
+	}
+
+	// Mismatch: the previous restart did not take effect.
+	if state.Status == StatusAwaitingRestart {
+		state.MarkRestartFailed(fmt.Errorf(
+			"process restarted with version %s, expected %s", runningVersion, state.NewVersion))
+		_ = state.Save(statePath)
+		result.RestartError = state.Error
+	}
+
+	result.Outcome = BootRestartFailed
+	return result, nil
+}

--- a/internal/upgrade/reconcile_test.go
+++ b/internal/upgrade/reconcile_test.go
@@ -1,0 +1,247 @@
+package upgrade
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStateMarkHelpers(t *testing.T) {
+	tests := []struct {
+		name               string
+		mutate             func(s *State)
+		wantStatus         UpgradeStatus
+		wantError          bool
+		wantBootReconcile  bool
+		wantCompletedZero  bool
+	}{
+		{
+			name:              "MarkAwaitingRestart",
+			mutate:            func(s *State) { s.MarkAwaitingRestart() },
+			wantStatus:        StatusAwaitingRestart,
+			wantBootReconcile: true,
+			wantCompletedZero: true,
+		},
+		{
+			name:              "MarkRestartFailed",
+			mutate:            func(s *State) { s.MarkRestartFailed(errors.New("exec exploded")) },
+			wantStatus:        StatusRestartFailed,
+			wantError:         true,
+			wantBootReconcile: true,
+			wantCompletedZero: true,
+		},
+		{
+			name:       "legacy completed needs no reconcile",
+			mutate:     func(s *State) { s.MarkCompleted() },
+			wantStatus: StatusCompleted,
+		},
+		{
+			name:       "failed stays in rollback domain",
+			mutate:     func(s *State) { s.MarkFailed(errors.New("download died")) },
+			wantStatus: StatusFailed,
+			wantError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &State{PreviousVersion: "1.0.0", NewVersion: "v2.0.0"}
+			tt.mutate(s)
+
+			if s.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", s.Status, tt.wantStatus)
+			}
+			if (s.Error != "") != tt.wantError {
+				t.Errorf("Error = %q, wantError %v", s.Error, tt.wantError)
+			}
+			if got := s.NeedsBootReconcile(); got != tt.wantBootReconcile {
+				t.Errorf("NeedsBootReconcile() = %v, want %v", got, tt.wantBootReconcile)
+			}
+			if tt.wantCompletedZero && !s.UpgradeCompleted.IsZero() {
+				t.Error("UpgradeCompleted should stay zero until promotion")
+			}
+			// New statuses must never look in-progress or trigger auto-rollback:
+			// the installed binary is good — rollback would resurrect the old one.
+			if s.Status == StatusAwaitingRestart || s.Status == StatusRestartFailed {
+				if s.IsPending() {
+					t.Error("IsPending() must be false for restart-phase statuses")
+				}
+				s.BackupPath = "/tmp/backup"
+				if s.NeedsRollback() {
+					t.Error("NeedsRollback() must be false for restart-phase statuses")
+				}
+			}
+		})
+	}
+}
+
+func TestState_NewStatuses_JSONRoundtrip(t *testing.T) {
+	for _, status := range []UpgradeStatus{StatusAwaitingRestart, StatusRestartFailed} {
+		t.Run(string(status), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "upgrade-state.json")
+			s := &State{NewVersion: "v2.0.0", Status: status, Error: "boom"}
+			if err := s.Save(path); err != nil {
+				t.Fatalf("Save() error = %v", err)
+			}
+			got, err := LoadState(path)
+			if err != nil {
+				t.Fatalf("LoadState() error = %v", err)
+			}
+			if got.Status != status || got.Error != "boom" {
+				t.Errorf("roundtrip = %q/%q, want %q/boom", got.Status, got.Error, status)
+			}
+		})
+	}
+}
+
+func TestReconcileBootState(t *testing.T) {
+	tests := []struct {
+		name            string
+		state           *State // nil = no state file
+		corrupt         bool
+		runningVersion  string
+		wantOutcome     BootOutcome
+		wantFileGone    bool
+		wantStatusAfter UpgradeStatus // checked when file expected to remain
+	}{
+		{
+			name:           "no state file",
+			runningVersion: "2.0.0",
+			wantOutcome:    BootNoAction,
+			wantFileGone:   true,
+		},
+		{
+			name:           "awaiting_restart with matching version is promoted",
+			state:          &State{PreviousVersion: "1.0.0", NewVersion: "v2.0.0", Status: StatusAwaitingRestart},
+			runningVersion: "2.0.0",
+			wantOutcome:    BootUpgradeVerified,
+			wantFileGone:   true,
+		},
+		{
+			name:           "v-prefix on running side still matches",
+			state:          &State{PreviousVersion: "1.0.0", NewVersion: "2.0.0", Status: StatusAwaitingRestart},
+			runningVersion: "v2.0.0",
+			wantOutcome:    BootUpgradeVerified,
+			wantFileGone:   true,
+		},
+		{
+			name:            "awaiting_restart with version mismatch becomes restart_failed",
+			state:           &State{PreviousVersion: "1.0.0", NewVersion: "v2.0.0", Status: StatusAwaitingRestart},
+			runningVersion:  "1.0.0",
+			wantOutcome:     BootRestartFailed,
+			wantStatusAfter: StatusRestartFailed,
+		},
+		{
+			name:           "restart_failed recovers after manual restart onto new version",
+			state:          &State{PreviousVersion: "1.0.0", NewVersion: "v2.0.0", Status: StatusRestartFailed, Error: "exec exploded"},
+			runningVersion: "2.0.0",
+			wantOutcome:    BootUpgradeVerified,
+			wantFileGone:   true,
+		},
+		{
+			name:            "restart_failed mismatch is idempotent across boots",
+			state:           &State{PreviousVersion: "1.0.0", NewVersion: "v2.0.0", Status: StatusRestartFailed, Error: "exec exploded"},
+			runningVersion:  "1.0.0",
+			wantOutcome:     BootRestartFailed,
+			wantStatusAfter: StatusRestartFailed,
+		},
+		{
+			name:            "legacy completed state is ignored",
+			state:           &State{PreviousVersion: "1.0.0", NewVersion: "v2.0.0", Status: StatusCompleted},
+			runningVersion:  "1.0.0",
+			wantOutcome:     BootNoAction,
+			wantStatusAfter: StatusCompleted,
+		},
+		{
+			name:            "failed state stays in the rollback domain",
+			state:           &State{PreviousVersion: "1.0.0", NewVersion: "v2.0.0", Status: StatusFailed, Error: "download died"},
+			runningVersion:  "1.0.0",
+			wantOutcome:     BootNoAction,
+			wantStatusAfter: StatusFailed,
+		},
+		{
+			name:           "corrupt state file degrades to no action",
+			corrupt:        true,
+			runningVersion: "2.0.0",
+			wantOutcome:    BootNoAction,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			statePath := filepath.Join(dir, "upgrade-state.json")
+
+			if tt.corrupt {
+				if err := os.WriteFile(statePath, []byte("{not json"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			} else if tt.state != nil {
+				if err := tt.state.Save(statePath); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			result, err := ReconcileBootState(tt.runningVersion, statePath)
+			if err != nil {
+				t.Fatalf("ReconcileBootState() error = %v — must never fail startup", err)
+			}
+			if result.Outcome != tt.wantOutcome {
+				t.Fatalf("Outcome = %v, want %v", result.Outcome, tt.wantOutcome)
+			}
+
+			_, statErr := os.Stat(statePath)
+			fileGone := os.IsNotExist(statErr)
+			if tt.wantFileGone != fileGone && !tt.corrupt {
+				t.Errorf("state file gone = %v, want %v", fileGone, tt.wantFileGone)
+			}
+			if tt.wantStatusAfter != "" {
+				after, lerr := LoadState(statePath)
+				if lerr != nil || after == nil {
+					t.Fatalf("LoadState() after reconcile = %v, %v", after, lerr)
+				}
+				if after.Status != tt.wantStatusAfter {
+					t.Errorf("Status after = %q, want %q", after.Status, tt.wantStatusAfter)
+				}
+			}
+			if tt.wantOutcome == BootRestartFailed && !strings.Contains(result.RestartError, "expected") && !strings.Contains(result.RestartError, "exec exploded") {
+				t.Errorf("RestartError = %q, want persisted or derived failure reason", result.RestartError)
+			}
+		})
+	}
+}
+
+func TestReconcileBootState_RemovesBackupOnPromotion(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "upgrade-state.json")
+	backupPath := filepath.Join(dir, "pilot.backup")
+	if err := os.WriteFile(backupPath, []byte("old-binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &State{PreviousVersion: "1.0.0", NewVersion: "v2.0.0", Status: StatusAwaitingRestart, BackupPath: backupPath}
+	if err := s.Save(statePath); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ReconcileBootState("2.0.0", statePath)
+	if err != nil || result.Outcome != BootUpgradeVerified {
+		t.Fatalf("ReconcileBootState() = %v, %v; want verified", result.Outcome, err)
+	}
+	if _, statErr := os.Stat(backupPath); !os.IsNotExist(statErr) {
+		t.Error("backup binary should be removed after verified upgrade")
+	}
+}
+
+func TestReconcileBootState_HotExecMarker(t *testing.T) {
+	t.Setenv("PILOT_RESTARTED", "1")
+	result, err := ReconcileBootState("2.0.0", filepath.Join(t.TempDir(), "upgrade-state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.HotExec {
+		t.Error("HotExec should reflect PILOT_RESTARTED=1")
+	}
+}

--- a/internal/upgrade/state.go
+++ b/internal/upgrade/state.go
@@ -46,6 +46,19 @@ const (
 	StatusCompleted   UpgradeStatus = "completed"
 	StatusFailed      UpgradeStatus = "failed"
 	StatusRolledBack  UpgradeStatus = "rolled_back"
+
+	// GH-3600: two-phase state for the hot-upgrade path. "completed" is only
+	// correct for the CLI graceful path where no restart is expected; the hot
+	// path must not claim success until the restarted process verifies it.
+
+	// StatusAwaitingRestart means the binary is installed but the restart has
+	// not been verified yet (hot path). Promoted to completed at next boot when
+	// the running version matches NewVersion.
+	StatusAwaitingRestart UpgradeStatus = "awaiting_restart"
+
+	// StatusRestartFailed means exec/smoke-test failed — the old binary is
+	// still running while the new one sits installed on disk.
+	StatusRestartFailed UpgradeStatus = "restart_failed"
 )
 
 // StateFile is the default state file name
@@ -147,4 +160,27 @@ func (s *State) MarkCompleted() {
 func (s *State) MarkRolledBack() {
 	s.Status = StatusRolledBack
 	s.UpgradeCompleted = time.Now()
+}
+
+// MarkAwaitingRestart marks the install as done with the restart still pending
+// (hot path). UpgradeCompleted stays zero until boot reconciliation promotes
+// the state to completed.
+func (s *State) MarkAwaitingRestart() {
+	s.Status = StatusAwaitingRestart
+}
+
+// MarkRestartFailed records that the post-install restart (exec or smoke test)
+// failed while the previous binary kept running.
+func (s *State) MarkRestartFailed(err error) {
+	s.Status = StatusRestartFailed
+	if err != nil {
+		s.Error = err.Error()
+	}
+}
+
+// NeedsBootReconcile returns true when the next process start must verify
+// whether the installed version actually took effect. Deliberately excludes
+// failed/rolled_back (the rollback domain) and legacy completed states.
+func (s *State) NeedsBootReconcile() bool {
+	return s.Status == StatusAwaitingRestart || s.Status == StatusRestartFailed
 }


### PR DESCRIPTION
Fixes #3600 (MANUAL — self-modifying upgrade machinery).

## What

Closes all three gaps that made the 2026-06-12 hot-upgrade failure silent (daemon installed v2.186.7, wrote `status: completed`, kept running 2.186.6):

**1. Two-phase upgrade state** (`internal/upgrade/state.go`, `graceful.go`, `hot.go`)
- New statuses: `awaiting_restart` (install done, restart pending) and `restart_failed` (exec/smoke-test failed, old binary still running).
- The hot path sets `UpgradeOptions.MarkAwaitingRestart` so the state file never claims `completed` before the restart is verified. CLI `pilot upgrade` semantics untouched — there, `completed` correctly means install-done-no-restart-expected (GH-272).
- A failed `RestartWithNewBinary` persists `restart_failed` + the error into the state file before returning.
- Both new statuses are deliberately excluded from `IsPending`/`NeedsRollback`: the installed binary is good; auto-rollback would resurrect the old binary.

**2. Boot reconciliation** (new `internal/upgrade/reconcile.go`, wired in `cmd/pilot/main.go`)
- `ReconcileBootState(runningVersion, statePath)`: the **running compiled version vs `state.NewVersion` is the ground truth** — covers hot exec, manual restarts, and the Windows no-exec branch alike. `PILOT_RESTARTED=1` only changes log phrasing (hot vs manual restart).
- Match → promote to completed, remove backup, clear state, log + dashboard "✅ Upgrade complete: X → Y". Mismatch → rewrite to `restart_failed` (idempotent across boots), log ERROR "previous upgrade did NOT take effect", and drive the sticky "! UPGRADE FAILED" TUI panel.
- Never blocks startup; legacy `completed` state files and `failed`/`rolled_back` (rollback domain) are ignored.

**3. Durable dashboard-mode logging** (`internal/logging/logging.go`, `main.go`)
- `logging.Suppress()` discarded all slog output in dashboard mode — that's why the original exec error was unrecoverable. Dashboard mode now redirects the package logger AND `slog.SetDefault` to a rotating `~/.pilot/logs/daemon.log` (reuses the existing `rotatingWriter`).
- Config: `logging.dashboard_log` — `""` default path, `"off"` restores the old discard behavior, anything else = custom path. Falls back to `Suppress()` if the path is unwritable (TUI must not be corrupted).
- Redirect hoisted to before runner/gateway creation, preserving the GH-190/GH-351 logger-caching ordering; the two downstream `Suppress()` sites are removed.

**TUI** (`internal/dashboard/tui.go`): the failure panel now states "Daemon still running vX — see ~/.pilot/logs/daemon.log".

## Verification

- 13 new test cases (table-driven, existing seams: `runSmokeTest` override + new one-line `canHotRestart` seam): state helpers + JSON round-trip, CLI-vs-hot state writes, exec-failure persistence, Windows branch, full reconcile table (match/mismatch/v-prefix/recovery/legacy/corrupt), backup removal, `RedirectToFile`.
- **Live-verified in an isolated HOME** with the built binary:
  - `awaiting_restart` + version mismatch → boot logs ERROR, state rewritten `restart_failed` with derived error;
  - match (+`PILOT_RESTARTED=1`) → "upgrade verified complete via hot restart", state file cleared;
  - `--dashboard` mode → the failure lands durably in `~/.pilot/logs/daemon.log`.
- `make test-short` 0 failures, `make lint` 0 issues.

## Notes

- Gateway mode surfaces reconcile outcomes via slog only (no `u`-key upgrade wiring exists there).
- Dev builds (version `v…-dirty`) with a stale `awaiting_restart` state warn truthfully — exact-string compare, no semver mangling.
- Old binaries reading the new statuses treat them as unknown strings → no-ops everywhere; harmless on downgrade.