### PR TITLE
fix: TASK-357 — TASK-322 Wave 4 lows (10 findings) + transcription tests

### DIFF
--- a/.agent/tasks/TASK-322-security-audit-findings.md
+++ b/.agent/tasks/TASK-322-security-audit-findings.md
@@ -222,6 +222,24 @@ from the chat:
 
 ### low
 
+> **✅ TASK-357 Wave 4 closure (2026-06-15) — re-audited against `main` @ ab15125b, all 10 actionable lows SHIPPED in [PR #3603](https://github.com/qf-studio/pilot/pull/3603).**
+> None were incidentally fixed by Waves 2–3 (re-verified before filing). Per-finding:
+>
+> | Finding | File | Status |
+> |---|---|---|
+> | A4a subagent `--model` single-argv bug | `executor/parallel.go` | ✅ fixed (#3603) |
+> | G1 `CleanupOrphanedWorktrees` success-as-error | `executor/worktree.go` | ✅ fixed — signature `(removed, freedBytes, err)` (#3603) |
+> | B6a `recordedMerges` unbounded | `autopilot/controller.go` | ✅ fixed — evict in `removePR` (#3603) |
+> | board-low GraphQL discards partial/aggregates only `Errors[0]` | `github/client.go` | ✅ partial — error aggregation done; partial-data tolerance → TASK-319 board track (#3603) |
+> | B6b `discoveryStart` leak on grace-expired | `autopilot/ci_monitor.go` | ✅ fixed (#3603) |
+> | A4b hook tmp dir leak on `WriteEmbeddedScripts` fail | `executor/runner.go` | ✅ fixed (#3603) |
+> | G2 `bridge.go` `%v` vs `%w` | `orchestrator/bridge.go` | ✅ fixed (#3603) |
+> | G3 discord heartbeat error discarded | `discord/transport.go` | ✅ fixed (#3603) |
+> | E7 `retryTracker` no TTL | `alerts/engine.go` | ✅ fixed — 24h TTL evict (#3603) |
+> | G4 `internal/transcription` 0 tests | `internal/transcription/*` | ✅ fixed — 3 test files added (#3603) |
+>
+> The 3 remaining `low` bullets below ("correctly engineered", "core HTTP/subprocess solid", "merge/idempotency well-tested") are **positive findings — no action**.
+
 - **Research subagent passes "--model X" as a single argv element, so the model flag is malformed**
   - dim: `executor-core` · file: `internal/executor/parallel.go:247` · cat: bug · conf: high
   - executeSubagent builds modelFlag as the string "--model " + model (e.g. "--model haiku") and then prepends it as one element: args = append([]string{modelFlag}, args...). exec.CommandContext passes each slice element as a separate argv entry, so the claude subprocess receives a single argument literally equal to "--model haiku" (including the embedded space) instead of two arguments "--model" and "haiku". Depending on the CLI's flag parser this either errors on an unknown flag or silently ignores the model selection, so parallel research subagents run on the default model rather than the intended fast haiku model (and may fail outright). The other two args entries ("-p", prompt) are correctly split, which is the giveaway that this one is wrong.

--- a/.agent/tasks/TASK-357-wave4-lows-reaudit.md
+++ b/.agent/tasks/TASK-357-wave4-lows-reaudit.md
@@ -1,6 +1,6 @@
 # TASK-357: TASK-322 Wave 4 — Lows + tests (re-audit gated)
 
-**Status:** 🟢 **GATE REACHED 2026-06-15** — ready to re-verify the 13 lows against current `main` and file survivors. (Park lifted; the 2-week cool-down after Wave 3 closed 2026-06-01 elapsed today.)
+**Status:** ✅ **SHIPPED 2026-06-15 (pending merge)** — re-audited against `main` @ ab15125b (all 10 actionable lows survived; none pre-fixed by Waves 2–3), implemented manually via nav-loop in one worktree → [PR #3603](https://github.com/qf-studio/pilot/pull/3603). Gates: build ✅ · `make lint` 0 issues ✅ · changed-package tests ✅. Ledger ticked in `TASK-322-security-audit-findings.md` § `low`. **Archive this file → `.agent/tasks/archive/` on merge** — that closes the entire TASK-322 audit (board-GraphQL partial-data tolerance carries over to the TASK-319 track).
 **Parent:** [[TASK-322-remediation-roadmap]] · final remaining tranche.
 
 > **Reminder context:** Waves 0–3 of the TASK-322 security audit are DONE (3 crit · 14 high · 17 med,

--- a/.agent/tasks/archive/TASK-357-wave4-lows-reaudit.md
+++ b/.agent/tasks/archive/TASK-357-wave4-lows-reaudit.md
@@ -1,6 +1,6 @@
 # TASK-357: TASK-322 Wave 4 — Lows + tests (re-audit gated)
 
-**Status:** ✅ **SHIPPED 2026-06-15 (pending merge)** — re-audited against `main` @ ab15125b (all 10 actionable lows survived; none pre-fixed by Waves 2–3), implemented manually via nav-loop in one worktree → [PR #3603](https://github.com/qf-studio/pilot/pull/3603). Gates: build ✅ · `make lint` 0 issues ✅ · changed-package tests ✅. Ledger ticked in `TASK-322-security-audit-findings.md` § `low`. **Archive this file → `.agent/tasks/archive/` on merge** — that closes the entire TASK-322 audit (board-GraphQL partial-data tolerance carries over to the TASK-319 track).
+**Status:** ✅ **DONE — TASK-322 audit closed.** Re-audited against `main` @ ab15125b (all 10 actionable lows survived; none pre-fixed by Waves 2–3), implemented manually via nav-loop in one worktree → [PR #3603](https://github.com/qf-studio/pilot/pull/3603). Gates: build ✅ · `make lint` 0 issues ✅ · changed-package tests ✅. Ledger ticked in `TASK-322-security-audit-findings.md` § `low`. Archived to `.agent/tasks/archive/` in PR #3603. **One carry-over:** board-GraphQL partial-data tolerance (unmarshal `Data` on partial errors + tolerant board caller) → TASK-319 board track; only error-aggregation shipped here.
 **Parent:** [[TASK-322-remediation-roadmap]] · final remaining tranche.
 
 > **Reminder context:** Waves 0–3 of the TASK-322 security audit are DONE (3 crit · 14 high · 17 med,

--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -586,9 +586,12 @@ Examples:
 
 			// GH-962: Clean up orphaned worktree directories from previous crashed executions
 			if cfg.Executor != nil && cfg.Executor.UseWorktree {
-				if err := executor.CleanupOrphanedWorktrees(ctx, projectPath); err != nil {
-					// Log the cleanup but don't fail startup - this is best-effort cleanup
-					fmt.Printf("   Worktree:  ✓ cleanup completed (%s)\n", err.Error())
+				removed, freedBytes, err := executor.CleanupOrphanedWorktrees(ctx, projectPath)
+				if err != nil {
+					// Real failure (e.g. temp dir unreadable) — don't fail startup.
+					fmt.Printf("   Worktree:  ⚠ cleanup error (%s)\n", err.Error())
+				} else if removed > 0 {
+					fmt.Printf("   Worktree:  ✓ cleaned up %d orphaned worktrees (freed %.1f MB)\n", removed, float64(freedBytes)/(1024*1024))
 				}
 			}
 
@@ -1120,8 +1123,11 @@ Examples:
 
 			// GH-962: Clean up orphaned worktree directories from previous crashed executions
 			if cfg.Executor != nil && cfg.Executor.UseWorktree {
-				if err := executor.CleanupOrphanedWorktrees(ctx, projectPath); err != nil {
-					fmt.Printf("🧹 Worktree cleanup completed (%s)\n", err.Error())
+				removed, freedBytes, err := executor.CleanupOrphanedWorktrees(ctx, projectPath)
+				if err != nil {
+					fmt.Printf("🧹 Worktree cleanup error (%s)\n", err.Error())
+				} else if removed > 0 {
+					fmt.Printf("🧹 Cleaned up %d orphaned worktrees (freed %.1f MB)\n", removed, float64(freedBytes)/(1024*1024))
 				}
 			}
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -404,9 +404,14 @@ Examples:
 
 				// GH-962: Clean up orphaned worktree directories from previous crashed executions
 				if cfg.Executor != nil && cfg.Executor.UseWorktree {
-					if err := executor.CleanupOrphanedWorktrees(context.Background(), projectPath); err != nil {
-						// Log the cleanup but don't fail startup - this is best-effort cleanup
-						logging.WithComponent("start").Info("worktree cleanup completed", slog.String("result", err.Error()))
+					removed, freedBytes, err := executor.CleanupOrphanedWorktrees(context.Background(), projectPath)
+					if err != nil {
+						// Real failure — don't fail startup, this is best-effort cleanup.
+						logging.WithComponent("start").Warn("worktree cleanup error", slog.String("error", err.Error()))
+					} else if removed > 0 {
+						logging.WithComponent("start").Info("worktree cleanup completed",
+							slog.Int("removed", removed),
+							slog.String("freed_mb", fmt.Sprintf("%.1f", float64(freedBytes)/(1024*1024))))
 					} else {
 						logging.WithComponent("start").Debug("worktree cleanup scan completed, no orphans found")
 					}
@@ -1437,9 +1442,14 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 
 	// GH-962: Clean up orphaned worktree directories from previous crashed executions
 	if cfg.Executor != nil && cfg.Executor.UseWorktree {
-		if err := executor.CleanupOrphanedWorktrees(ctx, projectPath); err != nil {
-			// Log the cleanup but don't fail startup - this is best-effort cleanup
-			logging.WithComponent("start").Info("worktree cleanup completed", slog.String("result", err.Error()))
+		removed, freedBytes, err := executor.CleanupOrphanedWorktrees(ctx, projectPath)
+		if err != nil {
+			// Real failure — don't fail startup, this is best-effort cleanup.
+			logging.WithComponent("start").Warn("worktree cleanup error", slog.String("error", err.Error()))
+		} else if removed > 0 {
+			logging.WithComponent("start").Info("worktree cleanup completed",
+				slog.Int("removed", removed),
+				slog.String("freed_mb", fmt.Sprintf("%.1f", float64(freedBytes)/(1024*1024))))
 		} else {
 			logging.WithComponent("start").Debug("worktree cleanup scan completed, no orphans found")
 		}

--- a/internal/adapters/discord/transport.go
+++ b/internal/adapters/discord/transport.go
@@ -142,7 +142,14 @@ func (g *GatewayClient) heartbeatLoop() {
 				D:  g.seq,
 			}
 
-			_ = g.conn.WriteJSON(hb)
+			// TASK-357 (G3): a heartbeat write failure is the earliest signal of a
+			// half-open socket. Surface it and stop the loop so reconnect happens
+			// immediately rather than only when the read loop next errors.
+			if err := g.conn.WriteJSON(hb); err != nil {
+				g.log.Warn("heartbeat write failed", slog.Any("error", err))
+				g.mu.Unlock()
+				return
+			}
 			g.mu.Unlock()
 		}
 	}

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -63,7 +63,25 @@ type GraphQLResponse struct {
 
 // GraphQLError is a single error from a GraphQL response.
 type GraphQLError struct {
-	Message string `json:"message"`
+	Message string        `json:"message"`
+	Type    string        `json:"type,omitempty"`
+	Path    []interface{} `json:"path,omitempty"`
+}
+
+// String renders a GraphQLError with its type/path when present, for diagnostics.
+func (e GraphQLError) String() string {
+	s := e.Message
+	if e.Type != "" {
+		s = e.Type + ": " + s
+	}
+	if len(e.Path) > 0 {
+		parts := make([]string, len(e.Path))
+		for i, p := range e.Path {
+			parts[i] = fmt.Sprintf("%v", p)
+		}
+		s += " (path: " + strings.Join(parts, ".") + ")"
+	}
+	return s
 }
 
 // Client is a GitHub API client
@@ -912,7 +930,15 @@ func (c *Client) ExecuteGraphQL(ctx context.Context, query string, variables map
 		}
 
 		if len(gqlResp.Errors) > 0 {
-			return fmt.Errorf("graphql error: %s", gqlResp.Errors[0].Message)
+			// TASK-357 (board low): aggregate ALL errors (message + type + path), not
+			// just Errors[0]. GitHub Projects V2 frequently returns several per-node
+			// errors at once, and surfacing only the first made board flows hard to
+			// diagnose.
+			msgs := make([]string, len(gqlResp.Errors))
+			for i, ge := range gqlResp.Errors {
+				msgs[i] = ge.String()
+			}
+			return fmt.Errorf("graphql error: %s", strings.Join(msgs, "; "))
 		}
 
 		if result != nil && len(gqlResp.Data) > 0 {

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -23,7 +23,8 @@ type Engine struct {
 	consecutiveFailures map[string]int           // project -> consecutive failure count
 	taskLastProgress    map[string]progressState // task ID -> last progress state
 	alertHistory        []AlertHistory
-	retryTracker        map[string]int // source (issue/PR) -> consecutive failure count (GH-848)
+	retryTracker        map[string]int       // source (issue/PR) -> consecutive failure count (GH-848)
+	retryLastSeen       map[string]time.Time // source -> last failure time, for TTL eviction (TASK-357 E7)
 
 	// Channels for events. priorityCh carries high-severity events
 	// (escalation / OOM / budget / security) on a dedicated buffer so a flood of
@@ -155,6 +156,7 @@ func NewEngine(config *AlertConfig, opts ...EngineOption) *Engine {
 		taskLastProgress:    make(map[string]progressState),
 		alertHistory:        make([]AlertHistory, 0),
 		retryTracker:        make(map[string]int),
+		retryLastSeen:       make(map[string]time.Time),
 		eventCh:             make(chan Event, 100),
 		priorityCh:          make(chan Event, 100),
 		done:                make(chan struct{}),
@@ -378,6 +380,7 @@ func (e *Engine) handleTaskCompleted(ctx context.Context, event Event) {
 	delete(e.taskLastProgress, event.TaskID)
 	// Reset per-source retry counter on success (GH-848)
 	delete(e.retryTracker, source)
+	delete(e.retryLastSeen, source) // TASK-357 (E7): keep TTL map in lockstep
 	e.mu.Unlock()
 }
 
@@ -397,6 +400,9 @@ func (e *Engine) handleTaskFailed(ctx context.Context, event Event) {
 	// Track per-source retries (GH-848)
 	e.retryTracker[source]++
 	retryCount := e.retryTracker[source]
+	// TASK-357 (E7): stamp last-seen so abandoned sources (failed, escalated, never
+	// re-attempted to success) can be evicted on a TTL instead of leaking forever.
+	e.retryLastSeen[source] = time.Now()
 	e.mu.Unlock()
 
 	// Check task_failed rule
@@ -591,6 +597,34 @@ func (e *Engine) evaluateStuckTasks(ctx context.Context) {
 			delete(e.taskLastProgress, id)
 		}
 		e.mu.Unlock()
+	}
+
+	// TASK-357 (E7): evict stale retryTracker entries. A source that fails, is
+	// escalated, and is then abandoned (never re-attempted to success) never hits
+	// the delete in handleTaskCompleted, so without a TTL its counter leaks for the
+	// daemon lifetime. Mirror the GH-2204 orphan-eviction for taskLastProgress.
+	e.evictStaleRetryTrackers(now)
+}
+
+// retryTrackerTTL bounds how long an idle per-source retry counter is retained.
+// A source with no failure for this long is treated as abandoned/resolved and
+// its retryTracker entry is evicted to keep the map bounded (TASK-357 E7).
+const retryTrackerTTL = 24 * time.Hour
+
+func (e *Engine) evictStaleRetryTrackers(now time.Time) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for source, lastSeen := range e.retryLastSeen {
+		if now.Sub(lastSeen) <= retryTrackerTTL {
+			continue
+		}
+		delete(e.retryTracker, source)
+		delete(e.retryLastSeen, source)
+		e.logger.Warn("evicting stale retry-tracker entry",
+			"source", source,
+			"idle_for", now.Sub(lastSeen).Round(time.Minute),
+			"ttl", retryTrackerTTL,
+		)
 	}
 }
 

--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -249,6 +249,14 @@ func (m *CIMonitor) checkAutoDiscoveredRuns(ctx context.Context, sha string, che
 			return CIPending, nil
 		}
 
+		// TASK-357 (B6b): the grace period is over and this is a terminal decision for
+		// the SHA — evict its discoveryStart entry so it does not leak for the daemon
+		// lifetime. Previously only the "checks found" path below deleted it, so every
+		// no-CI SHA (and every superseded intermediate commit) leaked an entry.
+		m.mu.Lock()
+		delete(m.discoveryStart, sha)
+		m.mu.Unlock()
+
 		// Grace period expired with no check runs — query commit-status API before
 		// concluding that no CI is configured. Providers like CircleCI, Jenkins,
 		// Travis, and Buildkite report exclusively via the statuses API.

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2312,6 +2312,11 @@ func (c *Controller) removePR(prNumber int) {
 		delete(c.activePRs, prNumber)
 	}
 	delete(c.prFailures, prNumber)
+	// TASK-357 (B6a): evict the merge-idempotency record alongside activePRs/prFailures.
+	// recordMergeSuccess sets recordedMerges[pr]=true and nothing else ever deleted it,
+	// so over a long-lived daemon it grew without bound. Idempotency is only needed
+	// while the PR is in flight; once removed it cannot be re-recorded by the live loop.
+	delete(c.recordedMerges, prNumber)
 	c.mu.Unlock()
 
 	// Clean up remote branch for closed/failed PRs (merged PRs already handled in handleMerging)

--- a/internal/executor/parallel.go
+++ b/internal/executor/parallel.go
@@ -241,25 +241,25 @@ DO NOT make any changes. Research only.`, desc),
 func (p *ParallelRunner) executeSubagent(ctx context.Context, projectPath string, task researchTask) *SubagentResult {
 	start := time.Now()
 
-	// Determine model flag
-	modelFlag := ""
+	// TASK-357 (A4a): determine the bare model name. Previously this stored the
+	// joined string "--model haiku" and prepended it as a SINGLE argv element, so
+	// the claude subprocess received one argument literally equal to "--model haiku"
+	// (embedded space) instead of two — the flag parser then errored or silently
+	// ignored model selection, so subagents ran on the default model.
+	modelName := ""
 	if p.defaultModel != "" {
-		modelFlag = "--model " + p.defaultModel
+		modelName = p.defaultModel
 	} else {
 		switch task.Model {
-		case "haiku":
-			modelFlag = "--model haiku"
-		case "sonnet":
-			modelFlag = "--model sonnet"
-		case "opus":
-			modelFlag = "--model opus"
+		case "haiku", "sonnet", "opus":
+			modelName = task.Model
 		}
 	}
 
 	// Build command - use haiku for fast research
 	args := []string{"-p", task.Prompt, "--output-format", "text"}
-	if modelFlag != "" {
-		args = append([]string{modelFlag}, args...)
+	if modelName != "" {
+		args = append([]string{"--model", modelName}, args...)
 	}
 
 	cmd := exec.CommandContext(ctx, "claude", args...)

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2019,6 +2019,12 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 			// Write embedded scripts
 			if err := WriteEmbeddedScripts(scriptDir); err != nil {
 				log.Error("Failed to write embedded hook scripts", slog.Any("error", err))
+				// TASK-357 (A4b): MkdirTemp already created scriptDir; this branch
+				// sets no hookRestoreFunc, so without cleanup the temp dir leaks for
+				// the process lifetime. Remove it now before falling through.
+				if rmErr := os.RemoveAll(scriptDir); rmErr != nil {
+					log.Warn("Failed to clean up hook scripts after write failure", slog.Any("error", rmErr))
+				}
 			} else {
 				// Generate Claude settings
 				hookSettings := GenerateClaudeSettings(r.config.Hooks, scriptDir)

--- a/internal/executor/worktree.go
+++ b/internal/executor/worktree.go
@@ -907,11 +907,15 @@ func EnsureNavigatorInWorktree(sourceRepo, worktreePath string) error {
 //
 // This function is safe to call at startup. Pool worktrees (pilot-worktree-pool-*)
 // are excluded because they are managed by the WorktreeManager lifecycle.
-func CleanupOrphanedWorktrees(ctx context.Context, repoPath string) error {
+// TASK-357 (G1): returns (removedCount, freedBytes, err). err is reserved for
+// real failures (e.g. reading the temp dir); a successful cleanup of N orphans
+// returns a nil error so idiomatic `if err != nil { return err }` callers don't
+// abort startup whenever orphans were reclaimed.
+func CleanupOrphanedWorktrees(ctx context.Context, repoPath string) (int, int64, error) {
 	tmpDir := os.TempDir()
 	entries, err := os.ReadDir(tmpDir)
 	if err != nil {
-		return fmt.Errorf("failed to read temp directory %s: %w", tmpDir, err)
+		return 0, 0, fmt.Errorf("failed to read temp directory %s: %w", tmpDir, err)
 	}
 
 	// Resolve symlinks in repoPath for reliable comparison with gitdir values.
@@ -1017,10 +1021,9 @@ func CleanupOrphanedWorktrees(ctx context.Context, repoPath string) error {
 			slog.Int("removed", orphanCount),
 			slog.String("freed_mb", fmt.Sprintf("%.1f", float64(totalBytes)/(1024*1024))),
 		)
-		return fmt.Errorf("cleaned up %d orphaned pilot worktree directories (freed %.1f MB)", orphanCount, float64(totalBytes)/(1024*1024))
 	}
 
-	return nil
+	return orphanCount, totalBytes, nil
 }
 
 // dirSizeBytes returns the total size of a directory tree in bytes.

--- a/internal/executor/worktree_test.go
+++ b/internal/executor/worktree_test.go
@@ -818,13 +818,13 @@ func TestCleanupOrphanedWorktrees(t *testing.T) {
 		t.Fatal("orphan2 should exist before cleanup")
 	}
 
-	// Run cleanup
-	err := CleanupOrphanedWorktrees(ctx, repoPath)
+	// Run cleanup — TASK-357 (G1): success returns nil err + a positive removed count.
+	removed, _, err := CleanupOrphanedWorktrees(ctx, repoPath)
 	if err != nil {
-		// Error should report number of cleaned directories and freed space
-		if !strings.Contains(err.Error(), "cleaned up") || !strings.Contains(err.Error(), "MB") {
-			t.Errorf("unexpected error format: %v", err)
-		}
+		t.Errorf("cleanup should not return an error on success: %v", err)
+	}
+	if removed < 2 {
+		t.Errorf("expected at least 2 orphans removed, got %d", removed)
 	}
 
 	// Verify orphaned pilot worktrees were removed
@@ -870,12 +870,14 @@ func TestCleanupOrphanedWorktrees_ValidWorktree(t *testing.T) {
 		t.Fatalf("worktree should exist before cleanup: %v", statErr)
 	}
 
-	// Run cleanup — GH-2168: should remove valid-but-stale worktrees at startup
-	err = CleanupOrphanedWorktrees(ctx, repoPath)
-	if err == nil {
-		t.Error("cleanup should report removed worktrees")
-	} else if !strings.Contains(err.Error(), "cleaned up") {
-		t.Errorf("unexpected error format: %v", err)
+	// Run cleanup — GH-2168: should remove valid-but-stale worktrees at startup.
+	// TASK-357 (G1): success returns nil err + a positive removed count.
+	removed, _, err := CleanupOrphanedWorktrees(ctx, repoPath)
+	if err != nil {
+		t.Errorf("cleanup should not return an error on success: %v", err)
+	}
+	if removed < 1 {
+		t.Error("cleanup should report at least one removed worktree")
 	}
 
 	// Verify the valid worktree was removed (it's stale at startup)
@@ -901,7 +903,7 @@ func TestCleanupOrphanedWorktrees_PoolSkipped(t *testing.T) {
 	defer func() { _ = os.RemoveAll(poolDir) }()
 
 	// Run cleanup
-	_ = CleanupOrphanedWorktrees(ctx, repoPath)
+	_, _, _ = CleanupOrphanedWorktrees(ctx, repoPath)
 
 	// Pool worktree should NOT be removed
 	if _, err := os.Stat(poolDir); os.IsNotExist(err) {
@@ -917,9 +919,12 @@ func TestCleanupOrphanedWorktrees_EmptyTmp(t *testing.T) {
 	ctx := context.Background()
 
 	// Run cleanup on clean system - should succeed with no action
-	err := CleanupOrphanedWorktrees(ctx, repoPath)
+	removed, _, err := CleanupOrphanedWorktrees(ctx, repoPath)
 	if err != nil {
 		t.Errorf("cleanup should succeed with no orphans: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("expected 0 removed on clean system, got %d", removed)
 	}
 }
 

--- a/internal/orchestrator/bridge.go
+++ b/internal/orchestrator/bridge.go
@@ -174,7 +174,10 @@ func (b *Bridge) runPython(ctx context.Context, script string) (string, error) {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("python error: %v: %s", err, stderr.String())
+		// TASK-357 (G2): wrap with %w so callers can errors.Is/As the underlying
+		// *exec.ExitError or context.DeadlineExceeded (the 30s timeout above) —
+		// distinguishing a python crash from a timeout requires the wrapped error.
+		return "", fmt.Errorf("python error: %w: %s", err, stderr.String())
 	}
 
 	return stdout.String(), nil

--- a/internal/transcription/setup_test.go
+++ b/internal/transcription/setup_test.go
@@ -1,0 +1,61 @@
+package transcription
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckSetup(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *Config
+		wantKeySet     bool
+		wantBackend    string
+		wantMissingKey bool
+	}{
+		{"key set", &Config{OpenAIAPIKey: "test-openai-key"}, true, "whisper-api", false},
+		{"empty key", &Config{}, false, "none", true},
+		{"nil config", nil, false, "none", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := CheckSetup(tt.config)
+			if status.OpenAIKeySet != tt.wantKeySet {
+				t.Errorf("OpenAIKeySet = %v, want %v", status.OpenAIKeySet, tt.wantKeySet)
+			}
+			if status.RecommendedBackend != tt.wantBackend {
+				t.Errorf("RecommendedBackend = %q, want %q", status.RecommendedBackend, tt.wantBackend)
+			}
+			hasMissingKey := false
+			for _, dep := range status.Missing {
+				if dep.Name == "OPENAI_API_KEY" {
+					hasMissingKey = true
+				}
+			}
+			if hasMissingKey != tt.wantMissingKey {
+				t.Errorf("missing OPENAI_API_KEY = %v, want %v", hasMissingKey, tt.wantMissingKey)
+			}
+		})
+	}
+}
+
+func TestGetInstallInstructions(t *testing.T) {
+	got := GetInstallInstructions()
+	for _, want := range []string{"OpenAI API key", "config.yaml", "Restart"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("instructions missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatStatusMessage(t *testing.T) {
+	ready := FormatStatusMessage(&SetupStatus{OpenAIKeySet: true})
+	if !strings.Contains(ready, "ready") || !strings.Contains(ready, "Whisper API") {
+		t.Errorf("ready message unexpected: %q", ready)
+	}
+
+	notReady := FormatStatusMessage(&SetupStatus{OpenAIKeySet: false})
+	if !strings.Contains(notReady, "not set") {
+		t.Errorf("not-ready message should mention missing key: %q", notReady)
+	}
+}

--- a/internal/transcription/transcriber_test.go
+++ b/internal/transcription/transcriber_test.go
@@ -1,0 +1,112 @@
+package transcription
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeTranscriber is a controllable Transcriber stub for Service tests.
+type fakeTranscriber struct {
+	name      string
+	available bool
+	result    *Result
+	err       error
+}
+
+func (f *fakeTranscriber) Transcribe(_ context.Context, _ string) (*Result, error) {
+	return f.result, f.err
+}
+func (f *fakeTranscriber) Name() string    { return f.name }
+func (f *fakeTranscriber) Available() bool { return f.available }
+
+func TestDefaultConfig(t *testing.T) {
+	if got := DefaultConfig().Backend; got != "auto" {
+		t.Errorf("DefaultConfig().Backend = %q, want auto", got)
+	}
+}
+
+func TestNewService(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+	}{
+		{"nil config (no key)", nil, true},
+		{"empty key", &Config{}, true},
+		{"with key", &Config{OpenAIAPIKey: "test-openai-key"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, err := NewService(tt.config)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if svc.BackendName() != "whisper-api" {
+				t.Errorf("BackendName() = %q, want whisper-api", svc.BackendName())
+			}
+			if !svc.Available() {
+				t.Error("Available() = false, want true")
+			}
+		})
+	}
+}
+
+func TestService_Transcribe_PrimarySuccess(t *testing.T) {
+	want := &Result{Text: "ok"}
+	svc := &Service{primary: &fakeTranscriber{name: "p", available: true, result: want}}
+	got, err := svc.Transcribe(context.Background(), "x.ogg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("result = %+v, want %+v", got, want)
+	}
+}
+
+func TestService_Transcribe_PrimaryFailsNoFallback(t *testing.T) {
+	svc := &Service{primary: &fakeTranscriber{name: "p", err: errors.New("boom")}}
+	_, err := svc.Transcribe(context.Background(), "x.ogg")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestService_Transcribe_FallbackUsedOnPrimaryFailure(t *testing.T) {
+	want := &Result{Text: "fallback"}
+	svc := &Service{
+		primary:  &fakeTranscriber{name: "p", err: errors.New("boom")},
+		fallback: &fakeTranscriber{name: "f", available: true, result: want},
+	}
+	got, err := svc.Transcribe(context.Background(), "x.ogg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("result = %+v, want fallback result", got)
+	}
+}
+
+func TestService_Transcribe_BothFail(t *testing.T) {
+	svc := &Service{
+		primary:  &fakeTranscriber{name: "p", err: errors.New("primary boom")},
+		fallback: &fakeTranscriber{name: "f", err: errors.New("fallback boom")},
+	}
+	_, err := svc.Transcribe(context.Background(), "x.ogg")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestService_BackendName_NoPrimary(t *testing.T) {
+	svc := &Service{}
+	if got := svc.BackendName(); got != "none" {
+		t.Errorf("BackendName() = %q, want none", got)
+	}
+}

--- a/internal/transcription/whisper_api_test.go
+++ b/internal/transcription/whisper_api_test.go
@@ -1,0 +1,159 @@
+package transcription
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// rewriteTransport redirects every request to the test server, so we can
+// exercise the Whisper HTTP/parse paths without hitting api.openai.com.
+type rewriteTransport struct{ base *url.URL }
+
+func (rt rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = rt.base.Scheme
+	req.URL.Host = rt.base.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// writeDummyAudio creates a small file to stand in for an audio upload.
+func writeDummyAudio(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "clip.ogg")
+	// 32000 bytes => ~1.0s under the size-based duration estimate.
+	if err := os.WriteFile(path, make([]byte, 32000), 0o600); err != nil {
+		t.Fatalf("write dummy audio: %v", err)
+	}
+	return path
+}
+
+func newTestWhisper(t *testing.T, handler http.HandlerFunc) *WhisperAPI {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	base, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	w := NewWhisperAPI("test-openai-key")
+	w.httpClient = &http.Client{Transport: rewriteTransport{base: base}}
+	return w
+}
+
+func TestWhisperAPI_NameAndAvailable(t *testing.T) {
+	if got := NewWhisperAPI("test-openai-key").Name(); got != "whisper-api" {
+		t.Errorf("Name() = %q, want whisper-api", got)
+	}
+	tests := []struct {
+		name   string
+		apiKey string
+		want   bool
+	}{
+		{"with key", "test-openai-key", true},
+		{"empty key", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewWhisperAPI(tt.apiKey).Available(); got != tt.want {
+				t.Errorf("Available() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWhisperAPI_Transcribe_PreflightErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		apiKey    string
+		audioPath string
+		wantErr   string
+	}{
+		{"no api key", "", writeDummyAudio(t), "not available"},
+		{"missing file", "test-openai-key", filepath.Join(t.TempDir(), "nope.ogg"), "failed to open audio file"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewWhisperAPI(tt.apiKey)
+			_, err := w.Transcribe(context.Background(), tt.audioPath)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestWhisperAPI_Transcribe_Success(t *testing.T) {
+	audio := writeDummyAudio(t)
+	w := newTestWhisper(t, func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		_, _ = rw.Write([]byte(`{"text":"hello world","language":"en","duration":3.5}`))
+	})
+
+	res, err := w.Transcribe(context.Background(), audio)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Text != "hello world" || res.Language != "en" || res.Duration != 3.5 {
+		t.Errorf("unexpected result: %+v", res)
+	}
+	if res.Confidence != 0.95 {
+		t.Errorf("Confidence = %v, want 0.95", res.Confidence)
+	}
+}
+
+func TestWhisperAPI_Transcribe_EmptyTranscriptEstimatesDuration(t *testing.T) {
+	audio := writeDummyAudio(t) // 32000 bytes => ~1.0s estimate
+	w := newTestWhisper(t, func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		// Empty text, duration omitted (0) -> falls back to size-based estimate.
+		_, _ = rw.Write([]byte(`{"text":"","language":""}`))
+	})
+
+	res, err := w.Transcribe(context.Background(), audio)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Text != "" {
+		t.Errorf("Text = %q, want empty", res.Text)
+	}
+	if res.Duration <= 0.9 || res.Duration >= 1.1 {
+		t.Errorf("estimated Duration = %v, want ~1.0", res.Duration)
+	}
+}
+
+func TestWhisperAPI_Transcribe_APIAndParseErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		wantErr string
+	}{
+		{"http 401", http.StatusUnauthorized, `{"error":"bad key"}`, "whisper API error (status 401)"},
+		{"http 500", http.StatusInternalServerError, `boom`, "whisper API error (status 500)"},
+		{"malformed json", http.StatusOK, `{not json`, "failed to parse Whisper API response"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			audio := writeDummyAudio(t)
+			w := newTestWhisper(t, func(rw http.ResponseWriter, _ *http.Request) {
+				rw.WriteHeader(tt.status)
+				_, _ = rw.Write([]byte(tt.body))
+			})
+			_, err := w.Transcribe(context.Background(), audio)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

Closes the final tranche of the TASK-322 security/code audit — the 13 deferred low-severity findings (Wave 4). All were **re-verified against `main` (ab15125b)** before fixing per the audit gate; none had been incidentally fixed by Waves 2–3, so all 10 distinct findings are addressed here.

## What changed

**Leak evictions** (`autopilot`, `alerts`)
- **B6a** `controller.go` — `removePR` now evicts `recordedMerges` alongside `activePRs`/`prFailures` (was never deleted → unbounded over daemon lifetime).
- **B6b** `ci_monitor.go` — grace-expired terminal paths now `delete(discoveryStart, sha)`; previously only the "checks found" path evicted, leaking every no-CI SHA + superseded commit.
- **E7** `engine.go` — added `retryLastSeen` + `evictStaleRetryTrackers` (24h TTL) on the existing `checkStuckTasks` ticker, mirroring GH-2204 orphan eviction; abandoned/escalated sources no longer leak.

**Error-handling hygiene** (`executor`, `orchestrator`, `discord`)
- **G1** `worktree.go` — `CleanupOrphanedWorktrees` returns `(removedCount, freedBytes, err)` with `err` reserved for real failures, instead of abusing a non-nil error to signal success (a trap for idiomatic callers). 4 call sites + 3 tests updated.
- **A4b** `runner.go` — clean up the `MkdirTemp` hook dir on the `WriteEmbeddedScripts` failure branch (was leaking for the process lifetime).
- **G2** `bridge.go` — `runPython` wraps with `%w` not `%v` so callers can `errors.Is(context.DeadlineExceeded)` / `errors.As(*exec.ExitError)`.
- **G3** `transport.go` — discord heartbeat logs the `WriteJSON` error and returns to trigger immediate reconnect instead of discarding it.

**Bug + diagnosability** (`executor`, `github`)
- **A4a** `parallel.go` — research subagent passes `--model` as **two** argv elements (`"--model"`, name) instead of one joined `"--model haiku"` string the CLI parsed as a single unknown flag. Subagents were silently running on the default model. *(tagged `bug · conf high`)*
- **board-low** `client.go` — `ExecuteGraphQL` aggregates **all** `gqlResp.Errors` (message + type + path) instead of only `Errors[0]`. Partial-data tolerance stays on the TASK-319 board track per the audit doc.

**Test coverage** (`transcription`)
- **G4** `internal/transcription` 0 → 3 test files: whisper_api error/parse/empty-transcript paths (httptest + URL-rewrite RoundTripper), setup status, Service primary/fallback routing.

## Acceptance

- `go build ./...` ✅
- `make lint` ✅ 0 issues
- Tests ✅ all changed packages pass (`autopilot`, `alerts`, `executor`, `orchestrator`, `discord`, `github`, `transcription`, `cmd/pilot`)

Re-audit + ledger tick-off and `TASK-357` archival to follow on merge — that closes the entire TASK-322 audit.