### PR TITLE
fix(logging): de-flake TestSafeGo_IncrementsCounter

### DIFF
--- a/internal/logging/safego_test.go
+++ b/internal/logging/safego_test.go
@@ -29,19 +29,24 @@ type stubCounter struct {
 	component string
 	count     atomic.Int64
 	done      chan struct{}
+	once      sync.Once
+	want      string
 }
 
 func (s *stubCounter) Inc(component string) {
+	if s.want != "" && component != s.want {
+		return
+	}
 	s.mu.Lock()
 	s.component = component
 	s.mu.Unlock()
 	s.count.Add(1)
-	close(s.done)
+	s.once.Do(func() { close(s.done) })
 }
 
 func TestSafeGo_IncrementsCounter(t *testing.T) {
 	prev := panicCounter
-	ctr := &stubCounter{done: make(chan struct{})}
+	ctr := &stubCounter{done: make(chan struct{}), want: "counter-test"}
 	SetPanicCounter(ctr)
 	t.Cleanup(func() { SetPanicCounter(prev) })
 


### PR DESCRIPTION
## Summary

- Adds a `want string` field to `stubCounter`; `Inc` returns early if `component != s.want`, dropping the leaked call from `TestSafeGo_RecoversFromPanic` (which uses `"test-component"`) before it can touch the stub in `TestSafeGo_IncrementsCounter` (which expects `"counter-test"`).
- Wraps `close(s.done)` in `sync.Once` so any stray matching call cannot double-close the channel.
- `safego.go` is unchanged — production behavior is unaffected.

Fixes #3605

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/logging/...` — clean
- [x] `go test ./internal/logging/ -run TestSafeGo -count=200 -race` — 200 passes, no failures
- [x] `go test ./internal/logging/...` — clean
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/logging/...` — 0 issues