### PR TITLE
feat(github): board-GraphQL partial-data tolerance (TASK-319)

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -84,6 +84,28 @@ func (e GraphQLError) String() string {
 	return s
 }
 
+// PartialGraphQLError is returned by ExecuteGraphQLTolerant when the response
+// contains only tolerable per-node errors (NOT_FOUND, FORBIDDEN). Data has been
+// unmarshalled into result; callers can inspect the dropped-node details via Errors.
+type PartialGraphQLError struct {
+	Errors []GraphQLError
+}
+
+func (e *PartialGraphQLError) Error() string {
+	msgs := make([]string, len(e.Errors))
+	for i, ge := range e.Errors {
+		msgs[i] = ge.String()
+	}
+	return "graphql partial error: " + strings.Join(msgs, "; ")
+}
+
+// isTolerable reports whether a GraphQL error type is a per-node access error
+// safe to skip on a partial board page. Only NOT_FOUND and FORBIDDEN qualify;
+// empty Type, RATE_LIMITED, auth, and syntax errors are all fatal.
+func isTolerable(errType string) bool {
+	return errType == "NOT_FOUND" || errType == "FORBIDDEN"
+}
+
 // Client is a GitHub API client
 type Client struct {
 	token      string
@@ -892,7 +914,29 @@ func (c *Client) GetPullRequestComments(ctx context.Context, owner, repo string,
 // Transient transport errors (5xx, network) and GraphQL-level rate limits
 // (HTTP 200 + RATE_LIMITED / "was submitted too quickly") are retried via
 // c.retryOpts, matching the behaviour of doRequest.
+// Any GraphQL error (regardless of type) aborts the call; use
+// ExecuteGraphQLTolerant for board pagination that must survive per-node
+// NOT_FOUND/FORBIDDEN errors.
 func (c *Client) ExecuteGraphQL(ctx context.Context, query string, variables map[string]interface{}, result interface{}) error {
+	return c.executeGraphQLCore(ctx, query, variables, result, false)
+}
+
+// ExecuteGraphQLTolerant is like ExecuteGraphQL but tolerates per-node
+// NOT_FOUND/FORBIDDEN errors in partial responses. When all errors are tolerable
+// it unmarshals Data into result and returns *PartialGraphQLError so the caller
+// can log/count the dropped nodes. A single non-tolerable error (e.g. RATE_LIMITED,
+// empty Type, auth, syntax) causes the whole call to fail exactly as ExecuteGraphQL
+// would, without unmarshalling Data.
+func (c *Client) ExecuteGraphQLTolerant(ctx context.Context, query string, variables map[string]interface{}, result interface{}) error {
+	return c.executeGraphQLCore(ctx, query, variables, result, true)
+}
+
+// executeGraphQLCore is the shared implementation for ExecuteGraphQL and
+// ExecuteGraphQLTolerant. When tolerant=false any error in the response is
+// fatal (strict mode). When tolerant=true, a response whose errors are all
+// NOT_FOUND/FORBIDDEN has its data unmarshalled and a *PartialGraphQLError
+// is returned; a single non-tolerable error makes the whole call fatal.
+func (c *Client) executeGraphQLCore(ctx context.Context, query string, variables map[string]interface{}, result interface{}, tolerant bool) error {
 	reqBody := GraphQLRequest{Query: query, Variables: variables}
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
@@ -934,6 +978,28 @@ func (c *Client) ExecuteGraphQL(ctx context.Context, query string, variables map
 			// just Errors[0]. GitHub Projects V2 frequently returns several per-node
 			// errors at once, and surfacing only the first made board flows hard to
 			// diagnose.
+			//
+			// In tolerant mode: if all errors are NOT_FOUND/FORBIDDEN, unmarshal
+			// the good data and return *PartialGraphQLError. Any non-tolerable error
+			// (including mixed tolerable+fatal) makes the whole response fatal.
+			if tolerant {
+				allTolerable := true
+				for _, ge := range gqlResp.Errors {
+					if !isTolerable(ge.Type) {
+						allTolerable = false
+						break
+					}
+				}
+				if allTolerable {
+					if result != nil && len(gqlResp.Data) > 0 {
+						if err := json.Unmarshal(gqlResp.Data, result); err != nil {
+							return fmt.Errorf("unmarshal graphql data: %w", err)
+						}
+					}
+					return &PartialGraphQLError{Errors: gqlResp.Errors}
+				}
+			}
+
 			msgs := make([]string, len(gqlResp.Errors))
 			for i, ge := range gqlResp.Errors {
 				msgs[i] = ge.String()

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -2725,6 +2725,152 @@ func TestExecuteGraphQL(t *testing.T) {
 	}
 }
 
+func TestExecuteGraphQLTolerant(t *testing.T) {
+	tests := []struct {
+		name           string
+		response       string
+		wantPartial    bool // want *PartialGraphQLError
+		wantFatal      bool // want a non-partial error
+		errContains    string
+		wantResultKey  string // key that must exist in unmarshalled result when wantPartial
+	}{
+		{
+			name:          "partial response: FORBIDDEN node error + good data",
+			response:      `{"data":{"items":{"nodes":[{"id":"good-1"}]}},"errors":[{"message":"Could not resolve","type":"FORBIDDEN","path":["node","items","nodes",1]}]}`,
+			wantPartial:   true,
+			errContains:   "FORBIDDEN",
+			wantResultKey: "items",
+		},
+		{
+			name:          "partial response: NOT_FOUND node error + good data",
+			response:      `{"data":{"items":{"nodes":[{"id":"good-2"}]}},"errors":[{"message":"Not found","type":"NOT_FOUND","path":["node","items","nodes",0]}]}`,
+			wantPartial:   true,
+			errContains:   "NOT_FOUND",
+			wantResultKey: "items",
+		},
+		{
+			name:        "fatal response: RATE_LIMITED error",
+			response:    `{"data":null,"errors":[{"message":"rate limit exceeded","type":"RATE_LIMITED"}]}`,
+			wantFatal:   true,
+			errContains: "RATE_LIMITED",
+		},
+		{
+			name:        "fatal response: empty Type (unknown error)",
+			response:    `{"data":null,"errors":[{"message":"something broke"}]}`,
+			wantFatal:   true,
+			errContains: "something broke",
+		},
+		{
+			name:        "mixed: one tolerable + one fatal → fatal",
+			response:    `{"data":{"x":1},"errors":[{"message":"not found","type":"NOT_FOUND"},{"message":"rate limit","type":"RATE_LIMITED"}]}`,
+			wantFatal:   true,
+			errContains: "RATE_LIMITED",
+		},
+		{
+			name:          "no errors: behaves same as strict",
+			response:      `{"data":{"viewer":{"login":"octocat"}}}`,
+			wantResultKey: "viewer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+			var result map[string]interface{}
+			err := client.ExecuteGraphQLTolerant(context.Background(), `query { x }`, nil, &result)
+
+			if tt.wantPartial {
+				var partialErr *PartialGraphQLError
+				if !errors.As(err, &partialErr) {
+					t.Fatalf("expected *PartialGraphQLError, got %T: %v", err, err)
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("partial error = %q, want containing %q", err.Error(), tt.errContains)
+				}
+				if tt.wantResultKey != "" && result[tt.wantResultKey] == nil {
+					t.Errorf("result[%q] is nil — data should have been unmarshalled alongside partial error", tt.wantResultKey)
+				}
+				return
+			}
+
+			if tt.wantFatal {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				var partialErr *PartialGraphQLError
+				if errors.As(err, &partialErr) {
+					t.Fatalf("expected fatal error, got *PartialGraphQLError: %v", err)
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("fatal error = %q, want containing %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			// No errors expected
+			if err != nil {
+				t.Fatalf("ExecuteGraphQLTolerant() unexpected error = %v", err)
+			}
+			if tt.wantResultKey != "" && result[tt.wantResultKey] == nil {
+				t.Errorf("result[%q] is nil, want populated", tt.wantResultKey)
+			}
+		})
+	}
+}
+
+// TestExecuteGraphQL_StrictUnchanged verifies that ExecuteGraphQL returns a fatal
+// error for any GraphQL error, including tolerable types like FORBIDDEN/NOT_FOUND.
+func TestExecuteGraphQL_StrictUnchanged(t *testing.T) {
+	tests := []struct {
+		name        string
+		response    string
+		errContains string
+	}{
+		{
+			name:        "FORBIDDEN is fatal in strict mode",
+			response:    `{"data":{"items":[{"id":"x"}]},"errors":[{"message":"no access","type":"FORBIDDEN"}]}`,
+			errContains: "graphql error",
+		},
+		{
+			name:        "NOT_FOUND is fatal in strict mode",
+			response:    `{"data":{"items":[{"id":"x"}]},"errors":[{"message":"gone","type":"NOT_FOUND"}]}`,
+			errContains: "graphql error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+			var result map[string]interface{}
+			err := client.ExecuteGraphQL(context.Background(), `query { x }`, nil, &result)
+			if err == nil {
+				t.Fatal("ExecuteGraphQL() should return error for any GraphQL error")
+			}
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("error = %q, want containing %q", err.Error(), tt.errContains)
+			}
+			// result must not be populated — strict mode does not unmarshal on error
+			if result != nil {
+				t.Errorf("result should be nil when ExecuteGraphQL returns an error, got %v", result)
+			}
+		})
+	}
+}
+
 func TestSearchMergedPRsForIssue(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/adapters/github/project_source.go
+++ b/internal/adapters/github/project_source.go
@@ -2,7 +2,9 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -121,8 +123,16 @@ func (s *ProjectBoardSource) FindIssuesFromProject(ctx context.Context, statusCo
 		}
 
 		var resp projectBoardItemsResponse
-		if err := s.client.ExecuteGraphQL(ctx, queryProjectBoardItems, vars, &resp); err != nil {
-			return nil, fmt.Errorf("list project board items: %w", err)
+		if err := s.client.ExecuteGraphQLTolerant(ctx, queryProjectBoardItems, vars, &resp); err != nil {
+			var partialErr *PartialGraphQLError
+			if errors.As(err, &partialErr) {
+				slog.Warn("board page has partial errors, some nodes dropped",
+					"dropped_count", len(partialErr.Errors),
+					"errors", partialErr.Error())
+				// resp already has the good nodes from the partial response — fall through.
+			} else {
+				return nil, fmt.Errorf("list project board items: %w", err)
+			}
 		}
 
 		for _, node := range resp.Node.Items.Nodes {

--- a/internal/adapters/github/project_source_test.go
+++ b/internal/adapters/github/project_source_test.go
@@ -444,6 +444,122 @@ func TestFindIssuesFromProject_OldestFirstOrdering(t *testing.T) {
 	}
 }
 
+// partialItemsResp builds a GraphQL response that contains both valid node data and one
+// per-node tolerable error, simulating a GitHub Projects V2 partial response.
+func partialItemsResp(nodes []map[string]interface{}, hasNextPage bool, endCursor string, errType string) string {
+	data := map[string]interface{}{
+		"node": map[string]interface{}{
+			"items": map[string]interface{}{
+				"pageInfo": map[string]interface{}{
+					"hasNextPage": hasNextPage,
+					"endCursor":   endCursor,
+				},
+				"nodes": nodes,
+			},
+		},
+	}
+	dataBytes, _ := json.Marshal(data)
+	resp := map[string]interface{}{
+		"data": json.RawMessage(dataBytes),
+		"errors": []map[string]interface{}{
+			{
+				"message": "Could not resolve to a node",
+				"type":    errType,
+				"path":    []interface{}{"node", "items", "nodes", 99},
+			},
+		},
+	}
+	b, _ := json.Marshal(resp)
+	return string(b)
+}
+
+// TestFindIssuesFromProject_PartialPage verifies that a partial board response
+// (valid data + one FORBIDDEN/NOT_FOUND node error) keeps the good nodes,
+// does not abort pagination, and returns results from all pages.
+func TestFindIssuesFromProject_PartialPage(t *testing.T) {
+	goodNode := issueNode(55, "I_55", "Good issue", "body", "OPEN", "org/repo", "Todo")
+	goodNode2 := issueNode(56, "I_56", "Good issue 2", "body2", "OPEN", "org/repo", "Todo")
+
+	server := fakeProjectSourceServer(t, []string{
+		orgProjectResp("PVT_partial"),
+		// Page 1: good node + FORBIDDEN error for an inaccessible node.
+		partialItemsResp([]map[string]interface{}{goodNode}, true, "cursor-partial", "FORBIDDEN"),
+		// Page 2: another good node, clean response — verifies pagination continues.
+		itemsResp([]map[string]interface{}{goodNode2}, false, ""),
+	})
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	src := NewProjectBoardSource(client, &ProjectBoardConfig{
+		ProjectNumber: 20,
+		StatusField:   "Status",
+	}, "org", "repo")
+
+	issues, err := src.FindIssuesFromProject(context.Background(), "Todo")
+	if err != nil {
+		t.Fatalf("FindIssuesFromProject() unexpected error = %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues (good nodes from both pages), got %d: %v", len(issues), issues)
+	}
+	numbers := map[int]bool{issues[0].Number: true, issues[1].Number: true}
+	if !numbers[55] || !numbers[56] {
+		t.Errorf("expected issue numbers 55 and 56, got %v", issues)
+	}
+}
+
+// TestFindIssuesFromProject_PartialNotFound mirrors TestFindIssuesFromProject_PartialPage
+// but uses a NOT_FOUND tolerable error instead of FORBIDDEN.
+func TestFindIssuesFromProject_PartialNotFound(t *testing.T) {
+	goodNode := issueNode(60, "I_60", "Surviving issue", "", "OPEN", "org/repo", "Todo")
+
+	server := fakeProjectSourceServer(t, []string{
+		orgProjectResp("PVT_notfound"),
+		partialItemsResp([]map[string]interface{}{goodNode}, false, "", "NOT_FOUND"),
+	})
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	src := NewProjectBoardSource(client, &ProjectBoardConfig{
+		ProjectNumber: 21,
+		StatusField:   "Status",
+	}, "org", "repo")
+
+	issues, err := src.FindIssuesFromProject(context.Background(), "Todo")
+	if err != nil {
+		t.Fatalf("FindIssuesFromProject() unexpected error = %v", err)
+	}
+	if len(issues) != 1 || issues[0].Number != 60 {
+		t.Errorf("expected issue #60, got %v", issues)
+	}
+}
+
+// TestFindIssuesFromProject_FatalErrorAborts verifies that a non-tolerable GraphQL
+// error (e.g. RATE_LIMITED) aborts pagination and returns an error.
+func TestFindIssuesFromProject_FatalErrorAborts(t *testing.T) {
+	fatalResp := `{"data":null,"errors":[{"message":"rate limit exceeded","type":"RATE_LIMITED"}]}`
+
+	server := fakeProjectSourceServer(t, []string{
+		orgProjectResp("PVT_fatal"),
+		fatalResp,
+	})
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	src := NewProjectBoardSource(client, &ProjectBoardConfig{
+		ProjectNumber: 22,
+		StatusField:   "Status",
+	}, "org", "repo")
+
+	_, err := src.FindIssuesFromProject(context.Background(), "Todo")
+	if err == nil {
+		t.Fatal("expected error on RATE_LIMITED response, got nil")
+	}
+	if !strings.Contains(err.Error(), "RATE_LIMITED") {
+		t.Errorf("error = %q, want containing RATE_LIMITED", err.Error())
+	}
+}
+
 // TestSourceEnabledFalse_UsesLabelPath is a regression guard: when source_enabled=false
 // (i.e. projectBoardSource is nil), findOldestUnprocessedIssue must reach the
 // label-based REST path (ListIssues), not the board GraphQL path.


### PR DESCRIPTION
## Summary

- Adds `ExecuteGraphQLTolerant` to `client.go` — an opt-in variant that classifies `NOT_FOUND`/`FORBIDDEN` as tolerable per-node errors, unmarshals `Data` alongside a typed `*PartialGraphQLError`, and treats every other error type (incl. `RATE_LIMITED`, empty `Type`) as fatal.
- `ExecuteGraphQL` is unchanged (delegates to a shared `executeGraphQLCore` with `tolerant=false`).
- Switches `FindIssuesFromProject` in `project_source.go` to `ExecuteGraphQLTolerant`: logs dropped-node count on partial pages, retains good nodes, and continues pagination — only fatal errors abort.

## Test plan

- [x] `TestExecuteGraphQLTolerant`: partial (FORBIDDEN/NOT_FOUND) → `*PartialGraphQLError` + data populated; fatal (RATE_LIMITED, empty Type) → fatal error; mixed tolerable+fatal → fatal; no errors → nil
- [x] `TestExecuteGraphQL_StrictUnchanged`: FORBIDDEN/NOT_FOUND still fatal in strict mode
- [x] `TestFindIssuesFromProject_PartialPage`: good nodes retained, pagination continues across second page
- [x] `TestFindIssuesFromProject_PartialNotFound`: NOT_FOUND variant
- [x] `TestFindIssuesFromProject_FatalErrorAborts`: RATE_LIMITED aborts and propagates error
- [x] `make lint` clean, `make test-short` green