### PR TITLE
feat(cli): interactive pilot project add wizard with gh CLI (GH-3017)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-06-16 (v2.151.0)
+**Last Updated:** 2026-06-15 (v2.151.0)
 
 ## Legend
 
@@ -433,6 +433,7 @@
 | Hot upgrade | ✅ | upgrade | `u` key in dashboard | - | Graceful drain + restart, no orphaned tasks (v0.18.0, v0.63.0) |
 | Config init | ✅ | config | `pilot init` | - | Creates default |
 | Setup wizard | ✅ | main | `pilot setup` | - | Interactive config |
+| Project add wizard | ✅ | cli | `pilot project add` (no flags) | - | gh CLI auth, repo picker, token seeding; `--no-wizard` for CI (GH-3017, v2.187.1) |
 | Shell completion | ✅ | main | `pilot completion` | - | bash/zsh/fish |
 | Zip archive support | ✅ | upgrade | - | - | Windows self-upgrade handles .zip archives |
 | Pipeline hardening | ✅ | executor | - | - | 4 correctness checks: constants, parity, coverage, dropped features (v1.10.0, GH-1321) |

--- a/cmd/pilot/project.go
+++ b/cmd/pilot/project.go
@@ -95,10 +95,11 @@ func newProjectAddCmd() *cobra.Command {
 	var (
 		name       string
 		path       string
-		github     string
+		ghRepo     string
 		branch     string
 		navigator  bool
 		setDefault bool
+		noWizard   bool
 	)
 
 	cmd := &cobra.Command{
@@ -106,140 +107,155 @@ func newProjectAddCmd() *cobra.Command {
 		Short: "Add a new project",
 		Long: `Add a new project to Pilot configuration.
 
-Auto-detection:
+Without flags on an interactive terminal, launches the interactive wizard
+which detects your gh CLI auth, lets you pick a repo, and prefills settings.
+
+Auto-detection (flag mode):
   - If --path is omitted, uses current working directory
   - If --branch is omitted, detects from git remote
   - If --navigator is omitted, checks for .agent/ directory
   - If --github is omitted, parses from git remote origin
 
 Examples:
+  pilot project add                            # interactive wizard (TTY only)
+  pilot project add --no-wizard                # force flag mode
   pilot project add --name my-app
   pilot project add --name my-app --github owner/repo
   pilot project add -n my-app -p /path/to/project -g owner/repo -b main`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if name == "" {
-				return fmt.Errorf("--name is required")
+			// Wizard mode: no --name and not explicitly disabled, and stdin is a terminal
+			if name == "" && !noWizard && isInteractiveTTY() {
+				return runProjectAddWizard(cmd)
 			}
-
-			configPath := cfgFile
-			if configPath == "" {
-				configPath = config.DefaultConfigPath()
-			}
-
-			cfg, err := config.Load(configPath)
-			if err != nil {
-				return fmt.Errorf("failed to load config: %w", err)
-			}
-
-			// Check for duplicate name
-			if cfg.GetProjectByName(name) != nil {
-				return fmt.Errorf("project '%s' already exists", name)
-			}
-
-			// Use current directory if path not specified
-			if path == "" {
-				cwd, err := os.Getwd()
-				if err != nil {
-					return fmt.Errorf("failed to get current directory: %w", err)
-				}
-				path = cwd
-			}
-
-			// Expand and validate path
-			path = expandProjectPath(path)
-			info, err := os.Stat(path)
-			if err != nil {
-				if os.IsNotExist(err) {
-					return fmt.Errorf("path does not exist: %s", path)
-				}
-				return fmt.Errorf("failed to access path: %w", err)
-			}
-			if !info.IsDir() {
-				return fmt.Errorf("path is not a directory: %s", path)
-			}
-
-			// Check for duplicate path
-			if cfg.GetProject(path) != nil {
-				return fmt.Errorf("path already configured: %s", path)
-			}
-
-			// Auto-detect GitHub if not specified
-			var ghConfig *config.ProjectGitHubConfig
-			if github != "" {
-				parts := strings.SplitN(github, "/", 2)
-				if len(parts) != 2 {
-					return fmt.Errorf("invalid GitHub format, expected owner/repo: %s", github)
-				}
-				ghConfig = &config.ProjectGitHubConfig{
-					Owner: parts[0],
-					Repo:  parts[1],
-				}
-			} else {
-				// Try to auto-detect from git remote
-				ghConfig = detectGitHubFromRemote(path)
-			}
-
-			// Auto-detect branch if not specified
-			if branch == "" {
-				branch = detectDefaultBranch(path)
-			}
-
-			// Auto-detect navigator if flag not explicitly set
-			if !cmd.Flags().Changed("navigator") {
-				navigator = detectNavigator(path)
-			}
-
-			// Create project config
-			proj := &config.ProjectConfig{
-				Name:          name,
-				Path:          path,
-				Navigator:     navigator,
-				DefaultBranch: branch,
-				GitHub:        ghConfig,
-			}
-
-			// Add to config
-			cfg.Projects = append(cfg.Projects, proj)
-
-			// Set as default if requested or if it's the only project
-			if setDefault || len(cfg.Projects) == 1 {
-				cfg.DefaultProject = name
-			}
-
-			// Save config
-			if err := config.Save(cfg, configPath); err != nil {
-				return fmt.Errorf("failed to save config: %w", err)
-			}
-
-			// Print success message
-			fmt.Printf("Project added: %s\n", name)
-			fmt.Printf("   Path:      %s\n", path)
-			if ghConfig != nil {
-				fmt.Printf("   GitHub:    %s/%s\n", ghConfig.Owner, ghConfig.Repo)
-			}
-			if branch != "" {
-				fmt.Printf("   Branch:    %s\n", branch)
-			}
-			navStr := "disabled"
-			if navigator {
-				navStr = "enabled"
-			}
-			fmt.Printf("   Navigator: %s\n", navStr)
-			fmt.Println()
-			fmt.Printf("   Start working: pilot start --project %s\n", name)
-
-			return nil
+			return runProjectAddFlags(cmd, name, path, ghRepo, branch, navigator, setDefault)
 		},
 	}
 
-	cmd.Flags().StringVarP(&name, "name", "n", "", "Project name (required)")
+	cmd.Flags().StringVarP(&name, "name", "n", "", "Project name (required in flag mode)")
 	cmd.Flags().StringVarP(&path, "path", "p", "", "Project path (default: current directory)")
-	cmd.Flags().StringVarP(&github, "github", "g", "", "GitHub repo (owner/repo)")
+	cmd.Flags().StringVarP(&ghRepo, "github", "g", "", "GitHub repo (owner/repo)")
 	cmd.Flags().StringVarP(&branch, "branch", "b", "", "Default branch (auto-detected)")
 	cmd.Flags().BoolVar(&navigator, "navigator", false, "Enable Navigator (auto-detected)")
 	cmd.Flags().BoolVarP(&setDefault, "set-default", "d", false, "Set as default project")
+	cmd.Flags().BoolVar(&noWizard, "no-wizard", false, "Force flag-driven mode (skip interactive wizard)")
 
 	return cmd
+}
+
+// runProjectAddFlags implements the flag-driven `pilot project add --name <n>` path.
+func runProjectAddFlags(cmd *cobra.Command, name, path, ghRepo, branch string, navigator, setDefault bool) error {
+	if name == "" {
+		return fmt.Errorf("--name is required")
+	}
+
+	configPath := cfgFile
+	if configPath == "" {
+		configPath = config.DefaultConfigPath()
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Check for duplicate name
+	if cfg.GetProjectByName(name) != nil {
+		return fmt.Errorf("project '%s' already exists", name)
+	}
+
+	// Use current directory if path not specified
+	if path == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current directory: %w", err)
+		}
+		path = cwd
+	}
+
+	// Expand and validate path
+	path = expandProjectPath(path)
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("path does not exist: %s", path)
+		}
+		return fmt.Errorf("failed to access path: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("path is not a directory: %s", path)
+	}
+
+	// Check for duplicate path
+	if cfg.GetProject(path) != nil {
+		return fmt.Errorf("path already configured: %s", path)
+	}
+
+	// Auto-detect GitHub if not specified
+	var ghConfig *config.ProjectGitHubConfig
+	if ghRepo != "" {
+		parts := strings.SplitN(ghRepo, "/", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid GitHub format, expected owner/repo: %s", ghRepo)
+		}
+		ghConfig = &config.ProjectGitHubConfig{
+			Owner: parts[0],
+			Repo:  parts[1],
+		}
+	} else {
+		// Try to auto-detect from git remote
+		ghConfig = detectGitHubFromRemote(path)
+	}
+
+	// Auto-detect branch if not specified
+	if branch == "" {
+		branch = detectDefaultBranch(path)
+	}
+
+	// Auto-detect navigator if flag not explicitly set
+	if cmd == nil || !cmd.Flags().Changed("navigator") {
+		navigator = detectNavigator(path)
+	}
+
+	// Create project config
+	proj := &config.ProjectConfig{
+		Name:          name,
+		Path:          path,
+		Navigator:     navigator,
+		DefaultBranch: branch,
+		GitHub:        ghConfig,
+	}
+
+	// Add to config
+	cfg.Projects = append(cfg.Projects, proj)
+
+	// Set as default if requested or if it's the only project
+	if setDefault || len(cfg.Projects) == 1 {
+		cfg.DefaultProject = name
+	}
+
+	// Save config
+	if err := config.Save(cfg, configPath); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	// Print success message
+	fmt.Printf("Project added: %s\n", name)
+	fmt.Printf("   Path:      %s\n", path)
+	if ghConfig != nil {
+		fmt.Printf("   GitHub:    %s/%s\n", ghConfig.Owner, ghConfig.Repo)
+	}
+	if branch != "" {
+		fmt.Printf("   Branch:    %s\n", branch)
+	}
+	navStr := "disabled"
+	if navigator {
+		navStr = "enabled"
+	}
+	fmt.Printf("   Navigator: %s\n", navStr)
+	fmt.Println()
+	fmt.Printf("   Start working: pilot start --project %s\n", name)
+
+	return nil
 }
 
 func newProjectRemoveCmd() *cobra.Command {

--- a/cmd/pilot/project_wizard.go
+++ b/cmd/pilot/project_wizard.go
@@ -1,0 +1,339 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/config"
+)
+
+// ghRunner executes a gh CLI subcommand and returns stdout.
+// It is a package-level variable so tests can inject a fake implementation.
+var ghRunner = func(args ...string) ([]byte, error) {
+	return exec.Command("gh", args...).Output() //nolint:gosec
+}
+
+// ghRepoEntry represents one entry from `gh repo list --json`.
+type ghRepoEntry struct {
+	NameWithOwner    string `json:"nameWithOwner"`
+	Description      string `json:"description"`
+	IsPrivate        bool   `json:"isPrivate"`
+	DefaultBranchRef *struct {
+		Name string `json:"name"`
+	} `json:"defaultBranchRef"`
+}
+
+// ghAuthStatus checks whether the gh CLI is installed and the user is authenticated.
+// Returns (username, true) on success; ("", false) when gh is absent or unauthenticated.
+func ghAuthStatus() (string, bool) {
+	if _, err := ghRunner("auth", "status"); err != nil {
+		return "", false
+	}
+	out, err := ghRunner("api", "user", "-q", ".login")
+	if err != nil {
+		// Authenticated but couldn't fetch username (network offline, etc.).
+		return "", true
+	}
+	return strings.TrimSpace(string(out)), true
+}
+
+// ghAuthToken returns the token stored in the gh CLI keychain.
+func ghAuthToken() (string, error) {
+	out, err := ghRunner("auth", "token")
+	if err != nil {
+		return "", fmt.Errorf("gh auth token: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ghRepoList fetches up to limit repos from the gh CLI.
+func ghRepoList(limit int) ([]ghRepoEntry, error) {
+	out, err := ghRunner(
+		"repo", "list",
+		"--limit", fmt.Sprintf("%d", limit),
+		"--json", "nameWithOwner,description,isPrivate,defaultBranchRef",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("gh repo list: %w", err)
+	}
+	var repos []ghRepoEntry
+	if err := json.Unmarshal(out, &repos); err != nil {
+		return nil, fmt.Errorf("gh repo list: parse: %w", err)
+	}
+	return repos, nil
+}
+
+// isInteractiveTTY returns true when stdin is connected to a terminal.
+func isInteractiveTTY() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// runProjectAddWizard runs the interactive wizard for `pilot project add` (no flags).
+// It guides the user through gh auth detection, repo picking, and config writing.
+func runProjectAddWizard(_ *cobra.Command) error {
+	reader := bufio.NewReader(os.Stdin)
+
+	configPath := cfgFile
+	if configPath == "" {
+		configPath = config.DefaultConfigPath()
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Println(onboardLabelStyle.Render("  pilot project add — interactive wizard"))
+	fmt.Println()
+
+	// ── gh auth detection ────────────────────────────────────────────────────
+	username, ghOK := ghAuthStatus()
+	if !ghOK {
+		fmt.Printf("  %s gh CLI not found or unauthenticated.\n",
+			onboardDimStyle.Render("!"))
+		fmt.Println("  Hint: install gh (https://cli.github.com) for the interactive picker.")
+		fmt.Println()
+		fmt.Println("  Use: pilot project add --name <name> [--github owner/repo] [--path <dir>]")
+		return nil
+	}
+
+	if username != "" {
+		fmt.Printf("  %s gh authenticated (user: %s)\n",
+			onboardSuccessStyle.Render("✓"), username)
+	} else {
+		fmt.Printf("  %s gh authenticated\n", onboardSuccessStyle.Render("✓"))
+	}
+
+	// Offer token seeding if no token is configured yet
+	var seedToken bool
+	hasToken := cfg.Adapters != nil && cfg.Adapters.GitHub != nil &&
+		cfg.Adapters.GitHub.Token != ""
+	if !hasToken {
+		fmt.Printf("  %s No GitHub token in %s\n",
+			onboardDimStyle.Render("○"), configPath)
+		fmt.Println()
+		fmt.Print("  Use your gh CLI token for Pilot? [Y/n] ")
+		seedToken = readYesNo(reader, true)
+		fmt.Println()
+	}
+
+	// ── repo picker ──────────────────────────────────────────────────────────
+	var selectedRepo *ghRepoEntry
+	var ghConfig *config.ProjectGitHubConfig
+
+	repos, listErr := ghRepoList(50)
+	if listErr != nil || len(repos) == 0 {
+		fmt.Printf("  %s Could not list repos — will auto-detect from git remote.\n",
+			onboardDimStyle.Render("!"))
+	} else {
+		fmt.Println()
+		fmt.Println("  Pick a repo:")
+		fmt.Println()
+
+		displayCount := len(repos)
+		if displayCount > 20 {
+			displayCount = 20
+		}
+		for i, r := range repos[:displayCount] {
+			visibility := "public"
+			if r.IsPrivate {
+				visibility = "private"
+			}
+			desc := r.Description
+			if len(desc) > 48 {
+				desc = desc[:45] + "..."
+			}
+			if desc != "" {
+				fmt.Printf("    %s  %-35s %s  %s\n",
+					onboardValueStyle.Render(fmt.Sprintf("[%d]", i+1)),
+					r.NameWithOwner,
+					onboardDimStyle.Render("("+visibility+")"),
+					onboardDimStyle.Render(desc),
+				)
+			} else {
+				fmt.Printf("    %s  %-35s %s\n",
+					onboardValueStyle.Render(fmt.Sprintf("[%d]", i+1)),
+					r.NameWithOwner,
+					onboardDimStyle.Render("("+visibility+")"),
+				)
+			}
+		}
+		if len(repos) > displayCount {
+			fmt.Printf("    %s\n",
+				onboardDimStyle.Render(fmt.Sprintf("↓ %d more (use --github to specify)", len(repos)-displayCount)))
+		}
+		fmt.Println()
+		fmt.Printf("  Select repo number (or Enter to skip) %s ", onboardCursorStyle.Render("▸"))
+
+		line := readLine(reader)
+		if line != "" {
+			var idx int
+			if n, _ := fmt.Sscanf(line, "%d", &idx); n == 1 && idx >= 1 && idx <= displayCount {
+				entry := repos[idx-1]
+				selectedRepo = &entry
+				parts := strings.SplitN(selectedRepo.NameWithOwner, "/", 2)
+				if len(parts) == 2 {
+					ghConfig = &config.ProjectGitHubConfig{
+						Owner: parts[0],
+						Repo:  parts[1],
+					}
+				}
+			}
+		}
+		fmt.Println()
+	}
+
+	// ── project name ─────────────────────────────────────────────────────────
+	cwd, _ := os.Getwd()
+	defaultName := filepath.Base(cwd)
+	if selectedRepo != nil {
+		parts := strings.SplitN(selectedRepo.NameWithOwner, "/", 2)
+		if len(parts) == 2 {
+			defaultName = parts[1]
+		}
+	}
+	name := readLineWithDefault(reader, "Project name", defaultName)
+	if name == "" {
+		name = defaultName
+	}
+
+	// ── local path ───────────────────────────────────────────────────────────
+	projectPath := readLineWithDefault(reader, "Local path", cwd)
+	if projectPath == "" {
+		projectPath = cwd
+	}
+	projectPath = expandProjectPath(projectPath)
+
+	info, err := os.Stat(projectPath)
+	if err != nil {
+		return fmt.Errorf("path does not exist: %s", projectPath)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("path is not a directory: %s", projectPath)
+	}
+
+	// ── duplicate checks ─────────────────────────────────────────────────────
+	if cfg.GetProjectByName(name) != nil {
+		return fmt.Errorf("project '%s' already exists", name)
+	}
+	if cfg.GetProject(projectPath) != nil {
+		return fmt.Errorf("path already configured: %s", projectPath)
+	}
+
+	// Fall back to git-remote detection if no repo was picked
+	if ghConfig == nil {
+		ghConfig = detectGitHubFromRemote(projectPath)
+	}
+
+	// Branch: prefer the selected repo's default branch, then auto-detect
+	branch := ""
+	if selectedRepo != nil && selectedRepo.DefaultBranchRef != nil {
+		branch = selectedRepo.DefaultBranchRef.Name
+	}
+	if branch == "" {
+		branch = detectDefaultBranch(projectPath)
+	}
+
+	navigator := detectNavigator(projectPath)
+
+	// ── set as default? ──────────────────────────────────────────────────────
+	fmt.Println()
+	fmt.Print("  Set as default project? [Y/n] ")
+	setDefault := readYesNo(reader, true)
+
+	// ── summary + confirm ────────────────────────────────────────────────────
+	navStr := "disabled"
+	if navigator {
+		navStr = "enabled"
+	}
+	defaultStr := "no"
+	if setDefault || len(cfg.Projects) == 0 {
+		defaultStr = "yes"
+	}
+
+	fmt.Println()
+	fmt.Println("  " + onboardLabelStyle.Render("Summary"))
+	fmt.Println()
+	fmt.Printf("    Name:       %s\n", onboardValueStyle.Render(name))
+	fmt.Printf("    Path:       %s\n", onboardValueStyle.Render(projectPath))
+	if ghConfig != nil {
+		fmt.Printf("    GitHub:     %s/%s\n",
+			onboardValueStyle.Render(ghConfig.Owner), onboardValueStyle.Render(ghConfig.Repo))
+	}
+	fmt.Printf("    Branch:     %s\n", onboardValueStyle.Render(branch))
+	fmt.Printf("    Navigator:  %s\n", onboardValueStyle.Render(navStr))
+	fmt.Printf("    Default:    %s\n", onboardValueStyle.Render(defaultStr))
+	if seedToken {
+		fmt.Printf("    gh token:   %s\n", onboardValueStyle.Render("will be seeded"))
+	}
+	fmt.Println()
+	fmt.Print("  Save to config? [Y/n] ")
+	if !readYesNo(reader, true) {
+		fmt.Println("  Cancelled.")
+		return nil
+	}
+	fmt.Println()
+
+	// ── seed token ───────────────────────────────────────────────────────────
+	if seedToken {
+		token, err := ghAuthToken()
+		if err != nil {
+			fmt.Printf("  %s Could not get gh token: %v\n", onboardFailStyle.Render("✗"), err)
+		} else if token != "" {
+			if cfg.Adapters == nil {
+				cfg.Adapters = &config.AdaptersConfig{}
+			}
+			if cfg.Adapters.GitHub == nil {
+				cfg.Adapters.GitHub = github.DefaultConfig()
+			}
+			cfg.Adapters.GitHub.Token = token
+			fmt.Printf("  %s Wrote adapters.github.token\n", onboardSuccessStyle.Render("✓"))
+		}
+	}
+
+	// ── add project ───────────────────────────────────────────────────────────
+	proj := &config.ProjectConfig{
+		Name:          name,
+		Path:          projectPath,
+		Navigator:     navigator,
+		DefaultBranch: branch,
+		GitHub:        ghConfig,
+	}
+	cfg.Projects = append(cfg.Projects, proj)
+	if setDefault || len(cfg.Projects) == 1 {
+		cfg.DefaultProject = name
+	}
+
+	if err := config.Save(cfg, configPath); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	// ── success ───────────────────────────────────────────────────────────────
+	fmt.Printf("  %s Project added: %s\n", onboardSuccessStyle.Render("✓"), name)
+	fmt.Printf("      Path:      %s\n", projectPath)
+	if ghConfig != nil {
+		fmt.Printf("      GitHub:    %s/%s\n", ghConfig.Owner, ghConfig.Repo)
+	}
+	fmt.Printf("      Branch:    %s\n", branch)
+	fmt.Printf("      Navigator: %s\n", navStr)
+	if defaultStr == "yes" {
+		fmt.Println("      Default:   yes")
+	}
+	fmt.Println()
+	fmt.Printf("  → Start working:  pilot start --project %s --github\n", name)
+
+	return nil
+}

--- a/cmd/pilot/project_wizard_test.go
+++ b/cmd/pilot/project_wizard_test.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/config"
+)
+
+// fakeGhRunner builds a fake ghRunner that replies based on the subcommand.
+func fakeGhRunner(t *testing.T, statusOK bool, username, token string, repos []ghRepoEntry) func(args ...string) ([]byte, error) {
+	t.Helper()
+	return func(args ...string) ([]byte, error) {
+		if len(args) == 0 {
+			return nil, fmt.Errorf("no args")
+		}
+		switch args[0] {
+		case "auth":
+			if len(args) >= 2 && args[1] == "status" {
+				if !statusOK {
+					return nil, fmt.Errorf("not authenticated")
+				}
+				return []byte("Logged in"), nil
+			}
+			if len(args) >= 2 && args[1] == "token" {
+				if token == "" {
+					return nil, fmt.Errorf("no token")
+				}
+				return []byte(token + "\n"), nil
+			}
+		case "api":
+			return []byte(username + "\n"), nil
+		case "repo":
+			data, err := json.Marshal(repos)
+			if err != nil {
+				return nil, err
+			}
+			return data, nil
+		}
+		return nil, fmt.Errorf("unknown gh command: %v", args)
+	}
+}
+
+// writeTempConfig writes an empty default config to a temp dir and returns the path.
+func writeTempConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	cfg := config.DefaultConfig()
+	if err := config.Save(cfg, path); err != nil {
+		t.Fatalf("writeTempConfig: %v", err)
+	}
+	return path
+}
+
+// TestGhAuthStatus_Authenticated confirms (username, true) when gh succeeds.
+func TestGhAuthStatus_Authenticated(t *testing.T) {
+	orig := ghRunner
+	t.Cleanup(func() { ghRunner = orig })
+	ghRunner = fakeGhRunner(t, true, "alice", "fake-token", nil)
+
+	user, ok := ghAuthStatus()
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if user != "alice" {
+		t.Fatalf("expected username=alice, got %q", user)
+	}
+}
+
+// TestGhAuthStatus_Unauthenticated confirms (_, false) when gh is absent.
+func TestGhAuthStatus_Unauthenticated(t *testing.T) {
+	orig := ghRunner
+	t.Cleanup(func() { ghRunner = orig })
+	ghRunner = fakeGhRunner(t, false, "", "", nil)
+
+	_, ok := ghAuthStatus()
+	if ok {
+		t.Fatal("expected ok=false")
+	}
+}
+
+// TestGhAuthToken returns the token trimmed of trailing newline.
+func TestGhAuthToken(t *testing.T) {
+	orig := ghRunner
+	t.Cleanup(func() { ghRunner = orig })
+	ghRunner = fakeGhRunner(t, true, "alice", "fake-test-gh-token", nil)
+
+	tok, err := ghAuthToken()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "fake-test-gh-token" {
+		t.Fatalf("expected fake-test-gh-token, got %q", tok)
+	}
+}
+
+// TestGhRepoList parses the JSON returned by the fake gh runner.
+func TestGhRepoList(t *testing.T) {
+	orig := ghRunner
+	t.Cleanup(func() { ghRunner = orig })
+
+	repos := []ghRepoEntry{
+		{NameWithOwner: "alice/foo", Description: "a repo", IsPrivate: false},
+		{NameWithOwner: "alice/bar", Description: "", IsPrivate: true},
+	}
+	ghRunner = fakeGhRunner(t, true, "alice", "fake-token", repos)
+
+	got, err := ghRepoList(50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(got))
+	}
+	if got[0].NameWithOwner != "alice/foo" {
+		t.Errorf("expected alice/foo, got %q", got[0].NameWithOwner)
+	}
+	if !got[1].IsPrivate {
+		t.Error("expected bar to be private")
+	}
+}
+
+// TestProjectAddFlags_Basic verifies the flag-driven path writes a project.
+func TestProjectAddFlags_Basic(t *testing.T) {
+	dir := t.TempDir()
+
+	cfgPath := writeTempConfig(t)
+	oldCfg := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = oldCfg })
+
+	if err := runProjectAddFlags(nil, "myapp", dir, "", "", false, false); err != nil {
+		t.Fatalf("runProjectAddFlags: %v", err)
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(cfg.Projects) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(cfg.Projects))
+	}
+	if cfg.Projects[0].Name != "myapp" {
+		t.Errorf("expected name=myapp, got %q", cfg.Projects[0].Name)
+	}
+	if cfg.Projects[0].Path != dir {
+		t.Errorf("expected path=%s, got %q", dir, cfg.Projects[0].Path)
+	}
+}
+
+// TestProjectAddFlags_DuplicateName rejects adding the same name twice.
+func TestProjectAddFlags_DuplicateName(t *testing.T) {
+	dir := t.TempDir()
+
+	cfgPath := writeTempConfig(t)
+	oldCfg := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = oldCfg })
+
+	if err := runProjectAddFlags(nil, "dupe", dir, "", "", false, false); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+
+	dir2 := t.TempDir()
+	err := runProjectAddFlags(nil, "dupe", dir2, "", "", false, false)
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected duplicate-name error, got: %v", err)
+	}
+}
+
+// TestProjectAddFlags_DuplicatePath rejects a path that is already configured.
+func TestProjectAddFlags_DuplicatePath(t *testing.T) {
+	dir := t.TempDir()
+
+	cfgPath := writeTempConfig(t)
+	oldCfg := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = oldCfg })
+
+	if err := runProjectAddFlags(nil, "first", dir, "", "", false, false); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+
+	err := runProjectAddFlags(nil, "second", dir, "", "", false, false)
+	if err == nil || !strings.Contains(err.Error(), "already configured") {
+		t.Fatalf("expected duplicate-path error, got: %v", err)
+	}
+}
+
+// TestProjectAddFlags_NameRequired returns an error when --name is empty.
+func TestProjectAddFlags_NameRequired(t *testing.T) {
+	cfgPath := writeTempConfig(t)
+	oldCfg := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = oldCfg })
+
+	err := runProjectAddFlags(nil, "", "", "", "", false, false)
+	if err == nil || !strings.Contains(err.Error(), "--name is required") {
+		t.Fatalf("expected --name required error, got: %v", err)
+	}
+}
+
+// TestProjectAddFlags_GitHubParsed verifies owner/repo is split from --github.
+func TestProjectAddFlags_GitHubParsed(t *testing.T) {
+	dir := t.TempDir()
+
+	cfgPath := writeTempConfig(t)
+	oldCfg := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = oldCfg })
+
+	if err := runProjectAddFlags(nil, "ghtest", dir, "alice/myrepo", "", false, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Projects[0].GitHub == nil {
+		t.Fatal("expected GitHub to be set")
+	}
+	if cfg.Projects[0].GitHub.Owner != "alice" || cfg.Projects[0].GitHub.Repo != "myrepo" {
+		t.Errorf("unexpected GitHub config: %+v", cfg.Projects[0].GitHub)
+	}
+}
+
+// TestProjectAddFlags_InvalidGitHub rejects a --github value without a slash.
+func TestProjectAddFlags_InvalidGitHub(t *testing.T) {
+	dir := t.TempDir()
+
+	cfgPath := writeTempConfig(t)
+	oldCfg := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = oldCfg })
+
+	err := runProjectAddFlags(nil, "bad", dir, "noslash", "", false, false)
+	if err == nil || !strings.Contains(err.Error(), "invalid GitHub format") {
+		t.Fatalf("expected invalid-format error, got: %v", err)
+	}
+}
+
+// TestIsInteractiveTTY is false in a `go test` run (stdin is a pipe).
+func TestIsInteractiveTTY(t *testing.T) {
+	// In a standard `go test` run stdin is not a terminal.
+	// If it somehow is, just skip — the function is correct either way.
+	if isInteractiveTTY() {
+		t.Skip("stdin is a TTY in this environment")
+	}
+}
+
+// TestProjectAddWizard_FallbackWhenGhAbsent confirms that runProjectAddWizard
+// prints a hint and returns nil (no error) when gh is unavailable.
+func TestProjectAddWizard_FallbackWhenGhAbsent(t *testing.T) {
+	orig := ghRunner
+	t.Cleanup(func() { ghRunner = orig })
+	ghRunner = fakeGhRunner(t, false, "", "", nil)
+
+	cfgPath := writeTempConfig(t)
+	oldCfg := cfgFile
+	cfgFile = cfgPath
+	t.Cleanup(func() { cfgFile = oldCfg })
+
+	err := runProjectAddWizard(nil)
+	if err != nil {
+		t.Fatalf("expected nil error on fallback, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `pilot project add` (no flags on interactive TTY) enters wizard mode, guiding new users from zero to a runnable project entry in `~/.pilot/config.yaml`
- Detects `gh auth status`; if authenticated and no GitHub token is configured, offers opt-in seeding of `adapters.github.token` via `gh auth token`
- Shows a numbered repo picker from `gh repo list --limit 50 --json` with visibility and description
- Prefills project name from selected repo, local path from CWD; prompts for set-as-default
- Shows a confirm-before-write summary; aborts cleanly on "n"
- Graceful fallback with hint message when `gh` is absent or unauthenticated
- All existing flag-driven invocations (`--name`, `--github`, `--path`, etc.) unchanged
- New `--no-wizard` flag forces flag-driven mode for CI/scripting

## Implementation

- `cmd/pilot/project.go` — added `--no-wizard` flag; extracted flag logic into `runProjectAddFlags()`; `RunE` branches on `name == "" && !noWizard && isInteractiveTTY()`
- `cmd/pilot/project_wizard.go` (new) — `ghRunner` injectable var; `ghAuthStatus`, `ghAuthToken`, `ghRepoList` helpers; `runProjectAddWizard` full wizard; `isInteractiveTTY` for TTY detection
- `cmd/pilot/project_wizard_test.go` (new) — 11 tests covering: gh auth helpers, repo list parsing, flag-mode happy path, duplicate name/path rejection, `--name` required, GitHub format validation, fallback when gh absent

## Test plan

- [ ] `go test ./cmd/pilot/... -run "TestGhAuth|TestGhRepo|TestProjectAddFlags|TestProjectAddWizard|TestIsInteractive"` — all pass
- [ ] `make build && make lint` — zero issues
- [ ] `./bin/pilot project add --name x --github a/b` — flag mode still works
- [ ] `./bin/pilot project add --no-wizard` — force flag mode (errors on missing --name)
- [ ] Manual: `./bin/pilot project add` on a TTY with `gh` authenticated → wizard launches