### PR TITLE
GH-3616: feat(memory): populate cache token fields from ExecutionResult

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -36,7 +36,8 @@ var sparkBlocks = []rune{' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '
 
 // MetricsCardData holds aggregated metrics for the dashboard metrics cards.
 type MetricsCardData struct {
-	TotalTokens, InputTokens, OutputTokens  int
+	TotalTokens, InputTokens, OutputTokens   int
+	CacheReadTokens, CacheWriteTokens        int
 	TotalCostUSD, CostPerTask               float64
 	TotalTasks, Succeeded, Failed, Declined int
 	// TASK-358: non-failure terminal outcomes, split out of "failed".
@@ -593,6 +594,8 @@ func (m *Model) hydrateFromStore() {
 		m.metricsCard.TotalTokens = int(lifetime.TotalTokens)
 		m.metricsCard.InputTokens = int(lifetime.InputTokens)
 		m.metricsCard.OutputTokens = int(lifetime.OutputTokens)
+		m.metricsCard.CacheReadTokens = int(lifetime.CacheReadTokens)
+		m.metricsCard.CacheWriteTokens = int(lifetime.CacheWriteTokens)
 		m.metricsCard.TotalCostUSD = lifetime.TotalCostUSD
 	}
 
@@ -892,6 +895,8 @@ func storeRefreshCmd(store *memory.Store, projectPath string) tea.Cmd {
 			msg.metricsCard.TotalTokens = int(lifetime.TotalTokens)
 			msg.metricsCard.InputTokens = int(lifetime.InputTokens)
 			msg.metricsCard.OutputTokens = int(lifetime.OutputTokens)
+			msg.metricsCard.CacheReadTokens = int(lifetime.CacheReadTokens)
+			msg.metricsCard.CacheWriteTokens = int(lifetime.CacheWriteTokens)
 			msg.metricsCard.TotalCostUSD = lifetime.TotalCostUSD
 		}
 
@@ -2047,9 +2052,11 @@ func buildMiniCard(title, value, detail1, detail2, sparkline string, cw int) str
 // renderTokenCard renders the TOKENS mini-card with the given card width.
 func (m Model) renderTokenCard(cw int) string {
 	ciw := cw - 6
-	value := titleStyle.Render(formatCompact(m.metricsCard.TotalTokens))
+	cacheTotal := m.metricsCard.CacheReadTokens + m.metricsCard.CacheWriteTokens
+	total := m.metricsCard.TotalTokens + cacheTotal
+	value := titleStyle.Render(formatCompact(total))
 	detail1 := dimStyle.Render(fmt.Sprintf("↑ %s input", formatCompact(m.metricsCard.InputTokens)))
-	detail2 := dimStyle.Render(fmt.Sprintf("↓ %s output", formatCompact(m.metricsCard.OutputTokens)))
+	detail2 := dimStyle.Render(fmt.Sprintf("⚡ %s cached", formatCompact(cacheTotal)))
 
 	// Convert int64 history to float64
 	floats := make([]float64, len(m.metricsCard.TokenHistory))

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -172,17 +172,19 @@ func TestBuildMiniCard(t *testing.T) {
 func TestRenderMetricsCards(t *testing.T) {
 	m := NewModel("test")
 	m.metricsCard = MetricsCardData{
-		TotalTokens:  50000,
-		InputTokens:  30000,
-		OutputTokens: 20000,
-		TotalCostUSD: 1.50,
-		CostPerTask:  0.25,
-		TotalTasks:   10,
-		Succeeded:    8,
-		Failed:       2,
-		TokenHistory: []int64{100, 200, 300, 400, 500, 600, 700},
-		CostHistory:  []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7},
-		TaskHistory:  []int{1, 2, 3, 2, 1, 3, 2},
+		TotalTokens:      50000,
+		InputTokens:      30000,
+		OutputTokens:     20000,
+		CacheReadTokens:  100000,
+		CacheWriteTokens: 50000,
+		TotalCostUSD:     1.50,
+		CostPerTask:      0.25,
+		TotalTasks:       10,
+		Succeeded:        8,
+		Failed:           2,
+		TokenHistory:     []int64{100, 200, 300, 400, 500, 600, 700},
+		CostHistory:      []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7},
+		TaskHistory:      []int{1, 2, 3, 2, 1, 3, 2},
 	}
 
 	output := m.renderMetricsCards()
@@ -195,6 +197,29 @@ func TestRenderMetricsCards(t *testing.T) {
 	}
 	if !strings.Contains(output, "QUEUE") {
 		t.Error("output missing TASKS card")
+	}
+	// TOKENS card should include the cached line
+	if !strings.Contains(output, "cached") {
+		t.Error("TOKENS card missing cached line")
+	}
+}
+
+func TestRenderTokenCard_CacheInclusive(t *testing.T) {
+	m := NewModel("test")
+	m.metricsCard = MetricsCardData{
+		TotalTokens:      10000,
+		InputTokens:      10000,
+		OutputTokens:     0,
+		CacheReadTokens:  80000,
+		CacheWriteTokens: 20000,
+	}
+	card := m.renderTokenCard(23)
+	// Total shown should be cache-inclusive: 10000 + 80000 + 20000 = 110000 → "110.0K"
+	if !strings.Contains(card, "110.0K") {
+		t.Errorf("expected cache-inclusive total 110.0K in card, got:\n%s", card)
+	}
+	if !strings.Contains(card, "cached") {
+		t.Errorf("expected cached line in token card, got:\n%s", card)
 	}
 }
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -3832,10 +3832,12 @@ func (r *Runner) recordLearning(ctx context.Context, task *Task, result *Executi
 		DurationMs:   result.Duration.Milliseconds(),
 		PRUrl:        result.PRUrl,
 		CommitSHA:    result.CommitSHA,
-		TokensInput:  result.TokensInput,
-		TokensOutput: result.TokensOutput,
-		FilesChanged: result.FilesChanged,
-		ModelName:    result.ModelName,
+		TokensInput:     result.TokensInput,
+		TokensOutput:    result.TokensOutput,
+		TokensCacheRead: result.CacheReadInputTokens,
+		TokensCacheWrite: result.CacheCreationInputTokens,
+		FilesChanged:    result.FilesChanged,
+		ModelName:       result.ModelName,
 	}
 	if learnErr := r.learningLoop.RecordExecution(ctx, exec, nil); learnErr != nil {
 		r.log.Warn("Failed to record execution for learning", slog.Any("error", learnErr))

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -335,6 +335,9 @@ func (s *Store) migrate() error {
 		`ALTER TABLE executions ADD COLUMN final_rss_mb INTEGER DEFAULT 0`,
 		// GH-3536: project scoping for eval tasks
 		`ALTER TABLE eval_tasks ADD COLUMN project_path TEXT DEFAULT ''`,
+		// GH-3616: cache token counts per execution
+		`ALTER TABLE executions ADD COLUMN tokens_cache_read INTEGER DEFAULT 0`,
+		`ALTER TABLE executions ADD COLUMN tokens_cache_write INTEGER DEFAULT 0`,
 	}
 
 	for _, migration := range migrations {
@@ -483,6 +486,9 @@ type Execution struct {
 	TokensInput      int64
 	TokensOutput     int64
 	TokensTotal      int64
+	// GH-3616: cache token counts
+	TokensCacheRead  int64
+	TokensCacheWrite int64
 	EstimatedCostUSD float64
 	FilesChanged     int
 	LinesAdded       int
@@ -526,13 +532,15 @@ func (s *Store) SaveExecution(exec *Execution) error {
 				tokens_input, tokens_output, tokens_total, estimated_cost_usd, files_changed, lines_added, lines_removed, model_name,
 				task_title, task_description, task_branch, task_base_branch, task_create_pr, task_verbose,
 				task_source_adapter, task_source_issue_id, task_labels,
-				approval_request_id, effort_level, complexity_level)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				approval_request_id, effort_level, complexity_level,
+				tokens_cache_read, tokens_cache_write)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, exec.ID, exec.TaskID, exec.ProjectPath, exec.Status, exec.Output, exec.Error, exec.DurationMs, exec.PRUrl, exec.CommitSHA, exec.CompletedAt,
 			exec.TokensInput, exec.TokensOutput, exec.TokensTotal, exec.EstimatedCostUSD, exec.FilesChanged, exec.LinesAdded, exec.LinesRemoved, exec.ModelName,
 			exec.TaskTitle, exec.TaskDescription, exec.TaskBranch, exec.TaskBaseBranch, exec.TaskCreatePR, exec.TaskVerbose,
 			exec.TaskSourceAdapter, exec.TaskSourceIssueID, labelsJSON,
-			exec.ApprovalRequestID, exec.EffortLevel, exec.ComplexityLevel)
+			exec.ApprovalRequestID, exec.EffortLevel, exec.ComplexityLevel,
+			exec.TokensCacheRead, exec.TokensCacheWrite)
 		return err
 	})
 }
@@ -579,7 +587,8 @@ func (s *Store) GetExecution(id string) (*Execution, error) {
 			COALESCE(approval_request_id, ''), COALESCE(approval_decision, ''),
 			approval_decision_at,
 			COALESCE(approval_decision_by, ''),
-			COALESCE(effort_level, ''), COALESCE(complexity_level, '')
+			COALESCE(effort_level, ''), COALESCE(complexity_level, ''),
+			COALESCE(tokens_cache_read, 0), COALESCE(tokens_cache_write, 0)
 		FROM executions WHERE id = ?
 	`, id)
 
@@ -592,7 +601,8 @@ func (s *Store) GetExecution(id string) (*Execution, error) {
 		&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose,
 		&exec.TaskSourceAdapter, &exec.TaskSourceIssueID, &labelsJSON,
 		&exec.ApprovalRequestID, &exec.ApprovalDecision, &approvalDecisionAt, &exec.ApprovalDecisionBy,
-		&exec.EffortLevel, &exec.ComplexityLevel)
+		&exec.EffortLevel, &exec.ComplexityLevel,
+		&exec.TokensCacheRead, &exec.TokensCacheWrite)
 	if err != nil {
 		return nil, err
 	}
@@ -1773,10 +1783,12 @@ func (s *Store) UpdateSessionTaskCount(sessionID string, completed, failed int) 
 
 // LifetimeTokens holds cumulative token and cost totals from all executions.
 type LifetimeTokens struct {
-	InputTokens  int64
-	OutputTokens int64
-	TotalTokens  int64
-	TotalCostUSD float64
+	InputTokens     int64
+	OutputTokens    int64
+	TotalTokens     int64
+	CacheReadTokens int64
+	CacheWriteTokens int64
+	TotalCostUSD    float64
 }
 
 // GetLifetimeTokens returns cumulative token usage and cost across all executions.
@@ -1790,6 +1802,8 @@ func (s *Store) GetLifetimeTokens(projectPath string) (*LifetimeTokens, error) {
 			COALESCE(SUM(tokens_input), 0),
 			COALESCE(SUM(tokens_output), 0),
 			COALESCE(SUM(tokens_total), 0),
+			COALESCE(SUM(tokens_cache_read), 0),
+			COALESCE(SUM(tokens_cache_write), 0),
 			COALESCE(SUM(estimated_cost_usd), 0)
 		FROM executions
 		WHERE tokens_total > 0`
@@ -1801,7 +1815,7 @@ func (s *Store) GetLifetimeTokens(projectPath string) (*LifetimeTokens, error) {
 	}
 
 	var lt LifetimeTokens
-	if err := row.Scan(&lt.InputTokens, &lt.OutputTokens, &lt.TotalTokens, &lt.TotalCostUSD); err != nil {
+	if err := row.Scan(&lt.InputTokens, &lt.OutputTokens, &lt.TotalTokens, &lt.CacheReadTokens, &lt.CacheWriteTokens, &lt.TotalCostUSD); err != nil {
 		return nil, fmt.Errorf("failed to get lifetime tokens: %w", err)
 	}
 	return &lt, nil


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3616.

Closes #3616

## Changes

At the result→Execution mapping site (where TokensInput/TokensOutput are copied from ExecutionResult), populate the new fields from CacheCreationInputTokens (→ TokensCacheWrite) and CacheReadInputTokens (→ TokensCacheRead).