### PR TITLE
feat(memory): surface cache token sums in aggregation metrics (GH-3617)

### DIFF
--- a/internal/memory/metrics.go
+++ b/internal/memory/metrics.go
@@ -45,10 +45,12 @@ type MetricsSummary struct {
 	MaxDurationMs   int64
 
 	// Tokens
-	TotalTokensInput  int64
-	TotalTokensOutput int64
-	TotalTokens       int64
-	AvgTokensPerTask  int64
+	TotalTokensInput      int64
+	TotalTokensOutput     int64
+	TotalTokens           int64
+	TotalTokensCacheRead  int64
+	TotalTokensCacheWrite int64
+	AvgTokensPerTask      int64
 
 	// Cost
 	TotalCostUSD float64
@@ -261,6 +263,8 @@ func (s *Store) GetMetricsSummary(query MetricsQuery) (*MetricsSummary, error) {
 			COALESCE(SUM(tokens_input), 0) as total_input,
 			COALESCE(SUM(tokens_output), 0) as total_output,
 			COALESCE(SUM(tokens_total), 0) as total_tokens,
+			COALESCE(SUM(tokens_cache_read), 0) as total_cache_read,
+			COALESCE(SUM(tokens_cache_write), 0) as total_cache_write,
 			COALESCE(SUM(estimated_cost_usd), 0) as total_cost,
 			COALESCE(SUM(files_changed), 0) as files_changed,
 			COALESCE(SUM(lines_added), 0) as lines_added,
@@ -280,6 +284,8 @@ func (s *Store) GetMetricsSummary(query MetricsQuery) (*MetricsSummary, error) {
 		&summary.TotalTokensInput,
 		&summary.TotalTokensOutput,
 		&summary.TotalTokens,
+		&summary.TotalTokensCacheRead,
+		&summary.TotalTokensCacheWrite,
 		&summary.TotalCostUSD,
 		&summary.TotalFilesChanged,
 		&summary.TotalLinesAdded,
@@ -545,7 +551,7 @@ func (s *Store) ExportMetrics(query MetricsQuery) ([]*ExportedExecution, error) 
 	rows, err := s.db.Query(`
 		SELECT
 			id, task_id, project_path, status, duration_ms,
-			tokens_input, tokens_output, tokens_total, estimated_cost_usd,
+			tokens_input, tokens_output, tokens_total, tokens_cache_read, tokens_cache_write, estimated_cost_usd,
 			files_changed, lines_added, lines_removed, model_name,
 			pr_url, commit_sha, created_at, completed_at
 		FROM executions
@@ -561,14 +567,14 @@ func (s *Store) ExportMetrics(query MetricsQuery) ([]*ExportedExecution, error) 
 	for rows.Next() {
 		var e ExportedExecution
 		var completedAt sql.NullTime
-		var tokensInput, tokensOutput, tokensTotal sql.NullInt64
+		var tokensInput, tokensOutput, tokensTotal, tokensCacheRead, tokensCacheWrite sql.NullInt64
 		var cost sql.NullFloat64
 		var filesChanged, linesAdded, linesRemoved sql.NullInt64
 		var modelName, prURL, commitSHA sql.NullString
 
 		if err := rows.Scan(
 			&e.ID, &e.TaskID, &e.ProjectPath, &e.Status, &e.DurationMs,
-			&tokensInput, &tokensOutput, &tokensTotal, &cost,
+			&tokensInput, &tokensOutput, &tokensTotal, &tokensCacheRead, &tokensCacheWrite, &cost,
 			&filesChanged, &linesAdded, &linesRemoved, &modelName,
 			&prURL, &commitSHA, &e.CreatedAt, &completedAt,
 		); err != nil {
@@ -583,6 +589,12 @@ func (s *Store) ExportMetrics(query MetricsQuery) ([]*ExportedExecution, error) 
 		}
 		if tokensTotal.Valid {
 			e.TokensTotal = tokensTotal.Int64
+		}
+		if tokensCacheRead.Valid {
+			e.TokensCacheRead = tokensCacheRead.Int64
+		}
+		if tokensCacheWrite.Valid {
+			e.TokensCacheWrite = tokensCacheWrite.Int64
 		}
 		if cost.Valid {
 			e.EstimatedCostUSD = cost.Float64
@@ -625,6 +637,8 @@ type ExportedExecution struct {
 	TokensInput      int64      `json:"tokens_input"`
 	TokensOutput     int64      `json:"tokens_output"`
 	TokensTotal      int64      `json:"tokens_total"`
+	TokensCacheRead  int64      `json:"tokens_cache_read"`
+	TokensCacheWrite int64      `json:"tokens_cache_write"`
 	EstimatedCostUSD float64    `json:"estimated_cost_usd"`
 	FilesChanged     int        `json:"files_changed"`
 	LinesAdded       int        `json:"lines_added"`

--- a/internal/memory/metrics_cache_tokens_test.go
+++ b/internal/memory/metrics_cache_tokens_test.go
@@ -1,0 +1,124 @@
+package memory
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestGetMetricsSummary_CacheTokens(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-metrics-cache-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().UTC()
+	execs := []*Execution{
+		{
+			ID:               "e1",
+			TaskID:           "T1",
+			ProjectPath:      "/proj",
+			Status:           "completed",
+			DurationMs:       1000,
+			TokensInput:      100,
+			TokensOutput:     200,
+			TokensTotal:      300,
+			TokensCacheRead:  400,
+			TokensCacheWrite: 50,
+			CreatedAt:        now,
+		},
+		{
+			ID:               "e2",
+			TaskID:           "T2",
+			ProjectPath:      "/proj",
+			Status:           "completed",
+			DurationMs:       2000,
+			TokensInput:      500,
+			TokensOutput:     600,
+			TokensTotal:      1100,
+			TokensCacheRead:  200,
+			TokensCacheWrite: 75,
+			CreatedAt:        now,
+		},
+	}
+	for _, e := range execs {
+		if err := store.SaveExecution(e); err != nil {
+			t.Fatalf("SaveExecution %s: %v", e.ID, err)
+		}
+	}
+
+	q := MetricsQuery{
+		Start: now.Add(-time.Hour),
+		End:   now.Add(time.Hour),
+	}
+	summary, err := store.GetMetricsSummary(q)
+	if err != nil {
+		t.Fatalf("GetMetricsSummary: %v", err)
+	}
+
+	if summary.TotalTokensCacheRead != 600 {
+		t.Errorf("TotalTokensCacheRead = %d, want 600", summary.TotalTokensCacheRead)
+	}
+	if summary.TotalTokensCacheWrite != 125 {
+		t.Errorf("TotalTokensCacheWrite = %d, want 125", summary.TotalTokensCacheWrite)
+	}
+}
+
+func TestExportMetrics_CacheTokens(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-export-cache-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().UTC()
+	e := &Execution{
+		ID:               "e1",
+		TaskID:           "T1",
+		ProjectPath:      "/proj",
+		Status:           "completed",
+		DurationMs:       1000,
+		TokensInput:      100,
+		TokensOutput:     200,
+		TokensTotal:      300,
+		TokensCacheRead:  777,
+		TokensCacheWrite: 333,
+		CreatedAt:        now,
+	}
+	if err := store.SaveExecution(e); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	q := MetricsQuery{
+		Start: now.Add(-time.Hour),
+		End:   now.Add(time.Hour),
+	}
+	exports, err := store.ExportMetrics(q)
+	if err != nil {
+		t.Fatalf("ExportMetrics: %v", err)
+	}
+	if len(exports) != 1 {
+		t.Fatalf("len(exports) = %d, want 1", len(exports))
+	}
+
+	got := exports[0]
+	if got.TokensCacheRead != 777 {
+		t.Errorf("TokensCacheRead = %d, want 777", got.TokensCacheRead)
+	}
+	if got.TokensCacheWrite != 333 {
+		t.Errorf("TokensCacheWrite = %d, want 333", got.TokensCacheWrite)
+	}
+}


### PR DESCRIPTION
## Summary

- Added `TotalTokensCacheRead` and `TotalTokensCacheWrite` fields to `MetricsSummary` struct
- Extended `GetMetricsSummary` SQL query to `COALESCE(SUM(tokens_cache_read), 0)` and `COALESCE(SUM(tokens_cache_write), 0)` with corresponding `Scan` targets
- Added `TokensCacheRead` and `TokensCacheWrite` to `ExportedExecution` struct and the `ExportMetrics` SELECT + scan path
- Added `metrics_cache_tokens_test.go` with two tests covering both aggregation and export paths

Builds on `55f835d3` which added the DB columns and `Execution` struct fields.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/memory/...` passes (all existing + 2 new tests)
- [x] `TestGetMetricsSummary_CacheTokens` — verifies SUM of cache read/write across two executions
- [x] `TestExportMetrics_CacheTokens` — verifies per-row cache token fields in export output