### PR TITLE
GH-3618: feat(memory): update TOKENS card in TUI to show cached/uncached split

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -36,9 +36,10 @@ var sparkBlocks = []rune{' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '
 
 // MetricsCardData holds aggregated metrics for the dashboard metrics cards.
 type MetricsCardData struct {
-	TotalTokens, InputTokens, OutputTokens  int
-	TotalCostUSD, CostPerTask               float64
-	TotalTasks, Succeeded, Failed, Declined int
+	TotalTokens, InputTokens, OutputTokens   int
+	CacheReadTokens, CacheWriteTokens        int
+	TotalCostUSD, CostPerTask                float64
+	TotalTasks, Succeeded, Failed, Declined  int
 	// TASK-358: non-failure terminal outcomes, split out of "failed".
 	NoOp, Stalled, RateLimited, Infra, Skipped int
 	TokenHistory                               []int64   // 7 days
@@ -593,6 +594,8 @@ func (m *Model) hydrateFromStore() {
 		m.metricsCard.TotalTokens = int(lifetime.TotalTokens)
 		m.metricsCard.InputTokens = int(lifetime.InputTokens)
 		m.metricsCard.OutputTokens = int(lifetime.OutputTokens)
+		m.metricsCard.CacheReadTokens = int(lifetime.CacheReadTokens)
+		m.metricsCard.CacheWriteTokens = int(lifetime.CacheWriteTokens)
 		m.metricsCard.TotalCostUSD = lifetime.TotalCostUSD
 	}
 
@@ -892,6 +895,8 @@ func storeRefreshCmd(store *memory.Store, projectPath string) tea.Cmd {
 			msg.metricsCard.TotalTokens = int(lifetime.TotalTokens)
 			msg.metricsCard.InputTokens = int(lifetime.InputTokens)
 			msg.metricsCard.OutputTokens = int(lifetime.OutputTokens)
+			msg.metricsCard.CacheReadTokens = int(lifetime.CacheReadTokens)
+			msg.metricsCard.CacheWriteTokens = int(lifetime.CacheWriteTokens)
 			msg.metricsCard.TotalCostUSD = lifetime.TotalCostUSD
 		}
 
@@ -2045,11 +2050,13 @@ func buildMiniCard(title, value, detail1, detail2, sparkline string, cw int) str
 // --- Card renderers ---
 
 // renderTokenCard renders the TOKENS mini-card with the given card width.
+// Shows a cached/uncached split: cached = cache_read tokens, uncached = input+output.
 func (m Model) renderTokenCard(cw int) string {
 	ciw := cw - 6
-	value := titleStyle.Render(formatCompact(m.metricsCard.TotalTokens))
-	detail1 := dimStyle.Render(fmt.Sprintf("↑ %s input", formatCompact(m.metricsCard.InputTokens)))
-	detail2 := dimStyle.Render(fmt.Sprintf("↓ %s output", formatCompact(m.metricsCard.OutputTokens)))
+	grandTotal := m.metricsCard.TotalTokens + m.metricsCard.CacheReadTokens + m.metricsCard.CacheWriteTokens
+	value := titleStyle.Render(formatCompact(grandTotal))
+	detail1 := dimStyle.Render(fmt.Sprintf("↑ %s cached", formatCompact(m.metricsCard.CacheReadTokens)))
+	detail2 := dimStyle.Render(fmt.Sprintf("↓ %s uncached", formatCompact(m.metricsCard.TotalTokens)))
 
 	// Convert int64 history to float64
 	floats := make([]float64, len(m.metricsCard.TokenHistory))

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -219,6 +219,52 @@ func TestRenderMetricsCards_ZeroState(t *testing.T) {
 	}
 }
 
+func TestRenderTokenCard_CacheBreakdown(t *testing.T) {
+	m := NewModel("test")
+	m.metricsCard = MetricsCardData{
+		TotalTokens:      10_000, // input+output
+		InputTokens:      7_000,
+		OutputTokens:     3_000,
+		CacheReadTokens:  90_000, // dominates throughput
+		CacheWriteTokens: 5_000,
+		TokenHistory:     []int64{100, 200, 300, 400, 500, 600, 700},
+	}
+
+	out := m.renderTokenCard(cardWidth)
+
+	// Grand total = 10_000 + 90_000 + 5_000 = 105_000
+	if !strings.Contains(out, "105.0K") {
+		t.Errorf("renderTokenCard: expected grand total 105.0K in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "cached") {
+		t.Errorf("renderTokenCard: expected 'cached' label in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "uncached") {
+		t.Errorf("renderTokenCard: expected 'uncached' label in output, got:\n%s", out)
+	}
+}
+
+func TestRenderTokenCard_ZeroCacheTokens(t *testing.T) {
+	m := NewModel("test")
+	m.metricsCard = MetricsCardData{
+		TotalTokens:  50_000,
+		InputTokens:  30_000,
+		OutputTokens: 20_000,
+		// CacheReadTokens and CacheWriteTokens both zero
+		TokenHistory: []int64{100, 200, 300, 400, 500, 600, 700},
+	}
+
+	out := m.renderTokenCard(cardWidth)
+
+	// When cache is zero, grand total == TotalTokens
+	if !strings.Contains(out, "50.0K") {
+		t.Errorf("renderTokenCard zero-cache: expected 50.0K total, got:\n%s", out)
+	}
+	if !strings.Contains(out, "uncached") {
+		t.Errorf("renderTokenCard zero-cache: expected 'uncached' label, got:\n%s", out)
+	}
+}
+
 func TestRenderTaskCard_ShowsQueueDepth(t *testing.T) {
 	m := NewModel("test")
 	// Simulate 10 lifetime tasks (succeeded + failed) in metrics

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1782,10 +1782,12 @@ func (s *Store) UpdateSessionTaskCount(sessionID string, completed, failed int) 
 
 // LifetimeTokens holds cumulative token and cost totals from all executions.
 type LifetimeTokens struct {
-	InputTokens  int64
-	OutputTokens int64
-	TotalTokens  int64
-	TotalCostUSD float64
+	InputTokens      int64
+	OutputTokens     int64
+	TotalTokens      int64
+	CacheReadTokens  int64
+	CacheWriteTokens int64
+	TotalCostUSD     float64
 }
 
 // GetLifetimeTokens returns cumulative token usage and cost across all executions.
@@ -1799,6 +1801,8 @@ func (s *Store) GetLifetimeTokens(projectPath string) (*LifetimeTokens, error) {
 			COALESCE(SUM(tokens_input), 0),
 			COALESCE(SUM(tokens_output), 0),
 			COALESCE(SUM(tokens_total), 0),
+			COALESCE(SUM(tokens_cache_read), 0),
+			COALESCE(SUM(tokens_cache_write), 0),
 			COALESCE(SUM(estimated_cost_usd), 0)
 		FROM executions
 		WHERE tokens_total > 0`
@@ -1810,7 +1814,8 @@ func (s *Store) GetLifetimeTokens(projectPath string) (*LifetimeTokens, error) {
 	}
 
 	var lt LifetimeTokens
-	if err := row.Scan(&lt.InputTokens, &lt.OutputTokens, &lt.TotalTokens, &lt.TotalCostUSD); err != nil {
+	if err := row.Scan(&lt.InputTokens, &lt.OutputTokens, &lt.TotalTokens,
+		&lt.CacheReadTokens, &lt.CacheWriteTokens, &lt.TotalCostUSD); err != nil {
 		return nil, fmt.Errorf("failed to get lifetime tokens: %w", err)
 	}
 	return &lt, nil

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1079,6 +1079,61 @@ func TestGetLifetimeTokens(t *testing.T) {
 	}
 }
 
+func TestGetLifetimeTokens_CacheFields(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Insert two executions with cache token data via SaveExecution.
+	execs := []struct {
+		id         string
+		input      int64
+		output     int64
+		cacheRead  int64
+		cacheWrite int64
+	}{
+		{"lt-cache-1", 1000, 500, 80000, 3000},
+		{"lt-cache-2", 2000, 1000, 40000, 2000},
+	}
+	for _, e := range execs {
+		total := e.input + e.output
+		if err := store.SaveExecution(&Execution{
+			ID:               e.id,
+			TaskID:           "TASK-" + e.id,
+			ProjectPath:      "/p",
+			Status:           "completed",
+			TokensInput:      e.input,
+			TokensOutput:     e.output,
+			TokensTotal:      total,
+			TokensCacheRead:  e.cacheRead,
+			TokensCacheWrite: e.cacheWrite,
+			EstimatedCostUSD: 0.01,
+		}); err != nil {
+			t.Fatalf("SaveExecution %s: %v", e.id, err)
+		}
+	}
+
+	lt, err := store.GetLifetimeTokens("")
+	if err != nil {
+		t.Fatalf("GetLifetimeTokens: %v", err)
+	}
+
+	if lt.CacheReadTokens != 120000 {
+		t.Errorf("CacheReadTokens = %d, want 120000", lt.CacheReadTokens)
+	}
+	if lt.CacheWriteTokens != 5000 {
+		t.Errorf("CacheWriteTokens = %d, want 5000", lt.CacheWriteTokens)
+	}
+	// Regular token fields unaffected
+	if lt.TotalTokens != 4500 {
+		t.Errorf("TotalTokens = %d, want 4500", lt.TotalTokens)
+	}
+}
+
 func TestGetLifetimeTaskCounts(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3618.

Closes #3618

## Changes

In internal/dashboard/tui.go: update renderTokenCard (~tui.go:2047) to show a cached/uncached breakdown using the new cache token fields, leaving the COST card output byte-identical.