### PR TITLE
feat(memory): populate cache token fields from ExecutionResult (GH-3616)

### DIFF
--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -739,6 +739,8 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 				TokensInput:      result.TokensInput,
 				TokensOutput:     result.TokensOutput,
 				TokensTotal:      result.TokensTotal,
+				TokensCacheRead:  result.CacheReadInputTokens,
+				TokensCacheWrite: result.CacheCreationInputTokens,
 				EstimatedCostUSD: result.EstimatedCostUSD,
 				FilesChanged:     result.FilesChanged,
 				LinesAdded:       result.LinesAdded,

--- a/internal/memory/metrics.go
+++ b/internal/memory/metrics.go
@@ -13,6 +13,8 @@ type ExecutionMetrics struct {
 	TokensInput      int64
 	TokensOutput     int64
 	TokensTotal      int64
+	TokensCacheRead  int64
+	TokensCacheWrite int64
 	EstimatedCostUSD float64
 	FilesChanged     int
 	LinesAdded       int
@@ -210,6 +212,8 @@ func (s *Store) SaveExecutionMetrics(metrics *ExecutionMetrics) error {
 				tokens_input = ?,
 				tokens_output = ?,
 				tokens_total = ?,
+				tokens_cache_read = ?,
+				tokens_cache_write = ?,
 				estimated_cost_usd = ?,
 				files_changed = ?,
 				lines_added = ?,
@@ -219,6 +223,7 @@ func (s *Store) SaveExecutionMetrics(metrics *ExecutionMetrics) error {
 				final_rss_mb = ?
 			WHERE id = ?
 		`, metrics.TokensInput, metrics.TokensOutput, metrics.TokensTotal,
+			metrics.TokensCacheRead, metrics.TokensCacheWrite,
 			metrics.EstimatedCostUSD, metrics.FilesChanged, metrics.LinesAdded,
 			metrics.LinesRemoved, metrics.ModelName,
 			metrics.PeakRSSMB, metrics.FinalRSSMB,


### PR DESCRIPTION
## Summary

- Adds `TokensCacheRead` and `TokensCacheWrite` fields to `memory.ExecutionMetrics` struct
- Extends `SaveExecutionMetrics` SQL UPDATE to persist `tokens_cache_read` and `tokens_cache_write` columns (added by GH-3615)
- Wires `result.CacheReadInputTokens → TokensCacheRead` and `result.CacheCreationInputTokens → TokensCacheWrite` at the dispatcher worker's result→Execution mapping site

Closes #3616. Part of GH-3567.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/memory/... ./internal/executor/...` passes