### PR TITLE
GH-3633: fix(memory): wire cache tokens into SaveExecutionMetrics UPDATE

### DIFF
--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -739,6 +739,8 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 				TokensInput:      result.TokensInput,
 				TokensOutput:     result.TokensOutput,
 				TokensTotal:      result.TokensTotal,
+				TokensCacheRead:  result.CacheReadInputTokens,
+				TokensCacheWrite: result.CacheCreationInputTokens,
 				EstimatedCostUSD: result.EstimatedCostUSD,
 				FilesChanged:     result.FilesChanged,
 				LinesAdded:       result.LinesAdded,

--- a/internal/memory/metrics.go
+++ b/internal/memory/metrics.go
@@ -13,6 +13,8 @@ type ExecutionMetrics struct {
 	TokensInput      int64
 	TokensOutput     int64
 	TokensTotal      int64
+	TokensCacheRead  int64
+	TokensCacheWrite int64
 	EstimatedCostUSD float64
 	FilesChanged     int
 	LinesAdded       int
@@ -210,6 +212,8 @@ func (s *Store) SaveExecutionMetrics(metrics *ExecutionMetrics) error {
 				tokens_input = ?,
 				tokens_output = ?,
 				tokens_total = ?,
+				tokens_cache_read = ?,
+				tokens_cache_write = ?,
 				estimated_cost_usd = ?,
 				files_changed = ?,
 				lines_added = ?,
@@ -219,6 +223,7 @@ func (s *Store) SaveExecutionMetrics(metrics *ExecutionMetrics) error {
 				final_rss_mb = ?
 			WHERE id = ?
 		`, metrics.TokensInput, metrics.TokensOutput, metrics.TokensTotal,
+			metrics.TokensCacheRead, metrics.TokensCacheWrite,
 			metrics.EstimatedCostUSD, metrics.FilesChanged, metrics.LinesAdded,
 			metrics.LinesRemoved, metrics.ModelName,
 			metrics.PeakRSSMB, metrics.FinalRSSMB,

--- a/internal/memory/metrics_cache_tokens_test.go
+++ b/internal/memory/metrics_cache_tokens_test.go
@@ -71,6 +71,69 @@ func TestGetMetricsSummary_CacheTokens(t *testing.T) {
 	}
 }
 
+func TestSaveExecutionMetrics_CacheTokens(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-save-metrics-cache-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().UTC()
+	exec := &Execution{
+		ID:          "ex-cache-1",
+		TaskID:      "T-cache-1",
+		ProjectPath: "/proj",
+		Status:      "completed",
+		DurationMs:  1000,
+		TokensTotal: 100,
+		CreatedAt:   now,
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	metrics := &ExecutionMetrics{
+		ExecutionID:      exec.ID,
+		TokensInput:      400,
+		TokensOutput:     600,
+		TokensTotal:      1000,
+		TokensCacheRead:  850,
+		TokensCacheWrite: 120,
+		EstimatedCostUSD: 0.01,
+		ModelName:        "claude-sonnet-4-6",
+	}
+	if err := store.SaveExecutionMetrics(metrics); err != nil {
+		t.Fatalf("SaveExecutionMetrics: %v", err)
+	}
+
+	q := MetricsQuery{
+		Start: now.Add(-time.Hour),
+		End:   now.Add(time.Hour),
+	}
+	summary, err := store.GetMetricsSummary(q)
+	if err != nil {
+		t.Fatalf("GetMetricsSummary: %v", err)
+	}
+	if summary.TotalTokensCacheRead == 0 {
+		t.Errorf("TotalTokensCacheRead = 0, want non-zero")
+	}
+	if summary.TotalTokensCacheRead != 850 {
+		t.Errorf("TotalTokensCacheRead = %d, want 850", summary.TotalTokensCacheRead)
+	}
+	if summary.TotalTokensCacheWrite == 0 {
+		t.Errorf("TotalTokensCacheWrite = 0, want non-zero")
+	}
+	if summary.TotalTokensCacheWrite != 120 {
+		t.Errorf("TotalTokensCacheWrite = %d, want 120", summary.TotalTokensCacheWrite)
+	}
+}
+
 func TestExportMetrics_CacheTokens(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "pilot-export-cache-*")
 	if err != nil {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3633.

Closes #3633

## Changes

Add TokensCacheRead/TokensCacheWrite fields to ExecutionMetrics in internal/memory/metrics.go (~line 11). Extend the UPDATE executions SET … in SaveExecutionMetrics (internal/memory/metrics.go:206-228) to include tokens_cache_read = ?, tokens_cache_write = ? immediately after tokens_total, and insert metrics.TokensCacheRead, metrics.TokensCacheWrite into the args slice in matching positional order. In internal/executor/dispatcher.go (~line 737), populate the new fields on the ExecutionMetrics literal from result.CacheReadInputTokens and result.CacheCreationInputTokens. Add a write-then-read integration test in internal/memory that constructs an ExecutionMetrics with non-zero cache tokens, calls SaveExecutionMetrics, re-reads the row, and asserts both cache columns are non-zero and that GetMetricsSummary / TotalTokensCacheRead/Write reflect them. Do NOT touch store.go:531 (INSERT already correct), metrics.go:594 (scan already correct), the COST card, or the learning-loop path at runner.go:3825. Verify with go build ./..., go test ./internal/memory/... ./internal/executor/... -run 'Metric|CacheToken|Execution' -v, and make lint.