### PR TITLE
docs(nav): archive completed cache-token tasks (TASK-366/367)

### DIFF
--- a/.agent/tasks/archive/TASK-366-persist-cache-tokens.md
+++ b/.agent/tasks/archive/TASK-366-persist-cache-tokens.md
@@ -1,0 +1,142 @@
+---
+status: completed
+priority: P3
+created: 2026-06-18
+execution: queued
+github_issue: 3567
+labels: [memory, dashboard, metrics]
+---
+
+# TASK-366: Persist cache token counts per execution + surface on TOKENS card
+
+**Status**: ✅ Completed — shipped across #3567 sub-issues (GH-3617/3618/3619) + populate fix #3634; verified on main @ v2.192.0
+**Assignee**: Pilot
+**GitHub Issue**: https://github.com/qf-studio/pilot/issues/3567
+
+---
+
+## Context
+
+**Problem**:
+The dashboard COST card is correct — `estimateCostWithCache` already factors cache
+read/write tokens into the $-figure. But the `executions` table persists only
+`tokens_input` / `tokens_output` (uncached input, observed 8–2060 per row). The cache
+token counts — which dominate real throughput — are computed at runtime
+(`ExecutionResult.CacheCreationInputTokens` / `CacheReadInputTokens`, set in
+`runner.go:2185-2186, 2233-2234, 2637-2638`) but **never written to the DB**. The TOKENS
+card therefore under-reports actual token throughput by orders of magnitude.
+
+The values already exist in memory at write time — they're passed to
+`estimateCostWithCache` (`runner.go:2191`) but dropped before the row is inserted. This
+task plumbs them through to storage and the TOKENS card.
+
+**Goal**:
+Persist `tokens_cache_read` + `tokens_cache_write` per execution and surface them on the
+TOKENS card, leaving the COST card unchanged.
+
+---
+
+## Acceptance Criteria
+
+- [ ] New executions persist cache read + cache write token counts (additive schema
+      migration; old rows default 0).
+- [ ] TOKENS card shows cache-inclusive totals (or a cached / uncached split).
+- [ ] COST card output is unchanged (already correct via `estimateCostWithCache`).
+- [ ] `go build ./...`, `make test`, `make lint` all green.
+
+---
+
+## Implementation
+
+### Phase 1: Schema + struct
+**Goal**: Add the two columns and the Go fields.
+
+**Tasks**:
+- [ ] Append two `ALTER TABLE executions ADD COLUMN` migrations after the existing token
+      columns (`store.go:144-147`):
+      `tokens_cache_read INTEGER DEFAULT 0`, `tokens_cache_write INTEGER DEFAULT 0`.
+      Migrations are additive + idempotent — DO NOT renumber or reorder existing entries;
+      append only (old DBs upgrade in place, old rows default 0).
+- [ ] Add `TokensCacheRead int64` + `TokensCacheWrite int64` to the `Execution` struct
+      (`store.go:483`, next to `TokensInput`/`TokensOutput`).
+
+**Files**: `internal/memory/store.go`
+
+### Phase 2: Write + read plumbing
+**Goal**: Persist and load the new columns.
+
+**Tasks**:
+- [ ] Extend the INSERT (`store.go:525-532`) column list + value args with the two new
+      fields.
+- [ ] Extend the SELECT scan (`store.go:572, 591`) with `COALESCE(tokens_cache_read,0)`,
+      `COALESCE(tokens_cache_write,0)` → `&exec.TokensCacheRead`, `&exec.TokensCacheWrite`.
+- [ ] Populate the `Execution` from `ExecutionResult.CacheCreationInputTokens` (→ write)
+      and `.CacheReadInputTokens` (→ read) at the call site that builds the memory
+      `Execution` from a runner result. (Grep for where `TokensInput`/`TokensOutput` are
+      copied from the result into the `Execution` struct and mirror it.)
+
+**Files**: `internal/memory/store.go`, the result→Execution mapping site (executor/autopilot).
+
+### Phase 3: Metrics + TOKENS card
+**Goal**: Aggregate and display.
+
+**Tasks**:
+- [ ] Extend the metrics aggregation query (`metrics.go:548` token block) to SUM the two
+      new columns; expose on the metrics struct it returns.
+- [ ] Update `renderTokenCard` (`tui.go:2047`) to show cache-inclusive totals or a
+      cached/uncached split. Keep COST card untouched.
+- [ ] Update/extend `tui_test.go` for the new card content.
+
+**Files**: `internal/memory/metrics.go`, `internal/dashboard/tui.go`, `internal/dashboard/tui_test.go`
+
+---
+
+## Out of Scope
+
+- Backfilling cache tokens for historical rows (default 0 is acceptable).
+- Changing `estimateCostWithCache` or any COST card behavior.
+- Per-model cache-token breakdowns.
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|----------|---------|--------|-----------|
+| Column naming | `tokens_cache_read/write` vs `cache_creation/read_input_tokens` | `tokens_cache_read` / `tokens_cache_write` | Matches issue proposal + existing `tokens_*` naming; `write` = cache *creation* |
+| Migration style | new numbered migration vs append ALTER | append `ALTER TABLE … ADD COLUMN` | Matches existing idempotent additive pattern in `store.go` |
+| Card display | total-only vs cached/uncached split | split (cached vs uncached) | More diagnostic; the whole point is cache reads dominate |
+
+---
+
+## Verify
+
+```bash
+go build ./...
+go test ./internal/memory/... ./internal/dashboard/... -v
+make lint
+# fresh DB migrates clean; old DB gains columns with 0 defaults
+```
+
+---
+
+## Done
+
+- [ ] Two new columns exist; fresh + existing DBs migrate clean (old rows = 0).
+- [ ] An execution writes non-zero cache read/write counts; SELECT round-trips them.
+- [ ] TOKENS card reflects cache tokens; COST card byte-identical.
+- [ ] build / test / lint green.
+
+---
+
+## Refs
+
+- GitHub issue: https://github.com/qf-studio/pilot/issues/3567
+- Cache token source: `runner.go:181-182, 362-365, 2185-2191, 2233-2239, 2637-2650`
+- Schema/write path: `store.go:73,144-160,483,525-532,572-591`
+- Metrics agg: `metrics.go:548` · TOKENS card: `tui.go:2047`
+- Origin: TASK-361 wave-2 cost-card investigation (the $36.64 figure verified correct)
+
+---
+
+**Last Updated**: 2026-06-18

--- a/.agent/tasks/archive/TASK-367-cache-tokens-populate-fix.md
+++ b/.agent/tasks/archive/TASK-367-cache-tokens-populate-fix.md
@@ -1,0 +1,128 @@
+---
+status: completed
+priority: P2
+created: 2026-06-18
+execution: queued
+labels: [memory, metrics, bug]
+---
+
+# TASK-367: Wire cache tokens into the completion UPDATE (finish #3567)
+
+**Status**: ✅ Completed — populate fix shipped via GH-3633 → PR #3634 (`07a69b40`), verified on main @ v2.192.0. Stuck epics #3632/#3636 closed (phantom-subtask retry loop, empty diffs).
+**Assignee**: Pilot
+**Supersedes**: GH-3616 (failed twice — PRs #3623, #3629 both closed unmerged; autopilot-fix #3630 stuck on `pilot-needs-clarification`)
+
+---
+
+## Context
+
+**Problem (regression / half-shipped feature):**
+TASK-366 / #3567 added `tokens_cache_read` + `tokens_cache_write` columns, the
+`Execution` struct fields, the queued-row INSERT, the metrics SUM, and the TOKENS-card
+cached/uncached split. **But the values are never written**, so the columns stay `0` and
+the TOKENS card's "cached" line is permanently `0`. The feature is inert.
+
+**Root cause (exact):**
+The `executions` row's token counts are NOT set at INSERT time (the row is inserted with
+status=`queued` and zero tokens at `dispatcher.go:399`). They are written later, on
+completion, by **`Store.SaveExecutionMetrics`** via an `UPDATE executions SET …`
+(`internal/memory/metrics.go:206-228`). That UPDATE lists `tokens_input … final_rss_mb`
+but **omits `tokens_cache_read` / `tokens_cache_write`**. The `ExecutionMetrics` struct
+(`metrics.go:11`) has no cache fields, and the caller (`dispatcher.go:737`) never passes
+them. So the cache columns are never updated off their `0` default.
+
+The runtime values already exist on the result:
+`ExecutionResult.CacheReadInputTokens` and `.CacheCreationInputTokens`
+(`runner.go:363-365`, populated by the backends).
+
+> ⚠️ **GH-3616 failed twice.** Do NOT patch the INSERT (`store.go:531` already has the
+> columns) or the read-path scan (`metrics.go:594`) — those are already correct. The bug
+> is the **completion UPDATE** in `SaveExecutionMetrics`. Watch the SQL placeholder
+> ordering: the `?` args must line up 1:1 with the `SET` columns or tests/round-trips fail.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `ExecutionMetrics` carries cache read/write token counts.
+- [ ] `SaveExecutionMetrics`'s UPDATE writes `tokens_cache_read` + `tokens_cache_write`.
+- [ ] The dispatcher passes the result's cache tokens into `ExecutionMetrics`.
+- [ ] A completed execution with non-zero cache tokens round-trips: the `executions` row
+      has non-zero `tokens_cache_read`/`write`, and `GetMetricsSummary` /
+      `TotalTokensCacheRead`/`Write` reflect them.
+- [ ] COST card behavior unchanged.
+- [ ] `go build ./...`, `make test`, `make lint` green.
+
+---
+
+## Implementation (3 sites — all in scope)
+
+### 1. `internal/memory/metrics.go` — struct (`type ExecutionMetrics struct`, ~line 11)
+Add next to `TokensTotal`:
+```go
+TokensCacheRead  int64
+TokensCacheWrite int64
+```
+
+### 2. `internal/memory/metrics.go` — UPDATE in `SaveExecutionMetrics` (~line 208-228)
+Add the two columns to the `SET` list AND the matching args, keeping placeholder order
+exact:
+```go
+UPDATE executions SET
+    tokens_input = ?,
+    tokens_output = ?,
+    tokens_total = ?,
+    tokens_cache_read = ?,     // NEW
+    tokens_cache_write = ?,    // NEW
+    estimated_cost_usd = ?,
+    ... (rest unchanged) ...
+WHERE id = ?
+```
+…and insert `metrics.TokensCacheRead, metrics.TokensCacheWrite` into the args slice in
+the SAME position (right after `metrics.TokensTotal`).
+
+### 3. `internal/executor/dispatcher.go` — caller (~line 737)
+In the `SaveExecutionMetrics(&memory.ExecutionMetrics{…})` literal, add:
+```go
+TokensCacheRead:  result.CacheReadInputTokens,
+TokensCacheWrite: result.CacheCreationInputTokens,
+```
+
+### Tests
+- [ ] Unit/integration: build an `ExecutionMetrics` with non-zero cache tokens →
+      `SaveExecutionMetrics` → re-read the row (`GetExecution` / metrics scan) → assert
+      both cache fields non-zero. Existing `metrics_cache_tokens_test.go` already covers
+      the SUM aggregation given populated rows; this closes the write gap.
+
+---
+
+## Out of Scope
+
+- The learning-loop `memory.Execution` at `runner.go:3825` (separate path; does not feed
+  the TOKENS card). Leave unless trivially consistent.
+- Backfilling historical rows (0 is fine).
+- Any COST card / `estimateCostWithCache` change.
+
+---
+
+## Verify
+
+```bash
+go build ./...
+go test ./internal/memory/... ./internal/executor/... -run 'Metric|CacheToken|Execution' -v
+make lint
+```
+
+---
+
+## Refs
+
+- Parent: #3567 (TASK-366) — added everything EXCEPT this write.
+- Failed predecessors: GH-3616 (#3623, #3629 closed unmerged), autopilot-fix #3630 (stuck).
+- Write site: `metrics.go:206` `SaveExecutionMetrics` UPDATE · caller `dispatcher.go:737`.
+- Cache source: `runner.go:363-365` (`ExecutionResult.Cache{Read,Creation}InputTokens`).
+- Read path (already correct): `store.go:531` INSERT, `metrics.go:266,594` SUM/scan.
+
+---
+
+**Last Updated**: 2026-06-18


### PR DESCRIPTION
Bookkeeping — doc-only, no code.

Archives the two Navigator task docs for the now-complete #3567 cache-token feature:
- **TASK-366** — persist cache token counts + TOKENS card (columns, struct, INSERT/SELECT, metrics SUM, card split)
- **TASK-367** — populate fix wiring `SaveExecutionMetrics` UPDATE + dispatcher (PR #3634, `07a69b40`)

## Status
Feature verified functional on `main` @ v2.192.0: build clean, `go test ./internal/memory/...` green, round-trip test `TestSaveExecutionMetrics_CacheTokens` passes.

Stuck epics #3632 / #3636 closed (phantom-subtask retry loop producing empty diffs on already-shipped work).