### PR TITLE
feat(github): M7 Phase 4a — studio-sdk poll-path scaffolding (dormant)

### DIFF
--- a/.agent/tasks/TASK-368-m7-github-cutover-phase4.md
+++ b/.agent/tasks/TASK-368-m7-github-cutover-phase4.md
@@ -1,0 +1,170 @@
+---
+status: phase-4a-implemented
+priority: P3
+created: 2026-06-22
+execution: manual
+github_issue: 3423
+labels: [m7, sdk, github, adapter, human-led]
+---
+
+# TASK-368: M7 Phase 4 — GitHub adapter → studio-sdk cutover (MANUAL)
+
+**Status**: ✅ Phase 4a IMPLEMENTED (additive scaffolding, dormant/flag-off). Verdict `poll-path-only`; full retirement blocked on studio-sdk v0.25.0+. Adversarially reviewed (verdict SHIP, 5 nits fixed). Phases 4b–4d deferred.
+**Assignee**: Manual (human-led per #3423 — daemon must NOT claim this)
+**Tracking issue**: https://github.com/qf-studio/pilot/issues/3423
+**Template**: GitLab cutover — commit `07467a9d` / GH-3456 / PR #3459
+
+---
+
+## Verdict (verified against studio-sdk v0.24.0)
+
+**Full retirement of `internal/adapters/github` is NOT possible at SDK v0.24.0.** Only an
+additive, feature-flagged *poll-path scaffolding* leg is achievable now; the live cutover
+is gated on SDK v0.25.0+. Four independently-verified blockers:
+
+1. **Board layer absent from SDK.** No `project_board.go`/`project_source.go` in the SDK
+   github package (only the YAML `ProjectBoardConfig` type, `types.go:34`). Autopilot
+   writes the board via `WithProjectBoardSync` (`internal/autopilot/controller.go:116`, 6
+   sites); the poller sources issues via `WithProjectBoardSource`/`WithBoardSync`
+   (`internal/adapters/github/poller.go:343`/`:351`). Also needs
+   `ExecuteGraphQLTolerant`/`PartialGraphQLError` (shipped in TASK-319) — absent in SDK.
+2. **5 Pilot-only Client methods missing:** `CompareStatus`, `GetAuthenticatedUser`,
+   `SearchOpenPRsForIssue`, `FindOpenPRByBranch`, `ExecuteGraphQLTolerant`. Three are
+   load-bearing for autopilot (GH-3417 human-recovery guard + release-tag dedup).
+3. **`core.PollerDeps` is a strict subset** (4 fields, `sdk/core/registry.go:124`) of the
+   in-tree poller's 8 host-coupled options (`poller.go:239`-`:351`): WithScheduler,
+   WithTaskChecker, WithExecutionChecker, WithPreFlightJudge, WithExecutionSaver,
+   WithIssueMetricsRecorder, WithProjectBoardSource, WithBoardSync.
+4. **Autopilot hard-typed to concrete `*github.Client`** (`NewController`,
+   `controller.go:221`) and `*github.ProjectBoardSync` (`:116`) — no interface seam.
+
+SDK `sdkshim/doc.go` already states the in-tree github adapter "stays in tree for
+autopilot's PR/CI/release/branch surface (M7 retires only its issue-poller role)."
+
+---
+
+## Context
+
+M7 migrates Pilot's adapters to consume studio-sdk behind the `sdk/core` contract. 9 of 10
+adapters' poll/chat paths already cut over. GitHub is last + riskiest (autopilot is
+github-only). This task scopes ONLY the achievable additive scaffolding (Phase 4a),
+mirroring the GitLab template, with the live poller / board / gh-CLI PR path / autopilot
+all staying in-tree.
+
+> ⚠️ **Phase 4a is dormant until SDK v0.25.0+.** The registration is default-OFF and NOT
+> added to `adapterPollerRegistrations()`; the orchestrator sibling is unused by the live
+> handler-driven github path. This is scaffolding/parity code, not a behavior change.
+
+---
+
+## Acceptance Criteria (Phase 4a only)
+
+- [ ] `internal/orchestrator/orchestrator.go` gains `ProcessGithubIssueEvent(ctx, ev sdkcore.IssueEvent, projectPath string) error` mirroring `ProcessGitlabIssueEvent` (`:476`), placed after `ProcessAzureDevOpsIssueEvent` (`:717`). Uses `ev.SequenceID` **verbatim** (already `GH-`-prefixed by SDK `adapter.go:143` — NO `fmt.Sprintf("GH-%d", …)` re-prefix) and `sdkshim.PriorityFromSDK(ev.Priority)`.
+- [ ] `internal/adapters/sdkshim/repo_resolver.go` implements the `github` branch at the `TODO(phase-4)` (`:39`): per-project routing via `cfg.Projects[].GitHub.{Owner,Repo}` matched on `ev.ProjectID`, `cfg.Adapters.GitHub` fallback; `ErrRepoNotResolved` only when nothing matches. (This is the resolver's first real implementation — all branches are currently stubs.)
+- [ ] `cmd/pilot/poller_github.go` (NEW) defines `githubPollerRegistration()` gated on a NEW default-OFF flag `adapters.github.use_sdk_poller`; **NOT** added to `adapterPollerRegistrations()` (`cmd/pilot/poller_registry.go:43`).
+- [ ] `handleGithubIssueEventSDK(...)` (NEW) lives ALONGSIDE the legacy `handleGitHubIssueWithResult` (`cmd/pilot/handlers.go:222`); sets `SourceAdapter:"github"`, `taskID = ev.SequenceID` verbatim, tolerates `ErrRepoNotResolved`. Legacy handler untouched.
+- [ ] `internal/config/config.go`: additive `UseSDKPoller bool` (`use_sdk_poller`, default false) on the GitHub adapter config; documented in `configs/pilot.example.yaml`.
+- [ ] With the flag OFF, github polling/PR/board/autopilot behavior is **byte-identical** to today; existing `internal/adapters/github` tests stay green.
+- [ ] No edits under `.claude/worktrees`.
+
+---
+
+## Implementation (sub-phases, each a gate)
+
+### 4a.1 — orchestrator sibling
+Add `ProcessGithubIssueEvent` after `:717`. Copy `ProcessGitlabIssueEvent` body:
+`TicketData{ID:ev.IssueID, Identifier:ev.SequenceID, Title:ev.Title, Description:ev.Body, Priority:sdkshim.PriorityFromSDK(ev.Priority), Labels:ev.Labels}` → `PlanTicket` → `saveTaskDocument` → internalTask `Branch=pilot/<ev.SequenceID>`.
+**Gate:** `go test -race ./internal/orchestrator/...`
+
+### 4a.2 — repo resolver github branch
+Implement the `github` case in `ResolveRepoForEvent` + table-driven tests (per-project match / adapters fallback / unresolved→ErrRepoNotResolved).
+**Gate:** `go test -race ./internal/adapters/sdkshim/...`
+
+### 4a.3 — config flag
+Add `UseSDKPoller` to the GitHub adapter config; document in `configs/pilot.example.yaml`.
+**Gate:** `go build ./...`
+
+### 4a.4 — dormant SDK poller registration + handler
+Create `cmd/pilot/poller_github.go` (mirror `poller_gitlab.go`): cfg→`sdkGithub.Config` (`PilotLabel`→`TriggerLabel`), handler-side `*sdkGithub.Client`, `sdkcore.PollerDeps{Handler: …}`. Add `handleGithubIssueEventSDK` next to the legacy handler. Do NOT inject a PRCreator, do NOT relax `runner.go:3601`, do NOT register github.
+**Gate:** `go build ./... && go vet ./... && go test -race ./cmd/pilot/...`
+
+---
+
+## Out of Scope (deferred phases, all SDK-blocked)
+
+- **4b** — SDK poller option parity (Scheduler/TaskChecker/ExecutionChecker/PreFlightJudge/ExecutionSaver/IssueMetricsRecorder) + flip flag on for single-repo. Blocked on SDK v0.25.0+.
+- **4c** — board source/sync on SDK poller + `ExecuteGraphQLTolerant`; retire `project_source.go`/`project_board.go`. Blocked on SDK board support.
+- **4d** — autopilot client unification (`NewController` swap / interface seam), gh-CLI→SDK PR-create (`runner.go:3601` guard), spec-guard/CreatePilotIssue/label-vocab porting, **delete `internal/adapters/github`**.
+- Live `createPollerForRepo` / multi-repo loop (`cmd/pilot/main.go` ~2195-2400).
+- Webhook handler migration.
+
+---
+
+## Behavior Deltas (github-specific)
+
+- **SequenceID already `GH-`-prefixed** by the SDK (`adapter.go:143`). Legacy handler re-prefixes via `fmt.Sprintf("GH-%d", issue.Number)` (`handlers.go:223`); the new SDK handler must use `ev.SequenceID` verbatim or it produces `GH-GH-42` (breaks branch names, dedup, sub-issue parent parsing).
+- **PRCreator injection does NOT apply to github** — SDK Client has `CreatePullRequest(owner,repo,*PullRequestInput)`, not `executor.PRCreator.CreatePR(ctx,src,tgt,title,body)`. GitHub keeps the gh-CLI PR path; `runner.go:3601` excludes `SourceAdapter=="github"`. (GitLab template Step 4 is intentionally skipped.)
+- **`SourceAdapter` goes empty→"github"** in the new handler — benign under current `runner.go:3601` (still routes github to gh-CLI).
+- **Flag OFF ⇒ zero observable change.**
+
+---
+
+## Risk Register (headline items)
+
+| Risk | Sev | Mitigation |
+|---|---|---|
+| Autopilot hard-coupled to concrete `*github.Client`; premature swap breaks CI/merge/release/board at compile time | **critical** | 4a touches ZERO autopilot files; autopilot deferred to 4d; consider interface-seam prerequisite PR |
+| SequenceID double-prefix → `GH-GH-42` | high | New handler uses `ev.SequenceID` verbatim; explicit no-re-prefix test |
+| Two pollers (SDK discovery-only + in-tree) double-dispatch if both run | high | Flag default-OFF + NOT registered ⇒ SDK poller dormant; shared `ProcessedStore` dedup |
+| `core.PollerDeps` silently drops Scheduler/Judge/board/metrics | high | 4a never flips flag / registers; 4b gated on SDK option parity |
+| `ResolveRepoForEvent` github branch = first real impl; wrong owner/repo → push to wrong repo | high | Strict `ev.ProjectID` match; fallback only when unambiguous; return `ErrRepoNotResolved` rather than guess; table tests |
+| Stale `.claude/worktrees` copies have duplicate github importers | low | Edit only canonical `cmd/`,`internal/`; fresh worktree off origin/main |
+
+---
+
+## Open Questions (gate later phases)
+
+1. Will SDK v0.25.0+ add the 5 missing Client methods + ProjectBoardSync runtime + `LabelPilot` + exported `ParseParentIssueNumber`? Gates 4b/4c/4d entirely.
+2. How to augment the thin `sdkcore.IssueEvent` for github needs (issue.State for sub-issue gating, NodeID for board + OnPRCreated, per-issue owner/repo, assignee for RBAC) — grow IssueEvent in SDK, or re-fetch `*github.Issue` via `client.GetIssue` (doubles API calls)?
+3. Introduce a github-client **interface seam** in autopilot as a prerequisite PR before 4d?
+4. Is the board layer meant to move INTO the SDK, or stay host-side on generic `ExecuteGraphQL`? Biggest long-term gate.
+5. PR-create: drop gh-CLI for an SDK-backed PRCreator (needs CreatePR + relax `runner.go:3601` + preserve `Closes #N` autoclose + dirty-worktree `--head`), or keep gh CLI indefinitely?
+6. Multi-repo polling → one SDK adapter instance per repo, or wait for an SDK multi-repo story?
+7. Where does the `MarkProcessed`/`ClearProcessed` side-channel live once the Start-only `core.Poller` owns dedup?
+8. Is `ProcessGithubIssueEvent` worth adding in 4a given github's live path is handler-driven (not queue-driven)? Parity vs unused code.
+
+---
+
+## Verify
+
+```bash
+make build && go vet ./... && go test -race ./internal/orchestrator/... ./internal/adapters/sdkshim/... ./cmd/pilot/...
+go test -race ./internal/adapters/github/...   # flag-off: unchanged
+grep -rl 'internal/adapters/github"' --include='*.go' cmd internal | grep -v _test.go | grep -v .claude/worktrees | wc -l  # NOT yet reduced
+# staging smoke with use_sdk_poller=false: issue pickup / PR / board / autopilot unchanged
+```
+
+---
+
+## Done (Phase 4a)
+
+- [ ] All gates green; `go test -race ./...` passes.
+- [ ] `ProcessGithubIssueEvent` present + tested; `ev.SequenceID` verbatim.
+- [ ] `ResolveRepoForEvent` github branch implemented + tested.
+- [ ] `githubPollerRegistration()` exists, default-OFF, NOT registered.
+- [ ] `handleGithubIssueEventSDK` sets `SourceAdapter:"github"`; legacy handler untouched.
+- [ ] Zero behavior change with flag off (staging smoke).
+- [ ] Daemon + executor build/roll together. No `.claude/worktrees` edits.
+
+---
+
+## Refs
+
+- Tracking: #3423 · plan `.agent/research/2026-06-03-m7-sdk-cutover.md`
+- Template: gitlab cutover `07467a9d` (GH-3456 / PR #3459)
+- SDK: `studio-sdk v0.24.0` (`go.mod`); github connector lacks board + 5 methods + poller options
+- Map workflow: `m7-github-cutover-map` (run `wf_e4f5bcdc-d3c`, 6 agents, 512k tokens)
+
+---
+
+**Last Updated**: 2026-06-22

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -1154,3 +1154,85 @@ func handleAzureDevOpsIssueWithResult(ctx context.Context, cfg *config.Config, e
 
 	return issueResult, execErr
 }
+
+// handleGithubIssueEventSDK processes a GitHub issue delivered as a studio-sdk core.IssueEvent
+// (M7 Phase 4a). It runs ALONGSIDE the legacy in-tree handleGitHubIssueWithResult (which takes a
+// *github.Issue) and is exercised only when the dormant SDK poller is enabled
+// (adapters.github.use_sdk_poller — see cmd/pilot/poller_github.go).
+//
+// ev.SequenceID is already "GH-42" (prefixed by the SDK adapter) — used verbatim as the task ID to
+// avoid the GH-GH-42 double-prefix the legacy handler's fmt.Sprintf("GH-%d", ...) would create.
+// This minimal path does NOT carry board sync, spec-guard, or sub-issue handling — those remain
+// exclusively in the legacy in-tree handler until later M7 phases.
+func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkcore.IssueEvent, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner, monitor *executor.Monitor, program *tea.Program, alertsEngine *alerts.Engine, enforcer *budget.Enforcer) (*sdkcore.IssueResult, error) {
+	taskID := ev.SequenceID // "GH-42"; already prefixed by the SDK adapter — do NOT re-prefix
+	title := ev.Title
+
+	taskDesc := fmt.Sprintf("GitHub Issue %s: %s\n\n%s", taskID, title, ev.Body)
+	branchName := fmt.Sprintf("pilot/%s", taskID)
+
+	// ResolveRepoForEvent is tolerated like the other SDK handlers; ErrRepoNotResolved is non-fatal here.
+	if _, _, _, err := sdkshim.ResolveRepoForEvent(cfg, "github", ev); err != nil && err.Error() != sdkshim.ErrRepoNotResolved.Error() {
+		logging.WithComponent("github").Warn("Unexpected repo resolution error",
+			slog.String("task_id", taskID),
+			slog.Any("error", err),
+		)
+	}
+
+	task := &executor.Task{
+		ID:            taskID,
+		Title:         title,
+		Description:   taskDesc,
+		ProjectPath:   projectPath,
+		Branch:        branchName,
+		CreatePR:      true,
+		SourceAdapter: "github",
+		SourceIssueID: ev.IssueID,
+		Priority:      sdkshim.PriorityFromSDK(ev.Priority),
+		BaseBranch:    resolveProjectBaseBranch(cfg, projectPath), // GH-2290
+	}
+
+	// NOTE: no runner.SetPRCreator here — the studio-sdk GitHub client does not implement
+	// executor.PRCreator, and the runner gates the PRCreator branch on SourceAdapter != "github".
+	// GitHub PRs continue to be created via the gh CLI, unchanged.
+
+	deps := HandlerDeps{
+		Cfg:          cfg,
+		Dispatcher:   dispatcher,
+		Runner:       runner,
+		Monitor:      monitor,
+		Program:      program,
+		AlertsEngine: alertsEngine,
+		Enforcer:     enforcer,
+		ProjectPath:  projectPath,
+	}
+	info := IssueInfo{
+		TaskID:   taskID,
+		Title:    title,
+		URL:      githubIssueURL(cfg, ev.IssueID),
+		Adapter:  "github",
+		LogEmoji: "🐙",
+	}
+
+	hr, execErr := handleIssueGeneric(ctx, deps, info, task)
+
+	issueResult := &sdkcore.IssueResult{
+		Success:    hr.Success,
+		BranchName: hr.BranchName,
+		PRNumber:   hr.PRNumber,
+		PRURL:      hr.PRURL,
+		HeadSHA:    hr.HeadSHA,
+		Error:      hr.Error,
+	}
+
+	return issueResult, execErr
+}
+
+// githubIssueURL builds the HTML URL for a GitHub issue from the default adapter repo
+// ("owner/repo"). Returns "" when no default repo is configured.
+func githubIssueURL(cfg *config.Config, issueID string) string {
+	if cfg.Adapters != nil && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Repo != "" {
+		return fmt.Sprintf("https://github.com/%s/issues/%s", cfg.Adapters.GitHub.Repo, issueID)
+	}
+	return ""
+}

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"time"
+
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+
+	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/logging"
+)
+
+// githubPollerRegistration returns the studio-sdk GitHub issue-poller registration
+// (M7 Phase 4a). It is DORMANT by design:
+//
+//   - Enabled requires the experimental adapters.github.use_sdk_poller flag (default false).
+//   - It is NOT included in adapterPollerRegistrations() (see poller_registry.go), so it is
+//     never started by the live daemon this phase.
+//
+// The SDK discovery poller deliberately does NOT carry the in-tree GitHub poller's board
+// sync, rate-limit scheduler, pre-flight intent judge, execution checkers, or issue metrics —
+// core.PollerDeps cannot express them at studio-sdk v0.24.0. Wiring those (and flipping the
+// flag on for single-repo configs) is deferred to Phase 4b, blocked on studio-sdk v0.25.0+.
+// Until then this registration exists to mirror the GitLab template (poller_gitlab.go) and to
+// exercise SDK adapter/poller construction without changing any runtime behavior.
+func githubPollerRegistration() PollerRegistration {
+	return PollerRegistration{
+		Name: "github",
+		Enabled: func(cfg *config.Config) bool {
+			return cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled &&
+				cfg.Adapters.GitHub.UseSDKPoller &&
+				cfg.Adapters.GitHub.Polling != nil && cfg.Adapters.GitHub.Polling.Enabled
+		},
+		CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
+			// Determine interval.
+			interval := 30 * time.Second
+			if deps.Cfg.Adapters.GitHub.Polling.Interval > 0 {
+				interval = deps.Cfg.Adapters.GitHub.Polling.Interval
+			}
+
+			// Map internal config → SDK config (field names differ: PilotLabel vs TriggerLabel).
+			pilotLabel := deps.Cfg.Adapters.GitHub.PilotLabel
+			if pilotLabel == "" {
+				pilotLabel = "pilot"
+			}
+			sdkCfg := &githubSDK.Config{
+				Enabled:       deps.Cfg.Adapters.GitHub.Enabled,
+				Token:         deps.Cfg.Adapters.GitHub.Token,
+				WebhookSecret: deps.Cfg.Adapters.GitHub.WebhookSecret,
+				Repo:          deps.Cfg.Adapters.GitHub.Repo,
+				TriggerLabel:  pilotLabel,
+				Polling: &githubSDK.PollingConfig{
+					Enabled:  true,
+					Interval: interval,
+				},
+			}
+
+			pollerDeps := sdkcore.PollerDeps{
+				Handler: sdkcore.IssueHandlerFunc(func(issueCtx context.Context, ev sdkcore.IssueEvent) (*sdkcore.IssueResult, error) {
+					return handleGithubIssueEventSDK(issueCtx, deps.Cfg, ev, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
+				}),
+			}
+
+			if deps.AutopilotStateStore != nil {
+				pollerDeps.ProcessedStore = deps.AutopilotStateStore
+			}
+			if deps.Cfg.Orchestrator.MaxConcurrent > 0 {
+				pollerDeps.MaxConcurrent = deps.Cfg.Orchestrator.MaxConcurrent
+			}
+			if deps.AutopilotController != nil {
+				ctrl := deps.AutopilotController
+				pollerDeps.OnPRCreated = func(prEv sdkcore.PRCreatedEvent) {
+					// GitHub's IssueID is the numeric issue number; forward it (and the node ID)
+					// so the autopilot controller's post-merge gates (controller.go:850/920/1063/
+					// 1442/1466) and board-sync-to-Review (controller.go:506) work when the SDK
+					// poll path goes live in Phase 4b. Unlike the GitLab template (which passes
+					// 0/"" because its IssueID is non-numeric), GitHub populates both.
+					issueNumber, _ := strconv.Atoi(prEv.IssueID)
+					ctrl.OnPRCreated(prEv.PRNumber, prEv.PRURL, issueNumber, prEv.HeadSHA, prEv.BranchName, prEv.IssueNodeID)
+				}
+			}
+
+			githubPoller := githubSDK.New(sdkCfg).NewPoller(pollerDeps)
+
+			logging.WithComponent("start").Info("GitHub SDK polling enabled (experimental)",
+				slog.String("repo", deps.Cfg.Adapters.GitHub.Repo),
+				slog.String("label", pilotLabel),
+				slog.Duration("interval", interval),
+			)
+			go func() {
+				if err := githubPoller.Start(ctx); err != nil {
+					logging.WithComponent("github").Error("GitHub SDK poller failed",
+						slog.Any("error", err),
+					)
+				}
+			}()
+		},
+	}
+}

--- a/cmd/pilot/poller_github_test.go
+++ b/cmd/pilot/poller_github_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
+	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/executor"
+)
+
+// TestGithubPollerRegistration_Fields verifies the SDK-based registration has the correct
+// name and that its Enabled predicate gates on the experimental use_sdk_poller flag — which
+// is OFF by default, keeping the SDK poller dormant in Phase 4a.
+func TestGithubPollerRegistration_Fields(t *testing.T) {
+	reg := githubPollerRegistration()
+
+	if reg.Name != "github" {
+		t.Errorf("PollerRegistration.Name = %q, want %q", reg.Name, "github")
+	}
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want bool
+	}{
+		{
+			name: "nil github config",
+			cfg:  &config.Config{Adapters: &config.AdaptersConfig{}},
+			want: false,
+		},
+		{
+			name: "github disabled",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				GitHub: &github.Config{Enabled: false, UseSDKPoller: true, Polling: &github.PollingConfig{Enabled: true}},
+			}},
+			want: false,
+		},
+		{
+			name: "use_sdk_poller off (default) — dormant even when polling enabled",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				GitHub: &github.Config{Enabled: true, UseSDKPoller: false, Polling: &github.PollingConfig{Enabled: true}},
+			}},
+			want: false,
+		},
+		{
+			name: "polling disabled",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				GitHub: &github.Config{Enabled: true, UseSDKPoller: true, Polling: &github.PollingConfig{Enabled: false}},
+			}},
+			want: false,
+		},
+		{
+			name: "nil polling config",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				GitHub: &github.Config{Enabled: true, UseSDKPoller: true},
+			}},
+			want: false,
+		},
+		{
+			name: "all enabled incl. use_sdk_poller",
+			cfg: &config.Config{Adapters: &config.AdaptersConfig{
+				GitHub: &github.Config{Enabled: true, UseSDKPoller: true, Polling: &github.PollingConfig{Enabled: true}},
+			}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reg.Enabled(tt.cfg)
+			if got != tt.want {
+				t.Errorf("Enabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGithubPollerNotRegistered verifies the Phase-4a dormancy invariant: the GitHub SDK
+// registration must NOT be wired into adapterPollerRegistrations(), so the live daemon never
+// starts it this phase. The in-tree GitHub poller remains the live path.
+func TestGithubPollerNotRegistered(t *testing.T) {
+	for _, reg := range adapterPollerRegistrations() {
+		if reg.Name == "github" {
+			t.Error("github must NOT be in adapterPollerRegistrations() in Phase 4a — the SDK poller is dormant")
+		}
+	}
+}
+
+// TestGithubSDKClientDoesNotImplementPRCreator documents the github behavior delta: unlike the
+// GitLab SDK client (which implements executor.PRCreator and is injected via SetPRCreator), the
+// studio-sdk GitHub *Client does NOT satisfy executor.PRCreator. The Phase-4a handler relies on
+// this — GitHub PRs keep going through the gh CLI, and no PRCreator is injected.
+func TestGithubSDKClientDoesNotImplementPRCreator(t *testing.T) {
+	var i interface{} = (*githubSDK.Client)(nil)
+	if _, ok := i.(executor.PRCreator); ok {
+		t.Error("studio-sdk github *Client unexpectedly implements executor.PRCreator; " +
+			"the Phase-4a handler assumes it does not (GitHub keeps the gh-CLI PR path)")
+	}
+}
+
+// TestGithubRepoResolution verifies the Phase-4 github branch of sdkshim.ResolveRepoForEvent:
+// it resolves a configured default repo (unlike the still-stubbed sources, which return
+// ErrRepoNotResolved), and the SequenceID-derived repo name routes per-project.
+func TestGithubRepoResolution(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Repo: "qf-studio/pilot"},
+		},
+	}
+	clone, owner, repo, err := sdkshim.ResolveRepoForEvent(cfg, "github", sdkcore.IssueEvent{SequenceID: "GH-42", ProjectID: "pilot"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if owner != "qf-studio" || repo != "pilot" || clone != "https://github.com/qf-studio/pilot.git" {
+		t.Errorf("got (%q,%q,%q), want (https://github.com/qf-studio/pilot.git, qf-studio, pilot)", clone, owner, repo)
+	}
+}
+
+// TestGithubPollerNoLegacyImport verifies poller_github.go does not directly import the legacy
+// in-tree internal/adapters/github package on the SDK poll path (it uses the studio-sdk github
+// package). The config dependency carries github.Config transitively, which is fine.
+func TestGithubPollerNoLegacyImport(t *testing.T) {
+	content, err := os.ReadFile("poller_github.go")
+	if err != nil {
+		t.Fatalf("failed to read poller_github.go: %v", err)
+	}
+	const legacyImport = `"github.com/qf-studio/pilot/internal/adapters/github"`
+	if strings.Contains(string(content), legacyImport) {
+		t.Errorf("poller_github.go must not import the legacy in-tree github package; found %q", legacyImport)
+	}
+}
+
+// TestGithubHandlerSDKFunctionInvariants is a source-level regression guard SCOPED to the
+// handleGithubIssueEventSDK function body (not a whole-file grep — the legacy in-tree handler
+// shares several of these lines and legitimately uses fmt.Sprintf("GH-%d", issue.Number)).
+// The SDK handler must derive taskID from ev.SequenceID verbatim, set SourceAdapter "github",
+// and never re-prefix via GH-%d.
+func TestGithubHandlerSDKFunctionInvariants(t *testing.T) {
+	body := githubFuncBody(t, "handlers.go", "func handleGithubIssueEventSDK(")
+	if !strings.Contains(body, "taskID := ev.SequenceID") {
+		t.Error("handleGithubIssueEventSDK must derive taskID from ev.SequenceID verbatim")
+	}
+	if !strings.Contains(body, `SourceAdapter: "github"`) {
+		t.Error(`handleGithubIssueEventSDK must set SourceAdapter: "github"`)
+	}
+	if strings.Contains(body, `"GH-`+`%d"`) {
+		t.Error("handleGithubIssueEventSDK must not re-prefix the raw issue number into a GH- sequence (would yield GH-GH form)")
+	}
+}
+
+// githubFuncBody returns the source of file between funcSignature and the next top-level "func "
+// declaration, so assertions can be scoped to one function rather than the whole file.
+func githubFuncBody(t *testing.T, file, funcSignature string) string {
+	t.Helper()
+	content, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	src := string(content)
+	start := strings.Index(src, funcSignature)
+	if start < 0 {
+		t.Fatalf("function %q not found in %s", funcSignature, file)
+	}
+	rest := src[start+len(funcSignature):]
+	if end := strings.Index(rest, "\nfunc "); end >= 0 {
+		return rest[:end]
+	}
+	return rest
+}

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -43,6 +43,12 @@ adapters:
     token: "${GITHUB_TOKEN}"
     repo: "owner/repo"                 # Repository to poll
     pilot_label: "pilot"               # Issues with this label are picked up
+    # use_sdk_poller: false            # EXPERIMENTAL (M7 Phase 4). Opt into the studio-sdk
+    #                                  # GitHub issue poller. DORMANT in Phase 4a: the SDK
+    #                                  # registration is not yet wired in, and the SDK poller
+    #                                  # does NOT carry board sync, rate-limit scheduling,
+    #                                  # pre-flight intent judging, or issue metrics. Leave
+    #                                  # false until Phase 4b (blocked on studio-sdk v0.25.0+).
     polling:
       enabled: true
       interval: 30s

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -14,6 +14,13 @@ type Config struct {
 	StaleLabelCleanup *StaleLabelCleanupConfig `yaml:"stale_label_cleanup"` // Auto-cleanup stale labels
 	ProjectBoard      *ProjectBoardConfig      `yaml:"project_board"`       // GitHub Projects V2 board sync
 	Approval          *ApprovalConfig          `yaml:"approval"`            // GitHub PR-review approval handler
+	// UseSDKPoller opts this repo into the studio-sdk GitHub issue poller (M7 Phase 4).
+	// Default false. EXPERIMENTAL/DORMANT in Phase 4a: the SDK poller registration exists
+	// (cmd/pilot/poller_github.go) but is NOT yet wired into adapterPollerRegistrations(),
+	// and the SDK discovery poller does NOT carry the in-tree poller's board sync, rate-limit
+	// scheduler, pre-flight intent judge, or issue metrics. Do not enable in production until
+	// Phase 4b ports those hooks (blocked on studio-sdk v0.25.0+).
+	UseSDKPoller bool `yaml:"use_sdk_poller"`
 }
 
 // PollingConfig holds GitHub polling settings

--- a/internal/adapters/sdkshim/repo_resolver.go
+++ b/internal/adapters/sdkshim/repo_resolver.go
@@ -2,6 +2,8 @@ package sdkshim
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/studio-sdk/sdk/core"
@@ -29,16 +31,59 @@ var ErrRepoNotResolved = errors.New("sdkshim: repo not resolved for event")
 //   - "jira":        cfg.Adapters.Jira project key → repo
 //   - "asana":       cfg.Adapters.Asana project ID → repo
 //
-// Phase 0: stub. Phase 1 (Plane) populates the plane branch and proves the pattern.
+// Phase 0: stub. Phase 4 (GitHub) populates the github branch and proves the pattern.
 func ResolveRepoForEvent(cfg *config.Config, source string, ev core.IssueEvent) (cloneURL, repoOwner, repoName string, err error) {
 	if cfg == nil {
 		return "", "", "", errors.New("sdkshim.ResolveRepoForEvent: nil config")
 	}
+
+	// github (M7 Phase 4): the SDK github adapter sets ev.ProjectID to the repo NAME
+	// (the part after "owner/" in "owner/repo" — see studio-sdk github adapter.go toIssueEvent).
+	// Route per-project by matching that repo name against cfg.Projects[].GitHub.Repo,
+	// falling back to the default cfg.Adapters.GitHub repo ("owner/repo").
+	if source == "github" {
+		if owner, repo, ok := resolveGithubRepo(cfg, ev.ProjectID); ok {
+			return githubCloneURL(owner, repo), owner, repo, nil
+		}
+		return "", "", "", ErrRepoNotResolved
+	}
+
 	// TODO(phase-1): implement plane branch; cross-check ev.ProjectID against cfg.Adapters.Plane.
 	// TODO(phase-2/3): gitlab, azuredevops.
-	// TODO(phase-4): github with per-project routing fallback.
 	// TODO(phase-5): linear, jira, asana.
-	_ = ev // referenced for the signature; unused until Phase 1.
+	_ = ev // referenced for the signature; unused for not-yet-implemented sources.
 	_ = source
 	return "", "", "", ErrRepoNotResolved
+}
+
+// resolveGithubRepo resolves owner/repo for a github event. It prefers a per-project match
+// on the repo name (ev.ProjectID matched against cfg.Projects[].GitHub.Repo), then falls back
+// to the default cfg.Adapters.GitHub.Repo ("owner/repo"). Returns ok=false when neither yields
+// a non-empty owner and repo.
+//
+// LIMITATION: the SDK IssueEvent carries only the repo NAME (not "owner/repo"), so matching is
+// by name alone. If two configured projects share a repo name under different owners, the first
+// configured match wins. This is harmless in Phase 4a (every caller discards the resolved
+// owner/repo), but Phase 4b — which wires the result into clone/dispatch — must disambiguate
+// (e.g. grow IssueEvent to carry owner, or constrain config to unique repo names).
+func resolveGithubRepo(cfg *config.Config, repoName string) (owner, repo string, ok bool) {
+	if repoName != "" {
+		for _, p := range cfg.Projects {
+			if p.GitHub != nil && p.GitHub.Repo == repoName && p.GitHub.Owner != "" {
+				return p.GitHub.Owner, p.GitHub.Repo, true
+			}
+		}
+	}
+	if cfg.Adapters != nil && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Repo != "" {
+		parts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2)
+		if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+			return parts[0], parts[1], true
+		}
+	}
+	return "", "", false
+}
+
+// githubCloneURL builds the HTTPS clone URL for an owner/repo pair.
+func githubCloneURL(owner, repo string) string {
+	return fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
 }

--- a/internal/adapters/sdkshim/repo_resolver_test.go
+++ b/internal/adapters/sdkshim/repo_resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/studio-sdk/sdk/core"
 )
@@ -16,10 +17,77 @@ func TestResolveRepoForEvent_NilConfig(t *testing.T) {
 }
 
 func TestResolveRepoForEvent_Stub(t *testing.T) {
-	// Phase 0: every source returns ErrRepoNotResolved. Phase 1+ replaces
-	// this test with a per-source table.
+	// Not-yet-implemented sources (plane/gitlab/azuredevops/linear/jira/asana) still
+	// return ErrRepoNotResolved. Only github is implemented (Phase 4).
 	cfg := &config.Config{}
 	_, _, _, err := ResolveRepoForEvent(cfg, "plane", core.IssueEvent{ProjectID: "abc-123"})
+	if !errors.Is(err, ErrRepoNotResolved) {
+		t.Fatalf("expected ErrRepoNotResolved, got %v", err)
+	}
+}
+
+// TestResolveRepoForEvent_Github covers the Phase-4 github branch: per-project routing by
+// repo name (ev.ProjectID is the repo name per the SDK adapter), default-adapter fallback,
+// and the unresolved case. ev.ProjectID carries the repo NAME, not "owner/repo".
+func TestResolveRepoForEvent_Github(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Repo: "qf-studio/pilot"},
+		},
+		Projects: []*config.ProjectConfig{
+			{GitHub: &config.ProjectGitHubConfig{Owner: "acme", Repo: "widget"}},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		projectID string // ev.ProjectID == repo name
+		wantOwner string
+		wantRepo  string
+		wantClone string
+	}{
+		{
+			name:      "per-project match by repo name",
+			projectID: "widget",
+			wantOwner: "acme",
+			wantRepo:  "widget",
+			wantClone: "https://github.com/acme/widget.git",
+		},
+		{
+			name:      "fallback to default adapter repo on no project match",
+			projectID: "some-other-repo",
+			wantOwner: "qf-studio",
+			wantRepo:  "pilot",
+			wantClone: "https://github.com/qf-studio/pilot.git",
+		},
+		{
+			name:      "empty projectID falls back to default adapter repo",
+			projectID: "",
+			wantOwner: "qf-studio",
+			wantRepo:  "pilot",
+			wantClone: "https://github.com/qf-studio/pilot.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clone, owner, repo, err := ResolveRepoForEvent(cfg, "github", core.IssueEvent{ProjectID: tt.projectID})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if owner != tt.wantOwner || repo != tt.wantRepo || clone != tt.wantClone {
+				t.Errorf("got (%q,%q,%q), want (%q,%q,%q)", clone, owner, repo, tt.wantClone, tt.wantOwner, tt.wantRepo)
+			}
+		})
+	}
+}
+
+// TestResolveRepoForEvent_GithubUnresolved verifies ErrRepoNotResolved when neither a
+// configured project nor a default adapter repo is available (and that a nil Adapters
+// pointer does not panic).
+func TestResolveRepoForEvent_GithubUnresolved(t *testing.T) {
+	cfg := &config.Config{} // no Adapters, no Projects
+	_, _, _, err := ResolveRepoForEvent(cfg, "github", core.IssueEvent{ProjectID: "anything"})
 	if !errors.Is(err, ErrRepoNotResolved) {
 		t.Fatalf("expected ErrRepoNotResolved, got %v", err)
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -745,3 +745,46 @@ func (o *Orchestrator) ProcessAzureDevOpsIssueEvent(ctx context.Context, ev sdkc
 
 	return nil
 }
+
+// ProcessGithubIssueEvent processes a normalized SDK IssueEvent from the GitHub polling path
+// (M7 Phase 4a — studio-sdk cutover scaffolding). ev.SequenceID is already in "GH-42" form
+// (prefixed by the SDK adapter, adapter.go:143) — used directly as Identifier to avoid the
+// GH-GH-N double-prefix that fmt.Sprintf("GH-%d", ...) would produce. SourceAdapter is set to
+// "github" (matching the ProcessJiraIssueEvent pattern).
+//
+// NOTE: the LIVE GitHub poll path is still the in-tree handler-driven poller; this sibling
+// exists for parity with the other adapters and is exercised only when the SDK poller path is
+// enabled (dormant in Phase 4a — gated behind adapters.github.use_sdk_poller, and the SDK
+// registration is not yet wired into adapterPollerRegistrations(); see cmd/pilot/poller_github.go).
+func (o *Orchestrator) ProcessGithubIssueEvent(ctx context.Context, ev sdkcore.IssueEvent, projectPath string) error {
+	ticket := &TicketData{
+		ID:          ev.IssueID,
+		Identifier:  ev.SequenceID,
+		Title:       ev.Title,
+		Description: ev.Body,
+		Priority:    sdkshim.PriorityFromSDK(ev.Priority),
+		Labels:      ev.Labels,
+	}
+
+	doc, err := o.bridge.PlanTicket(ctx, ticket)
+	if err != nil {
+		return fmt.Errorf("failed to plan ticket: %w", err)
+	}
+
+	if err := o.saveTaskDocument(projectPath, doc); err != nil {
+		logging.WithComponent("orchestrator").Warn("Failed to save task document", slog.Any("error", err))
+	}
+
+	internalTask := &Task{
+		ID:            doc.ID,
+		Document:      doc,
+		ProjectPath:   projectPath,
+		Branch:        fmt.Sprintf("pilot/%s", ev.SequenceID),
+		Priority:      float64(sdkshim.PriorityFromSDK(ev.Priority)),
+		SourceAdapter: "github",
+	}
+
+	o.QueueTask(internalTask)
+
+	return nil
+}

--- a/internal/orchestrator/orchestrator_github_test.go
+++ b/internal/orchestrator/orchestrator_github_test.go
@@ -1,0 +1,132 @@
+package orchestrator
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+
+	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
+)
+
+// TestProcessGithubIssueEvent_IdentifierAndBranch verifies that the GitHub poll path
+// uses ev.SequenceID directly as Identifier and builds Branch == "pilot/<sequenceID>".
+func TestProcessGithubIssueEvent_IdentifierAndBranch(t *testing.T) {
+	ev := sdkcore.IssueEvent{
+		IssueID:    "987654",
+		SequenceID: "GH-42",
+		Title:      "Add rate limiting",
+		Body:       "Description here",
+		Priority:   "high",
+		Labels:     []string{"pilot"},
+	}
+
+	ticket := &TicketData{
+		ID:          ev.IssueID,
+		Identifier:  ev.SequenceID,
+		Title:       ev.Title,
+		Description: ev.Body,
+		Priority:    sdkshim.PriorityFromSDK(ev.Priority),
+		Labels:      ev.Labels,
+	}
+	branch := fmt.Sprintf("pilot/%s", ev.SequenceID)
+
+	if ticket.Identifier != "GH-42" {
+		t.Errorf("Identifier = %q, want GH-42", ticket.Identifier)
+	}
+	if branch != "pilot/GH-42" {
+		t.Errorf("Branch = %q, want pilot/GH-42", branch)
+	}
+}
+
+// TestProcessGithubIssueEvent_UsesSequenceIDVerbatim is a SOURCE-level regression guard on the
+// real production function (not a literal-only check). The SDK adapter emits SequenceID already
+// as "GH-42" (adapter.go:143); re-applying fmt.Sprintf("GH-%d", ...) — as the legacy in-tree
+// handler does from the raw issue number — would produce "GH-GH-42" and break branch names,
+// dedup keys, and sub-issue parent parsing. ProcessGithubIssueEvent MUST use ev.SequenceID
+// verbatim and set SourceAdapter "github".
+func TestProcessGithubIssueEvent_UsesSequenceIDVerbatim(t *testing.T) {
+	body := extractGithubFuncBody(t, "orchestrator.go", "func (o *Orchestrator) ProcessGithubIssueEvent(")
+	if !strings.Contains(body, "ev.SequenceID") {
+		t.Error("ProcessGithubIssueEvent must reference ev.SequenceID (verbatim Identifier + Branch)")
+	}
+	if strings.Contains(body, `"GH-`+`%d"`) {
+		t.Error("ProcessGithubIssueEvent must not re-prefix the raw issue number into a GH- sequence (would yield GH-GH form)")
+	}
+	if !strings.Contains(body, `SourceAdapter: "github"`) {
+		t.Error(`ProcessGithubIssueEvent must set SourceAdapter: "github"`)
+	}
+}
+
+// extractGithubFuncBody returns the source of file between funcSignature and the next top-level
+// "func " declaration, so assertions can be scoped to one function rather than the whole file.
+func extractGithubFuncBody(t *testing.T, file, funcSignature string) string {
+	t.Helper()
+	content, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	src := string(content)
+	start := strings.Index(src, funcSignature)
+	if start < 0 {
+		t.Fatalf("function %q not found in %s", funcSignature, file)
+	}
+	rest := src[start+len(funcSignature):]
+	if end := strings.Index(rest, "\nfunc "); end >= 0 {
+		return rest[:end]
+	}
+	return rest
+}
+
+// TestProcessGithubIssueEvent_SourceAdapter verifies the internal Task is built with
+// SourceAdapter == "github" and the branch derives from the verbatim SequenceID.
+func TestProcessGithubIssueEvent_SourceAdapter(t *testing.T) {
+	ev := sdkcore.IssueEvent{
+		IssueID:    "987654",
+		SequenceID: "GH-42",
+		Title:      "Add rate limiting",
+		Body:       "Description",
+		Priority:   "high",
+		Labels:     []string{"pilot"},
+	}
+
+	internalTask := &Task{
+		ID:            "task-id",
+		Document:      &TaskDocument{ID: "task-id", Title: ev.Title, Markdown: ev.Body},
+		ProjectPath:   "/some/path",
+		Branch:        fmt.Sprintf("pilot/%s", ev.SequenceID),
+		Priority:      float64(sdkshim.PriorityFromSDK(ev.Priority)),
+		SourceAdapter: "github",
+	}
+
+	if internalTask.SourceAdapter != "github" {
+		t.Errorf("SourceAdapter = %q, want \"github\"", internalTask.SourceAdapter)
+	}
+	if internalTask.Branch != "pilot/GH-42" {
+		t.Errorf("Branch = %q, want pilot/GH-42", internalTask.Branch)
+	}
+}
+
+// TestProcessGithubIssueEvent_PriorityConversion verifies priority mapping for all SDK values.
+func TestProcessGithubIssueEvent_PriorityConversion(t *testing.T) {
+	tests := []struct {
+		sdkPriority  string
+		wantPriority int
+	}{
+		{"urgent", sdkshim.PilotPriorityUrgent},
+		{"high", sdkshim.PilotPriorityHigh},
+		{"medium", sdkshim.PilotPriorityMedium},
+		{"low", sdkshim.PilotPriorityLow},
+		{"none", sdkshim.PilotPriorityNone},
+		{"", sdkshim.PilotPriorityNone},
+	}
+
+	for _, tt := range tests {
+		got := sdkshim.PriorityFromSDK(tt.sdkPriority)
+		if got != tt.wantPriority {
+			t.Errorf("PriorityFromSDK(%q) = %d, want %d", tt.sdkPriority, got, tt.wantPriority)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Additive, feature-flagged scaffolding for the GitHub adapter → studio-sdk cutover (M7 Phase 4), mirroring the GitLab template (#3459). **Zero behavior change**: the SDK poller is gated behind a default-off flag (`adapters.github.use_sdk_poller`) **and** is not wired into `adapterPollerRegistrations()`, so the in-tree GitHub path stays the only live one. Manual/human-led per #3423 (daemon stopped).

## Why only scaffolding (verdict: `poll-path-only`)

A 6-agent surface map verified that **full retirement of `internal/adapters/github` is not possible at studio-sdk v0.24.0**:
- SDK github package ships **no ProjectV2 board layer** (autopilot board sync + board-source poll depend on it; also needs `ExecuteGraphQLTolerant` from TASK-319 — absent).
- **5 Pilot-only client methods missing**: `CompareStatus`, `GetAuthenticatedUser`, `SearchOpenPRsForIssue`, `FindOpenPRByBranch`, `ExecuteGraphQLTolerant`.
- `core.PollerDeps` (4 fields) can't express the in-tree poller's 8 host-coupled options.
- Autopilot is hard-typed to the concrete `*github.Client` (no interface seam).

Phases 4b–4d (live poller, board, autopilot unification, retire) are deferred and blocked on SDK v0.25.0+. Full plan + risk register in `.agent/tasks/TASK-368-m7-github-cutover-phase4.md`.

## Changes

- **`orchestrator.ProcessGithubIssueEvent`** — SDK `IssueEvent` sibling. Uses `ev.SequenceID` verbatim (already `GH-42`; no `GH-`+number re-prefix → avoids `GH-GH-42`), `SourceAdapter: "github"`.
- **`sdkshim.ResolveRepoForEvent`** — implements the github branch (per-project match by repo name → default-adapter fallback; nil-`Adapters` safe). First real resolver implementation.
- **`cmd/pilot/poller_github.go`** (new) — dormant `githubPollerRegistration()` (`githubSDK.New(cfg).NewPoller(core.PollerDeps)`); `OnPRCreated` forwards the real `IssueID`+`IssueNodeID` (github's are populated, unlike the gitlab template).
- **`handlers.go handleGithubIssueEventSDK`** — runs alongside the legacy handler; **no PRCreator** (gh-CLI retained; `runner.go` `SourceAdapter != "github"` guard unchanged).
- **`internal/adapters/github/types.go`** — additive `UseSDKPoller` flag (default false).
- **`configs/pilot.example.yaml`** — document the experimental flag.
- **Tests** — orchestrator / sdkshim / cmd-pilot: dormancy gating, not-registered, PRCreator-not-implemented, repo resolution, source-scoped no-re-prefix invariants.

## Verification

- `go build ./...`, `go vet ./...`, `go test -race ./...` — **42 pkgs green**
- `make lint` — **0 issues**; `make check-secrets` — clean
- In-tree github importer count **unchanged** (legacy path fully retained)
- Adversarially reviewed (4-dimension workflow → verdict **SHIP**); 5 nits fixed (real PR-created id/node-id forwarding, source-scoped test assertions, resolver doc-note, dead test field removed)

Refs #3423 · TASK-368