### PR TITLE
fix(comms,executor): skip ghost-SHA guard for read-only LocalMode tasks

### DIFF
--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -260,6 +260,8 @@ If the question is too broad, ask for clarification instead of exploring everyth
 		Title:       "Question: " + TruncateText(question, 40),
 		Description: prompt,
 		ProjectPath: h.getActiveProjectPath(contextID),
+		LocalMode:   true,
+		CreatePR:    false,
 		Verbose:     false,
 	}
 
@@ -300,6 +302,7 @@ Provide findings in a structured format with:
 
 DO NOT make any code changes. This is a read-only research task.`, query),
 		ProjectPath: h.getActiveProjectPath(contextID),
+		LocalMode:   true,
 		CreatePR:    false,
 	}
 
@@ -410,6 +413,7 @@ Be concise - this is a chat conversation, not a report. Keep response under 500 
 
 User message: %s`, h.getActiveProjectPath(contextID), message),
 		ProjectPath: h.getActiveProjectPath(contextID),
+		LocalMode:   true,
 		CreatePR:    false,
 	}
 

--- a/internal/executor/git_freshness.go
+++ b/internal/executor/git_freshness.go
@@ -3,8 +3,45 @@ package executor
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os/exec"
 )
+
+// applyGhostSHAGuard enforces GH-3126: reject executions that produced no new commit.
+// When Claude makes no new commit, git log returns the parent (pre-execution) SHA.
+// Recording that as CommitSHA causes IsTaskShipped to return true on a no-op run,
+// triggering pilot-done + issue close with no actual work delivered.
+// Skipped for LocalMode tasks (read-only intents have no commit expectation — GH-3642).
+// Fails open on check errors (e.g. no origin configured in test repos): only rejects
+// when the check conclusively shows the SHA is already on origin/<base>.
+func applyGhostSHAGuard(ctx context.Context, task *Task, result *ExecutionResult, executionPath string, log *slog.Logger) {
+	if task.LocalMode || result.CommitSHA == "" || !result.Success {
+		return
+	}
+	ghostBase := task.BaseBranch
+	if ghostBase == "" {
+		ghostBase, _ = NewGitOperations(executionPath).GetDefaultBranch(ctx)
+		if ghostBase == "" {
+			ghostBase = "main"
+		}
+	}
+	if isNew, checkErr := commitSHAIsNew(ctx, executionPath, result.CommitSHA, ghostBase); checkErr != nil {
+		log.Warn("executor: ghost-SHA check skipped (will not block)",
+			slog.String("task_id", task.ID),
+			slog.String("sha", result.CommitSHA[:min(7, len(result.CommitSHA))]),
+			slog.Any("error", checkErr),
+		)
+	} else if !isNew {
+		log.Warn("executor: harvested SHA is already on base branch — no new commit",
+			slog.String("task_id", task.ID),
+			slog.String("sha", result.CommitSHA[:min(7, len(result.CommitSHA))]),
+			slog.String("base", ghostBase),
+		)
+		result.CommitSHA = ""
+		result.Success = false
+		result.Error = "no new commit produced — worktree HEAD matches base branch parent"
+	}
+}
 
 // commitSHAIsNew returns true iff sha exists in the repo AND is NOT an ancestor of
 // origin/<baseBranch>. A SHA already reachable from the base branch is a parent SHA —

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2601,36 +2601,8 @@ retrySucceeded:
 	}
 
 	// GH-3126: Ghost-SHA guard — reject SHAs that are already on the base branch.
-	// When Claude makes no new commit, git log returns the parent (pre-execution) SHA.
-	// Recording that as CommitSHA causes IsTaskShipped to return true on a no-op run,
-	// triggering pilot-done + issue close with no actual work delivered.
-	// Fail open on check errors (e.g. no origin configured in test repos): only reject
-	// when the check conclusively shows the SHA is already on origin/<base>.
-	if result.CommitSHA != "" && result.Success {
-		ghostBase := task.BaseBranch
-		if ghostBase == "" {
-			ghostBase, _ = git.GetDefaultBranch(ctx)
-			if ghostBase == "" {
-				ghostBase = "main"
-			}
-		}
-		if isNew, checkErr := commitSHAIsNew(ctx, executionPath, result.CommitSHA, ghostBase); checkErr != nil {
-			log.Warn("executor: ghost-SHA check skipped (will not block)",
-				slog.String("task_id", task.ID),
-				slog.String("sha", result.CommitSHA[:min(7, len(result.CommitSHA))]),
-				slog.Any("error", checkErr),
-			)
-		} else if !isNew {
-			log.Warn("executor: harvested SHA is already on base branch — no new commit",
-				slog.String("task_id", task.ID),
-				slog.String("sha", result.CommitSHA[:min(7, len(result.CommitSHA))]),
-				slog.String("base", ghostBase),
-			)
-			result.CommitSHA = ""
-			result.Success = false
-			result.Error = "no new commit produced — worktree HEAD matches base branch parent"
-		}
-	}
+	// Skipped for LocalMode tasks (read-only intents have no commit expectation — GH-3642).
+	applyGhostSHAGuard(ctx, task, result, executionPath, log)
 
 	// Fill in additional metrics from state
 	result.FilesChanged = state.filesWrite

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -3942,4 +3943,67 @@ func TestMetricsRecorder_CalledOncePerExecution(t *testing.T) {
 	} else if rec.durationCalls[0] <= 0 {
 		t.Errorf("RecordExecutionDuration got %v, want positive duration", rec.durationCalls[0])
 	}
+}
+
+// TestGhostSHAGuard verifies applyGhostSHAGuard (GH-3126 + GH-3642).
+func TestGhostSHAGuard(t *testing.T) {
+	log := slog.Default()
+	ctx := context.Background()
+
+	t.Run("LocalMode_SkipsGuard", func(t *testing.T) {
+		// GH-3642: a LocalMode (read-only) task must not be rejected even when its
+		// CommitSHA is already on the base branch (no commit expected — no failure).
+		repoDir, _ := setupFreshnessRepo(t)
+		sha := strings.TrimSpace(gitOutput(t, repoDir, "rev-parse", "HEAD"))
+
+		result := &ExecutionResult{
+			TaskID:    "Q-1",
+			CommitSHA: sha,
+			Success:   true,
+			Output:    "here is your answer",
+		}
+		task := &Task{ID: "Q-1", LocalMode: true, BaseBranch: "main"}
+
+		applyGhostSHAGuard(ctx, task, result, repoDir, log)
+
+		if !result.Success {
+			t.Error("LocalMode task: Success should remain true, guard must be skipped")
+		}
+		if result.Error != "" {
+			t.Errorf("LocalMode task: Error should be empty, got %q", result.Error)
+		}
+		if result.Output != "here is your answer" {
+			t.Errorf("LocalMode task: Output should be preserved, got %q", result.Output)
+		}
+		if result.CommitSHA != sha {
+			t.Errorf("LocalMode task: CommitSHA should be unchanged, got %q", result.CommitSHA)
+		}
+	})
+
+	t.Run("NonLocalMode_RejectsAncestorSHA", func(t *testing.T) {
+		// GH-3126: a normal (non-LocalMode) PR task with a SHA already on origin/main
+		// must be rejected — proof no new commit was produced.
+		repoDir, _ := setupFreshnessRepo(t)
+		sha := strings.TrimSpace(gitOutput(t, repoDir, "rev-parse", "HEAD"))
+
+		result := &ExecutionResult{
+			TaskID:    "GH-1",
+			CommitSHA: sha,
+			Success:   true,
+			Output:    "changes applied",
+		}
+		task := &Task{ID: "GH-1", LocalMode: false, BaseBranch: "main"}
+
+		applyGhostSHAGuard(ctx, task, result, repoDir, log)
+
+		if result.Success {
+			t.Error("non-LocalMode task: Success should be false when SHA is already on base")
+		}
+		if result.CommitSHA != "" {
+			t.Errorf("non-LocalMode task: CommitSHA should be cleared, got %q", result.CommitSHA)
+		}
+		if result.Error != "no new commit produced — worktree HEAD matches base branch parent" {
+			t.Errorf("non-LocalMode task: unexpected error %q", result.Error)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- `handleQuestion`, `handleResearch`, `handleChat` in `internal/comms/handler.go` now set `LocalMode: true` and `CreatePR: false`, telling the executor these tasks have no commit expectation
- Extracted the ghost-SHA guard (GH-3126) from `executeWithOptions` into a standalone `applyGhostSHAGuard` function in `git_freshness.go`; added an early return when `task.LocalMode` is true so a no-commit read-only run is not treated as a failure
- Added regression tests: `LocalMode=true` with ancestor SHA → success preserved; `LocalMode=false` with ancestor SHA → still rejected (GH-3126 intact)

Fixes #3642 (TASK-369).

## Test plan

- [x] `go test ./internal/executor/... -run TestGhostSHAGuard -v` — both sub-tests pass
- [x] `go test ./internal/comms/...` — all existing tests pass
- [x] `go test ./...` — full suite green
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues