### PR TITLE
refactor(comms): unify Handler wiring across adapters via shared factory (TASK-370)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-06-24 (v2.151.0)
+**Last Updated:** 2026-06-18 (v2.151.0)
 
 ## Legend
 
@@ -163,6 +163,7 @@
 | Comms shared types | ✅ | comms | - | - | ProjectSource, RateLimiter shared types (v2.25.0, PR #1766) |
 | Comms intent consolidation | ✅ | comms | - | - | Conversation store + LLM classifier consolidated into intent package (v2.25.0, PR #1789) |
 | Comms main.go wiring | ✅ | main | - | - | Updated main.go wiring for unified comms.Handler (v2.25.0, PR #1775) |
+| Comms BuildHandler factory | ✅ | comms | - | `llm_classifier` under slack/discord | Single assembly point for comms.HandlerConfig; all 5 adapter call sites route through it; Slack/Discord/gateway reach classifier parity with Telegram (v2.193.0, PR #3645) |
 
 ## Alerts & Monitoring
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -37,7 +37,6 @@ import (
 	"github.com/qf-studio/pilot/internal/dashboard"
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/gateway"
-	"github.com/qf-studio/pilot/internal/intent"
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/pilot"
@@ -1866,54 +1865,33 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 		tgMessenger := telegram.NewMessenger(tgClient, cfg.Adapters.Telegram.PlainTextMode)
 
-		// Build LLM classifier + conversation store for comms.Handler
-		var tgLLMClassifier intent.Classifier
-		var tgConvStore *intent.ConversationStore
-		if cfg.Adapters.Telegram.LLMClassifier != nil && cfg.Adapters.Telegram.LLMClassifier.Enabled {
-			apiKey := cfg.Adapters.Telegram.LLMClassifier.APIKey
-			if apiKey == "" {
-				apiKey = os.Getenv("ANTHROPIC_API_KEY")
-			}
-			if apiKey != "" {
-				client := intent.NewAnthropicClient(apiKey)
-				if cfg.Executor != nil {
-					if cfg.Executor.DefaultModel != "" {
-						client.SetModel(cfg.Executor.DefaultModel)
-					}
-					if cfg.Executor.APIBaseURL != "" {
-						client.SetAPIURL(cfg.Executor.APIBaseURL + "/v1/messages")
-					}
-				}
-				tgLLMClassifier = client
-				historySize := 10
-				if cfg.Adapters.Telegram.LLMClassifier.HistorySize > 0 {
-					historySize = cfg.Adapters.Telegram.LLMClassifier.HistorySize
-				}
-				historyTTL := 30 * time.Minute
-				if cfg.Adapters.Telegram.LLMClassifier.HistoryTTL > 0 {
-					historyTTL = cfg.Adapters.Telegram.LLMClassifier.HistoryTTL
-				}
-				tgConvStore = intent.NewConversationStore(historySize, historyTTL)
-			}
-		}
-
 		// Build comms.MemberResolver wrapper (GH-634)
 		var tgMemberResolver comms.MemberResolver
 		if teamAdapter != nil {
 			tgMemberResolver = &telegram.MemberResolverAdapter{Inner: teamAdapter}
 		}
 
-		tgCommsHandler := comms.NewHandler(&comms.HandlerConfig{
-			Messenger:      tgMessenger,
-			Runner:         runner,
-			Projects:       config.NewProjectSource(cfg),
-			ProjectPath:    projectPath,
-			RateLimit:      cfg.Adapters.Telegram.RateLimit,
-			LLMClassifier:  tgLLMClassifier,
-			ConvStore:      tgConvStore,
-			MemberResolver: tgMemberResolver,
-			Store:          store,
-			TaskIDPrefix:   "TG",
+		var tgClassifierCfg *comms.ClassifierConfig
+		if cfg.Adapters.Telegram.LLMClassifier != nil {
+			tgClassifierCfg = &comms.ClassifierConfig{
+				Enabled:     cfg.Adapters.Telegram.LLMClassifier.Enabled,
+				APIKey:      cfg.Adapters.Telegram.LLMClassifier.APIKey,
+				HistorySize: cfg.Adapters.Telegram.LLMClassifier.HistorySize,
+				HistoryTTL:  cfg.Adapters.Telegram.LLMClassifier.HistoryTTL,
+			}
+		}
+
+		tgCommsHandler := comms.BuildHandler(comms.HandlerDeps{
+			Messenger:       tgMessenger,
+			Runner:          runner,
+			Projects:        config.NewProjectSource(cfg),
+			ProjectPath:     projectPath,
+			RateLimit:       cfg.Adapters.Telegram.RateLimit,
+			Classifier:      tgClassifierCfg,
+			MemberResolver:  tgMemberResolver,
+			Store:           store,
+			TaskIDPrefix:    "TG",
+			ExecutorBackend: cfg.Executor,
 		})
 
 		tgConfig := &telegram.HandlerConfig{
@@ -2563,6 +2541,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		Program:              program,
 		AlertsEngine:         alertsEngine,
 		Enforcer:             enforcer,
+		Store:                store,
 		AutopilotController:  autopilotController,
 		AutopilotStateStore:  autopilotStateStore,
 		AutopilotControllers: autopilotControllers,
@@ -2626,14 +2605,26 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			AllowedUsers:    cfg.Adapters.Slack.AllowedUsers,
 		}, nil).NewChatBridge(sdkCore.ChatDeps{Handler: slackChatHandler})
 
-		slackCommsHandler := comms.NewHandler(&comms.HandlerConfig{
-			Messenger:      sdkshim.MessengerToBridge(slackBridge),
-			Runner:         runner,
-			Projects:       config.NewSlackProjectSource(cfg),
-			ProjectPath:    projectPath,
-			MemberResolver: slackMemberResolver,
-			Store:          store,
-			TaskIDPrefix:   "SLACK",
+		var slackClassifierCfg *comms.ClassifierConfig
+		if cfg.Adapters.Slack.LLMClassifier != nil {
+			slackClassifierCfg = &comms.ClassifierConfig{
+				Enabled:     cfg.Adapters.Slack.LLMClassifier.Enabled,
+				APIKey:      cfg.Adapters.Slack.LLMClassifier.APIKey,
+				HistorySize: cfg.Adapters.Slack.LLMClassifier.HistorySize,
+				HistoryTTL:  cfg.Adapters.Slack.LLMClassifier.HistoryTTL,
+			}
+		}
+
+		slackCommsHandler := comms.BuildHandler(comms.HandlerDeps{
+			Messenger:       sdkshim.MessengerToBridge(slackBridge),
+			Runner:          runner,
+			Projects:        config.NewSlackProjectSource(cfg),
+			ProjectPath:     projectPath,
+			Classifier:      slackClassifierCfg,
+			MemberResolver:  slackMemberResolver,
+			Store:           store,
+			TaskIDPrefix:    "SLACK",
+			ExecutorBackend: cfg.Executor,
 		})
 		slackChatHandler.SetCommsHandler(slackCommsHandler)
 

--- a/cmd/pilot/poller_discord.go
+++ b/cmd/pilot/poller_discord.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
-	"time"
 
 	"github.com/qf-studio/pilot/internal/adapters/discord"
 	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
 	"github.com/qf-studio/pilot/internal/comms"
 	"github.com/qf-studio/pilot/internal/config"
-	"github.com/qf-studio/pilot/internal/intent"
 	"github.com/qf-studio/pilot/internal/logging"
 	sdkCore "github.com/qf-studio/studio-sdk/sdk/core"
 	sdkDiscord "github.com/qf-studio/studio-sdk/sdk/integrations/discord"
@@ -26,34 +23,13 @@ func discordPollerRegistration() PollerRegistration {
 		CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
 			discordCfg := deps.Cfg.Adapters.Discord
 
-			// Build LLM classifier + conversation store for comms.Handler
-			var llmClassifier intent.Classifier
-			var convStore *intent.ConversationStore
-			if discordCfg.LLMClassifier != nil && discordCfg.LLMClassifier.Enabled {
-				apiKey := discordCfg.LLMClassifier.APIKey
-				if apiKey == "" {
-					apiKey = os.Getenv("ANTHROPIC_API_KEY")
-				}
-				if apiKey != "" {
-					client := intent.NewAnthropicClient(apiKey)
-					if deps.Cfg.Executor != nil {
-						if deps.Cfg.Executor.DefaultModel != "" {
-							client.SetModel(deps.Cfg.Executor.DefaultModel)
-						}
-						if deps.Cfg.Executor.APIBaseURL != "" {
-							client.SetAPIURL(deps.Cfg.Executor.APIBaseURL + "/v1/messages")
-						}
-					}
-					llmClassifier = client
-					historySize := 10
-					if discordCfg.LLMClassifier.HistorySize > 0 {
-						historySize = discordCfg.LLMClassifier.HistorySize
-					}
-					historyTTL := 30 * time.Minute
-					if discordCfg.LLMClassifier.HistoryTTL > 0 {
-						historyTTL = discordCfg.LLMClassifier.HistoryTTL
-					}
-					convStore = intent.NewConversationStore(historySize, historyTTL)
+			var discordClassifierCfg *comms.ClassifierConfig
+			if discordCfg.LLMClassifier != nil {
+				discordClassifierCfg = &comms.ClassifierConfig{
+					Enabled:     discordCfg.LLMClassifier.Enabled,
+					APIKey:      discordCfg.LLMClassifier.APIKey,
+					HistorySize: discordCfg.LLMClassifier.HistorySize,
+					HistoryTTL:  discordCfg.LLMClassifier.HistoryTTL,
 				}
 			}
 
@@ -75,14 +51,16 @@ func discordPollerRegistration() PollerRegistration {
 				AllowedChannels: discordCfg.AllowedChannels,
 			}, nil).NewChatBridge(sdkCore.ChatDeps{Handler: discordChatHandler})
 
-			discordCommsHandler := comms.NewHandler(&comms.HandlerConfig{
-				Messenger:     sdkshim.MessengerToBridge(discordBridge),
-				Runner:        deps.Runner,
-				Projects:      config.NewProjectSource(deps.Cfg),
-				ProjectPath:   deps.ProjectPath,
-				LLMClassifier: llmClassifier,
-				ConvStore:     convStore,
-				TaskIDPrefix:  "DISCORD",
+			discordCommsHandler := comms.BuildHandler(comms.HandlerDeps{
+				Messenger:       sdkshim.MessengerToBridge(discordBridge),
+				Runner:          deps.Runner,
+				Projects:        config.NewProjectSource(deps.Cfg),
+				ProjectPath:     deps.ProjectPath,
+				RateLimit:       discordRateLimitToComms(discordCfg.RateLimit),
+				Classifier:      discordClassifierCfg,
+				Store:           deps.Store,
+				TaskIDPrefix:    "DISCORD",
+				ExecutorBackend: deps.Cfg.Executor,
 			})
 			discordChatHandler.SetCommsHandler(discordCommsHandler)
 
@@ -96,5 +74,19 @@ func discordPollerRegistration() PollerRegistration {
 			fmt.Println("🎮 Discord bot started")
 			logging.WithComponent("start").Info("Discord bot started")
 		},
+	}
+}
+
+// discordRateLimitToComms converts discord.RateLimitConfig units to comms.RateLimitConfig.
+// discord uses per-second messages and per-minute tasks; comms uses per-minute and per-hour.
+func discordRateLimitToComms(rl *discord.RateLimitConfig) *comms.RateLimitConfig {
+	if rl == nil {
+		return nil
+	}
+	return &comms.RateLimitConfig{
+		Enabled:           true,
+		MessagesPerMinute: rl.MessagesPerSecond * 60,
+		TasksPerHour:      rl.TasksPerMinute * 60,
+		BurstSize:         comms.DefaultRateLimitConfig().BurstSize,
 	}
 }

--- a/cmd/pilot/poller_registry.go
+++ b/cmd/pilot/poller_registry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/logging"
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 // PollerDeps groups shared infrastructure used by all adapter poller startup blocks.
@@ -25,6 +26,7 @@ type PollerDeps struct {
 	Program      *tea.Program
 	AlertsEngine *alerts.Engine
 	Enforcer     *budget.Enforcer
+	Store        *memory.Store
 
 	AutopilotController  *autopilot.Controller
 	AutopilotStateStore  *autopilot.StateStore

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -142,12 +142,26 @@ adapters:
     allowed_guilds: []       # Guild IDs (empty = all)
     allowed_channels: []     # Channel IDs (empty = all)
     command_prefix: "/"
+    # LLM-based intent classification (uses Claude Haiku for accurate intent detection)
+    llm_classifier:
+      enabled: false                   # Enable for better intent detection vs regex
+      # api_key: ""                    # Optional - uses ANTHROPIC_API_KEY env var if not set
+      history_size: 10                 # Messages to keep per channel for context
+      history_ttl: 30m                 # TTL for conversation history
 
-  # Slack - Notifications
+  # Slack - Notifications + Socket Mode chat
   slack:
     enabled: false
     bot_token: "${SLACK_BOT_TOKEN}"
     channel: "#dev-notifications"
+    # LLM-based intent classification (uses Claude Haiku for accurate intent detection)
+    # When enabled, phrases like "check the pilot queue" are classified correctly
+    # (as question/research) instead of defaulting to task via regex.
+    llm_classifier:
+      enabled: false                   # Enable for better intent detection vs regex
+      # api_key: ""                    # Optional - uses ANTHROPIC_API_KEY env var if not set
+      history_size: 10                 # Messages to keep per channel for context
+      history_ttl: 30m                 # TTL for conversation history
 
 # Orchestrator settings
 orchestrator:

--- a/internal/adapters/slack/handler.go
+++ b/internal/adapters/slack/handler.go
@@ -61,15 +61,6 @@ type HandlerConfig struct {
 	AllowedUsers    []string       // User IDs allowed to send tasks
 }
 
-// LLMClassifierConfig holds configuration for the LLM classifier.
-// Retained for config compatibility; now handled by comms.Handler.
-type LLMClassifierConfig struct {
-	Enabled     bool
-	APIKey      string
-	HistorySize int
-	HistoryTTL  time.Duration
-}
-
 // NewHandler creates a new Slack event handler.
 func NewHandler(config *HandlerConfig) *Handler {
 	allowedChannels := make(map[string]bool)

--- a/internal/adapters/slack/notifier.go
+++ b/internal/adapters/slack/notifier.go
@@ -3,19 +3,29 @@ package slack
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 // Config holds Slack adapter configuration
 type Config struct {
-	Enabled         bool            `yaml:"enabled"`
-	BotToken        string          `yaml:"bot_token"`
-	AppToken        string          `yaml:"app_token"`
-	Channel         string          `yaml:"channel"`
-	SigningSecret   string          `yaml:"signing_secret"`
-	SocketMode      bool            `yaml:"socket_mode"`
-	AllowedUsers    []string        `yaml:"allowed_users"`
-	AllowedChannels []string        `yaml:"allowed_channels"`
-	Approval        *ApprovalConfig `yaml:"approval,omitempty"`
+	Enabled         bool                 `yaml:"enabled"`
+	BotToken        string               `yaml:"bot_token"`
+	AppToken        string               `yaml:"app_token"`
+	Channel         string               `yaml:"channel"`
+	SigningSecret   string               `yaml:"signing_secret"`
+	SocketMode      bool                 `yaml:"socket_mode"`
+	AllowedUsers    []string             `yaml:"allowed_users"`
+	AllowedChannels []string             `yaml:"allowed_channels"`
+	Approval        *ApprovalConfig      `yaml:"approval,omitempty"`
+	LLMClassifier   *LLMClassifierConfig `yaml:"llm_classifier,omitempty"`
+}
+
+// LLMClassifierConfig configures LLM-based intent classification for Slack.
+type LLMClassifierConfig struct {
+	Enabled     bool          `yaml:"enabled"`
+	APIKey      string        `yaml:"api_key"`
+	HistorySize int           `yaml:"history_size"`
+	HistoryTTL  time.Duration `yaml:"history_ttl"`
 }
 
 // DefaultConfig returns default Slack configuration

--- a/internal/comms/factory.go
+++ b/internal/comms/factory.go
@@ -1,0 +1,94 @@
+package comms
+
+import (
+	"os"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/intent"
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// ClassifierConfig is the adapter-agnostic config for LLM intent classification.
+// Each adapter maps its own per-adapter YAML config into this struct before
+// calling BuildHandler, so the bootstrap logic lives in exactly one place.
+type ClassifierConfig struct {
+	Enabled     bool
+	APIKey      string
+	HistorySize int
+	HistoryTTL  time.Duration
+}
+
+// BuildClassifier bootstraps an intent classifier and conversation store.
+// Returns (nil, nil) when disabled or no API key is available (env fallback included).
+// Call sites do not need to guard for nil — comms.Handler handles nil classifiers gracefully.
+func BuildClassifier(cfg *ClassifierConfig, executorBackend *executor.BackendConfig) (intent.Classifier, *intent.ConversationStore) {
+	if cfg == nil || !cfg.Enabled {
+		return nil, nil
+	}
+
+	apiKey := cfg.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if apiKey == "" {
+		return nil, nil
+	}
+
+	client := intent.NewAnthropicClient(apiKey)
+	if executorBackend != nil {
+		if executorBackend.DefaultModel != "" {
+			client.SetModel(executorBackend.DefaultModel)
+		}
+		if executorBackend.APIBaseURL != "" {
+			client.SetAPIURL(executorBackend.APIBaseURL + "/v1/messages")
+		}
+	}
+
+	historySize := 10
+	if cfg.HistorySize > 0 {
+		historySize = cfg.HistorySize
+	}
+	historyTTL := 30 * time.Minute
+	if cfg.HistoryTTL > 0 {
+		historyTTL = cfg.HistoryTTL
+	}
+
+	return client, intent.NewConversationStore(historySize, historyTTL)
+}
+
+// HandlerDeps holds the per-adapter inputs needed to build a comms.Handler.
+// Pass this to BuildHandler — the only place HandlerConfig is assembled.
+type HandlerDeps struct {
+	Messenger      Messenger
+	Runner         *executor.Runner
+	Projects       ProjectSource
+	ProjectPath    string
+	RateLimit      *RateLimitConfig
+	Classifier     *ClassifierConfig
+	MemberResolver MemberResolver
+	Store          *memory.Store
+	TaskIDPrefix   string
+	// ExecutorBackend is used by BuildClassifier to override the Anthropic model and URL.
+	// May be nil — the factory handles that gracefully.
+	ExecutorBackend *executor.BackendConfig
+}
+
+// BuildHandler creates a Handler from adapter deps.
+// This is the single assembly point for HandlerConfig; all 5 adapter call sites
+// route through here so no field can be silently omitted per-adapter.
+func BuildHandler(deps HandlerDeps) *Handler {
+	classifier, convStore := BuildClassifier(deps.Classifier, deps.ExecutorBackend)
+	return NewHandler(&HandlerConfig{
+		Messenger:      deps.Messenger,
+		Runner:         deps.Runner,
+		Projects:       deps.Projects,
+		ProjectPath:    deps.ProjectPath,
+		RateLimit:      deps.RateLimit,
+		LLMClassifier:  classifier,
+		ConvStore:      convStore,
+		MemberResolver: deps.MemberResolver,
+		Store:          deps.Store,
+		TaskIDPrefix:   deps.TaskIDPrefix,
+	})
+}

--- a/internal/comms/factory_test.go
+++ b/internal/comms/factory_test.go
@@ -1,0 +1,241 @@
+package comms
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/intent"
+)
+
+// --- BuildClassifier tests ---
+
+func TestBuildClassifier_NilConfig(t *testing.T) {
+	classifier, store := BuildClassifier(nil, nil)
+	if classifier != nil {
+		t.Error("expected nil classifier for nil config")
+	}
+	if store != nil {
+		t.Error("expected nil store for nil config")
+	}
+}
+
+func TestBuildClassifier_Disabled(t *testing.T) {
+	cfg := &ClassifierConfig{Enabled: false, APIKey: "some-key"}
+	classifier, store := BuildClassifier(cfg, nil)
+	if classifier != nil {
+		t.Error("expected nil classifier when disabled")
+	}
+	if store != nil {
+		t.Error("expected nil store when disabled")
+	}
+}
+
+func TestBuildClassifier_NoAPIKey(t *testing.T) {
+	// Enabled but no key and no ANTHROPIC_API_KEY env var (test env has none).
+	cfg := &ClassifierConfig{Enabled: true, APIKey: ""}
+	// Do not set env var — ensure the function returns nil rather than panicking.
+	classifier, store := BuildClassifier(cfg, nil)
+	// Result depends on whether ANTHROPIC_API_KEY is set in the test environment.
+	// We only assert that if both are nil no panic occurred.
+	if (classifier == nil) != (store == nil) {
+		t.Error("classifier and store must both be nil or both non-nil")
+	}
+}
+
+func TestBuildClassifier_Enabled(t *testing.T) {
+	cfg := &ClassifierConfig{
+		Enabled:     true,
+		APIKey:      "test-anthropic-key",
+		HistorySize: 5,
+		HistoryTTL:  10 * time.Minute,
+	}
+	classifier, store := BuildClassifier(cfg, nil)
+	if classifier == nil {
+		t.Fatal("expected non-nil classifier when enabled with API key")
+	}
+	if store == nil {
+		t.Fatal("expected non-nil store when enabled with API key")
+	}
+}
+
+func TestBuildClassifier_DefaultHistorySizeAndTTL(t *testing.T) {
+	cfg := &ClassifierConfig{
+		Enabled: true,
+		APIKey:  "test-key",
+		// HistorySize and HistoryTTL left at zero → factory uses defaults
+	}
+	classifier, store := BuildClassifier(cfg, nil)
+	if classifier == nil {
+		t.Fatal("expected non-nil classifier")
+	}
+	if store == nil {
+		t.Fatal("expected non-nil store")
+	}
+	// Verify the store works (add + get a message)
+	store.Add("chan1", "user", "hello")
+	msgs := store.Get("chan1")
+	if len(msgs) != 1 {
+		t.Errorf("expected 1 message in store, got %d", len(msgs))
+	}
+}
+
+// --- BuildHandler tests ---
+
+func TestBuildHandler_AllFields(t *testing.T) {
+	m := &handlerMock{}
+	classifier := &hMockClassifier{result: intent.IntentQuestion}
+	resolver := &hMockMemberResolver{memberID: "member-1"}
+
+	h := BuildHandler(HandlerDeps{
+		Messenger: m,
+		Classifier: &ClassifierConfig{
+			Enabled: true,
+			APIKey:  "test-key",
+		},
+		MemberResolver: resolver,
+		TaskIDPrefix:   "SLACK",
+	})
+
+	if h == nil {
+		t.Fatal("expected non-nil Handler")
+	}
+	if h.taskIDPrefix != "SLACK" {
+		t.Errorf("expected prefix SLACK, got %s", h.taskIDPrefix)
+	}
+	if h.llmClassifier == nil {
+		t.Error("expected llmClassifier to be wired")
+	}
+	if h.convStore == nil {
+		t.Error("expected convStore to be wired when classifier is enabled")
+	}
+	if h.memberResolver == nil {
+		t.Error("expected memberResolver to be wired")
+	}
+	if h.rateLimit == nil {
+		t.Error("expected rateLimit to be initialized (default)")
+	}
+	_ = classifier // referenced in test setup only
+}
+
+func TestBuildHandler_DisabledClassifier(t *testing.T) {
+	m := &handlerMock{}
+	h := BuildHandler(HandlerDeps{
+		Messenger:    m,
+		TaskIDPrefix: "TG",
+		Classifier:   &ClassifierConfig{Enabled: false},
+	})
+
+	if h.llmClassifier != nil {
+		t.Error("expected nil llmClassifier when classifier disabled")
+	}
+	if h.convStore != nil {
+		t.Error("expected nil convStore when classifier disabled")
+	}
+}
+
+func TestBuildHandler_NilClassifierConfig(t *testing.T) {
+	m := &handlerMock{}
+	h := BuildHandler(HandlerDeps{
+		Messenger:    m,
+		TaskIDPrefix: "DISCORD",
+		Classifier:   nil,
+	})
+	if h.llmClassifier != nil {
+		t.Error("expected nil llmClassifier when ClassifierConfig is nil")
+	}
+}
+
+// TestBuildHandler_AdapterParity verifies all five adapter configurations
+// are exercised via BuildHandler and produce consistent fields.
+func TestBuildHandler_AdapterParity(t *testing.T) {
+	cases := []struct {
+		name         string
+		prefix       string
+		hasClassifier bool
+	}{
+		{"telegram-main", "TG", true},
+		{"slack-main", "SLACK", true},
+		{"discord", "DISCORD", true},
+		{"telegram-gateway", "TG", false},
+		{"slack-gateway", "SLACK", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var classifierCfg *ClassifierConfig
+			if tc.hasClassifier {
+				classifierCfg = &ClassifierConfig{
+					Enabled: true,
+					APIKey:  "test-key",
+				}
+			}
+
+			m := &handlerMock{}
+			h := BuildHandler(HandlerDeps{
+				Messenger:    m,
+				TaskIDPrefix: tc.prefix,
+				Classifier:   classifierCfg,
+			})
+
+			if h == nil {
+				t.Fatal("BuildHandler returned nil")
+			}
+			if h.taskIDPrefix != tc.prefix {
+				t.Errorf("expected prefix %s, got %s", tc.prefix, h.taskIDPrefix)
+			}
+			if h.rateLimit == nil {
+				t.Error("rateLimit must never be nil — factory should apply default")
+			}
+			if tc.hasClassifier && h.llmClassifier == nil {
+				t.Error("llmClassifier should be wired when classifier config is enabled")
+			}
+			if tc.hasClassifier && h.convStore == nil {
+				t.Error("convStore should be wired when classifier config is enabled")
+			}
+		})
+	}
+}
+
+// TestBuildHandler_ClassifierRoutedToHandler verifies that when a mock classifier
+// is wired, detectIntent uses it for messages that bypass the regex fast paths.
+// Slack regression: GH-3645 — "check the pilot queue" was classified as IntentTask
+// because the LLM classifier was never wired into Slack's comms.Handler.
+func TestBuildHandler_ClassifierRoutedToHandler(t *testing.T) {
+	// Mock classifier returns IntentGreeting so the handler calls handleGreeting
+	// (no runner required), letting us observe the send without a nil-runner panic.
+	mockClassifier := &hMockClassifier{result: intent.IntentGreeting}
+	m := &handlerMock{}
+
+	h := NewHandler(&HandlerConfig{
+		Messenger:     m,
+		LLMClassifier: mockClassifier,
+		TaskIDPrefix:  "SLACK",
+	})
+
+	ctx := context.Background()
+	// "check the pilot queue" — does not start with a greeting, is not a clear
+	// question, so it reaches the LLM classifier gate in detectIntent.
+	h.HandleMessage(ctx, &IncomingMessage{
+		ContextID: "C123",
+		SenderID:  "U1",
+		Text:      "check the pilot queue",
+	})
+
+	texts := m.getTexts()
+	for _, st := range texts {
+		if st.contextID == "C123" && st.text != "" {
+			// Any non-empty response means the message was handled — confirm it
+			// did NOT go to the task confirmation path (which has no text send).
+			// If classifier wasn't called, the message would be classified as
+			// IntentTask and sent to SendConfirmation, not SendText.
+			for _, c := range m.confirms {
+				if c.contextID == "C123" {
+					t.Error("message routed to task confirmation — LLM classifier not called")
+				}
+			}
+			return
+		}
+	}
+	t.Error("no response sent — LLM classifier not routed to handler")
+}

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -604,15 +604,27 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 			tgMemberResolver = &telegram.MemberResolverAdapter{Inner: p.telegramMemberResolver}
 		}
 
-		tgCommsHandler := comms.NewHandler(&comms.HandlerConfig{
-			Messenger:      tgMessenger,
-			Runner:         p.telegramRunner,
-			Projects:       config.NewProjectSource(cfg),
-			ProjectPath:    projectPath,
-			RateLimit:      cfg.Adapters.Telegram.RateLimit,
-			MemberResolver: tgMemberResolver,
-			Store:          p.store,
-			TaskIDPrefix:   "TG",
+		var tgClassifierCfg *comms.ClassifierConfig
+		if cfg.Adapters.Telegram.LLMClassifier != nil {
+			tgClassifierCfg = &comms.ClassifierConfig{
+				Enabled:     cfg.Adapters.Telegram.LLMClassifier.Enabled,
+				APIKey:      cfg.Adapters.Telegram.LLMClassifier.APIKey,
+				HistorySize: cfg.Adapters.Telegram.LLMClassifier.HistorySize,
+				HistoryTTL:  cfg.Adapters.Telegram.LLMClassifier.HistoryTTL,
+			}
+		}
+
+		tgCommsHandler := comms.BuildHandler(comms.HandlerDeps{
+			Messenger:       tgMessenger,
+			Runner:          p.telegramRunner,
+			Projects:        config.NewProjectSource(cfg),
+			ProjectPath:     projectPath,
+			RateLimit:       cfg.Adapters.Telegram.RateLimit,
+			Classifier:      tgClassifierCfg,
+			MemberResolver:  tgMemberResolver,
+			Store:           p.store,
+			TaskIDPrefix:    "TG",
+			ExecutorBackend: cfg.Executor,
 		})
 
 		p.telegramHandler = telegram.NewHandler(&telegram.HandlerConfig{
@@ -650,14 +662,26 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 			slackMemberResolver = &slack.MemberResolverAdapter{Inner: p.slackMemberResolver}
 		}
 
-		slackCommsHandler := comms.NewHandler(&comms.HandlerConfig{
-			Messenger:      slackMessenger,
-			Runner:         p.slackRunner,
-			Projects:       config.NewSlackProjectSource(cfg),
-			ProjectPath:    projectPath,
-			MemberResolver: slackMemberResolver,
-			Store:          p.store,
-			TaskIDPrefix:   "SLACK",
+		var slackClassifierCfg *comms.ClassifierConfig
+		if cfg.Adapters.Slack.LLMClassifier != nil {
+			slackClassifierCfg = &comms.ClassifierConfig{
+				Enabled:     cfg.Adapters.Slack.LLMClassifier.Enabled,
+				APIKey:      cfg.Adapters.Slack.LLMClassifier.APIKey,
+				HistorySize: cfg.Adapters.Slack.LLMClassifier.HistorySize,
+				HistoryTTL:  cfg.Adapters.Slack.LLMClassifier.HistoryTTL,
+			}
+		}
+
+		slackCommsHandler := comms.BuildHandler(comms.HandlerDeps{
+			Messenger:       slackMessenger,
+			Runner:          p.slackRunner,
+			Projects:        config.NewSlackProjectSource(cfg),
+			ProjectPath:     projectPath,
+			Classifier:      slackClassifierCfg,
+			MemberResolver:  slackMemberResolver,
+			Store:           p.store,
+			TaskIDPrefix:    "SLACK",
+			ExecutorBackend: cfg.Executor,
 		})
 
 		p.slackHandler = slack.NewHandler(&slack.HandlerConfig{


### PR DESCRIPTION
## Summary

- Introduces `comms.BuildHandler` + `comms.ClassifierConfig` as the single assembly point for `comms.HandlerConfig` across all 5 adapter call sites (Telegram main, Slack main, Discord, Telegram gateway, Slack gateway).
- Adds `LLMClassifier *LLMClassifierConfig` to `slack.Config` so Slack is now configurable for LLM-based intent classification — fixing the root-cause of `@Pilot check the pilot queue` being misclassified as a code task.
- Removes the dead `LLMClassifierConfig` stub from `slack/handler.go`.
- Wires Discord's `RateLimit` (via unit conversion) and `Store` (now in `PollerDeps`) that were previously omitted.
- Wires LLM classifiers into both gateway-mode handlers (Telegram + Slack) that previously always had `nil` classifiers.
- Documents `llm_classifier` under `slack:` and `discord:` in `configs/pilot.example.yaml`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `internal/comms/factory_test.go`: `BuildClassifier` (nil/disabled/no-key/enabled/defaults), `BuildHandler` (all-fields/disabled/nil/adapter-parity/classifier-routing)
- [ ] Manual: enable `adapters.slack.llm_classifier.enabled: true`, restart daemon, send `@Pilot check the pilot queue` in Slack → must NOT become a code task

Closes #3645