### PR TITLE
GH-3650: feat(comms): route operational queries to inline store-backed handler

### DIFF
--- a/internal/comms/commands.go
+++ b/internal/comms/commands.go
@@ -225,11 +225,14 @@ func (c *CommandHandler) handleStatus(ctx context.Context, contextID string) {
 		}
 	}
 
-	// Queue info from memory store
+	// Queue/running info from memory store
 	if c.store != nil {
+		running, _ := c.store.GetActiveExecutions()
 		queued, err := c.store.GetQueuedTasks(10)
-		if err == nil && len(queued) > 0 {
-			sb.WriteString(fmt.Sprintf("\n📋 Queue: %d task(s)\n", len(queued)))
+		if err == nil && (len(running) > 0 || len(queued) > 0) {
+			sb.WriteString("\n")
+			sb.WriteString(formatQueueSummary(running, queued))
+			sb.WriteString("\n")
 		}
 	}
 
@@ -251,6 +254,38 @@ func (c *CommandHandler) handleCancel(ctx context.Context, contextID string) {
 	_ = c.messenger.SendText(ctx, contextID, "No task to cancel.")
 }
 
+// formatQueueSummary returns a human-readable summary of running and queued executions.
+// Called from /queue, /status, and the operational intent handler.
+func formatQueueSummary(running, queued []*memory.Execution) string {
+	if len(running) == 0 && len(queued) == 0 {
+		return "📋 Queue is empty"
+	}
+
+	var sb strings.Builder
+
+	if len(running) > 0 {
+		sb.WriteString(fmt.Sprintf("🔄 Running (%d)\n", len(running)))
+		for _, exec := range running {
+			elapsed := time.Since(exec.CreatedAt).Round(time.Second)
+			sb.WriteString(fmt.Sprintf("• %s (%s)\n", exec.TaskID, elapsed))
+		}
+		if len(queued) > 0 {
+			sb.WriteString("\n")
+		}
+	}
+
+	if len(queued) > 0 {
+		sb.WriteString(fmt.Sprintf("📋 Queued (%d)\n\n", len(queued)))
+		for i, exec := range queued {
+			age := time.Since(exec.CreatedAt).Round(time.Minute)
+			sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, exec.TaskID))
+			sb.WriteString(fmt.Sprintf("   📁 %s • ⏱ %s ago\n\n", filepath.Base(exec.ProjectPath), age))
+		}
+	}
+
+	return strings.TrimRight(sb.String(), "\n")
+}
+
 // handleQueue shows queued tasks.
 func (c *CommandHandler) handleQueue(ctx context.Context, contextID string) {
 	if c.store == nil {
@@ -258,27 +293,14 @@ func (c *CommandHandler) handleQueue(ctx context.Context, contextID string) {
 		return
 	}
 
+	running, _ := c.store.GetActiveExecutions()
 	queued, err := c.store.GetQueuedTasks(10)
 	if err != nil {
 		_ = c.messenger.SendText(ctx, contextID, "❌ Failed to fetch queue")
 		return
 	}
 
-	if len(queued) == 0 {
-		_ = c.messenger.SendText(ctx, contextID, "📋 Queue is empty")
-		return
-	}
-
-	var sb strings.Builder
-	sb.WriteString("📋 Task Queue\n\n")
-
-	for i, task := range queued {
-		age := time.Since(task.CreatedAt).Round(time.Minute)
-		sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, task.TaskID))
-		sb.WriteString(fmt.Sprintf("   📁 %s • ⏱ %s ago\n\n", filepath.Base(task.ProjectPath), age))
-	}
-
-	_ = c.messenger.SendText(ctx, contextID, sb.String())
+	_ = c.messenger.SendText(ctx, contextID, formatQueueSummary(running, queued))
 }
 
 // handleProjects lists configured projects.

--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -173,6 +173,8 @@ func (h *Handler) HandleMessage(ctx context.Context, msg *IncomingMessage) {
 	switch detected {
 	case intent.IntentGreeting:
 		h.handleGreeting(ctx, contextID)
+	case intent.IntentOperational:
+		h.handleOperational(ctx, contextID, msg.ThreadID, text)
 	case intent.IntentQuestion:
 		h.handleQuestion(ctx, contextID, msg.ThreadID, text)
 	case intent.IntentResearch:
@@ -195,6 +197,13 @@ func (h *Handler) detectIntent(ctx context.Context, contextID, text string) inte
 	// Fast path: commands
 	if strings.HasPrefix(text, "/") {
 		return intent.IntentCommand
+	}
+
+	// Fast path: operational queries about live daemon state (queue, running tasks).
+	// Must be checked before greeting/question fast-paths so that phrases like
+	// "what's in the queue?" route here instead of IntentQuestion.
+	if intent.IsOperationalQuery(text) {
+		return intent.IntentOperational
 	}
 
 	// Fast path: greeting-prefixed messages (e.g. "Hello! How is it going?")
@@ -241,7 +250,27 @@ func (h *Handler) handleGreeting(ctx context.Context, contextID string) {
 	_ = h.messenger.SendText(ctx, contextID, "👋 Hello! I'm Pilot — send me a task, question, or say /help.")
 }
 
+func (h *Handler) handleOperational(ctx context.Context, contextID, threadID, text string) {
+	if h.store == nil {
+		h.handleQuestion(ctx, contextID, threadID, text)
+		return
+	}
+
+	running, _ := h.store.GetActiveExecutions()
+	queued, err := h.store.GetQueuedTasks(10)
+	if err != nil {
+		_ = h.messenger.SendText(ctx, contextID, "❌ Failed to fetch queue status.")
+		return
+	}
+
+	_ = h.messenger.SendText(ctx, contextID, formatQueueSummary(running, queued))
+}
+
 func (h *Handler) handleQuestion(ctx context.Context, contextID, threadID, question string) {
+	if h.runner == nil {
+		_ = h.messenger.SendText(ctx, contextID, "❌ Executor not available.")
+		return
+	}
 	_ = h.messenger.SendText(ctx, contextID, "🔍 Looking into that...")
 
 	questionCtx, cancel := context.WithTimeout(ctx, 90*time.Second)

--- a/internal/comms/handler_test.go
+++ b/internal/comms/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"unicode"
 
 	"github.com/qf-studio/pilot/internal/intent"
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 // handlerMock records all Messenger calls for assertion in handler tests.
@@ -708,5 +709,146 @@ func TestASCIISmuggling_HandleMessage_StripsTextAndVoice(t *testing.T) {
 	}
 	if !strings.HasPrefix(msg.Text, "hello") {
 		t.Errorf("visible Text content corrupted: got %q", msg.Text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Operational intent: detectIntent ordering + handleOperational
+// ---------------------------------------------------------------------------
+
+// TestDetectIntent_OperationalOrdering verifies that operational queries are
+// detected before greeting and question fast-paths.
+func TestDetectIntent_OperationalOrdering(t *testing.T) {
+	tests := []struct {
+		text string
+		want intent.Intent
+	}{
+		// Operational queries — must beat IsClearQuestion (ends with ?)
+		{"what's in the queue?", intent.IntentOperational},
+		{"what is in the queue?", intent.IntentOperational},
+		{"anything running?", intent.IntentOperational},
+		{"is anything running?", intent.IntentOperational},
+		{"what's running?", intent.IntentOperational},
+		{"how many tasks?", intent.IntentOperational},
+		{"show the queue", intent.IntentOperational},
+		{"queue status", intent.IntentOperational},
+		// Non-operational question still routes to question
+		{"What does the auth handler do?", intent.IntentQuestion},
+		// Command still wins over operational
+		{"/help", intent.IntentCommand},
+		// Greeting still wins after operational (no match)
+		{"hello", intent.IntentGreeting},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.text, func(t *testing.T) {
+			m := &handlerMock{}
+			h := newTestHandler(m)
+			got := h.detectIntent(context.Background(), "ch1", tt.text)
+			if got != tt.want {
+				t.Errorf("detectIntent(%q) = %s, want %s", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+// mustNewStore creates an isolated SQLite store backed by a temp directory.
+// Unlike mustCreateMemoryStore (which uses ":memory:" mapping to a shared path),
+// this guarantees test isolation.
+func mustNewStore(t *testing.T) *memory.Store {
+	t.Helper()
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	return store
+}
+
+// TestHandleOperational_WithStore verifies that handleOperational sends inline
+// text from the store and never invokes the executor (runner is nil; a call
+// to runner.Execute would panic).
+func TestHandleOperational_WithStore(t *testing.T) {
+	store := mustNewStore(t)
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-1",
+		TaskID:      "TASK-42",
+		ProjectPath: "/projects/pilot",
+		Status:      "queued",
+		CreatedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("seed execution: %v", err)
+	}
+
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		Store:        store,
+		TaskIDPrefix: "TEST",
+		// No runner: if handleOperational called runner.Execute it would panic.
+	})
+
+	h.handleOperational(context.Background(), "ch1", "", "what's in the queue?")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected text reply from handleOperational")
+	}
+	// Must contain the task ID from the store — confirms it's reading live state.
+	if !strings.Contains(texts[0].text, "TASK-42") {
+		t.Errorf("expected TASK-42 in reply, got: %s", texts[0].text)
+	}
+	// Must be a direct text reply, not a chunked/result/confirm message.
+	if len(m.results) > 0 || len(m.confirms) > 0 {
+		t.Error("handleOperational must not use result/confirm channels")
+	}
+}
+
+// TestHandleOperational_EmptyQueue verifies the "queue is empty" reply.
+func TestHandleOperational_EmptyQueue(t *testing.T) {
+	store := mustNewStore(t)
+
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		Store:        store,
+		TaskIDPrefix: "TEST",
+	})
+
+	h.handleOperational(context.Background(), "ch1", "", "what's in the queue?")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected text reply")
+	}
+	if !strings.Contains(texts[0].text, "Queue is empty") {
+		t.Errorf("expected 'Queue is empty', got: %s", texts[0].text)
+	}
+}
+
+// TestHandleOperational_NilStore verifies that a nil store falls back to
+// handleQuestion (no queue output; executor-not-available guard fires instead).
+func TestHandleOperational_NilStore(t *testing.T) {
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		TaskIDPrefix: "TEST",
+		// No store, no runner.
+	})
+
+	h.handleOperational(context.Background(), "ch1", "", "what's in the queue?")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected a response message")
+	}
+	// Must not produce queue-specific output (that would mean the operational path ran).
+	for _, st := range texts {
+		if strings.Contains(st.text, "Queue is empty") || strings.Contains(st.text, "Queued") {
+			t.Errorf("nil-store path must not produce queue output: %s", st.text)
+		}
+	}
+	// Should have fallen through to handleQuestion, which guards nil runner.
+	if texts[0].text != "❌ Executor not available." {
+		t.Errorf("expected executor-not-available fallback, got: %s", texts[0].text)
 	}
 }

--- a/internal/intent/classifier.go
+++ b/internal/intent/classifier.go
@@ -63,6 +63,7 @@ func (c *AnthropicClient) Classify(ctx context.Context, messages []ConversationM
 
 - command: Message starts with /
 - greeting: Simple greeting like "hi", "hello", "hey"
+- operational: Questions about live daemon state (e.g., "what's in the queue?", "anything running?", "how many tasks?")
 - research: Requests for analysis/research (e.g., "research how X works", "analyze the auth flow")
 - planning: Requests for implementation plans (e.g., "plan how to add X", "design a solution for Y")
 - question: Questions about code/project (e.g., "what files handle auth?", "how does X work?")
@@ -160,6 +161,8 @@ Respond with JSON only: {"intent": "...", "confidence": 0.0-1.0}`
 		return IntentCommand, nil
 	case "greeting":
 		return IntentGreeting, nil
+	case "operational":
+		return IntentOperational, nil
 	case "research":
 		return IntentResearch, nil
 	case "planning":

--- a/internal/intent/intent.go
+++ b/internal/intent/intent.go
@@ -9,14 +9,41 @@ import (
 type Intent string
 
 const (
-	IntentCommand  Intent = "command"
-	IntentGreeting Intent = "greeting"
-	IntentResearch Intent = "research"
-	IntentPlanning Intent = "planning"
-	IntentQuestion Intent = "question"
-	IntentChat     Intent = "chat"
-	IntentTask     Intent = "task"
+	IntentCommand     Intent = "command"
+	IntentGreeting    Intent = "greeting"
+	IntentOperational Intent = "operational"
+	IntentResearch    Intent = "research"
+	IntentPlanning    Intent = "planning"
+	IntentQuestion    Intent = "question"
+	IntentChat        Intent = "chat"
+	IntentTask        Intent = "task"
 )
+
+// operationalPatterns match questions about live daemon state (queue, running tasks).
+var operationalPatterns = []string{
+	`what(?:'?s| is)(?: in)? (?:the )?queue`,
+	`anything (?:running|in (?:the )?queue)`,
+	`is anything running`,
+	`how many (?:tasks?|jobs?)`,
+	`queue status`,
+	`show (?:me )?(?:the )?queue`,
+	`what(?:'?s| is) running`,
+	`what tasks? (?:are )?(?:running|queued|pending|waiting)`,
+	`active (?:tasks?|executions?)`,
+}
+
+// IsOperationalQuery returns true when the message is asking about live daemon state:
+// queue depth, running tasks, or task counts. These are answered from the memory store
+// without invoking the executor.
+func IsOperationalQuery(msg string) bool {
+	lower := strings.ToLower(strings.TrimSpace(msg))
+	for _, pattern := range operationalPatterns {
+		if matched, _ := regexp.MatchString(pattern, lower); matched {
+			return true
+		}
+	}
+	return false
+}
 
 // Common greeting patterns
 var greetingPatterns = []string{
@@ -84,7 +111,13 @@ func DetectIntent(message string) Intent {
 		return IntentGreeting
 	}
 
-	// 3. Check for research requests (research patterns with topic/URL)
+	// 3. Check for operational queries (queue/running status) before question patterns
+	// so "what's in the queue?" routes to operational, not question.
+	if IsOperationalQuery(msg) {
+		return IntentOperational
+	}
+
+	// 4. Check for research requests (research patterns with topic/URL)
 	if IsResearch(msg) {
 		return IntentResearch
 	}
@@ -348,6 +381,8 @@ func (i Intent) Description() string {
 		return "Command"
 	case IntentGreeting:
 		return "Greeting"
+	case IntentOperational:
+		return "Operational"
 	case IntentResearch:
 		return "Research"
 	case IntentPlanning:


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3650.

Closes #3650

## Changes

In internal/comms/handler.go, add the operational check at the top of detectIntent ahead of the greeting/question fast-path; add case intent.IntentOperational to the dispatch switch; implement handleOperational to query h.store.GetActiveExecutions() + h.store.GetQueuedTasks(N), format via shared helper, and reply via SendText() with no executor.Task or runner call. Guard h.store == nil to fall back to handleQuestion. In internal/comms/commands.go, extract formatQueueSummary(running, queued []*memory.Execution) string from existing /queue and /status handlers and call it from all three sites. Add table-driven tests in handler_test.go: detectIntent ordering, handleOperational with fake store asserting inline text and runner never invoked, empty queue → queue is empty message, nil store → falls back to handleQuestion. Verify make lint and make test green.