### PR TITLE
feat(comms): route operational queries to inline store-backed handler (GH-3650)

### DIFF
--- a/internal/comms/commands.go
+++ b/internal/comms/commands.go
@@ -182,6 +182,38 @@ Note: Ephemeral commands (serve, run, etc.) auto-skip PR creation.`
 	_ = c.messenger.SendText(ctx, contextID, helpText)
 }
 
+// formatQueueSummary formats active and queued executions into a concise status string.
+// Returns "📋 Queue is empty" when both slices are empty or nil.
+// Called by handleQueue, handleStatus, and the operational intent handler.
+func formatQueueSummary(running, queued []*memory.Execution) string {
+	if len(running) == 0 && len(queued) == 0 {
+		return "📋 Queue is empty"
+	}
+
+	var sb strings.Builder
+
+	if len(running) > 0 {
+		sb.WriteString(fmt.Sprintf("🔄 Running: %d\n", len(running)))
+		for _, exec := range running {
+			age := time.Since(exec.CreatedAt).Round(time.Second)
+			sb.WriteString(fmt.Sprintf("• %s (%s)\n", exec.TaskID, age))
+		}
+	}
+
+	if len(queued) > 0 {
+		if len(running) > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(fmt.Sprintf("📋 Queued: %d\n", len(queued)))
+		for i, exec := range queued {
+			age := time.Since(exec.CreatedAt).Round(time.Minute)
+			sb.WriteString(fmt.Sprintf("%d. %s — %s (%s ago)\n", i+1, exec.TaskID, filepath.Base(exec.ProjectPath), age))
+		}
+	}
+
+	return strings.TrimRight(sb.String(), "\n")
+}
+
 // handleStatus shows current status with running/pending/queue info.
 func (c *CommandHandler) handleStatus(ctx context.Context, contextID string) {
 	var sb strings.Builder
@@ -228,8 +260,10 @@ func (c *CommandHandler) handleStatus(ctx context.Context, contextID string) {
 	// Queue info from memory store
 	if c.store != nil {
 		queued, err := c.store.GetQueuedTasks(10)
-		if err == nil && len(queued) > 0 {
-			sb.WriteString(fmt.Sprintf("\n📋 Queue: %d task(s)\n", len(queued)))
+		if err == nil {
+			sb.WriteString("\n")
+			sb.WriteString(formatQueueSummary(nil, queued))
+			sb.WriteString("\n")
 		}
 	}
 
@@ -264,21 +298,7 @@ func (c *CommandHandler) handleQueue(ctx context.Context, contextID string) {
 		return
 	}
 
-	if len(queued) == 0 {
-		_ = c.messenger.SendText(ctx, contextID, "📋 Queue is empty")
-		return
-	}
-
-	var sb strings.Builder
-	sb.WriteString("📋 Task Queue\n\n")
-
-	for i, task := range queued {
-		age := time.Since(task.CreatedAt).Round(time.Minute)
-		sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, task.TaskID))
-		sb.WriteString(fmt.Sprintf("   📁 %s • ⏱ %s ago\n\n", filepath.Base(task.ProjectPath), age))
-	}
-
-	_ = c.messenger.SendText(ctx, contextID, sb.String())
+	_ = c.messenger.SendText(ctx, contextID, formatQueueSummary(nil, queued))
 }
 
 // handleProjects lists configured projects.

--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -173,6 +173,8 @@ func (h *Handler) HandleMessage(ctx context.Context, msg *IncomingMessage) {
 	switch detected {
 	case intent.IntentGreeting:
 		h.handleGreeting(ctx, contextID)
+	case intent.IntentOperational:
+		h.handleOperational(ctx, contextID, msg.ThreadID, text)
 	case intent.IntentQuestion:
 		h.handleQuestion(ctx, contextID, msg.ThreadID, text)
 	case intent.IntentResearch:
@@ -195,6 +197,13 @@ func (h *Handler) detectIntent(ctx context.Context, contextID, text string) inte
 	// Fast path: commands
 	if strings.HasPrefix(text, "/") {
 		return intent.IntentCommand
+	}
+
+	// Fast path: operational queries (live daemon/queue state) — must precede
+	// the greeting and IsClearQuestion checks because phrases like
+	// "what's in the queue?" match IsClearQuestion's "what's in" prefix.
+	if intent.IsOperationalQuery(text) {
+		return intent.IntentOperational
 	}
 
 	// Fast path: greeting-prefixed messages (e.g. "Hello! How is it going?")
@@ -241,8 +250,34 @@ func (h *Handler) handleGreeting(ctx context.Context, contextID string) {
 	_ = h.messenger.SendText(ctx, contextID, "👋 Hello! I'm Pilot — send me a task, question, or say /help.")
 }
 
+func (h *Handler) handleOperational(ctx context.Context, contextID, threadID, text string) {
+	if h.store == nil {
+		h.handleQuestion(ctx, contextID, threadID, text)
+		return
+	}
+
+	running, err := h.store.GetActiveExecutions()
+	if err != nil {
+		_ = h.messenger.SendText(ctx, contextID, "❌ Failed to fetch queue status")
+		return
+	}
+
+	queued, err := h.store.GetQueuedTasks(10)
+	if err != nil {
+		_ = h.messenger.SendText(ctx, contextID, "❌ Failed to fetch queue status")
+		return
+	}
+
+	_ = h.messenger.SendText(ctx, contextID, formatQueueSummary(running, queued))
+}
+
 func (h *Handler) handleQuestion(ctx context.Context, contextID, threadID, question string) {
 	_ = h.messenger.SendText(ctx, contextID, "🔍 Looking into that...")
+
+	if h.runner == nil {
+		_ = h.messenger.SendText(ctx, contextID, "I couldn't answer that question.")
+		return
+	}
 
 	questionCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()

--- a/internal/comms/handler_test.go
+++ b/internal/comms/handler_test.go
@@ -3,6 +3,7 @@ package comms
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"unicode"
 
 	"github.com/qf-studio/pilot/internal/intent"
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 // handlerMock records all Messenger calls for assertion in handler tests.
@@ -683,6 +685,150 @@ func hasAnyInvisible(s string) bool {
 		}
 	}
 	return false
+}
+
+// newTestStoreForHandler creates a real in-memory SQLite store for handler tests
+// and registers cleanup via t.Cleanup.
+func newTestStoreForHandler(t *testing.T) *memory.Store {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "comms-handler-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	store, err := memory.NewStore(dir)
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// ---------- operational intent tests ----------
+
+func TestDetectIntent_Operational_BeforeQuestion(t *testing.T) {
+	tests := []struct {
+		text string
+		want intent.Intent
+	}{
+		// These phrases match IsClearQuestion's "what's in" prefix WITHOUT the
+		// early operational check; verify they route to IntentOperational.
+		{"what's in the queue?", intent.IntentOperational},
+		{"what is in the queue?", intent.IntentOperational},
+		{"anything running?", intent.IntentOperational},
+		{"queue status", intent.IntentOperational},
+		// Sanity: non-operational queries still work.
+		{"hello", intent.IntentGreeting},
+		{"/help", intent.IntentCommand},
+	}
+
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	for _, tt := range tests {
+		t.Run(tt.text, func(t *testing.T) {
+			got := h.detectIntent(context.Background(), "ch1", tt.text)
+			if got != tt.want {
+				t.Errorf("detectIntent(%q) = %s, want %s", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleOperational_WithStore_InlineText_RunnerNeverInvoked(t *testing.T) {
+	store := newTestStoreForHandler(t)
+
+	// Seed one running and one queued execution.
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "r1",
+		TaskID:      "TASK-100",
+		ProjectPath: "/proj/alpha",
+		Status:      "running",
+		CreatedAt:   time.Now().Add(-2 * time.Minute),
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "q1",
+		TaskID:      "TASK-101",
+		ProjectPath: "/proj/alpha",
+		Status:      "queued",
+		CreatedAt:   time.Now().Add(-1 * time.Minute),
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	m := &handlerMock{}
+	// Runner intentionally omitted — any call to Runner.Execute would panic.
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		Store:        store,
+		TaskIDPrefix: "TEST",
+	})
+
+	h.handleOperational(context.Background(), "ch1", "", "what's in the queue?")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected a text response from handleOperational")
+	}
+
+	reply := texts[0].text
+	if strings.Contains(reply, "Looking into") {
+		t.Errorf("handleOperational invoked the question handler (runner path): %q", reply)
+	}
+	if !strings.Contains(reply, "TASK-100") {
+		t.Errorf("expected running task TASK-100 in reply, got: %q", reply)
+	}
+	if !strings.Contains(reply, "TASK-101") {
+		t.Errorf("expected queued task TASK-101 in reply, got: %q", reply)
+	}
+}
+
+func TestHandleOperational_EmptyQueue(t *testing.T) {
+	store := newTestStoreForHandler(t)
+
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		Store:        store,
+		TaskIDPrefix: "TEST",
+	})
+
+	h.handleOperational(context.Background(), "ch1", "", "anything running?")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected a text response")
+	}
+	if !strings.Contains(texts[0].text, "Queue is empty") {
+		t.Errorf("expected 'Queue is empty' message, got: %q", texts[0].text)
+	}
+}
+
+func TestHandleOperational_NilStore_FallsBackToQuestion(t *testing.T) {
+	m := &handlerMock{}
+	// No store, no runner — handler is intentionally minimal.
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		TaskIDPrefix: "TEST",
+	})
+
+	h.handleOperational(context.Background(), "ch1", "", "what's in the queue?")
+
+	texts := m.getTexts()
+	// handleQuestion sends "🔍 Looking into that..." as its first reply,
+	// confirming the operational handler delegated to it.
+	found := false
+	for _, st := range texts {
+		if strings.Contains(st.text, "Looking into") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'Looking into' message from handleQuestion fallback; got texts: %v", texts)
+	}
 }
 
 func TestASCIISmuggling_HandleMessage_StripsTextAndVoice(t *testing.T) {


### PR DESCRIPTION
## Summary

- `detectIntent` in `handler.go`: adds `IsOperationalQuery` fast-path **before** `IsClearQuestion`, so phrases like `"what's in the queue?"` correctly route to `IntentOperational` instead of `IntentQuestion`
- `HandleMessage` dispatch: new `case intent.IntentOperational` → `handleOperational`
- `handleOperational`: queries `store.GetActiveExecutions()` + `store.GetQueuedTasks(10)`, formats via shared `formatQueueSummary`, replies inline via `SendText` — no `executor.Task` or runner call; falls back to `handleQuestion` when `h.store == nil`
- `commands.go`: extracts `formatQueueSummary(running, queued []*memory.Execution) string`; refactors `handleQueue` and the queue section of `handleStatus` to call it (all three sites)
- `handler_test.go`: table-driven tests — detectIntent ordering (operational before question), `handleOperational` with real SQLite store (inline text, runner never invoked), empty queue → "Queue is empty", nil store → falls back to `handleQuestion`

## Test plan

- [ ] `go test ./internal/comms/... -v` — all tests green including 4 new `TestDetectIntent_Operational_*` / `TestHandleOperational_*` cases
- [ ] `go build ./...` — clean build
- [ ] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [ ] Closes GH-3650 (sub-issue of GH-3648)