### PR TITLE
fix(comms): route IntentCommand through CommandHandler; safe default dispatch (TASK-372)

### DIFF
--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -52,6 +52,7 @@ type Handler struct {
 	convStore      *intent.ConversationStore
 	memberResolver MemberResolver
 	store          *memory.Store
+	cmdHandler     *CommandHandler
 	taskIDPrefix   string
 	log            *slog.Logger
 
@@ -81,7 +82,7 @@ func NewHandler(cfg *HandlerConfig) *Handler {
 		lg = logging.WithComponent("comms.handler")
 	}
 
-	return &Handler{
+	h := &Handler{
 		messenger:      cfg.Messenger,
 		runner:         cfg.Runner,
 		projects:       cfg.Projects,
@@ -98,6 +99,45 @@ func NewHandler(cfg *HandlerConfig) *Handler {
 		runningTasks:   make(map[string]*RunningTask),
 		lastSender:     make(map[string]string),
 	}
+
+	// Wire command handler — must be built after h exists so callbacks can close over h.
+	cmd := NewCommandHandler(cfg.Messenger, cfg.Store)
+	cmd.SetStatusQueryFunc(func(contextID string) (pending, running interface{}) {
+		// Avoid wrapping typed nil pointers in interface{} — that produces a
+		// non-nil interface whose method calls panic (classic Go gotcha).
+		if p := h.GetPendingTask(contextID); p != nil {
+			pending = p
+		}
+		if r := h.GetRunningTask(contextID); r != nil {
+			running = r
+		}
+		return pending, running
+	})
+	cmd.SetActiveProjectFunc(func(contextID string) (name, path string) {
+		return h.GetActiveProject(contextID)
+	})
+	cmd.SetSetProjectFunc(func(contextID, projectName string) error {
+		return h.SetActiveProject(contextID, projectName)
+	})
+	cmd.SetCancelTaskFunc(func(ctx context.Context, contextID string) error {
+		return h.CancelTask(ctx, contextID)
+	})
+	cmd.SetStopTaskFunc(func(ctx context.Context, contextID string) error {
+		return h.CancelTask(ctx, contextID)
+	})
+	if cfg.Projects != nil {
+		cmd.SetProjectListFunc(func() []interface{} {
+			projs := cfg.Projects.ListProjects()
+			out := make([]interface{}, len(projs))
+			for i, p := range projs {
+				out[i] = p
+			}
+			return out
+		})
+	}
+	h.cmdHandler = cmd
+
+	return h
 }
 
 // HandleMessage is the main entry point for processing an incoming message.
@@ -173,6 +213,8 @@ func (h *Handler) HandleMessage(ctx context.Context, msg *IncomingMessage) {
 	switch detected {
 	case intent.IntentGreeting:
 		h.handleGreeting(ctx, contextID)
+	case intent.IntentCommand:
+		h.handleCommand(ctx, contextID, text)
 	case intent.IntentOperational:
 		h.handleOperational(ctx, contextID, msg.ThreadID, text)
 	case intent.IntentQuestion:
@@ -186,14 +228,16 @@ func (h *Handler) HandleMessage(ctx context.Context, msg *IncomingMessage) {
 	case intent.IntentTask:
 		h.handleTask(ctx, contextID, msg.ThreadID, text, msg.SenderID)
 	default:
-		// Fallback: treat as task
-		h.handleTask(ctx, contextID, msg.ThreadID, text, msg.SenderID)
+		// Unknown intent — clarify rather than auto-creating a task.
+		_ = h.messenger.SendText(ctx, contextID, "I didn't quite catch that — try /help, or rephrase your request.")
 	}
 }
 
 // ---------- intent detection ----------
 
 func (h *Handler) detectIntent(ctx context.Context, contextID, text string) intent.Intent {
+	text = strings.TrimSpace(text)
+
 	// Fast path: commands
 	if strings.HasPrefix(text, "/") {
 		return intent.IntentCommand
@@ -248,6 +292,14 @@ func (h *Handler) detectIntent(ctx context.Context, contextID, text string) inte
 
 func (h *Handler) handleGreeting(ctx context.Context, contextID string) {
 	_ = h.messenger.SendText(ctx, contextID, "👋 Hello! I'm Pilot — send me a task, question, or say /help.")
+}
+
+func (h *Handler) handleCommand(ctx context.Context, contextID, text string) {
+	if h.cmdHandler == nil {
+		_ = h.messenger.SendText(ctx, contextID, "I didn't quite catch that — try /help, or rephrase your request.")
+		return
+	}
+	h.cmdHandler.HandleCommand(ctx, contextID, text)
 }
 
 func (h *Handler) handleOperational(ctx context.Context, contextID, threadID, text string) {

--- a/internal/comms/handler_test.go
+++ b/internal/comms/handler_test.go
@@ -856,3 +856,224 @@ func TestASCIISmuggling_HandleMessage_StripsTextAndVoice(t *testing.T) {
 		t.Errorf("visible Text content corrupted: got %q", msg.Text)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// IntentCommand routing tests — verifies /help, /status, /queue reach the
+// shared CommandHandler and never create a PendingTask or invoke the runner.
+// ---------------------------------------------------------------------------
+
+func TestHandleMessage_Command_RoutesToCommandHandler(t *testing.T) {
+	tests := []struct {
+		name        string
+		text        string
+		wantInReply string // substring expected in messenger reply
+	}{
+		{"/help prints help", "/help", "Pilot Bot"},
+		{"/start alias for help", "/start", "Pilot Bot"},
+		{"/status shows status", "/status", "Status"},
+		{"/queue shows queue", "/queue", "Queue"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &handlerMock{}
+			h := newTestHandler(m)
+
+			h.HandleMessage(context.Background(), &IncomingMessage{
+				ContextID: "ch1",
+				SenderID:  "u1",
+				Text:      tt.text,
+			})
+
+			// Must NOT have created a pending task.
+			h.mu.Lock()
+			_, hasPending := h.pendingTasks["ch1"]
+			h.mu.Unlock()
+			if hasPending {
+				t.Errorf("%s: HandleMessage created a pending task — command was mis-routed to handleTask", tt.text)
+			}
+
+			// Must have produced at least one text reply.
+			texts := m.getTexts()
+			if len(texts) == 0 {
+				t.Fatalf("%s: expected a reply, got none", tt.text)
+			}
+
+			// Reply must contain the expected substring (not a task confirmation).
+			found := false
+			for _, st := range texts {
+				if strings.Contains(st.text, tt.wantInReply) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("%s: expected reply containing %q; got texts: %v", tt.text, tt.wantInReply, texts)
+			}
+		})
+	}
+}
+
+func TestHandleMessage_Command_WithLeadingSpace(t *testing.T) {
+	// Leading-space "/help" must still be detected as IntentCommand.
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "u1",
+		Text:      "  /help  ",
+	})
+
+	h.mu.Lock()
+	_, hasPending := h.pendingTasks["ch1"]
+	h.mu.Unlock()
+	if hasPending {
+		t.Error("leading-space /help created a pending task — TrimSpace not applied in detectIntent")
+	}
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected at least one reply")
+	}
+	if !strings.Contains(texts[0].text, "Pilot Bot") {
+		t.Errorf("expected help text, got: %s", texts[0].text)
+	}
+}
+
+func TestHandleMessage_UnknownIntent_SafeDefault_NoPendingTask(t *testing.T) {
+	// Free text that the regex and no LLM classifier cannot classify should
+	// produce a clarify reply — never a task confirmation.
+	m := &handlerMock{}
+	// No LLM classifier, no runner — any executor call would panic.
+	h := newTestHandler(m)
+
+	// Force an intent that hits default: by using LLM classifier that returns
+	// an unknown/unhandled intent string.
+	h.llmClassifier = &hMockClassifier{result: "unknown_intent_xyz"}
+
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "u1",
+		Text:      "do something weird",
+	})
+
+	h.mu.Lock()
+	_, hasPending := h.pendingTasks["ch1"]
+	h.mu.Unlock()
+	if hasPending {
+		t.Error("unknown intent produced a PendingTask — default is not safe")
+	}
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected a clarify reply")
+	}
+	found := false
+	for _, st := range texts {
+		if strings.Contains(st.text, "didn't quite catch") || strings.Contains(st.text, "/help") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected clarify message; got: %v", texts)
+	}
+}
+
+func TestHandleMessage_ExplicitTask_StillCreatesTask(t *testing.T) {
+	// Explicit task phrasing must still route to handleTask, creating a PendingTask.
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "u1",
+		Text:      "create a new login feature with OAuth support",
+	})
+
+	h.mu.Lock()
+	_, hasPending := h.pendingTasks["ch1"]
+	h.mu.Unlock()
+	if !hasPending {
+		t.Error("explicit task description did not create a PendingTask — task routing broken")
+	}
+
+	// Messenger should show a confirmation (SendConfirmation call), not a clarify.
+	m.mu.Lock()
+	confirms := len(m.confirms)
+	m.mu.Unlock()
+	if confirms == 0 {
+		t.Error("expected SendConfirmation for an explicit task, got none")
+	}
+}
+
+func TestHandleMessage_Command_NilCmdHandler_SafeFallback(t *testing.T) {
+	// When cmdHandler is nil (edge case: handler built without wiring),
+	// /help must produce a clarify reply, not a task confirmation.
+	m := &handlerMock{}
+	h := newTestHandler(m)
+	h.cmdHandler = nil // force the nil path
+
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "u1",
+		Text:      "/help",
+	})
+
+	h.mu.Lock()
+	_, hasPending := h.pendingTasks["ch1"]
+	h.mu.Unlock()
+	if hasPending {
+		t.Error("nil cmdHandler created a pending task from /help")
+	}
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected a reply when cmdHandler is nil")
+	}
+	found := false
+	for _, st := range texts {
+		if strings.Contains(st.text, "didn't quite catch") || strings.Contains(st.text, "/help") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected clarify message from nil-cmdHandler path; got: %v", texts)
+	}
+}
+
+func TestHandleMessage_UnknownCommand_RepliesUnknown(t *testing.T) {
+	// An unknown /foo command must reply "Unknown command" — not drop silently.
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "u1",
+		Text:      "/foo",
+	})
+
+	h.mu.Lock()
+	_, hasPending := h.pendingTasks["ch1"]
+	h.mu.Unlock()
+	if hasPending {
+		t.Error("/foo created a pending task — unknown command not handled")
+	}
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected a reply for unknown command")
+	}
+	found := false
+	for _, st := range texts {
+		if strings.Contains(st.text, "Unknown command") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'Unknown command' reply; got: %v", texts)
+	}
+}

--- a/internal/comms/project.go
+++ b/internal/comms/project.go
@@ -8,6 +8,15 @@ type ProjectInfo struct {
 	DefaultBranch string
 }
 
+// GetName satisfies duck-typed interface used by CommandHandler.handleProjects.
+func (p *ProjectInfo) GetName() string { return p.Name }
+
+// GetPath satisfies duck-typed interface used by CommandHandler.handleProjects.
+func (p *ProjectInfo) GetPath() string { return p.Path }
+
+// IsNavigator satisfies duck-typed interface used by CommandHandler.handleProjects.
+func (p *ProjectInfo) IsNavigator() bool { return p.Navigator }
+
 // ProjectSource provides project lookup methods (avoids import cycle with config).
 type ProjectSource interface {
 	GetProjectByName(name string) *ProjectInfo

--- a/internal/comms/types.go
+++ b/internal/comms/types.go
@@ -61,6 +61,12 @@ type PendingTask struct {
 	CreatedAt   time.Time
 }
 
+// GetTaskID satisfies duck-typed interface used by CommandHandler.handleStatus.
+func (p *PendingTask) GetTaskID() string { return p.TaskID }
+
+// GetCreatedAt satisfies duck-typed interface used by CommandHandler.handleStatus.
+func (p *PendingTask) GetCreatedAt() time.Time { return p.CreatedAt }
+
 // RunningTask represents a task currently being executed.
 type RunningTask struct {
 	TaskID    string
@@ -68,3 +74,9 @@ type RunningTask struct {
 	StartedAt time.Time
 	Cancel    context.CancelFunc
 }
+
+// GetTaskID satisfies duck-typed interface used by CommandHandler.handleStatus.
+func (r *RunningTask) GetTaskID() string { return r.TaskID }
+
+// GetStartedAt satisfies duck-typed interface used by CommandHandler.handleStatus.
+func (r *RunningTask) GetStartedAt() time.Time { return r.StartedAt }


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `IntentCommand` had no `case` in the dispatch switch, so `/help`, `/status`, `/queue` fell through to `default: handleTask(...)` — creating a task confirmation instead of printing help.
- **Part 1** — `Handler` now holds a `*CommandHandler` wired with callbacks from the existing state accessors (`GetPendingTask`, `GetRunningTask`, `GetActiveProject`, `CancelTask`, `SetActiveProject`, `ListProjects`). The dispatch switch gets `case intent.IntentCommand: h.handleCommand(...)`, routing all slash commands through the shared `CommandHandler` for Slack/Telegram/Discord parity.
- **Part 2** — `default:` changed from `handleTask` to a non-destructive clarify reply: _"I didn't quite catch that — try /help, or rephrase your request."_ No executor, no `PendingTask` created. Deliberate task phrasing still routes via `case intent.IntentTask`.
- `strings.TrimSpace` added at the top of `detectIntent` so leading-space `/help` (from Slack mention-strip) still hits the command fast-path.
- Nil-guard: `cmdHandler == nil` → clarify, never `handleTask`.
- Duck-typing methods added to `PendingTask`, `RunningTask`, `ProjectInfo` so `CommandHandler.handleStatus` and `handleProjects` render correctly.
- No per-adapter command fork in `slack/handler.go` — the fix lives entirely in `internal/comms`.

## Test plan

- [x] `TestHandleMessage_Command_RoutesToCommandHandler` — `/help`, `/start`, `/status`, `/queue` produce correct replies and no `PendingTask`
- [x] `TestHandleMessage_Command_WithLeadingSpace` — `"  /help  "` still routes to `CommandHandler`
- [x] `TestHandleMessage_UnknownIntent_SafeDefault_NoPendingTask` — unclassified text → clarify, no task
- [x] `TestHandleMessage_ExplicitTask_StillCreatesTask` — explicit task phrasing still creates `PendingTask`
- [x] `TestHandleMessage_Command_NilCmdHandler_SafeFallback` — nil `cmdHandler` → clarify, no task
- [x] `TestHandleMessage_UnknownCommand_RepliesUnknown` — `/foo` replies "Unknown command", not silent drop
- [x] All existing tests pass (`make test` green)
- [x] `make lint` green (golangci-lint --new-from-rev=origin/main)

Closes #3657