### PR TITLE
fix(slack): route SDK command events to CommandHandler (/help no longer creates a task)

### DIFF
--- a/internal/adapters/sdkshim/chat.go
+++ b/internal/adapters/sdkshim/chat.go
@@ -1,6 +1,8 @@
 package sdkshim
 
 import (
+	"strings"
+
 	"github.com/qf-studio/pilot/internal/comms"
 	"github.com/qf-studio/studio-sdk/sdk/core"
 )
@@ -35,9 +37,10 @@ func PassThroughSenderID(id string) string { return id }
 //   - core.MessageEvent.Text is pre-sanitized by the SDK adapter (live path).
 //   - Action ∈ {"message","command","callback"}: callback maps IsCallback=true
 //     plus CallbackID + ActionID (from Button.ActionID; the SDK exposes the
-//     callback ID via the dedicated CallbackID field). "command" is left as a
-//     plain message for Phase 0; Phase 6/7/8 will route Command/Args through
-//     comms.CommandHandler instead of the local Telegram parser.
+//     callback ID via the dedicated CallbackID field). "command" reconstructs
+//     the command line (Command + Args) into Text so comms.detectIntent routes
+//     it via IntentCommand → CommandHandler — the SDK bridge delivers commands
+//     with Command/Args set and Text empty, which would otherwise create a task.
 //   - Pilot-specific fields (ImagePath, VoiceText) are NOT in core.MessageEvent.
 //     The Telegram adapter retains photo + voice handling outside this shim
 //     and is responsible for filling those fields on its own host-side path.
@@ -62,7 +65,8 @@ func MessageEventToIncomingMessage(ev *core.MessageEvent, platform string, conv 
 		Platform:   platform,
 		RawEvent:   ev,
 	}
-	if ev.Action == "callback" {
+	switch ev.Action {
+	case "callback":
 		msg.IsCallback = true
 		msg.CallbackID = ev.CallbackID
 		// ActionID is conventionally encoded in ev.Data (e.g. "approve:TASK123").
@@ -70,6 +74,15 @@ func MessageEventToIncomingMessage(ev *core.MessageEvent, platform string, conv 
 		// before this shim — at the SDK boundary we just forward the raw payload
 		// and let comms route it.
 		msg.ActionID = ev.Data
+	case "command":
+		// The SDK chat bridge routes "/"-prefixed input as a structured command
+		// event (Command + Args set, Text empty). Reconstruct the command line so
+		// comms.detectIntent sees the "/" prefix and routes to IntentCommand →
+		// CommandHandler. Without this, the empty Text falls through comms' dispatch
+		// and an unintended task is created (the live "/help creates a task" bug).
+		if ev.Text == "" && ev.Command != "" {
+			msg.Text = strings.TrimSpace(ev.Command + " " + strings.Join(ev.Args, " "))
+		}
 	}
 	return msg
 }

--- a/internal/adapters/sdkshim/chat_test.go
+++ b/internal/adapters/sdkshim/chat_test.go
@@ -67,6 +67,44 @@ func TestMessageEventToIncomingMessage_Callback(t *testing.T) {
 	}
 }
 
+func TestMessageEventToIncomingMessage_Command(t *testing.T) {
+	// The SDK bridge delivers "/"-prefixed input as a command event with
+	// Command/Args set and Text empty. The shim must reconstruct the command
+	// line into Text so comms.detectIntent routes it via IntentCommand →
+	// CommandHandler rather than creating a task from empty text.
+	tests := []struct {
+		name    string
+		command string
+		args    []string
+		want    string
+	}{
+		{name: "help no args", command: "/help", args: nil, want: "/help"},
+		{name: "run with arg", command: "/run", args: []string{"42"}, want: "/run 42"},
+		{name: "multi arg", command: "/project", args: []string{"set", "pilot"}, want: "/project set pilot"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := &core.MessageEvent{
+				Action:    "command",
+				ChannelID: "C123",
+				Command:   tt.command,
+				Args:      tt.args,
+				Sender:    core.Identity{UserID: "U1"},
+			}
+			msg := MessageEventToIncomingMessage(ev, PlatformSlack, nil)
+			if msg == nil {
+				t.Fatal("expected non-nil message")
+			}
+			if msg.IsCallback {
+				t.Error("IsCallback should be false for command action")
+			}
+			if msg.Text != tt.want {
+				t.Errorf("Text = %q, want %q", msg.Text, tt.want)
+			}
+		})
+	}
+}
+
 func TestMessageEventToIncomingMessage_CustomConverter(t *testing.T) {
 	ev := &core.MessageEvent{
 		Sender: core.Identity{UserID: "raw-id"},

--- a/internal/adapters/slack/handler.go
+++ b/internal/adapters/slack/handler.go
@@ -42,7 +42,7 @@ func (a *MemberResolverAdapter) ResolveIdentity(senderID string) (string, error)
 // Delegates intent detection and task lifecycle to the shared comms.Handler (GH-2143).
 type Handler struct {
 	socketClient    *SocketModeClient
-	apiClient       *Client          // Kept for client access; Messenger wraps this
+	apiClient       *Client           // Kept for client access; Messenger wraps this
 	commsHandler    commsHandlerIface // Shared message handler for intent dispatch + task execution
 	allowedChannels map[string]bool   // Allowed channel IDs for security
 	allowedUsers    map[string]bool   // Allowed user IDs for security
@@ -225,12 +225,22 @@ func (h *Handler) HandleMessage(ctx context.Context, ev core.MessageEvent) error
 		Platform:   "slack",
 		RawEvent:   &ev,
 	}
-	if ev.Action == "callback" {
+	switch ev.Action {
+	case "callback":
 		msg.IsCallback = true
 		msg.CallbackID = ev.CallbackID
 		// ev.Data carries the button Data payload; bridgeMessenger.SendConfirmation
 		// sets Data=="execute"/"cancel" so comms.Handler can route directly.
 		msg.ActionID = ev.Data
+	case "command":
+		// The SDK bridge detects "/"-prefixed input upstream and delivers it as a
+		// command event with Command/Args set and Text empty. Reconstruct the
+		// command line into Text so comms.detectIntent routes it via IntentCommand
+		// → CommandHandler. Without this, the empty Text creates an unintended
+		// task (the live "@Pilot /help creates a task" bug).
+		if ev.Text == "" && ev.Command != "" {
+			msg.Text = strings.TrimSpace(ev.Command + " " + strings.Join(ev.Args, " "))
+		}
 	}
 	if h.commsHandler != nil {
 		h.commsHandler.HandleMessage(ctx, msg)

--- a/internal/adapters/slack/handler_test.go
+++ b/internal/adapters/slack/handler_test.go
@@ -224,7 +224,8 @@ func TestHandler_HandleMessage_CommandAction(t *testing.T) {
 	ev := core.MessageEvent{
 		Action:    "command",
 		ChannelID: "C123",
-		Command:   "/status",
+		Command:   "/run",
+		Args:      []string{"42"},
 		Sender:    core.Identity{UserID: "U789"},
 	}
 
@@ -240,6 +241,43 @@ func TestHandler_HandleMessage_CommandAction(t *testing.T) {
 	}
 	if got.IsCallback {
 		t.Error("IsCallback should be false for command action")
+	}
+	// The SDK bridge delivers commands with Text empty and Command/Args set.
+	// HandleMessage must reconstruct the command line so comms routes it via
+	// IntentCommand → CommandHandler instead of creating a task from empty text.
+	if got.Text != "/run 42" {
+		t.Errorf("Text = %q, want %q (command line must be reconstructed)", got.Text, "/run 42")
+	}
+}
+
+// TestHandler_HandleMessage_CommandHelpReconstructed is the regression test for
+// the live "@Pilot /help creates a task" bug. The SDK bridge intercepts the
+// "/" prefix upstream and delivers /help as a command event with empty Text;
+// HandleMessage must put "/help" into Text so comms.detectIntent returns
+// IntentCommand (→ CommandHandler) rather than defaulting an empty message to a task.
+func TestHandler_HandleMessage_CommandHelpReconstructed(t *testing.T) {
+	mock := &mockCommsHandler{}
+	h := NewHandler(&HandlerConfig{
+		AppToken: "xapp-test-token",
+		BotToken: "xoxb-test-token",
+	})
+	h.commsHandler = mock
+
+	ev := core.MessageEvent{
+		Action:    "command",
+		ChannelID: "C123",
+		Command:   "/help",
+		Sender:    core.Identity{UserID: "U789"},
+	}
+
+	if err := h.HandleMessage(context.Background(), ev); err != nil {
+		t.Fatalf("HandleMessage() error = %v", err)
+	}
+	if len(mock.got) != 1 {
+		t.Fatalf("HandleMessage() delivered %d messages, want 1", len(mock.got))
+	}
+	if got := mock.got[0].Text; got != "/help" {
+		t.Errorf("Text = %q, want %q (command must reach comms as /help, not empty)", got, "/help")
 	}
 }
 

--- a/internal/comms/handler_test.go
+++ b/internal/comms/handler_test.go
@@ -298,6 +298,35 @@ func TestDetectIntent_Command(t *testing.T) {
 	}
 }
 
+// TestHandleMessage_SlashCommandRoutesToHelp is the end-to-end dispatch guard for
+// the "/help creates a task" bug. detectIntent → IntentCommand and CommandHandler
+// are each tested in isolation; this connects them through HandleMessage's dispatch
+// switch with a real (NewHandler-wired) cmdHandler: "/help" must produce help text
+// and must NOT create a task confirmation.
+func TestHandleMessage_SlashCommandRoutesToHelp(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "u1",
+		Text:      "/help",
+	})
+
+	if len(m.confirms) != 0 {
+		t.Fatalf("/help created %d task confirmation(s); want 0 — command must not become a task", len(m.confirms))
+	}
+	var sawHelp bool
+	for _, st := range m.getTexts() {
+		if st.contextID == "ch1" && strings.Contains(st.text, "🤖 Pilot Bot") {
+			sawHelp = true
+		}
+	}
+	if !sawHelp {
+		t.Error("/help did not produce help text via CommandHandler")
+	}
+}
+
 func TestDetectIntent_ClearQuestion(t *testing.T) {
 	m := &handlerMock{}
 	h := newTestHandler(m)


### PR DESCRIPTION
## Problem

`@Pilot /help` on Slack **still creates a task** despite TASK-372 (PR #3659, merged v2.194.1). Live-verified broken 2026-06-25 after rebuild + daemon restart on the fix binary (`vcs.revision=9feac99a`, `vcs.modified=false`).

## Real root cause (TASK-372 fixed the wrong layer)

The live Slack path is the **studio-sdk chat bridge** (`main.go:2596` → `sdkSlack.NewChatBridge` → `slack.Handler.HandleMessage(core.MessageEvent)`), not the native `processEvent`. The SDK bridge (`bridge.go:132`) detects the `/` prefix **upstream** and emits:

```go
core.MessageEvent{Action: "command", Command: "/help", Args: [...], Text: ""}  // Text is EMPTY
```

Both mapping sites handled only `Action=="callback"` and copied the empty `ev.Text`:
- `internal/adapters/slack/handler.go:218` (live path)
- `internal/adapters/sdkshim/chat.go:49` (shared shim — Discord + future adapters)

So `/help` reached comms as **empty text** → fell through intent dispatch → task. TASK-372's `IntentCommand` fast-path in `comms.detectIntent` never fired because the command text never arrived there as `/help`.

## Fix

Add an `Action=="command"` case at both mapping sites that reconstructs the command line into `Text`:
```go
msg.Text = strings.TrimSpace(ev.Command + " " + strings.Join(ev.Args, " "))
```
`comms.detectIntent` then sees `/help` → `IntentCommand` → `CommandHandler.HandleCommand` (wired by TASK-372). The two fixes are complementary: TASK-372 made comms route commands; this makes commands actually reach comms.

## Tests (the gap that let TASK-372 merge green)

TASK-372 tested `detectIntent("/help")` and `CommandHandler` **in isolation**, never the adapter→comms seam. Added boundary + end-to-end coverage:
- `slack`: `HandleMessage` command events reconstruct `Text` (`/run 42`, `/help`). Strengthened the pre-existing `CommandAction` test that only asserted `Platform`/`IsCallback` and never checked `Text`.
- `sdkshim`: table test for command reconstruction (help/args/multi-arg).
- `comms`: end-to-end `HandleMessage("/help")` → help text, **no** task confirmation.

## Verification

`go build ./...`, `go vet`, `gofmt`, and all `comms`/`slack`/`sdkshim` tests green. Live Slack re-verification pending rebuild + daemon restart on this branch.