### PR TITLE
chore(docs): gitignore Next.js-generated next-env.d.ts

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -6,6 +6,9 @@ out/
 .env.local
 public/_pagefind/
 
+# Next.js generated type declarations (regenerated on every build)
+next-env.d.ts
+
 # misc
 .DS_Store
 *.pem


### PR DESCRIPTION
Stops `docs/next-env.d.ts` (regenerated on every Next.js build) from showing as untracked `git status` noise. Docs-only, one line.