### PR TITLE
feat(llm): internal/llm package — Client + Answer primitive (GH-3666)

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -1,0 +1,102 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/intent"
+)
+
+const defaultAPIURL = "https://api.anthropic.com/v1/messages"
+
+// Client sends requests to the Anthropic Messages API.
+type Client struct {
+	apiKey     string
+	httpClient *http.Client
+	apiURL     string
+}
+
+// NewClient creates a Client with the given API key.
+func NewClient(apiKey string) *Client {
+	return &Client{
+		apiKey: apiKey,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		apiURL: defaultAPIURL,
+	}
+}
+
+// Answer calls the Anthropic API with the provided model, system prompt,
+// conversation history, and user message, then returns the concatenated text
+// of all content blocks in the response.
+func (c *Client) Answer(ctx context.Context, model, system string, history []intent.ConversationMessage, user string) (string, error) {
+	// Build messages array from history + new user message.
+	messages := make([]map[string]string, 0, len(history)+1)
+	for _, msg := range history {
+		messages = append(messages, map[string]string{
+			"role":    msg.Role,
+			"content": msg.Content,
+		})
+	}
+	messages = append(messages, map[string]string{
+		"role":    "user",
+		"content": user,
+	})
+
+	body := map[string]interface{}{
+		"model":    model,
+		"system":   system,
+		"messages": messages,
+		"output_config": map[string]interface{}{
+			"effort": "low",
+		},
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("llm: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.apiURL, bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", fmt.Errorf("llm: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("llm: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("llm: API returned status %d", resp.StatusCode)
+	}
+
+	var apiResp struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return "", fmt.Errorf("llm: decode response: %w", err)
+	}
+
+	if len(apiResp.Content) == 0 {
+		return "", fmt.Errorf("llm: empty response from API")
+	}
+
+	var sb strings.Builder
+	for _, block := range apiResp.Content {
+		sb.WriteString(block.Text)
+	}
+	return sb.String(), nil
+}

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -1,0 +1,176 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/intent"
+)
+
+func makeServer(t *testing.T, statusCode int, body interface{}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify required headers are present.
+		if r.Header.Get("x-api-key") == "" {
+			http.Error(w, "missing x-api-key", http.StatusUnauthorized)
+			return
+		}
+		if r.Header.Get("anthropic-version") == "" {
+			http.Error(w, "missing anthropic-version", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write(mustJSON(t, body))
+	}))
+}
+
+func mustJSON(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("mustJSON: %v", err)
+	}
+	return b
+}
+
+func newTestClient(url string) *Client {
+	c := NewClient("test-api-key")
+	c.apiURL = url
+	return c
+}
+
+func TestAnswer_SingleBlock(t *testing.T) {
+	srv := makeServer(t, http.StatusOK, map[string]interface{}{
+		"content": []map[string]string{{"text": "hello world"}},
+	})
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	got, err := c.Answer(context.Background(), "claude-haiku-4-5-20251001", "sys", nil, "hi")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hello world" {
+		t.Errorf("got %q, want %q", got, "hello world")
+	}
+}
+
+func TestAnswer_MultipleBlocks(t *testing.T) {
+	srv := makeServer(t, http.StatusOK, map[string]interface{}{
+		"content": []map[string]string{
+			{"text": "foo"},
+			{"text": "bar"},
+		},
+	})
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	got, err := c.Answer(context.Background(), "claude-haiku-4-5-20251001", "sys", nil, "hi")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "foobar" {
+		t.Errorf("got %q, want %q", got, "foobar")
+	}
+}
+
+func TestAnswer_WithHistory(t *testing.T) {
+	var capturedBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		resp, _ := json.Marshal(map[string]interface{}{
+			"content": []map[string]string{{"text": "answer"}},
+		})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(resp)
+	}))
+	defer srv.Close()
+
+	history := []intent.ConversationMessage{
+		{Role: "user", Content: "previous question"},
+		{Role: "assistant", Content: "previous answer"},
+	}
+
+	c := newTestClient(srv.URL)
+	_, err := c.Answer(context.Background(), "claude-haiku-4-5-20251001", "system prompt", history, "new question")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	msgs, ok := capturedBody["messages"].([]interface{})
+	if !ok {
+		t.Fatalf("messages not an array")
+	}
+	if len(msgs) != 3 {
+		t.Errorf("expected 3 messages (2 history + 1 user), got %d", len(msgs))
+	}
+}
+
+func TestAnswer_Non200(t *testing.T) {
+	srv := makeServer(t, http.StatusInternalServerError, map[string]interface{}{
+		"error": "server error",
+	})
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.Answer(context.Background(), "claude-haiku-4-5-20251001", "sys", nil, "hi")
+	if err == nil {
+		t.Fatal("expected error on non-200 response")
+	}
+}
+
+func TestAnswer_EmptyContent(t *testing.T) {
+	srv := makeServer(t, http.StatusOK, map[string]interface{}{
+		"content": []map[string]string{},
+	})
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.Answer(context.Background(), "claude-haiku-4-5-20251001", "sys", nil, "hi")
+	if err == nil {
+		t.Fatal("expected error on empty content")
+	}
+}
+
+func TestAnswer_RequestShape(t *testing.T) {
+	var capturedBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		resp, _ := json.Marshal(map[string]interface{}{
+			"content": []map[string]string{{"text": "ok"}},
+		})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(resp)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.Answer(context.Background(), "my-model", "my-system", nil, "hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedBody["model"] != "my-model" {
+		t.Errorf("model: got %v, want my-model", capturedBody["model"])
+	}
+	if capturedBody["system"] != "my-system" {
+		t.Errorf("system: got %v, want my-system", capturedBody["system"])
+	}
+	cfg, ok := capturedBody["output_config"].(map[string]interface{})
+	if !ok {
+		t.Fatal("output_config missing or wrong type")
+	}
+	if cfg["effort"] != "low" {
+		t.Errorf("effort: got %v, want low", cfg["effort"])
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/llm` package: `Client`, `NewClient(apiKey string)`, and `Answer(ctx, model, system string, history []intent.ConversationMessage, user string) (string, error)`
- Request shape mirrors `internal/intent/classifier.go:104–147`: `x-api-key`, `anthropic-version: 2023-06-01`, `output_config.effort: "low"`
- Returns the concatenation of all `content[].text` blocks; errors on non-200 or empty content
- Stdlib only (`net/http`, `encoding/json`, `strings`, `bytes`); no new dependencies

## Test plan

- [ ] 6 httptest.NewServer unit tests — no network, no real key
- [ ] `TestAnswer_SingleBlock` — happy path, single content block
- [ ] `TestAnswer_MultipleBlocks` — verifies text concatenation
- [ ] `TestAnswer_WithHistory` — verifies 3 messages sent (2 history + 1 user)
- [ ] `TestAnswer_Non200` — errors on 500
- [ ] `TestAnswer_EmptyContent` — errors on empty content array
- [ ] `TestAnswer_RequestShape` — verifies model, system, output_config.effort in request body