### PR TITLE
feat(config): add BotConfig struct for bot: YAML block (GH-3667)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	Webhooks       *webhooks.Config        `yaml:"webhooks"`
 	TeamID         string                  `yaml:"team_id"` // Optional team ID for scoping execution
 	Team           *TeamConfig             `yaml:"team"`
+	Bot            *BotConfig              `yaml:"bot"`
 }
 
 // TeamConfig holds settings for team-based project access control (GH-635).
@@ -63,6 +64,35 @@ type TeamConfig struct {
 	Enabled     bool   `yaml:"enabled"`
 	TeamID      string `yaml:"team_id"`      // Team ID or name to scope execution
 	MemberEmail string `yaml:"member_email"` // Email of the member executing tasks
+}
+
+// BotConfig holds settings for the Pilot bot module (GH-3665).
+// When enabled, the bot can answer questions, handle issue intake, and respond via comms.
+type BotConfig struct {
+	Enabled     bool               `yaml:"enabled"`
+	Model       string             `yaml:"model"`        // Default: claude-haiku-4-5-20251001
+	AnswerModel string             `yaml:"answer_model"` // Override model for answer calls; falls back to Model
+	APIKey      string             `yaml:"api_key"`
+	Persona     string             `yaml:"persona"`
+	Retrieval   BotRetrievalConfig `yaml:"retrieval"`    // Reserved for TASK-375
+	IssueIntake BotIssueIntakeConfig `yaml:"issue_intake"` // Reserved for TASK-376
+	Voice       BotVoiceConfig     `yaml:"voice"`        // Reserved for TASK-377
+}
+
+// BotRetrievalConfig is reserved for TASK-375 (grounded Q&A retrieval).
+type BotRetrievalConfig struct{}
+
+// BotIssueIntakeConfig is reserved for TASK-376 (conversational issue intake).
+type BotIssueIntakeConfig struct{}
+
+// BotVoiceConfig is reserved for TASK-377 (persona and voice scaffold).
+type BotVoiceConfig struct{}
+
+// DefaultBotConfig returns a BotConfig with sensible defaults.
+func DefaultBotConfig() *BotConfig {
+	return &BotConfig{
+		Model: "claude-haiku-4-5-20251001",
+	}
 }
 
 // AdaptersConfig holds configuration for external service adapters.
@@ -467,6 +497,11 @@ func Load(path string) (*Config, error) {
 	}
 	for _, project := range config.Projects {
 		project.Path = expandPath(project.Path)
+	}
+
+	// Apply bot model default when bot is configured without an explicit model.
+	if config.Bot != nil && config.Bot.Model == "" {
+		config.Bot.Model = "claude-haiku-4-5-20251001"
 	}
 
 	// Log deprecation warnings

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1495,6 +1495,127 @@ func TestSave_PermissionsAre0600(t *testing.T) {
 	}
 }
 
+// TestBotConfigRoundTrip verifies that a bot: YAML block parses into the
+// expected BotConfig struct, including the model default when omitted (GH-3667).
+func TestBotConfigRoundTrip(t *testing.T) {
+	t.Run("full bot block", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		content := `
+version: "1.0"
+bot:
+  enabled: true
+  model: "claude-haiku-4-5-20251001"
+  answer_model: "claude-sonnet-4-6"
+  api_key: "test-api-key"
+  persona: "You are a helpful assistant."
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+
+		if cfg.Bot == nil {
+			t.Fatal("Bot config should not be nil")
+		}
+		if !cfg.Bot.Enabled {
+			t.Error("Bot.Enabled should be true")
+		}
+		if cfg.Bot.Model != "claude-haiku-4-5-20251001" {
+			t.Errorf("Bot.Model = %q, want claude-haiku-4-5-20251001", cfg.Bot.Model)
+		}
+		if cfg.Bot.AnswerModel != "claude-sonnet-4-6" {
+			t.Errorf("Bot.AnswerModel = %q, want claude-sonnet-4-6", cfg.Bot.AnswerModel)
+		}
+		if cfg.Bot.APIKey != "test-api-key" {
+			t.Errorf("Bot.APIKey = %q, want test-api-key", cfg.Bot.APIKey)
+		}
+		if cfg.Bot.Persona != "You are a helpful assistant." {
+			t.Errorf("Bot.Persona = %q, want \"You are a helpful assistant.\"", cfg.Bot.Persona)
+		}
+	})
+
+	t.Run("model defaults to haiku when omitted", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		content := `
+version: "1.0"
+bot:
+  enabled: true
+  persona: "Minimal bot."
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+
+		if cfg.Bot == nil {
+			t.Fatal("Bot config should not be nil")
+		}
+		if cfg.Bot.Model != "claude-haiku-4-5-20251001" {
+			t.Errorf("Bot.Model = %q, want claude-haiku-4-5-20251001 (default)", cfg.Bot.Model)
+		}
+	})
+
+	t.Run("bot absent defaults to nil", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		if err := os.WriteFile(configPath, []byte("version: \"1.0\"\n"), 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+
+		if cfg.Bot != nil {
+			t.Errorf("Bot config should be nil when not configured, got %+v", cfg.Bot)
+		}
+	})
+
+	t.Run("stub fields parse without error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		content := `
+version: "1.0"
+bot:
+  enabled: false
+  retrieval: {}
+  issue_intake: {}
+  voice: {}
+`
+		if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load with stub fields: %v", err)
+		}
+
+		if cfg.Bot == nil {
+			t.Fatal("Bot config should not be nil")
+		}
+		// Stub fields are empty structs — no fields to assert, just confirm no panic/error.
+		_ = cfg.Bot.Retrieval
+		_ = cfg.Bot.IssueIntake
+		_ = cfg.Bot.Voice
+	})
+}
+
 // TestSave_TightensExistingLoosePerms asserts that Save() rewrites a file
 // that previously existed with 0644 down to 0600. Covers the migration path
 // for users upgrading past TASK-290 with an existing 0644 config on disk.


### PR DESCRIPTION
## Summary

- Adds `BotConfig` struct to `internal/config` that parses a `bot:` top-level YAML block
- Fields: `enabled` (bool), `model` (default `claude-haiku-4-5-20251001`), `answer_model`, `api_key`, `persona`
- Stub empty structs `BotRetrievalConfig`, `BotIssueIntakeConfig`, `BotVoiceConfig` reserved for TASK-375/376/377
- `DefaultBotConfig()` helper returns a config with the model default set
- `Load()` applies the model default when the `bot:` block is present but `model` is omitted
- 4 round-trip sub-tests: full block, model default when omitted, nil when absent, stub fields parse without error

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/config/...` passes (all existing tests + 4 new round-trip sub-tests)
- [x] No realistic secrets in staged files (pre-commit hook passed)

Closes #3667