### PR TITLE
feat(comms): Responder + fast chat path — bot module phase 2 (GH-3668)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-06-26 (v2.151.0)
+**Last Updated:** 2026-06-25 (v2.151.0)
 
 ## Legend
 
@@ -164,6 +164,7 @@
 | Comms intent consolidation | ✅ | comms | - | - | Conversation store + LLM classifier consolidated into intent package (v2.25.0, PR #1789) |
 | Comms main.go wiring | ✅ | main | - | - | Updated main.go wiring for unified comms.Handler (v2.25.0, PR #1775) |
 | Comms BuildHandler factory | ✅ | comms | - | `llm_classifier` under slack/discord | Single assembly point for comms.HandlerConfig; all 5 adapter call sites route through it; Slack/Discord/gateway reach classifier parity with Telegram (v2.193.0, PR #3645) |
+| Bot Responder + fast chat | ✅ | comms, llm | - | `bot.enabled` | Responder wraps llm.Client; handleChat/handleGreeting bypass executor (~1–2s vs 15–30s); nil responder preserves executor fallback; persona-aware (GH-3668, v2.195.1) |
 
 ## Alerts & Monitoring
 

--- a/.agent/tasks/TASK-373-bot-llm-answer-primitive.md
+++ b/.agent/tasks/TASK-373-bot-llm-answer-primitive.md
@@ -1,0 +1,99 @@
+# TASK-373: Bot Module Phase 1 — `internal/llm` direct-Anthropic Answer primitive
+
+**Status**: 🚧 Dispatched to Pilot (with TASK-374) → [#3665](https://github.com/qf-studio/pilot/issues/3665)
+**Created**: 2026-06-26
+**Assignee**: Pilot
+**Parent plan**: `/Users/aleks.petrov/.claude/plans/there-is-a-problem-inherited-fiddle.md`
+
+---
+
+## Context
+
+**Problem**: Pilot's chat/question paths spin up the full Claude Code executor
+(15–30s) to respond conversationally. The fast direct-HTTP Anthropic client
+(`internal/intent/classifier.go` `AnthropicClient`) only has `Classify()` — there is
+**no direct-LLM answer path**. This phase adds that missing primitive.
+
+**Goal**: A small, dependency-light `internal/llm` package exposing a generic
+"answer" call that returns raw text, reusing the exact HTTP request shape already
+proven in `AnthropicClient.Classify`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] New package `internal/llm` with a `Client` type and constructor `NewClient(apiKey string) *Client`.
+- [ ] Method `Answer(ctx context.Context, model, system string, history []intent.ConversationMessage, user string) (string, error)`.
+- [ ] `SetAPIURL(url string)` and default model overridable per call (model passed as arg).
+- [ ] Request shape matches `classifier.go:104-147`: headers `x-api-key`, `anthropic-version: 2023-06-01`, `Content-Type: application/json`; body includes `model`, `max_tokens`, `system`, `messages`, and `output_config.effort` (default `"low"`, overridable).
+- [ ] Returns the concatenated `content[].text` from the API response; errors on non-200 / empty content.
+- [ ] Uses an `*http.Client` with a sane timeout (default 30s; configurable).
+- [ ] No new third-party deps — stdlib `net/http` + `encoding/json` only.
+
+---
+
+## Implementation
+
+### Phase 1: `internal/llm/client.go`
+**Goal**: Generic direct Anthropic Messages client returning text.
+
+**Tasks**:
+- [ ] Define `Client{apiKey, httpClient, apiURL}`.
+- [ ] Implement `Answer(...)`: build `messages` from `history` (cap last N, e.g. 10) + the `user` turn; POST; decode `{content:[{text}]}`; join text.
+- [ ] Accept `model` per call so the Responder (TASK-374) can choose Haiku vs Sonnet.
+- [ ] Keep `intent.ConversationMessage` as the history type to avoid a new shared type (import `internal/intent`). No import cycle: `intent` does not import `llm`.
+
+**Files**:
+- `internal/llm/client.go` (created)
+- `internal/llm/client_test.go` (created)
+
+---
+
+## Out of Scope
+
+- Refactoring `intent.AnthropicClient` to delegate to `llm.Client` (future cleanup).
+- Streaming responses.
+- Retrieval, persona, chat wiring — those are TASK-374+.
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|----------|---------|--------|-----------|
+| History type | new `llm.Message` vs reuse `intent.ConversationMessage` | reuse `intent.ConversationMessage` | Already the conversation-store type; no cycle (`intent` doesn't import `llm`) |
+| Effort | fixed vs configurable | configurable, default `low` | Chat is cheap; grounded Q&A may want higher |
+
+---
+
+## Verify
+
+```bash
+go test ./internal/llm/...
+go build ./...
+make lint
+```
+
+Unit test uses `httptest.NewServer` returning a canned Messages response — **no
+network, no real API key**. Assert: correct headers sent, request body has
+`system`/`messages`/`model`, and `Answer` returns the stubbed text.
+
+---
+
+## Done
+
+- [ ] `internal/llm/client.go` exports `Client` + `Answer`.
+- [ ] `go test ./internal/llm/...` passes (stub-server test, no network).
+- [ ] `go build ./...` + `make lint` clean.
+
+---
+
+## Refs
+
+- Parent plan: `there-is-a-problem-inherited-fiddle.md`
+- Reuse source: `internal/intent/classifier.go:104-147`
+- Next: TASK-374 (Responder + fast chat path) consumes this.
+
+---
+
+**Last Updated**: 2026-06-26

--- a/.agent/tasks/TASK-374-bot-responder-fast-chat.md
+++ b/.agent/tasks/TASK-374-bot-responder-fast-chat.md
@@ -1,0 +1,107 @@
+# TASK-374: Bot Module Phase 2 — comms Responder + fast chat path
+
+**Status**: 🚧 Dispatched to Pilot (with TASK-373) → [#3665](https://github.com/qf-studio/pilot/issues/3665)
+**Created**: 2026-06-26
+**Assignee**: Pilot
+**Parent plan**: `/Users/aleks.petrov/.claude/plans/there-is-a-problem-inherited-fiddle.md`
+**Depends on**: TASK-373 (`internal/llm`) — ships in the same PR.
+
+---
+
+## Context
+
+**Problem**: `handleChat` (`internal/comms/handler.go:487`) and `handleGreeting`
+(`:293`) route through the heavy Claude Code executor (60s timeout) for what is a
+pure conversation needing zero code reading. This is the biggest, lowest-risk UX win.
+
+**Goal**: A `Responder` (direct-LLM via `internal/llm`, configurable model + persona)
+wired into the comms intent handlers so chat/greeting answer in ~1–2s. When the bot
+is disabled or no API key is present, behavior is **identical to today** (executor
+fallback) — safe incremental rollout.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `internal/comms/responder.go`: `Responder` wrapping `*llm.Client`, holding `model`, `answerModel`, `persona`. Method `Chat(ctx, history []intent.ConversationMessage, msg string) (string, error)` builds a persona system prompt and calls `llm.Answer` with `model`.
+- [ ] `internal/config`: root-level `BotConfig` parsed from a `bot:` YAML block (fields: `enabled`, `model`, `answer_model`, `api_key`, `persona`; nested `retrieval`/`issue_intake`/`voice` may be stubbed now, used later). Default `model` = `claude-haiku-4-5-20251001`.
+- [ ] `internal/comms/factory.go`: `BuildResponder(cfg *BotConfig)` mirroring `BuildClassifier` (api-key resolution: `cfg.APIKey` → `ANTHROPIC_API_KEY`; returns nil when disabled/no key). Extend `HandlerDeps` with `Bot *BotConfig`; wire the built `Responder` into `HandlerConfig`/`Handler`.
+- [ ] `internal/comms/handler.go`: add `responder *Responder` field. `handleChat`: if `responder != nil` → `Chat(...)`, send reply, record to `convStore`; **else** current executor path unchanged. `handleGreeting`: persona greeting via responder when available, else current static text.
+- [ ] `cmd/pilot/main.go`: thread `cfg.Bot` into every adapter's `HandlerDeps` (Slack ~line 2608 + Telegram/Discord equivalents — the existing `*ClassifierConfig` wiring sites).
+- [ ] `configs/pilot.example.yaml`: root `bot:` block (see plan).
+
+---
+
+## Implementation
+
+### Phase 2a: Responder + config
+- [ ] `BotConfig` struct + parse; `responder.go`; `BuildResponder`.
+
+### Phase 2b: Wire handlers
+- [ ] `handleChat` / `handleGreeting` use responder with executor fallback.
+- [ ] Thread `cfg.Bot` through `HandlerDeps` at all adapter call sites.
+
+**Files**:
+- `internal/comms/responder.go` (created)
+- `internal/comms/factory.go` (modified — `BuildResponder`, `HandlerDeps.Bot`)
+- `internal/comms/handler.go` (modified — `responder` field, `handleChat`, `handleGreeting`)
+- `internal/config/config.go` (modified — `BotConfig`)
+- `cmd/pilot/main.go` (modified — thread `cfg.Bot`)
+- `configs/pilot.example.yaml` (modified — `bot:` block)
+- `internal/comms/responder_test.go`, `internal/comms/handler_chat_test.go` (created)
+
+---
+
+## Out of Scope
+
+- Grounded Q&A retrieval / `handleQuestion` rewrite → TASK-375.
+- Issue intake → TASK-376.
+- Voice wiring (flag only) → persona/docs TASK-377.
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|----------|---------|--------|-----------|
+| `bot:` placement | per-adapter vs root | root-level | Transport-agnostic; one block, threaded to all adapters |
+| Disabled behavior | error vs fallback | fallback to executor | Zero-regression rollout; `responder == nil` short-circuits |
+| Persona | hardcoded vs config | config `bot.persona` | Pilot's "voice" is user-tunable |
+
+---
+
+## Verify
+
+```bash
+go test ./internal/comms/... ./internal/config/...
+go build ./... && make lint
+```
+
+Responder test: mock/stub `llm.Client` → assert system prompt includes persona and
+the executor is never invoked. Handler test: with responder set, `handleChat`
+produces a reply via responder and **does not** call `runner.Execute`; with
+responder nil, the existing executor path is taken (regression guard).
+
+**Live** (after merge, `bot.enabled: true`): send "what do you think about Go
+generics?" on Slack → persona reply in ~1–2s; confirm no `CHAT-…` executor task and
+no "Creating isolated worktree" in daemon logs.
+
+---
+
+## Done
+
+- [ ] Chat + greeting answer via direct LLM when `bot.enabled`; executor fallback when not.
+- [ ] All adapter call sites pass `cfg.Bot`.
+- [ ] Tests pass; build + lint clean.
+
+---
+
+## Refs
+
+- Parent plan: `there-is-a-problem-inherited-fiddle.md`
+- Depends on TASK-373 (`internal/llm`).
+- Followups: TASK-375 (grounded Q&A), TASK-376 (issue intake), TASK-377 (persona/docs).
+
+---
+
+**Last Updated**: 2026-06-26

--- a/.agent/tasks/TASK-375-bot-grounded-qa-retrieval.md
+++ b/.agent/tasks/TASK-375-bot-grounded-qa-retrieval.md
@@ -1,0 +1,47 @@
+# TASK-375: Bot Module Phase 3 — grounded Q&A retrieval
+
+**Status**: 🚧 Dispatched, gated → [#3671](https://github.com/qf-studio/pilot/issues/3671) (`Blocked by: #3665`)
+**Created**: 2026-06-26
+**Assignee**: Pilot (queued)
+**Parent plan**: `/Users/aleks.petrov/.claude/plans/there-is-a-problem-inherited-fiddle.md`
+**Depends on**: TASK-374 (Responder).
+
+---
+
+## Context
+
+`handleQuestion` (`internal/comms/handler.go:326`) uses the executor (90s) even for
+shallow code questions. Add a bounded retrieval layer so code questions answer in
+~2–4s, with executor fallback when the question is too broad. This is the
+most-tunable piece — ship it behind `bot.retrieval.enabled`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `internal/comms/retrieval.go`: bounded walk of the active project (`filepath.WalkDir`), keyword/glob match, pick top `max_files`, read up to `max_bytes`, assemble a context block. Reuse an existing repo-search helper if one exists under `internal/executor`/`internal/memory`; else stdlib walk + `strings.Contains`. Returns `(contextBlock string, tooBroad bool)`.
+- [ ] `Responder.Answer(ctx, history, question)`: run retrieval → if `tooBroad`, signal fallback; else `llm.Answer` with `answerModel` (Sonnet) + the context block.
+- [ ] `handleQuestion`: if responder present → `Answer`; on `tooBroad`/error → existing executor path. Cite real file paths in the answer.
+- [ ] Config `bot.retrieval`: `enabled`, `max_files` (default 8), `max_bytes` (default 24000).
+
+---
+
+## Out of Scope
+- Embeddings / vector search (simple lexical retrieval only for v1).
+
+## Verify
+```bash
+go test ./internal/comms/...
+go build ./... && make lint
+```
+Live: "how does intent classification work?" → grounded answer citing real files in
+a few seconds; "explain the whole repo" → falls back to executor.
+
+## Done
+- [ ] Simple code questions answered via retrieval+LLM; broad ones fall back.
+- [ ] Flag-gated; tests + lint clean.
+
+## Refs
+- Parent plan; depends on TASK-374.
+
+**Last Updated**: 2026-06-26

--- a/.agent/tasks/TASK-376-bot-issue-intake.md
+++ b/.agent/tasks/TASK-376-bot-issue-intake.md
@@ -1,0 +1,53 @@
+# TASK-376: Bot Module Phase 4 — conversational issue intake
+
+**Status**: 🚧 Dispatched, gated → [#3672](https://github.com/qf-studio/pilot/issues/3672) (`Blocked by: #3665`)
+**Created**: 2026-06-26
+**Assignee**: Pilot (queued)
+**Parent plan**: `/Users/aleks.petrov/.claude/plans/there-is-a-problem-inherited-fiddle.md`
+**Depends on**: TASK-374 (Responder).
+
+---
+
+## Context
+
+No existing logic turns a freeform message into a structured issue. Add a
+conversational intake that drafts `title`/`body`/`labels` and **creates the issue
+directly + labels `pilot`** (locked decision — auto-executes). Guardrails are the
+existing repo allowlist + conventional-commit title check in `CreatePilotIssue`
+(`internal/adapters/github/issue_create.go:59,63`).
+
+---
+
+## Acceptance Criteria
+
+- [ ] `internal/comms/issue_intake.go`: `IssueDraft{Title,Body,Labels}`, per-context intake state machine (`pendingIssues map[string]*IssueDraft` on `Handler`, mirroring `pendingTasks`), and the `IssueCreator` interface:
+      `CreateIssue(ctx, projectPath string, d IssueDraft) (url string, err error)` (mirrors `MemberResolver` DI — keeps comms PM-agnostic, no executor→github cycle).
+- [ ] `Responder.DraftIssue(ctx, history, msg) (IssueDraft, error)`: LLM drafts a **conventional-commit** title (`type(scope): desc`) + body; default label `pilot` when `bot.issue_intake.auto_label_pilot`.
+- [ ] `internal/adapters/github/issue_creator.go`: concrete `comms.IssueCreator` resolving active project → `owner/repo` → `github.CreatePilotIssue(...)` with `pilot` label + `RepoAllowlist`.
+- [ ] Triggers: new `intent.IntentIssueIntake` (NL: "create an issue to…", "file a ticket…") in `intent.go`/`classifier.go`, **and** explicit `/draft-issue <text>` command in `commands.go` (pattern: `handleNoPR`/`handleForcePR`, `:552-580`).
+- [ ] `handleIssueIntake` dispatched in the `detectIntent` switch (`handler.go:213-233`); `cmd/pilot/main.go` wires the github-backed `IssueCreator` into `HandlerDeps`.
+
+---
+
+## Out of Scope
+- Linear/Jira issue creation (GitHub only for v1).
+- Human confirmation gate (decision = create directly + label pilot).
+
+## Verify
+```bash
+go test ./internal/comms/... ./internal/adapters/github/...
+go build ./... && make lint
+```
+Live: "create an issue to add rate limiting to the gateway" → bot drafts
+`feat(gateway): …`, creates the GitHub issue labeled `pilot`, returns the URL;
+confirm the Pilot daemon auto-picks it.
+
+## Done
+- [ ] NL + `/draft-issue` both produce a `pilot`-labeled GitHub issue with a valid conventional-commit title.
+- [ ] `IssueCreator` mock test asserts `CreateIssue` called once with the `pilot` label.
+- [ ] Tests + lint clean.
+
+## Refs
+- Parent plan; depends on TASK-374. Guardrails: `issue_create.go:59,63,75`.
+
+**Last Updated**: 2026-06-26

--- a/.agent/tasks/TASK-377-bot-persona-docs.md
+++ b/.agent/tasks/TASK-377-bot-persona-docs.md
@@ -1,0 +1,45 @@
+# TASK-377: Bot Module Phase 5 — persona, voice scaffold, docs
+
+**Status**: 🚧 Dispatched, gated → [#3673](https://github.com/qf-studio/pilot/issues/3673) (`Depends on: #3671, #3672`)
+**Created**: 2026-06-26
+**Assignee**: Pilot (queued)
+**Parent plan**: `/Users/aleks.petrov/.claude/plans/there-is-a-problem-inherited-fiddle.md`
+**Depends on**: TASK-374, TASK-375, TASK-376.
+
+---
+
+## Context
+
+Finalize the bot's identity and document the new fast-vs-executor path. Voice
+(Telegram/Slack calls) is deferred — this phase only ensures the seam exists.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `bot.persona` honored across `Chat`/`Answer`/`DraftIssue` system prompts; sensible default if unset.
+- [ ] `bot.voice.enabled` flag present (scaffold only). Confirm the comms chokepoint already consumes `IncomingMessage.VoiceText` so transcribed voice flows through the same intent→responder path; no call wiring in v1.
+- [ ] `bot.rate_limit` reuses the existing `RateLimiter` to bound per-context LLM calls.
+- [ ] Docs: `configs/pilot.example.yaml` `bot:` block fully commented; a `.agent/knowledge/memories/patterns/` entry "fast conversational path vs executor path" registered in `graph.json` (reference the mem-036 test-at-the-seam lesson).
+- [ ] `.agent/DEVELOPMENT-README.md` Current State refreshed with the bot module.
+
+---
+
+## Out of Scope
+- Actual voice/call transport (future task).
+
+## Verify
+```bash
+go build ./... && make lint && make test
+```
+Live regression: set `bot.enabled: false`, restart → chat/question/intake revert to
+the executor path (zero-regression guard).
+
+## Done
+- [ ] Persona applied; voice flag scaffolded; rate limit active.
+- [ ] Knowledge entry + example config + Current State updated.
+
+## Refs
+- Parent plan; mem-036 (`pitfalls/bug_sdk_command_action_dropped.md`).
+
+**Last Updated**: 2026-06-26

--- a/.agent/tasks/gh-3668.md
+++ b/.agent/tasks/gh-3668.md
@@ -1,0 +1,10 @@
+# GH-3668
+
+**Created:** 2026-06-26
+
+## Problem
+
+New internal/comms/responder.go defining Responder wrapping *llm.Client with model, answerModel, persona; Chat(ctx, history, msg) builds a persona system prompt and calls llm.Answer. New internal/comms/factory.go helper BuildResponder(cfg *BotConfig) mirroring BuildClassifier (api-key resolution cfg.APIKey → ANTHROPIC_API_KEY; returns nil when disabled or no key). Extend HandlerDeps with Bot *BotConfig and wire Responder into Handler. Update handleChat (handler.go:487): if responder != nil → Chat → send reply → record to convStore; else current executor path unchanged. Update handleGreeting (:293): persona greeting when available, else current static text. Adapter→comms seam tests asserting (a) responder path skips runner.Execute/worktree, (b) nil responder hits the existing executor path with zero regression (per mem-036).
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1881,6 +1881,17 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			}
 		}
 
+		var tgBotCfg *comms.BotConfig
+		if cfg.Bot != nil {
+			tgBotCfg = &comms.BotConfig{
+				Enabled:     cfg.Bot.Enabled,
+				Model:       cfg.Bot.Model,
+				AnswerModel: cfg.Bot.AnswerModel,
+				APIKey:      cfg.Bot.APIKey,
+				Persona:     cfg.Bot.Persona,
+			}
+		}
+
 		tgCommsHandler := comms.BuildHandler(comms.HandlerDeps{
 			Messenger:       tgMessenger,
 			Runner:          runner,
@@ -1888,6 +1899,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			ProjectPath:     projectPath,
 			RateLimit:       cfg.Adapters.Telegram.RateLimit,
 			Classifier:      tgClassifierCfg,
+			Bot:             tgBotCfg,
 			MemberResolver:  tgMemberResolver,
 			Store:           store,
 			TaskIDPrefix:    "TG",
@@ -2615,12 +2627,24 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			}
 		}
 
+		var slackBotCfg *comms.BotConfig
+		if cfg.Bot != nil {
+			slackBotCfg = &comms.BotConfig{
+				Enabled:     cfg.Bot.Enabled,
+				Model:       cfg.Bot.Model,
+				AnswerModel: cfg.Bot.AnswerModel,
+				APIKey:      cfg.Bot.APIKey,
+				Persona:     cfg.Bot.Persona,
+			}
+		}
+
 		slackCommsHandler := comms.BuildHandler(comms.HandlerDeps{
 			Messenger:       sdkshim.MessengerToBridge(slackBridge),
 			Runner:          runner,
 			Projects:        config.NewSlackProjectSource(cfg),
 			ProjectPath:     projectPath,
 			Classifier:      slackClassifierCfg,
+			Bot:             slackBotCfg,
 			MemberResolver:  slackMemberResolver,
 			Store:           store,
 			TaskIDPrefix:    "SLACK",

--- a/cmd/pilot/poller_discord.go
+++ b/cmd/pilot/poller_discord.go
@@ -33,6 +33,17 @@ func discordPollerRegistration() PollerRegistration {
 				}
 			}
 
+			var discordBotCfg *comms.BotConfig
+			if deps.Cfg.Bot != nil {
+				discordBotCfg = &comms.BotConfig{
+					Enabled:     deps.Cfg.Bot.Enabled,
+					Model:       deps.Cfg.Bot.Model,
+					AnswerModel: deps.Cfg.Bot.AnswerModel,
+					APIKey:      deps.Cfg.Bot.APIKey,
+					Persona:     deps.Cfg.Bot.Persona,
+				}
+			}
+
 			// discordChatHandler is the core.MessageHandler: it shims SDK events
 			// into comms.IncomingMessage and forwards them to discordCommsHandler.
 			// SetCommsHandler is called after the bridge messenger is created to
@@ -58,6 +69,7 @@ func discordPollerRegistration() PollerRegistration {
 				ProjectPath:     deps.ProjectPath,
 				RateLimit:       discordRateLimitToComms(discordCfg.RateLimit),
 				Classifier:      discordClassifierCfg,
+				Bot:             discordBotCfg,
 				Store:           deps.Store,
 				TaskIDPrefix:    "DISCORD",
 				ExecutorBackend: deps.Cfg.Executor,

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -14,6 +14,18 @@ auth:
   # token: "sk-ant-..."  # Required if type is "api-token"
   # ANTHROPIC_API_KEY env var enables Claude API features (Haiku subtask parsing, etc.)
 
+# Conversational Bot (GH-3665+)
+# When enabled, chat and greeting intents are answered directly via the Anthropic API
+# (~1-2s) instead of the full Claude Code executor (15-30s). Requires ANTHROPIC_API_KEY
+# or an explicit api_key. Leave disabled to keep existing executor-only behavior.
+# bot:
+#   enabled: false
+#   model: "claude-haiku-4-5-20251001"   # Used for chat; Haiku is fast and cheap
+#   answer_model: ""                     # Override for answer calls (defaults to model)
+#   api_key: ""                          # Fallback: uses ANTHROPIC_API_KEY env var
+#   persona: ""                          # Optional voice/persona injected into system prompt
+#                                        # e.g. "You are a friendly Go development assistant."
+
 # Adapters
 adapters:
   # Telegram - Chat-based task execution

--- a/internal/comms/factory.go
+++ b/internal/comms/factory.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/intent"
+	"github.com/qf-studio/pilot/internal/llm"
 	"github.com/qf-studio/pilot/internal/memory"
 )
 
@@ -57,6 +58,43 @@ func BuildClassifier(cfg *ClassifierConfig, executorBackend *executor.BackendCon
 	return client, intent.NewConversationStore(historySize, historyTTL)
 }
 
+// BotConfig holds the per-deployment bot configuration threaded from the root
+// YAML config into the comms layer. It mirrors the fields of config.BotConfig;
+// the caller (cmd/pilot/main.go) maps between the two to avoid an import cycle
+// (config imports adapters, which import comms).
+type BotConfig struct {
+	Enabled     bool
+	Model       string
+	AnswerModel string
+	APIKey      string
+	Persona     string
+}
+
+// BuildResponder constructs a Responder from BotConfig.
+// Returns nil when disabled or no API key is available (env fallback included).
+// Call sites do not need to guard for nil — comms.Handler handles nil gracefully.
+func BuildResponder(cfg *BotConfig) *Responder {
+	if cfg == nil || !cfg.Enabled {
+		return nil
+	}
+	apiKey := cfg.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if apiKey == "" {
+		return nil
+	}
+	model := cfg.Model
+	if model == "" {
+		model = "claude-haiku-4-5-20251001"
+	}
+	answerModel := cfg.AnswerModel
+	if answerModel == "" {
+		answerModel = model
+	}
+	return newResponder(llm.NewClient(apiKey), answerModel, cfg.Persona)
+}
+
 // HandlerDeps holds the per-adapter inputs needed to build a comms.Handler.
 // Pass this to BuildHandler — the only place HandlerConfig is assembled.
 type HandlerDeps struct {
@@ -66,6 +104,7 @@ type HandlerDeps struct {
 	ProjectPath    string
 	RateLimit      *RateLimitConfig
 	Classifier     *ClassifierConfig
+	Bot            *BotConfig
 	MemberResolver MemberResolver
 	Store          *memory.Store
 	TaskIDPrefix   string
@@ -75,10 +114,11 @@ type HandlerDeps struct {
 }
 
 // BuildHandler creates a Handler from adapter deps.
-// This is the single assembly point for HandlerConfig; all 5 adapter call sites
+// This is the single assembly point for HandlerConfig; all adapter call sites
 // route through here so no field can be silently omitted per-adapter.
 func BuildHandler(deps HandlerDeps) *Handler {
 	classifier, convStore := BuildClassifier(deps.Classifier, deps.ExecutorBackend)
+	responder := BuildResponder(deps.Bot)
 	return NewHandler(&HandlerConfig{
 		Messenger:      deps.Messenger,
 		Runner:         deps.Runner,
@@ -87,6 +127,7 @@ func BuildHandler(deps HandlerDeps) *Handler {
 		RateLimit:      deps.RateLimit,
 		LLMClassifier:  classifier,
 		ConvStore:      convStore,
+		Responder:      responder,
 		MemberResolver: deps.MemberResolver,
 		Store:          deps.Store,
 		TaskIDPrefix:   deps.TaskIDPrefix,

--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -33,6 +33,7 @@ type HandlerConfig struct {
 	RateLimit      *RateLimitConfig
 	LLMClassifier  intent.Classifier
 	ConvStore      *intent.ConversationStore
+	Responder      *Responder
 	MemberResolver MemberResolver
 	Store          *memory.Store
 	// TaskIDPrefix is the adapter-specific prefix for task IDs (e.g., "TG", "SLACK").
@@ -50,6 +51,7 @@ type Handler struct {
 	rateLimit      *RateLimiter
 	llmClassifier  intent.Classifier
 	convStore      *intent.ConversationStore
+	responder      *Responder
 	memberResolver MemberResolver
 	store          *memory.Store
 	cmdHandler     *CommandHandler
@@ -90,6 +92,7 @@ func NewHandler(cfg *HandlerConfig) *Handler {
 		rateLimit:      rl,
 		llmClassifier:  cfg.LLMClassifier,
 		convStore:      cfg.ConvStore,
+		responder:      cfg.Responder,
 		memberResolver: cfg.MemberResolver,
 		store:          cfg.Store,
 		taskIDPrefix:   prefix,
@@ -291,6 +294,10 @@ func (h *Handler) detectIntent(ctx context.Context, contextID, text string) inte
 // ---------- intent handlers ----------
 
 func (h *Handler) handleGreeting(ctx context.Context, contextID string) {
+	if h.responder != nil {
+		_ = h.messenger.SendText(ctx, contextID, h.responder.Greeting())
+		return
+	}
 	_ = h.messenger.SendText(ctx, contextID, "👋 Hello! I'm Pilot — send me a task, question, or say /help.")
 }
 
@@ -485,6 +492,33 @@ DO NOT make any code changes. Only explore and plan.`, request),
 }
 
 func (h *Handler) handleChat(ctx context.Context, contextID, threadID, message string) {
+	// Fast path: direct-LLM responder (skips executor and worktree entirely).
+	if h.responder != nil {
+		var history []intent.ConversationMessage
+		if h.convStore != nil {
+			history = h.convStore.Get(contextID)
+		}
+		response, err := h.responder.Chat(ctx, history, message)
+		if err != nil {
+			h.log.Warn("responder.Chat failed", slog.Any("error", err))
+			_ = h.messenger.SendText(ctx, contextID, "Sorry, I couldn't process that. Try rephrasing?")
+			return
+		}
+		if response == "" {
+			response = "I'm not sure how to respond to that. Could you rephrase?"
+		}
+		maxLen := h.messenger.MaxMessageLength()
+		if maxLen > 0 && len(response) > maxLen {
+			response = response[:maxLen-3] + "..."
+		}
+		_ = h.messenger.SendText(ctx, contextID, response)
+		if h.convStore != nil {
+			h.convStore.Add(contextID, "assistant", TruncateText(response, 500))
+		}
+		return
+	}
+
+	// Fallback: executor path (unchanged behavior when bot is disabled).
 	_ = h.messenger.SendText(ctx, contextID, "💬 Thinking...")
 
 	taskID := fmt.Sprintf("CHAT-%d", time.Now().Unix())

--- a/internal/comms/handler_chat_test.go
+++ b/internal/comms/handler_chat_test.go
@@ -1,0 +1,217 @@
+package comms
+
+// Adapter→comms seam tests (per mem-036 — test at the boundary, not in isolation).
+//
+// These tests assert:
+//   (a) When responder != nil, handleChat/handleGreeting bypass runner.Execute and
+//       any worktree creation entirely.
+//   (b) When responder == nil (bot disabled), the existing executor path is taken
+//       with zero regression.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/intent"
+)
+
+// newHandlerWithResponder builds a Handler with a mock responder wired in.
+// runner is intentionally nil so any runner.Execute call would panic — proving
+// the responder path never touches the executor.
+func newHandlerWithResponder(m *handlerMock, reply, persona string) (*Handler, *mockAnswerer) {
+	a := &mockAnswerer{reply: reply}
+	r := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001", persona: persona}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		Responder:    r,
+		TaskIDPrefix: "TEST",
+	})
+	return h, a
+}
+
+// ---------------------------------------------------------------------------
+// handleChat seam tests
+// ---------------------------------------------------------------------------
+
+// TestHandleChat_ResponderPath_SkipsRunner verifies that when a responder is
+// configured the chat reply arrives WITHOUT invoking runner.Execute (which would
+// panic because runner is nil here).
+func TestHandleChat_ResponderPath_SkipsRunner(t *testing.T) {
+	m := &handlerMock{}
+	h, _ := newHandlerWithResponder(m, "Hello from LLM", "")
+
+	h.handleChat(context.Background(), "ch1", "", "how are you?")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected at least one text reply")
+	}
+	got := texts[0].text
+	if got != "Hello from LLM" {
+		t.Errorf("handleChat responder path: got %q, want %q", got, "Hello from LLM")
+	}
+}
+
+// TestHandleChat_ResponderPath_RecordsToConvStore verifies the reply is stored
+// in the conversation store for multi-turn context.
+func TestHandleChat_ResponderPath_RecordsToConvStore(t *testing.T) {
+	m := &handlerMock{}
+	a := &mockAnswerer{reply: "LLM reply"}
+	r := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"}
+	convStore := intent.NewConversationStore(10, 0)
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		Responder:    r,
+		ConvStore:    convStore,
+		TaskIDPrefix: "TEST",
+	})
+
+	h.handleChat(context.Background(), "ch1", "", "hi")
+
+	msgs := convStore.Get("ch1")
+	found := false
+	for _, msg := range msgs {
+		if msg.Role == "assistant" && strings.Contains(msg.Content, "LLM reply") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("responder reply not recorded in convStore; got: %v", msgs)
+	}
+}
+
+// TestHandleChat_ResponderPath_PassesHistory verifies that existing conversation
+// history is forwarded to the responder's Chat call.
+func TestHandleChat_ResponderPath_PassesHistory(t *testing.T) {
+	m := &handlerMock{}
+	a := &mockAnswerer{reply: "ok"}
+	r := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"}
+	convStore := intent.NewConversationStore(10, 0)
+	convStore.Add("ch1", "user", "earlier message")
+	convStore.Add("ch1", "assistant", "earlier reply")
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		Responder:    r,
+		ConvStore:    convStore,
+		TaskIDPrefix: "TEST",
+	})
+
+	h.handleChat(context.Background(), "ch1", "", "follow up")
+
+	if len(a.calls) == 0 {
+		t.Fatal("expected at least one Answer call")
+	}
+	if len(a.calls[0].history) < 2 {
+		t.Errorf("expected >= 2 history entries forwarded to LLM, got %d", len(a.calls[0].history))
+	}
+}
+
+// TestHandleChat_NilResponder_ExecutorPath verifies that with no responder the
+// handler falls through to the "💬 Thinking..." executor path (runner nil → it
+// returns an error, but the key check is the "Thinking" message was sent first).
+func TestHandleChat_NilResponder_ExecutorPath(t *testing.T) {
+	m := &handlerMock{}
+	// No responder, no runner — falls into executor path; runner is nil so
+	// Execute will panic unless we guard. We only check the first message.
+	h := newTestHandler(m)
+
+	// We can't call runner.Execute here (nil runner). Recover the panic that
+	// would occur to verify we DO reach the executor path (the "Thinking" message
+	// is sent before Execute is called).
+	func() {
+		defer func() { recover() }() //nolint:errcheck
+		h.handleChat(context.Background(), "ch1", "", "chat with no bot")
+	}()
+
+	texts := m.getTexts()
+	found := false
+	for _, st := range texts {
+		if strings.Contains(st.text, "Thinking") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("nil-responder path did not send 'Thinking' preamble; texts: %v", texts)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleGreeting seam tests
+// ---------------------------------------------------------------------------
+
+// TestHandleGreeting_ResponderPath_UsesPersona verifies persona is returned when
+// responder is configured.
+func TestHandleGreeting_ResponderPath_UsesPersona(t *testing.T) {
+	m := &handlerMock{}
+	h, _ := newHandlerWithResponder(m, "", "I am your Go assistant.")
+
+	h.handleGreeting(context.Background(), "ch1")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected a greeting reply")
+	}
+	if !strings.Contains(texts[0].text, "I am your Go assistant.") {
+		t.Errorf("persona not in greeting: %q", texts[0].text)
+	}
+}
+
+// TestHandleGreeting_NilResponder_StaticText verifies the static fallback greeting.
+func TestHandleGreeting_NilResponder_StaticText(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.handleGreeting(context.Background(), "ch1")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected a greeting reply")
+	}
+	if texts[0].text != "👋 Hello! I'm Pilot — send me a task, question, or say /help." {
+		t.Errorf("unexpected static greeting: %q", texts[0].text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Full HandleMessage dispatch seam tests
+// ---------------------------------------------------------------------------
+
+// TestHandleMessage_Chat_ResponderPath_SkipsRunner exercises the full
+// HandleMessage→handleChat path when the responder is wired, confirming no
+// task confirmation and no runner invocation.
+func TestHandleMessage_Chat_ResponderPath_SkipsRunner(t *testing.T) {
+	m := &handlerMock{}
+	h, _ := newHandlerWithResponder(m, "I think about this...", "")
+
+	// Force IntentChat via the LLM classifier mock.
+	h.llmClassifier = &hMockClassifier{result: intent.IntentChat}
+
+	// Use text with no /prefix, no greeting, no clear-question prefix, no
+	// operational keywords — so it falls through to the LLM classifier mock.
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "u1",
+		Text:      "discuss generics with me please",
+	})
+
+	// Must NOT have created a pending task.
+	h.mu.Lock()
+	_, hasPending := h.pendingTasks["ch1"]
+	h.mu.Unlock()
+	if hasPending {
+		t.Error("responder chat path created a PendingTask — executor path should be bypassed")
+	}
+
+	texts := m.getTexts()
+	found := false
+	for _, st := range texts {
+		if strings.Contains(st.text, "I think about this") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected responder reply in texts; got: %v", texts)
+	}
+}

--- a/internal/comms/responder.go
+++ b/internal/comms/responder.go
@@ -1,0 +1,53 @@
+package comms
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/qf-studio/pilot/internal/intent"
+	"github.com/qf-studio/pilot/internal/llm"
+)
+
+// llmAnswerer is the narrow interface that Responder needs from llm.Client.
+// Using an interface keeps Responder testable without a live HTTP server.
+type llmAnswerer interface {
+	Answer(ctx context.Context, model, system string, history []intent.ConversationMessage, user string) (string, error)
+}
+
+// Responder answers conversational messages via direct Anthropic API calls,
+// bypassing the Claude Code executor for low-latency chat (~1–2s vs 15–30s).
+type Responder struct {
+	client      llmAnswerer
+	answerModel string
+	persona     string
+}
+
+func newResponder(client *llm.Client, answerModel, persona string) *Responder {
+	return &Responder{
+		client:      client,
+		answerModel: answerModel,
+		persona:     persona,
+	}
+}
+
+// Chat answers a conversational message using the direct LLM path.
+// History provides multi-turn context; persona is injected into the system prompt.
+func (r *Responder) Chat(ctx context.Context, history []intent.ConversationMessage, msg string) (string, error) {
+	return r.client.Answer(ctx, r.answerModel, r.systemPrompt(), history, msg)
+}
+
+// Greeting returns a persona-aware greeting without an LLM call.
+func (r *Responder) Greeting() string {
+	if r.persona != "" {
+		return fmt.Sprintf("👋 Hello! %s Send me a task, question, or say /help.", r.persona)
+	}
+	return "👋 Hello! I'm Pilot — send me a task, question, or say /help."
+}
+
+func (r *Responder) systemPrompt() string {
+	base := "Be concise and conversational. Keep responses under 400 words. Do not make code changes — chat only."
+	if r.persona != "" {
+		return r.persona + "\n\n" + base
+	}
+	return "You are Pilot, a helpful AI development assistant. " + base
+}

--- a/internal/comms/responder_test.go
+++ b/internal/comms/responder_test.go
@@ -1,0 +1,182 @@
+package comms
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/intent"
+)
+
+// mockAnswerer records calls to Answer and returns a canned reply.
+type mockAnswerer struct {
+	reply  string
+	err    error
+	calls  []mockAnswerCall
+}
+
+type mockAnswerCall struct {
+	model, system, user string
+	history             []intent.ConversationMessage
+}
+
+func (m *mockAnswerer) Answer(_ context.Context, model, system string, history []intent.ConversationMessage, user string) (string, error) {
+	m.calls = append(m.calls, mockAnswerCall{model: model, system: system, history: history, user: user})
+	return m.reply, m.err
+}
+
+func newMockResponder(reply, persona string) (*Responder, *mockAnswerer) {
+	a := &mockAnswerer{reply: reply}
+	r := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001", persona: persona}
+	return r, a
+}
+
+// TestResponder_Chat_CallsLLM verifies Chat returns the LLM reply.
+func TestResponder_Chat_CallsLLM(t *testing.T) {
+	r, _ := newMockResponder("Great question!", "")
+	got, err := r.Chat(context.Background(), nil, "how are you?")
+	if err != nil {
+		t.Fatalf("Chat returned error: %v", err)
+	}
+	if got != "Great question!" {
+		t.Errorf("Chat() = %q, want %q", got, "Great question!")
+	}
+}
+
+// TestResponder_Chat_WithHistory verifies that Chat passes history to the LLM.
+func TestResponder_Chat_WithHistory(t *testing.T) {
+	r, a := newMockResponder("You asked about testing.", "")
+	history := []intent.ConversationMessage{
+		{Role: "user", Content: "tell me about testing"},
+		{Role: "assistant", Content: "testing is important"},
+	}
+	_, err := r.Chat(context.Background(), history, "what did I ask?")
+	if err != nil {
+		t.Fatalf("Chat returned error: %v", err)
+	}
+	if len(a.calls) == 0 {
+		t.Fatal("expected at least one Answer call")
+	}
+	if len(a.calls[0].history) != 2 {
+		t.Errorf("expected 2 history entries, got %d", len(a.calls[0].history))
+	}
+}
+
+// TestResponder_Chat_PersonaInSystemPrompt verifies the persona is included.
+func TestResponder_Chat_PersonaInSystemPrompt(t *testing.T) {
+	r, a := newMockResponder("ok", "You are a Go expert.")
+	_, err := r.Chat(context.Background(), nil, "hello")
+	if err != nil {
+		t.Fatalf("Chat returned error: %v", err)
+	}
+	if len(a.calls) == 0 {
+		t.Fatal("expected an Answer call")
+	}
+	if !strings.Contains(a.calls[0].system, "You are a Go expert.") {
+		t.Errorf("persona not in system prompt; system = %q", a.calls[0].system)
+	}
+}
+
+// TestResponder_Chat_NoPersonaDefaultPrompt verifies the default system prompt.
+func TestResponder_Chat_NoPersonaDefaultPrompt(t *testing.T) {
+	r, a := newMockResponder("ok", "")
+	_, _ = r.Chat(context.Background(), nil, "hello")
+	if len(a.calls) == 0 {
+		t.Fatal("expected an Answer call")
+	}
+	if !strings.Contains(a.calls[0].system, "Pilot") {
+		t.Errorf("expected 'Pilot' in default system prompt; got %q", a.calls[0].system)
+	}
+}
+
+// TestResponder_Chat_Error propagates LLM errors.
+func TestResponder_Chat_Error(t *testing.T) {
+	a := &mockAnswerer{err: errors.New("timeout")}
+	r := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"}
+	_, err := r.Chat(context.Background(), nil, "hi")
+	if err == nil {
+		t.Error("expected error from Chat, got nil")
+	}
+}
+
+// TestResponder_Greeting_WithPersona verifies persona-formatted greeting.
+func TestResponder_Greeting_WithPersona(t *testing.T) {
+	r, _ := newMockResponder("", "I am your Go assistant.")
+	got := r.Greeting()
+	if !strings.Contains(got, "I am your Go assistant.") {
+		t.Errorf("persona not in greeting: %q", got)
+	}
+	if !strings.Contains(got, "/help") {
+		t.Errorf("greeting missing /help hint: %q", got)
+	}
+}
+
+// TestResponder_Greeting_NoPersona verifies the default (static) greeting.
+func TestResponder_Greeting_NoPersona(t *testing.T) {
+	r, _ := newMockResponder("", "")
+	got := r.Greeting()
+	if got != "👋 Hello! I'm Pilot — send me a task, question, or say /help." {
+		t.Errorf("unexpected default greeting: %q", got)
+	}
+}
+
+// TestBuildResponder_NilCfg verifies nil config returns nil responder.
+func TestBuildResponder_NilCfg(t *testing.T) {
+	if got := BuildResponder(nil); got != nil {
+		t.Errorf("BuildResponder(nil) = %v, want nil", got)
+	}
+}
+
+// TestBuildResponder_Disabled verifies disabled config returns nil responder.
+func TestBuildResponder_Disabled(t *testing.T) {
+	if got := BuildResponder(&BotConfig{Enabled: false, APIKey: "key"}); got != nil {
+		t.Errorf("BuildResponder(disabled) = %v, want nil", got)
+	}
+}
+
+// TestBuildResponder_NoKey verifies that no key (and env not set) returns nil.
+func TestBuildResponder_NoKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	got := BuildResponder(&BotConfig{Enabled: true, APIKey: ""})
+	if got != nil {
+		t.Errorf("BuildResponder(no key) = %v, want nil", got)
+	}
+}
+
+// TestBuildResponder_EnvKeyFallback verifies env var fallback.
+func TestBuildResponder_EnvKeyFallback(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "env-key")
+	got := BuildResponder(&BotConfig{Enabled: true, APIKey: ""})
+	if got == nil {
+		t.Error("BuildResponder(env key) = nil, want non-nil Responder")
+	}
+}
+
+// TestBuildResponder_DefaultModel verifies that empty model defaults to Haiku.
+func TestBuildResponder_DefaultModel(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "key")
+	r := BuildResponder(&BotConfig{Enabled: true})
+	if r == nil {
+		t.Fatal("expected non-nil Responder")
+	}
+	if r.answerModel != "claude-haiku-4-5-20251001" {
+		t.Errorf("answerModel = %q, want claude-haiku-4-5-20251001", r.answerModel)
+	}
+}
+
+// TestBuildResponder_AnswerModelOverride verifies answer_model overrides model.
+func TestBuildResponder_AnswerModelOverride(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "key")
+	r := BuildResponder(&BotConfig{
+		Enabled:     true,
+		Model:       "claude-haiku-4-5-20251001",
+		AnswerModel: "claude-sonnet-4-6",
+	})
+	if r == nil {
+		t.Fatal("expected non-nil Responder")
+	}
+	if r.answerModel != "claude-sonnet-4-6" {
+		t.Errorf("answerModel = %q, want claude-sonnet-4-6", r.answerModel)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,34 +66,22 @@ type TeamConfig struct {
 	MemberEmail string `yaml:"member_email"` // Email of the member executing tasks
 }
 
-// BotConfig holds settings for the Pilot bot module (GH-3665).
-// When enabled, the bot can answer questions, handle issue intake, and respond via comms.
+// BotConfig holds configuration for the conversational bot module (GH-3665+).
+// When enabled, chat and greeting intents bypass the Claude Code executor and are
+// answered directly via the Anthropic API (~1–2s vs 15–30s for the executor path).
 type BotConfig struct {
-	Enabled     bool               `yaml:"enabled"`
-	Model       string             `yaml:"model"`        // Default: claude-haiku-4-5-20251001
-	AnswerModel string             `yaml:"answer_model"` // Override model for answer calls; falls back to Model
-	APIKey      string             `yaml:"api_key"`
-	Persona     string             `yaml:"persona"`
-	Retrieval   BotRetrievalConfig `yaml:"retrieval"`    // Reserved for TASK-375
-	IssueIntake BotIssueIntakeConfig `yaml:"issue_intake"` // Reserved for TASK-376
-	Voice       BotVoiceConfig     `yaml:"voice"`        // Reserved for TASK-377
+	Enabled     bool   `yaml:"enabled"`
+	Model       string `yaml:"model"`        // Default: claude-haiku-4-5-20251001
+	AnswerModel string `yaml:"answer_model"` // Defaults to Model when empty
+	APIKey      string `yaml:"api_key"`
+	Persona     string `yaml:"persona"` // Injected into the system prompt
+
+	// Reserved for future phases (TASK-375/376/377); parsed but unused.
+	Retrieval   struct{} `yaml:"retrieval,omitempty"`
+	IssueIntake struct{} `yaml:"issue_intake,omitempty"`
+	Voice       struct{} `yaml:"voice,omitempty"`
 }
 
-// BotRetrievalConfig is reserved for TASK-375 (grounded Q&A retrieval).
-type BotRetrievalConfig struct{}
-
-// BotIssueIntakeConfig is reserved for TASK-376 (conversational issue intake).
-type BotIssueIntakeConfig struct{}
-
-// BotVoiceConfig is reserved for TASK-377 (persona and voice scaffold).
-type BotVoiceConfig struct{}
-
-// DefaultBotConfig returns a BotConfig with sensible defaults.
-func DefaultBotConfig() *BotConfig {
-	return &BotConfig{
-		Model: "claude-haiku-4-5-20251001",
-	}
-}
 
 // AdaptersConfig holds configuration for external service adapters.
 // Each adapter connects Pilot to a different service (Linear, Slack, GitHub, GitLab, etc.).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -189,6 +189,58 @@ func TestDefaultConfig(t *testing.T) {
 	})
 }
 
+func TestBotConfig_YAMLRoundTrip(t *testing.T) {
+	yaml := `
+version: "1.0"
+gateway:
+  host: "127.0.0.1"
+  port: 9090
+bot:
+  enabled: true
+  model: "claude-haiku-4-5-20251001"
+  answer_model: "claude-sonnet-4-6"
+  api_key: "test-api-key"
+  persona: "You are a Go expert."
+`
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.Bot == nil {
+		t.Fatal("Bot config is nil after parsing")
+	}
+	if !cfg.Bot.Enabled {
+		t.Error("Bot.Enabled should be true")
+	}
+	if cfg.Bot.Model != "claude-haiku-4-5-20251001" {
+		t.Errorf("Bot.Model = %q, want claude-haiku-4-5-20251001", cfg.Bot.Model)
+	}
+	if cfg.Bot.AnswerModel != "claude-sonnet-4-6" {
+		t.Errorf("Bot.AnswerModel = %q, want claude-sonnet-4-6", cfg.Bot.AnswerModel)
+	}
+	if cfg.Bot.APIKey != "test-api-key" {
+		t.Errorf("Bot.APIKey = %q, want test-api-key", cfg.Bot.APIKey)
+	}
+	if cfg.Bot.Persona != "You are a Go expert." {
+		t.Errorf("Bot.Persona = %q, want 'You are a Go expert.'", cfg.Bot.Persona)
+	}
+}
+
+func TestBotConfig_Nil_ByDefault(t *testing.T) {
+	// A config file without a bot: block should have nil Bot.
+	cfg := DefaultConfig()
+	if cfg.Bot != nil {
+		t.Errorf("DefaultConfig().Bot = %v, want nil", cfg.Bot)
+	}
+}
+
 func TestLoad(t *testing.T) {
 	t.Run("MissingFile", func(t *testing.T) {
 		config, err := Load("/nonexistent/path/config.yaml")

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -614,6 +614,17 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 			}
 		}
 
+		var tgBotCfg *comms.BotConfig
+		if cfg.Bot != nil {
+			tgBotCfg = &comms.BotConfig{
+				Enabled:     cfg.Bot.Enabled,
+				Model:       cfg.Bot.Model,
+				AnswerModel: cfg.Bot.AnswerModel,
+				APIKey:      cfg.Bot.APIKey,
+				Persona:     cfg.Bot.Persona,
+			}
+		}
+
 		tgCommsHandler := comms.BuildHandler(comms.HandlerDeps{
 			Messenger:       tgMessenger,
 			Runner:          p.telegramRunner,
@@ -621,6 +632,7 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 			ProjectPath:     projectPath,
 			RateLimit:       cfg.Adapters.Telegram.RateLimit,
 			Classifier:      tgClassifierCfg,
+			Bot:             tgBotCfg,
 			MemberResolver:  tgMemberResolver,
 			Store:           p.store,
 			TaskIDPrefix:    "TG",
@@ -672,12 +684,24 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 			}
 		}
 
+		var slackBotCfg *comms.BotConfig
+		if cfg.Bot != nil {
+			slackBotCfg = &comms.BotConfig{
+				Enabled:     cfg.Bot.Enabled,
+				Model:       cfg.Bot.Model,
+				AnswerModel: cfg.Bot.AnswerModel,
+				APIKey:      cfg.Bot.APIKey,
+				Persona:     cfg.Bot.Persona,
+			}
+		}
+
 		slackCommsHandler := comms.BuildHandler(comms.HandlerDeps{
 			Messenger:       slackMessenger,
 			Runner:          p.slackRunner,
 			Projects:        config.NewSlackProjectSource(cfg),
 			ProjectPath:     projectPath,
 			Classifier:      slackClassifierCfg,
+			Bot:             slackBotCfg,
 			MemberResolver:  slackMemberResolver,
 			Store:           p.store,
 			TaskIDPrefix:    "SLACK",


### PR DESCRIPTION
## Summary

- Adds `internal/comms/responder.go` — `Responder` wraps `*llm.Client` with `answerModel` and `persona`; `Chat(ctx, history, msg)` builds a persona system prompt and calls `llm.Answer` directly (bypasses Claude Code executor, ~1–2s vs 15–30s)
- Adds `internal/comms/factory.go` — `BuildResponder(cfg *BotConfig)` mirroring `BuildClassifier`; resolves API key from `cfg.APIKey` → `ANTHROPIC_API_KEY` env fallback; returns nil when disabled or no key
- Extends `HandlerDeps` with `Bot *BotConfig`; `BuildHandler` assembles and wires `Responder` into `Handler`
- Updates `handleChat` (handler.go): if `responder != nil` → `Chat` → send reply → record to `convStore`; else existing executor path unchanged
- Updates `handleGreeting`: returns persona greeting when `responder != nil`, else current static text
- Adds seam tests: `handler_chat_test.go` (responder path skips `runner.Execute`/worktree) and `responder_test.go` (unit tests for `Chat`, `Greeting`, `systemPrompt`)
- Resolves `BotConfig` conflict with GH-3667: adopts simplified `struct{}` inline fields (no named sub-config types), removes `DefaultBotConfig()` helper

Closes #3668

## Test plan

- [x] `go test ./internal/comms/...` — all pass
- [x] `go test ./internal/config/...` — all pass
- [x] `go build ./...` — clean
- [x] `handler_chat_test.go` — verifies responder path does NOT call `runner.Execute`; nil responder hits executor path with zero regression
- [x] `responder_test.go` — Chat success/error paths, Greeting with/without persona, systemPrompt variations