### PR TITLE
feat(comms): thread cfg.Bot into adapter HandlerDeps + example config (GH-3669)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1849,6 +1849,18 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		})
 	}
 
+	// Build comms.BotConfig once for all adapters (cfg.Bot is global, not per-adapter).
+	var commsBotCfg *comms.BotConfig
+	if cfg.Bot != nil {
+		commsBotCfg = &comms.BotConfig{
+			Enabled:     cfg.Bot.Enabled,
+			Model:       cfg.Bot.Model,
+			AnswerModel: cfg.Bot.AnswerModel,
+			APIKey:      cfg.Bot.APIKey,
+			Persona:     cfg.Bot.Persona,
+		}
+	}
+
 	// Initialize Telegram handler if enabled
 	var tgHandler *telegram.Handler
 	if hasTelegram {
@@ -1888,6 +1900,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			ProjectPath:     projectPath,
 			RateLimit:       cfg.Adapters.Telegram.RateLimit,
 			Classifier:      tgClassifierCfg,
+			Bot:             commsBotCfg,
 			MemberResolver:  tgMemberResolver,
 			Store:           store,
 			TaskIDPrefix:    "TG",
@@ -2621,6 +2634,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			Projects:        config.NewSlackProjectSource(cfg),
 			ProjectPath:     projectPath,
 			Classifier:      slackClassifierCfg,
+			Bot:             commsBotCfg,
 			MemberResolver:  slackMemberResolver,
 			Store:           store,
 			TaskIDPrefix:    "SLACK",

--- a/cmd/pilot/poller_discord.go
+++ b/cmd/pilot/poller_discord.go
@@ -51,6 +51,17 @@ func discordPollerRegistration() PollerRegistration {
 				AllowedChannels: discordCfg.AllowedChannels,
 			}, nil).NewChatBridge(sdkCore.ChatDeps{Handler: discordChatHandler})
 
+			var discordBotCfg *comms.BotConfig
+			if deps.Cfg.Bot != nil {
+				discordBotCfg = &comms.BotConfig{
+					Enabled:     deps.Cfg.Bot.Enabled,
+					Model:       deps.Cfg.Bot.Model,
+					AnswerModel: deps.Cfg.Bot.AnswerModel,
+					APIKey:      deps.Cfg.Bot.APIKey,
+					Persona:     deps.Cfg.Bot.Persona,
+				}
+			}
+
 			discordCommsHandler := comms.BuildHandler(comms.HandlerDeps{
 				Messenger:       sdkshim.MessengerToBridge(discordBridge),
 				Runner:          deps.Runner,
@@ -58,6 +69,7 @@ func discordPollerRegistration() PollerRegistration {
 				ProjectPath:     deps.ProjectPath,
 				RateLimit:       discordRateLimitToComms(discordCfg.RateLimit),
 				Classifier:      discordClassifierCfg,
+				Bot:             discordBotCfg,
 				Store:           deps.Store,
 				TaskIDPrefix:    "DISCORD",
 				ExecutorBackend: deps.Cfg.Executor,

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -431,6 +431,21 @@ autopilot:
     # required: []                # Only used in manual mode
     discovery_grace_period: 60s   # Wait for CI to start
 
+# Bot module — conversational Pilot assistant (GH-3665)
+# When enabled, the bot can answer questions and respond via comms adapters.
+bot:
+  enabled: false
+  model: claude-haiku-4-5-20251001     # Default model for classification and routing
+  answer_model: claude-haiku-4-5-20251001  # Override for answer calls; falls back to model
+  api_key: "${ANTHROPIC_API_KEY}"      # Falls back to ANTHROPIC_API_KEY env var when blank
+  persona: |
+    You are Pilot, an AI assistant that helps engineering teams ship faster.
+    Be concise, technical, and direct.
+  # Stub sections reserved for future phases:
+  retrieval: {}    # TASK-375: grounded Q&A retrieval
+  issue_intake: {} # TASK-376: conversational issue intake
+  voice: {}        # TASK-377: persona and voice scaffold
+
 # Dashboard settings
 dashboard:
   refresh_interval: 1000     # ms

--- a/internal/comms/factory.go
+++ b/internal/comms/factory.go
@@ -19,6 +19,17 @@ type ClassifierConfig struct {
 	HistoryTTL  time.Duration
 }
 
+// BotConfig is the adapter-agnostic configuration for the conversational bot module.
+// Each call site maps its config.BotConfig into this struct before calling BuildHandler
+// (comms cannot import the config package directly — config imports comms).
+type BotConfig struct {
+	Enabled     bool
+	Model       string
+	AnswerModel string
+	APIKey      string
+	Persona     string
+}
+
 // BuildClassifier bootstraps an intent classifier and conversation store.
 // Returns (nil, nil) when disabled or no API key is available (env fallback included).
 // Call sites do not need to guard for nil — comms.Handler handles nil classifiers gracefully.
@@ -66,6 +77,7 @@ type HandlerDeps struct {
 	ProjectPath    string
 	RateLimit      *RateLimitConfig
 	Classifier     *ClassifierConfig
+	Bot            *BotConfig
 	MemberResolver MemberResolver
 	Store          *memory.Store
 	TaskIDPrefix   string
@@ -75,7 +87,7 @@ type HandlerDeps struct {
 }
 
 // BuildHandler creates a Handler from adapter deps.
-// This is the single assembly point for HandlerConfig; all 5 adapter call sites
+// This is the single assembly point for HandlerConfig; all adapter call sites
 // route through here so no field can be silently omitted per-adapter.
 func BuildHandler(deps HandlerDeps) *Handler {
 	classifier, convStore := BuildClassifier(deps.Classifier, deps.ExecutorBackend)
@@ -87,6 +99,7 @@ func BuildHandler(deps HandlerDeps) *Handler {
 		RateLimit:      deps.RateLimit,
 		LLMClassifier:  classifier,
 		ConvStore:      convStore,
+		Bot:            deps.Bot,
 		MemberResolver: deps.MemberResolver,
 		Store:          deps.Store,
 		TaskIDPrefix:   deps.TaskIDPrefix,

--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -33,6 +33,7 @@ type HandlerConfig struct {
 	RateLimit      *RateLimitConfig
 	LLMClassifier  intent.Classifier
 	ConvStore      *intent.ConversationStore
+	Bot            *BotConfig
 	MemberResolver MemberResolver
 	Store          *memory.Store
 	// TaskIDPrefix is the adapter-specific prefix for task IDs (e.g., "TG", "SLACK").
@@ -50,6 +51,7 @@ type Handler struct {
 	rateLimit      *RateLimiter
 	llmClassifier  intent.Classifier
 	convStore      *intent.ConversationStore
+	bot            *BotConfig
 	memberResolver MemberResolver
 	store          *memory.Store
 	cmdHandler     *CommandHandler
@@ -90,6 +92,7 @@ func NewHandler(cfg *HandlerConfig) *Handler {
 		rateLimit:      rl,
 		llmClassifier:  cfg.LLMClassifier,
 		convStore:      cfg.ConvStore,
+		bot:            cfg.Bot,
 		memberResolver: cfg.MemberResolver,
 		store:          cfg.Store,
 		taskIDPrefix:   prefix,

--- a/internal/pilot/pilot.go
+++ b/internal/pilot/pilot.go
@@ -578,6 +578,18 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 		p.gateway.SetDashboardFS(p.dashboardFS)
 	}
 
+	// Build comms.BotConfig once for all adapters (cfg.Bot is global, not per-adapter).
+	var pilotBotCfg *comms.BotConfig
+	if cfg.Bot != nil {
+		pilotBotCfg = &comms.BotConfig{
+			Enabled:     cfg.Bot.Enabled,
+			Model:       cfg.Bot.Model,
+			AnswerModel: cfg.Bot.AnswerModel,
+			APIKey:      cfg.Bot.APIKey,
+			Persona:     cfg.Bot.Persona,
+		}
+	}
+
 	// Initialize Telegram handler if runner was provided via options (GH-349)
 	// This enables Telegram polling in gateway mode alongside Linear/Jira webhooks
 	if p.telegramRunner != nil && cfg.Adapters.Telegram != nil && cfg.Adapters.Telegram.Enabled && cfg.Adapters.Telegram.Polling {
@@ -621,6 +633,7 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 			ProjectPath:     projectPath,
 			RateLimit:       cfg.Adapters.Telegram.RateLimit,
 			Classifier:      tgClassifierCfg,
+			Bot:             pilotBotCfg,
 			MemberResolver:  tgMemberResolver,
 			Store:           p.store,
 			TaskIDPrefix:    "TG",
@@ -678,6 +691,7 @@ func New(cfg *config.Config, opts ...Option) (*Pilot, error) {
 			Projects:        config.NewSlackProjectSource(cfg),
 			ProjectPath:     projectPath,
 			Classifier:      slackClassifierCfg,
+			Bot:             pilotBotCfg,
 			MemberResolver:  slackMemberResolver,
 			Store:           p.store,
 			TaskIDPrefix:    "SLACK",


### PR DESCRIPTION
## Summary

- Adds `BotConfig` struct to `internal/comms` (mirrors `config.BotConfig`; avoids import cycle since `config` imports `comms`)
- Adds `Bot *BotConfig` field to `HandlerDeps`, `HandlerConfig`, and `Handler` in `internal/comms`
- Wires `cfg.Bot` at all adapter call sites: Telegram + Slack in `cmd/pilot/main.go`, Discord in `cmd/pilot/poller_discord.go`, Telegram + Slack in `internal/pilot/pilot.go`
- Adds `bot:` YAML block to `configs/pilot.example.yaml` documenting `enabled`, `model`, `answer_model`, `api_key`, `persona`, and stub sections for `retrieval`/`issue_intake`/`voice` (reserved for TASK-375/376/377)

## Test plan

- [x] `go build ./...` — clean
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `go test ./internal/comms/... ./internal/pilot/... ./internal/config/...` — all pass
- [x] All 5 call sites confirmed to have `Bot:` field set