### PR TITLE
feat(comms): add Responder and fast chat path in handler (GH-3668)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-06-26 (v2.151.0)
+**Last Updated:** 2026-06-25 (v2.151.0)
 
 ## Legend
 
@@ -164,6 +164,9 @@
 | Comms intent consolidation | ✅ | comms | - | - | Conversation store + LLM classifier consolidated into intent package (v2.25.0, PR #1789) |
 | Comms main.go wiring | ✅ | main | - | - | Updated main.go wiring for unified comms.Handler (v2.25.0, PR #1775) |
 | Comms BuildHandler factory | ✅ | comms | - | `llm_classifier` under slack/discord | Single assembly point for comms.HandlerConfig; all 5 adapter call sites route through it; Slack/Discord/gateway reach classifier parity with Telegram (v2.193.0, PR #3645) |
+| Bot module — llm.Client + Answer | ✅ | internal/llm | - | - | Direct Anthropic Messages API client; used by Responder (GH-3666, PR #4004) |
+| Bot module — BotConfig YAML struct | ✅ | internal/config | - | `bot:` block | BotConfig YAML struct with model/answer_model/api_key/persona/retrieval/issue_intake/voice (GH-3667) |
+| Bot module — Responder + fast chat path | ✅ | comms | - | `bot:` → HandlerDeps.Bot | Responder wraps llm.Client; handleChat fast path skips executor/worktree; handleGreeting uses persona; BuildResponder factory in comms (GH-3668) |
 
 ## Alerts & Monitoring
 

--- a/internal/comms/factory.go
+++ b/internal/comms/factory.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/intent"
+	"github.com/qf-studio/pilot/internal/llm"
 	"github.com/qf-studio/pilot/internal/memory"
 )
 
@@ -57,6 +58,42 @@ func BuildClassifier(cfg *ClassifierConfig, executorBackend *executor.BackendCon
 	return client, intent.NewConversationStore(historySize, historyTTL)
 }
 
+// BotConfig is the adapter-agnostic config for the Pilot bot module (GH-3665).
+// Adapters map their global bot: YAML block into this struct before calling BuildHandler.
+type BotConfig struct {
+	Enabled     bool
+	Model       string
+	AnswerModel string
+	APIKey      string
+	Persona     string
+}
+
+// BuildResponder bootstraps a Responder from bot config.
+// Returns nil when disabled or no API key is available (env fallback included).
+// Call sites do not need to guard for nil — comms.Handler handles nil responders gracefully.
+func BuildResponder(cfg *BotConfig) *Responder {
+	if cfg == nil || !cfg.Enabled {
+		return nil
+	}
+	apiKey := cfg.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if apiKey == "" {
+		return nil
+	}
+	model := cfg.Model
+	if model == "" {
+		model = "claude-haiku-4-5-20251001"
+	}
+	return &Responder{
+		client:      llm.NewClient(apiKey),
+		model:       model,
+		answerModel: cfg.AnswerModel,
+		persona:     cfg.Persona,
+	}
+}
+
 // HandlerDeps holds the per-adapter inputs needed to build a comms.Handler.
 // Pass this to BuildHandler — the only place HandlerConfig is assembled.
 type HandlerDeps struct {
@@ -66,6 +103,7 @@ type HandlerDeps struct {
 	ProjectPath    string
 	RateLimit      *RateLimitConfig
 	Classifier     *ClassifierConfig
+	Bot            *BotConfig
 	MemberResolver MemberResolver
 	Store          *memory.Store
 	TaskIDPrefix   string
@@ -79,6 +117,7 @@ type HandlerDeps struct {
 // route through here so no field can be silently omitted per-adapter.
 func BuildHandler(deps HandlerDeps) *Handler {
 	classifier, convStore := BuildClassifier(deps.Classifier, deps.ExecutorBackend)
+	responder := BuildResponder(deps.Bot)
 	return NewHandler(&HandlerConfig{
 		Messenger:      deps.Messenger,
 		Runner:         deps.Runner,
@@ -90,5 +129,6 @@ func BuildHandler(deps HandlerDeps) *Handler {
 		MemberResolver: deps.MemberResolver,
 		Store:          deps.Store,
 		TaskIDPrefix:   deps.TaskIDPrefix,
+		Responder:      responder,
 	})
 }

--- a/internal/comms/factory_test.go
+++ b/internal/comms/factory_test.go
@@ -197,6 +197,139 @@ func TestBuildHandler_AdapterParity(t *testing.T) {
 	}
 }
 
+// --- BuildResponder tests ---
+
+func TestBuildResponder_NilConfig(t *testing.T) {
+	r := BuildResponder(nil)
+	if r != nil {
+		t.Error("expected nil responder for nil config")
+	}
+}
+
+func TestBuildResponder_Disabled(t *testing.T) {
+	r := BuildResponder(&BotConfig{Enabled: false, APIKey: "test-key"})
+	if r != nil {
+		t.Error("expected nil responder when disabled")
+	}
+}
+
+func TestBuildResponder_NoAPIKey(t *testing.T) {
+	// Enabled but no key — result depends on ANTHROPIC_API_KEY env; just verify no panic.
+	r := BuildResponder(&BotConfig{Enabled: true, APIKey: ""})
+	_ = r
+}
+
+func TestBuildResponder_Enabled(t *testing.T) {
+	r := BuildResponder(&BotConfig{
+		Enabled: true,
+		APIKey:  "test-api-key",
+		Model:   "claude-haiku-4-5-20251001",
+	})
+	if r == nil {
+		t.Fatal("expected non-nil responder when enabled with API key")
+	}
+}
+
+func TestBuildResponder_DefaultModel(t *testing.T) {
+	r := BuildResponder(&BotConfig{Enabled: true, APIKey: "test-key"})
+	if r == nil {
+		t.Fatal("expected non-nil responder")
+	}
+	if r.model != "claude-haiku-4-5-20251001" {
+		t.Errorf("expected default model claude-haiku-4-5-20251001, got %s", r.model)
+	}
+}
+
+func TestBuildResponder_PersonaAndAnswerModel(t *testing.T) {
+	r := BuildResponder(&BotConfig{
+		Enabled:     true,
+		APIKey:      "test-key",
+		Model:       "claude-haiku-4-5-20251001",
+		AnswerModel: "claude-sonnet-4-6",
+		Persona:     "You are a helpful DevOps assistant.",
+	})
+	if r == nil {
+		t.Fatal("expected non-nil responder")
+	}
+	if r.answerModel != "claude-sonnet-4-6" {
+		t.Errorf("expected answerModel claude-sonnet-4-6, got %s", r.answerModel)
+	}
+	if r.persona != "You are a helpful DevOps assistant." {
+		t.Errorf("unexpected persona: %s", r.persona)
+	}
+}
+
+func TestBuildResponder_SystemPrompt_DefaultWhenNoPersona(t *testing.T) {
+	r := BuildResponder(&BotConfig{Enabled: true, APIKey: "test-key"})
+	if r == nil {
+		t.Fatal("expected non-nil responder")
+	}
+	sp := r.systemPrompt()
+	if sp == "" {
+		t.Error("expected a non-empty default system prompt")
+	}
+}
+
+func TestBuildResponder_SystemPrompt_UsesPersona(t *testing.T) {
+	r := BuildResponder(&BotConfig{
+		Enabled: true,
+		APIKey:  "test-key",
+		Persona: "You are specialized in Go.",
+	})
+	if r == nil {
+		t.Fatal("expected non-nil responder")
+	}
+	if r.systemPrompt() != "You are specialized in Go." {
+		t.Errorf("expected persona as system prompt, got: %s", r.systemPrompt())
+	}
+}
+
+// --- BuildHandler bot wiring tests ---
+
+func TestBuildHandler_WithBot_WiresResponder(t *testing.T) {
+	m := &handlerMock{}
+	h := BuildHandler(HandlerDeps{
+		Messenger:    m,
+		TaskIDPrefix: "SLACK",
+		Bot: &BotConfig{
+			Enabled: true,
+			APIKey:  "test-bot-key",
+			Model:   "claude-haiku-4-5-20251001",
+			Persona: "You are TestBot.",
+		},
+	})
+	if h == nil {
+		t.Fatal("expected non-nil handler")
+	}
+	if h.responder == nil {
+		t.Error("expected responder to be wired when bot config is enabled")
+	}
+}
+
+func TestBuildHandler_NilBot_NilResponder(t *testing.T) {
+	m := &handlerMock{}
+	h := BuildHandler(HandlerDeps{
+		Messenger:    m,
+		TaskIDPrefix: "SLACK",
+		Bot:          nil,
+	})
+	if h.responder != nil {
+		t.Error("expected nil responder when bot config is nil")
+	}
+}
+
+func TestBuildHandler_DisabledBot_NilResponder(t *testing.T) {
+	m := &handlerMock{}
+	h := BuildHandler(HandlerDeps{
+		Messenger:    m,
+		TaskIDPrefix: "TG",
+		Bot:          &BotConfig{Enabled: false, APIKey: "test-key"},
+	})
+	if h.responder != nil {
+		t.Error("expected nil responder when bot is disabled")
+	}
+}
+
 // TestBuildHandler_ClassifierRoutedToHandler verifies that when a mock classifier
 // is wired, detectIntent uses it for messages that bypass the regex fast paths.
 // Slack regression: GH-3645 — "check the pilot queue" was classified as IntentTask

--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -38,6 +38,9 @@ type HandlerConfig struct {
 	// TaskIDPrefix is the adapter-specific prefix for task IDs (e.g., "TG", "SLACK").
 	TaskIDPrefix string
 	Log          *slog.Logger
+	// Responder enables the fast chat path: direct API call, no executor/worktree.
+	// When nil, handleChat falls through to the executor path.
+	Responder *Responder
 }
 
 // Handler implements platform-agnostic message handling with intent dispatch,
@@ -53,6 +56,7 @@ type Handler struct {
 	memberResolver MemberResolver
 	store          *memory.Store
 	cmdHandler     *CommandHandler
+	responder      chatResponder // nil = executor path; non-nil = fast chat path
 	taskIDPrefix   string
 	log            *slog.Logger
 
@@ -98,6 +102,11 @@ func NewHandler(cfg *HandlerConfig) *Handler {
 		pendingTasks:   make(map[string]*PendingTask),
 		runningTasks:   make(map[string]*RunningTask),
 		lastSender:     make(map[string]string),
+	}
+	// Avoid wrapping a typed nil *Responder in the chatResponder interface — that
+	// would produce a non-nil interface whose Chat calls would panic.
+	if cfg.Responder != nil {
+		h.responder = cfg.Responder
 	}
 
 	// Wire command handler — must be built after h exists so callbacks can close over h.
@@ -291,6 +300,15 @@ func (h *Handler) detectIntent(ctx context.Context, contextID, text string) inte
 // ---------- intent handlers ----------
 
 func (h *Handler) handleGreeting(ctx context.Context, contextID string) {
+	if h.responder != nil {
+		greetCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		reply, err := h.responder.Chat(greetCtx, nil, "Hello!")
+		if err == nil && reply != "" {
+			_ = h.messenger.SendText(ctx, contextID, reply)
+			return
+		}
+	}
 	_ = h.messenger.SendText(ctx, contextID, "👋 Hello! I'm Pilot — send me a task, question, or say /help.")
 }
 
@@ -485,7 +503,37 @@ DO NOT make any code changes. Only explore and plan.`, request),
 }
 
 func (h *Handler) handleChat(ctx context.Context, contextID, threadID, message string) {
+	// Fast path: direct API call via Responder — no executor/worktree involved.
+	if h.responder != nil {
+		var history []intent.ConversationMessage
+		if h.convStore != nil {
+			history = h.convStore.Get(contextID)
+		}
+		chatCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		reply, err := h.responder.Chat(chatCtx, history, message)
+		if err != nil {
+			_ = h.messenger.SendText(ctx, contextID, "Sorry, I couldn't respond. Try again.")
+			return
+		}
+		maxLen := h.messenger.MaxMessageLength()
+		if maxLen > 0 && len(reply) > maxLen {
+			reply = reply[:maxLen-3] + "..."
+		}
+		_ = h.messenger.SendText(ctx, contextID, reply)
+		if h.convStore != nil {
+			h.convStore.Add(contextID, "assistant", TruncateText(reply, 500))
+		}
+		return
+	}
+
+	// Executor path: spawn Claude Code for conversational response.
 	_ = h.messenger.SendText(ctx, contextID, "💬 Thinking...")
+
+	if h.runner == nil {
+		_ = h.messenger.SendText(ctx, contextID, "Sorry, I couldn't process that. Try rephrasing?")
+		return
+	}
 
 	taskID := fmt.Sprintf("CHAT-%d", time.Now().Unix())
 	task := &executor.Task{

--- a/internal/comms/handler_test.go
+++ b/internal/comms/handler_test.go
@@ -95,6 +95,21 @@ func (m *handlerMock) getTexts() []hSentText {
 	return cp
 }
 
+// mockChatResponder is a test double for chatResponder.
+type mockChatResponder struct {
+	mu    sync.Mutex
+	calls int
+	reply string
+	err   error
+}
+
+func (m *mockChatResponder) Chat(_ context.Context, _ []intent.ConversationMessage, _ string) (string, error) {
+	m.mu.Lock()
+	m.calls++
+	m.mu.Unlock()
+	return m.reply, m.err
+}
+
 // hMockClassifier returns a fixed intent.
 type hMockClassifier struct {
 	result intent.Intent
@@ -1104,5 +1119,148 @@ func TestHandleMessage_UnknownCommand_RepliesUnknown(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected 'Unknown command' reply; got: %v", texts)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Adapter→comms seam tests for the Responder fast chat path (GH-3668).
+//
+// (a) When a Responder is wired, handleChat must use it directly —
+//     no runner.Execute / worktree. Asserted by injecting a nil runner
+//     (any Execute call would panic) and verifying the mock reply arrives.
+//
+// (b) When Responder is nil, handleChat must fall through to the existing
+//     executor path with zero regression. Asserted by confirming "💬 Thinking…"
+//     is the first sent text (the executor path's leading indicator).
+// ---------------------------------------------------------------------------
+
+func TestHandleChat_ResponderPath_SkipsRunner(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m) // runner is nil — any Execute call would panic
+	mock := &mockChatResponder{reply: "hello from responder"}
+	h.responder = mock
+
+	h.handleChat(context.Background(), "ch1", "", "how are you?")
+
+	mock.mu.Lock()
+	calls := mock.calls
+	mock.mu.Unlock()
+	if calls == 0 {
+		t.Error("expected responder.Chat to be called")
+	}
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected a reply from responder")
+	}
+	if texts[0].text != "hello from responder" {
+		t.Errorf("expected responder reply, got: %q", texts[0].text)
+	}
+}
+
+func TestHandleChat_ResponderError_SendsErrorMessage(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+	h.responder = &mockChatResponder{err: fmt.Errorf("api unavailable")}
+
+	h.handleChat(context.Background(), "ch1", "", "hello")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected an error message")
+	}
+	if !strings.Contains(texts[0].text, "couldn't respond") {
+		t.Errorf("expected error message, got: %q", texts[0].text)
+	}
+}
+
+func TestHandleChat_ResponderPath_RecordsToConvStore(t *testing.T) {
+	m := &handlerMock{}
+	convStore := intent.NewConversationStore(10, 0)
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		ConvStore:    convStore,
+		TaskIDPrefix: "TEST",
+	})
+	h.responder = &mockChatResponder{reply: "recorded reply"}
+
+	h.handleChat(context.Background(), "ch1", "", "remember this")
+
+	history := convStore.Get("ch1")
+	found := false
+	for _, msg := range history {
+		if msg.Role == "assistant" && strings.Contains(msg.Content, "recorded reply") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("responder reply was not recorded to convStore; history: %v", history)
+	}
+}
+
+func TestHandleChat_NilResponder_ExecutorPath(t *testing.T) {
+	// With nil responder and nil runner, handleChat must take the executor path
+	// (confirmed by "💬 Thinking…" as first text) and fail gracefully on nil runner.
+	m := &handlerMock{}
+	h := newTestHandler(m) // no responder, no runner
+
+	h.handleChat(context.Background(), "ch1", "", "how are you?")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected at least one text message from executor path")
+	}
+	if texts[0].text != "💬 Thinking..." {
+		t.Errorf("expected executor-path thinking indicator as first text, got: %q", texts[0].text)
+	}
+}
+
+func TestHandleGreeting_WithResponder(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+	h.responder = &mockChatResponder{reply: "Hi! I'm your custom bot persona."}
+
+	h.handleGreeting(context.Background(), "ch1")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected a greeting reply")
+	}
+	if texts[0].text != "Hi! I'm your custom bot persona." {
+		t.Errorf("expected responder greeting, got: %q", texts[0].text)
+	}
+}
+
+func TestHandleGreeting_NilResponder_StaticText(t *testing.T) {
+	// Regression guard: nil responder must produce the unchanged static greeting.
+	m := &handlerMock{}
+	h := newTestHandler(m)
+
+	h.handleGreeting(context.Background(), "ch1")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected static greeting")
+	}
+	want := "👋 Hello! I'm Pilot — send me a task, question, or say /help."
+	if texts[0].text != want {
+		t.Errorf("expected static greeting %q, got %q", want, texts[0].text)
+	}
+}
+
+func TestHandleGreeting_ResponderError_FallsBack(t *testing.T) {
+	m := &handlerMock{}
+	h := newTestHandler(m)
+	h.responder = &mockChatResponder{err: fmt.Errorf("api error")}
+
+	h.handleGreeting(context.Background(), "ch1")
+
+	texts := m.getTexts()
+	if len(texts) == 0 {
+		t.Fatal("expected fallback greeting")
+	}
+	want := "👋 Hello! I'm Pilot — send me a task, question, or say /help."
+	if texts[0].text != want {
+		t.Errorf("expected fallback greeting, got: %q", texts[0].text)
 	}
 }

--- a/internal/comms/responder.go
+++ b/internal/comms/responder.go
@@ -1,0 +1,44 @@
+package comms
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/qf-studio/pilot/internal/intent"
+	"github.com/qf-studio/pilot/internal/llm"
+)
+
+// chatResponder is the internal interface satisfied by Responder. Handler stores
+// this interface so tests can inject mocks without requiring a real Anthropic key.
+type chatResponder interface {
+	Chat(ctx context.Context, history []intent.ConversationMessage, msg string) (string, error)
+}
+
+// Responder answers conversational messages using the Anthropic API directly,
+// bypassing the executor/worktree path for low-latency chat replies.
+type Responder struct {
+	client      *llm.Client
+	model       string
+	answerModel string // overrides model for Answer calls; empty = use model
+	persona     string // system prompt; empty = default Pilot persona
+}
+
+// Chat calls the Anthropic API with the configured model and persona system prompt.
+func (r *Responder) Chat(ctx context.Context, history []intent.ConversationMessage, msg string) (string, error) {
+	m := r.answerModel
+	if m == "" {
+		m = r.model
+	}
+	reply, err := r.client.Answer(ctx, m, r.systemPrompt(), history, msg)
+	if err != nil {
+		return "", fmt.Errorf("responder: %w", err)
+	}
+	return reply, nil
+}
+
+func (r *Responder) systemPrompt() string {
+	if r.persona != "" {
+		return r.persona
+	}
+	return "You are Pilot, an AI assistant. Answer helpfully and concisely."
+}


### PR DESCRIPTION
## Summary

- New `internal/comms/responder.go`: `Responder` struct wrapping `*llm.Client` with `model`, `answerModel`, `persona`; `Chat(ctx, history, msg)` calls `llm.Answer` with the persona system prompt
- New `BotConfig` type and `BuildResponder` factory in `factory.go`, mirroring `BuildClassifier` (API key resolution, nil-safe defaults); `HandlerDeps` gains `Bot *BotConfig`; `BuildHandler` wires the `Responder`
- `handleChat` updated: if `responder != nil` → direct API call → send reply → record to `convStore`; else existing executor path unchanged (nil-runner guard added consistent with `handleQuestion`)
- `handleGreeting` updated: persona greeting via `responder.Chat` when available; falls back to static text on error or nil responder

## Test plan

- [x] `TestHandleChat_ResponderPath_SkipsRunner` — nil runner present, no panic; mock reply delivered
- [x] `TestHandleChat_NilResponder_ExecutorPath` — confirms executor path via "💬 Thinking..." leading text
- [x] `TestHandleChat_ResponderPath_RecordsToConvStore` — assistant reply recorded in conversation store
- [x] `TestHandleGreeting_WithResponder` / `_NilResponder_StaticText` / `_ResponderError_FallsBack`
- [x] `TestBuildResponder_*` — nil/disabled/no-key/default-model/persona
- [x] `TestBuildHandler_WithBot_WiresResponder` / `_NilBot_NilResponder` / `_DisabledBot_NilResponder`
- [x] `go build ./...` — clean
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues

Closes #3668
Parent: #3665