### PR TITLE
feat(comms): bot module P4 — conversational issue intake (GH-3672)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-06-26 (v2.151.0)
+**Last Updated:** 2026-06-25 (v2.151.0)
 
 ## Legend
 
@@ -164,7 +164,6 @@
 | Comms intent consolidation | ✅ | comms | - | - | Conversation store + LLM classifier consolidated into intent package (v2.25.0, PR #1789) |
 | Comms main.go wiring | ✅ | main | - | - | Updated main.go wiring for unified comms.Handler (v2.25.0, PR #1775) |
 | Comms BuildHandler factory | ✅ | comms | - | `llm_classifier` under slack/discord | Single assembly point for comms.HandlerConfig; all 5 adapter call sites route through it; Slack/Discord/gateway reach classifier parity with Telegram (v2.193.0, PR #3645) |
-| Bot Responder + fast chat | ✅ | comms, llm | - | `bot.enabled` | Responder wraps llm.Client; handleChat/handleGreeting bypass executor (~1–2s vs 15–30s); nil responder preserves executor fallback; persona-aware (GH-3668, v2.195.1) |
 
 ## Alerts & Monitoring
 
@@ -582,3 +581,4 @@ quality:
 | Ghost-SHA guard | v2.151.x | executor | Fail-closed when commit_sha already on base branch (TASK-300 / GH-3099) |
 | Merge→done race window closed | v2.163.0 | autopilot + adapters/github | `Controller.SetOnIssueDone` fires `MarkProcessed` on all pollers at PR-merge, preventing phantom re-dispatch during label propagation lag (TASK-321 PR-4 / GH-3271) |
 | Decomposed-child base-branch pinning | v2.184.x | executor | Resolve `BaseBranch` from main-repo git context before worktree creation; decomposed children never PR against a sibling branch (GH-3540) |
+| Bot P4 — conversational issue intake | v2.198.0 | comms + adapters/github | `IntentIssueIntake`, `IssueCreator` interface, `Responder.DraftIssue`, `/draft-issue` command, github `IssueCreatorAdapter` (GH-3672) |

--- a/cmd/pilot/issue_creator.go
+++ b/cmd/pilot/issue_creator.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/comms"
+	"github.com/qf-studio/pilot/internal/config"
+)
+
+// buildIssueCreator constructs a comms.IssueCreator backed by the GitHub API.
+// Returns nil when GitHub is not configured (no token or no default repo).
+// The caller may pass the result directly to comms.HandlerDeps.IssueCreator —
+// comms.Handler handles nil gracefully (responds with "not configured").
+func buildIssueCreator(cfg *config.Config) comms.IssueCreator {
+	if cfg.Adapters == nil || cfg.Adapters.GitHub == nil {
+		return nil
+	}
+
+	token := cfg.Adapters.GitHub.Token
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+	if token == "" {
+		return nil
+	}
+
+	var defaultOwner, defaultRepo string
+	if cfg.Adapters.GitHub.Repo != "" {
+		parts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2)
+		if len(parts) == 2 {
+			defaultOwner = parts[0]
+			defaultRepo = parts[1]
+		}
+	}
+
+	// Build per-project path→owner/repo lookup.
+	var projects []github.ProjectEntry
+	for _, p := range cfg.Projects {
+		if p == nil || p.GitHub == nil || p.GitHub.Owner == "" || p.GitHub.Repo == "" || p.Path == "" {
+			continue
+		}
+		projects = append(projects, github.ProjectEntry{
+			Path:  p.Path,
+			Owner: p.GitHub.Owner,
+			Repo:  p.GitHub.Repo,
+		})
+	}
+
+	client := github.NewClient(token)
+	allow := newConfigIssueAllowlist(cfg)
+
+	return github.NewIssueCreatorAdapter(client, allow, projects, defaultOwner, defaultRepo)
+}
+
+// configIssueAllowlist adapts *config.Config to github.IssueAllowlist.
+// Mirrors configRepoAllowlist in repo_allowlist.go but for the issue-creation path.
+type configIssueAllowlist struct {
+	cfg *config.Config
+}
+
+func newConfigIssueAllowlist(cfg *config.Config) github.IssueAllowlist {
+	if cfg == nil {
+		return nil
+	}
+	return &configIssueAllowlist{cfg: cfg}
+}
+
+func (a *configIssueAllowlist) RepoIsAllowed(owner, repo, _ string) bool {
+	if a == nil || a.cfg == nil {
+		return false
+	}
+	match := a.cfg.FindProjectByRepo(owner + "/" + repo)
+	if match != nil {
+		return true
+	}
+	// Also allow the default repo (adapters.github.repo) even if not in projects list.
+	if a.cfg.Adapters != nil && a.cfg.Adapters.GitHub != nil {
+		if a.cfg.Adapters.GitHub.Repo == owner+"/"+repo {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *configIssueAllowlist) ConfiguredRepos() []string {
+	if a == nil || a.cfg == nil {
+		return nil
+	}
+	var out []string
+	seen := make(map[string]bool)
+	if a.cfg.Adapters != nil && a.cfg.Adapters.GitHub != nil && a.cfg.Adapters.GitHub.Repo != "" {
+		seen[a.cfg.Adapters.GitHub.Repo] = true
+		out = append(out, a.cfg.Adapters.GitHub.Repo)
+	}
+	for _, p := range a.cfg.Projects {
+		if p == nil || p.GitHub == nil || p.GitHub.Owner == "" || p.GitHub.Repo == "" {
+			continue
+		}
+		key := p.GitHub.Owner + "/" + p.GitHub.Repo
+		if !seen[key] {
+			seen[key] = true
+			out = append(out, key)
+		}
+	}
+	return out
+}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1883,12 +1883,17 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 
 		var tgBotCfg *comms.BotConfig
 		if cfg.Bot != nil {
+			autoLabelPilot := true // default on
+			if cfg.Bot.IssueIntake.AutoLabelPilot != nil {
+				autoLabelPilot = *cfg.Bot.IssueIntake.AutoLabelPilot
+			}
 			tgBotCfg = &comms.BotConfig{
-				Enabled:     cfg.Bot.Enabled,
-				Model:       cfg.Bot.Model,
-				AnswerModel: cfg.Bot.AnswerModel,
-				APIKey:      cfg.Bot.APIKey,
-				Persona:     cfg.Bot.Persona,
+				Enabled:        cfg.Bot.Enabled,
+				Model:          cfg.Bot.Model,
+				AnswerModel:    cfg.Bot.AnswerModel,
+				APIKey:         cfg.Bot.APIKey,
+				Persona:        cfg.Bot.Persona,
+				AutoLabelPilot: autoLabelPilot,
 			}
 		}
 
@@ -1901,6 +1906,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			Classifier:      tgClassifierCfg,
 			Bot:             tgBotCfg,
 			MemberResolver:  tgMemberResolver,
+			IssueCreator:    buildIssueCreator(cfg),
 			Store:           store,
 			TaskIDPrefix:    "TG",
 			ExecutorBackend: cfg.Executor,
@@ -2629,12 +2635,17 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 
 		var slackBotCfg *comms.BotConfig
 		if cfg.Bot != nil {
+			autoLabelPilot := true // default on
+			if cfg.Bot.IssueIntake.AutoLabelPilot != nil {
+				autoLabelPilot = *cfg.Bot.IssueIntake.AutoLabelPilot
+			}
 			slackBotCfg = &comms.BotConfig{
-				Enabled:     cfg.Bot.Enabled,
-				Model:       cfg.Bot.Model,
-				AnswerModel: cfg.Bot.AnswerModel,
-				APIKey:      cfg.Bot.APIKey,
-				Persona:     cfg.Bot.Persona,
+				Enabled:        cfg.Bot.Enabled,
+				Model:          cfg.Bot.Model,
+				AnswerModel:    cfg.Bot.AnswerModel,
+				APIKey:         cfg.Bot.APIKey,
+				Persona:        cfg.Bot.Persona,
+				AutoLabelPilot: autoLabelPilot,
 			}
 		}
 
@@ -2646,6 +2657,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			Classifier:      slackClassifierCfg,
 			Bot:             slackBotCfg,
 			MemberResolver:  slackMemberResolver,
+			IssueCreator:    buildIssueCreator(cfg),
 			Store:           store,
 			TaskIDPrefix:    "SLACK",
 			ExecutorBackend: cfg.Executor,

--- a/internal/adapters/github/issue_creator.go
+++ b/internal/adapters/github/issue_creator.go
@@ -1,0 +1,70 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/qf-studio/pilot/internal/comms"
+)
+
+// ProjectEntry maps a local filesystem path to a GitHub owner/repo.
+type ProjectEntry struct {
+	Path  string
+	Owner string
+	Repo  string
+}
+
+// IssueCreatorAdapter implements comms.IssueCreator using the GitHub REST API.
+// It resolves the active project path to an owner/repo pair, then delegates to
+// CreatePilotIssue for conventional-commit title validation and allowlist enforcement.
+type IssueCreatorAdapter struct {
+	client       *Client
+	allow        IssueAllowlist
+	projects     []ProjectEntry
+	defaultOwner string
+	defaultRepo  string
+}
+
+// NewIssueCreatorAdapter constructs an IssueCreatorAdapter.
+//
+// projects lists all configured projects for path→owner/repo resolution.
+// defaultOwner/defaultRepo are used when projectPath does not match any entry.
+// allow enforces the repo allowlist (pass AllowAllIssueRepos() when the caller
+// has already constrained the target to trusted config).
+func NewIssueCreatorAdapter(client *Client, allow IssueAllowlist, projects []ProjectEntry, defaultOwner, defaultRepo string) *IssueCreatorAdapter {
+	return &IssueCreatorAdapter{
+		client:       client,
+		allow:        allow,
+		projects:     projects,
+		defaultOwner: defaultOwner,
+		defaultRepo:  defaultRepo,
+	}
+}
+
+// CreateIssue implements comms.IssueCreator.
+// It resolves projectPath → owner/repo, then calls CreatePilotIssue which
+// enforces the conventional-commit title format and the repo allowlist.
+func (a *IssueCreatorAdapter) CreateIssue(ctx context.Context, projectPath string, d comms.IssueDraft) (string, error) {
+	owner, repo := a.resolveRepo(projectPath)
+	if owner == "" || repo == "" {
+		return "", fmt.Errorf("cannot resolve GitHub owner/repo for project path %q", projectPath)
+	}
+
+	issue, err := CreatePilotIssue(ctx, a.client, a.allow, owner, repo, d.Title, d.Body, d.Labels)
+	if err != nil {
+		return "", err
+	}
+	return issue.HTMLURL, nil
+}
+
+// resolveRepo maps a filesystem path to (owner, repo).
+// Returns (defaultOwner, defaultRepo) when no project matches.
+func (a *IssueCreatorAdapter) resolveRepo(projectPath string) (string, string) {
+	for _, p := range a.projects {
+		if p.Path != "" && strings.EqualFold(p.Path, projectPath) {
+			return p.Owner, p.Repo
+		}
+	}
+	return a.defaultOwner, a.defaultRepo
+}

--- a/internal/adapters/github/issue_creator_test.go
+++ b/internal/adapters/github/issue_creator_test.go
@@ -1,0 +1,110 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/comms"
+)
+
+// TestIssueCreatorAdapter_CreateIssue_CallsGitHubAPI verifies that
+// CreateIssue resolves the project path to owner/repo, validates the title,
+// and calls the GitHub API.
+func TestIssueCreatorAdapter_CreateIssue_CallsGitHubAPI(t *testing.T) {
+	// Mock GitHub API server.
+	var capturedBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost {
+			if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+				http.Error(w, "bad body", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{
+				"number": 42,
+				"html_url": "https://github.com/owner/repo/issues/42",
+				"title": "fix(auth): handle nil token",
+				"state": "open"
+			}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := NewClientWithBaseURL("test-token", srv.URL)
+
+	projects := []ProjectEntry{{Path: "/my/project", Owner: "owner", Repo: "repo"}}
+	adapter := NewIssueCreatorAdapter(client, AllowAllIssueRepos(), projects, "", "")
+
+	draft := comms.IssueDraft{
+		Title:  "fix(auth): handle nil token",
+		Body:   "Nil token causes panic.",
+		Labels: []string{"pilot"},
+	}
+
+	url, err := adapter.CreateIssue(context.Background(), "/my/project", draft)
+	if err != nil {
+		t.Fatalf("CreateIssue returned error: %v", err)
+	}
+	if url != "https://github.com/owner/repo/issues/42" {
+		t.Errorf("url = %q, want issues/42", url)
+	}
+
+	// Verify labels were passed to the API.
+	if labels, ok := capturedBody["labels"].([]interface{}); ok {
+		found := false
+		for _, l := range labels {
+			if l == "pilot" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("pilot label not sent to API, labels = %v", labels)
+		}
+	} else {
+		t.Errorf("labels not in request body, body = %v", capturedBody)
+	}
+}
+
+// TestIssueCreatorAdapter_ResolveRepo_Fallback verifies that when no project
+// matches the path, the default owner/repo is used.
+func TestIssueCreatorAdapter_ResolveRepo_Fallback(t *testing.T) {
+	adapter := &IssueCreatorAdapter{
+		projects:     []ProjectEntry{{Path: "/other", Owner: "other", Repo: "other"}},
+		defaultOwner: "default-owner",
+		defaultRepo:  "default-repo",
+	}
+	owner, repo := adapter.resolveRepo("/unknown/path")
+	if owner != "default-owner" || repo != "default-repo" {
+		t.Errorf("resolveRepo fallback: got %q/%q, want default-owner/default-repo", owner, repo)
+	}
+}
+
+// TestIssueCreatorAdapter_ResolveRepo_Match verifies exact path matching.
+func TestIssueCreatorAdapter_ResolveRepo_Match(t *testing.T) {
+	adapter := &IssueCreatorAdapter{
+		projects: []ProjectEntry{
+			{Path: "/my/project", Owner: "my-org", Repo: "my-repo"},
+		},
+	}
+	owner, repo := adapter.resolveRepo("/my/project")
+	if owner != "my-org" || repo != "my-repo" {
+		t.Errorf("resolveRepo: got %q/%q, want my-org/my-repo", owner, repo)
+	}
+}
+
+// TestIssueCreatorAdapter_CreateIssue_NoRepo errors when no repo can be resolved.
+func TestIssueCreatorAdapter_CreateIssue_NoRepo(t *testing.T) {
+	adapter := &IssueCreatorAdapter{}
+	_, err := adapter.CreateIssue(context.Background(), "/some/path", comms.IssueDraft{
+		Title: "fix(x): y",
+	})
+	if err == nil {
+		t.Error("expected error when no repo configured")
+	}
+}

--- a/internal/comms/commands.go
+++ b/internal/comms/commands.go
@@ -13,17 +13,18 @@ import (
 // CommandHandler processes bot commands with access to messenger and memory store.
 // It provides a platform-agnostic implementation of all slash commands.
 type CommandHandler struct {
-	messenger          Messenger
-	store              *memory.Store
-	runCommandFunc     func(ctx context.Context, contextID, taskID string)
-	statusQueryFunc    func(contextID string) (pending, running interface{})
-	activeProjectFunc  func(contextID string) (name, path string)
-	projectListFunc    func() []interface{}
-	setProjectFunc     func(contextID, projectName string) error
-	cancelTaskFunc     func(ctx context.Context, contextID string) error
-	stopTaskFunc       func(ctx context.Context, contextID string) error
-	listTasksFunc      func() string
-	briefGeneratorFunc func(ctx context.Context, contextID string) error // Platform-specific brief generation
+	messenger            Messenger
+	store                *memory.Store
+	runCommandFunc       func(ctx context.Context, contextID, taskID string)
+	statusQueryFunc      func(contextID string) (pending, running interface{})
+	activeProjectFunc    func(contextID string) (name, path string)
+	projectListFunc      func() []interface{}
+	setProjectFunc       func(contextID, projectName string) error
+	cancelTaskFunc       func(ctx context.Context, contextID string) error
+	stopTaskFunc         func(ctx context.Context, contextID string) error
+	listTasksFunc        func() string
+	briefGeneratorFunc   func(ctx context.Context, contextID string) error // Platform-specific brief generation
+	draftIssueHandleFunc func(ctx context.Context, contextID, threadID, text string) // Issue intake
 }
 
 // NewCommandHandler creates a command handler with messenger and optional memory store.
@@ -77,6 +78,11 @@ func (c *CommandHandler) SetListTasksFunc(f func() string) {
 // SetBriefGeneratorFunc sets the brief generator function (platform-specific).
 func (c *CommandHandler) SetBriefGeneratorFunc(f func(ctx context.Context, contextID string) error) {
 	c.briefGeneratorFunc = f
+}
+
+// SetDraftIssueHandleFunc sets the /draft-issue handler (routes to handleIssueIntake).
+func (c *CommandHandler) SetDraftIssueHandleFunc(f func(ctx context.Context, contextID, threadID, text string)) {
+	c.draftIssueHandleFunc = f
 }
 
 // HandleCommand routes slash commands to their handlers.
@@ -138,6 +144,12 @@ func (c *CommandHandler) HandleCommand(ctx context.Context, contextID, text stri
 		} else {
 			_ = c.messenger.SendText(ctx, contextID, "Usage: /pr <task description>\nForces PR creation even for ephemeral-looking tasks.")
 		}
+	case "/draft-issue":
+		if len(args) > 0 {
+			c.handleDraftIssue(ctx, contextID, "", strings.Join(args, " "))
+		} else {
+			_ = c.messenger.SendText(ctx, contextID, "Usage: /draft-issue <description>\nDrafts and files a pilot-labeled GitHub issue.")
+		}
 	default:
 		_ = c.messenger.SendText(ctx, contextID, "Unknown command. Use /help for available commands.")
 	}
@@ -166,6 +178,7 @@ Task Commands
 /stop — Stop running task
 /nopr <task> — Execute without creating PR
 /pr <task> — Force PR creation
+/draft-issue <desc> — File a pilot-labeled GitHub issue
 
 Quick Patterns
 • 07 or task 07 — Run TASK-07
@@ -175,6 +188,7 @@ Quick Patterns
 What I Understand
 • Tasks: "Create a file...", "Add feature..."
 • Questions: "What handles auth?", "How does X work?"
+• Issues: "Create an issue to fix the login bug"
 • Greetings: "Hi", "Hello"
 
 Note: Ephemeral commands (serve, run, etc.) auto-skip PR creation.`
@@ -562,6 +576,15 @@ func (c *CommandHandler) handleNoPR(ctx context.Context, contextID, description 
 		_ = c.messenger.SendText(ctx, contextID,
 			fmt.Sprintf("🚀 Executing without PR: %s", TruncateText(description, 50)))
 	}
+}
+
+// handleDraftIssue handles the /draft-issue command by delegating to handleIssueIntake.
+func (c *CommandHandler) handleDraftIssue(ctx context.Context, contextID, threadID, text string) {
+	if c.draftIssueHandleFunc != nil {
+		c.draftIssueHandleFunc(ctx, contextID, threadID, text)
+		return
+	}
+	_ = c.messenger.SendText(ctx, contextID, "Issue intake not configured.")
 }
 
 // handleForcePR executes a task and forces PR creation.

--- a/internal/comms/factory.go
+++ b/internal/comms/factory.go
@@ -63,11 +63,12 @@ func BuildClassifier(cfg *ClassifierConfig, executorBackend *executor.BackendCon
 // the caller (cmd/pilot/main.go) maps between the two to avoid an import cycle
 // (config imports adapters, which import comms).
 type BotConfig struct {
-	Enabled     bool
-	Model       string
-	AnswerModel string
-	APIKey      string
-	Persona     string
+	Enabled        bool
+	Model          string
+	AnswerModel    string
+	APIKey         string
+	Persona        string
+	AutoLabelPilot bool // When true, /draft-issue and NL issue intake always add "pilot" label.
 }
 
 // BuildResponder constructs a Responder from BotConfig.
@@ -106,6 +107,7 @@ type HandlerDeps struct {
 	Classifier     *ClassifierConfig
 	Bot            *BotConfig
 	MemberResolver MemberResolver
+	IssueCreator   IssueCreator
 	Store          *memory.Store
 	TaskIDPrefix   string
 	// ExecutorBackend is used by BuildClassifier to override the Anthropic model and URL.
@@ -119,6 +121,10 @@ type HandlerDeps struct {
 func BuildHandler(deps HandlerDeps) *Handler {
 	classifier, convStore := BuildClassifier(deps.Classifier, deps.ExecutorBackend)
 	responder := BuildResponder(deps.Bot)
+	autoLabel := true // default: always add "pilot" label to drafted issues
+	if deps.Bot != nil {
+		autoLabel = deps.Bot.AutoLabelPilot
+	}
 	return NewHandler(&HandlerConfig{
 		Messenger:      deps.Messenger,
 		Runner:         deps.Runner,
@@ -129,6 +135,8 @@ func BuildHandler(deps HandlerDeps) *Handler {
 		ConvStore:      convStore,
 		Responder:      responder,
 		MemberResolver: deps.MemberResolver,
+		IssueCreator:   deps.IssueCreator,
+		AutoLabelPilot: autoLabel,
 		Store:          deps.Store,
 		TaskIDPrefix:   deps.TaskIDPrefix,
 	})

--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -35,6 +35,8 @@ type HandlerConfig struct {
 	ConvStore      *intent.ConversationStore
 	Responder      *Responder
 	MemberResolver MemberResolver
+	IssueCreator   IssueCreator
+	AutoLabelPilot bool // passed to Responder.DraftIssue
 	Store          *memory.Store
 	// TaskIDPrefix is the adapter-specific prefix for task IDs (e.g., "TG", "SLACK").
 	TaskIDPrefix string
@@ -53,15 +55,18 @@ type Handler struct {
 	convStore      *intent.ConversationStore
 	responder      *Responder
 	memberResolver MemberResolver
+	issueCreator   IssueCreator
+	autoLabelPilot bool
 	store          *memory.Store
 	cmdHandler     *CommandHandler
 	taskIDPrefix   string
 	log            *slog.Logger
 
-	activeProject map[string]string       // contextID -> projectPath
-	pendingTasks  map[string]*PendingTask // contextID -> pending task
-	runningTasks  map[string]*RunningTask // contextID -> running task
-	lastSender    map[string]string       // contextID -> senderID
+	activeProject map[string]string        // contextID -> projectPath
+	pendingTasks  map[string]*PendingTask  // contextID -> pending task
+	pendingIssues map[string]*PendingIssue // contextID -> pending issue (state machine)
+	runningTasks  map[string]*RunningTask  // contextID -> running task
+	lastSender    map[string]string        // contextID -> senderID
 	mu            sync.Mutex
 }
 
@@ -94,17 +99,23 @@ func NewHandler(cfg *HandlerConfig) *Handler {
 		convStore:      cfg.ConvStore,
 		responder:      cfg.Responder,
 		memberResolver: cfg.MemberResolver,
+		issueCreator:   cfg.IssueCreator,
+		autoLabelPilot: cfg.AutoLabelPilot,
 		store:          cfg.Store,
 		taskIDPrefix:   prefix,
 		log:            lg,
 		activeProject:  make(map[string]string),
 		pendingTasks:   make(map[string]*PendingTask),
+		pendingIssues:  make(map[string]*PendingIssue),
 		runningTasks:   make(map[string]*RunningTask),
 		lastSender:     make(map[string]string),
 	}
 
 	// Wire command handler — must be built after h exists so callbacks can close over h.
 	cmd := NewCommandHandler(cfg.Messenger, cfg.Store)
+	cmd.SetDraftIssueHandleFunc(func(ctx context.Context, contextID, threadID, text string) {
+		h.handleIssueIntake(ctx, contextID, threadID, text)
+	})
 	cmd.SetStatusQueryFunc(func(contextID string) (pending, running interface{}) {
 		// Avoid wrapping typed nil pointers in interface{} — that produces a
 		// non-nil interface whose method calls panic (classic Go gotcha).
@@ -228,6 +239,8 @@ func (h *Handler) HandleMessage(ctx context.Context, msg *IncomingMessage) {
 		h.handlePlanning(ctx, contextID, msg.ThreadID, text)
 	case intent.IntentChat:
 		h.handleChat(ctx, contextID, msg.ThreadID, text)
+	case intent.IntentIssueIntake:
+		h.handleIssueIntake(ctx, contextID, msg.ThreadID, text)
 	case intent.IntentTask:
 		h.handleTask(ctx, contextID, msg.ThreadID, text, msg.SenderID)
 	default:
@@ -570,6 +583,45 @@ User message: %s`, h.getActiveProjectPath(contextID), message),
 	if h.convStore != nil {
 		h.convStore.Add(contextID, "assistant", TruncateText(response, 500))
 	}
+}
+
+func (h *Handler) handleIssueIntake(ctx context.Context, contextID, threadID, text string) {
+	if h.responder == nil {
+		_ = h.messenger.SendText(ctx, contextID, "Issue intake requires bot.enabled=true in config.")
+		return
+	}
+	if h.issueCreator == nil {
+		_ = h.messenger.SendText(ctx, contextID, "Issue creation not configured (no GitHub adapter).")
+		return
+	}
+
+	_ = h.messenger.SendText(ctx, contextID, "🎫 Drafting issue...")
+
+	var history []intent.ConversationMessage
+	if h.convStore != nil {
+		history = h.convStore.Get(contextID)
+	}
+
+	draft, err := h.responder.DraftIssue(ctx, history, text, h.autoLabelPilot)
+	if err != nil {
+		h.log.Warn("DraftIssue failed", slog.Any("error", err))
+		_ = h.messenger.SendText(ctx, contextID, "❌ Failed to draft issue: "+err.Error())
+		return
+	}
+
+	projectPath := h.getActiveProjectPath(contextID)
+	url, err := h.issueCreator.CreateIssue(ctx, projectPath, draft)
+	if err != nil {
+		h.log.Warn("CreateIssue failed", slog.Any("error", err))
+		_ = h.messenger.SendText(ctx, contextID, "❌ Failed to create issue: "+err.Error())
+		return
+	}
+
+	h.log.Info("Issue created via intake",
+		slog.String("context_id", contextID),
+		slog.String("url", url),
+		slog.String("title", draft.Title))
+	_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("✅ Issue created: %s", url))
 }
 
 func (h *Handler) handleTask(ctx context.Context, contextID, threadID, description, senderID string) {

--- a/internal/comms/issue_intake.go
+++ b/internal/comms/issue_intake.go
@@ -1,0 +1,32 @@
+package comms
+
+import (
+	"context"
+	"time"
+)
+
+// IssueDraft holds the LLM-generated fields for a new GitHub issue.
+type IssueDraft struct {
+	Title  string
+	Body   string
+	Labels []string
+}
+
+// IssueCreator creates a GitHub issue from a draft.
+// Each adapter provides a concrete implementation that resolves
+// the active project path to an owner/repo pair.
+// Mirrors the MemberResolver DI pattern — keeps comms PM-agnostic.
+type IssueCreator interface {
+	// CreateIssue creates a GitHub issue and returns its HTML URL.
+	// projectPath identifies the active project for owner/repo resolution.
+	CreateIssue(ctx context.Context, projectPath string, d IssueDraft) (url string, err error)
+}
+
+// PendingIssue is a draft issue awaiting async creation (state machine entry,
+// mirroring PendingTask).
+type PendingIssue struct {
+	Draft     IssueDraft
+	ContextID string
+	ThreadID  string
+	CreatedAt time.Time
+}

--- a/internal/comms/issue_intake_test.go
+++ b/internal/comms/issue_intake_test.go
@@ -1,0 +1,286 @@
+package comms
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/intent"
+)
+
+// mockIssueCreator records calls to CreateIssue and returns a canned URL/error.
+type mockIssueCreator struct {
+	url   string
+	err   error
+	calls []issueCreatorCall
+}
+
+type issueCreatorCall struct {
+	projectPath string
+	draft       IssueDraft
+}
+
+func (m *mockIssueCreator) CreateIssue(_ context.Context, projectPath string, d IssueDraft) (string, error) {
+	m.calls = append(m.calls, issueCreatorCall{projectPath: projectPath, draft: d})
+	return m.url, m.err
+}
+
+// newDraftResponder builds a Responder whose Answer call returns JSON that
+// DraftIssue can parse. Labels may be nil (JSON becomes []).
+func newDraftResponder(title, body string, labels []string) (*Responder, *mockAnswerer) {
+	labelsJSON := "[]"
+	if len(labels) > 0 {
+		quoted := make([]string, len(labels))
+		for i, l := range labels {
+			quoted[i] = `"` + l + `"`
+		}
+		labelsJSON = "[" + strings.Join(quoted, ",") + "]"
+	}
+	reply := `{"title":"` + title + `","body":"` + body + `","labels":` + labelsJSON + `}`
+	a := &mockAnswerer{reply: reply}
+	r := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"}
+	return r, a
+}
+
+// buildIssueIntakeHandler creates a Handler wired for issue-intake tests.
+func buildIssueIntakeHandler(m *handlerMock, responder *Responder, creator IssueCreator, autoLabel bool) *Handler {
+	h := NewHandler(&HandlerConfig{
+		Messenger:      m,
+		Responder:      responder,
+		IssueCreator:   creator,
+		AutoLabelPilot: autoLabel,
+		TaskIDPrefix:   "TEST",
+	})
+	return h
+}
+
+// TestHandleIssueIntake_CallsCreateIssueOnce verifies that handleIssueIntake
+// calls IssueCreator.CreateIssue exactly once with the pilot label present.
+func TestHandleIssueIntake_CallsCreateIssueOnce(t *testing.T) {
+	responder, _ := newDraftResponder(
+		"fix(auth): handle nil session token",
+		"Nil session tokens cause a panic in the auth middleware.",
+		[]string{"pilot"},
+	)
+	creator := &mockIssueCreator{url: "https://github.com/owner/repo/issues/42"}
+	m := &handlerMock{}
+	h := buildIssueIntakeHandler(m, responder, creator, true)
+
+	h.handleIssueIntake(context.Background(), "ctx1", "", "create an issue to fix nil session token panics")
+
+	if len(creator.calls) != 1 {
+		t.Fatalf("expected CreateIssue called once, got %d", len(creator.calls))
+	}
+	call := creator.calls[0]
+	if !containsLabel(call.draft.Labels, "pilot") {
+		t.Errorf("expected 'pilot' label, got %v", call.draft.Labels)
+	}
+	if call.draft.Title == "" {
+		t.Error("expected non-empty title")
+	}
+}
+
+// TestHandleIssueIntake_NoResponder sends a graceful message when bot is unconfigured.
+func TestHandleIssueIntake_NoResponder(t *testing.T) {
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		TaskIDPrefix: "TEST",
+	})
+	h.handleIssueIntake(context.Background(), "ctx1", "", "create an issue")
+	texts := m.getTexts()
+	if len(texts) == 0 || !strings.Contains(texts[0].text, "bot.enabled") {
+		t.Errorf("expected bot-not-configured message, got %v", texts)
+	}
+}
+
+// TestHandleIssueIntake_NoIssueCreator sends a graceful message when GitHub is unconfigured.
+func TestHandleIssueIntake_NoIssueCreator(t *testing.T) {
+	responder, _ := newDraftResponder("feat(x): y", "body", []string{"pilot"})
+	m := &handlerMock{}
+	h := NewHandler(&HandlerConfig{
+		Messenger:    m,
+		Responder:    responder,
+		TaskIDPrefix: "TEST",
+	})
+	h.handleIssueIntake(context.Background(), "ctx1", "", "create an issue")
+	texts := m.getTexts()
+	if len(texts) == 0 || !strings.Contains(texts[0].text, "not configured") {
+		t.Errorf("expected not-configured message, got %v", texts)
+	}
+}
+
+// TestHandleIssueIntake_DraftError propagates LLM errors gracefully.
+func TestHandleIssueIntake_DraftError(t *testing.T) {
+	a := &mockAnswerer{err: errors.New("timeout")}
+	responder := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"}
+	creator := &mockIssueCreator{}
+	m := &handlerMock{}
+	h := buildIssueIntakeHandler(m, responder, creator, true)
+
+	h.handleIssueIntake(context.Background(), "ctx1", "", "file a ticket for broken login")
+
+	if len(creator.calls) != 0 {
+		t.Error("CreateIssue should not be called when DraftIssue fails")
+	}
+}
+
+// TestHandleIssueIntake_AutoLabelPilot_False verifies pilot label is NOT force-added.
+func TestHandleIssueIntake_AutoLabelPilot_False(t *testing.T) {
+	// LLM returns no labels; autoLabelPilot=false so no "pilot" is added.
+	a := &mockAnswerer{reply: `{"title":"fix(x): y","body":"body","labels":[]}`}
+	responder := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"}
+	creator := &mockIssueCreator{url: "https://github.com/owner/repo/issues/1"}
+	m := &handlerMock{}
+	h := buildIssueIntakeHandler(m, responder, creator, false)
+
+	h.handleIssueIntake(context.Background(), "ctx1", "", "create an issue to fix X")
+
+	if len(creator.calls) != 1 {
+		t.Fatalf("expected 1 CreateIssue call, got %d", len(creator.calls))
+	}
+	if containsLabel(creator.calls[0].draft.Labels, "pilot") {
+		t.Error("pilot label should not be added when autoLabelPilot=false")
+	}
+}
+
+// TestHandleIssueIntake_SuccessMessage verifies the URL is reported to the user.
+func TestHandleIssueIntake_SuccessMessage(t *testing.T) {
+	responder, _ := newDraftResponder("feat(ui): new button", "Adds a save button.", []string{"pilot"})
+	creator := &mockIssueCreator{url: "https://github.com/owner/repo/issues/99"}
+	m := &handlerMock{}
+	h := buildIssueIntakeHandler(m, responder, creator, true)
+
+	h.handleIssueIntake(context.Background(), "ctx1", "", "create an issue to add a save button")
+
+	texts := m.getTexts()
+	found := false
+	for _, st := range texts {
+		if strings.Contains(st.text, "https://github.com/owner/repo/issues/99") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected issue URL in reply, got texts: %v", texts)
+	}
+}
+
+// TestResponder_DraftIssue_ParsesJSON verifies DraftIssue parses the LLM JSON response.
+func TestResponder_DraftIssue_ParsesJSON(t *testing.T) {
+	a := &mockAnswerer{
+		reply: `{"title":"feat(auth): add OAuth support","body":"Adds OAuth2 login flow.","labels":["pilot","enhancement"]}`,
+	}
+	r := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"}
+
+	draft, err := r.DraftIssue(context.Background(), nil, "add OAuth login", true)
+	if err != nil {
+		t.Fatalf("DraftIssue returned error: %v", err)
+	}
+	if draft.Title != "feat(auth): add OAuth support" {
+		t.Errorf("title = %q", draft.Title)
+	}
+	if draft.Body != "Adds OAuth2 login flow." {
+		t.Errorf("body = %q", draft.Body)
+	}
+	if !containsLabel(draft.Labels, "pilot") {
+		t.Errorf("expected pilot label, got %v", draft.Labels)
+	}
+}
+
+// TestResponder_DraftIssue_StripsFences verifies DraftIssue handles markdown-wrapped JSON.
+func TestResponder_DraftIssue_StripsFences(t *testing.T) {
+	a := &mockAnswerer{
+		reply: "```json\n{\"title\":\"fix(x): y\",\"body\":\"b\",\"labels\":[\"pilot\"]}\n```",
+	}
+	r := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"}
+
+	draft, err := r.DraftIssue(context.Background(), nil, "fix X", true)
+	if err != nil {
+		t.Fatalf("DraftIssue returned error: %v", err)
+	}
+	if draft.Title != "fix(x): y" {
+		t.Errorf("title = %q", draft.Title)
+	}
+}
+
+// TestResponder_DraftIssue_AddsPilotLabel verifies auto-label adds pilot when absent.
+func TestResponder_DraftIssue_AddsPilotLabel(t *testing.T) {
+	a := &mockAnswerer{
+		reply: `{"title":"feat(ui): new button","body":"body","labels":["enhancement"]}`,
+	}
+	r := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"}
+
+	draft, err := r.DraftIssue(context.Background(), nil, "add a button", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !containsLabel(draft.Labels, "pilot") {
+		t.Errorf("expected pilot label to be added, got %v", draft.Labels)
+	}
+}
+
+// TestResponder_DraftIssue_ErrorPropagates verifies LLM errors propagate.
+func TestResponder_DraftIssue_ErrorPropagates(t *testing.T) {
+	a := &mockAnswerer{err: errors.New("api error")}
+	r := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"}
+	_, err := r.DraftIssue(context.Background(), nil, "create issue", true)
+	if err == nil {
+		t.Error("expected error from DraftIssue, got nil")
+	}
+}
+
+// TestDraftIssueCommand_RoutesToIssueIntake verifies /draft-issue dispatches to
+// handleIssueIntake via the CommandHandler wiring.
+func TestDraftIssueCommand_RoutesToIssueIntake(t *testing.T) {
+	responder, _ := newDraftResponder("fix(login): broken login", "Login is broken.", []string{"pilot"})
+	creator := &mockIssueCreator{url: "https://github.com/o/r/issues/7"}
+	m := &handlerMock{}
+	h := buildIssueIntakeHandler(m, responder, creator, true)
+
+	// Trigger via /draft-issue command path.
+	h.HandleMessage(context.Background(), &IncomingMessage{
+		ContextID: "ch1",
+		SenderID:  "u1",
+		Text:      "/draft-issue fix the broken login flow",
+	})
+
+	if len(creator.calls) != 1 {
+		t.Fatalf("expected 1 CreateIssue call via /draft-issue, got %d", len(creator.calls))
+	}
+	if !containsLabel(creator.calls[0].draft.Labels, "pilot") {
+		t.Errorf("expected pilot label via /draft-issue, got %v", creator.calls[0].draft.Labels)
+	}
+}
+
+// TestIsIssueIntake_Patterns verifies known issue-intake phrases are detected.
+func TestIsIssueIntake_Patterns(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{"create an issue to fix the login bug", true},
+		{"file a ticket for the API timeout", true},
+		{"open an issue about auth", true},
+		{"draft an issue", true},
+		{"create a ticket for this", true},
+		{"report an issue", true},
+		{"raise an issue", true},
+		// Non-intake phrases
+		{"create a login feature", false},
+		{"fix the login bug", false},
+		{"add a button", false},
+		{"what's in the queue?", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.msg, func(t *testing.T) {
+			m := &handlerMock{}
+			h := newTestHandler(m)
+			got := h.detectIntent(context.Background(), "ctx", tc.msg)
+			isIntake := got == intent.IntentIssueIntake
+			if isIntake != tc.want {
+				t.Errorf("detectIntent(%q) issue_intake=%v, want %v (got intent %s)", tc.msg, isIntake, tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/comms/responder.go
+++ b/internal/comms/responder.go
@@ -2,7 +2,9 @@ package comms
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/qf-studio/pilot/internal/intent"
 	"github.com/qf-studio/pilot/internal/llm"
@@ -42,6 +44,65 @@ func (r *Responder) Greeting() string {
 		return fmt.Sprintf("👋 Hello! %s Send me a task, question, or say /help.", r.persona)
 	}
 	return "👋 Hello! I'm Pilot — send me a task, question, or say /help."
+}
+
+// DraftIssue asks the LLM to produce a structured GitHub issue from the user's description.
+// The title always follows the conventional-commits format (type(scope): description).
+// Labels defaults to ["pilot"] when autoLabelPilot is true.
+func (r *Responder) DraftIssue(ctx context.Context, history []intent.ConversationMessage, msg string, autoLabelPilot bool) (IssueDraft, error) {
+	system := `You are a GitHub issue drafter for a software project. Given a description, produce a JSON object with these fields:
+- "title": a conventional-commit style title in format "type(scope): description" (types: feat, fix, chore, refactor, test, docs, perf, build, ci, style)
+- "body": a clear, concise issue body in Markdown explaining the problem or feature request
+- "labels": an array of label strings
+
+Rules:
+- Title MUST match: type(scope): description
+- Keep the title under 72 characters
+- Body should be 2-5 sentences
+- Always include "pilot" in labels
+
+Respond with ONLY valid JSON, no markdown fences.`
+
+	raw, err := r.client.Answer(ctx, r.answerModel, system, history, msg)
+	if err != nil {
+		return IssueDraft{}, fmt.Errorf("DraftIssue LLM call: %w", err)
+	}
+
+	raw = strings.TrimSpace(raw)
+	// Strip markdown code fences if the model wraps the JSON anyway.
+	raw = strings.TrimPrefix(raw, "```json")
+	raw = strings.TrimPrefix(raw, "```")
+	raw = strings.TrimSuffix(raw, "```")
+	raw = strings.TrimSpace(raw)
+
+	var draft struct {
+		Title  string   `json:"title"`
+		Body   string   `json:"body"`
+		Labels []string `json:"labels"`
+	}
+	if err := json.Unmarshal([]byte(raw), &draft); err != nil {
+		return IssueDraft{}, fmt.Errorf("DraftIssue parse JSON: %w (raw=%q)", err, raw)
+	}
+
+	labels := draft.Labels
+	if autoLabelPilot && !containsLabel(labels, "pilot") {
+		labels = append(labels, "pilot")
+	}
+
+	return IssueDraft{
+		Title:  draft.Title,
+		Body:   draft.Body,
+		Labels: labels,
+	}, nil
+}
+
+func containsLabel(labels []string, target string) bool {
+	for _, l := range labels {
+		if l == target {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Responder) systemPrompt() string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,10 +76,18 @@ type BotConfig struct {
 	APIKey      string `yaml:"api_key"`
 	Persona     string `yaml:"persona"` // Injected into the system prompt
 
-	// Reserved for future phases (TASK-375/376/377); parsed but unused.
-	Retrieval   struct{} `yaml:"retrieval,omitempty"`
-	IssueIntake struct{} `yaml:"issue_intake,omitempty"`
-	Voice       struct{} `yaml:"voice,omitempty"`
+	// Reserved for future phases (TASK-375/377); parsed but unused.
+	Retrieval struct{} `yaml:"retrieval,omitempty"`
+	Voice     struct{} `yaml:"voice,omitempty"`
+	// IssueIntake configures the conversational issue-creation path (GH-3672).
+	IssueIntake IssueIntakeConfig `yaml:"issue_intake,omitempty"`
+}
+
+// IssueIntakeConfig holds settings for the bot issue intake flow (GH-3672).
+type IssueIntakeConfig struct {
+	// AutoLabelPilot adds the "pilot" label to every drafted issue (default true).
+	// Set to false to suppress the automatic label.
+	AutoLabelPilot *bool `yaml:"auto_label_pilot,omitempty"`
 }
 
 

--- a/internal/intent/classifier.go
+++ b/internal/intent/classifier.go
@@ -68,11 +68,14 @@ func (c *AnthropicClient) Classify(ctx context.Context, messages []ConversationM
 - operational: Queries about live daemon or queue state (e.g., "what's in the queue?", "anything running?", "how many tasks", "status of the queue")
 - question: Questions about code/project (e.g., "what files handle auth?", "how does X work?")
 - chat: Conversational/opinion-seeking (e.g., "what do you think about...", "should I...")
+- issue_intake: Requests to create/file/draft a GitHub issue or ticket (e.g., "create an issue to fix X", "file a ticket for Y", "draft an issue about Z")
 - task: Requests to make changes (e.g., "add a button", "fix the bug", "implement feature X")
 
 IMPORTANT:
 - "What do you think about adding X?" is CHAT (asking opinion), not TASK
 - "Add X to the project" is TASK (direct instruction)
+- "Create an issue to fix the login bug" is ISSUE_INTAKE, not TASK
+- "File a ticket for the API timeout" is ISSUE_INTAKE, not TASK
 - Questions that don't require code changes are QUESTION
 - "What's in the queue?" or "anything running?" are OPERATIONAL (live state), not QUESTION
 - Be conservative: when in doubt between task and chat, prefer chat
@@ -172,6 +175,8 @@ Respond with JSON only: {"intent": "...", "confidence": 0.0-1.0}`
 		return IntentQuestion, nil
 	case "chat":
 		return IntentChat, nil
+	case "issue_intake":
+		return IntentIssueIntake, nil
 	case "task":
 		return IntentTask, nil
 	default:

--- a/internal/intent/intent.go
+++ b/internal/intent/intent.go
@@ -17,6 +17,7 @@ const (
 	IntentQuestion    Intent = "question"
 	IntentChat        Intent = "chat"
 	IntentTask        Intent = "task"
+	IntentIssueIntake Intent = "issue_intake"
 )
 
 // Common greeting patterns
@@ -48,6 +49,35 @@ var researchPatterns = []string{
 var planningPatterns = []string{
 	"plan", "design", "strategy", "how should we",
 	"approach for", "architect", "outline",
+}
+
+// Issue intake patterns — phrases that signal the user wants to file a ticket.
+// Checked before the generic task handler so "create an issue to..." routes here
+// rather than to IntentTask which would launch a full executor run.
+var issueIntakePatterns = []string{
+	"create an issue",
+	"file an issue",
+	"open an issue",
+	"draft an issue",
+	"create a ticket",
+	"file a ticket",
+	"open a ticket",
+	"draft a ticket",
+	"log an issue",
+	"raise an issue",
+	"report an issue",
+	"submit an issue",
+}
+
+// IsIssueIntake reports whether the message is asking to create a GitHub issue.
+func IsIssueIntake(msg string) bool {
+	lower := strings.ToLower(strings.TrimSpace(msg))
+	for _, pattern := range issueIntakePatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
 }
 
 // Chat patterns - indicate conversational/opinion requests
@@ -137,7 +167,12 @@ func DetectIntent(message string) Intent {
 		return IntentQuestion
 	}
 
-	// 7. Check for task action words
+	// 7. Check for issue intake ("create an issue to…", "file a ticket…")
+	if IsIssueIntake(msg) {
+		return IntentIssueIntake
+	}
+
+	// 8. Check for task action words
 	if IsTask(msg) {
 		return IntentTask
 	}
@@ -392,6 +427,8 @@ func (i Intent) Description() string {
 		return "Chat"
 	case IntentTask:
 		return "Task"
+	case IntentIssueIntake:
+		return "IssueIntake"
 	default:
 		return "Unknown"
 	}


### PR DESCRIPTION
## Summary

- Adds `IntentIssueIntake` intent with NL patterns ("create an issue to…", "file a ticket…", "open a ticket…") and LLM classifier support
- Adds `IssueCreator` interface in `internal/comms/issue_intake.go` (DI, keeps comms PM-agnostic — mirrors `MemberResolver` pattern)
- Adds `Responder.DraftIssue` — calls Anthropic to draft a conventional-commit title + body as JSON, force-adds `pilot` label via `auto_label_pilot` config (default `true`)
- Adds `/draft-issue <text>` command in `commands.go` (routes to `handleIssueIntake`)
- `handleIssueIntake` in `handler.go` — auto-executes: DraftIssue → CreateIssue immediately (no confirmation step per locked decision)
- `internal/adapters/github/issue_creator.go` — `IssueCreatorAdapter` resolves project path → owner/repo → `CreatePilotIssue` (conventional-commit title check + repo allowlist)
- `cmd/pilot/issue_creator.go` — `buildIssueCreator(cfg)` helper; wired into Telegram and Slack `HandlerDeps.IssueCreator` in `main.go`
- `config.BotConfig.IssueIntake.AutoLabelPilot *bool` (default true, parsed from `bot.issue_intake.auto_label_pilot` YAML)

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/comms/... ./internal/adapters/github/... ./internal/intent/... ./internal/config/...` — all pass
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `TestHandleIssueIntake_CallsCreateIssueOnce` — asserts `CreateIssue` called once with `pilot` label
- [x] `TestDraftIssueCommand_RoutesToIssueIntake` — `/draft-issue` command end-to-end
- [x] `TestIsIssueIntake_Patterns` — NL detection patterns
- [x] `TestIssueCreatorAdapter_CreateIssue_CallsGitHubAPI` — HTTP mock verifying `pilot` label sent to API

Closes #3672