### PR TITLE
docs(config): add retrieval/issue_intake/voice stubs to bot: example block (GH-3686)

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -25,6 +25,9 @@ auth:
 #   api_key: ""                          # Fallback: uses ANTHROPIC_API_KEY env var
 #   persona: ""                          # Optional voice/persona injected into system prompt
 #                                        # e.g. "You are a friendly Go development assistant."
+#   retrieval: {}                        # Reserved for TASK-375 (grounded Q&A retrieval)
+#   issue_intake: {}                     # Reserved for TASK-376 (conversational issue intake)
+#   voice: {}                            # Reserved for TASK-377 (persona/voice scaffold)
 
 # Adapters
 adapters:


### PR DESCRIPTION
## Summary

- Adds `retrieval: {}`, `issue_intake: {}`, and `voice: {}` stub fields to the commented `bot:` block in `configs/pilot.example.yaml`, matching the `BotConfig` struct fields (`Retrieval`, `IssueIntake`, `Voice`) added in GH-3667
- Discord adapter `Bot` wiring and `pilot.go` parity were already in place via the GH-3668 (#3678) merge — no code changes needed

## Test plan

- [ ] `go build ./...` — passes (zero errors)
- [ ] `make test` — all packages pass, no failures
- [ ] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues

Closes #3686