### PR TITLE
feat(comms): bot module P4 — conversational issue intake (GH-3672)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-06-26 (v2.151.0)
+**Last Updated:** 2026-06-25 (v2.151.0)
 
 ## Legend
 
@@ -164,9 +164,7 @@
 | Comms intent consolidation | ✅ | comms | - | - | Conversation store + LLM classifier consolidated into intent package (v2.25.0, PR #1789) |
 | Comms main.go wiring | ✅ | main | - | - | Updated main.go wiring for unified comms.Handler (v2.25.0, PR #1775) |
 | Comms BuildHandler factory | ✅ | comms | - | `llm_classifier` under slack/discord | Single assembly point for comms.HandlerConfig; all 5 adapter call sites route through it; Slack/Discord/gateway reach classifier parity with Telegram (v2.193.0, PR #3645) |
-| Bot module P1 — BotConfig | ✅ | config/comms | - | `bot:` | Root-level BotConfig struct with enabled/model/answer_model/api_key/persona; YAML round-trip test (v2.195.0, GH-3667) |
-| Bot module P2 — Responder + fast chat | ✅ | comms | - | `bot.enabled` | Responder wrapping llm.Client; handleChat/handleGreeting bypass executor; ~1-2s vs 15-30s (v2.196.0, GH-3668) |
-| Bot module P3 — grounded Q&A retrieval | ✅ | comms | - | `bot.retrieval.enabled` | Bounded filepath.WalkDir retrieval + LLM answer for code questions; ~2-4s; too-broad questions fall back to executor (v2.197.0, GH-3671) |
+| Bot Module P4 — issue intake | ✅ | comms, adapters/github | - | `bot.issue_intake` | NL + `/draft-issue` → LLM drafts conventional-commit title + body → creates `pilot`-labeled GitHub issue (GH-3672) |
 
 ## Alerts & Monitoring
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1849,6 +1849,31 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		})
 	}
 
+	// Build a shared IssueCreator for comms.Handler (bot /draft-issue + NL intake).
+	// Nil when GitHub is not configured — Handler degrades gracefully.
+	var commsIssueCreator comms.IssueCreator
+	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled && cfg.Adapters.GitHub.Repo != "" {
+		ghToken := cfg.Adapters.GitHub.Token
+		if ghToken == "" {
+			ghToken = os.Getenv("GITHUB_TOKEN")
+		}
+		if ghToken != "" {
+			repoParts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2)
+			if len(repoParts) == 2 {
+				ghIssueClient := github.NewClient(ghToken)
+				commsIssueCreator = github.NewIssueCreator(
+					ghIssueClient,
+					github.AllowAllIssueRepos(),
+					github.IssueCreatorEntry{
+						ProjectPath: cfg.Adapters.GitHub.ProjectPath,
+						Owner:       repoParts[0],
+						Repo:        repoParts[1],
+					},
+				)
+			}
+		}
+	}
+
 	// Initialize Telegram handler if enabled
 	var tgHandler *telegram.Handler
 	if hasTelegram {
@@ -1907,6 +1932,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			Bot:             tgBotCfg,
 			MemberResolver:  tgMemberResolver,
 			Store:           store,
+			IssueCreator:    commsIssueCreator,
 			TaskIDPrefix:    "TG",
 			ExecutorBackend: cfg.Executor,
 		})
@@ -2657,6 +2683,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			Bot:             slackBotCfg,
 			MemberResolver:  slackMemberResolver,
 			Store:           store,
+			IssueCreator:    commsIssueCreator,
 			TaskIDPrefix:    "SLACK",
 			ExecutorBackend: cfg.Executor,
 		})

--- a/internal/adapters/github/issue_creator.go
+++ b/internal/adapters/github/issue_creator.go
@@ -1,0 +1,69 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/qf-studio/pilot/internal/comms"
+)
+
+// issueCreator implements comms.IssueCreator using the GitHub REST API.
+// It is scoped to a single owner/repo pair; projectPath is accepted for
+// interface compatibility and used as a tie-breaker when multiple repos are
+// registered (falls back to the first entry when no match is found).
+type issueCreator struct {
+	client    *Client
+	allowlist IssueAllowlist
+	repos     []issueCreatorRepo
+}
+
+type issueCreatorRepo struct {
+	projectPath string // local disk path (may be empty = match-all)
+	owner       string
+	repo        string
+}
+
+// NewIssueCreator returns a comms.IssueCreator backed by the GitHub API.
+// repos maps local project paths to owner/repo pairs; the first entry whose
+// projectPath matches (or is empty) wins.  Pass at least one entry.
+func NewIssueCreator(client *Client, allowlist IssueAllowlist, entries ...IssueCreatorEntry) comms.IssueCreator {
+	repos := make([]issueCreatorRepo, len(entries))
+	for i, e := range entries {
+		repos[i] = issueCreatorRepo{projectPath: e.ProjectPath, owner: e.Owner, repo: e.Repo}
+	}
+	return &issueCreator{client: client, allowlist: allowlist, repos: repos}
+}
+
+// IssueCreatorEntry maps a local project path to a GitHub owner/repo.
+type IssueCreatorEntry struct {
+	ProjectPath string // local disk path; empty means "match any"
+	Owner       string
+	Repo        string
+}
+
+// CreateIssue implements comms.IssueCreator.
+func (c *issueCreator) CreateIssue(ctx context.Context, projectPath string, d comms.IssueDraft) (string, error) {
+	owner, repo, err := c.resolveRepo(projectPath)
+	if err != nil {
+		return "", err
+	}
+	issue, err := CreatePilotIssue(ctx, c.client, c.allowlist, owner, repo, d.Title, d.Body, d.Labels)
+	if err != nil {
+		return "", fmt.Errorf("github issue creation failed: %w", err)
+	}
+	return issue.HTMLURL, nil
+}
+
+func (c *issueCreator) resolveRepo(projectPath string) (owner, repo string, err error) {
+	// Exact path match first
+	for _, r := range c.repos {
+		if r.projectPath == projectPath {
+			return r.owner, r.repo, nil
+		}
+	}
+	// Empty projectPath or no match → first entry
+	if len(c.repos) > 0 {
+		return c.repos[0].owner, c.repos[0].repo, nil
+	}
+	return "", "", fmt.Errorf("no GitHub repo configured for project path %q", projectPath)
+}

--- a/internal/comms/commands.go
+++ b/internal/comms/commands.go
@@ -24,6 +24,7 @@ type CommandHandler struct {
 	stopTaskFunc       func(ctx context.Context, contextID string) error
 	listTasksFunc      func() string
 	briefGeneratorFunc func(ctx context.Context, contextID string) error // Platform-specific brief generation
+	issueIntakeFunc    func(ctx context.Context, contextID, text string) // Issue intake from /draft-issue
 }
 
 // NewCommandHandler creates a command handler with messenger and optional memory store.
@@ -77,6 +78,11 @@ func (c *CommandHandler) SetListTasksFunc(f func() string) {
 // SetBriefGeneratorFunc sets the brief generator function (platform-specific).
 func (c *CommandHandler) SetBriefGeneratorFunc(f func(ctx context.Context, contextID string) error) {
 	c.briefGeneratorFunc = f
+}
+
+// SetIssueIntakeFunc sets the issue intake function invoked by /draft-issue.
+func (c *CommandHandler) SetIssueIntakeFunc(f func(ctx context.Context, contextID, text string)) {
+	c.issueIntakeFunc = f
 }
 
 // HandleCommand routes slash commands to their handlers.
@@ -138,6 +144,12 @@ func (c *CommandHandler) HandleCommand(ctx context.Context, contextID, text stri
 		} else {
 			_ = c.messenger.SendText(ctx, contextID, "Usage: /pr <task description>\nForces PR creation even for ephemeral-looking tasks.")
 		}
+	case "/draft-issue":
+		if len(args) > 0 {
+			c.handleDraftIssue(ctx, contextID, strings.Join(args, " "))
+		} else {
+			_ = c.messenger.SendText(ctx, contextID, "Usage: /draft-issue <description>\nDrafts and creates a pilot-labeled GitHub issue.")
+		}
 	default:
 		_ = c.messenger.SendText(ctx, contextID, "Unknown command. Use /help for available commands.")
 	}
@@ -166,6 +178,7 @@ Task Commands
 /stop — Stop running task
 /nopr <task> — Execute without creating PR
 /pr <task> — Force PR creation
+/draft-issue <desc> — Create a pilot-labeled GitHub issue
 
 Quick Patterns
 • 07 or task 07 — Run TASK-07
@@ -576,5 +589,15 @@ func (c *CommandHandler) handleForcePR(ctx context.Context, contextID, descripti
 	} else {
 		_ = c.messenger.SendText(ctx, contextID,
 			fmt.Sprintf("🚀 Executing with PR: %s", TruncateText(description, 50)))
+	}
+}
+
+// handleDraftIssue creates a pilot-labeled GitHub issue from a freeform description.
+func (c *CommandHandler) handleDraftIssue(ctx context.Context, contextID, description string) {
+	if c.issueIntakeFunc != nil {
+		c.issueIntakeFunc(ctx, contextID, description)
+	} else {
+		_ = c.messenger.SendText(ctx, contextID,
+			"Issue intake is not available. Ensure bot and GitHub adapter are configured.")
 	}
 }

--- a/internal/comms/commands_test.go
+++ b/internal/comms/commands_test.go
@@ -30,6 +30,7 @@ func (m *mockMessenger) SendResult(ctx context.Context, contextID, threadID, tas
 }
 
 func (m *mockMessenger) SendChunked(ctx context.Context, contextID, threadID, content, prefix string) error {
+	m.messages = append(m.messages, content)
 	return nil
 }
 

--- a/internal/comms/factory.go
+++ b/internal/comms/factory.go
@@ -108,6 +108,7 @@ type HandlerDeps struct {
 	Bot            *BotConfig
 	MemberResolver MemberResolver
 	Store          *memory.Store
+	IssueCreator   IssueCreator
 	TaskIDPrefix   string
 	// ExecutorBackend is used by BuildClassifier to override the Anthropic model and URL.
 	// May be nil — the factory handles that gracefully.
@@ -131,6 +132,7 @@ func BuildHandler(deps HandlerDeps) *Handler {
 		Responder:      responder,
 		MemberResolver: deps.MemberResolver,
 		Store:          deps.Store,
+		IssueCreator:   deps.IssueCreator,
 		TaskIDPrefix:   deps.TaskIDPrefix,
 	})
 }

--- a/internal/comms/handler.go
+++ b/internal/comms/handler.go
@@ -36,6 +36,7 @@ type HandlerConfig struct {
 	Responder      *Responder
 	MemberResolver MemberResolver
 	Store          *memory.Store
+	IssueCreator   IssueCreator
 	// TaskIDPrefix is the adapter-specific prefix for task IDs (e.g., "TG", "SLACK").
 	TaskIDPrefix string
 	Log          *slog.Logger
@@ -54,12 +55,14 @@ type Handler struct {
 	responder      *Responder
 	memberResolver MemberResolver
 	store          *memory.Store
+	issueCreator   IssueCreator
 	cmdHandler     *CommandHandler
 	taskIDPrefix   string
 	log            *slog.Logger
 
 	activeProject map[string]string       // contextID -> projectPath
 	pendingTasks  map[string]*PendingTask // contextID -> pending task
+	pendingIssues map[string]*IssueDraft  // contextID -> in-progress issue draft
 	runningTasks  map[string]*RunningTask // contextID -> running task
 	lastSender    map[string]string       // contextID -> senderID
 	mu            sync.Mutex
@@ -95,10 +98,12 @@ func NewHandler(cfg *HandlerConfig) *Handler {
 		responder:      cfg.Responder,
 		memberResolver: cfg.MemberResolver,
 		store:          cfg.Store,
+		issueCreator:   cfg.IssueCreator,
 		taskIDPrefix:   prefix,
 		log:            lg,
 		activeProject:  make(map[string]string),
 		pendingTasks:   make(map[string]*PendingTask),
+		pendingIssues:  make(map[string]*IssueDraft),
 		runningTasks:   make(map[string]*RunningTask),
 		lastSender:     make(map[string]string),
 	}
@@ -138,6 +143,9 @@ func NewHandler(cfg *HandlerConfig) *Handler {
 			return out
 		})
 	}
+	cmd.SetIssueIntakeFunc(func(ctx context.Context, contextID, text string) {
+		h.handleIssueIntake(ctx, contextID, "", text)
+	})
 	h.cmdHandler = cmd
 
 	return h
@@ -230,6 +238,8 @@ func (h *Handler) HandleMessage(ctx context.Context, msg *IncomingMessage) {
 		h.handleChat(ctx, contextID, msg.ThreadID, text)
 	case intent.IntentTask:
 		h.handleTask(ctx, contextID, msg.ThreadID, text, msg.SenderID)
+	case intent.IntentIssueIntake:
+		h.handleIssueIntake(ctx, contextID, msg.ThreadID, text)
 	default:
 		// Unknown intent — clarify rather than auto-creating a task.
 		_ = h.messenger.SendText(ctx, contextID, "I didn't quite catch that — try /help, or rephrase your request.")
@@ -244,6 +254,11 @@ func (h *Handler) detectIntent(ctx context.Context, contextID, text string) inte
 	// Fast path: commands
 	if strings.HasPrefix(text, "/") {
 		return intent.IntentCommand
+	}
+
+	// Fast path: issue intake requests (before operational/question to avoid misclassification).
+	if intent.IsIssueIntakeRequest(text) {
+		return intent.IntentIssueIntake
 	}
 
 	// Fast path: operational queries (live daemon/queue state) — must precede

--- a/internal/comms/issue_intake.go
+++ b/internal/comms/issue_intake.go
@@ -1,0 +1,131 @@
+package comms
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/qf-studio/pilot/internal/intent"
+)
+
+// IssueDraft holds the LLM-drafted fields for a new GitHub issue.
+type IssueDraft struct {
+	Title  string
+	Body   string
+	Labels []string
+}
+
+// IssueCreator creates a GitHub issue for a given project.
+// The concrete implementation lives in internal/adapters/github to avoid import cycles.
+type IssueCreator interface {
+	// CreateIssue creates an issue and returns its HTML URL.
+	CreateIssue(ctx context.Context, projectPath string, d IssueDraft) (url string, err error)
+}
+
+// parseIssueDraft parses a JSON issue draft from LLM output.
+// Strips markdown code fences if present; always ensures "pilot" label is included.
+func parseIssueDraft(raw string) (IssueDraft, error) {
+	raw = strings.TrimSpace(raw)
+	// Strip markdown code fences
+	if strings.HasPrefix(raw, "```") {
+		raw = strings.TrimPrefix(raw, "```json")
+		raw = strings.TrimPrefix(raw, "```")
+		if idx := strings.LastIndex(raw, "```"); idx >= 0 {
+			raw = raw[:idx]
+		}
+		raw = strings.TrimSpace(raw)
+	}
+
+	var d struct {
+		Title  string   `json:"title"`
+		Body   string   `json:"body"`
+		Labels []string `json:"labels"`
+	}
+	if err := json.Unmarshal([]byte(raw), &d); err != nil {
+		return IssueDraft{}, fmt.Errorf("failed to parse issue draft JSON: %w — raw: %s", err, TruncateText(raw, 200))
+	}
+	if d.Title == "" {
+		return IssueDraft{}, fmt.Errorf("LLM returned empty issue title")
+	}
+
+	// Ensure "pilot" label is always present (locked decision: auto-execute).
+	hasPilot := false
+	for _, l := range d.Labels {
+		if l == "pilot" {
+			hasPilot = true
+			break
+		}
+	}
+	if !hasPilot {
+		d.Labels = append(d.Labels, "pilot")
+	}
+
+	return IssueDraft{Title: d.Title, Body: d.Body, Labels: d.Labels}, nil
+}
+
+// DraftIssue uses the LLM to draft a GitHub issue from a freeform message.
+// The returned IssueDraft always includes the "pilot" label.
+func (r *Responder) DraftIssue(ctx context.Context, history []intent.ConversationMessage, msg string) (IssueDraft, error) {
+	system := `You are Pilot, a developer assistant. Draft a GitHub issue from the user's description.
+
+Return ONLY a JSON object — no text before or after it:
+{
+  "title": "<conventional-commit title: type(scope): description>",
+  "body": "## Summary\n<1-2 sentence summary>\n\n## Acceptance Criteria\n- [ ] <criterion>",
+  "labels": ["pilot"]
+}
+
+RULES for the title:
+- Must start with a type: feat, fix, chore, refactor, test, docs, perf, build, ci, style
+- Format: type(scope): description  — e.g. "feat(gateway): add rate limiting"
+- scope is the affected subsystem (e.g. "gateway", "auth", "cli", "comms")
+- description is lowercase, imperative, no period at end`
+
+	raw, err := r.client.Answer(ctx, r.answerModel, system, history, msg)
+	if err != nil {
+		return IssueDraft{}, fmt.Errorf("LLM draft failed: %w", err)
+	}
+	return parseIssueDraft(raw)
+}
+
+// handleIssueIntake drafts a GitHub issue from the user's freeform message and creates it directly.
+func (h *Handler) handleIssueIntake(ctx context.Context, contextID, threadID, text string) {
+	if h.responder == nil {
+		_ = h.messenger.SendText(ctx, contextID, "Issue intake requires the bot module to be enabled (bot.enabled: true).")
+		return
+	}
+	if h.issueCreator == nil {
+		_ = h.messenger.SendText(ctx, contextID, "Issue creation requires GitHub to be configured (adapters.github).")
+		return
+	}
+
+	_ = h.messenger.SendText(ctx, contextID, "🎫 Drafting issue...")
+
+	var history []intent.ConversationMessage
+	if h.convStore != nil {
+		history = h.convStore.Get(contextID)
+	}
+
+	draft, err := h.responder.DraftIssue(ctx, history, text)
+	if err != nil {
+		h.log.Warn("DraftIssue failed", slog.Any("error", err))
+		_ = h.messenger.SendText(ctx, contextID, "❌ Failed to draft issue. Try being more specific about what you'd like to track.")
+		return
+	}
+
+	projectPath := h.getActiveProjectPath(contextID)
+	url, err := h.issueCreator.CreateIssue(ctx, projectPath, draft)
+	if err != nil {
+		h.log.Warn("CreateIssue failed", slog.Any("error", err), slog.String("title", draft.Title))
+		_ = h.messenger.SendText(ctx, contextID, fmt.Sprintf("❌ Failed to create issue: %s", err.Error()))
+		return
+	}
+
+	reply := fmt.Sprintf("✅ Issue created and queued for Pilot:\n\n*%s*\n%s", draft.Title, url)
+	_ = h.messenger.SendChunked(ctx, contextID, threadID, reply, "")
+	if h.convStore != nil {
+		h.convStore.Add(contextID, "assistant", TruncateText(reply, 500))
+	}
+}

--- a/internal/comms/issue_intake.go
+++ b/internal/comms/issue_intake.go
@@ -101,6 +101,22 @@ func (h *Handler) handleIssueIntake(ctx context.Context, contextID, threadID, te
 		return
 	}
 
+	// Guard: prevent parallel intakes on the same context (mirrors pendingTasks pattern).
+	h.mu.Lock()
+	if _, inFlight := h.pendingIssues[contextID]; inFlight {
+		h.mu.Unlock()
+		_ = h.messenger.SendText(ctx, contextID, "⚠️ An issue is already being drafted for this context. Please wait.")
+		return
+	}
+	placeholder := &IssueDraft{}
+	h.pendingIssues[contextID] = placeholder
+	h.mu.Unlock()
+	defer func() {
+		h.mu.Lock()
+		delete(h.pendingIssues, contextID)
+		h.mu.Unlock()
+	}()
+
 	_ = h.messenger.SendText(ctx, contextID, "🎫 Drafting issue...")
 
 	var history []intent.ConversationMessage

--- a/internal/comms/issue_intake_test.go
+++ b/internal/comms/issue_intake_test.go
@@ -1,0 +1,253 @@
+package comms
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/intent"
+)
+
+// mockIssueCreator records CreateIssue calls and returns canned results.
+type mockIssueCreator struct {
+	url   string
+	err   error
+	calls []mockCreateCall
+}
+
+type mockCreateCall struct {
+	projectPath string
+	draft       IssueDraft
+}
+
+func (m *mockIssueCreator) CreateIssue(_ context.Context, projectPath string, d IssueDraft) (string, error) {
+	m.calls = append(m.calls, mockCreateCall{projectPath: projectPath, draft: d})
+	return m.url, m.err
+}
+
+// TestParseIssueDraft_CleanJSON verifies clean JSON parsing.
+func TestParseIssueDraft_CleanJSON(t *testing.T) {
+	raw := `{"title":"feat(gateway): add rate limiting","body":"## Summary\nAdd rate limiting.","labels":["pilot"]}`
+	d, err := parseIssueDraft(raw)
+	if err != nil {
+		t.Fatalf("parseIssueDraft error: %v", err)
+	}
+	if d.Title != "feat(gateway): add rate limiting" {
+		t.Errorf("Title = %q", d.Title)
+	}
+	if d.Body != "## Summary\nAdd rate limiting." {
+		t.Errorf("Body = %q", d.Body)
+	}
+	if len(d.Labels) == 0 || d.Labels[0] != "pilot" {
+		t.Errorf("Labels = %v, want [pilot]", d.Labels)
+	}
+}
+
+// TestParseIssueDraft_MarkdownFences strips code fences.
+func TestParseIssueDraft_MarkdownFences(t *testing.T) {
+	raw := "```json\n{\"title\":\"fix(auth): handle nil token\",\"body\":\"body\",\"labels\":[]}\n```"
+	d, err := parseIssueDraft(raw)
+	if err != nil {
+		t.Fatalf("parseIssueDraft error: %v", err)
+	}
+	if d.Title != "fix(auth): handle nil token" {
+		t.Errorf("Title = %q", d.Title)
+	}
+	hasPilot := false
+	for _, l := range d.Labels {
+		if l == "pilot" {
+			hasPilot = true
+		}
+	}
+	if !hasPilot {
+		t.Errorf("expected 'pilot' in Labels, got %v", d.Labels)
+	}
+}
+
+// TestParseIssueDraft_AutoAddsPilotLabel verifies pilot label is always injected.
+func TestParseIssueDraft_AutoAddsPilotLabel(t *testing.T) {
+	raw := `{"title":"chore(deps): update go modules","body":"body","labels":["enhancement"]}`
+	d, err := parseIssueDraft(raw)
+	if err != nil {
+		t.Fatalf("parseIssueDraft error: %v", err)
+	}
+	hasPilot := false
+	for _, l := range d.Labels {
+		if l == "pilot" {
+			hasPilot = true
+		}
+	}
+	if !hasPilot {
+		t.Errorf("pilot label not added to %v", d.Labels)
+	}
+}
+
+// TestParseIssueDraft_EmptyTitle errors on empty title.
+func TestParseIssueDraft_EmptyTitle(t *testing.T) {
+	raw := `{"title":"","body":"body","labels":["pilot"]}`
+	_, err := parseIssueDraft(raw)
+	if err == nil {
+		t.Error("expected error for empty title")
+	}
+}
+
+// TestDraftIssue_CallsLLMAndParsesJSON verifies Responder.DraftIssue end-to-end.
+func TestDraftIssue_CallsLLMAndParsesJSON(t *testing.T) {
+	reply := `{"title":"feat(comms): add rate limiting","body":"body","labels":["pilot"]}`
+	r, a := newMockResponder(reply, "")
+	d, err := r.DraftIssue(context.Background(), nil, "add rate limiting to the comms layer")
+	if err != nil {
+		t.Fatalf("DraftIssue error: %v", err)
+	}
+	if d.Title != "feat(comms): add rate limiting" {
+		t.Errorf("Title = %q", d.Title)
+	}
+	if len(a.calls) == 0 {
+		t.Fatal("expected LLM call")
+	}
+	if !strings.Contains(a.calls[0].system, "conventional-commit") {
+		t.Errorf("system prompt missing conventional-commit guidance")
+	}
+}
+
+// TestDraftIssue_LLMError propagates errors.
+func TestDraftIssue_LLMError(t *testing.T) {
+	a := &mockAnswerer{err: errors.New("timeout")}
+	r := &Responder{client: a, answerModel: "claude-haiku-4-5-20251001"}
+	_, err := r.DraftIssue(context.Background(), nil, "create an issue")
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+// TestHandleIssueIntake_CreateIssue asserts CreateIssue called once with pilot label.
+func TestHandleIssueIntake_CreateIssue(t *testing.T) {
+	reply := `{"title":"feat(api): add endpoint","body":"body","labels":["pilot"]}`
+	responder, _ := newMockResponder(reply, "")
+	issueCreator := &mockIssueCreator{url: "https://github.com/owner/repo/issues/42"}
+	messenger := &mockMessenger{}
+
+	h := &Handler{
+		messenger:     messenger,
+		responder:     responder,
+		issueCreator:  issueCreator,
+		pendingIssues: make(map[string]*IssueDraft),
+		log:           slog.Default(),
+	}
+
+	h.handleIssueIntake(context.Background(), "ctx1", "", "create an issue to add a new API endpoint")
+
+	if len(issueCreator.calls) != 1 {
+		t.Fatalf("CreateIssue called %d times, want 1", len(issueCreator.calls))
+	}
+	call := issueCreator.calls[0]
+	hasPilot := false
+	for _, l := range call.draft.Labels {
+		if l == "pilot" {
+			hasPilot = true
+		}
+	}
+	if !hasPilot {
+		t.Errorf("CreateIssue called without pilot label: %v", call.draft.Labels)
+	}
+	if call.draft.Title != "feat(api): add endpoint" {
+		t.Errorf("Title = %q", call.draft.Title)
+	}
+}
+
+// TestHandleIssueIntake_NoResponder returns graceful message.
+func TestHandleIssueIntake_NoResponder(t *testing.T) {
+	messenger := &mockMessenger{}
+	h := &Handler{
+		messenger:     messenger,
+		responder:     nil,
+		issueCreator:  &mockIssueCreator{},
+		pendingIssues: make(map[string]*IssueDraft),
+		log:           slog.Default(),
+	}
+	h.handleIssueIntake(context.Background(), "ctx1", "", "file a ticket")
+	if len(messenger.messages) == 0 {
+		t.Fatal("expected a text message")
+	}
+	if !strings.Contains(messenger.messages[0], "bot module") {
+		t.Errorf("expected bot module hint in: %q", messenger.messages[0])
+	}
+}
+
+// TestHandleIssueIntake_NoIssueCreator returns graceful message.
+func TestHandleIssueIntake_NoIssueCreator(t *testing.T) {
+	responder, _ := newMockResponder(`{"title":"feat(x): y","body":"b","labels":[]}`, "")
+	messenger := &mockMessenger{}
+	h := &Handler{
+		messenger:     messenger,
+		responder:     responder,
+		issueCreator:  nil,
+		pendingIssues: make(map[string]*IssueDraft),
+		log:           slog.Default(),
+	}
+	h.handleIssueIntake(context.Background(), "ctx1", "", "file a ticket")
+	if len(messenger.messages) == 0 {
+		t.Fatal("expected a text message")
+	}
+	if !strings.Contains(messenger.messages[0], "GitHub") {
+		t.Errorf("expected GitHub hint in: %q", messenger.messages[0])
+	}
+}
+
+// TestHandleIssueIntake_CreateError surfaces create error to user.
+func TestHandleIssueIntake_CreateError(t *testing.T) {
+	reply := `{"title":"feat(api): add endpoint","body":"body","labels":["pilot"]}`
+	responder, _ := newMockResponder(reply, "")
+	issueCreator := &mockIssueCreator{err: errors.New("API error 422")}
+	messenger := &mockMessenger{}
+
+	h := &Handler{
+		messenger:     messenger,
+		responder:     responder,
+		issueCreator:  issueCreator,
+		pendingIssues: make(map[string]*IssueDraft),
+		log:           slog.Default(),
+	}
+	h.handleIssueIntake(context.Background(), "ctx1", "", "create an issue")
+
+	found := false
+	for _, txt := range messenger.messages {
+		if strings.Contains(txt, "Failed") || strings.Contains(txt, "failed") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected failure message in: %v", messenger.messages)
+	}
+}
+
+// TestIsIssueIntakeRequest covers recognition patterns.
+func TestIsIssueIntakeRequest(t *testing.T) {
+	positive := []string{
+		"create an issue to add rate limiting",
+		"file a ticket for the login bug",
+		"open an issue about the dashboard crash",
+		"raise a ticket for missing validation",
+		"log an issue for slow queries",
+		"report an issue with auth",
+	}
+	for _, text := range positive {
+		if !intent.IsIssueIntakeRequest(text) {
+			t.Errorf("IsIssueIntakeRequest(%q) = false, want true", text)
+		}
+	}
+
+	negative := []string{
+		"fix the login bug",
+		"add a rate limiter to the gateway",
+		"what issues are open?",
+	}
+	for _, text := range negative {
+		if intent.IsIssueIntakeRequest(text) {
+			t.Errorf("IsIssueIntakeRequest(%q) = true, want false", text)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,9 +78,10 @@ type BotConfig struct {
 
 	// Bounded file-retrieval for answering codebase questions (TASK-375).
 	Retrieval BotRetrievalConfig `yaml:"retrieval,omitempty"`
-	// Reserved for future phases (TASK-376/377); parsed but unused.
-	IssueIntake struct{} `yaml:"issue_intake,omitempty"`
-	Voice       struct{} `yaml:"voice,omitempty"`
+	// Conversational issue intake (TASK-376 / GH-3672).
+	IssueIntake BotIssueIntakeConfig `yaml:"issue_intake,omitempty"`
+	// Reserved for future phases (TASK-377).
+	Voice struct{} `yaml:"voice,omitempty"`
 }
 
 // BotRetrievalConfig controls bounded file-retrieval for grounded Q&A (TASK-375).
@@ -90,6 +91,13 @@ type BotRetrievalConfig struct {
 	Enabled  bool `yaml:"enabled"`
 	MaxFiles int  `yaml:"max_files"` // default 8
 	MaxBytes int  `yaml:"max_bytes"` // default 24000
+}
+
+// BotIssueIntakeConfig controls conversational issue intake (TASK-376).
+// When AutoLabelPilot is true (default), drafted issues are tagged "pilot"
+// so the daemon picks them up automatically.
+type BotIssueIntakeConfig struct {
+	AutoLabelPilot bool `yaml:"auto_label_pilot"`
 }
 
 

--- a/internal/intent/classifier.go
+++ b/internal/intent/classifier.go
@@ -69,10 +69,13 @@ func (c *AnthropicClient) Classify(ctx context.Context, messages []ConversationM
 - question: Questions about code/project (e.g., "what files handle auth?", "how does X work?")
 - chat: Conversational/opinion-seeking (e.g., "what do you think about...", "should I...")
 - task: Requests to make changes (e.g., "add a button", "fix the bug", "implement feature X")
+- issue_intake: Requests to file a new GitHub issue (e.g., "create an issue to...", "file a ticket for...", "open an issue about...", "raise a ticket")
 
 IMPORTANT:
 - "What do you think about adding X?" is CHAT (asking opinion), not TASK
 - "Add X to the project" is TASK (direct instruction)
+- "Create an issue to add rate limiting" is ISSUE_INTAKE (file a ticket), not TASK
+- "File a ticket for the login bug" is ISSUE_INTAKE, not TASK
 - Questions that don't require code changes are QUESTION
 - "What's in the queue?" or "anything running?" are OPERATIONAL (live state), not QUESTION
 - Be conservative: when in doubt between task and chat, prefer chat
@@ -174,6 +177,8 @@ Respond with JSON only: {"intent": "...", "confidence": 0.0-1.0}`
 		return IntentChat, nil
 	case "task":
 		return IntentTask, nil
+	case "issue_intake":
+		return IntentIssueIntake, nil
 	default:
 		return IntentTask, nil // Default fallback
 	}

--- a/internal/intent/intent.go
+++ b/internal/intent/intent.go
@@ -17,6 +17,7 @@ const (
 	IntentQuestion    Intent = "question"
 	IntentChat        Intent = "chat"
 	IntentTask        Intent = "task"
+	IntentIssueIntake Intent = "issue_intake"
 )
 
 // Common greeting patterns
@@ -55,6 +56,28 @@ var chatPatterns = []string{
 	"what do you think", "opinion on", "thoughts about",
 	"do you recommend", "should i", "is it better",
 	"discuss", "let's talk about", "lets talk about",
+}
+
+// Issue intake patterns - requests to file a new GitHub issue via the bot.
+var issueIntakePatterns = []string{
+	"create an issue", "create issue", "create a ticket", "create ticket",
+	"file an issue", "file a ticket", "file issue", "file ticket",
+	"open an issue", "open a ticket", "open issue", "open ticket",
+	"raise an issue", "raise a ticket", "raise issue",
+	"log a ticket", "log an issue", "log ticket", "log issue",
+	"report an issue", "report a bug", "submit a ticket",
+	"draft an issue", "draft a ticket", "new issue for", "new ticket for",
+}
+
+// IsIssueIntakeRequest reports whether text is asking to file a new GitHub issue.
+func IsIssueIntakeRequest(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	for _, p := range issueIntakePatterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // Operational patterns - queries about live daemon/queue state.
@@ -119,7 +142,12 @@ func DetectIntent(message string) Intent {
 		return IntentPlanning
 	}
 
-	// 5. Check for chat/conversational (opinion-seeking, no action words)
+	// 5. Check for issue intake requests before chat/task (more specific).
+	if IsIssueIntakeRequest(msg) {
+		return IntentIssueIntake
+	}
+
+	// 5.1 Check for chat/conversational (opinion-seeking, no action words)
 	// Checked before questions because "what do you think" starts with "what"
 	if IsChat(msg) && !ContainsActionWord(msg) {
 		return IntentChat
@@ -392,6 +420,8 @@ func (i Intent) Description() string {
 		return "Chat"
 	case IntentTask:
 		return "Task"
+	case IntentIssueIntake:
+		return "IssueIntake"
 	default:
 		return "Unknown"
 	}


### PR DESCRIPTION
## Summary

Closes #3672 — Bot Module Phase 4: conversational issue intake.

- **NL trigger**: "create an issue to…", "file a ticket…", etc. → `IntentIssueIntake` → `handleIssueIntake`
- **Command trigger**: `/draft-issue <description>` → same handler
- **Flow**: Responder.DraftIssue (LLM → conventional-commit title + markdown body + `pilot` label) → `IssueCreator.CreateIssue` → returns GitHub issue URL. No confirmation gate (locked decision: auto-execute).
- **Guardrails**: `github.CreatePilotIssue` enforces conventional-commit title regex and `IssueAllowlist`.

## Files changed

| File | Change |
|---|---|
| `internal/comms/issue_intake.go` | `IssueDraft`, `IssueCreator` interface, `Responder.DraftIssue`, `Handler.handleIssueIntake` |
| `internal/adapters/github/issue_creator.go` | Concrete `comms.IssueCreator` via `github.CreatePilotIssue` |
| `internal/intent/intent.go` | `IntentIssueIntake` const, `IsIssueIntakeRequest()` fast-path |
| `internal/intent/classifier.go` | `issue_intake` in LLM classifier prompt + switch |
| `internal/comms/commands.go` | `/draft-issue` command, `SetIssueIntakeFunc`, `handleDraftIssue` |
| `internal/comms/handler.go` | `pendingIssues`, `issueCreator` fields; dispatch in switch + detectIntent fast-path |
| `internal/comms/factory.go` | `IssueCreator` in `HandlerDeps` / `BuildHandler` |
| `internal/config/config.go` | `BotIssueIntakeConfig` replaces `struct{}` stub |
| `cmd/pilot/main.go` | Builds `commsIssueCreator` from `cfg.Adapters.GitHub`, wired into Telegram + Slack |
| `internal/comms/issue_intake_test.go` | 10 tests covering parse, DraftIssue, handleIssueIntake, intent patterns |

## Test plan

- [x] `go test ./internal/comms/... ./internal/adapters/github/... ./internal/intent/... ./internal/config/...` — all pass
- [x] `go build ./...` — clean
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `IssueCreator` mock test asserts `CreateIssue` called once with `pilot` label
- [x] NL patterns (`IsIssueIntakeRequest`) tested for true/false cases