### PR TITLE
fix(llm): send required max_tokens, drop output_config

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -14,6 +14,11 @@ import (
 
 const defaultAPIURL = "https://api.anthropic.com/v1/messages"
 
+// maxTokens caps the response length for bot replies (chat, grounded Q&A, issue
+// drafts). The Anthropic Messages API REQUIRES max_tokens — omitting it returns
+// HTTP 400 "max_tokens: Field required".
+const maxTokens = 2048
+
 // Client sends requests to the Anthropic Messages API.
 type Client struct {
 	apiKey     string
@@ -50,12 +55,10 @@ func (c *Client) Answer(ctx context.Context, model, system string, history []int
 	})
 
 	body := map[string]interface{}{
-		"model":    model,
-		"system":   system,
-		"messages": messages,
-		"output_config": map[string]interface{}{
-			"effort": "low",
-		},
+		"model":      model,
+		"max_tokens": maxTokens,
+		"system":     system,
+		"messages":   messages,
 	}
 
 	jsonBody, err := json.Marshal(body)

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -111,6 +111,16 @@ func TestAnswer_WithHistory(t *testing.T) {
 	if len(msgs) != 3 {
 		t.Errorf("expected 3 messages (2 history + 1 user), got %d", len(msgs))
 	}
+
+	// max_tokens is REQUIRED by the Anthropic Messages API — omitting it 400s.
+	mt, ok := capturedBody["max_tokens"].(float64)
+	if !ok || mt <= 0 {
+		t.Errorf("expected positive max_tokens in request body, got %v", capturedBody["max_tokens"])
+	}
+	// output_config is non-standard and must not be sent.
+	if _, present := capturedBody["output_config"]; present {
+		t.Errorf("output_config must not be in request body")
+	}
 }
 
 func TestAnswer_Non200(t *testing.T) {
@@ -166,11 +176,14 @@ func TestAnswer_RequestShape(t *testing.T) {
 	if capturedBody["system"] != "my-system" {
 		t.Errorf("system: got %v, want my-system", capturedBody["system"])
 	}
-	cfg, ok := capturedBody["output_config"].(map[string]interface{})
-	if !ok {
-		t.Fatal("output_config missing or wrong type")
+	// max_tokens is REQUIRED by the Anthropic Messages API; omitting it 400s.
+	mt, ok := capturedBody["max_tokens"].(float64)
+	if !ok || mt <= 0 {
+		t.Errorf("max_tokens: got %v, want positive int", capturedBody["max_tokens"])
 	}
-	if cfg["effort"] != "low" {
-		t.Errorf("effort: got %v, want low", cfg["effort"])
+	// output_config is non-standard and must not be sent (it was the cause of the
+	// 400 "max_tokens: Field required" regression — see fix/llm-max-tokens).
+	if _, present := capturedBody["output_config"]; present {
+		t.Error("output_config must not be in request body")
 	}
 }


### PR DESCRIPTION
## Problem
The conversational bot replied "Sorry, I couldn't process that." to every message. Root cause: `internal/llm/client.go` omitted `max_tokens` (REQUIRED by the Anthropic Messages API) and sent a non-standard `output_config{effort:low}`. Every call returned **HTTP 400 `max_tokens: Field required`** → `Responder.Chat` errored → the handler's fallback message.

Reproduced live: removing output_config + adding `max_tokens` turns the same request from 400 → 200.

## Fix
- Add `max_tokens: 2048`, remove `output_config`.
- Fix `TestAnswer_RequestShape` (it **asserted output_config present** and never checked max_tokens — it enforced the bug) + assert max_tokens in `TestAnswer_WithHistory`.

## Test
`go test ./internal/llm/...` green; gofmt + vet clean.