### PR TITLE
docs(nav): bot-debug pitfalls (max_tokens, auto-upgrade revert)

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -130,6 +130,23 @@
           "epic-decomposition",
           "git-operations"
         ]
+      },
+      "anthropic-api": {
+        "label": "Anthropic API",
+        "description": "Direct Anthropic Messages API calls (x-api-key, max_tokens required) used by the bot module's llm.Client — distinct from the Claude Code subprocess the executor uses",
+        "related": [
+          "llm-integration",
+          "claude-code-integration"
+        ]
+      },
+      "release": {
+        "label": "Release / Versioning",
+        "description": "Tag-driven GoReleaser release pipeline (GitHub release + Homebrew); the daemon hot-upgrades to the latest release",
+        "related": [
+          "autopilot",
+          "hot-upgrade",
+          "git-operations"
+        ]
       }
     },
     "tasks": {
@@ -669,6 +686,38 @@
         "created": "2026-06-26",
         "file": ".agent/knowledge/memories/patterns/pattern_fast_conversational_path_vs_executor.md",
         "origin_task": "TASK-377"
+      },
+      "mem-039": {
+        "type": "pitfall",
+        "summary": "Bot's direct LLM client (internal/llm/client.go) omitted required max_tokens and sent non-standard output_config{effort:low}, so every Anthropic Messages call 400'd ('max_tokens: Field required') and the bot replied 'Sorry, I couldn't process that.' Shipped GREEN because TestAnswer_RequestShape asserted output_config present and never checked max_tokens — the test encoded the bug. Diagnose request-shape bugs with curl (real key): code's request → 400, +max_tokens/-output_config → 200, in 2 calls. Fixed v2.200.1 (#3700): add max_tokens(2048), drop output_config, tests assert both. Lesson (again, see mem-036): assert the REQUIRED fields, not the optional ones.",
+        "concepts": [
+          "anthropic-api",
+          "llm-integration",
+          "testing",
+          "verification"
+        ],
+        "confidence": 0.95,
+        "severity": "high",
+        "created": "2026-06-26",
+        "incident": "2026-06-26: conversational bot live on Slack returned 'Sorry, I couldn't process that' to every message. Root cause max_tokens missing from llm.Client.Answer; output_config non-standard. Fixed in #3700, shipped v2.200.1.",
+        "file": ".agent/knowledge/memories/pitfalls/bug_llm_missing_max_tokens.md",
+        "origin_task": "TASK-374"
+      },
+      "mem-040": {
+        "type": "pitfall",
+        "summary": "Daemon hot-upgrades to the latest GitHub RELEASE and re-execs (pid preserved → ps lstart looks unchanged while the on-disk binary swaps). A dev binary cp'd to ~/.local/bin/pilot reverts within ~20min to the last release. A fix merged to main is NOT in the running daemon until a release containing it is cut (autopilot shouldTriggerRelease gap). Observed 2026-06-26: 29MB dev fix at 12:32 reverted to 20.6MB v2.200.0 release by 12:52, bot kept failing. Durable fix: tag-driven release (mem-022) with the fix → pilot upgrade (prompts y/N) → restart. v2.200.1 held because it's the latest release. Confirm running binary via lsof txt + stat size + pilot version, not lstart alone.",
+        "concepts": [
+          "hot-upgrade",
+          "release",
+          "autopilot",
+          "git-operations"
+        ],
+        "confidence": 0.9,
+        "severity": "medium",
+        "created": "2026-06-26",
+        "incident": "2026-06-26: shipping the bot max_tokens fix — dev binary installs (12:32) auto-reverted to pre-fix v2.200.0 release (12:52); only cutting v2.200.1 and pilot-upgrading made the fix stick in the live daemon.",
+        "file": ".agent/knowledge/memories/pitfalls/bug_daemon_autoupgrade_reverts_dev_binary.md",
+        "origin_task": "TASK-374"
       }
     }
   },
@@ -887,6 +936,26 @@
       "from": "mem-038",
       "to": "mem-036",
       "type": "references"
+    },
+    {
+      "from": "mem-039",
+      "to": "anthropic-api",
+      "type": "about"
+    },
+    {
+      "from": "mem-039",
+      "to": "mem-036",
+      "type": "relates-to"
+    },
+    {
+      "from": "mem-040",
+      "to": "hot-upgrade",
+      "type": "about"
+    },
+    {
+      "from": "mem-040",
+      "to": "release",
+      "type": "about"
     }
   ]
 }

--- a/.agent/knowledge/memories/pitfalls/bug_daemon_autoupgrade_reverts_dev_binary.md
+++ b/.agent/knowledge/memories/pitfalls/bug_daemon_autoupgrade_reverts_dev_binary.md
@@ -1,0 +1,46 @@
+---
+name: the daemon auto-upgrades to the latest RELEASE, so a dev binary cp'd into ~/.local/bin/pilot gets reverted within ~20min — ship fixes as releases, not local builds
+description: When testing a fix in the live daemon, building a dev binary and cp-ing it to ~/.local/bin/pilot then restarting does NOT stick. Pilot's hot-upgrade pulls the latest GitHub RELEASE and re-execs (pid preserved, so `ps lstart` looks unchanged while the on-disk binary mtime/size/version change underneath). Observed 2026-06-26: installed a 29MB dev build of the bot max_tokens fix at 12:32; by 12:52 ~/.local/bin/pilot was back to the 20.6MB v2.200.0 RELEASE (pre-fix), and the bot kept failing. The fix (#3700) was on main but in NO release yet (autopilot's shouldTriggerRelease gap), so the daemon had nothing newer to pull. Durable path: cut a release (tag-driven, mem-022) that contains the fix, then `pilot upgrade` → restart. v2.200.1 fixed it for good because it became the latest release.
+type: pitfall
+---
+**Symptom:** you build a fix, `cp` it to `~/.local/bin/pilot`, restart the daemon, test
+— still broken. Repeat — still broken. The dev binary silently reverts.
+
+**Cause:** the daemon **hot-upgrades to the latest GitHub _release_** and re-execs itself.
+The re-exec preserves the pid (and `ps -o lstart` keeps showing the *original* start time),
+so the process *looks* unchanged while the binary it's running was swapped underneath. The
+on-disk `~/.local/bin/pilot` flips from your dev build back to the latest release:
+- dev `go build` → ~29MB (with symbols), `pilot version` = `1.0.0`
+- release (GoReleaser, stripped) → ~20.6MB, `pilot version` = `2.200.x`
+
+Because a fix merged to `main` is **not in a release until one is cut** (and autopilot's
+`shouldTriggerRelease()` doesn't reliably fire — known P1 gap), the daemon's auto-upgrade
+keeps pulling the last *release*, which predates the fix. So a `main`-correct fix can still
+be absent from the running daemon.
+
+**How to confirm which binary is actually running:**
+```bash
+PID=$(pgrep -f 'pilot start' | head -1)
+lsof -p "$PID" | awk '$4=="txt"{print $NF}'      # the executable file
+stat -f '%Sm %z' ~/.local/bin/pilot               # mtime + size (release ≈20MB, dev ≈29MB)
+~/.local/bin/pilot version                         # 1.0.0 = dev, 2.x = release
+```
+A start time *earlier* than the binary's mtime means the process predates the current
+on-disk binary — it's holding an older image (restart needed), OR it re-exec'd to a newer
+one. Cross-check `version` + size, don't trust `lstart` alone.
+
+**How to apply — ship fixes as releases, not local builds:**
+1. Merge the fix to `main`.
+2. Cut a release that contains it — tag-driven (see [[learning_pilot_release_and_binary_path]]
+   / mem-022): `git tag vX.Y.Z origin/main && git push origin vX.Y.Z` → GoReleaser publishes
+   GitHub release + Homebrew. (Don't wait on autopilot's auto-release; it may not fire.)
+3. `pilot upgrade` (it prompts `[y/N]` — pipe `printf 'y\n' |` in non-interactive shells)
+   → updates `~/.local/bin/pilot` to the new release.
+4. **Restart the daemon** — `pilot upgrade` swaps the file but the running process keeps the
+   old image until restart (or its next hot-upgrade re-exec).
+5. The fix is now durable: it's the *latest* release, so the auto-upgrade has nothing older
+   to revert to.
+
+A dev-binary `cp` is fine for a 30-second smoke test, but expect it to be reverted within
+~20min by the next hot-upgrade. Relates to [[learn_restart_vs_rebuild_stale_binary]] (mem-025)
+and [[learning_pilot_release_and_binary_path]] (mem-020) — same binary-path family.

--- a/.agent/knowledge/memories/pitfalls/bug_llm_missing_max_tokens.md
+++ b/.agent/knowledge/memories/pitfalls/bug_llm_missing_max_tokens.md
@@ -1,0 +1,55 @@
+---
+name: bot's direct LLM client omitted required max_tokens (and a test asserted the buggy output_config) → every chat/Q&A/intake call 400'd
+description: internal/llm/client.go (the bot module's direct Anthropic Messages client) built its request body with model+system+messages+output_config{effort:low} but NO max_tokens, which the Anthropic Messages API REQUIRES. Every Responder.Chat/Answer/DraftIssue call returned HTTP 400 "max_tokens: Field required", so the bot replied "Sorry, I couldn't process that." live on Slack. It shipped GREEN because TestAnswer_RequestShape asserted output_config was PRESENT and never checked max_tokens — the test encoded the bug. output_config{effort:low} is also non-standard (copied from the never-enabled classifier) and isn't a valid Messages param. Fixed v2.200.1 (#3700): add max_tokens (2048), drop output_config, and make the tests assert max_tokens present + output_config absent.
+type: pitfall
+---
+The conversational bot replied **"Sorry, I couldn't process that. Try rephrasing?"**
+to every Slack message. That string is `handleChat`'s non-timeout error branch —
+i.e. `Responder.Chat()` returned an error. The error was the Anthropic API call.
+
+**Root cause:** `internal/llm/client.go` `Answer()` built the request body as
+```go
+body := map[string]interface{}{
+    "model": model, "system": system, "messages": messages,
+    "output_config": map[string]interface{}{"effort": "low"},   // non-standard
+    // NO max_tokens
+}
+```
+The Anthropic **Messages API requires `max_tokens`**. Omitting it →
+`HTTP 400 {"type":"invalid_request_error","message":"max_tokens: Field required"}`.
+`output_config{effort:low}` is **not** a Messages-API field — it was copied from
+`internal/intent/classifier.go`, whose classifier was never enabled (`llm_classifier: null`),
+so the bogus shape was never exercised until the bot used it for real.
+
+**Why it shipped green (the verification gap, again):** `TestAnswer_RequestShape`
+**asserted `output_config` was present** and `effort=="low"`, and **never checked
+`max_tokens`**. The test codified the broken request, so CI stayed green. This is the
+same lesson as [[bug_sdk_command_action_dropped]] (mem-036): *assert the thing the bug
+is about*. A request-shape test must assert the fields the API actually requires.
+
+**How it was diagnosed (fast):** reproduce the exact request with `curl` using the
+real key —
+- request as the code sent it (no max_tokens, with output_config) → **400 "max_tokens: Field required"**
+- same request + `max_tokens` − `output_config` → **200**, real answer.
+That isolates "the key/model/auth are fine; the client request shape is wrong" in two
+calls, without needing daemon logs (the daemon logs to the `--dashboard` TUI, ungreppable).
+
+**Fix (v2.200.1, PR #3700):**
+```go
+body := map[string]interface{}{
+    "model": model, "max_tokens": maxTokens /*2048*/, "system": system, "messages": messages,
+}
+```
+plus tests now assert `max_tokens` is a positive number in the body and `output_config`
+is absent.
+
+**How to apply:**
+- Any Anthropic **Messages API** request MUST include `max_tokens`. There is no default.
+- Don't copy `output_config`/`effort` into Messages requests — it's not a Messages field;
+  control output with `max_tokens` + model choice.
+- A "request-shape" unit test must assert the **required** fields (max_tokens, model,
+  messages), not just the optional ones. A test that asserts a field the API rejects is
+  worse than no test — it makes CI vouch for the bug.
+- When a chat/LLM feature errors with a generic user-facing fallback, reproduce the exact
+  outbound request with `curl` before touching code — it separates request-shape bugs from
+  auth/model/runtime bugs in ~2 calls.


### PR DESCRIPTION
Two reusable lessons from getting the conversational bot working live:

- **mem-039** — `internal/llm/client.go` omitted required `max_tokens` (and sent non-standard `output_config`), 400ing every call; a test *asserted the buggy output_config* and never checked max_tokens. Fixed in #3700/v2.200.1.
- **mem-040** — the daemon hot-upgrades to the latest *release*, so dev-binary `cp`s into `~/.local/bin/pilot` revert (~20min). Ship fixes as releases (tag-driven), then `pilot upgrade` + restart.

Files + graph nodes (mem-039/040), concepts `anthropic-api`/`release`, edges to mem-036/hot-upgrade.