### PR TITLE
feat(api): add /ping health check endpoint

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -306,6 +306,7 @@
 | Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |
 | OpenAI-compatible direct backend | ✅ | executor | `type: openai-api` | `executor.openai` | Direct /v1/chat/completions for OpenAI, OpenRouter, Groq, Synthetic, vLLM, Ollama (v2.105.0, GH-2382) |
+| Ping health check | ✅ | gateway | - | - | `/ping` → `pong`, no auth, no DB (v2.200.2, GH-3705) |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |
 | External-merge metrics | ✅ | autopilot | - | - | Record PRsMerged/IssuesProcessed/PRTimeToMerge for externally-merged PRs via scanner (v2.147.0, GH-2981) |

--- a/docs/content/deployment/monitoring.mdx
+++ b/docs/content/deployment/monitoring.mdx
@@ -368,6 +368,7 @@ Create a status page with health endpoints:
 
 | Endpoint | Check | Expected |
 |----------|-------|----------|
+| `/ping` | Lightweight alive check | 200 OK, body `pong` |
 | `/health` | Basic | 200 OK |
 | `/ready` | Component readiness | 200 when ready |
 | `/live` | Liveness | 200 when alive |

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -201,6 +201,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("/ws/dashboard", s.handleDashboardWebSocket)
 
 	// Public endpoints (no auth required)
+	mux.HandleFunc("/ping", s.handlePing)
 	mux.HandleFunc("/health", s.handleHealth)
 	mux.HandleFunc("/ready", s.handleReady)
 	mux.HandleFunc("/live", s.handleLive)
@@ -364,6 +365,13 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 		s.router.HandleMessage(session, message)
 	}
+}
+
+// handlePing is a lightweight health check that returns "pong" without
+// touching the database or any external service.
+func (s *Server) handlePing(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = w.Write([]byte("pong"))
 }
 
 // handleHealth returns server health status

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -38,6 +38,30 @@ func TestNewServer(t *testing.T) {
 	}
 }
 
+func TestPingEndpoint(t *testing.T) {
+	config := &Config{Host: "127.0.0.1", Port: 9090}
+	server := NewServer(config)
+
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	w := httptest.NewRecorder()
+
+	server.handlePing(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if body != "pong" {
+		t.Errorf("Expected body 'pong', got '%s'", body)
+	}
+
+	ct := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("Expected Content-Type text/plain, got '%s'", ct)
+	}
+}
+
 func TestHealthEndpoint(t *testing.T) {
 	config := &Config{Host: "127.0.0.1", Port: 9090}
 	server := NewServer(config)


### PR DESCRIPTION
## Summary

- Adds `GET /ping` as a lightweight health check endpoint registered in the public (no-auth) section of the gateway
- Returns `200 OK` with plain-text body `pong`; no database or external service calls
- Documented in `docs/content/deployment/monitoring.mdx` health check table and `.agent/system/FEATURE-MATRIX.md`

## Test plan

- [ ] `TestPingEndpoint` passes (added in `internal/gateway/server_test.go`)
- [ ] All existing gateway tests continue to pass
- [ ] `go build ./...` succeeds
- [ ] `curl http://localhost:9090/ping` returns `pong` when daemon is running

Closes #3705