### PR TITLE
docs(bot): document conversational bot module (chat, grounded Q&A, issue intake)

### DIFF
--- a/docs/content/concepts/model-routing.mdx
+++ b/docs/content/concepts/model-routing.mdx
@@ -4,6 +4,10 @@ import { Callout } from 'nextra/components'
 
 Pilot classifies every incoming task by complexity before execution begins. This classification drives three routing decisions: which model handles the task, how long it's allowed to run, and how much reasoning effort the model applies. The result is lower cost for simple work and deeper reasoning for architectural changes — automatically, with no manual intervention.
 
+<Callout type="info">
+This page covers the **executor path** — how code-writing tasks pick a model. Conversational messages (chat, questions, issue intake) take a separate, faster path with its own Haiku classifier. See the [Conversational Bot](/features/conversational-bot) feature guide.
+</Callout>
+
 ## The Five Complexity Levels
 
 Every task maps to one of five levels. Detection runs against the combined issue title and description.
@@ -391,3 +395,4 @@ Issue arrives
 
 - **[Architecture](/concepts/architecture)** — Full system architecture and autopilot state machine
 - **[Autopilot Mode](/features/autopilot)** — CI monitoring, auto-merge, and feedback loops
+- **[Conversational Bot](/features/conversational-bot)** — the separate fast path for chat, code Q&A, and issue intake

--- a/docs/content/features/_meta.js
+++ b/docs/content/features/_meta.js
@@ -1,4 +1,5 @@
 export default {
+  "conversational-bot": "Conversational Bot",
   telegram: "Telegram Bot",
   github: "GitHub Integration",
   dashboard: "Dashboard TUI",

--- a/docs/content/features/conversational-bot.mdx
+++ b/docs/content/features/conversational-bot.mdx
@@ -1,0 +1,201 @@
+import { Callout, Tabs } from 'nextra/components'
+
+# Conversational Bot
+
+The conversational bot is Pilot's **fast response path**. When enabled, chat, greeting, question, and issue-intake messages are answered directly through the Anthropic API in **~1–2 seconds** — instead of spinning up the full Claude Code executor, which takes **15–30 seconds** and is built for writing code, not holding a conversation.
+
+The result: you can talk to Pilot in Slack or Telegram like a teammate — ask what a function does, get a diagram, or turn a sentence into a tracked issue — without paying executor latency for every message.
+
+<Callout type="info">
+The bot is **opt-in** (`bot.enabled: false` by default). It needs an Anthropic API key, set via `bot.api_key` or the `ANTHROPIC_API_KEY` environment variable. Code execution still flows through Claude Code as usual — the bot only handles the conversational intents.
+</Callout>
+
+## Two Response Paths
+
+Every inbound message is classified by intent, then routed to one of two paths:
+
+| Path | Latency | Handles | Backed by |
+|------|---------|---------|-----------|
+| **Conversational** (bot) | ~1–2s chat, ~2–4s grounded Q&A | greetings, chat, code questions, issue intake | `internal/llm` → Anthropic API |
+| **Executor** (Claude Code) | 15–30s+ | tasks that change code, research, planning | Claude Code subprocess |
+
+When the bot is disabled, every message that isn't a `/`-command falls through to the executor — the pre-bot behavior.
+
+## Intent Routing
+
+Routing is driven by a **Haiku classifier** (`claude-haiku-4-5-20251001`). It is the natural-language router; a regex layer only fast-paths `/`-commands and obvious greetings.
+
+The classifier applies a **deliverable test** — *what does the user want to receive?*
+
+| The user wants… | Intent | Routed to |
+|-----------------|--------|-----------|
+| A greeting / small talk | `greeting`, `chat` | Bot — instant reply |
+| An answer, explanation, **diagram**, or summary about the code | `question` | Bot — grounded Q&A |
+| Files changed / a PR opened | `task` | Executor |
+| A new issue filed / ticket raised | `issue_intake` | Bot drafts → GitHub |
+| Live daemon or queue state | `operational` | Inline store-backed handler |
+| Deep multi-file analysis | `research` | Executor (research mode) |
+| An implementation plan before coding | `planning` | Executor (planning mode) |
+
+<Callout type="warning">
+Verbs like **draw, diagram, show, outline, sketch, explain, summarize** ask for an *answer*, not a code change — they route to `question`, not `task`. This is the deliverable test in action: an earlier classifier prompt misrouted "draw the architecture" to a code task ([#3703](https://github.com/qf-studio/pilot/issues/3703), v2.200.2).
+</Callout>
+
+The classifier runs with a **2-second timeout**. On timeout or API error it falls back to keyword matching, so the bot degrades gracefully rather than blocking.
+
+## The Three Capabilities
+
+### 1. Chat & Greeting
+
+The fast path. Greetings and conversational messages get a direct reply from the bot's `model` (Haiku by default) with a 2048-token cap. If a [persona](#persona) is configured, it's prepended to the system prompt so Pilot answers in a consistent voice.
+
+### 2. Grounded Q&A
+
+Code questions are answered against **bounded file retrieval** — the bot scores files in the active project by path relevance, reads the top matches into context (capped by `max_files` and `max_bytes`), and answers from that excerpt set in **~2–4 seconds**.
+
+```
+"how does the signal parser decide intent?"
+   → score files by path keywords
+   → read top 8 files (≤ 24 KB total)
+   → answer from excerpts
+```
+
+If a question is **too broad** (e.g. "explain the whole repo"), retrieval surfaces too many candidates and the bot automatically **falls back to the executor**, which has full codebase tools and a longer budget. You don't have to choose the path — the bot decides.
+
+<Callout type="info">
+Grounded Q&A defaults to the bot's `model`. For higher-quality code answers, set `answer_model: "claude-sonnet-4-6"` — Sonnet handles reasoning-heavy questions better while greetings stay cheap on Haiku.
+</Callout>
+
+### 3. Conversational Issue Intake
+
+Turn a freeform sentence into a structured, tracked issue. The bot drafts a `{title, body, labels}` payload from your message and opens it on GitHub.
+
+```
+You (Slack):  "create an issue to add a /ping health endpoint"
+Bot:          drafts issue → opens #3705 on GitHub (labeled `pilot`)
+Daemon:       picks up #3705 → implements → opens PR #3706 → merged
+```
+
+This is the full **talk → ticket → PR** loop: a sentence in chat became a merged pull request, hands-off. Drafted issues are always tagged `pilot` so the daemon auto-picks them.
+
+<Callout type="warning">
+Issue intake files to the repo configured under `adapters.github.repo`, **not** necessarily the chat session's active project — see [Limitations](#limitations--gotchas).
+</Callout>
+
+## Configuration
+
+```yaml
+# ~/.pilot/config.yaml
+bot:
+  enabled: true                          # master switch for the fast conversational path
+  model: "claude-haiku-4-5-20251001"     # chat / greeting model (fast, cheap)
+  answer_model: "claude-sonnet-4-6"      # grounded Q&A model; defaults to `model` when empty
+  api_key: ${ANTHROPIC_API_KEY}          # optional — falls back to ANTHROPIC_API_KEY env var
+  persona: ""                            # optional — prepended to the system prompt (Pilot's voice)
+
+  retrieval:
+    enabled: true                        # bounded file-retrieval for code questions
+    max_files: 8                         # max files read into the answer context
+    max_bytes: 24000                     # max total bytes of file excerpts
+
+  issue_intake:
+    auto_label_pilot: true               # drafted issues are tagged `pilot` (see note below)
+
+  voice:
+    enabled: false                       # voice scaffold — transport deferred
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Master switch for the conversational path |
+| `model` | string | `claude-haiku-4-5-20251001` | Model for chat and greetings |
+| `answer_model` | string | `model` | Model for grounded Q&A; falls back to `model` when empty |
+| `api_key` | string | — | Anthropic API key (falls back to `ANTHROPIC_API_KEY`) |
+| `persona` | string | `""` | Text prepended to the system prompt — Pilot's voice |
+| `retrieval.enabled` | bool | `false` | Enable bounded file retrieval for code questions |
+| `retrieval.max_files` | int | `8` | Max files read into the answer context |
+| `retrieval.max_bytes` | int | `24000` | Max total bytes of file excerpts |
+| `issue_intake.auto_label_pilot` | bool | `true` | Reserved — the `pilot` label is currently always applied (see note) |
+| `voice.enabled` | bool | `false` | Route transcribed voice through the intent → responder path (scaffold) |
+
+The bot is shared across adapters. To make conversational messages reach it, also enable the per-adapter intent classifier — see [Enabling on Slack & Telegram](#enabling-on-slack--telegram).
+
+## Persona
+
+`persona` is prepended to the bot's system prompt and shapes every reply — tone, naming, house style. Keep it short and declarative:
+
+```yaml
+bot:
+  persona: "You are Pilot, a terse senior engineer. Answer in plain language, lead with the answer, skip pleasantries."
+```
+
+The persona applies to chat, greetings, and grounded Q&A. It does not affect the executor path.
+
+## Voice
+
+The `voice` block is a **scaffold**. When `voice.enabled: true`, a transcribed voice message (`VoiceText`) is routed through the same intent → responder pipeline as text. Audio transport — capturing and transcribing the call itself — is **deferred** and not wired up. Enabling the flag today only affects how already-transcribed text is handled.
+
+## Limitations & Gotchas
+
+<Callout type="warning">
+**Issue intake follows `adapters.github.repo`, not the active project.** Switching the chat's active project (e.g. `/switch`) does **not** redirect where drafted issues are filed. Make sure `adapters.github.repo` points at the repo you want issues created in.
+</Callout>
+
+- **Active project resets on restart.** The per-conversation active project is held in memory and resets to `default_project` every time the daemon restarts. Re-select it after a restart if you rely on it.
+- **The `pilot` label is always applied.** Drafted issues are unconditionally tagged `pilot`; the `issue_intake.auto_label_pilot` field is currently reserved and not yet read by the code. There is no way to suppress the label today.
+- **Broad questions cost executor latency.** A question that matches too many files falls back to the 15–30s executor path rather than answering instantly. Narrow the question to stay on the fast path.
+- **Voice transport is not implemented** — see [Voice](#voice).
+
+## Enabling on Slack & Telegram
+
+The bot answers messages that a per-adapter **LLM classifier** has routed to a conversational intent. Enable both the classifier and the bot:
+
+<Tabs items={['Slack', 'Telegram']}>
+
+```yaml
+adapters:
+  slack:
+    enabled: true
+    bot_token: ${SLACK_BOT_TOKEN}
+    llm_classifier:
+      enabled: true                # route NL messages by intent (vs regex)
+      api_key: ${ANTHROPIC_API_KEY}
+      history_size: 10
+      history_ttl: 30m
+
+bot:
+  enabled: true
+  api_key: ${ANTHROPIC_API_KEY}
+  retrieval:
+    enabled: true
+```
+
+
+```yaml
+adapters:
+  telegram:
+    enabled: true
+    bot_token: ${TELEGRAM_BOT_TOKEN}
+    llm_classifier:
+      enabled: true
+      api_key: ${ANTHROPIC_API_KEY}
+      timeout_seconds: 2
+      history_size: 10
+      history_ttl: 30m
+
+bot:
+  enabled: true
+  api_key: ${ANTHROPIC_API_KEY}
+  retrieval:
+    enabled: true
+```
+
+</Tabs>
+
+Without the adapter's `llm_classifier`, intent detection falls back to regex, which routes most natural-language messages to the executor — the conversational path never engages.
+
+## What's Next
+
+- **[Configuration → Conversational Bot](/getting-started/configuration#conversational-bot)** — the `bot:` block in the full config reference
+- **[Slack Integration](/integrations/slack)** — wiring the bot into Slack
+- **[Model Routing](/concepts/model-routing)** — how the executor path picks models (distinct from the bot's classifier)

--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -186,6 +186,49 @@ Always set `allowed_ids` to restrict who can trigger Pilot via Telegram. Without
 
 ---
 
+## Conversational Bot
+
+The fast conversational path. When enabled, chat, greeting, question, and issue-intake messages are answered directly via the Anthropic API (~1–2s) instead of the 15–30s executor. See the [Conversational Bot](/features/conversational-bot) feature guide for the full behavior, intent routing, and limitations.
+
+```yaml
+bot:
+  enabled: true                          # master switch for the conversational path
+  model: "claude-haiku-4-5-20251001"     # chat / greeting model (fast, cheap)
+  answer_model: "claude-sonnet-4-6"      # grounded Q&A model; defaults to `model` when empty
+  api_key: ${ANTHROPIC_API_KEY}          # optional — falls back to ANTHROPIC_API_KEY env var
+  persona: ""                            # optional — prepended to the system prompt (Pilot's voice)
+
+  retrieval:
+    enabled: true                        # bounded file-retrieval for code questions
+    max_files: 8
+    max_bytes: 24000
+
+  issue_intake:
+    auto_label_pilot: true               # reserved — `pilot` label is currently always applied
+
+  voice:
+    enabled: false                       # voice scaffold — transport deferred
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Master switch for the conversational path |
+| `model` | string | `claude-haiku-4-5-20251001` | Model for chat and greetings |
+| `answer_model` | string | `model` | Model for grounded Q&A; falls back to `model` when empty |
+| `api_key` | string | — | Anthropic API key (falls back to `ANTHROPIC_API_KEY`) |
+| `persona` | string | `""` | Text prepended to the system prompt — Pilot's voice |
+| `retrieval.enabled` | bool | `false` | Enable bounded file retrieval for code questions |
+| `retrieval.max_files` | int | `8` | Max files read into the answer context |
+| `retrieval.max_bytes` | int | `24000` | Max total bytes of file excerpts |
+| `issue_intake.auto_label_pilot` | bool | `true` | Reserved — drafted issues are currently always tagged `pilot` |
+| `voice.enabled` | bool | `false` | Route transcribed voice through the intent → responder path (scaffold) |
+
+<Callout type="info">
+The `bot:` block is the conversational engine, shared across adapters. To route natural-language messages to it, also enable the adapter's `llm_classifier` (see [Slack](/integrations/slack) and [Telegram](#telegram) above). Without the classifier, messages fall back to regex routing and most reach the executor.
+</Callout>
+
+---
+
 ## Executor
 
 Controls how Pilot runs execution backends (Claude Code, Qwen Code, or OpenCode) to execute tasks.

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -81,6 +81,7 @@ Single Go binary. Runs on your infrastructure. Your secrets never leave your env
 | **Multi-Platform** | GitHub, GitLab, Linear, Jira, Asana, Azure DevOps, Plane, Discord |
 | **Autopilot** | CI monitoring, auto-merge, failure feedback loop |
 | **Telegram Bot** | Chat, research, plan, and execute tasks from mobile |
+| **Conversational Bot** | Fast chat, grounded code Q&A, and talk-to-ticket issue intake ([docs](/features/conversational-bot)) |
 | **Quality Gates** | Test, lint, and build gates with automatic retry |
 | **Self-Review** | Code review runs before PR push |
 | **Epic Decomposition** | Complex tickets automatically split into subtasks ([Epic Decomposition docs](/features/epic-decomposition)) |

--- a/docs/content/integrations/slack.mdx
+++ b/docs/content/integrations/slack.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components'
 
 # Slack Integration
 
-Pilot sends real-time notifications to Slack channels as it works on issues. It supports progress updates, PR-ready alerts, failure reports, and interactive approval workflows.
+Pilot sends real-time notifications to Slack channels as it works on issues. It supports progress updates, PR-ready alerts, failure reports, and interactive approval workflows. With the [conversational bot](/features/conversational-bot) enabled, Slack also becomes a two-way interface — chat, ask code questions, and file issues by talking to Pilot.
 
 ## Setup
 
@@ -61,6 +61,43 @@ Pilot accepts several channel identifier formats:
 | Channel without `#` | `general` |
 | Channel ID | `C1234567890` |
 | DM channel ID | `D1234567890` |
+
+## Conversational Bot
+
+Beyond notifications, Slack can be a two-way interface. When the [conversational bot](/features/conversational-bot) and the Slack `llm_classifier` are both enabled, natural-language messages are classified by intent and answered on the fast path (~1–2s) instead of always spinning up the executor:
+
+- **Chat & greetings** — direct replies from a fast model
+- **Code questions** — grounded answers from bounded file retrieval
+- **Issue intake** — "create an issue to add a /ping endpoint" → a drafted, `pilot`-labeled GitHub issue the daemon then picks up
+
+```yaml
+# ~/.pilot/config.yaml
+slack:
+  enabled: true
+  bot_token: ${SLACK_BOT_TOKEN}
+  llm_classifier:
+    enabled: true                # classify NL messages by intent (vs regex)
+    api_key: ${ANTHROPIC_API_KEY} # falls back to ANTHROPIC_API_KEY env var
+    history_size: 10
+    history_ttl: 30m
+
+bot:
+  enabled: true                  # the conversational fast path (shared across adapters)
+  api_key: ${ANTHROPIC_API_KEY}
+  retrieval:
+    enabled: true
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `llm_classifier.enabled` | bool | `false` | Enable LLM-based intent classification for Slack |
+| `llm_classifier.api_key` | string | — | Anthropic API key (falls back to `ANTHROPIC_API_KEY`) |
+| `llm_classifier.history_size` | int | `10` | Messages to keep per channel for context |
+| `llm_classifier.history_ttl` | duration | `30m` | TTL for conversation history |
+
+<Callout type="info">
+The Slack `llm_classifier` is **separate** from the `bot:` block. The classifier decides *which path* a message takes; the bot is the conversational fast path itself. Both must be enabled for the two-way experience. Without the classifier, messages fall back to regex routing and most reach the executor. See the [Conversational Bot](/features/conversational-bot) feature page for the full reference and limitations.
+</Callout>
 
 ## Notification Types
 


### PR DESCRIPTION
## What

Documents the **conversational bot module** (shipped across v2.195–v2.201) on the docs/ Nextra site — previously entirely undocumented.

## Changes

- **NEW** `features/conversational-bot.mdx` — the flagship page:
  - Two response paths (conversational ~1–2s vs executor 15–30s)
  - Intent routing via the Haiku classifier + deliverable test (regex only guards `/`-commands)
  - The three capabilities: chat/greeting, grounded Q&A (bounded retrieval), conversational issue intake (talk → ticket → PR)
  - Full `bot:` config block + reference table
  - Persona, voice scaffold, and a **Limitations & Gotchas** section
  - Slack/Telegram enablement (`llm_classifier` + `bot:`)
  - Registered in `features/_meta.js`
- **EDIT** `getting-started/configuration.mdx` — added the `bot:` block to the central config reference
- **EDIT** `integrations/slack.mdx` — added a Conversational Bot section + the missing `llm_classifier` reference
- **EDIT** `concepts/model-routing.mdx` — scoped to the executor path; cross-linked the bot's separate classifier
- **EDIT** `index.mdx` — Conversational Bot row in Core Features

## Accuracy notes

- `bot.issue_intake.auto_label_pilot` is documented as **reserved** — the `pilot` label is currently hardcoded/always applied; the field is not yet read by the code. Flagged honestly rather than implying it's a working toggle.
- Voice documented as a **scaffold** — transport deferred.

## Validation

All 5 MDX files compile clean via `@mdx-js/mdx`. No code changes.