### PR TITLE
docs(sops): new-project issue-authoring SOP + TASK-378 plan

### DIFF
--- a/.agent/sops/onboarding/new-project-issue-authoring.md
+++ b/.agent/sops/onboarding/new-project-issue-authoring.md
@@ -1,0 +1,62 @@
+# SOP: Authoring Pilot Issues for a New Project
+
+**Category:** onboarding
+**Created:** 2026-07-03
+**Trigger:** Onboarding any new repo into `~/.pilot/config.yaml` `projects:`, or filing the first batch of `pilot`-labeled issues against a fresh codebase.
+
+## Why this exists
+
+2026-06-30 live incident (`alekspetrov/ai-coding-summit`, Next.js/pnpm): first Pilot run on a new repo failed end-to-end — issues wrongly spec-rejected, tasks self-bootstrapped conflicting scaffolds, autopilot spun a conflict close→re-execute loop through 3 PRs. Every failure mode was already documented in the knowledge graph; the issues were authored without consulting it. This SOP is the checklist that prevents the repeat.
+
+Related memories: `learning_pilot_issue_spec_guard_headers`, `feedback_pilot_issue_section_headers`, `feedback_use_nav_task_for_issues`, `feedback_conventional_title_required`, `bug_handleconflict_no_refile`, `bug_inherited_spec_full_reimplement`.
+
+## Rule 1 — Scaffold lands first, alone
+
+The **first issue on any new repo is scaffold-only** (package manifest, tsconfig/go.mod, test config, lint config, base lib files). No dependencies, no features. **Wait for its PR to merge to `main` before any dependent issue is labeled `pilot`.**
+
+Why: dependent tasks that find no scaffold self-bootstrap their own (each invents its own `package.json`/`Makefile`) → every PR conflicts with every other → autopilot close→re-execute churn.
+
+## Rule 2 — H2 section headers, exact set
+
+The spec validator (`internal/adapters/github/spec_validator.go`) requires at least one **H2** header from: `## Acceptance`, `## Implementation`, `## Context`, `## Background`, `## Approach`, `## Design`, `## Refs`.
+
+- `### Acceptance criteria` (H3) **fails** the check today → issue gets `pilot-spec-incomplete` then `pilot-blocked` within two poll cycles.
+- Always author `## Context` + `## Acceptance` + `## Implementation` as H2. Sub-structure below them is free.
+- Escape hatch for trivial issues: `pilot-skip-spec-check` label.
+
+## Rule 3 — Dependencies are `#N` refs, never prose
+
+The poller's dependency gate (`ParseDependencies`, poller.go) only matches `Blocked by: #N` / `Depends on: #N` / `Requires: #N` with a **numeric issue ref**. Prose like `Blocked by: TASK-01 scaffold` is **silently ignored** — the issue dispatches immediately.
+
+Flow: file the scaffold issue first → capture its number → every dependent body carries `Blocked by: #<that number>`.
+
+## Rule 4 — Serialize anything that touches shared root files
+
+The parallel scope-overlap guard keys on **directories** named in issue bodies; two issues that both create root files (`package.json`, `tsconfig.json`, lockfiles) are NOT detected as overlapping. Until that's fixed in code, chain such issues with `Blocked by: #N` so they run one at a time.
+
+## Rule 5 — Conventional-commit titles
+
+`type(scope): description` — autopilot rejects PR creation otherwise.
+
+## Rule 6 — Per-project config before the first run
+
+In `~/.pilot/config.yaml` for the new project:
+
+1. **Quality gates**: the global `quality.gates` (typically `make build/test/lint` for the Pilot repo) applies to **every** project — a repo without a Makefile fails every gate. Until per-project overrides exist, either adjust global gates or ensure the scaffold provides matching `make` targets that map to the repo's real commands (e.g. Makefile wrapping `pnpm build/test/lint`).
+2. **Execution mode**: prefer `orchestrator.execution.mode: auto` (parallel + overlap guard) over bare `parallel` once the `auto` wiring fix ships; before that, `sequential` is the safe choice for a brand-new repo's first batch.
+3. **Token durability**: launch with `GITHUB_TOKEN=$(gh auth token) pilot start ...` or a fine-grained PAT in config. A dead token 401s **all** polling silently.
+
+## Pre-flight checklist (before adding the `pilot` label)
+
+- [ ] Scaffold issue merged to `main` (Rule 1) — or this IS the scaffold issue
+- [ ] Body has H2 `## Context` / `## Acceptance` / `## Implementation` (Rule 2)
+- [ ] All deps expressed as `Blocked by: #N` (Rule 3)
+- [ ] No two open issues create the same root files (Rule 4)
+- [ ] Title is `type(scope): description` (Rule 5)
+- [ ] Project entry + gates + token verified in config (Rule 6)
+- [ ] Issue authored via `nav-task` → task doc → `nav-pilot` handoff (not ad-hoc `gh issue create`)
+
+## Refs
+
+- Plan: `.agent/tasks/TASK-378-new-project-onboarding-hardening.md`
+- Code fixes tracked as `pilot` issues B0–B5 (see task doc)

--- a/.agent/tasks/TASK-378-new-project-onboarding-hardening.md
+++ b/.agent/tasks/TASK-378-new-project-onboarding-hardening.md
@@ -1,0 +1,59 @@
+# TASK-378: New-Project Onboarding Hardening
+
+**Status**: 🚧 In Progress (Lever A shipped; Lever B dispatched to Pilot)
+**Created**: 2026-07-03
+
+---
+
+## Context
+
+**Problem**: Running Pilot on a fresh, non-Go repo fails on the first run, every time. Live-observed 2026-06-30 on `alekspetrov/ai-coding-summit` (Next.js/pnpm): wrong spec-rejections (H3 headers), self-bootstrapped conflicting scaffolds, autopilot conflict close→re-execute churn across 3 PRs. Root cause is a cluster of known-but-unmitigated failure modes that compound only on new projects — Pilot treats every repo like the Pilot repo (Go + Makefile + globally-tuned config).
+
+**Goal**: A new project succeeds on the **first** run with no manual babysitting.
+
+## Acceptance Criteria
+
+- [ ] Lever A SOP exists and is linked from CLAUDE.md workflow (`.agent/sops/onboarding/new-project-issue-authoring.md`)
+- [ ] B0–B5 filed as `pilot` issues with H2 headers, `#N` deps, conventional titles (dogfooding the SOP)
+- [ ] End-to-end proof: a throwaway Node/pnpm repo with a scaffold-first, `#N`-linked issue set goes issue→PR cleanly on the first daemon run — scaffold merges first, dependents build on it, zero conflict loop
+
+## Implementation
+
+### Lever A — Process (manual, done first)
+- SOP: `.agent/sops/onboarding/new-project-issue-authoring.md` (6 rules + pre-flight checklist)
+
+### Lever B — Code fixes (dispatched to Pilot, ranked)
+
+| ID | Issue | Fix | Where | Effort |
+|----|-------|-----|-------|--------|
+| B0 | [#3713](https://github.com/qf-studio/pilot/issues/3713) | Spec validator accepts H2–H6 headers (`^##\s+` → `^#{2,6}\s+`) | `internal/adapters/github/spec_validator.go:22` | XS |
+| B1 | [#3716](https://github.com/qf-studio/pilot/issues/3716) | Per-project quality gates (`ProjectConfig.Quality`) + pnpm/yarn/bun detection | `internal/config/config.go:216`, `internal/quality/types.go:266-323`, factory sites `cmd/pilot/main.go:387/1016/1425` | M |
+| B2 | [#3714](https://github.com/qf-studio/pilot/issues/3714) | Overlap guard detects root-file collisions (package.json/tsconfig/lockfiles) | `internal/adapters/github/poller.go:1040` | M |
+| B3 | [#3715](https://github.com/qf-studio/pilot/issues/3715) | Cap auto-rebase oscillation (no counter at `controller.go:2259`) + persist in-memory `maxFailedRetries` (`poller.go:381`) | `internal/autopilot/controller.go`, `internal/adapters/github/poller.go` | S–M |
+| B4 | [#3717](https://github.com/qf-studio/pilot/issues/3717) | Wire `execution.mode: "auto"` → `ExecutionModeAuto` (both call-sites; today it silently runs sequential) ⚠️ behavior change, release-note | `cmd/pilot/main.go:750-768`, `~2191` | S |
+| B5 | [#3718](https://github.com/qf-studio/pilot/issues/3718) | `gh auth token` fallback + loud doctor 401 check | token resolution sites in `cmd/pilot/main.go`, `doctor` cmd | S |
+
+Dependency chain for main.go-touching fixes: #3716 (B1) → #3717 (B4) → #3718 (B5), serialized via `Blocked by: #N`. B0/B2/B3 independent.
+
+## Out of Scope
+
+- Decomposer rewrite (`bug_inherited_spec_full_reimplement` cluster) — B2 is the partial mitigation
+- B6 ghost-close skip (`bug_ghost_close_db_lockout`, tracked #2476) — separate track
+- M7 studio-sdk github cutover (TASK-368)
+- Non-GitHub adapters' onboarding
+
+## Verify
+
+```bash
+make build && make test && make lint   # per B-fix, on the Pilot repo
+```
+E2E: throwaway pnpm repo, scaffold-first issue set, one clean PR per issue, no conflict loop.
+
+## Refs
+
+- Plan: `~/.claude/plans/new-project-onboarding-hardening-compiled-bengio.md` (session artifact)
+- SOP: `.agent/sops/onboarding/new-project-issue-authoring.md`
+- Evidence memories: `learning_pilot_issue_spec_guard_headers`, `bug_handleconflict_no_refile`, `bug_inherited_spec_full_reimplement`, `bug_ghost_close_db_lockout`
+- Issue links: filled in below after dispatch
+
+**Last Updated**: 2026-07-03

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,11 @@ Documentation in `.agent/`:
 5. Review PR: `gh pr view <n>`
 6. Merge when ready: `gh pr merge <n>`
 
+**Onboarding a new repo / first issues on a fresh project:** follow
+`.agent/sops/onboarding/new-project-issue-authoring.md` (scaffold-first,
+H2 section headers, `#N` dependency refs, per-project config checklist) —
+skipping it is how first runs on new projects fail.
+
 ## Current Status
 
 See `docs/lib/version.ts` for the current release and `.agent/DEVELOPMENT-README.md` § "Current State" for recent feature history.


### PR DESCRIPTION
## Context

2026-06-30: first Pilot run on a fresh Next.js/pnpm repo failed end-to-end (wrong spec-rejections, conflicting self-bootstrapped scaffolds, autopilot conflict churn). Root-caused to a cluster of known failure modes that compound on new projects.

## Changes

- **`.agent/sops/onboarding/new-project-issue-authoring.md`** — 6 rules + pre-flight checklist (scaffold-first, H2 headers, `#N` deps, root-file serialization, conventional titles, per-project config)
- **`.agent/tasks/TASK-378-new-project-onboarding-hardening.md`** — umbrella plan; code fixes dispatched as pilot issues #3713 (B0 spec-validator H2–H6), #3716 (B1 per-project quality + pnpm), #3714 (B2 overlap guard root files), #3715 (B3 retry caps), #3717 (B4 auto-mode wiring), #3718 (B5 token fallback + doctor)
- **`CLAUDE.md`** — Development Workflow cross-link to the SOP

Docs only; no code changes.