### PR TITLE
fix(github): spec validator accepts H2-H6 section headers

### DIFF
--- a/internal/adapters/github/spec_validator.go
+++ b/internal/adapters/github/spec_validator.go
@@ -18,8 +18,8 @@ var (
 	parentRefRe = regexp.MustCompile(`(?i)Parent:\s*GH-(\d+)`)
 	// autopilotMetaRe detects decomposer-generated sub-issues.
 	autopilotMetaRe = regexp.MustCompile(`<!--\s*autopilot-meta\s`)
-	// sectionHeaderRe requires at least one recognized structural section header.
-	sectionHeaderRe = regexp.MustCompile(`(?im)^##\s+(Acceptance|Implementation|Context|Background|Approach|Design|Refs)\b`)
+	// sectionHeaderRe requires at least one recognized structural section header (H2–H6).
+	sectionHeaderRe = regexp.MustCompile(`(?im)^#{2,6}\s+(Acceptance|Implementation|Context|Background|Approach|Design|Refs)\b`)
 )
 
 // SpecValidationResult holds the outcome of ValidateSpec.
@@ -75,7 +75,7 @@ func ValidateSpec(issue *Issue, parentResolver func(int) (*Issue, error)) SpecVa
 
 	if !sectionHeaderRe.MatchString(body) {
 		reasons = append(reasons,
-			"no structural section header (need one of: ## Acceptance, ## Implementation, ## Context, ## Background, ## Approach, ## Design, ## Refs)")
+			"no structural section header (need one of Acceptance, Implementation, Context, Background, Approach, Design, or Refs as an H2–H6 header)")
 	}
 
 	return SpecValidationResult{

--- a/internal/adapters/github/spec_validator_test.go
+++ b/internal/adapters/github/spec_validator_test.go
@@ -159,3 +159,38 @@ func TestValidateSpec_SectionHeaderVariants(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateSpec_H3ToH6SectionHeaders(t *testing.T) {
+	// H3–H6 headers must be accepted (relaxed from H2-only).
+	passCases := []string{
+		"### Acceptance criteria",
+		"### Acceptance",
+		"#### Implementation",
+		"###### Refs",
+	}
+	for _, h := range passCases {
+		body := strings.Repeat("x", 80) + "\n\n" + h + "\n\nsome content here and there\n"
+		issue := &Issue{Number: 9, Body: body}
+		result := ValidateSpec(issue, nil)
+		if !result.Valid {
+			t.Errorf("H3–H6 header %q should be accepted, got reasons=%v", h, result.FailureReasons)
+		}
+	}
+
+	// H1 must still be rejected.
+	h1Body := strings.Repeat("x", 80) + "\n\n# Acceptance\n\nsome content here and there\n"
+	issue := &Issue{Number: 10, Body: h1Body}
+	result := ValidateSpec(issue, nil)
+	if result.Valid {
+		t.Error("H1 header '# Acceptance' should NOT be accepted as a structural section header")
+	}
+	foundHeader := false
+	for _, r := range result.FailureReasons {
+		if strings.Contains(r, "structural section header") {
+			foundHeader = true
+		}
+	}
+	if !foundHeader {
+		t.Errorf("expected 'structural section header' failure reason for H1 body, got %v", result.FailureReasons)
+	}
+}


### PR DESCRIPTION
## Context

`sectionHeaderRe` in `spec_validator.go` matched only `^##\s+`, so issues using H3–H6 headers (e.g. `### Acceptance criteria`) were wrongly rejected as thin specs, got `pilot-spec-incomplete` → `pilot-blocked`. Live incident 2026-06-30: first two issues on a new repo were blocked despite full Acceptance/Implementation sections.

## Changes

- `internal/adapters/github/spec_validator.go`: regex widened from `(?im)^##\s+` to `(?im)^#{2,6}\s+`; failure reason text updated to say "H2–H6 header" instead of listing `##` literally
- `internal/adapters/github/spec_validator_test.go`: new test `TestValidateSpec_H3ToH6SectionHeaders` covering `### Acceptance criteria`, `#### Implementation`, `###### Refs` (all pass) and `# Acceptance` (H1, still fails)

## Acceptance

- [x] `### Acceptance criteria`, `#### Implementation`, `###### Refs` all pass
- [x] `# Acceptance` (H1) and plain text still fail
- [x] All existing tests green
- [x] `make build && make lint` green
- [x] Rejection comment text no longer claims H2 is required

## Refs

- Closes #3713
- Part of TASK-378 new-project onboarding hardening