### PR TITLE
fix(github): scope-overlap guard detects root-file collisions

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -1038,7 +1038,11 @@ func (p *Poller) processIssueSequential(ctx context.Context, issue *Issue) (*Iss
 }
 
 // groupByOverlappingScope partitions issues into groups where members reference
-// at least one common directory (transitive closure). Within each group only the
+// at least one common directory (transitive closure), including a shared
+// root-level config/scaffold file (package.json, go.mod, Makefile, ...) since
+// those have no real parent directory to compare. Scaffold-flavored issues
+// (2+ distinct root config files mentioned) are treated as globally
+// overlapping and grouped with every candidate. Within each group only the
 // oldest issue should be dispatched to avoid merge conflicts.
 func groupByOverlappingScope(candidates []*Issue) [][]*Issue {
 	n := len(candidates)
@@ -1069,14 +1073,27 @@ func groupByOverlappingScope(candidates []*Issue) [][]*Issue {
 	// Comment bodies are attacker-controllable text; sanitize before parsing so
 	// smuggled paths cannot influence grouping decisions.
 	dirs := make([]map[string]bool, n)
+	scaffold := make([]bool, n)
 	for i, c := range candidates {
-		dirs[i] = executor.ExtractDirectoriesFromText(text.SanitizeUntrustedString(c.Body))
+		body := text.SanitizeUntrustedString(c.Body)
+		dirs[i] = executor.ExtractDirectoriesFromText(body)
+		// A body naming 2+ distinct root config/scaffold files (package.json,
+		// tsconfig.json, Makefile, lockfiles, ...) is bootstrapping project
+		// tooling from scratch — it collides with every other in-flight issue,
+		// not just ones sharing a directory (GH-3714).
+		scaffold[i] = len(executor.RootConfigFileMentions(body)) >= 2
 	}
 	for i := 0; i < n; i++ {
+		if scaffold[i] {
+			continue
+		}
 		if len(dirs[i]) == 0 {
 			continue
 		}
 		for j := i + 1; j < n; j++ {
+			if scaffold[j] {
+				continue
+			}
 			if len(dirs[j]) == 0 {
 				continue
 			}
@@ -1085,6 +1102,18 @@ func groupByOverlappingScope(candidates []*Issue) [][]*Issue {
 					union(i, j)
 					break
 				}
+			}
+		}
+	}
+
+	// Scaffold-flavored issues serialize against every other candidate.
+	for i := 0; i < n; i++ {
+		if !scaffold[i] {
+			continue
+		}
+		for j := 0; j < n; j++ {
+			if j != i {
+				union(i, j)
 			}
 		}
 	}

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -1390,6 +1390,40 @@ func TestGroupByOverlappingScope(t *testing.T) {
 			wantGroups:     2,
 			wantMaxGroupSz: 2,
 		},
+		{
+			// GH-3714: root-level files (package.json) share no directory,
+			// so plain directory extraction would miss this collision.
+			name: "two bodies both naming package.json group together",
+			issues: []*Issue{
+				{Number: 1, Body: "Add a package.json with the base dependencies", CreatedAt: now.Add(-2 * time.Hour)},
+				{Number: 2, Body: "Update package.json to add the lint script", CreatedAt: now.Add(-1 * time.Hour)},
+			},
+			wantGroups:     1,
+			wantMaxGroupSz: 2,
+		},
+		{
+			name: "bodies naming disjoint subdirs still run parallel",
+			issues: []*Issue{
+				{Number: 1, Body: "Modify internal/gateway/server.go", CreatedAt: now.Add(-2 * time.Hour)},
+				{Number: 2, Body: "Update internal/executor/runner.go", CreatedAt: now.Add(-1 * time.Hour)},
+			},
+			wantGroups:     2,
+			wantMaxGroupSz: 1,
+		},
+		{
+			// GH-3714: a scaffold/bootstrap issue naming 2+ root config files
+			// (package.json + tsconfig.json) is globally overlapping — it
+			// serializes with every other candidate, even ones referencing
+			// unrelated subdirectories.
+			name: "scaffold-flavored body groups with all candidates",
+			issues: []*Issue{
+				{Number: 1, Body: "Bootstrap the project: add package.json and tsconfig.json", CreatedAt: now.Add(-3 * time.Hour)},
+				{Number: 2, Body: "Modify internal/gateway/server.go", CreatedAt: now.Add(-2 * time.Hour)},
+				{Number: 3, Body: "Update internal/executor/runner.go", CreatedAt: now.Add(-1 * time.Hour)},
+			},
+			wantGroups:     1,
+			wantMaxGroupSz: 3,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/executor/scope.go
+++ b/internal/executor/scope.go
@@ -13,10 +13,33 @@ var filePathPattern = regexp.MustCompile(`\b((?:[\w\-]+/)+[\w\-]+\.(?:go|py|ts|t
 // Examples: internal/comms/, src/utils/, cmd/pilot/
 var dirOnlyPattern = regexp.MustCompile(`\b((?:[\w\-]+/)+[\w\-]+/)(?:\s|$|[),;:"'])`)
 
+// rootConfigFilePattern matches root-level scaffold/config files. These live at
+// the repo root, so they share no directory and filePathPattern's slash
+// requirement never matches them — two issues that both bootstrap package.json
+// look scope-disjoint even though dispatching them in parallel guarantees a
+// merge conflict (GH-3714).
+var rootConfigFilePattern = regexp.MustCompile(`\b(package(?:-lock)?\.json|tsconfig\.json|go\.(?:mod|sum)|Cargo\.(?:toml|lock)|Makefile|pnpm-lock\.yaml|yarn\.lock|vitest\.config\.\w+|eslint\.config\.\w+)\b`)
+
+// RootScopeKey is the pseudo-directory used to represent a shared reference to
+// a root-level config/scaffold file (see rootConfigFilePattern).
+const RootScopeKey = "<root>"
+
+// RootConfigFileMentions returns the set of distinct root-level config/scaffold
+// files (package.json, go.mod, Makefile, lockfiles, etc.) referenced in text.
+func RootConfigFileMentions(text string) map[string]bool {
+	mentions := make(map[string]bool)
+	for _, m := range rootConfigFilePattern.FindAllString(text, -1) {
+		mentions[m] = true
+	}
+	return mentions
+}
+
 // ExtractDirectoriesFromText finds file paths and directory references in text
 // and returns their unique parent directories. Handles both file paths
 // (e.g., "internal/executor/runner.go" → "internal/executor") and bare directory
-// references (e.g., "internal/comms/" → "internal/comms").
+// references (e.g., "internal/comms/" → "internal/comms"). Mentions of
+// root-level config/scaffold files (package.json, go.mod, Makefile, ...) are
+// folded into the RootScopeKey pseudo-directory since they have no real parent.
 func ExtractDirectoriesFromText(text string) map[string]bool {
 	dirs := make(map[string]bool)
 
@@ -44,6 +67,13 @@ func ExtractDirectoriesFromText(text string) map[string]bool {
 		if dir != "" {
 			dirs[dir] = true
 		}
+	}
+
+	// Fold root-level config/scaffold file mentions into a shared pseudo-path
+	// so two issues that both invent package.json/tsconfig.json/etc. collide
+	// even though neither reference contains a directory separator.
+	if len(RootConfigFileMentions(text)) > 0 {
+		dirs[RootScopeKey] = true
 	}
 
 	return dirs

--- a/internal/executor/scope_test.go
+++ b/internal/executor/scope_test.go
@@ -65,6 +65,16 @@ func TestExtractDirectoriesFromText(t *testing.T) {
 			text: "Edit configs/app.json and configs/settings.toml",
 			want: map[string]bool{"configs": true},
 		},
+		{
+			name: "root-level package.json folds into RootScopeKey",
+			text: "Add a package.json with the base dependencies",
+			want: map[string]bool{RootScopeKey: true},
+		},
+		{
+			name: "root-level Makefile folds into RootScopeKey",
+			text: "Add a Makefile with build and test targets",
+			want: map[string]bool{RootScopeKey: true},
+		},
 	}
 
 	for _, tt := range tests {
@@ -133,6 +143,14 @@ func TestIssuesOverlap(t *testing.T) {
 			bodyB: "Update internal/alerts/dispatcher.go and internal/config/loader.go",
 			want:  true,
 		},
+		{
+			// GH-3714: root-level files share no directory, so this only
+			// overlaps because RootScopeKey folds them together.
+			name:  "both bodies name root-level package.json",
+			bodyA: "Add a package.json with the base dependencies",
+			bodyB: "Update package.json to add the lint script",
+			want:  true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -140,6 +158,67 @@ func TestIssuesOverlap(t *testing.T) {
 			got := IssuesOverlap(tt.bodyA, tt.bodyB)
 			if got != tt.want {
 				t.Errorf("IssuesOverlap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRootConfigFileMentions(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want map[string]bool
+	}{
+		{
+			name: "no root config files",
+			text: "Add rate limiting to API endpoints",
+			want: map[string]bool{},
+		},
+		{
+			name: "single root config file",
+			text: "Add a package.json with the base dependencies",
+			want: map[string]bool{"package.json": true},
+		},
+		{
+			name: "scaffold body names two distinct root config files",
+			text: "Bootstrap the project: add package.json and tsconfig.json",
+			want: map[string]bool{"package.json": true, "tsconfig.json": true},
+		},
+		{
+			name: "repeated mention counts once",
+			text: "package.json needs updating; also update package.json again",
+			want: map[string]bool{"package.json": true},
+		},
+		{
+			name: "go and rust root manifests",
+			text: "Add go.mod, go.sum, Cargo.toml, and Cargo.lock",
+			want: map[string]bool{"go.mod": true, "go.sum": true, "Cargo.toml": true, "Cargo.lock": true},
+		},
+		{
+			name: "lockfiles and configs",
+			text: "Add pnpm-lock.yaml, yarn.lock, vitest.config.ts, eslint.config.js, and a Makefile",
+			want: map[string]bool{
+				"pnpm-lock.yaml":   true,
+				"yarn.lock":        true,
+				"vitest.config.ts": true,
+				"eslint.config.js": true,
+				"Makefile":         true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RootConfigFileMentions(tt.text)
+			if len(got) != len(tt.want) {
+				t.Errorf("RootConfigFileMentions() returned %d mentions, want %d\n  got:  %v\n  want: %v",
+					len(got), len(tt.want), got, tt.want)
+				return
+			}
+			for f := range tt.want {
+				if !got[f] {
+					t.Errorf("RootConfigFileMentions() missing %q\n  got: %v", f, got)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- `groupByOverlappingScope` keyed overlap on directories extracted from issue bodies, so two issues that each bootstrap root-level files (`package.json`, `tsconfig.json`, `Makefile`, lockfiles) shared no directory and dispatched in parallel — each invented its own scaffold and every PR merge-conflicted (live incident 2026-06-30 on a fresh Next.js repo, 3-PR conflict/re-execute churn).
- `executor.ExtractDirectoriesFromText` now folds explicit mentions of root config/scaffold files (`package.json`, `tsconfig.json`, `go.mod`/`go.sum`, `Cargo.toml`/`Cargo.lock`, `Makefile`, `pnpm-lock.yaml`, `yarn.lock`, `vitest.config.*`, `eslint.config.*`) into a shared `RootScopeKey` pseudo-directory.
- `groupByOverlappingScope` treats scaffold-flavored bodies (2+ distinct root config files mentioned) as globally overlapping, serializing them against every other candidate — the same mitigation applies to decomposer children re-implementing a full parent spec.
- Union-find grouping and oldest-first dispatch semantics unchanged.

## Test plan
- [x] `go test ./internal/adapters/github/... ./internal/executor/...`
- [x] New table tests: two bodies naming `package.json` group together; disjoint-subdir bodies still parallel; scaffold-flavored body groups with all candidates
- [x] `make build`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] Full `go test ./...` (one pre-existing unrelated failure in `desktop` package — snapshot test against live `git log`, reproduces identically on `origin/main`)

Refs: `internal/adapters/github/poller.go:1040` (guard), `poller.go:1328` (call-site)