### PR TITLE
fix(cli): pilot logs shows newest tasks and reads live DB state

### DIFF
--- a/cmd/pilot/config_cmd.go
+++ b/cmd/pilot/config_cmd.go
@@ -1,17 +1,20 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
 	"github.com/qf-studio/pilot/internal/config"
-	"github.com/qf-studio/pilot/internal/replay"
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 func newConfigCmd() *cobra.Command {
@@ -321,36 +324,46 @@ Examples:
 	return cmd
 }
 
+// logDisplayLimit is the number of execution_logs lines shown for `pilot logs <task-id>`.
+// verboseLogDisplayLimit raises the cap when --verbose is passed.
+const (
+	logDisplayLimit        = 100
+	verboseLogDisplayLimit = 500
+)
+
+// showTaskLogs prints logs for a specific task, sourced from the memory store (executions +
+// execution_logs tables) rather than replay recordings, so it also covers tasks that are
+// still running or finished recently but haven't produced a finalized recording (GH-3724).
 func showTaskLogs(taskID string, cfg *config.Config, verbose, jsonOut bool) error {
-	// Try to find recording by task ID
-	recordingsPath := replay.DefaultRecordingsPath()
-
-	// List all recordings and find matching task
-	recordings, err := replay.ListRecordings(recordingsPath, &replay.RecordingFilter{Limit: 100})
+	store, err := memory.NewStore(cfg.Memory.Path)
 	if err != nil {
-		return fmt.Errorf("failed to list recordings: %w", err)
+		return fmt.Errorf("failed to open memory store: %w", err)
 	}
+	defer func() { _ = store.Close() }()
 
-	var matchingRec *replay.RecordingSummary
-	for _, rec := range recordings {
-		if rec.TaskID == taskID || rec.ID == taskID || strings.Contains(rec.TaskID, taskID) {
-			matchingRec = rec
-			break
+	exec, err := store.GetLatestExecutionByTaskID(taskID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("no logs found for task: %s", taskID)
 		}
+		return fmt.Errorf("failed to look up task: %w", err)
 	}
 
-	if matchingRec == nil {
-		return fmt.Errorf("no logs found for task: %s", taskID)
+	limit := logDisplayLimit
+	if verbose {
+		limit = verboseLogDisplayLimit
 	}
-
-	// Load full recording
-	recording, err := replay.LoadRecording(recordingsPath, matchingRec.ID)
+	logs, err := store.GetLogsByExecutionID(exec.TaskID, limit)
 	if err != nil {
-		return fmt.Errorf("failed to load recording: %w", err)
+		return fmt.Errorf("failed to load logs: %w", err)
 	}
 
 	if jsonOut {
-		data, err := json.MarshalIndent(recording, "", "  ")
+		out := struct {
+			Execution *memory.Execution  `json:"execution"`
+			Logs      []*memory.LogEntry `json:"logs"`
+		}{exec, logs}
+		data, err := json.MarshalIndent(out, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal: %w", err)
 		}
@@ -360,66 +373,73 @@ func showTaskLogs(taskID string, cfg *config.Config, verbose, jsonOut bool) erro
 
 	// Display task info
 	statusIcon := "+"
-	switch recording.Status {
+	switch exec.Status {
 	case "failed":
 		statusIcon = "x"
-	case "cancelled":
+	case "cancelled", "no_op":
 		statusIcon = "!"
 	}
 
-	fmt.Printf("Task: %s [%s]\n", recording.TaskID, statusIcon)
-	fmt.Printf("Status: %s\n", recording.Status)
-	fmt.Printf("Duration: %s\n", recording.Duration)
-	fmt.Printf("Started: %s\n", recording.StartTime.Format("2006-01-02 15:04:05"))
+	fmt.Printf("Task: %s [%s]\n", exec.TaskID, statusIcon)
+	fmt.Printf("Status: %s\n", exec.Status)
+	fmt.Printf("Duration: %s\n", time.Duration(exec.DurationMs)*time.Millisecond)
+	fmt.Printf("Started: %s\n", exec.CreatedAt.Format("2006-01-02 15:04:05"))
 	fmt.Println()
 
-	if recording.Metadata != nil {
-		if recording.Metadata.Branch != "" {
-			fmt.Printf("Branch: %s\n", recording.Metadata.Branch)
+	if exec.TaskBranch != "" || exec.CommitSHA != "" || exec.PRUrl != "" {
+		if exec.TaskBranch != "" {
+			fmt.Printf("Branch: %s\n", exec.TaskBranch)
 		}
-		if recording.Metadata.CommitSHA != "" {
-			fmt.Printf("Commit: %s\n", recording.Metadata.CommitSHA)
+		if exec.CommitSHA != "" {
+			fmt.Printf("Commit: %s\n", exec.CommitSHA)
 		}
-		if recording.Metadata.PRUrl != "" {
-			fmt.Printf("PR: %s\n", recording.Metadata.PRUrl)
+		if exec.PRUrl != "" {
+			fmt.Printf("PR: %s\n", exec.PRUrl)
 		}
 		fmt.Println()
 	}
 
-	if verbose {
-		// Load and show events
-		events, err := replay.LoadStreamEvents(recording)
-		if err != nil {
-			return fmt.Errorf("failed to load events: %w", err)
-		}
+	if len(logs) == 0 {
+		fmt.Println("No log entries recorded for this task.")
+		return nil
+	}
 
-		fmt.Printf("Events (%d):\n", len(events))
-		fmt.Println(strings.Repeat("-", 50))
+	fmt.Printf("Log entries (%d):\n", len(logs))
+	fmt.Println(strings.Repeat("-", 50))
 
-		for i, event := range events {
-			formatted := replay.FormatEvent(event, true)
-			fmt.Printf("[%d] %s\n", i+1, formatted)
-		}
+	for _, entry := range logs {
+		fmt.Printf("[%s] %-5s %s: %s\n",
+			entry.Timestamp.Format("15:04:05"),
+			strings.ToUpper(entry.Level),
+			entry.Component,
+			entry.Message)
 	}
 
 	return nil
 }
 
+// showRecentLogs prints the most recently created tasks, sourced from the memory store
+// (executions table) so it reflects live/in-progress executions, not just finalized
+// replay recordings (GH-3724).
 func showRecentLogs(cfg *config.Config, limit int, jsonOut bool) error {
-	recordingsPath := replay.DefaultRecordingsPath()
-
-	recordings, err := replay.ListRecordings(recordingsPath, &replay.RecordingFilter{Limit: limit})
+	store, err := memory.NewStore(cfg.Memory.Path)
 	if err != nil {
-		return fmt.Errorf("failed to list recordings: %w", err)
+		return fmt.Errorf("failed to open memory store: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	executions, err := store.GetRecentExecutions(limit, "")
+	if err != nil {
+		return fmt.Errorf("failed to load recent executions: %w", err)
 	}
 
-	if len(recordings) == 0 {
+	if len(executions) == 0 {
 		fmt.Println("No task logs found.")
 		return nil
 	}
 
 	if jsonOut {
-		data, err := json.MarshalIndent(recordings, "", "  ")
+		data, err := json.MarshalIndent(executions, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal: %w", err)
 		}
@@ -427,23 +447,23 @@ func showRecentLogs(cfg *config.Config, limit int, jsonOut bool) error {
 		return nil
 	}
 
-	fmt.Printf("Recent Tasks (%d):\n", len(recordings))
+	fmt.Printf("Recent Tasks (%d):\n", len(executions))
 	fmt.Println()
 
-	for _, rec := range recordings {
+	for _, exec := range executions {
 		statusIcon := "+"
-		switch rec.Status {
+		switch exec.Status {
 		case "failed":
 			statusIcon = "x"
-		case "cancelled":
+		case "cancelled", "no_op":
 			statusIcon = "!"
 		}
 
 		fmt.Printf("  [%s] %-20s %8s  %s\n",
 			statusIcon,
-			rec.TaskID,
-			rec.Duration.Round(1),
-			rec.StartTime.Format("Jan 02 15:04"))
+			exec.TaskID,
+			(time.Duration(exec.DurationMs) * time.Millisecond).Round(time.Second),
+			exec.CreatedAt.Format("Jan 02 15:04"))
 	}
 
 	fmt.Println()

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -571,26 +571,25 @@ func unmarshalLabels(s string) []string {
 	return labels
 }
 
-// GetExecution retrieves an execution by its unique ID.
-// Returns sql.ErrNoRows if the execution is not found.
-func (s *Store) GetExecution(id string) (*Execution, error) {
-	row := s.db.QueryRow(`
-		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at,
-			COALESCE(tokens_input, 0), COALESCE(tokens_output, 0), COALESCE(tokens_total, 0),
-			COALESCE(tokens_cache_read, 0), COALESCE(tokens_cache_write, 0),
-			COALESCE(estimated_cost_usd, 0), COALESCE(files_changed, 0), COALESCE(lines_added, 0),
-			COALESCE(lines_removed, 0), COALESCE(model_name, ''),
-			COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
-			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
-			COALESCE(task_source_adapter, ''), COALESCE(task_source_issue_id, ''),
-			COALESCE(task_labels, ''),
-			COALESCE(approval_request_id, ''), COALESCE(approval_decision, ''),
-			approval_decision_at,
-			COALESCE(approval_decision_by, ''),
-			COALESCE(effort_level, ''), COALESCE(complexity_level, '')
-		FROM executions WHERE id = ?
-	`, id)
+// executionDetailColumns is the full column set for a single Execution row,
+// shared by GetExecution and GetLatestExecutionByTaskID.
+const executionDetailColumns = `
+	id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at,
+	COALESCE(tokens_input, 0), COALESCE(tokens_output, 0), COALESCE(tokens_total, 0),
+	COALESCE(tokens_cache_read, 0), COALESCE(tokens_cache_write, 0),
+	COALESCE(estimated_cost_usd, 0), COALESCE(files_changed, 0), COALESCE(lines_added, 0),
+	COALESCE(lines_removed, 0), COALESCE(model_name, ''),
+	COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
+	COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
+	COALESCE(task_source_adapter, ''), COALESCE(task_source_issue_id, ''),
+	COALESCE(task_labels, ''),
+	COALESCE(approval_request_id, ''), COALESCE(approval_decision, ''),
+	approval_decision_at,
+	COALESCE(approval_decision_by, ''),
+	COALESCE(effort_level, ''), COALESCE(complexity_level, '')`
 
+// scanExecutionDetail scans a row selected via executionDetailColumns into an Execution.
+func scanExecutionDetail(row *sql.Row) (*Execution, error) {
 	var exec Execution
 	var completedAt sql.NullTime
 	var approvalDecisionAt sql.NullTime
@@ -615,6 +614,27 @@ func (s *Store) GetExecution(id string) (*Execution, error) {
 	}
 
 	return &exec, nil
+}
+
+// GetExecution retrieves an execution by its unique ID.
+// Returns sql.ErrNoRows if the execution is not found.
+func (s *Store) GetExecution(id string) (*Execution, error) {
+	row := s.db.QueryRow(`SELECT `+executionDetailColumns+` FROM executions WHERE id = ?`, id)
+	return scanExecutionDetail(row)
+}
+
+// GetLatestExecutionByTaskID returns the most recent execution for a task, matched by
+// exact task_id first and falling back to a substring match (e.g. "GH-15" matching
+// "GH-15"). Returns sql.ErrNoRows if no execution matches.
+func (s *Store) GetLatestExecutionByTaskID(taskID string) (*Execution, error) {
+	row := s.db.QueryRow(`
+		SELECT `+executionDetailColumns+`
+		FROM executions
+		WHERE task_id = ? OR task_id LIKE ?
+		ORDER BY (task_id = ?) DESC, created_at DESC, rowid DESC
+		LIMIT 1
+	`, taskID, "%"+taskID+"%", taskID)
+	return scanExecutionDetail(row)
 }
 
 // HasCompletedExecution checks whether a genuine completed execution exists for the given task
@@ -2191,6 +2211,42 @@ func (s *Store) GetRecentLogs(limit int) ([]*LogEntry, error) {
 		entries = append(entries, &e)
 	}
 	return entries, rows.Err()
+}
+
+// GetLogsByExecutionID returns log entries for a specific task ID (execution_logs.execution_id
+// stores the task ID, e.g. "GH-3714", not the execution row's UUID), in chronological order.
+// At most limit entries are returned, keeping the most recent ones if the task has more.
+func (s *Store) GetLogsByExecutionID(executionID string, limit int) ([]*LogEntry, error) {
+	rows, err := s.db.Query(`
+		SELECT id, COALESCE(execution_id, ''), timestamp, level, message, COALESCE(component, 'executor')
+		FROM execution_logs
+		WHERE execution_id = ?
+		ORDER BY timestamp DESC
+		LIMIT ?
+	`, executionID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []*LogEntry
+	for rows.Next() {
+		var e LogEntry
+		if err := rows.Scan(&e.ID, &e.ExecutionID, &e.Timestamp, &e.Level, &e.Message, &e.Component); err != nil {
+			return nil, err
+		}
+		entries = append(entries, &e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Reverse to chronological (oldest first) order for readable tail output.
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+
+	return entries, nil
 }
 
 // GetLastBriefSent returns the most recent brief record for a given channel.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -103,6 +103,102 @@ func TestGetRecentExecutions(t *testing.T) {
 	}
 }
 
+func TestGetLatestExecutionByTaskID(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	// Two executions of the same task: an older completed run and a newer running one,
+	// mirroring a retried/re-dispatched task (GH-3724: "pilot logs GH-<n>" must surface
+	// the latest attempt, not miss it).
+	older := &Execution{ID: "exec-old", TaskID: "GH-3714", ProjectPath: "/path", Status: "failed"}
+	if err := store.SaveExecution(older); err != nil {
+		t.Fatalf("SaveExecution(older) failed: %v", err)
+	}
+	newer := &Execution{ID: "exec-new", TaskID: "GH-3714", ProjectPath: "/path", Status: "running"}
+	if err := store.SaveExecution(newer); err != nil {
+		t.Fatalf("SaveExecution(newer) failed: %v", err)
+	}
+
+	got, err := store.GetLatestExecutionByTaskID("GH-3714")
+	if err != nil {
+		t.Fatalf("GetLatestExecutionByTaskID failed: %v", err)
+	}
+	if got.ID != "exec-new" {
+		t.Errorf("Expected latest execution 'exec-new', got '%s'", got.ID)
+	}
+
+	// Partial match, mirroring the previous recordings-based lookup behavior.
+	gotPartial, err := store.GetLatestExecutionByTaskID("3714")
+	if err != nil {
+		t.Fatalf("GetLatestExecutionByTaskID (partial) failed: %v", err)
+	}
+	if gotPartial.ID != "exec-new" {
+		t.Errorf("Expected partial match to resolve to 'exec-new', got '%s'", gotPartial.ID)
+	}
+
+	if _, err := store.GetLatestExecutionByTaskID("GH-9999"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("Expected sql.ErrNoRows for unknown task, got %v", err)
+	}
+}
+
+func TestGetLogsByExecutionID(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	base := time.Now()
+	messages := []string{"starting", "planning", "implementing", "done"}
+	for i, msg := range messages {
+		entry := &LogEntry{
+			ExecutionID: "GH-3714",
+			Timestamp:   base.Add(time.Duration(i) * time.Second),
+			Level:       "info",
+			Message:     msg,
+			Component:   "executor",
+		}
+		if err := store.SaveLogEntry(entry); err != nil {
+			t.Fatalf("SaveLogEntry failed: %v", err)
+		}
+	}
+	// A log line for a different task must not leak into the result.
+	if err := store.SaveLogEntry(&LogEntry{ExecutionID: "GH-9999", Timestamp: base, Level: "info", Message: "other task", Component: "executor"}); err != nil {
+		t.Fatalf("SaveLogEntry (other task) failed: %v", err)
+	}
+
+	logs, err := store.GetLogsByExecutionID("GH-3714", 100)
+	if err != nil {
+		t.Fatalf("GetLogsByExecutionID failed: %v", err)
+	}
+
+	if len(logs) != len(messages) {
+		t.Fatalf("Expected %d log entries, got %d", len(messages), len(logs))
+	}
+
+	// Entries must come back in chronological order.
+	for i, entry := range logs {
+		if entry.Message != messages[i] {
+			t.Errorf("Log entry %d: expected message %q, got %q", i, messages[i], entry.Message)
+		}
+	}
+
+	// limit keeps the most recent entries, in chronological order.
+	limited, err := store.GetLogsByExecutionID("GH-3714", 2)
+	if err != nil {
+		t.Fatalf("GetLogsByExecutionID (limited) failed: %v", err)
+	}
+	if len(limited) != 2 {
+		t.Fatalf("Expected 2 log entries, got %d", len(limited))
+	}
+	if limited[0].Message != "implementing" || limited[1].Message != "done" {
+		t.Errorf("Expected the 2 most recent entries in order, got %q, %q", limited[0].Message, limited[1].Message)
+	}
+}
+
 func TestPatternCRUD(t *testing.T) {
 	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
 	defer func() { _ = os.RemoveAll(tmpDir) }()

--- a/internal/replay/recorder.go
+++ b/internal/replay/recorder.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -583,6 +584,14 @@ func ListRecordings(basePath string, filter *RecordingFilter) ([]*RecordingSumma
 			EventCount:  recording.EventCount,
 		})
 	}
+
+	// os.ReadDir returns entries in lexicographic filename order, which for
+	// "TG-<unix-ms>" directory names is chronological ascending — the oldest
+	// recordings first. Sort newest-first before applying the limit so callers
+	// asking for "recent" recordings actually get the most recent ones (GH-3724).
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].StartTime.After(summaries[j].StartTime)
+	})
 
 	// Apply limit
 	if filter != nil && filter.Limit > 0 && len(summaries) > filter.Limit {

--- a/internal/replay/recorder_test.go
+++ b/internal/replay/recorder_test.go
@@ -1,6 +1,7 @@
 package replay
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -159,6 +160,75 @@ func TestListRecordings(t *testing.T) {
 
 	if len(recordings) != 2 {
 		t.Errorf("Expected 2 recordings with limit, got %d", len(recordings))
+	}
+}
+
+// TestListRecordingsSortsNewestFirstBeforeLimit is a regression test for GH-3724:
+// os.ReadDir returns "TG-<unix-ms>" directories in lexicographic order, which is
+// chronological ascending (oldest first). Applying filter.Limit without sorting first
+// used to keep the OLDEST N recordings instead of the newest N.
+func TestListRecordingsSortsNewestFirstBeforeLimit(t *testing.T) {
+	tests := []struct {
+		name          string
+		numRecordings int
+		limit         int
+	}{
+		{name: "limit smaller than total", numRecordings: 5, limit: 2},
+		{name: "limit equal to total", numRecordings: 3, limit: 3},
+		{name: "no limit", numRecordings: 4, limit: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			var taskIDs []string
+			for i := 0; i < tt.numRecordings; i++ {
+				taskID := fmt.Sprintf("TASK-%d", i)
+				recorder, err := NewRecorder(taskID, "/test/project", tmpDir)
+				if err != nil {
+					t.Fatalf("Failed to create recorder %d: %v", i, err)
+				}
+				_ = recorder.Finish("completed")
+				taskIDs = append(taskIDs, taskID)
+				time.Sleep(10 * time.Millisecond) // ensure ascending StartTime + directory name order
+			}
+
+			recordings, err := ListRecordings(tmpDir, &RecordingFilter{Limit: tt.limit})
+			if err != nil {
+				t.Fatalf("Failed to list recordings: %v", err)
+			}
+
+			wantCount := tt.limit
+			if wantCount <= 0 || wantCount > tt.numRecordings {
+				wantCount = tt.numRecordings
+			}
+			if len(recordings) != wantCount {
+				t.Fatalf("Expected %d recordings, got %d", wantCount, len(recordings))
+			}
+
+			// Results must be sorted newest-first.
+			for i := 1; i < len(recordings); i++ {
+				if recordings[i-1].StartTime.Before(recordings[i].StartTime) {
+					t.Errorf("Recordings not sorted newest-first: %v before %v",
+						recordings[i-1].StartTime, recordings[i].StartTime)
+				}
+			}
+
+			// Results must be the NEWEST tasks, not the oldest.
+			wantNewest := taskIDs[len(taskIDs)-wantCount:]
+			gotTaskIDs := make([]string, len(recordings))
+			gotByTaskID := make(map[string]bool, len(recordings))
+			for i, rec := range recordings {
+				gotTaskIDs[i] = rec.TaskID
+				gotByTaskID[rec.TaskID] = true
+			}
+			for _, want := range wantNewest {
+				if !gotByTaskID[want] {
+					t.Errorf("Expected newest task %s in result, got %v", want, gotTaskIDs)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- `ListRecordings` sorted nothing before applying `filter.Limit`, so `os.ReadDir`'s lexicographic (chronological-ascending) order over `TG-<ms>` dirs meant the OLDEST recordings were shown under "Recent Tasks". Now sorts by `StartTime` descending before truncating.
- `pilot logs` (both the recent-list and per-task views) now reads from the memory store (`executions` + `execution_logs`) instead of exclusively from finalized replay recordings, so running/just-completed tasks show up immediately instead of "no logs found". Replay recordings remain the source for `pilot replay`'s deep inspection.
- Added `Store.GetLatestExecutionByTaskID` and `Store.GetLogsByExecutionID` to `internal/memory`, both covered by new tests.
- Added a table-driven regression test for the sort-before-limit fix in `internal/replay`.

Closes #3724

## Test plan
- [x] `make build`
- [x] `make test` (pre-existing unrelated failures in `desktop` package's git-graph tests, verified present on `main` before this change too — they assert against hardcoded commit SHAs and drift with every new commit)
- [x] `make lint` / `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] Manually verified against the live `~/.pilot` DB: `pilot logs --limit 5` now lists today's tasks descending; `pilot logs GH-3715` (a failed/timed-out run) now prints its execution log lines instead of "no logs found"