### PR TITLE
GH-3716: feat(quality): per-project quality gates and pnpm/yarn/bun detection

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-03 (v2.151.0)
+**Last Updated:** 2026-06-26 (v2.151.0)
 
 ## Legend
 
@@ -196,6 +196,8 @@
 | Lint gates | ✅ | quality | - | `quality.gates[].type=lint` | Run lint commands |
 | Build gates | ✅ | quality | - | `quality.gates[].type=build` | Compile check |
 | Retry on failure | ✅ | quality | - | `quality.max_retries` | Auto-retry with feedback |
+| Per-project quality gates | ✅ | config, quality | - | `projects[].quality` | Project overrides win over global `quality.*`, then auto-detect (v2.201.4, GH-3716) |
+| pnpm/yarn/bun auto-detection | ✅ | quality | - | - | Lockfile-based PM detection for auto-detected build/test gates (v2.201.4, GH-3716) |
 
 ## Memory & Learning
 
@@ -306,7 +308,6 @@
 | Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |
 | OpenAI-compatible direct backend | ✅ | executor | `type: openai-api` | `executor.openai` | Direct /v1/chat/completions for OpenAI, OpenRouter, Groq, Synthetic, vLLM, Ollama (v2.105.0, GH-2382) |
-| Ping health check | ✅ | gateway | - | - | `/ping` → `pong`, no auth, no DB (v2.200.2, GH-3705) |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |
 | External-merge metrics | ✅ | autopilot | - | - | Record PRsMerged/IssuesProcessed/PRTimeToMerge for externally-merged PRs via scanner (v2.147.0, GH-2981) |
@@ -458,7 +459,7 @@
 | Input Adapters | 35 | 0 | 0 | 0 |
 | Output/Notifications | 18 | 0 | 0 | 0 |
 | Alerts & Monitoring | 11 | 0 | 0 | 0 |
-| Quality Gates | 5 | 0 | 0 | 0 |
+| Quality Gates | 7 | 0 | 0 | 0 |
 | Memory & Learning | 23 | 0 | 0 | 0 |
 | Dashboard | 24 | 0 | 0 | 0 |
 | Replay & Debug | 6 | 0 | 0 | 0 |

--- a/cmd/pilot/adapters.go
+++ b/cmd/pilot/adapters.go
@@ -235,6 +235,30 @@ type qualityCheckerWrapper struct {
 	executor *quality.Executor
 }
 
+// newProjectQualityCheckerFactory builds a per-task quality checker factory
+// that resolves the effective quality gate config per project (GH-3716):
+// the registered project's own `quality:` block takes precedence over the
+// global `Config.Quality`, which in turn takes precedence over an
+// auto-detected minimal build/test gate. This lets one Pilot deployment mix
+// stacks (e.g. Go/Makefile + pnpm/Node) without a global config tuned for
+// one stack forcing the wrong commands onto another.
+func newProjectQualityCheckerFactory(cfg *config.Config) func(taskID, taskProjectPath string) executor.QualityChecker {
+	return func(taskID, taskProjectPath string) executor.QualityChecker {
+		var projectQuality *quality.Config
+		if proj := cfg.FindProjectByPath(taskProjectPath); proj != nil {
+			projectQuality = proj.Quality
+		}
+		resolved := quality.ResolveConfig(projectQuality, cfg.Quality, taskProjectPath)
+		return &qualityCheckerWrapper{
+			executor: quality.NewExecutor(&quality.ExecutorConfig{
+				Config:      resolved,
+				ProjectPath: taskProjectPath,
+				TaskID:      taskID,
+			}),
+		}
+	}
+}
+
 // Check implements executor.QualityChecker by delegating to quality.Executor
 // and converting the result type
 func (w *qualityCheckerWrapper) Check(ctx context.Context) (*executor.QualityOutcome, error) {

--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -31,7 +31,6 @@ import (
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/pilot"
-	"github.com/qf-studio/pilot/internal/quality"
 	"github.com/qf-studio/pilot/internal/replay"
 	"github.com/qf-studio/pilot/internal/upgrade"
 )
@@ -595,19 +594,10 @@ Examples:
 				}
 			}
 
-			// Quality gates (GH-207)
-			if cfg.Quality != nil && cfg.Quality.Enabled {
-				runner.SetQualityCheckerFactory(func(taskID, projectPath string) executor.QualityChecker {
-					return &qualityCheckerWrapper{
-						executor: quality.NewExecutor(&quality.ExecutorConfig{
-							Config:      cfg.Quality,
-							ProjectPath: projectPath,
-							TaskID:      taskID,
-						}),
-					}
-				})
-				fmt.Println("   Quality:   ✓ gates enabled")
-			}
+			// Quality gates (GH-207). GH-3716: resolved per-project, falling
+			// back to the global config, then auto-detection.
+			runner.SetQualityCheckerFactory(newProjectQualityCheckerFactory(cfg))
+			fmt.Println("   Quality:   ✓ gates enabled")
 
 			// Decomposer status (GH-218) - wired via NewRunnerWithConfig
 			if cfg.Executor != nil && cfg.Executor.Decompose != nil && cfg.Executor.Decompose.Enabled {

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -40,7 +40,6 @@ import (
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/pilot"
-	"github.com/qf-studio/pilot/internal/quality"
 	"github.com/qf-studio/pilot/internal/teams"
 	"github.com/qf-studio/pilot/internal/tunnel"
 	"github.com/qf-studio/pilot/internal/upgrade"
@@ -383,18 +382,9 @@ Examples:
 				// TASK-286 / GH-3027: refuse sub-issue creation on unmanaged repos.
 				gwRunner.SetRepoAllowlist(newConfigRepoAllowlist(cfg))
 
-				// Set up quality gates on runner if configured
-				if cfg.Quality != nil && cfg.Quality.Enabled {
-					gwRunner.SetQualityCheckerFactory(func(taskID, taskProjectPath string) executor.QualityChecker {
-						return &qualityCheckerWrapper{
-							executor: quality.NewExecutor(&quality.ExecutorConfig{
-								Config:      cfg.Quality,
-								ProjectPath: taskProjectPath,
-								TaskID:      taskID,
-							}),
-						}
-					})
-				}
+				// Set up quality gates on runner (GH-3716: resolved per-project,
+				// falling back to the global config, then auto-detection).
+				gwRunner.SetQualityCheckerFactory(newProjectQualityCheckerFactory(cfg))
 
 				// Set up team project access checker if configured (GH-635)
 				if gwTeamCleanup := wireProjectAccessChecker(gwRunner, cfg); gwTeamCleanup != nil {
@@ -1012,19 +1002,11 @@ Examples:
 				return fmt.Errorf("failed to create Pilot: %w", err)
 			}
 
-			// Set up quality gates if configured (GH-207) - for orchestrator/webhook mode
-			if cfg.Quality != nil && cfg.Quality.Enabled {
-				p.SetQualityCheckerFactory(func(taskID, taskProjectPath string) executor.QualityChecker {
-					return &qualityCheckerWrapper{
-						executor: quality.NewExecutor(&quality.ExecutorConfig{
-							Config:      cfg.Quality,
-							ProjectPath: taskProjectPath,
-							TaskID:      taskID,
-						}),
-					}
-				})
-				logging.WithComponent("start").Info("quality gates enabled for webhook mode")
-			}
+			// Set up quality gates (GH-207) - for orchestrator/webhook mode.
+			// GH-3716: resolved per-project, falling back to the global
+			// config, then auto-detection.
+			p.SetQualityCheckerFactory(newProjectQualityCheckerFactory(cfg))
+			logging.WithComponent("start").Info("quality gates enabled for webhook mode")
 
 			// GH-1585: Wire autopilot provider to gateway so /api/v1/autopilot returns live PR data
 			if gwAutopilotController != nil {
@@ -1420,19 +1402,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	// TASK-286 / GH-3027: refuse sub-issue creation on unmanaged repos.
 	runner.SetRepoAllowlist(newConfigRepoAllowlist(cfg))
 
-	// Set up quality gates if configured (GH-207)
-	if cfg.Quality != nil && cfg.Quality.Enabled {
-		runner.SetQualityCheckerFactory(func(taskID, taskProjectPath string) executor.QualityChecker {
-			return &qualityCheckerWrapper{
-				executor: quality.NewExecutor(&quality.ExecutorConfig{
-					Config:      cfg.Quality,
-					ProjectPath: taskProjectPath,
-					TaskID:      taskID,
-				}),
-			}
-		})
-		logging.WithComponent("start").Info("quality gates enabled for polling mode")
-	}
+	// Set up quality gates (GH-207). GH-3716: resolved per-project, falling
+	// back to the global config, then auto-detection.
+	runner.SetQualityCheckerFactory(newProjectQualityCheckerFactory(cfg))
+	logging.WithComponent("start").Info("quality gates enabled for polling mode")
 
 	// Set up team project access checker if configured (GH-635)
 	if teamCleanup := wireProjectAccessChecker(runner, cfg); teamCleanup != nil {

--- a/cmd/pilot/wiring_test.go
+++ b/cmd/pilot/wiring_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/approval"
 	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/quality"
 	"github.com/qf-studio/pilot/internal/testutil"
 )
 
@@ -499,6 +502,114 @@ func TestQualityCheckerWrapper_NilResultFields(t *testing.T) {
 	// quality.Executor to executor.QualityChecker. If the interface changes,
 	// this file won't compile.
 	_ = &qualityCheckerWrapper{}
+}
+
+// =============================================================================
+// GH-3716: newProjectQualityCheckerFactory resolution precedence
+// =============================================================================
+
+func TestNewProjectQualityCheckerFactory_ProjectOverrideWinsOverGlobal(t *testing.T) {
+	projectPath := t.TempDir()
+
+	cfg := &config.Config{
+		Quality: &quality.Config{
+			Enabled: true,
+			Gates:   []*quality.Gate{{Name: "build", Type: quality.GateBuild, Command: "false", Required: true}},
+		},
+		Projects: []*config.ProjectConfig{
+			{
+				Name: "override-project",
+				Path: projectPath,
+				Quality: &quality.Config{
+					Enabled: true,
+					Gates:   []*quality.Gate{{Name: "build", Type: quality.GateBuild, Command: "true", Required: true}},
+				},
+			},
+		},
+	}
+
+	factory := newProjectQualityCheckerFactory(cfg)
+	checker := factory("task-1", projectPath)
+
+	outcome, err := checker.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if !outcome.Passed {
+		t.Error("expected project-level quality override (command: true) to pass, indicating it took precedence over the failing global config")
+	}
+}
+
+func TestNewProjectQualityCheckerFactory_FallsBackToGlobal(t *testing.T) {
+	projectPath := t.TempDir()
+
+	cfg := &config.Config{
+		Quality: &quality.Config{
+			Enabled: true,
+			Gates:   []*quality.Gate{{Name: "build", Type: quality.GateBuild, Command: "true", Required: true}},
+		},
+		Projects: []*config.ProjectConfig{
+			{Name: "no-override", Path: projectPath}, // no Quality set
+		},
+	}
+
+	factory := newProjectQualityCheckerFactory(cfg)
+	checker := factory("task-1", projectPath)
+
+	outcome, err := checker.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if !outcome.Passed {
+		t.Error("expected global quality config to apply when project has no override")
+	}
+}
+
+func TestNewProjectQualityCheckerFactory_AutoDetectsWhenUnconfigured(t *testing.T) {
+	projectPath := t.TempDir()
+
+	// No global Quality, no matching project entry — should synthesize a
+	// minimal config via quality.AutoDetectConfig rather than reuse a
+	// mismatched global config or panic on a nil config.
+	cfg := &config.Config{}
+
+	factory := newProjectQualityCheckerFactory(cfg)
+	checker := factory("task-1", projectPath)
+
+	outcome, err := checker.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	// Empty tmp dir has no detectable build command, so AutoDetectConfig
+	// yields a disabled config, which Check() short-circuits as passed.
+	if !outcome.Passed {
+		t.Error("expected auto-detect on an unrecognized project to short-circuit as passed rather than fail or panic")
+	}
+}
+
+func TestNewProjectQualityCheckerFactory_AutoDetectsGoProject(t *testing.T) {
+	projectPath := t.TempDir()
+	if err := os.WriteFile(projectPath+"/go.mod", []byte("module autodetecttest\n\ngo 1.21\n"), 0644); err != nil {
+		t.Fatalf("failed to write go.mod: %v", err)
+	}
+
+	cfg := &config.Config{}
+
+	factory := newProjectQualityCheckerFactory(cfg)
+	checker := factory("task-1", projectPath)
+
+	// Sanity check the resolution picked the Go build command rather than
+	// silently disabling gates, without actually invoking `go build`.
+	resolved := quality.ResolveConfig(nil, cfg.Quality, projectPath)
+	if !resolved.Enabled {
+		t.Fatal("expected auto-detect to enable gates for a Go project")
+	}
+	if resolved.Gates[0].Command != "go build ./..." {
+		t.Errorf("auto-detected build command = %q, want %q", resolved.Gates[0].Command, "go build ./...")
+	}
+	if checker == nil {
+		t.Fatal("expected a non-nil checker")
+	}
 }
 
 // =============================================================================

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -414,6 +414,33 @@ memory:
     max_patterns: 5           # Max patterns injected per task
     include_anti: true        # Include anti-patterns in prompts
 
+# Quality gates (GH-207) - run after implementation, before a PR is created.
+# Applies to every project unless a project defines its own `quality:` block
+# below (GH-3716). If neither is set, Pilot auto-detects a minimal build/test
+# gate per project (Go/Makefile/npm/pnpm/yarn/bun) so unconfigured projects
+# never inherit commands tuned for a different stack.
+quality:
+  enabled: true
+  gates:
+    - name: build
+      type: build
+      command: "make build"
+      required: true
+      timeout: 5m
+    - name: test
+      type: test
+      command: "make test"
+      required: true
+      timeout: 10m
+    - name: lint
+      type: lint
+      command: "make lint"
+      required: false          # Warn only by default
+      timeout: 2m
+  on_failure:
+    action: retry              # retry, fail, or warn
+    max_retries: 2
+
 # Project configurations
 projects:
   # Example project
@@ -435,6 +462,24 @@ projects:
     # Precedence: project-level linear.project_id > workspace-level > default_project
     # linear:
     #   project_id: "proj-abc123"   # Linear project UUID
+    # Per-project quality gates (GH-3716) - overrides the top-level `quality:`
+    # block above for this project only. Useful when a deployment's global
+    # gates (e.g. Go/Makefile) don't fit a project on a different stack
+    # (e.g. a pnpm workspace). Resolution order: project quality > global
+    # quality > auto-detected build/test gate.
+    # quality:
+    #   enabled: true
+    #   gates:
+    #     - name: build
+    #       type: build
+    #       command: "pnpm run build"
+    #       required: true
+    #       timeout: 5m
+    #     - name: test
+    #       type: test
+    #       command: "pnpm test"
+    #       required: true
+    #       timeout: 10m
 
 # Autopilot settings
 autopilot:

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -13,6 +13,11 @@ import (
 // TestGetGitGraph_DefaultLimit verifies that passing limit=0 falls back to 100
 // and that the returned GitGraphData mirrors dashboard.GitGraphState fields.
 func TestGetGitGraph_DefaultLimit(t *testing.T) {
+	// Isolate from the real user config (~/.pilot/config.yaml), whose first
+	// configured project may point at a different repo entirely — App.GetGitGraph
+	// would then diff against that repo instead of ".".
+	t.Setenv("HOME", t.TempDir())
+
 	// Use "." as project path (current dir is inside a git repo during tests).
 	state := dashboard.FetchGitGraph(".", 100)
 	if state == nil {
@@ -32,6 +37,10 @@ func TestGetGitGraph_DefaultLimit(t *testing.T) {
 
 // TestGetGitGraph_LinesMapping verifies each GitGraphLine field is copied correctly.
 func TestGetGitGraph_LinesMapping(t *testing.T) {
+	// See TestGetGitGraph_DefaultLimit: isolate from the real user config so
+	// App.GetGitGraph resolves the same project path (".") as this test does.
+	t.Setenv("HOME", t.TempDir())
+
 	state := dashboard.FetchGitGraph(".", 5)
 	if state == nil || len(state.Lines) == 0 {
 		t.Skip("no git commits available in test environment")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,6 +226,11 @@ type ProjectConfig struct {
 	TeamReviewers []string             `yaml:"team_reviewers,omitempty"`
 	GitHub        *ProjectGitHubConfig `yaml:"github,omitempty"`
 	Linear        *ProjectLinearConfig `yaml:"linear,omitempty"`
+	// Quality overrides the global quality gate config for this project
+	// (GH-3716). Takes precedence over the top-level Config.Quality — lets a
+	// pnpm/yarn/bun or other non-Go project define its own build/test/lint
+	// gates instead of inheriting commands tuned for a different stack.
+	Quality *quality.Config `yaml:"quality,omitempty"`
 }
 
 // ResolveBaseBranch returns the branch that Pilot should branch from and

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1142,6 +1142,63 @@ projects:
 	}
 }
 
+func TestProjectConfigQualityYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `
+version: "1.0"
+quality:
+  enabled: true
+  gates:
+    - name: build
+      type: build
+      command: "make build"
+      required: true
+projects:
+  - name: "with-quality"
+    path: "/with-quality"
+    quality:
+      enabled: true
+      gates:
+        - name: build
+          type: build
+          command: "pnpm run build"
+          required: true
+  - name: "without-quality"
+    path: "/without-quality"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	withQuality := cfg.GetProject("/with-quality")
+	if withQuality == nil {
+		t.Fatal("project 'with-quality' not found")
+	}
+	if withQuality.Quality == nil || !withQuality.Quality.Enabled {
+		t.Fatal("expected project-level quality config to be set and enabled")
+	}
+	if len(withQuality.Quality.Gates) != 1 || withQuality.Quality.Gates[0].Command != "pnpm run build" {
+		t.Errorf("project quality gates = %+v, want single pnpm build gate", withQuality.Quality.Gates)
+	}
+
+	withoutQuality := cfg.GetProject("/without-quality")
+	if withoutQuality == nil {
+		t.Fatal("project 'without-quality' not found")
+	}
+	if withoutQuality.Quality != nil {
+		t.Errorf("expected project 'without-quality' to have nil Quality, got %+v", withoutQuality.Quality)
+	}
+
+	if cfg.Quality == nil || !cfg.Quality.Enabled {
+		t.Fatal("expected global quality config to remain set and enabled")
+	}
+}
+
 // Helper function to check if a string contains a substring
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||

--- a/internal/quality/types.go
+++ b/internal/quality/types.go
@@ -5,6 +5,7 @@ package quality
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -260,6 +261,50 @@ func MinimalBuildGate() *Config {
 	}
 }
 
+// ResolveConfig determines the effective quality gate config for a project
+// using the precedence: per-project config, then the global config, then an
+// auto-detected minimal build/test gate (GH-3716). This lets a single Pilot
+// deployment mix stacks (e.g. Go/Makefile + pnpm/Node) without a global
+// config tuned for one stack forcing the wrong commands onto another.
+func ResolveConfig(projectQuality, globalQuality *Config, projectPath string) *Config {
+	if projectQuality != nil && projectQuality.Enabled {
+		return projectQuality
+	}
+	if globalQuality != nil && globalQuality.Enabled {
+		return globalQuality
+	}
+	return AutoDetectConfig(projectPath)
+}
+
+// AutoDetectConfig synthesizes a minimal quality gate config by detecting
+// the project's build and test commands (GH-363). Returns a disabled Config
+// if no build command can be detected, so callers can run Check() against
+// the result unconditionally without special-casing "no gates".
+func AutoDetectConfig(projectPath string) *Config {
+	buildCmd := DetectBuildCommand(projectPath)
+	if buildCmd == "" {
+		return &Config{Enabled: false}
+	}
+
+	cfg := MinimalBuildGate()
+	cfg.Gates[0].Command = buildCmd
+
+	if testCmd := DetectTestCommand(projectPath); testCmd != "" {
+		cfg.Gates = append(cfg.Gates, &Gate{
+			Name:        "test",
+			Type:        GateTest,
+			Command:     testCmd,
+			Required:    true,
+			Timeout:     5 * time.Minute,
+			MaxRetries:  1,
+			RetryDelay:  3 * time.Second,
+			FailureHint: "Fix failing tests in the changed files",
+		})
+	}
+
+	return cfg
+}
+
 // DetectBuildCommand returns appropriate build command for the project.
 // Checks for common project indicators and returns the build command.
 // Returns empty string if project type cannot be detected.
@@ -270,10 +315,11 @@ func DetectBuildCommand(projectPath string) string {
 	}
 	// Check for Node.js project with TypeScript
 	if fileExists(filepath.Join(projectPath, "package.json")) {
+		pm := detectPackageManager(projectPath)
 		if fileExists(filepath.Join(projectPath, "tsconfig.json")) {
-			return "npm run build || npx tsc --noEmit"
+			return fmt.Sprintf("%s run build || npx tsc --noEmit", pm)
 		}
-		return "npm run build --if-present"
+		return fmt.Sprintf("%s run build --if-present", pm)
 	}
 	// Check for Rust project
 	if fileExists(filepath.Join(projectPath, "Cargo.toml")) {
@@ -311,7 +357,7 @@ func DetectTestCommand(projectPath string) string {
 		return "pytest -v 2>&1"
 	}
 	if fileExists(filepath.Join(projectPath, "package.json")) {
-		return "npm test"
+		return fmt.Sprintf("%s test", detectPackageManager(projectPath))
 	}
 	if fileExists(filepath.Join(projectPath, "Cargo.toml")) {
 		return "cargo test"
@@ -320,6 +366,22 @@ func DetectTestCommand(projectPath string) string {
 		return "go test ./..."
 	}
 	return ""
+}
+
+// detectPackageManager returns the Node.js package manager indicated by the
+// project's lockfile — pnpm-lock.yaml, yarn.lock, bun.lockb/bun.lock — or
+// "npm" if none of those are present (GH-3716).
+func detectPackageManager(projectPath string) string {
+	switch {
+	case fileExists(filepath.Join(projectPath, "pnpm-lock.yaml")):
+		return "pnpm"
+	case fileExists(filepath.Join(projectPath, "yarn.lock")):
+		return "yarn"
+	case fileExists(filepath.Join(projectPath, "bun.lockb")), fileExists(filepath.Join(projectPath, "bun.lock")):
+		return "bun"
+	default:
+		return "npm"
+	}
 }
 
 // hasMakefileTarget reports whether the Makefile at path declares the given

--- a/internal/quality/types_test.go
+++ b/internal/quality/types_test.go
@@ -310,6 +310,41 @@ func TestDetectBuildCommand(t *testing.T) {
 			expectedCmd: "npm run build --if-present",
 		},
 		{
+			name:        "pnpm project without typescript",
+			setupFiles:  []string{"package.json", "pnpm-lock.yaml"},
+			expectedCmd: "pnpm run build --if-present",
+		},
+		{
+			name:        "yarn project without typescript",
+			setupFiles:  []string{"package.json", "yarn.lock"},
+			expectedCmd: "yarn run build --if-present",
+		},
+		{
+			name:        "bun project without typescript (bun.lockb)",
+			setupFiles:  []string{"package.json", "bun.lockb"},
+			expectedCmd: "bun run build --if-present",
+		},
+		{
+			name:        "bun project without typescript (bun.lock)",
+			setupFiles:  []string{"package.json", "bun.lock"},
+			expectedCmd: "bun run build --if-present",
+		},
+		{
+			name:        "pnpm project with typescript",
+			setupFiles:  []string{"package.json", "tsconfig.json", "pnpm-lock.yaml"},
+			expectedCmd: "pnpm run build || npx tsc --noEmit",
+		},
+		{
+			name:        "yarn project with typescript",
+			setupFiles:  []string{"package.json", "tsconfig.json", "yarn.lock"},
+			expectedCmd: "yarn run build || npx tsc --noEmit",
+		},
+		{
+			name:        "bun project with typescript",
+			setupFiles:  []string{"package.json", "tsconfig.json", "bun.lockb"},
+			expectedCmd: "bun run build || npx tsc --noEmit",
+		},
+		{
 			name:        "rust project",
 			setupFiles:  []string{"Cargo.toml"},
 			expectedCmd: "cargo check",
@@ -394,6 +429,26 @@ func TestDetectTestCommand(t *testing.T) {
 			expectedCmd: "npm test",
 		},
 		{
+			name:        "pnpm test",
+			files:       map[string]string{"package.json": "{}", "pnpm-lock.yaml": ""},
+			expectedCmd: "pnpm test",
+		},
+		{
+			name:        "yarn test",
+			files:       map[string]string{"package.json": "{}", "yarn.lock": ""},
+			expectedCmd: "yarn test",
+		},
+		{
+			name:        "bun test (bun.lockb)",
+			files:       map[string]string{"package.json": "{}", "bun.lockb": ""},
+			expectedCmd: "bun test",
+		},
+		{
+			name:        "bun test (bun.lock)",
+			files:       map[string]string{"package.json": "{}", "bun.lock": ""},
+			expectedCmd: "bun test",
+		},
+		{
 			name:        "cargo test",
 			files:       map[string]string{"Cargo.toml": ""},
 			expectedCmd: "cargo test",
@@ -448,4 +503,158 @@ func TestDetectBuildCommand_Priority(t *testing.T) {
 	if got != "go build ./..." {
 		t.Errorf("expected Go build command to take priority, got %q", got)
 	}
+}
+
+func TestResolveConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "quality-resolve-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	goProjectDir := filepath.Join(tmpDir, "go-project")
+	if err := os.MkdirAll(goProjectDir, 0755); err != nil {
+		t.Fatalf("failed to create test dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(goProjectDir, "go.mod"), []byte("module x\n"), 0644); err != nil {
+		t.Fatalf("failed to write go.mod: %v", err)
+	}
+
+	emptyDir := filepath.Join(tmpDir, "empty")
+	if err := os.MkdirAll(emptyDir, 0755); err != nil {
+		t.Fatalf("failed to create test dir: %v", err)
+	}
+
+	projectQuality := &Config{
+		Enabled: true,
+		Gates:   []*Gate{{Name: "build", Type: GateBuild, Command: "pnpm run build", Required: true}},
+	}
+	globalQuality := &Config{
+		Enabled: true,
+		Gates:   []*Gate{{Name: "build", Type: GateBuild, Command: "make build", Required: true}},
+	}
+	disabledGlobal := &Config{Enabled: false}
+
+	tests := []struct {
+		name           string
+		projectQuality *Config
+		globalQuality  *Config
+		projectPath    string
+		wantConfig     *Config // exact pointer identity expected, or nil to check auto-detect
+		wantAutoDetect bool
+		wantEnabled    bool
+	}{
+		{
+			name:           "project config takes precedence over global",
+			projectQuality: projectQuality,
+			globalQuality:  globalQuality,
+			projectPath:    goProjectDir,
+			wantConfig:     projectQuality,
+		},
+		{
+			name:           "falls back to global when project has no override",
+			projectQuality: nil,
+			globalQuality:  globalQuality,
+			projectPath:    goProjectDir,
+			wantConfig:     globalQuality,
+		},
+		{
+			name:           "falls back to global when project quality disabled",
+			projectQuality: &Config{Enabled: false},
+			globalQuality:  globalQuality,
+			projectPath:    goProjectDir,
+			wantConfig:     globalQuality,
+		},
+		{
+			name:           "auto-detects when neither project nor global configured",
+			projectQuality: nil,
+			globalQuality:  nil,
+			projectPath:    goProjectDir,
+			wantAutoDetect: true,
+			wantEnabled:    true,
+		},
+		{
+			name:           "auto-detects when global present but disabled",
+			projectQuality: nil,
+			globalQuality:  disabledGlobal,
+			projectPath:    goProjectDir,
+			wantAutoDetect: true,
+			wantEnabled:    true,
+		},
+		{
+			name:           "auto-detect yields disabled config when nothing detectable",
+			projectQuality: nil,
+			globalQuality:  nil,
+			projectPath:    emptyDir,
+			wantAutoDetect: true,
+			wantEnabled:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveConfig(tt.projectQuality, tt.globalQuality, tt.projectPath)
+			if got == nil {
+				t.Fatal("ResolveConfig() returned nil, want a non-nil Config")
+			}
+			if tt.wantConfig != nil {
+				if got != tt.wantConfig {
+					t.Errorf("ResolveConfig() = %p, want %p (exact config)", got, tt.wantConfig)
+				}
+				return
+			}
+			if tt.wantAutoDetect {
+				if got.Enabled != tt.wantEnabled {
+					t.Errorf("ResolveConfig() auto-detected Enabled = %v, want %v", got.Enabled, tt.wantEnabled)
+				}
+			}
+		})
+	}
+}
+
+func TestAutoDetectConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "quality-autodetect-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	t.Run("go project with tests", func(t *testing.T) {
+		dir := filepath.Join(tmpDir, "go-project")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("failed to create test dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x\n"), 0644); err != nil {
+			t.Fatalf("failed to write go.mod: %v", err)
+		}
+
+		cfg := AutoDetectConfig(dir)
+		if !cfg.Enabled {
+			t.Fatal("expected auto-detected config to be enabled")
+		}
+		if len(cfg.Gates) != 2 {
+			t.Fatalf("expected build + test gates, got %d gates", len(cfg.Gates))
+		}
+		if cfg.Gates[0].Command != "go build ./..." {
+			t.Errorf("build command = %q, want %q", cfg.Gates[0].Command, "go build ./...")
+		}
+		if cfg.Gates[1].Command != "go test ./..." {
+			t.Errorf("test command = %q, want %q", cfg.Gates[1].Command, "go test ./...")
+		}
+	})
+
+	t.Run("undetectable project", func(t *testing.T) {
+		dir := filepath.Join(tmpDir, "unknown-project")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("failed to create test dir: %v", err)
+		}
+
+		cfg := AutoDetectConfig(dir)
+		if cfg.Enabled {
+			t.Error("expected disabled config when no build command is detectable")
+		}
+		if len(cfg.Gates) != 0 {
+			t.Errorf("expected no gates, got %d", len(cfg.Gates))
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3716.

Closes #3716

## Changes

GitHub Issue #3716: feat(quality): per-project quality gates and pnpm/yarn/bun detection

## Context

Quality gates are strictly global: `Config.Quality` applies to every project, and `ProjectConfig` (`internal/config/config.go:216-229`) has no `Quality` field. A deployment tuned for the Pilot repo (gates `make build/test/lint`) forces those commands onto every registered project — a fresh Next.js/pnpm repo without a Makefile fails every gate, and the executor agent works around it by inventing a Makefile (observed live 2026-06-30). Additionally, stack auto-detection (`DetectBuildCommand`/`DetectTestCommand`, `internal/quality/types.go:266-323`) is npm-only — it emits `npm run build`/`npm test` even on pnpm/yarn/bun workspaces.

## Approach

1. Add `Quality *quality.Config \`yaml:"quality,omitempty"\`` to `ProjectConfig`.
2. Resolution precedence per task: **project.Quality → global cfg.Quality → auto-detect** (`MinimalBuildGate()` + detect functions as the synthesized fallback, `types.go:241`). Wire at the three quality-factory sites — `cmd/pilot/main.go:387-396`, `1016-1026`, `1425-1427` — the `SetQualityCheckerFactory` closure is already keyed by `taskProjectPath`; resolve the project by path there. Reuse `quality.NewExecutor` unchanged.
3. Package-manager detection: in `DetectBuildCommand`/`DetectTestCommand`, check lockfiles before emitting a command — `pnpm-lock.yaml` → `pnpm`, `yarn.lock` → `yarn`, `bun.lockb`/`bun.lock` → `bun`, else `npm`. Apply the chosen PM to build/test invocations.

## Acceptance

- [ ] Table tests: project with own `quality:` block uses it; project without falls back to global; neither → auto-detect
- [ ] Table tests: pnpm/yarn/bun/npm lockfile matrix for both detect functions
- [ ] Pilot repo behavior unchanged (Go + Makefile + global gates)
- [ ] `configs/pilot.example.yaml` documents the per-project `quality:` block
- [ ] `make build && make test && make lint` green

## Refs

- `internal/config/config.go:216`, `internal/quality/types.go:161-323`, `cmd/pilot/main.go:387/1016/1425`
- Part of TASK-378 (`.agent/tasks/TASK-378-new-project-onboarding-hardening.md`)