### PR TITLE
fix(llm): include error body in non-200 API error messages

### DIFF
--- a/internal/intent/anthropic_test.go
+++ b/internal/intent/anthropic_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -173,6 +174,50 @@ func TestAnthropicClientClassify(t *testing.T) {
 				if intent != tt.expectedIntent {
 					t.Errorf("intent = %v, want %v", intent, tt.expectedIntent)
 				}
+			}
+		})
+	}
+}
+
+func TestAnthropicClientClassify_Non200IncludesBody(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantSubstr string
+	}{
+		{
+			name:       "400 invalid request error",
+			statusCode: http.StatusBadRequest,
+			body:       `{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens: Field required"}}`,
+			wantSubstr: "max_tokens: Field required",
+		},
+		{
+			name:       "401 authentication error",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`,
+			wantSubstr: "invalid x-api-key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewAnthropicClient("test-api-key")
+			client.SetAPIURL(server.URL)
+
+			ctx := context.Background()
+			_, err := client.Classify(ctx, nil, "hello")
+			if err == nil {
+				t.Fatal("expected error on non-200 response")
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tt.wantSubstr)
 			}
 		})
 	}

--- a/internal/intent/classifier.go
+++ b/internal/intent/classifier.go
@@ -5,9 +5,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"time"
 )
+
+// maxErrorBodyBytes caps how much of a non-200 response body we read into an
+// error message, so a misbehaving API doesn't force us to buffer an unbounded
+// payload.
+const maxErrorBodyBytes = 4096
 
 // ConversationMessage represents a message in the conversation
 type ConversationMessage struct {
@@ -136,7 +143,8 @@ Respond with JSON only: {"intent": "...", "confidence": 0.0-1.0}`
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("API returned status %d", resp.StatusCode)
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		return "", fmt.Errorf("API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
 	}
 
 	// Parse response

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -13,6 +14,11 @@ import (
 )
 
 const defaultAPIURL = "https://api.anthropic.com/v1/messages"
+
+// maxErrorBodyBytes caps how much of a non-200 response body we read into an
+// error message, so a misbehaving API doesn't force us to buffer an unbounded
+// payload.
+const maxErrorBodyBytes = 4096
 
 // maxTokens caps the response length for bot replies (chat, grounded Q&A, issue
 // drafts). The Anthropic Messages API REQUIRES max_tokens — omitting it returns
@@ -81,7 +87,8 @@ func (c *Client) Answer(ctx context.Context, model, system string, history []int
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("llm: API returned status %d", resp.StatusCode)
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		return "", fmt.Errorf("llm: API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
 	}
 
 	var apiResp struct {

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/qf-studio/pilot/internal/intent"
@@ -133,6 +134,56 @@ func TestAnswer_Non200(t *testing.T) {
 	_, err := c.Answer(context.Background(), "claude-haiku-4-5-20251001", "sys", nil, "hi")
 	if err == nil {
 		t.Fatal("expected error on non-200 response")
+	}
+}
+
+func TestAnswer_Non200IncludesBody(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       interface{}
+		wantSubstr string
+	}{
+		{
+			name:       "400 invalid request error",
+			statusCode: http.StatusBadRequest,
+			body: map[string]interface{}{
+				"type": "error",
+				"error": map[string]string{
+					"type":    "invalid_request_error",
+					"message": "max_tokens: Field required",
+				},
+			},
+			wantSubstr: "max_tokens: Field required",
+		},
+		{
+			name:       "401 authentication error",
+			statusCode: http.StatusUnauthorized,
+			body: map[string]interface{}{
+				"type": "error",
+				"error": map[string]string{
+					"type":    "authentication_error",
+					"message": "invalid x-api-key",
+				},
+			},
+			wantSubstr: "invalid x-api-key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := makeServer(t, tt.statusCode, tt.body)
+			defer srv.Close()
+
+			c := newTestClient(srv.URL)
+			_, err := c.Answer(context.Background(), "claude-haiku-4-5-20251001", "sys", nil, "hi")
+			if err == nil {
+				t.Fatal("expected error on non-200 response")
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tt.wantSubstr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Bound the non-200 response body read to 4KB via `io.LimitReader` in `internal/llm/client.go` (Answer) and `internal/intent/classifier.go` (Classify), then include the trimmed body in the returned error so Anthropic's diagnostic message (e.g. `max_tokens: Field required`) is surfaced instead of just the HTTP status code.

## Test plan
- [x] `go test ./internal/llm/... ./internal/intent/...` — new table-driven `httptest`-based tests (`TestAnswer_Non200IncludesBody`, `TestAnthropicClientClassify_Non200IncludesBody`) force a 400 with a JSON error body and assert the returned error string contains the body's message
- [x] `go build ./...`
- [x] `go vet ./internal/llm/... ./internal/intent/...`

Closes GH-3733