### PR TITLE
fix(executor): log alert engine start failure as Error with remediation hint

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -613,7 +613,7 @@ Examples:
 					ctx := context.Background()
 					gwAlertsEngine = alerts.NewEngine(alertsCfg, alerts.WithDispatcher(alertsDispatcher), alerts.WithAlertMetrics(alertsMetrics))
 					if alertErr := gwAlertsEngine.Start(ctx); alertErr != nil {
-						logging.WithComponent("start").Warn("failed to start alerts engine for gateway polling", slog.Any("error", alertErr))
+						logging.WithComponent("start").Error("alert engine failed to start — downstream alerters will be silently disabled; check alerts config", slog.Any("error", alertErr))
 						gwAlertsEngine = nil
 					}
 				}
@@ -2048,7 +2048,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 
 		alertsEngine = alerts.NewEngine(alertsCfg, alerts.WithDispatcher(alertsDispatcher), alerts.WithAlertMetrics(alertsMetrics))
 		if err := alertsEngine.Start(ctx); err != nil {
-			logging.WithComponent("start").Warn("failed to start alerts engine", slog.Any("error", err))
+			logging.WithComponent("start").Error("alert engine failed to start — downstream alerters will be silently disabled; check alerts config", slog.Any("error", err))
 			alertsEngine = nil
 		} else {
 			logging.WithComponent("start").Info("alerts engine started",


### PR DESCRIPTION
## Summary
- Raise the alerts.Engine.Start(ctx) failure log from Warn to Error at both call sites in cmd/pilot/main.go (gateway/dashboard polling path and standalone polling mode).
- Add a remediation hint to the message so operators know downstream alerters are silently disabled and to check the alerts config.

## Test plan
- [x] `go build ./...`
- [x] Verified both log sites via grep