### PR TITLE
fix(autopilot): cap auto-rebase oscillation and persist failed-retry counter

### DIFF
--- a/.agent/tasks/gh-3715.md
+++ b/.agent/tasks/gh-3715.md
@@ -1,0 +1,47 @@
+# GH-3715
+
+**Created:** 2026-07-03
+
+## Problem
+
+GitHub Issue #3715: fix(autopilot): cap auto-rebase oscillation and persist failed-retry counter
+
+## Context
+
+Two retry paths have no effective cap:
+
+1. **Auto-rebase oscillation.** `handleMergeConflict` (`internal/autopilot/controller.go:2251-2299`): when `UpdatePullRequestBranch` succeeds it returns the PR to `StageWaitingCI` consuming NO retry budget (`controller.go:2259-2264`). A PR can cycle conflict → rebase-success → CI → conflict indefinitely. (The close-PR path IS capped downstream via `pilot-retry-ready` → `pilot-retry-1/2` → `pilot-retry-exhausted` — do NOT add another re-dispatch cap there.)
+2. **`maxFailedRetries` is in-memory only** (`internal/adapters/github/poller.go:381`, `failedRetryCount` map): a daemon restart resets it, so a persistently failing issue retries indefinitely across restarts.
+
+## Approach
+
+- Add a per-PR rebase-cycle counter to `PRState` (sibling of `MaxMergeAttempts`, `internal/autopilot/types.go:154`), persisted via the existing autopilot state store. On the Nth successful auto-rebase for the same PR (suggest N=3), stop rebasing: escalate to `StageFailed` + comment for human attention instead.
+- Persist the failed-retry count restart-safe: mirror the GH-2432 label-counter pattern (`pilot-retry-N`) or store in the state store keyed by issue.
+- Regression-guard: re-dispatch is a multi-mechanism chain (autopilot close → `notifyExternalClose` → poller re-dispatch → decomposer) — verify no path bypasses the new counters (see knowledge-graph memory `bug_handleconflict_no_refile`).
+
+## Acceptance
+
+- [x] Test: 3rd auto-rebase for same PR escalates instead of rebasing; counter resets on merge
+- [x] Test: failed-retry count survives poller reconstruction (simulated restart)
+- [x] Existing autopilot/poller tests green; `make build && make test && make lint` green
+
+## Resolution
+
+- `PRState.RebaseAttempts` (types.go) caps successful auto-rebases in
+  `handleMergeConflict` (controller.go): Nth successful rebase (default N=3,
+  `Config.MaxRebaseAttempts`) escalates to `StageFailed` + PR comment instead of
+  returning to `StageWaitingCI`. Resets to 0 on clean merge. Persisted via
+  `state_store.go` (`rebase_attempts` column, migration + Save/Get/LoadAll).
+- `shouldRetryFailedIssue` (poller.go) now mirrors the GH-2432 label pattern:
+  `pilot-failed-retry-1` → `-2` → `-exhausted` replace the in-memory
+  `failedRetryCount` map as the source of truth, so the budget survives daemon
+  restarts. `auto_merger.go` strips these labels (like `RetryStateLabels`) on
+  merge success.
+
+## Refs
+
+- `internal/autopilot/controller.go:2259`, `internal/autopilot/types.go:154`, `internal/adapters/github/poller.go:381`, `poller.go:1871-1935`
+- Part of TASK-378 (`.agent/tasks/TASK-378-new-project-onboarding-hardening.md`)
+
+## Acceptance Criteria
+

--- a/internal/adapters/github/gh3715_test.go
+++ b/internal/adapters/github/gh3715_test.go
@@ -1,0 +1,229 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// GH-3715: pilot-failed retry counter is persisted via labels (pilot-failed-retry-1,
+// pilot-failed-retry-2, pilot-failed-retry-exhausted) so the budget survives
+// `pilot start` restarts, mirroring the GH-2432 pilot-retry-ready mechanism.
+
+// First retry on a fresh pilot-failed issue should add pilot-failed-retry-1.
+func TestPoller_FailedRetryLabel_FirstAttemptAddsRetry1(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+
+	var addedLabels atomic.Value
+	addedLabels.Store([]string(nil))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/issues/42/labels"):
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			prev, _ := addedLabels.Load().([]string)
+			addedLabels.Store(append(prev, body.Labels...))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+			return
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+			return
+		case r.URL.Path == "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithRetryGracePeriod(0))
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil || issue.Number != 42 {
+		t.Fatalf("expected #42 to be dispatched, got %v", issue)
+	}
+
+	added, _ := addedLabels.Load().([]string)
+	foundRetry1 := false
+	for _, l := range added {
+		if l == LabelFailedRetry1 {
+			foundRetry1 = true
+		}
+	}
+	if !foundRetry1 {
+		t.Errorf("expected pilot-failed-retry-1 to be added, got labels=%v", added)
+	}
+}
+
+// pilot-failed-retry-2 + pilot-failed → escalate to pilot-failed-retry-exhausted, no dispatch.
+func TestPoller_FailedRetryLabel_Retry2EscalatesToExhausted(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}, {Name: LabelFailedRetry2}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, State: "open", Title: "Available", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	var addedLabels atomic.Value
+	addedLabels.Store([]string(nil))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/issues/42/labels"):
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			prev, _ := addedLabels.Load().([]string)
+			addedLabels.Store(append(prev, body.Labels...))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+			return
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+			return
+		case r.URL.Path == "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithRetryGracePeriod(0))
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil {
+		t.Fatal("expected #43 to be dispatched (skipping exhausted #42)")
+	}
+	if issue.Number != 43 {
+		t.Errorf("got issue #%d, want #43", issue.Number)
+	}
+
+	added, _ := addedLabels.Load().([]string)
+	foundExhausted := false
+	for _, l := range added {
+		if l == LabelFailedRetryExhausted {
+			foundExhausted = true
+		}
+	}
+	if !foundExhausted {
+		t.Errorf("expected pilot-failed-retry-exhausted to be stamped on #42, got %v", added)
+	}
+}
+
+// pilot-failed-retry-exhausted is terminal — never dispatched.
+func TestPoller_FailedRetryLabel_ExhaustedIsTerminal(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Exhausted", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}, {Name: LabelFailedRetryExhausted}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, State: "open", Title: "Available", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithRetryGracePeriod(0))
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil || issue.Number != 43 {
+		t.Errorf("expected #43, got %v", issue)
+	}
+}
+
+// GH-3715 acceptance: the failed-retry count must survive a poller restart.
+// Because the counter lives in GitHub labels rather than the in-memory
+// failedRetryCount map, a brand-new Poller instance (simulating a daemon
+// restart) built against the same issue state must still honor the
+// exhausted/limit label — the previous in-memory map would have reset to
+// zero on reconstruction and allowed indefinite retries.
+func TestPoller_FailedRetryLabel_SurvivesPollerReconstruction(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}, {Name: LabelFailedRetry2}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, State: "open", Title: "Available", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/issues/42/labels"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+			return
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+			return
+		case r.URL.Path == "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	// Simulate a crash/restart: this is a fresh Poller with a zero-value
+	// failedRetryCount map, exactly as would happen after `pilot start`
+	// restarts. The label state (pilot-failed-retry-2) is what must carry
+	// the retry budget across the restart.
+	restarted, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithRetryGracePeriod(0))
+	if got := restarted.failedRetryCount[42]; got != 0 {
+		t.Fatalf("sanity check failed: fresh poller's in-memory counter should start at 0, got %d", got)
+	}
+
+	// The next retry attempt on #42 escalates it to exhausted rather than
+	// granting a 3rd retry — proving the label, not the reset in-memory map,
+	// is the source of truth.
+	issue, err := restarted.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil || issue.Number != 43 {
+		t.Fatalf("expected #43 to be dispatched (restart must not reset #42's retry budget), got %v", issue)
+	}
+}
+
+// FailedRetryStateLabels exposes the canonical list for cleanup on merge.
+func TestFailedRetryStateLabels_OrderingAndCompleteness(t *testing.T) {
+	want := []string{LabelFailedRetry1, LabelFailedRetry2, LabelFailedRetryExhausted}
+	if len(FailedRetryStateLabels) != len(want) {
+		t.Fatalf("FailedRetryStateLabels len = %d, want %d", len(FailedRetryStateLabels), len(want))
+	}
+	for i, l := range want {
+		if FailedRetryStateLabels[i] != l {
+			t.Errorf("FailedRetryStateLabels[%d] = %q, want %q", i, FailedRetryStateLabels[i], l)
+		}
+	}
+}

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -1830,6 +1830,11 @@ func (p *Poller) hasOpenPRAwaitingMerge(ctx context.Context, issue *Issue) bool 
 // shouldRetryFailedIssue checks if a pilot-failed issue should be auto-retried.
 // Returns true if the issue should be retried (label removed), false if it should be skipped.
 // GH-2176: Issues stuck with pilot-failed get retried up to maxFailedRetries times.
+//
+// GH-3715: Retry counter is persisted via GitHub labels (pilot-failed-retry-1,
+// -2, -exhausted) so the count survives `pilot start` restarts. The previous
+// in-memory failedRetryCount map silently reset on restart, allowing a
+// persistently failing issue to retry indefinitely across restarts.
 func (p *Poller) shouldRetryFailedIssue(ctx context.Context, issue *Issue) bool {
 	// Don't retry closed issues — they may have stale pilot-failed labels (GH-2252)
 	if issue.State != "open" {
@@ -1854,15 +1859,45 @@ func (p *Poller) shouldRetryFailedIssue(ctx context.Context, issue *Issue) bool 
 		return false
 	}
 
-	p.mu.RLock()
-	retries := p.failedRetryCount[issue.Number]
-	p.mu.RUnlock()
-
-	if retries >= p.maxFailedRetries {
-		p.logger.Warn("Issue has reached max failed retries, skipping",
+	// GH-3715: terminal state — exhausted retries never retry again, even
+	// across daemon restarts.
+	if HasLabel(issue, LabelFailedRetryExhausted) {
+		p.logger.Warn("Issue is pilot-failed-retry-exhausted, skipping",
 			slog.Int("number", issue.Number),
-			slog.Int("retries", retries),
-			slog.Int("max", p.maxFailedRetries),
+		)
+		return false
+	}
+
+	// Determine the next retry-counter label based on current state.
+	var currentRetryLabel, nextRetryLabel string
+	switch {
+	case HasLabel(issue, LabelFailedRetry2):
+		currentRetryLabel = LabelFailedRetry2
+		nextRetryLabel = LabelFailedRetryExhausted
+	case HasLabel(issue, LabelFailedRetry1):
+		currentRetryLabel = LabelFailedRetry1
+		nextRetryLabel = LabelFailedRetry2
+	default:
+		nextRetryLabel = LabelFailedRetry1
+	}
+
+	// If escalating to exhausted, mark the label and skip dispatch.
+	if nextRetryLabel == LabelFailedRetryExhausted {
+		if err := p.client.RemoveLabel(ctx, p.owner, p.repo, issue.Number, currentRetryLabel); err != nil {
+			p.logger.Warn("Failed to remove prior failed-retry label",
+				slog.Int("number", issue.Number),
+				slog.String("label", currentRetryLabel),
+				slog.Any("error", err),
+			)
+		}
+		if err := p.client.AddLabels(ctx, p.owner, p.repo, issue.Number, []string{LabelFailedRetryExhausted}); err != nil {
+			p.logger.Warn("Failed to add pilot-failed-retry-exhausted label",
+				slog.Int("number", issue.Number),
+				slog.Any("error", err),
+			)
+		}
+		p.logger.Warn("Issue exhausted failed-retry budget — escalated to pilot-failed-retry-exhausted",
+			slog.Int("number", issue.Number),
 		)
 		return false
 	}
@@ -1872,7 +1907,7 @@ func (p *Poller) shouldRetryFailedIssue(ctx context.Context, issue *Issue) bool 
 		return false
 	}
 
-	// Remove pilot-failed label and increment retry count
+	// Remove pilot-failed label so the poller doesn't loop the same issue.
 	if err := p.client.RemoveLabel(ctx, p.owner, p.repo, issue.Number, LabelFailed); err != nil {
 		p.logger.Warn("Failed to remove pilot-failed label for retry",
 			slog.Int("number", issue.Number),
@@ -1881,8 +1916,29 @@ func (p *Poller) shouldRetryFailedIssue(ctx context.Context, issue *Issue) bool 
 		return false
 	}
 
+	// Swap retry-N label: remove current (if any), add next.
+	if currentRetryLabel != "" {
+		if err := p.client.RemoveLabel(ctx, p.owner, p.repo, issue.Number, currentRetryLabel); err != nil {
+			p.logger.Warn("Failed to remove prior failed-retry label",
+				slog.Int("number", issue.Number),
+				slog.String("label", currentRetryLabel),
+				slog.Any("error", err),
+			)
+		}
+	}
+	if err := p.client.AddLabels(ctx, p.owner, p.repo, issue.Number, []string{nextRetryLabel}); err != nil {
+		p.logger.Warn("Failed to add failed-retry label",
+			slog.Int("number", issue.Number),
+			slog.String("label", nextRetryLabel),
+			slog.Any("error", err),
+		)
+		// Continue anyway; we'd rather retry than block on a label flake.
+	}
+
+	// Keep the legacy in-memory counter in sync so existing tests/state observers
+	// remain consistent. GH-3715: this is now a mirror, not the source of truth.
 	p.mu.Lock()
-	p.failedRetryCount[issue.Number] = retries + 1
+	p.failedRetryCount[issue.Number]++
 	p.mu.Unlock()
 
 	// Clear from processed map so the issue can be re-picked
@@ -1890,8 +1946,7 @@ func (p *Poller) shouldRetryFailedIssue(ctx context.Context, issue *Issue) bool 
 
 	p.logger.Info("Auto-retrying pilot-failed issue",
 		slog.Int("number", issue.Number),
-		slog.Int("retry", retries+1),
-		slog.Int("max", p.maxFailedRetries),
+		slog.String("retry_label", nextRetryLabel),
 	)
 
 	return true

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -472,10 +472,10 @@ func TestPoller_CheckForNewIssues_NoCallback(t *testing.T) {
 }
 
 func TestPoller_CheckForNewIssues_SkipsAlreadyProcessed(t *testing.T) {
-	// Issue 1 has pilot-failed and is at max retries — should be skipped
-	// Issue 2 has only pilot so should be processed
+	// Issue 1 has pilot-failed and is at max retries (pilot-failed-retry-exhausted,
+	// GH-3715) — should be skipped. Issue 2 has only pilot so should be processed.
 	issues := []*Issue{
-		{Number: 1, Title: "Issue 1", Labels: []Label{{Name: "pilot"}, {Name: "pilot-failed"}}},
+		{Number: 1, Title: "Issue 1", Labels: []Label{{Name: "pilot"}, {Name: "pilot-failed"}, {Name: LabelFailedRetryExhausted}}},
 		{Number: 2, Title: "Issue 2", Labels: []Label{{Name: "pilot"}}},
 	}
 
@@ -493,13 +493,7 @@ func TestPoller_CheckForNewIssues_SkipsAlreadyProcessed(t *testing.T) {
 			atomic.AddInt32(&callCount, 1)
 			return nil
 		}),
-		WithMaxFailedRetries(3),
 	)
-
-	// GH-2176: Set retry count to max so issue is skipped (not auto-retried)
-	poller.mu.Lock()
-	poller.failedRetryCount[1] = 3
-	poller.mu.Unlock()
 
 	poller.checkForNewIssues(context.Background())
 	poller.WaitForActive()
@@ -2133,10 +2127,13 @@ func TestPoller_AutoRetryFailedIssue_FirstFailure(t *testing.T) {
 	}
 }
 
+// GH-3715: retry limit is now enforced via the pilot-failed-retry-exhausted
+// label (persisted across restarts) rather than the in-memory failedRetryCount
+// map. An issue already carrying the exhausted label must be skipped.
 func TestPoller_AutoRetryFailedIssue_RetryLimitReached(t *testing.T) {
 	now := time.Now()
 	issues := []*Issue{
-		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}, {Name: LabelFailedRetryExhausted}}, CreatedAt: now.Add(-1 * time.Hour)},
 		{Number: 43, State: "open", Title: "Available issue", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
 	}
 
@@ -2147,14 +2144,7 @@ func TestPoller_AutoRetryFailedIssue_RetryLimitReached(t *testing.T) {
 	defer server.Close()
 
 	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
-	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
-		WithMaxFailedRetries(3),
-	)
-
-	// Simulate: already retried 3 times
-	poller.mu.Lock()
-	poller.failedRetryCount[42] = 3
-	poller.mu.Unlock()
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
 
 	issue, err := poller.findOldestUnprocessedIssue(context.Background())
 	if err != nil {
@@ -2278,10 +2268,12 @@ func TestPoller_AutoRetryFailedIssue_ParallelMode(t *testing.T) {
 	}
 }
 
+// GH-3715: retry limit is now enforced via the pilot-failed-retry-exhausted
+// label rather than the in-memory failedRetryCount map, so it survives restarts.
 func TestPoller_AutoRetryFailedIssue_ParallelMode_LimitReached(t *testing.T) {
 	now := time.Now()
 	issues := []*Issue{
-		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}, {Name: LabelFailedRetryExhausted}}, CreatedAt: now.Add(-1 * time.Hour)},
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2298,13 +2290,7 @@ func TestPoller_AutoRetryFailedIssue_ParallelMode_LimitReached(t *testing.T) {
 			processedCount.Add(1)
 			return nil
 		}),
-		WithMaxFailedRetries(2),
 	)
-
-	// Simulate: already at max retries
-	poller.mu.Lock()
-	poller.failedRetryCount[42] = 2
-	poller.mu.Unlock()
 
 	poller.checkForNewIssues(context.Background())
 	poller.WaitForActive()

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -119,10 +119,21 @@ const (
 	LabelRetry1         = "pilot-retry-1"
 	LabelRetry2         = "pilot-retry-2"
 	LabelRetryExhausted = "pilot-retry-exhausted"
+
+	// GH-3715: Failed-retry counter labels persist pilot-failed retry state
+	// across `pilot start` restarts (the in-memory failedRetryCount map was
+	// lost on restart, letting a persistently failing issue retry indefinitely).
+	LabelFailedRetry1         = "pilot-failed-retry-1"
+	LabelFailedRetry2         = "pilot-failed-retry-2"
+	LabelFailedRetryExhausted = "pilot-failed-retry-exhausted"
 )
 
 // RetryStateLabels lists the retry-counter labels in escalation order. GH-2432.
 var RetryStateLabels = []string{LabelRetry1, LabelRetry2, LabelRetryExhausted}
+
+// FailedRetryStateLabels lists the pilot-failed retry-counter labels in
+// escalation order. GH-3715.
+var FailedRetryStateLabels = []string{LabelFailedRetry1, LabelFailedRetry2, LabelFailedRetryExhausted}
 
 // Priority mapping from GitHub labels
 type Priority int

--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -101,10 +101,17 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 
 	// GH-2432: Strip retry-counter labels off the linked issue so a future
 	// regression on the same issue starts the retry budget from zero again.
+	// GH-3715: Also strip pilot-failed retry-counter labels for the same reason.
 	if prState.IssueNumber > 0 {
 		for _, label := range github.RetryStateLabels {
 			if err := m.ghClient.RemoveLabel(ctx, m.owner, m.repo, prState.IssueNumber, label); err != nil {
 				m.log.Debug("retry label cleanup: remove failed (likely not present)",
+					"issue", prState.IssueNumber, "label", label, "error", err)
+			}
+		}
+		for _, label := range github.FailedRetryStateLabels {
+			if err := m.ghClient.RemoveLabel(ctx, m.owner, m.repo, prState.IssueNumber, label); err != nil {
+				m.log.Debug("failed-retry label cleanup: remove failed (likely not present)",
 					"issue", prState.IssueNumber, "label", label, "error", err)
 			}
 		}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1467,6 +1467,7 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 
 	c.log.Info("PR merged successfully", "pr", prState.PRNumber)
 	prState.Stage = StageMerged
+	prState.RebaseAttempts = 0 // GH-3715: reset rebase-oscillation counter on a clean merge
 	c.recordMergeSuccess(prState)
 
 	// GH-1015: Add pilot-done label after successful merge (not at PR creation)
@@ -2266,7 +2267,37 @@ func (c *Controller) handleMergeConflict(ctx context.Context, prState *PRState) 
 	// Try GitHub auto-update first (merge-from-base, not true rebase)
 	err := c.ghClient.UpdatePullRequestBranch(ctx, c.owner, c.repo, prState.PRNumber)
 	if err == nil {
-		c.log.Info("auto-rebased conflicting PR", "pr", prState.PRNumber)
+		prState.RebaseAttempts++
+
+		// GH-3715: A successful rebase returns the PR to StageWaitingCI without
+		// consuming MergeAttempts or any other retry budget, so a PR can cycle
+		// conflict -> rebase-success -> CI -> conflict indefinitely. Cap the
+		// number of successful auto-rebases per PR and escalate instead of
+		// rebasing again once the cap is reached.
+		if prState.RebaseAttempts >= c.config.MaxRebaseAttempts {
+			errMsg := fmt.Sprintf("auto-rebase oscillation: %d successful rebases without a clean merge — manual intervention required",
+				prState.RebaseAttempts)
+			c.log.Error("handleMergeConflict: rebase attempt cap reached — escalating to StageFailed",
+				"pr", prState.PRNumber,
+				"attempts", prState.RebaseAttempts,
+				"max", c.config.MaxRebaseAttempts,
+			)
+			if prState.IssueNumber > 0 {
+				comment := fmt.Sprintf(
+					"⚠️ **Rebase escalation**: PR #%d has been auto-rebased %d times but keeps hitting merge conflicts.\n\nManual intervention is required — no further automatic rebases will be made.",
+					prState.PRNumber, prState.RebaseAttempts)
+				if _, cerr := c.ghClient.AddPRComment(ctx, c.owner, c.repo, prState.PRNumber, comment); cerr != nil {
+					c.log.Warn("failed to post rebase escalation comment", "pr", prState.PRNumber, "error", cerr)
+				}
+			}
+			prState.Stage = StageFailed
+			prState.Error = errMsg
+			c.metrics.RecordPRFailed()
+			c.metrics.RecordIssueProcessed("failed")
+			return nil
+		}
+
+		c.log.Info("auto-rebased conflicting PR", "pr", prState.PRNumber, "attempt", prState.RebaseAttempts, "max", c.config.MaxRebaseAttempts)
 		prState.Stage = StageWaitingCI // rebase triggers new CI
 		prState.HeadSHA = ""           // force refresh on next tick
 		return nil

--- a/internal/autopilot/gh3715_test.go
+++ b/internal/autopilot/gh3715_test.go
@@ -1,0 +1,303 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// GH-3715: a successful auto-rebase (handleMergeConflict's UpdatePullRequestBranch
+// path) returns the PR to StageWaitingCI without consuming MergeAttempts or any
+// other retry budget, so a PR could previously cycle
+// conflict -> rebase-success -> CI -> conflict indefinitely. RebaseAttempts caps
+// that oscillation.
+
+// TestController_HandleMergeConflict_RebaseAttemptCapEscalates verifies that the
+// 3rd successful auto-rebase for the same PR escalates to StageFailed with a
+// comment instead of rebasing again.
+func TestController_HandleMergeConflict_RebaseAttemptCapEscalates(t *testing.T) {
+	var (
+		updateBranchCalled      bool
+		escalationCommentBody   string
+		escalationCommentPosted bool
+	)
+
+	mergeable := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/77/merge" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			_, _ = w.Write([]byte(`{"message":"Pull Request is not mergeable"}`))
+
+		case r.URL.Path == "/repos/owner/repo/pulls/77" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:         77,
+				Head:           github.PRRef{SHA: "sha77", Ref: "pilot/GH-30"},
+				Mergeable:      &mergeable,
+				MergeableState: "dirty",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/77/update-branch" && r.Method == http.MethodPut:
+			updateBranchCalled = true
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": "Updating pull request branch."})
+
+		case r.URL.Path == "/repos/owner/repo/issues/77/comments" && r.Method == http.MethodPost:
+			escalationCommentPosted = true
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			escalationCommentBody = body["body"]
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.PRComment{ID: 1})
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.MaxRebaseAttempts = 3
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	// RebaseAttempts is 2; a successful rebase increments to 3 == MaxRebaseAttempts → cap fires.
+	c.activePRs[77] = &PRState{
+		PRNumber:       77,
+		PRURL:          "https://github.com/owner/repo/pull/77",
+		IssueNumber:    30,
+		BranchName:     "pilot/GH-30",
+		HeadSHA:        "sha77",
+		Stage:          StageMerging,
+		RebaseAttempts: 2,
+		CreatedAt:      time.Now(),
+	}
+	c.mu.Unlock()
+
+	err := c.ProcessPR(context.Background(), 77, nil)
+	if err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	if !updateBranchCalled {
+		t.Fatal("UpdatePullRequestBranch should have been called")
+	}
+
+	pr, ok := c.GetPRState(77)
+	if !ok {
+		t.Fatal("PR 77 not found in activePRs")
+	}
+	if pr.Stage != StageFailed {
+		t.Errorf("Stage = %s, want %s (rebase oscillation cap should escalate)", pr.Stage, StageFailed)
+	}
+	if pr.RebaseAttempts != 3 {
+		t.Errorf("RebaseAttempts = %d, want 3", pr.RebaseAttempts)
+	}
+	if !escalationCommentPosted {
+		t.Error("escalation comment should have been posted on the PR")
+	}
+	if escalationCommentBody == "" {
+		t.Error("escalation comment body should not be empty")
+	}
+}
+
+// TestController_HandleMergeConflict_BelowRebaseCapStaysWaitingCI verifies that a
+// successful auto-rebase below MaxRebaseAttempts still returns the PR to
+// StageWaitingCI (existing GH-1796 behavior) while incrementing the counter.
+func TestController_HandleMergeConflict_BelowRebaseCapStaysWaitingCI(t *testing.T) {
+	mergeable := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/78/merge" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			_, _ = w.Write([]byte(`{"message":"Pull Request is not mergeable"}`))
+
+		case r.URL.Path == "/repos/owner/repo/pulls/78" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:         78,
+				Head:           github.PRRef{SHA: "sha78", Ref: "pilot/GH-31"},
+				Mergeable:      &mergeable,
+				MergeableState: "dirty",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/78/update-branch" && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": "Updating pull request branch."})
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.MaxRebaseAttempts = 3
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	// RebaseAttempts is 1; a successful rebase increments to 2 < MaxRebaseAttempts(3).
+	c.activePRs[78] = &PRState{
+		PRNumber:       78,
+		PRURL:          "https://github.com/owner/repo/pull/78",
+		IssueNumber:    31,
+		BranchName:     "pilot/GH-31",
+		HeadSHA:        "sha78",
+		Stage:          StageMerging,
+		RebaseAttempts: 1,
+		CreatedAt:      time.Now(),
+	}
+	c.mu.Unlock()
+
+	err := c.ProcessPR(context.Background(), 78, nil)
+	if err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	pr, ok := c.GetPRState(78)
+	if !ok {
+		t.Fatal("PR 78 not found in activePRs")
+	}
+	if pr.Stage != StageWaitingCI {
+		t.Errorf("Stage = %s, want %s (below-cap rebase must stay retryable)", pr.Stage, StageWaitingCI)
+	}
+	if pr.RebaseAttempts != 2 {
+		t.Errorf("RebaseAttempts = %d, want 2", pr.RebaseAttempts)
+	}
+}
+
+// TestController_HandleMerging_ResetsRebaseAttemptsOnSuccess verifies that a
+// clean merge resets RebaseAttempts to 0 so a future regression on the same PR
+// starts the oscillation budget from zero again.
+func TestController_HandleMerging_ResetsRebaseAttemptsOnSuccess(t *testing.T) {
+	mergeable := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/sha79/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: "completed", Conclusion: "success"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/repos/owner/repo/pulls/79/merge" && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"sha": "merged79", "merged": "true"})
+
+		case r.URL.Path == "/repos/owner/repo/pulls/79" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:         79,
+				Head:           github.PRRef{SHA: "sha79"},
+				Mergeable:      &mergeable,
+				MergeableState: "clean",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoReview = false
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.mu.Lock()
+	c.activePRs[79] = &PRState{
+		PRNumber:       79,
+		PRURL:          "https://github.com/owner/repo/pull/79",
+		IssueNumber:    0,
+		BranchName:     "pilot/GH-32",
+		HeadSHA:        "sha79",
+		Stage:          StageMerging,
+		RebaseAttempts: 2,
+		CreatedAt:      time.Now(),
+	}
+	c.mu.Unlock()
+
+	err := c.ProcessPR(context.Background(), 79, nil)
+	if err != nil {
+		t.Fatalf("ProcessPR returned unexpected error: %v", err)
+	}
+
+	pr, ok := c.GetPRState(79)
+	if !ok {
+		t.Fatal("PR 79 not found in activePRs")
+	}
+	if pr.Stage != StageMerged {
+		t.Errorf("Stage = %s, want %s", pr.Stage, StageMerged)
+	}
+	if pr.RebaseAttempts != 0 {
+		t.Errorf("RebaseAttempts = %d, want 0 (must reset on clean merge)", pr.RebaseAttempts)
+	}
+}
+
+// TestStateStore_RebaseAttempts_SurvivesRestart verifies that RebaseAttempts is
+// persisted to SQLite and reloaded correctly via both GetPRState and
+// LoadAllPRStates — the path a daemon restart actually uses to restore
+// activePRs. Without this, a daemon restart would silently reset the
+// oscillation counter and re-open the conflict -> rebase -> CI -> conflict loop.
+func TestStateStore_RebaseAttempts_SurvivesRestart(t *testing.T) {
+	store := newTestStateStore(t)
+
+	pr := &PRState{
+		PRNumber:       55,
+		PRURL:          "https://github.com/owner/repo/pull/55",
+		IssueNumber:    20,
+		BranchName:     "pilot/GH-20",
+		HeadSHA:        "sha55",
+		Stage:          StageMerging,
+		RebaseAttempts: 2,
+		CreatedAt:      time.Now().Truncate(time.Second),
+	}
+
+	if err := store.SavePRState(pr); err != nil {
+		t.Fatalf("SavePRState failed: %v", err)
+	}
+
+	loaded, err := store.GetPRState(55)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("GetPRState returned nil")
+	}
+	if loaded.RebaseAttempts != 2 {
+		t.Errorf("GetPRState: RebaseAttempts = %d, want 2", loaded.RebaseAttempts)
+	}
+
+	all, err := store.LoadAllPRStates()
+	if err != nil {
+		t.Fatalf("LoadAllPRStates failed: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("LoadAllPRStates returned %d states, want 1", len(all))
+	}
+	if all[0].RebaseAttempts != 2 {
+		t.Errorf("LoadAllPRStates: RebaseAttempts = %d, want 2", all[0].RebaseAttempts)
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -94,6 +94,10 @@ func (s *StateStore) migrate() error {
 		// TASK-298: Add repo column to adapter_processed for cross-repo dedup (TASK-288 Step 2).
 		// Repo defaults to '' for tracker-style adapters (linear, jira, asana, etc.).
 		`ALTER TABLE adapter_processed ADD COLUMN repo TEXT NOT NULL DEFAULT ''`,
+		// GH-3715: Persist the auto-rebase cycle counter so the cap on successful
+		// rebases (conflict -> rebase-success -> CI -> conflict oscillation)
+		// survives daemon restarts.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN rebase_attempts INTEGER NOT NULL DEFAULT 0`,
 	}
 
 	for _, m := range migrations {
@@ -183,8 +187,8 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			merge_attempts, error, created_at, updated_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?)
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -204,7 +208,8 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			approval_decision = excluded.approval_decision,
 			approval_requested_at = excluded.approval_requested_at,
 			post_merge_sha = excluded.post_merge_sha,
-			post_merge_ci_started_at = excluded.post_merge_ci_started_at
+			post_merge_ci_started_at = excluded.post_merge_ci_started_at,
+			rebase_attempts = excluded.rebase_attempts
 	`,
 		pr.PRNumber, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
@@ -212,7 +217,7 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 		pr.MergeAttempts, pr.Error, nullTime(pr.CreatedAt),
 		pr.ReleaseVersion, string(pr.ReleaseBumpType), pr.MergeNotificationPosted,
 		pr.ApprovalRequestID, pr.ApprovalDecision, nullTime(pr.ApprovalRequestedAt),
-		pr.PostMergeSHA, nullTime(pr.PostMergeCIStartedAt),
+		pr.PostMergeSHA, nullTime(pr.PostMergeCIStartedAt), pr.RebaseAttempts,
 	)
 	return err
 }
@@ -226,7 +231,7 @@ func (s *StateStore) GetPRState(prNumber int) (*PRState, error) {
 			merge_attempts, error, created_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts
 		FROM autopilot_pr_state WHERE pr_number = ?
 	`, prNumber)
 
@@ -248,7 +253,7 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 			merge_attempts, error, created_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts
 		FROM autopilot_pr_state
 	`)
 	if err != nil {
@@ -268,7 +273,7 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 			&pr.MergeAttempts, &pr.Error, &createdAt,
 			&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
 			&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
-			&pr.PostMergeSHA, &postMergeCIStartedAt,
+			&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts,
 		); err != nil {
 			return nil, err
 		}
@@ -516,7 +521,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&pr.MergeAttempts, &pr.Error, &createdAt,
 		&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
 		&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
-		&pr.PostMergeSHA, &postMergeCIStartedAt,
+		&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -152,6 +152,13 @@ type Config struct {
 	// (MaxFailures) provides transient backoff; this cap makes persistent failures
 	// terminal so they don't loop indefinitely. Default: 5.
 	MaxMergeAttempts int `yaml:"max_merge_attempts"`
+	// MaxRebaseAttempts is the hard cap on successful auto-rebases (GitHub
+	// UpdatePullRequestBranch) for the same PR before autopilot stops
+	// re-rebasing and escalates to StageFailed for human attention. Without
+	// this cap a PR can cycle conflict -> rebase-success -> CI -> conflict
+	// indefinitely, since a successful rebase consumes no other retry budget.
+	// Default: 3.
+	MaxRebaseAttempts int `yaml:"max_rebase_attempts"`
 	// MaxReleasingAttempts is the hard cap on handleReleasing retries before the PR
 	// is transitioned to StageFailed. Prevents a release that can never succeed (e.g.
 	// persistent GitHub API errors or a tag creation race) from looping indefinitely.
@@ -331,6 +338,7 @@ func DefaultConfig() *Config {
 		FailureResetTimeout:  30 * time.Minute,
 		MaxMergesPerHour:     10,
 		MaxMergeAttempts:     5,
+		MaxRebaseAttempts:    3,
 		MaxReleasingAttempts: 10,
 		ApprovalTimeout:      1 * time.Hour,
 		Release:              nil, // Disabled by default
@@ -491,6 +499,12 @@ type PRState struct {
 	CIWaitStartedAt time.Time
 	// MergeAttempts counts how many times merge has been attempted.
 	MergeAttempts int
+	// RebaseAttempts counts how many times auto-rebase (UpdatePullRequestBranch)
+	// has succeeded for this PR. A successful rebase returns the PR to
+	// StageWaitingCI without consuming MergeAttempts, so without this counter
+	// a PR can cycle conflict -> rebase-success -> CI -> conflict indefinitely.
+	// Reset to 0 on merge success. Persisted so the cap survives restarts.
+	RebaseAttempts int
 	// Error holds the last error message if Stage is StageFailed.
 	Error string
 	// CreatedAt is when the PR entered the autopilot pipeline.
@@ -556,6 +570,7 @@ func (ps *PRState) snapshot() *PRState {
 		LastChecked:             ps.LastChecked,
 		CIWaitStartedAt:         ps.CIWaitStartedAt,
 		MergeAttempts:           ps.MergeAttempts,
+		RebaseAttempts:          ps.RebaseAttempts,
 		Error:                   ps.Error,
 		CreatedAt:               ps.CreatedAt,
 		ReleaseVersion:          ps.ReleaseVersion,


### PR DESCRIPTION
## Summary
- Adds `PRState.RebaseAttempts` (persisted in the autopilot state store) capped by `Config.MaxRebaseAttempts` (default 3). Previously a successful auto-rebase in `handleMergeConflict` returned the PR to `StageWaitingCI` without consuming any retry budget, letting a PR cycle conflict → rebase-success → CI → conflict indefinitely. The Nth successful rebase now escalates to `StageFailed` with a PR comment instead, and the counter resets to 0 on a clean merge.
- Replaces the poller's in-memory `failedRetryCount` map (reset on every daemon restart) with the GH-2432 label-counter pattern: `pilot-failed-retry-1` → `-2` → `-exhausted`, so the retry budget for `pilot-failed` issues survives restarts. `auto_merger.go` strips these labels on merge success, mirroring the existing `RetryStateLabels` cleanup.

Closes #3715.

## Test plan
- [x] `TestController_HandleMergeConflict_RebaseAttemptCapEscalates` — 3rd successful auto-rebase escalates to `StageFailed` with a comment
- [x] `TestController_HandleMergeConflict_BelowRebaseCapStaysWaitingCI` — below-cap rebase stays retryable
- [x] `TestController_HandleMerging_ResetsRebaseAttemptsOnSuccess` — counter resets on clean merge
- [x] `TestStateStore_RebaseAttempts_SurvivesRestart` — persisted via `GetPRState`/`LoadAllPRStates`
- [x] `TestPoller_FailedRetryLabel_*` (first attempt, escalation, terminal, restart-reconstruction) — GH-3715 label chain
- [x] `TestFailedRetryStateLabels_OrderingAndCompleteness`
- [x] `make build && make test && make lint` green