### PR TITLE
GH-3717: fix(cmd): wire execution.mode auto to ExecutionModeAuto

### DIFF
--- a/.agent/tasks/gh-3717.md
+++ b/.agent/tasks/gh-3717.md
@@ -1,0 +1,34 @@
+# GH-3717
+
+**Created:** 2026-07-03
+
+## Problem
+
+GitHub Issue #3717: fix(cmd): wire execution.mode auto to ExecutionModeAuto
+
+## Context
+
+Blocked by: #3716
+
+`ExecutionConfig.Mode` defaults to `"auto"` (`internal/config/config.go:150-157`), documented as "parallel dispatch with scope-overlap guard". The poller fully implements it: `Start()` routes auto to `startParallel` + guard (`internal/adapters/github/poller.go:436-442`) and even defaults internally to `ExecutionModeAuto` (`poller.go:374`). But both wiring blocks in `cmd/pilot/main.go` (~750-768 and ~2191-2210) initialize `execMode := ExecutionModeSequential` and only map the string `"parallel"` — so the default `"auto"` is silently clobbered to sequential via `WithExecutionMode`, and the overlap guard never runs for default configs.
+
+## Approach
+
+- At both call-sites, map all three strings explicitly: `"sequential"` → Sequential, `"parallel"` → Parallel, `"auto"` (or empty) → `ExecutionModeAuto`.
+- Update the `modeStr` display logic alongside.
+- **Behavior change**: default-config deployments move from (accidental) sequential to documented parallel+guard. Call this out prominently in the PR description so it lands in release notes.
+
+## Acceptance
+
+- [ ] Test: config mode "auto" and empty both produce `ExecutionModeAuto` at the poller; "sequential"/"parallel" unchanged
+- [ ] Both call-sites fixed (grep for `ExecutionModeSequential` initializations in cmd/pilot)
+- [ ] PR description flags the default-behavior change for release notes
+- [ ] `make build && make test && make lint` green
+
+## Refs
+
+- `cmd/pilot/main.go:750-768`, `cmd/pilot/main.go:~2191`, `internal/adapters/github/poller.go:374,436-442`
+- Part of TASK-378 (`.agent/tasks/TASK-378-new-project-onboarding-hardening.md`)
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -57,6 +57,24 @@ var (
 
 var quietMode bool
 
+// resolveExecutionMode maps the orchestrator.execution.mode config string to a
+// github.ExecutionMode. Empty and "auto" both resolve to ExecutionModeAuto
+// (parallel dispatch with scope-overlap guard), matching the poller's own
+// default (poller.go:374) and config.DefaultExecutionConfig(). Any other
+// unrecognized value falls back to ExecutionModeSequential.
+func resolveExecutionMode(mode string) github.ExecutionMode {
+	switch mode {
+	case "sequential":
+		return github.ExecutionModeSequential
+	case "parallel":
+		return github.ExecutionModeParallel
+	case "auto", "":
+		return github.ExecutionModeAuto
+	default:
+		return github.ExecutionModeSequential
+	}
+}
+
 func main() {
 	rootCmd := &cobra.Command{
 		Use:   "pilot",
@@ -745,9 +763,7 @@ Examples:
 
 					if cfg.Orchestrator != nil && cfg.Orchestrator.Execution != nil {
 						execCfg := cfg.Orchestrator.Execution
-						if execCfg.Mode == "parallel" {
-							execMode = github.ExecutionModeParallel
-						}
+						execMode = resolveExecutionMode(execCfg.Mode)
 						waitForMerge = execCfg.WaitForMerge
 						if execCfg.PollInterval > 0 {
 							pollInterval = execCfg.PollInterval
@@ -2168,9 +2184,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 
 			if cfg.Orchestrator != nil && cfg.Orchestrator.Execution != nil {
 				execCfg := cfg.Orchestrator.Execution
-				if execCfg.Mode == "parallel" {
-					execMode = github.ExecutionModeParallel
-				}
+				execMode = resolveExecutionMode(execCfg.Mode)
 				waitForMerge = execCfg.WaitForMerge
 				if execCfg.PollInterval > 0 {
 					pollInterval = execCfg.PollInterval
@@ -2180,10 +2194,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				}
 			}
 
-			modeStr := "sequential"
-			if execMode == github.ExecutionModeParallel {
-				modeStr = "parallel"
-			}
+			modeStr := string(execMode)
 
 			// Helper to create poller for a repo with its project path
 			createPollerForRepo := func(repoFullName, projPath string) (*github.Poller, error) {
@@ -2317,7 +2328,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					)
 				} else {
 					pollerOpts = append(pollerOpts,
-						github.WithExecutionMode(github.ExecutionModeParallel),
+						github.WithExecutionMode(execMode),
 						github.WithScheduler(rateLimitScheduler),
 						github.WithMaxConcurrent(cfg.Orchestrator.MaxConcurrent),
 						github.WithOnIssueWithResult(func(issueCtx context.Context, issue *github.Issue) (*github.IssueResult, error) {

--- a/cmd/pilot/main_test.go
+++ b/cmd/pilot/main_test.go
@@ -1039,3 +1039,28 @@ func TestCountGitHubRepos(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveExecutionMode verifies GH-3717: config mode "auto" and empty
+// both map to ExecutionModeAuto (parallel dispatch + scope-overlap guard),
+// matching the poller's own default and config.DefaultExecutionConfig(),
+// instead of being silently clobbered to sequential.
+func TestResolveExecutionMode(t *testing.T) {
+	tests := []struct {
+		modeStr string
+		want    github.ExecutionMode
+	}{
+		{"sequential", github.ExecutionModeSequential},
+		{"parallel", github.ExecutionModeParallel},
+		{"auto", github.ExecutionModeAuto},
+		{"", github.ExecutionModeAuto},
+		{"unrecognized", github.ExecutionModeSequential},
+	}
+	for _, tt := range tests {
+		t.Run(tt.modeStr, func(t *testing.T) {
+			got := resolveExecutionMode(tt.modeStr)
+			if got != tt.want {
+				t.Errorf("resolveExecutionMode(%q) = %q, want %q", tt.modeStr, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3717.

Closes #3717

## Changes

GitHub Issue #3717: fix(cmd): wire execution.mode auto to ExecutionModeAuto

## Context

Blocked by: #3716

`ExecutionConfig.Mode` defaults to `"auto"` (`internal/config/config.go:150-157`), documented as "parallel dispatch with scope-overlap guard". The poller fully implements it: `Start()` routes auto to `startParallel` + guard (`internal/adapters/github/poller.go:436-442`) and even defaults internally to `ExecutionModeAuto` (`poller.go:374`). But both wiring blocks in `cmd/pilot/main.go` (~750-768 and ~2191-2210) initialize `execMode := ExecutionModeSequential` and only map the string `"parallel"` — so the default `"auto"` is silently clobbered to sequential via `WithExecutionMode`, and the overlap guard never runs for default configs.

## Approach

- At both call-sites, map all three strings explicitly: `"sequential"` → Sequential, `"parallel"` → Parallel, `"auto"` (or empty) → `ExecutionModeAuto`.
- Update the `modeStr` display logic alongside.
- **Behavior change**: default-config deployments move from (accidental) sequential to documented parallel+guard. Call this out prominently in the PR description so it lands in release notes.

## Acceptance

- [ ] Test: config mode "auto" and empty both produce `ExecutionModeAuto` at the poller; "sequential"/"parallel" unchanged
- [ ] Both call-sites fixed (grep for `ExecutionModeSequential` initializations in cmd/pilot)
- [ ] PR description flags the default-behavior change for release notes
- [ ] `make build && make test && make lint` green

## Refs

- `cmd/pilot/main.go:750-768`, `cmd/pilot/main.go:~2191`, `internal/adapters/github/poller.go:374,436-442`
- Part of TASK-378 (`.agent/tasks/TASK-378-new-project-onboarding-hardening.md`)