### PR TITLE
feat(cmd): gh CLI token fallback and doctor check for dead GitHub token

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-03 (v2.151.0)
+**Last Updated:** 2026-06-26 (v2.151.0)
 
 ## Legend
 
@@ -186,6 +186,7 @@
 | Deadlock detector | ✅ | autopilot | - | - | Alert after 1h with no progress on PR (v0.38.0, GH-849) |
 | Alert dispatch metrics | ✅ | alerts/gateway | - | - | alerts_fired_total, alert_delivery_total, alert_events_dropped_total, alert_queue_depth on /metrics (TASK-332) |
 | Rate limit detection | ✅ | executor | - | - | Detect GitHub API rate limits, pause + resume at reset time (v0.34.0) |
+| GitHub token fallback + live validation | ✅ | cmd/pilot, health | `pilot doctor` | `adapters.github.token` | config → `GITHUB_TOKEN` env → `gh auth token` fallback; authenticated startup check logs ERROR + fires `config_error` alert on a dead/expired token (GH-3718) |
 
 ## Quality Gates
 
@@ -196,8 +197,6 @@
 | Lint gates | ✅ | quality | - | `quality.gates[].type=lint` | Run lint commands |
 | Build gates | ✅ | quality | - | `quality.gates[].type=build` | Compile check |
 | Retry on failure | ✅ | quality | - | `quality.max_retries` | Auto-retry with feedback |
-| Per-project quality gates | ✅ | config, quality | - | `projects[].quality` | Project overrides win over global `quality.*`, then auto-detect (v2.201.4, GH-3716) |
-| pnpm/yarn/bun auto-detection | ✅ | quality | - | - | Lockfile-based PM detection for auto-detected build/test gates (v2.201.4, GH-3716) |
 
 ## Memory & Learning
 
@@ -458,8 +457,8 @@
 | Intelligence | 15 | 0 | 0 | 0 |
 | Input Adapters | 35 | 0 | 0 | 0 |
 | Output/Notifications | 18 | 0 | 0 | 0 |
-| Alerts & Monitoring | 11 | 0 | 0 | 0 |
-| Quality Gates | 7 | 0 | 0 | 0 |
+| Alerts & Monitoring | 12 | 0 | 0 | 0 |
+| Quality Gates | 5 | 0 | 0 | 0 |
 | Memory & Learning | 23 | 0 | 0 | 0 |
 | Dashboard | 24 | 0 | 0 | 0 |
 | Replay & Debug | 6 | 0 | 0 | 0 |

--- a/cmd/pilot/github_token_test.go
+++ b/cmd/pilot/github_token_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/alerts"
+	"github.com/qf-studio/pilot/internal/config"
+)
+
+// resetGitHubTokenTestState clears env and the memoized gh-CLI cache so each
+// subtest starts from a clean resolution chain.
+func resetGitHubTokenTestState(t *testing.T) {
+	t.Helper()
+	origEnv, hadEnv := os.LookupEnv("GITHUB_TOKEN")
+	_ = os.Unsetenv("GITHUB_TOKEN")
+	origCache := ghTokenCache
+	ghTokenCache = &ghCLITokenCache{}
+	origRunner := ghRunner
+	t.Cleanup(func() {
+		if hadEnv {
+			_ = os.Setenv("GITHUB_TOKEN", origEnv)
+		} else {
+			_ = os.Unsetenv("GITHUB_TOKEN")
+		}
+		ghTokenCache = origCache
+		ghRunner = origRunner
+	})
+}
+
+// TestResolveGitHubToken_Precedence verifies config -> GITHUB_TOKEN env ->
+// `gh auth token` CLI fallback, in that order (GH-3718).
+func TestResolveGitHubToken_Precedence(t *testing.T) {
+	t.Run("config wins over env and gh CLI", func(t *testing.T) {
+		resetGitHubTokenTestState(t)
+		_ = os.Setenv("GITHUB_TOKEN", "env-token")
+		ghRunner = fakeGhRunner(t, true, "alice", "gh-cli-token", nil)
+
+		cfg := &config.Config{Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: true, Token: "config-token"},
+		}}
+
+		tok, source := resolveGitHubToken(cfg)
+		if tok != "config-token" {
+			t.Errorf("token = %q, want config-token", tok)
+		}
+		if source != githubTokenSourceConfig {
+			t.Errorf("source = %q, want %q", source, githubTokenSourceConfig)
+		}
+	})
+
+	t.Run("env wins over gh CLI when config empty", func(t *testing.T) {
+		resetGitHubTokenTestState(t)
+		_ = os.Setenv("GITHUB_TOKEN", "env-token")
+		ghRunner = fakeGhRunner(t, true, "alice", "gh-cli-token", nil)
+
+		cfg := &config.Config{Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: true},
+		}}
+
+		tok, source := resolveGitHubToken(cfg)
+		if tok != "env-token" {
+			t.Errorf("token = %q, want env-token", tok)
+		}
+		if source != githubTokenSourceEnv {
+			t.Errorf("source = %q, want %q", source, githubTokenSourceEnv)
+		}
+	})
+
+	t.Run("gh CLI fallback when config and env empty", func(t *testing.T) {
+		resetGitHubTokenTestState(t)
+		ghRunner = fakeGhRunner(t, true, "alice", "gh-cli-token", nil)
+
+		cfg := &config.Config{Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: true},
+		}}
+
+		tok, source := resolveGitHubToken(cfg)
+		if tok != "gh-cli-token" {
+			t.Errorf("token = %q, want gh-cli-token", tok)
+		}
+		if source != githubTokenSourceGhCLI {
+			t.Errorf("source = %q, want %q", source, githubTokenSourceGhCLI)
+		}
+	})
+
+	t.Run("gh CLI result is cached across calls", func(t *testing.T) {
+		resetGitHubTokenTestState(t)
+		var calls int
+		var mu sync.Mutex
+		ghRunner = func(args ...string) ([]byte, error) {
+			mu.Lock()
+			calls++
+			mu.Unlock()
+			return fakeGhRunner(t, true, "alice", "gh-cli-token", nil)(args...)
+		}
+
+		cfg := &config.Config{Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: true},
+		}}
+
+		resolveGitHubToken(cfg)
+		resolveGitHubToken(cfg)
+		resolveGitHubToken(cfg)
+
+		if calls != 1 {
+			t.Errorf("expected exactly 1 gh CLI exec (cached), got %d", calls)
+		}
+	})
+
+	t.Run("none resolved", func(t *testing.T) {
+		resetGitHubTokenTestState(t)
+		ghRunner = fakeGhRunner(t, false, "", "", nil)
+
+		cfg := &config.Config{Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: true},
+		}}
+
+		tok, source := resolveGitHubToken(cfg)
+		if tok != "" {
+			t.Errorf("token = %q, want empty", tok)
+		}
+		if source != githubTokenSourceNone {
+			t.Errorf("source = %q, want %q", source, githubTokenSourceNone)
+		}
+	})
+}
+
+// recordingChannel is a minimal alerts.Channel that records delivered alerts.
+type recordingChannel struct {
+	mu     sync.Mutex
+	alerts []*alerts.Alert
+}
+
+func (c *recordingChannel) Name() string { return "test-channel" }
+func (c *recordingChannel) Type() string { return "webhook" }
+func (c *recordingChannel) Send(_ context.Context, alert *alerts.Alert) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.alerts = append(c.alerts, alert)
+	return nil
+}
+func (c *recordingChannel) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.alerts)
+}
+
+func newTestAlertsEngine(t *testing.T) (*alerts.Engine, *recordingChannel) {
+	t.Helper()
+	cfg := &alerts.AlertConfig{
+		Enabled:  true,
+		Channels: []alerts.ChannelConfig{{Name: "test-channel", Type: "webhook", Enabled: true}},
+		Rules: []alerts.AlertRule{{
+			Name:     "service-unhealthy",
+			Type:     alerts.AlertTypeServiceUnhealthy,
+			Enabled:  true,
+			Severity: alerts.SeverityWarning,
+			Channels: []string{"test-channel"},
+		}},
+	}
+	ch := &recordingChannel{}
+	dispatcher := alerts.NewDispatcher(cfg)
+	dispatcher.RegisterChannel(ch)
+	engine := alerts.NewEngine(cfg, alerts.WithDispatcher(dispatcher))
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("engine.Start: %v", err)
+	}
+	return engine, ch
+}
+
+// TestValidateGitHubToken_DeadTokenFiresAlert confirms a 401 from GitHub
+// fires a config_error alert naming the token source (GH-3718 acceptance:
+// startup with a dead token must not fail silently).
+func TestValidateGitHubToken_DeadTokenFiresAlert(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+	defer srv.Close()
+
+	client := github.NewClientWithBaseURL("dead-token", srv.URL)
+	engine, ch := newTestAlertsEngine(t)
+
+	validateGitHubToken(context.Background(), client, githubTokenSourceEnv, engine)
+
+	deadline := time.After(2 * time.Second)
+	for ch.count() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("expected an alert to be fired for a dead token")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// TestValidateGitHubToken_ValidTokenNoAlert confirms a healthy token does not
+// fire a config_error alert.
+func TestValidateGitHubToken_ValidTokenNoAlert(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"login":"pilot-bot"}`))
+	}))
+	defer srv.Close()
+
+	client := github.NewClientWithBaseURL("good-token", srv.URL)
+	engine, ch := newTestAlertsEngine(t)
+
+	validateGitHubToken(context.Background(), client, githubTokenSourceConfig, engine)
+	engine.WaitForDispatch()
+
+	if got := ch.count(); got != 0 {
+		t.Errorf("expected no alerts for a valid token, got %d", got)
+	}
+}
+
+// TestValidateGitHubToken_NilAlertsEngineDoesNotPanic confirms validation is
+// safe to call before the alerts engine exists (some call-sites resolve the
+// token earlier in startup than the alerts engine is constructed).
+func TestValidateGitHubToken_NilAlertsEngineDoesNotPanic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+	defer srv.Close()
+
+	client := github.NewClientWithBaseURL("dead-token", srv.URL)
+	validateGitHubToken(context.Background(), client, githubTokenSourceNone, nil)
+}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -75,6 +75,92 @@ func resolveExecutionMode(mode string) github.ExecutionMode {
 	}
 }
 
+// githubTokenSource names where a resolved GitHub token came from, so a dead
+// token can be diagnosed without re-deriving the resolution chain (GH-3718).
+type githubTokenSource string
+
+const (
+	githubTokenSourceConfig githubTokenSource = "config (adapters.github.token)"
+	githubTokenSourceEnv    githubTokenSource = "env (GITHUB_TOKEN)"
+	githubTokenSourceGhCLI  githubTokenSource = "gh CLI (gh auth token)"
+	githubTokenSourceNone   githubTokenSource = "none"
+)
+
+// ghCLITokenCache memoizes the `gh auth token` fallback lookup for the process
+// lifetime — it forks a subprocess, and the credential can't change mid-run.
+// A pointer so tests can reset it by swapping in a fresh instance instead of
+// copying a sync.Once by value.
+type ghCLITokenCache struct {
+	once  sync.Once
+	token string
+	ok    bool
+}
+
+func (c *ghCLITokenCache) resolve() (string, bool) {
+	c.once.Do(func() {
+		tok, err := ghAuthToken()
+		if err == nil && tok != "" {
+			c.token = tok
+			c.ok = true
+		}
+	})
+	return c.token, c.ok
+}
+
+var ghTokenCache = &ghCLITokenCache{}
+
+// resolveGitHubToken resolves the GitHub token with precedence:
+// adapters.github.token config → GITHUB_TOKEN env → `gh auth token` CLI
+// fallback (GH-3718). It consolidates the pattern previously duplicated
+// across five call-sites in this file. The returned source lets callers log
+// which credential a startup 401 came from.
+func resolveGitHubToken(cfg *config.Config) (string, githubTokenSource) {
+	if cfg != nil && cfg.Adapters != nil && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Token != "" {
+		return cfg.Adapters.GitHub.Token, githubTokenSourceConfig
+	}
+	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
+		return tok, githubTokenSourceEnv
+	}
+	if tok, ok := ghTokenCache.resolve(); ok {
+		return tok, githubTokenSourceGhCLI
+	}
+	return "", githubTokenSourceNone
+}
+
+// validateGitHubToken makes one authenticated API call to confirm the
+// resolved token actually works. A dead/expired token otherwise fails
+// silently on every subsequent poll (live incident 2026-06-30) — this makes
+// the failure loud at startup instead. Never returns an error: validation
+// failure is logged (and alerted, if alertsEngine is configured) but must not
+// block daemon startup, since other adapters may still work fine.
+func validateGitHubToken(ctx context.Context, client *github.Client, source githubTokenSource, alertsEngine *alerts.Engine) {
+	log := logging.WithComponent("github")
+	if _, err := client.GetAuthenticatedUser(ctx); err != nil {
+		var authErr *github.AuthError
+		if errors.As(err, &authErr) {
+			log.Error("GitHub token rejected by API (401) — polling and PR operations will silently fail until this is fixed",
+				slog.String("token_source", string(source)),
+				slog.String("fix", "rotate the token at its source and restart pilot"),
+			)
+			if alertsEngine != nil {
+				alertsEngine.ProcessEvent(alerts.Event{
+					Type:      alerts.EventTypeConfigError,
+					Error:     fmt.Sprintf("GitHub token (source: %s) is invalid or expired — 401 from GitHub API", source),
+					Timestamp: time.Now(),
+				})
+			}
+			return
+		}
+		// Network error, rate limit, etc. — not evidence the token itself is dead.
+		log.Warn("could not verify GitHub token validity at startup",
+			slog.String("token_source", string(source)),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+	log.Info("GitHub token validated", slog.String("token_source", string(source)))
+}
+
 func main() {
 	rootCmd := &cobra.Command{
 		Use:   "pilot",
@@ -502,13 +588,7 @@ Examples:
 
 				// Create autopilot controller if enabled
 				if cfg.Orchestrator.Autopilot != nil && cfg.Orchestrator.Autopilot.Enabled {
-					ghToken := ""
-					if cfg.Adapters.GitHub != nil {
-						ghToken = cfg.Adapters.GitHub.Token
-						if ghToken == "" {
-							ghToken = os.Getenv("GITHUB_TOKEN")
-						}
-					}
+					ghToken, _ := resolveGitHubToken(cfg)
 					if ghToken != "" && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Repo != "" {
 						parts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2)
 						if len(parts) == 2 {
@@ -739,13 +819,11 @@ Examples:
 			if githubFlagSet && hasGithubPolling && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled &&
 				cfg.Adapters.GitHub.Polling != nil && cfg.Adapters.GitHub.Polling.Enabled {
 
-				token := cfg.Adapters.GitHub.Token
-				if token == "" {
-					token = os.Getenv("GITHUB_TOKEN")
-				}
+				token, tokenSource := resolveGitHubToken(cfg)
 
 				if token != "" && cfg.Adapters.GitHub.Repo != "" {
 					client := github.NewClient(token)
+					validateGitHubToken(context.Background(), client, tokenSource, gwAlertsEngine)
 					label := cfg.Adapters.GitHub.Polling.Label
 					if label == "" {
 						label = cfg.Adapters.GitHub.PilotLabel
@@ -1479,13 +1557,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	var autopilotController *autopilot.Controller // Default controller for backwards compat
 	if cfg.Orchestrator.Autopilot != nil && cfg.Orchestrator.Autopilot.Enabled {
 		// Need GitHub client for autopilot
-		ghToken := ""
-		if cfg.Adapters.GitHub != nil {
-			ghToken = cfg.Adapters.GitHub.Token
-			if ghToken == "" {
-				ghToken = os.Getenv("GITHUB_TOKEN")
-			}
-		}
+		ghToken, _ := resolveGitHubToken(cfg)
 		if ghToken == "" {
 			// GH-3050: surface silent autopilot disable when token is missing.
 			// Without this warning, --env=<...> appears accepted but autopilot
@@ -1745,10 +1817,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		// GH-2080: Wire PR review webhook events to autopilot controller in polling mode
 		if autopilotController != nil && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled {
 			capturedController := autopilotController
-			token := cfg.Adapters.GitHub.Token
-			if token == "" {
-				token = os.Getenv("GITHUB_TOKEN")
-			}
+			token, _ := resolveGitHubToken(cfg)
 			if token != "" {
 				ghClient := github.NewClient(token)
 				ghWH := github.NewWebhookHandler(ghClient, cfg.Adapters.GitHub.WebhookSecret, cfg.Adapters.GitHub.PilotLabel)
@@ -1842,10 +1911,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	// Nil when GitHub is not configured — Handler degrades gracefully.
 	var commsIssueCreator comms.IssueCreator
 	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled && cfg.Adapters.GitHub.Repo != "" {
-		ghToken := cfg.Adapters.GitHub.Token
-		if ghToken == "" {
-			ghToken = os.Getenv("GITHUB_TOKEN")
-		}
+		ghToken, _ := resolveGitHubToken(cfg)
 		if ghToken != "" {
 			repoParts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2)
 			if len(repoParts) == 2 {
@@ -2160,13 +2226,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled &&
 		cfg.Adapters.GitHub.Polling != nil && cfg.Adapters.GitHub.Polling.Enabled {
 
-		token := cfg.Adapters.GitHub.Token
-		if token == "" {
-			token = os.Getenv("GITHUB_TOKEN")
-		}
+		token, tokenSource := resolveGitHubToken(cfg)
 
 		if token != "" {
 			client := github.NewClient(token)
+			validateGitHubToken(context.Background(), client, tokenSource, alertsEngine)
 			label := cfg.Adapters.GitHub.Polling.Label
 			if label == "" {
 				label = cfg.Adapters.GitHub.PilotLabel

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -31,6 +31,18 @@ func (e *RateLimitError) Error() string {
 	return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Message)
 }
 
+// AuthError is returned by doRequest when GitHub rejects the token itself
+// (401 Unauthorized) — as opposed to a 403 which can mean rate-limited or
+// forbidden-but-authenticated. Callers use errors.As to distinguish a dead/
+// revoked token from other failures (GH-3718).
+type AuthError struct {
+	Message string
+}
+
+func (e *AuthError) Error() string {
+	return fmt.Sprintf("API error (status %d): %s", http.StatusUnauthorized, e.Message)
+}
+
 // parseRetryAfterHeader reads Retry-After and X-RateLimit-Reset headers and
 // returns the delay duration. Returns 0 when neither header is present.
 func parseRetryAfterHeader(h http.Header) time.Duration {
@@ -236,6 +248,9 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			msg := string(respBody)
+			if resp.StatusCode == http.StatusUnauthorized {
+				return &AuthError{Message: msg}
+			}
 			if resp.StatusCode == http.StatusTooManyRequests {
 				return &RateLimitError{
 					StatusCode: http.StatusTooManyRequests,

--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -101,6 +101,11 @@ const (
 	// handler so consecutive-failure tracking keeps working, but kept as a
 	// distinct type so rules and dashboards can single these out.
 	EventTypeOOMKilled EventType = "oom_killed"
+
+	// Config/credential health events (GH-3718): fired when a resolved
+	// credential (e.g. a GitHub token) fails an authenticated validation
+	// call at startup, so a dead credential doesn't fail silently.
+	EventTypeConfigError EventType = "config_error"
 )
 
 const (
@@ -271,7 +276,7 @@ func (e *Engine) ProcessEvent(event Event) {
 // isHighPriorityEvent reports whether an event must not be lost under load.
 func isHighPriorityEvent(t EventType) bool {
 	switch t {
-	case EventTypeEscalation, EventTypeOOMKilled, EventTypeBudgetExceeded, EventTypeSecurityEvent:
+	case EventTypeEscalation, EventTypeOOMKilled, EventTypeBudgetExceeded, EventTypeSecurityEvent, EventTypeConfigError:
 		return true
 	default:
 		return false
@@ -329,6 +334,8 @@ func (e *Engine) handleEvent(ctx context.Context, event Event) {
 		e.handleCostUpdate(ctx, event)
 	case EventTypeSecurityEvent:
 		e.handleSecurityEvent(ctx, event)
+	case EventTypeConfigError:
+		e.handleConfigError(ctx, event)
 	case EventTypeBudgetExceeded, EventTypeBudgetWarning:
 		e.handleBudgetEvent(ctx, event)
 	case EventTypeAutopilotMetrics:
@@ -499,6 +506,21 @@ func (e *Engine) handleSecurityEvent(ctx context.Context, event Event) {
 					fmt.Sprintf("Sensitive file modified: %s", filePath))
 				e.fireAlert(ctx, rule, alert)
 			}
+		}
+	}
+}
+
+// handleConfigError fires AlertTypeServiceUnhealthy rules when a resolved
+// credential fails validation (GH-3718), e.g. a dead GitHub token detected at
+// startup. Message comes from event.Error, set by the caller.
+func (e *Engine) handleConfigError(ctx context.Context, event Event) {
+	for _, rule := range e.config.Rules {
+		if !rule.Enabled {
+			continue
+		}
+		if rule.Type == AlertTypeServiceUnhealthy && e.shouldFire(rule) {
+			alert := e.createAlert(rule, event, event.Error)
+			e.fireAlert(ctx, rule, alert)
 		}
 	}
 }

--- a/internal/alerts/engine_task337_test.go
+++ b/internal/alerts/engine_task337_test.go
@@ -152,7 +152,7 @@ func TestProcessEvents_HungChannelDoesNotBlockEventLoop(t *testing.T) {
 }
 
 func TestIsHighPriorityEvent(t *testing.T) {
-	high := []EventType{EventTypeEscalation, EventTypeOOMKilled, EventTypeBudgetExceeded, EventTypeSecurityEvent}
+	high := []EventType{EventTypeEscalation, EventTypeOOMKilled, EventTypeBudgetExceeded, EventTypeSecurityEvent, EventTypeConfigError}
 	for _, et := range high {
 		if !isHighPriorityEvent(et) {
 			t.Errorf("%s should be high priority", et)

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1028,6 +1029,88 @@ func TestEngine_SecurityEvent(t *testing.T) {
 				t.Errorf("expected alert type %s, got %s", tt.alertType, alerts[0].Type)
 			}
 		})
+	}
+}
+
+// TestEngine_ConfigError verifies a dead-credential event (GH-3718, e.g. a
+// GitHub token that fails validation at startup) fires an
+// AlertTypeServiceUnhealthy rule with the diagnostic message from event.Error.
+func TestEngine_ConfigError(t *testing.T) {
+	config := &AlertConfig{
+		Enabled: true,
+		Channels: []ChannelConfig{
+			{Name: "test-channel", Type: "webhook", Enabled: true},
+		},
+		Rules: []AlertRule{
+			{
+				Name:     "config-error",
+				Type:     AlertTypeServiceUnhealthy,
+				Enabled:  true,
+				Severity: SeverityWarning,
+				Channels: []string{"test-channel"},
+				Cooldown: 0,
+			},
+		},
+	}
+
+	mockCh := newMockChannel("test-channel", "webhook")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	engine := NewEngine(config, WithDispatcher(dispatcher))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = engine.Start(ctx)
+
+	engine.ProcessEvent(Event{
+		Type:      EventTypeConfigError,
+		Error:     "GitHub token (source: env (GITHUB_TOKEN)) is invalid or expired — 401 from GitHub API",
+		Timestamp: time.Now(),
+	})
+
+	waitForAlerts(t, mockCh, 1, 2*time.Second)
+	alerts := mockCh.getAlerts()
+	if len(alerts) != 1 {
+		t.Fatalf("expected 1 alert, got %d", len(alerts))
+	}
+	if alerts[0].Type != AlertTypeServiceUnhealthy {
+		t.Errorf("expected alert type %s, got %s", AlertTypeServiceUnhealthy, alerts[0].Type)
+	}
+	if !strings.Contains(alerts[0].Message, "401") {
+		t.Errorf("expected alert message to mention 401, got %q", alerts[0].Message)
+	}
+}
+
+// TestEngine_ConfigError_NoMatchingRule confirms no alert fires when the
+// config has no AlertTypeServiceUnhealthy rule — the event is silently
+// dropped, matching handleSecurityEvent's existing behavior for unmatched rules.
+func TestEngine_ConfigError_NoMatchingRule(t *testing.T) {
+	config := &AlertConfig{
+		Enabled:  true,
+		Channels: []ChannelConfig{{Name: "test-channel", Type: "webhook", Enabled: true}},
+		Rules:    []AlertRule{},
+	}
+
+	mockCh := newMockChannel("test-channel", "webhook")
+	dispatcher := NewDispatcher(config)
+	dispatcher.RegisterChannel(mockCh)
+
+	engine := NewEngine(config, WithDispatcher(dispatcher))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = engine.Start(ctx)
+
+	engine.ProcessEvent(Event{
+		Type:      EventTypeConfigError,
+		Error:     "token invalid",
+		Timestamp: time.Now(),
+	})
+	engine.flushForTest()
+
+	if got := len(mockCh.getAlerts()); got != 0 {
+		t.Errorf("expected 0 alerts with no matching rule, got %d", got)
 	}
 }
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -134,6 +134,100 @@ var brewTapHTTPGet httpGetter = func(url string) (*http.Response, error) {
 	return client.Do(req)
 }
 
+// githubAuthChecker performs an authenticated GitHub API call to validate a
+// token, returning its HTTP status code (or an error for network failures).
+// Injectable for testability; overridden in tests. GH-3718.
+type githubAuthChecker func(token string) (int, error)
+
+// githubAuthCheck is the default githubAuthChecker: a real GET /user call.
+var githubAuthCheck githubAuthChecker = func(token string) (int, error) {
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/user", nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	return resp.StatusCode, nil
+}
+
+// ghAuthTokenExec runs `gh auth token` and returns the trimmed token.
+// Injectable so tests aren't at the mercy of the host's real gh CLI auth state.
+var ghAuthTokenExec = func() (string, error) {
+	out, err := exec.Command("gh", "auth", "token").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// resolveGitHubTokenForDoctor mirrors cmd/pilot's resolveGitHubToken precedence
+// (config -> GITHUB_TOKEN env -> `gh auth token` CLI) without importing cmd/pilot,
+// which would create an import cycle. Returns ("", "") when nothing resolves.
+func resolveGitHubTokenForDoctor(cfg *config.Config) (token, source string) {
+	if cfg.Adapters != nil && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Token != "" {
+		return cfg.Adapters.GitHub.Token, "config"
+	}
+	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
+		return tok, "env GITHUB_TOKEN"
+	}
+	if tok, err := ghAuthTokenExec(); err == nil && tok != "" {
+		return tok, "gh CLI"
+	}
+	return "", ""
+}
+
+// checkGitHubTokenLive makes one authenticated API call to confirm the
+// resolved GitHub token actually works, producing a clear pass/fail line
+// distinct from the presence-only "github"/"github.token" checks above.
+// Returns nil when GitHub isn't enabled or no token could be resolved — those
+// cases are already covered by the presence check. GH-3718.
+func checkGitHubTokenLive(cfg *config.Config, check githubAuthChecker) *ConfigCheck {
+	if cfg.Adapters == nil || cfg.Adapters.GitHub == nil || !cfg.Adapters.GitHub.Enabled {
+		return nil
+	}
+	token, source := resolveGitHubTokenForDoctor(cfg)
+	if token == "" {
+		return nil
+	}
+
+	status, err := check(token)
+	if err != nil {
+		return &ConfigCheck{
+			Name:    "github.token.live",
+			Status:  StatusWarning,
+			Message: fmt.Sprintf("could not verify token (%s source): %v", source, err),
+			Fix:     "Check network connectivity to api.github.com",
+		}
+	}
+	if status == http.StatusUnauthorized {
+		return &ConfigCheck{
+			Name:    "github.token.live",
+			Status:  StatusError,
+			Message: fmt.Sprintf("token invalid or expired (401, source: %s)", source),
+			Fix:     "Rotate adapters.github.token / GITHUB_TOKEN, or run: gh auth login",
+		}
+	}
+	if status < 200 || status >= 300 {
+		return &ConfigCheck{
+			Name:    "github.token.live",
+			Status:  StatusWarning,
+			Message: fmt.Sprintf("unexpected API response (%d, source: %s)", status, source),
+			Fix:     "Check GitHub API status",
+		}
+	}
+	return &ConfigCheck{
+		Name:    "github.token.live",
+		Status:  StatusOK,
+		Message: fmt.Sprintf("valid (source: %s)", source),
+	}
+}
+
 // checkBrewTapHealth checks whether the last release.yml run failed at a
 // homebrew step, which indicates that HOMEBREW_TAP_GITHUB_TOKEN has expired.
 // Uses unauthenticated GitHub API calls (public repo, 60 req/hour limit).
@@ -231,6 +325,9 @@ func RunChecks(cfg *config.Config) *HealthReport {
 		configChecks = append(configChecks, checkAgentDocSize(filepath.Join(cwd, ".agent"))...)
 	}
 	configChecks = append(configChecks, checkBrewTapHealth(brewTapHTTPGet))
+	if liveCheck := checkGitHubTokenLive(cfg, githubAuthCheck); liveCheck != nil {
+		configChecks = append(configChecks, *liveCheck)
+	}
 
 	report := &HealthReport{
 		Dependencies: checkDependenciesWithBackend(backendType),

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -1131,6 +1132,114 @@ func TestCheckBrewTapHealth_JobFetchFails(t *testing.T) {
 	check := checkBrewTapHealth(get)
 	if check.Status != StatusWarning {
 		t.Errorf("status = %v, want StatusWarning when jobs fetch fails", check.Status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// checkGitHubTokenLive (GH-3718)
+// ---------------------------------------------------------------------------
+
+func TestCheckGitHubTokenLive_DeadToken(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: true, Token: "dead-token"},
+		},
+	}
+	check := func(string) (int, error) { return http.StatusUnauthorized, nil }
+
+	got := checkGitHubTokenLive(cfg, check)
+	if got == nil {
+		t.Fatal("expected a check result, got nil")
+	}
+	if got.Status != StatusError {
+		t.Errorf("status = %v, want StatusError", got.Status)
+	}
+	if !strings.Contains(got.Message, "401") {
+		t.Errorf("message = %q, want mention of 401", got.Message)
+	}
+	if !strings.Contains(got.Message, "config") {
+		t.Errorf("message = %q, want token source named", got.Message)
+	}
+}
+
+func TestCheckGitHubTokenLive_ValidToken(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: true, Token: "good-token"},
+		},
+	}
+	check := func(string) (int, error) { return http.StatusOK, nil }
+
+	got := checkGitHubTokenLive(cfg, check)
+	if got == nil {
+		t.Fatal("expected a check result, got nil")
+	}
+	if got.Status != StatusOK {
+		t.Errorf("status = %v, want StatusOK", got.Status)
+	}
+}
+
+func TestCheckGitHubTokenLive_NetworkError(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: true, Token: "some-token"},
+		},
+	}
+	check := func(string) (int, error) { return 0, io.ErrUnexpectedEOF }
+
+	got := checkGitHubTokenLive(cfg, check)
+	if got == nil {
+		t.Fatal("expected a check result, got nil")
+	}
+	if got.Status != StatusWarning {
+		t.Errorf("status = %v, want StatusWarning for a network error (not evidence the token is dead)", got.Status)
+	}
+}
+
+func TestCheckGitHubTokenLive_SkipsWhenDisabled(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: false, Token: "some-token"},
+		},
+	}
+	called := false
+	check := func(string) (int, error) { called = true; return http.StatusOK, nil }
+
+	got := checkGitHubTokenLive(cfg, check)
+	if got != nil {
+		t.Errorf("expected nil check when GitHub disabled, got %+v", got)
+	}
+	if called {
+		t.Error("expected live check to be skipped when GitHub disabled")
+	}
+}
+
+func TestCheckGitHubTokenLive_SkipsWhenNoToken(t *testing.T) {
+	origEnv, hadEnv := os.LookupEnv("GITHUB_TOKEN")
+	_ = os.Unsetenv("GITHUB_TOKEN")
+	origExec := ghAuthTokenExec
+	ghAuthTokenExec = func() (string, error) { return "", errors.New("not authenticated") }
+	t.Cleanup(func() {
+		if hadEnv {
+			_ = os.Setenv("GITHUB_TOKEN", origEnv)
+		}
+		ghAuthTokenExec = origExec
+	})
+
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			GitHub: &github.Config{Enabled: true},
+		},
+	}
+	called := false
+	check := func(string) (int, error) { called = true; return http.StatusOK, nil }
+
+	got := checkGitHubTokenLive(cfg, check)
+	if got != nil {
+		t.Errorf("expected nil check when no token resolves, got %+v", got)
+	}
+	if called {
+		t.Error("expected live check to be skipped when no token resolves")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a third GitHub token resolution step: `gh auth token` (cached once per process), behind `adapters.github.token` config and `GITHUB_TOKEN` env — consolidated into a single `resolveGitHubToken()` helper that replaces five duplicated resolution blocks in `cmd/pilot/main.go`.
- Adds `validateGitHubToken()`: makes one authenticated `GET /user` call at daemon startup (wired at both GitHub-polling construction sites). On a 401 it logs an ERROR naming the token source and fires a new `config_error` alert event (routed through a new `AlertTypeServiceUnhealthy` handler) when the alerts engine is configured — never blocks startup.
- Adds a matching `pilot doctor` check (`github.token.live`) with a clear pass/fail/warn line, using the same resolution precedence and an injectable live-check function.
- Adds `github.AuthError` to the GitHub client so a 401 can be distinguished from other failures via `errors.As`, instead of string-matching the wrapped error.

Fixes the class of incident from 2026-06-30 where a dead PAT caused every poller to fail with a silent 401 on every poll cycle — no startup error, no alert.

## Test plan

- [x] `TestResolveGitHubToken_Precedence` — config → env → gh CLI precedence, including cache-hit count
- [x] `TestValidateGitHubToken_DeadTokenFiresAlert` / `_ValidTokenNoAlert` / `_NilAlertsEngineDoesNotPanic`
- [x] `TestEngine_ConfigError` / `_NoMatchingRule` — new alert event type
- [x] `TestCheckGitHubTokenLive_*` — doctor live-check (dead/valid/network-error/disabled/no-token)
- [x] `make build && make test && make lint` all green
- [x] Manual `pilot doctor` smoke test confirmed a real dead token in an existing config surfaces as `github.token.live ✗ token invalid or expired (401, source: config)`