### PR TITLE
fix(executor): re-adopt queued tasks on daemon restart, surface queue position

### DIFF
--- a/internal/comms/commands.go
+++ b/internal/comms/commands.go
@@ -218,9 +218,35 @@ func formatQueueSummary(running, queued []*memory.Execution) string {
 			sb.WriteString("\n")
 		}
 		sb.WriteString(fmt.Sprintf("📋 Queued: %d\n", len(queued)))
+
+		// GH-3732: surface per-project serialization — a queued task is blocked
+		// by whichever task is running for its project, or (if none is running
+		// yet) by the queued task immediately ahead of it in the same project.
+		runningByProject := make(map[string]string, len(running))
+		for _, r := range running {
+			runningByProject[r.ProjectPath] = r.TaskID
+		}
+		positionInProject := make(map[string]int, len(queued))
+		blockedByProject := make(map[string]string, len(queued))
+
 		for i, exec := range queued {
 			age := time.Since(exec.CreatedAt).Round(time.Minute)
-			sb.WriteString(fmt.Sprintf("%d. %s — %s (%s ago)\n", i+1, exec.TaskID, filepath.Base(exec.ProjectPath), age))
+			positionInProject[exec.ProjectPath]++
+			position := positionInProject[exec.ProjectPath]
+
+			blockedBy := blockedByProject[exec.ProjectPath]
+			if blockedBy == "" {
+				blockedBy = runningByProject[exec.ProjectPath]
+			}
+
+			if blockedBy != "" {
+				sb.WriteString(fmt.Sprintf("%d. %s — %s (%s ago) ⏳ behind %s (position %d)\n",
+					i+1, exec.TaskID, filepath.Base(exec.ProjectPath), age, blockedBy, position))
+			} else {
+				sb.WriteString(fmt.Sprintf("%d. %s — %s (%s ago)\n", i+1, exec.TaskID, filepath.Base(exec.ProjectPath), age))
+			}
+
+			blockedByProject[exec.ProjectPath] = exec.TaskID
 		}
 	}
 

--- a/internal/comms/commands_test.go
+++ b/internal/comms/commands_test.go
@@ -2,7 +2,9 @@ package comms
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/memory"
 )
@@ -525,6 +527,104 @@ func TestCommandHandler_ProjectAlias(t *testing.T) {
 	if !containsString(messenger.messages[0], "Active") {
 		t.Error("/project should show active project")
 	}
+}
+
+// TestFormatQueueSummary_BlockAnnotations covers GH-3732: queued entries must
+// show what they're waiting behind — the running task for their project, or
+// (chained) the queued task immediately ahead of them in the same project —
+// while an idle project's first queued entry stays a bare line.
+func TestFormatQueueSummary_BlockAnnotations(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name       string
+		running    []*memory.Execution
+		queued     []*memory.Execution
+		wantText   string              // exact expected output (unchanged/empty cases)
+		wantLines  map[string][]string // substring -> other substrings that must co-occur on its line
+		unwantChar map[string]string   // substring -> character that must NOT be on its line
+	}{
+		{
+			name:     "empty queue unchanged",
+			running:  nil,
+			queued:   nil,
+			wantText: "📋 Queue is empty",
+		},
+		{
+			name: "single project busy queue chains behind predecessor",
+			running: []*memory.Execution{
+				{TaskID: "GH-1", ProjectPath: "/p1", CreatedAt: now},
+			},
+			queued: []*memory.Execution{
+				{TaskID: "GH-2", ProjectPath: "/p1", CreatedAt: now},
+				{TaskID: "GH-3", ProjectPath: "/p1", CreatedAt: now},
+			},
+			wantLines: map[string][]string{
+				"GH-2": {"behind GH-1", "position 1"},
+				"GH-3": {"behind GH-2", "position 2"},
+			},
+		},
+		{
+			name: "multi-project mix only annotates entries with a live blocker",
+			running: []*memory.Execution{
+				{TaskID: "GH-10", ProjectPath: "/p1", CreatedAt: now},
+			},
+			queued: []*memory.Execution{
+				{TaskID: "GH-11", ProjectPath: "/p1", CreatedAt: now},
+				{TaskID: "GH-20", ProjectPath: "/p2", CreatedAt: now},
+			},
+			wantLines: map[string][]string{
+				"GH-11": {"behind GH-10", "position 1"},
+			},
+			unwantChar: map[string]string{
+				"GH-20": "⏳", // idle project (no running/queued predecessor) — bare line
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatQueueSummary(tc.running, tc.queued)
+
+			if tc.wantText != "" {
+				if got != tc.wantText {
+					t.Errorf("expected output %q, got %q", tc.wantText, got)
+				}
+				return
+			}
+
+			lines := strings.Split(got, "\n")
+			for marker, mustContain := range tc.wantLines {
+				line := findLineContaining(lines, marker)
+				if line == "" {
+					t.Fatalf("expected a line containing %q, got:\n%s", marker, got)
+				}
+				for _, want := range mustContain {
+					if !strings.Contains(line, want) {
+						t.Errorf("expected line %q to contain %q", line, want)
+					}
+				}
+			}
+			for marker, mustNotChar := range tc.unwantChar {
+				line := findLineContaining(lines, marker)
+				if line == "" {
+					t.Fatalf("expected a line containing %q, got:\n%s", marker, got)
+				}
+				if strings.Contains(line, mustNotChar) {
+					t.Errorf("expected line %q to NOT contain %q", line, mustNotChar)
+				}
+			}
+		})
+	}
+}
+
+func findLineContaining(lines []string, substr string) string {
+	for _, line := range lines {
+		if strings.Contains(line, substr) {
+			return line
+		}
+	}
+	return ""
 }
 
 // Helper functions

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -105,8 +106,23 @@ func (d *Dispatcher) SetDecomposer(decomposer *TaskDecomposer) {
 func (d *Dispatcher) Start(ctx context.Context) error {
 	d.log.Info("Starting dispatcher")
 
-	// Initial recovery pass on startup.
-	d.recoverStaleTasks()
+	// Recover stale RUNNING tasks first, before queue adoption below creates
+	// any workers — hasLiveWorker must reflect "nothing alive yet" for this
+	// pass, exactly as before GH-3732 (crashed-worker recovery is unchanged
+	// and out of scope for this fix).
+	d.recoverStaleRunningTasks()
+
+	// GH-3732: re-adopt projects that still have queued rows in SQLite. Only
+	// the in-memory workers map was lost on restart — recreating a worker per
+	// project lets Signal() drain the existing FIFO queue instead of the
+	// stale-queued reap below wrongly failing tasks that are simply waiting
+	// their turn (GH-3714/3715/3716 incident).
+	d.adoptQueuedProjects()
+
+	// Recover queued tasks that still have no worker after adoption — genuine
+	// orphans only (e.g. a duplicate of an already-completed task, or a
+	// project removed from config).
+	d.recoverStaleQueuedTasks()
 
 	// GH-2428: warn when the last batch of completed runs has no token
 	// telemetry. A persistent gap means the backend's usage events aren't
@@ -118,6 +134,22 @@ func (d *Dispatcher) Start(ctx context.Context) error {
 	go d.runStaleRecoveryLoop(ctx)
 
 	return nil
+}
+
+// adoptQueuedProjects recreates a worker for every project that still has
+// queued (or pending) executions in SQLite. Called once at Start, before the
+// stale-queued reap runs, so tasks left behind by a daemon restart resume
+// FIFO processing instead of being misclassified as orphans. GH-3732.
+func (d *Dispatcher) adoptQueuedProjects() {
+	projectPaths, err := d.store.GetQueuedProjectPaths()
+	if err != nil {
+		d.log.Warn("Failed to fetch queued project paths for restart adoption", slog.Any("error", err))
+		return
+	}
+	for _, path := range projectPaths {
+		d.log.Info("Re-adopting queued tasks after restart", slog.String("project", path))
+		d.ensureWorker(path)
+	}
 }
 
 // checkTelemetryGap inspects recent completed executions and logs a warning
@@ -194,10 +226,21 @@ func (d *Dispatcher) Stop() {
 
 // recoverStaleTasks marks orphaned running and queued tasks as failed.
 // Re-queuing without a worker just recreates the orphan, so we fail them.
+// Used by the periodic recovery loop, where both halves can safely run
+// back-to-back since queue adoption already happened at Start.
 func (d *Dispatcher) recoverStaleTasks() int {
+	resetCount := d.recoverStaleRunningTasks()
+	resetCount += d.recoverStaleQueuedTasks()
+	d.log.Info("stale recovery complete, reset N tasks", slog.Int("count", resetCount))
+	return resetCount
+}
+
+// recoverStaleRunningTasks marks orphaned running tasks (crashed workers) as
+// failed. Split out from recoverStaleTasks so Dispatcher.Start can run it
+// before queue adoption creates any workers. GH-3732.
+func (d *Dispatcher) recoverStaleRunningTasks() int {
 	var resetCount int
 
-	// Recover stale running tasks (crashed workers).
 	staleRunning, err := d.store.GetStaleRunningExecutions(d.config.StaleRunningThreshold)
 	if err != nil {
 		d.log.Warn("Failed to fetch stale running executions", slog.Any("error", err))
@@ -242,12 +285,19 @@ func (d *Dispatcher) recoverStaleTasks() int {
 		}
 	}
 
-	// Recover stale queued tasks (stuck in queue with no worker).
-	// GH-2331: Don't mark queued tasks stale when a live worker exists for the
-	// project — they're just waiting their turn. Pilot runs tasks serially per
-	// project; when one task takes 8+ minutes (common for epic/Navigator work),
-	// its siblings exceed the 5-minute threshold purely by waiting, and get
-	// killed mid-queue. Only orphans (no worker alive) should be reaped.
+	return resetCount
+}
+
+// recoverStaleQueuedTasks marks orphaned queued tasks as failed: either a
+// duplicate row for a task that already completed, or a queued task whose
+// project has no live worker even after Dispatcher.Start's adoption pass
+// (e.g. the project was removed from config). GH-2331: a live worker means
+// the task is simply waiting its turn — Pilot runs tasks serially per
+// project, and a sibling taking 8+ minutes (common for epic/Navigator work)
+// would otherwise exceed the 5-minute threshold and get killed mid-queue.
+func (d *Dispatcher) recoverStaleQueuedTasks() int {
+	var resetCount int
+
 	staleQueued, err := d.store.GetStaleQueuedExecutions(d.config.StaleQueuedThreshold)
 	if err != nil {
 		d.log.Warn("Failed to fetch stale queued executions", slog.Any("error", err))
@@ -280,19 +330,22 @@ func (d *Dispatcher) recoverStaleTasks() int {
 			continue
 		}
 
-		d.log.Warn("Marking stale queued task as failed",
+		d.log.Warn("Marking orphaned queued task as failed",
 			slog.String("execution_id", exec.ID),
 			slog.String("task_id", exec.TaskID),
 			slog.Time("created_at", exec.CreatedAt),
 		)
-		if err := d.store.UpdateExecutionStatus(exec.ID, "failed", "stale queued task recovered (no worker picked up)"); err != nil {
+		// GH-3732: reworded from "recovered" — restart adoption already gives
+		// every project with queued rows a worker, so reaching here means the
+		// project genuinely has none (e.g. removed from config), not that a
+		// normal restart failed to reconnect it.
+		if err := d.store.UpdateExecutionStatus(exec.ID, "failed", "queued task orphaned by restart; project no longer configured"); err != nil {
 			d.log.Error("Failed to mark stale queued task", slog.String("id", exec.ID), slog.Any("error", err))
 		} else {
 			resetCount++
 		}
 	}
 
-	d.log.Info("stale recovery complete, reset N tasks", slog.Int("count", resetCount))
 	return resetCount
 }
 
@@ -416,11 +469,24 @@ func (d *Dispatcher) queueSingleTask(ctx context.Context, task *Task) (string, e
 		return "", fmt.Errorf("failed to save execution: %w", err)
 	}
 
-	d.log.Info("Task queued",
-		slog.String("execution_id", execID),
-		slog.String("task_id", task.ID),
-		slog.String("project", task.ProjectPath),
-	)
+	// GH-3732: surface per-project serialization instead of leaving a queued
+	// task invisible until its turn comes up — log what it's waiting behind.
+	if blockedBy, position, busy := d.queueBlockInfo(task.ProjectPath); busy {
+		d.log.Info(fmt.Sprintf("task queued behind %s (position %d in %s queue)",
+			blockedBy, position, filepath.Base(task.ProjectPath)),
+			slog.String("execution_id", execID),
+			slog.String("task_id", task.ID),
+			slog.String("blocked_by", blockedBy),
+			slog.Int("position", position),
+			slog.String("project", task.ProjectPath),
+		)
+	} else {
+		d.log.Info("Task queued",
+			slog.String("execution_id", execID),
+			slog.String("task_id", task.ID),
+			slog.String("project", task.ProjectPath),
+		)
+	}
 
 	// Emit progress callback for task queued
 	d.runner.EmitProgress(task.ID, "Queued", 0, fmt.Sprintf("Task queued (exec: %s)", execID[:8]))
@@ -429,6 +495,25 @@ func (d *Dispatcher) queueSingleTask(ctx context.Context, task *Task) (string, e
 	d.ensureWorker(task.ProjectPath)
 
 	return execID, nil
+}
+
+// queueBlockInfo reports whether the project's worker is currently busy
+// processing another task and, if so, which task is blocking and what
+// position (1-indexed, tail of the FIFO queue) the newly-saved row holds.
+// GH-3732.
+func (d *Dispatcher) queueBlockInfo(projectPath string) (blockedBy string, position int, busy bool) {
+	d.mu.RLock()
+	worker, exists := d.workers[projectPath]
+	d.mu.RUnlock()
+	if !exists {
+		return "", 0, false
+	}
+
+	status := worker.Status()
+	if !status.IsProcessing {
+		return "", 0, false
+	}
+	return status.CurrentTaskID, status.QueuedCount, true
 }
 
 // ensureWorker creates a worker for the project if it doesn't exist and starts it.

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -1,10 +1,13 @@
 package executor
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -523,7 +526,9 @@ func TestRecoverStaleTasks_QueuedAndRunning(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
-	// Insert a stale running task and a stale queued task.
+	// Insert a stale running task and a stale queued task for the same
+	// project — mirrors the GH-3714/3715/3716 restart incident: a crashed
+	// worker leaves a "running" orphan while its FIFO siblings sit "queued".
 	executions := []*memory.Execution{
 		{ID: "exec-stale-run", TaskID: "TASK-RUN", ProjectPath: "/project", Status: "running"},
 		{ID: "exec-stale-q", TaskID: "TASK-Q", ProjectPath: "/project", Status: "queued"},
@@ -549,19 +554,35 @@ func TestRecoverStaleTasks_QueuedAndRunning(t *testing.T) {
 	}
 	defer dispatcher.Stop()
 
-	// Both stale tasks should be failed.
-	for _, id := range []string{"exec-stale-run", "exec-stale-q"} {
-		exec, err := store.GetExecution(id)
-		if err != nil {
-			t.Fatalf("failed to get execution %s: %v", id, err)
-		}
-		if exec.Status != "failed" {
-			t.Errorf("expected %s to be 'failed', got '%s'", id, exec.Status)
-		}
+	// The orphaned RUNNING task (crashed worker) is still reaped — unaffected
+	// by GH-3732, since recoverStaleRunningTasks runs before queue adoption
+	// creates any workers.
+	exec, err := store.GetExecution("exec-stale-run")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected exec-stale-run to be 'failed', got '%s'", exec.Status)
+	}
+
+	// GH-3732: the queued sibling must NOT be reaped as an orphan — its
+	// project gets re-adopted at Start, so a real worker should pick it up
+	// instead of the stale-queued reap wrongly failing it.
+	exec, err = store.GetExecution("exec-stale-q")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if exec.Status == "failed" && exec.Error == "queued task orphaned by restart; project no longer configured" {
+		t.Errorf("expected exec-stale-q to be adopted, not reaped as an orphan (error=%q)", exec.Error)
+	}
+
+	status := dispatcher.GetWorkerStatus()
+	if _, ok := status["/project"]; !ok {
+		t.Errorf("expected a re-adopted worker for /project, got workers: %v", status)
 	}
 
 	// Completed task should be untouched.
-	exec, err := store.GetExecution("exec-ok")
+	exec, err = store.GetExecution("exec-ok")
 	if err != nil {
 		t.Fatalf("failed to get execution: %v", err)
 	}
@@ -650,7 +671,7 @@ func TestRecoverStaleTasks_RespectsThresholds(t *testing.T) {
 		}
 	}
 
-	// Use very long thresholds so nothing is stale.
+	// Use very long thresholds so nothing is "stale" by age.
 	config := &DispatcherConfig{
 		StaleRunningThreshold: 24 * time.Hour,
 		StaleQueuedThreshold:  24 * time.Hour,
@@ -664,21 +685,21 @@ func TestRecoverStaleTasks_RespectsThresholds(t *testing.T) {
 	}
 	defer dispatcher.Stop()
 
-	// Nothing should have been marked failed.
-	for _, tc := range []struct {
-		id     string
-		expect string
-	}{
-		{"exec-fresh-run", "running"},
-		{"exec-fresh-q", "queued"},
-	} {
-		exec, err := store.GetExecution(tc.id)
-		if err != nil {
-			t.Fatalf("failed to get execution %s: %v", tc.id, err)
-		}
-		if exec.Status != tc.expect {
-			t.Errorf("expected %s to remain '%s', got '%s'", tc.id, tc.expect, exec.Status)
-		}
+	// The running task's threshold is respected — it isn't old enough to be
+	// considered a crash orphan, so it's left untouched.
+	exec, err := store.GetExecution("exec-fresh-run")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if exec.Status != "running" {
+		t.Errorf("expected exec-fresh-run to remain 'running', got '%s'", exec.Status)
+	}
+
+	// GH-3732: restart adoption is NOT threshold-gated — every project with a
+	// queued row gets a worker at Start regardless of how fresh the row is.
+	status := dispatcher.GetWorkerStatus()
+	if _, ok := status["/project"]; !ok {
+		t.Errorf("expected exec-fresh-q's project to be adopted with a worker regardless of threshold, got workers: %v", status)
 	}
 }
 
@@ -802,15 +823,27 @@ func TestRecoverStaleTasks_MarksFailedWhenNoCompleted(t *testing.T) {
 	}
 	defer dispatcher.Stop()
 
-	// Both should be marked failed (no completed execution exists).
-	for _, id := range []string{"exec-only-run", "exec-only-q"} {
-		exec, err := store.GetExecution(id)
-		if err != nil {
-			t.Fatalf("failed to get execution %s: %v", id, err)
-		}
-		if exec.Status != "failed" {
-			t.Errorf("expected %s to be 'failed', got '%s'", id, exec.Status)
-		}
+	// The running orphan has no worker (recoverStaleRunningTasks runs before
+	// adoption) and no completed sibling, so it's genuinely reaped.
+	exec, err := store.GetExecution("exec-only-run")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected exec-only-run to be 'failed', got '%s'", exec.Status)
+	}
+
+	// GH-3732: the queued task's project gets re-adopted at Start, so it must
+	// NOT be reaped via the stale-queued orphan path — it may still end up
+	// "failed" if the real worker attempts (and fails) execution against a
+	// nonexistent project path, but that's a distinct, legitimate outcome
+	// from the orphan-reap message.
+	exec, err = store.GetExecution("exec-only-q")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if exec.Status == "failed" && exec.Error == "queued task orphaned by restart; project no longer configured" {
+		t.Errorf("expected exec-only-q to be adopted, not reaped as an orphan (error=%q)", exec.Error)
 	}
 }
 
@@ -994,6 +1027,230 @@ func TestWaitForExecution_ClassifiedOutcomesAreTerminal(t *testing.T) {
 			}
 			if exec.Status != status {
 				t.Errorf("WaitForExecution(%s) returned status %q", status, exec.Status)
+			}
+		})
+	}
+}
+
+// GH-3732: restart adoption. A fresh Dispatcher (empty in-memory workers map)
+// must recreate a worker for every project that still has queued rows in
+// SQLite, so a daemon restart resumes FIFO processing instead of stranding
+// tasks that look idle from the outside.
+func TestDispatcher_AdoptQueuedProjectsOnRestart(t *testing.T) {
+	tests := []struct {
+		name     string
+		projects []string
+	}{
+		{name: "single project", projects: []string{"/project-adopt-a"}},
+		{name: "multiple projects", projects: []string{"/project-adopt-b", "/project-adopt-c", "/project-adopt-d"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+
+			// Simulate tasks left queued from before a restart: rows exist in
+			// SQLite, but this is a fresh Dispatcher with an empty workers map.
+			for i, proj := range tc.projects {
+				exec := &memory.Execution{
+					ID:          fmt.Sprintf("exec-adopt-%s-%d", tc.name, i),
+					TaskID:      fmt.Sprintf("TASK-ADOPT-%s-%d", tc.name, i),
+					ProjectPath: proj,
+					Status:      "queued",
+				}
+				if err := store.SaveExecution(exec); err != nil {
+					t.Fatalf("failed to save execution: %v", err)
+				}
+			}
+
+			runner := NewRunner()
+			dispatcher := NewDispatcher(store, runner, nil)
+
+			if len(dispatcher.GetWorkerStatus()) != 0 {
+				t.Fatalf("expected empty workers map before Start")
+			}
+
+			if err := dispatcher.Start(context.Background()); err != nil {
+				t.Fatalf("failed to start dispatcher: %v", err)
+			}
+			defer dispatcher.Stop()
+
+			// Give the adoption + worker goroutines time to spin up.
+			time.Sleep(150 * time.Millisecond)
+
+			status := dispatcher.GetWorkerStatus()
+			for _, proj := range tc.projects {
+				if _, ok := status[proj]; !ok {
+					t.Errorf("expected re-adopted worker for %s, got workers: %v", proj, status)
+				}
+			}
+		})
+	}
+}
+
+// TestStore_GetQueuedProjectPaths verifies the distinct-project query backing
+// restart adoption: only queued/pending rows count, duplicates collapse, and
+// completed/running rows are excluded. GH-3732.
+func TestStore_GetQueuedProjectPaths(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	executions := []*memory.Execution{
+		{ID: "exec-gp-1", TaskID: "TASK-GP-1", ProjectPath: "/project-gp-a", Status: "queued"},
+		{ID: "exec-gp-2", TaskID: "TASK-GP-2", ProjectPath: "/project-gp-a", Status: "queued"}, // duplicate project
+		{ID: "exec-gp-3", TaskID: "TASK-GP-3", ProjectPath: "/project-gp-b", Status: "pending"},
+		{ID: "exec-gp-4", TaskID: "TASK-GP-4", ProjectPath: "/project-gp-c", Status: "completed"}, // not queued
+		{ID: "exec-gp-5", TaskID: "TASK-GP-5", ProjectPath: "/project-gp-d", Status: "running"},   // not queued
+	}
+	for _, exec := range executions {
+		if err := store.SaveExecution(exec); err != nil {
+			t.Fatalf("failed to save execution: %v", err)
+		}
+	}
+
+	paths, err := store.GetQueuedProjectPaths()
+	if err != nil {
+		t.Fatalf("GetQueuedProjectPaths error: %v", err)
+	}
+
+	got := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		got[p] = true
+	}
+
+	for _, want := range []string{"/project-gp-a", "/project-gp-b"} {
+		if !got[want] {
+			t.Errorf("expected %s in queued project paths, got %v", want, paths)
+		}
+	}
+	for _, notWant := range []string{"/project-gp-c", "/project-gp-d"} {
+		if got[notWant] {
+			t.Errorf("did not expect %s in queued project paths, got %v", notWant, paths)
+		}
+	}
+	if len(paths) != 2 {
+		t.Errorf("expected 2 distinct queued project paths (dedup), got %d: %v", len(paths), paths)
+	}
+}
+
+// GH-3732: queueing a task behind a busy worker must log the blocking task ID
+// and the new task's FIFO position, instead of leaving it invisible until its
+// turn comes up (the GH-3725 incident: queued 70+ minutes with no signal why).
+func TestDispatcher_QueueSingleTask_BlockLogging(t *testing.T) {
+	tests := []struct {
+		name          string
+		busy          bool
+		blockedTaskID string
+	}{
+		{name: "idle_project_no_block", busy: false},
+		{name: "busy_project_logs_blocker_and_position", busy: true, blockedTaskID: "GH-1000"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+			runner := NewRunner()
+			dispatcher := NewDispatcher(store, runner, nil)
+
+			projectPath := "/project-block-" + tc.name
+			if tc.busy {
+				// Manually register a "busy" worker without starting its Run()
+				// goroutine, so the busy-check is deterministic instead of
+				// racing a real worker.
+				worker := NewProjectWorker(projectPath, store, runner, dispatcher.log)
+				worker.processing.Store(true)
+				worker.currentTaskID.Store(tc.blockedTaskID)
+				dispatcher.mu.Lock()
+				dispatcher.workers[projectPath] = worker
+				dispatcher.mu.Unlock()
+			}
+
+			var buf bytes.Buffer
+			dispatcher.log = slog.New(slog.NewTextHandler(&buf, nil))
+
+			task := &Task{ID: "GH-NEW", ProjectPath: projectPath}
+			if _, err := dispatcher.queueSingleTask(context.Background(), task); err != nil {
+				t.Fatalf("queueSingleTask error: %v", err)
+			}
+
+			logOutput := buf.String()
+			if !tc.busy {
+				if strings.Contains(logOutput, "blocked_by") {
+					t.Errorf("expected no blocked_by annotation for idle project, got: %s", logOutput)
+				}
+				return
+			}
+
+			if !strings.Contains(logOutput, "blocked_by="+tc.blockedTaskID) {
+				t.Errorf("expected blocked_by=%s in log, got: %s", tc.blockedTaskID, logOutput)
+			}
+			if !strings.Contains(logOutput, "position=1") {
+				t.Errorf("expected position=1 in log, got: %s", logOutput)
+			}
+			if !strings.Contains(logOutput, tc.blockedTaskID) {
+				t.Errorf("expected log message to name the blocking task %s, got: %s", tc.blockedTaskID, logOutput)
+			}
+		})
+	}
+}
+
+// TestRecoverStaleQueuedTasks_MessageAccuracy verifies the reworded orphan
+// message only fires for genuine orphans (no live worker), and that a
+// project with a live worker is left untouched. GH-3732.
+func TestRecoverStaleQueuedTasks_MessageAccuracy(t *testing.T) {
+	tests := []struct {
+		name          string
+		injectWorker  bool
+		wantStatus    string
+		wantErrSubstr string
+	}{
+		{
+			name:          "genuine orphan gets reworded message",
+			injectWorker:  false,
+			wantStatus:    "failed",
+			wantErrSubstr: "queued task orphaned by restart; project no longer configured",
+		},
+		{
+			name:         "live worker protects queued row from reap",
+			injectWorker: true,
+			wantStatus:   "queued",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+
+			exec := &memory.Execution{ID: "exec-msg", TaskID: "TASK-MSG", ProjectPath: "/project-msg", Status: "queued"}
+			if err := store.SaveExecution(exec); err != nil {
+				t.Fatalf("failed to save execution: %v", err)
+			}
+
+			config := &DispatcherConfig{StaleQueuedThreshold: 0}
+			dispatcher := NewDispatcher(store, NewRunner(), config)
+
+			if tc.injectWorker {
+				dispatcher.mu.Lock()
+				dispatcher.workers["/project-msg"] = &ProjectWorker{projectPath: "/project-msg"}
+				dispatcher.mu.Unlock()
+			}
+
+			// Call the queued-reap directly (no Start(), no adoption) to
+			// exercise the message logic in isolation.
+			dispatcher.recoverStaleQueuedTasks()
+
+			got, err := store.GetExecution("exec-msg")
+			if err != nil {
+				t.Fatalf("failed to get execution: %v", err)
+			}
+			if got.Status != tc.wantStatus {
+				t.Errorf("expected status %q, got %q", tc.wantStatus, got.Status)
+			}
+			if tc.wantErrSubstr != "" && got.Error != tc.wantErrSubstr {
+				t.Errorf("expected error %q, got %q", tc.wantErrSubstr, got.Error)
 			}
 		})
 	}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1340,6 +1340,32 @@ func (s *Store) GetStaleQueuedExecutions(staleDuration time.Duration) ([]*Execut
 	return executions, rows.Err()
 }
 
+// GetQueuedProjectPaths returns the distinct project paths that currently
+// have at least one queued or pending execution. Used by the dispatcher at
+// startup to re-adopt tasks left behind when the in-memory workers map is
+// lost on restart — the rows themselves survive in SQLite. GH-3732.
+func (s *Store) GetQueuedProjectPaths() ([]string, error) {
+	rows, err := s.db.Query(`
+		SELECT DISTINCT project_path
+		FROM executions
+		WHERE status = 'queued' OR status = 'pending'
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var paths []string
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			return nil, err
+		}
+		paths = append(paths, path)
+	}
+	return paths, rows.Err()
+}
+
 // DeleteExecution removes an execution row by ID. Used to clean up orphan rows
 // when the same task already has a completed execution.
 func (s *Store) DeleteExecution(id string) error {


### PR DESCRIPTION
## Summary
- `Dispatcher.Start` now re-adopts every project with queued rows left over from a restart (`adoptQueuedProjects`), recreating a `ProjectWorker` so FIFO draining resumes instead of the stale-queued reap wrongly failing them.
- Split `recoverStaleTasks` into `recoverStaleRunningTasks` (unchanged, runs first) and `recoverStaleQueuedTasks` (now runs after adoption, so it only reaches genuine orphans — e.g. a project removed from config). Reworded the failure message from "recovered" to "queued task orphaned by restart; project no longer configured" to reflect that.
- `queueSingleTask` now logs `task queued behind <taskID> (position N in <project> queue)` when the target project's worker is already busy, using the existing `ProjectWorker.Status()` fields.
- `formatQueueSummary` (shared by `/queue`, `/status`, and the operational-intent handler) now annotates each queued entry with `⏳ behind <taskID> (position N)` — chained through queued siblings in the same project, falling back to the currently running task when there's no queued predecessor yet.
- Added `Store.GetQueuedProjectPaths()` (distinct project paths with `status IN ('queued','pending')`) backing the restart adoption.

## Out of scope (per issue)
- Gateway `GetQueuedTasks` `waiting_behind`/`queue_position` field (subtask 3) — skipped; there's no HTTP handler wired to that DashboardStore method yet, so there's no consumer to extend. Can ship as a follow-up.
- Per-project serialization semantics, retry caps, and stale **running** task recovery are unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/executor/... -run 'TestDispatcher|TestProjectWorker|TestRecoverStale' -v` — all pass, including new restart-adoption, busy-worker logging, and reap-message-accuracy table-driven tests
- [x] `go test ./internal/comms/... -run TestFormatQueueSummary` — new table-driven tests for single-project chain, multi-project mix, and empty-queue cases
- [x] `make test` (full suite)
- [x] `make lint` / `golangci-lint run --new-from-rev=origin/main ./...`