### PR TITLE
fix(executor): fail-loud logging for silent model-routing paths

### DIFF
--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -26,6 +26,10 @@ type ExecuteOptions struct {
 	// Prompt is the full prompt to send to the AI backend
 	Prompt string
 
+	// TaskID identifies the task driving this execution, for correlating
+	// backend-level log lines (e.g. model-routing decisions) with the task.
+	TaskID string
+
 	// ProjectPath is the working directory for execution
 	ProjectPath string
 

--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -358,6 +358,11 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 	if opts.Model != "" {
 		args = append(args, "--model", opts.Model)
 		b.log.Info("Using routed model", slog.String("model", opts.Model))
+	} else {
+		b.log.Info("Omitting --model flag; worker will use its own default",
+			slog.String("backend", b.Name()),
+			slog.String("task_id", opts.TaskID),
+		)
 	}
 
 	// Add max-turns flag if set by .pilot/workflow.yaml agent.max_turns (TASK-304)

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -1,8 +1,10 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"runtime"
@@ -1069,5 +1071,64 @@ exit 2
 	}
 	if strings.Contains(lines[1], "--resume") {
 		t.Errorf("second invocation should not contain --resume: %q", lines[1])
+	}
+}
+
+// TestClaudeCodeBackendEmptyModelLogsAndOmitsFlag covers GH-3754: when
+// ExecuteOptions.Model is empty, the backend must not pass --model to the
+// worker (so it falls through to the worker's own default) and must log
+// that omission loudly, including the backend type and task ID, instead of
+// silently dropping the flag.
+func TestClaudeCodeBackendEmptyModelLogsAndOmitsFlag(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-CLI test relies on shell scripts; skipping on windows")
+	}
+
+	tmpDir := t.TempDir()
+	logFile := tmpDir + "/calls.log"
+	script := tmpDir + "/fake-claude"
+
+	body := `#!/bin/sh
+printf '%s\n' "$*" >> ` + logFile + `
+exit 0
+`
+	if err := os.WriteFile(script, []byte(body), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	var buf bytes.Buffer
+	backend := NewClaudeCodeBackend(&ClaudeCodeConfig{Command: script})
+	backend.log = slog.New(slog.NewTextHandler(&buf, nil))
+
+	opts := ExecuteOptions{
+		Prompt:       "hello",
+		ProjectPath:  tmpDir,
+		TaskID:       "GH-3754-test",
+		EventHandler: func(BackendEvent) {},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := backend.Execute(ctx, opts); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	data, readErr := os.ReadFile(logFile)
+	if readErr != nil {
+		t.Fatalf("read log: %v", readErr)
+	}
+	if strings.Contains(string(data), "--model") {
+		t.Errorf("expected no --model flag in argv when opts.Model is empty, got: %q", data)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "Omitting --model flag") {
+		t.Errorf("expected empty-model log line, got log output: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, BackendTypeClaudeCode) {
+		t.Errorf("expected backend type %q in log line, got: %s", BackendTypeClaudeCode, logOutput)
+	}
+	if !strings.Contains(logOutput, "GH-3754-test") {
+		t.Errorf("expected task_id in log line, got: %s", logOutput)
 	}
 }

--- a/internal/executor/model_routing.go
+++ b/internal/executor/model_routing.go
@@ -101,6 +101,9 @@ func (r *ModelRouter) resolveComplexity(task *Task) Complexity {
 // When an outcome tracker is set, checks failure rates and escalates if needed (GH-1991).
 func (r *ModelRouter) SelectModel(task *Task) string {
 	if r.modelConfig == nil || !r.modelConfig.Enabled {
+		slog.Debug("Model routing nil/disabled, returning empty model for backend default",
+			slog.String("task_id", task.ID),
+		)
 		return ""
 	}
 

--- a/internal/executor/model_routing_test.go
+++ b/internal/executor/model_routing_test.go
@@ -1,9 +1,12 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -614,5 +617,57 @@ func TestDefaultModelRoutingConfig_UserOverrideWins(t *testing.T) {
 	model := router.SelectModel(task)
 	if model != "" {
 		t.Errorf("user config enabled:false should disable routing; SelectModel() = %q, want empty", model)
+	}
+}
+
+// TestModelRouter_SelectModel_LogsWhenRoutingDisabled covers GH-3754: SelectModel
+// must not silently return "" when routing is nil/disabled — it should log a
+// Debug line so the empty-routing path is visible in telemetry.
+func TestModelRouter_SelectModel_LogsWhenRoutingDisabled(t *testing.T) {
+	var buf bytes.Buffer
+	prevDefault := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prevDefault)
+
+	router := NewModelRouter(&ModelRoutingConfig{Enabled: false}, nil)
+	task := &Task{ID: "GH-3754-routing-test", Description: "Fix typo in README"}
+
+	got := router.SelectModel(task)
+	if got != "" {
+		t.Fatalf("SelectModel() = %q, want empty when routing disabled", got)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "Model routing nil/disabled") {
+		t.Errorf("expected empty-routing debug log line, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "GH-3754-routing-test") {
+		t.Errorf("expected task_id in debug log line, got: %s", logOutput)
+	}
+}
+
+// TestModelRouter_SelectModel_NoLogWhenRoutingEnabled ensures the new debug
+// log is scoped to the nil/disabled branch and doesn't fire on the normal path.
+func TestModelRouter_SelectModel_NoLogWhenRoutingEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	prevDefault := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prevDefault)
+
+	router := NewModelRouter(&ModelRoutingConfig{
+		Enabled: true,
+		Trivial: "claude-haiku",
+		Simple:  "claude-sonnet",
+		Medium:  "claude-sonnet",
+		Complex: "claude-opus",
+	}, nil)
+	task := &Task{ID: "GH-3754-routing-enabled", Description: "Fix typo in README"}
+
+	if got := router.SelectModel(task); got == "" {
+		t.Fatalf("SelectModel() returned empty, want a routed model")
+	}
+
+	if strings.Contains(buf.String(), "Model routing nil/disabled") {
+		t.Errorf("did not expect empty-routing debug log line when routing is enabled, got: %s", buf.String())
 	}
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2100,6 +2100,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	allowedTools, mcpConfigPath := r.executionToolOptions()
 	backendResult, err := r.backend.Execute(stallExecutionCtx, ExecuteOptions{
 		Prompt:          prompt,
+		TaskID:          task.ID,
 		ProjectPath:     executionPath, // Use worktree path if active
 		Verbose:         task.Verbose,
 		Model:           selectedModel,
@@ -2421,6 +2422,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						smartAllowed, smartMCP := r.executionToolOptions()
 						retryResult, retryErr := r.backend.Execute(retryCtx, ExecuteOptions{
 							Prompt:          prompt,
+							TaskID:          task.ID,
 							ProjectPath:     executionPath, // TASK-323: retry in the worktree, not the user's real repo
 							Verbose:         task.Verbose,
 							Model:           selectedModel,
@@ -2613,6 +2615,9 @@ retrySucceeded:
 		result.ModelName = state.modelName
 	}
 	if result.ModelName == "" {
+		log.Warn("Telemetry produced no model name; recording config-derived guess",
+			slog.String("task_id", task.ID),
+		)
 		// GH-2428: derive from config (DefaultModel/OpenCode.Model/backend type)
 		// instead of hardcoding "claude-opus-4-6". The hardcoded value was stale
 		// (Claude Code reports 4-7) and silently labelled OpenCode/GLM runs as
@@ -2764,6 +2769,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				noopRetryAllowed, noopRetryMCP := r.executionToolOptions()
 				retryResult, retryErr := r.backend.Execute(ctx, ExecuteOptions{
 					Prompt:          retryPrompt,
+					TaskID:          task.ID,
 					ProjectPath:     executionPath, // TASK-323: retry in the worktree so CountNewCommits can see its commits
 					Verbose:         task.Verbose,
 					Model:           selectedModel,
@@ -3070,6 +3076,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					feedbackAllowed, feedbackMCP := r.executionToolOptions()
 					retryResult, retryErr := r.backend.Execute(ctx, ExecuteOptions{
 						Prompt:        retryPrompt,
+						TaskID:        task.ID,
 						ProjectPath:   executionPath, // GH-3577: retry in the worktree, not the daemon's repo root
 						Verbose:       task.Verbose,
 						Model:         selectedModel,
@@ -3349,6 +3356,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					intentAllowed, intentMCP := r.executionToolOptions()
 					_, retryErr := r.backend.Execute(ctx, ExecuteOptions{
 						Prompt:        retryPrompt,
+						TaskID:        task.ID,
 						ProjectPath:   executionPath, // GH-3577: retry in the worktree, not the daemon's repo root
 						Verbose:       task.Verbose,
 						Model:         selectedModel,
@@ -4005,6 +4013,7 @@ func (r *Runner) runSelfReview(ctx context.Context, task *Task, state *progressS
 	reviewAllowed, reviewMCP := r.executionToolOptions()
 	result, err := r.backend.Execute(reviewCtx, ExecuteOptions{
 		Prompt:          reviewPrompt,
+		TaskID:          task.ID,
 		ProjectPath:     task.ProjectPath,
 		Verbose:         task.Verbose,
 		Model:           selectedModel,

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -3441,6 +3442,61 @@ func TestRunnerFallbackModelName(t *testing.T) {
 				t.Errorf("fallbackModelName() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestExecuteWithOptions_EmptyModelNameLogsWarn covers GH-3754: when telemetry
+// produces no model name (backend result and stream state both empty), the
+// fallbackModelName() guess must be preceded by a loud Warn log instead of
+// silently recording a config-derived value.
+func TestExecuteWithOptions_EmptyModelNameLogsWarn(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	const branch = "pilot/GH-3754-model-warn"
+	dir := setupPRGuardRepo(t, branch, true) // adds a real commit so no-commit guard doesn't fire
+
+	backend := &mockFixedBackend{
+		result: &BackendResult{Success: true, Output: "done", Model: ""},
+	}
+
+	var buf bytes.Buffer
+	runner := NewRunnerWithBackend(backend)
+	runner.log = slog.New(slog.NewTextHandler(&buf, nil))
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+
+	task := &Task{
+		ID:          "GH-3754-model-warn",
+		Title:       "test empty model name warns",
+		Description: "verify fallback model name logs loudly",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    false,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Execute() not successful: %s", result.Error)
+	}
+	if result.ModelName == "" {
+		t.Fatal("expected fallbackModelName() to populate ModelName")
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "Telemetry produced no model name") {
+		t.Errorf("expected fallback-model warn log line, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, task.ID) {
+		t.Errorf("expected task_id in warn log line, got: %s", logOutput)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `backend_claudecode.go`: log INFO with backend type + task ID when `--model` is omitted, instead of silently falling through to the worker's own default.
- `runner.go`: log WARN before `fallbackModelName()` at the telemetry-fill site (~2611-2620), noting the recorded model name is a config-derived guess, not observed telemetry.
- `model_routing.go`: log DEBUG in `SelectModel` when routing is nil/disabled and it returns `""`.
- Added `ExecuteOptions.TaskID` so the backend-level log line can be correlated back to the originating task; threaded through all 6 call sites in `runner.go`.
- No behavior change to `--model` flag semantics — GH-2450 (`resolveSelectedModel`, default_model no longer clobbers routing) is untouched.

## Test plan
- [x] `go test ./internal/executor/... -run 'TestModelRout|TestResolveSelectedModel|TestBackendClaudeCode'` — green
- [x] New tests: `TestClaudeCodeBackendEmptyModelLogsAndOmitsFlag` (no `--model` arg + log line fires), `TestModelRouter_SelectModel_LogsWhenRoutingDisabled` / `_NoLogWhenRoutingEnabled`, `TestExecuteWithOptions_EmptyModelNameLogsWarn`
- [x] `make build`
- [x] `make test` (full suite)
- [x] `make lint`

Closes #3754