### PR TITLE
fix(config): fail loud on unset env vars in sensitive config keys

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -489,6 +490,53 @@ func defaultAlertRules() []AlertRuleConfig {
 	}
 }
 
+// envVarRefPattern matches ${VAR} and $VAR references the way os.ExpandEnv does.
+var envVarRefPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)`)
+
+// sensitiveConfigKeyPattern flags config keys that should never silently
+// resolve to an empty string (GH-3755): a dead/typo'd env var here means
+// auth silently fails instead of erroring at load time.
+var sensitiveConfigKeyPattern = regexp.MustCompile(`(?i)(token|key|secret|password)`)
+
+// checkEnvVarReferences pre-scans raw config YAML for ${VAR}/$VAR references
+// before os.ExpandEnv runs, and reports any that resolve to an empty value.
+// If the reference sits on a line whose key looks sensitive (token, key,
+// secret, password — case-insensitive substring match), it returns an error
+// naming both the variable and the offending config key/line so the failure
+// is loud instead of silently expanding to "". For non-sensitive keys it
+// logs a warning and lets expansion proceed unchanged.
+func checkEnvVarReferences(raw string) error {
+	for i, line := range strings.Split(raw, "\n") {
+		for _, m := range envVarRefPattern.FindAllStringSubmatch(line, -1) {
+			varName := m[1]
+			if varName == "" {
+				varName = m[2]
+			}
+			if value, ok := os.LookupEnv(varName); ok && value != "" {
+				continue
+			}
+
+			key := configKeyFromLine(line)
+			if sensitiveConfigKeyPattern.MatchString(key) {
+				return fmt.Errorf("config: environment variable %q referenced by sensitive key %q at line %d is unset or empty: %s", varName, key, i+1, strings.TrimSpace(line))
+			}
+			log.Printf("WARN: config: environment variable %q at line %d is unset or empty: %s", varName, i+1, strings.TrimSpace(line))
+		}
+	}
+	return nil
+}
+
+// configKeyFromLine extracts the YAML key (if any) from a single line, e.g.
+// `  token: ${VAR}` -> "token", `- name: ${VAR}` -> "name".
+func configKeyFromLine(line string) string {
+	trimmed := strings.TrimSpace(line)
+	trimmed = strings.TrimPrefix(trimmed, "- ")
+	if idx := strings.Index(trimmed, ":"); idx != -1 {
+		return strings.TrimSpace(trimmed[:idx])
+	}
+	return trimmed
+}
+
 // Load reads and parses configuration from a YAML file at the given path.
 // Environment variables in the file are expanded using os.ExpandEnv syntax.
 // If the file does not exist, default configuration is returned.
@@ -502,6 +550,11 @@ func Load(path string) (*Config, error) {
 			return config, nil // Return defaults if no config file
 		}
 		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+
+	// Pre-scan for env var references that would silently expand to "" (GH-3755).
+	if err := checkEnvVarReferences(string(data)); err != nil {
+		return nil, err
 	}
 
 	// Expand environment variables

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -428,6 +431,111 @@ gateway:
 		_, err := Load(configPath)
 		if err == nil {
 			t.Error("Load should fail for unreadable file")
+		}
+	})
+}
+
+// TestLoad_EnvVarPreScan covers GH-3755: unset/empty env var references in
+// sensitive config keys (token/key/secret/password) must fail loudly instead
+// of silently expanding to "", while non-sensitive keys only warn.
+func TestLoad_EnvVarPreScan(t *testing.T) {
+	t.Run("SensitiveKeyUnsetEnvVar_ReturnsError", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		configContent := `
+version: "1.0"
+adapters:
+  github:
+    enabled: true
+    token: "${UNSET_VAR}"
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		_, err := Load(configPath)
+		if err == nil {
+			t.Fatal("Load should return an error when a sensitive key references an unset env var")
+		}
+		if !strings.Contains(err.Error(), "UNSET_VAR") {
+			t.Errorf("error = %q, want it to mention UNSET_VAR", err.Error())
+		}
+	})
+
+	t.Run("NonSensitiveKeyUnsetEnvVar_WarnsAndLoads", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		configContent := `
+version: "1.0"
+adapters:
+  github:
+    enabled: true
+    pilot_label: "${UNSET_LABEL_VAR}"
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		var logBuf bytes.Buffer
+		originalOutput := log.Writer()
+		log.SetOutput(&logBuf)
+		defer log.SetOutput(originalOutput)
+
+		config, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load should succeed for a non-sensitive key with an unset env var, got error: %v", err)
+		}
+		if config.Adapters.GitHub.PilotLabel != "" {
+			t.Errorf("PilotLabel = %q, want empty (unset var expands to empty)", config.Adapters.GitHub.PilotLabel)
+		}
+		if !strings.Contains(logBuf.String(), "UNSET_LABEL_VAR") {
+			t.Errorf("expected a warning log mentioning UNSET_LABEL_VAR, got: %q", logBuf.String())
+		}
+	})
+
+	t.Run("RealConfigStillLoads", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		t.Setenv("REGRESSION_TEST_LINEAR_TOKEN", "real-token-value")
+
+		configContent := `
+version: "2.0"
+gateway:
+  host: "0.0.0.0"
+  port: 8080
+adapters:
+  linear:
+    enabled: true
+    api_key: "${REGRESSION_TEST_LINEAR_TOKEN}"
+orchestrator:
+  model: "claude-opus"
+  max_concurrent: 4
+projects:
+  - name: "test-project"
+    path: "/path/to/project"
+    navigator: true
+    default_branch: "develop"
+default_project: "test-project"
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		config, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load failed for regression config: %v", err)
+		}
+		if config.Adapters.Linear.APIKey != "real-token-value" {
+			t.Errorf("Linear.APIKey = %q, want %q", config.Adapters.Linear.APIKey, "real-token-value")
+		}
+		if config.Version != "2.0" {
+			t.Errorf("Version = %q, want %q", config.Version, "2.0")
+		}
+		if config.Projects[0].Name != "test-project" {
+			t.Errorf("Projects[0].Name = %q, want %q", config.Projects[0].Name, "test-project")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Pre-scan raw config YAML for `${VAR}`/`$VAR` references before `os.ExpandEnv` runs
- If a reference resolves to empty (unset or empty env var) on a line whose key looks sensitive (`token`, `key`, `secret`, `password` — case-insensitive substring), `Load` now returns an error naming the variable and the offending config key/line instead of silently expanding to `""`
- Non-sensitive fields still expand as before, but emit a `log.Printf("WARN: ...")` naming the unset variable

Closes GH-3755.

## Test plan
- [x] `make build`
- [x] `make test`
- [x] `make lint` (0 issues)
- [x] `go test ./internal/config/... -run 'TestLoad' -v` — new `TestLoad_EnvVarPreScan` subtests pass (sensitive-key error, non-sensitive-key warn, regression config unchanged)
- [x] `UNSET_TEST_VAR= go run ./cmd/pilot doctor 2>&1 | head -5` — real config loads unaffected