### PR TITLE
GH-3755: feat(config): fail loud on empty ${VAR} expansion for sensitive fields

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -489,6 +490,78 @@ func defaultAlertRules() []AlertRuleConfig {
 	}
 }
 
+// envVarRefPattern matches ${VAR} and $VAR references, the two forms
+// os.ExpandEnv supports.
+var envVarRefPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)`)
+
+// sensitiveConfigKeyPattern matches YAML keys that hold sensitive values,
+// where an empty ${VAR} expansion is a load-time error rather than a warning.
+var sensitiveConfigKeyPattern = regexp.MustCompile(`(?i)(token|key|secret|password)`)
+
+// checkEnvVarExpansion pre-scans raw YAML for ${VAR} and $VAR references
+// before os.ExpandEnv runs, so an empty/unset variable can be reported with
+// the config key and line it was found on. os.ExpandEnv silently substitutes
+// unset or empty variables with "", which is dangerous for fields like
+// github.token: a typo'd env var name would otherwise load a config with a
+// silently empty credential instead of failing loudly.
+//
+// References that resolve to empty are handled based on the YAML key they
+// appear on: sensitive keys (matching token/key/secret/password, case
+// insensitive) cause Load to fail with an error naming both the variable and
+// the offending key/line; all other keys just get a log.Warn and expansion
+// proceeds as before. The returned warnings are the non-sensitive messages
+// that were logged, exposed for testing.
+func checkEnvVarExpansion(data string) ([]string, error) {
+	var warnings []string
+
+	lines := strings.Split(data, "\n")
+	for i, line := range lines {
+		matches := envVarRefPattern.FindAllStringSubmatch(line, -1)
+		if matches == nil {
+			continue
+		}
+
+		for _, match := range matches {
+			varName := match[1]
+			if varName == "" {
+				varName = match[2]
+			}
+
+			// os.LookupEnv mirrors what os.ExpandEnv effectively does:
+			// an unset var and a var set to "" both expand to "".
+			value, _ := os.LookupEnv(varName)
+			if value != "" {
+				continue
+			}
+
+			key := yamlKeyFromLine(line)
+			lineNum := i + 1
+
+			if sensitiveConfigKeyPattern.MatchString(key) {
+				return warnings, fmt.Errorf("config: environment variable %q referenced by %q on line %d is unset or empty; refusing to load a config with an empty sensitive value (line: %q)", varName, key, lineNum, strings.TrimSpace(line))
+			}
+
+			msg := fmt.Sprintf("config: environment variable %q referenced by %q on line %d is unset or empty; proceeding with empty expansion (line: %q)", varName, key, lineNum, strings.TrimSpace(line))
+			log.Printf("WARN: %s", msg)
+			warnings = append(warnings, msg)
+		}
+	}
+	return warnings, nil
+}
+
+// yamlKeyFromLine extracts the YAML key from a "key: value" line, trimming
+// list-item dashes and surrounding whitespace. Returns "" if the line has no
+// colon (e.g. a bare list item or a multi-line value continuation).
+func yamlKeyFromLine(line string) string {
+	idx := strings.Index(line, ":")
+	if idx == -1 {
+		return ""
+	}
+	key := strings.TrimSpace(line[:idx])
+	key = strings.TrimPrefix(key, "-")
+	return strings.TrimSpace(key)
+}
+
 // Load reads and parses configuration from a YAML file at the given path.
 // Environment variables in the file are expanded using os.ExpandEnv syntax.
 // If the file does not exist, default configuration is returned.
@@ -502,6 +575,11 @@ func Load(path string) (*Config, error) {
 			return config, nil // Return defaults if no config file
 		}
 		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+
+	// Fail loud on empty ${VAR}/$VAR expansion for sensitive fields (GH-3755)
+	if _, err := checkEnvVarExpansion(string(data)); err != nil {
+		return nil, err
 	}
 
 	// Expand environment variables

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -355,6 +356,136 @@ adapters:
 
 		if config.Adapters.Linear.APIKey != testValue {
 			t.Errorf("Linear.APIKey = %q, want %q (env var expansion failed)", config.Adapters.Linear.APIKey, testValue)
+		}
+	})
+
+	t.Run("EmptySensitiveEnvVarFailsLoud", func(t *testing.T) {
+		// GH-3755: an unset env var referenced by a sensitive field (token,
+		// key, secret, password) must fail Load loudly instead of silently
+		// loading an empty credential.
+		if err := os.Unsetenv("GH3755_UNSET_TOKEN_VAR"); err != nil {
+			t.Fatalf("Unsetenv failed: %v", err)
+		}
+
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		configContent := `
+version: "1.0"
+adapters:
+  github:
+    enabled: true
+    token: "${GH3755_UNSET_TOKEN_VAR}"
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		_, err := Load(configPath)
+		if err == nil {
+			t.Fatal("Load should return an error for an unset env var referenced by a sensitive field")
+		}
+		if !strings.Contains(err.Error(), "GH3755_UNSET_TOKEN_VAR") {
+			t.Errorf("Load error = %q, want it to mention GH3755_UNSET_TOKEN_VAR", err.Error())
+		}
+		if !strings.Contains(err.Error(), "token") {
+			t.Errorf("Load error = %q, want it to mention the offending key %q", err.Error(), "token")
+		}
+	})
+
+	t.Run("EmptyNonSensitiveEnvVarWarnsAndLoads", func(t *testing.T) {
+		// A non-sensitive field with an unset env var should still load
+		// successfully, only logging a warning.
+		if err := os.Unsetenv("GH3755_UNSET_LABEL_VAR"); err != nil {
+			t.Fatalf("Unsetenv failed: %v", err)
+		}
+
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		configContent := `
+version: "1.0"
+projects:
+  - name: "${GH3755_UNSET_LABEL_VAR}"
+    path: "/path/to/project"
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		config, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load should succeed for a non-sensitive field with an unset env var, got error: %v", err)
+		}
+		if len(config.Projects) != 1 {
+			t.Fatalf("Projects length = %d, want 1", len(config.Projects))
+		}
+		if config.Projects[0].Name != "" {
+			t.Errorf("Projects[0].Name = %q, want empty string (expanded from unset var)", config.Projects[0].Name)
+		}
+
+		warnings, err := checkEnvVarExpansion(configContent)
+		if err != nil {
+			t.Fatalf("checkEnvVarExpansion returned unexpected error: %v", err)
+		}
+		if len(warnings) != 1 {
+			t.Fatalf("checkEnvVarExpansion warnings = %d, want 1", len(warnings))
+		}
+		if !strings.Contains(warnings[0], "GH3755_UNSET_LABEL_VAR") {
+			t.Errorf("warning = %q, want it to mention GH3755_UNSET_LABEL_VAR", warnings[0])
+		}
+	})
+
+	t.Run("RealConfigStillLoadsUnchanged", func(t *testing.T) {
+		// GH-3755 regression guard: a realistic config with sensitive fields
+		// backed by properly set env vars must still load unchanged.
+		t.Setenv("GH3755_REAL_GITHUB_TOKEN", "gh-real-token")
+		t.Setenv("GH3755_REAL_LINEAR_KEY", "linear-real-key")
+
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		configContent := `
+version: "2.0"
+gateway:
+  host: "0.0.0.0"
+  port: 8080
+adapters:
+  github:
+    enabled: true
+    token: "${GH3755_REAL_GITHUB_TOKEN}"
+  linear:
+    enabled: true
+    api_key: "${GH3755_REAL_LINEAR_KEY}"
+orchestrator:
+  model: "claude-opus"
+  max_concurrent: 4
+projects:
+  - name: "test-project"
+    path: "/path/to/project"
+    navigator: true
+    default_branch: "develop"
+default_project: "test-project"
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		config, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load failed for a real config with properly set env vars: %v", err)
+		}
+		if config.Adapters.GitHub.Token != "gh-real-token" {
+			t.Errorf("GitHub.Token = %q, want %q", config.Adapters.GitHub.Token, "gh-real-token")
+		}
+		if config.Adapters.Linear.APIKey != "linear-real-key" {
+			t.Errorf("Linear.APIKey = %q, want %q", config.Adapters.Linear.APIKey, "linear-real-key")
+		}
+		if config.Orchestrator.Model != "claude-opus" {
+			t.Errorf("Orchestrator.Model = %q, want %q", config.Orchestrator.Model, "claude-opus")
+		}
+		if config.DefaultProject != "test-project" {
+			t.Errorf("DefaultProject = %q, want %q", config.DefaultProject, "test-project")
 		}
 	})
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3755.

Closes #3755

## Changes

GitHub Issue #3755: feat(config): fail loud on empty ${VAR} expansion for sensitive fields

<!--autopilot-meta
parent: GH-3726
inherited-spec: true
-->

Parent: GH-3726

In internal/config/config.go around the os.ExpandEnv(string(data)) call at line 503, pre-scan the raw YAML for ${VAR} and $VAR references and check each against os.LookupEnv. For any reference that resolves to empty, inspect the YAML line it appears on: if the key matches token, key, secret, or password (case-insensitive substring match), return a load error naming both the variable and the offending config key/line; otherwise log.Warn naming the variable but proceed with expansion. Add unit tests in internal/config/: (a) github.token: ${UNSET_VAR} with UNSET_VAR unset asserts Load returns an error mentioning UNSET_VAR; (b) a non-sensitive field (e.g. a label or name) with an unset var loads successfully and emits a Warn; (c) an existing real config still loads unchanged as a regression guard. Verify with: make build && make test && make lint; go test ./internal/config/... -run 'TestLoad' -v; UNSET_TEST_VAR= go run ./cmd/pilot doctor 2>&1 | head -5

## Scope fence

Implement ONLY the slice described above. The parent issue GH-3726 is decomposed
into sibling sub-issues that cover the rest of its spec — consult the parent
for context, but do NOT implement parts of it that fall outside this subtask.