### PR TITLE
feat(health): add Verifiable contract and ReadinessChecker adapter

### DIFF
--- a/internal/health/verify/verify.go
+++ b/internal/health/verify/verify.go
@@ -1,0 +1,55 @@
+// Package verify defines a stable, context-aware health-check contract and
+// a small adapter that bridges it to the gateway's boolean ReadinessChecker
+// interface, so follow-up checks can be written once against Verifiable and
+// registered anywhere a gateway.ReadinessChecker is expected.
+package verify
+
+import (
+	"context"
+	"time"
+)
+
+// DefaultTimeout bounds a Verify call when NewReadinessAdapter is given a
+// non-positive timeout.
+const DefaultTimeout = 5 * time.Second
+
+// Verifiable is implemented by components that can self-check their health
+// via a context-bound call, allowing callers to bound the check's duration
+// and cancel it.
+type Verifiable interface {
+	// Name returns a unique identifier for this check.
+	Name() string
+	// Verify returns nil if the component is healthy, or an error describing
+	// why it isn't. Implementations should respect ctx cancellation/deadline.
+	Verify(ctx context.Context) error
+}
+
+// ReadinessAdapter adapts a Verifiable into the gateway's ReadinessChecker
+// shape (Name() string; Ready() bool) by calling Verify with a bounded
+// timeout and mapping err == nil to Ready() == true.
+type ReadinessAdapter struct {
+	v       Verifiable
+	timeout time.Duration
+}
+
+// NewReadinessAdapter wraps v so it satisfies gateway.ReadinessChecker.
+// A non-positive timeout falls back to DefaultTimeout.
+func NewReadinessAdapter(v Verifiable, timeout time.Duration) *ReadinessAdapter {
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	return &ReadinessAdapter{v: v, timeout: timeout}
+}
+
+// Name returns the wrapped Verifiable's name.
+func (a *ReadinessAdapter) Name() string {
+	return a.v.Name()
+}
+
+// Ready calls Verify with a bounded timeout and reports true only if it
+// returns nil before the timeout elapses.
+func (a *ReadinessAdapter) Ready() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), a.timeout)
+	defer cancel()
+	return a.v.Verify(ctx) == nil
+}

--- a/internal/health/verify/verify_test.go
+++ b/internal/health/verify/verify_test.go
@@ -1,0 +1,87 @@
+package verify
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/gateway"
+)
+
+// Compile-time check: *ReadinessAdapter must satisfy gateway.ReadinessChecker.
+var _ gateway.ReadinessChecker = (*ReadinessAdapter)(nil)
+
+// fakeVerifiable is a test double for Verifiable. If delay > 0, Verify
+// blocks until delay elapses or ctx is done, whichever comes first —
+// returning ctx.Err() in the latter case, exercising timeout mapping.
+type fakeVerifiable struct {
+	name  string
+	err   error
+	delay time.Duration
+}
+
+func (f *fakeVerifiable) Name() string { return f.name }
+
+func (f *fakeVerifiable) Verify(ctx context.Context) error {
+	if f.delay > 0 {
+		select {
+		case <-time.After(f.delay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return f.err
+}
+
+func TestReadinessAdapter_Name(t *testing.T) {
+	v := &fakeVerifiable{name: "db"}
+	a := NewReadinessAdapter(v, time.Second)
+	if got := a.Name(); got != "db" {
+		t.Errorf("Name() = %q, want %q", got, "db")
+	}
+}
+
+func TestReadinessAdapter_Ready_OK(t *testing.T) {
+	v := &fakeVerifiable{name: "ok-check", err: nil}
+	a := NewReadinessAdapter(v, 50*time.Millisecond)
+	if !a.Ready() {
+		t.Error("Ready() = false, want true when Verify returns nil")
+	}
+}
+
+func TestReadinessAdapter_Ready_Error(t *testing.T) {
+	v := &fakeVerifiable{name: "err-check", err: errors.New("dependency down")}
+	a := NewReadinessAdapter(v, 50*time.Millisecond)
+	if a.Ready() {
+		t.Error("Ready() = true, want false when Verify returns an error")
+	}
+}
+
+func TestReadinessAdapter_Ready_Timeout(t *testing.T) {
+	v := &fakeVerifiable{name: "slow-check", delay: 200 * time.Millisecond}
+	a := NewReadinessAdapter(v, 20*time.Millisecond)
+
+	start := time.Now()
+	ready := a.Ready()
+	elapsed := time.Since(start)
+
+	if ready {
+		t.Error("Ready() = true, want false when Verify exceeds the bounded timeout")
+	}
+	// Ready() must return once the bounded timeout fires, not wait for the
+	// full delay — proves the timeout is actually enforced via context.
+	if elapsed >= v.delay {
+		t.Errorf("Ready() took %v, want well under the %v Verify delay (timeout not enforced)", elapsed, v.delay)
+	}
+}
+
+func TestNewReadinessAdapter_NonPositiveTimeoutUsesDefault(t *testing.T) {
+	v := &fakeVerifiable{name: "default-timeout-check"}
+	for _, timeout := range []time.Duration{0, -time.Second} {
+		a := NewReadinessAdapter(v, timeout)
+		if a.timeout != DefaultTimeout {
+			t.Errorf("NewReadinessAdapter(%v) timeout = %v, want DefaultTimeout (%v)", timeout, a.timeout, DefaultTimeout)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/health/verify` with a `Verifiable{Name() string; Verify(ctx context.Context) error}` interface
- Add `ReadinessAdapter` that bridges `Verifiable` into the existing `gateway.ReadinessChecker` (`Name() string; Ready() bool`) by calling `Verify` with a bounded timeout (default 5s, override via `NewReadinessAdapter`) and mapping `err == nil` to `Ready() == true`
- Pure scaffolding — no adapter code changes, no wiring into `RegisterReadinessChecker` — so follow-up readiness checks compile against a stable contract

Closes #3766

## Test plan
- [x] `go build ./internal/health/...`
- [x] `go test ./internal/health/...` — covers ok/error/timeout mapping and default-timeout fallback
- [x] Compile-time assertion `var _ gateway.ReadinessChecker = (*ReadinessAdapter)(nil)`