### PR TITLE
feat(adapters): add Verify(ctx) auth probes for github, telegram, slack

### DIFF
--- a/.agent/tasks/gh-3767.md
+++ b/.agent/tasks/gh-3767.md
@@ -1,0 +1,10 @@
+# GH-3767
+
+**Created:** 2026-07-03
+
+## Problem
+
+Add Verify(ctx) implementations in the three adapter packages (internal/adapters/github, .../telegram, .../slack). GitHub calls the existing Client.GetAuthenticatedUser via the #3718 token resolver and includes the token source (config / GITHUB_TOKEN / gh CLI) in the returned error. Telegram reuses the GetUpdates probe pattern from cmd/pilot/onboard_notify.go:190-203. Slack adds a new auth.test call in internal/adapters/slack/client.go (replacing the intentional onboarding stub only for the probe path). Each package gets an httptest-based unit test covering success, 401, and timeout; tokens come from internal/testutil.
+
+## Acceptance Criteria
+

--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -1116,6 +1116,21 @@ func (c *Client) GetAuthenticatedUser(ctx context.Context) (*User, error) {
 	return &user, nil
 }
 
+// Verify confirms the client's token is valid by calling GetAuthenticatedUser.
+// tokenSource names where the token was resolved from (e.g. "config",
+// "env GITHUB_TOKEN", "gh CLI") and is included in the returned error so a
+// dead token can be diagnosed without re-deriving the resolution chain
+// (GH-3718). Pass "" when the source is unknown.
+func (c *Client) Verify(ctx context.Context, tokenSource string) error {
+	if _, err := c.GetAuthenticatedUser(ctx); err != nil {
+		if tokenSource != "" {
+			return fmt.Errorf("github token invalid (source: %s): %w", tokenSource, err)
+		}
+		return fmt.Errorf("github token invalid: %w", err)
+	}
+	return nil
+}
+
 // SearchMergedPRsForIssue checks if any merged PRs exist that reference the given
 // issue number in their title (e.g. "GH-123" pattern). Uses the GitHub Search API.
 // Returns true if at least one merged PR is found.

--- a/internal/adapters/github/verify_test.go
+++ b/internal/adapters/github/verify_test.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+func TestClientVerify(t *testing.T) {
+	tests := []struct {
+		name        string
+		tokenSource string
+		statusCode  int
+		body        string
+		wantErr     bool
+		errContains []string
+	}{
+		{
+			name:        "success",
+			tokenSource: "config",
+			statusCode:  http.StatusOK,
+			body:        `{"id":1,"login":"pilot-bot"}`,
+			wantErr:     false,
+		},
+		{
+			name:        "401 includes token source",
+			tokenSource: "env GITHUB_TOKEN",
+			statusCode:  http.StatusUnauthorized,
+			body:        `{"message":"Bad credentials"}`,
+			wantErr:     true,
+			errContains: []string{"github token invalid", "env GITHUB_TOKEN", "Bad credentials"},
+		},
+		{
+			name:        "401 with empty token source omits parenthetical",
+			tokenSource: "",
+			statusCode:  http.StatusUnauthorized,
+			body:        `{"message":"Bad credentials"}`,
+			wantErr:     true,
+			errContains: []string{"github token invalid"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasSuffix(r.URL.Path, "/user") {
+					t.Errorf("path = %q, want to end with /user", r.URL.Path)
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			err := client.Verify(context.Background(), tt.tokenSource)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				for _, want := range tt.errContains {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error = %q, want to contain %q", err.Error(), want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestClientVerifyTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(User{ID: 1, Login: "pilot-bot"})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	err := client.Verify(ctx, "config")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "github token invalid") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "github token invalid")
+	}
+}

--- a/internal/adapters/slack/client.go
+++ b/internal/adapters/slack/client.go
@@ -43,6 +43,64 @@ func NewClientWithBaseURL(botToken, baseURL string) *Client {
 	}
 }
 
+// AuthTestResponse represents the response from Slack's auth.test endpoint.
+type AuthTestResponse struct {
+	OK     bool   `json:"ok"`
+	URL    string `json:"url,omitempty"`
+	Team   string `json:"team,omitempty"`
+	User   string `json:"user,omitempty"`
+	TeamID string `json:"team_id,omitempty"`
+	UserID string `json:"user_id,omitempty"`
+	BotID  string `json:"bot_id,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// AuthTest calls Slack's auth.test endpoint to confirm the bot token is
+// valid, returning the authenticated bot identity.
+func (c *Client) AuthTest(ctx context.Context) (*AuthTestResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/auth.test", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.botToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call auth.test: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var result AuthTestResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("slack API error (401): %s", result.Error)
+	}
+	if !result.OK {
+		return nil, fmt.Errorf("slack API error: %s", result.Error)
+	}
+
+	return &result, nil
+}
+
+// Verify confirms the bot token is valid by calling auth.test. This is the
+// probe path only — it replaces the intentional onboarding stub in
+// cmd/pilot/onboard_notify.go's validateSlackConn with a real API call, but
+// does not otherwise change onboarding behavior.
+func (c *Client) Verify(ctx context.Context) error {
+	if _, err := c.AuthTest(ctx); err != nil {
+		return fmt.Errorf("slack token invalid: %w", err)
+	}
+	return nil
+}
+
 // Message represents a Slack message
 type Message struct {
 	Channel     string       `json:"channel"`

--- a/internal/adapters/slack/verify_test.go
+++ b/internal/adapters/slack/verify_test.go
@@ -1,0 +1,94 @@
+package slack
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+func TestClientAuthTestAndVerify(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			body:       `{"ok":true,"team":"Pilot","user":"pilot-bot","team_id":"T123","user_id":"U123"}`,
+			wantErr:    false,
+		},
+		{
+			name:       "401 unauthorized",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"ok":false,"error":"invalid_auth"}`,
+			wantErr:    true,
+		},
+		{
+			name:       "200 with ok false",
+			statusCode: http.StatusOK,
+			body:       `{"ok":false,"error":"invalid_auth"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.HasSuffix(r.URL.Path, "/auth.test") {
+					t.Errorf("path = %q, want to end with /auth.test", r.URL.Path)
+				}
+				if auth := r.Header.Get("Authorization"); !strings.HasPrefix(auth, "Bearer ") {
+					t.Errorf("Authorization = %q, want Bearer prefix", auth)
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeSlackBotToken, server.URL)
+			err := client.Verify(context.Background())
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), "slack token invalid") {
+					t.Errorf("error = %q, want to contain %q", err.Error(), "slack token invalid")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestClientVerifyTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeSlackBotToken, server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	err := client.Verify(ctx)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "slack token invalid") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "slack token invalid")
+	}
+}

--- a/internal/adapters/telegram/client.go
+++ b/internal/adapters/telegram/client.go
@@ -271,6 +271,16 @@ func (c *Client) GetUpdates(ctx context.Context, offset int64, timeout int) ([]*
 	return result.Result, nil
 }
 
+// Verify confirms the bot token is valid by making a lightweight getUpdates
+// call (offset=0, timeout=0 for an immediate, non-blocking response) —
+// mirrors the onboarding probe in cmd/pilot/onboard_notify.go.
+func (c *Client) Verify(ctx context.Context) error {
+	if _, err := c.GetUpdates(ctx, 0, 0); err != nil {
+		return fmt.Errorf("telegram token invalid: %w", err)
+	}
+	return nil
+}
+
 // SendMessage sends a message to a chat
 func (c *Client) SendMessage(ctx context.Context, chatID, text, parseMode string) (*SendMessageResponse, error) {
 	req := SendMessageRequest{

--- a/internal/adapters/telegram/verify_test.go
+++ b/internal/adapters/telegram/verify_test.go
@@ -1,0 +1,85 @@
+package telegram
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+func TestClientVerify(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			body:       `{"ok":true,"result":[]}`,
+			wantErr:    false,
+		},
+		{
+			name:       "401 unauthorized",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"ok":false,"error_code":401,"description":"Unauthorized"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !strings.Contains(r.URL.Path, "/getUpdates") {
+					t.Errorf("path = %q, want to contain /getUpdates", r.URL.Path)
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeTelegramBotToken, server.URL)
+			err := client.Verify(context.Background())
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), "telegram token invalid") {
+					t.Errorf("error = %q, want to contain %q", err.Error(), "telegram token invalid")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestClientVerifyTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true,"result":[]}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeTelegramBotToken, server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	err := client.Verify(ctx)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "telegram token invalid") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "telegram token invalid")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Client.Verify(ctx, tokenSource string) error` to `internal/adapters/github`, reusing the existing `GetAuthenticatedUser` call and including the token source (config / GITHUB_TOKEN / gh CLI, per #3718) in the wrapped error.
- Adds `Client.Verify(ctx) error` to `internal/adapters/telegram`, reusing the `getUpdates(offset=0, timeout=0)` probe pattern from `cmd/pilot/onboard_notify.go`.
- Adds `Client.AuthTest(ctx)` (real Slack `auth.test` call) and `Client.Verify(ctx) error` to `internal/adapters/slack`, for the probe path only — the onboarding stub in `onboard_notify.go` is untouched.
- Each package gets httptest-based unit tests covering success, 401, and timeout; tokens sourced from `internal/testutil`.

Scoped narrowly to the B2 probe implementations from TASK-379 (GH-3767); wiring these into `pilot doctor` / `/ready` / startup preflight is separate follow-up work.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/adapters/github/... ./internal/adapters/telegram/... ./internal/adapters/slack/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`