### PR TITLE
GH-3768: feat(adapters): add stub Verifiable probes for Linear, Jira, GitLab, Azure, and Asana

### DIFF
--- a/internal/adapters/asana/verify.go
+++ b/internal/adapters/asana/verify.go
@@ -1,0 +1,18 @@
+package asana
+
+import (
+	"context"
+
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+// Compile-time check: *Client implements verify.Verifiable.
+var _ verify.Verifiable = (*Client)(nil)
+
+// Name returns the adapter identifier used by doctor and /ready renderers.
+func (c *Client) Name() string { return "asana" }
+
+// Verify has no live probe wired up yet — see verify.ErrProbeNotImplemented.
+func (c *Client) Verify(ctx context.Context) error {
+	return verify.ErrProbeNotImplemented
+}

--- a/internal/adapters/asana/verify_test.go
+++ b/internal/adapters/asana/verify_test.go
@@ -1,0 +1,24 @@
+package asana
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+func TestClient_Verify_ReturnsSentinel(t *testing.T) {
+	c := NewClient("test-asana-access-token", "test-workspace-id")
+	err := c.Verify(context.Background())
+	if !errors.Is(err, verify.ErrProbeNotImplemented) {
+		t.Errorf("Verify() = %v, want %v", err, verify.ErrProbeNotImplemented)
+	}
+}
+
+func TestClient_Name(t *testing.T) {
+	c := NewClient("test-asana-access-token", "test-workspace-id")
+	if got := c.Name(); got != "asana" {
+		t.Errorf("Name() = %q, want %q", got, "asana")
+	}
+}

--- a/internal/adapters/azuredevops/verify.go
+++ b/internal/adapters/azuredevops/verify.go
@@ -1,0 +1,18 @@
+package azuredevops
+
+import (
+	"context"
+
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+// Compile-time check: *Client implements verify.Verifiable.
+var _ verify.Verifiable = (*Client)(nil)
+
+// Name returns the adapter identifier used by doctor and /ready renderers.
+func (c *Client) Name() string { return "azure_devops" }
+
+// Verify has no live probe wired up yet — see verify.ErrProbeNotImplemented.
+func (c *Client) Verify(ctx context.Context) error {
+	return verify.ErrProbeNotImplemented
+}

--- a/internal/adapters/azuredevops/verify_test.go
+++ b/internal/adapters/azuredevops/verify_test.go
@@ -1,0 +1,24 @@
+package azuredevops
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+func TestClient_Verify_ReturnsSentinel(t *testing.T) {
+	c := NewClient("test-azuredevops-pat", "test-org", "test-project")
+	err := c.Verify(context.Background())
+	if !errors.Is(err, verify.ErrProbeNotImplemented) {
+		t.Errorf("Verify() = %v, want %v", err, verify.ErrProbeNotImplemented)
+	}
+}
+
+func TestClient_Name(t *testing.T) {
+	c := NewClient("test-azuredevops-pat", "test-org", "test-project")
+	if got := c.Name(); got != "azure_devops" {
+		t.Errorf("Name() = %q, want %q", got, "azure_devops")
+	}
+}

--- a/internal/adapters/gitlab/verify.go
+++ b/internal/adapters/gitlab/verify.go
@@ -1,0 +1,18 @@
+package gitlab
+
+import (
+	"context"
+
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+// Compile-time check: *Client implements verify.Verifiable.
+var _ verify.Verifiable = (*Client)(nil)
+
+// Name returns the adapter identifier used by doctor and /ready renderers.
+func (c *Client) Name() string { return "gitlab" }
+
+// Verify has no live probe wired up yet — see verify.ErrProbeNotImplemented.
+func (c *Client) Verify(ctx context.Context) error {
+	return verify.ErrProbeNotImplemented
+}

--- a/internal/adapters/gitlab/verify_test.go
+++ b/internal/adapters/gitlab/verify_test.go
@@ -1,0 +1,24 @@
+package gitlab
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+func TestClient_Verify_ReturnsSentinel(t *testing.T) {
+	c := NewClient("test-gitlab-token", "test-namespace/test-project")
+	err := c.Verify(context.Background())
+	if !errors.Is(err, verify.ErrProbeNotImplemented) {
+		t.Errorf("Verify() = %v, want %v", err, verify.ErrProbeNotImplemented)
+	}
+}
+
+func TestClient_Name(t *testing.T) {
+	c := NewClient("test-gitlab-token", "test-namespace/test-project")
+	if got := c.Name(); got != "gitlab" {
+		t.Errorf("Name() = %q, want %q", got, "gitlab")
+	}
+}

--- a/internal/adapters/jira/verify.go
+++ b/internal/adapters/jira/verify.go
@@ -1,0 +1,18 @@
+package jira
+
+import (
+	"context"
+
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+// Compile-time check: *Client implements verify.Verifiable.
+var _ verify.Verifiable = (*Client)(nil)
+
+// Name returns the adapter identifier used by doctor and /ready renderers.
+func (c *Client) Name() string { return AdapterName }
+
+// Verify has no live probe wired up yet — see verify.ErrProbeNotImplemented.
+func (c *Client) Verify(ctx context.Context) error {
+	return verify.ErrProbeNotImplemented
+}

--- a/internal/adapters/jira/verify_test.go
+++ b/internal/adapters/jira/verify_test.go
@@ -1,0 +1,24 @@
+package jira
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+func TestClient_Verify_ReturnsSentinel(t *testing.T) {
+	c := NewClient("https://example.atlassian.net", "test-user", "test-jira-api-token", PlatformCloud)
+	err := c.Verify(context.Background())
+	if !errors.Is(err, verify.ErrProbeNotImplemented) {
+		t.Errorf("Verify() = %v, want %v", err, verify.ErrProbeNotImplemented)
+	}
+}
+
+func TestClient_Name(t *testing.T) {
+	c := NewClient("https://example.atlassian.net", "test-user", "test-jira-api-token", PlatformCloud)
+	if got := c.Name(); got != AdapterName {
+		t.Errorf("Name() = %q, want %q", got, AdapterName)
+	}
+}

--- a/internal/adapters/linear/verify.go
+++ b/internal/adapters/linear/verify.go
@@ -1,0 +1,18 @@
+package linear
+
+import (
+	"context"
+
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+// Compile-time check: *Client implements verify.Verifiable.
+var _ verify.Verifiable = (*Client)(nil)
+
+// Name returns the adapter identifier used by doctor and /ready renderers.
+func (c *Client) Name() string { return "linear" }
+
+// Verify has no live probe wired up yet — see verify.ErrProbeNotImplemented.
+func (c *Client) Verify(ctx context.Context) error {
+	return verify.ErrProbeNotImplemented
+}

--- a/internal/adapters/linear/verify_test.go
+++ b/internal/adapters/linear/verify_test.go
@@ -1,0 +1,24 @@
+package linear
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+func TestClient_Verify_ReturnsSentinel(t *testing.T) {
+	c := NewClient("test-linear-api-key")
+	err := c.Verify(context.Background())
+	if !errors.Is(err, verify.ErrProbeNotImplemented) {
+		t.Errorf("Verify() = %v, want %v", err, verify.ErrProbeNotImplemented)
+	}
+}
+
+func TestClient_Name(t *testing.T) {
+	c := NewClient("test-linear-api-key")
+	if got := c.Name(); got != "linear" {
+		t.Errorf("Name() = %q, want %q", got, "linear")
+	}
+}

--- a/internal/health/verify/verify.go
+++ b/internal/health/verify/verify.go
@@ -6,12 +6,19 @@ package verify
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
 // DefaultTimeout bounds a Verify call when NewReadinessAdapter is given a
 // non-positive timeout.
 const DefaultTimeout = 5 * time.Second
+
+// ErrProbeNotImplemented is returned by a Verifiable that has no live probe
+// wired up yet. Doctor and /ready renderers should treat it as "unchecked"
+// rather than a hard failure, so an adapter without a real check doesn't
+// masquerade as healthy (or as broken).
+var ErrProbeNotImplemented = errors.New("probe not implemented")
 
 // Verifiable is implemented by components that can self-check their health
 // via a context-bound call, allowing callers to bound the check's duration
@@ -44,6 +51,11 @@ func NewReadinessAdapter(v Verifiable, timeout time.Duration) *ReadinessAdapter 
 // Name returns the wrapped Verifiable's name.
 func (a *ReadinessAdapter) Name() string {
 	return a.v.Name()
+}
+
+// Timeout returns the bounded timeout applied to each Verify call.
+func (a *ReadinessAdapter) Timeout() time.Duration {
+	return a.timeout
 }
 
 // Ready calls Verify with a bounded timeout and reports true only if it

--- a/internal/health/verify/verify_test.go
+++ b/internal/health/verify/verify_test.go
@@ -1,4 +1,7 @@
-package verify
+// Package verify_test is an external (black-box) test package so it can
+// import gateway to assert ReadinessChecker satisfaction without creating an
+// import cycle: gateway -> adapters/linear -> verify.
+package verify_test
 
 import (
 	"context"
@@ -7,10 +10,11 @@ import (
 	"time"
 
 	"github.com/qf-studio/pilot/internal/gateway"
+	"github.com/qf-studio/pilot/internal/health/verify"
 )
 
 // Compile-time check: *ReadinessAdapter must satisfy gateway.ReadinessChecker.
-var _ gateway.ReadinessChecker = (*ReadinessAdapter)(nil)
+var _ gateway.ReadinessChecker = (*verify.ReadinessAdapter)(nil)
 
 // fakeVerifiable is a test double for Verifiable. If delay > 0, Verify
 // blocks until delay elapses or ctx is done, whichever comes first —
@@ -36,7 +40,7 @@ func (f *fakeVerifiable) Verify(ctx context.Context) error {
 
 func TestReadinessAdapter_Name(t *testing.T) {
 	v := &fakeVerifiable{name: "db"}
-	a := NewReadinessAdapter(v, time.Second)
+	a := verify.NewReadinessAdapter(v, time.Second)
 	if got := a.Name(); got != "db" {
 		t.Errorf("Name() = %q, want %q", got, "db")
 	}
@@ -44,7 +48,7 @@ func TestReadinessAdapter_Name(t *testing.T) {
 
 func TestReadinessAdapter_Ready_OK(t *testing.T) {
 	v := &fakeVerifiable{name: "ok-check", err: nil}
-	a := NewReadinessAdapter(v, 50*time.Millisecond)
+	a := verify.NewReadinessAdapter(v, 50*time.Millisecond)
 	if !a.Ready() {
 		t.Error("Ready() = false, want true when Verify returns nil")
 	}
@@ -52,7 +56,7 @@ func TestReadinessAdapter_Ready_OK(t *testing.T) {
 
 func TestReadinessAdapter_Ready_Error(t *testing.T) {
 	v := &fakeVerifiable{name: "err-check", err: errors.New("dependency down")}
-	a := NewReadinessAdapter(v, 50*time.Millisecond)
+	a := verify.NewReadinessAdapter(v, 50*time.Millisecond)
 	if a.Ready() {
 		t.Error("Ready() = true, want false when Verify returns an error")
 	}
@@ -60,7 +64,7 @@ func TestReadinessAdapter_Ready_Error(t *testing.T) {
 
 func TestReadinessAdapter_Ready_Timeout(t *testing.T) {
 	v := &fakeVerifiable{name: "slow-check", delay: 200 * time.Millisecond}
-	a := NewReadinessAdapter(v, 20*time.Millisecond)
+	a := verify.NewReadinessAdapter(v, 20*time.Millisecond)
 
 	start := time.Now()
 	ready := a.Ready()
@@ -79,9 +83,9 @@ func TestReadinessAdapter_Ready_Timeout(t *testing.T) {
 func TestNewReadinessAdapter_NonPositiveTimeoutUsesDefault(t *testing.T) {
 	v := &fakeVerifiable{name: "default-timeout-check"}
 	for _, timeout := range []time.Duration{0, -time.Second} {
-		a := NewReadinessAdapter(v, timeout)
-		if a.timeout != DefaultTimeout {
-			t.Errorf("NewReadinessAdapter(%v) timeout = %v, want DefaultTimeout (%v)", timeout, a.timeout, DefaultTimeout)
+		a := verify.NewReadinessAdapter(v, timeout)
+		if a.Timeout() != verify.DefaultTimeout {
+			t.Errorf("NewReadinessAdapter(%v) timeout = %v, want DefaultTimeout (%v)", timeout, a.Timeout(), verify.DefaultTimeout)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3768.

Closes #3768

## Changes

Each of the five adapter packages implements Verifiable returning a typed sentinel error (e.g. health.ErrProbeNotImplemented) so the doctor and /ready renderers can display them as 'unchecked' rather than falsely green. Small unit tests per adapter confirm the sentinel is returned and Name() reports the expected adapter identifier. No network code; keeps the surface consistent for wave V4 to fill in later.