### PR TITLE
feat(health,gateway,cmd): wire probes into doctor, /ready, and daemon preflight

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -305,6 +305,7 @@
 | Gateway WebSocket | ✅ | gateway | - | - | Session management active in gateway |
 | Health checks | ✅ | health | `pilot doctor` | - | System validation, 32 unit tests |
 | Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
+| Adapter Verifiable wiring | ✅ | health, gateway, cmd/pilot | `pilot doctor` | - | Per-adapter `Verify(ctx)` live probes wired into doctor red-checks, `/ready` readiness checkers, and a concurrent daemon-startup preflight that alerts (non-blocking) on failure (v2.207.0, GH-3769) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |
 | OpenAI-compatible direct backend | ✅ | executor | `type: openai-api` | `executor.openai` | Direct /v1/chat/completions for OpenAI, OpenRouter, Groq, Synthetic, vLLM, Ollama (v2.105.0, GH-2382) |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |

--- a/.agent/tasks/gh-3769.md
+++ b/.agent/tasks/gh-3769.md
@@ -1,0 +1,25 @@
+# GH-3769
+
+**Created:** 2026-07-03
+
+## Problem
+
+GitHub Issue #3769: feat(health,gateway,cmd): wire probes into doctor, /ready, and daemon preflight
+
+<!--autopilot-meta
+parent: GH-3760
+inherited-spec: true
+-->
+
+Parent: GH-3760
+
+Cross-cutting wiring only, after subtasks 1-3 land. In internal/health/health.go replace the presence-only adapter block (:474-656) with per-adapter Verify(ctx) calls, keeping empty-token presence as a fast pre-check and surfacing the token source in red-check output. In cmd/pilot/main.go (~:2168, after config Validate(), before poller construction) run enabled adapters' Verify concurrently with a bounded timeout, logging ERROR and emitting an alert event on failure without blocking startup. In internal/gateway/server.go register each Verifiable via RegisterReadinessChecker using the adapter from subtask 1 so /ready reports real per-adapter status. Add an integration-style test with a fake registry of Verifiables exercising the doctor + /ready output paths.
+
+## Scope fence
+
+Implement ONLY the slice described above. The parent issue GH-3760 is decomposed
+into sibling sub-issues that cover the rest of its spec — consult the parent
+for context, but do NOT implement parts of it that fall outside this subtask.
+
+## Acceptance Criteria
+

--- a/cmd/pilot/adapter_preflight.go
+++ b/cmd/pilot/adapter_preflight.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/asana"
+	"github.com/qf-studio/pilot/internal/adapters/azuredevops"
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/adapters/gitlab"
+	"github.com/qf-studio/pilot/internal/adapters/jira"
+	"github.com/qf-studio/pilot/internal/adapters/linear"
+	"github.com/qf-studio/pilot/internal/adapters/slack"
+	"github.com/qf-studio/pilot/internal/adapters/telegram"
+	"github.com/qf-studio/pilot/internal/alerts"
+	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/gateway"
+	"github.com/qf-studio/pilot/internal/health/verify"
+	"github.com/qf-studio/pilot/internal/logging"
+)
+
+// preflightVerifyTimeout bounds each adapter's Verify(ctx) call during
+// daemon startup so an unreachable API can't hang `pilot start`.
+const preflightVerifyTimeout = 8 * time.Second
+
+// buildAdapterVerifiers resolves a verify.Verifiable for every enabled
+// adapter that has a resolvable credential, skipping adapters with no token
+// configured (nothing to verify — already flagged by doctor's presence
+// checks). GH-3769: generalizes the GitHub-only preflight (validateGitHubToken)
+// across every adapter wired up in subtasks 1-2 of GH-3760.
+func buildAdapterVerifiers(cfg *config.Config) []verify.Verifiable {
+	if cfg == nil || cfg.Adapters == nil {
+		return nil
+	}
+	a := cfg.Adapters
+	var verifiers []verify.Verifiable
+
+	if a.Telegram != nil && a.Telegram.Enabled && a.Telegram.BotToken != "" {
+		verifiers = append(verifiers, telegram.NewClient(a.Telegram.BotToken))
+	}
+	if a.Slack != nil && a.Slack.Enabled && a.Slack.BotToken != "" {
+		verifiers = append(verifiers, slack.NewClient(a.Slack.BotToken))
+	}
+	if a.GitHub != nil && a.GitHub.Enabled {
+		if token, source := resolveGitHubToken(cfg); token != "" {
+			verifiers = append(verifiers, github.NewVerifier(github.NewClient(token), string(source)))
+		}
+	}
+	if a.Linear != nil && a.Linear.Enabled {
+		if wss := a.Linear.GetWorkspaces(); len(wss) > 0 && wss[0].APIKey != "" {
+			verifiers = append(verifiers, linear.NewClient(wss[0].APIKey))
+		}
+	}
+	if a.Jira != nil && a.Jira.Enabled && a.Jira.BaseURL != "" && a.Jira.APIToken != "" {
+		verifiers = append(verifiers, jira.NewClient(a.Jira.BaseURL, a.Jira.Username, a.Jira.APIToken, a.Jira.Platform))
+	}
+	if a.GitLab != nil && a.GitLab.Enabled && a.GitLab.Token != "" {
+		verifiers = append(verifiers, gitlab.NewClient(a.GitLab.Token, a.GitLab.Project))
+	}
+	if a.AzureDevOps != nil && a.AzureDevOps.Enabled && a.AzureDevOps.PAT != "" {
+		verifiers = append(verifiers, azuredevops.NewClient(a.AzureDevOps.PAT, a.AzureDevOps.Organization, a.AzureDevOps.Project))
+	}
+	if a.Asana != nil && a.Asana.Enabled && a.Asana.AccessToken != "" {
+		verifiers = append(verifiers, asana.NewClient(a.Asana.AccessToken, a.Asana.WorkspaceID))
+	}
+
+	return verifiers
+}
+
+// runAdapterPreflight calls Verify(ctx) on every verifier concurrently,
+// each bounded by preflightVerifyTimeout, and returns the per-adapter
+// result. A failure logs ERROR and emits an alerts.EventTypeConfigError
+// event (when alertsEngine is non-nil) but never blocks startup — the
+// caller is expected to ignore the returned errors for control flow.
+// verify.ErrProbeNotImplemented is treated as "nothing to report" (not
+// logged as an error) since it reflects an adapter with no live probe
+// wired up yet, not a broken credential.
+func runAdapterPreflight(ctx context.Context, verifiers []verify.Verifiable, alertsEngine *alerts.Engine) map[string]error {
+	results := make(map[string]error, len(verifiers))
+	if len(verifiers) == 0 {
+		return results
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	log := logging.WithComponent("preflight")
+
+	for _, v := range verifiers {
+		wg.Add(1)
+		go func(v verify.Verifiable) {
+			defer wg.Done()
+
+			vctx, cancel := context.WithTimeout(ctx, preflightVerifyTimeout)
+			defer cancel()
+			err := v.Verify(vctx)
+
+			mu.Lock()
+			results[v.Name()] = err
+			mu.Unlock()
+
+			switch {
+			case err == nil:
+				log.Info("adapter verified", slog.String("adapter", v.Name()))
+			case errors.Is(err, verify.ErrProbeNotImplemented):
+				// No live probe yet — not evidence of a broken credential.
+			default:
+				log.Error("adapter verification failed at startup — this adapter will silently fail until fixed",
+					slog.String("adapter", v.Name()),
+					slog.Any("error", err),
+				)
+				if alertsEngine != nil {
+					alertsEngine.ProcessEvent(alerts.Event{
+						Type:      alerts.EventTypeConfigError,
+						Error:     fmt.Sprintf("%s adapter verification failed: %v", v.Name(), err),
+						Timestamp: time.Now(),
+					})
+				}
+			}
+		}(v)
+	}
+	wg.Wait()
+
+	return results
+}
+
+// registerAdapterReadiness wraps each verifier as a gateway.ReadinessChecker
+// and registers it with gwServer so /ready reports real per-adapter status
+// (GH-3769). No-op when gwServer is nil (gateway disabled).
+func registerAdapterReadiness(gwServer *gateway.Server, verifiers []verify.Verifiable, timeout time.Duration) {
+	if gwServer == nil {
+		return
+	}
+	for _, v := range verifiers {
+		gwServer.RegisterReadinessChecker(verify.NewReadinessAdapter(v, timeout))
+	}
+}

--- a/cmd/pilot/adapter_preflight_test.go
+++ b/cmd/pilot/adapter_preflight_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/adapters/gitlab"
+	"github.com/qf-studio/pilot/internal/adapters/linear"
+	"github.com/qf-studio/pilot/internal/adapters/slack"
+	"github.com/qf-studio/pilot/internal/adapters/telegram"
+	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/gateway"
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+// fakeVerifiable is a minimal verify.Verifiable double used to exercise
+// runAdapterPreflight/registerAdapterReadiness without hitting real adapter
+// APIs (GH-3769).
+type fakeVerifiable struct {
+	name string
+	err  error
+}
+
+func (f *fakeVerifiable) Name() string                     { return f.name }
+func (f *fakeVerifiable) Verify(ctx context.Context) error { return f.err }
+
+var _ verify.Verifiable = (*fakeVerifiable)(nil)
+
+// TestBuildAdapterVerifiers confirms only enabled adapters with a resolvable
+// credential produce a verify.Verifiable, and disabled/empty-token adapters
+// are skipped (their presence is already flagged by doctor's checks).
+func TestBuildAdapterVerifiers(t *testing.T) {
+	resetGitHubTokenTestState(t)
+
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			Telegram: &telegram.Config{Enabled: true, BotToken: "tg-token"},
+			Slack:    &slack.Config{Enabled: false, BotToken: "slack-token"}, // disabled — skipped
+			GitHub:   &github.Config{Enabled: true, Token: "gh-token"},
+			Linear:   &linear.Config{Enabled: true, APIKey: ""}, // no key — skipped
+			GitLab:   &gitlab.Config{Enabled: true, Token: "gl-token", Project: "group/proj"},
+		},
+	}
+
+	verifiers := buildAdapterVerifiers(cfg)
+
+	names := make(map[string]bool, len(verifiers))
+	for _, v := range verifiers {
+		names[v.Name()] = true
+	}
+
+	for _, want := range []string{"telegram", "github", "gitlab"} {
+		if !names[want] {
+			t.Errorf("expected verifier %q to be built, got %v", want, names)
+		}
+	}
+	for _, notWant := range []string{"slack", "linear"} {
+		if names[notWant] {
+			t.Errorf("did not expect verifier %q (disabled or no credential), got %v", notWant, names)
+		}
+	}
+}
+
+// TestBuildAdapterVerifiers_NoAdapters confirms a nil/empty adapters config
+// produces no verifiers instead of panicking.
+func TestBuildAdapterVerifiers_NoAdapters(t *testing.T) {
+	if got := buildAdapterVerifiers(&config.Config{}); len(got) != 0 {
+		t.Errorf("expected no verifiers, got %v", got)
+	}
+	if got := buildAdapterVerifiers(nil); len(got) != 0 {
+		t.Errorf("expected no verifiers for nil config, got %v", got)
+	}
+}
+
+// TestRunAdapterPreflight_FakeRegistry exercises runAdapterPreflight against
+// a fake registry of Verifiables covering the healthy, failing, and
+// not-yet-implemented cases, confirming: the returned per-adapter result map
+// is accurate, a genuine failure fires a config_error alert, and a healthy
+// or not-implemented probe does not.
+func TestRunAdapterPreflight_FakeRegistry(t *testing.T) {
+	engine, ch := newTestAlertsEngine(t)
+
+	verifiers := []verify.Verifiable{
+		&fakeVerifiable{name: "healthy", err: nil},
+		&fakeVerifiable{name: "dead-credential", err: errors.New("token invalid: 401")},
+		&fakeVerifiable{name: "unimplemented", err: verify.ErrProbeNotImplemented},
+	}
+
+	results := runAdapterPreflight(context.Background(), verifiers, engine)
+
+	if err := results["healthy"]; err != nil {
+		t.Errorf("healthy result = %v, want nil", err)
+	}
+	if err := results["dead-credential"]; err == nil {
+		t.Error("dead-credential result = nil, want an error")
+	}
+	if err := results["unimplemented"]; !errors.Is(err, verify.ErrProbeNotImplemented) {
+		t.Errorf("unimplemented result = %v, want ErrProbeNotImplemented", err)
+	}
+
+	// Event dispatch is async (queued via a channel); poll with a deadline
+	// rather than engine.WaitForDispatch(), which only blocks on dispatches
+	// already in flight and can race ahead of the event being picked up.
+	deadline := time.After(2 * time.Second)
+	for ch.count() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("expected an alert to be fired for the dead-credential adapter")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	if got := ch.count(); got != 1 {
+		t.Errorf("expected exactly 1 alert (dead-credential only), got %d", got)
+	}
+}
+
+// TestRunAdapterPreflight_EmptyRegistry confirms an empty/nil verifier list
+// is a safe no-op.
+func TestRunAdapterPreflight_EmptyRegistry(t *testing.T) {
+	results := runAdapterPreflight(context.Background(), nil, nil)
+	if len(results) != 0 {
+		t.Errorf("expected empty result map, got %v", results)
+	}
+}
+
+// TestRegisterAdapterReadiness_Nil confirms registering against a nil
+// gateway server (gateway disabled) does not panic.
+func TestRegisterAdapterReadiness_Nil(t *testing.T) {
+	registerAdapterReadiness(nil, []verify.Verifiable{&fakeVerifiable{name: "x"}}, time.Second)
+}
+
+// TestRegisterAdapterReadiness_ReadyEndpoint wires a fake registry into a
+// real gateway.Server via registerAdapterReadiness and confirms /ready
+// reflects each adapter's live Verify(ctx) outcome end-to-end (GH-3769: the
+// same path daemon startup uses to make readiness real, not presence-only).
+func TestRegisterAdapterReadiness_ReadyEndpoint(t *testing.T) {
+	gwServer := gateway.NewServer(&gateway.Config{Host: "127.0.0.1", Port: 19199})
+
+	verifiers := []verify.Verifiable{
+		&fakeVerifiable{name: "healthy-adapter", err: nil},
+		&fakeVerifiable{name: "broken-adapter", err: errors.New("credential invalid")},
+	}
+	registerAdapterReadiness(gwServer, verifiers, time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go func() { _ = gwServer.Start(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+
+	resp, err := http.Get("http://127.0.0.1:19199/ready")
+	if err != nil {
+		t.Fatalf("GET /ready: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d (broken-adapter should trip readiness)", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+
+	var body struct {
+		Ready  bool            `json:"ready"`
+		Checks map[string]bool `json:"checks"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !body.Checks["healthy-adapter"] {
+		t.Error("healthy-adapter check = false, want true")
+	}
+	if body.Checks["broken-adapter"] {
+		t.Error("broken-adapter check = true, want false")
+	}
+}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/qf-studio/pilot/internal/dashboard"
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/gateway"
+	"github.com/qf-studio/pilot/internal/health/verify"
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/pilot"
@@ -2218,6 +2219,15 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			slog.Bool("store_nil", store == nil),
 		)
 	}
+
+	// GH-3769: Verify every enabled adapter's credentials concurrently
+	// before pollers start, so a dead token surfaces as a loud startup
+	// error/alert instead of silently failing on the first poll. Each
+	// verifier is also registered with the gateway so /ready reports real
+	// per-adapter status.
+	adapterVerifiers := buildAdapterVerifiers(cfg)
+	runAdapterPreflight(ctx, adapterVerifiers, alertsEngine)
+	registerAdapterReadiness(gwServer, adapterVerifiers, verify.DefaultTimeout)
 
 	// GH-929: Start GitHub polling for multiple repos if enabled
 	var ghPollers []*github.Poller

--- a/internal/adapters/github/verify.go
+++ b/internal/adapters/github/verify.go
@@ -1,0 +1,35 @@
+package github
+
+import (
+	"context"
+
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+// Verifier adapts *Client into verify.Verifiable by pinning the token
+// source resolved at construction time. Client.Verify takes tokenSource as
+// an argument (for diagnostic error messages, GH-3718) but the Verifiable
+// interface takes none, so this wrapper closes over it.
+type Verifier struct {
+	client      *Client
+	tokenSource string
+}
+
+// NewVerifier wraps client as a verify.Verifiable. tokenSource (e.g.
+// "config", "env GITHUB_TOKEN", "gh CLI") is included in any Verify error
+// so a dead token can be diagnosed without re-deriving the resolution
+// chain. Pass "" when the source is unknown.
+func NewVerifier(client *Client, tokenSource string) *Verifier {
+	return &Verifier{client: client, tokenSource: tokenSource}
+}
+
+// Compile-time check: *Verifier implements verify.Verifiable.
+var _ verify.Verifiable = (*Verifier)(nil)
+
+// Name returns the adapter identifier used by doctor and /ready renderers.
+func (v *Verifier) Name() string { return "github" }
+
+// Verify delegates to the wrapped client, supplying the pinned token source.
+func (v *Verifier) Verify(ctx context.Context) error {
+	return v.client.Verify(ctx, v.tokenSource)
+}

--- a/internal/adapters/slack/verify.go
+++ b/internal/adapters/slack/verify.go
@@ -1,0 +1,11 @@
+package slack
+
+import (
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+// Compile-time check: *Client implements verify.Verifiable.
+var _ verify.Verifiable = (*Client)(nil)
+
+// Name returns the adapter identifier used by doctor and /ready renderers.
+func (c *Client) Name() string { return "slack" }

--- a/internal/adapters/telegram/verify.go
+++ b/internal/adapters/telegram/verify.go
@@ -1,0 +1,11 @@
+package telegram
+
+import (
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+// Compile-time check: *Client implements verify.Verifiable.
+var _ verify.Verifiable = (*Client)(nil)
+
+// Name returns the adapter identifier used by doctor and /ready renderers.
+func (c *Client) Name() string { return "telegram" }

--- a/internal/gateway/verify_readiness_integration_test.go
+++ b/internal/gateway/verify_readiness_integration_test.go
@@ -1,0 +1,108 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+// fakeVerifiable is a minimal verify.Verifiable double standing in for a
+// real adapter client (GitHub/Telegram/Slack/...) so /ready can be
+// exercised end-to-end without live network calls (GH-3769).
+type fakeVerifiable struct {
+	name string
+	err  error
+}
+
+func (f *fakeVerifiable) Name() string                     { return f.name }
+func (f *fakeVerifiable) Verify(ctx context.Context) error { return f.err }
+
+var _ verify.Verifiable = (*fakeVerifiable)(nil)
+
+// TestReadyEndpoint_FakeVerifiableRegistry registers a small fake registry
+// of verify.Verifiable adapters — one healthy, one failing, one with an
+// unimplemented probe — via the same NewReadinessAdapter +
+// RegisterReadinessChecker path GH-3769 wires real adapters through, and
+// asserts /ready reflects each adapter's real Verify(ctx) outcome.
+func TestReadyEndpoint_FakeVerifiableRegistry(t *testing.T) {
+	server := NewServer(&Config{Host: "127.0.0.1", Port: 9090})
+
+	registry := []verify.Verifiable{
+		&fakeVerifiable{name: "github", err: nil},
+		&fakeVerifiable{name: "telegram", err: errors.New("telegram token invalid: 401")},
+		&fakeVerifiable{name: "linear", err: verify.ErrProbeNotImplemented},
+	}
+	for _, v := range registry {
+		server.RegisterReadinessChecker(verify.NewReadinessAdapter(v, time.Second))
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	w := httptest.NewRecorder()
+	server.handleReady(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d (a failing adapter should trip /ready)", w.Code, http.StatusServiceUnavailable)
+	}
+
+	var response struct {
+		Ready  bool            `json:"ready"`
+		Checks map[string]bool `json:"checks"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Ready {
+		t.Error("ready = true, want false")
+	}
+	if !response.Checks["github"] {
+		t.Error("github check = false, want true (Verify returned nil)")
+	}
+	if response.Checks["telegram"] {
+		t.Error("telegram check = true, want false (Verify returned an error)")
+	}
+	// ErrProbeNotImplemented has no live probe yet, so it maps to
+	// not-ready in the boolean ReadinessChecker contract — see
+	// verify.ReadinessAdapter's doc comment.
+	if response.Checks["linear"] {
+		t.Error("linear check = true, want false (probe not implemented yet)")
+	}
+}
+
+// TestReadyEndpoint_FakeVerifiableRegistry_AllHealthy confirms a registry
+// where every adapter verifies cleanly reports 200 and ready=true.
+func TestReadyEndpoint_FakeVerifiableRegistry_AllHealthy(t *testing.T) {
+	server := NewServer(&Config{Host: "127.0.0.1", Port: 9090})
+
+	registry := []verify.Verifiable{
+		&fakeVerifiable{name: "github", err: nil},
+		&fakeVerifiable{name: "slack", err: nil},
+	}
+	for _, v := range registry {
+		server.RegisterReadinessChecker(verify.NewReadinessAdapter(v, time.Second))
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	w := httptest.NewRecorder()
+	server.handleReady(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var response struct {
+		Ready bool `json:"ready"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !response.Ready {
+		t.Error("ready = false, want true")
+	}
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -7,7 +7,9 @@
 package health
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -18,7 +20,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/adapters/slack"
+	"github.com/qf-studio/pilot/internal/adapters/telegram"
 	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/health/verify"
 )
 
 // Status represents feature or dependency status
@@ -228,6 +233,88 @@ func checkGitHubTokenLive(cfg *config.Config, check githubAuthChecker) *ConfigCh
 	}
 }
 
+// verifyProbeTimeout bounds each adapter's live Verify(ctx) call during
+// doctor checks so an unreachable API can't hang `pilot doctor`.
+const verifyProbeTimeout = 5 * time.Second
+
+// checkAdapterVerify runs a live verify.Verifiable probe and turns the
+// result into a single ConfigCheck, tagging failures with tokenSource so a
+// dead credential can be diagnosed without re-deriving where it was
+// resolved from. This generalizes the GitHub-only mechanism in
+// checkGitHubTokenLive (GH-3718) to any adapter that implements Verifiable
+// (GH-3769) — callers only call it once the fast, network-free presence
+// pre-check (token/config non-empty) has already passed.
+func checkAdapterVerify(checkName, tokenSource string, v verify.Verifiable) ConfigCheck {
+	ctx, cancel := context.WithTimeout(context.Background(), verifyProbeTimeout)
+	defer cancel()
+
+	err := v.Verify(ctx)
+	switch {
+	case err == nil:
+		msg := "valid"
+		if tokenSource != "" {
+			msg = fmt.Sprintf("valid (source: %s)", tokenSource)
+		}
+		return ConfigCheck{Name: checkName, Status: StatusOK, Message: msg}
+	case errors.Is(err, verify.ErrProbeNotImplemented):
+		// No live probe wired up for this adapter yet — presence already
+		// passed, so report configured-but-unchecked rather than red.
+		return ConfigCheck{Name: checkName, Status: StatusOK, Message: "configured (no live probe yet)"}
+	default:
+		msg := err.Error()
+		if tokenSource != "" {
+			msg = fmt.Sprintf("%s (source: %s)", msg, tokenSource)
+		}
+		return ConfigCheck{
+			Name:    checkName,
+			Status:  StatusError,
+			Message: msg,
+			Fix:     fmt.Sprintf("Check %s credentials are valid and not expired", checkName),
+		}
+	}
+}
+
+// checkTelegramTokenLive makes one live getUpdates call to confirm the
+// configured Telegram bot token actually works, mirroring
+// checkGitHubTokenLive for the Telegram adapter (GH-3769). Returns nil when
+// Telegram isn't enabled or has no token — those cases are already covered
+// by the telegram.bot_token presence check.
+func checkTelegramTokenLive(cfg *config.Config, newClient func(token string) verify.Verifiable) *ConfigCheck {
+	if cfg.Adapters == nil || cfg.Adapters.Telegram == nil || !cfg.Adapters.Telegram.Enabled {
+		return nil
+	}
+	token := cfg.Adapters.Telegram.BotToken
+	if token == "" {
+		return nil
+	}
+	check := checkAdapterVerify("telegram.token.live", "", newClient(token))
+	return &check
+}
+
+// checkSlackTokenLive makes one live auth.test call to confirm the
+// configured Slack bot token actually works, mirroring
+// checkGitHubTokenLive for the Slack adapter (GH-3769). Returns nil when
+// Slack isn't enabled or has no token — those cases are already covered by
+// the slack.bot_token presence check.
+func checkSlackTokenLive(cfg *config.Config, newClient func(token string) verify.Verifiable) *ConfigCheck {
+	if cfg.Adapters == nil || cfg.Adapters.Slack == nil || !cfg.Adapters.Slack.Enabled {
+		return nil
+	}
+	token := cfg.Adapters.Slack.BotToken
+	if token == "" {
+		return nil
+	}
+	check := checkAdapterVerify("slack.token.live", "", newClient(token))
+	return &check
+}
+
+// newTelegramVerifier and newSlackVerifier build the real live-probe client
+// for checkTelegramTokenLive/checkSlackTokenLive. Injectable so tests can
+// substitute fake verify.Verifiable implementations instead of hitting the
+// real Telegram/Slack APIs.
+var newTelegramVerifier = func(token string) verify.Verifiable { return telegram.NewClient(token) }
+var newSlackVerifier = func(token string) verify.Verifiable { return slack.NewClient(token) }
+
 // checkBrewTapHealth checks whether the last release.yml run failed at a
 // homebrew step, which indicates that HOMEBREW_TAP_GITHUB_TOKEN has expired.
 // Uses unauthenticated GitHub API calls (public repo, 60 req/hour limit).
@@ -326,6 +413,12 @@ func RunChecks(cfg *config.Config) *HealthReport {
 	}
 	configChecks = append(configChecks, checkBrewTapHealth(brewTapHTTPGet))
 	if liveCheck := checkGitHubTokenLive(cfg, githubAuthCheck); liveCheck != nil {
+		configChecks = append(configChecks, *liveCheck)
+	}
+	if liveCheck := checkTelegramTokenLive(cfg, newTelegramVerifier); liveCheck != nil {
+		configChecks = append(configChecks, *liveCheck)
+	}
+	if liveCheck := checkSlackTokenLive(cfg, newSlackVerifier); liveCheck != nil {
 		configChecks = append(configChecks, *liveCheck)
 	}
 

--- a/internal/health/verify_integration_test.go
+++ b/internal/health/verify_integration_test.go
@@ -1,0 +1,182 @@
+package health
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/slack"
+	"github.com/qf-studio/pilot/internal/adapters/telegram"
+	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/health/verify"
+)
+
+// fakeVerifiable is a minimal verify.Verifiable double for exercising the
+// doctor output path without hitting real adapter APIs (GH-3769).
+type fakeVerifiable struct {
+	name string
+	err  error
+}
+
+func (f *fakeVerifiable) Name() string { return f.name }
+func (f *fakeVerifiable) Verify(ctx context.Context) error {
+	return f.err
+}
+
+var _ verify.Verifiable = (*fakeVerifiable)(nil)
+
+// TestCheckAdapterVerify_FakeRegistry exercises checkAdapterVerify — the
+// shared doctor-output builder behind checkTelegramTokenLive/
+// checkSlackTokenLive/checkGitHubTokenLive-style checks — against a small
+// fake registry of Verifiables covering the healthy, failing, and
+// not-yet-implemented cases.
+func TestCheckAdapterVerify_FakeRegistry(t *testing.T) {
+	registry := map[string]*fakeVerifiable{
+		"healthy":         {name: "healthy", err: nil},
+		"dead-credential": {name: "dead-credential", err: errFakeInvalidToken},
+		"unimplemented":   {name: "unimplemented", err: verify.ErrProbeNotImplemented},
+	}
+
+	tests := []struct {
+		name        string
+		key         string
+		tokenSource string
+		wantStatus  Status
+		wantSubstr  string
+	}{
+		{
+			name:        "healthy adapter reports OK with source",
+			key:         "healthy",
+			tokenSource: "config",
+			wantStatus:  StatusOK,
+			wantSubstr:  "source: config",
+		},
+		{
+			name:        "failing adapter reports red-check with token source",
+			key:         "dead-credential",
+			tokenSource: "env FAKE_TOKEN",
+			wantStatus:  StatusError,
+			wantSubstr:  "env FAKE_TOKEN",
+		},
+		{
+			name:       "unimplemented probe does not go red",
+			key:        "unimplemented",
+			wantStatus: StatusOK,
+			wantSubstr: "no live probe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkAdapterVerify("fake.check", tt.tokenSource, registry[tt.key])
+			if got.Status != tt.wantStatus {
+				t.Errorf("status = %v, want %v (message: %q)", got.Status, tt.wantStatus, got.Message)
+			}
+			if !strings.Contains(got.Message, tt.wantSubstr) {
+				t.Errorf("message = %q, want to contain %q", got.Message, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+var errFakeInvalidToken = &fakeVerifyError{"fake token invalid: 401"}
+
+type fakeVerifyError struct{ msg string }
+
+func (e *fakeVerifyError) Error() string { return e.msg }
+
+// TestCheckTelegramTokenLive_UsesInjectedVerifier confirms
+// checkTelegramTokenLive routes through the injected verify.Verifiable
+// factory (rather than hitting api.telegram.org), reflecting both the
+// healthy and failing outcomes in doctor output.
+func TestCheckTelegramTokenLive_UsesInjectedVerifier(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			Telegram: &telegram.Config{Enabled: true, BotToken: "fake-telegram-token"},
+		},
+	}
+
+	got := checkTelegramTokenLive(cfg, func(token string) verify.Verifiable {
+		if token != "fake-telegram-token" {
+			t.Errorf("verifier built with token %q, want the configured bot token", token)
+		}
+		return &fakeVerifiable{name: "telegram", err: nil}
+	})
+	if got == nil {
+		t.Fatal("expected a check result, got nil")
+	}
+	if got.Status != StatusOK {
+		t.Errorf("status = %v, want StatusOK", got.Status)
+	}
+
+	got = checkTelegramTokenLive(cfg, func(token string) verify.Verifiable {
+		return &fakeVerifiable{name: "telegram", err: errFakeInvalidToken}
+	})
+	if got == nil || got.Status != StatusError {
+		t.Fatalf("expected StatusError for a failing probe, got %+v", got)
+	}
+}
+
+// TestCheckSlackTokenLive_UsesInjectedVerifier mirrors the Telegram case
+// for Slack.
+func TestCheckSlackTokenLive_UsesInjectedVerifier(t *testing.T) {
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			Slack: &slack.Config{Enabled: true, BotToken: "fake-slack-token"},
+		},
+	}
+
+	got := checkSlackTokenLive(cfg, func(token string) verify.Verifiable {
+		return &fakeVerifiable{name: "slack", err: nil}
+	})
+	if got == nil || got.Status != StatusOK {
+		t.Fatalf("expected StatusOK, got %+v", got)
+	}
+
+	got = checkSlackTokenLive(cfg, func(token string) verify.Verifiable {
+		return &fakeVerifiable{name: "slack", err: errFakeInvalidToken}
+	})
+	if got == nil || got.Status != StatusError {
+		t.Fatalf("expected StatusError, got %+v", got)
+	}
+}
+
+// TestRunChecks_TelegramSlackLive_EndToEnd swaps the package-level verifier
+// factories (as production code does at startup) to confirm RunChecks — the
+// exact path `pilot doctor` calls — surfaces a live probe failure as a red
+// check, using a fake registry instead of real network calls.
+func TestRunChecks_TelegramSlackLive_EndToEnd(t *testing.T) {
+	origTelegram, origSlack := newTelegramVerifier, newSlackVerifier
+	t.Cleanup(func() {
+		newTelegramVerifier = origTelegram
+		newSlackVerifier = origSlack
+	})
+
+	newTelegramVerifier = func(token string) verify.Verifiable {
+		return &fakeVerifiable{name: "telegram", err: errFakeInvalidToken}
+	}
+	newSlackVerifier = func(token string) verify.Verifiable {
+		return &fakeVerifiable{name: "slack", err: nil}
+	}
+
+	cfg := &config.Config{
+		Adapters: &config.AdaptersConfig{
+			Telegram: &telegram.Config{Enabled: true, BotToken: "fake-telegram-token"},
+			Slack:    &slack.Config{Enabled: true, BotToken: "fake-slack-token"},
+		},
+	}
+
+	report := RunChecks(cfg)
+
+	tgLive := findConfigCheck(report.Config, "telegram.token.live")
+	if tgLive == nil || tgLive.Status != StatusError {
+		t.Fatalf("expected telegram.token.live StatusError, got %+v", tgLive)
+	}
+	slackLive := findConfigCheck(report.Config, "slack.token.live")
+	if slackLive == nil || slackLive.Status != StatusOK {
+		t.Fatalf("expected slack.token.live StatusOK, got %+v", slackLive)
+	}
+	if !report.HasErrors {
+		t.Error("HasErrors should be true when a live probe fails")
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/adapters/{telegram,slack}/verify.go`: add `Name()` + `verify.Verifiable` conformance on the existing `Client.Verify(ctx)` probes (added in a prior subtask).
- `internal/adapters/github/verify.go`: add a `Verifier` wrapper (github's `Client.Verify` needs a `tokenSource` argument the plain `Verifiable` interface doesn't carry).
- `internal/health/health.go`: keep the empty-token presence checks as fast, network-free pre-checks; add `checkTelegramTokenLive`/`checkSlackTokenLive` (mirroring the existing `checkGitHubTokenLive`) that run a live `Verify(ctx)` once a token is present, surfacing the token source in red-check output. Injectable verifier factories keep this test-safe (no real network calls in existing presence tests).
- `cmd/pilot/adapter_preflight.go`: `buildAdapterVerifiers` resolves a `Verifiable` for every enabled adapter with a credential (telegram/slack/github/linear/jira/gitlab/azuredevops/asana); `runAdapterPreflight` verifies them all concurrently with a bounded per-call timeout, logging ERROR + firing a `config_error` alert on real failures (an unimplemented probe is not treated as a failure) without blocking startup; wired in `runPollingMode` after budget setup, before poller construction.
- `internal/gateway` + `cmd/pilot`: `registerAdapterReadiness` wraps each `Verifiable` via `verify.NewReadinessAdapter` and registers it with the gateway server so `/ready` reports real per-adapter status instead of presence-only.
- Integration-style tests with fake `Verifiable` registries exercise both the `/ready` path (`internal/gateway/verify_readiness_integration_test.go`) and the doctor + preflight paths (`internal/health/verify_integration_test.go`, `cmd/pilot/adapter_preflight_test.go`), including a real end-to-end HTTP round trip against `/ready`.

Part of #3760 (parent). Scoped strictly to the cross-cutting wiring subtask (#3769) — the live/stub adapter probes themselves landed in prior subtasks.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/health/... ./internal/gateway/... ./internal/adapters/... ./cmd/pilot/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues