### PR TITLE
fix(executor): skip epic parent PR creation when branch has zero commits over base

### DIFF
--- a/.agent/tasks/gh-3779.md
+++ b/.agent/tasks/gh-3779.md
@@ -1,0 +1,10 @@
+# GH-3779
+
+**Created:** 2026-07-03
+
+## Problem
+
+In internal/executor/epic.go (and callers in runner.go), before invoking `gh pr create` on a decomposed parent's branch, run `git rev-list --count <base>..<branch>`. If zero and the task was decomposed, skip PR creation entirely: no failure comment, record the parent execution row as `completed` (or `no_op` if all children were `no_op`) with a summary of child terminal states. Add table-driven tests in internal/executor/epic_test.go covering: decomposed+empty branch (no PR, no failure comment, terminal state matches child mix), decomposed+non-empty branch (unchanged), non-decomposed+empty branch (existing behavior preserved). Verify with `go test ./internal/executor/... -run 'TestEpic|TestDecompos' -v`.
+
+## Acceptance Criteria
+

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1510,6 +1510,93 @@ func (r *Runner) CloseIssueWithComment(ctx context.Context, projectPath string, 
 	return nil
 }
 
+// childTerminalStateOrder fixes the iteration order summarizeChildTerminalStates
+// renders its per-state counts in, so the summary text is deterministic despite
+// being built from a map.
+var childTerminalStateOrder = []string{
+	"completed", "no_op", "skipped", "declined", "rate_limited", "stalled", "infra", "failed",
+}
+
+// summarizeChildTerminalStates classifies a decomposed parent from its
+// children's terminal states (each produced by TerminalStatus): "no_op" only
+// when every child no-op'd — nothing shipped anywhere — "completed" otherwise,
+// including when there are no children to summarize. GH-3779.
+func summarizeChildTerminalStates(states []string) (outcome string, summary string) {
+	if len(states) == 0 {
+		return "completed", "no child sub-issues to summarize"
+	}
+
+	counts := make(map[string]int, len(states))
+	allNoOp := true
+	for _, s := range states {
+		counts[s]++
+		if s != "no_op" {
+			allNoOp = false
+		}
+	}
+
+	parts := make([]string, 0, len(counts))
+	for _, s := range childTerminalStateOrder {
+		if c, ok := counts[s]; ok {
+			parts = append(parts, fmt.Sprintf("%s=%d", s, c))
+			delete(counts, s)
+		}
+	}
+	// Any state outside the known set still gets counted, just after the known ones.
+	for s, c := range counts {
+		parts = append(parts, fmt.Sprintf("%s=%d", s, c))
+	}
+
+	summary = fmt.Sprintf("%d child sub-issue(s): %s", len(states), strings.Join(parts, ", "))
+	if allNoOp {
+		return "no_op", summary
+	}
+	return "completed", summary
+}
+
+// evaluateEmptyBranchPRGuard decides what happens when a task's own branch
+// carries no commits relative to base, right before `gh pr create` would
+// otherwise run (git rev-list --count <base>..<branch> == 0 — see
+// GitOperations.CountNewCommits). GH-3779.
+//
+// Non-decomposed tasks (decomposed=false): unchanged GH-2743 behavior — an
+// empty branch means the task genuinely produced nothing, so it's a hard
+// failure. childTerminalStates is ignored in this case.
+//
+// Decomposed (epic) parents (decomposed=true): an empty parent branch is not
+// automatically a failure — the real deliverables may have shipped via child
+// sub-issue PRs. The parent records as "completed" unless every child also
+// no-op'd, in which case nothing shipped anywhere and the parent records as
+// "no_op" instead. Either way PR creation is skipped and no failure comment is
+// warranted — the caller must NOT push or call gh pr create when this returns.
+func evaluateEmptyBranchPRGuard(decomposed bool, childTerminalStates []string, result *ExecutionResult) {
+	if !decomposed {
+		result.Success = false
+		result.Error = "no_changes: branch has no commits relative to base (PR guard)"
+		return
+	}
+
+	outcome, summary := summarizeChildTerminalStates(childTerminalStates)
+	if outcome == "no_op" {
+		result.Success = false
+		result.Outcome = "no_op"
+		// "no new commit produced" matches noOpErrorSignatures (runner.go) so
+		// TerminalStatus classifies this row as no_op even if Outcome is ever
+		// dropped, and matches noOpErrorMarker (cmd/pilot/handlers.go) so the
+		// no-op re-dispatch paths there recognize it instead of posting a
+		// generic failure comment.
+		result.Error = fmt.Sprintf("no new commit produced — epic branch has no commits relative to base and %s", summary)
+		return
+	}
+
+	note := fmt.Sprintf("epic branch has no commits relative to base; deliverables shipped via child sub-issue PRs — %s", summary)
+	if result.Output == "" {
+		result.Output = note
+	} else {
+		result.Output = result.Output + " — " + note
+	}
+}
+
 // ExecuteSubIssues executes created sub-issues sequentially and tracks progress on the parent.
 // Each sub-issue is executed as a separate task, and the parent issue is updated with progress.
 // Returns an error if any sub-issue fails; completed sub-issues remain done.
@@ -1518,9 +1605,26 @@ func (r *Runner) CloseIssueWithComment(ctx context.Context, projectPath string, 
 // as their ProjectPath so they can create their own branches from the real repo.
 // executionPath is still used for gh CLI commands (issue comments) that need worktree context.
 func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []CreatedIssue, executionPath string, repoPath string) error {
+	_, err := r.executeSubIssuesTracked(ctx, parent, issues, executionPath, repoPath)
+	return err
+}
+
+// executeSubIssuesTracked is ExecuteSubIssues plus each child's terminal state
+// (TerminalStatus of its ExecutionResult, e.g. "completed" / "no_op"). GH-3779:
+// the decomposed-parent PR-finalize guard (evaluateEmptyBranchPRGuard) needs this
+// to tell a genuine no-op epic (every child no-op'd — nothing shipped anywhere)
+// from one whose deliverables shipped entirely via child sub-issue PRs.
+//
+// A child that no-ops (isNoOpResult) is non-fatal here and the loop continues —
+// mirrors the TASK-320 B2 tolerance already applied to the in-process decomposer
+// (runner_decompose.go isNoOpResult). Any other child failure still aborts the
+// whole epic, unchanged from ExecuteSubIssues' prior behavior.
+func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issues []CreatedIssue, executionPath string, repoPath string) ([]string, error) {
 	if len(issues) == 0 {
-		return fmt.Errorf("no sub-issues to execute")
+		return nil, fmt.Errorf("no sub-issues to execute")
 	}
+
+	var childStates []string
 
 	total := len(issues)
 	// Use executionPath for gh CLI commands (respects worktree isolation)
@@ -1553,7 +1657,7 @@ func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []Cr
 		// Check context cancellation
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("execution cancelled: %w", ctx.Err())
+			return childStates, fmt.Errorf("execution cancelled: %w", ctx.Err())
 		default:
 		}
 
@@ -1587,6 +1691,7 @@ func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []Cr
 			_ = r.UpdateIssueProgress(ctx, projectPath, issueRef, skipNote)
 			_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID,
 				fmt.Sprintf("⚠️ Skipped sub-issue #%s: no task description (manual dispatch needed)", issueRef))
+			childStates = append(childStates, "skipped")
 			continue
 		}
 
@@ -1633,15 +1738,33 @@ func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []Cr
 			failMsg := fmt.Sprintf("❌ Failed on %d/%d: %s - Error: %v",
 				i+1, total, issue.Subtask.Title, err)
 			_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
-			return fmt.Errorf("sub-issue %s failed: %w", issueRef, err)
+			return childStates, fmt.Errorf("sub-issue %s failed: %w", issueRef, err)
 		}
 
 		if !result.Success {
+			// GH-3779: a genuine no-op child (isNoOpResult — same classification the
+			// in-process decomposer uses, TASK-320 B2) is not a failure; it just
+			// delivered nothing. Track it and keep executing the remaining children
+			// instead of aborting the whole epic.
+			if isNoOpResult(result) {
+				childStates = append(childStates, "no_op")
+				noOpMsg := fmt.Sprintf("↩️ %d/%d produced no changes (no-op): %s — %s",
+					i+1, total, issue.Subtask.Title, result.Error)
+				_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, noOpMsg)
+				r.log.Info("sub-issue no-op; continuing epic",
+					"parent_id", parent.ID,
+					"sub_issue", issueRef,
+					"error", result.Error,
+				)
+				continue
+			}
 			failMsg := fmt.Sprintf("❌ Failed on %d/%d: %s - %s",
 				i+1, total, issue.Subtask.Title, result.Error)
 			_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
-			return fmt.Errorf("sub-issue %s failed: %s", issueRef, result.Error)
+			return childStates, fmt.Errorf("sub-issue %s failed: %s", issueRef, result.Error)
 		}
+
+		childStates = append(childStates, TerminalStatus(result))
 
 		// TASK-356 #1: work-loss guard. A sub-issue runs with CreatePR=true, so a
 		// successful child MUST yield a PR. When it instead reports success with real
@@ -1661,7 +1784,7 @@ func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []Cr
 				"commit_sha", shortSHA,
 				"branch", subTask.Branch,
 			)
-			return fmt.Errorf("sub-issue %s committed work (sha %s) but produced no PR — work would be lost, halting epic", issueRef, shortSHA)
+			return childStates, fmt.Errorf("sub-issue %s committed work (sha %s) but produced no PR — work would be lost, halting epic", issueRef, shortSHA)
 		}
 
 		// Register sub-issue PR with autopilot controller (GH-596)
@@ -1696,7 +1819,7 @@ func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []Cr
 				if err := r.subIssueMergeWait(ctx, prNum); err != nil {
 					failMsg := fmt.Sprintf("❌ Merge wait failed for %s (PR #%d): %v", issueRef, prNum, err)
 					_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
-					return fmt.Errorf("merge wait failed for sub-issue %s (PR #%d): %w", issueRef, prNum, err)
+					return childStates, fmt.Errorf("merge wait failed for sub-issue %s (PR #%d): %w", issueRef, prNum, err)
 				}
 
 				// Sync local main branch so the next sub-issue branches from the merged state.
@@ -1742,5 +1865,5 @@ func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []Cr
 		"total_completed", total,
 	)
 
-	return nil
+	return childStates, nil
 }

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -3283,3 +3283,258 @@ func TestRecoveryToExecutionPath_RehydratesDescription(t *testing.T) {
 			capturedDesc, realDesc)
 	}
 }
+
+// TestDecomposedChildTerminalStateSummary covers summarizeChildTerminalStates
+// (GH-3779): a decomposed parent's outcome is "no_op" only when every child
+// also no-op'd; any other mix — including no children at all — is "completed".
+func TestDecomposedChildTerminalStateSummary(t *testing.T) {
+	tests := []struct {
+		name        string
+		states      []string
+		wantOutcome string
+		wantSummary string
+	}{
+		{
+			name:        "no children recorded",
+			states:      nil,
+			wantOutcome: "completed",
+			wantSummary: "no child sub-issues to summarize",
+		},
+		{
+			name:        "single completed child",
+			states:      []string{"completed"},
+			wantOutcome: "completed",
+			wantSummary: "1 child sub-issue(s): completed=1",
+		},
+		{
+			name:        "all children no_op",
+			states:      []string{"no_op", "no_op", "no_op"},
+			wantOutcome: "no_op",
+			wantSummary: "3 child sub-issue(s): no_op=3",
+		},
+		{
+			name:        "mixed completed and no_op — not all no_op",
+			states:      []string{"completed", "no_op", "completed"},
+			wantOutcome: "completed",
+			wantSummary: "3 child sub-issue(s): completed=2, no_op=1",
+		},
+		{
+			name:        "one failed child among no_ops — not all no_op",
+			states:      []string{"no_op", "failed"},
+			wantOutcome: "completed",
+			wantSummary: "2 child sub-issue(s): no_op=1, failed=1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outcome, summary := summarizeChildTerminalStates(tt.states)
+			if outcome != tt.wantOutcome {
+				t.Errorf("outcome = %q, want %q", outcome, tt.wantOutcome)
+			}
+			if summary != tt.wantSummary {
+				t.Errorf("summary = %q, want %q", summary, tt.wantSummary)
+			}
+		})
+	}
+}
+
+// TestEpicEmptyBranchPRGuardDecision is the core GH-3779 regression: it drives
+// evaluateEmptyBranchPRGuard directly (no git, no PR creation) across the three
+// scenarios the task calls out —
+//
+//   - decomposed + empty branch, all children no_op: parent records no_op, not
+//     completed, with a summary of the child mix in the error.
+//   - decomposed + empty branch, mixed children: parent stays completed
+//     (deliverables shipped via child sub-issue PRs) with the summary recorded
+//     in Output — no failure comment risk since Success stays true.
+//   - non-decomposed + empty branch: existing GH-2743 behavior is byte-for-byte
+//     preserved, and child state data (if a caller mistakenly supplied any) is
+//     ignored — the case never legitimately arises since a non-decomposed task
+//     has no children, but the guard must not use it if it did.
+func TestEpicEmptyBranchPRGuardDecision(t *testing.T) {
+	tests := []struct {
+		name            string
+		decomposed      bool
+		childStates     []string
+		wantSuccess     bool
+		wantOutcome     string
+		wantErrContains string
+		wantOutContains string
+	}{
+		{
+			name:            "non-decomposed empty branch: existing behavior preserved",
+			decomposed:      false,
+			childStates:     nil,
+			wantSuccess:     false,
+			wantOutcome:     "",
+			wantErrContains: "no_changes: branch has no commits relative to base (PR guard)",
+		},
+		{
+			name:            "non-decomposed empty branch: child state data ignored",
+			decomposed:      false,
+			childStates:     []string{"no_op", "no_op"},
+			wantSuccess:     false,
+			wantOutcome:     "",
+			wantErrContains: "no_changes: branch has no commits relative to base (PR guard)",
+		},
+		{
+			name:            "decomposed empty branch: no child data defaults to completed",
+			decomposed:      true,
+			childStates:     nil,
+			wantSuccess:     true,
+			wantOutcome:     "",
+			wantOutContains: "no child sub-issues to summarize",
+		},
+		{
+			name:            "decomposed empty branch: all children no_op records no_op",
+			decomposed:      true,
+			childStates:     []string{"no_op", "no_op"},
+			wantSuccess:     false,
+			wantOutcome:     "no_op",
+			wantErrContains: "no new commit produced",
+		},
+		{
+			name:            "decomposed empty branch: mixed children stays completed",
+			decomposed:      true,
+			childStates:     []string{"completed", "no_op"},
+			wantSuccess:     true,
+			wantOutcome:     "",
+			wantOutContains: "completed=1, no_op=1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mirrors the caller's starting point: epicResult / direct-path result
+			// both start Success=true before the guard runs.
+			result := &ExecutionResult{TaskID: "GH-3779", Success: true, IsEpic: tt.decomposed}
+
+			evaluateEmptyBranchPRGuard(tt.decomposed, tt.childStates, result)
+
+			if result.Success != tt.wantSuccess {
+				t.Errorf("Success = %v, want %v (error=%q)", result.Success, tt.wantSuccess, result.Error)
+			}
+			if result.Outcome != tt.wantOutcome {
+				t.Errorf("Outcome = %q, want %q", result.Outcome, tt.wantOutcome)
+			}
+			if tt.wantErrContains != "" && !strings.Contains(result.Error, tt.wantErrContains) {
+				t.Errorf("Error = %q, want it to contain %q", result.Error, tt.wantErrContains)
+			}
+			if tt.wantOutContains != "" && !strings.Contains(result.Output, tt.wantOutContains) {
+				t.Errorf("Output = %q, want it to contain %q", result.Output, tt.wantOutContains)
+			}
+			// No-PR invariant: this guard only ever runs when gh pr create is about
+			// to be skipped, so PRUrl must never be populated by it.
+			if result.PRUrl != "" {
+				t.Errorf("PRUrl = %q, want empty — guard must never create a PR", result.PRUrl)
+			}
+			// GH-3779: "no failure comment" — the only way cmd/pilot posts a ❌
+			// failure comment for an epic-parent row is Success==false with an
+			// Error that ISN'T the recognized no-op marker. Every false-Success
+			// case above carries "no new commit produced" / "no_changes:" — both
+			// recognized no-op signatures (runner.go noOpErrorSignatures) — so
+			// none of them read as a generic failure downstream.
+			if !tt.wantSuccess {
+				if !containsAny(result.Error, noOpErrorSignatures) {
+					t.Errorf("Error = %q does not match any recognized no-op signature; would be misclassified as a generic failure", result.Error)
+				}
+			}
+		})
+	}
+}
+
+// TestEpicFinalizeDecomposedEmptyBranchSkipsPRCreation drives finalizeEpicBranchPR
+// end-to-end against a real git repo (no remote configured) with an empty parent
+// branch, proving GH-3779's "decomposed + empty branch" acceptance criteria: PR
+// creation is skipped entirely (a push attempt would fail loudly since there's no
+// remote — its absence here proves the guard short-circuited before push), and the
+// parent's terminal state matches the child mix.
+func TestEpicFinalizeDecomposedEmptyBranchSkipsPRCreation(t *testing.T) {
+	tests := []struct {
+		name        string
+		childStates []string
+		wantSuccess bool
+		wantOutcome string
+	}{
+		{
+			name:        "all children no_op: parent records no_op",
+			childStates: []string{"no_op", "no_op"},
+			wantSuccess: false,
+			wantOutcome: "no_op",
+		},
+		{
+			name:        "mixed children: parent stays completed",
+			childStates: []string{"completed", "no_op"},
+			wantSuccess: true,
+			wantOutcome: "",
+		},
+		{
+			name:        "all children completed: parent stays completed",
+			childStates: []string{"completed", "completed"},
+			wantSuccess: true,
+			wantOutcome: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := initRepoWithCommitTask359(t)
+
+			r := newSilentRunnerTask359()
+			result := &ExecutionResult{TaskID: "GH-3779", Success: true, IsEpic: true}
+			task := &Task{ID: "GH-3779", Title: "epic", Description: "d", Branch: "main", BaseBranch: "main", CreatePR: true}
+
+			r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result, tt.childStates)
+
+			if result.Success != tt.wantSuccess {
+				t.Errorf("Success = %v, want %v (error=%q)", result.Success, tt.wantSuccess, result.Error)
+			}
+			if result.Outcome != tt.wantOutcome {
+				t.Errorf("Outcome = %q, want %q", result.Outcome, tt.wantOutcome)
+			}
+			if result.PRUrl != "" {
+				t.Errorf("PRUrl = %q, want empty — branch has no commits, PR must not be created", result.PRUrl)
+			}
+			if result.CommitSHA != "" {
+				t.Errorf("CommitSHA = %q, want empty — no foreign SHA should be harvested when the guard skips", result.CommitSHA)
+			}
+		})
+	}
+}
+
+// TestEpicFinalizeDecomposedNonEmptyBranchUnchanged is GH-3779's "decomposed +
+// non-empty branch" acceptance criteria: when the parent branch DOES carry
+// commits vs base, the empty-branch guard must not fire regardless of child
+// terminal states, and finalizeEpicBranchPR proceeds exactly as before
+// (TestFinalizeEpicBranchPR_PushFailIsFailure) — push is attempted and fails
+// loud since no remote is configured.
+func TestEpicFinalizeDecomposedNonEmptyBranchUnchanged(t *testing.T) {
+	dir := initRepoWithCommitTask359(t)
+	runGit(t, dir, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("work\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runGit(t, dir, "add", "f.txt")
+	runGit(t, dir, "commit", "-m", "feature work")
+
+	r := newSilentRunnerTask359()
+	result := &ExecutionResult{TaskID: "GH-3779", Success: true, IsEpic: true}
+	task := &Task{ID: "GH-3779", Title: "feat: add f", Description: "d", Branch: "feature", BaseBranch: "main", CreatePR: true}
+
+	// Even a child mix that would force no_op on an EMPTY branch must have zero
+	// effect here — the guard only inspects childStates when guardCount == 0.
+	childStates := []string{"no_op", "no_op"}
+	r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result, childStates)
+
+	if result.Success {
+		t.Error("expected Success=false when epic push fails with no remote (unchanged non-empty-branch behavior)")
+	}
+	if result.Outcome != "" {
+		t.Errorf("Outcome = %q, want empty — non-empty-branch path does not classify via child states", result.Outcome)
+	}
+	if !strings.Contains(result.Error, "push failed") {
+		t.Errorf("expected push-failed error, got %q", result.Error)
+	}
+	if result.PRUrl != "" {
+		t.Errorf("expected no PR URL on push failure, got %q", result.PRUrl)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1309,7 +1309,11 @@ func (r *Runner) Execute(ctx context.Context, task *Task) (*ExecutionResult, err
 // epic whose deliverables shipped via child PRs (empty parent branch) is a clean
 // success, while a parent branch carrying real commits MUST push and PR
 // successfully or the epic is reported as failed.
-func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult) {
+//
+// childTerminalStates is each executed child sub-issue's TerminalStatus
+// ("completed", "no_op", ...); see evaluateEmptyBranchPRGuard (epic.go, GH-3779)
+// for how it's used to classify the parent when the branch guard trips.
+func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult, childTerminalStates []string) {
 	// Determine base branch before the no-commits guard.
 	baseBranch := task.BaseBranch
 	if baseBranch == "" {
@@ -1323,12 +1327,26 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 	// whose HEAD == base HEAD produced no parent-branch deliverable (work, if any,
 	// shipped via child PRs). Skipping PR creation here is a legitimate success —
 	// and we must NOT harvest the (foreign base) SHA in that case.
+	//
+	// GH-3779: classify the parent from its children's terminal states instead of
+	// always leaving Success untouched — a decomposed parent whose children ALL
+	// no-op'd shipped nothing anywhere and must record as no_op, not completed.
 	if guardCount, _ := git.CountNewCommits(ctx, baseBranch); guardCount == 0 {
-		r.log.Warn("Epic branch has no commits vs base, skipping PR creation",
-			slog.String("task_id", task.ID),
-			slog.String("base_branch", baseBranch),
-		)
-		r.reportProgress(task.ID, "PR Skipped", 97, "epic branch has no commits relative to base")
+		evaluateEmptyBranchPRGuard(true, childTerminalStates, result)
+		if result.Outcome == "no_op" {
+			r.log.Warn("Epic branch has no commits vs base and all children no-op'd, recording epic as no_op",
+				slog.String("task_id", task.ID),
+				slog.String("base_branch", baseBranch),
+				slog.String("summary", result.Error),
+			)
+			r.reportProgress(task.ID, "No-Op", 100, result.Error)
+		} else {
+			r.log.Warn("Epic branch has no commits vs base, skipping PR creation",
+				slog.String("task_id", task.ID),
+				slog.String("base_branch", baseBranch),
+			)
+			r.reportProgress(task.ID, "PR Skipped", 97, "epic branch has no commits relative to base")
+		}
 		return
 	}
 
@@ -1746,7 +1764,11 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				// GH-412: Execute sub-issues sequentially
 				// GH-2177: Pass task.ProjectPath as repoPath so sub-issues branch from
 				// the real repo, not the parent's worktree path.
-				if err := r.ExecuteSubIssues(ctx, task, issues, executionPath, task.ProjectPath); err != nil {
+				// GH-3779: also collect each child's terminal state so the PR-finalize
+				// guard below can tell a genuine no-op epic (all children no-op'd) from
+				// one whose deliverables shipped entirely via child sub-issue PRs.
+				childStates, err := r.executeSubIssuesTracked(ctx, task, issues, executionPath, task.ProjectPath)
+				if err != nil {
 					return &ExecutionResult{
 						TaskID:   task.ID,
 						Success:  false,
@@ -1778,7 +1800,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 					// instead of warn-and-continue, so a stranded epic is never recorded
 					// as a "completed" row with an empty PR (Shape A). A pre-create
 					// merged-work check avoids opening a duplicate PR (Shape C).
-					r.finalizeEpicBranchPR(ctx, task, NewGitOperations(executionPath), epicResult)
+					r.finalizeEpicBranchPR(ctx, task, NewGitOperations(executionPath), epicResult, childStates)
 				} else {
 					r.reportProgress(task.ID, "Complete", 100, "Epic completed successfully")
 				}
@@ -3478,9 +3500,13 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			// The no-commit check at ~line 2151 only runs when result.Success==true.
 			// If the initial execution fails, that check is bypassed and gh pr create
 			// receives an empty branch, producing "No commits between main and <branch>".
+			//
+			// GH-3779: this is the non-decomposed path — an empty branch here means the
+			// task genuinely produced nothing, so it stays a hard failure (unlike the
+			// decomposed/epic guard in finalizeEpicBranchPR, which treats an empty parent
+			// branch as a legitimate success when children shipped their own PRs).
 			if guardCount, _ := git.CountNewCommits(ctx, baseBranch); guardCount == 0 {
-				result.Success = false
-				result.Error = "no_changes: branch has no commits relative to base (PR guard)"
+				evaluateEmptyBranchPRGuard(false, nil, result)
 				if backendResult != nil {
 					backendResult.ErrorType = string(ErrorTypeNoChanges)
 				}

--- a/internal/executor/runner_task359_test.go
+++ b/internal/executor/runner_task359_test.go
@@ -47,7 +47,7 @@ func TestFinalizeEpicBranchPR_PushFailIsFailure(t *testing.T) {
 	result := &ExecutionResult{TaskID: "GH-1", Success: true, IsEpic: true}
 	task := &Task{ID: "GH-1", Title: "feat: add f", Description: "d", Branch: "feature", BaseBranch: "main", CreatePR: true}
 
-	r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result)
+	r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result, nil)
 
 	if result.Success {
 		t.Error("expected Success=false when epic push fails with no remote")
@@ -71,7 +71,7 @@ func TestFinalizeEpicBranchPR_NoCommitsIsCleanSuccess(t *testing.T) {
 	result := &ExecutionResult{TaskID: "GH-2", Success: true, IsEpic: true}
 	task := &Task{ID: "GH-2", Title: "epic", Description: "d", Branch: "main", BaseBranch: "main", CreatePR: true}
 
-	r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result)
+	r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result, nil)
 
 	if !result.Success {
 		t.Errorf("expected Success=true for empty parent branch, error=%q", result.Error)


### PR DESCRIPTION
## Summary
- Before `gh pr create` on a decomposed (epic) parent's branch, `finalizeEpicBranchPR` already ran `git rev-list --count <base>..<branch>` via `CountNewCommits`, but on zero it always left the row `completed` regardless of what the children actually delivered.
- `evaluateEmptyBranchPRGuard` (epic.go) now classifies the parent from its children's terminal states: `no_op` only when every child also no-op'd (nothing shipped anywhere), `completed` otherwise (deliverables shipped via child sub-issue PRs) — with a summary of the child mix recorded in Output/Error either way.
- The non-decomposed guard in `executeWithOptions` now routes through the same function with `decomposed=false`, preserving its existing hard-failure behavior byte-for-byte while making it table-testable alongside the decomposed cases.
- `ExecuteSubIssues` gains a `childTerminalStates`-tracking variant (`executeSubIssuesTracked`) that also tolerates a no-op child (`isNoOpResult`) instead of aborting the whole epic, mirroring the TASK-320 B2 tolerance already applied to the in-process decomposer.

Closes #3779

## Test plan
- [x] `go test ./internal/executor/... -run 'TestEpic|TestDecompos' -v` — all pass, including new table-driven cases: decomposed+empty (all no_op → no_op; mixed → completed; no child data → completed), decomposed+non-empty (unchanged), non-decomposed+empty (existing hard-failure behavior preserved)
- [x] `go build ./...`
- [x] `go vet ./internal/executor/...`
- [x] `go test ./internal/executor/...` (full package)