### PR TITLE
fix(autopilot): count no_op children as complete when auto-closing parents

### DIFF
--- a/internal/adapters/github/client.go
+++ b/internal/adapters/github/client.go
@@ -1257,6 +1257,62 @@ func (c *Client) LinkSubIssue(ctx context.Context, owner, repo string, parentNum
 	return c.ExecuteGraphQL(ctx, mutation, variables, nil)
 }
 
+// GetOpenSubIssueNumbers queries native GitHub sub-issues for a parent issue and returns:
+//   - numbers: issue numbers of sub-issues in OPEN state
+//   - hasNativeLinks: true when the parent has at least one native sub-issue link (totalCount > 0)
+//   - error: any API or parsing error
+//
+// GH-3780: callers use the individual numbers to cross-check each open child against the
+// local execution ledger (e.g. no_op reclassification) instead of trusting GitHub's
+// open/closed state alone — GetOpenSubIssueCount only exposes the aggregate count.
+func (c *Client) GetOpenSubIssueNumbers(ctx context.Context, owner, repo string, parentNum int) (numbers []int, hasNativeLinks bool, err error) {
+	parentID, err := c.GetIssueNodeID(ctx, owner, repo, parentNum)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolve parent node ID: %w", err)
+	}
+
+	const query = `query($issueID: ID!) {
+		node(id: $issueID) {
+			... on Issue {
+				subIssues(first: 100) {
+					totalCount
+					nodes {
+						number
+						state
+					}
+				}
+			}
+		}
+	}`
+
+	var result struct {
+		Node struct {
+			SubIssues struct {
+				TotalCount int `json:"totalCount"`
+				Nodes      []struct {
+					Number int    `json:"number"`
+					State  string `json:"state"`
+				} `json:"nodes"`
+			} `json:"subIssues"`
+		} `json:"node"`
+	}
+
+	if err := c.ExecuteGraphQL(ctx, query, map[string]interface{}{"issueID": parentID}, &result); err != nil {
+		return nil, false, fmt.Errorf("query sub-issues for %s/%s#%d: %w", owner, repo, parentNum, err)
+	}
+
+	if result.Node.SubIssues.TotalCount == 0 {
+		return nil, false, nil
+	}
+
+	for _, n := range result.Node.SubIssues.Nodes {
+		if n.State == "OPEN" {
+			numbers = append(numbers, n.Number)
+		}
+	}
+	return numbers, true, nil
+}
+
 // GetOpenSubIssueCount queries native GitHub sub-issues for a parent issue and returns:
 //   - count: number of sub-issues in OPEN state
 //   - hasNativeLinks: true when the parent has at least one native sub-issue link (totalCount > 0)

--- a/internal/adapters/github/client_test.go
+++ b/internal/adapters/github/client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -3293,6 +3294,103 @@ func TestLinkSubIssue(t *testing.T) {
 				if !strings.Contains(err.Error(), tt.errContains) {
 					t.Errorf("error = %q, want containing %q", err.Error(), tt.errContains)
 				}
+			}
+		})
+	}
+}
+
+func TestGetOpenSubIssueNumbers(t *testing.T) {
+	tests := []struct {
+		name            string
+		restResponse    string
+		restStatus      int
+		graphqlResponse string
+		graphqlStatus   int
+		wantNumbers     []int
+		wantNativeLinks bool
+		wantErr         bool
+		errContains     string
+	}{
+		{
+			name:            "some open sub-issues",
+			restResponse:    `{"node_id":"I_parent123","number":50}`,
+			restStatus:      http.StatusOK,
+			graphqlResponse: `{"data":{"node":{"subIssues":{"totalCount":3,"nodes":[{"number":1,"state":"OPEN"},{"number":2,"state":"CLOSED"},{"number":3,"state":"OPEN"}]}}}}`,
+			graphqlStatus:   http.StatusOK,
+			wantNumbers:     []int{1, 3},
+			wantNativeLinks: true,
+		},
+		{
+			name:            "all closed",
+			restResponse:    `{"node_id":"I_parent123","number":50}`,
+			restStatus:      http.StatusOK,
+			graphqlResponse: `{"data":{"node":{"subIssues":{"totalCount":2,"nodes":[{"number":1,"state":"CLOSED"},{"number":2,"state":"CLOSED"}]}}}}`,
+			graphqlStatus:   http.StatusOK,
+			wantNumbers:     nil,
+			wantNativeLinks: true,
+		},
+		{
+			name:            "no native links",
+			restResponse:    `{"node_id":"I_parent123","number":50}`,
+			restStatus:      http.StatusOK,
+			graphqlResponse: `{"data":{"node":{"subIssues":{"totalCount":0,"nodes":[]}}}}`,
+			graphqlStatus:   http.StatusOK,
+			wantNumbers:     nil,
+			wantNativeLinks: false,
+		},
+		{
+			name:         "parent REST error",
+			restResponse: `{"message":"Not Found"}`,
+			restStatus:   http.StatusNotFound,
+			wantErr:      true,
+			errContains:  "resolve parent node ID",
+		},
+		{
+			name:            "graphql error",
+			restResponse:    `{"node_id":"I_parent123","number":50}`,
+			restStatus:      http.StatusOK,
+			graphqlResponse: `{"data":null,"errors":[{"message":"something broke"}]}`,
+			graphqlStatus:   http.StatusOK,
+			wantErr:         true,
+			errContains:     "query sub-issues",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/repos/owner/repo/issues/50" && r.Method == http.MethodGet:
+					w.WriteHeader(tt.restStatus)
+					_, _ = w.Write([]byte(tt.restResponse))
+				case r.URL.Path == "/graphql" && r.Method == http.MethodPost:
+					w.WriteHeader(tt.graphqlStatus)
+					_, _ = w.Write([]byte(tt.graphqlResponse))
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			numbers, hasNative, err := client.GetOpenSubIssueNumbers(context.Background(), "owner", "repo", 50)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetOpenSubIssueNumbers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errContains != "" {
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %q, want containing %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if !reflect.DeepEqual(numbers, tt.wantNumbers) {
+				t.Errorf("GetOpenSubIssueNumbers() numbers = %v, want %v", numbers, tt.wantNumbers)
+			}
+			if hasNative != tt.wantNativeLinks {
+				t.Errorf("GetOpenSubIssueNumbers() hasNativeLinks = %v, want %v", hasNative, tt.wantNativeLinks)
 			}
 		})
 	}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -105,6 +105,11 @@ type EvalStore interface {
 	// stamps the PR URL after a successful merge. projectPath scopes the update
 	// to prevent cross-repo clobbering. GH-2402.
 	SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) error
+	// GetExecutionStatusByTaskID returns the status of the most recent execution
+	// row exactly matching taskID and projectPath (no substring fallback) — used
+	// to verify a child sub-issue's ledger status before treating it as complete
+	// for parent-close purposes. GH-3780.
+	GetExecutionStatusByTaskID(taskID, projectPath string) (string, error)
 }
 
 // ControllerOption is a functional option for Controller configuration.
@@ -1719,7 +1724,7 @@ func (c *Controller) maybeCloseParentIssue(ctx context.Context, prState *PRState
 // by the text search before the caller may close the parent. The max of both
 // tiers is returned.
 func (c *Controller) openSubIssueCount(ctx context.Context, parentNum int) (int, error) {
-	nativeCount, hasNativeLinks, err := c.ghClient.GetOpenSubIssueCount(ctx, c.owner, c.repo, parentNum)
+	numbers, hasNativeLinks, err := c.ghClient.GetOpenSubIssueNumbers(ctx, c.owner, c.repo, parentNum)
 	if err != nil || !hasNativeLinks {
 		if err != nil {
 			c.log.Warn("openSubIssueCount: native sub-issue count failed, falling back to search", slog.Int("parent", parentNum), slog.Any("error", err))
@@ -1729,11 +1734,12 @@ func (c *Controller) openSubIssueCount(ctx context.Context, parentNum int) (int,
 		return c.ghClient.SearchOpenSubIssues(ctx, c.owner, c.repo, parentNum)
 	}
 
+	nativeCount := c.blockingChildCount(numbers)
 	if nativeCount > 0 {
 		return nativeCount, nil
 	}
 
-	// Native says 0 — cross-check text search to catch unlinked open siblings.
+	// Native says 0 blocking — cross-check text search to catch unlinked open siblings.
 	textCount, err := c.ghClient.SearchOpenSubIssues(ctx, c.owner, c.repo, parentNum)
 	if err != nil {
 		return 0, fmt.Errorf("native count is 0 but confirmation search failed: %w", err)
@@ -1743,6 +1749,38 @@ func (c *Controller) openSubIssueCount(ctx context.Context, parentNum int) (int,
 			slog.Int("parent", parentNum), slog.Int("text_open", textCount))
 	}
 	return textCount, nil
+}
+
+// blockingChildCount returns how many of the given open native sub-issue numbers
+// still block the parent from closing. GH-3780: an open GitHub sub-issue normally
+// blocks, but a decomposed child whose execution ledger classifies it "no_op" (no
+// commits, no PR — so it never produced a merge to close its own issue) has
+// genuinely finished its work. Any other status (queued, running, failed, or no
+// ledger row at all) still blocks, matching the pre-GH-3780 behavior.
+func (c *Controller) blockingChildCount(numbers []int) int {
+	blocking := 0
+	for _, num := range numbers {
+		if !c.isChildNoOp(num) {
+			blocking++
+		}
+	}
+	return blocking
+}
+
+// isChildNoOp reports whether the sub-issue's most recent ledger execution is a
+// verified no_op, via the exact task_id+project_path join (GetExecutionStatusByTaskID)
+// rather than the fuzzy substring match GetLatestExecutionByTaskID uses — a wrong-repo
+// or wrong-issue match could otherwise let an unrelated no_op row wrongly close this
+// parent. Fails closed (false) when the eval store isn't wired or the lookup errors.
+func (c *Controller) isChildNoOp(issueNum int) bool {
+	if c.evalStore == nil {
+		return false
+	}
+	status, err := c.evalStore.GetExecutionStatusByTaskID(fmt.Sprintf("GH-%d", issueNum), c.projectPath)
+	if err != nil {
+		return false
+	}
+	return status == "no_op"
 }
 
 // closeParentNow adds pilot-done, removes stale labels, posts a summary comment,

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -4002,6 +4002,10 @@ type mockEvalStore struct {
 	saved        []*memory.EvalTask
 	selfHealed   []selfHealCall
 	updateStatus []updateStatusCall
+	// execStatusByTaskID configures GetExecutionStatusByTaskID responses keyed by
+	// task ID (e.g. "GH-11"). Missing keys return sql.ErrNoRows, matching a real
+	// store's behavior when no execution row exists for that task.
+	execStatusByTaskID map[string]string
 }
 
 type selfHealCall struct {
@@ -4024,6 +4028,14 @@ func (m *mockEvalStore) SaveEvalTask(task *memory.EvalTask) error {
 func (m *mockEvalStore) UpdateExecutionStatusByTaskID(taskID, projectPath, status string) error {
 	m.updateStatus = append(m.updateStatus, updateStatusCall{TaskID: taskID, ProjectPath: projectPath, Status: status})
 	return nil
+}
+
+func (m *mockEvalStore) GetExecutionStatusByTaskID(taskID, projectPath string) (string, error) {
+	status, ok := m.execStatusByTaskID[taskID]
+	if !ok {
+		return "", sql.ErrNoRows
+	}
+	return status, nil
 }
 
 func (m *mockEvalStore) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) error {
@@ -4382,8 +4394,10 @@ func TestMaybeCloseParentIssue(t *testing.T) {
 		openSubIssues    int // used by text-search fallback
 		getIssueErr      bool
 		searchErr        bool
-		nativeTotal      int      // totalCount returned by GraphQL native sub-issues
-		nativeOpenStates []string // states of natively linked sub-issues
+		nativeTotal      int               // totalCount returned by GraphQL native sub-issues
+		nativeOpenStates []string          // states of natively linked sub-issues
+		nativeNumbers    []int             // issue numbers matching nativeOpenStates by index; defaults to index+1 if unset
+		execStatuses     map[string]string // GH-3780: mockEvalStore.GetExecutionStatusByTaskID responses keyed by task ID (e.g. "GH-1")
 		wantClosed       bool
 		wantLabeled      bool
 		wantCommented    bool
@@ -4464,6 +4478,37 @@ func TestMaybeCloseParentIssue(t *testing.T) {
 			wantLabeled:      false,
 			wantCommented:    false,
 		},
+		{
+			// GH-3780: child mix {completed, no_op, no_op}. The "completed" sibling
+			// already merged its PR and closed on GitHub, so only the two no_op
+			// children remain OPEN. Neither ever produces a PR/merge, but the ledger
+			// verifies both are genuine no_ops — the parent should still auto-close.
+			name:             "native links with no_op siblings only - closes parent",
+			issueNumber:      10,
+			issueBody:        "Fix the bug\n\nParent: GH-5\n",
+			nativeTotal:      3,
+			nativeOpenStates: []string{"CLOSED", "OPEN", "OPEN"},
+			nativeNumbers:    []int{1, 2, 3},
+			execStatuses:     map[string]string{"GH-2": "no_op", "GH-3": "no_op"},
+			wantClosed:       true,
+			wantLabeled:      true,
+			wantCommented:    true,
+		},
+		{
+			// GH-3780: one open sibling is a genuine no_op, but another is still
+			// failed/queued — that one still blocks the close since its work isn't
+			// actually done.
+			name:             "native links with no_op plus failed sibling - blocks close",
+			issueNumber:      10,
+			issueBody:        "Fix the bug\n\nParent: GH-5\n",
+			nativeTotal:      2,
+			nativeOpenStates: []string{"OPEN", "OPEN"},
+			nativeNumbers:    []int{2, 3},
+			execStatuses:     map[string]string{"GH-2": "no_op", "GH-3": "failed"},
+			wantClosed:       false,
+			wantLabeled:      false,
+			wantCommented:    false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -4501,10 +4546,16 @@ func TestMaybeCloseParentIssue(t *testing.T) {
 					}
 
 				case r.URL.Path == "/graphql" && r.Method == http.MethodPost:
-					// Serve native sub-issues GraphQL response in node(id:) format used by GetOpenSubIssueCount.
-					nodes := make([]map[string]string, len(tt.nativeOpenStates))
+					// Serve native sub-issues GraphQL response in node(id:) format used by
+					// GetOpenSubIssueNumbers/GetOpenSubIssueCount. nativeNumbers defaults to
+					// index+1 per-entry when the test case doesn't set it explicitly.
+					nodes := make([]map[string]interface{}, len(tt.nativeOpenStates))
 					for i, s := range tt.nativeOpenStates {
-						nodes[i] = map[string]string{"state": s}
+						num := i + 1
+						if i < len(tt.nativeNumbers) {
+							num = tt.nativeNumbers[i]
+						}
+						nodes[i] = map[string]interface{}{"state": s, "number": num}
 					}
 					resp := map[string]interface{}{
 						"data": map[string]interface{}{
@@ -4558,6 +4609,9 @@ func TestMaybeCloseParentIssue(t *testing.T) {
 			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
 			cfg := DefaultConfig()
 			c := NewController(cfg, ghClient, nil, "owner", "repo")
+			if tt.execStatuses != nil {
+				c.SetEvalStore(&mockEvalStore{execStatusByTaskID: tt.execStatuses})
+			}
 
 			prState := &PRState{
 				PRNumber:    42,

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1231,6 +1231,22 @@ func (s *Store) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) e
 	})
 }
 
+// GetExecutionStatusByTaskID returns the status of the most recent execution row
+// exactly matching taskID (scoped to projectPath, mirroring SelfHealExecutionAfterMerge:
+// empty projectPath drops the scope for legacy single-repo callers) — no substring
+// fallback, unlike GetLatestExecutionByTaskID, so a no_op verdict can't be borrowed
+// from an unrelated task or repo. Returns sql.ErrNoRows when no row matches. GH-3780.
+func (s *Store) GetExecutionStatusByTaskID(taskID, projectPath string) (string, error) {
+	var status string
+	err := s.db.QueryRow(`
+		SELECT status FROM executions
+		WHERE task_id = ? AND (? = '' OR project_path = ?)
+		ORDER BY created_at DESC, rowid DESC
+		LIMIT 1
+	`, taskID, projectPath, projectPath).Scan(&status)
+	return status, err
+}
+
 // UpdateExecutionResult updates the result fields of an execution record.
 // Called when task execution completes successfully with PR/commit info.
 func (s *Store) UpdateExecutionResult(id string, prURL, commitSHA string, durationMs int64) error {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2064,6 +2064,65 @@ func TestSelfHealExecutionAfterMerge_EmptyProjectPath(t *testing.T) {
 	}
 }
 
+// TestGetExecutionStatusByTaskID_ExactMatchScopedToProject verifies the lookup
+// matches task_id exactly (no substring fallback) and stays scoped to project_path,
+// so a no_op verdict for one repo's "GH-6" can't be borrowed by another repo's
+// same-numbered issue. GH-3780.
+func TestGetExecutionStatusByTaskID_ExactMatchScopedToProject(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "e1", TaskID: "GH-6", ProjectPath: "/proj/a", Status: "no_op"})
+	_ = store.SaveExecution(&Execution{ID: "e2", TaskID: "GH-6", ProjectPath: "/proj/b", Status: "failed"})
+	// A task ID that would falsely substring-match "GH-6" (e.g. GetLatestExecutionByTaskID's
+	// "%GH-6%" fallback) must not be returned instead of the exact match.
+	_ = store.SaveExecution(&Execution{ID: "e3", TaskID: "GH-60", ProjectPath: "/proj/a", Status: "completed"})
+
+	status, err := store.GetExecutionStatusByTaskID("GH-6", "/proj/a")
+	if err != nil {
+		t.Fatalf("GetExecutionStatusByTaskID: %v", err)
+	}
+	if status != "no_op" {
+		t.Errorf("status = %q, want %q", status, "no_op")
+	}
+
+	status, err = store.GetExecutionStatusByTaskID("GH-6", "/proj/b")
+	if err != nil {
+		t.Fatalf("GetExecutionStatusByTaskID: %v", err)
+	}
+	if status != "failed" {
+		t.Errorf("status = %q, want %q", status, "failed")
+	}
+
+	if _, err := store.GetExecutionStatusByTaskID("GH-6", "/proj/c"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows for unmatched project, got %v", err)
+	}
+}
+
+// TestGetExecutionStatusByTaskID_EmptyProjectPath verifies that an empty
+// projectPath falls back to task_id-only matching, mirroring
+// SelfHealExecutionAfterMerge's legacy single-repo behavior. GH-3780.
+func TestGetExecutionStatusByTaskID_EmptyProjectPath(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "e1", TaskID: "GH-7", ProjectPath: "/proj/a", Status: "no_op"})
+
+	status, err := store.GetExecutionStatusByTaskID("GH-7", "")
+	if err != nil {
+		t.Fatalf("GetExecutionStatusByTaskID: %v", err)
+	}
+	if status != "no_op" {
+		t.Errorf("status = %q, want %q", status, "no_op")
+	}
+}
+
 // TestRecentCompletedTelemetryStats verifies the zero-token telemetry gap
 // query: rows are filtered to completed runs with a real commit, and rows
 // without commit_sha (e.g. epic orchestrators) are excluded so they don't


### PR DESCRIPTION
## Summary
- `openSubIssueCount` in `internal/autopilot/controller.go` only trusted GitHub's open/closed issue state. A decomposed sub-issue whose execution is a genuine `no_op` (no commits, no PR) never produces a merge event to close its own GitHub issue, so it stayed "open" forever and blocked the parent from auto-closing.
- Added `github.Client.GetOpenSubIssueNumbers` (returns individual open sub-issue numbers, not just a count) and `memory.Store.GetExecutionStatusByTaskID` (exact `task_id`+`project_path` match — no substring fallback like `GetLatestExecutionByTaskID`).
- `openSubIssueCount` now excludes open children whose latest ledger execution is verified `no_op` from the blocking count via the new `EvalStore.GetExecutionStatusByTaskID` method. Any other status (queued, failed, missing ledger row) still blocks, unchanged.

## Test plan
- [x] `go test ./internal/autopilot/... -v` — new cases: child mix `{completed, no_op, no_op}` auto-closes the parent; a no_op + failed sibling mix still blocks close.
- [x] `go test ./internal/adapters/github/... -run TestGetOpenSubIssueNumbers -v`
- [x] `go test ./internal/memory/... -run TestGetExecutionStatusByTaskID -v`
- [x] `make test`
- [x] `make lint`