### PR TITLE
fix(executor): gate epic parent failure on terminal child execution state

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1597,6 +1598,159 @@ func evaluateEmptyBranchPRGuard(decomposed bool, childTerminalStates []string, r
 	}
 }
 
+// defaultChildOutcomeReconcilePollInterval / defaultChildOutcomeReconcileTimeout
+// bound reconcileChildOutcome's poll loop. GH-3786.
+const (
+	defaultChildOutcomeReconcilePollInterval = 3 * time.Second
+	defaultChildOutcomeReconcileTimeout      = 5 * time.Minute
+)
+
+// childExecutionNonTerminalStatuses are executions.status values that mean a
+// child's own tracked run has not finished yet.
+var childExecutionNonTerminalStatuses = map[string]bool{
+	"queued":  true,
+	"pending": true,
+	"running": true,
+}
+
+// reconcileChildOutcome re-checks a sub-issue's own execution row before
+// letting a synchronous exec signal (err or result.Success=false) fail the
+// epic. GH-3786 (TASK-382 D3): GH-3760 failed on "sub-issue 3769 failed:
+// unknown: exit status 1" while GH-3769's own execution row was still
+// "running" — it went on to reach "completed" and ship PR #3778
+// independently. The synchronous return from executing a sub-issue is not
+// proof the child is actually done: it can race a concurrently-tracked run
+// of the same issue (e.g. picked up separately by the normal dispatch
+// queue). Only a terminal status on the child's tracked execution row is
+// proof.
+//
+// When no failure signal is present, or no log store is wired to check
+// against, the original (result, err) pass through unchanged. Otherwise this
+// polls GetExecutionStatusByTaskID for taskID (scoped to projectPath) until
+// it reports a terminal status, the context is cancelled, or
+// childOutcomeReconcileTimeout elapses — whichever comes first, so this can
+// never block the epic indefinitely. On terminal success ("completed" /
+// "no_op") it synthesizes a passing ExecutionResult from the tracked row so
+// the caller's normal success/no-op handling applies; on terminal failure it
+// enriches the returned error with the tracked row's real error message
+// instead of the uninformative "unknown: exit status 1" backend
+// classification.
+func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath string, result *ExecutionResult, execErr error) (*ExecutionResult, error) {
+	hasFailureSignal := execErr != nil || (result != nil && !result.Success)
+	if !hasFailureSignal {
+		return result, execErr
+	}
+	if r.logStore == nil {
+		return result, execErr
+	}
+
+	// First lookup outside the poll loop: if the child has no tracked
+	// execution row at all (the common case for a genuine, non-racing
+	// failure — inline sub-issue execution doesn't itself write an
+	// executions row), there is nothing to wait for. Only enter the bounded
+	// poll when a row actually exists and is still in flight, so a plain
+	// single-run failure fails immediately instead of paying the full poll
+	// timeout on every epic error.
+	status, err := r.logStore.GetExecutionStatusByTaskID(taskID, projectPath)
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			r.log.Warn("reconcileChildOutcome: execution status lookup failed",
+				"task_id", taskID, "project_path", projectPath, "error", err)
+		}
+		return result, execErr
+	}
+	if !childExecutionNonTerminalStatuses[status] {
+		return r.resolveChildTerminalOutcome(taskID, status, result, execErr)
+	}
+
+	pollInterval := r.childOutcomeReconcilePollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultChildOutcomeReconcilePollInterval
+	}
+	timeout := r.childOutcomeReconcileTimeout
+	if timeout <= 0 {
+		timeout = defaultChildOutcomeReconcileTimeout
+	}
+
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return result, execErr
+		case <-ticker.C:
+		}
+
+		status, err := r.logStore.GetExecutionStatusByTaskID(taskID, projectPath)
+		if err == nil && !childExecutionNonTerminalStatuses[status] {
+			return r.resolveChildTerminalOutcome(taskID, status, result, execErr)
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			r.log.Warn("reconcileChildOutcome: execution status lookup failed",
+				"task_id", taskID, "project_path", projectPath, "error", err)
+		}
+		if time.Now().After(deadline) {
+			r.log.Warn("reconcileChildOutcome: gave up waiting for terminal child execution state",
+				"task_id", taskID, "project_path", projectPath, "timeout", timeout)
+			return result, execErr
+		}
+	}
+}
+
+// resolveChildTerminalOutcome turns a terminal execution-row status for
+// taskID into the (result, error) pair reconcileChildOutcome should return.
+// "completed" / "no_op" become a synthetic success/no-op ExecutionResult so
+// the normal caller-side handling (PR registration, merge wait, no-op
+// continue) applies unchanged; any other terminal status is a genuine
+// failure, reported with the tracked row's real Error message when the
+// original signal lacked one.
+func (r *Runner) resolveChildTerminalOutcome(taskID, status string, result *ExecutionResult, execErr error) (*ExecutionResult, error) {
+	row, rowErr := r.logStore.GetLatestExecutionByTaskID(taskID)
+	if rowErr != nil {
+		row = nil
+	}
+
+	switch status {
+	case "completed":
+		synth := &ExecutionResult{TaskID: taskID, Success: true}
+		if row != nil {
+			synth.PRUrl = row.PRUrl
+			synth.CommitSHA = row.CommitSHA
+		}
+		r.log.Info("reconcileChildOutcome: child execution row reached terminal success after a synchronous failure signal; treating as succeeded",
+			"task_id", taskID, "status", status)
+		return synth, nil
+	case "no_op":
+		synth := &ExecutionResult{TaskID: taskID, Success: false, Outcome: "no_op"}
+		if row != nil && row.Error != "" {
+			synth.Error = row.Error
+		}
+		r.log.Info("reconcileChildOutcome: child execution row reached terminal no_op after a synchronous failure signal; treating as no-op",
+			"task_id", taskID, "status", status)
+		return synth, nil
+	default:
+		msg := ""
+		if row != nil && strings.TrimSpace(row.Error) != "" {
+			msg = row.Error
+		} else if execErr != nil {
+			msg = execErr.Error()
+		} else if result != nil {
+			msg = result.Error
+		}
+		if msg == "" {
+			msg = fmt.Sprintf("child execution ended with status %q", status)
+		}
+		if result == nil {
+			result = &ExecutionResult{TaskID: taskID}
+		}
+		result.Success = false
+		result.Error = msg
+		return result, fmt.Errorf("child execution status=%s: %s", status, msg)
+	}
+}
+
 // ExecuteSubIssues executes created sub-issues sequentially and tracks progress on the parent.
 // Each sub-issue is executed as a separate task, and the parent issue is updated with progress.
 // Returns an error if any sub-issue fails; completed sub-issues remain done.
@@ -1734,6 +1888,13 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			// subTask.ProjectPath points to the real repo, not the parent's worktree.
 			result, err = r.executeWithOptions(ctx, subTask, true)
 		}
+
+		// GH-3786: a synchronous err/Success=false here is not proof the child
+		// is actually done — it can race a separately-tracked run of the same
+		// sub-issue. Re-check the child's own execution row before trusting
+		// this signal as terminal.
+		result, err = r.reconcileChildOutcome(ctx, taskID, subTaskRepoPath, result, err)
+
 		if err != nil {
 			failMsg := fmt.Sprintf("❌ Failed on %d/%d: %s - Error: %v",
 				i+1, total, issue.Subtask.Title, err)

--- a/internal/executor/epic_child_reconcile_test.go
+++ b/internal/executor/epic_child_reconcile_test.go
@@ -1,0 +1,166 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestExecuteSubIssues_ChildTransientFailureEventualSuccess is the GH-3786
+// (TASK-382 D3) regression test: GH-3760 failed with "sub-issue 3769 failed:
+// unknown: exit status 1" while GH-3769's own execution row was still
+// "running" — it went on to reach "completed" and ship its PR. The parent
+// must not conclude the child failed while the child's execution row is
+// non-terminal; it must reconcile against that row before failing the epic.
+func TestExecuteSubIssues_ChildTransientFailureEventualSuccess(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-101"
+	if err := store.SaveExecution(&memory.Execution{
+		ID:     "exec-101",
+		TaskID: taskID,
+		Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	issues := makeSubIssues(1, 101)
+	parent := &Task{ID: "GH-50", Title: "[epic] transient child failure"}
+
+	// Simulates the inline sub-issue execution observing the early
+	// inner-subtask exit-1 signal while a separately-tracked run of the same
+	// issue is still in flight.
+	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{
+			TaskID:  task.ID,
+			Success: false,
+			Error:   "unknown: exit status 1",
+		}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	runner.childOutcomeReconcileTimeout = 2 * time.Second
+
+	var prCalls []subIssuePRCall
+	runner.SetOnSubIssuePRCreated(func(prNumber int, prURL string, issueNumber int, commitSHA, branchName, issueNodeID string) {
+		prCalls = append(prCalls, subIssuePRCall{
+			PRNumber: prNumber, PRURL: prURL, IssueNumber: issueNumber, CommitSHA: commitSHA, BranchName: branchName,
+		})
+	})
+
+	// The child's real, separately-tracked execution finishes shortly after
+	// the inline call observed its transient failure signal.
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		if mcErr := store.MarkExecutionCompleted("exec-101", "https://github.com/owner/repo/pull/9101", "sha-final", 1000); mcErr != nil {
+			t.Errorf("MarkExecutionCompleted: %v", mcErr)
+		}
+	}()
+
+	err = runner.ExecuteSubIssues(context.Background(), parent, issues, parent.ProjectPath, "")
+	if err != nil {
+		t.Fatalf("ExecuteSubIssues returned error, want nil (child eventually succeeded): %v", err)
+	}
+
+	if len(prCalls) != 1 {
+		t.Fatalf("PR callback count = %d, want 1", len(prCalls))
+	}
+	if prCalls[0].PRNumber != 9101 {
+		t.Errorf("PR callback PRNumber = %d, want 9101", prCalls[0].PRNumber)
+	}
+	if prCalls[0].CommitSHA != "sha-final" {
+		t.Errorf("PR callback CommitSHA = %q, want %q", prCalls[0].CommitSHA, "sha-final")
+	}
+}
+
+// TestExecuteSubIssues_ChildFailureMessageSurfacesRealError verifies that
+// when a child's execution row reaches a genuine terminal failure, the
+// error the epic reports includes the row's real error message instead of
+// the uninformative "unknown: exit status 1" backend classification.
+func TestExecuteSubIssues_ChildFailureMessageSurfacesRealError(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-102"
+	if err := store.SaveExecution(&memory.Execution{
+		ID:     "exec-102",
+		TaskID: taskID,
+		Status: "failed",
+		Error:  "panic: nil pointer dereference in health.go:42",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	issues := makeSubIssues(1, 102)
+	parent := &Task{ID: "GH-51", Title: "[epic] real child failure"}
+
+	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{
+			TaskID:  task.ID,
+			Success: false,
+			Error:   "unknown: exit status 1",
+		}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	runner.childOutcomeReconcileTimeout = 2 * time.Second
+
+	err = runner.ExecuteSubIssues(context.Background(), parent, issues, parent.ProjectPath, "")
+	if err == nil {
+		t.Fatal("expected error from genuinely failed child, got nil")
+	}
+	if !strings.Contains(err.Error(), "panic: nil pointer dereference in health.go:42") {
+		t.Errorf("error = %q, want it to contain the child's real error message", err.Error())
+	}
+	if strings.Contains(err.Error(), "unknown: exit status 1") {
+		t.Errorf("error = %q, should not surface the uninformative classification once the real error is known", err.Error())
+	}
+}
+
+// TestExecuteSubIssues_NoLogStoreFailsImmediately verifies that without a
+// log store wired, a synchronous child failure fails the epic immediately
+// (unchanged pre-GH-3786 behavior) rather than blocking on a poll it has no
+// way to resolve.
+func TestExecuteSubIssues_NoLogStoreFailsImmediately(t *testing.T) {
+	issues := makeSubIssues(1, 103)
+	parent := &Task{ID: "GH-52", Title: "[epic] no log store"}
+
+	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{
+			TaskID:  task.ID,
+			Success: false,
+			Error:   "compile error",
+		}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	// logStore intentionally left nil.
+
+	start := time.Now()
+	err := runner.ExecuteSubIssues(context.Background(), parent, issues, parent.ProjectPath, "")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "compile error") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "compile error")
+	}
+	if elapsed > time.Second {
+		t.Errorf("ExecuteSubIssues took %s, want near-immediate failure with no log store wired", elapsed)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -576,6 +576,12 @@ type Runner struct {
 	// guardrail logs a one-shot WARN and (without PILOT_ALLOW_UNMANAGED_REPO=1)
 	// refuses to create sub-issues — safe default for newly-wired call paths.
 	repoAllowlist RepoAllowlist
+	// GH-3786: bounds reconcileChildOutcome's poll loop that re-checks a sub-issue's
+	// own execution row before letting a synchronous exec failure fail the epic.
+	// Zero uses the package defaults (defaultChildOutcomeReconcilePollInterval /
+	// defaultChildOutcomeReconcileTimeout); tests shrink these for fast runs.
+	childOutcomeReconcilePollInterval time.Duration
+	childOutcomeReconcileTimeout      time.Duration
 }
 
 // SetRepoAllowlist injects the allowlist used by the sub-issue creation


### PR DESCRIPTION
## Summary

Fixes GH-3786 (TASK-382 D3): GH-3760 failed with `sub-issue execution failed: sub-issue 3769 failed: unknown: exit status 1` while GH-3769's own execution row was still `running` — it went on to reach `completed` and ship PR #3778 independently. The parent's inline sub-issue execution observed a synchronous exec signal that raced a separately-tracked run of the same sub-issue and gave up prematurely.

- `executeSubIssuesTracked` now calls `reconcileChildOutcome` after a synchronous exec failure/error, before treating it as terminal.
- If the child has no tracked execution row at all, behavior is unchanged (immediate failure — no added latency for genuine single-run failures).
- If the child's tracked execution row is non-terminal (`queued`/`pending`/`running`), it polls (bounded by a configurable interval/timeout, honoring context cancellation) until the row reaches a terminal state.
- A terminal `completed`/`no_op` row is treated as the real outcome (synthesizes a passing/no-op result from the row's PR URL / commit SHA), letting the epic proceed normally (PR registration, merge wait, issue close).
- A terminal failure surfaces the row's actual `error` field instead of the uninformative `unknown: exit status 1` classification.

## Test plan

- [x] New regression tests in `internal/executor/epic_child_reconcile_test.go`:
  - `TestExecuteSubIssues_ChildTransientFailureEventualSuccess` — child's tracked row starts `running`, transitions to `completed` mid-poll → epic reports success, PR callback fires with the real PR/commit info.
  - `TestExecuteSubIssues_ChildFailureMessageSurfacesRealError` — child's tracked row is already `failed` with a real error → epic error contains that message, not `unknown: exit status 1`.
  - `TestExecuteSubIssues_NoLogStoreFailsImmediately` — no log store wired → epic fails immediately (no regression in latency/behavior for the common case).
- [x] `make test`
- [x] `make lint`