### PR TITLE
GH-3785: fix(executor): child worker commits work but push/PR step fails silently — work stranded in local odb

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updated": "2026-06-26",
+  "updated": "2026-07-04",
   "nodes": {
     "concepts": {
       "pilot-architecture": {
@@ -73,7 +73,7 @@
       },
       "git-operations": {
         "label": "Git Operations",
-        "description": "Git command wrappers in executor — clone, fetch, push, sync, worktree management. Source of data-loss risk if destructive ops (reset --hard, push --force) are used without divergence checks.",
+        "description": "Git command wrappers in executor \u2014 clone, fetch, push, sync, worktree management. Source of data-loss risk if destructive ops (reset --hard, push --force) are used without divergence checks.",
         "related": [
           "executor"
         ],
@@ -133,7 +133,7 @@
       },
       "anthropic-api": {
         "label": "Anthropic API",
-        "description": "Direct Anthropic Messages API calls (x-api-key, max_tokens required) used by the bot module's llm.Client — distinct from the Claude Code subprocess the executor uses",
+        "description": "Direct Anthropic Messages API calls (x-api-key, max_tokens required) used by the bot module's llm.Client \u2014 distinct from the Claude Code subprocess the executor uses",
         "related": [
           "llm-integration",
           "claude-code-integration"
@@ -164,6 +164,14 @@
           "intent-routing",
           "anthropic-api"
         ]
+      },
+      "doctor": {
+        "label": "doctor",
+        "description": "pilot doctor health checks (internal/health) \u2014 presence-only today, target: live auth probes via Verifiable interface"
+      },
+      "canary": {
+        "label": "canary",
+        "description": "Scheduled synthetic end-to-end pipeline check against a sandbox repo"
       }
     },
     "tasks": {
@@ -226,11 +234,28 @@
         "released": "v2.166.10-11"
       },
       "TASK-359": {
-        "title": "Daemon finalization hardening — Shapes A/B/C closure",
+        "title": "Daemon finalization hardening \u2014 Shapes A/B/C closure",
         "status": "planned",
         "priority": "P1",
         "file": ".agent/tasks/TASK-359-daemon-finalization-hardening.md",
         "created": "2026-06-03"
+      },
+      "TASK-379": {
+        "label": "Runtime self-verification: Verifiable preflight, fail-loud policy, execution ledger, synthetic canary",
+        "status": "planned",
+        "file": ".agent/tasks/TASK-379-runtime-self-verification.md",
+        "priority": "P0",
+        "created": "2026-07-03",
+        "concepts": [
+          "doctor",
+          "alerts",
+          "executor",
+          "memory",
+          "autopilot",
+          "github-adapter",
+          "canary",
+          "anthropic-api"
+        ]
       }
     },
     "memories": {
@@ -289,7 +314,7 @@
       },
       "mem-006": {
         "type": "pattern",
-        "summary": "Navigator prompt should use 'Run until done' to trigger Loop Mode. Navigator then handles WORKFLOW CHECK, phase transitions (RESEARCH→PLAN→IMPL→VERIFY→COMPLETE), and EXIT_SIGNAL for completion.",
+        "summary": "Navigator prompt should use 'Run until done' to trigger Loop Mode. Navigator then handles WORKFLOW CHECK, phase transitions (RESEARCH\u2192PLAN\u2192IMPL\u2192VERIFY\u2192COMPLETE), and EXIT_SIGNAL for completion.",
         "concepts": [
           "executor",
           "navigator-integration"
@@ -341,7 +366,7 @@
       },
       "mem-011": {
         "type": "pitfall",
-        "summary": "CRITICAL: syncMainBranch() uses git reset --hard origin/main after every task. When GitHub push propagation lags behind the immediately-following fetch+reset, local commits are silently destroyed (only reflog-recoverable, 90d window). Race is in remote propagation, not push failure — reordering does NOT fix it. Fix: replace with merge --ff-only. Two call sites: runner.go:3258 (config-gated) and epic.go:1498 (NOT gated).",
+        "summary": "CRITICAL: syncMainBranch() uses git reset --hard origin/main after every task. When GitHub push propagation lags behind the immediately-following fetch+reset, local commits are silently destroyed (only reflog-recoverable, 90d window). Race is in remote propagation, not push failure \u2014 reordering does NOT fix it. Fix: replace with merge --ff-only. Two call sites: runner.go:3258 (config-gated) and epic.go:1498 (NOT gated).",
         "concepts": [
           "executor",
           "git-operations"
@@ -428,7 +453,7 @@
       },
       "mem-018": {
         "type": "learning",
-        "summary": "AUP/cyber-safeguard kills security-audit model output mid-run, but Workflow tool persists findings to /tmp/claude-501/.../<wfId>.output — recover via jq, never re-summarize via the model. File: learning_audit_safeguard_bypass.md (TASK-322).",
+        "summary": "AUP/cyber-safeguard kills security-audit model output mid-run, but Workflow tool persists findings to /tmp/claude-501/.../<wfId>.output \u2014 recover via jq, never re-summarize via the model. File: learning_audit_safeguard_bypass.md (TASK-322).",
         "concepts": [
           "workflow-tool",
           "security-audit",
@@ -450,7 +475,7 @@
       },
       "mem-020": {
         "type": "learning",
-        "summary": "Releasing Pilot: autopilot auto-cuts releases only on pilot/GH-* merges, so a manual fix/* PR sits on main unreleased. Manual release = push a v* tag (release.yml GoReleaser → Homebrew); do NOT also `make release`. Daemon runs ~/.local/bin/pilot (not make-install ~/go/bin, not brew) — update via `pilot upgrade`. Version string lags the commit; check `go version -m <bin> | grep vcs.revision`. File: learning_pilot_release_and_binary_path.md.",
+        "summary": "Releasing Pilot: autopilot auto-cuts releases only on pilot/GH-* merges, so a manual fix/* PR sits on main unreleased. Manual release = push a v* tag (release.yml GoReleaser \u2192 Homebrew); do NOT also `make release`. Daemon runs ~/.local/bin/pilot (not make-install ~/go/bin, not brew) \u2014 update via `pilot upgrade`. Version string lags the commit; check `go version -m <bin> | grep vcs.revision`. File: learning_pilot_release_and_binary_path.md.",
         "concepts": [
           "release",
           "autopilot",
@@ -461,7 +486,7 @@
       },
       "mem-021": {
         "type": "learning",
-        "summary": "Making a client method paginate (per_page+page until short page) silently breaks fixed-list httptest mocks that return the full list per request — they loop to maxPages (N×pages items) and starve callers, hanging tests to the 600s package timeout. C6/#3369 did this to the stress mocks. Fix: mocks return [] for page>=2, and ALWAYS bound test busy-waits with a deadline. A 600s 'FAIL <pkg>' with no '--- FAIL: Test' = a hang, not an assertion. File: learning_paginated_client_breaks_fixedlist_mocks.md (TASK-353).",
+        "summary": "Making a client method paginate (per_page+page until short page) silently breaks fixed-list httptest mocks that return the full list per request \u2014 they loop to maxPages (N\u00d7pages items) and starve callers, hanging tests to the 600s package timeout. C6/#3369 did this to the stress mocks. Fix: mocks return [] for page>=2, and ALWAYS bound test busy-waits with a deadline. A 600s 'FAIL <pkg>' with no '--- FAIL: Test' = a hang, not an assertion. File: learning_paginated_client_breaks_fixedlist_mocks.md (TASK-353).",
         "concepts": [
           "github-adapter",
           "testing",
@@ -472,7 +497,7 @@
       },
       "mem-022": {
         "type": "decision",
-        "summary": "Release pipeline is tag-only — goreleaser (release.yml) is the SOLE publisher. As of #3377 (after v2.166.6) `make release` only pushes the version tag; it no longer does a local `gh release create`, which had 422-collided with goreleaser and made it skip the Homebrew formula publish (bit v2.149.4 and v2.166.6). Never publish assets before goreleaser. File: decision_release_pipeline_tag_only.md.",
+        "summary": "Release pipeline is tag-only \u2014 goreleaser (release.yml) is the SOLE publisher. As of #3377 (after v2.166.6) `make release` only pushes the version tag; it no longer does a local `gh release create`, which had 422-collided with goreleaser and made it skip the Homebrew formula publish (bit v2.149.4 and v2.166.6). Never publish assets before goreleaser. File: decision_release_pipeline_tag_only.md.",
         "concepts": [
           "release",
           "homebrew",
@@ -521,7 +546,7 @@
       },
       "mem-026": {
         "type": "learning",
-        "summary": "The Pilot daemon's *finalization* path (push -> PR-create -> label) is the active reliability bottleneck — the *execution* path (Claude Code subprocess) is reliable. Studio-sdk extraction (PRs #28-#56, 2026-06-02/-03): 9/10 connectors shipped, but ~7/12 finalization runs needed manual recovery (Shape A stall-before-push), 2 hit a retry-race vs human recovery PRs (Shape B), 1 late-duplicate-PR (Shape C). The harness + review gates carried the outcome, not daemon finalization reliability. `no-decompose` label routes through the direct path (fatal error handling) instead of the epic path (warn-only) and was empirically reliable. Canonical fix: TASK-359 (3-layer plan: unified finalizeExecution MANUAL + 4 no-decompose Pilot issues for boundary fixes). RESOLUTION (2026-06-04): Shape A + C CLOSED & live-verified via TASK-359 Layer 1 (v2.166.16, studio-sdk #63/PR#64); Shape B (Layer 2b) + negative token-revoke shipped/unit-covered but not yet live-verified.",
+        "summary": "The Pilot daemon's *finalization* path (push -> PR-create -> label) is the active reliability bottleneck \u2014 the *execution* path (Claude Code subprocess) is reliable. Studio-sdk extraction (PRs #28-#56, 2026-06-02/-03): 9/10 connectors shipped, but ~7/12 finalization runs needed manual recovery (Shape A stall-before-push), 2 hit a retry-race vs human recovery PRs (Shape B), 1 late-duplicate-PR (Shape C). The harness + review gates carried the outcome, not daemon finalization reliability. `no-decompose` label routes through the direct path (fatal error handling) instead of the epic path (warn-only) and was empirically reliable. Canonical fix: TASK-359 (3-layer plan: unified finalizeExecution MANUAL + 4 no-decompose Pilot issues for boundary fixes). RESOLUTION (2026-06-04): Shape A + C CLOSED & live-verified via TASK-359 Layer 1 (v2.166.16, studio-sdk #63/PR#64); Shape B (Layer 2b) + negative token-revoke shipped/unit-covered but not yet live-verified.",
         "concepts": [
           "executor",
           "autopilot",
@@ -546,7 +571,7 @@
       },
       "mem-028": {
         "type": "learning",
-        "summary": "When grep for an alleged write API in internal/ returns zero, the root cause is external (config/another bot/GitHub workflow) — don't draft a Pilot fix",
+        "summary": "When grep for an alleged write API in internal/ returns zero, the root cause is external (config/another bot/GitHub workflow) \u2014 don't draft a Pilot fix",
         "concepts": [
           "task-investigation",
           "github-adapter",
@@ -559,7 +584,7 @@
       },
       "mem-029": {
         "type": "learning",
-        "summary": "For ad-hoc gh CLI writes to qf-studio (project board edits, etc.) use Pilot's PAT from ~/.pilot/config.yaml via GH_TOKEN env — OAuth refresh is silently blocked by SAML SSO",
+        "summary": "For ad-hoc gh CLI writes to qf-studio (project board edits, etc.) use Pilot's PAT from ~/.pilot/config.yaml via GH_TOKEN env \u2014 OAuth refresh is silently blocked by SAML SSO",
         "concepts": [
           "github-adapter",
           "auth",
@@ -572,7 +597,7 @@
       },
       "mem-030": {
         "type": "pitfall",
-        "summary": "maybeCloseParentIssue trusted native sub-issue open-count alone; partial LinkSubIssue coverage makes count hit 0 while unlinked siblings are open — parent closes pilot-done with no PR-merge verification (GH-3513). Fixed PR #3527: native 0 must be confirmed by text search.",
+        "summary": "maybeCloseParentIssue trusted native sub-issue open-count alone; partial LinkSubIssue coverage makes count hit 0 while unlinked siblings are open \u2014 parent closes pilot-done with no PR-merge verification (GH-3513). Fixed PR #3527: native 0 must be confirmed by text search.",
         "concepts": [
           "autopilot",
           "decomposition",
@@ -587,7 +612,7 @@
       },
       "mem-031": {
         "type": "pitfall",
-        "summary": "skipSupersededByParent superseded live children off parent.State==closed && pilot-done label — no merge verification; orphaned complete green PRs in GH-3513. Fixed PR #3527: open pilot/GH-N PR vetoes supersession.",
+        "summary": "skipSupersededByParent superseded live children off parent.State==closed && pilot-done label \u2014 no merge verification; orphaned complete green PRs in GH-3513. Fixed PR #3527: open pilot/GH-N PR vetoes supersession.",
         "concepts": [
           "autopilot",
           "poller",
@@ -602,7 +627,7 @@
       },
       "mem-032": {
         "type": "pitfall",
-        "summary": "inherited-spec:true children fetch the parent issue as their spec and re-implement the FULL feature — N redundant colliding PRs per epic (GH-3513). Fixed PR #3527 with a scope fence in subIssueBody(); sibling-branch PR base routing still unfixed.",
+        "summary": "inherited-spec:true children fetch the parent issue as their spec and re-implement the FULL feature \u2014 N redundant colliding PRs per epic (GH-3513). Fixed PR #3527 with a scope fence in subIssueBody(); sibling-branch PR base routing still unfixed.",
         "concepts": [
           "decomposition",
           "inherited-spec",
@@ -631,7 +656,7 @@
       },
       "mem-034": {
         "type": "pitfall",
-        "summary": "Subprocess without cmd.Dir: getPostExecutionSummary ran git in the daemon's CWD and reported the wrong repo's HEAD as the commit SHA — ghost guard then killed real worker commits (TASK-320 false no-ops) or recorded wrong-repo completed SHAs (TASK-355). One bug, both incident families. Fix v2.186.2: worktree git harvest first, summary pinned to executionPath. Lesson: every executor exec.Command must set cmd.Dir; never ask an LLM for what git answers deterministically.",
+        "summary": "Subprocess without cmd.Dir: getPostExecutionSummary ran git in the daemon's CWD and reported the wrong repo's HEAD as the commit SHA \u2014 ghost guard then killed real worker commits (TASK-320 false no-ops) or recorded wrong-repo completed SHAs (TASK-355). One bug, both incident families. Fix v2.186.2: worktree git harvest first, summary pinned to executionPath. Lesson: every executor exec.Command must set cmd.Dir; never ask an LLM for what git answers deterministically.",
         "concepts": [
           "executor",
           "commit-harvest",
@@ -646,7 +671,7 @@
       },
       "mem-035": {
         "type": "learning",
-        "summary": "GH-201 'OAuth loop' ghost issues (#3562-64, #3576) were created by the TEST SUITE: TestCreateSubIssues_ProceedsWhenNoChildren drives CreateSubIssues past the dedup guard with fixture parent GH-201 and executionPath='' — createSubIssuesViaGitHub has no dryRun guard, so authed gh creates real issues; sibling tests spawn the real claude binary. Teammate/shared-PAT attribution was wrong: tests stamp the same autopilot-meta markers and bypass the DB (zero rows proves test path, not remote actor). Lessons: stub the exec boundary in tests; dryRun must guard every side-effecting path; verify the spawner not the signature. Fix: #3579.",
+        "summary": "GH-201 'OAuth loop' ghost issues (#3562-64, #3576) were created by the TEST SUITE: TestCreateSubIssues_ProceedsWhenNoChildren drives CreateSubIssues past the dedup guard with fixture parent GH-201 and executionPath='' \u2014 createSubIssuesViaGitHub has no dryRun guard, so authed gh creates real issues; sibling tests spawn the real claude binary. Teammate/shared-PAT attribution was wrong: tests stamp the same autopilot-meta markers and bypass the DB (zero rows proves test path, not remote actor). Lessons: stub the exec boundary in tests; dryRun must guard every side-effecting path; verify the spawner not the signature. Fix: #3579.",
         "concepts": [
           "executor",
           "testing",
@@ -678,7 +703,7 @@
       },
       "mem-037": {
         "type": "pitfall",
-        "summary": "Autopilot orphans the LAST epic child PRs: the epic's execution run owns child-PR merging, so children whose PRs are created late are left created-but-unmerged when the run ends. The standalone auto-merge loop won't reclaim them because their tracking issues are already CLOSED (it thinks the work is done) — so green/CLEAN child PRs sit with ZERO autopilot review/comment even under stage's require_approval:false + auto_merge:true + green test/lint. Epic stays OPEN+pilot-in-progress; any 'Blocked by: #<epic>' dependent is gated forever via poller hasPendingDependencies. Recover: merge the orphans in order yourself, then close the epic to release dependents. Late siblings often CONFLICT once one merges (same wiring) — close the conflicted PR and re-dispatch only its UNIQUE remainder vs updated main, don't hand-resolve in root. Observed 2026-06-26 epic #3665 (bot module): merged #3670/#3674 mid-run, orphaned #3678/#3679. TASK-359 finalization shape.",
+        "summary": "Autopilot orphans the LAST epic child PRs: the epic's execution run owns child-PR merging, so children whose PRs are created late are left created-but-unmerged when the run ends. The standalone auto-merge loop won't reclaim them because their tracking issues are already CLOSED (it thinks the work is done) \u2014 so green/CLEAN child PRs sit with ZERO autopilot review/comment even under stage's require_approval:false + auto_merge:true + green test/lint. Epic stays OPEN+pilot-in-progress; any 'Blocked by: #<epic>' dependent is gated forever via poller hasPendingDependencies. Recover: merge the orphans in order yourself, then close the epic to release dependents. Late siblings often CONFLICT once one merges (same wiring) \u2014 close the conflicted PR and re-dispatch only its UNIQUE remainder vs updated main, don't hand-resolve in root. Observed 2026-06-26 epic #3665 (bot module): merged #3670/#3674 mid-run, orphaned #3678/#3679. TASK-359 finalization shape.",
         "concepts": [
           "autopilot",
           "epic-decomposition",
@@ -693,7 +718,7 @@
       },
       "mem-038": {
         "type": "pattern",
-        "summary": "Bot module dual-path: fast conversational path (~1-2s, direct LLM via Responder) vs executor path (~15-30s, Claude Code worktree). Intents: greeting/chat/question/issue-intake → Responder; task/research/planning → executor. Fallback guarantee: Responder nil (bot disabled) → identical-to-before executor path. Rate limit via AllowMessage() before all dispatch. Voice seam: VoiceText merged into text when Text empty. Test-at-the-seam lesson: tests must cross adapter→comms boundary (ref mem-036).",
+        "summary": "Bot module dual-path: fast conversational path (~1-2s, direct LLM via Responder) vs executor path (~15-30s, Claude Code worktree). Intents: greeting/chat/question/issue-intake \u2192 Responder; task/research/planning \u2192 executor. Fallback guarantee: Responder nil (bot disabled) \u2192 identical-to-before executor path. Rate limit via AllowMessage() before all dispatch. Voice seam: VoiceText merged into text when Text empty. Test-at-the-seam lesson: tests must cross adapter\u2192comms boundary (ref mem-036).",
         "concepts": [
           "comms-intent-dispatch",
           "executor",
@@ -706,7 +731,7 @@
       },
       "mem-039": {
         "type": "pitfall",
-        "summary": "Bot's direct LLM client (internal/llm/client.go) omitted required max_tokens and sent non-standard output_config{effort:low}, so every Anthropic Messages call 400'd ('max_tokens: Field required') and the bot replied 'Sorry, I couldn't process that.' Shipped GREEN because TestAnswer_RequestShape asserted output_config present and never checked max_tokens — the test encoded the bug. Diagnose request-shape bugs with curl (real key): code's request → 400, +max_tokens/-output_config → 200, in 2 calls. Fixed v2.200.1 (#3700): add max_tokens(2048), drop output_config, tests assert both. Lesson (again, see mem-036): assert the REQUIRED fields, not the optional ones.",
+        "summary": "Bot's direct LLM client (internal/llm/client.go) omitted required max_tokens and sent non-standard output_config{effort:low}, so every Anthropic Messages call 400'd ('max_tokens: Field required') and the bot replied 'Sorry, I couldn't process that.' Shipped GREEN because TestAnswer_RequestShape asserted output_config present and never checked max_tokens \u2014 the test encoded the bug. Diagnose request-shape bugs with curl (real key): code's request \u2192 400, +max_tokens/-output_config \u2192 200, in 2 calls. Fixed v2.200.1 (#3700): add max_tokens(2048), drop output_config, tests assert both. Lesson (again, see mem-036): assert the REQUIRED fields, not the optional ones.",
         "concepts": [
           "anthropic-api",
           "llm-integration",
@@ -722,7 +747,7 @@
       },
       "mem-040": {
         "type": "pitfall",
-        "summary": "Daemon hot-upgrades to the latest GitHub RELEASE and re-execs (pid preserved → ps lstart looks unchanged while the on-disk binary swaps). A dev binary cp'd to ~/.local/bin/pilot reverts within ~20min to the last release. A fix merged to main is NOT in the running daemon until a release containing it is cut (autopilot shouldTriggerRelease gap). Observed 2026-06-26: 29MB dev fix at 12:32 reverted to 20.6MB v2.200.0 release by 12:52, bot kept failing. Durable fix: tag-driven release (mem-022) with the fix → pilot upgrade (prompts y/N) → restart. v2.200.1 held because it's the latest release. Confirm running binary via lsof txt + stat size + pilot version, not lstart alone.",
+        "summary": "Daemon hot-upgrades to the latest GitHub RELEASE and re-execs (pid preserved \u2192 ps lstart looks unchanged while the on-disk binary swaps). A dev binary cp'd to ~/.local/bin/pilot reverts within ~20min to the last release. A fix merged to main is NOT in the running daemon until a release containing it is cut (autopilot shouldTriggerRelease gap). Observed 2026-06-26: 29MB dev fix at 12:32 reverted to 20.6MB v2.200.0 release by 12:52, bot kept failing. Durable fix: tag-driven release (mem-022) with the fix \u2192 pilot upgrade (prompts y/N) \u2192 restart. v2.200.1 held because it's the latest release. Confirm running binary via lsof txt + stat size + pilot version, not lstart alone.",
         "concepts": [
           "hot-upgrade",
           "release",
@@ -732,13 +757,13 @@
         "confidence": 0.9,
         "severity": "medium",
         "created": "2026-06-26",
-        "incident": "2026-06-26: shipping the bot max_tokens fix — dev binary installs (12:32) auto-reverted to pre-fix v2.200.0 release (12:52); only cutting v2.200.1 and pilot-upgrading made the fix stick in the live daemon.",
+        "incident": "2026-06-26: shipping the bot max_tokens fix \u2014 dev binary installs (12:32) auto-reverted to pre-fix v2.200.0 release (12:52); only cutting v2.200.1 and pilot-upgrading made the fix stick in the live daemon.",
         "file": ".agent/knowledge/memories/pitfalls/bug_daemon_autoupgrade_reverts_dev_binary.md",
         "origin_task": "TASK-374"
       },
       "mem-041": {
         "type": "pitfall",
-        "summary": "LLM intent classifier was doubly broken so the bot misrouted open-ended input. (1) classifier.go sent output_config{effort} → Haiku 400 'does not support the effort parameter' → every Classify failed → silent regex fallback (same class as mem-039; a test asserted output_config present). (2) Prompt routed 'draw/outline/show' as code TASK → heavy executor + dangling tasks. Fixed v2.200.2 (#3703): drop output_config; add DELIVERABLE TEST (answer/diagram→question/chat, change-code→task, file-ticket→issue_intake). Haiku now primary NL router, regex only guards /-commands. Validate classifier prompts via curl (TUI logs ungreppable). 8/8 live.",
+        "summary": "LLM intent classifier was doubly broken so the bot misrouted open-ended input. (1) classifier.go sent output_config{effort} \u2192 Haiku 400 'does not support the effort parameter' \u2192 every Classify failed \u2192 silent regex fallback (same class as mem-039; a test asserted output_config present). (2) Prompt routed 'draw/outline/show' as code TASK \u2192 heavy executor + dangling tasks. Fixed v2.200.2 (#3703): drop output_config; add DELIVERABLE TEST (answer/diagram\u2192question/chat, change-code\u2192task, file-ticket\u2192issue_intake). Haiku now primary NL router, regex only guards /-commands. Validate classifier prompts via curl (TUI logs ungreppable). 8/8 live.",
         "concepts": [
           "intent-routing",
           "anthropic-api",
@@ -753,7 +778,7 @@
       },
       "mem-042": {
         "type": "pitfall",
-        "summary": "Bot answers/issues hit the WRONG repo via two traps. (1) Intake (comms.IssueCreator) resolves owner/repo from a SINGLE hardwired NewIssueCreator entry = cfg.Adapters.GitHub.Repo; resolveRepo falls to repos[0] for unmatched paths, so intake ALWAYS targets adapters.github.repo and /switch doesn't change it. (2) The per-context active project is in-memory and RESETS to default_project on every daemon restart, so Q&A answers about the wrong repo until re-/switch'd. Demo fix: point default_project AND adapters.github.repo at the same repo (+ project_board.enabled:false for label polling). Proper fix: NewIssueCreator entry per cfg.Projects + persist active project across restarts. Board-source repos also need intake→board or label polling.",
+        "summary": "Bot answers/issues hit the WRONG repo via two traps. (1) Intake (comms.IssueCreator) resolves owner/repo from a SINGLE hardwired NewIssueCreator entry = cfg.Adapters.GitHub.Repo; resolveRepo falls to repos[0] for unmatched paths, so intake ALWAYS targets adapters.github.repo and /switch doesn't change it. (2) The per-context active project is in-memory and RESETS to default_project on every daemon restart, so Q&A answers about the wrong repo until re-/switch'd. Demo fix: point default_project AND adapters.github.repo at the same repo (+ project_board.enabled:false for label polling). Proper fix: NewIssueCreator entry per cfg.Projects + persist active project across restarts. Board-source repos also need intake\u2192board or label polling.",
         "concepts": [
           "conversational-bot",
           "intent-routing",
@@ -765,6 +790,22 @@
         "incident": "2026-06-26: Q&A answered studio-sdk not pilot; intake filed feat(api)/feat(gateway) issues on studio-sdk repeatedly despite /switch + default_project:pilot. Closed loop only after repointing adapters.github.repo to pilot.",
         "file": ".agent/knowledge/memories/pitfalls/bug_bot_active_project_and_intake_repo.md",
         "origin_task": "TASK-376"
+      },
+      "mem-043": {
+        "type": "pitfall",
+        "summary": "Child push/PR-create failure (runner.go ~:3560-3760) ran git push and gh pr create exactly once with no retry, and the only ref to committed work was the worktree branch deleted by the unconditional defer cleanupWorktree() on return. GH-3764 (6 commits, 616a3095..05c8271b) was stranded this way and salvaged manually into PR #3773; epic parent reported only a bare sha. Fix: bounded retry (3x, 300ms) on push/PR/MR creation, and on exhausted retries GitOperations.CreateRecoveryRef pins the commit under refs/pilot-recovery/<task-id> (a ref namespace that survives worktree removal), with the failing step name + stderr + branch/sha/recovery_ref folded into result.Error.",
+        "concepts": [
+          "epic-decomposition",
+          "git-operations",
+          "worktree-isolation",
+          "error-recovery"
+        ],
+        "confidence": 0.9,
+        "severity": "high",
+        "created": "2026-07-04",
+        "incident": "2026-07-03: GH-3764 child sub-issue completed 6 commits but push/PR step failed silently; no remote branch existed; commits survived only in shared local object store, salvaged manually into PR #3773 (TASK-382 defect D2).",
+        "file": ".agent/knowledge/memories/pitfalls/bug_child_push_pr_silent_stranding.md",
+        "origin_task": "GH-3785"
       }
     }
   },
@@ -1023,6 +1064,41 @@
       "from": "mem-042",
       "to": "mem-041",
       "type": "relates-to"
+    },
+    {
+      "from": "TASK-379",
+      "to": "doctor",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-379",
+      "to": "executor",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-379",
+      "to": "autopilot",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-379",
+      "to": "canary",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-379",
+      "to": "anthropic-api",
+      "type": "implements"
+    },
+    {
+      "from": "mem-043",
+      "to": "epic-decomposition",
+      "type": "describes"
+    },
+    {
+      "from": "mem-043",
+      "to": "worktree",
+      "type": "describes"
     }
   ]
 }

--- a/.agent/knowledge/memories/pitfalls/bug_child_push_pr_silent_stranding.md
+++ b/.agent/knowledge/memories/pitfalls/bug_child_push_pr_silent_stranding.md
@@ -1,0 +1,47 @@
+---
+name: child worker push/PR-create failure was un-retried and left committed work reachable only via a bare sha
+description: A sub-issue's push/PR step (internal/executor/runner.go, ~:3560-3760) ran git push and gh pr create exactly once each. On failure it set result.Success=false with a message that WAS informative (git.go wraps stderr via "%w: %s"), but there was no retry and no independent ref pinning the commit — the only recovery anchor was the branch inside the worktree, which the unconditional `defer cleanupWorktree()` (runner.go ~:1573) deletes on return. GH-3764's push/PR step failed silently in this way: 6 commits (616a3095..05c8271b) vanished from any reachable branch and had to be salvaged from the shared git object store manually into PR #3773.
+type: pitfall
+---
+**Symptom:** epic parent reports `sub-issue N committed work (sha X) but produced no PR` (the
+TASK-356 #1 work-loss guard, `internal/executor/epic.go` ~:1937) with no detail beyond the
+sha — or, for the non-decomposed direct path, the task just fails with `push failed: <err>` /
+`PR creation failed: <err>` and the worktree (and with it the only reachable ref to the
+commits) is deleted moments later by the unconditional `defer cleanupWorktree()`.
+
+**Root cause:** two independent gaps compounded:
+1. **No retry** on `git.Push` / `git.CreatePR` (`internal/executor/runner.go`) — a single
+   transient failure (network blip, API rate limit, momentary `gh` auth hiccup) was treated
+   as permanent.
+2. **No recovery anchor** — the branch created inside the worktree (`task.Branch`) is the
+   *only* ref to the commits until push succeeds. `WorktreeManager.cleanupWorktree`
+   (`internal/executor/worktree.go` ~:143) runs `git worktree remove --force` unconditionally
+   on return, and while branch refs themselves survive worktree removal (they live in the
+   shared repo, not the per-worktree admin area), nothing was pinning them independent of
+   task-retry bookkeeping — a later `git.DeleteBranch` on a "stale branch" recreate path, or
+   simple GC pressure, could still take them.
+
+**Fix (GH-3785):**
+- `git.Push` / `git.CreatePR` / `PRCreator.CreatePR` now retry up to `gitPushRetryAttempts` /
+  `prCreateRetryAttempts` (3, 300ms apart) before giving up.
+- On exhausted retries, `GitOperations.CreateRecoveryRef(ctx, taskID, fromRef)` pins the
+  commit under `refs/pilot-recovery/<sanitized-task-id>` — a ref namespace outside
+  `refs/heads/`, shared across worktrees, so it survives `git worktree remove` and stays
+  fetchable (`git fetch <repo> refs/pilot-recovery/<id>`) even if the branch itself is later
+  deleted. `formatGitStepFailureWithRecovery` (runner.go) puts the failing step name
+  (`push` / `pr-create` / `mr-create`), attempt count, raw stderr, and
+  `branch=... sha=... recovery_ref=...` into `result.Error` in one message.
+- The epic-level work-loss guard (epic.go ~:1937) also pins a recovery ref (via
+  `subTaskRepoPath`, using `refs/heads/<branch>` as the source since the epic runs outside
+  the child's worktree) so even the anomalous Success=true/no-PR path gets a real recovery
+  ref, not just a bare sha.
+
+**How to apply:** any future "child does X but the parent only reports a bare identifier"
+report is a signal to check whether the failing step (1) retries transient failures and
+(2) pins its output to a ref/anchor that survives normal cleanup, *before* assuming the
+step itself is broken — the step's own error may already be correct and just discarded.
+
+Related: [[bug_autopilot_epic_orphan_child_prs]] (a different epic work-loss shape — orphaned
+PRs rather than un-pushed commits), TASK-382 D2/D3 (siblings: D3/[GH-3786] fixed a false
+epic-parent-failure race via `reconcileChildOutcome`; this fix is the complementary
+"genuine push/PR failure must not be silent or unrecoverable" half).

--- a/.agent/tasks/gh-3785.md
+++ b/.agent/tasks/gh-3785.md
@@ -1,0 +1,49 @@
+# GH-3785
+
+**Created:** 2026-07-04
+
+## Problem
+
+GitHub Issue #3785: fix(executor): child worker commits work but push/PR step fails silently — work stranded in local odb
+
+## Context
+Defect D2 from TASK-382. Child GH-3764 completed its full implementation (6 commits, `616a3095..05c8271b`) but the push/PR step failed; parent reported `sub-issue 3764 committed work (sha 05c8271) but produced no PR`. No remote branch existed; the commits survived only in the shared local object store and were salvaged manually into PR #3773. Push/API auth was healthy at the time (a sibling worker created PR #3771 minutes later).
+
+## Investigate & fix
+- Root-cause the child push/PR path: why did push not happen/fail, and why silently (no error detail in the parent message beyond the sha)?
+- On push/PR failure with committed work: retry push+PR creation; if still failing, pin the sha (local ref or keep the worktree/branch) and include the exact push/PR error in the parent failure message and issue comment — the work must be recoverable and the cause visible.
+- Never delete a worktree containing unpushed committed work without leaving a recoverable ref.
+
+## Acceptance
+- [x] Simulated push failure after commit → retried; on persistent failure a recovery ref exists and the error names the failing step (push vs pr-create) with stderr
+- [x] Parent error message includes recovery instructions (branch/sha)
+- [x] make test && make lint pass
+
+## Resolution
+
+Root-caused: `git.Push` / `git.CreatePR` in `internal/executor/runner.go` ran exactly once
+with no retry, and the only ref to committed work was the worktree's own branch — deleted
+unconditionally by `defer cleanupWorktree()` on any return path. A transient push/PR failure
+was therefore both un-retried and effectively unrecoverable once the worktree was cleaned up.
+
+Fix:
+- `git.Push` / `git.CreatePR` / `PRCreator.CreatePR` now retry up to 3 times (300ms apart)
+  before giving up (`gitPushRetryAttempts`, `prCreateRetryAttempts` in runner.go).
+- On exhausted retries, `GitOperations.CreateRecoveryRef` (git.go) pins the commit under
+  `refs/pilot-recovery/<task-id>` — a ref namespace outside `refs/heads/` that survives
+  `git worktree remove`. `formatGitStepFailureWithRecovery` folds the failing step name
+  (push / pr-create / mr-create), attempt count, raw git/gh stderr, and
+  `branch=... sha=... recovery_ref=...` into `result.Error`.
+- The epic-level work-loss guard (`epic.go` ~:1937, `success=true` + no PR anomaly) also
+  now pins a recovery ref and includes the same recovery instructions in both the parent
+  progress comment and the returned error.
+
+Tests: `TestRunner_PRCreate_HasCommits_ProceedsToCreate` (runner_test.go) simulates a
+persistent push failure (no remote configured) and asserts the retried-step error format,
+recovery instructions, and that the recovery ref resolves in the repo. `TestCreateRecoveryRef`
+(git_test.go) covers ref creation, sanitization, HEAD default, and invalid-fromRef errors.
+
+Memory: `.agent/knowledge/memories/pitfalls/bug_child_push_pr_silent_stranding.md` (mem-043).
+
+## Acceptance Criteria
+

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1936,16 +1936,33 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 		// instead of the work vanishing behind a false "completed" record.
 		if result.PRUrl == "" && result.CommitSHA != "" {
 			shortSHA := result.CommitSHA[:min(7, len(result.CommitSHA))]
-			warnMsg := fmt.Sprintf("⚠️ %d/%d produced commits (%s) but no PR — work not delivered; leaving issue open for retry: %s",
-				i+1, total, shortSHA, issue.Subtask.Title)
+
+			// GH-3785: this branch only fires when the child reported success
+			// with no push/PR error at all (an anomaly the push/PR retry path
+			// above should now prevent in the common case) — pin the commit
+			// under a recovery ref from the shared repo so the recovery
+			// instructions below are backed by a ref that survives worktree
+			// cleanup, not just a bare sha.
+			recoveryGit := NewGitOperations(subTaskRepoPath)
+			recoveryRef, refErr := recoveryGit.CreateRecoveryRef(ctx, taskID, "refs/heads/"+subTask.Branch)
+			recovery := fmt.Sprintf("branch=%s sha=%s", subTask.Branch, shortSHA)
+			if refErr == nil && recoveryRef != "" {
+				recovery += fmt.Sprintf(" recovery_ref=%s", recoveryRef)
+			} else if refErr != nil {
+				recovery += fmt.Sprintf(" (recovery ref also failed: %v)", refErr)
+			}
+
+			warnMsg := fmt.Sprintf("⚠️ %d/%d produced commits (%s) but no PR — work not delivered; leaving issue open for retry: %s — recovery: %s",
+				i+1, total, shortSHA, issue.Subtask.Title, recovery)
 			_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, warnMsg)
 			r.log.Error("sub-issue committed work but produced no PR — refusing to discard",
 				"parent_id", parent.ID,
 				"sub_issue", issueRef,
 				"commit_sha", shortSHA,
 				"branch", subTask.Branch,
+				"recovery_ref", recoveryRef,
 			)
-			return childStates, fmt.Errorf("sub-issue %s committed work (sha %s) but produced no PR — work would be lost, halting epic", issueRef, shortSHA)
+			return childStates, fmt.Errorf("sub-issue %s committed work (sha %s) but produced no PR — work would be lost, halting epic — recovery: %s", issueRef, shortSHA, recovery)
 		}
 
 		// Register sub-issue PR with autopilot controller (GH-596)

--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -494,6 +494,31 @@ func (g *GitOperations) DeleteBranch(ctx context.Context, branchName string) err
 	return nil
 }
 
+// CreateRecoveryRef pins fromRef (typically "HEAD", or "refs/heads/<branch>"
+// when called from outside the worktree that made the commits) under a
+// dedicated ref namespace (refs/pilot-recovery/<taskID>) so committed work
+// survives even if push/PR creation never succeeds and the worktree is
+// later removed. Unlike a worktree's own branch, this ref lives in the
+// shared repository (not the per-worktree admin area), so `git worktree
+// remove` cannot take it with it — the commit stays reachable via `git
+// fetch <repo> <returned-ref>` or `git show <sha>` from the main repo.
+// GH-3785: prevents child-worker commits from being stranded in the object
+// store with no reachable ref once a push/PR failure leads to worktree
+// cleanup.
+func (g *GitOperations) CreateRecoveryRef(ctx context.Context, taskID, fromRef string) (string, error) {
+	if fromRef == "" {
+		fromRef = "HEAD"
+	}
+	refName := "refs/pilot-recovery/" + sanitizeBranchName(taskID)
+	cmd := exec.CommandContext(ctx, "git", "update-ref", refName, fromRef)
+	cmd.Dir = g.projectPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to create recovery ref %s: %w: %s", refName, err, output)
+	}
+	return refName, nil
+}
+
 // GitDiff holds numstat output from `git diff --numstat origin/main...HEAD`.
 type GitDiff struct {
 	// Files is the list of changed file paths.

--- a/internal/executor/git_test.go
+++ b/internal/executor/git_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -843,4 +844,92 @@ func TestCommitScopedStaging(t *testing.T) {
 			t.Error("node_modules/some-pkg/bin.js should remain untracked after commit")
 		}
 	})
+}
+
+// TestCreateRecoveryRef verifies GH-3785's recovery-ref mechanism: a commit
+// pinned under refs/pilot-recovery/<taskID> resolves to the expected sha,
+// survives being looked up independent of any branch, and sanitizes the
+// task ID into a safe ref path.
+func TestCreateRecoveryRef(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "pilot-git-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	ctx := context.Background()
+	_ = exec.CommandContext(ctx, "git", "-C", tmpDir, "init").Run()
+	_ = exec.CommandContext(ctx, "git", "-C", tmpDir, "config", "user.email", "test@test.com").Run()
+	_ = exec.CommandContext(ctx, "git", "-C", tmpDir, "config", "user.name", "Test User").Run()
+	_ = os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte("initial"), 0644)
+	_ = exec.CommandContext(ctx, "git", "-C", tmpDir, "add", ".").Run()
+	_ = exec.CommandContext(ctx, "git", "-C", tmpDir, "commit", "-m", "initial").Run()
+
+	headSHA, err := exec.CommandContext(ctx, "git", "-C", tmpDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("failed to resolve HEAD: %v", err)
+	}
+	wantSHA := trimNewline(string(headSHA))
+
+	git := NewGitOperations(tmpDir)
+
+	t.Run("pins HEAD under a stable ref name", func(t *testing.T) {
+		refName, err := git.CreateRecoveryRef(ctx, "GH-3764", "HEAD")
+		if err != nil {
+			t.Fatalf("CreateRecoveryRef failed: %v", err)
+		}
+		if refName != "refs/pilot-recovery/GH-3764" {
+			t.Errorf("refName = %q, want refs/pilot-recovery/GH-3764", refName)
+		}
+
+		resolved, err := exec.CommandContext(ctx, "git", "-C", tmpDir, "rev-parse", refName).Output()
+		if err != nil {
+			t.Fatalf("recovery ref did not resolve: %v", err)
+		}
+		if trimNewline(string(resolved)) != wantSHA {
+			t.Errorf("recovery ref resolved to %q, want %q", trimNewline(string(resolved)), wantSHA)
+		}
+	})
+
+	t.Run("sanitizes unsafe task IDs", func(t *testing.T) {
+		refName, err := git.CreateRecoveryRef(ctx, "weird/task id!", "HEAD")
+		if err != nil {
+			t.Fatalf("CreateRecoveryRef failed: %v", err)
+		}
+		if strings.ContainsAny(refName, " !") {
+			t.Errorf("refName not sanitized: %q", refName)
+		}
+	})
+
+	t.Run("defaults empty fromRef to HEAD", func(t *testing.T) {
+		refName, err := git.CreateRecoveryRef(ctx, "GH-9000", "")
+		if err != nil {
+			t.Fatalf("CreateRecoveryRef failed: %v", err)
+		}
+		resolved, err := exec.CommandContext(ctx, "git", "-C", tmpDir, "rev-parse", refName).Output()
+		if err != nil {
+			t.Fatalf("recovery ref did not resolve: %v", err)
+		}
+		if trimNewline(string(resolved)) != wantSHA {
+			t.Errorf("recovery ref resolved to %q, want %q", trimNewline(string(resolved)), wantSHA)
+		}
+	})
+
+	t.Run("fails cleanly on invalid fromRef", func(t *testing.T) {
+		_, err := git.CreateRecoveryRef(ctx, "GH-9001", "refs/heads/does-not-exist")
+		if err == nil {
+			t.Fatal("expected error for nonexistent fromRef, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to create recovery ref") {
+			t.Errorf("error missing context: %v", err)
+		}
+	})
+}
+
+func trimNewline(s string) string {
+	return strings.TrimRight(s, "\n")
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -54,6 +54,43 @@ func IsPermanentFailure(errStr string) bool {
 	return false
 }
 
+// gitPushRetryAttempts / gitPushRetryDelay and prCreateRetryAttempts /
+// prCreateRetryDelay bound the retry loops around the child push/PR-create
+// step (GH-3785). Prior behavior gave up on the first transient failure,
+// leaving committed work reachable only via a bare sha in the parent's
+// failure message. A short bounded retry absorbs transient network/API
+// blips without materially slowing down a genuine, persistent failure.
+const (
+	gitPushRetryAttempts  = 3
+	gitPushRetryDelay     = 300 * time.Millisecond
+	prCreateRetryAttempts = 3
+	prCreateRetryDelay    = 300 * time.Millisecond
+)
+
+// formatGitStepFailureWithRecovery builds the result.Error string for a
+// push or PR-create step that exhausted its retries while committed work
+// still sits in the worktree. It pins the current HEAD under a
+// refs/pilot-recovery/<task-id> ref (GitOperations.CreateRecoveryRef) so
+// cleanup can never garbage-collect the commits, then names the failing
+// step, the attempt count, and the raw stderr (already embedded in stepErr
+// via GitOperations' "%w: %s" wrapping) alongside recovery instructions —
+// branch name, sha, and the pinned ref — so the parent failure message and
+// issue comment are actionable instead of a bare sha. GH-3785.
+func formatGitStepFailureWithRecovery(ctx context.Context, git *GitOperations, step string, attempts int, stepErr error, taskID, branch, sha string) string {
+	recoveryRef, refErr := git.CreateRecoveryRef(ctx, taskID, "HEAD")
+	shortSHA := sha
+	if len(shortSHA) > 7 {
+		shortSHA = shortSHA[:7]
+	}
+	recovery := fmt.Sprintf("branch=%s sha=%s", branch, shortSHA)
+	if refErr == nil && recoveryRef != "" {
+		recovery += fmt.Sprintf(" recovery_ref=%s", recoveryRef)
+	} else if refErr != nil {
+		recovery += fmt.Sprintf(" (recovery ref also failed: %v)", refErr)
+	}
+	return fmt.Sprintf("%s failed after %d attempt(s): %v — recovery: %s", step, attempts, stepErr, recovery)
+}
+
 // Non-failure terminal-outcome signatures. The dispatcher classifies an execution
 // by the deterministic fragments the runner (or its subprocess) writes to
 // result.Error, so the dashboard's "failed" count reflects genuine task failures
@@ -3531,21 +3568,40 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					}
 				}
 			}
-			// Push branch
-			if err := git.Push(ctx, task.Branch); err != nil {
+			// Push branch — retry transient failures before declaring the work
+			// stranded (GH-3785: a single failed push previously produced a
+			// silent "committed work but no PR" report with no detail).
+			var pushErr error
+			for attempt := 1; attempt <= gitPushRetryAttempts; attempt++ {
+				pushErr = git.Push(ctx, task.Branch)
+				if pushErr == nil {
+					break
+				}
 				// GH-1389: Worktree push may fail with chdir error even if data was already pushed.
 				// Check if branch exists on remote before declaring failure.
 				if git.RemoteBranchExists(ctx, task.Branch) {
 					log.Warn("Push reported error but branch exists on remote, continuing",
-						slog.Any("error", err),
+						slog.Any("error", pushErr),
 						slog.String("branch", task.Branch),
 					)
-				} else {
-					result.Success = false
-					result.Error = fmt.Sprintf("push failed: %v", err)
-					r.reportProgress(task.ID, "PR Failed", 100, result.Error)
-					return result, nil
+					pushErr = nil
+					break
 				}
+				if attempt < gitPushRetryAttempts {
+					log.Warn("Push failed, retrying",
+						slog.String("task_id", task.ID),
+						slog.Int("attempt", attempt),
+						slog.Int("max_attempts", gitPushRetryAttempts),
+						slog.Any("error", pushErr),
+					)
+					time.Sleep(gitPushRetryDelay)
+				}
+			}
+			if pushErr != nil {
+				result.Success = false
+				result.Error = formatGitStepFailureWithRecovery(ctx, git, "push", gitPushRetryAttempts, pushErr, task.ID, task.Branch, result.CommitSHA)
+				r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+				return result, nil
 			}
 
 			// GH-457: Use actual pushed HEAD as CommitSHA source of truth.
@@ -3649,11 +3705,28 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					closeKeyword = fmt.Sprintf("\n\nCloses #%s", task.SourceIssueID)
 				}
 				prBody := fmt.Sprintf("## Summary\n\nAutomated MR created by Pilot for task %s.%s\n\n## Changes\n\n%s", task.ID, closeKeyword, task.Description)
+				// Retry MR creation before giving up (GH-3785): the branch is
+				// already pushed at this point, so a transient API failure here
+				// must not strand delivered commits behind a bare error.
 				var createErr error
-				prURL, createErr = r.prCreator.CreatePR(ctx, task.Branch, baseBranch, prTitle, prBody)
+				for attempt := 1; attempt <= prCreateRetryAttempts; attempt++ {
+					prURL, createErr = r.prCreator.CreatePR(ctx, task.Branch, baseBranch, prTitle, prBody)
+					if createErr == nil {
+						break
+					}
+					if attempt < prCreateRetryAttempts {
+						log.Warn("MR creation failed, retrying",
+							slog.String("task_id", task.ID),
+							slog.Int("attempt", attempt),
+							slog.Int("max_attempts", prCreateRetryAttempts),
+							slog.Any("error", createErr),
+						)
+						time.Sleep(prCreateRetryDelay)
+					}
+				}
 				if createErr != nil {
 					result.Success = false
-					result.Error = fmt.Sprintf("MR creation failed: %v", createErr)
+					result.Error = formatGitStepFailureWithRecovery(ctx, git, "mr-create", prCreateRetryAttempts, createErr, task.ID, task.Branch, result.CommitSHA)
 					r.reportProgress(task.ID, "MR Failed", 100, result.Error)
 					return result, nil
 				}
@@ -3661,11 +3734,27 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				// GitHub: use gh CLI with auto-close keyword
 				issueNum := strings.TrimPrefix(task.ID, "GH-")
 				prBody := fmt.Sprintf("## Summary\n\nAutomated PR created by Pilot for task %s.\n\nCloses #%s\n\n## Changes\n\n%s", task.ID, issueNum, task.Description)
+				// Retry PR creation before giving up (GH-3785): same rationale as
+				// the MR-creator branch above — the branch is already pushed.
 				var createErr error
-				prURL, createErr = git.CreatePR(ctx, prTitle, prBody, baseBranch)
+				for attempt := 1; attempt <= prCreateRetryAttempts; attempt++ {
+					prURL, createErr = git.CreatePR(ctx, prTitle, prBody, baseBranch)
+					if createErr == nil {
+						break
+					}
+					if attempt < prCreateRetryAttempts {
+						log.Warn("PR creation failed, retrying",
+							slog.String("task_id", task.ID),
+							slog.Int("attempt", attempt),
+							slog.Int("max_attempts", prCreateRetryAttempts),
+							slog.Any("error", createErr),
+						)
+						time.Sleep(prCreateRetryDelay)
+					}
+				}
 				if createErr != nil {
 					result.Success = false
-					result.Error = fmt.Sprintf("PR creation failed: %v", createErr)
+					result.Error = formatGitStepFailureWithRecovery(ctx, git, "pr-create", prCreateRetryAttempts, createErr, task.ID, task.Branch, result.CommitSHA)
 					r.reportProgress(task.ID, "PR Failed", 100, result.Error)
 					return result, nil
 				}

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3672,6 +3672,13 @@ func TestRunner_PRCreate_EmptyBranch_TriggersRetry(t *testing.T) {
 // does NOT fire when the branch has commits, allowing PR creation to proceed past
 // the guard. Execution reaches the push step (which fails without a remote),
 // confirming the guard was not the source of failure.
+//
+// GH-3785: this also doubles as the "simulated push failure after commit"
+// acceptance test — no remote is configured, so every retry attempt fails
+// the same way, exhausting gitPushRetryAttempts. The assertions verify the
+// retried push names its step ("push"), includes the underlying git stderr,
+// and leaves a recovery ref pinning the commit so it survives worktree
+// cleanup.
 func TestRunner_PRCreate_HasCommits_ProceedsToCreate(t *testing.T) {
 	const branch = "pilot/GH-9998"
 	dir := setupPRGuardRepo(t, branch, true) // one commit on branch
@@ -3705,10 +3712,33 @@ func TestRunner_PRCreate_HasCommits_ProceedsToCreate(t *testing.T) {
 	if strings.HasPrefix(result.Error, "no_changes:") {
 		t.Errorf("Guard fired unexpectedly on branch with commits: %q", result.Error)
 	}
-	// Error comes from the push step (no remote configured), proving execution
-	// proceeded past both the no-commit check and the GH-2743 guard.
-	if !strings.HasPrefix(result.Error, "push failed:") {
-		t.Errorf("Expected push failed error (guard passed), got: %q", result.Error)
+	// Error names the failing step and attempt count (guard passed, retries exhausted).
+	wantPrefix := fmt.Sprintf("push failed after %d attempt(s):", gitPushRetryAttempts)
+	if !strings.HasPrefix(result.Error, wantPrefix) {
+		t.Errorf("Expected push-failed-after-retries error, got: %q", result.Error)
+	}
+	// Underlying git stderr ("No configured push destination" or similar) must
+	// survive into the message, not just a generic wrapper.
+	if !strings.Contains(result.Error, "push") {
+		t.Errorf("Expected git stderr detail in error, got: %q", result.Error)
+	}
+	// Recovery instructions (branch + sha) must be present for the parent/issue comment.
+	if !strings.Contains(result.Error, "recovery: branch="+branch) {
+		t.Errorf("Expected recovery instructions with branch name, got: %q", result.Error)
+	}
+	if !strings.Contains(result.Error, "recovery_ref=refs/pilot-recovery/GH-9998") {
+		t.Errorf("Expected recovery_ref in error, got: %q", result.Error)
+	}
+
+	// The recovery ref must actually exist in the repo and resolve to a commit,
+	// proving the work is recoverable even though push never succeeded.
+	verifyCmd := exec.Command("git", "-C", dir, "rev-parse", "refs/pilot-recovery/GH-9998")
+	out, verifyErr := verifyCmd.Output()
+	if verifyErr != nil {
+		t.Fatalf("recovery ref not found in repo: %v", verifyErr)
+	}
+	if strings.TrimSpace(string(out)) == "" {
+		t.Error("recovery ref resolved to empty sha")
 	}
 }
 


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3785.

Closes #3785

## Changes

GitHub Issue #3785: fix(executor): child worker commits work but push/PR step fails silently — work stranded in local odb

## Context
Defect D2 from TASK-382. Child GH-3764 completed its full implementation (6 commits, `616a3095..05c8271b`) but the push/PR step failed; parent reported `sub-issue 3764 committed work (sha 05c8271) but produced no PR`. No remote branch existed; the commits survived only in the shared local object store and were salvaged manually into PR #3773. Push/API auth was healthy at the time (a sibling worker created PR #3771 minutes later).

## Investigate & fix
- Root-cause the child push/PR path: why did push not happen/fail, and why silently (no error detail in the parent message beyond the sha)?
- On push/PR failure with committed work: retry push+PR creation; if still failing, pin the sha (local ref or keep the worktree/branch) and include the exact push/PR error in the parent failure message and issue comment — the work must be recoverable and the cause visible.
- Never delete a worktree containing unpushed committed work without leaving a recoverable ref.

## Acceptance
- [ ] Simulated push failure after commit → retried; on persistent failure a recovery ref exists and the error names the failing step (push vs pr-create) with stderr
- [ ] Parent error message includes recovery instructions (branch/sha)
- [ ] make test && make lint pass