### PR TITLE
fix(autopilot): apply rate-limit cooldown to ScanRecentlyMergedPRs (GH-3784)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -305,7 +305,6 @@
 | Gateway WebSocket | ✅ | gateway | - | - | Session management active in gateway |
 | Health checks | ✅ | health | `pilot doctor` | - | System validation, 32 unit tests |
 | Agent doc size check | ✅ | health | `pilot doctor` | - | Warns >500 lines, errors >1000 lines per .agent/*.md (GH-2462) |
-| Adapter Verifiable wiring | ✅ | health, gateway, cmd/pilot | `pilot doctor` | - | Per-adapter `Verify(ctx)` live probes wired into doctor red-checks, `/ready` readiness checkers, and a concurrent daemon-startup preflight that alerts (non-blocking) on failure (v2.207.0, GH-3769) |
 | OpenCode backend | ✅ | executor | `--backend opencode` | `executor.backend` | HTTP/SSE alternative to Claude Code |
 | OpenAI-compatible direct backend | ✅ | executor | `type: openai-api` | `executor.openai` | Direct /v1/chat/completions for OpenAI, OpenRouter, Groq, Synthetic, vLLM, Ollama (v2.105.0, GH-2382) |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
@@ -403,6 +402,7 @@
 | Board sync owner guard | ✅ | adapters/github | - | - | Guard owner extraction in board sync construction (v2.30.0, PR #1871) |
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
+| Rate-limit-aware PR loop backoff | ✅ | autopilot | - | - | processAllPRs + orphan-PR reconciler enter a bounded cooldown on GitHub 403 rate-limit instead of re-hitting the API every tick; poller logs Warn (not Info) when a created PR has no autopilot callback wired (v2.207.3, GH-3784) |
 
 ## Epic Management
 

--- a/.agent/tasks/gh-3784.md
+++ b/.agent/tasks/gh-3784.md
@@ -1,0 +1,64 @@
+# GH-3784
+
+**Created:** 2026-07-04
+
+## Problem
+
+GitHub Issue #3784: fix(autopilot): PRs created after daemon restart are never tracked — green PRs strand unmerged
+
+## Context
+Defect D1 from TASK-382 (`.agent/tasks/TASK-382-restart-epic-defect-burndown.md`). After the 2026-07-03 ~18:00 UTC daemon restart (v2.206.1), autopilot's boot recovery correctly merged the pre-existing PR #3776 (18:06), then went silent: PRs #3778 (created 18:36), #3781, #3782 all reached green CI + MERGEABLE and sat untracked — no `autopilot_pr_state` row, no merge — until manually merged. Last autopilot-driven merge was 18:08.
+
+## Investigate & fix
+- Whether `OnPRCreated` callbacks (wired in `cmd/pilot/main.go`, consumed by `internal/autopilot/controller.go:468`) are registered on the post-restart poller/runner instances.
+- Add a defensive periodic sweep: discover open `pilot/GH-*` PRs with no tracked state (client methods `SearchOpenPRsForIssue`/`FindOpenPRByBranch` exist) and adopt them — self-heals any future tracking loss.
+- Fail loud: if a PR-created event has no autopilot to deliver to, log Warn.
+
+## Acceptance
+- [x] PR created post-restart gets tracked and auto-merged on green CI
+- [x] Untracked open pilot PRs adopted by sweep within one interval, with INFO log
+- [x] Regression test for callback registration across restart-shaped reconstruction
+- [x] make test && make lint pass
+
+## Root cause (from `~/.pilot/logs/daemon.log`, 2026-07-03 evening)
+
+The stated hypothesis (missing `OnPRCreated` wiring) did not match the evidence:
+- `OnPRCreated` wiring in `cmd/pilot/main.go` (polling: line ~2296/2536, gateway:
+  ~860/862) is unconditional on every process boot — restart or not — and was
+  confirmed correct by both `internal/wiring` harnesses.
+- The periodic orphan-PR reconciler (`Controller.reconcileOrphanPRs`, GH-3113,
+  merged 2026-05-26) already existed and self-healed PR #3782 in the real
+  incident at 22:12:49 (registered via reconciler 7 min before its CI passed).
+- PRs #3778 and #3781 *were* registered immediately via `OnPRCreated` at PR
+  creation (`"PR registered for autopilot"` in the logs). #3778 progressed all
+  the way to `awaiting_approval` and was human-approved at 20:59:30.
+
+The actual defect: a sustained GitHub primary-rate-limit window (`403 API rate
+limit exceeded`, ~40-70 minutes) hit `processAllPRs`'s `GetPullRequest` call on
+every 10-60s tick, for every tracked PR, with no backoff — `continue`ing to the
+next PR and retrying the exhausted quota on the very next tick instead of
+waiting it out. The approved PR could not progress past its next tick because
+every tick's cheapest possible action (fetch the PR) failed. Both #3778 and
+#3781 only resolved because a human ran `gh pr merge` externally; autopilot's
+own merge path never fired during the outage window.
+
+## Fix
+
+- `internal/autopilot/controller.go`: added `rateLimitCooldownActive()` /
+  `enterRateLimitCooldown()` (bounded 30s-20m off `*github.RateLimitError`'s
+  parsed `Retry-After`/`X-RateLimit-Reset`). `processAllPRs` now stops
+  iterating further PRs on the tick that hits a rate limit (instead of
+  `continue`, which re-hit the exhausted quota for every other tracked PR);
+  `reconcileOrphanPRs` skips its `ListPullRequests` call during the same
+  cooldown window.
+- `internal/autopilot/controller.go`: reconciler's orphan-adoption log moved
+  from Warn to Info (self-heal working as designed, not an anomaly).
+- `internal/adapters/github/poller.go`: both `OnPRCreated`-not-wired
+  diagnostics (sequential + parallel paths) elevated Info → Warn — a PR that
+  exists with no autopilot to track it is a structural problem, not routine.
+- Regression tests: `internal/autopilot/controller_ratelimit_test.go` (cooldown
+  entry/bounds, no repeated API calls during cooldown),
+  `internal/wiring/callback_test.go` `TestOnPRCreatedWiredAcrossRestartShapedReconstruction`
+  (fresh Runner+Controller pair against the same GitHub state adopts a PR that
+  was already open with no local tracking state).
+

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -719,9 +719,13 @@ func (p *Poller) startSequential(ctx context.Context) {
 				slog.String("head_sha", result.HeadSHA),
 			)
 		} else if p.OnPRCreated == nil {
-			p.logger.Info("OnPRCreated skipped: callback not wired",
+			// GH-3784: a real PR exists but no autopilot controller is wired to
+			// track it — it will never auto-merge unless the periodic orphan-PR
+			// reconciler (or a human) picks it up. Fail loud, not Info.
+			p.logger.Warn("OnPRCreated skipped: PR created but no autopilot callback wired",
 				slog.Int("pr_number", result.PRNumber),
 				slog.Int("issue_number", issue.Number),
+				slog.String("branch", result.BranchName),
 			)
 		}
 		// Gate: PRNumber > 0 implies executor surfaced a valid PR URL via runner.go:3151. Empty PRUrl (no-commits guard, push-fail, title-rejection) leaves PRNumber=0 and we silently skip — see TASK-60 for the upstream chain.
@@ -1496,9 +1500,13 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 						slog.String("head_sha", result.HeadSHA),
 					)
 				} else if p.OnPRCreated == nil {
-					p.logger.Info("OnPRCreated skipped: callback not wired",
+					// GH-3784: a real PR exists but no autopilot controller is wired to
+					// track it — it will never auto-merge unless the periodic orphan-PR
+					// reconciler (or a human) picks it up. Fail loud, not Info.
+					p.logger.Warn("OnPRCreated skipped: PR created but no autopilot callback wired",
 						slog.Int("pr_number", result.PRNumber),
 						slog.Int("issue_number", issue.Number),
+						slog.String("branch", result.BranchName),
 					)
 				}
 				// Gate: PRNumber > 0 implies executor surfaced a valid PR URL via runner.go:3151. Empty PRUrl (no-commits guard, push-fail, title-rejection) leaves PRNumber=0 and we silently skip — see TASK-60 for the upstream chain.

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -220,6 +220,13 @@ type Controller struct {
 	// cachedBotLogin holds the authenticated GitHub login for the Pilot token.
 	// Populated lazily by getBotLogin; protected by mu. GH-3417.
 	cachedBotLogin string
+
+	// rateLimitedUntil holds off processAllPRs/reconcileOrphanPRs/ScanRecentlyMergedPRs
+	// after a GitHub primary-rate-limit response, instead of re-hitting the API on every
+	// PR on every tick until quota resets. Protected by mu. GH-3784: a sustained rate-limit
+	// window with no backoff left green, approved PRs unmerged for over an hour because
+	// every tick burned through the exhausted quota re-fetching every tracked PR.
+	rateLimitedUntil time.Time
 }
 
 // NewController creates an autopilot controller with all required components.
@@ -2752,8 +2759,19 @@ func (c *Controller) startReconciler(ctx context.Context) {
 // fired — e.g. the executor returned pr_url="" or the poller gate filtered it.
 // The function is idempotent and safe to call concurrently with processAllPRs.
 func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
+	if c.rateLimitCooldownActive() {
+		return
+	}
+
 	prs, err := c.ghClient.ListPullRequests(ctx, c.owner, c.repo, "open")
 	if err != nil {
+		var rlErr *github.RateLimitError
+		if errors.As(err, &rlErr) {
+			wait := c.enterRateLimitCooldown(rlErr.RetryAfter)
+			c.log.Warn("reconciler: GitHub rate limit hit, pausing orphan-PR sweep until cooldown elapses",
+				"cooldown", wait, "error", err)
+			return
+		}
 		c.log.Warn("reconciler: failed to list open PRs", "error", err)
 		return
 	}
@@ -2776,7 +2794,9 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 			continue
 		}
 
-		c.log.Warn("reconciler: registering orphan PR",
+		// GH-3784: adopting an orphan PR within the 60s sweep interval is the
+		// self-heal working as designed, not an anomaly — log at Info.
+		c.log.Info("reconciler: adopting untracked open PR",
 			"pr", pr.Number,
 			"branch", pr.Head.Ref,
 			"issue", issueNum,
@@ -3063,8 +3083,46 @@ func (c *Controller) Run(ctx context.Context) error {
 	}
 }
 
+// rateLimitCooldownActive reports whether a prior GitHub primary-rate-limit
+// response is still within its backoff window. GH-3784.
+func (c *Controller) rateLimitCooldownActive() bool {
+	c.mu.RLock()
+	until := c.rateLimitedUntil
+	c.mu.RUnlock()
+	return time.Now().Before(until)
+}
+
+// enterRateLimitCooldown records a backoff window so processAllPRs and
+// reconcileOrphanPRs stop re-hitting the GitHub API on every tracked PR every
+// tick and instead wait out the reported quota reset. Returns the (bounded)
+// cooldown actually applied, for logging.
+//
+// GH-3784: PRs #3778/#3781 sat approved-and-green for 40-80 minutes because a
+// sustained "API rate limit exceeded" 403 window had no backoff — every 10-60s
+// tick re-fetched every tracked PR, burning the little quota headroom that
+// existed and extending the outage instead of waiting it out.
+func (c *Controller) enterRateLimitCooldown(retryAfter time.Duration) time.Duration {
+	const minCooldown = 30 * time.Second
+	const maxCooldown = 20 * time.Minute
+	if retryAfter < minCooldown {
+		retryAfter = minCooldown
+	}
+	if retryAfter > maxCooldown {
+		retryAfter = maxCooldown
+	}
+	c.mu.Lock()
+	c.rateLimitedUntil = time.Now().Add(retryAfter)
+	c.mu.Unlock()
+	return retryAfter
+}
+
 // processAllPRs processes all active PRs in one iteration.
 func (c *Controller) processAllPRs(ctx context.Context) {
+	if c.rateLimitCooldownActive() {
+		c.log.Debug("processAllPRs: skipping tick, GitHub rate-limit cooldown active")
+		return
+	}
+
 	prs := c.GetActivePRs()
 
 	// Update active PR gauges every tick
@@ -3101,6 +3159,13 @@ func (c *Controller) processAllPRs(ctx context.Context) {
 			// Fetch PR once, use twice - cache to avoid redundant API calls
 			ghPR, err := c.ghClient.GetPullRequest(ctx, c.owner, c.repo, pr.PRNumber)
 			if err != nil {
+				var rlErr *github.RateLimitError
+				if errors.As(err, &rlErr) {
+					wait := c.enterRateLimitCooldown(rlErr.RetryAfter)
+					c.log.Warn("processAllPRs: GitHub rate limit hit, pausing PR processing until cooldown elapses",
+						"pr", pr.PRNumber, "cooldown", wait, "error", err)
+					return
+				}
 				c.log.Warn("failed to fetch PR", "pr", pr.PRNumber, "error", err)
 				continue
 			}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -221,11 +221,12 @@ type Controller struct {
 	// Populated lazily by getBotLogin; protected by mu. GH-3417.
 	cachedBotLogin string
 
-	// rateLimitedUntil holds off processAllPRs/reconcileOrphanPRs/ScanRecentlyMergedPRs
-	// after a GitHub primary-rate-limit response, instead of re-hitting the API on every
-	// PR on every tick until quota resets. Protected by mu. GH-3784: a sustained rate-limit
-	// window with no backoff left green, approved PRs unmerged for over an hour because
-	// every tick burned through the exhausted quota re-fetching every tracked PR.
+	// rateLimitedUntil holds off processAllPRs, reconcileOrphanPRs, and
+	// ScanRecentlyMergedPRs after a GitHub primary-rate-limit response,
+	// instead of re-hitting the API on every tick until quota resets.
+	// Protected by mu. GH-3784: a sustained rate-limit window with no backoff
+	// left green, approved PRs unmerged for over an hour because every tick
+	// burned through the exhausted quota re-fetching every tracked PR.
 	rateLimitedUntil time.Time
 }
 
@@ -2811,6 +2812,14 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 // autopilot (e.g. via `gh pr merge` or the GitHub UI).
 // Called on startup and periodically from the Run loop.
 func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
+	// GH-3784: honor the same rate-limit cooldown as processAllPRs/reconcileOrphanPRs.
+	// This scan's own cadence (5+ min) is already gentle, but a cooldown opened by
+	// one of the hot loops can still span into this tick — skip rather than add
+	// another failing call on top of an active outage.
+	if c.rateLimitCooldownActive() {
+		return nil
+	}
+
 	// Run the scan unconditionally — it covers self-heal + merge metrics even when
 	// neither auto-release nor board sync is enabled (e.g. a plain GH-issue-source
 	// deployment). Internal gates below handle release-trigger and board-writeback
@@ -2832,6 +2841,13 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 	// List closed PRs
 	prs, err := c.ghClient.ListPullRequests(ctx, c.owner, c.repo, "closed")
 	if err != nil {
+		var rlErr *github.RateLimitError
+		if errors.As(err, &rlErr) {
+			wait := c.enterRateLimitCooldown(rlErr.RetryAfter)
+			c.log.Warn("ScanRecentlyMergedPRs: GitHub rate limit hit, pausing until cooldown elapses",
+				"cooldown", wait, "error", err)
+			return nil
+		}
 		return fmt.Errorf("failed to list closed PRs: %w", err)
 	}
 

--- a/internal/autopilot/controller_ratelimit_test.go
+++ b/internal/autopilot/controller_ratelimit_test.go
@@ -1,0 +1,123 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestController_ProcessAllPRs_RateLimitBackoff verifies that a GitHub
+// primary-rate-limit response from GetPullRequest opens a cooldown window
+// instead of being retried on every tick. GH-3784: without this, a sustained
+// rate-limit window left approved, green PRs unmerged for over an hour
+// because every tick re-fetched every tracked PR and burned the little quota
+// headroom that existed.
+func TestController_ProcessAllPRs_RateLimitBackoff(t *testing.T) {
+	var pullRequestCalls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls/42" {
+			atomic.AddInt32(&pullRequestCalls, 1)
+			w.Header().Set("X-RateLimit-Remaining", "0")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"API rate limit exceeded for user ID 123."}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	c.mu.Lock()
+	c.activePRs[42] = &PRState{
+		PRNumber:    42,
+		IssueNumber: 100,
+		BranchName:  "pilot/GH-100",
+		HeadSHA:     "abc1234",
+		Stage:       StageWaitingCI,
+	}
+	c.mu.Unlock()
+
+	if c.rateLimitCooldownActive() {
+		t.Fatal("cooldown should not be active before any request")
+	}
+
+	c.processAllPRs(context.Background())
+
+	if calls := atomic.LoadInt32(&pullRequestCalls); calls != 1 {
+		t.Fatalf("expected 1 GetPullRequest call on first tick, got %d", calls)
+	}
+	if !c.rateLimitCooldownActive() {
+		t.Fatal("expected rate-limit cooldown to be active after a 403 rate-limit response")
+	}
+
+	// A second tick while the cooldown is active must not re-hit the API.
+	c.processAllPRs(context.Background())
+	if calls := atomic.LoadInt32(&pullRequestCalls); calls != 1 {
+		t.Fatalf("expected no additional GetPullRequest calls during cooldown, got %d total", calls)
+	}
+}
+
+// TestController_ReconcileOrphanPRs_RateLimitBackoff verifies that a
+// rate-limit response from ListPullRequests opens the same cooldown window
+// the processAllPRs loop honors, so the periodic orphan-PR sweep also stops
+// hammering the API during a sustained outage.
+func TestController_ReconcileOrphanPRs_RateLimitBackoff(t *testing.T) {
+	var listCalls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls" {
+			atomic.AddInt32(&listCalls, 1)
+			w.Header().Set("X-RateLimit-Remaining", "0")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"API rate limit exceeded for user ID 123."}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	c.reconcileOrphanPRs(context.Background())
+	if calls := atomic.LoadInt32(&listCalls); calls != 1 {
+		t.Fatalf("expected 1 ListPullRequests call on first sweep, got %d", calls)
+	}
+	if !c.rateLimitCooldownActive() {
+		t.Fatal("expected rate-limit cooldown to be active after a 403 rate-limit response")
+	}
+
+	c.reconcileOrphanPRs(context.Background())
+	if calls := atomic.LoadInt32(&listCalls); calls != 1 {
+		t.Fatalf("expected no additional ListPullRequests calls during cooldown, got %d total", calls)
+	}
+}
+
+// TestController_EnterRateLimitCooldown_Bounds verifies the cooldown window
+// is floored and capped so a missing Retry-After doesn't hot-loop and a
+// runaway header value doesn't stall the controller indefinitely.
+func TestController_EnterRateLimitCooldown_Bounds(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	if got := c.enterRateLimitCooldown(0); got != 30*time.Second {
+		t.Errorf("floor: enterRateLimitCooldown(0) = %v, want 30s", got)
+	}
+
+	c2 := NewController(cfg, ghClient, nil, "owner", "repo")
+	if got := c2.enterRateLimitCooldown(2 * time.Hour); got != 20*time.Minute {
+		t.Errorf("cap: enterRateLimitCooldown(2h) = %v, want 20m", got)
+	}
+}

--- a/internal/wiring/callback_test.go
+++ b/internal/wiring/callback_test.go
@@ -1,10 +1,16 @@
 package wiring
 
 import (
+	"context"
 	"testing"
 
+	"github.com/qf-studio/pilot/e2e/mocks"
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/approval"
+	"github.com/qf-studio/pilot/internal/autopilot"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/dashboard"
+	"github.com/qf-studio/pilot/internal/executor"
 )
 
 // TestOnPRCreatedCallbackWired verifies that the OnSubIssuePRCreated callback
@@ -24,6 +30,65 @@ func TestOnPRCreatedCallbackWired(t *testing.T) {
 				t.Fatal("OnSubIssuePRCreated callback not wired")
 			}
 		})
+	}
+}
+
+// TestOnPRCreatedWiredAcrossRestartShapedReconstruction simulates a daemon
+// restart: the pre-restart Runner+Controller pair is discarded (as happens
+// when the process exits and cmd/pilot/main.go runs again from scratch) and
+// a brand-new pair is constructed against the SAME GitHub state, mirroring
+// main.go's `runner.SetOnSubIssuePRCreated(autopilotController.OnPRCreated)`
+// wiring call. It verifies both that the callback is wired on the freshly
+// reconstructed Runner and that a PR already open in GitHub with no local
+// tracking state (e.g. created moments before or during the restart) is
+// still adopted once the reconstructed controller runs its boot scan —
+// GH-3784: the failure mode was such a PR being left permanently untracked.
+func TestOnPRCreatedWiredAcrossRestartShapedReconstruction(t *testing.T) {
+	ghMock := mocks.NewGitHubMock()
+	t.Cleanup(ghMock.Close)
+
+	newControllerRunnerPair := func() (*executor.Runner, *autopilot.Controller) {
+		ghClient := github.NewClientWithBaseURL("test-github-token", ghMock.URL())
+		runner, err := executor.NewRunnerWithConfig(nil)
+		if err != nil {
+			t.Fatalf("NewRunnerWithConfig: %v", err)
+		}
+		approvalMgr := approval.NewManager(nil)
+		ctrl := autopilot.NewController(autopilot.DefaultConfig(), ghClient, approvalMgr, "test-owner", "test-repo")
+
+		// Mirrors main.go's runPollingMode / gateway wiring: the sub-issue PR
+		// callback is set on the Runner every time this construction runs,
+		// restart or not — never conditional on prior process state.
+		runner.SetOnSubIssuePRCreated(ctrl.OnPRCreated)
+		return runner, ctrl
+	}
+
+	// "Pre-restart" process.
+	preRunner, _ := newControllerRunnerPair()
+	if !preRunner.HasOnSubIssuePRCreated() {
+		t.Fatal("pre-restart: OnSubIssuePRCreated callback not wired")
+	}
+
+	// A PR is open in GitHub with no local tracking state by the time the
+	// "process" comes back — e.g. created just before or during the restart
+	// window, so OnPRCreated was never delivered to any live controller.
+	ghMock.CreatePR(77, "Fix thing", "pilot/GH-500", "deadbeef")
+
+	// "Restart": fresh Runner + Controller, same GitHub backing state.
+	postRunner, postCtrl := newControllerRunnerPair()
+	if !postRunner.HasOnSubIssuePRCreated() {
+		t.Fatal("post-restart: OnSubIssuePRCreated callback not wired on reconstructed Runner")
+	}
+
+	if err := postCtrl.ScanExistingPRs(context.Background()); err != nil {
+		t.Fatalf("ScanExistingPRs: %v", err)
+	}
+	pr, ok := postCtrl.GetPRState(77)
+	if !ok {
+		t.Fatal("PR 77 (open before reconstruction, untracked) was not adopted by the post-restart boot scan")
+	}
+	if pr.IssueNumber != 500 {
+		t.Errorf("adopted PR IssueNumber = %d, want 500", pr.IssueNumber)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #3784 (D1 from TASK-382).

Investigation (prior commit ccb75331 on this branch) traced the reported
"PRs created after daemon restart are never tracked" symptom to the daemon
log for the 2026-07-03 incident: `OnPRCreated` wiring and the orphan-PR
reconciler (GH-3113) both worked correctly — PR #3778 was registered
immediately on creation. The actual defect was `processAllPRs` re-hitting a
sustained GitHub rate-limit window on every tick with no backoff, stalling
an already-green, approved PR for over an hour.

That commit added a bounded rate-limit cooldown to `processAllPRs` and
`reconcileOrphanPRs`, an Info-level log when the orphan-PR sweep adopts an
untracked PR, a Warn-level "fail loud" log in the poller when a PR is created
with no autopilot callback wired, and a regression test
(`internal/wiring/callback_test.go`,
`TestOnPRCreatedWiredAcrossRestartShapedReconstruction`) simulating a
restart-shaped Runner/Controller reconstruction.

This PR closes the one remaining gap: `ScanRecentlyMergedPRs`'s own doc
comment already claimed it was covered by the same cooldown, but the check
was never added to that function — it kept calling `ListPullRequests`
unconditionally even during an active cooldown opened by one of the other
loops.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite passes)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `internal/wiring` regression test covers callback wiring across a
      restart-shaped reconstruction and adoption of an untracked open PR