### PR TITLE
fix(autopilot): self-upgrade went silent — auto-trigger + staleness fail-loud check

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updated": "2026-07-04",
+  "updated": "2026-07-03",
   "nodes": {
     "concepts": {
       "pilot-architecture": {
@@ -806,6 +806,22 @@
         "incident": "2026-07-03: GH-3764 child sub-issue completed 6 commits but push/PR step failed silently; no remote branch existed; commits survived only in shared local object store, salvaged manually into PR #3773 (TASK-382 defect D2).",
         "file": ".agent/knowledge/memories/pitfalls/bug_child_push_pr_silent_stranding.md",
         "origin_task": "GH-3785"
+      },
+      "mem-044": {
+        "type": "pitfall",
+        "summary": "GH-3790/D7: self-upgrade only fires on a TUI \"u\" keypress (internal/dashboard/tui.go:1017 is the sole writer to upgradeRequestCh; main.go:2833 OnUpdate only logs+notifies, never enqueues). VersionChecker keeps detecting releases every 5min forever, but PerformHotUpgrade never runs unless a human is watching the dashboard and presses u. Confirmed via daemon.log: restarts cluster around active terminal sessions (2026-06-26, and 2026-07-03 up to 12:50:23), then a clean 7h silent gap (12:50-20:01) with zero restart attempts/errors while v2.201.3-v2.207.0 shipped, ending only at a manual daemon restart. Outside --dashboard mode the whole checker+hot-upgrade subsystem is never constructed at all.",
+        "concepts": [
+          "hot-upgrade",
+          "release",
+          "autopilot",
+          "self-upgrade"
+        ],
+        "confidence": 0.95,
+        "severity": "high",
+        "created": "2026-07-04",
+        "incident": "2026-07-03: daemon hot-upgraded to v2.201.2 at 12:50:23+02:00, then sat 7+ hours through v2.202.0-v2.207.0 with zero upgrade attempts (not failures \u2014 total silence) until a manual restart at 20:01.",
+        "file": ".agent/knowledge/memories/pitfalls/pitfall_self_upgrade_requires_manual_keypress.md",
+        "origin_task": "GH-3790-1"
       }
     }
   },

--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -962,6 +962,11 @@
       "type": "relates_to"
     },
     {
+      "from": "mem-040",
+      "to": "mem-044",
+      "type": "relates_to"
+    },
+    {
       "from": "TASK-358",
       "to": "mem-024",
       "type": "produced"

--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -822,6 +822,21 @@
         "incident": "2026-07-03: daemon hot-upgraded to v2.201.2 at 12:50:23+02:00, then sat 7+ hours through v2.202.0-v2.207.0 with zero upgrade attempts (not failures \u2014 total silence) until a manual restart at 20:01.",
         "file": ".agent/knowledge/memories/pitfalls/pitfall_self_upgrade_requires_manual_keypress.md",
         "origin_task": "GH-3790-1"
+      },
+      "mem-045": {
+        "type": "decision",
+        "summary": "GH-3790 fix: OnUpdate now auto-enqueues the hot upgrade (config-gated via upgrade.auto_hot_upgrade, keypress kept as manual override); new VersionChecker staleness check logs WARN + fires alerts.Event once upgrade.stale_release_threshold releases behind, plus a pilot doctor counterpart (checkSelfUpgradeStaleness). Also added the missing default service_unhealthy alert rule so config-error/staleness alerts actually dispatch out of the box.",
+        "concepts": [
+          "hot-upgrade",
+          "release",
+          "self-upgrade",
+          "alerts"
+        ],
+        "confidence": 0.9,
+        "severity": "high",
+        "created": "2026-07-04",
+        "file": ".agent/knowledge/memories/decisions/decision_self_upgrade_auto_trigger_and_staleness_check.md",
+        "origin_task": "GH-3790-3"
       }
     }
   },
@@ -1120,6 +1135,21 @@
       "from": "mem-043",
       "to": "worktree",
       "type": "describes"
+    },
+    {
+      "from": "mem-045",
+      "to": "mem-044",
+      "type": "resolves"
+    },
+    {
+      "from": "mem-045",
+      "to": "hot-upgrade",
+      "type": "about"
+    },
+    {
+      "from": "mem-045",
+      "to": "self-upgrade",
+      "type": "about"
     }
   ]
 }

--- a/.agent/knowledge/memories/decisions/decision_self_upgrade_auto_trigger_and_staleness_check.md
+++ b/.agent/knowledge/memories/decisions/decision_self_upgrade_auto_trigger_and_staleness_check.md
@@ -1,0 +1,20 @@
+---
+name: self-upgrade now auto-triggers on detection, plus a fail-loud "N releases behind" check
+description: GH-3790 fix — VersionChecker.OnUpdate auto-enqueues the hot upgrade (config-gated, keypress still works as a manual override) instead of requiring a human to press 'u' in the TUI; a new staleness check logs WARN + fires an alerts.Event once the daemon falls upgrade.stale_release_threshold releases behind, with a pilot doctor counterpart.
+type: decision
+---
+Fixes the root cause traced in [[pitfall_self_upgrade_requires_manual_keypress]] (mem-044): `main.go`'s `versionChecker.OnUpdate` callback only logged and notified the dashboard — `PerformHotUpgrade` never ran unless a human was watching `--dashboard` and pressed `'u'`. The daemon sat 8 releases stale for 7h11m on 2026-07-03 with zero errors logged, because nothing was actually broken — the trigger simply never existed.
+
+**Fix 1 — auto-trigger (`cmd/pilot/main.go`, `internal/config`):** `OnUpdate` now sends to `upgradeRequestCh` (the same channel the TUI keypress writes to) whenever `cfg.Upgrade.AutoHotUpgrade` is true (default). Non-blocking send on the buffered-1 channel — a request already queued/running is a no-op, so this can't double-fire. The keypress path is untouched, so a human can still force an upgrade manually. Gated by config (not hardcoded) per the pitfall's own recommendation, so it's a documented behavior change (`upgrade.auto_hot_upgrade`), not a silent one.
+
+**Fix 2 — fail-loud staleness (`internal/upgrade`, `internal/health`, `internal/config`):**
+- `Upgrader.CheckVersion` now also returns `VersionInfo.ReleasesBehind`, computed by the new exported `upgrade.ReleasesBehind(releases, currentVersion)` (counts stable, non-draft/non-prerelease releases newer than current, from the same `/releases?per_page=30` fetch — bumped from 10 so an 8-releases-behind daemon like the incident doesn't undercount).
+- `VersionChecker.SetStaleThreshold(n)` / `OnStale(fn)`: once `ReleasesBehind >= n`, every check logs `slog.Warn` and invokes the callback. Wired in `main.go` to also emit `alerts.Event{Type: EventTypeConfigError, Metadata: {"check": "self_upgrade_stale", ...}}` when an alerts engine is configured — reuses the existing `AlertTypeServiceUnhealthy` rule/handler (`internal/alerts/engine.go handleConfigError`) rather than inventing a new event/rule type for a single check.
+- Also added a `pilot doctor` counterpart (`checkSelfUpgradeStaleness` in `internal/health/health.go`) using the same `upgrade.ReleasesBehind` helper against an unauthenticated GitHub API call — a one-shot equivalent of the periodic runtime check, per the task's "doctor check candidate" framing and TASK-379's Verifiable/preflight family.
+- Threshold defaults to 3 (`config.DefaultConfig()`'s `UpgradeConfig.StaleReleaseThreshold`); 0 disables the check.
+
+**Side fix:** `defaultAlertRules()` had no default `service_unhealthy`-type rule at all, so the existing GH-3718 config-error alert path (and this new one) would never actually dispatch on a fresh install even with `alerts.enabled: true` — the WARN log would fire but the alert wouldn't. Added `service_unhealthy` (enabled, warning, 1h cooldown) to the defaults list so both paths are live out of the box.
+
+**Not done:** the whole checker+hot-upgrader subsystem is still only constructed when `dashboardMode && program != nil` — non-dashboard (`pilot start --telegram --github` without `--dashboard`) still has zero self-upgrade capability, automatic or manual. Root-caused in [[pitfall_self_upgrade_requires_manual_keypress]] but out of scope for this fix (GH-3790-3); flag if a future task needs self-upgrade in polling-only mode.
+
+Related: [[pitfall_self_upgrade_requires_manual_keypress]], [[bug_daemon_autoupgrade_reverts_dev_binary]].

--- a/.agent/knowledge/memories/pitfalls/bug_daemon_autoupgrade_reverts_dev_binary.md
+++ b/.agent/knowledge/memories/pitfalls/bug_daemon_autoupgrade_reverts_dev_binary.md
@@ -44,3 +44,14 @@ one. Cross-check `version` + size, don't trust `lstart` alone.
 A dev-binary `cp` is fine for a 30-second smoke test, but expect it to be reverted within
 ~20min by the next hot-upgrade. Relates to [[learn_restart_vs_rebuild_stale_binary]] (mem-025)
 and [[learning_pilot_release_and_binary_path]] (mem-020) — same binary-path family.
+
+**Update (GH-3790-2, 2026-07-04):** the ~20min revert window observed here is not the
+hot-upgrade running continuously/unattended — [[pitfall_self_upgrade_requires_manual_keypress]]
+(mem-044) later traced the trigger to a single manual TUI `'u'` keypress
+(`internal/dashboard/tui.go:1017`); nothing else ever writes to `upgradeRequestCh`. The
+2026-06-26 12:32→12:52 revert happened during an actively-attended dashboard session (the
+same session mem-044 cites when explaining why restarts cluster around attended terminals) —
+someone pressed `'u'` after the dev binary was installed, pulling the latest release over it.
+Don't read this pitfall as "the daemon silently re-upgrades on a timer" — it re-upgrades only
+when a human triggers it, which happens to make dev-binary testing during active sessions
+just as fragile as staying stale during unattended ones (mem-044).

--- a/.agent/knowledge/memories/pitfalls/pitfall_self_upgrade_requires_manual_keypress.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_self_upgrade_requires_manual_keypress.md
@@ -1,0 +1,59 @@
+---
+name: self-upgrade (hot upgrade) only fires on a TUI 'u' keypress — there is no automatic/unattended trigger, so it silently stops the moment nobody is watching the dashboard
+description: GH-3790/D7 — daemon stayed on v2.201.2 through 8 releases (v2.202-v2.206) for 7+ hours; root cause traced from daemon.log, not inferred from reading code alone
+metadata:
+  type: pitfall
+---
+
+**Symptom:** background version checks keep firing forever ("update available"
+logged every 5 min in `~/.pilot/logs/daemon.log`, tracking each new release as
+it ships), but the daemon never actually installs any of them — no
+`"restarting with new binary"` line appears for hours, across many releases.
+
+**Root cause (traced via daemon.log timestamps, not just code reading):**
+
+The self-upgrade pipeline has three legs, and only the first is automatic:
+
+1. `internal/upgrade/checker.go` `VersionChecker.run()` — background goroutine,
+   ticks every `DefaultCheckInterval` (5 min), always runs, never stops on its
+   own. **Confirmed always firing** — logged continuously 11:06→22:37 on
+   2026-07-03 even while current=2.201.2 sat behind 6 releases.
+2. `cmd/pilot/main.go:2833` `versionChecker.OnUpdate(...)` — the *only*
+   consumer of a detected update. It logs and pushes a dashboard notification
+   (`dashboard.NotifyUpdateAvailable`). **It never enqueues an upgrade.**
+3. `cmd/pilot/main.go:2847` `case <-upgradeRequestCh:` — this is the *only*
+   code path that calls `hotUpgrader.PerformHotUpgrade`. The *only* writer to
+   `upgradeRequestCh` is `internal/dashboard/tui.go:1017` `case "u":` — a
+   literal keyboard keypress inside the Bubbletea TUI. Grepped the full repo:
+   zero other senders to that channel, no idle timer, no cron, no autopilot
+   hook. Outside `--dashboard` mode the whole subsystem (`VersionChecker` +
+   `HotUpgrader`) is never even constructed (gated by
+   `if dashboardMode && program != nil` at main.go:2828).
+
+So "self-upgrade" has always meant: *a human watching the TUI presses 'u'
+when they notice the banner.* GH-369's original design doc even lists an
+"auto-trigger if idle for 5 min" and an `auto_upgrade_on_idle` config knob —
+neither was ever implemented; only the manual key handler shipped.
+
+**Evidence this is attention-gated, not a regression:** `restarting with new
+binary` events across `~/.pilot/logs/daemon.log` cluster tightly around times
+the operator was actively at the terminal (e.g. 2026-06-26 09:33/12:05/12:52/
+14:24 during a heavy live-debug session — the same session as mem-040's
+(`bug_daemon_autoupgrade_reverts_dev_binary.md`) 12:32→12:52 dev binary
+revert. On 2026-07-03 the pattern breaks cleanly: restart at 12:50:23
+(2.201.0→v2.201.2, during active TASK-378 dispatch work), then **zero**
+restart attempts — no success, no failure, no error logged, just silence —
+for the entire 12:50→20:01 window while `v2.201.3` through `v2.207.0` shipped
+underneath it, resuming only at 20:01:12 when the daemon was manually
+restarted (fresh process, not a hot-upgrade exec).
+
+**How to apply:** don't assume the daemon self-heals onto new releases just
+because it's running with `--dashboard`. If nobody is watching that specific
+terminal, it will happily run 8+ releases stale with no error anywhere. The
+real fix (tracked as GH-3790, split into follow-on subtasks) needs an
+unattended trigger — e.g. auto-invoke `PerformHotUpgrade` from `OnUpdate`
+after N consecutive detections (with the existing task-draining/graceful
+wait already in `HotUpgrader`), gated by config rather than a keypress — plus
+a fail-loud ">N releases behind" doctor/alert check per the GH-3790 issue
+body, since silent staleness is the actual incident, not just the missing
+trigger.

--- a/.agent/knowledge/memories/pitfalls/pitfall_self_upgrade_requires_manual_keypress.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_self_upgrade_requires_manual_keypress.md
@@ -57,3 +57,12 @@ wait already in `HotUpgrader`), gated by config rather than a keypress — plus
 a fail-loud ">N releases behind" doctor/alert check per the GH-3790 issue
 body, since silent staleness is the actual incident, not just the missing
 trigger.
+
+**Resolved (GH-3790-3):** see
+[[decision_self_upgrade_auto_trigger_and_staleness_check]] (mem-045).
+`OnUpdate` now auto-enqueues the hot upgrade (config-gated via
+`upgrade.auto_hot_upgrade`, keypress kept as a manual override), and
+`VersionChecker` fails loud past `upgrade.stale_release_threshold` releases
+behind (WARN log + alert + `pilot doctor` check). Still open: the
+checker+hot-upgrader subsystem remains dashboard-mode-only — non-dashboard
+polling mode still has no self-upgrade path at all, automatic or manual.

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -438,7 +438,8 @@
 |---------|--------|---------|-------------|------------|-------|
 | Version check | ✅ | upgrade | `pilot version` | - | Shows current |
 | Auto-upgrade | ✅ | upgrade | `pilot upgrade` | - | Downloads latest |
-| Hot upgrade | ✅ | upgrade | `u` key in dashboard | - | Graceful drain + restart, no orphaned tasks (v0.18.0, v0.63.0) |
+| Hot upgrade | ✅ | upgrade | `u` key in dashboard (manual) or automatic | `upgrade.auto_hot_upgrade` | Graceful drain + restart, no orphaned tasks (v0.18.0, v0.63.0); auto-enqueues on detection by default, keypress still works as manual override (GH-3790) |
+| Self-upgrade staleness check | ✅ | upgrade, health | `pilot doctor` | `upgrade.stale_release_threshold` | Warns (log + alert) when the daemon is N+ releases behind — catches the failure mode where self-upgrade silently stops firing (GH-3790) |
 | Config init | ✅ | config | `pilot init` | - | Creates default |
 | Setup wizard | ✅ | main | `pilot setup` | - | Interactive config |
 | Project add wizard | ✅ | cli | `pilot project add` (no flags) | - | gh CLI auth, repo picker, token seeding; `--no-wizard` for CI (GH-3017, v2.187.1) |

--- a/.agent/tasks/archive/gh-3790-2.md
+++ b/.agent/tasks/archive/gh-3790-2.md
@@ -1,0 +1,65 @@
+# GH-3790-2
+
+**Created:** 2026-07-04
+
+## Subtask 2 of 5
+
+**Parent Task:** GH-3790 - fix(autopilot): self-upgrade went silent — daemon stayed on v2.201.2 through 8 releases until manual restart
+
+## Objective
+
+Known pitfall mem-040 (`daemon auto-upgrade reverts dev binary`) may be related.
+
+## Findings
+
+**mem-040 is the same mechanism, observed from a different angle — not a separate defect.**
+
+mem-040 (`.agent/knowledge/memories/pitfalls/bug_daemon_autoupgrade_reverts_dev_binary.md`,
+recorded 2026-06-26) documents a dev binary `cp`'d into `~/.local/bin/pilot` getting reverted
+to the latest GitHub release within ~20 minutes (12:32→12:52). Read in isolation, that reads
+like the hot-upgrade running continuously/unattended — which would contradict GH-3790-1's
+finding (`pitfall_self_upgrade_requires_manual_keypress`, mem-044) that `PerformHotUpgrade`
+only ever runs from a single TUI `'u'` keypress handler
+(`internal/dashboard/tui.go:1017` → `upgradeRequestCh` → `main.go:2847`), with **zero** other
+writers to that channel anywhere in the repo (idle timer, cron, autopilot hook — none exist).
+
+Cross-checking the timestamps resolves the apparent conflict rather than contradicting it:
+mem-044 already lists 2026-06-26 as one of the sessions where `"restarting with new binary"`
+events cluster around an actively-attended dashboard terminal (09:33/12:05/**12:52**/14:24).
+The mem-040 revert at 12:52 falls exactly inside that cluster — i.e. it wasn't the daemon
+auto-upgrading on a timer, it was a human at that terminal pressing `'u'` (attracted by the
+update banner) shortly after the dev binary was installed, same trigger path mem-044 traced
+in code. The two pitfalls describe one mechanism (manual-keypress-gated hot-upgrade to
+latest release) producing two different symptoms depending on who's watching and what's on
+disk:
+- **Attended + dev binary present → mem-040**: the keypress reverts your local test build.
+- **Unattended, for hours → mem-044/GH-3790**: nothing ever presses the key, so the daemon
+  sits stale through many releases with no error.
+
+No separate root cause exists for mem-040; it does not need its own code fix beyond what
+GH-3790's remaining subtasks (auto-trigger + fail-loud staleness check) already cover — an
+automatic, config-gated trigger removes the keypress dependency for both symptoms at once
+(a stale daemon self-upgrades instead of waiting for someone to notice a banner, *and*
+nobody manually pressing `'u'` mid-dev-session means no more surprise dev-binary reverts).
+
+**Change made:** updated mem-040's pitfall doc with a note (and a `[[pitfall_self_upgrade_requires_manual_keypress]]`
+cross-link) clarifying the trigger is keypress-gated, not a timer, so future readers don't
+infer autonomous re-upgrade behavior from it in isolation. Added the `mem-040 --relates_to-->
+mem-044` edge to `.agent/knowledge/graph.json` (previously only mem-040→hot-upgrade/release
+concept edges existed; no link to the newer GH-3790 finding).
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+This subtask is scoped to confirming/reconciling the mem-040 relationship called out in the
+parent issue body — implementing the automatic-trigger fix and the ">N releases stale"
+fail-loud check are handled by the remaining GH-3790 subtasks.
+
+## Acceptance Criteria
+
+- [x] Confirmed relationship between mem-040 and the GH-3790 root cause (mem-044): same
+      keypress-gated trigger mechanism, not a distinct bug — no separate fix required for
+      mem-040 beyond the shared auto-trigger fix.
+- [x] Cross-referenced the two pitfall docs and added the missing graph edge.
+- [ ] Fix implementation (auto-trigger, fail-loud staleness check) — out of scope for this
+      subtask, see remaining GH-3790 subtasks.

--- a/.agent/tasks/archive/gh-3790-3.md
+++ b/.agent/tasks/archive/gh-3790-3.md
@@ -1,0 +1,61 @@
+# GH-3790-3
+
+**Created:** 2026-07-04
+
+## Subtask 3 of 5
+
+**Parent Task:** GH-3790 - fix(autopilot): self-upgrade went silent — daemon stayed on v2.201.2 through 8 releases until manual restart
+
+## Objective
+
+Fix the root cause, and add a fail-loud check: daemon periodically compares its version to the latest release; if >N releases behind, log Warn + alert (doctor check candidate — fits the Verifiable/preflight family from TASK-379).
+
+## Fix
+
+**Root cause (from GH-3790-1, mem-044):** `versionChecker.OnUpdate` (`cmd/pilot/main.go`) only
+logged and pushed a dashboard notification — it never enqueued an upgrade. The only writer to
+`upgradeRequestCh` was the TUI's `'u'` keypress handler, so self-upgrade silently required a
+human watching `--dashboard`.
+
+**Fix 1 — auto-trigger:** `OnUpdate` now sends to `upgradeRequestCh` (same channel the keypress
+uses) whenever `cfg.Upgrade.AutoHotUpgrade` is true (new config, default true). Non-blocking send
+on the buffered-1 channel, so a request already queued/running is a no-op. The keypress still
+works as a manual override.
+
+**Fix 2 — fail-loud staleness check:**
+- `upgrade.Upgrader.CheckVersion` now returns `VersionInfo.ReleasesBehind`, via new exported
+  `upgrade.ReleasesBehind(releases, currentVersion)`. Release fetch bumped from `per_page=10` to
+  `per_page=30` (releasesFetchLimit) so an 8-releases-behind daemon doesn't undercount.
+- `VersionChecker.SetStaleThreshold(n)` / `OnStale(fn)`: WARNs and fires the callback once
+  `ReleasesBehind >= n`. Wired in `main.go` to also emit an `alerts.Event` (reusing
+  `EventTypeConfigError` / `AlertTypeServiceUnhealthy`) when an alerts engine is configured.
+- `pilot doctor` counterpart: `checkSelfUpgradeStaleness` in `internal/health/health.go`, same
+  `upgrade.ReleasesBehind` helper against an unauthenticated GitHub API call.
+- New `config.UpgradeConfig` (`upgrade.auto_hot_upgrade`, `upgrade.stale_release_threshold`,
+  default threshold 3).
+- Side fix: `defaultAlertRules()` had no default `service_unhealthy` rule, so the existing
+  GH-3718 config-error alert path (and this new one) would never actually dispatch even with
+  alerts enabled — added the missing default rule.
+
+**Not fixed (documented, out of scope):** the whole checker+hot-upgrader subsystem is still only
+constructed when `dashboardMode && program != nil` — non-dashboard polling mode has zero
+self-upgrade capability, automatic or manual.
+
+Full writeup: `.agent/knowledge/memories/decisions/decision_self_upgrade_auto_trigger_and_staleness_check.md`
+(mem-045). Pitfall `mem-044` updated with a resolved note.
+
+## Verification
+
+- `go build ./...` clean
+- `go test ./...` all packages pass (added `TestReleasesBehind`, `TestVersionChecker_OnUpdate_*`,
+  `TestVersionChecker_OnStale_*`, `TestCheckSelfUpgradeStaleness_*`)
+- `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
+
+## Acceptance Criteria
+
+- [x] Root cause fixed: `OnUpdate` auto-enqueues the hot upgrade instead of requiring a keypress
+      (config-gated, default on)
+- [x] Fail-loud check added: periodic comparison of current vs. latest release; logs WARN + fires
+      an alert once `stale_release_threshold` releases behind
+- [x] Doctor check candidate implemented: `pilot doctor` now includes a
+      `self-upgrade.staleness` check using the same comparison logic

--- a/.agent/tasks/gh-3790-1.md
+++ b/.agent/tasks/gh-3790-1.md
@@ -1,0 +1,105 @@
+# GH-3790-1
+
+**Created:** 2026-07-04
+
+## Subtask 1 of 5
+
+**Parent Task:** GH-3790 - fix(autopilot): self-upgrade went silent — daemon stayed on v2.201.2 through 8 releases until manual restart
+
+## Objective
+
+Trace the self-upgrade path (release pipeline → upgrade trigger → binary swap → re-exec): which step stopped firing after 09:49? Logs/state from the 09:49 upgrade vs later releases.
+
+## Findings
+
+### The pipeline, and which leg is automatic
+
+1. **Release detection** — `internal/upgrade/checker.go` `VersionChecker.run()`, a
+   background goroutine ticking every `DefaultCheckInterval` (5 min). Fully
+   automatic, never needs a human.
+2. **Upgrade trigger** — `cmd/pilot/main.go:2833`
+   `versionChecker.OnUpdate(func(info) {...})`. This callback **only logs and
+   pushes a dashboard notification** (`dashboard.NotifyUpdateAvailable`). It
+   never calls `PerformHotUpgrade` and never enqueues one.
+3. **Binary swap / re-exec** — `hotUpgrader.PerformHotUpgrade(...)` at
+   `main.go:2881`, invoked from the single `case <-upgradeRequestCh:` branch
+   at `main.go:2847`. The **only** writer to `upgradeRequestCh` anywhere in
+   the repo is `internal/dashboard/tui.go:1017` `case "u":` — a literal
+   keypress in the Bubbletea TUI. Confirmed by grepping the whole tree for
+   `upgradeRequestCh <-`: zero other senders (no idle timer, no cron, no
+   autopilot hook). The entire checker+hot-upgrade subsystem is also gated
+   behind `if dashboardMode && program != nil` (`main.go:2828`) — outside
+   `--dashboard` mode it isn't even constructed.
+
+**So step 2 is where it "stops firing," and it always has.** There is no
+regression in the code between the 09:49-ish successful upgrade and the
+later ones that were skipped — the mechanism has never had an automatic
+trigger. GH-369's original design doc (`.agent/tasks/archive/GH-369-hot-reload-on-release.md`)
+even lists "auto-trigger if idle for 5 min" and an `auto_upgrade_on_idle`
+config knob as intended features; neither was ever implemented. Only the
+manual `'u'` keypress path shipped.
+
+### Evidence from `~/.pilot/logs/daemon.log` (2026-07-03)
+
+- `"update available"` is logged continuously and correctly all day —
+  11:06 → 22:37, tracking every release as it ships (v2.201.1 → v2.201.2 →
+  v2.201.3 → v2.202.0 → ... → v2.207.1). The background checker (leg 1)
+  **never stopped**.
+- `"restarting with new binary"` (leg 3 firing) occurred at:
+  - `11:47:49` 2.201.0 → v2.201.1 — then `11:47:54` **failed**
+    (`hot restart FAILED`, pre-exec smoke test timeout)
+  - `12:50:23` 2.201.0 → v2.201.2 — **succeeded**
+    (`"upgrade verified complete"` at `12:50:24`)
+  - next entry: `20:01:12` 2.201.2 → v2.206.1 — this is the manual restart
+    mentioned in the parent context, not a hot-upgrade exec
+- Between `12:50:24` and `20:01:12` (**7h11m**): zero `"restarting with new
+  binary"` lines, zero `"Upgrade failed"` / error lines, zero
+  `upgrade progress` lines — total silence, not a failure. Meanwhile
+  `"update available"` kept logging `latest=` climbing through v2.201.3,
+  v2.202.0, v2.203.x, v2.204.x, v2.205.0, v2.206.0/.1 every 5 minutes the
+  entire time. `~/.pilot/upgrade-state.json` shows the *next* successful hot
+  upgrade after that gap was 2.206.1 → v2.207.1, completed 22:44 the same
+  day — i.e. the mechanism works fine whenever it's actually invoked.
+- Historical `"restarting with new binary"` timestamps (2026-06-15 through
+  2026-07-03 morning) cluster around hours matching known active/attended
+  work sessions (e.g. 2026-06-26 09:33 / 12:05 / 12:52 / 14:24, the same
+  session as pitfall mem-040's 12:32→12:52 dev-binary-revert observation).
+  The 07-03 pattern is the same shape: restarts while the user was actively
+  dispatching TASK-378 fixes through midday, then silence once attention
+  moved elsewhere, resuming only when someone next opened/pressed a key in
+  that terminal (or force-restarted it at ~20:01).
+
+### Root cause
+
+**"Self-upgrade" is not autonomous.** It requires a human to be watching the
+`--dashboard` TUI and to press `'u'` when the update banner appears. The
+09:49-built binary (v2.201.2, installed via the hot-upgrade that completed
+at 12:50:23 local) sat as `current` for 6 further releases purely because
+nobody pressed `'u'` again during that window — not because any step in the
+pipeline broke. This is a design gap present since GH-369, not a regression
+introduced recently.
+
+Documented as pitfall `mem-044` /
+`.agent/knowledge/memories/pitfalls/pitfall_self_upgrade_requires_manual_keypress.md`
+for the subtasks that implement the fix.
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+This subtask is scoped to tracing/root-causing only — implementing the
+automatic-trigger fix and the ">N releases stale" fail-loud check are handled
+by the remaining GH-3790 subtasks (per the parent issue's acceptance
+criteria).
+
+## Acceptance Criteria
+
+- [x] Root cause identified: `OnUpdate` callback (main.go:2833) never enqueues
+      an upgrade; `upgradeRequestCh` is only ever written by the TUI's `'u'`
+      key handler (dashboard/tui.go:1017) — self-upgrade has always been
+      manual-keypress-gated, not autonomous.
+- [x] Evidence gathered: `~/.pilot/logs/daemon.log` timestamps for 2026-07-03
+      showing the checker running continuously vs. the 7h11m gap in actual
+      restart attempts, plus historical restart clustering around attended
+      sessions.
+- [ ] Fix implementation — out of scope for this subtask, see remaining
+      GH-3790 subtasks.

--- a/cmd/pilot/doctor.go
+++ b/cmd/pilot/doctor.go
@@ -30,7 +30,7 @@ Examples:
 			}
 
 			// Run health checks
-			report := health.RunChecks(cfg)
+			report := health.RunChecks(cfg, version)
 
 			// Header
 			fmt.Println()

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2829,11 +2829,52 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		fmt.Println("\n🖥️  Starting TUI dashboard...")
 
 		// Start background version checker for hot reload (GH-369)
+		upgradeCfg := cfg.Upgrade
+		if upgradeCfg == nil {
+			upgradeCfg = &config.UpgradeConfig{AutoHotUpgrade: true, StaleReleaseThreshold: 3}
+		}
 		versionChecker := upgrade.NewVersionChecker(version, upgrade.DefaultCheckInterval)
 		versionChecker.OnUpdate(func(info *upgrade.VersionInfo) {
 			program.Send(dashboard.NotifyUpdateAvailable(info.Current, info.Latest, info.ReleaseNotes)())
 			program.Send(dashboard.AddLog(fmt.Sprintf("⬆️ Update available: %s → %s", info.Current, info.Latest))())
+
+			// GH-3790 root cause: this callback used to only log/notify —
+			// PerformHotUpgrade never ran unless a human pressed 'u' in the
+			// TUI, so the daemon silently sat on stale releases whenever
+			// nobody was watching. Auto-enqueue the same request the
+			// keypress sends, unless disabled via config.
+			if upgradeCfg.AutoHotUpgrade {
+				select {
+				case upgradeRequestCh <- struct{}{}:
+				default:
+					// an upgrade is already queued/running
+				}
+			}
 		})
+		if upgradeCfg.StaleReleaseThreshold > 0 {
+			versionChecker.SetStaleThreshold(upgradeCfg.StaleReleaseThreshold)
+			versionChecker.OnStale(func(info *upgrade.VersionInfo) {
+				program.Send(dashboard.AddLog(fmt.Sprintf(
+					"⚠️ %d releases behind (running %s, latest %s) — check ~/.pilot/logs/daemon.log",
+					info.ReleasesBehind, info.Current, info.Latest))())
+				if alertsEngine != nil {
+					alertsEngine.ProcessEvent(alerts.Event{
+						Type:      alerts.EventTypeConfigError,
+						TaskID:    "self-upgrade",
+						TaskTitle: "Self-upgrade staleness check",
+						Error: fmt.Sprintf("daemon is %d releases behind (running %s, latest %s)",
+							info.ReleasesBehind, info.Current, info.Latest),
+						Metadata: map[string]string{
+							"check":           "self_upgrade_stale",
+							"current_version": info.Current,
+							"latest_version":  info.Latest,
+							"releases_behind": fmt.Sprintf("%d", info.ReleasesBehind),
+						},
+						Timestamp: time.Now(),
+					})
+				}
+			})
+		}
 		versionChecker.Start(ctx)
 		defer versionChecker.Stop()
 

--- a/internal/banner/banner.go
+++ b/internal/banner/banner.go
@@ -51,7 +51,7 @@ func StartupBanner(version, gateway string) {
 
 // StartupWithHealth prints startup banner with health status
 func StartupWithHealth(version string, cfg *config.Config) {
-	report := health.RunChecks(cfg)
+	report := health.RunChecks(cfg, version)
 
 	// Header
 	fmt.Println()
@@ -99,7 +99,7 @@ func StartupWithHealth(version string, cfg *config.Config) {
 
 // StartupTelegram prints telegram-specific startup with health
 func StartupTelegram(version, project, chatID string, cfg *config.Config) {
-	report := health.RunChecks(cfg)
+	report := health.RunChecks(cfg, version)
 
 	// ASCII logo
 	fmt.Print(Logo)
@@ -204,7 +204,7 @@ func StartupTelegram(version, project, chatID string, cfg *config.Config) {
 
 // StartupServer prints server-specific startup with health
 func StartupServer(version, gateway string, cfg *config.Config) {
-	report := health.RunChecks(cfg)
+	report := health.RunChecks(cfg, version)
 
 	// Header
 	fmt.Print(Logo)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,21 @@ type Config struct {
 	TeamID         string                  `yaml:"team_id"` // Optional team ID for scoping execution
 	Team           *TeamConfig             `yaml:"team"`
 	Bot            *BotConfig              `yaml:"bot"`
+	Upgrade        *UpgradeConfig          `yaml:"upgrade"`
+}
+
+// UpgradeConfig controls self-upgrade behavior (GH-3790). Self-upgrade
+// previously only ran when a human pressed 'u' in the TUI dashboard — the
+// background checker kept detecting releases forever but nothing ever
+// enqueued the upgrade, so the daemon silently drifted for 8+ releases.
+type UpgradeConfig struct {
+	// AutoHotUpgrade enqueues a hot upgrade automatically as soon as the
+	// background checker detects a new release, instead of relying solely on
+	// the TUI keypress. Defaults to true.
+	AutoHotUpgrade bool `yaml:"auto_hot_upgrade"`
+	// StaleReleaseThreshold is how many releases behind triggers a WARN log
+	// + alert that self-upgrade may not be firing. 0 disables the check.
+	StaleReleaseThreshold int `yaml:"stale_release_threshold"`
 }
 
 // TeamConfig holds settings for team-based project access control (GH-635).
@@ -423,6 +438,10 @@ func DefaultConfig() *Config {
 		Quality:  quality.DefaultConfig(),
 		Tunnel:   tunnel.DefaultConfig(),
 		Webhooks: webhooks.DefaultConfig(),
+		Upgrade: &UpgradeConfig{
+			AutoHotUpgrade:        true,
+			StaleReleaseThreshold: 3,
+		},
 	}
 }
 
@@ -486,6 +505,16 @@ func defaultAlertRules() []AlertRuleConfig {
 			Channels:    []string{},
 			Cooldown:    4 * time.Hour,
 			Description: "Alert when budget limit is exceeded",
+		},
+		{
+			Name:        "service_unhealthy",
+			Type:        "service_unhealthy",
+			Enabled:     true,
+			Condition:   AlertConditionConfig{},
+			Severity:    "warning",
+			Channels:    []string{},
+			Cooldown:    1 * time.Hour,
+			Description: "Alert on daemon health degradations (dead credentials, stale self-upgrade, etc.)",
 		},
 	}
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -24,6 +24,7 @@ import (
 	"github.com/qf-studio/pilot/internal/adapters/telegram"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/health/verify"
+	"github.com/qf-studio/pilot/internal/upgrade"
 )
 
 // Status represents feature or dependency status
@@ -399,8 +400,65 @@ func checkBrewTapHealth(get httpGetter) ConfigCheck {
 	return ConfigCheck{Name: checkName, Status: StatusOK, Message: "last release failed (not at brew step)"}
 }
 
-// RunChecks performs all health checks based on config
-func RunChecks(cfg *config.Config) *HealthReport {
+// defaultStaleReleaseThreshold mirrors config.UpgradeConfig's default so
+// doctor still warns when cfg.Upgrade is unset (e.g. loaded via
+// config.DefaultConfig() paths that predate the field).
+const defaultStaleReleaseThreshold = 3
+
+// checkSelfUpgradeStaleness compares the running version against GitHub
+// releases and warns when the daemon has fallen threshold-or-more releases
+// behind (GH-3790: self-upgrade previously had no automatic trigger, so a
+// daemon could silently run 8+ releases stale with nothing surfacing it).
+// This is the doctor/one-shot counterpart to the periodic runtime check in
+// upgrade.VersionChecker — same threshold and comparison, different cadence.
+func checkSelfUpgradeStaleness(get httpGetter, currentVersion string, threshold int) ConfigCheck {
+	const checkName = "self-upgrade.staleness"
+
+	if threshold <= 0 {
+		return ConfigCheck{Name: checkName, Status: StatusOK, Message: "check disabled"}
+	}
+
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases?per_page=%d", upgrade.GitHubRepo, releasesCheckLimit)
+	resp, err := get(url)
+	if err != nil {
+		return ConfigCheck{Name: checkName, Status: StatusWarning, Message: "could not reach GitHub API"}
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return ConfigCheck{
+			Name:    checkName,
+			Status:  StatusWarning,
+			Message: fmt.Sprintf("GitHub API returned %d", resp.StatusCode),
+		}
+	}
+
+	var releases []upgrade.Release
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return ConfigCheck{Name: checkName, Status: StatusWarning, Message: "could not parse releases"}
+	}
+
+	behind := upgrade.ReleasesBehind(releases, currentVersion)
+	if behind >= threshold {
+		return ConfigCheck{
+			Name:    checkName,
+			Status:  StatusWarning,
+			Message: fmt.Sprintf("%d releases behind (running %s)", behind, currentVersion),
+			Fix:     "Check ~/.pilot/logs/daemon.log for hot-upgrade errors, or restart the daemon manually",
+		}
+	}
+
+	return ConfigCheck{Name: checkName, Status: StatusOK, Message: fmt.Sprintf("up to date (%d behind)", behind)}
+}
+
+// releasesCheckLimit mirrors upgrade.releasesFetchLimit — kept as a separate
+// constant since it belongs to a different package's public API surface.
+const releasesCheckLimit = 30
+
+// RunChecks performs all health checks based on config. currentVersion is
+// compared against GitHub releases for the self-upgrade staleness check
+// (GH-3790); pass "" to skip it.
+func RunChecks(cfg *config.Config, currentVersion string) *HealthReport {
 	// Determine active backend type from config
 	backendType := "claude-code" // default
 	if cfg.Executor != nil && cfg.Executor.Type != "" {
@@ -420,6 +478,13 @@ func RunChecks(cfg *config.Config) *HealthReport {
 	}
 	if liveCheck := checkSlackTokenLive(cfg, newSlackVerifier); liveCheck != nil {
 		configChecks = append(configChecks, *liveCheck)
+	}
+	if currentVersion != "" {
+		threshold := defaultStaleReleaseThreshold
+		if cfg.Upgrade != nil {
+			threshold = cfg.Upgrade.StaleReleaseThreshold
+		}
+		configChecks = append(configChecks, checkSelfUpgradeStaleness(brewTapHTTPGet, currentVersion, threshold))
 	}
 
 	report := &HealthReport{

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -587,7 +587,7 @@ func TestCheckFeatures_AlertsDisabled(t *testing.T) {
 
 func TestRunChecks_SetsFlags(t *testing.T) {
 	cfg := &config.Config{}
-	report := RunChecks(cfg)
+	report := RunChecks(cfg, "")
 
 	if report == nil {
 		t.Fatal("RunChecks returned nil")
@@ -610,7 +610,7 @@ func TestRunChecks_HasErrorsFlagSet(t *testing.T) {
 			},
 		},
 	}
-	report := RunChecks(cfg)
+	report := RunChecks(cfg, "")
 
 	// Config should have an error for missing telegram token
 	hasConfigError := false
@@ -634,7 +634,7 @@ func TestRunChecks_ProjectCount(t *testing.T) {
 			{Name: "b", Path: "/tmp"},
 		},
 	}
-	report := RunChecks(cfg)
+	report := RunChecks(cfg, "")
 
 	if report.Projects != 2 {
 		t.Errorf("Projects = %d, want 2", report.Projects)
@@ -1132,6 +1132,80 @@ func TestCheckBrewTapHealth_JobFetchFails(t *testing.T) {
 	check := checkBrewTapHealth(get)
 	if check.Status != StatusWarning {
 		t.Errorf("status = %v, want StatusWarning when jobs fetch fails", check.Status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// checkSelfUpgradeStaleness (GH-3790)
+// ---------------------------------------------------------------------------
+
+func TestCheckSelfUpgradeStaleness_ThresholdDisabled(t *testing.T) {
+	get := func(_ string) (*http.Response, error) {
+		t.Fatal("should not make a network call when threshold <= 0")
+		return nil, nil
+	}
+	check := checkSelfUpgradeStaleness(get, "2.201.2", 0)
+	if check.Status != StatusOK {
+		t.Errorf("status = %v, want StatusOK", check.Status)
+	}
+}
+
+func TestCheckSelfUpgradeStaleness_NetworkError(t *testing.T) {
+	get := func(_ string) (*http.Response, error) { return nil, io.ErrUnexpectedEOF }
+	check := checkSelfUpgradeStaleness(get, "2.201.2", 3)
+	if check.Status != StatusWarning {
+		t.Errorf("status = %v, want StatusWarning", check.Status)
+	}
+}
+
+func TestCheckSelfUpgradeStaleness_UpToDate(t *testing.T) {
+	body := `[{"tag_name":"v2.201.2","draft":false,"prerelease":false}]`
+	get := makeBrewTapGetter([]struct {
+		code int
+		body string
+	}{{200, body}})
+	check := checkSelfUpgradeStaleness(get, "2.201.2", 3)
+	if check.Status != StatusOK {
+		t.Errorf("status = %v, want StatusOK", check.Status)
+	}
+}
+
+func TestCheckSelfUpgradeStaleness_BehindThreshold(t *testing.T) {
+	body := `[
+		{"tag_name":"v2.207.1","draft":false,"prerelease":false},
+		{"tag_name":"v2.206.1","draft":false,"prerelease":false},
+		{"tag_name":"v2.206.0","draft":false,"prerelease":false},
+		{"tag_name":"v2.205.0","draft":false,"prerelease":false},
+		{"tag_name":"v2.201.2","draft":false,"prerelease":false}
+	]`
+	get := makeBrewTapGetter([]struct {
+		code int
+		body string
+	}{{200, body}})
+	check := checkSelfUpgradeStaleness(get, "2.201.2", 3)
+	if check.Status != StatusWarning {
+		t.Errorf("status = %v, want StatusWarning", check.Status)
+	}
+	if check.Fix == "" {
+		t.Error("expected a Fix hint")
+	}
+	if !strings.Contains(check.Message, "4 releases behind") {
+		t.Errorf("message = %q, want mention of release count", check.Message)
+	}
+}
+
+func TestCheckSelfUpgradeStaleness_BelowThreshold(t *testing.T) {
+	body := `[
+		{"tag_name":"v2.202.0","draft":false,"prerelease":false},
+		{"tag_name":"v2.201.2","draft":false,"prerelease":false}
+	]`
+	get := makeBrewTapGetter([]struct {
+		code int
+		body string
+	}{{200, body}})
+	check := checkSelfUpgradeStaleness(get, "2.201.2", 3)
+	if check.Status != StatusOK {
+		t.Errorf("status = %v, want StatusOK (1 release behind < threshold 3)", check.Status)
 	}
 }
 

--- a/internal/health/verify_integration_test.go
+++ b/internal/health/verify_integration_test.go
@@ -166,7 +166,7 @@ func TestRunChecks_TelegramSlackLive_EndToEnd(t *testing.T) {
 		},
 	}
 
-	report := RunChecks(cfg)
+	report := RunChecks(cfg, "")
 
 	tgLive := findConfigCheck(report.Config, "telegram.token.live")
 	if tgLive == nil || tgLive.Status != StatusError {

--- a/internal/upgrade/checker.go
+++ b/internal/upgrade/checker.go
@@ -16,6 +16,13 @@ type VersionChecker struct {
 	checkInterval  time.Duration
 	onUpdate       func(info *VersionInfo)
 
+	// staleThreshold and onStale implement the GH-3790 fail-loud check: if
+	// the daemon falls this many releases behind, self-upgrade has likely
+	// stopped firing (root cause: it previously only ran when a human
+	// pressed 'u' in the TUI) and someone needs to notice. 0 disables it.
+	staleThreshold int
+	onStale        func(info *VersionInfo)
+
 	mu          sync.RWMutex
 	latestInfo  *VersionInfo
 	lastCheck   time.Time
@@ -53,6 +60,25 @@ func (c *VersionChecker) OnUpdate(fn func(info *VersionInfo)) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.onUpdate = fn
+}
+
+// SetStaleThreshold configures the fail-loud staleness check (GH-3790): once
+// the daemon is at least n releases behind, each check logs a WARN and (if
+// OnStale is set) fires a callback so an alert can be raised. n <= 0 disables
+// the check (the default).
+func (c *VersionChecker) SetStaleThreshold(n int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.staleThreshold = n
+}
+
+// OnStale sets the callback invoked when the staleness threshold is met or
+// exceeded. Called on every check while the daemon remains stale, so callers
+// that want deduplication/cooldown should implement it in fn.
+func (c *VersionChecker) OnStale(fn func(info *VersionInfo)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onStale = fn
 }
 
 // Start begins periodic version checking in the background
@@ -129,8 +155,21 @@ func (c *VersionChecker) check(ctx context.Context) {
 	c.mu.Lock()
 	c.latestInfo = info
 	c.lastCheck = time.Now()
-	callback := c.onUpdate
 	c.mu.Unlock()
+
+	c.evaluate(info)
+}
+
+// evaluate fires the OnUpdate/OnStale callbacks for a freshly fetched
+// VersionInfo. Split out from check() so the callback-decision logic (which
+// doesn't touch the network) can be unit-tested directly with a synthetic
+// VersionInfo, instead of only indirectly via a live GitHub API call.
+func (c *VersionChecker) evaluate(info *VersionInfo) {
+	c.mu.RLock()
+	callback := c.onUpdate
+	staleThreshold := c.staleThreshold
+	staleCallback := c.onStale
+	c.mu.RUnlock()
 
 	if info.UpdateAvail && callback != nil {
 		slog.Info("update available",
@@ -138,6 +177,22 @@ func (c *VersionChecker) check(ctx context.Context) {
 			slog.String("latest", info.Latest),
 		)
 		callback(info)
+	}
+
+	// GH-3790: fail loud instead of letting staleness go unnoticed the way
+	// it did for 7+ hours across 8 releases — self-upgrade previously had no
+	// automatic trigger at all, so nothing ever surfaced how far behind the
+	// daemon had drifted.
+	if staleThreshold > 0 && info.ReleasesBehind >= staleThreshold {
+		slog.Warn("daemon is running a stale release — self-upgrade may not be firing",
+			slog.String("current", info.Current),
+			slog.String("latest", info.Latest),
+			slog.Int("releases_behind", info.ReleasesBehind),
+			slog.Int("stale_threshold", staleThreshold),
+		)
+		if staleCallback != nil {
+			staleCallback(info)
+		}
 	}
 }
 

--- a/internal/upgrade/checker_test.go
+++ b/internal/upgrade/checker_test.go
@@ -1,0 +1,86 @@
+package upgrade
+
+import (
+	"testing"
+)
+
+// newTestChecker builds a VersionChecker without running NewVersionChecker's
+// NewUpgrader probe (which touches os.Executable/symlinks) — evaluate() only
+// needs the callback/threshold fields these tests exercise.
+func newTestChecker() *VersionChecker {
+	return &VersionChecker{currentVersion: "2.201.2"}
+}
+
+func TestVersionChecker_OnUpdate_FiresOnUpdateAvail(t *testing.T) {
+	c := newTestChecker()
+	var got *VersionInfo
+	c.OnUpdate(func(info *VersionInfo) { got = info })
+
+	c.evaluate(&VersionInfo{Current: "2.201.2", Latest: "v2.201.3", UpdateAvail: true})
+
+	if got == nil {
+		t.Fatal("OnUpdate callback was not invoked")
+	}
+	if got.Latest != "v2.201.3" {
+		t.Errorf("Latest = %q, want v2.201.3", got.Latest)
+	}
+}
+
+func TestVersionChecker_OnUpdate_SkippedWhenNoUpdate(t *testing.T) {
+	c := newTestChecker()
+	called := false
+	c.OnUpdate(func(info *VersionInfo) { called = true })
+
+	c.evaluate(&VersionInfo{Current: "2.201.2", Latest: "v2.201.2", UpdateAvail: false})
+
+	if called {
+		t.Error("OnUpdate callback should not fire when UpdateAvail is false")
+	}
+}
+
+func TestVersionChecker_OnStale_DisabledByDefault(t *testing.T) {
+	c := newTestChecker()
+	called := false
+	c.OnStale(func(info *VersionInfo) { called = true })
+
+	// staleThreshold defaults to 0 (disabled) — even 8 releases behind must
+	// not fire until a threshold is explicitly set (GH-3790).
+	c.evaluate(&VersionInfo{Current: "2.201.2", Latest: "v2.207.1", ReleasesBehind: 8})
+
+	if called {
+		t.Error("OnStale should not fire when staleThreshold is 0 (disabled)")
+	}
+}
+
+func TestVersionChecker_OnStale_FiresAtOrAboveThreshold(t *testing.T) {
+	c := newTestChecker()
+	c.SetStaleThreshold(3)
+
+	var calls int
+	var lastInfo *VersionInfo
+	c.OnStale(func(info *VersionInfo) {
+		calls++
+		lastInfo = info
+	})
+
+	// Below threshold: no callback.
+	c.evaluate(&VersionInfo{Current: "2.201.2", Latest: "v2.202.0", ReleasesBehind: 2})
+	if calls != 0 {
+		t.Fatalf("calls = %d, want 0 for releases_behind below threshold", calls)
+	}
+
+	// At threshold: callback fires.
+	c.evaluate(&VersionInfo{Current: "2.201.2", Latest: "v2.204.0", ReleasesBehind: 3})
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1 at threshold", calls)
+	}
+	if lastInfo.ReleasesBehind != 3 {
+		t.Errorf("ReleasesBehind = %d, want 3", lastInfo.ReleasesBehind)
+	}
+
+	// Above threshold: callback fires again (GH-3790 shape: 8 releases behind).
+	c.evaluate(&VersionInfo{Current: "2.201.2", Latest: "v2.207.1", ReleasesBehind: 8})
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2 above threshold", calls)
+	}
+}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -57,6 +57,10 @@ type VersionInfo struct {
 	LatestRelease *Release
 	UpdateAvail   bool
 	ReleaseNotes  string
+	// ReleasesBehind counts stable (non-draft, non-prerelease) releases newer
+	// than Current, up to releasesFetchLimit. Used by the staleness check
+	// (GH-3790) to fail loud when self-upgrade has silently stopped firing.
+	ReleasesBehind int
 }
 
 // Upgrader handles version checking and self-update
@@ -119,23 +123,48 @@ func isHomebrewPath(path string) bool {
 
 // CheckVersion checks if a newer version is available
 func (u *Upgrader) CheckVersion(ctx context.Context) (*VersionInfo, error) {
-	release, err := u.fetchLatestRelease(ctx)
+	releases, err := u.fetchReleases(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch latest release: %w", err)
+	}
+
+	release := firstStableRelease(releases)
+	if release == nil {
+		return nil, fmt.Errorf("no releases found")
 	}
 
 	latest := strings.TrimPrefix(release.TagName, "v")
 	current := strings.TrimPrefix(u.currentVersion, "v")
 
 	info := &VersionInfo{
-		Current:       u.currentVersion,
-		Latest:        release.TagName,
-		LatestRelease: release,
-		UpdateAvail:   compareVersions(current, latest) < 0,
-		ReleaseNotes:  release.Body,
+		Current:        u.currentVersion,
+		Latest:         release.TagName,
+		LatestRelease:  release,
+		UpdateAvail:    compareVersions(current, latest) < 0,
+		ReleaseNotes:   release.Body,
+		ReleasesBehind: ReleasesBehind(releases, u.currentVersion),
 	}
 
 	return info, nil
+}
+
+// ReleasesBehind counts how many releases in the list are stable
+// (non-draft, non-prerelease) and newer than currentVersion. Exported so
+// callers outside this package (e.g. internal/health's doctor check) can
+// reuse the same comparison instead of re-deriving it (GH-3790).
+func ReleasesBehind(releases []Release, currentVersion string) int {
+	current := strings.TrimPrefix(currentVersion, "v")
+	count := 0
+	for i := range releases {
+		if releases[i].Draft || releases[i].Prerelease {
+			continue
+		}
+		tag := strings.TrimPrefix(releases[i].TagName, "v")
+		if compareVersions(current, tag) < 0 {
+			count++
+		}
+	}
+	return count
 }
 
 // Upgrade downloads and installs the latest version
@@ -224,11 +253,17 @@ func (u *Upgrader) BinaryPath() string {
 	return u.binaryPath
 }
 
-// fetchLatestRelease fetches the latest release from GitHub
+// releasesFetchLimit bounds how many releases are pulled per check. Needs to
+// comfortably exceed how many releases can ship between checks — GH-3790 saw
+// 8 releases pass silently in one 7h11m gap — so staleness counting doesn't
+// undercount once it starts falling behind.
+const releasesFetchLimit = 30
+
+// fetchReleases fetches the most recent releases from GitHub.
 // Uses /releases endpoint instead of /releases/latest to avoid GitHub API caching
 // which can return stale data for several minutes after a new release is created.
-func (u *Upgrader) fetchLatestRelease(ctx context.Context) (*Release, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/releases?per_page=10", GitHubRepo)
+func (u *Upgrader) fetchReleases(ctx context.Context) ([]Release, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases?per_page=%d", GitHubRepo, releasesFetchLimit)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
@@ -254,19 +289,22 @@ func (u *Upgrader) fetchLatestRelease(ctx context.Context) (*Release, error) {
 		return nil, fmt.Errorf("failed to parse releases: %w", err)
 	}
 
-	// Find first non-draft, non-prerelease release
+	return releases, nil
+}
+
+// firstStableRelease returns the first non-draft, non-prerelease release, or
+// falls back to the first release if all are drafts/prereleases. Returns nil
+// for an empty list.
+func firstStableRelease(releases []Release) *Release {
 	for i := range releases {
 		if !releases[i].Draft && !releases[i].Prerelease {
-			return &releases[i], nil
+			return &releases[i]
 		}
 	}
-
 	if len(releases) == 0 {
-		return nil, fmt.Errorf("no releases found")
+		return nil
 	}
-
-	// Fallback to first release if all are drafts/prereleases
-	return &releases[0], nil
+	return &releases[0]
 }
 
 // findAsset finds the appropriate release asset for the current platform

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -69,6 +69,70 @@ func TestParseVersion(t *testing.T) {
 	}
 }
 
+func TestReleasesBehind(t *testing.T) {
+	tests := []struct {
+		name     string
+		releases []Release
+		current  string
+		want     int
+	}{
+		{
+			name:     "empty list",
+			releases: nil,
+			current:  "2.201.2",
+			want:     0,
+		},
+		{
+			name: "several releases behind (GH-3790 shape)",
+			releases: []Release{
+				{TagName: "v2.207.1"},
+				{TagName: "v2.206.1"},
+				{TagName: "v2.206.0"},
+				{TagName: "v2.205.0"},
+				{TagName: "v2.201.2"},
+			},
+			current: "2.201.2",
+			want:    4,
+		},
+		{
+			name: "up to date",
+			releases: []Release{
+				{TagName: "v2.201.2"},
+			},
+			current: "2.201.2",
+			want:    0,
+		},
+		{
+			name: "drafts and prereleases excluded",
+			releases: []Release{
+				{TagName: "v2.202.0", Draft: true},
+				{TagName: "v2.201.3", Prerelease: true},
+				{TagName: "v2.201.2"},
+			},
+			current: "2.201.2",
+			want:    0,
+		},
+		{
+			name: "v prefix on current is normalized",
+			releases: []Release{
+				{TagName: "v2.202.0"},
+				{TagName: "v2.201.2"},
+			},
+			current: "v2.201.2",
+			want:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ReleasesBehind(tt.releases, tt.current)
+			if got != tt.want {
+				t.Errorf("ReleasesBehind() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestVersionInfo_UpdateAvailable(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- Root-caused (GH-3790-1/2): `versionChecker.OnUpdate` only logged/notified — `upgradeRequestCh` was only ever written by the TUI's `'u'` keypress, so hot upgrade silently required a human watching `--dashboard`. Confirmed via daemon.log: 7h11m silent gap across 8 releases with zero errors.
- Fix (GH-3790-3): `OnUpdate` now auto-enqueues the same request the keypress sends, gated by new `upgrade.auto_hot_upgrade` config (default true). Keypress still works as a manual override.
- Fail-loud check: `VersionChecker.SetStaleThreshold`/`OnStale` logs WARN and fires an `alerts.Event` once the daemon is `upgrade.stale_release_threshold` releases behind (new `upgrade.ReleasesBehind` helper; release fetch bumped from 10 to 30 per page so an 8-behind daemon doesn't undercount). Added a `pilot doctor` counterpart (`checkSelfUpgradeStaleness`).
- Side fix: added the missing default `service_unhealthy` alert rule so config-error/staleness alerts actually dispatch instead of only logging (pre-existing gap from GH-3718).

Closes #3790.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite green, incl. new `TestReleasesBehind`, `TestVersionChecker_On{Update,Stale}_*`, `TestCheckSelfUpgradeStaleness_*`)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues