### PR TITLE
fix(adapters): enforce Blocked-by gating at dispatch time

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -656,6 +656,18 @@ func (p *Poller) startSequential(ctx context.Context) {
 			}
 		}
 
+		// GH-3789 (D6): findOldestUnprocessedIssue checked dependencies during
+		// candidate selection; the pre-flight judge call above can take enough
+		// wall-clock time (LLM round trip) for a blocker to reopen before actual
+		// dispatch. Re-verify immediately before starting work.
+		if p.hasPendingDependencies(ctx, issue) {
+			p.logger.Info("Skipping dispatch — blocker reopened since candidate selection",
+				slog.Int("number", issue.Number),
+			)
+			p.recordSkip(skipreason.ReasonPendingDependency)
+			continue
+		}
+
 		// Board sync: move card to in-progress on confirmed dispatch (GH-3252).
 		p.syncBoardStatusInProgress(ctx, issue)
 
@@ -1016,6 +1028,7 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 			slog.Int("number", candidate.Number),
 			slog.String("title", candidate.Title),
 		)
+		p.recordSkip(skipreason.ReasonPendingDependency)
 	}
 
 	// All candidates have pending dependencies
@@ -1428,6 +1441,23 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case p.semaphore <- struct{}{}:
+		}
+
+		// GH-3789 (D6): an issue can sit here behind a full semaphore for
+		// the rest of the poll interval. Phase 1's hasPendingDependencies
+		// check ran before that wait started, so a blocker that reopened
+		// in the meantime would otherwise slip through — replaying the
+		// GH-3759 incident where a gated task ran while its "Blocked by"
+		// issue was still open. Re-verify immediately before burning the
+		// worker slot.
+		if p.hasPendingDependencies(ctx, issue) {
+			<-p.semaphore // release the slot we just acquired
+			p.unmarkProcessed(issue.Number)
+			p.logger.Info("Skipping dispatch — blocker reopened while queued for a worker slot",
+				slog.Int("number", issue.Number),
+			)
+			p.recordSkip(skipreason.ReasonPendingDependency)
+			continue
 		}
 
 		p.recordDispatched()

--- a/internal/adapters/github/poller_skip_metrics_test.go
+++ b/internal/adapters/github/poller_skip_metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -191,6 +192,166 @@ func TestPoller_ScopeOverlapDeferral_IncrementsMetric(t *testing.T) {
 	}
 	if m.dispatched != 1 {
 		t.Errorf("dispatched = %d, want 1", m.dispatched)
+	}
+}
+
+// GH-3789 (D6): the parallel/auto-mode Phase 1 gate must skip an issue whose
+// "Blocked by" dependency is still open, and that skip must be visible via
+// pollerMetrics — not just a log line.
+func TestPoller_CheckForNewIssues_SkipsPendingDependency_RecordsMetric(t *testing.T) {
+	pilot := Label{Name: "pilot"}
+	issue := &Issue{Number: 1, Title: "gated task", Body: "Blocked by: #100", Labels: []Label{pilot}, CreatedAt: time.Now()}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode([]*Issue{issue})
+		case "/repos/owner/repo/issues/100":
+			_ = json.NewEncoder(w).Encode(&Issue{Number: 100, State: "open"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	m := newFakePollerMetrics()
+	var dispatches int32
+
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, i *Issue) error {
+			atomic.AddInt32(&dispatches, 1)
+			return nil
+		}),
+		WithPollerMetrics(m),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&dispatches); got != 0 {
+		t.Errorf("dispatched %d times, want 0 (blocker still open)", got)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if got := m.skipped[skipreason.ReasonPendingDependency]; got != 1 {
+		t.Errorf("skipped[pending_dependency] = %d, want 1", got)
+	}
+}
+
+// GH-3789 (D6): an issue can clear the Phase 1 dependency gate (blocker
+// closed) and then sit in the dispatch loop waiting for a worker slot. If
+// the blocker reopens during that wait, dispatch must re-check and refuse
+// to run — this reproduces the GH-3759 incident where a gated task executed
+// while its blocker was still open.
+func TestPoller_CheckForNewIssues_DispatchTimeRecheck_BlockerReopened(t *testing.T) {
+	pilot := Label{Name: "pilot"}
+	issue := &Issue{Number: 1, Title: "gated task", Body: "Blocked by: #100", Labels: []Label{pilot}, CreatedAt: time.Now()}
+
+	var depCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode([]*Issue{issue})
+		case "/repos/owner/repo/issues/1":
+			// GH-2341 fresh-label refresh before dispatch — same issue, still gated-clean.
+			_ = json.NewEncoder(w).Encode(issue)
+		case "/repos/owner/repo/issues/100":
+			// First call is the Phase 1 candidate-selection check (blocker closed).
+			// Second call is the new dispatch-time recheck — blocker reopened.
+			n := atomic.AddInt32(&depCalls, 1)
+			state := "closed"
+			if n > 1 {
+				state = "open"
+			}
+			_ = json.NewEncoder(w).Encode(&Issue{Number: 100, State: state})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	m := newFakePollerMetrics()
+	var dispatches int32
+
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, i *Issue) error {
+			atomic.AddInt32(&dispatches, 1)
+			return nil
+		}),
+		WithPollerMetrics(m),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&dispatches); got != 0 {
+		t.Errorf("dispatched %d times, want 0 (blocker reopened before dispatch)", got)
+	}
+	if got := atomic.LoadInt32(&depCalls); got < 2 {
+		t.Fatalf("dependency issue fetched %d times, want ≥2 (poll-time + dispatch-time recheck)", got)
+	}
+
+	m.mu.Lock()
+	skippedPending := m.skipped[skipreason.ReasonPendingDependency]
+	m.mu.Unlock()
+	if skippedPending != 1 {
+		t.Errorf("skipped[pending_dependency] = %d, want 1", skippedPending)
+	}
+
+	// The issue must not be left permanently marked processed — it should be
+	// reconsidered on the very next poll once the blocker closes again.
+	poller.mu.RLock()
+	_, processed := poller.processed[1]
+	poller.mu.RUnlock()
+	if processed {
+		t.Error("issue should not remain marked processed after blocker-reopened skip")
+	}
+}
+
+// GH-3789 (D6): the sequential/FIFO path (findOldestUnprocessedIssue) had no
+// pollerMetrics visibility at all for skipped issues — per-project FIFO
+// happening to queue the blocker first masked the missing gate. Verify the
+// skip is now recorded the same way the parallel path already does.
+func TestPoller_FindOldestUnprocessedIssue_RecordsSkipMetric(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 1, Title: "gated", Body: "Blocked by: #100", Labels: []Label{{Name: "pilot"}}, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode(issues)
+		case "/repos/owner/repo/issues/100":
+			_ = json.NewEncoder(w).Encode(&Issue{Number: 100, State: "open"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	m := newFakePollerMetrics()
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithPollerMetrics(m))
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue != nil {
+		t.Errorf("issue should be nil (only candidate has an open blocker), got #%d", issue.Number)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if got := m.skipped[skipreason.ReasonPendingDependency]; got != 1 {
+		t.Errorf("skipped[pending_dependency] = %d, want 1", got)
 	}
 }
 

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1247,6 +1248,80 @@ func TestPoller_FindOldestUnprocessedIssue_AllDepsOpen(t *testing.T) {
 	// Should return nil when all issues have open dependencies
 	if issue != nil {
 		t.Errorf("issue should be nil when all have open dependencies, got #%d", issue.Number)
+	}
+}
+
+// GH-3789 (D6): table-driven coverage for multiple "Blocked by" / "Depends on"
+// references on a single issue — any one open blocker must hold the gate,
+// and a bare "#N" mention that isn't dependency syntax must not.
+func TestPoller_HasPendingDependencies_MultipleBlockers(t *testing.T) {
+	tests := []struct {
+		name      string
+		issueBody string
+		states    map[int]string // dependency issue number -> state
+		want      bool
+	}{
+		{
+			name:      "two blockers, both closed",
+			issueBody: "Blocked by: #100\nBlocked by: #101",
+			states:    map[int]string{100: "closed", 101: "closed"},
+			want:      false,
+		},
+		{
+			name:      "two blockers, one still open",
+			issueBody: "Blocked by: #100\nBlocked by: #101",
+			states:    map[int]string{100: "closed", 101: "open"},
+			want:      true,
+		},
+		{
+			name:      "two blockers, both open",
+			issueBody: "Blocked by: #100\nBlocked by: #101",
+			states:    map[int]string{100: "open", 101: "open"},
+			want:      true,
+		},
+		{
+			name:      "mixed dependency verbs, one open",
+			issueBody: "Depends on: #100\nRequires: #101",
+			states:    map[int]string{100: "closed", 101: "open"},
+			want:      true,
+		},
+		{
+			name:      "bare issue mention is not a dependency",
+			issueBody: "See #100 for context",
+			states:    map[int]string{100: "open"},
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+				num, err := strconv.Atoi(parts[len(parts)-1])
+				if err != nil {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				state, ok := tt.states[num]
+				if !ok {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(&Issue{Number: num, State: state})
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+			issue := &Issue{Number: 1, Body: tt.issueBody}
+			got := poller.hasPendingDependencies(context.Background(), issue)
+
+			if got != tt.want {
+				t.Errorf("hasPendingDependencies() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes GH-3789 / Defect D6 (TASK-382): `Blocked by: #N` gating already ran at poll/candidate-selection time (`hasPendingDependencies`, both sequential and parallel/auto pollers), but neither path re-checked the blocker's state right before actually claiming a worker slot. A task could clear the gate, sit queued behind a full semaphore (parallel) or a pre-flight judge round trip (sequential), and dispatch even if the blocker reopened in the meantime — this is how GH-3759 ran while `#3754` was still open.
- Added a dispatch-time recheck of `hasPendingDependencies` right after the semaphore slot is claimed in `checkForNewIssues` (parallel/auto), releasing the slot and un-marking the issue for retry if the blocker is open.
- Added the same recheck in `startSequential`, right before `processIssueSequential` is called.
- The sequential path (`findOldestUnprocessedIssue`) never recorded a `skipreason` metric for pending-dependency skips, unlike the parallel path — added `recordSkip(skipreason.ReasonPendingDependency)` there so the FIFO path has the same metrics visibility.

## Test plan

- [x] `TestPoller_HasPendingDependencies_MultipleBlockers` — table-driven: two blockers both closed/one open/both open, mixed verb blockers, bare `#N` mention not treated as a dependency
- [x] `TestPoller_CheckForNewIssues_SkipsPendingDependency_RecordsMetric` — parallel-mode Phase 1 gate skips an open blocker and records the metric
- [x] `TestPoller_CheckForNewIssues_DispatchTimeRecheck_BlockerReopened` — reproduces the GH-3759 race: blocker closed at candidate selection, reopened before the worker slot is claimed; asserts zero dispatches and the issue is not left permanently marked processed
- [x] `TestPoller_FindOldestUnprocessedIssue_RecordsSkipMetric` — sequential-mode skip now visible via `skipreason`
- [x] `make test && make lint` pass (one pre-existing flaky test in `internal/replay` unrelated to this change, confirmed flaky on `main` too)