### PR TITLE
GH-3787: fix(executor): retry accounting counts infra noise and exhausts retries on already-shipped work

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -401,6 +401,18 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 		boardStatuses := cfg.Adapters.GitHub.ProjectBoard.GetStatuses()
 
 		if execErr != nil {
+			// GH-3787: restart-reap / rate-limit / infra / startup-preflight noise is
+			// not a genuine execution failure. Skip labeling entirely — no pilot-failed,
+			// no retry-counter escalation — so the poller silently re-picks the issue
+			// on its next cycle without burning failed-retry budget on work that may
+			// already be shipped.
+			if executor.IsInfraNoise(execErr.Error()) {
+				slog.Info("execution failure classified as infra noise — skipping pilot-failed label, will retry quietly",
+					slog.Int("issue", issue.Number),
+					slog.String("error", execErr.Error()),
+				)
+				return issueResult, nil
+			}
 			// GH-2402: Classify deterministic failures (e.g. non-conventional title)
 			// as pilot-blocked instead of pilot-failed so the poller stops retrying.
 			failureLabel := github.LabelFailed
@@ -544,6 +556,13 @@ func handleGitHubIssueWithResult(ctx context.Context, cfg *config.Config, client
 				}
 				// issueResult.Success stays false (no new deliverable this run), but no
 				// failure/blocked label is applied — the open PR is the deliverable.
+			} else if hr.Result.Error != "" && executor.IsInfraNoise(hr.Result.Error) {
+				// GH-3787: same infra-noise skip as the execErr branch above — no
+				// label, no comment, quiet re-dispatch next cycle.
+				slog.Info("execution result classified as infra noise — skipping pilot-failed label, will retry quietly",
+					slog.Int("issue", issue.Number),
+					slog.String("error", hr.Result.Error),
+				)
 			} else {
 				// result exists but Success is false - mark as failed
 				// GH-2402: Use pilot-blocked for deterministic failures so we don't retry.

--- a/internal/adapters/github/gh3715_test.go
+++ b/internal/adapters/github/gh3715_test.go
@@ -215,6 +215,80 @@ func TestPoller_FailedRetryLabel_SurvivesPollerReconstruction(t *testing.T) {
 	}
 }
 
+// GH-3787: when the retry budget is about to escalate to
+// pilot-failed-retry-exhausted, but the deliverable already shipped (merged
+// PR found via search), the issue must be closed as done instead of parked
+// as permanently failed. Regression for the incident where GH-3759's PR
+// merged while restart noise burned the last retry slot.
+func TestPoller_FailedRetryLabel_ShippedClosesAsDoneInsteadOfExhausted(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Stuck issue", Labels: []Label{{Name: "pilot"}, {Name: LabelFailed}, {Name: LabelFailedRetry2}}, CreatedAt: now.Add(-1 * time.Hour)},
+		{Number: 43, State: "open", Title: "Available", Labels: []Label{{Name: "pilot"}}, CreatedAt: now},
+	}
+
+	var addedLabels atomic.Value
+	addedLabels.Store([]string(nil))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/issues/42/labels"):
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			prev, _ := addedLabels.Load().([]string)
+			addedLabels.Store(append(prev, body.Labels...))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+			return
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+			return
+		case r.URL.Path == "/search/issues":
+			// A merged PR referencing #42 already exists — the deliverable shipped.
+			// #43 has no merged work, so its search query must report zero.
+			if strings.Contains(r.URL.RawQuery, "GH-42") {
+				_, _ = w.Write([]byte(`{"total_count": 1}`))
+			} else {
+				_, _ = w.Write([]byte(`{"total_count": 0}`))
+			}
+			return
+		}
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithRetryGracePeriod(0))
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue == nil || issue.Number != 43 {
+		t.Errorf("expected #43, got %v", issue)
+	}
+
+	added, _ := addedLabels.Load().([]string)
+	var foundDone, foundExhausted bool
+	for _, l := range added {
+		if l == LabelDone {
+			foundDone = true
+		}
+		if l == LabelFailedRetryExhausted {
+			foundExhausted = true
+		}
+	}
+	if !foundDone {
+		t.Errorf("expected pilot-done to be added to shipped issue #42, got labels=%v", added)
+	}
+	if foundExhausted {
+		t.Errorf("expected pilot-failed-retry-exhausted NOT to be added to a shipped issue, got labels=%v", added)
+	}
+}
+
 // FailedRetryStateLabels exposes the canonical list for cleanup on merge.
 func TestFailedRetryStateLabels_OrderingAndCompleteness(t *testing.T) {
 	want := []string{LabelFailedRetry1, LabelFailedRetry2, LabelFailedRetryExhausted}

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -1876,6 +1876,15 @@ func (p *Poller) shouldRetryFailedIssue(ctx context.Context, issue *Issue) bool 
 		return false
 	}
 
+	// GH-3787: check shipped-ness BEFORE any retry-counter accounting,
+	// including the escalate-to-exhausted path below. A restart-noise streak
+	// (stale-task reap + preflight blip) can burn through the retry budget
+	// on an issue whose deliverable already merged — hasMergedWork closes it
+	// as done instead of letting it get parked as pilot-failed-retry-exhausted.
+	if p.hasMergedWork(ctx, issue) {
+		return false
+	}
+
 	// Determine the next retry-counter label based on current state.
 	var currentRetryLabel, nextRetryLabel string
 	switch {
@@ -1907,11 +1916,6 @@ func (p *Poller) shouldRetryFailedIssue(ctx context.Context, issue *Issue) bool 
 		p.logger.Warn("Issue exhausted failed-retry budget — escalated to pilot-failed-retry-exhausted",
 			slog.Int("number", issue.Number),
 		)
-		return false
-	}
-
-	// Check if merged work already exists before retrying
-	if p.hasMergedWork(ctx, issue) {
 		return false
 	}
 

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -54,6 +54,65 @@ func IsPermanentFailure(errStr string) bool {
 	return false
 }
 
+// reapErrorSignatures are substrings written by the dispatcher's stale-task
+// recovery (dispatcher.go recoverStaleRunningTasks / recoverStaleQueuedTasks)
+// when a daemon restart orphans a running or queued execution row. These
+// describe operational noise from the restart itself, not a genuine
+// execution failure — the underlying task may already be shipped, or simply
+// waiting for its next dispatch attempt. GH-3787.
+var reapErrorSignatures = []string{
+	"stale running task recovered",
+	"stale queued task recovered",
+	"queued task orphaned by restart",
+}
+
+// preflightFailureSignature marks an error produced by
+// RunPreflightChecksCustom (preflight.go). GH-3787.
+const preflightFailureSignature = "preflight check"
+
+// PreflightBootGrace bounds how long after process start a preflight
+// failure is treated as startup noise instead of a persistent problem.
+// GH-3787: a check like claude_available can transiently fail immediately
+// after a daemon restart/upgrade while its own environment (PATH, auth)
+// is still settling.
+const PreflightBootGrace = 2 * time.Minute
+
+// processStartTime marks when this process began, used by IsInfraNoise to
+// gate preflight failures to the PreflightBootGrace window. GH-3787.
+var processStartTime = time.Now()
+
+// IsInfraNoise reports whether an execution error represents operational
+// noise — a dispatcher restart-reap row, rate limiting, an infra/plumbing
+// failure, or a preflight check that failed within the startup grace window
+// — rather than a genuine execution failure. GH-3787: callers that track a
+// bounded failed-retry budget (poller pilot-failed-retry-N labels) must not
+// consume that budget for these outcomes, or a daemon restart can exhaust
+// retries on work that already shipped.
+func IsInfraNoise(errStr string) bool {
+	return isInfraNoiseAt(errStr, time.Since(processStartTime))
+}
+
+// isInfraNoiseAt is the time-injectable core of IsInfraNoise so tests don't
+// depend on real elapsed wall-clock time.
+func isInfraNoiseAt(errStr string, sinceProcessStart time.Duration) bool {
+	if errStr == "" {
+		return false
+	}
+	if containsAny(errStr, reapErrorSignatures) {
+		return true
+	}
+	if containsAny(errStr, rateLimitedSignatures) {
+		return true
+	}
+	if containsAny(errStr, infraErrorSignatures) {
+		return true
+	}
+	if sinceProcessStart < PreflightBootGrace && containsAny(errStr, []string{preflightFailureSignature}) {
+		return true
+	}
+	return false
+}
+
 // gitPushRetryAttempts / gitPushRetryDelay and prCreateRetryAttempts /
 // prCreateRetryDelay bound the retry loops around the child push/PR-create
 // step (GH-3785). Prior behavior gave up on the first transient failure,

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3462,6 +3462,40 @@ func TestIsPermanentFailure(t *testing.T) {
 	}
 }
 
+// TestIsInfraNoise verifies that restart-reap rows, rate limiting, infra
+// plumbing failures, and boot-window preflight failures are classified as
+// operational noise — not genuine execution failures — so callers that cap
+// a failed-retry budget (poller pilot-failed-retry-N labels) don't burn it
+// on a daemon restart. GH-3787.
+func TestIsInfraNoise(t *testing.T) {
+	tests := []struct {
+		name              string
+		err               string
+		sinceProcessStart time.Duration
+		want              bool
+	}{
+		{"empty string", "", time.Hour, false},
+		{"stale running task reap", "stale running task recovered (orphaned worker)", time.Hour, true},
+		{"stale queued task reap", "stale queued task recovered (no worker picked up)", time.Hour, true},
+		{"queued task orphaned by restart", "queued task orphaned by restart; project no longer configured", time.Hour, true},
+		{"rate limited", "hit your limit for the day", time.Hour, true},
+		{"oom killed", "oom_killed: signal: killed", time.Hour, true},
+		{"push failed infra", "push failed after 3 attempt(s): connection reset", time.Hour, true},
+		{"preflight failure within boot grace", "pre-flight check failed: preflight check \"claude_available\" failed: exec: \"claude\": not found", 30 * time.Second, true},
+		{"preflight failure after boot grace", "pre-flight check failed: preflight check \"claude_available\" failed: exec: \"claude\": not found", 10 * time.Minute, false},
+		{"genuine execution failure", "quality gate failed: 3 lint errors", time.Hour, false},
+		{"genuine planning failure", "unknown: exit status 1", time.Hour, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInfraNoiseAt(tt.err, tt.sinceProcessStart); got != tt.want {
+				t.Errorf("isInfraNoiseAt(%q, %v) = %v, want %v", tt.err, tt.sinceProcessStart, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestRunnerFallbackModelName verifies that the telemetry fallback model name
 // reflects the configured backend, not a hardcoded default. GH-2428.
 func TestRunnerFallbackModelName(t *testing.T) {


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3787.

Closes #3787

## Changes

GitHub Issue #3787: fix(executor): retry accounting counts infra noise and exhausts retries on already-shipped work

Blocked by: #3786

## Context
Defect D4 from TASK-382. GH-3759's deliverable merged at 17:52 (PR #3773), yet the issue was labeled `pilot-failed-retry-exhausted` at ~18:05 — the retry counter (B3, #3715) consumed its budget on restart noise: a `stale running task recovered (orphaned worker)` reap row and a transient `claude_available` preflight failure during daemon boot. A shipped task was parked as permanently failed and needed manual closing.

## Fix
- Do not count infra-classified outcomes (`stale * recovered`, `rate_limited`, `infra`, preflight failures during startup grace) toward the failed-retry cap — only genuine execution failures.
- Before applying `pilot-failed-retry-exhausted`, check shipped-ness (`IsTaskShipped`/`HasCompletedExecution` in `internal/memory/store.go:631`, and merged PR presence) — if shipped, close the issue as done instead of parking it.
- Transient preflight failures within N seconds of daemon boot should retry quietly, not consume attempts.

## Acceptance
- [ ] Reap/infra rows don't increment the retry counter (unit test)
- [ ] Retry-exhaustion path checks shipped-ness first; shipped → close-as-done
- [ ] make test && make lint pass