### PR TITLE
GH-3806: fix(autopilot): CI-failed PRs are closed silently — no PR comment, no issue label correction

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -837,6 +837,19 @@
         "created": "2026-07-04",
         "file": ".agent/knowledge/memories/decisions/decision_self_upgrade_auto_trigger_and_staleness_check.md",
         "origin_task": "GH-3790-3"
+      },
+      "mem-046": {
+        "type": "pitfall",
+        "summary": "Autopilot's direct PR-close call sites (handleCIFailed iteration-limit/size-guard/main, handleReviewRequested iteration-limit/main) never posted a PR/issue comment or corrected issue labels \u2014 the only convergence point that could have was notifyExternalClose, whose pilot-done skip-guard (GH-2340) returned with zero comments when the issue already had pilot-done from an earlier, unrelated PR. Result: PR #3802 (fix for #3789) closed CI-red with zero explanation and #3789 kept pilot-done, making discarded work look shipped (TASK-382 D9). Fix (GH-3806): notifyExternalClose now always posts a PR comment (AddPRComment hits /issues/{prNumber}/comments, not /pulls/.../comments) + issue comment from prState.Error on every branch including both skip guards; close sites set prState.Error (specific reason) and new in-memory PRState.TerminalLabel (forces pilot-failed instead of pilot-retry-ready when terminal or superseded by a follow-up issue) instead of commenting inline.",
+        "concepts": [
+          "autopilot"
+        ],
+        "confidence": 0.9,
+        "severity": "high",
+        "created": "2026-07-04",
+        "incident": "TASK-382 D9, observed 2026-07-04 00:30 UTC: PR #3802 closed CI-red silently, issue #3789 retained pilot-done.",
+        "file": ".agent/knowledge/memories/pitfalls/bug_autopilot_silent_pr_close_notifyexternalclose_convergence.md",
+        "origin_task": "GH-3806"
       }
     }
   },

--- a/.agent/knowledge/memories/pitfalls/bug_autopilot_silent_pr_close_notifyexternalclose_convergence.md
+++ b/.agent/knowledge/memories/pitfalls/bug_autopilot_silent_pr_close_notifyexternalclose_convergence.md
@@ -1,0 +1,46 @@
+---
+name: autopilot's direct PR-close call sites (handleCIFailed, handleReviewRequested, handleMergeConflict) never post comments themselves — the audit trail is only written a poll cycle later, in notifyExternalClose, which the pilot-done skip guard used to bypass entirely
+description: Any code closing a PR in controller.go must set prState.Error (and prState.TerminalLabel if the issue must not be auto-retried) instead of trying to comment inline — notifyExternalClose is the single convergence point for every non-merge close and is where GH-3806's audit trail lives.
+type: pitfall
+---
+**Symptom:** PR #3802 (fix for #3789) went CI-red and autopilot closed it and deleted
+the branch with zero explanation — no PR comment naming the failing check, no issue
+comment, and the source issue #3789 kept its `pilot-done` label from an earlier,
+unrelated successful PR, making discarded work look shipped (TASK-382 D9, GH-3806).
+
+**Root cause — two compounding gaps:**
+1. `handleCIFailed`'s three direct `ClosePullRequest` call sites (iteration-limit,
+   size-guard, and the main cascade path) never posted a PR comment and never
+   touched the linked issue's labels at all. Same for `handleReviewRequested`'s two
+   close sites.
+2. The actual "why" only gets a chance to surface a poll cycle *later*: every close
+   (autopilot's own, or a human's) becomes visible via `checkExternalMergeOrClose` →
+   `notifyExternalClose`, which is the single place that historically added
+   `pilot-retry-ready` / removed `pilot-in-progress`. But its `pilot-done` skip-guard
+   (added for GH-2340, for the legitimate case of a duplicate PR closed after the
+   *real* PR already merged) returned immediately with **zero comments posted at
+   all** — silently eating the story exactly when an issue already had `pilot-done`
+   from an earlier, different PR.
+
+**Fix (GH-3806):** `notifyExternalClose` now always posts a PR comment (`AddPRComment`,
+which — note — hits `/repos/.../issues/{prNumber}/comments`, not `/pulls/.../comments`)
+and an issue comment built from `prState.Error`, on *every* branch including the
+`pilot-done` and human-recovery-PR skip guards. Every direct close site in
+`handleCIFailed`/`handleReviewRequested` now sets `prState.Error` to a specific,
+human-readable reason (embedding failing check names / the follow-up issue number)
+before returning — they don't post comments themselves, because `notifyExternalClose`
+is the one place with confirmed proof the close is visible on GitHub. A new
+`PRState.TerminalLabel` field (in-memory only, same pattern as `EscalationReason`)
+lets a close site force `pilot-failed` instead of the default `pilot-retry-ready`
+when the failure is terminal (iteration/size-guard cap) or a dependent follow-up
+issue already owns the retry — otherwise `notifyExternalClose` would happily
+re-queue a cascade that already hit its cap, or double-dispatch alongside the new
+issue.
+
+**How to apply:** any *new* code path that closes a PR in `controller.go` should set
+`prState.Error` (always) and `prState.TerminalLabel = github.LabelFailed` (when the
+issue must not be auto-retried under its own number) and then just return — do not
+add ad-hoc `AddPRComment`/`AddComment` calls at the close site itself, and do not
+add new logic to the `pilot-done`/human-recovery skip-guard branches without also
+keeping the comment posted. Relates to [[bug_daemon_autoupgrade_reverts_dev_binary]]
+(same TASK-382 defect-burndown epic).

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -966,8 +966,17 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 				}
 			}
 
+			// GH-3806: name the reason and terminal outcome so notifyExternalClose
+			// (which fires on the next poll once it sees this PR closed) can post a
+			// PR/issue comment and correct the issue's labels instead of silently
+			// leaving a stale pilot-in-progress/pilot-done on discarded work.
+			reason := fmt.Sprintf("CI fix iteration limit reached (%d/%d): stopping cascade to prevent infinite loop", iteration, c.config.MaxCIFixIterations)
+			if len(failedChecks) > 0 {
+				reason = fmt.Sprintf("%s (failing checks: %s)", reason, strings.Join(failedChecks, ", "))
+			}
 			prState.Stage = StageFailed
-			prState.Error = fmt.Sprintf("CI fix iteration limit reached (%d/%d): stopping cascade to prevent infinite loop", iteration, c.config.MaxCIFixIterations)
+			prState.Error = reason
+			prState.TerminalLabel = github.LabelFailed
 			c.metrics.RecordPRFailed()
 			c.metrics.RecordIssueProcessed("failed")
 			return nil
@@ -1000,8 +1009,10 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 						c.log.Warn("board sync on exec failure (size guard) failed", "pr", prState.PRNumber, "error", err)
 					}
 				}
+				// GH-3806: see the matching comment on the iteration-limit branch above.
 				prState.Stage = StageFailed
 				prState.Error = fmt.Sprintf("CI fix size guard: PR has %d additions, over limit %d (likely cascade contamination — escalate to human)", netAdditions, c.config.MaxCIFixPRSize)
+				prState.TerminalLabel = github.LabelFailed
 				c.metrics.RecordPRFailed()
 				c.metrics.RecordIssueProcessed("failed")
 				return nil
@@ -1053,7 +1064,18 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 		}
 	}
 
+	// GH-3806: name the reason (and the follow-up issue that now owns this work)
+	// so notifyExternalClose can post the audit-trail comments and mark this
+	// issue pilot-failed instead of leaving it stranded on a stale label — the
+	// fix issue created above carries the retry forward, so this issue must not
+	// also be re-queued (that would double-dispatch the same failure).
+	reason := "CI checks failed"
+	if len(failedChecks) > 0 {
+		reason = fmt.Sprintf("CI checks failed (%s)", strings.Join(failedChecks, ", "))
+	}
 	prState.Stage = StageFailed
+	prState.Error = fmt.Sprintf("%s; fix issue #%d created to continue this work", reason, issueNum)
+	prState.TerminalLabel = github.LabelFailed
 	c.metrics.RecordPRFailed()
 	return nil
 }
@@ -1099,8 +1121,10 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 				c.log.Warn("failed to close PR", "pr", prState.PRNumber, "error", err)
 			}
 
+			// GH-3806: see the matching comment on handleCIFailed's iteration-limit branch.
 			prState.Stage = StageFailed
 			prState.Error = fmt.Sprintf("review feedback iteration limit reached (%d/%d)", iteration, c.config.ReviewFeedback.MaxIterations)
+			prState.TerminalLabel = github.LabelFailed
 			c.metrics.RecordPRFailed()
 			c.metrics.RecordIssueProcessed("failed")
 			return nil
@@ -1161,7 +1185,12 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 		}
 	}
 
+	// GH-3806: the revision issue created above now owns the retry, so this
+	// issue must be marked pilot-failed rather than re-queued (see the matching
+	// comment on handleCIFailed's main CI-fail branch).
 	prState.Stage = StageFailed
+	prState.Error = fmt.Sprintf("changes requested by reviewer; revision issue #%d created to continue this work", issueNum)
+	prState.TerminalLabel = github.LabelFailed
 	c.metrics.RecordPRFailed()
 	return nil
 }
@@ -3304,14 +3333,40 @@ func (c *Controller) getBotLogin(ctx context.Context) string {
 	return user.Login
 }
 
-// notifyExternalClose sends notification when a PR is closed externally without merge.
-// GH-1015: Marks the issue as pilot-retry-ready so it can be re-picked by the poller.
+// notifyExternalClose runs once autopilot observes a PR closed without a merge —
+// whether a human closed it, or autopilot closed it itself a poll cycle earlier
+// (handleCIFailed/handleReviewRequested/handleMergeConflict set prState.Error and
+// return; this is the next place execution reaches once the close is visible on
+// GitHub). Every non-merge close converges here, which makes it the single place
+// to guarantee GH-3806's audit trail: a PR comment naming the reason (plus a CI
+// run link when a SHA is known) and a matching issue comment, even along the
+// branches that intentionally skip label changes below.
+//
+// GH-1015: Marks the issue as pilot-retry-ready so it can be re-picked by the
+// poller — unless prState.TerminalLabel says the failure is terminal or already
+// continues under a different issue number, in which case that label is used
+// instead so the issue is never silently re-queued.
 func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) {
 	c.log.Info("PR closed externally without merge", "pr", prState.PRNumber, "issue", prState.IssueNumber)
+
+	reason := prState.Error
+	if reason == "" {
+		reason = "closed without merging (no reason recorded)"
+	}
+
+	prComment := fmt.Sprintf("This PR was closed without merging: %s", reason)
+	if prState.HeadSHA != "" {
+		prComment += fmt.Sprintf("\n\nCI run: https://github.com/%s/%s/commit/%s/checks", c.owner, c.repo, prState.HeadSHA)
+	}
+	if _, err := c.ghClient.AddPRComment(ctx, c.owner, c.repo, prState.PRNumber, prComment); err != nil {
+		c.log.Warn("failed to comment on closed PR", "pr", prState.PRNumber, "error", err)
+	}
 
 	// GH-1015: Add pilot-retry-ready label so the issue can be retried
 	// Remove pilot-in-progress to allow the poller to re-pick it
 	if prState.IssueNumber > 0 {
+		issueComment := fmt.Sprintf("PR #%d was closed without merging: %s", prState.PRNumber, reason)
+
 		// GH-2340: Skip pilot-retry-ready when the issue already carries
 		// pilot-done. This happens when Pilot itself closed a duplicate PR
 		// (e.g. via handleMergeConflict) after the original PR was already
@@ -3322,6 +3377,13 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 			c.log.Warn("failed to fetch issue for label check", "issue", prState.IssueNumber, "error", err)
 		} else if github.HasLabel(issue, github.LabelDone) {
 			c.log.Info("skipping pilot-retry-ready: issue already pilot-done", "issue", prState.IssueNumber, "pr", prState.PRNumber)
+			// GH-3806: pilot-done here means an earlier PR for this issue already
+			// shipped — the label is intentionally left untouched, but this PR's
+			// discarded work must not vanish silently just because of that.
+			issueComment += "\n\nThe issue is already marked pilot-done from an earlier PR, so its labels were left unchanged. This closed PR represents separate, discarded work."
+			if _, cerr := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, issueComment); cerr != nil {
+				c.log.Warn("failed to comment on issue after PR close", "issue", prState.IssueNumber, "error", cerr)
+			}
 			c.maybeCloseParentIssue(ctx, prState)
 			return
 		}
@@ -3340,6 +3402,10 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 							"issue", prState.IssueNumber,
 							"recovery_pr", pr.HTMLURL,
 							"author", pr.User.Login)
+						issueComment += fmt.Sprintf("\n\nA human recovery PR (%s) is already open for this issue, so it was left as-is instead of being re-queued.", pr.HTMLURL)
+						if _, cerr := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, issueComment); cerr != nil {
+							c.log.Warn("failed to comment on issue after PR close", "issue", prState.IssueNumber, "error", cerr)
+						}
 						c.maybeCloseParentIssue(ctx, prState)
 						return
 					}
@@ -3347,17 +3413,37 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 			}
 		}
 
-		if err := c.ghClient.AddLabels(ctx, c.owner, c.repo, prState.IssueNumber, []string{github.LabelRetryReady}); err != nil {
-			c.log.Warn("failed to add pilot-retry-ready label", "issue", prState.IssueNumber, "error", err)
+		// GH-3806: a close path that already knows the failure is terminal, or
+		// that a dependent follow-up issue now owns the retry, sets TerminalLabel
+		// so this issue is marked pilot-failed instead of silently re-queued
+		// (which would either retry a cascade that already hit its cap, or
+		// double-dispatch work a follow-up issue is already doing).
+		issueLabel := github.LabelRetryReady
+		nextSteps := "The issue has been marked pilot-retry-ready and will be retried automatically."
+		if prState.TerminalLabel != "" {
+			issueLabel = prState.TerminalLabel
+			nextSteps = "This issue will not be retried automatically under its own number — see the reason above for what happens next."
+		}
+
+		if err := c.ghClient.AddLabels(ctx, c.owner, c.repo, prState.IssueNumber, []string{issueLabel}); err != nil {
+			c.log.Warn("failed to set issue label on PR close", "issue", prState.IssueNumber, "label", issueLabel, "error", err)
 		}
 		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelInProgress); err != nil {
 			c.log.Warn("failed to remove pilot-in-progress label", "issue", prState.IssueNumber, "error", err)
 		}
-		// Remove stale pilot-failed label (GH-1302 gap)
-		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelFailed); err != nil {
-			c.log.Debug("failed to remove pilot-failed (may not exist)", "issue", prState.IssueNumber, "error", err)
+		if issueLabel != github.LabelFailed {
+			// Remove stale pilot-failed label (GH-1302 gap) — only when we're not
+			// the ones setting it above.
+			if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelFailed); err != nil {
+				c.log.Debug("failed to remove pilot-failed (may not exist)", "issue", prState.IssueNumber, "error", err)
+			}
 		}
-		c.log.Info("marked issue as pilot-retry-ready (PR closed without merge)", "issue", prState.IssueNumber, "pr", prState.PRNumber)
+		c.log.Info("corrected issue label on PR close", "issue", prState.IssueNumber, "pr", prState.PRNumber, "label", issueLabel)
+
+		issueComment += "\n\n" + nextSteps
+		if _, cerr := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, issueComment); cerr != nil {
+			c.log.Warn("failed to comment on issue after PR close", "issue", prState.IssueNumber, "error", cerr)
+		}
 	}
 
 	// GH-2198: Close parent epic when all sub-issues are done (even if this one

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2904,6 +2905,153 @@ func TestController_CIFixCascadeLimit(t *testing.T) {
 	if !strings.Contains(pr.Error, "CI fix iteration limit reached") {
 		t.Errorf("error should mention iteration limit, got: %s", pr.Error)
 	}
+	if !strings.Contains(pr.Error, "build") {
+		t.Errorf("error should name the failing check, got: %s", pr.Error)
+	}
+	if pr.TerminalLabel != github.LabelFailed {
+		t.Errorf("TerminalLabel = %q, want %q (iteration-limit close must not be silently re-queued)", pr.TerminalLabel, github.LabelFailed)
+	}
+}
+
+// GH-3806: Simulates the full CI-failure close path end to end — handleCIFailed
+// closes the PR after the iteration limit is hit, and on the next poll
+// notifyExternalClose observes the closed PR and must post a PR comment naming
+// the reason and failing check, correct the issue's labels (pilot-failed, not
+// pilot-retry-ready — a stale pilot-done/pilot-in-progress must not survive),
+// and post a matching issue comment. No step in this chain may be silent.
+func TestController_CIFailedClose_PostsCommentsAndCorrectsLabels(t *testing.T) {
+	var prCommentBody, issueCommentBody string
+	var prCommentPosted, issueCommentPosted, failedLabelAdded, inProgressRemoved bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/abc1234/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "unit-tests", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/issues/10" && r.Method == http.MethodGet:
+			resp := github.Issue{
+				Number: 10,
+				State:  "open",
+				Body:   "Fix CI failure\n\n<!-- autopilot-meta branch:pilot/GH-5 pr:99 iteration:3 -->\n",
+				Labels: []github.Label{{Name: github.LabelInProgress}},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == http.MethodGet:
+			resp := github.PullRequest{
+				Number:  42,
+				State:   "closed",
+				HTMLURL: "https://github.com/owner/repo/pull/42",
+				Head:    github.PRRef{Ref: "pilot/GH-10", SHA: "abc1234"},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		// PRs use the issues comments API (AddPRComment posts to /issues/{prNumber}/comments).
+		case r.URL.Path == "/repos/owner/repo/issues/42/comments" && r.Method == http.MethodPost:
+			prCommentPosted = true
+			body, _ := io.ReadAll(r.Body)
+			prCommentBody = string(body)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]int{"id": 1})
+		case r.URL.Path == "/repos/owner/repo/issues/10/comments" && r.Method == http.MethodPost:
+			issueCommentPosted = true
+			body, _ := io.ReadAll(r.Body)
+			issueCommentBody = string(body)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]int{"id": 2})
+		case r.URL.Path == "/repos/owner/repo/issues/10/labels" && r.Method == http.MethodPost:
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			for _, l := range body.Labels {
+				if l == github.LabelFailed {
+					failedLabelAdded = true
+				}
+				if l == github.LabelRetryReady {
+					t.Error("pilot-retry-ready must not be added for a terminal iteration-limit close")
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.URL.Path == "/repos/owner/repo/issues/10/labels/"+github.LabelInProgress && r.Method == http.MethodDelete:
+			inProgressRemoved = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 1 * time.Second
+	cfg.MaxCIFixIterations = 3
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc1234", "pilot/GH-10", "")
+
+	ctx := context.Background()
+	if err := c.ProcessPR(ctx, 42, nil); err != nil { // PR created -> waiting CI
+		t.Fatalf("stage 1 error: %v", err)
+	}
+	if err := c.ProcessPR(ctx, 42, nil); err != nil { // waiting CI -> CI failed
+		t.Fatalf("stage 2 error: %v", err)
+	}
+	if err := c.ProcessPR(ctx, 42, nil); err != nil { // CI failed -> closed (iteration limit)
+		t.Fatalf("stage 3 error: %v", err)
+	}
+
+	pr, _ := c.GetPRState(42)
+	if pr.Stage != StageFailed {
+		t.Fatalf("Stage = %s, want %s", pr.Stage, StageFailed)
+	}
+
+	// Next poll: the poller observes the PR is now closed on GitHub and runs
+	// notifyExternalClose — this is where GH-3806's audit trail is written.
+	prState, _ := c.GetPRState(42)
+	ghPR, err := ghClient.GetPullRequest(ctx, "owner", "repo", 42)
+	if err != nil {
+		t.Fatalf("GetPullRequest: %v", err)
+	}
+	prState.mu.Lock()
+	resolved := c.checkExternalMergeOrClose(ctx, prState, ghPR)
+	prState.mu.Unlock()
+	if !resolved {
+		t.Fatal("checkExternalMergeOrClose should report the PR as resolved (closed)")
+	}
+
+	if !prCommentPosted {
+		t.Fatal("expected a PR comment explaining why the PR was closed")
+	}
+	if !strings.Contains(prCommentBody, "unit-tests") {
+		t.Errorf("PR comment should name the failing check, got: %s", prCommentBody)
+	}
+	if !strings.Contains(prCommentBody, "abc1234") {
+		t.Errorf("PR comment should link to the CI run for the head SHA, got: %s", prCommentBody)
+	}
+	if !issueCommentPosted {
+		t.Fatal("expected an issue comment explaining why the linked PR was closed")
+	}
+	if !strings.Contains(issueCommentBody, "42") {
+		t.Errorf("issue comment should reference the closed PR number, got: %s", issueCommentBody)
+	}
+	if !failedLabelAdded {
+		t.Error("issue should be labeled pilot-failed, not left to be silently re-queued")
+	}
+	if !inProgressRemoved {
+		t.Error("pilot-in-progress should be removed from the issue on close")
+	}
 }
 
 // GH-1566: Test that CI fix proceeds when under the iteration limit.
@@ -5123,6 +5271,65 @@ func TestNotifyExternalClose_SkipsRetryReadyWhenDone(t *testing.T) {
 				t.Errorf("pilot-retry-ready added = %v, want %v", retryReadyAdded, tt.wantRetryAdded)
 			}
 		})
+	}
+}
+
+// GH-3806 (TASK-382 D9): reproduces the exact defect — a PR closed after CI
+// failure for an issue that already carries pilot-done (e.g. a duplicate PR,
+// or a later PR against an issue an earlier PR already shipped). Before this
+// fix, notifyExternalClose's pilot-done guard returned immediately with zero
+// comments anywhere, so the discarded PR's failure was invisible and the
+// issue's pilot-done label wrongly implied its later attempt also shipped.
+func TestNotifyExternalClose_PostsCommentsEvenWhenIssueAlreadyDone(t *testing.T) {
+	var prCommentPosted, issueCommentPosted bool
+	var issueCommentBody string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/issues/10" && r.Method == http.MethodGet:
+			issue := github.Issue{Number: 10, State: "closed", Labels: []github.Label{{Name: github.LabelDone}}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(issue)
+		// PRs use the issues comments API (AddPRComment posts to /issues/{prNumber}/comments).
+		case r.URL.Path == "/repos/owner/repo/issues/42/comments" && r.Method == http.MethodPost:
+			prCommentPosted = true
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]int{"id": 1})
+		case r.URL.Path == "/repos/owner/repo/issues/10/comments" && r.Method == http.MethodPost:
+			issueCommentPosted = true
+			body, _ := io.ReadAll(r.Body)
+			issueCommentBody = string(body)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]int{"id": 2})
+		case r.URL.Path == "/repos/owner/repo/issues/10/labels" && r.Method == http.MethodPost:
+			t.Error("labels must not be touched when the issue is already pilot-done")
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:    42,
+		IssueNumber: 10,
+		HeadSHA:     "deadbee",
+		Error:       "CI checks failed (unit-tests); fix issue #200 created to continue this work",
+	}
+	c.notifyExternalClose(context.Background(), prState)
+
+	if !prCommentPosted {
+		t.Error("expected a PR comment naming the close reason even though the issue is already pilot-done")
+	}
+	if !issueCommentPosted {
+		t.Fatal("expected an issue comment even though pilot-done skips label correction — a discarded PR must never be silent")
+	}
+	if !strings.Contains(issueCommentBody, "42") || !strings.Contains(issueCommentBody, "unit-tests") {
+		t.Errorf("issue comment should reference the closed PR and the failure reason, got: %s", issueCommentBody)
 	}
 }
 

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -550,6 +550,17 @@ type PRState struct {
 	// names the actual trigger (GH-3569). In-memory only; lost on restart, which
 	// degrades to the env-based fallback wording.
 	EscalationReason string
+	// TerminalLabel overrides the default pilot-retry-ready label that
+	// notifyExternalClose applies once it observes this PR closed on GitHub.
+	// Set by a close path that already determined the issue must NOT be
+	// auto-retried under its own number — either because the failure is
+	// terminal (iteration/size-guard cap reached) or because a dependent
+	// follow-up issue was already created to continue the work, and re-queuing
+	// the original would cause a duplicate dispatch. Empty means "use the
+	// default retry-ready flow" (GH-3806). In-memory only; lost on restart —
+	// safe because a restart re-enters the handler that sets it before the PR
+	// can reach notifyExternalClose again.
+	TerminalLabel string
 }
 
 // snapshot returns a detached, field-by-field copy of the PRState with a fresh
@@ -589,6 +600,7 @@ func (ps *PRState) snapshot() *PRState {
 		ReleasingAttempts:       ps.ReleasingAttempts,
 		ReleasingFirstAt:        ps.ReleasingFirstAt,
 		EscalationReason:        ps.EscalationReason,
+		TerminalLabel:           ps.TerminalLabel,
 	}
 	// DiscoveredChecks is a slice — copy the backing array so consumers can't
 	// mutate the live PR's slice through the snapshot.


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3806.

Closes #3806

## Changes

GitHub Issue #3806: fix(autopilot): CI-failed PRs are closed silently — no PR comment, no issue label correction

## Context
Defect D9 from TASK-382. Observed 2026-07-04 00:30 UTC: PR #3802 (fix for #3789) went `UNSTABLE` (test check failed), autopilot closed it and deleted the branch — with **zero explanation**: no comment on the PR stating why (CI failure? which check?), and the source issue #3789 retained its `pilot-done` label, claiming success for discarded work. The only trace was the GitHub event log. A human auditing the issue would believe D6 shipped when it didn't.

## Fix
- When autopilot closes a PR (CI failure, conflict, any reason), post a comment on the PR naming the reason and the failing check, with a link to the CI run.
- Correct the source issue's labels: remove `pilot-done`/`pilot-in-progress`, apply the appropriate retry/failed label so the poller's next action is well-defined.
- Comment on the source issue: PR closed, why, and what happens next (retry queued / retry-cap state).

## Acceptance
- [ ] Simulated CI-failure close → PR comment with reason + check name; issue labels corrected; issue comment posted
- [ ] No silent close path remains in the controller's close/removePR flows (audit `internal/autopilot/controller.go` close call sites)
- [ ] make test && make lint pass