### PR TITLE
fix(autopilot): reclassify completed execution rows when a PR closes unmerged

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -110,6 +110,10 @@ type EvalStore interface {
 	// to verify a child sub-issue's ledger status before treating it as complete
 	// for parent-close purposes. GH-3780.
 	GetExecutionStatusByTaskID(taskID, projectPath string) (string, error)
+	// ReclassifyCompletionAsFailed demotes a genuine completed execution row to
+	// "failed" with reason, so a PR closed without merging can never leave a
+	// "completed" row behind that HasCompletedExecution keeps trusting. GH-3818.
+	ReclassifyCompletionAsFailed(taskID, projectPath, reason string) error
 }
 
 // ControllerOption is a functional option for Controller configuration.
@@ -3352,6 +3356,19 @@ func (c *Controller) notifyExternalClose(ctx context.Context, prState *PRState) 
 	reason := prState.Error
 	if reason == "" {
 		reason = "closed without merging (no reason recorded)"
+	}
+
+	// GH-3818/D10: reclassify any "completed" execution row for this issue to
+	// "failed" now that we know its PR was discarded — otherwise HasCompletedExecution
+	// keeps trusting the stale row and the poller re-marks the issue pilot-done on
+	// every subsequent poll even though nothing shipped. A later merge heals this
+	// back to "completed" via SelfHealExecutionAfterMerge.
+	if c.evalStore != nil && prState.IssueNumber > 0 {
+		taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
+		if err := c.evalStore.ReclassifyCompletionAsFailed(taskID, c.projectPath, reason); err != nil {
+			c.log.Warn("failed to reclassify completed execution after PR close",
+				"task_id", taskID, "pr", prState.PRNumber, "error", err)
+		}
 	}
 
 	prComment := fmt.Sprintf("This PR was closed without merging: %s", reason)

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -4150,6 +4150,7 @@ type mockEvalStore struct {
 	saved        []*memory.EvalTask
 	selfHealed   []selfHealCall
 	updateStatus []updateStatusCall
+	reclassified []reclassifyCall
 	// execStatusByTaskID configures GetExecutionStatusByTaskID responses keyed by
 	// task ID (e.g. "GH-11"). Missing keys return sql.ErrNoRows, matching a real
 	// store's behavior when no execution row exists for that task.
@@ -4166,6 +4167,13 @@ type updateStatusCall struct {
 	TaskID      string
 	ProjectPath string
 	Status      string
+}
+
+// reclassifyCall records one ReclassifyCompletionAsFailed invocation. GH-3818.
+type reclassifyCall struct {
+	TaskID      string
+	ProjectPath string
+	Reason      string
 }
 
 func (m *mockEvalStore) SaveEvalTask(task *memory.EvalTask) error {
@@ -4188,6 +4196,12 @@ func (m *mockEvalStore) GetExecutionStatusByTaskID(taskID, projectPath string) (
 
 func (m *mockEvalStore) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) error {
 	m.selfHealed = append(m.selfHealed, selfHealCall{TaskID: taskID, ProjectPath: projectPath, PRURL: prURL})
+	return nil
+}
+
+// ReclassifyCompletionAsFailed records the call for assertions. GH-3818.
+func (m *mockEvalStore) ReclassifyCompletionAsFailed(taskID, projectPath, reason string) error {
+	m.reclassified = append(m.reclassified, reclassifyCall{TaskID: taskID, ProjectPath: projectPath, Reason: reason})
 	return nil
 }
 
@@ -5202,6 +5216,97 @@ func TestNotifyExternalClose_MaybeCloseParent(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNotifyExternalClose_ReclassifiesCompletedExecution covers GH-3818/D10:
+// notifyExternalClose is the single place every non-merge PR close converges
+// on, so it must reclassify the issue's completed execution row to "failed"
+// there — otherwise HasCompletedExecution keeps trusting a "completed" row
+// whose PR was actually discarded, and the poller re-marks the issue
+// pilot-done on every subsequent poll (the exact #3789/#3802 incident).
+func TestNotifyExternalClose_ReclassifiesCompletedExecution(t *testing.T) {
+	tests := []struct {
+		name           string
+		issueNumber    int
+		prError        string
+		wantReclassify bool
+		wantTaskID     string
+		wantReason     string
+	}{
+		{
+			name:           "issue closed unmerged with recorded reason - reclassified",
+			issueNumber:    3789,
+			prError:        "CI checks failed (build); fix issue #3803 created to continue this work",
+			wantReclassify: true,
+			wantTaskID:     "GH-3789",
+			wantReason:     "CI checks failed (build); fix issue #3803 created to continue this work",
+		},
+		{
+			name:           "issue closed unmerged with no recorded reason - default reason used",
+			issueNumber:    3790,
+			prError:        "",
+			wantReclassify: true,
+			wantTaskID:     "GH-3790",
+			wantReason:     "closed without merging (no reason recorded)",
+		},
+		{
+			name:           "PR has no linked issue - nothing to reclassify",
+			issueNumber:    0,
+			prError:        "CI checks failed",
+			wantReclassify: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("[]"))
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+			evalMock := &mockEvalStore{}
+			c.SetEvalStore(evalMock)
+
+			prState := &PRState{PRNumber: 42, IssueNumber: tt.issueNumber, Error: tt.prError}
+			c.notifyExternalClose(context.Background(), prState)
+
+			if tt.wantReclassify {
+				if len(evalMock.reclassified) != 1 {
+					t.Fatalf("reclassify calls = %d, want 1: %+v", len(evalMock.reclassified), evalMock.reclassified)
+				}
+				got := evalMock.reclassified[0]
+				if got.TaskID != tt.wantTaskID {
+					t.Errorf("TaskID = %q, want %q", got.TaskID, tt.wantTaskID)
+				}
+				if got.Reason != tt.wantReason {
+					t.Errorf("Reason = %q, want %q", got.Reason, tt.wantReason)
+				}
+			} else if len(evalMock.reclassified) != 0 {
+				t.Errorf("expected no reclassify calls, got %+v", evalMock.reclassified)
+			}
+		})
+	}
+}
+
+// TestNotifyExternalClose_ReclassifyNotCalledWithoutEvalStore verifies the nil
+// guard: when no eval store is configured, notifyExternalClose must not panic
+// and simply skips the reclassify step. GH-3818.
+func TestNotifyExternalClose_ReclassifyNotCalledWithoutEvalStore(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	prState := &PRState{PRNumber: 42, IssueNumber: 3789, Error: "CI checks failed"}
+	c.notifyExternalClose(context.Background(), prState) // must not panic
 }
 
 // GH-2340: notifyExternalClose must not stamp pilot-retry-ready on issues

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -679,6 +679,34 @@ func (s *Store) InvalidateCompletion(taskID, projectPath string) error {
 	return nil
 }
 
+// ReclassifyCompletionAsFailed demotes genuine completed execution records (the
+// same rows HasCompletedExecution would count: status='completed', no error, at
+// least one deliverable) to status='failed' with reason recorded in the error
+// column. GH-3818/D10: called by autopilot the moment it observes a PR closed
+// without merging, so a "completed" row can never outlive the PR it was built
+// on — without this, HasCompletedExecution keeps trusting the stale row forever
+// and the poller re-marks the issue pilot-done on every subsequent poll even
+// though the deliverable was discarded.
+//
+// projectPath follows SelfHealExecutionAfterMerge's scoping convention: empty
+// drops the scope and matches by task_id alone (legacy single-repo callers).
+// A later merge (human recovery PR, retried issue) heals the row back to
+// "completed" via SelfHealExecutionAfterMerge, so this is not a one-way trip.
+func (s *Store) ReclassifyCompletionAsFailed(taskID, projectPath, reason string) error {
+	return s.withRetry("ReclassifyCompletionAsFailed", func() error {
+		_, err := s.db.Exec(`
+			UPDATE executions
+			SET status = 'failed',
+				error = ?,
+				completed_at = CURRENT_TIMESTAMP
+			WHERE task_id = ? AND (? = '' OR project_path = ?) AND status = 'completed'
+				AND (error IS NULL OR error = '')
+				AND (commit_sha != '' OR pr_url != '')
+		`, reason, taskID, projectPath, projectPath)
+		return err
+	})
+}
+
 // SetApprovalDecision records an approval decision on the execution linked to requestID.
 // It sets approval_decision, approval_decision_at, and approval_decision_by on the row
 // whose approval_request_id matches. Returns sql.ErrNoRows if no matching row is found.
@@ -1218,11 +1246,17 @@ func (s *Store) UpdateExecutionStatusByTaskID(taskID, projectPath, status string
 // dropped and rows match by task_id alone (legacy single-repo behavior); this also
 // guards against a caller passing the wrong discriminator silently healing nothing.
 // TASK-352.
+//
+// GH-3818: also clears the error column. Without this, a row healed from
+// "failed" (which always carries a non-empty error — every writer of that
+// status passes a message) stayed invisible to HasCompletedExecution, which
+// excludes rows with a non-empty error even once status flips back to "completed".
 func (s *Store) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) error {
 	return s.withRetry("SelfHealExecutionAfterMerge", func() error {
 		_, err := s.db.Exec(`
 			UPDATE executions
 			SET status = 'completed',
+				error = '',
 				completed_at = CURRENT_TIMESTAMP,
 				pr_url = CASE WHEN ? <> '' THEN ? ELSE pr_url END
 			WHERE task_id = ? AND status IN ('failed', 'no_op', 'stalled', 'rate_limited', 'infra', 'skipped') AND (? = '' OR project_path = ?)

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2252,6 +2252,152 @@ func TestInvalidateCompletion(t *testing.T) {
 	}
 }
 
+// TestReclassifyCompletionAsFailed covers GH-3818/D10: a PR closed without
+// merging must demote the "completed" execution row so HasCompletedExecution
+// stops trusting it (re-pick), while a genuinely merged PR's row is left
+// untouched so idempotency still holds.
+func TestReclassifyCompletionAsFailed(t *testing.T) {
+	tests := []struct {
+		name            string
+		row             Execution
+		taskID          string
+		projectPath     string
+		reason          string
+		wantStillDone   bool // HasCompletedExecution result after reclassify
+		wantStatusAfter string
+	}{
+		{
+			name: "completed with PR closed unmerged - reclassified to failed (re-pick allowed)",
+			row: Execution{
+				ID: "exec-closed-unmerged", TaskID: "GH-3789", ProjectPath: "/project",
+				Status: "completed", PRUrl: "https://github.com/o/r/pull/3802",
+			},
+			taskID:          "GH-3789",
+			projectPath:     "/project",
+			reason:          "CI checks failed; PR closed without merge",
+			wantStillDone:   false,
+			wantStatusAfter: "failed",
+		},
+		{
+			name: "different task ID - untouched",
+			row: Execution{
+				ID: "exec-other-task", TaskID: "GH-999", ProjectPath: "/project",
+				Status: "completed", PRUrl: "https://github.com/o/r/pull/1",
+			},
+			taskID:          "GH-3789", // reclassify call targets a different task
+			projectPath:     "/project",
+			reason:          "closed without merge",
+			wantStillDone:   true, // GH-999's own row is unaffected; check with its own ID below
+			wantStatusAfter: "completed",
+		},
+		{
+			name: "different project path - untouched (cross-repo isolation)",
+			row: Execution{
+				ID: "exec-other-project", TaskID: "GH-3789", ProjectPath: "/other-project",
+				Status: "completed", PRUrl: "https://github.com/o/r/pull/2",
+			},
+			taskID:          "GH-3789",
+			projectPath:     "/project", // reclassify call scoped to a different project
+			reason:          "closed without merge",
+			wantStillDone:   true,
+			wantStatusAfter: "completed",
+		},
+		{
+			name: "orphan-recovered row (error set) - not a genuine completion, untouched",
+			row: Execution{
+				ID: "exec-orphan", TaskID: "GH-3789", ProjectPath: "/project",
+				Status: "completed", Error: "stale running task recovered", PRUrl: "https://github.com/o/r/pull/3",
+			},
+			taskID:          "GH-3789",
+			projectPath:     "/project",
+			reason:          "closed without merge",
+			wantStillDone:   false, // HasCompletedExecution already excludes error!='' rows
+			wantStatusAfter: "completed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			store, err := NewStore(tmpDir)
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			if err := store.SaveExecution(&tt.row); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			if err := store.ReclassifyCompletionAsFailed(tt.taskID, tt.projectPath, tt.reason); err != nil {
+				t.Fatalf("ReclassifyCompletionAsFailed: %v", err)
+			}
+
+			completed, err := store.HasCompletedExecution(tt.row.TaskID, tt.row.ProjectPath)
+			if err != nil {
+				t.Fatalf("HasCompletedExecution: %v", err)
+			}
+			if completed != tt.wantStillDone {
+				t.Errorf("HasCompletedExecution(%s, %s) = %v, want %v", tt.row.TaskID, tt.row.ProjectPath, completed, tt.wantStillDone)
+			}
+
+			got, err := store.GetExecution(tt.row.ID)
+			if err != nil {
+				t.Fatalf("GetExecution: %v", err)
+			}
+			if got.Status != tt.wantStatusAfter {
+				t.Errorf("status after reclassify = %q, want %q", got.Status, tt.wantStatusAfter)
+			}
+		})
+	}
+}
+
+// TestReclassifyCompletionAsFailed_HealsBackOnMerge verifies the round trip: a
+// row demoted by ReclassifyCompletionAsFailed (PR closed unmerged) is later
+// healed back to "completed" by SelfHealExecutionAfterMerge when a follow-up
+// PR for the same issue actually merges — this is the "not a one-way trip"
+// guarantee the reclassify doc comment promises. Acceptance: completed
+// execution + merged PR must still be skipped as idempotent.
+func TestReclassifyCompletionAsFailed_HealsBackOnMerge(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	taskID := "GH-3789"
+	projectPath := "/project"
+
+	if err := store.SaveExecution(&Execution{
+		ID: "exec-1", TaskID: taskID, ProjectPath: projectPath,
+		Status: "completed", PRUrl: "https://github.com/o/r/pull/3802",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	// PR #3802 closes unmerged (CI failure) — poller must re-pick the issue.
+	if err := store.ReclassifyCompletionAsFailed(taskID, projectPath, "CI checks failed"); err != nil {
+		t.Fatalf("ReclassifyCompletionAsFailed: %v", err)
+	}
+	if completed, _ := store.HasCompletedExecution(taskID, projectPath); completed {
+		t.Fatal("expected re-pick (HasCompletedExecution=false) after unmerged close")
+	}
+
+	// A follow-up PR (#3810) for the same issue merges — self-heal must restore
+	// "completed" so idempotency resumes.
+	if err := store.SelfHealExecutionAfterMerge(taskID, projectPath, "https://github.com/o/r/pull/3810"); err != nil {
+		t.Fatalf("SelfHealExecutionAfterMerge: %v", err)
+	}
+	completed, err := store.HasCompletedExecution(taskID, projectPath)
+	if err != nil {
+		t.Fatalf("HasCompletedExecution: %v", err)
+	}
+	if !completed {
+		t.Error("expected idempotency restored (HasCompletedExecution=true) after merge")
+	}
+}
+
 func TestGetLifetimeTokens_ExcludesZeroTokenRows(t *testing.T) {
 	tmpDir := t.TempDir()
 	store, err := NewStore(tmpDir)


### PR DESCRIPTION
## Summary
- Closes #3818 (D10 from TASK-382). `notifyExternalClose` is the single place every non-merge PR close converges on (internal `ClosePullRequest` calls and human/external closes alike), so it now reclassifies the issue's "completed" execution row to "failed" there via a new `Store.ReclassifyCompletionAsFailed`, wired through the `EvalStore` interface.
- Without this, `HasCompletedExecution` kept trusting a stale "completed" row after autopilot discarded its PR — the poller re-marked the issue `pilot-done` on every subsequent poll even though nothing shipped (the #3789/#3802 incident, previously requiring manual DB surgery to unblock).
- A later merge for the same issue heals the row back to "completed" via the existing `SelfHealExecutionAfterMerge`, so this is not a one-way trip. That healing path had a latent bug of its own — it never cleared the `error` column, so a healed row stayed invisible to `HasCompletedExecution`'s `error != ''` exclusion even after a genuine merge. Fixed alongside since it's required for the round trip to actually work.

## Test plan
- [x] `internal/memory/store_test.go`: table-driven `TestReclassifyCompletionAsFailed` (genuine completed row demoted; different task/project untouched; orphan-recovered row untouched) + `TestReclassifyCompletionAsFailed_HealsBackOnMerge` round-trip test
- [x] `internal/autopilot/controller_test.go`: table-driven `TestNotifyExternalClose_ReclassifiesCompletedExecution` (reason recorded / default reason / no linked issue) + nil-evalStore guard test
- [x] `make test && make lint` pass