### PR TITLE
fix(autopilot): adapter_processed rows stamped with wrong repo — cross-project dedup contamination

### DIFF
--- a/internal/adapters/github/gh3819_cross_project_test.go
+++ b/internal/adapters/github/gh3819_cross_project_test.go
@@ -1,0 +1,139 @@
+package github_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/autopilot"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// newGH3819ProjectServer simulates a single-repo GitHub project with one open,
+// unlabeled-status issue at the given number. Mirrors the mock pattern used by
+// TestPoller_UnmarkProcessed_PermanentFailureRetainsMarker (poller_gh3270_test.go):
+// "/search/issues" reports no results, every other path returns the issue.
+func newGH3819ProjectServer(t *testing.T, issueNumber int) *httptest.Server {
+	t.Helper()
+	issue := &github.Issue{
+		Number:    issueNumber,
+		Title:     fmt.Sprintf("GH-%d fix something", issueNumber),
+		State:     "open",
+		Labels:    []github.Label{{Name: "pilot"}},
+		CreatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/search/issues" {
+			_, _ = fmt.Fprintf(w, `{"total_count":0}`)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]*github.Issue{issue})
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// TestCrossProjectDedup_SameIssueNumberProcessedIndependently guards GH-3819:
+// two Pilot projects (different repos) sharing one autopilot.StateStore must
+// dispatch/skip their own issue #N independently. Before the fix, adapter_processed
+// was keyed on (adapter, issue_id) only, so marking issue #5 done in one repo
+// silently clobbered — or was clobbered by — the other repo's row for the same
+// issue_id, corrupting both repos' dedup state.
+func TestCrossProjectDedup_SameIssueNumberProcessedIndependently(t *testing.T) {
+	store, err := autopilot.NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+
+	// Project A already processed issue #5 in its own repo before this test's
+	// pollers start — simulates a prior poll cycle.
+	if err := store.Mark("github", "org/repo-a", "5"); err != nil {
+		t.Fatalf("seed Mark(repo-a): %v", err)
+	}
+
+	serverA := newGH3819ProjectServer(t, 5)
+	serverB := newGH3819ProjectServer(t, 5)
+
+	var dispatchedA, dispatchedB atomic.Bool
+	dispatchedBCh := make(chan struct{})
+
+	pollerA, err := github.NewPoller(
+		github.NewClientWithBaseURL(testutil.FakeGitHubToken, serverA.URL),
+		"org/repo-a", "pilot", time.Hour,
+		github.WithOnIssueWithResult(func(ctx context.Context, i *github.Issue) (*github.IssueResult, error) {
+			dispatchedA.Store(true)
+			return &github.IssueResult{Success: true, PRNumber: 100, PRURL: "https://example.invalid/pr/100"}, nil
+		}),
+		github.WithProcessedStore(store),
+		github.WithMaxConcurrent(1),
+	)
+	if err != nil {
+		t.Fatalf("NewPoller(repo-a): %v", err)
+	}
+
+	pollerB, err := github.NewPoller(
+		github.NewClientWithBaseURL(testutil.FakeGitHubToken, serverB.URL),
+		"org/repo-b", "pilot", time.Hour,
+		github.WithOnIssueWithResult(func(ctx context.Context, i *github.Issue) (*github.IssueResult, error) {
+			dispatchedB.Store(true)
+			close(dispatchedBCh)
+			return &github.IssueResult{Success: true, PRNumber: 200, PRURL: "https://example.invalid/pr/200"}, nil
+		}),
+		github.WithProcessedStore(store),
+		github.WithMaxConcurrent(1),
+	)
+	if err != nil {
+		t.Fatalf("NewPoller(repo-b): %v", err)
+	}
+
+	ctxA, cancelA := context.WithCancel(context.Background())
+	ctxB, cancelB := context.WithCancel(context.Background())
+	doneA := make(chan struct{})
+	doneB := make(chan struct{})
+	go func() { pollerA.Start(ctxA); close(doneA) }()
+	go func() { pollerB.Start(ctxB); close(doneB) }()
+
+	select {
+	case <-dispatchedBCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for repo-b to dispatch its own issue #5")
+	}
+	pollerB.WaitForActive()
+
+	cancelA()
+	cancelB()
+	<-doneA
+	<-doneB
+
+	if dispatchedA.Load() {
+		t.Error("repo-a re-dispatched issue #5 — should have stayed skipped (already processed, within grace period)")
+	}
+	if !dispatchedB.Load() {
+		t.Error("repo-b never dispatched its own issue #5 — should be independent of repo-a's processed state")
+	}
+
+	// Store-level cross-check: dispatching repo-b's issue #5 must not disturb
+	// repo-a's row (the GH-3819 collision would clobber whichever repo's row
+	// was written most recently for the shared issue_id).
+	okA, err := store.IsProcessed("github", "org/repo-a", "5")
+	if err != nil {
+		t.Fatalf("IsProcessed(repo-a): %v", err)
+	}
+	if !okA {
+		t.Error("repo-a's issue #5 should still be marked processed after repo-b marked its own issue #5")
+	}
+	okB, err := store.IsProcessed("github", "org/repo-b", "5")
+	if err != nil {
+		t.Fatalf("IsProcessed(repo-b): %v", err)
+	}
+	if !okB {
+		t.Error("repo-b's issue #5 should be marked processed after its own dispatch")
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -121,6 +121,16 @@ func (s *StateStore) migrate() error {
 		return fmt.Errorf("adapter_processed primary key migration failed: %w", err)
 	}
 
+	// GH-3819: Purge orphaned empty-repo rows for repo-scoped adapters. These
+	// can only have been written before the repo column existed (or by the
+	// GH-3819 collision bug clobbering a row down to its zero value); a
+	// repo-scoped poller always calls Mark/IsProcessed/Load with a non-empty
+	// "owner/repo" key, so such rows can never be matched again and would
+	// otherwise sit as permanent dead weight.
+	if err := s.pruneOrphanedEmptyRepoRows(); err != nil {
+		return fmt.Errorf("adapter_processed empty-repo cleanup failed: %w", err)
+	}
+
 	// TASK-298: Consolidate 7 legacy per-adapter tables into adapter_processed.
 	if err := s.migrateLegacyProcessedTables(); err != nil {
 		return fmt.Errorf("legacy processed tables migration failed: %w", err)
@@ -200,6 +210,32 @@ func (s *StateStore) migrateAdapterProcessedPrimaryKey() error {
 		return fmt.Errorf("rename adapter_processed_gh3819: %w", err)
 	}
 	return tx.Commit()
+}
+
+// repoScopedAdapters lists adapter names whose pollers always dedup within a
+// specific repo (as opposed to tracker-style adapters — linear, jira, asana,
+// plane — which pass repo="" by design, see Mark's doc comment).
+var repoScopedAdapters = []string{"github", "gitlab", "azuredevops"}
+
+// pruneOrphanedEmptyRepoRows deletes adapter_processed rows for repo-scoped
+// adapters that have an empty repo. Such rows cannot correspond to any real
+// lookup (repoKey() is never empty for these adapters) and are either
+// pre-TASK-298 leftovers from before the repo column existed, or residue from
+// the GH-3819 collision bug. Safe to run on every startup: idempotent, and
+// never touches tracker-style adapters, which legitimately use repo="".
+func (s *StateStore) pruneOrphanedEmptyRepoRows() error {
+	placeholders := make([]string, len(repoScopedAdapters))
+	args := make([]interface{}, len(repoScopedAdapters))
+	for i, a := range repoScopedAdapters {
+		placeholders[i] = "?"
+		args[i] = a
+	}
+	query := fmt.Sprintf(
+		`DELETE FROM adapter_processed WHERE repo = '' AND adapter IN (%s)`,
+		strings.Join(placeholders, ", "),
+	)
+	_, err := s.db.Exec(query, args...)
+	return err
 }
 
 // migrateLegacyProcessedTables copies rows from the 7 legacy per-adapter tables

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -75,12 +75,16 @@ func (s *StateStore) migrate() error {
 		)`,
 		// GH-1838: Generic adapter_processed table — replaces 7 per-adapter tables.
 		// Source and repo form the namespace; repo is '' for tracker-style adapters.
+		// GH-3819: repo is part of the PRIMARY KEY from the start on fresh installs.
+		// (Older DBs had repo added later via ALTER TABLE, which cannot extend a
+		// PRIMARY KEY — see migrateAdapterProcessedPrimaryKey below.)
 		`CREATE TABLE IF NOT EXISTS adapter_processed (
 			adapter TEXT NOT NULL,
+			repo TEXT NOT NULL DEFAULT '',
 			issue_id TEXT NOT NULL,
 			processed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 			result TEXT DEFAULT '',
-			PRIMARY KEY (adapter, issue_id)
+			PRIMARY KEY (adapter, repo, issue_id)
 		)`,
 		// GH-2685: Async approval state — persisted so crash-recovery can resume
 		// the non-blocking tick handler without re-submitting the request.
@@ -110,12 +114,92 @@ func (s *StateStore) migrate() error {
 		}
 	}
 
+	// GH-3819: Rebuild adapter_processed with repo in the PRIMARY KEY if an
+	// older DB still has the pre-GH-1838-fixup schema. Must run before the
+	// legacy-table migration below so legacy rows land in the corrected table.
+	if err := s.migrateAdapterProcessedPrimaryKey(); err != nil {
+		return fmt.Errorf("adapter_processed primary key migration failed: %w", err)
+	}
+
 	// TASK-298: Consolidate 7 legacy per-adapter tables into adapter_processed.
 	if err := s.migrateLegacyProcessedTables(); err != nil {
 		return fmt.Errorf("legacy processed tables migration failed: %w", err)
 	}
 
 	return nil
+}
+
+// migrateAdapterProcessedPrimaryKey rebuilds adapter_processed so repo is part
+// of the PRIMARY KEY. The original table (GH-1838) keyed on (adapter, issue_id)
+// only; repo was bolted on afterward via ALTER TABLE ADD COLUMN, which SQLite
+// cannot use to extend a PRIMARY KEY. As a result, two different repos
+// processing the same issue_id (e.g. issue #5 in two separate projects) shared
+// one row: Mark()'s ON CONFLICT upsert silently overwrote that row's repo
+// column with whichever repo processed the colliding ID most recently,
+// corrupting cross-project dedup state (GH-3819).
+//
+// No-op if repo is already part of the primary key (fresh install, or already
+// migrated).
+func (s *StateStore) migrateAdapterProcessedPrimaryKey() error {
+	rows, err := s.db.Query(`PRAGMA table_info(adapter_processed)`)
+	if err != nil {
+		return fmt.Errorf("inspect adapter_processed schema: %w", err)
+	}
+	repoInPK := false
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, ctype string
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notNull, &dflt, &pk); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan adapter_processed schema: %w", err)
+		}
+		if name == "repo" && pk > 0 {
+			repoInPK = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate adapter_processed schema: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close adapter_processed schema query: %w", err)
+	}
+	if repoInPK {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(`
+		CREATE TABLE adapter_processed_gh3819 (
+			adapter TEXT NOT NULL,
+			repo TEXT NOT NULL DEFAULT '',
+			issue_id TEXT NOT NULL,
+			processed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			result TEXT DEFAULT '',
+			PRIMARY KEY (adapter, repo, issue_id)
+		)
+	`); err != nil {
+		return fmt.Errorf("create adapter_processed_gh3819: %w", err)
+	}
+	if _, err := tx.Exec(`
+		INSERT OR IGNORE INTO adapter_processed_gh3819 (adapter, repo, issue_id, processed_at, result)
+		SELECT adapter, repo, issue_id, processed_at, result FROM adapter_processed
+	`); err != nil {
+		return fmt.Errorf("copy adapter_processed rows: %w", err)
+	}
+	if _, err := tx.Exec(`DROP TABLE adapter_processed`); err != nil {
+		return fmt.Errorf("drop old adapter_processed: %w", err)
+	}
+	if _, err := tx.Exec(`ALTER TABLE adapter_processed_gh3819 RENAME TO adapter_processed`); err != nil {
+		return fmt.Errorf("rename adapter_processed_gh3819: %w", err)
+	}
+	return tx.Commit()
 }
 
 // migrateLegacyProcessedTables copies rows from the 7 legacy per-adapter tables
@@ -314,8 +398,7 @@ func (s *StateStore) Mark(source, repo, issueID string) error {
 	_, err := s.db.Exec(`
 		INSERT INTO adapter_processed (adapter, repo, issue_id, processed_at, result)
 		VALUES (?, ?, ?, CURRENT_TIMESTAMP, '')
-		ON CONFLICT(adapter, issue_id) DO UPDATE SET
-			repo = excluded.repo,
+		ON CONFLICT(adapter, repo, issue_id) DO UPDATE SET
 			processed_at = CURRENT_TIMESTAMP
 	`, source, repo, issueID)
 	return err

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -121,19 +121,22 @@ func (s *StateStore) migrate() error {
 		return fmt.Errorf("adapter_processed primary key migration failed: %w", err)
 	}
 
-	// GH-3819: Purge orphaned empty-repo rows for repo-scoped adapters. These
-	// can only have been written before the repo column existed (or by the
-	// GH-3819 collision bug clobbering a row down to its zero value); a
-	// repo-scoped poller always calls Mark/IsProcessed/Load with a non-empty
-	// "owner/repo" key, so such rows can never be matched again and would
-	// otherwise sit as permanent dead weight.
-	if err := s.pruneOrphanedEmptyRepoRows(); err != nil {
-		return fmt.Errorf("adapter_processed empty-repo cleanup failed: %w", err)
-	}
-
 	// TASK-298: Consolidate 7 legacy per-adapter tables into adapter_processed.
+	// Must run before the empty-repo prune below: these legacy tables predate
+	// the repo column and are always consolidated with repo='', so pruning
+	// first would miss the very rows this step creates until a second restart.
 	if err := s.migrateLegacyProcessedTables(); err != nil {
 		return fmt.Errorf("legacy processed tables migration failed: %w", err)
+	}
+
+	// GH-3819: Purge orphaned empty-repo rows for repo-scoped adapters. These
+	// can only have been written before the repo column existed, by the
+	// GH-3819 collision bug clobbering a row down to its zero value, or by
+	// the legacy-table consolidation above; a repo-scoped poller always calls
+	// Mark/IsProcessed/Load with a non-empty "owner/repo" key, so such rows
+	// can never be matched again and would otherwise sit as dead weight.
+	if err := s.pruneOrphanedEmptyRepoRows(); err != nil {
+		return fmt.Errorf("adapter_processed empty-repo cleanup failed: %w", err)
 	}
 
 	return nil

--- a/internal/autopilot/state_store_test.go
+++ b/internal/autopilot/state_store_test.go
@@ -923,6 +923,61 @@ func TestStateStore_MigrateAdapterProcessedPrimaryKey(t *testing.T) {
 	}
 }
 
+// TestStateStore_PruneOrphanedEmptyRepoRows verifies GH-3819 cleanup: rows for
+// repo-scoped adapters (github/gitlab/azuredevops) with an empty repo are
+// dead weight (repoKey() is never empty for these adapters) and get purged,
+// while tracker-style adapters (linear/jira/asana/plane), which legitimately
+// use repo="", are left untouched.
+func TestStateStore_PruneOrphanedEmptyRepoRows(t *testing.T) {
+	store := newTestStateStore(t)
+
+	// Seed an orphaned empty-repo row directly, bypassing Mark() (which a
+	// correctly-behaving repo-scoped poller would never call with repo="").
+	if _, err := store.db.Exec(
+		`INSERT INTO adapter_processed (adapter, repo, issue_id, processed_at, result)
+		 VALUES ('github', '', '5', CURRENT_TIMESTAMP, '')`,
+	); err != nil {
+		t.Fatalf("seed orphaned row: %v", err)
+	}
+
+	// Legitimate rows that must survive: a real repo-scoped row, and the
+	// tracker-style repo="" rows.
+	if err := store.Mark("github", "org/repo-a", "5"); err != nil {
+		t.Fatalf("Mark(github, org/repo-a) failed: %v", err)
+	}
+	if err := store.Mark("jira", "", "PROJ-1"); err != nil {
+		t.Fatalf("Mark(jira) failed: %v", err)
+	}
+
+	if err := store.pruneOrphanedEmptyRepoRows(); err != nil {
+		t.Fatalf("pruneOrphanedEmptyRepoRows failed: %v", err)
+	}
+
+	ok, err := store.IsProcessed("github", "", "5")
+	if err != nil {
+		t.Fatalf("IsProcessed(github, empty repo) failed: %v", err)
+	}
+	if ok {
+		t.Error("orphaned empty-repo github row should have been pruned")
+	}
+
+	ok, err = store.IsProcessed("github", "org/repo-a", "5")
+	if err != nil {
+		t.Fatalf("IsProcessed(github, org/repo-a) failed: %v", err)
+	}
+	if !ok {
+		t.Error("legitimate github row should survive pruning")
+	}
+
+	ok, err = store.IsProcessed("jira", "", "PROJ-1")
+	if err != nil {
+		t.Fatalf("IsProcessed(jira) failed: %v", err)
+	}
+	if !ok {
+		t.Error("tracker-style jira row (repo=\"\" by design) should survive pruning")
+	}
+}
+
 func TestStateStore_MigrateLegacyProcessedTables(t *testing.T) {
 	// Migration test: seed adapter_processed directly (legacy tables are dropped on migrate).
 	store := newTestStateStore(t)

--- a/internal/autopilot/state_store_test.go
+++ b/internal/autopilot/state_store_test.go
@@ -978,6 +978,59 @@ func TestStateStore_PruneOrphanedEmptyRepoRows(t *testing.T) {
 	}
 }
 
+// TestStateStore_LegacyMigrationRowsPrunedSamePass verifies GH-3819 subtask 5:
+// a legacy per-adapter table (pre-TASK-298, pre-repo-column) for a repo-scoped
+// adapter is consolidated into adapter_processed with repo='' by
+// migrateLegacyProcessedTables, and that dead-weight row must be purged in the
+// SAME migrate() pass by pruneOrphanedEmptyRepoRows — not left to linger until
+// a second restart. This pins the migration step ordering in migrate().
+func TestStateStore_LegacyMigrationRowsPrunedSamePass(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	// Seed the pre-TASK-298 legacy github table directly, bypassing migrate().
+	if _, err := db.Exec(`
+		CREATE TABLE autopilot_processed (
+			issue_number INTEGER PRIMARY KEY,
+			processed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			result TEXT DEFAULT ''
+		)
+	`); err != nil {
+		t.Fatalf("failed to seed legacy autopilot_processed: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO autopilot_processed (issue_number) VALUES (5)`); err != nil {
+		t.Fatalf("failed to seed legacy row: %v", err)
+	}
+
+	store, err := NewStateStore(db)
+	if err != nil {
+		t.Fatalf("NewStateStore (running migrations) failed: %v", err)
+	}
+
+	// The legacy table must be dropped and its row consolidated, then
+	// immediately pruned as dead weight — a repo-scoped adapter can never
+	// look this row up again since real lookups always pass a non-empty repo.
+	var exists int
+	if err := store.db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='autopilot_processed'`,
+	).Scan(&exists); err != nil {
+		t.Fatalf("check legacy table: %v", err)
+	}
+	if exists != 0 {
+		t.Error("legacy autopilot_processed table should have been dropped")
+	}
+
+	ok, err := store.IsProcessed("github", "", "5")
+	if err != nil {
+		t.Fatalf("IsProcessed(github, \"\") failed: %v", err)
+	}
+	if ok {
+		t.Error("orphaned empty-repo row from legacy migration should be pruned within the same migrate() pass, not left for a second restart")
+	}
+}
+
 func TestStateStore_MigrateLegacyProcessedTables(t *testing.T) {
 	// Migration test: seed adapter_processed directly (legacy tables are dropped on migrate).
 	store := newTestStateStore(t)

--- a/internal/autopilot/state_store_test.go
+++ b/internal/autopilot/state_store_test.go
@@ -2,6 +2,7 @@ package autopilot
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/testutil"
+
+	_ "modernc.org/sqlite"
 )
 
 func newTestStateStore(t *testing.T) *StateStore {
@@ -812,6 +815,111 @@ func TestStateStore_GenericAdapterProcessed_Upsert(t *testing.T) {
 	}
 	if len(all) != 1 {
 		t.Errorf("expected 1 entry after upsert, got %d", len(all))
+	}
+}
+
+// TestStateStore_GenericAdapterProcessed_CrossRepoIssueIDCollision guards
+// against GH-3819: adapter_processed's primary key must include repo, or two
+// repos processing the same issue_id silently overwrite each other's row.
+func TestStateStore_GenericAdapterProcessed_CrossRepoIssueIDCollision(t *testing.T) {
+	store := newTestStateStore(t)
+
+	if err := store.Mark("github", "org/repo-a", "5"); err != nil {
+		t.Fatalf("Mark(repo-a) failed: %v", err)
+	}
+	if err := store.Mark("github", "org/repo-b", "5"); err != nil {
+		t.Fatalf("Mark(repo-b) failed: %v", err)
+	}
+
+	okA, err := store.IsProcessed("github", "org/repo-a", "5")
+	if err != nil {
+		t.Fatalf("IsProcessed(repo-a) failed: %v", err)
+	}
+	if !okA {
+		t.Error("issue 5 in repo-a should still be marked processed after repo-b marks its own issue 5")
+	}
+
+	okB, err := store.IsProcessed("github", "org/repo-b", "5")
+	if err != nil {
+		t.Fatalf("IsProcessed(repo-b) failed: %v", err)
+	}
+	if !okB {
+		t.Error("issue 5 in repo-b should be marked processed")
+	}
+
+	repoAIssues, err := store.Load("github", "org/repo-a")
+	if err != nil {
+		t.Fatalf("Load(repo-a) failed: %v", err)
+	}
+	if len(repoAIssues) != 1 {
+		t.Errorf("expected 1 processed issue for repo-a, got %d", len(repoAIssues))
+	}
+
+	repoBIssues, err := store.Load("github", "org/repo-b")
+	if err != nil {
+		t.Fatalf("Load(repo-b) failed: %v", err)
+	}
+	if len(repoBIssues) != 1 {
+		t.Errorf("expected 1 processed issue for repo-b, got %d", len(repoBIssues))
+	}
+}
+
+// TestStateStore_MigrateAdapterProcessedPrimaryKey verifies that a DB with the
+// pre-GH-3819 schema (PRIMARY KEY (adapter, issue_id), repo not part of the
+// key) is rebuilt so repo joins the primary key, and existing rows survive
+// the rebuild.
+func TestStateStore_MigrateAdapterProcessedPrimaryKey(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	// Seed the old (pre-fix) schema directly, bypassing NewStateStore's migrate().
+	if _, err := db.Exec(`
+		CREATE TABLE adapter_processed (
+			adapter TEXT NOT NULL,
+			issue_id TEXT NOT NULL,
+			processed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			result TEXT DEFAULT '',
+			PRIMARY KEY (adapter, issue_id)
+		)
+	`); err != nil {
+		t.Fatalf("failed to seed legacy schema: %v", err)
+	}
+	if _, err := db.Exec(`ALTER TABLE adapter_processed ADD COLUMN repo TEXT NOT NULL DEFAULT ''`); err != nil {
+		t.Fatalf("failed to add legacy repo column: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO adapter_processed (adapter, repo, issue_id, processed_at, result)
+		VALUES ('github', 'org/repo-a', '5', CURRENT_TIMESTAMP, '')
+	`); err != nil {
+		t.Fatalf("failed to seed legacy row: %v", err)
+	}
+
+	store, err := NewStateStore(db)
+	if err != nil {
+		t.Fatalf("NewStateStore (running migrations) failed: %v", err)
+	}
+
+	// Pre-existing row must survive the rebuild.
+	ok, err := store.IsProcessed("github", "org/repo-a", "5")
+	if err != nil {
+		t.Fatalf("IsProcessed failed: %v", err)
+	}
+	if !ok {
+		t.Error("pre-existing row for org/repo-a issue 5 should survive the primary-key migration")
+	}
+
+	// Post-migration, colliding issue IDs across repos must not overwrite each other.
+	if err := store.Mark("github", "org/repo-b", "5"); err != nil {
+		t.Fatalf("Mark(repo-b) failed: %v", err)
+	}
+	ok, err = store.IsProcessed("github", "org/repo-a", "5")
+	if err != nil {
+		t.Fatalf("IsProcessed failed: %v", err)
+	}
+	if !ok {
+		t.Error("org/repo-a issue 5 should remain processed after org/repo-b marks its own issue 5")
 	}
 }
 


### PR DESCRIPTION
Closes #3819
TASK-382 D11. Salvaged delivery: the GH-3819 worker completed all four commits (`558e8c09..f449ffc3`) but the push/PR step failed silently — the D2 fix (#3785, v2.207.3) that automates this recovery is merged but not yet in the running daemon binary (v2.207.1). Branch pushed manually from the pinned odb chain.

## Contents
- Fix wrong-repo stamping in `adapter_processed` writes
- Prune orphaned empty-repo rows on migration + ordering fix
- Test: two projects with the same issue number process independently

## Verify
```bash
make test && make lint
```