### PR TITLE
fix(adapters): enforce Blocked-by gating at dispatch time, not just poll time

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -656,6 +656,20 @@ func (p *Poller) startSequential(ctx context.Context) {
 			}
 		}
 
+		// GH-3789: Re-check dependency state right before dispatch. The
+		// candidate was found dependency-free at the top of this loop, but
+		// the pre-flight judge call above (an LLM round trip) opens a real
+		// window in which a "Blocked by: #N" issue could reopen. Without
+		// this recheck the gate at findOldestUnprocessedIssue is decorative
+		// for sequential mode.
+		if p.hasPendingDependencies(ctx, issue) {
+			p.logger.Info("Blocker reopened before dispatch, skipping",
+				slog.Int("number", issue.Number),
+			)
+			p.recordSkip(skipreason.ReasonPendingDependency)
+			continue
+		}
+
 		// Board sync: move card to in-progress on confirmed dispatch (GH-3252).
 		p.syncBoardStatusInProgress(ctx, issue)
 
@@ -1016,6 +1030,7 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 			slog.Int("number", candidate.Number),
 			slog.String("title", candidate.Title),
 		)
+		p.recordSkip(skipreason.ReasonPendingDependency)
 	}
 
 	// All candidates have pending dependencies
@@ -1400,6 +1415,21 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 				slog.Int("number", issue.Number),
 				slog.Any("error", ferr),
 			)
+		}
+
+		// GH-3789: Re-check dependency state right before dispatch. The
+		// candidate cleared hasPendingDependencies during Phase 1, but
+		// Phase 3 can be reached an arbitrary amount of time later (waiting
+		// on the semaphore for a free max_concurrent slot, or on the fresh
+		// label GET above), long enough for a "Blocked by: #N" issue to
+		// reopen. Without this recheck the poll-time gate is decorative for
+		// any task that sits queued behind a full worker pool.
+		if p.hasPendingDependencies(ctx, issue) {
+			p.logger.Info("Blocker reopened before dispatch, skipping",
+				slog.Int("number", issue.Number),
+			)
+			p.recordSkip(skipreason.ReasonPendingDependency)
+			continue
 		}
 
 		// GH-2802: Pre-flight judge — evaluate issue quality before burning a worker slot.

--- a/internal/adapters/github/poller_skip_metrics_test.go
+++ b/internal/adapters/github/poller_skip_metrics_test.go
@@ -3,10 +3,12 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -191,6 +193,302 @@ func TestPoller_ScopeOverlapDeferral_IncrementsMetric(t *testing.T) {
 	}
 	if m.dispatched != 1 {
 		t.Errorf("dispatched = %d, want 1", m.dispatched)
+	}
+}
+
+// TestPoller_SequentialMode_PendingDependency_RecordsSkipMetric covers GH-3789:
+// findOldestUnprocessedIssue used to skip dependency-gated issues silently
+// (log only, no metric), which made the gate invisible in poller metrics.
+func TestPoller_SequentialMode_PendingDependency_RecordsSkipMetric(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		depStates  map[int]string // dependency issue number -> state
+		wantSkip   int
+		wantNumber int // issue number expected to be returned, 0 if none
+	}{
+		{
+			name:       "open blocker",
+			body:       "Blocked by: #100",
+			depStates:  map[int]string{100: "open"},
+			wantSkip:   1,
+			wantNumber: 0,
+		},
+		{
+			name:       "closed blocker",
+			body:       "Blocked by: #100",
+			depStates:  map[int]string{100: "closed"},
+			wantSkip:   0,
+			wantNumber: 1,
+		},
+		{
+			name:       "missing blocker reference",
+			body:       "Regular issue, no dependency",
+			depStates:  nil,
+			wantSkip:   0,
+			wantNumber: 1,
+		},
+		{
+			name:       "multiple blockers, one still open",
+			body:       "Depends on: #100\nBlocked by: #101",
+			depStates:  map[int]string{100: "closed", 101: "open"},
+			wantSkip:   1,
+			wantNumber: 0,
+		},
+		{
+			name:       "multiple blockers, all closed",
+			body:       "Depends on: #100\nBlocked by: #101",
+			depStates:  map[int]string{100: "closed", 101: "closed"},
+			wantSkip:   0,
+			wantNumber: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &Issue{Number: 1, Title: "gated", Body: tt.body, Labels: []Label{{Name: "pilot"}}, CreatedAt: time.Now()}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+				if r.URL.Path == "/repos/owner/repo/issues" {
+					_ = json.NewEncoder(w).Encode([]*Issue{issue})
+					return
+				}
+				var num int
+				_, _ = fmt.Sscanf(parts[len(parts)-1], "%d", &num)
+				if state, ok := tt.depStates[num]; ok {
+					_ = json.NewEncoder(w).Encode(&Issue{Number: num, State: state})
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			m := newFakePollerMetrics()
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithPollerMetrics(m))
+
+			got, err := poller.findOldestUnprocessedIssue(context.Background())
+			if err != nil {
+				t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+			}
+
+			if tt.wantNumber == 0 && got != nil {
+				t.Errorf("got issue #%d, want nil", got.Number)
+			}
+			if tt.wantNumber != 0 && (got == nil || got.Number != tt.wantNumber) {
+				t.Errorf("got issue = %+v, want #%d", got, tt.wantNumber)
+			}
+
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			if got := m.skipped[skipreason.ReasonPendingDependency]; got != tt.wantSkip {
+				t.Errorf("skipped[pending_dependency] = %d, want %d", got, tt.wantSkip)
+			}
+		})
+	}
+}
+
+// TestPoller_CheckForNewIssues_PendingDependency_RecordsSkipMetric covers the
+// parallel/auto dispatch path's Phase 1 filter (GH-3789).
+func TestPoller_CheckForNewIssues_PendingDependency_RecordsSkipMetric(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           string
+		depStates      map[int]string
+		wantSkip       int
+		wantDispatched int
+	}{
+		{
+			name:      "open blocker",
+			body:      "Blocked by: #100",
+			depStates: map[int]string{100: "open"},
+			wantSkip:  1,
+		},
+		{
+			name:           "closed blocker",
+			body:           "Blocked by: #100",
+			depStates:      map[int]string{100: "closed"},
+			wantDispatched: 1,
+		},
+		{
+			name:      "multiple blockers, one still open",
+			body:      "Depends on: #100\nBlocked by: #101",
+			depStates: map[int]string{100: "closed", 101: "open"},
+			wantSkip:  1,
+		},
+		{
+			name:           "multiple blockers, all closed",
+			body:           "Depends on: #100\nBlocked by: #101",
+			depStates:      map[int]string{100: "closed", 101: "closed"},
+			wantDispatched: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &Issue{Number: 1, Title: "gated", Body: tt.body, Labels: []Label{{Name: "pilot"}}, CreatedAt: time.Now()}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == "/repos/owner/repo/issues" {
+					_ = json.NewEncoder(w).Encode([]*Issue{issue})
+					return
+				}
+				parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+				var num int
+				_, _ = fmt.Sscanf(parts[len(parts)-1], "%d", &num)
+				if num == issue.Number {
+					// fresh-label GET before dispatch
+					_ = json.NewEncoder(w).Encode(issue)
+					return
+				}
+				if state, ok := tt.depStates[num]; ok {
+					_ = json.NewEncoder(w).Encode(&Issue{Number: num, State: state})
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			m := newFakePollerMetrics()
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+				WithOnIssue(func(ctx context.Context, issue *Issue) error { return nil }),
+				WithPollerMetrics(m),
+			)
+
+			poller.checkForNewIssues(context.Background())
+			poller.WaitForActive()
+
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			if got := m.skipped[skipreason.ReasonPendingDependency]; got != tt.wantSkip {
+				t.Errorf("skipped[pending_dependency] = %d, want %d", got, tt.wantSkip)
+			}
+			if m.dispatched != tt.wantDispatched {
+				t.Errorf("dispatched = %d, want %d", m.dispatched, tt.wantDispatched)
+			}
+		})
+	}
+}
+
+// TestPoller_CheckForNewIssues_DispatchTimeRecheck_BlockerReopened covers
+// GH-3789's dispatch-time recheck: a candidate that cleared the Phase 1
+// dependency check must not be dispatched if the blocker is open again by
+// the time Phase 3 actually reaches it (simulating a task that sat queued
+// behind a full worker pool while its blocker reopened).
+func TestPoller_CheckForNewIssues_DispatchTimeRecheck_BlockerReopened(t *testing.T) {
+	issue := &Issue{Number: 1, Title: "gated", Body: "Blocked by: #100", Labels: []Label{{Name: "pilot"}}, CreatedAt: time.Now()}
+
+	var blockerCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/repos/owner/repo/issues" {
+			_ = json.NewEncoder(w).Encode([]*Issue{issue})
+			return
+		}
+		if r.URL.Path == "/repos/owner/repo/issues/1" {
+			// fresh-label GET before dispatch
+			_ = json.NewEncoder(w).Encode(issue)
+			return
+		}
+		if r.URL.Path == "/repos/owner/repo/issues/100" {
+			n := atomic.AddInt32(&blockerCalls, 1)
+			state := "closed"
+			if n > 1 {
+				// Reopened between the Phase 1 filter and the Phase 3 recheck.
+				state = "open"
+			}
+			_ = json.NewEncoder(w).Encode(&Issue{Number: 100, State: state})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	m := newFakePollerMetrics()
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			t.Fatal("issue should not have been dispatched — blocker reopened before dispatch")
+			return nil
+		}),
+		WithPollerMetrics(m),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if atomic.LoadInt32(&blockerCalls) < 2 {
+		t.Fatalf("blocker state should have been checked at both Phase 1 and Phase 3, got %d calls", blockerCalls)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.dispatched != 0 {
+		t.Errorf("dispatched = %d, want 0", m.dispatched)
+	}
+	if got := m.skipped[skipreason.ReasonPendingDependency]; got < 1 {
+		t.Errorf("skipped[pending_dependency] = %d, want ≥ 1", got)
+	}
+}
+
+// TestPoller_StartSequential_DispatchTimeRecheck_BlockerReopened is the
+// sequential-mode counterpart: findOldestUnprocessedIssue clears the issue,
+// but the dispatch-time recheck in startSequential must catch a blocker that
+// reopens before processIssueSequential is invoked.
+func TestPoller_StartSequential_DispatchTimeRecheck_BlockerReopened(t *testing.T) {
+	issue := &Issue{Number: 1, Title: "gated", Body: "Blocked by: #100", Labels: []Label{{Name: "pilot"}}, CreatedAt: time.Now()}
+
+	var blockerCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/repos/owner/repo/issues" {
+			_ = json.NewEncoder(w).Encode([]*Issue{issue})
+			return
+		}
+		if r.URL.Path == "/repos/owner/repo/issues/100" {
+			n := atomic.AddInt32(&blockerCalls, 1)
+			state := "closed"
+			if n > 1 {
+				state = "open"
+			}
+			_ = json.NewEncoder(w).Encode(&Issue{Number: 100, State: state})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	m := newFakePollerMetrics()
+
+	var dispatchedIssue int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 10*time.Millisecond,
+		WithExecutionMode(ExecutionModeSequential),
+		WithSequentialConfig(false, 10*time.Millisecond, 100*time.Millisecond),
+		WithOnIssueWithResult(func(ctx context.Context, issue *Issue) (*IssueResult, error) {
+			atomic.StoreInt32(&dispatchedIssue, int32(issue.Number))
+			return &IssueResult{Success: true}, nil
+		}),
+		WithPollerMetrics(m),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	poller.Start(ctx)
+
+	if got := atomic.LoadInt32(&dispatchedIssue); got != 0 {
+		t.Errorf("issue #%d was dispatched, want none — blocker reopened before dispatch-time recheck", got)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if got := m.skipped[skipreason.ReasonPendingDependency]; got < 1 {
+		t.Errorf("skipped[pending_dependency] = %d, want ≥ 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes GH-3789 (Defect D6 from TASK-382): `Blocked by: #N` gating was checked once at candidate-selection time in both sequential (`findOldestUnprocessedIssue`) and parallel/auto (`checkForNewIssues`) dispatch paths, but never re-verified right before actual dispatch. A task could clear the check and then sit queued (pre-flight LLM judge call, or waiting on the concurrency semaphore) long enough for its blocker to reopen before executing.
- `findOldestUnprocessedIssue`'s pending-dependency skip was log-only — no `skipreason.ReasonPendingDependency` metric was recorded, unlike the parallel path, making the gate invisible in `pilot_poller_skipped_total`.
- Adds a dependency recheck immediately before dispatch in both `startSequential` and `checkForNewIssues` (Phase 3), recording the skip reason when a blocker is found open at that point.

## Changes
- `internal/adapters/github/poller.go`:
  - `findOldestUnprocessedIssue`: record `ReasonPendingDependency` on skip (was silent).
  - `startSequential`: recheck `hasPendingDependencies` immediately before `processIssueSequential`.
  - `checkForNewIssues`: recheck `hasPendingDependencies` immediately before per-issue dispatch (alongside the existing fresh-label recheck).
- `internal/adapters/github/poller_skip_metrics_test.go`: table-driven tests for open/closed/missing/multiple blockers in both dispatch paths, plus two "blocker reopens between poll and dispatch" tests (parallel and sequential) verifying the recheck fires and the skip metric is recorded.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/adapters/github/...`
- [x] `go test ./...` (full suite)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`