### PR TITLE
fix(cmd): warn when telegram approval channel is send-only

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/qf-studio/pilot/internal/dashboard"
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/gateway"
+	"github.com/qf-studio/pilot/internal/health"
 	"github.com/qf-studio/pilot/internal/health/verify"
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
@@ -278,6 +279,16 @@ Examples:
 
 			// Apply flag overrides to config
 			applyInputOverrides(cfg, cmd, enableTelegram, enableGithub, enableLinear, enableSlack, enableTunnel, enablePlane, enableDiscord)
+
+			// GH-3826: warn loudly when Telegram will send approval requests
+			// but has no inbound polling to receive the approve/reject tap —
+			// otherwise decisions silently strand until the approval stage
+			// times out.
+			if msg := health.TelegramApprovalStranding(cfg); msg != "" {
+				logging.WithComponent("start").Error(msg,
+					slog.Bool("telegram_polling", cfg.Adapters.Telegram.Polling))
+				fmt.Fprintf(os.Stderr, "⚠️  %s — run 'pilot doctor' for details, or set adapters.telegram.polling: true / start with --telegram\n", msg)
+			}
 
 			// Apply team ID override if flag provided
 			if teamID != "" {

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -725,6 +725,38 @@ func checkIssueSourceAdapter(cfg *config.Config) ConfigCheck {
 	}
 }
 
+// TelegramApprovalStranding returns a non-empty warning when Telegram is
+// configured as an approval channel (it will send approve/reject requests)
+// but has no inbound polling running to receive the button tap that answers
+// them (GH-3826). Decisions in this configuration can only resolve via the
+// approval stage's timeout/default_action, never via the approver's actual
+// choice. Returns "" when there's no stranding risk.
+func TelegramApprovalStranding(cfg *config.Config) string {
+	if cfg == nil || cfg.Adapters == nil || cfg.Adapters.Telegram == nil {
+		return ""
+	}
+	tg := cfg.Adapters.Telegram
+	if !tg.Enabled || tg.BotToken == "" || tg.Polling {
+		return ""
+	}
+	if tg.Approval != nil && !tg.Approval.Enabled {
+		return ""
+	}
+
+	ac := cfg.Approval
+	if ac == nil || !ac.Enabled {
+		return ""
+	}
+	stageEnabled := (ac.PreMerge != nil && ac.PreMerge.Enabled) ||
+		(ac.PreExecution != nil && ac.PreExecution.Enabled) ||
+		(ac.PostFailure != nil && ac.PostFailure.Enabled)
+	if !stageEnabled {
+		return ""
+	}
+
+	return "approval channel telegram is send-only in this configuration — approvals will strand"
+}
+
 // checkConfig validates configuration
 func checkConfig(cfg *config.Config) []ConfigCheck {
 	checks := []ConfigCheck{}
@@ -905,6 +937,19 @@ func checkConfig(cfg *config.Config) []ConfigCheck {
 				break // one diagnostic per run is enough
 			}
 		}
+	}
+
+	// GH-3826: Telegram is registered as an approval channel (sends approve/reject
+	// requests) but has no inbound polling running to receive the button tap —
+	// approvals can only resolve via the stage timeout/default_action, not the
+	// approver's decision.
+	if msg := TelegramApprovalStranding(cfg); msg != "" {
+		checks = append(checks, ConfigCheck{
+			Name:    "telegram-approval-stranding",
+			Status:  StatusError,
+			Message: msg + " (adapters.telegram.polling=false — no inbound path for approve/reject taps)",
+			Fix:     "Set adapters.telegram.polling: true (or start with --telegram) so button taps can be received, or remove Telegram as an approval channel",
+		})
 	}
 
 	// Check daily brief schedule

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1335,3 +1335,101 @@ func TestCheckConfig_ApprovalMisconfig_NotReported_WhenNoEnvRequiresApproval(t *
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// GH-3826: Telegram approval-stranding checks
+// ---------------------------------------------------------------------------
+
+func telegramStrandingConfig() *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.Adapters.Telegram = &telegram.Config{
+		Enabled:  true,
+		BotToken: "test-bot-token",
+		Polling:  false,
+	}
+	approvalCfg := approval.DefaultConfig()
+	approvalCfg.Enabled = true
+	approvalCfg.PreMerge = &approval.StageConfig{Enabled: true}
+	cfg.Approval = approvalCfg
+	return cfg
+}
+
+func TestTelegramApprovalStranding_Detected(t *testing.T) {
+	cfg := telegramStrandingConfig()
+
+	msg := TelegramApprovalStranding(cfg)
+	if msg == "" {
+		t.Fatal("expected stranding warning when telegram is enabled, polling is off, and pre_merge approval is enabled")
+	}
+	if !strings.Contains(msg, "telegram") {
+		t.Errorf("expected message to mention telegram, got: %s", msg)
+	}
+}
+
+func TestTelegramApprovalStranding_NotReported_WhenPollingEnabled(t *testing.T) {
+	cfg := telegramStrandingConfig()
+	cfg.Adapters.Telegram.Polling = true
+
+	if msg := TelegramApprovalStranding(cfg); msg != "" {
+		t.Errorf("expected no stranding warning when polling is enabled, got: %s", msg)
+	}
+}
+
+func TestTelegramApprovalStranding_NotReported_WhenTelegramDisabled(t *testing.T) {
+	cfg := telegramStrandingConfig()
+	cfg.Adapters.Telegram.Enabled = false
+
+	if msg := TelegramApprovalStranding(cfg); msg != "" {
+		t.Errorf("expected no stranding warning when telegram is disabled, got: %s", msg)
+	}
+}
+
+func TestTelegramApprovalStranding_NotReported_WhenTelegramApprovalChannelDisabled(t *testing.T) {
+	cfg := telegramStrandingConfig()
+	cfg.Adapters.Telegram.Approval = &telegram.ApprovalConfig{Enabled: false}
+
+	if msg := TelegramApprovalStranding(cfg); msg != "" {
+		t.Errorf("expected no stranding warning when telegram approval channel is disabled, got: %s", msg)
+	}
+}
+
+func TestTelegramApprovalStranding_NotReported_WhenNoApprovalStageEnabled(t *testing.T) {
+	cfg := telegramStrandingConfig()
+	cfg.Approval.PreMerge.Enabled = false
+
+	if msg := TelegramApprovalStranding(cfg); msg != "" {
+		t.Errorf("expected no stranding warning when no approval stage is enabled, got: %s", msg)
+	}
+}
+
+func TestTelegramApprovalStranding_NotReported_WhenNoBotToken(t *testing.T) {
+	cfg := telegramStrandingConfig()
+	cfg.Adapters.Telegram.BotToken = ""
+
+	if msg := TelegramApprovalStranding(cfg); msg != "" {
+		t.Errorf("expected no stranding warning when bot token is missing, got: %s", msg)
+	}
+}
+
+func TestCheckConfig_TelegramApprovalStranding_Detected(t *testing.T) {
+	cfg := telegramStrandingConfig()
+
+	checks := checkConfig(cfg)
+	found := findConfigCheck(checks, "telegram-approval-stranding")
+	if found == nil {
+		t.Fatal("expected 'telegram-approval-stranding' check to appear in ConfigChecks")
+	}
+	if found.Status != StatusError {
+		t.Errorf("telegram-approval-stranding status = %v, want StatusError", found.Status)
+	}
+}
+
+func TestCheckConfig_TelegramApprovalStranding_NotReported_WhenPollingEnabled(t *testing.T) {
+	cfg := telegramStrandingConfig()
+	cfg.Adapters.Telegram.Polling = true
+
+	checks := checkConfig(cfg)
+	if found := findConfigCheck(checks, "telegram-approval-stranding"); found != nil {
+		t.Errorf("unexpected telegram-approval-stranding check when polling is enabled: %+v", found)
+	}
+}


### PR DESCRIPTION
## Summary
- GitHub Issue #3826 / TASK-382 defect D15: `adapters.telegram.enabled: true` registers the Telegram approval handler (sends approve/reject requests) independent of whether `--telegram` was passed to actually enable inbound polling — so decisions can silently strand.
- Adds `health.TelegramApprovalStranding(cfg)`: fires when Telegram is enabled + used as an approval channel + `adapters.telegram.polling` is false + at least one approval stage (pre_merge/pre_execution/post_failure) is enabled.
- Surfaced in two places: a loud `ERROR`-level log + stderr banner at `pilot start` boot, and a red `telegram-approval-stranding` check in `pilot doctor`.
- Verified approval requests already resolve within a bounded time even with no responsive channel — `approval.Manager.SubmitApprovalRequest`'s background goroutine and `autopilot.Controller.handleAwaitApproval`'s wall-clock guard both fall back to the stage's `default_action` on timeout (1h for pre_execution/post_failure, 24h for pre_merge), so this was already non-infinite; this PR adds the missing visibility.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/pilot/... ./internal/health/... ./internal/approval/... ./internal/autopilot/...`
- [x] `make test`
- [x] `make lint` (0 issues)
- [x] Manually built the binary and ran `pilot doctor -v` against a crafted config (`telegram.enabled=true`, `polling=false`, `approval.pre_merge.enabled=true`) — confirmed the new `telegram-approval-stranding` red check and fix suggestion appear.