### PR TITLE
fix(autopilot): scope-drift gate silently abstains on 'GH-NNNN: ' title prefixes

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -876,7 +876,7 @@ func (c *Controller) handleCIPassed(ctx context.Context, prState *PRState) error
 		if issueErr != nil {
 			c.log.Warn("handleCIPassed: GetIssue failed, skipping scope-drift gate (fail-open)",
 				"pr", prState.PRNumber, "issue", prState.IssueNumber, "error", issueErr)
-		} else if reason := ScopeDriftReason(prState.PRTitle, issue.Title); reason != "" {
+		} else if reason := ScopeDriftReason(c.log, prState.PRTitle, issue.Title); reason != "" {
 			escalateReason = reason
 		}
 	}

--- a/internal/autopilot/scope_guard.go
+++ b/internal/autopilot/scope_guard.go
@@ -2,6 +2,7 @@ package autopilot
 
 import (
 	"fmt"
+	"log/slog"
 	"regexp"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
@@ -20,11 +21,33 @@ import (
 
 var convCommitRE = regexp.MustCompile(`^([a-z]+)\(([a-z0-9_./-]+)\)\s*[!:]`)
 
+// issueRefPrefixRE matches a leading issue-reference tag such as "GH-3785: ",
+// "JIRA-123: ", or "TASK-12: " that Pilot workers prepend to PR titles.
+// GH-3827: these prefixes shifted the conventional-commit type off string
+// start, so convCommitRE silently failed to match and the scope-drift gate
+// abstained on every prefixed worker PR (observed on #3796, #3816).
+var issueRefPrefixRE = regexp.MustCompile(`(?i)^[a-z]+-\d+:\s*`)
+
+// stripIssueRefPrefix removes leading issue-reference tags (e.g. "GH-3785: ")
+// so the conventional-commit type/scope can be matched at the new start.
+// Strips repeatedly in case more than one tag is stacked.
+func stripIssueRefPrefix(title string) string {
+	for {
+		stripped := issueRefPrefixRE.ReplaceAllString(title, "")
+		if stripped == title {
+			return title
+		}
+		title = stripped
+	}
+}
+
 // extractTypeScope returns the conventional-commit type and scope from a title.
-// Returns ("", "") if the title doesn't match the conventional-commit prefix.
+// Returns ("", "") if the title doesn't match the conventional-commit prefix,
+// after stripping any leading issue-reference tag (e.g. "GH-3785: ").
 // Example: "feat(auth): add OAuth" -> ("feat", "auth").
+// Example: "GH-3785: fix(executor): X" -> ("fix", "executor").
 func extractTypeScope(title string) (string, string) {
-	m := convCommitRE.FindStringSubmatch(title)
+	m := convCommitRE.FindStringSubmatch(stripIssueRefPrefix(title))
 	if m == nil {
 		return "", ""
 	}
@@ -34,17 +57,29 @@ func extractTypeScope(title string) (string, string) {
 // ScopeDriftReason returns a non-empty reason if the PR's conventional-commit
 // type or scope diverges from the linked issue's. Empty string = no drift
 // (or insufficient signal — both titles must have a conventional prefix).
+// logger may be nil (e.g. in tests); when non-nil, abstentions are logged at
+// INFO so a silently-bypassed gate is visible (GH-3827 — a genuinely
+// unparseable title used to abstain without a trace).
 //
 // Closes the cascade-2 attack surface where a `fix(upgrade)` issue produced a
 // `feat(auth)` PR. We only escalate (force human approval), never block.
-func ScopeDriftReason(prTitle, issueTitle string) string {
+func ScopeDriftReason(logger *slog.Logger, prTitle, issueTitle string) string {
 	if prTitle == "" || issueTitle == "" {
+		if logger != nil {
+			logger.Info("scope-drift gate abstained: empty PR or issue title",
+				"pr_title", prTitle, "issue_title", issueTitle)
+		}
 		return ""
 	}
 	prType, prScope := extractTypeScope(prTitle)
 	issueType, issueScope := extractTypeScope(issueTitle)
 	// If either side has no conventional prefix, we can't compare — abstain.
 	if prType == "" || issueType == "" {
+		if logger != nil {
+			logger.Info("scope-drift gate abstained: no conventional-commit shape found",
+				"pr_title", prTitle, "issue_title", issueTitle,
+				"pr_parsed", prType != "", "issue_parsed", issueType != "")
+		}
 		return ""
 	}
 	if prType != issueType {

--- a/internal/autopilot/scope_guard_test.go
+++ b/internal/autopilot/scope_guard_test.go
@@ -1,6 +1,7 @@
 package autopilot
 
 import (
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -19,6 +20,12 @@ func TestExtractTypeScope(t *testing.T) {
 		{"feat(auth)!: breaking change", "feat", "auth"},
 		{"random title", "", ""},
 		{"", "", ""},
+		// GH-3827: worker PRs are titled with a leading issue-ref tag.
+		{"GH-3785: fix(executor): retry backoff", "fix", "executor"},
+		{"GH-3785: feat(auth): add OAuth", "feat", "auth"},
+		{"gh-3785: fix(executor): case-insensitive tag", "fix", "executor"},
+		{"JIRA-123: chore: bump deps", "", ""}, // missing scope, still no match
+		{"GH-3785:fix(executor): no space after colon", "fix", "executor"},
 	}
 	for _, tc := range cases {
 		gotType, gotS := extractTypeScope(tc.title)
@@ -61,10 +68,34 @@ func TestScopeDriftReason(t *testing.T) {
 			prTitle:    "raw title",
 			issueTitle: "feat(auth): X",
 		},
+		// GH-3827: worker PRs are titled "GH-NNNN: type(scope): ..." — the gate
+		// must strip the issue-ref tag rather than abstain on every such PR.
+		{
+			name:         "GH-NNNN prefix on PR title — type mismatch still escalates",
+			prTitle:      "GH-3785: feat(auth): add OAuth provider integration",
+			issueTitle:   "fix(executor): cherry-pick atomic binary replacement",
+			wantContains: "type",
+		},
+		{
+			name:         "GH-NNNN prefix on PR title — scope mismatch still escalates",
+			prTitle:      "GH-3785: fix(memory): X",
+			issueTitle:   "fix(executor): Y",
+			wantContains: "scope",
+		},
+		{
+			name:       "GH-NNNN prefix on PR title — matching type/scope, no drift",
+			prTitle:    "GH-3785: fix(executor): retry backoff tweak",
+			issueTitle: "fix(executor): retry backoff bug",
+		},
+		{
+			name:       "GH-NNNN prefix on both titles — matching, no drift",
+			prTitle:    "GH-3796: fix(executor): retry backoff tweak",
+			issueTitle: "GH-3785: fix(executor): retry backoff bug",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ScopeDriftReason(tc.prTitle, tc.issueTitle)
+			got := ScopeDriftReason(nil, tc.prTitle, tc.issueTitle)
 			if tc.wantContains == "" && got != "" {
 				t.Errorf("expected no drift, got %q", got)
 			}
@@ -72,6 +103,26 @@ func TestScopeDriftReason(t *testing.T) {
 				t.Errorf("want reason containing %q, got %q", tc.wantContains, got)
 			}
 		})
+	}
+}
+
+// TestScopeDriftReason_AbstainLogsReason verifies GH-3827: a genuinely
+// unparseable title (no conventional-commit shape at all) must be logged at
+// INFO instead of abstaining silently.
+func TestScopeDriftReason_AbstainLogsReason(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	got := ScopeDriftReason(logger, "raw title with no conventional shape", "also raw")
+	if got != "" {
+		t.Fatalf("expected abstain (empty reason), got %q", got)
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "abstained") {
+		t.Errorf("expected abstention to be logged at INFO, got log output: %q", logged)
+	}
+	if !strings.Contains(logged, "level=INFO") {
+		t.Errorf("expected log level INFO, got: %q", logged)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes GH-3827 / defect D12 from TASK-382: `ScopeDriftReason`'s conventional-commit regex required the type at string start, so worker PR titles like `GH-3785: fix(executor): ...` (observed on #3796, #3816) never matched — the gate abstained instead of comparing, bypassing the type/scope drift defense-in-depth (only the 500-line size floor remained active).
- Strips a leading issue-ref tag (`GH-123:`, `JIRA-123:`, etc., case-insensitive) before conventional-commit matching in `extractTypeScope`.
- `ScopeDriftReason` now takes a `*slog.Logger` and logs at INFO whenever it abstains (empty title, or no conventional-commit shape found on either side) so a bypass is no longer silent.

## Test plan
- [x] Table-driven tests: `GH-NNNN:`-prefixed titles with matching and mismatching type/scope (`TestExtractTypeScope`, `TestScopeDriftReason`)
- [x] New `TestScopeDriftReason_AbstainLogsReason` asserts an INFO log line is emitted on genuine abstention
- [x] `go build ./...` passes
- [x] `go test ./...` passes (full suite)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues