### PR TITLE
fix(adapters): enforce 'Blocked by: #N' at dispatch time, not just poll

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -656,6 +656,18 @@ func (p *Poller) startSequential(ctx context.Context) {
 			}
 		}
 
+		// GH-3789: Re-check dependency state immediately before dispatch. The
+		// pre-flight judge call above (and, on a busy poller, the gap since
+		// findOldestUnprocessedIssue selected this candidate) leaves a window
+		// where a blocker could have reopened after passing the initial gate.
+		if p.hasPendingDependencies(ctx, issue) {
+			p.logger.Info("Skipping dispatch — dependency reopened since candidate selection",
+				slog.Int("number", issue.Number),
+			)
+			p.recordSkip(skipreason.ReasonPendingDependency)
+			continue
+		}
+
 		// Board sync: move card to in-progress on confirmed dispatch (GH-3252).
 		p.syncBoardStatusInProgress(ctx, issue)
 
@@ -1016,6 +1028,7 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 			slog.Int("number", candidate.Number),
 			slog.String("title", candidate.Title),
 		)
+		p.recordSkip(skipreason.ReasonPendingDependency)
 	}
 
 	// All candidates have pending dependencies
@@ -1428,6 +1441,19 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case p.semaphore <- struct{}{}:
+		}
+
+		// GH-3789: Re-check dependency state now that a worker slot is free — a
+		// blocker could have reopened while this issue waited behind other
+		// in-flight dispatches since Phase 1 candidate selection.
+		if p.hasPendingDependencies(ctx, issue) {
+			p.logger.Info("Skipping dispatch — dependency reopened while queued for a worker slot",
+				slog.Int("number", issue.Number),
+			)
+			<-p.semaphore // release slot we acquired without using it
+			p.unmarkProcessed(issue.Number)
+			p.recordSkip(skipreason.ReasonPendingDependency)
+			continue
 		}
 
 		p.recordDispatched()

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/adapters/skipreason"
 	"github.com/qf-studio/pilot/internal/testutil"
 )
 
@@ -1247,6 +1249,229 @@ func TestPoller_FindOldestUnprocessedIssue_AllDepsOpen(t *testing.T) {
 	// Should return nil when all issues have open dependencies
 	if issue != nil {
 		t.Errorf("issue should be nil when all have open dependencies, got #%d", issue.Number)
+	}
+}
+
+// GH-3789: multiple blockers where only some have closed — the issue must stay
+// gated until every referenced dependency is closed.
+func TestPoller_HasPendingDependencies_MultipleBlockers(t *testing.T) {
+	tests := []struct {
+		name        string
+		issueBody   string
+		depStates   map[int]string
+		wantPending bool
+	}{
+		{
+			name:        "one open one closed",
+			issueBody:   "Depends on: #100\nBlocked by: #101",
+			depStates:   map[int]string{100: "closed", 101: "open"},
+			wantPending: true,
+		},
+		{
+			name:        "all closed",
+			issueBody:   "Depends on: #100\nBlocked by: #101",
+			depStates:   map[int]string{100: "closed", 101: "closed"},
+			wantPending: false,
+		},
+		{
+			name:        "all open",
+			issueBody:   "Depends on: #100\nBlocked by: #101",
+			depStates:   map[int]string{100: "open", 101: "open"},
+			wantPending: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				for num, state := range tt.depStates {
+					if r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", num) {
+						_ = json.NewEncoder(w).Encode(&Issue{Number: num, State: state})
+						return
+					}
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+			issue := &Issue{Number: 1, Body: tt.issueBody}
+			got := poller.hasPendingDependencies(context.Background(), issue)
+
+			if got != tt.wantPending {
+				t.Errorf("hasPendingDependencies() = %v, want %v", got, tt.wantPending)
+			}
+		})
+	}
+}
+
+// GH-3789: a blocker missing entirely from the body (no dependency reference)
+// must never gate dispatch.
+func TestPoller_HasPendingDependencies_MissingBlocker(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second)
+
+	issue := &Issue{Number: 1, Body: "No dependency references here."}
+	got := poller.hasPendingDependencies(context.Background(), issue)
+
+	if got {
+		t.Error("hasPendingDependencies() = true, want false when no blocker is referenced")
+	}
+}
+
+// mockPollerMetrics implements skipreason.PollerMetricsRecorder for assertions
+// on skip-reason visibility (GH-3789 acceptance: skip reason recorded and
+// visible in poller metrics).
+type mockPollerMetrics struct {
+	mu         sync.Mutex
+	skipped    []string
+	dispatched int
+}
+
+func (m *mockPollerMetrics) RecordPollerSkipped(repo, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.skipped = append(m.skipped, reason)
+}
+
+func (m *mockPollerMetrics) RecordPollerDispatched(repo string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dispatched++
+}
+
+func (m *mockPollerMetrics) RecordPollerDeferredScopeOverlap(repo string) {}
+
+func (m *mockPollerMetrics) skipCount(reason string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := 0
+	for _, r := range m.skipped {
+		if r == reason {
+			count++
+		}
+	}
+	return count
+}
+
+// GH-3789: sequential mode's candidate-selection skip must be visible in
+// poller metrics — previously only the parallel/auto path recorded it.
+func TestPoller_FindOldestUnprocessedIssue_RecordsPendingDependencySkipMetric(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 1, Title: "Blocked", Body: "Blocked by: #100", Labels: []Label{{Name: "pilot"}}, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode(issues)
+		case "/repos/owner/repo/issues/100":
+			_ = json.NewEncoder(w).Encode(&Issue{Number: 100, State: "open"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	metrics := &mockPollerMetrics{}
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithPollerMetrics(metrics),
+	)
+
+	issue, err := poller.findOldestUnprocessedIssue(context.Background())
+	if err != nil {
+		t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+	}
+	if issue != nil {
+		t.Errorf("issue should be nil (blocked), got #%d", issue.Number)
+	}
+
+	if got := metrics.skipCount(skipreason.ReasonPendingDependency); got != 1 {
+		t.Errorf("pending_dependency skip count = %d, want 1", got)
+	}
+}
+
+// GH-3789: a blocker that reopens after Phase 1 candidate selection but
+// before Phase 3 dispatch (e.g. while waiting for a free semaphore slot)
+// must still gate the issue — the poll-time check alone is not enough.
+func TestPoller_CheckForNewIssues_SkipsDispatchWhenDependencyReopensBeforeDispatch(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 1, Title: "Gated task", Body: "Blocked by: #100", Labels: []Label{{Name: "pilot"}}, CreatedAt: now.Add(-1 * time.Hour)},
+	}
+
+	var depHits int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues":
+			_ = json.NewEncoder(w).Encode(issues)
+		case "/repos/owner/repo/issues/100":
+			hit := atomic.AddInt32(&depHits, 1)
+			state := "closed"
+			if hit > 1 {
+				// The blocker reopened between candidate selection and dispatch.
+				state = "open"
+			}
+			_ = json.NewEncoder(w).Encode(&Issue{Number: 100, State: state})
+		case "/repos/owner/repo/issues/1":
+			_ = json.NewEncoder(w).Encode(issues[0])
+		case "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	metrics := &mockPollerMetrics{}
+
+	var dispatched []int
+	var mu sync.Mutex
+
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithPollerMetrics(metrics),
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			mu.Lock()
+			dispatched = append(dispatched, issue.Number)
+			mu.Unlock()
+			return nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(dispatched) != 0 {
+		t.Errorf("dispatched %v, want none — dependency reopened before dispatch", dispatched)
+	}
+
+	if got := metrics.skipCount(skipreason.ReasonPendingDependency); got != 1 {
+		t.Errorf("pending_dependency skip count = %d, want 1", got)
+	}
+
+	// Issue should not be permanently marked processed — it must be retried
+	// once the blocker closes again.
+	poller.mu.RLock()
+	_, processed := poller.processed[1]
+	poller.mu.RUnlock()
+	if processed {
+		t.Error("issue should not be marked processed after dispatch-time dependency skip")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes GH-3789 (Defect D6 from TASK-382): the `Blocked by: #N` / `Depends on: #N` gate (`hasPendingDependencies`) already checked blocker state at **poll** time in both sequential and parallel/auto modes, but had two real gaps:
  - Sequential mode's pending-dependency skip was never recorded in poller metrics (parallel mode already called `recordSkip(skipreason.ReasonPendingDependency)`; sequential only logged).
  - Neither mode re-verified blocker state **immediately before dispatch** — in parallel mode a candidate can sit behind a full semaphore (`max_concurrent`) after Phase 1 filtering; in sequential mode a pre-flight judge call runs between candidate selection and dispatch. A blocker that reopens in that window would previously slip through undetected.
- Added a re-check right before actual dispatch in both paths:
  - Sequential (`startSequential`): re-check after the pre-flight judge, before `processIssueSequential`.
  - Parallel/auto (`checkForNewIssues` Phase 3): re-check right after acquiring the semaphore slot, releasing the slot and un-marking processed if the blocker has reopened.
- Both new skip points record `skipreason.ReasonPendingDependency` for metrics visibility.

## Test plan

- [x] `TestPoller_HasPendingDependencies_MultipleBlockers` — table test: one-open-one-closed, all-closed, all-open
- [x] `TestPoller_HasPendingDependencies_MissingBlocker` — no dependency reference never gates
- [x] `TestPoller_FindOldestUnprocessedIssue_RecordsPendingDependencySkipMetric` — sequential skip now visible in poller metrics
- [x] `TestPoller_CheckForNewIssues_SkipsDispatchWhenDependencyReopensBeforeDispatch` — simulates a blocker reopening between Phase 1 selection and Phase 3 dispatch; asserts the issue is not dispatched, skip is recorded, and the issue is not permanently marked processed
- [x] `make build && make test && make lint` all pass