### PR TITLE
fix(approval): restart-safe Telegram approval decisions, expired-request sweep

### DIFF
--- a/.agent/tasks/gh-3825-4.md
+++ b/.agent/tasks/gh-3825-4.md
@@ -1,0 +1,50 @@
+# GH-3825-4
+
+**Created:** 2026-07-04
+
+## Problem
+
+## Subtask 4 of 5
+
+**Parent Task:** GH-3825 - fix(approval): decisions lost after daemon restart — Rehydrate restores UI but not the decision pipeline
+
+## Objective
+
+Approve after restart → `executions.approval_decision` written, autopilot resumes merge
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+
+
+## Acceptance Criteria
+
+- [x] After a simulated daemon restart, a Telegram approval tap writes
+      `executions.approval_decision` (verified via real SQLite `memory.Store`,
+      not a mock).
+- [x] The autopilot controller's next tick advances the restored PR from
+      `StageAwaitApproval` to `StageMerging`.
+
+## Resolution
+
+The write-through (`TelegramHandler.HandleCallback` → `approval.Manager.
+RecordDecision` → `Controller.SetApprovalDecision` → `memory.Store.
+SetApprovalDecision`) and the restart-time reload (`Controller.RestoreState`
+loading `StageAwaitApproval` PRs from `autopilot.StateStore`, matched by
+`ApprovalRequestID`) were already wired by GH-3825-1..3. What was missing was
+proof the two halves compose correctly across a real restart. Added
+`internal/autopilot/restart_approval_integration_test.go`
+(`TestRestartApprovalFlow_WritesExecutionDecisionAndResumesMerge`), which uses
+a real on-disk `memory.Store` + `autopilot.StateStore` and two independent
+`Controller`/`approval.Manager`/`TelegramHandler` instances (pre- and
+post-"restart") to prove: request submission persists `approval_request_id`,
+`RestoreState` reloads the pending PR, a post-restart Telegram callback writes
+`executions.approval_decision`, and the following tick reaches `StageMerging`.
+No production code change was needed — this closes the coverage gap for the
+objective. Test passes; `go build ./...`, `go test ./internal/autopilot/...
+./internal/approval/... ./internal/memory/...`, and
+`golangci-lint run --new-from-rev=origin/main ./internal/autopilot/...` are
+all clean.
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -586,6 +586,10 @@ Examples:
 						}
 					}
 					approvalMgr.RegisterHandler(gwTgApprovalHandler)
+					// GH-3825: prune requests that expired while the daemon was
+					// down (or with no in-process waiter) instead of leaving them
+					// pending forever.
+					startApprovalExpirySweep(context.Background(), gwTgApprovalHandler)
 				}
 
 				// Register Slack approval handler if enabled
@@ -1479,6 +1483,35 @@ func setupDashboardLogging(cfg *config.Config) {
 	}
 }
 
+// approvalExpirySweepInterval is how often startApprovalExpirySweep checks
+// for pending Telegram approvals past their expires_at.
+const approvalExpirySweepInterval = 1 * time.Minute
+
+// startApprovalExpirySweep runs a background loop that prunes pending Telegram
+// approvals whose expires_at has passed, editing their message to show they
+// expired. A request rehydrated after a restart (see TelegramHandler.Rehydrate)
+// has no waiter goroutine enforcing its own timeout, so without this sweep it
+// would sit in the pending set forever instead of resolving (GH-3825).
+func startApprovalExpirySweep(ctx context.Context, handler *approval.TelegramHandler) {
+	if handler == nil {
+		return
+	}
+	logging.SafeGo("approval-expiry-sweep", func() {
+		ticker := time.NewTicker(approvalExpirySweepInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if _, err := handler.PruneExpired(ctx); err != nil {
+					logging.WithComponent("approval").Warn("expired approval sweep failed", slog.Any("error", err))
+				}
+			}
+		}
+	})
+}
+
 // runPollingMode runs lightweight polling-only mode.
 // When noGateway is false, the HTTP gateway starts in the background so the
 // desktop app (and any other client hitting /health) can reach the daemon.
@@ -1695,6 +1728,9 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			logging.WithComponent("approval").Warn("telegram approval rehydrate failed", slog.Any("error", rErr))
 		}
 	}
+	// GH-3825: prune requests that expired while the daemon was down (or with
+	// no in-process waiter) instead of leaving them pending forever.
+	startApprovalExpirySweep(ctx, tgApprovalHandlerImpl)
 
 	// GH-726: Initialize autopilot state store for crash recovery
 	var autopilotStateStore *autopilot.StateStore

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -575,6 +575,10 @@ Examples:
 					(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
 					tgClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 					gwTgApprovalHandler = approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgClient}, cfg.Adapters.Telegram.ChatID)
+					// GH-3825: persist decisions directly to PRState via the manager so a
+					// button tap on a Rehydrate-restored request isn't lost when no
+					// waiter goroutine survived the restart.
+					gwTgApprovalHandler.WithDecisionRecorder(approvalMgr)
 					if gwStore != nil {
 						gwTgApprovalHandler.WithStore(gwStore)
 						if rErr := gwTgApprovalHandler.Rehydrate(context.Background()); rErr != nil {
@@ -1543,6 +1547,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		(cfg.Adapters.Telegram.Approval == nil || cfg.Adapters.Telegram.Approval.Enabled) {
 		tgApprovalClient := telegram.NewClient(cfg.Adapters.Telegram.BotToken)
 		tgApprovalHandlerImpl = approval.NewTelegramHandler(&telegramApprovalAdapter{client: tgApprovalClient}, cfg.Adapters.Telegram.ChatID)
+		// GH-3825: persist decisions directly to PRState via the manager so a
+		// button tap on a Rehydrate-restored request isn't lost when no waiter
+		// goroutine survived the restart.
+		tgApprovalHandlerImpl.WithDecisionRecorder(approvalMgr)
 		approvalMgr.RegisterHandler(tgApprovalHandlerImpl)
 		tgApprovalHandler = tgApprovalHandlerImpl
 		logging.WithComponent("start").Info("registered Telegram approval handler")

--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -46,12 +46,13 @@ type MessageResult struct {
 
 // TelegramHandler handles approval requests via Telegram
 type TelegramHandler struct {
-	client  TelegramClient
-	chatID  string
-	pending map[string]*telegramPending // requestID -> pending state
-	mu      sync.RWMutex
-	log     *slog.Logger
-	store   PendingApprovalStore // optional; enables restart persistence
+	client   TelegramClient
+	chatID   string
+	pending  map[string]*telegramPending // requestID -> pending state
+	mu       sync.RWMutex
+	log      *slog.Logger
+	store    PendingApprovalStore // optional; enables restart persistence
+	recorder DecisionRecorder     // optional; persists decisions directly (restart-safe)
 }
 
 // telegramPending tracks a pending Telegram approval request
@@ -81,6 +82,17 @@ func (h *TelegramHandler) Name() string {
 // Returns h to allow builder-style chaining after NewTelegramHandler.
 func (h *TelegramHandler) WithStore(store PendingApprovalStore) *TelegramHandler {
 	h.store = store
+	return h
+}
+
+// WithDecisionRecorder attaches a DecisionRecorder so HandleCallback persists
+// decisions directly to the PRState/executions store rather than relying
+// solely on a live goroutine reading pending.ResponseCh. This is what makes a
+// button tap on a Rehydrate-restored request actually reach the pipeline —
+// after a restart there is no waiter goroutine left to consume the channel.
+// Returns h to allow builder-style chaining.
+func (h *TelegramHandler) WithDecisionRecorder(recorder DecisionRecorder) *TelegramHandler {
+	h.recorder = recorder
 	return h
 }
 
@@ -266,6 +278,16 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 	if h.store != nil {
 		if err := h.store.DeletePendingApproval(requestID); err != nil {
 			h.log.Warn("failed to delete persisted approval on callback", slog.String("request_id", requestID), slog.Any("error", err))
+		}
+	}
+
+	// Persist the decision directly so it reaches the pipeline even when
+	// nothing is left waiting on pending.ResponseCh — the common case after a
+	// daemon restart, where Rehydrate reconstructs this entry with a fresh
+	// channel but no goroutine to read it (GH-3825).
+	if h.recorder != nil {
+		if err := h.recorder.RecordDecision(ctx, requestID, decision, username); err != nil {
+			h.log.Warn("failed to record approval decision", slog.String("request_id", requestID), slog.Any("error", err))
 		}
 	}
 

--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -341,6 +341,28 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 		}
 	}
 
+	// A tap can race the periodic PruneExpired sweep: the request is still in
+	// h.pending but its deadline has already passed. Treat it the same as the
+	// not-found case instead of recording a real decision — otherwise the user
+	// sees "Approved!"/"Rejected" for a request the system has already decided
+	// to time out (GH-3825).
+	if pending.Request.ExpiresAt.Before(time.Now()) {
+		_ = h.client.AnswerCallback(ctx, callbackID, "Request expired or already processed")
+		if pending.MessageID != 0 {
+			text := h.formatExpiredMessage(pending.Request)
+			if err := h.client.EditMessage(ctx, pending.ChatID, pending.MessageID, text, ""); err != nil {
+				h.log.Warn("Failed to edit expired message", slog.Any("error", err))
+			}
+		}
+		select {
+		case pending.ResponseCh <- &Response{RequestID: requestID, Decision: DecisionTimeout, RespondedAt: time.Now()}:
+		default:
+		}
+		close(pending.ResponseCh)
+		h.log.Info("Approval callback arrived after expiry", slog.String("request_id", requestID))
+		return true
+	}
+
 	// Persist the decision directly so it reaches the pipeline even when
 	// nothing is left waiting on pending.ResponseCh — the common case after a
 	// daemon restart, where Rehydrate reconstructs this entry with a fresh

--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -18,6 +18,7 @@ type PendingApprovalStore interface {
 	InsertPendingApproval(*memory.PendingApproval) error
 	DeletePendingApproval(id string) error
 	LoadPendingApprovals() ([]*memory.PendingApproval, error)
+	PrunePendingApprovals(cutoff time.Time) (int64, error)
 }
 
 // TelegramClient defines the interface for Telegram operations
@@ -147,6 +148,65 @@ func (h *TelegramHandler) Rehydrate(ctx context.Context) error {
 		h.log.Info("rehydrated pending approvals", slog.Int("count", rehydrated))
 	}
 	return nil
+}
+
+// PruneExpired scans the in-memory pending set for requests whose ExpiresAt
+// has passed, edits their Telegram message to show they expired, removes
+// them from the pending map, and deletes their persisted row. It also sweeps
+// the store directly via PrunePendingApproval for rows with no in-memory
+// counterpart (e.g. left behind by a process that crashed before Rehydrate
+// ran). Returns the number of in-memory requests pruned.
+//
+// A request rehydrated after a daemon restart has no waiter goroutine
+// enforcing its own timeout — Manager's async dispatch loop only watches
+// requests it created in the current process. Without this sweep, a
+// rehydrated request that expires just sits in h.pending forever instead of
+// resolving to "expired" (GH-3825).
+func (h *TelegramHandler) PruneExpired(ctx context.Context) (int, error) {
+	now := time.Now()
+
+	h.mu.Lock()
+	var expired []*telegramPending
+	for id, p := range h.pending {
+		if p.Request.ExpiresAt.Before(now) {
+			expired = append(expired, p)
+			delete(h.pending, id)
+		}
+	}
+	h.mu.Unlock()
+
+	for _, p := range expired {
+		if h.store != nil {
+			if err := h.store.DeletePendingApproval(p.Request.ID); err != nil {
+				h.log.Warn("failed to delete expired persisted approval",
+					slog.String("request_id", p.Request.ID), slog.Any("error", err))
+			}
+		}
+		if p.MessageID != 0 {
+			text := h.formatExpiredMessage(p.Request)
+			if err := h.client.EditMessage(ctx, p.ChatID, p.MessageID, text, ""); err != nil {
+				h.log.Warn("failed to edit expired message",
+					slog.String("request_id", p.Request.ID), slog.Any("error", err))
+			}
+		}
+		select {
+		case p.ResponseCh <- &Response{RequestID: p.Request.ID, Decision: DecisionTimeout, RespondedAt: now}:
+		default:
+		}
+		close(p.ResponseCh)
+	}
+
+	if h.store != nil {
+		if _, err := h.store.PrunePendingApprovals(now); err != nil {
+			return len(expired), fmt.Errorf("prune expired: sweep store: %w", err)
+		}
+	}
+
+	if len(expired) > 0 {
+		h.log.Info("pruned expired pending approvals", slog.Int("count", len(expired)))
+	}
+
+	return len(expired), nil
 }
 
 // SendApprovalRequest sends an approval request via Telegram
@@ -421,6 +481,11 @@ func (h *TelegramHandler) formatResponseMessage(req *Request, decision Decision,
 // formatCancelledMessage formats the message when request is cancelled
 func (h *TelegramHandler) formatCancelledMessage(req *Request) string {
 	return fmt.Sprintf("⏹ CANCELLED\n\nTask: %s\n%s\n\nApproval request was cancelled.", req.TaskID, req.Title)
+}
+
+// formatExpiredMessage formats the message when a request expires unanswered.
+func (h *TelegramHandler) formatExpiredMessage(req *Request) string {
+	return fmt.Sprintf("⏱ EXPIRED\n\nTask: %s\n%s\n\nApproval request expired — no action taken.", req.TaskID, req.Title)
 }
 
 // truncateForTelegram truncates text to fit Telegram message limits

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -939,6 +939,7 @@ type mockPendingStore struct {
 	insertErr error
 	deleteErr error
 	loadErr   error
+	pruneErr  error
 }
 
 func newMockPendingStore() *mockPendingStore {
@@ -978,6 +979,22 @@ func (s *mockPendingStore) LoadPendingApprovals() ([]*memory.PendingApproval, er
 		out = append(out, &cp)
 	}
 	return out, nil
+}
+
+func (s *mockPendingStore) PrunePendingApprovals(cutoff time.Time) (int64, error) {
+	if s.pruneErr != nil {
+		return 0, s.pruneErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var deleted int64
+	for id, r := range s.rows {
+		if r.ExpiresAt.Before(cutoff) {
+			delete(s.rows, id)
+			deleted++
+		}
+	}
+	return deleted, nil
 }
 
 func (s *mockPendingStore) get(id string) *memory.PendingApproval {
@@ -1259,4 +1276,171 @@ func findSubstring(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// --- PruneExpired tests (GH-3825) ---
+
+func TestTelegramHandler_PruneExpired_EditsMessageAndRemoves(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockPendingStore()
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+
+	req := &Request{
+		ID: "exp-1", TaskID: "T-1", Stage: StagePreMerge,
+		Title: "Test", ExpiresAt: time.Now().Add(-time.Minute),
+	}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	n, err := handler.PruneExpired(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 pruned, got %d", n)
+	}
+
+	handler.mu.RLock()
+	_, stillPending := handler.pending["exp-1"]
+	handler.mu.RUnlock()
+	if stillPending {
+		t.Error("expected expired request to be removed from pending map")
+	}
+
+	edited := client.getEditedMessages()
+	if len(edited) != 1 {
+		t.Fatalf("expected 1 edited message, got %d", len(edited))
+	}
+	if !containsString(edited[0].Text, "expired") && !containsString(edited[0].Text, "EXPIRED") {
+		t.Errorf("expected edited message to mention expiry, got: %s", edited[0].Text)
+	}
+
+	if store.get("exp-1") != nil {
+		t.Error("expected persisted row to be deleted")
+	}
+}
+
+func TestTelegramHandler_PruneExpired_LeavesNonExpired(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockPendingStore()
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+
+	expired := &Request{ID: "exp-2", TaskID: "T-2", Stage: StagePreMerge, Title: "Old", ExpiresAt: time.Now().Add(-time.Minute)}
+	live := &Request{ID: "live-2", TaskID: "T-3", Stage: StagePreMerge, Title: "Fresh", ExpiresAt: time.Now().Add(time.Hour)}
+	if _, err := handler.SendApprovalRequest(context.Background(), expired); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := handler.SendApprovalRequest(context.Background(), live); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	n, err := handler.PruneExpired(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 pruned, got %d", n)
+	}
+
+	handler.mu.RLock()
+	_, expiredPending := handler.pending["exp-2"]
+	_, livePending := handler.pending["live-2"]
+	handler.mu.RUnlock()
+	if expiredPending {
+		t.Error("expected expired request to be pruned")
+	}
+	if !livePending {
+		t.Error("expected non-expired request to remain pending")
+	}
+	if store.get("live-2") == nil {
+		t.Error("expected non-expired row to remain persisted")
+	}
+}
+
+func TestTelegramHandler_PruneExpired_RehydratedWithoutMessageID(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockPendingStore()
+	// Insert with a short-lived future expiry so Rehydrate accepts it, then
+	// let it lapse before pruning — this simulates a request rehydrated after
+	// a restart, which has no known MessageID (never persisted).
+	_ = store.InsertPendingApproval(&memory.PendingApproval{
+		ID: "rehy-prune", TaskID: "T-R", Stage: "pre_merge",
+		Title: "Rehydrated", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(20 * time.Millisecond),
+	})
+
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+	if err := handler.Rehydrate(context.Background()); err != nil {
+		t.Fatalf("rehydrate error: %v", err)
+	}
+
+	time.Sleep(30 * time.Millisecond)
+
+	n, err := handler.PruneExpired(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 pruned, got %d", n)
+	}
+
+	// No MessageID was ever known for this rehydrated request, so no edit
+	// should have been attempted — but it must still be removed.
+	if len(client.getEditedMessages()) != 0 {
+		t.Errorf("expected no message edit for rehydrated request without a MessageID, got %d", len(client.getEditedMessages()))
+	}
+	handler.mu.RLock()
+	_, stillPending := handler.pending["rehy-prune"]
+	handler.mu.RUnlock()
+	if stillPending {
+		t.Error("expected rehydrated expired request to be removed from pending map")
+	}
+	if store.get("rehy-prune") != nil {
+		t.Error("expected persisted row to be deleted")
+	}
+}
+
+func TestTelegramHandler_PruneExpired_NoStore(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123")
+
+	req := &Request{ID: "exp-3", TaskID: "T-4", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(-time.Minute)}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	n, err := handler.PruneExpired(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error without a store: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 pruned, got %d", n)
+	}
+	if len(client.getEditedMessages()) != 1 {
+		t.Errorf("expected message to still be edited without a store, got %d edits", len(client.getEditedMessages()))
+	}
+}
+
+func TestTelegramHandler_PruneExpired_SweepsOrphanedStoreRows(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockPendingStore()
+	handler := NewTelegramHandler(client, "chat123").WithStore(store)
+
+	// A row with no in-memory pending counterpart — e.g. left behind by a
+	// process that crashed before Rehydrate ran.
+	_ = store.InsertPendingApproval(&memory.PendingApproval{
+		ID: "orphan-1", TaskID: "T-5", Stage: "pre_merge",
+		Title: "Orphan", CreatedAt: time.Now().Add(-2 * time.Hour), ExpiresAt: time.Now().Add(-time.Hour),
+	})
+
+	n, err := handler.PruneExpired(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 in-memory prunes (orphan was never in pending), got %d", n)
+	}
+	if store.get("orphan-1") != nil {
+		t.Error("expected orphaned expired row to be swept from the store")
+	}
 }

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -1137,6 +1137,115 @@ func TestTelegramHandler_Rehydrate_CallbackWorksAfterRehydrate(t *testing.T) {
 	}
 }
 
+// mockDecisionRecorder is a test double for DecisionRecorder.
+type mockDecisionRecorder struct {
+	mu    sync.Mutex
+	calls []struct {
+		requestID string
+		decision  Decision
+		by        string
+	}
+	err error
+}
+
+func (r *mockDecisionRecorder) RecordDecision(_ context.Context, requestID string, decision Decision, by string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, struct {
+		requestID string
+		decision  Decision
+		by        string
+	}{requestID, decision, by})
+	return r.err
+}
+
+func (r *mockDecisionRecorder) getCalls() []struct {
+	requestID string
+	decision  Decision
+	by        string
+} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]struct {
+		requestID string
+		decision  Decision
+		by        string
+	}, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+func TestTelegramHandler_HandleCallback_RecordsDecisionViaRecorder(t *testing.T) {
+	client := &mockTelegramClient{}
+	recorder := &mockDecisionRecorder{}
+	handler := NewTelegramHandler(client, "chat123").WithDecisionRecorder(recorder)
+
+	req := &Request{ID: "req-1", TaskID: "T-1", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handler.HandleCallback(context.Background(), "cb-1", "approve:req-1", "u1", "tester")
+
+	calls := recorder.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 RecordDecision call, got %d", len(calls))
+	}
+	if calls[0].requestID != "req-1" || calls[0].decision != DecisionApproved || calls[0].by != "tester" {
+		t.Errorf("unexpected recorded decision: %+v", calls[0])
+	}
+}
+
+// TestTelegramHandler_Rehydrate_CallbackRecordsDecisionDirectly is the GH-3825
+// regression test: after a restart, Rehydrate reconstructs the pending entry
+// with a fresh ResponseCh that no goroutine is reading (the original waiter
+// died with the old process). Without a DecisionRecorder, the decision made
+// by a button tap would only be sent into that unread channel and lost. With
+// the recorder wired, HandleCallback must persist the decision directly.
+func TestTelegramHandler_Rehydrate_CallbackRecordsDecisionDirectly(t *testing.T) {
+	client := &mockTelegramClient{}
+	store := newMockPendingStore()
+	recorder := &mockDecisionRecorder{}
+	_ = store.InsertPendingApproval(&memory.PendingApproval{
+		ID: "rehy-rec", TaskID: "T-R2", Stage: "pre_merge",
+		Title: "Rehydrated", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	handler := NewTelegramHandler(client, "chat123").WithStore(store).WithDecisionRecorder(recorder)
+	if err := handler.Rehydrate(context.Background()); err != nil {
+		t.Fatalf("rehydrate error: %v", err)
+	}
+
+	handled := handler.HandleCallback(context.Background(), "cb-r2", "reject:rehy-rec", "u2", "reviewer")
+	if !handled {
+		t.Fatal("expected callback to be handled")
+	}
+
+	calls := recorder.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected decision to be recorded directly after rehydrate, got %d calls", len(calls))
+	}
+	if calls[0].requestID != "rehy-rec" || calls[0].decision != DecisionRejected || calls[0].by != "reviewer" {
+		t.Errorf("unexpected recorded decision: %+v", calls[0])
+	}
+}
+
+func TestTelegramHandler_HandleCallback_RecorderErrorIsNonFatal(t *testing.T) {
+	client := &mockTelegramClient{}
+	recorder := &mockDecisionRecorder{err: errors.New("db down")}
+	handler := NewTelegramHandler(client, "chat123").WithDecisionRecorder(recorder)
+
+	req := &Request{ID: "req-2", TaskID: "T-2", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handled := handler.HandleCallback(context.Background(), "cb-2", "approve:req-2", "u1", "tester")
+	if !handled {
+		t.Error("expected callback to still be handled when recorder fails")
+	}
+}
+
 // containsString is a helper to check if a string contains a substring
 func containsString(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -493,6 +493,62 @@ func TestTelegramHandler_HandleCallback_ExpiredRequest(t *testing.T) {
 	}
 }
 
+func TestTelegramHandler_HandleCallback_ExpiredButStillPending(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123")
+
+	req := &Request{
+		ID:        "req-expired-race",
+		TaskID:    "TASK-01",
+		Stage:     StagePreExecution,
+		Title:     "Test task",
+		ExpiresAt: time.Now().Add(-time.Minute), // already past its deadline
+	}
+
+	respCh, err := handler.SendApprovalRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// A button tap races the periodic PruneExpired sweep: the request is
+	// still in the pending map, but its ExpiresAt has already elapsed.
+	handled := handler.HandleCallback(context.Background(), "cb123", "approve:req-expired-race", "user123", "testuser")
+	if !handled {
+		t.Error("expected callback to be handled")
+	}
+
+	// Must NOT fake an approval — the deadline already passed.
+	cbs := client.getAnsweredCallbacks()
+	if len(cbs) != 1 {
+		t.Fatalf("expected 1 answered callback, got %d", len(cbs))
+	}
+	if !containsString(cbs[0].Text, "expired") {
+		t.Errorf("expected expired message, got: %s", cbs[0].Text)
+	}
+
+	// Message should be edited to show expiry, not approval.
+	edited := client.getEditedMessages()
+	if len(edited) != 1 {
+		t.Fatalf("expected 1 edited message, got %d", len(edited))
+	}
+	if !containsString(edited[0].Text, "EXPIRED") {
+		t.Errorf("expected EXPIRED in message, got: %s", edited[0].Text)
+	}
+
+	// Response channel should resolve to timeout, not approved.
+	select {
+	case resp := <-respCh:
+		if resp == nil {
+			t.Fatal("expected response, got nil")
+		}
+		if resp.Decision != DecisionTimeout {
+			t.Errorf("expected timeout, got %s", resp.Decision)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+}
+
 func TestTelegramHandler_HandleCallback_EditError(t *testing.T) {
 	client := &mockTelegramClient{
 		editError: errors.New("edit failed"),
@@ -809,9 +865,10 @@ func TestTelegramHandler_HandleCallbackWithZeroMessageID(t *testing.T) {
 	handler.mu.Lock()
 	handler.pending["req-zero-cb"] = &telegramPending{
 		Request: &Request{
-			ID:     "req-zero-cb",
-			TaskID: "TASK-01",
-			Title:  "Test",
+			ID:        "req-zero-cb",
+			TaskID:    "TASK-01",
+			Title:     "Test",
+			ExpiresAt: time.Now().Add(1 * time.Hour),
 		},
 		MessageID:  0,
 		ResponseCh: respCh,

--- a/internal/approval/types.go
+++ b/internal/approval/types.go
@@ -61,6 +61,16 @@ type PRStateWriter interface {
 	SetApprovalDecision(ctx context.Context, requestID string, decision string, by string) error
 }
 
+// DecisionRecorder persists an approval decision straight to the PRState/
+// executions store, bypassing the in-process ResponseCh. *Manager satisfies
+// this via RecordDecision. Callback-driven handlers (e.g. Telegram button
+// taps) should call it directly so a decision made after a daemon restart —
+// when no goroutine is left waiting on that channel — is not silently lost
+// (GH-3825).
+type DecisionRecorder interface {
+	RecordDecision(ctx context.Context, requestID string, decision Decision, by string) error
+}
+
 // Handler is the interface for approval channel handlers
 // Each channel (Telegram, Slack, etc.) implements this interface
 type Handler interface {

--- a/internal/autopilot/restart_approval_integration_test.go
+++ b/internal/autopilot/restart_approval_integration_test.go
@@ -17,10 +17,8 @@ import (
 // drive TelegramHandler through a simulated daemon restart without depending on
 // package approval's unexported test mocks.
 type fakeRestartTelegramClient struct {
-	mu          sync.Mutex
-	nextID      int64
-	answeredCbs []string
-	editedTexts []string
+	mu     sync.Mutex
+	nextID int64
 }
 
 func (f *fakeRestartTelegramClient) SendMessageWithKeyboard(_ context.Context, _, _, _ string, _ [][]approval.InlineKeyboardButton) (*approval.MessageResponse, error) {
@@ -30,17 +28,11 @@ func (f *fakeRestartTelegramClient) SendMessageWithKeyboard(_ context.Context, _
 	return &approval.MessageResponse{Result: &approval.MessageResult{MessageID: f.nextID}}, nil
 }
 
-func (f *fakeRestartTelegramClient) EditMessage(_ context.Context, _ string, _ int64, text, _ string) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.editedTexts = append(f.editedTexts, text)
+func (f *fakeRestartTelegramClient) EditMessage(_ context.Context, _ string, _ int64, _, _ string) error {
 	return nil
 }
 
-func (f *fakeRestartTelegramClient) AnswerCallback(_ context.Context, _, text string) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.answeredCbs = append(f.answeredCbs, text)
+func (f *fakeRestartTelegramClient) AnswerCallback(_ context.Context, _, _ string) error {
 	return nil
 }
 

--- a/internal/autopilot/restart_approval_integration_test.go
+++ b/internal/autopilot/restart_approval_integration_test.go
@@ -1,0 +1,211 @@
+package autopilot
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/approval"
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// fakeRestartTelegramClient is a minimal approval.TelegramClient double used to
+// drive TelegramHandler through a simulated daemon restart without depending on
+// package approval's unexported test mocks.
+type fakeRestartTelegramClient struct {
+	mu          sync.Mutex
+	nextID      int64
+	answeredCbs []string
+	editedTexts []string
+}
+
+func (f *fakeRestartTelegramClient) SendMessageWithKeyboard(_ context.Context, _, _, _ string, _ [][]approval.InlineKeyboardButton) (*approval.MessageResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nextID++
+	return &approval.MessageResponse{Result: &approval.MessageResult{MessageID: f.nextID}}, nil
+}
+
+func (f *fakeRestartTelegramClient) EditMessage(_ context.Context, _ string, _ int64, text, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.editedTexts = append(f.editedTexts, text)
+	return nil
+}
+
+func (f *fakeRestartTelegramClient) AnswerCallback(_ context.Context, _, text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.answeredCbs = append(f.answeredCbs, text)
+	return nil
+}
+
+// TestRestartApprovalFlow_WritesExecutionDecisionAndResumesMerge exercises the
+// full GH-3825 chain end-to-end across a simulated daemon restart, using a real
+// SQLite-backed memory.Store and autopilot.StateStore (not mocks):
+//
+//  1. A PR reaches StageAwaitApproval and submits an async approval request;
+//     approval_request_id lands on the executions row and the pending Telegram
+//     approval is persisted.
+//  2. The daemon "restarts": a brand new Controller and approval.Manager/
+//     TelegramHandler are constructed and rehydrate purely from the shared
+//     on-disk store — nothing from the pre-restart in-memory goroutines survives.
+//  3. A Telegram button tap after restart must still write
+//     executions.approval_decision (no waiter goroutine is left to consume the
+//     old ResponseCh), and the next controller tick must resume the pipeline by
+//     advancing the restored PR to StageMerging.
+func TestRestartApprovalFlow_WritesExecutionDecisionAndResumesMerge(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "gh3825-restart-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-77"
+	const execID = "exec-gh3825-restart"
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          execID,
+		TaskID:      taskID,
+		ProjectPath: "/tmp/gh3825-restart-proj",
+		Status:      "running",
+		CreatedAt:   time.Now(),
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	stateStore, err := NewStateStore(store.DB())
+	if err != nil {
+		t.Fatalf("NewStateStore: %v", err)
+	}
+
+	approvalCfg := &approval.Config{
+		Enabled:        true,
+		DefaultTimeout: 1 * time.Hour,
+		DefaultAction:  approval.DecisionRejected,
+		PreMerge: &approval.StageConfig{
+			Enabled:       true,
+			Timeout:       1 * time.Hour,
+			DefaultAction: approval.DecisionRejected,
+		},
+	}
+
+	tgClient := &fakeRestartTelegramClient{}
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+
+	// --- Pre-restart process ---
+	mgr1 := approval.NewManager(approvalCfg)
+	tg1 := approval.NewTelegramHandler(tgClient, "chat-1").WithStore(store)
+	tg1.WithDecisionRecorder(mgr1)
+	mgr1.RegisterHandler(tg1)
+
+	c1 := NewController(DefaultConfig(), ghClient, mgr1, "owner", "repo")
+	c1.SetMemoryStore(store)
+	c1.SetStateStore(stateStore)
+	mgr1.WithStateWriter(c1)
+
+	c1.mu.Lock()
+	c1.activePRs[42] = &PRState{
+		PRNumber:    42,
+		PRURL:       "https://github.com/owner/repo/pull/42",
+		PRTitle:     "feat: something restart-worthy",
+		IssueNumber: 77,
+		Stage:       StageAwaitApproval,
+		CreatedAt:   time.Now(),
+	}
+	c1.mu.Unlock()
+
+	ctx := context.Background()
+
+	// Tick 1: submits the async approval request — persists ApprovalRequestID to
+	// both the PR-state store and executions.approval_request_id.
+	if err := c1.ProcessPR(ctx, 42, nil); err != nil {
+		t.Fatalf("pre-restart tick: %v", err)
+	}
+	pr1, ok := c1.GetPRState(42)
+	if !ok || pr1.ApprovalRequestID == "" {
+		t.Fatalf("expected ApprovalRequestID to be set before restart, got %+v", pr1)
+	}
+	requestID := pr1.ApprovalRequestID
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution before restart: %v", err)
+	}
+	if exec.ApprovalRequestID != requestID {
+		t.Fatalf("executions.approval_request_id = %q, want %q", exec.ApprovalRequestID, requestID)
+	}
+	if exec.ApprovalDecision != "" {
+		t.Fatalf("executions.approval_decision should be empty before any decision, got %q", exec.ApprovalDecision)
+	}
+
+	// --- Simulated daemon restart: fresh Manager, TelegramHandler and Controller,
+	// sharing only the on-disk store/state store. No goroutine or in-memory map
+	// from c1/mgr1/tg1 survives into this section. ---
+	mgr2 := approval.NewManager(approvalCfg)
+	tg2 := approval.NewTelegramHandler(tgClient, "chat-1").WithStore(store)
+	tg2.WithDecisionRecorder(mgr2)
+	mgr2.RegisterHandler(tg2)
+	if err := tg2.Rehydrate(ctx); err != nil {
+		t.Fatalf("Rehydrate: %v", err)
+	}
+
+	c2 := NewController(DefaultConfig(), ghClient, mgr2, "owner", "repo")
+	c2.SetMemoryStore(store)
+	c2.SetStateStore(stateStore)
+	mgr2.WithStateWriter(c2)
+
+	restored, err := c2.RestoreState()
+	if err != nil {
+		t.Fatalf("RestoreState: %v", err)
+	}
+	if restored != 1 {
+		t.Fatalf("RestoreState: restored %d PRs, want 1", restored)
+	}
+
+	pr2, ok := c2.GetPRState(42)
+	if !ok {
+		t.Fatal("PR 42 not restored into post-restart controller")
+	}
+	if pr2.Stage != StageAwaitApproval || pr2.ApprovalRequestID != requestID {
+		t.Fatalf("restored PR state mismatch: %+v", pr2)
+	}
+
+	// A button tap arrives after restart — HandleCallback must persist the
+	// decision directly (no waiter goroutine survived) rather than silently
+	// dropping it.
+	handled := tg2.HandleCallback(ctx, "callback-1", "approve:"+requestID, "12345", "reviewer1")
+	if !handled {
+		t.Fatal("HandleCallback did not recognize the approval callback")
+	}
+
+	// executions.approval_decision must be written by the post-restart process.
+	exec, err = store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution after callback: %v", err)
+	}
+	if exec.ApprovalDecision != string(approval.DecisionApproved) {
+		t.Fatalf("executions.approval_decision = %q, want %q", exec.ApprovalDecision, approval.DecisionApproved)
+	}
+	if exec.ApprovalDecisionBy != "reviewer1" {
+		t.Fatalf("executions.approval_decision_by = %q, want %q", exec.ApprovalDecisionBy, "reviewer1")
+	}
+
+	// Autopilot must resume the merge pipeline on its next tick.
+	if err := c2.ProcessPR(ctx, 42, nil); err != nil {
+		t.Fatalf("post-restart tick: %v", err)
+	}
+	pr2, _ = c2.GetPRState(42)
+	if pr2.Stage != StageMerging {
+		t.Fatalf("after post-restart approval: stage = %s, want %s", pr2.Stage, StageMerging)
+	}
+}


### PR DESCRIPTION
Closes #3825
TASK-382 D13. Worker completed and pushed the branch (D2's push-retry fix working as designed) but PR creation silently failed — opened manually to complete delivery.

## Contents
- Persist Telegram approval decisions directly to the store — restart-safe, no in-process channel dependency
- Periodic sweep of expired approvals (wires the previously-dead `PrunePendingApprovals`)
- Reject taps on requests that expired before the sweep
- Test proving restart → approve → `executions.approval_decision` written → merge resumes

## Verify
```bash
make test && make lint
```