### PR TITLE
fix(autopilot): orphan-reconciler and OnPRCreated race — PRs registered twice, duplicate approval requests

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updated": "2026-07-03",
+  "updated": "2026-07-04",
   "nodes": {
     "concepts": {
       "pilot-architecture": {
@@ -850,6 +850,17 @@
         "incident": "TASK-382 D9, observed 2026-07-04 00:30 UTC: PR #3802 closed CI-red silently, issue #3789 retained pilot-done.",
         "file": ".agent/knowledge/memories/pitfalls/bug_autopilot_silent_pr_close_notifyexternalclose_convergence.md",
         "origin_task": "GH-3806"
+      },
+      "mem-047": {
+        "type": "pitfall",
+        "summary": "OnPRCreated check-then-act race let orphan-reconciler double-register a PR, resetting PRState and duplicating approval requests + merge comments (GH-3828)",
+        "concepts": [
+          "autopilot"
+        ],
+        "confidence": 0.95,
+        "created": "2026-07-04",
+        "file": ".agent/knowledge/memories/pitfalls/bug_onprcreated_reconciler_double_register.md",
+        "origin_task": "GH-3828"
       }
     }
   },
@@ -987,11 +998,6 @@
     {
       "from": "mem-025",
       "to": "mem-024",
-      "type": "relates_to"
-    },
-    {
-      "from": "mem-040",
-      "to": "mem-044",
       "type": "relates_to"
     },
     {
@@ -1140,6 +1146,11 @@
       "type": "implements"
     },
     {
+      "from": "mem-040",
+      "to": "mem-044",
+      "type": "relates_to"
+    },
+    {
       "from": "mem-043",
       "to": "epic-decomposition",
       "type": "describes"
@@ -1163,6 +1174,11 @@
       "from": "mem-045",
       "to": "self-upgrade",
       "type": "about"
+    },
+    {
+      "from": "autopilot",
+      "to": "mem-047",
+      "type": "has_pitfall"
     }
   ]
 }

--- a/.agent/knowledge/memories/pitfalls/bug_onprcreated_reconciler_double_register.md
+++ b/.agent/knowledge/memories/pitfalls/bug_onprcreated_reconciler_double_register.md
@@ -1,0 +1,58 @@
+---
+name: OnPRCreated check-then-act race lets orphan-reconciler double-register a PR
+description: reconciler and the normal poller OnPRCreated callback can both register the same PR, resetting PRState and duplicating approval requests + merge comments
+type: pitfall
+---
+
+## Symptom
+
+Nightly logs (2026-07-04) showed PRs #3808 and #3820 each going through TWO
+full register→CI→escalate cycles: one via `reconciler: registering orphan
+PR`, a second via the normal github-poller `OnPRCreated` path ~1–10 min
+later — producing two separate `approval_request_id`s per PR. Same failure
+mode produced double "PR merged" comments on #3792's linked issue.
+
+## Root cause
+
+`reconcileOrphanPRs` (and `ScanExistingPRs`) do a check-then-act: read
+`activePRs[pr.Number]` under `c.mu.RLock()`, release the lock, then — if
+untracked — call `c.OnPRCreated(...)` later in the same loop iteration
+(`internal/autopilot/controller.go`, `reconcileOrphanPRs`/`ScanExistingPRs`).
+Between the check and the call, the normal poller's `OnPRCreated` callback
+can register the same PR first. `OnPRCreated` itself then made things worse:
+it unconditionally did `c.activePRs[prNumber] = &PRState{...}` — a fresh
+struct reset to `StagePRCreated`/`CIPending` — silently overwriting whatever
+progress the winning registration had already made (CI wait state,
+`ApprovalRequestID`, `MergeNotificationPosted`). The overwritten PR then
+replayed the entire pipeline, submitting a second approval request and (if it
+reached merge) posting a second "PR merged" comment.
+
+**The general lesson: a caller-side "is it tracked?" check across two lock
+acquisitions is not atomic — the source of truth must gate at the single
+point that mutates the map, not at every call site that reads it first.**
+
+## Fix (GH-3828)
+
+Made `OnPRCreated` itself the atomic gate: check `activePRs[prNumber]` and
+insert under the *same* `c.mu.Lock()` critical section; if already present,
+log Debug and return without touching the existing `*PRState`. This makes
+registration idempotent regardless of which caller (reconciler, startup
+scan, or the real-time poller callback) wins the race — the callers'
+own pre-checks become pure optimizations, not correctness-load-bearing.
+Approval-request and merge-comment dedup were already correct *per PRState*
+(`ApprovalRequestID == ""` guard, `MergeNotificationPosted` flag) — they just
+needed the single-PRState-per-PR invariant restored to actually apply.
+
+Added `Metrics.DuplicateRegistrationsSkipped` (plain counter — `OnPRCreated`
+has no visibility into which caller lost the race) to make sustained
+duplicate-registration attempts observable.
+
+## Where to look
+
+- `internal/autopilot/controller.go` — `OnPRCreated`, `reconcileOrphanPRs`,
+  `ScanExistingPRs`
+- `internal/autopilot/controller_duplicate_registration_test.go` — regression
+  tests: duplicate no-op preserves the same `*PRState` pointer, a `-race`
+  concurrent-callers test, and full-flow tests asserting a duplicate
+  registration does not spawn a sibling approval request or a second merge
+  comment.

--- a/.agent/tasks/gh-3828.md
+++ b/.agent/tasks/gh-3828.md
@@ -1,0 +1,43 @@
+# GH-3828
+
+**Created:** 2026-07-04
+
+## Problem
+
+GitHub Issue #3828: fix(autopilot): orphan-reconciler and OnPRCreated race — PRs registered twice, duplicate approval requests
+
+## Context
+Defect D16 from TASK-382. Nightly logs (2026-07-04) show PRs #3808 and #3820 each going through TWO full register→CI→escalate cycles: one via `reconciler: registering orphan PR`, a second via the normal github-poller `OnPRCreated` path ~1–10 min later — producing two separate `approval_request_id`s per PR (and double 'PR merged' comments observed on #3792's issue earlier the same night).
+
+## Fix
+- Registration must be idempotent: whichever of {orphan-reconciler, OnPRCreated callback} arrives second should detect the existing PRState and no-op (log Debug).
+- Dedupe approval requests per (pr_number, stage): a second escalation for an already-pending request should reuse it, not create a sibling.
+
+## Acceptance
+- [x] Simulated double registration → single PRState, single approval request, single merged-comment
+- [x] Regression test covering reconciler+callback race
+- [x] make test && make lint pass
+
+## Resolution
+
+`OnPRCreated` (internal/autopilot/controller.go) did the map insert unguarded;
+callers (`reconcileOrphanPRs`, `ScanExistingPRs`) checked `activePRs` for
+"already tracked" under a separate, earlier lock acquisition, so a second
+caller could land in the window and get a fresh `*PRState` that overwrote the
+first's progress. Fixed by making the check-and-insert atomic inside
+`OnPRCreated` itself (single `c.mu.Lock()` critical section) — the second
+caller now no-ops with a Debug log instead of overwriting. Added
+`Metrics.DuplicateRegistrationsSkipped` for observability. Approval-request
+and merge-comment dedup were already correct per-`*PRState`
+(`ApprovalRequestID == ""` guard, `MergeNotificationPosted` flag); they only
+needed the single-PRState-per-PR invariant restored to actually apply.
+
+Regression tests in `internal/autopilot/controller_duplicate_registration_test.go`:
+duplicate-registration no-op (pointer identity + metric), a `-race` concurrent
+callers test, and full-flow tests proving a duplicate registration doesn't
+spawn a sibling approval request or a second "PR merged" comment.
+
+Pitfall captured: `.agent/knowledge/memories/pitfalls/bug_onprcreated_reconciler_double_register.md`.
+
+## Acceptance Criteria
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -489,8 +489,28 @@ func (c *Controller) SetOnIssueDone(fn func(issueNumber int)) {
 }
 
 // OnPRCreated registers a new PR for autopilot processing.
+//
+// GH-3828: the orphan-reconciler (60s sweep) and the normal poller callback
+// path both race to register the same PR — the reconciler's tracked-check and
+// its OnPRCreated call are two separate lock acquisitions, so a callback can
+// land in between and register the PR first. Without a check here, the
+// second caller would silently overwrite the first's *PRState (discarding any
+// progress already made — CI wait state, escalation reason, a submitted
+// approval request) and restart the whole pipeline, producing duplicate
+// approval requests and duplicate "PR merged" comments. Registration must
+// therefore be idempotent at the source of truth (the activePRs map, under
+// c.mu), not just at each caller's pre-check.
 func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, headSHA string, branchName string, issueNodeID string) {
 	c.mu.Lock()
+	if _, exists := c.activePRs[prNumber]; exists {
+		c.mu.Unlock()
+		c.log.Debug("PR already registered, skipping duplicate registration",
+			"pr", prNumber,
+			"issue", issueNumber,
+		)
+		c.metrics.RecordDuplicateRegistrationSkipped()
+		return
+	}
 	prState := &PRState{
 		PRNumber:        prNumber,
 		PRURL:           prURL,

--- a/internal/autopilot/controller_duplicate_registration_test.go
+++ b/internal/autopilot/controller_duplicate_registration_test.go
@@ -1,0 +1,245 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/approval"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestController_OnPRCreated_DuplicateRegistrationIsNoOp is a regression test for
+// GH-3828 (defect D16): the orphan-reconciler and the normal poller OnPRCreated
+// callback can both observe the same PR as "untracked" and both call
+// OnPRCreated for it, because each caller's tracked-check and its registration
+// call are separate lock acquisitions. Before the fix, the second call
+// silently overwrote the first's *PRState with a brand-new struct reset to
+// StagePRCreated, discarding any progress (e.g. a submitted approval request)
+// and restarting the whole register→CI→escalate cycle a second time.
+func TestController_OnPRCreated_DuplicateRegistrationIsNoOp(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// First registration (e.g. the normal poller's OnPRCreated callback).
+	c.OnPRCreated(3808, "https://github.com/owner/repo/pull/3808", 100, "sha1", "pilot/GH-100", "")
+
+	first, ok := c.GetPRState(3808)
+	if !ok {
+		t.Fatal("PR 3808 not tracked after first OnPRCreated")
+	}
+
+	// Advance state past creation, as ProcessPR would have done by the time
+	// the reconciler's delayed registration lands.
+	first.mu.Lock()
+	first.Stage = StageWaitingCI
+	first.ApprovalRequestID = "req-already-pending"
+	first.mu.Unlock()
+
+	// Second registration for the SAME PR (e.g. the orphan-reconciler, which
+	// snapshotted "untracked" before the callback above ran, then calls
+	// OnPRCreated after losing the race).
+	c.OnPRCreated(3808, "https://github.com/owner/repo/pull/3808", 100, "sha1-stale", "pilot/GH-100", "")
+
+	second, ok := c.GetPRState(3808)
+	if !ok {
+		t.Fatal("PR 3808 no longer tracked after duplicate OnPRCreated")
+	}
+
+	if second != first {
+		t.Fatal("duplicate OnPRCreated replaced the tracked *PRState — progress (stage, approval request) was discarded")
+	}
+
+	second.mu.Lock()
+	stage := second.Stage
+	approvalID := second.ApprovalRequestID
+	second.mu.Unlock()
+
+	if stage != StageWaitingCI {
+		t.Errorf("Stage = %q after duplicate registration, want %q (must not reset to StagePRCreated)", stage, StageWaitingCI)
+	}
+	if approvalID != "req-already-pending" {
+		t.Errorf("ApprovalRequestID = %q after duplicate registration, want unchanged %q (must not spawn a sibling request)", approvalID, "req-already-pending")
+	}
+
+	activePRs := c.GetActivePRs()
+	count := 0
+	for _, pr := range activePRs {
+		if pr.PRNumber == 3808 {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("activePRs contains %d entries for PR 3808, want 1", count)
+	}
+
+	snap := c.metrics.Snapshot()
+	if snap.DuplicateRegistrationsSkipped != 1 {
+		t.Errorf("DuplicateRegistrationsSkipped = %d, want 1", snap.DuplicateRegistrationsSkipped)
+	}
+}
+
+// TestController_OnPRCreated_ConcurrentRace drives the orphan-reconciler and
+// the OnPRCreated callback path concurrently against the same PR number under
+// -race. Exactly one call must win the registration; every other call must
+// no-op rather than overwrite the winner's PRState.
+func TestController_OnPRCreated_ConcurrentRace(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	const callers = 20
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			c.OnPRCreated(3820, "https://github.com/owner/repo/pull/3820", 200, "sha", "pilot/GH-200", "")
+		}()
+	}
+	wg.Wait()
+
+	activePRs := c.GetActivePRs()
+	count := 0
+	for _, pr := range activePRs {
+		if pr.PRNumber == 3820 {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("activePRs contains %d entries for PR 3820 after concurrent registration, want 1", count)
+	}
+
+	snap := c.metrics.Snapshot()
+	if snap.DuplicateRegistrationsSkipped != callers-1 {
+		t.Errorf("DuplicateRegistrationsSkipped = %d, want %d (one winner, rest skipped)", snap.DuplicateRegistrationsSkipped, callers-1)
+	}
+}
+
+// TestController_OnPRCreated_DuplicateDoesNotDuplicateMergedComment simulates
+// the reconciler racing in AFTER a PR has already been merged and the
+// completion comment posted. Before the fix, the duplicate registration would
+// reset Stage to StagePRCreated, and a subsequent processing pass would drive
+// the PR through the whole pipeline again — including a second "PR merged"
+// comment on the linked issue (observed on #3792 the night this defect was
+// found).
+func TestController_OnPRCreated_DuplicateDoesNotDuplicateMergedComment(t *testing.T) {
+	commentCount := 0
+	server := mergeMockServer(t, 3808, 100, &commentCount)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoReview = false
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.OnPRCreated(3808, "https://github.com/owner/repo/pull/3808", 100, "abc1234", "pilot/GH-100", "")
+	prState, _ := c.GetPRState(3808)
+	prState.Stage = StageMerging
+
+	ctx := context.Background()
+	if err := c.handleMerging(ctx, prState); err != nil {
+		t.Fatalf("handleMerging returned error: %v", err)
+	}
+	if commentCount != 1 {
+		t.Fatalf("comment count after merge = %d, want 1", commentCount)
+	}
+	if prState.Stage != StageMerged {
+		t.Fatalf("Stage after merge = %q, want %q", prState.Stage, StageMerged)
+	}
+
+	// Reconciler arrives late and re-registers the same PR.
+	c.OnPRCreated(3808, "https://github.com/owner/repo/pull/3808", 100, "abc1234", "pilot/GH-100", "")
+
+	after, _ := c.GetPRState(3808)
+	if after != prState {
+		t.Fatal("duplicate OnPRCreated replaced the merged PRState")
+	}
+	after.mu.Lock()
+	stage := after.Stage
+	after.mu.Unlock()
+	if stage != StageMerged {
+		t.Errorf("Stage = %q after duplicate registration, want %q (must not restart the pipeline)", stage, StageMerged)
+	}
+	if commentCount != 1 {
+		t.Errorf("comment count after duplicate registration = %d, want 1 (no duplicate merge comment)", commentCount)
+	}
+}
+
+// TestController_OnPRCreated_DuplicateDoesNotDuplicateApprovalRequest simulates
+// the reconciler racing in AFTER an approval request has already been
+// submitted for the PR. The duplicate registration must preserve the pending
+// request rather than clobbering the PRState and letting handleAwaitApproval
+// submit a sibling request on the next tick.
+func TestController_OnPRCreated_DuplicateDoesNotDuplicateApprovalRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd
+
+	mgr := approval.NewManager(&approval.Config{
+		Enabled:        true,
+		DefaultTimeout: 0,
+		PreMerge: &approval.StageConfig{
+			Enabled: true,
+		},
+	})
+
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+	c.OnPRCreated(3820, "https://github.com/owner/repo/pull/3820", 200, "sha", "pilot/GH-200", "")
+	prState, _ := c.GetPRState(3820)
+	prState.mu.Lock()
+	prState.Stage = StageAwaitApproval
+	prState.mu.Unlock()
+
+	ctx := context.Background()
+	if err := c.handleAwaitApproval(ctx, prState); err != nil {
+		t.Fatalf("handleAwaitApproval returned error: %v", err)
+	}
+	prState.mu.Lock()
+	firstRequestID := prState.ApprovalRequestID
+	prState.mu.Unlock()
+	if firstRequestID == "" {
+		t.Fatal("expected an approval request ID to be set after first handleAwaitApproval tick")
+	}
+
+	// Reconciler arrives late and re-registers the same PR while approval is pending.
+	c.OnPRCreated(3820, "https://github.com/owner/repo/pull/3820", 200, "sha", "pilot/GH-200", "")
+
+	after, _ := c.GetPRState(3820)
+	if after != prState {
+		t.Fatal("duplicate OnPRCreated replaced the awaiting-approval PRState")
+	}
+	after.mu.Lock()
+	stage := after.Stage
+	requestID := after.ApprovalRequestID
+	after.mu.Unlock()
+	if stage != StageAwaitApproval {
+		t.Errorf("Stage = %q after duplicate registration, want %q", stage, StageAwaitApproval)
+	}
+	if requestID != firstRequestID {
+		t.Errorf("ApprovalRequestID changed from %q to %q after duplicate registration — a sibling request was created", firstRequestID, requestID)
+	}
+
+	// A subsequent tick must take the "still waiting" path, not resubmit.
+	if err := c.handleAwaitApproval(ctx, prState); err != nil {
+		t.Fatalf("second handleAwaitApproval returned error: %v", err)
+	}
+	prState.mu.Lock()
+	finalRequestID := prState.ApprovalRequestID
+	prState.mu.Unlock()
+	if finalRequestID != firstRequestID {
+		t.Errorf("ApprovalRequestID changed to %q after a follow-up tick, want unchanged %q (single request)", finalRequestID, firstRequestID)
+	}
+}

--- a/internal/autopilot/metrics.go
+++ b/internal/autopilot/metrics.go
@@ -57,6 +57,14 @@ type Metrics struct {
 	// Sustained spikes indicate OnPRCreated is missing fires.
 	OrphanPRsRegistered map[string]int64 // trigger → count
 
+	// Duplicate registration skips (GH-3828): OnPRCreated fired twice for the
+	// same PR (e.g. orphan-reconciler and the normal poller callback racing).
+	// OnPRCreated has no visibility into which caller arrived first, so this
+	// is a single counter rather than a per-trigger breakdown. Sustained
+	// counts indicate the two paths are racing often, though each occurrence
+	// is already handled safely (no-op, not a bug).
+	DuplicateRegistrationsSkipped int64
+
 	// Gauges (point-in-time values)
 	ActivePRsByStage map[PRStage]int
 	QueueDepth       int // issues with `pilot` label, no `pilot-in-progress`
@@ -77,10 +85,10 @@ type Metrics struct {
 // NewMetrics creates a new Metrics instance.
 func NewMetrics() *Metrics {
 	return &Metrics{
-		IssuesProcessed:       make(map[string]int64),
-		APIErrors:             make(map[string]int64),
-		LabelCleanups:         make(map[string]int64),
-		ApprovalPersistMisses: make(map[string]int64),
+		IssuesProcessed:            make(map[string]int64),
+		APIErrors:                  make(map[string]int64),
+		LabelCleanups:              make(map[string]int64),
+		ApprovalPersistMisses:      make(map[string]int64),
 		TokensConsumed:             make(map[tokenKey]int64),
 		ExecutionCostUSD:           make(map[string]float64),
 		ExecutionsByResult:         make(map[execKey]int64),
@@ -89,11 +97,11 @@ func NewMetrics() *Metrics {
 		PollerDeferredScopeOverlap: make(map[string]int64),
 		OrphanPRsRegistered:        make(map[string]int64),
 		ActivePRsByStage:           make(map[PRStage]int),
-		PRTimeToMerge:         make([]time.Duration, 0, 100),
-		CIWaitDurations:       make([]time.Duration, 0, 100),
-		ExecutionDurations:    make([]time.Duration, 0, 100),
-		apiErrorTimes:         make([]time.Time, 0, 100),
-		maxSamples:            1000,
+		PRTimeToMerge:              make([]time.Duration, 0, 100),
+		CIWaitDurations:            make([]time.Duration, 0, 100),
+		ExecutionDurations:         make([]time.Duration, 0, 100),
+		apiErrorTimes:              make([]time.Time, 0, 100),
+		maxSamples:                 1000,
 	}
 }
 
@@ -133,6 +141,14 @@ func (m *Metrics) RecordOrphanPRRegistered(trigger string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.OrphanPRsRegistered[trigger]++
+}
+
+// RecordDuplicateRegistrationSkipped increments the counter for a second
+// OnPRCreated call landing on an already-tracked PR.
+func (m *Metrics) RecordDuplicateRegistrationSkipped() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.DuplicateRegistrationsSkipped++
 }
 
 // RecordPRMerged increments the merged PR counter.
@@ -279,30 +295,31 @@ func (m *Metrics) Snapshot() MetricsSnapshot {
 	defer m.mu.RUnlock()
 
 	snap := MetricsSnapshot{
-		IssuesProcessed:       copyStringIntMap(m.IssuesProcessed),
-		PRsMerged:             m.PRsMerged,
-		PRsFailed:             m.PRsFailed,
-		PRsConflicting:        m.PRsConflicting,
-		CircuitBreakerTrips:   m.CircuitBreakerTrips,
-		APIErrors:             copyStringIntMap(m.APIErrors),
-		LabelCleanups:         copyStringIntMap(m.LabelCleanups),
-		ApprovalPersistMisses: copyStringIntMap(m.ApprovalPersistMisses),
-		TokensConsumed:             copyTokenKeyMap(m.TokensConsumed),
-		ExecutionCostUSD:           copyStringFloatMap(m.ExecutionCostUSD),
-		ExecutionsByResult:         copyExecKeyMap(m.ExecutionsByResult),
-		PollerSkipped:              copyPollerSkipKeyMap(m.PollerSkipped),
-		PollerDispatched:           copyStringIntMap(m.PollerDispatched),
-		PollerDeferredScopeOverlap: copyStringIntMap(m.PollerDeferredScopeOverlap),
-		OrphanPRsRegistered:        copyStringIntMap(m.OrphanPRsRegistered),
-		ActivePRsByStage:           copyStageIntMap(m.ActivePRsByStage),
-		QueueDepth:            m.QueueDepth,
-		FailedQueueDepth:      m.FailedQueueDepth,
-		TotalActivePRs:        sumStageMap(m.ActivePRsByStage),
-		AvgPRTimeToMerge:      avgDuration(m.PRTimeToMerge),
-		AvgCIWaitDuration:     avgDuration(m.CIWaitDurations),
-		AvgExecutionDuration:  avgDuration(m.ExecutionDurations),
-		APIErrorRate:          m.apiErrorRate(),
-		SnapshotAt:            time.Now(),
+		IssuesProcessed:               copyStringIntMap(m.IssuesProcessed),
+		PRsMerged:                     m.PRsMerged,
+		PRsFailed:                     m.PRsFailed,
+		PRsConflicting:                m.PRsConflicting,
+		CircuitBreakerTrips:           m.CircuitBreakerTrips,
+		APIErrors:                     copyStringIntMap(m.APIErrors),
+		LabelCleanups:                 copyStringIntMap(m.LabelCleanups),
+		ApprovalPersistMisses:         copyStringIntMap(m.ApprovalPersistMisses),
+		TokensConsumed:                copyTokenKeyMap(m.TokensConsumed),
+		ExecutionCostUSD:              copyStringFloatMap(m.ExecutionCostUSD),
+		ExecutionsByResult:            copyExecKeyMap(m.ExecutionsByResult),
+		PollerSkipped:                 copyPollerSkipKeyMap(m.PollerSkipped),
+		PollerDispatched:              copyStringIntMap(m.PollerDispatched),
+		PollerDeferredScopeOverlap:    copyStringIntMap(m.PollerDeferredScopeOverlap),
+		OrphanPRsRegistered:           copyStringIntMap(m.OrphanPRsRegistered),
+		DuplicateRegistrationsSkipped: m.DuplicateRegistrationsSkipped,
+		ActivePRsByStage:              copyStageIntMap(m.ActivePRsByStage),
+		QueueDepth:                    m.QueueDepth,
+		FailedQueueDepth:              m.FailedQueueDepth,
+		TotalActivePRs:                sumStageMap(m.ActivePRsByStage),
+		AvgPRTimeToMerge:              avgDuration(m.PRTimeToMerge),
+		AvgCIWaitDuration:             avgDuration(m.CIWaitDurations),
+		AvgExecutionDuration:          avgDuration(m.ExecutionDurations),
+		APIErrorRate:                  m.apiErrorRate(),
+		SnapshotAt:                    time.Now(),
 	}
 
 	// Calculate success rate
@@ -352,6 +369,9 @@ type MetricsSnapshot struct {
 
 	// Orphan PR registration (TASK-302)
 	OrphanPRsRegistered map[string]int64 // trigger → count
+
+	// Duplicate registration skips (GH-3828)
+	DuplicateRegistrationsSkipped int64
 
 	// Gauges
 	ActivePRsByStage map[PRStage]int


### PR DESCRIPTION
## Summary

- Closes #3828 (defect D16 from TASK-382). `reconcileOrphanPRs`/`ScanExistingPRs` check `activePRs` for "already tracked" under one lock acquisition, then call `OnPRCreated` afterward — a normal poller callback could register the same PR in the gap, and `OnPRCreated` unconditionally overwrote the map entry with a fresh `*PRState`, discarding CI-wait state, a submitted approval request, and the merge-notification flag, restarting the whole pipeline. Observed on PRs #3808/#3820 (duplicate register→CI→escalate cycles, duplicate `approval_request_id`s) and #3792 (duplicate "PR merged" comment).
- Fix: `OnPRCreated` now checks-and-inserts atomically under a single `c.mu.Lock()`; a second call for an already-tracked PR no-ops with a Debug log instead of overwriting. This restores the single-PRState-per-PR invariant that the existing approval-request (`ApprovalRequestID == ""`) and merge-comment (`MergeNotificationPosted`) dedup guards depend on.
- Added `Metrics.DuplicateRegistrationsSkipped` for observability.

## Test plan

- [x] New regression tests in `internal/autopilot/controller_duplicate_registration_test.go`:
  - duplicate registration is a no-op (same `*PRState` pointer, stage/fields untouched, metric incremented)
  - concurrent racing callers under `-race` (exactly one winner)
  - duplicate registration after an approval request is already pending does not spawn a sibling request
  - duplicate registration after a PR is merged does not post a second "PR merged" comment
- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` (0 issues)