### PR TITLE
feat(adapters,health): 401 escalation counters, disabled-subsystems doctor panel, config-show secret redaction

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-04 (v2.151.0)
+**Last Updated:** 2026-07-03 (v2.151.0)
 
 ## Legend
 
@@ -402,7 +402,6 @@
 | Board sync owner guard | ✅ | adapters/github | - | - | Guard owner extraction in board sync construction (v2.30.0, PR #1871) |
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
-| Rate-limit-aware PR loop backoff | ✅ | autopilot | - | - | processAllPRs + orphan-PR reconciler enter a bounded cooldown on GitHub 403 rate-limit instead of re-hitting the API every tick; poller logs Warn (not Info) when a created PR has no autopilot callback wired (v2.207.3, GH-3784) |
 
 ## Epic Management
 
@@ -438,8 +437,7 @@
 |---------|--------|---------|-------------|------------|-------|
 | Version check | ✅ | upgrade | `pilot version` | - | Shows current |
 | Auto-upgrade | ✅ | upgrade | `pilot upgrade` | - | Downloads latest |
-| Hot upgrade | ✅ | upgrade | `u` key in dashboard (manual) or automatic | `upgrade.auto_hot_upgrade` | Graceful drain + restart, no orphaned tasks (v0.18.0, v0.63.0); auto-enqueues on detection by default, keypress still works as manual override (GH-3790) |
-| Self-upgrade staleness check | ✅ | upgrade, health | `pilot doctor` | `upgrade.stale_release_threshold` | Warns (log + alert) when the daemon is N+ releases behind — catches the failure mode where self-upgrade silently stops firing (GH-3790) |
+| Hot upgrade | ✅ | upgrade | `u` key in dashboard | - | Graceful drain + restart, no orphaned tasks (v0.18.0, v0.63.0) |
 | Config init | ✅ | config | `pilot init` | - | Creates default |
 | Setup wizard | ✅ | main | `pilot setup` | - | Interactive config |
 | Project add wizard | ✅ | cli | `pilot project add` (no flags) | - | gh CLI auth, repo picker, token seeding; `--no-wizard` for CI (GH-3017, v2.187.1) |
@@ -589,3 +587,4 @@ quality:
 | Ghost-SHA guard | v2.151.x | executor | Fail-closed when commit_sha already on base branch (TASK-300 / GH-3099) |
 | Merge→done race window closed | v2.163.0 | autopilot + adapters/github | `Controller.SetOnIssueDone` fires `MarkProcessed` on all pollers at PR-merge, preventing phantom re-dispatch during label propagation lag (TASK-321 PR-4 / GH-3271) |
 | Decomposed-child base-branch pinning | v2.184.x | executor | Resolve `BaseBranch` from main-repo git context before worktree creation; decomposed children never PR against a sibling branch (GH-3540) |
+| GitHub-poller auth-failure escalation | v2.207.x | adapters/github + health | Consecutive 401/non-ratelimit-403 fetch errors escalate to ERROR log + alert at threshold (`WithAlertProcessor`/`WithTokenSource`); `pilot doctor` disabled-subsystems panel; `pilot config show` secret redaction + `--reveal` (TASK-379 V4 / GH-3839) |

--- a/cmd/pilot/config_cmd.go
+++ b/cmd/pilot/config_cmd.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -36,10 +37,16 @@ func newConfigCmd() *cobra.Command {
 
 func newConfigShowCmd() *cobra.Command {
 	var outputJSON bool
+	var reveal bool
 
 	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Show current configuration",
+		Long: `Show current configuration.
+
+Values whose key looks like a token, key, secret, or password are masked by
+default (first 4 + last 4 characters shown). Pass --reveal to print the raw,
+unredacted values.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configPath := cfgFile
 			if configPath == "" {
@@ -56,6 +63,11 @@ func newConfigShowCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("failed to marshal config: %w", err)
 				}
+				if !reveal {
+					if data, err = redactSecretsJSON(data); err != nil {
+						return fmt.Errorf("failed to redact config: %w", err)
+					}
+				}
 				fmt.Println(string(data))
 				return nil
 			}
@@ -65,6 +77,11 @@ func newConfigShowCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to marshal config: %w", err)
 			}
+			if !reveal {
+				if data, err = redactSecretsYAML(data); err != nil {
+					return fmt.Errorf("failed to redact config: %w", err)
+				}
+			}
 			fmt.Print(string(data))
 
 			return nil
@@ -72,8 +89,68 @@ func newConfigShowCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
+	cmd.Flags().BoolVar(&reveal, "reveal", false, "Show raw, unredacted secret values")
 
 	return cmd
+}
+
+// secretKeyPattern matches config keys likely to hold sensitive values
+// (tokens, API keys, secrets, passwords) so `pilot config show` can redact
+// them by default (GH-3839).
+var secretKeyPattern = regexp.MustCompile(`(?i)(token|key|secret|password)`)
+
+// maskSecret shows only the first 4 and last 4 characters of a secret value
+// (e.g. "ghp_...cdef"). Values too short to mask meaningfully (<=8 chars)
+// are fully masked so no useful substring leaks.
+func maskSecret(s string) string {
+	if len(s) <= 8 {
+		return "****"
+	}
+	return s[:4] + "..." + s[len(s)-4:]
+}
+
+// redactSecretValue walks a generically-decoded config tree (nested maps and
+// slices from a YAML/JSON round-trip) and masks any string value whose key
+// matches secretKeyPattern. Operating on the generic tree rather than the
+// typed *config.Config struct means every current and future secret-shaped
+// field is covered without needing a matching struct tag or field list.
+func redactSecretValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		for k, sub := range val {
+			if s, ok := sub.(string); ok && s != "" && secretKeyPattern.MatchString(k) {
+				val[k] = maskSecret(s)
+			} else {
+				val[k] = redactSecretValue(sub)
+			}
+		}
+		return val
+	case []interface{}:
+		for i, sub := range val {
+			val[i] = redactSecretValue(sub)
+		}
+		return val
+	default:
+		return v
+	}
+}
+
+// redactSecretsYAML re-serializes YAML-encoded config with secret values masked.
+func redactSecretsYAML(data []byte) ([]byte, error) {
+	var generic interface{}
+	if err := yaml.Unmarshal(data, &generic); err != nil {
+		return nil, err
+	}
+	return yaml.Marshal(redactSecretValue(generic))
+}
+
+// redactSecretsJSON re-serializes JSON-encoded config with secret values masked.
+func redactSecretsJSON(data []byte) ([]byte, error) {
+	var generic interface{}
+	if err := json.Unmarshal(data, &generic); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(redactSecretValue(generic), "", "  ")
 }
 
 func newConfigEditCmd() *cobra.Command {

--- a/cmd/pilot/config_cmd_test.go
+++ b/cmd/pilot/config_cmd_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestMaskSecret(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "****"},
+		{"short (<=8 chars)", "abcd1234", "****"},
+		{"long token", "ghp_1234567890abcdef", "ghp_...cdef"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := maskSecret(tt.in); got != tt.want {
+				t.Errorf("maskSecret(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedactSecretsYAML_MasksMatchingKeys(t *testing.T) {
+	input := `
+adapters:
+  github:
+    token: ghp_1234567890abcdef
+  telegram:
+    bot_token: 1234567890:AAFakeTelegramBotTokenForTests
+alerts:
+  enabled: true
+projects:
+  - path: /some/project
+`
+	out, err := redactSecretsYAML([]byte(input))
+	if err != nil {
+		t.Fatalf("redactSecretsYAML: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := yaml.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("unmarshal redacted output: %v", err)
+	}
+
+	adapters := decoded["adapters"].(map[string]interface{})
+	ghToken := adapters["github"].(map[string]interface{})["token"].(string)
+	if ghToken == "ghp_1234567890abcdef" {
+		t.Errorf("github.token not redacted: %q", ghToken)
+	}
+	if !strings.HasPrefix(ghToken, "ghp_") || !strings.HasSuffix(ghToken, "cdef") {
+		t.Errorf("github.token redaction = %q, want first4...last4 shape", ghToken)
+	}
+
+	tgToken := adapters["telegram"].(map[string]interface{})["bot_token"].(string)
+	if tgToken == "1234567890:AAFakeTelegramBotTokenForTests" {
+		t.Errorf("telegram.bot_token not redacted: %q", tgToken)
+	}
+
+	// Non-secret keys must pass through untouched.
+	if decoded["alerts"].(map[string]interface{})["enabled"] != true {
+		t.Error("non-secret key alerts.enabled was altered")
+	}
+	projects := decoded["projects"].([]interface{})
+	if projects[0].(map[string]interface{})["path"] != "/some/project" {
+		t.Error("non-secret nested slice value was altered")
+	}
+}
+
+func TestRedactSecretsJSON_MasksMatchingKeys(t *testing.T) {
+	type cfg struct {
+		APIKey   string `json:"api_key"`
+		Password string `json:"password"`
+		Name     string `json:"name"`
+	}
+	data, err := json.Marshal(cfg{APIKey: "sk-abcdefghijklmnop", Password: "hunter2hunter2", Name: "pilot"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	out, err := redactSecretsJSON(data)
+	if err != nil {
+		t.Fatalf("redactSecretsJSON: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("unmarshal redacted output: %v", err)
+	}
+
+	if decoded["api_key"] == "sk-abcdefghijklmnop" {
+		t.Error("api_key not redacted")
+	}
+	if decoded["password"] == "hunter2hunter2" {
+		t.Error("password not redacted")
+	}
+	if decoded["name"] != "pilot" {
+		t.Errorf("non-secret key altered: name=%v", decoded["name"])
+	}
+}
+
+func TestRedactSecretValue_EmptyStringLeftAlone(t *testing.T) {
+	in := map[string]interface{}{"token": ""}
+	out := redactSecretValue(in).(map[string]interface{})
+	if out["token"] != "" {
+		t.Errorf("empty secret value should stay empty, got %q", out["token"])
+	}
+}

--- a/cmd/pilot/doctor.go
+++ b/cmd/pilot/doctor.go
@@ -75,6 +75,19 @@ Examples:
 			}
 			fmt.Println()
 
+			// Silently disabled subsystems (GH-3839): configured-but-inert or
+			// wired-off subsystems that don't show up as errors/warnings above
+			// but silently no-op in production.
+			fmt.Println("Silently Disabled Subsystems:")
+			for _, s := range report.Subsystems {
+				yn := "N"
+				if s.Wired {
+					yn = "Y"
+				}
+				fmt.Printf("  [%s] %-32s %s\n", yn, s.Name, s.Reason)
+			}
+			fmt.Println()
+
 			// Summary and recommendations
 			errors, warnings := report.Summary()
 			if errors > 0 || warnings > 0 {

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -873,6 +873,10 @@ Examples:
 
 					var pollerOpts []github.PollerOption
 					pollerOpts = append(pollerOpts, github.WithExecutionMode(execMode))
+					pollerOpts = append(pollerOpts, github.WithTokenSource(string(tokenSource)))
+					if gwAlertsEngine != nil {
+						pollerOpts = append(pollerOpts, github.WithAlertProcessor(alerts.NewEngineAdapter(gwAlertsEngine)))
+					}
 
 					// Wire autopilot OnPRCreated callback if controller initialized
 					if gwAutopilotController != nil {
@@ -2343,6 +2347,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				}
 
 				var pollerOpts []github.PollerOption
+				pollerOpts = append(pollerOpts, github.WithTokenSource(string(tokenSource)))
+				if alertsEngine != nil {
+					pollerOpts = append(pollerOpts, github.WithAlertProcessor(alerts.NewEngineAdapter(alertsEngine)))
+				}
 
 				// Wire autopilot callback to the correct controller for this repo
 				controller := autopilotControllers[repoFullName]

--- a/internal/adapters/github/auth_escalation_test.go
+++ b/internal/adapters/github/auth_escalation_test.go
@@ -1,0 +1,226 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// fakeAlertProcessor implements executor.AlertEventProcessor for GH-3839 tests.
+type fakeAlertProcessor struct {
+	mu     sync.Mutex
+	events []executor.AlertEvent
+}
+
+func (f *fakeAlertProcessor) ProcessEvent(e executor.AlertEvent) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, e)
+}
+
+func (f *fakeAlertProcessor) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.events)
+}
+
+func (f *fakeAlertProcessor) last() executor.AlertEvent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.events[len(f.events)-1]
+}
+
+// TestPoller_AuthFailureEscalation_AlertsAfterThreshold simulates a dead
+// GitHub token (persistent 401) and asserts the poller escalates only once
+// the consecutive-failure count reaches the configured threshold, naming the
+// token source in the emitted alert (GH-3839).
+func TestPoller_AuthFailureEscalation_AlertsAfterThreshold(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	alertProc := &fakeAlertProcessor{}
+	poller, err := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithAlertProcessor(alertProc),
+		WithTokenSource("env GITHUB_TOKEN"),
+	)
+	if err != nil {
+		t.Fatalf("NewPoller: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		poller.checkForNewIssues(context.Background())
+		if got := alertProc.count(); got != 0 {
+			t.Fatalf("after %d consecutive auth failure(s): alert fired early (count=%d)", i+1, got)
+		}
+	}
+
+	poller.checkForNewIssues(context.Background())
+	if got := alertProc.count(); got != 1 {
+		t.Fatalf("after 3rd consecutive auth failure: got %d alerts, want 1", got)
+	}
+
+	ev := alertProc.last()
+	if ev.Type != executor.AlertEventTypeConfigError {
+		t.Errorf("alert type = %v, want AlertEventTypeConfigError", ev.Type)
+	}
+	if ev.Metadata["token_source"] != "env GITHUB_TOKEN" {
+		t.Errorf("token_source metadata = %q, want %q", ev.Metadata["token_source"], "env GITHUB_TOKEN")
+	}
+	if ev.Metadata["consecutive_failures"] != "3" {
+		t.Errorf("consecutive_failures metadata = %q, want %q", ev.Metadata["consecutive_failures"], "3")
+	}
+}
+
+// TestPoller_AuthFailureEscalation_TransientErrorsDontTrip asserts that
+// non-auth transient errors (5xx) neither increment the auth-failure counter
+// nor fire an alert, however many times they occur (GH-3839).
+func TestPoller_AuthFailureEscalation_TransientErrorsDontTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	alertProc := &fakeAlertProcessor{}
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithAlertProcessor(alertProc))
+
+	for i := 0; i < 5; i++ {
+		poller.checkForNewIssues(context.Background())
+	}
+
+	if got := alertProc.count(); got != 0 {
+		t.Errorf("transient 500s fired %d alerts, want 0", got)
+	}
+	if got := poller.consecutiveAuthFailures.Load(); got != 0 {
+		t.Errorf("consecutiveAuthFailures = %d, want 0 (500s are not auth errors)", got)
+	}
+}
+
+// TestPoller_AuthFailureEscalation_RateLimitedDoesNotTrip asserts that a
+// rate-limited 403 (the existing #3798 backoff path) never increments the
+// auth-failure counter, even repeated many times.
+func TestPoller_AuthFailureEscalation_RateLimitedDoesNotTrip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"rate limit exceeded"}`))
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	alertProc := &fakeAlertProcessor{}
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithAlertProcessor(alertProc))
+
+	for i := 0; i < 5; i++ {
+		poller.checkForNewIssues(context.Background())
+	}
+
+	if got := alertProc.count(); got != 0 {
+		t.Errorf("rate-limited 403s fired %d alerts, want 0", got)
+	}
+	if got := poller.consecutiveAuthFailures.Load(); got != 0 {
+		t.Errorf("consecutiveAuthFailures = %d, want 0 (rate-limit 403s stay on the #3798 backoff path)", got)
+	}
+}
+
+// TestPoller_AuthFailureEscalation_ResetsOnSuccess asserts a successful fetch
+// clears the streak, so a fresh run of consecutive failures is required
+// before escalating again (GH-3839).
+func TestPoller_AuthFailureEscalation_ResetsOnSuccess(t *testing.T) {
+	var authMode atomic.Bool
+	authMode.Store(true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if authMode.Load() {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]*Issue{})
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	alertProc := &fakeAlertProcessor{}
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithAlertProcessor(alertProc))
+
+	poller.checkForNewIssues(context.Background())
+	poller.checkForNewIssues(context.Background())
+	if got := poller.consecutiveAuthFailures.Load(); got != 2 {
+		t.Fatalf("after 2 auth failures, counter = %d, want 2", got)
+	}
+
+	authMode.Store(false)
+	poller.checkForNewIssues(context.Background())
+	if got := poller.consecutiveAuthFailures.Load(); got != 0 {
+		t.Fatalf("after a successful fetch, counter = %d, want 0", got)
+	}
+
+	authMode.Store(true)
+	poller.checkForNewIssues(context.Background())
+	poller.checkForNewIssues(context.Background())
+	if got := alertProc.count(); got != 0 {
+		t.Fatalf("after reset, 2 failures should not yet re-trigger; got %d alerts", got)
+	}
+	poller.checkForNewIssues(context.Background())
+	if got := alertProc.count(); got != 1 {
+		t.Errorf("a fresh 3-streak after reset should fire exactly 1 alert; got %d", got)
+	}
+}
+
+// TestPoller_RecoverOrphanedIssues_AuthFailureEscalates asserts the startup
+// orphan-recovery fetch path also escalates on a dead token (GH-3839).
+func TestPoller_RecoverOrphanedIssues_AuthFailureEscalates(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	alertProc := &fakeAlertProcessor{}
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second, WithAlertProcessor(alertProc))
+
+	for i := 0; i < 3; i++ {
+		poller.recoverOrphanedIssues(context.Background())
+	}
+
+	if got := alertProc.count(); got != 1 {
+		t.Errorf("recoverOrphanedIssues: got %d alerts after 3 consecutive 401s, want 1", got)
+	}
+}
+
+// TestIsAuthFetchError covers the auth-vs-transient classification directly.
+func TestIsAuthFetchError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"AuthError (401)", &AuthError{Message: "bad creds"}, true},
+		{"RateLimitError (403 rate-limited)", &RateLimitError{StatusCode: 403, Message: "rate limit exceeded"}, false},
+		{"RateLimitError (429)", &RateLimitError{StatusCode: 429, Message: "too many requests"}, false},
+		{"generic 403 (non-rate-limit forbidden)", errors.New("API error (status 403): insufficient scope"), true},
+		{"generic 500", errors.New("API error (status 500): internal error"), false},
+		{"network error", errors.New("dial tcp: connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAuthFetchError(tt.err); got != tt.want {
+				t.Errorf("isAuthFetchError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -17,6 +18,11 @@ import (
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/text"
 )
+
+// defaultAuthFailureThreshold is the number of consecutive auth-classified
+// fetch errors (401, or non-rate-limited 403) required before the poller
+// escalates to an ERROR log + alert (GH-3839).
+const defaultAuthFailureThreshold = 3
 
 // ExecutionMode determines how issues are processed
 type ExecutionMode string
@@ -184,6 +190,17 @@ type Poller struct {
 	// nil or empty inProgressStatus disables the write-back, keeping label-mode identical.
 	boardSync        *ProjectBoardSync
 	inProgressStatus string
+
+	// GH-3839: consecutive auth-failure escalation. Auth errors (401, or
+	// non-rate-limited 403) on candidate fetches increment this counter; a
+	// successful fetch resets it to zero. At authFailureThreshold consecutive
+	// failures, an ERROR log names tokenSource and an alert fires through
+	// alertProcessor (if configured). Rate-limited 403s stay on the existing
+	// backoff path (#3798) and never touch this counter.
+	consecutiveAuthFailures atomic.Int32
+	authFailureThreshold    int
+	tokenSource             string
+	alertProcessor          executor.AlertEventProcessor
 }
 
 // PollerOption configures a Poller
@@ -355,6 +372,39 @@ func WithBoardSync(bs *ProjectBoardSync, inProgressStatus string) PollerOption {
 	}
 }
 
+// WithAlertProcessor sets the alert processor used to escalate consecutive
+// GitHub auth failures (GH-3839). The interface is the same narrow,
+// import-cycle-free shape executor.Runner already uses (ProcessEvent(AlertEvent));
+// callers typically pass alerts.NewEngineAdapter(engine). Pass nil (default)
+// to disable alerting — escalation still logs at ERROR either way.
+func WithAlertProcessor(ap executor.AlertEventProcessor) PollerOption {
+	return func(p *Poller) {
+		p.alertProcessor = ap
+	}
+}
+
+// WithTokenSource names where the poller's GitHub token was resolved from
+// (e.g. "config", "env GITHUB_TOKEN", "gh CLI"), included in auth-failure
+// escalation logs/alerts so a dead token can be diagnosed without
+// re-deriving the resolution chain (GH-3839, mirrors Client.Verify's
+// tokenSource parameter from GH-3718).
+func WithTokenSource(source string) PollerOption {
+	return func(p *Poller) {
+		p.tokenSource = source
+	}
+}
+
+// WithAuthFailureThreshold sets the number of consecutive auth failures
+// required before escalating to an ERROR log + alert (GH-3839). Default: 3.
+func WithAuthFailureThreshold(n int) PollerOption {
+	return func(p *Poller) {
+		if n < 1 {
+			n = 1
+		}
+		p.authFailureThreshold = n
+	}
+}
+
 // NewPoller creates a new GitHub issue poller
 func NewPoller(client *Client, repo string, label string, interval time.Duration, opts ...PollerOption) (*Poller, error) {
 	parts := strings.Split(repo, "/")
@@ -381,6 +431,7 @@ func NewPoller(client *Client, repo string, label string, interval time.Duration
 		maxFailedRetries:     3, // GH-2176: default max retries for pilot-failed issues
 		retryReadyCount:      make(map[int]int),
 		maxRetryReadyRetries: 3, // GH-2276: default max retries for pilot-retry-ready issues
+		authFailureThreshold: defaultAuthFailureThreshold,
 	}
 
 	for _, opt := range opts {
@@ -452,9 +503,14 @@ func (p *Poller) recoverOrphanedIssues(ctx context.Context) {
 		State:  StateOpen,
 	})
 	if err != nil {
-		p.logger.Warn("Failed to check for orphaned issues", slog.Any("error", err))
+		if isAuthFetchError(err) {
+			p.recordAuthFailure(err)
+		} else {
+			p.logger.Warn("Failed to check for orphaned issues", slog.Any("error", err))
+		}
 		return
 	}
+	p.resetAuthFailures()
 
 	if len(issues) == 0 {
 		return
@@ -1136,6 +1192,74 @@ func groupByOverlappingScope(candidates []*Issue) [][]*Issue {
 	return result
 }
 
+// isAuthFetchError classifies a candidate-fetch error as an authentication
+// failure — 401 (AuthError), or a 403 that doRequest did NOT classify as
+// rate-limited (RateLimitError) — as opposed to a transient/network error.
+// Rate-limited 403s are excluded so they stay on the existing backoff path
+// (#3798) rather than tripping the auth-failure counter (GH-3839).
+func isAuthFetchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var authErr *AuthError
+	if errors.As(err, &authErr) {
+		return true
+	}
+	var rlErr *RateLimitError
+	if errors.As(err, &rlErr) {
+		return false
+	}
+	// A non-rate-limited 403 reaches doRequest's generic fallback path
+	// (client.go) as a plain "API error (status 403): ..." string rather
+	// than a typed error, since only the rate-limited case gets RateLimitError.
+	return strings.Contains(err.Error(), "status 403")
+}
+
+// recordAuthFailure increments the consecutive-auth-failure counter for a
+// classified auth error and escalates once authFailureThreshold is reached:
+// an ERROR log naming the token source, plus an alert via alertProcessor (if
+// configured). Below threshold it logs at Warn so an isolated failure
+// doesn't page anyone (GH-3839).
+func (p *Poller) recordAuthFailure(err error) {
+	n := p.consecutiveAuthFailures.Add(1)
+	threshold := p.authFailureThreshold
+	if threshold <= 0 {
+		threshold = defaultAuthFailureThreshold
+	}
+
+	if int(n) < threshold {
+		p.logger.Warn("github fetch auth error",
+			slog.Int("consecutive_auth_failures", int(n)),
+			slog.Any("error", err))
+		return
+	}
+
+	p.logger.Error("github token appears invalid — consecutive auth failures reached threshold",
+		slog.Int("consecutive_auth_failures", int(n)),
+		slog.String("token_source", p.tokenSource),
+		slog.Any("error", err))
+
+	if p.alertProcessor != nil {
+		p.alertProcessor.ProcessEvent(executor.AlertEvent{
+			Type: executor.AlertEventTypeConfigError,
+			Error: fmt.Sprintf("GitHub token invalid (source: %s) — %d consecutive auth failures",
+				p.tokenSource, n),
+			Metadata: map[string]string{
+				"reason":               "github_auth_failure",
+				"token_source":         p.tokenSource,
+				"consecutive_failures": strconv.Itoa(int(n)),
+			},
+			Timestamp: time.Now(),
+		})
+	}
+}
+
+// resetAuthFailures clears the consecutive-auth-failure streak after a
+// successful candidate fetch (GH-3839).
+func (p *Poller) resetAuthFailures() {
+	p.consecutiveAuthFailures.Store(0)
+}
+
 // repoKey returns "owner/repo" for use as the Prometheus `repo` label.
 func (p *Poller) repoKey() string { return p.owner + "/" + p.repo }
 
@@ -1193,9 +1317,14 @@ func (p *Poller) syncBoardStatusInProgress(ctx context.Context, issue *Issue) {
 func (p *Poller) checkForNewIssues(ctx context.Context) {
 	issues, err := p.fetchCandidates(ctx)
 	if err != nil {
-		p.logger.Warn("Failed to fetch issues", slog.Any("error", err))
+		if isAuthFetchError(err) {
+			p.recordAuthFailure(err)
+		} else {
+			p.logger.Warn("Failed to fetch issues", slog.Any("error", err))
+		}
 		return
 	}
+	p.resetAuthFailures()
 
 	// Phase 1: Collect candidates eligible for dispatch
 	var candidates []*Issue

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -68,6 +68,7 @@ type HealthReport struct {
 	Dependencies []Check
 	Config       []ConfigCheck
 	Features     []FeatureStatus
+	Subsystems   []SubsystemCheck
 	Projects     int
 	HasErrors    bool
 	HasWarnings  bool
@@ -491,6 +492,7 @@ func RunChecks(cfg *config.Config, currentVersion string) *HealthReport {
 		Dependencies: checkDependenciesWithBackend(backendType),
 		Config:       configChecks,
 		Features:     checkFeatures(cfg),
+		Subsystems:   CheckDisabledSubsystems(cfg),
 		Projects:     len(cfg.Projects),
 	}
 

--- a/internal/health/subsystems.go
+++ b/internal/health/subsystems.go
@@ -1,0 +1,163 @@
+package health
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/qf-studio/pilot/internal/config"
+)
+
+// SubsystemCheck reports whether a subsystem that can silently no-op is
+// actually wired up, plus the reason for its Y/N state. Unlike the
+// presence-only checks in checkConfig (e.g. "telegram.bot_token missing"),
+// these checks target subsystems that look configured but never actually run
+// because a second, less obvious gate (a missing wiring call, an unresolved
+// env-scoped policy, a binary that's not on PATH) keeps them inert — the
+// class of bug that GH-3718/GH-3826/GH-3839 kept finding one at a time.
+type SubsystemCheck struct {
+	Name   string
+	Wired  bool
+	Reason string
+}
+
+// CheckDisabledSubsystems evaluates each known configured-but-possibly-inert
+// subsystem from static config (and, where the wiring gap is a build-time
+// fact rather than a config toggle, from the current code path) so `pilot
+// doctor` can surface silent no-ops instead of leaving them to be discovered
+// in production (GH-3839).
+func CheckDisabledSubsystems(cfg *config.Config) []SubsystemCheck {
+	checks := []SubsystemCheck{}
+
+	wired, reason := checkAlertEngineStarted(cfg)
+	checks = append(checks, SubsystemCheck{Name: "alert engine started", Wired: wired, Reason: reason})
+
+	wired, reason = checkAlertProcessorWiredOnRunner(cfg)
+	checks = append(checks, SubsystemCheck{Name: "alert processor wired on runner", Wired: wired, Reason: reason})
+
+	wired, reason = checkReleaserResolved(cfg)
+	checks = append(checks, SubsystemCheck{Name: "releaser resolved", Wired: wired, Reason: reason})
+
+	wired, reason = checkModelRoutingEnabled(cfg)
+	checks = append(checks, SubsystemCheck{Name: "model routing enabled", Wired: wired, Reason: reason})
+
+	wired, reason = checkSubprocessLimitsEnabled(cfg)
+	checks = append(checks, SubsystemCheck{Name: "subprocess_limits enabled", Wired: wired, Reason: reason})
+
+	wired, reason = checkIntentClassifier(cfg)
+	checks = append(checks, SubsystemCheck{Name: "intent classifier", Wired: wired, Reason: reason})
+
+	wired, reason = checkApprovalChannelDeliverable(cfg)
+	checks = append(checks, SubsystemCheck{Name: "approval channel deliverable", Wired: wired, Reason: reason})
+
+	return checks
+}
+
+// checkAlertEngineStarted reports whether the alerts engine would actually
+// start (cfg.alerts.enabled=true) and has somewhere to dispatch to.
+func checkAlertEngineStarted(cfg *config.Config) (bool, string) {
+	if cfg.Alerts == nil || !cfg.Alerts.Enabled {
+		return false, "alerts.enabled=false — no rule can ever fire"
+	}
+	if len(cfg.Alerts.Channels) == 0 {
+		return false, "alerts.enabled=true but no channels configured — engine starts with nowhere to dispatch"
+	}
+	return true, fmt.Sprintf("%d channel(s) configured", len(cfg.Alerts.Channels))
+}
+
+// checkAlertProcessorWiredOnRunner reports whether cmd/pilot's active start
+// path calls executor.Runner.SetAlertProcessor. GH-394 makes runPollingMode
+// (cmd/pilot/main.go) the default whenever GitHub or Telegram polling is
+// enabled, and that path never calls SetAlertProcessor — alertsEngine is only
+// passed into individual issue-handler calls for one-off ProcessEvent
+// invocations, never wired onto the runner itself. That means task-lifecycle
+// events (stagnation/OOM/retry/escalation, emitted via Runner.emitAlertEvent)
+// are dropped silently even when the alert engine is healthy and running.
+// This is a build-time fact about the current start path, not a config
+// toggle — update this check if cmd/pilot/main.go is changed to wire
+// SetAlertProcessor there (internal/pilot's gateway-only path already does,
+// via orchestrator.SetAlertProcessor, but that path is not the default once
+// any polling adapter is enabled).
+func checkAlertProcessorWiredOnRunner(cfg *config.Config) (bool, string) {
+	if cfg.Alerts == nil || !cfg.Alerts.Enabled {
+		return false, "alert engine not started (see \"alert engine started\")"
+	}
+	return false, "runner.SetAlertProcessor is not called on the polling-mode start path (cmd/pilot/main.go runPollingMode) — task lifecycle alerts (stagnation/OOM/retry) are dropped even though the alert engine is running"
+}
+
+// checkReleaserResolved mirrors autopilot.resolveRelease's env-scoped-wins-
+// over-global resolution so doctor can report whether a releaser would
+// actually be constructed, without needing autopilot's unexported helper.
+func checkReleaserResolved(cfg *config.Config) (bool, string) {
+	if cfg.Orchestrator == nil || cfg.Orchestrator.Autopilot == nil {
+		return false, "orchestrator.autopilot not configured"
+	}
+	ap := cfg.Orchestrator.Autopilot
+	if !ap.Enabled {
+		return false, "orchestrator.autopilot.enabled=false"
+	}
+
+	source := "global"
+	relCfg := ap.Release
+	if env := ap.ResolvedEnv(); env != nil && env.Release != nil {
+		relCfg = env.Release
+		source = "env:" + ap.EnvironmentName()
+	}
+
+	if relCfg == nil {
+		return false, "no release policy configured (autopilot.release or environments.<env>.release)"
+	}
+	if !relCfg.Enabled {
+		return false, fmt.Sprintf("release policy present but disabled (source: %s)", source)
+	}
+	return true, fmt.Sprintf("resolved from %s", source)
+}
+
+// checkModelRoutingEnabled reports whether complexity-based model routing is
+// configured; without it every task uses executor.default_model regardless
+// of complexity.
+func checkModelRoutingEnabled(cfg *config.Config) (bool, string) {
+	if cfg.Executor == nil || cfg.Executor.ModelRouting == nil {
+		return false, "executor.model_routing not set — every task uses default_model"
+	}
+	return true, "executor.model_routing configured"
+}
+
+// checkSubprocessLimitsEnabled reports whether the executor subprocess memory
+// cap/telemetry is enabled.
+func checkSubprocessLimitsEnabled(cfg *config.Config) (bool, string) {
+	if cfg.Executor == nil || cfg.Executor.SubprocessLimits == nil || !cfg.Executor.SubprocessLimits.Enabled {
+		return false, "executor.subprocess_limits.enabled=false — no RSS telemetry or memory cap on task subprocesses"
+	}
+	return true, "executor.subprocess_limits.enabled=true"
+}
+
+// checkIntentClassifier reports whether the pre-flight issue-quality judge
+// (GH-2802) is enabled and its backend binary is actually on PATH — matching
+// the same guard cmd/pilot/main.go uses before wiring it into the poller.
+func checkIntentClassifier(cfg *config.Config) (bool, string) {
+	if cfg.Executor == nil || cfg.Executor.PreFlightJudge == nil || !cfg.Executor.PreFlightJudge.Enabled {
+		return false, "executor.pre_flight_judge.enabled=false — issues dispatch without quality pre-screening"
+	}
+	claudeCmd := "claude"
+	if cfg.Executor.ClaudeCode != nil && cfg.Executor.ClaudeCode.Command != "" {
+		claudeCmd = cfg.Executor.ClaudeCode.Command
+	}
+	if _, err := exec.LookPath(claudeCmd); err != nil {
+		return false, fmt.Sprintf("enabled in config but disabled at runtime: %q binary not found on PATH", claudeCmd)
+	}
+	return true, "executor.pre_flight_judge.enabled=true"
+}
+
+// checkApprovalChannelDeliverable reports whether the configured approval
+// channel can actually receive the approver's decision. Reuses
+// TelegramApprovalStranding (GH-3826) so the send-only warning surfaces here
+// too, alongside the other silently-inert subsystems.
+func checkApprovalChannelDeliverable(cfg *config.Config) (bool, string) {
+	if msg := TelegramApprovalStranding(cfg); msg != "" {
+		return false, msg + " — inbound polling is off, taps can never be received"
+	}
+	if cfg.Approval == nil || !cfg.Approval.Enabled {
+		return false, "approval.enabled=false"
+	}
+	return true, "inbound processing active"
+}

--- a/internal/health/subsystems_test.go
+++ b/internal/health/subsystems_test.go
@@ -1,0 +1,196 @@
+package health
+
+import (
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/telegram"
+	"github.com/qf-studio/pilot/internal/approval"
+	"github.com/qf-studio/pilot/internal/autopilot"
+	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/executor"
+)
+
+func findSubsystem(checks []SubsystemCheck, name string) *SubsystemCheck {
+	for i := range checks {
+		if checks[i].Name == name {
+			return &checks[i]
+		}
+	}
+	return nil
+}
+
+func TestCheckDisabledSubsystems_EmptyConfig_AllDisabled(t *testing.T) {
+	cfg := &config.Config{}
+	checks := CheckDisabledSubsystems(cfg)
+
+	wantNames := []string{
+		"alert engine started",
+		"alert processor wired on runner",
+		"releaser resolved",
+		"model routing enabled",
+		"subprocess_limits enabled",
+		"intent classifier",
+		"approval channel deliverable",
+	}
+	for _, name := range wantNames {
+		c := findSubsystem(checks, name)
+		if c == nil {
+			t.Errorf("missing subsystem check %q", name)
+			continue
+		}
+		if c.Wired {
+			t.Errorf("subsystem %q: wired=true on an empty config, want false", c.Name)
+		}
+		if c.Reason == "" {
+			t.Errorf("subsystem %q: empty reason", c.Name)
+		}
+	}
+}
+
+func TestCheckAlertEngineStarted(t *testing.T) {
+	cfg := &config.Config{}
+	if wired, _ := checkAlertEngineStarted(cfg); wired {
+		t.Error("nil alerts config: wired=true, want false")
+	}
+
+	cfg.Alerts = &config.AlertsConfig{Enabled: true}
+	if wired, reason := checkAlertEngineStarted(cfg); wired {
+		t.Errorf("enabled but no channels: wired=true, want false (reason=%q)", reason)
+	}
+
+	cfg.Alerts.Channels = []config.AlertChannelConfig{{Name: "ops", Type: "slack", Enabled: true}}
+	if wired, reason := checkAlertEngineStarted(cfg); !wired {
+		t.Errorf("enabled with channels: wired=false, want true (reason=%q)", reason)
+	}
+}
+
+func TestCheckAlertProcessorWiredOnRunner_AlwaysFalse(t *testing.T) {
+	// GH-3839: the poller's alertProcessor (this issue's B4) is a different
+	// wire than the runner's task-lifecycle alertProcessor — cmd/pilot's
+	// polling-mode start path never calls Runner.SetAlertProcessor, so this
+	// check must report false regardless of how alerts are configured.
+	cfg := &config.Config{
+		Alerts: &config.AlertsConfig{
+			Enabled:  true,
+			Channels: []config.AlertChannelConfig{{Name: "ops", Type: "slack", Enabled: true}},
+		},
+	}
+	if wired, reason := checkAlertProcessorWiredOnRunner(cfg); wired {
+		t.Errorf("wired=true, want false (reason=%q)", reason)
+	}
+}
+
+func TestCheckReleaserResolved(t *testing.T) {
+	cfg := &config.Config{}
+	if wired, _ := checkReleaserResolved(cfg); wired {
+		t.Error("no autopilot config: wired=true, want false")
+	}
+
+	cfg.Orchestrator = &config.OrchestratorConfig{Autopilot: autopilot.DefaultConfig()}
+	if wired, reason := checkReleaserResolved(cfg); wired {
+		t.Errorf("autopilot disabled: wired=true, want false (reason=%q)", reason)
+	}
+
+	cfg.Orchestrator.Autopilot.Enabled = true
+	if wired, reason := checkReleaserResolved(cfg); wired {
+		t.Errorf("no release policy: wired=true, want false (reason=%q)", reason)
+	}
+
+	cfg.Orchestrator.Autopilot.Release = autopilot.DefaultReleaseConfig() // Enabled: false
+	if wired, reason := checkReleaserResolved(cfg); wired {
+		t.Errorf("release policy present but disabled: wired=true, want false (reason=%q)", reason)
+	}
+
+	cfg.Orchestrator.Autopilot.Release.Enabled = true
+	if wired, reason := checkReleaserResolved(cfg); !wired {
+		t.Errorf("global release policy enabled: wired=false, want true (reason=%q)", reason)
+	}
+
+	// Env-scoped release config wins over global.
+	cfg.Orchestrator.Autopilot.DefaultEnvironment = "stage-custom"
+	envRelease := autopilot.DefaultReleaseConfig()
+	envRelease.Enabled = false
+	cfg.Orchestrator.Autopilot.Environments = map[string]*autopilot.EnvironmentConfig{
+		"stage-custom": {Release: envRelease},
+	}
+	if err := cfg.Orchestrator.Autopilot.SetActiveEnvironment("stage-custom"); err != nil {
+		t.Fatalf("SetActiveEnvironment: %v", err)
+	}
+	if wired, reason := checkReleaserResolved(cfg); wired {
+		t.Errorf("env release policy disabled should win over enabled global: wired=true, want false (reason=%q)", reason)
+	}
+}
+
+func TestCheckModelRoutingEnabled(t *testing.T) {
+	cfg := &config.Config{}
+	if wired, _ := checkModelRoutingEnabled(cfg); wired {
+		t.Error("nil executor config: wired=true, want false")
+	}
+
+	cfg.Executor = &executor.BackendConfig{}
+	if wired, _ := checkModelRoutingEnabled(cfg); wired {
+		t.Error("nil model_routing: wired=true, want false")
+	}
+
+	cfg.Executor.ModelRouting = &executor.ModelRoutingConfig{}
+	if wired, reason := checkModelRoutingEnabled(cfg); !wired {
+		t.Errorf("model_routing set: wired=false, want true (reason=%q)", reason)
+	}
+}
+
+func TestCheckSubprocessLimitsEnabled(t *testing.T) {
+	cfg := &config.Config{Executor: &executor.BackendConfig{}}
+	if wired, _ := checkSubprocessLimitsEnabled(cfg); wired {
+		t.Error("nil subprocess_limits: wired=true, want false")
+	}
+
+	cfg.Executor.SubprocessLimits = executor.DefaultSubprocessLimitsConfig()
+	if wired, reason := checkSubprocessLimitsEnabled(cfg); wired {
+		t.Errorf("default subprocess_limits (telemetry-only, enabled=false): wired=true, want false (reason=%q)", reason)
+	}
+
+	cfg.Executor.SubprocessLimits.Enabled = true
+	if wired, reason := checkSubprocessLimitsEnabled(cfg); !wired {
+		t.Errorf("subprocess_limits.enabled=true: wired=false, want true (reason=%q)", reason)
+	}
+}
+
+func TestCheckIntentClassifier(t *testing.T) {
+	cfg := &config.Config{Executor: &executor.BackendConfig{}}
+	if wired, _ := checkIntentClassifier(cfg); wired {
+		t.Error("nil pre_flight_judge: wired=true, want false")
+	}
+
+	cfg.Executor.PreFlightJudge = &executor.PreFlightJudgeConfig{Enabled: true}
+	wired, reason := checkIntentClassifier(cfg)
+	// Whether this reports true depends on whether "claude" is on the test
+	// runner's PATH — assert the two are consistent rather than hardcoding one.
+	if wired && reason != "executor.pre_flight_judge.enabled=true" {
+		t.Errorf("wired=true but unexpected reason %q", reason)
+	}
+	if !wired && reason == "" {
+		t.Error("wired=false but empty reason")
+	}
+}
+
+func TestCheckApprovalChannelDeliverable(t *testing.T) {
+	cfg := &config.Config{}
+	if wired, _ := checkApprovalChannelDeliverable(cfg); wired {
+		t.Error("no approval config: wired=true, want false")
+	}
+
+	cfg.Approval = approval.DefaultConfig()
+	cfg.Approval.Enabled = true
+	if wired, reason := checkApprovalChannelDeliverable(cfg); !wired {
+		t.Errorf("approval enabled, no telegram stranding: wired=false, want true (reason=%q)", reason)
+	}
+
+	// GH-3826: Telegram registered as an approval channel but polling is off.
+	cfg.Adapters = &config.AdaptersConfig{
+		Telegram: &telegram.Config{Enabled: true, BotToken: "test-telegram-token", Polling: false},
+	}
+	cfg.Approval.PreMerge = &approval.StageConfig{Enabled: true}
+	if wired, reason := checkApprovalChannelDeliverable(cfg); wired {
+		t.Errorf("telegram send-only stranding should force wired=false (reason=%q)", reason)
+	}
+}


### PR DESCRIPTION
## Summary
- **B4 — GitHub poller auth-failure escalation**: `checkForNewIssues`/`recoverOrphanedIssues` now classify fetch errors (401, or non-rate-limited 403) via `isAuthFetchError`, count consecutive auth failures, and escalate to an ERROR log naming the token source + an alert (via the new narrow `WithAlertProcessor`/`executor.AlertEventProcessor` injection point) once `authFailureThreshold` (default 3) is reached. A successful fetch resets the counter. Rate-limited 403s/5xx/network errors are untouched, staying on the existing #3798 backoff path. Wired into both `cmd/pilot/main.go` poller-construction sites via `alerts.NewEngineAdapter`.
- **B5 — "Silently Disabled Subsystems" doctor panel**: new `internal/health/subsystems.go` reports Y/N + reason for 7 subsystems that can look configured but stay inert: alert engine started, alert processor wired on runner (confirmed via code audit: `cmd/pilot/main.go`'s `runPollingMode` — the default start path once GitHub/Telegram polling is enabled per GH-394 — never calls `Runner.SetAlertProcessor`, so task-lifecycle alerts are dropped even with a healthy alert engine), releaser resolved (env + policy), model routing enabled, subprocess_limits enabled, intent classifier on/off, and approval-channel deliverability (reuses GH-3826's `TelegramApprovalStranding`).
- **B6 — `pilot config show` secret redaction**: values whose key matches `token|key|secret|password` (case-insensitive) are masked to `first4...last4` by default; `--reveal` prints the raw config. Works generically over the YAML/JSON-decoded tree so it covers every current and future secret-shaped field without a hardcoded list.

## Test plan
- [x] `go build ./...`
- [x] `make test` (full suite, including new tests below)
- [x] `make lint` / `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] New tests: `internal/adapters/github/auth_escalation_test.go` (dead-token 3-strike escalation, transient 500s and rate-limited 403s don't trip the counter, success resets it, `recoverOrphanedIssues` path, `isAuthFetchError` classification)
- [x] New tests: `internal/health/subsystems_test.go` (all 7 checks, empty vs. populated config, env-scoped release policy overriding global)
- [x] New tests: `cmd/pilot/config_cmd_test.go` (mask shape, YAML/JSON redaction round-trip, non-secret keys untouched, empty values left alone)
- [x] Manual end-to-end verification: built the binary, ran `pilot doctor --config <test-config>` and confirmed the new panel reflects a hand-crafted config's alerts/pre_flight_judge/autopilot settings correctly; ran `pilot config show` vs `--reveal` and confirmed token masking (`ghp_...FAKE`) vs raw output