### PR TITLE
refactor(llm): shared Anthropic Messages request builder for client.Answer

### DIFF
--- a/internal/llm/anthropic/request.go
+++ b/internal/llm/anthropic/request.go
@@ -1,0 +1,48 @@
+// Package anthropic provides a shared request builder for the Anthropic
+// Messages API (https://api.anthropic.com/v1/messages), used across every
+// Pilot call site that talks to Claude. Building requests through a single
+// typed constructor keeps required fields (like max_tokens) impossible to
+// omit and unsupported ones (like a top-level output_config/effort) impossible
+// to add by accident — both have shipped as 400-error regressions before
+// (PR #3700, #3703).
+package anthropic
+
+import "fmt"
+
+// Message is one turn in an Anthropic Messages API conversation.
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// Request is the JSON payload for a Messages API call. Construct one via
+// NewRequest so the API's required fields are validated at construction time
+// rather than discovered as a 400 at request time.
+type Request struct {
+	Model     string    `json:"model"`
+	MaxTokens int       `json:"max_tokens"`
+	System    string    `json:"system,omitempty"`
+	Messages  []Message `json:"messages"`
+}
+
+// NewRequest builds a Request. max_tokens is mandatory on every Messages API
+// call — omitting it returns HTTP 400 "max_tokens: Field required" (PR #3700).
+func NewRequest(model string, maxTokens int, messages []Message) (*Request, error) {
+	if model == "" {
+		return nil, fmt.Errorf("anthropic: model must not be empty")
+	}
+	if maxTokens <= 0 {
+		return nil, fmt.Errorf("anthropic: max_tokens must be > 0, got %d", maxTokens)
+	}
+	return &Request{
+		Model:     model,
+		MaxTokens: maxTokens,
+		Messages:  messages,
+	}, nil
+}
+
+// WithSystem sets the system prompt and returns the Request for chaining.
+func (r *Request) WithSystem(system string) *Request {
+	r.System = system
+	return r
+}

--- a/internal/llm/anthropic/request_test.go
+++ b/internal/llm/anthropic/request_test.go
@@ -1,0 +1,118 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNewRequest_RejectsEmptyModel(t *testing.T) {
+	_, err := NewRequest("", 1024, []Message{{Role: "user", Content: "hi"}})
+	if err == nil {
+		t.Fatal("expected error for empty model, got nil")
+	}
+}
+
+func TestNewRequest_RejectsNonPositiveMaxTokens(t *testing.T) {
+	tests := []int{0, -1, -100}
+	for _, mt := range tests {
+		if _, err := NewRequest("claude-haiku-4-5", mt, nil); err == nil {
+			t.Errorf("max_tokens=%d: expected error, got nil", mt)
+		}
+	}
+}
+
+func TestNewRequest_ContractShape(t *testing.T) {
+	req, err := NewRequest("claude-haiku-4-5", 2048, []Message{
+		{Role: "user", Content: "hi"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req.WithSystem("be helpful")
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// model must always be present and non-empty.
+	model, ok := body["model"].(string)
+	if !ok || model == "" {
+		t.Errorf("model: got %v, want non-empty string", body["model"])
+	}
+
+	// max_tokens is REQUIRED by the Anthropic Messages API — omitting it 400s.
+	mt, ok := body["max_tokens"].(float64)
+	if !ok || mt <= 0 {
+		t.Errorf("max_tokens: got %v, want positive number", body["max_tokens"])
+	}
+
+	// system must round-trip when set via WithSystem.
+	if body["system"] != "be helpful" {
+		t.Errorf("system: got %v, want %q", body["system"], "be helpful")
+	}
+
+	// output_config/effort are non-standard top-level fields that have caused
+	// 400 regressions in the past (PR #3703) — the builder must never emit them.
+	for _, forbidden := range []string{"output_config", "effort"} {
+		if _, present := body[forbidden]; present {
+			t.Errorf("%s must not be a top-level field in the request body", forbidden)
+		}
+	}
+}
+
+func TestRequest_SystemOmittedWhenUnset(t *testing.T) {
+	req, err := NewRequest("claude-haiku-4-5", 1024, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if _, present := body["system"]; present {
+		t.Errorf("system must be omitted from the body when never set")
+	}
+}
+
+func TestRequest_MessagesRoundTrip(t *testing.T) {
+	messages := []Message{
+		{Role: "user", Content: "previous question"},
+		{Role: "assistant", Content: "previous answer"},
+		{Role: "user", Content: "new question"},
+	}
+	req, err := NewRequest("claude-haiku-4-5", 1024, messages)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	msgs, ok := body["messages"].([]interface{})
+	if !ok {
+		t.Fatalf("messages not an array")
+	}
+	if len(msgs) != len(messages) {
+		t.Errorf("messages: got %d entries, want %d", len(msgs), len(messages))
+	}
+}

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/qf-studio/pilot/internal/intent"
+	"github.com/qf-studio/pilot/internal/llm/anthropic"
 )
 
 const defaultAPIURL = "https://api.anthropic.com/v1/messages"
@@ -48,26 +49,25 @@ func NewClient(apiKey string) *Client {
 // of all content blocks in the response.
 func (c *Client) Answer(ctx context.Context, model, system string, history []intent.ConversationMessage, user string) (string, error) {
 	// Build messages array from history + new user message.
-	messages := make([]map[string]string, 0, len(history)+1)
+	messages := make([]anthropic.Message, 0, len(history)+1)
 	for _, msg := range history {
-		messages = append(messages, map[string]string{
-			"role":    msg.Role,
-			"content": msg.Content,
+		messages = append(messages, anthropic.Message{
+			Role:    msg.Role,
+			Content: msg.Content,
 		})
 	}
-	messages = append(messages, map[string]string{
-		"role":    "user",
-		"content": user,
+	messages = append(messages, anthropic.Message{
+		Role:    "user",
+		Content: user,
 	})
 
-	body := map[string]interface{}{
-		"model":      model,
-		"max_tokens": maxTokens,
-		"system":     system,
-		"messages":   messages,
+	apiReq, err := anthropic.NewRequest(model, maxTokens, messages)
+	if err != nil {
+		return "", fmt.Errorf("llm: build request: %w", err)
 	}
+	apiReq.WithSystem(system)
 
-	jsonBody, err := json.Marshal(body)
+	jsonBody, err := json.Marshal(apiReq)
 	if err != nil {
 		return "", fmt.Errorf("llm: marshal request: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Subtask 1/5 of #3841: `internal/llm/client.go:43-62` hand-rolled its Anthropic Messages request body as a `map[string]interface{}` — one of six sites doing this independently, two of which shipped 400-error regressions (missing `max_tokens`, stray `output_config`) because each site re-invents the body.
- Adds `internal/llm/anthropic` with a typed `NewRequest` constructor that validates `model`/`max_tokens` at construction time and can't emit unsupported top-level fields.
- Migrates `client.Answer` (backing `comms.Responder.Chat`/`Answer`/`DraftIssue`) to build its request through the new package.
- Remaining five call sites are tracked as separate subtasks of #3841.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `go test ./...` — all green, including new contract tests in `internal/llm/anthropic` (max_tokens always present/positive, model required, no `output_config`/`effort` top-level keys, system omitted when unset) and unchanged existing `internal/llm` behavior tests