### PR TITLE
feat(memory): add execution_events table, migration, and Insert/Query API

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -225,6 +225,7 @@
 | PR review comments API | ✅ | adapters/github | - | - | GetPullRequestComments for line-level review feedback (v2.25.0, PR #1825) |
 | CI log pattern learning | ✅ | autopilot | - | - | Wire CI log learning into autopilot feedback loop (v2.50.0, PR #1977) |
 | Staticcheck S1011 fix | ✅ | memory | - | - | Replace loop with append for staticcheck compliance (v2.46.1, PR #1971) |
+| Execution stage ledger (data layer) | ✅ | memory | - | - | `execution_events` table + Stage enum, `InsertExecutionEvent`/`ListExecutionEvents`/`ListExecutionsForTask`; no consumers wired yet (TASK-379 C3, GH-3844, v2.208.0) |
 
 ## Dashboard
 

--- a/internal/memory/execution_events_test.go
+++ b/internal/memory/execution_events_test.go
@@ -1,0 +1,213 @@
+package memory
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// newExecutionEventsTestStore creates a real-file-backed Store (foreign_keys=ON,
+// matching production) for execution_events tests.
+func newExecutionEventsTestStore(t *testing.T) *Store {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "pilot-test-events-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestInsertAndListExecutionEvents covers insert/list, chronological ordering,
+// and the unknown-execution-id → empty-result case.
+func TestInsertAndListExecutionEvents(t *testing.T) {
+	tests := []struct {
+		name       string
+		seedEvents []struct {
+			stage  Stage
+			detail string
+		}
+		queryID     string
+		wantStages  []Stage
+		wantDetails []string
+	}{
+		{
+			name:    "unknown execution id returns empty result",
+			queryID: "exec-does-not-exist",
+		},
+		{
+			name: "single event round-trips",
+			seedEvents: []struct {
+				stage  Stage
+				detail string
+			}{
+				{StageQueued, "picked up from queue"},
+			},
+			queryID:     "exec-1",
+			wantStages:  []Stage{StageQueued},
+			wantDetails: []string{"picked up from queue"},
+		},
+		{
+			name: "multiple events ordered by occurred_at ascending",
+			seedEvents: []struct {
+				stage  Stage
+				detail string
+			}{
+				{StageQueued, "queued"},
+				{StageRunning, "started"},
+				{StagePRCreated, "opened PR #1"},
+				{StageMerged, "merged"},
+			},
+			queryID:     "exec-1",
+			wantStages:  []Stage{StageQueued, StageRunning, StagePRCreated, StageMerged},
+			wantDetails: []string{"queued", "started", "opened PR #1", "merged"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newExecutionEventsTestStore(t)
+
+			// Seed the parent execution row so INSERTs satisfy the FK, unless this
+			// case is specifically testing an execution id that was never created.
+			if len(tt.seedEvents) > 0 {
+				if err := store.SaveExecution(&Execution{
+					ID:          "exec-1",
+					TaskID:      "GH-1",
+					ProjectPath: "/project",
+					Status:      "running",
+				}); err != nil {
+					t.Fatalf("SaveExecution failed: %v", err)
+				}
+			}
+
+			for _, seed := range tt.seedEvents {
+				if err := store.InsertExecutionEvent("exec-1", seed.stage, seed.detail); err != nil {
+					t.Fatalf("InsertExecutionEvent(%s) failed: %v", seed.stage, err)
+				}
+				// Ensure distinct occurred_at values so ASC ordering is meaningful
+				// even on filesystems/clocks with coarse resolution.
+				time.Sleep(time.Millisecond)
+			}
+
+			events, err := store.ListExecutionEvents(tt.queryID)
+			if err != nil {
+				t.Fatalf("ListExecutionEvents failed: %v", err)
+			}
+
+			if len(events) != len(tt.wantStages) {
+				t.Fatalf("got %d events, want %d", len(events), len(tt.wantStages))
+			}
+			var prevOccurredAt time.Time
+			for i, e := range events {
+				if e.Stage != tt.wantStages[i] {
+					t.Errorf("event[%d].Stage = %q, want %q", i, e.Stage, tt.wantStages[i])
+				}
+				if e.Detail != tt.wantDetails[i] {
+					t.Errorf("event[%d].Detail = %q, want %q", i, e.Detail, tt.wantDetails[i])
+				}
+				if e.ExecutionID != "exec-1" {
+					t.Errorf("event[%d].ExecutionID = %q, want exec-1", i, e.ExecutionID)
+				}
+				if i > 0 && e.OccurredAt.Before(prevOccurredAt) {
+					t.Errorf("event[%d].OccurredAt = %v is before previous event's %v; want ascending order", i, e.OccurredAt, prevOccurredAt)
+				}
+				prevOccurredAt = e.OccurredAt
+			}
+		})
+	}
+}
+
+// TestInsertExecutionEventUsesExplicitUTC verifies occurred_at is written with
+// an explicit UTC clock value rather than relying on SQLite's local-time default.
+func TestInsertExecutionEventUsesExplicitUTC(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	if err := store.SaveExecution(&Execution{
+		ID:          "exec-1",
+		TaskID:      "GH-1",
+		ProjectPath: "/project",
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	before := time.Now().UTC()
+	if err := store.InsertExecutionEvent("exec-1", StageQueued, ""); err != nil {
+		t.Fatalf("InsertExecutionEvent failed: %v", err)
+	}
+	after := time.Now().UTC()
+
+	events, err := store.ListExecutionEvents("exec-1")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+
+	got := events[0].OccurredAt
+	if got.Before(before) || got.After(after) {
+		t.Errorf("OccurredAt = %v, want between %v and %v", got, before, after)
+	}
+}
+
+// TestListExecutionsForTask covers newest-first ordering and an unknown task id.
+func TestListExecutionsForTask(t *testing.T) {
+	tests := []struct {
+		name      string
+		seedIDs   []string // in insertion order
+		queryTask string
+		wantIDs   []string // expected order returned
+	}{
+		{
+			name:      "unknown task id returns empty result",
+			queryTask: "GH-does-not-exist",
+		},
+		{
+			name:      "multiple executions returned newest first",
+			seedIDs:   []string{"exec-1", "exec-2", "exec-3"},
+			queryTask: "GH-1",
+			wantIDs:   []string{"exec-3", "exec-2", "exec-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newExecutionEventsTestStore(t)
+
+			for _, id := range tt.seedIDs {
+				if err := store.SaveExecution(&Execution{
+					ID:          id,
+					TaskID:      "GH-1",
+					ProjectPath: "/project",
+					Status:      "queued",
+				}); err != nil {
+					t.Fatalf("SaveExecution(%s) failed: %v", id, err)
+				}
+				// created_at defaults to CURRENT_TIMESTAMP; sleep so insertion order
+				// is distinguishable by time, not just rowid.
+				time.Sleep(time.Millisecond)
+			}
+
+			got, err := store.ListExecutionsForTask(tt.queryTask)
+			if err != nil {
+				t.Fatalf("ListExecutionsForTask failed: %v", err)
+			}
+			if len(got) != len(tt.wantIDs) {
+				t.Fatalf("got %d executions, want %d", len(got), len(tt.wantIDs))
+			}
+			for i, exec := range got {
+				if exec.ID != tt.wantIDs[i] {
+					t.Errorf("execution[%d].ID = %q, want %q", i, exec.ID, tt.wantIDs[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -338,6 +338,17 @@ func (s *Store) migrate() error {
 		`ALTER TABLE executions ADD COLUMN tokens_cache_write INTEGER DEFAULT 0`,
 		// GH-3536: project scoping for eval tasks
 		`ALTER TABLE eval_tasks ADD COLUMN project_path TEXT DEFAULT ''`,
+		// GH-3844 (TASK-379 C3): stage-transition ledger, durable across autopilot's
+		// practice of deleting successful PR state rows.
+		`CREATE TABLE IF NOT EXISTS execution_events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			execution_id TEXT NOT NULL,
+			stage TEXT NOT NULL,
+			occurred_at DATETIME NOT NULL,
+			detail TEXT DEFAULT '',
+			FOREIGN KEY (execution_id) REFERENCES executions(id) ON DELETE CASCADE
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_execution_events_execution_id ON execution_events(execution_id)`,
 	}
 
 	for _, migration := range migrations {
@@ -588,8 +599,14 @@ const executionDetailColumns = `
 	COALESCE(approval_decision_by, ''),
 	COALESCE(effort_level, ''), COALESCE(complexity_level, '')`
 
+// rowScanner abstracts *sql.Row and *sql.Rows so scanExecutionDetail serves both
+// a single QueryRow result and a Query loop (used by ListExecutionsForTask).
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
 // scanExecutionDetail scans a row selected via executionDetailColumns into an Execution.
-func scanExecutionDetail(row *sql.Row) (*Execution, error) {
+func scanExecutionDetail(row rowScanner) (*Execution, error) {
 	var exec Execution
 	var completedAt sql.NullTime
 	var approvalDecisionAt sql.NullTime
@@ -635,6 +652,107 @@ func (s *Store) GetLatestExecutionByTaskID(taskID string) (*Execution, error) {
 		LIMIT 1
 	`, taskID, "%"+taskID+"%", taskID)
 	return scanExecutionDetail(row)
+}
+
+// ListExecutionsForTask returns every execution recorded for taskID (exact match),
+// newest first. Unlike GetLatestExecutionByTaskID (single row, exact-or-substring
+// match), this returns the full history so the CLI can render a per-execution
+// stage timeline across retries (TASK-379 C4).
+func (s *Store) ListExecutionsForTask(taskID string) ([]*Execution, error) {
+	rows, err := s.db.Query(`
+		SELECT `+executionDetailColumns+`
+		FROM executions
+		WHERE task_id = ?
+		ORDER BY created_at DESC, rowid DESC
+	`, taskID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var executions []*Execution
+	for rows.Next() {
+		exec, err := scanExecutionDetail(rows)
+		if err != nil {
+			return nil, err
+		}
+		executions = append(executions, exec)
+	}
+	return executions, rows.Err()
+}
+
+// Stage identifies a discrete milestone in an execution's lifecycle. Stage events
+// accumulate in execution_events to build an append-only timeline for `pilot trace`
+// (TASK-379 C3/C4) — unlike executions.status, a single mutable field, this
+// timeline survives autopilot's practice of deleting successful PR state rows.
+// Values match the enum in GH-3840.
+type Stage string
+
+const (
+	StageQueued           Stage = "queued"
+	StageSpecValidated    Stage = "spec_validated"
+	StageRunning          Stage = "running"
+	StageCommit           Stage = "commit"
+	StagePRCreated        Stage = "pr_created"
+	StageCIPassed         Stage = "ci_passed"
+	StageCIFailed         Stage = "ci_failed"
+	StageAwaitingApproval Stage = "awaiting_approval"
+	StageMerged           Stage = "merged"
+	StageReleased         Stage = "released"
+	StageFailed           Stage = "failed"
+	StageNoOp             Stage = "no_op"
+	StageSkipped          Stage = "skipped"
+	StageStalled          Stage = "stalled"
+)
+
+// Event represents a single stage-transition record for an execution.
+type Event struct {
+	ID          int64
+	ExecutionID string
+	Stage       Stage
+	OccurredAt  time.Time
+	Detail      string
+}
+
+// InsertExecutionEvent records a stage transition for executionID. occurred_at is
+// always the write-time UTC clock, not a caller-supplied value, so the ledger
+// can't be back-dated or skewed by local timezone (TASK-379 C2/C3).
+func (s *Store) InsertExecutionEvent(executionID string, stage Stage, detail string) error {
+	return s.withRetry("InsertExecutionEvent", func() error {
+		_, err := s.db.Exec(`
+			INSERT INTO execution_events (execution_id, stage, occurred_at, detail)
+			VALUES (?, ?, ?, ?)
+		`, executionID, string(stage), time.Now().UTC(), detail)
+		return err
+	})
+}
+
+// ListExecutionEvents returns the stage timeline for executionID in chronological
+// (occurred_at ASC) order. Returns an empty slice, not an error, for an unknown
+// execution ID.
+func (s *Store) ListExecutionEvents(executionID string) ([]*Event, error) {
+	rows, err := s.db.Query(`
+		SELECT id, execution_id, stage, occurred_at, COALESCE(detail, '')
+		FROM execution_events
+		WHERE execution_id = ?
+		ORDER BY occurred_at ASC, id ASC
+	`, executionID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var events []*Event
+	for rows.Next() {
+		var e Event
+		var stage string
+		if err := rows.Scan(&e.ID, &e.ExecutionID, &stage, &e.OccurredAt, &e.Detail); err != nil {
+			return nil, err
+		}
+		e.Stage = Stage(stage)
+		events = append(events, &e)
+	}
+	return events, rows.Err()
 }
 
 // HasCompletedExecution checks whether a genuine completed execution exists for the given task


### PR DESCRIPTION
## Summary
- Adds an additive, idempotent `execution_events` table (`execution_id` FK -> `executions.id`, `stage`, `occurred_at` written via explicit `time.Now().UTC()`, `detail`) plus an index on `execution_id`, following the existing ALTER-pattern migration style.
- Exposes `InsertExecutionEvent(executionID, stage, detail)` and `ListExecutionEvents(executionID) []*Event` (ordered `occurred_at ASC`).
- Adds `ListExecutionsForTask(taskID) []*Execution` (newest first) for the upcoming `pilot trace` CLI command.
- Adds a `Stage` string enum with the 14 stage values from the GH-3840 spec (`queued`, `spec_validated`, `running`, `commit`, `pr_created`, `ci_passed`, `ci_failed`, `awaiting_approval`, `merged`, `released`, `failed`, `no_op`, `skipped`, `stalled`).

Pure data-layer landing — no consumers wired yet; this unblocks the parallel sibling subtasks under GH-3840/TASK-379 (C3/C4).

Closes #3844

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/memory/...` (new table-driven tests: insert/list round-trip, chronological ordering, unknown-execution-id and unknown-task-id -> empty result, explicit-UTC occurred_at)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` (0 issues)