### PR TITLE
feat(dashboard): stage strip on execution cards

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -237,6 +237,7 @@
 | Queue metrics card | ✅ | dashboard | - | - | Current queue depth, succeeded/failed (v0.21.2) |
 | Autopilot panel | ✅ | dashboard | - | - | Live PR lifecycle status |
 | Task history | ✅ | dashboard | - | - | Recent 5 completed tasks |
+| Execution stage strip | ✅ | dashboard | - | - | Per-stage glyph strip on HISTORY cards (e.g. `✓✓✓✗ running`), fed from `execution_events`, cached at hydrate/refresh time not per render (GH-3849, v2.208.0) |
 | Hot upgrade key | ✅ | dashboard | `u` key | - | In-place upgrade from dashboard |
 | SQLite persistence | ✅ | dashboard | - | - | Metrics survive restarts (v0.21.2) |
 | Queue state panel | ✅ | dashboard | - | - | 5-state: done/running/queued/pending/failed with shimmer (v0.63.0) |

--- a/.agent/tasks/gh-3849.md
+++ b/.agent/tasks/gh-3849.md
@@ -1,0 +1,25 @@
+# GH-3849
+
+**Created:** 2026-07-04
+
+## Problem
+
+GitHub Issue #3849: feat(dashboard): stage strip on execution cards
+
+<!--autopilot-meta
+parent: GH-3840
+inherited-spec: true
+-->
+
+Parent: GH-3840
+
+In internal/dashboard/tui.go around lines 624-627, replace the binary success/failed collapse with a compact stage strip (e.g. ✓✓✓✗ spec_validated) driven by store.ListExecutionEvents for the card's execution. Cache the event list per card render tick to avoid a store hit per frame. Update the existing TUI render tests to assert the new strip renders for happy path, in-progress, and failed-at-stage-N cases. Runs after subtask #1; independent of #2/#3/#4.
+
+## Scope fence
+
+Implement ONLY the slice described above. The parent issue GH-3840 is decomposed
+into sibling sub-issues that cover the rest of its spec — consult the parent
+for context, but do NOT implement parts of it that fall outside this subtask.
+
+## Acceptance Criteria
+

--- a/internal/dashboard/stage_strip.go
+++ b/internal/dashboard/stage_strip.go
@@ -1,0 +1,62 @@
+package dashboard
+
+import (
+	"strings"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// maxStageStripGlyphs caps how many stage-event glyphs are shown on a single
+// execution card, so the strip stays compact regardless of how many stage
+// transitions (including retries) accumulated over a long-running execution.
+const maxStageStripGlyphs = 8
+
+// maxStageStripLabelWidth caps the trailing stage-name label so a long enum
+// value (e.g. "awaiting_approval") can't blow the card's fixed layout budget.
+const maxStageStripLabelWidth = 20
+
+// stageStripFailureStages are the terminal stages that render as a ✗ glyph in
+// the stage strip; every other recorded stage renders as ✓.
+var stageStripFailureStages = map[memory.Stage]bool{
+	memory.StageFailed:   true,
+	memory.StageCIFailed: true,
+	memory.StageStalled:  true,
+}
+
+// buildStageStrip renders a compact per-event glyph strip (e.g. "✓✓✓✗ running")
+// from an execution's execution_events timeline (GH-3849). The trailing label
+// names the current stage — or, when the last event is a failure, the last
+// stage successfully reached before it failed.
+//
+// Falls back to a single ✓/✗ glyph derived from the execution's terminal
+// status when no events are recorded: executions predating the events table
+// (GH-3844), or before the dispatcher/runner emit events per GH-3846.
+func buildStageStrip(events []*memory.Event, executionFailed bool) string {
+	if len(events) == 0 {
+		if executionFailed {
+			return "✗"
+		}
+		return "✓"
+	}
+
+	shown := events
+	if len(shown) > maxStageStripGlyphs {
+		shown = shown[len(shown)-maxStageStripGlyphs:]
+	}
+
+	var glyphs strings.Builder
+	for _, e := range shown {
+		if stageStripFailureStages[e.Stage] {
+			glyphs.WriteString("✗")
+		} else {
+			glyphs.WriteString("✓")
+		}
+	}
+
+	labelStage := events[len(events)-1].Stage
+	if stageStripFailureStages[labelStage] && len(events) >= 2 {
+		labelStage = events[len(events)-2].Stage
+	}
+
+	return glyphs.String() + " " + truncateString(string(labelStage), maxStageStripLabelWidth)
+}

--- a/internal/dashboard/stage_strip_test.go
+++ b/internal/dashboard/stage_strip_test.go
@@ -1,0 +1,113 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+func evt(stage memory.Stage) *memory.Event {
+	return &memory.Event{Stage: stage}
+}
+
+func TestBuildStageStrip_NoEvents(t *testing.T) {
+	if got := buildStageStrip(nil, false); got != "✓" {
+		t.Errorf("no events, not failed: got %q, want %q", got, "✓")
+	}
+	if got := buildStageStrip(nil, true); got != "✗" {
+		t.Errorf("no events, failed: got %q, want %q", got, "✗")
+	}
+}
+
+func TestBuildStageStrip_HappyPath(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StageQueued),
+		evt(memory.StageSpecValidated),
+		evt(memory.StageRunning),
+		evt(memory.StageCommit),
+		evt(memory.StagePRCreated),
+		evt(memory.StageMerged),
+	}
+	got := buildStageStrip(events, false)
+	want := "✓✓✓✓✓✓ merged"
+	if got != want {
+		t.Errorf("happy path: got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "✗") {
+		t.Errorf("happy path strip should not contain a failure glyph: %q", got)
+	}
+}
+
+func TestBuildStageStrip_InProgress(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StageQueued),
+		evt(memory.StageSpecValidated),
+		evt(memory.StageRunning),
+	}
+	got := buildStageStrip(events, false)
+	want := "✓✓✓ running"
+	if got != want {
+		t.Errorf("in-progress: got %q, want %q", got, want)
+	}
+}
+
+func TestBuildStageStrip_FailedAtStageN(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StageQueued),
+		evt(memory.StageSpecValidated),
+		evt(memory.StageRunning),
+		evt(memory.StageFailed),
+	}
+	got := buildStageStrip(events, true)
+	want := "✓✓✓✗ running"
+	if got != want {
+		t.Errorf("failed-at-stage-N: got %q, want %q", got, want)
+	}
+}
+
+// TestBuildStageStrip_FailedAsFirstEvent covers the edge case where the only
+// recorded event is itself a failure — there's no prior stage to name, so the
+// label falls back to the failure stage's own name.
+func TestBuildStageStrip_FailedAsFirstEvent(t *testing.T) {
+	events := []*memory.Event{evt(memory.StageFailed)}
+	got := buildStageStrip(events, true)
+	want := "✗ failed"
+	if got != want {
+		t.Errorf("failed as first event: got %q, want %q", got, want)
+	}
+}
+
+// TestBuildStageStrip_CapsGlyphCount ensures a long retry-heavy timeline stays
+// compact rather than growing unboundedly.
+func TestBuildStageStrip_CapsGlyphCount(t *testing.T) {
+	events := make([]*memory.Event, 0, 20)
+	for i := 0; i < 20; i++ {
+		events = append(events, evt(memory.StageRunning))
+	}
+	got := buildStageStrip(events, false)
+	glyphs := strings.SplitN(got, " ", 2)[0]
+	if len([]rune(glyphs)) != maxStageStripGlyphs {
+		t.Errorf("glyph count = %d, want capped at %d", len([]rune(glyphs)), maxStageStripGlyphs)
+	}
+}
+
+// TestBuildStageStrip_TruncatesLongLabel guards the fixed-width card layout
+// against an oversized stage/detail value.
+func TestBuildStageStrip_TruncatesLongLabel(t *testing.T) {
+	events := []*memory.Event{evt(memory.Stage(strings.Repeat("x", 40)))}
+	got := buildStageStrip(events, false)
+	label := strings.SplitN(got, " ", 2)[1]
+	if len(label) > maxStageStripLabelWidth {
+		t.Errorf("label length = %d, want <= %d: %q", len(label), maxStageStripLabelWidth, label)
+	}
+}
+
+func TestBuildStageStrip_CIFailedAndStalledAreFailureGlyphs(t *testing.T) {
+	if got := buildStageStrip([]*memory.Event{evt(memory.StageCIFailed)}, true); !strings.HasPrefix(got, "✗") {
+		t.Errorf("ci_failed should render as a failure glyph: %q", got)
+	}
+	if got := buildStageStrip([]*memory.Event{evt(memory.StageStalled)}, true); !strings.HasPrefix(got, "✗") {
+		t.Errorf("stalled should render as a failure glyph: %q", got)
+	}
+}

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -360,6 +360,11 @@ type CompletedTask struct {
 	// PeakRSSMB is the peak subprocess RSS in MiB from the RSS sampler. GH-3028.
 	// Zero when the sampler had no data (pre-3028 executions, non-Linux/darwin).
 	PeakRSSMB int
+	// StageStrip is a compact per-stage glyph strip (e.g. "✓✓✓✗ running") built
+	// from the execution's execution_events timeline (GH-3849). Empty when the
+	// task wasn't hydrated from the store (e.g. AddCompletedTask callers), in
+	// which case the card falls back to the plain status icon.
+	StageStrip string
 }
 
 // UpdateInfo contains information about an available update
@@ -629,6 +634,13 @@ func (m *Model) hydrateFromStore() {
 		if exec.CompletedAt != nil {
 			completedAt = *exec.CompletedAt
 		}
+		// GH-3849: fetch the stage timeline once here (hydrate runs once per
+		// process start, not per render frame) and cache the derived strip on
+		// the CompletedTask so View() never hits the store.
+		events, err := m.store.ListExecutionEvents(exec.ID)
+		if err != nil {
+			slog.Warn("failed to load execution events", slog.Any("error", err), slog.String("execution_id", exec.ID))
+		}
 		m.completedTasks = append(m.completedTasks, CompletedTask{
 			ID:          exec.TaskID,
 			Title:       exec.TaskTitle,
@@ -636,6 +648,7 @@ func (m *Model) hydrateFromStore() {
 			Duration:    fmt.Sprintf("%dms", exec.DurationMs),
 			CompletedAt: completedAt,
 			PeakRSSMB:   exec.PeakRSSMB,
+			StageStrip:  buildStageStrip(events, status == "failed"),
 		})
 	}
 
@@ -878,6 +891,12 @@ func storeRefreshCmd(store *memory.Store, projectPath string) tea.Cmd {
 			if exec.CompletedAt != nil {
 				completedAt = *exec.CompletedAt
 			}
+			// GH-3849: fetched once per periodic refresh (every 5th tick), not
+			// per render frame — View() reads the cached CompletedTask.StageStrip.
+			events, err := store.ListExecutionEvents(exec.ID)
+			if err != nil {
+				slog.Warn("store refresh: failed to load execution events", slog.Any("error", err), slog.String("execution_id", exec.ID))
+			}
 			msg.completedTasks = append(msg.completedTasks, CompletedTask{
 				ID:          exec.TaskID,
 				Title:       exec.TaskTitle,
@@ -885,6 +904,7 @@ func storeRefreshCmd(store *memory.Store, projectPath string) tea.Cmd {
 				Duration:    fmt.Sprintf("%dms", exec.DurationMs),
 				CompletedAt: completedAt,
 				PeakRSSMB:   exec.PeakRSSMB,
+				StageStrip:  buildStageStrip(events, status == "failed"),
 			})
 		}
 
@@ -2574,10 +2594,20 @@ func (m Model) renderHistory() string {
 
 // renderStandaloneLine renders a standalone (non-epic) task line.
 // Layout: "  + GH-156  Title...                                    2m ago"
-// indent(2) + icon(1) + space(1) + id(7) + space(2) + title + space(2) + timeAgo(8) = iw
+// indent(2) + strip(variable) + space(1) + id(7) + space(2) + title + space(2) + timeAgo(8) = iw
 // When PeakRSSMB > 0 (GH-3028), an RSS indicator ("4.2G") is appended after the time.
+// GH-3849: the leading glyph column shows the cached StageStrip (e.g. "✓✓✓✗ running")
+// when the task was hydrated from the store; falls back to the plain status icon
+// otherwise (e.g. live completions added via AddCompletedTask).
 func renderStandaloneLine(task CompletedTask, iw int) string {
 	icon, style := statusIconStyle(task.Status)
+	stripText := task.StageStrip
+	if stripText == "" {
+		stripText = icon
+	}
+	strip := style.Render(stripText)
+	stripWidth := lipgloss.Width(strip)
+
 	timeAgoStr := formatTimeAgo(task.CompletedAt)
 
 	var rssStr string
@@ -2585,15 +2615,15 @@ func renderStandaloneLine(task CompletedTask, iw int) string {
 		rssStr = fmt.Sprintf(" %s", formatRSSMB(task.PeakRSSMB))
 	}
 
-	// Reserve space: indent(2)+icon(1)+sp(1)+id(7)+sp(2)+sp(2)+time(8)+rss = 23+len(rssStr)
-	titleWidth := iw - 23 - len(rssStr)
+	// Reserve space: indent(2)+strip+sp(1)+id(7)+sp(2)+sp(2)+time(8)+rss
+	titleWidth := iw - 2 - stripWidth - 1 - 7 - 2 - 2 - 8 - len(rssStr)
 	if titleWidth < 10 {
 		titleWidth = 10
 	}
 	titleStr := padOrTruncate(task.Title, titleWidth)
 
 	return fmt.Sprintf("  %s %-7s  %s  %8s%s",
-		style.Render(icon),
+		strip,
 		task.ID,
 		titleStr,
 		dimStyle.Render(timeAgoStr),

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -713,6 +713,71 @@ func TestRenderHistory_StandaloneTask(t *testing.T) {
 	}
 }
 
+// TestRenderHistory_StageStrip verifies the compact per-stage glyph strip
+// (GH-3849) renders in place of the plain status icon for happy path,
+// in-progress, and failed-at-stage-N executions, and that the fixed card
+// width invariant still holds regardless of strip length.
+func TestRenderHistory_StageStrip(t *testing.T) {
+	m := NewModel("test")
+	m.completedTasks = []CompletedTask{
+		{
+			ID:          "GH-200",
+			Title:       "Happy path task",
+			Status:      "success",
+			Duration:    "3m",
+			CompletedAt: time.Now().Add(-3 * time.Minute),
+			StageStrip: buildStageStrip([]*memory.Event{
+				evt(memory.StageQueued),
+				evt(memory.StageSpecValidated),
+				evt(memory.StageRunning),
+				evt(memory.StageCommit),
+				evt(memory.StagePRCreated),
+				evt(memory.StageMerged),
+			}, false),
+		},
+		{
+			ID:          "GH-201",
+			Title:       "In progress task",
+			Status:      "success",
+			Duration:    "1m",
+			CompletedAt: time.Now().Add(-1 * time.Minute),
+			StageStrip: buildStageStrip([]*memory.Event{
+				evt(memory.StageQueued),
+				evt(memory.StageSpecValidated),
+				evt(memory.StageRunning),
+			}, false),
+		},
+		{
+			ID:          "GH-202",
+			Title:       "Failed at stage N task",
+			Status:      "failed",
+			Duration:    "45s",
+			CompletedAt: time.Now().Add(-10 * time.Minute),
+			StageStrip: buildStageStrip([]*memory.Event{
+				evt(memory.StageQueued),
+				evt(memory.StageSpecValidated),
+				evt(memory.StageRunning),
+				evt(memory.StageFailed),
+			}, true),
+		},
+	}
+
+	output := m.renderHistory()
+	assertPanelLineWidths(t, output)
+
+	plain := stripANSI(output)
+
+	if !strings.Contains(plain, "✓✓✓✓✓✓ merged") {
+		t.Errorf("happy path stage strip not found in output:\n%s", plain)
+	}
+	if !strings.Contains(plain, "✓✓✓ running") {
+		t.Errorf("in-progress stage strip not found in output:\n%s", plain)
+	}
+	if !strings.Contains(plain, "✓✓✓✗ running") {
+		t.Errorf("failed-at-stage-N stage strip not found in output:\n%s", plain)
+	}
+}
+
 func TestRenderHistory_ActiveEpicWithMixedStates(t *testing.T) {
 	now := time.Now()
 	m := NewModel("test")


### PR DESCRIPTION
## Summary
- Replaces the binary success/failed collapse on HISTORY panel cards (`internal/dashboard/tui.go` `hydrateFromStore`/`storeRefreshCmd`) with a compact per-stage glyph strip (e.g. `✓✓✓✗ running`), built from `store.ListExecutionEvents` for the card's execution.
- Event list is fetched once at hydrate time and once per periodic store refresh (every 5th tick), then cached on `CompletedTask.StageStrip` — `View()`/render never hits the store.
- Falls back to the previous single ✓/✗ icon when no events are recorded (pre-GH-3844 executions, or executions from before the dispatcher/runner emit stage events per GH-3846) or when a `CompletedTask` wasn't hydrated from the store (e.g. `AddCompletedTask` live-completion callers).

Closes #3849 (parent: #3840).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New unit tests for `buildStageStrip` covering happy path, in-progress, failed-at-stage-N, empty-events fallback, glyph-count cap, and label-truncation
- [x] Updated `TestRenderHistory_StandaloneTask`-adjacent coverage with a new `TestRenderHistory_StageStrip` test asserting the strip renders for happy path / in-progress / failed-at-stage-N, and that the fixed HISTORY card width invariant still holds