### PR TITLE
feat(cli): add pilot trace <task-id> command

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -270,6 +270,7 @@
 | Interactive replay | ✅ | replay | `pilot replay play` | - | TUI viewer |
 | Analyze recording | ✅ | replay | `pilot replay analyze` | - | Token/phase breakdown |
 | Export recording | ✅ | replay | `pilot replay export` | - | HTML/JSON/Markdown |
+| Execution stage trace | ✅ | cmd/pilot | `pilot trace <task-id>` | - | Renders `execution_events` timeline per execution (newest first, UTC timestamps + inter-stage durations); consumes TASK-379 C3 data layer (GH-3848) |
 
 ## Reports & Briefs
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -201,6 +201,7 @@ func main() {
 		newCompletionCmd(),
 		newConfigCmd(),
 		newLogsCmd(),
+		newTraceCmd(),
 		newWebhooksCmd(),
 		newUpgradeCmd(),
 		newReleaseCmd(),

--- a/cmd/pilot/testdata/trace_GH-42.golden
+++ b/cmd/pilot/testdata/trace_GH-42.golden
@@ -1,0 +1,13 @@
+Execution 1/2: exec-2 (status: completed)
+------------------------------------------------------------
+  2026-07-04 10:10:00 UTC  queued                         retry
+  2026-07-04 10:10:05 UTC  running            +5s
+  2026-07-04 10:12:00 UTC  commit             +1m55s      abc123
+  2026-07-04 10:12:30 UTC  pr_created         +30s        PR #99
+  2026-07-04 10:15:00 UTC  merged             +2m30s
+
+Execution 2/2: exec-1 (status: failed)
+------------------------------------------------------------
+  2026-07-04 10:00:00 UTC  queued                         picked up from queue
+  2026-07-04 10:00:05 UTC  running            +5s
+  2026-07-04 10:02:00 UTC  failed             +1m55s      build failed

--- a/cmd/pilot/trace.go
+++ b/cmd/pilot/trace.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/qf-studio/pilot/internal/config"
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// newTraceCmd implements `pilot trace <task-id>` (TASK-379 C4 / GH-3848): it
+// renders the execution_events stage timeline for every execution recorded
+// for a task, so retries and stage-level durations are visible without
+// grepping raw logs.
+func newTraceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "trace <task-id>",
+		Short: "Render the stage-transition timeline for a task's executions",
+		Long: `Render the stage-transition timeline recorded in execution_events for
+every execution of a task, newest execution first. Retries are rendered as
+separate blocks; each stage line shows a UTC timestamp and the duration since
+the previous stage.
+
+Examples:
+  pilot trace GH-42       # Show the stage timeline for task GH-42
+  pilot trace TASK-379    # Show the stage timeline for a Navigator task ID`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath := cfgFile
+			if configPath == "" {
+				configPath = config.DefaultConfigPath()
+			}
+
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("failed to load config: %w", err)
+			}
+
+			store, err := memory.NewStore(cfg.Memory.Path)
+			if err != nil {
+				return fmt.Errorf("failed to open memory store: %w", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			return runTrace(cmd.OutOrStdout(), store, args[0])
+		},
+	}
+
+	return cmd
+}
+
+// runTrace writes the stage timeline for every execution of taskID to w,
+// newest execution first (matching store.ListExecutionsForTask). Returns an
+// error naming taskID when no executions are recorded, so the CLI exits
+// non-zero with a clear message instead of printing an empty report.
+func runTrace(w io.Writer, store *memory.Store, taskID string) error {
+	executions, err := store.ListExecutionsForTask(taskID)
+	if err != nil {
+		return fmt.Errorf("failed to look up task %s: %w", taskID, err)
+	}
+	if len(executions) == 0 {
+		return fmt.Errorf("no executions found for task %s", taskID)
+	}
+
+	for i, exec := range executions {
+		events, err := store.ListExecutionEvents(exec.ID)
+		if err != nil {
+			return fmt.Errorf("failed to load stage events for execution %s: %w", exec.ID, err)
+		}
+
+		_, _ = fmt.Fprintf(w, "Execution %d/%d: %s (status: %s)\n", i+1, len(executions), exec.ID, exec.Status)
+		_, _ = fmt.Fprintln(w, strings.Repeat("-", 60))
+		writeEventTimeline(w, events)
+
+		if i < len(executions)-1 {
+			_, _ = fmt.Fprintln(w)
+		}
+	}
+
+	return nil
+}
+
+// writeEventTimeline renders one execution's stage events in chronological
+// order (the order ListExecutionEvents already returns them in): a UTC
+// timestamp, the stage name, the duration since the previous stage (blank
+// for the first event), and any detail text.
+func writeEventTimeline(w io.Writer, events []*memory.Event) {
+	if len(events) == 0 {
+		_, _ = fmt.Fprintln(w, "  (no stage events recorded)")
+		return
+	}
+
+	var prev time.Time
+	for i, e := range events {
+		ts := e.OccurredAt.UTC().Format("2006-01-02 15:04:05 UTC")
+
+		duration := ""
+		if i > 0 {
+			duration = "+" + e.OccurredAt.Sub(prev).Round(time.Second).String()
+		}
+
+		line := fmt.Sprintf("  %s  %-18s %-10s", ts, e.Stage, duration)
+		if e.Detail != "" {
+			line += "  " + e.Detail
+		}
+		_, _ = fmt.Fprintln(w, strings.TrimRight(line, " "))
+
+		prev = e.OccurredAt
+	}
+}

--- a/cmd/pilot/trace_test.go
+++ b/cmd/pilot/trace_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// newTraceTestStore creates a real, file-backed memory.Store (matching
+// production schema/migrations) for trace tests, and returns both the store
+// and its underlying pilot.db path so tests can seed deterministic
+// occurred_at timestamps directly (InsertExecutionEvent always stamps
+// time.Now().UTC(), which golden-file assertions can't depend on).
+func newTraceTestStore(t *testing.T) (*memory.Store, string) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "pilot-test-trace-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	return store, filepath.Join(tmpDir, "pilot.db")
+}
+
+// seedEventAt inserts an execution_events row with an explicit occurred_at,
+// bypassing store.InsertExecutionEvent (which always uses time.Now().UTC())
+// so the golden fixture has stable, reproducible timestamps.
+func seedEventAt(t *testing.T, dbPath string, executionID string, stage memory.Stage, detail string, occurredAt time.Time) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec(
+		`INSERT INTO execution_events (execution_id, stage, occurred_at, detail) VALUES (?, ?, ?, ?)`,
+		executionID, string(stage), occurredAt, detail,
+	); err != nil {
+		t.Fatalf("seed event failed: %v", err)
+	}
+}
+
+func TestRunTrace_UnknownTaskID(t *testing.T) {
+	store, _ := newTraceTestStore(t)
+
+	var buf bytes.Buffer
+	err := runTrace(&buf, store, "GH-does-not-exist")
+	if err == nil {
+		t.Fatal("expected error for unknown task id, got nil")
+	}
+	want := "no executions found for task GH-does-not-exist"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no output on error, got %q", buf.String())
+	}
+}
+
+// TestRunTrace_Golden seeds two executions (a failed attempt followed by a
+// successful retry) for the same task and checks the rendered timeline
+// against a golden fixture: newest execution first, each in its own block,
+// with UTC timestamps and inter-stage durations.
+func TestRunTrace_Golden(t *testing.T) {
+	store, dbPath := newTraceTestStore(t)
+
+	base := time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC)
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-1",
+		TaskID:      "GH-42",
+		ProjectPath: "/project",
+		Status:      "failed",
+	}); err != nil {
+		t.Fatalf("SaveExecution(exec-1) failed: %v", err)
+	}
+	seedEventAt(t, dbPath, "exec-1", memory.StageQueued, "picked up from queue", base)
+	seedEventAt(t, dbPath, "exec-1", memory.StageRunning, "", base.Add(5*time.Second))
+	seedEventAt(t, dbPath, "exec-1", memory.StageFailed, "build failed", base.Add(2*time.Minute))
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-2",
+		TaskID:      "GH-42",
+		ProjectPath: "/project",
+		Status:      "completed",
+	}); err != nil {
+		t.Fatalf("SaveExecution(exec-2) failed: %v", err)
+	}
+	retryBase := base.Add(10 * time.Minute)
+	seedEventAt(t, dbPath, "exec-2", memory.StageQueued, "retry", retryBase)
+	seedEventAt(t, dbPath, "exec-2", memory.StageRunning, "", retryBase.Add(5*time.Second))
+	seedEventAt(t, dbPath, "exec-2", memory.StageCommit, "abc123", retryBase.Add(2*time.Minute))
+	seedEventAt(t, dbPath, "exec-2", memory.StagePRCreated, "PR #99", retryBase.Add(2*time.Minute+30*time.Second))
+	seedEventAt(t, dbPath, "exec-2", memory.StageMerged, "", retryBase.Add(5*time.Minute))
+
+	var buf bytes.Buffer
+	if err := runTrace(&buf, store, "GH-42"); err != nil {
+		t.Fatalf("runTrace failed: %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "trace_GH-42.golden")
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("failed to read golden file %s: %v", goldenPath, err)
+	}
+
+	if buf.String() != string(want) {
+		t.Errorf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", buf.String(), string(want))
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `pilot trace <task-id>`: resolves executions for a task via `store.ListExecutionsForTask` (newest first) and renders each execution's `ListExecutionEvents` stage timeline with UTC timestamps and inter-stage durations.
- Multiple executions (retries) render as separate labeled blocks.
- Unknown task-id returns a clear `no executions found for task <id>` error with non-zero exit.
- Golden-file test (`cmd/pilot/testdata/trace_GH-42.golden`) against a seeded store fixture covering a failed execution followed by a successful retry.

Closes #3848 (subtask of #3840).

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/pilot/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] Manually built the binary and ran `pilot trace <unknown>` (non-zero exit, clear error) and `pilot trace <seeded-task>` against a real seeded store to confirm rendering.