### PR TITLE
feat(autopilot): emit PR stage events from controller

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -404,6 +404,7 @@
 | Board sync owner guard | ✅ | adapters/github | - | - | Guard owner extraction in board sync construction (v2.30.0, PR #1871) |
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
+| PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
 
 ## Epic Management
 

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -19,10 +19,16 @@ import (
 )
 
 // approvalPersister is the subset of memory.Store used for approval persistence
-// in the executions table.
+// and execution-event audit-trail writes in the executions / execution_events
+// tables. GH-3847: PR stage transitions are recorded here so the audit trail
+// survives autopilot's own PR-state-row cleanup after merge (state_store.go
+// deletes the row; execution_events is keyed off executions.id, not the PR
+// state row, so it is unaffected).
 type approvalPersister interface {
 	SetApprovalRequestID(ctx context.Context, taskID, requestID string) error
 	SetApprovalDecision(ctx context.Context, requestID, decision, by string) error
+	GetLatestExecutionByTaskID(taskID string) (*memory.Execution, error)
+	InsertExecutionEvent(executionID string, stage memory.Stage, detail string) error
 }
 
 // projectBoardSyncer abstracts GitHub Projects V2 board status updates.
@@ -413,6 +419,62 @@ func (c *Controller) persistRemovePR(prNumber int) {
 	}
 }
 
+// executionEventStageFor maps a PRStage to the memory.Stage recorded in the
+// execution-events audit trail. Only the subset of PRStages that mark a
+// durable milestone (as opposed to an in-progress poll state like
+// StageWaitingCI) has an entry; ok is false for everything else, so callers
+// skip the write instead of logging noise for every poll cycle.
+func executionEventStageFor(prStage PRStage) (memory.Stage, bool) {
+	switch prStage {
+	case StageCIPassed:
+		return memory.StageCIPassed, true
+	case StageCIFailed:
+		return memory.StageCIFailed, true
+	case StageAwaitApproval:
+		return memory.StageAwaitingApproval, true
+	case StageMerged:
+		return memory.StageMerged, true
+	case StageFailed:
+		return memory.StageFailed, true
+	default:
+		return "", false
+	}
+}
+
+// recordExecutionEvent writes a best-effort audit-trail entry for prState's
+// current stage to the execution_events table (GH-3847). It resolves the
+// execution row via the same "GH-<issue>" task ID used for approval
+// persistence, so it survives autopilot's own PR-state-row cleanup — the
+// event is keyed off executions.id, not the PR state row that gets deleted
+// after a successful merge.
+//
+// Failures (no memory store wired, no matching execution row, insert error)
+// are logged and swallowed: the audit trail is a diagnostic aid, not load-
+// bearing for the state machine, so a lookup miss must never fail the PR's
+// processing cycle.
+func (c *Controller) recordExecutionEvent(prState *PRState, stage memory.Stage, detail string) {
+	if c.memoryStore == nil {
+		return
+	}
+
+	taskID := fmt.Sprintf("GH-%d", prState.IssueNumber)
+	if prState.IssueNumber == 0 {
+		taskID = fmt.Sprintf("PR-%d", prState.PRNumber)
+	}
+
+	exec, err := c.memoryStore.GetLatestExecutionByTaskID(taskID)
+	if err != nil {
+		c.log.Warn("execution audit trail: no execution row for task, skipping event",
+			"pr", prState.PRNumber, "task_id", taskID, "stage", stage, "error", err)
+		return
+	}
+
+	if err := c.memoryStore.InsertExecutionEvent(exec.ID, stage, detail); err != nil {
+		c.log.Warn("execution audit trail: failed to insert execution event",
+			"pr", prState.PRNumber, "execution_id", exec.ID, "stage", stage, "error", err)
+	}
+}
+
 // persistPRFailures saves per-PR failure state to the store if available.
 func (c *Controller) persistPRFailures(prNumber int, state *prFailureState) {
 	if c.stateStore == nil {
@@ -685,6 +747,13 @@ func (c *Controller) ProcessPR(ctx context.Context, prNumber int, ghPR *github.P
 		c.lastProgressAt = time.Now()
 		c.deadlockAlertSent = false
 		c.mu.Unlock()
+
+		// GH-3847: record durable-milestone transitions to the execution-events
+		// audit trail. Best-effort — see recordExecutionEvent.
+		if eventStage, ok := executionEventStageFor(prState.Stage); ok {
+			detail := fmt.Sprintf("pr #%d: %s -> %s", prNumber, previousStage, prState.Stage)
+			c.recordExecutionEvent(prState, eventStage, detail)
+		}
 	}
 
 	if err != nil {
@@ -2239,6 +2308,13 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 			}
 		}
 	}
+
+	// GH-3847: unlike ci_passed/ci_failed/awaiting_approval/merged/failed, a
+	// successful release never changes prState.Stage (it stays StageReleasing
+	// until removePR below), so it can't be caught by ProcessPR's stage-diff
+	// hook — record it explicitly here instead.
+	c.recordExecutionEvent(prState, memory.StageReleased,
+		fmt.Sprintf("pr #%d: released %s (tag %s)", prState.PRNumber, prState.ReleaseVersion, tagName))
 
 	c.removePR(prState.PRNumber)
 	return nil

--- a/internal/autopilot/controller_execution_events_test.go
+++ b/internal/autopilot/controller_execution_events_test.go
@@ -1,0 +1,210 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestController_ExecutionEvents_PRLifecycle drives ProcessPR through a full
+// happy-path PR lifecycle (waiting_ci → ci_passed → merging → merged →
+// releasing → released) and a CI-failure branch (waiting_ci → ci_failed →
+// failed), asserting InsertExecutionEvent is called with the right stage at
+// each durable milestone (GH-3847).
+//
+// Both cases resolve execution rows through the mock's execByTask map keyed by
+// "GH-<issue>" — the same task ID scheme handleAwaitApproval/SetApprovalDecision
+// already use to address the executions table — so the audit trail write is
+// exercised end to end, not just the in-package mapping helper.
+func TestController_ExecutionEvents_PRLifecycle(t *testing.T) {
+	tests := []struct {
+		name       string
+		buildSteps func(t *testing.T) (server *httptest.Server, prNumber int, issueNumber int, headSHA string, cfgure func(cfg *Config))
+		wantStages []memory.Stage
+	}{
+		{
+			name:       "happy path: CI passes, merges, and releases",
+			buildSteps: buildHappyPathServer,
+			wantStages: []memory.Stage{
+				memory.StageCIPassed,
+				memory.StageMerged,
+				memory.StageReleased,
+			},
+		},
+		{
+			name:       "CI failure branch",
+			buildSteps: buildCIFailureServer,
+			wantStages: []memory.Stage{
+				memory.StageCIFailed,
+				memory.StageFailed,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, prNumber, issueNumber, headSHA, configure := tt.buildSteps(t)
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.Environment = EnvStage
+			cfg.AutoReview = false
+			cfg.RequiredChecks = []string{"build"}
+			if configure != nil {
+				configure(cfg)
+			}
+
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			mock := &mockApprovalPersister{
+				execByTask: map[string]string{
+					"GH-10": "exec-gh-10",
+				},
+			}
+			c.memoryStore = mock
+
+			c.OnPRCreated(prNumber, "https://github.com/owner/repo/pull/42", issueNumber, headSHA, "pilot/GH-10", "")
+
+			ctx := context.Background()
+			// Drive the state machine until the PR drains from tracking (merged +
+			// released / failed) or a bound is hit — whichever tests exercise,
+			// neither lifecycle needs more than a handful of ticks.
+			for i := 0; i < 8; i++ {
+				if _, ok := c.GetPRState(prNumber); !ok {
+					break
+				}
+				if err := c.ProcessPR(ctx, prNumber, nil); err != nil {
+					t.Fatalf("ProcessPR tick %d: %v", i, err)
+				}
+			}
+
+			var gotStages []memory.Stage
+			for _, ev := range mock.executionEvents {
+				if ev.executionID != "exec-gh-10" {
+					t.Errorf("execution event executionID = %q, want %q", ev.executionID, "exec-gh-10")
+				}
+				gotStages = append(gotStages, ev.stage)
+			}
+
+			if len(gotStages) != len(tt.wantStages) {
+				t.Fatalf("recorded stages = %v, want %v", gotStages, tt.wantStages)
+			}
+			for i, want := range tt.wantStages {
+				if gotStages[i] != want {
+					t.Errorf("stage[%d] = %q, want %q (full: %v)", i, gotStages[i], want, gotStages)
+				}
+			}
+		})
+	}
+}
+
+// buildHappyPathServer wires a fake GitHub API sufficient to drive a PR all
+// the way from waiting_ci through a released tag: CI success, a clean merge,
+// an empty tag history (no dedup/ancestor short-circuit), a reachable HEAD SHA
+// via the "stage" environment's default branch, and a conventional-commit PR
+// history that triggers a patch release.
+func buildHappyPathServer(t *testing.T) (*httptest.Server, int, int, string, func(cfg *Config)) {
+	t.Helper()
+	const prNumber = 42
+	const issueNumber = 10
+	const headSHA = "abc1234"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/"+headSHA+"/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: "completed", Conclusion: "success"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/pulls/42/merge":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sha":"` + headSHA + `","merged":true,"message":"merged"}`))
+		case r.URL.Path == "/repos/owner/repo/branches/main":
+			resp := github.Branch{Name: "main", Commit: github.BranchCommit{SHA: headSHA}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/compare/"+headSHA+"..."+headSHA:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"identical"}`))
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			// Empty tag history: tagCoveringCommit and GetTagForSHA both see no
+			// prior release, so the dedup/ancestor short-circuits never fire.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case r.URL.Path == "/repos/owner/repo/releases/latest":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+		case r.URL.Path == "/repos/owner/repo/pulls/42/commits":
+			resp := []github.Commit{{SHA: "c1"}}
+			resp[0].Commit.Message = "fix: patch release"
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/git/refs" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+
+	configure := func(cfg *Config) {
+		cfg.Release = &ReleaseConfig{
+			Enabled:         true,
+			Trigger:         "on_merge",
+			TagPrefix:       "v",
+			NotifyOnRelease: false,
+			GenerateSummary: false,
+			RequireCI:       false,
+		}
+	}
+
+	return server, prNumber, issueNumber, headSHA, configure
+}
+
+// buildCIFailureServer wires a fake GitHub API where CI fails, driving the PR
+// through ci_failed → failed (fix-issue creation + PR close).
+func buildCIFailureServer(t *testing.T) (*httptest.Server, int, int, string, func(cfg *Config)) {
+	t.Helper()
+	const prNumber = 42
+	const issueNumber = 10
+	const headSHA = "abc1234"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/"+headSHA+"/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: "completed", Conclusion: "failure"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/issues" && r.Method == http.MethodPost:
+			resp := github.Issue{Number: 100}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == http.MethodPatch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+
+	return server, prNumber, issueNumber, headSHA, nil
+}

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6359,9 +6359,21 @@ func TestController_TwoPRQueue_StalledApprovalDoesNotBlockOther(t *testing.T) {
 
 // mockApprovalPersister records calls to SetApprovalRequestID and SetApprovalDecision
 // so tests can verify that the controller wires through to the memory store.
+// It also backs GH-3847's execution-event audit trail: execByTask lets a test
+// seed which task IDs resolve to which execution rows, and executionEvents
+// records every InsertExecutionEvent call for assertion.
 type mockApprovalPersister struct {
 	requestIDCalls []struct{ taskID, requestID string }
 	decisionCalls  []struct{ requestID, decision, by string }
+
+	execByTask      map[string]string
+	executionEvents []recordedExecutionEvent
+}
+
+type recordedExecutionEvent struct {
+	executionID string
+	stage       memory.Stage
+	detail      string
 }
 
 func (m *mockApprovalPersister) SetApprovalRequestID(_ context.Context, taskID, requestID string) error {
@@ -6371,6 +6383,19 @@ func (m *mockApprovalPersister) SetApprovalRequestID(_ context.Context, taskID, 
 
 func (m *mockApprovalPersister) SetApprovalDecision(_ context.Context, requestID, decision, by string) error {
 	m.decisionCalls = append(m.decisionCalls, struct{ requestID, decision, by string }{requestID, decision, by})
+	return nil
+}
+
+func (m *mockApprovalPersister) GetLatestExecutionByTaskID(taskID string) (*memory.Execution, error) {
+	id, ok := m.execByTask[taskID]
+	if !ok {
+		return nil, sql.ErrNoRows
+	}
+	return &memory.Execution{ID: id, TaskID: taskID}, nil
+}
+
+func (m *mockApprovalPersister) InsertExecutionEvent(executionID string, stage memory.Stage, detail string) error {
+	m.executionEvents = append(m.executionEvents, recordedExecutionEvent{executionID, stage, detail})
 	return nil
 }
 
@@ -6430,6 +6455,14 @@ func (m *errApprovalPersister) SetApprovalRequestID(_ context.Context, _, _ stri
 
 func (m *errApprovalPersister) SetApprovalDecision(_ context.Context, _, _, _ string) error {
 	return m.decisionErr
+}
+
+func (m *errApprovalPersister) GetLatestExecutionByTaskID(_ string) (*memory.Execution, error) {
+	return nil, sql.ErrNoRows
+}
+
+func (m *errApprovalPersister) InsertExecutionEvent(_ string, _ memory.Stage, _ string) error {
+	return nil
 }
 
 // TestController_ApprovalPersistMiss_RequestID verifies that a sql.ErrNoRows from


### PR DESCRIPTION
## Summary

- Hooks `store.InsertExecutionEvent` into `Controller.ProcessPR`'s stage-transition detection, recording `ci_passed`, `ci_failed`, `awaiting_approval`, `merged`, and terminal `failed` PRStage transitions to the `execution_events` audit trail.
- Adds an explicit call in `handleReleasing` for the `released` milestone, since a successful release never changes `prState.Stage` (it stays `StageReleasing` until the PR is drained), so it can't be caught by the generic stage-diff hook.
- Events resolve their execution row via the same `GH-<issue>` task ID scheme already used for approval persistence (`SetApprovalRequestID`/`SetApprovalDecision`), keying the write off `executions.id` rather than the PR state row — the durable audit trail survives autopilot's own state-row cleanup after merge.
- Extends the `approvalPersister` interface (and both test mocks) with `GetLatestExecutionByTaskID` / `InsertExecutionEvent`.

Closes #3847 (subtask of #3840).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (existing suite + new table-driven test)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New `TestController_ExecutionEvents_PRLifecycle` covers a happy-path lifecycle (ci_passed → merged → released) and a CI-failure branch (ci_failed → failed), asserting the recorded stage sequence and that events remain queryable after the PR is drained from tracking (state-row cleanup).