### PR TITLE
feat(executor): emit execution_events stage transitions from dispatcher and runner

### DIFF
--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -761,6 +761,9 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			continue
 		}
 
+		// GH-3846: record queued->running transition to the execution-events audit trail.
+		w.recordExecutionEvent(exec.ID, memory.StageRunning, fmt.Sprintf("worker started task %s", exec.TaskID))
+
 		// Emit progress callback for task started
 		w.runner.EmitProgress(exec.TaskID, "Running", 2, fmt.Sprintf("Worker started: %s", truncateForLog(exec.TaskTitle, 40)))
 
@@ -784,6 +787,8 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			if err := w.store.UpdateExecutionStatus(exec.ID, "failed", execErr.Error()); err != nil {
 				w.log.Error("Failed to update status to failed", slog.Any("error", err))
 			}
+			// GH-3846: record terminal-failure transition to the execution-events audit trail.
+			w.recordExecutionEvent(exec.ID, memory.StageFailed, truncateForLog(execErr.Error(), 200))
 			// Emit progress callback for task failed
 			w.runner.EmitProgress(exec.TaskID, "Failed", 100, fmt.Sprintf("Execution error: %s", truncateForLog(execErr.Error(), 60)))
 		} else if !result.Success {
@@ -801,6 +806,12 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 				w.log.Error("Failed to update execution status",
 					slog.String("status", status), slog.Any("error", err))
 			}
+			// GH-3846: record no_op/skipped transitions to the execution-events audit
+			// trail. Stalled is instrumented at its detection site in runner.go instead;
+			// declined/rate_limited/infra have no execution_events Stage equivalent yet.
+			if stage, ok := dispatchTerminalStage(status); ok {
+				w.recordExecutionEvent(exec.ID, stage, fmt.Sprintf("%s: %s", status, truncateForLog(result.Error, 200)))
+			}
 			// Emit progress callback with a phase that matches the classified outcome.
 			w.runner.EmitProgress(exec.TaskID, terminalPhaseLabel(status), 100,
 				fmt.Sprintf("%s: %s", status, truncateForLog(result.Error, 60)))
@@ -815,6 +826,10 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			// between those two could leave a 'completed' row with an empty pr_url.
 			if err := w.store.MarkExecutionCompleted(exec.ID, result.PRUrl, result.CommitSHA, duration.Milliseconds()); err != nil {
 				w.log.Error("Failed to mark execution completed", slog.Any("error", err))
+			}
+			// GH-3846: record terminal-success transition to the execution-events audit trail.
+			if stage, ok := dispatchSuccessStage(result.PRUrl); ok {
+				w.recordExecutionEvent(exec.ID, stage, fmt.Sprintf("completed with PR: %s", result.PRUrl))
 			}
 			// Emit progress callback for task completed
 			msg := fmt.Sprintf("Completed in %s", duration.Round(time.Second))
@@ -867,6 +882,52 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 		}
 
 		w.currentTaskID.Store("")
+	}
+}
+
+// recordExecutionEvent writes a best-effort stage-transition record to the
+// execution_events audit trail (GH-3846). Mirrors the worker's other store
+// writes here: a nil store or insert failure is logged and swallowed, never
+// fails the worker loop — the audit trail is a diagnostic aid, not load-bearing.
+func (w *ProjectWorker) recordExecutionEvent(executionID string, stage memory.Stage, detail string) {
+	if w.store == nil {
+		return
+	}
+	if err := w.store.InsertExecutionEvent(executionID, stage, detail); err != nil {
+		w.log.Warn("Failed to record execution event",
+			slog.String("execution_id", executionID),
+			slog.String("stage", string(stage)),
+			slog.Any("error", err))
+	}
+}
+
+// dispatchSuccessStage reports the execution_events Stage (and whether to
+// write one) for the dispatcher's terminal-success site. The Stage enum
+// (GH-3840) has no generic "completed" value, so a PR is the only durable
+// milestone this site can map to today — runner.go already emits pr_created
+// at creation time; this dispatcher-level entry marks the run as a whole
+// finishing. Direct-commit tasks with no PR have no matching Stage yet, so
+// they're intentionally left uninstrumented here (GH-3846).
+func dispatchSuccessStage(prURL string) (memory.Stage, bool) {
+	if prURL == "" {
+		return "", false
+	}
+	return memory.StagePRCreated, true
+}
+
+// dispatchTerminalStage maps a dispatcher-classified terminal status (see
+// TerminalStatus) to its execution_events Stage, for the subset that mark a
+// durable milestone. Stalled is instrumented at its detection site in
+// runner.go instead (GH-3846); declined/rate_limited/infra have no Stage
+// enum equivalent yet, so they're skipped rather than mismapped.
+func dispatchTerminalStage(status string) (memory.Stage, bool) {
+	switch status {
+	case "no_op":
+		return memory.StageNoOp, true
+	case "skipped":
+		return memory.StageSkipped, true
+	default:
+		return "", false
 	}
 }
 

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -1422,3 +1422,221 @@ func TestDispatcher_AdoptQueuedProjects_ReportsFailureWithoutAdopting(t *testing
 		t.Errorf("expected no workers adopted when the store query fails, got: %v", status)
 	}
 }
+
+// TestDispatchSuccessStage covers the dispatcher's terminal-success mapping:
+// a PR produces a pr_created event, a PR-less completion (direct-commit mode)
+// has no matching Stage yet and is intentionally left uninstrumented (GH-3846).
+func TestDispatchSuccessStage(t *testing.T) {
+	tests := []struct {
+		name      string
+		prURL     string
+		wantStage memory.Stage
+		wantOK    bool
+	}{
+		{"pr url present", "https://github.com/test/repo/pull/1", memory.StagePRCreated, true},
+		{"no pr url", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stage, ok := dispatchSuccessStage(tt.prURL)
+			if ok != tt.wantOK {
+				t.Errorf("dispatchSuccessStage(%q) ok = %v, want %v", tt.prURL, ok, tt.wantOK)
+			}
+			if stage != tt.wantStage {
+				t.Errorf("dispatchSuccessStage(%q) stage = %q, want %q", tt.prURL, stage, tt.wantStage)
+			}
+		})
+	}
+}
+
+// TestDispatchTerminalStage covers the classified-status → execution_events
+// Stage mapping used at the dispatcher's no_op/skipped instrumentation site
+// (GH-3846). Stalled is instrumented at its detection site in runner.go
+// instead, and declined/rate_limited/infra have no Stage enum equivalent yet
+// — all three must report ok=false rather than a made-up mapping.
+func TestDispatchTerminalStage(t *testing.T) {
+	tests := []struct {
+		status    string
+		wantStage memory.Stage
+		wantOK    bool
+	}{
+		{"no_op", memory.StageNoOp, true},
+		{"skipped", memory.StageSkipped, true},
+		{"stalled", "", false},
+		{"declined", "", false},
+		{"rate_limited", "", false},
+		{"infra", "", false},
+		{"failed", "", false},
+		{"completed", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			stage, ok := dispatchTerminalStage(tt.status)
+			if ok != tt.wantOK {
+				t.Errorf("dispatchTerminalStage(%q) ok = %v, want %v", tt.status, ok, tt.wantOK)
+			}
+			if stage != tt.wantStage {
+				t.Errorf("dispatchTerminalStage(%q) stage = %q, want %q", tt.status, stage, tt.wantStage)
+			}
+		})
+	}
+}
+
+// TestProjectWorker_recordExecutionEvent_NilStore verifies recordExecutionEvent
+// is a no-op when the worker's store is nil, mirroring the Runner-side guard
+// (GH-3846).
+func TestProjectWorker_recordExecutionEvent_NilStore(t *testing.T) {
+	w := &ProjectWorker{log: slog.New(slog.NewTextHandler(os.Stdout, nil))}
+	// Should not panic with nil store
+	w.recordExecutionEvent("exec-1", memory.StageRunning, "test detail")
+}
+
+// syntheticDispatchBackend is a minimal Backend that always succeeds, used to
+// drive a full dispatcher→worker→runner pass without real git/Claude Code
+// tooling (GH-3846).
+type syntheticDispatchBackend struct{}
+
+func (syntheticDispatchBackend) Name() string      { return "synthetic" }
+func (syntheticDispatchBackend) IsAvailable() bool { return true }
+func (syntheticDispatchBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+	return &BackendResult{Success: true, Output: "synthetic success"}, nil
+}
+
+// waitForTerminalStatus polls until the execution leaves "queued"/"running",
+// mirroring the polling pattern in TestDispatcher_BootWithQueuedRows_FIFODrainNoStaleReap.
+func waitForTerminalStatus(t *testing.T, store *memory.Store, execID string, timeout time.Duration) *memory.Execution {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		exec, err := store.GetExecution(execID)
+		if err != nil {
+			t.Fatalf("failed to get execution: %v", err)
+		}
+		if exec.Status != "queued" && exec.Status != "running" {
+			return exec
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("execution %s did not reach a terminal status within %v (last status: %s)", execID, timeout, exec.Status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestDispatcher_SyntheticDispatch_SuccessEventSequence drives a full
+// synthetic dispatch (queue → worker pickup → runner execution → completion)
+// through the real dispatcher and runner, and asserts the execution_events
+// timeline records the expected cross-file sequence: dispatcher's
+// queued→running transition and runner's spec-validated milestone. This task
+// has no PR (CreatePR: false), so the dispatcher's terminal-success write is
+// a no-op by design (see the recordExecutionEvent call site in processQueue)
+// — TestRunner_recordExecutionEvent_WritesEvent covers the pr_created write
+// directly. GH-3846.
+func TestDispatcher_SyntheticDispatch_SuccessEventSequence(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunnerWithBackend(syntheticDispatchBackend{})
+	runner.skipPreflightChecks = true
+	runner.SetLogStore(store)
+	runner.SetRecordingEnabled(false)
+
+	dispatcher := NewDispatcher(store, runner, nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	task := &Task{
+		ID:          "GH-SYNTH-OK",
+		Title:       "Synthetic dispatch success",
+		Description: "GH-3846 synthetic dispatch coverage",
+		ProjectPath: t.TempDir(),
+	}
+
+	execID, err := dispatcher.QueueTask(context.Background(), task)
+	if err != nil {
+		t.Fatalf("failed to queue task: %v", err)
+	}
+
+	exec := waitForTerminalStatus(t, store, execID, 10*time.Second)
+	if exec.Status != "completed" {
+		t.Fatalf("expected status completed, got %q (error: %s)", exec.Status, exec.Error)
+	}
+
+	events, err := store.ListExecutionEvents(execID)
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+
+	wantStages := []memory.Stage{memory.StageRunning, memory.StageSpecValidated}
+	if len(events) != len(wantStages) {
+		var gotStages []memory.Stage
+		for _, e := range events {
+			gotStages = append(gotStages, e.Stage)
+		}
+		t.Fatalf("got %d events %v, want %d %v", len(events), gotStages, len(wantStages), wantStages)
+	}
+	for i, want := range wantStages {
+		if events[i].Stage != want {
+			t.Errorf("event[%d].Stage = %q, want %q", i, events[i].Stage, want)
+		}
+	}
+}
+
+// TestDispatcher_SyntheticDispatch_FailureEventSequence drives a synthetic
+// dispatch that fails preflight checks (real Runner, nonexistent project
+// path — same fast-fail mechanism TestDispatcher_BootWithQueuedRows_
+// FIFODrainNoStaleReap relies on) and asserts the execution_events timeline
+// records dispatcher's queued→running transition, runner's spec-validated
+// milestone, and dispatcher's terminal-failure transition (GH-3846).
+func TestDispatcher_SyntheticDispatch_FailureEventSequence(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	runner.SetLogStore(store)
+
+	dispatcher := NewDispatcher(store, runner, nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	task := &Task{
+		ID:          "GH-SYNTH-FAIL",
+		Title:       "Synthetic dispatch failure",
+		Description: "GH-3846 synthetic dispatch coverage",
+		ProjectPath: "/nonexistent/synthetic-dispatch-path",
+	}
+
+	execID, err := dispatcher.QueueTask(context.Background(), task)
+	if err != nil {
+		t.Fatalf("failed to queue task: %v", err)
+	}
+
+	exec := waitForTerminalStatus(t, store, execID, 10*time.Second)
+	if exec.Status != "failed" {
+		t.Fatalf("expected status failed, got %q", exec.Status)
+	}
+
+	events, err := store.ListExecutionEvents(execID)
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+
+	wantStages := []memory.Stage{memory.StageRunning, memory.StageSpecValidated, memory.StageFailed}
+	if len(events) != len(wantStages) {
+		var gotStages []memory.Stage
+		for _, e := range events {
+			gotStages = append(gotStages, e.Stage)
+		}
+		t.Fatalf("got %d events %v, want %d %v", len(events), gotStages, len(wantStages), wantStages)
+	}
+	for i, want := range wantStages {
+		if events[i].Stage != want {
+			t.Errorf("event[%d].Stage = %q, want %q", i, events[i].Stage, want)
+		}
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1246,6 +1246,23 @@ func (r *Runner) saveLogEntry(executionID, level, message string) {
 	}
 }
 
+// recordExecutionEvent writes a best-effort stage-transition record to the
+// execution_events audit trail (GH-3846). Mirrors saveLogEntry's fire-and-
+// forget semantics: a missing store or insert failure is logged and
+// swallowed, never fails the execution.
+func (r *Runner) recordExecutionEvent(executionID string, stage memory.Stage, detail string) {
+	if r.logStore == nil {
+		return
+	}
+	if err := r.logStore.InsertExecutionEvent(executionID, stage, detail); err != nil {
+		r.log.Warn("Failed to record execution event",
+			slog.String("execution_id", executionID),
+			slog.String("stage", string(stage)),
+			slog.Any("error", err),
+		)
+	}
+}
+
 // Diagnostic truncation caps used by persistBackendDiagnostics. Exposed as
 // constants so tests can assert the ceiling and project-side tooling can
 // depend on a fixed upper bound. GH-2328.
@@ -1556,6 +1573,10 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 			}, fmt.Errorf("cross-project execution blocked: %w", err)
 		}
 	}
+
+	// GH-3846: task spec passed its pre-execution validation gates above — record
+	// the milestone to the execution-events audit trail.
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StageSpecValidated, "task spec validated")
 
 	// GH-634: Enforce team permissions before execution
 	if r.teamChecker != nil && task.MemberID != "" {
@@ -2399,6 +2420,8 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				slog.Duration("duration", duration),
 			)
 			r.reportProgress(task.ID, "Stalled", 100, result.Error)
+			// GH-3846: record stall detection to the execution-events audit trail.
+			r.recordExecutionEvent(task.LogExecutionID(), memory.StageStalled, result.Error)
 			if r.monitor != nil {
 				r.monitor.Stall(task.ID, result.Error)
 			}
@@ -2705,6 +2728,8 @@ retrySucceeded:
 	// Extract commit SHA from state (parsed from Claude Code output)
 	if len(state.commitSHAs) > 0 {
 		result.CommitSHA = state.commitSHAs[len(state.commitSHAs)-1] // Use last commit
+		// GH-3846: record the commit milestone to the execution-events audit trail.
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageCommit, "commit created: "+result.CommitSHA)
 	}
 
 	// GH-3569/GH-3570 incident (TASK-320/TASK-355 root cause): harvest the SHA
@@ -3823,6 +3848,8 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			log.Info("Pull request created", slog.String("pr_url", prURL))
 			r.reportProgress(task.ID, "Completed", 100, fmt.Sprintf("PR created: %s", prURL))
 			r.saveLogEntry(task.LogExecutionID(), "info", "PR created: "+prURL)
+			// GH-3846: record the PR-created milestone to the execution-events audit trail.
+			r.recordExecutionEvent(task.LogExecutionID(), memory.StagePRCreated, "pr created: "+prURL)
 
 			// Update recording with PR info
 			if recorder != nil {

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -3015,6 +3015,88 @@ func TestRunner_saveLogEntry_ErrorLevel(t *testing.T) {
 	}
 }
 
+// TestRunner_recordExecutionEvent_NilStore verifies recordExecutionEvent is a
+// no-op when logStore is nil (GH-3846) — mirrors saveLogEntry's fire-and-forget
+// contract so a Runner without a wired store never panics on a milestone write.
+func TestRunner_recordExecutionEvent_NilStore(t *testing.T) {
+	runner := NewRunner()
+	// Should not panic with nil store
+	runner.recordExecutionEvent("exec-1", memory.StageSpecValidated, "test detail")
+}
+
+// TestRunner_recordExecutionEvent_UnknownExecution verifies recordExecutionEvent
+// swallows the store's error (FK violation: no matching executions row) instead
+// of panicking, and does not leave a dangling event behind. GH-3846.
+func TestRunner_recordExecutionEvent_UnknownExecution(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	runner := NewRunner()
+	runner.SetLogStore(store)
+
+	// Should not panic even though "exec-ghost" was never saved via SaveExecution.
+	runner.recordExecutionEvent("exec-ghost", memory.StageCommit, "commit created: abc1234")
+
+	events, err := store.ListExecutionEvents("exec-ghost")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events for an execution row that was never saved, got %d", len(events))
+	}
+}
+
+// TestRunner_recordExecutionEvent_WritesEvent verifies recordExecutionEvent
+// writes to execution_events and the timeline can be read back in order,
+// covering the spec_validated/commit/pr_created/stalled milestones runner.go
+// emits (GH-3846).
+func TestRunner_recordExecutionEvent_WritesEvent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-runner-42",
+		TaskID:      "GH-42",
+		ProjectPath: "/project",
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	runner := NewRunner()
+	runner.SetLogStore(store)
+
+	runner.recordExecutionEvent("exec-runner-42", memory.StageSpecValidated, "task spec validated")
+	runner.recordExecutionEvent("exec-runner-42", memory.StageCommit, "commit created: abc1234")
+	runner.recordExecutionEvent("exec-runner-42", memory.StagePRCreated, "pr created: https://github.com/test/repo/pull/42")
+
+	events, err := store.ListExecutionEvents("exec-runner-42")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+
+	wantStages := []memory.Stage{memory.StageSpecValidated, memory.StageCommit, memory.StagePRCreated}
+	if len(events) != len(wantStages) {
+		t.Fatalf("got %d events, want %d", len(events), len(wantStages))
+	}
+	for i, want := range wantStages {
+		if events[i].Stage != want {
+			t.Errorf("event[%d].Stage = %q, want %q", i, events[i].Stage, want)
+		}
+		if events[i].ExecutionID != "exec-runner-42" {
+			t.Errorf("event[%d].ExecutionID = %q, want exec-runner-42", i, events[i].ExecutionID)
+		}
+	}
+}
+
 // --- GH-1955: Self-review pattern extraction ---
 
 // mockSelfReviewBackend implements Backend for self-review tests.


### PR DESCRIPTION
## Summary

Closes #3846 (subtask of #3840, TASK-379 V6).

- `internal/executor/dispatcher.go`: `ProjectWorker.processQueue` now writes `execution_events` rows at the queued→running transition, terminal failure, no_op/skipped classified outcomes, and terminal success (mapped to `pr_created` when a PR was produced — the `Stage` enum from #3840 has no generic "completed" value, so PR-less direct-commit completions are left uninstrumented at this site).
- `internal/executor/runner.go`: adds `Runner.recordExecutionEvent`, called at the four milestone sites named in the issue — spec-validated (after the cross-project spec-validation guard), commit (when a commit SHA is first extracted from agent tool output), pr_created (right after PR creation succeeds), and stalled (at stall detection).
- Both files already held a `*memory.Store` handle (`ProjectWorker.store`, `Runner.logStore`), so no new plumbing was required.
- All writes are best-effort/fire-and-forget (nil-store guard + Warn-log-and-swallow on error), mirroring the pattern `autopilot.Controller.recordExecutionEvent` established in the sibling subtask.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/... ./internal/memory/... ./internal/autopilot/... ./internal/dashboard/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New unit tests: `dispatchTerminalStage`/`dispatchSuccessStage` mapping tables, nil-store no-op guards on both `Runner.recordExecutionEvent` and `ProjectWorker.recordExecutionEvent`, and two full synthetic-dispatch tests (`TestDispatcher_SyntheticDispatch_SuccessEventSequence`, `TestDispatcher_SyntheticDispatch_FailureEventSequence`) that drive a real dispatcher+runner pass and assert the recorded `execution_events` stage sequence.