### PR TITLE
ci(canary): add synthetic end-to-end pipeline canary workflow

### DIFF
--- a/.github/workflows/pilot-canary.yml
+++ b/.github/workflows/pilot-canary.yml
@@ -1,0 +1,198 @@
+name: Pilot Synthetic Pipeline Canary
+
+# TASK-379 V8: proves the deployed daemon still ships code end-to-end
+# (poll -> spec -> execute -> PR -> merge) by filing a real issue on a
+# sandbox repo and watching it travel through the real pipeline. Runs
+# from outside the daemon (GitHub Actions) so it survives daemon death.
+#
+# Modeled on the existing production precedent:
+# .github/workflows/brew-tap-token-canary.yml (schedule -> check ->
+# idempotent `gh issue create` on failure).
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'  # every 6 hours
+  workflow_dispatch: {}
+
+env:
+  SANDBOX_REPO: qf-studio/pilot-canary-sandbox
+  ALERT_REPO: qf-studio/pilot
+  # Must exceed the poller's in-memory retry grace period (GH-2201,
+  # internal/adapters/github/poller.go:428, default 5m) so a
+  # slow-but-working run does not false-alarm.
+  CANARY_TIMEOUT_MINUTES: 35
+  POLL_INTERVAL_SECONDS: 60
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Idempotency guard
+        id: guard
+        env:
+          GH_TOKEN: ${{ secrets.CANARY_GH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          OPEN_COUNT=$(gh issue list \
+            --repo "$SANDBOX_REPO" \
+            --label pilot \
+            --state open \
+            --json number \
+            --jq 'length')
+
+          if [ "$OPEN_COUNT" -gt 0 ]; then
+            echo "A pilot-labeled canary issue is already open on $SANDBOX_REPO — a prior run is still in flight. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No open canary issue found — proceeding."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: File synthetic canary issue
+        id: file_issue
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CANARY_GH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          TIMESTAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          TITLE="chore(version): bump patch for canary run $TIMESTAMP"
+          BODY=$(cat <<EOF
+          Synthetic canary run (TASK-379 V8). This issue exists to prove the
+          deployed Pilot daemon still ships code end-to-end.
+
+          Increment the PATCH component of the \`Version\` constant in
+          \`version.go\` by exactly one (e.g. \`0.0.1\` -> \`0.0.2\`). Keep the
+          change to that single line so \`version_test.go\` (semver guard)
+          stays green. Do not touch any other file.
+          EOF
+          )
+
+          ISSUE_URL=$(gh issue create \
+            --repo "$SANDBOX_REPO" \
+            --title "$TITLE" \
+            --label pilot \
+            --body "$BODY")
+
+          ISSUE_NUMBER=$(basename "$ISSUE_URL")
+          echo "Filed canary issue $SANDBOX_REPO#$ISSUE_NUMBER"
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Poll for pipeline progression
+        id: poll
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CANARY_GH_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.file_issue.outputs.issue_number }}
+        run: |
+          set -uo pipefail
+
+          DEADLINE=$(( $(date -u +%s) + CANARY_TIMEOUT_MINUTES * 60 ))
+          STAGE="issue-filed"
+          PR_NUMBER=""
+          RESULT="failure"
+
+          while [ "$(date -u +%s)" -lt "$DEADLINE" ]; do
+            if [ -z "$PR_NUMBER" ]; then
+              # Pilot branches follow `pilot/GH-<issue-number>` (project
+              # convention); fall back to a body reference in case the
+              # branch-naming convention drifts.
+              PR_NUMBER=$(gh pr list \
+                --repo "$SANDBOX_REPO" \
+                --state all \
+                --json number,headRefName,body \
+                --jq --arg n "$ISSUE_NUMBER" \
+                  '[.[] | select(.headRefName == ("pilot/GH-" + $n) or (.body // "" | test("#" + $n)))][0].number // empty')
+
+              if [ -n "$PR_NUMBER" ]; then
+                STAGE="PR-opened"
+                echo "Found PR #$PR_NUMBER referencing canary issue #$ISSUE_NUMBER."
+              fi
+            else
+              PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$SANDBOX_REPO" --json state,mergedAt)
+              PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
+              MERGED_AT=$(echo "$PR_JSON" | jq -r '.mergedAt')
+
+              if [ "$PR_STATE" = "MERGED" ] && [ "$MERGED_AT" != "null" ]; then
+                STAGE="merged"
+                RESULT="success"
+                break
+              elif [ "$PR_STATE" = "CLOSED" ]; then
+                STAGE="merge-stalled"
+                echo "PR #$PR_NUMBER was closed without merging."
+                break
+              fi
+            fi
+
+            sleep "$POLL_INTERVAL_SECONDS"
+          done
+
+          if [ "$RESULT" != "success" ] && [ "$STAGE" != "merge-stalled" ] && [ -n "$PR_NUMBER" ]; then
+            STAGE="merge-stalled"
+          fi
+
+          echo "Final stage: $STAGE (result: $RESULT)"
+          echo "stage=$STAGE" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+
+          if [ "$RESULT" != "success" ]; then
+            exit 1
+          fi
+
+      - name: Close canary issue on success
+        if: steps.guard.outputs.skip != 'true' && steps.poll.outputs.result == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.CANARY_GH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          ISSUE_NUMBER="${{ steps.file_issue.outputs.issue_number }}"
+          STATE=$(gh issue view "$ISSUE_NUMBER" --repo "$SANDBOX_REPO" --json state --jq '.state')
+
+          if [ "$STATE" = "OPEN" ]; then
+            gh issue close "$ISSUE_NUMBER" \
+              --repo "$SANDBOX_REPO" \
+              --comment "Canary PR #${{ steps.poll.outputs.pr_number }} merged — pipeline verified end-to-end."
+          else
+            echo "Canary issue already closed (auto-closed by merge)."
+          fi
+
+      - name: File deduped pipeline-stall alert
+        if: failure() && steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          TITLE="[canary] pipeline stall"
+          STAGE="${{ steps.poll.outputs.stage || 'issue-filed' }}"
+          ISSUE_NUMBER="${{ steps.file_issue.outputs.issue_number }}"
+
+          EXISTING=$(gh issue list \
+            --repo "$ALERT_REPO" \
+            --state open \
+            --search "$TITLE in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" | head -1)
+
+          if [ -n "$EXISTING" ]; then
+            echo "Alert issue #$EXISTING already open — adding status comment."
+            gh issue comment "$EXISTING" \
+              --repo "$ALERT_REPO" \
+              --body "Canary re-triggered $(date -u '+%Y-%m-%d %H:%M UTC'): stalled at stage \`$STAGE\` (canary issue $SANDBOX_REPO#$ISSUE_NUMBER)."
+          else
+            echo "Creating new alert issue."
+            gh issue create \
+              --repo "$ALERT_REPO" \
+              --title "$TITLE" \
+              --label bug \
+              --body "Synthetic end-to-end pipeline canary stalled at stage \`$STAGE\`. Canary issue: $SANDBOX_REPO#$ISSUE_NUMBER. Investigate daemon health (poll -> spec -> execute -> PR -> merge). See TASK-379 V8."
+          fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pilot-canary.yml`: schedule (every 6h) + `workflow_dispatch` synthetic canary that files an issue on `qf-studio/pilot-canary-sandbox`, polls GitHub-visible signals (branch/PR/merge) for terminal state, and asserts the pipeline shipped a PR within a tunable timeout (`CANARY_TIMEOUT_MINUTES`, default 35m — above the GH-2201 poller retry grace period of 5m).
- Idempotency guard prevents stacking a second canary issue while one is open.
- On stall/timeout/PR-closed-unmerged, fails the workflow and files a deduped alert issue on `qf-studio/pilot` (label `bug`, fixed title `[canary] pipeline stall`) naming the last observed stage (`issue-filed` / `PR-opened` / `merge-stalled`), reusing the idempotent-create pattern from `.github/workflows/brew-tap-token-canary.yml`.
- No Go changes — CI workflow only.

Part of TASK-379 V8 (runtime self-verification / synthetic canary). Closes #3862.

## Prerequisites (human, before first run)
- Add repo secret `CANARY_GH_TOKEN` to `qf-studio/pilot` — a PAT with `repo` scope on `qf-studio/pilot-canary-sandbox` (default `GITHUB_TOKEN` can't reach a cross-repo target).
- Daemon needs a restart to pick up the `pilot-canary-sandbox` project already added to `~/.pilot/config.yaml`.

## Test plan
- [ ] YAML validated (`python3 -c "import yaml; yaml.safe_load(open(...))"`) and each `run:` block checked with `bash -n` — both pass.
- [ ] `go build ./...` passes (no Go changes).
- [ ] Manual `workflow_dispatch` run against the sandbox once `CANARY_GH_TOKEN` secret is added — confirm issue → PR → merge → success, and issue closes.
- [ ] Induced-stall run (daemon stopped) — confirm workflow fails and exactly one deduped alert issue is filed on `qf-studio/pilot`; a second failing run adds a comment instead of duplicating.