### PR TITLE
GH-3862: ci(canary): synthetic end-to-end pipeline canary workflow (TASK-379 V8)

### DIFF
--- a/.github/workflows/pilot-canary.yml
+++ b/.github/workflows/pilot-canary.yml
@@ -1,0 +1,198 @@
+name: Pilot Synthetic Pipeline Canary
+
+# TASK-379 V8: proves the deployed daemon still ships code end-to-end
+# (poll -> spec -> execute -> PR -> merge) by filing a real issue on a
+# sandbox repo and watching it travel through the real pipeline. Runs
+# from outside the daemon (GitHub Actions) so it survives daemon death.
+#
+# Modeled on the existing production precedent:
+# .github/workflows/brew-tap-token-canary.yml (schedule -> check ->
+# idempotent `gh issue create` on failure).
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'  # every 6 hours
+  workflow_dispatch: {}
+
+env:
+  SANDBOX_REPO: qf-studio/pilot-canary-sandbox
+  ALERT_REPO: qf-studio/pilot
+  # Must exceed the poller's in-memory retry grace period (GH-2201,
+  # internal/adapters/github/poller.go:428, default 5m) so a
+  # slow-but-working run does not false-alarm.
+  CANARY_TIMEOUT_MINUTES: 35
+  POLL_INTERVAL_SECONDS: 60
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Idempotency guard
+        id: guard
+        env:
+          GH_TOKEN: ${{ secrets.CANARY_GH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          OPEN_COUNT=$(gh issue list \
+            --repo "$SANDBOX_REPO" \
+            --label pilot \
+            --state open \
+            --json number \
+            --jq 'length')
+
+          if [ "$OPEN_COUNT" -gt 0 ]; then
+            echo "A pilot-labeled canary issue is already open on $SANDBOX_REPO — a prior run is still in flight. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No open canary issue found — proceeding."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: File synthetic canary issue
+        id: file_issue
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CANARY_GH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          TIMESTAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          TITLE="chore(version): bump patch for canary run $TIMESTAMP"
+          BODY=$(cat <<EOF
+          Synthetic canary run (TASK-379 V8). This issue exists to prove the
+          deployed Pilot daemon still ships code end-to-end.
+
+          Increment the PATCH component of the \`Version\` constant in
+          \`version.go\` by exactly one (e.g. \`0.0.1\` -> \`0.0.2\`). Keep the
+          change to that single line so \`version_test.go\` (semver guard)
+          stays green. Do not touch any other file.
+          EOF
+          )
+
+          ISSUE_URL=$(gh issue create \
+            --repo "$SANDBOX_REPO" \
+            --title "$TITLE" \
+            --label pilot \
+            --body "$BODY")
+
+          ISSUE_NUMBER=$(basename "$ISSUE_URL")
+          echo "Filed canary issue $SANDBOX_REPO#$ISSUE_NUMBER"
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Poll for pipeline progression
+        id: poll
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CANARY_GH_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.file_issue.outputs.issue_number }}
+        run: |
+          set -uo pipefail
+
+          DEADLINE=$(( $(date -u +%s) + CANARY_TIMEOUT_MINUTES * 60 ))
+          STAGE="issue-filed"
+          PR_NUMBER=""
+          RESULT="failure"
+
+          while [ "$(date -u +%s)" -lt "$DEADLINE" ]; do
+            if [ -z "$PR_NUMBER" ]; then
+              # Pilot branches follow `pilot/GH-<issue-number>` (project
+              # convention); fall back to a body reference in case the
+              # branch-naming convention drifts.
+              PR_NUMBER=$(gh pr list \
+                --repo "$SANDBOX_REPO" \
+                --state all \
+                --json number,headRefName,body \
+                --jq --arg n "$ISSUE_NUMBER" \
+                  '[.[] | select(.headRefName == ("pilot/GH-" + $n) or (.body // "" | test("#" + $n)))][0].number // empty')
+
+              if [ -n "$PR_NUMBER" ]; then
+                STAGE="PR-opened"
+                echo "Found PR #$PR_NUMBER referencing canary issue #$ISSUE_NUMBER."
+              fi
+            else
+              PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$SANDBOX_REPO" --json state,mergedAt)
+              PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
+              MERGED_AT=$(echo "$PR_JSON" | jq -r '.mergedAt')
+
+              if [ "$PR_STATE" = "MERGED" ] && [ "$MERGED_AT" != "null" ]; then
+                STAGE="merged"
+                RESULT="success"
+                break
+              elif [ "$PR_STATE" = "CLOSED" ]; then
+                STAGE="merge-stalled"
+                echo "PR #$PR_NUMBER was closed without merging."
+                break
+              fi
+            fi
+
+            sleep "$POLL_INTERVAL_SECONDS"
+          done
+
+          if [ "$RESULT" != "success" ] && [ "$STAGE" != "merge-stalled" ] && [ -n "$PR_NUMBER" ]; then
+            STAGE="merge-stalled"
+          fi
+
+          echo "Final stage: $STAGE (result: $RESULT)"
+          echo "stage=$STAGE" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+
+          if [ "$RESULT" != "success" ]; then
+            exit 1
+          fi
+
+      - name: Close canary issue on success
+        if: steps.guard.outputs.skip != 'true' && steps.poll.outputs.result == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.CANARY_GH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          ISSUE_NUMBER="${{ steps.file_issue.outputs.issue_number }}"
+          STATE=$(gh issue view "$ISSUE_NUMBER" --repo "$SANDBOX_REPO" --json state --jq '.state')
+
+          if [ "$STATE" = "OPEN" ]; then
+            gh issue close "$ISSUE_NUMBER" \
+              --repo "$SANDBOX_REPO" \
+              --comment "Canary PR #${{ steps.poll.outputs.pr_number }} merged — pipeline verified end-to-end."
+          else
+            echo "Canary issue already closed (auto-closed by merge)."
+          fi
+
+      - name: File deduped pipeline-stall alert
+        if: failure() && steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          TITLE="[canary] pipeline stall"
+          STAGE="${{ steps.poll.outputs.stage || 'issue-filed' }}"
+          ISSUE_NUMBER="${{ steps.file_issue.outputs.issue_number }}"
+
+          EXISTING=$(gh issue list \
+            --repo "$ALERT_REPO" \
+            --state open \
+            --search "$TITLE in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" | head -1)
+
+          if [ -n "$EXISTING" ]; then
+            echo "Alert issue #$EXISTING already open — adding status comment."
+            gh issue comment "$EXISTING" \
+              --repo "$ALERT_REPO" \
+              --body "Canary re-triggered $(date -u '+%Y-%m-%d %H:%M UTC'): stalled at stage \`$STAGE\` (canary issue $SANDBOX_REPO#$ISSUE_NUMBER)."
+          else
+            echo "Creating new alert issue."
+            gh issue create \
+              --repo "$ALERT_REPO" \
+              --title "$TITLE" \
+              --label bug \
+              --body "Synthetic end-to-end pipeline canary stalled at stage \`$STAGE\`. Canary issue: $SANDBOX_REPO#$ISSUE_NUMBER. Investigate daemon health (poll -> spec -> execute -> PR -> merge). See TASK-379 V8."
+          fi


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3862.

Closes #3862

## Changes

GitHub Issue #3862: ci(canary): synthetic end-to-end pipeline canary workflow (TASK-379 V8)

Synthetic end-to-end canary that proves the deployed Pilot daemon still ships code, on a schedule. Part of **TASK-379 V8** (runtime self-verification). Sandbox repo `qf-studio/pilot-canary-sandbox` already exists, is scaffolded (a `Version` const in `version.go` guarded by `version_test.go`), and carries a `pilot` label. The daemon has a `projects:` entry for it.

This issue adds **one GitHub Actions workflow** to the `pilot` repo. No Go changes.

## Context

Every other TASK-379 wave makes a *wire* probeable (doctor, `/ready`, fail-loud alerts). None of them prove the whole pipeline — `poll → spec → execute → PR → merge` — actually ships a PR against real GitHub + real Anthropic. This canary is that proof. It runs from *outside* the daemon (GitHub Actions), so it survives daemon death — which is exactly what it must detect.

Modeled on the existing production precedent `.github/workflows/brew-tap-token-canary.yml` (schedule → check → idempotent `gh issue create` on failure).

## Scope — add `.github/workflows/pilot-canary.yml`

**Trigger:** `schedule` cron every 6 hours + `workflow_dispatch` (for manual runs).

**Steps:**

1. **Idempotency guard** — query open issues on `qf-studio/pilot-canary-sandbox` with label `pilot`. If one already exists (a prior run still in flight), log and exit 0. Do not stack canary issues.
2. **File synthetic issue** on `qf-studio/pilot-canary-sandbox`:
   - Label: `pilot`
   - Title: `chore(version): bump patch for canary run <UTC-timestamp>`
   - Body: instruct incrementing the PATCH component of `Version` in `version.go` by one (e.g. `0.0.1` → `0.0.2`). Keep the change to that one line so `version_test.go` (semver guard) stays green.
   - Capture the created issue number.
3. **Poll for stage progression** (GitHub-visible signals — labels/PR/merge; no dependency on `execution_events`):
   - Wait for a PR whose body/branch references the canary issue to appear.
   - Wait for that PR to reach a terminal state (merged, or closed).
   - Overall timeout **must exceed the poller grace period** (GH-2201, in-memory `p.processed` map + retry grace) so a slow-but-working run does not false-alarm. Propose a 30–45 min ceiling; make it a workflow env var so it's tunable.
4. **Assert + alert:**
   - PR merged within timeout → success. Close the canary issue if the merge did not auto-close it.
   - Stall / timeout / PR closed-unmerged → **fail the workflow** AND file an idempotent alert issue on the **`pilot`** repo (label `bug`, dedupe by a fixed title marker like `[canary] pipeline stall`) naming the last observed stage (issue-filed / PR-opened / merge-stalled). Reuse the brew-canary idempotent-create pattern.

## Prerequisites (human, before first run)

- Add repo secret **`CANARY_GH_TOKEN`** to the `pilot` repo — a PAT with `repo` scope on `qf-studio/pilot-canary-sandbox`. The workflow's default `GITHUB_TOKEN` is scoped to the `pilot` repo only and cannot file issues on a *different* repo.
- Daemon must be running with the `pilot-canary-sandbox` project configured (already added to `~/.pilot/config.yaml`; requires a daemon restart to take effect).

## Acceptance Criteria

- [ ] `.github/workflows/pilot-canary.yml` exists; `workflow_dispatch` runs green end-to-end against the sandbox (issue → PR → merge → assert).
- [ ] Idempotency guard prevents a second canary issue while one is open.
- [ ] Timeout is an env var, set above the poller grace period.
- [ ] On induced stall (e.g. run while daemon is stopped), the workflow fails and files exactly one deduped alert issue on `pilot` naming the stalled stage; a second failing run does not create a duplicate.
- [ ] Synthetic issue title uses `chore(version)` scope so Pilot's sandbox PR scope matches (avoids the scope-drift approval gate).

## Out of Scope

- `execution_events`-based tracing (TASK-379 V6 / #3840) — optional upgrade to the poll step *later*; this canary uses GitHub-visible signals only.
- Any Go code in the `pilot` binary — this is a CI workflow only.
- Sandbox repo scaffolding and the `projects:` config entry — already done.

## Refs

- TASK-379 V8 (`.agent/tasks/TASK-379-runtime-self-verification.md`, Phase D / D2)
- Precedent: `.github/workflows/brew-tap-token-canary.yml`
- Sandbox: https://github.com/qf-studio/pilot-canary-sandbox
- Approval-gate scope-drift knowledge: keep issue-title `type(scope)` aligned with the PR's implementation scope.


## Planned Steps (execute all in sequence)

1. **ci(canary): add pilot-canary GitHub Actions workflow** — Create `.github/workflows/pilot-canary.yml` in the `pilot` repo implementing the full synthetic end-to-end pipeline canary. The workflow must: trigger on `schedule` (cron every 6 hours) and `workflow_dispatch`; authenticate to `qf-studio/pilot-canary-sandbox` using repo secret `CANARY_GH_TOKEN` (default `GITHUB_TOKEN` cannot reach a cross-repo target); implement an idempotency guard that queries open `pilot`-labeled issues on the sandbox and logs + exits 0 if any exist (do not stack canaries); file a synthetic issue on the sandbox with label `pilot`, title `chore(version): bump patch for canary run <UTC-timestamp>` (scope must be `chore(version)` to avoid Pilot's scope-drift approval gate), and body instructing a single-line PATCH bump of `Version` in `version.go` (keeps `version_test.go` semver guard green), capturing the created issue number; poll for pipeline progression using only GitHub-visible signals (no `execution_events` dependency) — wait for a PR whose body/branch references the canary issue, then wait for the PR to reach a terminal state (merged or closed); expose timeout as workflow env var `CANARY_TIMEOUT_MINUTES` with default in the 30–45 min range, exceeding the poller grace period (GH-2201 `p.processed` retry window) so slow-but-working runs don't false-alarm; on success (PR merged within timeout), exit green and close the canary issue if auto-close didn't already fire; on failure (stall / timeout / PR closed-unmerged), fail the workflow and file an idempotent alert issue on the `pilot` repo with label `bug`, deduped by fixed title marker `[canary] pipeline stall`, naming the last observed stage (`issue-filed` / `PR-opened` / `merge-stalled`), reusing the idempotent-create pattern from `.github/workflows/brew-tap-token-canary.yml`. Verify via `workflow_dispatch` run end-to-end against the sandbox (green path), then induce a stall (stop daemon) and confirm exactly one deduped alert issue is filed on `pilot`, and a second failing run does not duplicate it.
