### PR TITLE
fix(canary): gh pr list --jq cannot take --arg; pipe to standalone jq

### DIFF
--- a/.github/workflows/pilot-canary.yml
+++ b/.github/workflows/pilot-canary.yml
@@ -108,8 +108,8 @@ jobs:
                 --repo "$SANDBOX_REPO" \
                 --state all \
                 --json number,headRefName,body \
-                --jq --arg n "$ISSUE_NUMBER" \
-                  '[.[] | select(.headRefName == ("pilot/GH-" + $n) or (.body // "" | test("#" + $n)))][0].number // empty')
+                | jq -r --arg n "$ISSUE_NUMBER" \
+                  '[.[] | select(.headRefName == ("pilot/GH-" + $n) or ((.body // "") | test("#" + $n)))][0].number // empty')
 
               if [ -n "$PR_NUMBER" ]; then
                 STAGE="PR-opened"


### PR DESCRIPTION
## Summary
- Fixes GH-3866: the canary's **Poll for pipeline progression** step used `gh pr list --jq --arg n "$ISSUE_NUMBER" '...'`, but `gh`'s `-q/--jq` only accepts a filter expression and does not forward `--arg` to its embedded jq.
- At runtime `gh` errors (`unknown arguments ["n" ...]`); under `set -uo pipefail` (no `-e`) this silently yields an empty `PR_NUMBER` every poll iteration, so the canary always times out and files a false `[canary] pipeline stall` alert.
- Fix: pipe `gh pr list`'s JSON output to standalone `jq -r --arg n "$ISSUE_NUMBER" '...'` (available on `ubuntu-latest`), preserving identical filter semantics.

## Test plan
- [x] Verified the jq filter logic standalone with sample JSON — correctly matches by `headRefName == pilot/GH-<n>` first, falls back to a body reference to `#<n>`.
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] Diff scoped to the single broken command; no other workflow changes.