### PR TITLE
fix(canary): synthetic issue body needs H2 headers to pass spec-completeness gate

### DIFF
--- a/.github/workflows/pilot-canary.yml
+++ b/.github/workflows/pilot-canary.yml
@@ -65,13 +65,23 @@ jobs:
           TIMESTAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
           TITLE="chore(version): bump patch for canary run $TIMESTAMP"
           BODY=$(cat <<EOF
-          Synthetic canary run (TASK-379 V8). This issue exists to prove the
-          deployed Pilot daemon still ships code end-to-end.
+          ## Context
 
-          Increment the PATCH component of the \`Version\` constant in
-          \`version.go\` by exactly one (e.g. \`0.0.1\` -> \`0.0.2\`). Keep the
-          change to that single line so \`version_test.go\` (semver guard)
-          stays green. Do not touch any other file.
+          Synthetic canary run (TASK-379 V8). This issue exists to prove the
+          deployed Pilot daemon still ships code end-to-end (poll -> spec ->
+          execute -> PR -> merge).
+
+          ## Acceptance
+
+          - [ ] Increment the PATCH component of the \`Version\` constant in
+                \`version.go\` by exactly one (e.g. \`0.0.1\` -> \`0.0.2\`).
+          - [ ] Change only that single line so \`version_test.go\` (semver
+                guard) stays green.
+          - [ ] Do not touch any other file.
+
+          ## Implementation
+
+          Edit the \`const Version\` line in \`version.go\`. Nothing else.
           EOF
           )
 


### PR DESCRIPTION
## Summary
- The synthetic canary workflow's `File synthetic canary issue` step filed an issue body that was plain prose with no structural section header, so the daemon's spec-completeness gate rejected it (`pilot-spec-incomplete`/`pilot-blocked`) before it ever reached execute → PR → merge.
- Restructured the `BODY` heredoc to use `## Context`, `## Acceptance`, and `## Implementation` H2 headers. Task semantics unchanged (single-line PATCH bump of `Version` in `version.go`); title, `pilot` label, and issue-number capture logic untouched.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pilot-canary.yml'))"` — YAML parses cleanly.
- [x] Simulated GH Actions' YAML dedent of the `run:` block and confirmed `## Context`/`## Acceptance`/`## Implementation` land at column 0 (heredoc indentation is stripped by the YAML literal block scalar before bash ever sees it).
- [x] Ran the gate's actual regex (`internal/adapters/github/spec_validator.go` `sectionHeaderRe`) against the rendered body text — matches, and body length (518 chars) clears the 100-char minimum.
- [x] `go build ./...` passes (no Go code touched).