### PR TITLE
fix(canary): stop hardcoding version example in synthetic issue body

### DIFF
--- a/.github/workflows/pilot-canary.yml
+++ b/.github/workflows/pilot-canary.yml
@@ -73,8 +73,10 @@ jobs:
 
           ## Acceptance
 
-          - [ ] Increment the PATCH component of the \`Version\` constant in
-                \`version.go\` by exactly one (e.g. \`0.0.1\` -> \`0.0.2\`).
+          - [ ] Read the current PATCH component of the \`Version\` constant in
+                \`version.go\` and increment it by exactly one (current+1). Do
+                not assume a starting value -- derive the target from what is
+                in the file.
           - [ ] Change only that single line so \`version_test.go\` (semver
                 guard) stays green.
           - [ ] Do not touch any other file.


### PR DESCRIPTION
## Summary
- The synthetic canary issue body hardcoded a literal `0.0.1 -> 0.0.2` PATCH-bump example in `.github/workflows/pilot-canary.yml`.
- The executor's intent judge anchors on that literal example, so once the sandbox `version.go` climbs past `0.0.1` (e.g. to `0.0.3`), a correct `current+1` bump gets a false "increment of 2" veto (observed on canary run `28715585378`).
- Reworded the acceptance criterion to instruct reading the current PATCH value from the file and incrementing by exactly one, with no fixed from→to literal to drift.

Closes #3874

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` confirms the workflow YAML still parses.
- [x] `## Context` / `## Acceptance` / `## Implementation` structure preserved (required by the daemon spec-completeness gate).
- [ ] Next canary run (any current version) should produce a diff the intent judge accepts without a false veto.