### PR TITLE
fix(autopilot): stop pre-merge CI re-verify from restarting no-CI discovery grace

### DIFF
--- a/internal/autopilot/ci_monitor.go
+++ b/internal/autopilot/ci_monitor.go
@@ -107,7 +107,7 @@ func (m *CIMonitor) WaitForCI(ctx context.Context, sha string) (CIStatus, error)
 				return CIPending, fmt.Errorf("CI timeout after %v", m.waitTimeout)
 			}
 
-			status, err := m.checkStatus(ctx, sha)
+			status, err := m.checkStatus(ctx, sha, false)
 			if err != nil {
 				m.log.Warn("CI status check failed", "error", err)
 				continue
@@ -123,7 +123,10 @@ func (m *CIMonitor) WaitForCI(ctx context.Context, sha string) (CIStatus, error)
 }
 
 // checkStatus gets current CI status for a SHA.
-func (m *CIMonitor) checkStatus(ctx context.Context, sha string) (CIStatus, error) {
+// skipGrace, when true, bypasses the no-CI discovery grace period entirely
+// (see checkAutoDiscoveredRuns) for callers that already know CI resolved
+// once for this SHA earlier in the PR lifecycle.
+func (m *CIMonitor) checkStatus(ctx context.Context, sha string, skipGrace bool) (CIStatus, error) {
 	// Get check runs (GitHub Actions)
 	checkRuns, err := m.ghClient.ListCheckRuns(ctx, m.owner, m.repo, sha)
 	if err != nil {
@@ -154,7 +157,7 @@ func (m *CIMonitor) checkStatus(ctx context.Context, sha string) (CIStatus, erro
 
 	// Auto mode: use discovered checks with exclusions and grace period
 	if m.ciChecks != nil && m.ciChecks.Mode == "auto" {
-		return m.checkAutoDiscoveredRuns(ctx, sha, checkRuns)
+		return m.checkAutoDiscoveredRuns(ctx, sha, checkRuns, skipGrace)
 	}
 
 	// Manual mode: If no required checks configured, check all runs
@@ -213,7 +216,12 @@ func (m *CIMonitor) checkAllRuns(checkRuns *github.CheckRunsResponse) CIStatus {
 // checkAutoDiscoveredRuns checks CI status in auto mode with exclusion filtering.
 // It waits during the grace period if no checks are found yet, then falls back
 // to the commit-status API before treating a SHA as having no CI configured.
-func (m *CIMonitor) checkAutoDiscoveredRuns(ctx context.Context, sha string, checkRuns *github.CheckRunsResponse) (CIStatus, error) {
+// skipGrace bypasses the discoveryStart wait/eviction entirely and goes straight
+// to the commit-status fallback — for callers (verifyCIBeforeMerge, via
+// GetCIStatus) that only run after this SHA already resolved to CISuccess once
+// earlier in the PR lifecycle, so re-discovering "no CI" from scratch would
+// incorrectly restart the grace period (GH-3873).
+func (m *CIMonitor) checkAutoDiscoveredRuns(ctx context.Context, sha string, checkRuns *github.CheckRunsResponse, skipGrace bool) (CIStatus, error) {
 	// Filter checks by exclusion patterns
 	var filteredRuns []github.CheckRun
 	for _, run := range checkRuns.CheckRuns {
@@ -224,42 +232,44 @@ func (m *CIMonitor) checkAutoDiscoveredRuns(ctx context.Context, sha string, che
 
 	// Handle grace period for check discovery
 	if len(filteredRuns) == 0 {
-		m.mu.Lock()
-		startTime, exists := m.discoveryStart[sha]
-		if !exists {
-			// First check: start the grace period
-			m.discoveryStart[sha] = time.Now()
+		if !skipGrace {
+			m.mu.Lock()
+			startTime, exists := m.discoveryStart[sha]
+			if !exists {
+				// First check: start the grace period
+				m.discoveryStart[sha] = time.Now()
+				m.mu.Unlock()
+				m.log.Debug("no CI checks found, starting grace period",
+					"sha", ShortSHA(sha),
+					"grace_period", m.ciChecks.DiscoveryGracePeriod,
+				)
+				return CIPending, nil
+			}
 			m.mu.Unlock()
-			m.log.Debug("no CI checks found, starting grace period",
-				"sha", ShortSHA(sha),
-				"grace_period", m.ciChecks.DiscoveryGracePeriod,
-			)
-			return CIPending, nil
+
+			// Check if grace period has expired
+			elapsed := time.Since(startTime)
+			if elapsed < m.ciChecks.DiscoveryGracePeriod {
+				m.log.Debug("waiting for CI checks during grace period",
+					"sha", ShortSHA(sha),
+					"elapsed", elapsed,
+					"remaining", m.ciChecks.DiscoveryGracePeriod-elapsed,
+				)
+				return CIPending, nil
+			}
+
+			// TASK-357 (B6b): the grace period is over and this is a terminal decision for
+			// the SHA — evict its discoveryStart entry so it does not leak for the daemon
+			// lifetime. Previously only the "checks found" path below deleted it, so every
+			// no-CI SHA (and every superseded intermediate commit) leaked an entry.
+			m.mu.Lock()
+			delete(m.discoveryStart, sha)
+			m.mu.Unlock()
 		}
-		m.mu.Unlock()
 
-		// Check if grace period has expired
-		elapsed := time.Since(startTime)
-		if elapsed < m.ciChecks.DiscoveryGracePeriod {
-			m.log.Debug("waiting for CI checks during grace period",
-				"sha", ShortSHA(sha),
-				"elapsed", elapsed,
-				"remaining", m.ciChecks.DiscoveryGracePeriod-elapsed,
-			)
-			return CIPending, nil
-		}
-
-		// TASK-357 (B6b): the grace period is over and this is a terminal decision for
-		// the SHA — evict its discoveryStart entry so it does not leak for the daemon
-		// lifetime. Previously only the "checks found" path below deleted it, so every
-		// no-CI SHA (and every superseded intermediate commit) leaked an entry.
-		m.mu.Lock()
-		delete(m.discoveryStart, sha)
-		m.mu.Unlock()
-
-		// Grace period expired with no check runs — query commit-status API before
-		// concluding that no CI is configured. Providers like CircleCI, Jenkins,
-		// Travis, and Buildkite report exclusively via the statuses API.
+		// Grace period expired (or skipped) with no check runs — query commit-status
+		// API before concluding that no CI is configured. Providers like CircleCI,
+		// Jenkins, Travis, and Buildkite report exclusively via the statuses API.
 		combined, err := m.ghClient.GetCombinedStatus(ctx, m.owner, m.repo, sha)
 		if err != nil {
 			m.log.Warn("grace period expired; combined-status lookup failed, treating as no CI",
@@ -397,7 +407,7 @@ func (m *CIMonitor) mapCheckStatus(status, conclusion string) CIStatus {
 // This is the non-blocking alternative to WaitForCI.
 // Returns CIPending/CIRunning if checks are still running.
 func (m *CIMonitor) CheckCI(ctx context.Context, sha string) (CIStatus, error) {
-	status, err := m.checkStatus(ctx, sha)
+	status, err := m.checkStatus(ctx, sha, false)
 	if err != nil {
 		m.log.Debug("CheckCI: status check failed",
 			"sha", ShortSHA(sha),
@@ -416,9 +426,13 @@ func (m *CIMonitor) CheckCI(ctx context.Context, sha string) (CIStatus, error) {
 
 // GetCIStatus returns the current overall CI status for a SHA.
 // This is useful for point-in-time status checks without waiting.
+// Its sole production caller (verifyCIBeforeMerge) only runs after the PR
+// state machine already reached StageCIPassed, proving CI resolved CISuccess
+// once on this SHA — so it skips the no-CI discovery grace period rather than
+// restarting it (GH-3873).
 // Deprecated: Use CheckCI instead for clarity.
 func (m *CIMonitor) GetCIStatus(ctx context.Context, sha string) (CIStatus, error) {
-	return m.checkStatus(ctx, sha)
+	return m.checkStatus(ctx, sha, true)
 }
 
 // GetFailedChecks returns names of failed checks for a SHA.

--- a/internal/autopilot/ci_monitor_test.go
+++ b/internal/autopilot/ci_monitor_test.go
@@ -788,9 +788,15 @@ func TestCIMonitor_GetCIStatus(t *testing.T) {
 			wantStatus: CIPending, // Running maps to pending in aggregate
 		},
 		{
+			// GH-3873: GetCIStatus's sole production caller (verifyCIBeforeMerge) only
+			// runs after CI already resolved once for this SHA, so it skips the
+			// no-CI discovery grace entirely (skipGrace=true) and falls straight
+			// through to the commit-status fallback. The mock server here answers
+			// every path with the same TotalCount:0 body, so that fallback also
+			// reports no statuses configured → CISuccess, not CIPending.
 			name:       "no checks",
 			checkRuns:  []github.CheckRun{},
-			wantStatus: CIPending,
+			wantStatus: CISuccess,
 		},
 	}
 
@@ -1051,6 +1057,74 @@ func TestCIMonitor_AutoDiscovery_GracePeriodExpired(t *testing.T) {
 	}
 	if status != CISuccess {
 		t.Errorf("CheckCI() after grace period status = %s, want %s", status, CISuccess)
+	}
+}
+
+// TestCIMonitor_GetCIStatus_DoesNotRestartGraceAfterResolved is the regression
+// test for GH-3873: once a no-CI SHA has resolved to CISuccess via CheckCI
+// (grace expired, discoveryStart entry evicted per TASK-357 B6b),
+// verifyCIBeforeMerge's GetCIStatus call for the SAME SHA must return
+// CISuccess immediately — not restart the grace period and return CIPending.
+func TestCIMonitor_GetCIStatus_DoesNotRestartGraceAfterResolved(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/abc1234/check-runs":
+			resp := github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/commits/abc1234/status":
+			// No commit statuses → genuine no-CI repo
+			resp := github.CombinedStatus{State: github.StatusPending, TotalCount: 0, Statuses: []github.CommitStatus{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 1 * time.Second
+	cfg.RequiredChecks = nil
+	cfg.CIChecks = &CIChecksConfig{
+		Mode:                 "auto",
+		DiscoveryGracePeriod: 20 * time.Millisecond, // Very short grace period
+	}
+
+	monitor := NewCIMonitor(ghClient, "owner", "repo", cfg)
+
+	// First call (mirrors handleWaitingCI) starts the grace period.
+	status, _ := monitor.CheckCI(context.Background(), "abc1234")
+	if status != CIPending {
+		t.Fatalf("First CheckCI() status = %s, want %s", status, CIPending)
+	}
+
+	// Wait for grace period to expire.
+	time.Sleep(30 * time.Millisecond)
+
+	// Second CheckCI (still mirrors handleWaitingCI's periodic poll) resolves
+	// the SHA to CISuccess and evicts discoveryStart[sha] (TASK-357 B6b).
+	status, err := monitor.CheckCI(context.Background(), "abc1234")
+	if err != nil {
+		t.Fatalf("CheckCI() error = %v", err)
+	}
+	if status != CISuccess {
+		t.Fatalf("CheckCI() after grace period status = %s, want %s", status, CISuccess)
+	}
+
+	// This mirrors verifyCIBeforeMerge's pre-merge re-verification. Before the
+	// GH-3873 fix, discoveryStart[sha] was gone, so this call would treat the
+	// SHA as first-seen, restart the grace period, and return CIPending here —
+	// causing "CI checks still pending" merge failures on the very first
+	// handleMerging attempt.
+	status, err = monitor.GetCIStatus(context.Background(), "abc1234")
+	if err != nil {
+		t.Fatalf("GetCIStatus() error = %v", err)
+	}
+	if status != CISuccess {
+		t.Errorf("GetCIStatus() after CheckCI resolved = %s, want %s (grace period must not restart)", status, CISuccess)
 	}
 }
 

--- a/internal/autopilot/controller_merge_test.go
+++ b/internal/autopilot/controller_merge_test.go
@@ -315,7 +315,7 @@ func TestController_HandleMerging_MergeAttemptCapEscalates(t *testing.T) {
 	mergeable := true
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/repos/owner/repo/pulls/88/merge" && r.Method == http.MethodPost:
+		case r.URL.Path == "/repos/owner/repo/pulls/88/merge" && r.Method == http.MethodPut:
 			// Simulate a persistent non-conflict merge failure (e.g. branch-protection).
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			_, _ = w.Write([]byte(`{"message":"405 Method Not Allowed"}`))
@@ -394,7 +394,7 @@ func TestController_HandleMerging_BelowCapReturnsRetryableError(t *testing.T) {
 	mergeable := true
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/repos/owner/repo/pulls/66/merge" && r.Method == http.MethodPost:
+		case r.URL.Path == "/repos/owner/repo/pulls/66/merge" && r.Method == http.MethodPut:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			_, _ = w.Write([]byte(`{"message":"405 Method Not Allowed"}`))
 

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -1006,6 +1006,121 @@ func TestController_MergeAttemptIncrement(t *testing.T) {
 	}
 }
 
+// TestController_FirstMergeAttemptSucceedsOnNoCIRepo is the integration
+// regression test for GH-3873: a PR on a repo with no CI checks configured
+// must merge on the FIRST handleMerging attempt, not fail with
+// "CI checks still pending" while the discovery grace period restarts.
+//
+// Root cause: handleWaitingCI's CheckCI and verifyCIBeforeMerge's GetCIStatus
+// share the same CIMonitor.discoveryStart map. Once CheckCI resolves the SHA
+// to CISuccess (grace expired, entry evicted per TASK-357 B6b),
+// verifyCIBeforeMerge must NOT see a missing entry and restart the grace —
+// that previously forced 2-3+ failed merge attempts (or a permanent
+// StageFailed under fast poll cadence) before self-healing.
+func TestController_FirstMergeAttemptSucceedsOnNoCIRepo(t *testing.T) {
+	mergeCallCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/commits/abc1234/check-runs":
+			// No CI checks configured on this repo.
+			resp := github.CheckRunsResponse{TotalCount: 0, CheckRuns: []github.CheckRun{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/commits/abc1234/status":
+			// No commit statuses either → genuine no-CI repo.
+			resp := github.CombinedStatus{State: github.StatusPending, TotalCount: 0, Statuses: []github.CommitStatus{}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/repos/owner/repo/pulls/42/files":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.PRFile{})
+		case "/repos/owner/repo/pulls/42/merge":
+			mergeCallCount++
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoReview = false
+	cfg.RequiredChecks = nil
+	cfg.CIChecks = &CIChecksConfig{
+		Mode:                 "auto",
+		DiscoveryGracePeriod: 20 * time.Millisecond, // Very short grace period
+	}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	ghPR := &github.PullRequest{
+		Number: 42,
+		Head:   github.PRRef{SHA: "abc1234"},
+		Base:   github.PRRef{Ref: "main"},
+	}
+
+	c.mu.Lock()
+	c.activePRs[42] = &PRState{
+		PRNumber: 42,
+		HeadSHA:  "abc1234",
+		Stage:    StageWaitingCI,
+	}
+	c.mu.Unlock()
+
+	ctx := context.Background()
+
+	// First handleWaitingCI tick: no checks found yet, starts the discovery grace.
+	if err := c.ProcessPR(ctx, 42, ghPR); err != nil {
+		t.Fatalf("first ProcessPR (waiting_ci) error = %v", err)
+	}
+	pr, _ := c.GetPRState(42)
+	if pr.Stage != StageWaitingCI {
+		t.Fatalf("stage after first tick = %s, want %s", pr.Stage, StageWaitingCI)
+	}
+
+	// Wait for the grace period to expire.
+	time.Sleep(30 * time.Millisecond)
+
+	// Second handleWaitingCI tick: grace expired, commit-status fallback resolves
+	// CISuccess (TotalCount==0) → transitions to StageCIPassed. This evicts the
+	// discoveryStart[sha] entry (TASK-357 B6b).
+	if err := c.ProcessPR(ctx, 42, ghPR); err != nil {
+		t.Fatalf("second ProcessPR (waiting_ci->ci_passed) error = %v", err)
+	}
+	pr, _ = c.GetPRState(42)
+	if pr.Stage != StageCIPassed {
+		t.Fatalf("stage after grace expiry = %s, want %s", pr.Stage, StageCIPassed)
+	}
+
+	// handleCIPassed: no escalation, no approval required in dev → StageMerging.
+	if err := c.ProcessPR(ctx, 42, ghPR); err != nil {
+		t.Fatalf("third ProcessPR (ci_passed->merging) error = %v", err)
+	}
+	pr, _ = c.GetPRState(42)
+	if pr.Stage != StageMerging {
+		t.Fatalf("stage after ci_passed = %s, want %s", pr.Stage, StageMerging)
+	}
+
+	// handleMerging: verifyCIBeforeMerge's GetCIStatus must return CISuccess
+	// immediately (no discovery-grace restart) so the FIRST merge attempt succeeds.
+	if err := c.ProcessPR(ctx, 42, ghPR); err != nil {
+		t.Fatalf("first handleMerging attempt should succeed, got error: %v", err)
+	}
+	pr, _ = c.GetPRState(42)
+	if pr.Stage != StageMerged {
+		t.Errorf("stage after merge attempt = %s, want %s", pr.Stage, StageMerged)
+	}
+	if pr.MergeAttempts != 1 {
+		t.Errorf("MergeAttempts = %d, want 1 (merge must succeed on first attempt)", pr.MergeAttempts)
+	}
+	if mergeCallCount != 1 {
+		t.Errorf("merge endpoint called %d times, want 1", mergeCallCount)
+	}
+}
+
 func TestController_ScanExistingPRs(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/autopilot/gh3715_test.go
+++ b/internal/autopilot/gh3715_test.go
@@ -31,7 +31,7 @@ func TestController_HandleMergeConflict_RebaseAttemptCapEscalates(t *testing.T) 
 	mergeable := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/repos/owner/repo/pulls/77/merge" && r.Method == http.MethodPost:
+		case r.URL.Path == "/repos/owner/repo/pulls/77/merge" && r.Method == http.MethodPut:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			_, _ = w.Write([]byte(`{"message":"Pull Request is not mergeable"}`))
 
@@ -119,7 +119,7 @@ func TestController_HandleMergeConflict_BelowRebaseCapStaysWaitingCI(t *testing.
 	mergeable := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/repos/owner/repo/pulls/78/merge" && r.Method == http.MethodPost:
+		case r.URL.Path == "/repos/owner/repo/pulls/78/merge" && r.Method == http.MethodPut:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			_, _ = w.Write([]byte(`{"message":"Pull Request is not mergeable"}`))
 


### PR DESCRIPTION
## Summary
- Fixes GH-3873: on no-CI repos, `verifyCIBeforeMerge`'s `GetCIStatus` call shared the same `CIMonitor.discoveryStart` map as `handleWaitingCI`'s `CheckCI`. Once a no-CI SHA resolved to `CISuccess` and its grace-period entry was evicted (TASK-357 B6b), `GetCIStatus` saw no entry, restarted the 60s discovery grace, and returned `CIPending` → `"CI checks still pending"` on the very first `handleMerging` attempt.
- Added a `skipGrace bool` parameter threaded through `checkStatus`/`checkAutoDiscoveredRuns`. `GetCIStatus` passes `true` (its sole production caller, `verifyCIBeforeMerge`, only runs after the PR state machine already reached `StageCIPassed`, proving CI resolved once). `CheckCI`/`WaitForCI` pass `false`, preserving first-observation grace for `handleWaitingCI` and `handlePostMergeCI`.
- Preserves TASK-357 B6b leak eviction, TASK-345 B4 fail-fast matrix guard, `mapCombinedStatus` `TotalCount==0 → CISuccess`, and fail-open-on-API-error parity.
- Fixed a latent bug in three pre-existing tests (`gh3715_test.go` x2, `controller_merge_test.go` x2) whose mock merge-endpoint handlers matched `r.Method == http.MethodPost` for the merge PUT endpoint — a mismatch previously masked by this very CI-monitor bug short-circuiting before the real merge call.

## Test plan
- [x] `TestCIMonitor_GetCIStatus_DoesNotRestartGraceAfterResolved` (new, unit) — fails before fix, passes after.
- [x] `TestController_FirstMergeAttemptSucceedsOnNoCIRepo` (new, integration) — drives `waiting_ci → ci_passed → merging` on a no-CI repo and asserts the first `handleMerging` attempt succeeds; fails before fix (reproduces `"CI checks still pending"`), passes after.
- [x] `go build ./...`
- [x] `go test ./...` (full repo, all green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues