### PR TITLE
feat(dashboard): HISTORY pipeline-progress fraction (retire checkmark strip)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -237,7 +237,7 @@
 | Queue metrics card | ✅ | dashboard | - | - | Current queue depth, succeeded/failed (v0.21.2) |
 | Autopilot panel | ✅ | dashboard | - | - | Live PR lifecycle status |
 | Task history | ✅ | dashboard | - | - | Recent 5 completed tasks |
-| Execution stage strip | ✅ | dashboard | - | - | Per-stage glyph strip on HISTORY cards (e.g. `✓✓✓✗ running`), fed from `execution_events`, cached at hydrate/refresh time not per render (GH-3849, v2.208.0) |
+| Execution stage strip | ✅ | dashboard | - | - | Pipeline-progress fraction on HISTORY cards (e.g. `4/7 ✗ ci_failed`), fed from `execution_events` via a fixed 7-rung ladder position (not raw event count, so retries don't inflate it), cached at hydrate/refresh time not per render (GH-3849, v2.208.0; fraction format TASK-383, v2.213.4) |
 | Hot upgrade key | ✅ | dashboard | `u` key | - | In-place upgrade from dashboard |
 | SQLite persistence | ✅ | dashboard | - | - | Metrics survive restarts (v0.21.2) |
 | Queue state panel | ✅ | dashboard | - | - | 5-state: done/running/queued/pending/failed with shimmer (v0.63.0) |

--- a/internal/dashboard/stage_strip.go
+++ b/internal/dashboard/stage_strip.go
@@ -1,62 +1,97 @@
 package dashboard
 
 import (
-	"strings"
+	"fmt"
 
 	"github.com/qf-studio/pilot/internal/memory"
 )
-
-// maxStageStripGlyphs caps how many stage-event glyphs are shown on a single
-// execution card, so the strip stays compact regardless of how many stage
-// transitions (including retries) accumulated over a long-running execution.
-const maxStageStripGlyphs = 8
 
 // maxStageStripLabelWidth caps the trailing stage-name label so a long enum
 // value (e.g. "awaiting_approval") can't blow the card's fixed layout budget.
 const maxStageStripLabelWidth = 20
 
-// stageStripFailureStages are the terminal stages that render as a ✗ glyph in
-// the stage strip; every other recorded stage renders as ✓.
+// stageLadderTotal is the canonical pipeline length the HISTORY fraction is
+// measured against: spec_validated -> running -> commit -> pr_created ->
+// ci_passed -> merged -> released.
+const stageLadderTotal = 7
+
+// stageStripFailureStages are the terminal stages that render with a ✗
+// prefix in the HISTORY fraction; every other recorded stage renders plain.
 var stageStripFailureStages = map[memory.Stage]bool{
 	memory.StageFailed:   true,
 	memory.StageCIFailed: true,
 	memory.StageStalled:  true,
 }
 
-// buildStageStrip renders a compact per-event glyph strip (e.g. "✓✓✓✗ running")
-// from an execution's execution_events timeline (GH-3849). The trailing label
-// names the current stage — or, when the last event is a failure, the last
-// stage successfully reached before it failed.
+// stageLadderPosition maps a memory.Stage to its 1-indexed position on the
+// canonical 7-rung pipeline ladder; released == stageLadderTotal. Off-ramp
+// stages that still name a real rung (awaiting_approval, ci_failed) resolve
+// to the last rung actually reached. Generic terminal outcomes that don't
+// name a rung of their own (failed, stalled) — plus pre-ladder / non-ladder
+// stages (queued, no_op, skipped) — return 0; buildStageStrip resolves those
+// by walking back to the prior event that does have a ladder position.
+func stageLadderPosition(s memory.Stage) int {
+	switch s {
+	case memory.StageSpecValidated:
+		return 1
+	case memory.StageRunning:
+		return 2
+	case memory.StageCommit:
+		return 3
+	case memory.StagePRCreated:
+		return 4
+	case memory.StageCIPassed:
+		return 5
+	case memory.StageMerged:
+		return 6
+	case memory.StageReleased:
+		return 7
+	case memory.StageAwaitingApproval:
+		return 5 // reached ci_passed, gated on approval
+	case memory.StageCIFailed:
+		return 4 // reached pr_created, died at ci
+	}
+	return 0
+}
+
+// buildStageStrip renders a fixed-denominator pipeline-progress fraction
+// (e.g. "4/7 ✗ ci_failed", "7/7 released") from an execution's
+// execution_events timeline (GH-3849; revised to a fraction in TASK-383).
+// `reached` is the ladder position of the last stage actually completed —
+// derived via stageLadderPosition, never from len(events) — so retries never
+// inflate the fraction.
 //
-// Falls back to a single ✓/✗ glyph derived from the execution's terminal
-// status when no events are recorded: executions predating the events table
-// (GH-3844), or before the dispatcher/runner emit events per GH-3846.
+// Falls back to "–" when no events are recorded: executions predating the
+// events table (GH-3844), or before the dispatcher/runner emitted events per
+// GH-3846. There is no stage evidence in that case, so a terminal success is
+// never fabricated into "7/7".
 func buildStageStrip(events []*memory.Event, executionFailed bool) string {
 	if len(events) == 0 {
-		if executionFailed {
-			return "✗"
+		return "–"
+	}
+
+	current := events[len(events)-1].Stage
+	failed := stageStripFailureStages[current] || executionFailed
+
+	label := current
+	reached := stageLadderPosition(current)
+	if reached == 0 {
+		// current stage carries no ladder rung of its own — walk back to
+		// the last event that does, so a generic failure/stall/retry run
+		// still reports how far the pipeline actually got.
+		for i := len(events) - 2; i >= 0; i-- {
+			if pos := stageLadderPosition(events[i].Stage); pos > 0 {
+				reached = pos
+				label = events[i].Stage
+				break
+			}
 		}
-		return "✓"
 	}
 
-	shown := events
-	if len(shown) > maxStageStripGlyphs {
-		shown = shown[len(shown)-maxStageStripGlyphs:]
+	prefix := ""
+	if failed {
+		prefix = "✗ "
 	}
 
-	var glyphs strings.Builder
-	for _, e := range shown {
-		if stageStripFailureStages[e.Stage] {
-			glyphs.WriteString("✗")
-		} else {
-			glyphs.WriteString("✓")
-		}
-	}
-
-	labelStage := events[len(events)-1].Stage
-	if stageStripFailureStages[labelStage] && len(events) >= 2 {
-		labelStage = events[len(events)-2].Stage
-	}
-
-	return glyphs.String() + " " + truncateString(string(labelStage), maxStageStripLabelWidth)
+	return fmt.Sprintf("%d/%d %s%s", reached, stageLadderTotal, prefix, truncateString(string(label), maxStageStripLabelWidth))
 }

--- a/internal/dashboard/stage_strip_test.go
+++ b/internal/dashboard/stage_strip_test.go
@@ -12,11 +12,11 @@ func evt(stage memory.Stage) *memory.Event {
 }
 
 func TestBuildStageStrip_NoEvents(t *testing.T) {
-	if got := buildStageStrip(nil, false); got != "✓" {
-		t.Errorf("no events, not failed: got %q, want %q", got, "✓")
+	if got := buildStageStrip(nil, false); got != "–" {
+		t.Errorf("no events, not failed: got %q, want %q", got, "–")
 	}
-	if got := buildStageStrip(nil, true); got != "✗" {
-		t.Errorf("no events, failed: got %q, want %q", got, "✗")
+	if got := buildStageStrip(nil, true); got != "–" {
+		t.Errorf("no events, failed: got %q, want %q", got, "–")
 	}
 }
 
@@ -30,12 +30,39 @@ func TestBuildStageStrip_HappyPath(t *testing.T) {
 		evt(memory.StageMerged),
 	}
 	got := buildStageStrip(events, false)
-	want := "✓✓✓✓✓✓ merged"
+	want := "6/7 merged"
 	if got != want {
 		t.Errorf("happy path: got %q, want %q", got, want)
 	}
 	if strings.Contains(got, "✗") {
-		t.Errorf("happy path strip should not contain a failure glyph: %q", got)
+		t.Errorf("happy path strip should not contain a failure marker: %q", got)
+	}
+}
+
+func TestBuildStageStrip_Released(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StageQueued),
+		evt(memory.StageSpecValidated),
+		evt(memory.StageRunning),
+		evt(memory.StageCommit),
+		evt(memory.StagePRCreated),
+		evt(memory.StageCIPassed),
+		evt(memory.StageMerged),
+		evt(memory.StageReleased),
+	}
+	got := buildStageStrip(events, false)
+	want := "7/7 released"
+	if got != want {
+		t.Errorf("released: got %q, want %q", got, want)
+	}
+}
+
+func TestBuildStageStrip_SpecValidatedOnly(t *testing.T) {
+	events := []*memory.Event{evt(memory.StageSpecValidated)}
+	got := buildStageStrip(events, false)
+	want := "1/7 spec_validated"
+	if got != want {
+		t.Errorf("spec_validated only: got %q, want %q", got, want)
 	}
 }
 
@@ -46,7 +73,7 @@ func TestBuildStageStrip_InProgress(t *testing.T) {
 		evt(memory.StageRunning),
 	}
 	got := buildStageStrip(events, false)
-	want := "✓✓✓ running"
+	want := "2/7 running"
 	if got != want {
 		t.Errorf("in-progress: got %q, want %q", got, want)
 	}
@@ -60,35 +87,66 @@ func TestBuildStageStrip_FailedAtStageN(t *testing.T) {
 		evt(memory.StageFailed),
 	}
 	got := buildStageStrip(events, true)
-	want := "✓✓✓✗ running"
+	want := "2/7 ✗ running"
 	if got != want {
 		t.Errorf("failed-at-stage-N: got %q, want %q", got, want)
 	}
 }
 
 // TestBuildStageStrip_FailedAsFirstEvent covers the edge case where the only
-// recorded event is itself a failure — there's no prior stage to name, so the
-// label falls back to the failure stage's own name.
+// recorded event is itself a failure — there's no prior stage to walk back
+// to, so the fraction reports 0 reached and names the failure stage itself.
 func TestBuildStageStrip_FailedAsFirstEvent(t *testing.T) {
 	events := []*memory.Event{evt(memory.StageFailed)}
 	got := buildStageStrip(events, true)
-	want := "✗ failed"
+	want := "0/7 ✗ failed"
 	if got != want {
 		t.Errorf("failed as first event: got %q, want %q", got, want)
 	}
 }
 
-// TestBuildStageStrip_CapsGlyphCount ensures a long retry-heavy timeline stays
-// compact rather than growing unboundedly.
-func TestBuildStageStrip_CapsGlyphCount(t *testing.T) {
+// TestBuildStageStrip_CIFailed asserts the ci_failed off-ramp resolves
+// directly to its own ladder rung (pr_created, reached=4) rather than
+// walking back — it names a real position, unlike a generic failure.
+func TestBuildStageStrip_CIFailed(t *testing.T) {
+	got := buildStageStrip([]*memory.Event{evt(memory.StageCIFailed)}, true)
+	want := "4/7 ✗ ci_failed"
+	if got != want {
+		t.Errorf("ci_failed: got %q, want %q", got, want)
+	}
+}
+
+func TestBuildStageStrip_Stalled(t *testing.T) {
+	got := buildStageStrip([]*memory.Event{evt(memory.StageStalled)}, true)
+	want := "0/7 ✗ stalled"
+	if got != want {
+		t.Errorf("stalled with no prior stage: got %q, want %q", got, want)
+	}
+}
+
+func TestBuildStageStrip_AwaitingApproval(t *testing.T) {
+	got := buildStageStrip([]*memory.Event{evt(memory.StageAwaitingApproval)}, false)
+	want := "5/7 awaiting_approval"
+	if got != want {
+		t.Errorf("awaiting_approval: got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "✗") {
+		t.Errorf("awaiting_approval is a gated in-flight state, not a failure: %q", got)
+	}
+}
+
+// TestBuildStageStrip_RetriesDoNotInflate ensures a long retry-heavy
+// timeline reports the same ladder-position fraction as a short one — the
+// fraction reflects position, not event count.
+func TestBuildStageStrip_RetriesDoNotInflate(t *testing.T) {
 	events := make([]*memory.Event, 0, 20)
 	for i := 0; i < 20; i++ {
 		events = append(events, evt(memory.StageRunning))
 	}
 	got := buildStageStrip(events, false)
-	glyphs := strings.SplitN(got, " ", 2)[0]
-	if len([]rune(glyphs)) != maxStageStripGlyphs {
-		t.Errorf("glyph count = %d, want capped at %d", len([]rune(glyphs)), maxStageStripGlyphs)
+	want := "2/7 running"
+	if got != want {
+		t.Errorf("retries should not inflate the fraction: got %q, want %q", got, want)
 	}
 }
 
@@ -103,11 +161,29 @@ func TestBuildStageStrip_TruncatesLongLabel(t *testing.T) {
 	}
 }
 
-func TestBuildStageStrip_CIFailedAndStalledAreFailureGlyphs(t *testing.T) {
-	if got := buildStageStrip([]*memory.Event{evt(memory.StageCIFailed)}, true); !strings.HasPrefix(got, "✗") {
-		t.Errorf("ci_failed should render as a failure glyph: %q", got)
+func TestStageLadderPosition_AllStages(t *testing.T) {
+	cases := []struct {
+		stage memory.Stage
+		want  int
+	}{
+		{memory.StageQueued, 0},
+		{memory.StageSpecValidated, 1},
+		{memory.StageRunning, 2},
+		{memory.StageCommit, 3},
+		{memory.StagePRCreated, 4},
+		{memory.StageCIPassed, 5},
+		{memory.StageCIFailed, 4},
+		{memory.StageAwaitingApproval, 5},
+		{memory.StageMerged, 6},
+		{memory.StageReleased, 7},
+		{memory.StageFailed, 0},
+		{memory.StageNoOp, 0},
+		{memory.StageSkipped, 0},
+		{memory.StageStalled, 0},
 	}
-	if got := buildStageStrip([]*memory.Event{evt(memory.StageStalled)}, true); !strings.HasPrefix(got, "✗") {
-		t.Errorf("stalled should render as a failure glyph: %q", got)
+	for _, c := range cases {
+		if got := stageLadderPosition(c.stage); got != c.want {
+			t.Errorf("stageLadderPosition(%q) = %d, want %d", c.stage, got, c.want)
+		}
 	}
 }

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -360,10 +360,11 @@ type CompletedTask struct {
 	// PeakRSSMB is the peak subprocess RSS in MiB from the RSS sampler. GH-3028.
 	// Zero when the sampler had no data (pre-3028 executions, non-Linux/darwin).
 	PeakRSSMB int
-	// StageStrip is a compact per-stage glyph strip (e.g. "✓✓✓✗ running") built
-	// from the execution's execution_events timeline (GH-3849). Empty when the
-	// task wasn't hydrated from the store (e.g. AddCompletedTask callers), in
-	// which case the card falls back to the plain status icon.
+	// StageStrip is a pipeline-progress fraction (e.g. "4/7 ✗ ci_failed") built
+	// from the execution's execution_events timeline (GH-3849; fraction format
+	// TASK-383). Empty when the task wasn't hydrated from the store (e.g.
+	// AddCompletedTask callers), in which case the card falls back to the
+	// plain status icon.
 	StageStrip string
 }
 
@@ -2596,8 +2597,9 @@ func (m Model) renderHistory() string {
 // Layout: "  + GH-156  Title...                                    2m ago"
 // indent(2) + strip(variable) + space(1) + id(7) + space(2) + title + space(2) + timeAgo(8) = iw
 // When PeakRSSMB > 0 (GH-3028), an RSS indicator ("4.2G") is appended after the time.
-// GH-3849: the leading glyph column shows the cached StageStrip (e.g. "✓✓✓✗ running")
-// when the task was hydrated from the store; falls back to the plain status icon
+// GH-3849: the leading column shows the cached StageStrip pipeline-progress
+// fraction (e.g. "4/7 ✗ ci_failed") when the task was hydrated from the
+// store; falls back to the plain status icon
 // otherwise (e.g. live completions added via AddCompletedTask).
 func renderStandaloneLine(task CompletedTask, iw int) string {
 	icon, style := statusIconStyle(task.Status)

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -767,14 +767,14 @@ func TestRenderHistory_StageStrip(t *testing.T) {
 
 	plain := stripANSI(output)
 
-	if !strings.Contains(plain, "✓✓✓✓✓✓ merged") {
-		t.Errorf("happy path stage strip not found in output:\n%s", plain)
+	if !strings.Contains(plain, "6/7 merged") {
+		t.Errorf("happy path stage fraction not found in output:\n%s", plain)
 	}
-	if !strings.Contains(plain, "✓✓✓ running") {
-		t.Errorf("in-progress stage strip not found in output:\n%s", plain)
+	if !strings.Contains(plain, "2/7 running") {
+		t.Errorf("in-progress stage fraction not found in output:\n%s", plain)
 	}
-	if !strings.Contains(plain, "✓✓✓✗ running") {
-		t.Errorf("failed-at-stage-N stage strip not found in output:\n%s", plain)
+	if !strings.Contains(plain, "2/7 ✗ running") {
+		t.Errorf("failed-at-stage-N stage fraction not found in output:\n%s", plain)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `buildStageStrip` now renders a fixed-denominator `<reached>/7 <stage>` fraction (e.g. `4/7 ✗ ci_failed`, `7/7 released`) instead of a variable-length `✓`-run — readable in O(1) and retry-proof.
- Added `stageLadderPosition(memory.Stage) int` + `stageLadderTotal = 7`, covering the canonical 7-rung ladder and off-ramp mappings (`awaiting_approval`→5, `ci_failed`→4); generic terminal failures/stalls walk back to the last rung actually reached.
- Retired `maxStageStripGlyphs`; kept `maxStageStripLabelWidth` truncation.
- Zero-events fallback now renders `–` (no fabricated `7/7`).
- No legend/key/caption added to the HISTORY panel — color + `✗` prefix carry state, per spec.
- Epic-group / sub-issue rows (`renderActiveEpicLine`, `renderCompletedEpicLine`, `renderSubIssueLine`) never used the glyph strip (they use single-char status icons), so they're unaffected — confirmed via grep, no `StageStrip` usage there before or after.

Closes #3879

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/...` (all packages green)
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/dashboard/...` — 0 issues
- [x] Table-driven tests in `stage_strip_test.go` cover: `released`→`7/7 released`, `spec_validated`→`1/7 spec_validated`, `ci_failed`→`4/7 ✗ ci_failed`, `awaiting_approval`→`5/7 awaiting_approval`, retried event streams (20x running) still yielding `2/7 running` (not event count), zero-events fallback (`–`), and `stageLadderPosition` coverage for every `memory.Stage`.
- [ ] Visual: `pilot start --dashboard` (not run in this non-interactive execution session — please confirm fractions render, colors map, no legend row appears)