### PR TITLE
docs(knowledge): salvage lost .agent docs from backup/local-main-2026-05-27

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updated": "2026-07-05",
+  "updated": "2026-07-06",
   "nodes": {
     "concepts": {
       "pilot-architecture": {
@@ -524,7 +524,8 @@
           "hot-upgrade"
         ],
         "confidence": 0.9,
-        "created": "2026-05-26"
+        "created": "2026-05-26",
+        "file": ".agent/knowledge/memories/pitfalls/bug_hot_upgrade_silent_codesign.md"
       },
       "mem-017": {
         "type": "pitfall",
@@ -534,7 +535,8 @@
           "dashboard"
         ],
         "confidence": 0.9,
-        "created": "2026-05-26"
+        "created": "2026-05-26",
+        "file": ".agent/knowledge/memories/pitfalls/bug_hot_upgrade_restarting_ui_trap.md"
       },
       "mem-018": {
         "type": "learning",
@@ -1366,6 +1368,75 @@
         "created": "2026-05-20",
         "indexed": "2026-07-05",
         "origin": "2026-07-05 graph reconciliation (auto-memory migration backfill)"
+      },
+      "mem-081": {
+        "type": "pitfall",
+        "summary": "Event-driven-only PR discovery (OnPRCreated) left PRs invisible to autopilot until restart; superseded by reconcileOrphanPRs. Incident: PR #3107.",
+        "file": ".agent/knowledge/memories/pitfalls/resolved/bug_autopilot_pr_discovery_orphans.md",
+        "concepts": [
+          "autopilot",
+          "poller",
+          "github-adapter"
+        ],
+        "confidence": 0.85,
+        "created": "2026-05-26",
+        "indexed": "2026-07-06",
+        "origin": "salvaged from backup/local-main-2026-05-27",
+        "resolved": true
+      },
+      "mem-082": {
+        "type": "pitfall",
+        "summary": "Autopilot can be silently disabled at startup when a gate check fails without a log line \u2014 operators unaware execution is off",
+        "file": ".agent/knowledge/memories/pitfalls/pitfall_silent_autopilot_gate_disable.md",
+        "concepts": [
+          "autopilot",
+          "doctor",
+          "verification"
+        ],
+        "confidence": 0.85,
+        "created": "2026-05-26",
+        "indexed": "2026-07-06",
+        "origin": "salvaged from backup/local-main-2026-05-27"
+      },
+      "mem-083": {
+        "type": "pitfall",
+        "summary": "Ephemeral /tmp/pilot-worktree-* paths fail strict repo-allowlist equality checks; resolve via git rev-parse --git-common-dir before comparing",
+        "file": ".agent/knowledge/memories/pitfalls/pitfall_worktree_path_repo_allowlist.md",
+        "concepts": [
+          "worktree",
+          "executor",
+          "git-operations"
+        ],
+        "confidence": 0.85,
+        "created": "2026-05-26",
+        "indexed": "2026-07-06",
+        "origin": "salvaged from backup/local-main-2026-05-27"
+      },
+      "mem-084": {
+        "type": "pitfall",
+        "summary": "allChildrenDone() returned true for empty child set \u2014 vacuous truth tripped epic-complete exit with zero work done; require >=1 child",
+        "file": ".agent/knowledge/memories/pitfalls/pitfall_allchildrendone_vacuous_truth.md",
+        "concepts": [
+          "epic-decomposition",
+          "executor"
+        ],
+        "confidence": 0.85,
+        "created": "2026-05-26",
+        "indexed": "2026-07-06",
+        "origin": "salvaged from backup/local-main-2026-05-27"
+      },
+      "mem-085": {
+        "type": "pitfall",
+        "summary": "Epic-parent results legitimately have empty CommitSHA/PRUrl (children carry them); guard with IsEpic before empty-value failure heuristic",
+        "file": ".agent/knowledge/memories/pitfalls/pitfall_isepic_guard_empty_result_fields.md",
+        "concepts": [
+          "epic-decomposition",
+          "executor"
+        ],
+        "confidence": 0.85,
+        "created": "2026-05-26",
+        "indexed": "2026-07-06",
+        "origin": "salvaged from backup/local-main-2026-05-27"
       }
     }
   },
@@ -2103,6 +2174,71 @@
     {
       "from": "mem-080",
       "to": "claude-code-integration",
+      "type": "describes"
+    },
+    {
+      "from": "mem-081",
+      "to": "autopilot",
+      "type": "describes"
+    },
+    {
+      "from": "mem-081",
+      "to": "poller",
+      "type": "describes"
+    },
+    {
+      "from": "mem-081",
+      "to": "github-adapter",
+      "type": "describes"
+    },
+    {
+      "from": "mem-082",
+      "to": "autopilot",
+      "type": "describes"
+    },
+    {
+      "from": "mem-082",
+      "to": "doctor",
+      "type": "describes"
+    },
+    {
+      "from": "mem-082",
+      "to": "verification",
+      "type": "describes"
+    },
+    {
+      "from": "mem-083",
+      "to": "worktree",
+      "type": "describes"
+    },
+    {
+      "from": "mem-083",
+      "to": "executor",
+      "type": "describes"
+    },
+    {
+      "from": "mem-083",
+      "to": "git-operations",
+      "type": "describes"
+    },
+    {
+      "from": "mem-084",
+      "to": "epic-decomposition",
+      "type": "describes"
+    },
+    {
+      "from": "mem-084",
+      "to": "executor",
+      "type": "describes"
+    },
+    {
+      "from": "mem-085",
+      "to": "epic-decomposition",
+      "type": "describes"
+    },
+    {
+      "from": "mem-085",
+      "to": "executor",
       "type": "describes"
     }
   ]

--- a/.agent/knowledge/memories/pitfalls/bug_hot_upgrade_restarting_ui_trap.md
+++ b/.agent/knowledge/memories/pitfalls/bug_hot_upgrade_restarting_ui_trap.md
@@ -1,0 +1,64 @@
+---
+name: Hot upgrade "Restarting..." UI hides the failure
+description: TUI renders "Now running X - Restarting..." in UpgradeStateComplete and "Installing X... 100%" in InProgress without surfacing upgradeMessage, so a successful-message render can be confused for an actual exec — and the failure case scrolls past as a log line
+type: pitfall
+---
+
+## What
+
+Two related TUI rendering issues in `internal/dashboard/tui.go` that make hot-upgrade outcomes ambiguous:
+
+### 1. `UpgradeStateInProgress` ignores `upgradeMessage`
+
+`tui.go:2744-2747`:
+```go
+case UpgradeStateInProgress:
+    bar := m.renderProgressBar(m.upgradeProgress, 30)
+    content.WriteString(fmt.Sprintf("  Installing %s... %s %d%%", m.updateInfo.LatestVersion, bar, m.upgradeProgress))
+```
+
+The `upgradeMessage` field is updated by every `upgradeProgressMsg` (line 1124-1125), including the final `progress(100, "Restarting...")` from `hot.go:139`. But the InProgress renderer never reads it — the user only sees "Installing v2.x.x... [████] 100%", never "Restarting...".
+
+### 2. `UpgradeStateComplete` text implies a restart that didn't happen
+
+`tui.go:2749-2751`:
+```go
+case UpgradeStateComplete:
+    content.WriteString(fmt.Sprintf("  Now running %s - Restarting...", m.updateInfo.LatestVersion))
+```
+
+This state is reached when `NotifyUpgradeComplete(true, "")` arrives. On Unix, that should be unreachable — a successful `syscall.Exec` replaces the process before the message can be sent. In practice this state IS visible in the wild, which means either:
+- The Windows code path is being exercised (it isn't — build tags are clean), OR
+- `syscall.Exec` returned nil without actually swapping the image, OR
+- Some other path returns nil from `PerformHotUpgrade` without exec
+
+Whatever the cause, the *text* is misleading: it claims "Now running v2.x.x" but the old process is still alive and the version banner elsewhere in the TUI still shows the old version. The user reasonably concludes "the message is lying."
+
+### 3. Failure `AddLog` competes with success rendering
+
+The goroutine sends `AddLog("❌ Upgrade failed: ...")` on error (`main.go:2603`), but this scrolls into the regular log panel while the upgrade panel may still be rendering a stale "Installing... 100%". Two competing surfaces, no single source of truth.
+
+## Why this matters
+
+The bug `[[bug_hot_upgrade_silent_codesign]]` produces a failure that exec'd-with-Gatekeeper makes visible only as a log line. Combined with the InProgress renderer not showing "Restarting...", the user perceives the upgrade as "stuck halfway" rather than "failed."
+
+## How to apply
+
+When touching `internal/dashboard/tui.go` upgrade rendering:
+
+- Display `m.upgradeMessage` in `UpgradeStateInProgress` (e.g., below the progress bar).
+- Re-word `UpgradeStateComplete` to reflect reality: on Unix this state should be unreachable in practice — if it IS reached, say "Upgrade installed — restart manually to apply" (matches Windows behavior, which is the only legit way to reach this state).
+- Ensure `UpgradeStateFailed` is shown prominently — replace any "Installing... 100%" or "Restarting..." text rather than letting them coexist.
+- Consider adding a `lastUpgradeAttempt` timestamp + last-error to a persistent status line so the user doesn't lose the signal when logs scroll.
+
+## Evidence
+
+- `internal/dashboard/tui.go:2735-2755` — render switch on `UpgradeState`
+- `internal/dashboard/tui.go:1123-1135` — `upgradeProgressMsg` / `upgradeCompleteMsg` handlers
+- `cmd/pilot/main.go:2602-2607` — goroutine notify pattern
+- `internal/upgrade/hot.go:139` — `progress(100, "Restarting...")` that's never displayed
+
+## Related
+
+- [[bug_hot_upgrade_silent_codesign]] — the upstream cause this UX hides
+- [[pattern_hot_upgrade_bootstrap]] — design rationale for the upgrade flow

--- a/.agent/knowledge/memories/pitfalls/bug_hot_upgrade_silent_codesign.md
+++ b/.agent/knowledge/memories/pitfalls/bug_hot_upgrade_silent_codesign.md
@@ -1,0 +1,56 @@
+---
+name: Hot upgrade silently swallows macOS codesign failure
+description: PrepareForExecution error is discarded with `_ =` at upgrade.go:407, so a failed ad-hoc codesign produces an unsigned binary that Gatekeeper later refuses to syscall.Exec — manifests as "hit u, see restart, old version still running"
+type: pitfall
+---
+
+## What
+
+`internal/upgrade/upgrade.go:407`:
+
+```go
+// Prepare binary for execution (removes quarantine, signs on macOS)
+// Errors are non-fatal - binary may still work
+_ = PrepareForExecution(u.binaryPath)
+```
+
+`PrepareForExecution` on macOS (`internal/upgrade/codesign_darwin.go:11-17`):
+1. `xattr -d com.apple.quarantine <binary>` — error ignored *inside* the function
+2. `codesign -s - <binary>` (ad-hoc sign) — error **returned to caller**
+
+The caller throws the returned error away. If ad-hoc signing fails (codesign tool missing, hardened-runtime mismatch, transient FS issue), the binary on disk after the atomic rename is **unsigned and quarantined**. When `syscall.Exec` later tries to load it, macOS Gatekeeper refuses — exec returns EPERM / EACCES.
+
+## Why this matches the symptom
+
+User reports: hit `u` → "update loading" → "restart" message → old version still running → only full stop + manual relaunch fixes it.
+
+Manual relaunch works because terminal-initiated process spawn gets different Gatekeeper treatment than a `syscall.Exec` from a running daemon. Same on-disk binary, different verdict.
+
+## Where the failure is visible (or isn't)
+
+- `RestartWithNewBinary` returns the exec error (`internal/upgrade/restart.go:53`)
+- `PerformHotUpgrade` wraps it ("restart failed: ...") and returns (`hot.go:145-147`)
+- Goroutine in `cmd/pilot/main.go:2602-2605` sends `NotifyUpgradeComplete(false, errStr)` + `AddLog("❌ Upgrade failed: ...")`
+- TUI transitions to `UpgradeStateFailed` with the error visible (`tui.go:1131-1135`, `2753-2755`)
+
+The failure **is** displayed, but is easy to miss in a busy dashboard. The bigger smell is that the *root cause* (codesign failure) is invisible — the user sees the *symptom* (exec failed) without the upstream trigger.
+
+## How to apply
+
+When touching `internal/upgrade/upgrade.go` or the codesign helpers:
+
+- Do NOT swallow `PrepareForExecution` errors — at minimum log them at WARN; ideally fail the upgrade if codesign returns non-nil on macOS.
+- Treat ad-hoc signing as a *required* step, not a best-effort one, on Darwin builds.
+- Before `syscall.Exec`, smoke-test the new binary with `exec.Command(binaryPath, "--version").Run()` — a 100ms guard that catches Gatekeeper rejection cleanly without losing the running process.
+
+## Evidence
+
+- `internal/upgrade/upgrade.go:405-407` — the swallowed error
+- `internal/upgrade/codesign_darwin.go:11-17` — what gets swallowed
+- `internal/upgrade/restart.go:53` — where Gatekeeper rejection surfaces
+- `internal/upgrade/graceful.go:125` — pre-existing GH-272 comment acknowledging this class of issue
+
+## Related
+
+- [[bug_hot_upgrade_restarting_ui_trap]] — sibling pitfall on the "Restarting..." UX confusion
+- [[pattern_hot_upgrade_bootstrap]] — chicken-and-egg risk for persistence fixes

--- a/.agent/knowledge/memories/pitfalls/pitfall_allchildrendone_vacuous_truth.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_allchildrendone_vacuous_truth.md
@@ -1,0 +1,26 @@
+# Pitfall: allChildrenDone vacuous-truth on empty set
+
+## Summary
+`allChildrenDone()` returned `true` for an empty child set, tripping the epic-complete branch and exiting the executor without doing any work; empty-set guard added to require at least one child before reporting complete.
+
+## Context
+Surfaced during workshop dry-run as the third Pilot failure of the session. Patched in v2.149.3 (commit fd0f7b69).
+
+## Details
+At `epic.go:923`, `allChildrenDone()` performed a logical AND over the child slice. With zero children the AND-over-empty returned `true` (vacuous truth), so an epic with no expanded sub-issues was treated as already complete. The executor exited the loop without picking up work or surfacing an error. Fix added an explicit empty-set guard returning `false` when the child slice is empty, plus regression test coverage in `epic_test.go` (7 subcases).
+
+## Recommended Approach
+When the executor exits cleanly but no work happened on an epic:
+1. Check `epic.go:923` and surrounding code for empty-set behavior in completion predicates.
+2. Verify the child-expansion step actually produced sub-issues before the predicate runs.
+3. This pattern recurs anywhere `all(...)` / `every(...)` is applied to a potentially-empty collection — audit similar predicates across the codebase.
+
+## Related
+- v2.149.3 commit fd0f7b69
+- `epic.go:923`, `epic_test.go`
+- mem-pilot-001, mem-pilot-002, mem-pilot-004 (other v2.149.x patterns)
+
+---
+**Captured**: 2026-05-26
+**Confidence**: 95%
+**Concepts**: pilot, executor, debugging, epic, vacuous-truth, predicates

--- a/.agent/knowledge/memories/pitfalls/pitfall_isepic_guard_empty_result_fields.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_isepic_guard_empty_result_fields.md
@@ -1,0 +1,26 @@
+# Pitfall: Missing IsEpic guard mislabels parent results
+
+## Summary
+Epic-parent results legitimately have empty `CommitSHA` and `PRUrl` (children carry those), but the result-handling path treated empty values as failure and mislabeled the parent issue; guard with `IsEpic` check before applying the empty-value failure heuristic.
+
+## Context
+Surfaced during workshop dry-run alongside the vacuous-truth bug. Patched in v2.149.3 (commit fd0f7b69) as part of the empty-set guard work.
+
+## Details
+In `cmd/pilot/handlers.go` and `cmd/pilot/commands.go`, the path that turned execution results into issue labels/comments checked for empty `CommitSHA`/`PRUrl` as a failure signal. For epic parents this is the expected shape — children produce the commits and PRs, the parent aggregates. Without an `IsEpic` guard, every successful epic run was being labeled as failed. Fix added an `IsEpic` short-circuit before the empty-value failure check.
+
+## Recommended Approach
+When epic parent issues are reported failed despite their children succeeding:
+1. Check `cmd/pilot/handlers.go` and `cmd/pilot/commands.go` for failure-detection paths that inspect `CommitSHA`/`PRUrl`.
+2. Verify each such path has an `IsEpic` guard branching before the empty-value check.
+3. This is a result-classification bug, not an execution bug — children may have run fine and still be labeled wrong.
+
+## Related
+- v2.149.3 commit fd0f7b69
+- `cmd/pilot/handlers.go`, `cmd/pilot/commands.go`
+- mem-pilot-001, mem-pilot-002, mem-pilot-003 (other v2.149.x patterns)
+
+---
+**Captured**: 2026-05-26
+**Confidence**: 90%
+**Concepts**: pilot, executor, debugging, epic, result-classification, guard

--- a/.agent/knowledge/memories/pitfalls/pitfall_silent_autopilot_gate_disable.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_silent_autopilot_gate_disable.md
@@ -1,0 +1,25 @@
+# Pitfall: Silent autopilot gate disable
+
+## Summary
+Autopilot can be silently disabled at startup when a gate check fails without emitting a log line, leaving operators unaware that automated execution is off.
+
+## Context
+Surfaced during workshop dry-run when autopilot didn't fire despite a valid queue. Patched in v2.149.1 (commit f032689b).
+
+## Details
+Startup gates evaluated during autopilot init were short-circuiting to "disabled" without writing a corresponding log entry. Operators saw no error — just no execution. The fix added explicit warning log lines whenever a startup gate trips the disable path so the failure mode is observable.
+
+## Recommended Approach
+When user reports "autopilot didn't fire" or "pilot stuck at startup":
+1. Grep startup logs for "autopilot disabled" first.
+2. If absent, inspect the autopilot init path for gate-evaluation branches that exit without logging.
+3. Do NOT pivot to queue/DB state investigation until the startup-gate path is ruled out.
+
+## Related
+- v2.149.1 commit f032689b
+- mem-pilot-002, mem-pilot-003, mem-pilot-004 (other v2.149.x patterns)
+
+---
+**Captured**: 2026-05-26
+**Confidence**: 95%
+**Concepts**: pilot, executor, debugging, autopilot, gates, silent-failure

--- a/.agent/knowledge/memories/pitfalls/pitfall_worktree_path_repo_allowlist.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_worktree_path_repo_allowlist.md
@@ -1,0 +1,27 @@
+# Pitfall: Worktree path equality vs repo allowlist
+
+## Summary
+Pilot's ephemeral `/tmp/pilot-worktree-*` checkouts are rejected by a strict repo-allowlist path check because the worktree path does not equal the configured project path; use `git rev-parse --git-common-dir` to resolve the common git dir before comparing.
+
+## Context
+Surfaced during workshop dry-run as the second Pilot failure of the session. Patched in v2.149.2 (commit aac6de5f, TASK-286).
+
+## Details
+The repo allowlist in `cmd/pilot/repo_allowlist.go:53` compared the runtime working directory against configured project paths via direct equality. Pilot's executor creates worktrees in `/tmp/pilot-worktree-*` (`executor/worktree.go:86`), which never match the project root path string. The fix uses `git rev-parse --git-common-dir` to resolve the worktree back to its common git dir before equality comparison, so worktrees of allowed projects pass the gate.
+
+## Recommended Approach
+When a Pilot run fails at allowlist/permission check:
+1. Check whether the failing path matches `/tmp/pilot-worktree-*` pattern.
+2. If yes, verify `repo_allowlist.go` is using `git-common-dir` resolution, not raw string equality.
+3. Do NOT chase config-file or env-var issues until the worktree resolution path is verified.
+
+## Related
+- v2.149.2 commit aac6de5f
+- TASK-286
+- `executor/worktree.go:86`, `cmd/pilot/repo_allowlist.go:53`
+- mem-pilot-001, mem-pilot-003, mem-pilot-004 (other v2.149.x patterns)
+
+---
+**Captured**: 2026-05-26
+**Confidence**: 95%
+**Concepts**: pilot, executor, debugging, worktree, allowlist, git

--- a/.agent/knowledge/memories/pitfalls/resolved/bug_autopilot_pr_discovery_orphans.md
+++ b/.agent/knowledge/memories/pitfalls/resolved/bug_autopilot_pr_discovery_orphans.md
@@ -1,0 +1,76 @@
+> **RESOLVED/SUPERSEDED (2026-07-06):** Periodic PR reconciliation now exists (reconcileOrphanPRs) and the OnPRCreated/reconciler double-register interplay is covered by pitfalls/bug_onprcreated_reconciler_double_register.md (mem-047). Salvaged from backup/local-main-2026-05-27 for incident forensics (PR #3107).
+
+---
+name: Autopilot PR discovery orphans — PRs invisible to autopilot until daemon restart
+description: Autopilot relies on a synchronous OnPRCreated callback for PR discovery; if that callback doesn't fire (executor returned PRNumber=0, orphan-recovery missed an unlabeled issue, etc), the PR is invisible to autopilot until the daemon restarts and ScanExistingPRs runs. Critical reliability gap with no failsafe.
+type: pitfall
+---
+
+## What goes wrong
+
+Autopilot's PR-discovery is **purely event-driven via `OnPRCreated`** (`internal/autopilot/controller.go:354`). The callback is fired by the GitHub poller at `internal/adapters/github/poller.go:596` AND the gateway handler at `cmd/pilot/main.go:825-826`, gated on `result != nil && result.PRNumber > 0`. If that gate fails for any reason, autopilot will never learn about the PR.
+
+There is **no periodic reconciliation** during normal operation. Only two startup paths register PRs:
+- `RestoreState()` at `controller.go:309` — replays existing `autopilot_pr_state` SQLite rows
+- `ScanExistingPRs()` at `controller.go:2083` — one-shot `ListPullRequests("open")` at startup that registers any `pilot/GH-*` PR not already in `activePRs`
+
+If a PR is created during a window where `OnPRCreated` doesn't fire correctly, it stays orphaned until the daemon restarts.
+
+## Observed incident (2026-05-26, PR #3107 / issue #3100)
+
+- Issue #3100 (TASK-298-redo) executed by Pilot
+- PR #3107 created (`refactor(state_store): consolidate 7 *_processed tables`, branch `pilot/GH-3100`)
+- CI failed on **GitHub Actions infrastructure error** (`codeload.github.com 404 on actions/setup-go`)
+- Pilot recorded `executions.commit_sha = 84273ab8` (a parent SHA, wrong), `pr_url = ''` — and yet PR #3107 exists on GitHub with the real work
+- Autopilot's `autopilot_pr_state` had no row for #3107
+- Adding the `pilot` label to PR #3107 did NOT trigger tracking
+- **Restarting `pilot start --github` made `ScanExistingPRs` run, which then registered #3107** (stage progressed to `ci_passed` after CI re-run)
+
+## Why OnPRCreated didn't fire (ranked hypotheses)
+
+1. **Executor returned `PRNumber=0`** — most likely. The infrastructure CI failure may have caused the runner's post-PR-create verification (or a parallel check) to return `PRNumber=0`. Gate at `poller.go:596` then skipped `OnPRCreated`. The `executions.pr_url=''` record corroborates this — the executor didn't capture the PR URL even though the PR exists.
+2. **`recoverOrphanedIssues` orphan gap** — Issue #3100 had `pilot-in-progress` label remaining when the daemon restarted with the issue label-less. `recoverOrphanedIssues` (`poller.go:401-436`) only queries issues with BOTH the poller label AND `pilot-in-progress` — a label-less stuck issue is invisible to recovery, and the subsequent `HasLabel(InProgress)` gate at `poller.go:721` then permanently skips it.
+3. **`ListPullRequests` no pagination** — `client.go:505-511` does a single GET, GitHub defaults to 30 PRs. Startup scan silently truncates if >30 open PRs.
+
+## How to detect orphaned PRs
+
+```bash
+# All open PRs from Pilot branches
+PILOT_PRS=$(gh pr list --state open --search "head:pilot/" --json number,headRefName --jq '.[].number')
+
+# Compare to what autopilot tracks
+TRACKED=$(sqlite3 ~/.pilot/data/pilot.db \
+  "SELECT pr_number FROM autopilot_pr_state WHERE stage NOT IN ('failed','merged')")
+
+# Orphans = on GitHub but not in autopilot_pr_state
+comm -23 <(echo "$PILOT_PRS" | sort) <(echo "$TRACKED" | sort)
+```
+
+If output is non-empty, those PRs are stuck — autopilot won't move them through CI/merge.
+
+## How to recover
+
+**Immediate fix:** restart the Pilot daemon — `pkill -f "pilot start" && pilot start --github --env <env> --dashboard`. The startup `ScanExistingPRs` will pick up orphans. **Caveat:** if >30 open PRs, the orphan beyond 30 is still missed; see fix direction #2 below.
+
+## Fix direction
+
+### 1. Periodic reconciliation loop (P0, structural)
+Add a goroutine that runs every 60s in `controller.go` (alongside the existing `Run` loop): query `gh pr list --head pilot/* --state open`, diff against `activePRs`, register any missing PR via the same code path as `ScanExistingPRs`. This closes the entire bug class regardless of why `OnPRCreated` missed.
+
+### 2. Paginate `ListPullRequests` (P1)
+`client.go:505-511` — add pagination support, fetch all pages until empty. Currently silently caps at 30.
+
+### 3. Tighten orphan recovery (P1)
+`poller.go:401-436` — query for issues with `pilot-in-progress` regardless of poller label, not the intersection. Or: when poller skips an issue at `poller.go:721` due to `pilot-in-progress`, also check if any orphan PR exists for that issue and surface a structured alert.
+
+### 4. Failsafe in OnPRCreated gate (P1)
+`poller.go:596`, `main.go:825` — when `result != nil && result.PRNumber == 0`, log a structured warning AND call a new `tryRecoverPR(issueNumber)` that does a one-shot `gh pr list --head pilot/GH-{N}` to find the orphaned PR and call `OnPRCreated` manually. This catches the H1 case where the executor lost the PR number.
+
+### 5. Tighten `IsResultShipped` / `result.PRNumber` capture (related)
+The executions.pr_url='' for PR #3107 (which DOES exist on GitHub) indicates the executor's PR-URL capture failed even though `gh pr create` succeeded. See [[bug_pilot_ghost_closes]] Variant 4 — same root cause as the ghost-SHA bug. The capture path needs hardening.
+
+## Related memories
+
+- [[bug_pilot_ghost_closes]] — Variants 4 + 5 share the underlying problem: Pilot's subsystems have inconsistent notions of "this work is alive"
+- [[bug_handleconflict_no_refile]] — autopilot's conflict path was previously fixed for one orphan class
+- [[bug_poller_silent_stop]] — sibling pattern: poller stops, no alarm

--- a/.agent/tasks/archive/TASK-300-executor-ghost-sha-guard.md
+++ b/.agent/tasks/archive/TASK-300-executor-ghost-sha-guard.md
@@ -1,0 +1,143 @@
+> **SALVAGED 2026-07-06** from `backup/local-main-2026-05-27` (never landed on main; status frozen as of 2026-05-26 Wave-5 planning).
+
+# TASK-300: Executor ghost-SHA guard — fail closed when commit_sha is already on base branch
+
+**Wave:** 4 (S) · **Severity:** P0 (silent data loss — 1h10m of Pilot work vanished for #3090) · **Source:** ghost-close incident 2026-05-26 (Variant 4 in `bug_pilot_ghost_closes.md`)
+
+---
+
+## Problem
+
+Executor harvests `commit_sha` from worktree HEAD at `internal/executor/runner.go:2158-2200`. When Claude finishes without making a new commit, `git log -1 --format=%H` returns the **parent commit** (the base SHA from before execution started). That SHA is then recorded in `executions.commit_sha`. `IsResultShipped` at `internal/executor/task_shipped.go:20-27` returns true on `commit_sha != ""`, so:
+
+- `result.Success = true`
+- `IsResultShipped(result) = true` (CommitSHA is non-empty, even though it's a parent SHA)
+- Completion comment posts at `cmd/pilot/handlers.go:834`
+- `pilot-done` label added, issue closed
+- No branch on remote, no PR — work is permanently lost
+
+**Concrete incident:** Issue #3090 (TASK-298), 2026-05-26 11:08 UTC. `executions.commit_sha = 84273ab8` — which is TASK-293's already-shipped commit on main.
+
+## Approach
+
+### Step 1 — SHA freshness check (~30 min)
+
+New helper in `internal/executor/runner.go` (or a new `internal/executor/git_freshness.go`):
+
+```go
+// commitSHAIsNew returns true iff sha exists in the repo AND is NOT an ancestor of origin/<baseBranch>.
+// A SHA already on the base branch is a parent SHA — proof the executor made no new commit.
+func commitSHAIsNew(ctx context.Context, repoPath, sha, baseBranch string) (bool, error) {
+    if sha == "" {
+        return false, nil
+    }
+    // `git merge-base --is-ancestor SHA origin/BASE` exits 0 if SHA is ancestor of BASE.
+    // We want it NOT to be — i.e., a new commit not yet merged.
+    cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "merge-base", "--is-ancestor", sha, "origin/"+baseBranch)
+    err := cmd.Run()
+    if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+        return true, nil // not ancestor — fresh commit
+    }
+    if err != nil {
+        return false, fmt.Errorf("merge-base check: %w", err)
+    }
+    return false, nil // ancestor — parent SHA, not fresh
+}
+```
+
+### Step 2 — Gate the SHA capture (~30 min)
+
+`internal/executor/runner.go:2158-2200` (post-claude SHA harvest):
+
+```go
+result.CommitSHA = capturedSHA
+isNew, _ := commitSHAIsNew(ctx, projectPath, capturedSHA, baseBranch)
+if !isNew {
+    slog.Warn("executor: harvested SHA is already on base branch — no new commit",
+        "sha", capturedSHA, "base", baseBranch, "task", taskID)
+    result.CommitSHA = "" // treat as no-op
+    result.Success = false
+    result.Error = "no new commit produced — worktree HEAD matches base branch parent"
+}
+```
+
+Repeat after `git push` at runner.go:3082 (post-push SHA capture) — defense in depth.
+
+### Step 3 — Tighten `IsResultShipped` predicate (~15 min)
+
+`internal/executor/task_shipped.go:20-27`:
+
+```go
+// Before:
+//   return row.CommitSHA != "" || row.PRUrl != ""
+// After:
+func IsTaskShipped(row Execution) bool {
+    if row.Status != "completed" {
+        return false
+    }
+    // PR URL is the strongest signal — a PR with that URL was created against the remote
+    if row.PRUrl != "" {
+        return true
+    }
+    // CommitSHA alone is insufficient (Variant 4: can be parent SHA).
+    // But if we have a SHA AND status==completed AND error=="", trust it for backwards-compat
+    // until autopilot is hardened. Log when this path is taken.
+    if row.CommitSHA != "" && row.Error == "" {
+        slog.Warn("IsTaskShipped: trusting CommitSHA without PRUrl — verify freshness",
+            "sha", row.CommitSHA)
+        return true
+    }
+    return false
+}
+```
+
+(Or take the stricter path: require `PRUrl != ""`. Decision deferred until TASK-301 lands the autopilot-side hardening — see Out of scope.)
+
+### Step 4 — Tests (~45 min)
+
+- New `internal/executor/git_freshness_test.go`:
+  - SHA on main → `commitSHAIsNew` returns false
+  - SHA on local branch ahead of main → returns true
+  - SHA that doesn't exist → returns error
+  - Empty SHA → returns false
+- New `internal/executor/task_shipped_test.go` additions (file exists from TASK-296):
+  - Row with CommitSHA + Status=completed + no PR URL → should warn but return true (or false per Step 3 decision)
+  - Row with parent-SHA equivalent: assert the upstream guard at runner.go prevents this row from being recorded as `completed`
+
+### Step 5 — Backfill correction (~30 min)
+
+One-shot SQL migration that marks affected legacy rows:
+
+```sql
+-- Find executions where commit_sha is already on origin/main — these are ghosts
+-- (Cannot run automatically without git context; provide a manual `pilot db backfill-ghosts` CLI command instead)
+```
+
+Or document the detection query (already in `bug_pilot_ghost_closes.md` Variant 4) and let operators reconcile manually.
+
+## Files to modify
+
+- New: `internal/executor/git_freshness.go`
+- New: `internal/executor/git_freshness_test.go`
+- `internal/executor/runner.go` (SHA capture sites at lines 2158, 3082)
+- `internal/executor/task_shipped.go` (Step 3 hardening)
+- `internal/executor/task_shipped_test.go` (extend coverage)
+
+## Test Strategy
+
+- Unit: `commitSHAIsNew` table-driven against a temp git repo
+- Integration: synthetic Claude run that produces no commit → assert `executions.status='failed'` not `'completed'`
+- Manual: re-run #3090 against a worktree where Claude is forced to no-op (e.g. trivial issue)
+
+## Effort
+
+S (~2h total). One PR.
+
+## Out of scope
+
+- Hardening the autopilot-side `pilot-done` label timing — TASK-301
+- Backfill of historical ghost executions in `~/.pilot/data/pilot.db` — operational, not code
+
+## Recovery of #3090 work
+
+This task does NOT recover the lost #3090 work. Open a fresh issue (TASK-298 redo) so Pilot's worker sees a new issue number not in its processed set.

--- a/.agent/tasks/archive/TASK-301-autopilot-done-on-merge.md
+++ b/.agent/tasks/archive/TASK-301-autopilot-done-on-merge.md
@@ -1,0 +1,85 @@
+> **SALVAGED 2026-07-06** from `backup/local-main-2026-05-27` (never landed on main; status frozen as of 2026-05-26 Wave-5 planning).
+
+# TASK-301: Gate `pilot-done` + issue close on PR merge, not PR creation
+
+**Wave:** 4 (M) · **Severity:** P1 (silent data loss when post-creation rebase fails) · **Source:** ghost-close incident 2026-05-26 (Variant 5 in `bug_pilot_ghost_closes.md`)
+
+---
+
+## Problem
+
+`pilot-done` label is added and issue is closed at `cmd/pilot/handlers.go:354-382` when `IsResultShipped(result)` returns true at PR-creation time. This fires AS SOON AS a PR URL is captured — long before merge.
+
+When autopilot later detects a merge conflict (`internal/autopilot/controller.go:1766-1806` `handleMergeConflict`), it closes the PR but:
+- Line 1799: only removes `pilot-in-progress` from the issue
+- Does NOT remove `pilot-done`
+- Does NOT reopen the issue
+- Does NOT re-add `pilot` for re-dispatch
+
+Steady-state outcome: issue closed with `pilot-done`, PR closed without merge, code never on main. Pilot's worker won't re-pick because the issue is in CLOSED+pilot-done state.
+
+**Concrete incident:** Issue #3081 (TASK-297), 2026-05-26. PR #3088 opened, post-creation rebase against fresh `docs: sync v2.150.0` + `v2.151.0` commits conflicted on `.agent/system/FEATURE-MATRIX.md`. PR closed by autopilot with comment "Merge conflict detected. Auto-rebase failed — closing PR so the issue can be re-executed from updated main." But the issue was already closed+`pilot-done`, so Pilot never re-picked it.
+
+## Approach
+
+### Option A (preferred) — Move `pilot-done` to merge-success handler
+
+The structurally correct fix.
+
+1. **Remove premature add at `cmd/pilot/handlers.go:354-382`** — keep only `pilot-in-progress` removal there
+2. **Add `pilot-done` + issue close in autopilot's merge-success path** — locate the existing merge handler in `internal/autopilot/controller.go` (search for `handleMergeSuccess` or wherever `removePR` is called on a successfully-merged PR)
+3. **On merge-conflict path (`handleMergeConflict`)** — issue stays open, `pilot` label preserved for re-dispatch
+4. **Edge case**: when running with `--no-autopilot` or in CI mode without autopilot, the merge gate doesn't fire. Add a manual close path: `pilot close <issue> --reason merged` for operators, OR have `handlers.go` add `pilot-done` only when both `IsResultShipped && !autopilotEnabled` (legacy behavior preserved).
+
+### Option B (conservative) — Reverse the close in conflict path
+
+Less invasive but leaves the underlying race intact.
+
+In `internal/autopilot/controller.go:1799` (`handleMergeConflict`):
+
+```go
+gh.RemoveLabel(issue, "pilot-in-progress")
+// NEW:
+gh.RemoveLabel(issue, "pilot-done")
+gh.AddLabel(issue, "pilot")
+gh.ReopenIssue(issue) // only if issue.State == "closed"
+gh.AddComment(issue, fmt.Sprintf("Re-opening for re-execution after auto-rebase failure on PR #%d. Rebase target: current main HEAD.", pr.Number))
+```
+
+### Step-by-step (assuming Option A)
+
+1. **Research (~30 min)**: find the merge-success handler. Grep `internal/autopilot/controller.go` for `MergedAt`, `IsMerged`, `removePR`. Identify where successful merges are observed in the poll loop.
+2. **Move label/close logic (~60 min)**: extract a helper `markIssueShipped(issue, prURL)` that adds `pilot-done` + closes the issue. Call from merge-success handler. Delete the eager call in `handlers.go:354-382`.
+3. **Update conflict path (~30 min)**: `handleMergeConflict` keeps `pilot` label on issue, re-adds it if missing.
+4. **Tests (~90 min)**:
+   - Unit: `markIssueShipped` adds label + closes (mock GitHub client)
+   - Integration: simulate PR-open → conflict-detected → assert issue stays open with `pilot` label
+   - Integration: simulate PR-open → merged → assert issue closes with `pilot-done`
+5. **Backfill (~15 min)**: document `bin/pilot ghost-recovery` operator command or manual gh script for existing ghost-closed issues (already present in `bug_pilot_ghost_closes.md` "How to recover" section).
+
+### Coordination with docs-version-sync
+
+Files commonly conflicting with `docs-version-sync` workflow are guaranteed conflict surfaces for long-running tasks. Add a pre-execution advisory at `internal/executor/runner.go` (BuildPrompt phase): if the task plan mentions any of `.agent/system/FEATURE-MATRIX.md`, `.agent/DEVELOPMENT-README.md`, `docs/lib/version.ts`, and a release is pending (check `gh workflow list --workflow=docs-version-sync.yml`), warn or defer.
+
+(This third item is the smallest of the three but the highest-leverage for preventing TASK-297-style conflicts in the future.)
+
+## Files to modify
+
+- `cmd/pilot/handlers.go` (remove eager close at 354-382, keep `pilot-in-progress` toggle)
+- `internal/autopilot/controller.go` (merge-success path adds `pilot-done` + close; merge-conflict path preserves `pilot` label)
+- New: `internal/autopilot/controller_merge_test.go` (or extend existing test file)
+
+## Test Strategy
+
+- Unit + integration as above
+- Manual: open a PR, force a conflict (rebase main), observe issue stays open and re-picks
+
+## Effort
+
+M (~4h total). One PR.
+
+## Out of scope
+
+- Backfill of existing ghost-closed issues — operational
+- Versioning the `pilot-done` semantic (e.g. add `pilot-ghost-recovered` label) — separate task if needed
+- Per-task-file lock against docs-version-sync — separate enhancement

--- a/.agent/tasks/archive/TASK-302-autopilot-pr-reconciliation.md
+++ b/.agent/tasks/archive/TASK-302-autopilot-pr-reconciliation.md
@@ -1,0 +1,138 @@
+> **SALVAGED 2026-07-06** from `backup/local-main-2026-05-27` (never landed on main; status frozen as of 2026-05-26 Wave-5 planning).
+
+# TASK-302: Autopilot PR reconciliation loop (failsafe for OnPRCreated misses)
+
+**Wave:** 4 (M) · **Severity:** P0 (critical-component reliability gap) · **Source:** autopilot-orphan incident 2026-05-26 (PR #3107 / issue #3100)
+
+---
+
+## Problem
+
+Autopilot's PR-discovery is purely event-driven via `OnPRCreated` callback (`internal/autopilot/controller.go:354`). If that callback misses a fire — for any of multiple known causes — the PR is permanently orphaned until the daemon restarts. There is no periodic reconciliation during normal operation.
+
+**Observed failure modes** (any one of these orphans a PR):
+1. Executor returns `result.PRNumber == 0` (gate at `internal/adapters/github/poller.go:596` and `cmd/pilot/main.go:825`) — happens when post-create verification fails (e.g., CI-already-red, network blip during PR-URL capture)
+2. `recoverOrphanedIssues` (`poller.go:401-436`) skips label-less stuck issues; `HasLabel(InProgress)` gate at `poller.go:721` then permanently skips them
+3. `ListPullRequests` (`internal/adapters/github/client.go:505-511`) has no pagination; startup `ScanExistingPRs` silently caps at 30 open PRs
+
+**Incident (2026-05-26):** PR #3107 (TASK-298-redo) was created on remote but invisible to autopilot for ~40 min until daemon restart. CI initially failed on GitHub Actions infra error (codeload 404), executor recorded `pr_url=''` despite the PR existing. See `.agent/knowledge/memories/pitfalls/bug_autopilot_pr_discovery_orphans.md`.
+
+## Approach
+
+### Step 1 — Reconciliation loop in `controller.go` (~90 min)
+
+Add a periodic reconciliation goroutine alongside the existing `Run` loop:
+
+```go
+// In controller.go, inside Start() or a new startReconciler():
+func (c *Controller) startReconciler(ctx context.Context) {
+    ticker := time.NewTicker(60 * time.Second)
+    defer ticker.Stop()
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case <-ticker.C:
+            c.reconcileOrphanPRs(ctx)
+        }
+    }
+}
+
+func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
+    prs, err := c.gh.ListPullRequests(ctx, "open") // paginated — see Step 2
+    if err != nil {
+        slog.Warn("reconciler: list PRs failed", "err", err)
+        return
+    }
+    for _, pr := range prs {
+        if !strings.HasPrefix(pr.HeadBranch, "pilot/GH-") {
+            continue
+        }
+        c.activeMu.Lock()
+        _, tracked := c.activePRs[pr.Number]
+        c.activeMu.Unlock()
+        if tracked {
+            continue
+        }
+        // Found an orphan — register via same code path as OnPRCreated
+        slog.Warn("reconciler: registering orphan PR",
+            "pr", pr.Number, "branch", pr.HeadBranch)
+        // Reuse ScanExistingPRs' insertion logic OR call OnPRCreated directly
+        c.registerOrphan(pr)
+        autopilotMetrics.OrphanRegistered.Inc()
+    }
+}
+```
+
+### Step 2 — Paginate `ListPullRequests` (~45 min)
+
+`internal/adapters/github/client.go:505-511` — current single GET caps at 30. Add pagination:
+
+```go
+func (c *Client) ListPullRequests(ctx context.Context, state string) ([]*PullRequest, error) {
+    var all []*PullRequest
+    page := 1
+    for {
+        prs, err := c.listPullRequestsPage(ctx, state, page, 100)
+        if err != nil {
+            return nil, err
+        }
+        all = append(all, prs...)
+        if len(prs) < 100 {
+            break
+        }
+        page++
+        if page > 50 { // safety limit
+            slog.Warn("ListPullRequests: hit pagination safety limit", "count", len(all))
+            break
+        }
+    }
+    return all, nil
+}
+```
+
+### Step 3 — Metric for orphan registrations (~15 min)
+
+New counter: `pilot_autopilot_orphan_pr_registered_total{trigger="reconciler"|"startup_scan"}`. Spikes indicate `OnPRCreated` is missing fires — a signal worth alerting on.
+
+### Step 4 — Tests (~60 min)
+
+- Unit (`controller_test.go`): seed an open PR that's NOT in `activePRs`, run one reconciler tick, assert the PR is now in `activePRs` AND `autopilot_pr_state` has a row
+- Unit: PR already tracked → no duplicate registration
+- Unit (paginated `ListPullRequests`): mock GitHub to return 100+ PRs across 2 pages, assert all returned
+
+### Step 5 — Operational doc (~30 min)
+
+Update `.agent/sops/autopilot/` (create dir if needed) with a runbook entry:
+- Detection query for orphan PRs (already in pitfall memory, copy here)
+- How the reconciler closes the gap
+- What to do if metric shows persistent orphan registrations (root-cause investigation pointer)
+
+## Files to modify
+
+- `internal/autopilot/controller.go` (reconciler loop + orphan registration)
+- `internal/autopilot/controller_test.go` (or new `controller_reconciler_test.go`)
+- `internal/adapters/github/client.go` (pagination)
+- `internal/adapters/github/client_test.go` (pagination test)
+- `internal/autopilot/metrics.go` (or wherever counters live — add `OrphanRegistered`)
+- New: `.agent/sops/autopilot/orphan-pr-recovery.md`
+
+## Test Strategy
+
+- Unit + integration as above
+- Manual: kill `OnPRCreated` callback (force result.PRNumber=0 in a test build), create a PR via the executor, wait 60s, observe reconciler logs registering it
+
+## Effort
+
+M (~4h total). One PR.
+
+## Out of scope
+
+- Hardening `OnPRCreated`'s upstream (executor PR-URL capture) — covered by [[TASK-300]] and a follow-up TASK
+- Orphan recovery for label-less issues — covered by a separate sibling task
+- Reconciliation alarms / paging — observability work, separate
+
+## Closes / blocks
+
+- Closes orphan-PR class of bugs described in `.agent/knowledge/memories/pitfalls/bug_autopilot_pr_discovery_orphans.md`
+- Does NOT block TASK-300 or TASK-301 — parallel-safe

--- a/.agent/tasks/archive/TASK-303-hot-upgrade-restart-failure.md
+++ b/.agent/tasks/archive/TASK-303-hot-upgrade-restart-failure.md
@@ -1,0 +1,215 @@
+> **SALVAGED 2026-07-06** from `backup/local-main-2026-05-27` (never landed on main; status frozen as of 2026-05-26 Wave-5 planning).
+
+# TASK-303 — Hot-upgrade "u" key produces silent failure on macOS
+
+**Status:** open
+**Created:** 2026-05-26
+**Type:** bug + UX
+**Priority:** high (every release rollout is affected)
+**Affects:** macOS users running `pilot start` with dashboard mode
+**Related:** [[bug_hot_upgrade_silent_codesign]], [[bug_hot_upgrade_restarting_ui_trap]]
+
+---
+
+## Symptom
+
+User presses `u` in the dashboard to apply a newly-detected release. The TUI shows:
+
+1. `Installing v2.x.x... [████████] 100%` (UpgradeStateInProgress)
+2. Then "restart" wording appears somewhere
+3. But the running process keeps reporting the **previous** version
+4. Only a manual `Ctrl+C` + `pilot start` picks up the new binary
+
+The new binary **is on disk** (manual relaunch loads it cleanly) — the in-place hot restart is what fails.
+
+---
+
+## Root cause analysis
+
+Full chain traced end-to-end in research session (2026-05-26). Three defects compound:
+
+### Defect 1 — `PrepareForExecution` error is swallowed
+
+`internal/upgrade/upgrade.go:405-407`:
+```go
+// Prepare binary for execution (removes quarantine, signs on macOS)
+// Errors are non-fatal - binary may still work
+_ = PrepareForExecution(u.binaryPath)
+```
+
+On macOS, `PrepareForExecution` runs `codesign -s -` (ad-hoc sign) and returns its error (`internal/upgrade/codesign_darwin.go:16`). When that error is discarded, the freshly-installed binary may be unsigned. Gatekeeper then blocks `syscall.Exec` from loading it.
+
+### Defect 2 — `UpgradeStateInProgress` never displays `upgradeMessage`
+
+`internal/dashboard/tui.go:2744-2747` renders `"Installing %s... %s %d%%"` and ignores `m.upgradeMessage`. The hot-upgrade flow updates `upgradeMessage` to `"Restarting..."` at 100% (`internal/upgrade/hot.go:139`), but the user never sees that text.
+
+### Defect 3 — `UpgradeStateComplete` text claims a restart that didn't happen
+
+`internal/dashboard/tui.go:2749-2751` renders `"Now running %s - Restarting..."`. On Unix this state should be unreachable (successful `syscall.Exec` would have replaced the process). When the state IS reached, the message lies — the user sees "Now running v2.x.x" but the process is still old. Whether the state is reachable on Unix today is itself a question (see "Verification" below).
+
+---
+
+## Goals
+
+1. **Surface the real failure** — codesign errors must propagate so the user / logs see them
+2. **Fix the UI** — the dashboard must accurately reflect whether exec succeeded, failed, or was skipped
+3. **Pre-flight the new binary** — verify it can actually run before committing to `syscall.Exec`
+4. **No regression in Windows path** — Windows correctly returns nil + manual-restart message; preserve that
+
+---
+
+## Acceptance criteria
+
+- [ ] `PrepareForExecution` returns its error and the caller treats codesign failure as fatal on Darwin
+- [ ] When the upgrade fails for ANY reason, the TUI shows a clearly-labeled failure pane with the error message — not a "Restarting..." or "Installing... 100%" frozen state
+- [ ] A new pre-exec smoke test (`exec.Command(binaryPath, "--version").Run()` or equivalent) runs immediately before `syscall.Exec` and fails the upgrade cleanly if the new binary cannot start
+- [ ] On macOS, attempting to hot-upgrade an unsigned binary produces a specific error string mentioning Gatekeeper / codesign — not a generic "restart failed"
+- [ ] On Windows, the user still sees "Upgrade installed — restart manually" (no behavioral regression)
+- [ ] Unit tests cover: codesign error propagation, smoke-test failure, TUI state transitions for all four `UpgradeState*` values
+- [ ] Manual smoke test on macOS: deliberately corrupt a release artifact's signature, press `u`, observe a clear failure message
+
+---
+
+## Out of scope (split into follow-ups if needed)
+
+- Telemetry / metrics for upgrade success rate (separate task)
+- Removing the dependency on the system `codesign` binary entirely (would require Go-native Mach-O signing — large effort)
+- Notarization workflow for releases (operational, not code)
+
+---
+
+## Implementation plan
+
+### Phase 1 — Surface the codesign error (1-2h, smallest blast radius)
+
+**Files:**
+- `internal/upgrade/upgrade.go:407` — replace `_ =` with explicit error handling
+- `internal/upgrade/codesign_darwin.go` — return a wrapped error that mentions the binary path
+- `internal/upgrade/codesign_other.go` — keep no-op stub returning nil (verify file exists)
+
+**Changes:**
+```go
+// upgrade.go:407 (after install)
+if err := PrepareForExecution(u.binaryPath); err != nil {
+    return fmt.Errorf("post-install preparation failed (binary may be blocked by Gatekeeper): %w", err)
+}
+```
+
+**Tests:**
+- `internal/upgrade/upgrade_test.go` — add test that injects a failing `PrepareForExecution` (via interface or build-tag injection) and asserts the upgrade returns the wrapped error
+
+### Phase 2 — Pre-exec smoke test (2-3h)
+
+**Files:**
+- `internal/upgrade/restart.go` — add a `verifyExecutable(binaryPath string) error` helper called before `syscall.Exec`
+
+**Changes:**
+```go
+// restart.go:35 (before stdout/stderr sync)
+if err := verifyExecutable(binaryPath); err != nil {
+    return fmt.Errorf("new binary failed pre-exec verification: %w", err)
+}
+
+func verifyExecutable(binaryPath string) error {
+    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    defer cancel()
+    out, err := exec.CommandContext(ctx, binaryPath, "--version").CombinedOutput()
+    if err != nil {
+        return fmt.Errorf("--version failed (%w): %s", err, string(out))
+    }
+    return nil
+}
+```
+
+**Tests:**
+- `internal/upgrade/restart_test.go` — table tests for: binary missing, binary not executable, binary crashes on `--version`, binary succeeds
+
+### Phase 3 — TUI failure rendering (2-3h)
+
+**Files:**
+- `internal/dashboard/tui.go:2735-2755` — rework the upgrade panel switch
+
+**Changes:**
+
+1. `UpgradeStateInProgress` should append `m.upgradeMessage` when non-empty:
+```go
+case UpgradeStateInProgress:
+    bar := m.renderProgressBar(m.upgradeProgress, 30)
+    content.WriteString(fmt.Sprintf("  Installing %s... %s %d%%", m.updateInfo.LatestVersion, bar, m.upgradeProgress))
+    if m.upgradeMessage != "" {
+        content.WriteString(fmt.Sprintf("\n  %s", m.upgradeMessage))
+    }
+```
+
+2. `UpgradeStateComplete` should match the *actual* semantics — on success exec already replaced the process, so this state in practice means "install done, restart required" (matches Windows). Reword to:
+```go
+case UpgradeStateComplete:
+    content.WriteString(fmt.Sprintf("  Upgrade to %s installed — restart Pilot manually to apply.", m.updateInfo.LatestVersion))
+```
+
+3. `UpgradeStateFailed` rendering already exists at 2753-2755; verify it visually dominates the panel and isn't easily missed. Consider a red/yellow style if `lipgloss` is used.
+
+**Tests:**
+- `internal/dashboard/tui_test.go` — render-snapshot tests for each upgrade state
+
+### Phase 4 — Documentation + memory update (30 min)
+
+- Update `.agent/knowledge/memories/patterns/pattern_hot_upgrade_bootstrap.md` if behavior changes
+- Add to `.agent/knowledge/graph.json` (use `nav-graph` skill to add nodes for the two new pitfalls + this task)
+- Verify CLAUDE.md mentions nothing stale about hot upgrade
+
+---
+
+## Verification steps (manual, post-implementation)
+
+1. **Happy path:**
+   - Build local binary, tag a fake release, run `pilot start`, press `u`
+   - Expect: process replaces in-place, version banner updates to new tag
+
+2. **Codesign failure repro (macOS):**
+   - Stub `PrepareForExecution` to return an error (via test build tag)
+   - Press `u` — expect TUI shows "post-install preparation failed (binary may be blocked by Gatekeeper): ..."
+
+3. **Corrupted binary repro:**
+   - Stub the download to write `#!/bin/false` instead of a valid binary
+   - Press `u` — expect TUI shows "new binary failed pre-exec verification: ..."
+   - Critically: old process must still be running with old version, user can dismiss and retry
+
+4. **Windows regression check:**
+   - On Windows VM, press `u`
+   - Expect: "Upgrade to vX.Y.Z installed — restart Pilot manually to apply."
+
+---
+
+## Risk / blast radius
+
+- **Low-to-medium.** Changes are localized to `internal/upgrade/*.go` and `internal/dashboard/tui.go`. No DB schema changes, no API changes. Worst case: a new bug in the upgrade path makes upgrades fail more loudly — but the current symptom is "fails silently with confusing UX," so loud failure is itself an improvement.
+- The pre-exec smoke test adds ~50-200ms to upgrade time (one `--version` invocation). Acceptable.
+- Tests must cover the build-tag matrix (`darwin`, `linux`, `windows`) for `codesign_*.go` and `restart*.go`.
+
+---
+
+## Effort estimate
+
+- Phase 1: 1-2h
+- Phase 2: 2-3h
+- Phase 3: 2-3h
+- Phase 4: 30 min
+- **Total: ~6-9h**
+
+Reasonable to hand off as a single Pilot issue.
+
+---
+
+## Handoff template (GitHub issue body)
+
+```
+Hot-upgrade ("u" key) silently fails on macOS — new binary lands on disk but `syscall.Exec` is blocked by Gatekeeper, and the TUI doesn't surface the real failure. Full RCA in .agent/tasks/TASK-303-hot-upgrade-restart-failure.md.
+
+Fix in three phases (single PR):
+1. Stop swallowing PrepareForExecution errors (internal/upgrade/upgrade.go:407)
+2. Add pre-exec smoke test in RestartWithNewBinary (internal/upgrade/restart.go)
+3. Make TUI upgrade panel render upgradeMessage in-progress and reword Complete state (internal/dashboard/tui.go:2735-2755)
+
+Acceptance criteria + verification steps in the task file. Preserve Windows manual-restart behavior.
+```

--- a/.agent/tasks/archive/TASK-304-workflow-yaml-per-repo-override.md
+++ b/.agent/tasks/archive/TASK-304-workflow-yaml-per-repo-override.md
@@ -1,0 +1,164 @@
+> **SALVAGED 2026-07-06** from `backup/local-main-2026-05-27` (never landed on main; status frozen as of 2026-05-26 Wave-5 planning).
+
+# TASK-304: `.pilot/workflow.yaml` per-repo prompt + policy override
+
+**Status**: queued
+**Created**: 2026-05-26
+**Severity**: P1
+**Effort**: L (~1 day)
+**Job (JTD)**: J2 Hand-off
+**Source**: Symphony research, Wave 5 / `~/.claude/plans/let-s-plan-that-use-staged-seal.md`
+
+---
+
+## Context
+
+**Problem**: Pilot's executor prompt and execution policy live entirely on the Pilot side. Customers cannot customize agent behavior per repo without forking Pilot. Different teams have different conventions (commit format, branch naming, definition-of-done, test-running) that today must be implicit knowledge.
+
+**Goal**: A `.pilot/workflow.yaml` file (YAML front-matter + Markdown body) checked into the target repo, read by Pilot at the start of each run. Sections:
+
+```yaml
+---
+version: 1
+agent:
+  max_turns: 20
+  reasoning_effort: high
+policy:
+  commit_format: conventional
+  branch_prefix: pilot/GH-
+  pr_template: .github/pull_request_template.md
+hooks:                       # placeholder; full hooks in TASK-305
+  after_create: null
+  before_run: null
+  after_run: null
+  before_remove: null
+---
+
+# Workflow
+
+[Markdown prompt body — appended to executor system prompt, gives the agent
+project-specific instructions, definition-of-done, conventions, etc.]
+```
+
+Borrowed from Symphony's `WORKFLOW.md` (`/tmp/symphony/elixir/WORKFLOW.md`).
+
+**Why now**: J2 Hand-off is P1 both personas. Per-repo override is the path to multi-team adoption — same insight that made Codex's repo-local `.codex/skills/` work for Symphony.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Pilot reads `.pilot/workflow.yaml` from the target repo's worktree before executor run.
+- [ ] If file missing, fall back to current behavior (zero regression).
+- [ ] Front-matter `agent.*` overrides corresponding executor profile fields.
+- [ ] Front-matter `policy.*` is exposed to executor prompt as structured fields.
+- [ ] Markdown body is appended to executor system prompt under a clear header (e.g., `## Project Workflow`).
+- [ ] Schema is versioned (`version: 1`); unknown top-level keys are ignored with a warning, not an error.
+- [ ] `hooks:` is parsed but not yet executed in this task (TASK-305 does that).
+
+---
+
+## Implementation
+
+### Phase 1: Loader + schema
+**Tasks**:
+- [ ] Create `internal/executor/workflow/workflow.go` with `Workflow` struct + `Load(repoPath string) (*Workflow, error)`.
+- [ ] Parse YAML front-matter delimited by `---` (use `gopkg.in/yaml.v3`).
+- [ ] Markdown body stored as `PromptAppendix string`.
+- [ ] Validate version field; warn on unknown keys.
+
+**Files**:
+- `internal/executor/workflow/workflow.go` (new)
+- `internal/executor/workflow/workflow_test.go` (new)
+
+### Phase 2: Executor integration
+**Tasks**:
+- [ ] In `internal/executor/runner.go`, after worktree setup and before prompt construction:
+  1. Call `workflow.Load(worktreePath)`.
+  2. If found: apply `agent.*` overrides to executor profile; merge `policy.*` into prompt context; append `PromptAppendix` to system prompt.
+  3. If not found: log debug, proceed with defaults.
+
+**Files**:
+- `internal/executor/runner.go`
+- `internal/executor/prompt_builder.go` (or equivalent)
+
+### Phase 3: Documentation + example
+**Tasks**:
+- [ ] Add `.pilot/workflow.yaml` example to `configs/` directory.
+- [ ] Document schema in `docs/` (workflow.yaml reference page).
+- [ ] **Dogfood**: convert Pilot's own repo to use `.pilot/workflow.yaml` and measure how much of the hardcoded executor prompt absorbs.
+
+**Files**:
+- `configs/workflow.example.yaml`
+- `docs/` (workflow reference)
+- `.pilot/workflow.yaml` (Pilot's own — dogfood)
+
+---
+
+## Out of Scope
+
+- Hook execution (`after_create`, `before_run`, etc.) — implemented in TASK-305.
+- Workflow inheritance / includes (v1 is single file).
+- Live reload during a run — workflow is loaded once at run start.
+- Workflow validation CLI (`pilot workflow validate`) — defer if dogfood finds bugs.
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|---|---|---|---|
+| File location | `.pilot/workflow.yaml`, `pilot.yaml`, `.github/pilot.yaml` | `.pilot/workflow.yaml` | Matches Symphony naming, room for siblings (`.pilot/skills/`) |
+| Front-matter format | YAML, TOML, JSON | YAML | Consistent with `~/.pilot/config.yaml`; humans read it |
+| Body format | Markdown, plaintext | Markdown | Same as Symphony; renders nicely in repo |
+| Version handling | strict, lax, schema-validated | Lax (warn on unknown keys, fail only on bad version) | Forward-compatible |
+
+---
+
+## Files Affected (estimate)
+
+- `internal/executor/workflow/` (new package)
+- `internal/executor/runner.go`
+- `internal/executor/prompt_builder.go`
+- `configs/workflow.example.yaml` (new)
+- `.pilot/workflow.yaml` (new, in Pilot's own repo)
+- `docs/` (workflow reference page)
+
+---
+
+## Verify
+
+```bash
+go test ./internal/executor/workflow/...
+go test ./internal/executor/...
+
+# Dogfood: spawn Pilot run on a fork using .pilot/workflow.yaml override; confirm
+# prompt appendix appears in executor logs; confirm agent.max_turns honored.
+make test
+```
+
+**Dogfood gate** (from master plan verification §3): if `.pilot/workflow.yaml` doesn't naturally absorb >50% of currently-hardcoded executor prompt content, the abstraction is wrong — revisit before TASK-305.
+
+---
+
+## Done
+
+- [ ] Loader package shipped with unit tests
+- [ ] Executor reads + applies overrides
+- [ ] Example file in `configs/`
+- [ ] Schema documented
+- [ ] Pilot's own repo dogfoods the override (50%+ absorption signal)
+- [ ] Zero regression when file absent
+
+---
+
+## Refs
+
+- Master plan: `~/.claude/plans/let-s-plan-that-use-staged-seal.md`
+- Symphony evidence: `/tmp/symphony/elixir/WORKFLOW.md` (entire file)
+- Symphony spec: `/tmp/symphony/SPEC.md` §3 (workflow), §11 (extensions)
+- Related: `TASK-305` (workspace hooks consume `hooks:` block)
+
+---
+
+**Last Updated**: 2026-05-26

--- a/.agent/tasks/archive/TASK-305-workspace-lifecycle-hooks.md
+++ b/.agent/tasks/archive/TASK-305-workspace-lifecycle-hooks.md
@@ -1,0 +1,144 @@
+> **SALVAGED 2026-07-06** from `backup/local-main-2026-05-27` (never landed on main; status frozen as of 2026-05-26 Wave-5 planning).
+
+# TASK-305: Workspace lifecycle hooks (after_create / before_run / after_run / before_remove)
+
+**Status**: queued
+**Created**: 2026-05-26
+**Severity**: P2
+**Effort**: M (~4h)
+**Job (JTD)**: J2 Hand-off
+**Source**: Symphony research, Wave 5 / `~/.claude/plans/let-s-plan-that-use-staged-seal.md`
+**Depends on**: TASK-304 (consumes `hooks:` block from `.pilot/workflow.yaml`)
+
+---
+
+## Context
+
+**Problem**: Pilot's worktree setup is largely hardcoded. Per-project bootstrap (run `mise`, install deps, build artifacts, snapshot logs on exit) requires either Pilot-side code changes or implicit conventions. Customers cannot inject project-specific lifecycle steps without forking.
+
+**Goal**: Four shell-script hook points executed by Pilot around each session, configured from `.pilot/workflow.yaml`:
+
+| Hook | When | Use case |
+|---|---|---|
+| `after_create` | Right after worktree created, before agent starts | Install deps, run `mise install`, fetch submodules |
+| `before_run` | Just before agent prompt is sent | Set env vars, warm caches |
+| `after_run` | After agent finishes (any status) | Snapshot artifacts, run cleanup linter |
+| `before_remove` | Just before worktree is destroyed | Archive logs, persist artifacts |
+
+Borrowed from Symphony's workspace hooks (`/tmp/symphony/elixir/lib/symphony_elixir/workspace.ex`).
+
+**Why now**: Builds on TASK-304. Without hooks, the workflow.yaml is half a story.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Each hook is an optional shell script (or list of shell scripts) declared under `hooks:` in `.pilot/workflow.yaml`.
+- [ ] Hooks execute in the worktree directory with the same env as the executor.
+- [ ] `after_create` failure aborts the run with status `setup_failed`.
+- [ ] `before_run` failure aborts the run with status `setup_failed`.
+- [ ] `after_run` and `before_remove` failures log warnings but don't change the run's success status (cleanup-best-effort).
+- [ ] Each hook has a configurable timeout (default 300s).
+- [ ] Hook stdout/stderr captured into executor logs (visible in TUI LOGS panel).
+- [ ] Hooks can read env vars `$PILOT_TASK_ID`, `$PILOT_BRANCH`, `$PILOT_ISSUE_URL`, `$PILOT_WORKTREE`.
+
+---
+
+## Implementation
+
+### Phase 1: Hook runner
+**Tasks**:
+- [ ] Create `internal/executor/workflow/hooks.go` with `RunHook(ctx, name, workflow, env)` function.
+- [ ] Resolve hook string from `workflow.Hooks[name]`; support single string or list.
+- [ ] Execute via `bash -lc "<script>"` in worktree dir.
+- [ ] Apply timeout; stream stdout/stderr to executor log.
+
+**Files**:
+- `internal/executor/workflow/hooks.go` (new)
+- `internal/executor/workflow/hooks_test.go` (new)
+
+### Phase 2: Executor wiring
+**Tasks**:
+- [ ] In `internal/executor/runner.go`, call hooks at the 4 lifecycle points:
+  - After `WorktreeCreate`: `after_create`.
+  - Before `SendPrompt`: `before_run`.
+  - After agent finishes: `after_run`.
+  - Before `WorktreeDestroy`: `before_remove`.
+- [ ] Honor abort semantics for `after_create` and `before_run`.
+
+**Files**:
+- `internal/executor/runner.go`
+
+### Phase 3: Env + observability
+**Tasks**:
+- [ ] Populate hook env: `PILOT_TASK_ID`, `PILOT_BRANCH`, `PILOT_ISSUE_URL`, `PILOT_WORKTREE`.
+- [ ] Add `executions.status = 'setup_failed'` (new) for hook-driven aborts.
+- [ ] Add Prometheus counter `pilot_hook_runs_total{hook="after_create",status="ok"}`.
+
+**Files**:
+- `internal/executor/runner.go`
+- `internal/memory/store.go`
+
+---
+
+## Out of Scope
+
+- Hook templating (no `{{ task_id }}` substitution; env vars only).
+- Hook composition / inheritance (each hook is a single shell snippet or list).
+- Per-hook resource limits beyond timeout (no CPU/memory caps in v1).
+- Cross-platform hooks (assume Unix shell; Windows worktrees not supported anyway).
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|---|---|---|---|
+| Hook execution | Direct exec, bash -lc, sh -c | `bash -lc` | Matches Symphony; loads user profile (mise, asdf, nvm work) |
+| List support | Single string only, list of strings | List of strings (sequential) | Common pattern (e.g., install deps + warm cache) |
+| Failure semantics | Always abort, never abort, per-hook | Per-hook (after_create + before_run abort; rest warn) | Mirrors Symphony; matches lifecycle intent |
+| Timeout default | 60s, 300s, 600s, none | 300s | Compile/install can be slow; configurable |
+
+---
+
+## Files Affected (estimate)
+
+- `internal/executor/workflow/hooks.go` (new)
+- `internal/executor/workflow/hooks_test.go` (new)
+- `internal/executor/runner.go`
+- `internal/memory/store.go` (new status value)
+
+---
+
+## Verify
+
+```bash
+go test ./internal/executor/workflow/...
+
+# Dogfood: add a `hooks.after_create: ["mise install"]` to Pilot's own .pilot/workflow.yaml;
+# verify executor logs show hook ran; verify env vars passed correctly.
+```
+
+---
+
+## Done
+
+- [ ] Hook runner shipped with tests
+- [ ] Executor invokes 4 hooks at correct lifecycle points
+- [ ] Abort semantics correct (`after_create`/`before_run` abort; `after_run`/`before_remove` warn)
+- [ ] Env vars available inside hooks
+- [ ] `setup_failed` status visible in dashboard
+- [ ] Pilot's own repo dogfoods at least one hook
+
+---
+
+## Refs
+
+- Master plan: `~/.claude/plans/let-s-plan-that-use-staged-seal.md`
+- Symphony evidence: `/tmp/symphony/elixir/lib/symphony_elixir/workspace.ex` (hook lifecycle)
+- Symphony spec: `/tmp/symphony/SPEC.md` §3 (workspace lifecycle)
+- Parent: `TASK-304` (workflow.yaml)
+
+---
+
+**Last Updated**: 2026-05-26

--- a/.agent/tasks/archive/TASK-306-workpad-ticket-comment-pattern.md
+++ b/.agent/tasks/archive/TASK-306-workpad-ticket-comment-pattern.md
@@ -1,0 +1,172 @@
+> **SALVAGED 2026-07-06** from `backup/local-main-2026-05-27` (never landed on main; status frozen as of 2026-05-26 Wave-5 planning).
+
+# TASK-306: Workpad ticket-comment pattern (cross-adapter)
+
+**Status**: queued
+**Created**: 2026-05-26
+**Severity**: P0
+**Effort**: M-L (~1 day)
+**Job (JTD)**: J3 Observe + J5 Review
+**Source**: Symphony research, Wave 5 / `~/.claude/plans/let-s-plan-that-use-staged-seal.md`
+
+---
+
+## Context
+
+**Problem**: Today Pilot's executor leaves a stream of free-form comments on the source ticket (GitHub Issue, Linear, Jira, etc.). Operators/reviewers must scroll the thread to reconstruct what the agent is doing. There is no single canonical artifact per ticket. Stakeholders watching from the tracker side see noise, not progress.
+
+**Goal**: One persistent, structured comment per ticket — the **Workpad** — that the agent edits in place at each milestone. Always renders the same template:
+
+```
+## Pilot Workpad
+
+### Plan
+1. ...
+2. ...
+
+### Acceptance Criteria
+- [ ] ...
+- [ ] ...
+
+### Validation
+- ...
+
+### Notes
+- ...
+
+### Confusions / Pushback
+- ...
+```
+
+Borrowed from OpenAI Symphony's Codex Workpad (`/tmp/symphony/elixir/WORKFLOW.md` lines 296–326).
+
+**Why now**: Highest-ROI Symphony borrow per JTD map. Hits Observe (J3) and Review (J5) jobs simultaneously. Low surface-area change touching only adapter comment-poster paths — no executor or autopilot churn.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Single comment per ticket on each of the 6 trackers (github, gitlab, jira, linear, azuredevops, asana, plane). On second + subsequent milestones, **edit** the existing comment rather than post a new one.
+- [ ] Workpad section template fixed (Plan / Acceptance Criteria / Validation / Notes / Confusions) and identical across adapters.
+- [ ] Comment carries a stable marker (e.g., HTML comment `<!-- pilot-workpad:v1 -->`) so future runs can locate and update it.
+- [ ] Executor populates Workpad fields at: (a) start of run (Plan + Acceptance Criteria), (b) after each significant phase (Validation + Notes), (c) on completion / failure (final state).
+- [ ] If the adapter API does not support comment editing (Slack/Discord/Telegram out of scope; they're chat, not trackers), gracefully skip — no error.
+- [ ] Verbose per-step chatter elsewhere is reduced or routed to executor logs, not the ticket.
+
+---
+
+## Implementation
+
+### Phase 1: Workpad renderer + locator (adapter-agnostic)
+**Goal**: Define the canonical Workpad type and renderer in one place.
+
+**Tasks**:
+- [ ] Create `internal/executor/workpad/workpad.go` with `Workpad` struct (Plan, AcceptanceCriteria, Validation, Notes, Confusions fields) and `Render() string` method.
+- [ ] Define marker constant (e.g., `<!-- pilot-workpad:v1 -->`) used as locator for find-and-edit.
+- [ ] Unit test the renderer for stable output across multiple update cycles.
+
+**Files**:
+- `internal/executor/workpad/workpad.go` (new)
+- `internal/executor/workpad/workpad_test.go` (new)
+
+### Phase 2: Per-adapter UpsertWorkpad
+**Goal**: Each tracker adapter gains an `UpsertWorkpad(issueID, workpad)` method that locates the marker and either creates or edits the comment.
+
+**Tasks**:
+- [ ] Extend each adapter's comment client with `UpsertWorkpad`:
+  - `internal/adapters/github/client.go` (GH REST: PATCH `/repos/:o/:r/issues/comments/:id`)
+  - `internal/adapters/gitlab/client.go` (notes API supports edit)
+  - `internal/adapters/jira/client.go` (PUT `/issue/:key/comment/:id`)
+  - `internal/adapters/linear/client.go` (`commentUpdate` GraphQL mutation)
+  - `internal/adapters/azuredevops/client.go` (PATCH work-item-comments API)
+  - `internal/adapters/asana/client.go` (story update — verify if supported; if not, fall back to delete+create)
+  - `internal/adapters/plane/client.go` (comment update endpoint)
+- [ ] Each `UpsertWorkpad` first list-comments + grep-for-marker, then create OR update.
+
+**Files**: see above per adapter.
+
+### Phase 3: Executor wiring
+**Goal**: Executor calls `UpsertWorkpad` at three points: start-of-run, post-phase, end-of-run.
+
+**Tasks**:
+- [ ] In `internal/executor/runner.go` (around the existing comment-posting calls) replace ad-hoc comment posts with `workpad.Upsert(...)` calls.
+- [ ] Allow the Claude Code session to update the Workpad mid-flight by exposing a small tool/hook (deferred — phase 4 if needed).
+- [ ] Confirm `executor.Task` has enough metadata (`SourceAdapter`, `SourceIssueID`) to route Workpad writes (already does, per `internal/executor/runner.go:134`).
+
+**Files**:
+- `internal/executor/runner.go`
+
+### Phase 4 (optional): Agent-driven Workpad updates
+**Goal**: Claude Code itself can update Workpad fields during the run, not just at executor-controlled boundaries.
+
+Deferred — ship phases 1–3 first, measure stakeholder feedback, then decide.
+
+---
+
+## Out of Scope
+
+- Workpad on chat adapters (Slack/Discord/Telegram). Different surface — handled by a separate task if/when needed.
+- Backfill of Workpads on already-merged or in-flight pre-TASK-306 tickets.
+- Workpad localization / templating per repo (that's `TASK-304` territory).
+- Removing all existing executor comments — only consolidate the *operational status* updates; PR-creation and final-state comments may stay separate if cleaner.
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|---|---|---|---|
+| Marker mechanism | HTML comment, hidden char, frontmatter | HTML comment (`<!-- pilot-workpad:v1 -->`) | Visible in raw markdown, ignored by renderers, easy to grep, version-able |
+| Renderer location | Per-adapter, shared package | Shared package (`internal/executor/workpad/`) | One source of truth; identical render across trackers |
+| Edit vs delete+recreate | edit, delete+recreate, append | Edit (with fallback to delete+recreate where API doesn't support edit) | Preserves comment ID for permalink stability |
+| Trigger points | Every event, fixed milestones | Fixed milestones (start, post-phase, end) | Avoids API rate-limit thrash; clear semantics |
+
+---
+
+## Files Affected (estimate)
+
+- `internal/executor/workpad/` (new package)
+- `internal/executor/runner.go` (modified)
+- `internal/adapters/{github,gitlab,jira,linear,azuredevops,asana,plane}/client.go` (each modified)
+
+Test files alongside each.
+
+---
+
+## Verify
+
+```bash
+# Unit tests for the Workpad renderer
+go test ./internal/executor/workpad/...
+
+# Per-adapter UpsertWorkpad tests (mocked HTTP)
+go test ./internal/adapters/{github,gitlab,jira,linear,azuredevops,asana,plane}/...
+
+# Full executor integration test against a sandbox repo
+make test
+```
+
+**Manual E2E**: file a `pilot`-labeled issue on a test repo; confirm exactly one Pilot Workpad comment exists at end of run; confirm marker present; confirm second run on same issue *edits* the comment, doesn't duplicate.
+
+---
+
+## Done
+
+- [ ] Workpad renderer ships with unit tests
+- [ ] All 6 tracker adapters have working `UpsertWorkpad`
+- [ ] Executor uses Workpad at 3 milestone points
+- [ ] One-comment-per-ticket invariant verified on at least 2 adapters end-to-end (GitHub + Linear minimum)
+- [ ] No regression in existing comment paths (PR creation, final-state notification)
+
+---
+
+## Refs
+
+- Master plan: `~/.claude/plans/let-s-plan-that-use-staged-seal.md` (JTD context)
+- Symphony evidence: `/tmp/symphony/elixir/WORKFLOW.md` lines 296–326 (Workpad template)
+- Symphony spec: `/tmp/symphony/SPEC.md` §10 (agent protocol)
+- Related: `TASK-304` (`.pilot/workflow.yaml` may eventually override Workpad template)
+
+---
+
+**Last Updated**: 2026-05-26

--- a/.agent/tasks/archive/TASK-307-rework-lane-on-changes-requested.md
+++ b/.agent/tasks/archive/TASK-307-rework-lane-on-changes-requested.md
@@ -1,0 +1,150 @@
+> **SALVAGED 2026-07-06** from `backup/local-main-2026-05-27` (never landed on main; status frozen as of 2026-05-26 Wave-5 planning).
+
+# TASK-307: `Rework` lane — clean reset on review-changes-requested
+
+**Status**: queued
+**Created**: 2026-05-26
+**Severity**: P0
+**Effort**: M (~4h)
+**Job (JTD)**: J4 Course-correct
+**Source**: Symphony research, Wave 5 / `~/.claude/plans/let-s-plan-that-use-staged-seal.md`
+
+---
+
+## Context
+
+**Problem**: When a human reviewer requests changes on a Pilot PR, today's flow falls into `review_requested` (PRStage enum, `internal/autopilot/types.go:366-388`) and the agent incrementally patches the existing PR. Patching a rotten plan is the #1 source of bad autonomous PRs — the agent compounds confusion instead of replanning.
+
+**Goal**: A `Rework` lane that, on review-changes-requested, executes a **clean reset**:
+1. Close the PR (no merge).
+2. Delete or archive the Workpad (TASK-306 dependency where shipped).
+3. Create a fresh branch from `main`.
+4. Re-run the planning phase — the agent sees the reviewer's feedback as new input, not as a patch instruction.
+
+Borrowed from Symphony's `Rework` lane (`/tmp/symphony/elixir/WORKFLOW.md` lines 251–260).
+
+**Why now**: Trust gap. Adjacent to Wave 4 ghost-SHA / orphan-PR fixes (TASK-300, TASK-302). Without `Rework`, the existing `review_requested` stage drives agents into compounding-mistake loops.
+
+---
+
+## Acceptance Criteria
+
+- [ ] When reviewer comments "needs rework" (configurable trigger phrase) **or** transitions PR via explicit Pilot label `pilot-rework`, the autopilot closes the PR.
+- [ ] Branch is deleted/archived; new branch is created from latest `origin/main`.
+- [ ] Reviewer's most recent comments are passed to the agent as planning input, not as a patch instruction.
+- [ ] `autopilot_pr_state.stage` records the rework cycle (new enum value: `reworking`).
+- [ ] Limited to N rework cycles per issue (configurable, default 2) — beyond that, escalate to human-required.
+- [ ] No data loss: prior PR description + Workpad archived for audit.
+
+---
+
+## Implementation
+
+### Phase 1: PRStage extension
+**Tasks**:
+- [ ] Add `reworking` to `PRStage` enum in `internal/autopilot/types.go`.
+- [ ] Update `AllPRStages()` and Prometheus zero-value gauges.
+- [ ] Add transition: `review_requested → reworking → pr_created` (new cycle).
+- [ ] Add rework-cycle counter column to `autopilot_pr_state` (migration).
+
+**Files**:
+- `internal/autopilot/types.go`
+- `internal/autopilot/state_store.go` (migration + counter column)
+
+### Phase 2: Trigger detection
+**Tasks**:
+- [ ] In autopilot reviewer-feedback handler, detect rework-trigger (configurable phrase + label).
+- [ ] Add config field `autopilot.rework_trigger_phrase` (default `"rework"`) and `autopilot.rework_label` (default `"pilot-rework"`).
+
+**Files**:
+- `internal/autopilot/feedback.go` (or equivalent reviewer-comment scanner — verify exact path during impl)
+- `internal/config/` (YAML schema)
+
+### Phase 3: Reset sequence
+**Tasks**:
+- [ ] Implement `Rework()` in autopilot:
+  1. Close PR via adapter (GitHub/GitLab/etc.) — non-merge close.
+  2. Archive Workpad comment (rename marker to `<!-- pilot-workpad:archived-{cycle} -->`).
+  3. Delete or rename old branch to `pilot/archive/{branch}-{cycle}`.
+  4. Create new branch from `origin/main`.
+  5. Re-enqueue issue with `from_pr: <old_pr_number>` + `rework_feedback: <reviewer_comments>` so executor prompt includes feedback as planning input.
+- [ ] Cap at `autopilot.max_rework_cycles` (default 2). Beyond that, label issue `pilot-needs-human`.
+
+**Files**:
+- `internal/autopilot/rework.go` (new)
+- `internal/autopilot/state_machine.go` (wire transitions)
+
+### Phase 4: Executor prompt awareness
+**Tasks**:
+- [ ] Executor prompt template recognizes `rework_feedback` field and frames it as "Reviewer feedback on prior attempt" rather than "patch this PR".
+
+**Files**:
+- `internal/executor/prompt_builder.go` (or current prompt-construction site)
+
+---
+
+## Out of Scope
+
+- Auto-detection of "this rework is going nowhere, escalate" beyond a hard cycle cap.
+- ML-based reviewer-intent classification (use configurable phrase + label for v1).
+- Cross-issue rework correlation (no learning across reworks in v1; deferred to J7 / future).
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|---|---|---|---|
+| Trigger mechanism | Phrase-only, label-only, both | Both (OR) | Label = explicit; phrase = lower-friction |
+| Branch handling | Delete, archive-rename, keep | Archive-rename (`pilot/archive/...`) | Preserves audit trail; restorable if cycle cap hit |
+| Cycle cap | None, 1, 2, 3, configurable | Default 2, configurable | Empirically: 2 rework attempts before human is right |
+| Feedback to executor | Patch list, free-text, structured | Free-text from reviewer comments, framed as planning input | Avoids the "patch this" anchor |
+
+---
+
+## Files Affected (estimate)
+
+- `internal/autopilot/types.go`
+- `internal/autopilot/state_store.go`
+- `internal/autopilot/rework.go` (new)
+- `internal/autopilot/feedback.go`
+- `internal/autopilot/state_machine.go`
+- `internal/executor/prompt_builder.go`
+- `internal/config/` (YAML schema)
+
+---
+
+## Verify
+
+```bash
+go test ./internal/autopilot/...
+go test ./internal/executor/...
+
+# E2E: file a Pilot ticket on a test repo, open PR, comment "needs rework" on the PR,
+# verify branch archived + new branch from main + new PR opened + cycle counter incremented.
+make test
+```
+
+---
+
+## Done
+
+- [ ] `reworking` PRStage exists + persisted + observable in dashboard
+- [ ] Rework triggers on configured phrase or label
+- [ ] Old branch archived, new branch from main, new PR opened, Workpad reset
+- [ ] Cycle cap enforced; `pilot-needs-human` label applied at cap
+- [ ] E2E run on test repo demonstrates full reset
+- [ ] No regression on incremental-fix path (when rework NOT triggered, behavior unchanged)
+
+---
+
+## Refs
+
+- Master plan: `~/.claude/plans/let-s-plan-that-use-staged-seal.md`
+- Symphony evidence: `/tmp/symphony/elixir/WORKFLOW.md` lines 251–260
+- Wave 4 adjacent: `TASK-300`, `TASK-301`, `TASK-302`
+- Related: `TASK-306` (Workpad archive on reset)
+
+---
+
+**Last Updated**: 2026-05-26

--- a/.agent/tasks/archive/TASK-308-event-based-stall-timer.md
+++ b/.agent/tasks/archive/TASK-308-event-based-stall-timer.md
@@ -1,0 +1,127 @@
+> **SALVAGED 2026-07-06** from `backup/local-main-2026-05-27` (never landed on main; status frozen as of 2026-05-26 Wave-5 planning).
+
+# TASK-308: Event-based stall timer (last-event vs global-elapsed)
+
+**Status**: queued
+**Created**: 2026-05-26
+**Severity**: P1
+**Effort**: S (~2h)
+**Job (JTD)**: J4 Course-correct
+**Source**: Symphony research, Wave 5 / `~/.claude/plans/let-s-plan-that-use-staged-seal.md`
+
+---
+
+## Context
+
+**Problem**: Pilot's current stall detection (where it exists) measures global-elapsed turn time. A live-but-slow agent (large file edit, slow tool call, long thinking turn) can be killed prematurely. Conversely, a genuinely hung agent (deadlocked on a tool call, infinite loop) goes undetected until the global timeout — by which point Pilot has wasted budget.
+
+**Goal**: Stall detection measured against **last meaningful event** (turn output, tool call, tool result), not global elapsed. Threshold (e.g., `stall_timeout_ms=180_000`) kills only sessions with no event activity in that window. Long-but-live runs survive; hung runs die fast.
+
+Borrowed from Symphony's `codex.stall_timeout_ms` (`/tmp/symphony/SPEC.md` lines 783–789).
+
+**Why now**: Adjacent to TASK-302 (PR reconciliation) and the Wave 4 reliability theme. Cheap to implement, big trust win.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Executor tracks a `last_event_at` timestamp per running session, updated on each agent event (output chunk, tool call, tool result).
+- [ ] Stall watchdog (configurable interval, default 30s) checks `now - last_event_at > stall_timeout`; if true, terminates session with `stalled` status.
+- [ ] Stall threshold configurable per executor profile (default 3 minutes).
+- [ ] Session-terminated-as-stalled is distinguishable from session-failed-as-error in `executions.status` and dashboard.
+- [ ] Long-but-live sessions (e.g., 5-minute file write with periodic output) are NOT killed by the watchdog.
+
+---
+
+## Implementation
+
+### Phase 1: Event-time tracking
+**Tasks**:
+- [ ] In `internal/executor/runner.go` (or wherever the Claude Code stream is read), record `lastEventAt time.Time` per session.
+- [ ] Update on each chunk/event from the agent stream.
+
+**Files**:
+- `internal/executor/runner.go`
+
+### Phase 2: Watchdog goroutine
+**Tasks**:
+- [ ] Spawn a `safeGo()` watchdog per session (use existing pattern, see TASK-292) that ticks every 30s.
+- [ ] On tick: if `now - lastEventAt > stallTimeout`, kill the session (cancel context).
+- [ ] Mark execution status `stalled` (new value), distinct from `failed`.
+
+**Files**:
+- `internal/executor/runner.go` (or `internal/executor/watchdog.go` if cleaner)
+
+### Phase 3: Config + observability
+**Tasks**:
+- [ ] Add `executor.stall_timeout_ms` (default 180000) to config schema.
+- [ ] Add new `executions.status = 'stalled'` value; backfill safe (new value, no migration needed beyond enum docs).
+- [ ] Emit Prometheus counter `pilot_executor_stalled_total` and surface in dashboard HISTORY panel as a distinct icon.
+
+**Files**:
+- `internal/config/`
+- `internal/memory/store.go` (status enum doc)
+- `internal/dashboard/tui.go` (HISTORY icon for stalled)
+
+---
+
+## Out of Scope
+
+- Per-tool stall budgets (e.g., "if bash call hangs for X, kill"). v1 is whole-session granularity.
+- Automatic restart on stall — stalled means failed; user/autopilot decides retry.
+- Stall heuristics beyond simple time delta.
+
+---
+
+## Technical Decisions
+
+| Decision | Options | Chosen | Reasoning |
+|---|---|---|---|
+| Event definition | Any byte, only structured events, tool calls only | Any chunk/event from agent stream | Simplest; long file writes still emit chunks |
+| Watchdog frequency | Per-event check, periodic tick | 30s tick | Lower overhead; granularity sufficient |
+| Default threshold | 60s, 180s, 300s, 600s | 180s | Per Symphony spec default; balances trust vs false-positive |
+| Status value | reuse `failed`, new `stalled` | New `stalled` | Distinguishable; supports targeted alerting |
+
+---
+
+## Files Affected (estimate)
+
+- `internal/executor/runner.go`
+- `internal/executor/watchdog.go` (new, optional)
+- `internal/config/`
+- `internal/memory/store.go`
+- `internal/dashboard/tui.go`
+
+---
+
+## Verify
+
+```bash
+go test ./internal/executor/...
+
+# Manual: spawn a deliberately-hung agent (e.g., infinite-loop tool mock); verify it dies at threshold.
+# Manual: spawn a long-but-streaming agent (large file write); verify it survives.
+```
+
+---
+
+## Done
+
+- [ ] `lastEventAt` tracked per session
+- [ ] Watchdog kills idle sessions at threshold
+- [ ] `executions.status = 'stalled'` surfaced in dashboard
+- [ ] Long-but-live sessions don't trip the watchdog (verified manually)
+- [ ] Prometheus counter emits
+
+---
+
+## Refs
+
+- Master plan: `~/.claude/plans/let-s-plan-that-use-staged-seal.md`
+- Symphony evidence: `/tmp/symphony/SPEC.md` lines 783–789 (`stall_timeout_ms`)
+- Related: `TASK-292` (`safeGo()` panic-recovery — use that pattern for the watchdog)
+- Adjacent: `TASK-302` (PR reconciliation, similar reliability theme)
+
+---
+
+**Last Updated**: 2026-05-26

--- a/.agent/tasks/archive/TASK-309-autopilot-releasing-stage-stuck.md
+++ b/.agent/tasks/archive/TASK-309-autopilot-releasing-stage-stuck.md
@@ -1,0 +1,115 @@
+> **SALVAGED 2026-07-06** from `backup/local-main-2026-05-27` (never landed on main; status frozen as of 2026-05-26 Wave-5 planning).
+
+# TASK-309: Autopilot `releasing` stage stuck forever — purge predicate + scan re-registration + handler retry
+
+**Wave:** 5 (M) · **Severity:** P1 (cosmetic now, structural state leak) · **Source:** observation 2026-05-26 (PR #3130, plus historical residue from PR #3107, #3101)
+
+---
+
+## Problem
+
+`autopilot_pr_state` rows stay at `stage='releasing'` indefinitely after the PR is merged on GitHub. Observed for PR #3130 (TASK-294-redo): merged 2026-05-26 ~14:58 UTC, row still at `stage='releasing', updated_at=14:58:52` 20+ minutes later. Same pattern on historical PRs #3107 and #3101.
+
+Side effect: `autopilot_metrics.active_prs` stays at `1` indefinitely (the `activePRs` map isn't pruned because `handleReleasing`/`removePR` never runs to completion).
+
+## Root cause (single root, four interacting bugs)
+
+Researched via navigator agent. The releasing stage has *four* compounding problems, any one of which would create the stuck state; together they make recovery impossible without manual SQL.
+
+### B1 — `checkExternalMergeOrClose` ejects before `handleReleasing` runs
+
+`internal/autopilot/controller.go:2425-2473`. Every tick, `processAllPRs` calls `checkExternalMergeOrClose` (line 2394) BEFORE `ProcessPR` (line 2414). When `ghPR.Merged=true` AND `prState.Stage == StageReleasing`, the condition at line 2461 falls through to `c.removePR(prState.PRNumber)` (line 2472) and returns `true`. `ProcessPR` is never called; `handleReleasing` never runs. The PR is in this state from tick 2 onward forever.
+
+### B2 — `handleReleasing` returns error → state frozen, no retry budget
+
+`internal/autopilot/controller.go:1681-1683`. `GetPRCommits` (or `GetTagForSHA`/`CreateTagForRepo`) error → `handleReleasing` returns the error. `recordPRFailure` fires. Stage stays `StageReleasing` (the function never advanced). `persistPRState` writes the frozen row. There's no `handleReleasing`-specific retry — only the global per-PR circuit breaker (`MaxFailures=3`, types.go:317) which only stops `ProcessPR` from running, not the stage transition.
+
+### B3 — `ScanRecentlyMergedPRs` re-registers the PR after cleanup
+
+`internal/autopilot/controller.go:2236-2279`. The scan skip gate (line 2238) only checks the in-memory `activePRs` map. After `removePR` deletes from `activePRs` (B1 path) but DB still has `stage='releasing'`, the next scan re-registers the PR at `stage=StageReleasing` (line 2277) and writes a new DB row. Then on the next tick, B1 fires again. Net effect: row deleted and re-created every `mergedScanInterval` (default 5 min), always at `releasing`.
+
+### B4 — `PurgeTerminalPRStates` only purges `failed`
+
+`internal/autopilot/state_store.go:451`. The cleanup query only filters on `stage='failed'`. `stage='releasing'` rows are never auto-purged — they're immortal until an explicit `RemovePRState` succeeds. Combined with B3's silent failures, the row never clears.
+
+## Approach
+
+### Step 1 — B1 fix (highest impact, ~30 min)
+
+`internal/autopilot/controller.go:2461` — change the ejection logic so that when `prState.Stage == StageReleasing`, we DO NOT call `removePR`. Instead return `false` (or `continue`) so `ProcessPR` proceeds to `handleReleasing` for completion.
+
+```go
+// Before (releasing PR ejected without finishing):
+if ghPR.Merged && prState.Stage != StageMerging {
+    c.removePR(prState.PRNumber)
+    return true
+}
+
+// After (let releasing PRs reach their handler):
+if ghPR.Merged && prState.Stage != StageMerging && prState.Stage != StageReleasing {
+    c.removePR(prState.PRNumber)
+    return true
+}
+```
+
+### Step 2 — B2 fix (~60 min)
+
+Add `handleReleasing`-specific retry budget separate from the global circuit breaker:
+
+- Up to 3 attempts with 30s backoff between
+- If exhausted, log structured error AND call `removePR` to free the slot (don't leave the row at `releasing` forever)
+- New counter: `pilot_autopilot_releasing_retry_total{outcome="success"|"exhausted"}`
+
+### Step 3 — B3 fix (~30 min)
+
+`internal/autopilot/controller.go:2236-2241` — extend the skip gate to also query `stateStore.GetPRState(pr.Number)`. Skip re-registration if a row exists at `stage='releasing'` AND `updated_at` is recent (within `2 × mergedScanInterval`). Otherwise the scan correctly catches abandoned-tracker cases.
+
+### Step 4 — B4 fix (~15 min)
+
+`internal/autopilot/state_store.go:451` — broaden `PurgeTerminalPRStates` to also purge `stage='releasing'` rows older than 30 minutes (configurable). This is a safety net for any future bug that still leaves orphans.
+
+### Step 5 — Manual cleanup for existing stuck rows (~15 min)
+
+One-off SQL or `pilot autopilot cleanup-releasing` admin command:
+
+```sql
+DELETE FROM autopilot_pr_state
+WHERE stage = 'releasing'
+  AND updated_at < datetime('now', '-30 minutes');
+```
+
+### Step 6 — Tests (~90 min)
+
+- Unit (`controller_test.go`): merged PR with stage=releasing → assert `handleReleasing` runs, not `removePR`
+- Unit: `handleReleasing` returns error 3x → assert `removePR` called, stage cleared from DB
+- Unit: scan re-registration → assert PR with existing `releasing` row is skipped
+- Unit (`state_store_test.go`): `PurgeTerminalPRStates` removes a 31-min-old `releasing` row
+
+### Step 7 — Manual smoke (~30 min)
+
+- Stop daemon, manually insert a `releasing` row for a real merged PR
+- Start daemon, observe row transitions to `done`/deleted within 1-2 ticks
+- Verify metric `active_prs` returns to 0 if no other active PRs
+
+## Files
+
+- `internal/autopilot/controller.go` (B1 fix at line 2461; B2 retry budget around line 1681; B3 skip gate at line 2238)
+- `internal/autopilot/state_store.go` (B4 purge predicate at line 451)
+- `internal/autopilot/controller_test.go` (extend)
+- `internal/autopilot/state_store_test.go` (extend)
+- `internal/autopilot/metrics.go` (new `ReleasingRetry` counter)
+- Optional: new `cmd/pilot/autopilot_cleanup.go` admin command
+
+## Out of scope
+
+- **Observing release-workflow completion** (GoReleaser CI / Docker / Desktop). Current behavior: `handleReleasing` considers itself done as soon as `CreateTagForRepo` returns success. Whether to extend autopilot to also watch the downstream CI workflows is a separate (larger) decision; this task only ensures stage transitions clear properly.
+- The duplicated TASK-302 commit pattern (`bd392b11` shipped 13 min after PR #3119 squash-merge) — separate cleanup task if recurring.
+
+## Related memories
+
+- `bug_autopilot_pr_discovery_orphans.md` — sister bug, TASK-302 fixed it for PR-discovery; this task fixes it for PR-transition.
+- `bug_pilot_ghost_closes.md` — same theme: subsystems with inconsistent notions of "this work is alive".
+
+## Wave 5 status
+
+This is the third autopilot reliability gap surfaced this week (TASK-302 = orphan-PR registration; TASK-301 = pilot-done timing; TASK-309 = releasing-stage drain). All three share the same architectural root: the autopilot state machine has fragmented invariants. After TASK-309 lands, the autopilot side is structurally consistent; the executor side still has TASK-300 + TASK-301 pending.

--- a/.claude/skills/pilot-debug/SKILL.md
+++ b/.claude/skills/pilot-debug/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: pilot-debug
+description: Pin Pilot executor failures against known v2.149.x patterns before exploring adjacent systems. Invoke when user says "pilot failed", "executor stuck", "epic stuck", "autopilot didn't fire", or similar pilot-failure phrasing.
+allowed-tools: Read, Grep, Bash
+---
+
+# Pilot Executor Debug Triage
+
+When invoked, state the hypothesis FIRST in this exact order before
+running any investigation tool. Each pattern was patched in v2.149.1–.3
+and has high prior probability of recurring.
+
+## Triage order
+
+1. **Silent autopilot gate** (v2.149.1, commit f032689b)
+   - Diagnostic: grep startup logs for "autopilot disabled" or missing
+     startup gate log lines
+   - Code: autopilot init path / startup gate evaluation
+
+2. **Worktree path equality** (v2.149.2, commit aac6de5f, TASK-286)
+   - Diagnostic: check whether the worktree path is `/tmp/pilot-worktree-*`
+     and whether `git rev-parse --git-common-dir` resolves correctly
+   - Code: `executor/worktree.go:86` vs `cmd/pilot/repo_allowlist.go:53`
+
+3. **Vacuous-truth empty children** (v2.149.3, commit fd0f7b69)
+   - Diagnostic: inspect `allChildrenDone(...)` invocation site for empty
+     child-set handling
+   - Code: `epic.go:923`
+
+4. **Missing IsEpic guard** (v2.149.3, commit fd0f7b69)
+   - Diagnostic: check whether epic-parent results with empty `CommitSHA`
+     or `PRUrl` are being flagged as failed
+   - Code: `cmd/pilot/handlers.go`, `cmd/pilot/commands.go`
+
+## Output
+
+State one of:
+
+- `match: <pattern N>` — proceed with the per-pattern diagnostic above.
+- `novel: <one-line reason none match>` — write a failing regression test
+  FIRST, then escalate.
+
+## Anti-patterns
+
+Do NOT touch session dirs, daemon config, queue state, or DB until all 4
+known patterns are ruled out. Past sessions burned cycles wandering
+through session_dirs/ and daemon config before the actual bug surfaced.
+
+## Related memories
+
+- `.agent/knowledge/memories/pitfalls/mem-pilot-001.md` — silent gate
+- `.agent/knowledge/memories/pitfalls/mem-pilot-002.md` — worktree path
+- `.agent/knowledge/memories/pitfalls/mem-pilot-003.md` — vacuous truth
+- `.agent/knowledge/memories/pitfalls/mem-pilot-004.md` — IsEpic guard


### PR DESCRIPTION
Recovery PR from the branch audit. `backup/local-main-2026-05-27` held 18 files that never landed on main (orphaned by the May-27 root-branch incident).

## Salvaged

| What | Where | Graph |
|---|---|---|
| `bug_hot_upgrade_silent_codesign.md`, `bug_hot_upgrade_restarting_ui_trap.md` | `memories/pitfalls/` | mem-016/mem-017 `file:` links repaired (dangling since May) |
| 4 `mem-pilot-00X.md` pitfalls, renamed to descriptive slugs | `memories/pitfalls/` | indexed as mem-082..085 |
| `bug_autopilot_pr_discovery_orphans.md` | `memories/pitfalls/resolved/` (superseded by `reconcileOrphanPRs` + mem-047; PR #3107 forensics kept) | indexed as mem-081, `resolved: true` |
| TASK-300..309 Wave-5 planning docs | `tasks/archive/` with provenance headers | — |
| `pilot-debug` skill | `.claude/skills/pilot-debug/` | — |

## Verification
0 broken `file:` links · graph 80→85 memories, 147→160 edges

Branch `backup/local-main-2026-05-27` is kept until this merges (per approval).