### PR TITLE
feat(handlers): M7 4d.3 — spec-guard on the SDK poll path

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -21,7 +21,9 @@ import (
 	"github.com/qf-studio/pilot/internal/budget"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/ghissue"
 	"github.com/qf-studio/pilot/internal/logging"
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
 // syncBoardStatus updates a GitHub Projects V2 board column for an issue.
@@ -1181,8 +1183,8 @@ func handleAzureDevOpsIssueWithResult(ctx context.Context, cfg *config.Config, e
 //
 // ev.SequenceID is already "GH-42" (prefixed by the SDK adapter) — used verbatim as the task ID to
 // avoid the GH-GH-42 double-prefix the legacy handler's fmt.Sprintf("GH-%d", ...) would create.
-// This minimal path does NOT carry board sync, spec-guard, or sub-issue handling — those remain
-// exclusively in the legacy in-tree handler until later M7 phases.
+// Board sync is handled at the SDK-poller level (config-driven); the spec-guard gate runs below
+// (M7 4d.3). Sub-issue handling remains exclusive to the legacy in-tree handler until later phases.
 func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkcore.IssueEvent, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner, monitor *executor.Monitor, program *tea.Program, alertsEngine *alerts.Engine, enforcer *budget.Enforcer) (*sdkcore.IssueResult, error) {
 	taskID := ev.SequenceID // "GH-42"; already prefixed by the SDK adapter — do NOT re-prefix
 	title := ev.Title
@@ -1191,11 +1193,35 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 	branchName := fmt.Sprintf("pilot/%s", taskID)
 
 	// ResolveRepoForEvent is tolerated like the other SDK handlers; ErrRepoNotResolved is non-fatal here.
-	if _, _, _, err := sdkshim.ResolveRepoForEvent(cfg, "github", ev); err != nil && err.Error() != sdkshim.ErrRepoNotResolved.Error() {
+	_, repoOwner, repoName, resolveErr := sdkshim.ResolveRepoForEvent(cfg, "github", ev)
+	if resolveErr != nil && resolveErr.Error() != sdkshim.ErrRepoNotResolved.Error() {
 		logging.WithComponent("github").Warn("Unexpected repo resolution error",
 			slog.String("task_id", taskID),
-			slog.Any("error", err),
+			slog.Any("error", resolveErr),
 		)
+	}
+
+	// M7 4d.3: pre-dispatch spec quality gate on the SDK path (GH-2619 parity —
+	// previously exclusive to the legacy in-tree handler). The issue is
+	// reconstructed from the event; labels ride along so the
+	// pilot-skip-spec-check opt-out works.
+	if resolveErr == nil && repoOwner != "" && repoName != "" {
+		if ghToken, _ := resolveGitHubToken(cfg); ghToken != "" {
+			specClient := githubSDK.NewClient(ghToken)
+			issueNum, _ := strconv.Atoi(ev.IssueID)
+			specLabels := make([]githubSDK.Label, 0, len(ev.Labels))
+			for _, l := range ev.Labels {
+				specLabels = append(specLabels, githubSDK.Label{Name: l})
+			}
+			specIssue := &githubSDK.Issue{Number: issueNum, Title: title, Body: ev.Body, Labels: specLabels}
+			parentResolver := func(parentNum int) (*githubSDK.Issue, error) {
+				return specClient.GetIssue(ctx, repoOwner, repoName, parentNum)
+			}
+			if specResult := ghissue.ValidateSpec(specIssue, parentResolver); !specResult.Valid && specResult.SkipReason == "" {
+				applySpecGuardSDK(ctx, specClient, repoOwner, repoName, specIssue, specResult.FailureReasons)
+				return &sdkcore.IssueResult{Success: false, Skipped: true, SkipReason: "spec_incomplete"}, nil
+			}
+		}
 	}
 
 	task := &executor.Task{

--- a/cmd/pilot/spec_guard_sdk.go
+++ b/cmd/pilot/spec_guard_sdk.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+
+	"github.com/qf-studio/pilot/internal/ghissue"
+)
+
+// applySpecGuardSDK runs the two-strike spec validation gate for an issue on
+// the SDK poll path (M7 4d.3). SDK-typed sibling of applySpecGuard — the two
+// share semantics and the comment marker; the in-tree version retires with
+// the adapter package. Returns true when dispatch should be skipped.
+//
+// First call with a failing issue adds pilot-spec-incomplete and posts a
+// structured comment. Subsequent call (comment marker already present)
+// escalates to pilot-blocked. Board-failed-column sync is handled at the SDK
+// poller level, not here.
+func applySpecGuardSDK(ctx context.Context, client *githubSDK.Client, owner, repo string, issue *githubSDK.Issue, reasons []string) bool {
+	comments, err := client.ListIssueComments(ctx, owner, repo, issue.Number)
+	if err != nil {
+		slog.Warn("spec-guard(sdk): failed to list comments, skipping guard",
+			slog.Int("issue", issue.Number), slog.Any("error", err))
+		return false
+	}
+
+	markerFound := false
+	for _, c := range comments {
+		if strings.Contains(c.Body, ghissue.SpecCommentMarker) {
+			markerFound = true
+			break
+		}
+	}
+
+	if !markerFound {
+		// First strike: warn and ask the author to improve the body.
+		if err := client.AddLabels(ctx, owner, repo, issue.Number, []string{githubSDK.LabelSpecIncomplete}); err != nil {
+			logGitHubAPIError("AddLabels[spec-incomplete,sdk]", owner, repo, issue.Number, err)
+		}
+		comment := buildSpecIncompleteComment(reasons)
+		if _, err := client.AddComment(ctx, owner, repo, issue.Number, comment); err != nil {
+			logGitHubAPIError("AddComment[spec-incomplete,sdk]", owner, repo, issue.Number, err)
+		}
+		slog.Warn("spec-guard(sdk): first strike — issue body too thin, dispatch skipped",
+			slog.Int("issue", issue.Number), slog.Any("reasons", reasons))
+	} else {
+		// Second strike: block the issue.
+		if err := client.AddLabels(ctx, owner, repo, issue.Number, []string{githubSDK.LabelBlocked}); err != nil {
+			logGitHubAPIError("AddLabels[blocked,sdk]", owner, repo, issue.Number, err)
+		}
+		slog.Warn("spec-guard(sdk): second strike — escalating to pilot-blocked",
+			slog.Int("issue", issue.Number))
+	}
+
+	return true
+}

--- a/cmd/pilot/spec_guard_sdk_test.go
+++ b/cmd/pilot/spec_guard_sdk_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+
+	"github.com/qf-studio/pilot/internal/ghissue"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+type specGuardFake struct {
+	server        *httptest.Server
+	mu            sync.Mutex
+	existing      []string // comment bodies returned by ListIssueComments
+	labelsAdded   []string
+	commentsAdded []string
+}
+
+func newSpecGuardFake(existingComments ...string) *specGuardFake {
+	f := &specGuardFake{existing: existingComments}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/comments"):
+			type c struct {
+				Body string `json:"body"`
+			}
+			out := make([]c, len(f.existing))
+			for i, b := range f.existing {
+				out[i] = c{Body: b}
+			}
+			_ = json.NewEncoder(w).Encode(out)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			var body struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			f.mu.Lock()
+			f.labelsAdded = append(f.labelsAdded, body.Labels...)
+			f.mu.Unlock()
+			_, _ = w.Write([]byte("[]"))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			f.mu.Lock()
+			f.commentsAdded = append(f.commentsAdded, body.Body)
+			f.mu.Unlock()
+			_, _ = w.Write([]byte(`{"id":1}`))
+		default:
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	return f
+}
+
+func TestApplySpecGuardSDK_FirstStrike(t *testing.T) {
+	f := newSpecGuardFake()
+	defer f.server.Close()
+
+	client := githubSDK.NewClientWithBaseURL(testutil.FakeGitHubToken, f.server.URL)
+	issue := &githubSDK.Issue{Number: 7, Title: "thin", Body: "too thin"}
+
+	skipped := applySpecGuardSDK(context.Background(), client, "o", "r", issue, []string{"body too short"})
+	if !skipped {
+		t.Fatal("guard must skip dispatch on first strike")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.labelsAdded) != 1 || f.labelsAdded[0] != githubSDK.LabelSpecIncomplete {
+		t.Errorf("labels added = %v, want [%s]", f.labelsAdded, githubSDK.LabelSpecIncomplete)
+	}
+	if len(f.commentsAdded) != 1 || !strings.Contains(f.commentsAdded[0], ghissue.SpecCommentMarker) {
+		t.Errorf("first-strike comment missing marker; comments = %d", len(f.commentsAdded))
+	}
+}
+
+func TestApplySpecGuardSDK_SecondStrikeEscalates(t *testing.T) {
+	f := newSpecGuardFake("earlier strike\n" + ghissue.SpecCommentMarker + "\ndetails")
+	defer f.server.Close()
+
+	client := githubSDK.NewClientWithBaseURL(testutil.FakeGitHubToken, f.server.URL)
+	issue := &githubSDK.Issue{Number: 7, Title: "still thin", Body: "still too thin"}
+
+	skipped := applySpecGuardSDK(context.Background(), client, "o", "r", issue, []string{"body too short"})
+	if !skipped {
+		t.Fatal("guard must skip dispatch on second strike")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.labelsAdded) != 1 || f.labelsAdded[0] != githubSDK.LabelBlocked {
+		t.Errorf("labels added = %v, want [%s]", f.labelsAdded, githubSDK.LabelBlocked)
+	}
+	if len(f.commentsAdded) != 0 {
+		t.Errorf("second strike must not post another comment; got %d", len(f.commentsAdded))
+	}
+}
+
+// TestGithubHandlerSDK_SpecGuardWired is a source-level guard: the SDK handler
+// must run ghissue.ValidateSpec before dispatch (M7 4d.3 — the canary-caught
+// spec-gate class must not regress when the SDK poll path goes live).
+func TestGithubHandlerSDK_SpecGuardWired(t *testing.T) {
+	content, err := os.ReadFile("handlers.go")
+	if err != nil {
+		t.Fatalf("read handlers.go: %v", err)
+	}
+	body := githubFuncBody(t, "handlers.go", "func handleGithubIssueEventSDK(")
+	_ = content
+	if !strings.Contains(body, "ghissue.ValidateSpec") {
+		t.Error("handleGithubIssueEventSDK must run ghissue.ValidateSpec before dispatch")
+	}
+	if !strings.Contains(body, "applySpecGuardSDK") {
+		t.Error("handleGithubIssueEventSDK must apply the spec guard on validation failure")
+	}
+}

--- a/internal/ghissue/spec.go
+++ b/internal/ghissue/spec.go
@@ -1,0 +1,94 @@
+package ghissue
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// SpecCommentMarker is embedded in the first-strike comment to enable
+// idempotency checks. MUST stay byte-identical to the legacy in-tree marker
+// (internal/adapters/github/spec_validator.go) so a strike recorded by one
+// path is visible to the other during the M7 transition.
+const SpecCommentMarker = "<!-- pilot-spec-incomplete -->"
+
+const specMinBodyLen = 100
+
+var (
+	// parentOnlyRe matches a body that is solely a "Parent: GH-NNN" line.
+	parentOnlyRe = regexp.MustCompile(`(?i)^\s*Parent:\s*GH-\d+\s*$`)
+	// parentRefRe extracts the parent issue number from a Parent: GH-NNN line.
+	parentRefRe = regexp.MustCompile(`(?i)Parent:\s*GH-(\d+)`)
+	// autopilotMetaRe detects decomposer-generated sub-issues.
+	autopilotMetaRe = regexp.MustCompile(`<!--\s*autopilot-meta\s`)
+	// sectionHeaderRe requires at least one recognized structural section header (H2–H6).
+	sectionHeaderRe = regexp.MustCompile(`(?im)^#{2,6}\s+(Acceptance|Implementation|Context|Background|Approach|Design|Refs)\b`)
+)
+
+// SpecValidationResult holds the outcome of ValidateSpec.
+type SpecValidationResult struct {
+	Valid          bool
+	FailureReasons []string // human-readable; e.g. "body too short (78 chars, need 100)"
+	SkipReason     string   // non-empty when the check was opted out
+}
+
+// ValidateSpec checks whether the issue body is sufficiently specified for
+// dispatch. parentResolver, if non-nil, is called to fetch a parent issue by
+// number when evaluating decomposer-generated sub-issues.
+//
+// SDK-typed port of internal/adapters/github.ValidateSpec (M7 4d.3); the
+// in-tree copy serves the legacy handler until the adapter package retires.
+// Rule changes must land in BOTH until then.
+func ValidateSpec(issue *github.Issue, parentResolver func(int) (*github.Issue, error)) SpecValidationResult {
+	// Opt-out: pilot-skip-spec-check label bypasses all rules.
+	for _, l := range issue.Labels {
+		if l.Name == github.LabelSkipSpecCheck {
+			return SpecValidationResult{
+				Valid:      true,
+				SkipReason: fmt.Sprintf("opted out via %s label", github.LabelSkipSpecCheck),
+			}
+		}
+	}
+
+	body := strings.TrimSpace(issue.Body)
+
+	// Sub-issue with autopilot-meta marker: if parent is well-specced the child passes.
+	if parentResolver != nil && autopilotMetaRe.MatchString(issue.Body) {
+		if m := parentRefRe.FindStringSubmatch(issue.Body); len(m) > 1 {
+			var parentNum int
+			if _, err := fmt.Sscanf(m[1], "%d", &parentNum); err == nil && parentNum > 0 {
+				if parent, err := parentResolver(parentNum); err == nil {
+					parentResult := ValidateSpec(parent, nil)
+					if parentResult.Valid || parentResult.SkipReason != "" {
+						return SpecValidationResult{
+							Valid:      true,
+							SkipReason: fmt.Sprintf("parent GH-%d passes spec check", parentNum),
+						}
+					}
+				}
+			}
+		}
+	}
+
+	var reasons []string
+
+	if len(body) < specMinBodyLen {
+		reasons = append(reasons, fmt.Sprintf("body too short (%d chars, need %d)", len(body), specMinBodyLen))
+	}
+
+	if parentOnlyRe.MatchString(body) {
+		reasons = append(reasons, "body contains only a parent reference line")
+	}
+
+	if !sectionHeaderRe.MatchString(body) {
+		reasons = append(reasons,
+			"no structural section header (need one of Acceptance, Implementation, Context, Background, Approach, Design, or Refs as an H2–H6 header)")
+	}
+
+	return SpecValidationResult{
+		Valid:          len(reasons) == 0,
+		FailureReasons: reasons,
+	}
+}

--- a/internal/ghissue/spec_test.go
+++ b/internal/ghissue/spec_test.go
@@ -1,0 +1,197 @@
+package ghissue
+
+import (
+	"errors"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+	"strings"
+	"testing"
+)
+
+// validBody returns a body with a section header and >= 100 chars to pass all rules.
+func validBody() string {
+	return strings.Repeat("x", 60) + "\n\n## Acceptance\n\n- [ ] Does the thing correctly\n"
+}
+
+func TestValidateSpec_ValidBody(t *testing.T) {
+	issue := &github.Issue{
+		Number: 1,
+		Title:  "feat(foo): do something",
+		Body:   validBody(),
+	}
+	result := ValidateSpec(issue, nil)
+	if !result.Valid {
+		t.Errorf("expected Valid=true, got reasons=%v", result.FailureReasons)
+	}
+	if result.SkipReason != "" {
+		t.Errorf("expected no SkipReason, got %q", result.SkipReason)
+	}
+}
+
+func TestValidateSpec_BodyTooShort(t *testing.T) {
+	issue := &github.Issue{
+		Number: 2,
+		Title:  "cascade-2 repro",
+		Body:   "cascade-2 repro", // 15 chars — mirrors the real cascade-2 sub-issues
+	}
+	result := ValidateSpec(issue, nil)
+	if result.Valid {
+		t.Fatal("expected Valid=false for 15-char body")
+	}
+	foundShort := false
+	for _, r := range result.FailureReasons {
+		if strings.Contains(r, "body too short") {
+			foundShort = true
+		}
+	}
+	if !foundShort {
+		t.Errorf("expected 'body too short' reason, got %v", result.FailureReasons)
+	}
+}
+
+func TestValidateSpec_ParentOnlyBody(t *testing.T) {
+	issue := &github.Issue{
+		Number: 3,
+		Body:   "Parent: GH-201",
+	}
+	result := ValidateSpec(issue, nil)
+	if result.Valid {
+		t.Fatal("expected Valid=false for parent-only body")
+	}
+	foundParent := false
+	for _, r := range result.FailureReasons {
+		if strings.Contains(r, "parent reference") {
+			foundParent = true
+		}
+	}
+	if !foundParent {
+		t.Errorf("expected 'parent reference' reason, got %v", result.FailureReasons)
+	}
+}
+
+func TestValidateSpec_NoSectionHeader(t *testing.T) {
+	// 200 chars, no section header
+	body := strings.Repeat("This is a long body without any structural section header. ", 4)
+	issue := &github.Issue{
+		Number: 4,
+		Body:   body,
+	}
+	result := ValidateSpec(issue, nil)
+	if result.Valid {
+		t.Fatal("expected Valid=false for body without section header")
+	}
+	foundHeader := false
+	for _, r := range result.FailureReasons {
+		if strings.Contains(r, "structural section header") {
+			foundHeader = true
+		}
+	}
+	if !foundHeader {
+		t.Errorf("expected 'structural section header' reason, got %v", result.FailureReasons)
+	}
+}
+
+func TestValidateSpec_SkipLabelOptOut(t *testing.T) {
+	// Body fails all rules — but the skip label is present.
+	issue := &github.Issue{
+		Number: 5,
+		Body:   "too short",
+		Labels: []github.Label{{Name: github.LabelSkipSpecCheck}},
+	}
+	result := ValidateSpec(issue, nil)
+	if !result.Valid {
+		t.Errorf("expected Valid=true (opted out), got reasons=%v", result.FailureReasons)
+	}
+	if result.SkipReason == "" {
+		t.Error("expected non-empty SkipReason for opted-out issue")
+	}
+}
+
+func TestValidateSpec_SubIssueParentPasses(t *testing.T) {
+	// Child body is "see parent" (terse) but has autopilot-meta marker and the
+	// parent is well-specced → child should pass.
+	parentBody := validBody()
+	parentResolver := func(num int) (*github.Issue, error) {
+		if num == 201 {
+			return &github.Issue{Number: 201, Body: parentBody}, nil
+		}
+		return nil, errors.New("not found")
+	}
+
+	child := &github.Issue{
+		Number: 6,
+		Body:   "see parent\nParent: GH-201\n<!-- autopilot-meta branch:pilot/GH-200 pr:99 iteration:1 -->",
+	}
+	result := ValidateSpec(child, parentResolver)
+	if !result.Valid {
+		t.Errorf("expected Valid=true (parent passes), got reasons=%v", result.FailureReasons)
+	}
+	if !strings.Contains(result.SkipReason, "parent GH-201") {
+		t.Errorf("expected SkipReason to mention parent GH-201, got %q", result.SkipReason)
+	}
+}
+
+func TestValidateSpec_SubIssueParentFails(t *testing.T) {
+	// Child has autopilot-meta marker but parent also fails — child should fail.
+	parentResolver := func(num int) (*github.Issue, error) {
+		return &github.Issue{Number: num, Body: "too short"}, nil
+	}
+
+	child := &github.Issue{
+		Number: 7,
+		Body:   "see parent\nParent: GH-300\n<!-- autopilot-meta branch:pilot/GH-299 pr:88 iteration:1 -->",
+	}
+	result := ValidateSpec(child, parentResolver)
+	if result.Valid {
+		t.Error("expected Valid=false when both child and parent fail")
+	}
+}
+
+func TestValidateSpec_SectionHeaderVariants(t *testing.T) {
+	headers := []string{
+		"## Acceptance", "## Implementation", "## Context",
+		"## Background", "## Approach", "## Design", "## Refs",
+	}
+	for _, h := range headers {
+		body := strings.Repeat("x", 80) + "\n\n" + h + "\n\nsome content here and there\n"
+		issue := &github.Issue{Number: 8, Body: body}
+		result := ValidateSpec(issue, nil)
+		if !result.Valid {
+			t.Errorf("header %q should make body valid, got reasons=%v", h, result.FailureReasons)
+		}
+	}
+}
+
+func TestValidateSpec_H3ToH6SectionHeaders(t *testing.T) {
+	// H3–H6 headers must be accepted (relaxed from H2-only).
+	passCases := []string{
+		"### Acceptance criteria",
+		"### Acceptance",
+		"#### Implementation",
+		"###### Refs",
+	}
+	for _, h := range passCases {
+		body := strings.Repeat("x", 80) + "\n\n" + h + "\n\nsome content here and there\n"
+		issue := &github.Issue{Number: 9, Body: body}
+		result := ValidateSpec(issue, nil)
+		if !result.Valid {
+			t.Errorf("H3–H6 header %q should be accepted, got reasons=%v", h, result.FailureReasons)
+		}
+	}
+
+	// H1 must still be rejected.
+	h1Body := strings.Repeat("x", 80) + "\n\n# Acceptance\n\nsome content here and there\n"
+	issue := &github.Issue{Number: 10, Body: h1Body}
+	result := ValidateSpec(issue, nil)
+	if result.Valid {
+		t.Error("H1 header '# Acceptance' should NOT be accepted as a structural section header")
+	}
+	foundHeader := false
+	for _, r := range result.FailureReasons {
+		if strings.Contains(r, "structural section header") {
+			foundHeader = true
+		}
+	}
+	if !foundHeader {
+		t.Errorf("expected 'structural section header' failure reason for H1 body, got %v", result.FailureReasons)
+	}
+}


### PR DESCRIPTION
## Context
M7 4d.3 (TASK-368 / #3423). `handleGithubIssueEventSDK` documented its own gap: SDK-routed issues bypassed the two-strike spec-completeness gate entirely — the exact class the synthetic canary caught in `2e82e997`. With `use_sdk_poller` now flippable (4b), this had to close before the live trial dispatches anything thin.

## Changes
- `internal/ghissue/spec.go`: SDK-typed `ValidateSpec` + `SpecCommentMarker` (byte-identical marker → strikes recorded by either path are mutually visible; in-tree copy remains for the legacy handler until 4d.6 — rule changes must land in both, noted in code).
- `cmd/pilot/spec_guard_sdk.go`: `applySpecGuardSDK` two-strike gate, sibling of the in-tree-typed `applySpecGuard`; shares the comment builder.
- `handleGithubIssueEventSDK`: issue reconstructed from the `IssueEvent` (labels included so `pilot-skip-spec-check` opt-out works), owner/repo from the existing `ResolveRepoForEvent`, parent-resolver via SDK client for decomposer sub-issues; guard fire → `Skipped/spec_incomplete`, no dispatch, grace-period throttles the recheck, second strike → `pilot-blocked` (poller filters it).

## Scope fences
Board-failed-column sync on spec-fail not wired on the SDK path (poller-level board sync handles in-progress; failed-column parity tracked for 4d.6). Legacy handler untouched.

## Tests
Ported validator table tests; first-strike (label+marker comment) and second-strike (escalate, no duplicate comment) httptest cases; source-level invariant keeping the gate wired in the handler. Full suite green.