### PR TITLE
feat(executor): M7 4d.4 — SDK PR-create for SDK-managed github repos

### DIFF
--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -1236,10 +1236,11 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 		Priority:      sdkshim.PriorityFromSDK(ev.Priority),
 		BaseBranch:    resolveProjectBaseBranch(cfg, projectPath), // GH-2290
 	}
-
-	// NOTE: no runner.SetPRCreator here — the studio-sdk GitHub client does not implement
-	// executor.PRCreator, and the runner gates the PRCreator branch on SourceAdapter != "github".
-	// GitHub PRs continue to be created via the gh CLI, unchanged.
+	if resolveErr == nil && repoOwner != "" && repoName != "" {
+		// M7 4d.4: lets the runner select the startup-registered SDK PR creator
+		// ("github:owner/repo"); tasks without it keep the gh-CLI path.
+		task.SourceRepo = repoOwner + "/" + repoName
+	}
 
 	deps := HandlerDeps{
 		Cfg:          cfg,

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -12,6 +12,7 @@ import (
 	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
 	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 
+	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/logging"
@@ -240,6 +241,13 @@ func githubPollerRegistration() PollerRegistration {
 				logging.WithComponent("start").Warn("Failed to start rate limit scheduler (SDK path)", slog.Any("error", schErr))
 			}
 			pollerDeps.RateLimitScheduler = sdkRateLimitScheduler{scheduler: rateLimitScheduler}
+
+			// M7 4d.4: PRs for SDK-managed repos go through the SDK client instead
+			// of the gh CLI. Startup-time registration keyed by repo — the runner
+			// falls back to gh CLI for any github task without a registered creator.
+			if deps.Runner != nil {
+				deps.Runner.RegisterPRCreator("github:"+ghCfg.Repo, sdkshim.NewGitHubPRCreator(sdkClient, repoOwner, repoName))
+			}
 
 			githubPoller := githubSDK.New(sdkCfg).NewPoller(pollerDeps)
 

--- a/internal/adapters/sdkshim/github_pr_creator.go
+++ b/internal/adapters/sdkshim/github_pr_creator.go
@@ -1,0 +1,64 @@
+package sdkshim
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GitHubPRCreator adapts the studio-sdk github client to executor.PRCreator
+// (M7 4d.4 — retires the gh-CLI PR path for SDK-managed repos). Unlike the
+// gitlab/plane SDK clients, which satisfy PRCreator by signature, the github
+// client is multi-repo (owner/repo per call) and returns a struct — so this
+// shim closes over one repo and extracts the URL.
+type GitHubPRCreator struct {
+	client *githubSDK.Client
+	owner  string
+	repo   string
+}
+
+// NewGitHubPRCreator returns a PR creator bound to one owner/repo.
+func NewGitHubPRCreator(client *githubSDK.Client, owner, repo string) *GitHubPRCreator {
+	return &GitHubPRCreator{client: client, owner: owner, repo: repo}
+}
+
+// CreatePR opens a pull request and returns its URL. Idempotent against the
+// "already exists" 422 the gh CLI used to absorb: when GitHub rejects the
+// create because an open PR for the branch exists, the existing PR's URL is
+// recovered and returned instead of an error.
+func (g *GitHubPRCreator) CreatePR(ctx context.Context, sourceBranch, targetBranch, title, body string) (string, error) {
+	pr, err := g.client.CreatePullRequest(ctx, g.owner, g.repo, &githubSDK.PullRequestInput{
+		Title: title,
+		Body:  body,
+		Head:  sourceBranch,
+		Base:  targetBranch,
+	})
+	if err == nil {
+		return pr.HTMLURL, nil
+	}
+
+	// GitHub 422: "A pull request already exists for <owner>:<branch>."
+	if strings.Contains(err.Error(), "already exists") {
+		if url, ferr := g.findOpenPRURL(ctx, sourceBranch); ferr == nil && url != "" {
+			return url, nil
+		}
+	}
+	return "", fmt.Errorf("create PR %s -> %s: %w", sourceBranch, targetBranch, err)
+}
+
+// findOpenPRURL returns the HTML URL of the open PR whose head is branch, or
+// "" when none exists.
+func (g *GitHubPRCreator) findOpenPRURL(ctx context.Context, branch string) (string, error) {
+	prs, err := g.client.ListPullRequests(ctx, g.owner, g.repo, "open")
+	if err != nil {
+		return "", err
+	}
+	for _, pr := range prs {
+		if pr.Head.Ref == branch {
+			return pr.HTMLURL, nil
+		}
+	}
+	return "", nil
+}

--- a/internal/adapters/sdkshim/github_pr_creator_test.go
+++ b/internal/adapters/sdkshim/github_pr_creator_test.go
@@ -1,0 +1,86 @@
+package sdkshim
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// Compile-time proof the shim satisfies the executor contract.
+var _ executor.PRCreator = (*GitHubPRCreator)(nil)
+
+func TestGitHubPRCreator_CreatesAndReturnsURL(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pulls") {
+			buf := make([]byte, r.ContentLength)
+			_, _ = r.Body.Read(buf)
+			gotBody = string(buf)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"number":9,"html_url":"https://github.com/o/r/pull/9"}`))
+			return
+		}
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	c := NewGitHubPRCreator(githubSDK.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL), "o", "r")
+	url, err := c.CreatePR(context.Background(), "pilot/GH-9", "main", "GH-9: fix", "body")
+	if err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if url != "https://github.com/o/r/pull/9" {
+		t.Errorf("url = %q", url)
+	}
+	for _, want := range []string{`"head":"pilot/GH-9"`, `"base":"main"`} {
+		if !strings.Contains(gotBody, want) {
+			t.Errorf("request body missing %s; got %s", want, gotBody)
+		}
+	}
+}
+
+func TestGitHubPRCreator_AlreadyExistsRecoversURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/pulls"):
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"Validation Failed","errors":[{"message":"A pull request already exists for o:pilot/GH-9."}]}`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pulls"):
+			_, _ = w.Write([]byte(`[{"number":9,"html_url":"https://github.com/o/r/pull/9","state":"open","head":{"ref":"pilot/GH-9"}}]`))
+		default:
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer srv.Close()
+
+	c := NewGitHubPRCreator(githubSDK.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL), "o", "r")
+	url, err := c.CreatePR(context.Background(), "pilot/GH-9", "main", "GH-9: fix", "body")
+	if err != nil {
+		t.Fatalf("CreatePR must recover the existing PR URL, got error: %v", err)
+	}
+	if url != "https://github.com/o/r/pull/9" {
+		t.Errorf("url = %q, want existing PR URL", url)
+	}
+}
+
+func TestGitHubPRCreator_HardFailurePropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"Validation Failed","errors":[{"message":"base branch not found"}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewGitHubPRCreator(githubSDK.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL), "o", "r")
+	if _, err := c.CreatePR(context.Background(), "pilot/GH-9", "nope", "GH-9: fix", "body"); err == nil {
+		t.Fatal("non-already-exists 422 must propagate as an error")
+	}
+}

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -391,14 +391,14 @@ func consolidateEpicPlan(originalDesc string, subtasks []PlannedSubtask) string 
 // would cause merge conflicts because each sub-issue branches from main independently.
 //
 // Detection strategy:
-// 1. Extract file paths from subtask titles and descriptions — they define the
-//    actual work scope. Paths cited only in the parent description are context
-//    (e.g. code being defended against) and must not flip the verdict (GH-3597:
-//    #3582 cited grouping.go as context while all work was in internal/executor/,
-//    which bypassed this guard and caused a 4-way split of a single-PR task).
-// 2. Compute unique parent directories
-// 3. If only 1 directory → single-package scope. If subtasks cite no paths,
-//    fall back to the parent description, then to the title heuristic.
+//  1. Extract file paths from subtask titles and descriptions — they define the
+//     actual work scope. Paths cited only in the parent description are context
+//     (e.g. code being defended against) and must not flip the verdict (GH-3597:
+//     #3582 cited grouping.go as context while all work was in internal/executor/,
+//     which bypassed this guard and caused a 4-way split of a single-PR task).
+//  2. Compute unique parent directories
+//  3. If only 1 directory → single-package scope. If subtasks cite no paths,
+//     fall back to the parent description, then to the title heuristic.
 //
 // GH-1265: This prevents the "serial conflict cascade" bug where N sub-issues
 // all touching cmd/pilot/ create N branches from main, each redeclaring shared types.

--- a/internal/executor/retry.go
+++ b/internal/executor/retry.go
@@ -97,7 +97,7 @@ func DefaultRetryConfig() *RetryConfig {
 			TimeoutMultiplier: 1.5,
 		},
 		OOMKilled: &RetryStrategy{
-			MaxAttempts:       2,    // Retry once — GH-22/sub-43 succeeded in 33s on first retry
+			MaxAttempts:       2, // Retry once — GH-22/sub-43 succeeded in 33s on first retry
 			InitialBackoff:    10 * time.Second,
 			BackoffMultiplier: 1.0, // flat backoff; OOM is not time-sensitive
 		},

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -640,6 +640,11 @@ type Runner struct {
 	// GH-1471: SubIssueCreator for non-GitHub adapters
 	subIssueCreator SubIssueCreator // Optional creator for sub-issues in external trackers
 	prCreator       PRCreator       // Optional creator for MRs/PRs in external forges
+	// prCreators holds startup-registered per-repo PR creators keyed by
+	// "adapter:owner/repo" (M7 4d.4). Guarded separately from prCreator,
+	// which legacy handlers still mutate per-event.
+	prCreators   map[string]PRCreator
+	prCreatorsMu sync.RWMutex
 	// GH-2211: SubIssueLinker for native GitHub sub-issue API linking
 	subIssueLinker SubIssueLinker // Optional linker for native GitHub parent→child wiring
 	// GH-1599: Execution log store for milestone entries
@@ -1090,6 +1095,27 @@ func (r *Runner) SetSubIssueCreator(creator SubIssueCreator) {
 // SetPRCreator sets the creator for pull/merge requests in external forges.
 func (r *Runner) SetPRCreator(creator PRCreator) {
 	r.prCreator = creator
+}
+
+// RegisterPRCreator registers a PR creator under an explicit key
+// ("adapter:owner/repo"), looked up per-task via SourceAdapter+SourceRepo.
+// Unlike SetPRCreator (a single shared slot mutated per-event by handlers),
+// registrations happen once at startup, so concurrent tasks from different
+// adapters or repos can never observe another repo's creator (M7 4d.4).
+func (r *Runner) RegisterPRCreator(key string, creator PRCreator) {
+	r.prCreatorsMu.Lock()
+	defer r.prCreatorsMu.Unlock()
+	if r.prCreators == nil {
+		r.prCreators = make(map[string]PRCreator)
+	}
+	r.prCreators[key] = creator
+}
+
+// prCreatorFor returns the registered creator for key, or nil.
+func (r *Runner) prCreatorFor(key string) PRCreator {
+	r.prCreatorsMu.RLock()
+	defer r.prCreatorsMu.RUnlock()
+	return r.prCreators[key]
 }
 
 // SetSubIssueLinker sets the linker for native GitHub sub-issue linking (GH-2211).
@@ -3781,7 +3807,39 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 
 			// Route PR/MR creation through adapter-specific creator when available
 			var prURL string
-			if r.prCreator != nil && task.SourceAdapter != "" && task.SourceAdapter != "github" {
+			// M7 4d.4: SDK-managed github repos register a per-repo creator at
+			// startup; everything else keeps its existing path (shared prCreator
+			// slot for non-github adapters, gh CLI for github).
+			ghSDKCreator := PRCreator(nil)
+			if task.SourceAdapter == "github" && task.SourceRepo != "" {
+				ghSDKCreator = r.prCreatorFor("github:" + task.SourceRepo)
+			}
+			if ghSDKCreator != nil {
+				issueNum := strings.TrimPrefix(task.ID, "GH-")
+				prBody := fmt.Sprintf("## Summary\n\nAutomated PR created by Pilot for task %s.\n\nCloses #%s\n\n## Changes\n\n%s", task.ID, issueNum, task.Description)
+				var createErr error
+				for attempt := 1; attempt <= prCreateRetryAttempts; attempt++ {
+					prURL, createErr = ghSDKCreator.CreatePR(ctx, task.Branch, baseBranch, prTitle, prBody)
+					if createErr == nil {
+						break
+					}
+					if attempt < prCreateRetryAttempts {
+						log.Warn("PR creation failed (SDK), retrying",
+							slog.String("task_id", task.ID),
+							slog.Int("attempt", attempt),
+							slog.Int("max_attempts", prCreateRetryAttempts),
+							slog.Any("error", createErr),
+						)
+						time.Sleep(prCreateRetryDelay)
+					}
+				}
+				if createErr != nil {
+					result.Success = false
+					result.Error = formatGitStepFailureWithRecovery(ctx, git, "pr-create", prCreateRetryAttempts, createErr, task.ID, task.Branch, result.CommitSHA)
+					r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+					return result, nil
+				}
+			} else if r.prCreator != nil && task.SourceAdapter != "" && task.SourceAdapter != "github" {
 				// Non-GitHub adapter: use PRCreator (e.g., GitLab MR API)
 				// Include "Closes #N" keyword so GitLab auto-closes the source issue on merge
 				closeKeyword := ""

--- a/internal/executor/runner_base_branch_test.go
+++ b/internal/executor/runner_base_branch_test.go
@@ -75,11 +75,11 @@ func TestDecomposedChildBaseBranch_NonEmpty(t *testing.T) {
 // will resolve it at execution time (GH-3540).
 func TestCreateSubtasks_BaseBranchPropagation(t *testing.T) {
 	tests := []struct {
-		name            string
+		name             string
 		parentBaseBranch string
 	}{
-		{"explicit main",  "main"},
-		{"explicit dev",   "dev"},
+		{"explicit main", "main"},
+		{"explicit dev", "dev"},
 		{"empty inherited", ""},
 	}
 

--- a/internal/executor/runner_prcreator_registry_test.go
+++ b/internal/executor/runner_prcreator_registry_test.go
@@ -1,0 +1,35 @@
+package executor
+
+import (
+	"context"
+	"testing"
+)
+
+// TestRegisterPRCreator_KeyedLookup covers the M7 4d.4 registry: startup-time
+// per-repo registration, exact-key lookup, nil on miss.
+func TestRegisterPRCreator_KeyedLookup(t *testing.T) {
+	r := &Runner{}
+	if got := r.prCreatorFor("github:o/r"); got != nil {
+		t.Fatal("empty registry must return nil")
+	}
+
+	fake := prCreatorFunc(func() string { return "https://x/pull/1" })
+	r.RegisterPRCreator("github:o/r", fake)
+
+	if got := r.prCreatorFor("github:o/r"); got == nil {
+		t.Fatal("registered creator not found")
+	}
+	if got := r.prCreatorFor("github:other/repo"); got != nil {
+		t.Fatal("lookup must be exact-key — other repos get the gh-CLI fallback")
+	}
+	if got := r.prCreatorFor("gitlab:o/r"); got != nil {
+		t.Fatal("adapter prefix must namespace the key")
+	}
+}
+
+// prCreatorFunc is a minimal PRCreator stub.
+type prCreatorFunc func() string
+
+func (f prCreatorFunc) CreatePR(_ context.Context, _, _, _, _ string) (string, error) {
+	return f(), nil
+}

--- a/internal/executor/task_shipped.go
+++ b/internal/executor/task_shipped.go
@@ -8,7 +8,7 @@ import (
 
 // IsTaskShipped reports whether an execution row represents real shipped work.
 // PRUrl is the primary signal — it proves a PR was opened against the remote, but only
-// when the row has no error (mirrors the HasCompletedExecution SQL which excludes error!=''
+// when the row has no error (mirrors the HasCompletedExecution SQL which excludes error!=”
 // rows unconditionally, preventing the two sites from diverging on the {pr_url, error} case).
 // CommitSHA alone is accepted for backwards-compat (direct-commit workflows) but
 // logs a warning because it can be a parent SHA if the ghost-SHA guard was bypassed.


### PR DESCRIPTION
## Context
M7 4d.4 (TASK-368 / #3423). GitHub was the last adapter creating PRs through the gh CLI. The inventory flagged two traps, both handled:

1. **The shared `SetPRCreator` slot is mutated per-event by handlers** — dropping the `!= "github"` guard naively would let a gitlab-set creator serve a github task (wrong repo). Instead: a startup-registered per-repo registry (`RegisterPRCreator("github:owner/repo")`), selected per-task via `SourceAdapter`+`SourceRepo`. No shared-slot mutation, no cross-adapter races; non-github adapters' behavior is untouched.
2. **gh CLI's 'already exists' idempotency** — `GitHubPRCreator` recovers the existing open PR's URL via `ListPullRequests` head-ref filter when the create 422s with 'already exists'; other 422s propagate.

## Behavior
- SDK-managed repos (registered by the `use_sdk_poller` registration): PRs via SDK client, same title/body/Closes-#N format, same retry loop.
- Everything else — legacy github tasks, multi-repo `projects:` tasks, non-github adapters: byte-identical paths, gh CLI fallback intact.
- `TestGithubSDKClientDoesNotImplementPRCreator` still passes: the *client* deliberately doesn't satisfy `PRCreator`; the shim does.

## Tests
Shim httptest triple (create / already-exists URL recovery / hard-failure propagation) + compile-time interface assertion; registry exact-key + adapter-namespace unit. Full suite + stress green.