### PR TITLE
docs(nav): TASK-386/387 dispatched — graph CI drift gate + executor memory injection

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -344,6 +344,37 @@
           "autopilot",
           "executor"
         ]
+      },
+      "TASK-386": {
+        "path": "/Users/aleks.petrov/Projects/startups/pilot/.agent/tasks/TASK-386-knowledge-graph-ci-drift-gate.md",
+        "title": "Task 386 Knowledge Graph Ci Drift Gate",
+        "status": "unknown",
+        "concepts": [
+          "context",
+          "api",
+          "deployment",
+          "skills",
+          "authentication",
+          "knowledge",
+          "testing"
+        ]
+      },
+      "TASK-387": {
+        "path": "/Users/aleks.petrov/Projects/startups/pilot/.agent/tasks/TASK-387-executor-memory-injection.md",
+        "title": "Task 387 Executor Memory Injection",
+        "status": "unknown",
+        "concepts": [
+          "simplification",
+          "workflow",
+          "knowledge",
+          "testing",
+          "context",
+          "skills",
+          "api",
+          "markers",
+          "deployment",
+          "database"
+        ]
       }
     },
     "memories": {
@@ -2274,6 +2305,82 @@
       "from": "autopilot",
       "to": "mem-086",
       "type": "has_pitfall"
+    },
+    {
+      "from": "TASK-386",
+      "to": "testing",
+      "type": "implements"
+    },
+    {
+      "from": "TASK-387",
+      "to": "testing",
+      "type": "implements"
     }
-  ]
+  ],
+  "concept_index": {
+    "memory": [
+      "TASK-386",
+      "TASK-387"
+    ],
+    "verification": [
+      "TASK-386"
+    ],
+    "workflow-discipline": [
+      "TASK-386"
+    ],
+    "executor": [
+      "TASK-387"
+    ],
+    "claude-code-integration": [
+      "TASK-387"
+    ],
+    "intent-routing": [
+      "TASK-387"
+    ],
+    "skills": [
+      "TASK-386",
+      "TASK-387"
+    ],
+    "knowledge": [
+      "TASK-386",
+      "TASK-387"
+    ],
+    "deployment": [
+      "TASK-386",
+      "TASK-387"
+    ],
+    "authentication": [
+      "TASK-386"
+    ],
+    "testing": [
+      "TASK-386",
+      "TASK-387"
+    ],
+    "api": [
+      "TASK-386",
+      "TASK-387"
+    ],
+    "context": [
+      "TASK-386",
+      "TASK-387"
+    ],
+    "markers": [
+      "TASK-387"
+    ],
+    "database": [
+      "TASK-387"
+    ],
+    "workflow": [
+      "TASK-387"
+    ],
+    "simplification": [
+      "TASK-387"
+    ]
+  },
+  "last_updated": "2026-07-06T09:55:29.169568+00:00",
+  "stats": {
+    "total_nodes": 134,
+    "total_edges": 166,
+    "memory_count": 86
+  }
 }

--- a/.agent/tasks/TASK-386-knowledge-graph-ci-drift-gate.md
+++ b/.agent/tasks/TASK-386-knowledge-graph-ci-drift-gate.md
@@ -1,0 +1,153 @@
+# feat(ci): knowledge-graph drift gate — fail CI on disk-vs-graph divergence (TASK-386)
+
+**Status**: 🚀 Dispatched to Pilot
+**Created**: 2026-07-06
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**:
+The `.agent/knowledge/graph.json` memory graph silently drifts from the
+memory files on disk. A 2026-07-05 audit found **52 of 84 memory files with
+zero graph presence**, 42 freeform concept tags, and 4 dangling edges — the
+drift accumulated for ~6 weeks because nothing checked. It was fixed by a
+one-off manual reconciliation (PRs #3886/#3887/#3888); without a gate it
+will drift again.
+
+Navigator v6.17.0 ships the reconciliation logic (`graph_maintenance.py
+--action reconcile/health`), but CI cannot depend on a locally-installed
+Claude Code plugin. The gate must be self-contained in this repo.
+
+**Goal**:
+A stdlib-only Python drift checker vendored into this repo, wired as
+`make check-graph` and a CI job, that fails the build when the graph and
+disk disagree.
+
+---
+
+## Known Pitfalls & Patterns
+
+<!-- From knowledge graph (nav-task Step 2.5) -->
+
+- **LEARNING** (90%, mem-033): Pilot done-states are claims, not evidence — verify the artifact (grep main for the expected signature), not status labels. Apply: the Done section greps for the workflow job and script on main.
+- **PITFALL** (95%, mem-024): Dashboard failed-count conflation — collapsing distinct failure classes into one bucket hides real state. Apply: the checker reports each drift class separately (broken links / unindexed active / dangling edges / concept drift), never one merged count.
+- **LEARNING** (95%, mem-019): Path-style mismatches (absolute FS path vs owner/repo) made a filter match 0 rows. Apply: the checker must resolve BOTH node path styles (`file` root-relative and `path` base_dir-relative) before comparing.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `scripts/check-graph.py` exists: stdlib-only Python 3, no external deps, no Navigator-plugin imports
+- [ ] Detects and reports, each as a separate count with file/node lists:
+  1. **Broken file links** — memory node `file`/`path`/`memory_file` refs that resolve to no file on disk (nodes with no path field are legal, NOT broken)
+  2. **Unindexed active memory files** — `.agent/knowledge/memories/**/*.md` (excluding `README*` and files under a `resolved/` directory) with no graph node referencing them
+  3. **Dangling edges** — edge endpoints that are not existing node ids
+  4. **Invalid concept refs** (WARN only, non-fatal) — node concepts with no matching key in `nodes.concepts`
+- [ ] Exit code 1 when classes 1–3 are non-zero; exit 0 with a warning block for class 4
+- [ ] Path resolution handles both styles present in this repo's graph: root-relative (`.agent/knowledge/memories/...`) and base_dir-relative (`memories/...`)
+- [ ] `make check-graph` target runs it
+- [ ] CI job `graph-check` added to `.github/workflows/ci.yml`, runs on every PR + push to main, completes in <30s
+- [ ] Running against the current repo state passes (the graph was reconciled 2026-07-06: 85 memories, 0 broken links, 0 unindexed active)
+- [ ] Table-driven Python tests (or a shell fixture test) covering: clean repo, each drift class, both path styles, `resolved/` exclusion
+
+---
+
+## Implementation
+
+### Phase 1: Checker script
+**Goal**: Self-contained drift detector
+
+**Tasks**:
+- [ ] Write `scripts/check-graph.py` (~120 lines): load graph.json, glob memory files, run the 4 checks, print a per-class report, exit accordingly
+- [ ] Reference algorithm: Navigator v6.17.0 `skills/nav-graph/functions/graph_maintenance.py` (`find_broken_file_links`, `find_unindexed_memory_files`, `find_invalid_concept_refs`, `find_dangling_edges`) — port the logic, do NOT import or vendor the file wholesale
+- [ ] Tests in `scripts/check_graph_test.py` or table-driven fixtures under `scripts/testdata/`
+
+**Files**:
+- `scripts/check-graph.py` — the checker
+- `scripts/` test file — fixtures for each drift class
+
+### Phase 2: Wiring
+**Goal**: Make it enforced, not optional
+
+**Tasks**:
+- [ ] `Makefile`: add `check-graph` target (python3 scripts/check-graph.py)
+- [ ] `.github/workflows/ci.yml`: add `graph-check` job (ubuntu, setup nothing beyond checkout — system python3 suffices)
+- [ ] Verify the job passes on the PR itself
+
+**Files**:
+- `Makefile`
+- `.github/workflows/ci.yml`
+
+---
+
+## Out of Scope
+
+- Auto-repair/reconcile in CI (report-only gate; fixing is a human/Navigator action via the plugin)
+- Concept-vocabulary enforcement as a FAILURE (warn only — legacy freeform tags on old nodes are a known, accepted residue)
+- Graph health scoring, staleness, confidence decay (Navigator-side concerns)
+- Any change to graph.json itself
+
+---
+
+## Technical Decisions
+
+| Decision | Options Considered | Chosen | Reasoning |
+|----------|-------------------|--------|-----------|
+| Where the checker lives | (a) checkout Navigator repo in CI, (b) vendor self-contained script, (c) publish plugin as package | (b) vendor | CI must not depend on plugin availability or cross-repo auth; the algorithm is ~100 lines and stable |
+| Language | Go (repo primary), Python | Python 3 stdlib | Mirrors the reference implementation 1:1; no build step; CI has python3 |
+| Concept drift severity | fail, warn | warn | Old nodes carry accepted freeform tags; failing would force a mass rewrite with no value |
+| `resolved/` files | count as drift, exclude | exclude from failure | Archived-without-node is this repo's established convention (2026-07-05 curation) |
+
+---
+
+## Verify
+
+```bash
+# Checker passes on current state
+python3 scripts/check-graph.py
+
+# Make target
+make check-graph
+
+# Tests
+python3 -m unittest discover -s scripts -p "*_test.py" 2>/dev/null || python3 scripts/check_graph_test.py
+
+# Break it on purpose: temporarily move a memory file, expect exit 1
+mv .agent/knowledge/memories/patterns/pattern_hot_upgrade_bootstrap.md /tmp/ && \
+  (python3 scripts/check-graph.py; echo "exit=$?") ; \
+  mv /tmp/pattern_hot_upgrade_bootstrap.md .agent/knowledge/memories/patterns/
+```
+
+---
+
+## Done
+
+- [ ] `scripts/check-graph.py` on main, exits 0 against current repo state
+- [ ] `make check-graph` target exists
+- [ ] `graph-check` job visible and green in the PR's CI run
+- [ ] Deliberate-drift test (moved file) exits 1 with the file named in output
+- [ ] Tests pass in CI
+
+---
+
+## Refs
+
+- Dispatched: https://github.com/qf-studio/pilot/issues/3898
+- Audit + reconciliation this gates: PRs #3886, #3887, #3888 (2026-07-05/06)
+- Reference implementation: Navigator v6.17.0 `skills/nav-graph/functions/graph_maintenance.py`
+- Navigator release notes: alekspetrov/navigator releases/RELEASE-NOTES-v6.17.0.md
+
+---
+
+## Notes
+
+The graph currently has 85 memories / 35 concepts / 160 edges and is clean
+as of 2026-07-06 — the gate's first job is to keep it that way. Legacy
+freeform concept tags exist on old nodes (mem-015..mem-045 range); that is
+why concept drift is WARN, not FAIL.
+
+---
+
+**Last Updated**: 2026-07-06

--- a/.agent/tasks/TASK-387-executor-memory-injection.md
+++ b/.agent/tasks/TASK-387-executor-memory-injection.md
@@ -1,0 +1,159 @@
+# feat(executor): inject relevant knowledge-graph memories into task prompts (TASK-387)
+
+**Status**: 🚀 Dispatched to Pilot
+**Created**: 2026-07-06
+**Assignee**: Pilot
+
+---
+
+## Context
+
+**Problem**:
+Pilot's executor repeats mistakes the knowledge graph already documents.
+`bug_pilot_ghost_closes` alone catalogs a failure class that recurred across
+TASK-320/321/334/355/369 — each time rediscovered, never recalled. The graph
+now holds 85 curated memories (reconciled 2026-07-06) with pitfalls tied to
+concepts like `epic-decomposition`, `worktree`, `release` — but nothing
+injects them into the prompts autonomous executions actually run with.
+
+Navigator v6.17.0 closed this loop for *interactive* sessions (session-start
+surfacing + nav-task recall). The executor path — where mistakes are most
+expensive because nobody is watching — is still blind.
+
+**Goal**:
+`BuildPrompt` appends a compact "Known pitfalls (project memory)" block —
+the top-N graph memories whose concepts match the task — implemented
+natively in Go, fail-open, capped, and config-gated.
+
+---
+
+## Known Pitfalls & Patterns
+
+<!-- From knowledge graph (nav-task Step 2.5) — these MUST shape the implementation -->
+
+- **PITFALL** (100%, mem-004): **CRITICAL: Navigator integration in the executor prompt is THE CORE VALUE of Pilot.** When touching `BuildPrompt()`, ALWAYS preserve the Navigator session prefix / `/nav-loop` invocation. It was once removed during a "simplification" refactor and broke the entire system. The memory block must be APPENDED — zero changes to existing prompt structure.
+- **PATTERN** (95%, mem-005): BuildPrompt checks for `.agent/` to conditionally add the Navigator session start — the same `hasNavigator` detection gates memory injection (no `.agent/` → no graph → no injection).
+- **LEARNING** (90%, mem-077): LLM primitives must spawn the claude subprocess, never call api.anthropic.com directly. Corollary here: recall must be pure local computation (read graph.json, rank in Go) — no LLM call, no Python subprocess.
+- **PATTERN** (95%, mem-006): Navigator prompt uses 'Run until done' to trigger Loop Mode — the injected block must sit outside/after that scaffolding so WORKFLOW CHECK and EXIT_SIGNAL behavior are untouched.
+
+---
+
+## Acceptance Criteria
+
+- [ ] New Go recall implementation (suggested: `internal/executor/memory_recall.go` or `internal/memory/graphrecall`): loads `.agent/knowledge/graph.json` from the project path, ranks memories by concept overlap, returns top-N summaries
+- [ ] Concept matching: derive target concepts by case-insensitive matching of graph concept ids AND their aliases as substrings/words against the task title + body; rank memories by `|mem.concepts ∩ targets|` desc, then `confidence` desc, then id asc (port of Navigator v6.17.0 `memory_recall.py` — the reference algorithm)
+- [ ] Excludes memories with `resolved: true` or a `superseded_by` field
+- [ ] Schema-tolerant: node path key may be `path`, `file`, `memory_file`, or absent; graph may lack `concept_index` (never use it); malformed/missing graph.json → empty result, never an error that blocks execution (**fail-open**)
+- [ ] `BuildPrompt` appends (never prepends/modifies existing sections) a block formatted:
+  ```
+  ## Known pitfalls from project memory
+  - PITFALL: "<summary>" (90%)
+  ...
+  Heed these before implementing.
+  ```
+  capped at 5 memories AND ~1500 chars total, whichever is smaller
+- [ ] Injection happens on the Navigator path and the standard path; **skipped for `task.LocalMode`** (GH-2103 LocalMode priority untouched)
+- [ ] The `"Start my Navigator session"` / `/nav-loop` prefix and all existing prompt content remain byte-identical when the graph is absent or empty (regression-guarded by test)
+- [ ] Config: `executor.memory_injection.enabled` (default **true**) + `executor.memory_injection.max_memories` (default 5) in config schema + `configs/pilot.example.yaml`
+- [ ] Table-driven tests: ranking, resolved-exclusion, schema variants (path/file/no-key), missing graph, LocalMode skip, char cap, prompt-unchanged-when-disabled
+
+---
+
+## Implementation
+
+### Phase 1: Go recall
+**Goal**: Pure-local ranking, mirroring the reference algorithm
+
+**Tasks**:
+- [ ] Graph structs (only the fields recall needs; tolerate unknown fields)
+- [ ] `RecallRelevant(projectPath, taskText string, limit int) []MemorySummary`
+- [ ] Table-driven tests incl. a fixture mirroring this repo's real graph shape (`file:` keys, no concept_index, summary-only nodes)
+
+**Files**:
+- `internal/executor/memory_recall.go` (or `internal/memory/graphrecall/recall.go`)
+- matching `_test.go`
+
+### Phase 2: Prompt wiring
+**Goal**: Append-only injection in BuildPrompt
+
+**Tasks**:
+- [ ] `internal/executor/prompt_builder.go` — after existing prompt assembly (`BuildPrompt`, :67; Navigator gate at :134-151), append the block when enabled && !LocalMode && recall non-empty
+- [ ] Config plumbing: `internal/config` struct + defaults + `configs/pilot.example.yaml` docs
+- [ ] Prompt tests: golden/structure assertions that existing sections are unchanged
+
+**Files**:
+- `internal/executor/prompt_builder.go`
+- `internal/config/*.go`
+- `configs/pilot.example.yaml`
+
+---
+
+## Out of Scope
+
+- Writing memories from executions (feedback loop — future task)
+- Python/`memory_recall.py` subprocess invocation (Go-native only)
+- LLM-based concept extraction (substring/alias matching only)
+- Semantic/embedding relevance (concept overlap only)
+- Dashboard surfacing of injected memories
+- Changing what memories exist (graph content is Navigator's domain)
+
+---
+
+## Technical Decisions
+
+| Decision | Options Considered | Chosen | Reasoning |
+|----------|-------------------|--------|-----------|
+| Recall runtime | shell out to Navigator's memory_recall.py, Go-native port | Go-native | Daemon can't depend on plugin install paths or python3; algorithm is ~80 lines; fail-open is trivial in-process |
+| Concept derivation | LLM classify, keyword map, match graph vocabulary against task text | graph vocabulary match | Zero-cost, deterministic, uses the project's own concept ids + aliases as the keyword set |
+| Default state | opt-in (dormant), default-on with kill switch | default-on + `enabled: false` opt-out | Additive appended text, fail-open, capped — low risk; value requires it actually running |
+| LocalMode | inject, skip | skip | LocalMode is the sandbox/bench problem-solving path (GH-2103); keep it hermetic |
+| Placement | prepend, inline, append | append only | mem-004: BuildPrompt structure is load-bearing; append cannot break the Navigator prefix |
+
+---
+
+## Verify
+
+```bash
+# Build + unit tests
+make build
+go test ./internal/executor/... ./internal/config/... ./internal/memory/... 
+
+# Live: prompt for a fake epic-decomposition task against THIS repo's graph
+# (expect the ghost-close / orphan-PR pitfalls in the block)
+go test ./internal/executor/ -run TestBuildPrompt -v | grep -A8 "Known pitfalls" || true
+
+# Lint
+make lint
+```
+
+---
+
+## Done
+
+- [ ] Recall implementation + tests on main; `go test ./...` green
+- [ ] `BuildPrompt` output for a task mentioning "epic decomposition" against this repo's graph contains a `## Known pitfalls from project memory` block listing epic-decomposition pitfalls
+- [ ] With `executor.memory_injection.enabled: false` or no `.agent/knowledge/graph.json`, prompt output is byte-identical to pre-change output (test-asserted)
+- [ ] LocalMode prompts contain no injection (test-asserted)
+- [ ] `configs/pilot.example.yaml` documents both keys
+
+---
+
+## Refs
+
+- Dispatched: https://github.com/qf-studio/pilot/issues/3899
+- Reference algorithm: Navigator v6.17.0 `skills/nav-graph/functions/memory_recall.py` (alekspetrov/navigator)
+- Blocked by: none. Related: TASK-386 (CI drift gate keeps the injected data trustworthy)
+- Motivating incident class: `.agent/knowledge/memories/pitfalls/bug_pilot_ghost_closes.md` (recurred 5×)
+- CLAUDE.md § "CRITICAL: Core Architecture Constraints" (BuildPrompt Navigator integration)
+
+---
+
+## Notes
+
+The graph this reads was reconciled and gate-protected on 2026-07-05/06
+(85 memories, 0 drift). Injection quality depends on that hygiene — which
+is why TASK-386 ships alongside.
+
+---
+
+**Last Updated**: 2026-07-06


### PR DESCRIPTION
Task docs + graph sync for the two Navigator-v6.17.0 follow-ups, dispatched as pilot-labeled issues:

| Task | Issue | Scope |
|---|---|---|
| TASK-386 | #3898 | `scripts/check-graph.py` + `make check-graph` + CI job — drift gate for `.agent/knowledge/graph.json` |
| TASK-387 | #3899 | Go-native memory recall appended to `BuildPrompt` — top-5 concept-matched pitfalls in executor prompts (fail-open, config-gated, LocalMode-skipped) |

Both specs authored with nav-task v6.17.0 Step 2.5 recall — TASK-387's `## Known Pitfalls & Patterns` carries **mem-004** (CRITICAL: never touch the Navigator prefix in BuildPrompt), surfaced automatically.

Graph: +2 task nodes (retagged to pilot vocabulary; `task_to_graph`'s generic keyword tags would have introduced 15 invalid concept refs — flagged as a v6.17.x upstream limitation). Post-sync health: 0 broken links / 0 unindexed / 0 invalid refs.