### PR TITLE
GH-3901: feat(ci): add stdlib graph drift checker with make target and CI job (TASK-386)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,18 @@ jobs:
       - name: Check for realistic secret patterns in tests
         run: ./scripts/check-secret-patterns.sh
 
+  graph-check:
+    name: Knowledge Graph Drift Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check knowledge-graph drift
+        run: python3 scripts/check-graph.py
+
+      - name: Run checker tests
+        run: python3 -m unittest discover -s scripts -p "*_test.py"
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-e2e clean install lint fmt deps dev install-hooks check-secrets gate check-integration auto-fix test-short test-integration test-chaos test-wiring package release docker-build docker-push desktop-dev desktop-build desktop-build-windows desktop-build-linux desktop desktop-deps desktop-package desktop-dmg desktop-clean build-with-dashboard
+.PHONY: build run test test-e2e clean install lint fmt deps dev install-hooks check-secrets check-graph gate check-integration auto-fix test-short test-integration test-chaos test-wiring package release docker-build docker-push desktop-dev desktop-build desktop-build-windows desktop-build-linux desktop desktop-deps desktop-package desktop-dmg desktop-clean build-with-dashboard
 
 # Variables
 BINARY_NAME=pilot
@@ -128,6 +128,10 @@ install-hooks:
 # Check for realistic secret patterns in test files
 check-secrets:
 	@./scripts/check-secret-patterns.sh
+
+# Check knowledge-graph drift (graph.json vs .agent/knowledge/memories/ on disk)
+check-graph:
+	@python3 scripts/check-graph.py
 
 # Run short tests (for pre-push gate)
 test-short:
@@ -271,6 +275,7 @@ help:
 	@echo "  make install-global Install to /usr/local/bin"
 	@echo "  make install-hooks  Install git pre-commit/pre-push hooks"
 	@echo "  make check-secrets  Check for secret patterns in tests"
+	@echo "  make check-graph    Check knowledge-graph drift (graph.json vs disk)"
 	@echo "  make check-integration  Check for orphan code"
 	@echo "  make gate           Run pre-push validation gate"
 	@echo "  make auto-fix       Auto-fix common issues"

--- a/scripts/check-graph.py
+++ b/scripts/check-graph.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Knowledge-graph drift gate.
+
+Fails when .agent/knowledge/graph.json disagrees with the memory files on
+disk under .agent/knowledge/memories/. Ports the four checks from Navigator
+v6.17.0's graph_maintenance.py (reimplemented, not vendored):
+
+  1. Broken file links   — memory node file/path/memory_file refs that don't
+                            resolve on disk (FAIL)
+  2. Unindexed active    — memory files with no node referencing them (FAIL)
+  3. Dangling edges      — edge endpoints not present in nodes (FAIL)
+  4. Invalid concept refs — node concepts with no matching concept key (WARN)
+
+Exit 0 when classes 1-3 are empty (regardless of class 4). Exit 1 otherwise.
+"""
+import glob
+import json
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GRAPH_PATH = os.path.join(REPO_ROOT, ".agent", "knowledge", "graph.json")
+MEMORIES_BASE = os.path.join(REPO_ROOT, ".agent", "knowledge", "memories")
+PATH_FIELDS = ("file", "path", "memory_file")
+
+
+def load_graph(graph_path):
+    with open(graph_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def resolve_path(repo_root, raw_path):
+    """Resolve a node path field against both known styles: root-relative
+    (.agent/knowledge/memories/...) and base_dir-relative (memories/...)."""
+    candidates = [
+        os.path.join(repo_root, raw_path),
+        os.path.join(repo_root, ".agent", "knowledge", raw_path),
+    ]
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def find_broken_file_links(graph, repo_root):
+    broken = []
+    for node_id, node in graph.get("nodes", {}).get("memories", {}).items():
+        raw_path = None
+        for field in PATH_FIELDS:
+            if field in node:
+                raw_path = node[field]
+                break
+        if raw_path is None:
+            continue
+        if resolve_path(repo_root, raw_path) is None:
+            broken.append((node_id, raw_path))
+    return broken
+
+
+def find_unindexed_memory_files(graph, memories_base, repo_root):
+    indexed = set()
+    for node in graph.get("nodes", {}).get("memories", {}).values():
+        for field in PATH_FIELDS:
+            if field in node:
+                resolved = resolve_path(repo_root, node[field])
+                if resolved:
+                    indexed.add(os.path.normpath(resolved))
+
+    unindexed = []
+    pattern = os.path.join(memories_base, "**", "*.md")
+    for filepath in glob.glob(pattern, recursive=True):
+        rel = os.path.relpath(filepath, memories_base)
+        parts = rel.split(os.sep)
+        if parts[0] == "resolved" or "resolved" in parts[:-1]:
+            continue
+        if os.path.basename(filepath).startswith("README"):
+            continue
+        if os.path.normpath(filepath) not in indexed:
+            unindexed.append(os.path.relpath(filepath, repo_root))
+    return sorted(unindexed)
+
+
+def find_dangling_edges(graph):
+    node_ids = set()
+    for category in graph.get("nodes", {}).values():
+        node_ids.update(category.keys())
+
+    dangling = []
+    for edge in graph.get("edges", []):
+        src, dst = edge.get("from"), edge.get("to")
+        if src not in node_ids or dst not in node_ids:
+            dangling.append(edge)
+    return dangling
+
+
+def find_invalid_concept_refs(graph):
+    concept_ids = set(graph.get("nodes", {}).get("concepts", {}).keys())
+    invalid = []
+    for node_id, node in graph.get("nodes", {}).get("memories", {}).items():
+        for concept in node.get("concepts", []):
+            if concept not in concept_ids:
+                invalid.append((node_id, concept))
+    return invalid
+
+
+def main():
+    graph = load_graph(GRAPH_PATH)
+
+    broken_links = find_broken_file_links(graph, REPO_ROOT)
+    unindexed = find_unindexed_memory_files(graph, MEMORIES_BASE, REPO_ROOT)
+    dangling_edges = find_dangling_edges(graph)
+    invalid_concepts = find_invalid_concept_refs(graph)
+
+    fail = False
+
+    print("== Broken file links ==")
+    if broken_links:
+        fail = True
+        for node_id, raw_path in broken_links:
+            print(f"  FAIL {node_id}: {raw_path}")
+    else:
+        print("  none")
+
+    print("== Unindexed active memory files ==")
+    if unindexed:
+        fail = True
+        for rel_path in unindexed:
+            print(f"  FAIL {rel_path}")
+    else:
+        print("  none")
+
+    print("== Dangling edges ==")
+    if dangling_edges:
+        fail = True
+        for edge in dangling_edges:
+            print(f"  FAIL {edge.get('from')} -> {edge.get('to')} ({edge.get('type')})")
+    else:
+        print("  none")
+
+    print("== Invalid concept refs (warn only) ==")
+    if invalid_concepts:
+        for node_id, concept in invalid_concepts:
+            print(f"  WARN {node_id}: unknown concept '{concept}'")
+    else:
+        print("  none")
+
+    if fail:
+        print("\nFAIL: knowledge graph drift detected (see FAIL lines above)")
+        return 1
+
+    print("\nOK: knowledge graph matches disk state")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_graph_test.py
+++ b/scripts/check_graph_test.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Table-driven tests for scripts/check-graph.py."""
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+SCRIPT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "check-graph.py")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_graph", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cg = _load_module()
+
+
+def _write(path, content=""):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+class ResolvePathTest(unittest.TestCase):
+    def test_root_relative_style(self):
+        with tempfile.TemporaryDirectory() as root:
+            target = os.path.join(root, ".agent", "knowledge", "memories", "patterns", "a.md")
+            _write(target, "x")
+            resolved = cg.resolve_path(root, ".agent/knowledge/memories/patterns/a.md")
+            self.assertEqual(os.path.normpath(resolved), os.path.normpath(target))
+
+    def test_base_dir_relative_style(self):
+        with tempfile.TemporaryDirectory() as root:
+            target = os.path.join(root, ".agent", "knowledge", "memories", "patterns", "a.md")
+            _write(target, "x")
+            resolved = cg.resolve_path(root, "memories/patterns/a.md")
+            self.assertEqual(os.path.normpath(resolved), os.path.normpath(target))
+
+    def test_unresolvable_path(self):
+        with tempfile.TemporaryDirectory() as root:
+            self.assertIsNone(cg.resolve_path(root, "memories/patterns/missing.md"))
+
+
+class BrokenFileLinksTest(unittest.TestCase):
+    def test_no_path_field_is_legal(self):
+        graph = {"nodes": {"memories": {"mem-001": {"type": "decision", "summary": "no path"}}}}
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(cg.find_broken_file_links(graph, root), [])
+
+    def test_broken_link_reported(self):
+        graph = {"nodes": {"memories": {"mem-001": {"file": ".agent/knowledge/memories/patterns/missing.md"}}}}
+        with tempfile.TemporaryDirectory() as root:
+            broken = cg.find_broken_file_links(graph, root)
+            self.assertEqual(broken, [("mem-001", ".agent/knowledge/memories/patterns/missing.md")])
+
+    def test_resolves_memory_file_and_path_fields(self):
+        with tempfile.TemporaryDirectory() as root:
+            target = os.path.join(root, ".agent", "knowledge", "memories", "patterns", "a.md")
+            _write(target, "x")
+            graph = {
+                "nodes": {
+                    "memories": {
+                        "mem-001": {"memory_file": ".agent/knowledge/memories/patterns/a.md"},
+                        "mem-002": {"path": "memories/patterns/a.md"},
+                    }
+                }
+            }
+            self.assertEqual(cg.find_broken_file_links(graph, root), [])
+
+
+class UnindexedMemoryFilesTest(unittest.TestCase):
+    def test_clean_repo_no_unindexed(self):
+        with tempfile.TemporaryDirectory() as root:
+            memories_base = os.path.join(root, ".agent", "knowledge", "memories")
+            _write(os.path.join(memories_base, "patterns", "a.md"), "x")
+            graph = {"nodes": {"memories": {"mem-001": {"file": ".agent/knowledge/memories/patterns/a.md"}}}}
+            self.assertEqual(cg.find_unindexed_memory_files(graph, memories_base, root), [])
+
+    def test_unindexed_file_reported(self):
+        with tempfile.TemporaryDirectory() as root:
+            memories_base = os.path.join(root, ".agent", "knowledge", "memories")
+            _write(os.path.join(memories_base, "patterns", "orphan.md"), "x")
+            graph = {"nodes": {"memories": {}}}
+            unindexed = cg.find_unindexed_memory_files(graph, memories_base, root)
+            self.assertEqual(unindexed, [os.path.join(".agent", "knowledge", "memories", "patterns", "orphan.md")])
+
+    def test_readme_excluded(self):
+        with tempfile.TemporaryDirectory() as root:
+            memories_base = os.path.join(root, ".agent", "knowledge", "memories")
+            _write(os.path.join(memories_base, "patterns", "README.md"), "x")
+            graph = {"nodes": {"memories": {}}}
+            self.assertEqual(cg.find_unindexed_memory_files(graph, memories_base, root), [])
+
+    def test_resolved_dir_excluded(self):
+        with tempfile.TemporaryDirectory() as root:
+            memories_base = os.path.join(root, ".agent", "knowledge", "memories")
+            _write(os.path.join(memories_base, "patterns", "resolved", "archived.md"), "x")
+            graph = {"nodes": {"memories": {}}}
+            self.assertEqual(cg.find_unindexed_memory_files(graph, memories_base, root), [])
+
+    def test_base_dir_relative_index_recognized(self):
+        with tempfile.TemporaryDirectory() as root:
+            memories_base = os.path.join(root, ".agent", "knowledge", "memories")
+            _write(os.path.join(memories_base, "patterns", "a.md"), "x")
+            graph = {"nodes": {"memories": {"mem-001": {"file": "memories/patterns/a.md"}}}}
+            self.assertEqual(cg.find_unindexed_memory_files(graph, memories_base, root), [])
+
+
+class DanglingEdgesTest(unittest.TestCase):
+    def test_clean_edges(self):
+        graph = {
+            "nodes": {"concepts": {"a": {}}, "memories": {"mem-001": {}}},
+            "edges": [{"from": "a", "to": "mem-001", "type": "uses"}],
+        }
+        self.assertEqual(cg.find_dangling_edges(graph), [])
+
+    def test_dangling_edge_reported(self):
+        graph = {
+            "nodes": {"concepts": {"a": {}}, "memories": {}},
+            "edges": [{"from": "a", "to": "ghost", "type": "uses"}],
+        }
+        dangling = cg.find_dangling_edges(graph)
+        self.assertEqual(len(dangling), 1)
+        self.assertEqual(dangling[0]["to"], "ghost")
+
+
+class InvalidConceptRefsTest(unittest.TestCase):
+    def test_valid_concepts(self):
+        graph = {
+            "nodes": {
+                "concepts": {"executor": {}},
+                "memories": {"mem-001": {"concepts": ["executor"]}},
+            }
+        }
+        self.assertEqual(cg.find_invalid_concept_refs(graph), [])
+
+    def test_invalid_concept_warns_only(self):
+        graph = {
+            "nodes": {
+                "concepts": {"executor": {}},
+                "memories": {"mem-001": {"concepts": ["nonexistent"]}},
+            }
+        }
+        self.assertEqual(cg.find_invalid_concept_refs(graph), [("mem-001", "nonexistent")])
+
+
+class MainExitCodeTest(unittest.TestCase):
+    def _build_repo(self, root):
+        memories_base = os.path.join(root, ".agent", "knowledge", "memories")
+        _write(os.path.join(memories_base, "patterns", "a.md"), "x")
+        graph = {
+            "version": "1.0.0",
+            "nodes": {
+                "concepts": {"executor": {}},
+                "tasks": {},
+                "memories": {"mem-001": {"file": ".agent/knowledge/memories/patterns/a.md", "concepts": ["executor"]}},
+            },
+            "edges": [],
+        }
+        graph_path = os.path.join(root, ".agent", "knowledge", "graph.json")
+        os.makedirs(os.path.dirname(graph_path), exist_ok=True)
+        import json
+        with open(graph_path, "w", encoding="utf-8") as f:
+            json.dump(graph, f)
+        return graph_path, memories_base
+
+    def _run_main(self, root, graph_path, memories_base):
+        cg.REPO_ROOT = root
+        cg.GRAPH_PATH = graph_path
+        cg.MEMORIES_BASE = memories_base
+        return cg.main()
+
+    def test_clean_repo_exits_zero(self):
+        with tempfile.TemporaryDirectory() as root:
+            graph_path, memories_base = self._build_repo(root)
+            self.assertEqual(self._run_main(root, graph_path, memories_base), 0)
+
+    def test_broken_link_exits_one(self):
+        with tempfile.TemporaryDirectory() as root:
+            graph_path, memories_base = self._build_repo(root)
+            os.remove(os.path.join(memories_base, "patterns", "a.md"))
+            self.assertEqual(self._run_main(root, graph_path, memories_base), 1)
+
+    def test_unindexed_file_exits_one(self):
+        with tempfile.TemporaryDirectory() as root:
+            graph_path, memories_base = self._build_repo(root)
+            _write(os.path.join(memories_base, "patterns", "orphan.md"), "x")
+            self.assertEqual(self._run_main(root, graph_path, memories_base), 1)
+
+    def test_dangling_edge_exits_one(self):
+        with tempfile.TemporaryDirectory() as root:
+            graph_path, memories_base = self._build_repo(root)
+            import json
+            with open(graph_path, "r+", encoding="utf-8") as f:
+                graph = json.load(f)
+                graph["edges"].append({"from": "ghost", "to": "mem-001", "type": "uses"})
+                f.seek(0)
+                json.dump(graph, f)
+                f.truncate()
+            self.assertEqual(self._run_main(root, graph_path, memories_base), 1)
+
+    def test_invalid_concept_alone_exits_zero(self):
+        with tempfile.TemporaryDirectory() as root:
+            graph_path, memories_base = self._build_repo(root)
+            import json
+            with open(graph_path, "r+", encoding="utf-8") as f:
+                graph = json.load(f)
+                graph["nodes"]["memories"]["mem-001"]["concepts"] = ["nonexistent"]
+                f.seek(0)
+                json.dump(graph, f)
+                f.truncate()
+            self.assertEqual(self._run_main(root, graph_path, memories_base), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3901.

Closes #3901

## Changes

Ship the full drift gate as a single, self-contained change. Scope (all in one PR): Create scripts/check-graph.py (stdlib Python 3, ~120 lines) porting the four checks from Navigator v6.17.0 graph_maintenance.py (do NOT vendor wholesale — reimplement): (1) Broken file links — memory nodes whose file/path/memory_file doesn't resolve on disk; nodes without any path field are legal. (2) Unindexed active memory files — .agent/knowledge/memories/**/*.md (exclude README* and anything under resolved/) with no node referencing them. (3) Dangling edges — edge endpoints not in nodes. (4) Invalid concept refs — WARN only, non-fatal. Path resolver MUST handle both root-relative (.agent/knowledge/memories/...) and base_dir-relative (memories/...) styles present in this repo — verify by resolving both forms before comparing (per mem-019). Report each drift class separately with file/node lists — never merge counts (per mem-024). Exit 1 when classes 1–3 non-zero; exit 0 with warning block for class 4. Add scripts/check_graph_test.py (or scripts/testdata/ fixtures) with table-driven cases: clean repo, each drift class, both path styles, resolved/ exclusion. Add check-graph target to Makefile (python3 scripts/check-graph.py). Add graph-check job to .github/workflows/ci.yml — ubuntu, checkout only (system python3 suffices), runs on PR + push to main, completes in <30s. Verify before marking done (per mem-033 — done-states are claims, verify the artifact): python3 scripts/check-graph.py exits 0 against current repo state (85 memories, 0 broken links as of 2026-07-06); python3 -m unittest discover -s scripts -p '*_test.py' passes; break-it test: mv .agent/knowledge/memories/patterns/pattern_hot_upgrade_bootstrap.md /tmp/ && python3 scripts/check-graph.py; echo $? → exit 1 with file named in output, then restore file; the PR's own graph-check job is green in GitHub Actions (grep the workflow run, not just the label). Files touched: scripts/check-graph.py, scripts/check_graph_test.py (+ optional scripts/testdata/), Makefile, .github/workflows/ci.yml.