### PR TITLE
GH-3907: feat(memory): add graph-based memory recall package

### DIFF
--- a/.agent/tasks/gh-3907.md
+++ b/.agent/tasks/gh-3907.md
@@ -1,0 +1,10 @@
+# GH-3907
+
+**Created:** 2026-07-06
+
+## Problem
+
+Create a new internal/memory/graphrecall package (or internal/executor/memory_recall.go if kept adjacent) implementing RecallRelevant(projectPath, taskText string, limit int) []MemorySummary. Load .agent/knowledge/graph.json, tolerate the path / file / memory_file node-path variants (never use concept_index), derive target concepts by case-insensitive substring/word matching of graph concept ids and their aliases against taskText, then rank memories by |mem.concepts ∩ targets| desc → confidence desc → id asc. Exclude memories where resolved: true or superseded_by is set. Fail-open on missing/malformed graph (return empty, no error). Table-driven tests cover: ranking, resolved/superseded exclusion, path-key schema variants, missing graph file, empty task text, and a fixture mirroring this repo's real graph shape. This subtask is self-contained — no other package touched.
+
+## Acceptance Criteria
+

--- a/internal/memory/graphrecall/recall.go
+++ b/internal/memory/graphrecall/recall.go
@@ -1,0 +1,194 @@
+// Package graphrecall ranks Navigator knowledge-graph memories against a
+// task description so an executor prompt can be seeded with relevant
+// history without loading the whole .agent/knowledge tree.
+package graphrecall
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// MemorySummary is a lightweight, ranked view of a knowledge-graph memory
+// node relevant to a given task.
+type MemorySummary struct {
+	ID         string
+	Type       string
+	Summary    string
+	Concepts   []string
+	Confidence float64
+	Path       string
+}
+
+type graphDoc struct {
+	Nodes struct {
+		Concepts map[string]conceptNode `json:"concepts"`
+		Memories map[string]memoryNode  `json:"memories"`
+	} `json:"nodes"`
+}
+
+type conceptNode struct {
+	Label string `json:"label"`
+}
+
+type memoryNode struct {
+	Type         string      `json:"type"`
+	Summary      string      `json:"summary"`
+	Concepts     []string    `json:"concepts"`
+	Confidence   float64     `json:"confidence"`
+	Resolved     interface{} `json:"resolved,omitempty"`
+	SupersededBy string      `json:"superseded_by,omitempty"`
+	File         string      `json:"file,omitempty"`
+	Path         string      `json:"path,omitempty"`
+	MemoryFile   string      `json:"memory_file,omitempty"`
+}
+
+// resolvedPath tolerates the file/path/memory_file node-path variants seen
+// across graph.json revisions, checked in that order — the same precedence
+// scripts/check-graph.py uses. concept_index is a stale derived index and
+// is never consulted.
+func (m memoryNode) resolvedPath() string {
+	if m.File != "" {
+		return m.File
+	}
+	if m.Path != "" {
+		return m.Path
+	}
+	return m.MemoryFile
+}
+
+// isExcluded reports whether a memory is retired: resolved may be recorded
+// as a bare bool (true) or as a date string (e.g. "2026-05-20 (v2.146.7)"),
+// both of which mark the memory closed.
+func (m memoryNode) isExcluded() bool {
+	if m.SupersededBy != "" {
+		return true
+	}
+	switch v := m.Resolved.(type) {
+	case nil:
+		return false
+	case bool:
+		return v
+	case string:
+		return v != ""
+	default:
+		return v != nil
+	}
+}
+
+// RecallRelevant loads the Navigator knowledge graph at
+// <projectPath>/.agent/knowledge/graph.json and returns up to limit
+// memories relevant to taskText, ranked by concept overlap (desc), then
+// confidence (desc), then id (asc). It fails open: a missing or malformed
+// graph, or a limit <= 0, yields an empty slice, never an error.
+func RecallRelevant(projectPath, taskText string, limit int) []MemorySummary {
+	if limit <= 0 {
+		return []MemorySummary{}
+	}
+
+	graphPath := filepath.Join(projectPath, ".agent", "knowledge", "graph.json")
+	data, err := os.ReadFile(graphPath)
+	if err != nil {
+		return []MemorySummary{}
+	}
+
+	var doc graphDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return []MemorySummary{}
+	}
+
+	targets := targetConcepts(doc.Nodes.Concepts, taskText)
+	if len(targets) == 0 {
+		return []MemorySummary{}
+	}
+
+	type ranked struct {
+		id      string
+		mem     memoryNode
+		overlap int
+	}
+
+	candidates := make([]ranked, 0, len(doc.Nodes.Memories))
+	for id, mem := range doc.Nodes.Memories {
+		if mem.isExcluded() {
+			continue
+		}
+		overlap := countOverlap(mem.Concepts, targets)
+		if overlap == 0 {
+			continue
+		}
+		candidates = append(candidates, ranked{id: id, mem: mem, overlap: overlap})
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].overlap != candidates[j].overlap {
+			return candidates[i].overlap > candidates[j].overlap
+		}
+		if candidates[i].mem.Confidence != candidates[j].mem.Confidence {
+			return candidates[i].mem.Confidence > candidates[j].mem.Confidence
+		}
+		return candidates[i].id < candidates[j].id
+	})
+
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+
+	out := make([]MemorySummary, 0, len(candidates))
+	for _, c := range candidates {
+		out = append(out, MemorySummary{
+			ID:         c.id,
+			Type:       c.mem.Type,
+			Summary:    c.mem.Summary,
+			Concepts:   c.mem.Concepts,
+			Confidence: c.mem.Confidence,
+			Path:       c.mem.resolvedPath(),
+		})
+	}
+	return out
+}
+
+func countOverlap(concepts []string, targets map[string]struct{}) int {
+	n := 0
+	for _, c := range concepts {
+		if _, ok := targets[c]; ok {
+			n++
+		}
+	}
+	return n
+}
+
+// targetConcepts derives the set of graph concept ids relevant to taskText
+// by case-insensitive substring matching of each concept's id and label
+// (its human-readable alias) against taskText. Hyphens/underscores in both
+// the concept id and taskText are normalized to spaces first, so phrase
+// wording matters rather than punctuation style.
+func targetConcepts(concepts map[string]conceptNode, taskText string) map[string]struct{} {
+	targets := map[string]struct{}{}
+	normText := normalize(taskText)
+	if normText == "" {
+		return targets
+	}
+	for id, c := range concepts {
+		if matches(normText, id) || matches(normText, c.Label) {
+			targets[id] = struct{}{}
+		}
+	}
+	return targets
+}
+
+func matches(normText, candidate string) bool {
+	norm := normalize(candidate)
+	if norm == "" {
+		return false
+	}
+	return strings.Contains(normText, norm)
+}
+
+func normalize(s string) string {
+	s = strings.ToLower(s)
+	s = strings.NewReplacer("-", " ", "_", " ").Replace(s)
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/internal/memory/graphrecall/recall_test.go
+++ b/internal/memory/graphrecall/recall_test.go
@@ -1,0 +1,257 @@
+package graphrecall
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeGraph(t *testing.T, projectPath, content string) {
+	t.Helper()
+	dir := filepath.Join(projectPath, ".agent", "knowledge")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "graph.json"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+}
+
+func TestRecallRelevant(t *testing.T) {
+	// Mirrors this repo's real .agent/knowledge/graph.json shape: nodes
+	// grouped by category (concepts/tasks/memories), a top-level
+	// concept_index that must never be consulted directly, and memory
+	// path fields expressed via the file/path/memory_file variants.
+	const fixture = `{
+  "version": 1,
+  "nodes": {
+    "concepts": {
+      "executor": {
+        "label": "Executor",
+        "description": "Claude Code process spawner",
+        "files": ["internal/executor/runner.go"]
+      },
+      "git-operations": {
+        "label": "Git Operations",
+        "description": "sync/reset/merge handling"
+      },
+      "dashboard": {
+        "label": "Dashboard",
+        "description": "TUI"
+      }
+    },
+    "tasks": {
+      "TASK-01": {"title": "Gateway Foundation", "status": "completed", "concepts": ["executor"]}
+    },
+    "memories": {
+      "mem-low": {
+        "type": "pattern",
+        "summary": "single concept match, low confidence",
+        "concepts": ["executor"],
+        "confidence": 0.5,
+        "file": "internal/memory/memories/mem-low.md"
+      },
+      "mem-high-conf": {
+        "type": "pattern",
+        "summary": "single concept match, high confidence",
+        "concepts": ["executor"],
+        "confidence": 0.9,
+        "path": "memories/mem-high-conf.md"
+      },
+      "mem-two-concepts": {
+        "type": "pitfall",
+        "summary": "two concept matches beats single match",
+        "concepts": ["executor", "git-operations"],
+        "confidence": 0.1,
+        "memory_file": ".agent/knowledge/memories/pitfalls/mem-two-concepts.md"
+      },
+      "mem-tie-b": {
+        "type": "decision",
+        "summary": "tie on overlap and confidence, id asc wins",
+        "concepts": ["git-operations"],
+        "confidence": 0.7
+      },
+      "mem-tie-a": {
+        "type": "decision",
+        "summary": "tie on overlap and confidence, id asc wins",
+        "concepts": ["git-operations"],
+        "confidence": 0.7
+      },
+      "mem-resolved-bool": {
+        "type": "pitfall",
+        "summary": "excluded: resolved true",
+        "concepts": ["executor"],
+        "confidence": 1.0,
+        "resolved": true
+      },
+      "mem-resolved-date": {
+        "type": "pitfall",
+        "summary": "excluded: resolved as date string",
+        "concepts": ["executor"],
+        "confidence": 1.0,
+        "resolved": "2026-05-20 (v2.146.7)"
+      },
+      "mem-superseded": {
+        "type": "pitfall",
+        "summary": "excluded: superseded_by set",
+        "concepts": ["executor"],
+        "confidence": 1.0,
+        "superseded_by": "mem-two-concepts"
+      },
+      "mem-unrelated": {
+        "type": "pattern",
+        "summary": "no concept overlap with task",
+        "concepts": ["dashboard"],
+        "confidence": 1.0
+      }
+    }
+  },
+  "edges": [],
+  "concept_index": {
+    "executor": ["TASK-01"],
+    "memory": ["should-never-be-read"]
+  }
+}`
+
+	t.Run("ranking by overlap then confidence then id", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGraph(t, dir, fixture)
+
+		got := RecallRelevant(dir, "fix executor and git-operations bug", 10)
+
+		wantOrder := []string{
+			"mem-two-concepts", // overlap=2
+			"mem-high-conf",    // overlap=1, confidence=0.9
+			"mem-tie-a",        // overlap=1, confidence=0.7, id asc
+			"mem-tie-b",        // overlap=1, confidence=0.7
+			"mem-low",          // overlap=1, confidence=0.5
+		}
+		if len(got) != len(wantOrder) {
+			t.Fatalf("got %d results, want %d: %+v", len(got), len(wantOrder), got)
+		}
+		for i, id := range wantOrder {
+			if got[i].ID != id {
+				t.Errorf("position %d: got %q, want %q (full: %+v)", i, got[i].ID, id, got)
+			}
+		}
+	})
+
+	t.Run("resolved and superseded memories excluded", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGraph(t, dir, fixture)
+
+		got := RecallRelevant(dir, "executor", 100)
+		for _, m := range got {
+			if m.ID == "mem-resolved-bool" || m.ID == "mem-resolved-date" || m.ID == "mem-superseded" {
+				t.Errorf("expected %q to be excluded, but it was returned", m.ID)
+			}
+		}
+	})
+
+	t.Run("limit caps results", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGraph(t, dir, fixture)
+
+		got := RecallRelevant(dir, "fix executor and git-operations bug", 1)
+		if len(got) != 1 {
+			t.Fatalf("got %d results, want 1", len(got))
+		}
+		if got[0].ID != "mem-two-concepts" {
+			t.Errorf("got %q, want mem-two-concepts", got[0].ID)
+		}
+	})
+
+	t.Run("path key schema variants all resolve", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGraph(t, dir, fixture)
+
+		got := RecallRelevant(dir, "fix executor and git-operations bug", 10)
+		paths := map[string]string{}
+		for _, m := range got {
+			paths[m.ID] = m.Path
+		}
+		if paths["mem-low"] != "internal/memory/memories/mem-low.md" {
+			t.Errorf("file variant: got %q", paths["mem-low"])
+		}
+		if paths["mem-high-conf"] != "memories/mem-high-conf.md" {
+			t.Errorf("path variant: got %q", paths["mem-high-conf"])
+		}
+		if paths["mem-two-concepts"] != ".agent/knowledge/memories/pitfalls/mem-two-concepts.md" {
+			t.Errorf("memory_file variant: got %q", paths["mem-two-concepts"])
+		}
+		if paths["mem-tie-a"] != "" {
+			t.Errorf("no path fields set: got %q, want empty", paths["mem-tie-a"])
+		}
+	})
+
+	t.Run("unrelated concepts never surface", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGraph(t, dir, fixture)
+
+		got := RecallRelevant(dir, "fix executor bug", 100)
+		for _, m := range got {
+			if m.ID == "mem-unrelated" {
+				t.Errorf("mem-unrelated has no concept overlap with task text and should not be returned")
+			}
+		}
+	})
+
+	t.Run("missing graph file fails open", func(t *testing.T) {
+		dir := t.TempDir() // no .agent/knowledge/graph.json written
+
+		got := RecallRelevant(dir, "fix executor bug", 10)
+		if len(got) != 0 {
+			t.Fatalf("got %d results for missing graph, want 0: %+v", len(got), got)
+		}
+	})
+
+	t.Run("malformed graph file fails open", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGraph(t, dir, `{not valid json`)
+
+		got := RecallRelevant(dir, "fix executor bug", 10)
+		if len(got) != 0 {
+			t.Fatalf("got %d results for malformed graph, want 0: %+v", len(got), got)
+		}
+	})
+
+	t.Run("empty task text yields no matches", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGraph(t, dir, fixture)
+
+		got := RecallRelevant(dir, "", 10)
+		if len(got) != 0 {
+			t.Fatalf("got %d results for empty task text, want 0: %+v", len(got), got)
+		}
+	})
+
+	t.Run("zero or negative limit yields no results", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGraph(t, dir, fixture)
+
+		if got := RecallRelevant(dir, "executor", 0); len(got) != 0 {
+			t.Errorf("limit=0: got %d results, want 0", len(got))
+		}
+		if got := RecallRelevant(dir, "executor", -1); len(got) != 0 {
+			t.Errorf("limit=-1: got %d results, want 0", len(got))
+		}
+	})
+
+	t.Run("label alias matching", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGraph(t, dir, fixture)
+
+		// Task text uses the human-readable label "Git Operations" rather
+		// than the concept id "git-operations".
+		got := RecallRelevant(dir, "investigate Git Operations regression", 10)
+		found := false
+		for _, m := range got {
+			if m.ID == "mem-tie-a" || m.ID == "mem-tie-b" || m.ID == "mem-two-concepts" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected label-based match to surface git-operations memories, got %+v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3907.

Closes #3907

## Changes

Create a new internal/memory/graphrecall package (or internal/executor/memory_recall.go if kept adjacent) implementing RecallRelevant(projectPath, taskText string, limit int) []MemorySummary. Load .agent/knowledge/graph.json, tolerate the path / file / memory_file node-path variants (never use concept_index), derive target concepts by case-insensitive substring/word matching of graph concept ids and their aliases against taskText, then rank memories by |mem.concepts ∩ targets| desc → confidence desc → id asc. Exclude memories where resolved: true or superseded_by is set. Fail-open on missing/malformed graph (return empty, no error). Table-driven tests cover: ranking, resolved/superseded exclusion, path-key schema variants, missing graph file, empty task text, and a fixture mirroring this repo's real graph shape. This subtask is self-contained — no other package touched.