### PR TITLE
feat(executor): add memory_injection config for knowledge-graph recall (GH-3908)

### DIFF
--- a/.agent/tasks/gh-3908.md
+++ b/.agent/tasks/gh-3908.md
@@ -1,0 +1,10 @@
+# GH-3908
+
+**Created:** 2026-07-06
+
+## Problem
+
+Add MemoryInjection struct to internal/config with Enabled bool (default true) and MaxMemories int (default 5), nested under Executor. Update configs/pilot.example.yaml with both keys and inline comments describing behavior (fail-open, LocalMode-skipped, capped). Unit tests assert defaults populate when the section is omitted from YAML and that explicit values override them. Depends on subtask 1 only for the max-memories constant reference (loose); can run in parallel.
+
+## Acceptance Criteria
+

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -348,6 +348,16 @@ executor:
   #   max_rss_mb: 4096            # virtual address space cap in MiB (Linux only)
   #   sample_interval_sec: 10     # how often to poll RSS
 
+  # Knowledge-graph memory injection (TASK-387) - append relevant past
+  # pitfalls/patterns/decisions/learnings from .agent/knowledge/graph.json
+  # to executor prompts. Recall is local computation only (no LLM call) and
+  # fails open: a missing or malformed graph yields no injection, never an
+  # error. Skipped entirely for LocalMode tasks (GH-2103) and projects
+  # without a .agent/ directory.
+  # memory_injection:
+  #   enabled: true        # Master switch; false disables the block entirely
+  #   max_memories: 5       # Cap on ranked memories included (also capped at ~1500 chars total)
+
   # Stagnation detection (GH-925) - detect and recover from stuck tasks
   # stagnation:
   #   enabled: true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1862,3 +1862,90 @@ func TestSave_TightensExistingLoosePerms(t *testing.T) {
 		t.Errorf("config file mode after rewrite = %o, want 0600", got)
 	}
 }
+
+// TestLoadMemoryInjectionConfig covers TASK-387's config plumbing:
+// executor.memory_injection defaults to Enabled=true/MaxMemories=5 when
+// omitted, and explicit YAML values override those defaults.
+func TestLoadMemoryInjectionConfig(t *testing.T) {
+	t.Run("defaults when section omitted", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		if err := os.WriteFile(configPath, []byte(`version: "1.0"`), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load failed: %v", err)
+		}
+
+		if cfg.Executor == nil || cfg.Executor.MemoryInjection == nil {
+			t.Fatal("Executor.MemoryInjection should not be nil")
+		}
+		if !cfg.Executor.MemoryInjection.Enabled {
+			t.Error("MemoryInjection.Enabled should default to true")
+		}
+		if cfg.Executor.MemoryInjection.MaxMemories != 5 {
+			t.Errorf("MemoryInjection.MaxMemories = %d, want 5", cfg.Executor.MemoryInjection.MaxMemories)
+		}
+	})
+
+	t.Run("explicit values override defaults", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		configContent := `
+version: "1.0"
+executor:
+  memory_injection:
+    enabled: false
+    max_memories: 3
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load failed: %v", err)
+		}
+
+		if cfg.Executor == nil || cfg.Executor.MemoryInjection == nil {
+			t.Fatal("Executor.MemoryInjection should not be nil")
+		}
+		if cfg.Executor.MemoryInjection.Enabled {
+			t.Error("MemoryInjection.Enabled should be false")
+		}
+		if cfg.Executor.MemoryInjection.MaxMemories != 3 {
+			t.Errorf("MemoryInjection.MaxMemories = %d, want 3", cfg.Executor.MemoryInjection.MaxMemories)
+		}
+	})
+
+	t.Run("partial override keeps other default", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		configContent := `
+version: "1.0"
+executor:
+  memory_injection:
+    enabled: false
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write test config: %v", err)
+		}
+
+		cfg, err := Load(configPath)
+		if err != nil {
+			t.Fatalf("Load failed: %v", err)
+		}
+
+		if cfg.Executor.MemoryInjection.Enabled {
+			t.Error("MemoryInjection.Enabled should be false")
+		}
+		if cfg.Executor.MemoryInjection.MaxMemories != 5 {
+			t.Errorf("MemoryInjection.MaxMemories = %d, want default 5 to survive partial override", cfg.Executor.MemoryInjection.MaxMemories)
+		}
+	})
+}

--- a/internal/executor/backend.go
+++ b/internal/executor/backend.go
@@ -287,6 +287,10 @@ type BackendConfig struct {
 	// conflicting/stale/out-of-scope issues are declined without burning a worker slot.
 	PreFlightJudge *PreFlightJudgeConfig `yaml:"pre_flight_judge,omitempty"`
 
+	// MemoryInjection contains knowledge-graph memory recall settings for
+	// executor prompts (TASK-387).
+	MemoryInjection *MemoryInjectionConfig `yaml:"memory_injection,omitempty"`
+
 	// Navigator contains Navigator auto-init settings
 	Navigator *NavigatorConfig `yaml:"navigator,omitempty"`
 
@@ -604,6 +608,38 @@ type PreFlightJudgeConfig struct {
 	APIKey string `yaml:"api_key,omitempty"`
 }
 
+// MemoryInjectionConfig controls whether relevant knowledge-graph memories
+// (pitfalls, patterns, decisions, learnings) are appended to executor
+// prompts. Recall is pure local computation over .agent/knowledge/graph.json
+// (see internal/memory/graphrecall) — fail-open on a missing or malformed
+// graph, so injection never blocks execution. Skipped for LocalMode tasks
+// (GH-2103) and when the project has no .agent/ directory. TASK-387.
+//
+// Example YAML configuration:
+//
+//	executor:
+//	  memory_injection:
+//	    enabled: true
+//	    max_memories: 5
+type MemoryInjectionConfig struct {
+	// Enabled controls whether the "Known pitfalls from project memory"
+	// block is appended to the prompt. Default: true.
+	Enabled bool `yaml:"enabled"`
+
+	// MaxMemories caps how many ranked memories are included in the
+	// injected block (also capped at ~1500 chars total, whichever is
+	// smaller). Default: 5.
+	MaxMemories int `yaml:"max_memories"`
+}
+
+// DefaultMemoryInjectionConfig returns default memory injection configuration.
+func DefaultMemoryInjectionConfig() *MemoryInjectionConfig {
+	return &MemoryInjectionConfig{
+		Enabled:     true,
+		MaxMemories: 5,
+	}
+}
+
 // ClaudeCodeConfig contains Claude Code backend configuration.
 type ClaudeCodeConfig struct {
 	// Command is the path to the claude CLI (default: "claude")
@@ -765,6 +801,7 @@ func DefaultBackendConfig() *BackendConfig {
 		IntentJudge:      DefaultIntentJudgeConfig(),
 		Navigator:        DefaultNavigatorConfig(),
 		Hooks:            DefaultHooksConfig(),
+		MemoryInjection:  DefaultMemoryInjectionConfig(),
 		Planning:         DefaultPlanningConfig(),
 		Retry:            DefaultRetryConfig(),
 		Stagnation:       DefaultStagnationConfig(),

--- a/internal/executor/backend_test.go
+++ b/internal/executor/backend_test.go
@@ -84,6 +84,29 @@ func TestDefaultBackendConfig(t *testing.T) {
 	if config.OpenCode.ServerURL != "http://127.0.0.1:4096" {
 		t.Errorf("OpenCode.ServerURL = %q, want http://127.0.0.1:4096", config.OpenCode.ServerURL)
 	}
+	if config.MemoryInjection == nil {
+		t.Fatal("MemoryInjection config should not be nil")
+	}
+	if !config.MemoryInjection.Enabled {
+		t.Error("MemoryInjection.Enabled should default to true")
+	}
+	if config.MemoryInjection.MaxMemories != 5 {
+		t.Errorf("MemoryInjection.MaxMemories = %d, want 5", config.MemoryInjection.MaxMemories)
+	}
+}
+
+func TestDefaultMemoryInjectionConfig(t *testing.T) {
+	config := DefaultMemoryInjectionConfig()
+
+	if config == nil {
+		t.Fatal("DefaultMemoryInjectionConfig returned nil")
+	}
+	if !config.Enabled {
+		t.Error("Enabled should default to true")
+	}
+	if config.MaxMemories != 5 {
+		t.Errorf("MaxMemories = %d, want 5", config.MaxMemories)
+	}
 }
 
 func TestBackendConfigTypes(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `MemoryInjectionConfig` (`Enabled` default `true`, `MaxMemories` default `5`) nested under `executor.BackendConfig` (`internal/executor/backend.go`), wired into `DefaultBackendConfig()`.
- Documents `executor.memory_injection.enabled` / `max_memories` in `configs/pilot.example.yaml` with inline comments on fail-open, LocalMode-skipped, and capped behavior.
- Unit tests: defaults populate when the section is omitted from YAML, explicit values override, and a partial override preserves the other default.

This is the config-plumbing subtask for TASK-387 (knowledge-graph memory injection into executor prompts). Prompt wiring itself (`BuildPrompt`) is a separate subtask.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/config/... ./internal/executor/...`
- [x] `go test ./...` (full suite)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`