### PR TITLE
fix(autopilot): scope PR state per repo — add repo column migration (GH-3903-1)

### DIFF
--- a/.agent/tasks/gh-3903-1.md
+++ b/.agent/tasks/gh-3903-1.md
@@ -1,0 +1,23 @@
+# GH-3903-1
+
+**Created:** 2026-07-06
+
+## Problem
+
+## Subtask 1 of 5
+
+**Parent Task:** GH-3903 - fix(autopilot): scope PR state per repo — cross-repo PR-number collisions drive wrong-repo actions
+
+## Objective
+
+**Migration**: add `repo TEXT NOT NULL DEFAULT ''` to `autopilot_pr_state` and `autopilot_pr_failures`; uniqueness becomes `(repo, pr_number)`. Backfill `repo` for existing `autopilot_pr_state` rows by parsing `pr_url` (`https://github.com/{owner}/{repo}/pull/{n}`); `autopilot_pr_failures` rows without a resolvable repo may be dropped (ephemeral retry counters).
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+
+
+## Acceptance Criteria
+

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -114,6 +114,17 @@ func (s *StateStore) migrate() error {
 		}
 	}
 
+	// GH-3903: Rebuild autopilot_pr_state / autopilot_pr_failures with repo in
+	// the PRIMARY KEY so cross-repo PR-number collisions can't clobber each
+	// other's state. pr_state must migrate first: the failures backfill joins
+	// against its (now repo-populated) rows to resolve each failure row's repo.
+	if err := s.migratePRStateRepoColumn(); err != nil {
+		return fmt.Errorf("autopilot_pr_state repo column migration failed: %w", err)
+	}
+	if err := s.migratePRFailuresRepoColumn(); err != nil {
+		return fmt.Errorf("autopilot_pr_failures repo column migration failed: %w", err)
+	}
+
 	// GH-3819: Rebuild adapter_processed with repo in the PRIMARY KEY if an
 	// older DB still has the pre-GH-1838-fixup schema. Must run before the
 	// legacy-table migration below so legacy rows land in the corrected table.
@@ -215,6 +226,228 @@ func (s *StateStore) migrateAdapterProcessedPrimaryKey() error {
 	return tx.Commit()
 }
 
+// parsePRRepoFromURL returns "owner/repo" parsed out of a PR URL, or "" if the
+// URL doesn't match the expected GitHub shape. Reuses PRState.RepoOwnerAndName
+// (types.go) so migration backfill and runtime parsing agree on one rule.
+func parsePRRepoFromURL(prURL string) string {
+	owner, repo := (&PRState{PRURL: prURL}).RepoOwnerAndName("", "")
+	if owner == "" || repo == "" {
+		return ""
+	}
+	return owner + "/" + repo
+}
+
+// columnInPrimaryKey reports whether the given column is part of table's
+// PRIMARY KEY. table must be a fixed, code-controlled identifier (interpolated
+// directly into PRAGMA, which does not accept bound parameters).
+func (s *StateStore) columnInPrimaryKey(table, column string) (bool, error) {
+	rows, err := s.db.Query(fmt.Sprintf(`PRAGMA table_info(%s)`, table))
+	if err != nil {
+		return false, fmt.Errorf("inspect %s schema: %w", table, err)
+	}
+	found := false
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, ctype string
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notNull, &dflt, &pk); err != nil {
+			_ = rows.Close()
+			return false, fmt.Errorf("scan %s schema: %w", table, err)
+		}
+		if name == column && pk > 0 {
+			found = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return false, fmt.Errorf("iterate %s schema: %w", table, err)
+	}
+	if err := rows.Close(); err != nil {
+		return false, fmt.Errorf("close %s schema query: %w", table, err)
+	}
+	return found, nil
+}
+
+// migratePRStateRepoColumn rebuilds autopilot_pr_state so repo is part of the
+// PRIMARY KEY (GH-3903). The original table keyed on pr_number alone, so any
+// two repos with a controller tracking the same PR number silently shared one
+// row. repo is backfilled by parsing each row's pr_url; rows whose pr_url
+// doesn't match the expected GitHub shape keep repo='' (the column default).
+//
+// No-op if repo is already part of the primary key (fresh install, or already
+// migrated).
+func (s *StateStore) migratePRStateRepoColumn() error {
+	hasRepo, err := s.columnInPrimaryKey("autopilot_pr_state", "repo")
+	if err != nil {
+		return err
+	}
+	if hasRepo {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(`
+		CREATE TABLE autopilot_pr_state_gh3903 (
+			pr_number INTEGER NOT NULL,
+			pr_url TEXT NOT NULL,
+			issue_number INTEGER DEFAULT 0,
+			branch_name TEXT NOT NULL DEFAULT '',
+			head_sha TEXT DEFAULT '',
+			stage TEXT NOT NULL,
+			ci_status TEXT NOT NULL DEFAULT 'pending',
+			last_checked DATETIME,
+			ci_wait_started_at DATETIME,
+			merge_attempts INTEGER DEFAULT 0,
+			error TEXT DEFAULT '',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			release_version TEXT DEFAULT '',
+			release_bump_type TEXT DEFAULT '',
+			merge_notification_posted INTEGER NOT NULL DEFAULT 0,
+			approval_request_id TEXT NOT NULL DEFAULT '',
+			approval_decision TEXT NOT NULL DEFAULT '',
+			approval_requested_at DATETIME,
+			post_merge_sha TEXT NOT NULL DEFAULT '',
+			post_merge_ci_started_at DATETIME,
+			rebase_attempts INTEGER NOT NULL DEFAULT 0,
+			repo TEXT NOT NULL DEFAULT '',
+			PRIMARY KEY (repo, pr_number)
+		)
+	`); err != nil {
+		return fmt.Errorf("create autopilot_pr_state_gh3903: %w", err)
+	}
+
+	if _, err := tx.Exec(`
+		INSERT INTO autopilot_pr_state_gh3903 (
+			pr_number, pr_url, issue_number, branch_name, head_sha,
+			stage, ci_status, last_checked, ci_wait_started_at,
+			merge_attempts, error, created_at, updated_at,
+			release_version, release_bump_type, merge_notification_posted,
+			approval_request_id, approval_decision, approval_requested_at,
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts
+		)
+		SELECT
+			pr_number, pr_url, issue_number, branch_name, head_sha,
+			stage, ci_status, last_checked, ci_wait_started_at,
+			merge_attempts, error, created_at, updated_at,
+			release_version, release_bump_type, merge_notification_posted,
+			approval_request_id, approval_decision, approval_requested_at,
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts
+		FROM autopilot_pr_state
+	`); err != nil {
+		return fmt.Errorf("copy autopilot_pr_state rows: %w", err)
+	}
+
+	rows, err := tx.Query(`SELECT pr_number, pr_url FROM autopilot_pr_state_gh3903`)
+	if err != nil {
+		return fmt.Errorf("query rows for repo backfill: %w", err)
+	}
+	type prRow struct {
+		prNumber int
+		prURL    string
+	}
+	var toBackfill []prRow
+	for rows.Next() {
+		var r prRow
+		if err := rows.Scan(&r.prNumber, &r.prURL); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan row for repo backfill: %w", err)
+		}
+		toBackfill = append(toBackfill, r)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate rows for repo backfill: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close repo backfill query: %w", err)
+	}
+
+	for _, r := range toBackfill {
+		repo := parsePRRepoFromURL(r.prURL)
+		if repo == "" {
+			continue
+		}
+		// pr_number was the sole PRIMARY KEY pre-migration, so it is still
+		// unique among the rows just copied above.
+		if _, err := tx.Exec(
+			`UPDATE autopilot_pr_state_gh3903 SET repo = ? WHERE pr_number = ?`,
+			repo, r.prNumber,
+		); err != nil {
+			return fmt.Errorf("backfill repo for pr_number %d: %w", r.prNumber, err)
+		}
+	}
+
+	if _, err := tx.Exec(`DROP TABLE autopilot_pr_state`); err != nil {
+		return fmt.Errorf("drop old autopilot_pr_state: %w", err)
+	}
+	if _, err := tx.Exec(`ALTER TABLE autopilot_pr_state_gh3903 RENAME TO autopilot_pr_state`); err != nil {
+		return fmt.Errorf("rename autopilot_pr_state_gh3903: %w", err)
+	}
+	return tx.Commit()
+}
+
+// migratePRFailuresRepoColumn rebuilds autopilot_pr_failures so repo is part
+// of the PRIMARY KEY (GH-3903), matching migratePRStateRepoColumn. Failure
+// rows carry no pr_url of their own, so repo is resolved by joining against
+// the (already repo-backfilled) autopilot_pr_state on pr_number; rows whose
+// pr_number has no match there, or whose match's repo is unresolved, are
+// dropped rather than kept with repo='' — they are ephemeral retry counters,
+// and repo='' would risk colliding with a different repo's PR of that number.
+//
+// Must run after migratePRStateRepoColumn. No-op if repo is already part of
+// the primary key (fresh install, or already migrated).
+func (s *StateStore) migratePRFailuresRepoColumn() error {
+	hasRepo, err := s.columnInPrimaryKey("autopilot_pr_failures", "repo")
+	if err != nil {
+		return err
+	}
+	if hasRepo {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(`
+		CREATE TABLE autopilot_pr_failures_gh3903 (
+			pr_number INTEGER NOT NULL,
+			failure_count INTEGER NOT NULL DEFAULT 0,
+			last_failure_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			repo TEXT NOT NULL DEFAULT '',
+			PRIMARY KEY (repo, pr_number)
+		)
+	`); err != nil {
+		return fmt.Errorf("create autopilot_pr_failures_gh3903: %w", err)
+	}
+
+	if _, err := tx.Exec(`
+		INSERT INTO autopilot_pr_failures_gh3903 (pr_number, failure_count, last_failure_time, repo)
+		SELECT f.pr_number, f.failure_count, f.last_failure_time, s.repo
+		FROM autopilot_pr_failures f
+		JOIN autopilot_pr_state s ON s.pr_number = f.pr_number
+		WHERE s.repo != ''
+	`); err != nil {
+		return fmt.Errorf("copy autopilot_pr_failures rows: %w", err)
+	}
+
+	if _, err := tx.Exec(`DROP TABLE autopilot_pr_failures`); err != nil {
+		return fmt.Errorf("drop old autopilot_pr_failures: %w", err)
+	}
+	if _, err := tx.Exec(`ALTER TABLE autopilot_pr_failures_gh3903 RENAME TO autopilot_pr_failures`); err != nil {
+		return fmt.Errorf("rename autopilot_pr_failures_gh3903: %w", err)
+	}
+	return tx.Commit()
+}
+
 // repoScopedAdapters lists adapter names whose pollers always dedup within a
 // specific repo (as opposed to tracker-style adapters — linear, jira, asana,
 // plane — which pass repo="" by design, see Mark's doc comment).
@@ -312,7 +545,7 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(pr_number) DO UPDATE SET
+		ON CONFLICT(repo, pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
 			branch_name = excluded.branch_name,
@@ -530,7 +763,7 @@ func (s *StateStore) SavePRFailures(prNumber, failureCount int, lastFailureTime 
 	_, err := s.db.Exec(`
 		INSERT INTO autopilot_pr_failures (pr_number, failure_count, last_failure_time)
 		VALUES (?, ?, ?)
-		ON CONFLICT(pr_number) DO UPDATE SET
+		ON CONFLICT(repo, pr_number) DO UPDATE SET
 			failure_count = excluded.failure_count,
 			last_failure_time = excluded.last_failure_time
 	`, prNumber, failureCount, lastFailureTime)

--- a/internal/autopilot/state_store_test.go
+++ b/internal/autopilot/state_store_test.go
@@ -1031,6 +1031,177 @@ func TestStateStore_LegacyMigrationRowsPrunedSamePass(t *testing.T) {
 	}
 }
 
+// --- GH-3903: repo-scoped autopilot_pr_state / autopilot_pr_failures ---
+
+// TestStateStore_MigratePRStateAndFailuresRepoColumn verifies the pre-GH-3903
+// schema (pr_number as the sole PRIMARY KEY, no repo column) upgrades cleanly:
+// repo is backfilled on autopilot_pr_state by parsing pr_url, and
+// autopilot_pr_failures rows are joined against it, dropping any row whose
+// repo cannot be resolved (no matching pr_state row, or an unparseable
+// pr_url).
+func TestStateStore_MigratePRStateAndFailuresRepoColumn(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	// Seed the pre-GH-3903 autopilot_pr_state schema directly, bypassing
+	// NewStateStore's migrate().
+	if _, err := db.Exec(`
+		CREATE TABLE autopilot_pr_state (
+			pr_number INTEGER PRIMARY KEY,
+			pr_url TEXT NOT NULL,
+			issue_number INTEGER DEFAULT 0,
+			branch_name TEXT NOT NULL DEFAULT '',
+			head_sha TEXT DEFAULT '',
+			stage TEXT NOT NULL,
+			ci_status TEXT NOT NULL DEFAULT 'pending',
+			last_checked DATETIME,
+			ci_wait_started_at DATETIME,
+			merge_attempts INTEGER DEFAULT 0,
+			error TEXT DEFAULT '',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			release_version TEXT DEFAULT '',
+			release_bump_type TEXT DEFAULT ''
+		)
+	`); err != nil {
+		t.Fatalf("failed to seed legacy autopilot_pr_state schema: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO autopilot_pr_state (pr_number, pr_url, stage, ci_status)
+		VALUES (74, 'https://github.com/qf-studio/studio-sdk/pull/74', 'waiting_ci', 'pending')
+	`); err != nil {
+		t.Fatalf("failed to seed row with resolvable pr_url: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO autopilot_pr_state (pr_number, pr_url, stage, ci_status)
+		VALUES (999, 'not-a-github-url', 'waiting_ci', 'pending')
+	`); err != nil {
+		t.Fatalf("failed to seed row with malformed pr_url: %v", err)
+	}
+
+	// Seed the pre-GH-3903 autopilot_pr_failures schema directly.
+	if _, err := db.Exec(`
+		CREATE TABLE autopilot_pr_failures (
+			pr_number INTEGER PRIMARY KEY,
+			failure_count INTEGER NOT NULL DEFAULT 0,
+			last_failure_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)
+	`); err != nil {
+		t.Fatalf("failed to seed legacy autopilot_pr_failures schema: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO autopilot_pr_failures (pr_number, failure_count) VALUES (74, 3)
+	`); err != nil {
+		t.Fatalf("failed to seed resolvable failure row: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO autopilot_pr_failures (pr_number, failure_count) VALUES (999, 1)
+	`); err != nil {
+		t.Fatalf("failed to seed failure row with unresolvable repo: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO autopilot_pr_failures (pr_number, failure_count) VALUES (12345, 2)
+	`); err != nil {
+		t.Fatalf("failed to seed orphaned failure row: %v", err)
+	}
+
+	store, err := NewStateStore(db)
+	if err != nil {
+		t.Fatalf("NewStateStore (running migrations) failed: %v", err)
+	}
+
+	// Pre-existing pr_state rows must survive the rebuild with data intact.
+	pr, err := store.GetPRState(74)
+	if err != nil {
+		t.Fatalf("GetPRState(74) failed: %v", err)
+	}
+	if pr == nil || pr.PRURL != "https://github.com/qf-studio/studio-sdk/pull/74" {
+		t.Fatalf("pr_number 74 did not survive migration intact: %+v", pr)
+	}
+
+	var repo74, repo999 string
+	if err := store.db.QueryRow(`SELECT repo FROM autopilot_pr_state WHERE pr_number = 74`).Scan(&repo74); err != nil {
+		t.Fatalf("query repo for pr 74: %v", err)
+	}
+	if repo74 != "qf-studio/studio-sdk" {
+		t.Errorf("repo for pr 74 = %q, want %q", repo74, "qf-studio/studio-sdk")
+	}
+	if err := store.db.QueryRow(`SELECT repo FROM autopilot_pr_state WHERE pr_number = 999`).Scan(&repo999); err != nil {
+		t.Fatalf("query repo for pr 999: %v", err)
+	}
+	if repo999 != "" {
+		t.Errorf("repo for pr 999 (malformed pr_url) = %q, want empty", repo999)
+	}
+
+	// Only the failure row whose repo could be resolved should survive.
+	failures, err := store.LoadAllPRFailures()
+	if err != nil {
+		t.Fatalf("LoadAllPRFailures failed: %v", err)
+	}
+	if len(failures) != 1 {
+		t.Fatalf("expected 1 surviving failure row, got %d: %+v", len(failures), failures)
+	}
+	f74, ok := failures[74]
+	if !ok {
+		t.Fatal("expected failure row for pr_number 74 to survive")
+	}
+	if f74.FailureCount != 3 {
+		t.Errorf("FailureCount for pr 74 = %d, want 3", f74.FailureCount)
+	}
+	if _, ok := failures[999]; ok {
+		t.Error("failure row for pr_number 999 (unresolvable repo) should have been dropped")
+	}
+	if _, ok := failures[12345]; ok {
+		t.Error("orphaned failure row for pr_number 12345 (no matching pr_state row) should have been dropped")
+	}
+
+	var failureRepo string
+	if err := store.db.QueryRow(`SELECT repo FROM autopilot_pr_failures WHERE pr_number = 74`).Scan(&failureRepo); err != nil {
+		t.Fatalf("query repo for failure row 74: %v", err)
+	}
+	if failureRepo != "qf-studio/studio-sdk" {
+		t.Errorf("repo for failure row 74 = %q, want %q", failureRepo, "qf-studio/studio-sdk")
+	}
+
+	// Idempotent: running again on an already-migrated DB is a no-op.
+	if err := store.migratePRStateRepoColumn(); err != nil {
+		t.Fatalf("second migratePRStateRepoColumn: %v", err)
+	}
+	if err := store.migratePRFailuresRepoColumn(); err != nil {
+		t.Fatalf("second migratePRFailuresRepoColumn: %v", err)
+	}
+}
+
+// TestStateStore_PRStateRepoCollision verifies the post-migration uniqueness
+// constraint is (repo, pr_number): the same pr_number in two different repos
+// must coexist as distinct rows.
+func TestStateStore_PRStateRepoCollision(t *testing.T) {
+	store := newTestStateStore(t)
+
+	if _, err := store.db.Exec(`
+		INSERT INTO autopilot_pr_state (pr_number, pr_url, stage, ci_status, repo)
+		VALUES (5, 'https://github.com/org/repo-a/pull/5', 'waiting_ci', 'pending', 'org/repo-a')
+	`); err != nil {
+		t.Fatalf("insert pr 5 for org/repo-a failed: %v", err)
+	}
+	if _, err := store.db.Exec(`
+		INSERT INTO autopilot_pr_state (pr_number, pr_url, stage, ci_status, repo)
+		VALUES (5, 'https://github.com/org/repo-b/pull/5', 'waiting_ci', 'pending', 'org/repo-b')
+	`); err != nil {
+		t.Fatalf("expected colliding pr_number in a different repo to be allowed: %v", err)
+	}
+
+	var count int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM autopilot_pr_state WHERE pr_number = 5`).Scan(&count); err != nil {
+		t.Fatalf("count pr_number=5 rows: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 rows for colliding pr_number 5 across repos, got %d", count)
+	}
+}
+
 func TestStateStore_MigrateLegacyProcessedTables(t *testing.T) {
 	// Migration test: seed adapter_processed directly (legacy tables are dropped on migrate).
 	store := newTestStateStore(t)


### PR DESCRIPTION
## Summary

Subtask 1 of 5 for #3903 — implements the migration piece only.

- Rebuilds `autopilot_pr_state` with `repo TEXT NOT NULL DEFAULT ''` in the PRIMARY KEY (`(repo, pr_number)`), backfilling `repo` for existing rows by parsing `pr_url` (reuses `PRState.RepoOwnerAndName`).
- Rebuilds `autopilot_pr_failures` the same way, resolving `repo` via a join against the now-repo-backfilled `autopilot_pr_state` on `pr_number`; rows whose repo can't be resolved (no matching PR-state row, or an unparseable `pr_url`) are dropped — they're ephemeral retry counters.
- Fixes the `ON CONFLICT(pr_number)` targets in `SavePRState`/`SavePRFailures` to `ON CONFLICT(repo, pr_number)` to match the new composite key (both still write `repo=''` for now — scoping the Store API by repo is subtask 2).
- Migration is idempotent and safe on fresh installs (mirrors the existing `migrateAdapterProcessedPrimaryKey` pattern).

Out of scope for this PR (tracked by remaining #3903 subtasks): scoping `SavePRState`/`LoadAllPRStates`/etc. by repo, `Controller.RestoreState` filtering, the 404-eviction guard, and the two-controller collision tests.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` — added `TestStateStore_MigratePRStateAndFailuresRepoColumn` (backfill + drop-unresolved) and `TestStateStore_PRStateRepoCollision` (same `pr_number` across two repos now coexists)
- [x] `go test ./...` (full suite)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`