### PR TITLE
fix(autopilot): scope PR state per repo — cross-repo pr_number collisions (GH-3903)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -365,6 +365,14 @@ func (c *Controller) SetStateStore(store *StateStore) {
 	c.stateStore = store
 }
 
+// repoKey returns this controller's "owner/repo" identity, used to scope
+// every StateStore read/write so a pr_number collision with another repo
+// sharing the same SQLite DB can never be restored or acted on by this
+// controller (GH-3903).
+func (c *Controller) repoKey() string {
+	return c.owner + "/" + c.repo
+}
+
 // SetLearningLoop sets the learning loop for capturing PR review feedback.
 // When set, handleMerged will fetch reviews after merge and extract patterns.
 func (c *Controller) SetLearningLoop(loop *memory.LearningLoop) {
@@ -404,7 +412,7 @@ func (c *Controller) persistPRState(prState *PRState) {
 	if c.stateStore == nil {
 		return
 	}
-	if err := c.stateStore.SavePRState(prState); err != nil {
+	if err := c.stateStore.SavePRState(c.repoKey(), prState); err != nil {
 		c.log.Warn("failed to persist PR state", "pr", prState.PRNumber, "error", err)
 	}
 }
@@ -414,7 +422,7 @@ func (c *Controller) persistRemovePR(prNumber int) {
 	if c.stateStore == nil {
 		return
 	}
-	if err := c.stateStore.RemovePRState(prNumber); err != nil {
+	if err := c.stateStore.RemovePRState(c.repoKey(), prNumber); err != nil {
 		c.log.Warn("failed to remove persisted PR state", "pr", prNumber, "error", err)
 	}
 }
@@ -480,7 +488,7 @@ func (c *Controller) persistPRFailures(prNumber int, state *prFailureState) {
 	if c.stateStore == nil {
 		return
 	}
-	if err := c.stateStore.SavePRFailures(prNumber, state.FailureCount, state.LastFailureTime); err != nil {
+	if err := c.stateStore.SavePRFailures(c.repoKey(), prNumber, state.FailureCount, state.LastFailureTime); err != nil {
 		c.log.Warn("failed to persist PR failure state", "pr", prNumber, "error", err)
 	}
 }
@@ -490,7 +498,7 @@ func (c *Controller) removePRFailures(prNumber int) {
 	if c.stateStore == nil {
 		return
 	}
-	if err := c.stateStore.RemovePRFailures(prNumber); err != nil {
+	if err := c.stateStore.RemovePRFailures(c.repoKey(), prNumber); err != nil {
 		c.log.Warn("failed to remove PR failure state", "pr", prNumber, "error", err)
 	}
 }
@@ -504,7 +512,7 @@ func (c *Controller) RestoreState() (int, error) {
 	}
 
 	// Restore PR states
-	states, err := c.stateStore.LoadAllPRStates()
+	states, err := c.stateStore.LoadAllPRStates(c.repoKey())
 	if err != nil {
 		return 0, fmt.Errorf("failed to load PR states: %w", err)
 	}
@@ -520,7 +528,7 @@ func (c *Controller) RestoreState() (int, error) {
 	c.mu.Unlock()
 
 	// Restore per-PR failures
-	prFailures, err := c.stateStore.LoadAllPRFailures()
+	prFailures, err := c.stateStore.LoadAllPRFailures(c.repoKey())
 	if err != nil {
 		c.log.Warn("failed to load per-PR failure states", "error", err)
 	} else {
@@ -1125,7 +1133,7 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 	// GH-1964/GH-1979: Learn from CI failure patterns (self-improvement).
 	// Guard: skip learning when CI logs are empty/whitespace (nothing to extract).
 	if c.learningLoop != nil && strings.TrimSpace(ciLogs) != "" {
-		projectPath := c.owner + "/" + c.repo
+		projectPath := c.repoKey()
 		if learnErr := c.learningLoop.LearnFromCIFailure(ctx, projectPath, ciLogs, failedChecks); learnErr != nil {
 			c.log.Warn("Failed to learn from CI failure", slog.Any("error", learnErr))
 		}
@@ -1251,7 +1259,7 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 			})
 		}
 		if len(reviewData) > 0 {
-			projectPath := c.owner + "/" + c.repo
+			projectPath := c.repoKey()
 			if learnErr := c.learningLoop.LearnFromReview(ctx, projectPath, reviewData, prState.PRURL); learnErr != nil {
 				c.log.Warn("Failed to learn from review feedback", slog.Any("error", learnErr))
 			}
@@ -1415,7 +1423,7 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 	// Stage intentionally stays at StageAwaitApproval.
 
 	if c.stateStore != nil {
-		if serr := c.stateStore.SavePRState(prState); serr != nil {
+		if serr := c.stateStore.SavePRState(c.repoKey(), prState); serr != nil {
 			c.log.Warn("failed to persist approval request state", "pr", prState.PRNumber, "error", serr)
 		}
 	}
@@ -1488,7 +1496,7 @@ func (c *Controller) SetApprovalDecision(ctx context.Context, requestID string, 
 		}
 		pr.ApprovalDecision = decision
 		if c.stateStore != nil {
-			_ = c.stateStore.SavePRState(pr)
+			_ = c.stateStore.SavePRState(c.repoKey(), pr)
 		}
 		prNumber := pr.PRNumber
 		issueNumber := pr.IssueNumber
@@ -2044,7 +2052,7 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 		// GH-1964/GH-1979: Learn from post-merge CI failure patterns (self-improvement).
 		// Guard: skip learning when CI logs are empty/whitespace (nothing to extract).
 		if c.learningLoop != nil && strings.TrimSpace(ciLogs) != "" {
-			projectPath := c.owner + "/" + c.repo
+			projectPath := c.repoKey()
 			if learnErr := c.learningLoop.LearnFromCIFailure(ctx, projectPath, ciLogs, failedChecks); learnErr != nil {
 				c.log.Warn("Failed to learn from post-merge CI failure", slog.Any("error", learnErr))
 			}
@@ -3062,7 +3070,7 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 		// releasingStaleThreshold) are intentionally NOT skipped so a genuinely
 		// wedged release can be re-driven.
 		if c.stateStore != nil {
-			if age, found, err := c.stateStore.PersistedReleasingAge(pr.Number); err != nil {
+			if age, found, err := c.stateStore.PersistedReleasingAge(c.repoKey(), pr.Number); err != nil {
 				c.log.Warn("failed to check persisted releasing state, will track to be safe",
 					"pr", pr.Number,
 					"error", err,
@@ -3295,9 +3303,24 @@ func (c *Controller) processAllPRs(ctx context.Context) {
 						"pr", pr.PRNumber, "cooldown", wait, "error", err)
 					return
 				}
+				if isNotFoundError(err) {
+					pr.mu.Lock()
+					pr.NotFoundCount++
+					notFoundCount := pr.NotFoundCount
+					pr.mu.Unlock()
+					if notFoundCount >= notFoundEvictionThreshold {
+						c.evictNotFoundPR(pr.PRNumber)
+						continue
+					}
+					c.log.Warn("failed to fetch PR", "pr", pr.PRNumber, "error", err, "not_found_count", notFoundCount)
+					continue
+				}
 				c.log.Warn("failed to fetch PR", "pr", pr.PRNumber, "error", err)
 				continue
 			}
+			pr.mu.Lock()
+			pr.NotFoundCount = 0
+			pr.mu.Unlock()
 
 			// TASK-324: hold pr.mu around the external-merge/close check and the
 			// polling-mode changes-requested read-modify-write + persist. Release it
@@ -3332,6 +3355,51 @@ func (c *Controller) processAllPRs(ctx context.Context) {
 			}
 		}
 	}
+}
+
+// isNotFoundError reports whether err represents a GitHub API 404 response.
+// studio-sdk's github client wraps non-2xx responses as a plain
+// fmt.Errorf("API error (status %d): ...", code, msg) with no typed error to
+// check via errors.As, so the status-code substring is the only signal available.
+func isNotFoundError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "status 404")
+}
+
+// notFoundEvictionThreshold bounds how many consecutive 404s fetching a
+// tracked PR are tolerated before the row is evicted. Guards against a stale
+// or foreign PR-state row (e.g. GH-3903: rows written before repo scoping
+// existed, or any future collision) driving an infinite "failed to fetch PR"
+// retry loop.
+const notFoundEvictionThreshold = 5
+
+// evictNotFoundPR drops a PR that has 404'd repeatedly from in-memory
+// tracking and the persisted state store. Unlike removePR, it deliberately
+// does NOT attempt remote branch cleanup: a repeated 404 means this
+// controller has no verified relationship to the PR, so touching c.owner/
+// c.repo's remote state based on nothing but a matching number would repeat
+// the exact wrong-repo mutation this eviction exists to prevent (GH-3903).
+func (c *Controller) evictNotFoundPR(prNumber int) {
+	c.mu.Lock()
+	prState, ok := c.activePRs[prNumber]
+	var headSHA string
+	if ok {
+		headSHA = prState.HeadSHA
+		delete(c.activePRs, prNumber)
+	}
+	delete(c.prFailures, prNumber)
+	delete(c.recordedMerges, prNumber)
+	c.mu.Unlock()
+
+	// GH-862: mirror removePR's discovery-state cleanup so an evicted PR
+	// doesn't leak an entry in ciMonitor's discovery map forever.
+	if headSHA != "" {
+		c.ciMonitor.ClearDiscovery(headSHA)
+	}
+
+	c.persistRemovePR(prNumber)
+	c.removePRFailures(prNumber)
+	c.log.Warn("evicted PR after repeated 404s fetching it — stale or foreign state-store row",
+		"pr", prNumber, "repo", c.repoKey(), "threshold", notFoundEvictionThreshold)
 }
 
 // checkExternalMergeOrClose checks if a PR was merged or closed externally (by human).

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -681,7 +681,7 @@ func TestController_ScanRecentlyMergedPRs_SkipsPersistedReleasing(t *testing.T) 
 
 	t.Run("fresh persisted releasing row is skipped", func(t *testing.T) {
 		c, store := newScanController(t)
-		if err := store.SavePRState(&PRState{PRNumber: 77, BranchName: "pilot/GH-770", Stage: StageReleasing, CreatedAt: time.Now()}); err != nil {
+		if err := store.SavePRState("owner/repo", &PRState{PRNumber: 77, BranchName: "pilot/GH-770", Stage: StageReleasing, CreatedAt: time.Now()}); err != nil {
 			t.Fatalf("SavePRState: %v", err)
 		}
 		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
@@ -694,7 +694,7 @@ func TestController_ScanRecentlyMergedPRs_SkipsPersistedReleasing(t *testing.T) 
 
 	t.Run("stale persisted releasing row is re-driven", func(t *testing.T) {
 		c, store := newScanController(t)
-		if err := store.SavePRState(&PRState{PRNumber: 77, BranchName: "pilot/GH-770", Stage: StageReleasing, CreatedAt: time.Now()}); err != nil {
+		if err := store.SavePRState("owner/repo", &PRState{PRNumber: 77, BranchName: "pilot/GH-770", Stage: StageReleasing, CreatedAt: time.Now()}); err != nil {
 			t.Fatalf("SavePRState: %v", err)
 		}
 		if _, err := store.db.Exec(
@@ -6017,11 +6017,11 @@ func TestController_handleMerging_CommentFlagPersists(t *testing.T) {
 		CreatedAt:               time.Now().Add(-5 * time.Minute).Truncate(time.Second),
 		MergeNotificationPosted: true,
 	}
-	if err := store.SavePRState(pr); err != nil {
+	if err := store.SavePRState("owner/repo", pr); err != nil {
 		t.Fatalf("SavePRState failed: %v", err)
 	}
 
-	loaded, err := store.GetPRState(42)
+	loaded, err := store.GetPRState("owner/repo", 42)
 	if err != nil {
 		t.Fatalf("GetPRState failed: %v", err)
 	}
@@ -6029,7 +6029,7 @@ func TestController_handleMerging_CommentFlagPersists(t *testing.T) {
 		t.Fatalf("MergeNotificationPosted did not persist: got %+v", loaded)
 	}
 
-	all, err := store.LoadAllPRStates()
+	all, err := store.LoadAllPRStates("owner/repo")
 	if err != nil {
 		t.Fatalf("LoadAllPRStates failed: %v", err)
 	}

--- a/internal/autopilot/gh3715_test.go
+++ b/internal/autopilot/gh3715_test.go
@@ -275,11 +275,11 @@ func TestStateStore_RebaseAttempts_SurvivesRestart(t *testing.T) {
 		CreatedAt:      time.Now().Truncate(time.Second),
 	}
 
-	if err := store.SavePRState(pr); err != nil {
+	if err := store.SavePRState("owner/repo", pr); err != nil {
 		t.Fatalf("SavePRState failed: %v", err)
 	}
 
-	loaded, err := store.GetPRState(55)
+	loaded, err := store.GetPRState("owner/repo", 55)
 	if err != nil {
 		t.Fatalf("GetPRState failed: %v", err)
 	}
@@ -290,7 +290,7 @@ func TestStateStore_RebaseAttempts_SurvivesRestart(t *testing.T) {
 		t.Errorf("GetPRState: RebaseAttempts = %d, want 2", loaded.RebaseAttempts)
 	}
 
-	all, err := store.LoadAllPRStates()
+	all, err := store.LoadAllPRStates("owner/repo")
 	if err != nil {
 		t.Fatalf("LoadAllPRStates failed: %v", err)
 	}

--- a/internal/autopilot/gh3903_test.go
+++ b/internal/autopilot/gh3903_test.go
@@ -1,0 +1,376 @@
+package autopilot
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-3903: autopilot_pr_state/autopilot_pr_failures used to key rows on
+// pr_number alone. With one project-scoped Controller per `projects:` repo
+// sharing a single SQLite DB, every controller restored and could act on
+// every other controller's rows whenever PR numbers collided across repos —
+// applying labels, closing issues, and deleting branches in the wrong repo.
+// These tests pin the fix: repo joins the primary key, RestoreState/persist
+// are scoped per-controller, and a 404-eviction guard bounds any residual
+// foreign-row retry loop.
+
+// TestController_CrossRepoPRNumberCollision_RestoreIsolation verifies that a
+// PR persisted by one repo's controller is never restored by a different
+// repo's controller, even when both use the identical PR number and share
+// one SQLite-backed StateStore (the exact shape of the 2026-07-06 incident:
+// studio-sdk PR #74 and pilot PR #74 sharing one daemon's DB).
+func TestController_CrossRepoPRNumberCollision_RestoreIsolation(t *testing.T) {
+	store := newTestStateStore(t)
+
+	ctrlA := NewController(DefaultConfig(), nil, nil, "qf-studio", "studio-sdk")
+	ctrlA.SetStateStore(store)
+	ctrlA.OnPRCreated(74, "https://github.com/qf-studio/studio-sdk/pull/74", 500, "sha-a", "pilot/GH-500", "")
+
+	ctrlB := NewController(DefaultConfig(), nil, nil, "qf-studio", "pilot")
+	ctrlB.SetStateStore(store)
+	ctrlB.OnPRCreated(74, "https://github.com/qf-studio/pilot/pull/74", 72, "sha-b", "pilot/GH-72", "")
+
+	// Fresh controllers simulate a daemon restart: RestoreState must only
+	// adopt each controller's own repo's row.
+	freshA := NewController(DefaultConfig(), nil, nil, "qf-studio", "studio-sdk")
+	freshA.SetStateStore(store)
+	restoredA, err := freshA.RestoreState()
+	if err != nil {
+		t.Fatalf("RestoreState (studio-sdk): %v", err)
+	}
+	if restoredA != 1 {
+		t.Fatalf("restored (studio-sdk) = %d, want 1 (only its own PR 74)", restoredA)
+	}
+	prA, ok := freshA.GetPRState(74)
+	if !ok {
+		t.Fatal("studio-sdk's own PR 74 should be restored")
+	}
+	if prA.IssueNumber != 500 {
+		t.Errorf("studio-sdk PR 74 issue = %d, want 500 (its own issue, not pilot's)", prA.IssueNumber)
+	}
+
+	freshB := NewController(DefaultConfig(), nil, nil, "qf-studio", "pilot")
+	freshB.SetStateStore(store)
+	restoredB, err := freshB.RestoreState()
+	if err != nil {
+		t.Fatalf("RestoreState (pilot): %v", err)
+	}
+	if restoredB != 1 {
+		t.Fatalf("restored (pilot) = %d, want 1 (only its own PR 74)", restoredB)
+	}
+	prB, ok := freshB.GetPRState(74)
+	if !ok {
+		t.Fatal("pilot's own PR 74 should be restored")
+	}
+	if prB.IssueNumber != 72 {
+		t.Errorf("pilot PR 74 issue = %d, want 72 (its own issue, not studio-sdk's)", prB.IssueNumber)
+	}
+}
+
+// TestController_CrossRepoPRNumberCollision_PersistIsolation verifies that
+// removing a PR in one repo's controller does not delete or otherwise affect
+// the colliding-numbered row belonging to a different repo.
+func TestController_CrossRepoPRNumberCollision_PersistIsolation(t *testing.T) {
+	store := newTestStateStore(t)
+
+	ctrlA := NewController(DefaultConfig(), nil, nil, "qf-studio", "studio-sdk")
+	ctrlA.SetStateStore(store)
+	ctrlA.OnPRCreated(74, "https://github.com/qf-studio/studio-sdk/pull/74", 500, "sha-a", "pilot/GH-500", "")
+
+	ctrlB := NewController(DefaultConfig(), nil, nil, "qf-studio", "pilot")
+	ctrlB.SetStateStore(store)
+	ctrlB.OnPRCreated(74, "https://github.com/qf-studio/pilot/pull/74", 72, "sha-b", "pilot/GH-72", "")
+
+	// Repo A resolves (e.g. merged externally) and removes its own PR 74.
+	ctrlA.removePR(74)
+
+	removedA, err := store.GetPRState("qf-studio/studio-sdk", 74)
+	if err != nil {
+		t.Fatalf("GetPRState(studio-sdk): %v", err)
+	}
+	if removedA != nil {
+		t.Error("studio-sdk's PR 74 should be removed from the store")
+	}
+
+	stillThereB, err := store.GetPRState("qf-studio/pilot", 74)
+	if err != nil {
+		t.Fatalf("GetPRState(pilot): %v", err)
+	}
+	if stillThereB == nil {
+		t.Fatal("pilot's PR 74 must survive studio-sdk removing its own colliding PR 74")
+	}
+	if stillThereB.IssueNumber != 72 {
+		t.Errorf("surviving pilot PR 74 issue = %d, want 72", stillThereB.IssueNumber)
+	}
+}
+
+// TestStateStore_PurgeTerminalPRStates_RepoIsolation verifies that a
+// housekeeping purge scoped to one repo never deletes a colliding-numbered
+// terminal row belonging to a different repo.
+func TestStateStore_PurgeTerminalPRStates_RepoIsolation(t *testing.T) {
+	store := newTestStateStore(t)
+
+	failedA := &PRState{PRNumber: 1, BranchName: "pilot/GH-1", Stage: StageFailed, CreatedAt: time.Now()}
+	failedB := &PRState{PRNumber: 1, BranchName: "pilot/GH-1", Stage: StageFailed, CreatedAt: time.Now()}
+	if err := store.SavePRState("qf-studio/studio-sdk", failedA); err != nil {
+		t.Fatalf("SavePRState(studio-sdk): %v", err)
+	}
+	if err := store.SavePRState("qf-studio/pilot", failedB); err != nil {
+		t.Fatalf("SavePRState(pilot): %v", err)
+	}
+
+	purged, err := store.PurgeTerminalPRStates("qf-studio/studio-sdk", 0)
+	if err != nil {
+		t.Fatalf("PurgeTerminalPRStates: %v", err)
+	}
+	if purged != 1 {
+		t.Fatalf("purged = %d, want 1 (only studio-sdk's own row)", purged)
+	}
+
+	remaining, err := store.GetPRState("qf-studio/pilot", 1)
+	if err != nil {
+		t.Fatalf("GetPRState(pilot): %v", err)
+	}
+	if remaining == nil {
+		t.Fatal("pilot's colliding-numbered failed row must survive a studio-sdk-scoped purge")
+	}
+}
+
+// TestStateStore_MigratePRStateRepoScoping verifies that a DB seeded with the
+// pre-GH-3903 schema (pr_number alone as PRIMARY KEY, no repo column) is
+// rebuilt so repo joins the primary key, with repo backfilled from pr_url for
+// autopilot_pr_state and resolved via pr_number for autopilot_pr_failures.
+// Failure rows with no resolvable repo are dropped (ephemeral counters).
+func TestStateStore_MigratePRStateRepoScoping(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	// Seed the pre-fix schema directly, bypassing NewStateStore's migrate().
+	if _, err := db.Exec(`
+		CREATE TABLE autopilot_pr_state (
+			pr_number INTEGER PRIMARY KEY,
+			pr_url TEXT NOT NULL,
+			issue_number INTEGER DEFAULT 0,
+			branch_name TEXT NOT NULL DEFAULT '',
+			head_sha TEXT DEFAULT '',
+			stage TEXT NOT NULL,
+			ci_status TEXT NOT NULL DEFAULT 'pending',
+			last_checked DATETIME,
+			ci_wait_started_at DATETIME,
+			merge_attempts INTEGER DEFAULT 0,
+			error TEXT DEFAULT '',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			release_version TEXT DEFAULT '',
+			release_bump_type TEXT DEFAULT '',
+			merge_notification_posted INTEGER NOT NULL DEFAULT 0,
+			approval_request_id TEXT NOT NULL DEFAULT '',
+			approval_decision TEXT NOT NULL DEFAULT '',
+			approval_requested_at DATETIME,
+			post_merge_sha TEXT NOT NULL DEFAULT '',
+			post_merge_ci_started_at DATETIME,
+			rebase_attempts INTEGER NOT NULL DEFAULT 0
+		)
+	`); err != nil {
+		t.Fatalf("seed legacy autopilot_pr_state: %v", err)
+	}
+	if _, err := db.Exec(`
+		CREATE TABLE autopilot_pr_failures (
+			pr_number INTEGER PRIMARY KEY,
+			failure_count INTEGER NOT NULL DEFAULT 0,
+			last_failure_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)
+	`); err != nil {
+		t.Fatalf("seed legacy autopilot_pr_failures: %v", err)
+	}
+
+	if _, err := db.Exec(`
+		INSERT INTO autopilot_pr_state (pr_number, pr_url, stage, ci_status, created_at)
+		VALUES (74, 'https://github.com/qf-studio/studio-sdk/pull/74', 'merging', 'success', CURRENT_TIMESTAMP)
+	`); err != nil {
+		t.Fatalf("seed legacy pr_state row: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO autopilot_pr_failures (pr_number, failure_count) VALUES (74, 2)`); err != nil {
+		t.Fatalf("seed legacy pr_failures row: %v", err)
+	}
+	// A failure row with no matching pr_state row (unresolvable repo) — must be dropped.
+	if _, err := db.Exec(`INSERT INTO autopilot_pr_failures (pr_number, failure_count) VALUES (999, 1)`); err != nil {
+		t.Fatalf("seed orphan pr_failures row: %v", err)
+	}
+
+	store, err := NewStateStore(db)
+	if err != nil {
+		t.Fatalf("NewStateStore (running migrations) failed: %v", err)
+	}
+
+	// Pre-existing row survives with repo backfilled from pr_url.
+	state, err := store.GetPRState("qf-studio/studio-sdk", 74)
+	if err != nil {
+		t.Fatalf("GetPRState: %v", err)
+	}
+	if state == nil {
+		t.Fatal("pre-existing PR 74 row should survive the repo-scoping migration with backfilled repo")
+	}
+	if state.Stage != StageMerging {
+		t.Errorf("Stage = %s, want %s", state.Stage, StageMerging)
+	}
+
+	// A different repo with the colliding PR number must not see the backfilled row.
+	collision, err := store.GetPRState("qf-studio/pilot", 74)
+	if err != nil {
+		t.Fatalf("GetPRState(qf-studio/pilot, 74): %v", err)
+	}
+	if collision != nil {
+		t.Error("a different repo must not see another repo's backfilled PR 74 row")
+	}
+
+	// The failure row matched to a resolved repo survives, scoped to that repo.
+	failures, err := store.LoadAllPRFailures("qf-studio/studio-sdk")
+	if err != nil {
+		t.Fatalf("LoadAllPRFailures: %v", err)
+	}
+	if failures[74] == nil || failures[74].FailureCount != 2 {
+		t.Errorf("failure state for PR 74 not preserved: %+v", failures)
+	}
+
+	// The unresolvable orphan failure row (pr_number 999) must be dropped entirely.
+	var orphanCount int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM autopilot_pr_failures WHERE pr_number = 999`).Scan(&orphanCount); err != nil {
+		t.Fatalf("count orphan failures: %v", err)
+	}
+	if orphanCount != 0 {
+		t.Errorf("orphan failure row with no resolvable repo should be dropped, found %d", orphanCount)
+	}
+
+	// Re-running migrate() must be a no-op (idempotent).
+	if err := store.migrate(); err != nil {
+		t.Fatalf("second migrate() failed: %v", err)
+	}
+	state, err = store.GetPRState("qf-studio/studio-sdk", 74)
+	if err != nil {
+		t.Fatalf("GetPRState after second migrate: %v", err)
+	}
+	if state == nil {
+		t.Fatal("PR 74 row should still exist after a second, idempotent migrate() run")
+	}
+}
+
+// TestController_ProcessAllPRs_EvictsAfterRepeatedNotFound verifies the
+// 404-eviction guard: a PR that 404s on every fetch (e.g. a stale or foreign
+// state-store row) is dropped from tracking and the persisted store after
+// notFoundEvictionThreshold consecutive failures, WITHOUT ever attempting to
+// delete a remote branch — a 404 means this controller has no verified
+// relationship to the PR, so touching its repo's branches based on nothing
+// but a matching number would repeat the wrong-repo mutation this guard
+// exists to prevent.
+func TestController_ProcessAllPRs_EvictsAfterRepeatedNotFound(t *testing.T) {
+	branchDeleteCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/74" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+		case r.Method == http.MethodDelete:
+			branchDeleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	store := newTestStateStore(t)
+
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+	c.SetStateStore(store)
+	c.OnPRCreated(74, "https://github.com/owner/repo/pull/74", 500, "sha74", "pilot/GH-500", "")
+
+	for i := 0; i < notFoundEvictionThreshold; i++ {
+		c.processAllPRs(context.Background())
+	}
+
+	if _, ok := c.GetPRState(74); ok {
+		t.Error("PR should be evicted from in-memory tracking after repeated 404s")
+	}
+	persisted, err := store.GetPRState("owner/repo", 74)
+	if err != nil {
+		t.Fatalf("GetPRState: %v", err)
+	}
+	if persisted != nil {
+		t.Error("persisted row should be removed after eviction")
+	}
+	if branchDeleteCalled {
+		t.Error("eviction must not attempt remote branch cleanup for an unverified PR")
+	}
+}
+
+// TestController_ProcessAllPRs_NotFoundCountResetsOnSuccess verifies that a
+// PR is NOT evicted while its consecutive-404 count is under threshold, and
+// that a subsequent successful fetch resets the counter to 0.
+func TestController_ProcessAllPRs_NotFoundCountResetsOnSuccess(t *testing.T) {
+	fetchCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/74" && r.Method == http.MethodGet:
+			fetchCount++
+			if fetchCount <= 2 {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+				return
+			}
+			resp := github.PullRequest{
+				Number: 74,
+				State:  "open",
+				Head:   github.PRRef{SHA: "sha74", Ref: "pilot/GH-500"},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.OnPRCreated(74, "https://github.com/owner/repo/pull/74", 500, "sha74", "pilot/GH-500", "")
+
+	c.processAllPRs(context.Background())
+	c.processAllPRs(context.Background())
+
+	pr, ok := c.GetPRState(74)
+	if !ok {
+		t.Fatal("PR should still be tracked after 2 consecutive 404s (below threshold)")
+	}
+	if pr.NotFoundCount != 2 {
+		t.Errorf("NotFoundCount = %d, want 2", pr.NotFoundCount)
+	}
+
+	// Third tick succeeds — counter must reset.
+	c.processAllPRs(context.Background())
+
+	pr, ok = c.GetPRState(74)
+	if !ok {
+		t.Fatal("PR should still be tracked after recovering")
+	}
+	if pr.NotFoundCount != 0 {
+		t.Errorf("NotFoundCount after a successful fetch = %d, want 0", pr.NotFoundCount)
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -102,6 +103,11 @@ func (s *StateStore) migrate() error {
 		// rebases (conflict -> rebase-success -> CI -> conflict oscillation)
 		// survives daemon restarts.
 		`ALTER TABLE autopilot_pr_state ADD COLUMN rebase_attempts INTEGER NOT NULL DEFAULT 0`,
+		// GH-3903: Add repo ahead of the primary-key rebuild in
+		// migratePRStateRepoScoping below — pr_number alone is not unique when
+		// multiple project-scoped controllers share one SQLite DB.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN repo TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE autopilot_pr_failures ADD COLUMN repo TEXT NOT NULL DEFAULT ''`,
 	}
 
 	for _, m := range migrations {
@@ -137,6 +143,13 @@ func (s *StateStore) migrate() error {
 	// can never be matched again and would otherwise sit as dead weight.
 	if err := s.pruneOrphanedEmptyRepoRows(); err != nil {
 		return fmt.Errorf("adapter_processed empty-repo cleanup failed: %w", err)
+	}
+
+	// GH-3903: rebuild autopilot_pr_state/autopilot_pr_failures so repo joins
+	// the primary key, fixing cross-repo pr_number collisions between
+	// project-scoped controllers sharing one SQLite DB.
+	if err := s.migratePRStateRepoScoping(); err != nil {
+		return fmt.Errorf("autopilot_pr_state repo-scoping migration failed: %w", err)
 	}
 
 	return nil
@@ -212,6 +225,203 @@ func (s *StateStore) migrateAdapterProcessedPrimaryKey() error {
 	if _, err := tx.Exec(`ALTER TABLE adapter_processed_gh3819 RENAME TO adapter_processed`); err != nil {
 		return fmt.Errorf("rename adapter_processed_gh3819: %w", err)
 	}
+	return tx.Commit()
+}
+
+// prURLRepoRe extracts "owner/repo" from a GitHub PR URL of the form
+// "https://github.com/{owner}/{repo}/pull/{n}".
+var prURLRepoRe = regexp.MustCompile(`^https://github\.com/([^/]+)/([^/]+)/pull/\d+$`)
+
+// repoFromPRURL extracts "owner/repo" from a GitHub PR URL, or "" if prURL
+// doesn't match the expected shape (empty/malformed legacy row).
+func repoFromPRURL(prURL string) string {
+	m := prURLRepoRe.FindStringSubmatch(prURL)
+	if m == nil {
+		return ""
+	}
+	return m[1] + "/" + m[2]
+}
+
+// tableHasColumnInPK reports whether column is part of table's PRIMARY KEY,
+// per PRAGMA table_info. Used to make a PK-rebuild migration idempotent: skip
+// it on every startup after the first successful run (or on a fresh install
+// where the table is already created with the column in its key).
+func (s *StateStore) tableHasColumnInPK(table, column string) (bool, error) {
+	rows, err := s.db.Query(`PRAGMA table_info(` + table + `)`)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, ctype string
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notNull, &dflt, &pk); err != nil {
+			return false, err
+		}
+		if name == column && pk > 0 {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+// migratePRStateRepoScoping rebuilds autopilot_pr_state and
+// autopilot_pr_failures so repo is part of the primary key, fixing GH-3903:
+// with pr_number alone as the key, every project-scoped controller sharing
+// one SQLite DB restores and processes every other controller's rows too — a
+// PR closed in one repo could apply labels, close issues, and delete branches
+// in a completely unrelated repo that merely happens to have a PR with the
+// same number.
+//
+// repo is backfilled for existing autopilot_pr_state rows by parsing pr_url.
+// autopilot_pr_failures has no URL of its own; its rows are matched to their
+// PR's resolved repo via pr_number, and dropped if no match is found — these
+// are ephemeral retry counters, safe to lose (a real failure recurs and
+// re-persists on the very next tick).
+//
+// No-op if repo is already part of the primary key (fresh install, or a
+// prior run already migrated this DB).
+func (s *StateStore) migratePRStateRepoScoping() error {
+	already, err := s.tableHasColumnInPK("autopilot_pr_state", "repo")
+	if err != nil {
+		return fmt.Errorf("inspect autopilot_pr_state schema: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Backfill repo for pr_state rows that don't have one yet, parsed from pr_url.
+	rows, err := tx.Query(`SELECT pr_number, pr_url FROM autopilot_pr_state WHERE repo = ''`)
+	if err != nil {
+		return fmt.Errorf("query autopilot_pr_state for backfill: %w", err)
+	}
+	type prRepoPair struct {
+		prNumber int
+		repo     string
+	}
+	var backfill []prRepoPair
+	for rows.Next() {
+		var prNumber int
+		var prURL string
+		if err := rows.Scan(&prNumber, &prURL); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan autopilot_pr_state row: %w", err)
+		}
+		if repo := repoFromPRURL(prURL); repo != "" {
+			backfill = append(backfill, prRepoPair{prNumber, repo})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate autopilot_pr_state rows: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close autopilot_pr_state rows: %w", err)
+	}
+	for _, pair := range backfill {
+		if _, err := tx.Exec(
+			`UPDATE autopilot_pr_state SET repo = ? WHERE pr_number = ? AND repo = ''`,
+			pair.repo, pair.prNumber,
+		); err != nil {
+			return fmt.Errorf("backfill repo for pr %d: %w", pair.prNumber, err)
+		}
+	}
+
+	// Rebuild autopilot_pr_state with repo in the primary key.
+	if _, err := tx.Exec(`
+		CREATE TABLE autopilot_pr_state_gh3903 (
+			pr_number INTEGER NOT NULL,
+			repo TEXT NOT NULL DEFAULT '',
+			pr_url TEXT NOT NULL,
+			issue_number INTEGER DEFAULT 0,
+			branch_name TEXT NOT NULL DEFAULT '',
+			head_sha TEXT DEFAULT '',
+			stage TEXT NOT NULL,
+			ci_status TEXT NOT NULL DEFAULT 'pending',
+			last_checked DATETIME,
+			ci_wait_started_at DATETIME,
+			merge_attempts INTEGER DEFAULT 0,
+			error TEXT DEFAULT '',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			release_version TEXT DEFAULT '',
+			release_bump_type TEXT DEFAULT '',
+			merge_notification_posted INTEGER NOT NULL DEFAULT 0,
+			approval_request_id TEXT NOT NULL DEFAULT '',
+			approval_decision TEXT NOT NULL DEFAULT '',
+			approval_requested_at DATETIME,
+			post_merge_sha TEXT NOT NULL DEFAULT '',
+			post_merge_ci_started_at DATETIME,
+			rebase_attempts INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (repo, pr_number)
+		)
+	`); err != nil {
+		return fmt.Errorf("create autopilot_pr_state_gh3903: %w", err)
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO autopilot_pr_state_gh3903 (
+			pr_number, repo, pr_url, issue_number, branch_name, head_sha,
+			stage, ci_status, last_checked, ci_wait_started_at,
+			merge_attempts, error, created_at, updated_at,
+			release_version, release_bump_type, merge_notification_posted,
+			approval_request_id, approval_decision, approval_requested_at,
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts
+		)
+		SELECT
+			pr_number, repo, pr_url, issue_number, branch_name, head_sha,
+			stage, ci_status, last_checked, ci_wait_started_at,
+			merge_attempts, error, created_at, updated_at,
+			release_version, release_bump_type, merge_notification_posted,
+			approval_request_id, approval_decision, approval_requested_at,
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts
+		FROM autopilot_pr_state
+	`); err != nil {
+		return fmt.Errorf("copy autopilot_pr_state rows: %w", err)
+	}
+	if _, err := tx.Exec(`DROP TABLE autopilot_pr_state`); err != nil {
+		return fmt.Errorf("drop old autopilot_pr_state: %w", err)
+	}
+	if _, err := tx.Exec(`ALTER TABLE autopilot_pr_state_gh3903 RENAME TO autopilot_pr_state`); err != nil {
+		return fmt.Errorf("rename autopilot_pr_state_gh3903: %w", err)
+	}
+
+	// Rebuild autopilot_pr_failures, matching each row to its PR's resolved
+	// repo via pr_number (against the now-scoped autopilot_pr_state above).
+	// Rows that cannot be matched to any repo are dropped.
+	if _, err := tx.Exec(`
+		CREATE TABLE autopilot_pr_failures_gh3903 (
+			pr_number INTEGER NOT NULL,
+			repo TEXT NOT NULL DEFAULT '',
+			failure_count INTEGER NOT NULL DEFAULT 0,
+			last_failure_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (repo, pr_number)
+		)
+	`); err != nil {
+		return fmt.Errorf("create autopilot_pr_failures_gh3903: %w", err)
+	}
+	if _, err := tx.Exec(`
+		INSERT OR IGNORE INTO autopilot_pr_failures_gh3903 (pr_number, repo, failure_count, last_failure_time)
+		SELECT f.pr_number, s.repo, f.failure_count, f.last_failure_time
+		FROM autopilot_pr_failures f
+		JOIN autopilot_pr_state s ON s.pr_number = f.pr_number
+		WHERE s.repo != ''
+	`); err != nil {
+		return fmt.Errorf("copy autopilot_pr_failures rows: %w", err)
+	}
+	if _, err := tx.Exec(`DROP TABLE autopilot_pr_failures`); err != nil {
+		return fmt.Errorf("drop old autopilot_pr_failures: %w", err)
+	}
+	if _, err := tx.Exec(`ALTER TABLE autopilot_pr_failures_gh3903 RENAME TO autopilot_pr_failures`); err != nil {
+		return fmt.Errorf("rename autopilot_pr_failures_gh3903: %w", err)
+	}
+
 	return tx.Commit()
 }
 
@@ -301,18 +511,21 @@ func (s *StateStore) migrateLegacyProcessedTables() error {
 	return tx.Commit()
 }
 
-// SavePRState persists a PR state to the database (upsert).
-func (s *StateStore) SavePRState(pr *PRState) error {
+// SavePRState persists a PR state to the database (upsert), scoped to repo
+// ("owner/repo"). GH-3903: repo is part of the primary key alongside
+// pr_number so project-scoped controllers sharing one SQLite DB cannot
+// collide on the same PR number from different repos.
+func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 	_, err := s.db.Exec(`
 		INSERT INTO autopilot_pr_state (
-			pr_number, pr_url, issue_number, branch_name, head_sha,
+			pr_number, repo, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
 			merge_attempts, error, created_at, updated_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(pr_number) DO UPDATE SET
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(repo, pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
 			branch_name = excluded.branch_name,
@@ -334,7 +547,7 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 			post_merge_ci_started_at = excluded.post_merge_ci_started_at,
 			rebase_attempts = excluded.rebase_attempts
 	`,
-		pr.PRNumber, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
+		pr.PRNumber, repo, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
 		nullTime(pr.LastChecked), nullTime(pr.CIWaitStartedAt),
 		pr.MergeAttempts, pr.Error, nullTime(pr.CreatedAt),
@@ -345,9 +558,9 @@ func (s *StateStore) SavePRState(pr *PRState) error {
 	return err
 }
 
-// GetPRState retrieves a single PR state by number.
+// GetPRState retrieves a single PR state by repo and number.
 // Returns nil, nil if not found.
-func (s *StateStore) GetPRState(prNumber int) (*PRState, error) {
+func (s *StateStore) GetPRState(repo string, prNumber int) (*PRState, error) {
 	row := s.db.QueryRow(`
 		SELECT pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
@@ -355,8 +568,8 @@ func (s *StateStore) GetPRState(prNumber int) (*PRState, error) {
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts
-		FROM autopilot_pr_state WHERE pr_number = ?
-	`, prNumber)
+		FROM autopilot_pr_state WHERE repo = ? AND pr_number = ?
+	`, repo, prNumber)
 
 	pr, err := scanPRState(row)
 	if err == sql.ErrNoRows {
@@ -368,8 +581,9 @@ func (s *StateStore) GetPRState(prNumber int) (*PRState, error) {
 	return pr, nil
 }
 
-// LoadAllPRStates retrieves all persisted PR states.
-func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
+// LoadAllPRStates retrieves all persisted PR states for the given repo.
+// GH-3903: scoped so one controller can never restore another repo's rows.
+func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 	rows, err := s.db.Query(`
 		SELECT pr_number, pr_url, issue_number, branch_name, head_sha,
 			stage, ci_status, last_checked, ci_wait_started_at,
@@ -377,8 +591,8 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts
-		FROM autopilot_pr_state
-	`)
+		FROM autopilot_pr_state WHERE repo = ?
+	`, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -424,9 +638,9 @@ func (s *StateStore) LoadAllPRStates() ([]*PRState, error) {
 	return states, nil
 }
 
-// RemovePRState deletes a PR state record.
-func (s *StateStore) RemovePRState(prNumber int) error {
-	_, err := s.db.Exec(`DELETE FROM autopilot_pr_state WHERE pr_number = ?`, prNumber)
+// RemovePRState deletes a PR state record, scoped to repo.
+func (s *StateStore) RemovePRState(repo string, prNumber int) error {
+	_, err := s.db.Exec(`DELETE FROM autopilot_pr_state WHERE repo = ? AND pr_number = ?`, repo, prNumber)
 	return err
 }
 
@@ -525,30 +739,30 @@ func (s *StateStore) GetMetadata(key string) (string, error) {
 	return value, err
 }
 
-// SavePRFailures persists the per-PR failure state.
-func (s *StateStore) SavePRFailures(prNumber, failureCount int, lastFailureTime time.Time) error {
+// SavePRFailures persists the per-PR failure state, scoped to repo.
+func (s *StateStore) SavePRFailures(repo string, prNumber, failureCount int, lastFailureTime time.Time) error {
 	_, err := s.db.Exec(`
-		INSERT INTO autopilot_pr_failures (pr_number, failure_count, last_failure_time)
-		VALUES (?, ?, ?)
-		ON CONFLICT(pr_number) DO UPDATE SET
+		INSERT INTO autopilot_pr_failures (pr_number, repo, failure_count, last_failure_time)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(repo, pr_number) DO UPDATE SET
 			failure_count = excluded.failure_count,
 			last_failure_time = excluded.last_failure_time
-	`, prNumber, failureCount, lastFailureTime)
+	`, prNumber, repo, failureCount, lastFailureTime)
 	return err
 }
 
-// RemovePRFailures removes per-PR failure state.
-func (s *StateStore) RemovePRFailures(prNumber int) error {
-	_, err := s.db.Exec(`DELETE FROM autopilot_pr_failures WHERE pr_number = ?`, prNumber)
+// RemovePRFailures removes per-PR failure state, scoped to repo.
+func (s *StateStore) RemovePRFailures(repo string, prNumber int) error {
+	_, err := s.db.Exec(`DELETE FROM autopilot_pr_failures WHERE repo = ? AND pr_number = ?`, repo, prNumber)
 	return err
 }
 
-// LoadAllPRFailures loads all per-PR failure states.
-func (s *StateStore) LoadAllPRFailures() (map[int]*prFailureState, error) {
+// LoadAllPRFailures loads all per-PR failure states for the given repo.
+func (s *StateStore) LoadAllPRFailures(repo string) (map[int]*prFailureState, error) {
 	rows, err := s.db.Query(`
 		SELECT pr_number, failure_count, last_failure_time
-		FROM autopilot_pr_failures
-	`)
+		FROM autopilot_pr_failures WHERE repo = ?
+	`, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -578,22 +792,27 @@ func (s *StateStore) LoadAllPRFailures() (map[int]*prFailureState, error) {
 // gate (B3, PersistedReleasingAge) so both agree on what "stale" means.
 const releasingStaleThreshold = 30 * time.Minute
 
-// PurgeTerminalPRStates removes housekeeping-eligible PR state rows: terminal
-// 'failed' rows older than olderThan, plus 'releasing' rows untouched for longer
-// than releasingStaleThreshold. A 'releasing' row is not strictly terminal, but
-// one stuck past the threshold is a wedged release (B4/TASK-309) — purging it is a
-// safety net so the row cannot live forever and suppress re-discovery by
-// ScanRecentlyMergedPRs. Active PRs (fresh rows, other stages) are never purged.
-func (s *StateStore) PurgeTerminalPRStates(olderThan time.Duration) (int64, error) {
+// PurgeTerminalPRStates removes housekeeping-eligible PR state rows for the
+// given repo: terminal 'failed' rows older than olderThan, plus 'releasing'
+// rows untouched for longer than releasingStaleThreshold. A 'releasing' row
+// is not strictly terminal, but one stuck past the threshold is a wedged
+// release (B4/TASK-309) — purging it is a safety net so the row cannot live
+// forever and suppress re-discovery by ScanRecentlyMergedPRs. Active PRs
+// (fresh rows, other stages) are never purged. GH-3903: scoped by repo so a
+// housekeeping purge from one controller can never delete another repo's
+// terminal rows.
+func (s *StateStore) PurgeTerminalPRStates(repo string, olderThan time.Duration) (int64, error) {
 	// updated_at is written as CURRENT_TIMESTAMP (SQLite UTC), so the cutoffs must
 	// be evaluated against SQLite's own UTC clock — binding a Go (local) time.Time
 	// here mis-compares by the host's tz offset. <= keeps the olderThan=0 degenerate
 	// case ("purge all terminal rows now") reaping same-second rows.
 	result, err := s.db.Exec(`
 		DELETE FROM autopilot_pr_state
-		WHERE (stage = 'failed'    AND updated_at <= datetime('now', ?))
-		   OR (stage = 'releasing' AND updated_at <= datetime('now', ?))
+		WHERE repo = ?
+		  AND ((stage = 'failed'    AND updated_at <= datetime('now', ?))
+		   OR  (stage = 'releasing' AND updated_at <= datetime('now', ?)))
 	`,
+		repo,
 		fmt.Sprintf("-%d seconds", int64(olderThan.Seconds())),
 		fmt.Sprintf("-%d seconds", int64(releasingStaleThreshold.Seconds())),
 	)
@@ -604,16 +823,18 @@ func (s *StateStore) PurgeTerminalPRStates(olderThan time.Duration) (int64, erro
 }
 
 // PersistedReleasingAge reports the age (time since last update) of a persisted PR
-// row at stage='releasing'. found is false when no row exists for prNumber or the
-// row is in a different stage. The scanner uses this (B3/TASK-309) to skip
-// re-registering a release that is already in flight in the state store but absent
-// from the in-memory activePRs map (e.g. after a daemon restart), without relying
-// on the in-memory map alone. Returning the age (rather than a bool) lets the
-// caller ignore genuinely wedged rows so they can be re-driven.
-func (s *StateStore) PersistedReleasingAge(prNumber int) (age time.Duration, found bool, err error) {
+// row at stage='releasing', scoped to repo. found is false when no row exists for
+// repo/prNumber or the row is in a different stage. The scanner uses this
+// (B3/TASK-309) to skip re-registering a release that is already in flight in the
+// state store but absent from the in-memory activePRs map (e.g. after a daemon
+// restart), without relying on the in-memory map alone. Returning the age (rather
+// than a bool) lets the caller ignore genuinely wedged rows so they can be
+// re-driven. GH-3903: scoped by repo so one controller can never read another
+// repo's colliding pr_number and wrongly skip (or fail to skip) a release.
+func (s *StateStore) PersistedReleasingAge(repo string, prNumber int) (age time.Duration, found bool, err error) {
 	var stage string
 	var updatedAt sql.NullTime
-	row := s.db.QueryRow(`SELECT stage, updated_at FROM autopilot_pr_state WHERE pr_number = ?`, prNumber)
+	row := s.db.QueryRow(`SELECT stage, updated_at FROM autopilot_pr_state WHERE repo = ? AND pr_number = ?`, repo, prNumber)
 	if scanErr := row.Scan(&stage, &updatedAt); scanErr != nil {
 		if errors.Is(scanErr, sql.ErrNoRows) {
 			return 0, false, nil

--- a/internal/autopilot/state_store_test.go
+++ b/internal/autopilot/state_store_test.go
@@ -45,12 +45,12 @@ func TestStateStore_SaveAndLoadPRState(t *testing.T) {
 	}
 
 	// Save
-	if err := store.SavePRState(pr); err != nil {
+	if err := store.SavePRState("owner/repo", pr); err != nil {
 		t.Fatalf("SavePRState failed: %v", err)
 	}
 
 	// Load single
-	loaded, err := store.GetPRState(42)
+	loaded, err := store.GetPRState("owner/repo", 42)
 	if err != nil {
 		t.Fatalf("GetPRState failed: %v", err)
 	}
@@ -97,12 +97,12 @@ func TestStateStore_LoadAllPRStates(t *testing.T) {
 			CIStatus:   CIPending,
 			CreatedAt:  time.Now(),
 		}
-		if err := store.SavePRState(pr); err != nil {
+		if err := store.SavePRState("owner/repo", pr); err != nil {
 			t.Fatalf("SavePRState(%d) failed: %v", num, err)
 		}
 	}
 
-	states, err := store.LoadAllPRStates()
+	states, err := store.LoadAllPRStates("owner/repo")
 	if err != nil {
 		t.Fatalf("LoadAllPRStates failed: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestStateStore_UpdatePRState(t *testing.T) {
 		CreatedAt:  time.Now(),
 	}
 
-	if err := store.SavePRState(pr); err != nil {
+	if err := store.SavePRState("owner/repo", pr); err != nil {
 		t.Fatalf("initial SavePRState failed: %v", err)
 	}
 
@@ -131,11 +131,11 @@ func TestStateStore_UpdatePRState(t *testing.T) {
 	pr.Stage = StageWaitingCI
 	pr.CIStatus = CIRunning
 	pr.CIWaitStartedAt = time.Now()
-	if err := store.SavePRState(pr); err != nil {
+	if err := store.SavePRState("owner/repo", pr); err != nil {
 		t.Fatalf("update SavePRState failed: %v", err)
 	}
 
-	loaded, err := store.GetPRState(42)
+	loaded, err := store.GetPRState("owner/repo", 42)
 	if err != nil {
 		t.Fatalf("GetPRState failed: %v", err)
 	}
@@ -159,15 +159,15 @@ func TestStateStore_RemovePRState(t *testing.T) {
 		CreatedAt:  time.Now(),
 	}
 
-	if err := store.SavePRState(pr); err != nil {
+	if err := store.SavePRState("owner/repo", pr); err != nil {
 		t.Fatalf("SavePRState failed: %v", err)
 	}
 
-	if err := store.RemovePRState(42); err != nil {
+	if err := store.RemovePRState("owner/repo", 42); err != nil {
 		t.Fatalf("RemovePRState failed: %v", err)
 	}
 
-	loaded, err := store.GetPRState(42)
+	loaded, err := store.GetPRState("owner/repo", 42)
 	if err != nil {
 		t.Fatalf("GetPRState failed: %v", err)
 	}
@@ -319,15 +319,15 @@ func TestStateStore_PurgeTerminalPRStates(t *testing.T) {
 		CreatedAt:  time.Now(),
 	}
 
-	if err := store.SavePRState(failedPR); err != nil {
+	if err := store.SavePRState("owner/repo", failedPR); err != nil {
 		t.Fatalf("SavePRState(failed) failed: %v", err)
 	}
-	if err := store.SavePRState(activePR); err != nil {
+	if err := store.SavePRState("owner/repo", activePR); err != nil {
 		t.Fatalf("SavePRState(active) failed: %v", err)
 	}
 
 	// Purge terminal states older than 0 (immediate)
-	purged, err := store.PurgeTerminalPRStates(0)
+	purged, err := store.PurgeTerminalPRStates("owner/repo", 0)
 	if err != nil {
 		t.Fatalf("PurgeTerminalPRStates failed: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestStateStore_PurgeTerminalPRStates(t *testing.T) {
 	}
 
 	// Active PR should still exist
-	states, _ := store.LoadAllPRStates()
+	states, _ := store.LoadAllPRStates("owner/repo")
 	if len(states) != 1 {
 		t.Fatalf("got %d states, want 1", len(states))
 	}
@@ -363,7 +363,7 @@ func TestStateStore_PurgeTerminalPRStates_Releasing(t *testing.T) {
 		CreatedAt:  time.Now(),
 	}
 	for _, pr := range []*PRState{freshReleasing, staleReleasing} {
-		if err := store.SavePRState(pr); err != nil {
+		if err := store.SavePRState("owner/repo", pr); err != nil {
 			t.Fatalf("SavePRState(%d): %v", pr.PRNumber, err)
 		}
 	}
@@ -376,7 +376,7 @@ func TestStateStore_PurgeTerminalPRStates_Releasing(t *testing.T) {
 
 	// A large olderThan keeps any 'failed' row out of scope, so the only eligible
 	// row is the stale 'releasing' one (reaped on its own 30-min threshold).
-	purged, err := store.PurgeTerminalPRStates(24 * time.Hour)
+	purged, err := store.PurgeTerminalPRStates("owner/repo", 24*time.Hour)
 	if err != nil {
 		t.Fatalf("PurgeTerminalPRStates: %v", err)
 	}
@@ -384,7 +384,7 @@ func TestStateStore_PurgeTerminalPRStates_Releasing(t *testing.T) {
 		t.Errorf("purged = %d, want 1 (only the stale releasing row)", purged)
 	}
 
-	states, _ := store.LoadAllPRStates()
+	states, _ := store.LoadAllPRStates("owner/repo")
 	if len(states) != 1 || states[0].PRNumber != 1 {
 		t.Errorf("remaining states = %+v, want only the fresh releasing PR 1", states)
 	}
@@ -396,23 +396,23 @@ func TestStateStore_PersistedReleasingAge(t *testing.T) {
 	store := newTestStateStore(t)
 
 	// (a) no row → not found.
-	if _, found, err := store.PersistedReleasingAge(99); err != nil || found {
+	if _, found, err := store.PersistedReleasingAge("owner/repo", 99); err != nil || found {
 		t.Errorf("missing row: got found=%v err=%v, want found=false err=nil", found, err)
 	}
 
 	// (b) non-releasing stage → not found.
-	if err := store.SavePRState(&PRState{PRNumber: 10, BranchName: "pilot/GH-10", Stage: StageWaitingCI, CreatedAt: time.Now()}); err != nil {
+	if err := store.SavePRState("owner/repo", &PRState{PRNumber: 10, BranchName: "pilot/GH-10", Stage: StageWaitingCI, CreatedAt: time.Now()}); err != nil {
 		t.Fatalf("SavePRState(waiting): %v", err)
 	}
-	if _, found, err := store.PersistedReleasingAge(10); err != nil || found {
+	if _, found, err := store.PersistedReleasingAge("owner/repo", 10); err != nil || found {
 		t.Errorf("non-releasing row: got found=%v err=%v, want found=false", found, err)
 	}
 
 	// (c) fresh releasing row → found, age below threshold.
-	if err := store.SavePRState(&PRState{PRNumber: 20, BranchName: "pilot/GH-20", Stage: StageReleasing, CreatedAt: time.Now()}); err != nil {
+	if err := store.SavePRState("owner/repo", &PRState{PRNumber: 20, BranchName: "pilot/GH-20", Stage: StageReleasing, CreatedAt: time.Now()}); err != nil {
 		t.Fatalf("SavePRState(releasing): %v", err)
 	}
-	age, found, err := store.PersistedReleasingAge(20)
+	age, found, err := store.PersistedReleasingAge("owner/repo", 20)
 	if err != nil || !found {
 		t.Fatalf("fresh releasing: got found=%v err=%v, want found=true", found, err)
 	}
@@ -426,7 +426,7 @@ func TestStateStore_PersistedReleasingAge(t *testing.T) {
 	); err != nil {
 		t.Fatalf("backdate: %v", err)
 	}
-	age, found, err = store.PersistedReleasingAge(20)
+	age, found, err = store.PersistedReleasingAge("owner/repo", 20)
 	if err != nil || !found {
 		t.Fatalf("stale releasing: got found=%v err=%v, want found=true", found, err)
 	}
@@ -471,7 +471,7 @@ func TestController_RestoreState(t *testing.T) {
 	}
 
 	for _, pr := range []*PRState{pr1, pr2, pr3} {
-		if err := store.SavePRState(pr); err != nil {
+		if err := store.SavePRState("owner/repo", pr); err != nil {
 			t.Fatalf("SavePRState(%d) failed: %v", pr.PRNumber, err)
 		}
 	}
@@ -535,7 +535,7 @@ func TestController_OnPRCreated_PersistsToStore(t *testing.T) {
 	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", "")
 
 	// Verify persisted to store
-	loaded, err := store.GetPRState(42)
+	loaded, err := store.GetPRState("owner/repo", 42)
 	if err != nil {
 		t.Fatalf("GetPRState failed: %v", err)
 	}
@@ -560,7 +560,7 @@ func TestController_RemovePR_RemovesFromStore(t *testing.T) {
 	c.removePR(42)
 
 	// Verify removed from store
-	loaded, err := store.GetPRState(42)
+	loaded, err := store.GetPRState("owner/repo", 42)
 	if err != nil {
 		t.Fatalf("GetPRState failed: %v", err)
 	}
@@ -595,7 +595,7 @@ func TestController_ProcessPR_PersistsTransition(t *testing.T) {
 	}
 
 	// Verify state persisted with new stage
-	loaded, err := store.GetPRState(42)
+	loaded, err := store.GetPRState("owner/repo", 42)
 	if err != nil {
 		t.Fatalf("GetPRState failed: %v", err)
 	}
@@ -622,12 +622,12 @@ func TestStateStore_PRFailures(t *testing.T) {
 
 	// Save failure state
 	failureTime := time.Now().Truncate(time.Second)
-	if err := store.SavePRFailures(42, 3, failureTime); err != nil {
+	if err := store.SavePRFailures("owner/repo", 42, 3, failureTime); err != nil {
 		t.Fatalf("SavePRFailures failed: %v", err)
 	}
 
 	// Load and verify
-	failures, err := store.LoadAllPRFailures()
+	failures, err := store.LoadAllPRFailures("owner/repo")
 	if err != nil {
 		t.Fatalf("LoadAllPRFailures failed: %v", err)
 	}
@@ -642,19 +642,19 @@ func TestStateStore_PRFailures(t *testing.T) {
 	}
 
 	// Update failure state
-	if err := store.SavePRFailures(42, 5, time.Now()); err != nil {
+	if err := store.SavePRFailures("owner/repo", 42, 5, time.Now()); err != nil {
 		t.Fatalf("SavePRFailures update failed: %v", err)
 	}
-	failures, _ = store.LoadAllPRFailures()
+	failures, _ = store.LoadAllPRFailures("owner/repo")
 	if failures[42].FailureCount != 5 {
 		t.Errorf("FailureCount after update = %d, want 5", failures[42].FailureCount)
 	}
 
 	// Remove failure state
-	if err := store.RemovePRFailures(42); err != nil {
+	if err := store.RemovePRFailures("owner/repo", 42); err != nil {
 		t.Fatalf("RemovePRFailures failed: %v", err)
 	}
-	failures, _ = store.LoadAllPRFailures()
+	failures, _ = store.LoadAllPRFailures("owner/repo")
 	if len(failures) != 0 {
 		t.Errorf("got %d failures after remove, want 0", len(failures))
 	}
@@ -673,10 +673,10 @@ func TestController_RestoreState_LoadsPRFailures(t *testing.T) {
 		CIStatus:   CIRunning,
 		CreatedAt:  time.Now(),
 	}
-	if err := store.SavePRState(pr); err != nil {
+	if err := store.SavePRState("owner/repo", pr); err != nil {
 		t.Fatalf("SavePRState failed: %v", err)
 	}
-	if err := store.SavePRFailures(42, 2, time.Now()); err != nil {
+	if err := store.SavePRFailures("owner/repo", 42, 2, time.Now()); err != nil {
 		t.Fatalf("SavePRFailures failed: %v", err)
 	}
 
@@ -712,7 +712,7 @@ func TestController_RemovePR_RemovesFailures(t *testing.T) {
 	c.persistPRFailures(42, c.prFailures[42])
 
 	// Verify failure state persisted
-	failures, _ := store.LoadAllPRFailures()
+	failures, _ := store.LoadAllPRFailures("owner/repo")
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure record, got %d", len(failures))
 	}
@@ -721,7 +721,7 @@ func TestController_RemovePR_RemovesFailures(t *testing.T) {
 	c.removePR(42)
 
 	// Verify failure state also removed
-	failures, _ = store.LoadAllPRFailures()
+	failures, _ = store.LoadAllPRFailures("owner/repo")
 	if len(failures) != 0 {
 		t.Errorf("expected 0 failure records after removePR, got %d", len(failures))
 	}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -517,6 +517,12 @@ type PRState struct {
 	DiscoveredChecks []string
 	// ConsecutiveAPIFailures counts consecutive CI check API failures.
 	ConsecutiveAPIFailures int
+	// NotFoundCount tracks consecutive 404s fetching this PR from c.owner/c.repo
+	// in processAllPRs. In-memory only (not persisted): a foreign or stale row
+	// should evict quickly regardless of restart cadence, and a restart resets
+	// the counter anyway, giving a freshly-restored row a few more tries before
+	// eviction (GH-3903 404-eviction guard).
+	NotFoundCount int
 	// EnvironmentName is the user-friendly environment label (e.g. "staging").
 	EnvironmentName string
 	// PRTitle is the title of the pull request.
@@ -587,6 +593,7 @@ func (ps *PRState) snapshot() *PRState {
 		ReleaseVersion:          ps.ReleaseVersion,
 		ReleaseBumpType:         ps.ReleaseBumpType,
 		ConsecutiveAPIFailures:  ps.ConsecutiveAPIFailures,
+		NotFoundCount:           ps.NotFoundCount,
 		EnvironmentName:         ps.EnvironmentName,
 		PRTitle:                 ps.PRTitle,
 		TargetBranch:            ps.TargetBranch,


### PR DESCRIPTION
## Summary

- Fixes GH-3903: `autopilot_pr_state`/`autopilot_pr_failures` keyed rows on `pr_number` alone. With one project-scoped `Controller` per `projects:` repo sharing a single SQLite DB, every controller restored (and could act on) every other repo's rows whenever PR numbers collided — applying labels, closing issues, and deleting branches in the wrong repo (observed 2026-07-06: pilot's controller mutated issues/branches belonging to a colliding studio-sdk PR number after a restart).
- Adds `repo` to the primary key of both tables via an idempotent migration that backfills `repo` from `pr_url` for `autopilot_pr_state`, and resolves it for `autopilot_pr_failures` by joining on the now-scoped `pr_state` via `pr_number` (dropping unresolvable rows — ephemeral retry counters).
- Scopes every relevant `StateStore` CRUD method (`SavePRState`, `GetPRState`, `LoadAllPRStates`, `RemovePRState`, `SavePRFailures`, `RemovePRFailures`, `LoadAllPRFailures`, `PersistedReleasingAge`, `PurgeTerminalPRStates`) by an explicit `repo` parameter; `Controller` threads its own `owner/repo` through via a new `repoKey()` helper.
- Adds a bounded 404-eviction guard in `processAllPRs`: a PR that 404s 5 consecutive ticks (stale/foreign row, or any future collision) is dropped from tracking and the store — without ever touching remote branch state, since a 404 means this controller has no verified relationship to that PR/repo.

This is a single, non-decomposed PR per the attempt-1 postmortem in the issue (a prior decomposed attempt hung the `stress` suite).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` → 0 issues
- [x] `go test ./internal/autopilot/... -race` → pass
- [x] `go test ./stress/ -timeout 10m` → pass (~7s, no hang)
- [x] `go test ./...` (full suite, 47 packages) → all pass
- [x] New tests: two-controller restore/persist isolation on a colliding `pr_number`, migration backfill + collision isolation + orphan-failure drop, `PurgeTerminalPRStates` repo isolation, 404-eviction (with an assertion that branch delete is never called), and not-found-count reset-on-success.