### PR TITLE
feat(config): add per-project release overlay and publish-enum validation

### DIFF
--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -365,6 +365,25 @@ type ReleaseConfig struct {
 	RequireCI bool `yaml:"require_ci"`
 	// GenerateSummary enables LLM-generated release summary prepended to GoReleaser changelog.
 	GenerateSummary bool `yaml:"generate_summary"`
+	// Publish selects how releases are published: "workflow" (default — GoReleaser
+	// via CI creates the GitHub Release), "api" (Pilot calls the GitHub Releases
+	// API directly), or "tag_only" (push the tag, publish nothing). Empty
+	// behaves like "workflow". See internal/config Config.Validate for the
+	// enum check (GH-3930).
+	Publish string `yaml:"publish,omitempty"`
+}
+
+// ProjectReleaseConfig overlays release settings for a single project on top
+// of the global and per-environment ReleaseConfig blocks. Unset fields
+// inherit the base value — e.g. a project may override Publish while leaving
+// Enabled nil to inherit the global setting. See internal/config
+// ProjectConfig.Release (GH-3930); overlay resolution (Apply/PublishMode) and
+// controller wiring land in GH-3929/GH-3931.
+type ProjectReleaseConfig struct {
+	// Enabled overrides ReleaseConfig.Enabled for this project. Nil inherits.
+	Enabled *bool `yaml:"enabled,omitempty"`
+	// Publish overrides ReleaseConfig.Publish for this project. Empty inherits.
+	Publish string `yaml:"publish,omitempty"`
 }
 
 // DefaultReleaseConfig returns sensible defaults for release configuration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -247,6 +247,11 @@ type ProjectConfig struct {
 	// pnpm/yarn/bun or other non-Go project define its own build/test/lint
 	// gates instead of inheriting commands tuned for a different stack.
 	Quality *quality.Config `yaml:"quality,omitempty"`
+	// Release overlays the global/environment release publish mode for this
+	// project (GH-3930). Unset fields inherit from
+	// Config.Orchestrator.Autopilot's global and per-environment release
+	// blocks.
+	Release *autopilot.ProjectReleaseConfig `yaml:"release,omitempty"`
 }
 
 // ResolveBaseBranch returns the branch that Pilot should branch from and
@@ -693,6 +698,16 @@ var validEffortLevels = map[string]bool{
 	"":       true, // Empty uses default
 }
 
+// validReleasePublishValues are the accepted values for release.publish,
+// checked at the global, per-environment, and per-project overlay levels
+// (GH-3930).
+var validReleasePublishValues = map[string]bool{
+	"workflow": true,
+	"api":      true,
+	"tag_only": true,
+	"":         true, // Empty inherits the default (workflow)
+}
+
 // Validate checks the configuration for errors and returns an error if invalid.
 // It validates required fields, port ranges, authentication settings, and routing config.
 func (c *Config) Validate() error {
@@ -749,6 +764,34 @@ func (c *Config) Validate() error {
 			if !validModes[c.Orchestrator.Execution.Mode] {
 				return fmt.Errorf("orchestrator.execution.mode must be 'sequential', 'parallel', or 'auto', got %q", c.Orchestrator.Execution.Mode)
 			}
+		}
+
+		// GH-3930: Validate release.publish enum on the global release block
+		// and on every per-environment release block.
+		if c.Orchestrator.Autopilot != nil {
+			if release := c.Orchestrator.Autopilot.Release; release != nil {
+				if !validReleasePublishValues[release.Publish] {
+					return fmt.Errorf("orchestrator.autopilot.release.publish must be \"workflow\", \"api\", or \"tag_only\", got %q", release.Publish)
+				}
+			}
+			for envName, env := range c.Orchestrator.Autopilot.Environments {
+				if env == nil || env.Release == nil {
+					continue
+				}
+				if !validReleasePublishValues[env.Release.Publish] {
+					return fmt.Errorf("orchestrator.autopilot.environments[%s].release.publish must be \"workflow\", \"api\", or \"tag_only\", got %q", envName, env.Release.Publish)
+				}
+			}
+		}
+	}
+
+	// GH-3930: Validate release.publish enum on each project's release overlay.
+	for i, p := range c.Projects {
+		if p == nil || p.Release == nil {
+			continue
+		}
+		if !validReleasePublishValues[p.Release.Publish] {
+			return fmt.Errorf("projects[%d].release.publish must be \"workflow\", \"api\", or \"tag_only\", got %q", i, p.Release.Publish)
 		}
 	}
 

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/qf-studio/pilot/internal/autopilot"
 	"github.com/qf-studio/pilot/internal/budget"
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/gateway"
@@ -472,6 +473,165 @@ func TestConfig_Validate_BudgetBounds(t *testing.T) {
 			} else {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// GH-3930: Validate release.publish enum at the global, per-environment, and
+// per-project overlay levels.
+func TestConfig_Validate_ReleasePublish(t *testing.T) {
+	tests := []struct {
+		name      string
+		buildCfg  func() *Config
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid empty publish at all levels",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Publish: ""},
+						Environments: map[string]*autopilot.EnvironmentConfig{
+							"prod": {Release: &autopilot.ReleaseConfig{Publish: ""}},
+						},
+					},
+				}
+				cfg.Projects[0].Release = &autopilot.ProjectReleaseConfig{Publish: ""}
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid workflow publish at global level",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Publish: "workflow"},
+					},
+				}
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid api publish at global level",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Publish: "api"},
+					},
+				}
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid tag_only publish at global level",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Publish: "tag_only"},
+					},
+				}
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid publish at global level",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Publish: "bogus"},
+					},
+				}
+				return cfg
+			},
+			wantErr:   true,
+			errSubstr: `orchestrator.autopilot.release.publish must be "workflow", "api", or "tag_only"`,
+		},
+		{
+			name: "invalid publish at environment level",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Environments: map[string]*autopilot.EnvironmentConfig{
+							"prod": {Release: &autopilot.ReleaseConfig{Publish: "bogus"}},
+						},
+					},
+				}
+				return cfg
+			},
+			wantErr:   true,
+			errSubstr: `orchestrator.autopilot.environments[prod].release.publish must be "workflow", "api", or "tag_only"`,
+		},
+		{
+			name: "invalid publish at project overlay level",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Projects[0].Release = &autopilot.ProjectReleaseConfig{Publish: "bogus"}
+				return cfg
+			},
+			wantErr:   true,
+			errSubstr: `projects[0].release.publish must be "workflow", "api", or "tag_only"`,
+		},
+		{
+			name: "project overlay sets only publish, inherits enabled from global",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Enabled: true, Publish: "workflow"},
+					},
+				}
+				// Only Publish is set on the overlay — Enabled is left nil so
+				// it inherits the global Enabled: true above (GH-3930).
+				cfg.Projects[0].Release = &autopilot.ProjectReleaseConfig{Publish: "api"}
+				return cfg
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.buildCfg()
+
+			err := cfg.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errSubstr)
+				} else if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+
+			if tt.name == "project overlay sets only publish, inherits enabled from global" {
+				if cfg.Projects[0].Release.Enabled != nil {
+					t.Errorf("expected overlay Enabled to remain nil (inherit), got %v", cfg.Projects[0].Release.Enabled)
+				}
+				if !cfg.Orchestrator.Autopilot.Release.Enabled {
+					t.Errorf("expected global Enabled to remain true")
 				}
 			}
 		})


### PR DESCRIPTION
## Summary
- Adds `ProjectConfig.Release (*autopilot.ProjectReleaseConfig)`, mirroring the existing `Quality *quality.Config` overlay pattern.
- Adds validation in `Config.Validate()` rejecting any `release.publish` value outside `{workflow, api, tag_only, ""}` at three levels: the global `orchestrator.autopilot.release` block, each `orchestrator.autopilot.environments[*].release` block, and each `projects[N].release` overlay.
- Adds a `Publish string` field to `autopilot.ReleaseConfig` and a new `autopilot.ProjectReleaseConfig` overlay type (`Enabled *bool`, `Publish string`) — the minimal prerequisite this task needs to compile against. These were originally scoped to GH-3929, but GH-3929 hadn't landed yet when this task dispatched, so the field/type additions are included here as unblocking scaffolding; `PublishMode()`/`Apply()` overlay-resolution semantics and controller wiring remain GH-3929/GH-3931's responsibility.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/config/... ./internal/autopilot/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New table-driven test `TestConfig_Validate_ReleasePublish` covers: valid empty at all 3 levels, each valid enum value (workflow/api/tag_only) at global level, invalid value at global/environment/project-overlay levels, and a project overlay that sets only `publish` while inheriting `enabled` from global.

Closes GH-3930.