### PR TITLE
feat(autopilot): wire per-project release override at controller sites

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -642,6 +642,10 @@ Examples:
 							// TASK-352: scope self-heal to the project's fs path (matches
 							// executions.project_path) so merged work flips failed→completed.
 							gwBoardOpts = append(gwBoardOpts, autopilot.WithProjectPath(projectPath))
+							// GH-3931: apply the per-project release overlay (GH-3930) when configured.
+							if proj := cfg.FindProjectByRepo(cfg.Adapters.GitHub.Repo); proj != nil && proj.Release != nil {
+								gwBoardOpts = append(gwBoardOpts, autopilot.WithReleaseOverride(proj.Release))
+							}
 							gwAutopilotController = autopilot.NewController(
 								cfg.Orchestrator.Autopilot,
 								apGHClient,
@@ -1672,6 +1676,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					// TASK-352: scope self-heal to the project's fs path. Fresh slice so
 					// the per-project loop below does not alias this controller's option.
 					ctrlOpts := append(append([]autopilot.ControllerOption{}, autopilotBoardOpts...), autopilot.WithProjectPath(projectPath))
+					// GH-3931: apply the per-project release overlay (GH-3930) when configured.
+					if proj := cfg.FindProjectByRepo(cfg.Adapters.GitHub.Repo); proj != nil && proj.Release != nil {
+						ctrlOpts = append(ctrlOpts, autopilot.WithReleaseOverride(proj.Release))
+					}
 					controller := autopilot.NewController(
 						cfg.Orchestrator.Autopilot,
 						apGHClient,
@@ -1697,6 +1705,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				// TASK-352: scope self-heal to this project's fs path (matches
 				// executions.project_path). Fresh slice to avoid aliasing the shared opts.
 				ctrlOpts := append(append([]autopilot.ControllerOption{}, autopilotBoardOpts...), autopilot.WithProjectPath(proj.Path))
+				// GH-3931: apply the per-project release overlay (GH-3930) when configured.
+				if proj.Release != nil {
+					ctrlOpts = append(ctrlOpts, autopilot.WithReleaseOverride(proj.Release))
+				}
 				controller := autopilot.NewController(
 					cfg.Orchestrator.Autopilot,
 					apGHClient,

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -157,6 +157,17 @@ func WithProjectPath(path string) ControllerOption {
 	}
 }
 
+// WithReleaseOverride wires a per-project release config overlay (GH-3930)
+// for this controller's repo. Nil is a no-op. Overlay resolution against the
+// global/env ReleaseConfig (Apply/resolvedRelease) and consumption in
+// handleReleasing land in GH-3929; this option only stores the overlay so
+// call sites can wire it ahead of that work (GH-3931).
+func WithReleaseOverride(o *ProjectReleaseConfig) ControllerOption {
+	return func(c *Controller) {
+		c.projectRelease = o
+	}
+}
+
 // Controller orchestrates the autopilot loop for PR processing.
 // It manages the state machine: PR created → CI check → merge → post-merge CI → feedback loop.
 type Controller struct {
@@ -221,6 +232,11 @@ type Controller struct {
 	// executions.project_path. Used to scope self-heal to this project's rows.
 	// Empty = match by task_id only (single-repo / tests). TASK-352.
 	projectPath string
+
+	// projectRelease is the per-project release config overlay (GH-3930),
+	// wired via WithReleaseOverride. Nil = no project-level override. Overlay
+	// resolution and handleReleasing consumption land in GH-3929.
+	projectRelease *ProjectReleaseConfig
 
 	// GH-3271: called after a PR merges and pilot-done is applied so pollers
 	// can immediately re-mark the issue as processed, closing the merge→done


### PR DESCRIPTION
## Summary
- Resolves GH-3931 (sub-issue of GH-3926): wires `autopilot.WithReleaseOverride(project.Release)` at all three `autopilot.NewController` call sites in `cmd/pilot/main.go` — gateway path and polling default-repo path via `cfg.FindProjectByRepo`, per-project loop via the loop variable directly.
- `WithReleaseOverride` didn't exist yet (its full design — overlay resolution + `handleReleasing` consumption — is spec'd under sibling issue GH-3929, still open). Added a minimal `ControllerOption` in `internal/autopilot/controller.go` that stores the `*ProjectReleaseConfig` overlay on the controller, so this wiring compiles. GH-3929 owns resolving the overlay against the global/env `ReleaseConfig`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/pilot/... ./internal/autopilot/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`