### PR TITLE
fix(executor): close epic-parent trace gap, harvest child tokens, add zero-artifact no-op guard

### DIFF
--- a/.agent/tasks/gh-3938.md
+++ b/.agent/tasks/gh-3938.md
@@ -1,0 +1,10 @@
+# GH-3938
+
+**Created:** 2026-07-06
+
+## Problem
+
+In internal/executor/, close the fail-silent regression on the epic-parent path: Emit execution_events past spec_validated (claude_started, decomposed with child issue list or implementation_started, and a terminal event completed/failed/no_op) so pilot trace <task-id> shows the full lifecycle. Fix the token harvester so executions.tokens_output/tokens_input are populated whenever Claude is actually invoked — a 37-minute run must not persist as tokens_output=0. Add a no-op guard that classifies 'completed with zero tokens AND zero files AND no commit/PR' as failed (or explicit no_op with reason), following the GH-3224 ghost-SHA guard shape referenced in bug_pilot_ghost_closes. Replace the '⚠ no changes were made' comment on decomposed epic parents with an honest 'decomposed into N children: #a, #b, #c' summary sourced from the actual child-dispatch results. Add table-driven tests covering: (a) a fake Claude stream produces tokens_output > 0 and full event sequence; (b) zero-output run trips the no-op guard instead of marking completed; (c) decomposition emits the child-list comment; (d) existing close-guards (GH-3513 text-search confirmation, open-PR veto) remain unchanged.
+
+## Acceptance Criteria
+

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -818,6 +818,15 @@ func buildExecutionComment(result *executor.ExecutionResult, branchName string) 
 			result.FilesChanged, result.LinesAdded, result.LinesRemoved))
 	}
 
+	// GH-3938: a decomposed epic parent that shipped no PR of its own is not
+	// "no changes were made" — its children carried the work. Report the
+	// actual dispatched child issues instead of leaving the reader to infer
+	// nothing happened from an otherwise-sparse table.
+	if result.IsEpic && result.PRUrl == "" && len(result.ChildIssues) > 0 {
+		sb.WriteString(fmt.Sprintf("| Decomposed | %d children: %s |\n",
+			len(result.ChildIssues), formatChildIssueRefs(result.ChildIssues)))
+	}
+
 	// Branch
 	if branchName != "" {
 		sb.WriteString(fmt.Sprintf("| Branch | `%s` |\n", branchName))
@@ -834,6 +843,25 @@ func buildExecutionComment(result *executor.ExecutionResult, branchName string) 
 	}
 
 	return sb.String()
+}
+
+// formatChildIssueRefs renders an epic's actual dispatched child issues as a
+// comma-separated list for the completion comment (GH-3938): "#101, #102" for
+// GitHub issues (Number > 0), the adapter identifier for non-GitHub trackers,
+// falling back to the issue URL when neither is set.
+func formatChildIssueRefs(children []executor.CreatedIssue) string {
+	refs := make([]string, 0, len(children))
+	for _, c := range children {
+		switch {
+		case c.Number > 0:
+			refs = append(refs, fmt.Sprintf("#%d", c.Number))
+		case c.Identifier != "":
+			refs = append(refs, c.Identifier)
+		default:
+			refs = append(refs, c.URL)
+		}
+	}
+	return strings.Join(refs, ", ")
 }
 
 // buildFailureComment formats a comment for failed executions.

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -864,6 +864,28 @@ func formatChildIssueRefs(children []executor.CreatedIssue) string {
 	return strings.Join(refs, ", ")
 }
 
+// buildGitlabSuccessNote formats the GitLab issue-note counterpart to
+// buildExecutionComment (GH-3938): a decomposed epic parent with no MR of its
+// own shipped work via its children, not "nothing happened".
+func buildGitlabSuccessNote(result *executor.ExecutionResult, branchName string) string {
+	var parts []string
+	parts = append(parts, "✅ Pilot execution completed successfully!")
+	parts = append(parts, "")
+	if result.PRUrl != "" {
+		parts = append(parts, fmt.Sprintf("Merge Request: %s", result.PRUrl))
+	}
+	if result.CommitSHA != "" {
+		parts = append(parts, fmt.Sprintf("Commit: %s", result.CommitSHA[:min(8, len(result.CommitSHA))]))
+	}
+	if result.IsEpic && result.PRUrl == "" && len(result.ChildIssues) > 0 {
+		parts = append(parts, fmt.Sprintf("Decomposed: %d children: %s",
+			len(result.ChildIssues), formatChildIssueRefs(result.ChildIssues)))
+	}
+	parts = append(parts, fmt.Sprintf("Branch: %s", branchName))
+	parts = append(parts, fmt.Sprintf("Duration: %s", result.Duration))
+	return strings.Join(parts, "\n")
+}
+
 // buildFailureComment formats a comment for failed executions.
 func buildFailureComment(result *executor.ExecutionResult) string {
 	var sb strings.Builder
@@ -1110,18 +1132,7 @@ func handleGitlabIssueWithResult(ctx context.Context, cfg *config.Config, client
 			}
 			issueResult.Success = false
 		} else {
-			var parts []string
-			parts = append(parts, "✅ Pilot execution completed successfully!")
-			parts = append(parts, "")
-			if hr.Result.PRUrl != "" {
-				parts = append(parts, fmt.Sprintf("Merge Request: %s", hr.Result.PRUrl))
-			}
-			if hr.Result.CommitSHA != "" {
-				parts = append(parts, fmt.Sprintf("Commit: %s", hr.Result.CommitSHA[:min(8, len(hr.Result.CommitSHA))]))
-			}
-			parts = append(parts, fmt.Sprintf("Branch: %s", branchName))
-			parts = append(parts, fmt.Sprintf("Duration: %s", hr.Result.Duration))
-			note := strings.Join(parts, "\n")
+			note := buildGitlabSuccessNote(hr.Result, branchName)
 			if _, err := client.AddIssueNote(ctx, issueIID, note); err != nil {
 				logging.WithComponent("gitlab").Warn("Failed to add success note",
 					slog.String("task_id", taskID),

--- a/cmd/pilot/handlers_already_merged_test.go
+++ b/cmd/pilot/handlers_already_merged_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/testutil"
 )
 
@@ -130,5 +131,37 @@ func TestIssueHasOpenChildren(t *testing.T) {
 				t.Errorf("issueHasOpenChildren() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestZeroArtifactNoOpGuard_CompatibleWithExistingCloseGuards covers GH-3938
+// acceptance (d): runner.go's new applyZeroArtifactNoOpGuard (package
+// executor) emits an error prefixed with the shared "no new commit produced"
+// marker specifically so it is recognized by cmd/pilot's existing GH-3513
+// text-search confirmation (noOpErrorMarker) and the open-PR veto guards that
+// sit behind it at handlers.go's no-op re-dispatch branches (~line 503-539).
+// The two constants are independently defined in different packages (the
+// executor-side equivalent is noOpErrorSignatures[0] in runner.go) — this
+// pins their value so a future edit to either side doesn't silently break
+// that cross-package classification. See TestApplyZeroArtifactNoOpGuard
+// (internal/executor) for the guard's own behavior, and
+// TestIssueHasOpenChildren/TestIssueAlreadyMerged above (unmodified by this
+// change) for the close-guards this classification feeds into.
+func TestZeroArtifactNoOpGuard_CompatibleWithExistingCloseGuards(t *testing.T) {
+	const wantMarker = "no new commit produced"
+	if noOpErrorMarker != wantMarker {
+		t.Fatalf("cmd/pilot's noOpErrorMarker = %q, want %q — internal/executor's applyZeroArtifactNoOpGuard and noOpErrorSignatures[0] (runner.go) must stay in sync with this constant or the GH-3513 text-search close-guards will stop recognizing GH-3938's zero-artifact no-op classification",
+			noOpErrorMarker, wantMarker)
+	}
+
+	// Sanity-check the composed message shape applyZeroArtifactNoOpGuard
+	// produces (runner.go: fmt.Sprintf("no new commit produced — %s completed
+	// with zero tokens, zero files changed, and no commit/PR", context)) still
+	// satisfies a strings.Contains(err, noOpErrorMarker) check.
+	sample := &executor.ExecutionResult{
+		Error: "no new commit produced — epic GH-1 across 2 sub-issue(s) completed with zero tokens, zero files changed, and no commit/PR",
+	}
+	if !strings.Contains(sample.Error, noOpErrorMarker) {
+		t.Fatalf("sample zero-artifact guard error %q does not contain noOpErrorMarker %q", sample.Error, noOpErrorMarker)
 	}
 }

--- a/cmd/pilot/main_comment_test.go
+++ b/cmd/pilot/main_comment_test.go
@@ -124,6 +124,76 @@ func TestBuildExecutionComment_WithIntentWarning(t *testing.T) {
 	}
 }
 
+// TestBuildGitlabSuccessNote covers the GitLab counterpart of GH-3938
+// acceptance (c): parity with buildExecutionComment so a decomposed epic
+// parent reports its actual children instead of implying nothing happened,
+// while a non-epic or own-PR result is unaffected.
+func TestBuildGitlabSuccessNote(t *testing.T) {
+	tests := []struct {
+		name        string
+		result      *executor.ExecutionResult
+		branch      string
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name: "decomposed epic with no PR of its own reports children",
+			result: &executor.ExecutionResult{
+				Success:  true,
+				Duration: 37 * time.Minute,
+				IsEpic:   true,
+				ChildIssues: []executor.CreatedIssue{
+					{Number: 101},
+					{Identifier: "APP-9"},
+				},
+			},
+			branch:      "pilot/GL-42",
+			wantContain: []string{"Decomposed: 2 children: #101, APP-9", "Branch: pilot/GL-42"},
+			wantAbsent:  []string{"Merge Request:"},
+		},
+		{
+			name: "epic that shipped its own MR shows no decomposed row",
+			result: &executor.ExecutionResult{
+				Success: true,
+				IsEpic:  true,
+				PRUrl:   "https://gitlab.com/org/repo/-/merge_requests/7",
+				ChildIssues: []executor.CreatedIssue{
+					{Number: 55},
+				},
+			},
+			branch:      "pilot/GL-43",
+			wantContain: []string{"Merge Request: https://gitlab.com/org/repo/-/merge_requests/7"},
+			wantAbsent:  []string{"Decomposed:"},
+		},
+		{
+			name: "non-epic success with commit and no children",
+			result: &executor.ExecutionResult{
+				Success:   true,
+				CommitSHA: "abcdef1234567890",
+			},
+			branch:      "pilot/GL-44",
+			wantContain: []string{"Commit: abcdef12", "Branch: pilot/GL-44"},
+			wantAbsent:  []string{"Decomposed:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			note := buildGitlabSuccessNote(tt.result, tt.branch)
+			for _, want := range tt.wantContain {
+				if !strings.Contains(note, want) {
+					t.Errorf("note missing %q\nGot:\n%s", want, note)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(note, absent) {
+					t.Errorf("note should not contain %q\nGot:\n%s", absent, note)
+				}
+			}
+		})
+	}
+}
+
 func TestBuildFailureComment(t *testing.T) {
 	result := &executor.ExecutionResult{
 		Error:            "build failed: undefined method foo",

--- a/cmd/pilot/main_comment_test.go
+++ b/cmd/pilot/main_comment_test.go
@@ -41,6 +41,55 @@ func TestBuildExecutionComment_FullResult(t *testing.T) {
 	}
 }
 
+// TestBuildExecutionComment_DecomposedEpicChildren covers GH-3938 acceptance
+// (c): a decomposed epic parent that shipped no PR of its own must report an
+// honest "decomposed into N children: #a, #b, #c" summary sourced from the
+// actual child-dispatch results (ChildIssues), replacing the misleading
+// "⚠ no changes were made" impression a bare table would otherwise leave.
+func TestBuildExecutionComment_DecomposedEpicChildren(t *testing.T) {
+	result := &executor.ExecutionResult{
+		Success:  true,
+		Duration: 37 * time.Minute,
+		IsEpic:   true,
+		ChildIssues: []executor.CreatedIssue{
+			{Number: 101},
+			{Number: 102},
+			{Identifier: "APP-9"},
+		},
+	}
+	comment := buildExecutionComment(result, "pilot/GH-999")
+
+	if !strings.Contains(comment, "| Decomposed | 3 children: #101, #102, APP-9 |") {
+		t.Errorf("comment missing decomposed children summary\nGot:\n%s", comment)
+	}
+	if strings.Contains(comment, "no changes were made") {
+		t.Error("decomposed epic parent comment should not claim no changes were made")
+	}
+}
+
+// TestBuildExecutionComment_EpicWithOwnPR_NoDecomposedRow verifies that an
+// epic result which DID ship its own PR (task.CreatePR path) shows the normal
+// PR row instead of the decomposed-children summary — the two are mutually
+// exclusive completion shapes.
+func TestBuildExecutionComment_EpicWithOwnPR_NoDecomposedRow(t *testing.T) {
+	result := &executor.ExecutionResult{
+		Success: true,
+		IsEpic:  true,
+		PRUrl:   "https://github.com/org/repo/pull/789",
+		ChildIssues: []executor.CreatedIssue{
+			{Number: 55},
+		},
+	}
+	comment := buildExecutionComment(result, "pilot/GH-1000")
+
+	if strings.Contains(comment, "| Decomposed |") {
+		t.Errorf("expected no Decomposed row when the epic shipped its own PR\nGot:\n%s", comment)
+	}
+	if !strings.Contains(comment, "pull/789") {
+		t.Error("expected PR row to be present")
+	}
+}
+
 func TestBuildExecutionComment_MinimalResult(t *testing.T) {
 	result := &executor.ExecutionResult{
 		Success:  true,

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -827,9 +827,13 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			if err := w.store.MarkExecutionCompleted(exec.ID, result.PRUrl, result.CommitSHA, duration.Milliseconds()); err != nil {
 				w.log.Error("Failed to mark execution completed", slog.Any("error", err))
 			}
-			// GH-3846: record terminal-success transition to the execution-events audit trail.
+			// GH-3846/GH-3938: record terminal-success transition to the execution-events
+			// audit trail. Fires unconditionally so a run with no PR (epic parents,
+			// direct-commit tasks) still gets a terminal marker instead of the trace
+			// dead-ending after spec_validated.
 			if stage, ok := dispatchSuccessStage(result.PRUrl); ok {
-				w.recordExecutionEvent(exec.ID, stage, fmt.Sprintf("completed with PR: %s", result.PRUrl))
+				detail := fmt.Sprintf("completed: pr=%s commit=%s", result.PRUrl, result.CommitSHA)
+				w.recordExecutionEvent(exec.ID, stage, detail)
 			}
 			// Emit progress callback for task completed
 			msg := fmt.Sprintf("Completed in %s", duration.Round(time.Second))
@@ -901,18 +905,15 @@ func (w *ProjectWorker) recordExecutionEvent(executionID string, stage memory.St
 	}
 }
 
-// dispatchSuccessStage reports the execution_events Stage (and whether to
-// write one) for the dispatcher's terminal-success site. The Stage enum
-// (GH-3840) has no generic "completed" value, so a PR is the only durable
-// milestone this site can map to today — runner.go already emits pr_created
-// at creation time; this dispatcher-level entry marks the run as a whole
-// finishing. Direct-commit tasks with no PR have no matching Stage yet, so
-// they're intentionally left uninstrumented here (GH-3846).
-func dispatchSuccessStage(prURL string) (memory.Stage, bool) {
-	if prURL == "" {
-		return "", false
-	}
-	return memory.StagePRCreated, true
+// dispatchSuccessStage reports the execution_events Stage for the dispatcher's
+// terminal-success site. GH-3938: fires unconditionally via the generic
+// StageCompleted milestone — runner.go already emits pr_created/commit at
+// their own creation-time milestones, but a run with no PR (epic parents,
+// direct-commit tasks) previously left no terminal event at all, so
+// `pilot trace` dead-ended at spec_validated. prURL is accepted for call-site
+// stability but no longer changes the outcome.
+func dispatchSuccessStage(_ string) (memory.Stage, bool) {
+	return memory.StageCompleted, true
 }
 
 // dispatchTerminalStage maps a dispatcher-classified terminal status (see

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -1424,8 +1424,9 @@ func TestDispatcher_AdoptQueuedProjects_ReportsFailureWithoutAdopting(t *testing
 }
 
 // TestDispatchSuccessStage covers the dispatcher's terminal-success mapping:
-// a PR produces a pr_created event, a PR-less completion (direct-commit mode)
-// has no matching Stage yet and is intentionally left uninstrumented (GH-3846).
+// GH-3938 — every successful run gets a generic StageCompleted terminal event,
+// with or without a PR, so `pilot trace` never dead-ends at spec_validated
+// for epic parents or direct-commit tasks.
 func TestDispatchSuccessStage(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -1433,8 +1434,8 @@ func TestDispatchSuccessStage(t *testing.T) {
 		wantStage memory.Stage
 		wantOK    bool
 	}{
-		{"pr url present", "https://github.com/test/repo/pull/1", memory.StagePRCreated, true},
-		{"no pr url", "", "", false},
+		{"pr url present", "https://github.com/test/repo/pull/1", memory.StageCompleted, true},
+		{"no pr url", "", memory.StageCompleted, true},
 	}
 
 	for _, tt := range tests {
@@ -1527,12 +1528,13 @@ func waitForTerminalStatus(t *testing.T, store *memory.Store, execID string, tim
 // TestDispatcher_SyntheticDispatch_SuccessEventSequence drives a full
 // synthetic dispatch (queue → worker pickup → runner execution → completion)
 // through the real dispatcher and runner, and asserts the execution_events
-// timeline records the expected cross-file sequence: dispatcher's
-// queued→running transition and runner's spec-validated milestone. This task
-// has no PR (CreatePR: false), so the dispatcher's terminal-success write is
-// a no-op by design (see the recordExecutionEvent call site in processQueue)
-// — TestRunner_recordExecutionEvent_WritesEvent covers the pr_created write
-// directly. GH-3846.
+// timeline records the full cross-file lifecycle: dispatcher's queued→running
+// transition, runner's spec-validated/claude-started/implementation-started
+// milestones, and the dispatcher's generic terminal-success event. This task
+// has no PR (CreatePR: false); GH-3938 made the terminal-success write fire
+// unconditionally (StageCompleted) instead of only when a PR exists, so
+// `pilot trace` never dead-ends at spec_validated for PR-less runs (e.g. epic
+// parents). GH-3846/GH-3938.
 func TestDispatcher_SyntheticDispatch_SuccessEventSequence(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
@@ -1570,7 +1572,13 @@ func TestDispatcher_SyntheticDispatch_SuccessEventSequence(t *testing.T) {
 		t.Fatalf("ListExecutionEvents failed: %v", err)
 	}
 
-	wantStages := []memory.Stage{memory.StageRunning, memory.StageSpecValidated}
+	wantStages := []memory.Stage{
+		memory.StageRunning,
+		memory.StageSpecValidated,
+		memory.StageClaudeStarted,
+		memory.StageImplementationStarted,
+		memory.StageCompleted,
+	}
 	if len(events) != len(wantStages) {
 		var gotStages []memory.Stage
 		for _, e := range events {

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -961,6 +961,31 @@ func allChildrenDone(issues []CreatedIssue) bool {
 	return true
 }
 
+// childIssueRef formats a single CreatedIssue for a human-readable summary:
+// "#123" for GitHub issues (Number > 0), the raw Identifier for other adapters
+// (e.g. Linear/Jira), falling back to the issue URL when neither is set.
+func childIssueRef(issue CreatedIssue) string {
+	if issue.Number > 0 {
+		return fmt.Sprintf("#%d", issue.Number)
+	}
+	if issue.Identifier != "" {
+		return issue.Identifier
+	}
+	return issue.URL
+}
+
+// decomposedEventDetail builds the execution_events detail string for the
+// StageDecomposed milestone (GH-3938): "decomposed into N children: #a, #b, #c".
+// Sourced from the actual dispatched/recovered child issues, not the planned
+// subtask count, so the trace reflects what really got created.
+func decomposedEventDetail(issues []CreatedIssue) string {
+	refs := make([]string, 0, len(issues))
+	for _, iss := range issues {
+		refs = append(refs, childIssueRef(iss))
+	}
+	return fmt.Sprintf("decomposed into %d children: %s", len(issues), strings.Join(refs, ", "))
+}
+
 // issueNumberRegex extracts the issue number from a GitHub issue URL.
 // Matches patterns like: https://github.com/owner/repo/issues/123
 var issueNumberRegex = regexp.MustCompile(`/issues/(\d+)`)
@@ -1759,8 +1784,58 @@ func (r *Runner) resolveChildTerminalOutcome(taskID, status string, result *Exec
 // as their ProjectPath so they can create their own branches from the real repo.
 // executionPath is still used for gh CLI commands (issue comments) that need worktree context.
 func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []CreatedIssue, executionPath string, repoPath string) error {
-	_, err := r.executeSubIssuesTracked(ctx, parent, issues, executionPath, repoPath)
+	_, _, err := r.executeSubIssuesTracked(ctx, parent, issues, executionPath, repoPath)
 	return err
+}
+
+// epicChildMetrics aggregates token/cost/diff metrics across executed child
+// sub-issues (GH-3938). Each child runs as its own executeWithOptions call and
+// carries real Claude usage in its own *ExecutionResult, but that result was
+// previously discarded once its terminal status string was recorded — leaving
+// the epic-parent's own execution row persisted with tokens_output=0 even
+// after a run that took tens of minutes across its children.
+type epicChildMetrics struct {
+	TokensInput              int64
+	TokensOutput             int64
+	CacheCreationInputTokens int64
+	CacheReadInputTokens     int64
+	EstimatedCostUSD         float64
+	FilesChanged             int
+	LinesAdded               int
+	LinesRemoved             int
+}
+
+// add folds a single child's ExecutionResult into the aggregate. Safe to call
+// with a nil result (no-op).
+func (m *epicChildMetrics) add(result *ExecutionResult) {
+	if m == nil || result == nil {
+		return
+	}
+	m.TokensInput += result.TokensInput
+	m.TokensOutput += result.TokensOutput
+	m.CacheCreationInputTokens += result.CacheCreationInputTokens
+	m.CacheReadInputTokens += result.CacheReadInputTokens
+	m.EstimatedCostUSD += result.EstimatedCostUSD
+	m.FilesChanged += result.FilesChanged
+	m.LinesAdded += result.LinesAdded
+	m.LinesRemoved += result.LinesRemoved
+}
+
+// applyTo copies the aggregate onto the epic-parent's own ExecutionResult.
+// Safe to call with a nil receiver or target.
+func (m *epicChildMetrics) applyTo(result *ExecutionResult) {
+	if m == nil || result == nil {
+		return
+	}
+	result.TokensInput += m.TokensInput
+	result.TokensOutput += m.TokensOutput
+	result.TokensTotal = result.TokensInput + result.TokensOutput
+	result.CacheCreationInputTokens += m.CacheCreationInputTokens
+	result.CacheReadInputTokens += m.CacheReadInputTokens
+	result.EstimatedCostUSD += m.EstimatedCostUSD
+	result.FilesChanged += m.FilesChanged
+	result.LinesAdded += m.LinesAdded
+	result.LinesRemoved += m.LinesRemoved
 }
 
 // executeSubIssuesTracked is ExecuteSubIssues plus each child's terminal state
@@ -1773,9 +1848,10 @@ func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []Cr
 // mirrors the TASK-320 B2 tolerance already applied to the in-process decomposer
 // (runner_decompose.go isNoOpResult). Any other child failure still aborts the
 // whole epic, unchanged from ExecuteSubIssues' prior behavior.
-func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issues []CreatedIssue, executionPath string, repoPath string) ([]string, error) {
+func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issues []CreatedIssue, executionPath string, repoPath string) ([]string, *epicChildMetrics, error) {
+	metrics := &epicChildMetrics{}
 	if len(issues) == 0 {
-		return nil, fmt.Errorf("no sub-issues to execute")
+		return nil, metrics, fmt.Errorf("no sub-issues to execute")
 	}
 
 	var childStates []string
@@ -1811,7 +1887,7 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 		// Check context cancellation
 		select {
 		case <-ctx.Done():
-			return childStates, fmt.Errorf("execution cancelled: %w", ctx.Err())
+			return childStates, metrics, fmt.Errorf("execution cancelled: %w", ctx.Err())
 		default:
 		}
 
@@ -1899,8 +1975,13 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			failMsg := fmt.Sprintf("❌ Failed on %d/%d: %s - Error: %v",
 				i+1, total, issue.Subtask.Title, err)
 			_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
-			return childStates, fmt.Errorf("sub-issue %s failed: %w", issueRef, err)
+			return childStates, metrics, fmt.Errorf("sub-issue %s failed: %w", issueRef, err)
 		}
+
+		// GH-3938: fold this child's real token/cost/diff usage into the epic
+		// aggregate regardless of success/no-op — Claude ran and consumed tokens
+		// either way, and the parent's own execution row should reflect that.
+		metrics.add(result)
 
 		if !result.Success {
 			// GH-3779: a genuine no-op child (isNoOpResult — same classification the
@@ -1922,7 +2003,7 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			failMsg := fmt.Sprintf("❌ Failed on %d/%d: %s - %s",
 				i+1, total, issue.Subtask.Title, result.Error)
 			_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
-			return childStates, fmt.Errorf("sub-issue %s failed: %s", issueRef, result.Error)
+			return childStates, metrics, fmt.Errorf("sub-issue %s failed: %s", issueRef, result.Error)
 		}
 
 		childStates = append(childStates, TerminalStatus(result))
@@ -1962,7 +2043,7 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 				"branch", subTask.Branch,
 				"recovery_ref", recoveryRef,
 			)
-			return childStates, fmt.Errorf("sub-issue %s committed work (sha %s) but produced no PR — work would be lost, halting epic — recovery: %s", issueRef, shortSHA, recovery)
+			return childStates, metrics, fmt.Errorf("sub-issue %s committed work (sha %s) but produced no PR — work would be lost, halting epic — recovery: %s", issueRef, shortSHA, recovery)
 		}
 
 		// Register sub-issue PR with autopilot controller (GH-596)
@@ -1997,7 +2078,7 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 				if err := r.subIssueMergeWait(ctx, prNum); err != nil {
 					failMsg := fmt.Sprintf("❌ Merge wait failed for %s (PR #%d): %v", issueRef, prNum, err)
 					_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
-					return childStates, fmt.Errorf("merge wait failed for sub-issue %s (PR #%d): %w", issueRef, prNum, err)
+					return childStates, metrics, fmt.Errorf("merge wait failed for sub-issue %s (PR #%d): %w", issueRef, prNum, err)
 				}
 
 				// Sync local main branch so the next sub-issue branches from the merged state.
@@ -2043,5 +2124,5 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 		"total_completed", total,
 	)
 
-	return childStates, nil
+	return childStates, metrics, nil
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -261,6 +261,41 @@ func TerminalStatus(result *ExecutionResult) string {
 	return "failed"
 }
 
+// isZeroArtifactResult reports whether result claims success but shows no
+// observable evidence of real work: no tokens consumed, no files changed, and
+// no commit or PR anywhere. A result meeting all four conditions cannot have
+// done anything — GH-3938.
+func isZeroArtifactResult(result *ExecutionResult) bool {
+	if result == nil || !result.Success {
+		return false
+	}
+	return result.TokensInput == 0 && result.TokensOutput == 0 &&
+		result.FilesChanged == 0 && result.CommitSHA == "" && result.PRUrl == ""
+}
+
+// applyZeroArtifactNoOpGuard reclassifies a "completed with zero tokens, zero
+// files, and no commit/PR" result as a genuine no_op instead of a silent
+// false-positive completion — following the GH-3224 ghost-SHA guard shape
+// (bug_pilot_ghost_closes.md, "epic-parent false-positive" pattern, TASK-296):
+// a result can look successful (Success=true, no error) while having produced
+// nothing a human or the tracker could verify. context is a short human-
+// readable description of what ran, used in the resulting Error message.
+// No-op when result already claims something other than success. GH-3938.
+func applyZeroArtifactNoOpGuard(result *ExecutionResult, context string) {
+	if !isZeroArtifactResult(result) {
+		return
+	}
+	result.Success = false
+	result.Outcome = "no_op"
+	// "no new commit produced" matches noOpErrorSignatures (runner.go) and
+	// noOpErrorMarker (cmd/pilot/handlers.go) so every existing no-op
+	// classification path (TerminalStatus, IsPermanentFailure, the
+	// already-merged/open-children re-dispatch guards) recognizes this the
+	// same way it recognizes the ghost-SHA no-op, even if Outcome is ever
+	// dropped on a round-trip.
+	result.Error = fmt.Sprintf("no new commit produced — %s completed with zero tokens, zero files changed, and no commit/PR", context)
+}
+
 // StreamEvent represents a Claude Code stream-json event
 type StreamEvent struct {
 	Type          string          `json:"type"`
@@ -509,6 +544,12 @@ type ExecutionResult struct {
 	IsEpic bool
 	// EpicPlan contains the planning result for epic tasks (GH-405)
 	EpicPlan *EpicPlan
+	// ChildIssues holds the actual child issues dispatched during epic
+	// decomposition (GH-3938), sourced from the real CreateSubIssues/recovery
+	// result rather than the planned subtask count — used to build an honest
+	// "decomposed into N children: #a, #b, #c" summary instead of a generic
+	// "no changes were made" comment on a decomposed parent.
+	ChildIssues []CreatedIssue
 	// IntentWarning contains the reason if the intent judge flagged a mismatch.
 	// When set, the PR was created despite intent misalignment (after retry failed).
 	IntentWarning string
@@ -1791,6 +1832,11 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		)
 		r.reportProgress(task.ID, "Planning", 10, "Running epic planning...")
 
+		// GH-3938: record that Claude is actually being invoked (planning mode)
+		// before the fallible planFn call, so a trace never dead-ends at
+		// spec_validated even when planning itself fails below.
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageClaudeStarted, "invoking planning model")
+
 		planFn := r.planEpicFn
 		if planFn == nil {
 			planFn = r.PlanEpic
@@ -1875,13 +1921,14 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 							)
 							r.reportProgress(task.ID, "Complete", 100, "All sub-issues already completed")
 							return &ExecutionResult{
-								TaskID:    task.ID,
-								Success:   true,
-								Output:    fmt.Sprintf("Epic already completed: %d sub-issues recovered", len(recovered)),
-								Duration:  time.Since(start),
-								IsEpic:    true,
-								EpicPlan:  plan,
-								ModelName: r.fallbackModelName(),
+								TaskID:      task.ID,
+								Success:     true,
+								Output:      fmt.Sprintf("Epic already completed: %d sub-issues recovered", len(recovered)),
+								Duration:    time.Since(start),
+								IsEpic:      true,
+								EpicPlan:    plan,
+								ChildIssues: recovered,
+								ModelName:   r.fallbackModelName(),
 							}, nil
 						}
 						// Filter to open children only and continue execution.
@@ -1908,6 +1955,12 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 					}
 				}
 
+				// GH-3938: record the decomposition milestone with the actual dispatched
+				// child issue list (not just the planned subtask count), so the eventual
+				// parent comment can report an honest "decomposed into N children: ..."
+				// summary instead of a misleading "no changes were made".
+				r.recordExecutionEvent(task.LogExecutionID(), memory.StageDecomposed, decomposedEventDetail(issues))
+
 				r.reportProgress(task.ID, "Executing", 50, fmt.Sprintf("Executing %d sub-issues sequentially...", len(issues)))
 
 				// GH-412: Execute sub-issues sequentially
@@ -1916,7 +1969,11 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				// GH-3779: also collect each child's terminal state so the PR-finalize
 				// guard below can tell a genuine no-op epic (all children no-op'd) from
 				// one whose deliverables shipped entirely via child sub-issue PRs.
-				childStates, err := r.executeSubIssuesTracked(ctx, task, issues, executionPath, task.ProjectPath)
+				// GH-3938: also collect aggregated child token/cost/diff metrics so the
+				// epic-parent's own execution row reflects real Claude usage instead of
+				// persisting as tokens_output=0 for a run that may have taken tens of
+				// minutes across its children.
+				childStates, childMetrics, err := r.executeSubIssuesTracked(ctx, task, issues, executionPath, task.ProjectPath)
 				if err != nil {
 					return &ExecutionResult{
 						TaskID:   task.ID,
@@ -1933,14 +1990,16 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				// GH-2428: Set ModelName so the saved row distinguishes "epic
 				// orchestrator (no backend call)" from "telemetry-missing".
 				epicResult := &ExecutionResult{
-					TaskID:    task.ID,
-					Success:   true,
-					Output:    fmt.Sprintf("Epic completed: %d sub-issues executed", len(issues)),
-					Duration:  time.Since(start),
-					IsEpic:    true,
-					EpicPlan:  plan,
-					ModelName: r.fallbackModelName(),
+					TaskID:      task.ID,
+					Success:     true,
+					Output:      fmt.Sprintf("Epic completed: %d sub-issues executed", len(issues)),
+					Duration:    time.Since(start),
+					IsEpic:      true,
+					EpicPlan:    plan,
+					ChildIssues: issues,
+					ModelName:   r.fallbackModelName(),
 				}
+				childMetrics.applyTo(epicResult)
 
 				if task.CreatePR && task.Branch != "" {
 					// TASK-359 Layer 1: route epic finalization through the same error
@@ -1953,6 +2012,14 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				} else {
 					r.reportProgress(task.ID, "Complete", 100, "Epic completed successfully")
 				}
+
+				// GH-3938: zero-artifact no-op guard. An epic exists to get real work
+				// done via its children (or its own branch) — a "successful" epic that
+				// consumed no tokens, changed no files, and produced no commit/PR
+				// anywhere did no real work, following the GH-3224 ghost-SHA guard shape
+				// (bug_pilot_ghost_closes.md): classify as no_op instead of completed.
+				applyZeroArtifactNoOpGuard(epicResult, fmt.Sprintf("epic %s across %d sub-issue(s)", task.ID, len(issues)))
+
 				return epicResult, nil
 			}
 		} // else: plan succeeded
@@ -2270,6 +2337,14 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 
 	// GH-1599: Log implementation phase
 	r.saveLogEntry(task.LogExecutionID(), "info", "Implementing changes...")
+
+	// GH-3938: record that Claude is about to be invoked for direct
+	// implementation (as opposed to epic planning, which records the same
+	// Stage at its own call site), followed immediately by the
+	// implementation-phase milestone — closes the fail-silent gap where a
+	// trace dead-ended at spec_validated with no evidence Claude ever ran.
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StageClaudeStarted, fmt.Sprintf("invoking backend: %s", r.backend.Name()))
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StageImplementationStarted, "implementing changes")
 
 	// TASK-308: Stall detection — track last event time and spawn a watchdog.
 	var (
@@ -4053,6 +4128,18 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				log.Debug("Stored task completion memory", slog.String("task_id", task.ID))
 			}
 		}
+	}
+
+	// GH-3938: zero-artifact no-op guard for direct-commit runs. The CreatePR
+	// retry path above (the "no commits" guard, ~runner.go:2920) already
+	// catches the common CreatePR-branch case; this is a defense-in-depth net
+	// for task.DirectCommit workflows and any other path that reaches here
+	// still claiming success with literally no observable output. Scoped to
+	// tasks that actually expected a deliverable (CreatePR or DirectCommit) so
+	// legitimate no-code-required runs (Q&A, LocalMode, planning-only) are not
+	// misclassified.
+	if task.CreatePR || task.DirectCommit {
+		applyZeroArtifactNoOpGuard(result, fmt.Sprintf("task %s", task.ID))
 	}
 
 	// GH-1813: Record execution outcome for pattern learning (self-improvement)

--- a/internal/executor/runner_gh3938_test.go
+++ b/internal/executor/runner_gh3938_test.go
@@ -1,0 +1,391 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// tokenFakeBackend is a minimal Backend that returns a configurable token
+// count without spawning a real subprocess, used to simulate "Claude was
+// actually invoked and consumed tokens" (GH-3938).
+type tokenFakeBackend struct {
+	tokensIn, tokensOut int64
+}
+
+func (b tokenFakeBackend) Name() string      { return "token-fake" }
+func (b tokenFakeBackend) IsAvailable() bool { return true }
+func (b tokenFakeBackend) Execute(_ context.Context, _ ExecuteOptions) (*BackendResult, error) {
+	return &BackendResult{
+		Success:      true,
+		Output:       "fake output",
+		TokensInput:  b.tokensIn,
+		TokensOutput: b.tokensOut,
+	}, nil
+}
+
+// TestDispatcher_SyntheticDispatch_TokenStream_FullEventSequence covers GH-3938
+// acceptance (a): a fake Claude stream that actually reports token usage must
+// (1) persist tokens_output/tokens_input > 0 on the executions row — the
+// "37-minute run must not persist as tokens_output=0" token-harvester fix —
+// and (2) produce the full execution_events lifecycle past spec_validated
+// (claude_started, implementation_started, and the terminal completed event),
+// closing the fail-silent regression where a trace dead-ended at spec_validated.
+func TestDispatcher_SyntheticDispatch_TokenStream_FullEventSequence(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunnerWithBackend(tokenFakeBackend{tokensIn: 5000, tokensOut: 3200})
+	runner.skipPreflightChecks = true
+	runner.SetLogStore(store)
+	runner.SetRecordingEnabled(false)
+
+	dispatcher := NewDispatcher(store, runner, nil)
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	task := &Task{
+		ID:          "GH-SYNTH-TOKENS",
+		Title:       "Synthetic dispatch with real token usage",
+		Description: "GH-3938 fake Claude stream coverage",
+		ProjectPath: t.TempDir(),
+	}
+
+	execID, err := dispatcher.QueueTask(context.Background(), task)
+	if err != nil {
+		t.Fatalf("failed to queue task: %v", err)
+	}
+
+	exec := waitForTerminalStatus(t, store, execID, 10*time.Second)
+	if exec.Status != "completed" {
+		t.Fatalf("expected status completed, got %q (error: %s)", exec.Status, exec.Error)
+	}
+
+	// SaveExecutionMetrics writes tokens in a follow-up store call after the
+	// status flip to "completed" — poll briefly instead of asserting
+	// immediately to avoid a race against that write.
+	deadline := time.Now().Add(5 * time.Second)
+	for exec.TokensOutput == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+		exec, err = store.GetExecution(execID)
+		if err != nil {
+			t.Fatalf("GetExecution failed: %v", err)
+		}
+	}
+
+	if exec.TokensOutput <= 0 {
+		t.Fatalf("expected executions.tokens_output > 0 for a run where Claude was actually invoked, got %d", exec.TokensOutput)
+	}
+	if exec.TokensInput <= 0 {
+		t.Fatalf("expected executions.tokens_input > 0, got %d", exec.TokensInput)
+	}
+
+	events, err := store.ListExecutionEvents(execID)
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+
+	wantStages := []memory.Stage{
+		memory.StageRunning,
+		memory.StageSpecValidated,
+		memory.StageClaudeStarted,
+		memory.StageImplementationStarted,
+		memory.StageCompleted,
+	}
+	if len(events) != len(wantStages) {
+		var gotStages []memory.Stage
+		for _, e := range events {
+			gotStages = append(gotStages, e.Stage)
+		}
+		t.Fatalf("got %d events %v, want %d %v", len(events), gotStages, len(wantStages), wantStages)
+	}
+	for i, want := range wantStages {
+		if events[i].Stage != want {
+			t.Errorf("event[%d].Stage = %q, want %q", i, events[i].Stage, want)
+		}
+	}
+}
+
+// TestApplyZeroArtifactNoOpGuard covers GH-3938 acceptance (b): a run that
+// claims success but shows zero tokens, zero files, and no commit/PR must be
+// reclassified as no_op instead of completed — mirroring the GH-3224 ghost-SHA
+// guard shape (bug_pilot_ghost_closes.md) — while a run with any real artifact
+// (tokens, files, commit, or PR) must be left untouched.
+func TestApplyZeroArtifactNoOpGuard(t *testing.T) {
+	tests := []struct {
+		name        string
+		result      *ExecutionResult
+		wantSuccess bool
+		wantOutcome string
+	}{
+		{
+			name:        "zero tokens, zero files, no commit, no PR — reclassified as no_op",
+			result:      &ExecutionResult{Success: true},
+			wantSuccess: false,
+			wantOutcome: "no_op",
+		},
+		{
+			name:        "real output tokens — left untouched",
+			result:      &ExecutionResult{Success: true, TokensInput: 100, TokensOutput: 50},
+			wantSuccess: true,
+			wantOutcome: "",
+		},
+		{
+			name:        "files changed — left untouched",
+			result:      &ExecutionResult{Success: true, FilesChanged: 2},
+			wantSuccess: true,
+			wantOutcome: "",
+		},
+		{
+			name:        "commit present — left untouched",
+			result:      &ExecutionResult{Success: true, CommitSHA: "abc1234"},
+			wantSuccess: true,
+			wantOutcome: "",
+		},
+		{
+			name:        "PR present — left untouched",
+			result:      &ExecutionResult{Success: true, PRUrl: "https://github.com/org/repo/pull/1"},
+			wantSuccess: true,
+			wantOutcome: "",
+		},
+		{
+			name:        "already failed — left untouched (guard is success-only)",
+			result:      &ExecutionResult{Success: false, Error: "some other failure"},
+			wantSuccess: false,
+			wantOutcome: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyZeroArtifactNoOpGuard(tt.result, "test task")
+			if tt.result.Success != tt.wantSuccess {
+				t.Errorf("Success = %v, want %v", tt.result.Success, tt.wantSuccess)
+			}
+			if tt.result.Outcome != tt.wantOutcome {
+				t.Errorf("Outcome = %q, want %q", tt.result.Outcome, tt.wantOutcome)
+			}
+			if tt.wantOutcome == "no_op" {
+				if !strings.Contains(tt.result.Error, "no new commit produced") {
+					t.Errorf("Error = %q, want it to contain the shared no-op marker %q", tt.result.Error, "no new commit produced")
+				}
+				if status := TerminalStatus(tt.result); status != "no_op" {
+					t.Errorf("TerminalStatus = %q, want no_op", status)
+				}
+			}
+		})
+	}
+}
+
+// TestExecuteWithOptions_ZeroArtifactNoOpGuard drives GH-3938 acceptance (b)
+// through the real Runner.Execute path: a task that expects a deliverable
+// (CreatePR) but whose backend produces no tokens, no files, and no commit/PR
+// must come back Success=false/Outcome=no_op instead of completed — and a
+// task that never expected a deliverable (plain read-only/LocalMode-style
+// run) must be left as a legitimate success. The DirectCommit branch of the
+// same guard (task.CreatePR || task.DirectCommit scoping in runner.go) is
+// covered at the unit level by TestApplyZeroArtifactNoOpGuard instead of here,
+// since exercising DirectCommit's git-push path needs a real remote.
+func TestExecuteWithOptions_ZeroArtifactNoOpGuard(t *testing.T) {
+	tests := []struct {
+		name        string
+		createPR    bool
+		wantSuccess bool
+		wantOutcome string
+	}{
+		{
+			name:        "CreatePR expected a deliverable — zero output trips no_op",
+			createPR:    true,
+			wantSuccess: false,
+			wantOutcome: "no_op",
+		},
+		{
+			name:        "no deliverable expected — zero output is a legitimate success",
+			createPR:    false,
+			wantSuccess: true,
+			wantOutcome: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewRunnerWithBackend(tokenFakeBackend{})
+			runner.skipPreflightChecks = true
+
+			task := &Task{
+				ID:          "GH-ZERO-OUTPUT",
+				Title:       "Task that produces nothing",
+				ProjectPath: t.TempDir(),
+				CreatePR:    tt.createPR,
+			}
+
+			result, err := runner.Execute(context.Background(), task)
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if result.Success != tt.wantSuccess {
+				t.Errorf("Success = %v, want %v (error: %s)", result.Success, tt.wantSuccess, result.Error)
+			}
+			if result.Outcome != tt.wantOutcome {
+				t.Errorf("Outcome = %q, want %q", result.Outcome, tt.wantOutcome)
+			}
+			if tt.wantOutcome == "no_op" {
+				if !strings.Contains(result.Error, "no new commit produced") {
+					t.Errorf("Error = %q, want it to contain the shared no-op marker", result.Error)
+				}
+				if status := TerminalStatus(result); status != "no_op" {
+					t.Errorf("TerminalStatus = %q, want no_op", status)
+				}
+			}
+		})
+	}
+}
+
+// TestDecomposedEventDetail covers the StageDecomposed detail string (GH-3938):
+// "decomposed into N children: #a, #b, #c", sourced from the actual dispatched
+// child issues rather than the planned subtask count.
+func TestDecomposedEventDetail(t *testing.T) {
+	tests := []struct {
+		name   string
+		issues []CreatedIssue
+		want   string
+	}{
+		{
+			name:   "github issues",
+			issues: []CreatedIssue{{Number: 101}, {Number: 102}, {Number: 103}},
+			want:   "decomposed into 3 children: #101, #102, #103",
+		},
+		{
+			name:   "non-github identifiers",
+			issues: []CreatedIssue{{Identifier: "APP-1"}, {Identifier: "APP-2"}},
+			want:   "decomposed into 2 children: APP-1, APP-2",
+		},
+		{
+			name:   "no children",
+			issues: nil,
+			want:   "decomposed into 0 children: ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decomposedEventDetail(tt.issues)
+			if got != tt.want {
+				t.Errorf("decomposedEventDetail() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunner_Execute_EpicDecomposition_RecordsChildrenAndAggregatesTokens
+// covers GH-3938 acceptance (c) plus the token-harvester fix together: an epic
+// parent that dispatches real child sub-issue work must (1) record the
+// StageDecomposed execution_event carrying the actual child issue list, (2)
+// carry those same children on ExecutionResult.ChildIssues so the completion
+// comment can report an honest "decomposed into N children: ..." summary
+// instead of a misleading "no changes were made", and (3) aggregate each
+// child's real token usage onto the epic-parent's own result instead of
+// persisting as tokens_output=0.
+func TestRunner_Execute_EpicDecomposition_RecordsChildrenAndAggregatesTokens(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	r := NewRunner()
+	r.skipPreflightChecks = true
+	r.dryRun = true
+	r.SetLogStore(store)
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "exec-epic-gh9002",
+		TaskID:      "GH-9002",
+		ProjectPath: "/project",
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	// openSubIssueCheck returns true → CreateSubIssues returns ErrSubIssuesAlreadyExist,
+	// so recoverSubIssuesFn supplies the child list without touching the real gh CLI.
+	r.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) {
+		return true, nil
+	}
+
+	r.recoverSubIssuesFn = func(_ context.Context, _, _ string) ([]CreatedIssue, error) {
+		return []CreatedIssue{
+			{Number: 21, Identifier: "21", URL: "https://github.com/o/r/issues/21", State: "open",
+				Subtask: PlannedSubtask{Title: "feat(adapters): add telegram bot", Description: "Wire bot client in internal/adapters/telegram/bot.go"}},
+		}, nil
+	}
+
+	// The child sub-issue "actually ran" and consumed real tokens.
+	r.executeFunc = func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{TaskID: task.ID, Success: true, TokensInput: 4000, TokensOutput: 2500}, nil
+	}
+
+	r.planEpicFn = func(_ context.Context, _ *Task, _ string) (*EpicPlan, error) {
+		return &EpicPlan{
+			ParentTask: &Task{ID: "GH-9002"},
+			Subtasks: []PlannedSubtask{
+				{Order: 1, Title: "feat(gateway): add websocket handler", Description: "Implement upgrade handler in internal/gateway/server.go"},
+				{Order: 2, Title: "feat(adapters): add telegram bot", Description: "Wire bot client in internal/adapters/telegram/bot.go"},
+			},
+		}, nil
+	}
+
+	task := &Task{
+		ID:          "GH-9002",
+		Title:       "[epic] decomposition records children and aggregates tokens",
+		ExecutionID: "exec-epic-gh9002",
+	}
+
+	result, err := r.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if !result.IsEpic {
+		t.Error("expected IsEpic=true")
+	}
+	if !result.Success {
+		t.Errorf("expected Success=true (child delivered real tokens), got false — error: %s", result.Error)
+	}
+	if len(result.ChildIssues) != 1 || result.ChildIssues[0].Number != 21 {
+		t.Errorf("expected ChildIssues=[#21], got %+v", result.ChildIssues)
+	}
+	if result.TokensOutput <= 0 {
+		t.Errorf("expected epic result to aggregate the child's tokens_output, got %d", result.TokensOutput)
+	}
+	if result.TokensInput <= 0 {
+		t.Errorf("expected epic result to aggregate the child's tokens_input, got %d", result.TokensInput)
+	}
+
+	events, err := store.ListExecutionEvents("exec-epic-gh9002")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	var decomposedDetail string
+	found := false
+	for _, e := range events {
+		if e.Stage == memory.StageDecomposed {
+			found = true
+			decomposedDetail = e.Detail
+		}
+	}
+	if !found {
+		var stages []memory.Stage
+		for _, e := range events {
+			stages = append(stages, e.Stage)
+		}
+		t.Fatalf("expected a StageDecomposed event, got stages %v", stages)
+	}
+	if want := "decomposed into 1 children: #21"; decomposedDetail != want {
+		t.Errorf("StageDecomposed detail = %q, want %q", decomposedDetail, want)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -689,8 +689,18 @@ func (s *Store) ListExecutionsForTask(taskID string) ([]*Execution, error) {
 type Stage string
 
 const (
-	StageQueued           Stage = "queued"
-	StageSpecValidated    Stage = "spec_validated"
+	StageQueued        Stage = "queued"
+	StageSpecValidated Stage = "spec_validated"
+	// StageClaudeStarted marks the moment Claude is actually invoked (planning
+	// or implementation). Closes the fail-silent gap where a trace dead-ended
+	// at spec_validated with no evidence Claude ever ran (GH-3938).
+	StageClaudeStarted Stage = "claude_started"
+	// StageImplementationStarted marks a non-epic task moving from "Claude
+	// invoked" into the implementation phase (GH-3938).
+	StageImplementationStarted Stage = "implementation_started"
+	// StageDecomposed marks an epic parent splitting into child issues; the
+	// event detail carries the child issue list (GH-3938).
+	StageDecomposed       Stage = "decomposed"
 	StageRunning          Stage = "running"
 	StageCommit           Stage = "commit"
 	StagePRCreated        Stage = "pr_created"
@@ -699,10 +709,14 @@ const (
 	StageAwaitingApproval Stage = "awaiting_approval"
 	StageMerged           Stage = "merged"
 	StageReleased         Stage = "released"
-	StageFailed           Stage = "failed"
-	StageNoOp             Stage = "no_op"
-	StageSkipped          Stage = "skipped"
-	StageStalled          Stage = "stalled"
+	// StageCompleted is the generic terminal-success milestone (GH-3938):
+	// unlike StagePRCreated/StageCommit it fires regardless of whether the run
+	// produced a PR, so `pilot trace` always has a terminal event on success.
+	StageCompleted Stage = "completed"
+	StageFailed    Stage = "failed"
+	StageNoOp      Stage = "no_op"
+	StageSkipped   Stage = "skipped"
+	StageStalled   Stage = "stalled"
 )
 
 // Event represents a single stage-transition record for an execution.


### PR DESCRIPTION
## Summary

Closes the fail-silent regression on the epic-parent path described in GH-3938:

- **Execution-events trace**: added `claude_started`, `decomposed`, `implementation_started`, and a generic terminal `completed` `Stage`, wired into both the epic-planning and direct-execution paths plus the dispatcher's terminal-success site (previously only fired when a PR existed). `pilot trace <task-id>` no longer dead-ends at `spec_validated` for epic parents or PR-less direct-commit runs.
- **Token harvester**: each child sub-issue's real token/cost/diff usage is now aggregated onto the epic-parent's own `ExecutionResult` instead of being discarded once its terminal status string was recorded — a long-running epic no longer persists `tokens_output=0`.
- **Zero-artifact no-op guard**: a "successful" result with zero tokens, zero files changed, and no commit/PR anywhere is reclassified as `no_op` (following the GH-3224 ghost-SHA guard shape) instead of silently completing. Scoped to epics and to direct tasks that actually expected a deliverable (`CreatePR`/`DirectCommit`), so legitimate no-code-required runs aren't misclassified.
- **Honest decomposition comment**: `ExecutionResult.ChildIssues` now carries the real dispatched/recovered child issue list, and the completion comment reports "decomposed into N children: #a, #b, #c" instead of a blank-looking table for parents that shipped no PR of their own.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `go test ./...` — all 47 packages pass
- [x] New table-driven tests in `internal/executor/runner_gh3938_test.go`:
  - full event sequence + token persistence via a fake token-producing backend
  - `applyZeroArtifactNoOpGuard` classification table
  - `Runner.Execute` zero-output guard scoped by `CreatePR`/`DirectCommit`
  - `decomposedEventDetail` formatting
  - epic decomposition recording children + aggregating child tokens
- [x] New/updated tests in `cmd/pilot`: decomposed-children comment rendering, and a compatibility pin between the new guard's error text and the existing GH-3513 `noOpErrorMarker` text-search close-guard
- [x] Updated existing `TestDispatcher_SyntheticDispatch_SuccessEventSequence` / `TestDispatchSuccessStage` for the new unconditional terminal event