### PR TITLE
feat(autopilot): close epic parents on poll cycle once children ship

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2887,6 +2887,11 @@ func (c *Controller) startReconciler(ctx context.Context) {
 			return
 		case <-ticker.C:
 			c.reconcileOrphanPRs(ctx)
+			// GH-3939: poll-cycle check for decomposed epic-parents whose
+			// children are all closed and merged. Runs on this 60s cadence
+			// rather than the (sometimes 10s) main CI ticker to stay well
+			// under the GitHub Search API's rate limit.
+			c.pollCloseEpicParents(ctx)
 		}
 	}
 }

--- a/internal/autopilot/epic_close.go
+++ b/internal/autopilot/epic_close.go
@@ -1,0 +1,213 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// epicChild is one child issue of a decomposed epic-parent, as returned by
+// allSubIssueStates: its number and whether it is still open. GH-3939.
+type epicChild struct {
+	Number int
+	Open   bool
+}
+
+// allSubIssueStates queries the native GitHub sub-issues GraphQL API for every
+// child of parentNum, regardless of state. Unlike GetOpenSubIssueNumbers
+// (which filters to OPEN only, since the merge-triggered maybeCloseParentIssue
+// and startup-only recoverStaleParentIssues paths only need a count of what's
+// still blocking), pollCloseEpicParents needs the CLOSED children too, so it
+// can verify each one individually shipped via a merged PR rather than trust
+// "closed" alone. hasNativeLinks is false when the parent has no native
+// sub-issue links at all (totalCount==0) — the poll-cycle check then has no
+// concrete child list to verify and skips the parent, leaving it to the
+// coarser count-based recovery/merge paths. GH-3939.
+func (c *Controller) allSubIssueStates(ctx context.Context, parentNum int) (children []epicChild, hasNativeLinks bool, err error) {
+	parentID, err := c.ghClient.GetIssueNodeID(ctx, c.owner, c.repo, parentNum)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolve parent node ID: %w", err)
+	}
+
+	const query = `query($issueID: ID!) {
+		node(id: $issueID) {
+			... on Issue {
+				subIssues(first: 100) {
+					totalCount
+					nodes {
+						number
+						state
+					}
+				}
+			}
+		}
+	}`
+
+	var result struct {
+		Node struct {
+			SubIssues struct {
+				TotalCount int `json:"totalCount"`
+				Nodes      []struct {
+					Number int    `json:"number"`
+					State  string `json:"state"`
+				} `json:"nodes"`
+			} `json:"subIssues"`
+		} `json:"node"`
+	}
+
+	if err := c.ghClient.ExecuteGraphQL(ctx, query, map[string]interface{}{"issueID": parentID}, &result); err != nil {
+		return nil, false, fmt.Errorf("query sub-issues for %s/%s#%d: %w", c.owner, c.repo, parentNum, err)
+	}
+
+	if result.Node.SubIssues.TotalCount == 0 {
+		return nil, false, nil
+	}
+
+	children = make([]epicChild, 0, len(result.Node.SubIssues.Nodes))
+	for _, n := range result.Node.SubIssues.Nodes {
+		children = append(children, epicChild{Number: n.Number, Open: n.State == "OPEN"})
+	}
+	return children, true, nil
+}
+
+// pollCloseEpicParents runs on autopilot's periodic poll cycle (wired into
+// startReconciler) and closes decomposed epic-parent issues once every child
+// is BOTH closed and shipped via a merged PR, posting a summary comment that
+// names each merged PR. GH-3939.
+//
+// This is a stricter gate than openSubIssueCount (used by the merge-triggered
+// maybeCloseParentIssue and the startup-only recoverStaleParentIssues): those
+// two only check that no child issue is still OPEN, so a child that was
+// closed without shipping (wontfix, duplicate, or a PR closed instead of
+// merged) would let the parent close having delivered less than the epic
+// promised. pollCloseEpicParents additionally requires a merged PR per child.
+func (c *Controller) pollCloseEpicParents(ctx context.Context) {
+	const maxCandidates = 50
+	candidates, err := c.ghClient.SearchOpenPilotIssuesWithSubIssues(ctx, c.owner, c.repo, maxCandidates)
+	if err != nil {
+		c.log.Warn("pollCloseEpicParents: search for epic-parent candidates failed", "error", err)
+		return
+	}
+
+	for _, parentNum := range candidates {
+		c.closeEpicParentIfChildrenShipped(ctx, parentNum)
+	}
+}
+
+// closeEpicParentIfChildrenShipped is the per-parent worker for
+// pollCloseEpicParents. Every close-guard veto (an open child, a closed child
+// with no merged PR, an open PR still referencing the parent, or a lookup
+// failure) is logged with an explicit reason and the function returns without
+// touching the parent — no retry, no repeated GitHub writes. Seeing the same
+// veto reason on consecutive ticks is expected while an epic is in progress;
+// it is not evidence of a stuck loop, so callers scraping these logs for a
+// dedupe/suppression signal can key off the reason string instead of
+// interpreting "checked again" as "something is wrong". GH-3939.
+func (c *Controller) closeEpicParentIfChildrenShipped(ctx context.Context, parentNum int) {
+	issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, parentNum)
+	if err != nil {
+		c.log.Warn("pollCloseEpicParents: veto — failed to fetch parent issue",
+			"parent", parentNum, "reason", err.Error())
+		return
+	}
+	if issue == nil || issue.State == "closed" {
+		// Already closed: a no-op, not a veto — nothing pending for a dedupe
+		// path to suppress.
+		return
+	}
+
+	// Close-guard: an open PR that still references the parent issue number
+	// itself (as opposed to one of its children) means work against this
+	// epic hasn't landed yet, even if every decomposed child is done.
+	openParentPRs, err := c.ghClient.SearchOpenPRsForIssue(ctx, c.owner, c.repo, parentNum)
+	if err != nil {
+		c.log.Warn("pollCloseEpicParents: veto — failed to check for open PRs referencing parent",
+			"parent", parentNum, "reason", err.Error())
+		return
+	}
+	if len(openParentPRs) > 0 {
+		c.log.Warn("pollCloseEpicParents: veto — an open PR still references the parent issue",
+			"parent", parentNum, "reason", "open PR references parent", "open_pr_count", len(openParentPRs))
+		return
+	}
+
+	children, hasNativeLinks, err := c.allSubIssueStates(ctx, parentNum)
+	if err != nil {
+		c.log.Warn("pollCloseEpicParents: veto — failed to list child issues",
+			"parent", parentNum, "reason", err.Error())
+		return
+	}
+	if !hasNativeLinks {
+		c.log.Debug("pollCloseEpicParents: no native sub-issue links, deferring to count-based recovery path",
+			"parent", parentNum)
+		return
+	}
+
+	var mergedPRs []string
+	for _, child := range children {
+		if child.Open {
+			// Expected, high-frequency state while an epic is still in progress —
+			// log at Debug so it never spams Info/Warn on every poll cycle.
+			c.log.Debug("pollCloseEpicParents: child issue still open, deferring parent close",
+				"parent", parentNum, "child", child.Number)
+			return
+		}
+
+		prs, err := c.ghClient.SearchPRsForIssue(ctx, c.owner, c.repo, child.Number)
+		if err != nil {
+			c.log.Warn("pollCloseEpicParents: veto — merged-PR lookup failed for closed child",
+				"parent", parentNum, "child", child.Number, "reason", err.Error())
+			return
+		}
+
+		mergedURL := ""
+		for _, pr := range prs {
+			if pr.Merged {
+				mergedURL = pr.HTMLURL
+				break
+			}
+		}
+		if mergedURL == "" {
+			c.log.Warn("pollCloseEpicParents: veto — child closed but no merged PR references it",
+				"parent", parentNum, "child", child.Number, "reason", "child closed without a merged PR")
+			return
+		}
+		mergedPRs = append(mergedPRs, mergedURL)
+	}
+
+	c.closeParentWithMergedPRs(ctx, parentNum, mergedPRs)
+}
+
+// closeParentWithMergedPRs closes an epic-parent issue whose children are all
+// closed and individually verified merged, posting a summary comment that
+// names every merged PR. Mirrors closeParentNow's label cleanup but with a
+// PR-specific comment instead of the generic "sub-issues complete" message.
+// All errors are logged as warnings without blocking the rest of the poll
+// cycle. GH-3939.
+func (c *Controller) closeParentWithMergedPRs(ctx context.Context, parentNum int, mergedPRs []string) {
+	c.log.Info("pollCloseEpicParents: all children closed and merged, closing epic parent",
+		"parent", parentNum, "merged_prs", mergedPRs)
+
+	if err := c.ghClient.AddLabels(ctx, c.owner, c.repo, parentNum, []string{"pilot-done"}); err != nil {
+		c.log.Warn("pollCloseEpicParents: failed to add pilot-done label", "parent", parentNum, "error", err)
+	}
+	for _, stale := range []string{"pilot-failed", "pilot-in-progress", "pilot-blocked"} {
+		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, parentNum, stale); err != nil {
+			c.log.Warn("pollCloseEpicParents: failed to remove label", "label", stale, "parent", parentNum, "error", err)
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("All child issues for GH-%d are closed and shipped. Closing parent issue automatically.\n\n", parentNum))
+	sb.WriteString("Merged PRs:\n")
+	for _, prURL := range mergedPRs {
+		sb.WriteString(fmt.Sprintf("- %s\n", prURL))
+	}
+	if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, parentNum, sb.String()); err != nil {
+		c.log.Warn("pollCloseEpicParents: failed to post summary comment", "parent", parentNum, "error", err)
+	}
+
+	if err := c.ghClient.UpdateIssueState(ctx, c.owner, c.repo, parentNum, "closed"); err != nil {
+		c.log.Warn("pollCloseEpicParents: failed to close parent issue", "parent", parentNum, "error", err)
+	}
+}

--- a/internal/autopilot/epic_close_test.go
+++ b/internal/autopilot/epic_close_test.go
@@ -1,0 +1,374 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// childFixture describes one child issue of a fixture epic-parent, along with
+// the PRs the mock server reports for it when queried by SearchPRsForIssue.
+type childFixture struct {
+	number int
+	closed bool
+	prs    []prFixture
+}
+
+type prFixture struct {
+	number int
+	merged bool
+	url    string
+}
+
+// newEpicCloseTestServer builds an httptest server that fakes the GitHub REST
+// + GraphQL surface closeEpicParentIfChildrenShipped depends on for a single
+// parent issue number (100): GetIssue/GetIssueNodeID, the native sub-issues
+// GraphQL query, SearchOpenPRsForIssue, SearchPRsForIssue, and the
+// label/comment/close mutations. Returns the server plus recorders the test
+// can assert against.
+func newEpicCloseTestServer(t *testing.T, parentClosed bool, openParentPRs int, children []childFixture) (*httptest.Server, *bool, *string) {
+	t.Helper()
+
+	closeCalled := false
+	var commentBody string
+
+	childByNumber := map[int]childFixture{}
+	for _, c := range children {
+		childByNumber[c.number] = c
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/100":
+			state := "open"
+			if parentClosed {
+				state = "closed"
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"number":100,"node_id":"node_100","state":%q}`, state)
+
+		case r.Method == http.MethodGet && r.URL.Path == "/search/issues" && strings.Contains(r.URL.Query().Get("q"), "is:open"):
+			// SearchOpenPRsForIssue for the parent itself.
+			items := make([]map[string]interface{}, openParentPRs)
+			for i := range items {
+				items[i] = map[string]interface{}{
+					"id": i + 1, "number": 900 + i, "title": "manual PR", "state": "open",
+					"html_url": fmt.Sprintf("https://github.com/owner/repo/pull/%d", 900+i),
+				}
+			}
+			resp := map[string]interface{}{"total_count": len(items), "items": items}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+			// SearchPRsForIssue for a child issue: "repo:owner/repo is:pr #<num>"
+			var childNum int
+			_, _ = fmt.Sscanf(r.URL.Query().Get("q"), "repo:owner/repo is:pr #%d", &childNum)
+			cand := childByNumber[childNum]
+			items := make([]map[string]interface{}, 0, len(cand.prs))
+			for _, pr := range cand.prs {
+				mergedAt := ""
+				if pr.merged {
+					mergedAt = "2026-01-01T00:00:00Z"
+				}
+				items = append(items, map[string]interface{}{
+					"id": pr.number, "number": pr.number, "title": "fix: work", "state": "closed",
+					"html_url":     pr.url,
+					"pull_request": map[string]interface{}{"merged_at": mergedAt},
+				})
+			}
+			resp := map[string]interface{}{"total_count": len(items), "items": items}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			// allSubIssueStates native sub-issues query.
+			nodes := make([]map[string]interface{}, 0, len(children))
+			for _, c := range children {
+				state := "OPEN"
+				if c.closed {
+					state = "CLOSED"
+				}
+				nodes = append(nodes, map[string]interface{}{"number": c.number, "state": state})
+			}
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"node": map[string]interface{}{
+						"subIssues": map[string]interface{}{
+							"totalCount": len(nodes),
+							"nodes":      nodes,
+						},
+					},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/labels/"):
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			commentBody = body.Body
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":1}`))
+
+		case r.Method == http.MethodPatch && r.URL.Path == "/repos/owner/repo/issues/100":
+			closeCalled = true
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+
+	return server, &closeCalled, &commentBody
+}
+
+// TestCloseEpicParentIfChildrenShipped covers the GH-3939 poll-cycle epic
+// close check's core scenarios:
+//
+//	(a) all children closed and merged -> parent closes in one call
+//	(b) one child still open -> parent stays open, no WARN-level veto log
+//	(c) a closed child with no merged PR -> vetoed, WARN log names the reason
+//	(d) parent already closed -> no-op
+func TestCloseEpicParentIfChildrenShipped(t *testing.T) {
+	tests := []struct {
+		name            string
+		parentClosed    bool
+		openParentPRs   int
+		children        []childFixture
+		wantClosed      bool
+		wantCommentSubs []string // substrings the summary comment must contain
+		wantWarnLog     bool
+		wantWarnSubstr  string
+		wantNoWarnLog   bool
+	}{
+		{
+			name: "all children merged closes parent within one poll cycle",
+			children: []childFixture{
+				{number: 101, closed: true, prs: []prFixture{{number: 201, merged: true, url: "https://github.com/owner/repo/pull/201"}}},
+				{number: 102, closed: true, prs: []prFixture{{number: 202, merged: true, url: "https://github.com/owner/repo/pull/202"}}},
+			},
+			wantClosed:      true,
+			wantCommentSubs: []string{"pull/201", "pull/202"},
+		},
+		{
+			name: "one child still open leaves parent open without veto log spam",
+			children: []childFixture{
+				{number: 101, closed: false},
+				{number: 102, closed: true, prs: []prFixture{{number: 202, merged: true, url: "https://github.com/owner/repo/pull/202"}}},
+			},
+			wantClosed:    false,
+			wantNoWarnLog: true,
+		},
+		{
+			name: "child closed but PR unmerged vetoes with explicit reason",
+			children: []childFixture{
+				{number: 101, closed: true, prs: []prFixture{{number: 201, merged: false, url: "https://github.com/owner/repo/pull/201"}}},
+			},
+			wantClosed:     false,
+			wantWarnLog:    true,
+			wantWarnSubstr: "child closed without a merged PR",
+		},
+		{
+			name:         "parent already closed is a no-op",
+			parentClosed: true,
+			children: []childFixture{
+				{number: 101, closed: true, prs: []prFixture{{number: 201, merged: true, url: "https://github.com/owner/repo/pull/201"}}},
+			},
+			wantClosed: false,
+		},
+		{
+			name:          "open PR referencing parent vetoes the close",
+			openParentPRs: 1,
+			children: []childFixture{
+				{number: 101, closed: true, prs: []prFixture{{number: 201, merged: true, url: "https://github.com/owner/repo/pull/201"}}},
+			},
+			wantClosed:     false,
+			wantWarnLog:    true,
+			wantWarnSubstr: "open PR references parent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, closeCalled, commentBody := newEpicCloseTestServer(t, tt.parentClosed, tt.openParentPRs, tt.children)
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			logger, buf := newCapturingLogger()
+			c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+			c.log = logger
+
+			c.closeEpicParentIfChildrenShipped(context.Background(), 100)
+
+			if *closeCalled != tt.wantClosed {
+				t.Errorf("parent closed = %v, want %v (log: %s)", *closeCalled, tt.wantClosed, buf.String())
+			}
+
+			for _, sub := range tt.wantCommentSubs {
+				if !strings.Contains(*commentBody, sub) {
+					t.Errorf("summary comment %q missing substring %q", *commentBody, sub)
+				}
+			}
+
+			out := buf.String()
+			if tt.wantNoWarnLog && strings.Contains(out, "level=WARN") {
+				t.Errorf("expected no WARN-level veto log, got: %s", out)
+			}
+			if tt.wantWarnLog {
+				if !strings.Contains(out, "level=WARN") {
+					t.Errorf("expected a WARN-level veto log, got: %s", out)
+				}
+				if tt.wantWarnSubstr != "" && !strings.Contains(out, tt.wantWarnSubstr) {
+					t.Errorf("expected veto log to contain %q, got: %s", tt.wantWarnSubstr, out)
+				}
+			}
+		})
+	}
+}
+
+// TestPollCloseEpicParents_SearchWiring verifies pollCloseEpicParents fetches
+// candidates via SearchOpenPilotIssuesWithSubIssues and drives each one
+// through closeEpicParentIfChildrenShipped, and that a search failure is a
+// logged no-op rather than a panic.
+func TestPollCloseEpicParents_SearchWiring(t *testing.T) {
+	t.Run("closes a candidate returned by search", func(t *testing.T) {
+		closeCalled := false
+		children := []childFixture{
+			{number: 101, closed: true, prs: []prFixture{{number: 201, merged: true, url: "https://github.com/owner/repo/pull/201"}}},
+		}
+		childByNumber := map[int]childFixture{101: children[0]}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+				var body map[string]interface{}
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				query, _ := body["query"].(string)
+
+				if strings.Contains(query, "subIssuesSummary") {
+					// SearchOpenPilotIssuesWithSubIssues: parent #100 is the sole candidate.
+					resp := map[string]interface{}{
+						"data": map[string]interface{}{
+							"repository": map[string]interface{}{
+								"issues": map[string]interface{}{
+									"nodes": []map[string]interface{}{
+										{"number": 100, "subIssuesSummary": map[string]int{"total": 1, "completed": 1}},
+									},
+								},
+							},
+						},
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+					return
+				}
+
+				// allSubIssueStates: parent #100 has one closed child, #101.
+				nodes := make([]map[string]interface{}, 0, len(children))
+				for _, c := range children {
+					state := "OPEN"
+					if c.closed {
+						state = "CLOSED"
+					}
+					nodes = append(nodes, map[string]interface{}{"number": c.number, "state": state})
+				}
+				resp := map[string]interface{}{
+					"data": map[string]interface{}{
+						"node": map[string]interface{}{
+							"subIssues": map[string]interface{}{"totalCount": len(nodes), "nodes": nodes},
+						},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+
+			case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/issues/100":
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprintf(w, `{"number":100,"node_id":"node_100","state":"open"}`)
+
+			case r.Method == http.MethodGet && r.URL.Path == "/search/issues" && strings.Contains(r.URL.Query().Get("q"), "is:open"):
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"total_count":0,"items":[]}`))
+
+			case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+				var childNum int
+				_, _ = fmt.Sscanf(r.URL.Query().Get("q"), "repo:owner/repo is:pr #%d", &childNum)
+				cand := childByNumber[childNum]
+				items := make([]map[string]interface{}, 0, len(cand.prs))
+				for _, pr := range cand.prs {
+					items = append(items, map[string]interface{}{
+						"id": pr.number, "number": pr.number, "title": "fix: work", "state": "closed",
+						"html_url":     pr.url,
+						"pull_request": map[string]interface{}{"merged_at": "2026-01-01T00:00:00Z"},
+					})
+				}
+				resp := map[string]interface{}{"total_count": len(items), "items": items}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("[]"))
+
+			case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/labels/"):
+				w.WriteHeader(http.StatusOK)
+
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id":1}`))
+
+			case r.Method == http.MethodPatch && r.URL.Path == "/repos/owner/repo/issues/100":
+				closeCalled = true
+				w.WriteHeader(http.StatusOK)
+
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+		c.pollCloseEpicParents(context.Background())
+
+		if !closeCalled {
+			t.Error("expected candidate parent #100 to be closed")
+		}
+	})
+
+	t.Run("search failure is a logged no-op", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		logger, buf := newCapturingLogger()
+		c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+		c.log = logger
+
+		c.pollCloseEpicParents(context.Background())
+
+		if !strings.Contains(buf.String(), "search for epic-parent candidates failed") {
+			t.Errorf("expected search-failure log, got: %s", buf.String())
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `pollCloseEpicParents`, run every 60s from `startReconciler`, which inspects decomposed epic-parent issues (native GitHub sub-issue links) and closes them once every child is BOTH closed AND has a merged PR — stricter than the existing merge-triggered `maybeCloseParentIssue` / startup-only `recoverStaleParentIssues`, which only check that no child is still open (so a child closed without shipping could previously let the parent close early).
- Closing comment names every merged PR (`closeParentWithMergedPRs`).
- Close-guard vetoes (open child, closed child with no merged PR, an open PR still referencing the parent, or a lookup failure) log an explicit reason at Warn; the routine "child still open" case logs at Debug so it doesn't spam every poll cycle while an epic is still in progress.

## Test plan
- [x] `make build`
- [x] `go test ./internal/autopilot/...`
- [x] `make lint`
- New table-driven tests in `internal/autopilot/epic_close_test.go` cover: all children merged (parent closes, PRs named in comment), one child still open (parent stays open, no WARN-level log), child closed but PR unmerged (WARN veto with reason), parent already closed (no-op), and an open PR referencing the parent (veto), plus a search-wiring test for `pollCloseEpicParents`.

GH-3939