### PR TITLE
fix(autopilot): auto-close epic parent when all decomposed children are merged

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -406,6 +406,7 @@
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
+| Poll-cycle epic-parent auto-close | ✅ | autopilot | - | - | `reconcileEpicParents` sweeps open decomposed parents every poll tick, verifying each closed child shipped a merged PR (not just "closed") before closing the parent with a summary comment naming the merged PRs; a closed-without-merge child vetoes the close with an explicit logged reason (GH-3939) |
 
 ## Epic Management
 

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1861,7 +1861,7 @@ func (c *Controller) maybeCloseParentIssue(ctx context.Context, prState *PRState
 		return
 	}
 
-	c.closeParentNow(ctx, parentNum)
+	c.closeParentNow(ctx, parentNum, nil)
 }
 
 // openSubIssueCount returns the number of open sub-issues for a parent,
@@ -1938,7 +1938,23 @@ func (c *Controller) isChildNoOp(issueNum int) bool {
 
 // closeParentNow adds pilot-done, removes stale labels, posts a summary comment,
 // and closes the parent issue. All errors are logged as warnings without propagating.
-func (c *Controller) closeParentNow(ctx context.Context, parentNum int) {
+//
+// mergedPRs optionally names the child PRs that shipped this epic's work (GH-3939,
+// populated by reconcileEpicParent's merged-PR verification); nil/empty falls back
+// to the plain "sub-issues are complete" comment used by the older count-only
+// callers (maybeCloseParentIssue, recoverStaleParentIssues).
+func (c *Controller) closeParentNow(ctx context.Context, parentNum int, mergedPRs []int) {
+	// GH-3939: guard against re-closing an already-closed parent — two close
+	// paths (reactive maybeCloseParentIssue and the periodic reconcileEpicParents
+	// sweep) can both observe "no open children" for the same parent before either
+	// has closed it, which would otherwise double-post the summary comment and
+	// re-run label churn. Fail-open on lookup error so a transient API failure
+	// never blocks a legitimate close.
+	if issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, parentNum); err == nil && strings.EqualFold(issue.State, "closed") {
+		c.log.Debug("closeParentNow: parent already closed, no-op", slog.Int("parent", parentNum))
+		return
+	}
+
 	c.log.Info("closeParentNow: all sub-issues done, closing parent", slog.Int("parent", parentNum))
 
 	// Label cleanup: add pilot-done, remove stale labels.
@@ -1951,8 +1967,11 @@ func (c *Controller) closeParentNow(ctx context.Context, parentNum int) {
 		}
 	}
 
-	// Post summary comment.
+	// Post summary comment, naming the merged child PRs when known.
 	comment := fmt.Sprintf("All sub-issues for GH-%d are complete. Closing parent issue automatically.", parentNum)
+	if len(mergedPRs) > 0 {
+		comment += fmt.Sprintf("\n\nMerged PRs: %s", formatMergedPRRefs(mergedPRs))
+	}
 	if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, parentNum, comment); err != nil {
 		c.log.Warn("closeParentNow: failed to post comment", slog.Int("parent", parentNum), slog.Any("error", err))
 	}
@@ -1961,6 +1980,16 @@ func (c *Controller) closeParentNow(ctx context.Context, parentNum int) {
 	if err := c.ghClient.UpdateIssueState(ctx, c.owner, c.repo, parentNum, "closed"); err != nil {
 		c.log.Warn("closeParentNow: failed to close parent issue", slog.Int("parent", parentNum), slog.Any("error", err))
 	}
+}
+
+// formatMergedPRRefs renders merged PR numbers as a comma-separated "#N" list
+// for the parent-close summary comment (GH-3939).
+func formatMergedPRRefs(nums []int) string {
+	parts := make([]string, len(nums))
+	for i, n := range nums {
+		parts[i] = fmt.Sprintf("#%d", n)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // recoverStaleParentIssues scans open pilot parent issues at startup and closes any
@@ -1988,7 +2017,7 @@ func (c *Controller) recoverStaleParentIssues(ctx context.Context) {
 		if openCount > 0 {
 			continue
 		}
-		c.closeParentNow(ctx, parentNum)
+		c.closeParentNow(ctx, parentNum, nil)
 		closed++
 	}
 
@@ -3195,6 +3224,14 @@ func (c *Controller) Run(ctx context.Context) error {
 	mergedScanTicker := time.NewTicker(mergedScanInterval)
 	defer mergedScanTicker.Stop()
 
+	// GH-3939: Periodic epic-parent reconciliation. maybeCloseParentIssue only
+	// fires reactively (when a sibling's own PR merges) and recoverStaleParentIssues
+	// only runs once at startup, so a parent left behind by any other close path
+	// (e.g. a child closed out-of-band) would otherwise never be revisited. This
+	// ticker sweeps every open decomposed parent each poll cycle.
+	epicParentTicker := time.NewTicker(basePollInterval)
+	defer epicParentTicker.Stop()
+
 	ticker := time.NewTicker(currentInterval)
 	defer ticker.Stop()
 
@@ -3209,6 +3246,9 @@ func (c *Controller) Run(ctx context.Context) error {
 			if err := c.ScanRecentlyMergedPRs(ctx); err != nil {
 				c.log.Warn("periodic merged PR scan failed", "error", err)
 			}
+		case <-epicParentTicker.C:
+			// GH-3939: poll-cycle epic-parent auto-close sweep.
+			c.reconcileEpicParents(ctx)
 		case <-ticker.C:
 			c.processAllPRs(ctx)
 

--- a/internal/autopilot/epic_reconcile.go
+++ b/internal/autopilot/epic_reconcile.go
@@ -1,0 +1,190 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// maxEpicReconcile caps how many open, pilot-labeled parent-with-sub-issues
+// candidates a single reconcileEpicParents sweep fetches. Mirrors
+// recoverStaleParentIssues' maxRecover — bounded so one pathological repo with
+// hundreds of open epics can't turn a poll tick into an unbounded API burst.
+const maxEpicReconcile = 50
+
+// subIssueState is one native GitHub sub-issue's number and open/closed state.
+// Unlike GetOpenSubIssueNumbers (which discards closed children), reconcileEpicParent
+// needs the CLOSED ones too, to verify each actually shipped a merged PR.
+type subIssueState struct {
+	Number int
+	Closed bool
+}
+
+// childCloseVeto explains why a specific closed child blocks its parent epic's
+// auto-close. Reason is a stable, human-readable string (not per-call-unique)
+// so repeated poll-cycle sightings of the same stalled child produce the same
+// log line — the dedupe path downstream can key off (parent, child, reason)
+// to recognize "still the same stall" instead of re-triggering on every tick.
+type childCloseVeto struct {
+	Child  int
+	Reason string
+}
+
+// getAllSubIssueNumbers queries native GitHub sub-issues for parentNum and
+// returns every child regardless of state (open AND closed), plus whether the
+// parent has any native sub-issue links at all. This mirrors the SDK's
+// GetOpenSubIssueNumbers query shape but keeps closed children too — GH-3939's
+// merged-PR verification must inspect exactly the children that open-only
+// listings discard.
+func (c *Controller) getAllSubIssueNumbers(ctx context.Context, parentNum int) ([]subIssueState, bool, error) {
+	parentID, err := c.ghClient.GetIssueNodeID(ctx, c.owner, c.repo, parentNum)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolve parent node ID: %w", err)
+	}
+
+	const query = `query($issueID: ID!) {
+		node(id: $issueID) {
+			... on Issue {
+				subIssues(first: 100) {
+					totalCount
+					nodes {
+						number
+						state
+					}
+				}
+			}
+		}
+	}`
+
+	var result struct {
+		Node struct {
+			SubIssues struct {
+				TotalCount int `json:"totalCount"`
+				Nodes      []struct {
+					Number int    `json:"number"`
+					State  string `json:"state"`
+				} `json:"nodes"`
+			} `json:"subIssues"`
+		} `json:"node"`
+	}
+
+	if err := c.ghClient.ExecuteGraphQL(ctx, query, map[string]interface{}{"issueID": parentID}, &result); err != nil {
+		return nil, false, fmt.Errorf("query sub-issues for %s/%s#%d: %w", c.owner, c.repo, parentNum, err)
+	}
+
+	if result.Node.SubIssues.TotalCount == 0 {
+		return nil, false, nil
+	}
+
+	children := make([]subIssueState, 0, len(result.Node.SubIssues.Nodes))
+	for _, n := range result.Node.SubIssues.Nodes {
+		children = append(children, subIssueState{Number: n.Number, Closed: n.State == "CLOSED"})
+	}
+	return children, true, nil
+}
+
+// verifyChildrenShippedForClose re-checks every CLOSED child in children has
+// either a merged PR or a verified no_op ledger row (GH-3780: a decomposed
+// child that never produced a PR can still be a genuine, verified completion).
+// A closed child with neither is a real guard veto — closing the parent would
+// silently drop that slice's work.
+//
+// Returns every merged PR number found (for the closing summary comment) and a
+// non-nil veto on the FIRST closed child that fails verification. Fails open
+// (skips, does not veto) on a PR-search error for an individual child, since a
+// transient API failure must not indefinitely block a legitimate close.
+func (c *Controller) verifyChildrenShippedForClose(ctx context.Context, parentNum int, children []subIssueState) (mergedPRs []int, veto *childCloseVeto) {
+	for _, child := range children {
+		if !child.Closed {
+			continue
+		}
+		if c.isChildNoOp(child.Number) {
+			continue
+		}
+
+		prs, err := c.ghClient.SearchPRsForIssue(ctx, c.owner, c.repo, child.Number)
+		if err != nil {
+			c.log.Warn("verifyChildrenShippedForClose: PR search failed, fail-open on this child",
+				slog.Int("parent", parentNum), slog.Int("child", child.Number), slog.Any("error", err))
+			continue
+		}
+
+		merged := false
+		for _, pr := range prs {
+			if pr.Merged {
+				mergedPRs = append(mergedPRs, pr.Number)
+				merged = true
+			}
+		}
+		if !merged {
+			return mergedPRs, &childCloseVeto{Child: child.Number, Reason: "issue is closed but has no merged PR"}
+		}
+	}
+	return mergedPRs, nil
+}
+
+// reconcileEpicParents is the poll-cycle epic-parent auto-close check (GH-3939).
+// On each tick it inspects every open, pilot-labeled issue that has native
+// GitHub sub-issues (a decomposed epic parent) and closes the ones whose
+// children are ALL closed AND shipped a merged PR (or verified no_op).
+//
+// This complements the two existing close paths: maybeCloseParentIssue fires
+// reactively only when a sibling's own PR merges, and recoverStaleParentIssues
+// runs once at startup. Neither revisits a parent left behind by some other
+// event (a child closed out-of-band, a webhook missed) — this sweep does, so
+// such a parent converges within one poll cycle instead of staying stuck until
+// the next restart.
+func (c *Controller) reconcileEpicParents(ctx context.Context) {
+	candidates, err := c.ghClient.SearchOpenPilotIssuesWithSubIssues(ctx, c.owner, c.repo, maxEpicReconcile)
+	if err != nil {
+		c.log.Warn("reconcileEpicParents: search failed", slog.Any("error", err))
+		return
+	}
+
+	for _, parentNum := range candidates {
+		c.reconcileEpicParent(ctx, parentNum)
+	}
+}
+
+// reconcileEpicParent runs the full close-or-veto decision for a single epic
+// parent. Split out from reconcileEpicParents so tests can drive one parent
+// directly, mirroring how maybeCloseParentIssue/recoverStaleParentIssues are tested.
+func (c *Controller) reconcileEpicParent(ctx context.Context, parentNum int) {
+	children, hasNativeLinks, err := c.getAllSubIssueNumbers(ctx, parentNum)
+	if err != nil {
+		c.log.Warn("reconcileEpicParents: failed to list children", slog.Int("parent", parentNum), slog.Any("error", err))
+		return
+	}
+	if !hasNativeLinks {
+		// No native sub-issue links to verify against — leave this parent to the
+		// text-search-based paths (maybeCloseParentIssue / recoverStaleParentIssues),
+		// which is the only signal available for pre-native-linking epics.
+		return
+	}
+
+	openBlocking := 0
+	for _, child := range children {
+		if child.Closed {
+			continue
+		}
+		if c.isChildNoOp(child.Number) {
+			continue
+		}
+		openBlocking++
+	}
+	if openBlocking > 0 {
+		// Routine, not a veto — an epic mid-flight looks like this on every tick,
+		// so this stays at Debug to avoid spamming logs while children finish.
+		c.log.Debug("reconcileEpicParents: siblings still open", slog.Int("parent", parentNum), slog.Int("open", openBlocking))
+		return
+	}
+
+	mergedPRs, veto := c.verifyChildrenShippedForClose(ctx, parentNum, children)
+	if veto != nil {
+		c.log.Warn("reconcileEpicParents: close vetoed",
+			slog.Int("parent", parentNum), slog.Int("child", veto.Child), slog.String("veto_reason", veto.Reason))
+		return
+	}
+
+	c.closeParentNow(ctx, parentNum, mergedPRs)
+}

--- a/internal/autopilot/epic_reconcile.go
+++ b/internal/autopilot/epic_reconcile.go
@@ -141,6 +141,14 @@ func (c *Controller) reconcileEpicParents(ctx context.Context) {
 		return
 	}
 
+	// GH-3939: mirror recoverStaleParentIssues' cap-hit log — this sweep repeats
+	// every poll cycle (not just once at startup), so a repo that consistently
+	// sits at the cap would otherwise silently and indefinitely skip the overflow
+	// candidates with no operator-visible signal.
+	if len(candidates) == maxEpicReconcile {
+		c.log.Info("reconcileEpicParents: hit limit, some candidates may be skipped", slog.Int("limit", maxEpicReconcile))
+	}
+
 	for _, parentNum := range candidates {
 		c.reconcileEpicParent(ctx, parentNum)
 	}

--- a/internal/autopilot/epic_reconcile_test.go
+++ b/internal/autopilot/epic_reconcile_test.go
@@ -1,0 +1,331 @@
+package autopilot
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+var searchChildRe = regexp.MustCompile(`#(\d+)`)
+
+// TestReconcileEpicParent covers GH-3939's poll-cycle epic-parent auto-close
+// check end to end: (a) all children merged closes within one call, (b) one
+// child still open is a quiet no-op, (c) a child closed without a merged PR
+// vetoes the close with an explicit, logged reason, and (d) an already-closed
+// parent is a no-op even when every child looks done.
+func TestReconcileEpicParent(t *testing.T) {
+	const parentNum = 100
+
+	type child struct {
+		num    int
+		closed bool
+		merged bool // only consulted when closed
+	}
+
+	tests := []struct {
+		name          string
+		parentState   string
+		children      []child
+		execStatuses  map[string]string
+		wantClosed    bool
+		wantVetoChild int // 0 if no veto expected
+	}{
+		{
+			name:        "a: all children merged - parent closes within one poll cycle",
+			parentState: "open",
+			children: []child{
+				{num: 1, closed: true, merged: true},
+				{num: 2, closed: true, merged: true},
+			},
+			wantClosed: true,
+		},
+		{
+			name:        "b: one child still open - parent stays open, no veto",
+			parentState: "open",
+			children: []child{
+				{num: 1, closed: true, merged: true},
+				{num: 2, closed: false},
+			},
+			wantClosed: false,
+		},
+		{
+			name:        "c: child closed but PR unmerged - vetoed with explicit reason",
+			parentState: "open",
+			children: []child{
+				{num: 1, closed: true, merged: true},
+				{num: 2, closed: true, merged: false},
+			},
+			wantClosed:    false,
+			wantVetoChild: 2,
+		},
+		{
+			name:        "d: parent already closed - no-op",
+			parentState: "closed",
+			children: []child{
+				{num: 1, closed: true, merged: true},
+				{num: 2, closed: true, merged: true},
+			},
+			wantClosed: false,
+		},
+		{
+			name:        "closed child with no_op ledger status counts as shipped",
+			parentState: "open",
+			children: []child{
+				{num: 1, closed: true, merged: true},
+				{num: 2, closed: true, merged: false},
+			},
+			execStatuses: map[string]string{"GH-2": "no_op"},
+			wantClosed:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				closeCalled     bool
+				addLabelsCalled bool
+				commentBody     string
+			)
+			mergedByChild := map[int]bool{}
+			for _, ch := range tt.children {
+				mergedByChild[ch.num] = ch.merged
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+					state := tt.parentState
+					if state == "" {
+						state = "open"
+					}
+					w.WriteHeader(http.StatusOK)
+					_, _ = fmt.Fprintf(w, `{"node_id":"I_parent","number":%d,"state":%q}`, parentNum, state)
+
+				case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+					var body map[string]interface{}
+					_ = json.NewDecoder(r.Body).Decode(&body)
+					nodes := make([]map[string]interface{}, len(tt.children))
+					for i, ch := range tt.children {
+						state := "OPEN"
+						if ch.closed {
+							state = "CLOSED"
+						}
+						nodes[i] = map[string]interface{}{"number": ch.num, "state": state}
+					}
+					resp := map[string]interface{}{
+						"data": map[string]interface{}{
+							"node": map[string]interface{}{
+								"subIssues": map[string]interface{}{
+									"totalCount": len(tt.children),
+									"nodes":      nodes,
+								},
+							},
+						},
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+
+				case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+					q, _ := url.QueryUnescape(r.URL.Query().Get("q"))
+					m := searchChildRe.FindStringSubmatch(q)
+					var childNum int
+					if len(m) == 2 {
+						_, _ = fmt.Sscanf(m[1], "%d", &childNum)
+					}
+					items := []map[string]interface{}{}
+					if mergedByChild[childNum] {
+						items = append(items, map[string]interface{}{
+							"id":     1,
+							"number": 900 + childNum,
+							"title":  fmt.Sprintf("fix: child %d", childNum),
+							"state":  "closed",
+							"pull_request": map[string]interface{}{
+								"merged_at": "2026-01-01T00:00:00Z",
+							},
+						})
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": items})
+
+				case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d/labels", parentNum):
+					addLabelsCalled = true
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("[]"))
+
+				case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, fmt.Sprintf("/repos/owner/repo/issues/%d/labels/", parentNum)):
+					w.WriteHeader(http.StatusOK)
+
+				case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d/comments", parentNum):
+					b, _ := json.Marshal(map[string]interface{}{"id": 1})
+					var payload struct {
+						Body string `json:"body"`
+					}
+					_ = json.NewDecoder(r.Body).Decode(&payload)
+					commentBody = payload.Body
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(b)
+
+				case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+					closeCalled = true
+					w.WriteHeader(http.StatusOK)
+
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			var logBuf bytes.Buffer
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+			c.log = slog.New(slog.NewTextHandler(&logBuf, nil))
+			if tt.execStatuses != nil {
+				c.SetEvalStore(&mockEvalStore{execStatusByTaskID: tt.execStatuses})
+			}
+
+			c.reconcileEpicParent(context.Background(), parentNum)
+
+			if closeCalled != tt.wantClosed {
+				t.Errorf("parent closed = %v, want %v", closeCalled, tt.wantClosed)
+			}
+			if tt.wantClosed != addLabelsCalled {
+				t.Errorf("pilot-done label added = %v, want %v", addLabelsCalled, tt.wantClosed)
+			}
+
+			logs := logBuf.String()
+			if tt.wantVetoChild != 0 {
+				if !strings.Contains(logs, "close vetoed") {
+					t.Errorf("expected a veto log line, got logs:\n%s", logs)
+				}
+				if !strings.Contains(logs, fmt.Sprintf("child=%d", tt.wantVetoChild)) {
+					t.Errorf("expected veto log to name child %d, got logs:\n%s", tt.wantVetoChild, logs)
+				}
+				if !strings.Contains(logs, "veto_reason=") {
+					t.Errorf("expected veto log to carry an explicit veto_reason, got logs:\n%s", logs)
+				}
+			} else if strings.Contains(logs, "close vetoed") {
+				t.Errorf("did not expect a veto log line (no spam for routine no-op), got logs:\n%s", logs)
+			}
+
+			if tt.wantClosed && len(mergedByChild) > 0 {
+				hasMerged := false
+				for _, m := range mergedByChild {
+					if m {
+						hasMerged = true
+					}
+				}
+				if hasMerged && !strings.Contains(commentBody, "Merged PRs:") {
+					t.Errorf("expected closing comment to name merged PRs, got: %q", commentBody)
+				}
+			}
+		})
+	}
+}
+
+// TestReconcileEpicParents_Wrapper verifies the search-driven entry point
+// dispatches each open, sub-issue-bearing candidate through reconcileEpicParent.
+func TestReconcileEpicParents_Wrapper(t *testing.T) {
+	const parentNum = 200
+	var closeCalled bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			query, _ := body["query"].(string)
+
+			if strings.Contains(query, "subIssuesSummary") {
+				resp := map[string]interface{}{
+					"data": map[string]interface{}{
+						"repository": map[string]interface{}{
+							"issues": map[string]interface{}{
+								"nodes": []map[string]interface{}{
+									{
+										"number":           parentNum,
+										"subIssuesSummary": map[string]int{"total": 1, "completed": 1},
+									},
+								},
+							},
+						},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+
+			// getAllSubIssueNumbers: one closed, merged child.
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"node": map[string]interface{}{
+						"subIssues": map[string]interface{}{
+							"totalCount": 1,
+							"nodes": []map[string]interface{}{
+								{"number": 1, "state": "CLOSED"},
+							},
+						},
+					},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"node_id":"I_parent","number":%d,"state":"open"}`, parentNum)
+
+		case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+			items := []map[string]interface{}{
+				{
+					"id": 1, "number": 901, "title": "fix: child",
+					"state":        "closed",
+					"pull_request": map[string]interface{}{"merged_at": "2026-01-01T00:00:00Z"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": items})
+
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/labels/"):
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":1}`))
+
+		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			closeCalled = true
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	c.reconcileEpicParents(context.Background())
+
+	if !closeCalled {
+		t.Error("expected reconcileEpicParents to close the fully-shipped parent via the search-driven sweep")
+	}
+}


### PR DESCRIPTION
## Summary

Closes GH-3939 (subtask of GH-3924).

- Adds `reconcileEpicParents`/`reconcileEpicParent` (`internal/autopilot/epic_reconcile.go`): a poll-cycle sweep, wired into `Controller.Run()`, that inspects every open decomposed epic-parent issue each tick.
- Closes the parent once every child is closed **and** verified to have a merged PR (`SearchPRsForIssue`), or a verified `no_op` ledger row (GH-3780) — closing the gap where the existing count-only paths (`maybeCloseParentIssue`, `recoverStaleParentIssues`) only proved a child was no longer OPEN, not that its work actually merged.
- A closed child with no merged PR now **vetoes** the close with an explicit, stable `veto_reason` log line (parent + child + reason) instead of silently closing early, so a downstream dedupe path can recognize "same stall as last tick."
- The closing summary comment now names the merged PRs (`closeParentNow` takes `mergedPRs []int`).
- `closeParentNow` is now idempotent against an already-closed parent (fail-open on lookup error).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` — includes new table-driven `TestReconcileEpicParent` covering: (a) all children merged → closes in one call, (b) one child open → stays open, no veto log, (c) child closed but PR unmerged → vetoed with explicit reason, (d) parent already closed → no-op, plus a no_op-ledger case and a `TestReconcileEpicParents_Wrapper` for the search-driven entry point.
- [x] `make lint` (`golangci-lint run --new-from-rev=origin/main ./...`) — 0 issues