### PR TITLE
fix(executor): emit epic-parent stage events, harvest child tokens, honest decomposition comment

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -420,6 +420,7 @@
 | Conventional sub-issue titles | ✅ | executor | - | - | CC-format enforced on subtask titles: re-prompt → Approach B fallback → creation guard (GH-2494) |
 | Sub-issue dedup guard | ✅ | executor | - | - | CreateSubIssues skips if open children referencing parent already exist (GH-2494) |
 | createPilotIssue chokepoint | ✅ | adapters/github, autopilot | - | - | All Pilot-internal issue creation validated through CreatePilotIssue CC gate (GH-2494) |
+| Epic-parent lifecycle instrumentation | ✅ | executor | `pilot trace <task-id>` | - | Epic-parent path emits `claude_started`/`decomposed`/terminal (`completed`/`no_op`/`failed`) execution_events past `spec_validated`; children's real token/file/cost metrics roll up onto the parent's own row (previously zero even on long runs); zero-tokens+zero-files+no-commit/PR completions reclassify to `no_op`; decomposition posts an honest "decomposed into N children: #a, #b, #c" comment sourced from the actual created sub-issues (GH-3938, v2.222.0) |
 
 ## Test Coverage
 

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 // conventionalCommitPrefixRegex matches conventional-commit type prefixes like
@@ -1759,23 +1761,46 @@ func (r *Runner) resolveChildTerminalOutcome(taskID, status string, result *Exec
 // as their ProjectPath so they can create their own branches from the real repo.
 // executionPath is still used for gh CLI commands (issue comments) that need worktree context.
 func (r *Runner) ExecuteSubIssues(ctx context.Context, parent *Task, issues []CreatedIssue, executionPath string, repoPath string) error {
-	_, err := r.executeSubIssuesTracked(ctx, parent, issues, executionPath, repoPath)
+	_, _, err := r.executeSubIssuesTracked(ctx, parent, issues, executionPath, repoPath)
 	return err
 }
 
+// formatDecomposedChildrenSummary builds the honest, evidence-sourced summary of
+// what decomposition actually produced — "decomposed into N children: #a, #b, #c"
+// — from the real CreatedIssue list rather than a generic "no changes were made"
+// or "N sub-issues executed" placeholder. GH-3938. Used both for the parent-issue
+// progress comment and the execution_events StageDecomposed detail.
+func formatDecomposedChildrenSummary(issues []CreatedIssue) string {
+	refs := make([]string, 0, len(issues))
+	for _, iss := range issues {
+		if iss.Number > 0 {
+			refs = append(refs, fmt.Sprintf("#%d", iss.Number))
+		} else if iss.Identifier != "" {
+			refs = append(refs, iss.Identifier)
+		}
+	}
+	return fmt.Sprintf("decomposed into %d children: %s", len(issues), strings.Join(refs, ", "))
+}
+
 // executeSubIssuesTracked is ExecuteSubIssues plus each child's terminal state
-// (TerminalStatus of its ExecutionResult, e.g. "completed" / "no_op"). GH-3779:
-// the decomposed-parent PR-finalize guard (evaluateEmptyBranchPRGuard) needs this
-// to tell a genuine no-op epic (every child no-op'd — nothing shipped anywhere)
-// from one whose deliverables shipped entirely via child sub-issue PRs.
+// (TerminalStatus of its ExecutionResult, e.g. "completed" / "no_op") and the
+// aggregated token/cost/file metrics rolled up from every child that actually
+// ran. GH-3779: childStates lets the decomposed-parent PR-finalize guard
+// (evaluateEmptyBranchPRGuard) tell a genuine no-op epic (every child no-op'd —
+// nothing shipped anywhere) from one whose deliverables shipped entirely via
+// child sub-issue PRs. GH-3938: the aggregated metrics let the epic-parent's
+// own executions row report the real tokens/files its children burned —
+// previously only childStates (pass/fail strings) were tracked here, so a
+// 37-minute epic run persisted as tokens_output=0.
 //
 // A child that no-ops (isNoOpResult) is non-fatal here and the loop continues —
 // mirrors the TASK-320 B2 tolerance already applied to the in-process decomposer
 // (runner_decompose.go isNoOpResult). Any other child failure still aborts the
 // whole epic, unchanged from ExecuteSubIssues' prior behavior.
-func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issues []CreatedIssue, executionPath string, repoPath string) ([]string, error) {
+func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issues []CreatedIssue, executionPath string, repoPath string) ([]string, *ExecutionResult, error) {
+	metrics := &ExecutionResult{}
 	if len(issues) == 0 {
-		return nil, fmt.Errorf("no sub-issues to execute")
+		return nil, metrics, fmt.Errorf("no sub-issues to execute")
 	}
 
 	var childStates []string
@@ -1800,18 +1825,21 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 		"total_issues", total,
 	)
 
-	// Update parent with start message
-	startMsg := fmt.Sprintf("🚀 Starting sequential execution of %d sub-issues", total)
+	// Update parent with an honest, evidence-sourced decomposition summary
+	// (GH-3938) instead of a generic "starting" message — the actual child
+	// issue numbers are already known at this point.
+	startMsg := fmt.Sprintf("🚀 %s — starting sequential execution", formatDecomposedChildrenSummary(issues))
 	if err := r.UpdateIssueProgress(ctx, projectPath, parent.ID, startMsg); err != nil {
 		r.log.Warn("Failed to update parent progress", "error", err)
 		// Non-fatal, continue execution
 	}
+	r.recordExecutionEvent(parent.LogExecutionID(), memory.StageDecomposed, formatDecomposedChildrenSummary(issues))
 
 	for i, issue := range issues {
 		// Check context cancellation
 		select {
 		case <-ctx.Done():
-			return childStates, fmt.Errorf("execution cancelled: %w", ctx.Err())
+			return childStates, metrics, fmt.Errorf("execution cancelled: %w", ctx.Err())
 		default:
 		}
 
@@ -1899,8 +1927,19 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			failMsg := fmt.Sprintf("❌ Failed on %d/%d: %s - Error: %v",
 				i+1, total, issue.Subtask.Title, err)
 			_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
-			return childStates, fmt.Errorf("sub-issue %s failed: %w", issueRef, err)
+			return childStates, metrics, fmt.Errorf("sub-issue %s failed: %w", issueRef, err)
 		}
+
+		// GH-3938: fold this child's real Claude usage into the epic-parent's
+		// aggregate metrics — every child (success or no-op) that produced an
+		// ExecutionResult actually invoked Claude and burned real tokens, even
+		// when it delivered no diff. This is what previously went untracked and
+		// left the parent's own executions row at tokens_output=0.
+		aggregateSubtaskCost(metrics, result)
+		metrics.FilesChanged += result.FilesChanged
+		metrics.LinesAdded += result.LinesAdded
+		metrics.LinesRemoved += result.LinesRemoved
+		metrics.EstimatedCostUSD += result.EstimatedCostUSD
 
 		if !result.Success {
 			// GH-3779: a genuine no-op child (isNoOpResult — same classification the
@@ -1922,7 +1961,7 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			failMsg := fmt.Sprintf("❌ Failed on %d/%d: %s - %s",
 				i+1, total, issue.Subtask.Title, result.Error)
 			_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
-			return childStates, fmt.Errorf("sub-issue %s failed: %s", issueRef, result.Error)
+			return childStates, metrics, fmt.Errorf("sub-issue %s failed: %s", issueRef, result.Error)
 		}
 
 		childStates = append(childStates, TerminalStatus(result))
@@ -1962,7 +2001,7 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 				"branch", subTask.Branch,
 				"recovery_ref", recoveryRef,
 			)
-			return childStates, fmt.Errorf("sub-issue %s committed work (sha %s) but produced no PR — work would be lost, halting epic — recovery: %s", issueRef, shortSHA, recovery)
+			return childStates, metrics, fmt.Errorf("sub-issue %s committed work (sha %s) but produced no PR — work would be lost, halting epic — recovery: %s", issueRef, shortSHA, recovery)
 		}
 
 		// Register sub-issue PR with autopilot controller (GH-596)
@@ -1997,7 +2036,7 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 				if err := r.subIssueMergeWait(ctx, prNum); err != nil {
 					failMsg := fmt.Sprintf("❌ Merge wait failed for %s (PR #%d): %v", issueRef, prNum, err)
 					_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
-					return childStates, fmt.Errorf("merge wait failed for sub-issue %s (PR #%d): %w", issueRef, prNum, err)
+					return childStates, metrics, fmt.Errorf("merge wait failed for sub-issue %s (PR #%d): %w", issueRef, prNum, err)
 				}
 
 				// Sync local main branch so the next sub-issue branches from the merged state.
@@ -2043,5 +2082,5 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 		"total_completed", total,
 	)
 
-	return childStates, nil
+	return childStates, metrics, nil
 }

--- a/internal/executor/gh3938_test.go
+++ b/internal/executor/gh3938_test.go
@@ -1,0 +1,424 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// gh3938MultiPackageSubtasks returns two subtasks that reference distinct
+// directories so isSinglePackageScope does not consolidate them into a single
+// task — mirrors the fixture pattern already used by the epic recovery tests
+// in epic_test.go.
+func gh3938MultiPackageSubtasks() []PlannedSubtask {
+	return []PlannedSubtask{
+		{Order: 1, Title: "feat(gateway): add websocket handler", Description: "Implement upgrade handler in internal/gateway/server.go"},
+		{Order: 2, Title: "feat(adapters): add telegram bot", Description: "Wire bot client in internal/adapters/telegram/bot.go"},
+	}
+}
+
+// gh3938RecoveredIssues returns two open CreatedIssues matching
+// gh3938MultiPackageSubtasks, used to drive CreateSubIssues down the
+// ErrSubIssuesAlreadyExist → recovery path without shelling out to a real
+// "gh issue create".
+func gh3938RecoveredIssues() []CreatedIssue {
+	subs := gh3938MultiPackageSubtasks()
+	return []CreatedIssue{
+		{Number: 101, State: "open", Subtask: subs[0]},
+		{Number: 102, State: "open", Subtask: subs[1]},
+	}
+}
+
+// gh3938EpicTestRunner builds a Runner wired for an in-process epic run: no
+// real gh/git calls (dryRun + injected recovery), a real memory.Store so
+// execution_events can be asserted, and a caller-supplied executeFunc
+// standing in for the per-child Claude invocation.
+func gh3938EpicTestRunner(store *memory.Store, execFn func(ctx context.Context, task *Task) (*ExecutionResult, error)) *Runner {
+	r := NewRunner()
+	r.skipPreflightChecks = true
+	r.dryRun = true
+	r.SetLogStore(store)
+	r.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) {
+		return true, nil // force the ErrSubIssuesAlreadyExist → recovery path
+	}
+	r.recoverSubIssuesFn = func(_ context.Context, _, _ string) ([]CreatedIssue, error) {
+		return gh3938RecoveredIssues(), nil
+	}
+	r.planEpicFn = func(_ context.Context, task *Task, _ string) (*EpicPlan, error) {
+		return &EpicPlan{
+			ParentTask: task,
+			Subtasks:   gh3938MultiPackageSubtasks(),
+		}, nil
+	}
+	r.executeFunc = execFn
+	return r
+}
+
+// TestEpicPath_TokenHarvestAndFullEventSequence covers GH-3938 acceptance (a):
+// a fake Claude stream (via executeFunc, standing in for each child's real
+// Claude invocation) produces tokens_output > 0 on the epic-parent's own
+// result, and the execution_events timeline records the full lifecycle past
+// spec_validated instead of going silent.
+func TestEpicPath_TokenHarvestAndFullEventSequence(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	childCalls := 0
+	r := gh3938EpicTestRunner(store, func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		childCalls++
+		return &ExecutionResult{
+			TaskID:       task.ID,
+			Success:      true,
+			TokensInput:  1000,
+			TokensOutput: 2000,
+			TokensTotal:  3000,
+			FilesChanged: 3,
+			CommitSHA:    "deadbeef" + task.ID,
+			PRUrl:        "https://github.com/owner/repo/pull/" + task.ID,
+		}, nil
+	})
+
+	task := &Task{ID: "GH-3938TOK", Title: "[epic] fake claude stream token harvest test"}
+	if err := store.SaveExecution(&memory.Execution{ID: task.ID, TaskID: task.ID, Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	result, err := r.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+	if result == nil || !result.Success {
+		t.Fatalf("expected successful epic result, got: %+v", result)
+	}
+	if !result.IsEpic {
+		t.Error("expected IsEpic=true")
+	}
+	if childCalls != 2 {
+		t.Fatalf("expected 2 child executions, got %d", childCalls)
+	}
+
+	// The core regression: a real (simulated) Claude invocation per child must
+	// roll up onto the epic-parent's own row instead of persisting as zero.
+	if result.TokensOutput <= 0 {
+		t.Errorf("TokensOutput = %d, want > 0", result.TokensOutput)
+	}
+	if result.TokensInput <= 0 {
+		t.Errorf("TokensInput = %d, want > 0", result.TokensInput)
+	}
+	if result.TokensOutput != 4000 {
+		t.Errorf("TokensOutput = %d, want 4000 (2 children x 2000)", result.TokensOutput)
+	}
+	if result.FilesChanged != 6 {
+		t.Errorf("FilesChanged = %d, want 6 (2 children x 3)", result.FilesChanged)
+	}
+
+	events, err := store.ListExecutionEvents(task.LogExecutionID())
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	wantStages := []memory.Stage{
+		memory.StageSpecValidated,
+		memory.StageClaudeStarted,
+		memory.StageDecomposed,
+		memory.StageCompleted,
+	}
+	if len(events) != len(wantStages) {
+		var gotStages []memory.Stage
+		for _, e := range events {
+			gotStages = append(gotStages, e.Stage)
+		}
+		t.Fatalf("got %d events %v, want %d %v", len(events), gotStages, len(wantStages), wantStages)
+	}
+	for i, want := range wantStages {
+		if events[i].Stage != want {
+			t.Errorf("event[%d].Stage = %q, want %q", i, events[i].Stage, want)
+		}
+	}
+	if !strings.Contains(events[2].Detail, "decomposed into 2 children: #101, #102") {
+		t.Errorf("decomposed event detail = %q, want it to mention decomposed into 2 children: #101, #102", events[2].Detail)
+	}
+}
+
+// TestEpicPath_ZeroDeliveryTripsNoOpGuard covers GH-3938 acceptance (b): an
+// epic whose children all report Success=true but ship zero tokens, zero
+// file changes, and no commit/PR anywhere must not silently persist as
+// "completed" — the ghost-SHA-shaped no-op guard must reclassify it.
+func TestEpicPath_ZeroDeliveryTripsNoOpGuard(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	r := gh3938EpicTestRunner(store, func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		// Every child "completes" but delivers nothing: no tokens, no files,
+		// no commit, no PR — a ghost success.
+		return &ExecutionResult{TaskID: task.ID, Success: true}, nil
+	})
+
+	task := &Task{ID: "GH-3938ZERO", Title: "[epic] zero delivery no-op guard test"}
+	if err := store.SaveExecution(&memory.Execution{ID: task.ID, TaskID: task.ID, Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	result, err := r.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Success {
+		t.Errorf("expected Success=false after zero-delivery reclassification, got true")
+	}
+	if result.Outcome != "no_op" {
+		t.Errorf("Outcome = %q, want %q", result.Outcome, "no_op")
+	}
+	if result.Error == "" {
+		t.Error("expected a descriptive no-op reason, got empty Error")
+	}
+
+	events, err := store.ListExecutionEvents(task.LogExecutionID())
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected execution events to be recorded")
+	}
+	last := events[len(events)-1]
+	if last.Stage != memory.StageNoOp {
+		t.Errorf("terminal event stage = %q, want %q (must NOT be StageCompleted)", last.Stage, memory.StageNoOp)
+	}
+}
+
+// TestClassifyZeroDeliveryEpicCompletion is a focused table-driven unit test
+// for the guard predicate itself, independent of the full Execute() path.
+func TestClassifyZeroDeliveryEpicCompletion(t *testing.T) {
+	tests := []struct {
+		name           string
+		result         *ExecutionResult
+		wantSuccess    bool
+		wantOutcome    string
+		wantUnaffected bool // if true, the result must be byte-for-byte unchanged
+	}{
+		{
+			name:        "zero everything on an epic result is reclassified as no_op",
+			result:      &ExecutionResult{Success: true, IsEpic: true},
+			wantSuccess: false,
+			wantOutcome: "no_op",
+		},
+		{
+			name:           "nonzero TokensOutput leaves an epic result untouched",
+			result:         &ExecutionResult{Success: true, IsEpic: true, TokensOutput: 5},
+			wantSuccess:    true,
+			wantUnaffected: true,
+		},
+		{
+			name:           "nonzero FilesChanged leaves an epic result untouched",
+			result:         &ExecutionResult{Success: true, IsEpic: true, FilesChanged: 1},
+			wantSuccess:    true,
+			wantUnaffected: true,
+		},
+		{
+			name:           "a commit SHA leaves an epic result untouched",
+			result:         &ExecutionResult{Success: true, IsEpic: true, CommitSHA: "abc123"},
+			wantSuccess:    true,
+			wantUnaffected: true,
+		},
+		{
+			name:           "a PR URL leaves an epic result untouched",
+			result:         &ExecutionResult{Success: true, IsEpic: true, PRUrl: "https://github.com/o/r/pull/1"},
+			wantSuccess:    true,
+			wantUnaffected: true,
+		},
+		{
+			name: "non-epic zero-delivery completions are legitimate and untouched " +
+				"(GH-3846 synthetic-dispatch coverage relies on this)",
+			result:         &ExecutionResult{Success: true, IsEpic: false},
+			wantSuccess:    true,
+			wantUnaffected: true,
+		},
+		{
+			name:           "an already-failed result is untouched",
+			result:         &ExecutionResult{Success: false, IsEpic: true, Error: "some other failure"},
+			wantSuccess:    false,
+			wantUnaffected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := *tt.result
+			classifyZeroDeliveryEpicCompletion(tt.result)
+			if tt.wantUnaffected {
+				if tt.result.Success != before.Success || tt.result.Outcome != before.Outcome || tt.result.Error != before.Error {
+					t.Errorf("result mutated: got %+v, want unchanged %+v", tt.result, before)
+				}
+				return
+			}
+			if tt.result.Success != tt.wantSuccess {
+				t.Errorf("Success = %v, want %v", tt.result.Success, tt.wantSuccess)
+			}
+			if tt.result.Outcome != tt.wantOutcome {
+				t.Errorf("Outcome = %q, want %q", tt.result.Outcome, tt.wantOutcome)
+			}
+		})
+	}
+
+	// nil must not panic.
+	classifyZeroDeliveryEpicCompletion(nil)
+}
+
+// ghAppendLogScript writes a fake "gh" executable to a temp bin dir that
+// appends every invocation's arguments to logPath (one field per arg,
+// \x1f-separated; \x1e-separated between invocations) and always exits 0.
+// Mirrors the fake-gh-with-captured-args pattern already used in epic_test.go
+// (TestCreateSubIssuesViaGitHub_PropagatesNoDecomposeLabel), extended to
+// accumulate across multiple calls instead of truncating on each one.
+func ghAppendLogScript(t *testing.T, logPath string) {
+	t.Helper()
+	fakeBin := t.TempDir()
+	script := filepath.Join(fakeBin, "gh")
+	content := "#!/bin/sh\n" +
+		"{ for arg in \"$@\"; do printf '%s\\037' \"$arg\"; done; printf '\\036'; } >> \"$GH3938_TEST_LOG\"\n" +
+		"exit 0\n"
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("GH3938_TEST_LOG", logPath)
+	origPATH := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+origPATH)
+}
+
+// parseGhInvocations splits a ghAppendLogScript log file into one []string of
+// args per "gh" invocation, in call order.
+func parseGhInvocations(t *testing.T, logPath string) [][]string {
+	t.Helper()
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read gh log: %v", err)
+	}
+	var calls [][]string
+	for _, record := range strings.Split(string(raw), "\x1e") {
+		if record == "" {
+			continue
+		}
+		fields := strings.Split(record, "\x1f")
+		// Trailing separator leaves one empty trailing field.
+		if len(fields) > 0 && fields[len(fields)-1] == "" {
+			fields = fields[:len(fields)-1]
+		}
+		calls = append(calls, fields)
+	}
+	return calls
+}
+
+// TestExecuteSubIssuesTracked_PostsDecomposedChildrenComment covers GH-3938
+// acceptance (c): decomposition posts an honest, evidence-sourced
+// "decomposed into N children: #a, #b, #c" comment on the parent issue,
+// sourced from the actual created sub-issues — not a generic placeholder.
+func TestExecuteSubIssuesTracked_PostsDecomposedChildrenComment(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "gh-calls.log")
+	ghAppendLogScript(t, logPath)
+
+	runner := newTestRunnerWithExecFunc(func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{
+			TaskID:    task.ID,
+			Success:   true,
+			CommitSHA: "sha-" + task.ID,
+			PRUrl:     "https://github.com/owner/repo/pull/" + task.ID,
+		}, nil
+	})
+	runner.dryRun = false // this test needs the real (faked) gh CLI path
+
+	subs := gh3938MultiPackageSubtasks()
+	issues := []CreatedIssue{
+		{Number: 501, Subtask: subs[0]},
+		{Number: 502, Subtask: subs[1]},
+	}
+	parent := &Task{ID: "GH-3938PARENT", ProjectPath: t.TempDir()}
+
+	_, metrics, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, "", "")
+	if err != nil {
+		t.Fatalf("executeSubIssuesTracked failed: %v", err)
+	}
+	if metrics == nil {
+		t.Fatal("expected non-nil metrics")
+	}
+
+	calls := parseGhInvocations(t, logPath)
+	var found string
+	for _, args := range calls {
+		if len(args) >= 4 && args[0] == "issue" && args[1] == "comment" && args[2] == parent.ID {
+			// args: issue comment <id> --body <message>
+			for i, a := range args {
+				if a == "--body" && i+1 < len(args) {
+					found = args[i+1]
+				}
+			}
+			if found != "" {
+				break
+			}
+		}
+	}
+	if found == "" {
+		t.Fatalf("no 'gh issue comment %s --body ...' call captured; calls = %v", parent.ID, calls)
+	}
+	want := "decomposed into 2 children: #501, #502"
+	if !strings.Contains(found, want) {
+		t.Errorf("decomposition comment = %q, want it to contain %q", found, want)
+	}
+}
+
+// TestGH3938_ExistingCloseGuardsUnchanged verifies the two pre-existing
+// epic-parent close guards this change sits next to are unaffected:
+//   - GH-3513 text-search confirmation: CreateSubIssues still refuses to
+//     spawn duplicate sub-issues when the dedup checker reports a recent
+//     sibling.
+//   - Open-PR / work-loss veto: a child that commits real work but produces
+//     no PR still halts the epic instead of silently discarding the work,
+//     and still does so with the executeSubIssuesTracked signature change
+//     (metrics is returned alongside the error, not swallowed).
+func TestGH3938_ExistingCloseGuardsUnchanged(t *testing.T) {
+	t.Run("GH-3513 text-search confirmation still blocks duplicate creation", func(t *testing.T) {
+		r := NewRunner()
+		r.dryRun = true
+		r.openSubIssueCheck = func(_ context.Context, _, _ string) (bool, error) {
+			return true, nil // simulate a recently-created sibling found via text search
+		}
+		plan := &EpicPlan{
+			ParentTask: &Task{ID: "GH-3513CHECK", Title: "feat(scope): some epic", State: "open"},
+			Subtasks:   []PlannedSubtask{{Order: 1, Title: "feat(scope): sub-task one", Description: "do it"}},
+		}
+		_, err := r.CreateSubIssues(context.Background(), plan, "")
+		if !errors.Is(err, ErrSubIssuesAlreadyExist) {
+			t.Errorf("CreateSubIssues error = %v, want ErrSubIssuesAlreadyExist", err)
+		}
+	})
+
+	t.Run("open-PR veto still halts the epic on commit-without-PR child", func(t *testing.T) {
+		runner := newTestRunnerWithExecFunc(func(_ context.Context, task *Task) (*ExecutionResult, error) {
+			return &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "committed-but-stranded", PRUrl: ""}, nil
+		})
+		issues := []CreatedIssue{
+			{Number: 601, Subtask: PlannedSubtask{Order: 1, Title: "feat(scope): sub-task", Description: "do it"}},
+		}
+		parent := &Task{ID: "GH-8888", ProjectPath: t.TempDir()}
+
+		_, metrics, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, "", t.TempDir())
+		if err == nil {
+			t.Fatal("expected the work-loss guard to return an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "produced no PR") {
+			t.Errorf("error = %v, want it to mention 'produced no PR'", err)
+		}
+		if metrics == nil {
+			t.Error("expected non-nil metrics even when the guard vetoes the epic (signature change regression check)")
+		}
+	})
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1570,6 +1570,46 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 	r.reportProgress(task.ID, "Complete", 100, "Epic completed successfully")
 }
 
+// classifyZeroDeliveryEpicCompletion reclassifies an epic-parent result that
+// reports Success=true but carries no evidence any real work happened —
+// zero tokens burned by Claude (planning or children), zero files changed,
+// and no commit or PR anywhere — as a no_op instead of a silent "completed".
+// Mirrors the GH-3224 ghost-SHA guard shape (bug_pilot_ghost_closes.md
+// Variant 4): a bare Success flag is not proof of work; the row must carry a
+// deliverable. GH-3938.
+//
+// Scoped to IsEpic results: non-epic zero-deliverable completions (e.g.
+// analysis-only LocalMode tasks, GH-3846's synthetic-dispatch coverage) are
+// legitimate and must not be touched here.
+func classifyZeroDeliveryEpicCompletion(result *ExecutionResult) {
+	if result == nil || !result.Success || !result.IsEpic {
+		return
+	}
+	if result.TokensInput != 0 || result.TokensOutput != 0 || result.FilesChanged != 0 {
+		return
+	}
+	if result.CommitSHA != "" || result.PRUrl != "" {
+		return
+	}
+	result.Success = false
+	result.Outcome = "no_op"
+	result.Error = "epic completed with zero tokens, zero files changed, and no commit/PR — reclassified as no_op"
+}
+
+// recordEpicTerminalEvent writes the epic-parent's terminal execution_events
+// milestone (completed / no_op / failed) so `pilot trace` shows the full
+// lifecycle instead of stopping at spec_validated. GH-3938.
+func (r *Runner) recordEpicTerminalEvent(executionID string, result *ExecutionResult) {
+	switch {
+	case result.Outcome == "no_op":
+		r.recordExecutionEvent(executionID, memory.StageNoOp, result.Error)
+	case !result.Success:
+		r.recordExecutionEvent(executionID, memory.StageFailed, truncateForLog(result.Error, 200))
+	default:
+		r.recordExecutionEvent(executionID, memory.StageCompleted, result.Output)
+	}
+}
+
 // executeWithOptions is the internal implementation that allows controlling worktree creation.
 // When allowWorktree is false, it skips worktree creation even if configured.
 // This prevents recursive worktree creation in sub-issues and decomposed tasks.
@@ -1795,6 +1835,11 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 		if planFn == nil {
 			planFn = r.PlanEpic
 		}
+		// GH-3938: mark the point Claude is actually invoked for this task —
+		// epic planning is a real Claude Code call, and the epic-parent path
+		// previously emitted nothing past spec_validated, leaving `pilot trace`
+		// silent for the entire epic lifecycle.
+		r.recordExecutionEvent(task.LogExecutionID(), memory.StageClaudeStarted, "epic planning invoked claude")
 		plan, err := planFn(ctx, task, executionPath)
 		if err != nil {
 			// GH-1687: Planning failure is non-fatal — fall through to direct execution
@@ -1841,12 +1886,14 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						slog.String("dispatched", task.ID),
 						slog.String("plan_parent", planParent),
 					)
+					mismatchErr := fmt.Sprintf("epic plan parent %q does not match dispatched task %q — refusing sub-issue creation", planParent, task.ID)
+					r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed, truncateForLog(mismatchErr, 200))
 					return &ExecutionResult{
 						TaskID:   task.ID,
 						Success:  false,
 						IsEpic:   true,
 						EpicPlan: plan,
-						Error:    fmt.Sprintf("epic plan parent %q does not match dispatched task %q — refusing sub-issue creation", planParent, task.ID),
+						Error:    mismatchErr,
 						Duration: time.Since(start),
 					}, nil
 				}
@@ -1874,10 +1921,13 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 								slog.Int("recovered_count", len(recovered)),
 							)
 							r.reportProgress(task.ID, "Complete", 100, "All sub-issues already completed")
+							recoveredSummary := formatDecomposedChildrenSummary(recovered)
+							r.recordExecutionEvent(task.LogExecutionID(), memory.StageDecomposed, recoveredSummary)
+							r.recordExecutionEvent(task.LogExecutionID(), memory.StageCompleted, recoveredSummary)
 							return &ExecutionResult{
 								TaskID:    task.ID,
 								Success:   true,
-								Output:    fmt.Sprintf("Epic already completed: %d sub-issues recovered", len(recovered)),
+								Output:    fmt.Sprintf("Epic already completed: %s", recoveredSummary),
 								Duration:  time.Since(start),
 								IsEpic:    true,
 								EpicPlan:  plan,
@@ -1897,10 +1947,12 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						)
 						issues = open
 					} else {
+						createErr := fmt.Sprintf("failed to create sub-issues: %v", err)
+						r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed, truncateForLog(createErr, 200))
 						return &ExecutionResult{
 							TaskID:   task.ID,
 							Success:  false,
-							Error:    fmt.Sprintf("failed to create sub-issues: %v", err),
+							Error:    createErr,
 							Duration: time.Since(start),
 							IsEpic:   true,
 							EpicPlan: plan,
@@ -1916,12 +1968,16 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				// GH-3779: also collect each child's terminal state so the PR-finalize
 				// guard below can tell a genuine no-op epic (all children no-op'd) from
 				// one whose deliverables shipped entirely via child sub-issue PRs.
-				childStates, err := r.executeSubIssuesTracked(ctx, task, issues, executionPath, task.ProjectPath)
+				// GH-3938: childMetrics carries the real tokens/files/cost every child
+				// actually burned, rolled up onto the epic-parent's own result below.
+				childStates, childMetrics, err := r.executeSubIssuesTracked(ctx, task, issues, executionPath, task.ProjectPath)
 				if err != nil {
+					execErr := fmt.Sprintf("sub-issue execution failed: %v", err)
+					r.recordExecutionEvent(task.LogExecutionID(), memory.StageFailed, truncateForLog(execErr, 200))
 					return &ExecutionResult{
 						TaskID:   task.ID,
 						Success:  false,
-						Error:    fmt.Sprintf("sub-issue execution failed: %v", err),
+						Error:    execErr,
 						Duration: time.Since(start),
 						IsEpic:   true,
 						EpicPlan: plan,
@@ -1935,11 +1991,29 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				epicResult := &ExecutionResult{
 					TaskID:    task.ID,
 					Success:   true,
-					Output:    fmt.Sprintf("Epic completed: %d sub-issues executed", len(issues)),
+					Output:    fmt.Sprintf("Epic completed: %s", formatDecomposedChildrenSummary(issues)),
 					Duration:  time.Since(start),
 					IsEpic:    true,
 					EpicPlan:  plan,
 					ModelName: r.fallbackModelName(),
+				}
+				// GH-3938: roll up the children's real Claude usage onto the parent's
+				// own executions row — previously left at zero even after a long
+				// sequential run, since only pass/fail strings were tracked per child.
+				if childMetrics != nil {
+					epicResult.TokensInput = childMetrics.TokensInput
+					epicResult.TokensOutput = childMetrics.TokensOutput
+					epicResult.TokensTotal = childMetrics.TokensTotal
+					epicResult.CacheCreationInputTokens = childMetrics.CacheCreationInputTokens
+					epicResult.CacheReadInputTokens = childMetrics.CacheReadInputTokens
+					epicResult.ResearchTokens = childMetrics.ResearchTokens
+					epicResult.FilesChanged = childMetrics.FilesChanged
+					epicResult.LinesAdded = childMetrics.LinesAdded
+					epicResult.LinesRemoved = childMetrics.LinesRemoved
+					epicResult.EstimatedCostUSD = childMetrics.EstimatedCostUSD
+					if childMetrics.ModelName != "" {
+						epicResult.ModelName = childMetrics.ModelName
+					}
 				}
 
 				if task.CreatePR && task.Branch != "" {
@@ -1953,6 +2027,13 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				} else {
 					r.reportProgress(task.ID, "Complete", 100, "Epic completed successfully")
 				}
+				// GH-3938 / GH-3224 ghost-SHA guard shape: a bare Success=true is not
+				// proof of work. If this epic run shipped zero tokens, zero file
+				// changes, and no commit/PR anywhere — not even via finalizeEpicBranchPR
+				// — reclassify it as no_op instead of silently persisting a "completed"
+				// row that hides the fact nothing happened.
+				classifyZeroDeliveryEpicCompletion(epicResult)
+				r.recordEpicTerminalEvent(task.LogExecutionID(), epicResult)
 				return epicResult, nil
 			}
 		} // else: plan succeeded

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -689,20 +689,29 @@ func (s *Store) ListExecutionsForTask(taskID string) ([]*Execution, error) {
 type Stage string
 
 const (
-	StageQueued           Stage = "queued"
-	StageSpecValidated    Stage = "spec_validated"
-	StageRunning          Stage = "running"
-	StageCommit           Stage = "commit"
-	StagePRCreated        Stage = "pr_created"
-	StageCIPassed         Stage = "ci_passed"
-	StageCIFailed         Stage = "ci_failed"
-	StageAwaitingApproval Stage = "awaiting_approval"
-	StageMerged           Stage = "merged"
-	StageReleased         Stage = "released"
-	StageFailed           Stage = "failed"
-	StageNoOp             Stage = "no_op"
-	StageSkipped          Stage = "skipped"
-	StageStalled          Stage = "stalled"
+	StageQueued        Stage = "queued"
+	StageSpecValidated Stage = "spec_validated"
+	StageRunning       Stage = "running"
+	StageClaudeStarted Stage = "claude_started"
+	StageDecomposed    Stage = "decomposed"
+	// StageImplementationStarted marks a direct (non-epic) task handing off to
+	// Claude for real implementation work. GH-3938 wires claude_started/
+	// decomposed/completed on the epic-parent path only; this value is
+	// reserved for a future direct-path instrumentation pass so the enum
+	// matches the full lifecycle described in GH-3840 up front.
+	StageImplementationStarted Stage = "implementation_started"
+	StageCommit                Stage = "commit"
+	StagePRCreated             Stage = "pr_created"
+	StageCIPassed              Stage = "ci_passed"
+	StageCIFailed              Stage = "ci_failed"
+	StageAwaitingApproval      Stage = "awaiting_approval"
+	StageMerged                Stage = "merged"
+	StageReleased              Stage = "released"
+	StageCompleted             Stage = "completed"
+	StageFailed                Stage = "failed"
+	StageNoOp                  Stage = "no_op"
+	StageSkipped               Stage = "skipped"
+	StageStalled               Stage = "stalled"
 )
 
 // Event represents a single stage-transition record for an execution.


### PR DESCRIPTION
## Summary

Closes GH-3938 (subtask of GH-3924): the epic-parent path in `executeWithOptions` returned directly after `spec_validated`, so `pilot trace` never showed `claude_started`/`decomposed`/terminal events for epics, and children's real token/file/cost metrics were discarded (only pass/fail strings tracked per child) — a long epic run could persist as `tokens_output=0` on its own row.

- Emits `claude_started` (epic planning invocation), `decomposed` (with the actual child issue list), and a terminal `completed`/`no_op`/`failed` event on every epic-parent code path (happy path, plan-mismatch guard, sub-issue creation failure, sub-issue execution failure, and the "already recovered" short-circuit).
- `executeSubIssuesTracked` now returns the aggregated token/cost/file metrics rolled up from every child that actually ran, and the epic-parent's `ExecutionResult` copies them over — fixing the root cause of the zero-token regression.
- Adds a no-op guard (`classifyZeroDeliveryEpicCompletion`, mirroring the GH-3224 ghost-SHA guard shape): an epic reporting `Success=true` with zero tokens, zero files, and no commit/PR anywhere is reclassified as `no_op` instead of silently persisting as `completed`.
- The parent-issue decomposition comment now reads "decomposed into N children: #a, #b, #c" (sourced from the real `CreatedIssue` list) instead of a generic "starting sequential execution" message.
- Adds `StageClaudeStarted`/`StageDecomposed`/`StageCompleted`/`StageImplementationStarted` to the `memory.Stage` enum (the last is reserved for a future direct-path instrumentation pass, out of this subtask's scope fence).

Scope fence: only `internal/executor/` — dashboard, CLI trace renderer, and autopilot policy are sibling GH-3924 subtasks and untouched here.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite green, including all pre-existing `internal/executor` and `internal/memory` tests)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` → 0 issues
- [x] New table-driven tests in `internal/executor/gh3938_test.go`:
  - `TestEpicPath_TokenHarvestAndFullEventSequence` — fake Claude stream produces `tokens_output > 0` and the full `spec_validated → claude_started → decomposed → completed` event sequence
  - `TestEpicPath_ZeroDeliveryTripsNoOpGuard` — a zero-output run trips the no-op guard instead of marking `completed`
  - `TestClassifyZeroDeliveryEpicCompletion` — focused unit coverage of the guard predicate, including a case proving legitimate non-epic zero-deliverable completions (GH-3846 synthetic dispatch) stay untouched
  - `TestExecuteSubIssuesTracked_PostsDecomposedChildrenComment` — decomposition posts the honest child-list comment
  - `TestGH3938_ExistingCloseGuardsUnchanged` — regression coverage for the GH-3513 text-search dedup guard and the open-PR/work-loss veto