### PR TITLE
feat(autopilot): per-project release publish mode (workflow|api|tag_only) (GH-3926)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -407,6 +407,7 @@
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
 | Poll-cycle epic-parent auto-close | ✅ | autopilot | - | - | `reconcileEpicParents` sweeps open decomposed parents every poll tick, verifying each closed child shipped a merged PR (not just "closed") before closing the parent with a summary comment naming the merged PRs; a closed-without-merge child vetoes the close with an explicit logged reason (GH-3939) |
+| Per-project release publish mode | ✅ | autopilot | - | `release.publish`, `projects[].release` | `workflow` (default, unchanged)/`api` (Pilot calls `CreateRelease` after tagging)/`tag_only`; project overlay (`ProjectReleaseConfig.Apply`) resolves project > env > global; idempotent retry via `ensureReleasePublished` if CreateRelease fails after a successful tag (v2.222.3, GH-3926) |
 
 ## Epic Management
 

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -158,10 +158,10 @@ func WithProjectPath(path string) ControllerOption {
 }
 
 // WithReleaseOverride wires a per-project release config overlay (GH-3930)
-// for this controller's repo. Nil is a no-op. Overlay resolution against the
-// global/env ReleaseConfig (Apply/resolvedRelease) and consumption in
-// handleReleasing land in GH-3929; this option only stores the overlay so
-// call sites can wire it ahead of that work (GH-3931).
+// for this controller's repo. Nil is a no-op. NewController applies the
+// overlay (ProjectReleaseConfig.Apply) against the resolved global/env
+// ReleaseConfig before constructing the releaser, so options must be applied
+// before that point — see the options loop at the top of NewController. GH-3926.
 func WithReleaseOverride(o *ProjectReleaseConfig) ControllerOption {
 	return func(c *Controller) {
 		c.projectRelease = o
@@ -234,9 +234,16 @@ type Controller struct {
 	projectPath string
 
 	// projectRelease is the per-project release config overlay (GH-3930),
-	// wired via WithReleaseOverride. Nil = no project-level override. Overlay
-	// resolution and handleReleasing consumption land in GH-3929.
+	// wired via WithReleaseOverride. Nil = no project-level override. Applied
+	// once during NewController — see resolvedReleaseCfg. GH-3926.
 	projectRelease *ProjectReleaseConfig
+
+	// resolvedReleaseCfg is the effective release config computed once in
+	// NewController: env-scoped config wins over global, then projectRelease
+	// (if any) is overlaid on top. resolvedRelease() returns this directly —
+	// it is NOT recomputed per call, so it reflects exactly what c.releaser
+	// was constructed with. Nil = releasing is not configured at any level. GH-3926.
+	resolvedReleaseCfg *ReleaseConfig
 
 	// GH-3271: called after a PR merges and pilot-done is applied so pollers
 	// can immediately re-mark the issue as processed, closing the merge→done
@@ -271,20 +278,53 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 		log:            slog.Default().With("component", "autopilot"),
 	}
 
+	// Options must apply before the releaser is constructed below: the
+	// per-project release overlay (WithReleaseOverride) needs c.projectRelease
+	// set so the resolved+overlaid config below reflects it, rather than the
+	// options loop overwriting c.projectRelease after the releaser already
+	// picked up the un-overlaid config (GH-3926). Every other option (board
+	// sync, project path, memory store, ...) only sets plain fields, so
+	// running them first is safe.
+	for _, opt := range opts {
+		opt(c)
+	}
+
 	c.ciMonitor = NewCIMonitor(ghClient, owner, repo, cfg)
 	c.autoMerger = NewAutoMerger(ghClient, approvalMgr, c.ciMonitor, owner, repo, cfg)
 	c.feedbackLoop = NewFeedbackLoop(ghClient, owner, repo, cfg)
 
-	// Initialize releaser from resolved release config (env-scoped wins over global).
-	// Mirrors resolvedRelease() so construction matches runtime decision path.
-	relCfg := resolveRelease(cfg)
+	// Resolve the effective release config: env-scoped wins over global, then
+	// the per-project overlay (if any) is applied on top (GH-3926/GH-3930).
+	// Stored once on the controller — resolvedRelease() returns this value
+	// directly rather than recomputing it, so it always matches what the
+	// releaser below was constructed with.
+	baseRelCfg := resolveRelease(cfg)
 	relSource := "none"
 	if env := cfg.ResolvedEnv(); env != nil && env.Release != nil {
 		relSource = "env:" + cfg.EnvironmentName()
 	} else if cfg.Release != nil {
 		relSource = "global"
 	}
-	c.log.Info("resolved release policy", "enabled", relCfg != nil && relCfg.Enabled, "source", relSource)
+	relCfg := baseRelCfg
+	if c.projectRelease != nil {
+		relCfg = c.projectRelease.Apply(baseRelCfg)
+		if relSource == "none" {
+			relSource = "project-only"
+		} else {
+			relSource += "+project-overlay"
+		}
+	}
+	c.resolvedReleaseCfg = relCfg
+
+	publishMode := ""
+	if relCfg != nil {
+		publishMode = relCfg.PublishMode()
+	}
+	c.log.Info("resolved release policy",
+		"enabled", relCfg != nil && relCfg.Enabled,
+		"source", relSource,
+		"publish", publishMode,
+	)
 	if relCfg != nil && relCfg.Enabled {
 		c.releaser = NewReleaser(ghClient, owner, repo, relCfg)
 	}
@@ -292,10 +332,6 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 	// Initialize deployer if post-merge config exists
 	if env := cfg.ResolvedEnv(); env.PostMerge != nil && env.PostMerge.Action != "" && env.PostMerge.Action != "none" {
 		c.deployer = NewDeployer(ghClient, owner, repo, env.PostMerge)
-	}
-
-	for _, opt := range opts {
-		opt(c)
 	}
 
 	return c
@@ -2155,10 +2191,12 @@ func resolveRelease(cfg *Config) *ReleaseConfig {
 	return cfg.Release
 }
 
-// resolvedRelease returns the effective release config, preferring per-environment
-// config over global. Returns nil if neither is set.
+// resolvedRelease returns the effective release config: per-environment config
+// wins over global, then the per-project overlay (if any) is applied on top.
+// Computed once in NewController and cached — see resolvedReleaseCfg. Returns
+// nil if releasing is not configured at any level.
 func (c *Controller) resolvedRelease() *ReleaseConfig {
-	return resolveRelease(c.config)
+	return c.resolvedReleaseCfg
 }
 
 // shouldTriggerRelease returns true if auto-release is configured.
@@ -2216,6 +2254,8 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		prState.ReleasingFirstAt = time.Now()
 	}
 
+	rel := c.resolvedRelease()
+
 	// Resolve the actual repo owner/name from the PR URL.
 	// Cross-repo PRs (e.g. auth-service) have a PRURL pointing to a different repo
 	// than c.owner/c.repo (the pilot repo). All release API calls must target the
@@ -2242,6 +2282,11 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 			fmt.Errorf("failed to check existing tags for PR #%d: %w", prState.PRNumber, err))
 	}
 	if existingTag != "" {
+		// GH-3926: publish mode "api" idempotence — if a prior pass created
+		// this tag (or the tag it's an ancestor of) but a transient failure
+		// meant the GitHub Release was never published, publish it now instead
+		// of silently draining the PR with no release ever created.
+		c.ensureReleasePublished(ctx, rel, owner, repo, existingTag, prState)
 		c.log.Info("commit already covered by existing tag, skipping release",
 			"pr", prState.PRNumber,
 			"sha", ShortSHA(prState.HeadSHA),
@@ -2260,6 +2305,8 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 			fmt.Errorf("failed to check published release for PR #%d: %w", prState.PRNumber, err))
 	}
 	if exactTag != "" {
+		// GH-3926: same idempotence as the existingTag drain above.
+		c.ensureReleasePublished(ctx, rel, owner, repo, exactTag, prState)
 		c.log.Info("commit already tagged (exact match in full tag history) — treating as released",
 			"pr", prState.PRNumber,
 			"sha", ShortSHA(prState.HeadSHA),
@@ -2304,7 +2351,6 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 
 	// Calculate new version
 	newVersion := currentVersion.Bump(bumpType)
-	rel := c.resolvedRelease()
 	prState.ReleaseVersion = newVersion.String(rel.TagPrefix)
 
 	c.log.Info("creating release",
@@ -2322,6 +2368,11 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		// Treat it as success so the PR drains from activePRs instead of
 		// looping forever on a tag it can never re-create. (TASK-316)
 		if isDuplicateTagError(err) {
+			// GH-3926: the tag we attempted to create is prState.ReleaseVersion —
+			// same idempotence as the existingTag/exactTag drains above, so a
+			// prior CreateReleaseForRepo failure on this exact tag still gets
+			// the release published before draining.
+			c.ensureReleasePublished(ctx, rel, owner, repo, prState.ReleaseVersion, prState)
 			c.log.Info("tag already exists at HEAD SHA — treating as released",
 				"pr", prState.PRNumber,
 				"sha", ShortSHA(prState.HeadSHA),
@@ -2334,16 +2385,60 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	}
 
 	releaseURL := fmt.Sprintf("https://github.com/%s/%s/releases/tag/%s", owner, repo, tagName)
-	c.log.Info("tag created (GoReleaser will create release)",
-		"pr", prState.PRNumber,
-		"version", prState.ReleaseVersion,
-		"tag", tagName,
-	)
+
+	// GH-3926: branch on the resolved publish mode. "workflow" (default)
+	// preserves the original behavior byte-for-byte — Pilot only tags, the
+	// repo's own tag-triggered CI (e.g. GoReleaser) publishes the release.
+	switch rel.PublishMode() {
+	case ReleasePublishAPI:
+		body := ""
+		if rel.GenerateChangelog {
+			body = GenerateChangelog(commits, prState.PRNumber)
+		}
+		release, relErr := c.releaser.CreateReleaseForRepo(ctx, owner, repo, tagName, body)
+		switch {
+		case relErr == nil:
+			releaseURL = release.HTMLURL
+			c.log.Info("tag created — published GitHub Release via API",
+				"pr", prState.PRNumber,
+				"version", prState.ReleaseVersion,
+				"tag", tagName,
+				"release_url", releaseURL,
+			)
+		case isDuplicateReleaseError(relErr):
+			c.log.Info("tag created — GitHub Release already exists for tag, treating as published",
+				"pr", prState.PRNumber,
+				"tag", tagName,
+			)
+		default:
+			// The tag already landed — only the release publish failed. Retry
+			// (or escalate at the cap) WITHOUT re-creating the tag: the next
+			// pass hits the existingTag/exactTag drain above, which retries
+			// CreateReleaseForRepo via ensureReleasePublished.
+			return c.checkReleasingRetryOrEscalate(ctx, prState,
+				fmt.Errorf("failed to publish GitHub Release for tag %s: %w", tagName, relErr))
+		}
+	case ReleasePublishTagOnly:
+		c.log.Info("tag created (tag_only mode — no GitHub Release will be published)",
+			"pr", prState.PRNumber,
+			"version", prState.ReleaseVersion,
+			"tag", tagName,
+		)
+	default:
+		c.log.Info("tag created — waiting for release workflow to publish GitHub Release",
+			"pr", prState.PRNumber,
+			"version", prState.ReleaseVersion,
+			"tag", tagName,
+		)
+	}
 
 	// Enrich release with LLM-generated summary (best-effort, non-blocking).
-	// Runs in a goroutine because it polls for GoReleaser to publish the release
-	// (up to 5 min) and we don't want to block the notification or PR cleanup.
-	if c.releaseSummary != nil && rel.GenerateSummary {
+	// Runs in a goroutine because in "workflow" mode it polls for GoReleaser to
+	// publish the release (up to 5 min); in "api" mode GetReleaseByTag succeeds
+	// immediately since the release was just created above. Skipped entirely
+	// for "tag_only" — no release will ever appear, so the poll would just
+	// burn 5 min before warning.
+	if rel.PublishMode() != ReleasePublishTagOnly && c.releaseSummary != nil && rel.GenerateSummary {
 		logging.SafeGo("autopilot-controller", func() {
 			enrichCtx, cancel := context.WithTimeout(context.Background(), releasePollTimeout+releaseSummaryTimeout)
 			defer cancel()
@@ -2383,6 +2478,50 @@ func isDuplicateTagError(err error) bool {
 		return false
 	}
 	return strings.Contains(strings.ToLower(err.Error()), "already exists")
+}
+
+// ensureReleasePublished makes handleReleasing's "commit already tagged"
+// drain paths idempotent under publish mode "api": if a prior pass tagged this
+// commit but then failed to publish the GitHub Release (transient API error,
+// process restart, ...), the retry poll finds the tag via
+// tagCoveringCommit/GetTagForSHA/isDuplicateTagError and would otherwise drain
+// the PR having never published a release. No-op for "workflow"/"tag_only" —
+// neither mode expects Pilot to have created a release. Best-effort: logs and
+// returns on failure rather than blocking the drain, since the tag is the
+// source of truth for "released" and a human can always publish manually.
+// GH-3926.
+func (c *Controller) ensureReleasePublished(ctx context.Context, rel *ReleaseConfig, owner, repo, tagName string, prState *PRState) {
+	if rel == nil || rel.PublishMode() != ReleasePublishAPI {
+		return
+	}
+	existing, err := c.ghClient.GetReleaseByTag(ctx, owner, repo, tagName)
+	if err != nil {
+		c.log.Warn("ensureReleasePublished: failed to check for existing release, skipping",
+			"tag", tagName, "error", err)
+		return
+	}
+	if existing != nil {
+		return
+	}
+
+	body := ""
+	if rel.GenerateChangelog {
+		if commits, cErr := c.ghClient.GetPRCommits(ctx, owner, repo, prState.PRNumber); cErr == nil {
+			body = GenerateChangelog(commits, prState.PRNumber)
+		}
+	}
+	release, err := c.releaser.CreateReleaseForRepo(ctx, owner, repo, tagName, body)
+	if err != nil {
+		if isDuplicateReleaseError(err) {
+			c.log.Info("ensureReleasePublished: release already exists for tag (idempotent retry)", "tag", tagName)
+			return
+		}
+		c.log.Warn("ensureReleasePublished: failed to publish release for already-tagged commit",
+			"tag", tagName, "error", err)
+		return
+	}
+	c.log.Info("ensureReleasePublished: published GitHub Release for already-tagged commit",
+		"tag", tagName, "release_url", release.HTMLURL)
 }
 
 // checkReleasingRetryOrEscalate returns nil (transitioning prState to StageFailed) when

--- a/internal/autopilot/controller_releasing_test.go
+++ b/internal/autopilot/controller_releasing_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -71,6 +72,296 @@ func newReleasingController(t *testing.T, serverURL string) *Controller {
 		t.Fatal("releaser not initialized — check ReleaseConfig wiring")
 	}
 	return c
+}
+
+// newReleasingControllerWithPublish is like newReleasingController but lets the
+// test choose the release publish mode (GH-3926).
+func newReleasingControllerWithPublish(t *testing.T, serverURL, publish string) *Controller {
+	t.Helper()
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, serverURL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.Release = &ReleaseConfig{
+		Enabled:           true,
+		Trigger:           "on_merge",
+		TagPrefix:         "v",
+		NotifyOnRelease:   false,
+		GenerateSummary:   false,
+		GenerateChangelog: true,
+		Publish:           publish,
+	}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	if c.releaser == nil {
+		t.Fatal("releaser not initialized — check ReleaseConfig wiring")
+	}
+	return c
+}
+
+// publishModeTestServer serves the full happy path through tag creation (no
+// covering tags, a reachable SHA, and a feat commit to trigger a version
+// bump), delegating any request whose path contains "/releases" (other than
+// GET .../releases/latest, served here so every mode gets a base version) to
+// onReleases — so each publish-mode test only has to describe the release
+// side without duplicating the tag/version/commit plumbing.
+func publishModeTestServer(onReleases http.HandlerFunc) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.0.0"})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/commits"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat: add a thing")})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/branches/"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"name":   "main",
+				"commit": map[string]string{"sha": "publishmodemainsha"},
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ahead"})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
+			w.WriteHeader(http.StatusCreated)
+		case strings.Contains(r.URL.Path, "/releases"):
+			onReleases(w, r)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+}
+
+// TestHandleReleasing_PublishModes verifies GH-3926's per-mode behavior at the
+// point a tag has just been created: "api" publishes a GitHub Release via the
+// API exactly once (tag_name + generated changelog body); "workflow" and
+// "tag_only" never call POST /releases. All three modes drain the PR.
+func TestHandleReleasing_PublishModes(t *testing.T) {
+	tests := []struct {
+		name        string
+		publish     string
+		wantPublish bool
+	}{
+		{name: "workflow leaves publishing to the repo's CI", publish: "workflow", wantPublish: false},
+		{name: "tag_only publishes nothing", publish: "tag_only", wantPublish: false},
+		{name: "api publishes the GitHub Release itself", publish: "api", wantPublish: true},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				releasePosts int
+				gotTagName   string
+				gotBody      string
+			)
+			server := publishModeTestServer(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/releases"):
+					releasePosts++
+					var input github.ReleaseInput
+					raw, _ := io.ReadAll(r.Body)
+					_ = json.Unmarshal(raw, &input)
+					gotTagName = input.TagName
+					gotBody = input.Body
+					w.WriteHeader(http.StatusCreated)
+					_ = json.NewEncoder(w).Encode(github.Release{
+						TagName: input.TagName,
+						HTMLURL: "https://github.com/owner/repo/releases/tag/" + input.TagName,
+					})
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			})
+			defer server.Close()
+
+			c := newReleasingControllerWithPublish(t, server.URL, tt.publish)
+			prNumber := 600 + i
+			prState := &PRState{PRNumber: prNumber, HeadSHA: fmt.Sprintf("sha%d", prNumber), Stage: StageReleasing}
+			c.mu.Lock()
+			c.activePRs[prNumber] = prState
+			c.mu.Unlock()
+
+			if err := c.handleReleasing(context.Background(), prState); err != nil {
+				t.Fatalf("handleReleasing returned error: %v", err)
+			}
+
+			if (releasePosts > 0) != tt.wantPublish {
+				t.Errorf("POST /releases called %d times, want called=%v", releasePosts, tt.wantPublish)
+			}
+			if tt.wantPublish {
+				if releasePosts != 1 {
+					t.Errorf("POST /releases called %d times, want exactly 1", releasePosts)
+				}
+				if gotTagName != prState.ReleaseVersion {
+					t.Errorf("release tag_name = %q, want %q", gotTagName, prState.ReleaseVersion)
+				}
+				if gotBody == "" {
+					t.Error("release body should carry the generated changelog")
+				}
+			}
+			c.mu.RLock()
+			_, tracked := c.activePRs[prNumber]
+			c.mu.RUnlock()
+			if tracked {
+				t.Error("PR must drain from activePRs in every publish mode")
+			}
+		})
+	}
+}
+
+// TestHandleReleasing_APIModeRetryAfterCreateReleaseFailure pins the
+// idempotence fix (GH-3926): a transient CreateRelease failure right after a
+// successful tag push must not permanently lose the release. Pass 1 tags
+// successfully but the release POST 500s (retryable, PR stays tracked). Pass
+// 2 finds the tag already exists (drain path) and — because no release exists
+// yet for it — publishes the release there instead of silently draining.
+func TestHandleReleasing_APIModeRetryAfterCreateReleaseFailure(t *testing.T) {
+	const headSHA = "sha700retry"
+	var (
+		releasePosts   int
+		tagCreated     bool
+		createdTagName string
+	)
+	pass := 1
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			if pass == 1 || createdTagName == "" {
+				_, _ = w.Write([]byte(`[]`))
+				return
+			}
+			// Pass 2: the tag created in pass 1 now exists at HeadSHA.
+			_ = json.NewEncoder(w).Encode([]github.Tag{tagAt(createdTagName, headSHA)})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.0.0"})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/commits"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat: add a thing")})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/branches/"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"name":   "main",
+				"commit": map[string]string{"sha": "retrymainsha"},
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ahead"})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
+			tagCreated = true
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
+			// No release ever exists yet in this test — that's the point.
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/releases"):
+			releasePosts++
+			var input github.ReleaseInput
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &input)
+			createdTagName = input.TagName
+			if pass == 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"server error"}`))
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.Release{
+				TagName: input.TagName,
+				HTMLURL: "https://github.com/owner/repo/releases/tag/" + input.TagName,
+			})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := newReleasingControllerWithPublish(t, server.URL, "api")
+	prState := &PRState{PRNumber: 700, HeadSHA: headSHA, Stage: StageReleasing}
+	c.mu.Lock()
+	c.activePRs[700] = prState
+	c.mu.Unlock()
+
+	// Pass 1: tag creation succeeds, release publish fails transiently.
+	err := c.handleReleasing(context.Background(), prState)
+	if err == nil {
+		t.Fatal("pass 1: expected a retryable error after CreateRelease failure, got nil")
+	}
+	if !tagCreated {
+		t.Fatal("pass 1: tag should have been created")
+	}
+	if createdTagName == "" {
+		t.Fatal("pass 1: CreateRelease should have been attempted for the new tag")
+	}
+	c.mu.RLock()
+	_, tracked := c.activePRs[700]
+	c.mu.RUnlock()
+	if !tracked {
+		t.Error("pass 1: PR must remain tracked for retry after a release-publish failure")
+	}
+
+	// Pass 2: the tag now exists — handleReleasing must reach the drain path's
+	// idempotence check (ensureReleasePublished) and successfully publish the
+	// release instead of silently draining with no release ever created.
+	pass = 2
+	tagCreated = false
+	err = c.handleReleasing(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("pass 2: expected nil (drained), got error: %v", err)
+	}
+	if tagCreated {
+		t.Error("pass 2: CreateGitTag must NOT be called again — the tag already exists")
+	}
+	if releasePosts != 2 {
+		t.Errorf("POST /releases called %d times across both passes, want 2 (pass 1 failed, pass 2 succeeded)", releasePosts)
+	}
+	c.mu.RLock()
+	_, tracked = c.activePRs[700]
+	c.mu.RUnlock()
+	if tracked {
+		t.Error("pass 2: PR must drain from activePRs once the release is published")
+	}
+}
+
+// TestHandleReleasing_APIModeDuplicateRelease verifies that a 422
+// "already_exists" response from POST /releases is treated as success: the
+// release already exists (e.g. a racing retry created it first), so the PR
+// drains instead of looping on an error it can never recover from.
+func TestHandleReleasing_APIModeDuplicateRelease(t *testing.T) {
+	server := publishModeTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/releases"):
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"Validation Failed","errors":[{"resource":"Release","code":"already_exists","field":"tag_name"}]}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+	defer server.Close()
+
+	c := newReleasingControllerWithPublish(t, server.URL, "api")
+	prState := &PRState{PRNumber: 800, HeadSHA: "sha800duplicate", Stage: StageReleasing}
+	c.mu.Lock()
+	c.activePRs[800] = prState
+	c.mu.Unlock()
+
+	err := c.handleReleasing(context.Background(), prState)
+	if err != nil {
+		t.Fatalf("422 already_exists must be treated as released, got error: %v", err)
+	}
+	c.mu.RLock()
+	_, tracked := c.activePRs[800]
+	c.mu.RUnlock()
+	if tracked {
+		t.Error("PR must drain once the release is confirmed to already exist")
+	}
 }
 
 // TestHandleReleasing_GetTagForSHAError verifies that a tag-lookup failure makes

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -106,6 +106,72 @@ func TestNewController_ReleaserInit(t *testing.T) {
 	}
 }
 
+// TestResolvedRelease_Precedence verifies GH-3926's three-level precedence for
+// the effective release config: project overlay > per-environment config >
+// global config, wired via WithReleaseOverride and resolved once in
+// NewController (resolvedRelease()/resolvedReleaseCfg).
+func TestResolvedRelease_Precedence(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+
+	t.Run("global only", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", Publish: "workflow"}
+		c := NewController(cfg, ghClient, nil, "owner", "repo")
+		rel := c.resolvedRelease()
+		if rel == nil || rel.PublishMode() != "workflow" {
+			t.Fatalf("resolvedRelease() = %+v, want publish=workflow from global", rel)
+		}
+	})
+
+	t.Run("env overrides global", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", Publish: "workflow"}
+		cfg.activeEnvName = "test"
+		cfg.activeEnvConfig = &EnvironmentConfig{
+			Release: &ReleaseConfig{Enabled: true, Trigger: "on_merge", Publish: "tag_only"},
+		}
+		c := NewController(cfg, ghClient, nil, "owner", "repo")
+		rel := c.resolvedRelease()
+		if rel == nil || rel.PublishMode() != "tag_only" {
+			t.Fatalf("resolvedRelease() = %+v, want publish=tag_only from env (overriding global)", rel)
+		}
+	})
+
+	t.Run("project overlay wins over env and global", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", Publish: "workflow"}
+		cfg.activeEnvName = "test"
+		cfg.activeEnvConfig = &EnvironmentConfig{
+			Release: &ReleaseConfig{Enabled: true, Trigger: "on_merge", Publish: "tag_only"},
+		}
+		overlay := &ProjectReleaseConfig{Publish: "api"}
+		c := NewController(cfg, ghClient, nil, "owner", "repo", WithReleaseOverride(overlay))
+		rel := c.resolvedRelease()
+		if rel == nil || rel.PublishMode() != "api" {
+			t.Fatalf("resolvedRelease() = %+v, want publish=api from project overlay (overriding env+global)", rel)
+		}
+		if !rel.Enabled {
+			t.Error("Enabled should still be inherited as true from env config")
+		}
+	})
+
+	t.Run("project overlay alone enables release with no base config", func(t *testing.T) {
+		cfg := DefaultConfig()
+		overlay := &ProjectReleaseConfig{Enabled: boolPtr(true), Publish: "api"}
+		c := NewController(cfg, ghClient, nil, "owner", "repo", WithReleaseOverride(overlay))
+		rel := c.resolvedRelease()
+		if rel == nil {
+			t.Fatal("resolvedRelease() = nil, want a config derived from DefaultReleaseConfig via the overlay")
+		}
+		if rel.PublishMode() != "api" {
+			t.Errorf("PublishMode() = %q, want %q", rel.PublishMode(), "api")
+		}
+		if c.releaser == nil {
+			t.Error("releaser should be initialized when the project overlay alone enables release")
+		}
+	})
+}
+
 func TestController_OnPRCreated(t *testing.T) {
 	ghClient := github.NewClient(testutil.FakeGitHubToken)
 	cfg := DefaultConfig()

--- a/internal/autopilot/releaser.go
+++ b/internal/autopilot/releaser.go
@@ -283,6 +283,36 @@ func (r *Releaser) CreateTagForRepo(ctx context.Context, owner, repo string, prS
 	return tagName, nil
 }
 
+// CreateReleaseForRepo publishes a GitHub Release for tagName in the specified
+// repository via the REST API (publish mode "api", GH-3926). When body is
+// empty, GenerateNotes is requested so GitHub compiles release notes from the
+// commits since the previous release.
+func (r *Releaser) CreateReleaseForRepo(ctx context.Context, owner, repo, tagName, body string) (*github.Release, error) {
+	input := &github.ReleaseInput{
+		TagName:       tagName,
+		Name:          tagName,
+		Body:          body,
+		GenerateNotes: body == "",
+	}
+	release, err := r.ghClient.CreateRelease(ctx, owner, repo, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create release %s: %w", tagName, err)
+	}
+	return release, nil
+}
+
+// isDuplicateReleaseError reports whether err indicates a release already
+// exists for the requested tag. GitHub returns HTTP 422 with an
+// `"already_exists"` error code when POSTing /releases for a tag that already
+// has a release — treated as success so a retry after a transient failure
+// doesn't loop forever trying to recreate it.
+func isDuplicateReleaseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "already_exists")
+}
+
 // GetCurrentVersionForRepo gets the current version from the specified repository.
 func (r *Releaser) GetCurrentVersionForRepo(ctx context.Context, owner, repo string) (SemVer, error) {
 	release, err := r.ghClient.GetLatestRelease(ctx, owner, repo)

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -373,17 +373,93 @@ type ReleaseConfig struct {
 	Publish string `yaml:"publish,omitempty"`
 }
 
+// Publish mode values for ReleaseConfig.Publish / ProjectReleaseConfig.Publish (GH-3926).
+const (
+	// ReleasePublishWorkflow leaves publishing to the repo's own tag-triggered
+	// CI (e.g. GoReleaser). This is the default when Publish is empty.
+	ReleasePublishWorkflow = "workflow"
+	// ReleasePublishAPI has Pilot publish the GitHub Release itself via the
+	// REST API immediately after tagging.
+	ReleasePublishAPI = "api"
+	// ReleasePublishTagOnly pushes the tag and publishes nothing.
+	ReleasePublishTagOnly = "tag_only"
+)
+
+// PublishMode returns the normalized publish mode, defaulting empty to
+// ReleasePublishWorkflow so callers never need to special-case "". A nil
+// receiver also returns the default. See internal/config Config.Validate for
+// the enum check (GH-3930).
+func (r *ReleaseConfig) PublishMode() string {
+	if r == nil || r.Publish == "" {
+		return ReleasePublishWorkflow
+	}
+	return r.Publish
+}
+
 // ProjectReleaseConfig overlays release settings for a single project on top
 // of the global and per-environment ReleaseConfig blocks. Unset fields
 // inherit the base value — e.g. a project may override Publish while leaving
-// Enabled nil to inherit the global setting. See internal/config
-// ProjectConfig.Release (GH-3930); overlay resolution (Apply/PublishMode) and
-// controller wiring land in GH-3929/GH-3931.
+// Enabled nil to inherit the global setting. Trigger, VersionStrategy, and
+// RequireCI are intentionally NOT overlayable here — they stay env/global-only
+// (a project overriding when releases fire or how versions bump would make
+// the release cadence inconsistent across repos sharing one autopilot config).
+// See internal/config ProjectConfig.Release (GH-3930); overlay resolution
+// (Apply) and controller wiring land here and in GH-3931.
 type ProjectReleaseConfig struct {
 	// Enabled overrides ReleaseConfig.Enabled for this project. Nil inherits.
 	Enabled *bool `yaml:"enabled,omitempty"`
 	// Publish overrides ReleaseConfig.Publish for this project. Empty inherits.
 	Publish string `yaml:"publish,omitempty"`
+	// TagPrefix overrides ReleaseConfig.TagPrefix for this project. Empty inherits.
+	TagPrefix string `yaml:"tag_prefix,omitempty"`
+	// GenerateChangelog overrides ReleaseConfig.GenerateChangelog for this project. Nil inherits.
+	GenerateChangelog *bool `yaml:"generate_changelog,omitempty"`
+	// NotifyOnRelease overrides ReleaseConfig.NotifyOnRelease for this project. Nil inherits.
+	NotifyOnRelease *bool `yaml:"notify_on_release,omitempty"`
+}
+
+// Apply overlays this project-level config on top of base (the resolved
+// global/environment ReleaseConfig), returning a new *ReleaseConfig with only
+// the fields this overlay explicitly sets overridden. Trigger, VersionStrategy,
+// and RequireCI always come from base — see the ProjectReleaseConfig doc.
+//
+// A nil receiver returns base unchanged (no overlay configured). When base is
+// nil (no release configured at the env/global level), Apply returns nil
+// unless the overlay itself turns releasing on (Enabled != nil && *Enabled),
+// in which case it starts from DefaultReleaseConfig() — a project block
+// consisting only of `release: { enabled: true, publish: api }` must work
+// without a global release block. GH-3926/GH-3930.
+func (p *ProjectReleaseConfig) Apply(base *ReleaseConfig) *ReleaseConfig {
+	if p == nil {
+		return base
+	}
+
+	var result ReleaseConfig
+	switch {
+	case base != nil:
+		result = *base
+	case p.Enabled != nil && *p.Enabled:
+		result = *DefaultReleaseConfig()
+	default:
+		return nil
+	}
+
+	if p.Enabled != nil {
+		result.Enabled = *p.Enabled
+	}
+	if p.Publish != "" {
+		result.Publish = p.Publish
+	}
+	if p.TagPrefix != "" {
+		result.TagPrefix = p.TagPrefix
+	}
+	if p.GenerateChangelog != nil {
+		result.GenerateChangelog = *p.GenerateChangelog
+	}
+	if p.NotifyOnRelease != nil {
+		result.NotifyOnRelease = *p.NotifyOnRelease
+	}
+	return &result
 }
 
 // DefaultReleaseConfig returns sensible defaults for release configuration.

--- a/internal/autopilot/types_test.go
+++ b/internal/autopilot/types_test.go
@@ -5,6 +5,112 @@ import (
 	"time"
 )
 
+func TestProjectReleaseConfig_Apply(t *testing.T) {
+	t.Run("nil overlay returns base unchanged", func(t *testing.T) {
+		base := &ReleaseConfig{Enabled: true, Publish: "workflow", TagPrefix: "v"}
+		var p *ProjectReleaseConfig
+		got := p.Apply(base)
+		if got != base {
+			t.Errorf("Apply(base) with nil overlay = %+v, want the same base pointer %+v", got, base)
+		}
+	})
+
+	t.Run("nil base with overlay not enabling release returns nil", func(t *testing.T) {
+		p := &ProjectReleaseConfig{Publish: "api"}
+		if got := p.Apply(nil); got != nil {
+			t.Errorf("Apply(nil) = %+v, want nil (overlay does not enable release)", got)
+		}
+	})
+
+	t.Run("nil base with enabled overlay starts from DefaultReleaseConfig", func(t *testing.T) {
+		p := &ProjectReleaseConfig{Enabled: boolPtr(true), Publish: "api"}
+		got := p.Apply(nil)
+		if got == nil {
+			t.Fatal("Apply(nil) = nil, want a config derived from DefaultReleaseConfig")
+		}
+		want := DefaultReleaseConfig()
+		if !got.Enabled {
+			t.Error("Enabled = false, want true")
+		}
+		if got.Publish != "api" {
+			t.Errorf("Publish = %q, want %q", got.Publish, "api")
+		}
+		if got.TagPrefix != want.TagPrefix {
+			t.Errorf("TagPrefix = %q, want default %q (uninvolved field must inherit)", got.TagPrefix, want.TagPrefix)
+		}
+	})
+
+	t.Run("publish-only overlay inherits everything else", func(t *testing.T) {
+		base := &ReleaseConfig{
+			Enabled:           true,
+			Trigger:           "on_merge",
+			VersionStrategy:   "conventional_commits",
+			TagPrefix:         "v",
+			GenerateChangelog: true,
+			NotifyOnRelease:   true,
+			RequireCI:         true,
+			Publish:           "workflow",
+		}
+		p := &ProjectReleaseConfig{Publish: "api"}
+		got := p.Apply(base)
+		if got.Publish != "api" {
+			t.Errorf("Publish = %q, want %q", got.Publish, "api")
+		}
+		if !got.Enabled {
+			t.Error("Enabled must be inherited as true from base")
+		}
+		if got.TagPrefix != "v" {
+			t.Errorf("TagPrefix = %q, want inherited %q", got.TagPrefix, "v")
+		}
+		if !got.RequireCI {
+			t.Error("RequireCI must be inherited from base (not overlayable)")
+		}
+		// Base must not be mutated.
+		if base.Publish != "workflow" {
+			t.Errorf("base.Publish mutated to %q, want unchanged %q", base.Publish, "workflow")
+		}
+	})
+
+	t.Run("enabled override false disables an otherwise-enabled base", func(t *testing.T) {
+		base := &ReleaseConfig{Enabled: true, Publish: "workflow"}
+		p := &ProjectReleaseConfig{Enabled: boolPtr(false)}
+		got := p.Apply(base)
+		if got.Enabled {
+			t.Error("Enabled = true, want false (overlay explicitly disables)")
+		}
+	})
+
+	t.Run("tag_prefix override", func(t *testing.T) {
+		base := &ReleaseConfig{Enabled: true, TagPrefix: "v"}
+		p := &ProjectReleaseConfig{TagPrefix: "release-"}
+		got := p.Apply(base)
+		if got.TagPrefix != "release-" {
+			t.Errorf("TagPrefix = %q, want %q", got.TagPrefix, "release-")
+		}
+	})
+}
+
+func TestReleaseConfig_PublishMode(t *testing.T) {
+	tests := []struct {
+		name string
+		rel  *ReleaseConfig
+		want string
+	}{
+		{name: "nil receiver defaults to workflow", rel: nil, want: ReleasePublishWorkflow},
+		{name: "empty publish defaults to workflow", rel: &ReleaseConfig{Publish: ""}, want: ReleasePublishWorkflow},
+		{name: "explicit workflow", rel: &ReleaseConfig{Publish: "workflow"}, want: "workflow"},
+		{name: "api", rel: &ReleaseConfig{Publish: "api"}, want: "api"},
+		{name: "tag_only", rel: &ReleaseConfig{Publish: "tag_only"}, want: "tag_only"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.rel.PublishMode(); got != tt.want {
+				t.Errorf("PublishMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolvedEnv_LegacyDev(t *testing.T) {
 	cfg := &Config{Environment: EnvDev}
 	env := cfg.ResolvedEnv()


### PR DESCRIPTION
## Summary

Completes the per-project release publish mode (GH-3926): autopilot creates tags for all configured repos, but the post-tag path assumed a tag-triggered CI workflow (e.g. GoReleaser) would publish the GitHub Release. Only the pilot repo actually has one — on 2026-07-06 autopilot tagged `studio-sdk v0.29.0` and no Release was ever published, since studio-sdk has a CI-only workflow.

- `ReleaseConfig.PublishMode()` normalizes `Publish` (`workflow`/`api`/`tag_only`, default `workflow`).
- `ProjectReleaseConfig.Apply()` resolves the project > env > global overlay (a project block setting only `publish: api` inherits `Enabled`/`TagPrefix`/etc. rather than silently disabling releasing).
- `NewController` now applies options before constructing the releaser, so `WithReleaseOverride` participates in the resolved config the releaser is built from.
- `handleReleasing` dispatches its post-tag behavior on the resolved mode:
  - `workflow` (default): unchanged behavior, reworded log.
  - `api`: Pilot calls the new `Releaser.CreateReleaseForRepo` directly; 422 `already_exists` is treated as released.
  - `tag_only`: stops at the tag, skips the release-summary enrichment goroutine (which would otherwise poll for 5 min before warning).
- Idempotence fix: the "commit already tagged" drain paths (exact-tag match, duplicate-tag-create) now check `GetReleaseByTag` and create the release if missing, before draining the PR — so a transient `CreateRelease` failure after a successful tag never permanently loses the release.
- Removes the hardcoded `"tag created (GoReleaser will create release)"` log line.

Config validation (`internal/config`) and controller-construction wiring (`cmd/pilot/main.go`) landed in prior commits (6eea98ce, 248d80a0, 8bc3ed0f); this PR finishes the overlay resolution and `handleReleasing` consumption those commits were built to compile against.

**Note on a prior attempt:** an earlier identical implementation (PR #3949) was auto-closed by autopilot's CI-fix size guard after an unrelated `stress/` package test (`TestMemory_LargePayloads`) timed out in CI — a known, pre-existing flaky-suite issue (see `.agent/knowledge/memories/pitfalls/pitfall_poller_api_calls_deadlock_stress_suite.md`) unrelated to this diff, which touches only `internal/autopilot`. If CI flakes the same way here, please re-run rather than treat it as a diff defect.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/... ./internal/config/...` — all green, including new tests: `TestProjectReleaseConfig_Apply`, `TestReleaseConfig_PublishMode`, `TestResolvedRelease_Precedence`, `TestHandleReleasing_PublishModes`, `TestHandleReleasing_APIModeDuplicateRelease`, `TestHandleReleasing_APIModeRetryAfterCreateReleaseFailure`
- [x] `go test ./...` (full suite) green
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `grep -r "GoReleaser will create release"` — no matches