### PR TITLE
feat(alerts): add release_missing alert type and handler

### DIFF
--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -106,6 +106,10 @@ const (
 	// credential (e.g. a GitHub token) fails an authenticated validation
 	// call at startup, so a dead credential doesn't fail silently.
 	EventTypeConfigError EventType = "config_error"
+
+	// Post-tag release verification (GH-3927): fired when a release tag was
+	// created but no GitHub Release appeared within the verification window.
+	EventTypeReleaseMissing EventType = "release_missing"
 )
 
 const (
@@ -336,6 +340,8 @@ func (e *Engine) handleEvent(ctx context.Context, event Event) {
 		e.handleSecurityEvent(ctx, event)
 	case EventTypeConfigError:
 		e.handleConfigError(ctx, event)
+	case EventTypeReleaseMissing:
+		e.handleReleaseMissing(ctx, event)
 	case EventTypeBudgetExceeded, EventTypeBudgetWarning:
 		e.handleBudgetEvent(ctx, event)
 	case EventTypeAutopilotMetrics:
@@ -519,6 +525,21 @@ func (e *Engine) handleConfigError(ctx context.Context, event Event) {
 			continue
 		}
 		if rule.Type == AlertTypeServiceUnhealthy && e.shouldFire(rule) {
+			alert := e.createAlert(rule, event, event.Error)
+			e.fireAlert(ctx, rule, alert)
+		}
+	}
+}
+
+// handleReleaseMissing fires AlertTypeReleaseMissing rules when a release tag
+// was created but no GitHub Release appeared within the verification window
+// (GH-3927). Message comes from event.Error; metadata carries repo, tag, pr.
+func (e *Engine) handleReleaseMissing(ctx context.Context, event Event) {
+	for _, rule := range e.config.Rules {
+		if !rule.Enabled {
+			continue
+		}
+		if rule.Type == AlertTypeReleaseMissing && e.shouldFire(rule) {
 			alert := e.createAlert(rule, event, event.Error)
 			e.fireAlert(ctx, rule, alert)
 		}

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -1114,6 +1114,146 @@ func TestEngine_ConfigError_NoMatchingRule(t *testing.T) {
 	}
 }
 
+// TestHandleReleaseMissing verifies the release_missing alert (GH-3927): a
+// release tag was created but no GitHub Release appeared within the
+// verification window. Covers fire, disabled-rule, and cooldown paths.
+func TestHandleReleaseMissing(t *testing.T) {
+	releaseMissingEvent := Event{
+		Type:  EventTypeReleaseMissing,
+		Error: "tag v1.2.3 exists in qf-studio/studio-sdk but no GitHub Release was published within 10m0s — check the repo's release workflow (or the release is a draft)",
+		Metadata: map[string]string{
+			"repo": "qf-studio/studio-sdk",
+			"tag":  "v1.2.3",
+			"pr":   "64",
+		},
+		Timestamp: time.Now(),
+	}
+
+	t.Run("fires alert with repo/tag metadata", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "release_missing",
+					Type:     AlertTypeReleaseMissing,
+					Enabled:  true,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(releaseMissingEvent)
+
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+		alerts := mockCh.getAlerts()
+		if len(alerts) != 1 {
+			t.Fatalf("expected 1 alert, got %d", len(alerts))
+		}
+		if alerts[0].Type != AlertTypeReleaseMissing {
+			t.Errorf("expected alert type %s, got %s", AlertTypeReleaseMissing, alerts[0].Type)
+		}
+		if !strings.Contains(alerts[0].Message, "v1.2.3") {
+			t.Errorf("expected alert message to mention tag, got %q", alerts[0].Message)
+		}
+		if alerts[0].Metadata["repo"] != "qf-studio/studio-sdk" || alerts[0].Metadata["tag"] != "v1.2.3" || alerts[0].Metadata["pr"] != "64" {
+			t.Errorf("expected repo/tag/pr metadata to be preserved, got %+v", alerts[0].Metadata)
+		}
+	})
+
+	t.Run("disabled rule stays silent", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "release_missing",
+					Type:     AlertTypeReleaseMissing,
+					Enabled:  false,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(releaseMissingEvent)
+		engine.flushForTest()
+
+		if got := len(mockCh.getAlerts()); got != 0 {
+			t.Errorf("expected 0 alerts for disabled rule, got %d", got)
+		}
+	})
+
+	t.Run("cooldown suppresses repeat fires", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "release_missing",
+					Type:     AlertTypeReleaseMissing,
+					Enabled:  true,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 30 * time.Minute,
+				},
+			},
+			Defaults: AlertDefaults{
+				SuppressDuplicates: false,
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(releaseMissingEvent)
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+
+		// Second event within the cooldown window for the same rule must not fire again.
+		secondEvent := releaseMissingEvent
+		secondEvent.Metadata = map[string]string{"repo": "qf-studio/other-repo", "tag": "v9.9.9", "pr": "1"}
+		engine.ProcessEvent(secondEvent)
+		engine.flushForTest()
+
+		if got := len(mockCh.getAlerts()); got != 1 {
+			t.Errorf("expected cooldown to suppress second alert, got %d alerts", got)
+		}
+	})
+}
+
 func TestEngine_ChannelAcceptsSeverity(t *testing.T) {
 	config := &AlertConfig{Enabled: true}
 	engine := NewEngine(config)

--- a/internal/alerts/types.go
+++ b/internal/alerts/types.go
@@ -48,6 +48,9 @@ const (
 
 	// Eval regression detection (GH-2065)
 	AlertTypeEvalRegression AlertType = "eval_regression"
+
+	// Post-tag release verification (GH-3927)
+	AlertTypeReleaseMissing AlertType = "release_missing"
 )
 
 // Alert represents an alert event
@@ -351,6 +354,17 @@ func defaultRules() []AlertRule {
 			Channels:    []string{}, // Will route to PagerDuty channels by severity
 			Cooldown:    1 * time.Hour,
 			Description: "Escalate to PagerDuty after repeated failures for the same source",
+		},
+		// Post-tag release verification (GH-3927)
+		{
+			Name:        "release_missing",
+			Type:        AlertTypeReleaseMissing,
+			Enabled:     true,
+			Condition:   RuleCondition{},
+			Severity:    SeverityWarning,
+			Channels:    []string{},
+			Cooldown:    30 * time.Minute,
+			Description: "Release tag exists but no GitHub Release was published within the verification window",
 		},
 	}
 }

--- a/internal/alerts/types_test.go
+++ b/internal/alerts/types_test.go
@@ -62,6 +62,8 @@ func TestDefaultRules(t *testing.T) {
 		AlertTypeEvalRegression: {"eval_regression", true},
 		// Escalation (GH-848)
 		AlertTypeEscalation: {"escalation", true},
+		// Post-tag release verification (GH-3927)
+		AlertTypeReleaseMissing: {"release_missing", true},
 	}
 
 	if len(rules) != len(expectedRules) {


### PR DESCRIPTION
## Summary
- Adds `AlertTypeReleaseMissing` (`release_missing`) with a default rule in `internal/alerts/types.go`: enabled, `SeverityWarning`, 30m cooldown, description "Release tag exists but no GitHub Release was published within the verification window".
- Adds `EventTypeReleaseMissing` and `handleReleaseMissing` in `internal/alerts/engine.go`, mirroring the existing `handleConfigError` pattern, wired into `handleEvent`'s switch. Alert metadata carries `repo`, `tag`, `pr` as passed through the event.
- This is the alert primitive only, per the scope fence on GH-3952 (sub-issue of GH-3927). The autopilot-side post-tag verification that fires `EventTypeReleaseMissing` lands in a separate sub-issue.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/alerts/...` — new `TestHandleReleaseMissing` covers fire (with repo/tag/pr metadata), disabled-rule, and cooldown-suppression paths; updated `TestDefaultRules` to include the new rule.
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/alerts/...` clean