### PR TITLE
feat(autopilot): opt-in release tagging for human-authored merged PRs (GH-3928)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -406,6 +406,7 @@
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
+| Opt-in release tagging for human merges | ✅ | autopilot | - | - | `release.tag_human_merges` (default false) widens `ScanRecentlyMergedPRs` discovery to non-`pilot/*` PRs merged to the default branch; merge metrics/self-heal/board write-back stay Pilot-PR-only (GH-3928) |
 | Poll-cycle epic-parent auto-close | ✅ | autopilot | - | - | `reconcileEpicParents` sweeps open decomposed parents every poll tick, verifying each closed child shipped a merged PR (not just "closed") before closing the parent with a summary comment naming the merged PRs; a closed-without-merge child vetoes the close with an explicit logged reason (GH-3939) |
 | Per-project release publish mode | ✅ | autopilot | - | `release.publish`, `projects[].release` | `workflow` (default, unchanged)/`api` (Pilot calls `CreateRelease` after tagging)/`tag_only`; project overlay (`ProjectReleaseConfig.Apply`) resolves project > env > global; idempotent retry via `ensureReleasePublished` if CreateRelease fails after a successful tag (v2.222.3, GH-3926) |
 

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -506,10 +506,11 @@ projects:
   #     owner: "qf-studio"
   #     repo: "studio-sdk"
   #   release:
-  #     publish: api    # only set publish: api on repos with NO tag-triggered release
-  #                     # workflow - pre-creating the release makes GoReleaser's asset
-  #                     # upload 422-collide and silently skips downstream publish steps
-  #                     # (Homebrew tap). Repos with GoReleaser must stay workflow.
+  #     publish: api            # only set publish: api on repos with NO tag-triggered release
+  #                             # workflow - pre-creating the release makes GoReleaser's asset
+  #                             # upload 422-collide and silently skips downstream publish steps
+  #                             # (Homebrew tap). Repos with GoReleaser must stay workflow.
+  #     tag_human_merges: true  # opt this repo into tagging human-authored merges too (GH-3928)
 
 # Autopilot settings
 autopilot:
@@ -546,6 +547,20 @@ autopilot:
     #   tag_only  - the tag is created and nothing publishes a release; use
     #             for repos with an intentionally manual release process.
     publish: workflow
+    # Opt-in: also tag releases for merged PRs whose head branch is NOT
+    # pilot/* (GH-3928). Default false - existing configs see zero behavior
+    # change; only pilot/* merges are scanned for release candidates.
+    #
+    # When enabled, ScanRecentlyMergedPRs additionally considers PRs merged
+    # by a human directly into the environment's default branch. Because PRs
+    # are almost always squash-merged, the PR TITLE becomes the squash
+    # commit's subject line - so a conventional-commit PR title (e.g.
+    # "feat: add rate limiting") drives the version bump exactly like a
+    # pilot/* branch's commits do, and a non-conventional title (e.g. "Fix
+    # typo") produces no release (DetectBumpType -> BumpNone). Merge-success
+    # metrics, execution self-heal, and project-board write-back only ever
+    # fire for pilot/* PRs - human merges are release candidates only.
+    tag_human_merges: false
 
   # Define named environment configurations
   # Each environment can have different branch, approval, and CI settings

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3138,6 +3138,7 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 	// per-mode; both are idempotent so duplicate calls are safe.
 	releaseEnabled := c.shouldTriggerRelease()
 	boardEnabled := c.boardSync != nil && c.doneStatus != ""
+	rel := c.resolvedRelease()
 
 	scanWindow := c.config.MergedPRScanWindow
 	if scanWindow == 0 {
@@ -3162,8 +3163,22 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 	triggered := 0
 
 	for _, pr := range prs {
-		// Filter for Pilot branches (pilot/GH-* or pilot/*)
-		if !strings.HasPrefix(pr.Head.Ref, "pilot/") {
+		// Filter for Pilot branches (pilot/GH-* or pilot/*), unless
+		// release.tag_human_merges opts in to tagging human-authored merges too
+		// (GH-3928). DetectBumpType still gates non-release-worthy commits
+		// (docs/chore/refactor) to BumpNone, so this only widens *discovery*,
+		// not what actually gets tagged.
+		isPilotPR := strings.HasPrefix(pr.Head.Ref, "pilot/")
+		tagHuman := releaseEnabled && rel.TagHumanMerges
+		if !isPilotPR && !tagHuman {
+			continue
+		}
+
+		// Human PRs are only eligible when merged into the repo's configured
+		// default/main branch — merges into feature/integration branches are
+		// silently skipped here rather than surfaced later as a noisy
+		// guardReleaseSHAReachable escalation.
+		if !isPilotPR && pr.Base.Ref != c.resolveMainBranchName() {
 			continue
 		}
 
@@ -3200,18 +3215,24 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 		// recordedMerges so handleMerging + scanner can both call it.
 		// Use pr.CreatedAt for a meaningful time-to-merge sample; fall back to
 		// mergedAt so the histogram still records on PRs missing CreatedAt.
-		createdAt, _ := time.Parse(time.RFC3339, pr.CreatedAt)
-		if createdAt.IsZero() {
-			createdAt = mergedAt
+		// Human PRs (GH-3928) are release candidates only, not Pilot executions —
+		// they must not pollute merge metrics, self-heal, or board write-back.
+		if isPilotPR {
+			createdAt, _ := time.Parse(time.RFC3339, pr.CreatedAt)
+			if createdAt.IsZero() {
+				createdAt = mergedAt
+			}
+			c.recordMergeSuccess(&PRState{PRNumber: pr.Number, CreatedAt: createdAt})
 		}
-		c.recordMergeSuccess(&PRState{PRNumber: pr.Number, CreatedAt: createdAt})
 
 		// TASK-352: Self-heal execution records for externally-merged PRs (gh pr
 		// merge / GitHub UI). These never pass through handleMerging, so their
 		// "failed" rows would otherwise never flip to "completed". Like
 		// recordMergeSuccess above, this fires before the release-tag/activePRs skip
 		// gates because the heal must happen on every discovered merged Pilot PR.
-		c.selfHealForPR(ctx, issueNum, pr.HTMLURL)
+		if isPilotPR {
+			c.selfHealForPR(ctx, issueNum, pr.HTMLURL)
+		}
 
 		// TASK-356 #2: board write-back for externally-merged PRs. Large PRs that
 		// hit the stage approval-misconfig (require_approval=true + approval disabled)
@@ -3222,7 +3243,7 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 		// Pilot PR (before the release-tag/activePRs skip gates) and is independent of
 		// whether release is enabled. UpdateProjectItemStatus is idempotent and silently
 		// skips issues that aren't on the board.
-		if boardEnabled && issueNum > 0 {
+		if isPilotPR && boardEnabled && issueNum > 0 {
 			if nodeID, nodeErr := c.ghClient.GetIssueNodeID(ctx, c.owner, c.repo, issueNum); nodeErr != nil {
 				c.log.Warn("board sync on external merge: failed to resolve issue node id",
 					"pr", pr.Number, "issue", issueNum, "error", nodeErr)
@@ -3290,12 +3311,20 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			}
 		}
 
-		c.log.Info("found merged Pilot PR needing release",
-			"pr", pr.Number,
-			"branch", pr.Head.Ref,
-			"merged_at", mergedAt,
-			"merge_sha", ShortSHA(pr.MergeCommitSHA),
-		)
+		if isPilotPR {
+			c.log.Info("found merged Pilot PR needing release",
+				"pr", pr.Number,
+				"branch", pr.Head.Ref,
+				"merged_at", mergedAt,
+				"merge_sha", ShortSHA(pr.MergeCommitSHA),
+			)
+		} else {
+			c.log.Info("found merged human PR needing release",
+				"pr", pr.Number,
+				"branch", pr.Head.Ref,
+				"title", pr.Title,
+			)
+		}
 
 		// Create PR state and trigger release
 		prState := &PRState{

--- a/internal/autopilot/controller_releasing_test.go
+++ b/internal/autopilot/controller_releasing_test.go
@@ -687,6 +687,121 @@ func TestHandleReleasing_RetryCapEscalates(t *testing.T) {
 	}
 }
 
+// TestHandleReleasing_HumanPR_NoIssueComment verifies GH-3928: a scanner-registered
+// human PR (IssueNumber == 0, no linked GitHub issue) never attempts to post an
+// issue comment — neither on the escalation path (retry cap) nor on the happy
+// path (clean tag + publish).
+func TestHandleReleasing_HumanPR_NoIssueComment(t *testing.T) {
+	t.Run("escalation path", func(t *testing.T) {
+		commentPosted := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+				// Persistent API failure on every tag lookup forces escalation.
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"server error"}`))
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/issues/") && strings.HasSuffix(r.URL.Path, "/comments"):
+				commentPosted = true
+				w.WriteHeader(http.StatusCreated)
+				_ = json.NewEncoder(w).Encode(github.PRComment{ID: 1})
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		cfg := DefaultConfig()
+		cfg.Environment = EnvStage
+		cfg.MaxReleasingAttempts = 3
+		cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", TagPrefix: "v", TagHumanMerges: true}
+		c := NewController(cfg, ghClient, nil, "owner", "repo")
+		prState := &PRState{
+			PRNumber:          920,
+			HeadSHA:           "humansha920",
+			IssueNumber:       0, // human-authored branch, no linked issue
+			Stage:             StageReleasing,
+			ReleasingAttempts: 2, // next call increments to 3 == cap
+		}
+		c.mu.Lock()
+		c.activePRs[920] = prState
+		c.mu.Unlock()
+
+		if err := c.handleReleasing(context.Background(), prState); err != nil {
+			t.Fatalf("at cap, handleReleasing must return nil (not error), got: %v", err)
+		}
+		if prState.Stage != StageFailed {
+			t.Errorf("Stage = %s, want StageFailed after retry cap", prState.Stage)
+		}
+		if commentPosted {
+			t.Error("escalation comment must NOT be posted when IssueNumber == 0 (human PR, no linked issue)")
+		}
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		commentPosted := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/issues/") && strings.HasSuffix(r.URL.Path, "/comments"):
+				commentPosted = true
+				w.WriteHeader(http.StatusCreated)
+				_ = json.NewEncoder(w).Encode(github.PRComment{ID: 1})
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[]`))
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/releases/latest"):
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.0.0"})
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/commits"):
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat: add a thing")})
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/branches/"):
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"name":   "main",
+					"commit": map[string]string{"sha": "humanprmainsha"},
+				})
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]string{"status": "ahead"})
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
+				w.WriteHeader(http.StatusCreated)
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		c := newReleasingControllerWithPublish(t, server.URL, "tag_only")
+		prState := &PRState{
+			PRNumber:     930,
+			HeadSHA:      "humansha930",
+			IssueNumber:  0, // human-authored branch, no linked issue
+			BranchName:   "feat/human-change",
+			TargetBranch: "main",
+			Stage:        StageReleasing,
+		}
+		c.mu.Lock()
+		c.activePRs[930] = prState
+		c.mu.Unlock()
+
+		if err := c.handleReleasing(context.Background(), prState); err != nil {
+			t.Fatalf("handleReleasing returned error: %v", err)
+		}
+		if prState.ReleaseVersion == "" {
+			t.Error("expected a release version to be computed (feat commit should bump minor)")
+		}
+		if commentPosted {
+			t.Error("no issue comment should ever be posted for a human PR with IssueNumber == 0")
+		}
+		c.mu.RLock()
+		_, tracked := c.activePRs[930]
+		c.mu.RUnlock()
+		if tracked {
+			t.Error("PR must drain from activePRs after a successful tag")
+		}
+	})
+}
+
 // TestHandleReleasing_RetryCapBelowCapReturnsError verifies that a failure when
 // ReleasingAttempts is still below MaxReleasingAttempts returns a retryable error
 // rather than escalating to StageFailed.

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -7384,6 +7384,255 @@ func TestController_ScanRecentlyMergedPRs_FlagMatrix(t *testing.T) {
 	}
 }
 
+// TestScanRecentlyMergedPRs_HumanMerges verifies GH-3928: release.tag_human_merges
+// opts the scanner in to discovering merged PRs whose head branch is NOT pilot/*.
+func TestScanRecentlyMergedPRs_HumanMerges(t *testing.T) {
+	recentMergedAt := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	oldMergedAt := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+
+	tests := []struct {
+		name           string
+		tagHumanMerges bool
+		pr             github.PullRequest
+		taggedAtMerge  bool // GetTagForSHA returns a hit for pr.MergeCommitSHA
+		wantRegistered bool
+	}{
+		{
+			name:           "flag off: human PR merged to main in-window is not registered",
+			tagHumanMerges: false,
+			pr: github.PullRequest{
+				Number:         901,
+				Head:           github.PRRef{Ref: "feat/add-rate-limit", SHA: "humansha901"},
+				Base:           github.PRRef{Ref: "main"},
+				HTMLURL:        "https://github.com/owner/repo/pull/901",
+				Title:          "feat: add rate limiting",
+				Merged:         true,
+				MergedAt:       recentMergedAt,
+				MergeCommitSHA: "merge-sha-901",
+			},
+			wantRegistered: false,
+		},
+		{
+			name:           "flag on: human PR merged to main in-window is registered",
+			tagHumanMerges: true,
+			pr: github.PullRequest{
+				Number:         902,
+				Head:           github.PRRef{Ref: "feat/add-rate-limit", SHA: "humansha902"},
+				Base:           github.PRRef{Ref: "main"},
+				HTMLURL:        "https://github.com/owner/repo/pull/902",
+				Title:          "feat: add rate limiting",
+				Merged:         true,
+				MergedAt:       recentMergedAt,
+				MergeCommitSHA: "merge-sha-902",
+			},
+			wantRegistered: true,
+		},
+		{
+			name:           "flag on: human PR merged to non-default base is skipped",
+			tagHumanMerges: true,
+			pr: github.PullRequest{
+				Number:         903,
+				Head:           github.PRRef{Ref: "feat/add-rate-limit", SHA: "humansha903"},
+				Base:           github.PRRef{Ref: "release/1.0"},
+				HTMLURL:        "https://github.com/owner/repo/pull/903",
+				Title:          "feat: add rate limiting",
+				Merged:         true,
+				MergedAt:       recentMergedAt,
+				MergeCommitSHA: "merge-sha-903",
+			},
+			wantRegistered: false,
+		},
+		{
+			name:           "flag on: already-tagged human merge commit is skipped",
+			tagHumanMerges: true,
+			pr: github.PullRequest{
+				Number:         904,
+				Head:           github.PRRef{Ref: "feat/add-rate-limit", SHA: "humansha904"},
+				Base:           github.PRRef{Ref: "main"},
+				HTMLURL:        "https://github.com/owner/repo/pull/904",
+				Title:          "feat: add rate limiting",
+				Merged:         true,
+				MergedAt:       recentMergedAt,
+				MergeCommitSHA: "merge-sha-904",
+			},
+			taggedAtMerge:  true,
+			wantRegistered: false,
+		},
+		{
+			name:           "flag on: human PR merged outside scan window is skipped",
+			tagHumanMerges: true,
+			pr: github.PullRequest{
+				Number:         905,
+				Head:           github.PRRef{Ref: "feat/add-rate-limit", SHA: "humansha905"},
+				Base:           github.PRRef{Ref: "main"},
+				HTMLURL:        "https://github.com/owner/repo/pull/905",
+				Title:          "feat: add rate limiting",
+				Merged:         true,
+				MergedAt:       oldMergedAt,
+				MergeCommitSHA: "merge-sha-905",
+			},
+			wantRegistered: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode([]*github.PullRequest{&tt.pr})
+				case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/tags"):
+					w.WriteHeader(http.StatusOK)
+					if tt.taggedAtMerge {
+						tag := github.Tag{Name: "v1.0.0", Commit: struct {
+							SHA string `json:"sha"`
+						}{SHA: tt.pr.MergeCommitSHA}}
+						_ = json.NewEncoder(w).Encode([]*github.Tag{&tag})
+					} else {
+						_, _ = w.Write([]byte("[]"))
+					}
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.Release = &ReleaseConfig{
+				Enabled:        true,
+				Trigger:        "on_merge",
+				TagPrefix:      "v",
+				TagHumanMerges: tt.tagHumanMerges,
+			}
+			cfg.MergedPRScanWindow = 30 * time.Minute
+
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+			c.SetStateStore(newTestStateStore(t))
+
+			if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+				t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+			}
+
+			c.mu.RLock()
+			prState, tracked := c.activePRs[tt.pr.Number]
+			c.mu.RUnlock()
+
+			if tracked != tt.wantRegistered {
+				t.Fatalf("PR %d tracked = %v, want %v", tt.pr.Number, tracked, tt.wantRegistered)
+			}
+			if !tt.wantRegistered {
+				return
+			}
+			if prState.Stage != StageReleasing {
+				t.Errorf("Stage = %v, want StageReleasing", prState.Stage)
+			}
+			if prState.IssueNumber != 0 {
+				t.Errorf("IssueNumber = %d, want 0 for a human-authored branch", prState.IssueNumber)
+			}
+			if prState.HeadSHA != tt.pr.MergeCommitSHA {
+				t.Errorf("HeadSHA = %q, want %q (merge commit SHA)", prState.HeadSHA, tt.pr.MergeCommitSHA)
+			}
+		})
+	}
+}
+
+// TestScanRecentlyMergedPRs_HumanMerges_PilotOnlySideEffects verifies that, with
+// tag_human_merges enabled, a human PR is a release candidate ONLY — it must not
+// trigger recordMergeSuccess, selfHealForPR, or board write-back, while a pilot/*
+// PR discovered in the same scan still gets all three (GH-3928).
+func TestScanRecentlyMergedPRs_HumanMerges_PilotOnlySideEffects(t *testing.T) {
+	recentMergedAt := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+
+	pilotPR := github.PullRequest{
+		Number:         910,
+		Head:           github.PRRef{Ref: "pilot/GH-500", SHA: "pilotsha910"},
+		Base:           github.PRRef{Ref: "main"},
+		HTMLURL:        "https://github.com/owner/repo/pull/910",
+		Title:          "feat(api): pilot change",
+		Merged:         true,
+		MergedAt:       recentMergedAt,
+		MergeCommitSHA: "merge-sha-910",
+	}
+	humanPR := github.PullRequest{
+		Number:         911,
+		Head:           github.PRRef{Ref: "feat/human-change", SHA: "humansha911"},
+		Base:           github.PRRef{Ref: "main"},
+		HTMLURL:        "https://github.com/owner/repo/pull/911",
+		Title:          "feat: human change",
+		Merged:         true,
+		MergedAt:       recentMergedAt,
+		MergeCommitSHA: "merge-sha-911",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.PullRequest{&pilotPR, &humanPR})
+		case r.URL.Path == "/repos/owner/repo/issues/500":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"node_id": "I_kwDOissue500"})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{
+		Enabled:        true,
+		Trigger:        "on_merge",
+		TagPrefix:      "v",
+		TagHumanMerges: true,
+	}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	boardMock := &mockBoardSyncer{}
+	c := NewController(cfg, ghClient, nil, "owner", "repo",
+		withBoardSyncerForTest(boardMock, "Done", "Failed", "In Review", "In Dev"))
+	c.SetStateStore(newTestStateStore(t))
+	evalMock := &mockEvalStore{}
+	c.SetEvalStore(evalMock)
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	// Both PRs are release candidates.
+	c.mu.RLock()
+	_, pilotTracked := c.activePRs[pilotPR.Number]
+	_, humanTracked := c.activePRs[humanPR.Number]
+	c.mu.RUnlock()
+	if !pilotTracked {
+		t.Error("pilot PR must still be tracked for release")
+	}
+	if !humanTracked {
+		t.Error("human PR must be tracked for release when tag_human_merges is enabled")
+	}
+
+	// recordMergeSuccess metrics: exactly one merge recorded (the pilot PR).
+	snap := c.metrics.Snapshot()
+	if snap.PRsMerged != 1 {
+		t.Errorf("PRsMerged = %d, want 1 (human PR must not record merge metrics)", snap.PRsMerged)
+	}
+
+	// Self-heal: only the pilot PR's issue is healed.
+	if len(evalMock.selfHealed) != 1 {
+		t.Errorf("selfHealed entries = %d, want 1 (only the pilot PR)", len(evalMock.selfHealed))
+	}
+
+	// Board write-back: only the pilot PR's card moves.
+	if len(boardMock.calls) != 1 {
+		t.Errorf("board sync calls = %d, want 1 (only the pilot PR)", len(boardMock.calls))
+	}
+}
+
 // TestController_RecordMergeSuccess_Idempotency verifies recordMergeSuccess
 // fires exactly once per PR number even when called multiple times from
 // different code paths (e.g. handleMerging + ScanRecentlyMergedPRs both

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -371,6 +371,13 @@ type ReleaseConfig struct {
 	// behaves like "workflow". See internal/config Config.Validate for the
 	// enum check (GH-3930).
 	Publish string `yaml:"publish,omitempty"`
+	// TagHumanMerges opts in to tagging releases for merged PRs whose head
+	// branch is NOT pilot/*  (i.e. human-authored PRs merged to the default
+	// branch). Default false — zero behavior change for existing configs.
+	// DetectBumpType already gates non-release-worthy commits (docs/chore/
+	// refactor) to BumpNone, so enabling this is conventional-commit hygiene
+	// opting in, not a branch-naming relaxation. See GH-3928.
+	TagHumanMerges bool `yaml:"tag_human_merges,omitempty"`
 }
 
 // Publish mode values for ReleaseConfig.Publish / ProjectReleaseConfig.Publish (GH-3926).
@@ -416,6 +423,8 @@ type ProjectReleaseConfig struct {
 	GenerateChangelog *bool `yaml:"generate_changelog,omitempty"`
 	// NotifyOnRelease overrides ReleaseConfig.NotifyOnRelease for this project. Nil inherits.
 	NotifyOnRelease *bool `yaml:"notify_on_release,omitempty"`
+	// TagHumanMerges overrides ReleaseConfig.TagHumanMerges for this project. Nil inherits.
+	TagHumanMerges *bool `yaml:"tag_human_merges,omitempty"`
 }
 
 // Apply overlays this project-level config on top of base (the resolved
@@ -458,6 +467,9 @@ func (p *ProjectReleaseConfig) Apply(base *ReleaseConfig) *ReleaseConfig {
 	}
 	if p.NotifyOnRelease != nil {
 		result.NotifyOnRelease = *p.NotifyOnRelease
+	}
+	if p.TagHumanMerges != nil {
+		result.TagHumanMerges = *p.TagHumanMerges
 	}
 	return &result
 }


### PR DESCRIPTION
## Summary

- `ScanRecentlyMergedPRs` only ever discovered `pilot/*` branches — human-authored merges (e.g. `feat/*` PRs) were never auto-tagged (v2.215.0 had to be tagged manually).
- Add opt-in `release.tag_human_merges` (default `false`, zero behavior change for existing configs) to `ReleaseConfig`/`ProjectReleaseConfig` (types.go), wired through `Apply` for the per-project overlay (GH-3926).
- Scanner change (controller.go, `ScanRecentlyMergedPRs`): when enabled, also considers PRs merged by a human directly into the environment's default branch. `DetectBumpType` already gates non-conventional/docs/chore commits to `BumpNone`, so this only widens *discovery*, not what gets tagged.
- Pilot-only side effects (`recordMergeSuccess`, `selfHealForPR`, board write-back) are gated to `pilot/*` PRs only — human merges are release candidates, not Pilot executions.
- `IssueNumber` stays `0` for human branches; `escalateReleasingFailed`'s existing `IssueNumber > 0` gate already skips issue comments for these — no change needed there.
- Documented the knob (global + per-project) in `configs/pilot.example.yaml`, including the squash-merge PR-title-becomes-commit-subject gotcha.

## Test plan

- [x] `TestScanRecentlyMergedPRs_HumanMerges` (table-driven): flag off/on, non-default base, already-tagged, outside scan window
- [x] `TestScanRecentlyMergedPRs_HumanMerges_PilotOnlySideEffects`: pilot PR still gets merge metrics/self-heal/board write-back; human PR does not
- [x] `TestHandleReleasing_HumanPR_NoIssueComment`: escalation path (retry cap) and happy path (clean tag+publish) with `IssueNumber: 0` — no issue comment ever posted
- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `golangci-lint run` clean