### PR TITLE
fix(alerts): recover release_missing alert type from closed PR #3955 (GH-3956)

### DIFF
--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -106,6 +106,11 @@ const (
 	// credential (e.g. a GitHub token) fails an authenticated validation
 	// call at startup, so a dead credential doesn't fail silently.
 	EventTypeConfigError EventType = "config_error"
+
+	// Release missing events (GH-3952): fired when a merged pilot/GH-* PR
+	// did not produce its expected release tag, so a stalled release
+	// pipeline doesn't go unnoticed.
+	EventTypeReleaseMissing EventType = "release_missing"
 )
 
 const (
@@ -336,6 +341,8 @@ func (e *Engine) handleEvent(ctx context.Context, event Event) {
 		e.handleSecurityEvent(ctx, event)
 	case EventTypeConfigError:
 		e.handleConfigError(ctx, event)
+	case EventTypeReleaseMissing:
+		e.handleReleaseMissing(ctx, event)
 	case EventTypeBudgetExceeded, EventTypeBudgetWarning:
 		e.handleBudgetEvent(ctx, event)
 	case EventTypeAutopilotMetrics:
@@ -520,6 +527,23 @@ func (e *Engine) handleConfigError(ctx context.Context, event Event) {
 		}
 		if rule.Type == AlertTypeServiceUnhealthy && e.shouldFire(rule) {
 			alert := e.createAlert(rule, event, event.Error)
+			e.fireAlert(ctx, rule, alert)
+		}
+	}
+}
+
+// handleReleaseMissing fires AlertTypeReleaseMissing rules when a merged PR
+// did not produce its expected release tag (GH-3952). Metadata carries repo,
+// tag, and pr so operators can find the stalled release from the alert alone.
+func (e *Engine) handleReleaseMissing(ctx context.Context, event Event) {
+	for _, rule := range e.config.Rules {
+		if !rule.Enabled {
+			continue
+		}
+		if rule.Type == AlertTypeReleaseMissing && e.shouldFire(rule) {
+			message := fmt.Sprintf("Release missing for %s: expected tag %s after PR #%s was merged",
+				event.Metadata["repo"], event.Metadata["tag"], event.Metadata["pr"])
+			alert := e.createAlert(rule, event, message)
 			e.fireAlert(ctx, rule, alert)
 		}
 	}

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -1114,6 +1114,165 @@ func TestEngine_ConfigError_NoMatchingRule(t *testing.T) {
 	}
 }
 
+// TestHandleReleaseMissing covers the fire, disabled, and cooldown paths for
+// AlertTypeReleaseMissing (GH-3952).
+func TestHandleReleaseMissing(t *testing.T) {
+	t.Run("fires with repo/tag/pr metadata", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "release_missing",
+					Type:     AlertTypeReleaseMissing,
+					Enabled:  true,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(Event{
+			Type: EventTypeReleaseMissing,
+			Metadata: map[string]string{
+				"repo": "qf-studio/pilot",
+				"tag":  "v2.223.0",
+				"pr":   "3951",
+			},
+			Timestamp: time.Now(),
+		})
+
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+		alerts := mockCh.getAlerts()
+		if len(alerts) != 1 {
+			t.Fatalf("expected 1 alert, got %d", len(alerts))
+		}
+		if alerts[0].Type != AlertTypeReleaseMissing {
+			t.Errorf("expected alert type %s, got %s", AlertTypeReleaseMissing, alerts[0].Type)
+		}
+		if !strings.Contains(alerts[0].Message, "qf-studio/pilot") ||
+			!strings.Contains(alerts[0].Message, "v2.223.0") ||
+			!strings.Contains(alerts[0].Message, "3951") {
+			t.Errorf("expected alert message to mention repo/tag/pr, got %q", alerts[0].Message)
+		}
+	})
+
+	t.Run("disabled rule does not fire", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "release_missing",
+					Type:     AlertTypeReleaseMissing,
+					Enabled:  false, // Disabled
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 0,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		engine.ProcessEvent(Event{
+			Type: EventTypeReleaseMissing,
+			Metadata: map[string]string{
+				"repo": "qf-studio/pilot",
+				"tag":  "v2.223.0",
+				"pr":   "3951",
+			},
+			Timestamp: time.Now(),
+		})
+
+		engine.flushForTest()
+		if got := len(mockCh.getAlerts()); got != 0 {
+			t.Errorf("expected 0 alerts (rule disabled), got %d", got)
+		}
+	})
+
+	t.Run("cooldown suppresses repeat fires", func(t *testing.T) {
+		config := &AlertConfig{
+			Enabled: true,
+			Channels: []ChannelConfig{
+				{Name: "test-channel", Type: "webhook", Enabled: true},
+			},
+			Rules: []AlertRule{
+				{
+					Name:     "release_missing",
+					Type:     AlertTypeReleaseMissing,
+					Enabled:  true,
+					Severity: SeverityWarning,
+					Channels: []string{"test-channel"},
+					Cooldown: 30 * time.Minute,
+				},
+			},
+		}
+
+		mockCh := newMockChannel("test-channel", "webhook")
+		dispatcher := NewDispatcher(config)
+		dispatcher.RegisterChannel(mockCh)
+
+		engine := NewEngine(config, WithDispatcher(dispatcher))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = engine.Start(ctx)
+
+		firstEvent := Event{
+			Type: EventTypeReleaseMissing,
+			Metadata: map[string]string{
+				"repo": "qf-studio/pilot",
+				"tag":  "v2.223.0",
+				"pr":   "3951",
+			},
+			Timestamp: time.Now(),
+		}
+		engine.ProcessEvent(firstEvent)
+		waitForAlerts(t, mockCh, 1, 2*time.Second)
+
+		// Second event within the cooldown window should be suppressed.
+		engine.ProcessEvent(Event{
+			Type: EventTypeReleaseMissing,
+			Metadata: map[string]string{
+				"repo": "qf-studio/pilot",
+				"tag":  "v2.224.0",
+				"pr":   "3960",
+			},
+			Timestamp: time.Now(),
+		})
+		engine.flushForTest()
+
+		alerts := mockCh.getAlerts()
+		if len(alerts) != 1 {
+			t.Errorf("expected 1 alert (second suppressed by cooldown), got %d", len(alerts))
+		}
+	})
+}
+
 func TestEngine_ChannelAcceptsSeverity(t *testing.T) {
 	config := &AlertConfig{Enabled: true}
 	engine := NewEngine(config)

--- a/internal/alerts/types.go
+++ b/internal/alerts/types.go
@@ -48,6 +48,10 @@ const (
 
 	// Eval regression detection (GH-2065)
 	AlertTypeEvalRegression AlertType = "eval_regression"
+
+	// Release monitoring (GH-3952): a merged pilot/GH-* PR that never
+	// produced its expected release tag.
+	AlertTypeReleaseMissing AlertType = "release_missing"
 )
 
 // Alert represents an alert event
@@ -351,6 +355,17 @@ func defaultRules() []AlertRule {
 			Channels:    []string{}, // Will route to PagerDuty channels by severity
 			Cooldown:    1 * time.Hour,
 			Description: "Escalate to PagerDuty after repeated failures for the same source",
+		},
+		// Release monitoring (GH-3952)
+		{
+			Name:        "release_missing",
+			Type:        AlertTypeReleaseMissing,
+			Enabled:     true,
+			Condition:   RuleCondition{},
+			Severity:    SeverityWarning,
+			Channels:    []string{},
+			Cooldown:    30 * time.Minute,
+			Description: "Alert when a merged PR did not produce its expected release tag",
 		},
 	}
 }

--- a/internal/alerts/types_test.go
+++ b/internal/alerts/types_test.go
@@ -62,6 +62,8 @@ func TestDefaultRules(t *testing.T) {
 		AlertTypeEvalRegression: {"eval_regression", true},
 		// Escalation (GH-848)
 		AlertTypeEscalation: {"escalation", true},
+		// Release monitoring (GH-3952)
+		AlertTypeReleaseMissing: {"release_missing", true},
 	}
 
 	if len(rules) != len(expectedRules) {


### PR DESCRIPTION
## Summary
- Recovers the `release_missing` alert work that was closed unmerged in #3955 (branch `pilot/GH-3952`, SHA d035241). Its code never landed on `main`.
- CI failure attributed to that PR (`FAIL github.com/qf-studio/pilot/stress ... panic: test timed out after 10m0s`, `TestMemory_LargePayloads`) was an intermittent stress-test timeout, unrelated to the alerts change itself — matches the known GH-3903 failure class.
- Adds `AlertTypeReleaseMissing` / `EventTypeReleaseMissing` + `handleReleaseMissing` in `internal/alerts/`, mirroring the existing `config_error`/`handleConfigError` shape, plus a default enabled `AlertRule` (Warning severity, 30m cooldown).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/alerts/...` — pass
- [x] `go test ./stress/ -timeout 10m` — pass (confirms the original stress timeout was intermittent, not a real regression)
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/alerts/...` — 0 issues
- [x] Diff scoped to `internal/alerts/` only, per GH-3903 postmortem constraint

Refs: #3952 (ghost-closed original) · #3955 (closed PR with the work) · #3927 (parent epic) · GH-3903 (same stress-timeout failure mode)