### PR TITLE
fix(stress): bound TestMemory_LargePayloads wait to stop package-timeout hangs

### DIFF
--- a/stress/concurrent_test.go
+++ b/stress/concurrent_test.go
@@ -433,12 +433,13 @@ func TestStress_GoroutineStability(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 	go poller.Start(ctx)
 
-	// Wait for all issues to process
-	for atomic.LoadInt64(&processedCount) < int64(numIssues) {
-		time.Sleep(50 * time.Millisecond)
-	}
+	// GH-3959: bounded wait instead of an unbounded busy-loop — see memory_test.go's
+	// waitForProcessed doc comment for why an unbounded loop here can hang until the
+	// package's 10m timeout kills the whole `stress` package.
+	waitForProcessed(t, func() int64 { return atomic.LoadInt64(&processedCount) }, int64(numIssues), 12*time.Second)
 
 	cancel()
 	poller.WaitForActive()

--- a/stress/memory_test.go
+++ b/stress/memory_test.go
@@ -337,11 +337,19 @@ func TestMemory_LargePayloads(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	go poller.Start(ctx)
 
-	for atomic.LoadInt64(&processedCount) < int64(numIssues) {
-		time.Sleep(100 * time.Millisecond)
-	}
+	// GH-3959: this loop used to busy-wait with no deadline of its own, relying
+	// solely on the poller's 30s ctx. If ctx expired before all issues were
+	// dispatched/processed (e.g. under CI load), startParallel's ctx.Done()
+	// branch stops the dispatch loop for good, processedCount never reaches
+	// numIssues, and this loop spun forever — hanging until the package's 10m
+	// timeout killed the whole `stress` package (server.Close() never reached,
+	// leaving its goroutine parked in httptest.(*Server).goServe). Use the
+	// same bounded waitForProcessed helper the sibling memory tests already
+	// use (TASK-353) so this fails fast with a clear message instead.
+	waitForProcessed(t, func() int64 { return atomic.LoadInt64(&processedCount) }, int64(numIssues), 25*time.Second)
 
 	cancel()
 	poller.WaitForActive()


### PR DESCRIPTION
## Root cause

`TestMemory_LargePayloads` (stress/memory_test.go) busy-waited on `processedCount`
with **no deadline of its own**:

```go
for atomic.LoadInt64(&processedCount) < int64(numIssues) {
    time.Sleep(100 * time.Millisecond)
}
```

It relied entirely on the poller's 30s `context.WithTimeout`. But `startParallel`'s
`ctx.Done()` branch permanently stops the dispatch loop once the context expires —
so if not all 20 issues were dispatched/processed before that 30s elapsed (e.g. CI
under load, GC pauses, slow scheduling), `processedCount` never reaches its target
and this loop spins **forever**, hanging until the *package's* 10-minute test
timeout kills the whole `stress` package. Because the hang happens before the
`defer server.Close()` line is ever reached, the goroutine dump at kill-time shows
a goroutine parked in `httptest.(*Server).goServe` — exactly what was observed on
the two sniped PRs (#3918, #3955).

The three sibling memory stress tests in the same file already had this exact
problem fixed under TASK-353 via a `waitForProcessed(t, get, want, timeout)`
helper that fails the *single test* fast with `t.Fatalf` instead of spinning —
`TestMemory_LargePayloads` was just never migrated to it.

While auditing the rest of the `stress` package for the same pattern, found and
fixed an identical unbounded loop in `TestStress_GoroutineStability`
(concurrent_test.go) — same risk, same fix.

## Fix

- `stress/memory_test.go`: `TestMemory_LargePayloads` now uses the existing
  `waitForProcessed` helper (25s bound, inside the 30s poller ctx) instead of an
  unbounded loop. Added `defer cancel()` for the context (was previously only
  cancelled on the success path).
- `stress/concurrent_test.go`: same fix for `TestStress_GoroutineStability`
  (12s bound, inside the 15s poller ctx).

No test deleted or skipped; package-level 10m timeout unchanged. This makes a
stall fail the *individual* test with a clear "timed out after Xs waiting for
processed count: got N, want M" message rather than killing the whole package
and sniping unrelated PRs.

## Test plan

- [x] `go test ./stress/ -timeout 10m -count=3` — passes
- [x] `go test ./stress/ -timeout 10m -count=5 -race` — passes (135s)
- [x] `golangci-lint run --new-from-rev=origin/main ./stress/...` — 0 issues
- [x] `go build ./...` — passes