### PR TITLE
fix(autopilot): CI fix-request issues excerpt end-of-log failure, not preamble

### DIFF
--- a/internal/autopilot/feedback_loop.go
+++ b/internal/autopilot/feedback_loop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 
 	"github.com/qf-studio/pilot/internal/ghissue"
@@ -11,6 +12,63 @@ import (
 	"github.com/qf-studio/pilot/internal/text"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
+
+// ciFailureExcerptRe matches the start of an actionable CI failure: a Go test
+// failure header, a panic, or a GitHub Actions error annotation. These lines
+// are typically prefixed by a runner timestamp, so the patterns are not
+// anchored to line start.
+var ciFailureExcerptRe = regexp.MustCompile(`--- FAIL:|panic:|##\[error\]`)
+
+// maxCIErrorExcerptChars caps the size of the CI Error Logs section embedded
+// in fix-request issue bodies to stay well within GitHub's issue body limit.
+const maxCIErrorExcerptChars = 4000
+
+// ciFailureExcerptFallbackLines is how many trailing lines to keep when no
+// failure marker is found in the log (e.g. plain build/lint output).
+const ciFailureExcerptFallbackLines = 150
+
+// extractFailureExcerpt returns the actionable slice of CI logs to embed in a
+// fix-request issue body: from the first failure marker onward (this
+// naturally includes the trailing `FAIL <pkg>` summary since it always
+// follows the failure in a Go test log), or the last N lines when no marker
+// is found.
+//
+// GH-3958: excerpting from the head of the log only captured GitHub Actions
+// runner-provisioning preamble ("Current runner version", "Runner Image
+// Provisioner"...) and never the actual failure, which sits near the end of
+// the log. Every auto-generated fix issue self-rejected as vague as a result.
+func extractFailureExcerpt(logs string, maxChars int) string {
+	lines := strings.Split(logs, "\n")
+
+	start := -1
+	for i, line := range lines {
+		if ciFailureExcerptRe.MatchString(line) {
+			start = i
+			break
+		}
+	}
+
+	var excerpt []string
+	switch {
+	case start >= 0:
+		if start > 3 {
+			start -= 3 // small lead-in context before the failure marker
+		} else {
+			start = 0
+		}
+		excerpt = lines[start:]
+	case len(lines) > ciFailureExcerptFallbackLines:
+		excerpt = lines[len(lines)-ciFailureExcerptFallbackLines:]
+	default:
+		excerpt = lines
+	}
+
+	result := strings.Join(excerpt, "\n")
+	if len(result) > maxChars {
+		result = result[:maxChars] + "\n... (truncated)"
+	}
+	return result
+}
 
 // FeedbackLoop creates issues when CI fails or bugs are detected.
 // It closes the autonomous loop by automatically creating fix issues
@@ -168,12 +226,7 @@ func (f *FeedbackLoop) generateBody(prState *PRState, failureType FailureType, f
 	if logs != "" {
 		sb.WriteString("<details><summary>CI Error Logs</summary>\n\n")
 		sb.WriteString("```\n")
-		if len(logs) > 2000 {
-			sb.WriteString(logs[:2000])
-			sb.WriteString("\n... (truncated)")
-		} else {
-			sb.WriteString(logs)
-		}
+		sb.WriteString(extractFailureExcerpt(logs, maxCIErrorExcerptChars))
 		sb.WriteString("\n```\n\n")
 		sb.WriteString("</details>\n\n")
 	}

--- a/internal/autopilot/feedback_loop_test.go
+++ b/internal/autopilot/feedback_loop_test.go
@@ -3,6 +3,7 @@ package autopilot
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -1228,6 +1229,136 @@ func TestCreateReviewIssue(t *testing.T) {
 	}
 	if !strings.Contains(createdBody, "autopilot-meta") {
 		t.Error("body should contain autopilot-meta")
+	}
+}
+
+// TestExtractFailureExcerpt_FailureAtEnd covers GH-3958: fix-request issues
+// were excerpting from the head of the CI log (runner-provisioning preamble)
+// instead of the actual failure, which sits at the end of a Go test log.
+func TestExtractFailureExcerpt_FailureAtEnd(t *testing.T) {
+	provisioningPreamble := strings.Repeat(
+		"Current runner version: '2.319.1'\nRunner Image Provisioner\nRunner Image: ubuntu-24.04\n", 40,
+	)
+	normalTestOutput := strings.Repeat("=== RUN   TestSomethingUnrelated\n--- PASS: TestSomethingUnrelated (0.00s)\n", 30)
+
+	tests := []struct {
+		name        string
+		logs        string
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name: "go test FAIL block at end of log",
+			logs: provisioningPreamble + normalTestOutput +
+				"--- FAIL: TestFoo (0.00s)\n" +
+				"    foo_test.go:42: assertion failed: got 1, want 2\n" +
+				"FAIL\n" +
+				"FAIL\tgithub.com/qf-studio/pilot/internal/foo\t0.004s\n",
+			wantContain: []string{
+				"--- FAIL: TestFoo",
+				"assertion failed: got 1, want 2",
+				"FAIL\tgithub.com/qf-studio/pilot/internal/foo",
+			},
+			wantAbsent: []string{"Current runner version", "Runner Image Provisioner"},
+		},
+		{
+			name: "panic timeout at end of log (GH-3956 shape)",
+			logs: provisioningPreamble + normalTestOutput +
+				"panic: test timed out after 10m0s\n" +
+				"\nrunning tests:\n\tTestMemory_LargePayloads (9m50s)\n" +
+				"FAIL\tgithub.com/qf-studio/pilot/internal/stress\t600.012s\n",
+			wantContain: []string{
+				"panic: test timed out after 10m0s",
+				"TestMemory_LargePayloads",
+				"FAIL\tgithub.com/qf-studio/pilot/internal/stress",
+			},
+			wantAbsent: []string{"Current runner version", "Runner Image Provisioner"},
+		},
+		{
+			name: "no failure marker falls back to trailing lines",
+			logs: func() string {
+				var sb strings.Builder
+				for i := 1; i <= 300; i++ {
+					sb.WriteString(fmt.Sprintf("build output line %d\n", i))
+				}
+				return sb.String()
+			}(),
+			wantContain: []string{"build output line 300", "build output line 152"},
+			wantAbsent:  []string{"build output line 1\n", "build output line 151\n"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			excerpt := extractFailureExcerpt(tt.logs, maxCIErrorExcerptChars)
+			for _, want := range tt.wantContain {
+				if !strings.Contains(excerpt, want) {
+					t.Errorf("excerpt missing %q\nexcerpt:\n%s", want, excerpt)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(excerpt, absent) {
+					t.Errorf("excerpt should not contain %q", absent)
+				}
+			}
+		})
+	}
+}
+
+// TestFeedbackLoop_CreateFailureIssue_FailureExcerptAtEnd verifies the fix
+// end-to-end through CreateFailureIssue: a fix-request issue body must
+// contain the actionable failure excerpt, not just log-head preamble.
+func TestFeedbackLoop_CreateFailureIssue_FailureExcerptAtEnd(t *testing.T) {
+	capturedBody := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/issues" && r.Method == "POST" {
+			var input github.IssueInput
+			_ = json.NewDecoder(r.Body).Decode(&input)
+			capturedBody = input.Body
+
+			resp := github.Issue{Number: 200}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+
+	fl := NewFeedbackLoop(ghClient, "owner", "repo", cfg)
+
+	preamble := strings.Repeat("Current runner version: '2.319.1'\nRunner Image Provisioner\n", 60)
+	unrelatedTestOutput := strings.Repeat("=== RUN   TestSomethingUnrelated\n--- PASS: TestSomethingUnrelated (0.00s)\n", 30)
+	logs := preamble + unrelatedTestOutput +
+		"panic: test timed out after 10m0s\n" +
+		"FAIL\tgithub.com/qf-studio/pilot/internal/stress\t600.012s\n"
+
+	prState := &PRState{PRNumber: 42, HeadSHA: "abc1234"}
+
+	_, err := fl.CreateFailureIssue(
+		context.Background(),
+		prState,
+		FailureCIPreMerge,
+		[]string{"test"},
+		logs,
+		0,
+	)
+	if err != nil {
+		t.Fatalf("CreateFailureIssue() error = %v", err)
+	}
+
+	if !strings.Contains(capturedBody, "panic: test timed out after 10m0s") {
+		t.Error("body should contain the panic excerpt, not just log-head preamble")
+	}
+	if !strings.Contains(capturedBody, "FAIL\tgithub.com/qf-studio/pilot/internal/stress") {
+		t.Error("body should contain the trailing FAIL summary")
+	}
+	if strings.Contains(capturedBody, "Current runner version") {
+		t.Error("body should not contain runner-provisioning preamble when a failure marker is present")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `FeedbackLoop.generateBody` embedded `logs[:2000]` from the head of the CI log into fix-request issue bodies — that's GitHub Actions runner-provisioning preamble (`Current runner version`, `Runner Image Provisioner`...), never the actual failure.
- Both autopilot-generated CI fix-request issues from the last 18h (#3937, #3956) self-rejected as `reject_vague` in the pre-flight intent judge for exactly this reason — 2/2 failure rate, CI-fix feedback loop dead on arrival.
- New `extractFailureExcerpt` locates the first `--- FAIL:`, `panic:`, or `##[error]` marker and excerpts from there to the end of the log (naturally including the trailing `FAIL <pkg>` summary), falling back to the last 150 lines when no marker is found. Cap raised from 2000 to 4000 chars, still well within GitHub's issue body limit.

Closes GH-3958.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (all green, including new `TestExtractFailureExcerpt_FailureAtEnd` table-driven test and `TestFeedbackLoop_CreateFailureIssue_FailureExcerptAtEnd` end-to-end test using the #3956 panic-at-end-of-log shape)
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/autopilot/...` — 0 issues