### PR TITLE
fix(autopilot): preserve trailing FAIL summary in oversized excerpts (GH-3958)

### DIFF
--- a/internal/autopilot/feedback_loop.go
+++ b/internal/autopilot/feedback_loop.go
@@ -63,11 +63,26 @@ func extractFailureExcerpt(logs string, maxChars int) string {
 		excerpt = lines
 	}
 
-	result := strings.Join(excerpt, "\n")
-	if len(result) > maxChars {
-		result = result[:maxChars] + "\n... (truncated)"
+	return truncateKeepingTail(strings.Join(excerpt, "\n"), maxChars)
+}
+
+// truncateKeepingTail caps s to maxChars while preserving both ends: the
+// head (where the failure marker and its lead-in context live) and the tail
+// (where the trailing `FAIL <pkg>` summary lives). A naive head-only cut can
+// silently drop the summary line on a large panic/stack-trace dump that
+// exceeds maxChars on its own.
+func truncateKeepingTail(s string, maxChars int) string {
+	if len(s) <= maxChars {
+		return s
 	}
-	return result
+	const marker = "\n... (truncated) ...\n"
+	budget := maxChars - len(marker)
+	if budget <= 0 {
+		return s[:maxChars] + "\n... (truncated)"
+	}
+	headLen := budget * 7 / 10
+	tailLen := budget - headLen
+	return s[:headLen] + marker + s[len(s)-tailLen:]
 }
 
 // FeedbackLoop creates issues when CI fails or bugs are detected.

--- a/internal/autopilot/feedback_loop_test.go
+++ b/internal/autopilot/feedback_loop_test.go
@@ -1362,6 +1362,40 @@ func TestFeedbackLoop_CreateFailureIssue_FailureExcerptAtEnd(t *testing.T) {
 	}
 }
 
+// TestExtractFailureExcerpt_OversizedExcerptKeepsTrailingSummary covers the
+// case where the failure excerpt itself (marker to end of log) exceeds
+// maxChars, e.g. a panic with a very large goroutine dump. Naively
+// truncating from the head would drop the trailing `FAIL <pkg>` summary,
+// which defeats the point of the excerpt.
+func TestExtractFailureExcerpt_OversizedExcerptKeepsTrailingSummary(t *testing.T) {
+	preamble := strings.Repeat("Current runner version: '2.319.1'\nRunner Image Provisioner\n", 40)
+	unrelatedTestOutput := strings.Repeat("=== RUN   TestSomethingUnrelated\n--- PASS: TestSomethingUnrelated (0.00s)\n", 10)
+	hugeStackDump := strings.Repeat("goroutine 1 [running]:\nsome.deeply.nested.function(...)\n\t/path/to/file.go:123 +0x45\n", 200)
+	logs := preamble + unrelatedTestOutput +
+		"panic: test timed out after 10m0s\n" +
+		hugeStackDump +
+		"FAIL\tgithub.com/qf-studio/pilot/internal/stress\t600.012s\n"
+
+	if len("panic: test timed out after 10m0s\n"+hugeStackDump) <= maxCIErrorExcerptChars {
+		t.Fatal("test fixture excerpt should exceed maxCIErrorExcerptChars to exercise the oversized path")
+	}
+
+	excerpt := extractFailureExcerpt(logs, maxCIErrorExcerptChars)
+
+	if !strings.Contains(excerpt, "panic: test timed out after 10m0s") {
+		t.Error("excerpt should retain the panic marker near the head")
+	}
+	if !strings.Contains(excerpt, "FAIL\tgithub.com/qf-studio/pilot/internal/stress") {
+		t.Error("excerpt should retain the trailing FAIL summary even when the excerpt itself is oversized")
+	}
+	if strings.Contains(excerpt, "Current runner version") {
+		t.Error("excerpt should not contain runner-provisioning preamble")
+	}
+	if len(excerpt) > maxCIErrorExcerptChars+len("\n... (truncated) ...\n") {
+		t.Errorf("excerpt length %d exceeds budget", len(excerpt))
+	}
+}
+
 func mustFLJSON(t *testing.T, v any) []byte {
 	t.Helper()
 	b, err := json.Marshal(v)


### PR DESCRIPTION
## Summary
- Follow-up to #3967 (GH-3958). `extractFailureExcerpt` correctly seeks the failure marker (`--- FAIL:`, `panic:`, `##[error]`) to the end of the log, but if that marker-to-end excerpt itself exceeds the 4000-char budget, the old truncation cut from the head — which could silently drop the trailing `FAIL <pkg>` summary on a large panic/stack-trace dump, defeating the point of the excerpt.
- `truncateKeepingTail` now budgets space for both the head (marker + lead-in context) and the tail (summary line) instead of truncating the tail away entirely.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/... -count=1` (includes new `TestExtractFailureExcerpt_OversizedExcerptKeepsTrailingSummary`)