### PR TITLE
fix(stress): bound TestMemory_LargePayloads wait loop with waitForProcessed

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updated": "2026-07-06",
+  "updated": "2026-07-07",
   "nodes": {
     "concepts": {
       "pilot-architecture": {
@@ -1499,6 +1499,20 @@
         "summary": "Extraction-era SDK ports go stale vs evolving in-tree code: SDK GetTagForSHA shipped bounded (20 tags) while in-tree moved to exhaustive pagination \u2014 would have stalled release draining. Caught by running the consumer test suite against the SDK client (TestHandleReleasing_ExhaustiveTagDrain). Before cutover: diff SDK methods against CURRENT in-tree source; typed-error/pagination/retry drift compiles fine and fails only behaviorally.",
         "type": "pitfall",
         "file": ".agent/knowledge/memories/pitfalls/pitfall_sdk_ports_go_stale_vs_intree.md"
+      },
+      "mem-088": {
+        "type": "pitfall",
+        "summary": "TestMemory_LargePayloads used a raw unbounded busy-wait loop instead of the waitForProcessed(t, ...) helper (TASK-353), so a dispatch stall hung the goroutine until the 600s package timeout \u2014 sniping 3 unrelated PRs (#3918, #3955, #3960) whose diffs never touched stress/. Fixed by switching it to waitForProcessed. Root-cause dispatch stall tracked separately by GH-3959.",
+        "file": ".agent/knowledge/memories/pitfalls/pitfall_stress_test_unbounded_wait_loop.md",
+        "confidence": 0.95,
+        "concepts": [
+          "stress-tests",
+          "github-adapter",
+          "poller"
+        ],
+        "created": "2026-07-07",
+        "severity": "high",
+        "origin_task": "GH-3961"
       }
     }
   },
@@ -2337,6 +2351,21 @@
       "from": "TASK-368",
       "to": "testing",
       "type": "implements"
+    },
+    {
+      "from": "stress-tests",
+      "to": "mem-088",
+      "type": "has_pitfall"
+    },
+    {
+      "from": "github-adapter",
+      "to": "mem-088",
+      "type": "has_pitfall"
+    },
+    {
+      "from": "poller",
+      "to": "mem-088",
+      "type": "has_pitfall"
     }
   ],
   "concept_index": {
@@ -2411,10 +2440,10 @@
       "TASK-368"
     ]
   },
-  "last_updated": "2026-07-06T12:16:33.258633+00:00",
+  "last_updated": "2026-07-07T00:00:00+00:00",
   "stats": {
-    "total_nodes": 135,
-    "total_edges": 167,
-    "memory_count": 86
+    "total_nodes": 136,
+    "total_edges": 170,
+    "memory_count": 87
   }
 }

--- a/.agent/knowledge/memories/pitfalls/pitfall_stress_test_unbounded_wait_loop.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_stress_test_unbounded_wait_loop.md
@@ -1,0 +1,39 @@
+---
+name: stress-test-unbounded-wait-loop
+description: TestMemory_LargePayloads used a raw unbounded busy-wait loop instead of the waitForProcessed(t, ...) helper, so any stall in dispatch hung the goroutine until the 600s package timeout killed the whole stress suite — sniping 3 unrelated PRs (#3918, #3955, #3960).
+type: pitfall
+---
+
+**Every wait-for-processed-count loop in `stress/memory_test.go` must use the
+`waitForProcessed(t, get, want, timeout)` helper** (added by TASK-353), never
+a raw `for get() < want { time.Sleep(...) }` loop with no deadline.
+
+**Why:** TASK-353 introduced `waitForProcessed` specifically to bound these
+loops after they caused whole-package 600s timeouts, but the migration missed
+`TestMemory_LargePayloads` (line ~342) — it kept the old unbounded form. When
+the underlying poller dispatch stalled (a real but separate concurrency issue,
+tracked as GH-3959 / mem-048 family), the test goroutine parked in
+`time.Sleep` at `memory_test.go:343` for the full 10 minutes, killing the
+`test` CI job package-wide. This sniped three unrelated PRs whose diffs never
+touched `stress/`: #3918 (GH-3903), #3955 (GH-3952 alerts wiring), and #3960
+(same branch, retry). Each looked like a real CI failure to the autopilot
+fix-request bot, but the fix-request logs only captured the runner
+provisioning preamble, not the panic — see
+[[ci-fix-request-excerpts-head-of-log-instead-of-failure]].
+
+**How to apply:**
+1. When adding or reviewing a wait loop in `stress/*_test.go`, always call
+   `waitForProcessed(t, func() int64 { return atomic.LoadInt64(&counter) },
+   want, timeout)` — never hand-roll the loop.
+2. If a new test needs a different wait condition (not a simple counter),
+   still bound it with a `deadline := time.Now().Add(timeout)` check inside
+   the loop (see `TestMemory_RepeatedStartStop`'s per-cycle pattern) so a
+   stall fails fast with a clear message instead of riding to the package
+   timeout.
+3. This is a symptom fix, not a root cause fix — the actual dispatch stall in
+   the poller is tracked separately by GH-3959 (open as of 2026-07-07,
+   scoped to `stress/` root-cause + no-decompose).
+
+Related: [[poller-api-calls-deadlock-stress-suite]] (same stress-suite-timeout
+failure mode, different root cause); GH-3959 (root-cause task, still open);
+GH-3961 (this fix).

--- a/stress/memory_test.go
+++ b/stress/memory_test.go
@@ -337,11 +337,10 @@ func TestMemory_LargePayloads(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	go poller.Start(ctx)
 
-	for atomic.LoadInt64(&processedCount) < int64(numIssues) {
-		time.Sleep(100 * time.Millisecond)
-	}
+	waitForProcessed(t, func() int64 { return atomic.LoadInt64(&processedCount) }, int64(numIssues), 25*time.Second)
 
 	cancel()
 	poller.WaitForActive()


### PR DESCRIPTION
## Summary

Fixes GH-3961: CI failure on PR #3960 (branch `pilot/GH-3952`) — the `test` job hit the package-level 10-minute timeout in `stress/`:

```
panic: test timed out after 10m0s
running tests:
    TestMemory_LargePayloads (9m50s)
FAIL	github.com/qf-studio/pilot/stress	600.030s
```

PR #3960's own diff only touches `internal/alerts/*` — the failure is unrelated to that change. Root cause: `TestMemory_LargePayloads` (`stress/memory_test.go`) was the one test in the file still using a raw, unbounded busy-wait loop:

```go
for atomic.LoadInt64(&processedCount) < int64(numIssues) {
    time.Sleep(100 * time.Millisecond)
}
```

TASK-353 introduced the `waitForProcessed(t, get, want, timeout)` helper specifically to bound these loops and fail fast instead of riding the package timeout — `TestMemory_NoUnboundedGrowth` and `TestMemory_ProcessedMapGrowth` were migrated, but `TestMemory_LargePayloads` was missed. When poller dispatch stalled, this test's goroutine parked in the unbounded loop until the whole `stress` package hit its 600s CI timeout, killing the `test` job for any concurrently-running PR. This has now sniped three unrelated PRs: #3918, #3955, #3960.

## Changes

- `stress/memory_test.go`: switch `TestMemory_LargePayloads`'s wait loop to `waitForProcessed(t, ..., 25*time.Second)`, matching the other tests in the file.
- Add knowledge-graph pitfall entry (`mem-088`) documenting the pattern so future new/edited stress tests use the bounded helper.

Note: the underlying poller dispatch stall (why processing occasionally doesn't complete) is a separate, deeper issue already tracked in GH-3959 (open, scoped to root-causing the `stress/` deadlock). This PR only bounds the blast radius so a stall fails one test fast instead of killing CI for unrelated work.

## Test plan

- [x] `go build ./...`
- [x] `go test ./stress/... -timeout 120s -count=5 -v` — all pass, including `TestMemory_LargePayloads`
- [x] `go test ./internal/alerts/...` — passes (the actual PR #3960 diff)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `python3 scripts/check-graph.py` — knowledge graph matches disk state (for the files in this PR)

Depends on: #3952