### PR TITLE
feat(autopilot): post-tag release verification with backstop scanner

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -264,6 +264,16 @@ type Controller struct {
 	// main.go, not just the default one.
 	alertsEngine alertSink
 
+	// alertedMissingReleases deduplicates release_missing alerts per
+	// "owner/repo@tag", guarded by mu. Needed because the alerts engine's
+	// cooldown is keyed by rule name (shouldFire -> lastAlertTimes[rule.Name]),
+	// not by source — without this map a second repo/tag breaking inside the
+	// same cooldown window would be silently swallowed. Both afterTagCreated
+	// (goroutine path) and the ScanRecentlyMergedPRs backstop share it, since a
+	// hot-upgrade restart can kill the former mid-flight and let the scanner
+	// catch the same tag. GH-3927.
+	alertedMissingReleases map[string]bool
+
 	// cachedBotLogin holds the authenticated GitHub login for the Pilot token.
 	// Populated lazily by getBotLogin; protected by mu. GH-3417.
 	cachedBotLogin string
@@ -279,17 +289,18 @@ type Controller struct {
 // NewController creates an autopilot controller with all required components.
 func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.Manager, owner, repo string, opts ...ControllerOption) *Controller {
 	c := &Controller{
-		config:         cfg,
-		ghClient:       ghClient,
-		approvalMgr:    approvalMgr,
-		owner:          owner,
-		repo:           repo,
-		activePRs:      make(map[int]*PRState),
-		recordedMerges: make(map[int]bool),
-		prFailures:     make(map[int]*prFailureState),
-		lastProgressAt: time.Now(), // Initialize to now to avoid false alarm on startup
-		metrics:        NewMetrics(),
-		log:            slog.Default().With("component", "autopilot"),
+		config:                 cfg,
+		ghClient:               ghClient,
+		approvalMgr:            approvalMgr,
+		owner:                  owner,
+		repo:                   repo,
+		activePRs:              make(map[int]*PRState),
+		recordedMerges:         make(map[int]bool),
+		prFailures:             make(map[int]*prFailureState),
+		lastProgressAt:         time.Now(), // Initialize to now to avoid false alarm on startup
+		metrics:                NewMetrics(),
+		log:                    slog.Default().With("component", "autopilot"),
+		alertedMissingReleases: make(map[string]bool),
 	}
 
 	// Options must apply before the releaser is constructed below: the
@@ -2455,21 +2466,10 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		)
 	}
 
-	// Enrich release with LLM-generated summary (best-effort, non-blocking).
-	// Runs in a goroutine because in "workflow" mode it polls for GoReleaser to
-	// publish the release (up to 5 min); in "api" mode GetReleaseByTag succeeds
-	// immediately since the release was just created above. Skipped entirely
-	// for "tag_only" — no release will ever appear, so the poll would just
-	// burn 5 min before warning.
-	if rel.PublishMode() != ReleasePublishTagOnly && c.releaseSummary != nil && rel.GenerateSummary {
-		logging.SafeGo("autopilot-controller", func() {
-			enrichCtx, cancel := context.WithTimeout(context.Background(), releasePollTimeout+releaseSummaryTimeout)
-			defer cancel()
-			if err := c.releaseSummary.EnrichRelease(enrichCtx, owner, repo, tagName, commits); err != nil {
-				c.log.Warn("failed to enrich release notes", "tag", tagName, "error", err)
-			}
-		})
-	}
+	// Enrichment + post-tag release verification (GH-3927), unified into a
+	// single goroutine so "workflow" mode polls for the release exactly once
+	// (afterTagCreated does not launch anything for "tag_only").
+	c.afterTagCreated(owner, repo, tagName, prState.PRNumber, prState.IssueNumber, commits, rel)
 
 	// Send notification
 	if rel.NotifyOnRelease && c.notifier != nil {
@@ -2581,6 +2581,126 @@ func (c *Controller) escalateReleasingFailed(ctx context.Context, prState *PRSta
 	prState.Error = reason
 	c.metrics.RecordPRFailed()
 	c.metrics.RecordIssueProcessed("failed")
+}
+
+// afterTagCreated runs once a release tag has been created, unifying release-note
+// enrichment with post-tag release verification (GH-3927) into a single per-mode
+// goroutine so "workflow" mode polls for the release exactly once:
+//   - "tag_only": no release will ever appear — nothing is launched.
+//   - "api": the GitHub Release already exists (Pilot just created it above) —
+//     enrichment-only, no polling needed.
+//   - "workflow": polls waitForReleaseByTag for up to rel.VerifyTimeout. On
+//     success, enriches like "api". On timeout, fires a release_missing alert
+//     (unless VerifyRelease was explicitly disabled) via fireReleaseMissingAlert.
+//
+// Uses context.Background()+timeout inside the goroutine (not the ctx
+// handleReleasing was called with) so a poll-tick cancellation cannot kill
+// verification or enrichment mid-flight — mirrors the pre-existing enrichment
+// goroutine this replaces.
+func (c *Controller) afterTagCreated(owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig) {
+	if rel.PublishMode() == ReleasePublishTagOnly {
+		return
+	}
+
+	if rel.PublishMode() == ReleasePublishAPI {
+		logging.SafeGo("autopilot-controller", func() {
+			c.enrichReleaseNotes(owner, repo, tagName, commits, rel)
+		})
+		return
+	}
+
+	// "workflow": verify the release appears within VerifyTimeout before enriching.
+	timeout := rel.VerifyTimeout
+	if timeout <= 0 {
+		timeout = releasePollTimeout
+	}
+	logging.SafeGo("autopilot-controller", func() {
+		c.verifyReleaseAfterTag(context.Background(), owner, repo, tagName, prNumber, issueNumber, commits, rel, releasePollInterval, timeout)
+	})
+}
+
+// enrichReleaseNotes generates and attaches an LLM release summary. Best-effort:
+// logs and returns on failure rather than propagating an error, since a missing
+// summary should never affect release state.
+func (c *Controller) enrichReleaseNotes(owner, repo, tagName string, commits []*github.Commit, rel *ReleaseConfig) {
+	if c.releaseSummary == nil || !rel.GenerateSummary {
+		return
+	}
+	enrichCtx, cancel := context.WithTimeout(context.Background(), releasePollTimeout+releaseSummaryTimeout)
+	defer cancel()
+	if err := c.releaseSummary.EnrichRelease(enrichCtx, owner, repo, tagName, commits); err != nil {
+		c.log.Warn("failed to enrich release notes", "tag", tagName, "error", err)
+	}
+}
+
+// verifyReleaseAfterTag is the synchronous body of afterTagCreated's "workflow"
+// verification goroutine, factored out (interval/timeout as params) so tests can
+// call it directly with short values instead of racing a background goroutine
+// against the real releasePollInterval/VerifyTimeout. On success it enriches like
+// "api" mode; on timeout it fires a release_missing alert unless VerifyRelease
+// was explicitly disabled. GH-3927.
+func (c *Controller) verifyReleaseAfterTag(ctx context.Context, owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig, interval, timeout time.Duration) {
+	verifyCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if _, err := waitForReleaseByTag(verifyCtx, c.ghClient, c.log, owner, repo, tagName, interval, timeout); err != nil {
+		if rel.VerifyReleaseEnabled() {
+			c.fireReleaseMissingAlert(owner, repo, tagName, prNumber, issueNumber, timeout)
+		}
+		return
+	}
+	c.enrichReleaseNotes(owner, repo, tagName, commits, rel)
+}
+
+// fireReleaseMissingAlert fires a release_missing alert (GH-3927) for a tag whose
+// GitHub Release never appeared within the verification window, and comments on
+// the source issue (in c.owner/c.repo, mirroring escalateReleasingFailed) when
+// known. Deduplicated per "owner/repo@tag" via alertedMissingReleases: the alerts
+// engine's cooldown is keyed by rule name, not by source, so without
+// controller-side dedup a second break inside the same cooldown window would be
+// silently swallowed. Shared by afterTagCreated and the ScanRecentlyMergedPRs
+// backstop, since a hot-upgrade restart can kill the former mid-flight.
+func (c *Controller) fireReleaseMissingAlert(owner, repo, tag string, prNumber, issueNumber int, timeout time.Duration) {
+	key := owner + "/" + repo + "@" + tag
+	c.mu.Lock()
+	if c.alertedMissingReleases == nil {
+		c.alertedMissingReleases = make(map[string]bool)
+	}
+	if c.alertedMissingReleases[key] {
+		c.mu.Unlock()
+		return
+	}
+	c.alertedMissingReleases[key] = true
+	c.mu.Unlock()
+
+	msg := fmt.Sprintf(
+		"tag %s exists in %s/%s but no GitHub Release was published within %s — check the repo's release workflow (or the release is a draft)",
+		tag, owner, repo, timeout,
+	)
+	c.log.Warn("release verification: no GitHub Release published within window",
+		"owner", owner, "repo", repo, "tag", tag, "pr", prNumber, "timeout", timeout,
+	)
+
+	if c.alertsEngine == nil {
+		c.log.Error("release_missing alert not delivered: SetAlertsEngine was never called", "tag", tag)
+	} else {
+		c.alertsEngine.ProcessEvent(alerts.Event{
+			Type:      alerts.EventType("release_missing"),
+			Error:     msg,
+			Timestamp: time.Now(),
+			Metadata: map[string]string{
+				"repo": owner + "/" + repo,
+				"tag":  tag,
+				"pr":   strconv.Itoa(prNumber),
+			},
+		})
+	}
+
+	if issueNumber > 0 {
+		comment := fmt.Sprintf("⚠️ **Release verification failed**: %s", msg)
+		if _, cerr := c.ghClient.AddComment(context.Background(), c.owner, c.repo, issueNumber, comment); cerr != nil {
+			c.log.Warn("failed to post release-missing comment", "issue", issueNumber, "error", cerr)
+		}
+	}
 }
 
 // guardReleaseSHAReachable verifies that prState.HeadSHA is reachable from the default
@@ -3150,6 +3270,44 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 	}
 }
 
+// backstopCheckReleaseMissing is the scanner-side counterpart to afterTagCreated's
+// verification (GH-3927). A hot-upgrade restart kills afterTagCreated's in-flight
+// goroutine, and autopilot_pr_state rows are deleted on completion by design, so
+// there is no persistence to resume verification from — this backstop re-derives
+// it from GitHub state alone during ScanRecentlyMergedPRs's already-tagged branch.
+// Fires (through the shared alertedMissingReleases dedup) when: publish mode is
+// "workflow" or "api" (both expect a GitHub Release to exist — "tag_only" never
+// does), verification is enabled, the merge is older than VerifyTimeout, and no
+// GitHub Release exists for tag. Known limitation: only covers gaps up to
+// MergedPRScanWindow (default 30m) after the goroutine would have fired, since
+// that is how far back this scan looks.
+func (c *Controller) backstopCheckReleaseMissing(ctx context.Context, rel *ReleaseConfig, prNumber, issueNumber int, tag string, mergedAt time.Time) {
+	if rel == nil || !rel.VerifyReleaseEnabled() {
+		return
+	}
+	mode := rel.PublishMode()
+	if mode != ReleasePublishWorkflow && mode != ReleasePublishAPI {
+		return
+	}
+	timeout := rel.VerifyTimeout
+	if timeout <= 0 {
+		timeout = releasePollTimeout
+	}
+	if time.Since(mergedAt) <= timeout {
+		return
+	}
+	release, err := c.ghClient.GetReleaseByTag(ctx, c.owner, c.repo, tag)
+	if err != nil {
+		c.log.Warn("backstop: failed to check release for already-tagged PR, skipping",
+			"pr", prNumber, "tag", tag, "error", err)
+		return
+	}
+	if release != nil {
+		return
+	}
+	c.fireReleaseMissingAlert(c.owner, c.repo, tag, prNumber, issueNumber, timeout)
+}
+
 // ScanRecentlyMergedPRs scans for Pilot PRs that were merged externally.
 // This catches PRs that need release triggering but were merged outside of
 // autopilot (e.g. via `gh pr merge` or the GitHub UI).
@@ -3161,6 +3319,7 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 	// per-mode; both are idempotent so duplicate calls are safe.
 	releaseEnabled := c.shouldTriggerRelease()
 	boardEnabled := c.boardSync != nil && c.doneStatus != ""
+	rel := c.resolvedRelease()
 
 	scanWindow := c.config.MergedPRScanWindow
 	if scanWindow == 0 {
@@ -3309,6 +3468,7 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 					"merge_sha", ShortSHA(pr.MergeCommitSHA),
 					"tag", existingTag,
 				)
+				c.backstopCheckReleaseMissing(ctx, rel, pr.Number, issueNum, existingTag, mergedAt)
 				continue
 			}
 		}

--- a/internal/autopilot/controller_release_verify_test.go
+++ b/internal/autopilot/controller_release_verify_test.go
@@ -1,0 +1,220 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// releaseTagsServer serves GET .../releases/tags/<tag> according to a sequence
+// of canned responses ("missing" -> 404, "present" -> 200 with a release body),
+// consumed one per call so tests can simulate "not yet published, then published".
+// Requests past the end of the sequence repeat the last entry.
+func releaseTagsServer(t *testing.T, sequence []string) *httptest.Server {
+	t.Helper()
+	var calls int
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/releases/tags/") {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		idx := calls
+		if idx >= len(sequence) {
+			idx = len(sequence) - 1
+		}
+		calls++
+		if sequence[idx] == "present" {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.2.3", HTMLURL: "https://example.com/releases/v1.2.3"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+}
+
+// TestAfterTagCreated_WorkflowMode_ReleaseAppears verifies that when the release
+// publishes before VerifyTimeout elapses, verifyReleaseAfterTag returns without
+// firing an alert (and enrichment, when configured, would run against the now-
+// published release).
+func TestAfterTagCreated_WorkflowMode_ReleaseAppears(t *testing.T) {
+	server := releaseTagsServer(t, []string{"missing", "present"})
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", TagPrefix: "v", Publish: ReleasePublishWorkflow}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	rel := &ReleaseConfig{Publish: ReleasePublishWorkflow, VerifyRelease: boolPtr(true), VerifyTimeout: time.Second}
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v1.2.3", 42, 7, nil, rel, 5*time.Millisecond, 500*time.Millisecond)
+
+	if len(sink.events) != 0 {
+		t.Errorf("expected no alert when the release appears in time, got %d events", len(sink.events))
+	}
+	c.mu.Lock()
+	alerted := c.alertedMissingReleases["owner/repo@v1.2.3"]
+	c.mu.Unlock()
+	if alerted {
+		t.Error("tag must not be marked as alerted when the release appears in time")
+	}
+}
+
+// TestAfterTagCreated_WorkflowMode_Timeout_FiresAlert verifies that when the
+// release never appears within VerifyTimeout, exactly one release_missing event
+// reaches the alerts engine — and that calling verifyReleaseAfterTag again for
+// the same tag does NOT fire a second event (controller-side dedup, since the
+// alerts engine's cooldown is keyed by rule name, not by source).
+func TestAfterTagCreated_WorkflowMode_Timeout_FiresAlert(t *testing.T) {
+	server := releaseTagsServer(t, []string{"missing"})
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", TagPrefix: "v", Publish: ReleasePublishWorkflow}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	rel := &ReleaseConfig{Publish: ReleasePublishWorkflow, VerifyRelease: boolPtr(true), VerifyTimeout: 20 * time.Millisecond}
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond)
+
+	if len(sink.events) != 1 {
+		t.Fatalf("expected exactly 1 release_missing event, got %d", len(sink.events))
+	}
+	if sink.events[0].Metadata["tag"] != "v9.9.9" {
+		t.Errorf("event metadata tag = %q, want v9.9.9", sink.events[0].Metadata["tag"])
+	}
+	if sink.events[0].Metadata["repo"] != "owner/repo" {
+		t.Errorf("event metadata repo = %q, want owner/repo", sink.events[0].Metadata["repo"])
+	}
+
+	// Same tag again — dedup must suppress a second event.
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond)
+	if len(sink.events) != 1 {
+		t.Errorf("dedup: expected still exactly 1 event after re-verifying the same tag, got %d", len(sink.events))
+	}
+}
+
+// TestAfterTagCreated_WorkflowMode_VerifyDisabled_NoAlert verifies that an
+// explicit VerifyRelease=false suppresses the alert even on timeout.
+func TestAfterTagCreated_WorkflowMode_VerifyDisabled_NoAlert(t *testing.T) {
+	server := releaseTagsServer(t, []string{"missing"})
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	rel := &ReleaseConfig{Publish: ReleasePublishWorkflow, VerifyRelease: boolPtr(false), VerifyTimeout: 20 * time.Millisecond}
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v5.5.5", 1, 0, nil, rel, 5*time.Millisecond, 20*time.Millisecond)
+
+	if len(sink.events) != 0 {
+		t.Errorf("expected no alert when VerifyRelease is explicitly false, got %d events", len(sink.events))
+	}
+}
+
+// TestAfterTagCreated_TagOnly_NoPolling verifies that "tag_only" mode never
+// launches verification: zero requests to GET .../releases/tags/....
+func TestAfterTagCreated_TagOnly_NoPolling(t *testing.T) {
+	var releaseTagRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/") {
+			releaseTagRequests++
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	rel := &ReleaseConfig{Publish: ReleasePublishTagOnly, VerifyRelease: boolPtr(true), VerifyTimeout: time.Second}
+	c.afterTagCreated("owner", "repo", "v1.0.0", 1, 0, nil, rel)
+
+	// afterTagCreated returns synchronously without launching a goroutine for
+	// tag_only, so no sleep/wait is needed before asserting.
+	if releaseTagRequests != 0 {
+		t.Errorf("tag_only mode must not poll for the release, got %d GET .../releases/tags/... requests", releaseTagRequests)
+	}
+}
+
+// TestScanRecentlyMergedPRs_BackstopAlert verifies the scanner backstop
+// (backstopCheckReleaseMissing): a merge older than VerifyTimeout with a covering
+// tag but no GitHub Release fires exactly one alert; a merge with a release
+// present, tag_only mode, or a merge still within the timeout window fire none.
+func TestScanRecentlyMergedPRs_BackstopAlert(t *testing.T) {
+	tests := []struct {
+		name        string
+		publish     string
+		mergedAgo   time.Duration
+		releaseName string // "" = GetReleaseByTag returns nil (no release)
+		wantAlert   bool
+	}{
+		{name: "workflow mode, past timeout, no release fires", publish: ReleasePublishWorkflow, mergedAgo: time.Hour, wantAlert: true},
+		{name: "api mode, past timeout, no release fires", publish: ReleasePublishAPI, mergedAgo: time.Hour, wantAlert: true},
+		{name: "release present suppresses alert", publish: ReleasePublishWorkflow, mergedAgo: time.Hour, releaseName: "v1.0.0", wantAlert: false},
+		{name: "tag_only never alerts", publish: ReleasePublishTagOnly, mergedAgo: time.Hour, wantAlert: false},
+		{name: "within verify window does not alert yet", publish: ReleasePublishWorkflow, mergedAgo: time.Second, wantAlert: false},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tag := "vbackstop"
+			c := &Controller{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+			// Minimal fake ghClient via httptest is overkill here — exercise the
+			// unit directly since ScanRecentlyMergedPRs's full HTTP plumbing is
+			// already covered elsewhere; backstopCheckReleaseMissing is the new
+			// logic under test.
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/") {
+					if tt.releaseName == "" {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(github.Release{TagName: tt.releaseName})
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			c.ghClient = ghClient
+			c.owner = "owner"
+			c.repo = "repo"
+			c.alertedMissingReleases = make(map[string]bool)
+			sink := &fakeAlertSink{}
+			c.SetAlertsEngine(sink)
+
+			rel := &ReleaseConfig{
+				Publish:       tt.publish,
+				VerifyRelease: boolPtr(true),
+				VerifyTimeout: 10 * time.Minute,
+			}
+			mergedAt := time.Now().Add(-tt.mergedAgo)
+			c.backstopCheckReleaseMissing(context.Background(), rel, 100+i, 0, tag+string(rune('a'+i)), mergedAt)
+
+			gotAlert := len(sink.events) == 1
+			if gotAlert != tt.wantAlert {
+				t.Errorf("alert fired = %v (events=%d), want %v", gotAlert, len(sink.events), tt.wantAlert)
+			}
+		})
+	}
+}

--- a/internal/autopilot/release_summary.go
+++ b/internal/autopilot/release_summary.go
@@ -107,12 +107,22 @@ func (g *ReleaseSummaryGenerator) waitForRelease(ctx context.Context, owner, rep
 
 // waitForReleaseWithInterval polls with configurable interval (testable).
 func (g *ReleaseSummaryGenerator) waitForReleaseWithInterval(ctx context.Context, owner, repo, tag string, interval time.Duration) (*github.Release, error) {
-	deadline := time.After(releasePollTimeout)
+	return waitForReleaseByTag(ctx, g.ghClient, g.log, owner, repo, tag, interval, releasePollTimeout)
+}
+
+// waitForReleaseByTag polls GetReleaseByTag on the given client until the
+// release appears or timeout elapses. Extracted from
+// ReleaseSummaryGenerator.waitForReleaseWithInterval so the post-tag release
+// verification backstop (GH-3927) can reuse the same polling loop with its
+// own client, logger, and configurable timeout (ReleaseConfig.VerifyTimeout)
+// without needing summary-generation state.
+func waitForReleaseByTag(ctx context.Context, ghClient *github.Client, log *slog.Logger, owner, repo, tag string, interval, timeout time.Duration) (*github.Release, error) {
+	deadline := time.After(timeout)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	// Check immediately before first tick
-	release, err := g.ghClient.GetReleaseByTag(ctx, owner, repo, tag)
+	release, err := ghClient.GetReleaseByTag(ctx, owner, repo, tag)
 	if err == nil && release != nil {
 		return release, nil
 	}
@@ -122,17 +132,17 @@ func (g *ReleaseSummaryGenerator) waitForReleaseWithInterval(ctx context.Context
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-deadline:
-			return nil, fmt.Errorf("timed out waiting for release %s (polled %v)", tag, releasePollTimeout)
+			return nil, fmt.Errorf("timed out waiting for release %s (polled %v)", tag, timeout)
 		case <-ticker.C:
-			release, err := g.ghClient.GetReleaseByTag(ctx, owner, repo, tag)
+			release, err := ghClient.GetReleaseByTag(ctx, owner, repo, tag)
 			if err != nil {
-				g.log.Warn("failed to fetch release", "tag", tag, "error", err)
+				log.Warn("failed to fetch release", "tag", tag, "error", err)
 				continue
 			}
 			if release != nil {
 				return release, nil
 			}
-			g.log.Debug("release not yet published, waiting", "tag", tag)
+			log.Debug("release not yet published, waiting", "tag", tag)
 		}
 	}
 }

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -371,6 +371,15 @@ type ReleaseConfig struct {
 	// behaves like "workflow". See internal/config Config.Validate for the
 	// enum check (GH-3930).
 	Publish string `yaml:"publish,omitempty"`
+	// VerifyRelease controls post-tag verification that a GitHub Release
+	// actually appears (GH-3927). Nil defers to VerifyReleaseEnabled's
+	// per-publish-mode default (true in "workflow" mode); explicit false
+	// opts out regardless of mode.
+	VerifyRelease *bool `yaml:"verify_release,omitempty"`
+	// VerifyTimeout bounds how long post-tag verification polls for the
+	// release to appear before firing a release_missing alert. Zero means
+	// unset; DefaultReleaseConfig sets the 10m default (GH-3927).
+	VerifyTimeout time.Duration `yaml:"verify_timeout,omitempty"`
 }
 
 // Publish mode values for ReleaseConfig.Publish / ProjectReleaseConfig.Publish (GH-3926).
@@ -396,6 +405,21 @@ func (r *ReleaseConfig) PublishMode() string {
 	return r.Publish
 }
 
+// VerifyReleaseEnabled resolves whether post-tag release verification
+// (GH-3927) should run. An explicit VerifyRelease always wins; an unset
+// (nil) value defaults to true only in "workflow" publish mode, since that
+// is the mode where the chain can break silently after the tag (a broken
+// or missing release workflow). A nil receiver returns false.
+func (r *ReleaseConfig) VerifyReleaseEnabled() bool {
+	if r == nil {
+		return false
+	}
+	if r.VerifyRelease != nil {
+		return *r.VerifyRelease
+	}
+	return r.PublishMode() == ReleasePublishWorkflow
+}
+
 // ProjectReleaseConfig overlays release settings for a single project on top
 // of the global and per-environment ReleaseConfig blocks. Unset fields
 // inherit the base value — e.g. a project may override Publish while leaving
@@ -416,6 +440,10 @@ type ProjectReleaseConfig struct {
 	GenerateChangelog *bool `yaml:"generate_changelog,omitempty"`
 	// NotifyOnRelease overrides ReleaseConfig.NotifyOnRelease for this project. Nil inherits.
 	NotifyOnRelease *bool `yaml:"notify_on_release,omitempty"`
+	// VerifyRelease overrides ReleaseConfig.VerifyRelease for this project. Nil inherits.
+	VerifyRelease *bool `yaml:"verify_release,omitempty"`
+	// VerifyTimeout overrides ReleaseConfig.VerifyTimeout for this project. Zero inherits.
+	VerifyTimeout time.Duration `yaml:"verify_timeout,omitempty"`
 }
 
 // Apply overlays this project-level config on top of base (the resolved
@@ -459,6 +487,12 @@ func (p *ProjectReleaseConfig) Apply(base *ReleaseConfig) *ReleaseConfig {
 	if p.NotifyOnRelease != nil {
 		result.NotifyOnRelease = *p.NotifyOnRelease
 	}
+	if p.VerifyRelease != nil {
+		result.VerifyRelease = p.VerifyRelease
+	}
+	if p.VerifyTimeout != 0 {
+		result.VerifyTimeout = p.VerifyTimeout
+	}
 	return &result
 }
 
@@ -473,6 +507,7 @@ func DefaultReleaseConfig() *ReleaseConfig {
 		NotifyOnRelease:   true,
 		RequireCI:         true,
 		GenerateSummary:   true,
+		VerifyTimeout:     10 * time.Minute,
 	}
 }
 

--- a/internal/autopilot/types_test.go
+++ b/internal/autopilot/types_test.go
@@ -88,6 +88,60 @@ func TestProjectReleaseConfig_Apply(t *testing.T) {
 			t.Errorf("TagPrefix = %q, want %q", got.TagPrefix, "release-")
 		}
 	})
+
+	t.Run("verify_release and verify_timeout override", func(t *testing.T) {
+		base := &ReleaseConfig{Enabled: true, VerifyRelease: boolPtr(true), VerifyTimeout: 10 * time.Minute}
+		p := &ProjectReleaseConfig{VerifyRelease: boolPtr(false), VerifyTimeout: 5 * time.Minute}
+		got := p.Apply(base)
+		if got.VerifyRelease == nil || *got.VerifyRelease {
+			t.Errorf("VerifyRelease = %v, want false", got.VerifyRelease)
+		}
+		if got.VerifyTimeout != 5*time.Minute {
+			t.Errorf("VerifyTimeout = %v, want %v", got.VerifyTimeout, 5*time.Minute)
+		}
+	})
+
+	t.Run("verify_release and verify_timeout unset inherit from base", func(t *testing.T) {
+		base := &ReleaseConfig{Enabled: true, VerifyRelease: boolPtr(true), VerifyTimeout: 10 * time.Minute}
+		p := &ProjectReleaseConfig{Publish: "api"}
+		got := p.Apply(base)
+		if got.VerifyRelease == nil || !*got.VerifyRelease {
+			t.Errorf("VerifyRelease = %v, want inherited true", got.VerifyRelease)
+		}
+		if got.VerifyTimeout != 10*time.Minute {
+			t.Errorf("VerifyTimeout = %v, want inherited %v", got.VerifyTimeout, 10*time.Minute)
+		}
+	})
+}
+
+func TestReleaseConfig_VerifyReleaseEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		rel  *ReleaseConfig
+		want bool
+	}{
+		{name: "nil receiver", rel: nil, want: false},
+		{name: "unset defaults to true in workflow mode", rel: &ReleaseConfig{Publish: "workflow"}, want: true},
+		{name: "unset defaults to true when publish empty (workflow)", rel: &ReleaseConfig{}, want: true},
+		{name: "unset defaults to false in api mode", rel: &ReleaseConfig{Publish: "api"}, want: false},
+		{name: "unset defaults to false in tag_only mode", rel: &ReleaseConfig{Publish: "tag_only"}, want: false},
+		{name: "explicit true in api mode wins", rel: &ReleaseConfig{Publish: "api", VerifyRelease: boolPtr(true)}, want: true},
+		{name: "explicit false in workflow mode wins", rel: &ReleaseConfig{Publish: "workflow", VerifyRelease: boolPtr(false)}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.rel.VerifyReleaseEnabled(); got != tt.want {
+				t.Errorf("VerifyReleaseEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultReleaseConfig_VerifyTimeout(t *testing.T) {
+	got := DefaultReleaseConfig()
+	if got.VerifyTimeout != 10*time.Minute {
+		t.Errorf("DefaultReleaseConfig().VerifyTimeout = %v, want %v", got.VerifyTimeout, 10*time.Minute)
+	}
 }
 
 func TestReleaseConfig_PublishMode(t *testing.T) {


### PR DESCRIPTION
## Summary
- `internal/autopilot/types.go`: `ReleaseConfig.VerifyRelease *bool` / `VerifyTimeout time.Duration` (+ `ProjectReleaseConfig` overlay), default 10m in `workflow` publish mode
- `internal/autopilot/release_summary.go`: extracted `waitForReleaseByTag` so verification can reuse the poll loop independent of the (often-nil in production) release-summary generator
- `internal/autopilot/controller.go`: unified `afterTagCreated` (enrichment + verification per publish mode), `release_missing` alerting via the existing `alertSink`/`SetAlertsEngine` wiring with per-tag dedup, and a `ScanRecentlyMergedPRs` backstop that re-derives the same check from GitHub state after a restart kills the verification goroutine

Closes the silent-break gap from the 2026-07-06 `studio-sdk v0.29.0` incident: a tag with no follow-up release now surfaces loudly within a bounded window instead of never being noticed.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/... ./internal/alerts/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New tests: `TestAfterTagCreated_WorkflowMode_ReleaseAppears`, `TestAfterTagCreated_WorkflowMode_Timeout_FiresAlert` (incl. dedup), `TestAfterTagCreated_WorkflowMode_VerifyDisabled_NoAlert`, `TestAfterTagCreated_TagOnly_NoPolling`, `TestScanRecentlyMergedPRs_BackstopAlert`