### PR TITLE
feat(autopilot): opt-in release tagging for human-authored merged PRs (release.tag_human_merges)

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -510,6 +510,7 @@ projects:
   #                     # workflow - pre-creating the release makes GoReleaser's asset
   #                     # upload 422-collide and silently skips downstream publish steps
   #                     # (Homebrew tap). Repos with GoReleaser must stay workflow.
+  #     tag_human_merges: true  # also tag human-authored PRs merged on this repo (GH-3928)
 
 # Autopilot settings
 autopilot:
@@ -546,6 +547,18 @@ autopilot:
     #   tag_only  - the tag is created and nothing publishes a release; use
     #             for repos with an intentionally manual release process.
     publish: workflow
+    # Opt-in: also tag human-authored merged PRs (branches not prefixed
+    # pilot/*), not just Pilot-authored ones (GH-3928). Default false - zero
+    # behavior change for existing configs. Merges are only picked up by the
+    # periodic ScanRecentlyMergedPRs sweep (webhook/poller paths never see
+    # untracked human PRs pre-merge) and only when merged into the
+    # environment's default branch. Whether a release actually gets cut is
+    # still decided by conventional-commit hygiene on the (squash-merge) PR
+    # title, not branch naming: a "feat: ..." title bumps a release, a
+    # "docs: ..." or "chore: ..." title does not. Enabling this mid-flight
+    # backfills any untagged human PR merged within `merged_pr_scan_window`
+    # of the first scan after enabling - expected, not a bug.
+    tag_human_merges: false
 
   # Define named environment configurations
   # Each environment can have different branch, approval, and CI settings

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3319,6 +3319,9 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 	// per-mode; both are idempotent so duplicate calls are safe.
 	releaseEnabled := c.shouldTriggerRelease()
 	boardEnabled := c.boardSync != nil && c.doneStatus != ""
+	// GH-3928: rel is guaranteed non-nil whenever releaseEnabled is true (see
+	// shouldTriggerRelease), so `releaseEnabled && rel.TagHumanMerges` below
+	// never dereferences a nil rel.
 	rel := c.resolvedRelease()
 
 	scanWindow := c.config.MergedPRScanWindow
@@ -3344,8 +3347,14 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 	triggered := 0
 
 	for _, pr := range prs {
-		// Filter for Pilot branches (pilot/GH-* or pilot/*)
-		if !strings.HasPrefix(pr.Head.Ref, "pilot/") {
+		// Filter for Pilot branches (pilot/GH-* or pilot/*), plus human-authored
+		// branches when release.tag_human_merges is on (GH-3928). Pilot-only
+		// side effects (merge metrics, self-heal, board write-back) below are
+		// still gated on isPilotPR — only the release-scanning path extends to
+		// human PRs.
+		isPilotPR := strings.HasPrefix(pr.Head.Ref, "pilot/")
+		tagHuman := releaseEnabled && rel.TagHumanMerges
+		if !isPilotPR && !tagHuman {
 			continue
 		}
 
@@ -3368,54 +3377,66 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			continue
 		}
 
-		// Extract issue number from branch name (optional)
+		// Human PRs are only eligible when merged into the default branch —
+		// merges into a feature/integration branch would otherwise reach
+		// guardReleaseSHAReachable and escalate noisily later. Pilot PRs already
+		// only ever target the configured base, so this is a no-op for them.
+		if !isPilotPR && pr.Base.Ref != c.resolveMainBranchName() {
+			continue
+		}
+
+		// Extract issue number from branch name (optional; always 0 for human PRs)
 		var issueNum int
 		if strings.HasPrefix(pr.Head.Ref, "pilot/GH-") {
 			_, _ = fmt.Sscanf(pr.Head.Ref, "pilot/GH-%d", &issueNum)
 		}
 
-		// Record merge metrics BEFORE the activePRs/release-exists skip gates
-		// below — those gates exist to avoid duplicate release triggering, but
-		// the metric must fire on every discovered merged Pilot PR regardless
-		// of whether a release tag already exists or whether autopilot tracked
-		// the PR through creation. recordMergeSuccess is idempotent via
-		// recordedMerges so handleMerging + scanner can both call it.
-		// Use pr.CreatedAt for a meaningful time-to-merge sample; fall back to
-		// mergedAt so the histogram still records on PRs missing CreatedAt.
-		createdAt, _ := time.Parse(time.RFC3339, pr.CreatedAt)
-		if createdAt.IsZero() {
-			createdAt = mergedAt
-		}
-		c.recordMergeSuccess(&PRState{PRNumber: pr.Number, CreatedAt: createdAt})
+		if isPilotPR {
+			// Record merge metrics BEFORE the activePRs/release-exists skip gates
+			// below — those gates exist to avoid duplicate release triggering, but
+			// the metric must fire on every discovered merged Pilot PR regardless
+			// of whether a release tag already exists or whether autopilot tracked
+			// the PR through creation. recordMergeSuccess is idempotent via
+			// recordedMerges so handleMerging + scanner can both call it.
+			// Use pr.CreatedAt for a meaningful time-to-merge sample; fall back to
+			// mergedAt so the histogram still records on PRs missing CreatedAt.
+			createdAt, _ := time.Parse(time.RFC3339, pr.CreatedAt)
+			if createdAt.IsZero() {
+				createdAt = mergedAt
+			}
+			c.recordMergeSuccess(&PRState{PRNumber: pr.Number, CreatedAt: createdAt})
 
-		// TASK-352: Self-heal execution records for externally-merged PRs (gh pr
-		// merge / GitHub UI). These never pass through handleMerging, so their
-		// "failed" rows would otherwise never flip to "completed". Like
-		// recordMergeSuccess above, this fires before the release-tag/activePRs skip
-		// gates because the heal must happen on every discovered merged Pilot PR.
-		c.selfHealForPR(ctx, issueNum, pr.HTMLURL)
+			// TASK-352: Self-heal execution records for externally-merged PRs (gh pr
+			// merge / GitHub UI). These never pass through handleMerging, so their
+			// "failed" rows would otherwise never flip to "completed". Like
+			// recordMergeSuccess above, this fires before the release-tag/activePRs skip
+			// gates because the heal must happen on every discovered merged Pilot PR.
+			c.selfHealForPR(ctx, issueNum, pr.HTMLURL)
 
-		// TASK-356 #2: board write-back for externally-merged PRs. Large PRs that
-		// hit the stage approval-misconfig (require_approval=true + approval disabled)
-		// are merged manually (`gh pr merge` / GitHub UI) and never pass through
-		// handleMerging, so their board card stays stuck "In Review". Move it to Done
-		// here, mirroring the on-merge write-back in handleMerging. Like
-		// recordMergeSuccess/selfHealForPR above, this fires on every discovered merged
-		// Pilot PR (before the release-tag/activePRs skip gates) and is independent of
-		// whether release is enabled. UpdateProjectItemStatus is idempotent and silently
-		// skips issues that aren't on the board.
-		if boardEnabled && issueNum > 0 {
-			if nodeID, nodeErr := c.ghClient.GetIssueNodeID(ctx, c.owner, c.repo, issueNum); nodeErr != nil {
-				c.log.Warn("board sync on external merge: failed to resolve issue node id",
-					"pr", pr.Number, "issue", issueNum, "error", nodeErr)
-			} else if err := c.boardSync.UpdateProjectItemStatus(ctx, nodeID, c.doneStatus); err != nil {
-				c.log.Warn("board sync on external merge failed",
-					"pr", pr.Number, "issue", issueNum, "error", err)
+			// TASK-356 #2: board write-back for externally-merged PRs. Large PRs that
+			// hit the stage approval-misconfig (require_approval=true + approval disabled)
+			// are merged manually (`gh pr merge` / GitHub UI) and never pass through
+			// handleMerging, so their board card stays stuck "In Review". Move it to Done
+			// here, mirroring the on-merge write-back in handleMerging. Like
+			// recordMergeSuccess/selfHealForPR above, this fires on every discovered merged
+			// Pilot PR (before the release-tag/activePRs skip gates) and is independent of
+			// whether release is enabled. UpdateProjectItemStatus is idempotent and silently
+			// skips issues that aren't on the board.
+			if boardEnabled && issueNum > 0 {
+				if nodeID, nodeErr := c.ghClient.GetIssueNodeID(ctx, c.owner, c.repo, issueNum); nodeErr != nil {
+					c.log.Warn("board sync on external merge: failed to resolve issue node id",
+						"pr", pr.Number, "issue", issueNum, "error", nodeErr)
+				} else if err := c.boardSync.UpdateProjectItemStatus(ctx, nodeID, c.doneStatus); err != nil {
+					c.log.Warn("board sync on external merge failed",
+						"pr", pr.Number, "issue", issueNum, "error", err)
+				}
 			}
 		}
 
 		// Everything below is release-triggering machinery — skip it entirely when
 		// release is disabled (the scan may be running for board sync alone).
+		// Human PRs only ever reach here via tagHuman, which already implies
+		// releaseEnabled, but the check is kept for symmetry with the Pilot path.
 		if !releaseEnabled {
 			continue
 		}
@@ -3473,12 +3494,20 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			}
 		}
 
-		c.log.Info("found merged Pilot PR needing release",
-			"pr", pr.Number,
-			"branch", pr.Head.Ref,
-			"merged_at", mergedAt,
-			"merge_sha", ShortSHA(pr.MergeCommitSHA),
-		)
+		if isPilotPR {
+			c.log.Info("found merged Pilot PR needing release",
+				"pr", pr.Number,
+				"branch", pr.Head.Ref,
+				"merged_at", mergedAt,
+				"merge_sha", ShortSHA(pr.MergeCommitSHA),
+			)
+		} else {
+			c.log.Info("found merged human PR needing release",
+				"pr", pr.Number,
+				"branch", pr.Head.Ref,
+				"title", pr.Title,
+			)
+		}
 
 		// Create PR state and trigger release
 		prState := &PRState{

--- a/internal/autopilot/controller_releasing_test.go
+++ b/internal/autopilot/controller_releasing_test.go
@@ -364,6 +364,95 @@ func TestHandleReleasing_APIModeDuplicateRelease(t *testing.T) {
 	}
 }
 
+// TestHandleReleasing_HumanPR_NoIssueComment verifies handleReleasing tolerates
+// IssueNumber == 0 (human-authored PRs scanned via release.tag_human_merges,
+// GH-3928, never have a linked issue): the escalation path must not attempt to
+// post a GitHub issue comment, and the happy path must tag+publish cleanly.
+func TestHandleReleasing_HumanPR_NoIssueComment(t *testing.T) {
+	t.Run("escalation path: no issue comment posted", func(t *testing.T) {
+		issueCommentPosted := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+				// Persistent API failure on every tag lookup forces the retry-cap path.
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"server error"}`))
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/issues/") && strings.HasSuffix(r.URL.Path, "/comments"):
+				issueCommentPosted = true
+				w.WriteHeader(http.StatusCreated)
+				_ = json.NewEncoder(w).Encode(github.PRComment{ID: 1})
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		cfg := DefaultConfig()
+		cfg.Environment = EnvStage
+		cfg.MaxReleasingAttempts = 3
+		cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", TagPrefix: "v"}
+		c := NewController(cfg, ghClient, nil, "owner", "repo")
+		prState := &PRState{
+			PRNumber:    900,
+			HeadSHA:     "humansha900",
+			IssueNumber: 0, // human PR: no linked issue
+			Stage:       StageReleasing,
+			// Pre-set to 2; next call increments to 3 == cap.
+			ReleasingAttempts: 2,
+		}
+		c.mu.Lock()
+		c.activePRs[900] = prState
+		c.mu.Unlock()
+
+		err := c.handleReleasing(context.Background(), prState)
+		if err != nil {
+			t.Fatalf("at cap, handleReleasing must return nil (not error), got: %v", err)
+		}
+		if prState.Stage != StageFailed {
+			t.Errorf("Stage = %s, want StageFailed after retry cap", prState.Stage)
+		}
+		if issueCommentPosted {
+			t.Error("escalation must NOT post a GitHub issue comment when IssueNumber == 0")
+		}
+	})
+
+	t.Run("happy path: tag+publish cleanly with no linked issue", func(t *testing.T) {
+		server := publishModeTestServer(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/releases"):
+				w.WriteHeader(http.StatusCreated)
+				_ = json.NewEncoder(w).Encode(github.Release{
+					TagName: "v1.1.0",
+					HTMLURL: "https://github.com/owner/repo/releases/tag/v1.1.0",
+				})
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		})
+		defer server.Close()
+
+		c := newReleasingControllerWithPublish(t, server.URL, "api")
+		prState := &PRState{PRNumber: 901, HeadSHA: "humansha901", IssueNumber: 0, Stage: StageReleasing}
+		c.mu.Lock()
+		c.activePRs[901] = prState
+		c.mu.Unlock()
+
+		if err := c.handleReleasing(context.Background(), prState); err != nil {
+			t.Fatalf("handleReleasing returned error: %v", err)
+		}
+		c.mu.RLock()
+		_, tracked := c.activePRs[901]
+		c.mu.RUnlock()
+		if tracked {
+			t.Error("PR must drain from activePRs once tagged and published")
+		}
+	})
+}
+
 // TestHandleReleasing_GetTagForSHAError verifies that a tag-lookup failure makes
 // handleReleasing return an error (retry next poll) WITHOUT attempting to create
 // a tag and WITHOUT removing the PR from tracking. (TASK-316, path 1)

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -7438,6 +7438,218 @@ func TestController_ScanRecentlyMergedPRs_FlagMatrix(t *testing.T) {
 	}
 }
 
+// TestScanRecentlyMergedPRs_HumanMerges verifies release.tag_human_merges
+// (GH-3928): opting human-authored merged PRs (non pilot/* branches) into the
+// release scanner, gated off by default, without affecting Pilot-only side
+// effects (merge metrics, self-heal, board write-back).
+func TestScanRecentlyMergedPRs_HumanMerges(t *testing.T) {
+	recentMergedAt := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	oldMergedAt := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+
+	humanPR := github.PullRequest{
+		Number:         900,
+		Head:           github.PRRef{Ref: "feat/add-thing", SHA: "humansha900"},
+		Base:           github.PRRef{Ref: "main"},
+		HTMLURL:        "https://github.com/owner/repo/pull/900",
+		Title:          "feat: add a thing",
+		Merged:         true,
+		MergedAt:       recentMergedAt,
+		MergeCommitSHA: "merge-sha-900",
+	}
+
+	// newCase spins up a fresh server + controller per subtest so state
+	// (activePRs, recordedMerges, self-heal calls) never leaks across cases.
+	newCase := func(t *testing.T, tagHuman bool, prs []github.PullRequest, taggedSHA string) (*Controller, *mockEvalStore, *mockBoardSyncer) {
+		t.Helper()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+				out := make([]*github.PullRequest, len(prs))
+				for i := range prs {
+					out[i] = &prs[i]
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(out)
+			case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/tags"):
+				w.WriteHeader(http.StatusOK)
+				if taggedSHA == "" {
+					_, _ = w.Write([]byte("[]"))
+					return
+				}
+				_ = json.NewEncoder(w).Encode([]github.Tag{
+					{Name: "v1.0.0", Commit: struct {
+						SHA string `json:"sha"`
+					}{SHA: taggedSHA}},
+				})
+			case r.URL.Path == "/repos/owner/repo/issues/901":
+				// Node ID for the pilot PR's linked issue (board write-back).
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]string{"node_id": "I_kwDOissue901"})
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		t.Cleanup(server.Close)
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		cfg := DefaultConfig()
+		cfg.Release = &ReleaseConfig{
+			Enabled:        true,
+			Trigger:        "on_merge",
+			TagPrefix:      "v",
+			TagHumanMerges: tagHuman,
+		}
+		cfg.MergedPRScanWindow = 30 * time.Minute
+
+		boardMock := &mockBoardSyncer{}
+		c := NewController(cfg, ghClient, nil, "owner", "repo",
+			withBoardSyncerForTest(boardMock, "Done", "Failed", "In Review", "In Dev"))
+		c.SetStateStore(newTestStateStore(t))
+		evalMock := &mockEvalStore{}
+		c.SetEvalStore(evalMock)
+		return c, evalMock, boardMock
+	}
+
+	t.Run("flag off: human PR not registered", func(t *testing.T) {
+		c, _, _ := newCase(t, false, []github.PullRequest{humanPR}, "")
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+		}
+		c.mu.RLock()
+		_, tracked := c.activePRs[humanPR.Number]
+		c.mu.RUnlock()
+		if tracked {
+			t.Error("human PR must not be registered when tag_human_merges is off")
+		}
+	})
+
+	t.Run("flag on: human PR merged to main in-window is registered", func(t *testing.T) {
+		c, _, _ := newCase(t, true, []github.PullRequest{humanPR}, "")
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+		}
+		c.mu.RLock()
+		prState, tracked := c.activePRs[humanPR.Number]
+		c.mu.RUnlock()
+		if !tracked {
+			t.Fatal("human PR must be registered when tag_human_merges is on")
+		}
+		if prState.Stage != StageReleasing {
+			t.Errorf("Stage = %v, want StageReleasing", prState.Stage)
+		}
+		if prState.IssueNumber != 0 {
+			t.Errorf("IssueNumber = %d, want 0 (human PR has no linked issue)", prState.IssueNumber)
+		}
+		if prState.HeadSHA != humanPR.MergeCommitSHA {
+			t.Errorf("HeadSHA = %q, want %q (merge commit SHA)", prState.HeadSHA, humanPR.MergeCommitSHA)
+		}
+	})
+
+	t.Run("flag on: human PR to non-default base is skipped", func(t *testing.T) {
+		nonDefaultBasePR := humanPR
+		nonDefaultBasePR.Base = github.PRRef{Ref: "release/1.x"}
+		c, _, _ := newCase(t, true, []github.PullRequest{nonDefaultBasePR}, "")
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+		}
+		c.mu.RLock()
+		_, tracked := c.activePRs[humanPR.Number]
+		c.mu.RUnlock()
+		if tracked {
+			t.Error("human PR merged into a non-default base must be skipped")
+		}
+	})
+
+	t.Run("flag on: already-tagged merge commit is skipped", func(t *testing.T) {
+		c, _, _ := newCase(t, true, []github.PullRequest{humanPR}, humanPR.MergeCommitSHA)
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+		}
+		c.mu.RLock()
+		_, tracked := c.activePRs[humanPR.Number]
+		c.mu.RUnlock()
+		if tracked {
+			t.Error("human PR whose merge commit is already tagged must be skipped")
+		}
+	})
+
+	t.Run("flag on: merged outside window is skipped", func(t *testing.T) {
+		staleHumanPR := humanPR
+		staleHumanPR.MergedAt = oldMergedAt
+		c, _, _ := newCase(t, true, []github.PullRequest{staleHumanPR}, "")
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+		}
+		c.mu.RLock()
+		_, tracked := c.activePRs[humanPR.Number]
+		c.mu.RUnlock()
+		if tracked {
+			t.Error("human PR merged outside the scan window must be skipped")
+		}
+	})
+
+	t.Run("flag on: pilot PR still gets merge metrics and self-heal, human PR does not", func(t *testing.T) {
+		pilotPR := github.PullRequest{
+			Number:         901,
+			Head:           github.PRRef{Ref: "pilot/GH-901", SHA: "pilotsha901"},
+			Base:           github.PRRef{Ref: "main"},
+			HTMLURL:        "https://github.com/owner/repo/pull/901",
+			Title:          "feat: pilot change",
+			Merged:         true,
+			MergedAt:       recentMergedAt,
+			MergeCommitSHA: "merge-sha-901",
+		}
+		c, evalMock, boardMock := newCase(t, true, []github.PullRequest{pilotPR, humanPR}, "")
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+		}
+
+		if !c.recordedMerges[pilotPR.Number] {
+			t.Error("pilot PR must record merge success metrics")
+		}
+		if c.recordedMerges[humanPR.Number] {
+			t.Error("human PR must NOT record merge success metrics")
+		}
+
+		var pilotHealed, humanHealed bool
+		for _, h := range evalMock.selfHealed {
+			if h.TaskID == "GH-901" {
+				pilotHealed = true
+			}
+			if h.TaskID == "GH-900" {
+				humanHealed = true
+			}
+		}
+		if !pilotHealed {
+			t.Error("pilot PR must trigger self-heal")
+		}
+		if humanHealed {
+			t.Error("human PR must NOT trigger self-heal (IssueNumber is always 0)")
+		}
+
+		// Board write-back requires issueNum > 0: fires once for the pilot PR
+		// (issue 901, parsed from pilot/GH-901) and never for the human PR
+		// (issueNum always 0).
+		if len(boardMock.calls) != 1 {
+			t.Errorf("board sync calls = %d, want 1 (only the pilot PR has a linked issue)", len(boardMock.calls))
+		} else if boardMock.calls[0].issueNodeID != "I_kwDOissue901" {
+			t.Errorf("board sync issueNodeID = %q, want the pilot PR's issue node id", boardMock.calls[0].issueNodeID)
+		}
+
+		// Both should still be registered for release.
+		c.mu.RLock()
+		_, pilotTracked := c.activePRs[pilotPR.Number]
+		_, humanTracked := c.activePRs[humanPR.Number]
+		c.mu.RUnlock()
+		if !pilotTracked {
+			t.Error("pilot PR must be registered for release")
+		}
+		if !humanTracked {
+			t.Error("human PR must be registered for release")
+		}
+	})
+}
+
 // TestController_RecordMergeSuccess_Idempotency verifies recordMergeSuccess
 // fires exactly once per PR number even when called multiple times from
 // different code paths (e.g. handleMerging + ScanRecentlyMergedPRs both

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -380,6 +380,14 @@ type ReleaseConfig struct {
 	// release to appear before firing a release_missing alert. Zero means
 	// unset; DefaultReleaseConfig sets the 10m default (GH-3927).
 	VerifyTimeout time.Duration `yaml:"verify_timeout,omitempty"`
+	// TagHumanMerges opts human-authored merged PRs (non pilot/* branches) into
+	// the release scanner, not just Pilot-authored PRs. Default false — zero
+	// behavior change for existing configs. Conventional-commit hygiene
+	// (DetectBumpType) still decides whether a release is actually cut, so
+	// enabling this is safe even for repos with mixed commit styles: a
+	// non-conventional PR title just produces no tag. See ScanRecentlyMergedPRs
+	// (GH-3928).
+	TagHumanMerges bool `yaml:"tag_human_merges,omitempty"`
 }
 
 // Publish mode values for ReleaseConfig.Publish / ProjectReleaseConfig.Publish (GH-3926).
@@ -444,6 +452,8 @@ type ProjectReleaseConfig struct {
 	VerifyRelease *bool `yaml:"verify_release,omitempty"`
 	// VerifyTimeout overrides ReleaseConfig.VerifyTimeout for this project. Zero inherits.
 	VerifyTimeout time.Duration `yaml:"verify_timeout,omitempty"`
+	// TagHumanMerges overrides ReleaseConfig.TagHumanMerges for this project. Nil inherits.
+	TagHumanMerges *bool `yaml:"tag_human_merges,omitempty"`
 }
 
 // Apply overlays this project-level config on top of base (the resolved
@@ -492,6 +502,9 @@ func (p *ProjectReleaseConfig) Apply(base *ReleaseConfig) *ReleaseConfig {
 	}
 	if p.VerifyTimeout != 0 {
 		result.VerifyTimeout = p.VerifyTimeout
+	}
+	if p.TagHumanMerges != nil {
+		result.TagHumanMerges = *p.TagHumanMerges
 	}
 	return &result
 }


### PR DESCRIPTION
## Summary

- Adds `release.tag_human_merges` (default `false`) so `ScanRecentlyMergedPRs` can opt into tagging human-authored merged PRs (non `pilot/*` branches), not just Pilot-authored ones — closes the gap where PRs like #3890/#3894–96 were never auto-tagged.
- Human PRs are only eligible when merged into the environment's default branch; Pilot-only side effects (merge metrics, self-heal, board write-back) stay gated on the original `pilot/*` branch check so human merges never pollute those paths.
- Conventional-commit hygiene (`DetectBumpType`) still decides whether a release is actually cut — a non-conventional PR title produces no tag regardless of this flag.
- Documents the knob (and squash-merge PR-title caveat) in `configs/pilot.example.yaml`.
- Rebased onto latest main to pick up #3927 (post-tag release verification backstop), which touches the same `ScanRecentlyMergedPRs`/`ReleaseConfig` surface — resolved as additive, non-overlapping merges.

Depends on #3926 (already merged) for `ProjectReleaseConfig` overlay plumbing.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/... ./internal/config/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New table-driven tests: `TestScanRecentlyMergedPRs_HumanMerges` (flag off/on, non-default base, already-tagged, outside window, pilot-vs-human side-effect gating) and `TestHandleReleasing_HumanPR_NoIssueComment` (escalation path posts no issue comment when `IssueNumber == 0`; happy path tags+publishes cleanly)