### PR TITLE
fix(stress): TestMemory_LargePayloads intermittent hang (GH-3959)

### DIFF
--- a/stress/memory_test.go
+++ b/stress/memory_test.go
@@ -302,6 +302,29 @@ func TestMemory_LargePayloads(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		// mem-048: the poller's dispatch cycle also calls GetIssue (GH-2341 fresh
+		// label re-check) and the merged-work guard (GH-1983/GH-3269: search +
+		// branch lookup) for every candidate. Those routes must be served with
+		// correctly-shaped, cheap responses — otherwise they fall through to the
+		// full 2MB issue-list branch below, which fails to decode into the
+		// expected shape and multiplies large-payload traffic per issue on every
+		// poll tick (known pitfall: unserved routes in the poller poll/dispatch
+		// cycle stall the stress suite).
+		if strings.Contains(r.URL.Path, "/issues/") {
+			parts := strings.Split(r.URL.Path, "/")
+			if n, perr := strconv.Atoi(parts[len(parts)-1]); perr == nil && n >= 1 && n <= numIssues {
+				_ = json.NewEncoder(w).Encode(issues[n-1])
+				return
+			}
+		}
+		if strings.HasPrefix(r.URL.Path, "/search/issues") {
+			_, _ = w.Write([]byte(`{"total_count":0,"items":[]}`))
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/pulls") {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
 		// C6/TASK-346: paginate-aware mock — full list on page 1, empty after, so
 		// ListIssues pagination terminates instead of looping to maxPages. TASK-353.
 		if p := r.URL.Query().Get("page"); p != "" && p != "1" {
@@ -339,9 +362,11 @@ func TestMemory_LargePayloads(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	go poller.Start(ctx)
 
-	for atomic.LoadInt64(&processedCount) < int64(numIssues) {
-		time.Sleep(100 * time.Millisecond)
-	}
+	// GH-3959: bounded wait (mirrors waitForProcessed used elsewhere in this
+	// file, TASK-353) — an unbounded busy-wait here let any transient dispatch
+	// slowness escalate into a full 10m package-timeout kill instead of a fast,
+	// clear failure.
+	waitForProcessed(t, func() int64 { return atomic.LoadInt64(&processedCount) }, int64(numIssues), 25*time.Second)
 
 	cancel()
 	poller.WaitForActive()


### PR DESCRIPTION
## Summary

Fixes GH-3959: `TestMemory_LargePayloads` intermittently hung until the package's
10-minute timeout killed the run, previously sniping PRs #3918 and #3955.

## Root cause

Two compounding issues in `stress/memory_test.go`:

1. **Unbounded wait loop (the actual hang).** The test's completion loop was a
   raw busy-wait with no deadline:
   ```go
   for atomic.LoadInt64(&processedCount) < int64(numIssues) {
       time.Sleep(100 * time.Millisecond)
   }
   ```
   Every sibling test in this file (`TestMemory_NoUnboundedGrowth`,
   `TestMemory_ProcessedMapGrowth`) already uses the bounded `waitForProcessed`
   helper introduced by TASK-353 specifically to prevent this class of bug —
   `TestMemory_LargePayloads` was the one test in the file that never got that
   fix applied. Any transient dispatch slowness (slow CI, GC pressure from the
   2MB payloads) that delayed even one issue's processing turned into an
   unbounded hang instead of a fast, clear failure.

2. **Contributing factor: unserved routes in the poller's dispatch cycle
   (mem-048).** The mock HTTP server only implemented the issues-list route.
   The poller's per-candidate fresh-label re-check (`GetIssue`, GH-2341) and
   merged-work guard (`SearchMergedPRsForIssue`/`FindMergedPRByBranch`,
   GH-1983/GH-3269) both fall through to the same full-list branch, returning
   a 2MB array where a single object (or search/PR-list shape) was expected.
   This produces decode-failure warnings and multiplies large-payload traffic
   per issue per poll tick — the same "unserved route in the poller poll/dispatch
   cycle" pitfall already recorded in the knowledge graph as `mem-048`
   (`.agent/knowledge/memories/pitfalls/pitfall_poller_api_calls_deadlock_stress_suite.md`),
   previously fixed the same way for `TestMemory_ProcessedMapGrowth` in this
   same file.

## Fix

- Bound the wait with the existing `waitForProcessed(t, ..., 25*time.Second)`
  helper (mirrors sibling tests) — the test now fails fast with a clear message
  instead of hanging to the 10m package timeout.
- Extended the mock server to serve `/issues/{n}`, `/search/issues`, and
  `/pulls` with correctly-shaped, cheap responses, mirroring the pattern
  already used by `TestMemory_ProcessedMapGrowth` in the same file. This
  removes the wasted 2MB-decode-mismatch traffic entirely.

Per-run wall time dropped from ~1.2s to ~0.46s after the mock fix, confirming
the wasted large-payload traffic was real overhead.

## Test plan

- [x] `go build ./...`
- [x] `go test ./stress/ -timeout 10m -count=3` — passes
- [x] `go test ./stress/ -run TestMemory_LargePayloads -timeout 10m -count=10 -v` — passes
- [x] `go test ./stress/ -timeout 10m -race -count=2` — passes
- [x] `golangci-lint run --new-from-rev=origin/main ./stress/...` — 0 issues
- [x] No test deleted or skipped; package timeout unchanged