### PR TITLE
GH-3959: fix(stress): TestMemory_LargePayloads intermittent hang kills package at 10m timeout — sniped 2 unrelated PRs

### DIFF
--- a/stress/memory_test.go
+++ b/stress/memory_test.go
@@ -302,6 +302,29 @@ func TestMemory_LargePayloads(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		// mem-048: the poller's dispatch cycle also calls GetIssue (GH-2341 fresh
+		// label re-check) and the merged-work guard (GH-1983/GH-3269: search +
+		// branch lookup) for every candidate. Those routes must be served with
+		// correctly-shaped, cheap responses — otherwise they fall through to the
+		// full 2MB issue-list branch below, which fails to decode into the
+		// expected shape and multiplies large-payload traffic per issue on every
+		// poll tick (known pitfall: unserved routes in the poller poll/dispatch
+		// cycle stall the stress suite).
+		if strings.Contains(r.URL.Path, "/issues/") {
+			parts := strings.Split(r.URL.Path, "/")
+			if n, perr := strconv.Atoi(parts[len(parts)-1]); perr == nil && n >= 1 && n <= numIssues {
+				_ = json.NewEncoder(w).Encode(issues[n-1])
+				return
+			}
+		}
+		if strings.HasPrefix(r.URL.Path, "/search/issues") {
+			_, _ = w.Write([]byte(`{"total_count":0,"items":[]}`))
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/pulls") {
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
 		// C6/TASK-346: paginate-aware mock — full list on page 1, empty after, so
 		// ListIssues pagination terminates instead of looping to maxPages. TASK-353.
 		if p := r.URL.Query().Get("page"); p != "" && p != "1" {
@@ -339,9 +362,11 @@ func TestMemory_LargePayloads(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	go poller.Start(ctx)
 
-	for atomic.LoadInt64(&processedCount) < int64(numIssues) {
-		time.Sleep(100 * time.Millisecond)
-	}
+	// GH-3959: bounded wait (mirrors waitForProcessed used elsewhere in this
+	// file, TASK-353) — an unbounded busy-wait here let any transient dispatch
+	// slowness escalate into a full 10m package-timeout kill instead of a fast,
+	// clear failure.
+	waitForProcessed(t, func() int64 { return atomic.LoadInt64(&processedCount) }, int64(numIssues), 25*time.Second)
 
 	cancel()
 	poller.WaitForActive()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-3959.

Closes #3959

## Changes

GitHub Issue GH-3959: fix(stress): TestMemory_LargePayloads intermittent hang kills package at 10m timeout — sniped 2 unrelated PRs

## Context

`TestMemory_LargePayloads` in the `stress` package intermittently hangs until the 10-minute package timeout kills the run (`panic: test timed out after 10m0s`, test at 9m50s when killed). It has now sniped **two unrelated PRs**:

- PR #3918 (GH-3903 attempt 1, 2026-07-06) — failure triggered the CI-fix size guard and closed the PR
- PR #3955 (GH-3952 alerts work, 2026-07-07, CI run 28844966062) — failure cascaded into a ghost-closed issue + declined fix-request

Known-issue class: mem-048 (stress deadlock) in the knowledge graph.

## Task

1. Root-cause the hang in `TestMemory_LargePayloads` (`stress/` package): reproduce with `go test ./stress/ -run TestMemory_LargePayloads -timeout 10m -count=5 -v` (may take multiple runs — it is intermittent). Look for: goroutine leak / channel deadlock under large payloads, httptest server teardown ordering (the timeout dump shows goroutines parked in `httptest.(*Server).goServe`), unbounded buffering.
2. Fix the underlying deadlock/leak — do NOT just raise the timeout or skip the test.
3. If genuine fix is impossible to verify deterministically, add a per-test watchdog (`t.Deadline`-aware context) so the single test fails fast with a goroutine dump instead of killing the whole package at 10m.

## Constraints

- Do NOT decompose this issue.
- Scope: `stress/` package only.
- Before pushing: `go test ./stress/ -timeout 10m -count=3`.

## Acceptance criteria

- [ ] `go test ./stress/ -timeout 10m -count=3` passes repeatedly
- [ ] Hang root cause documented in the PR description
- [ ] No test deleted/skipped; package timeout unchanged