### PR TITLE
fix(dashboard): QUEUE rows ignore panel width — 65-char hardcoded layout while other panels flex

### DIFF
--- a/internal/dashboard/queue_width_test.go
+++ b/internal/dashboard/queue_width_test.go
@@ -1,0 +1,110 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TestRenderTask_WidthAware covers GH-3970: QUEUE rows must flex their title
+// column with the panel width instead of hardcoding a 65-inner-char layout,
+// matching the HISTORY panel's iw-driven pattern.
+func TestRenderTask_WidthAware(t *testing.T) {
+	m := NewModel("test")
+	longTitle := "a very long queued task title that definitely exceeds twenty visible characters by a lot"
+
+	widths := []int{65, 90, 120}
+	statuses := []string{"done", "running", "queued", "failed", "pending"}
+
+	for _, iw := range widths {
+		for _, status := range statuses {
+			task := TaskDisplay{
+				ID:       "GH-1234",
+				Title:    longTitle,
+				Status:   status,
+				Progress: 42,
+				Phase:    "build",
+				PRURL:    "https://github.com/o/r/pull/42",
+			}
+			row := m.renderTask(task, false, 0, iw)
+			if w := lipgloss.Width(row); w > iw {
+				t.Errorf("iw=%d status=%s: row width %d exceeds iw", iw, status, w)
+			}
+		}
+	}
+}
+
+// TestRenderTask_TitleExpandsWithWidth verifies the title column shows more
+// characters as the panel widens, rather than staying clipped at 20 chars.
+func TestRenderTask_TitleExpandsWithWidth(t *testing.T) {
+	m := NewModel("test")
+	longTitle := "a very long queued task title that definitely exceeds twenty visible characters by a lot"
+
+	task := func() TaskDisplay {
+		return TaskDisplay{ID: "GH-1234", Title: longTitle, Status: "running", Progress: 42}
+	}
+
+	narrow := m.renderTask(task(), false, 0, 65)
+	wide := m.renderTask(task(), false, 0, 120)
+
+	titleLen := func(row string) int {
+		// Count visible chars of longTitle actually present in the row.
+		n := 0
+		for n < len(longTitle) && strings.Contains(row, longTitle[:n+1]) {
+			n++
+		}
+		return n
+	}
+
+	narrowChars := titleLen(narrow)
+	wideChars := titleLen(wide)
+
+	if wideChars <= narrowChars {
+		t.Errorf("expected wider panel to show more title chars: narrow=%d wide=%d", narrowChars, wideChars)
+	}
+}
+
+// TestRenderTask_NarrowRegressionPin pins the exact byte output at iw=65 (the
+// default, non-stacked panel content width) so the width-aware refactor does
+// not alter today's rendering for the common case.
+func TestRenderTask_NarrowRegressionPin(t *testing.T) {
+	m := NewModel("test")
+	task := TaskDisplay{
+		ID:       "GH-1234",
+		Title:    "a very long title that exceeds twenty chars for sure",
+		Status:   "done",
+		Progress: 42,
+		PRURL:    "https://github.com/o/r/pull/42",
+	}
+
+	row := m.renderTask(task, false, 0, 65)
+	const want = "  ✓ done    GH-1234 a very long title...  [██████████████]   #42"
+	if row != want {
+		t.Errorf("narrow (iw=65) rendering changed:\ngot:  %q\nwant: %q", row, want)
+	}
+}
+
+// TestRenderTask_BarColumnsAligned checks all five states keep the same
+// 16-char bracketed bar column regardless of panel width (bar-width scaling
+// is explicitly out of scope for GH-3970).
+func TestRenderTask_BarColumnsAligned(t *testing.T) {
+	m := NewModel("test")
+	statuses := []string{"done", "running", "queued", "failed", "pending"}
+
+	for _, iw := range []int{65, 90, 120} {
+		for _, status := range statuses {
+			task := TaskDisplay{ID: "GH-1", Title: "t", Status: status, Progress: 50, Phase: "x"}
+			row := m.renderTask(task, false, 0, iw)
+			open := strings.Index(row, "[")
+			closeIdx := strings.Index(row, "]")
+			if open == -1 || closeIdx == -1 {
+				t.Fatalf("iw=%d status=%s: missing bar brackets in %q", iw, status, row)
+			}
+			barWidth := lipgloss.Width(row[open : closeIdx+1])
+			if barWidth != 16 {
+				t.Errorf("iw=%d status=%s: bar column width = %d, want 16", iw, status, barWidth)
+			}
+		}
+	}
+}

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -2201,6 +2201,8 @@ func taskStatePriority(status string) int {
 func (m Model) renderTasks() string {
 	var content strings.Builder
 
+	iw := m.effectivePanelTotalWidth() - 4
+
 	if len(m.tasks) == 0 {
 		content.WriteString("  No tasks in queue")
 	} else {
@@ -2225,7 +2227,7 @@ func (m Model) renderTasks() string {
 				offset = queueIdx
 				queueIdx++
 			}
-			content.WriteString(m.renderTask(task, i == m.selectedTask, offset))
+			content.WriteString(m.renderTask(task, i == m.selectedTask, offset, iw))
 		}
 	}
 
@@ -2234,10 +2236,18 @@ func (m Model) renderTasks() string {
 
 // renderTask renders a single task row with state-aware icons, bars, and meta.
 //
-// Layout (65 inner chars):
+// Layout (width-aware, minimum 65 inner chars):
 //
-//	sel(2) + icon+state(8) + space(1) + id(7) + space(1) + title(20) + gap(2) + bar(16) + gap(1) + meta(5)
-func (m Model) renderTask(task TaskDisplay, selected bool, queueOffset int) string {
+//	sel(2) + icon+state(9) + space(1) + id(7) + space(1) + title(flex, min 20) + gap(2) + bar(16) + gap(1) + meta(5)
+//
+// Everything but the title is fixed; the title expands to fill iw (GH-3970),
+// mirroring how renderStandaloneLine flexes titles in HISTORY.
+func (m Model) renderTask(task TaskDisplay, selected bool, queueOffset int, iw int) string {
+	const fixedCols = 45 // non-title columns (44) + 1 reserve so the row never exceeds iw
+	titleW := iw - fixedCols
+	if titleW < 20 {
+		titleW = 20
+	}
 	var icon, stateLabel, meta string
 	var iconStyle, barStyle lipgloss.Style
 
@@ -2309,11 +2319,11 @@ func (m Model) renderTask(task TaskDisplay, selected bool, queueOffset int) stri
 
 	// Left side: selector + icon+state + id + title
 	// Right side: bar + meta (right-aligned)
-	return fmt.Sprintf("%s%s %-7s %-20s  %s %s",
+	return fmt.Sprintf("%s%s %-7s %s  %s %s",
 		selector,
 		iconState,
 		task.ID,
-		truncateVisual(task.Title, 20),
+		padOrTruncate(truncateVisual(task.Title, titleW), titleW),
 		progressBar,
 		renderedMeta,
 	)


### PR DESCRIPTION
## Summary
- `renderTask` rendered every QUEUE row at a hardcoded 65-inner-char layout, chopping titles to 20 chars and leaving the panel's right half blank on wide/stacked terminals, while HISTORY/GIT GRAPH already flex with `effectivePanelTotalWidth()`.
- `renderTasks` now computes `iw := m.effectivePanelTotalWidth() - 4` and passes it to `renderTask`; the title column flexes (`titleW := iw - 45`, clamped to a minimum of 20), matching the HISTORY panel's pattern. All other columns (selector, icon+state, id, bar, meta) stay fixed and aligned across states.
- The bar stays 14-in-brackets (16 total) — only the title flexes, per scope.

Closes GH-3970.

## Test plan
- [x] `go test ./internal/dashboard/...` — new table-driven tests cover narrow (65)/default/wide (120) widths across all 5 task states: row width never exceeds `iw`, title expands with width, bar columns stay 16-wide, and iw=65 output is byte-identical to pre-change rendering (regression pin).
- [x] `go build ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/dashboard/...` — 0 issues