### PR TITLE
feat(autopilot): opt-in release tagging for human-authored merged PRs (GH-3928)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-07 (v2.151.0)
+**Last Updated:** 2026-07-06 (v2.151.0)
 
 ## Legend
 
@@ -406,8 +406,7 @@
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
-| Poll-cycle epic-parent auto-close | ✅ | autopilot | - | - | `reconcileEpicParents` sweeps open decomposed parents every poll tick, verifying each closed child shipped a merged PR (not just "closed") before closing the parent with a summary comment naming the merged PRs; a closed-without-merge child vetoes the close with an explicit logged reason (GH-3939) |
-| Per-project release publish mode | ✅ | autopilot | - | `release.publish`, `projects[].release` | `workflow` (default, unchanged)/`api` (Pilot calls `CreateRelease` after tagging)/`tag_only`; project overlay (`ProjectReleaseConfig.Apply`) resolves project > env > global; idempotent retry via `ensureReleasePublished` if CreateRelease fails after a successful tag (v2.222.3, GH-3926) |
+| Release tagging for human-authored merges | ✅ | autopilot | - | - | `release.tag_human_merges` (default false) opts `ScanRecentlyMergedPRs` into tagging merged non-`pilot/*` PRs into the default branch; `DetectBumpType` still gates on conventional-commit hygiene; Pilot-only side effects (merge metrics, self-heal, board sync) stay gated on `isPilotPR` (v2.225.1, GH-3928) |
 
 ## Epic Management
 
@@ -422,7 +421,6 @@
 | Conventional sub-issue titles | ✅ | executor | - | - | CC-format enforced on subtask titles: re-prompt → Approach B fallback → creation guard (GH-2494) |
 | Sub-issue dedup guard | ✅ | executor | - | - | CreateSubIssues skips if open children referencing parent already exist (GH-2494) |
 | createPilotIssue chokepoint | ✅ | adapters/github, autopilot | - | - | All Pilot-internal issue creation validated through CreatePilotIssue CC gate (GH-2494) |
-| Epic-parent lifecycle instrumentation | ✅ | executor | `pilot trace <task-id>` | - | Epic-parent path emits `claude_started`/`decomposed`/terminal (`completed`/`no_op`/`failed`) execution_events past `spec_validated`; children's real token/file/cost metrics roll up onto the parent's own row (previously zero even on long runs); zero-tokens+zero-files+no-commit/PR completions reclassify to `no_op`; decomposition posts an honest "decomposed into N children: #a, #b, #c" comment sourced from the actual created sub-issues (GH-3938, v2.222.0) |
 
 ## Test Coverage
 

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -510,6 +510,7 @@ projects:
   #                     # workflow - pre-creating the release makes GoReleaser's asset
   #                     # upload 422-collide and silently skips downstream publish steps
   #                     # (Homebrew tap). Repos with GoReleaser must stay workflow.
+  #     tag_human_merges: true  # also tag this project's human-authored merges (GH-3928)
 
 # Autopilot settings
 autopilot:
@@ -546,6 +547,17 @@ autopilot:
     #   tag_only  - the tag is created and nothing publishes a release; use
     #             for repos with an intentionally manual release process.
     publish: workflow
+    # Opt-in: also consider merged PRs whose head branch is NOT pilot/* for
+    # release tagging (GH-3928). Default false - zero behavior change; only
+    # pilot/* branches are scanned. When true, ScanRecentlyMergedPRs also
+    # picks up human-authored PRs merged into the environment's default
+    # branch. Whether a release is actually cut still depends entirely on
+    # conventional-commit hygiene: squash-merge means the PR TITLE becomes
+    # the commit subject, so a `feat: ...`/`fix: ...` title bumps a version
+    # and a non-conventional title (or `docs:`/`chore:`/`refactor:`) produces
+    # no release. Merge metrics, self-heal, and board sync are unaffected -
+    # those remain Pilot-PR-only regardless of this flag.
+    tag_human_merges: false
 
   # Define named environment configurations
   # Each environment can have different branch, approval, and CI settings

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3344,8 +3344,20 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 	triggered := 0
 
 	for _, pr := range prs {
-		// Filter for Pilot branches (pilot/GH-* or pilot/*)
-		if !strings.HasPrefix(pr.Head.Ref, "pilot/") {
+		// Filter for Pilot branches (pilot/GH-* or pilot/*), or human-authored
+		// PRs when release.tag_human_merges is enabled (GH-3928). rel.TagHumanMerges
+		// is only read when releaseEnabled is true, which guarantees rel != nil
+		// (shouldTriggerRelease short-circuits on a nil rel).
+		isPilotPR := strings.HasPrefix(pr.Head.Ref, "pilot/")
+		tagHuman := releaseEnabled && rel.TagHumanMerges
+		if !isPilotPR && !tagHuman {
+			continue
+		}
+
+		// Human PRs only count toward releases when merged into the default
+		// branch — merges into feature/integration branches are silently
+		// skipped here rather than escalated later by guardReleaseSHAReachable.
+		if !isPilotPR && pr.Base.Ref != c.resolveMainBranchName() {
 			continue
 		}
 
@@ -3382,35 +3394,39 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 		// recordedMerges so handleMerging + scanner can both call it.
 		// Use pr.CreatedAt for a meaningful time-to-merge sample; fall back to
 		// mergedAt so the histogram still records on PRs missing CreatedAt.
-		createdAt, _ := time.Parse(time.RFC3339, pr.CreatedAt)
-		if createdAt.IsZero() {
-			createdAt = mergedAt
-		}
-		c.recordMergeSuccess(&PRState{PRNumber: pr.Number, CreatedAt: createdAt})
+		// GH-3928: gated on isPilotPR — human merges must not pollute merge
+		// metrics, execution self-heal, or the board.
+		if isPilotPR {
+			createdAt, _ := time.Parse(time.RFC3339, pr.CreatedAt)
+			if createdAt.IsZero() {
+				createdAt = mergedAt
+			}
+			c.recordMergeSuccess(&PRState{PRNumber: pr.Number, CreatedAt: createdAt})
 
-		// TASK-352: Self-heal execution records for externally-merged PRs (gh pr
-		// merge / GitHub UI). These never pass through handleMerging, so their
-		// "failed" rows would otherwise never flip to "completed". Like
-		// recordMergeSuccess above, this fires before the release-tag/activePRs skip
-		// gates because the heal must happen on every discovered merged Pilot PR.
-		c.selfHealForPR(ctx, issueNum, pr.HTMLURL)
+			// TASK-352: Self-heal execution records for externally-merged PRs (gh pr
+			// merge / GitHub UI). These never pass through handleMerging, so their
+			// "failed" rows would otherwise never flip to "completed". Like
+			// recordMergeSuccess above, this fires before the release-tag/activePRs skip
+			// gates because the heal must happen on every discovered merged Pilot PR.
+			c.selfHealForPR(ctx, issueNum, pr.HTMLURL)
 
-		// TASK-356 #2: board write-back for externally-merged PRs. Large PRs that
-		// hit the stage approval-misconfig (require_approval=true + approval disabled)
-		// are merged manually (`gh pr merge` / GitHub UI) and never pass through
-		// handleMerging, so their board card stays stuck "In Review". Move it to Done
-		// here, mirroring the on-merge write-back in handleMerging. Like
-		// recordMergeSuccess/selfHealForPR above, this fires on every discovered merged
-		// Pilot PR (before the release-tag/activePRs skip gates) and is independent of
-		// whether release is enabled. UpdateProjectItemStatus is idempotent and silently
-		// skips issues that aren't on the board.
-		if boardEnabled && issueNum > 0 {
-			if nodeID, nodeErr := c.ghClient.GetIssueNodeID(ctx, c.owner, c.repo, issueNum); nodeErr != nil {
-				c.log.Warn("board sync on external merge: failed to resolve issue node id",
-					"pr", pr.Number, "issue", issueNum, "error", nodeErr)
-			} else if err := c.boardSync.UpdateProjectItemStatus(ctx, nodeID, c.doneStatus); err != nil {
-				c.log.Warn("board sync on external merge failed",
-					"pr", pr.Number, "issue", issueNum, "error", err)
+			// TASK-356 #2: board write-back for externally-merged PRs. Large PRs that
+			// hit the stage approval-misconfig (require_approval=true + approval disabled)
+			// are merged manually (`gh pr merge` / GitHub UI) and never pass through
+			// handleMerging, so their board card stays stuck "In Review". Move it to Done
+			// here, mirroring the on-merge write-back in handleMerging. Like
+			// recordMergeSuccess/selfHealForPR above, this fires on every discovered merged
+			// Pilot PR (before the release-tag/activePRs skip gates) and is independent of
+			// whether release is enabled. UpdateProjectItemStatus is idempotent and silently
+			// skips issues that aren't on the board.
+			if boardEnabled && issueNum > 0 {
+				if nodeID, nodeErr := c.ghClient.GetIssueNodeID(ctx, c.owner, c.repo, issueNum); nodeErr != nil {
+					c.log.Warn("board sync on external merge: failed to resolve issue node id",
+						"pr", pr.Number, "issue", issueNum, "error", nodeErr)
+				} else if err := c.boardSync.UpdateProjectItemStatus(ctx, nodeID, c.doneStatus); err != nil {
+					c.log.Warn("board sync on external merge failed",
+						"pr", pr.Number, "issue", issueNum, "error", err)
+				}
 			}
 		}
 
@@ -3473,12 +3489,20 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			}
 		}
 
-		c.log.Info("found merged Pilot PR needing release",
-			"pr", pr.Number,
-			"branch", pr.Head.Ref,
-			"merged_at", mergedAt,
-			"merge_sha", ShortSHA(pr.MergeCommitSHA),
-		)
+		if isPilotPR {
+			c.log.Info("found merged Pilot PR needing release",
+				"pr", pr.Number,
+				"branch", pr.Head.Ref,
+				"merged_at", mergedAt,
+				"merge_sha", ShortSHA(pr.MergeCommitSHA),
+			)
+		} else {
+			c.log.Info("found merged human PR needing release",
+				"pr", pr.Number,
+				"branch", pr.Head.Ref,
+				"title", pr.Title,
+			)
+		}
 
 		// Create PR state and trigger release
 		prState := &PRState{

--- a/internal/autopilot/gh3928_test.go
+++ b/internal/autopilot/gh3928_test.go
@@ -1,0 +1,263 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// gh3928HumanPR builds a human-authored (non pilot/*) merged PR fixture for the
+// TestScanRecentlyMergedPRs_HumanMerges table below.
+func gh3928HumanPR(mergedAt, base string) github.PullRequest {
+	return github.PullRequest{
+		Number:         900,
+		Head:           github.PRRef{Ref: "feat/human-thing", SHA: "humansha"},
+		Base:           github.PRRef{Ref: base},
+		HTMLURL:        "https://github.com/owner/repo/pull/900",
+		Title:          "feat: human thing",
+		Merged:         true,
+		MergedAt:       mergedAt,
+		MergeCommitSHA: "humanmergesha",
+	}
+}
+
+func gh3928Server(t *testing.T, prs []*github.PullRequest, tags []*github.Tag) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/tags"):
+			w.WriteHeader(http.StatusOK)
+			if tags == nil {
+				_, _ = w.Write([]byte(`[]`))
+				return
+			}
+			_ = json.NewEncoder(w).Encode(tags)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func gh3928Controller(t *testing.T, serverURL string, tagHuman bool) *Controller {
+	t.Helper()
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, serverURL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{
+		Enabled:        true,
+		Trigger:        "on_merge",
+		TagPrefix:      "v",
+		TagHumanMerges: tagHuman,
+	}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(newTestStateStore(t))
+	return c
+}
+
+// TestScanRecentlyMergedPRs_HumanMerges verifies GH-3928: release.tag_human_merges
+// opts ScanRecentlyMergedPRs into considering merged PRs whose head branch is
+// NOT pilot/* for release tagging, gated behind the opt-in flag and the
+// default-branch requirement, without touching Pilot-only side effects.
+func TestScanRecentlyMergedPRs_HumanMerges(t *testing.T) {
+	recentMergedAt := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	staleMergedAt := time.Now().Add(-45 * time.Minute).UTC().Format(time.RFC3339)
+
+	t.Run("flag off: human PR not registered", func(t *testing.T) {
+		pr := gh3928HumanPR(recentMergedAt, "main")
+		server := gh3928Server(t, []*github.PullRequest{&pr}, nil)
+
+		c := gh3928Controller(t, server.URL, false)
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+		}
+		c.mu.RLock()
+		_, tracked := c.activePRs[900]
+		c.mu.RUnlock()
+		if tracked {
+			t.Error("human PR registered with tag_human_merges=false; today's default behavior must be unchanged")
+		}
+	})
+
+	t.Run("flag on: human PR merged to default branch in-window registered", func(t *testing.T) {
+		pr := gh3928HumanPR(recentMergedAt, "main")
+		server := gh3928Server(t, []*github.PullRequest{&pr}, nil)
+
+		c := gh3928Controller(t, server.URL, true)
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+		}
+		c.mu.RLock()
+		prState, tracked := c.activePRs[900]
+		c.mu.RUnlock()
+		if !tracked {
+			t.Fatal("human PR not registered with tag_human_merges=true")
+		}
+		if prState.Stage != StageReleasing {
+			t.Errorf("stage = %v, want StageReleasing", prState.Stage)
+		}
+		if prState.IssueNumber != 0 {
+			t.Errorf("IssueNumber = %d, want 0 (human branch has no pilot/GH-N)", prState.IssueNumber)
+		}
+		if prState.HeadSHA != pr.MergeCommitSHA {
+			t.Errorf("HeadSHA = %q, want merge commit SHA %q", prState.HeadSHA, pr.MergeCommitSHA)
+		}
+	})
+
+	t.Run("flag on: human PR to non-default base skipped", func(t *testing.T) {
+		pr := gh3928HumanPR(recentMergedAt, "develop")
+		server := gh3928Server(t, []*github.PullRequest{&pr}, nil)
+
+		c := gh3928Controller(t, server.URL, true)
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+		}
+		c.mu.RLock()
+		_, tracked := c.activePRs[900]
+		c.mu.RUnlock()
+		if tracked {
+			t.Error("human PR merged into a non-default base branch was registered; must be skipped")
+		}
+	})
+
+	t.Run("flag on: already-tagged human PR skipped", func(t *testing.T) {
+		pr := gh3928HumanPR(recentMergedAt, "main")
+		existingTag := &github.Tag{Name: "v1.0.0", Commit: struct {
+			SHA string `json:"sha"`
+		}{SHA: pr.MergeCommitSHA}}
+		server := gh3928Server(t, []*github.PullRequest{&pr}, []*github.Tag{existingTag})
+
+		c := gh3928Controller(t, server.URL, true)
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+		}
+		c.mu.RLock()
+		_, tracked := c.activePRs[900]
+		c.mu.RUnlock()
+		if tracked {
+			t.Error("already-tagged human PR was registered; must be skipped")
+		}
+	})
+
+	t.Run("flag on: human PR merged outside scan window skipped", func(t *testing.T) {
+		pr := gh3928HumanPR(staleMergedAt, "main")
+		server := gh3928Server(t, []*github.PullRequest{&pr}, nil)
+
+		c := gh3928Controller(t, server.URL, true)
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+		}
+		c.mu.RLock()
+		_, tracked := c.activePRs[900]
+		c.mu.RUnlock()
+		if tracked {
+			t.Error("human PR merged outside the scan window was registered; must be skipped")
+		}
+	})
+
+	t.Run("flag on: pilot PR side effects fire, human PR side effects do not", func(t *testing.T) {
+		pilotPR := github.PullRequest{
+			Number:         901,
+			Head:           github.PRRef{Ref: "pilot/GH-500", SHA: "pilotsha"},
+			Base:           github.PRRef{Ref: "main"},
+			HTMLURL:        "https://github.com/owner/repo/pull/901",
+			Title:          "feat: pilot thing",
+			Merged:         true,
+			MergedAt:       recentMergedAt,
+			MergeCommitSHA: "pilotmergesha",
+		}
+		humanPR := gh3928HumanPR(recentMergedAt, "main")
+
+		server := gh3928Server(t, []*github.PullRequest{&pilotPR, &humanPR}, nil)
+
+		c := gh3928Controller(t, server.URL, true)
+		evalMock := &mockEvalStore{}
+		c.SetEvalStore(evalMock)
+
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+		}
+
+		c.mu.RLock()
+		_, pilotTracked := c.activePRs[901]
+		_, humanTracked := c.activePRs[900]
+		c.mu.RUnlock()
+		if !pilotTracked {
+			t.Error("pilot PR not registered")
+		}
+		if !humanTracked {
+			t.Error("human PR not registered")
+		}
+
+		if got := c.Metrics().Snapshot().PRsMerged; got != 1 {
+			t.Errorf("PRsMerged = %d, want 1 (pilot PR only — human merges must not pollute merge metrics)", got)
+		}
+		if len(evalMock.selfHealed) != 1 {
+			t.Errorf("selfHealed entries = %d, want 1 (pilot PR only — human merges must not trigger self-heal)", len(evalMock.selfHealed))
+		}
+	})
+}
+
+// TestHandleReleasing_HumanPR_NoIssueComment verifies GH-3928: a scanner-registered
+// human PR carries IssueNumber==0, and handleReleasing's escalation-comment path
+// (which only fires for IssueNumber > 0) must not attempt to comment on a
+// nonexistent issue — on both the escalation and happy paths.
+func TestHandleReleasing_HumanPR_NoIssueComment(t *testing.T) {
+	var issueCommentPosts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/issues/") && strings.HasSuffix(r.URL.Path, "/comments"):
+			issueCommentPosts++
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/branches/"):
+			// Diverged SHA: branch tip never matches the PR's head SHA, driving
+			// handleReleasing down the escalation path (guardReleaseSHAReachable fails).
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"name":   "main",
+				"commit": map[string]string{"sha": "unrelated-main-tip-sha"},
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "diverged"})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := newReleasingController(t, server.URL)
+	prState := &PRState{
+		PRNumber:    902,
+		HeadSHA:     "humanmergesha",
+		Stage:       StageReleasing,
+		IssueNumber: 0, // GH-3928: human PRs never have an associated issue
+	}
+	c.mu.Lock()
+	c.activePRs[902] = prState
+	c.mu.Unlock()
+
+	if err := c.handleReleasing(context.Background(), prState); err != nil {
+		t.Fatalf("handleReleasing returned error: %v", err)
+	}
+
+	if issueCommentPosts != 0 {
+		t.Errorf("POST .../issues/*/comments called %d times, want 0 for IssueNumber==0", issueCommentPosts)
+	}
+	if prState.Stage != StageFailed {
+		t.Errorf("stage = %v, want StageFailed (unreachable SHA escalates)", prState.Stage)
+	}
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -380,6 +380,13 @@ type ReleaseConfig struct {
 	// release to appear before firing a release_missing alert. Zero means
 	// unset; DefaultReleaseConfig sets the 10m default (GH-3927).
 	VerifyTimeout time.Duration `yaml:"verify_timeout,omitempty"`
+	// TagHumanMerges opts ScanRecentlyMergedPRs into considering merged PRs
+	// whose head branch is NOT pilot/* for release tagging. Default false —
+	// zero behavior change for existing configs. Conventional-commit hygiene
+	// (via DetectBumpType on the squash-merge PR title) still decides
+	// whether a release is actually cut, so enabling this is safe even for
+	// repos with mixed commit-message discipline (GH-3928).
+	TagHumanMerges bool `yaml:"tag_human_merges,omitempty"`
 }
 
 // Publish mode values for ReleaseConfig.Publish / ProjectReleaseConfig.Publish (GH-3926).
@@ -444,6 +451,8 @@ type ProjectReleaseConfig struct {
 	VerifyRelease *bool `yaml:"verify_release,omitempty"`
 	// VerifyTimeout overrides ReleaseConfig.VerifyTimeout for this project. Zero inherits.
 	VerifyTimeout time.Duration `yaml:"verify_timeout,omitempty"`
+	// TagHumanMerges overrides ReleaseConfig.TagHumanMerges for this project. Nil inherits.
+	TagHumanMerges *bool `yaml:"tag_human_merges,omitempty"`
 }
 
 // Apply overlays this project-level config on top of base (the resolved
@@ -492,6 +501,9 @@ func (p *ProjectReleaseConfig) Apply(base *ReleaseConfig) *ReleaseConfig {
 	}
 	if p.VerifyTimeout != 0 {
 		result.VerifyTimeout = p.VerifyTimeout
+	}
+	if p.TagHumanMerges != nil {
+		result.TagHumanMerges = *p.TagHumanMerges
 	}
 	return &result
 }


### PR DESCRIPTION
## Summary
- `ScanRecentlyMergedPRs` hard-filtered on `pilot/*` head branches, so human-authored merges (e.g. `feat/*` PRs) never reached the release pipeline and had to be tagged manually.
- Adds opt-in `release.tag_human_merges` (global `ReleaseConfig` + per-project `ProjectReleaseConfig` overlay, default `false` — zero behavior change).
- When enabled, the scanner also considers non-`pilot/*` PRs merged into the environment's default branch; conventional-commit hygiene (`DetectBumpType` on the squash-merge PR title) still gates whether a release is actually cut.
- Pilot-only side effects (`recordMergeSuccess`, `selfHealForPR`, board write-back) are now explicitly gated on `isPilotPR` so human merges never pollute merge metrics, execution self-heal, or the board.
- Documented the knob in `configs/pilot.example.yaml` (global + per-project) and added a `FEATURE-MATRIX.md` row.

Closes #3928. Depends on #3926 (already merged — `ProjectReleaseConfig`/`Apply` overlay).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/... ./internal/config/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New table-driven `TestScanRecentlyMergedPRs_HumanMerges` covering: flag off, flag on + in-window default-branch merge, non-default base skipped, already-tagged skipped, outside-window skipped, and pilot-vs-human side-effect gating
- [x] New `TestHandleReleasing_HumanPR_NoIssueComment` covering `IssueNumber == 0` on the escalation path