### PR TITLE
feat(autopilot): release-cycle triggers (on_scope_close, on_schedule) — config surface + hold semantics

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-07 (v2.151.0)
+**Last Updated:** 2026-07-06 (v2.151.0)
 
 ## Legend
 
@@ -406,7 +406,7 @@
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
-| Release tagging for human-authored merges | ✅ | autopilot | - | - | `release.tag_human_merges` (default false) opts `ScanRecentlyMergedPRs` into tagging merged non-`pilot/*` PRs into the default branch; `DetectBumpType` still gates on conventional-commit hygiene; Pilot-only side effects (merge metrics, self-heal, board sync) stay gated on `isPilotPR` (v2.225.1, GH-3928) |
+| Release cycles: trigger config + hold semantics | ✅ | autopilot | - | `release.trigger`, `release.scope_label_prefix`, `release.schedule`, `release.schedule_timezone` | `on_scope_close`/`on_schedule` triggers hold merges at all four release-decision sites (`handleMerged` fast path, `handlePostMergeCI`, `checkExternalMergeOrClose`, `ScanRecentlyMergedPRs`) via `Controller.releaseActionFor`/`heldByScope`; held work is inert-but-safe (fully reconstructable from GitHub) — the scope-close reconciler and cron scheduler that actually fire the release ship in follow-up issues. `on_merge` behavior is byte-identical (v2.226.x, GH-3989) |
 
 ## Epic Management
 

--- a/.agent/tasks/gh-3989.md
+++ b/.agent/tasks/gh-3989.md
@@ -1,0 +1,84 @@
+# GH-3989
+
+**Created:** 2026-07-07
+
+## Problem
+
+GitHub Issue GH-3989: feat(autopilot): release-cycle triggers (on_scope_close, on_schedule) — config surface + per-PR hold semantics
+
+Part of TASK-389 (release cycles). Foundation issue — gates the rest of the chain.
+
+## Context
+
+`trigger: on_merge` cuts a release per merged PR (TASK-388 produced 6 versions in 14h). Release cycles add two opt-in cadences: `on_scope_close` (hold scope members, release once when the scope completes) and `on_schedule` (cron release trains). This issue ships the **config surface + hold semantics only** — scopes don't release yet (Issue B does that). Holds are inert-but-safe: held work is fully reconstructable from GitHub, so this ships dark behind the trigger value.
+
+⚠ Verified ground truth: the de-facto per-merge release entry point is the external-merge hijack `checkExternalMergeOrClose` (controller.go ~:3822, GH-411 block) which force-jumps merged tracked PRs to StageReleasing — NOT `handleMerged`. `ScanRecentlyMergedPRs` registers untracked merged PRs at StageReleasing (~:3484). Hold must be enforced at ALL FOUR decision sites.
+
+## Implementation
+
+1. **`internal/autopilot/types.go`**
+   - `Trigger` accepts `on_scope_close` and `on_schedule` (extend doc comment at ~:355).
+   - New `ReleaseConfig` fields: `ScopeLabelPrefix string` (yaml `scope_label_prefix`, empty → `"scope:"` — matches the label-propagation prefix in `internal/executor/epic.go:77`), `ScopeLookback time.Duration` (yaml `scope_lookback`, 0 → 24h, set in `DefaultReleaseConfig`), `Schedule string` (yaml `schedule`, robfig cron syntax), `ScheduleTimezone string` (yaml `schedule_timezone`, empty → daemon local).
+   - Promote `Trigger`, `ScopeLabelPrefix`, `Schedule`, `ScheduleTimezone` into `ProjectReleaseConfig` + `Apply` — this REVERSES the documented exclusion at types.go ~:426-431; rewrite that comment (release cadence is per-repo by design now). `VersionStrategy`/`RequireCI` stay excluded.
+   - Helpers: `ScopeReleaseEnabled()` (nil-safe: Enabled && Trigger=="on_scope_close"), `ScheduleReleaseEnabled()` (Enabled && Trigger=="on_schedule").
+2. **`internal/autopilot/releaser.go`** — `ShouldRelease` (~:352): accept all three release triggers (`on_merge|on_scope_close|on_schedule`).
+3. **`internal/config/config.go`** — validation at global/env/project levels (mirror the publish-enum pattern): trigger enum `""|on_merge|manual|on_scope_close|on_schedule`; when trigger==`on_schedule`, `schedule` is required and must parse via `cron.ParseStandard` (robfig/cron/v3 — already a dependency, precedent `internal/briefs/scheduler.go`); `schedule_timezone` must `time.LoadLocation` when set.
+4. **NEW `internal/autopilot/scope_membership.go`** — `heldByScope(ctx, issueNum int) (scopeKey, scopeTitle string, held bool)`:
+   - Not held unless `resolvedRelease().ScopeReleaseEnabled()`; `issueNum == 0` → not held.
+   - `GetIssue(c.owner, c.repo, issueNum)` — **any error → fail-open, NOT held** (hard constraint: detection errors must never hold a release forever).
+   - Open epic parent (`github.ParseParentIssueNumber(issue.Body)` — same SDK call as controller.go ~:1919; then GetIssue(parent), parent open) → held, key `epic:<N>`, title = parent title. Parent closed/error → fall through (late straggler releases per-merge).
+   - Else first label with `ScopeLabelPrefix` (case-insensitive) → held, key `label:<name-sans-prefix>`, title = label name. Epic wins over label (deterministic).
+5. **`internal/autopilot/controller.go`** — one helper `releaseActionFor(ctx, prState) (action, scopeKey, scopeTitle)` encapsulating: trigger==on_schedule → hold ALL; trigger==on_scope_close → heldByScope; else → release. Wire at all four sites:
+   - `checkExternalMergeOrClose` hijack (~:3822): held members take the existing removePR path (~:3833) AFTER the GH-1486 label/close bookkeeping, with INFO log + one-time issue comment `held for scope release <key>`;
+   - `handleMerged` SkipPostMergeCI fast path (~:1882);
+   - `handlePostMergeCI` success branch (~:2149);
+   - `ScanRecentlyMergedPRs`: release gate (~:3319) becomes "release configured (any trigger)"; in-loop, held PRs `continue` with a log (no StageReleasing registration).
+
+## Config example
+
+```yaml
+autopilot:
+  release:
+    trigger: on_merge              # on_merge (default) | manual | on_scope_close | on_schedule
+    scope_label_prefix: "scope:"
+    scope_lookback: 24h
+    schedule: "0 21 * * FRI"       # on_schedule only
+    schedule_timezone: "Europe/Berlin"
+projects:
+  - name: pilot
+    release: { trigger: on_scope_close }   # Trigger now overlayable
+```
+
+## Edge cases
+
+- Membership API error → per-merge release (test-asserted).
+- `trigger: manual` unchanged (all four sites: no release, as today).
+- Cross-repo PR (RepoOwnerAndName ≠ c.owner/c.repo): predicate queries c.owner/c.repo only → fail-open to per-merge (fence).
+- Issue with `scope:` label AND open epic parent → epic wins.
+- `on_schedule` with no scheduler running yet (Issue F pending): merges hold; work reconstructable via CompareCommits — document in code comment.
+
+## Tests
+
+Table-driven, httptest fake-GitHub (`controller_releasing_test.go:57` pattern):
+- ProjectReleaseConfig `Apply` table extended for Trigger/Schedule/ScopeLabelPrefix.
+- `TestHeldByScope`: epic-open / epic-closed / label / no-issue / API-error→fail-open.
+- Per-site hold tests: merged member PR under on_scope_close → drained, ZERO `POST /git/refs`; standalone PR under on_scope_close → tag created (mixed mode); any merged PR under on_schedule → held.
+- Backward-compat snapshot: `trigger: on_merge` → zero new API calls vs today.
+- Config validation: bad trigger rejected at all 3 levels; on_schedule without schedule rejected; bad cron rejected; bad timezone rejected.
+
+## Acceptance criteria
+
+- [x] `trigger` absent/on_merge → byte-identical behavior (test-pinned)
+- [x] on_scope_close holds members at all four sites; standalones release per-merge
+- [x] on_schedule holds everything
+- [x] Validation covers trigger enum + schedule parseability at global/env/project
+- [x] `go test ./internal/autopilot/... ./internal/config/...` green; `make lint` clean
+
+## Out of scope (fences)
+
+- No state store changes, no reconcilers, no scheduler, no release execution, no notes, no cmd/pilot/main.go changes
+- Do NOT decompose this issue
+- Before pushing: `go test ./stress/ -timeout 10m` (known flaky TestMemory_LargePayloads — #3959; rerun once if it hangs)
+
+## Acceptance Criteria
+

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -500,6 +500,12 @@ projects:
   # off by an overlay that only sets `publish`. Example: a project with no
   # tag-triggered release workflow of its own, so Pilot publishes the GitHub
   # Release directly via the API.
+  #
+  # `trigger`, `scope_label_prefix`, `schedule`, and `schedule_timezone` are
+  # also overlayable here (GH-3989) - release cadence is per-repo by design,
+  # so one repo can run `on_merge` while another in the same autopilot config
+  # runs `on_scope_close`:
+  #     release: { trigger: on_scope_close }
   # - name: "studio-sdk"
   #   path: "/path/to/studio-sdk"
   #   github:
@@ -527,7 +533,23 @@ autopilot:
   # Automatic release creation on PR merge (GH-3926).
   release:
     enabled: false
-    trigger: on_merge                  # "on_merge" (default) or "manual"
+    # Release cadence (GH-3989):
+    #   on_merge       (default) - cut a release for every merged PR.
+    #   manual         - never auto-release.
+    #   on_scope_close - hold merges belonging to an open epic (parent issue)
+    #                    or a shared "scope:"-prefixed label; standalone
+    #                    merges still release per-merge. The scope releases
+    #                    once when it completes (scope-close reconciler ships
+    #                    in a follow-up issue; this issue is config + hold
+    #                    semantics only - held work is fully reconstructable
+    #                    from GitHub in the meantime).
+    #   on_schedule    - hold every merge for a cron release train (see
+    #                    `schedule` below). No scheduler ships in this issue
+    #                    either; the hold is inert-but-safe until it does.
+    trigger: on_merge
+    # scope_label_prefix: "scope:"       # on_scope_close only; default "scope:"
+    # schedule: "0 21 * * FRI"           # on_schedule only; robfig/cron/v3 standard (5-field) syntax
+    # schedule_timezone: "Europe/Berlin" # on_schedule only; empty = daemon local time
     version_strategy: conventional_commits
     tag_prefix: "v"
     generate_changelog: true

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1879,11 +1879,19 @@ func (c *Controller) handleMerged(ctx context.Context, prState *PRState) error {
 
 	if c.config.ResolvedEnv().SkipPostMergeCI {
 		// Fast path: skip post-merge CI, check if we should release immediately
-		if c.shouldTriggerRelease() && !c.resolvedRelease().RequireCI {
-			c.log.Info("skipping post-merge CI: proceeding to release",
-				"pr", prState.PRNumber,
+		if c.releaseConfigured() && !c.resolvedRelease().RequireCI {
+			action, scopeKey, scopeTitle := c.releaseActionFor(ctx, prState.IssueNumber)
+			if action == releaseActionRelease {
+				c.log.Info("skipping post-merge CI: proceeding to release",
+					"pr", prState.PRNumber,
+				)
+				prState.Stage = StageReleasing
+				return nil
+			}
+			c.log.Info("skipping post-merge CI: holding PR for scope release",
+				"pr", prState.PRNumber, "scope", scopeKey, "scope_title", scopeTitle,
 			)
-			prState.Stage = StageReleasing
+			c.removePR(prState.PRNumber)
 			return nil
 		}
 		c.log.Info("skipping post-merge CI: PR complete", "pr", prState.PRNumber)
@@ -2146,9 +2154,15 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 	switch status {
 	case CISuccess:
 		c.log.Info("post-merge CI passed", "pr", prState.PRNumber, "sha", ShortSHA(mainSHA))
-		if c.shouldTriggerRelease() {
-			prState.Stage = StageReleasing
-			return nil
+		if c.releaseConfigured() {
+			action, scopeKey, scopeTitle := c.releaseActionFor(ctx, prState.IssueNumber)
+			if action == releaseActionRelease {
+				prState.Stage = StageReleasing
+				return nil
+			}
+			c.log.Info("holding merged PR for scope release",
+				"pr", prState.PRNumber, "scope", scopeKey, "scope_title", scopeTitle,
+			)
 		}
 		c.removePR(prState.PRNumber)
 
@@ -2233,10 +2247,62 @@ func (c *Controller) resolvedRelease() *ReleaseConfig {
 	return c.resolvedReleaseCfg
 }
 
-// shouldTriggerRelease returns true if auto-release is configured.
+// shouldTriggerRelease returns true if auto-release is configured for the
+// per-merge cadence specifically (Trigger "on_merge"). Use releaseConfigured
+// for gates that must also cover the on_scope_close/on_schedule cadences
+// (which release too, just not on every merge — see releaseActionFor).
 func (c *Controller) shouldTriggerRelease() bool {
 	rel := c.resolvedRelease()
 	return rel != nil && rel.Enabled && rel.Trigger == "on_merge"
+}
+
+// releaseConfigured returns true if auto-release is enabled at ANY trigger
+// cadence (on_merge, on_scope_close, on_schedule). This gates the four
+// release-decision sites (handleMerged fast path, handlePostMergeCI,
+// checkExternalMergeOrClose, ScanRecentlyMergedPRs) so on_scope_close/
+// on_schedule merges are still routed through releaseActionFor — and
+// possibly held — instead of being silently drained like Trigger "manual"
+// (GH-3989).
+func (c *Controller) releaseConfigured() bool {
+	rel := c.resolvedRelease()
+	return rel != nil && rel.Enabled
+}
+
+// releaseAction is the outcome of releaseActionFor: whether a merged PR
+// should proceed to StageReleasing now or be held for a later scope/schedule
+// release.
+type releaseAction int
+
+const (
+	// releaseActionRelease proceeds to StageReleasing immediately.
+	releaseActionRelease releaseAction = iota
+	// releaseActionHold drains the PR without releasing; the merge is fully
+	// reconstructable from GitHub once the scope/schedule fires (GH-3989 Issue B/F).
+	releaseActionHold
+)
+
+// releaseActionFor decides, for a merged PR linked to issueNumber (0 if
+// none/standalone), whether to release now or hold — based on the effective
+// release Trigger. Callers must have already confirmed releaseConfigured().
+//
+//   - Trigger "on_schedule" holds every merge unconditionally (no scheduler
+//     ships in this issue — the hold is inert-but-safe until Issue F lands).
+//   - Trigger "on_scope_close" holds only merges whose issue is a scope
+//     member per heldByScope; standalone merges release per-merge as today.
+//   - Any other trigger ("on_merge") releases immediately.
+func (c *Controller) releaseActionFor(ctx context.Context, issueNumber int) (action releaseAction, scopeKey, scopeTitle string) {
+	rel := c.resolvedRelease()
+	switch {
+	case rel.ScheduleReleaseEnabled():
+		return releaseActionHold, "schedule", ""
+	case rel.ScopeReleaseEnabled():
+		if key, title, held := c.heldByScope(ctx, issueNumber); held {
+			return releaseActionHold, key, title
+		}
+		return releaseActionRelease, "", ""
+	default:
+		return releaseActionRelease, "", ""
+	}
 }
 
 // tagCoveringCommit returns the name of an existing release tag that already
@@ -3317,7 +3383,10 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 	// neither auto-release nor board sync is enabled (e.g. a plain GH-issue-source
 	// deployment). Internal gates below handle release-trigger and board-writeback
 	// per-mode; both are idempotent so duplicate calls are safe.
-	releaseEnabled := c.shouldTriggerRelease()
+	// releaseEnabled means "release configured at any trigger cadence" — a
+	// PR under on_scope_close/on_schedule still needs the self-heal/board
+	// bookkeeping above and the hold check below, not just on_merge (GH-3989).
+	releaseEnabled := c.releaseConfigured()
 	boardEnabled := c.boardSync != nil && c.doneStatus != ""
 	rel := c.resolvedRelease()
 
@@ -3347,7 +3416,7 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 		// Filter for Pilot branches (pilot/GH-* or pilot/*), or human-authored
 		// PRs when release.tag_human_merges is enabled (GH-3928). rel.TagHumanMerges
 		// is only read when releaseEnabled is true, which guarantees rel != nil
-		// (shouldTriggerRelease short-circuits on a nil rel).
+		// (releaseConfigured short-circuits on a nil rel).
 		isPilotPR := strings.HasPrefix(pr.Head.Ref, "pilot/")
 		tagHuman := releaseEnabled && rel.TagHumanMerges
 		if !isPilotPR && !tagHuman {
@@ -3502,6 +3571,17 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 				"branch", pr.Head.Ref,
 				"title", pr.Title,
 			)
+		}
+
+		// GH-3989: on_scope_close/on_schedule may hold this PR instead of
+		// registering it at StageReleasing. Held PRs are simply skipped here —
+		// no StageReleasing registration — since they're fully reconstructable
+		// from GitHub once the scope/schedule fires.
+		if action, scopeKey, scopeTitle := c.releaseActionFor(ctx, issueNum); action == releaseActionHold {
+			c.log.Info("holding merged PR for scope release (scan)",
+				"pr", pr.Number, "scope", scopeKey, "scope_title", scopeTitle,
+			)
+			continue
 		}
 
 		// Create PR state and trigger release
@@ -3843,15 +3923,29 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 		}
 
 		// GH-411: Trigger release for externally merged PRs if auto-release is enabled
-		if c.shouldTriggerRelease() && prState.Stage != StageReleasing {
-			c.log.Info("triggering release for externally merged PR", "pr", prState.PRNumber)
-			// Update SHA to merge commit if available
-			if ghPR.MergeCommitSHA != "" {
-				prState.HeadSHA = ghPR.MergeCommitSHA
+		if c.releaseConfigured() && prState.Stage != StageReleasing {
+			action, scopeKey, _ := c.releaseActionFor(ctx, prState.IssueNumber)
+			if action == releaseActionRelease {
+				c.log.Info("triggering release for externally merged PR", "pr", prState.PRNumber)
+				// Update SHA to merge commit if available
+				if ghPR.MergeCommitSHA != "" {
+					prState.HeadSHA = ghPR.MergeCommitSHA
+				}
+				prState.Stage = StageReleasing
+				c.persistPRState(prState)
+				return false // Continue processing to handle release
 			}
-			prState.Stage = StageReleasing
-			c.persistPRState(prState)
-			return false // Continue processing to handle release
+
+			// GH-3989: held for scope/schedule release — drain the PR like any
+			// other externally-merged, non-releasing PR, but leave a one-time
+			// breadcrumb on the issue so held-vs-forgotten is visible from GitHub.
+			c.log.Info("holding externally merged PR for scope release", "pr", prState.PRNumber, "scope", scopeKey)
+			if prState.IssueNumber > 0 {
+				comment := fmt.Sprintf("held for scope release %s", scopeKey)
+				if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, prState.IssueNumber, comment); err != nil {
+					c.log.Warn("failed to post scope-hold comment after external merge", "issue", prState.IssueNumber, "error", err)
+				}
+			}
 		}
 
 		c.removePR(prState.PRNumber)

--- a/internal/autopilot/controller_release_cycles_test.go
+++ b/internal/autopilot/controller_release_cycles_test.go
@@ -1,0 +1,459 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// releaseCyclesServer builds a fake GitHub server covering everything
+// ScanRecentlyMergedPRs + handleReleasing need to drive a merged PR all the
+// way through tag creation, plus a GetIssue route serving fake issues by
+// number (for heldByScope / maybeCloseParentIssue). gitRefPosts counts
+// POST /git/refs calls so tests can assert a hold never creates a tag.
+func releaseCyclesServer(t *testing.T, issues map[int]scopeMembershipFakeIssue, gitRefPosts, issueGets *int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/") && strings.HasSuffix(r.URL.Path, "/comments") && r.Method == http.MethodPost:
+			atomic.AddInt64(issueGets, 0) // no-op, kept for symmetry
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": 1})
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/"):
+			atomic.AddInt64(issueGets, 1)
+			var num int
+			_, _ = fmtSscanIssueNum(r.URL.Path, &num)
+			issue, ok := issues[num]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			labels := make([]github.Label, 0, len(issue.labels))
+			for _, name := range issue.labels {
+				labels = append(labels, github.Label{Name: name})
+			}
+			state := issue.state
+			if state == "" {
+				state = "open"
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{Number: num, Title: issue.title, Body: issue.body, State: state, Labels: labels})
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.0.0"})
+		case strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/commits"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat: add a thing")})
+		case strings.Contains(r.URL.Path, "/branches/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "main", "commit": map[string]string{"sha": "mainsha"}})
+		case strings.Contains(r.URL.Path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ahead"})
+		case strings.HasSuffix(r.URL.Path, "/git/refs"):
+			atomic.AddInt64(gitRefPosts, 1)
+			w.WriteHeader(http.StatusCreated)
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+}
+
+// fmtSscanIssueNum extracts the trailing /issues/<N> number from a path.
+func fmtSscanIssueNum(path string, num *int) (int, error) {
+	const marker = "/issues/"
+	idx := strings.LastIndex(path, marker)
+	if idx < 0 {
+		return 0, nil
+	}
+	rest := path[idx+len(marker):]
+	n := 0
+	for _, ch := range rest {
+		if ch < '0' || ch > '9' {
+			break
+		}
+		n = n*10 + int(ch-'0')
+	}
+	*num = n
+	return n, nil
+}
+
+// TestScanRecentlyMergedPRs_HoldsUnderScopeClose covers the "mixed mode" case:
+// a scope-member PR (open epic parent) is held (never registered at
+// StageReleasing), while a standalone PR in the same scan releases per-merge
+// as today (GH-3989).
+func TestScanRecentlyMergedPRs_HoldsUnderScopeClose(t *testing.T) {
+	recentMergedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+
+	var gitRefPosts, issueGets int64
+	server := releaseCyclesServer(t, map[int]scopeMembershipFakeIssue{
+		100: {title: "member", body: "Parent: GH-1"},
+		1:   {title: "epic", state: "open"},
+		200: {title: "standalone"},
+	}, &gitRefPosts, &issueGets)
+	defer server.Close()
+
+	// Override the default pulls route with the specific PR fixtures for this test.
+	prs := []github.PullRequest{
+		{
+			Number:         42,
+			Head:           github.PRRef{Ref: "pilot/GH-100", SHA: "sha42"},
+			Base:           github.PRRef{Ref: "main"},
+			HTMLURL:        "https://github.com/owner/repo/pull/42",
+			Title:          "feat(member): scoped work",
+			Merged:         true,
+			MergedAt:       recentMergedAt,
+			MergeCommitSHA: "merge-sha-42",
+		},
+		{
+			Number:         43,
+			Head:           github.PRRef{Ref: "pilot/GH-200", SHA: "sha43"},
+			Base:           github.PRRef{Ref: "main"},
+			HTMLURL:        "https://github.com/owner/repo/pull/43",
+			Title:          "fix(standalone): unrelated bug",
+			Merged:         true,
+			MergedAt:       recentMergedAt,
+			MergeCommitSHA: "merge-sha-43",
+		},
+	}
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls") && !strings.Contains(r.URL.Path, "/commits") {
+			out := make([]*github.PullRequest, len(prs))
+			for i := range prs {
+				out[i] = &prs[i]
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(out)
+			return
+		}
+		server.Config.Handler.ServeHTTP(w, r)
+	}))
+	defer server2.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server2.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close", ScopeLabelPrefix: "scope:", TagPrefix: "v"}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	if _, ok := c.GetPRState(42); ok {
+		t.Error("PR 42 (scope member, open epic) should be held — not registered in activePRs")
+	}
+
+	standalone, ok := c.GetPRState(43)
+	if !ok {
+		t.Fatal("PR 43 (standalone) should be registered at StageReleasing")
+	}
+	if standalone.Stage != StageReleasing {
+		t.Errorf("PR 43 stage = %v, want StageReleasing", standalone.Stage)
+	}
+
+	if got := atomic.LoadInt64(&gitRefPosts); got != 0 {
+		t.Errorf("git/refs POST count after scan = %d, want 0 (tag creation happens later in handleReleasing)", got)
+	}
+
+	// Drive the standalone PR through handleReleasing directly (mirrors the
+	// controller's main loop dispatching StageReleasing) and confirm it tags.
+	if err := c.handleReleasing(context.Background(), standalone); err != nil {
+		t.Fatalf("handleReleasing() error = %v", err)
+	}
+	if got := atomic.LoadInt64(&gitRefPosts); got != 1 {
+		t.Errorf("git/refs POST count after handleReleasing = %d, want 1 (standalone PR must still tag)", got)
+	}
+}
+
+// TestScanRecentlyMergedPRs_HoldsUnderSchedule verifies Trigger "on_schedule"
+// holds every merged PR unconditionally, without ever consulting
+// heldByScope/GetIssue (GH-3989).
+func TestScanRecentlyMergedPRs_HoldsUnderSchedule(t *testing.T) {
+	recentMergedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+
+	var gitRefPosts, issueGets int64
+	base := releaseCyclesServer(t, map[int]scopeMembershipFakeIssue{}, &gitRefPosts, &issueGets)
+	defer base.Close()
+
+	prs := []github.PullRequest{
+		{
+			Number:         50,
+			Head:           github.PRRef{Ref: "pilot/GH-300", SHA: "sha50"},
+			Base:           github.PRRef{Ref: "main"},
+			HTMLURL:        "https://github.com/owner/repo/pull/50",
+			Title:          "feat: scheduled work",
+			Merged:         true,
+			MergedAt:       recentMergedAt,
+			MergeCommitSHA: "merge-sha-50",
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls") && !strings.Contains(r.URL.Path, "/commits") {
+			out := make([]*github.PullRequest, len(prs))
+			for i := range prs {
+				out[i] = &prs[i]
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(out)
+			return
+		}
+		base.Config.Handler.ServeHTTP(w, r)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_schedule", Schedule: "0 21 * * FRI", TagPrefix: "v"}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	if _, ok := c.GetPRState(50); ok {
+		t.Error("PR 50 should be held under on_schedule — not registered in activePRs")
+	}
+	if got := atomic.LoadInt64(&gitRefPosts); got != 0 {
+		t.Errorf("git/refs POST count = %d, want 0", got)
+	}
+	if got := atomic.LoadInt64(&issueGets); got != 0 {
+		t.Errorf("GetIssue call count = %d, want 0 (on_schedule never consults scope membership)", got)
+	}
+}
+
+// TestCheckExternalMergeOrClose_HoldsUnderScopeClose verifies the GH-411
+// external-merge hijack holds scope members: the PR still drains via the
+// existing removePR path (label/close bookkeeping unaffected), no tag is
+// created, and a one-time "held for scope release" comment is posted.
+func TestCheckExternalMergeOrClose_HoldsUnderScopeClose(t *testing.T) {
+	var gitRefPosts, issueGets int64
+	var commentPosts int64
+	var commentBodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/42":
+			resp := github.PullRequest{
+				Number:         42,
+				State:          "closed",
+				Merged:         true,
+				HTMLURL:        "https://github.com/owner/repo/pull/42",
+				MergeCommitSHA: "merge-sha-42",
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/issues/10/comments" && r.Method == http.MethodPost:
+			atomic.AddInt64(&commentPosts, 1)
+			var body struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			commentBodies = append(commentBodies, body.Body)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": 1})
+		case r.URL.Path == "/repos/owner/repo/issues/10":
+			atomic.AddInt64(&issueGets, 1)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{
+				Number: 10,
+				Title:  "member issue",
+				State:  "open",
+				Labels: []github.Label{{Name: "scope:billing"}},
+			})
+		case strings.HasSuffix(r.URL.Path, "/git/refs"):
+			atomic.AddInt64(&gitRefPosts, 1)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close", ScopeLabelPrefix: "scope:"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc123", "pilot/GH-10", "")
+
+	c.processAllPRs(context.Background())
+
+	if _, ok := c.GetPRState(42); ok {
+		t.Error("held PR should still be drained from tracking (existing removePR path)")
+	}
+	if got := atomic.LoadInt64(&gitRefPosts); got != 0 {
+		t.Errorf("git/refs POST count = %d, want 0 (held PR must not tag)", got)
+	}
+	// GH-2297's merge-completion comment also posts here, so assert on
+	// content rather than a raw count: exactly one comment must carry the
+	// scope-hold breadcrumb.
+	if got := atomic.LoadInt64(&commentPosts); got == 0 {
+		t.Fatal("expected at least one comment to be posted")
+	}
+	holdComments := 0
+	for _, body := range commentBodies {
+		if strings.Contains(body, "held for scope release label:billing") {
+			holdComments++
+		}
+	}
+	if holdComments != 1 {
+		t.Errorf("scope-hold comment count = %d, want exactly 1 (bodies: %v)", holdComments, commentBodies)
+	}
+}
+
+// TestHandleMerged_SkipPostMergeCI_HoldsUnderScopeClose covers the dev-env
+// fast path (SkipPostMergeCI + RequireCI=false): a scope-member merge is
+// held (drained without releasing) instead of jumping straight to
+// StageReleasing (GH-3989).
+func TestHandleMerged_SkipPostMergeCI_HoldsUnderScopeClose(t *testing.T) {
+	var issueGets int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/issues/10":
+			atomic.AddInt64(&issueGets, 1)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{
+				Number: 10,
+				Title:  "member issue",
+				State:  "open",
+				Labels: []github.Label{{Name: "scope:billing"}},
+			})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev // SkipPostMergeCI: true
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close", ScopeLabelPrefix: "scope:", RequireCI: false}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{PRNumber: 77, IssueNumber: 10, Stage: StageMerged}
+	c.mu.Lock()
+	c.activePRs[77] = prState
+	c.mu.Unlock()
+
+	if err := c.handleMerged(context.Background(), prState); err != nil {
+		t.Fatalf("handleMerged() error = %v", err)
+	}
+
+	if prState.Stage == StageReleasing {
+		t.Error("held PR must not advance to StageReleasing")
+	}
+	if _, ok := c.GetPRState(77); ok {
+		t.Error("held PR should be drained from tracking")
+	}
+	if got := atomic.LoadInt64(&issueGets); got == 0 {
+		t.Error("expected at least one GetIssue call to evaluate scope membership")
+	}
+}
+
+// TestHandlePostMergeCI_HoldsUnderScopeClose covers the post-merge CI success
+// branch: a scope-member merge is held (drained) rather than advancing to
+// StageReleasing once CI passes (GH-3989).
+func TestHandlePostMergeCI_HoldsUnderScopeClose(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo/branches/main":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"commit": map[string]string{"sha": "mainsha42"}})
+		case "/repos/owner/repo/commits/mainsha42/check-runs":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: "completed", Conclusion: "success"}},
+			})
+		case "/repos/owner/repo/issues/10":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Issue{
+				Number: 10,
+				Title:  "member issue",
+				State:  "open",
+				Labels: []github.Label{{Name: "scope:billing"}},
+			})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage // SkipPostMergeCI: false
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 5 * time.Second
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close", ScopeLabelPrefix: "scope:"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{PRNumber: 88, IssueNumber: 10, Stage: StagePostMergeCI}
+	c.mu.Lock()
+	c.activePRs[88] = prState
+	c.mu.Unlock()
+
+	if err := c.handlePostMergeCI(context.Background(), prState); err != nil {
+		t.Fatalf("handlePostMergeCI() error = %v", err)
+	}
+
+	if prState.Stage == StageReleasing {
+		t.Error("held PR must not advance to StageReleasing")
+	}
+	if _, ok := c.GetPRState(88); ok {
+		t.Error("held PR should be drained from tracking")
+	}
+}
+
+// TestReleaseTrigger_OnMerge_BackwardCompatSnapshot pins Trigger "on_merge"
+// (absent/default) to byte-identical behavior: releaseActionFor always
+// releases immediately and never calls GetIssue, matching pre-GH-3989
+// on-merge semantics exactly (zero new API calls).
+func TestReleaseTrigger_OnMerge_BackwardCompatSnapshot(t *testing.T) {
+	var issueGets int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/") {
+			atomic.AddInt64(&issueGets, 1)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge"}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	action, scopeKey, scopeTitle := c.releaseActionFor(context.Background(), 10)
+	if action != releaseActionRelease {
+		t.Errorf("action = %v, want releaseActionRelease", action)
+	}
+	if scopeKey != "" || scopeTitle != "" {
+		t.Errorf("scopeKey/scopeTitle = %q/%q, want empty for on_merge", scopeKey, scopeTitle)
+	}
+	if got := atomic.LoadInt64(&issueGets); got != 0 {
+		t.Errorf("GetIssue call count = %d, want 0 (on_merge must never consult scope membership)", got)
+	}
+}

--- a/internal/autopilot/releaser.go
+++ b/internal/autopilot/releaser.go
@@ -353,11 +353,19 @@ func (r *Releaser) GetCurrentVersionForRepo(ctx context.Context, owner, repo str
 }
 
 // ShouldRelease determines if a release should be created based on config and bump type.
+// Accepts all three auto-release triggers (on_merge, on_scope_close,
+// on_schedule) — "manual" and unset never auto-release. Hold semantics for
+// on_scope_close/on_schedule (deciding whether THIS merge should release now
+// vs. wait) are enforced upstream by Controller.releaseActionFor; by the time
+// a PR reaches handleReleasing/DetectBumpType it has already cleared any hold
+// (GH-3989).
 func (r *Releaser) ShouldRelease(bumpType BumpType) bool {
 	if !r.config.Enabled {
 		return false
 	}
-	if r.config.Trigger != "on_merge" {
+	switch r.config.Trigger {
+	case "on_merge", "on_scope_close", "on_schedule":
+	default:
 		return false
 	}
 	return bumpType != BumpNone

--- a/internal/autopilot/scope_membership.go
+++ b/internal/autopilot/scope_membership.go
@@ -1,0 +1,61 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+)
+
+// heldByScope determines whether a merged PR's linked issue belongs to a
+// release scope that Trigger "on_scope_close" is configured to hold: either
+// an open epic (the issue's parent, per github.ParseParentIssueNumber — the
+// same resolution controller.go's maybeCloseParentIssue uses) or a shared
+// "scope:"-prefixed label. The epic check wins when both are present, so
+// scope membership is always deterministic for a given issue.
+//
+// Any GitHub API error along the way fails OPEN (not held, scopeKey/title
+// empty) rather than wedging a release forever on a transient lookup
+// failure — held work is fully reconstructable from GitHub, so a false
+// "not held" merely releases a little early, while a false "held" could hang
+// indefinitely (GH-3989).
+func (c *Controller) heldByScope(ctx context.Context, issueNum int) (scopeKey, scopeTitle string, held bool) {
+	rel := c.resolvedRelease()
+	if !rel.ScopeReleaseEnabled() {
+		return "", "", false
+	}
+	if issueNum == 0 {
+		return "", "", false
+	}
+
+	issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, issueNum)
+	if err != nil {
+		c.log.Warn("heldByScope: failed to fetch issue, failing open (not held)",
+			"issue", issueNum, "error", err)
+		return "", "", false
+	}
+
+	if parentNum := github.ParseParentIssueNumber(issue.Body); parentNum != 0 {
+		parent, parentErr := c.ghClient.GetIssue(ctx, c.owner, c.repo, parentNum)
+		switch {
+		case parentErr != nil:
+			c.log.Debug("heldByScope: failed to fetch epic parent, falling through to label check",
+				"issue", issueNum, "parent", parentNum, "error", parentErr)
+		case parent.State == "open":
+			return fmt.Sprintf("epic:%d", parentNum), parent.Title, true
+		default:
+			// Parent already closed: a late straggler merge — release per-merge
+			// rather than holding on a scope that has already shipped.
+		}
+	}
+
+	prefix := strings.ToLower(rel.effectiveScopeLabelPrefix())
+	for _, label := range issue.Labels {
+		if strings.HasPrefix(strings.ToLower(label.Name), prefix) {
+			return "label:" + label.Name[len(prefix):], label.Name, true
+		}
+	}
+
+	return "", "", false
+}

--- a/internal/autopilot/scope_membership_test.go
+++ b/internal/autopilot/scope_membership_test.go
@@ -1,0 +1,150 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// scopeMembershipFakeIssue describes one issue served by the fake GitHub
+// server used across TestHeldByScope subtests.
+type scopeMembershipFakeIssue struct {
+	title  string
+	body   string
+	state  string
+	labels []string
+}
+
+// newScopeMembershipController wires a Controller with the given effective
+// ReleaseConfig against a fake GitHub server serving issues from the
+// provided map (keyed by issue number). Missing issue numbers 404.
+func newScopeMembershipController(t *testing.T, rel *ReleaseConfig, issues map[int]scopeMembershipFakeIssue) *Controller {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var num int
+		if _, err := fmt.Sscanf(r.URL.Path, "/repos/owner/repo/issues/%d", &num); err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		issue, ok := issues[num]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		labels := make([]github.Label, 0, len(issue.labels))
+		for _, name := range issue.labels {
+			labels = append(labels, github.Label{Name: name})
+		}
+		state := issue.state
+		if state == "" {
+			state = "open"
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(github.Issue{
+			Number: num,
+			Title:  issue.title,
+			Body:   issue.body,
+			State:  state,
+			Labels: labels,
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.Release = rel
+	return NewController(cfg, ghClient, nil, "owner", "repo")
+}
+
+func TestHeldByScope(t *testing.T) {
+	scopeRel := &ReleaseConfig{Enabled: true, Trigger: "on_scope_close", ScopeLabelPrefix: "scope:"}
+
+	t.Run("not held: scope release disabled (on_merge)", func(t *testing.T) {
+		c := newScopeMembershipController(t, &ReleaseConfig{Enabled: true, Trigger: "on_merge"}, map[int]scopeMembershipFakeIssue{
+			10: {title: "child", body: "Parent: GH-1"},
+			1:  {title: "epic", state: "open"},
+		})
+		_, _, held := c.heldByScope(context.Background(), 10)
+		if held {
+			t.Error("held = true, want false (trigger is on_merge, not on_scope_close)")
+		}
+	})
+
+	t.Run("not held: issueNum is 0 (standalone/unknown)", func(t *testing.T) {
+		c := newScopeMembershipController(t, scopeRel, map[int]scopeMembershipFakeIssue{})
+		_, _, held := c.heldByScope(context.Background(), 0)
+		if held {
+			t.Error("held = true, want false (issueNum 0 is never a scope member)")
+		}
+	})
+
+	t.Run("held: open epic parent wins", func(t *testing.T) {
+		c := newScopeMembershipController(t, scopeRel, map[int]scopeMembershipFakeIssue{
+			10: {title: "child", body: "Parent: GH-1", labels: []string{"scope:checkout"}},
+			1:  {title: "Checkout epic", state: "open"},
+		})
+		key, title, held := c.heldByScope(context.Background(), 10)
+		if !held {
+			t.Fatal("held = false, want true (open epic parent)")
+		}
+		if key != "epic:1" {
+			t.Errorf("scopeKey = %q, want %q", key, "epic:1")
+		}
+		if title != "Checkout epic" {
+			t.Errorf("scopeTitle = %q, want %q", title, "Checkout epic")
+		}
+	})
+
+	t.Run("not held: epic parent closed falls through, no label present", func(t *testing.T) {
+		c := newScopeMembershipController(t, scopeRel, map[int]scopeMembershipFakeIssue{
+			10: {title: "child", body: "Parent: GH-1"},
+			1:  {title: "epic", state: "closed"},
+		})
+		_, _, held := c.heldByScope(context.Background(), 10)
+		if held {
+			t.Error("held = true, want false (parent already closed — late straggler releases per-merge)")
+		}
+	})
+
+	t.Run("held: scope label, case-insensitive prefix match", func(t *testing.T) {
+		c := newScopeMembershipController(t, scopeRel, map[int]scopeMembershipFakeIssue{
+			20: {title: "standalone", labels: []string{"priority:high", "SCOPE:Billing"}},
+		})
+		key, title, held := c.heldByScope(context.Background(), 20)
+		if !held {
+			t.Fatal("held = false, want true (scope-prefixed label present)")
+		}
+		if key != "label:Billing" {
+			t.Errorf("scopeKey = %q, want %q", key, "label:Billing")
+		}
+		if title != "SCOPE:Billing" {
+			t.Errorf("scopeTitle = %q, want %q", title, "SCOPE:Billing")
+		}
+	})
+
+	t.Run("not held: no epic parent and no scope label", func(t *testing.T) {
+		c := newScopeMembershipController(t, scopeRel, map[int]scopeMembershipFakeIssue{
+			30: {title: "standalone", labels: []string{"priority:high"}},
+		})
+		_, _, held := c.heldByScope(context.Background(), 30)
+		if held {
+			t.Error("held = true, want false (no scope signal)")
+		}
+	})
+
+	t.Run("not held: GetIssue error fails open", func(t *testing.T) {
+		c := newScopeMembershipController(t, scopeRel, map[int]scopeMembershipFakeIssue{})
+		// Issue 99 is not in the map, so the fake server 404s.
+		_, _, held := c.heldByScope(context.Background(), 99)
+		if held {
+			t.Error("held = true, want false (API error must fail open, never hold forever)")
+		}
+	})
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -351,7 +351,12 @@ func DefaultConfig() *Config {
 type ReleaseConfig struct {
 	// Enabled controls whether auto-release is active.
 	Enabled bool `yaml:"enabled"`
-	// Trigger determines when to release: "on_merge" or "manual".
+	// Trigger determines when to release: "on_merge" (release per merged PR,
+	// the default), "manual" (never auto-release), "on_scope_close" (hold
+	// members of an open epic or a shared "scope:" label until the scope
+	// completes, then release once), or "on_schedule" (hold everything for a
+	// cron release train — see Schedule). See internal/config Config.Validate
+	// for the enum check (GH-3989).
 	Trigger string `yaml:"trigger"`
 	// VersionStrategy determines how to bump version: "conventional_commits" or "pr_labels".
 	VersionStrategy string `yaml:"version_strategy"`
@@ -387,6 +392,47 @@ type ReleaseConfig struct {
 	// whether a release is actually cut, so enabling this is safe even for
 	// repos with mixed commit-message discipline (GH-3928).
 	TagHumanMerges bool `yaml:"tag_human_merges,omitempty"`
+	// ScopeLabelPrefix is the label prefix identifying a release scope for
+	// Trigger "on_scope_close" (e.g. a "scope:checkout" label groups PRs that
+	// must all land before releasing). Empty defaults to "scope:", matching
+	// the label-propagation prefix in internal/executor/epic.go (GH-3989).
+	ScopeLabelPrefix string `yaml:"scope_label_prefix,omitempty"`
+	// ScopeLookback bounds how far back to look for scope membership signals
+	// (e.g. sibling sub-issues) when Trigger is "on_scope_close". Zero
+	// defaults to 24h. Not yet consumed by hold detection in this issue —
+	// reserved for the scope-completion reconciler (GH-3989 Issue B).
+	ScopeLookback time.Duration `yaml:"scope_lookback,omitempty"`
+	// Schedule is a robfig/cron/v3 standard cron expression (5 fields:
+	// minute hour dom month dow) used when Trigger is "on_schedule" to cut a
+	// release train. Required when Trigger is "on_schedule"; see
+	// internal/config Config.Validate for the parse check (GH-3989).
+	Schedule string `yaml:"schedule,omitempty"`
+	// ScheduleTimezone is the IANA timezone the Schedule cron expression is
+	// evaluated in. Empty defaults to the daemon's local timezone.
+	ScheduleTimezone string `yaml:"schedule_timezone,omitempty"`
+}
+
+// ScopeReleaseEnabled reports whether this release config is active and
+// configured to hold scope members for a single release-on-scope-close
+// (Trigger "on_scope_close"). A nil receiver returns false.
+func (r *ReleaseConfig) ScopeReleaseEnabled() bool {
+	return r != nil && r.Enabled && r.Trigger == "on_scope_close"
+}
+
+// ScheduleReleaseEnabled reports whether this release config is active and
+// configured to hold all merges for a cron release train (Trigger
+// "on_schedule"). A nil receiver returns false.
+func (r *ReleaseConfig) ScheduleReleaseEnabled() bool {
+	return r != nil && r.Enabled && r.Trigger == "on_schedule"
+}
+
+// effectiveScopeLabelPrefix returns ScopeLabelPrefix, defaulting empty to
+// "scope:".
+func (r *ReleaseConfig) effectiveScopeLabelPrefix() string {
+	if r.ScopeLabelPrefix == "" {
+		return "scope:"
+	}
+	return r.ScopeLabelPrefix
 }
 
 // Publish mode values for ReleaseConfig.Publish / ProjectReleaseConfig.Publish (GH-3926).
@@ -430,15 +476,21 @@ func (r *ReleaseConfig) VerifyReleaseEnabled() bool {
 // ProjectReleaseConfig overlays release settings for a single project on top
 // of the global and per-environment ReleaseConfig blocks. Unset fields
 // inherit the base value — e.g. a project may override Publish while leaving
-// Enabled nil to inherit the global setting. Trigger, VersionStrategy, and
-// RequireCI are intentionally NOT overlayable here — they stay env/global-only
-// (a project overriding when releases fire or how versions bump would make
-// the release cadence inconsistent across repos sharing one autopilot config).
-// See internal/config ProjectConfig.Release (GH-3930); overlay resolution
-// (Apply) and controller wiring land here and in GH-3931.
+// Enabled nil to inherit the global setting. VersionStrategy and RequireCI
+// stay env/global-only (a project overriding how versions bump, or whether
+// releases wait on CI, would make version hygiene inconsistent across repos
+// sharing one autopilot config). Trigger, ScopeLabelPrefix, Schedule, and
+// ScheduleTimezone ARE overlayable — as of GH-3989 release *cadence* is
+// per-repo by design, since different repos in one autopilot config
+// legitimately want different release trains (e.g. a fast-moving repo on
+// on_merge next to a scope-gated one on on_scope_close). This reverses the
+// prior exclusion of Trigger from this struct (GH-3930/GH-3931).
+// See internal/config ProjectConfig.Release (GH-3930).
 type ProjectReleaseConfig struct {
 	// Enabled overrides ReleaseConfig.Enabled for this project. Nil inherits.
 	Enabled *bool `yaml:"enabled,omitempty"`
+	// Trigger overrides ReleaseConfig.Trigger for this project. Empty inherits.
+	Trigger string `yaml:"trigger,omitempty"`
 	// Publish overrides ReleaseConfig.Publish for this project. Empty inherits.
 	Publish string `yaml:"publish,omitempty"`
 	// TagPrefix overrides ReleaseConfig.TagPrefix for this project. Empty inherits.
@@ -453,6 +505,12 @@ type ProjectReleaseConfig struct {
 	VerifyTimeout time.Duration `yaml:"verify_timeout,omitempty"`
 	// TagHumanMerges overrides ReleaseConfig.TagHumanMerges for this project. Nil inherits.
 	TagHumanMerges *bool `yaml:"tag_human_merges,omitempty"`
+	// ScopeLabelPrefix overrides ReleaseConfig.ScopeLabelPrefix for this project. Empty inherits.
+	ScopeLabelPrefix string `yaml:"scope_label_prefix,omitempty"`
+	// Schedule overrides ReleaseConfig.Schedule for this project. Empty inherits.
+	Schedule string `yaml:"schedule,omitempty"`
+	// ScheduleTimezone overrides ReleaseConfig.ScheduleTimezone for this project. Empty inherits.
+	ScheduleTimezone string `yaml:"schedule_timezone,omitempty"`
 }
 
 // Apply overlays this project-level config on top of base (the resolved
@@ -484,6 +542,9 @@ func (p *ProjectReleaseConfig) Apply(base *ReleaseConfig) *ReleaseConfig {
 	if p.Enabled != nil {
 		result.Enabled = *p.Enabled
 	}
+	if p.Trigger != "" {
+		result.Trigger = p.Trigger
+	}
 	if p.Publish != "" {
 		result.Publish = p.Publish
 	}
@@ -505,6 +566,15 @@ func (p *ProjectReleaseConfig) Apply(base *ReleaseConfig) *ReleaseConfig {
 	if p.TagHumanMerges != nil {
 		result.TagHumanMerges = *p.TagHumanMerges
 	}
+	if p.ScopeLabelPrefix != "" {
+		result.ScopeLabelPrefix = p.ScopeLabelPrefix
+	}
+	if p.Schedule != "" {
+		result.Schedule = p.Schedule
+	}
+	if p.ScheduleTimezone != "" {
+		result.ScheduleTimezone = p.ScheduleTimezone
+	}
 	return &result
 }
 
@@ -520,6 +590,8 @@ func DefaultReleaseConfig() *ReleaseConfig {
 		RequireCI:         true,
 		GenerateSummary:   true,
 		VerifyTimeout:     10 * time.Minute,
+		ScopeLabelPrefix:  "scope:",
+		ScopeLookback:     24 * time.Hour,
 	}
 }
 

--- a/internal/autopilot/types_test.go
+++ b/internal/autopilot/types_test.go
@@ -112,6 +112,76 @@ func TestProjectReleaseConfig_Apply(t *testing.T) {
 			t.Errorf("VerifyTimeout = %v, want inherited %v", got.VerifyTimeout, 10*time.Minute)
 		}
 	})
+
+	// GH-3989: Trigger, ScopeLabelPrefix, Schedule, and ScheduleTimezone are
+	// now overlayable per-project — release cadence is per-repo by design.
+	t.Run("trigger override", func(t *testing.T) {
+		base := &ReleaseConfig{Enabled: true, Trigger: "on_merge"}
+		p := &ProjectReleaseConfig{Trigger: "on_scope_close"}
+		got := p.Apply(base)
+		if got.Trigger != "on_scope_close" {
+			t.Errorf("Trigger = %q, want %q", got.Trigger, "on_scope_close")
+		}
+	})
+
+	t.Run("trigger unset inherits from base", func(t *testing.T) {
+		base := &ReleaseConfig{Enabled: true, Trigger: "on_scope_close"}
+		p := &ProjectReleaseConfig{Publish: "api"}
+		got := p.Apply(base)
+		if got.Trigger != "on_scope_close" {
+			t.Errorf("Trigger = %q, want inherited %q", got.Trigger, "on_scope_close")
+		}
+	})
+
+	t.Run("scope_label_prefix, schedule, and schedule_timezone override", func(t *testing.T) {
+		base := &ReleaseConfig{Enabled: true, ScopeLabelPrefix: "scope:", Schedule: "0 21 * * FRI", ScheduleTimezone: "UTC"}
+		p := &ProjectReleaseConfig{ScopeLabelPrefix: "team:", Schedule: "0 9 * * MON", ScheduleTimezone: "Europe/Berlin"}
+		got := p.Apply(base)
+		if got.ScopeLabelPrefix != "team:" {
+			t.Errorf("ScopeLabelPrefix = %q, want %q", got.ScopeLabelPrefix, "team:")
+		}
+		if got.Schedule != "0 9 * * MON" {
+			t.Errorf("Schedule = %q, want %q", got.Schedule, "0 9 * * MON")
+		}
+		if got.ScheduleTimezone != "Europe/Berlin" {
+			t.Errorf("ScheduleTimezone = %q, want %q", got.ScheduleTimezone, "Europe/Berlin")
+		}
+	})
+}
+
+func TestReleaseConfig_ScopeAndScheduleEnabled(t *testing.T) {
+	tests := []struct {
+		name         string
+		rel          *ReleaseConfig
+		wantScope    bool
+		wantSchedule bool
+	}{
+		{name: "nil receiver", rel: nil, wantScope: false, wantSchedule: false},
+		{name: "disabled", rel: &ReleaseConfig{Enabled: false, Trigger: "on_scope_close"}, wantScope: false, wantSchedule: false},
+		{name: "on_merge", rel: &ReleaseConfig{Enabled: true, Trigger: "on_merge"}, wantScope: false, wantSchedule: false},
+		{name: "on_scope_close", rel: &ReleaseConfig{Enabled: true, Trigger: "on_scope_close"}, wantScope: true, wantSchedule: false},
+		{name: "on_schedule", rel: &ReleaseConfig{Enabled: true, Trigger: "on_schedule"}, wantScope: false, wantSchedule: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.rel.ScopeReleaseEnabled(); got != tt.wantScope {
+				t.Errorf("ScopeReleaseEnabled() = %v, want %v", got, tt.wantScope)
+			}
+			if got := tt.rel.ScheduleReleaseEnabled(); got != tt.wantSchedule {
+				t.Errorf("ScheduleReleaseEnabled() = %v, want %v", got, tt.wantSchedule)
+			}
+		})
+	}
+}
+
+func TestDefaultReleaseConfig_ScopeDefaults(t *testing.T) {
+	got := DefaultReleaseConfig()
+	if got.ScopeLabelPrefix != "scope:" {
+		t.Errorf("ScopeLabelPrefix = %q, want %q", got.ScopeLabelPrefix, "scope:")
+	}
+	if got.ScopeLookback != 24*time.Hour {
+		t.Errorf("ScopeLookback = %v, want %v", got.ScopeLookback, 24*time.Hour)
+	}
 }
 
 func TestReleaseConfig_VerifyReleaseEnabled(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/robfig/cron/v3"
 	"gopkg.in/yaml.v3"
 
 	"github.com/qf-studio/pilot/internal/adapters/asana"
@@ -708,6 +709,44 @@ var validReleasePublishValues = map[string]bool{
 	"":         true, // Empty inherits the default (workflow)
 }
 
+// validReleaseTriggerValues are the accepted values for release.trigger,
+// checked at the global, per-environment, and per-project overlay levels
+// (GH-3989).
+var validReleaseTriggerValues = map[string]bool{
+	"":               true, // Empty inherits the default (on_merge)
+	"on_merge":       true,
+	"manual":         true,
+	"on_scope_close": true,
+	"on_schedule":    true,
+}
+
+// validateReleaseTriggerFields validates the trigger enum and, when trigger
+// is "on_schedule", that schedule is present and parses as a robfig/cron/v3
+// standard (5-field: minute hour dom month dow) cron expression; when
+// schedule_timezone is set, it must be a loadable IANA location. pathPrefix
+// identifies the release block in the returned error (e.g.
+// "orchestrator.autopilot.release"). Shared by the global, per-environment,
+// and per-project-overlay release blocks (GH-3989).
+func validateReleaseTriggerFields(pathPrefix, trigger, schedule, timezone string) error {
+	if !validReleaseTriggerValues[trigger] {
+		return fmt.Errorf("%s.trigger must be \"\", \"on_merge\", \"manual\", \"on_scope_close\", or \"on_schedule\", got %q", pathPrefix, trigger)
+	}
+	if trigger == "on_schedule" {
+		if schedule == "" {
+			return fmt.Errorf("%s.schedule is required when trigger is \"on_schedule\"", pathPrefix)
+		}
+		if _, err := cron.ParseStandard(schedule); err != nil {
+			return fmt.Errorf("%s.schedule %q is not a valid cron expression: %w", pathPrefix, schedule, err)
+		}
+	}
+	if timezone != "" {
+		if _, err := time.LoadLocation(timezone); err != nil {
+			return fmt.Errorf("%s.schedule_timezone %q is invalid: %w", pathPrefix, timezone, err)
+		}
+	}
+	return nil
+}
+
 // Validate checks the configuration for errors and returns an error if invalid.
 // It validates required fields, port ranges, authentication settings, and routing config.
 func (c *Config) Validate() error {
@@ -768,10 +807,15 @@ func (c *Config) Validate() error {
 
 		// GH-3930: Validate release.publish enum on the global release block
 		// and on every per-environment release block.
+		// GH-3989: Validate release.trigger + schedule/schedule_timezone
+		// alongside publish, at the same three levels.
 		if c.Orchestrator.Autopilot != nil {
 			if release := c.Orchestrator.Autopilot.Release; release != nil {
 				if !validReleasePublishValues[release.Publish] {
 					return fmt.Errorf("orchestrator.autopilot.release.publish must be \"workflow\", \"api\", or \"tag_only\", got %q", release.Publish)
+				}
+				if err := validateReleaseTriggerFields("orchestrator.autopilot.release", release.Trigger, release.Schedule, release.ScheduleTimezone); err != nil {
+					return err
 				}
 			}
 			for envName, env := range c.Orchestrator.Autopilot.Environments {
@@ -781,17 +825,26 @@ func (c *Config) Validate() error {
 				if !validReleasePublishValues[env.Release.Publish] {
 					return fmt.Errorf("orchestrator.autopilot.environments[%s].release.publish must be \"workflow\", \"api\", or \"tag_only\", got %q", envName, env.Release.Publish)
 				}
+				envPath := fmt.Sprintf("orchestrator.autopilot.environments[%s].release", envName)
+				if err := validateReleaseTriggerFields(envPath, env.Release.Trigger, env.Release.Schedule, env.Release.ScheduleTimezone); err != nil {
+					return err
+				}
 			}
 		}
 	}
 
 	// GH-3930: Validate release.publish enum on each project's release overlay.
+	// GH-3989: Validate release.trigger + schedule/schedule_timezone alongside.
 	for i, p := range c.Projects {
 		if p == nil || p.Release == nil {
 			continue
 		}
 		if !validReleasePublishValues[p.Release.Publish] {
 			return fmt.Errorf("projects[%d].release.publish must be \"workflow\", \"api\", or \"tag_only\", got %q", i, p.Release.Publish)
+		}
+		projectPath := fmt.Sprintf("projects[%d].release", i)
+		if err := validateReleaseTriggerFields(projectPath, p.Release.Trigger, p.Release.Schedule, p.Release.ScheduleTimezone); err != nil {
+			return err
 		}
 	}
 

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -637,3 +637,165 @@ func TestConfig_Validate_ReleasePublish(t *testing.T) {
 		})
 	}
 }
+
+// GH-3989: Validate release.trigger enum + schedule/schedule_timezone
+// parseability at the global, per-environment, and per-project overlay
+// levels — mirrors TestConfig_Validate_ReleasePublish's structure.
+func TestConfig_Validate_ReleaseTrigger(t *testing.T) {
+	tests := []struct {
+		name      string
+		buildCfg  func() *Config
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid triggers at all levels",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Trigger: "on_scope_close"},
+						Environments: map[string]*autopilot.EnvironmentConfig{
+							"prod": {Release: &autopilot.ReleaseConfig{Trigger: "manual"}},
+						},
+					},
+				}
+				cfg.Projects[0].Release = &autopilot.ProjectReleaseConfig{Trigger: ""}
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid trigger at global level",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Trigger: "bogus"},
+					},
+				}
+				return cfg
+			},
+			wantErr:   true,
+			errSubstr: `orchestrator.autopilot.release.trigger must be "", "on_merge", "manual", "on_scope_close", or "on_schedule"`,
+		},
+		{
+			name: "invalid trigger at environment level",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Environments: map[string]*autopilot.EnvironmentConfig{
+							"prod": {Release: &autopilot.ReleaseConfig{Trigger: "bogus"}},
+						},
+					},
+				}
+				return cfg
+			},
+			wantErr:   true,
+			errSubstr: `orchestrator.autopilot.environments[prod].release.trigger must be`,
+		},
+		{
+			name: "invalid trigger at project overlay level",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Projects[0].Release = &autopilot.ProjectReleaseConfig{Trigger: "bogus"}
+				return cfg
+			},
+			wantErr:   true,
+			errSubstr: `projects[0].release.trigger must be`,
+		},
+		{
+			name: "on_schedule without schedule is rejected",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Trigger: "on_schedule"},
+					},
+				}
+				return cfg
+			},
+			wantErr:   true,
+			errSubstr: `orchestrator.autopilot.release.schedule is required when trigger is "on_schedule"`,
+		},
+		{
+			name: "on_schedule with invalid cron expression is rejected",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Trigger: "on_schedule", Schedule: "not a cron"},
+					},
+				}
+				return cfg
+			},
+			wantErr:   true,
+			errSubstr: `orchestrator.autopilot.release.schedule "not a cron" is not a valid cron expression`,
+		},
+		{
+			name: "on_schedule with valid cron expression passes",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Trigger: "on_schedule", Schedule: "0 21 * * FRI"},
+					},
+				}
+				return cfg
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid schedule_timezone is rejected",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Trigger: "on_schedule", Schedule: "0 21 * * FRI", ScheduleTimezone: "Not/A_Zone"},
+					},
+				}
+				return cfg
+			},
+			wantErr:   true,
+			errSubstr: `orchestrator.autopilot.release.schedule_timezone "Not/A_Zone" is invalid`,
+		},
+		{
+			name: "valid schedule_timezone passes",
+			buildCfg: func() *Config {
+				cfg := baseValidConfig()
+				cfg.Orchestrator = &OrchestratorConfig{
+					MaxConcurrent: 1,
+					Autopilot: &autopilot.Config{
+						Release: &autopilot.ReleaseConfig{Trigger: "on_schedule", Schedule: "0 21 * * FRI", ScheduleTimezone: "Europe/Berlin"},
+					},
+				}
+				return cfg
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.buildCfg()
+			err := cfg.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errSubstr)
+				} else if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `on_scope_close` and `on_schedule` as opt-in `release.trigger` values alongside `on_merge`/`manual`.
- `on_scope_close` holds merges belonging to an open epic (parent issue) or a shared `scope:`-prefixed label until the scope completes; standalone merges still release per-merge as today.
- `on_schedule` holds every merge for a future cron release train (schedule/timezone config only — no scheduler in this issue).
- Holds are inert-but-safe: held work is fully reconstructable from GitHub, since neither the scope-completion reconciler nor the scheduler ships yet (follow-up issues gated by this one).
- Wires the hold decision (`Controller.releaseActionFor` / `heldByScope`) into all four release-decision sites: `handleMerged` fast path, `handlePostMergeCI`, the `checkExternalMergeOrClose` GH-411 hijack, and `ScanRecentlyMergedPRs`.
- Extends `internal/config` validation for the trigger enum + schedule/timezone parseability at global, per-environment, and per-project overlay levels.
- Makes release cadence (`trigger`, `scope_label_prefix`, `schedule`, `schedule_timezone`) overlayable per-project (previously excluded).
- `on_merge` behavior is byte-identical (test-pinned).

Part of TASK-389 (release cycles) — foundation issue that gates the rest of the chain (scope-close reconciler, scheduler).

Closes #3989

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/... ./internal/config/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] `go test ./stress/ -timeout 10m`
- New tests: `TestHeldByScope`, per-site hold tests (`TestScanRecentlyMergedPRs_HoldsUnderScopeClose`, `TestScanRecentlyMergedPRs_HoldsUnderSchedule`, `TestCheckExternalMergeOrClose_HoldsUnderScopeClose`, `TestHandleMerged_SkipPostMergeCI_HoldsUnderScopeClose`, `TestHandlePostMergeCI_HoldsUnderScopeClose`), backward-compat snapshot (`TestReleaseTrigger_OnMerge_BackwardCompatSnapshot`), config validation (`TestConfig_Validate_ReleaseTrigger`), `Apply` overlay table extensions.