### PR TITLE
feat(autopilot): scope release state table + carrier execution

### DIFF
--- a/.agent/sops/autopilot/state-store-column-rebuild-drop.md
+++ b/.agent/sops/autopilot/state-store-column-rebuild-drop.md
@@ -1,0 +1,24 @@
+# SOP: `state_store.go` column rebuild migrations silently drop new columns
+
+**Category:** Autopilot / SQLite migrations
+**Implemented:** 2026-07-07
+**Source incident:** GH-3990 implementation — every `autopilot_pr_state` test failed with "no such column: scope_key" despite the `ALTER TABLE ... ADD COLUMN scope_key` migration running successfully.
+
+## Problem
+
+Adding a new column to `autopilot_pr_state` via `ALTER TABLE ... ADD COLUMN` in the `migrations` slice is not sufficient. `migratePRStateRepoScoping` (GH-3903) rebuilds the entire table via `CREATE TABLE autopilot_pr_state_gh3903 (...)` with an **explicit, hardcoded column list**, then copies rows with an explicit `INSERT INTO ... (col list) SELECT (col list) FROM autopilot_pr_state`. On a fresh `:memory:`/new install, this rebuild runs unconditionally right after the `ALTER TABLE ADD COLUMN` migrations — so any column added to the `migrations` slice but *not* also added to `migratePRStateRepoScoping`'s `CREATE TABLE` + `INSERT`/`SELECT` column lists is silently dropped during the rebuild, one migration pass later in the same `NewStateStore()` call.
+
+## Root cause
+
+`migratePRStateRepoScoping` is guarded by `tableHasColumnInPK("autopilot_pr_state", "repo")` — it only runs once, on a table that doesn't yet have `repo` in its primary key (i.e. every fresh install). On an *already-migrated* production DB it correctly no-ops, so this only bites fresh installs and `:memory:` test databases — exactly the ones covered by the test suite, which is why it failed loudly instead of shipping silently broken.
+
+## Fix
+
+Any new column added to `autopilot_pr_state` must be added in **three** places:
+1. The `ALTER TABLE autopilot_pr_state ADD COLUMN ...` migration.
+2. `migratePRStateRepoScoping`'s `CREATE TABLE autopilot_pr_state_gh3903 (...)` column list.
+3. `migratePRStateRepoScoping`'s `INSERT INTO ... SELECT ...` column lists (both sides).
+
+## Prevention
+
+When adding a column to `autopilot_pr_state`, run `go test ./internal/autopilot/... -run TestStateStore` against a fresh `:memory:` DB (the default in `newTestStateStore`) before writing any feature tests — a missing column shows up immediately as "no such column" on the very first `SavePRState`/`GetPRState` call, rather than as a subtle silent data-loss bug in production.

--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-07 (v2.151.0)
+**Last Updated:** 2026-07-06 (v2.151.0)
 
 ## Legend
 
@@ -407,6 +407,7 @@
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
 | Release cycles: trigger config + hold semantics | ✅ | autopilot | - | `release.trigger`, `release.scope_label_prefix`, `release.schedule`, `release.schedule_timezone` | `on_scope_close`/`on_schedule` triggers hold merges at all four release-decision sites (`handleMerged` fast path, `handlePostMergeCI`, `checkExternalMergeOrClose`, `ScanRecentlyMergedPRs`) via `Controller.releaseActionFor`/`heldByScope`; held work is inert-but-safe (fully reconstructable from GitHub) — the scope-close reconciler and cron scheduler that actually fire the release ship in follow-up issues. `on_merge` behavior is byte-identical (v2.226.x, GH-3989) |
+| Scope release carrier execution | ✅ | autopilot | - | `autopilot.release.trigger: on_scope_close` | `autopilot_scope_release` durable table (pending→releasing→done/failed) + `startPendingScopeReleases`/`handleReleasing` cut ONE tag covering every held member once an epic completes, gated on post-merge-CI-validated main SHA; crash-safe (claim+re-drive), capped retries with `scope_release_failed` alert (GH-3990) |
 
 ## Epic Management
 

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2021,16 +2021,25 @@ func (c *Controller) isChildNoOp(issueNum int) bool {
 // populated by reconcileEpicParent's merged-PR verification); nil/empty falls back
 // to the plain "sub-issues are complete" comment used by the older count-only
 // callers (maybeCloseParentIssue, recoverStaleParentIssues).
-func (c *Controller) closeParentNow(ctx context.Context, parentNum int, mergedPRs []int) {
+// closeParentNow returns closed=true only when this call actually transitioned
+// the parent to closed — false for an already-closed no-op or a failed
+// UpdateIssueState call. GH-3990: reconcileEpicParent gates enqueueScopeRelease
+// on this so a scope release is never enqueued for a close that didn't happen.
+// parentTitle is best-effort (empty if the pre-close GetIssue failed).
+func (c *Controller) closeParentNow(ctx context.Context, parentNum int, mergedPRs []int) (closed bool, parentTitle string) {
 	// GH-3939: guard against re-closing an already-closed parent — two close
 	// paths (reactive maybeCloseParentIssue and the periodic reconcileEpicParents
 	// sweep) can both observe "no open children" for the same parent before either
 	// has closed it, which would otherwise double-post the summary comment and
 	// re-run label churn. Fail-open on lookup error so a transient API failure
 	// never blocks a legitimate close.
-	if issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, parentNum); err == nil && strings.EqualFold(issue.State, "closed") {
-		c.log.Debug("closeParentNow: parent already closed, no-op", slog.Int("parent", parentNum))
-		return
+	issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, parentNum)
+	if err == nil {
+		parentTitle = issue.Title
+		if strings.EqualFold(issue.State, "closed") {
+			c.log.Debug("closeParentNow: parent already closed, no-op", slog.Int("parent", parentNum))
+			return false, parentTitle
+		}
 	}
 
 	c.log.Info("closeParentNow: all sub-issues done, closing parent", slog.Int("parent", parentNum))
@@ -2057,7 +2066,9 @@ func (c *Controller) closeParentNow(ctx context.Context, parentNum int, mergedPR
 	// Close the parent issue.
 	if err := c.ghClient.UpdateIssueState(ctx, c.owner, c.repo, parentNum, "closed"); err != nil {
 		c.log.Warn("closeParentNow: failed to close parent issue", slog.Int("parent", parentNum), slog.Any("error", err))
+		return false, parentTitle
 	}
+	return true, parentTitle
 }
 
 // formatMergedPRRefs renders merged PR numbers as a comma-separated "#N" list
@@ -2105,6 +2116,9 @@ func (c *Controller) recoverStaleParentIssues(ctx context.Context) {
 // Start runs one-time startup recovery sweeps. Call before the main Run loop.
 func (c *Controller) Start(ctx context.Context) {
 	c.recoverStaleParentIssues(ctx)
+	// GH-3990: claim any scope releases left pending (or re-drive any left
+	// 'releasing' with no live carrier) by a daemon restart.
+	c.startPendingScopeReleases(ctx)
 }
 
 // handlePostMergeCI monitors deployment/post-merge checks (non-blocking).
@@ -2135,6 +2149,14 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 	}
 	if time.Since(prState.PostMergeCIStartedAt) > ciTimeout {
 		c.log.Warn("post-merge CI timeout", "pr", prState.PRNumber, "waited", time.Since(prState.PostMergeCIStartedAt))
+		if prState.ScopeKey != "" {
+			// GH-3990: re-queue the scope for a fresh carrier attempt instead of
+			// leaving this one wedged at StageFailed forever — drain it now so the
+			// anchor PR slot frees for the retry.
+			c.handleScopeReleaseFailure(ctx, prState, fmt.Sprintf("post-merge CI timeout after %v", ciTimeout))
+			c.removePR(prState.PRNumber)
+			return nil
+		}
 		prState.Stage = StageFailed
 		prState.Error = fmt.Sprintf("post-merge CI timeout after %v", ciTimeout)
 		return nil
@@ -2154,6 +2176,13 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 	switch status {
 	case CISuccess:
 		c.log.Info("post-merge CI passed", "pr", prState.PRNumber, "sha", ShortSHA(mainSHA))
+		if prState.ScopeKey != "" {
+			// GH-3990: this is the scope carrier itself — the hold decision
+			// already happened when the scope was enqueued; proceed straight to
+			// releasing rather than re-consulting releaseActionFor/heldByScope.
+			prState.Stage = StageReleasing
+			return nil
+		}
 		if c.releaseConfigured() {
 			action, scopeKey, scopeTitle := c.releaseActionFor(ctx, prState.IssueNumber)
 			if action == releaseActionRelease {
@@ -2185,6 +2214,11 @@ func (c *Controller) handlePostMergeCI(ctx context.Context, prState *PRState) er
 			if learnErr := c.learningLoop.LearnFromCIFailure(ctx, projectPath, ciLogs, failedChecks); learnErr != nil {
 				c.log.Warn("Failed to learn from post-merge CI failure", slog.Any("error", learnErr))
 			}
+		}
+		// GH-3990: the fix-issue flow above is unchanged — additionally re-queue
+		// the scope release for a fresh carrier attempt.
+		if prState.ScopeKey != "" {
+			c.handleScopeReleaseFailure(ctx, prState, fmt.Sprintf("post-merge CI failed at %s", ShortSHA(mainSHA)))
 		}
 		c.removePR(prState.PRNumber)
 
@@ -2356,70 +2390,92 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 
 	rel := c.resolvedRelease()
 
+	// GH-3990: a scope-release carrier's HeadSHA is the post-merge-CI-validated
+	// main SHA captured on first entry to StagePostMergeCI, not the anchor
+	// member PR's own (unrelated) head commit. Set it explicitly before any of
+	// the logic below reads prState.HeadSHA.
+	isScope := prState.ScopeKey != ""
+	if isScope {
+		prState.HeadSHA = prState.PostMergeSHA
+		if len(prState.ScopeMemberPRs) == 0 {
+			// Restart path: autopilot_pr_state persists ScopeKey but not the
+			// in-memory-only ScopeMemberPRs/ScopeTitle fields.
+			c.hydrateScopeMembers(prState)
+		}
+	}
+
 	// Resolve the actual repo owner/name from the PR URL.
 	// Cross-repo PRs (e.g. auth-service) have a PRURL pointing to a different repo
 	// than c.owner/c.repo (the pilot repo). All release API calls must target the
 	// correct repo to avoid stuck-forever releasing state.
 	owner, repo := prState.RepoOwnerAndName(c.owner, c.repo)
 
-	// Race condition guard: Check if this commit is already covered by a tag.
-	// When multiple PRs merge rapidly, each triggers handleReleasing but only
-	// the first should create a tag. Subsequent PRs see their commit is already
-	// covered (by an earlier release) and skip. "Covered" means either the
-	// commit is tagged exactly, OR it is an ANCESTOR of an existing release
-	// tag's commit — e.g. it was already shipped inside a later squash-merge or
-	// a manual tag on a descendant commit. Without the ancestor check we cut a
-	// redundant, lower-content release for already-shipped work (the spurious
-	// v2.178.0 incident: #3494's commit was an ancestor of v2.177.0).
-	existingTag, err := c.tagCoveringCommit(ctx, owner, repo, prState.HeadSHA)
-	if err != nil {
-		// Transient lookup failure: do NOT fall through to CreateTagForRepo. If a
-		// tag already exists but we couldn't see it, the create call fails with
-		// "Reference already exists", returns an error, and the PR stays in
-		// StageReleasing forever (re-tried every poll). Return the error so this
-		// PR is retried cleanly on the next poll once the lookup recovers. (TASK-316)
-		return c.checkReleasingRetryOrEscalate(ctx, prState,
-			fmt.Errorf("failed to check existing tags for PR #%d: %w", prState.PRNumber, err))
-	}
-	if existingTag != "" {
-		// GH-3926: publish mode "api" idempotence — if a prior pass created
-		// this tag (or the tag it's an ancestor of) but a transient failure
-		// meant the GitHub Release was never published, publish it now instead
-		// of silently draining the PR with no release ever created.
-		c.ensureReleasePublished(ctx, rel, owner, repo, existingTag, prState)
-		c.log.Info("commit already covered by existing tag, skipping release",
-			"pr", prState.PRNumber,
-			"sha", ShortSHA(prState.HeadSHA),
-			"tag", existingTag,
-		)
-		c.removePR(prState.PRNumber)
-		return nil
-	}
+	if !isScope {
+		// Race condition guard: Check if this commit is already covered by a tag.
+		// When multiple PRs merge rapidly, each triggers handleReleasing but only
+		// the first should create a tag. Subsequent PRs see their commit is already
+		// covered (by an earlier release) and skip. "Covered" means either the
+		// commit is tagged exactly, OR it is an ANCESTOR of an existing release
+		// tag's commit — e.g. it was already shipped inside a later squash-merge or
+		// a manual tag on a descendant commit. Without the ancestor check we cut a
+		// redundant, lower-content release for already-shipped work (the spurious
+		// v2.178.0 incident: #3494's commit was an ancestor of v2.177.0).
+		//
+		// GH-3990: skipped for a scope carrier — an interleaved standalone release
+		// landing on the same commit range would otherwise falsely drain the scope
+		// before its own tag is cut. The autopilot_scope_release row is the dedup
+		// for scope releases (ClaimScopeRelease's single-winner claim).
+		existingTag, err := c.tagCoveringCommit(ctx, owner, repo, prState.HeadSHA)
+		if err != nil {
+			// Transient lookup failure: do NOT fall through to CreateTagForRepo. If a
+			// tag already exists but we couldn't see it, the create call fails with
+			// "Reference already exists", returns an error, and the PR stays in
+			// StageReleasing forever (re-tried every poll). Return the error so this
+			// PR is retried cleanly on the next poll once the lookup recovers. (TASK-316)
+			return c.checkReleasingRetryOrEscalate(ctx, prState,
+				fmt.Errorf("failed to check existing tags for PR #%d: %w", prState.PRNumber, err))
+		}
+		if existingTag != "" {
+			// GH-3926: publish mode "api" idempotence — if a prior pass created
+			// this tag (or the tag it's an ancestor of) but a transient failure
+			// meant the GitHub Release was never published, publish it now instead
+			// of silently draining the PR with no release ever created.
+			c.ensureReleasePublished(ctx, rel, owner, repo, existingTag, prState)
+			c.log.Info("commit already covered by existing tag, skipping release",
+				"pr", prState.PRNumber,
+				"sha", ShortSHA(prState.HeadSHA),
+				"tag", existingTag,
+			)
+			c.removePR(prState.PRNumber)
+			return nil
+		}
 
-	// Published-release guard: tagCoveringCommit uses a bounded window of 10 tags.
-	// This exhaustive lookup (paginates all tags) catches the case where the SHA
-	// was tagged more than 10 releases ago and treats it as already released.
-	exactTag, err := c.ghClient.GetTagForSHA(ctx, owner, repo, prState.HeadSHA)
-	if err != nil {
-		return c.checkReleasingRetryOrEscalate(ctx, prState,
-			fmt.Errorf("failed to check published release for PR #%d: %w", prState.PRNumber, err))
-	}
-	if exactTag != "" {
-		// GH-3926: same idempotence as the existingTag drain above.
-		c.ensureReleasePublished(ctx, rel, owner, repo, exactTag, prState)
-		c.log.Info("commit already tagged (exact match in full tag history) — treating as released",
-			"pr", prState.PRNumber,
-			"sha", ShortSHA(prState.HeadSHA),
-			"tag", exactTag,
-		)
-		c.removePR(prState.PRNumber)
-		return nil
+		// Published-release guard: tagCoveringCommit uses a bounded window of 10 tags.
+		// This exhaustive lookup (paginates all tags) catches the case where the SHA
+		// was tagged more than 10 releases ago and treats it as already released.
+		exactTag, err := c.ghClient.GetTagForSHA(ctx, owner, repo, prState.HeadSHA)
+		if err != nil {
+			return c.checkReleasingRetryOrEscalate(ctx, prState,
+				fmt.Errorf("failed to check published release for PR #%d: %w", prState.PRNumber, err))
+		}
+		if exactTag != "" {
+			// GH-3926: same idempotence as the existingTag drain above.
+			c.ensureReleasePublished(ctx, rel, owner, repo, exactTag, prState)
+			c.log.Info("commit already tagged (exact match in full tag history) — treating as released",
+				"pr", prState.PRNumber,
+				"sha", ShortSHA(prState.HeadSHA),
+				"tag", exactTag,
+			)
+			c.removePR(prState.PRNumber)
+			return nil
+		}
 	}
 
 	// Reachability guard: refuse to tag a commit that is not reachable from the
 	// default branch. A diverged SHA (e.g. from a force-push or a PR merged to a
 	// non-main branch) can never be released from main; failing immediately avoids
-	// unbounded retries on a permanently unreleasable commit.
+	// unbounded retries on a permanently unreleasable commit. Kept for scope
+	// carriers too.
 	if reachErr := c.guardReleaseSHAReachable(ctx, owner, repo, prState); reachErr != nil {
 		c.escalateReleasingFailed(ctx, prState, reachErr.Error())
 		return nil
@@ -2432,11 +2488,21 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		currentVersion = SemVer{}
 	}
 
-	// Get PR commits for bump detection
-	commits, err := c.ghClient.GetPRCommits(ctx, owner, repo, prState.PRNumber)
-	if err != nil {
-		return c.checkReleasingRetryOrEscalate(ctx, prState,
-			fmt.Errorf("failed to get PR commits: %w", err))
+	// Get commits for bump detection: a scope carrier unions every member PR's
+	// commits; a regular release reads just its own PR's commits.
+	var commits []*github.Commit
+	if isScope {
+		commits, err = c.scopeReleaseCommits(ctx, owner, repo, prState, currentVersion, rel)
+		if err != nil {
+			return c.checkReleasingRetryOrEscalate(ctx, prState,
+				fmt.Errorf("failed to get scope release commits for %s: %w", prState.ScopeKey, err))
+		}
+	} else {
+		commits, err = c.ghClient.GetPRCommits(ctx, owner, repo, prState.PRNumber)
+		if err != nil {
+			return c.checkReleasingRetryOrEscalate(ctx, prState,
+				fmt.Errorf("failed to get PR commits: %w", err))
+		}
 	}
 
 	// Detect bump type from commits
@@ -2445,6 +2511,11 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 
 	if !c.releaser.ShouldRelease(bumpType) {
 		c.log.Info("no release needed", "pr", prState.PRNumber, "bump", bumpType)
+		if isScope {
+			// GH-3990: a no-op scope (no releasable commits across any member)
+			// must never retry — record it done with an empty tag.
+			c.markScopeReleaseDone(prState, "")
+		}
 		c.removePR(prState.PRNumber)
 		return nil
 	}
@@ -2477,6 +2548,9 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 				"pr", prState.PRNumber,
 				"sha", ShortSHA(prState.HeadSHA),
 			)
+			if isScope {
+				c.markScopeReleaseDone(prState, prState.ReleaseVersion)
+			}
 			c.removePR(prState.PRNumber)
 			return nil
 		}
@@ -2553,6 +2627,9 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	c.recordExecutionEvent(prState, memory.StageReleased,
 		fmt.Sprintf("pr #%d: released %s (tag %s)", prState.PRNumber, prState.ReleaseVersion, tagName))
 
+	if isScope {
+		c.markScopeReleaseDone(prState, tagName)
+	}
 	c.removePR(prState.PRNumber)
 	return nil
 }
@@ -2647,6 +2724,14 @@ func (c *Controller) escalateReleasingFailed(ctx context.Context, prState *PRSta
 	prState.Error = reason
 	c.metrics.RecordPRFailed()
 	c.metrics.RecordIssueProcessed("failed")
+
+	// GH-3990: a scope-release carrier must not stay wedged at StageFailed —
+	// flip the scope back to pending (or terminal-failed past the retry cap)
+	// and drain the carrier so the anchor PR slot frees for the next attempt.
+	if prState.ScopeKey != "" {
+		c.handleScopeReleaseFailure(ctx, prState, reason)
+		c.removePR(prState.PRNumber)
+	}
 }
 
 // afterTagCreated runs once a release tag has been created, unifying release-note
@@ -3505,6 +3590,21 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			continue
 		}
 
+		// GH-3990: skip a merged PR that is a pending/in-flight scope-release
+		// member — the carrier will tag it. This closes the window where the
+		// scope has already completed (issue+parent closed, so heldByScope
+		// would fail open) and the scanner would otherwise cut a redundant
+		// per-merge tag for it ahead of the carrier.
+		if c.stateStore != nil {
+			if pending, err := c.stateStore.ScopeMemberPending(c.repoKey(), pr.Number); err != nil {
+				c.log.Warn("failed to check scope-member pending state, will track to be safe",
+					"pr", pr.Number, "error", err)
+			} else if pending {
+				c.log.Debug("skipping PR: member of a pending/in-flight scope release", "pr", pr.Number)
+				continue
+			}
+		}
+
 		// Skip if already tracked in activePRs (avoid duplicate processing)
 		c.mu.RLock()
 		_, alreadyTracked := c.activePRs[pr.Number]
@@ -3675,6 +3775,13 @@ func (c *Controller) Run(ctx context.Context) error {
 		case <-epicParentTicker.C:
 			// GH-3939: poll-cycle epic-parent auto-close sweep.
 			c.reconcileEpicParents(ctx)
+			// GH-3990: sweep closed epics that completed without an enqueued
+			// scope release (daemon down at close time, or crashed between
+			// close and enqueue).
+			c.reconcileClosedEpicScopes(ctx)
+			// GH-3990: claim any scope releases now unblocked, and re-drive
+			// stale 'releasing' rows with no live carrier.
+			c.startPendingScopeReleases(ctx)
 		case <-ticker.C:
 			c.processAllPRs(ctx)
 
@@ -3888,6 +3995,13 @@ func (c *Controller) evictNotFoundPR(prNumber int) {
 // Returns true if the PR was removed from tracking, false otherwise.
 // Accepts cached ghPR to avoid redundant API calls.
 func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRState, ghPR *github.PullRequest) bool {
+	// GH-3990: this PRState is a scope-release carrier, not the real PR entry
+	// for prState.PRNumber (its anchor is an already-merged member PR reused
+	// as the release vehicle). The external-merge hijack must never touch it —
+	// the carrier's own StagePostMergeCI/StageReleasing flow owns its lifecycle.
+	if prState.ScopeKey != "" {
+		return false
+	}
 
 	// Check if PR was merged externally
 	if ghPR.Merged {

--- a/internal/autopilot/epic_reconcile.go
+++ b/internal/autopilot/epic_reconcile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 )
 
 // maxEpicReconcile caps how many open, pilot-labeled parent-with-sub-issues
@@ -194,5 +195,126 @@ func (c *Controller) reconcileEpicParent(ctx context.Context, parentNum int) {
 		return
 	}
 
-	c.closeParentNow(ctx, parentNum, mergedPRs)
+	closed, title := c.closeParentNow(ctx, parentNum, mergedPRs)
+	// GH-3990: an epic just completed — enqueue its scope release. Gated on
+	// closed=true so a no-op/failed close never enqueues a release for work
+	// that didn't actually finish closing.
+	if closed && c.resolvedRelease().ScopeReleaseEnabled() {
+		c.enqueueScopeRelease(ctx, fmt.Sprintf("epic:%d", parentNum), title, mergedPRs)
+	}
+}
+
+// reconcileClosedEpicScopes sweeps closed, pilot-labeled epic parents updated
+// within the configured scope lookback window that have native sub-issues but
+// no scope-release row yet, and enqueues one. This covers the window
+// reconcileEpicParent's reactive enqueue can miss entirely: the epic closed
+// while the daemon was down, or the daemon crashed between closeParentNow
+// succeeding and enqueueScopeRelease running (GH-3990).
+func (c *Controller) reconcileClosedEpicScopes(ctx context.Context) {
+	rel := c.resolvedRelease()
+	if !rel.ScopeReleaseEnabled() || c.stateStore == nil {
+		return
+	}
+
+	lookback := rel.ScopeLookback
+	if lookback <= 0 {
+		lookback = 24 * time.Hour
+	}
+
+	candidates, err := c.searchClosedPilotIssuesWithSubIssues(ctx, maxEpicReconcile, lookback)
+	if err != nil {
+		c.log.Warn("reconcileClosedEpicScopes: search failed", slog.Any("error", err))
+		return
+	}
+
+	repo := c.repoKey()
+	for _, parentNum := range candidates {
+		scopeKey := fmt.Sprintf("epic:%d", parentNum)
+
+		existing, err := c.stateStore.GetScopeRelease(repo, scopeKey)
+		if err != nil {
+			c.log.Warn("reconcileClosedEpicScopes: failed to check existing scope row",
+				slog.Int("parent", parentNum), slog.Any("error", err))
+			continue
+		}
+		if existing != nil {
+			// Already enqueued (any state) — idempotent, no further API calls.
+			continue
+		}
+
+		children, hasNativeLinks, err := c.getAllSubIssueNumbers(ctx, parentNum)
+		if err != nil || !hasNativeLinks {
+			continue
+		}
+		mergedPRs, veto := c.verifyChildrenShippedForClose(ctx, parentNum, children)
+		if veto != nil {
+			c.log.Warn("reconcileClosedEpicScopes: closed parent has an unverified child, skipping enqueue",
+				slog.Int("parent", parentNum), slog.Int("child", veto.Child), slog.String("veto_reason", veto.Reason))
+			continue
+		}
+
+		title := ""
+		if issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, parentNum); err == nil {
+			title = issue.Title
+		}
+		c.enqueueScopeRelease(ctx, scopeKey, title, mergedPRs)
+	}
+}
+
+// searchClosedPilotIssuesWithSubIssues returns issue numbers for CLOSED issues
+// labeled both "pilot" and "pilot-done" that have at least one sub-issue and
+// were updated within lookback. Mirrors SearchOpenPilotIssuesWithSubIssues's
+// query shape (in-package GraphQL, no SDK change — GH-3990); results are
+// ordered newest-updated-first so the scan can stop as soon as it crosses the
+// lookback cutoff instead of paging through the whole closed-issue history.
+func (c *Controller) searchClosedPilotIssuesWithSubIssues(ctx context.Context, limit int, lookback time.Duration) ([]int, error) {
+	const query = `query($owner: String!, $repo: String!, $first: Int!) {
+		repository(owner: $owner, name: $repo) {
+			issues(first: $first, states: [CLOSED], labels: ["pilot", "pilot-done"], orderBy: {field: UPDATED_AT, direction: DESC}) {
+				nodes {
+					number
+					updatedAt
+					subIssuesSummary {
+						total
+					}
+				}
+			}
+		}
+	}`
+
+	var result struct {
+		Repository struct {
+			Issues struct {
+				Nodes []struct {
+					Number           int       `json:"number"`
+					UpdatedAt        time.Time `json:"updatedAt"`
+					SubIssuesSummary struct {
+						Total int `json:"total"`
+					} `json:"subIssuesSummary"`
+				} `json:"nodes"`
+			} `json:"issues"`
+		} `json:"repository"`
+	}
+
+	variables := map[string]interface{}{
+		"owner": c.owner,
+		"repo":  c.repo,
+		"first": limit,
+	}
+	if err := c.ghClient.ExecuteGraphQL(ctx, query, variables, &result); err != nil {
+		return nil, fmt.Errorf("search closed pilot issues with sub-issues for %s/%s: %w", c.owner, c.repo, err)
+	}
+
+	cutoff := time.Now().Add(-lookback)
+	var numbers []int
+	for _, node := range result.Repository.Issues.Nodes {
+		if node.UpdatedAt.Before(cutoff) {
+			// Results are ordered newest-first — everything after this is older still.
+			break
+		}
+		if node.SubIssuesSummary.Total > 0 {
+			numbers = append(numbers, node.Number)
+		}
+	}
+	return numbers, nil
 }

--- a/internal/autopilot/epic_reconcile_test.go
+++ b/internal/autopilot/epic_reconcile_test.go
@@ -11,7 +11,9 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/testutil"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
@@ -327,5 +329,182 @@ func TestReconcileEpicParents_Wrapper(t *testing.T) {
 
 	if !closeCalled {
 		t.Error("expected reconcileEpicParents to close the fully-shipped parent via the search-driven sweep")
+	}
+}
+
+// TestReconcileEpicParent_EnqueuesScopeRelease verifies that once
+// closeParentNow actually closes a fully-shipped epic and Trigger
+// "on_scope_close" is active, reconcileEpicParent enqueues a durable scope
+// release row naming the merged child PRs (GH-3990).
+func TestReconcileEpicParent_EnqueuesScopeRelease(t *testing.T) {
+	const parentNum = 300
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"node_id":"I_parent","number":%d,"title":"Checkout epic","state":"open"}`, parentNum)
+
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"node": map[string]interface{}{
+						"subIssues": map[string]interface{}{
+							"totalCount": 1,
+							"nodes":      []map[string]interface{}{{"number": 1, "state": "CLOSED"}},
+						},
+					},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+			items := []map[string]interface{}{{
+				"id": 1, "number": 901, "title": "fix: child",
+				"state":        "closed",
+				"pull_request": map[string]interface{}{"merged_at": "2026-01-01T00:00:00Z"},
+			}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": items})
+
+		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close"}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	stateStore := newTestStateStore(t)
+	c.SetStateStore(stateStore)
+
+	c.reconcileEpicParent(context.Background(), parentNum)
+
+	row, err := stateStore.GetScopeRelease("owner/repo", fmt.Sprintf("epic:%d", parentNum))
+	if err != nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row == nil {
+		t.Fatal("expected a scope release row enqueued after the epic closed")
+	}
+	if row.ScopeTitle != "Checkout epic" {
+		t.Errorf("ScopeTitle = %q, want %q", row.ScopeTitle, "Checkout epic")
+	}
+	if len(row.MemberPRs) != 1 || row.MemberPRs[0] != 901 {
+		t.Errorf("MemberPRs = %v, want [901]", row.MemberPRs)
+	}
+}
+
+// TestReconcileClosedEpicScopes covers the lookback sweep (GH-3990): a closed,
+// pilot+pilot-done epic with sub-issues and no scope row gets one enqueued;
+// a second sweep after the row exists makes zero further release API calls
+// (idempotence).
+func TestReconcileClosedEpicScopes(t *testing.T) {
+	const parentNum = 400
+
+	var graphqlCalls, searchCalls int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			query, _ := body["query"].(string)
+
+			if strings.Contains(query, "repository(owner:") {
+				resp := map[string]interface{}{
+					"data": map[string]interface{}{
+						"repository": map[string]interface{}{
+							"issues": map[string]interface{}{
+								"nodes": []map[string]interface{}{{
+									"number":           parentNum,
+									"updatedAt":        time.Now().UTC().Format(time.RFC3339),
+									"subIssuesSummary": map[string]int{"total": 1},
+								}},
+							},
+						},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+
+			atomic.AddInt64(&graphqlCalls, 1)
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"node": map[string]interface{}{
+						"subIssues": map[string]interface{}{
+							"totalCount": 1,
+							"nodes":      []map[string]interface{}{{"number": 1, "state": "CLOSED"}},
+						},
+					},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+			atomic.AddInt64(&searchCalls, 1)
+			items := []map[string]interface{}{{
+				"id": 1, "number": 902, "title": "fix: child",
+				"state":        "closed",
+				"pull_request": map[string]interface{}{"merged_at": "2026-01-01T00:00:00Z"},
+			}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": items})
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"node_id":"I_parent400","number":%d,"title":"Closed while daemon was down","state":"closed"}`, parentNum)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close", ScopeLookback: 24 * time.Hour}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	stateStore := newTestStateStore(t)
+	c.SetStateStore(stateStore)
+
+	c.reconcileClosedEpicScopes(context.Background())
+
+	row, err := stateStore.GetScopeRelease("owner/repo", fmt.Sprintf("epic:%d", parentNum))
+	if err != nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row == nil {
+		t.Fatal("expected reconcileClosedEpicScopes to enqueue a scope release for the closed epic")
+	}
+	if len(row.MemberPRs) != 1 || row.MemberPRs[0] != 902 {
+		t.Errorf("MemberPRs = %v, want [902]", row.MemberPRs)
+	}
+
+	firstGraphQL := atomic.LoadInt64(&graphqlCalls)
+	firstSearch := atomic.LoadInt64(&searchCalls)
+	if firstGraphQL == 0 || firstSearch == 0 {
+		t.Fatalf("expected verification API calls on first sweep, got graphql=%d search=%d", firstGraphQL, firstSearch)
+	}
+
+	// Second sweep: the scope row already exists — GetScopeRelease must
+	// short-circuit before any verification API calls.
+	c.reconcileClosedEpicScopes(context.Background())
+
+	if got := atomic.LoadInt64(&graphqlCalls); got != firstGraphQL {
+		t.Errorf("getAllSubIssueNumbers graphql calls after second sweep = %d, want unchanged at %d (idempotent)", got, firstGraphQL)
+	}
+	if got := atomic.LoadInt64(&searchCalls); got != firstSearch {
+		t.Errorf("verifyChildrenShippedForClose search calls after second sweep = %d, want unchanged at %d (idempotent)", got, firstSearch)
 	}
 }

--- a/internal/autopilot/scope_release.go
+++ b/internal/autopilot/scope_release.go
@@ -1,0 +1,328 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// maxScopeReleaseAttempts caps how many times a scope-release carrier may fail
+// (post-merge CI red/timeout, or a handleReleasing escalation) before the
+// scope is given up on and flagged for human attention via a
+// scope_release_failed alert. Each failure short of the cap re-queues the
+// scope as 'pending' so the next startPendingScopeReleases sweep registers a
+// fresh carrier (GH-3990).
+const maxScopeReleaseAttempts = 5
+
+// enqueueScopeRelease durably records that scopeKey's members (mergedPRs) are
+// ready to release as one carrier once startPendingScopeReleases claims the
+// row. Idempotent: a second call for the same scopeKey (e.g. the reactive
+// epic-close path racing the closed-epic lookback sweep) is a no-op via
+// INSERT OR IGNORE. No-op with a WARN when no state store is wired — a scope
+// release must survive a restart between "epic closed" and "carrier claimed",
+// so it requires persistence (GH-3990).
+func (c *Controller) enqueueScopeRelease(ctx context.Context, scopeKey, title string, mergedPRs []int) {
+	_ = ctx
+	if c.stateStore == nil {
+		c.log.Warn("enqueueScopeRelease: no state store wired, scope release requires persistence — skipping",
+			"scope", scopeKey)
+		return
+	}
+	members := dedupeSortInts(mergedPRs)
+	if len(members) == 0 {
+		c.log.Warn("enqueueScopeRelease: no merged member PRs, skipping", "scope", scopeKey)
+		return
+	}
+	if err := c.stateStore.EnqueueScopeRelease(c.repoKey(), scopeKey, title, members); err != nil {
+		c.log.Warn("enqueueScopeRelease: failed to persist scope release", "scope", scopeKey, "error", err)
+		return
+	}
+	c.log.Info("enqueued scope release", "scope", scopeKey, "title", title, "members", members)
+}
+
+// dedupeSortInts returns nums deduplicated and sorted ascending.
+func dedupeSortInts(nums []int) []int {
+	seen := make(map[int]bool, len(nums))
+	out := make([]int, 0, len(nums))
+	for _, n := range nums {
+		if seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// startPendingScopeReleases claims durable scope-release rows ready to carry
+// and registers a carrier PRState for each, and re-drives any 'releasing' row
+// left behind by a crash with no live carrier. Called once at startup
+// (Controller.Start) and on every epicParentTicker tick (GH-3990).
+func (c *Controller) startPendingScopeReleases(ctx context.Context) {
+	if c.stateStore == nil {
+		return
+	}
+	repo := c.repoKey()
+
+	releasing, err := c.stateStore.ListScopeReleases(repo, "releasing")
+	if err != nil {
+		c.log.Warn("startPendingScopeReleases: failed to list releasing scope rows", "error", err)
+	}
+	for _, row := range releasing {
+		if c.scopeKeyHasLiveCarrier(row.ScopeKey) {
+			continue
+		}
+		c.log.Info("re-driving scope release with no live carrier", "scope", row.ScopeKey)
+		if err := c.stateStore.MarkScopeReleasePending(repo, row.ScopeKey, false); err != nil {
+			c.log.Warn("startPendingScopeReleases: failed to re-queue stale releasing row",
+				"scope", row.ScopeKey, "error", err)
+		}
+	}
+
+	pending, err := c.stateStore.ListScopeReleases(repo, "pending")
+	if err != nil {
+		c.log.Warn("startPendingScopeReleases: failed to list pending scope rows", "error", err)
+		return
+	}
+	for _, row := range pending {
+		c.tryStartScopeRelease(row)
+	}
+}
+
+// tryStartScopeRelease claims one pending scope-release row and registers a
+// carrier PRState for it. Defers (without claiming) when any member PR is
+// still tracked in activePRs — members may sit mid-pipeline (issues close at
+// merge while post-merge CI still runs) — or when the chosen anchor PR is
+// already tracked or has a fresh persisted 'releasing' row, guarding against
+// double-registration across a restart-timing gap (GH-3990).
+func (c *Controller) tryStartScopeRelease(row *ScopeRelease) {
+	if len(row.MemberPRs) == 0 {
+		c.log.Warn("tryStartScopeRelease: scope release has no members, skipping", "scope", row.ScopeKey)
+		return
+	}
+	if c.memberPRsStillActive(row.MemberPRs) {
+		c.log.Debug("deferring scope release: a member PR is still mid-pipeline", "scope", row.ScopeKey)
+		return
+	}
+
+	anchorPR := row.MemberPRs[len(row.MemberPRs)-1]
+	repo := c.repoKey()
+
+	c.mu.RLock()
+	_, tracked := c.activePRs[anchorPR]
+	c.mu.RUnlock()
+	if tracked {
+		c.log.Debug("deferring scope release: anchor PR already tracked", "scope", row.ScopeKey, "anchor_pr", anchorPR)
+		return
+	}
+	if age, found, err := c.stateStore.PersistedReleasingAge(repo, anchorPR); err != nil {
+		c.log.Warn("tryStartScopeRelease: failed to check persisted releasing state, deferring to be safe",
+			"scope", row.ScopeKey, "anchor_pr", anchorPR, "error", err)
+		return
+	} else if found && age < releasingStaleThreshold {
+		c.log.Debug("deferring scope release: anchor PR has a fresh persisted releasing row",
+			"scope", row.ScopeKey, "anchor_pr", anchorPR)
+		return
+	}
+
+	claimed, err := c.stateStore.ClaimScopeRelease(repo, row.ScopeKey)
+	if err != nil {
+		c.log.Warn("tryStartScopeRelease: failed to claim scope release", "scope", row.ScopeKey, "error", err)
+		return
+	}
+	if !claimed {
+		return
+	}
+
+	prState := &PRState{
+		PRNumber:        anchorPR,
+		PRURL:           fmt.Sprintf("https://github.com/%s/%s/pull/%d", c.owner, c.repo, anchorPR),
+		IssueNumber:     epicParentFromScopeKey(row.ScopeKey),
+		Stage:           StagePostMergeCI,
+		CreatedAt:       time.Now(),
+		EnvironmentName: c.config.EnvironmentName(),
+		ScopeKey:        row.ScopeKey,
+		ScopeTitle:      row.ScopeTitle,
+		ScopeMemberPRs:  row.MemberPRs,
+	}
+	c.mu.Lock()
+	c.activePRs[anchorPR] = prState
+	c.mu.Unlock()
+	// prState is now published in activePRs — persist under prState.mu per the
+	// caller-holds-the-lock contract (mirrors OnPRCreated/ScanRecentlyMergedPRs).
+	prState.mu.Lock()
+	c.persistPRState(prState)
+	prState.mu.Unlock()
+
+	c.log.Info("registered scope release carrier", "scope", row.ScopeKey, "anchor_pr", anchorPR, "members", row.MemberPRs)
+}
+
+// scopeKeyHasLiveCarrier reports whether any tracked PRState currently carries
+// scopeKey.
+func (c *Controller) scopeKeyHasLiveCarrier(scopeKey string) bool {
+	c.mu.RLock()
+	live := make([]*PRState, 0, len(c.activePRs))
+	for _, pr := range c.activePRs {
+		live = append(live, pr)
+	}
+	c.mu.RUnlock()
+
+	for _, pr := range live {
+		pr.mu.Lock()
+		k := pr.ScopeKey
+		pr.mu.Unlock()
+		if k == scopeKey {
+			return true
+		}
+	}
+	return false
+}
+
+// memberPRsStillActive reports whether any of the given PR numbers is still
+// tracked in activePRs.
+func (c *Controller) memberPRsStillActive(memberPRs []int) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, n := range memberPRs {
+		if _, ok := c.activePRs[n]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// epicScopeKeyRe extracts the epic parent issue number from a scope key of the
+// form "epic:<N>".
+var epicScopeKeyRe = regexp.MustCompile(`^epic:(\d+)$`)
+
+// epicParentFromScopeKey returns the epic parent issue number encoded in an
+// "epic:<N>" scope key, or 0 for label:/train: keys — which have no natural
+// issue to attach failure comments/notifications to.
+func epicParentFromScopeKey(scopeKey string) int {
+	m := epicScopeKeyRe.FindStringSubmatch(scopeKey)
+	if m == nil {
+		return 0
+	}
+	n, _ := strconv.Atoi(m[1])
+	return n
+}
+
+// hydrateScopeMembers re-populates a scope carrier's in-memory ScopeTitle/
+// ScopeMemberPRs from the persisted scope_release row when they're empty — the
+// case after a daemon restart restores the carrier's PRState from
+// autopilot_pr_state, which persists ScopeKey but not these fields (GH-3990).
+func (c *Controller) hydrateScopeMembers(prState *PRState) {
+	if c.stateStore == nil {
+		return
+	}
+	row, err := c.stateStore.GetScopeRelease(c.repoKey(), prState.ScopeKey)
+	if err != nil || row == nil {
+		c.log.Warn("hydrateScopeMembers: failed to load scope release row", "scope", prState.ScopeKey, "error", err)
+		return
+	}
+	prState.ScopeTitle = row.ScopeTitle
+	prState.ScopeMemberPRs = row.MemberPRs
+}
+
+// scopeReleaseCommits builds the commit set for a scope carrier's release: the
+// union of every member PR's commits, deduped by SHA. If that union comes back
+// empty (e.g. every member GetPRCommits call failed), it falls back to
+// comparing against the tag for the current version (GH-3990).
+func (c *Controller) scopeReleaseCommits(ctx context.Context, owner, repo string, prState *PRState, currentVersion SemVer, rel *ReleaseConfig) ([]*github.Commit, error) {
+	seen := make(map[string]bool)
+	var commits []*github.Commit
+	for _, member := range prState.ScopeMemberPRs {
+		memberCommits, err := c.ghClient.GetPRCommits(ctx, owner, repo, member)
+		if err != nil {
+			c.log.Warn("scope release: failed to fetch member PR commits",
+				"scope", prState.ScopeKey, "member_pr", member, "error", err)
+			continue
+		}
+		for _, mc := range memberCommits {
+			if seen[mc.SHA] {
+				continue
+			}
+			seen[mc.SHA] = true
+			commits = append(commits, mc)
+		}
+	}
+	if len(commits) > 0 {
+		return commits, nil
+	}
+
+	lastTag := currentVersion.String(rel.TagPrefix)
+	c.log.Warn("scope release: member commit union empty, falling back to compare against last tag",
+		"scope", prState.ScopeKey, "last_tag", lastTag, "head_sha", ShortSHA(prState.HeadSHA))
+	return c.ghClient.CompareCommits(ctx, owner, repo, lastTag, prState.HeadSHA)
+}
+
+// markScopeReleaseDone records a scope carrier's successful (or no-op)
+// completion in the state store. tag is "" for a no-op release (BumpNone).
+// No-op when prState is not a scope carrier or no state store is wired.
+func (c *Controller) markScopeReleaseDone(prState *PRState, tag string) {
+	if prState.ScopeKey == "" || c.stateStore == nil {
+		return
+	}
+	if err := c.stateStore.MarkScopeReleaseDone(c.repoKey(), prState.ScopeKey, tag, prState.HeadSHA); err != nil {
+		c.log.Warn("markScopeReleaseDone: failed to mark scope release done",
+			"scope", prState.ScopeKey, "tag", tag, "error", err)
+	}
+}
+
+// handleScopeReleaseFailure records a carrier failure against its scope
+// release row: increments attempts and re-queues it as 'pending' for a fresh
+// carrier, or — once attempts exceeds maxScopeReleaseAttempts — marks the
+// scope 'failed' and fires a scope_release_failed alert so a human can
+// intervene. No-op when prState is not a scope carrier or no state store is
+// wired. Callers remain responsible for draining the carrier PRState itself
+// (removePR) so the anchor PR slot frees for the next attempt (GH-3990).
+func (c *Controller) handleScopeReleaseFailure(ctx context.Context, prState *PRState, reason string) {
+	_ = ctx
+	if prState.ScopeKey == "" || c.stateStore == nil {
+		return
+	}
+	repo := c.repoKey()
+	if err := c.stateStore.MarkScopeReleasePending(repo, prState.ScopeKey, true); err != nil {
+		c.log.Warn("handleScopeReleaseFailure: failed to re-queue scope release", "scope", prState.ScopeKey, "error", err)
+		return
+	}
+	row, err := c.stateStore.GetScopeRelease(repo, prState.ScopeKey)
+	if err != nil || row == nil {
+		c.log.Warn("handleScopeReleaseFailure: failed to read back scope release row", "scope", prState.ScopeKey, "error", err)
+		return
+	}
+	c.log.Warn("scope release carrier failed",
+		"scope", prState.ScopeKey, "pr", prState.PRNumber, "attempts", row.Attempts, "reason", reason)
+
+	if row.Attempts <= maxScopeReleaseAttempts {
+		return
+	}
+
+	if err := c.stateStore.MarkScopeReleaseFailed(repo, prState.ScopeKey); err != nil {
+		c.log.Warn("handleScopeReleaseFailure: failed to mark scope release failed", "scope", prState.ScopeKey, "error", err)
+		return
+	}
+
+	msg := fmt.Sprintf("scope release %s failed after %d attempts: %s — manual intervention required",
+		prState.ScopeKey, row.Attempts, reason)
+	if c.alertsEngine == nil {
+		c.log.Error("scope_release_failed alert not delivered: SetAlertsEngine was never called", "scope", prState.ScopeKey)
+	} else {
+		c.alertsEngine.ProcessEvent(alerts.Event{
+			Type:      alerts.EventType("scope_release_failed"),
+			Error:     msg,
+			Timestamp: time.Now(),
+			Metadata: map[string]string{
+				"repo":  repo,
+				"scope": prState.ScopeKey,
+			},
+		})
+	}
+}

--- a/internal/autopilot/scope_release_state_store_test.go
+++ b/internal/autopilot/scope_release_state_store_test.go
@@ -1,0 +1,247 @@
+package autopilot
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestStateStore_EnqueueScopeRelease_Idempotent(t *testing.T) {
+	store := newTestStateStore(t)
+
+	// EnqueueScopeRelease is a dumb CRUD layer — dedupe/sort is the controller
+	// wrapper's job (dedupeSortInts), so members are stored in the given order.
+	if err := store.EnqueueScopeRelease("owner/repo", "epic:1", "Checkout epic", []int{5, 10, 20}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	// Second call for the same scope key must be a no-op (INSERT OR IGNORE).
+	if err := store.EnqueueScopeRelease("owner/repo", "epic:1", "different title", []int{99}); err != nil {
+		t.Fatalf("EnqueueScopeRelease (second call) failed: %v", err)
+	}
+
+	row, err := store.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row == nil {
+		t.Fatal("GetScopeRelease returned nil")
+	}
+	if row.ScopeTitle != "Checkout epic" {
+		t.Errorf("ScopeTitle = %q, want %q (second enqueue must not clobber)", row.ScopeTitle, "Checkout epic")
+	}
+	if row.State != "pending" {
+		t.Errorf("State = %q, want pending", row.State)
+	}
+	if row.AnchorPR != 20 {
+		t.Errorf("AnchorPR = %d, want 20 (highest member)", row.AnchorPR)
+	}
+	wantMembers := []int{5, 10, 20}
+	if len(row.MemberPRs) != len(wantMembers) {
+		t.Fatalf("MemberPRs = %v, want %v", row.MemberPRs, wantMembers)
+	}
+	for i, m := range wantMembers {
+		if row.MemberPRs[i] != m {
+			t.Errorf("MemberPRs[%d] = %d, want %d", i, row.MemberPRs[i], m)
+		}
+	}
+}
+
+func TestStateStore_ClaimScopeRelease_ExactlyOneWinner(t *testing.T) {
+	store := newTestStateStore(t)
+	// A SQLite ":memory:" DB is per-connection: without capping the pool to a
+	// single connection, concurrent goroutines below can each open a fresh
+	// connection backed by its own empty in-memory database, missing the
+	// schema entirely. Real usage opens one long-lived *sql.DB per daemon, so
+	// this only matters for the concurrent-access shape this test exercises.
+	store.db.SetMaxOpenConns(1)
+	if err := store.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{1, 2, 3}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+
+	const n = 8
+	var wg sync.WaitGroup
+	results := make([]bool, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			claimed, err := store.ClaimScopeRelease("owner/repo", "epic:1")
+			if err != nil {
+				t.Errorf("ClaimScopeRelease failed: %v", err)
+				return
+			}
+			results[i] = claimed
+		}(i)
+	}
+	wg.Wait()
+
+	winners := 0
+	for _, r := range results {
+		if r {
+			winners++
+		}
+	}
+	if winners != 1 {
+		t.Errorf("winners = %d, want exactly 1 (results: %v)", winners, results)
+	}
+
+	row, err := store.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "releasing" {
+		t.Errorf("State = %q, want releasing", row.State)
+	}
+}
+
+func TestStateStore_MarkScopeReleaseDone(t *testing.T) {
+	store := newTestStateStore(t)
+	if err := store.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{1}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	if _, err := store.ClaimScopeRelease("owner/repo", "epic:1"); err != nil {
+		t.Fatalf("ClaimScopeRelease failed: %v", err)
+	}
+	if err := store.MarkScopeReleaseDone("owner/repo", "epic:1", "v1.2.0", "deadbeef"); err != nil {
+		t.Fatalf("MarkScopeReleaseDone failed: %v", err)
+	}
+
+	row, err := store.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "done" {
+		t.Errorf("State = %q, want done", row.State)
+	}
+	if row.Tag != "v1.2.0" {
+		t.Errorf("Tag = %q, want v1.2.0", row.Tag)
+	}
+	if row.FinalSHA != "deadbeef" {
+		t.Errorf("FinalSHA = %q, want deadbeef", row.FinalSHA)
+	}
+}
+
+func TestStateStore_MarkScopeReleasePending_AttemptsIncrement(t *testing.T) {
+	store := newTestStateStore(t)
+	if err := store.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{1}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	if _, err := store.ClaimScopeRelease("owner/repo", "epic:1"); err != nil {
+		t.Fatalf("ClaimScopeRelease failed: %v", err)
+	}
+
+	// incrementAttempts=false: crash-recovery re-drive, attempts unchanged.
+	if err := store.MarkScopeReleasePending("owner/repo", "epic:1", false); err != nil {
+		t.Fatalf("MarkScopeReleasePending(false) failed: %v", err)
+	}
+	row, err := store.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "pending" || row.Attempts != 0 {
+		t.Errorf("state/attempts = %q/%d, want pending/0", row.State, row.Attempts)
+	}
+
+	// incrementAttempts=true: genuine carrier failure, attempts bumps.
+	if err := store.MarkScopeReleasePending("owner/repo", "epic:1", true); err != nil {
+		t.Fatalf("MarkScopeReleasePending(true) failed: %v", err)
+	}
+	row, err = store.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.Attempts != 1 {
+		t.Errorf("Attempts = %d, want 1", row.Attempts)
+	}
+}
+
+func TestStateStore_MarkScopeReleaseFailed(t *testing.T) {
+	store := newTestStateStore(t)
+	if err := store.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{1}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	if err := store.MarkScopeReleaseFailed("owner/repo", "epic:1"); err != nil {
+		t.Fatalf("MarkScopeReleaseFailed failed: %v", err)
+	}
+	row, err := store.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "failed" {
+		t.Errorf("State = %q, want failed", row.State)
+	}
+
+	// A failed scope must not be claimable again.
+	claimed, err := store.ClaimScopeRelease("owner/repo", "epic:1")
+	if err != nil {
+		t.Fatalf("ClaimScopeRelease failed: %v", err)
+	}
+	if claimed {
+		t.Error("claimed a failed scope release row, want not claimable")
+	}
+}
+
+func TestStateStore_ListScopeReleases(t *testing.T) {
+	store := newTestStateStore(t)
+	if err := store.EnqueueScopeRelease("owner/repo", "epic:1", "epic1", []int{1}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	if err := store.EnqueueScopeRelease("owner/repo", "epic:2", "epic2", []int{2}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	if err := store.EnqueueScopeRelease("owner/other-repo", "epic:1", "other epic", []int{3}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	if _, err := store.ClaimScopeRelease("owner/repo", "epic:2"); err != nil {
+		t.Fatalf("ClaimScopeRelease failed: %v", err)
+	}
+
+	pending, err := store.ListScopeReleases("owner/repo", "pending")
+	if err != nil {
+		t.Fatalf("ListScopeReleases failed: %v", err)
+	}
+	if len(pending) != 1 || pending[0].ScopeKey != "epic:1" {
+		t.Errorf("pending rows = %+v, want exactly [epic:1]", pending)
+	}
+
+	releasing, err := store.ListScopeReleases("owner/repo", "releasing")
+	if err != nil {
+		t.Fatalf("ListScopeReleases failed: %v", err)
+	}
+	if len(releasing) != 1 || releasing[0].ScopeKey != "epic:2" {
+		t.Errorf("releasing rows = %+v, want exactly [epic:2]", releasing)
+	}
+}
+
+func TestStateStore_ScopeMemberPending(t *testing.T) {
+	store := newTestStateStore(t)
+	if err := store.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{10, 20}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+
+	pending, err := store.ScopeMemberPending("owner/repo", 10)
+	if err != nil {
+		t.Fatalf("ScopeMemberPending failed: %v", err)
+	}
+	if !pending {
+		t.Error("ScopeMemberPending(10) = false, want true (member of pending scope)")
+	}
+
+	pending, err = store.ScopeMemberPending("owner/repo", 30)
+	if err != nil {
+		t.Fatalf("ScopeMemberPending failed: %v", err)
+	}
+	if pending {
+		t.Error("ScopeMemberPending(30) = true, want false (not a member)")
+	}
+
+	if err := store.MarkScopeReleaseDone("owner/repo", "epic:1", "v1.0.0", "sha"); err != nil {
+		t.Fatalf("MarkScopeReleaseDone failed: %v", err)
+	}
+	pending, err = store.ScopeMemberPending("owner/repo", 10)
+	if err != nil {
+		t.Fatalf("ScopeMemberPending failed: %v", err)
+	}
+	if pending {
+		t.Error("ScopeMemberPending(10) = true after done, want false (done is terminal, not pending/releasing)")
+	}
+}

--- a/internal/autopilot/scope_release_test.go
+++ b/internal/autopilot/scope_release_test.go
@@ -1,0 +1,561 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// scopeCarrierServer builds a fake GitHub server covering everything a scope
+// carrier needs to flow from StagePostMergeCI through a tagged release:
+// branch/check-runs for post-merge CI, member PR commits, releases/tags for
+// version resolution, and /git/refs for tag creation. gitRefPosts counts
+// POST /git/refs calls.
+func scopeCarrierServer(t *testing.T, memberCommits map[int][]*github.Commit, gitRefPosts *int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/branches/main":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "main", "commit": map[string]string{"sha": "mainsha"}})
+		case r.URL.Path == "/repos/owner/repo/commits/mainsha/check-runs":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: "completed", Conclusion: "success"}},
+			})
+		case strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/commits"):
+			var num int
+			_, _ = fmtSscanIssueNum(strings.Replace(r.URL.Path, "/pulls/", "/issues/", 1), &num)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(memberCommits[num])
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.0.0"})
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(r.URL.Path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "identical"})
+		case strings.HasSuffix(r.URL.Path, "/git/refs"):
+			atomic.AddInt64(gitRefPosts, 1)
+			w.WriteHeader(http.StatusCreated)
+		case strings.HasSuffix(r.URL.Path, "/releases/tags/v1.1.0"):
+			// Post-tag verification (afterTagCreated, "workflow" mode) — report
+			// the release as already published so the background poll goroutine
+			// returns immediately instead of running past test teardown.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.1.0", HTMLURL: "https://github.com/owner/repo/releases/tag/v1.1.0"})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+}
+
+func newScopeCarrierController(t *testing.T, server *httptest.Server) (*Controller, *StateStore) {
+	t.Helper()
+	stateStore := newTestStateStore(t)
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 5 * time.Second
+	cfg.Release = &ReleaseConfig{
+		Enabled:          true,
+		Trigger:          "on_scope_close",
+		ScopeLabelPrefix: "scope:",
+		TagPrefix:        "v",
+		RequireCI:        true,
+		VerifyRelease:    boolPtr(false),
+	}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+	return c, stateStore
+}
+
+// TestScopeCarrierFullFlow drives a scope-release carrier end to end: a
+// pending scope row with two members claims a carrier, the carrier captures
+// main's SHA, waits for post-merge CI, unions both members' commits, and cuts
+// exactly one tag — leaving the scope row 'done' (GH-3990).
+func TestScopeCarrierFullFlow(t *testing.T) {
+	commit101 := makeCommit("fix: member one")
+	commit101.SHA = "sha-101"
+	commit102 := makeCommit("feat: member two")
+	commit102.SHA = "sha-102"
+
+	var gitRefPosts int64
+	server := scopeCarrierServer(t, map[int][]*github.Commit{
+		101: {commit101},
+		102: {commit102},
+	}, &gitRefPosts)
+	defer server.Close()
+
+	c, stateStore := newScopeCarrierController(t, server)
+
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:1", "Checkout epic", []int{101, 102}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+
+	c.startPendingScopeReleases(context.Background())
+
+	carrier, ok := c.GetPRState(102)
+	if !ok {
+		t.Fatal("expected carrier registered at anchor PR 102 (highest member)")
+	}
+	if carrier.Stage != StagePostMergeCI {
+		t.Errorf("carrier stage = %v, want StagePostMergeCI", carrier.Stage)
+	}
+	if carrier.ScopeKey != "epic:1" {
+		t.Errorf("carrier ScopeKey = %q, want epic:1", carrier.ScopeKey)
+	}
+	if carrier.IssueNumber != 1 {
+		t.Errorf("carrier IssueNumber = %d, want 1 (parsed from epic:1)", carrier.IssueNumber)
+	}
+
+	row, err := stateStore.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "releasing" {
+		t.Errorf("scope release state = %q, want releasing (claimed)", row.State)
+	}
+
+	// Drive post-merge CI to completion — CISuccess sends the carrier straight
+	// to StageReleasing (no hold re-check).
+	if err := c.handlePostMergeCI(context.Background(), carrier); err != nil {
+		t.Fatalf("handlePostMergeCI() error = %v", err)
+	}
+	if carrier.Stage != StageReleasing {
+		t.Fatalf("carrier stage after CI success = %v, want StageReleasing", carrier.Stage)
+	}
+	if carrier.PostMergeSHA != "mainsha" {
+		t.Errorf("carrier PostMergeSHA = %q, want mainsha", carrier.PostMergeSHA)
+	}
+
+	if err := c.handleReleasing(context.Background(), carrier); err != nil {
+		t.Fatalf("handleReleasing() error = %v", err)
+	}
+
+	if got := atomic.LoadInt64(&gitRefPosts); got != 1 {
+		t.Errorf("git/refs POST count = %d, want exactly 1", got)
+	}
+	if carrier.HeadSHA != "mainsha" {
+		t.Errorf("carrier HeadSHA = %q, want mainsha (set from PostMergeSHA)", carrier.HeadSHA)
+	}
+	if carrier.ReleaseVersion != "v1.1.0" {
+		t.Errorf("carrier ReleaseVersion = %q, want v1.1.0 (minor bump from the feat: commit)", carrier.ReleaseVersion)
+	}
+
+	if _, ok := c.GetPRState(102); ok {
+		t.Error("carrier should be drained from tracking after a successful release")
+	}
+
+	row, err = stateStore.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "done" {
+		t.Errorf("scope release state = %q, want done", row.State)
+	}
+	if row.Tag != "v1.1.0" {
+		t.Errorf("scope release tag = %q, want v1.1.0", row.Tag)
+	}
+}
+
+// TestScopeCarrier_InterleavedStandaloneTag verifies that a standalone tag
+// landing on (or ahead of) the carrier's final SHA does not falsely drain the
+// scope release without tagging: handleReleasing must skip the
+// tagCoveringCommit/GetTagForSHA drains for a scope carrier and still cut its
+// own tag (GH-3990 edge case: "interleaved standalone tag").
+func TestScopeCarrier_InterleavedStandaloneTag(t *testing.T) {
+	var gitRefPosts int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/commits"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat: scoped work")})
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.0.0"})
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			// An interleaved standalone release already covers this exact SHA.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"name":"v1.0.1","commit":{"sha":"mainsha"}}]`))
+		case strings.Contains(r.URL.Path, "/branches/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "main", "commit": map[string]string{"sha": "mainsha"}})
+		case strings.Contains(r.URL.Path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "identical"})
+		case strings.HasSuffix(r.URL.Path, "/git/refs"):
+			atomic.AddInt64(&gitRefPosts, 1)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	c, _ := newScopeCarrierController(t, server)
+	carrier := &PRState{
+		PRNumber:       200,
+		Stage:          StageReleasing,
+		PostMergeSHA:   "mainsha",
+		ScopeKey:       "epic:1",
+		ScopeTitle:     "epic",
+		ScopeMemberPRs: []int{200},
+	}
+	c.mu.Lock()
+	c.activePRs[200] = carrier
+	c.mu.Unlock()
+
+	if err := c.handleReleasing(context.Background(), carrier); err != nil {
+		t.Fatalf("handleReleasing() error = %v", err)
+	}
+
+	if got := atomic.LoadInt64(&gitRefPosts); got != 1 {
+		t.Errorf("git/refs POST count = %d, want 1 (scope carrier must still tag despite the interleaved standalone tag on the same SHA)", got)
+	}
+}
+
+// TestScopeCarrier_CIFailure_RequeuesForRetry covers the post-merge CI-red
+// path: the carrier is drained, the scope row goes back to 'pending' with
+// attempts incremented, and no tag is ever created (GH-3990).
+func TestScopeCarrier_CIFailure_RequeuesForRetry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/branches/main":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "main", "commit": map[string]string{"sha": "mainsha"}})
+		case r.URL.Path == "/repos/owner/repo/commits/mainsha/check-runs":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: "completed", Conclusion: "failure"}},
+			})
+		case r.URL.Path == "/repos/owner/repo/issues" || strings.HasSuffix(r.URL.Path, "/comments"):
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"number": 999, "id": 1})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	c, stateStore := newScopeCarrierController(t, server)
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{55}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	c.startPendingScopeReleases(context.Background())
+
+	carrier, ok := c.GetPRState(55)
+	if !ok {
+		t.Fatal("expected carrier registered")
+	}
+
+	if err := c.handlePostMergeCI(context.Background(), carrier); err != nil {
+		t.Fatalf("handlePostMergeCI() error = %v", err)
+	}
+
+	if _, ok := c.GetPRState(55); ok {
+		t.Error("carrier should be drained after CI failure")
+	}
+
+	row, err := stateStore.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "pending" {
+		t.Errorf("scope release state = %q, want pending (re-queued for retry)", row.State)
+	}
+	if row.Attempts != 1 {
+		t.Errorf("scope release attempts = %d, want 1", row.Attempts)
+	}
+}
+
+// TestScopeCarrier_AttemptsCapEscalatesToFailedAlert verifies that once a
+// scope release has failed more than maxScopeReleaseAttempts times, it is
+// marked terminal-failed and a scope_release_failed alert fires instead of
+// re-queuing indefinitely (GH-3990).
+func TestScopeCarrier_AttemptsCapEscalatesToFailedAlert(t *testing.T) {
+	stateStore := newTestStateStore(t)
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{9}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	// Pre-load the row to attempts=maxScopeReleaseAttempts so the next failure crosses the cap.
+	for i := 0; i < maxScopeReleaseAttempts; i++ {
+		if err := stateStore.MarkScopeReleasePending("owner/repo", "epic:1", true); err != nil {
+			t.Fatalf("MarkScopeReleasePending failed: %v", err)
+		}
+	}
+
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close"}
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, "http://127.0.0.1:0")
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prState := &PRState{PRNumber: 9, ScopeKey: "epic:1", IssueNumber: 1}
+	c.handleScopeReleaseFailure(context.Background(), prState, "post-merge CI failed")
+
+	row, err := stateStore.GetScopeRelease("owner/repo", "epic:1")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "failed" {
+		t.Errorf("scope release state = %q, want failed (attempts cap exceeded)", row.State)
+	}
+
+	found := false
+	for _, e := range sink.events {
+		if e.Type == alerts.EventType("scope_release_failed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a scope_release_failed alert event, got: %+v", sink.events)
+	}
+}
+
+// TestScopeCarrier_RestartResumesFromPostMergeCI persists a carrier at
+// StagePostMergeCI, simulates a daemon restart with a fresh Controller against
+// the same StateStore, and verifies RestoreState resumes it through to a
+// completed release (GH-3990).
+func TestScopeCarrier_RestartResumesFromPostMergeCI(t *testing.T) {
+	var gitRefPosts int64
+	server := scopeCarrierServer(t, map[int][]*github.Commit{
+		301: {makeCommit("feat: restart survivor")},
+	}, &gitRefPosts)
+	defer server.Close()
+
+	stateStore := newTestStateStore(t)
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:2", "Restart epic", []int{301}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	if _, err := stateStore.ClaimScopeRelease("owner/repo", "epic:2"); err != nil {
+		t.Fatalf("ClaimScopeRelease failed: %v", err)
+	}
+
+	// Simulate a carrier that reached StagePostMergeCI (SHA already captured)
+	// before the daemon died — persisted the same way tryStartScopeRelease +
+	// handlePostMergeCI would have left it.
+	carrier := &PRState{
+		PRNumber:     301,
+		PRURL:        "https://github.com/owner/repo/pull/301",
+		IssueNumber:  2,
+		Stage:        StagePostMergeCI,
+		PostMergeSHA: "mainsha",
+		ScopeKey:     "epic:2",
+	}
+	if err := stateStore.SavePRState("owner/repo", carrier); err != nil {
+		t.Fatalf("SavePRState failed: %v", err)
+	}
+
+	// "Restart": brand new Controller against the same StateStore.
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.Release = &ReleaseConfig{
+		Enabled: true, Trigger: "on_scope_close", TagPrefix: "v",
+		RequireCI: true, VerifyRelease: boolPtr(false),
+	}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+
+	if _, err := c.RestoreState(); err != nil {
+		t.Fatalf("RestoreState failed: %v", err)
+	}
+
+	restored, ok := c.GetPRState(301)
+	if !ok {
+		t.Fatal("expected carrier restored into activePRs")
+	}
+	if restored.ScopeKey != "epic:2" {
+		t.Errorf("restored ScopeKey = %q, want epic:2", restored.ScopeKey)
+	}
+	if len(restored.ScopeMemberPRs) != 0 {
+		t.Errorf("restored ScopeMemberPRs = %v, want empty (not persisted — hydrated lazily)", restored.ScopeMemberPRs)
+	}
+
+	if err := c.handlePostMergeCI(context.Background(), restored); err != nil {
+		t.Fatalf("handlePostMergeCI() error = %v", err)
+	}
+	if restored.Stage != StageReleasing {
+		t.Fatalf("stage after CI success = %v, want StageReleasing", restored.Stage)
+	}
+
+	if err := c.handleReleasing(context.Background(), restored); err != nil {
+		t.Fatalf("handleReleasing() error = %v", err)
+	}
+	if restored.ScopeMemberPRs == nil || restored.ScopeMemberPRs[0] != 301 {
+		t.Errorf("ScopeMemberPRs after hydration = %v, want [301]", restored.ScopeMemberPRs)
+	}
+
+	if got := atomic.LoadInt64(&gitRefPosts); got != 1 {
+		t.Errorf("git/refs POST count = %d, want 1", got)
+	}
+
+	row, err := stateStore.GetScopeRelease("owner/repo", "epic:2")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "done" {
+		t.Errorf("scope release state = %q, want done", row.State)
+	}
+}
+
+// TestStartPendingScopeReleases_RedrivesStaleReleasingRow verifies that a
+// 'releasing' row left behind with no live carrier (daemon killed after claim,
+// before the carrier was ever registered) is re-driven back to pending and
+// then re-claimed with a fresh carrier (GH-3990).
+func TestStartPendingScopeReleases_RedrivesStaleReleasingRow(t *testing.T) {
+	stateStore := newTestStateStore(t)
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:3", "epic", []int{7}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	// Claim without ever registering a carrier — simulates a crash right after
+	// ClaimScopeRelease, before tryStartScopeRelease published it to activePRs.
+	if _, err := stateStore.ClaimScopeRelease("owner/repo", "epic:3"); err != nil {
+		t.Fatalf("ClaimScopeRelease failed: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close"}
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, "http://127.0.0.1:0")
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+
+	c.startPendingScopeReleases(context.Background())
+
+	if _, ok := c.GetPRState(7); !ok {
+		t.Fatal("expected a fresh carrier registered after re-driving the stale releasing row")
+	}
+	row, err := stateStore.GetScopeRelease("owner/repo", "epic:3")
+	if err != nil || row == nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row.State != "releasing" {
+		t.Errorf("scope release state = %q, want releasing (re-claimed)", row.State)
+	}
+}
+
+// TestCheckExternalMergeOrClose_IgnoresScopeCarrier verifies the GH-411
+// external-merge hijack never touches a scope-release carrier: the carrier's
+// anchor PR number is a real, already-merged member PR, so without the
+// ScopeKey guard checkExternalMergeOrClose would re-run issue-close/label
+// bookkeeping and re-evaluate release triggering on every poll tick (GH-3990).
+func TestCheckExternalMergeOrClose_IgnoresScopeCarrier(t *testing.T) {
+	var closeCalls, commentCalls int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/"):
+			atomic.AddInt64(&closeCalls, 1)
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+			atomic.AddInt64(&commentCalls, 1)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": 1})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	carrier := &PRState{PRNumber: 102, IssueNumber: 1, ScopeKey: "epic:1"}
+	ghPR := &github.PullRequest{Number: 102, Merged: true, State: "closed"}
+
+	resolved := c.checkExternalMergeOrClose(context.Background(), carrier, ghPR)
+	if resolved {
+		t.Error("checkExternalMergeOrClose returned true for a scope carrier, want false (must never hijack it)")
+	}
+	if got := atomic.LoadInt64(&closeCalls); got != 0 {
+		t.Errorf("issue close calls = %d, want 0", got)
+	}
+	if got := atomic.LoadInt64(&commentCalls); got != 0 {
+		t.Errorf("comment calls = %d, want 0", got)
+	}
+}
+
+// TestScanRecentlyMergedPRs_SkipsScopeMemberPending verifies the scanner never
+// cuts a per-merge tag for a PR that is still a pending/in-flight scope-release
+// member — closing the race where the scope has already completed and closed
+// the epic parent (heldByScope would fail open) before the carrier tags
+// (GH-3990).
+func TestScanRecentlyMergedPRs_SkipsScopeMemberPending(t *testing.T) {
+	recentMergedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+
+	var gitRefPosts int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls") && !strings.Contains(r.URL.Path, "/commits"):
+			prs := []*github.PullRequest{{
+				Number:         42,
+				Head:           github.PRRef{Ref: "pilot/GH-100", SHA: "sha42"},
+				Base:           github.PRRef{Ref: "main"},
+				HTMLURL:        "https://github.com/owner/repo/pull/42",
+				Title:          "feat(member): scoped work",
+				Merged:         true,
+				MergedAt:       recentMergedAt,
+				MergeCommitSHA: "merge-sha-42",
+			}}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		case strings.HasSuffix(r.URL.Path, "/git/refs"):
+			atomic.AddInt64(&gitRefPosts, 1)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_scope_close", ScopeLabelPrefix: "scope:", TagPrefix: "v"}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	stateStore := newTestStateStore(t)
+	c.SetStateStore(stateStore)
+
+	// PR 42 is already a member of an in-flight scope release (e.g. its epic
+	// closed and the carrier hasn't tagged yet).
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:1", "epic", []int{42}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	if _, ok := c.GetPRState(42); ok {
+		t.Error("PR 42 (pending scope member) should not be registered by the scanner")
+	}
+	if got := atomic.LoadInt64(&gitRefPosts); got != 0 {
+		t.Errorf("git/refs POST count = %d, want 0 (scanner must not cut a per-merge tag for a scope member)", got)
+	}
+}

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -108,6 +109,27 @@ func (s *StateStore) migrate() error {
 		// multiple project-scoped controllers share one SQLite DB.
 		`ALTER TABLE autopilot_pr_state ADD COLUMN repo TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE autopilot_pr_failures ADD COLUMN repo TEXT NOT NULL DEFAULT ''`,
+		// GH-3990: durable scope-release state — one row per epic/label scope held
+		// under Trigger "on_scope_close", tracking its carrier release through
+		// pending -> releasing -> done/failed.
+		`CREATE TABLE IF NOT EXISTS autopilot_scope_release (
+			repo TEXT NOT NULL,
+			scope_key TEXT NOT NULL,
+			scope_title TEXT NOT NULL DEFAULT '',
+			member_prs TEXT NOT NULL DEFAULT '',
+			anchor_pr INTEGER NOT NULL DEFAULT 0,
+			state TEXT NOT NULL DEFAULT 'pending',
+			final_sha TEXT NOT NULL DEFAULT '',
+			tag TEXT NOT NULL DEFAULT '',
+			attempts INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (repo, scope_key)
+		)`,
+		// GH-3990: scope_key namespaces a PR's release scope ("epic:<N>" |
+		// "label:<name>" | "train:<RFC3339>") — persisted so a scope-release
+		// carrier's identity survives a restart via LoadAllPRStates.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN scope_key TEXT NOT NULL DEFAULT ''`,
 	}
 
 	for _, m := range migrations {
@@ -360,6 +382,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			post_merge_sha TEXT NOT NULL DEFAULT '',
 			post_merge_ci_started_at DATETIME,
 			rebase_attempts INTEGER NOT NULL DEFAULT 0,
+			scope_key TEXT NOT NULL DEFAULT '',
 			PRIMARY KEY (repo, pr_number)
 		)
 	`); err != nil {
@@ -372,7 +395,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			merge_attempts, error, created_at, updated_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at, rebase_attempts
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key
 		)
 		SELECT
 			pr_number, repo, pr_url, issue_number, branch_name, head_sha,
@@ -380,7 +403,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			merge_attempts, error, created_at, updated_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at, rebase_attempts
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key
 		FROM autopilot_pr_state
 	`); err != nil {
 		return fmt.Errorf("copy autopilot_pr_state rows: %w", err)
@@ -523,8 +546,8 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			merge_attempts, error, created_at, updated_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at, rebase_attempts
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(repo, pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -545,7 +568,8 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			approval_requested_at = excluded.approval_requested_at,
 			post_merge_sha = excluded.post_merge_sha,
 			post_merge_ci_started_at = excluded.post_merge_ci_started_at,
-			rebase_attempts = excluded.rebase_attempts
+			rebase_attempts = excluded.rebase_attempts,
+			scope_key = excluded.scope_key
 	`,
 		pr.PRNumber, repo, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
@@ -553,7 +577,7 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 		pr.MergeAttempts, pr.Error, nullTime(pr.CreatedAt),
 		pr.ReleaseVersion, string(pr.ReleaseBumpType), pr.MergeNotificationPosted,
 		pr.ApprovalRequestID, pr.ApprovalDecision, nullTime(pr.ApprovalRequestedAt),
-		pr.PostMergeSHA, nullTime(pr.PostMergeCIStartedAt), pr.RebaseAttempts,
+		pr.PostMergeSHA, nullTime(pr.PostMergeCIStartedAt), pr.RebaseAttempts, pr.ScopeKey,
 	)
 	return err
 }
@@ -567,7 +591,7 @@ func (s *StateStore) GetPRState(repo string, prNumber int) (*PRState, error) {
 			merge_attempts, error, created_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at, rebase_attempts
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key
 		FROM autopilot_pr_state WHERE repo = ? AND pr_number = ?
 	`, repo, prNumber)
 
@@ -590,7 +614,7 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			merge_attempts, error, created_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at, rebase_attempts
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key
 		FROM autopilot_pr_state WHERE repo = ?
 	`, repo)
 	if err != nil {
@@ -610,7 +634,7 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			&pr.MergeAttempts, &pr.Error, &createdAt,
 			&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
 			&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
-			&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts,
+			&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts, &pr.ScopeKey,
 		); err != nil {
 			return nil, err
 		}
@@ -864,7 +888,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&pr.MergeAttempts, &pr.Error, &createdAt,
 		&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
 		&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
-		&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts,
+		&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts, &pr.ScopeKey,
 	)
 	if err != nil {
 		return nil, err
@@ -897,4 +921,235 @@ func nullTime(t time.Time) sql.NullTime {
 		return sql.NullTime{}
 	}
 	return sql.NullTime{Time: t, Valid: true}
+}
+
+// ScopeRelease is one durable scope-release row: the set of merged member PRs
+// held under release Trigger "on_scope_close" for a single epic/label scope,
+// and the carrier release's progress through pending -> releasing ->
+// done/failed (GH-3990).
+type ScopeRelease struct {
+	Repo       string
+	ScopeKey   string
+	ScopeTitle string
+	MemberPRs  []int
+	AnchorPR   int
+	State      string
+	FinalSHA   string
+	Tag        string
+	Attempts   int
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// encodeIntCSV renders a sorted []int as a comma-separated string for storage
+// in a TEXT column (autopilot_scope_release.member_prs).
+func encodeIntCSV(nums []int) string {
+	parts := make([]string, len(nums))
+	for i, n := range nums {
+		parts[i] = strconv.Itoa(n)
+	}
+	return strings.Join(parts, ",")
+}
+
+// decodeIntCSV parses a comma-separated int list written by encodeIntCSV.
+// Malformed entries are skipped rather than erroring — a corrupt stored value
+// should degrade to "fewer members" rather than fail the caller.
+func decodeIntCSV(s string) []int {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	nums := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil {
+			continue
+		}
+		nums = append(nums, n)
+	}
+	return nums
+}
+
+// EnqueueScopeRelease durably records that scopeKey's members are ready to
+// release as one carrier once startPendingScopeReleases claims the row.
+// Idempotent: a second call for the same (repo, scopeKey) is a no-op via
+// INSERT OR IGNORE, so the epic-close reactive path and the closed-epic
+// lookback sweep can both call it without duplicating or clobbering an
+// in-flight/completed row. memberPRs should be pre-sorted ascending; anchor_pr
+// is its highest element (GH-3990).
+func (s *StateStore) EnqueueScopeRelease(repo, scopeKey, scopeTitle string, memberPRs []int) error {
+	anchor := 0
+	if len(memberPRs) > 0 {
+		anchor = memberPRs[len(memberPRs)-1]
+	}
+	_, err := s.db.Exec(`
+		INSERT OR IGNORE INTO autopilot_scope_release
+			(repo, scope_key, scope_title, member_prs, anchor_pr, state)
+		VALUES (?, ?, ?, ?, ?, 'pending')
+	`, repo, scopeKey, scopeTitle, encodeIntCSV(memberPRs), anchor)
+	return err
+}
+
+// ClaimScopeRelease atomically transitions one pending scope-release row to
+// 'releasing'. Returns claimed=true only when THIS call performed the
+// transition (RowsAffected==1) — the same single-winner discipline
+// PersistedReleasingAge/ClaimExecution-style callers rely on elsewhere, so the
+// epicParentTicker sweep and a startup backstop can both attempt the same row
+// without registering two carriers for it (GH-3990).
+func (s *StateStore) ClaimScopeRelease(repo, scopeKey string) (bool, error) {
+	result, err := s.db.Exec(`
+		UPDATE autopilot_scope_release
+		SET state = 'releasing', updated_at = CURRENT_TIMESTAMP
+		WHERE repo = ? AND scope_key = ? AND state = 'pending'
+	`, repo, scopeKey)
+	if err != nil {
+		return false, err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n == 1, nil
+}
+
+// GetScopeRelease returns one scope-release row by repo+scopeKey, or nil, nil
+// if not found.
+func (s *StateStore) GetScopeRelease(repo, scopeKey string) (*ScopeRelease, error) {
+	row := s.db.QueryRow(`
+		SELECT repo, scope_key, scope_title, member_prs, anchor_pr, state, final_sha, tag, attempts, created_at, updated_at
+		FROM autopilot_scope_release WHERE repo = ? AND scope_key = ?
+	`, repo, scopeKey)
+	sr, err := scanScopeRelease(row.Scan)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return sr, nil
+}
+
+// ListScopeReleases returns every scope-release row for repo whose state is
+// one of states.
+func (s *StateStore) ListScopeReleases(repo string, states ...string) ([]*ScopeRelease, error) {
+	if len(states) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(states))
+	args := make([]interface{}, 0, len(states)+1)
+	args = append(args, repo)
+	for i, st := range states {
+		placeholders[i] = "?"
+		args = append(args, st)
+	}
+	query := fmt.Sprintf(`
+		SELECT repo, scope_key, scope_title, member_prs, anchor_pr, state, final_sha, tag, attempts, created_at, updated_at
+		FROM autopilot_scope_release WHERE repo = ? AND state IN (%s)
+	`, strings.Join(placeholders, ", "))
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*ScopeRelease
+	for rows.Next() {
+		sr, err := scanScopeRelease(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sr)
+	}
+	return out, rows.Err()
+}
+
+// MarkScopeReleaseDone marks a scope-release row terminal-success. tag is ""
+// for a no-op release (BumpNone — the scope's commits carry no releasable
+// change), recorded so a no-op scope never retries.
+func (s *StateStore) MarkScopeReleaseDone(repo, scopeKey, tag, finalSHA string) error {
+	_, err := s.db.Exec(`
+		UPDATE autopilot_scope_release
+		SET state = 'done', tag = ?, final_sha = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE repo = ? AND scope_key = ?
+	`, tag, finalSHA, repo, scopeKey)
+	return err
+}
+
+// MarkScopeReleasePending re-queues a scope-release row as 'pending' so the
+// next startPendingScopeReleases sweep claims a fresh carrier for it.
+// incrementAttempts distinguishes a genuine carrier failure (true — bumps the
+// retry-cap counter handleScopeReleaseFailure checks) from crash recovery
+// (false — a 'releasing' row left with no live carrier after a restart, which
+// is not itself a failure of the release).
+func (s *StateStore) MarkScopeReleasePending(repo, scopeKey string, incrementAttempts bool) error {
+	q := `UPDATE autopilot_scope_release SET state = 'pending', updated_at = CURRENT_TIMESTAMP WHERE repo = ? AND scope_key = ?`
+	if incrementAttempts {
+		q = `UPDATE autopilot_scope_release SET state = 'pending', attempts = attempts + 1, updated_at = CURRENT_TIMESTAMP WHERE repo = ? AND scope_key = ?`
+	}
+	_, err := s.db.Exec(q, repo, scopeKey)
+	return err
+}
+
+// MarkScopeReleaseFailed marks a scope-release row terminal-failed, once
+// handleScopeReleaseFailure's attempt cap has been exceeded.
+func (s *StateStore) MarkScopeReleaseFailed(repo, scopeKey string) error {
+	_, err := s.db.Exec(`
+		UPDATE autopilot_scope_release SET state = 'failed', updated_at = CURRENT_TIMESTAMP
+		WHERE repo = ? AND scope_key = ?
+	`, repo, scopeKey)
+	return err
+}
+
+// ScopeMemberPending reports whether prNumber is a member of any non-terminal
+// (pending or releasing) scope-release row for repo. ScanRecentlyMergedPRs
+// consults this to skip a member PR whose scope has already completed and
+// closed the epic parent (heldByScope would fail open there) — otherwise the
+// scanner would cut a redundant per-merge tag for it ahead of the carrier
+// (GH-3990).
+func (s *StateStore) ScopeMemberPending(repo string, prNumber int) (bool, error) {
+	rows, err := s.db.Query(`
+		SELECT member_prs FROM autopilot_scope_release
+		WHERE repo = ? AND state IN ('pending', 'releasing')
+	`, repo)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var memberCSV string
+		if err := rows.Scan(&memberCSV); err != nil {
+			return false, err
+		}
+		for _, n := range decodeIntCSV(memberCSV) {
+			if n == prNumber {
+				return true, nil
+			}
+		}
+	}
+	return false, rows.Err()
+}
+
+// scanScopeRelease scans one row into a ScopeRelease via the given scan func —
+// satisfied by both *sql.Row.Scan (GetScopeRelease) and *sql.Rows.Scan
+// (ListScopeReleases), so both callers share one column-order source of truth.
+func scanScopeRelease(scan func(dest ...interface{}) error) (*ScopeRelease, error) {
+	var sr ScopeRelease
+	var memberCSV string
+	var createdAt, updatedAt sql.NullTime
+	err := scan(
+		&sr.Repo, &sr.ScopeKey, &sr.ScopeTitle, &memberCSV, &sr.AnchorPR,
+		&sr.State, &sr.FinalSHA, &sr.Tag, &sr.Attempts, &createdAt, &updatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	sr.MemberPRs = decodeIntCSV(memberCSV)
+	if createdAt.Valid {
+		sr.CreatedAt = createdAt.Time
+	}
+	if updatedAt.Valid {
+		sr.UpdatedAt = updatedAt.Time
+	}
+	return &sr, nil
 }

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -781,6 +781,23 @@ type PRState struct {
 	// safe because a restart re-enters the handler that sets it before the PR
 	// can reach notifyExternalClose again.
 	TerminalLabel string
+	// ScopeKey marks this PRState as a scope-release CARRIER — registered by
+	// startPendingScopeReleases on behalf of a completed epic ("epic:<N>") or
+	// label scope ("label:<name>") once release Trigger "on_scope_close" has
+	// held all its members. Empty means "not a scope carrier" (the common
+	// case). Persisted, so a restart can recognize the carrier row via
+	// LoadAllPRStates without re-querying the scope table (GH-3990).
+	ScopeKey string
+	// ScopeTitle is the human-readable scope title (epic issue title or scope
+	// label name), used in carrier logging/notifications. In-memory only —
+	// hydrateScopeMembers restores it from the autopilot_scope_release table
+	// when empty after a restart (GH-3990).
+	ScopeTitle string
+	// ScopeMemberPRs lists the merged member PR numbers this scope carrier
+	// releases on behalf of; their union of commits determines the carrier's
+	// release content. In-memory only — restored the same way as ScopeTitle
+	// (GH-3990).
+	ScopeMemberPRs []int
 }
 
 // snapshot returns a detached, field-by-field copy of the PRState with a fresh
@@ -822,12 +839,18 @@ func (ps *PRState) snapshot() *PRState {
 		ReleasingFirstAt:        ps.ReleasingFirstAt,
 		EscalationReason:        ps.EscalationReason,
 		TerminalLabel:           ps.TerminalLabel,
+		ScopeKey:                ps.ScopeKey,
+		ScopeTitle:              ps.ScopeTitle,
 	}
-	// DiscoveredChecks is a slice — copy the backing array so consumers can't
-	// mutate the live PR's slice through the snapshot.
+	// DiscoveredChecks and ScopeMemberPRs are slices — copy the backing arrays
+	// so consumers can't mutate the live PR's slice through the snapshot.
 	if ps.DiscoveredChecks != nil {
 		cp.DiscoveredChecks = make([]string, len(ps.DiscoveredChecks))
 		copy(cp.DiscoveredChecks, ps.DiscoveredChecks)
+	}
+	if ps.ScopeMemberPRs != nil {
+		cp.ScopeMemberPRs = make([]int, len(ps.ScopeMemberPRs))
+		copy(cp.ScopeMemberPRs, ps.ScopeMemberPRs)
 	}
 	return cp
 }


### PR DESCRIPTION
## Summary

Closes GH-3990 (part of TASK-389 release cycles). Ships the release half of `on_scope_close`: durable scope state, the carrier PR, aggregate release execution, and the epic-completion hook + crash backstop that #3989's hold semantics needed to actually release.

- `internal/autopilot/state_store.go`: new `autopilot_scope_release` table (`pending`→`releasing`→`done`/`failed`) + `scope_key` column on `autopilot_pr_state`, plus CRUD (`EnqueueScopeRelease`, `ClaimScopeRelease`, `GetScopeRelease`, `ListScopeReleases`, `MarkScopeReleaseDone/Pending/Failed`, `ScopeMemberPending`).
- `internal/autopilot/types.go`: `PRState.ScopeKey` (persisted) + in-memory `ScopeTitle`/`ScopeMemberPRs` (rehydrated from the table on restart).
- `internal/autopilot/scope_release.go` (new): `enqueueScopeRelease`, `startPendingScopeReleases` (claim + register the carrier, re-drive stale `releasing` rows), `handleScopeReleaseFailure` (retry/escalate + `scope_release_failed` alert), `scopeReleaseCommits` (union of member PR commits).
- `internal/autopilot/controller.go`: `checkExternalMergeOrClose` never touches a carrier; `handlePostMergeCI`/`handleReleasing`/`escalateReleasingFailed` branch on `ScopeKey` to skip the per-PR tag-dedup drains (the scope table is the dedup instead), union commits, and mark the scope row done/pending/failed; `ScanRecentlyMergedPRs` skips pending scope members; `Start`/the epic-parent ticker drive `startPendingScopeReleases`.
- `internal/autopilot/epic_reconcile.go`: `closeParentNow` now reports success so `reconcileEpicParent` can enqueue a scope release only on an actual close; new `reconcileClosedEpicScopes` lookback sweep covers the daemon-down window.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (full suite, incl. 12 new tests: carrier full flow, interleaved-standalone-tag, CI-red retry, attempts-cap escalation + alert, restart resume, stale-row re-drive, scanner skip, external-merge-hijack guard, epic-close enqueue, closed-epic lookback idempotence)
- [x] `go test ./...` (full repo)
- [x] `go test ./stress/ -timeout 10m`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`