### PR TITLE
feat(autopilot): aggregated scope release notes + wire LLM What's New summary + scope notifications

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-07 (v2.151.0)
+**Last Updated:** 2026-07-06 (v2.151.0)
 
 ## Legend
 
@@ -406,8 +406,6 @@
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
-| Release cycles: trigger config + hold semantics | ✅ | autopilot | - | `release.trigger`, `release.scope_label_prefix`, `release.schedule`, `release.schedule_timezone` | `on_scope_close`/`on_schedule` triggers hold merges at all four release-decision sites (`handleMerged` fast path, `handlePostMergeCI`, `checkExternalMergeOrClose`, `ScanRecentlyMergedPRs`) via `Controller.releaseActionFor`/`heldByScope`; held work is inert-but-safe (fully reconstructable from GitHub) — the scope-close reconciler and cron scheduler that actually fire the release ship in follow-up issues. `on_merge` behavior is byte-identical (v2.226.x, GH-3989) |
-| Scope release carrier execution | ✅ | autopilot | - | `autopilot.release.trigger: on_scope_close` | `autopilot_scope_release` durable table (pending→releasing→done/failed) + `startPendingScopeReleases`/`handleReleasing` cut ONE tag covering every held member once an epic completes, gated on post-merge-CI-validated main SHA; crash-safe (claim+re-drive), capped retries with `scope_release_failed` alert (GH-3990) |
 
 ## Epic Management
 
@@ -595,3 +593,5 @@ quality:
 | Decomposed-child base-branch pinning | v2.184.x | executor | Resolve `BaseBranch` from main-repo git context before worktree creation; decomposed children never PR against a sibling branch (GH-3540) |
 | GitHub-poller auth-failure escalation | v2.207.x | adapters/github + health | Consecutive 401/non-ratelimit-403 fetch errors escalate to ERROR log + alert at threshold (`WithAlertProcessor`/`WithTokenSource`); `pilot doctor` disabled-subsystems panel; `pilot config show` secret redaction + `--reveal` (TASK-379 V4 / GH-3839) |
 | Executor prompt memory injection | v2.219.x | executor | `BuildPrompt` appends a "Known pitfalls from project memory" block ranked via `graphrecall.RecallRelevant`, gated on `MemoryInjection.Enabled`/non-LocalMode/Navigator/recall hits, capped at `min(MaxMemories,5)` entries and ~1500 chars (TASK-387 / GH-3909) |
+| Aggregated scope release notes | v2.230.x | autopilot | `BuildScopeReleaseNotes` composes a scope carrier's release body — headline, grouped Features/Bug Fixes/Other Changes with `#PR`/`GH-issue` attribution per member commit, `## ⚠ Breaking Changes`, compare-link + stats footer; `publish: api` uses it as the body directly, `publish: workflow` composes it into the LLM enrichment step via `EnrichScopeRelease` alongside GoReleaser's original body (TASK-389 / GH-3992) |
+| LLM release-summary generator wired | v2.230.x | cmd/pilot | `SetReleaseSummaryGenerator` now called at every autopilot controller construction site (`ANTHROPIC_API_KEY` env, nil generator when unset); "What's New" enrichment actually runs instead of always being nil (TASK-389 / GH-3992) |

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -657,6 +657,13 @@ Examples:
 							// GH-2685: wire the controller as the approval state writer so
 							// async approval decisions update the in-memory PRState.
 							approvalMgr.WithStateWriter(gwAutopilotController)
+
+							// GH-3992: wire the LLM release-summary generator so "What's New"
+							// enrichment actually runs. NewReleaseSummaryGenerator returns nil
+							// on an empty key (graceful — releases still ship without it).
+							gwAutopilotController.SetReleaseSummaryGenerator(
+								autopilot.NewReleaseSummaryGenerator(apGHClient, os.Getenv("ANTHROPIC_API_KEY"), logging.WithComponent("autopilot")),
+							)
 						}
 					}
 				}
@@ -1649,6 +1656,10 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			// M7 4d.1: autopilot consumes the studio-sdk client; ghClient (in-tree)
 			// stays for the approval handler and legacy paths until later phases.
 			apGHClient := githubSDK.NewClient(ghToken)
+			// GH-3992: LLM release-summary API key, resolved once and reused for
+			// every controller below. NewReleaseSummaryGenerator returns nil on an
+			// empty key (graceful — releases still ship without a summary).
+			releaseSummaryAPIKey := os.Getenv("ANTHROPIC_API_KEY")
 
 			// GH-1870: Build board sync option for autopilot controllers.
 			var autopilotBoardOpts []autopilot.ControllerOption
@@ -1695,6 +1706,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 						parts[1],
 						ctrlOpts...,
 					)
+					controller.SetReleaseSummaryGenerator(autopilot.NewReleaseSummaryGenerator(apGHClient, releaseSummaryAPIKey, logging.WithComponent("autopilot")))
 					autopilotControllers[cfg.Adapters.GitHub.Repo] = controller
 					autopilotController = controller // Default for backwards compat
 				}
@@ -1724,6 +1736,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					proj.GitHub.Repo,
 					ctrlOpts...,
 				)
+				controller.SetReleaseSummaryGenerator(autopilot.NewReleaseSummaryGenerator(apGHClient, releaseSummaryAPIKey, logging.WithComponent("autopilot")))
 				autopilotControllers[repoFullName] = controller
 				logging.WithComponent("autopilot").Info("created controller for project",
 					slog.String("project", proj.Name),

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -539,17 +539,25 @@ autopilot:
     #   on_scope_close - hold merges belonging to an open epic (parent issue)
     #                    or a shared "scope:"-prefixed label; standalone
     #                    merges still release per-merge. The scope releases
-    #                    once when it completes (scope-close reconciler ships
-    #                    in a follow-up issue; this issue is config + hold
-    #                    semantics only - held work is fully reconstructable
-    #                    from GitHub in the meantime).
+    #                    once when it completes (epic-close reconciler, GH-3990;
+    #                    shared-label reconciler, GH-3991), aggregating every
+    #                    held member PR into one release with grouped
+    #                    Features/Bug Fixes/Other Changes notes, a Breaking
+    #                    Changes section, and an LLM "What's New" summary
+    #                    (GH-3992) - held work is fully reconstructable from
+    #                    GitHub in the meantime if the daemon restarts mid-hold.
     #   on_schedule    - hold every merge for a cron release train (see
-    #                    `schedule` below). No scheduler ships in this issue
-    #                    either; the hold is inert-but-safe until it does.
+    #                    `schedule` below), releasing on the same cron-triggered
+    #                    aggregation as on_scope_close.
     trigger: on_merge
     # scope_label_prefix: "scope:"       # on_scope_close only; default "scope:"
     # schedule: "0 21 * * FRI"           # on_schedule only; robfig/cron/v3 standard (5-field) syntax
     # schedule_timezone: "Europe/Berlin" # on_schedule only; empty = daemon local time
+    # Scope release notes (GH-3992) require a `publish` mode that actually
+    # produces a GitHub Release object — `workflow` (GoReleaser-published) or
+    # `api` (Pilot-published) both work. `tag_only` never creates a release,
+    # so on_scope_close/on_schedule still hold and tag correctly but no
+    # aggregated notes are ever attached anywhere.
     version_strategy: conventional_commits
     tag_prefix: "v"
     generate_changelog: true

--- a/docs/content/features/autopilot-environments.mdx
+++ b/docs/content/features/autopilot-environments.mdx
@@ -226,6 +226,23 @@ github_review:
 
 ---
 
+## Release Scopes (`on_scope_close` / `on_schedule`)
+
+By default (`release.trigger: on_merge`), every merged PR cuts its own release. Two alternate triggers hold merges and release them together instead:
+
+- **`on_scope_close`** — merges belonging to an open epic (parent issue) or a shared `scope:`-prefixed label (`release.scope_label_prefix`, default `"scope:"`) are held until the whole scope completes, then released as one aggregated release covering every member PR.
+- **`on_schedule`** — every merge is held for a cron release train (`release.schedule`, robfig/cron/v3 5-field syntax; `release.schedule_timezone` for the cron's timezone, default daemon local time) and released together on the next scheduled tick.
+
+A scope release's notes aggregate every held member PR: a headline, grouped **Features** / **Bug Fixes** / **Other Changes** sections (each entry linking its source `#PR` and `GH-<issue>`), a **⚠ Breaking Changes** section when any commit signals one, an LLM "What's New" summary (`release.generate_summary`), and a compare-link + stats footer.
+
+<Callout type="warning">
+  Scope release notes require a `release.publish` mode that actually creates a GitHub Release — `workflow` (the repo's own tag-triggered CI, e.g. GoReleaser) or `api` (Pilot publishes directly). `tag_only` still holds and tags correctly under `on_scope_close`/`on_schedule`, but no release object exists to attach notes to.
+</Callout>
+
+`release.trigger`, `release.scope_label_prefix`, `release.schedule`, and `release.schedule_timezone` can all be overlaid per-project under `projects[].release`, so one repo can run `on_merge` while another in the same autopilot config runs `on_scope_close` — see `configs/pilot.example.yaml`.
+
+---
+
 ## Environment Comparison Matrix
 
 ### PR Lifecycle by Environment

--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -560,11 +560,18 @@ orchestrator:
 | `approval_timeout` | duration | `1h` | Time before approval request expires |
 | `merged_pr_scan_window` | duration | `30m` | Window to scan for recently merged PRs |
 | `release.enabled` | bool | `false` | Auto-create releases on merge |
-| `release.trigger` | string | `"on_merge"` | When to trigger release |
+| `release.trigger` | string | `"on_merge"` | When to trigger release: `on_merge` (every merge), `manual` (never), `on_scope_close` (hold until an epic/shared-label scope completes, then cut one aggregated release), `on_schedule` (hold for a cron release train, see `release.schedule`) |
+| `release.scope_label_prefix` | string | `"scope:"` | `on_scope_close` only — label prefix that groups sibling issues into one release scope |
+| `release.schedule` | string | — | `on_schedule` only — cron expression (robfig/cron/v3, 5-field) for the release train |
+| `release.schedule_timezone` | string | daemon local time | `on_schedule` only — IANA timezone for `release.schedule` |
 | `release.version_strategy` | string | `"conventional_commits"` | How to determine version bump |
 | `release.tag_prefix` | string | `"v"` | Git tag prefix |
 | `release.generate_changelog` | bool | `true` | Auto-generate changelog |
+| `release.generate_summary` | bool | `true` | LLM-generated "What's New" summary attached to the release (requires `ANTHROPIC_API_KEY`) |
+| `release.publish` | string | `"workflow"` | Who publishes the GitHub Release: `workflow` (repo's own tag-triggered CI, e.g. GoReleaser), `api` (Pilot publishes directly), `tag_only` (tag only, nothing publishes). Scope release notes (`on_scope_close`/`on_schedule`) require `workflow` or `api` — `tag_only` never creates a release object to attach notes to |
 | `release.require_ci` | bool | `true` | Require CI pass before release |
+
+Per-project overrides live under `projects[].release` and follow the same fields — see the `release:` overlay example in `configs/pilot.example.yaml` for overriding `trigger`/`publish` on a single repo.
 
 ---
 

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2560,6 +2560,21 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 
 	releaseURL := fmt.Sprintf("https://github.com/%s/%s/releases/tag/%s", owner, repo, tagName)
 
+	// GH-3992: build the aggregated scope release notes once, up front, so
+	// both the "api" body and the "workflow" enrichment composition below can
+	// use it. Empty for non-scope carriers.
+	var scopeNotesBody string
+	if isScope {
+		scopeNotesBody = BuildScopeReleaseNotes(ScopeNotesInput{
+			Owner:      owner,
+			Repo:       repo,
+			ScopeTitle: scopeNotesTitle(prState),
+			Members:    c.scopeReleaseMembers(ctx, owner, repo, prState),
+			LastTag:    currentVersion.String(rel.TagPrefix),
+			NewTag:     tagName,
+		})
+	}
+
 	// GH-3926: branch on the resolved publish mode. "workflow" (default)
 	// preserves the original behavior byte-for-byte — Pilot only tags, the
 	// repo's own tag-triggered CI (e.g. GoReleaser) publishes the release.
@@ -2567,7 +2582,14 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	case ReleasePublishAPI:
 		body := ""
 		if rel.GenerateChangelog {
-			body = GenerateChangelog(commits, prState.PRNumber)
+			// GH-3992: a scope carrier's body is the aggregated scope notes
+			// (headline, grouped sections, breaking changes, footer) instead
+			// of the single-PR GenerateChangelog output.
+			if isScope {
+				body = scopeNotesBody
+			} else {
+				body = GenerateChangelog(commits, prState.PRNumber)
+			}
 		}
 		release, relErr := c.releaser.CreateReleaseForRepo(ctx, owner, repo, tagName, body)
 		switch {
@@ -2608,8 +2630,10 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 
 	// Enrichment + post-tag release verification (GH-3927), unified into a
 	// single goroutine so "workflow" mode polls for the release exactly once
-	// (afterTagCreated does not launch anything for "tag_only").
-	c.afterTagCreated(owner, repo, tagName, prState.PRNumber, prState.IssueNumber, commits, rel)
+	// (afterTagCreated does not launch anything for "tag_only"). scopeNotesBody
+	// is only threaded through for "workflow" mode enrichment — "api" mode
+	// already baked it into the release body created above (GH-3992).
+	c.afterTagCreated(owner, repo, tagName, prState.PRNumber, prState.IssueNumber, commits, rel, scopeNotesBody)
 
 	// Send notification
 	if rel.NotifyOnRelease && c.notifier != nil {
@@ -2748,14 +2772,18 @@ func (c *Controller) escalateReleasingFailed(ctx context.Context, prState *PRSta
 // handleReleasing was called with) so a poll-tick cancellation cannot kill
 // verification or enrichment mid-flight — mirrors the pre-existing enrichment
 // goroutine this replaces.
-func (c *Controller) afterTagCreated(owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig) {
+// scopeNotes is the aggregated scope changelog (BuildScopeReleaseNotes'
+// output) for a scope-carrier release, or "" for a regular per-PR release.
+// Only consumed by "workflow" mode enrichment — "api" mode already bakes it
+// into the release body created in handleReleasing (GH-3992).
+func (c *Controller) afterTagCreated(owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig, scopeNotes string) {
 	if rel.PublishMode() == ReleasePublishTagOnly {
 		return
 	}
 
 	if rel.PublishMode() == ReleasePublishAPI {
 		logging.SafeGo("autopilot-controller", func() {
-			c.enrichReleaseNotes(owner, repo, tagName, commits, rel)
+			c.enrichReleaseNotes(owner, repo, tagName, commits, rel, "")
 		})
 		return
 	}
@@ -2766,20 +2794,27 @@ func (c *Controller) afterTagCreated(owner, repo, tagName string, prNumber, issu
 		timeout = releasePollTimeout
 	}
 	logging.SafeGo("autopilot-controller", func() {
-		c.verifyReleaseAfterTag(context.Background(), owner, repo, tagName, prNumber, issueNumber, commits, rel, releasePollInterval, timeout)
+		c.verifyReleaseAfterTag(context.Background(), owner, repo, tagName, prNumber, issueNumber, commits, rel, releasePollInterval, timeout, scopeNotes)
 	})
 }
 
-// enrichReleaseNotes generates and attaches an LLM release summary. Best-effort:
-// logs and returns on failure rather than propagating an error, since a missing
-// summary should never affect release state.
-func (c *Controller) enrichReleaseNotes(owner, repo, tagName string, commits []*github.Commit, rel *ReleaseConfig) {
+// enrichReleaseNotes generates and attaches an LLM release summary, composing
+// in scopeNotes (when non-empty) ahead of the release's original body. Best-
+// effort: logs and returns on failure rather than propagating an error, since
+// a missing summary should never affect release state.
+func (c *Controller) enrichReleaseNotes(owner, repo, tagName string, commits []*github.Commit, rel *ReleaseConfig, scopeNotes string) {
 	if c.releaseSummary == nil || !rel.GenerateSummary {
 		return
 	}
 	enrichCtx, cancel := context.WithTimeout(context.Background(), releasePollTimeout+releaseSummaryTimeout)
 	defer cancel()
-	if err := c.releaseSummary.EnrichRelease(enrichCtx, owner, repo, tagName, commits); err != nil {
+	var err error
+	if scopeNotes != "" {
+		err = c.releaseSummary.EnrichScopeRelease(enrichCtx, owner, repo, tagName, commits, scopeNotes)
+	} else {
+		err = c.releaseSummary.EnrichRelease(enrichCtx, owner, repo, tagName, commits)
+	}
+	if err != nil {
 		c.log.Warn("failed to enrich release notes", "tag", tagName, "error", err)
 	}
 }
@@ -2790,7 +2825,7 @@ func (c *Controller) enrichReleaseNotes(owner, repo, tagName string, commits []*
 // against the real releasePollInterval/VerifyTimeout. On success it enriches like
 // "api" mode; on timeout it fires a release_missing alert unless VerifyRelease
 // was explicitly disabled. GH-3927.
-func (c *Controller) verifyReleaseAfterTag(ctx context.Context, owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig, interval, timeout time.Duration) {
+func (c *Controller) verifyReleaseAfterTag(ctx context.Context, owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig, interval, timeout time.Duration, scopeNotes string) {
 	verifyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	if _, err := waitForReleaseByTag(verifyCtx, c.ghClient, c.log, owner, repo, tagName, interval, timeout); err != nil {
@@ -2799,7 +2834,7 @@ func (c *Controller) verifyReleaseAfterTag(ctx context.Context, owner, repo, tag
 		}
 		return
 	}
-	c.enrichReleaseNotes(owner, repo, tagName, commits, rel)
+	c.enrichReleaseNotes(owner, repo, tagName, commits, rel, scopeNotes)
 }
 
 // fireReleaseMissingAlert fires a release_missing alert (GH-3927) for a tag whose

--- a/internal/autopilot/controller_release_verify_test.go
+++ b/internal/autopilot/controller_release_verify_test.go
@@ -59,7 +59,7 @@ func TestAfterTagCreated_WorkflowMode_ReleaseAppears(t *testing.T) {
 	c.SetAlertsEngine(sink)
 
 	rel := &ReleaseConfig{Publish: ReleasePublishWorkflow, VerifyRelease: boolPtr(true), VerifyTimeout: time.Second}
-	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v1.2.3", 42, 7, nil, rel, 5*time.Millisecond, 500*time.Millisecond)
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v1.2.3", 42, 7, nil, rel, 5*time.Millisecond, 500*time.Millisecond, "")
 
 	if len(sink.events) != 0 {
 		t.Errorf("expected no alert when the release appears in time, got %d events", len(sink.events))
@@ -90,7 +90,7 @@ func TestAfterTagCreated_WorkflowMode_Timeout_FiresAlert(t *testing.T) {
 	c.SetAlertsEngine(sink)
 
 	rel := &ReleaseConfig{Publish: ReleasePublishWorkflow, VerifyRelease: boolPtr(true), VerifyTimeout: 20 * time.Millisecond}
-	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond)
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond, "")
 
 	if len(sink.events) != 1 {
 		t.Fatalf("expected exactly 1 release_missing event, got %d", len(sink.events))
@@ -103,7 +103,7 @@ func TestAfterTagCreated_WorkflowMode_Timeout_FiresAlert(t *testing.T) {
 	}
 
 	// Same tag again — dedup must suppress a second event.
-	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond)
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond, "")
 	if len(sink.events) != 1 {
 		t.Errorf("dedup: expected still exactly 1 event after re-verifying the same tag, got %d", len(sink.events))
 	}
@@ -121,7 +121,7 @@ func TestAfterTagCreated_WorkflowMode_VerifyDisabled_NoAlert(t *testing.T) {
 	c.SetAlertsEngine(sink)
 
 	rel := &ReleaseConfig{Publish: ReleasePublishWorkflow, VerifyRelease: boolPtr(false), VerifyTimeout: 20 * time.Millisecond}
-	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v5.5.5", 1, 0, nil, rel, 5*time.Millisecond, 20*time.Millisecond)
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v5.5.5", 1, 0, nil, rel, 5*time.Millisecond, 20*time.Millisecond, "")
 
 	if len(sink.events) != 0 {
 		t.Errorf("expected no alert when VerifyRelease is explicitly false, got %d events", len(sink.events))
@@ -144,7 +144,7 @@ func TestAfterTagCreated_TagOnly_NoPolling(t *testing.T) {
 	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
 
 	rel := &ReleaseConfig{Publish: ReleasePublishTagOnly, VerifyRelease: boolPtr(true), VerifyTimeout: time.Second}
-	c.afterTagCreated("owner", "repo", "v1.0.0", 1, 0, nil, rel)
+	c.afterTagCreated("owner", "repo", "v1.0.0", 1, 0, nil, rel, "")
 
 	// afterTagCreated returns synchronously without launching a goroutine for
 	// tag_only, so no sleep/wait is needed before asserting.

--- a/internal/autopilot/release_summary.go
+++ b/internal/autopilot/release_summary.go
@@ -74,6 +74,24 @@ func (g *ReleaseSummaryGenerator) SetAPIURL(url string) {
 // from the commit messages, and prepends it to the release body.
 // Returns nil on any failure — release enrichment is best-effort.
 func (g *ReleaseSummaryGenerator) EnrichRelease(ctx context.Context, owner, repo, tag string, commits []*github.Commit) error {
+	return g.enrichRelease(ctx, owner, repo, tag, commits, "")
+}
+
+// EnrichScopeRelease is EnrichRelease's scope-carrier counterpart: on top of
+// prepending the LLM summary, it also inserts scopeNotes (the aggregated
+// scope changelog built by BuildScopeReleaseNotes) ahead of the original
+// body. Needed only for publish mode "workflow" — GoReleaser owns the
+// release's initial body there, so it never contains scope-aware content;
+// "api" mode has Pilot pass scopeNotes as the body at creation time already,
+// so EnrichRelease's plain prepend is sufficient there (GH-3992).
+func (g *ReleaseSummaryGenerator) EnrichScopeRelease(ctx context.Context, owner, repo, tag string, commits []*github.Commit, scopeNotes string) error {
+	return g.enrichRelease(ctx, owner, repo, tag, commits, scopeNotes)
+}
+
+// enrichRelease is the shared body of EnrichRelease/EnrichScopeRelease: poll
+// for the release, generate the LLM summary, and update the body to
+// summary + [scopeNotes] + original body.
+func (g *ReleaseSummaryGenerator) enrichRelease(ctx context.Context, owner, repo, tag string, commits []*github.Commit, scopeNotes string) error {
 	// Poll for GoReleaser to publish the release
 	release, err := g.waitForRelease(ctx, owner, repo, tag)
 	if err != nil {
@@ -86,8 +104,12 @@ func (g *ReleaseSummaryGenerator) EnrichRelease(ctx context.Context, owner, repo
 		return fmt.Errorf("generating summary: %w", err)
 	}
 
-	// Prepend summary to existing GoReleaser changelog body
-	enrichedBody := summary + "\n\n" + release.Body
+	// Prepend summary (and scope notes, when present) to the existing body.
+	enrichedBody := summary
+	if scopeNotes != "" {
+		enrichedBody += "\n\n" + scopeNotes
+	}
+	enrichedBody += "\n\n" + release.Body
 
 	_, err = g.ghClient.UpdateRelease(ctx, owner, repo, release.ID, &github.ReleaseInput{
 		Body: enrichedBody,

--- a/internal/autopilot/release_summary.go
+++ b/internal/autopilot/release_summary.go
@@ -169,10 +169,20 @@ func waitForReleaseByTag(ctx context.Context, ghClient *github.Client, log *slog
 	}
 }
 
+// maxSummaryCommitLines caps how many commit first-lines are sent to the LLM
+// for a "What's New" summary. A scope release can aggregate hundreds of
+// commits across many member PRs; past this cap the prompt cost grows
+// unbounded for no summarization benefit, so only the most recent
+// maxSummaryCommitLines are included (GH-3992).
+const maxSummaryCommitLines = 200
+
 // generateSummary calls Haiku to produce a human-friendly summary from commit messages.
 func (g *ReleaseSummaryGenerator) generateSummary(ctx context.Context, tag string, commits []*github.Commit) (string, error) {
 	if len(commits) == 0 {
 		return fmt.Sprintf("## What's New in %s\n\nMaintenance release.", tag), nil
+	}
+	if len(commits) > maxSummaryCommitLines {
+		commits = commits[len(commits)-maxSummaryCommitLines:]
 	}
 
 	// Build commit list for the prompt

--- a/internal/autopilot/release_summary_test.go
+++ b/internal/autopilot/release_summary_test.go
@@ -147,6 +147,55 @@ func TestReleaseSummaryGenerator_GenerateSummary(t *testing.T) {
 	}
 }
 
+// TestReleaseSummaryGenerator_GenerateSummary_CapsCommitLines verifies the
+// maxSummaryCommitLines guard (GH-3992): a scope release's member-PR commit
+// union can run into the hundreds, and the prompt sent to the LLM must stay
+// bounded to the most recent maxSummaryCommitLines commits.
+func TestReleaseSummaryGenerator_GenerateSummary_CapsCommitLines(t *testing.T) {
+	const total = maxSummaryCommitLines + 100
+
+	commits := make([]*github.Commit, 0, total)
+	for i := 0; i < total; i++ {
+		commits = append(commits, makeCommit(fmt.Sprintf("chore: commit number %d", i)))
+	}
+
+	var capturedBody summaryRequest
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"content":[{"text":"## What's New in v1.0.0\n\n- stuff happened"}]}`)
+	}))
+	defer apiServer.Close()
+
+	gen := NewReleaseSummaryGenerator(nil, testutil.FakeAnthropicKey, slog.Default())
+	gen.SetAPIURL(apiServer.URL)
+
+	if _, err := gen.generateSummary(context.Background(), "v1.0.0", commits); err != nil {
+		t.Fatalf("generateSummary() error = %v", err)
+	}
+
+	promptCommitLines := 0
+	for _, line := range strings.Split(capturedBody.Messages[0].Content, "\n") {
+		if strings.HasPrefix(line, "- ") {
+			promptCommitLines++
+		}
+	}
+	if promptCommitLines != maxSummaryCommitLines {
+		t.Errorf("prompt contains %d commit lines, want %d", promptCommitLines, maxSummaryCommitLines)
+	}
+
+	// Only the most recent maxSummaryCommitLines commits should survive —
+	// the earliest (dropped) commit must be absent, the latest must remain.
+	if strings.Contains(capturedBody.Messages[0].Content, "commit number 0\n") {
+		t.Error("prompt unexpectedly contains the oldest (should-be-dropped) commit")
+	}
+	if !strings.Contains(capturedBody.Messages[0].Content, fmt.Sprintf("commit number %d", total-1)) {
+		t.Error("prompt is missing the most recent commit")
+	}
+}
+
 // testSummaryGenerator is a minimal clone of the LLM call logic for testing with a custom URL.
 type testSummaryGenerator struct {
 	apiKey     string

--- a/internal/autopilot/release_summary_test.go
+++ b/internal/autopilot/release_summary_test.go
@@ -274,6 +274,108 @@ func TestReleaseSummaryGenerator_EnrichRelease(t *testing.T) {
 	}
 }
 
+// TestReleaseSummaryGenerator_EnrichScopeRelease_ComposesInOrder verifies the
+// GH-3992 "workflow" mode enrichment composition: the final release body is
+// LLM summary, then the aggregated scope notes, then GoReleaser's original
+// body — in that order, each separated by a blank line.
+func TestReleaseSummaryGenerator_EnrichScopeRelease_ComposesInOrder(t *testing.T) {
+	var updatedBody string
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"id":42,"tag_name":"v1.1.0","body":"* original goreleaser changelog"}`)
+		case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/releases/42"):
+			var input map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&input)
+			updatedBody, _ = input["body"].(string)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"id":42,"tag_name":"v1.1.0","body":"updated"}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ghServer.Close()
+
+	anthropicServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"content":[{"text":"## What's New in v1.1.0\n\n- Great scope stuff"}]}`)
+	}))
+	defer anthropicServer.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, ghServer.URL)
+	gen := NewReleaseSummaryGenerator(ghClient, testutil.FakeAnthropicKey, slog.Default())
+	gen.SetAPIURL(anthropicServer.URL)
+
+	scopeNotes := "# Epic: Widgets\n\n## Features\n- add resize handle (#10, GH-100)"
+	commits := []*github.Commit{makeCommit("feat(widgets): add resize handle")}
+
+	if err := gen.EnrichScopeRelease(context.Background(), "owner", "repo", "v1.1.0", commits, scopeNotes); err != nil {
+		t.Fatalf("EnrichScopeRelease() error = %v", err)
+	}
+
+	summaryIdx := strings.Index(updatedBody, "What's New")
+	scopeIdx := strings.Index(updatedBody, "Epic: Widgets")
+	originalIdx := strings.Index(updatedBody, "original goreleaser changelog")
+
+	if summaryIdx == -1 || scopeIdx == -1 || originalIdx == -1 {
+		t.Fatalf("updated body missing expected section, got: %q", updatedBody)
+	}
+	if summaryIdx >= scopeIdx || scopeIdx >= originalIdx {
+		t.Errorf("expected order summary < scopeNotes < original body, got indices %d, %d, %d in %q",
+			summaryIdx, scopeIdx, originalIdx, updatedBody)
+	}
+}
+
+// TestReleaseSummaryGenerator_EnrichRelease_NoScopeNotes verifies EnrichRelease
+// (the non-scope path) still prepends only the LLM summary — scope-notes
+// composition is opt-in via EnrichScopeRelease only.
+func TestReleaseSummaryGenerator_EnrichRelease_NoScopeNotes(t *testing.T) {
+	var updatedBody string
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"id":7,"tag_name":"v1.0.0","body":"* original changelog"}`)
+		case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/releases/7"):
+			var input map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&input)
+			updatedBody, _ = input["body"].(string)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"id":7,"tag_name":"v1.0.0","body":"updated"}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ghServer.Close()
+
+	anthropicServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"content":[{"text":"## What's New in v1.0.0\n\n- Great stuff"}]}`)
+	}))
+	defer anthropicServer.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, ghServer.URL)
+	gen := NewReleaseSummaryGenerator(ghClient, testutil.FakeAnthropicKey, slog.Default())
+	gen.SetAPIURL(anthropicServer.URL)
+
+	commits := []*github.Commit{makeCommit("feat: something")}
+	if err := gen.EnrichRelease(context.Background(), "owner", "repo", "v1.0.0", commits); err != nil {
+		t.Fatalf("EnrichRelease() error = %v", err)
+	}
+
+	if !strings.Contains(updatedBody, "What's New") || !strings.Contains(updatedBody, "original changelog") {
+		t.Fatalf("updated body missing expected sections, got: %q", updatedBody)
+	}
+	summaryIdx := strings.Index(updatedBody, "What's New")
+	originalIdx := strings.Index(updatedBody, "original changelog")
+	if summaryIdx >= originalIdx {
+		t.Errorf("expected summary before original body, got: %q", updatedBody)
+	}
+}
+
 func TestReleaseSummaryGenerator_WaitForRelease_Timeout(t *testing.T) {
 	// Server always returns 404 — release never published
 	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/autopilot/scope_notes.go
+++ b/internal/autopilot/scope_notes.go
@@ -1,0 +1,120 @@
+package autopilot
+
+import (
+	"fmt"
+	"strings"
+
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// ScopeMember is one merged member PR contributing to a scope release: its
+// own commits (fetched per-PR so each changelog entry attributes to the
+// exact PR/issue it shipped in, rather than the deduped cross-member union
+// used for bump detection) and the issue number it closed, when known.
+type ScopeMember struct {
+	PR      int
+	Issue   int
+	Commits []*github.Commit
+}
+
+// ScopeNotesInput is the input to BuildScopeReleaseNotes.
+type ScopeNotesInput struct {
+	Owner      string
+	Repo       string
+	ScopeTitle string
+	Members    []ScopeMember
+	LastTag    string
+	NewTag     string
+}
+
+// BuildScopeReleaseNotes renders the aggregated release notes for a scope
+// carrier: a headline, grouped Features/Bug Fixes/Other Changes sections
+// (each entry attributed to its exact source PR and issue), a
+// "## ⚠ Breaking Changes" section when any first-line commit message signals
+// a breaking change (reusing parseBumpFromMessage's breaking predicate — a
+// `!` suffix or BREAKING type prefix; body `BREAKING CHANGE:` footers are out
+// of scope, matching bump detection), and a compare-link + stats footer
+// (GH-3992).
+func BuildScopeReleaseNotes(in ScopeNotesInput) string {
+	headline := in.ScopeTitle
+	if headline == "" {
+		headline = "Release"
+	}
+
+	var features, fixes, others, breaking []string
+	commitCount := 0
+
+	for _, member := range in.Members {
+		for _, commit := range member.Commits {
+			commitCount++
+			msg := commit.Commit.Message
+			if idx := strings.Index(msg, "\n"); idx > 0 {
+				msg = msg[:idx]
+			}
+			attribution := formatScopeAttribution(member.PR, member.Issue)
+
+			matches := conventionalCommitRegex.FindStringSubmatch(msg)
+			if matches == nil {
+				others = append(others, fmt.Sprintf("- %s %s", msg, attribution))
+				continue
+			}
+
+			commitType := strings.ToLower(matches[1])
+			description := matches[4]
+			line := fmt.Sprintf("- %s %s", description, attribution)
+
+			if matches[3] == "!" || strings.HasPrefix(strings.ToUpper(commitType), "BREAKING") {
+				breaking = append(breaking, line)
+			}
+
+			switch commitType {
+			case "feat", "feature":
+				features = append(features, line)
+			case "fix", "bugfix":
+				fixes = append(fixes, line)
+			default:
+				others = append(others, line)
+			}
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("# %s\n", headline))
+
+	if len(features) > 0 {
+		sb.WriteString("\n## Features\n")
+		sb.WriteString(strings.Join(features, "\n"))
+		sb.WriteString("\n")
+	}
+	if len(fixes) > 0 {
+		sb.WriteString("\n## Bug Fixes\n")
+		sb.WriteString(strings.Join(fixes, "\n"))
+		sb.WriteString("\n")
+	}
+	if len(others) > 0 {
+		sb.WriteString("\n## Other Changes\n")
+		sb.WriteString(strings.Join(others, "\n"))
+		sb.WriteString("\n")
+	}
+	if len(breaking) > 0 {
+		sb.WriteString("\n## ⚠ Breaking Changes\n")
+		sb.WriteString(strings.Join(breaking, "\n"))
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString(fmt.Sprintf("\n**Full Changelog**: https://github.com/%s/%s/compare/%s...%s\n",
+		in.Owner, in.Repo, in.LastTag, in.NewTag))
+	sb.WriteString(fmt.Sprintf("\n_%d PRs, %d commits_\n", len(in.Members), commitCount))
+
+	return sb.String()
+}
+
+// formatScopeAttribution renders a changelog entry's source suffix: the PR
+// always, plus the linked issue when known (a member PR whose issue link
+// couldn't be resolved — e.g. a fetch failure — still attributes to its PR).
+func formatScopeAttribution(pr, issue int) string {
+	if issue > 0 {
+		return fmt.Sprintf("(#%d, GH-%d)", pr, issue)
+	}
+	return fmt.Sprintf("(#%d)", pr)
+}

--- a/internal/autopilot/scope_notes_test.go
+++ b/internal/autopilot/scope_notes_test.go
@@ -1,0 +1,134 @@
+package autopilot
+
+import (
+	"strings"
+	"testing"
+
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+func TestBuildScopeReleaseNotes(t *testing.T) {
+	tests := []struct {
+		name           string
+		in             ScopeNotesInput
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name: "features fixes and other grouped with attribution",
+			in: ScopeNotesInput{
+				Owner:      "owner",
+				Repo:       "repo",
+				ScopeTitle: "Epic: Ship Widgets",
+				Members: []ScopeMember{
+					{PR: 10, Issue: 100, Commits: []*github.Commit{makeCommit("feat(widgets): add resize handle")}},
+					{PR: 11, Issue: 101, Commits: []*github.Commit{makeCommit("fix(widgets): correct off-by-one")}},
+					{PR: 12, Issue: 102, Commits: []*github.Commit{makeCommit("chore(deps): bump lodash")}},
+				},
+				LastTag: "v1.0.0",
+				NewTag:  "v1.1.0",
+			},
+			wantContains: []string{
+				"# Epic: Ship Widgets",
+				"## Features",
+				"- add resize handle (#10, GH-100)",
+				"## Bug Fixes",
+				"- correct off-by-one (#11, GH-101)",
+				"## Other Changes",
+				"- bump lodash (#12, GH-102)",
+				"**Full Changelog**: https://github.com/owner/repo/compare/v1.0.0...v1.1.0",
+				"_3 PRs, 3 commits_",
+			},
+			wantNotContain: []string{"⚠ Breaking Changes"},
+		},
+		{
+			name: "breaking change via bang suffix",
+			in: ScopeNotesInput{
+				ScopeTitle: "Scope A",
+				Members: []ScopeMember{
+					{PR: 20, Issue: 200, Commits: []*github.Commit{makeCommit("feat(api)!: remove legacy endpoint")}},
+				},
+				LastTag: "v1.0.0",
+				NewTag:  "v2.0.0",
+			},
+			wantContains: []string{
+				"## ⚠ Breaking Changes",
+				"- remove legacy endpoint (#20, GH-200)",
+				"## Features",
+			},
+		},
+		{
+			name: "breaking change via BREAKING prefix",
+			in: ScopeNotesInput{
+				ScopeTitle: "Scope B",
+				Members: []ScopeMember{
+					{PR: 21, Issue: 201, Commits: []*github.Commit{makeCommit("BREAKING: drop support for v1 tokens")}},
+				},
+				LastTag: "v1.0.0",
+				NewTag:  "v2.0.0",
+			},
+			wantContains: []string{
+				"## ⚠ Breaking Changes",
+				"- drop support for v1 tokens (#21, GH-201)",
+			},
+		},
+		{
+			name: "non-conventional commit lands in Other Changes verbatim",
+			in: ScopeNotesInput{
+				ScopeTitle: "Scope C",
+				Members: []ScopeMember{
+					{PR: 30, Issue: 300, Commits: []*github.Commit{makeCommit("quick typo fix")}},
+				},
+				LastTag: "v1.0.0",
+				NewTag:  "v1.0.1",
+			},
+			wantContains: []string{
+				"## Other Changes",
+				"- quick typo fix (#30, GH-300)",
+			},
+		},
+		{
+			name: "member with no linked issue omits GH- attribution",
+			in: ScopeNotesInput{
+				ScopeTitle: "Scope D",
+				Members: []ScopeMember{
+					{PR: 40, Issue: 0, Commits: []*github.Commit{makeCommit("fix: patch race condition")}},
+				},
+				LastTag: "v1.0.0",
+				NewTag:  "v1.0.1",
+			},
+			wantContains:   []string{"- patch race condition (#40)"},
+			wantNotContain: []string{"GH-0"},
+		},
+		{
+			name: "empty members produce headline, footer, and zero counts",
+			in: ScopeNotesInput{
+				ScopeTitle: "Scope E",
+				LastTag:    "v1.0.0",
+				NewTag:     "v1.0.0",
+			},
+			wantContains: []string{
+				"# Scope E",
+				"**Full Changelog**: https://github.com///compare/v1.0.0...v1.0.0",
+				"_0 PRs, 0 commits_",
+			},
+			wantNotContain: []string{"## Features", "## Bug Fixes", "## Other Changes", "⚠ Breaking Changes"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildScopeReleaseNotes(tt.in)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("BuildScopeReleaseNotes() = %q\nmissing substring %q", got, want)
+				}
+			}
+			for _, notWant := range tt.wantNotContain {
+				if strings.Contains(got, notWant) {
+					t.Errorf("BuildScopeReleaseNotes() = %q\nunexpectedly contains %q", got, notWant)
+				}
+			}
+		})
+	}
+}

--- a/internal/autopilot/scope_release.go
+++ b/internal/autopilot/scope_release.go
@@ -263,6 +263,50 @@ func (c *Controller) scopeReleaseCommits(ctx context.Context, owner, repo string
 	return c.ghClient.CompareCommits(ctx, owner, repo, lastTag, prState.HeadSHA)
 }
 
+// pilotBranchIssueRe extracts the issue number encoded in a Pilot-created
+// branch name of the form "pilot/GH-<N>".
+var pilotBranchIssueRe = regexp.MustCompile(`^pilot/GH-(\d+)$`)
+
+// scopeNotesTitle resolves the human-readable headline for a scope carrier's
+// release notes: the scope's title, falling back to the scope key itself
+// when no title was resolved (GH-3992).
+func scopeNotesTitle(prState *PRState) string {
+	if prState.ScopeTitle != "" {
+		return prState.ScopeTitle
+	}
+	return prState.ScopeKey
+}
+
+// scopeReleaseMembers builds the per-member attribution list consumed by
+// BuildScopeReleaseNotes: each member PR's own commits (fetched individually
+// rather than reusing scopeReleaseCommits's cross-member deduped union, since
+// changelog attribution needs the exact PR/issue a commit shipped in) plus
+// the issue number parsed from its head branch name (Pilot branches are
+// always "pilot/GH-<issue>"). Best-effort — a member whose PR or commits
+// can't be fetched is still included (Issue 0 / no commits) rather than
+// failing the whole release (GH-3992).
+func (c *Controller) scopeReleaseMembers(ctx context.Context, owner, repo string, prState *PRState) []ScopeMember {
+	members := make([]ScopeMember, 0, len(prState.ScopeMemberPRs))
+	for _, pr := range prState.ScopeMemberPRs {
+		issue := 0
+		if pull, err := c.ghClient.GetPullRequest(ctx, owner, repo, pr); err != nil {
+			c.log.Warn("scopeReleaseMembers: failed to fetch member PR, issue link unavailable",
+				"scope", prState.ScopeKey, "member_pr", pr, "error", err)
+		} else if m := pilotBranchIssueRe.FindStringSubmatch(pull.Head.Ref); m != nil {
+			issue, _ = strconv.Atoi(m[1])
+		}
+
+		commits, err := c.ghClient.GetPRCommits(ctx, owner, repo, pr)
+		if err != nil {
+			c.log.Warn("scopeReleaseMembers: failed to fetch member PR commits",
+				"scope", prState.ScopeKey, "member_pr", pr, "error", err)
+		}
+
+		members = append(members, ScopeMember{PR: pr, Issue: issue, Commits: commits})
+	}
+	return members
+}
+
 // markScopeReleaseDone records a scope carrier's successful (or no-op)
 // completion in the state store. tag is "" for a no-op release (BumpNone).
 // No-op when prState is not a scope carrier or no state store is wired.

--- a/internal/autopilot/scope_release_test.go
+++ b/internal/autopilot/scope_release_test.go
@@ -559,3 +559,99 @@ func TestScanRecentlyMergedPRs_SkipsScopeMemberPending(t *testing.T) {
 		t.Errorf("git/refs POST count = %d, want 0 (scanner must not cut a per-merge tag for a scope member)", got)
 	}
 }
+
+// TestScopeCarrier_APIPublish_ReleaseBodyIsAggregatedScopeNotes verifies that
+// under publish mode "api" a scope carrier's release body is
+// BuildScopeReleaseNotes' output — headline, grouped Features/Bug Fixes
+// sections with #PR/GH-issue attribution, the breaking-changes section, and
+// the compare-link + stats footer — passed straight to CreateReleaseForRepo
+// (GH-3992).
+func TestScopeCarrier_APIPublish_ReleaseBodyIsAggregatedScopeNotes(t *testing.T) {
+	var releaseBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/branches/main":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "main", "commit": map[string]string{"sha": "mainsha"}})
+		case r.URL.Path == "/repos/owner/repo/commits/mainsha/check-runs":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: "completed", Conclusion: "success"}},
+			})
+		case r.URL.Path == "/repos/owner/repo/pulls/201":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.PullRequest{Number: 201, Head: github.PRRef{Ref: "pilot/GH-501"}})
+		case r.URL.Path == "/repos/owner/repo/pulls/202":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.PullRequest{Number: 202, Head: github.PRRef{Ref: "pilot/GH-502"}})
+		case strings.HasSuffix(r.URL.Path, "/pulls/201/commits"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat(widgets): add resize handle")})
+		case strings.HasSuffix(r.URL.Path, "/pulls/202/commits"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("fix(widgets)!: correct breaking resize bug")})
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.0.0"})
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(r.URL.Path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "identical"})
+		case strings.HasSuffix(r.URL.Path, "/git/refs"):
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/releases"):
+			var input map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&input)
+			releaseBody, _ = input["body"].(string)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.Release{ID: 1, HTMLURL: "https://github.com/owner/repo/releases/tag/v1.1.0"})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{
+		Enabled: true, Trigger: "on_scope_close", TagPrefix: "v",
+		Publish: ReleasePublishAPI, GenerateChangelog: true,
+		VerifyRelease: boolPtr(false),
+	}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	carrier := &PRState{
+		PRNumber:       202,
+		Stage:          StageReleasing,
+		PostMergeSHA:   "mainsha",
+		ScopeKey:       "epic:1",
+		ScopeTitle:     "Epic: Ship Widgets",
+		ScopeMemberPRs: []int{201, 202},
+	}
+	c.mu.Lock()
+	c.activePRs[202] = carrier
+	c.mu.Unlock()
+
+	if err := c.handleReleasing(context.Background(), carrier); err != nil {
+		t.Fatalf("handleReleasing() error = %v", err)
+	}
+
+	wantContains := []string{
+		"# Epic: Ship Widgets",
+		"## Features",
+		"- add resize handle (#201, GH-501)",
+		"## ⚠ Breaking Changes",
+		"- correct breaking resize bug (#202, GH-502)",
+		"**Full Changelog**: https://github.com/owner/repo/compare/v1.0.0...v1.1.0",
+		"_2 PRs, 2 commits_",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(releaseBody, want) {
+			t.Errorf("release body missing %q, got: %s", want, releaseBody)
+		}
+	}
+}

--- a/internal/autopilot/telegram_notifier.go
+++ b/internal/autopilot/telegram_notifier.go
@@ -119,16 +119,23 @@ func (n *TelegramNotifier) NotifyReleased(ctx context.Context, prState *PRState,
 		bumpLabel = "patch release"
 	}
 
+	// GH-3992: a scope carrier releases on behalf of every member PR, so the
+	// notification names the scope instead of a single source PR.
+	sourceLine := fmt.Sprintf("From PR: #%d", prState.PRNumber)
+	if prState.ScopeTitle != "" {
+		sourceLine = fmt.Sprintf("Scope: %s (%d PRs)", escapeMarkdown(prState.ScopeTitle), len(prState.ScopeMemberPRs))
+	}
+
 	msg := fmt.Sprintf("%s✨ *Release %s Published*\n\n"+
 		"Version: `%s`\n"+
 		"Type: %s\n"+
-		"From PR: #%d\n\n"+
+		"%s\n\n"+
 		"[View Release](%s)",
 		envPrefix(prState),
 		escapeMarkdown(prState.ReleaseVersion),
 		prState.ReleaseVersion,
 		bumpLabel,
-		prState.PRNumber,
+		sourceLine,
 		releaseURL,
 	)
 

--- a/internal/autopilot/telegram_notifier_test.go
+++ b/internal/autopilot/telegram_notifier_test.go
@@ -304,6 +304,40 @@ func TestTelegramNotifier_NotifyReleased(t *testing.T) {
 	}
 }
 
+// TestTelegramNotifier_NotifyReleased_ScopeCarrier verifies that a scope
+// carrier's release notification names the scope and member count instead of
+// a single source PR (GH-3992).
+func TestTelegramNotifier_NotifyReleased_ScopeCarrier(t *testing.T) {
+	var receivedText string
+	notifier, server := newTestNotifier(t, &receivedText)
+	defer server.Close()
+
+	prState := &PRState{
+		PRNumber:        99,
+		ReleaseVersion:  "v2.0.0",
+		ReleaseBumpType: BumpMinor,
+		EnvironmentName: "staging",
+		ScopeKey:        "epic:1",
+		ScopeTitle:      "Epic: Ship Widgets",
+		ScopeMemberPRs:  []int{10, 11, 12},
+	}
+
+	err := notifier.NotifyReleased(context.Background(), prState, "https://github.com/owner/repo/releases/tag/v2.0.0")
+	if err != nil {
+		t.Fatalf("NotifyReleased error: %v", err)
+	}
+
+	wantContains := []string{"Scope: Epic: Ship Widgets (3 PRs)"}
+	for _, want := range wantContains {
+		if !strings.Contains(receivedText, want) {
+			t.Errorf("expected notification to contain %q, got: %s", want, receivedText)
+		}
+	}
+	if strings.Contains(receivedText, "From PR:") {
+		t.Errorf("scope carrier notification should not mention 'From PR:', got: %s", receivedText)
+	}
+}
+
 func TestNewTelegramNotifier(t *testing.T) {
 	client := telegram.NewClient("test-token")
 	notifier := NewTelegramNotifier(client, "123456")


### PR DESCRIPTION
## Summary

- New `internal/autopilot/scope_notes.go`: `BuildScopeReleaseNotes` composes a scope carrier's aggregated release body — headline, grouped `## Features`/`## Bug Fixes`/`## Other Changes` sections with per-commit `(#PR, GH-issue)` attribution, `## ⚠ Breaking Changes` when a first-line commit signals one, and a compare-link + stats footer.
- `handleReleasing`'s scope branch: `publish: api` passes the scope notes straight to `CreateReleaseForRepo` as the body; `publish: workflow` composes them into the LLM enrichment step via the new `ReleaseSummaryGenerator.EnrichScopeRelease` (final body = LLM "What's New" + scope notes + GoReleaser's original body).
- `cmd/pilot/main.go`: wires `SetReleaseSummaryGenerator` (`ANTHROPIC_API_KEY` env, graceful nil when unset) at every autopilot controller construction site — the LLM summary generator was previously never wired.
- `TelegramNotifier.NotifyReleased`: scope carriers now show `Scope: <title> (<K> PRs)` instead of `From PR: #N`.
- `generateSummary` caps its LLM prompt at the 200 most recent commit first-lines — a scope carrier's member-PR commit union has no upper bound otherwise (missing from the prior attempt, added in the last commit here).
- `configs/pilot.example.yaml` + docs (`autopilot-environments.mdx`, `configuration.mdx`): document `on_scope_close`/`on_schedule`, `scope_label_prefix`, `schedule`, per-project trigger overlay, and the requirement that scope notes need `publish: workflow` or `api` (not `tag_only`).

Part of TASK-389 (release cycles). Closes #3992 (blocked by #3990, both merged).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full repo, including `stress/`)
- [x] `golangci-lint run` — 0 issues
- [x] `TestBuildScopeReleaseNotes` (grouping/breaking/attribution/footer table)
- [x] `TestReleaseSummaryGenerator_EnrichScopeRelease_ComposesInOrder` / `TestReleaseSummaryGenerator_EnrichRelease_NoScopeNotes` (enrichment composition order)
- [x] `TestReleaseSummaryGenerator_GenerateSummary_CapsCommitLines` (new — verifies the 200-line cap)
- [x] `TestTelegramNotifier_NotifyReleased_ScopeCarrier`
- [x] Existing per-merge (non-scope) release/notifier tests pass unchanged — byte-identical body confirmed