### PR TITLE
feat(autopilot): release automation is per-project opt-in (GH-4001)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-07 (v2.151.0)
+**Last Updated:** 2026-07-06 (v2.151.0)
 
 ## Legend
 
@@ -406,9 +406,7 @@
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
-| Release cycles: trigger config + hold semantics | ✅ | autopilot | - | `release.trigger`, `release.scope_label_prefix`, `release.schedule`, `release.schedule_timezone` | `on_scope_close`/`on_schedule` triggers hold merges at all four release-decision sites (`handleMerged` fast path, `handlePostMergeCI`, `checkExternalMergeOrClose`, `ScanRecentlyMergedPRs`) via `Controller.releaseActionFor`/`heldByScope`; held work is inert-but-safe (fully reconstructable from GitHub) — the scope-close reconciler and cron scheduler that actually fire the release ship in follow-up issues. `on_merge` behavior is byte-identical (v2.226.x, GH-3989) |
-| Scope release carrier execution | ✅ | autopilot | - | `autopilot.release.trigger: on_scope_close` | `autopilot_scope_release` durable table (pending→releasing→done/failed) + `startPendingScopeReleases`/`handleReleasing` cut ONE tag covering every held member once an epic completes, gated on post-merge-CI-validated main SHA; crash-safe (claim+re-drive), capped retries with `scope_release_failed` alert (GH-3990) |
-| Label-scope release reconciler | ✅ | autopilot | - | `release.scope_label_prefix`, `release.scope_stale_after` | `reconcileLabelScopes` completes `scope:<name>` label groups with no epic parent — every member closed+shipped enqueues one scope release; abandoned scopes (shipped + stale open member) fire a deduped `scope_stale` alert (GH-3991, v2.229.0) |
+| Per-project release opt-in | ✅ | autopilot | - | `projects[].release` | Global/env `release:` cascade applies only to the default repo; `projects:` controllers release only with their own `release:` block (`WithReleaseNotOptedIn` forces disabled otherwise). Startup logs tag posture as `source=project-not-opted-in`; WARN emitted per non-opted-in project when global release is enabled (v2.230.0, GH-4001) |
 
 ## Epic Management
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1700,6 +1700,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				}
 			}
 
+			// GH-4001: release automation is per-project opt-in for projects-loop
+			// controllers — resolved once here so the WARN below fires only when
+			// global release would otherwise have cascaded to a non-opted-in repo.
+			globalReleaseEnabled := autopilot.GlobalReleaseEnabled(cfg.Orchestrator.Autopilot)
+
 			// GH-929: Create controllers for each project with GitHub config
 			for _, proj := range cfg.Projects {
 				if proj.GitHub == nil || proj.GitHub.Owner == "" || proj.GitHub.Repo == "" {
@@ -1712,9 +1717,23 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				// TASK-352: scope self-heal to this project's fs path (matches
 				// executions.project_path). Fresh slice to avoid aliasing the shared opts.
 				ctrlOpts := append(append([]autopilot.ControllerOption{}, autopilotBoardOpts...), autopilot.WithProjectPath(proj.Path))
-				// GH-3931: apply the per-project release overlay (GH-3930) when configured.
+				// GH-4001: a project's own `release:` block keeps today's overlay
+				// semantics (GH-3931/GH-3930); no block means this repo never
+				// opted into release automation and must not inherit the
+				// global/env cascade — two incidents (studio-sdk 2026-07-06,
+				// Navigator 2026-07-07 near-miss) came from a forgotten repo
+				// silently releasing.
 				if proj.Release != nil {
 					ctrlOpts = append(ctrlOpts, autopilot.WithReleaseOverride(proj.Release))
+				} else {
+					ctrlOpts = append(ctrlOpts, autopilot.WithReleaseNotOptedIn())
+					if globalReleaseEnabled {
+						logging.WithComponent("autopilot").Warn(
+							"project has no release: block — it will NOT auto-release even though global release is enabled (GH-4001); add a release block to opt in",
+							slog.String("project", proj.Name),
+							slog.String("repo", repoFullName),
+						)
+					}
 				}
 				controller := autopilot.NewController(
 					cfg.Orchestrator.Autopilot,

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -501,6 +501,18 @@ projects:
   # tag-triggered release workflow of its own, so Pilot publishes the GitHub
   # Release directly via the API.
   #
+  # OPT-IN REQUIRED (GH-4001): this applies ONLY to `projects:` entries
+  # (below) — a project listed here with NO `release:` block never tags or
+  # releases, even when autopilot.release above is enabled. The global
+  # release config only cascades to the default repo (adapters.github.repo).
+  # This is intentional: a repo added to `projects:` for issue-polling/PR
+  # automation but never meant to auto-release (e.g. a plugin repo whose
+  # releases drive an auto-updater) must not silently start tagging just
+  # because global release got turned on for other repos. To opt a project
+  # in, add at minimum `release: { enabled: true }` (or any block below —
+  # setting any field opts the project in and inherits the rest from the
+  # resolved env/global config).
+  #
   # `trigger`, `scope_label_prefix`, `schedule`, and `schedule_timezone` are
   # also overlayable here (GH-3989) - release cadence is per-repo by design,
   # so one repo can run `on_merge` while another in the same autopilot config

--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -566,6 +566,8 @@ orchestrator:
 | `release.generate_changelog` | bool | `true` | Auto-generate changelog |
 | `release.require_ci` | bool | `true` | Require CI pass before release |
 
+**Release automation is per-project opt-in.** The `orchestrator.autopilot.release` block above only applies to the default repo (`adapters.github.repo`). Any additional repo listed under top-level `projects:` releases only if that project declares its own `release:` block — even an empty `release: {}` — which then inherits the rest of its settings from the resolved env/global config above. A project with no `release:` block never tags or releases, regardless of the global setting; startup logs show the resolved posture per repo (`resolved release policy ... source=project-not-opted-in` vs `source=global`/`...+project-overlay`). See the `projects:` section for the per-project overlay syntax.
+
 ---
 
 ## Quality
@@ -1793,7 +1795,31 @@ memory:
 | `projects[].navigator` | bool | `false` | Enable context intelligence for this project |
 | `projects[].github.owner` | string | — | GitHub organization or user |
 | `projects[].github.repo` | string | — | GitHub repository name |
+| `projects[].release` | object | — | Per-project release overlay (opt-in — see below) |
 | `default_project` | string | — | Name of the project used when none is specified |
+
+**Release opt-in (GH-4001)**
+
+A project in `projects:` never auto-releases unless it declares its own
+`release:` block, even if `orchestrator.autopilot.release.enabled` is
+`true` globally:
+
+```yaml
+projects:
+  - name: "backend"
+    path: "/path/to/backend"
+    github:
+      owner: "myorg"
+      repo: "backend"
+    release:
+      enabled: true   # opts this repo into the global/env release cascade
+```
+
+An empty `release: {}` is enough to opt in — every other field then
+inherits from the resolved env/global config. Omitting `release:` entirely
+disables release automation for that repo regardless of global settings;
+Pilot logs the resolved posture per repo at startup
+(`resolved release policy ... source=project-not-opted-in`).
 
 **Repo allowlist guardrail**
 

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -176,6 +176,25 @@ func WithReleaseOverride(o *ProjectReleaseConfig) ControllerOption {
 	}
 }
 
+// WithReleaseNotOptedIn marks this controller's repo as NOT opted into
+// release automation via a project-level `release:` block (GH-4001).
+// Release automation for projects-loop controllers is per-project opt-in: a
+// repo with no `release:` block must never inherit the global/env cascade
+// (a forgotten repo silently tagging releases has caused two incidents —
+// studio-sdk 2026-07-06, Navigator 2026-07-07 near-miss). This forces the
+// resolved release config to disabled regardless of global/env settings,
+// and tags the "resolved release policy" startup log with
+// source=project-not-opted-in so the posture is loud and greppable rather
+// than silently inherited. Do not combine with WithReleaseOverride on the
+// same controller — whichever option runs last wins.
+func WithReleaseNotOptedIn() ControllerOption {
+	return func(c *Controller) {
+		disabled := false
+		c.projectRelease = &ProjectReleaseConfig{Enabled: &disabled}
+		c.releaseNotOptedIn = true
+	}
+}
+
 // Controller orchestrates the autopilot loop for PR processing.
 // It manages the state machine: PR created → CI check → merge → post-merge CI → feedback loop.
 type Controller struct {
@@ -245,6 +264,12 @@ type Controller struct {
 	// wired via WithReleaseOverride. Nil = no project-level override. Applied
 	// once during NewController — see resolvedReleaseCfg. GH-3926.
 	projectRelease *ProjectReleaseConfig
+
+	// releaseNotOptedIn is true when projectRelease was synthesized by
+	// WithReleaseNotOptedIn rather than a real per-project `release:` block
+	// (GH-4001). Only affects the "resolved release policy" log source tag —
+	// resolvedReleaseCfg is already forced disabled either way.
+	releaseNotOptedIn bool
 
 	// resolvedReleaseCfg is the effective release config computed once in
 	// NewController: env-scoped config wins over global, then projectRelease
@@ -339,9 +364,14 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 	relCfg := baseRelCfg
 	if c.projectRelease != nil {
 		relCfg = c.projectRelease.Apply(baseRelCfg)
-		if relSource == "none" {
+		switch {
+		case c.releaseNotOptedIn:
+			// GH-4001: no per-project `release:` block — never inherit the
+			// global/env cascade, regardless of relSource above.
+			relSource = "project-not-opted-in"
+		case relSource == "none":
 			relSource = "project-only"
-		} else {
+		default:
 			relSource += "+project-overlay"
 		}
 	}
@@ -2277,6 +2307,16 @@ func resolveRelease(cfg *Config) *ReleaseConfig {
 		return env.Release
 	}
 	return cfg.Release
+}
+
+// GlobalReleaseEnabled reports whether the resolved env/global release
+// config is enabled, ignoring any per-project overlay. main.go's
+// projects-loop wiring (GH-4001) uses this to decide whether a project with
+// no `release:` block needs a migration WARN — that project used to inherit
+// this cascade and, as of GH-4001, no longer does.
+func GlobalReleaseEnabled(cfg *Config) bool {
+	rel := resolveRelease(cfg)
+	return rel != nil && rel.Enabled
 }
 
 // resolvedRelease returns the effective release config: per-environment config

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -1,11 +1,13 @@
 package autopilot
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -224,6 +226,103 @@ func TestResolvedRelease_Precedence(t *testing.T) {
 			t.Error("releaser should be initialized when the project overlay alone enables release")
 		}
 	})
+}
+
+// TestWithReleaseNotOptedIn verifies GH-4001: a projects-loop controller
+// wired with WithReleaseNotOptedIn (i.e. the project declares no `release:`
+// block) must never inherit the global/env release cascade, and the
+// "resolved release policy" log must tag it distinctly
+// (source=project-not-opted-in) from an explicit `release: { enabled: false }`
+// overlay, even though both resolve to the same disabled outcome.
+func TestWithReleaseNotOptedIn(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+
+	t.Run("forces disabled even when global release is enabled", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge"}
+
+		c := NewController(cfg, ghClient, nil, "owner", "repo", WithReleaseNotOptedIn())
+
+		rel := c.resolvedRelease()
+		if rel == nil || rel.Enabled {
+			t.Fatalf("resolvedRelease() = %+v, want disabled", rel)
+		}
+		if c.releaser != nil {
+			t.Error("releaser should be nil when the project has not opted in")
+		}
+	})
+
+	t.Run("logs source=project-not-opted-in", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+		prev := slog.Default()
+		slog.SetDefault(slog.New(h))
+		defer slog.SetDefault(prev)
+
+		cfg := DefaultConfig()
+		cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge"}
+		NewController(cfg, ghClient, nil, "owner", "repo", WithReleaseNotOptedIn())
+
+		out := buf.String()
+		if !strings.Contains(out, "source=project-not-opted-in") {
+			t.Errorf("expected source=project-not-opted-in in log, got: %s", out)
+		}
+	})
+
+	t.Run("explicit release:false overlay is tagged project-overlay, not not-opted-in", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+		prev := slog.Default()
+		slog.SetDefault(slog.New(h))
+		defer slog.SetDefault(prev)
+
+		cfg := DefaultConfig()
+		cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge"}
+		disabled := false
+		c := NewController(cfg, ghClient, nil, "owner", "repo", WithReleaseOverride(&ProjectReleaseConfig{Enabled: &disabled}))
+
+		rel := c.resolvedRelease()
+		if rel == nil || rel.Enabled {
+			t.Fatalf("resolvedRelease() = %+v, want disabled", rel)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "source=global+project-overlay") {
+			t.Errorf("expected source=global+project-overlay in log, got: %s", out)
+		}
+		if strings.Contains(out, "project-not-opted-in") {
+			t.Errorf("explicit disable must not be tagged project-not-opted-in, got: %s", out)
+		}
+	})
+}
+
+// TestGlobalReleaseEnabled covers GH-4001's migration-WARN gate: main.go
+// only warns about a non-opted-in project when the global/env release
+// cascade it would have inherited is actually enabled.
+func TestGlobalReleaseEnabled(t *testing.T) {
+	tests := []struct {
+		name          string
+		globalRelease *ReleaseConfig
+		envRelease    *ReleaseConfig
+		want          bool
+	}{
+		{name: "neither set", want: false},
+		{name: "global enabled", globalRelease: &ReleaseConfig{Enabled: true}, want: true},
+		{name: "global disabled", globalRelease: &ReleaseConfig{Enabled: false}, want: false},
+		{name: "env enabled overrides global disabled", globalRelease: &ReleaseConfig{Enabled: false}, envRelease: &ReleaseConfig{Enabled: true}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Release = tt.globalRelease
+			if tt.envRelease != nil {
+				cfg.activeEnvName = "test"
+				cfg.activeEnvConfig = &EnvironmentConfig{Release: tt.envRelease}
+			}
+			if got := GlobalReleaseEnabled(cfg); got != tt.want {
+				t.Errorf("GlobalReleaseEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestController_OnPRCreated(t *testing.T) {


### PR DESCRIPTION
## Summary
- Flips the release-config polarity: `orchestrator.autopilot.release` (global/env) now cascades only to the default repo's controllers (gateway + polling default). Projects-loop controllers release only when their own `projects[].release` block is present.
- Adds `WithReleaseNotOptedIn()` controller option, which forces the resolved release config to disabled and tags the "resolved release policy" startup log with `source=project-not-opted-in`, distinct from an explicit `release: { enabled: false }` overlay (`source=global+project-overlay`).
- Adds `autopilot.GlobalReleaseEnabled()` helper; `cmd/pilot/main.go`'s projects-loop wiring uses it to emit a startup WARN per non-opted-in project only when the global/env cascade it would have inherited pre-GH-4001 is actually enabled.
- Documents opt-in semantics in `configs/pilot.example.yaml` and `docs/content/getting-started/configuration.mdx`.

Two incidents motivated this: autopilot tagged v0.29.0 on studio-sdk with no release workflow configured (2026-07-06), and the Navigator plugin repo was one config flag away from the same failure mode, which would have poisoned its plugin auto-updater (2026-07-07 near-miss).

**BREAKING CHANGE:** multi-repo configs relying on the global release cascade reaching `projects[]` entries must add an explicit `release:` block (even an empty `release: {}`) to each project that should keep auto-releasing.

## Test plan
- [x] `go test ./internal/autopilot/... ./internal/config/... ./cmd/...` — green
- [x] `make lint` — 0 issues
- [x] `TestWithReleaseNotOptedIn` — forces disabled even when global release enabled; logs `source=project-not-opted-in`; explicit `release:false` overlay tagged distinctly (`source=global+project-overlay`)
- [x] `TestGlobalReleaseEnabled` — table-driven precedence (global/env/neither)
- [x] Default repo (gateway + polling-default) controller construction unchanged — byte-identical for single-repo configs (no `projects:` list)

Refs: TASK-389 design session · #3926 (publish modes) · #3931 (override wiring)