### PR TITLE
feat(autopilot): aggregated scope release notes + wire LLM What's New summary + scope notifications

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-07 (v2.151.0)
+**Last Updated:** 2026-07-06 (v2.151.0)
 
 ## Legend
 
@@ -407,6 +407,12 @@
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
 | Per-project release opt-in | ✅ | autopilot | - | `projects[].release` | Global/env `release:` cascade applies only to the default repo; `projects:` controllers release only with their own `release:` block (`WithReleaseNotOptedIn` forces disabled otherwise). Startup logs tag posture as `source=project-not-opted-in`; WARN emitted per non-opted-in project when global release is enabled (v2.230.0, GH-4001) |
+| Release cycles: trigger config + hold semantics | ✅ | autopilot | - | `release.trigger`, `release.scope_label_prefix`, `release.schedule`, `release.schedule_timezone` | `on_scope_close`/`on_schedule` triggers hold merges at all four release-decision sites (`handleMerged` fast path, `handlePostMergeCI`, `checkExternalMergeOrClose`, `ScanRecentlyMergedPRs`) via `Controller.releaseActionFor`/`heldByScope`; held work is inert-but-safe (fully reconstructable from GitHub) — the scope-close reconciler and cron scheduler that actually fire the release ship in follow-up issues. `on_merge` behavior is byte-identical (v2.226.x, GH-3989) |
+| Scope release carrier execution | ✅ | autopilot | - | `autopilot.release.trigger: on_scope_close` | `autopilot_scope_release` durable table (pending→releasing→done/failed) + `startPendingScopeReleases`/`handleReleasing` cut ONE tag covering every held member once an epic completes, gated on post-merge-CI-validated main SHA; crash-safe (claim+re-drive), capped retries with `scope_release_failed` alert (GH-3990) |
+| Label-scope release reconciler | ✅ | autopilot | - | `release.scope_label_prefix`, `release.scope_stale_after` | `reconcileLabelScopes` completes `scope:<name>` label groups with no epic parent — every member closed+shipped enqueues one scope release; abandoned scopes (shipped + stale open member) fire a deduped `scope_stale` alert (GH-3991, v2.229.0) |
+| Aggregated scope release notes | ✅ | autopilot | - | `release.publish` (workflow/api, not tag_only) | `BuildScopeReleaseNotes` renders headline + grouped Features/Fixes/Other with exact #PR+GH-issue attribution + ⚠ Breaking Changes + compare-link/stats footer for a scope carrier's release; `publish: api` ships it as the release body directly, `publish: workflow` splices it into GoReleaser's body via `EnrichScopeRelease` (v2.230.0, GH-3992) |
+| Release "What's New" LLM wiring | ✅ | autopilot, cmd/pilot | - | `release.generate_summary`, `ANTHROPIC_API_KEY` | `NewReleaseSummaryGenerator` wired at every autopilot controller construction site (gateway + CLI/per-project); nil generator when `ANTHROPIC_API_KEY` unset — releases ship without a summary. Commit list capped at 200 first-lines per prompt (v2.230.0, GH-3992) |
+| Scope-carrier release notification | ✅ | autopilot | - | - | Telegram `NotifyReleased` renders `Scope: <title> (<K> PRs)` instead of `From PR: #N` when `prState.ScopeTitle != ""` (v2.230.0, GH-3992) |
 
 ## Epic Management
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -657,6 +657,16 @@ Examples:
 							// GH-2685: wire the controller as the approval state writer so
 							// async approval decisions update the in-memory PRState.
 							approvalMgr.WithStateWriter(gwAutopilotController)
+							// GH-3992: wire the LLM release-summary generator (Haiku
+							// "What's New") so releases (including scope carriers) get
+							// enriched. NewReleaseSummaryGenerator returns nil when no
+							// ANTHROPIC_API_KEY is set — SetReleaseSummaryGenerator(nil)
+							// is a no-op guard already handled throughout handleReleasing,
+							// so this is graceful no-op-by-default (env-fallback precedent:
+							// internal/comms/factory.go BuildClassifier).
+							gwAutopilotController.SetReleaseSummaryGenerator(
+								autopilot.NewReleaseSummaryGenerator(apGHClient, os.Getenv("ANTHROPIC_API_KEY"), logging.WithComponent("autopilot")),
+							)
 						}
 					}
 				}
@@ -1748,6 +1758,18 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					slog.String("project", proj.Name),
 					slog.String("repo", repoFullName),
 				)
+			}
+
+			// GH-3992: wire the LLM release-summary generator (Haiku "What's
+			// New") into every controller sharing this apGHClient/token. Built
+			// once and reused — EnrichRelease/EnrichScopeRelease take
+			// owner/repo per call, so one generator serves every repo. Nil
+			// ANTHROPIC_API_KEY => NewReleaseSummaryGenerator returns nil =>
+			// SetReleaseSummaryGenerator(nil), identical to today's behavior
+			// (env-fallback precedent: internal/comms/factory.go BuildClassifier).
+			releaseSummaryGen := autopilot.NewReleaseSummaryGenerator(apGHClient, os.Getenv("ANTHROPIC_API_KEY"), logging.WithComponent("autopilot"))
+			for _, c := range autopilotControllers {
+				c.SetReleaseSummaryGenerator(releaseSummaryGen)
 			}
 		}
 	}

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -559,7 +559,9 @@ autopilot:
     #                    `schedule` below). No scheduler ships in this issue
     #                    either; the hold is inert-but-safe until it does.
     trigger: on_merge
-    # scope_label_prefix: "scope:"       # on_scope_close only; default "scope:"
+    # scope_label_prefix: "scope:"       # on_scope_close only; groups sibling issues sharing a
+    #                                     # "scope:<name>" label into one release (GH-3991), same
+    #                                     # as an open epic parent; default "scope:"
     # schedule: "0 21 * * FRI"           # on_schedule only; robfig/cron/v3 standard (5-field) syntax
     # schedule_timezone: "Europe/Berlin" # on_schedule only; empty = daemon local time
     version_strategy: conventional_commits
@@ -567,6 +569,11 @@ autopilot:
     generate_changelog: true
     notify_on_release: true
     require_ci: true
+    # generate_summary prepends an LLM "## What's New" section (Haiku, via the
+    # ANTHROPIC_API_KEY env var) to every release, including aggregated
+    # scope-release notes. No ANTHROPIC_API_KEY in the daemon's environment
+    # => the generator is nil and releases ship without a summary — the tag,
+    # changelog, and scope notes are unaffected (GH-3992).
     generate_summary: true
     # Who actually publishes the GitHub Release once the tag is created:
     #   workflow  (default when empty) - Pilot only creates the tag; the repo's
@@ -580,6 +587,9 @@ autopilot:
     #             GoReleaser).
     #   tag_only  - the tag is created and nothing publishes a release; use
     #             for repos with an intentionally manual release process.
+    #             NOTE: aggregated scope-release notes (GH-3992) require
+    #             publish: workflow or publish: api — tag_only never creates
+    #             a GitHub Release object for the notes to attach to.
     publish: workflow
     # Opt-in: also consider merged PRs whose head branch is NOT pilot/* for
     # release tagging (GH-3928). Default false - zero behavior change; only

--- a/docs/content/features/autopilot-environments.mdx
+++ b/docs/content/features/autopilot-environments.mdx
@@ -122,6 +122,10 @@ orchestrator:
       require_ci: true           # wait for post-merge CI
 ```
 
+<Callout type="info">
+  `release.trigger` also supports `on_scope_close` (hold merges for an open epic or a shared `scope:`-prefixed label, then cut one aggregated release with a "What's New" summary and per-PR/issue changelog) and `on_schedule` (hold everything for a cron release train). See [Configuration → Autopilot](/getting-started/configuration#autopilot) for `scope_label_prefix`, `schedule`, and the `publish` modes each trigger supports.
+</Callout>
+
 ### When to Use
 
 - Team projects with shared staging branches

--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -24,6 +24,7 @@ Pilot delegates AI execution to **Claude Code**, which manages its own authentic
 | **Telegram** | `TELEGRAM_BOT_TOKEN` env var or config | No |
 | **LLM classifier** (smart intent routing) | `ANTHROPIC_API_KEY` env var | No — falls back to keyword matching |
 | **Epic decomposition** (Haiku subtask parser) | `ANTHROPIC_API_KEY` env var | No — falls back to regex parser |
+| **Release summaries** (Haiku "What's New" section) | `ANTHROPIC_API_KEY` env var | No — releases ship without a summary |
 | **Discord** | `DISCORD_BOT_TOKEN` env var or `adapters.discord.bot_token` in config | Yes, if using Discord |
 | **Plane** | `PLANE_API_KEY` env var or `adapters.plane.api_key` in config | Yes, if using Plane |
 
@@ -38,7 +39,7 @@ Pilot delegates AI execution to **Claude Code**, which manages its own authentic
 | `GITHUB_TOKEN` | GitHub personal access token (`repo` + `workflow` scopes) | If using GitHub |
 | `GITLAB_TOKEN` | GitLab personal or project access token | If using GitLab |
 | `TELEGRAM_BOT_TOKEN` | Telegram bot token for chat interface | No |
-| `ANTHROPIC_API_KEY` | Enables LLM intent classifier and structured subtask parsing | No |
+| `ANTHROPIC_API_KEY` | Enables LLM intent classifier, structured subtask parsing, and the release-summary "What's New" generator | No |
 | `OPENAI_API_KEY` | Enables Whisper voice transcription in Telegram | No |
 | `SLACK_BOT_TOKEN` | Slack bot token for notifications | No |
 | `DISCORD_BOT_TOKEN` | Discord bot token for chat interface | No |
@@ -532,12 +533,16 @@ orchestrator:
 
     release:
       enabled: false
-      trigger: "on_merge"
+      trigger: "on_merge"                 # on_merge, manual, on_scope_close, on_schedule
+      scope_label_prefix: "scope:"        # on_scope_close only
+      # schedule: "0 21 * * FRI"          # on_schedule only — robfig/cron/v3 5-field syntax
       version_strategy: "conventional_commits"
       tag_prefix: "v"
       generate_changelog: true
+      generate_summary: true              # LLM "What's New" section (needs ANTHROPIC_API_KEY)
       notify_on_release: true
       require_ci: true
+      publish: "workflow"                 # workflow, api, tag_only
 ```
 
 | Field | Type | Default | Description |
@@ -560,11 +565,22 @@ orchestrator:
 | `approval_timeout` | duration | `1h` | Time before approval request expires |
 | `merged_pr_scan_window` | duration | `30m` | Window to scan for recently merged PRs |
 | `release.enabled` | bool | `false` | Auto-create releases on merge |
-| `release.trigger` | string | `"on_merge"` | When to trigger release |
+| `release.trigger` | string | `"on_merge"` | `on_merge` — release every merged PR. `manual` — never auto-release. `on_scope_close` — hold merges belonging to an open epic (parent issue) or a shared `scope:`-prefixed label and cut one aggregated release when the scope completes; standalone merges still release per-merge. `on_schedule` — hold every merge for a cron release train (see `schedule`) |
+| `release.scope_label_prefix` | string | `"scope:"` | `on_scope_close` only — label prefix that groups sibling issues (no epic parent) into one release scope |
+| `release.schedule` | string | — | `on_schedule` only — robfig/cron/v3 standard 5-field cron expression for the release train |
+| `release.schedule_timezone` | string | daemon local | `on_schedule` only — IANA timezone the `schedule` cron expression is evaluated in |
 | `release.version_strategy` | string | `"conventional_commits"` | How to determine version bump |
 | `release.tag_prefix` | string | `"v"` | Git tag prefix |
 | `release.generate_changelog` | bool | `true` | Auto-generate changelog |
+| `release.generate_summary` | bool | `true` | Prepend an LLM "What's New" section (Haiku, via `ANTHROPIC_API_KEY`) — no key set means releases ship without a summary |
 | `release.require_ci` | bool | `true` | Require CI pass before release |
+| `release.publish` | string | `"workflow"` | `workflow` — Pilot only tags; the repo's own tag-triggered CI (e.g. GoReleaser) publishes the release. `api` — Pilot publishes the GitHub Release itself immediately after tagging (only for repos with no tag-triggered release workflow). `tag_only` — push the tag, publish nothing |
+
+<Callout type="warning">
+Aggregated scope-release notes (`on_scope_close`/`on_schedule`) require `release.publish: workflow` or `release.publish: api` — `tag_only` never creates a GitHub Release object for the notes to attach to.
+</Callout>
+
+Per-project overlays (under `projects:`) can override any `release.*` field for a single repo — for example, a repo with no GoReleaser workflow can set `release: { publish: api }` while the global default stays `workflow`. The same applies to `trigger`: one project can use `on_scope_close` while another stays on `on_merge`.
 
 **Release automation is per-project opt-in.** The `orchestrator.autopilot.release` block above only applies to the default repo (`adapters.github.repo`). Any additional repo listed under top-level `projects:` releases only if that project declares its own `release:` block — even an empty `release: {}` — which then inherits the rest of its settings from the resolved env/global config above. A project with no `release:` block never tags or releases, regardless of the global setting; startup logs show the resolved posture per repo (`resolved release policy ... source=project-not-opted-in` vs `source=global`/`...+project-overlay`). See the `projects:` section for the per-project overlay syntax.
 
@@ -1795,7 +1811,7 @@ memory:
 | `projects[].navigator` | bool | `false` | Enable context intelligence for this project |
 | `projects[].github.owner` | string | — | GitHub organization or user |
 | `projects[].github.repo` | string | — | GitHub repository name |
-| `projects[].release` | object | — | Per-project release overlay (opt-in — see below) |
+| `projects[].release` | object | — | Per-project release overlay (opt-in — see below) — any field, e.g. `trigger`, `publish`, `scope_label_prefix`; lets one repo use `on_scope_close`/`publish: api` while others stay on the global default |
 | `default_project` | string | — | Name of the project used when none is specified |
 
 **Release opt-in (GH-4001)**

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2606,13 +2606,36 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 
 	releaseURL := fmt.Sprintf("https://github.com/%s/%s/releases/tag/%s", owner, repo, tagName)
 
+	// GH-3992: a scope carrier's release body is the aggregated scope release
+	// notes (headline, grouped Features/Fixes/Other with #PR+GH-issue links,
+	// breaking changes, compare footer) rather than GenerateChangelog's
+	// per-PR output. Built once here — publish mode "api" ships it directly
+	// as the release body below; publish mode "workflow" hands it to
+	// afterTagCreated so enrichReleaseNotes can splice it into the
+	// GoReleaser-owned body once the release appears.
+	var scopeNotesBody string
+	if isScope {
+		scopeNotesBody = BuildScopeReleaseNotes(ScopeNotesInput{
+			Owner:      owner,
+			Repo:       repo,
+			ScopeKey:   prState.ScopeKey,
+			ScopeTitle: prState.ScopeTitle,
+			Members:    c.scopeReleaseMembers(ctx, owner, repo, prState),
+			LastTag:    currentVersion.String(rel.TagPrefix),
+			NewTag:     tagName,
+		})
+	}
+
 	// GH-3926: branch on the resolved publish mode. "workflow" (default)
 	// preserves the original behavior byte-for-byte — Pilot only tags, the
 	// repo's own tag-triggered CI (e.g. GoReleaser) publishes the release.
 	switch rel.PublishMode() {
 	case ReleasePublishAPI:
 		body := ""
-		if rel.GenerateChangelog {
+		switch {
+		case isScope:
+			body = scopeNotesBody
+		case rel.GenerateChangelog:
 			body = GenerateChangelog(commits, prState.PRNumber)
 		}
 		release, relErr := c.releaser.CreateReleaseForRepo(ctx, owner, repo, tagName, body)
@@ -2655,7 +2678,7 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 	// Enrichment + post-tag release verification (GH-3927), unified into a
 	// single goroutine so "workflow" mode polls for the release exactly once
 	// (afterTagCreated does not launch anything for "tag_only").
-	c.afterTagCreated(owner, repo, tagName, prState.PRNumber, prState.IssueNumber, commits, rel)
+	c.afterTagCreated(owner, repo, tagName, prState.PRNumber, prState.IssueNumber, commits, rel, scopeNotesBody)
 
 	// Send notification
 	if rel.NotifyOnRelease && c.notifier != nil {
@@ -2794,14 +2817,14 @@ func (c *Controller) escalateReleasingFailed(ctx context.Context, prState *PRSta
 // handleReleasing was called with) so a poll-tick cancellation cannot kill
 // verification or enrichment mid-flight — mirrors the pre-existing enrichment
 // goroutine this replaces.
-func (c *Controller) afterTagCreated(owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig) {
+func (c *Controller) afterTagCreated(owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig, scopeNotesBody string) {
 	if rel.PublishMode() == ReleasePublishTagOnly {
 		return
 	}
 
 	if rel.PublishMode() == ReleasePublishAPI {
 		logging.SafeGo("autopilot-controller", func() {
-			c.enrichReleaseNotes(owner, repo, tagName, commits, rel)
+			c.enrichReleaseNotes(owner, repo, tagName, commits, rel, scopeNotesBody)
 		})
 		return
 	}
@@ -2812,20 +2835,33 @@ func (c *Controller) afterTagCreated(owner, repo, tagName string, prNumber, issu
 		timeout = releasePollTimeout
 	}
 	logging.SafeGo("autopilot-controller", func() {
-		c.verifyReleaseAfterTag(context.Background(), owner, repo, tagName, prNumber, issueNumber, commits, rel, releasePollInterval, timeout)
+		c.verifyReleaseAfterTag(context.Background(), owner, repo, tagName, prNumber, issueNumber, commits, rel, releasePollInterval, timeout, scopeNotesBody)
 	})
 }
 
 // enrichReleaseNotes generates and attaches an LLM release summary. Best-effort:
 // logs and returns on failure rather than propagating an error, since a missing
 // summary should never affect release state.
-func (c *Controller) enrichReleaseNotes(owner, repo, tagName string, commits []*github.Commit, rel *ReleaseConfig) {
+//
+// scopeNotesBody is non-empty only for a scope carrier. In publish mode "api"
+// it is already the release body Pilot set at creation time (handleReleasing),
+// so it's passed through EnrichRelease unmodified rather than re-inserted;
+// only "workflow" mode — where GoReleaser owns the initial body — needs
+// EnrichScopeRelease to splice the scope notes in (GH-3992).
+func (c *Controller) enrichReleaseNotes(owner, repo, tagName string, commits []*github.Commit, rel *ReleaseConfig, scopeNotesBody string) {
 	if c.releaseSummary == nil || !rel.GenerateSummary {
 		return
 	}
 	enrichCtx, cancel := context.WithTimeout(context.Background(), releasePollTimeout+releaseSummaryTimeout)
 	defer cancel()
-	if err := c.releaseSummary.EnrichRelease(enrichCtx, owner, repo, tagName, commits); err != nil {
+
+	var err error
+	if scopeNotesBody != "" && rel.PublishMode() == ReleasePublishWorkflow {
+		err = c.releaseSummary.EnrichScopeRelease(enrichCtx, owner, repo, tagName, commits, scopeNotesBody)
+	} else {
+		err = c.releaseSummary.EnrichRelease(enrichCtx, owner, repo, tagName, commits)
+	}
+	if err != nil {
 		c.log.Warn("failed to enrich release notes", "tag", tagName, "error", err)
 	}
 }
@@ -2836,7 +2872,7 @@ func (c *Controller) enrichReleaseNotes(owner, repo, tagName string, commits []*
 // against the real releasePollInterval/VerifyTimeout. On success it enriches like
 // "api" mode; on timeout it fires a release_missing alert unless VerifyRelease
 // was explicitly disabled. GH-3927.
-func (c *Controller) verifyReleaseAfterTag(ctx context.Context, owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig, interval, timeout time.Duration) {
+func (c *Controller) verifyReleaseAfterTag(ctx context.Context, owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig, interval, timeout time.Duration, scopeNotesBody string) {
 	verifyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	if _, err := waitForReleaseByTag(verifyCtx, c.ghClient, c.log, owner, repo, tagName, interval, timeout); err != nil {
@@ -2845,7 +2881,7 @@ func (c *Controller) verifyReleaseAfterTag(ctx context.Context, owner, repo, tag
 		}
 		return
 	}
-	c.enrichReleaseNotes(owner, repo, tagName, commits, rel)
+	c.enrichReleaseNotes(owner, repo, tagName, commits, rel, scopeNotesBody)
 }
 
 // fireReleaseMissingAlert fires a release_missing alert (GH-3927) for a tag whose

--- a/internal/autopilot/controller_release_verify_test.go
+++ b/internal/autopilot/controller_release_verify_test.go
@@ -59,7 +59,7 @@ func TestAfterTagCreated_WorkflowMode_ReleaseAppears(t *testing.T) {
 	c.SetAlertsEngine(sink)
 
 	rel := &ReleaseConfig{Publish: ReleasePublishWorkflow, VerifyRelease: boolPtr(true), VerifyTimeout: time.Second}
-	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v1.2.3", 42, 7, nil, rel, 5*time.Millisecond, 500*time.Millisecond)
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v1.2.3", 42, 7, nil, rel, 5*time.Millisecond, 500*time.Millisecond, "")
 
 	if len(sink.events) != 0 {
 		t.Errorf("expected no alert when the release appears in time, got %d events", len(sink.events))
@@ -90,7 +90,7 @@ func TestAfterTagCreated_WorkflowMode_Timeout_FiresAlert(t *testing.T) {
 	c.SetAlertsEngine(sink)
 
 	rel := &ReleaseConfig{Publish: ReleasePublishWorkflow, VerifyRelease: boolPtr(true), VerifyTimeout: 20 * time.Millisecond}
-	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond)
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond, "")
 
 	if len(sink.events) != 1 {
 		t.Fatalf("expected exactly 1 release_missing event, got %d", len(sink.events))
@@ -103,7 +103,7 @@ func TestAfterTagCreated_WorkflowMode_Timeout_FiresAlert(t *testing.T) {
 	}
 
 	// Same tag again — dedup must suppress a second event.
-	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond)
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond, "")
 	if len(sink.events) != 1 {
 		t.Errorf("dedup: expected still exactly 1 event after re-verifying the same tag, got %d", len(sink.events))
 	}
@@ -121,7 +121,7 @@ func TestAfterTagCreated_WorkflowMode_VerifyDisabled_NoAlert(t *testing.T) {
 	c.SetAlertsEngine(sink)
 
 	rel := &ReleaseConfig{Publish: ReleasePublishWorkflow, VerifyRelease: boolPtr(false), VerifyTimeout: 20 * time.Millisecond}
-	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v5.5.5", 1, 0, nil, rel, 5*time.Millisecond, 20*time.Millisecond)
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v5.5.5", 1, 0, nil, rel, 5*time.Millisecond, 20*time.Millisecond, "")
 
 	if len(sink.events) != 0 {
 		t.Errorf("expected no alert when VerifyRelease is explicitly false, got %d events", len(sink.events))
@@ -144,7 +144,7 @@ func TestAfterTagCreated_TagOnly_NoPolling(t *testing.T) {
 	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
 
 	rel := &ReleaseConfig{Publish: ReleasePublishTagOnly, VerifyRelease: boolPtr(true), VerifyTimeout: time.Second}
-	c.afterTagCreated("owner", "repo", "v1.0.0", 1, 0, nil, rel)
+	c.afterTagCreated("owner", "repo", "v1.0.0", 1, 0, nil, rel, "")
 
 	// afterTagCreated returns synchronously without launching a goroutine for
 	// tag_only, so no sleep/wait is needed before asserting.

--- a/internal/autopilot/release_summary.go
+++ b/internal/autopilot/release_summary.go
@@ -28,6 +28,12 @@ const (
 
 	// anthropicAPIURL is the Anthropic Messages API endpoint.
 	anthropicAPIURL = "https://api.anthropic.com/v1/messages"
+
+	// maxSummaryCommitLines caps how many commit first-lines are sent to the
+	// LLM per summary request — a large scope carrier can union hundreds of
+	// commits, and the prompt only needs enough signal to write 3-5 bullets
+	// (GH-3992).
+	maxSummaryCommitLines = 200
 )
 
 // ReleaseSummaryGenerator enriches GitHub releases with LLM-generated summaries.
@@ -74,6 +80,27 @@ func (g *ReleaseSummaryGenerator) SetAPIURL(url string) {
 // from the commit messages, and prepends it to the release body.
 // Returns nil on any failure — release enrichment is best-effort.
 func (g *ReleaseSummaryGenerator) EnrichRelease(ctx context.Context, owner, repo, tag string, commits []*github.Commit) error {
+	return g.enrichReleaseBody(ctx, owner, repo, tag, commits, "")
+}
+
+// EnrichScopeRelease enriches a scope carrier's release the same way as
+// EnrichRelease, but inserts the aggregated scope release notes between the
+// LLM "What's New" summary and the release's existing body — used for publish
+// mode "workflow", where GoReleaser (not Pilot) owns the initial body, so the
+// scope notes were never part of it (GH-3992). For publish mode "api" the
+// scope notes are already the body Pilot set at release-creation time —
+// callers should use EnrichRelease there instead so the notes aren't
+// duplicated.
+func (g *ReleaseSummaryGenerator) EnrichScopeRelease(ctx context.Context, owner, repo, tag string, commits []*github.Commit, scopeNotes string) error {
+	return g.enrichReleaseBody(ctx, owner, repo, tag, commits, scopeNotes)
+}
+
+// enrichReleaseBody is the shared body of EnrichRelease/EnrichScopeRelease:
+// poll for the release, generate the LLM summary, then compose
+// summary + [middle] + existing body and update the release. middle is
+// inserted only when non-empty, so EnrichRelease's byte-for-byte behavior
+// (summary + "\n\n" + release.Body) is unchanged for non-scope releases.
+func (g *ReleaseSummaryGenerator) enrichReleaseBody(ctx context.Context, owner, repo, tag string, commits []*github.Commit, middle string) error {
 	// Poll for GoReleaser to publish the release
 	release, err := g.waitForRelease(ctx, owner, repo, tag)
 	if err != nil {
@@ -86,8 +113,12 @@ func (g *ReleaseSummaryGenerator) EnrichRelease(ctx context.Context, owner, repo
 		return fmt.Errorf("generating summary: %w", err)
 	}
 
-	// Prepend summary to existing GoReleaser changelog body
-	enrichedBody := summary + "\n\n" + release.Body
+	parts := []string{summary}
+	if middle != "" {
+		parts = append(parts, middle)
+	}
+	parts = append(parts, release.Body)
+	enrichedBody := strings.Join(parts, "\n\n")
 
 	_, err = g.ghClient.UpdateRelease(ctx, owner, repo, release.ID, &github.ReleaseInput{
 		Body: enrichedBody,
@@ -153,9 +184,14 @@ func (g *ReleaseSummaryGenerator) generateSummary(ctx context.Context, tag strin
 		return fmt.Sprintf("## What's New in %s\n\nMaintenance release.", tag), nil
 	}
 
-	// Build commit list for the prompt
+	// Build commit list for the prompt, capped at maxSummaryCommitLines so a
+	// large scope carrier's commit union doesn't blow up the prompt.
+	cappedCommits := commits
+	if len(cappedCommits) > maxSummaryCommitLines {
+		cappedCommits = cappedCommits[:maxSummaryCommitLines]
+	}
 	var commitLines []string
-	for _, c := range commits {
+	for _, c := range cappedCommits {
 		msg := c.Commit.Message
 		// Use only first line of commit message
 		if idx := strings.Index(msg, "\n"); idx >= 0 {

--- a/internal/autopilot/release_summary_test.go
+++ b/internal/autopilot/release_summary_test.go
@@ -274,6 +274,116 @@ func TestReleaseSummaryGenerator_EnrichRelease(t *testing.T) {
 	}
 }
 
+// TestReleaseSummaryGenerator_EnrichScopeRelease verifies the scope-carrier
+// enrichment composition order: LLM summary, then the scope notes, then the
+// release's existing body (GoReleaser's own changelog in publish mode
+// "workflow") — via a fake /releases/tags/ + PATCH /releases/{id} server and
+// a fake Anthropic server, mirroring TestReleaseSummaryGenerator_EnrichRelease
+// (GH-3992).
+func TestReleaseSummaryGenerator_EnrichScopeRelease(t *testing.T) {
+	var updatedBody string
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"id":99,"tag_name":"v2.0.0","body":"* goreleaser commit 1\n* goreleaser commit 2"}`)
+		case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/releases/99"):
+			var input map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&input)
+			updatedBody, _ = input["body"].(string)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"id":99,"tag_name":"v2.0.0","body":"updated"}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ghServer.Close()
+
+	anthropicServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"content":[{"text":"## What's New in v2.0.0\n\n- Great scope stuff"}]}`)
+	}))
+	defer anthropicServer.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, ghServer.URL)
+
+	gen := &ReleaseSummaryGenerator{
+		ghClient:   ghClient,
+		apiKey:     testutil.FakeAnthropicKey,
+		apiURL:     anthropicServer.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		log:        slog.Default(),
+	}
+
+	scopeNotes := "# Checkout Revamp\n\n## Features\n- add express pay (#101, GH-201)\n"
+
+	err := gen.EnrichScopeRelease(context.Background(), "owner", "repo", "v2.0.0", nil, scopeNotes)
+	if err != nil {
+		t.Fatalf("EnrichScopeRelease() error = %v", err)
+	}
+
+	summaryIdx := strings.Index(updatedBody, "What's New")
+	notesIdx := strings.Index(updatedBody, "Checkout Revamp")
+	origIdx := strings.Index(updatedBody, "goreleaser commit 1")
+
+	if summaryIdx == -1 || notesIdx == -1 || origIdx == -1 {
+		t.Fatalf("updated body missing expected section, got: %q", updatedBody)
+	}
+	if summaryIdx >= notesIdx || notesIdx >= origIdx {
+		t.Errorf("expected composition order summary -> scope notes -> original body, got: %q", updatedBody)
+	}
+}
+
+// TestReleaseSummaryGenerator_EnrichRelease_NoMiddleUnchanged verifies
+// EnrichRelease's non-scope composition (summary + "\n\n" + original body) is
+// unaffected by the EnrichScopeRelease refactor — no scope-notes section is
+// inserted when middle is empty (GH-3992).
+func TestReleaseSummaryGenerator_EnrichRelease_NoMiddleUnchanged(t *testing.T) {
+	var updatedBody string
+	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"id":7,"tag_name":"v1.0.0","body":"* plain commit"}`)
+		case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/releases/7"):
+			var input map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&input)
+			updatedBody, _ = input["body"].(string)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"id":7,"tag_name":"v1.0.0","body":"updated"}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ghServer.Close()
+
+	anthropicServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"content":[{"text":"## What's New in v1.0.0\n\n- Plain stuff"}]}`)
+	}))
+	defer anthropicServer.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, ghServer.URL)
+	gen := &ReleaseSummaryGenerator{
+		ghClient:   ghClient,
+		apiKey:     testutil.FakeAnthropicKey,
+		apiURL:     anthropicServer.URL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		log:        slog.Default(),
+	}
+
+	if err := gen.EnrichRelease(context.Background(), "owner", "repo", "v1.0.0", []*github.Commit{makeCommit("fix: plain thing")}); err != nil {
+		t.Fatalf("EnrichRelease() error = %v", err)
+	}
+
+	want := "## What's New in v1.0.0\n\n- Plain stuff\n\n* plain commit"
+	if updatedBody != want {
+		t.Errorf("EnrichRelease() body = %q, want %q", updatedBody, want)
+	}
+}
+
 func TestReleaseSummaryGenerator_WaitForRelease_Timeout(t *testing.T) {
 	// Server always returns 404 — release never published
 	ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/autopilot/scope_notes.go
+++ b/internal/autopilot/scope_notes.go
@@ -1,0 +1,117 @@
+package autopilot
+
+import (
+	"fmt"
+	"strings"
+
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// ScopeMember is one merged PR contributing to a scope release, carrying its
+// own commits (fetched per-PR rather than folded into the deduped union used
+// for bump detection) so every changelog entry can be attributed to its exact
+// PR and linked issue (GH-3992).
+type ScopeMember struct {
+	PR      int
+	Issue   int
+	Commits []*github.Commit
+}
+
+// ScopeNotesInput is the input to BuildScopeReleaseNotes.
+type ScopeNotesInput struct {
+	Owner      string
+	Repo       string
+	ScopeKey   string
+	ScopeTitle string
+	Members    []ScopeMember
+	LastTag    string
+	NewTag     string
+}
+
+// BuildScopeReleaseNotes renders the aggregated release notes for a scope
+// carrier: a headline, grouped Features/Bug Fixes/Other Changes sections with
+// exact per-PR/per-issue attribution, a Breaking Changes section, and a
+// compare-link + stats footer. Locked format per TASK-389/GH-3992.
+func BuildScopeReleaseNotes(in ScopeNotesInput) string {
+	headline := in.ScopeTitle
+	if headline == "" {
+		headline = in.ScopeKey
+	}
+
+	var features, fixes, others, breaking []string
+	commitCount := 0
+
+	for _, member := range in.Members {
+		for _, commit := range member.Commits {
+			commitCount++
+			msg := commit.Commit.Message
+			if idx := strings.Index(msg, "\n"); idx > 0 {
+				msg = msg[:idx]
+			}
+
+			// Breaking-change detection reuses parseBumpFromMessage's
+			// first-line-only predicate (releaser.go) so scope notes agree
+			// with the bump that was actually cut — body "BREAKING CHANGE:"
+			// footers are out of scope, matching DetectBumpType.
+			isBreaking := parseBumpFromMessage(msg) == BumpMajor
+
+			matches := conventionalCommitRegex.FindStringSubmatch(msg)
+			if matches == nil {
+				entry := formatScopeEntry(msg, member)
+				others = append(others, entry)
+				if isBreaking {
+					breaking = append(breaking, entry)
+				}
+				continue
+			}
+
+			commitType := strings.ToLower(matches[1])
+			description := matches[4]
+			entry := formatScopeEntry(description, member)
+
+			switch commitType {
+			case "feat", "feature":
+				features = append(features, entry)
+			case "fix", "bugfix":
+				fixes = append(fixes, entry)
+			default:
+				others = append(others, entry)
+			}
+			if isBreaking {
+				breaking = append(breaking, entry)
+			}
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("# %s\n", headline))
+
+	if len(features) > 0 {
+		sb.WriteString("\n## Features\n" + strings.Join(features, "\n") + "\n")
+	}
+	if len(fixes) > 0 {
+		sb.WriteString("\n## Bug Fixes\n" + strings.Join(fixes, "\n") + "\n")
+	}
+	if len(others) > 0 {
+		sb.WriteString("\n## Other Changes\n" + strings.Join(others, "\n") + "\n")
+	}
+	if len(breaking) > 0 {
+		sb.WriteString("\n## ⚠ Breaking Changes\n" + strings.Join(breaking, "\n") + "\n")
+	}
+
+	sb.WriteString(fmt.Sprintf("\n**Full Changelog**: https://github.com/%s/%s/compare/%s...%s\n",
+		in.Owner, in.Repo, in.LastTag, in.NewTag))
+	sb.WriteString(fmt.Sprintf("_%d PRs, %d commits_\n", len(in.Members), commitCount))
+
+	return sb.String()
+}
+
+// formatScopeEntry renders one changelog line, omitting the GH-<issue> suffix
+// when the member PR has no linked issue (its body carried no recognizable
+// "Closes #N" reference).
+func formatScopeEntry(description string, member ScopeMember) string {
+	if member.Issue > 0 {
+		return fmt.Sprintf("- %s (#%d, GH-%d)", description, member.PR, member.Issue)
+	}
+	return fmt.Sprintf("- %s (#%d)", description, member.PR)
+}

--- a/internal/autopilot/scope_notes_test.go
+++ b/internal/autopilot/scope_notes_test.go
@@ -1,0 +1,143 @@
+package autopilot
+
+import (
+	"strings"
+	"testing"
+
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestBuildScopeReleaseNotes covers the locked notes format: headline,
+// grouped Features/Fixes/Other sections with #PR+GH-issue attribution,
+// breaking changes (both "!" and BREAKING-prefix forms), non-conventional
+// commits, empty members, link formatting, and footer counts (GH-3992).
+func TestBuildScopeReleaseNotes(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         ScopeNotesInput
+		wantSubstr []string
+		wantAbsent []string
+	}{
+		{
+			name: "features fixes other grouped with attribution",
+			in: ScopeNotesInput{
+				Owner:      "owner",
+				Repo:       "repo",
+				ScopeTitle: "Checkout Revamp",
+				LastTag:    "v1.0.0",
+				NewTag:     "v1.1.0",
+				Members: []ScopeMember{
+					{PR: 101, Issue: 201, Commits: []*github.Commit{makeCommit("feat(checkout): add express pay")}},
+					{PR: 102, Issue: 202, Commits: []*github.Commit{makeCommit("fix(checkout): correct tax calc")}},
+					{PR: 103, Issue: 0, Commits: []*github.Commit{makeCommit("chore: bump deps")}},
+				},
+			},
+			wantSubstr: []string{
+				"# Checkout Revamp",
+				"## Features",
+				"- add express pay (#101, GH-201)",
+				"## Bug Fixes",
+				"- correct tax calc (#102, GH-202)",
+				"## Other Changes",
+				"- bump deps (#103)",
+				"**Full Changelog**: https://github.com/owner/repo/compare/v1.0.0...v1.1.0",
+				"_3 PRs, 3 commits_",
+			},
+			wantAbsent: []string{"GH-0", "⚠ Breaking Changes"},
+		},
+		{
+			name: "breaking change via bang suffix",
+			in: ScopeNotesInput{
+				Owner: "owner", Repo: "repo", ScopeTitle: "Auth", LastTag: "v1.0.0", NewTag: "v2.0.0",
+				Members: []ScopeMember{
+					{PR: 201, Issue: 301, Commits: []*github.Commit{makeCommit("feat(auth)!: drop legacy tokens")}},
+				},
+			},
+			wantSubstr: []string{
+				"## Features",
+				"- drop legacy tokens (#201, GH-301)",
+				"## ⚠ Breaking Changes",
+			},
+		},
+		{
+			name: "breaking change via BREAKING prefix",
+			in: ScopeNotesInput{
+				Owner: "owner", Repo: "repo", ScopeTitle: "Auth", LastTag: "v1.0.0", NewTag: "v2.0.0",
+				Members: []ScopeMember{
+					{PR: 202, Issue: 302, Commits: []*github.Commit{makeCommit("BREAKING: remove v1 API")}},
+				},
+			},
+			wantSubstr: []string{
+				"## ⚠ Breaking Changes",
+				"- remove v1 API (#202, GH-302)",
+			},
+		},
+		{
+			name: "non-conventional commit falls into Other Changes",
+			in: ScopeNotesInput{
+				Owner: "owner", Repo: "repo", ScopeTitle: "Misc", LastTag: "v1.0.0", NewTag: "v1.0.1",
+				Members: []ScopeMember{
+					{PR: 301, Issue: 401, Commits: []*github.Commit{makeCommit("update readme wording")}},
+				},
+			},
+			wantSubstr: []string{
+				"## Other Changes",
+				"- update readme wording (#301, GH-401)",
+			},
+			wantAbsent: []string{"## Features", "## Bug Fixes"},
+		},
+		{
+			name: "empty members still renders headline and footer",
+			in: ScopeNotesInput{
+				Owner: "owner", Repo: "repo", ScopeTitle: "Nothing", LastTag: "v1.0.0", NewTag: "v1.0.0",
+			},
+			wantSubstr: []string{
+				"# Nothing",
+				"**Full Changelog**: https://github.com/owner/repo/compare/v1.0.0...v1.0.0",
+				"_0 PRs, 0 commits_",
+			},
+			wantAbsent: []string{"## Features", "## Bug Fixes", "## Other Changes", "⚠ Breaking Changes"},
+		},
+		{
+			name: "empty scope title falls back to scope key",
+			in: ScopeNotesInput{
+				Owner: "owner", Repo: "repo", ScopeKey: "epic:42", LastTag: "v1.0.0", NewTag: "v1.0.1",
+			},
+			wantSubstr: []string{"# epic:42"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildScopeReleaseNotes(tt.in)
+			for _, want := range tt.wantSubstr {
+				if !strings.Contains(got, want) {
+					t.Errorf("BuildScopeReleaseNotes() missing %q\ngot:\n%s", want, got)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("BuildScopeReleaseNotes() unexpectedly contains %q\ngot:\n%s", absent, got)
+				}
+			}
+		})
+	}
+}
+
+func TestClosingIssueNumber(t *testing.T) {
+	tests := []struct {
+		body string
+		want int
+	}{
+		{"## Summary\n\nCloses #123\n\n## Changes", 123},
+		{"fixes #45", 45},
+		{"Resolves #7 and does other stuff", 7},
+		{"no reference here", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		if got := closingIssueNumber(tt.body); got != tt.want {
+			t.Errorf("closingIssueNumber(%q) = %d, want %d", tt.body, got, tt.want)
+		}
+	}
+}

--- a/internal/autopilot/scope_release.go
+++ b/internal/autopilot/scope_release.go
@@ -263,6 +263,50 @@ func (c *Controller) scopeReleaseCommits(ctx context.Context, owner, repo string
 	return c.ghClient.CompareCommits(ctx, owner, repo, lastTag, prState.HeadSHA)
 }
 
+// closingIssueRegex extracts the issue number a PR body declares it closes,
+// matching the "Closes #N" / "Fixes #N" / "Resolves #N" convention Pilot
+// writes into every PR body it creates (runner.go prBody). Case-insensitive,
+// first match wins (GH-3992).
+var closingIssueRegex = regexp.MustCompile(`(?i)\b(?:closes|fixes|resolves)\s+#(\d+)`)
+
+// closingIssueNumber returns the issue number a PR body closes, or 0 when no
+// recognizable reference is present.
+func closingIssueNumber(body string) int {
+	matches := closingIssueRegex.FindStringSubmatch(body)
+	if matches == nil {
+		return 0
+	}
+	n, _ := strconv.Atoi(matches[1])
+	return n
+}
+
+// scopeReleaseMembers builds the per-member PR/commit/issue breakdown for a
+// scope carrier's aggregated release notes: each member PR's own commits
+// (preserving exact PR attribution, unlike scopeReleaseCommits' deduped
+// union used for bump detection) plus the issue it closes. A member whose PR
+// or commit lookup fails is skipped (logged) rather than failing the whole
+// release — the notes ship with whatever members were resolvable (GH-3992).
+func (c *Controller) scopeReleaseMembers(ctx context.Context, owner, repo string, prState *PRState) []ScopeMember {
+	members := make([]ScopeMember, 0, len(prState.ScopeMemberPRs))
+	for _, pr := range prState.ScopeMemberPRs {
+		commits, err := c.ghClient.GetPRCommits(ctx, owner, repo, pr)
+		if err != nil {
+			c.log.Warn("scope release notes: failed to fetch member PR commits",
+				"scope", prState.ScopeKey, "member_pr", pr, "error", err)
+			continue
+		}
+		issue := 0
+		if prObj, err := c.ghClient.GetPullRequest(ctx, owner, repo, pr); err != nil {
+			c.log.Warn("scope release notes: failed to fetch member PR for issue linkage",
+				"scope", prState.ScopeKey, "member_pr", pr, "error", err)
+		} else {
+			issue = closingIssueNumber(prObj.Body)
+		}
+		members = append(members, ScopeMember{PR: pr, Issue: issue, Commits: commits})
+	}
+	return members
+}
+
 // markScopeReleaseDone records a scope carrier's successful (or no-op)
 // completion in the state store. tag is "" for a no-op release (BumpNone).
 // No-op when prState is not a scope carrier or no state store is wired.

--- a/internal/autopilot/scope_release_test.go
+++ b/internal/autopilot/scope_release_test.go
@@ -559,3 +559,95 @@ func TestScanRecentlyMergedPRs_SkipsScopeMemberPending(t *testing.T) {
 		t.Errorf("git/refs POST count = %d, want 0 (scanner must not cut a per-merge tag for a scope member)", got)
 	}
 }
+
+// TestScopeCarrier_APIPublish_BodyIsScopeNotes verifies handleReleasing's
+// publish-mode-"api" branch for a scope carrier: the POST /releases body is
+// the aggregated scope release notes (headline + Features/Fixes attributed
+// to each member PR and its linked issue + compare footer) rather than
+// GenerateChangelog's per-PR output (GH-3992).
+func TestScopeCarrier_APIPublish_BodyIsScopeNotes(t *testing.T) {
+	var releaseBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/pulls/301") && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.PullRequest{Number: 301, Body: "Closes #401"})
+		case strings.HasSuffix(r.URL.Path, "/pulls/302") && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.PullRequest{Number: 302, Body: "Closes #402"})
+		case strings.Contains(r.URL.Path, "/pulls/301/commits"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat(checkout): add express pay")})
+		case strings.Contains(r.URL.Path, "/pulls/302/commits"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("fix(checkout): correct tax calc")})
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.0.0"})
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(r.URL.Path, "/branches/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "main", "commit": map[string]string{"sha": "mainsha"}})
+		case strings.Contains(r.URL.Path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "identical"})
+		case strings.HasSuffix(r.URL.Path, "/git/refs"):
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/repos/owner/repo/releases"):
+			var input struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&input)
+			releaseBody = input.Body
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.Release{ID: 1, TagName: "v1.1.0", HTMLURL: "https://github.com/owner/repo/releases/tag/v1.1.0"})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{
+		Enabled:   true,
+		Trigger:   "on_scope_close",
+		TagPrefix: "v",
+		Publish:   ReleasePublishAPI,
+	}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	carrier := &PRState{
+		PRNumber:       302,
+		Stage:          StageReleasing,
+		PostMergeSHA:   "mainsha",
+		ScopeKey:       "epic:1",
+		ScopeTitle:     "Checkout Revamp",
+		ScopeMemberPRs: []int{301, 302},
+	}
+	c.mu.Lock()
+	c.activePRs[302] = carrier
+	c.mu.Unlock()
+
+	if err := c.handleReleasing(context.Background(), carrier); err != nil {
+		t.Fatalf("handleReleasing() error = %v", err)
+	}
+
+	wantSubstrs := []string{
+		"# Checkout Revamp",
+		"## Features",
+		"- add express pay (#301, GH-401)",
+		"## Bug Fixes",
+		"- correct tax calc (#302, GH-402)",
+		"**Full Changelog**: https://github.com/owner/repo/compare/v1.0.0...v1.1.0",
+		"_2 PRs, 2 commits_",
+	}
+	for _, want := range wantSubstrs {
+		if !strings.Contains(releaseBody, want) {
+			t.Errorf("release body missing %q\ngot:\n%s", want, releaseBody)
+		}
+	}
+}

--- a/internal/autopilot/telegram_notifier.go
+++ b/internal/autopilot/telegram_notifier.go
@@ -119,16 +119,24 @@ func (n *TelegramNotifier) NotifyReleased(ctx context.Context, prState *PRState,
 		bumpLabel = "patch release"
 	}
 
+	// GH-3992: a scope carrier ships multiple member PRs in one release —
+	// "From PR: #N" would misattribute it to just the anchor PR, so scope
+	// carriers get a "Scope: <title> (<K> PRs)" line instead.
+	source := fmt.Sprintf("From PR: #%d", prState.PRNumber)
+	if prState.ScopeTitle != "" {
+		source = fmt.Sprintf("Scope: %s (%d PRs)", escapeMarkdown(prState.ScopeTitle), len(prState.ScopeMemberPRs))
+	}
+
 	msg := fmt.Sprintf("%s✨ *Release %s Published*\n\n"+
 		"Version: `%s`\n"+
 		"Type: %s\n"+
-		"From PR: #%d\n\n"+
+		"%s\n\n"+
 		"[View Release](%s)",
 		envPrefix(prState),
 		escapeMarkdown(prState.ReleaseVersion),
 		prState.ReleaseVersion,
 		bumpLabel,
-		prState.PRNumber,
+		source,
 		releaseURL,
 	)
 

--- a/internal/autopilot/telegram_notifier_test.go
+++ b/internal/autopilot/telegram_notifier_test.go
@@ -304,6 +304,38 @@ func TestTelegramNotifier_NotifyReleased(t *testing.T) {
 	}
 }
 
+// TestTelegramNotifier_NotifyReleased_ScopeCarrier verifies a scope carrier
+// (prState.ScopeTitle != "") renders "Scope: <title> (<K> PRs)" instead of
+// "From PR: #N", since attributing a multi-PR release to just its anchor PR
+// would be misleading (GH-3992).
+func TestTelegramNotifier_NotifyReleased_ScopeCarrier(t *testing.T) {
+	var receivedText string
+	notifier, server := newTestNotifier(t, &receivedText)
+	defer server.Close()
+
+	prState := &PRState{
+		PRNumber:        42,
+		ReleaseVersion:  "v1.2.0",
+		ReleaseBumpType: BumpMinor,
+		EnvironmentName: "staging",
+		ScopeKey:        "epic:7",
+		ScopeTitle:      "Checkout Revamp",
+		ScopeMemberPRs:  []int{40, 41, 42},
+	}
+
+	err := notifier.NotifyReleased(context.Background(), prState, "https://github.com/owner/repo/releases/tag/v1.2.0")
+	if err != nil {
+		t.Fatalf("NotifyReleased error: %v", err)
+	}
+
+	if !strings.Contains(receivedText, "Scope: Checkout Revamp (3 PRs)") {
+		t.Errorf("expected scope headline, got: %s", receivedText)
+	}
+	if strings.Contains(receivedText, "From PR:") {
+		t.Errorf("scope carrier must not render From PR:, got: %s", receivedText)
+	}
+}
+
 func TestNewTelegramNotifier(t *testing.T) {
 	client := telegram.NewClient("test-token")
 	notifier := NewTelegramNotifier(client, "123456")


### PR DESCRIPTION
## Summary
- `BuildScopeReleaseNotes` (`internal/autopilot/scope_notes.go`) renders a scope carrier's release body: headline, grouped Features/Bug Fixes/Other Changes with exact `#PR`/`GH-issue` attribution, `⚠ Breaking Changes` (first-line predicate reused from `parseBumpFromMessage`), and a compare-link + stats footer.
- `handleReleasing` (`internal/autopilot/controller.go`) uses the scope notes as the release body directly for `publish: api`, and splices them between the LLM summary and GoReleaser's own body via the new `EnrichScopeRelease` for `publish: workflow`.
- `cmd/pilot/main.go` finally wires `SetReleaseSummaryGenerator` (built from `ANTHROPIC_API_KEY`) at every autopilot controller construction site (gateway path + both projects-loop construction sites, via the shared `autopilotControllers` map).
- `generateSummary` caps its commit-list prompt input at 200 first-lines (`maxSummaryCommitLines`) so a large scope carrier's commit union can't blow up the LLM prompt.
- Telegram `NotifyReleased` shows `Scope: <title> (<K> PRs)` instead of `From PR: #N` for scope carriers.
- `configs/pilot.example.yaml` + `docs/content/features/autopilot-environments.mdx` + `docs/content/getting-started/configuration.mdx` document the new behavior and the `publish: workflow`/`api`-only constraint (not `tag_only`).

Part of TASK-389 (release cycles). Blocked by #3990 (already merged).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite, green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` (0 issues)
- [x] `TestBuildScopeReleaseNotes` table covers features/fixes/other, both breaking-change predicates, non-conventional commits, empty members, and empty scope title fallback
- [x] Rebased onto latest `origin/main` (picks up GH-4001 per-project release opt-in) — no regressions, `GenerateChangelog`/per-merge release bodies untouched