### PR TITLE
feat(autopilot): on_schedule release trains — cron-batched releases (GH-3993)

### DIFF
--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -529,6 +529,18 @@ projects:
   #                     # upload 422-collide and silently skips downstream publish steps
   #                     # (Homebrew tap). Repos with GoReleaser must stay workflow.
   #     tag_human_merges: true  # also tag this project's human-authored merges (GH-3928)
+  #
+  # on_schedule example (GH-3993): batch everything merged since the last tag
+  # into one release train, cut every Friday at 21:00 in Europe/Berlin.
+  # - name: some-product
+  #   path: "/path/to/some-product"
+  #   github:
+  #     owner: "qf-studio"
+  #     repo: "some-product"
+  #   release:
+  #     trigger: on_schedule
+  #     schedule: "0 21 * * FRI"          # Fridays 21:00
+  #     schedule_timezone: "Europe/Berlin"
 
 # Autopilot settings
 autopilot:
@@ -556,12 +568,22 @@ autopilot:
     #                    semantics only - held work is fully reconstructable
     #                    from GitHub in the meantime).
     #   on_schedule    - hold every merge for a cron release train (see
-    #                    `schedule` below). No scheduler ships in this issue
-    #                    either; the hold is inert-but-safe until it does.
+    #                    `schedule` below). At each tick, everything merged
+    #                    since the last tag is batched into one validated
+    #                    release (GH-3993). Restart across a tick still fires
+    #                    it exactly once (missed-tick recovery, bounded by
+    #                    `scope_lookback` below); a miss older than that
+    #                    window needs a manual re-trigger. DST transitions
+    #                    follow robfig/cron/v3's cron.WithLocation semantics
+    #                    (no special-casing). Urgent hotfix under
+    #                    `on_schedule`: everything still waits for the next
+    #                    tick by design - flip `trigger` to `on_merge`
+    #                    temporarily (config reload) if it can't wait.
     trigger: on_merge
     # scope_label_prefix: "scope:"       # on_scope_close only; default "scope:"
     # schedule: "0 21 * * FRI"           # on_schedule only; robfig/cron/v3 standard (5-field) syntax
     # schedule_timezone: "Europe/Berlin" # on_schedule only; empty = daemon local time
+    # scope_lookback: 24h                # on_scope_close AND on_schedule; also bounds missed-tick recovery
     version_strategy: conventional_commits
     tag_prefix: "v"
     generate_changelog: true

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2155,6 +2155,9 @@ func (c *Controller) Start(ctx context.Context) {
 	// GH-3990: claim any scope releases left pending (or re-drive any left
 	// 'releasing' with no live carrier) by a daemon restart.
 	c.startPendingScopeReleases(ctx)
+	// GH-3993: start the on_schedule release-train cron (no-op unless
+	// resolvedRelease().ScheduleReleaseEnabled()).
+	c.startScheduleRelease(ctx)
 }
 
 // handlePostMergeCI monitors deployment/post-merge checks (non-blocking).
@@ -2534,16 +2537,25 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 		currentVersion = SemVer{}
 	}
 
-	// Get commits for bump detection: a scope carrier unions every member PR's
-	// commits; a regular release reads just its own PR's commits.
+	// Get commits for bump detection: a "train:" scope carrier is defined as
+	// "everything since the last tag" (CompareCommits, not a member-PR union
+	// — GH-3993); any other scope carrier (epic:/label:) unions every member
+	// PR's own commits; a regular release reads just its own PR's commits.
 	var commits []*github.Commit
-	if isScope {
+	switch {
+	case isScope && strings.HasPrefix(prState.ScopeKey, "train:"):
+		commits, err = c.trainReleaseCommits(ctx, owner, repo, prState, currentVersion, rel)
+		if err != nil {
+			return c.checkReleasingRetryOrEscalate(ctx, prState,
+				fmt.Errorf("failed to get train release commits for %s: %w", prState.ScopeKey, err))
+		}
+	case isScope:
 		commits, err = c.scopeReleaseCommits(ctx, owner, repo, prState, currentVersion, rel)
 		if err != nil {
 			return c.checkReleasingRetryOrEscalate(ctx, prState,
 				fmt.Errorf("failed to get scope release commits for %s: %w", prState.ScopeKey, err))
 		}
-	} else {
+	default:
 		commits, err = c.ghClient.GetPRCommits(ctx, owner, repo, prState.PRNumber)
 		if err != nil {
 			return c.checkReleasingRetryOrEscalate(ctx, prState,

--- a/internal/autopilot/scope_schedule.go
+++ b/internal/autopilot/scope_schedule.go
@@ -1,0 +1,257 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+	"github.com/robfig/cron/v3"
+)
+
+// trainPRSuffixRe matches a GitHub squash-merge PR reference suffix on a
+// commit's first message line, e.g. "fix(x): do the thing (#123)" (GH-3993).
+var trainPRSuffixRe = regexp.MustCompile(`\(#(\d+)\)\s*$`)
+
+// previousScheduledSearchWindow bounds how far back previousScheduledTime
+// walks looking for a schedule's most recent fire time before a reference
+// instant. Wide enough to cover any reasonable release-train cadence
+// (weekly, monthly) — a narrower window (e.g. the on_scope_close
+// ScopeLookback default of 24h) would miss the slot entirely for a weekly
+// schedule before ever comparing it against the lookback eligibility gate
+// in recoverMissedTrainTick (GH-3993).
+const previousScheduledSearchWindow = 400 * 24 * time.Hour
+
+// previousScheduledTime returns the most recent time at or before `before`
+// that `schedule` would have fired, or the zero time if none falls within
+// previousScheduledSearchWindow. robfig/cron/v3 only exposes Schedule.Next
+// (forward), so this walks forward from the search-window floor and keeps
+// the last hit at-or-before `before` — mirrors
+// internal/briefs.Scheduler.maybeCatchUp's backward search
+// (internal/briefs/scheduler.go ~:236-247), generalized to a wider fixed
+// window instead of a hardcoded 48h (GH-3993).
+func previousScheduledTime(schedule cron.Schedule, before time.Time) time.Time {
+	checkTime := before.Add(-previousScheduledSearchWindow)
+	var prev time.Time
+	for {
+		next := schedule.Next(checkTime)
+		if next.After(before) {
+			break
+		}
+		prev = next
+		checkTime = next
+	}
+	return prev
+}
+
+// trainScopeKey renders the "train:<RFC3339>" scope key for a scheduled
+// release-train tick at t. Normalized to UTC so the live-fire tick and a
+// restart-recovered tick for the same slot always agree on the same key
+// regardless of which time.Location representation computed t — the state
+// store's INSERT OR IGNORE on this key is what makes a tick-then-recovery
+// race for the same slot exactly-once (GH-3993).
+func trainScopeKey(t time.Time) string {
+	return "train:" + t.UTC().Format(time.RFC3339)
+}
+
+// startScheduleRelease starts the cron release-train scheduler for Trigger
+// "on_schedule" (GH-3993). No-op unless resolvedRelease().ScheduleReleaseEnabled().
+// Mirrors internal/briefs.Scheduler's cron.New/AddFunc/Start pattern
+// (robfig/cron/v3), adapted to Controller's shutdown model: Controller has no
+// separate Stop() call site — main.go's Run(ctx) exits on ctx.Done() instead
+// — so the cron instance ties its own Stop to the same ctx via a watcher
+// goroutine rather than a paired Stop method.
+func (c *Controller) startScheduleRelease(ctx context.Context) {
+	rel := c.resolvedRelease()
+	if !rel.ScheduleReleaseEnabled() {
+		return
+	}
+
+	loc := time.Local
+	if rel.ScheduleTimezone != "" {
+		l, err := time.LoadLocation(rel.ScheduleTimezone)
+		if err != nil {
+			c.log.Warn("startScheduleRelease: invalid schedule_timezone, using local timezone",
+				"timezone", rel.ScheduleTimezone, "error", err)
+		} else {
+			loc = l
+		}
+	}
+
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	schedule, err := parser.Parse(rel.Schedule)
+	if err != nil {
+		c.log.Error("startScheduleRelease: invalid schedule, release train disabled",
+			"schedule", rel.Schedule, "error", err)
+		return
+	}
+
+	cronInst := cron.New(cron.WithLocation(loc))
+	entryID, err := cronInst.AddFunc(rel.Schedule, func() {
+		scheduledAt := previousScheduledTime(schedule, time.Now().In(loc))
+		c.scheduleReleaseTick(ctx, scheduledAt)
+	})
+	if err != nil {
+		c.log.Error("startScheduleRelease: failed to register cron job",
+			"schedule", rel.Schedule, "error", err)
+		return
+	}
+	cronInst.Start()
+
+	c.log.Info("release train scheduler started",
+		"schedule", rel.Schedule,
+		"timezone", loc.String(),
+		"next_run", cronInst.Entry(entryID).Next,
+	)
+
+	go func() {
+		<-ctx.Done()
+		stopCtx := cronInst.Stop()
+		<-stopCtx.Done()
+	}()
+
+	c.recoverMissedTrainTick(ctx, rel, schedule, loc)
+}
+
+// recoverMissedTrainTick runs the release-train tick once, immediately, if
+// the daemon was offline across a scheduled fire and the missed slot is
+// still within rel.ScopeLookback. A miss older than the lookback is left for
+// a human to manually re-trigger (documented in configs/pilot.example.yaml)
+// rather than silently tagging a long-stale train — mirrors the
+// lookback-gated backstop precedent in reconcileLabelScope
+// (internal/autopilot/scope_reconcile.go) (GH-3993).
+func (c *Controller) recoverMissedTrainTick(ctx context.Context, rel *ReleaseConfig, schedule cron.Schedule, loc *time.Location) {
+	prevScheduled := previousScheduledTime(schedule, time.Now().In(loc))
+	if prevScheduled.IsZero() {
+		return
+	}
+
+	lookback := rel.ScopeLookback
+	if lookback <= 0 {
+		lookback = 24 * time.Hour
+	}
+	if time.Since(prevScheduled) > lookback {
+		c.log.Debug("recoverMissedTrainTick: previous scheduled tick predates the lookback window, skipping",
+			"scheduled_at", prevScheduled.Format(time.RFC3339), "lookback", lookback)
+		return
+	}
+
+	scopeKey := trainScopeKey(prevScheduled)
+	if c.stateStore != nil {
+		row, err := c.stateStore.GetScopeRelease(c.repoKey(), scopeKey)
+		if err != nil {
+			c.log.Warn("recoverMissedTrainTick: failed to check for an existing train row, skipping recovery",
+				"scope", scopeKey, "error", err)
+			return
+		}
+		if row != nil {
+			// Already enqueued — either the tick fired on schedule, or a prior
+			// recovery pass already ran for this slot.
+			return
+		}
+	}
+
+	c.log.Warn("recovering missed train", "scheduled_at", prevScheduled.Format(time.RFC3339))
+	c.scheduleReleaseTick(ctx, prevScheduled)
+}
+
+// scheduleReleaseTick batches everything merged since the last tag into one
+// scope-release carrier for Trigger "on_schedule" (GH-3993). scheduledAt is
+// the cron-scheduled fire time (not the actual wall-clock time this call
+// runs) — used verbatim as the "train:<RFC3339>" scope key so a live tick
+// and a restart-recovered tick for the same slot always resolve to the same
+// key; enqueueScopeRelease's INSERT OR IGNORE then makes a double-fire for
+// the same slot exactly-once.
+func (c *Controller) scheduleReleaseTick(ctx context.Context, scheduledAt time.Time) {
+	rel := c.resolvedRelease()
+	branch := c.resolveMainBranchName()
+
+	currentVersion, err := c.releaser.GetCurrentVersionForRepo(ctx, c.owner, c.repo)
+	if err != nil {
+		c.log.Warn("scheduleReleaseTick: failed to get current version, defaulting to 0.0.0", "error", err)
+		currentVersion = SemVer{}
+	}
+	lastTag := currentVersion.String(rel.TagPrefix)
+
+	commits, err := c.ghClient.CompareCommits(ctx, c.owner, c.repo, lastTag, branch)
+	if err != nil {
+		c.log.Warn("scheduleReleaseTick: failed to compare commits, skipping this tick",
+			"last_tag", lastTag, "branch", branch, "error", err)
+		return
+	}
+	if len(commits) == 0 {
+		c.log.Debug("scheduleReleaseTick: empty train, skipping",
+			"last_tag", lastTag, "scheduled_at", scheduledAt.Format(time.RFC3339))
+		return
+	}
+
+	memberPRs := c.resolveTrainMemberPRs(ctx, commits)
+	if len(memberPRs) == 0 {
+		c.log.Warn("scheduleReleaseTick: no resolvable member PRs (direct-commit-only train), skipping — "+
+			"v1 limitation, the scope-release carrier requires a real merged PR",
+			"last_tag", lastTag, "commits", len(commits), "scheduled_at", scheduledAt.Format(time.RFC3339))
+		return
+	}
+
+	scopeKey := trainScopeKey(scheduledAt)
+	title := fmt.Sprintf("Release train %s", scheduledAt.Format("2006-01-02 15:04"))
+	c.enqueueScopeRelease(ctx, scopeKey, title, memberPRs)
+}
+
+// resolveTrainMemberPRs extracts "(#N)" squash-merge PR references from each
+// commit's first message line, dedupes, and keeps only numbers that resolve
+// to an actual merged PR. An unverifiable number (deleted PR, a direct
+// commit with no PR, a non-squash merge commit) is dropped from the member
+// list — its commit still counts toward the train via the CompareCommits
+// result in scheduleReleaseTick, but it can't anchor a carrier or contribute
+// release-notes attribution (GH-3993).
+func (c *Controller) resolveTrainMemberPRs(ctx context.Context, commits []*github.Commit) []int {
+	seen := make(map[int]bool)
+	var candidates []int
+	for _, commit := range commits {
+		if commit == nil {
+			continue
+		}
+		firstLine := strings.SplitN(commit.Commit.Message, "\n", 2)[0]
+		m := trainPRSuffixRe.FindStringSubmatch(firstLine)
+		if m == nil {
+			continue
+		}
+		n, err := strconv.Atoi(m[1])
+		if err != nil || seen[n] {
+			continue
+		}
+		seen[n] = true
+		candidates = append(candidates, n)
+	}
+
+	var members []int
+	for _, n := range candidates {
+		pr, err := c.ghClient.GetPullRequest(ctx, c.owner, c.repo, n)
+		if err != nil {
+			c.log.Debug("resolveTrainMemberPRs: failed to verify candidate PR, dropping from members",
+				"pr", n, "error", err)
+			continue
+		}
+		if !pr.Merged {
+			c.log.Debug("resolveTrainMemberPRs: candidate PR is not merged, dropping from members", "pr", n)
+			continue
+		}
+		members = append(members, n)
+	}
+	return dedupeSortInts(members)
+}
+
+// trainReleaseCommits returns the commit set for a "train:" scope carrier's
+// release: everything reachable from HeadSHA since the last tag. Unlike
+// scopeReleaseCommits (epic:/label: scopes, which union each member PR's own
+// commits), a release train is defined as "everything since the last tag" —
+// so it always reads directly off CompareCommits rather than the member
+// list, which exists only for release-notes attribution (GH-3993).
+func (c *Controller) trainReleaseCommits(ctx context.Context, owner, repo string, prState *PRState, currentVersion SemVer, rel *ReleaseConfig) ([]*github.Commit, error) {
+	lastTag := currentVersion.String(rel.TagPrefix)
+	return c.ghClient.CompareCommits(ctx, owner, repo, lastTag, prState.HeadSHA)
+}

--- a/internal/autopilot/scope_schedule_test.go
+++ b/internal/autopilot/scope_schedule_test.go
@@ -1,0 +1,391 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+	"github.com/robfig/cron/v3"
+)
+
+// scheduleTickServer builds a fake GitHub server covering everything
+// scheduleReleaseTick needs: releases/latest + tags for version resolution,
+// compare for the commit train, and pulls/<n> for member-PR verification.
+// prs maps candidate PR numbers to their merged state; a number absent from
+// the map 404s (unverifiable, dropped from members).
+func scheduleTickServer(t *testing.T, lastTag string, commits []*github.Commit, prs map[int]bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: lastTag})
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(r.URL.Path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"commits": commits})
+		case strings.Contains(r.URL.Path, "/pulls/"):
+			var num int
+			_, _ = fmtSscanIssueNum(strings.Replace(r.URL.Path, "/pulls/", "/issues/", 1), &num)
+			merged, ok := prs[num]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.PullRequest{Number: num, Merged: merged})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+}
+
+// newScheduleController builds a controller with Trigger "on_schedule" wired
+// to a test GitHub server and a fresh in-memory state store.
+func newScheduleController(t *testing.T, serverURL, schedule string) (*Controller, *StateStore) {
+	t.Helper()
+	stateStore := newTestStateStore(t)
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, serverURL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.Release = &ReleaseConfig{
+		Enabled:   true,
+		Trigger:   "on_schedule",
+		TagPrefix: "v",
+		Schedule:  schedule,
+	}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	if c.releaser == nil {
+		t.Fatal("releaser not initialized — check ReleaseConfig wiring")
+	}
+	c.SetStateStore(stateStore)
+	return c, stateStore
+}
+
+// TestScheduleReleaseTick_EnqueuesTrainWithResolvedMembers covers the happy
+// path: commits since the last tag include two squash-merge PR suffixes and
+// one direct commit with no suffix; the enqueued row keys on
+// "train:<RFC3339>" and lists only the two resolvable, verified-merged
+// members (GH-3993).
+func TestScheduleReleaseTick_EnqueuesTrainWithResolvedMembers(t *testing.T) {
+	c1 := makeCommit("feat: add thing (#101)")
+	c1.SHA = "sha1"
+	c2 := makeCommit("fix: another thing (#102)")
+	c2.SHA = "sha2"
+	c3 := makeCommit("chore: direct commit, no PR")
+	c3.SHA = "sha3"
+
+	server := scheduleTickServer(t, "v1.0.0", []*github.Commit{c1, c2, c3}, map[int]bool{101: true, 102: true})
+	defer server.Close()
+
+	c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
+
+	scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
+	c.scheduleReleaseTick(context.Background(), scheduledAt)
+
+	row, err := stateStore.GetScopeRelease("owner/repo", "train:2026-07-10T21:00:00Z")
+	if err != nil {
+		t.Fatalf("GetScopeRelease failed: %v", err)
+	}
+	if row == nil {
+		t.Fatal("expected a train row to be enqueued")
+	}
+	if want := []int{101, 102}; !reflect.DeepEqual(row.MemberPRs, want) {
+		t.Errorf("members = %v, want %v", row.MemberPRs, want)
+	}
+	if want := "Release train 2026-07-10 21:00"; row.ScopeTitle != want {
+		t.Errorf("title = %q, want %q", row.ScopeTitle, want)
+	}
+}
+
+// TestScheduleReleaseTick_DropsUnverifiablePRNumber covers a commit whose
+// "(#N)" suffix does not resolve to a merged PR (deleted/never-existed) —
+// it is dropped from the member list, but a co-occurring resolvable member
+// still enqueues the train (GH-3993).
+func TestScheduleReleaseTick_DropsUnverifiablePRNumber(t *testing.T) {
+	c1 := makeCommit("feat: add thing (#201)")
+	c1.SHA = "sha1"
+	c2 := makeCommit("fix: ghost pr (#999)")
+	c2.SHA = "sha2"
+
+	server := scheduleTickServer(t, "v1.0.0", []*github.Commit{c1, c2}, map[int]bool{201: true})
+	defer server.Close()
+
+	c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
+
+	scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
+	c.scheduleReleaseTick(context.Background(), scheduledAt)
+
+	row, err := stateStore.GetScopeRelease("owner/repo", "train:2026-07-10T21:00:00Z")
+	if err != nil || row == nil {
+		t.Fatalf("expected a train row, err=%v row=%v", err, row)
+	}
+	if want := []int{201}; !reflect.DeepEqual(row.MemberPRs, want) {
+		t.Errorf("members = %v, want %v", row.MemberPRs, want)
+	}
+}
+
+// TestScheduleReleaseTick_EmptyCompare_NoRow covers "empty week": no commits
+// since the last tag means no row and no noise (GH-3993 acceptance criteria).
+func TestScheduleReleaseTick_EmptyCompare_NoRow(t *testing.T) {
+	server := scheduleTickServer(t, "v1.0.0", nil, nil)
+	defer server.Close()
+
+	c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
+
+	scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
+	c.scheduleReleaseTick(context.Background(), scheduledAt)
+
+	rows, err := stateStore.ListScopeReleases("owner/repo", "pending", "releasing", "done", "failed")
+	if err != nil {
+		t.Fatalf("ListScopeReleases failed: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected no rows for an empty compare, got %d", len(rows))
+	}
+}
+
+// TestScheduleReleaseTick_DirectCommitOnlyTrain_NoRow covers the v1
+// limitation: commits exist but none carry a resolvable PR suffix (an
+// all-direct-commit train) — skipped with a WARN rather than enqueued,
+// since the carrier requires a real merged PR to anchor on (GH-3993).
+func TestScheduleReleaseTick_DirectCommitOnlyTrain_NoRow(t *testing.T) {
+	c1 := makeCommit("chore: direct commit, no PR suffix")
+	c1.SHA = "sha1"
+
+	server := scheduleTickServer(t, "v1.0.0", []*github.Commit{c1}, nil)
+	defer server.Close()
+
+	c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
+
+	scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
+	c.scheduleReleaseTick(context.Background(), scheduledAt)
+
+	rows, err := stateStore.ListScopeReleases("owner/repo", "pending", "releasing", "done", "failed")
+	if err != nil {
+		t.Fatalf("ListScopeReleases failed: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected no rows for a direct-commit-only train, got %d", len(rows))
+	}
+}
+
+// TestRecoverMissedTrainTick covers the three missed-tick recovery gates:
+// a genuine miss within lookback fires the tick once; an already-enqueued
+// slot is a no-op; a miss older than the lookback is left for manual
+// re-trigger (GH-3993). None of these sleep on a real cron — they call
+// recoverMissedTrainTick directly against a fixed schedule.
+func TestRecoverMissedTrainTick(t *testing.T) {
+	loc := time.UTC
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	schedule, err := parser.Parse("0 21 * * FRI")
+	if err != nil {
+		t.Fatalf("parse schedule: %v", err)
+	}
+
+	t.Run("no prior row, commits exist, within lookback runs tick once", func(t *testing.T) {
+		c1 := makeCommit("feat: add thing (#301)")
+		c1.SHA = "sha1"
+		server := scheduleTickServer(t, "v1.0.0", []*github.Commit{c1}, map[int]bool{301: true})
+		defer server.Close()
+
+		c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
+		rel := c.resolvedRelease()
+		rel.ScopeLookback = 7 * 24 * time.Hour
+
+		c.recoverMissedTrainTick(context.Background(), rel, schedule, loc)
+
+		rows, err := stateStore.ListScopeReleases("owner/repo", "pending")
+		if err != nil {
+			t.Fatalf("ListScopeReleases: %v", err)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("expected exactly 1 recovered row, got %d", len(rows))
+		}
+	})
+
+	t.Run("row already exists for the missed slot is a no-op", func(t *testing.T) {
+		var compareHits int64
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "/compare/") {
+				atomic.AddInt64(&compareHits, 1)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+
+		c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
+		rel := c.resolvedRelease()
+		rel.ScopeLookback = 7 * 24 * time.Hour
+
+		prevScheduled := previousScheduledTime(schedule, time.Now().In(loc))
+		if err := stateStore.EnqueueScopeRelease("owner/repo", trainScopeKey(prevScheduled), "Release train existing", []int{1}); err != nil {
+			t.Fatalf("EnqueueScopeRelease: %v", err)
+		}
+
+		c.recoverMissedTrainTick(context.Background(), rel, schedule, loc)
+
+		if got := atomic.LoadInt64(&compareHits); got != 0 {
+			t.Errorf("expected no compare-commits call when a row already exists for the slot, got %d", got)
+		}
+	})
+
+	t.Run("miss older than lookback is a no-op", func(t *testing.T) {
+		var compareHits int64
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "/compare/") {
+				atomic.AddInt64(&compareHits, 1)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+
+		c, _ := newScheduleController(t, server.URL, "0 21 * * FRI")
+		rel := c.resolvedRelease()
+		rel.ScopeLookback = 1 * time.Millisecond // any past scheduled slot is older than this
+
+		c.recoverMissedTrainTick(context.Background(), rel, schedule, loc)
+
+		if got := atomic.LoadInt64(&compareHits); got != 0 {
+			t.Errorf("expected no compare-commits call for a miss older than the lookback window, got %d", got)
+		}
+	})
+}
+
+// TestPreviousScheduledTime_HonorsLocation verifies the same cron expression
+// resolves to different absolute instants depending on the location the
+// reference time is evaluated in — the "Timezone: schedule evaluated in
+// configured location" requirement (GH-3993).
+func TestPreviousScheduledTime_HonorsLocation(t *testing.T) {
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	schedule, err := parser.Parse("0 21 * * FRI")
+	if err != nil {
+		t.Fatalf("parse schedule: %v", err)
+	}
+
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Skipf("Europe/Berlin tzdata unavailable: %v", err)
+	}
+
+	ref := time.Date(2026, 7, 11, 10, 0, 0, 0, time.UTC) // a Saturday, comfortably after either zone's Friday 21:00
+
+	prevUTC := previousScheduledTime(schedule, ref.In(time.UTC))
+	prevBerlin := previousScheduledTime(schedule, ref.In(berlin))
+
+	if prevUTC.IsZero() || prevBerlin.IsZero() {
+		t.Fatal("expected both evaluations to resolve to a non-zero previous scheduled time")
+	}
+	if prevUTC.Equal(prevBerlin) {
+		t.Errorf("expected different absolute instants for UTC vs Europe/Berlin schedule evaluation, both = %v", prevUTC)
+	}
+	if h := prevBerlin.In(berlin).Hour(); h != 21 {
+		t.Errorf("Berlin previous scheduled hour = %d, want 21", h)
+	}
+	if h := prevUTC.In(time.UTC).Hour(); h != 21 {
+		t.Errorf("UTC previous scheduled hour = %d, want 21", h)
+	}
+}
+
+// trainReleaseServer builds a fake GitHub server for driving handleReleasing
+// on a "train:" scope carrier: branch/check-runs for post-merge CI plumbing,
+// releases/tags for version resolution, a combined compare response serving
+// both CompareStatus (reachability guard) and CompareCommits (train commit
+// source), and /git/refs for tag creation.
+func trainReleaseServer(t *testing.T, commits []*github.Commit, gitRefPosts *int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/branches/main":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "main", "commit": map[string]string{"sha": "mainsha"}})
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.0.0"})
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(r.URL.Path, "/compare/"):
+			// Serves both CompareStatus (reachability guard reads .status) and
+			// CompareCommits (train commit source reads .commits) from one route.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "identical", "commits": commits})
+		case strings.HasSuffix(r.URL.Path, "/git/refs"):
+			atomic.AddInt64(gitRefPosts, 1)
+			w.WriteHeader(http.StatusCreated)
+		case strings.HasSuffix(r.URL.Path, "/releases/tags/v1.1.0"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.1.0", HTMLURL: "https://github.com/owner/repo/releases/tag/v1.1.0"})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+}
+
+// TestHandleReleasing_TrainScope_UsesCompareCommitsNotMemberUnion covers the
+// controller.go handleReleasing branch: a "train:" scope carrier's commit
+// source is CompareCommits(lastTag -> HeadSHA), not a member-PR commit
+// union, and cuts exactly one tag (GH-3993).
+func TestHandleReleasing_TrainScope_UsesCompareCommitsNotMemberUnion(t *testing.T) {
+	commit := makeCommit("feat: add a thing (#55)")
+	commit.SHA = "train-sha-1"
+
+	var gitRefPosts int64
+	server := trainReleaseServer(t, []*github.Commit{commit}, &gitRefPosts)
+	defer server.Close()
+
+	stateStore := newTestStateStore(t)
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.Release = &ReleaseConfig{
+		Enabled:       true,
+		Trigger:       "on_schedule",
+		TagPrefix:     "v",
+		RequireCI:     true,
+		Schedule:      "0 21 * * FRI",
+		VerifyRelease: boolPtr(false),
+	}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+
+	prState := &PRState{
+		PRNumber:       999,
+		PRURL:          "https://github.com/owner/repo/pull/999",
+		ScopeKey:       "train:2026-07-10T21:00:00Z",
+		ScopeTitle:     "Release train 2026-07-10 21:00",
+		ScopeMemberPRs: []int{55},
+		PostMergeSHA:   "train-sha-1",
+		Stage:          StageReleasing,
+	}
+
+	if err := c.handleReleasing(context.Background(), prState); err != nil {
+		t.Fatalf("handleReleasing failed: %v", err)
+	}
+
+	if got := atomic.LoadInt64(&gitRefPosts); got != 1 {
+		t.Errorf("git ref posts = %d, want 1", got)
+	}
+	if prState.Stage == StageFailed {
+		t.Errorf("prState unexpectedly failed: %s", prState.Error)
+	}
+	if prState.HeadSHA != "train-sha-1" {
+		t.Errorf("HeadSHA = %q, want the PostMergeSHA (train-sha-1)", prState.HeadSHA)
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/autopilot/scope_schedule.go`: per-controller robfig/cron/v3 scheduler (mirrors `internal/briefs.Scheduler`) that, under `Trigger: on_schedule`, ticks on the configured `schedule`/`schedule_timezone`, batches everything merged since the last tag into one scope-release carrier via the existing #3990 scope-release machinery (`train:<RFC3339>` scope key), and includes restart-safe missed-tick recovery bounded by `scope_lookback`.
- Member PRs for a train are resolved from squash-merge `(#N)` commit-suffixes and verified merged via `GetPullRequest`; unresolvable numbers are dropped from the member list (still counted in commits) — a zero-member (direct-commit-only) train is skipped with a WARN (v1 limitation, documented).
- `controller.go`'s `handleReleasing`: a `train:` carrier's commit source is now `CompareCommits(lastTag → HeadSHA)` (not the `epic:`/`label:` scopes' member-PR commit union), since a release train is defined as "everything since the last tag."
- `configs/pilot.example.yaml`: documents the `on_schedule` trigger (missed-tick recovery, DST via `cron.WithLocation` semantics, hotfix override via temporary `trigger: on_merge`) and adds a per-project `on_schedule` example block.

Blocked by / builds on #3990 (scope-release carrier machinery). Part of TASK-389 (release cycles).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` — new table-driven tests: tick enqueues train with resolved+verified members, drops unverifiable PR numbers, empty compare → no row, direct-commit-only → WARN + no row; missed-tick recovery (fires once within lookback / no-op when row exists / no-op when older than lookback); timezone-aware schedule evaluation; `handleReleasing` train branch uses `CompareCommits`, cuts exactly one tag.
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `go test ./stress/ -timeout 10m` — green