### PR TITLE
fix(autopilot): epic parent re-dispatch loop breaker on permanent close-veto

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -407,6 +407,7 @@
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
 | Per-project release opt-in | ✅ | autopilot | - | `projects[].release` | Global/env `release:` cascade applies only to the default repo; `projects:` controllers release only with their own `release:` block (`WithReleaseNotOptedIn` forces disabled otherwise). Startup logs tag posture as `source=project-not-opted-in`; WARN emitted per non-opted-in project when global release is enabled (v2.230.0, GH-4001) |
+| Epic close-veto loop breaker | ✅ | autopilot | - | - | `reconcileEpicParent` tracks consecutive identical close-vetoes per parent; after 3 (`epicCloseVetoBreakerThreshold`) it adds `pilot-needs-clarification` (excludes from dispatch), posts one comment naming the blocking child, fires one `epic_close_vetoed` alert (v2.232.0, GH-4006) |
 
 ## Epic Management
 

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -304,6 +304,16 @@ type Controller struct {
 	// alertedMissingReleases (GH-3991).
 	alertedStaleScopes map[string]bool
 
+	// epicVeto tracks, per epic parent issue number, how many consecutive
+	// reconcile passes have failed the SAME close-veto (same blocking child +
+	// same reason), guarded by mu. Lets reconcileEpicParent tell "still
+	// converging" (veto changes or clears) apart from "permanently stuck"
+	// (identical veto, epicCloseVetoBreakerThreshold times running) and break
+	// the re-dispatch loop instead of burning tokens forever (GH-4006).
+	// In-memory only: a daemon restart resets the streak, which only delays
+	// (never skips) the eventual escalation.
+	epicVeto map[int]*epicCloseVetoTracking
+
 	// cachedBotLogin holds the authenticated GitHub login for the Pilot token.
 	// Populated lazily by getBotLogin; protected by mu. GH-3417.
 	cachedBotLogin string
@@ -332,6 +342,7 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 		log:                    slog.Default().With("component", "autopilot"),
 		alertedMissingReleases: make(map[string]bool),
 		alertedStaleScopes:     make(map[string]bool),
+		epicVeto:               make(map[int]*epicCloseVetoTracking),
 	}
 
 	// Options must apply before the releaser is constructed below: the
@@ -2084,7 +2095,10 @@ func (c *Controller) closeParentNow(ctx context.Context, parentNum int, mergedPR
 	if err := c.ghClient.AddLabels(ctx, c.owner, c.repo, parentNum, []string{"pilot-done"}); err != nil {
 		c.log.Warn("closeParentNow: failed to add pilot-done label", slog.Int("parent", parentNum), slog.Any("error", err))
 	}
-	for _, stale := range []string{"pilot-failed", "pilot-in-progress", "pilot-blocked"} {
+	// GH-4006: also clear a needs-clarification label left by an earlier
+	// escalateEpicCloseVeto pass whose veto later resolved — harmless if it
+	// was never applied (RemoveLabel on an absent label is a no-op).
+	for _, stale := range []string{"pilot-failed", "pilot-in-progress", "pilot-blocked", github.LabelNeedsClarification} {
 		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, parentNum, stale); err != nil {
 			c.log.Warn("closeParentNow: failed to remove label", slog.String("label", stale), slog.Int("parent", parentNum), slog.Any("error", err))
 		}

--- a/internal/autopilot/epic_reconcile.go
+++ b/internal/autopilot/epic_reconcile.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"time"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
 // maxEpicReconcile caps how many open, pilot-labeled parent-with-sub-issues
@@ -12,6 +16,26 @@ import (
 // recoverStaleParentIssues' maxRecover — bounded so one pathological repo with
 // hundreds of open epics can't turn a poll tick into an unbounded API burst.
 const maxEpicReconcile = 50
+
+// epicCloseVetoBreakerThreshold caps how many consecutive reconcile passes a
+// parent may fail the SAME close-veto (identical blocking child + reason)
+// before the loop breaker escalates. Without this, a permanently-vetoed
+// parent gets re-dispatched by the poller forever: #3927 ran 6 completed
+// executions in ~2h before a human closed it manually (GH-4006) because its
+// ghost-closed child #3952 could never produce a merged PR under its own
+// issue number — the actual fix shipped via a different issue's PR (#3980).
+const epicCloseVetoBreakerThreshold = 3
+
+// epicCloseVetoTracking is the in-memory streak for one epic parent's
+// close-veto: which child is blocking, why, how many consecutive reconcile
+// passes have seen that exact pair, and whether the breaker has already
+// escalated it (so escalateEpicCloseVeto fires its label/comment/alert once).
+type epicCloseVetoTracking struct {
+	child     int
+	reason    string
+	count     int
+	escalated bool
+}
 
 // subIssueState is one native GitHub sub-issue's number and open/closed state.
 // Unlike GetOpenSubIssueNumbers (which discards closed children), reconcileEpicParent
@@ -185,6 +209,9 @@ func (c *Controller) reconcileEpicParent(ctx context.Context, parentNum int) {
 		// Routine, not a veto — an epic mid-flight looks like this on every tick,
 		// so this stays at Debug to avoid spamming logs while children finish.
 		c.log.Debug("reconcileEpicParents: siblings still open", slog.Int("parent", parentNum), slog.Int("open", openBlocking))
+		// The epic re-entered a "still building" phase (a new/reopened sibling) —
+		// forget any prior close-veto streak so it doesn't carry over (GH-4006).
+		c.clearEpicCloseVeto(parentNum)
 		return
 	}
 
@@ -192,8 +219,12 @@ func (c *Controller) reconcileEpicParent(ctx context.Context, parentNum int) {
 	if veto != nil {
 		c.log.Warn("reconcileEpicParents: close vetoed",
 			slog.Int("parent", parentNum), slog.Int("child", veto.Child), slog.String("veto_reason", veto.Reason))
+		if c.recordEpicCloseVeto(parentNum, veto) {
+			c.escalateEpicCloseVeto(ctx, parentNum, veto)
+		}
 		return
 	}
+	c.clearEpicCloseVeto(parentNum)
 
 	closed, title := c.closeParentNow(ctx, parentNum, mergedPRs)
 	// GH-3990: an epic just completed — enqueue its scope release. Gated on
@@ -317,4 +348,90 @@ func (c *Controller) searchClosedPilotIssuesWithSubIssues(ctx context.Context, l
 		}
 	}
 	return numbers, nil
+}
+
+// recordEpicCloseVeto tracks parentNum's veto against its previous sighting
+// (GH-4006). A different blocking child or a different reason resets the
+// streak — the epic's blocking condition changed, so the escalation clock
+// starts over; the identical signature bumps the count. Returns true exactly
+// once, on the pass that first reaches epicCloseVetoBreakerThreshold, so
+// escalateEpicCloseVeto fires its label/comment/alert a single time instead of
+// repeating on every subsequent poll while the same veto persists.
+func (c *Controller) recordEpicCloseVeto(parentNum int, veto *childCloseVeto) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.epicVeto == nil {
+		c.epicVeto = make(map[int]*epicCloseVetoTracking)
+	}
+	st, ok := c.epicVeto[parentNum]
+	if !ok || st.child != veto.Child || st.reason != veto.Reason {
+		st = &epicCloseVetoTracking{child: veto.Child, reason: veto.Reason}
+		c.epicVeto[parentNum] = st
+	}
+	st.count++
+	if st.count >= epicCloseVetoBreakerThreshold && !st.escalated {
+		st.escalated = true
+		return true
+	}
+	return false
+}
+
+// clearEpicCloseVeto forgets parentNum's close-veto streak (GH-4006), called
+// once its children verify shipped or it re-enters a "still building" phase —
+// so a resolved stall doesn't leave a stale escalated flag behind that would
+// suppress a genuinely new veto on this parent later.
+func (c *Controller) clearEpicCloseVeto(parentNum int) {
+	c.mu.Lock()
+	delete(c.epicVeto, parentNum)
+	c.mu.Unlock()
+}
+
+// escalateEpicCloseVeto breaks the parent re-dispatch loop once its close-veto
+// has persisted for epicCloseVetoBreakerThreshold consecutive reconcile passes
+// (GH-4006): adds LabelNeedsClarification — already excluded from dispatch by
+// the poller — posts one explanatory comment naming the blocking child and
+// why, and fires a single epic_close_vetoed alert. Best-effort throughout:
+// errors are logged, never propagated, matching closeParentNow's style.
+func (c *Controller) escalateEpicCloseVeto(ctx context.Context, parentNum int, veto *childCloseVeto) {
+	c.log.Warn("reconcileEpicParents: close veto persisted, breaking re-dispatch loop",
+		slog.Int("parent", parentNum), slog.Int("child", veto.Child), slog.String("veto_reason", veto.Reason),
+		slog.Int("attempts", epicCloseVetoBreakerThreshold))
+
+	if err := c.ghClient.AddLabels(ctx, c.owner, c.repo, parentNum, []string{github.LabelNeedsClarification}); err != nil {
+		c.log.Warn("escalateEpicCloseVeto: failed to add needs-clarification label",
+			slog.Int("parent", parentNum), slog.Any("error", err))
+	}
+
+	comment := fmt.Sprintf(
+		"⚠️ **Epic auto-close is permanently blocked**\n\n"+
+			"GH-%d has failed the shipped-check %d reconcile passes in a row for the same reason: "+
+			"child #%d %s.\n\n"+
+			"Pilot will not re-dispatch this issue while `%s` is present.\n\n"+
+			"**To resume:**\n"+
+			"- Close this parent manually if the work is verified complete, or\n"+
+			"- Give child #%d a merged PR (or a verified no-op ledger row) referencing it so the next "+
+			"reconciliation pass confirms it shipped, then remove the `%s` label.",
+		parentNum, epicCloseVetoBreakerThreshold, veto.Child, veto.Reason,
+		github.LabelNeedsClarification, veto.Child, github.LabelNeedsClarification,
+	)
+	if _, err := c.ghClient.AddComment(ctx, c.owner, c.repo, parentNum, comment); err != nil {
+		c.log.Warn("escalateEpicCloseVeto: failed to post comment", slog.Int("parent", parentNum), slog.Any("error", err))
+	}
+
+	if c.alertsEngine == nil {
+		c.log.Error("epic_close_vetoed alert not delivered: SetAlertsEngine was never called", slog.Int("parent", parentNum))
+		return
+	}
+	c.alertsEngine.ProcessEvent(alerts.Event{
+		Type:      alerts.EventType("epic_close_vetoed"),
+		Error:     fmt.Sprintf("epic parent #%d permanently blocked: child #%d %s", parentNum, veto.Child, veto.Reason),
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"repo":   c.repoKey(),
+			"parent": strconv.Itoa(parentNum),
+			"child":  strconv.Itoa(veto.Child),
+			"reason": veto.Reason,
+		},
+	})
 }

--- a/internal/autopilot/epic_reconcile_test.go
+++ b/internal/autopilot/epic_reconcile_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/alerts"
 	"github.com/qf-studio/pilot/internal/testutil"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
@@ -507,4 +508,220 @@ func TestReconcileClosedEpicScopes(t *testing.T) {
 	if got := atomic.LoadInt64(&searchCalls); got != firstSearch {
 		t.Errorf("verifyChildrenShippedForClose search calls after second sweep = %d, want unchanged at %d (idempotent)", got, firstSearch)
 	}
+}
+
+// TestEpicCloseVetoBreaker covers GH-4006's loop breaker: a parent whose
+// close-veto never changes (a ghost-closed child that can never produce its
+// own merged PR, e.g. #3927/#3952) must stop being silently re-vetoed forever
+// — after epicCloseVetoBreakerThreshold consecutive reconcile passes it adds
+// LabelNeedsClarification (which already excludes the issue from dispatch),
+// posts exactly ONE explanatory comment, and fires exactly ONE
+// epic_close_vetoed alert, even as further passes keep observing the same
+// veto. A veto that resolves before the threshold (the child's PR merges
+// late) must close the parent normally with no escalation at all.
+func TestEpicCloseVetoBreaker(t *testing.T) {
+	const parentNum = 500
+	const childNum = 1
+
+	t.Run("permanent veto escalates once and never repeats", func(t *testing.T) {
+		var (
+			addLabelsCalls []string
+			commentBodies  []string
+			closeCalled    bool
+		)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprintf(w, `{"node_id":"I_parent","number":%d,"state":"open"}`, parentNum)
+
+			case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+				resp := map[string]interface{}{
+					"data": map[string]interface{}{
+						"node": map[string]interface{}{
+							"subIssues": map[string]interface{}{
+								"totalCount": 1,
+								"nodes":      []map[string]interface{}{{"number": childNum, "state": "CLOSED"}},
+							},
+						},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+
+			case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+				// Ghost-closed child: closed, but never produces a merged PR
+				// under its own issue number (its work shipped via a different
+				// issue's branch/PR — the class of bug this task does not fix).
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": []map[string]interface{}{}})
+
+			case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d/labels", parentNum):
+				var payload struct {
+					Labels []string `json:"labels"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&payload)
+				addLabelsCalls = append(addLabelsCalls, payload.Labels...)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("[]"))
+
+			case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d/comments", parentNum):
+				var payload struct {
+					Body string `json:"body"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&payload)
+				commentBodies = append(commentBodies, payload.Body)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id":1}`))
+
+			case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+				closeCalled = true
+				w.WriteHeader(http.StatusOK)
+
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		cfg := DefaultConfig()
+		c := NewController(cfg, ghClient, nil, "owner", "repo")
+		sink := &fakeAlertSink{}
+		c.SetAlertsEngine(sink)
+
+		for i := 0; i < epicCloseVetoBreakerThreshold; i++ {
+			c.reconcileEpicParent(context.Background(), parentNum)
+		}
+
+		if closeCalled {
+			t.Error("parent should never close while permanently vetoed")
+		}
+		if len(commentBodies) != 1 {
+			t.Fatalf("expected exactly one escalation comment after %d passes, got %d: %v",
+				epicCloseVetoBreakerThreshold, len(commentBodies), commentBodies)
+		}
+		if !strings.Contains(commentBodies[0], fmt.Sprintf("child #%d", childNum)) {
+			t.Errorf("comment should name the blocking child, got: %q", commentBodies[0])
+		}
+		if !strings.Contains(commentBodies[0], "no merged PR") {
+			t.Errorf("comment should explain why the child fails the shipped-check, got: %q", commentBodies[0])
+		}
+		foundLabel := false
+		for _, l := range addLabelsCalls {
+			if l == github.LabelNeedsClarification {
+				foundLabel = true
+			}
+		}
+		if !foundLabel {
+			t.Errorf("expected %s label to be added, got labels: %v", github.LabelNeedsClarification, addLabelsCalls)
+		}
+		if len(sink.events) != 1 {
+			t.Fatalf("expected exactly one alert fired, got %d", len(sink.events))
+		}
+		if sink.events[0].Type != alerts.EventType("epic_close_vetoed") {
+			t.Errorf("alert type = %q, want epic_close_vetoed", sink.events[0].Type)
+		}
+
+		// Further passes past the threshold must not repeat the comment or alert.
+		c.reconcileEpicParent(context.Background(), parentNum)
+		if len(commentBodies) != 1 {
+			t.Errorf("expected no additional comment beyond the escalation, got %d: %v", len(commentBodies), commentBodies)
+		}
+		if len(sink.events) != 1 {
+			t.Errorf("expected no additional alert beyond the escalation, got %d", len(sink.events))
+		}
+	})
+
+	t.Run("veto resolves before threshold — counter resets and parent closes normally", func(t *testing.T) {
+		pass := 0
+		var closeCalled bool
+		var commentBodies []string
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprintf(w, `{"node_id":"I_parent","number":%d,"state":"open"}`, parentNum)
+
+			case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+				resp := map[string]interface{}{
+					"data": map[string]interface{}{
+						"node": map[string]interface{}{
+							"subIssues": map[string]interface{}{
+								"totalCount": 1,
+								"nodes":      []map[string]interface{}{{"number": childNum, "state": "CLOSED"}},
+							},
+						},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+
+			case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+				items := []map[string]interface{}{}
+				if pass >= 2 {
+					// Third pass: the child's PR finally merges — the veto resolves
+					// before it ever reaches epicCloseVetoBreakerThreshold.
+					items = append(items, map[string]interface{}{
+						"id": 1, "number": 900 + childNum, "title": "fix: child",
+						"state":        "closed",
+						"pull_request": map[string]interface{}{"merged_at": "2026-01-01T00:00:00Z"},
+					})
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": items})
+
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("[]"))
+
+			case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d/comments", parentNum):
+				var payload struct {
+					Body string `json:"body"`
+				}
+				_ = json.NewDecoder(r.Body).Decode(&payload)
+				commentBodies = append(commentBodies, payload.Body)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"id":1}`))
+
+			case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+				closeCalled = true
+				w.WriteHeader(http.StatusOK)
+
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		cfg := DefaultConfig()
+		c := NewController(cfg, ghClient, nil, "owner", "repo")
+		sink := &fakeAlertSink{}
+		c.SetAlertsEngine(sink)
+
+		// Two vetoed passes (below threshold), then the child's PR merges.
+		for ; pass < 2; pass++ {
+			c.reconcileEpicParent(context.Background(), parentNum)
+		}
+		if closeCalled {
+			t.Fatal("parent should not close while still vetoed")
+		}
+
+		c.reconcileEpicParent(context.Background(), parentNum)
+
+		if !closeCalled {
+			t.Error("expected parent to close once the child's PR merges")
+		}
+		for _, body := range commentBodies {
+			if strings.Contains(body, "permanently blocked") {
+				t.Errorf("did not expect an escalation comment once the veto resolved, got: %q", body)
+			}
+		}
+		if len(sink.events) != 0 {
+			t.Errorf("expected no epic_close_vetoed alert once the veto resolved, got %d", len(sink.events))
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- `verifyChildrenShippedForClose` correctly vetoes an epic-parent auto-close when a closed child has no merged PR — but nothing stopped the poller from re-dispatching that parent forever once the veto could never resolve. Epic parent #3927 ran 6 completed executions in ~2h (11:39–13:29) before a human closed it manually, root-caused to child #3952 being ghost-closed while its actual fix shipped under a different issue's PR (#3980).
- `reconcileEpicParent` now tracks consecutive identical close-vetoes (same blocking child + same reason) per parent. After 3 in a row it adds `pilot-needs-clarification` (already excluded from dispatch by the poller), posts exactly ONE comment naming the blocking child and why, and fires a single `epic_close_vetoed` alert.
- A veto that changes (different child/reason) or resolves (child's PR merges) clears the streak, so normal auto-close and mid-flight epics are unaffected.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` — new `TestEpicCloseVetoBreaker` covers: permanent veto escalates exactly once and doesn't repeat on further passes; veto that resolves before the threshold closes the parent normally with no escalation. Existing `TestReconcileEpicParent`/`TestReconcileClosedEpicScopes` unaffected.
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `go test ./...` — full suite green

## Out of scope (per issue)

- Fixing ghost-close itself (the close-attribution bug when work ships under a different issue's branch) — separate class of defect.