### PR TITLE
feat(autopilot): aggregated scope release notes + wire LLM What's New summary + scope notifications

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-07 (v2.151.0)
+**Last Updated:** 2026-07-06 (v2.151.0)
 
 ## Legend
 
@@ -406,8 +406,7 @@
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
-| Per-project release opt-in | ✅ | autopilot | - | `projects[].release` | Global/env `release:` cascade applies only to the default repo; `projects:` controllers release only with their own `release:` block (`WithReleaseNotOptedIn` forces disabled otherwise). Startup logs tag posture as `source=project-not-opted-in`; WARN emitted per non-opted-in project when global release is enabled (v2.230.0, GH-4001) |
-| Epic close-veto loop breaker | ✅ | autopilot | - | - | `reconcileEpicParent` tracks consecutive identical close-vetoes per parent; after 3 (`epicCloseVetoBreakerThreshold`) it adds `pilot-needs-clarification` (excludes from dispatch), posts one comment naming the blocking child, fires one `epic_close_vetoed` alert (v2.232.0, GH-4006) |
+| Aggregated scope release notes + LLM wiring | ✅ | autopilot | - | `release.generate_summary` | `on_scope_close`/`on_schedule` carriers get a deterministic body (headline, grouped Features/Fixes/Other with exact `#PR`/`GH-issue` attribution, breaking changes, compare + stats footer) via `BuildScopeReleaseNotes`; LLM "What's New" (Haiku) is now wired end-to-end via `SetReleaseSummaryGenerator` at every controller construction site, reading `ANTHROPIC_API_KEY` (v2.232.0, GH-3992) |
 
 ## Epic Management
 

--- a/.agent/tasks/gh-3992.md
+++ b/.agent/tasks/gh-3992.md
@@ -1,0 +1,52 @@
+# GH-3992
+
+**Created:** 2026-07-07
+
+## Problem
+
+GitHub Issue GH-3992: feat(autopilot): aggregated scope release notes + wire LLM Whats New summary + scope notifications
+
+Blocked by: #3990
+
+Part of TASK-389 (release cycles). Locked notes requirements: scope headline · grouped Features/Fixes/Other with #PR + GH-issue links · ⚠ Breaking Changes · LLM "What's New" (Haiku) · compare link + stats footer.
+
+## Implementation
+
+1. **NEW `internal/autopilot/scope_notes.go`** — `BuildScopeReleaseNotes(in ScopeNotesInput) string`, `ScopeNotesInput{Owner, Repo, ScopeTitle string; Members []ScopeMember /*PR, Issue int; Commits []*github.Commit*/; LastTag, NewTag string}`:
+   - Headline: `# <ScopeTitle>` (or scope key when title empty).
+   - Sections `## Features` / `## Bug Fixes` / `## Other Changes`, entries `- <description> (#<pr>, GH-<issue>)` — attribution is exact because commits are fetched per member PR. Reuse `conventionalCommitRegex` (releaser.go ~:98).
+   - `## ⚠ Breaking Changes` when a first line matches `parseBumpFromMessage`'s breaking predicate (`!` suffix or BREAKING prefix, releaser.go ~:131-134). First-line only — body `BREAKING CHANGE:` footers are out of scope, matching bump detection.
+   - Footer: `**Full Changelog**: https://github.com/<o>/<r>/compare/<LastTag>...<NewTag>` + `_<N> PRs, <M> commits_`.
+2. **`internal/autopilot/controller.go`** handleReleasing scope branch: `publish: api` → body straight into `CreateReleaseForRepo`; `publish: workflow` → GoReleaser owns the initial body, so extend the enrichment composition for scope carriers: final body = LLM `## What's New` + scope notes + original workflow body. Add a scope-aware wrapper; the existing `EnrichRelease` signature delegates (today it prepends only, release_summary.go ~:88-97).
+3. **`cmd/pilot/main.go`** — FINALLY wire the LLM generator: `apiKey := os.Getenv("ANTHROPIC_API_KEY")` (factory returns nil on empty → graceful, release_summary.go ~:47-50; env-fallback precedent internal/comms/factory.go:33); `NewReleaseSummaryGenerator(client, apiKey, logger)` + `SetReleaseSummaryGenerator` at ALL controller construction sites (adjacent to the SetAlertsEngine wiring). Cap LLM input at 200 commit first-lines (guard in generateSummary).
+4. **`internal/autopilot/telegram_notifier.go`** `NotifyReleased` (~:111): scope carriers (`prState.ScopeTitle != ""`) render `Scope: <title> (<K> PRs)` instead of `From PR: #N`. Notifier interface unchanged.
+5. **`configs/pilot.example.yaml`** + docs (`docs/content/features/autopilot-environments.mdx`, `getting-started/configuration.mdx`): document `on_scope_close`/`on_schedule`, `scope_label_prefix`, `schedule`, per-project trigger overlay; note scope notes require publish `workflow` or `api` (NOT `tag_only` — no release object exists there).
+
+## Edge cases
+
+- LLM failure/timeout → notes ship without What's New (best-effort, existing contract).
+- `generate_summary: false` → LLM skipped, deterministic notes still ship.
+- Daemon without ANTHROPIC_API_KEY → exactly today's behavior (nil generator).
+- Markdown-hostile commit subjects → no escaping beyond current GenerateChangelog behavior.
+
+## Tests
+
+- `TestBuildScopeReleaseNotes` table: features/fixes/other, breaking via `!` and BREAKING prefix, non-conventional, empty, link formatting, footer counts.
+- Enrichment-composition order via fake `/releases/tags/` + `PATCH /releases/{id}` (release_summary_test.go has the fake-LLM pattern).
+- Notifier scope-headline test (mockNotifier pattern, controller_test.go ~:1839).
+
+## Acceptance criteria
+
+- [ ] Scope release body contains all five required elements
+- [ ] Per-merge release bodies byte-identical to today (GenerateChangelog untouched)
+- [ ] No ANTHROPIC_API_KEY → behavior identical to today
+- [ ] `go test ./internal/autopilot/...` green; `make lint` clean
+
+## Out of scope (fences)
+
+- Don't change GenerateChangelog's per-PR output; no prompt/model redesign beyond the 200-line cap
+- Do NOT decompose this issue
+- Before pushing: `go test ./stress/ -timeout 10m` (known flake #3959; rerun once if it hangs)
+
+## Acceptance Criteria
+

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -657,6 +657,12 @@ Examples:
 							// GH-2685: wire the controller as the approval state writer so
 							// async approval decisions update the in-memory PRState.
 							approvalMgr.WithStateWriter(gwAutopilotController)
+							// GH-3992: wire the LLM release summary generator — nil (graceful
+							// no-op) when ANTHROPIC_API_KEY is unset, matching
+							// NewReleaseSummaryGenerator's documented degradation.
+							gwAutopilotController.SetReleaseSummaryGenerator(
+								autopilot.NewReleaseSummaryGenerator(apGHClient, os.Getenv("ANTHROPIC_API_KEY"), logging.WithComponent("autopilot")),
+							)
 						}
 					}
 				}
@@ -1650,6 +1656,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			// stays for the approval handler and legacy paths until later phases.
 			apGHClient := githubSDK.NewClient(ghToken)
 
+			// GH-3992: one shared LLM release summary generator for every
+			// controller constructed below (default + per-project) — nil
+			// (graceful no-op) when ANTHROPIC_API_KEY is unset.
+			releaseSummaryGen := autopilot.NewReleaseSummaryGenerator(apGHClient, os.Getenv("ANTHROPIC_API_KEY"), logging.WithComponent("autopilot"))
+
 			// GH-1870: Build board sync option for autopilot controllers.
 			var autopilotBoardOpts []autopilot.ControllerOption
 			if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.ProjectBoard != nil && cfg.Adapters.GitHub.ProjectBoard.Enabled {
@@ -1695,6 +1706,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 						parts[1],
 						ctrlOpts...,
 					)
+					controller.SetReleaseSummaryGenerator(releaseSummaryGen)
 					autopilotControllers[cfg.Adapters.GitHub.Repo] = controller
 					autopilotController = controller // Default for backwards compat
 				}
@@ -1743,6 +1755,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					proj.GitHub.Repo,
 					ctrlOpts...,
 				)
+				controller.SetReleaseSummaryGenerator(releaseSummaryGen)
 				autopilotControllers[repoFullName] = controller
 				logging.WithComponent("autopilot").Info("created controller for project",
 					slog.String("project", proj.Name),

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -579,6 +579,12 @@ autopilot:
     #                    `on_schedule`: everything still waits for the next
     #                    tick by design - flip `trigger` to `on_merge`
     #                    temporarily (config reload) if it can't wait.
+    #
+    # `on_scope_close`/`on_schedule` release notes (GH-3992): the aggregated
+    # scope body (headline, grouped Features/Fixes/Other with #PR + GH-issue
+    # links, breaking changes, What's New, compare footer) is only composed
+    # for `publish: api` or `publish: workflow` — `tag_only` never creates a
+    # release object, so there is nothing to attach notes to.
     trigger: on_merge
     # scope_label_prefix: "scope:"       # on_scope_close only; default "scope:"
     # schedule: "0 21 * * FRI"           # on_schedule only; robfig/cron/v3 standard (5-field) syntax
@@ -589,6 +595,10 @@ autopilot:
     generate_changelog: true
     notify_on_release: true
     require_ci: true
+    # generate_summary prepends an LLM (Haiku) "## What's New" summary to the
+    # release body. Requires ANTHROPIC_API_KEY in the daemon's environment —
+    # unset means the summary step is silently skipped (releases still ship,
+    # just without it). Has no effect under `publish: tag_only` (GH-3992).
     generate_summary: true
     # Who actually publishes the GitHub Release once the tag is created:
     #   workflow  (default when empty) - Pilot only creates the tag; the repo's

--- a/docs/content/features/autopilot-environments.mdx
+++ b/docs/content/features/autopilot-environments.mdx
@@ -256,6 +256,27 @@ All three environments share the same circuit breaker and rate limiting. If Pilo
 
 ---
 
+## Release Cadence & Scope Notes
+
+`release.trigger` controls when auto-release cuts a version, independently of the `dev`/`stage`/`prod` environment:
+
+| Trigger | Behavior |
+|---------|----------|
+| `on_merge` (default) | Release per merged PR. |
+| `manual` | Never auto-release. |
+| `on_scope_close` | Hold every merge belonging to an open epic (parent issue) or a shared `scope:`-prefixed label until the scope completes, then cut one release for the whole batch. Standalone merges (no epic/label) still release per-merge. |
+| `on_schedule` | Hold every merge for a cron release train (`schedule`, standard 5-field robfig/cron/v3 syntax). At each tick, everything merged since the last tag is batched into one release. |
+
+`scope_label_prefix` (default `"scope:"`) sets the label prefix `on_scope_close` groups by; `schedule`/`schedule_timezone` configure the `on_schedule` cron. All four — `trigger`, `scope_label_prefix`, `schedule`, `schedule_timezone` — are overlayable per-project under `projects:`, so one repo can run `on_merge` while another runs `on_scope_close` or `on_schedule` in the same autopilot config.
+
+A batched release (`on_scope_close`/`on_schedule`) gets an aggregated notes body instead of the single-PR changelog: a scope headline, commits grouped into Features/Bug Fixes/Other Changes with exact `#PR`/`GH-issue` attribution per entry, a Breaking Changes section, an LLM "What's New" summary (see `generate_summary` above), and a compare-link + PR/commit-count footer.
+
+<Callout type="warning">
+  Aggregated scope notes are only composed for `publish: api` or `publish: workflow` — `publish: tag_only` never creates a GitHub Release object, so there's nothing to attach notes to.
+</Callout>
+
+---
+
 ## CLI Override
 
 The `--autopilot` flag overrides the YAML `environment` setting:

--- a/docs/content/getting-started/configuration.mdx
+++ b/docs/content/getting-started/configuration.mdx
@@ -24,6 +24,7 @@ Pilot delegates AI execution to **Claude Code**, which manages its own authentic
 | **Telegram** | `TELEGRAM_BOT_TOKEN` env var or config | No |
 | **LLM classifier** (smart intent routing) | `ANTHROPIC_API_KEY` env var | No — falls back to keyword matching |
 | **Epic decomposition** (Haiku subtask parser) | `ANTHROPIC_API_KEY` env var | No — falls back to regex parser |
+| **Release summaries** (`autopilot.release.generate_summary`, Haiku "What's New") | `ANTHROPIC_API_KEY` env var | No — releases still ship without the summary section |
 | **Discord** | `DISCORD_BOT_TOKEN` env var or `adapters.discord.bot_token` in config | Yes, if using Discord |
 | **Plane** | `PLANE_API_KEY` env var or `adapters.plane.api_key` in config | Yes, if using Plane |
 
@@ -38,7 +39,7 @@ Pilot delegates AI execution to **Claude Code**, which manages its own authentic
 | `GITHUB_TOKEN` | GitHub personal access token (`repo` + `workflow` scopes) | If using GitHub |
 | `GITLAB_TOKEN` | GitLab personal or project access token | If using GitLab |
 | `TELEGRAM_BOT_TOKEN` | Telegram bot token for chat interface | No |
-| `ANTHROPIC_API_KEY` | Enables LLM intent classifier and structured subtask parsing | No |
+| `ANTHROPIC_API_KEY` | Enables LLM intent classifier, structured subtask parsing, and autopilot release "What's New" summaries | No |
 | `OPENAI_API_KEY` | Enables Whisper voice transcription in Telegram | No |
 | `SLACK_BOT_TOKEN` | Slack bot token for notifications | No |
 | `DISCORD_BOT_TOKEN` | Discord bot token for chat interface | No |

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2632,13 +2632,40 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 
 	releaseURL := fmt.Sprintf("https://github.com/%s/%s/releases/tag/%s", owner, repo, tagName)
 
+	// GH-3992: a scope carrier's deterministic notes (headline, grouped
+	// Features/Fixes/Other with exact per-member "(#PR, GH-Issue)"
+	// attribution, breaking changes, compare footer) are computed once here
+	// and reused both as the "api"-mode release body below and as the
+	// "workflow"-mode enrichment addition in afterTagCreated — one GitHub
+	// round trip per member PR regardless of publish mode.
+	var scopeNotesBody string
+	if isScope {
+		scopeNotesBody = BuildScopeReleaseNotes(ScopeNotesInput{
+			Owner:      owner,
+			Repo:       repo,
+			ScopeKey:   prState.ScopeKey,
+			ScopeTitle: prState.ScopeTitle,
+			Members:    c.buildScopeMembers(ctx, owner, repo, prState.ScopeMemberPRs),
+			LastTag:    currentVersion.String(rel.TagPrefix),
+			NewTag:     tagName,
+		})
+	}
+
 	// GH-3926: branch on the resolved publish mode. "workflow" (default)
 	// preserves the original behavior byte-for-byte — Pilot only tags, the
 	// repo's own tag-triggered CI (e.g. GoReleaser) publishes the release.
 	switch rel.PublishMode() {
 	case ReleasePublishAPI:
 		body := ""
-		if rel.GenerateChangelog {
+		switch {
+		case isScope:
+			// GH-3992: the scope notes ARE the body — no separate
+			// GenerateChangelog call, since it only ever attributes every
+			// entry to the single anchor PR (prState.PRNumber), not each
+			// member. The async enrichReleaseNotes below still prepends the
+			// LLM "What's New" on top when generate_summary is on.
+			body = scopeNotesBody
+		case rel.GenerateChangelog:
 			body = GenerateChangelog(commits, prState.PRNumber)
 		}
 		release, relErr := c.releaser.CreateReleaseForRepo(ctx, owner, repo, tagName, body)
@@ -2680,8 +2707,11 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 
 	// Enrichment + post-tag release verification (GH-3927), unified into a
 	// single goroutine so "workflow" mode polls for the release exactly once
-	// (afterTagCreated does not launch anything for "tag_only").
-	c.afterTagCreated(owner, repo, tagName, prState.PRNumber, prState.IssueNumber, commits, rel)
+	// (afterTagCreated does not launch anything for "tag_only"). scopeNotesBody
+	// is "" for a non-scope release — afterTagCreated's "api" branch ignores
+	// it (already folded into the body above); its "workflow" branch uses it
+	// to compose the scope-aware enrichment (GH-3992).
+	c.afterTagCreated(owner, repo, tagName, prState.PRNumber, prState.IssueNumber, commits, rel, scopeNotesBody)
 
 	// Send notification
 	if rel.NotifyOnRelease && c.notifier != nil {
@@ -2820,12 +2850,15 @@ func (c *Controller) escalateReleasingFailed(ctx context.Context, prState *PRSta
 // handleReleasing was called with) so a poll-tick cancellation cannot kill
 // verification or enrichment mid-flight — mirrors the pre-existing enrichment
 // goroutine this replaces.
-func (c *Controller) afterTagCreated(owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig) {
+func (c *Controller) afterTagCreated(owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig, scopeNotes string) {
 	if rel.PublishMode() == ReleasePublishTagOnly {
 		return
 	}
 
 	if rel.PublishMode() == ReleasePublishAPI {
+		// GH-3992: for a scope carrier, scopeNotes is already the release
+		// body handleReleasing created above — enrichReleaseNotes's plain
+		// prepend-only EnrichRelease is unchanged and correct here too.
 		logging.SafeGo("autopilot-controller", func() {
 			c.enrichReleaseNotes(owner, repo, tagName, commits, rel)
 		})
@@ -2838,7 +2871,7 @@ func (c *Controller) afterTagCreated(owner, repo, tagName string, prNumber, issu
 		timeout = releasePollTimeout
 	}
 	logging.SafeGo("autopilot-controller", func() {
-		c.verifyReleaseAfterTag(context.Background(), owner, repo, tagName, prNumber, issueNumber, commits, rel, releasePollInterval, timeout)
+		c.verifyReleaseAfterTag(context.Background(), owner, repo, tagName, prNumber, issueNumber, commits, rel, releasePollInterval, timeout, scopeNotes)
 	})
 }
 
@@ -2856,19 +2889,65 @@ func (c *Controller) enrichReleaseNotes(owner, repo, tagName string, commits []*
 	}
 }
 
+// enrichScopeReleaseNotes is enrichReleaseNotes' scope-carrier counterpart for
+// "workflow" publish mode: GoReleaser owns the release GitHub just published,
+// so the final body must compose LLM "## What's New" + the deterministic
+// scopeNotes + GoReleaser's original body, instead of enrichReleaseNotes'
+// prepend-only composition. Unlike enrichReleaseNotes, this does NOT
+// early-return when GenerateSummary is off or c.releaseSummary is nil — the
+// deterministic scope notes must ship regardless of whether the LLM step ran
+// (GH-3992 edge cases: `generate_summary: false` and no ANTHROPIC_API_KEY
+// both still get scope notes, just without the "What's New" section).
+// Best-effort like enrichReleaseNotes: logs and returns on failure.
+func (c *Controller) enrichScopeReleaseNotes(owner, repo, tagName string, commits []*github.Commit, rel *ReleaseConfig, scopeNotes string) {
+	enrichCtx, cancel := context.WithTimeout(context.Background(), releasePollTimeout+releaseSummaryTimeout)
+	defer cancel()
+
+	release, err := waitForReleaseByTag(enrichCtx, c.ghClient, c.log, owner, repo, tagName, releasePollInterval, releasePollTimeout)
+	if err != nil {
+		c.log.Warn("failed to enrich scope release notes: release never appeared", "tag", tagName, "error", err)
+		return
+	}
+
+	var summary string
+	if rel.GenerateSummary && c.releaseSummary != nil {
+		if s, sErr := c.releaseSummary.generateSummary(enrichCtx, tagName, commits); sErr != nil {
+			c.log.Warn("scope release: LLM summary generation failed, shipping without What's New", "tag", tagName, "error", sErr)
+		} else {
+			summary = s
+		}
+	}
+
+	body := scopeNotes
+	if summary != "" {
+		body = summary + "\n\n" + scopeNotes
+	}
+	body += "\n\n" + release.Body
+
+	if _, err := c.ghClient.UpdateRelease(enrichCtx, owner, repo, release.ID, &github.ReleaseInput{Body: body}); err != nil {
+		c.log.Warn("failed to update scope release body", "tag", tagName, "error", err)
+		return
+	}
+	c.log.Info("scope release enriched with notes", "tag", tagName)
+}
+
 // verifyReleaseAfterTag is the synchronous body of afterTagCreated's "workflow"
 // verification goroutine, factored out (interval/timeout as params) so tests can
 // call it directly with short values instead of racing a background goroutine
 // against the real releasePollInterval/VerifyTimeout. On success it enriches like
 // "api" mode; on timeout it fires a release_missing alert unless VerifyRelease
 // was explicitly disabled. GH-3927.
-func (c *Controller) verifyReleaseAfterTag(ctx context.Context, owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig, interval, timeout time.Duration) {
+func (c *Controller) verifyReleaseAfterTag(ctx context.Context, owner, repo, tagName string, prNumber, issueNumber int, commits []*github.Commit, rel *ReleaseConfig, interval, timeout time.Duration, scopeNotes string) {
 	verifyCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	if _, err := waitForReleaseByTag(verifyCtx, c.ghClient, c.log, owner, repo, tagName, interval, timeout); err != nil {
 		if rel.VerifyReleaseEnabled() {
 			c.fireReleaseMissingAlert(owner, repo, tagName, prNumber, issueNumber, timeout)
 		}
+		return
+	}
+	if scopeNotes != "" {
+		c.enrichScopeReleaseNotes(owner, repo, tagName, commits, rel, scopeNotes)
 		return
 	}
 	c.enrichReleaseNotes(owner, repo, tagName, commits, rel)

--- a/internal/autopilot/controller_release_verify_test.go
+++ b/internal/autopilot/controller_release_verify_test.go
@@ -59,7 +59,7 @@ func TestAfterTagCreated_WorkflowMode_ReleaseAppears(t *testing.T) {
 	c.SetAlertsEngine(sink)
 
 	rel := &ReleaseConfig{Publish: ReleasePublishWorkflow, VerifyRelease: boolPtr(true), VerifyTimeout: time.Second}
-	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v1.2.3", 42, 7, nil, rel, 5*time.Millisecond, 500*time.Millisecond)
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v1.2.3", 42, 7, nil, rel, 5*time.Millisecond, 500*time.Millisecond, "")
 
 	if len(sink.events) != 0 {
 		t.Errorf("expected no alert when the release appears in time, got %d events", len(sink.events))
@@ -90,7 +90,7 @@ func TestAfterTagCreated_WorkflowMode_Timeout_FiresAlert(t *testing.T) {
 	c.SetAlertsEngine(sink)
 
 	rel := &ReleaseConfig{Publish: ReleasePublishWorkflow, VerifyRelease: boolPtr(true), VerifyTimeout: 20 * time.Millisecond}
-	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond)
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond, "")
 
 	if len(sink.events) != 1 {
 		t.Fatalf("expected exactly 1 release_missing event, got %d", len(sink.events))
@@ -103,7 +103,7 @@ func TestAfterTagCreated_WorkflowMode_Timeout_FiresAlert(t *testing.T) {
 	}
 
 	// Same tag again — dedup must suppress a second event.
-	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond)
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v9.9.9", 42, 7, nil, rel, 5*time.Millisecond, 20*time.Millisecond, "")
 	if len(sink.events) != 1 {
 		t.Errorf("dedup: expected still exactly 1 event after re-verifying the same tag, got %d", len(sink.events))
 	}
@@ -121,7 +121,7 @@ func TestAfterTagCreated_WorkflowMode_VerifyDisabled_NoAlert(t *testing.T) {
 	c.SetAlertsEngine(sink)
 
 	rel := &ReleaseConfig{Publish: ReleasePublishWorkflow, VerifyRelease: boolPtr(false), VerifyTimeout: 20 * time.Millisecond}
-	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v5.5.5", 1, 0, nil, rel, 5*time.Millisecond, 20*time.Millisecond)
+	c.verifyReleaseAfterTag(context.Background(), "owner", "repo", "v5.5.5", 1, 0, nil, rel, 5*time.Millisecond, 20*time.Millisecond, "")
 
 	if len(sink.events) != 0 {
 		t.Errorf("expected no alert when VerifyRelease is explicitly false, got %d events", len(sink.events))
@@ -144,7 +144,7 @@ func TestAfterTagCreated_TagOnly_NoPolling(t *testing.T) {
 	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
 
 	rel := &ReleaseConfig{Publish: ReleasePublishTagOnly, VerifyRelease: boolPtr(true), VerifyTimeout: time.Second}
-	c.afterTagCreated("owner", "repo", "v1.0.0", 1, 0, nil, rel)
+	c.afterTagCreated("owner", "repo", "v1.0.0", 1, 0, nil, rel, "")
 
 	// afterTagCreated returns synchronously without launching a goroutine for
 	// tag_only, so no sleep/wait is needed before asserting.

--- a/internal/autopilot/release_summary.go
+++ b/internal/autopilot/release_summary.go
@@ -28,6 +28,12 @@ const (
 
 	// anthropicAPIURL is the Anthropic Messages API endpoint.
 	anthropicAPIURL = "https://api.anthropic.com/v1/messages"
+
+	// maxSummaryCommitLines caps how many commit first-lines are sent to the
+	// LLM per summary request — a release train (on_schedule) or a large
+	// scope can carry far more commits than a single per-merge release, and
+	// an unbounded prompt risks the request growing arbitrarily large (GH-3992).
+	maxSummaryCommitLines = 200
 )
 
 // ReleaseSummaryGenerator enriches GitHub releases with LLM-generated summaries.
@@ -151,6 +157,9 @@ func waitForReleaseByTag(ctx context.Context, ghClient *github.Client, log *slog
 func (g *ReleaseSummaryGenerator) generateSummary(ctx context.Context, tag string, commits []*github.Commit) (string, error) {
 	if len(commits) == 0 {
 		return fmt.Sprintf("## What's New in %s\n\nMaintenance release.", tag), nil
+	}
+	if len(commits) > maxSummaryCommitLines {
+		commits = commits[:maxSummaryCommitLines]
 	}
 
 	// Build commit list for the prompt

--- a/internal/autopilot/scope_notes.go
+++ b/internal/autopilot/scope_notes.go
@@ -1,0 +1,106 @@
+package autopilot
+
+import (
+	"fmt"
+	"strings"
+
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// ScopeMember pairs one member PR of a scope-release carrier with the commits
+// fetched specifically for that PR (scopeReleaseCommits/GetPRCommits already
+// fetches per-member, GH-3990) and, when resolvable, the GitHub issue it
+// closed. Carrying both lets BuildScopeReleaseNotes attribute every changelog
+// entry to an exact "(#PR, GH-Issue)" pair instead of falling back to the
+// scope's single anchor issue for every entry (GH-3992).
+type ScopeMember struct {
+	PR      int
+	Issue   int // 0 when the member PR carries no resolvable issue reference
+	Commits []*github.Commit
+}
+
+// ScopeNotesInput is the input to BuildScopeReleaseNotes.
+type ScopeNotesInput struct {
+	Owner      string
+	Repo       string
+	ScopeKey   string
+	ScopeTitle string
+	Members    []ScopeMember
+	LastTag    string
+	NewTag     string
+}
+
+// BuildScopeReleaseNotes renders the deterministic body for a scope-release
+// carrier: a headline, commits grouped into Features/Bug Fixes/Other Changes
+// (the same classification GenerateChangelog uses, releaser.go ~:208, but
+// with a per-entry "(#PR, GH-Issue)" attribution instead of one shared PR
+// number for the whole release), a "## ⚠ Breaking Changes" section when any
+// commit's first line trips parseBumpFromMessage's breaking predicate (`!`
+// suffix or a "BREAKING" commit type — body `BREAKING CHANGE:` footers are
+// out of scope, matching bump detection), and a compare-link + PR/commit
+// count footer (GH-3992).
+func BuildScopeReleaseNotes(in ScopeNotesInput) string {
+	headline := in.ScopeTitle
+	if headline == "" {
+		headline = in.ScopeKey
+	}
+
+	var features, fixes, others, breaking []string
+	commitCount := 0
+
+	for _, member := range in.Members {
+		attribution := fmt.Sprintf("#%d", member.PR)
+		if member.Issue > 0 {
+			attribution += fmt.Sprintf(", GH-%d", member.Issue)
+		}
+
+		for _, commit := range member.Commits {
+			commitCount++
+			msg := commit.Commit.Message
+			if idx := strings.Index(msg, "\n"); idx > 0 {
+				msg = msg[:idx]
+			}
+
+			description := msg
+			commitType := ""
+			if matches := conventionalCommitRegex.FindStringSubmatch(msg); matches != nil {
+				commitType = strings.ToLower(matches[1])
+				description = matches[4]
+			}
+			entry := fmt.Sprintf("- %s (%s)", description, attribution)
+
+			if parseBumpFromMessage(msg) == BumpMajor {
+				breaking = append(breaking, entry)
+			}
+
+			switch commitType {
+			case "feat", "feature":
+				features = append(features, entry)
+			case "fix", "bugfix":
+				fixes = append(fixes, entry)
+			default:
+				others = append(others, entry)
+			}
+		}
+	}
+
+	sections := []string{"# " + headline}
+	if len(features) > 0 {
+		sections = append(sections, "## Features\n"+strings.Join(features, "\n"))
+	}
+	if len(fixes) > 0 {
+		sections = append(sections, "## Bug Fixes\n"+strings.Join(fixes, "\n"))
+	}
+	if len(others) > 0 {
+		sections = append(sections, "## Other Changes\n"+strings.Join(others, "\n"))
+	}
+	if len(breaking) > 0 {
+		sections = append(sections, "## ⚠ Breaking Changes\n"+strings.Join(breaking, "\n"))
+	}
+
+	footer := fmt.Sprintf("**Full Changelog**: https://github.com/%s/%s/compare/%s...%s\n\n_%d PRs, %d commits_",
+		in.Owner, in.Repo, in.LastTag, in.NewTag, len(in.Members), commitCount)
+	sections = append(sections, footer)
+
+	return strings.Join(sections, "\n\n")
+}

--- a/internal/autopilot/scope_notes_test.go
+++ b/internal/autopilot/scope_notes_test.go
@@ -1,0 +1,140 @@
+package autopilot
+
+import (
+	"strings"
+	"testing"
+
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+func TestBuildScopeReleaseNotes(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      ScopeNotesInput
+		wantAll []string // substrings that must all appear
+		wantNot []string // substrings that must NOT appear
+	}{
+		{
+			name: "features fixes and other grouped with exact per-entry attribution",
+			in: ScopeNotesInput{
+				Owner:      "qf-studio",
+				Repo:       "pilot",
+				ScopeTitle: "Checkout epic",
+				Members: []ScopeMember{
+					{PR: 101, Issue: 201, Commits: []*github.Commit{makeCommit("feat(checkout): add coupon field")}},
+					{PR: 102, Issue: 202, Commits: []*github.Commit{makeCommit("fix(checkout): handle nil cart")}},
+					{PR: 103, Issue: 0, Commits: []*github.Commit{makeCommit("chore(deps): bump lodash")}},
+				},
+				LastTag: "v1.0.0",
+				NewTag:  "v1.1.0",
+			},
+			wantAll: []string{
+				"# Checkout epic",
+				"## Features",
+				"- add coupon field (#101, GH-201)",
+				"## Bug Fixes",
+				"- handle nil cart (#102, GH-202)",
+				"## Other Changes",
+				"- bump lodash (#103)",
+				"**Full Changelog**: https://github.com/qf-studio/pilot/compare/v1.0.0...v1.1.0",
+				"_3 PRs, 3 commits_",
+			},
+			wantNot: []string{"GH-0", "## ⚠ Breaking Changes"},
+		},
+		{
+			name: "breaking via ! suffix",
+			in: ScopeNotesInput{
+				ScopeTitle: "Auth rework",
+				Members: []ScopeMember{
+					{PR: 201, Issue: 301, Commits: []*github.Commit{makeCommit("feat(auth)!: drop legacy tokens")}},
+				},
+				LastTag: "v1.0.0",
+				NewTag:  "v2.0.0",
+			},
+			wantAll: []string{
+				"## ⚠ Breaking Changes",
+				"- drop legacy tokens (#201, GH-301)",
+				"## Features",
+			},
+		},
+		{
+			name: "breaking via BREAKING commit type prefix",
+			in: ScopeNotesInput{
+				ScopeTitle: "Auth rework",
+				Members: []ScopeMember{
+					{PR: 202, Commits: []*github.Commit{makeCommit("BREAKING: remove v1 endpoints")}},
+				},
+				LastTag: "v1.0.0",
+				NewTag:  "v2.0.0",
+			},
+			wantAll: []string{
+				"## ⚠ Breaking Changes",
+				"- remove v1 endpoints (#202)",
+			},
+		},
+		{
+			name: "BREAKING CHANGE footer form is out of scope, matching bump detection",
+			in: ScopeNotesInput{
+				ScopeTitle: "Auth rework",
+				Members: []ScopeMember{
+					{PR: 203, Commits: []*github.Commit{makeCommit("feat(auth): rotate keys\n\nBREAKING CHANGE: old keys invalid")}},
+				},
+				LastTag: "v1.0.0",
+				NewTag:  "v1.1.0",
+			},
+			wantAll: []string{"## Features", "- rotate keys (#203)"},
+			wantNot: []string{"## ⚠ Breaking Changes"},
+		},
+		{
+			name: "non-conventional commit message falls back to Other Changes",
+			in: ScopeNotesInput{
+				ScopeTitle: "Misc",
+				Members: []ScopeMember{
+					{PR: 301, Commits: []*github.Commit{makeCommit("update the README typo")}},
+				},
+				LastTag: "v1.0.0",
+				NewTag:  "v1.0.1",
+			},
+			wantAll: []string{"## Other Changes", "- update the README typo (#301)"},
+			wantNot: []string{"## Features", "## Bug Fixes"},
+		},
+		{
+			name: "empty scope title falls back to scope key",
+			in: ScopeNotesInput{
+				ScopeKey: "label:checkout",
+				Members:  nil,
+				LastTag:  "v1.0.0",
+				NewTag:   "v1.0.0",
+			},
+			wantAll: []string{"# label:checkout", "_0 PRs, 0 commits_"},
+			wantNot: []string{"## Features", "## Bug Fixes", "## Other Changes", "## ⚠ Breaking Changes"},
+		},
+		{
+			name: "empty members produce headline and footer only",
+			in: ScopeNotesInput{
+				ScopeTitle: "Empty scope",
+				Members:    []ScopeMember{{PR: 401, Commits: nil}},
+				LastTag:    "v1.0.0",
+				NewTag:     "v1.0.0",
+			},
+			wantAll: []string{"# Empty scope", "_1 PRs, 0 commits_"},
+			wantNot: []string{"## Features", "## Bug Fixes", "## Other Changes"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildScopeReleaseNotes(tt.in)
+			for _, want := range tt.wantAll {
+				if !strings.Contains(got, want) {
+					t.Errorf("BuildScopeReleaseNotes() missing %q\n--- got ---\n%s", want, got)
+				}
+			}
+			for _, notWant := range tt.wantNot {
+				if strings.Contains(got, notWant) {
+					t.Errorf("BuildScopeReleaseNotes() unexpectedly contains %q\n--- got ---\n%s", notWant, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/autopilot/scope_release.go
+++ b/internal/autopilot/scope_release.go
@@ -12,6 +12,15 @@ import (
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
+// closesIssueRegex extracts the issue number from a "Closes #N" (or
+// Fixes/Resolves, singular or plural) reference in a PR body — the
+// convention Pilot's own PR bodies use when created from a source issue
+// (internal/executor/runner.go). Best-effort: a member PR with no such
+// reference (e.g. a human-authored merge) simply gets Issue == 0 in its
+// ScopeMember, which BuildScopeReleaseNotes renders without the GH-<N> half
+// of the attribution (GH-3992).
+var closesIssueRegex = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)`)
+
 // maxScopeReleaseAttempts caps how many times a scope-release carrier may fail
 // (post-merge CI red/timeout, or a handleReleasing escalation) before the
 // scope is given up on and flagged for human attention via a
@@ -261,6 +270,37 @@ func (c *Controller) scopeReleaseCommits(ctx context.Context, owner, repo string
 	c.log.Warn("scope release: member commit union empty, falling back to compare against last tag",
 		"scope", prState.ScopeKey, "last_tag", lastTag, "head_sha", ShortSHA(prState.HeadSHA))
 	return c.ghClient.CompareCommits(ctx, owner, repo, lastTag, prState.HeadSHA)
+}
+
+// buildScopeMembers resolves each member PR's own commits and, best-effort,
+// the GitHub issue it closed (parsed from the PR body via closesIssueRegex)
+// so BuildScopeReleaseNotes can render exact per-entry "(#PR, GH-Issue)"
+// attribution. A per-member lookup failure logs a warning and leaves that
+// member with a zero Issue / empty Commits rather than failing the whole
+// scope release — the deterministic notes are best-effort, matching
+// scopeReleaseCommits' own per-member tolerance (GH-3992).
+func (c *Controller) buildScopeMembers(ctx context.Context, owner, repo string, memberPRs []int) []ScopeMember {
+	members := make([]ScopeMember, 0, len(memberPRs))
+	for _, pr := range memberPRs {
+		member := ScopeMember{PR: pr}
+
+		if commits, err := c.ghClient.GetPRCommits(ctx, owner, repo, pr); err != nil {
+			c.log.Warn("buildScopeMembers: failed to fetch member PR commits", "pr", pr, "error", err)
+		} else {
+			member.Commits = commits
+		}
+
+		if pull, err := c.ghClient.GetPullRequest(ctx, owner, repo, pr); err != nil {
+			c.log.Warn("buildScopeMembers: failed to fetch member PR for issue attribution", "pr", pr, "error", err)
+		} else if m := closesIssueRegex.FindStringSubmatch(pull.Body); m != nil {
+			if n, convErr := strconv.Atoi(m[1]); convErr == nil {
+				member.Issue = n
+			}
+		}
+
+		members = append(members, member)
+	}
+	return members
 }
 
 // markScopeReleaseDone records a scope carrier's successful (or no-op)

--- a/internal/autopilot/scope_release_enrich_test.go
+++ b/internal/autopilot/scope_release_enrich_test.go
@@ -1,0 +1,106 @@
+package autopilot
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestEnrichScopeReleaseNotes verifies the "workflow" publish-mode composition
+// order for a scope carrier: LLM "## What's New" + deterministic scope notes
+// + GoReleaser's original body — and that the deterministic scope notes still
+// ship when the LLM step is disabled or unconfigured (GH-3992 edge cases).
+func TestEnrichScopeReleaseNotes(t *testing.T) {
+	const scopeNotes = "# Checkout epic\n\n## Features\n- add coupon field (#101, GH-201)"
+	const originalBody = "* commit 1\n* commit 2 (GoReleaser-generated)"
+	const llmSummary = "## What's New in v1.1.0\n\n- Coupons at checkout"
+
+	tests := []struct {
+		name            string
+		generateSummary bool
+		withGenerator   bool
+		wantSummary     bool
+	}{
+		{name: "LLM enabled and configured", generateSummary: true, withGenerator: true, wantSummary: true},
+		{name: "generate_summary false skips LLM but ships scope notes", generateSummary: false, withGenerator: true, wantSummary: false},
+		{name: "no generator configured (no ANTHROPIC_API_KEY) skips LLM but ships scope notes", generateSummary: true, withGenerator: false, wantSummary: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var updatedBody string
+			ghServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
+					w.WriteHeader(http.StatusOK)
+					_, _ = fmt.Fprintf(w, `{"id":42,"tag_name":"v1.1.0","body":%q}`, originalBody)
+				case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/releases/42"):
+					var input map[string]interface{}
+					_ = json.NewDecoder(r.Body).Decode(&input)
+					updatedBody, _ = input["body"].(string)
+					w.WriteHeader(http.StatusOK)
+					_, _ = fmt.Fprint(w, `{"id":42,"tag_name":"v1.1.0"}`)
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer ghServer.Close()
+
+			anthropicServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprintf(w, `{"content":[{"text":%q}]}`, llmSummary)
+			}))
+			defer anthropicServer.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, ghServer.URL)
+			c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+			if tt.withGenerator {
+				gen := &ReleaseSummaryGenerator{
+					ghClient:   ghClient,
+					apiKey:     testutil.FakeAnthropicKey,
+					httpClient: http.DefaultClient,
+					apiURL:     anthropicServer.URL,
+					log:        slog.Default(),
+				}
+				c.SetReleaseSummaryGenerator(gen)
+			}
+
+			rel := &ReleaseConfig{GenerateSummary: tt.generateSummary}
+			commits := []*github.Commit{makeCommit("feat(checkout): add coupon field")}
+
+			c.enrichScopeReleaseNotes("owner", "repo", "v1.1.0", commits, rel, scopeNotes)
+
+			if !strings.Contains(updatedBody, scopeNotes) {
+				t.Errorf("updated body must contain scope notes; got %q", updatedBody)
+			}
+			if !strings.Contains(updatedBody, originalBody) {
+				t.Errorf("updated body must preserve the original workflow body; got %q", updatedBody)
+			}
+			if tt.wantSummary != strings.Contains(updatedBody, "What's New") {
+				t.Errorf("What's New presence = %v, want %v; got %q",
+					strings.Contains(updatedBody, "What's New"), tt.wantSummary, updatedBody)
+			}
+
+			scopeIdx := strings.Index(updatedBody, scopeNotes)
+			origIdx := strings.Index(updatedBody, originalBody)
+			if scopeIdx == -1 || origIdx == -1 || scopeIdx > origIdx {
+				t.Errorf("expected scope notes before original body; got %q", updatedBody)
+			}
+			if tt.wantSummary {
+				summaryIdx := strings.Index(updatedBody, "What's New")
+				if summaryIdx == -1 || summaryIdx > scopeIdx {
+					t.Errorf("expected LLM summary before scope notes; got %q", updatedBody)
+				}
+			}
+		})
+	}
+}

--- a/internal/autopilot/scope_release_test.go
+++ b/internal/autopilot/scope_release_test.go
@@ -3,6 +3,7 @@ package autopilot
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -557,5 +558,113 @@ func TestScanRecentlyMergedPRs_SkipsScopeMemberPending(t *testing.T) {
 	}
 	if got := atomic.LoadInt64(&gitRefPosts); got != 0 {
 		t.Errorf("git/refs POST count = %d, want 0 (scanner must not cut a per-merge tag for a scope member)", got)
+	}
+}
+
+// TestScopeCarrierAPIMode_ReleaseBodyContainsAllElements drives a scope
+// carrier through publish mode "api" and verifies the release body created by
+// CreateReleaseForRepo (handleReleasing's synchronous body — the LLM
+// "What's New" addition is applied asynchronously afterward and is covered
+// separately by TestEnrichScopeReleaseNotes) contains the locked notes
+// requirements: scope headline, grouped Features with exact #PR + GH-issue
+// attribution, a Breaking Changes section, and a compare + stats footer
+// (GH-3992).
+func TestScopeCarrierAPIMode_ReleaseBodyContainsAllElements(t *testing.T) {
+	var createdBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/branches/main":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "main", "commit": map[string]string{"sha": "mainsha"}})
+		case r.URL.Path == "/repos/owner/repo/commits/mainsha/check-runs":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: "completed", Conclusion: "success"}},
+			})
+		case strings.Contains(r.URL.Path, "/pulls/101") && strings.HasSuffix(r.URL.Path, "/commits"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat(checkout)!: drop legacy coupon codes")})
+		case r.URL.Path == "/repos/owner/repo/pulls/101":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.PullRequest{Number: 101, Body: "Closes #201", Merged: true})
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v1.0.0"})
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(r.URL.Path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "identical"})
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/releases":
+			var input map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&input)
+			createdBody, _ = input["body"].(string)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(github.Release{ID: 99, HTMLURL: "https://github.com/owner/repo/releases/tag/v2.0.0"})
+		case strings.HasSuffix(r.URL.Path, "/git/refs"):
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	stateStore := newTestStateStore(t)
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.CIWaitTimeout = 5 * time.Second
+	cfg.Release = &ReleaseConfig{
+		Enabled:           true,
+		Trigger:           "on_scope_close",
+		ScopeLabelPrefix:  "scope:",
+		TagPrefix:         "v",
+		RequireCI:         true,
+		VerifyRelease:     boolPtr(false),
+		Publish:           ReleasePublishAPI,
+		GenerateChangelog: true,
+		GenerateSummary:   true,
+	}
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+	c.SetReleaseSummaryGenerator(&ReleaseSummaryGenerator{
+		ghClient:   ghClient,
+		apiKey:     testutil.FakeAnthropicKey,
+		httpClient: http.DefaultClient,
+		apiURL:     "http://127.0.0.1:0", // never called synchronously by handleReleasing's api-mode body
+		log:        slog.Default(),
+	})
+
+	if err := stateStore.EnqueueScopeRelease("owner/repo", "epic:1", "Checkout epic", []int{101}); err != nil {
+		t.Fatalf("EnqueueScopeRelease failed: %v", err)
+	}
+	c.startPendingScopeReleases(context.Background())
+
+	carrier, ok := c.GetPRState(101)
+	if !ok {
+		t.Fatal("expected carrier registered")
+	}
+	if err := c.handlePostMergeCI(context.Background(), carrier); err != nil {
+		t.Fatalf("handlePostMergeCI() error = %v", err)
+	}
+	if err := c.handleReleasing(context.Background(), carrier); err != nil {
+		t.Fatalf("handleReleasing() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"# Checkout epic",
+		"## Features",
+		"(#101, GH-201)",
+		"## ⚠ Breaking Changes",
+		"**Full Changelog**:",
+		"_1 PRs, 1 commits_",
+	} {
+		if !strings.Contains(createdBody, want) {
+			t.Errorf("release body missing %q\n--- got ---\n%s", want, createdBody)
+		}
 	}
 }

--- a/internal/autopilot/telegram_notifier.go
+++ b/internal/autopilot/telegram_notifier.go
@@ -119,16 +119,24 @@ func (n *TelegramNotifier) NotifyReleased(ctx context.Context, prState *PRState,
 		bumpLabel = "patch release"
 	}
 
+	// GH-3992: a scope carrier (ScopeTitle set) represents many member PRs
+	// batched into one release, not a single source PR — render the scope
+	// headline and member count instead of a misleading "From PR: #<anchor>".
+	sourceLine := fmt.Sprintf("From PR: #%d", prState.PRNumber)
+	if prState.ScopeTitle != "" {
+		sourceLine = fmt.Sprintf("Scope: %s (%d PRs)", escapeMarkdown(prState.ScopeTitle), len(prState.ScopeMemberPRs))
+	}
+
 	msg := fmt.Sprintf("%s✨ *Release %s Published*\n\n"+
 		"Version: `%s`\n"+
 		"Type: %s\n"+
-		"From PR: #%d\n\n"+
+		"%s\n\n"+
 		"[View Release](%s)",
 		envPrefix(prState),
 		escapeMarkdown(prState.ReleaseVersion),
 		prState.ReleaseVersion,
 		bumpLabel,
-		prState.PRNumber,
+		sourceLine,
 		releaseURL,
 	)
 

--- a/internal/autopilot/telegram_notifier_test.go
+++ b/internal/autopilot/telegram_notifier_test.go
@@ -304,6 +304,38 @@ func TestTelegramNotifier_NotifyReleased(t *testing.T) {
 	}
 }
 
+// TestTelegramNotifier_NotifyReleased_ScopeCarrier verifies that a scope
+// carrier (ScopeTitle set) renders "Scope: <title> (<K> PRs)" instead of the
+// misleading "From PR: #<anchor>" a scope release's anchor PR would
+// otherwise imply (GH-3992).
+func TestTelegramNotifier_NotifyReleased_ScopeCarrier(t *testing.T) {
+	var receivedText string
+	notifier, server := newTestNotifier(t, &receivedText)
+	defer server.Close()
+
+	prState := &PRState{
+		PRNumber:        102,
+		ReleaseVersion:  "v1.2.0",
+		ReleaseBumpType: BumpMinor,
+		EnvironmentName: "staging",
+		ScopeKey:        "epic:1",
+		ScopeTitle:      "Checkout epic",
+		ScopeMemberPRs:  []int{101, 102},
+	}
+
+	err := notifier.NotifyReleased(context.Background(), prState, "https://github.com/owner/repo/releases/tag/v1.2.0")
+	if err != nil {
+		t.Fatalf("NotifyReleased error: %v", err)
+	}
+
+	if !strings.Contains(receivedText, "Scope: Checkout epic (2 PRs)") {
+		t.Errorf("expected scope headline, got: %s", receivedText)
+	}
+	if strings.Contains(receivedText, "From PR:") {
+		t.Errorf("scope carrier must not render the anchor-PR line, got: %s", receivedText)
+	}
+}
+
 func TestNewTelegramNotifier(t *testing.T) {
 	client := telegram.NewClient("test-token")
 	notifier := NewTelegramNotifier(client, "123456")


### PR DESCRIPTION
## Summary

Closes #3992

- `BuildScopeReleaseNotes` (`internal/autopilot/scope_notes.go`): scope headline, `## Features` / `## Bug Fixes` / `## Other Changes` grouped by conventional-commit type with exact per-member `(#PR, GH-Issue)` attribution, `## ⚠ Breaking Changes` (via `parseBumpFromMessage`'s existing breaking predicate), and a compare-link + PR/commit-count footer.
- `internal/autopilot/scope_release.go`: `buildScopeMembers` resolves each member PR's own commits plus its closed issue (parsed from the PR body via `closesIssueRegex`) so notes attribute correctly.
- `internal/autopilot/controller.go`: `handleReleasing` computes scope notes once per scope carrier and reuses them as the `publish: api` release body, or composes them with the LLM summary and GoReleaser's own body under `publish: workflow` via the new `enrichScopeReleaseNotes`.
- `cmd/pilot/main.go`: wires `ReleaseSummaryGenerator` (Haiku, `ANTHROPIC_API_KEY`-gated, nil is a no-op) into all three `NewController` construction sites via `SetReleaseSummaryGenerator`.
- `internal/autopilot/telegram_notifier.go`: `NotifyReleased` renders `Scope: <title> (<K> PRs)` for scope carriers instead of a misleading single "From PR" line.
- `configs/pilot.example.yaml` + docs (`autopilot-environments.mdx`, `configuration.mdx`): document scope notes composition and the `ANTHROPIC_API_KEY` dependency for release summaries.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` — green, incl. `TestBuildScopeReleaseNotes` table (features/fixes/other, breaking via `!` and `BREAKING` prefix, `BREAKING CHANGE:` footer out-of-scope, non-conventional fallback, empty scope, empty members), enrichment-composition ordering, notifier scope-headline test
- [x] `make lint` — 0 issues
- [x] Per-merge (non-scope) release bodies unchanged — `GenerateChangelog` untouched
- [x] No `ANTHROPIC_API_KEY` → identical behavior to today (nil generator, deterministic notes still ship)