### PR TITLE
fix(executor): guard direct-path PR creation against branch already merged/open

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -20,6 +20,7 @@
 | Task execution | ✅ | executor | `pilot task` | - | Claude Code subprocess |
 | Branch creation | ✅ | executor | `--no-branch` disables | - | Auto `pilot/TASK-XXX` |
 | PR creation | ✅ | executor | `--create-pr` | - | Via `gh pr create` |
+| Direct-path duplicate-PR guard | ✅ | executor | - | - | Pre-push merged-branch short-circuit + pre-create open-PR adoption on the non-epic path, mirrors TASK-359 Shape C (GH-4022) |
 | Progress display | ✅ | executor | - | - | Lipgloss visual bar |
 | Navigator detection | ✅ | executor | - | - | Auto-prefix if `.agent/` exists |
 | AGENTS.md loading | ✅ | executor | - | - | LoadAgentsFile reads project AGENTS.md (v0.24.1) |

--- a/.agent/tasks/gh-4022.md
+++ b/.agent/tasks/gh-4022.md
@@ -1,0 +1,10 @@
+# GH-4022
+
+**Created:** 2026-07-07
+
+## Problem
+
+In internal/executor/runner.go (~line 3880, direct-path git.CreatePR branch), before push+create, check for an already-merged PR on the task branch via FindMergedPRByBranch (mirroring the TASK-359 Shape C short-circuit on the epic finalization path). Also consult the adopted-PR registry / autopilot_pr_state. On hit: record pr_created+merged success events referencing the existing PR number, skip the push (autopilot may have deleted the branch) and skip CreatePR. Table-driven test covering: (a) branch PR merged mid-run → no second PR, execution success with existing PR ref; (b) branch PR still open → adopt, no duplicate; (c) no prior PR → create as today. Regression fixture: execution 76c1c97f event sequence.
+
+## Acceptance Criteria
+

--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -259,6 +259,25 @@ func (g *GitOperations) FindMergedPRByBranch(ctx context.Context, branch string)
 	return parseFirstPRURL(output), nil
 }
 
+// FindOpenPRByBranch returns the URL of an open PR whose head is branch, or ""
+// if none exists. GH-4022: lets the direct (non-epic) executor path adopt an
+// already-open PR from a prior/retried dispatch of the same branch instead of
+// racing gh CLI into a duplicate PR.
+func (g *GitOperations) FindOpenPRByBranch(ctx context.Context, branch string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "list",
+		"--head", branch,
+		"--state", "open",
+		"--json", "url",
+		"--limit", "1",
+	)
+	cmd.Dir = g.projectPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to list open PRs for %s: %w: %s", branch, err, output)
+	}
+	return parseFirstPRURL(output), nil
+}
+
 // parseFirstPRURL extracts the first "url" field from `gh pr list --json url`
 // output (a JSON array like [{"url":"https://github.com/o/r/pull/1"}]). Returns
 // "" for an empty array or unparseable input.

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1570,6 +1570,68 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 	r.reportProgress(task.ID, "Complete", 100, "Epic completed successfully")
 }
 
+// checkAlreadyMergedBranch consults FindMergedPRByBranch on the direct
+// (non-epic) execution path, BEFORE push+CreatePR. GH-4022: mirrors the
+// TASK-359 Shape C short-circuit on the epic finalization path
+// (finalizeEpicBranchPR above, Shape C check), which runs the same lookup
+// AFTER push. The direct path must check first: a retried/duplicate dispatch
+// of a branch whose PR already merged may find autopilot has already deleted
+// the remote branch, so push would fail (or resurrect stale work) here.
+//
+// On a hit, the existing PR's pr_created + merged events are recorded so the
+// execution row carries a deliverable reference instead of stranding with an
+// empty pr_url and possibly opening a second PR for the same work.
+// Regression shape: execution 76c1c97f (retried dispatch raced a merge and
+// opened a duplicate PR because the direct path never re-checked branch state
+// before push+create).
+func (r *Runner) checkAlreadyMergedBranch(ctx context.Context, git *GitOperations, task *Task, result *ExecutionResult, recorder *replay.Recorder) bool {
+	mergedURL, mergedErr := git.FindMergedPRByBranch(ctx, task.Branch)
+	if mergedErr != nil || mergedURL == "" {
+		return false
+	}
+	result.PRUrl = mergedURL
+	r.log.Info("Branch already merged, skipping push and PR creation",
+		slog.String("task_id", task.ID),
+		slog.String("branch", task.Branch),
+		slog.String("pr_url", mergedURL),
+	)
+	r.reportProgress(task.ID, "Completed", 100, fmt.Sprintf("work already merged: %s", mergedURL))
+	r.saveLogEntry(task.LogExecutionID(), "info", "branch already merged, existing PR: "+mergedURL)
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StagePRCreated, "pr already exists (pre-push merge check): "+mergedURL)
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StageMerged, "branch already merged: "+mergedURL)
+	if recorder != nil {
+		recorder.SetPRUrl(mergedURL)
+	}
+	return true
+}
+
+// adoptOpenBranchPR consults FindOpenPRByBranch on the direct execution path,
+// AFTER push (the branch must exist on the remote for gh CLI to find it) but
+// BEFORE CreatePR. GH-4022: a retried dispatch that already pushed this
+// branch in a prior run may find an open PR awaiting review — reuse it
+// instead of racing gh CLI into a duplicate PR for the same branch. Unlike
+// checkAlreadyMergedBranch, push still runs first here so any new commits
+// from this run reach the existing open PR.
+func (r *Runner) adoptOpenBranchPR(ctx context.Context, git *GitOperations, task *Task, result *ExecutionResult, recorder *replay.Recorder) bool {
+	openURL, openErr := git.FindOpenPRByBranch(ctx, task.Branch)
+	if openErr != nil || openURL == "" {
+		return false
+	}
+	result.PRUrl = openURL
+	r.log.Info("Branch already has an open PR, adopting instead of creating a duplicate",
+		slog.String("task_id", task.ID),
+		slog.String("branch", task.Branch),
+		slog.String("pr_url", openURL),
+	)
+	r.reportProgress(task.ID, "Completed", 100, fmt.Sprintf("adopted existing PR: %s", openURL))
+	r.saveLogEntry(task.LogExecutionID(), "info", "adopted existing open PR: "+openURL)
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StagePRCreated, "adopted existing open pr: "+openURL)
+	if recorder != nil {
+		recorder.SetPRUrl(openURL)
+	}
+	return true
+}
+
 // classifyZeroDeliveryEpicCompletion reclassifies an epic-parent result that
 // reports Success=true but carries no evidence any real work happened —
 // zero tokens burned by Claude (planning or children), zero files changed,
@@ -3721,6 +3783,14 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			// Create PR if requested and we have commits
 			r.reportProgress(task.ID, "Creating PR", 96, "Pushing branch...")
 
+			// GH-4022: an already-merged branch short-circuits push+CreatePR —
+			// must run BEFORE the no-commits guard below and before push, since a
+			// merged branch may already be deleted on the remote (see
+			// checkAlreadyMergedBranch doc comment).
+			if r.checkAlreadyMergedBranch(ctx, git, task, result, recorder) {
+				return result, nil
+			}
+
 			// Determine base branch before the no-commits guard.
 			baseBranch := task.BaseBranch
 			if baseBranch == "" {
@@ -3838,6 +3908,14 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 					r.reportProgress(task.ID, "PR Failed", 100, result.Error)
 					return result, nil
 				}
+			}
+
+			// GH-4022: adopt an already-open PR for this branch (e.g. a retried
+			// dispatch that pushed in a prior run) instead of racing gh CLI into a
+			// duplicate PR. Runs after push so the branch is guaranteed to exist on
+			// the remote for the gh CLI lookup.
+			if r.adoptOpenBranchPR(ctx, git, task, result, recorder) {
+				return result, nil
 			}
 
 			r.reportProgress(task.ID, "Creating PR", 98, "Creating pull request...")

--- a/internal/executor/runner_gh4022_test.go
+++ b/internal/executor/runner_gh4022_test.go
@@ -1,0 +1,210 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// writeFakeGhPRList writes a fake "gh" binary to fakeBin that answers
+// `gh pr list --head <branch> --state <merged|open> --json url --limit 1`
+// by inspecting the --state flag: "merged" state returns mergedJSON, "open"
+// state returns openJSON, anything else (e.g. a later `gh pr create` call)
+// returns an empty array so an accidental call is visible in assertions
+// rather than silently satisfied.
+func writeFakeGhPRList(t *testing.T, fakeBin string, mergedJSON, openJSON []byte) {
+	t.Helper()
+	mergedFile := filepath.Join(fakeBin, "merged.json")
+	openFile := filepath.Join(fakeBin, "open.json")
+	if err := os.WriteFile(mergedFile, mergedJSON, 0o644); err != nil {
+		t.Fatalf("write merged.json: %v", err)
+	}
+	if err := os.WriteFile(openFile, openJSON, 0o644); err != nil {
+		t.Fatalf("write open.json: %v", err)
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+case "$*" in
+  *"--state merged"*) cat %q ;;
+  *"--state open"*) cat %q ;;
+  *) echo "[]" ;;
+esac
+`, mergedFile, openFile)
+	if err := os.WriteFile(filepath.Join(fakeBin, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+}
+
+// setUpFakeGhPATH prepends a fake "gh" binary (see writeFakeGhPRList) to PATH
+// for the duration of the test and returns its directory.
+func setUpFakeGhPATH(t *testing.T, mergedJSON, openJSON []byte) string {
+	t.Helper()
+	fakeBin := t.TempDir()
+	writeFakeGhPRList(t, fakeBin, mergedJSON, openJSON)
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+os.Getenv("PATH"))
+	return fakeBin
+}
+
+// TestDirectPathExistingBranchPR is the GH-4022 table-driven regression
+// suite for the direct (non-epic) execution path's pre-push/pre-create
+// branch-PR checks (checkAlreadyMergedBranch, adoptOpenBranchPR). It mirrors
+// the TASK-359 Shape C short-circuit on the epic finalization path
+// (finalizeEpicBranchPR, runner_task359_test.go) but exercises the direct
+// path's two checkpoints instead of one.
+//
+// Regression shape: execution 76c1c97f — a retried/duplicate dispatch of a
+// branch whose PR had already merged reached push+CreatePR again because the
+// direct path never re-checked branch state, producing a duplicate PR.
+func TestDirectPathExistingBranchPR(t *testing.T) {
+	tests := []struct {
+		name string
+		// mergedJSON/openJSON are the fake `gh pr list` responses for
+		// --state merged / --state open respectively.
+		mergedJSON []byte
+		openJSON   []byte
+
+		// wantMergedHandled/wantOpenHandled assert which checkpoint (if any)
+		// short-circuits the direct path.
+		wantMergedHandled bool
+		wantOpenHandled   bool
+		wantPRUrl         string
+		wantStages        []memory.Stage
+	}{
+		{
+			// (a) branch PR merged mid-run: the pre-push check finds a
+			// merged PR and short-circuits before push+CreatePR ever run —
+			// no second PR is opened, and the execution records success
+			// referencing the existing PR.
+			name:              "branch PR merged mid-run: no second PR, success with existing PR ref",
+			mergedJSON:        []byte(`[{"url":"https://github.com/o/r/pull/42"}]`),
+			openJSON:          []byte(`[]`),
+			wantMergedHandled: true,
+			wantOpenHandled:   false,
+			wantPRUrl:         "https://github.com/o/r/pull/42",
+			wantStages:        []memory.Stage{memory.StagePRCreated, memory.StageMerged},
+		},
+		{
+			// (b) branch PR still open: not merged, so the pre-push check
+			// does not fire — but the pre-create check adopts the open PR
+			// instead of creating a duplicate.
+			name:              "branch PR still open: adopt, no duplicate",
+			mergedJSON:        []byte(`[]`),
+			openJSON:          []byte(`[{"url":"https://github.com/o/r/pull/43"}]`),
+			wantMergedHandled: false,
+			wantOpenHandled:   true,
+			wantPRUrl:         "https://github.com/o/r/pull/43",
+			wantStages:        []memory.Stage{memory.StagePRCreated},
+		},
+		{
+			// (c) no prior PR: neither checkpoint fires, leaving the
+			// existing push+CreatePR flow to run as today.
+			name:              "no prior PR: create as today",
+			mergedJSON:        []byte(`[]`),
+			openJSON:          []byte(`[]`),
+			wantMergedHandled: false,
+			wantOpenHandled:   false,
+			wantPRUrl:         "",
+			wantStages:        nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setUpFakeGhPATH(t, tt.mergedJSON, tt.openJSON)
+
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+
+			r := newSilentRunnerTask359()
+			r.SetLogStore(store)
+			git := NewGitOperations(t.TempDir())
+			task := &Task{
+				ID:       "GH-4022",
+				Title:    "feat: existing branch PR handling",
+				Branch:   "pilot/GH-4022",
+				CreatePR: true,
+			}
+			if err := store.SaveExecution(&memory.Execution{ID: task.ID, TaskID: task.ID, Status: "running"}); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+			result := &ExecutionResult{TaskID: task.ID, Success: true}
+
+			mergedHandled := r.checkAlreadyMergedBranch(context.Background(), git, task, result, nil)
+			if mergedHandled != tt.wantMergedHandled {
+				t.Fatalf("checkAlreadyMergedBranch handled = %v, want %v", mergedHandled, tt.wantMergedHandled)
+			}
+
+			var openHandled bool
+			if !mergedHandled {
+				openHandled = r.adoptOpenBranchPR(context.Background(), git, task, result, nil)
+				if openHandled != tt.wantOpenHandled {
+					t.Fatalf("adoptOpenBranchPR handled = %v, want %v", openHandled, tt.wantOpenHandled)
+				}
+			}
+
+			if result.PRUrl != tt.wantPRUrl {
+				t.Errorf("result.PRUrl = %q, want %q", result.PRUrl, tt.wantPRUrl)
+			}
+			if !result.Success {
+				t.Errorf("expected Success to remain true, got false (error=%q)", result.Error)
+			}
+
+			events, err := store.ListExecutionEvents(task.LogExecutionID())
+			if err != nil {
+				t.Fatalf("ListExecutionEvents: %v", err)
+			}
+			if len(events) != len(tt.wantStages) {
+				var gotStages []memory.Stage
+				for _, e := range events {
+					gotStages = append(gotStages, e.Stage)
+				}
+				t.Fatalf("got %d events %v, want %d %v", len(events), gotStages, len(tt.wantStages), tt.wantStages)
+			}
+			for i, want := range tt.wantStages {
+				if events[i].Stage != want {
+					t.Errorf("event[%d].Stage = %q, want %q", i, events[i].Stage, want)
+				}
+			}
+			if tt.wantPRUrl != "" && len(events) > 0 && !strings.Contains(events[0].Detail, tt.wantPRUrl) {
+				t.Errorf("event[0].Detail = %q, want it to reference %q", events[0].Detail, tt.wantPRUrl)
+			}
+			// (c): neither checkpoint should have consumed the branch — the
+			// caller falls through to the existing push+CreatePR flow.
+			if tt.name == "no prior PR: create as today" && (mergedHandled || openHandled) {
+				t.Error("expected neither checkpoint to fire so the existing create-PR flow runs unmodified")
+			}
+		})
+	}
+}
+
+// TestAdoptOpenBranchPR_NotCalledWhenMerged verifies checkAlreadyMergedBranch
+// and adoptOpenBranchPR compose correctly: a caller that short-circuits on
+// checkAlreadyMergedBranch's true return must never invoke adoptOpenBranchPR
+// (mirrors the runner.go call-site guard `if !mergedHandled { ... }`), so a
+// merged branch never triggers a second gh CLI open-PR lookup at all.
+func TestAdoptOpenBranchPR_NotCalledWhenMerged(t *testing.T) {
+	setUpFakeGhPATH(t,
+		[]byte(`[{"url":"https://github.com/o/r/pull/99"}]`),  // merged
+		[]byte(`[{"url":"https://github.com/o/r/pull/100"}]`), // open — must never be consulted
+	)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	r := newSilentRunnerTask359()
+	r.SetLogStore(store)
+	git := NewGitOperations(t.TempDir())
+	task := &Task{ID: "GH-4022B", Title: "feat: x", Branch: "pilot/GH-4022B", CreatePR: true}
+	result := &ExecutionResult{TaskID: task.ID, Success: true}
+
+	if !r.checkAlreadyMergedBranch(context.Background(), git, task, result, nil) {
+		t.Fatal("expected checkAlreadyMergedBranch to short-circuit")
+	}
+	if result.PRUrl != "https://github.com/o/r/pull/99" {
+		t.Errorf("PRUrl = %q, want the merged PR (99), not the open one (100)", result.PRUrl)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #4022

- Adds a pre-push `FindMergedPRByBranch` check to the direct (non-epic) execution path in `internal/executor/runner.go` (`checkAlreadyMergedBranch`), mirroring the TASK-359 Shape C short-circuit already used on the epic finalization path (`finalizeEpicBranchPR`). On a hit, push and `CreatePR` are both skipped — a retried/duplicate dispatch of an already-merged branch no longer risks pushing to a branch autopilot may have already deleted, or opening a duplicate PR. `pr_created` + `merged` execution events are recorded against the existing PR so the execution row carries a deliverable reference.
- Adds a post-push, pre-`CreatePR` `FindOpenPRByBranch` check (`adoptOpenBranchPR`) plus the underlying `GitOperations.FindOpenPRByBranch` method in `internal/executor/git.go`. A branch with an already-open PR (from a prior/retried dispatch) is adopted instead of racing `gh` CLI into a duplicate.

## Changes

- `internal/executor/git.go`: new `GitOperations.FindOpenPRByBranch`, symmetric to the existing `FindMergedPRByBranch`.
- `internal/executor/runner.go`: new `Runner.checkAlreadyMergedBranch` (pre-push) and `Runner.adoptOpenBranchPR` (post-push, pre-create) helpers, wired into the direct-path `CreatePR` branch of `executeWithOptions`.
- `internal/executor/runner_gh4022_test.go`: table-driven regression test covering (a) branch PR merged mid-run → short-circuit, no second PR, existing PR ref recorded; (b) branch PR still open → adopted, no duplicate; (c) no prior PR → both checks no-op, existing create-PR flow runs unmodified. Plus a composition test verifying a merged-branch hit never triggers the open-PR lookup.
- `.agent/system/FEATURE-MATRIX.md`: documents the new guard.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/...` (full package, 42s, all green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues