### PR TITLE
fix(dashboard): track max ladder rung across stage strip event stream (GH-4023)

### DIFF
--- a/internal/dashboard/stage_strip.go
+++ b/internal/dashboard/stage_strip.go
@@ -56,10 +56,14 @@ func stageLadderPosition(s memory.Stage) int {
 
 // buildStageStrip renders a fixed-denominator pipeline-progress fraction
 // (e.g. "4/7 ✗ ci_failed", "7/7 released") from an execution's
-// execution_events timeline (GH-3849; revised to a fraction in TASK-383).
-// `reached` is the ladder position of the last stage actually completed —
-// derived via stageLadderPosition, never from len(events) — so retries never
-// inflate the fraction.
+// execution_events timeline (GH-3849; revised to a fraction in TASK-383;
+// revised to a running-max reducer in GH-4023). `reached` is the highest
+// ladder position observed across the whole stream — derived via
+// stageLadderPosition, never from len(events) — so retries never inflate
+// the fraction and a later regression (e.g. a stray pr_created/failed event
+// recorded after released, GH-4023) never pulls the displayed rung backward.
+// The terminal-status glyph (✗) is attached to whichever event defined that
+// max rung, not to the last event in the stream.
 //
 // Falls back to "–" when no events are recorded: executions predating the
 // events table (GH-3844), or before the dispatcher/runner emitted events per
@@ -70,26 +74,40 @@ func buildStageStrip(events []*memory.Event, executionFailed bool) string {
 		return "–"
 	}
 
-	current := events[len(events)-1].Stage
-	failed := stageStripFailureStages[current] || executionFailed
+	var (
+		reached       = -1
+		label         memory.Stage
+		failed        bool
+		lastGoodPos   int
+		lastGoodStage memory.Stage
+	)
 
-	label := current
-	reached := stageLadderPosition(current)
-	if reached == 0 {
-		// current stage carries no ladder rung of its own — walk back to
-		// the last event that does, so a generic failure/stall/retry run
-		// still reports how far the pipeline actually got.
-		for i := len(events) - 2; i >= 0; i-- {
-			if pos := stageLadderPosition(events[i].Stage); pos > 0 {
-				reached = pos
-				label = events[i].Stage
-				break
-			}
+	for _, e := range events {
+		// Resolve this event's own ladder position, walking back to the
+		// last stage that named a real rung when this one doesn't (a
+		// generic failure/stall/retry carries no rung of its own).
+		pos := stageLadderPosition(e.Stage)
+		resolvedPos := pos
+		resolvedLabel := e.Stage
+		if pos > 0 {
+			lastGoodPos = pos
+			lastGoodStage = e.Stage
+		} else if lastGoodPos > 0 {
+			resolvedPos = lastGoodPos
+			resolvedLabel = lastGoodStage
+		}
+
+		// Only advance (or hold at) the running max — a resolved position
+		// behind the current max is a regression and must not overwrite it.
+		if resolvedPos >= reached {
+			reached = resolvedPos
+			label = resolvedLabel
+			failed = stageStripFailureStages[e.Stage]
 		}
 	}
 
 	prefix := ""
-	if failed {
+	if failed || executionFailed {
 		prefix = "✗ "
 	}
 

--- a/internal/dashboard/stage_strip_test.go
+++ b/internal/dashboard/stage_strip_test.go
@@ -161,6 +161,52 @@ func TestBuildStageStrip_TruncatesLongLabel(t *testing.T) {
 	}
 }
 
+// TestBuildStageStrip_MaxRungNoRegression covers GH-4023: a later
+// pr_created/failed recorded after released must not pull the displayed
+// rung backward. The reducer must track the maximum ladder position
+// observed across the whole stream, and the terminal glyph attaches to
+// whichever event defined that max — not to the last event in the stream.
+func TestBuildStageStrip_MaxRungNoRegression(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StagePRCreated),
+		evt(memory.StageMerged),
+		evt(memory.StageReleased),
+		evt(memory.StagePRCreated),
+		evt(memory.StageFailed),
+	}
+	got := buildStageStrip(events, false)
+	want := "7/7 released"
+	if got != want {
+		t.Errorf("max-rung no regression: got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "✗") {
+		t.Errorf("max rung was reached at released, a later failed event must not add a failure marker: %q", got)
+	}
+}
+
+// TestBuildStageStrip_MaxRungHealthyPath guards against an off-by-one in
+// the running-max reducer on a full, unbroken ladder climb — every rung
+// must be visited in order and the final fraction must still land on 7/7.
+func TestBuildStageStrip_MaxRungHealthyPath(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StageSpecValidated),
+		evt(memory.StageRunning),
+		evt(memory.StageCommit),
+		evt(memory.StagePRCreated),
+		evt(memory.StageCIPassed),
+		evt(memory.StageMerged),
+		evt(memory.StageReleased),
+	}
+	got := buildStageStrip(events, false)
+	want := "7/7 released"
+	if got != want {
+		t.Errorf("max-rung healthy path: got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "✗") {
+		t.Errorf("healthy full-ladder path should not contain a failure marker: %q", got)
+	}
+}
+
 func TestStageLadderPosition_AllStages(t *testing.T) {
 	cases := []struct {
 		stage memory.Stage


### PR DESCRIPTION
## Summary
- `buildStageStrip` previously derived the displayed rung from the last non-terminal event in the execution's event stream. A later `pr_created`/`failed` event recorded after `released` (e.g. retry noise) pulled the displayed fraction backward — `4/7 ✗ pr_created` instead of `7/7 released`.
- Reducer now tracks the maximum ladder rung observed across the whole event stream; the terminal glyph (✗) attaches to whichever event defined that max rung, not to the last event in the stream.
- All existing `buildStageStrip` test cases pass unchanged with the new reducer.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/dashboard/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/dashboard/...`
- [x] New test: `[pr_created, merged, released, pr_created, failed]` → `7/7 released` (no regression, no failure glyph)
- [x] New test: healthy full-ladder climb → `7/7 released` (off-by-one guard)

Closes GH-4023.