### PR TITLE
fix(github/executor): guard auto-retry against completed-execution race, fix waiter false-alert (GH-4021)

### DIFF
--- a/.agent/sops/autopilot/retry-ready-completed-execution-invariant.md
+++ b/.agent/sops/autopilot/retry-ready-completed-execution-invariant.md
@@ -1,0 +1,72 @@
+# SOP: pilot-retry-ready and HasCompletedExecution — the invariant that must hold
+
+**Category:** Autopilot / GitHub SDK poller reliability
+**Implemented:** 2026-07-07
+**Source incident:** GH-3992 (auto-retry re-dispatched a shipped task, orphan-row
+delete raced the waiter into a false `task_failed` alert) → fixed by GH-4021
+
+---
+
+## The invariant
+
+`shouldRetryRetryReadyIssue` (poller.go) treats any `HasCompletedExecution`
+row it finds while `pilot-retry-ready` is set as **stale** — left over from
+the PR-closed-without-merge event that set the label — and either ignores it
+(`hasMergedWork`'s DB fallback is skipped under this label) or deletes it
+(`InvalidateCompletion`) before re-dispatching.
+
+That assumption is only safe if this holds:
+
+> **A completed-execution row can never be genuinely fresh while
+> `pilot-retry-ready` is set.**
+
+Two things make this true today:
+
+1. `notifyExternalClose` (controller.go, GH-3818/D10) reclassifies the
+   completed row to `status="failed"` the instant it detects a PR closed
+   without merging — the same call that sets `pilot-retry-ready`. So by the
+   time the poller sees the label, the row backing it is no longer
+   `"completed"`.
+2. `clearRetryLabels` (controller.go, GH-4021) removes `pilot-retry-*` labels
+   the moment a PR **does** merge — so a fresh, genuinely-shipped completed
+   row can never coexist with the label past the merge event.
+
+**The gap GH-3992 exploited:** between a later retry's execution completing
+(PR created, row written as `"completed"`) and that PR actually merging
+(when #2 above fires), there's a window where the label is still set and the
+row is genuinely fresh. `hasOpenPRAwaitingMerge` closes this window — an
+open PR is unambiguous "don't re-dispatch" evidence regardless of label
+staleness, checked *before* any invalidation happens.
+
+## Do NOT add a raw, unconditional `HasCompletedExecution` check here
+
+It's tempting — the normal dispatch path has exactly this check
+(poller.go, "Skipping re-dispatch — completed execution exists"), and GH-4021's
+issue text even cites those line numbers as the model to mirror. Adding it
+verbatim to `shouldRetryRetryReadyIssue`, positioned before
+`InvalidateCompletion` runs, breaks the **legitimate** retry-ready flow:
+
+- `TestPoller_RetryReady_InvalidatesCompletedExecution` pins this — a
+  completed row legitimately exists at that point (simulating a stale
+  PR-closed-without-merge row) and must be invalidated + retried, not
+  skipped.
+- Reclassification depends on `Controller.evalStore` being non-nil.
+  `TestNotifyExternalClose_ReclassifyNotCalledWithoutEvalStore` confirms nil
+  `evalStore` is a supported configuration — in that config the stale row
+  is *never* reclassified, so a raw check would permanently block
+  retry-ready re-dispatch for any deployment without an eval store wired up.
+
+If you're tempted to add this check: use `hasOpenPRAwaitingMerge` (timing-safe,
+no false-positive risk) instead, or extend `clearRetryLabels`'s call sites,
+not a bare `HasCompletedExecution` gate ahead of `InvalidateCompletion`.
+
+## Where the three GH-4021 fixes live
+
+- `poller.go` `shouldRetryRetryReadyIssue`: `hasOpenPRAwaitingMerge` guard
+  (closes the open-PR window).
+- `controller.go` `clearRetryLabels` + its two call sites (`handleMerging`,
+  `checkExternalMergeOrClose`) and `poller.go` `hasMergedWork`: clear
+  `pilot-retry-*` the moment work ships, so the label can't outlive the merge.
+- `dispatcher.go` `WaitForExecution`: resolves a mid-wait `sql.ErrNoRows`
+  (row deleted by `recoverStaleRunningTasks` orphan cleanup) against
+  `HasCompletedExecution` instead of surfacing it as a waiter error.

--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -1932,6 +1932,14 @@ func (p *Poller) hasMergedWork(ctx context.Context, issue *Issue) bool {
 			slog.Any("error", err),
 		)
 	}
+	// GH-4021: A pilot-retry-* label from an earlier PR-closed-without-merge
+	// cycle must not survive a later poller-detected merge, or it arms a
+	// redundant auto-retry against already-shipped work.
+	for _, label := range []string{LabelRetryReady, LabelRetry1, LabelRetry2, LabelRetryExhausted} {
+		if err := p.client.RemoveLabel(ctx, p.owner, p.repo, issue.Number, label); err != nil {
+			p.logger.Debug("retry label cleanup", slog.Int("issue", issue.Number), slog.String("label", label), slog.Any("error", err))
+		}
+	}
 	p.markProcessed(issue.Number)
 	return true
 }
@@ -2163,6 +2171,28 @@ func (p *Poller) shouldRetryRetryReadyIssue(ctx context.Context, issue *Issue) b
 
 	// Check if merged work already exists before retrying
 	if p.hasMergedWork(ctx, issue) {
+		return false
+	}
+
+	// GH-4021: Mirror the normal-dispatch hasOpenPRAwaitingMerge guard here
+	// too. hasMergedWork's DB fallback above is skipped whenever
+	// LabelRetryReady is set, on the assumption that any completed row
+	// surviving under that label is stale from the PR-closed-without-merge
+	// event that set it — true once notifyExternalClose (GH-3818/D10)
+	// reclassifies that row to "failed", but there's a window between a
+	// later retry's execution completing (PR created, row completed) and
+	// its PR actually merging where hasMergedWork sees neither a merged PR
+	// nor (thanks to the label-based skip) the completed row. GH-3992: the
+	// auto-retry fired in exactly that window — PR #4018 was open, not yet
+	// merged — and dispatched a redundant third run. An open PR is
+	// unambiguous evidence work is already in flight regardless of label
+	// staleness, so check it before invalidating anything.
+	if p.hasOpenPRAwaitingMerge(ctx, issue) {
+		// Mirror the normal path (markProcessed, don't remove the label):
+		// the PR will either merge (hasMergedWork closes the issue and
+		// clears retry labels) or close without merging (re-arms this same
+		// retry-ready path next poll). Throttles re-checks in the meantime.
+		p.markProcessed(issue.Number)
 		return false
 	}
 

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -2757,6 +2757,60 @@ func TestPoller_RetryReady_InvalidatesCompletedExecution(t *testing.T) {
 	}
 }
 
+// GH-3992/GH-4021: pilot-retry-ready must not re-dispatch while a PR from a
+// later, successful run is still open awaiting merge. hasMergedWork's DB
+// completed-execution fallback is intentionally skipped under this label
+// (any completed row is assumed stale from the close-without-merge event
+// that set the label), so an open PR was the only reliable signal left —
+// and nothing checked for it before this fix. In the incident, the
+// auto-retry fired 5 minutes after a successful retry completed but 2
+// minutes before its PR actually merged, dispatching a redundant third run
+// whose orphan-row cleanup later raced the waiter into a false task_failed
+// alert.
+func TestPoller_RetryReady_SkipsWhenOpenPRAwaitingMerge(t *testing.T) {
+	now := time.Now()
+	issues := []*Issue{
+		{Number: 42, State: "open", Title: "Retry-ready with PR still open",
+			Labels:    []Label{{Name: "pilot"}, {Name: LabelRetryReady}},
+			CreatedAt: now.Add(-1 * time.Hour)},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count": 0}`))
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.URL.Query().Get("state") == "closed":
+			_, _ = w.Write([]byte(`[]`))
+		case r.URL.Path == "/repos/owner/repo/pulls" && r.URL.Query().Get("state") == "open":
+			_, _ = w.Write([]byte(`[{"number": 4018, "state": "open", "head": {"ref": "pilot/GH-42"}}]`))
+		default:
+			_ = json.NewEncoder(w).Encode(issues)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+
+	var callCount int32
+	poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+		WithRetryGracePeriod(0),
+		WithOnIssue(func(ctx context.Context, issue *Issue) error {
+			atomic.AddInt32(&callCount, 1)
+			return nil
+		}),
+	)
+
+	poller.checkForNewIssues(context.Background())
+	poller.WaitForActive()
+
+	if got := atomic.LoadInt32(&callCount); got != 0 {
+		t.Errorf("OnIssue called %d times, want 0 (retry-ready must skip re-dispatch while its PR is open awaiting merge)", got)
+	}
+}
+
 // GH-2341: Search API may lag up to ~30s after a merge. hasMergedWork must
 // supplement with a direct REST PR lookup by branch to catch that window.
 func TestPoller_HasMergedWork_SearchLag_BranchFallback(t *testing.T) {

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1765,6 +1765,10 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 			// 404 is expected if label doesn't exist - silently ignore
 			c.log.Debug("pilot-failed label cleanup", "issue", prState.IssueNumber, "error", err)
 		}
+		// GH-4021: A pilot-retry-* label from an earlier PR-closed-without-merge
+		// cycle must not survive a later successful merge — left in place it
+		// arms a redundant auto-retry against already-shipped work.
+		c.clearRetryLabels(ctx, prState.IssueNumber)
 		// Close the issue after successful merge
 		if err := c.ghClient.UpdateIssueState(ctx, c.owner, c.repo, prState.IssueNumber, "closed"); err != nil {
 			c.log.Warn("failed to close issue after merge", "issue", prState.IssueNumber, "error", err)
@@ -4177,6 +4181,8 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 			if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, prState.IssueNumber, github.LabelFailed); err != nil {
 				c.log.Debug("pilot-failed label cleanup on external merge", "issue", prState.IssueNumber, "error", err)
 			}
+			// GH-4021: same stale-label cleanup as the polled-merge path.
+			c.clearRetryLabels(ctx, prState.IssueNumber)
 			// Close the issue
 			if err := c.ghClient.UpdateIssueState(ctx, c.owner, c.repo, prState.IssueNumber, "closed"); err != nil {
 				c.log.Warn("failed to close issue after external merge", "issue", prState.IssueNumber, "error", err)
@@ -4264,6 +4270,22 @@ func (c *Controller) getBotLogin(ctx context.Context) string {
 	c.cachedBotLogin = user.Login
 	c.mu.Unlock()
 	return user.Login
+}
+
+// clearRetryLabels removes any pilot-retry-* bookkeeping labels once an issue's
+// work has genuinely shipped (merged, internally or externally). Left in place,
+// a stale pilot-retry-ready/pilot-retry-N label survives to the next poll and
+// arms a redundant auto-retry dispatch against already-shipped work — GH-4021:
+// pilot-retry-ready outlived a successful merge by five minutes and fired a
+// third, redundant dispatch that raced the orphan-row cleanup into a false
+// task_failed alert.
+func (c *Controller) clearRetryLabels(ctx context.Context, issueNumber int) {
+	for _, label := range []string{github.LabelRetryReady, github.LabelRetry1, github.LabelRetry2, github.LabelRetryExhausted} {
+		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, issueNumber, label); err != nil {
+			// 404 is expected when the label was never set - silently ignore.
+			c.log.Debug("retry label cleanup", "issue", issueNumber, "label", label, "error", err)
+		}
+	}
 }
 
 // notifyExternalClose runs once autopilot observes a PR closed without a merge —

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -2858,6 +2858,97 @@ func TestController_handleMerging_Success_RemovesFailedLabel(t *testing.T) {
 	}
 }
 
+// GH-4021: a pilot-retry-* label from an earlier PR-closed-without-merge
+// cycle must be cleared on a later successful merge, or it survives to arm a
+// redundant auto-retry against already-shipped work (GH-3992).
+func TestController_handleMerging_Success_ClearsRetryLabels(t *testing.T) {
+	retryReadyRemoved := false
+	retry1Removed := false
+	retry2Removed := false
+	retryExhaustedRemoved := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/commits/abc1234/check-runs":
+			resp := github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns: []github.CheckRun{
+					{Name: "build", Status: "completed", Conclusion: "success"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+		case r.URL.Path == "/repos/owner/repo/pulls/42/merge" && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"sha":     "merged123",
+				"merged":  true,
+				"message": "Pull Request successfully merged",
+			})
+		case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == http.MethodGet:
+			pr := github.PullRequest{
+				Number: 42,
+				State:  "open",
+				Head: github.PRRef{
+					Ref: "pilot/GH-10",
+					SHA: "abc1234",
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(pr)
+		case r.URL.Path == "/repos/owner/repo/issues/10/labels" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]github.Label{{Name: github.LabelDone}})
+		case r.URL.Path == "/repos/owner/repo/issues/10/labels/"+github.LabelRetryReady && r.Method == http.MethodDelete:
+			retryReadyRemoved = true
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/repos/owner/repo/issues/10/labels/"+github.LabelRetry1 && r.Method == http.MethodDelete:
+			retry1Removed = true
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/repos/owner/repo/issues/10/labels/"+github.LabelRetry2 && r.Method == http.MethodDelete:
+			retry2Removed = true
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/repos/owner/repo/issues/10/labels/"+github.LabelRetryExhausted && r.Method == http.MethodDelete:
+			retryExhaustedRemoved = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoReview = false
+	cfg.RequiredChecks = []string{"build"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc1234", "pilot/GH-10", "")
+	prState, _ := c.GetPRState(42)
+	prState.Stage = StageMerging
+
+	ctx := context.Background()
+
+	if err := c.ProcessPR(ctx, 42, nil); err != nil {
+		t.Fatalf("ProcessPR returned error: %v", err)
+	}
+
+	if !retryReadyRemoved {
+		t.Error("pilot-retry-ready label should have been removed on merge")
+	}
+	if !retry1Removed {
+		t.Error("pilot-retry-1 label should have been removed on merge")
+	}
+	if !retry2Removed {
+		t.Error("pilot-retry-2 label should have been removed on merge")
+	}
+	if !retryExhaustedRemoved {
+		t.Error("pilot-retry-exhausted label should have been removed on merge")
+	}
+}
+
 // Test consecutive API failure counter logic
 func TestController_ConsecutiveAPIFailures(t *testing.T) {
 	// Mock HTTP server that always returns error for check runs API

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -295,6 +296,15 @@ func (d *Dispatcher) recoverStaleRunningTasks() int {
 			)
 			if err := d.store.DeleteExecution(exec.ID); err != nil {
 				d.log.Error("Failed to delete orphan running row", slog.String("id", exec.ID), slog.Any("error", err))
+			}
+			// GH-4021: the orphaned run's worktree outlives the DB row it was
+			// tracked under — prune it now instead of leaving it for the next
+			// restart's full CleanupOrphanedWorktrees sweep.
+			if pruned, pruneErr := PruneOrphanedWorktreeForTask(d.ctx, exec.ProjectPath, exec.TaskID); pruneErr != nil {
+				d.log.Warn("Failed to prune orphaned task worktree",
+					slog.String("task_id", exec.TaskID), slog.Any("error", pruneErr))
+			} else if pruned > 0 {
+				d.log.Info("Pruned orphaned task worktree", slog.String("task_id", exec.TaskID), slog.Int("count", pruned))
 			}
 			continue
 		}
@@ -620,6 +630,11 @@ func (d *Dispatcher) WaitForExecution(ctx context.Context, execID string, pollIn
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
+	// GH-4021: remembers the row's identity from the last successful poll so
+	// a later sql.ErrNoRows (the row vanished between ticks) can be resolved
+	// against HasCompletedExecution instead of surfacing as a waiter error.
+	var lastTaskID, lastProjectPath string
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -627,8 +642,29 @@ func (d *Dispatcher) WaitForExecution(ctx context.Context, execID string, pollIn
 		case <-ticker.C:
 			exec, err := d.store.GetExecution(execID)
 			if err != nil {
+				// GH-4021: recoverStaleRunningTasks deletes this exact "running"
+				// row out from under us once it observes a genuine completed
+				// execution for the same task (orphan-row cleanup after a
+				// redundant re-dispatch) — the row disappearing is that success,
+				// not a failure. Resolve it as such instead of returning
+				// "sql: no rows", which the caller reports as a false
+				// task_failed alert for work that actually shipped.
+				if errors.Is(err, sql.ErrNoRows) && lastTaskID != "" {
+					if completed, hcErr := d.store.HasCompletedExecution(lastTaskID, lastProjectPath); hcErr == nil && completed {
+						if completedExec, gErr := d.store.GetLatestExecutionByTaskID(lastTaskID); gErr == nil {
+							d.log.Info("Execution row vanished after orphan recovery — task already completed, resolving wait as success",
+								slog.String("execution_id", execID),
+								slog.String("task_id", lastTaskID),
+							)
+							return completedExec, nil
+						}
+					}
+				}
 				return nil, fmt.Errorf("failed to get execution: %w", err)
 			}
+
+			lastTaskID = exec.TaskID
+			lastProjectPath = exec.ProjectPath
 
 			// Check if terminal state. The TASK-358 classified worker outcomes
 			// (no_op, declined, skipped, stalled, rate_limited, infra) are terminal

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -1072,6 +1072,74 @@ func TestWaitForExecution_ClassifiedOutcomesAreTerminal(t *testing.T) {
 	}
 }
 
+// GH-4021: recoverStaleRunningTasks deletes a task's orphaned "running" row
+// once it observes the task actually completed under a different execution
+// ID (cleanup after a redundant re-dispatch). A waiter still polling that
+// exact execID must resolve the vanished row as success — not surface
+// "sql: no rows" as a failure. GH-3992: this raced a false task_failed alert
+// for work that had already shipped.
+func TestWaitForExecution_RowDeletedAfterCompletion_ResolvesAsSuccess(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	dispatcher := NewDispatcher(store, NewRunner(), nil)
+
+	const orphanID = "exec-orphan"
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          orphanID,
+		TaskID:      "GH-99",
+		ProjectPath: "/tmp/p",
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution(orphan): %v", err)
+	}
+
+	const completedID = "exec-completed"
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          completedID,
+		TaskID:      "GH-99",
+		ProjectPath: "/tmp/p",
+		Status:      "completed",
+		PRUrl:       "https://github.com/owner/repo/pull/1",
+	}); err != nil {
+		t.Fatalf("SaveExecution(completed): %v", err)
+	}
+
+	type result struct {
+		exec *memory.Execution
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	go func() {
+		exec, err := dispatcher.WaitForExecution(ctx, orphanID, 10*time.Millisecond)
+		resultCh <- result{exec, err}
+	}()
+
+	// Let the waiter observe the "running" row at least once (capturing its
+	// task/project identity) before it's deleted out from under it — this
+	// mirrors the real race, where the row exists when the wait starts.
+	time.Sleep(30 * time.Millisecond)
+	if err := store.DeleteExecution(orphanID); err != nil {
+		t.Fatalf("DeleteExecution: %v", err)
+	}
+
+	select {
+	case res := <-resultCh:
+		if res.err != nil {
+			t.Fatalf("WaitForExecution returned error, want success: %v", res.err)
+		}
+		if res.exec.Status != "completed" {
+			t.Errorf("Status = %q, want %q", res.exec.Status, "completed")
+		}
+		if res.exec.ID != completedID {
+			t.Errorf("resolved execution ID = %q, want %q (the genuinely completed row)", res.exec.ID, completedID)
+		}
+	case <-ctx.Done():
+		t.Fatal("WaitForExecution did not return before timeout")
+	}
+}
+
 // GH-3732: restart adoption. A fresh Dispatcher (empty in-memory workers map)
 // must recreate a worker for every project that still has queued rows in
 // SQLite, so a daemon restart resumes FIFO processing instead of stranding

--- a/internal/executor/worktree.go
+++ b/internal/executor/worktree.go
@@ -1026,6 +1026,57 @@ func CleanupOrphanedWorktrees(ctx context.Context, repoPath string) (int, int64,
 	return orphanCount, totalBytes, nil
 }
 
+// PruneOrphanedWorktreeForTask removes any worktree directory belonging to
+// taskID (matches the "pilot-worktree-<sanitized-taskID>-<timestamp>" naming
+// from CreateWorktree/CreateWorktreeWithBranch). Unlike CleanupOrphanedWorktrees
+// — a startup-only sweep that treats every pilot worktree as stale — this is
+// scoped to a single task, so it's safe to call while the daemon is live and
+// other tasks may have their own active worktrees.
+//
+// GH-4021: recoverStaleRunningTasks deletes a task's orphaned "running" DB row
+// once it observes the task actually completed (a redundant re-dispatch that
+// never got to clean up after itself), but left the worktree directory on
+// disk until the next full restart swept it. Pruning it here reclaims the
+// space immediately instead of waiting for a restart.
+func PruneOrphanedWorktreeForTask(ctx context.Context, repoPath, taskID string) (int, error) {
+	tmpDir := os.TempDir()
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read temp directory %s: %w", tmpDir, err)
+	}
+
+	prefix := "pilot-worktree-" + sanitizeBranchName(taskID) + "-"
+	removed := 0
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), prefix) {
+			continue
+		}
+		worktreePath := filepath.Join(tmpDir, entry.Name())
+
+		removeCmd := exec.CommandContext(ctx, "git", "worktree", "remove", "--force", worktreePath)
+		removeCmd.Dir = repoPath
+		_ = removeCmd.Run()
+
+		if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
+			slog.Warn("Failed to remove orphaned task worktree",
+				slog.String("path", worktreePath),
+				slog.String("task_id", taskID),
+				slog.Any("error", rmErr),
+			)
+			continue
+		}
+		removed++
+	}
+
+	if removed > 0 && repoPath != "" {
+		pruneCmd := exec.CommandContext(ctx, "git", "worktree", "prune", "-v")
+		pruneCmd.Dir = repoPath
+		_ = pruneCmd.Run()
+	}
+
+	return removed, nil
+}
+
 // dirSizeBytes returns the total size of a directory tree in bytes.
 // Returns 0 on any error — used for best-effort logging only.
 func dirSizeBytes(path string) int64 {


### PR DESCRIPTION
## Summary

GH-3992 postmortem: `pilot-retry-ready` survived a successful retry's merge
by 5 minutes and fired a redundant third dispatch, whose orphan-row cleanup
then raced the poller's waiter into a false `task_failed` alert for work
that had actually shipped.

- `shouldRetryRetryReadyIssue`: add the `hasOpenPRAwaitingMerge` guard
  (mirrors the normal dispatch path) — an open PR is unambiguous "already
  in flight" evidence, checked before `InvalidateCompletion` runs.
- `clearRetryLabels` (+ `hasMergedWork`): remove `pilot-retry-*` labels the
  instant work ships (merge, external merge, poller-detected merge), so
  the label can't outlive the event that makes it stale.
- `WaitForExecution`: resolve a mid-wait `sql.ErrNoRows` (row deleted by
  orphan-row recovery) against `HasCompletedExecution` instead of
  surfacing it as a waiter failure.
- `recoverStaleRunningTasks`: prune the orphaned run's worktree
  immediately instead of leaving it for the next restart's sweep.

A raw, unconditional `HasCompletedExecution` check ahead of
`InvalidateCompletion` was considered (and matches the issue's literal
line-number citation) but rejected: it breaks the legitimate
PR-closed-without-merge retry flow pinned by
`TestPoller_RetryReady_InvalidatesCompletedExecution`, and permanently
blocks retry-ready re-dispatch in the nil-`evalStore` deployment
configuration (`TestNotifyExternalClose_ReclassifyNotCalledWithoutEvalStore`).
Documented the reasoning in
`.agent/sops/autopilot/retry-ready-completed-execution-invariant.md` so
this isn't re-attempted blind.

Closes #4021.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/adapters/github/ ./internal/executor/ ./internal/autopilot/ -count=1`
- [x] `go test -short ./...` (full suite)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New regression tests: `TestPoller_RetryReady_SkipsWhenOpenPRAwaitingMerge`, `TestController_handleMerging_Success_ClearsRetryLabels`, `TestWaitForExecution_RowDeletedAfterCompletion_ResolvesAsSuccess`