### PR TITLE
fix(executor): finalize push+PR on decomposed-parent path with fail-loud contract (GH-4031)

### DIFF
--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
+	"github.com/qf-studio/pilot/internal/memory"
 	"github.com/qf-studio/pilot/internal/webhooks"
 )
 
@@ -197,6 +199,16 @@ func (r *Runner) executeDecomposedTask(ctx context.Context, parentTask *Task, su
 		r.escalateDecomposedNoOp(ctx, parentTask, subtasks, executionPath, aggregateResult)
 	}
 
+	// GH-4028 / TASK-359 Layer 1: subtasks run with task.Branch cleared (see
+	// "subtask.Branch = ..." above), so the direct path's push+PR block
+	// (task.CreatePR && task.Branch != "") never fires for any subtask —
+	// including the final one, which carries the parent's real CreatePR
+	// intent. The decomposed parent must finalize push+PR itself once all
+	// subtasks (and any no-op escalation) are done.
+	if aggregateResult.Success && parentTask.CreatePR && parentTask.Branch != "" && aggregateResult.PRUrl == "" {
+		r.finalizeDecomposedParentPR(ctx, parentTask, git, aggregateResult)
+	}
+
 	aggregateResult.Duration = time.Since(start)
 	aggregateResult.EstimatedCostUSD = estimateCostWithCache(
 		aggregateResult.TokensInput+aggregateResult.ResearchTokens,
@@ -332,4 +344,189 @@ func (r *Runner) escalateDecomposedNoOp(ctx context.Context, parentTask *Task, s
 	}
 	agg.Success = false
 	agg.Error = fmt.Sprintf("no new commit produced — all %d subtask(s) were no-ops after one escalated retry (task %s)", len(subtasks), parentTask.ID)
+}
+
+// finalizeDecomposedParentPR runs the decomposed-parent's push → PR-create →
+// record pr_created sequence with the SAME error contract as the direct path
+// (runner.go executeWithOptions ~line 3782) and finalizeEpicBranchPR
+// (TASK-359 Layer 1): a push or PR-create failure marks the execution
+// failed, never leaving a "completed" row with an empty pr_url.
+//
+// GH-4028: every subtask executes with task.Branch cleared (so the direct
+// path's own `task.CreatePR && task.Branch != ""` push+PR block never runs
+// for a subtask), so the parent branch was never pushed and no PR was ever
+// opened even though the final subtask carried the parent's CreatePR
+// intent. This is called once, after all subtasks (and any no-op
+// escalation) have finished, using the parent task's own Branch/CreatePR.
+func (r *Runner) finalizeDecomposedParentPR(ctx context.Context, task *Task, git *GitOperations, result *ExecutionResult) {
+	log := r.log
+
+	// TASK-359 Shape C / GH-4022: an already-merged branch short-circuits
+	// push+CreatePR — check first, since a merged branch's remote copy may
+	// already have been deleted by autopilot.
+	if r.checkAlreadyMergedBranch(ctx, git, task, result, nil) {
+		return
+	}
+
+	baseBranch := task.BaseBranch
+	if baseBranch == "" {
+		baseBranch, _ = git.GetDefaultBranch(ctx)
+		if baseBranch == "" {
+			baseBranch = "main"
+		}
+	}
+
+	// GH-2743-style no-commits guard: a decomposed parent that reaches this
+	// point with no commits vs base produced nothing on the branch — unlike
+	// the epic path (children may have shipped their own PRs), a
+	// decomposed-task branch with zero commits is a genuine failure.
+	if guardCount, _ := git.CountNewCommits(ctx, baseBranch); guardCount == 0 {
+		result.Success = false
+		result.Error = "decomposed-parent branch has no commits vs base branch"
+		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		return
+	}
+
+	r.reportProgress(task.ID, "Creating PR", 96, "Pushing branch...")
+
+	var pushErr error
+	for attempt := 1; attempt <= gitPushRetryAttempts; attempt++ {
+		pushErr = git.Push(ctx, task.Branch)
+		if pushErr == nil {
+			break
+		}
+		// GH-1389: a worktree push may report a chdir error even though the
+		// data reached the remote.
+		if git.RemoteBranchExists(ctx, task.Branch) {
+			log.Warn("Decomposed-parent push reported error but branch exists on remote, continuing",
+				slog.String("task_id", task.ID),
+				slog.String("branch", task.Branch),
+				slog.Any("error", pushErr),
+			)
+			pushErr = nil
+			break
+		}
+		if attempt < gitPushRetryAttempts {
+			log.Warn("Decomposed-parent push failed, retrying",
+				slog.String("task_id", task.ID),
+				slog.Int("attempt", attempt),
+				slog.Int("max_attempts", gitPushRetryAttempts),
+				slog.Any("error", pushErr),
+			)
+			time.Sleep(gitPushRetryDelay)
+		}
+	}
+	if pushErr != nil {
+		result.Success = false
+		result.Error = formatGitStepFailureWithRecovery(ctx, git, "push", gitPushRetryAttempts, pushErr, task.ID, task.Branch, result.CommitSHA)
+		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		return
+	}
+
+	// GH-457: use the actual pushed HEAD as the CommitSHA source of truth.
+	if pushedSHA, shaErr := git.GetCurrentCommitSHA(ctx); shaErr == nil && pushedSHA != "" {
+		result.CommitSHA = pushedSHA
+	}
+
+	// GH-4022: adopt an already-open PR for this branch instead of racing
+	// gh CLI into a duplicate. Runs after push so the branch is guaranteed
+	// to exist on the remote for the lookup.
+	if r.adoptOpenBranchPR(ctx, git, task, result, nil) {
+		return
+	}
+
+	r.reportProgress(task.ID, "Creating PR", 98, "Creating pull request...")
+
+	issueNum := strings.TrimPrefix(task.ID, "GH-")
+	prTitle := fmt.Sprintf("%s: %s", task.ID, task.Title)
+
+	// Route PR/MR creation through the adapter-specific creator when
+	// available, mirroring the direct path's registry → non-GitHub
+	// PRCreator → gh CLI fallback order (runner.go ~line 3967).
+	var prURL string
+	var createErr error
+	ghSDKCreator := PRCreator(nil)
+	if task.SourceAdapter == "github" && task.SourceRepo != "" {
+		ghSDKCreator = r.prCreatorFor("github:" + task.SourceRepo)
+	}
+	switch {
+	case ghSDKCreator != nil:
+		prBody := fmt.Sprintf("## Summary\n\nAutomated PR created by Pilot for task %s.\n\nCloses #%s\n\n## Changes\n\n%s", task.ID, issueNum, task.Description)
+		for attempt := 1; attempt <= prCreateRetryAttempts; attempt++ {
+			prURL, createErr = ghSDKCreator.CreatePR(ctx, task.Branch, baseBranch, prTitle, prBody)
+			if createErr == nil {
+				break
+			}
+			if attempt < prCreateRetryAttempts {
+				log.Warn("Decomposed-parent PR creation failed (SDK), retrying",
+					slog.String("task_id", task.ID),
+					slog.Int("attempt", attempt),
+					slog.Int("max_attempts", prCreateRetryAttempts),
+					slog.Any("error", createErr),
+				)
+				time.Sleep(prCreateRetryDelay)
+			}
+		}
+	case r.prCreator != nil && task.SourceAdapter != "" && task.SourceAdapter != "github":
+		closeKeyword := ""
+		if task.SourceIssueID != "" {
+			closeKeyword = fmt.Sprintf("\n\nCloses #%s", task.SourceIssueID)
+		}
+		prBody := fmt.Sprintf("## Summary\n\nAutomated MR created by Pilot for task %s.%s\n\n## Changes\n\n%s", task.ID, closeKeyword, task.Description)
+		for attempt := 1; attempt <= prCreateRetryAttempts; attempt++ {
+			prURL, createErr = r.prCreator.CreatePR(ctx, task.Branch, baseBranch, prTitle, prBody)
+			if createErr == nil {
+				break
+			}
+			if attempt < prCreateRetryAttempts {
+				log.Warn("Decomposed-parent MR creation failed, retrying",
+					slog.String("task_id", task.ID),
+					slog.Int("attempt", attempt),
+					slog.Int("max_attempts", prCreateRetryAttempts),
+					slog.Any("error", createErr),
+				)
+				time.Sleep(prCreateRetryDelay)
+			}
+		}
+	default:
+		prBody := fmt.Sprintf("## Summary\n\nAutomated PR created by Pilot for task %s.\n\nCloses #%s\n\n## Changes\n\n%s", task.ID, issueNum, task.Description)
+		for attempt := 1; attempt <= prCreateRetryAttempts; attempt++ {
+			prURL, createErr = git.CreatePR(ctx, prTitle, prBody, baseBranch)
+			if createErr == nil {
+				break
+			}
+			if attempt < prCreateRetryAttempts {
+				log.Warn("Decomposed-parent PR creation failed, retrying",
+					slog.String("task_id", task.ID),
+					slog.Int("attempt", attempt),
+					slog.Int("max_attempts", prCreateRetryAttempts),
+					slog.Any("error", createErr),
+				)
+				time.Sleep(prCreateRetryDelay)
+			}
+		}
+	}
+
+	if createErr != nil {
+		result.Success = false
+		result.Error = formatGitStepFailureWithRecovery(ctx, git, "pr-create", prCreateRetryAttempts, createErr, task.ID, task.Branch, result.CommitSHA)
+		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		return
+	}
+
+	// TASK-359 Layer 1 invariant: a PR-mode task that finished without a PR
+	// URL is NOT a success. Guards against CreatePR returning a non-error
+	// empty URL.
+	if prURL == "" {
+		result.Success = false
+		result.Error = "decomposed-parent finalize produced no PR URL"
+		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		return
+	}
+
+	result.PRUrl = prURL
+	log.Info("Decomposed-parent PR created", slog.String("task_id", task.ID), slog.String("pr_url", prURL))
+	r.saveLogEntry(task.LogExecutionID(), "info", "PR created: "+prURL)
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StagePRCreated, "pr created: "+prURL)
+	r.reportProgress(task.ID, "Completed", 100, fmt.Sprintf("PR created: %s", prURL))
 }

--- a/internal/executor/runner_gh4031_test.go
+++ b/internal/executor/runner_gh4031_test.go
@@ -1,0 +1,124 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakePRCreatorGH4031 is a minimal PRCreator stub for exercising the
+// registry/non-GitHub CreatePR branch of finalizeDecomposedParentPR without
+// depending on gh CLI or network access.
+type fakePRCreatorGH4031 struct {
+	url string
+	err error
+}
+
+func (f *fakePRCreatorGH4031) CreatePR(_ context.Context, _, _, _, _ string) (string, error) {
+	return f.url, f.err
+}
+
+// setupDecomposedParentRepoGH4031 builds a repo with a pushable bare remote
+// (main, one commit), then creates and checks out branch with one additional
+// commit so the caller has real, pushable work — mirroring the state a
+// decomposed parent's worktree is in once all subtasks finished (GH-4028).
+func setupDecomposedParentRepoGH4031(t *testing.T, branch string) string {
+	t.Helper()
+	repoDir, _ := setupFreshnessRepo(t)
+	runGit(t, repoDir, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(repoDir, "f.txt"), []byte("subtask work\n"), 0644); err != nil {
+		t.Fatalf("write f.txt: %v", err)
+	}
+	runGit(t, repoDir, "add", "f.txt")
+	runGit(t, repoDir, "commit", "-m", "subtask work")
+	return repoDir
+}
+
+// TestFinalizeDecomposedParentPR_SuccessPushesAndCreatesPR is acceptance (a):
+// a decomposed parent whose subtasks all succeeded (real commits on the
+// branch) must have finalizeDecomposedParentPR push the branch and create a
+// PR — landing a non-empty PRUrl and leaving Success=true. GH-4028: before
+// this fix, subtasks always ran with task.Branch cleared, so the direct
+// path's push+PR block never fired for any subtask and the parent finished
+// "completed" with pr_url="".
+func TestFinalizeDecomposedParentPR_SuccessPushesAndCreatesPR(t *testing.T) {
+	setUpFakeGhPATH(t, []byte(`[]`), []byte(`[]`)) // no pre-existing merged/open PR
+
+	repoDir := setupDecomposedParentRepoGH4031(t, "pilot/GH-9001")
+
+	r := newSilentRunnerTask359()
+	r.prCreator = &fakePRCreatorGH4031{url: "https://gitlab.example.com/o/r/-/merge_requests/7"}
+	task := &Task{
+		ID:            "GH-9001",
+		Title:         "add feature",
+		Description:   "d",
+		Branch:        "pilot/GH-9001",
+		BaseBranch:    "main",
+		CreatePR:      true,
+		SourceAdapter: "gitlab", // non-github so the registry PRCreator branch is used
+	}
+	result := &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "placeholder"}
+
+	r.finalizeDecomposedParentPR(context.Background(), task, NewGitOperations(repoDir), result)
+
+	if !result.Success {
+		t.Fatalf("expected Success=true, got false (error=%q)", result.Error)
+	}
+	if result.PRUrl != "https://gitlab.example.com/o/r/-/merge_requests/7" {
+		t.Errorf("PRUrl = %q, want mocked PR URL", result.PRUrl)
+	}
+	if result.Error != "" {
+		t.Errorf("expected no error on success, got %q", result.Error)
+	}
+
+	// The branch must actually have been pushed to origin.
+	git := NewGitOperations(repoDir)
+	if !git.RemoteBranchExists(context.Background(), "pilot/GH-9001") {
+		t.Error("expected branch to be pushed to origin")
+	}
+}
+
+// TestFinalizeDecomposedParentPR_PRCreateFailIsFailure is acceptance (b):
+// push succeeds but PR-create fails — the execution MUST be marked failed
+// (fail-loud, TASK-379/TASK-359 Layer 1), not "completed" with an empty
+// pr_url, so the task remains retry-eligible instead of silently stranding
+// pushed work behind a closed completed-execution guard.
+func TestFinalizeDecomposedParentPR_PRCreateFailIsFailure(t *testing.T) {
+	setUpFakeGhPATH(t, []byte(`[]`), []byte(`[]`)) // no pre-existing merged/open PR
+
+	repoDir := setupDecomposedParentRepoGH4031(t, "pilot/GH-9002")
+
+	r := newSilentRunnerTask359()
+	r.prCreator = &fakePRCreatorGH4031{err: errors.New("mr create: forbidden")}
+	task := &Task{
+		ID:            "GH-9002",
+		Title:         "add feature",
+		Description:   "d",
+		Branch:        "pilot/GH-9002",
+		BaseBranch:    "main",
+		CreatePR:      true,
+		SourceAdapter: "gitlab",
+	}
+	result := &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "placeholder"}
+
+	r.finalizeDecomposedParentPR(context.Background(), task, NewGitOperations(repoDir), result)
+
+	if result.Success {
+		t.Error("expected Success=false when PR-create fails")
+	}
+	if result.PRUrl != "" {
+		t.Errorf("expected no PR URL on PR-create failure, got %q", result.PRUrl)
+	}
+	if result.Error == "" {
+		t.Error("expected a descriptive error, got empty string")
+	}
+
+	// The push itself must have succeeded despite the later PR-create
+	// failure — the branch should exist on origin so no work is lost.
+	git := NewGitOperations(repoDir)
+	if !git.RemoteBranchExists(context.Background(), "pilot/GH-9002") {
+		t.Error("expected branch to have been pushed to origin before PR-create failed")
+	}
+}


### PR DESCRIPTION
## Summary

Subtasks under `TaskDecomposer` (GH-218) run with `task.Branch` cleared, so the direct path's push+PR block (`task.CreatePR && task.Branch != ""`) never fires — including for the final subtask that carries the parent's real `CreatePR` intent. `executeDecomposedTask` was reporting a decomposed task "completed" with an empty `pr_url`, and no branch ever reached origin (GH-4028).

- Adds `finalizeDecomposedParentPR` (`internal/executor/runner_decompose.go`), invoked once after all subtasks (and any no-op escalation) finish, mirroring `finalizeEpicBranchPR`/the direct path's TASK-359 Layer 1 contract:
  - already-merged branch short-circuit
  - no-new-commits guard
  - push with retry
  - open-PR adoption
  - PR creation via registry / `PRCreator` / `gh` CLI fallback with retry
  - `pr_created` event recording
- Enforces the TASK-379 fail-loud invariant: any push or PR-create failure marks the execution `failed` (not `completed` with an empty `pr_url`), keeping the task retry-eligible.

## Test plan

- [x] `TestFinalizeDecomposedParentPR_SuccessPushesAndCreatesPR` — all subtasks succeed → push+PR attempted, execution completed with non-empty `pr_url`
- [x] `TestFinalizeDecomposedParentPR_PRCreateFailIsFailure` — push succeeds, PR-create fails → execution failed, not completed
- [x] `go build ./...`
- [x] `go test ./internal/executor/...`