### PR TITLE
fix(executor): route decomposed subtask ledger writes to parent execution row (GH-4032)

### DIFF
--- a/internal/executor/decompose.go
+++ b/internal/executor/decompose.go
@@ -322,6 +322,13 @@ func (d *TaskDecomposer) createSubtasks(parent *Task, parts []string, partType s
 			BaseBranch:  parent.BaseBranch,
 			CreatePR:    false, // Only final subtask creates PR
 			Verbose:     parent.Verbose,
+			// GH-4032: subtasks never get their own dispatcher-assigned executions
+			// row (they run inline inside the parent's single Execute() call), so
+			// borrow the parent's resolved execution ID for ledger writes. Without
+			// this, LogExecutionID() fell back to the subtask's own ID (e.g.
+			// "GH-4021-2"), which has no matching executions row and trips the
+			// execution_events FOREIGN KEY constraint on every stage write.
+			ParentExecutionID: parent.LogExecutionID(),
 		}
 
 		// Last subtask creates the PR

--- a/internal/executor/decompose_test.go
+++ b/internal/executor/decompose_test.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 func TestDecomposeConfig_Defaults(t *testing.T) {
@@ -908,5 +910,108 @@ func TestDecomposeWithContext_HeuristicEnforcesWordCountGate(t *testing.T) {
 	}
 	if !strings.Contains(result.Reason, "heuristic mode") {
 		t.Errorf("Expected reason to mention heuristic mode, got %q", result.Reason)
+	}
+}
+
+// TestDecomposedSubtasks_ExecutionEventsJoinParentRow is a regression test for
+// GH-4032: subtasks minted by createSubtasks never get their own dispatcher-
+// assigned executions row (they run inline inside the parent's single
+// Execute() call), so before this fix Task.LogExecutionID() fell back to the
+// subtask's own human-readable ID (e.g. "GH-4021-2"). That ID has no matching
+// row in `executions`, so every InsertExecutionEvent call for a subtask (e.g.
+// the runner.go:1707 spec_validated write) tripped the execution_events
+// FOREIGN KEY constraint (SQLite error 787).
+//
+// This decomposes a parent task into >=2 subtasks the same way the runner
+// does, then writes the spec_validated and quality-gates-passed milestones
+// for every subtask straight through the store — exactly the calls
+// recordExecutionEvent makes during real execution — and asserts none of
+// them error and all of them land in the parent execution's ledger.
+func TestDecomposedSubtasks_ExecutionEventsJoinParentRow(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const parentExecutionID = "11111111-2222-3333-4444-555555555555"
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          parentExecutionID,
+		TaskID:      "GH-4021",
+		ProjectPath: "/test/project",
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	config := &DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "medium",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 10,
+	}
+	decomposer := NewTaskDecomposer(config)
+
+	parent := &Task{
+		ID:          "GH-4021",
+		ExecutionID: parentExecutionID,
+		Title:       "Fix ledger FK violation for decomposed subtasks",
+		Description: `This task requires multiple coordinated changes:
+
+1. Root-cause the FOREIGN KEY constraint failure for subtask ledger writes
+2. Route subtask execution events to the parent's executions row
+3. Add regression coverage decomposing a task into multiple subtasks`,
+		ProjectPath: "/test/project",
+	}
+
+	result := decomposer.Decompose(parent)
+	if !result.Decomposed {
+		t.Fatalf("expected task to be decomposed, reason: %s", result.Reason)
+	}
+	if len(result.Subtasks) < 2 {
+		t.Fatalf("expected >=2 subtasks, got %d", len(result.Subtasks))
+	}
+
+	const qualityGatesPassed memory.Stage = "quality_gates_passed"
+
+	for _, subtask := range result.Subtasks {
+		if subtask.LogExecutionID() != parentExecutionID {
+			t.Errorf("subtask %s: LogExecutionID() = %q, want parent execution ID %q",
+				subtask.ID, subtask.LogExecutionID(), parentExecutionID)
+		}
+
+		if err := store.InsertExecutionEvent(subtask.LogExecutionID(), memory.StageSpecValidated, "task spec validated"); err != nil {
+			t.Errorf("subtask %s: InsertExecutionEvent(spec_validated) failed (FK error?): %v", subtask.ID, err)
+		}
+		if err := store.InsertExecutionEvent(subtask.LogExecutionID(), qualityGatesPassed, "quality gates passed"); err != nil {
+			t.Errorf("subtask %s: InsertExecutionEvent(quality_gates_passed) failed (FK error?): %v", subtask.ID, err)
+		}
+	}
+
+	events, err := store.ListExecutionEvents(parentExecutionID)
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+
+	wantCount := len(result.Subtasks) * 2
+	if len(events) != wantCount {
+		t.Fatalf("got %d events on the parent execution row, want %d (2 per subtask)", len(events), wantCount)
+	}
+
+	var specValidatedCount, qualityGatesCount int
+	for _, e := range events {
+		switch e.Stage {
+		case memory.StageSpecValidated:
+			specValidatedCount++
+		case qualityGatesPassed:
+			qualityGatesCount++
+		}
+	}
+	if specValidatedCount != len(result.Subtasks) {
+		t.Errorf("got %d spec_validated events, want %d", specValidatedCount, len(result.Subtasks))
+	}
+	if qualityGatesCount != len(result.Subtasks) {
+		t.Errorf("got %d quality_gates_passed events, want %d", qualityGatesCount, len(result.Subtasks))
 	}
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -416,17 +416,29 @@ type Task struct {
 	// State is the current issue state in the source adapter (GH-2867).
 	// Examples: "open", "closed", "merged"
 	State string
+	// ParentExecutionID is the resolved LogExecutionID() of the parent task that
+	// spawned this one via in-process decomposition (decompose.go createSubtasks).
+	// Decomposed subtasks never get their own dispatcher-assigned executions row —
+	// they run inline inside the parent's single Execute() call — so without this,
+	// LogExecutionID() fell back to the subtask's human-readable ID (e.g.
+	// "GH-4021-2"), which has no matching executions row and trips the
+	// execution_events FOREIGN KEY constraint on every stage write (GH-4032).
+	ParentExecutionID string
 }
 
 // LogExecutionID returns the ID that runner-side writes (execution_logs.execution_id,
-// pattern_feedback.execution_id) should join against the executions table with.
-// It prefers ExecutionID (the dispatcher-assigned UUID); tasks that never got a
-// dedicated executions row — decomposed subtasks and epic sub-issues built directly
-// via &Task{} (decompose.go, epic.go), or local/bench runs outside the dispatcher —
-// fall back to the human-readable ID so logging still works, just without a join. GH-3764.
+// pattern_feedback.execution_id, execution_events.execution_id) should join against
+// the executions table with. It prefers ExecutionID (the dispatcher-assigned UUID),
+// then ParentExecutionID (borrowed from the parent task for decomposed subtasks,
+// GH-4032), then falls back to the human-readable ID — the last resort for epic
+// sub-issues built directly via &Task{} (epic.go) and local/bench runs outside the
+// dispatcher, where logging still works, just without a join. GH-3764.
 func (t *Task) LogExecutionID() string {
 	if t.ExecutionID != "" {
 		return t.ExecutionID
+	}
+	if t.ParentExecutionID != "" {
+		return t.ParentExecutionID
 	}
 	return t.ID
 }

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -2670,9 +2670,9 @@ func TestTask_MemberID_Field(t *testing.T) {
 }
 
 // TestTask_LogExecutionID verifies the join-ID precedence: the dispatcher-assigned
-// execution UUID when present, falling back to the human-readable task ID for tasks
-// that never got a dedicated executions row (decomposed subtasks, epic sub-issues,
-// local/bench runs). GH-3764.
+// execution UUID when present, then the borrowed parent execution ID for decomposed
+// subtasks (GH-4032), falling back to the human-readable task ID for tasks that
+// never got a dedicated executions row (epic sub-issues, local/bench runs). GH-3764.
 func TestTask_LogExecutionID(t *testing.T) {
 	tests := []struct {
 		name string
@@ -2688,6 +2688,16 @@ func TestTask_LogExecutionID(t *testing.T) {
 			"falls back to ID when ExecutionID is empty",
 			&Task{ID: "GH-3714"},
 			"GH-3714",
+		},
+		{
+			"prefers ParentExecutionID over ID for decomposed subtasks",
+			&Task{ID: "GH-4021-2", ParentExecutionID: "11111111-2222-3333-4444-555555555555"},
+			"11111111-2222-3333-4444-555555555555",
+		},
+		{
+			"ExecutionID wins over ParentExecutionID if both set",
+			&Task{ID: "GH-4021-2", ExecutionID: "own-uuid", ParentExecutionID: "parent-uuid"},
+			"own-uuid",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Root-causes and fixes the `FOREIGN KEY constraint failed (787) execution_id=GH-4021-N stage=spec_validated` error reported for decomposed subtasks.

**Root cause:** `TaskDecomposer.createSubtasks` (`internal/executor/decompose.go`) mints subtasks (`GH-4021-1`, `GH-4021-2`, ...) that run inline inside the parent's single `Execute()` call — they never get their own dispatcher-assigned `executions` row. `Task.LogExecutionID()` therefore fell back to the subtask's own human-readable ID, which has no matching row in `executions`, so every `execution_events` write for that subtask (`spec_validated`, `commit`, `pr_created`, etc.) tripped the FK constraint on the `execution_events.execution_id → executions.id` reference added in GH-3844/TASK-379.

**Fix (shape ii — route to parent execution ID):** Added `Task.ParentExecutionID`, set by `createSubtasks` to the parent's resolved `LogExecutionID()`. `LogExecutionID()` now prefers `ExecutionID` (dispatcher UUID), then `ParentExecutionID` (borrowed from the parent for decomposed subtasks), then falls back to the human-readable `ID` as before for epic sub-issues / local runs. This preserves the existing "one `executions` row per dispatched task" invariant (`HasCompletedExecution`, dashboard counts, etc. all key off it) while letting subtask ledger writes join against a row that actually exists.

`DecomposeForRetry` funnels through the same `createSubtasks` helper, so the fix covers both the initial-decomposition and kill-triggered-retry decomposition paths.

## Test plan

- [x] New regression test `TestDecomposedSubtasks_ExecutionEventsJoinParentRow` (`internal/executor/decompose_test.go`): decomposes a task into subtasks, writes `spec_validated` + `quality_gates_passed` events for every subtask straight through the store (mirroring `recordExecutionEvent`'s real calls), and asserts none error and all land under the parent's execution ID.
- [x] Extended `TestTask_LogExecutionID` with `ParentExecutionID` precedence cases.
- [x] `go build ./...`
- [x] `go test ./...` (all packages green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` (0 issues)