### PR TITLE
fix(executor): refresh epic parent's stuck-monitor entry per child execution (GH-4033)

### DIFF
--- a/.agent/knowledge/memories/pitfalls/mem-089.md
+++ b/.agent/knowledge/memories/pitfalls/mem-089.md
@@ -1,0 +1,24 @@
+# Pitfall: Epic parent's stuck-monitor entry freezes once sub-issue execution starts — false eviction on long sequential epics
+
+## Summary
+`internal/executor/epic.go`'s `executeSubIssuesTracked` (the GH-405/412 epic sub-issue fan-out — the actual live decomposition path; `TaskDecomposer`/`decompose.go` is never wired via `SetDecomposer` in `cmd/pilot/main.go`, so it's dead code) posts per-child progress to GitHub via `UpdateIssueProgress` (a `gh issue comment` call) but never called `r.reportProgress(parent.ID, ...)` inside the loop. `UpdateIssueProgress` never reaches the alerts engine. So the parent's `taskLastProgress[parent.ID]` entry (`internal/alerts/engine.go`) was last touched once, right before the loop (`"Executing"` progress at 50%), and then frozen for the rest of the sequential run — each child executes under its *own* task ID (its GitHub issue number), so its progress never touches the parent's entry either. A long epic (several real Claude Code sub-issue runs) then has `stuck_for` measured from that single pre-loop timestamp, and the orphan-eviction sweep (4x the stuck threshold) can evict a parent whose child is still actively executing. Seen on GH-4021: queued/pre-loop-touch far enough back, evicted with `stuck_for=41m0s` while sub-issue 2 was actively running.
+
+## Context
+GH-4033 fix. Sibling of GH-4032 (`c7f8fd8a`), which fixed `execution_events` FK violations for the *other*, unwired `TaskDecomposer` subtask path — don't assume that path is live just because it has tests; check `SetDecomposer` call sites before trusting `decompose.go`.
+
+## Details
+Fixed by adding `r.reportProgress(parent.ID, "Executing", progressPct, progressMsg)` inside the `executeSubIssuesTracked` loop, right where the existing `UpdateIssueProgress` GitHub-comment call already fires per child. This refreshes `taskLastProgress[parent.ID].UpdatedAt` at each child's execution start, switching the stuck-monitor's effective reference clock from the one-time pre-loop timestamp to per-child execution activity — mirrors the pattern `runner_decompose.go`'s (dead) `executeDecomposedTask` already used correctly (`r.reportProgress(parentTask.ID, "Decomposed", progressPct, ...)` per subtask).
+
+## Recommended Approach
+When a parent task's real work happens inside a loop over children with their own task IDs, any progress channel that doesn't explicitly touch the parent's own ID (GitHub comments, webhooks, child-scoped `reportProgress`) is invisible to the alerts engine's per-task tracking. Explicitly re-touch the parent's entry at each meaningful step. Regression test: `TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution` pattern in `internal/alerts/engine_test.go` / `internal/executor/epic_test.go`.
+
+## Related
+- TASK-379
+- `internal/executor/epic.go`
+- `internal/alerts/engine.go`
+- `internal/executor/decompose.go` (dead code — verify wiring before trusting)
+
+---
+**Captured**: 2026-07-07
+**Confidence**: 0.9
+**Concepts**: alerts, executor, epic, stuck-monitor

--- a/.agent/tasks/gh-4033.md
+++ b/.agent/tasks/gh-4033.md
@@ -1,0 +1,10 @@
+# GH-4033
+
+**Created:** 2026-07-07
+
+## Problem
+
+Fix the stuck-task monitor so stuck_for is computed from the task's execution-start timestamp (when the runner actually begins the subtask fan-out) rather than the queue-enqueue timestamp. Evidence: GH-4021 was evicted at 18:50 with stuck_for=41m0s while subtask 2 was actively running — queue time was 18:09, execution start was 18:34. Locate the timer in the stuck-monitor code path (likely internal/executor/stuck_monitor.go or the autopilot supervisor), switch its reference clock to execution.started_at, and add a table-driven test with a decomposed task whose subtasks legitimately run past the queue-time threshold but not past the start-time threshold — assert no false eviction.
+
+## Acceptance Criteria
+

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -2417,6 +2417,102 @@ func TestEngine_TaskProgressUpdatesStuckState(t *testing.T) {
 	}
 }
 
+// TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution pins
+// GH-4033: an epic parent's stuck_for must be computed from the most recent
+// child sub-issue's execution-start activity, not from the one-time
+// pre-loop timestamp recorded before the sequential sub-issue fan-out began.
+// Mirrors the GH-4021 incident: the parent's last alerts-visible touch was
+// long before sub-issue 2 actually started executing (everything in between
+// — GitHub issue comments via UpdateIssueProgress, and each child's own
+// progress under its own task ID — never reaches the parent's
+// taskLastProgress entry), and the orphan sweep evicted the parent with
+// stuck_for=41m0s even though sub-issue 2 was actively running.
+func TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution(t *testing.T) {
+	tests := []struct {
+		name              string
+		childTouchAgo     time.Duration // 0 means no child-execution-start touch fires
+		wantParentEvicted bool
+	}{
+		{
+			name:              "child running past pre-loop-time threshold but not its own start-time threshold: no false eviction",
+			childTouchAgo:     16 * time.Minute, // sub-issue 2 execution start, 16m before the sweep
+			wantParentEvicted: false,
+		},
+		{
+			name:              "no child ever started executing: parent legitimately orphaned",
+			childTouchAgo:     0,
+			wantParentEvicted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &AlertConfig{
+				Enabled: true,
+				Channels: []ChannelConfig{
+					{Name: "test-channel", Type: "webhook", Enabled: true},
+				},
+				Rules: []AlertRule{
+					{
+						Name:    "task_stuck",
+						Type:    AlertTypeTaskStuck,
+						Enabled: true,
+						Condition: RuleCondition{
+							ProgressUnchangedFor: 10 * time.Minute,
+						},
+						Severity: SeverityWarning,
+						Channels: []string{"test-channel"},
+						Cooldown: 0,
+					},
+				},
+			}
+
+			mockCh := newMockChannel("test-channel", "webhook")
+			dispatcher := NewDispatcher(config)
+			dispatcher.RegisterChannel(mockCh)
+
+			engine := NewEngine(config, WithDispatcher(dispatcher))
+
+			// Parent's last alerts-visible touch (the pre-loop "Executing"
+			// progress report) was 41 min ago — past the 4x10m=40m orphan
+			// threshold on its own.
+			engine.handleTaskStarted(Event{
+				Type:      EventTypeTaskStarted,
+				TaskID:    "GH-4021",
+				Phase:     "Executing",
+				Timestamp: time.Now().Add(-41 * time.Minute),
+			})
+
+			if tt.childTouchAgo > 0 {
+				// epic.go's executeSubIssuesTracked loop now reports progress
+				// under the PARENT's own task ID at each child's execution
+				// start (GH-4033 fix), so this models sub-issue 2 starting.
+				engine.handleTaskProgress(Event{
+					Type:      EventTypeTaskProgress,
+					TaskID:    "GH-4021",
+					Phase:     "Executing",
+					Progress:  60,
+					Timestamp: time.Now().Add(-tt.childTouchAgo),
+				})
+			}
+
+			ctx := context.Background()
+			engine.evaluateStuckTasks(ctx)
+
+			engine.mu.RLock()
+			_, parentExists := engine.taskLastProgress["GH-4021"]
+			engine.mu.RUnlock()
+
+			if tt.wantParentEvicted && parentExists {
+				t.Error("expected parent GH-4021 to be evicted as orphaned, but it still exists")
+			}
+			if !tt.wantParentEvicted && !parentExists {
+				t.Error("expected parent GH-4021 to survive (child actively executing), but it was evicted")
+			}
+		})
+	}
+}
+
 // =============================================================================
 // Event Queue Full Test
 // =============================================================================

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1884,6 +1884,19 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			r.log.Warn("Failed to update parent progress", "error", err)
 		}
 
+		// GH-4033: refresh the parent's own stuck-monitor entry as each child
+		// starts. UpdateIssueProgress above only posts a GitHub comment — it
+		// never reaches the alerts engine — so without this the parent's
+		// taskLastProgress[parent.ID] entry is last touched once, right before
+		// this loop starts (the "Executing" progress report above), and then
+		// frozen for the entire sequential sub-issue run. A long-running epic
+		// (several children, each a real Claude Code call) then has its
+		// stuck_for measured from that single pre-loop timestamp instead of
+		// from the most recent child's actual execution start, and the
+		// orphan-eviction sweep (4x the stuck threshold) can evict a parent
+		// whose child is still legitimately executing.
+		r.reportProgress(parent.ID, "Executing", 50+(40*i/total), progressMsg)
+
 		// Create task from sub-issue
 		// GH-2177: Use real repo path so sub-issues can create branches from main,
 		// not from inside the parent's worktree (which locks the branch).

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2517,6 +2517,54 @@ func TestRunner_Execute_EpicRecoversThenExecutesOpenChildren(t *testing.T) {
 	}
 }
 
+// TestExecuteSubIssuesTracked_TouchesParentProgressPerChild is a wiring
+// regression test for GH-4033: executeSubIssuesTracked must report progress
+// under the PARENT's own task ID as each child sub-issue starts executing,
+// not just once before the sequential loop begins. UpdateIssueProgress (a
+// `gh issue comment` call) never reaches the alerts engine, so without this
+// touch the parent's stuck-monitor entry (internal/alerts/engine.go
+// taskLastProgress) goes stale for the entire sequential run and can be
+// falsely evicted as an orphan while a child is still actively executing
+// (see internal/alerts/engine_test.go
+// TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution for the
+// eviction-level regression test).
+func TestExecuteSubIssuesTracked_TouchesParentProgressPerChild(t *testing.T) {
+	r := NewRunner()
+	r.skipPreflightChecks = true
+	r.dryRun = true // UpdateIssueProgress becomes a no-op instead of shelling out to gh
+
+	processor := &fakeAlertProcessor{}
+	r.SetAlertProcessor(processor)
+
+	r.executeFunc = func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{TaskID: task.ID, Success: true}, nil
+	}
+
+	parent := &Task{ID: "GH-4021", ProjectPath: "/test/project"}
+	issues := []CreatedIssue{
+		{Number: 4022, Identifier: "4022", URL: "https://github.com/o/r/issues/4022",
+			Subtask: PlannedSubtask{Title: "part 1", Description: "do part 1"}},
+		{Number: 4023, Identifier: "4023", URL: "https://github.com/o/r/issues/4023",
+			Subtask: PlannedSubtask{Title: "part 2", Description: "do part 2"}},
+	}
+
+	_, _, err := r.executeSubIssuesTracked(context.Background(), parent, issues, "/test/project", "/test/project")
+	if err != nil {
+		t.Fatalf("executeSubIssuesTracked returned unexpected error: %v", err)
+	}
+
+	var parentProgressEvents int
+	for _, e := range processor.events {
+		if e.Type == AlertEventTypeTaskProgress && e.TaskID == parent.ID {
+			parentProgressEvents++
+		}
+	}
+	if parentProgressEvents < len(issues) {
+		t.Errorf("expected at least %d task_progress events for parent %s (one per child start), got %d",
+			len(issues), parent.ID, parentProgressEvents)
+	}
+}
+
 // staticAllowlist is a test helper that allows a fixed set of "owner/repo"
 // pairs. projectPath comparison is ignored (tests don't need that dimension).
 type staticAllowlist struct {


### PR DESCRIPTION
## Summary
- `executeSubIssuesTracked` (the live epic sub-issue fan-out) posted per-child progress to GitHub via `UpdateIssueProgress`, a `gh issue comment` call that never reaches the alerts engine. The parent's `taskLastProgress` entry was only touched once, right before the sequential loop started, then frozen for the entire run — each child executes under its own task ID, so its own progress never touched the parent's entry either.
- On a long epic this let `stuck_for` be measured from that one-time pre-loop timestamp instead of the most recent child's actual execution start, so the orphan-eviction sweep (4x the stuck threshold) could evict a parent whose child was still legitimately executing. Matches the GH-4021 incident: evicted with `stuck_for=41m0s` while sub-issue 2 was actively running.
- Fix: report progress under the parent's own task ID at each child's execution start (`internal/executor/epic.go`), mirroring the pattern the (unwired) `TaskDecomposer`/`decompose.go` path already used correctly. This switches the stuck-monitor's effective reference clock from the queue/pre-loop timestamp to real execution activity.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/executor/... ./internal/alerts/...`
- [x] New table-driven regression test `TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution` (`internal/alerts/engine_test.go`) reproduces the exact GH-4021 timing (`stuck_for=41m0s`) and asserts no false eviction when a child is actively executing past the queue-time threshold but not the execution-start threshold.
- [x] New wiring test `TestExecuteSubIssuesTracked_TouchesParentProgressPerChild` (`internal/executor/epic_test.go`) confirms the parent's task ID receives a progress event per child start.