### PR TITLE
fix(metrics): restore Prometheus counter baselines from store on startup (GH-4041)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-07 (v2.151.0)
+**Last Updated:** 2026-07-06 (v2.151.0)
 
 ## Legend
 
@@ -20,7 +20,6 @@
 | Task execution | ✅ | executor | `pilot task` | - | Claude Code subprocess |
 | Branch creation | ✅ | executor | `--no-branch` disables | - | Auto `pilot/TASK-XXX` |
 | PR creation | ✅ | executor | `--create-pr` | - | Via `gh pr create` |
-| Direct-path duplicate-PR guard | ✅ | executor | - | - | Pre-push merged-branch short-circuit + pre-create open-PR adoption on the non-epic path, mirrors TASK-359 Shape C (GH-4022) |
 | Progress display | ✅ | executor | - | - | Lipgloss visual bar |
 | Navigator detection | ✅ | executor | - | - | Auto-prefix if `.agent/` exists |
 | AGENTS.md loading | ✅ | executor | - | - | LoadAgentsFile reads project AGENTS.md (v0.24.1) |
@@ -313,6 +312,7 @@
 | OpenAI-compatible direct backend | ✅ | executor | `type: openai-api` | `executor.openai` | Direct /v1/chat/completions for OpenAI, OpenRouter, Groq, Synthetic, vLLM, Ollama (v2.105.0, GH-2382) |
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |
+| Prometheus counter baselines on restart | ✅ | autopilot/memory | - | - | `HydrateFromStore` restores lifetime per-(model,direction/result) token/cost/execution counters from `executions` table before `/metrics` starts serving, so `pilot_tokens_consumed_total`/`pilot_execution_cost_usd_total`/`pilot_executions_total`/`pilot_success_rate` survive daemon restarts instead of resetting to zero (GH-4041) |
 | External-merge metrics | ✅ | autopilot | - | - | Record PRsMerged/IssuesProcessed/PRTimeToMerge for externally-merged PRs via scanner (v2.147.0, GH-2981) |
 | JSON structured logging | ✅ | - | - | `logging.format` | Optional JSON log output mode (v0.38.0) |
 | Qwen Code backend | ✅ | executor | `--backend qwen` | `executor.backend` | Alibaba Qwen Code CLI with stream-json (v1.9.0, GH-1314) |
@@ -407,7 +407,6 @@
 | Board sync tests | ✅ | adapters/github | - | - | ProjectBoardSync and ExecuteGraphQL unit tests (v2.30.0, PR #1865) |
 | CI context wiring | ✅ | autopilot | - | - | Wire proper CI context from autopilot controller (v2.52.0, PR #1981) |
 | PR stage execution-event audit trail | ✅ | autopilot | - | - | `Controller` writes `execution_events` rows (ci_passed/ci_failed/awaiting_approval/merged/released/failed) via `memory.Store.InsertExecutionEvent`; survives PR-state-row cleanup after merge since it keys off `executions.id` (GH-3847) |
-| Aggregated scope release notes + LLM wiring | ✅ | autopilot | - | `release.generate_summary` | `on_scope_close`/`on_schedule` carriers get a deterministic body (headline, grouped Features/Fixes/Other with exact `#PR`/`GH-issue` attribution, breaking changes, compare + stats footer) via `BuildScopeReleaseNotes`; LLM "What's New" (Haiku) is now wired end-to-end via `SetReleaseSummaryGenerator` at every controller construction site, reading `ANTHROPIC_API_KEY` (v2.232.0, GH-3992) |
 
 ## Epic Management
 

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1160,6 +1160,16 @@ Examples:
 				if gwRunner != nil {
 					gwRunner.SetMetricsRecorder(gwAutopilotController.Metrics())
 				}
+				// GH-4041: restore Prometheus counter baselines from the store's
+				// lifetime execution history before p.Start() below brings up the
+				// /metrics handler, so external dashboards don't observe a
+				// reset-to-zero on restart. Fail loud rather than silently start
+				// with zero baselines.
+				if gwStore != nil {
+					if hydrateErr := autopilot.HydrateFromStore(context.Background(), gwStore, gwAutopilotController.Metrics()); hydrateErr != nil {
+						return fmt.Errorf("failed to hydrate metrics from store: %w", hydrateErr)
+					}
+				}
 			}
 			// TASK-332: Wire alert metrics into the Prometheus exporter
 			if gwAlertsEngine != nil {
@@ -1935,6 +1945,16 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			gwServer.SetMetricsSource(autopilotController.Metrics())
 			// GH-2855: wire token/cost/execution counters into executor
 			runner.SetMetricsRecorder(autopilotController.Metrics())
+			// GH-4041: restore Prometheus counter baselines from the store's
+			// lifetime execution history before the /metrics handler starts
+			// serving scrapes below, so external dashboards don't observe a
+			// reset-to-zero on restart. Fail loud rather than silently start
+			// with zero baselines.
+			if store != nil {
+				if hydrateErr := autopilot.HydrateFromStore(ctx, store, autopilotController.Metrics()); hydrateErr != nil {
+					return fmt.Errorf("failed to hydrate metrics from store: %w", hydrateErr)
+				}
+			}
 		}
 
 		// GH-2080: Wire PR review webhook events to autopilot controller in polling mode

--- a/internal/autopilot/metrics.go
+++ b/internal/autopilot/metrics.go
@@ -227,6 +227,24 @@ func (m *Metrics) RecordExecution(model, result string) {
 	m.ExecutionsByResult[execKey{Model: model, Result: result}]++
 }
 
+// HydrateExecutions adds a store-lifetime baseline to the {model, result}
+// execution counter. Unlike RecordExecution (per-event, +1), this adds an
+// arbitrary count — intended for one-time startup hydration from the store
+// before /metrics starts serving scrapes (GH-4041), not live recording.
+func (m *Metrics) HydrateExecutions(model, result string, n int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ExecutionsByResult[execKey{Model: model, Result: result}] += n
+}
+
+// HydrateIssuesProcessed adds a store-lifetime baseline to the issues-processed
+// counter. See HydrateExecutions (GH-4041).
+func (m *Metrics) HydrateIssuesProcessed(result string, n int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.IssuesProcessed[result] += n
+}
+
 // --- Gauge updates ---
 
 // UpdateActivePRs recalculates active PR counts by stage from a snapshot.

--- a/internal/autopilot/metrics_hydrator.go
+++ b/internal/autopilot/metrics_hydrator.go
@@ -1,0 +1,57 @@
+package autopilot
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// HydrateFromStore restores Prometheus counter baselines from the store's
+// lifetime execution history into metrics, so external dashboards match
+// Pilot's store-backed totals across daemon restarts instead of observing a
+// reset-to-zero (GH-4041). Counters stay true Counters — this adds the
+// lifetime baseline on top of the freshly constructed, all-zero in-memory
+// Metrics, it does not replace or reset anything.
+//
+// Must be called once at startup, after metrics are registered and before
+// the HTTP server starts serving /metrics. Callers should treat a non-nil
+// error as fatal — starting with silent zero baselines defeats the point.
+//
+// pilot_success_rate is a gauge derived from IssuesProcessed at scrape time
+// (see Metrics.Snapshot), so hydrating IssuesProcessed here fixes it for
+// free — no separate wiring needed.
+func HydrateFromStore(ctx context.Context, store *memory.Store, metrics *Metrics) error {
+	if store == nil || metrics == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	baselines, err := store.GetLifetimeCounterBaselines()
+	if err != nil {
+		return fmt.Errorf("hydrate metrics from store: %w", err)
+	}
+	for key, n := range baselines.TokensByModelDirection {
+		metrics.RecordTokens(key.Model, key.Direction, n)
+	}
+	for model, cost := range baselines.CostByModel {
+		metrics.RecordCost(model, cost)
+	}
+	for key, n := range baselines.ExecutionsByModelResult {
+		metrics.HydrateExecutions(key.Model, key.Result, n)
+	}
+
+	taskCounts, err := store.GetLifetimeTaskCounts("")
+	if err != nil {
+		return fmt.Errorf("hydrate metrics from store: lifetime task counts: %w", err)
+	}
+	metrics.HydrateIssuesProcessed("success", int64(taskCounts.Succeeded))
+	metrics.HydrateIssuesProcessed("rate_limited", int64(taskCounts.RateLimited))
+	if failed := taskCounts.Total - taskCounts.Succeeded - taskCounts.RateLimited; failed > 0 {
+		metrics.HydrateIssuesProcessed("failed", int64(failed))
+	}
+
+	return nil
+}

--- a/internal/autopilot/metrics_hydrator_test.go
+++ b/internal/autopilot/metrics_hydrator_test.go
@@ -23,19 +23,19 @@ func TestHydrateFromStore_PerLabelValues(t *testing.T) {
 	execs := []*memory.Execution{
 		{
 			ID: "h-1", TaskID: "TASK-1", ProjectPath: "/p", Status: "completed",
-			ModelName: "claude-sonnet-4-5",
+			ModelName:   "claude-sonnet-4-5",
 			TokensInput: 1000, TokensOutput: 500, TokensTotal: 1500,
 			EstimatedCostUSD: 0.05,
 		},
 		{
 			ID: "h-2", TaskID: "TASK-2", ProjectPath: "/p", Status: "completed",
-			ModelName: "claude-sonnet-4-5",
+			ModelName:   "claude-sonnet-4-5",
 			TokensInput: 2000, TokensOutput: 1000, TokensTotal: 3000,
 			EstimatedCostUSD: 0.10,
 		},
 		{
 			ID: "h-3", TaskID: "TASK-3", ProjectPath: "/p", Status: "failed",
-			ModelName: "claude-opus-4-6",
+			ModelName:   "claude-opus-4-6",
 			TokensInput: 500, TokensOutput: 250, TokensTotal: 750,
 			EstimatedCostUSD: 0.02,
 		},
@@ -137,7 +137,7 @@ func TestHydrateFromStore_RestartContinuity(t *testing.T) {
 
 	if err := store.SaveExecution(&memory.Execution{
 		ID: "restart-1", TaskID: "TASK-1", ProjectPath: "/p", Status: "completed",
-		ModelName: "claude-sonnet-4-5",
+		ModelName:   "claude-sonnet-4-5",
 		TokensInput: 1000, TokensOutput: 500, TokensTotal: 1500,
 		EstimatedCostUSD: 0.05,
 	}); err != nil {
@@ -157,7 +157,7 @@ func TestHydrateFromStore_RestartContinuity(t *testing.T) {
 	// More work happens against the same store before the simulated restart.
 	if err := store.SaveExecution(&memory.Execution{
 		ID: "restart-2", TaskID: "TASK-2", ProjectPath: "/p", Status: "completed",
-		ModelName: "claude-sonnet-4-5",
+		ModelName:   "claude-sonnet-4-5",
 		TokensInput: 500, TokensOutput: 250, TokensTotal: 750,
 		EstimatedCostUSD: 0.02,
 	}); err != nil {

--- a/internal/autopilot/metrics_hydrator_test.go
+++ b/internal/autopilot/metrics_hydrator_test.go
@@ -1,0 +1,194 @@
+package autopilot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestHydrateFromStore_PerLabelValues seeds a store with executions across two
+// models and asserts HydrateFromStore restores per-(model,direction) token
+// counters, per-model cost counters, per-(model,result) execution counters,
+// and the derived success rate — matching the store's lifetime totals
+// (GH-4041 acceptance criteria).
+func TestHydrateFromStore_PerLabelValues(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	execs := []*memory.Execution{
+		{
+			ID: "h-1", TaskID: "TASK-1", ProjectPath: "/p", Status: "completed",
+			ModelName: "claude-sonnet-4-5",
+			TokensInput: 1000, TokensOutput: 500, TokensTotal: 1500,
+			EstimatedCostUSD: 0.05,
+		},
+		{
+			ID: "h-2", TaskID: "TASK-2", ProjectPath: "/p", Status: "completed",
+			ModelName: "claude-sonnet-4-5",
+			TokensInput: 2000, TokensOutput: 1000, TokensTotal: 3000,
+			EstimatedCostUSD: 0.10,
+		},
+		{
+			ID: "h-3", TaskID: "TASK-3", ProjectPath: "/p", Status: "failed",
+			ModelName: "claude-opus-4-6",
+			TokensInput: 500, TokensOutput: 250, TokensTotal: 750,
+			EstimatedCostUSD: 0.02,
+		},
+	}
+	for _, e := range execs {
+		if err := store.SaveExecution(e); err != nil {
+			t.Fatalf("SaveExecution %s: %v", e.ID, err)
+		}
+	}
+
+	metrics := NewMetrics()
+	if err := HydrateFromStore(context.Background(), store, metrics); err != nil {
+		t.Fatalf("HydrateFromStore: %v", err)
+	}
+
+	snap := metrics.Snapshot()
+
+	// Per-label token totals restored individually.
+	wantTokens := map[tokenKey]int64{
+		{Model: "claude-sonnet-4-5", Direction: "input"}:  3000,
+		{Model: "claude-sonnet-4-5", Direction: "output"}: 1500,
+		{Model: "claude-opus-4-6", Direction: "input"}:    500,
+		{Model: "claude-opus-4-6", Direction: "output"}:   250,
+	}
+	for k, want := range wantTokens {
+		if got := snap.TokensConsumed[k]; got != want {
+			t.Errorf("TokensConsumed[%+v] = %d, want %d", k, got, want)
+		}
+	}
+	var tokenSum int64
+	for _, v := range snap.TokensConsumed {
+		tokenSum += v
+	}
+	if want := int64(5250); tokenSum != want {
+		t.Errorf("sum(TokensConsumed) = %d, want %d", tokenSum, want)
+	}
+
+	// Per-model cost restored.
+	const epsilon = 0.0001
+	if got, want := snap.ExecutionCostUSD["claude-sonnet-4-5"], 0.15; got < want-epsilon || got > want+epsilon {
+		t.Errorf("ExecutionCostUSD[claude-sonnet-4-5] = %.4f, want %.4f", got, want)
+	}
+	if got, want := snap.ExecutionCostUSD["claude-opus-4-6"], 0.02; got < want-epsilon || got > want+epsilon {
+		t.Errorf("ExecutionCostUSD[claude-opus-4-6] = %.4f, want %.4f", got, want)
+	}
+
+	// Per-(model,result) execution counts restored; sum matches total executions.
+	wantExecs := map[execKey]int64{
+		{Model: "claude-sonnet-4-5", Result: "success"}: 2,
+		{Model: "claude-opus-4-6", Result: "failed"}:    1,
+	}
+	for k, want := range wantExecs {
+		if got := snap.ExecutionsByResult[k]; got != want {
+			t.Errorf("ExecutionsByResult[%+v] = %d, want %d", k, got, want)
+		}
+	}
+	var execSum int64
+	for _, v := range snap.ExecutionsByResult {
+		execSum += v
+	}
+	if execSum != int64(len(execs)) {
+		t.Errorf("sum(ExecutionsByResult) = %d, want %d", execSum, len(execs))
+	}
+
+	// pilot_success_rate inherits the fix for free via IssuesProcessed hydration:
+	// 2 of the 3 lifetime executions succeeded.
+	wantRate := 2.0 / 3.0
+	if snap.SuccessRate < wantRate-epsilon || snap.SuccessRate > wantRate+epsilon {
+		t.Errorf("SuccessRate = %.4f, want %.4f", snap.SuccessRate, wantRate)
+	}
+}
+
+// TestHydrateFromStore_NilStoreIsNoop verifies hydration is a no-op (not an
+// error) when no store is configured, matching how other optional
+// store-backed features degrade in this codebase.
+func TestHydrateFromStore_NilStoreIsNoop(t *testing.T) {
+	metrics := NewMetrics()
+	if err := HydrateFromStore(context.Background(), nil, metrics); err != nil {
+		t.Fatalf("HydrateFromStore with nil store: %v", err)
+	}
+	snap := metrics.Snapshot()
+	if len(snap.TokensConsumed) != 0 {
+		t.Errorf("expected no hydration with nil store, got %+v", snap.TokensConsumed)
+	}
+}
+
+// TestHydrateFromStore_RestartContinuity simulates a daemon restart: snapshot
+// counter values after the first hydration (pre-restart), then hydrate a
+// brand-new Metrics instance from the same store (post-restart) and assert
+// the post-hydration values are >= the pre-restart snapshot — the core
+// GH-4041 acceptance criterion (no observable regression across restart).
+func TestHydrateFromStore_RestartContinuity(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "restart-1", TaskID: "TASK-1", ProjectPath: "/p", Status: "completed",
+		ModelName: "claude-sonnet-4-5",
+		TokensInput: 1000, TokensOutput: 500, TokensTotal: 1500,
+		EstimatedCostUSD: 0.05,
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	// Pre-restart: daemon boots, hydrates from store.
+	preMetrics := NewMetrics()
+	if err := HydrateFromStore(context.Background(), store, preMetrics); err != nil {
+		t.Fatalf("HydrateFromStore (pre-restart): %v", err)
+	}
+	preSnap := preMetrics.Snapshot()
+	preTokens := preSnap.TokensConsumed[tokenKey{Model: "claude-sonnet-4-5", Direction: "input"}]
+	preCost := preSnap.ExecutionCostUSD["claude-sonnet-4-5"]
+	preExecs := preSnap.ExecutionsByResult[execKey{Model: "claude-sonnet-4-5", Result: "success"}]
+
+	// More work happens against the same store before the simulated restart.
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "restart-2", TaskID: "TASK-2", ProjectPath: "/p", Status: "completed",
+		ModelName: "claude-sonnet-4-5",
+		TokensInput: 500, TokensOutput: 250, TokensTotal: 750,
+		EstimatedCostUSD: 0.02,
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	// Post-restart: a fresh (all-zero) Metrics is constructed, as happens on
+	// daemon boot, then hydrated from the same store.
+	postMetrics := NewMetrics()
+	if err := HydrateFromStore(context.Background(), store, postMetrics); err != nil {
+		t.Fatalf("HydrateFromStore (post-restart): %v", err)
+	}
+	postSnap := postMetrics.Snapshot()
+	postTokens := postSnap.TokensConsumed[tokenKey{Model: "claude-sonnet-4-5", Direction: "input"}]
+	postCost := postSnap.ExecutionCostUSD["claude-sonnet-4-5"]
+	postExecs := postSnap.ExecutionsByResult[execKey{Model: "claude-sonnet-4-5", Result: "success"}]
+
+	if postTokens < preTokens {
+		t.Errorf("post-restart tokens = %d, want >= pre-restart %d", postTokens, preTokens)
+	}
+	if postCost < preCost {
+		t.Errorf("post-restart cost = %.4f, want >= pre-restart %.4f", postCost, preCost)
+	}
+	if postExecs < preExecs {
+		t.Errorf("post-restart executions = %d, want >= pre-restart %d", postExecs, preExecs)
+	}
+
+	// No 0-then-baseline gap: the freshly constructed postMetrics never
+	// observably held zero for these labels before HydrateFromStore returned —
+	// nothing reads postMetrics between NewMetrics() and HydrateFromStore().
+	if postTokens == 0 {
+		t.Error("post-restart tokens baseline is zero, hydration did not run")
+	}
+}

--- a/internal/memory/lifetime_counter_baselines_test.go
+++ b/internal/memory/lifetime_counter_baselines_test.go
@@ -44,19 +44,19 @@ func TestGetLifetimeCounterBaselines_PerLabel(t *testing.T) {
 	execs := []*Execution{
 		{
 			ID: "base-1", TaskID: "TASK-1", ProjectPath: "/p", Status: "completed",
-			ModelName: "claude-sonnet-4-5",
+			ModelName:   "claude-sonnet-4-5",
 			TokensInput: 1000, TokensOutput: 500, TokensTotal: 1500,
 			TokensCacheRead: 200, TokensCacheWrite: 100, EstimatedCostUSD: 0.05,
 		},
 		{
 			ID: "base-2", TaskID: "TASK-2", ProjectPath: "/p", Status: "completed",
-			ModelName: "claude-sonnet-4-5",
+			ModelName:   "claude-sonnet-4-5",
 			TokensInput: 2000, TokensOutput: 1000, TokensTotal: 3000,
 			EstimatedCostUSD: 0.10,
 		},
 		{
 			ID: "base-3", TaskID: "TASK-3", ProjectPath: "/p", Status: "failed",
-			ModelName: "claude-opus-4-6",
+			ModelName:   "claude-opus-4-6",
 			TokensInput: 500, TokensOutput: 250, TokensTotal: 750,
 			EstimatedCostUSD: 0.02,
 		},

--- a/internal/memory/lifetime_counter_baselines_test.go
+++ b/internal/memory/lifetime_counter_baselines_test.go
@@ -1,0 +1,133 @@
+package memory
+
+import "testing"
+
+// TestGetLifetimeCounterBaselines_Empty verifies an empty executions table
+// yields empty (not nil) maps, so callers can range over them unconditionally.
+func TestGetLifetimeCounterBaselines_Empty(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	b, err := store.GetLifetimeCounterBaselines()
+	if err != nil {
+		t.Fatalf("GetLifetimeCounterBaselines (empty): %v", err)
+	}
+	if len(b.TokensByModelDirection) != 0 {
+		t.Errorf("TokensByModelDirection = %v, want empty", b.TokensByModelDirection)
+	}
+	if len(b.CostByModel) != 0 {
+		t.Errorf("CostByModel = %v, want empty", b.CostByModel)
+	}
+	if len(b.ExecutionsByModelResult) != 0 {
+		t.Errorf("ExecutionsByModelResult = %v, want empty", b.ExecutionsByModelResult)
+	}
+}
+
+// TestGetLifetimeCounterBaselines_PerLabel verifies per-(model,direction) token
+// totals, per-model cost totals, and per-(model,result) execution totals are
+// aggregated correctly, and that summing the per-label values reproduces the
+// same totals GetLifetimeTokens/GetLifetimeTaskCounts report (GH-4041).
+func TestGetLifetimeCounterBaselines_PerLabel(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	execs := []*Execution{
+		{
+			ID: "base-1", TaskID: "TASK-1", ProjectPath: "/p", Status: "completed",
+			ModelName: "claude-sonnet-4-5",
+			TokensInput: 1000, TokensOutput: 500, TokensTotal: 1500,
+			TokensCacheRead: 200, TokensCacheWrite: 100, EstimatedCostUSD: 0.05,
+		},
+		{
+			ID: "base-2", TaskID: "TASK-2", ProjectPath: "/p", Status: "completed",
+			ModelName: "claude-sonnet-4-5",
+			TokensInput: 2000, TokensOutput: 1000, TokensTotal: 3000,
+			EstimatedCostUSD: 0.10,
+		},
+		{
+			ID: "base-3", TaskID: "TASK-3", ProjectPath: "/p", Status: "failed",
+			ModelName: "claude-opus-4-6",
+			TokensInput: 500, TokensOutput: 250, TokensTotal: 750,
+			EstimatedCostUSD: 0.02,
+		},
+		{
+			ID: "base-4", TaskID: "TASK-4", ProjectPath: "/p", Status: "stalled",
+			ModelName: "claude-opus-4-6",
+			// Zero tokens — excluded from the token/cost baseline (like
+			// GetLifetimeTokens), but still counted as an execution.
+		},
+		{
+			// Non-terminal row (still queued) — must not be counted as an execution.
+			ID: "base-5", TaskID: "TASK-5", ProjectPath: "/p", Status: "queued",
+			ModelName: "claude-opus-4-6",
+		},
+	}
+	for _, e := range execs {
+		if err := store.SaveExecution(e); err != nil {
+			t.Fatalf("SaveExecution %s: %v", e.ID, err)
+		}
+	}
+
+	b, err := store.GetLifetimeCounterBaselines()
+	if err != nil {
+		t.Fatalf("GetLifetimeCounterBaselines: %v", err)
+	}
+
+	wantTokens := map[ModelDirectionKey]int64{
+		{Model: "claude-sonnet-4-5", Direction: "input"}:          3000,
+		{Model: "claude-sonnet-4-5", Direction: "output"}:         1500,
+		{Model: "claude-sonnet-4-5", Direction: "cache_read"}:     200,
+		{Model: "claude-sonnet-4-5", Direction: "cache_creation"}: 100,
+		{Model: "claude-opus-4-6", Direction: "input"}:            500,
+		{Model: "claude-opus-4-6", Direction: "output"}:           250,
+	}
+	for k, want := range wantTokens {
+		if got := b.TokensByModelDirection[k]; got != want {
+			t.Errorf("TokensByModelDirection[%+v] = %d, want %d", k, got, want)
+		}
+	}
+	for k := range b.TokensByModelDirection {
+		if _, ok := wantTokens[k]; !ok {
+			t.Errorf("unexpected TokensByModelDirection key %+v = %d", k, b.TokensByModelDirection[k])
+		}
+	}
+
+	wantCost := map[string]float64{
+		"claude-sonnet-4-5": 0.15,
+		"claude-opus-4-6":   0.02,
+	}
+	const epsilon = 0.0001
+	for model, want := range wantCost {
+		if got := b.CostByModel[model]; got < want-epsilon || got > want+epsilon {
+			t.Errorf("CostByModel[%s] = %.4f, want %.4f", model, got, want)
+		}
+	}
+
+	wantExecs := map[ModelResultKey]int64{
+		{Model: "claude-sonnet-4-5", Result: "success"}: 2,
+		{Model: "claude-opus-4-6", Result: "failed"}:    1,
+		{Model: "claude-opus-4-6", Result: "stalled"}:   1,
+	}
+	for k, want := range wantExecs {
+		if got := b.ExecutionsByModelResult[k]; got != want {
+			t.Errorf("ExecutionsByModelResult[%+v] = %d, want %d", k, got, want)
+		}
+	}
+	var totalExecs int64
+	for _, v := range b.ExecutionsByModelResult {
+		totalExecs += v
+	}
+	if totalExecs != 4 {
+		t.Errorf("total executions = %d, want 4 (base-5 queued row excluded)", totalExecs)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -2097,6 +2097,129 @@ func (s *Store) GetLifetimeTaskCounts(projectPath string) (*LifetimeTaskCounts, 
 	return &tc, nil
 }
 
+// ModelDirectionKey identifies a token bucket by model and direction, mirroring
+// autopilot's internal tokenKey so lifetime baselines line up with the
+// in-memory Prometheus counter they hydrate (GH-4041).
+type ModelDirectionKey struct {
+	Model     string
+	Direction string
+}
+
+// ModelResultKey identifies an execution bucket by model and outcome, mirroring
+// autopilot's internal execKey (GH-4041).
+type ModelResultKey struct {
+	Model  string
+	Result string
+}
+
+// LifetimeCounterBaselines holds per-label lifetime totals aggregated from the
+// executions table, used to restore Prometheus counter baselines on daemon
+// startup so external dashboards match the store's lifetime totals across
+// restarts instead of resetting to zero (GH-4041). Read-only — computed from
+// existing columns, no schema changes.
+type LifetimeCounterBaselines struct {
+	TokensByModelDirection  map[ModelDirectionKey]int64
+	CostByModel             map[string]float64
+	ExecutionsByModelResult map[ModelResultKey]int64
+}
+
+// GetLifetimeCounterBaselines aggregates lifetime token, cost, and execution
+// totals from the executions table, broken down the same way the live
+// Prometheus counters are keyed (model+direction for tokens, model for cost,
+// model+result for executions). GH-4041.
+//
+// The execution "result" label collapses the executions table's richer status
+// vocabulary (completed/failed/declined/no_op/stalled/rate_limited/infra/
+// skipped) into the three values RecordExecution ever actually receives live
+// (runner.go TerminalStatus / outcomeLabel): "success" for completed,
+// "stalled" for stalled, everything else terminal folds into "failed" — so a
+// restart does not introduce label values the live path never produces.
+func (s *Store) GetLifetimeCounterBaselines() (*LifetimeCounterBaselines, error) {
+	baselines := &LifetimeCounterBaselines{
+		TokensByModelDirection:  make(map[ModelDirectionKey]int64),
+		CostByModel:             make(map[string]float64),
+		ExecutionsByModelResult: make(map[ModelResultKey]int64),
+	}
+
+	// Rows with zero tokens (dispatcher queue rows, early-failure rows) are
+	// excluded so they don't dilute the baseline, mirroring GetLifetimeTokens.
+	tokRows, err := s.db.Query(`
+		SELECT
+			COALESCE(NULLIF(model_name, ''), 'unknown'),
+			COALESCE(SUM(tokens_input), 0),
+			COALESCE(SUM(tokens_output), 0),
+			COALESCE(SUM(tokens_cache_write), 0),
+			COALESCE(SUM(tokens_cache_read), 0),
+			COALESCE(SUM(estimated_cost_usd), 0)
+		FROM executions
+		WHERE tokens_total > 0
+		GROUP BY model_name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get lifetime token/cost baselines: %w", err)
+	}
+	defer func() { _ = tokRows.Close() }()
+
+	for tokRows.Next() {
+		var model string
+		var input, output, cacheWrite, cacheRead int64
+		var cost float64
+		if err := tokRows.Scan(&model, &input, &output, &cacheWrite, &cacheRead, &cost); err != nil {
+			return nil, fmt.Errorf("failed to scan lifetime token/cost baseline row: %w", err)
+		}
+		if input > 0 {
+			baselines.TokensByModelDirection[ModelDirectionKey{Model: model, Direction: "input"}] = input
+		}
+		if output > 0 {
+			baselines.TokensByModelDirection[ModelDirectionKey{Model: model, Direction: "output"}] = output
+		}
+		if cacheWrite > 0 {
+			baselines.TokensByModelDirection[ModelDirectionKey{Model: model, Direction: "cache_creation"}] = cacheWrite
+		}
+		if cacheRead > 0 {
+			baselines.TokensByModelDirection[ModelDirectionKey{Model: model, Direction: "cache_read"}] = cacheRead
+		}
+		if cost != 0 {
+			baselines.CostByModel[model] += cost
+		}
+	}
+	if err := tokRows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate lifetime token/cost baselines: %w", err)
+	}
+
+	execRows, err := s.db.Query(`
+		SELECT
+			COALESCE(NULLIF(model_name, ''), 'unknown'),
+			CASE
+				WHEN status = 'completed' THEN 'success'
+				WHEN status = 'stalled' THEN 'stalled'
+				ELSE 'failed'
+			END AS result,
+			COUNT(*)
+		FROM executions
+		WHERE status NOT IN ('queued', 'pending', 'running')
+		GROUP BY model_name, result
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get lifetime execution baselines: %w", err)
+	}
+	defer func() { _ = execRows.Close() }()
+
+	for execRows.Next() {
+		var model, result string
+		var count int64
+		if err := execRows.Scan(&model, &result, &count); err != nil {
+			return nil, fmt.Errorf("failed to scan lifetime execution baseline row: %w", err)
+		}
+		baselines.ExecutionsByModelResult[ModelResultKey{Model: model, Result: result}] += count
+	}
+	if err := execRows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate lifetime execution baselines: %w", err)
+	}
+
+	return baselines, nil
+}
+
 // EndSession marks a session as ended.
 func (s *Store) EndSession(sessionID string) error {
 	return s.withRetry("EndSession", func() error {


### PR DESCRIPTION
## Summary

- `internal/memory`: adds `Store.GetLifetimeCounterBaselines()`, a read-only aggregation over the existing `executions` table (no schema changes) returning per-`(model,direction)` token totals, per-`model` cost totals, and per-`(model,result)` execution totals.
- `internal/autopilot`: adds `autopilot.HydrateFromStore(ctx, store, metrics)`, which adds those lifetime baselines onto a freshly constructed `Metrics` (via existing `RecordTokens`/`RecordCost` plus new arbitrary-`n` `HydrateExecutions`/`HydrateIssuesProcessed`). Counters remain true Counters — nothing switches to a gauge. Hydrating `IssuesProcessed` also fixes `pilot_success_rate` for free, since it's a gauge derived from `IssuesProcessed` at scrape time.
- `cmd/pilot`: calls `HydrateFromStore` right after the metrics recorder is wired, in both the polling-mode and full-gateway-mode boot paths, before the gateway's HTTP server (and therefore `/metrics`) starts listening. Hydration errors fail startup loudly rather than silently serving zero baselines.

### Non-goals honored
No store schema changes, no TUI changes, no new gauges. Counters without an authoritative store-backed lifetime source — `pilot_prs_merged_total`, `pilot_prs_failed_total`, `pilot_circuit_breaker_trips_total`, `pilot_api_errors_total`, `pilot_label_cleanups_total`, `pilot_approval_persist_misses_total`, the poller skip/dispatch/deferred counters, and `pilot_panics_total` — are intentionally left unhydrated; restoring them would require new persisted state, which is out of scope per the ticket.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/memory/... ./internal/autopilot/... ./internal/gateway/... ./internal/executor/... ./cmd/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] Unit test for the hydrator with per-label assertions (`TestHydrateFromStore_PerLabelValues`), summing per-label values back to the totals
- [x] Restart continuity test: hydrate `Metrics` A from a store, add more executions, hydrate a fresh `Metrics` B from the same store, assert B >= A per label (`TestHydrateFromStore_RestartContinuity`)
- [x] Store-level lifetime aggregation tests (`TestGetLifetimeCounterBaselines_Empty`, `TestGetLifetimeCounterBaselines_PerLabel`)