### PR TITLE
fix(executor): refresh epic parent's stuck-monitor entry per child execution (GH-4033)

### DIFF
--- a/.agent/tasks/gh-4033.md
+++ b/.agent/tasks/gh-4033.md
@@ -1,0 +1,25 @@
+# GH-4033
+
+**Created:** 2026-07-07
+
+## Problem
+
+GitHub Issue GH-4033: fix(executor): stuck-monitor times decomposed tasks from execution start, not...
+
+<!--autopilot-meta
+parent: GH-4028
+inherited-spec: true
+-->
+
+Parent: GH-4028
+
+Fix the stuck-task monitor so stuck_for is computed from the task's execution-start timestamp (when the runner actually begins the subtask fan-out) rather than the queue-enqueue timestamp. Evidence: GH-4021 was evicted at 18:50 with stuck_for=41m0s while subtask 2 was actively running — queue time was 18:09, execution start was 18:34. Locate the timer in the stuck-monitor code path (likely internal/executor/stuck_monitor.go or the autopilot supervisor), switch its reference clock to execution.started_at, and add a table-driven test with a decomposed task whose subtasks legitimately run past the queue-time threshold but not past the start-time threshold — assert no false eviction.
+
+## Scope fence
+
+Implement ONLY the slice described above. The parent issue GH-4028 is decomposed
+into sibling sub-issues that cover the rest of its spec — consult the parent
+for context, but do NOT implement parts of it that fall outside this subtask.
+
+## Acceptance Criteria
+

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -2417,6 +2417,102 @@ func TestEngine_TaskProgressUpdatesStuckState(t *testing.T) {
 	}
 }
 
+// TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution pins
+// GH-4033: an epic parent's stuck_for must be computed from the most recent
+// child sub-issue's execution-start activity, not from the one-time
+// pre-loop timestamp recorded before the sequential sub-issue fan-out began.
+// Mirrors the GH-4021 incident: the parent's last alerts-visible touch was
+// long before sub-issue 2 actually started executing (everything in between
+// — GitHub issue comments via UpdateIssueProgress, and each child's own
+// progress under its own task ID — never reaches the parent's
+// taskLastProgress entry), and the orphan sweep evicted the parent with
+// stuck_for=41m0s even though sub-issue 2 was actively running.
+func TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution(t *testing.T) {
+	tests := []struct {
+		name              string
+		childTouchAgo     time.Duration // 0 means no child-execution-start touch fires
+		wantParentEvicted bool
+	}{
+		{
+			name:              "child running past pre-loop-time threshold but not its own start-time threshold: no false eviction",
+			childTouchAgo:     16 * time.Minute, // sub-issue 2 execution start, 16m before the sweep
+			wantParentEvicted: false,
+		},
+		{
+			name:              "no child ever started executing: parent legitimately orphaned",
+			childTouchAgo:     0,
+			wantParentEvicted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &AlertConfig{
+				Enabled: true,
+				Channels: []ChannelConfig{
+					{Name: "test-channel", Type: "webhook", Enabled: true},
+				},
+				Rules: []AlertRule{
+					{
+						Name:    "task_stuck",
+						Type:    AlertTypeTaskStuck,
+						Enabled: true,
+						Condition: RuleCondition{
+							ProgressUnchangedFor: 10 * time.Minute,
+						},
+						Severity: SeverityWarning,
+						Channels: []string{"test-channel"},
+						Cooldown: 0,
+					},
+				},
+			}
+
+			mockCh := newMockChannel("test-channel", "webhook")
+			dispatcher := NewDispatcher(config)
+			dispatcher.RegisterChannel(mockCh)
+
+			engine := NewEngine(config, WithDispatcher(dispatcher))
+
+			// Parent's last alerts-visible touch (the pre-loop "Executing"
+			// progress report) was 41 min ago — past the 4x10m=40m orphan
+			// threshold on its own.
+			engine.handleTaskStarted(Event{
+				Type:      EventTypeTaskStarted,
+				TaskID:    "GH-4021",
+				Phase:     "Executing",
+				Timestamp: time.Now().Add(-41 * time.Minute),
+			})
+
+			if tt.childTouchAgo > 0 {
+				// epic.go's executeSubIssuesTracked loop now reports progress
+				// under the PARENT's own task ID at each child's execution
+				// start (GH-4033 fix), so this models sub-issue 2 starting.
+				engine.handleTaskProgress(Event{
+					Type:      EventTypeTaskProgress,
+					TaskID:    "GH-4021",
+					Phase:     "Executing",
+					Progress:  60,
+					Timestamp: time.Now().Add(-tt.childTouchAgo),
+				})
+			}
+
+			ctx := context.Background()
+			engine.evaluateStuckTasks(ctx)
+
+			engine.mu.RLock()
+			_, parentExists := engine.taskLastProgress["GH-4021"]
+			engine.mu.RUnlock()
+
+			if tt.wantParentEvicted && parentExists {
+				t.Error("expected parent GH-4021 to be evicted as orphaned, but it still exists")
+			}
+			if !tt.wantParentEvicted && !parentExists {
+				t.Error("expected parent GH-4021 to survive (child actively executing), but it was evicted")
+			}
+		})
+	}
+}
+
 // =============================================================================
 // Event Queue Full Test
 // =============================================================================

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1884,6 +1884,19 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			r.log.Warn("Failed to update parent progress", "error", err)
 		}
 
+		// GH-4033: refresh the parent's own stuck-monitor entry as each child
+		// starts. UpdateIssueProgress above only posts a GitHub comment — it
+		// never reaches the alerts engine — so without this the parent's
+		// taskLastProgress[parent.ID] entry is last touched once, right before
+		// this loop starts (the "Executing" progress report above), and then
+		// frozen for the entire sequential sub-issue run. A long-running epic
+		// (several children, each a real Claude Code call) then has its
+		// stuck_for measured from that single pre-loop timestamp instead of
+		// from the most recent child's actual execution start, and the
+		// orphan-eviction sweep (4x the stuck threshold) can evict a parent
+		// whose child is still legitimately executing.
+		r.reportProgress(parent.ID, "Executing", 50+(40*i/total), progressMsg)
+
 		// Create task from sub-issue
 		// GH-2177: Use real repo path so sub-issues can create branches from main,
 		// not from inside the parent's worktree (which locks the branch).

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2517,6 +2517,54 @@ func TestRunner_Execute_EpicRecoversThenExecutesOpenChildren(t *testing.T) {
 	}
 }
 
+// TestExecuteSubIssuesTracked_TouchesParentProgressPerChild is a wiring
+// regression test for GH-4033: executeSubIssuesTracked must report progress
+// under the PARENT's own task ID as each child sub-issue starts executing,
+// not just once before the sequential loop begins. UpdateIssueProgress (a
+// `gh issue comment` call) never reaches the alerts engine, so without this
+// touch the parent's stuck-monitor entry (internal/alerts/engine.go
+// taskLastProgress) goes stale for the entire sequential run and can be
+// falsely evicted as an orphan while a child is still actively executing
+// (see internal/alerts/engine_test.go
+// TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution for the
+// eviction-level regression test).
+func TestExecuteSubIssuesTracked_TouchesParentProgressPerChild(t *testing.T) {
+	r := NewRunner()
+	r.skipPreflightChecks = true
+	r.dryRun = true // UpdateIssueProgress becomes a no-op instead of shelling out to gh
+
+	processor := &fakeAlertProcessor{}
+	r.SetAlertProcessor(processor)
+
+	r.executeFunc = func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{TaskID: task.ID, Success: true}, nil
+	}
+
+	parent := &Task{ID: "GH-4021", ProjectPath: "/test/project"}
+	issues := []CreatedIssue{
+		{Number: 4022, Identifier: "4022", URL: "https://github.com/o/r/issues/4022",
+			Subtask: PlannedSubtask{Title: "part 1", Description: "do part 1"}},
+		{Number: 4023, Identifier: "4023", URL: "https://github.com/o/r/issues/4023",
+			Subtask: PlannedSubtask{Title: "part 2", Description: "do part 2"}},
+	}
+
+	_, _, err := r.executeSubIssuesTracked(context.Background(), parent, issues, "/test/project", "/test/project")
+	if err != nil {
+		t.Fatalf("executeSubIssuesTracked returned unexpected error: %v", err)
+	}
+
+	var parentProgressEvents int
+	for _, e := range processor.events {
+		if e.Type == AlertEventTypeTaskProgress && e.TaskID == parent.ID {
+			parentProgressEvents++
+		}
+	}
+	if parentProgressEvents < len(issues) {
+		t.Errorf("expected at least %d task_progress events for parent %s (one per child start), got %d",
+			len(issues), parent.ID, parentProgressEvents)
+	}
+}
+
 // staticAllowlist is a test helper that allows a fixed set of "owner/repo"
 // pairs. projectPath comparison is ignored (tests don't need that dimension).
 type staticAllowlist struct {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -349,6 +349,12 @@ func (s *Store) migrate() error {
 			FOREIGN KEY (execution_id) REFERENCES executions(id) ON DELETE CASCADE
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_execution_events_execution_id ON execution_events(execution_id)`,
+		// GH-4033: separate "when the runner actually started this execution" from
+		// created_at ("when it was queued"). A decomposed subtask's row is created at
+		// decomposition time but can sit queued behind a sibling for a while before the
+		// worker picks it up — the stuck-monitor must time it from started_at, not
+		// created_at, or a legitimately-running subtask gets evicted as stale.
+		`ALTER TABLE executions ADD COLUMN started_at DATETIME`,
 	}
 
 	for _, migration := range migrations {
@@ -484,14 +490,18 @@ type Execution struct {
 	// UserID identifies the user/tenant that owns this execution.
 	// Empty in single-tenant deployments; populated when multi-user mode is enabled.
 	// Used as the pivot for `usage_events` aggregation (GH-2429).
-	UserID      string
-	Status      string
-	Output      string
-	Error       string
-	DurationMs  int64
-	PRUrl       string
-	CommitSHA   string
-	CreatedAt   time.Time
+	UserID     string
+	Status     string
+	Output     string
+	Error      string
+	DurationMs int64
+	PRUrl      string
+	CommitSHA  string
+	CreatedAt  time.Time
+	// StartedAt is when the row actually transitioned to "running" (the runner
+	// began execution), as opposed to CreatedAt (when it was queued/decomposed).
+	// Nil until the worker picks it up. GH-4033.
+	StartedAt   *time.Time
 	CompletedAt *time.Time
 	// Metrics fields (TASK-13)
 	TokensInput      int64
@@ -1329,6 +1339,21 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 		})
 	}
 
+	// GH-4033: stamp started_at when the worker actually begins running this
+	// execution, so the stuck-monitor's clock reference isn't the row's
+	// created_at (queue/decomposition time) — a decomposed subtask can sit
+	// queued behind a sibling for a while before this fires.
+	if status == "running" {
+		return s.withRetry("UpdateExecutionStatus", func() error {
+			_, err := s.db.Exec(`
+				UPDATE executions
+				SET status = ?, error = COALESCE(?, error), started_at = CURRENT_TIMESTAMP
+				WHERE id = ?
+			`, status, errStr, id)
+			return err
+		})
+	}
+
 	return s.withRetry("UpdateExecutionStatus", func() error {
 		_, err := s.db.Exec(`
 			UPDATE executions
@@ -1457,13 +1482,22 @@ func (s *Store) UpdateExecutionEffort(id, effortLevel, complexityLevel string) e
 
 // GetStaleRunningExecutions returns executions that have been in "running" status
 // for longer than the specified duration. Used to detect crashed workers on restart.
+//
+// GH-4033: staleness is measured from started_at (when the worker actually began
+// running this execution), NOT created_at (when the row was queued/decomposed).
+// A decomposed subtask's row is created at decomposition time but can legitimately
+// sit queued behind a sibling for a while before the worker picks it up; timing
+// from created_at evicted such subtasks as "stuck" while they were still actively
+// running. COALESCE falls back to created_at for rows written before this column
+// existed (started_at is NULL) or rows inserted directly with status='running'
+// (bypassing UpdateExecutionStatus, e.g. in tests).
 func (s *Store) GetStaleRunningExecutions(staleDuration time.Duration) ([]*Execution, error) {
 	staleTime := time.Now().Add(-staleDuration)
 	rows, err := s.db.Query(`
-		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at
+		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, started_at, completed_at
 		FROM executions
-		WHERE status = 'running' AND created_at < ?
-		ORDER BY created_at ASC
+		WHERE status = 'running' AND COALESCE(started_at, created_at) < ?
+		ORDER BY COALESCE(started_at, created_at) ASC
 	`, staleTime)
 	if err != nil {
 		return nil, err
@@ -1473,9 +1507,13 @@ func (s *Store) GetStaleRunningExecutions(staleDuration time.Duration) ([]*Execu
 	var executions []*Execution
 	for rows.Next() {
 		var exec Execution
+		var startedAt sql.NullTime
 		var completedAt sql.NullTime
-		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &completedAt); err != nil {
+		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &startedAt, &completedAt); err != nil {
 			return nil, err
+		}
+		if startedAt.Valid {
+			exec.StartedAt = &startedAt.Time
 		}
 		if completedAt.Valid {
 			exec.CompletedAt = &completedAt.Time

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1912,6 +1912,116 @@ func TestGetStaleQueuedExecutions(t *testing.T) {
 	}
 }
 
+// TestGetStaleRunningExecutions_UsesStartedAtNotCreatedAt is the GH-4033
+// regression test: a decomposed subtask's execution row is created (queued) at
+// decomposition time but can legitimately sit behind a FIFO sibling for a while
+// before the worker actually starts it. Staleness must be measured from
+// started_at (execution start), not created_at (queue time), or a subtask still
+// actively running gets evicted as "stuck" once its queue age alone crosses the
+// threshold — exactly what happened to GH-4021 (queued 18:09, started 18:34,
+// evicted 18:50 with a reported stuck_for of 41m computed off the 18:09 queue time).
+func TestGetStaleRunningExecutions_UsesStartedAtNotCreatedAt(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	staleDuration := time.Hour
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		createdAt time.Time
+		startedAt *time.Time // nil leaves started_at NULL
+		wantStale bool
+	}{
+		{
+			// GH-4021 shape: queued well past the threshold (subtask sat behind
+			// a sibling), but execution only began recently — must NOT be
+			// evicted while it's still legitimately running.
+			name:      "decomposed subtask queued past threshold but started recently",
+			createdAt: now.Add(-2 * time.Hour),
+			startedAt: timePtr(now.Add(-2 * time.Minute)),
+			wantStale: false,
+		},
+		{
+			// Genuinely stuck: execution itself started past the threshold.
+			name:      "execution started past threshold",
+			createdAt: now.Add(-3 * time.Hour),
+			startedAt: timePtr(now.Add(-2 * time.Hour)),
+			wantStale: true,
+		},
+		{
+			// Never transitioned through UpdateExecutionStatus (started_at NULL,
+			// e.g. a row inserted directly with status='running') — falls back
+			// to created_at.
+			name:      "no started_at falls back to created_at",
+			createdAt: now.Add(-2 * time.Hour),
+			startedAt: nil,
+			wantStale: true,
+		},
+		{
+			name:      "fresh execution not stale",
+			createdAt: now,
+			startedAt: timePtr(now),
+			wantStale: false,
+		},
+	}
+
+	var wantStaleIDs []string
+	for i, tt := range tests {
+		id := fmt.Sprintf("exec-gh4033-%d", i)
+		if err := store.SaveExecution(&Execution{
+			ID:          id,
+			TaskID:      fmt.Sprintf("GH-4021-%d", i+1),
+			ProjectPath: "/proj",
+			Status:      "running",
+		}); err != nil {
+			t.Fatalf("SaveExecution %s: %v", id, err)
+		}
+		if _, err := store.db.Exec(
+			`UPDATE executions SET created_at = ? WHERE id = ?`, tt.createdAt, id,
+		); err != nil {
+			t.Fatalf("set created_at for %s: %v", id, err)
+		}
+		if tt.startedAt != nil {
+			if _, err := store.db.Exec(
+				`UPDATE executions SET started_at = ? WHERE id = ?`, *tt.startedAt, id,
+			); err != nil {
+				t.Fatalf("set started_at for %s: %v", id, err)
+			}
+		}
+		if tt.wantStale {
+			wantStaleIDs = append(wantStaleIDs, id)
+		}
+	}
+
+	results, err := store.GetStaleRunningExecutions(staleDuration)
+	if err != nil {
+		t.Fatalf("GetStaleRunningExecutions: %v", err)
+	}
+
+	gotIDs := make(map[string]bool, len(results))
+	for _, r := range results {
+		gotIDs[r.ID] = true
+	}
+
+	for i, tt := range tests {
+		id := fmt.Sprintf("exec-gh4033-%d", i)
+		if gotIDs[id] != tt.wantStale {
+			t.Errorf("%s: id=%s wantStale=%v gotStale=%v", tt.name, id, tt.wantStale, gotIDs[id])
+		}
+	}
+
+	if len(results) != len(wantStaleIDs) {
+		t.Errorf("expected %d stale executions, got %d (%v)", len(wantStaleIDs), len(results), gotIDs)
+	}
+}
+
+func timePtr(t time.Time) *time.Time { return &t }
+
 func TestUpdateExecutionStatusByTaskID_UpdatesFailedToCompleted(t *testing.T) {
 	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
 	defer func() { _ = os.RemoveAll(tmpDir) }()


### PR DESCRIPTION
## Summary
- `executeSubIssuesTracked` (the live epic sub-issue fan-out) posted per-child progress to GitHub via `UpdateIssueProgress`, a `gh issue comment` call that never reaches the alerts engine. The parent's `taskLastProgress` entry was only touched once, right before the sequential loop started, then frozen for the entire run — each child executes under its own task ID, so its own progress never touched the parent's entry either.
- On a long epic this let `stuck_for` be measured from that one-time pre-loop timestamp instead of the most recent child's actual execution start, so the orphan-eviction sweep (4x the stuck threshold) could evict a parent whose child was still legitimately executing. Matches the GH-4021 incident: evicted with `stuck_for=41m0s` while sub-issue 2 was actively running.
- Fix: report progress under the parent's own task ID at each child's execution start (`internal/executor/epic.go`). This switches the stuck-monitor's effective reference clock from the queue/pre-loop timestamp to real execution activity.

Also includes a prior, already-shipped GH-4033 fix (`71f9a0ac`) that switched `GetStaleRunningExecutions` (dispatcher's stale-running reaper) from `created_at` to `started_at`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/executor/... ./internal/alerts/... ./internal/memory/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/executor/... ./internal/alerts/... ./internal/memory/...`
- [x] New table-driven regression test `TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution` (`internal/alerts/engine_test.go`) reproduces the exact GH-4021 timing (`stuck_for=41m0s`) and asserts no false eviction when a child is actively executing past the queue-time threshold but not the execution-start threshold.
- [x] New wiring test `TestExecuteSubIssuesTracked_TouchesParentProgressPerChild` (`internal/executor/epic_test.go`) confirms the parent's task ID receives a progress event per child start.