### PR TITLE
fix(autopilot): honor release.require_ci on polled merge paths

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1499,6 +1499,19 @@
         "summary": "Extraction-era SDK ports go stale vs evolving in-tree code: SDK GetTagForSHA shipped bounded (20 tags) while in-tree moved to exhaustive pagination \u2014 would have stalled release draining. Caught by running the consumer test suite against the SDK client (TestHandleReleasing_ExhaustiveTagDrain). Before cutover: diff SDK methods against CURRENT in-tree source; typed-error/pagination/retry drift compiles fine and fails only behaviorally.",
         "type": "pitfall",
         "file": ".agent/knowledge/memories/pitfalls/pitfall_sdk_ports_go_stale_vs_intree.md"
+      },
+      "mem-089": {
+        "type": "decision",
+        "summary": "GH-3994 subtask 2: decided to honor require_ci uniformly by routing checkExternalMergeOrClose (GH-411 hijack) and ScanRecentlyMergedPRs (scan-recovery) through StagePostMergeCI when require_ci=true, instead of short-circuiting to StageReleasing. Rejected deprecating require_ci and rejected documenting it as webhook-path-only \u2014 both leave the release-before-CI gap live on the majority-case merge paths (external merge, restart scan-recovery). handlePostMergeCI already has the CI-poll -> StageReleasing state machine; the fix reuses it rather than duplicating CI-check logic inline.",
+        "concepts": [
+          "autopilot",
+          "release",
+          "ci"
+        ],
+        "confidence": 0.9,
+        "created": "2026-07-07",
+        "file": ".agent/knowledge/memories/decisions/decision_require_ci_polled_merge_paths.md",
+        "origin_task": "GH-3994-2"
       }
     }
   },
@@ -2411,10 +2424,10 @@
       "TASK-368"
     ]
   },
-  "last_updated": "2026-07-06T12:16:33.258633+00:00",
+  "last_updated": "2026-07-07T22:50:00+00:00",
   "stats": {
-    "total_nodes": 135,
+    "total_nodes": 136,
     "total_edges": 167,
-    "memory_count": 86
+    "memory_count": 87
   }
 }

--- a/.agent/knowledge/memories/decisions/decision_require_ci_polled_merge_paths.md
+++ b/.agent/knowledge/memories/decisions/decision_require_ci_polled_merge_paths.md
@@ -70,3 +70,15 @@ fix — they must be updated in lockstep, not left passing against dead code.
 
 Related: [[pitfall_release_before_ci_polled_merge_paths]] (if filed),
 `.agent/tasks/archive/gh-3994-1.md`, `.agent/tasks/gh-3994-2.md`.
+
+**Shipped (GH-3994 subtask 5, 2026-07-07):** both sites now gate on
+`c.resolvedRelease().RequireCI` exactly as specified above —
+`checkExternalMergeOrClose` (controller.go, GH-411 block) and
+`ScanRecentlyMergedPRs` (controller.go, scan-recovery block) route to
+`StagePostMergeCI` with `PostMergeSHA` seeded from the already-known merge
+commit SHA when `true`, and keep the direct `StageReleasing` short-circuit
+(scan path's `CIStatus: CISuccess` included) when `false`. Subtask 1's repro
+tests (`internal/autopilot/controller_require_ci_repro_test.go`) were
+rewritten in lockstep to pin the fixed behavior instead of the bug; subtask
+3's `require_ci: false` regression test
+(`controller_gh411_release_trigger_pin_test.go`) passes unmodified.

--- a/.agent/knowledge/memories/decisions/decision_require_ci_polled_merge_paths.md
+++ b/.agent/knowledge/memories/decisions/decision_require_ci_polled_merge_paths.md
@@ -1,0 +1,72 @@
+---
+name: honor require_ci uniformly — route the GH-411 hijack and scan-recovery through StagePostMergeCI, do not deprecate or scope the flag to webhook-only
+description: GH-3994 subtask 2 decision — of the three options (a) honor require_ci at checkExternalMergeOrClose/ScanRecentlyMergedPRs by routing to StagePostMergeCI, (b) deprecate require_ci, (c) document it as webhook-path-only — (a) was chosen. (b)/(c) both leave the release-before-CI gap live on the most common real-world merge paths.
+type: decision
+---
+
+Decided 2026-07-07 (GH-3994 subtask 2), following subtask 1's reproduction
+(`internal/autopilot/controller_require_ci_repro_test.go`, commit 469e988b)
+which pinned the bug: with `release.require_ci: true`, both
+`checkExternalMergeOrClose` (GH-411 external-merge hijack, controller.go
+~4156-4228) and `ScanRecentlyMergedPRs` (scan-recovery, controller.go
+~3621-3860) set `prState.Stage = StageReleasing` directly and never call
+`CheckCI(mainSHA)`. Only `handleMerged`'s `SkipPostMergeCI` fast path
+(controller.go:1931-1951) actually reads `RequireCI`.
+
+**Decision: option (a) — honor `require_ci` at both sites by routing to
+`StagePostMergeCI` instead of short-circuiting to `StageReleasing`.**
+
+**Why not (b) deprecate `require_ci`:** it's a documented, currently
+load-bearing release safety gate (`RequireCI bool // waits for post-merge CI
+before releasing`, types.go:369-370) that some configs rely on today.
+Deprecating it doesn't fix the actual defect (release firing before CI on
+main finishes) — it just removes the promise instead of keeping it. Bigger,
+unrelated blast radius for zero correctness gain.
+
+**Why not (c) document as webhook-path-only:** this launders a correctness
+gap into a "known limitation" instead of fixing it, and it contradicts the
+field's own unqualified doc comment. It would also leave the flag protecting
+only the *minority* merge path — the GH-411 external-merge hijack and
+scan-recovery-after-restart are the common real-world triggers (a human
+merging via the GitHub UI, or the daemon restarting mid-flight), not an edge
+case. A user who sets `require_ci: true` and reads the field name has no way
+to discover it silently doesn't apply to how most of their PRs actually get
+merged.
+
+**Why (a) is the correct fix, and cheap:** `SkipPostMergeCI`'s own fast path
+already conditions release on `!c.resolvedRelease().RequireCI`
+(controller.go:1933) — proving `RequireCI` was always meant as a universal
+precondition on release, not a per-merge-path opt-in. The state machine to
+honor it already exists and is exercised daily: `handlePostMergeCI`
+(controller.go:2184-2288) captures `PostMergeSHA`, starts the CI timer,
+polls `CheckCI`, and transitions to `StageReleasing` on success (or
+fails/holds/removes on timeout/failure) — exactly the behavior both bug
+sites need. Fixing this is "route into the existing stage" rather than
+"invent new CI-polling logic," which is why the parent task title already
+names the destination (`StagePostMergeCI`).
+
+**Concrete shape for the follow-up implementation subtasks:** at both
+`checkExternalMergeOrClose` (~4201, where it currently sets
+`prState.Stage = StageReleasing` after `ghPR.MergeCommitSHA` is copied to
+`prState.HeadSHA`) and `ScanRecentlyMergedPRs` (~3849, the `PRState{...
+Stage: StageReleasing, CIStatus: CISuccess ...}` literal), gate on
+`c.releaseConfigured() && c.resolvedRelease().RequireCI`:
+- `true` → set `Stage: StagePostMergeCI` (leave `PostMergeSHA` unset so
+  `handlePostMergeCI`'s existing first-tick capture runs, or seed it
+  directly from the already-known merge commit SHA — equivalent, since
+  scan-recovery/external-merge already have it in hand) and drop the
+  hardcoded `CIStatus: CISuccess` in the scan path (it's currently a lie
+  when CI hasn't been checked).
+- `false` (today's default-preserving path) → unchanged, direct
+  `StageReleasing` — this is the behavior subtask 4's regression test
+  pins (`require_ci: false` externally-merged PR still releases at
+  `MergeCommitSHA`, no behavior change).
+
+Subtask 1's repro tests
+(`TestCheckExternalMergeOrClose_RequireCITrue_ReleasesWithoutCICheck_GH3994`,
+`TestScanRecentlyMergedPRs_RequireCITrue_ReleasesWithoutCICheck_GH3994`) are
+expected to flip from pinning-the-bug to failing once subtask 5 lands the
+fix — they must be updated in lockstep, not left passing against dead code.
+
+Related: [[pitfall_release_before_ci_polled_merge_paths]] (if filed),
+`.agent/tasks/archive/gh-3994-1.md`, `.agent/tasks/gh-3994-2.md`.

--- a/.agent/tasks/archive/gh-3994-2.md
+++ b/.agent/tasks/archive/gh-3994-2.md
@@ -1,0 +1,33 @@
+# GH-3994-2
+
+**Created:** 2026-07-07
+
+## Problem
+
+## Subtask 2 of 5
+
+**Parent Task:** GH-3994 - fix(autopilot): honor release.require_ci on the polled merge path — route GH-411 hijack + scan-recovery through StagePostMergeCI
+
+## Objective
+
+Decide: honor require_ci at the hijack (route to StagePostMergeCI) vs deprecate require_ci vs document as webhook-path-only.
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+## Decision
+
+**Chosen: honor `require_ci` at both hijack sites by routing to `StagePostMergeCI`** (option a), not deprecating the flag (b) nor documenting it as webhook-path-only (c).
+
+Full rationale and the concrete implementation shape for subtasks 4/5: `.agent/knowledge/memories/decisions/decision_require_ci_polled_merge_paths.md` (graph node `mem-089`).
+
+Summary: `RequireCI`'s own doc comment ("waits for post-merge CI before releasing", types.go:369-370) is unqualified — it doesn't say "except when merged externally or recovered via scan." `SkipPostMergeCI`'s fast path already gates release on `!RequireCI` (controller.go:1933), proving the flag is meant as a universal release precondition. The external-merge hijack (`checkExternalMergeOrClose`, controller.go ~4156-4228) and scan-recovery (`ScanRecentlyMergedPRs`, controller.go ~3621-3860) are the *majority* real-world merge-detection paths (human merges via GitHub UI, daemon-restart recovery) — silently skipping the CI gate on exactly those paths defeats the feature for most users who set it. `handlePostMergeCI` (controller.go:2184-2288) already implements the CI-poll -> `StageReleasing` state machine (timeout/failure/success handling included); the fix is to route into that existing stage rather than invent new inline CI-check logic — cheap, and matches the parent task's own title.
+
+## Acceptance Criteria
+
+- [x] Three options weighed against `RequireCI`'s existing contract and the `SkipPostMergeCI` precedent.
+- [x] Decision recorded with rationale in Navigator memory (`.agent/knowledge/memories/decisions/decision_require_ci_polled_merge_paths.md`, graph `mem-089`).
+- [x] Concrete gating shape for subtasks 4/5 specified (gate on `c.releaseConfigured() && c.resolvedRelease().RequireCI`; `true` -> `StagePostMergeCI`, `false` -> unchanged `StageReleasing`).
+

--- a/.agent/tasks/archive/gh-3994-3.md
+++ b/.agent/tasks/archive/gh-3994-3.md
@@ -1,0 +1,33 @@
+# GH-3994-3
+
+**Created:** 2026-07-07
+
+## Problem
+
+## Subtask 3 of 5
+
+**Parent Task:** GH-3994 - fix(autopilot): honor release.require_ci on the polled merge path — route GH-411 hijack + scan-recovery through StagePostMergeCI
+
+## Objective
+
+Whatever the fix: pin the current GH-411 external-merge release trigger semantics with a regression test first.
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+## Result
+
+Added `TestCheckExternalMergeOrClose_RequireCIFalse_ReleasesImmediately_PinsCurrentSemantics_GH3994`
+(`internal/autopilot/controller_gh411_release_trigger_pin_test.go`), pinning
+the `require_ci: false` (default-preserving) branch of `checkExternalMergeOrClose`'s
+GH-411 release trigger: immediate `StageReleasing`, `HeadSHA` updated to the
+merge commit SHA, zero `CheckCI`/check-runs calls, PR handed off (not drained)
+to the release path.
+
+Unlike subtask 1's `TestCheckExternalMergeOrClose_RequireCITrue_ReleasesWithoutCICheck_GH3994`
+(`controller_require_ci_repro_test.go`), which pins the bug and is *expected*
+to flip once subtasks 4/5 land the `require_ci: true` fix, this test must
+keep passing unmodified through that fix — it's the safety net proving the
+fix doesn't regress the majority `require_ci: false` case.

--- a/.agent/tasks/archive/gh-3994-4.md
+++ b/.agent/tasks/archive/gh-3994-4.md
@@ -1,0 +1,52 @@
+# GH-3994-4
+
+**Created:** 2026-07-07
+
+## Problem
+
+## Subtask 4 of 5
+
+**Parent Task:** GH-3994 - fix(autopilot): honor release.require_ci on the polled merge path — route GH-411 hijack + scan-recovery through StagePostMergeCI
+
+## Objective
+
+**Regression test FIRST** pinning current GH-411 external-merge semantics with `require_ci: false`: externally merged PR + `shouldTriggerRelease()` → `StageReleasing` at `MergeCommitSHA` (behavior preserved).
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+## Result
+
+**NO-OP — duplicate of subtask 3.** This objective ("Regression test FIRST
+pinning current GH-411 external-merge semantics with `require_ci: false`:
+externally merged PR → `StageReleasing` at `MergeCommitSHA`, behavior
+preserved") is byte-for-byte the same claim as subtask 3's objective
+("pin the current GH-411 external-merge release trigger semantics with a
+regression test first").
+
+Subtask 3 already shipped this exact test in commit `3feb9423`:
+`TestCheckExternalMergeOrClose_RequireCIFalse_ReleasesImmediately_PinsCurrentSemantics_GH3994`
+(`internal/autopilot/controller_gh411_release_trigger_pin_test.go`). It
+asserts, against `checkExternalMergeOrClose` with `require_ci: false`:
+
+- `resolved == false` (hands off to the release path, doesn't drain)
+- `prState.Stage == StageReleasing`
+- `prState.HeadSHA == ghPR.MergeCommitSHA`
+- zero `check-runs` (CheckCI) calls
+
+Re-ran it (`go test ./internal/autopilot/... -run
+TestCheckExternalMergeOrClose_RequireCIFalse_ReleasesImmediately_PinsCurrentSemantics_GH3994
+-v`): PASS. No code or test change made here — see subtask 3's archived
+doc (`.agent/tasks/archive/gh-3994-3.md`) and commit `3feb9423` for the
+implementation.
+
+NO-OP RATIONALE: internal/autopilot/controller_gh411_release_trigger_pin_test.go:32
+the regression test this subtask asks for already exists (committed under
+subtask 3) and passes; writing a second, near-identical test would only
+duplicate coverage of the same `checkExternalMergeOrClose` require_ci:false
+branch.
+
+## Acceptance Criteria
+

--- a/.agent/tasks/archive/gh-3994-5.md
+++ b/.agent/tasks/archive/gh-3994-5.md
@@ -1,0 +1,63 @@
+# GH-3994-5
+
+**Created:** 2026-07-07
+
+## Problem
+
+## Subtask 5 of 5
+
+**Parent Task:** GH-3994 - fix(autopilot): honor release.require_ci on the polled merge path — route GH-411 hijack + scan-recovery through StagePostMergeCI
+
+## Objective
+
+**`checkExternalMergeOrClose`** (controller.go, GH-411 block ~:3376): when `shouldTriggerRelease()` and PR is merged:
+
+## Context
+
+This is part of a larger task that has been decomposed for better execution.
+Focus on this specific objective. Other subtasks will handle the remaining work.
+
+**Note:** This is the final subtask. Ensure all previous subtasks are complete before finishing.
+
+## Result
+
+Implemented subtask 2's decision (`.agent/knowledge/memories/decisions/decision_require_ci_polled_merge_paths.md`,
+graph `mem-089`) at both polled-merge sites in `internal/autopilot/controller.go`:
+
+- **`checkExternalMergeOrClose`** (GH-411 external-merge hijack, ~4201): when
+  `action == releaseActionRelease` and `c.resolvedRelease().RequireCI` is
+  true, set `prState.PostMergeSHA = ghPR.MergeCommitSHA` and
+  `prState.Stage = StagePostMergeCI` instead of `StageReleasing`. When false
+  (default), behavior is unchanged — direct `StageReleasing`.
+- **`ScanRecentlyMergedPRs`** (scan-recovery, ~3843): same gate on
+  `releaseEnabled && rel.RequireCI`. When true, the constructed `PRState`
+  gets `Stage: StagePostMergeCI`, `PostMergeSHA` seeded from
+  `pr.MergeCommitSHA`, and `CIStatus` left empty instead of the previously
+  hardcoded `CISuccess` (which was a lie — CI was never actually checked).
+  When false, behavior is unchanged.
+
+Both routes land in the existing `handlePostMergeCI` state machine
+(controller.go:2184), which polls `CheckCI(mainSHA)` and only transitions to
+`StageReleasing` on `CISuccess` — no new CI-polling logic was written.
+
+Updated subtask 1's repro tests
+(`internal/autopilot/controller_require_ci_repro_test.go`) in lockstep, per
+the decision doc's explicit requirement: they now pin the FIXED behavior
+(`StagePostMergeCI` + `PostMergeSHA` seeded + a subsequent tick actually
+calls `CheckCI`) instead of the bug. Subtask 3's `require_ci: false`
+regression test (`controller_gh411_release_trigger_pin_test.go`) required no
+changes and still passes — proving the fix doesn't regress the majority
+default-preserving path.
+
+Verified: `go build ./...` clean, `go vet ./internal/autopilot/...` clean,
+`golangci-lint run --new-from-rev=origin/main ./internal/autopilot/...` 0
+issues, `go test ./internal/autopilot/...` full package PASS.
+
+## Acceptance Criteria
+
+- [x] `checkExternalMergeOrClose` honors `RequireCI` by routing to `StagePostMergeCI` (was: unconditional `StageReleasing`).
+- [x] `ScanRecentlyMergedPRs` honors `RequireCI` by routing to `StagePostMergeCI` and dropping the hardcoded `CIStatus: CISuccess` lie.
+- [x] `require_ci: false` behavior unchanged (subtask 3's pin test passes unmodified).
+- [x] Subtask 1's repro tests updated in lockstep to pin the fixed behavior.
+- [x] Build, vet, lint, and full `internal/autopilot` test suite pass.
+

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3839,15 +3839,27 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			continue
 		}
 
-		// Create PR state and trigger release
+		// Create PR state and trigger release. GH-3994: honor require_ci on the
+		// scan-recovery path too — route through the existing post-merge CI
+		// poll/gate instead of hardcoding CIStatus: CISuccess (a lie when CI was
+		// never actually checked) and short-circuiting straight to StageReleasing.
+		stage := StageReleasing
+		ciStatus := CISuccess // Assume CI passed if merged, unless require_ci gates it below
+		postMergeSHA := ""
+		if releaseEnabled && rel.RequireCI {
+			stage = StagePostMergeCI
+			ciStatus = ""
+			postMergeSHA = pr.MergeCommitSHA
+		}
 		prState := &PRState{
 			PRNumber:        pr.Number,
 			PRURL:           pr.HTMLURL,
 			IssueNumber:     issueNum,
 			BranchName:      pr.Head.Ref,
 			HeadSHA:         pr.MergeCommitSHA,
-			Stage:           StageReleasing,
-			CIStatus:        CISuccess, // Assume CI passed if merged
+			Stage:           stage,
+			CIStatus:        ciStatus,
+			PostMergeSHA:    postMergeSHA,
 			CreatedAt:       time.Now(),
 			EnvironmentName: c.config.EnvironmentName(),
 			PRTitle:         pr.Title,
@@ -4206,7 +4218,17 @@ func (c *Controller) checkExternalMergeOrClose(ctx context.Context, prState *PRS
 				if ghPR.MergeCommitSHA != "" {
 					prState.HeadSHA = ghPR.MergeCommitSHA
 				}
-				prState.Stage = StageReleasing
+				// GH-3994: honor require_ci on the external-merge hijack path —
+				// route through the existing post-merge CI poll/gate instead of
+				// short-circuiting straight to StageReleasing. The merge commit
+				// SHA is already known, so seed PostMergeSHA directly rather than
+				// letting handlePostMergeCI's first-tick GetBranch lookup re-derive it.
+				if c.resolvedRelease().RequireCI {
+					prState.PostMergeSHA = ghPR.MergeCommitSHA
+					prState.Stage = StagePostMergeCI
+				} else {
+					prState.Stage = StageReleasing
+				}
 				c.persistPRState(prState)
 				return false // Continue processing to handle release
 			}

--- a/internal/autopilot/controller_gh411_release_trigger_pin_test.go
+++ b/internal/autopilot/controller_gh411_release_trigger_pin_test.go
@@ -1,0 +1,92 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-3994 subtask 3: pins the CURRENT GH-411 external-merge release trigger
+// semantics for the require_ci: false (default-preserving) path, independent
+// of whatever shape the require_ci: true fix (subtasks 4/5) ends up taking.
+//
+// checkExternalMergeOrClose's release branch must keep doing exactly this
+// when require_ci is false/unset:
+//   - update prState.HeadSHA to the GitHub-reported merge commit SHA
+//   - set prState.Stage = StageReleasing directly (no CI poll)
+//   - report resolved=false (hand off to the release path, PR stays tracked)
+//   - never call CheckCI/check-runs
+//
+// Unlike TestCheckExternalMergeOrClose_RequireCITrue_ReleasesWithoutCICheck_GH3994
+// (controller_require_ci_repro_test.go), which pins the BUG and is expected to
+// start failing once the require_ci: true fix lands, THIS test must keep
+// passing unmodified through that fix — it is the safety net proving the fix
+// didn't regress the require_ci: false majority case.
+func TestCheckExternalMergeOrClose_RequireCIFalse_ReleasesImmediately_PinsCurrentSemantics_GH3994(t *testing.T) {
+	var checkRunsCalls int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/check-runs") {
+			atomic.AddInt64(&checkRunsCalls, 1)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", RequireCI: false, TagPrefix: "v"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber: 42,
+		PRURL:    "https://github.com/owner/repo/pull/42",
+		HeadSHA:  "abc123",
+		Stage:    StageMerging,
+	}
+	c.mu.Lock()
+	c.activePRs[42] = prState
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{
+		Number:         42,
+		State:          "closed",
+		Merged:         true,
+		HTMLURL:        "https://github.com/owner/repo/pull/42",
+		MergeCommitSHA: "merge-sha-42",
+	}
+
+	prState.mu.Lock()
+	resolved := c.checkExternalMergeOrClose(context.Background(), prState, ghPR)
+	prState.mu.Unlock()
+
+	if resolved {
+		t.Fatal("checkExternalMergeOrClose reported the PR as fully resolved/drained; expected it to hand off to the release path (resolved=false)")
+	}
+
+	if prState.Stage != StageReleasing {
+		t.Fatalf("REGRESSION: prState.Stage = %v, want StageReleasing (require_ci: false must keep releasing immediately on external merge)", prState.Stage)
+	}
+
+	if prState.HeadSHA != "merge-sha-42" {
+		t.Fatalf("REGRESSION: prState.HeadSHA = %q, want the merge commit SHA %q", prState.HeadSHA, "merge-sha-42")
+	}
+
+	if got := atomic.LoadInt64(&checkRunsCalls); got != 0 {
+		t.Errorf("REGRESSION: check-runs (CheckCI) was called %d time(s); require_ci: false must never poll CI on this path", got)
+	}
+
+	if _, ok := c.GetPRState(42); !ok {
+		t.Fatal("REGRESSION: PR 42 should remain tracked in activePRs, handed off to the release path")
+	}
+}

--- a/internal/autopilot/controller_require_ci_repro_test.go
+++ b/internal/autopilot/controller_require_ci_repro_test.go
@@ -14,24 +14,26 @@ import (
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
-// GH-3994 subtask 1: reproduction tests pinning the CURRENT (buggy) behavior —
-// with release.require_ci: true configured, both polled-merge detection paths
-// (the GH-411 external-merge hijack in checkExternalMergeOrClose and the
-// scan-recovery path in ScanRecentlyMergedPRs) set StageReleasing directly
-// without ever calling CheckCI(mainSHA) or routing through StagePostMergeCI.
-// RequireCI is only consulted by handleMerged's SkipPostMergeCI fast path
-// (controller.go ~line 1933) — these two sites never read it.
+// GH-3994 subtask 1 originally pinned the bug: with release.require_ci: true,
+// both polled-merge detection paths (the GH-411 external-merge hijack in
+// checkExternalMergeOrClose and the scan-recovery path in
+// ScanRecentlyMergedPRs) set StageReleasing directly without ever calling
+// CheckCI(mainSHA) or routing through StagePostMergeCI. RequireCI was only
+// consulted by handleMerged's SkipPostMergeCI fast path (controller.go
+// ~line 1933) — these two sites never read it.
 //
-// These tests are expected to keep PASSING until a later GH-3994 subtask
-// fixes checkExternalMergeOrClose/ScanRecentlyMergedPRs to honor require_ci;
-// at that point they document behavior that must change and should be
-// updated alongside the fix.
+// GH-3994 subtask 5 fixed both sites to route through StagePostMergeCI when
+// require_ci: true, per the decision in
+// .agent/knowledge/memories/decisions/decision_require_ci_polled_merge_paths.md.
+// These tests now pin the FIXED behavior in lockstep with that change.
 
-// TestCheckExternalMergeOrClose_RequireCITrue_ReleasesWithoutCICheck_GH3994
-// reproduces the GH-411 hijack bug: an externally merged PR with
-// require_ci: true still jumps straight to StageReleasing with zero
-// CheckCI/check-runs calls.
-func TestCheckExternalMergeOrClose_RequireCITrue_ReleasesWithoutCICheck_GH3994(t *testing.T) {
+// TestCheckExternalMergeOrClose_RequireCITrue_RoutesThroughPostMergeCI_GH3994
+// verifies the GH-411 hijack fix: an externally merged PR with
+// require_ci: true is routed to StagePostMergeCI (with PostMergeSHA seeded
+// from the already-known merge commit SHA) instead of jumping straight to
+// StageReleasing, and a subsequent tick actually polls CheckCI before any
+// release decision is made.
+func TestCheckExternalMergeOrClose_RequireCITrue_RoutesThroughPostMergeCI_GH3994(t *testing.T) {
 	var checkRunsCalls int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/check-runs") {
@@ -72,26 +74,47 @@ func TestCheckExternalMergeOrClose_RequireCITrue_ReleasesWithoutCICheck_GH3994(t
 	resolved := c.checkExternalMergeOrClose(context.Background(), prState, ghPR)
 	prState.mu.Unlock()
 
-	// checkExternalMergeOrClose returns false ("continue processing") when it
-	// triggers a release, rather than draining the PR immediately.
+	// checkExternalMergeOrClose still returns false ("continue processing")
+	// when it triggers a release, rather than draining the PR immediately.
 	if resolved {
 		t.Fatal("checkExternalMergeOrClose reported the PR as fully resolved/drained; expected it to hand off to the release path (resolved=false)")
 	}
 
-	if prState.Stage != StageReleasing {
-		t.Fatalf("BUG NOT REPRODUCED: prState.Stage = %v, want StageReleasing (GH-3994 expects the current buggy short-circuit)", prState.Stage)
+	if prState.Stage != StagePostMergeCI {
+		t.Fatalf("FIX NOT APPLIED: prState.Stage = %v, want StagePostMergeCI (require_ci: true must route the external-merge hijack through the post-merge CI gate)", prState.Stage)
+	}
+
+	if prState.PostMergeSHA != "merge-sha-42" {
+		t.Fatalf("FIX NOT APPLIED: prState.PostMergeSHA = %q, want the merge commit SHA %q seeded directly", prState.PostMergeSHA, "merge-sha-42")
 	}
 
 	if got := atomic.LoadInt64(&checkRunsCalls); got != 0 {
-		t.Errorf("BUG NOT REPRODUCED: check-runs (CheckCI) was called %d time(s); GH-3994 bug is that require_ci=true is never consulted on this path, so CheckCI must be called 0 times", got)
+		t.Errorf("checkExternalMergeOrClose itself must not call CheckCI synchronously; got %d call(s) — CI polling belongs to the subsequent StagePostMergeCI tick", got)
+	}
+
+	// Drive one StagePostMergeCI tick and confirm CI is now actually polled
+	// before any release decision — this is the behavior that was missing.
+	prState.mu.Lock()
+	err := c.handlePostMergeCI(context.Background(), prState)
+	prState.mu.Unlock()
+	if err != nil {
+		t.Fatalf("handlePostMergeCI() error = %v", err)
+	}
+
+	if got := atomic.LoadInt64(&checkRunsCalls); got != 1 {
+		t.Errorf("FIX NOT APPLIED: check-runs (CheckCI) was called %d time(s) after the StagePostMergeCI tick; want 1 — require_ci: true must poll CI before releasing", got)
+	}
+
+	if prState.Stage == StageReleasing {
+		t.Fatal("FIX NOT APPLIED: prState.Stage reached StageReleasing after a single tick with no resolved CI checks; must wait for CheckCI to report success")
 	}
 }
 
-// TestScanRecentlyMergedPRs_RequireCITrue_ReleasesWithoutCICheck_GH3994
-// reproduces the scan-recovery bug: ScanRecentlyMergedPRs registers a merged
-// PR directly at StageReleasing (with a hardcoded CIStatus: CISuccess) even
-// when require_ci: true is configured, without ever calling CheckCI.
-func TestScanRecentlyMergedPRs_RequireCITrue_ReleasesWithoutCICheck_GH3994(t *testing.T) {
+// TestScanRecentlyMergedPRs_RequireCITrue_RoutesThroughPostMergeCI_GH3994
+// verifies the scan-recovery fix: ScanRecentlyMergedPRs registers a merged
+// PR at StagePostMergeCI (not StageReleasing, and without the previously
+// hardcoded CIStatus: CISuccess lie) when require_ci: true is configured.
+func TestScanRecentlyMergedPRs_RequireCITrue_RoutesThroughPostMergeCI_GH3994(t *testing.T) {
 	recentMergedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
 
 	var checkRunsCalls int64
@@ -148,14 +171,17 @@ func TestScanRecentlyMergedPRs_RequireCITrue_ReleasesWithoutCICheck_GH3994(t *te
 		t.Fatal("PR 42 should be registered in activePRs")
 	}
 
-	if pr.Stage != StageReleasing {
-		t.Fatalf("BUG NOT REPRODUCED: PR 42 stage = %v, want StageReleasing (GH-3994 expects the current buggy short-circuit)", pr.Stage)
+	if pr.Stage != StagePostMergeCI {
+		t.Fatalf("FIX NOT APPLIED: PR 42 stage = %v, want StagePostMergeCI (require_ci: true must route scan-recovery through the post-merge CI gate)", pr.Stage)
 	}
-	if pr.CIStatus != CISuccess {
-		t.Errorf("BUG NOT REPRODUCED: PR 42 CIStatus = %v, want CISuccess hardcoded by the scan-recovery path without ever checking CI", pr.CIStatus)
+	if pr.CIStatus == CISuccess {
+		t.Error("FIX NOT APPLIED: PR 42 CIStatus = CISuccess hardcoded without ever checking CI; require_ci: true must not lie about CI status")
+	}
+	if pr.PostMergeSHA != "merge-sha-42" {
+		t.Fatalf("FIX NOT APPLIED: PR 42 PostMergeSHA = %q, want the merge commit SHA %q seeded directly", pr.PostMergeSHA, "merge-sha-42")
 	}
 
 	if got := atomic.LoadInt64(&checkRunsCalls); got != 0 {
-		t.Errorf("BUG NOT REPRODUCED: check-runs (CheckCI) was called %d time(s); GH-3994 bug is that require_ci=true is never consulted on this path, so CheckCI must be called 0 times", got)
+		t.Errorf("ScanRecentlyMergedPRs itself must not call CheckCI synchronously; got %d call(s) — CI polling belongs to the subsequent StagePostMergeCI tick", got)
 	}
 }

--- a/internal/autopilot/controller_require_ci_repro_test.go
+++ b/internal/autopilot/controller_require_ci_repro_test.go
@@ -1,0 +1,161 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-3994 subtask 1: reproduction tests pinning the CURRENT (buggy) behavior —
+// with release.require_ci: true configured, both polled-merge detection paths
+// (the GH-411 external-merge hijack in checkExternalMergeOrClose and the
+// scan-recovery path in ScanRecentlyMergedPRs) set StageReleasing directly
+// without ever calling CheckCI(mainSHA) or routing through StagePostMergeCI.
+// RequireCI is only consulted by handleMerged's SkipPostMergeCI fast path
+// (controller.go ~line 1933) — these two sites never read it.
+//
+// These tests are expected to keep PASSING until a later GH-3994 subtask
+// fixes checkExternalMergeOrClose/ScanRecentlyMergedPRs to honor require_ci;
+// at that point they document behavior that must change and should be
+// updated alongside the fix.
+
+// TestCheckExternalMergeOrClose_RequireCITrue_ReleasesWithoutCICheck_GH3994
+// reproduces the GH-411 hijack bug: an externally merged PR with
+// require_ci: true still jumps straight to StageReleasing with zero
+// CheckCI/check-runs calls.
+func TestCheckExternalMergeOrClose_RequireCITrue_ReleasesWithoutCICheck_GH3994(t *testing.T) {
+	var checkRunsCalls int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/check-runs") {
+			atomic.AddInt64(&checkRunsCalls, 1)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.CIPollInterval = 10 * time.Millisecond
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", RequireCI: true, TagPrefix: "v"}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber: 42,
+		PRURL:    "https://github.com/owner/repo/pull/42",
+		HeadSHA:  "abc123",
+		Stage:    StageMerging,
+	}
+	c.mu.Lock()
+	c.activePRs[42] = prState
+	c.mu.Unlock()
+
+	ghPR := &github.PullRequest{
+		Number:         42,
+		State:          "closed",
+		Merged:         true,
+		HTMLURL:        "https://github.com/owner/repo/pull/42",
+		MergeCommitSHA: "merge-sha-42",
+	}
+
+	prState.mu.Lock()
+	resolved := c.checkExternalMergeOrClose(context.Background(), prState, ghPR)
+	prState.mu.Unlock()
+
+	// checkExternalMergeOrClose returns false ("continue processing") when it
+	// triggers a release, rather than draining the PR immediately.
+	if resolved {
+		t.Fatal("checkExternalMergeOrClose reported the PR as fully resolved/drained; expected it to hand off to the release path (resolved=false)")
+	}
+
+	if prState.Stage != StageReleasing {
+		t.Fatalf("BUG NOT REPRODUCED: prState.Stage = %v, want StageReleasing (GH-3994 expects the current buggy short-circuit)", prState.Stage)
+	}
+
+	if got := atomic.LoadInt64(&checkRunsCalls); got != 0 {
+		t.Errorf("BUG NOT REPRODUCED: check-runs (CheckCI) was called %d time(s); GH-3994 bug is that require_ci=true is never consulted on this path, so CheckCI must be called 0 times", got)
+	}
+}
+
+// TestScanRecentlyMergedPRs_RequireCITrue_ReleasesWithoutCICheck_GH3994
+// reproduces the scan-recovery bug: ScanRecentlyMergedPRs registers a merged
+// PR directly at StageReleasing (with a hardcoded CIStatus: CISuccess) even
+// when require_ci: true is configured, without ever calling CheckCI.
+func TestScanRecentlyMergedPRs_RequireCITrue_ReleasesWithoutCICheck_GH3994(t *testing.T) {
+	recentMergedAt := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+
+	var checkRunsCalls int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/check-runs") {
+			atomic.AddInt64(&checkRunsCalls, 1)
+		}
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			prs := []github.PullRequest{
+				{
+					Number:         42,
+					Head:           github.PRRef{Ref: "pilot/GH-100", SHA: "sha42"},
+					Base:           github.PRRef{Ref: "main"},
+					HTMLURL:        "https://github.com/owner/repo/pull/42",
+					Title:          "feat(api): add endpoint",
+					Merged:         true,
+					MergedAt:       recentMergedAt,
+					MergeCommitSHA: "merge-sha-42",
+				},
+			}
+			out := make([]*github.PullRequest, len(prs))
+			for i := range prs {
+				out[i] = &prs[i]
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(out)
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/releases"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge", RequireCI: true, TagPrefix: "v"}
+	cfg.MergedPRScanWindow = 30 * time.Minute
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs() error = %v", err)
+	}
+
+	pr, ok := c.GetPRState(42)
+	if !ok {
+		t.Fatal("PR 42 should be registered in activePRs")
+	}
+
+	if pr.Stage != StageReleasing {
+		t.Fatalf("BUG NOT REPRODUCED: PR 42 stage = %v, want StageReleasing (GH-3994 expects the current buggy short-circuit)", pr.Stage)
+	}
+	if pr.CIStatus != CISuccess {
+		t.Errorf("BUG NOT REPRODUCED: PR 42 CIStatus = %v, want CISuccess hardcoded by the scan-recovery path without ever checking CI", pr.CIStatus)
+	}
+
+	if got := atomic.LoadInt64(&checkRunsCalls); got != 0 {
+		t.Errorf("BUG NOT REPRODUCED: check-runs (CheckCI) was called %d time(s); GH-3994 bug is that require_ci=true is never consulted on this path, so CheckCI must be called 0 times", got)
+	}
+}


### PR DESCRIPTION
## Summary
- `checkExternalMergeOrClose` (GH-411 external-merge hijack) and `ScanRecentlyMergedPRs` (scan-recovery) short-circuited straight to `StageReleasing` without ever consulting `require_ci` or calling `CheckCI` — `RequireCI` was only honored by `handleMerged`'s `SkipPostMergeCI` fast path.
- Both sites now route through the existing `StagePostMergeCI` state machine when `require_ci: true`, seeding `PostMergeSHA` from the already-known merge commit SHA; the scan path also drops its hardcoded `CIStatus: CISuccess`, which lied about CI having been checked.
- `require_ci: false` (default) behavior is unchanged.
- Decision + rationale recorded in `.agent/knowledge/memories/decisions/decision_require_ci_polled_merge_paths.md`.

Closes #3994

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/autopilot/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/autopilot/...` — 0 issues
- [x] `go test ./internal/autopilot/...` — full package PASS
- [x] Rewrote `TestCheckExternalMergeOrClose_RequireCITrue_*` and `TestScanRecentlyMergedPRs_RequireCITrue_*` to pin the fixed behavior (route to `StagePostMergeCI`, `CheckCI` actually polled)
- [x] `TestCheckExternalMergeOrClose_RequireCIFalse_ReleasesImmediately_PinsCurrentSemantics_GH3994` (require_ci: false regression pin) passes unmodified