### PR TITLE
fix(ci): index mem-089 pitfall to satisfy knowledge-graph drift gate (GH-4039)

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -1499,6 +1499,19 @@
         "summary": "Extraction-era SDK ports go stale vs evolving in-tree code: SDK GetTagForSHA shipped bounded (20 tags) while in-tree moved to exhaustive pagination \u2014 would have stalled release draining. Caught by running the consumer test suite against the SDK client (TestHandleReleasing_ExhaustiveTagDrain). Before cutover: diff SDK methods against CURRENT in-tree source; typed-error/pagination/retry drift compiles fine and fails only behaviorally.",
         "type": "pitfall",
         "file": ".agent/knowledge/memories/pitfalls/pitfall_sdk_ports_go_stale_vs_intree.md"
+      },
+      "mem-089": {
+        "type": "pitfall",
+        "summary": "Epic parent's stuck-monitor entry freezes once sub-issue execution starts \u2014 false eviction on long sequential epics. executeSubIssuesTracked posted per-child progress to GitHub via UpdateIssueProgress, which never reaches the alerts engine, so the parent's taskLastProgress entry was touched once before the loop then frozen for the whole run. GH-4021: evicted with stuck_for=41m0s while sub-issue 2 was actively running. Fixed by calling r.reportProgress(parent.ID, ...) inside the loop per child (GH-4033, merged via 51fd3348).",
+        "path": "memories/pitfalls/mem-089.md",
+        "confidence": 0.9,
+        "concepts": [
+          "alerts",
+          "executor",
+          "epic-decomposition"
+        ],
+        "created": "2026-07-07",
+        "last_validated": "2026-07-07"
       }
     }
   },

--- a/.agent/knowledge/memories/pitfalls/mem-089.md
+++ b/.agent/knowledge/memories/pitfalls/mem-089.md
@@ -1,0 +1,24 @@
+# Pitfall: Epic parent's stuck-monitor entry freezes once sub-issue execution starts — false eviction on long sequential epics
+
+## Summary
+`internal/executor/epic.go`'s `executeSubIssuesTracked` (the GH-405/412 epic sub-issue fan-out — the actual live decomposition path; `TaskDecomposer`/`decompose.go` is never wired via `SetDecomposer` in `cmd/pilot/main.go`, so it's dead code) posted per-child progress to GitHub via `UpdateIssueProgress` (a `gh issue comment` call) but never called `r.reportProgress(parent.ID, ...)` inside the loop. `UpdateIssueProgress` never reaches the alerts engine. So the parent's `taskLastProgress[parent.ID]` entry (`internal/alerts/engine.go`) was last touched once, right before the loop (`"Executing"` progress at 50%), and then frozen for the rest of the sequential run — each child executes under its *own* task ID (its GitHub issue number), so its progress never touched the parent's entry either. A long epic (several real Claude Code sub-issue runs) then had `stuck_for` measured from that single pre-loop timestamp, and the orphan-eviction sweep (4x the stuck threshold) could evict a parent whose child was still actively executing. Seen on GH-4021: queued/pre-loop-touch far enough back, evicted with `stuck_for=41m0s` while sub-issue 2 was actively running.
+
+## Context
+GH-4033 fix, merged to main via 51fd3348. Sibling of GH-4032 (`c7f8fd8a`), which fixed `execution_events` FK violations for the *other*, unwired `TaskDecomposer` subtask path — don't assume that path is live just because it has tests; check `SetDecomposer` call sites before trusting `decompose.go`.
+
+## Details
+Fixed by adding `r.reportProgress(parent.ID, "Executing", progressPct, progressMsg)` inside the `executeSubIssuesTracked` loop, right where the existing `UpdateIssueProgress` GitHub-comment call already fires per child. This refreshes `taskLastProgress[parent.ID].UpdatedAt` at each child's execution start, switching the stuck-monitor's effective reference clock from the one-time pre-loop timestamp to per-child execution activity — mirrors the pattern `runner_decompose.go`'s (dead) `executeDecomposedTask` already used correctly (`r.reportProgress(parentTask.ID, "Decomposed", progressPct, ...)` per subtask).
+
+## Recommended Approach
+When a parent task's real work happens inside a loop over children with their own task IDs, any progress channel that doesn't explicitly touch the parent's own ID (GitHub comments, webhooks, child-scoped `reportProgress`) is invisible to the alerts engine's per-task tracking. Explicitly re-touch the parent's entry at each meaningful step. Regression test: `TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution` pattern in `internal/alerts/engine_test.go` / `internal/executor/epic_test.go`.
+
+## Related
+- TASK-379
+- `internal/executor/epic.go`
+- `internal/alerts/engine.go`
+- `internal/executor/decompose.go` (dead code — verify wiring before trusting)
+
+---
+**Captured**: 2026-07-07
+**Confidence**: 90%
+**Concepts**: alerts, executor, epic-decomposition


### PR DESCRIPTION
## Summary
- Fixes the "Knowledge Graph Drift Gate" CI failure from PR #4038.
- PR #4038's branch (`pilot/GH-4033`) added `.agent/knowledge/memories/pitfalls/mem-089.md` but never indexed it in `.agent/knowledge/graph.json`, so `scripts/check-graph.py` failed with `FAIL .agent/knowledge/memories/pitfalls/mem-089.md` (unindexed active memory file). The GH-4033 code fix itself already landed on `main` via 51fd3348; only the accompanying memory file was dropped.
- Re-adds `mem-089.md` (the GH-4033 epic stuck-monitor pitfall) and its `graph.json` node.

## Test plan
- [x] `python3 scripts/check-graph.py` — exits 0, no FAIL lines
- [x] `python3 -m unittest discover -s scripts -p "*_test.py"` — 20 tests pass
- [x] `go build ./...` — clean

Depends on: #4033