### PR TITLE
fix(executor): skip decomposer for single-package epics, emit prose steps

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -373,12 +373,18 @@ func buildPlanningPrompt(task *Task) string {
 // consolidateEpicPlan merges the original task description with the planned subtasks
 // into a single description for non-decomposed execution. The executor gets the full
 // implementation plan but executes it as one unit on one branch.
+//
+// GH-4052: steps are rendered as bullet prose ("- Step N: ...") rather than a
+// line-anchored numbered list ("N. ..."). The regex TaskDecomposer (decompose.go
+// extractNumberedSteps) matches `^\d+[.)]\s+` and `^step\s+\d+[:\s]+` against the
+// task description — a numbered list here would hand it a trivially matchable
+// pattern and re-explode a task the epic planner already decided was single-scope.
 func consolidateEpicPlan(originalDesc string, subtasks []PlannedSubtask) string {
 	var sb strings.Builder
 	sb.WriteString(originalDesc)
 	sb.WriteString("\n\n## Planned Steps (execute all in sequence)\n\n")
 	for _, st := range subtasks {
-		sb.WriteString(fmt.Sprintf("%d. **%s**", st.Order, st.Title))
+		sb.WriteString(fmt.Sprintf("- Step %d: **%s**", st.Order, st.Title))
 		if st.Description != "" {
 			sb.WriteString(" — ")
 			sb.WriteString(st.Description)

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -547,18 +547,37 @@ func TestConsolidateEpicPlan(t *testing.T) {
 	if !strings.Contains(result, "Planned Steps") {
 		t.Error("should contain Planned Steps header")
 	}
-	if !strings.Contains(result, "1. **First step** — Do the first thing") {
+	if !strings.Contains(result, "- Step 1: **First step** — Do the first thing") {
 		t.Error("should contain first subtask with description")
 	}
-	if !strings.Contains(result, "2. **Second step** — Do the second thing") {
+	if !strings.Contains(result, "- Step 2: **Second step** — Do the second thing") {
 		t.Error("should contain second subtask with description")
 	}
-	if !strings.Contains(result, "3. **Third step**") {
+	if !strings.Contains(result, "- Step 3: **Third step**") {
 		t.Error("should contain third subtask")
 	}
 	// Third subtask has no description, so no " — " separator
-	if strings.Contains(result, "3. **Third step** —") {
+	if strings.Contains(result, "- Step 3: **Third step** —") {
 		t.Error("third subtask should not have separator when description is empty")
+	}
+}
+
+// TestConsolidateEpicPlan_DoesNotMatchNumberedStepsRegex is a regression guard for
+// GH-4052: consolidateEpicPlan's output must never be re-explodable by the regex
+// TaskDecomposer's extractNumberedSteps, which matches line-anchored "1. " / "1) "
+// and "Step 1:" patterns. Bullet-prefixed output ("- Step N: ...") must not match.
+func TestConsolidateEpicPlan_DoesNotMatchNumberedStepsRegex(t *testing.T) {
+	subtasks := []PlannedSubtask{
+		{Title: "First step", Description: "Do the first thing", Order: 1},
+		{Title: "Second step", Description: "Do the second thing", Order: 2},
+		{Title: "Third step", Description: "Do the third thing", Order: 3},
+	}
+
+	result := consolidateEpicPlan("Original description", subtasks)
+
+	steps := extractNumberedSteps(result)
+	if len(steps) != 0 {
+		t.Errorf("extractNumberedSteps() on consolidateEpicPlan output = %v, want empty (bullet output must not be regex-decomposable)", steps)
 	}
 }
 

--- a/internal/executor/gh4052_test.go
+++ b/internal/executor/gh4052_test.go
@@ -1,0 +1,98 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// gh4052SinglePackagePlan returns two subtasks whose descriptions both cite
+// files under internal/executor/, so isSinglePackageScope consolidates them
+// into a single task instead of creating separate GitHub issues.
+func gh4052SinglePackagePlan(task *Task) *EpicPlan {
+	return &EpicPlan{
+		ParentTask: task,
+		Subtasks: []PlannedSubtask{
+			{Order: 1, Title: "fix(executor): update epic.go", Description: "Edit internal/executor/epic.go"},
+			{Order: 2, Title: "fix(executor): update runner.go", Description: "Edit internal/executor/runner.go"},
+		},
+	}
+}
+
+// TestExecute_SinglePackageEpic_NumberedListDescription_SkipsDecomposition is a
+// regression test for GH-4052: an epic task the planner classifies as
+// single-package scope must run as ONE unit of work, even though its original
+// description (mirroring the GH-3994 require_ci issue body) contains numbered
+// lists that the regex TaskDecomposer would otherwise explode into up to
+// MaxSubtasks subtasks.
+func TestExecute_SinglePackageEpic_NumberedListDescription_SkipsDecomposition(t *testing.T) {
+	dir := setupPRGuardRepo(t, "pilot/GH-4052-decompose-guard", true)
+
+	backend := &mockFixedBackend{
+		result: &BackendResult{Success: true, Output: "done", Model: "claude"},
+	}
+
+	var buf bytes.Buffer
+	runner := NewRunnerWithBackend(backend)
+	runner.log = slog.New(slog.NewTextHandler(&buf, nil))
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	// Decomposition enabled with real regex-based decomposer — if the GH-4052
+	// gate is missing, this decomposer WILL match the numbered lists below.
+	runner.EnableDecomposition(nil)
+
+	task := &Task{
+		ID:    "GH-4052-TEST",
+		Title: "[epic] fix(executor): honor require_ci on polled merge path",
+		Description: "## Suggested investigation scope\n\n" +
+			"1. Check the epic planner's single-package guard\n" +
+			"2. Check the regex decomposer's numbered-list matcher\n" +
+			"3. Check the Decompose() call site in runner.go\n\n" +
+			"## Implementation spec\n\n" +
+			"1. Fix epic.go consolidateEpicPlan\n" +
+			"2. Fix runner.go call site\n" +
+			"3. Add regression tests\n" +
+			"4. Run go build\n" +
+			"5. Run go test\n" +
+			"6. Commit changes",
+		ProjectPath: dir,
+		Branch:      "pilot/GH-4052-decompose-guard",
+		CreatePR:    false,
+	}
+	runner.planEpicFn = func(_ context.Context, tsk *Task, _ string) (*EpicPlan, error) {
+		return gh4052SinglePackagePlan(tsk), nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Execute() not successful: %s", result.Error)
+	}
+	if result.IsEpic {
+		t.Error("single-package epic should fall through to direct execution, not report IsEpic=true")
+	}
+
+	backend.mu.Lock()
+	execCount := backend.execCount
+	backend.mu.Unlock()
+	if execCount != 1 {
+		t.Errorf("backend.execCount = %d, want 1 (task must run as a single unit, not be decomposed)", execCount)
+	}
+
+	logOutput := buf.String()
+	if strings.Contains(logOutput, "Task decomposed") {
+		t.Errorf("expected no 'Task decomposed' log line for single-package epic, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "Single-package scope detected") {
+		t.Errorf("expected 'Single-package scope detected' log line, got: %s", logOutput)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1942,6 +1942,13 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				// has the full implementation plan but executes it as one unit.
 				task.Description = consolidateEpicPlan(task.Description, plan.Subtasks)
 
+				// GH-4052: the planner already decided this is a single unit of
+				// work — don't let the regex TaskDecomposer below re-explode it
+				// into up to MaxSubtasks in-process subtasks, whether the match
+				// comes from the original description's numbered lists or from
+				// the "Planned Steps" section just injected above.
+				hasNoDecompose = true
+
 				// Fall through to normal execution below (past epic and decomposer blocks)
 			} else {
 				// Multi-package epic: safe to create separate GitHub issues
@@ -2115,7 +2122,10 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 
 	// Check for task decomposition (GH-218)
 	// Decomposition happens before timeout setup because subtasks have their own timeouts
-	if r.decomposer != nil {
+	// GH-4052: also gated on hasNoDecompose, which the single-package epic-consolidation
+	// branch above sets — Decompose()'s internal label re-check no-ops today when labels
+	// are dropped (#4050), so the call site must not rely on it alone.
+	if r.decomposer != nil && !hasNoDecompose {
 		result := r.decomposer.Decompose(task)
 		if result.Decomposed && len(result.Subtasks) > 1 {
 			r.log.Info("Task decomposed",


### PR DESCRIPTION
## Summary
- `consolidateEpicPlan` (epic.go) now renders the "Planned Steps" section as bullet prose (`- Step N: ...`) instead of a line-anchored numbered list, so it can never match `extractNumberedSteps`' regex.
- `runner.go`'s single-package epic branch now sets `hasNoDecompose = true`, which gates the `r.decomposer.Decompose(task)` call site so a task the epic planner already decided is single-scope is never re-exploded — whether the numbered list comes from the original issue body (e.g. GH-3994's "Suggested investigation scope") or from the epic-injected steps.

Closes GH-4052.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/executor/...` (full package, 43s, all green)
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/executor/...` — 0 issues
- [x] New regression test `TestExecute_SinglePackageEpic_NumberedListDescription_SkipsDecomposition` (gh4052_test.go): replays a GH-3994-shaped issue body (numbered "Suggested investigation scope" + "Implementation spec" lists) through a real `Decompose()` and confirms the task runs as ONE backend call with no "Task decomposed" log line — verified this test **fails** (5-subtask explosion, exactly matching the bug report) when the `hasNoDecompose` gate is reverted, and passes with the fix.
- [x] New regression test `TestConsolidateEpicPlan_DoesNotMatchNumberedStepsRegex` (epic_test.go): asserts `consolidateEpicPlan` output is never regex-decomposable via `extractNumberedSteps`.
- [x] Updated `TestConsolidateEpicPlan` for the new bullet output format.