### PR TITLE
fix(autopilot): exclude .agent/** bookkeeping additions from size-floor gate

### DIFF
--- a/internal/autopilot/scope_guard.go
+++ b/internal/autopilot/scope_guard.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"strings"
 
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
@@ -98,17 +99,38 @@ func ScopeDriftReason(logger *slog.Logger, prTitle, issueTitle string) string {
 // class while sparing ordinary multi-file fixes.
 const SizeFloorThreshold = 500
 
-// SizeFloorReason returns a non-empty reason if the PR's net additions exceed
-// SizeFloorThreshold. Pilot's median PR is well under 100 additions — anything
-// over the floor is large enough that auto-merge is too aggressive even on a
-// passing CI signal.
+// isBookkeepingPath reports whether path is Navigator bookkeeping/generated
+// content (`.agent/**`, e.g. task docs, the knowledge graph) rather than
+// shipped code. GH-4055: these files inflate PR additions with no bearing on
+// the risk the size-floor gate exists to catch — a large `.agent/` diff
+// (task docs, graph.json regen) should never itself trigger escalation.
+func isBookkeepingPath(path string) bool {
+	return path == ".agent" || strings.HasPrefix(path, ".agent/")
+}
+
+// SizeFloorReason returns a non-empty reason if the PR's code additions
+// (excluding Navigator bookkeeping paths, see isBookkeepingPath) exceed
+// SizeFloorThreshold. Pilot's median PR is well under 100 additions —
+// anything over the floor is large enough that auto-merge is too aggressive
+// even on a passing CI signal. GH-4055: PR #4047 (586 total additions, 281 of
+// them `.agent/**`, 305 code) wrongly escalated under the old net-additions
+// count — bookkeeping additions are now tracked separately and excluded from
+// the gate, while still surfaced in the reason string for visibility.
 func SizeFloorReason(files []*github.PRFile) string {
-	var net int
+	var codeAdditions, bookkeepingAdditions int
 	for _, f := range files {
-		net += f.Additions
+		if isBookkeepingPath(f.Filename) {
+			bookkeepingAdditions += f.Additions
+		} else {
+			codeAdditions += f.Additions
+		}
 	}
-	if net > SizeFloorThreshold {
-		return fmt.Sprintf("PR adds %d net lines (> %d threshold)", net, SizeFloorThreshold)
+	if codeAdditions > SizeFloorThreshold {
+		if bookkeepingAdditions > 0 {
+			return fmt.Sprintf("PR adds %d code additions (> %d threshold; %d bookkeeping additions excluded)",
+				codeAdditions, SizeFloorThreshold, bookkeepingAdditions)
+		}
+		return fmt.Sprintf("PR adds %d net lines (> %d threshold)", codeAdditions, SizeFloorThreshold)
 	}
 	return ""
 }

--- a/internal/autopilot/scope_guard_test.go
+++ b/internal/autopilot/scope_guard_test.go
@@ -182,3 +182,92 @@ func TestSizeFloorReason(t *testing.T) {
 		})
 	}
 }
+
+// TestIsBookkeepingPath covers GH-4055 path classification: Navigator
+// bookkeeping/generated content under .agent/** (including nested paths and
+// the knowledge graph) must be recognized separately from shipped code.
+func TestIsBookkeepingPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"internal/autopilot/controller.go", false},
+		{"cmd/pilot/main.go", false},
+		{".agent/tasks/foo.md", true},
+		{".agent/knowledge/graph.json", true},
+		{".agent", true},
+		{".agentfoo/bar.go", false}, // must not match by prefix-of-name alone
+	}
+	for _, tc := range cases {
+		if got := isBookkeepingPath(tc.path); got != tc.want {
+			t.Errorf("isBookkeepingPath(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+// TestSizeFloorReason_BookkeepingExclusion covers GH-4055: .agent/** additions
+// (Navigator task docs, knowledge graph regen) must not count toward the
+// size-floor gate, while ordinary code additions still do.
+func TestSizeFloorReason_BookkeepingExclusion(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []*github.PRFile
+		want  bool // true if a reason is expected
+	}{
+		{
+			// PR #4047 scenario: 586 total additions, 305 code + 281 bookkeeping.
+			// Previously escalated on the 586 net-additions total; must not now.
+			name: "PR #4047 scenario: 305 code + 281 bookkeeping — no escalation",
+			files: []*github.PRFile{
+				{Filename: "internal/autopilot/controller.go", Status: "modified", Additions: 305},
+				{Filename: ".agent/knowledge/graph.json", Status: "modified", Additions: 281},
+			},
+		},
+		{
+			name: "305 code + 400 code — escalates",
+			files: []*github.PRFile{
+				{Filename: "internal/autopilot/controller.go", Status: "modified", Additions: 305},
+				{Filename: "internal/autopilot/scope_guard.go", Status: "modified", Additions: 400},
+			},
+			want: true,
+		},
+		{
+			name: "0 code + 800 bookkeeping — no escalation",
+			files: []*github.PRFile{
+				{Filename: ".agent/tasks/TASK-999-foo.md", Status: "added", Additions: 800},
+			},
+		},
+		{
+			name: "threshold boundary: 500 code — no escalation",
+			files: []*github.PRFile{
+				{Filename: "internal/autopilot/controller.go", Status: "modified", Additions: 500},
+			},
+		},
+		{
+			name: "threshold boundary: 501 code — escalates",
+			files: []*github.PRFile{
+				{Filename: "internal/autopilot/controller.go", Status: "modified", Additions: 501},
+			},
+			want: true,
+		},
+		{
+			name: "mixed nested bookkeeping paths correctly excluded",
+			files: []*github.PRFile{
+				{Filename: "internal/autopilot/controller.go", Status: "modified", Additions: 300},
+				{Filename: ".agent/tasks/foo.md", Status: "added", Additions: 250},
+				{Filename: ".agent/knowledge/graph.json", Status: "modified", Additions: 250},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SizeFloorReason(tc.files)
+			if tc.want && got == "" {
+				t.Errorf("expected size-floor to fire, got empty reason")
+			}
+			if !tc.want && got != "" {
+				t.Errorf("expected no size-floor fire, got %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `SizeFloorReason` (internal/autopilot/scope_guard.go) previously summed *all* file additions, including Navigator bookkeeping/generated content under `.agent/**` (task docs, knowledge graph regen), when deciding whether a PR must escalate to human approval.
- PR #4047 was 305 code additions + 281 `.agent/**` additions (586 total) — it wrongly tripped the 500-line size floor even though the actual shipped code was well under threshold.
- Added `isBookkeepingPath(path string) bool` to classify `.agent/**` paths, and split the accumulation in `SizeFloorReason` into `codeAdditions` / `bookkeepingAdditions`. The gate now fires only on `codeAdditions > SizeFloorThreshold`, while the excluded bookkeeping total remains visible in the escalation reason string for auditability.
- No call-site changes needed — `controller.go`'s `SizeFloorReason(files)` call (~L1096) is unchanged; classification happens inside the function.

## Test plan
- [x] `go build ./...`
- [x] `make test` (full suite, plus targeted `TestIsBookkeepingPath` / `TestSizeFloorReason_BookkeepingExclusion` covering: PR #4047 scenario (305 code + 281 bookkeeping → no escalation), 305+400 code → escalates, 0 code + 800 bookkeeping → no escalation, threshold boundary 500/501 code, mixed nested `.agent/` paths)
- [x] `make lint` (0 issues)