### PR TITLE
fix(autopilot): escalate + evict PRs that fail to persist state (GH-4053)

### DIFF
--- a/.agent/sops/autopilot/pr-persist-failure-escalation.md
+++ b/.agent/sops/autopilot/pr-persist-failure-escalation.md
@@ -1,0 +1,20 @@
+# SOP: A PR that cannot persist to the state store must escalate, not spin
+
+**Category:** Autopilot / SQLite state store
+**Implemented:** 2026-07-08
+**Source incident:** GH-4053 — reconciler-adopted PR #4047 looped every poll tick on `"SQL logic error: ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint (1)"` from `SavePRState`. 22+ occurrences over hours; the PR could never advance stage (every stage handler ends in `persistPRState`), and nothing outside the log stream ever signaled it.
+
+## Problem
+
+`persistPRState` (controller.go) only logged `WARN` on a `SavePRState` failure and returned. Any persist failure that isn't transient (schema drift, a corrupted/partially-migrated row, a residual single-column `ON CONFLICT` clause vs. the live composite `PRIMARY KEY (repo, pr_number)`) wedges the PR forever: the row can never be saved, so it can never transition stage, so it retries the exact same failing write every `processAllPRs` tick with no operator-visible signal beyond a WARN line.
+
+## Fix
+
+`persistPRState` now tracks `PRState.PersistFailureCount` (in-memory only, reset to 0 on a successful persist):
+- On the **first** failure for a PR, `alertPersistFailureOnce` fires a `pr_persist_failed` alert (deduplicated per PR number via `alertedPersistFailures`, mirroring the `alertedMissingReleases` pattern from GH-3927/GH-3991) — so the failure is visible outside the log stream immediately, not after a human happens to notice log spam.
+- After `persistFailureEvictThreshold` (5, mirroring the GH-3903 404-eviction threshold) consecutive failures, `evictPersistFailedPR` drops the PR from `activePRs`/`prFailures`/`recordedMerges` and calls `persistRemovePR` — a plain `DELETE` with no `ON CONFLICT` clause, so it succeeds even when the upsert path that got the row into this state cannot. This is the same one-time row reconciliation a human would otherwise run by hand.
+- The evicted PR number is recorded in `persistFailedPRs` (with a timestamp), and `reconcileOrphanPRs` / the startup PR scan both consult `recentlyEvictedForPersistFailure` before re-adopting an untracked open PR — otherwise the 60s reconciler sweep re-adopts the still-open PR on the very next tick and repeats the identical adopt-fail-evict cycle forever. The cooldown (1h) is intentionally not permanent: it's in-memory only and a daemon restart clears it, giving a fixed underlying issue (e.g. a corrected schema) a path back to normal tracking.
+
+## Prevention
+
+Any new per-PR write path added to `state_store.go` should go through `persistPRState`/`persistRemovePR` rather than a bespoke `db.Exec` call, so it inherits this escalation behavior automatically. If you add a *new* `ON CONFLICT` clause anywhere in `state_store.go`, verify its column list against the target table's actual `PRAGMA table_info` PK/unique-index columns — see `state-store-column-rebuild-drop.md` for why the live schema can drift from what a fresh `:memory:` DB would suggest.

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -304,6 +304,22 @@ type Controller struct {
 	// alertedMissingReleases (GH-3991).
 	alertedStaleScopes map[string]bool
 
+	// alertedPersistFailures deduplicates pr_persist_failed alerts per PR
+	// number, guarded by mu — same rationale as alertedMissingReleases: a
+	// wedged PR retries every tick, and without this map the alerts engine's
+	// per-rule cooldown would still let through a repeat every cooldown
+	// window instead of firing exactly once per PR (GH-4053).
+	alertedPersistFailures map[int]bool
+
+	// persistFailedPRs records, per PR number, when persistPRState evicted the
+	// PR after persistFailureEvictThreshold consecutive SavePRState failures.
+	// Guarded by mu. reconcileOrphanPRs and restorePilotPRs consult this to
+	// skip re-adopting a PR whose state store row cannot be saved, within
+	// persistFailureReadoptCooldown — otherwise the 60s reconciler sweep would
+	// immediately re-adopt the still-open PR and repeat the identical
+	// adopt-fail-evict cycle forever (GH-4053).
+	persistFailedPRs map[int]time.Time
+
 	// epicVeto tracks, per epic parent issue number, how many consecutive
 	// reconcile passes have failed the SAME close-veto (same blocking child +
 	// same reason), guarded by mu. Lets reconcileEpicParent tell "still
@@ -342,6 +358,8 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 		log:                    slog.Default().With("component", "autopilot"),
 		alertedMissingReleases: make(map[string]bool),
 		alertedStaleScopes:     make(map[string]bool),
+		alertedPersistFailures: make(map[int]bool),
+		persistFailedPRs:       make(map[int]time.Time),
 		epicVeto:               make(map[int]*epicCloseVetoTracking),
 	}
 
@@ -524,6 +542,24 @@ func (c *Controller) SetReleaseSummaryGenerator(gen *ReleaseSummaryGenerator) {
 	c.releaseSummary = gen
 }
 
+// persistFailureEvictThreshold bounds how many consecutive SavePRState
+// failures are tolerated for one PR before persistPRState evicts it from
+// tracking. Mirrors notFoundEvictionThreshold's rationale: a row this
+// controller cannot persist (e.g. a schema/ON CONFLICT mismatch surfaced by a
+// reconciler-adopted or otherwise irregular row) can never advance stage —
+// every handler ends in a persist call — so without an eviction it retries
+// silently forever instead of escalating (GH-4053).
+const persistFailureEvictThreshold = 5
+
+// persistFailureReadoptCooldown bounds how long reconcileOrphanPRs and
+// restorePilotPRs skip re-adopting a PR evicted by evictPersistFailedPR. A
+// short cooldown (rather than a permanent skip) lets the same PR be retried
+// once whatever caused the persist failure might have cleared (e.g. a state
+// store hot-swap or migration on daemon restart, which also resets this
+// in-memory map) — but stops the 60s reconciler sweep from re-adopting an
+// unpersistable PR every single tick (GH-4053).
+const persistFailureReadoptCooldown = 1 * time.Hour
+
 // persistPRState saves a PR state to the store if available.
 //
 // TASK-324 concurrency contract: this method is LOCK-FREE with respect to the
@@ -531,14 +567,106 @@ func (c *Controller) SetReleaseSummaryGenerator(gen *ReleaseSummaryGenerator) {
 // stateStore.SavePRState are stable) — OR the prState must not yet be published in
 // c.activePRs (e.g. freshly constructed). It must NOT take prState.mu itself: every
 // caller that holds the live pointer already owns prState.mu, and re-locking would
-// deadlock (Go's sync.Mutex is non-reentrant).
+// deadlock (Go's sync.Mutex is non-reentrant). It MAY take c.mu (via
+// evictPersistFailedPR below): every call site releases c.mu before taking
+// prState.mu, so prState.mu -> c.mu is the only order ever exercised here.
 func (c *Controller) persistPRState(prState *PRState) {
 	if c.stateStore == nil {
 		return
 	}
 	if err := c.stateStore.SavePRState(c.repoKey(), prState); err != nil {
-		c.log.Warn("failed to persist PR state", "pr", prState.PRNumber, "error", err)
+		prState.PersistFailureCount++
+		failures := prState.PersistFailureCount
+		c.log.Warn("failed to persist PR state", "pr", prState.PRNumber, "error", err, "consecutive_failures", failures)
+		c.alertPersistFailureOnce(prState.PRNumber, err)
+		if failures >= persistFailureEvictThreshold {
+			c.evictPersistFailedPR(prState.PRNumber)
+		}
+		return
 	}
+	prState.PersistFailureCount = 0
+}
+
+// alertPersistFailureOnce fires a pr_persist_failed alert the first time a PR
+// fails to persist, deduplicated per PR number via alertedPersistFailures — a
+// wedged PR retries every processAllPRs tick, so without this dedup the
+// same underlying error would otherwise only surface via repeated WARN log
+// lines (GH-4053: reconciler-adopted PR #4047 looped silently on an
+// "ON CONFLICT clause does not match" persist error for 22+ ticks with no
+// alert ever firing).
+func (c *Controller) alertPersistFailureOnce(prNumber int, persistErr error) {
+	c.mu.Lock()
+	if c.alertedPersistFailures == nil {
+		c.alertedPersistFailures = make(map[int]bool)
+	}
+	if c.alertedPersistFailures[prNumber] {
+		c.mu.Unlock()
+		return
+	}
+	c.alertedPersistFailures[prNumber] = true
+	c.mu.Unlock()
+
+	msg := fmt.Sprintf(
+		"PR #%d (%s) cannot be persisted to the state store: %s — it will be evicted from tracking after %d consecutive failures and cannot advance stage until then",
+		prNumber, c.repoKey(), persistErr, persistFailureEvictThreshold,
+	)
+	if c.alertsEngine == nil {
+		c.log.Error("pr_persist_failed alert not delivered: SetAlertsEngine was never called", "pr", prNumber, "error", persistErr)
+		return
+	}
+	c.alertsEngine.ProcessEvent(alerts.Event{
+		Type:      alerts.EventType("pr_persist_failed"),
+		Error:     msg,
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"repo": c.repoKey(),
+			"pr":   strconv.Itoa(prNumber),
+		},
+	})
+}
+
+// evictPersistFailedPR drops a PR that has failed to persist
+// persistFailureEvictThreshold times in a row from in-memory tracking, and
+// records it in persistFailedPRs so reconcileOrphanPRs/restorePilotPRs won't
+// immediately re-adopt it (GH-4053). Unlike a normal removePR, it does not
+// attempt any GitHub-side cleanup — the row is unpersistable, not resolved,
+// and a stuck PR should escalate for human attention (the alert already
+// fired), not have its branch/labels touched based on incomplete state.
+//
+// persistRemovePR issues a plain DELETE (no ON CONFLICT clause), so it is
+// expected to succeed even when the upsert path that got the PR into this
+// state cannot — clearing the stuck row is the same one-time reconciliation
+// a human would otherwise run by hand.
+func (c *Controller) evictPersistFailedPR(prNumber int) {
+	c.mu.Lock()
+	delete(c.activePRs, prNumber)
+	delete(c.prFailures, prNumber)
+	delete(c.recordedMerges, prNumber)
+	if c.persistFailedPRs == nil {
+		c.persistFailedPRs = make(map[int]time.Time)
+	}
+	c.persistFailedPRs[prNumber] = time.Now()
+	c.mu.Unlock()
+
+	c.persistRemovePR(prNumber)
+	c.removePRFailures(prNumber)
+	c.log.Error("evicted PR after repeated persist failures — state store cannot save this PR's row",
+		"pr", prNumber, "repo", c.repoKey(), "threshold", persistFailureEvictThreshold)
+}
+
+// recentlyEvictedForPersistFailure reports whether prNumber was evicted by
+// evictPersistFailedPR within persistFailureReadoptCooldown, so orphan-PR
+// adoption (reconciler sweep and startup scan) can skip it instead of
+// re-registering a PR whose row the state store just proved it cannot save
+// (GH-4053).
+func (c *Controller) recentlyEvictedForPersistFailure(prNumber int) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	evictedAt, ok := c.persistFailedPRs[prNumber]
+	if !ok {
+		return false
+	}
+	return time.Since(evictedAt) < persistFailureReadoptCooldown
 }
 
 // persistRemovePR removes a PR state from the store if available.
@@ -3491,6 +3619,10 @@ func (c *Controller) ScanExistingPRs(ctx context.Context) error {
 			c.log.Debug("skipping already-tracked PR in scan", "pr", pr.Number, "branch", pr.Head.Ref)
 			continue
 		}
+		if c.recentlyEvictedForPersistFailure(pr.Number) {
+			c.log.Debug("skipping PR recently evicted for persist failure", "pr", pr.Number, "branch", pr.Head.Ref)
+			continue
+		}
 
 		c.log.Info("restoring Pilot PR for tracking",
 			"pr", pr.Number,
@@ -3555,6 +3687,10 @@ func (c *Controller) reconcileOrphanPRs(ctx context.Context) {
 		_, tracked := c.activePRs[pr.Number]
 		c.mu.RUnlock()
 		if tracked {
+			continue
+		}
+		if c.recentlyEvictedForPersistFailure(pr.Number) {
+			c.log.Debug("reconciler: skipping PR recently evicted for persist failure", "pr", pr.Number, "branch", pr.Head.Ref)
 			continue
 		}
 

--- a/internal/autopilot/controller_reconciler_test.go
+++ b/internal/autopilot/controller_reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/testutil"
 	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
@@ -137,6 +138,62 @@ func TestController_ReconcileOrphanPRs_NonPilotBranchSkipped(t *testing.T) {
 	prs := c.GetActivePRs()
 	if len(prs) != 0 {
 		t.Errorf("expected 0 registered PRs, got %d", len(prs))
+	}
+}
+
+// TestController_ReconcileOrphanPRs_SkipsRecentlyEvictedForPersistFailure
+// verifies that a PR evicted by evictPersistFailedPR is not immediately
+// re-adopted by the next reconciler sweep — otherwise a PR whose row the
+// state store cannot save would adopt-fail-evict every 60s tick forever
+// (GH-4053).
+func TestController_ReconcileOrphanPRs_SkipsRecentlyEvictedForPersistFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls" {
+			prs := []*github.PullRequest{
+				{
+					Number:  4047,
+					HTMLURL: "https://github.com/owner/repo/pull/4047",
+					Head:    github.PRRef{Ref: "pilot/GH-100", SHA: "abc1234"},
+					Base:    github.PRRef{Ref: "main"},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	// Simulate a prior eviction: PR 4047 is untracked (as if just evicted)
+	// but was evicted for persist failure moments ago.
+	c.mu.Lock()
+	c.persistFailedPRs[4047] = time.Now()
+	c.mu.Unlock()
+
+	c.reconcileOrphanPRs(context.Background())
+
+	if _, ok := c.GetPRState(4047); ok {
+		t.Fatal("reconciler should not have re-adopted a PR recently evicted for persist failure")
+	}
+	snap := c.metrics.Snapshot()
+	if snap.OrphanPRsRegistered["reconciler"] != 0 {
+		t.Errorf("OrphanPRsRegistered[reconciler] = %d, want 0", snap.OrphanPRsRegistered["reconciler"])
+	}
+
+	// Once the cooldown has elapsed, the PR is eligible for adoption again.
+	c.mu.Lock()
+	c.persistFailedPRs[4047] = time.Now().Add(-2 * persistFailureReadoptCooldown)
+	c.mu.Unlock()
+
+	c.reconcileOrphanPRs(context.Background())
+
+	if _, ok := c.GetPRState(4047); !ok {
+		t.Fatal("reconciler should re-adopt the PR once the persist-failure cooldown has elapsed")
 	}
 }
 

--- a/internal/autopilot/gh4053_persist_failure_test.go
+++ b/internal/autopilot/gh4053_persist_failure_test.go
@@ -1,0 +1,130 @@
+package autopilot
+
+import (
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/alerts"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// corruptPRStateTableSingleColumnPK rebuilds autopilot_pr_state with the
+// pre-GH-3903 single-column PRIMARY KEY (pr_number only, no repo), while
+// leaving SavePRState's query text (state_store.go) untouched — it still
+// issues `ON CONFLICT(repo, pr_number)`. This reproduces the GH-4053
+// production symptom: a row whose live schema doesn't match the upsert's
+// conflict target raises "ON CONFLICT clause does not match any PRIMARY KEY
+// or UNIQUE constraint" on every SavePRState call for that installation.
+func corruptPRStateTableSingleColumnPK(t *testing.T, store *StateStore) {
+	t.Helper()
+	if _, err := store.db.Exec(`DROP TABLE autopilot_pr_state`); err != nil {
+		t.Fatalf("drop autopilot_pr_state: %v", err)
+	}
+	if _, err := store.db.Exec(`
+		CREATE TABLE autopilot_pr_state (
+			pr_number INTEGER PRIMARY KEY,
+			repo TEXT NOT NULL DEFAULT '',
+			pr_url TEXT NOT NULL DEFAULT '',
+			issue_number INTEGER DEFAULT 0,
+			branch_name TEXT NOT NULL DEFAULT '',
+			head_sha TEXT DEFAULT '',
+			stage TEXT NOT NULL DEFAULT '',
+			ci_status TEXT NOT NULL DEFAULT 'pending',
+			last_checked DATETIME,
+			ci_wait_started_at DATETIME,
+			merge_attempts INTEGER DEFAULT 0,
+			error TEXT DEFAULT '',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			release_version TEXT DEFAULT '',
+			release_bump_type TEXT DEFAULT '',
+			merge_notification_posted INTEGER NOT NULL DEFAULT 0,
+			approval_request_id TEXT NOT NULL DEFAULT '',
+			approval_decision TEXT NOT NULL DEFAULT '',
+			approval_requested_at DATETIME,
+			post_merge_sha TEXT NOT NULL DEFAULT '',
+			post_merge_ci_started_at DATETIME,
+			rebase_attempts INTEGER NOT NULL DEFAULT 0,
+			scope_key TEXT NOT NULL DEFAULT ''
+		)
+	`); err != nil {
+		t.Fatalf("recreate autopilot_pr_state with single-column PK: %v", err)
+	}
+}
+
+// TestGH4053_PersistFailureAlertsOnceAndEvicts verifies that a PR whose
+// SavePRState call fails repeatedly (e.g. a reconciler-adopted row hitting an
+// ON CONFLICT/schema mismatch) fires exactly one pr_persist_failed alert and
+// is evicted from tracking after persistFailureEvictThreshold consecutive
+// failures, instead of retry-looping forever with only WARN logs (GH-4053).
+func TestGH4053_PersistFailureAlertsOnceAndEvicts(t *testing.T) {
+	store, err := NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+	corruptPRStateTableSingleColumnPK(t, store)
+
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	c := NewController(DefaultConfig(), ghClient, nil, "qf-studio", "pilot")
+	c.SetStateStore(store)
+	sink := &fakeAlertSink{}
+	c.SetAlertsEngine(sink)
+
+	prState := &PRState{
+		PRNumber: 4047,
+		PRURL:    "https://github.com/qf-studio/pilot/pull/4047",
+		Stage:    StageAwaitApproval,
+	}
+	c.mu.Lock()
+	c.activePRs[4047] = prState
+	c.mu.Unlock()
+
+	for i := 0; i < persistFailureEvictThreshold; i++ {
+		prState.mu.Lock()
+		c.persistPRState(prState)
+		prState.mu.Unlock()
+	}
+
+	if len(sink.events) != 1 {
+		t.Fatalf("expected exactly 1 pr_persist_failed alert (deduped across retries), got %d", len(sink.events))
+	}
+	if sink.events[0].Type != alerts.EventType("pr_persist_failed") {
+		t.Errorf("alert type = %s, want pr_persist_failed", sink.events[0].Type)
+	}
+
+	if _, tracked := c.GetPRState(4047); tracked {
+		t.Error("PR should have been evicted from activePRs after threshold consecutive persist failures")
+	}
+	if !c.recentlyEvictedForPersistFailure(4047) {
+		t.Error("recentlyEvictedForPersistFailure should report true immediately after eviction")
+	}
+}
+
+// TestGH4053_PersistSuccessResetsFailureCount verifies that a successful
+// persist clears PersistFailureCount, so a transient failure (e.g. a busy
+// DB) doesn't count toward eviction once the write starts succeeding again.
+func TestGH4053_PersistSuccessResetsFailureCount(t *testing.T) {
+	store, err := NewStateStoreFromPath(":memory:")
+	if err != nil {
+		t.Fatalf("NewStateStoreFromPath: %v", err)
+	}
+
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	c := NewController(DefaultConfig(), ghClient, nil, "qf-studio", "pilot")
+	c.SetStateStore(store)
+
+	prState := &PRState{
+		PRNumber: 55,
+		PRURL:    "https://github.com/qf-studio/pilot/pull/55",
+		Stage:    StagePRCreated,
+	}
+	prState.mu.Lock()
+	prState.PersistFailureCount = persistFailureEvictThreshold - 1
+	c.persistPRState(prState)
+	failures := prState.PersistFailureCount
+	prState.mu.Unlock()
+
+	if failures != 0 {
+		t.Errorf("PersistFailureCount = %d after a successful persist, want 0", failures)
+	}
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -752,6 +752,13 @@ type PRState struct {
 	// the counter anyway, giving a freshly-restored row a few more tries before
 	// eviction (GH-3903 404-eviction guard).
 	NotFoundCount int
+	// PersistFailureCount tracks consecutive SavePRState errors for this PR
+	// (e.g. a schema/ON CONFLICT mismatch on an adopted or otherwise
+	// irregular row). Reset to 0 on a successful persist. In-memory only:
+	// once it reaches persistFailureEvictThreshold, persistPRState evicts the
+	// PR from tracking rather than spinning on the same error forever
+	// (GH-4053).
+	PersistFailureCount int
 	// EnvironmentName is the user-friendly environment label (e.g. "staging").
 	EnvironmentName string
 	// PRTitle is the title of the pull request.
@@ -840,6 +847,7 @@ func (ps *PRState) snapshot() *PRState {
 		ReleaseBumpType:         ps.ReleaseBumpType,
 		ConsecutiveAPIFailures:  ps.ConsecutiveAPIFailures,
 		NotFoundCount:           ps.NotFoundCount,
+		PersistFailureCount:     ps.PersistFailureCount,
 		EnvironmentName:         ps.EnvironmentName,
 		PRTitle:                 ps.PRTitle,
 		TargetBranch:            ps.TargetBranch,


### PR DESCRIPTION
## Summary

Fixes GH-4053: reconciler-adopted PR #4047 looped every poll tick on
`"SQL logic error: ON CONFLICT clause does not match any PRIMARY KEY or
UNIQUE constraint (1)"` from `SavePRState`, wedging the PR forever with
only a WARN log and no operator-visible signal.

- Audited every `ON CONFLICT` clause writing to `autopilot_pr_state` /
  `autopilot_pr_failures` / `autopilot_scope_release` in `state_store.go` —
  all match their table's current (migrated) PK today. Reproduced the
  exact production error message via a regression test that simulates a
  drifted/partially-migrated schema (single-column PK on
  `autopilot_pr_state` while `SavePRState` still issues
  `ON CONFLICT(repo, pr_number)`), matching how such a mismatch can occur
  against a real, older/corrupted installation even though HEAD's fresh-install
  migration path is internally consistent.
- `persistPRState` now fires a deduplicated `pr_persist_failed` alert on the
  **first** persist failure per PR (mirrors the `alertedMissingReleases`
  pattern), then **evicts** the PR from tracking after 5 consecutive
  failures (`persistFailureEvictThreshold`, mirroring the existing
  404-eviction threshold) via `evictPersistFailedPR`. Eviction clears the
  stuck row with a plain `DELETE` (no `ON CONFLICT` clause, so it succeeds
  even when the upsert can't) — the same one-time reconciliation a human
  would otherwise run by hand.
- `reconcileOrphanPRs` and the startup PR scan now check
  `recentlyEvictedForPersistFailure` (1h in-memory cooldown) before
  re-adopting an untracked open PR, so the 60s reconciler sweep doesn't
  immediately re-adopt a PR whose row it just proved it can't save and
  repeat the identical adopt-fail-evict cycle forever.
- Added `.agent/sops/autopilot/pr-persist-failure-escalation.md`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...` (full package, including new tests)
- [x] `go test ./internal/...` (full repo)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] New regression test `TestGH4053_PersistFailureAlertsOnceAndEvicts`
      reproduces the exact production error string and verifies exactly one
      alert fires plus eviction after threshold failures
- [x] New regression test `TestGH4053_PersistSuccessResetsFailureCount`
- [x] New regression test
      `TestController_ReconcileOrphanPRs_SkipsRecentlyEvictedForPersistFailure`
      verifies the reconciler guard and its cooldown expiry