### PR TITLE
feat(dashboard): logs panel flexes to terminal bottom TASK-390

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -1497,9 +1497,17 @@ func (m Model) renderDashboard() string {
 	b.WriteString(m.renderHistory())
 	b.WriteString("\n")
 
-	// Logs (if enabled)
+	// Logs (if enabled) — the flex panel: stretches to the bottom of the
+	// terminal in full-width and side-by-side layouts. In stacked mode
+	// (narrow terminal, git graph below) it stays content-sized so the
+	// graph keeps its height; history/autopilot stay dynamic either way.
 	if m.showLogs {
-		b.WriteString(m.renderLogs())
+		flex := 0
+		if m.height > 1 && !m.isStackedMode() {
+			used := strings.Count(b.String(), "\n")
+			flex = m.height - 1 - used // reserve the help footer line
+		}
+		b.WriteString(m.renderLogs(flex))
 		b.WriteString("\n")
 	}
 
@@ -2342,30 +2350,45 @@ func formatTimeAgo(t time.Time) string {
 	return t.Format("Jan 2")
 }
 
-// renderLogs renders the logs section
-func (m Model) renderLogs() string {
-	var content strings.Builder
+// logsFlexMinHeight is the smallest total panel height worth stretching to:
+// 2 borders + 2 padding lines + 1 log line.
+const logsFlexMinHeight = 5
+
+// renderLogs renders the logs section. flexHeight > 0 stretches the panel to
+// exactly that many terminal lines (log tail fills the space, blank-padded
+// below); flexHeight <= 0 keeps the content-sized panel with a 10-line tail —
+// used in stacked mode so the git graph below keeps its room.
+func (m Model) renderLogs(flexHeight int) string {
 	tw := m.effectivePanelTotalWidth()
 	iw := tw - 4
 	w := iw - 4 // Account for indent (2 spaces each side)
 
+	capacity := 10
+	flex := flexHeight >= logsFlexMinHeight
+	if flex {
+		capacity = flexHeight - 4 // 2 borders + 2 padding lines
+	}
+
+	var lines []string
 	if len(m.logs) == 0 {
-		content.WriteString("  No logs yet")
+		lines = append(lines, "  No logs yet")
 	} else {
-		start := len(m.logs) - 10
+		start := len(m.logs) - capacity
 		if start < 0 {
 			start = 0
 		}
-
-		for i, log := range m.logs[start:] {
-			if i > 0 {
-				content.WriteString("\n")
-			}
-			content.WriteString("  " + truncateVisual(log, w))
+		for _, log := range m.logs[start:] {
+			lines = append(lines, "  "+truncateVisual(log, w))
 		}
 	}
-
-	return renderPanel("LOGS", content.String(), tw)
+	if flex {
+		for len(lines) < capacity {
+			lines = append(lines, "")
+		}
+		padded := "\n" + strings.Join(lines, "\n") + "\n"
+		return render.Panel("logs", padded, tw, flexHeight, panelChrome)
+	}
+	return renderPanel("LOGS", strings.Join(lines, "\n"), tw)
 }
 
 // updateMetricsCardMsg updates the metrics card data

--- a/internal/dashboard/tui_test.go
+++ b/internal/dashboard/tui_test.go
@@ -68,6 +68,48 @@ func TestBuildStatCard(t *testing.T) {
 	}
 }
 
+// Logs is the flex panel: in full-width / side-by-side layouts it stretches
+// so its bottom border sits directly above the help footer instead of a
+// ghost-line void; the log tail grows to fill the space.
+func TestLogsPanelFlexHeight(t *testing.T) {
+	m := NewModel("test")
+	m.width = 100
+	m.height = 40
+	m.logs = []string{"alpha", "beta"}
+
+	out := m.View()
+	lines := strings.Split(out, "\n")
+	if len(lines) != m.height {
+		t.Fatalf("View() height = %d lines, want %d", len(lines), m.height)
+	}
+	// Last line is the help footer; the line above it must be the logs
+	// panel's bottom border, not blank padding.
+	if !strings.Contains(lines[m.height-2], "╰") {
+		t.Errorf("expected logs bottom border above help footer, got %q", lines[m.height-2])
+	}
+	if !strings.Contains(out, "alpha") || !strings.Contains(out, "beta") {
+		t.Error("log lines missing from flexed panel")
+	}
+}
+
+// In stacked mode (graph visible, terminal too narrow for side-by-side) the
+// logs panel stays content-sized so the git graph below keeps its height.
+func TestLogsPanelStackedStaysCompact(t *testing.T) {
+	m := NewModel("test")
+	m.width = 60 // < panelTotalWidth+1+20 → stacked once the graph is visible
+	m.height = 50
+	m.logs = []string{"alpha"}
+
+	m.gitGraphMode = GitGraphVisible
+	stacked := strings.Count(m.renderDashboard(), "\n")
+	m.gitGraphMode = GitGraphHidden
+	flexed := strings.Count(m.renderDashboard(), "\n")
+
+	if stacked >= flexed {
+		t.Errorf("stacked dashboard (%d lines) should be shorter than flexed (%d)", stacked, flexed)
+	}
+}
+
 // TASK-390: two-series stacked variant (tokens cached/fresh, queue ✓/✗)
 // keeps the exact card geometry of buildStatCard and fills the band even
 // with a 7-point history (BrailleStacked right-aligns unstretched series).


### PR DESCRIPTION
## Summary

Follow-up to #4061 (v2.234.0 grot redesign): the logs panel now stretches to the bottom of the terminal instead of leaving a ghost-line void under a content-sized panel.

- Full-width + side-by-side (git graph) layouts: logs bottom border sits directly above the help footer; the log tail capacity grows with the available height.
- Stacked mode (terminal too narrow, graph renders below the dashboard): logs stays content-sized (10-line tail) so the graph keeps its room.
- History / autopilot panels remain dynamic-height, unchanged.

## Testing

- `TestLogsPanelFlexHeight` — View() at 100×40: exact terminal height, logs border adjacent to help footer, tail visible.
- `TestLogsPanelStackedStaysCompact` — stacked dashboard shorter than flexed.
- Full dashboard suite + lint green; probe-rendered at 100×38 to eyeball the layout.