### PR TITLE
fix(dashboard): history rows show real execution status TASK-390

### DIFF
--- a/internal/dashboard/grot_chrome.go
+++ b/internal/dashboard/grot_chrome.go
@@ -161,6 +161,8 @@ func stageMeter(info StageInfo, width int) string {
 	}
 	hex := grotTheme.Accent
 	switch {
+	case info.Muted:
+		hex = grotTheme.Dim // terminal non-ladder outcome: not climbing, not failed
 	case info.Failed:
 		hex = grotTheme.Error
 	case info.Reached >= stageLadderTotal:

--- a/internal/dashboard/stage_strip.go
+++ b/internal/dashboard/stage_strip.go
@@ -63,6 +63,45 @@ type StageInfo struct {
 	Label   string // stage name that defined the rung (e.g. "ci_failed")
 	Failed  bool   // rung-defining stage was terminal-failure, or execution failed
 	Known   bool   // false when no events were recorded
+	Muted   bool   // terminal non-ladder outcome (skipped/no_op/…): dim meter
+}
+
+// displayStatus maps an executions.status value to the history-row status
+// vocabulary. "completed" renders as success; every other value (failed,
+// skipped, no_op, declined, rate_limited, infra, stalled, running, pending)
+// passes through so statusIconStyle picks its own glyph. Collapsing every
+// non-failed status to success is how a skipped run — and a still-running
+// one — rendered ✓ in HISTORY (GH-3927 / GH-4064).
+func displayStatus(execStatus string) string {
+	if execStatus == "completed" {
+		return "success"
+	}
+	return execStatus
+}
+
+// mutedOutcomes are terminal statuses that never name a ladder rung: the row
+// label shows the outcome itself (a skipped run must not read "running") and
+// the meter renders muted. stalled is excluded — it keeps the rung label to
+// show where the run died, like failed.
+var mutedOutcomes = map[string]bool{
+	"skipped":      true,
+	"no_op":        true,
+	"declined":     true,
+	"rate_limited": true,
+	"infra":        true,
+}
+
+// stageInfoForExecution derives the history-row StageInfo from the event
+// timeline plus the authoritative executions.status. The label override is
+// status-driven, never event-driven, so GH-4023's stray-late-event guard in
+// buildStageInfo is untouched.
+func stageInfoForExecution(events []*memory.Event, status string) StageInfo {
+	info := buildStageInfo(events, status == "failed" || status == "stalled")
+	if mutedOutcomes[status] && info.Known {
+		info.Label = truncateString(status, maxStageStripLabelWidth)
+		info.Muted = true
+	}
+	return info
 }
 
 // buildStageInfo reduces an execution's execution_events timeline to a

--- a/internal/dashboard/stage_strip_test.go
+++ b/internal/dashboard/stage_strip_test.go
@@ -223,3 +223,67 @@ func TestStageLadderPosition_AllStages(t *testing.T) {
 		}
 	}
 }
+
+// GH-3927 regression: a skipped execution (events end in failed → skipped)
+// must not render as a succeeded run stuck at "running" — the authoritative
+// executions.status owns the label and mutes the meter. Event stream is the
+// verbatim timeline from the production run that surfaced the bug.
+func TestStageInfoForExecution_SkippedRun(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StageRunning),
+		evt(memory.StageSpecValidated),
+		evt(memory.StageClaudeStarted),
+		evt(memory.StageFailed),
+		evt(memory.StageSkipped),
+	}
+	got := stageInfoForExecution(events, "skipped")
+	want := StageInfo{Reached: 2, Label: "skipped", Failed: false, Known: true, Muted: true}
+	if got != want {
+		t.Errorf("skipped run: got %+v, want %+v", got, want)
+	}
+}
+
+// GH-4064 regression: a genuinely running execution keeps its ladder label
+// (not muted) — the row glyph ● carries the live state.
+func TestStageInfoForExecution_RunningPassthrough(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StageRunning),
+		evt(memory.StageSpecValidated),
+	}
+	got := stageInfoForExecution(events, "running")
+	want := StageInfo{Reached: 2, Label: "running", Failed: false, Known: true, Muted: false}
+	if got != want {
+		t.Errorf("running run: got %+v, want %+v", got, want)
+	}
+}
+
+// stalled keeps the rung label (shows where it died) and flags failure,
+// like failed — it is deliberately not a muted outcome.
+func TestStageInfoForExecution_StalledKeepsRung(t *testing.T) {
+	events := []*memory.Event{
+		evt(memory.StageSpecValidated),
+		evt(memory.StageRunning),
+		evt(memory.StageCommit),
+	}
+	got := stageInfoForExecution(events, "stalled")
+	want := StageInfo{Reached: 3, Label: "commit", Failed: true, Known: true, Muted: false}
+	if got != want {
+		t.Errorf("stalled run: got %+v, want %+v", got, want)
+	}
+}
+
+func TestDisplayStatus(t *testing.T) {
+	cases := map[string]string{
+		"completed":    "success",
+		"failed":       "failed",
+		"skipped":      "skipped",
+		"no_op":        "no_op",
+		"running":      "running",
+		"rate_limited": "rate_limited",
+	}
+	for in, want := range cases {
+		if got := displayStatus(in); got != want {
+			t.Errorf("displayStatus(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -595,10 +595,7 @@ func (m *Model) hydrateFromStore() {
 		if i >= 5 {
 			break
 		}
-		status := "success"
-		if exec.Status == "failed" {
-			status = "failed"
-		}
+		status := displayStatus(exec.Status)
 		completedAt := exec.CreatedAt
 		if exec.CompletedAt != nil {
 			completedAt = *exec.CompletedAt
@@ -617,7 +614,7 @@ func (m *Model) hydrateFromStore() {
 			Duration:    fmt.Sprintf("%dms", exec.DurationMs),
 			CompletedAt: completedAt,
 			PeakRSSMB:   exec.PeakRSSMB,
-			Stage:       buildStageInfo(events, status == "failed"),
+			Stage:       stageInfoForExecution(events, status),
 		})
 	}
 
@@ -863,10 +860,7 @@ func storeRefreshCmd(store *memory.Store, projectPath string) tea.Cmd {
 			if i >= 5 {
 				break
 			}
-			status := "success"
-			if exec.Status == "failed" {
-				status = "failed"
-			}
+			status := displayStatus(exec.Status)
 			completedAt := exec.CreatedAt
 			if exec.CompletedAt != nil {
 				completedAt = *exec.CompletedAt
@@ -884,7 +878,7 @@ func storeRefreshCmd(store *memory.Store, projectPath string) tea.Cmd {
 				Duration:    fmt.Sprintf("%dms", exec.DurationMs),
 				CompletedAt: completedAt,
 				PeakRSSMB:   exec.PeakRSSMB,
-				Stage:       buildStageInfo(events, status == "failed"),
+				Stage:       stageInfoForExecution(events, status),
 			})
 		}
 


### PR DESCRIPTION
## Bug

HISTORY showed `✓ GH-3927 … running` for a **skipped** execution, and `✓` for the genuinely **running** GH-4064. Root cause: both DB-fed paths collapsed every non-`failed` status to `success`, while `statusIconStyle` already knew the full TASK-358 vocabulary.

Production evidence (`~/.pilot/data/pilot.db`): GH-3927's latest execution has `status=skipped`, events `running → spec_validated → claude_started → failed → skipped` — max-rung reducer correctly lands on rung 2 ("running"), but the row claimed ✓ success.

## Fix

- `displayStatus`: `completed` → `success`; everything else passes through (`· skipped`, `○ no_op`, `● running`, `⟲ rate_limited`, …)
- `stageInfoForExecution`: terminal non-ladder outcomes own the row label (a skipped run reads `skipped`, not `running`) and mute the meter. Status-driven, never event-driven — GH-4023's stray-late-event guard in `buildStageInfo` is untouched (reducer unmodified). `stalled` keeps its rung label like `failed` to show where the run died.
- `stageMeter`: muted outcomes render dim, not accent "climbing".

## Testing

- Regression tests use the verbatim production event streams (skipped run, running passthrough, stalled keeps rung) + `displayStatus` table.
- Full dashboard suite + lint green.
- Probe-rendered against the production store: `● GH-4064 running`, `○ GH-4063 no_op`, `·` skipped rows — all truthful.