### PR TITLE
fix(autopilot): pilot_prs_conflicting_total is never incremented (TASK-391)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -3207,6 +3207,15 @@ func (c *Controller) handleMergeConflict(ctx context.Context, prState *PRState) 
 		"branch", prState.BranchName,
 	)
 
+	// GH-4069: record exactly once per PR-conflict event. handleMergeConflict
+	// is re-entered on every poll tick while the conflict persists (and from
+	// multiple call sites), so guard on ConflictRecorded rather than
+	// incrementing unconditionally.
+	if !prState.ConflictRecorded {
+		c.metrics.RecordPRConflicting()
+		prState.ConflictRecorded = true
+	}
+
 	// Try GitHub auto-update first (merge-from-base, not true rebase)
 	err := c.ghClient.UpdatePullRequestBranch(ctx, c.owner, c.repo, prState.PRNumber)
 	if err == nil {

--- a/internal/autopilot/gh4069_test.go
+++ b/internal/autopilot/gh4069_test.go
@@ -1,0 +1,110 @@
+package autopilot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// GH-4069/TASK-391: pilot_prs_conflicting_total had zero production call
+// sites — RecordPRConflicting was only exercised by metrics_test.go, so the
+// counter never moved regardless of how many PRs hit merge conflicts.
+// handleMergeConflict now records the metric once per PR-conflict event.
+
+// TestController_HandleMergeConflict_RecordsConflictMetricOnce verifies that
+// entering the merge-conflict path increments pilot_prs_conflicting_total
+// exactly once, and that re-entering the same path for the same PR (e.g. on
+// a subsequent poll tick before the conflict is resolved) does not
+// double-count.
+func TestController_HandleMergeConflict_RecordsConflictMetricOnce(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/55/update-branch" && r.Method == http.MethodPut:
+			// 422: true conflict, auto-rebase cannot resolve it.
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"merge conflict between base and head"}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:    55,
+		PRURL:       "https://github.com/owner/repo/pull/55",
+		IssueNumber: 20,
+		BranchName:  "pilot/GH-20",
+		Stage:       StageMerging,
+		CreatedAt:   time.Now(),
+	}
+
+	ctx := context.Background()
+	if err := c.handleMergeConflict(ctx, prState); err != nil {
+		t.Fatalf("handleMergeConflict (1st call) returned error: %v", err)
+	}
+	if err := c.handleMergeConflict(ctx, prState); err != nil {
+		t.Fatalf("handleMergeConflict (2nd call, re-entry) returned error: %v", err)
+	}
+
+	snap := c.metrics.Snapshot()
+	if snap.PRsConflicting != 1 {
+		t.Errorf("PRsConflicting = %d, want 1 (re-entry for the same PR must not double-count)", snap.PRsConflicting)
+	}
+	if !prState.ConflictRecorded {
+		t.Error("ConflictRecorded should be true after handleMergeConflict runs")
+	}
+}
+
+// TestController_HandleMergeConflict_RecordsConflictMetricPerPR verifies that
+// distinct PRs each entering the merge-conflict path are counted
+// independently (the guard is per-PR, not global).
+func TestController_HandleMergeConflict_RecordsConflictMetricPerPR(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/pulls/56/update-branch" && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"merge conflict between base and head"}`))
+		case r.URL.Path == "/repos/owner/repo/pulls/57/update-branch" && r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"merge conflict between base and head"}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prA := &PRState{PRNumber: 56, PRURL: "https://github.com/owner/repo/pull/56", IssueNumber: 21, BranchName: "pilot/GH-21", Stage: StageMerging, CreatedAt: time.Now()}
+	prB := &PRState{PRNumber: 57, PRURL: "https://github.com/owner/repo/pull/57", IssueNumber: 22, BranchName: "pilot/GH-22", Stage: StageMerging, CreatedAt: time.Now()}
+
+	ctx := context.Background()
+	if err := c.handleMergeConflict(ctx, prA); err != nil {
+		t.Fatalf("handleMergeConflict(prA) returned error: %v", err)
+	}
+	if err := c.handleMergeConflict(ctx, prB); err != nil {
+		t.Fatalf("handleMergeConflict(prB) returned error: %v", err)
+	}
+
+	snap := c.metrics.Snapshot()
+	if snap.PRsConflicting != 2 {
+		t.Errorf("PRsConflicting = %d, want 2 (one per distinct PR)", snap.PRsConflicting)
+	}
+}

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -820,6 +820,15 @@ type PRState struct {
 	// release content. In-memory only — restored the same way as ScopeTitle
 	// (GH-3990).
 	ScopeMemberPRs []int
+	// ConflictRecorded is true once handleMergeConflict has incremented
+	// pilot_prs_conflicting_total for this PR. handleMergeConflict can be
+	// re-entered many times for the same PR (each poll tick while the
+	// conflict persists, plus the pre-CI and post-CI call sites), so this
+	// guards against inflating the counter beyond one increment per
+	// PR-conflict event (TASK-391). In-memory only: a restart re-detects
+	// the conflict via isMergeConflict and may re-record once, which is an
+	// acceptable trade-off for a low-cardinality observability counter.
+	ConflictRecorded bool
 }
 
 // snapshot returns a detached, field-by-field copy of the PRState with a fresh
@@ -864,6 +873,7 @@ func (ps *PRState) snapshot() *PRState {
 		TerminalLabel:           ps.TerminalLabel,
 		ScopeKey:                ps.ScopeKey,
 		ScopeTitle:              ps.ScopeTitle,
+		ConflictRecorded:        ps.ConflictRecorded,
 	}
 	// DiscoveredChecks and ScopeMemberPRs are slices — copy the backing arrays
 	// so consumers can't mutate the live PR's slice through the snapshot.


### PR DESCRIPTION
## Summary
- `Metrics.RecordPRConflicting` had zero production call sites — the `pilot_prs_conflicting_total` counter could never move regardless of how many PRs hit merge conflicts (a storm of 5+ conflict-closed PRs on 2026-07-07 went unrecorded).
- `handleMergeConflict` (`internal/autopilot/controller.go`) now calls `c.metrics.RecordPRConflicting()` once per PR-conflict event.
- Added `PRState.ConflictRecorded` (in-memory, non-persisted) to guard against double-counting when the conflict path is re-entered for the same PR across poll ticks / multiple call sites.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/autopilot/...`
- [x] `go test -short ./...` (full suite)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] New tests: `TestController_HandleMergeConflict_RecordsConflictMetricOnce` (re-entry for same PR doesn't double-count), `TestController_HandleMergeConflict_RecordsConflictMetricPerPR` (distinct PRs counted independently)

Refs: TASK-391. Note (per task): the counter becomes visible on `/metrics` once TASK-390 (multi-controller export aggregation) lands; this fix is independent.