### PR TITLE
GH-4068: fix(metrics): wire Prometheus export/hydration/alerting/persistence across ALL autopilot controllers — not just the default (TASK-390)

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1775,13 +1775,24 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		}
 	}
 
+	// GH-4068: one fleet-wide metrics view spanning every controller (default
+	// + per-project) — /metrics, MetricsAlerter, and MetricsPersister below
+	// all read this instead of the single default-repo controller, which
+	// previously left any projects-map controller's PR activity invisible to
+	// them (autopilotController is one of the entries summed here, since the
+	// default-repo controller is also stored under its own key in the map).
+	var aggregateMetrics *autopilot.AggregateMetrics
+	var allControllers []*autopilot.Controller
+	for _, c := range autopilotControllers {
+		allControllers = append(allControllers, c)
+	}
+	if len(allControllers) > 0 {
+		aggregateMetrics = autopilot.NewAggregateMetrics(allControllers)
+	}
+
 	// GH-2685: wire all controllers as the approval state writer so async approval
 	// decisions update the correct in-memory PRState across multi-repo deployments.
 	if len(autopilotControllers) > 0 {
-		var allControllers []*autopilot.Controller
-		for _, c := range autopilotControllers {
-			allControllers = append(allControllers, c)
-		}
 		approvalMgr.WithStateWriter(autopilot.NewMultiControllerStateWriter(allControllers...))
 	}
 
@@ -1942,7 +1953,6 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		gwServer = gateway.NewServer(cfg.Gateway)
 		if autopilotController != nil {
 			gwServer.SetAutopilotProvider(&autopilotProviderAdapter{controller: autopilotController})
-			gwServer.SetMetricsSource(autopilotController.Metrics())
 			// GH-2855: wire token/cost/execution counters into executor
 			runner.SetMetricsRecorder(autopilotController.Metrics())
 			// GH-4041: restore Prometheus counter baselines from the store's
@@ -1950,11 +1960,22 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			// serving scrapes below, so external dashboards don't observe a
 			// reset-to-zero on restart. Fail loud rather than silently start
 			// with zero baselines.
+			//
+			// GH-4068: autopilotController.Metrics() is the SOLE hydration
+			// target — it is one of the sources summed into aggregateMetrics
+			// below, so this lifetime baseline is counted exactly once
+			// fleet-wide. Never hydrate any other controller's Metrics, or
+			// the aggregate would double-count on every scrape.
 			if store != nil {
 				if hydrateErr := autopilot.HydrateFromStore(ctx, store, autopilotController.Metrics()); hydrateErr != nil {
 					return fmt.Errorf("failed to hydrate metrics from store: %w", hydrateErr)
 				}
 			}
+		}
+		// GH-4068: /metrics reads the fleet-wide aggregate (default + every
+		// projects-map controller), not just the default controller.
+		if aggregateMetrics != nil {
+			gwServer.SetMetricsSource(aggregateMetrics)
 		}
 
 		// GH-2080: Wire PR review webhook events to autopilot controller in polling mode
@@ -2674,15 +2695,20 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					fmt.Printf("● autopilot enabled · %s environment (%d repos)\n", cfg.Orchestrator.Autopilot.Environment, len(autopilotControllers))
 				}
 
-				// Start metrics alerter for default controller (GH-728)
-				if alertsEngine != nil && autopilotController != nil {
-					metricsAlerter := autopilot.NewMetricsAlerter(autopilotController, alertsEngine)
+				// Start metrics alerter over the fleet-wide aggregate (GH-728,
+				// GH-4068 — previously scoped to the default controller only,
+				// so alert metadata silently excluded every projects-map
+				// controller's PR/queue activity; mirrors the GH-3954
+				// alerts-engine fix below, which fixed the same silo for
+				// direct controller alerts).
+				if alertsEngine != nil && aggregateMetrics != nil {
+					metricsAlerter := autopilot.NewMetricsAlerter(aggregateMetrics, alertsEngine)
 					go metricsAlerter.Run(ctx)
 				}
 
-				// Start metrics persister for default controller (GH-728)
-				if store != nil && autopilotController != nil {
-					metricsPersister := autopilot.NewMetricsPersister(autopilotController, store)
+				// Start metrics persister over the fleet-wide aggregate (GH-728, GH-4068)
+				if store != nil && aggregateMetrics != nil {
+					metricsPersister := autopilot.NewMetricsPersister(aggregateMetrics, store)
 					go metricsPersister.Run(ctx)
 				}
 

--- a/internal/autopilot/metrics_aggregate.go
+++ b/internal/autopilot/metrics_aggregate.go
@@ -1,0 +1,171 @@
+package autopilot
+
+import "time"
+
+// AggregateMetrics presents a single fleet-wide, read-only view over the
+// Metrics of every autopilot Controller in multi-repo polling mode. GH-929
+// creates one Controller — and one Metrics — per configured repo, and live
+// recording is correctly scoped to each controller's own Metrics. But the
+// /metrics Prometheus endpoint, MetricsAlerter, and MetricsPersister each
+// need exactly ONE view across all of them; previously they read only the
+// single default-repo controller, so PR activity recorded on any
+// projects-map controller never reached them (GH-4068).
+//
+// Snapshot() and HistogramSnapshot() recompute the merge on every call
+// instead of caching, mirroring Metrics' own read-on-demand Snapshot.
+type AggregateMetrics struct {
+	controllers []*Controller
+}
+
+// NewAggregateMetrics builds an AggregateMetrics over the given controllers.
+// Order does not matter — every merge below is commutative (sum or concat).
+func NewAggregateMetrics(controllers []*Controller) *AggregateMetrics {
+	return &AggregateMetrics{controllers: controllers}
+}
+
+// Snapshot returns a merged snapshot: counters and per-stage gauge buckets
+// sum across every controller; SuccessRate and the histogram averages are
+// recomputed from the merged totals/samples rather than averaged
+// per-controller, so the weighting stays correct.
+func (a *AggregateMetrics) Snapshot() MetricsSnapshot {
+	snap := MetricsSnapshot{
+		IssuesProcessed:            make(map[string]int64),
+		APIErrors:                  make(map[string]int64),
+		LabelCleanups:              make(map[string]int64),
+		ApprovalPersistMisses:      make(map[string]int64),
+		TokensConsumed:             make(map[tokenKey]int64),
+		ExecutionCostUSD:           make(map[string]float64),
+		ExecutionsByResult:         make(map[execKey]int64),
+		PollerSkipped:              make(map[pollerSkipKey]int64),
+		PollerDispatched:           make(map[string]int64),
+		PollerDeferredScopeOverlap: make(map[string]int64),
+		OrphanPRsRegistered:        make(map[string]int64),
+		ActivePRsByStage:           make(map[PRStage]int),
+		SnapshotAt:                 time.Now(),
+	}
+
+	for _, c := range a.controllers {
+		if c == nil {
+			continue
+		}
+		s := c.Metrics().Snapshot()
+
+		for k, v := range s.IssuesProcessed {
+			snap.IssuesProcessed[k] += v
+		}
+		snap.PRsMerged += s.PRsMerged
+		snap.PRsFailed += s.PRsFailed
+		snap.PRsConflicting += s.PRsConflicting
+		snap.CircuitBreakerTrips += s.CircuitBreakerTrips
+		for k, v := range s.APIErrors {
+			snap.APIErrors[k] += v
+		}
+		for k, v := range s.LabelCleanups {
+			snap.LabelCleanups[k] += v
+		}
+		for k, v := range s.ApprovalPersistMisses {
+			snap.ApprovalPersistMisses[k] += v
+		}
+		for k, v := range s.TokensConsumed {
+			snap.TokensConsumed[k] += v
+		}
+		for k, v := range s.ExecutionCostUSD {
+			snap.ExecutionCostUSD[k] += v
+		}
+		for k, v := range s.ExecutionsByResult {
+			snap.ExecutionsByResult[k] += v
+		}
+		for k, v := range s.PollerSkipped {
+			snap.PollerSkipped[k] += v
+		}
+		for k, v := range s.PollerDispatched {
+			snap.PollerDispatched[k] += v
+		}
+		for k, v := range s.PollerDeferredScopeOverlap {
+			snap.PollerDeferredScopeOverlap[k] += v
+		}
+		for k, v := range s.OrphanPRsRegistered {
+			snap.OrphanPRsRegistered[k] += v
+		}
+		snap.DuplicateRegistrationsSkipped += s.DuplicateRegistrationsSkipped
+		for k, v := range s.ActivePRsByStage {
+			snap.ActivePRsByStage[k] += v
+		}
+		snap.QueueDepth += s.QueueDepth
+		snap.FailedQueueDepth += s.FailedQueueDepth
+		snap.APIErrorRate += s.APIErrorRate
+	}
+
+	snap.TotalActivePRs = sumStageMap(snap.ActivePRsByStage)
+
+	var totalIssues int64
+	for _, v := range snap.IssuesProcessed {
+		totalIssues += v
+	}
+	if totalIssues > 0 {
+		snap.SuccessRate = float64(snap.IssuesProcessed["success"]) / float64(totalIssues)
+	}
+
+	hist := a.HistogramSnapshot()
+	snap.AvgPRTimeToMerge = avgDuration(hist.PRTimeToMerge)
+	snap.AvgCIWaitDuration = avgDuration(hist.CIWaitDurations)
+	snap.AvgExecutionDuration = avgDuration(hist.ExecutionDurations)
+
+	return snap
+}
+
+// HistogramSnapshot concatenates raw duration samples across every controller.
+func (a *AggregateMetrics) HistogramSnapshot() HistogramData {
+	var hist HistogramData
+	for _, c := range a.controllers {
+		if c == nil {
+			continue
+		}
+		h := c.Metrics().HistogramSnapshot()
+		hist.PRTimeToMerge = append(hist.PRTimeToMerge, h.PRTimeToMerge...)
+		hist.CIWaitDurations = append(hist.CIWaitDurations, h.CIWaitDurations...)
+		hist.ExecutionDurations = append(hist.ExecutionDurations, h.ExecutionDurations...)
+	}
+	return hist
+}
+
+// ActivePRs concatenates the live PRState of every aggregated controller.
+// Used by MetricsAlerter for fleet-wide stuck-PR detection (GH-4068).
+func (a *AggregateMetrics) ActivePRs() []*PRState {
+	var all []*PRState
+	for _, c := range a.controllers {
+		if c == nil {
+			continue
+		}
+		all = append(all, c.GetActivePRs()...)
+	}
+	return all
+}
+
+// LastProgressAt returns the most recent progress timestamp across every
+// controller — the fleet is only considered stalled once EVERY repo has
+// gone quiet, not just the first one checked.
+func (a *AggregateMetrics) LastProgressAt() time.Time {
+	var latest time.Time
+	for _, c := range a.controllers {
+		if c == nil {
+			continue
+		}
+		if t := c.GetLastProgressAt(); t.After(latest) {
+			latest = t
+		}
+	}
+	return latest
+}
+
+// RepoNames returns "owner/repo" for every aggregated controller.
+func (a *AggregateMetrics) RepoNames() []string {
+	names := make([]string, 0, len(a.controllers))
+	for _, c := range a.controllers {
+		if c == nil {
+			continue
+		}
+		names = append(names, c.repoKey())
+	}
+	return names
+}

--- a/internal/autopilot/metrics_aggregate_test.go
+++ b/internal/autopilot/metrics_aggregate_test.go
@@ -1,0 +1,86 @@
+package autopilot
+
+import (
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+func newTestControllerForAggregate(t *testing.T, owner, repo string) *Controller {
+	t.Helper()
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	return NewController(DefaultConfig(), ghClient, nil, owner, repo)
+}
+
+// TestAggregateMetrics_PRMergedOnNonDefaultController is a regression test
+// for GH-4068: recording a merge on a projects-map controller (not the
+// backwards-compat "default" one) must still surface in the fleet-wide
+// aggregate that /metrics, MetricsAlerter, and MetricsPersister read.
+func TestAggregateMetrics_PRMergedOnNonDefaultController(t *testing.T) {
+	defaultController := newTestControllerForAggregate(t, "qf-studio", "pilot")
+	projectController := newTestControllerForAggregate(t, "qf-studio", "studio-sdk")
+
+	// PR activity recorded on the non-default (project) controller only.
+	projectController.Metrics().RecordPRMerged()
+
+	agg := NewAggregateMetrics([]*Controller{defaultController, projectController})
+	snap := agg.Snapshot()
+
+	if snap.PRsMerged < 1 {
+		t.Fatalf("expected aggregate pilot_prs_merged_total >= 1, got %d", snap.PRsMerged)
+	}
+	if snap.PRsMerged != 1 {
+		t.Errorf("expected exactly 1 merged PR summed across controllers, got %d", snap.PRsMerged)
+	}
+}
+
+// TestAggregateMetrics_ActivePRsSumAcrossControllers pins that
+// pilot_active_prs{stage} sums per-stage counts across every controller,
+// not just the default one (GH-4068).
+func TestAggregateMetrics_ActivePRsSumAcrossControllers(t *testing.T) {
+	c1 := newTestControllerForAggregate(t, "qf-studio", "pilot")
+	c2 := newTestControllerForAggregate(t, "qf-studio", "studio-sdk")
+
+	c1.Metrics().UpdateActivePRs([]*PRState{
+		{PRNumber: 1, Stage: StageWaitingCI},
+		{PRNumber: 2, Stage: StageWaitingCI},
+	})
+	c2.Metrics().UpdateActivePRs([]*PRState{
+		{PRNumber: 3, Stage: StageWaitingCI},
+		{PRNumber: 4, Stage: StageMerging},
+	})
+
+	agg := NewAggregateMetrics([]*Controller{c1, c2})
+	snap := agg.Snapshot()
+
+	if got := snap.ActivePRsByStage[StageWaitingCI]; got != 3 {
+		t.Errorf("expected 3 active PRs in stage %q summed across controllers, got %d", StageWaitingCI, got)
+	}
+	if got := snap.ActivePRsByStage[StageMerging]; got != 1 {
+		t.Errorf("expected 1 active PR in stage %q, got %d", StageMerging, got)
+	}
+	if snap.TotalActivePRs != 4 {
+		t.Errorf("expected TotalActivePRs=4, got %d", snap.TotalActivePRs)
+	}
+}
+
+// TestAggregateMetrics_HydrationCountedOnce pins the GH-4068 hydration
+// invariant: the store-lifetime baseline is applied to exactly one
+// controller's Metrics (the designated "default" hydration owner), and the
+// aggregate must reflect it exactly once — not doubled just because there
+// are multiple controllers being summed.
+func TestAggregateMetrics_HydrationCountedOnce(t *testing.T) {
+	hydratedController := newTestControllerForAggregate(t, "qf-studio", "pilot")
+	otherController := newTestControllerForAggregate(t, "qf-studio", "studio-sdk")
+
+	// Simulate HydrateFromStore landing on the designated owner only.
+	hydratedController.Metrics().HydrateIssuesProcessed("success", 1723)
+
+	agg := NewAggregateMetrics([]*Controller{hydratedController, otherController})
+	snap := agg.Snapshot()
+
+	if got := snap.IssuesProcessed["success"]; got != 1723 {
+		t.Errorf("expected hydrated baseline counted exactly once (1723), got %d", got)
+	}
+}

--- a/internal/autopilot/metrics_alerter.go
+++ b/internal/autopilot/metrics_alerter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -88,17 +89,26 @@ func (t *tripTracker) recentTripCount() int {
 // MetricsAlerter periodically evaluates autopilot metrics and sends events
 // to the alerts engine for rule evaluation.
 type MetricsAlerter struct {
-	controller  *Controller
+	source      *AggregateMetrics
 	engine      *alerts.Engine
 	interval    time.Duration
 	log         *slog.Logger
 	tripTracker *tripTracker
+
+	// Fleet-level deadlock bookkeeping (GH-4068). Previously delegated to a
+	// single Controller's lastProgressAt/deadlockAlertSent fields, which only
+	// make sense per-repo; multi-controller mode tracks the same state here,
+	// keyed off the most recent progress across every aggregated controller
+	// (see evaluate()).
+	lastSeenProgressAt time.Time
+	deadlockAlertSent  bool
 }
 
-// NewMetricsAlerter creates a new MetricsAlerter.
-func NewMetricsAlerter(controller *Controller, engine *alerts.Engine) *MetricsAlerter {
+// NewMetricsAlerter creates a new MetricsAlerter over an aggregate metrics
+// source spanning every autopilot controller (GH-4068).
+func NewMetricsAlerter(source *AggregateMetrics, engine *alerts.Engine) *MetricsAlerter {
 	return &MetricsAlerter{
-		controller:  controller,
+		source:      source,
 		engine:      engine,
 		interval:    30 * time.Second,
 		log:         slog.Default().With("component", "metrics-alerter"),
@@ -128,14 +138,14 @@ func (ma *MetricsAlerter) Run(ctx context.Context) {
 
 // evaluate takes a metrics snapshot and emits an autopilot_metrics event.
 func (ma *MetricsAlerter) evaluate() {
-	snap := ma.controller.Metrics().Snapshot()
+	snap := ma.source.Snapshot()
 
 	// Calculate stuck PRs (in waiting_ci)
 	var prStuckCount int
 	var prMaxWaitMin float64
 	var lastStuckPR *PRState
 
-	activePRs := ma.controller.GetActivePRs()
+	activePRs := ma.source.ActivePRs()
 	for _, pr := range activePRs {
 		if pr.Stage == StageWaitingCI && !pr.CIWaitStartedAt.IsZero() {
 			waitMin := time.Since(pr.CIWaitStartedAt).Minutes()
@@ -147,10 +157,16 @@ func (ma *MetricsAlerter) evaluate() {
 		}
 	}
 
-	// GH-849: Deadlock detection - time since last progress
-	lastProgressAt := ma.controller.GetLastProgressAt()
+	// GH-849/GH-4068: Deadlock detection - time since last progress across
+	// every aggregated controller. The sent-flag resets the moment ANY
+	// repo makes progress again (lastProgressAt advances).
+	lastProgressAt := ma.source.LastProgressAt()
+	if lastProgressAt.After(ma.lastSeenProgressAt) {
+		ma.lastSeenProgressAt = lastProgressAt
+		ma.deadlockAlertSent = false
+	}
 	noProgressMin := time.Since(lastProgressAt).Minutes()
-	deadlockAlertSent := ma.controller.IsDeadlockAlertSent()
+	deadlockAlertSent := ma.deadlockAlertSent
 
 	// Find the last known state for deadlock context
 	lastKnownState := ""
@@ -171,7 +187,7 @@ func (ma *MetricsAlerter) evaluate() {
 		Type:      alerts.EventTypeAutopilotMetrics,
 		TaskID:    "autopilot",
 		TaskTitle: "Autopilot Health Check",
-		Project:   fmt.Sprintf("%s/%s", ma.controller.owner, ma.controller.repo),
+		Project:   ma.projectLabel(),
 		Metadata: map[string]string{
 			"failed_queue_depth":    fmt.Sprintf("%d", snap.FailedQueueDepth),
 			"circuit_breaker_trips": fmt.Sprintf("%d", snap.CircuitBreakerTrips),
@@ -196,8 +212,17 @@ func (ma *MetricsAlerter) evaluate() {
 	// This prevents repeated alerts until progress resumes.
 	// Default threshold is 1 hour (60 minutes).
 	if noProgressMin >= 60 && !deadlockAlertSent && len(activePRs) > 0 {
-		ma.controller.MarkDeadlockAlertSent()
+		ma.deadlockAlertSent = true
 	}
+}
+
+// projectLabel joins every aggregated repo's "owner/repo" for alert context.
+func (ma *MetricsAlerter) projectLabel() string {
+	names := ma.source.RepoNames()
+	if len(names) == 0 {
+		return "unknown"
+	}
+	return strings.Join(names, ",")
 }
 
 // RecordCircuitBreakerTrip records a circuit breaker trip and checks if escalation is needed.
@@ -236,7 +261,7 @@ func (ma *MetricsAlerter) emitEscalationAlert(tripCount int, lastPR int, lastRea
 		Type:      alerts.EventTypeEscalation,
 		TaskID:    "autopilot-circuit-breaker",
 		TaskTitle: "Autopilot Circuit Breaker Escalation",
-		Project:   fmt.Sprintf("%s/%s", ma.controller.owner, ma.controller.repo),
+		Project:   ma.projectLabel(),
 		Metadata: map[string]string{
 			"trips_in_hour":        fmt.Sprintf("%d", tripCount),
 			"escalation_threshold": fmt.Sprintf("%d", ma.tripTracker.escalationThreshold),

--- a/internal/autopilot/metrics_alerter_test.go
+++ b/internal/autopilot/metrics_alerter_test.go
@@ -130,7 +130,7 @@ func TestMetricsAlerter_RecordCircuitBreakerTrip_NoEscalation(t *testing.T) {
 		repo:  "repo",
 	}
 
-	ma := NewMetricsAlerter(controller, engine)
+	ma := NewMetricsAlerter(NewAggregateMetrics([]*Controller{controller}), engine)
 
 	// Record 2 trips - should not trigger escalation
 	ma.RecordCircuitBreakerTrip(1, "failure 1")
@@ -155,7 +155,7 @@ func TestMetricsAlerter_RecordCircuitBreakerTrip_Escalation(t *testing.T) {
 		repo:  "repo",
 	}
 
-	ma := NewMetricsAlerter(controller, engine)
+	ma := NewMetricsAlerter(NewAggregateMetrics([]*Controller{controller}), engine)
 
 	// Record 3 trips - should trigger escalation
 	ma.RecordCircuitBreakerTrip(1, "failure 1")

--- a/internal/autopilot/metrics_persister.go
+++ b/internal/autopilot/metrics_persister.go
@@ -10,22 +10,23 @@ import (
 
 // MetricsPersister periodically saves metrics snapshots to SQLite for history.
 type MetricsPersister struct {
-	controller *Controller
-	store      *memory.Store
-	interval   time.Duration
-	retention  time.Duration // How long to keep snapshots
-	log        *slog.Logger
+	source    *AggregateMetrics
+	store     *memory.Store
+	interval  time.Duration
+	retention time.Duration // How long to keep snapshots
+	log       *slog.Logger
 }
 
-// NewMetricsPersister creates a new MetricsPersister.
+// NewMetricsPersister creates a new MetricsPersister over an aggregate
+// metrics source spanning every autopilot controller (GH-4068).
 // Saves snapshots every 5 minutes and retains 7 days of history.
-func NewMetricsPersister(controller *Controller, store *memory.Store) *MetricsPersister {
+func NewMetricsPersister(source *AggregateMetrics, store *memory.Store) *MetricsPersister {
 	return &MetricsPersister{
-		controller: controller,
-		store:      store,
-		interval:   5 * time.Minute,
-		retention:  7 * 24 * time.Hour,
-		log:        slog.Default().With("component", "metrics-persister"),
+		source:    source,
+		store:     store,
+		interval:  5 * time.Minute,
+		retention: 7 * 24 * time.Hour,
+		log:       slog.Default().With("component", "metrics-persister"),
 	}
 }
 
@@ -53,7 +54,7 @@ func (mp *MetricsPersister) Run(ctx context.Context) {
 }
 
 func (mp *MetricsPersister) persist() {
-	snap := mp.controller.Metrics().Snapshot()
+	snap := mp.source.Snapshot()
 
 	// Sum up API errors total
 	var apiErrorsTotal int64


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4068.

Closes #4068

## Changes

GitHub Issue GH-4068: fix(metrics): wire Prometheus export/hydration/alerting/persistence across ALL autopilot controllers — not just the default (TASK-390)

# fix(metrics): wire Prometheus export/hydration/alerting/persistence across ALL autopilot controllers — not just the default (TASK-390)

**Status**: Authored, pending dispatch
**Created**: 2026-07-08
**Priority**: HIGH — every PR-family metric on `:9093` reads zero fleet-wide
**Assignee**: Pilot

## Context

Every autopilot `Controller` constructs its **own** `*autopilot.Metrics` (`internal/autopilot/controller.go:357`). `runPollingMode` builds one controller per project (`cmd/pilot/main.go:1760-1769`) plus the backward-compat default (`autopilotController`, `main.go:1650`). Live recording is correctly per-repo — merges/failures/active-PR gauges land on the matching controller's `Metrics` (`main.go:2439-2461`).

But the export surface is wired to **only the default controller**:

- `gwServer.SetMetricsSource(autopilotController.Metrics())` — `main.go:1945`
- `HydrateFromStore(..., autopilotController.Metrics())` — `main.go:1954` (and `:1169`)
- `MetricsAlerter` — `main.go:2678-2681`
- `MetricsPersister` — `main.go:2684-2687`

Result: PR activity recorded on any projects-map controller never reaches `/metrics`. **Live repro on our own deployment:** `qf-studio/pilot` appears in BOTH `adapters.github.repo` (default) and `projects[]` — the projects-loop controller does the real work while `:9093` exports the idle default one. Observed 2026-07-08: `pilot_prs_merged_total`, `_failed_total`, `_conflicting_total`, `pilot_active_prs*`, `pilot_pr_time_to_merge_seconds_*` ALL zero across a session with 1,723 successful executions and a full day of autopilot merges (v2.233.x).

**This exact bug class was already fixed once** for the alerts engine — GH-3954, `main.go:2713-2721`: *"wire the alerts engine into every controller, not just the default one."* The Prometheus exporter, hydrator, alerter, and persister never got the same fix.

## Fix

1. Introduce a small aggregating `MetricsSource` (the `PrometheusExporter` currently takes exactly one source): it iterates the default controller + every entry in `autopilotControllers` and sums/merges their `Snapshot()`s (counters sum; `active_prs` gauges sum per stage; time-to-merge histograms merge observations).
2. Wire `gwServer.SetMetricsSource`, `MetricsAlerter`, and `MetricsPersister` to the aggregate (mirror the GH-3954 pattern at `main.go:2713-2721`).
3. `HydrateFromStore`: hydrate ONCE into a designated baseline (the aggregate view must not double-count if hydration lands on the default controller while per-repo controllers also hydrate) — pick one owner for the lifetime baseline and document it.
4. Keep per-controller `Metrics` objects intact — per-repo scoping of live recording is correct and must not regress (see `main.go:2439-2461`).

## Acceptance Criteria

- [ ] Unit test: two controllers, PR merged on the non-default one → aggregate snapshot (and thus `/metrics`) shows `pilot_prs_merged_total ≥ 1`.
- [ ] Unit test: `pilot_active_prs{stage}` sums across controllers each tick.
- [ ] Hydration lands exactly once in the aggregate (no double-count with per-controller baselines).
- [ ] `MetricsAlerter`/`MetricsPersister` consume the aggregate; alert metadata `success_rate`/`total_active_prs` (`metrics_alerter.go:181-182`) reflect all projects.
- [ ] No change to per-repo live recording paths.
- [ ] Full short suite + lint green.

## Constraints

- Single PR. Do not decompose.
- Do NOT add PR-family hydration here — that is #4029's re-scoped job, explicitly sequenced AFTER this fix (hydrating before this fix papers over the silo with a plausible non-zero number on the wrong object).

## Refs

- Sibling: TASK-391 (`RecordPRConflicting` dead call site), TASK-392 (`success_rate` semantics), #4029 (re-scoped: PR-family hydration from `execution_events`, blocked by this task's issue)
- Prior art: GH-3954 (`main.go:2713-2721`), GH-4041/PR #4043 (baseline hydration, deliberately skipped PR family)
- Consumers currently lied to: `deploy/grafana/grafterm-pilot.json` "Active PRs" widget; grot dashboards scraping `:9093`