### PR TITLE
fix(autopilot): persist PR title so dashboard rows survive restart TASK-390

### DIFF
--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -130,6 +130,10 @@ func (s *StateStore) migrate() error {
 		// "label:<name>" | "train:<RFC3339>") — persisted so a scope-release
 		// carrier's identity survives a restart via LoadAllPRStates.
 		`ALTER TABLE autopilot_pr_state ADD COLUMN scope_key TEXT NOT NULL DEFAULT ''`,
+		// TASK-390: persist the PR title. Restored post-merge states (tag/
+		// release stages) never re-fetch the PR from GitHub, so without this
+		// their dashboard rows render with a blank title forever.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN pr_title TEXT NOT NULL DEFAULT ''`,
 	}
 
 	for _, m := range migrations {
@@ -383,6 +387,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			post_merge_ci_started_at DATETIME,
 			rebase_attempts INTEGER NOT NULL DEFAULT 0,
 			scope_key TEXT NOT NULL DEFAULT '',
+			pr_title TEXT NOT NULL DEFAULT '',
 			PRIMARY KEY (repo, pr_number)
 		)
 	`); err != nil {
@@ -395,7 +400,8 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			merge_attempts, error, created_at, updated_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
+			pr_title
 		)
 		SELECT
 			pr_number, repo, pr_url, issue_number, branch_name, head_sha,
@@ -403,7 +409,8 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			merge_attempts, error, created_at, updated_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
+			pr_title
 		FROM autopilot_pr_state
 	`); err != nil {
 		return fmt.Errorf("copy autopilot_pr_state rows: %w", err)
@@ -546,8 +553,9 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			merge_attempts, error, created_at, updated_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
+			pr_title
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(repo, pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -569,7 +577,8 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			post_merge_sha = excluded.post_merge_sha,
 			post_merge_ci_started_at = excluded.post_merge_ci_started_at,
 			rebase_attempts = excluded.rebase_attempts,
-			scope_key = excluded.scope_key
+			scope_key = excluded.scope_key,
+			pr_title = excluded.pr_title
 	`,
 		pr.PRNumber, repo, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
@@ -578,6 +587,7 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 		pr.ReleaseVersion, string(pr.ReleaseBumpType), pr.MergeNotificationPosted,
 		pr.ApprovalRequestID, pr.ApprovalDecision, nullTime(pr.ApprovalRequestedAt),
 		pr.PostMergeSHA, nullTime(pr.PostMergeCIStartedAt), pr.RebaseAttempts, pr.ScopeKey,
+		pr.PRTitle,
 	)
 	return err
 }
@@ -591,7 +601,8 @@ func (s *StateStore) GetPRState(repo string, prNumber int) (*PRState, error) {
 			merge_attempts, error, created_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
+			pr_title
 		FROM autopilot_pr_state WHERE repo = ? AND pr_number = ?
 	`, repo, prNumber)
 
@@ -614,7 +625,8 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			merge_attempts, error, created_at,
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
-			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key
+			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
+			pr_title
 		FROM autopilot_pr_state WHERE repo = ?
 	`, repo)
 	if err != nil {
@@ -635,6 +647,7 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
 			&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
 			&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts, &pr.ScopeKey,
+			&pr.PRTitle,
 		); err != nil {
 			return nil, err
 		}
@@ -889,6 +902,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
 		&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
 		&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts, &pr.ScopeKey,
+		&pr.PRTitle,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/autopilot/state_store_test.go
+++ b/internal/autopilot/state_store_test.go
@@ -33,6 +33,7 @@ func TestStateStore_SaveAndLoadPRState(t *testing.T) {
 		IssueNumber:     10,
 		BranchName:      "pilot/GH-10",
 		HeadSHA:         "abc123def456",
+		PRTitle:         "feat(gateway): add webhook handler",
 		Stage:           StageWaitingCI,
 		CIStatus:        CIRunning,
 		LastChecked:     time.Now().Truncate(time.Second),
@@ -72,6 +73,11 @@ func TestStateStore_SaveAndLoadPRState(t *testing.T) {
 	}
 	if loaded.HeadSHA != "abc123def456" {
 		t.Errorf("HeadSHA = %s, want abc123def456", loaded.HeadSHA)
+	}
+	// TASK-390: pr_title survives the restart round-trip — post-merge stages
+	// never re-fetch the PR, so a lost title stays lost on the dashboard.
+	if loaded.PRTitle != pr.PRTitle {
+		t.Errorf("PRTitle = %q, want %q", loaded.PRTitle, pr.PRTitle)
 	}
 	if loaded.Stage != StageWaitingCI {
 		t.Errorf("Stage = %s, want %s", loaded.Stage, StageWaitingCI)

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -217,10 +217,18 @@ func renderAutopilotRow(pr *autopilot.PRState, failures, maxFailures, iw int) []
 		titleWidth = 10
 	}
 
+	// Title fallback: states restored from SQLite before pr_title was
+	// persisted (or before the poll backfill runs) identify by branch name
+	// instead of a blank flex column.
+	title := pr.PRTitle
+	if title == "" {
+		title = pr.BranchName
+	}
+
 	row := fmt.Sprintf("  %s %-6s  %s  %s %s  %s",
 		glyphStyle.Render(glyph),
 		fmt.Sprintf("#%d", pr.PRNumber),
-		padOrTruncate(pr.PRTitle, titleWidth),
+		padOrTruncate(title, titleWidth),
 		segmentMeter(pos, len(autopilotNodes), len(autopilotNodes), hex),
 		dimStyle.Render(padOrTruncate(label, autopilotStageLabelWidth)),
 		dimStyle.Render(fmt.Sprintf("%6s", formatDurationShort(time.Since(pr.CreatedAt)))),


### PR DESCRIPTION
## Bug

After daemon restarts, autopilot panel rows render with a blank title column:

```
● #4072                                   ■■■■■ release     55m
```

Two-layer cause:
1. `autopilot_pr_state` has no `pr_title` column — titles lived only in memory, so every restart restored blank-titled states.
2. The poll-cycle backfill (`controller.go` — copies `ghPR.Title` when empty) only fires for stages that still fetch the PR. Post-merge stages (`tag`/`release`) never re-fetch → blank forever.

## Fix

- Persist `pr_title`: ALTER migration, the GH-3903 rebuild schema (fresh DBs recreate the table after the ALTERs run — same treatment `scope_key` got), and save/scan in `SavePRState` / `GetPRState` / `LoadAllPRStates`.
- Dashboard row falls back to `BranchName` while the title is missing (pre-migration rows, pre-backfill states) — never a blank flex column.

## Testing

- Round-trip test asserts `PRTitle` survives save → restore.
- Full autopilot + dashboard suites, lint 0 issues. Cross-repo migration tests exercise the rebuilt schema on fresh DBs.