### PR TITLE
fix(metrics): aggregate Prometheus export/hydration/alerting/persistence across all autopilot controllers

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1938,23 +1938,41 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 
 	// GH-1662: Start gateway in background so desktop app can reach /health
 	var gwServer *gateway.Server // hoisted so TASK-332 alert-metrics wiring can run after alerts engine is created
+	// GH-4068: aggregate every controller's Metrics (default + one per
+	// project, not just the backward-compat default) so /metrics, the
+	// metrics alerter, and the metrics persister all reflect fleet-wide PR
+	// activity. Hoisted so the alerter/persister wiring further down (after
+	// pollers start) can reuse it. autopilotControllers always contains the
+	// default controller too (see assignment above), so ranging over it
+	// alone covers both.
+	var fleetMetrics []*autopilot.Metrics
+	for _, c := range autopilotControllers {
+		fleetMetrics = append(fleetMetrics, c.Metrics())
+	}
+	autopilotMetricsAggregate := autopilot.NewAggregateMetrics(fleetMetrics...)
 	if !noGateway && cfg.Gateway != nil {
 		gwServer = gateway.NewServer(cfg.Gateway)
+
 		if autopilotController != nil {
 			gwServer.SetAutopilotProvider(&autopilotProviderAdapter{controller: autopilotController})
-			gwServer.SetMetricsSource(autopilotController.Metrics())
 			// GH-2855: wire token/cost/execution counters into executor
 			runner.SetMetricsRecorder(autopilotController.Metrics())
 			// GH-4041: restore Prometheus counter baselines from the store's
 			// lifetime execution history before the /metrics handler starts
 			// serving scrapes below, so external dashboards don't observe a
 			// reset-to-zero on restart. Fail loud rather than silently start
-			// with zero baselines.
+			// with zero baselines. The default controller is the sole
+			// hydration owner (GH-4068) — hydrating any other controller's
+			// Metrics would double-count once autopilotMetricsAggregate sums
+			// them below.
 			if store != nil {
 				if hydrateErr := autopilot.HydrateFromStore(ctx, store, autopilotController.Metrics()); hydrateErr != nil {
 					return fmt.Errorf("failed to hydrate metrics from store: %w", hydrateErr)
 				}
 			}
+		}
+		if len(fleetMetrics) > 0 {
+			gwServer.SetMetricsSource(autopilotMetricsAggregate)
 		}
 
 		// GH-2080: Wire PR review webhook events to autopilot controller in polling mode
@@ -2674,15 +2692,23 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					fmt.Printf("● autopilot enabled · %s environment (%d repos)\n", cfg.Orchestrator.Autopilot.Environment, len(autopilotControllers))
 				}
 
-				// Start metrics alerter for default controller (GH-728)
+				// Start metrics alerter for default controller (GH-728). The
+				// alerter's stuck-PR/deadlock detection stays scoped to the
+				// default controller (inherently per-repo), but its
+				// success_rate/total_active_prs/queue_depth alert metadata is
+				// widened to the fleet-wide aggregate (GH-4068).
 				if alertsEngine != nil && autopilotController != nil {
 					metricsAlerter := autopilot.NewMetricsAlerter(autopilotController, alertsEngine)
+					metricsAlerter.SetMetricsSource(autopilotMetricsAggregate)
 					go metricsAlerter.Run(ctx)
 				}
 
-				// Start metrics persister for default controller (GH-728)
+				// Start metrics persister for default controller (GH-728).
+				// Persisted snapshots reflect the fleet-wide aggregate, not
+				// just the default controller (GH-4068).
 				if store != nil && autopilotController != nil {
 					metricsPersister := autopilot.NewMetricsPersister(autopilotController, store)
+					metricsPersister.SetMetricsSource(autopilotMetricsAggregate)
 					go metricsPersister.Run(ctx)
 				}
 

--- a/internal/autopilot/metrics_aggregate.go
+++ b/internal/autopilot/metrics_aggregate.go
@@ -1,0 +1,163 @@
+package autopilot
+
+import "time"
+
+// SnapshotSource is satisfied by *Metrics and *AggregateMetrics — anything
+// that can produce a MetricsSnapshot for alerting/persistence/export
+// purposes (GH-4068).
+type SnapshotSource interface {
+	Snapshot() MetricsSnapshot
+}
+
+// AggregateMetrics merges Snapshot()/HistogramSnapshot() calls across every
+// autopilot Controller's *Metrics into one fleet-wide view.
+//
+// GH-4068: every Controller (default + one per projects-map entry, see
+// cmd/pilot/main.go) owns its own *Metrics, and live recording correctly
+// scopes merges/failures/active-PR gauges to the matching controller. But
+// the Prometheus exporter, hydrator, alerter, and persister were all wired
+// to exactly one *Metrics (the backward-compat default controller), so PR
+// activity recorded on any other controller never reached /metrics.
+// AggregateMetrics is the single source those four consumers now share.
+//
+// Counters sum across sources. ActivePRsByStage gauges sum per stage.
+// Histogram samples concatenate so bucket/sum/count reflect the whole
+// fleet, and Avg* fields are recomputed from the concatenated samples
+// (an average-of-averages would be wrong when sources have different
+// sample counts). SuccessRate/IssueLevelSuccessRate are likewise
+// recomputed from the merged counters/gauges, not summed.
+//
+// Store-hydrated lifetime baselines (HydrateFromStore) and the
+// issue-level ship/attempt gauges are owned by exactly one controller —
+// the default, see the HydrateFromStore call site in main.go — so summing
+// the other (zero-valued for these fields) controllers alongside it does
+// not double-count.
+type AggregateMetrics struct {
+	sources []*Metrics
+}
+
+// NewAggregateMetrics builds a fleet-wide view over every controller's
+// Metrics. Nil entries are ignored so callers can pass results of a lookup
+// map without filtering first.
+func NewAggregateMetrics(sources ...*Metrics) *AggregateMetrics {
+	return &AggregateMetrics{sources: sources}
+}
+
+// Snapshot returns a merged, point-in-time copy of all sources' metrics.
+func (a *AggregateMetrics) Snapshot() MetricsSnapshot {
+	agg := MetricsSnapshot{
+		IssuesProcessed:            make(map[string]int64),
+		APIErrors:                  make(map[string]int64),
+		LabelCleanups:              make(map[string]int64),
+		ApprovalPersistMisses:      make(map[string]int64),
+		TokensConsumed:             make(map[tokenKey]int64),
+		ExecutionCostUSD:           make(map[string]float64),
+		ExecutionsByResult:         make(map[execKey]int64),
+		PollerSkipped:              make(map[pollerSkipKey]int64),
+		PollerDispatched:           make(map[string]int64),
+		PollerDeferredScopeOverlap: make(map[string]int64),
+		OrphanPRsRegistered:        make(map[string]int64),
+		ActivePRsByStage:           make(map[PRStage]int),
+		SnapshotAt:                 time.Now(),
+	}
+
+	for _, m := range a.sources {
+		if m == nil {
+			continue
+		}
+		s := m.Snapshot()
+
+		for k, v := range s.IssuesProcessed {
+			agg.IssuesProcessed[k] += v
+		}
+		agg.PRsMerged += s.PRsMerged
+		agg.PRsFailed += s.PRsFailed
+		agg.PRsConflicting += s.PRsConflicting
+		agg.CircuitBreakerTrips += s.CircuitBreakerTrips
+		for k, v := range s.APIErrors {
+			agg.APIErrors[k] += v
+		}
+		for k, v := range s.LabelCleanups {
+			agg.LabelCleanups[k] += v
+		}
+		for k, v := range s.ApprovalPersistMisses {
+			agg.ApprovalPersistMisses[k] += v
+		}
+		for k, v := range s.TokensConsumed {
+			agg.TokensConsumed[k] += v
+		}
+		for k, v := range s.ExecutionCostUSD {
+			agg.ExecutionCostUSD[k] += v
+		}
+		for k, v := range s.ExecutionsByResult {
+			agg.ExecutionsByResult[k] += v
+		}
+		for k, v := range s.PollerSkipped {
+			agg.PollerSkipped[k] += v
+		}
+		for k, v := range s.PollerDispatched {
+			agg.PollerDispatched[k] += v
+		}
+		for k, v := range s.PollerDeferredScopeOverlap {
+			agg.PollerDeferredScopeOverlap[k] += v
+		}
+		for k, v := range s.OrphanPRsRegistered {
+			agg.OrphanPRsRegistered[k] += v
+		}
+		agg.DuplicateRegistrationsSkipped += s.DuplicateRegistrationsSkipped
+
+		for stage, count := range s.ActivePRsByStage {
+			agg.ActivePRsByStage[stage] += count
+		}
+		agg.QueueDepth += s.QueueDepth
+		agg.FailedQueueDepth += s.FailedQueueDepth
+		agg.IssuesShipped += s.IssuesShipped
+		agg.IssuesAttempted += s.IssuesAttempted
+
+		// Each source's APIErrorRate is already "errors in the last 5min / 5"
+		// for that source's independent error timestamps, so the fleet-wide
+		// rate is a plain sum, not an average.
+		agg.APIErrorRate += s.APIErrorRate
+	}
+
+	agg.TotalActivePRs = sumStageMap(agg.ActivePRsByStage)
+
+	hist := a.HistogramSnapshot()
+	agg.AvgPRTimeToMerge = avgDuration(hist.PRTimeToMerge)
+	agg.AvgCIWaitDuration = avgDuration(hist.CIWaitDurations)
+	agg.AvgExecutionDuration = avgDuration(hist.ExecutionDurations)
+
+	// Recompute success rate over the merged counters (TASK-392 semantics:
+	// rate_limited is excluded from the denominator).
+	total := int64(0)
+	for k, v := range agg.IssuesProcessed {
+		if k == "rate_limited" {
+			continue
+		}
+		total += v
+	}
+	if total > 0 {
+		agg.SuccessRate = float64(agg.IssuesProcessed["success"]) / float64(total)
+	}
+	if agg.IssuesAttempted > 0 {
+		agg.IssueLevelSuccessRate = float64(agg.IssuesShipped) / float64(agg.IssuesAttempted)
+	}
+
+	return agg
+}
+
+// HistogramSnapshot returns the concatenated raw duration samples across
+// every source.
+func (a *AggregateMetrics) HistogramSnapshot() HistogramData {
+	var out HistogramData
+	for _, m := range a.sources {
+		if m == nil {
+			continue
+		}
+		h := m.HistogramSnapshot()
+		out.PRTimeToMerge = append(out.PRTimeToMerge, h.PRTimeToMerge...)
+		out.CIWaitDurations = append(out.CIWaitDurations, h.CIWaitDurations...)
+		out.ExecutionDurations = append(out.ExecutionDurations, h.ExecutionDurations...)
+	}
+	return out
+}

--- a/internal/autopilot/metrics_aggregate_test.go
+++ b/internal/autopilot/metrics_aggregate_test.go
@@ -1,0 +1,135 @@
+package autopilot
+
+import (
+	"testing"
+	"time"
+)
+
+// TestAggregateMetrics_SumsCountersAcrossControllers reproduces the GH-4068
+// bug: a PR merged on a non-default (projects-map) controller must still
+// show up in the exported /metrics surface, which reads the aggregate.
+func TestAggregateMetrics_SumsCountersAcrossControllers(t *testing.T) {
+	defaultMetrics := NewMetrics()
+	otherMetrics := NewMetrics()
+
+	// PR merged only on the non-default controller's Metrics.
+	otherMetrics.RecordPRMerged()
+	otherMetrics.RecordPRMerged()
+	defaultMetrics.RecordPRFailed()
+
+	agg := NewAggregateMetrics(defaultMetrics, otherMetrics)
+	snap := agg.Snapshot()
+
+	if snap.PRsMerged < 1 {
+		t.Fatalf("expected aggregate pilot_prs_merged_total >= 1, got %d", snap.PRsMerged)
+	}
+	if snap.PRsMerged != 2 {
+		t.Errorf("expected aggregate PRsMerged=2 (summed across controllers), got %d", snap.PRsMerged)
+	}
+	if snap.PRsFailed != 1 {
+		t.Errorf("expected aggregate PRsFailed=1, got %d", snap.PRsFailed)
+	}
+}
+
+// TestAggregateMetrics_SumsActivePRsByStagePerTick verifies pilot_active_prs{stage}
+// sums across controllers on every scrape, not just at hydration/startup.
+func TestAggregateMetrics_SumsActivePRsByStagePerTick(t *testing.T) {
+	m1 := NewMetrics()
+	m2 := NewMetrics()
+
+	agg := NewAggregateMetrics(m1, m2)
+
+	m1.UpdateActivePRs([]*PRState{{Stage: StageWaitingCI}, {Stage: StageWaitingCI}})
+	m2.UpdateActivePRs([]*PRState{{Stage: StageWaitingCI}})
+
+	snap := agg.Snapshot()
+	if got := snap.ActivePRsByStage[StageWaitingCI]; got != 3 {
+		t.Fatalf("expected pilot_active_prs{stage=waiting_ci}=3 summed across controllers, got %d", got)
+	}
+	if snap.TotalActivePRs != 3 {
+		t.Errorf("expected TotalActivePRs=3, got %d", snap.TotalActivePRs)
+	}
+
+	// A second tick with changed gauges must reflect the new totals, not the
+	// first tick's — UpdateActivePRs replaces (not accumulates) per source.
+	m1.UpdateActivePRs([]*PRState{{Stage: StageWaitingCI}})
+	m2.UpdateActivePRs(nil)
+
+	snap = agg.Snapshot()
+	if got := snap.ActivePRsByStage[StageWaitingCI]; got != 1 {
+		t.Fatalf("expected pilot_active_prs{stage=waiting_ci}=1 after second tick, got %d", got)
+	}
+}
+
+// TestAggregateMetrics_HistogramMergesSamples verifies histogram samples
+// from every controller are concatenated so bucket/sum/count reflect the
+// whole fleet.
+func TestAggregateMetrics_HistogramMergesSamples(t *testing.T) {
+	m1 := NewMetrics()
+	m2 := NewMetrics()
+
+	m1.RecordPRTimeToMerge(10 * time.Minute)
+	m2.RecordPRTimeToMerge(20 * time.Minute)
+	m2.RecordPRTimeToMerge(30 * time.Minute)
+
+	agg := NewAggregateMetrics(m1, m2)
+	hist := agg.HistogramSnapshot()
+
+	if len(hist.PRTimeToMerge) != 3 {
+		t.Fatalf("expected 3 merged PRTimeToMerge samples, got %d", len(hist.PRTimeToMerge))
+	}
+
+	snap := agg.Snapshot()
+	wantAvg := (10*time.Minute + 20*time.Minute + 30*time.Minute) / 3
+	if snap.AvgPRTimeToMerge != wantAvg {
+		t.Errorf("expected AvgPRTimeToMerge=%v (recomputed from merged samples), got %v", wantAvg, snap.AvgPRTimeToMerge)
+	}
+}
+
+// TestAggregateMetrics_SuccessRateRecomputedFromMergedCounters guards against
+// naively averaging each controller's SuccessRate, which would be wrong when
+// controllers have different attempt volumes.
+func TestAggregateMetrics_SuccessRateRecomputedFromMergedCounters(t *testing.T) {
+	m1 := NewMetrics()
+	m2 := NewMetrics()
+
+	// m1: 1 success, 1 failed (50%). m2: 9 successes, 1 failed (90%).
+	m1.RecordIssueProcessed("success")
+	m1.RecordIssueProcessed("failed")
+	for i := 0; i < 9; i++ {
+		m2.RecordIssueProcessed("success")
+	}
+	m2.RecordIssueProcessed("failed")
+
+	agg := NewAggregateMetrics(m1, m2)
+	snap := agg.Snapshot()
+
+	// Fleet-wide: 10 successes, 2 failed => 10/12, not (0.5+0.9)/2=0.7.
+	const want = float64(10) / float64(12)
+	if diff := snap.SuccessRate - want; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("expected recomputed SuccessRate=%.4f, got %.4f", want, snap.SuccessRate)
+	}
+}
+
+// TestAggregateMetrics_NilSourcesIgnored ensures a nil *Metrics entry (e.g.
+// from an unpopulated map lookup) doesn't panic.
+func TestAggregateMetrics_NilSourcesIgnored(t *testing.T) {
+	m1 := NewMetrics()
+	m1.RecordPRMerged()
+
+	agg := NewAggregateMetrics(m1, nil)
+	snap := agg.Snapshot()
+	if snap.PRsMerged != 1 {
+		t.Errorf("expected PRsMerged=1 with nil source ignored, got %d", snap.PRsMerged)
+	}
+}
+
+// TestAggregateMetrics_EmptySourcesZeroSnapshot documents behavior when
+// autopilot is disabled or has no controllers.
+func TestAggregateMetrics_EmptySourcesZeroSnapshot(t *testing.T) {
+	agg := NewAggregateMetrics()
+	snap := agg.Snapshot()
+	if snap.PRsMerged != 0 || snap.TotalActivePRs != 0 || snap.SuccessRate != 0 {
+		t.Errorf("expected all-zero snapshot for empty aggregate, got %+v", snap)
+	}
+}

--- a/internal/autopilot/metrics_alerter.go
+++ b/internal/autopilot/metrics_alerter.go
@@ -88,22 +88,36 @@ func (t *tripTracker) recentTripCount() int {
 // MetricsAlerter periodically evaluates autopilot metrics and sends events
 // to the alerts engine for rule evaluation.
 type MetricsAlerter struct {
-	controller  *Controller
-	engine      *alerts.Engine
-	interval    time.Duration
-	log         *slog.Logger
-	tripTracker *tripTracker
+	controller    *Controller
+	engine        *alerts.Engine
+	interval      time.Duration
+	log           *slog.Logger
+	tripTracker   *tripTracker
+	metricsSource SnapshotSource
 }
 
-// NewMetricsAlerter creates a new MetricsAlerter.
+// NewMetricsAlerter creates a new MetricsAlerter. Deadlock/stuck-PR detection
+// stays scoped to controller (those concepts — active PRs, last-progress
+// timestamp — are inherently per-repo), but the metrics snapshot used for the
+// success_rate/total_active_prs/queue_depth alert metadata defaults to
+// controller.Metrics() and can be widened to a fleet-wide view via
+// SetMetricsSource (GH-4068).
 func NewMetricsAlerter(controller *Controller, engine *alerts.Engine) *MetricsAlerter {
 	return &MetricsAlerter{
-		controller:  controller,
-		engine:      engine,
-		interval:    30 * time.Second,
-		log:         slog.Default().With("component", "metrics-alerter"),
-		tripTracker: newTripTracker(),
+		controller:    controller,
+		engine:        engine,
+		interval:      30 * time.Second,
+		log:           slog.Default().With("component", "metrics-alerter"),
+		tripTracker:   newTripTracker(),
+		metricsSource: controller.Metrics(),
 	}
+}
+
+// SetMetricsSource overrides the metrics snapshot used for alert metadata
+// (GH-4068). Pass an *AggregateMetrics to report fleet-wide totals instead
+// of just this alerter's controller.
+func (ma *MetricsAlerter) SetMetricsSource(source SnapshotSource) {
+	ma.metricsSource = source
 }
 
 // Run starts the metrics alerter loop.
@@ -128,7 +142,7 @@ func (ma *MetricsAlerter) Run(ctx context.Context) {
 
 // evaluate takes a metrics snapshot and emits an autopilot_metrics event.
 func (ma *MetricsAlerter) evaluate() {
-	snap := ma.controller.Metrics().Snapshot()
+	snap := ma.metricsSource.Snapshot()
 
 	// Calculate stuck PRs (in waiting_ci)
 	var prStuckCount int

--- a/internal/autopilot/metrics_persister.go
+++ b/internal/autopilot/metrics_persister.go
@@ -10,23 +10,34 @@ import (
 
 // MetricsPersister periodically saves metrics snapshots to SQLite for history.
 type MetricsPersister struct {
-	controller *Controller
-	store      *memory.Store
-	interval   time.Duration
-	retention  time.Duration // How long to keep snapshots
-	log        *slog.Logger
+	controller    *Controller
+	store         *memory.Store
+	interval      time.Duration
+	retention     time.Duration // How long to keep snapshots
+	log           *slog.Logger
+	metricsSource SnapshotSource
 }
 
 // NewMetricsPersister creates a new MetricsPersister.
-// Saves snapshots every 5 minutes and retains 7 days of history.
+// Saves snapshots every 5 minutes and retains 7 days of history. The
+// persisted snapshot defaults to controller.Metrics() and can be widened to
+// a fleet-wide view via SetMetricsSource (GH-4068).
 func NewMetricsPersister(controller *Controller, store *memory.Store) *MetricsPersister {
 	return &MetricsPersister{
-		controller: controller,
-		store:      store,
-		interval:   5 * time.Minute,
-		retention:  7 * 24 * time.Hour,
-		log:        slog.Default().With("component", "metrics-persister"),
+		controller:    controller,
+		store:         store,
+		interval:      5 * time.Minute,
+		retention:     7 * 24 * time.Hour,
+		log:           slog.Default().With("component", "metrics-persister"),
+		metricsSource: controller.Metrics(),
 	}
+}
+
+// SetMetricsSource overrides the metrics snapshot persisted to history
+// (GH-4068). Pass an *AggregateMetrics to persist fleet-wide totals instead
+// of just this persister's controller.
+func (mp *MetricsPersister) SetMetricsSource(source SnapshotSource) {
+	mp.metricsSource = source
 }
 
 // Run starts the persister loop.
@@ -68,7 +79,7 @@ func (mp *MetricsPersister) refreshIssueLevelCounts() {
 }
 
 func (mp *MetricsPersister) persist() {
-	snap := mp.controller.Metrics().Snapshot()
+	snap := mp.metricsSource.Snapshot()
 
 	// Sum up API errors total
 	var apiErrorsTotal int64


### PR DESCRIPTION
## Summary

Fixes GH-4068 (TASK-390). Every autopilot `Controller` constructs its own `*autopilot.Metrics`, and live recording (merges/failures/active-PR gauges) is correctly per-repo. But the export surface was wired to only the backward-compat default controller:

- `gwServer.SetMetricsSource(autopilotController.Metrics())`
- `HydrateFromStore(..., autopilotController.Metrics())`
- `MetricsAlerter` / `MetricsPersister`

PR activity recorded on any projects-map controller never reached `/metrics`.

- Adds `autopilot.AggregateMetrics` (`internal/autopilot/metrics_aggregate.go`), a `MetricsSource` that sums counters, sums `ActivePRsByStage` gauges per stage, and concatenates histogram samples across every controller's `Metrics`. `SuccessRate`/`IssueLevelSuccessRate`/`Avg*` are recomputed from the merged data rather than averaged.
- `gwServer.SetMetricsSource` now receives the aggregate (built by ranging over `autopilotControllers`, which already contains the default controller).
- `MetricsAlerter`/`MetricsPersister` gain a `SetMetricsSource` override (default: their own controller's `Metrics()`, unchanged for any other caller) and are wired to the aggregate in `main.go`. Stuck-PR/deadlock detection in the alerter stays scoped to the default controller since that's inherently per-repo state.
- `HydrateFromStore` keeps hydrating only the default controller's `Metrics` — the sole lifetime-baseline owner — so the aggregate doesn't double-count.
- Per-repo live recording paths are untouched.
- Explicitly out of scope per the issue: PR-family hydration (deferred to #4029).

## Test plan

- [x] Unit test: PR merged on the non-default controller → aggregate snapshot `PRsMerged >= 1` (`TestAggregateMetrics_SumsCountersAcrossControllers`)
- [x] Unit test: `ActivePRsByStage` sums across controllers each tick (`TestAggregateMetrics_SumsActivePRsByStagePerTick`)
- [x] Unit test: histogram samples merge and `Avg*` recomputed from merged samples (`TestAggregateMetrics_HistogramMergesSamples`)
- [x] Unit test: `SuccessRate` recomputed from merged counters, not averaged (`TestAggregateMetrics_SuccessRateRecomputedFromMergedCounters`)
- [x] Unit test: nil sources ignored, empty aggregate is all-zero
- [x] `go build ./...`, `go test ./...` (full suite), `golangci-lint run --new-from-rev=origin/main ./...` all green