### PR TITLE
fix(github/sdk-poller): populate Labels/State/MemberID/AcceptanceCriteria/FromPR (GH-4050)

### DIFF
--- a/cmd/pilot/github_sdk_task_fields_test.go
+++ b/cmd/pilot/github_sdk_task_fields_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/testutil"
+)
+
+// TestFetchGithubIssueForSDKTask_ReturnsStateAndUser is a regression test for GH-4050:
+// the SDK-poller path (handleGithubIssueEventSDK) must fetch the real issue so State and
+// author flow into the executor.Task the same way the legacy in-tree path
+// (handleGitHubIssueWithResult) sets them. Before this fix, sdkcore.IssueEvent's lack of a
+// State field meant task.State was always "" on the SDK path, silently bypassing the
+// epic.go parent-done gate (GH-201 regression).
+func TestFetchGithubIssueForSDKTask_ReturnsStateAndUser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(githubSDK.Issue{
+			Number: 4050,
+			State:  "closed",
+			User:   githubSDK.User{Login: "alice", Email: "alice@example.com"},
+		})
+	}))
+	defer srv.Close()
+
+	client := githubSDK.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+
+	issue := fetchGithubIssueForSDKTask(context.Background(), client, "o", "r", 4050, "GH-4050")
+	if issue == nil {
+		t.Fatal("fetchGithubIssueForSDKTask() = nil, want a populated issue")
+	}
+	if issue.State != "closed" {
+		t.Errorf("issue.State = %q, want %q", issue.State, "closed")
+	}
+	if issue.User.Login != "alice" {
+		t.Errorf("issue.User.Login = %q, want %q", issue.User.Login, "alice")
+	}
+}
+
+// TestFetchGithubIssueForSDKTask_ErrorReturnsNil verifies the fetch is best-effort: a fetch
+// failure (e.g. transient API error) must not crash task construction, mirroring the
+// tolerance already used by the spec-guard path elsewhere in this file.
+func TestFetchGithubIssueForSDKTask_ErrorReturnsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := githubSDK.NewClientWithBaseURL(testutil.FakeGitHubToken, srv.URL)
+
+	if issue := fetchGithubIssueForSDKTask(context.Background(), client, "o", "r", 4050, "GH-4050"); issue != nil {
+		t.Errorf("fetchGithubIssueForSDKTask() = %+v, want nil on fetch error", issue)
+	}
+}
+
+// TestResolveGitHubMemberIDByLogin_NilAdapterReturnsEmpty documents the fail-open behavior
+// resolveGitHubMemberIDByLogin shares with resolveGitHubMemberID: with no team adapter
+// configured (the default in this test binary), RBAC resolution returns "" rather than
+// panicking or erroring, on both the legacy and SDK-poller paths (GH-4050).
+func TestResolveGitHubMemberIDByLogin_NilAdapterReturnsEmpty(t *testing.T) {
+	if teamAdapter != nil {
+		t.Skip("teamAdapter unexpectedly configured in test binary")
+	}
+	if got := resolveGitHubMemberIDByLogin("alice", "alice@example.com"); got != "" {
+		t.Errorf("resolveGitHubMemberIDByLogin() = %q, want \"\" with nil teamAdapter", got)
+	}
+}
+
+// TestGithubHandlerSDK_FieldsWired is a source-level regression guard scoped to the
+// handleGithubIssueEventSDK function body (GH-4050): the constructed executor.Task must
+// carry Labels, State, MemberID, AcceptanceCriteria, and FromPR, mirroring the legacy
+// in-tree handleGitHubIssueWithResult. This is the exact bug class that regressed
+// unnoticed — the legacy path had no equivalent wiring test either.
+func TestGithubHandlerSDK_FieldsWired(t *testing.T) {
+	body := githubFuncBody(t, "handlers.go", "func handleGithubIssueEventSDK(")
+
+	for _, want := range []string{
+		"Labels:",
+		"ev.Labels",
+		"State:",
+		"issueState",
+		"MemberID:",
+		"memberID",
+		"AcceptanceCriteria:",
+		"github.ExtractAcceptanceCriteria(ev.Body)",
+		"FromPR:",
+		"fromPR",
+		"fetchGithubIssueForSDKTask(",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("handleGithubIssueEventSDK body must contain %q (GH-4050: task.Labels/State/MemberID/AcceptanceCriteria/FromPR must be populated)", want)
+		}
+	}
+}
+
+// TestGithubSDKTask_NoDecomposeLabelStaysSingleTask reproduces the GH-3994 forensic
+// scenario (GH-4050): a human adds the no-decompose label ~1h before re-dispatch, but
+// because handleGithubIssueEventSDK never set task.Labels, the no-decompose gate at
+// decompose.go:135/206 silently no-oped and the retry still decomposed into subtasks.
+// This test asserts that a Task built the way the fixed SDK-poller path builds it (Labels
+// populated from the event) is skipped by TaskDecomposer regardless of its complexity or
+// description length.
+func TestGithubSDKTask_NoDecomposeLabelStaysSingleTask(t *testing.T) {
+	longDescription := strings.Repeat("implement a complex multi-file refactor across several packages with new interfaces and extensive test coverage. ", 10)
+
+	task := &executor.Task{
+		ID:          "GH-3994",
+		Title:       "Large refactor",
+		Description: longDescription,
+		Labels:      []string{"no-decompose"}, // GH-4050: now flows from ev.Labels
+	}
+
+	decomposer := executor.NewTaskDecomposer(&executor.DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 10,
+	})
+
+	result := decomposer.Decompose(task)
+	if result.Decomposed {
+		t.Fatalf("Decompose() = decomposed with subtasks=%d, want a single task (no-decompose label must gate this)", len(result.Subtasks))
+	}
+	if result.Reason != "skipped: no-decompose label" {
+		t.Errorf("Decompose().Reason = %q, want %q", result.Reason, "skipped: no-decompose label")
+	}
+	if len(result.Subtasks) != 1 || result.Subtasks[0] != task {
+		t.Errorf("Decompose().Subtasks = %v, want the single original task", result.Subtasks)
+	}
+}
+
+// TestGithubSDKTask_EmptyLabelsWouldHaveDecomposed is the negative control for
+// TestGithubSDKTask_NoDecomposeLabelStaysSingleTask: it documents that WITHOUT Labels
+// populated (the pre-GH-4050 bug), the same task is not protected by the no-decompose gate
+// and proceeds to complexity-based decomposition — this is exactly the fleet-wide failure
+// mode GH-4050 fixed.
+func TestGithubSDKTask_EmptyLabelsWouldHaveDecomposed(t *testing.T) {
+	longDescription := strings.Repeat("implement a complex multi-file refactor across several packages with new interfaces and extensive test coverage. ", 10)
+
+	task := &executor.Task{
+		ID:          "GH-3994",
+		Title:       "Large refactor",
+		Description: longDescription,
+		Labels:      nil, // simulates the pre-fix constructor, which never set Labels
+	}
+
+	decomposer := executor.NewTaskDecomposer(&executor.DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 10,
+	})
+
+	result := decomposer.Decompose(task)
+	if result.Reason == "skipped: no-decompose label" {
+		t.Error("Decompose() skipped via the no-decompose label with Labels=nil; the label gate must NOT fire on empty Labels")
+	}
+}

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -185,20 +185,28 @@ func parseAutopilotIteration(body string) int {
 // Uses the global teamAdapter (set at startup). Returns "" if no adapter is configured
 // or no matching member is found — callers treat "" as "skip RBAC".
 func resolveGitHubMemberID(issue *github.Issue) string {
+	return resolveGitHubMemberIDByLogin(issue.User.Login, issue.User.Email)
+}
+
+// resolveGitHubMemberIDByLogin resolves a GitHub login/email pair to a team member ID
+// (GH-634). Factored out of resolveGitHubMemberID so the SDK-poller path (which fetches
+// issue authorship via studio-sdk's githubSDK.Issue rather than the legacy github.Issue)
+// can reuse the same RBAC lookup (GH-4050).
+func resolveGitHubMemberIDByLogin(login, email string) string {
 	if teamAdapter == nil {
 		return ""
 	}
-	memberID, err := teamAdapter.ResolveGitHubIdentity(issue.User.Login, issue.User.Email)
+	memberID, err := teamAdapter.ResolveGitHubIdentity(login, email)
 	if err != nil {
 		logging.WithComponent("teams").Warn("failed to resolve GitHub identity",
-			slog.String("github_user", issue.User.Login),
+			slog.String("github_user", login),
 			slog.Any("error", err),
 		)
 		return ""
 	}
 	if memberID != "" {
 		logging.WithComponent("teams").Info("resolved GitHub user to team member",
-			slog.String("github_user", issue.User.Login),
+			slog.String("github_user", login),
 			slog.String("member_id", memberID),
 		)
 	}
@@ -1192,6 +1200,22 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 	taskDesc := fmt.Sprintf("GitHub Issue %s: %s\n\n%s", taskID, title, ev.Body)
 	branchName := fmt.Sprintf("pilot/%s", taskID)
 
+	// GH-489/GH-1267: For autopilot-fix issues, reuse the original branch so the fix
+	// lands on the same branch as the failed PR, and extract the PR number for
+	// --from-pr session resumption. Mirrors handleGitHubIssueWithResult (GH-4050).
+	var fromPR int
+	for _, label := range ev.Labels {
+		if label == "autopilot-fix" {
+			if parsed := parseAutopilotBranch(ev.Body); parsed != "" {
+				branchName = parsed
+			}
+			if pr := parseAutopilotPR(ev.Body); pr > 0 {
+				fromPR = pr
+			}
+			break
+		}
+	}
+
 	// ResolveRepoForEvent is tolerated like the other SDK handlers; ErrRepoNotResolved is non-fatal here.
 	_, repoOwner, repoName, resolveErr := sdkshim.ResolveRepoForEvent(cfg, "github", ev)
 	if resolveErr != nil && resolveErr.Error() != sdkshim.ErrRepoNotResolved.Error() {
@@ -1201,40 +1225,61 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 		)
 	}
 
-	// M7 4d.3: pre-dispatch spec quality gate on the SDK path (GH-2619 parity —
-	// previously exclusive to the legacy in-tree handler). The issue is
-	// reconstructed from the event; labels ride along so the
-	// pilot-skip-spec-check opt-out works.
+	// GH-4050: Fetch the real issue so State (and author, for MemberID) flow into the
+	// task the same way the legacy in-tree path sets them. sdkcore.IssueEvent doesn't
+	// surface issue state — without it, an empty State + empty Labels combo bypasses
+	// the epic.go parent-done gate and permits spurious sub-issue spawning on
+	// re-dispatch of a closed/merged parent (GH-201 OAuth dispatch loop).
+	issueNum, _ := strconv.Atoi(ev.IssueID)
+	var issueState, memberID string
+	var specClient *githubSDK.Client
 	if resolveErr == nil && repoOwner != "" && repoName != "" {
 		if ghToken, _ := resolveGitHubToken(cfg); ghToken != "" {
-			specClient := githubSDK.NewClient(ghToken)
-			issueNum, _ := strconv.Atoi(ev.IssueID)
-			specLabels := make([]githubSDK.Label, 0, len(ev.Labels))
-			for _, l := range ev.Labels {
-				specLabels = append(specLabels, githubSDK.Label{Name: l})
-			}
-			specIssue := &githubSDK.Issue{Number: issueNum, Title: title, Body: ev.Body, Labels: specLabels}
-			parentResolver := func(parentNum int) (*githubSDK.Issue, error) {
-				return specClient.GetIssue(ctx, repoOwner, repoName, parentNum)
-			}
-			if specResult := ghissue.ValidateSpec(specIssue, parentResolver); !specResult.Valid && specResult.SkipReason == "" {
-				applySpecGuardSDK(ctx, specClient, repoOwner, repoName, specIssue, specResult.FailureReasons)
-				return &sdkcore.IssueResult{Success: false, Skipped: true, SkipReason: "spec_incomplete"}, nil
+			specClient = githubSDK.NewClient(ghToken)
+			if realIssue := fetchGithubIssueForSDKTask(ctx, specClient, repoOwner, repoName, issueNum, taskID); realIssue != nil {
+				issueState = realIssue.State
+				memberID = resolveGitHubMemberIDByLogin(realIssue.User.Login, realIssue.User.Email)
 			}
 		}
 	}
 
+	// M7 4d.3: pre-dispatch spec quality gate on the SDK path (GH-2619 parity —
+	// previously exclusive to the legacy in-tree handler). The issue is
+	// reconstructed from the event; labels ride along so the
+	// pilot-skip-spec-check opt-out works.
+	if specClient != nil {
+		specLabels := make([]githubSDK.Label, 0, len(ev.Labels))
+		for _, l := range ev.Labels {
+			specLabels = append(specLabels, githubSDK.Label{Name: l})
+		}
+		specIssue := &githubSDK.Issue{Number: issueNum, Title: title, Body: ev.Body, Labels: specLabels}
+		parentResolver := func(parentNum int) (*githubSDK.Issue, error) {
+			return specClient.GetIssue(ctx, repoOwner, repoName, parentNum)
+		}
+		if specResult := ghissue.ValidateSpec(specIssue, parentResolver); !specResult.Valid && specResult.SkipReason == "" {
+			applySpecGuardSDK(ctx, specClient, repoOwner, repoName, specIssue, specResult.FailureReasons)
+			return &sdkcore.IssueResult{Success: false, Skipped: true, SkipReason: "spec_incomplete"}, nil
+		}
+	}
+
 	task := &executor.Task{
-		ID:            taskID,
-		Title:         title,
-		Description:   taskDesc,
-		ProjectPath:   projectPath,
-		Branch:        branchName,
-		CreatePR:      true,
-		SourceAdapter: "github",
-		SourceIssueID: ev.IssueID,
-		Priority:      sdkshim.PriorityFromSDK(ev.Priority),
-		BaseBranch:    resolveProjectBaseBranch(cfg, projectPath), // GH-2290
+		ID:                 taskID,
+		Title:              title,
+		Description:        taskDesc,
+		ProjectPath:        projectPath,
+		Branch:             branchName,
+		CreatePR:           true,
+		SourceAdapter:      "github",
+		SourceIssueID:      ev.IssueID,
+		Priority:           sdkshim.PriorityFromSDK(ev.Priority),
+		BaseBranch:         resolveProjectBaseBranch(cfg, projectPath), // GH-2290
+		MemberID:           memberID,                                   // GH-634: RBAC lookup
+		Labels:             ev.Labels,                                  // GH-727: flow labels for complexity/no-decompose classifier
+		AcceptanceCriteria: github.ExtractAcceptanceCriteria(ev.Body),  // GH-920: acceptance criteria in prompts
+		FromPR:             fromPR,                                     // GH-1267: session resumption from PR context
+		// Propagate parent state so isParentDone() can refuse sub-issue creation
+		// when the daemon re-dispatches a closed/merged parent (GH-201 gate parity).
+		State: issueState,
 	}
 	if resolveErr == nil && repoOwner != "" && repoName != "" {
 		// M7 4d.4: lets the runner select the startup-registered SDK PR creator
@@ -1272,6 +1317,24 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 	}
 
 	return issueResult, execErr
+}
+
+// fetchGithubIssueForSDKTask fetches the real issue via the studio-sdk GitHub client so
+// State (and author, for MemberID resolution) can flow into the executor.Task the SDK-poller
+// path constructs (GH-4050). sdkcore.IssueEvent does not surface issue state itself, so
+// without this fetch the epic.go parent-done gate silently no-ops on every SDK-dispatched
+// task. Returns nil on any fetch error — best-effort, matching the existing spec-guard
+// fetch tolerance elsewhere in this file.
+func fetchGithubIssueForSDKTask(ctx context.Context, client *githubSDK.Client, owner, repo string, issueNum int, taskID string) *githubSDK.Issue {
+	issue, err := client.GetIssue(ctx, owner, repo, issueNum)
+	if err != nil {
+		logging.WithComponent("github").Warn("failed to fetch issue for state/member resolution",
+			slog.String("task_id", taskID),
+			slog.Any("error", err),
+		)
+		return nil
+	}
+	return issue
 }
 
 // githubIssueURL builds the HTML URL for a GitHub issue from the default adapter repo

--- a/cmd/pilot/poller_github_test.go
+++ b/cmd/pilot/poller_github_test.go
@@ -158,7 +158,7 @@ func TestGithubHandlerSDKFunctionInvariants(t *testing.T) {
 	if !strings.Contains(body, "taskID := ev.SequenceID") {
 		t.Error("handleGithubIssueEventSDK must derive taskID from ev.SequenceID verbatim")
 	}
-	if !strings.Contains(body, `SourceAdapter: "github"`) {
+	if !strings.Contains(strings.Join(strings.Fields(body), " "), `SourceAdapter: "github"`) {
 		t.Error(`handleGithubIssueEventSDK must set SourceAdapter: "github"`)
 	}
 	if strings.Contains(body, `"GH-`+`%d"`) {


### PR DESCRIPTION
## Summary

- `handleGithubIssueEventSDK` (the SDK-poller GitHub dispatch path) built `executor.Task` without `Labels`, `State`, `MemberID`, `AcceptanceCriteria`, or `FromPR` — unlike the legacy `handleGitHubIssueWithResult` it runs alongside, which sets all five and explicitly warns "empty State + empty Labels combo bypasses the gate at epic.go … permits spurious sub-issue spawning (GH-201 OAuth dispatch loop)".
- Since `use_sdk_poller: true` has been live fleet-wide since 2026-07-06 (M7 Phase 4b), every SDK-dispatched task ran with empty `Labels`/`State`, silently no-oping: `no-decompose` and complexity routing (GH-727), the epic.go parent-done gate (GH-201), RBAC lookup (GH-634), acceptance-criteria injection (GH-920), and PR session resumption (GH-1267).
- Confirmed live during GH-3994 forensics: a human added `no-decompose` ~1h before re-dispatch, but the retry still decomposed into 5 subtasks because `task.Labels` arrived empty.

## Fix

- `Labels` now flows directly from `ev.Labels` (reusing the slice already built for spec-guard validation).
- `State` and the issue author (for `MemberID`) are resolved via a new `fetchGithubIssueForSDKTask` helper that fetches the real issue through the existing studio-sdk GitHub client, since `sdkcore.IssueEvent` doesn't surface issue state.
- `AcceptanceCriteria` is derived from `ev.Body` via `github.ExtractAcceptanceCriteria`.
- `FromPR`/branch override mirror the legacy `autopilot-fix` handling.
- `resolveGitHubMemberID` is factored into a login/email-based `resolveGitHubMemberIDByLogin` so both the legacy and SDK paths share the RBAC lookup.

## Test plan

- [x] `go build ./...`
- [x] `go test ./cmd/pilot/...` — all pass, including new tests:
  - `TestFetchGithubIssueForSDKTask_ReturnsStateAndUser` / `_ErrorReturnsNil`
  - `TestResolveGitHubMemberIDByLogin_NilAdapterReturnsEmpty`
  - `TestGithubHandlerSDK_FieldsWired` (source-level guard: Labels/State/MemberID/AcceptanceCriteria/FromPR wiring)
  - `TestGithubSDKTask_NoDecomposeLabelStaysSingleTask` — reproduces the GH-3994 forensic scenario; a task built with `Labels: []string{"no-decompose"}` is skipped by `TaskDecomposer` regardless of complexity/length
  - `TestGithubSDKTask_EmptyLabelsWouldHaveDecomposed` — negative control documenting the pre-fix failure mode
- [x] Fixed existing `TestGithubHandlerSDKFunctionInvariants` assertion to tolerate gofmt struct-literal realignment from the added fields
- [x] `go test ./internal/executor/...` — pass
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues