### PR TITLE
fix(memory): drop hardcoded model_name default + add ErrParentDone bucket (GH-4084)

### DIFF
--- a/internal/memory/metrics.go
+++ b/internal/memory/metrics.go
@@ -621,7 +621,8 @@ func (s *Store) ExportMetrics(query MetricsQuery) ([]*ExportedExecution, error) 
 		if linesRemoved.Valid {
 			e.LinesRemoved = int(linesRemoved.Int64)
 		}
-		if modelName.Valid {
+		e.ModelName = "unknown"
+		if modelName.Valid && modelName.String != "" {
 			e.ModelName = modelName.String
 		}
 		if prURL.Valid {

--- a/internal/memory/reclassify_outcomes_test.go
+++ b/internal/memory/reclassify_outcomes_test.go
@@ -35,6 +35,7 @@ func TestReclassifyLegacyOutcomes(t *testing.T) {
 		// skipped
 		{ID: "e9", TaskID: "GH-9", ProjectPath: "/p", Status: "failed", Error: "stale queued task recovered (no worker picked up)"},
 		{ID: "e10", TaskID: "GH-10", ProjectPath: "/p", Status: "failed", Error: "failed to start Claude Code: context canceled"},
+		{ID: "e16", TaskID: "GH-16", ProjectPath: "/p", Status: "failed", Error: "failed to create sub-issues: parent task is already done; refusing to create sub-issues"},
 		// infra
 		{ID: "e11", TaskID: "GH-11", ProjectPath: "/p", Status: "failed", Error: "oom_killed: Process killed by SIGKILL (exit code 137)"},
 		{ID: "e12", TaskID: "GH-12", ProjectPath: "/p", Status: "failed", Error: "push failed: failed to push: exit status 1"},
@@ -60,7 +61,7 @@ func TestReclassifyLegacyOutcomes(t *testing.T) {
 		"e1": "no_op", "e2": "no_op", "e3": "no_op", "e3b": "no_op",
 		"e4": "stalled", "e5": "stalled",
 		"e8": "rate_limited",
-		"e9": "skipped", "e10": "skipped",
+		"e9": "skipped", "e10": "skipped", "e16": "skipped",
 		"e11": "infra", "e12": "infra", "e13": "infra",
 		"e6": "failed", "e14": "failed", "e15": "failed", // genuine failures stay failed
 		"e7": "completed", // untouched
@@ -88,11 +89,11 @@ func TestReclassifyLegacyOutcomes(t *testing.T) {
 	assertCount("NoOp", counts.NoOp, 4)
 	assertCount("Stalled", counts.Stalled, 2)
 	assertCount("RateLimited", counts.RateLimited, 1)
-	assertCount("Skipped", counts.Skipped, 2)
+	assertCount("Skipped", counts.Skipped, 3)
 	assertCount("Infra", counts.Infra, 3)
 	assertCount("Succeeded", counts.Succeeded, 1)
 	assertCount("Total", counts.Total, len(seed))
-	assertCount("NonFailure", counts.NonFailure(), 12)
+	assertCount("NonFailure", counts.NonFailure(), 13)
 }
 
 // TestReclassifyLegacyOutcomesIdempotent verifies re-running the backfill makes

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -148,7 +148,12 @@ func (s *Store) migrate() error {
 		`ALTER TABLE executions ADD COLUMN files_changed INTEGER DEFAULT 0`,
 		`ALTER TABLE executions ADD COLUMN lines_added INTEGER DEFAULT 0`,
 		`ALTER TABLE executions ADD COLUMN lines_removed INTEGER DEFAULT 0`,
-		`ALTER TABLE executions ADD COLUMN model_name TEXT DEFAULT 'claude-sonnet-4-5'`,
+		// GH-3764(c): no literal default — a guessed model name is worse than an
+		// honest NULL. Existing rows already backfilled with the old
+		// 'claude-sonnet-4-5' default are left untouched (this is an additive
+		// ALTER TABLE; SQLite can't rewrite a column's default in place).
+		// Readers COALESCE(NULLIF(model_name, ''), 'unknown') instead of guessing.
+		`ALTER TABLE executions ADD COLUMN model_name TEXT`,
 		// Task queue columns for storing task details (GH-46)
 		`ALTER TABLE executions ADD COLUMN task_title TEXT`,
 		`ALTER TABLE executions ADD COLUMN task_description TEXT`,
@@ -416,7 +421,8 @@ func (s *Store) reclassifyLegacyOutcomes() error {
 		 WHERE status = 'failed' AND (
 			error LIKE '%stale queued task recovered%' OR
 			error LIKE '%context canceled%' OR
-			error LIKE '%context cancelled%'
+			error LIKE '%context cancelled%' OR
+			error LIKE '%parent task is already done%'
 		 )`,
 		`UPDATE executions SET status = 'stalled'
 		 WHERE status = 'failed' AND (
@@ -599,7 +605,7 @@ const executionDetailColumns = `
 	COALESCE(tokens_input, 0), COALESCE(tokens_output, 0), COALESCE(tokens_total, 0),
 	COALESCE(tokens_cache_read, 0), COALESCE(tokens_cache_write, 0),
 	COALESCE(estimated_cost_usd, 0), COALESCE(files_changed, 0), COALESCE(lines_added, 0),
-	COALESCE(lines_removed, 0), COALESCE(model_name, ''),
+	COALESCE(lines_removed, 0), COALESCE(NULLIF(model_name, ''), 'unknown'),
 	COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
 	COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
 	COALESCE(task_source_adapter, ''), COALESCE(task_source_issue_id, ''),

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -2805,6 +2805,67 @@ func TestEffortLevelColumns_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestModelNameColumn_NoHardcodedDefault verifies GH-3764(c): a fresh executions
+// table's model_name column carries no literal SQL default (dflt_value IS NULL
+// in pragma_table_info), so a future NULL row is never silently backfilled with
+// a guessed model name.
+func TestModelNameColumn_NoHardcodedDefault(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	var dfltValue sql.NullString
+	row := store.db.QueryRow(`SELECT dflt_value FROM pragma_table_info('executions') WHERE name = 'model_name'`)
+	if err := row.Scan(&dfltValue); err != nil {
+		t.Fatalf("pragma_table_info model_name: %v", err)
+	}
+	if dfltValue.Valid {
+		t.Errorf("model_name dflt_value = %q, want no default (NULL)", dfltValue.String)
+	}
+}
+
+// TestModelNameColumn_NullRendersUnknown verifies GH-3764(c): a row whose
+// model_name is NULL (e.g. a pre-migration legacy row, simulated here via a raw
+// UPDATE since SaveExecution always writes an explicit value) reads back as
+// "unknown" through GetExecution and ExportMetrics rather than a blank string.
+func TestModelNameColumn_NullRendersUnknown(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().UTC()
+	exec := &Execution{ID: "exec-null-model", TaskID: "T-null-model", ProjectPath: "/p", Status: "completed", CreatedAt: now}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	if _, err := store.db.Exec(`UPDATE executions SET model_name = NULL WHERE id = ?`, exec.ID); err != nil {
+		t.Fatalf("UPDATE model_name = NULL: %v", err)
+	}
+
+	got, err := store.GetExecution("exec-null-model")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if got.ModelName != "unknown" {
+		t.Errorf("GetExecution ModelName = %q, want %q", got.ModelName, "unknown")
+	}
+
+	exports, err := store.ExportMetrics(MetricsQuery{Start: now.Add(-time.Hour), End: now.Add(time.Hour)})
+	if err != nil {
+		t.Fatalf("ExportMetrics: %v", err)
+	}
+	if len(exports) != 1 {
+		t.Fatalf("len(exports) = %d, want 1", len(exports))
+	}
+	if exports[0].ModelName != "unknown" {
+		t.Errorf("ExportMetrics ModelName = %q, want %q", exports[0].ModelName, "unknown")
+	}
+}
+
 // TestPruneExecutionLogs verifies D5: deletes logs older than the cutoff and
 // leaves newer ones untouched.
 func TestPruneExecutionLogs(t *testing.T) {


### PR DESCRIPTION
## Summary
- Closes the two pieces of GH-3764 that never landed in `internal/memory/store.go` (see TASK-381).
- (c) `store.go` no longer bakes `DEFAULT 'claude-sonnet-4-5'` into the `model_name` column — a guessed model is worse than an honest NULL. Existing rows are left untouched (additive `ALTER TABLE`, can't rewrite in place); readers now `COALESCE(NULLIF(model_name, ''), 'unknown')` so NULL/empty renders as `unknown` in `GetExecution`/`GetLatestExecutionByTaskID`/`ListExecutionsForTask` and in `ExportMetrics` (feeds `pilot metrics export`).
- (d) `reclassifyLegacyOutcomes()` gains the `ErrParentDone` ("parent task is already done; refusing to create sub-issues") signature in its `skipped` bucket, mirroring `TerminalStatus` in `runner.go` — legacy rows with that error text and `status='failed'` now self-correct to `skipped` on next boot.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` (0 issues)
- [x] New tests: `TestModelNameColumn_NoHardcodedDefault`, `TestModelNameColumn_NullRendersUnknown` (store_test.go); extended `TestReclassifyLegacyOutcomes` with an `ErrParentDone`-signature row