### PR TITLE
fix(docker): bump builder image to golang:1.25 TASK-390

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # which requires Node.js, git, and gh CLI at runtime.
 
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
TASK-390 moved go.mod to go 1.25 (grot dep) and bumped the four CI workflows, but the Dockerfile builder stage still pins `golang:1.24-alpine` — every Docker workflow run on main fails with `go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)`. One-line bump to `golang:1.25-alpine`, matching ci.yml/release.yml.