### PR TITLE
fix(executor): heal stale-running rows with merged PRs, floor stuck-task orphan eviction

### DIFF
--- a/internal/alerts/engine.go
+++ b/internal/alerts/engine.go
@@ -53,6 +53,16 @@ type Engine struct {
 	metrics *AlertMetrics
 }
 
+// minOrphanEvictionThreshold floors evaluateStuckTasks' orphan-eviction window
+// regardless of how short the task_stuck rule's ProgressUnchangedFor is
+// configured. It mirrors the executor's worst-case single-attempt budget: a
+// Complex task's 60m default timeout doubled by the runner's watchdog
+// (runner.go watchdogTimeout = 2 * timeout) = 120m. GH-4092: eviction fired at
+// a fixed 4×threshold (40m at the 10m default) while workers were still
+// legitimately executing, mistaking a flat-progress self-correction loop for a
+// crashed one.
+const minOrphanEvictionThreshold = 120 * time.Minute
+
 type progressState struct {
 	Progress      int
 	UpdatedAt     time.Time
@@ -590,6 +600,17 @@ func (e *Engine) evaluateStuckTasks(ctx context.Context) {
 
 		cooldown := rule.Cooldown
 		orphanThreshold := 4 * threshold // Evict entries stuck for 4× the threshold (GH-2204)
+		// GH-4092: a 4×threshold orphan window (40m at the 10m default) evicted
+		// entries for tasks that were still demonstrably alive — a single
+		// long-running Claude turn (self-review/intent-judge veto retry loops)
+		// can legitimately produce no progress-milestone update for tens of
+		// minutes, well inside the executor's own Complex-task timeout (60m
+		// default) and its 2× watchdog kill ceiling (120m, runner.go
+		// watchdogTimeout). Floor the orphan window at that ceiling so eviction
+		// never preempts a task the runner itself hasn't given up on yet.
+		if orphanThreshold < minOrphanEvictionThreshold {
+			orphanThreshold = minOrphanEvictionThreshold
+		}
 
 		for taskID, state := range tasks {
 			stuckDuration := now.Sub(state.UpdatedAt)

--- a/internal/alerts/engine_test.go
+++ b/internal/alerts/engine_test.go
@@ -2298,7 +2298,11 @@ func TestEngine_EvaluateStuckTasks_ProgressResetsCooldown(t *testing.T) {
 }
 
 func TestEngine_EvaluateStuckTasks_OrphanEviction(t *testing.T) {
-	// Tasks stuck for 4× threshold should be evicted from the map.
+	// Tasks stuck past minOrphanEvictionThreshold should be evicted from the
+	// map. GH-4092: the orphan window is floored at minOrphanEvictionThreshold
+	// (120m) regardless of the rule's ProgressUnchangedFor, since a 4×threshold
+	// window (40m at this rule's 10m threshold) evicted entries for tasks that
+	// were still legitimately executing a long single Claude turn.
 	config := &AlertConfig{
 		Enabled: true,
 		Channels: []ChannelConfig{
@@ -2326,16 +2330,19 @@ func TestEngine_EvaluateStuckTasks_OrphanEviction(t *testing.T) {
 	logger := slog.Default()
 	engine := NewEngine(config, WithDispatcher(dispatcher), WithLogger(logger))
 
-	// Add an orphaned task: stuck for 50 min > 4 * 10 min = 40 min orphan threshold
+	// Add an orphaned task: stuck for 130 min > minOrphanEvictionThreshold (120m)
 	engine.mu.Lock()
 	engine.taskLastProgress["GH-ORPHAN"] = progressState{
 		Progress:  0,
-		UpdatedAt: time.Now().Add(-50 * time.Minute),
+		UpdatedAt: time.Now().Add(-130 * time.Minute),
 	}
-	// Also add a non-orphan stuck task: 15 min > 10 min threshold, < 40 min orphan
+	// Also add a non-orphan stuck task: 50 min > 10 min threshold (still alerts)
+	// but well under the 120m orphan floor — a legitimately long-running
+	// Claude turn must not be evicted just because it exceeds the pre-GH-4092
+	// 4×threshold window.
 	engine.taskLastProgress["GH-STUCK"] = progressState{
 		Progress:  0,
-		UpdatedAt: time.Now().Add(-15 * time.Minute),
+		UpdatedAt: time.Now().Add(-50 * time.Minute),
 	}
 	engine.mu.Unlock()
 
@@ -2427,6 +2434,11 @@ func TestEngine_TaskProgressUpdatesStuckState(t *testing.T) {
 // progress under its own task ID — never reaches the parent's
 // taskLastProgress entry), and the orphan sweep evicted the parent with
 // stuck_for=41m0s even though sub-issue 2 was actively running.
+//
+// GH-4092: the orphan window is now floored at minOrphanEvictionThreshold
+// (120m) regardless of the rule's ProgressUnchangedFor, so the pre-loop touch
+// below is pushed past that floor (was 41m, past only the old 4×10m=40m
+// window) to keep this test's "legitimately orphaned" case meaningful.
 func TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -2474,13 +2486,13 @@ func TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution(t *testin
 			engine := NewEngine(config, WithDispatcher(dispatcher))
 
 			// Parent's last alerts-visible touch (the pre-loop "Executing"
-			// progress report) was 41 min ago — past the 4x10m=40m orphan
-			// threshold on its own.
+			// progress report) was 130 min ago — past the minOrphanEvictionThreshold
+			// (120m) orphan floor on its own.
 			engine.handleTaskStarted(Event{
 				Type:      EventTypeTaskStarted,
 				TaskID:    "GH-4021",
 				Phase:     "Executing",
-				Timestamp: time.Now().Add(-41 * time.Minute),
+				Timestamp: time.Now().Add(-130 * time.Minute),
 			})
 
 			if tt.childTouchAgo > 0 {

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -316,6 +317,27 @@ func (d *Dispatcher) recoverStaleRunningTasks() int {
 			)
 			continue
 		}
+
+		// GH-4092: a stale "running" row does not mean the work was lost — the
+		// worker may have shipped a PR (autopilot merged it) and only the row's
+		// own status update raced the reap. HasCompletedExecution above only
+		// catches a *separate* completed row for the same task; this row IS the
+		// one being reaped, so it never satisfies that check. Consult the task
+		// branch's PR state directly before failing it.
+		branch := fmt.Sprintf("pilot/%s", exec.TaskID)
+		if mergedURL, mergedErr := staleRunningMergedPRCheck(d.ctx, exec.ProjectPath, branch); mergedErr == nil && mergedURL != "" {
+			d.log.Info("Stale running task's branch already merged; healing to completed instead of failed",
+				slog.String("execution_id", exec.ID),
+				slog.String("task_id", exec.TaskID),
+				slog.String("pr_url", mergedURL),
+			)
+			durationMs := time.Since(exec.CreatedAt).Milliseconds()
+			if err := d.store.MarkExecutionCompleted(exec.ID, mergedURL, "", durationMs); err != nil {
+				d.log.Error("Failed to heal stale running task to completed", slog.String("id", exec.ID), slog.Any("error", err))
+			}
+			continue
+		}
+
 		d.log.Warn("Marking stale running task as failed",
 			slog.String("execution_id", exec.ID),
 			slog.String("task_id", exec.TaskID),
@@ -329,6 +351,20 @@ func (d *Dispatcher) recoverStaleRunningTasks() int {
 	}
 
 	return resetCount
+}
+
+// staleRunningMergedPRCheck reports the URL of a merged PR for branch in
+// projectPath, or "" if none exists. Used by recoverStaleRunningTasks to
+// distinguish a genuinely orphaned worker from one whose work already shipped
+// (GH-4092). Production shells out via GitOperations.FindMergedPRByBranch
+// (the same gh-CLI dependency CreatePR already relies on); tests override
+// this var directly, mirroring isParentDoneLiveFallback in epic.go — real
+// subprocess calls never run during `go test`.
+var staleRunningMergedPRCheck = func(ctx context.Context, projectPath, branch string) (string, error) {
+	if testing.Testing() {
+		return "", nil
+	}
+	return NewGitOperations(projectPath).FindMergedPRByBranch(ctx, branch)
 }
 
 // recoverStaleQueuedTasks marks orphaned queued tasks as failed: either a

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -696,6 +696,91 @@ func TestRecoverStaleTasks_QueuedSkipsWhenLiveWorker(t *testing.T) {
 	}
 }
 
+// TestRecoverStaleRunningTasks_HealsToCompletedWhenBranchMerged is the GH-4092
+// regression guard: a stale "running" row whose own branch already has a
+// merged PR (autopilot shipped the work; only the row's own status update
+// raced the reap) must heal to "completed" with the PR URL recorded — not
+// "failed". Live incident: GH-4084 was marked failed 3 seconds after its PR
+// #4089 merged.
+func TestRecoverStaleRunningTasks_HealsToCompletedWhenBranchMerged(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{ID: "exec-merged-run", TaskID: "GH-4092", ProjectPath: "/project-merged", Status: "running"}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("failed to save execution: %v", err)
+	}
+
+	const mergedPRURL = "https://github.com/qf-studio/pilot/pull/4089"
+	origCheck := staleRunningMergedPRCheck
+	staleRunningMergedPRCheck = func(_ context.Context, projectPath, branch string) (string, error) {
+		if projectPath == "/project-merged" && branch == "pilot/GH-4092" {
+			return mergedPRURL, nil
+		}
+		return "", nil
+	}
+	defer func() { staleRunningMergedPRCheck = origCheck }()
+
+	config := &DispatcherConfig{
+		StaleRunningThreshold: 0,
+		StaleQueuedThreshold:  0,
+		StaleRecoveryInterval: time.Hour,
+	}
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, config)
+
+	dispatcher.recoverStaleRunningTasks()
+
+	got, err := store.GetExecution("exec-merged-run")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if got.Status != "completed" {
+		t.Errorf("expected stale running task with merged branch PR to heal to 'completed', got %q (error=%q)", got.Status, got.Error)
+	}
+	if got.PRUrl != mergedPRURL {
+		t.Errorf("expected pr_url = %q, got %q", mergedPRURL, got.PRUrl)
+	}
+}
+
+// TestRecoverStaleRunningTasks_MarksFailedWhenNoMergedPR guards the negative
+// case: a genuinely orphaned running row (no live worker, no merged PR on its
+// branch) must still be marked "failed" — the GH-4092 healing path must not
+// swallow real orphans.
+func TestRecoverStaleRunningTasks_MarksFailedWhenNoMergedPR(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{ID: "exec-orphan-run", TaskID: "GH-9999", ProjectPath: "/project-orphan", Status: "running"}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("failed to save execution: %v", err)
+	}
+
+	origCheck := staleRunningMergedPRCheck
+	staleRunningMergedPRCheck = func(_ context.Context, _, _ string) (string, error) {
+		return "", nil
+	}
+	defer func() { staleRunningMergedPRCheck = origCheck }()
+
+	config := &DispatcherConfig{
+		StaleRunningThreshold: 0,
+		StaleQueuedThreshold:  0,
+		StaleRecoveryInterval: time.Hour,
+	}
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, config)
+
+	dispatcher.recoverStaleRunningTasks()
+
+	got, err := store.GetExecution("exec-orphan-run")
+	if err != nil {
+		t.Fatalf("failed to get execution: %v", err)
+	}
+	if got.Status != "failed" {
+		t.Errorf("expected genuinely orphaned running task to be marked 'failed', got %q", got.Status)
+	}
+}
+
 func TestRecoverStaleTasks_RespectsThresholds(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Closes #4092 — the dispatcher-side gap in a recurring false-failure family (5th instance, following #4020/#4021/#4033).

- **Stale-recovery path** (`recoverStaleRunningTasks`, `internal/executor/dispatcher.go`): a stale `running` row was marked `failed` without checking whether its branch had already shipped a merged PR. Live instance GH-4084 was marked failed 3 seconds after autopilot merged PR #4089. Now checks `FindMergedPRByBranch` for the task's own branch before failing and heals the row to `completed` + `pr_url` (via `MarkExecutionCompleted`) instead. The check is a testable package-level var (`staleRunningMergedPRCheck`), mirroring the `isParentDoneLiveFallback` pattern in `epic.go` — no real `gh` subprocess calls run during `go test`.
- **Stuck-monitor orphan eviction** (`evaluateStuckTasks`, `internal/alerts/engine.go`): the orphan-eviction window was a fixed `4×threshold` (40m at the 10m default `task_stuck` threshold), decoupled from the executor's own timeout budget. A single long-running Claude turn (self-review / intent-judge veto retry loops) can legitimately produce no progress-milestone update for tens of minutes — well inside the Complex-task timeout (60m default) and its 2× watchdog kill ceiling (120m). Recurrences: GH-4021, GH-4028, GH-4029, GH-4084, all evicted at 40–41m while still executing. Floored the orphan window at `minOrphanEvictionThreshold` (120m), matching the watchdog ceiling, so eviction never preempts a task the runner itself hasn't given up on.

## Test plan

- [x] `TestRecoverStaleRunningTasks_HealsToCompletedWhenBranchMerged` — stale running row whose branch has a merged PR heals to `completed` with `pr_url` set, not `failed`.
- [x] `TestRecoverStaleRunningTasks_MarksFailedWhenNoMergedPR` — genuinely orphaned row (no merged PR) is still marked `failed` (negative-case guard).
- [x] `TestEngine_EvaluateStuckTasks_OrphanEviction` (updated) + `TestEngine_EvaluateStuckTasks_EpicParentRefreshedByChildExecution` (updated) — orphan eviction now requires exceeding the 120m floor, not just 4×threshold.
- [x] `go build ./...`
- [x] `go test ./... -short` — all green
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues