### PR TITLE
feat(metrics): hydrate PR-family counters from execution_events at daemon start

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -204,6 +204,7 @@
 |---------|--------|---------|-------------|------------|-------|
 | Execution history | ✅ | memory | - | `memory.path` | SQLite store |
 | Lifetime metrics | ✅ | memory | - | - | Token/cost/task counts persist across restarts (v0.21.2) |
+| PR-family counter hydration | ✅ | autopilot/memory | - | - | `pilot_prs_merged_total`/`pilot_prs_failed_total`/`pilot_pr_time_to_merge_seconds` hydrated at daemon start from the durable `execution_events` ledger (`Store.GetLifetimePRCounters`/`GetLifetimePRTimeToMerge`), not from `executions`/`autopilot_pr_state` which is deleted on PR completion. `failed` is scoped to execution_ids that also have a `pr_created` event, excluding executor-level task failures that never produced a PR. Lands on the same designated-owner `Metrics` as other `HydrateFromStore` baselines (GH-4068's aggregate), so no double-count with per-controller live recording (GH-4093, follow-up to GH-4029/GH-4041's PR #4043). Reset-on-restart by design (no durable per-event source): `pilot_prs_conflicting_total`, `pilot_circuit_breaker_trips_total`, `pilot_api_errors_total`, `pilot_label_cleanups_total`, `pilot_approval_persist_misses_total`, poller skip/dispatch/deferred counters, `pilot_panics_total` |
 | Cross-project patterns | ✅ | memory | `pilot patterns` | - | Pattern learning |
 | Pattern search | ✅ | memory | `pilot patterns search` | - | Keyword search |
 | Pattern stats | ✅ | memory | `pilot patterns stats` | - | Usage analytics |

--- a/internal/autopilot/metrics.go
+++ b/internal/autopilot/metrics.go
@@ -251,6 +251,23 @@ func (m *Metrics) HydrateIssuesProcessed(result string, n int64) {
 	m.IssuesProcessed[result] += n
 }
 
+// HydratePRsMerged adds a store-lifetime baseline to the merged-PR counter.
+// See HydrateExecutions (GH-4093, restores pilot_prs_merged_total across
+// restarts from the durable execution_events ledger).
+func (m *Metrics) HydratePRsMerged(n int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PRsMerged += n
+}
+
+// HydratePRsFailed adds a store-lifetime baseline to the failed-PR counter.
+// See HydrateExecutions (GH-4093).
+func (m *Metrics) HydratePRsFailed(n int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PRsFailed += n
+}
+
 // --- Gauge updates ---
 
 // UpdateActivePRs recalculates active PR counts by stage from a snapshot.

--- a/internal/autopilot/metrics_hydrator.go
+++ b/internal/autopilot/metrics_hydrator.go
@@ -63,5 +63,46 @@ func HydrateFromStore(ctx context.Context, store *memory.Store, metrics *Metrics
 	}
 	metrics.SetIssueLevelCounts(int64(issueLevel.Shipped), int64(issueLevel.Attempted))
 
+	// GH-4093: pilot_prs_merged_total / pilot_prs_failed_total from the durable
+	// execution_events ledger. Must land on this same designated-owner Metrics
+	// (see AggregateMetrics doc comment) exactly once — hydrating any other
+	// controller's Metrics here would double count in the fleet-wide aggregate.
+	prCounters, err := store.GetLifetimePRCounters()
+	if err != nil {
+		return fmt.Errorf("hydrate metrics from store: lifetime PR counters: %w", err)
+	}
+	metrics.HydratePRsMerged(prCounters.Merged)
+	metrics.HydratePRsFailed(prCounters.Failed)
+
+	// pilot_pr_time_to_merge_seconds: derivable from execution_events
+	// (pr_created -> merged deltas), so hydrate it too rather than leaving it
+	// session-scoped.
+	timeToMerge, err := store.GetLifetimePRTimeToMerge()
+	if err != nil {
+		return fmt.Errorf("hydrate metrics from store: lifetime PR time-to-merge: %w", err)
+	}
+	for _, d := range timeToMerge {
+		metrics.RecordPRTimeToMerge(d)
+	}
+
+	// The remaining counters are intentionally NOT hydrated here — they have no
+	// durable per-event source to hydrate from (unlike execution_events, which
+	// is an append-only ledger keyed off executions.id) and reset to zero on
+	// every restart by design:
+	//   - pilot_prs_conflicting_total (RecordPRConflicting): no execution_events
+	//     stage exists for "conflicting" — handleMergeConflict does not log to
+	//     the ledger, only to the in-memory counter (GH-4069).
+	//   - pilot_circuit_breaker_trips_total, pilot_api_errors_total,
+	//     pilot_label_cleanups_total, pilot_approval_persist_misses_total,
+	//     pilot_poller_skipped_total, pilot_poller_dispatched_total,
+	//     pilot_poller_deferred_scope_overlap_total, pilot_panics_total: pure
+	//     in-memory operational/diagnostic counters with no matching table or
+	//     ledger row anywhere in the store. The periodic autopilot_metrics
+	//     snapshot table (SaveAutopilotMetrics) records point-in-time values of
+	//     these but is not append-only across restarts — its "latest row"
+	//     reflects the session since the previous restart, not lifetime, so
+	//     using it as a hydration baseline would silently drop everything
+	//     between the last snapshot write and the actual restart. Treated as
+	//     reset-on-restart by design; see FEATURE-MATRIX.md.
 	return nil
 }

--- a/internal/autopilot/metrics_hydrator_test.go
+++ b/internal/autopilot/metrics_hydrator_test.go
@@ -206,6 +206,64 @@ func TestHydrateFromStore_IssueLevelCounts(t *testing.T) {
 	}
 }
 
+// TestHydrateFromStore_PRFamilyCounters pins GH-4093: pilot_prs_merged_total
+// and pilot_prs_failed_total hydrate from the durable execution_events
+// ledger (not from executions/autopilot_pr_state, which is deleted on PR
+// completion), and a bare executor-level task failure with no PR ever
+// created must not inflate PRsFailed.
+func TestHydrateFromStore_PRFamilyCounters(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	type seed struct {
+		id     string
+		stages []memory.Stage
+	}
+	seeds := []seed{
+		{"pr-1", []memory.Stage{memory.StagePRCreated, memory.StageCIPassed, memory.StageMerged}},
+		{"pr-2", []memory.Stage{memory.StagePRCreated, memory.StageCIPassed, memory.StageMerged}},
+		{"pr-3", []memory.Stage{memory.StagePRCreated, memory.StageCIFailed, memory.StageFailed}},
+		// Executor-level failure: no PR was ever created for this attempt.
+		{"pr-4", []memory.Stage{memory.StageQueued, memory.StageRunning, memory.StageFailed}},
+	}
+	for _, s := range seeds {
+		if err := store.SaveExecution(&memory.Execution{
+			ID: s.id, TaskID: "TASK-" + s.id, ProjectPath: "/p", Status: "completed",
+		}); err != nil {
+			t.Fatalf("SaveExecution %s: %v", s.id, err)
+		}
+		for _, stage := range s.stages {
+			if err := store.InsertExecutionEvent(s.id, stage, ""); err != nil {
+				t.Fatalf("InsertExecutionEvent %s/%s: %v", s.id, stage, err)
+			}
+		}
+	}
+
+	metrics := NewMetrics()
+	if err := HydrateFromStore(context.Background(), store, metrics); err != nil {
+		t.Fatalf("HydrateFromStore: %v", err)
+	}
+	snap := metrics.Snapshot()
+
+	if snap.PRsMerged != 2 {
+		t.Errorf("PRsMerged = %d, want 2", snap.PRsMerged)
+	}
+	if snap.PRsFailed != 1 {
+		t.Errorf("PRsFailed = %d, want 1 (executor-only failure with no PR must be excluded)", snap.PRsFailed)
+	}
+
+	// Acceptance: live merges on top of the hydrated baseline must not
+	// double count — a fresh live RecordPRMerged() call adds exactly 1.
+	metrics.RecordPRMerged()
+	if got := metrics.Snapshot().PRsMerged; got != 3 {
+		t.Errorf("PRsMerged after live merge = %d, want 3 (hydrated 2 + live 1)", got)
+	}
+}
+
 // TestHydrateFromStore_NilStoreIsNoop verifies hydration is a no-op (not an
 // error) when no store is configured, matching how other optional
 // store-backed features degrade in this codebase.

--- a/internal/memory/lifetime_pr_counters_test.go
+++ b/internal/memory/lifetime_pr_counters_test.go
@@ -1,0 +1,181 @@
+package memory
+
+import (
+	"testing"
+	"time"
+)
+
+// seedExecutionWithEvents creates the parent execution row (satisfying the
+// execution_events FK) and inserts the given stage events in order, sleeping
+// between inserts so occurred_at values are distinguishable.
+func seedExecutionWithEvents(t *testing.T, store *Store, executionID, taskID string, stages []Stage) {
+	t.Helper()
+	if err := store.SaveExecution(&Execution{
+		ID:          executionID,
+		TaskID:      taskID,
+		ProjectPath: "/project",
+		Status:      "completed",
+	}); err != nil {
+		t.Fatalf("SaveExecution(%s) failed: %v", executionID, err)
+	}
+	for _, stage := range stages {
+		if err := store.InsertExecutionEvent(executionID, stage, ""); err != nil {
+			t.Fatalf("InsertExecutionEvent(%s, %s) failed: %v", executionID, stage, err)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestGetLifetimePRCounters covers dedupe (multiple events don't double count
+// a single execution) and mixed stages — specifically that a bare 'failed'
+// event with no preceding 'pr_created' (an executor-level task failure that
+// never produced a PR) must NOT be counted as a PR-family failure (GH-4093).
+func TestGetLifetimePRCounters(t *testing.T) {
+	tests := []struct {
+		name       string
+		executions map[string][]Stage // executionID -> stage sequence
+		wantMerged int64
+		wantFailed int64
+	}{
+		{
+			name:       "no events",
+			executions: map[string][]Stage{},
+			wantMerged: 0,
+			wantFailed: 0,
+		},
+		{
+			name: "single merged PR counts once",
+			executions: map[string][]Stage{
+				"exec-1": {StageQueued, StagePRCreated, StageCIPassed, StageMerged},
+			},
+			wantMerged: 1,
+			wantFailed: 0,
+		},
+		{
+			name: "single failed PR counts once",
+			executions: map[string][]Stage{
+				"exec-1": {StageQueued, StagePRCreated, StageCIFailed, StageFailed},
+			},
+			wantMerged: 0,
+			wantFailed: 1,
+		},
+		{
+			name: "task failure with no PR created is excluded from PRsFailed",
+			executions: map[string][]Stage{
+				"exec-1": {StageQueued, StageRunning, StageFailed},
+			},
+			wantMerged: 0,
+			wantFailed: 0,
+		},
+		{
+			name: "mixed: PR-family failure and non-PR task failure both present",
+			executions: map[string][]Stage{
+				"exec-1": {StagePRCreated, StageCIFailed, StageFailed},
+				"exec-2": {StageQueued, StageRunning, StageFailed},
+			},
+			wantMerged: 0,
+			wantFailed: 1,
+		},
+		{
+			name: "dedupe: repeated merged event for the same execution counts once",
+			executions: map[string][]Stage{
+				"exec-1": {StagePRCreated, StageMerged, StageMerged},
+			},
+			wantMerged: 1,
+			wantFailed: 0,
+		},
+		{
+			name: "multiple distinct merged and failed executions",
+			executions: map[string][]Stage{
+				"exec-1": {StagePRCreated, StageMerged},
+				"exec-2": {StagePRCreated, StageMerged},
+				"exec-3": {StagePRCreated, StageFailed},
+			},
+			wantMerged: 2,
+			wantFailed: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newExecutionEventsTestStore(t)
+
+			for execID, stages := range tt.executions {
+				seedExecutionWithEvents(t, store, execID, "GH-1", stages)
+			}
+
+			got, err := store.GetLifetimePRCounters()
+			if err != nil {
+				t.Fatalf("GetLifetimePRCounters failed: %v", err)
+			}
+			if got.Merged != tt.wantMerged {
+				t.Errorf("Merged = %d, want %d", got.Merged, tt.wantMerged)
+			}
+			if got.Failed != tt.wantFailed {
+				t.Errorf("Failed = %d, want %d", got.Failed, tt.wantFailed)
+			}
+		})
+	}
+}
+
+// TestGetLifetimePRTimeToMerge covers the pr_created->merged delta derivation,
+// exclusion of executions missing either stage, and dedupe via MIN(occurred_at)
+// when a stage is (unexpectedly) logged more than once for the same execution.
+func TestGetLifetimePRTimeToMerge(t *testing.T) {
+	t.Run("execution with both stages yields one positive sample", func(t *testing.T) {
+		store := newExecutionEventsTestStore(t)
+		if err := store.SaveExecution(&Execution{ID: "exec-1", TaskID: "GH-1", ProjectPath: "/p", Status: "completed"}); err != nil {
+			t.Fatalf("SaveExecution: %v", err)
+		}
+		if err := store.InsertExecutionEvent("exec-1", StagePRCreated, ""); err != nil {
+			t.Fatalf("InsertExecutionEvent(pr_created): %v", err)
+		}
+		time.Sleep(5 * time.Millisecond)
+		if err := store.InsertExecutionEvent("exec-1", StageMerged, ""); err != nil {
+			t.Fatalf("InsertExecutionEvent(merged): %v", err)
+		}
+
+		samples, err := store.GetLifetimePRTimeToMerge()
+		if err != nil {
+			t.Fatalf("GetLifetimePRTimeToMerge failed: %v", err)
+		}
+		if len(samples) != 1 {
+			t.Fatalf("got %d samples, want 1", len(samples))
+		}
+		if samples[0] <= 0 {
+			t.Errorf("sample duration = %v, want > 0", samples[0])
+		}
+	})
+
+	t.Run("execution missing merged stage is excluded", func(t *testing.T) {
+		store := newExecutionEventsTestStore(t)
+		seedExecutionWithEvents(t, store, "exec-1", "GH-1", []Stage{StagePRCreated, StageCIFailed, StageFailed})
+
+		samples, err := store.GetLifetimePRTimeToMerge()
+		if err != nil {
+			t.Fatalf("GetLifetimePRTimeToMerge failed: %v", err)
+		}
+		if len(samples) != 0 {
+			t.Errorf("got %d samples, want 0", len(samples))
+		}
+	})
+
+	t.Run("multiple merged executions produce multiple samples", func(t *testing.T) {
+		store := newExecutionEventsTestStore(t)
+		seedExecutionWithEvents(t, store, "exec-1", "GH-1", []Stage{StagePRCreated, StageMerged})
+		seedExecutionWithEvents(t, store, "exec-2", "GH-2", []Stage{StagePRCreated, StageMerged})
+
+		samples, err := store.GetLifetimePRTimeToMerge()
+		if err != nil {
+			t.Fatalf("GetLifetimePRTimeToMerge failed: %v", err)
+		}
+		if len(samples) != 2 {
+			t.Fatalf("got %d samples, want 2", len(samples))
+		}
+		for i, d := range samples {
+			if d <= 0 {
+				t.Errorf("sample[%d] = %v, want > 0", i, d)
+			}
+		}
+	})
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -2298,6 +2298,136 @@ func (s *Store) GetLifetimeCounterBaselines() (*LifetimeCounterBaselines, error)
 	return baselines, nil
 }
 
+// LifetimePRCounters holds lifetime PR-family counter baselines derived from
+// the durable execution_events ledger (GH-4093, follow-up to GH-4029/GH-4041).
+// PR #4043 deliberately skipped hydrating pilot_prs_merged_total/
+// pilot_prs_failed_total on the premise that no persisted state survives a
+// restart — that premise was wrong for these two: autopilot_pr_state rows are
+// deleted on PR completion (controller.go persistRemovePR), but every
+// merged/failed transition is also durably logged to execution_events
+// (GH-3844/TASK-379 C3), which is append-only and never pruned.
+type LifetimePRCounters struct {
+	Merged int64
+	Failed int64
+}
+
+// GetLifetimePRCounters queries execution_events for lifetime pilot_prs_merged_total
+// / pilot_prs_failed_total baselines, deduped per execution_id (COUNT(DISTINCT),
+// not COUNT(*)) so a stage logged more than once for the same execution is not
+// double counted.
+//
+// "failed" is ambiguous in the raw ledger: the executor writes stage='failed'
+// for executions that never produced a PR (Claude Code failed before any PR
+// existed — internal/executor/runner.go, dispatcher.go), while the autopilot
+// controller writes stage='failed' for PRs that failed after being created
+// (CI failure, merge failure, release failure — controller.go
+// executionEventStageFor). Both share the same execution_events.stage value,
+// so counting all 'failed' rows would conflate "task never shipped a PR" with
+// "PR-family failure" and wildly overcount pilot_prs_failed_total (most
+// executions fail during coding, not PR review). Restricting to execution_ids
+// that also have a 'pr_created' row scopes both merged and failed to genuine
+// PR outcomes, matching what RecordPRMerged/RecordPRFailed count live.
+func (s *Store) GetLifetimePRCounters() (*LifetimePRCounters, error) {
+	counters := &LifetimePRCounters{}
+
+	rows, err := s.db.Query(`
+		SELECT stage, COUNT(DISTINCT execution_id)
+		FROM execution_events
+		WHERE stage IN (?, ?)
+			AND execution_id IN (
+				SELECT execution_id FROM execution_events WHERE stage = ?
+			)
+		GROUP BY stage
+	`, string(StageMerged), string(StageFailed), string(StagePRCreated))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get lifetime PR counters: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var stage string
+		var count int64
+		if err := rows.Scan(&stage, &count); err != nil {
+			return nil, fmt.Errorf("failed to scan lifetime PR counter row: %w", err)
+		}
+		switch Stage(stage) {
+		case StageMerged:
+			counters.Merged = count
+		case StageFailed:
+			counters.Failed = count
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate lifetime PR counters: %w", err)
+	}
+
+	return counters, nil
+}
+
+// earliestStageOccurrences returns, per execution_id, the earliest occurred_at
+// for the given stage. Selects the raw column directly (not through a
+// GROUP BY/MIN() aggregate) — the sqlite driver only recovers the DATETIME
+// declared-type for direct column reads; scanning an aggregate result into
+// time.Time fails, so ORDER BY + first-write-wins in Go stands in for MIN().
+func (s *Store) earliestStageOccurrences(stage Stage) (map[string]time.Time, error) {
+	rows, err := s.db.Query(`
+		SELECT execution_id, occurred_at
+		FROM execution_events
+		WHERE stage = ?
+		ORDER BY occurred_at ASC, id ASC
+	`, string(stage))
+	if err != nil {
+		return nil, fmt.Errorf("failed to query %s stage occurrences: %w", stage, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[string]time.Time)
+	for rows.Next() {
+		var execID string
+		var occurredAt time.Time
+		if err := rows.Scan(&execID, &occurredAt); err != nil {
+			return nil, fmt.Errorf("failed to scan %s stage occurrence: %w", stage, err)
+		}
+		if _, exists := out[execID]; !exists {
+			out[execID] = occurredAt
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate %s stage occurrences: %w", stage, err)
+	}
+	return out, nil
+}
+
+// GetLifetimePRTimeToMerge derives pilot_pr_time_to_merge_seconds histogram
+// samples from execution_events timestamps: for every execution_id that has
+// both a 'pr_created' and a 'merged' row, the sample is the earliest 'merged'
+// occurred_at minus the earliest 'pr_created' occurred_at (GH-4093). Samples
+// with a non-positive duration are dropped defensively — they should not
+// occur (occurred_at is a monotonic write-time clock per InsertExecutionEvent)
+// but a negative bucket observation would corrupt the histogram.
+func (s *Store) GetLifetimePRTimeToMerge() ([]time.Duration, error) {
+	created, err := s.earliestStageOccurrences(StagePRCreated)
+	if err != nil {
+		return nil, err
+	}
+	merged, err := s.earliestStageOccurrences(StageMerged)
+	if err != nil {
+		return nil, err
+	}
+
+	var samples []time.Duration
+	for execID, mergedAt := range merged {
+		createdAt, ok := created[execID]
+		if !ok {
+			continue
+		}
+		if d := mergedAt.Sub(createdAt); d > 0 {
+			samples = append(samples, d)
+		}
+	}
+	return samples, nil
+}
+
 // EndSession marks a session as ended.
 func (s *Store) EndSession(sessionID string) error {
 	return s.withRetry("EndSession", func() error {


### PR DESCRIPTION
## Summary
- Hydrate `pilot_prs_merged_total`/`pilot_prs_failed_total`/`pilot_pr_time_to_merge_seconds` at daemon start from the durable `execution_events` ledger (`Store.GetLifetimePRCounters`/`GetLifetimePRTimeToMerge`), correcting PR #4043's premise that no persisted state exists for the PR-family counters — `autopilot_pr_state` rows are deleted on PR completion, but `execution_events` is append-only and survives that cleanup (GH-3844).
- `failed` is scoped to execution_ids that also have a `pr_created` event, since the executor separately writes `stage='failed'` for task attempts that never produced a PR — without that filter, hydration would conflate "task never shipped" with "PR failed after creation" and badly overcount `pilot_prs_failed_total`.
- Hydration lands on the same designated-owner `Metrics` object as the other `HydrateFromStore` baselines (GH-4068's aggregate), so it can't double count against per-controller live recording.
- Documented the remaining reset-on-restart-by-design counters (circuit breaker trips, API errors, label cleanups, approval misses, poller counters, conflicting PRs, panics) in code comments and `FEATURE-MATRIX.md` — none of them have a durable per-event source.

Closes GH-4093 (follow-up to GH-4029, unblocked by #4068/PR #4081).

## Test plan
- [x] `go build ./...`
- [x] `go test -short ./...` (full suite green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` (0 issues)
- [x] New table-driven tests: `internal/memory/lifetime_pr_counters_test.go` (dedupe, mixed merged/failed/task-only-failure stages, time-to-merge derivation)
- [x] New hydrator test: `TestHydrateFromStore_PRFamilyCounters` — asserts merged/failed hydrate correctly and a live `RecordPRMerged()` call after hydration adds exactly 1 (no double count)