### PR TITLE
fix(autopilot): epic-parent reconciler misses body-marker-only children and label-stripped parents

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2265,18 +2265,13 @@ func formatMergedPRRefs(nums []int) string {
 
 // recoverStaleParentIssues scans open pilot parent issues at startup and closes any
 // whose sub-issues are all done. Catches parents orphaned when the daemon was down.
+//
+// GH-4099: candidates come from epicParentCandidates, not a bare native-link search
+// — a parent whose "pilot" label was stripped out-of-band, or whose children were
+// only ever linked via the "Parent: GH-N" body-marker convention (LinkSubIssue is
+// non-fatal at creation time, GH-3513), used to be silently invisible here forever.
 func (c *Controller) recoverStaleParentIssues(ctx context.Context) {
-	const maxRecover = 50
-
-	candidates, err := c.ghClient.SearchOpenPilotIssuesWithSubIssues(ctx, c.owner, c.repo, maxRecover)
-	if err != nil {
-		c.log.Warn("recoverStaleParentIssues: search failed", slog.Any("error", err))
-		return
-	}
-
-	if len(candidates) == maxRecover {
-		c.log.Info("recoverStaleParentIssues: hit limit, some candidates may be skipped", slog.Int("limit", maxRecover))
-	}
+	candidates := c.epicParentCandidates(ctx)
 
 	closed := 0
 	for _, parentNum := range candidates {
@@ -2286,13 +2281,14 @@ func (c *Controller) recoverStaleParentIssues(ctx context.Context) {
 			continue
 		}
 		if openCount > 0 {
+			c.log.Debug("recoverStaleParentIssues: siblings still open, skipping", slog.Int("parent", parentNum), slog.Int("open", openCount))
 			continue
 		}
 		c.closeParentNow(ctx, parentNum, nil)
 		closed++
 	}
 
-	c.log.Info("recoverStaleParentIssues: done", slog.Int("closed", closed))
+	c.log.Info("recoverStaleParentIssues: done", slog.Int("closed", closed), slog.Int("candidates", len(candidates)))
 }
 
 // Start runs one-time startup recovery sweeps. Call before the main Run loop.

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -5543,6 +5543,271 @@ func TestRecoverStaleParentIssues_TruncatesAt50(t *testing.T) {
 	}
 }
 
+// TestReconcileEpicParents_GH4099CandidateDiscovery reproduces the two
+// real-world shapes that left #4020 and #4051 open for hours while every
+// reconcile pass logged nothing to do (GH-4099):
+//
+//   - "unlabeled parent + body-marker children": the parent has lost its
+//     "pilot" label (out-of-band, e.g. to break a dispatch retry loop) and its
+//     children were only ever linked via the "Parent: GH-N" body-marker
+//     convention (LinkSubIssue never ran — GH-3513) — invisible to the native
+//     SearchOpenPilotIssuesWithSubIssues candidate query no matter what.
+//   - "labeled parent + sub-issue-API children": the pre-existing, already-
+//     working shape — a regression guard proving the fix doesn't disturb it.
+//
+// Both must close via reconcileEpicParents (the poll-cycle sweep) with the
+// standard completion comment naming the merged child PR.
+func TestReconcileEpicParents_GH4099CandidateDiscovery(t *testing.T) {
+	tests := []struct {
+		name          string
+		parentLabeled bool // parent appears in the native candidate search results
+		nativeLinked  bool // children linked via the native GitHub sub-issue API
+		parentNum     int
+		childNum      int
+		mergedPR      int
+	}{
+		{
+			name:          "unlabeled parent + body-marker-only children closes via text-search fallback",
+			parentLabeled: false,
+			nativeLinked:  false,
+			parentNum:     700,
+			childNum:      701,
+			mergedPR:      900,
+		},
+		{
+			name:          "labeled parent + native sub-issue-API children still closes (regression guard)",
+			parentLabeled: true,
+			nativeLinked:  true,
+			parentNum:     710,
+			childNum:      711,
+			mergedPR:      910,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var closeCalled bool
+			var commentBody string
+
+			childBody := fmt.Sprintf("<!--autopilot-meta\nparent: GH-%d\ninherited-spec: true\n-->\n\nParent: GH-%d\n\nDo the thing.",
+				tt.parentNum, tt.parentNum)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+					var body map[string]interface{}
+					_ = json.NewDecoder(r.Body).Decode(&body)
+					query, _ := body["query"].(string)
+
+					switch {
+					case strings.Contains(query, "body"):
+						// discoverBodyMarkerEpicParents: recently-closed pilot-done
+						// children, regardless of the referenced parent's own label.
+						resp := map[string]interface{}{
+							"data": map[string]interface{}{
+								"repository": map[string]interface{}{
+									"issues": map[string]interface{}{
+										"nodes": []map[string]interface{}{
+											{"updatedAt": time.Now().UTC().Format(time.RFC3339), "body": childBody},
+										},
+									},
+								},
+							},
+						}
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(resp)
+
+					case strings.Contains(query, "search(query:"):
+						// getSubIssuesByTextSearch fallback (no native links).
+						resp := map[string]interface{}{
+							"data": map[string]interface{}{
+								"search": map[string]interface{}{
+									"nodes": []map[string]interface{}{
+										{"number": tt.childNum, "state": "CLOSED"},
+									},
+								},
+							},
+						}
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(resp)
+
+					case strings.Contains(query, "subIssuesSummary"):
+						// SearchOpenPilotIssuesWithSubIssues (native candidate search).
+						nodes := []map[string]interface{}{}
+						if tt.parentLabeled {
+							total := 0
+							if tt.nativeLinked {
+								total = 1
+							}
+							nodes = append(nodes, map[string]interface{}{
+								"number":           tt.parentNum,
+								"subIssuesSummary": map[string]int{"total": total, "completed": total},
+							})
+						}
+						resp := map[string]interface{}{
+							"data": map[string]interface{}{
+								"repository": map[string]interface{}{
+									"issues": map[string]interface{}{"nodes": nodes},
+								},
+							},
+						}
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(resp)
+
+					default:
+						// getAllSubIssueNumbers native per-parent query.
+						totalCount := 0
+						nodes := []map[string]interface{}{}
+						if tt.nativeLinked {
+							totalCount = 1
+							nodes = append(nodes, map[string]interface{}{"number": tt.childNum, "state": "CLOSED"})
+						}
+						resp := map[string]interface{}{
+							"data": map[string]interface{}{
+								"node": map[string]interface{}{
+									"subIssues": map[string]interface{}{
+										"totalCount": totalCount,
+										"nodes":      nodes,
+									},
+								},
+							},
+						}
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(resp)
+					}
+
+				case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", tt.parentNum):
+					w.WriteHeader(http.StatusOK)
+					_, _ = fmt.Fprintf(w, `{"node_id":"I_parent","number":%d,"title":"epic","state":"open"}`, tt.parentNum)
+
+				case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+					// SearchPRsForIssue (verifyChildrenShippedForClose).
+					items := []map[string]interface{}{{
+						"id": 1, "number": tt.mergedPR, "title": "fix: child",
+						"state":        "closed",
+						"pull_request": map[string]interface{}{"merged_at": "2026-01-01T00:00:00Z"},
+					}}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": items})
+
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("[]"))
+
+				case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/labels/"):
+					w.WriteHeader(http.StatusOK)
+
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/comments"):
+					var payload struct {
+						Body string `json:"body"`
+					}
+					_ = json.NewDecoder(r.Body).Decode(&payload)
+					commentBody = payload.Body
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"id":1}`))
+
+				case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", tt.parentNum):
+					closeCalled = true
+					w.WriteHeader(http.StatusOK)
+
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			c.reconcileEpicParents(context.Background())
+
+			if !closeCalled {
+				t.Fatalf("expected parent #%d to be closed, it wasn't", tt.parentNum)
+			}
+			if !strings.Contains(commentBody, fmt.Sprintf("GH-%d", tt.parentNum)) {
+				t.Errorf("expected standard completion comment naming GH-%d, got: %q", tt.parentNum, commentBody)
+			}
+			if !strings.Contains(commentBody, fmt.Sprintf("#%d", tt.mergedPR)) {
+				t.Errorf("expected completion comment to name merged PR #%d, got: %q", tt.mergedPR, commentBody)
+			}
+		})
+	}
+}
+
+// TestReconcileEpicParent_NoLinksLogsReason covers GH-4099's fail-loud
+// requirement: a candidate parent that turns out to have no discoverable
+// children via EITHER the native sub-issue API or the body-marker text search
+// must never skip silently — it must log why (previously this path just
+// returned with no log line at all, matching the "closed=0, no visible reason"
+// symptom that hid #4020/#4051 for hours).
+func TestReconcileEpicParent_NoLinksLogsReason(t *testing.T) {
+	const parentNum = 720
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			var body map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			query, _ := body["query"].(string)
+
+			if strings.Contains(query, "search(query:") {
+				// getSubIssuesByTextSearch: no matching children either.
+				resp := map[string]interface{}{
+					"data": map[string]interface{}{
+						"search": map[string]interface{}{"nodes": []map[string]interface{}{}},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+
+			// getAllSubIssueNumbers native query: no native links.
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"node": map[string]interface{}{
+						"subIssues": map[string]interface{}{
+							"totalCount": 0,
+							"nodes":      []map[string]interface{}{},
+						},
+					},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"node_id":"I_parent","number":%d,"state":"open"}`, parentNum)
+
+		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			t.Errorf("parent should not be closed when it has no discoverable children")
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.log = slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	c.reconcileEpicParent(context.Background(), parentNum)
+
+	logs := logBuf.String()
+	if !strings.Contains(logs, "no discoverable children") {
+		t.Errorf("expected a fail-loud skip-reason log line, got logs:\n%s", logs)
+	}
+	if !strings.Contains(logs, fmt.Sprintf("parent=%d", parentNum)) {
+		t.Errorf("expected skip log to name the parent, got logs:\n%s", logs)
+	}
+}
+
 // TestNotifyExternalClose_MaybeCloseParent verifies that notifyExternalClose
 // calls maybeCloseParentIssue so parent epics are auto-closed when the last
 // sub-issue PR is closed without merge (GH-2198).

--- a/internal/autopilot/epic_reconcile.go
+++ b/internal/autopilot/epic_reconcile.go
@@ -57,10 +57,17 @@ type childCloseVeto struct {
 
 // getAllSubIssueNumbers queries native GitHub sub-issues for parentNum and
 // returns every child regardless of state (open AND closed), plus whether the
-// parent has any native sub-issue links at all. This mirrors the SDK's
-// GetOpenSubIssueNumbers query shape but keeps closed children too — GH-3939's
-// merged-PR verification must inspect exactly the children that open-only
-// listings discard.
+// parent has any linked children at all (native OR text-based). This mirrors
+// the SDK's GetOpenSubIssueNumbers query shape but keeps closed children too —
+// GH-3939's merged-PR verification must inspect exactly the children that
+// open-only listings discard.
+//
+// GH-4099: when the parent has no native sub-issue links (LinkSubIssue is
+// non-fatal at child-creation time, GH-3513, and some epics are decomposed
+// using only the body-marker "Parent: GH-N" convention), falls back to a text
+// search for children referencing this parent — otherwise such epics are
+// invisible to the merged-PR-verified close path even once discovered as a
+// reconcile candidate.
 func (c *Controller) getAllSubIssueNumbers(ctx context.Context, parentNum int) ([]subIssueState, bool, error) {
 	parentID, err := c.ghClient.GetIssueNodeID(ctx, c.owner, c.repo, parentNum)
 	if err != nil {
@@ -98,11 +105,54 @@ func (c *Controller) getAllSubIssueNumbers(ctx context.Context, parentNum int) (
 	}
 
 	if result.Node.SubIssues.TotalCount == 0 {
-		return nil, false, nil
+		return c.getSubIssuesByTextSearch(ctx, parentNum)
 	}
 
 	children := make([]subIssueState, 0, len(result.Node.SubIssues.Nodes))
 	for _, n := range result.Node.SubIssues.Nodes {
+		children = append(children, subIssueState{Number: n.Number, Closed: n.State == "CLOSED"})
+	}
+	return children, true, nil
+}
+
+// getSubIssuesByTextSearch finds every issue (open AND closed) referencing
+// "Parent: GH-{parentNum}" in its body via GitHub's GraphQL search (GH-4099).
+// Returns the same subIssueState + hasLinks shape as the native-link query so
+// callers don't need to special-case the linkage source. Used as the fallback
+// for parents whose children were never LinkSubIssue-linked (GH-3513) or were
+// decomposed using only the body-marker convention.
+func (c *Controller) getSubIssuesByTextSearch(ctx context.Context, parentNum int) ([]subIssueState, bool, error) {
+	const query = `query($q: String!, $first: Int!) {
+		search(query: $q, type: ISSUE, first: $first) {
+			nodes {
+				... on Issue {
+					number
+					state
+				}
+			}
+		}
+	}`
+
+	q := fmt.Sprintf(`repo:%s/%s "Parent: GH-%d" is:issue`, c.owner, c.repo, parentNum)
+	var result struct {
+		Search struct {
+			Nodes []struct {
+				Number int    `json:"number"`
+				State  string `json:"state"`
+			} `json:"nodes"`
+		} `json:"search"`
+	}
+
+	if err := c.ghClient.ExecuteGraphQL(ctx, query, map[string]interface{}{"q": q, "first": 100}, &result); err != nil {
+		return nil, false, fmt.Errorf("text-search sub-issues for %s/%s#%d: %w", c.owner, c.repo, parentNum, err)
+	}
+
+	if len(result.Search.Nodes) == 0 {
+		return nil, false, nil
+	}
+
+	children := make([]subIssueState, 0, len(result.Search.Nodes))
+	for _, n := range result.Search.Nodes {
 		children = append(children, subIssueState{Number: n.Number, Closed: n.State == "CLOSED"})
 	}
 	return children, true, nil
@@ -149,9 +199,9 @@ func (c *Controller) verifyChildrenShippedForClose(ctx context.Context, parentNu
 }
 
 // reconcileEpicParents is the poll-cycle epic-parent auto-close check (GH-3939).
-// On each tick it inspects every open, pilot-labeled issue that has native
-// GitHub sub-issues (a decomposed epic parent) and closes the ones whose
-// children are ALL closed AND shipped a merged PR (or verified no_op).
+// On each tick it inspects every candidate epic parent (see epicParentCandidates)
+// and closes the ones whose children are ALL closed AND shipped a merged PR (or
+// verified no_op).
 //
 // This complements the two existing close paths: maybeCloseParentIssue fires
 // reactively only when a sibling's own PR merges, and recoverStaleParentIssues
@@ -160,38 +210,138 @@ func (c *Controller) verifyChildrenShippedForClose(ctx context.Context, parentNu
 // such a parent converges within one poll cycle instead of staying stuck until
 // the next restart.
 func (c *Controller) reconcileEpicParents(ctx context.Context) {
-	candidates, err := c.ghClient.SearchOpenPilotIssuesWithSubIssues(ctx, c.owner, c.repo, maxEpicReconcile)
-	if err != nil {
-		c.log.Warn("reconcileEpicParents: search failed", slog.Any("error", err))
-		return
-	}
-
-	// GH-3939: mirror recoverStaleParentIssues' cap-hit log — this sweep repeats
-	// every poll cycle (not just once at startup), so a repo that consistently
-	// sits at the cap would otherwise silently and indefinitely skip the overflow
-	// candidates with no operator-visible signal.
-	if len(candidates) == maxEpicReconcile {
-		c.log.Info("reconcileEpicParents: hit limit, some candidates may be skipped", slog.Int("limit", maxEpicReconcile))
-	}
-
-	for _, parentNum := range candidates {
+	for _, parentNum := range c.epicParentCandidates(ctx) {
 		c.reconcileEpicParent(ctx, parentNum)
 	}
+}
+
+// epicParentCandidates merges the two independent epic-parent discovery
+// sources and returns their union, de-duplicated (GH-4099). Shared by
+// recoverStaleParentIssues (startup) and reconcileEpicParents (poll-cycle) so
+// neither sweep depends on only one of:
+//
+//   - Native GitHub sub-issue links via SearchOpenPilotIssuesWithSubIssues,
+//     gated on the PARENT's own "pilot" label and on subIssuesSummary.total>0.
+//   - The body-marker "Parent: GH-N" text convention via
+//     discoverBodyMarkerEpicParents, derived from the CHILD side and therefore
+//     immune to the parent losing its label or never getting a native link.
+//
+// #4020 and #4051 both sat open for hours because they were invisible to the
+// first source (both had subIssuesSummary.total==0 — LinkSubIssue never ran —
+// and #4051 had additionally lost its "pilot" label) and there was no second
+// source to catch them. Each source's own failure is logged and non-fatal to
+// the other, so a transient outage in one query never blocks the sweep.
+func (c *Controller) epicParentCandidates(ctx context.Context) []int {
+	native, err := c.ghClient.SearchOpenPilotIssuesWithSubIssues(ctx, c.owner, c.repo, maxEpicReconcile)
+	if err != nil {
+		c.log.Warn("epicParentCandidates: native-link search failed", slog.Any("error", err))
+	}
+	// GH-3939: this cap-hit log used to live only in recoverStaleParentIssues;
+	// reconcileEpicParents repeats every poll cycle (not just once at startup),
+	// so a repo that consistently sits at the cap would otherwise silently and
+	// indefinitely skip the overflow candidates with no operator-visible signal.
+	if len(native) == maxEpicReconcile {
+		c.log.Info("epicParentCandidates: hit native-link limit, some candidates may be skipped", slog.Int("limit", maxEpicReconcile))
+	}
+
+	bodyMarker, err := c.discoverBodyMarkerEpicParents(ctx)
+	if err != nil {
+		c.log.Warn("epicParentCandidates: body-marker discovery failed", slog.Any("error", err))
+	}
+
+	seen := make(map[int]bool, len(native)+len(bodyMarker))
+	merged := make([]int, 0, len(native)+len(bodyMarker))
+	for _, group := range [][]int{native, bodyMarker} {
+		for _, n := range group {
+			if !seen[n] {
+				seen[n] = true
+				merged = append(merged, n)
+			}
+		}
+	}
+	return merged
+}
+
+// epicParentDiscoveryLookback bounds how far back discoverBodyMarkerEpicParents
+// scans recently-closed pilot subtasks for a "Parent: GH-N" body reference
+// (GH-4099). Wide enough that a parent whose children shipped days apart still
+// surfaces as a candidate, but bounded so the query stays a single cheap page.
+const epicParentDiscoveryLookback = 7 * 24 * time.Hour
+
+// discoverBodyMarkerEpicParents finds candidate epic-parent numbers referenced
+// by recently-closed, pilot-managed child issues' "Parent: GH-N" body marker
+// (GH-4099). See epicParentCandidates for why this candidate source exists
+// alongside the native sub-issue-link search: it is deliberately NOT gated on
+// the parent's own label or native links — it derives candidates purely from
+// the CHILD side, which is reliably labeled "pilot"/"pilot-done" regardless of
+// what happens to the parent's own label or linkage.
+func (c *Controller) discoverBodyMarkerEpicParents(ctx context.Context) ([]int, error) {
+	const query = `query($owner: String!, $repo: String!, $first: Int!) {
+		repository(owner: $owner, name: $repo) {
+			issues(first: $first, states: [CLOSED], labels: ["pilot", "pilot-done"], orderBy: {field: UPDATED_AT, direction: DESC}) {
+				nodes {
+					updatedAt
+					body
+				}
+			}
+		}
+	}`
+
+	var result struct {
+		Repository struct {
+			Issues struct {
+				Nodes []struct {
+					UpdatedAt time.Time `json:"updatedAt"`
+					Body      string    `json:"body"`
+				} `json:"nodes"`
+			} `json:"issues"`
+		} `json:"repository"`
+	}
+
+	variables := map[string]interface{}{
+		"owner": c.owner,
+		"repo":  c.repo,
+		"first": maxEpicReconcile,
+	}
+	if err := c.ghClient.ExecuteGraphQL(ctx, query, variables, &result); err != nil {
+		return nil, fmt.Errorf("discover body-marker epic parents for %s/%s: %w", c.owner, c.repo, err)
+	}
+
+	cutoff := time.Now().Add(-epicParentDiscoveryLookback)
+	seen := make(map[int]bool)
+	var parents []int
+	for _, node := range result.Repository.Issues.Nodes {
+		if node.UpdatedAt.Before(cutoff) {
+			// Results are ordered newest-first — everything after this is older still.
+			break
+		}
+		parentNum := github.ParseParentIssueNumber(node.Body)
+		if parentNum == 0 || seen[parentNum] {
+			continue
+		}
+		seen[parentNum] = true
+		parents = append(parents, parentNum)
+	}
+	return parents, nil
 }
 
 // reconcileEpicParent runs the full close-or-veto decision for a single epic
 // parent. Split out from reconcileEpicParents so tests can drive one parent
 // directly, mirroring how maybeCloseParentIssue/recoverStaleParentIssues are tested.
 func (c *Controller) reconcileEpicParent(ctx context.Context, parentNum int) {
-	children, hasNativeLinks, err := c.getAllSubIssueNumbers(ctx, parentNum)
+	children, hasLinks, err := c.getAllSubIssueNumbers(ctx, parentNum)
 	if err != nil {
 		c.log.Warn("reconcileEpicParents: failed to list children", slog.Int("parent", parentNum), slog.Any("error", err))
 		return
 	}
-	if !hasNativeLinks {
-		// No native sub-issue links to verify against — leave this parent to the
-		// text-search-based paths (maybeCloseParentIssue / recoverStaleParentIssues),
-		// which is the only signal available for pre-native-linking epics.
+	if !hasLinks {
+		// GH-4099: getAllSubIssueNumbers already tried both the native sub-issue
+		// API and the body-marker text-search fallback — neither found a single
+		// child. This parent was a candidate (native link or a child's body
+		// marker pointed at it), so a silent no-op here would hide exactly the
+		// kind of gap that left #4020/#4051 open for hours; log why instead.
+		c.log.Warn("reconcileEpicParents: candidate parent has no discoverable children via native links or text search, skipping",
+			slog.Int("parent", parentNum))
 		return
 	}
 
@@ -273,8 +423,8 @@ func (c *Controller) reconcileClosedEpicScopes(ctx context.Context) {
 			continue
 		}
 
-		children, hasNativeLinks, err := c.getAllSubIssueNumbers(ctx, parentNum)
-		if err != nil || !hasNativeLinks {
+		children, hasLinks, err := c.getAllSubIssueNumbers(ctx, parentNum)
+		if err != nil || !hasLinks {
 			continue
 		}
 		mergedPRs, veto := c.verifyChildrenShippedForClose(ctx, parentNum, children)


### PR DESCRIPTION
## Summary

- `recoverStaleParentIssues`/`reconcileEpicParents` discovered epic-parent candidates solely via `SearchOpenPilotIssuesWithSubIssues`, which is gated on the parent's own `pilot` label AND on native GitHub `subIssuesSummary.total>0`. #4020 and #4051 both sat open for hours (19h / 6h) with every reconcile pass silently logging `closed=0`, no reason given.
- Root cause confirmed against live GitHub data: both #4020 and #4051 have `subIssuesSummary.total == 0` — their children (#4022/#4023, #4055) were linked only via the `Parent: GH-N` body-marker convention, never via `LinkSubIssue` (non-fatal at creation time, GH-3513). #4051 additionally lost its `pilot` label out-of-band, compounding the gap.
- Added a second, label-independent candidate source (`discoverBodyMarkerEpicParents`) that discovers parent numbers from recently-closed children's body markers, merged with the native source via `epicParentCandidates` (shared by both `recoverStaleParentIssues` and `reconcileEpicParents`).
- `getAllSubIssueNumbers` now falls back to a GraphQL text search (`getSubIssuesByTextSearch`) for children when native sub-issue links are absent, so a parent discovered via the new source can still be verified (all children closed + merged PR) and closed.
- A candidate parent that ends up with no discoverable children via either linkage source now logs a warning naming the parent, instead of returning silently (fail-loud per TASK-379 policy).

## Test plan

- [x] New table-driven test `TestReconcileEpicParents_GH4099CandidateDiscovery` reproduces both required shapes end-to-end via `reconcileEpicParents`: (1) unlabeled parent + body-marker-only children now closes via the text-search fallback: (2) labeled parent + native sub-issue-API children still closes (regression guard).
- [x] New test `TestReconcileEpicParent_NoLinksLogsReason` asserts the fail-loud skip-reason log line.
- [x] Full existing `internal/autopilot` suite green (including `TestRecoverStaleParentIssues`, `TestReconcileEpicParent`, `TestReconcileEpicParents_Wrapper`, `TestReconcileClosedEpicScopes`, `TestEpicCloseVetoBreaker`).
- [x] `make test-short` green across all packages.
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues.