### PR TITLE
docs(readme): drop duplicate dashboard still

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ Pilot picks up tickets from GitHub, Linear, Jira, or Asana—plans the implement
 └─────────────┘      └─────────────┘      └─────────────┘      └─────────────┘
 ```
 
-<img width="1200" height="630" alt="Pilot dashboard on the grot design system" src="docs/public/pilot-preview.png" />
-
-
-
 ## Install
 
 ### Homebrew (recommended)


### PR DESCRIPTION
Follow-up to #4104: the OG still in 'The Solution' duplicated the demo GIF above the fold (same dashboard, one static). README keeps the GIF as the single visual; `docs/public/pilot-preview.png` remains for the OG/Twitter card.