### PR TITLE
GH-4105: fix(executor): split exit 137/139 classification on cancelled context

### DIFF
--- a/internal/executor/backend_claudecode.go
+++ b/internal/executor/backend_claudecode.go
@@ -61,6 +61,12 @@ const (
 	ErrorTypeTimeout ClaudeCodeErrorType = "timeout"
 	// ErrorTypeOOM indicates the process was OOM-killed (exit 137/139) (GH-2112)
 	ErrorTypeOOM ClaudeCodeErrorType = "oom_killed"
+	// ErrorTypeShutdownTerminated indicates the process exited with an
+	// OOM-signature exit code (137/139) but the run context was already
+	// cancelled by our own shutdown/timeout path — the process was killed
+	// by us (SIGTERM/SIGKILL via context cancellation), not the kernel's
+	// OOM killer. GH-4105.
+	ErrorTypeShutdownTerminated ClaudeCodeErrorType = "shutdown_terminated"
 	// ErrorTypeSessionNotFound indicates the session for --from-pr or --resume was not found (GH-1267)
 	ErrorTypeSessionNotFound ClaudeCodeErrorType = "session_not_found"
 	// ErrorTypeNoChanges indicates Claude exited 0 but produced no diff — typically
@@ -98,13 +104,25 @@ func (e *ClaudeCodeError) ErrorMessage() string { return e.Message }
 func (e *ClaudeCodeError) ErrorStderr() string { return e.Stderr }
 
 // classifyClaudeCodeError examines stderr output and exit code to classify the error.
-func classifyClaudeCodeError(stderr string, originalErr error) *ClaudeCodeError {
+// ctxCancelled indicates whether the run's context was already cancelled (by our
+// own shutdown or timeout path) at the time the process exited — GH-4105.
+func classifyClaudeCodeError(stderr string, originalErr error, ctxCancelled bool) *ClaudeCodeError {
 	// GH-2112: Check exit code first — OOM kills (137=SIGKILL, 139=SIGSEGV) often
 	// produce no stderr, so exit code is the only reliable signal.
 	if exitCode := extractExitCode(originalErr); exitCode == 137 || exitCode == 139 {
 		sigName := "SIGKILL"
 		if exitCode == 139 {
 			sigName = "SIGSEGV"
+		}
+		// GH-4105: if we ourselves cancelled the context (shutdown/timeout),
+		// the resulting SIGKILL/SIGSEGV-shaped exit is expected process
+		// teardown, not a genuine out-of-memory kill.
+		if ctxCancelled {
+			return &ClaudeCodeError{
+				Type:    ErrorTypeShutdownTerminated,
+				Message: fmt.Sprintf("Process terminated by %s after context cancellation (exit code %d)", sigName, exitCode),
+				Stderr:  strings.TrimSpace(stderr),
+			}
 		}
 		return &ClaudeCodeError{
 			Type:    ErrorTypeOOM,
@@ -207,8 +225,8 @@ func extractExitCode(err error) int {
 
 // parseClaudeCodeError examines stderr output and exit code to classify the error.
 // This function matches the specification in GH-917 and returns error interface.
-func parseClaudeCodeError(stderr string, originalErr error) error {
-	return classifyClaudeCodeError(stderr, originalErr)
+func parseClaudeCodeError(stderr string, originalErr error, ctxCancelled bool) error {
+	return classifyClaudeCodeError(stderr, originalErr, ctxCancelled)
 }
 
 // ClaudeCodeBackend implements Backend for Claude Code CLI.
@@ -710,9 +728,12 @@ func (b *ClaudeCodeBackend) executeWithFromPR(ctx context.Context, opts ExecuteO
 
 		result.Success = false
 
-		// GH-917: Classify the error for better handling
+		// GH-917: Classify the error for better handling.
+		// GH-4105: pass whether the run context was already cancelled (our own
+		// shutdown/timeout path) so 137/139 exits during teardown aren't
+		// misclassified as OOM kills.
 		stderr := stderrOutput.String()
-		ccErr := parseClaudeCodeError(stderr, err).(*ClaudeCodeError)
+		ccErr := parseClaudeCodeError(stderr, err, ctx.Err() != nil).(*ClaudeCodeError)
 
 		// GH-2328: surface the raw stderr + classification so the runner can
 		// write them to execution_logs. Without this, "unknown: exit status 1"

--- a/internal/executor/backend_claudecode_test.go
+++ b/internal/executor/backend_claudecode_test.go
@@ -512,7 +512,7 @@ func TestClassifyClaudeCodeError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := classifyClaudeCodeError(tt.stderr, nil)
+			err := classifyClaudeCodeError(tt.stderr, nil, false)
 			if err.Type != tt.expectType {
 				t.Errorf("classifyClaudeCodeError() type = %q, want %q", err.Type, tt.expectType)
 			}
@@ -559,7 +559,7 @@ func TestParseClaudeCodeError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := parseClaudeCodeError(tt.stderr, nil)
+			err := parseClaudeCodeError(tt.stderr, nil, false)
 			ccErr, ok := err.(*ClaudeCodeError)
 			if !ok {
 				t.Errorf("parseClaudeCodeError() did not return *ClaudeCodeError, got %T", err)
@@ -699,7 +699,78 @@ func TestClassifyClaudeCodeError_OOM(t *testing.T) {
 				cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", tt.exitCode))
 				exitErr = cmd.Run()
 			}
-			err := classifyClaudeCodeError(tt.stderr, exitErr)
+			err := classifyClaudeCodeError(tt.stderr, exitErr, false)
+			if err.Type != tt.expectType {
+				t.Errorf("type = %q, want %q", err.Type, tt.expectType)
+			}
+			if tt.expectMsg != "" && err.Message != tt.expectMsg {
+				t.Errorf("message = %q, want %q", err.Message, tt.expectMsg)
+			}
+		})
+	}
+}
+
+func TestClassifyClaudeCodeError_ShutdownVsOOM(t *testing.T) {
+	// GH-4105: exit 137/139 must be classified as oom_killed only when the run
+	// context was NOT already cancelled by our own shutdown/timeout path.
+	// When the context was cancelled, the same exit codes are expected
+	// teardown noise and must be tagged shutdown_terminated instead.
+	tests := []struct {
+		name         string
+		exitCode     int
+		ctxCancelled bool
+		expectType   ClaudeCodeErrorType
+		expectMsg    string
+	}{
+		{
+			// (a) exit 137, context not cancelled -> oom_killed
+			name:         "exit 137, context not cancelled -> oom_killed",
+			exitCode:     137,
+			ctxCancelled: false,
+			expectType:   ErrorTypeOOM,
+			expectMsg:    "Process killed by SIGKILL (exit code 137)",
+		},
+		{
+			// (b) exit 137, context cancelled -> shutdown classification
+			name:         "exit 137, context cancelled -> shutdown_terminated",
+			exitCode:     137,
+			ctxCancelled: true,
+			expectType:   ErrorTypeShutdownTerminated,
+			expectMsg:    "Process terminated by SIGKILL after context cancellation (exit code 137)",
+		},
+		{
+			// (c) exit 139 mirror
+			name:         "exit 139, context not cancelled -> oom_killed",
+			exitCode:     139,
+			ctxCancelled: false,
+			expectType:   ErrorTypeOOM,
+			expectMsg:    "Process killed by SIGSEGV (exit code 139)",
+		},
+		{
+			name:         "exit 139, context cancelled -> shutdown_terminated",
+			exitCode:     139,
+			ctxCancelled: true,
+			expectType:   ErrorTypeShutdownTerminated,
+			expectMsg:    "Process terminated by SIGSEGV after context cancellation (exit code 139)",
+		},
+		{
+			// (d) clean exit unaffected — no exit error at all, ctxCancelled must not
+			// spuriously trigger the shutdown classification.
+			name:         "clean exit (no error) unaffected by ctxCancelled",
+			exitCode:     0,
+			ctxCancelled: true,
+			expectType:   ErrorTypeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var exitErr error
+			if tt.exitCode > 0 {
+				cmd := exec.Command("sh", "-c", fmt.Sprintf("exit %d", tt.exitCode))
+				exitErr = cmd.Run()
+			}
+			err := classifyClaudeCodeError("", exitErr, tt.ctxCancelled)
 			if err.Type != tt.expectType {
 				t.Errorf("type = %q, want %q", err.Type, tt.expectType)
 			}


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4105.

Closes #4105

## Changes

In internal/executor/backend_claudecode.go:104, teach the exit-code classifier to distinguish operator-initiated shutdown from real OOM. When the run context is cancelled by our own shutdown path, tag the result with a new shutdown_terminated (or equivalent) classification instead of oom_killed; leave the OOM path intact for genuinely uncancelled 137/139 exits. Add table-driven tests covering: (a) exit 137, context not cancelled -> oom_killed; (b) exit 137, context cancelled -> shutdown classification; (c) exit 139 mirror; (d) clean exit unaffected. No changes outside internal/executor/.