### PR TITLE
feat(upgrade): cross-process drain signal + poll handshake (GH-4106)

### DIFF
--- a/internal/upgrade/drain.go
+++ b/internal/upgrade/drain.go
@@ -1,0 +1,251 @@
+// Package upgrade: cross-process drain handshake (GH-4106).
+//
+// A caller (e.g. an external supervisor doing a blue/green restart) needs to
+// tell a *different* Pilot process — identified only by PID — to stop
+// accepting new work, then wait until it reports zero in-flight executions
+// or a bounded timeout elapses. GracefulUpgrader/TaskChecker only cover the
+// in-process case (a process checking its own tasks before upgrading
+// itself); this file adds the missing IPC leg for the cross-process case.
+//
+// The handshake is deliberately the lightest option that fits the existing
+// patterns in this package: a UNIX signal (see drain_unix.go/drain_windows.go)
+// tells the target to enter drain mode, and a JSON status file — the same
+// disk-based approach state.go already uses for upgrade state — lets the
+// target report its in-flight count back without a socket or RPC layer.
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// DrainOutcome is the typed result of waiting for a target process to drain.
+type DrainOutcome int
+
+const (
+	// DrainUnknown means the wait did not complete normally (e.g. the
+	// caller's context was cancelled, or the status file could not be read).
+	DrainUnknown DrainOutcome = iota
+
+	// Drained means the target process reported zero in-flight executions
+	// after entering drain mode.
+	Drained
+
+	// TimedOut means the bounded wait elapsed before the target reported
+	// zero in-flight executions.
+	TimedOut
+)
+
+// String implements fmt.Stringer for logging.
+func (o DrainOutcome) String() string {
+	switch o {
+	case Drained:
+		return "drained"
+	case TimedOut:
+		return "timed_out"
+	default:
+		return "unknown"
+	}
+}
+
+// DrainStatus is the cross-process handshake payload. The target process is
+// expected to write this file (via Save, or ReportDrainStatus) after it
+// receives the drain signal, updating InFlightCount as its running tasks
+// finish. The requester polls the same file with WaitForDrain.
+type DrainStatus struct {
+	// PID is the process that wrote this status.
+	PID int `json:"pid"`
+
+	// Draining is true once the target has acknowledged the drain signal
+	// and stopped accepting new work.
+	Draining bool `json:"draining"`
+
+	// InFlightCount is the number of executions still running.
+	InFlightCount int `json:"in_flight_count"`
+
+	// UpdatedAt is when this status was last written.
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// DrainStatusFile is the default status file name, mirroring StateFile.
+const DrainStatusFile = "drain-status.json"
+
+// DefaultDrainStatusPath returns the default path for the drain status
+// handshake file, mirroring DefaultStatePath.
+func DefaultDrainStatusPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".pilot", DrainStatusFile)
+}
+
+// LoadDrainStatus reads the drain status file. A missing file is not an
+// error — it returns (nil, nil), mirroring LoadState's "nothing signaled
+// yet" semantics.
+func LoadDrainStatus(path string) (*DrainStatus, error) {
+	if path == "" {
+		path = DefaultDrainStatusPath()
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read drain status: %w", err)
+	}
+
+	var status DrainStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return nil, fmt.Errorf("failed to parse drain status: %w", err)
+	}
+
+	return &status, nil
+}
+
+// Save writes the drain status to disk, creating the parent directory if
+// needed. The write is atomic (temp file + rename) so a concurrent
+// WaitForDrain-style reader — polling this same path while the target
+// process updates it — never observes a partially-written file.
+func (d *DrainStatus) Save(path string) error {
+	if path == "" {
+		path = DefaultDrainStatusPath()
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create drain status directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal drain status: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".drain-status-*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp drain status file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }() // no-op once the rename below succeeds
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to write drain status: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to write drain status: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("failed to write drain status: %w", err)
+	}
+
+	return nil
+}
+
+// ReportDrainStatus is the receiving side of the handshake: the target
+// process calls this (typically from its drain-signal handler and again as
+// running tasks finish) to publish its current in-flight count.
+func ReportDrainStatus(path string, pid int, draining bool, inFlightCount int) error {
+	status := &DrainStatus{
+		PID:           pid,
+		Draining:      draining,
+		InFlightCount: inFlightCount,
+		UpdatedAt:     time.Now(),
+	}
+	return status.Save(path)
+}
+
+// clock abstracts time so the poll loop below can be driven by fake clocks
+// in tests instead of real sleeps.
+type clock interface {
+	Now() time.Time
+	After(d time.Duration) <-chan time.Time
+}
+
+// realClock is the production clock implementation.
+type realClock struct{}
+
+func (realClock) Now() time.Time                         { return time.Now() }
+func (realClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+// DrainConfig configures RequestDrain's signal+poll handshake.
+type DrainConfig struct {
+	// StatusPath is where the target process reports its drain status.
+	// Defaults to DefaultDrainStatusPath().
+	StatusPath string
+
+	// Timeout bounds how long to wait for the target to report drained.
+	// Defaults to 30s.
+	Timeout time.Duration
+
+	// PollInterval is how often the status file is re-read. Defaults to
+	// 500ms.
+	PollInterval time.Duration
+}
+
+func (c *DrainConfig) withDefaults() DrainConfig {
+	cfg := DrainConfig{}
+	if c != nil {
+		cfg = *c
+	}
+	if cfg.StatusPath == "" {
+		cfg.StatusPath = DefaultDrainStatusPath()
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 30 * time.Second
+	}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 500 * time.Millisecond
+	}
+	return cfg
+}
+
+// RequestDrain signals pid to enter drain mode, then polls its status file
+// until it reports zero in-flight executions or cfg.Timeout elapses.
+// Returns Drained or TimedOut; DrainUnknown plus a non-nil error indicates
+// the signal failed to send, the status file could not be read, or ctx was
+// cancelled.
+func (g *GracefulUpgrader) RequestDrain(ctx context.Context, pid int, cfg *DrainConfig) (DrainOutcome, error) {
+	resolved := cfg.withDefaults()
+
+	if err := SignalDrain(pid); err != nil {
+		return DrainUnknown, fmt.Errorf("failed to signal drain: %w", err)
+	}
+
+	return waitForDrain(ctx, resolved.StatusPath, resolved.Timeout, resolved.PollInterval, g.clock)
+}
+
+// waitForDrain polls statusPath until the reported status shows the target
+// has drained (Draining && InFlightCount == 0), timeout elapses, or ctx is
+// cancelled.
+func waitForDrain(ctx context.Context, statusPath string, timeout, pollInterval time.Duration, clk clock) (DrainOutcome, error) {
+	if clk == nil {
+		clk = realClock{}
+	}
+
+	deadline := clk.Now().Add(timeout)
+
+	for {
+		status, err := LoadDrainStatus(statusPath)
+		if err != nil {
+			return DrainUnknown, err
+		}
+		if status != nil && status.Draining && status.InFlightCount == 0 {
+			return Drained, nil
+		}
+
+		if !clk.Now().Before(deadline) {
+			return TimedOut, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return DrainUnknown, ctx.Err()
+		case <-clk.After(pollInterval):
+		}
+	}
+}

--- a/internal/upgrade/drain_test.go
+++ b/internal/upgrade/drain_test.go
@@ -1,0 +1,353 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock is a deterministic clock for testing waitForDrain's poll loop
+// without real sleeps. Each After(d) call advances Now() by d immediately
+// and fires right away, so a bounded timeout resolves in a fixed number of
+// loop iterations instead of wall-clock time.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock(start time.Time) *fakeClock {
+	return &fakeClock{now: start}
+}
+
+func (f *fakeClock) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.now
+}
+
+func (f *fakeClock) After(d time.Duration) <-chan time.Time {
+	f.mu.Lock()
+	f.now = f.now.Add(d)
+	now := f.now
+	f.mu.Unlock()
+
+	ch := make(chan time.Time, 1)
+	ch <- now
+	return ch
+}
+
+// ---------------------------------------------------------------------------
+// DrainStatus persistence
+// ---------------------------------------------------------------------------
+
+func TestDrainStatus_SaveAndLoad_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	original := &DrainStatus{
+		PID:           1234,
+		Draining:      true,
+		InFlightCount: 2,
+		UpdatedAt:     time.Now().Truncate(time.Second),
+	}
+
+	if err := original.Save(path); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := LoadDrainStatus(path)
+	if err != nil {
+		t.Fatalf("LoadDrainStatus() error = %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("loaded status is nil")
+	}
+	if loaded.PID != original.PID {
+		t.Errorf("PID = %d, want %d", loaded.PID, original.PID)
+	}
+	if loaded.Draining != original.Draining {
+		t.Errorf("Draining = %v, want %v", loaded.Draining, original.Draining)
+	}
+	if loaded.InFlightCount != original.InFlightCount {
+		t.Errorf("InFlightCount = %d, want %d", loaded.InFlightCount, original.InFlightCount)
+	}
+}
+
+func TestLoadDrainStatus_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist.json")
+
+	status, err := LoadDrainStatus(path)
+	if err != nil {
+		t.Fatalf("LoadDrainStatus() error = %v, want nil for missing file", err)
+	}
+	if status != nil {
+		t.Errorf("status = %+v, want nil for missing file", status)
+	}
+}
+
+func TestLoadDrainStatus_CorruptedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corrupt.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadDrainStatus(path)
+	if err == nil {
+		t.Fatal("LoadDrainStatus() expected error for corrupted file, got nil")
+	}
+}
+
+func TestDrainStatus_SaveCreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "deep", "drain-status.json")
+
+	status := &DrainStatus{PID: 1, Draining: true}
+	if err := status.Save(path); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := LoadDrainStatus(path)
+	if err != nil {
+		t.Fatalf("LoadDrainStatus() error = %v", err)
+	}
+	if loaded == nil || !loaded.Draining {
+		t.Errorf("loaded = %+v, want Draining=true", loaded)
+	}
+}
+
+func TestReportDrainStatus(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	if err := ReportDrainStatus(path, 999, true, 3); err != nil {
+		t.Fatalf("ReportDrainStatus() error = %v", err)
+	}
+
+	loaded, err := LoadDrainStatus(path)
+	if err != nil {
+		t.Fatalf("LoadDrainStatus() error = %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("loaded status is nil")
+	}
+	if loaded.PID != 999 || !loaded.Draining || loaded.InFlightCount != 3 {
+		t.Errorf("loaded = %+v, want {PID:999 Draining:true InFlightCount:3}", loaded)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DrainOutcome
+// ---------------------------------------------------------------------------
+
+func TestDrainOutcome_String(t *testing.T) {
+	tests := []struct {
+		outcome DrainOutcome
+		want    string
+	}{
+		{Drained, "drained"},
+		{TimedOut, "timed_out"},
+		{DrainUnknown, "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.outcome.String(); got != tt.want {
+			t.Errorf("String() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// waitForDrain poll loop (fake clock — no real sleeping)
+// ---------------------------------------------------------------------------
+
+func TestWaitForDrain_DrainedImmediately(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	status := &DrainStatus{PID: 1, Draining: true, InFlightCount: 0}
+	if err := status.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	clk := newFakeClock(time.Now())
+	outcome, err := waitForDrain(context.Background(), path, 5*time.Second, 100*time.Millisecond, clk)
+	if err != nil {
+		t.Fatalf("waitForDrain() error = %v", err)
+	}
+	if outcome != Drained {
+		t.Errorf("outcome = %v, want Drained", outcome)
+	}
+}
+
+func TestWaitForDrain_DrainedAfterFewPolls(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	// Not draining yet — still has an in-flight execution.
+	status := &DrainStatus{PID: 1, Draining: true, InFlightCount: 1}
+	if err := status.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	// This test exercises real concurrent updates against a real-time poll
+	// loop, so it uses realClock rather than fakeClock: fakeClock's virtual
+	// time advances instantly on every poll tick, decoupled from wall-clock
+	// time, which would race ahead of the background goroutine's real sleep
+	// below and time out before the status file is ever updated.
+	done := make(chan struct{})
+	go func() {
+		// Simulate the target process finishing its last execution
+		// shortly after being signaled.
+		time.Sleep(20 * time.Millisecond)
+		final := &DrainStatus{PID: 1, Draining: true, InFlightCount: 0}
+		_ = final.Save(path)
+		close(done)
+	}()
+
+	outcome, err := waitForDrain(context.Background(), path, 2*time.Second, 5*time.Millisecond, realClock{})
+	<-done
+	if err != nil {
+		t.Fatalf("waitForDrain() error = %v", err)
+	}
+	if outcome != Drained {
+		t.Errorf("outcome = %v, want Drained", outcome)
+	}
+}
+
+func TestWaitForDrain_TimedOut(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	// Perpetually busy — never reports zero in-flight.
+	status := &DrainStatus{PID: 1, Draining: true, InFlightCount: 4}
+	if err := status.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	clk := newFakeClock(time.Now())
+	outcome, err := waitForDrain(context.Background(), path, 1*time.Second, 100*time.Millisecond, clk)
+	if err != nil {
+		t.Fatalf("waitForDrain() error = %v", err)
+	}
+	if outcome != TimedOut {
+		t.Errorf("outcome = %v, want TimedOut", outcome)
+	}
+}
+
+func TestWaitForDrain_NoStatusFileYet_TimesOut(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "never-written.json")
+
+	clk := newFakeClock(time.Now())
+	outcome, err := waitForDrain(context.Background(), path, 1*time.Second, 100*time.Millisecond, clk)
+	if err != nil {
+		t.Fatalf("waitForDrain() error = %v", err)
+	}
+	if outcome != TimedOut {
+		t.Errorf("outcome = %v, want TimedOut", outcome)
+	}
+}
+
+func TestWaitForDrain_NotDrainingIgnoresZeroInFlight(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	// An idle process that hasn't been signaled yet may happen to have
+	// InFlightCount == 0 — that must not read as "drained" without
+	// Draining also being true.
+	status := &DrainStatus{PID: 1, Draining: false, InFlightCount: 0}
+	if err := status.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	clk := newFakeClock(time.Now())
+	outcome, err := waitForDrain(context.Background(), path, 1*time.Second, 100*time.Millisecond, clk)
+	if err != nil {
+		t.Fatalf("waitForDrain() error = %v", err)
+	}
+	if outcome != TimedOut {
+		t.Errorf("outcome = %v, want TimedOut", outcome)
+	}
+}
+
+func TestWaitForDrain_ContextCancelled(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	status := &DrainStatus{PID: 1, Draining: true, InFlightCount: 1}
+	if err := status.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	clk := newFakeClock(time.Now())
+	outcome, err := waitForDrain(ctx, path, 5*time.Second, 100*time.Millisecond, clk)
+	if err == nil {
+		t.Fatal("waitForDrain() expected error for cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+	if outcome != DrainUnknown {
+		t.Errorf("outcome = %v, want DrainUnknown", outcome)
+	}
+}
+
+func TestWaitForDrain_LoadErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corrupt.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	clk := newFakeClock(time.Now())
+	outcome, err := waitForDrain(context.Background(), path, 1*time.Second, 100*time.Millisecond, clk)
+	if err == nil {
+		t.Fatal("waitForDrain() expected error for corrupted status file, got nil")
+	}
+	if outcome != DrainUnknown {
+		t.Errorf("outcome = %v, want DrainUnknown", outcome)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DrainConfig defaults
+// ---------------------------------------------------------------------------
+
+func TestDrainConfig_WithDefaults_NilConfig(t *testing.T) {
+	var cfg *DrainConfig
+	resolved := cfg.withDefaults()
+
+	if resolved.Timeout != 30*time.Second {
+		t.Errorf("Timeout = %v, want 30s", resolved.Timeout)
+	}
+	if resolved.PollInterval != 500*time.Millisecond {
+		t.Errorf("PollInterval = %v, want 500ms", resolved.PollInterval)
+	}
+	if resolved.StatusPath != DefaultDrainStatusPath() {
+		t.Errorf("StatusPath = %q, want %q", resolved.StatusPath, DefaultDrainStatusPath())
+	}
+}
+
+func TestDrainConfig_WithDefaults_PartialOverride(t *testing.T) {
+	cfg := &DrainConfig{Timeout: 2 * time.Second}
+	resolved := cfg.withDefaults()
+
+	if resolved.Timeout != 2*time.Second {
+		t.Errorf("Timeout = %v, want 2s", resolved.Timeout)
+	}
+	if resolved.PollInterval != 500*time.Millisecond {
+		t.Errorf("PollInterval = %v, want default 500ms", resolved.PollInterval)
+	}
+}
+
+// GracefulUpgrader.RequestDrain's signal-delivery half depends on SignalDrain,
+// which is platform-specific (drain_unix.go / drain_windows.go) — see
+// drain_unix_test.go for the live signal+poll integration test.

--- a/internal/upgrade/drain_unix.go
+++ b/internal/upgrade/drain_unix.go
@@ -1,0 +1,33 @@
+// Package upgrade provides self-update functionality for Pilot.
+// This file sends the drain signal on UNIX-like systems.
+
+//go:build !windows
+
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// drainSignal is the OS signal used to ask a target process to enter drain
+// mode. SIGUSR1 is not used elsewhere in Pilot and is safe to repurpose for
+// this handshake.
+const drainSignal = syscall.SIGUSR1
+
+// SignalDrain asks the process at pid to enter drain mode by sending
+// drainSignal. The target process is expected to have installed a handler
+// (via signal.Notify with drainSignal) that begins reporting its in-flight
+// count with ReportDrainStatus at DefaultDrainStatusPath (or whatever path
+// the caller and target have agreed on).
+func SignalDrain(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("failed to find process %d: %w", pid, err)
+	}
+	if err := proc.Signal(drainSignal); err != nil {
+		return fmt.Errorf("failed to signal drain to pid %d: %w", pid, err)
+	}
+	return nil
+}

--- a/internal/upgrade/drain_unix_test.go
+++ b/internal/upgrade/drain_unix_test.go
@@ -1,0 +1,100 @@
+// Package upgrade provides self-update functionality for Pilot.
+// This file tests the UNIX drain signal delivery.
+
+//go:build !windows
+
+package upgrade
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestSignalDrain_DeliversSignal sends the drain signal to the current
+// process and verifies it arrives. A signal.Notify handler must be
+// registered first — SIGUSR1's default disposition is to terminate the
+// process, so an unhandled send here would kill the test binary.
+func TestSignalDrain_DeliversSignal(t *testing.T) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, drainSignal)
+	defer signal.Stop(sigCh)
+
+	if err := SignalDrain(os.Getpid()); err != nil {
+		t.Fatalf("SignalDrain() error = %v", err)
+	}
+
+	select {
+	case sig := <-sigCh:
+		if sig != syscall.SIGUSR1 {
+			t.Errorf("received signal = %v, want SIGUSR1", sig)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for drain signal to be delivered")
+	}
+}
+
+func TestSignalDrain_InvalidPID(t *testing.T) {
+	// PID 0 and negative PIDs are never valid single-process targets; on most
+	// UNIX systems this either errors on FindProcess/Signal or targets a
+	// process group, so assert only that the exported PID lookup path (not a
+	// crash) is exercised. A defensively huge PID is guaranteed unused.
+	err := SignalDrain(1 << 30)
+	if err == nil {
+		t.Fatal("SignalDrain() expected error for a PID that does not exist, got nil")
+	}
+}
+
+// TestGracefulUpgrader_RequestDrain_SignalAndPoll exercises the full
+// handshake end-to-end: RequestDrain signals this process, a background
+// goroutine acts as the "target" by catching the signal and reporting a
+// drained status shortly after, and RequestDrain's poll loop picks it up.
+func TestGracefulUpgrader_RequestDrain_SignalAndPoll(t *testing.T) {
+	tc := &mockTaskChecker{}
+	g, dir := newTestGracefulUpgrader(t, tc)
+	g.clock = realClock{}
+
+	statusPath := filepath.Join(dir, "drain-status.json")
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, drainSignal)
+	defer signal.Stop(sigCh)
+
+	go func() {
+		<-sigCh
+		// Simulate the target finishing one in-flight execution after
+		// acknowledging the drain request.
+		time.Sleep(20 * time.Millisecond)
+		_ = ReportDrainStatus(statusPath, os.Getpid(), true, 0)
+	}()
+
+	outcome, err := g.RequestDrain(context.Background(), os.Getpid(), &DrainConfig{
+		StatusPath:   statusPath,
+		Timeout:      2 * time.Second,
+		PollInterval: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("RequestDrain() error = %v", err)
+	}
+	if outcome != Drained {
+		t.Errorf("outcome = %v, want Drained", outcome)
+	}
+}
+
+func TestGracefulUpgrader_RequestDrain_SignalFailurePropagates(t *testing.T) {
+	tc := &mockTaskChecker{}
+	g, _ := newTestGracefulUpgrader(t, tc)
+	g.clock = realClock{}
+
+	outcome, err := g.RequestDrain(context.Background(), 1<<30, nil)
+	if err == nil {
+		t.Fatal("RequestDrain() expected error for nonexistent PID, got nil")
+	}
+	if outcome != DrainUnknown {
+		t.Errorf("outcome = %v, want DrainUnknown", outcome)
+	}
+}

--- a/internal/upgrade/drain_windows.go
+++ b/internal/upgrade/drain_windows.go
@@ -1,0 +1,17 @@
+// Package upgrade provides self-update functionality for Pilot.
+// This file contains the Windows drain-signal stub.
+
+//go:build windows
+
+package upgrade
+
+import "fmt"
+
+// SignalDrain is not supported on Windows: there is no SIGUSR1 equivalent
+// exposed by the Go runtime for arbitrary target processes. Callers on
+// Windows should coordinate draining out-of-band (e.g. the target process
+// checking DefaultDrainStatusPath's directory for a request file written by
+// the caller) before falling back to WaitForDrain-style polling.
+func SignalDrain(pid int) error {
+	return fmt.Errorf("signal-based drain is not supported on Windows")
+}

--- a/internal/upgrade/drain_windows_test.go
+++ b/internal/upgrade/drain_windows_test.go
@@ -1,0 +1,18 @@
+// Package upgrade provides self-update functionality for Pilot.
+// This file tests the Windows drain-signal stub.
+
+//go:build windows
+
+package upgrade
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSignalDrain_UnsupportedOnWindows(t *testing.T) {
+	err := SignalDrain(os.Getpid())
+	if err == nil {
+		t.Fatal("SignalDrain() expected an unsupported-platform error on Windows, got nil")
+	}
+}

--- a/internal/upgrade/graceful.go
+++ b/internal/upgrade/graceful.go
@@ -11,6 +11,10 @@ type GracefulUpgrader struct {
 	upgrader    *Upgrader
 	statePath   string
 	taskChecker TaskChecker
+
+	// clock drives RequestDrain's poll loop (drain.go); defaults to
+	// realClock{} and is swapped for a fake in tests.
+	clock clock
 }
 
 // TaskChecker interface for checking running tasks
@@ -33,6 +37,7 @@ func NewGracefulUpgrader(currentVersion string, taskChecker TaskChecker) (*Grace
 		upgrader:    upgrader,
 		statePath:   DefaultStatePath(),
 		taskChecker: taskChecker,
+		clock:       realClock{},
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- Extends `internal/upgrade` (GracefulUpgrader/TaskChecker) with the missing cross-process IPC leg: `SignalDrain(pid)` asks a target PID to enter drain mode (SIGUSR1 on UNIX; unsupported stub on Windows), and `GracefulUpgrader.RequestDrain` polls a JSON `DrainStatus` file (same on-disk pattern as `state.go`) until the target reports zero in-flight executions or a bounded timeout elapses.
- Returns a typed `DrainOutcome` (`Drained` / `TimedOut` / `DrainUnknown`) so callers can branch.
- The poll loop takes an injectable `clock` interface so unit tests exercise timeout/backoff deterministically without real sleeps.
- Scope confined to `internal/upgrade/` per the task.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/upgrade/...` (incl. new drain tests, run with `-count=10` for flake-checking)
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/upgrade/...`