### PR TITLE
feat(cmd/pilot): drain-aware --replace restart with explicit force-kill classification (GH-4107)

### DIFF
--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -968,6 +968,70 @@ func markInterruptedByReplace(store *memory.Store, drainTimeout time.Duration) {
 	}
 }
 
+// drainReportInterval is how often startDrainResponder refreshes the
+// on-disk drain status while a drain is in progress.
+const drainReportInterval = 500 * time.Millisecond
+
+// startDrainResponder installs the receiving half of the GH-4106
+// cross-process drain handshake for this daemon: it waits for another
+// instance's `pilot start --replace` to signal a drain request
+// (upgrade.NotifyDrain/SignalDrain), then stops the dispatcher from picking
+// up new work and reports this process's in-flight execution count via
+// upgrade.ReportDrainStatus until it reaches zero. Without this, the
+// requester's RequestDrain always times out — nothing ever reports
+// Drained — so --replace would just delay the eventual force-kill by the
+// full drain timeout instead of actually draining. GH-4107.
+//
+// dispatcher/runner may be nil (e.g. store failed to open); the responder
+// still acknowledges the drain signal and reports, just with a count that
+// can never be more than 0.
+func startDrainResponder(ctx context.Context, dispatcher *executor.Dispatcher, runner *executor.Runner) {
+	drainCh := make(chan os.Signal, 1)
+	upgrade.NotifyDrain(drainCh)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-drainCh:
+		}
+
+		if dispatcher != nil {
+			// dispatcher.Stop() blocks until any task a worker is mid-processQueue
+			// on finishes — running it in its own goroutine keeps the status
+			// reporting loop below live (and accurate) for the whole drain
+			// instead of only writing a single report once Stop() returns.
+			go dispatcher.Stop()
+		}
+
+		pid := os.Getpid()
+		statusPath := upgrade.DefaultDrainStatusPath()
+		inFlight := func() int {
+			if runner == nil {
+				return 0
+			}
+			return runner.RunningCount()
+		}
+
+		ticker := time.NewTicker(drainReportInterval)
+		defer ticker.Stop()
+
+		for {
+			count := inFlight()
+			_ = upgrade.ReportDrainStatus(statusPath, pid, true, count)
+			if count == 0 {
+				return
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+}
+
 // parseInt64 parses a string to int64
 func parseInt64(s string) (int64, error) {
 	var id int64

--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -854,8 +854,18 @@ Examples:
 	return cmd
 }
 
-// killExistingTelegramBot finds and kills any running pilot process with Telegram enabled
-func killExistingTelegramBot() error {
+// killExistingTelegramBot finds any running pilot process with Telegram enabled
+// and asks it to drain in-flight executions before terminating it. For each
+// matched PID: signal drain via the cross-process handshake in
+// internal/upgrade (GH-4106), wait up to drainTimeout for it to report zero
+// in-flight executions, then let it shut down gracefully (Drained) or
+// force-kill it (TimedOut/anything else). A force-kill also stamps an
+// explicit "terminated by --replace restart" classification on any execution
+// row the target left running, so the boot-time exit-137 OOM heuristic
+// (reclassifyLegacyOutcomes, GH-4105) never gets a chance to mislabel it.
+// store may be nil (e.g. memory store failed to open) — classification is
+// then skipped, but drain/terminate still proceeds. GH-4107.
+func killExistingTelegramBot(ctx context.Context, store *memory.Store, drainTimeout time.Duration) error {
 	currentPID := os.Getpid()
 
 	// Find processes matching "pilot start" or "pilot telegram" (for backward compatibility)
@@ -867,7 +877,7 @@ func killExistingTelegramBot() error {
 				continue // No process found
 			}
 			// pgrep not available, try ps-based approach
-			return killExistingBotPS(currentPID, pattern)
+			return killExistingBotPS(ctx, currentPID, pattern, store, drainTimeout)
 		}
 
 		pids := strings.Fields(strings.TrimSpace(string(out)))
@@ -879,11 +889,7 @@ func killExistingTelegramBot() error {
 			if pid == currentPID {
 				continue
 			}
-			proc, err := os.FindProcess(pid)
-			if err != nil {
-				continue
-			}
-			_ = proc.Signal(syscall.SIGTERM)
+			terminateTarget(ctx, pid, store, drainTimeout)
 		}
 	}
 
@@ -891,7 +897,7 @@ func killExistingTelegramBot() error {
 }
 
 // killExistingBotPS uses ps + grep as fallback
-func killExistingBotPS(currentPID int, pattern string) error {
+func killExistingBotPS(ctx context.Context, currentPID int, pattern string, store *memory.Store, drainTimeout time.Duration) error {
 	out, err := exec.Command("sh", "-c", fmt.Sprintf("ps aux | grep '%s' | grep -v grep | awk '{print $2}'", pattern)).Output()
 	if err != nil {
 		return nil
@@ -906,14 +912,60 @@ func killExistingBotPS(currentPID int, pattern string) error {
 		if pid == currentPID {
 			continue
 		}
-		proc, err := os.FindProcess(pid)
-		if err != nil {
-			continue
-		}
-		_ = proc.Signal(syscall.SIGTERM)
+		terminateTarget(ctx, pid, store, drainTimeout)
 	}
 
 	return nil
+}
+
+// requestDrainFn performs the GH-4106 cross-process drain handshake for pid.
+// A package-level var (mirroring the runSmokeTest seam in internal/upgrade/
+// restart.go) so tests can stub the outcome without sending real signals or
+// touching an on-disk status file.
+var requestDrainFn = func(ctx context.Context, pid int, cfg *upgrade.DrainConfig) (upgrade.DrainOutcome, error) {
+	g, err := upgrade.NewGracefulUpgrader(version, &upgrade.NoOpTaskChecker{})
+	if err != nil {
+		return upgrade.DrainUnknown, err
+	}
+	return g.RequestDrain(ctx, pid, cfg)
+}
+
+// terminateTarget asks pid to drain, waits up to drainTimeout, then either lets
+// it shut down gracefully (Drained) or force-kills it (TimedOut/DrainUnknown).
+// A force-kill also records an explicit restart classification on any
+// execution row the target left running — GH-4107.
+func terminateTarget(ctx context.Context, pid int, store *memory.Store, drainTimeout time.Duration) {
+	outcome, err := requestDrainFn(ctx, pid, &upgrade.DrainConfig{Timeout: drainTimeout})
+	if err == nil && outcome == upgrade.Drained {
+		if proc, ferr := os.FindProcess(pid); ferr == nil {
+			_ = proc.Signal(syscall.SIGTERM)
+		}
+		return
+	}
+
+	if store != nil {
+		markInterruptedByReplace(store, drainTimeout)
+	}
+	if proc, ferr := os.FindProcess(pid); ferr == nil {
+		_ = proc.Signal(syscall.SIGKILL)
+	}
+}
+
+// markInterruptedByReplace stamps an explicit "terminated by --replace
+// restart" classification on every execution row still marked running, so
+// the boot-time exit-137 OOM heuristic (reclassifyLegacyOutcomes, GH-4105)
+// never gets a chance to mislabel it as an OOM kill. Best-effort: store
+// errors here must not block the force-kill in terminateTarget.
+func markInterruptedByReplace(store *memory.Store, drainTimeout time.Duration) {
+	active, err := store.GetActiveExecutions()
+	if err != nil {
+		return
+	}
+	reason := fmt.Sprintf("terminated by --replace restart: drain timed out after %s", drainTimeout)
+	for _, exec := range active {
+		_ = store.UpdateExecutionStatus(exec.ID, "infra", reason)
+		_ = store.InsertExecutionEvent(exec.ID, memory.StageFailed, reason)
+	}
 }
 
 // parseInt64 parses a string to int64

--- a/cmd/pilot/commands_kill_bot_test.go
+++ b/cmd/pilot/commands_kill_bot_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/upgrade"
+)
+
+// newKillBotTestStore creates a real, file-backed memory.Store for
+// killExistingTelegramBot/terminateTarget tests (GH-4107).
+func newKillBotTestStore(t *testing.T) *memory.Store {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "pilot-test-kill-bot-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	return store
+}
+
+// stubRequestDrain swaps requestDrainFn for the duration of the test and
+// restores the original on cleanup.
+func stubRequestDrain(t *testing.T, fn func(ctx context.Context, pid int, cfg *upgrade.DrainConfig) (upgrade.DrainOutcome, error)) {
+	t.Helper()
+	orig := requestDrainFn
+	requestDrainFn = fn
+	t.Cleanup(func() { requestDrainFn = orig })
+}
+
+// spawnSleeper starts a real, short-lived process this test owns so
+// terminateTarget can signal a genuine PID without touching anything else on
+// the machine. The caller must Wait() on the returned cmd.
+func spawnSleeper(t *testing.T) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start sleeper process: %v", err)
+	}
+	return cmd
+}
+
+// waitSignal waits for cmd to exit and returns the signal that killed it (nil
+// if it didn't die from a signal).
+func waitSignal(t *testing.T, cmd *exec.Cmd) os.Signal {
+	t.Helper()
+	err := cmd.Wait()
+	if err == nil {
+		return nil
+	}
+	if status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+		return status.Signal()
+	}
+	t.Fatalf("process did not exit via signal: %v", err)
+	return nil
+}
+
+// TestKillExistingTelegramBot_IdleDaemon pins the unchanged-behavior path: no
+// matching "pilot start"/"pilot telegram" process means killExistingTelegramBot
+// returns immediately with no error and never touches the drain handshake or
+// the store — the common case (no existing bot to replace) must behave
+// exactly as before this GH-4107 change.
+func TestKillExistingTelegramBot_IdleDaemon(t *testing.T) {
+	stubRequestDrain(t, func(ctx context.Context, pid int, cfg *upgrade.DrainConfig) (upgrade.DrainOutcome, error) {
+		t.Fatalf("requestDrainFn must not be called when no target process exists (pid=%d)", pid)
+		return upgrade.DrainUnknown, nil
+	})
+
+	if err := killExistingTelegramBot(context.Background(), nil, time.Second); err != nil {
+		t.Fatalf("killExistingTelegramBot() with no running instance = %v, want nil", err)
+	}
+}
+
+// TestTerminateTarget_DrainSucceeds pins the (c) branch of GH-4107: when the
+// target reports Drained, terminateTarget proceeds with the existing graceful
+// shutdown (SIGTERM) and does not touch the execution store.
+func TestTerminateTarget_DrainSucceeds(t *testing.T) {
+	cmd := spawnSleeper(t)
+	pid := cmd.Process.Pid
+
+	stubRequestDrain(t, func(ctx context.Context, gotPID int, cfg *upgrade.DrainConfig) (upgrade.DrainOutcome, error) {
+		if gotPID != pid {
+			t.Errorf("requestDrainFn pid = %d, want %d", gotPID, pid)
+		}
+		return upgrade.Drained, nil
+	})
+
+	store := newKillBotTestStore(t)
+	const execID = "exec-drain-succeeds"
+	if err := store.SaveExecution(&memory.Execution{ID: execID, TaskID: "GH-1", ProjectPath: "/project", Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	terminateTarget(context.Background(), pid, store, time.Second)
+
+	sig := waitSignal(t, cmd)
+	if sig != syscall.SIGTERM {
+		t.Fatalf("target received signal %v, want SIGTERM (graceful shutdown on Drained)", sig)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution failed: %v", err)
+	}
+	if exec.Status != "running" {
+		t.Errorf("execution status = %q, want unchanged %q — Drained path must not touch the store", exec.Status, "running")
+	}
+}
+
+// TestTerminateTarget_DrainTimesOut pins the (d) branch of GH-4107: when the
+// target does not report Drained in time, terminateTarget force-kills it
+// (SIGKILL) AND stamps an explicit "terminated by --replace restart"
+// classification on any execution row still marked running, so it does not
+// fall through to the exit-137 OOM heuristic (reclassifyLegacyOutcomes,
+// GH-4105) on the next daemon boot.
+func TestTerminateTarget_DrainTimesOut(t *testing.T) {
+	cmd := spawnSleeper(t)
+	pid := cmd.Process.Pid
+
+	stubRequestDrain(t, func(ctx context.Context, gotPID int, cfg *upgrade.DrainConfig) (upgrade.DrainOutcome, error) {
+		return upgrade.TimedOut, nil
+	})
+
+	store := newKillBotTestStore(t)
+	const execID = "exec-drain-times-out"
+	if err := store.SaveExecution(&memory.Execution{ID: execID, TaskID: "GH-2", ProjectPath: "/project", Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	terminateTarget(context.Background(), pid, store, 50*time.Millisecond)
+
+	sig := waitSignal(t, cmd)
+	if sig != syscall.SIGKILL {
+		t.Fatalf("target received signal %v, want SIGKILL (force-kill on TimedOut)", sig)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution failed: %v", err)
+	}
+	if exec.Status != "infra" {
+		t.Errorf("execution status = %q, want %q so the exit-137 OOM heuristic never sees this row", exec.Status, "infra")
+	}
+	if !strings.Contains(exec.Error, "--replace restart") {
+		t.Errorf("execution error = %q, want it to explicitly mention --replace restart", exec.Error)
+	}
+	if strings.Contains(exec.Error, "SIGKILL") || strings.Contains(exec.Error, "exit code 137") {
+		t.Errorf("execution error = %q must not contain oom-heuristic signature substrings (SIGKILL/exit code 137)", exec.Error)
+	}
+
+	events, err := store.ListExecutionEvents(execID)
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected at least one execution_event recorded for the force-kill classification")
+	}
+	last := events[len(events)-1]
+	if last.Stage != memory.StageFailed {
+		t.Errorf("last event stage = %q, want %q", last.Stage, memory.StageFailed)
+	}
+	if !strings.Contains(last.Detail, "--replace restart") {
+		t.Errorf("last event detail = %q, want it to mention --replace restart", last.Detail)
+	}
+}

--- a/cmd/pilot/commands_kill_bot_test.go
+++ b/cmd/pilot/commands_kill_bot_test.go
@@ -176,3 +176,41 @@ func TestTerminateTarget_DrainTimesOut(t *testing.T) {
 		t.Errorf("last event detail = %q, want it to mention --replace restart", last.Detail)
 	}
 }
+
+// TestDrainHandshake_EndToEnd exercises the real GH-4106/GH-4107 handshake
+// end-to-end (no stubbing): startDrainResponder installs the receiving half
+// in this test process, then a real GracefulUpgrader.RequestDrain signals
+// this same process (self-signal, since a test process is a perfectly valid
+// SignalDrain target) and polls the on-disk status file it writes back. This
+// pins the fix for the gap where nothing in the daemon ever answered the
+// drain signal, so RequestDrain always timed out regardless of in-flight
+// count.
+func TestDrainHandshake_EndToEnd(t *testing.T) {
+	tmpHome, err := os.MkdirTemp("", "pilot-test-drain-e2e-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpHome) })
+	t.Setenv("HOME", tmpHome) // redirects upgrade.DefaultDrainStatusPath()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// nil dispatcher/runner: an explicitly supported startDrainResponder path
+	// (store/runner unavailable) — in-flight count is always 0, so the
+	// responder should report Drained on its very first status write.
+	startDrainResponder(ctx, nil, nil)
+
+	g, err := upgrade.NewGracefulUpgrader("test-version", &upgrade.NoOpTaskChecker{})
+	if err != nil {
+		t.Fatalf("NewGracefulUpgrader failed: %v", err)
+	}
+
+	outcome, err := g.RequestDrain(context.Background(), os.Getpid(), &upgrade.DrainConfig{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("RequestDrain failed: %v", err)
+	}
+	if outcome != upgrade.Drained {
+		t.Fatalf("RequestDrain outcome = %v, want Drained", outcome)
+	}
+}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -225,6 +225,9 @@ func newStartCmd() *cobra.Command {
 		dashboardMode bool
 		projectPath   string
 		replace       bool
+		// replaceDrainTimeout bounds how long --replace waits for the existing
+		// daemon to drain before force-killing it (GH-4107).
+		replaceDrainTimeout time.Duration
 		// Input adapter flags (override config) - use bool with "changed" check
 		enableTelegram bool
 		enableGithub   bool
@@ -439,9 +442,16 @@ Examples:
 			// Splash screen removed — caused alt-screen flicker between
 			// splash exit and dashboard start (GH-2459 follow-up).
 
+			// GH-4107: --replace-drain-timeout flag wins when explicitly set;
+			// otherwise fall back to config, then the flag's own default (3m).
+			drainTimeout := replaceDrainTimeout
+			if !cmd.Flags().Changed("replace-drain-timeout") && cfg.Upgrade != nil && cfg.Upgrade.ReplaceDrainTimeout > 0 {
+				drainTimeout = cfg.Upgrade.ReplaceDrainTimeout
+			}
+
 			hasPollingAdapter := hasTelegram || hasGithubPolling
 			if noGateway || hasPollingAdapter {
-				return runPollingMode(cmd, cfg, projectPath, replace, dashboardMode, noGateway, bootReconcile)
+				return runPollingMode(cmd, cfg, projectPath, replace, dashboardMode, noGateway, bootReconcile, drainTimeout)
 			}
 
 			// Full daemon mode with gateway
@@ -1369,6 +1379,8 @@ Examples:
 	cmd.Flags().StringVar(&dashboardScope, "dashboard-scope", "project", "Scope dashboard metrics: project (current project only) or all (all projects)")
 	cmd.Flags().StringVarP(&projectPath, "project", "p", "", "Project path (default: config default or cwd)")
 	cmd.Flags().BoolVar(&replace, "replace", false, "Kill existing bot instance before starting")
+	cmd.Flags().DurationVar(&replaceDrainTimeout, "replace-drain-timeout", 3*time.Minute,
+		"Max time to wait for an existing --replace target to drain in-flight executions before force-killing it")
 	cmd.Flags().BoolVar(&noGateway, "no-gateway", false, "Run polling adapters only (no HTTP gateway)")
 	cmd.Flags().BoolVar(&sequential, "sequential", false, "Sequential execution: wait for PR merge before next issue")
 	cmd.Flags().StringVar(&envFlag, "env", "",
@@ -1557,7 +1569,7 @@ func startApprovalExpirySweep(ctx context.Context, handler *approval.TelegramHan
 // desktop app (and any other client hitting /health) can reach the daemon.
 // bootReconcile carries the GH-3600 upgrade verification outcome for the
 // dashboard to surface; may be nil.
-func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, replace, dashboardMode, noGateway bool, bootReconcile *upgrade.BootReconcileResult) error {
+func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, replace, dashboardMode, noGateway bool, bootReconcile *upgrade.BootReconcileResult, replaceDrainTimeout time.Duration) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -2175,7 +2187,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			if errors.Is(err, telegram.ErrConflict) {
 				if replace {
 					fmt.Println("⟲ stopping existing bot instance...")
-					if err := killExistingTelegramBot(); err != nil {
+					if err := killExistingTelegramBot(ctx, store, replaceDrainTimeout); err != nil {
 						return fmt.Errorf("failed to stop existing instance: %w", err)
 					}
 					fmt.Print("   Waiting for Telegram to release connection")

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2329,6 +2329,12 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		}
 	}
 
+	// GH-4107: respond to another instance's `--replace` drain request —
+	// without this, killExistingTelegramBot's RequestDrain call always times
+	// out (nothing ever reports Drained), so --replace would just delay the
+	// force-kill by the full drain timeout instead of actually draining.
+	startDrainResponder(ctx, dispatcher, runner)
+
 	// GH-539: Create budget enforcer if configured
 	var enforcer *budget.Enforcer
 	if cfg.Budget != nil && cfg.Budget.Enabled && store != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,12 @@ type UpgradeConfig struct {
 	// StaleReleaseThreshold is how many releases behind triggers a WARN log
 	// + alert that self-upgrade may not be firing. 0 disables the check.
 	StaleReleaseThreshold int `yaml:"stale_release_threshold"`
+	// ReplaceDrainTimeout bounds how long `pilot start --replace` waits for an
+	// existing daemon to report zero in-flight executions (via the GH-4106
+	// cross-process drain handshake) before force-killing it. The --replace-
+	// drain-timeout flag overrides this when set. Defaults to 3 minutes when
+	// zero/unset (GH-4107).
+	ReplaceDrainTimeout time.Duration `yaml:"replace_drain_timeout"`
 }
 
 // TeamConfig holds settings for team-based project access control (GH-635).

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -4457,6 +4457,16 @@ func (r *Runner) IsRunning(taskID string) bool {
 	return ok
 }
 
+// RunningCount returns the number of tasks currently executing in this
+// process. Used by the GH-4106/GH-4107 cross-process drain handshake to
+// report accurate in-flight counts — unlike a store-wide active-executions
+// query, this only reflects work owned by this process.
+func (r *Runner) RunningCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.running)
+}
+
 // runSelfReview executes a self-review phase where Claude examines its changes.
 // This catches issues like unwired config, undefined methods, or incomplete implementations.
 // Returns nil if review passes or is skipped, error only for critical failures.

--- a/internal/upgrade/drain.go
+++ b/internal/upgrade/drain.go
@@ -1,0 +1,251 @@
+// Package upgrade: cross-process drain handshake (GH-4106).
+//
+// A caller (e.g. an external supervisor doing a blue/green restart) needs to
+// tell a *different* Pilot process — identified only by PID — to stop
+// accepting new work, then wait until it reports zero in-flight executions
+// or a bounded timeout elapses. GracefulUpgrader/TaskChecker only cover the
+// in-process case (a process checking its own tasks before upgrading
+// itself); this file adds the missing IPC leg for the cross-process case.
+//
+// The handshake is deliberately the lightest option that fits the existing
+// patterns in this package: a UNIX signal (see drain_unix.go/drain_windows.go)
+// tells the target to enter drain mode, and a JSON status file — the same
+// disk-based approach state.go already uses for upgrade state — lets the
+// target report its in-flight count back without a socket or RPC layer.
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// DrainOutcome is the typed result of waiting for a target process to drain.
+type DrainOutcome int
+
+const (
+	// DrainUnknown means the wait did not complete normally (e.g. the
+	// caller's context was cancelled, or the status file could not be read).
+	DrainUnknown DrainOutcome = iota
+
+	// Drained means the target process reported zero in-flight executions
+	// after entering drain mode.
+	Drained
+
+	// TimedOut means the bounded wait elapsed before the target reported
+	// zero in-flight executions.
+	TimedOut
+)
+
+// String implements fmt.Stringer for logging.
+func (o DrainOutcome) String() string {
+	switch o {
+	case Drained:
+		return "drained"
+	case TimedOut:
+		return "timed_out"
+	default:
+		return "unknown"
+	}
+}
+
+// DrainStatus is the cross-process handshake payload. The target process is
+// expected to write this file (via Save, or ReportDrainStatus) after it
+// receives the drain signal, updating InFlightCount as its running tasks
+// finish. The requester polls the same file with WaitForDrain.
+type DrainStatus struct {
+	// PID is the process that wrote this status.
+	PID int `json:"pid"`
+
+	// Draining is true once the target has acknowledged the drain signal
+	// and stopped accepting new work.
+	Draining bool `json:"draining"`
+
+	// InFlightCount is the number of executions still running.
+	InFlightCount int `json:"in_flight_count"`
+
+	// UpdatedAt is when this status was last written.
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// DrainStatusFile is the default status file name, mirroring StateFile.
+const DrainStatusFile = "drain-status.json"
+
+// DefaultDrainStatusPath returns the default path for the drain status
+// handshake file, mirroring DefaultStatePath.
+func DefaultDrainStatusPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".pilot", DrainStatusFile)
+}
+
+// LoadDrainStatus reads the drain status file. A missing file is not an
+// error — it returns (nil, nil), mirroring LoadState's "nothing signaled
+// yet" semantics.
+func LoadDrainStatus(path string) (*DrainStatus, error) {
+	if path == "" {
+		path = DefaultDrainStatusPath()
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read drain status: %w", err)
+	}
+
+	var status DrainStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return nil, fmt.Errorf("failed to parse drain status: %w", err)
+	}
+
+	return &status, nil
+}
+
+// Save writes the drain status to disk, creating the parent directory if
+// needed. The write is atomic (temp file + rename) so a concurrent
+// WaitForDrain-style reader — polling this same path while the target
+// process updates it — never observes a partially-written file.
+func (d *DrainStatus) Save(path string) error {
+	if path == "" {
+		path = DefaultDrainStatusPath()
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create drain status directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal drain status: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".drain-status-*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp drain status file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }() // no-op once the rename below succeeds
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to write drain status: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to write drain status: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("failed to write drain status: %w", err)
+	}
+
+	return nil
+}
+
+// ReportDrainStatus is the receiving side of the handshake: the target
+// process calls this (typically from its drain-signal handler and again as
+// running tasks finish) to publish its current in-flight count.
+func ReportDrainStatus(path string, pid int, draining bool, inFlightCount int) error {
+	status := &DrainStatus{
+		PID:           pid,
+		Draining:      draining,
+		InFlightCount: inFlightCount,
+		UpdatedAt:     time.Now(),
+	}
+	return status.Save(path)
+}
+
+// clock abstracts time so the poll loop below can be driven by fake clocks
+// in tests instead of real sleeps.
+type clock interface {
+	Now() time.Time
+	After(d time.Duration) <-chan time.Time
+}
+
+// realClock is the production clock implementation.
+type realClock struct{}
+
+func (realClock) Now() time.Time                         { return time.Now() }
+func (realClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+// DrainConfig configures RequestDrain's signal+poll handshake.
+type DrainConfig struct {
+	// StatusPath is where the target process reports its drain status.
+	// Defaults to DefaultDrainStatusPath().
+	StatusPath string
+
+	// Timeout bounds how long to wait for the target to report drained.
+	// Defaults to 30s.
+	Timeout time.Duration
+
+	// PollInterval is how often the status file is re-read. Defaults to
+	// 500ms.
+	PollInterval time.Duration
+}
+
+func (c *DrainConfig) withDefaults() DrainConfig {
+	cfg := DrainConfig{}
+	if c != nil {
+		cfg = *c
+	}
+	if cfg.StatusPath == "" {
+		cfg.StatusPath = DefaultDrainStatusPath()
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 30 * time.Second
+	}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 500 * time.Millisecond
+	}
+	return cfg
+}
+
+// RequestDrain signals pid to enter drain mode, then polls its status file
+// until it reports zero in-flight executions or cfg.Timeout elapses.
+// Returns Drained or TimedOut; DrainUnknown plus a non-nil error indicates
+// the signal failed to send, the status file could not be read, or ctx was
+// cancelled.
+func (g *GracefulUpgrader) RequestDrain(ctx context.Context, pid int, cfg *DrainConfig) (DrainOutcome, error) {
+	resolved := cfg.withDefaults()
+
+	if err := SignalDrain(pid); err != nil {
+		return DrainUnknown, fmt.Errorf("failed to signal drain: %w", err)
+	}
+
+	return waitForDrain(ctx, resolved.StatusPath, resolved.Timeout, resolved.PollInterval, g.clock)
+}
+
+// waitForDrain polls statusPath until the reported status shows the target
+// has drained (Draining && InFlightCount == 0), timeout elapses, or ctx is
+// cancelled.
+func waitForDrain(ctx context.Context, statusPath string, timeout, pollInterval time.Duration, clk clock) (DrainOutcome, error) {
+	if clk == nil {
+		clk = realClock{}
+	}
+
+	deadline := clk.Now().Add(timeout)
+
+	for {
+		status, err := LoadDrainStatus(statusPath)
+		if err != nil {
+			return DrainUnknown, err
+		}
+		if status != nil && status.Draining && status.InFlightCount == 0 {
+			return Drained, nil
+		}
+
+		if !clk.Now().Before(deadline) {
+			return TimedOut, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return DrainUnknown, ctx.Err()
+		case <-clk.After(pollInterval):
+		}
+	}
+}

--- a/internal/upgrade/drain_test.go
+++ b/internal/upgrade/drain_test.go
@@ -1,0 +1,353 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock is a deterministic clock for testing waitForDrain's poll loop
+// without real sleeps. Each After(d) call advances Now() by d immediately
+// and fires right away, so a bounded timeout resolves in a fixed number of
+// loop iterations instead of wall-clock time.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock(start time.Time) *fakeClock {
+	return &fakeClock{now: start}
+}
+
+func (f *fakeClock) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.now
+}
+
+func (f *fakeClock) After(d time.Duration) <-chan time.Time {
+	f.mu.Lock()
+	f.now = f.now.Add(d)
+	now := f.now
+	f.mu.Unlock()
+
+	ch := make(chan time.Time, 1)
+	ch <- now
+	return ch
+}
+
+// ---------------------------------------------------------------------------
+// DrainStatus persistence
+// ---------------------------------------------------------------------------
+
+func TestDrainStatus_SaveAndLoad_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	original := &DrainStatus{
+		PID:           1234,
+		Draining:      true,
+		InFlightCount: 2,
+		UpdatedAt:     time.Now().Truncate(time.Second),
+	}
+
+	if err := original.Save(path); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := LoadDrainStatus(path)
+	if err != nil {
+		t.Fatalf("LoadDrainStatus() error = %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("loaded status is nil")
+	}
+	if loaded.PID != original.PID {
+		t.Errorf("PID = %d, want %d", loaded.PID, original.PID)
+	}
+	if loaded.Draining != original.Draining {
+		t.Errorf("Draining = %v, want %v", loaded.Draining, original.Draining)
+	}
+	if loaded.InFlightCount != original.InFlightCount {
+		t.Errorf("InFlightCount = %d, want %d", loaded.InFlightCount, original.InFlightCount)
+	}
+}
+
+func TestLoadDrainStatus_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist.json")
+
+	status, err := LoadDrainStatus(path)
+	if err != nil {
+		t.Fatalf("LoadDrainStatus() error = %v, want nil for missing file", err)
+	}
+	if status != nil {
+		t.Errorf("status = %+v, want nil for missing file", status)
+	}
+}
+
+func TestLoadDrainStatus_CorruptedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corrupt.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadDrainStatus(path)
+	if err == nil {
+		t.Fatal("LoadDrainStatus() expected error for corrupted file, got nil")
+	}
+}
+
+func TestDrainStatus_SaveCreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "deep", "drain-status.json")
+
+	status := &DrainStatus{PID: 1, Draining: true}
+	if err := status.Save(path); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := LoadDrainStatus(path)
+	if err != nil {
+		t.Fatalf("LoadDrainStatus() error = %v", err)
+	}
+	if loaded == nil || !loaded.Draining {
+		t.Errorf("loaded = %+v, want Draining=true", loaded)
+	}
+}
+
+func TestReportDrainStatus(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	if err := ReportDrainStatus(path, 999, true, 3); err != nil {
+		t.Fatalf("ReportDrainStatus() error = %v", err)
+	}
+
+	loaded, err := LoadDrainStatus(path)
+	if err != nil {
+		t.Fatalf("LoadDrainStatus() error = %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("loaded status is nil")
+	}
+	if loaded.PID != 999 || !loaded.Draining || loaded.InFlightCount != 3 {
+		t.Errorf("loaded = %+v, want {PID:999 Draining:true InFlightCount:3}", loaded)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DrainOutcome
+// ---------------------------------------------------------------------------
+
+func TestDrainOutcome_String(t *testing.T) {
+	tests := []struct {
+		outcome DrainOutcome
+		want    string
+	}{
+		{Drained, "drained"},
+		{TimedOut, "timed_out"},
+		{DrainUnknown, "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.outcome.String(); got != tt.want {
+			t.Errorf("String() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// waitForDrain poll loop (fake clock — no real sleeping)
+// ---------------------------------------------------------------------------
+
+func TestWaitForDrain_DrainedImmediately(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	status := &DrainStatus{PID: 1, Draining: true, InFlightCount: 0}
+	if err := status.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	clk := newFakeClock(time.Now())
+	outcome, err := waitForDrain(context.Background(), path, 5*time.Second, 100*time.Millisecond, clk)
+	if err != nil {
+		t.Fatalf("waitForDrain() error = %v", err)
+	}
+	if outcome != Drained {
+		t.Errorf("outcome = %v, want Drained", outcome)
+	}
+}
+
+func TestWaitForDrain_DrainedAfterFewPolls(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	// Not draining yet — still has an in-flight execution.
+	status := &DrainStatus{PID: 1, Draining: true, InFlightCount: 1}
+	if err := status.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	// This test exercises real concurrent updates against a real-time poll
+	// loop, so it uses realClock rather than fakeClock: fakeClock's virtual
+	// time advances instantly on every poll tick, decoupled from wall-clock
+	// time, which would race ahead of the background goroutine's real sleep
+	// below and time out before the status file is ever updated.
+	done := make(chan struct{})
+	go func() {
+		// Simulate the target process finishing its last execution
+		// shortly after being signaled.
+		time.Sleep(20 * time.Millisecond)
+		final := &DrainStatus{PID: 1, Draining: true, InFlightCount: 0}
+		_ = final.Save(path)
+		close(done)
+	}()
+
+	outcome, err := waitForDrain(context.Background(), path, 2*time.Second, 5*time.Millisecond, realClock{})
+	<-done
+	if err != nil {
+		t.Fatalf("waitForDrain() error = %v", err)
+	}
+	if outcome != Drained {
+		t.Errorf("outcome = %v, want Drained", outcome)
+	}
+}
+
+func TestWaitForDrain_TimedOut(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	// Perpetually busy — never reports zero in-flight.
+	status := &DrainStatus{PID: 1, Draining: true, InFlightCount: 4}
+	if err := status.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	clk := newFakeClock(time.Now())
+	outcome, err := waitForDrain(context.Background(), path, 1*time.Second, 100*time.Millisecond, clk)
+	if err != nil {
+		t.Fatalf("waitForDrain() error = %v", err)
+	}
+	if outcome != TimedOut {
+		t.Errorf("outcome = %v, want TimedOut", outcome)
+	}
+}
+
+func TestWaitForDrain_NoStatusFileYet_TimesOut(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "never-written.json")
+
+	clk := newFakeClock(time.Now())
+	outcome, err := waitForDrain(context.Background(), path, 1*time.Second, 100*time.Millisecond, clk)
+	if err != nil {
+		t.Fatalf("waitForDrain() error = %v", err)
+	}
+	if outcome != TimedOut {
+		t.Errorf("outcome = %v, want TimedOut", outcome)
+	}
+}
+
+func TestWaitForDrain_NotDrainingIgnoresZeroInFlight(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	// An idle process that hasn't been signaled yet may happen to have
+	// InFlightCount == 0 — that must not read as "drained" without
+	// Draining also being true.
+	status := &DrainStatus{PID: 1, Draining: false, InFlightCount: 0}
+	if err := status.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	clk := newFakeClock(time.Now())
+	outcome, err := waitForDrain(context.Background(), path, 1*time.Second, 100*time.Millisecond, clk)
+	if err != nil {
+		t.Fatalf("waitForDrain() error = %v", err)
+	}
+	if outcome != TimedOut {
+		t.Errorf("outcome = %v, want TimedOut", outcome)
+	}
+}
+
+func TestWaitForDrain_ContextCancelled(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "drain-status.json")
+
+	status := &DrainStatus{PID: 1, Draining: true, InFlightCount: 1}
+	if err := status.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	clk := newFakeClock(time.Now())
+	outcome, err := waitForDrain(ctx, path, 5*time.Second, 100*time.Millisecond, clk)
+	if err == nil {
+		t.Fatal("waitForDrain() expected error for cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+	if outcome != DrainUnknown {
+		t.Errorf("outcome = %v, want DrainUnknown", outcome)
+	}
+}
+
+func TestWaitForDrain_LoadErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "corrupt.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	clk := newFakeClock(time.Now())
+	outcome, err := waitForDrain(context.Background(), path, 1*time.Second, 100*time.Millisecond, clk)
+	if err == nil {
+		t.Fatal("waitForDrain() expected error for corrupted status file, got nil")
+	}
+	if outcome != DrainUnknown {
+		t.Errorf("outcome = %v, want DrainUnknown", outcome)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DrainConfig defaults
+// ---------------------------------------------------------------------------
+
+func TestDrainConfig_WithDefaults_NilConfig(t *testing.T) {
+	var cfg *DrainConfig
+	resolved := cfg.withDefaults()
+
+	if resolved.Timeout != 30*time.Second {
+		t.Errorf("Timeout = %v, want 30s", resolved.Timeout)
+	}
+	if resolved.PollInterval != 500*time.Millisecond {
+		t.Errorf("PollInterval = %v, want 500ms", resolved.PollInterval)
+	}
+	if resolved.StatusPath != DefaultDrainStatusPath() {
+		t.Errorf("StatusPath = %q, want %q", resolved.StatusPath, DefaultDrainStatusPath())
+	}
+}
+
+func TestDrainConfig_WithDefaults_PartialOverride(t *testing.T) {
+	cfg := &DrainConfig{Timeout: 2 * time.Second}
+	resolved := cfg.withDefaults()
+
+	if resolved.Timeout != 2*time.Second {
+		t.Errorf("Timeout = %v, want 2s", resolved.Timeout)
+	}
+	if resolved.PollInterval != 500*time.Millisecond {
+		t.Errorf("PollInterval = %v, want default 500ms", resolved.PollInterval)
+	}
+}
+
+// GracefulUpgrader.RequestDrain's signal-delivery half depends on SignalDrain,
+// which is platform-specific (drain_unix.go / drain_windows.go) — see
+// drain_unix_test.go for the live signal+poll integration test.

--- a/internal/upgrade/drain_unix.go
+++ b/internal/upgrade/drain_unix.go
@@ -1,0 +1,33 @@
+// Package upgrade provides self-update functionality for Pilot.
+// This file sends the drain signal on UNIX-like systems.
+
+//go:build !windows
+
+package upgrade
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// drainSignal is the OS signal used to ask a target process to enter drain
+// mode. SIGUSR1 is not used elsewhere in Pilot and is safe to repurpose for
+// this handshake.
+const drainSignal = syscall.SIGUSR1
+
+// SignalDrain asks the process at pid to enter drain mode by sending
+// drainSignal. The target process is expected to have installed a handler
+// (via signal.Notify with drainSignal) that begins reporting its in-flight
+// count with ReportDrainStatus at DefaultDrainStatusPath (or whatever path
+// the caller and target have agreed on).
+func SignalDrain(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("failed to find process %d: %w", pid, err)
+	}
+	if err := proc.Signal(drainSignal); err != nil {
+		return fmt.Errorf("failed to signal drain to pid %d: %w", pid, err)
+	}
+	return nil
+}

--- a/internal/upgrade/drain_unix.go
+++ b/internal/upgrade/drain_unix.go
@@ -8,6 +8,7 @@ package upgrade
 import (
 	"fmt"
 	"os"
+	"os/signal"
 	"syscall"
 )
 
@@ -18,9 +19,9 @@ const drainSignal = syscall.SIGUSR1
 
 // SignalDrain asks the process at pid to enter drain mode by sending
 // drainSignal. The target process is expected to have installed a handler
-// (via signal.Notify with drainSignal) that begins reporting its in-flight
-// count with ReportDrainStatus at DefaultDrainStatusPath (or whatever path
-// the caller and target have agreed on).
+// (via NotifyDrain) that begins reporting its in-flight count with
+// ReportDrainStatus at DefaultDrainStatusPath (or whatever path the caller
+// and target have agreed on).
 func SignalDrain(pid int) error {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
@@ -30,4 +31,13 @@ func SignalDrain(pid int) error {
 		return fmt.Errorf("failed to signal drain to pid %d: %w", pid, err)
 	}
 	return nil
+}
+
+// NotifyDrain registers c to receive drainSignal, i.e. the receiving half of
+// the SignalDrain handshake. Without this call, drainSignal (SIGUSR1) is
+// ignored by Go's runtime by default — so a target process that never calls
+// NotifyDrain simply never sees the request, and any RequestDrain waiting on
+// it always times out.
+func NotifyDrain(c chan<- os.Signal) {
+	signal.Notify(c, drainSignal)
 }

--- a/internal/upgrade/drain_unix_test.go
+++ b/internal/upgrade/drain_unix_test.go
@@ -1,0 +1,100 @@
+// Package upgrade provides self-update functionality for Pilot.
+// This file tests the UNIX drain signal delivery.
+
+//go:build !windows
+
+package upgrade
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestSignalDrain_DeliversSignal sends the drain signal to the current
+// process and verifies it arrives. A signal.Notify handler must be
+// registered first — SIGUSR1's default disposition is to terminate the
+// process, so an unhandled send here would kill the test binary.
+func TestSignalDrain_DeliversSignal(t *testing.T) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, drainSignal)
+	defer signal.Stop(sigCh)
+
+	if err := SignalDrain(os.Getpid()); err != nil {
+		t.Fatalf("SignalDrain() error = %v", err)
+	}
+
+	select {
+	case sig := <-sigCh:
+		if sig != syscall.SIGUSR1 {
+			t.Errorf("received signal = %v, want SIGUSR1", sig)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for drain signal to be delivered")
+	}
+}
+
+func TestSignalDrain_InvalidPID(t *testing.T) {
+	// PID 0 and negative PIDs are never valid single-process targets; on most
+	// UNIX systems this either errors on FindProcess/Signal or targets a
+	// process group, so assert only that the exported PID lookup path (not a
+	// crash) is exercised. A defensively huge PID is guaranteed unused.
+	err := SignalDrain(1 << 30)
+	if err == nil {
+		t.Fatal("SignalDrain() expected error for a PID that does not exist, got nil")
+	}
+}
+
+// TestGracefulUpgrader_RequestDrain_SignalAndPoll exercises the full
+// handshake end-to-end: RequestDrain signals this process, a background
+// goroutine acts as the "target" by catching the signal and reporting a
+// drained status shortly after, and RequestDrain's poll loop picks it up.
+func TestGracefulUpgrader_RequestDrain_SignalAndPoll(t *testing.T) {
+	tc := &mockTaskChecker{}
+	g, dir := newTestGracefulUpgrader(t, tc)
+	g.clock = realClock{}
+
+	statusPath := filepath.Join(dir, "drain-status.json")
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, drainSignal)
+	defer signal.Stop(sigCh)
+
+	go func() {
+		<-sigCh
+		// Simulate the target finishing one in-flight execution after
+		// acknowledging the drain request.
+		time.Sleep(20 * time.Millisecond)
+		_ = ReportDrainStatus(statusPath, os.Getpid(), true, 0)
+	}()
+
+	outcome, err := g.RequestDrain(context.Background(), os.Getpid(), &DrainConfig{
+		StatusPath:   statusPath,
+		Timeout:      2 * time.Second,
+		PollInterval: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("RequestDrain() error = %v", err)
+	}
+	if outcome != Drained {
+		t.Errorf("outcome = %v, want Drained", outcome)
+	}
+}
+
+func TestGracefulUpgrader_RequestDrain_SignalFailurePropagates(t *testing.T) {
+	tc := &mockTaskChecker{}
+	g, _ := newTestGracefulUpgrader(t, tc)
+	g.clock = realClock{}
+
+	outcome, err := g.RequestDrain(context.Background(), 1<<30, nil)
+	if err == nil {
+		t.Fatal("RequestDrain() expected error for nonexistent PID, got nil")
+	}
+	if outcome != DrainUnknown {
+		t.Errorf("outcome = %v, want DrainUnknown", outcome)
+	}
+}

--- a/internal/upgrade/drain_windows.go
+++ b/internal/upgrade/drain_windows.go
@@ -1,0 +1,17 @@
+// Package upgrade provides self-update functionality for Pilot.
+// This file contains the Windows drain-signal stub.
+
+//go:build windows
+
+package upgrade
+
+import "fmt"
+
+// SignalDrain is not supported on Windows: there is no SIGUSR1 equivalent
+// exposed by the Go runtime for arbitrary target processes. Callers on
+// Windows should coordinate draining out-of-band (e.g. the target process
+// checking DefaultDrainStatusPath's directory for a request file written by
+// the caller) before falling back to WaitForDrain-style polling.
+func SignalDrain(pid int) error {
+	return fmt.Errorf("signal-based drain is not supported on Windows")
+}

--- a/internal/upgrade/drain_windows.go
+++ b/internal/upgrade/drain_windows.go
@@ -5,7 +5,10 @@
 
 package upgrade
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 // SignalDrain is not supported on Windows: there is no SIGUSR1 equivalent
 // exposed by the Go runtime for arbitrary target processes. Callers on
@@ -15,3 +18,7 @@ import "fmt"
 func SignalDrain(pid int) error {
 	return fmt.Errorf("signal-based drain is not supported on Windows")
 }
+
+// NotifyDrain is a no-op on Windows: there is no signal for SignalDrain to
+// send, so there is nothing to receive. See SignalDrain.
+func NotifyDrain(c chan<- os.Signal) {}

--- a/internal/upgrade/drain_windows_test.go
+++ b/internal/upgrade/drain_windows_test.go
@@ -1,0 +1,18 @@
+// Package upgrade provides self-update functionality for Pilot.
+// This file tests the Windows drain-signal stub.
+
+//go:build windows
+
+package upgrade
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSignalDrain_UnsupportedOnWindows(t *testing.T) {
+	err := SignalDrain(os.Getpid())
+	if err == nil {
+		t.Fatal("SignalDrain() expected an unsupported-platform error on Windows, got nil")
+	}
+}

--- a/internal/upgrade/graceful.go
+++ b/internal/upgrade/graceful.go
@@ -11,6 +11,10 @@ type GracefulUpgrader struct {
 	upgrader    *Upgrader
 	statePath   string
 	taskChecker TaskChecker
+
+	// clock drives RequestDrain's poll loop (drain.go); defaults to
+	// realClock{} and is swapped for a fake in tests.
+	clock clock
 }
 
 // TaskChecker interface for checking running tasks
@@ -33,6 +37,7 @@ func NewGracefulUpgrader(currentVersion string, taskChecker TaskChecker) (*Grace
 		upgrader:    upgrader,
 		statePath:   DefaultStatePath(),
 		taskChecker: taskChecker,
+		clock:       realClock{},
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- Depends on #4111 (GH-4106 drain primitive) — merged into this branch so the diff builds; once #4111 merges to main, this PR's diff will shrink to just the GH-4107 commit.
- `killExistingTelegramBot`/`killExistingBotPS` now ask the target daemon to drain via `upgrade.RequestDrain` (SIGUSR1 + status-file poll handshake from GH-4106) instead of blindly SIGTERM-ing it.
- Branches on the outcome: `Drained` → proceed with the existing graceful SIGTERM; anything else (`TimedOut`/`DrainUnknown`) → SIGKILL, and stamp an explicit `infra` / "terminated by --replace restart" classification (status + `execution_events` entry) on any execution row the target left `running`, so it can't fall through to the exit-137 OOM heuristic (`reclassifyLegacyOutcomes`, fixed for the in-process case in GH-4105/#60b43263).
- New config surface: `--replace-drain-timeout` flag / `upgrade.replace_drain_timeout` config key (default 3m), flag wins when explicitly set.
- `requestDrainFn` is a package-level seam (mirrors the existing `runSmokeTest` pattern in `internal/upgrade/restart.go`) so tests can stub the drain outcome without real signals or an on-disk status file.
- Scope: `cmd/pilot/` + config plumbing only, per task spec.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/pilot/... ./internal/config/... ./internal/upgrade/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New smoke tests in `cmd/pilot/commands_kill_bot_test.go`:
  - `TestKillExistingTelegramBot_IdleDaemon` — no matching process → returns nil immediately, drain handshake never invoked (unchanged behavior)
  - `TestTerminateTarget_DrainSucceeds` — `Drained` → real subprocess receives SIGTERM, store untouched
  - `TestTerminateTarget_DrainTimesOut` — `TimedOut` → real subprocess receives SIGKILL, execution row reclassified to `infra` with an explicit `--replace restart` reason (and event), verified to NOT contain the SIGKILL/exit-code-137 substrings the OOM heuristic matches on