### PR TITLE
fix(cmd): reach SDK poller from sub-issue-skip / done / stale-label loops (GH-4110)

### DIFF
--- a/cmd/pilot/github_poller_registry.go
+++ b/cmd/pilot/github_poller_registry.go
@@ -1,0 +1,114 @@
+package main
+
+import "sync"
+
+// githubProcessedMarker is the subset of GitHub poller behavior the cross-poller
+// skip / clear loops depend on (GH-3240 sub-issue skip, GH-3271 done re-mark,
+// GH-2589/GH-2402 stale-label recovery). Both the in-tree *github.Poller and the
+// SDK *githubSDK.Poller satisfy it, so a single registry can route marking to
+// whichever poller owns a given repo.
+type githubProcessedMarker interface {
+	MarkProcessed(number int)
+	ClearProcessed(number int)
+}
+
+// githubPollerRegistry maps owner/repo → the poller(s) responsible for that repo.
+//
+// It closes two defects at once (GH-4110):
+//
+//   - The SDK poller handle never left githubPollerRegistration()'s CreateAndStart
+//     closure, so the main.go skip / clear loops — which ranged only the in-tree
+//     ghPollers slice — could not reach it. Since 2026-07-06 the pilot repo polls
+//     via the SDK poller, so its epic-created sub-issues were never skip-marked and
+//     got duplicate-dispatched (confirmed live on epic GH-3927's children).
+//   - Marking ranged every in-tree poller regardless of repo, so a sub-issue number
+//     in one repo could suppress an unrelated same-numbered issue in another repo.
+//
+// Registration happens during startup: in-tree pollers add themselves inline, the
+// SDK poller adds itself from its synchronous CreateAndStart. The skip / clear
+// callbacks capture the registry by reference and fire later at runtime, by which
+// point every poller is registered. Designed for N per-repo instances — the M7
+// 4d.2 fan-out will register multiple SDK pollers here.
+//
+// All methods are safe on a nil receiver so callers need not guard.
+type githubPollerRegistry struct {
+	mu     sync.Mutex
+	byRepo map[string][]githubProcessedMarker
+}
+
+func newGithubPollerRegistry() *githubPollerRegistry {
+	return &githubPollerRegistry{byRepo: make(map[string][]githubProcessedMarker)}
+}
+
+// add registers a poller as an owner of repo (owner/repo form). No-op when the
+// registry, marker, or repo is empty.
+func (r *githubPollerRegistry) add(repo string, m githubProcessedMarker) {
+	if r == nil || m == nil || repo == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.byRepo[repo] = append(r.byRepo[repo], m)
+}
+
+// markProcessed marks issue number n processed in every poller registered for
+// repo. When repo is empty (source repo unknown) it falls back to marking all
+// pollers: under-marking would re-introduce the duplicate-dispatch bug this
+// registry exists to fix, which is the worse failure than the cross-repo
+// over-mark the fallback risks.
+func (r *githubPollerRegistry) markProcessed(repo string, n int) {
+	if r == nil {
+		return
+	}
+	if repo == "" {
+		r.markProcessedAll(n)
+		return
+	}
+	for _, m := range r.snapshot(repo) {
+		m.MarkProcessed(n)
+	}
+}
+
+// markProcessedAll marks n processed in every registered poller across all repos.
+func (r *githubPollerRegistry) markProcessedAll(n int) {
+	if r == nil {
+		return
+	}
+	for _, m := range r.snapshotAll() {
+		m.MarkProcessed(n)
+	}
+}
+
+// clearProcessed clears issue number n in every poller registered for repo
+// (stale-label recovery). Cleaners are always constructed for a concrete repo,
+// so repo is non-empty in practice.
+func (r *githubPollerRegistry) clearProcessed(repo string, n int) {
+	if r == nil {
+		return
+	}
+	for _, m := range r.snapshot(repo) {
+		m.ClearProcessed(n)
+	}
+}
+
+// snapshot copies the markers for one repo under lock so callouts happen without
+// holding the mutex.
+func (r *githubPollerRegistry) snapshot(repo string) []githubProcessedMarker {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	src := r.byRepo[repo]
+	out := make([]githubProcessedMarker, len(src))
+	copy(out, src)
+	return out
+}
+
+// snapshotAll copies every registered marker under lock.
+func (r *githubPollerRegistry) snapshotAll() []githubProcessedMarker {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []githubProcessedMarker
+	for _, ms := range r.byRepo {
+		out = append(out, ms...)
+	}
+	return out
+}

--- a/cmd/pilot/github_poller_registry_test.go
+++ b/cmd/pilot/github_poller_registry_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"sort"
+	"sync"
+	"testing"
+)
+
+// fakeMarker records MarkProcessed / ClearProcessed calls for assertions.
+type fakeMarker struct {
+	mu      sync.Mutex
+	marked  []int
+	cleared []int
+}
+
+func (f *fakeMarker) MarkProcessed(n int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.marked = append(f.marked, n)
+}
+
+func (f *fakeMarker) ClearProcessed(n int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cleared = append(f.cleared, n)
+}
+
+func (f *fakeMarker) snapshotMarked() []int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := append([]int(nil), f.marked...)
+	sort.Ints(out)
+	return out
+}
+
+func (f *fakeMarker) snapshotCleared() []int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := append([]int(nil), f.cleared...)
+	sort.Ints(out)
+	return out
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// GH-4110 core guarantee: marking is scoped to the target repo so a sub-issue
+// number in one repo cannot suppress a same-numbered issue in another.
+func TestGithubPollerRegistry_MarkProcessedScopedByRepo(t *testing.T) {
+	reg := newGithubPollerRegistry()
+	a := &fakeMarker{}
+	b := &fakeMarker{}
+	reg.add("owner/a", a)
+	reg.add("owner/b", b)
+
+	reg.markProcessed("owner/a", 42)
+
+	if got := a.snapshotMarked(); !equalInts(got, []int{42}) {
+		t.Errorf("repo a marked = %v, want [42]", got)
+	}
+	if got := b.snapshotMarked(); len(got) != 0 {
+		t.Errorf("repo b marked = %v, want [] (cross-repo leak)", got)
+	}
+}
+
+// N pollers for the same repo (M7 4d.2 fan-out shape) all get marked.
+func TestGithubPollerRegistry_MultiplePollersPerRepo(t *testing.T) {
+	reg := newGithubPollerRegistry()
+	p1 := &fakeMarker{}
+	p2 := &fakeMarker{}
+	reg.add("owner/a", p1)
+	reg.add("owner/a", p2)
+
+	reg.markProcessed("owner/a", 7)
+
+	for i, p := range []*fakeMarker{p1, p2} {
+		if got := p.snapshotMarked(); !equalInts(got, []int{7}) {
+			t.Errorf("poller %d marked = %v, want [7]", i, got)
+		}
+	}
+}
+
+// Empty repo (unknown source repo) falls back to marking every poller so the
+// skip guarantee is never lost — under-marking is the worse failure.
+func TestGithubPollerRegistry_EmptyRepoMarksAll(t *testing.T) {
+	reg := newGithubPollerRegistry()
+	a := &fakeMarker{}
+	b := &fakeMarker{}
+	reg.add("owner/a", a)
+	reg.add("owner/b", b)
+
+	reg.markProcessed("", 99)
+
+	if got := a.snapshotMarked(); !equalInts(got, []int{99}) {
+		t.Errorf("repo a marked = %v, want [99]", got)
+	}
+	if got := b.snapshotMarked(); !equalInts(got, []int{99}) {
+		t.Errorf("repo b marked = %v, want [99]", got)
+	}
+}
+
+// clearProcessed is likewise repo-scoped (stale-label recovery).
+func TestGithubPollerRegistry_ClearProcessedScopedByRepo(t *testing.T) {
+	reg := newGithubPollerRegistry()
+	a := &fakeMarker{}
+	b := &fakeMarker{}
+	reg.add("owner/a", a)
+	reg.add("owner/b", b)
+
+	reg.clearProcessed("owner/b", 13)
+
+	if got := a.snapshotCleared(); len(got) != 0 {
+		t.Errorf("repo a cleared = %v, want []", got)
+	}
+	if got := b.snapshotCleared(); !equalInts(got, []int{13}) {
+		t.Errorf("repo b cleared = %v, want [13]", got)
+	}
+}
+
+// Marking/clearing a repo with no registered poller is a harmless no-op — this
+// is what lets the stale-label cleaner wire callbacks unconditionally.
+func TestGithubPollerRegistry_UnknownRepoNoop(t *testing.T) {
+	reg := newGithubPollerRegistry()
+	reg.add("owner/a", &fakeMarker{})
+	// Must not panic.
+	reg.markProcessed("owner/missing", 1)
+	reg.clearProcessed("owner/missing", 1)
+}
+
+// All methods are nil-safe so callers (gateway mode, GitHub polling off) need
+// not guard.
+func TestGithubPollerRegistry_NilSafe(t *testing.T) {
+	var reg *githubPollerRegistry
+	reg.add("owner/a", &fakeMarker{})
+	reg.markProcessed("owner/a", 1)
+	reg.markProcessedAll(1)
+	reg.clearProcessed("owner/a", 1)
+}
+
+// add ignores empty repo / nil marker rather than corrupting the map.
+func TestGithubPollerRegistry_AddGuards(t *testing.T) {
+	reg := newGithubPollerRegistry()
+	reg.add("", &fakeMarker{})
+	reg.add("owner/a", nil)
+	// Nothing registered → marking is a no-op, no panic.
+	reg.markProcessed("owner/a", 1)
+	if len(reg.byRepo) != 0 {
+		t.Errorf("registry byRepo = %v, want empty after guarded adds", reg.byRepo)
+	}
+}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2391,6 +2391,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 
 	// GH-929: Start GitHub polling for multiple repos if enabled
 	var ghPollers []*github.Poller
+	// GH-4110: repo-keyed registry of every GitHub poller (in-tree ones added
+	// inline below, the SDK poller from its CreateAndStart). The sub-issue-skip /
+	// done-remark / stale-label callbacks route through this so they reach the SDK
+	// poller and stay scoped to the correct repo.
+	ghPollerRegistry := newGithubPollerRegistry()
 	polledRepos := make(map[string]bool) // Track repos already polled to avoid duplicates
 
 	if cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled &&
@@ -2597,6 +2602,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					}
 				} else {
 					ghPollers = append(ghPollers, poller)
+					ghPollerRegistry.add(cfg.Adapters.GitHub.Repo, poller)
 					if !dashboardMode {
 						fmt.Printf("● github polling · %s (every %s, mode: %s)\n", cfg.Adapters.GitHub.Repo, interval, modeStr)
 					}
@@ -2628,6 +2634,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					continue
 				}
 				ghPollers = append(ghPollers, poller)
+				ghPollerRegistry.add(repoFullName, poller)
 				if !dashboardMode {
 					fmt.Printf("● github polling · %s (project: %s, every %s, mode: %s)\n", repoFullName, proj.Name, interval, modeStr)
 				}
@@ -2717,22 +2724,24 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					runner.SetOnSubIssuePRCreated(autopilotController.OnPRCreated)
 				}
 
-				// GH-3240: mark epic-created sub-issues as processed in all pollers so
-				// findOldestUnprocessedIssue does not re-dispatch them.
-				runner.SetSubIssuePollerSkip(func(n int) {
-					for _, p := range ghPollers {
-						p.MarkProcessed(n)
-					}
+				// GH-3240: mark epic-created sub-issues as processed so
+				// findOldestUnprocessedIssue does not re-dispatch them. GH-4110: route
+				// through the repo-keyed registry (reaches the SDK poller, whose handle
+				// never leaves githubPollerRegistration()) and scope the mark to the
+				// sub-issue's repo so it cannot suppress a same-numbered issue elsewhere.
+				runner.SetSubIssuePollerSkip(func(n int, repo string) {
+					ghPollerRegistry.markProcessed(repo, n)
 				})
 
 				// GH-3271: when autopilot marks an issue done after PR-merge, immediately
-				// re-mark it processed in all pollers so a poll tick during the
-				// merge→pilot-done label propagation window cannot re-dispatch it.
-				for _, ctrl := range autopilotControllers {
+				// re-mark it processed so a poll tick during the merge→pilot-done label
+				// propagation window cannot re-dispatch it. GH-4110: scope to the
+				// controller's own repo and route via the registry so the SDK poller is
+				// covered too.
+				for repoKey, ctrl := range autopilotControllers {
+					repoKey := repoKey
 					ctrl.SetOnIssueDone(func(n int) {
-						for _, p := range ghPollers {
-							p.MarkProcessed(n)
-						}
+						ghPollerRegistry.markProcessed(repoKey, n)
 					})
 				}
 
@@ -2767,27 +2776,25 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			if cfg.Adapters.GitHub.Repo != "" && cfg.Adapters.GitHub.StaleLabelCleanup != nil && cfg.Adapters.GitHub.StaleLabelCleanup.Enabled {
 				if store != nil {
 					cleanerOpts := []github.CleanerOption{}
-					// Wire callback to clear processed map when pilot-failed labels are removed
-					if len(ghPollers) > 0 {
-						cleanerOpts = append(cleanerOpts, github.WithOnFailedCleaned(func(issueNumber int) {
-							for _, p := range ghPollers {
-								p.ClearProcessed(issueNumber)
-							}
-						}))
-						// GH-2402: Same wiring for pilot-blocked so removal allows re-dispatch.
-						cleanerOpts = append(cleanerOpts, github.WithOnBlockedCleaned(func(issueNumber int) {
-							for _, p := range ghPollers {
-								p.ClearProcessed(issueNumber)
-							}
-						}))
-						// GH-2589: On startup recovery, clear the persistent processed store
-						// so the issue is re-dispatched on the next poll cycle.
-						cleanerOpts = append(cleanerOpts, github.WithOnStartupRecovered(func(issueNumber int) {
-							for _, p := range ghPollers {
-								p.ClearProcessed(issueNumber)
-							}
-						}))
-					}
+					// Clear the poller's processed map when a stale label is removed so
+					// the issue can be re-dispatched. GH-4110: this cleaner is scoped to
+					// the default repo, so route the clear through the registry keyed by
+					// that repo — it reaches the SDK poller (which is the default repo's
+					// poller when use_sdk_poller is on) and is a no-op if no poller for
+					// that repo is registered, so no ghPollers length guard is needed.
+					defaultRepo := cfg.Adapters.GitHub.Repo
+					cleanerOpts = append(cleanerOpts, github.WithOnFailedCleaned(func(issueNumber int) {
+						ghPollerRegistry.clearProcessed(defaultRepo, issueNumber)
+					}))
+					// GH-2402: Same wiring for pilot-blocked so removal allows re-dispatch.
+					cleanerOpts = append(cleanerOpts, github.WithOnBlockedCleaned(func(issueNumber int) {
+						ghPollerRegistry.clearProcessed(defaultRepo, issueNumber)
+					}))
+					// GH-2589: On startup recovery, clear the processed map so the issue
+					// is re-dispatched on the next poll cycle.
+					cleanerOpts = append(cleanerOpts, github.WithOnStartupRecovered(func(issueNumber int) {
+						ghPollerRegistry.clearProcessed(defaultRepo, issueNumber)
+					}))
 					// GH-2354: when pilot-in-progress is stripped from a closed
 					// issue, remove its task from the dashboard monitor so it
 					// stops showing in the queue view.
@@ -2838,6 +2845,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		AutopilotController:  autopilotController,
 		AutopilotStateStore:  autopilotStateStore,
 		AutopilotControllers: autopilotControllers,
+		GitHubPollers:        ghPollerRegistry, // GH-4110: SDK poller registers itself here
 	}
 	StartAdapterPollers(ctx, pollingDeps, adapterPollerRegistrations())
 

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -326,6 +326,20 @@ func githubPollerRegistration() PollerRegistration {
 
 			githubPoller := githubSDK.New(sdkCfg).NewPoller(pollerDeps)
 
+			// GH-4110: publish the SDK poller handle to the shared repo-keyed
+			// registry so the main.go sub-issue-skip / done-remark / stale-label
+			// loops can mark/clear it. Without this the handle stays trapped in this
+			// closure and the pilot repo's epic sub-issues get duplicate-dispatched.
+			// NewPoller returns the core.Poller interface (Start only), so assert to
+			// the mark/clear surface and fail loud if a future SDK drops it.
+			if deps.GitHubPollers != nil {
+				if marker, ok := githubPoller.(githubProcessedMarker); ok {
+					deps.GitHubPollers.add(ghCfg.Repo, marker)
+				} else {
+					log.Error("GitHub SDK poller does not expose MarkProcessed/ClearProcessed; cross-poller sub-issue skip and stale-label recovery cannot reach it (GH-4110)")
+				}
+			}
+
 			log.Info("GitHub SDK polling enabled (M7 4b)",
 				slog.String("repo", ghCfg.Repo),
 				slog.String("label", pilotLabel),

--- a/cmd/pilot/poller_registry.go
+++ b/cmd/pilot/poller_registry.go
@@ -31,6 +31,12 @@ type PollerDeps struct {
 	AutopilotController  *autopilot.Controller
 	AutopilotStateStore  *autopilot.StateStore
 	AutopilotControllers map[string]*autopilot.Controller // polling mode: per-repo controllers
+
+	// GitHubPollers is the repo-keyed registry the SDK poller adds itself to so the
+	// main.go sub-issue-skip / done-remark / stale-label loops can reach it — its
+	// handle otherwise never leaves githubPollerRegistration() (GH-4110). Nil when
+	// GitHub polling is off.
+	GitHubPollers *githubPollerRegistry
 }
 
 // PollerRegistration describes a single adapter poller that can be conditionally started.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/qf-studio/grot v0.1.0
-	github.com/qf-studio/studio-sdk v0.29.0
+	github.com/qf-studio/studio-sdk v0.30.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/wailsapp/wails/v2 v2.11.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qf-studio/grot v0.1.0 h1:ehDjZTiQ+IRr6P+gKWVgL+j6Hluq3U2HxFug2ry51rI=
 github.com/qf-studio/grot v0.1.0/go.mod h1:cJGVeAEoskCOQZG1CNgI/CAYXDG6vUUpsqVqi30tLRk=
-github.com/qf-studio/studio-sdk v0.29.0 h1:z+aUP2eOHaElI3uSRNlMzNolW6fTwc0ky64riRdVcWk=
-github.com/qf-studio/studio-sdk v0.29.0/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
+github.com/qf-studio/studio-sdk v0.30.0 h1:zr/4nqmCSgwNU+OIc0naA7w0nl/MlAnbNzi5CFbo8Sw=
+github.com/qf-studio/studio-sdk v0.30.0/go.mod h1:M/uFBeXsPAtsrO7wiIgE/GgWzfw80ftW6BrQUIOwxUM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1427,8 +1427,14 @@ func (r *Runner) createSubIssuesViaGitHub(ctx context.Context, plan *EpicPlan, e
 
 		// GH-3240: pre-mark in the poller so the sub-issue is not re-dispatched
 		// on the next poll cycle (the epic will execute it directly via ExecuteSubIssues).
+		// GH-4110: scope the mark to the parent's repo (sub-issues are created in it)
+		// so it reaches that repo's poller and no other.
 		if r.subIssuePollerSkip != nil && issueNumber > 0 {
-			r.subIssuePollerSkip(issueNumber)
+			skipRepo := ""
+			if plan.ParentTask != nil {
+				skipRepo = plan.ParentTask.SourceRepo
+			}
+			r.subIssuePollerSkip(issueNumber, skipRepo)
 		}
 
 		// Track order → issue number for dependency resolution (GH-1794)

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -2762,14 +2762,16 @@ echo "https://github.com/owner/repo/issues/$N"
 
 	var mu sync.Mutex
 	var skipped []int
-	runner.SetSubIssuePollerSkip(func(n int) {
+	var skippedRepos []string
+	runner.SetSubIssuePollerSkip(func(n int, repo string) {
 		mu.Lock()
 		skipped = append(skipped, n)
+		skippedRepos = append(skippedRepos, repo)
 		mu.Unlock()
 	})
 
 	plan := &EpicPlan{
-		ParentTask: &Task{ID: "GH-99"},
+		ParentTask: &Task{ID: "GH-99", SourceRepo: "qf-studio/pilot"},
 		Subtasks: []PlannedSubtask{
 			{Title: "feat(sub): first subtask", Description: "First", Order: 1},
 			{Title: "feat(sub): second subtask", Description: "Second", Order: 2},
@@ -2786,6 +2788,7 @@ echo "https://github.com/owner/repo/issues/$N"
 
 	mu.Lock()
 	got := append([]int(nil), skipped...)
+	gotRepos := append([]string(nil), skippedRepos...)
 	mu.Unlock()
 
 	if len(got) != 2 {
@@ -2794,6 +2797,10 @@ echo "https://github.com/owner/repo/issues/$N"
 	for i, issue := range created {
 		if got[i] != issue.Number {
 			t.Errorf("skipped[%d] = %d, want %d (issue.Number)", i, got[i], issue.Number)
+		}
+		// GH-4110: the skip must carry the parent's repo so marking is scoped to it.
+		if gotRepos[i] != "qf-studio/pilot" {
+			t.Errorf("skippedRepos[%d] = %q, want %q (ParentTask.SourceRepo)", i, gotRepos[i], "qf-studio/pilot")
 		}
 	}
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -570,9 +570,12 @@ type SubIssuePRCallback func(prNumber int, prURL string, issueNumber int, headSH
 // to enforce sequential ordering: sub-issue N+1 only starts after sub-issue N is merged.
 type SubIssueMergeWaitFn func(ctx context.Context, prNumber int) error
 
-// SubIssuePollerSkipFn is called with each newly-created GitHub sub-issue number so the
-// poller marks it as already-processed and does not re-dispatch it (GH-3240).
-type SubIssuePollerSkipFn func(issueNumber int)
+// SubIssuePollerSkipFn is called with each newly-created GitHub sub-issue number and the
+// owner/repo it was created in so the poller for that repo marks it as already-processed
+// and does not re-dispatch it (GH-3240). The repo scopes the mark so a sub-issue number
+// in one repo cannot suppress an unrelated same-numbered issue in another (GH-4110); an
+// empty repo marks all pollers as a safe fallback.
+type SubIssuePollerSkipFn func(issueNumber int, repo string)
 
 // SubIssueCreator is an interface for creating sub-issues in external issue trackers.
 // Adapters like Linear, Jira, GitLab, and Azure DevOps can implement this interface


### PR DESCRIPTION
Closes #4110. M7 4d.2a (human-led — no `pilot` label).

## Problem
Since 2026-07-06 the pilot repo polls via the **SDK poller**, but three `main.go` cross-poller loops ranged only the in-tree `ghPollers` slice — the SDK poller handle never left `githubPollerRegistration()`'s `CreateAndStart` closure:

- **GH-3240** sub-issue skip (`runner.SetSubIssuePollerSkip`)
- **GH-3271** done-issue re-mark (`ctrl.SetOnIssueDone`)
- **GH-2589/2402** stale-label `ClearProcessed` recovery

**Confirmed live damage:** epic **GH-3927** children 3952/3953/3954 were skip-unmarked and duplicate-dispatched by the SDK poller (GH-3954 ran twice concurrently). Downstream guards contained it, but every pilot-repo epic risked wasted duplicate child runs.

Secondary latent bug: marking ranged *every* poller regardless of repo, so a sub-issue number in one repo could suppress an unrelated same-numbered issue in another.

## Fix
A repo-keyed `githubPollerRegistry` that both in-tree and SDK pollers register into (in-tree inline; SDK from its synchronous `CreateAndStart`). The loops capture it by reference and route mark/clear through it at runtime — reaching the SDK poller and **scoping to the correct repo**. Designed for N per-repo instances (M7 4d.2 fan-out registers more here).

- Bumps `studio-sdk` → **v0.30.0** (exported `Poller.MarkProcessed`, studio-sdk#81/#82).
- `SubIssuePollerSkipFn` now carries the parent repo (`epic.go` passes `ParentTask.SourceRepo`); empty repo → mark-all fallback so the skip guarantee is never lost.
- Stale-label cleaner routes via the registry scoped to the default repo; drops the `len(ghPollers)>0` guard (registry is a no-op when unregistered), which also covers the flag-on/no-projects config.
- Fail-loud if a future SDK ever drops the mark/clear surface (stale-vs-intree pitfall class).

## Tests / gates
- New `github_poller_registry_test.go`: repo-scoped mark/clear, **cross-repo isolation**, N-per-repo fan-out shape, empty-repo fallback, nil-safety, add-guards.
- `epic_test.go` asserts the skip carries `ParentTask.SourceRepo`.
- `go build ./...`, `go vet`, `gofmt`, `golangci-lint` (0 issues), and **`go test -race ./...`** (full stress gate) all green.

## Scope / follow-up
- **In scope:** the three loops + SDK poller reachability + repo-scoping (all of #4110).
- **Not touched:** hot-upgrade `Drain()` loop (`p.Drain()` on `ghPollers`) — separate concern from the drain family (#4105–4107); the registry interface is mark/clear only.
- **Sequencing:** lands before the 4d.2b per-repo fan-out.