### PR TITLE
feat(cmd): fan out SDK poller per repo — default + projects[] (M7 4d.2b/c)

### DIFF
--- a/cmd/pilot/github_sdk_fanout_test.go
+++ b/cmd/pilot/github_sdk_fanout_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/adapters/github"
+	"github.com/qf-studio/pilot/internal/config"
+)
+
+func ghProj(name, owner, repo, path string) *config.ProjectConfig {
+	return &config.ProjectConfig{
+		Name:   name,
+		Path:   path,
+		GitHub: &config.ProjectGitHubConfig{Owner: owner, Repo: repo},
+	}
+}
+
+// M7 4d.2b: the fan-out drives the default adapter repo plus every projects[]
+// github entry, config order, de-duplicated, with per-project path fallback and
+// only the default repo flagged isDefault (board wiring).
+func TestGithubSDKPollerTargets(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		defaultPath string
+		want        []githubSDKPollerTarget
+	}{
+		{
+			name:        "default repo only",
+			cfg:         &config.Config{Adapters: &config.AdaptersConfig{GitHub: &github.Config{Repo: "acme/default"}}},
+			defaultPath: "/def",
+			want:        []githubSDKPollerTarget{{repoFullName: "acme/default", projectPath: "/def", isDefault: true}},
+		},
+		{
+			name: "default plus projects in config order, path fallback",
+			cfg: &config.Config{
+				Adapters: &config.AdaptersConfig{GitHub: &github.Config{Repo: "acme/default"}},
+				Projects: []*config.ProjectConfig{ghProj("svc", "acme", "svc", "/svc"), ghProj("web", "acme", "web", "")},
+			},
+			defaultPath: "/def",
+			want: []githubSDKPollerTarget{
+				{repoFullName: "acme/default", projectPath: "/def", isDefault: true},
+				{repoFullName: "acme/svc", projectPath: "/svc", isDefault: false},
+				{repoFullName: "acme/web", projectPath: "/def", isDefault: false}, // no Path → default
+			},
+		},
+		{
+			name: "project duplicating the default repo is de-duped",
+			cfg: &config.Config{
+				Adapters: &config.AdaptersConfig{GitHub: &github.Config{Repo: "acme/default"}},
+				Projects: []*config.ProjectConfig{ghProj("dup", "acme", "default", "/dup"), ghProj("svc", "acme", "svc", "/svc")},
+			},
+			defaultPath: "/def",
+			want: []githubSDKPollerTarget{
+				{repoFullName: "acme/default", projectPath: "/def", isDefault: true},
+				{repoFullName: "acme/svc", projectPath: "/svc", isDefault: false},
+			},
+		},
+		{
+			name: "projects without github config are skipped",
+			cfg: &config.Config{
+				Adapters: &config.AdaptersConfig{GitHub: &github.Config{Repo: "acme/default"}},
+				Projects: []*config.ProjectConfig{{Name: "nogh", Path: "/nogh"}, ghProj("svc", "acme", "svc", "/svc")},
+			},
+			defaultPath: "/def",
+			want: []githubSDKPollerTarget{
+				{repoFullName: "acme/default", projectPath: "/def", isDefault: true},
+				{repoFullName: "acme/svc", projectPath: "/svc", isDefault: false},
+			},
+		},
+		{
+			name: "no default repo yields only projects, none isDefault",
+			cfg: &config.Config{
+				Adapters: &config.AdaptersConfig{GitHub: &github.Config{}},
+				Projects: []*config.ProjectConfig{ghProj("svc", "acme", "svc", "/svc")},
+			},
+			defaultPath: "/def",
+			want: []githubSDKPollerTarget{
+				{repoFullName: "acme/svc", projectPath: "/svc", isDefault: false},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := githubSDKPollerTargets(tt.cfg, tt.defaultPath)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d targets, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("target[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// M7 4d.2c: the issue URL must use the resolved owner/repo (project repos are not
+// the default adapter repo) and fall back to the default repo, then to empty.
+func TestGithubIssueURL(t *testing.T) {
+	cfg := &config.Config{Adapters: &config.AdaptersConfig{GitHub: &github.Config{Repo: "acme/default"}}}
+
+	if got := githubIssueURL(cfg, "acme", "svc", "42"); got != "https://github.com/acme/svc/issues/42" {
+		t.Errorf("explicit owner/repo: got %q", got)
+	}
+	if got := githubIssueURL(cfg, "", "", "42"); got != "https://github.com/acme/default/issues/42" {
+		t.Errorf("default fallback: got %q", got)
+	}
+	emptyCfg := &config.Config{Adapters: &config.AdaptersConfig{GitHub: &github.Config{}}}
+	if got := githubIssueURL(emptyCfg, "", "", "42"); got != "" {
+		t.Errorf("no repo anywhere: got %q, want empty", got)
+	}
+}

--- a/cmd/pilot/handlers.go
+++ b/cmd/pilot/handlers.go
@@ -1193,7 +1193,7 @@ func handleAzureDevOpsIssueWithResult(ctx context.Context, cfg *config.Config, e
 // avoid the GH-GH-42 double-prefix the legacy handler's fmt.Sprintf("GH-%d", ...) would create.
 // Board sync is handled at the SDK-poller level (config-driven); the spec-guard gate runs below
 // (M7 4d.3). Sub-issue handling remains exclusive to the legacy in-tree handler until later phases.
-func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkcore.IssueEvent, projectPath string, dispatcher *executor.Dispatcher, runner *executor.Runner, monitor *executor.Monitor, program *tea.Program, alertsEngine *alerts.Engine, enforcer *budget.Enforcer) (*sdkcore.IssueResult, error) {
+func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkcore.IssueEvent, projectPath string, repoFullName string, dispatcher *executor.Dispatcher, runner *executor.Runner, monitor *executor.Monitor, program *tea.Program, alertsEngine *alerts.Engine, enforcer *budget.Enforcer) (*sdkcore.IssueResult, error) {
 	taskID := ev.SequenceID // "GH-42"; already prefixed by the SDK adapter — do NOT re-prefix
 	title := ev.Title
 
@@ -1216,13 +1216,26 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 		}
 	}
 
-	// ResolveRepoForEvent is tolerated like the other SDK handlers; ErrRepoNotResolved is non-fatal here.
-	_, repoOwner, repoName, resolveErr := sdkshim.ResolveRepoForEvent(cfg, "github", ev)
-	if resolveErr != nil && resolveErr.Error() != sdkshim.ErrRepoNotResolved.Error() {
-		logging.WithComponent("github").Warn("Unexpected repo resolution error",
-			slog.String("task_id", taskID),
-			slog.Any("error", resolveErr),
-		)
+	// Resolve owner/repo. M7 4d.2c: the per-repo SDK poller passes its repo
+	// explicitly (repoFullName) because resolveGithubRepo matches by repo NAME only
+	// and is ambiguous when two projects share a repo name under different owners
+	// (repo_resolver.go documents this limitation). Event-based resolution remains
+	// the fallback for the webhook / rate-limit-retry paths that don't carry it.
+	var repoOwner, repoName string
+	if repoFullName != "" {
+		if parts := strings.SplitN(repoFullName, "/", 2); len(parts) == 2 {
+			repoOwner, repoName = parts[0], parts[1]
+		}
+	}
+	if repoOwner == "" || repoName == "" {
+		_, ro, rn, resolveErr := sdkshim.ResolveRepoForEvent(cfg, "github", ev)
+		if resolveErr != nil && resolveErr.Error() != sdkshim.ErrRepoNotResolved.Error() {
+			logging.WithComponent("github").Warn("Unexpected repo resolution error",
+				slog.String("task_id", taskID),
+				slog.Any("error", resolveErr),
+			)
+		}
+		repoOwner, repoName = ro, rn
 	}
 
 	// GH-4050: Fetch the real issue so State (and author, for MemberID) flow into the
@@ -1233,7 +1246,7 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 	issueNum, _ := strconv.Atoi(ev.IssueID)
 	var issueState, memberID string
 	var specClient *githubSDK.Client
-	if resolveErr == nil && repoOwner != "" && repoName != "" {
+	if repoOwner != "" && repoName != "" {
 		if ghToken, _ := resolveGitHubToken(cfg); ghToken != "" {
 			specClient = githubSDK.NewClient(ghToken)
 			if realIssue := fetchGithubIssueForSDKTask(ctx, specClient, repoOwner, repoName, issueNum, taskID); realIssue != nil {
@@ -1281,7 +1294,7 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 		// when the daemon re-dispatches a closed/merged parent (GH-201 gate parity).
 		State: issueState,
 	}
-	if resolveErr == nil && repoOwner != "" && repoName != "" {
+	if repoOwner != "" && repoName != "" {
 		// M7 4d.4: lets the runner select the startup-registered SDK PR creator
 		// ("github:owner/repo"); tasks without it keep the gh-CLI path.
 		task.SourceRepo = repoOwner + "/" + repoName
@@ -1300,7 +1313,7 @@ func handleGithubIssueEventSDK(ctx context.Context, cfg *config.Config, ev sdkco
 	info := IssueInfo{
 		TaskID:  taskID,
 		Title:   title,
-		URL:     githubIssueURL(cfg, ev.IssueID),
+		URL:     githubIssueURL(cfg, repoOwner, repoName, ev.IssueID),
 		Adapter: "github",
 		LogMark: "▸",
 	}
@@ -1337,9 +1350,14 @@ func fetchGithubIssueForSDKTask(ctx context.Context, client *githubSDK.Client, o
 	return issue
 }
 
-// githubIssueURL builds the HTML URL for a GitHub issue from the default adapter repo
-// ("owner/repo"). Returns "" when no default repo is configured.
-func githubIssueURL(cfg *config.Config, issueID string) string {
+// githubIssueURL builds the HTML URL for a GitHub issue. It prefers the resolved
+// owner/repo (M7 4d.2c: under the per-repo poller fan-out an event may belong to a
+// project repo, not the default adapter repo) and falls back to the default adapter
+// repo. Returns "" when neither is available.
+func githubIssueURL(cfg *config.Config, owner, repo, issueID string) string {
+	if owner != "" && repo != "" {
+		return fmt.Sprintf("https://github.com/%s/%s/issues/%s", owner, repo, issueID)
+	}
 	if cfg.Adapters != nil && cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Repo != "" {
 		return fmt.Sprintf("https://github.com/%s/issues/%s", cfg.Adapters.GitHub.Repo, issueID)
 	}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2583,11 +2583,18 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				return github.NewPoller(client, repoFullName, label, interval, pollerOpts...)
 			}
 
+			// M7 4d.2b: when use_sdk_poller is on, the SDK registration fans out a
+			// poller for the default repo AND every projects[] github repo — the
+			// in-tree pollers below skip all of them. This is the single source of
+			// truth for "is a github poller going to exist" so the autopilot-start
+			// gate below counts SDK pollers even when ghPollers ends up empty.
+			sdkGithubPollerEnabled := githubPollerRegistration().Enabled(cfg)
+
 			// Create poller for default repo (adapters.github.repo).
 			// M7 4b: when use_sdk_poller is on, the SDK registration (poller_github.go)
 			// owns the default repo — mark it polled so the projects loop skips it,
-			// but do not start the in-tree poller for it. `projects:` repos stay
-			// in-tree until Phase 4d.
+			// but do not start the in-tree poller for it. M7 4d.2b: projects[] repos
+			// are SDK-owned too when the flag is on.
 			if cfg.Adapters.GitHub.Repo != "" && cfg.Adapters.GitHub.UseSDKPoller {
 				polledRepos[cfg.Adapters.GitHub.Repo] = true
 				if !dashboardMode {
@@ -2620,6 +2627,15 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				}
 				polledRepos[repoFullName] = true
 
+				// M7 4d.2b: the SDK fan-out owns every projects[] github repo when the
+				// flag is on — skip the in-tree poller for it (mutual exclusion).
+				if sdkGithubPollerEnabled {
+					if !dashboardMode {
+						fmt.Printf("● github polling (sdk, m7 4d.2b) · %s (project: %s)\n", repoFullName, proj.Name)
+					}
+					continue
+				}
+
 				projPath := proj.Path
 				if projPath == "" {
 					projPath = projectPath // Fall back to default project path
@@ -2645,7 +2661,13 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				go poller.Start(ctx)
 			}
 
-			if len(ghPollers) == 0 {
+			// M7 4d.2b: SDK pollers are created later (StartAdapterPollers) and never
+			// land in ghPollers, so gate on "will any github poller exist" — otherwise
+			// a flag-on config with all repos SDK-owned would look like "no pollers"
+			// and silently skip autopilot startup.
+			hasGithubPollers := len(ghPollers) > 0 || sdkGithubPollerEnabled
+
+			if !hasGithubPollers {
 				logging.WithComponent("github").Warn("GitHub polling enabled but no repos configured — set adapters.github.repo or add project-level github.owner/github.repo",
 					slog.Int("pollers", 0))
 				// GH-3050: surface second silent autopilot gate. Controllers
@@ -2658,7 +2680,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				}
 			}
 
-			if len(ghPollers) > 0 {
+			if hasGithubPollers {
 				if !dashboardMode && execMode == github.ExecutionModeSequential && waitForMerge {
 					fmt.Printf("   ◌ sequential mode · waiting for PR merge before next issue (timeout: %s)\n", prTimeout)
 				}

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -113,12 +113,13 @@ func (s sdkRateLimitScheduler) QueueRetryIfRateLimited(taskID, title, body, errT
 // githubPollerRegistration returns the studio-sdk GitHub issue-poller registration.
 //
 // M7 Phase 4b (studio-sdk v0.27.0): LIVE behind adapters.github.use_sdk_poller.
-// When the flag is on, this registration polls the DEFAULT repo
-// (adapters.github.repo) via the SDK poller with full host-hook parity —
-// board source/sync, rate-limit scheduler, pre-flight judge, execution
-// checkers, and issue metrics — and the in-tree poller skips that repo
-// (main.go gateway + standalone default-repo blocks). Multi-repo `projects:`
-// entries remain on the in-tree poller until Phase 4d.
+// M7 Phase 4d.2b (studio-sdk v0.30.0): when the flag is on, this registration fans
+// out one SDK poller per repo — the DEFAULT repo (adapters.github.repo) plus every
+// projects[] GitHub entry — each with full host-hook parity (rate-limit scheduler,
+// pre-flight judge, execution checkers, issue metrics, per-repo autopilot controller
+// and PR creator). The default repo additionally gets board source/sync wiring;
+// project repos do not (parity with the in-tree path). The in-tree poller skips every
+// SDK-owned repo (main.go standalone block).
 //
 // Known 4b limitation: the SDK adapter runs ExecutionModeAuto only —
 // execution.mode=sequential configs should keep the flag off.
@@ -132,16 +133,14 @@ func githubPollerRegistration() PollerRegistration {
 				cfg.Adapters.GitHub.Polling != nil && cfg.Adapters.GitHub.Polling.Enabled
 		},
 		CreateAndStart: func(ctx context.Context, deps *PollerDeps) {
-			ghCfg := deps.Cfg.Adapters.GitHub
 			log := logging.WithComponent("github-sdk-poller")
 
-			// GH-3917: resolve the token via the same chain every in-tree
-			// GitHub path uses (config -> GITHUB_TOKEN env -> `gh auth token`
-			// CLI) instead of trusting ghCfg.Token verbatim. With token: ""
-			// in config (the common setup, since the resolver exists
-			// precisely so config can omit it), the SDK poller previously
-			// sent empty credentials on every poll while startup still
-			// logged "polling enabled".
+			// GH-3917: resolve the token via the same chain every in-tree GitHub
+			// path uses (config -> GITHUB_TOKEN env -> `gh auth token` CLI) instead
+			// of trusting ghCfg.Token verbatim. With token: "" in config (the common
+			// setup), the SDK poller previously sent empty credentials on every poll
+			// while startup still logged "polling enabled". One token is shared across
+			// every per-repo poller (M7 4d.2b fan-out).
 			token, tokenSource := resolveGitHubToken(deps.Cfg)
 			if token == "" {
 				log.Error("GitHub SDK poller disabled: no token resolved",
@@ -150,209 +149,286 @@ func githubPollerRegistration() PollerRegistration {
 				return
 			}
 
-			// Determine interval.
-			interval := 30 * time.Second
-			if ghCfg.Polling.Interval > 0 {
-				interval = ghCfg.Polling.Interval
-			}
-
-			// Map internal config → SDK config (field names differ: PilotLabel vs TriggerLabel).
-			pilotLabel := ghCfg.PilotLabel
-			if pilotLabel == "" {
-				pilotLabel = "pilot"
-			}
-			sdkCfg := &githubSDK.Config{
-				Enabled:       ghCfg.Enabled,
-				Token:         token,
-				WebhookSecret: ghCfg.WebhookSecret,
-				Repo:          ghCfg.Repo,
-				TriggerLabel:  pilotLabel,
-				Polling: &githubSDK.PollingConfig{
-					Enabled:  true,
-					Interval: interval,
-				},
-			}
-
-			// Board layer is config-driven in the SDK adapter (v0.27.0): mapping the
-			// internal ProjectBoard config is all the wiring board mode needs.
-			if pb := ghCfg.ProjectBoard; pb != nil {
-				sdkCfg.ProjectBoard = &githubSDK.ProjectBoardConfig{
-					Enabled:       pb.Enabled,
-					ProjectNumber: pb.ProjectNumber,
-					StatusField:   pb.StatusField,
-					Statuses: githubSDK.ProjectStatuses{
-						InProgress: pb.Statuses.InProgress,
-						Review:     pb.Statuses.Review,
-						Done:       pb.Statuses.Done,
-						Failed:     pb.Statuses.Failed,
-					},
-					SourceEnabled: pb.SourceEnabled,
-					SourceStatus:  pb.SourceStatus,
-				}
-			}
-
-			pollerDeps := sdkcore.PollerDeps{
-				Handler: sdkcore.IssueHandlerFunc(func(issueCtx context.Context, ev sdkcore.IssueEvent) (*sdkcore.IssueResult, error) {
-					return handleGithubIssueEventSDK(issueCtx, deps.Cfg, ev, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
-				}),
-				ProjectPath: deps.ProjectPath,
-				// GH-3921: tag every poller-originated log line with the same
-				// component verifySDKGithubToken uses, so incidents like the
-				// 2026-07-06 untagged "Failed to fetch issues" no longer reach
-				// the daemon log without a component field.
-				Logger: log,
-			}
-
-			if deps.AutopilotStateStore != nil {
-				pollerDeps.ProcessedStore = deps.AutopilotStateStore
-			}
-			if deps.Cfg.Orchestrator.MaxConcurrent > 0 {
-				pollerDeps.MaxConcurrent = deps.Cfg.Orchestrator.MaxConcurrent
-			}
-			if deps.AutopilotController != nil {
-				ctrl := deps.AutopilotController
-				pollerDeps.OnPRCreated = func(prEv sdkcore.PRCreatedEvent) {
-					// GitHub's IssueID is the numeric issue number; forward it (and the node ID)
-					// so the autopilot controller's post-merge gates and board-sync-to-Review work.
-					issueNumber, _ := strconv.Atoi(prEv.IssueID)
-					ctrl.OnPRCreated(prEv.PRNumber, prEv.PRURL, issueNumber, prEv.HeadSHA, prEv.BranchName, prEv.IssueNodeID)
-				}
-				pollerDeps.IssueMetricsRecorder = ctrl.Metrics()
-			}
-
-			// GH-2201/GH-2242: task-queued gate + completed-execution guard.
-			if deps.Store != nil {
-				pollerDeps.TaskChecker = storeTaskChecker{store: deps.Store}
-				pollerDeps.ExecutionChecker = deps.Store
-			}
-
-			// GH-2802: pre-flight judge (CC subprocess, no API key) — mirrors the
-			// in-tree gating incl. the claude-binary lookup.
-			if deps.Cfg.Executor != nil && deps.Cfg.Executor.PreFlightJudge != nil && deps.Cfg.Executor.PreFlightJudge.Enabled {
-				claudeCmd := ""
-				if deps.Cfg.Executor.ClaudeCode != nil {
-					claudeCmd = deps.Cfg.Executor.ClaudeCode.Command
-				}
-				if claudeCmd == "" {
-					claudeCmd = "claude"
-				}
-				if _, err := exec.LookPath(claudeCmd); err != nil {
-					log.Warn("Pre-flight judge disabled: claude binary not found",
-						slog.String("command", claudeCmd))
-				} else {
-					pollerDeps.PreFlightJudge = sdkPreFlightJudge{judge: executor.NewIntentJudge(claudeCmd)}
-					if deps.Store != nil {
-						pollerDeps.ExecutionSaver = storeExecutionSaver{store: deps.Store}
-					}
-				}
-			}
-
-			// Rate-limit retry scheduler. The retry callback re-fetches the issue via
-			// the SDK client and re-enters the SDK handler path, so the whole retry
-			// loop stays on core.IssueEvent. Priority is left "" on retry — it only
-			// affects queue ordering and the event is already past candidate selection.
-			repoParts := strings.SplitN(ghCfg.Repo, "/", 2)
-			if len(repoParts) != 2 {
-				log.Error("GitHub SDK poller disabled: invalid repo format",
-					slog.String("repo", ghCfg.Repo))
-				return
-			}
-			repoOwner, repoName := repoParts[0], repoParts[1]
-			sdkClient := githubSDK.NewClient(token)
-
-			// GH-3917: fail loud on a dead/invalid token instead of letting every
-			// poll silently 401.
-			if !verifySDKGithubToken(ctx, sdkClient, tokenSource, deps.AlertsEngine) {
+			// GH-3917: fail loud on a dead/invalid token once, up front, instead of
+			// letting every repo's poll silently 401.
+			if !verifySDKGithubToken(ctx, githubSDK.NewClient(token), tokenSource, deps.AlertsEngine) {
 				return
 			}
 
-			rateLimitScheduler := executor.NewScheduler(executor.DefaultSchedulerConfig(), nil)
-			rateLimitScheduler.SetRetryCallback(func(retryCtx context.Context, pendingTask *executor.PendingTask) error {
-				var issueNum int
-				if _, err := fmt.Sscanf(pendingTask.Task.ID, "GH-%d", &issueNum); err != nil {
-					return fmt.Errorf("invalid task ID format: %s", pendingTask.Task.ID)
-				}
-
-				issue, err := sdkClient.GetIssue(retryCtx, repoOwner, repoName, issueNum)
-				if err != nil {
-					return fmt.Errorf("failed to fetch issue for retry: %w", err)
-				}
-
-				logging.WithComponent("scheduler").Info("Retrying rate-limited issue (SDK path)",
-					slog.Int("issue", issueNum),
-					slog.Int("attempt", pendingTask.Attempts),
-				)
-
-				labelNames := make([]string, 0, len(issue.Labels))
-				for _, l := range issue.Labels {
-					labelNames = append(labelNames, l.Name)
-				}
-				ev := sdkcore.IssueEvent{
-					Action:     "created",
-					IssueID:    strconv.Itoa(issue.Number),
-					SequenceID: pendingTask.Task.ID,
-					Title:      issue.Title,
-					Body:       issue.Body,
-					Labels:     labelNames,
-					ProjectID:  repoName,
-				}
-
-				result, err := handleGithubIssueEventSDK(retryCtx, deps.Cfg, ev, deps.ProjectPath, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
-
-				// GH-797: surface retried-issue PRs to autopilot so their merge gates run.
-				if result != nil && result.PRNumber > 0 && deps.AutopilotController != nil {
-					deps.AutopilotController.OnPRCreated(result.PRNumber, result.PRURL, issue.Number, result.HeadSHA, result.BranchName, issue.NodeID)
-				}
-
-				return err
-			})
-			rateLimitScheduler.SetExpiredCallback(func(expiredCtx context.Context, pendingTask *executor.PendingTask) {
-				logging.WithComponent("scheduler").Error("Task exceeded max retry attempts",
-					slog.String("task_id", pendingTask.Task.ID),
-					slog.Int("attempts", pendingTask.Attempts),
-				)
-			})
-			if schErr := rateLimitScheduler.Start(ctx); schErr != nil {
-				logging.WithComponent("start").Warn("Failed to start rate limit scheduler (SDK path)", slog.Any("error", schErr))
-			}
-			pollerDeps.RateLimitScheduler = sdkRateLimitScheduler{scheduler: rateLimitScheduler}
-
-			// M7 4d.4: PRs for SDK-managed repos go through the SDK client instead
-			// of the gh CLI. Startup-time registration keyed by repo — the runner
-			// falls back to gh CLI for any github task without a registered creator.
-			if deps.Runner != nil {
-				deps.Runner.RegisterPRCreator("github:"+ghCfg.Repo, sdkshim.NewGitHubPRCreator(sdkClient, repoOwner, repoName))
-			}
-
-			githubPoller := githubSDK.New(sdkCfg).NewPoller(pollerDeps)
-
-			// GH-4110: publish the SDK poller handle to the shared repo-keyed
-			// registry so the main.go sub-issue-skip / done-remark / stale-label
-			// loops can mark/clear it. Without this the handle stays trapped in this
-			// closure and the pilot repo's epic sub-issues get duplicate-dispatched.
-			// NewPoller returns the core.Poller interface (Start only), so assert to
-			// the mark/clear surface and fail loud if a future SDK drops it.
-			if deps.GitHubPollers != nil {
-				if marker, ok := githubPoller.(githubProcessedMarker); ok {
-					deps.GitHubPollers.add(ghCfg.Repo, marker)
-				} else {
-					log.Error("GitHub SDK poller does not expose MarkProcessed/ClearProcessed; cross-poller sub-issue skip and stale-label recovery cannot reach it (GH-4110)")
+			// M7 4d.2b: one SDK poller per repo — default adapter repo + projects[].
+			targets := githubSDKPollerTargets(deps.Cfg, deps.ProjectPath)
+			started := 0
+			for _, target := range targets {
+				if startGithubSDKPollerForRepo(ctx, deps, log, token, tokenSource, target) {
+					started++
 				}
 			}
-
-			log.Info("GitHub SDK polling enabled (M7 4b)",
-				slog.String("repo", ghCfg.Repo),
-				slog.String("label", pilotLabel),
+			log.Info("GitHub SDK polling enabled (M7 4b/4d.2b)",
+				slog.Int("repos_configured", len(targets)),
+				slog.Int("repos_started", started),
 				slog.String("token_source", string(tokenSource)),
-				slog.Duration("interval", interval),
 			)
-			go func() {
-				if err := githubPoller.Start(ctx); err != nil {
-					log.Error("GitHub SDK poller failed",
-						slog.Any("error", err),
-					)
-				}
-			}()
 		},
 	}
+}
+
+// githubSDKPollerTarget is one repo the SDK poller fan-out drives.
+type githubSDKPollerTarget struct {
+	repoFullName string // "owner/repo"
+	projectPath  string
+	isDefault    bool // the default adapter repo — the only target that gets board wiring
+}
+
+// githubSDKPollerTargets derives the repo set the SDK poller drives when
+// use_sdk_poller is on (M7 4d.2b): the default adapter repo (adapters.github.repo)
+// first, then every projects[] entry with a GitHub owner/repo, in config order,
+// de-duplicated. defaultProjectPath is used for the default repo and as the fallback
+// for a project entry with no explicit Path.
+func githubSDKPollerTargets(cfg *config.Config, defaultProjectPath string) []githubSDKPollerTarget {
+	var targets []githubSDKPollerTarget
+	seen := make(map[string]bool)
+	if gh := cfg.Adapters.GitHub; gh != nil && gh.Repo != "" {
+		targets = append(targets, githubSDKPollerTarget{repoFullName: gh.Repo, projectPath: defaultProjectPath, isDefault: true})
+		seen[gh.Repo] = true
+	}
+	for _, proj := range cfg.Projects {
+		if proj.GitHub == nil || proj.GitHub.Owner == "" || proj.GitHub.Repo == "" {
+			continue
+		}
+		full := proj.GitHub.Owner + "/" + proj.GitHub.Repo
+		if seen[full] {
+			continue
+		}
+		seen[full] = true
+		projPath := proj.Path
+		if projPath == "" {
+			projPath = defaultProjectPath
+		}
+		targets = append(targets, githubSDKPollerTarget{repoFullName: full, projectPath: projPath, isDefault: false})
+	}
+	return targets
+}
+
+// startGithubSDKPollerForRepo constructs and starts one SDK poller for target.
+// The shared token is already resolved and verified by the caller. Returns false
+// (and logs) without starting when the repo cannot be driven safely (invalid repo
+// format). Each poller carries its own repo identity, project path, autopilot
+// controller, rate-limit scheduler and PR creator; they share the token and the
+// repo-scoped processed store.
+func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slog.Logger, token string, tokenSource githubTokenSource, target githubSDKPollerTarget) bool {
+	ghCfg := deps.Cfg.Adapters.GitHub
+
+	repoParts := strings.SplitN(target.repoFullName, "/", 2)
+	if len(repoParts) != 2 || repoParts[0] == "" || repoParts[1] == "" {
+		log.Error("GitHub SDK poller skipped: invalid repo format",
+			slog.String("repo", target.repoFullName))
+		return false
+	}
+	repoOwner, repoName := repoParts[0], repoParts[1]
+	repoLog := log.With(slog.String("repo", target.repoFullName))
+
+	// Determine interval (shared adapter polling config; projects have no per-repo interval).
+	interval := 30 * time.Second
+	if ghCfg.Polling != nil && ghCfg.Polling.Interval > 0 {
+		interval = ghCfg.Polling.Interval
+	}
+
+	// Map internal config → SDK config (field names differ: PilotLabel vs TriggerLabel).
+	pilotLabel := ghCfg.PilotLabel
+	if pilotLabel == "" {
+		pilotLabel = "pilot"
+	}
+	sdkCfg := &githubSDK.Config{
+		Enabled:       ghCfg.Enabled,
+		Token:         token,
+		WebhookSecret: ghCfg.WebhookSecret,
+		Repo:          target.repoFullName,
+		TriggerLabel:  pilotLabel,
+		Polling: &githubSDK.PollingConfig{
+			Enabled:  true,
+			Interval: interval,
+		},
+	}
+
+	// Board layer is wired for the default repo only — parity with the in-tree path,
+	// which gates board source/sync to adapters.github.repo (main.go). Per-project
+	// board sync is a 4d.6+ question; project repos get no board wiring.
+	if target.isDefault {
+		if pb := ghCfg.ProjectBoard; pb != nil {
+			sdkCfg.ProjectBoard = &githubSDK.ProjectBoardConfig{
+				Enabled:       pb.Enabled,
+				ProjectNumber: pb.ProjectNumber,
+				StatusField:   pb.StatusField,
+				Statuses: githubSDK.ProjectStatuses{
+					InProgress: pb.Statuses.InProgress,
+					Review:     pb.Statuses.Review,
+					Done:       pb.Statuses.Done,
+					Failed:     pb.Statuses.Failed,
+				},
+				SourceEnabled: pb.SourceEnabled,
+				SourceStatus:  pb.SourceStatus,
+			}
+		}
+	}
+
+	pollerDeps := sdkcore.PollerDeps{
+		Handler: sdkcore.IssueHandlerFunc(func(issueCtx context.Context, ev sdkcore.IssueEvent) (*sdkcore.IssueResult, error) {
+			// M7 4d.2c: pass the poller's own repo explicitly so the handler does not
+			// have to resolve it from the event by name (ambiguous across same-named repos).
+			return handleGithubIssueEventSDK(issueCtx, deps.Cfg, ev, target.projectPath, target.repoFullName, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
+		}),
+		ProjectPath: target.projectPath,
+		// GH-3921: tag every poller-originated log line with the component +
+		// repo, so incidents no longer reach the daemon log untagged.
+		Logger: repoLog,
+	}
+
+	if deps.AutopilotStateStore != nil {
+		pollerDeps.ProcessedStore = deps.AutopilotStateStore
+	}
+	if deps.Cfg.Orchestrator.MaxConcurrent > 0 {
+		pollerDeps.MaxConcurrent = deps.Cfg.Orchestrator.MaxConcurrent
+	}
+
+	// M7 4d.2b: per-repo autopilot controller (keyed owner/repo). The default repo
+	// falls back to the backwards-compat singular controller. When autopilot is
+	// enabled but this repo has no controller, fail loud — its PRs would strand
+	// unmerged — but still start the poller so issues are not silently dropped.
+	controller := deps.AutopilotControllers[target.repoFullName]
+	if controller == nil && target.isDefault {
+		controller = deps.AutopilotController
+	}
+	if controller != nil {
+		ctrl := controller
+		pollerDeps.OnPRCreated = func(prEv sdkcore.PRCreatedEvent) {
+			// GitHub's IssueID is the numeric issue number; forward it (and the node ID)
+			// so the autopilot controller's post-merge gates and board-sync-to-Review work.
+			issueNumber, _ := strconv.Atoi(prEv.IssueID)
+			ctrl.OnPRCreated(prEv.PRNumber, prEv.PRURL, issueNumber, prEv.HeadSHA, prEv.BranchName, prEv.IssueNodeID)
+		}
+		pollerDeps.IssueMetricsRecorder = ctrl.Metrics()
+	} else if len(deps.AutopilotControllers) > 0 {
+		repoLog.Error("GitHub SDK poller: no autopilot controller for repo — PRs from this repo will not be auto-merged; check projects[] vs autopilot config")
+	}
+
+	// GH-2201/GH-2242: task-queued gate + completed-execution guard.
+	if deps.Store != nil {
+		pollerDeps.TaskChecker = storeTaskChecker{store: deps.Store}
+		pollerDeps.ExecutionChecker = deps.Store
+	}
+
+	// GH-2802: pre-flight judge (CC subprocess, no API key) — mirrors the
+	// in-tree gating incl. the claude-binary lookup.
+	if deps.Cfg.Executor != nil && deps.Cfg.Executor.PreFlightJudge != nil && deps.Cfg.Executor.PreFlightJudge.Enabled {
+		claudeCmd := ""
+		if deps.Cfg.Executor.ClaudeCode != nil {
+			claudeCmd = deps.Cfg.Executor.ClaudeCode.Command
+		}
+		if claudeCmd == "" {
+			claudeCmd = "claude"
+		}
+		if _, err := exec.LookPath(claudeCmd); err != nil {
+			repoLog.Warn("Pre-flight judge disabled: claude binary not found",
+				slog.String("command", claudeCmd))
+		} else {
+			pollerDeps.PreFlightJudge = sdkPreFlightJudge{judge: executor.NewIntentJudge(claudeCmd)}
+			if deps.Store != nil {
+				pollerDeps.ExecutionSaver = storeExecutionSaver{store: deps.Store}
+			}
+		}
+	}
+
+	// Rate-limit retry scheduler. The retry callback re-fetches the issue via the
+	// SDK client and re-enters the SDK handler path, so the whole retry loop stays
+	// on core.IssueEvent. Priority is left "" on retry — it only affects queue
+	// ordering and the event is already past candidate selection.
+	sdkClient := githubSDK.NewClient(token)
+	rateLimitScheduler := executor.NewScheduler(executor.DefaultSchedulerConfig(), nil)
+	rateLimitScheduler.SetRetryCallback(func(retryCtx context.Context, pendingTask *executor.PendingTask) error {
+		var issueNum int
+		if _, err := fmt.Sscanf(pendingTask.Task.ID, "GH-%d", &issueNum); err != nil {
+			return fmt.Errorf("invalid task ID format: %s", pendingTask.Task.ID)
+		}
+
+		issue, err := sdkClient.GetIssue(retryCtx, repoOwner, repoName, issueNum)
+		if err != nil {
+			return fmt.Errorf("failed to fetch issue for retry: %w", err)
+		}
+
+		logging.WithComponent("scheduler").Info("Retrying rate-limited issue (SDK path)",
+			slog.Int("issue", issueNum),
+			slog.Int("attempt", pendingTask.Attempts),
+			slog.String("repo", target.repoFullName),
+		)
+
+		labelNames := make([]string, 0, len(issue.Labels))
+		for _, l := range issue.Labels {
+			labelNames = append(labelNames, l.Name)
+		}
+		ev := sdkcore.IssueEvent{
+			Action:     "created",
+			IssueID:    strconv.Itoa(issue.Number),
+			SequenceID: pendingTask.Task.ID,
+			Title:      issue.Title,
+			Body:       issue.Body,
+			Labels:     labelNames,
+			ProjectID:  repoName,
+		}
+
+		result, err := handleGithubIssueEventSDK(retryCtx, deps.Cfg, ev, target.projectPath, target.repoFullName, deps.Dispatcher, deps.Runner, deps.Monitor, deps.Program, deps.AlertsEngine, deps.Enforcer)
+
+		// GH-797: surface retried-issue PRs to autopilot so their merge gates run.
+		if result != nil && result.PRNumber > 0 && controller != nil {
+			controller.OnPRCreated(result.PRNumber, result.PRURL, issue.Number, result.HeadSHA, result.BranchName, issue.NodeID)
+		}
+
+		return err
+	})
+	rateLimitScheduler.SetExpiredCallback(func(expiredCtx context.Context, pendingTask *executor.PendingTask) {
+		logging.WithComponent("scheduler").Error("Task exceeded max retry attempts",
+			slog.String("task_id", pendingTask.Task.ID),
+			slog.Int("attempts", pendingTask.Attempts),
+		)
+	})
+	if schErr := rateLimitScheduler.Start(ctx); schErr != nil {
+		logging.WithComponent("start").Warn("Failed to start rate limit scheduler (SDK path)", slog.Any("error", schErr))
+	}
+	pollerDeps.RateLimitScheduler = sdkRateLimitScheduler{scheduler: rateLimitScheduler}
+
+	// M7 4d.4: PRs for SDK-managed repos go through the SDK client instead of the gh
+	// CLI. Startup-time registration keyed by "github:owner/repo" — the runner falls
+	// back to gh CLI for any github task without a registered creator.
+	if deps.Runner != nil {
+		deps.Runner.RegisterPRCreator("github:"+target.repoFullName, sdkshim.NewGitHubPRCreator(sdkClient, repoOwner, repoName))
+	}
+
+	githubPoller := githubSDK.New(sdkCfg).NewPoller(pollerDeps)
+
+	// GH-4110: publish the SDK poller handle to the shared repo-keyed registry so
+	// the main.go sub-issue-skip / done-remark / stale-label loops can mark/clear it.
+	// NewPoller returns the core.Poller interface (Start only), so assert to the
+	// mark/clear surface and fail loud if a future SDK drops it.
+	if deps.GitHubPollers != nil {
+		if marker, ok := githubPoller.(githubProcessedMarker); ok {
+			deps.GitHubPollers.add(target.repoFullName, marker)
+		} else {
+			repoLog.Error("GitHub SDK poller does not expose MarkProcessed/ClearProcessed; cross-poller sub-issue skip and stale-label recovery cannot reach it (GH-4110)")
+		}
+	}
+
+	repoLog.Info("GitHub SDK poller started",
+		slog.String("label", pilotLabel),
+		slog.String("token_source", string(tokenSource)),
+		slog.Duration("interval", interval),
+		slog.Bool("default_repo", target.isDefault),
+		slog.Bool("board_wired", sdkCfg.ProjectBoard != nil),
+	)
+	go func() {
+		if err := githubPoller.Start(ctx); err != nil {
+			repoLog.Error("GitHub SDK poller failed",
+				slog.Any("error", err),
+			)
+		}
+	}()
+	return true
 }

--- a/configs/pilot.example.yaml
+++ b/configs/pilot.example.yaml
@@ -82,14 +82,14 @@ adapters:
     token: "${GITHUB_TOKEN}"
     repo: "owner/repo"                 # Repository to poll
     pilot_label: "pilot"               # Issues with this label are picked up
-    # use_sdk_poller: false            # M7 Phase 4b (studio-sdk v0.27.0): opt into the
-    #                                  # studio-sdk GitHub issue poller for the DEFAULT repo
-    #                                  # above. Full host-hook parity: board source/sync,
-    #                                  # rate-limit retry scheduling, pre-flight judge,
-    #                                  # execution checkers, issue metrics. `projects:` repos
-    #                                  # stay on the in-tree poller until Phase 4d. Runs
-    #                                  # execution mode auto only — keep false with
-    #                                  # execution.mode: sequential.
+    # use_sdk_poller: false            # M7 Phase 4b/4d.2 (studio-sdk v0.30.0): opt into the
+    #                                  # studio-sdk GitHub issue poller. Full host-hook parity:
+    #                                  # board source/sync (default repo only), rate-limit retry
+    #                                  # scheduling, pre-flight judge, execution checkers, issue
+    #                                  # metrics. Phase 4d.2: the flag now fans out to the DEFAULT
+    #                                  # repo above AND every `projects:` github repo — the in-tree
+    #                                  # poller skips all SDK-owned repos. Runs execution mode auto
+    #                                  # only — keep false with execution.mode: sequential.
     polling:
       enabled: true
       interval: 30s

--- a/internal/adapters/github/types.go
+++ b/internal/adapters/github/types.go
@@ -14,12 +14,12 @@ type Config struct {
 	StaleLabelCleanup *StaleLabelCleanupConfig `yaml:"stale_label_cleanup"` // Auto-cleanup stale labels
 	ProjectBoard      *ProjectBoardConfig      `yaml:"project_board"`       // GitHub Projects V2 board sync
 	Approval          *ApprovalConfig          `yaml:"approval"`            // GitHub PR-review approval handler
-	// UseSDKPoller opts this repo into the studio-sdk GitHub issue poller (M7 Phase 4).
-	// Default false. EXPERIMENTAL/DORMANT in Phase 4a: the SDK poller registration exists
-	// (cmd/pilot/poller_github.go) but is NOT yet wired into adapterPollerRegistrations(),
-	// and the SDK discovery poller does NOT carry the in-tree poller's board sync, rate-limit
-	// scheduler, pre-flight intent judge, or issue metrics. Do not enable in production until
-	// Phase 4b ports those hooks (blocked on studio-sdk v0.25.0+).
+	// UseSDKPoller opts into the studio-sdk GitHub issue poller (M7 Phase 4). Default
+	// false. LIVE since Phase 4b (studio-sdk v0.27.0) with full host-hook parity — board
+	// sync, rate-limit scheduler, pre-flight judge, execution checkers, issue metrics.
+	// Phase 4d.2 (v0.30.0) fans the poller out per repo: the flag now covers the default
+	// repo AND every projects[] github repo (cmd/pilot/poller_github.go), and the in-tree
+	// poller skips all SDK-owned repos. Runs execution mode auto only.
 	UseSDKPoller bool `yaml:"use_sdk_poller"`
 }
 


### PR DESCRIPTION
M7 4d.2b + 4d.2c (human-led, #3423). Follows #4114 (GH-4110 registry). **No `pilot` label — merge deliberately after review.**

## What
With `use_sdk_poller: true`, `githubPollerRegistration()` now fans out **one SDK poller per repo** — the default adapter repo **plus every `projects[]` github entry** — instead of only the default repo.

- **4d.2b fan-out** (`poller_github.go`): `githubSDKPollerTargets(cfg, defaultPath)` derives the repo set (default first, then projects, config order, de-duped, per-project path fallback). `startGithubSDKPollerForRepo` builds each poller with its own repo identity, project path, **autopilot controller keyed `owner/repo`** (fail-loud when autopilot is on but a repo has no controller — its PRs would strand), rate-limit scheduler and PR creator. Token is resolved + verified **once**, shared. Only the **default repo** gets board wiring (parity — the in-tree path gates board sync to the default repo).
- **4d.2c handler repo-identity** (`handlers.go`): `handleGithubIssueEventSDK` takes the poller's `owner/repo` explicitly — `resolveGithubRepo` matches by repo **name only** and collides across same-named repos under different owners (documented limitation). Event-based resolution stays as the webhook/retry fallback. `githubIssueURL` now uses the resolved owner/repo (project issues aren't on the default repo), falling back to the default.
- **main.go**: standalone `projects:` loop **skips in-tree pollers for SDK-owned repos** (mutual exclusion). The autopilot-start gate now **counts SDK pollers** — `len(ghPollers)` is 0 when every repo is SDK-owned, which previously skipped autopilot startup + the sub-issue-skip/done/stale-label wiring entirely (latent fleet-breaker the fan-out would otherwise trip).

## Tests / gates
- New `github_sdk_fanout_test.go`: target derivation (dedup vs default, path fallback, skip-non-github, no-default-repo), `githubIssueURL` resolution.
- GH-4050 field-parity guard (`TestGithubHandlerSDK_FieldsWired`) still green.
- `go build ./...`, `go vet`, `gofmt -s`, `golangci-lint` (0 issues), **`go test -race ./...`** all green.

## Docs
`configs/pilot.example.yaml` + `types.go` `UseSDKPoller` comment — flag now covers `projects[]`.

## ⚠️ Activation (4d.2e — separate, human-owned)
The flag is **adapter-level, all-or-nothing** (Decision A). Flipping to this binary moves **every** `projects[]` repo to SDK at once (#4050-class blast radius). Smoke on one repo before trusting the fleet; rollback = flag off (in-tree path untouched until 4d.6). Requires a daemon restart to activate.

## Scope
- **Done:** 4d.2b fan-out + 4d.2c repo-identity + main.go mutual-exclusion/gate + docs (4d.2d).
- **Remaining:** 4d.5 webhook repoint, 4d.6 in-tree deletion/residual decision.