### PR TITLE
fix(dashboard): dedup history by task before the 5-item cap

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -582,11 +582,12 @@ func (m *Model) hydrateFromStore() {
 		m.metricsCard.Skipped = taskCounts.Skipped
 	}
 
-	// Populate history panel from recent executions (most recent 5)
-	for i, exec := range executions {
-		if i >= 5 {
-			break
-		}
+	// Populate history panel from the 5 most recent DISTINCT tasks. A single task
+	// can have many execution rows (retries); capping on raw rows lets one retried
+	// task fill the whole window and hide the rest of the history — after
+	// groupedHistory dedups by task ID a 4×-retried task collapses the panel to a
+	// couple of entries. Cap on task_id instead so 5 real tasks always show.
+	for _, exec := range firstNDistinctByTask(executions, 5) {
 		status := displayStatus(exec.Status)
 		completedAt := exec.CreatedAt
 		if exec.CompletedAt != nil {
@@ -617,6 +618,30 @@ func (m *Model) hydrateFromStore() {
 
 	// Load sparkline history
 	m.loadMetricsHistory()
+}
+
+// firstNDistinctByTask returns up to n executions, at most one per task_id,
+// preserving input order. GetRecentExecutions is ordered created_at DESC, so the
+// first row for each task is its latest execution. This keeps a task that retried
+// several times (many rows) from consuming the whole history window — the panel
+// dedups by task ID at render, so a raw-row cap otherwise collapses to 1-2 entries.
+func firstNDistinctByTask(execs []*memory.Execution, n int) []*memory.Execution {
+	if n <= 0 {
+		return nil
+	}
+	seen := make(map[string]bool, n)
+	out := make([]*memory.Execution, 0, n)
+	for _, e := range execs {
+		if seen[e.TaskID] {
+			continue
+		}
+		seen[e.TaskID] = true
+		out = append(out, e)
+		if len(out) >= n {
+			break
+		}
+	}
+	return out
 }
 
 // persistTokenUsage saves token usage to the current session.

--- a/internal/dashboard/tui_history_test.go
+++ b/internal/dashboard/tui_history_test.go
@@ -1,0 +1,91 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+func taskIDs(execs []*memory.Execution) []string {
+	out := make([]string, len(execs))
+	for i, e := range execs {
+		out[i] = e.TaskID
+	}
+	return out
+}
+
+func eq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestFirstNDistinctByTask(t *testing.T) {
+	ex := func(id, status string) *memory.Execution {
+		return &memory.Execution{TaskID: id, Status: status}
+	}
+
+	tests := []struct {
+		name string
+		in   []*memory.Execution
+		n    int
+		want []string
+	}{
+		{
+			name: "retried task does not crowd out the rest (GH-4100 scenario)",
+			// created_at DESC: GH-4100 retried 4×, then distinct tasks.
+			in: []*memory.Execution{
+				ex("GH-4100", "skipped"), ex("GH-4100", "completed"), ex("GH-4100", "completed"),
+				ex("GH-4100", "completed"), ex("GH-4105", "no_op"), ex("GH-4106", "no_op"),
+				ex("GH-4107", "failed"), ex("GH-4101", "completed"),
+			},
+			n:    5,
+			want: []string{"GH-4100", "GH-4105", "GH-4106", "GH-4107", "GH-4101"},
+		},
+		{
+			name: "keeps first (latest) occurrence per task",
+			in:   []*memory.Execution{ex("A", "skipped"), ex("A", "completed"), ex("B", "completed")},
+			n:    5,
+			want: []string{"A", "B"},
+		},
+		{
+			name: "caps at n distinct tasks",
+			in:   []*memory.Execution{ex("A", "c"), ex("B", "c"), ex("C", "c"), ex("D", "c")},
+			n:    2,
+			want: []string{"A", "B"},
+		},
+		{
+			name: "fewer distinct than n returns all",
+			in:   []*memory.Execution{ex("A", "c"), ex("A", "c")},
+			n:    5,
+			want: []string{"A"},
+		},
+		{name: "n<=0 returns nil", in: []*memory.Execution{ex("A", "c")}, n: 0, want: nil},
+		{name: "empty input", in: nil, n: 5, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := taskIDs(firstNDistinctByTask(tt.in, tt.n))
+			if len(tt.want) == 0 && len(got) == 0 {
+				return
+			}
+			if !eq(got, tt.want) {
+				t.Errorf("firstNDistinctByTask = %v, want %v", got, tt.want)
+			}
+			// the kept row for a retried task must be the FIRST (latest) one
+			if tt.name == "keeps first (latest) occurrence per task" {
+				kept := firstNDistinctByTask(tt.in, tt.n)
+				if kept[0].Status != "skipped" {
+					t.Errorf("kept status = %q, want %q (latest, not an older retry)", kept[0].Status, "skipped")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Symptom
The dashboard **history** panel shows the same 1-2 stale entries after every restart (reported live: `GH-4100 skipped` + `GH-4105 no_op`, ~10h old), even though newer executions exist.

## Root cause
Restart hydration (`tui.go`) capped at the **first 5 raw execution rows**, but `groupedHistory()` dedups by `task_id` at render. A single retried task consumes the window: the top-5 pilot-path rows were **GH-4100 ×4 (retries) + GH-4105**, which dedup to just `{GH-4100, GH-4105}`. Verified against the live DB — those two rows are exactly what the panel showed. (The `404M` in the row is `final_rss_mb`, unrelated.)

## Fix
Cap on **distinct `task_id`** via a small `firstNDistinctByTask(execs, 5)` helper, keeping each task's latest execution (rows are `created_at DESC`). The query already fetches 20, so the panel now shows 5 real recent tasks (GH-4100, GH-4105, GH-4106, GH-4107, GH-4101) instead of 2.

## Tests
`TestFirstNDistinctByTask` — table-driven incl. the exact GH-4100 4×-retry scenario, cap-at-n, keep-latest-per-task, n<=0, empty. Dashboard `-race` + `go build ./...` + golangci-lint (0 issues) green.

Not `pilot`-labeled — merge deliberately (no auto-release).