### PR TITLE
fix(dashboard): dedup storeRefreshCmd + live-event history cap by task_id

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -644,6 +644,31 @@ func firstNDistinctByTask(execs []*memory.Execution, n int) []*memory.Execution 
 	return out
 }
 
+// lastNDistinctByTask returns up to n tasks, at most one per task ID, keeping
+// each task's most recent entry. Unlike firstNDistinctByTask, tasks arrive in
+// chronological (oldest-first) append order here, so "most recent" is the
+// last occurrence, not the first — same GH-4100 crowding fix, opposite input
+// order. Output preserves chronological order (oldest first).
+func lastNDistinctByTask(tasks []CompletedTask, n int) []CompletedTask {
+	if n <= 0 {
+		return nil
+	}
+	seen := make(map[string]bool, n)
+	out := make([]CompletedTask, 0, n)
+	for i := len(tasks) - 1; i >= 0 && len(out) < n; i-- {
+		t := tasks[i]
+		if seen[t.ID] {
+			continue
+		}
+		seen[t.ID] = true
+		out = append(out, t)
+	}
+	for l, r := 0, len(out)-1; l < r; l, r = l+1, r-1 {
+		out[l], out[r] = out[r], out[l]
+	}
+	return out
+}
+
 // persistTokenUsage saves token usage to the current session.
 func (m *Model) persistTokenUsage(inputDelta, outputDelta int) {
 	if m.store == nil || m.sessionID == "" {
@@ -873,10 +898,7 @@ func storeRefreshCmd(store *memory.Store, projectPath string) tea.Cmd {
 			slog.Warn("store refresh: failed to load executions", slog.Any("error", err))
 			return msg
 		}
-		for i, exec := range executions {
-			if i >= 5 {
-				break
-			}
+		for _, exec := range firstNDistinctByTask(executions, 5) {
 			status := displayStatus(exec.Status)
 			completedAt := exec.CreatedAt
 			if exec.CompletedAt != nil {
@@ -1118,9 +1140,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case addCompletedTaskMsg:
 		prevLen := len(m.completedTasks)
 		m.completedTasks = append(m.completedTasks, CompletedTask(msg))
-		if len(m.completedTasks) > 5 {
-			m.completedTasks = m.completedTasks[len(m.completedTasks)-5:]
-		}
+		m.completedTasks = lastNDistinctByTask(m.completedTasks, 5)
 
 		// Update metrics card task counters
 		m.metricsCard.TotalTasks++

--- a/internal/dashboard/tui_history_test.go
+++ b/internal/dashboard/tui_history_test.go
@@ -1,7 +1,9 @@
 package dashboard
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/memory"
 )
@@ -87,5 +89,72 @@ func TestFirstNDistinctByTask(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestStoreRefreshCmd_DedupsRetriesAcrossFiveDistinctTasks is the GH-4119
+// regression test: storeRefreshCmd (the periodic refresh path) must dedup by
+// task_id like hydrateFromStore does, not cap on raw rows — otherwise a
+// retried task re-collapses the history panel on the first timer tick after
+// #4117 fixed only the startup path.
+func TestStoreRefreshCmd_DedupsRetriesAcrossFiveDistinctTasks(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const projectPath = "/proj"
+
+	// 16 older executions, one per distinct task.
+	for i := 0; i < 16; i++ {
+		id := fmt.Sprintf("older-exec-%d", i)
+		taskID := fmt.Sprintf("GH-41%02d", i)
+		if err := store.SaveExecution(&memory.Execution{
+			ID: id, TaskID: taskID, ProjectPath: projectPath, Status: "completed",
+		}); err != nil {
+			t.Fatalf("SaveExecution %s: %v", id, err)
+		}
+	}
+
+	// created_at has 1-second resolution (SQLite CURRENT_TIMESTAMP default) —
+	// cross a second boundary so the newest task's retries reliably sort
+	// above the older batch in GetRecentExecutions' created_at DESC order.
+	time.Sleep(1100 * time.Millisecond)
+
+	// 4 retries for the newest task (mirrors the live GH-4100 scenario).
+	const newestTaskID = "GH-4100"
+	for i := 0; i < 4; i++ {
+		id := fmt.Sprintf("retry-exec-%d", i)
+		if err := store.SaveExecution(&memory.Execution{
+			ID: id, TaskID: newestTaskID, ProjectPath: projectPath, Status: "completed",
+		}); err != nil {
+			t.Fatalf("SaveExecution %s: %v", id, err)
+		}
+	}
+
+	msg, ok := storeRefreshCmd(store, projectPath)().(storeRefreshMsg)
+	if !ok {
+		t.Fatalf("storeRefreshCmd returned unexpected message type")
+	}
+
+	if len(msg.completedTasks) != 5 {
+		t.Fatalf("completedTasks = %d entries, want 5", len(msg.completedTasks))
+	}
+
+	seen := make(map[string]bool, len(msg.completedTasks))
+	foundNewest := false
+	for _, ct := range msg.completedTasks {
+		if seen[ct.ID] {
+			t.Errorf("duplicate task ID %q in completedTasks", ct.ID)
+		}
+		seen[ct.ID] = true
+		if ct.ID == newestTaskID {
+			foundNewest = true
+		}
+	}
+	if !foundNewest {
+		t.Errorf("completedTasks missing newest retried task %q — retries crowded it out (raw-row cap regression)", newestTaskID)
 	}
 }


### PR DESCRIPTION
## Summary

- `#4117` fixed the dashboard history raw-5-cap collapse only in `hydrateFromStore` (startup path). `storeRefreshCmd` — the periodic refresh path that runs on every timer tick and full-replaces `m.completedTasks` — still capped on the first 5 **raw** rows, so a task with several retry executions in the recent window re-collapsed the panel to 1-2 distinct tasks on the first refresh tick.
- Applied the existing `firstNDistinctByTask` helper to `storeRefreshCmd`, matching the hydrate path exactly.
- Also fixed the same class of bug in the live-event path (`addCompletedTaskMsg`), which capped on the last 5 raw appended entries. Added `lastNDistinctByTask` (dedup keeping the newest per task, then cap) since that path appends in oldest-first chronological order — opposite of the DESC-ordered DB query results the other two paths consume.

## Test plan

- [x] New table-driven regression test `TestStoreRefreshCmd_DedupsRetriesAcrossFiveDistinctTasks` in `internal/dashboard/tui_history_test.go`: seeds a real SQLite store with 16 older distinct-task executions + 4 retries for the newest task, calls `storeRefreshCmd` directly, and asserts the result contains 5 distinct task IDs including the newest retried task.
- [x] Existing `TestFirstNDistinctByTask` unit test stays green.
- [x] `make test` — full suite green.
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues.

## Refs

Closes #4119
Incomplete fix: #4117