### PR TITLE
feat(executor): instrument direct-path stage/quality/research/retry events (GH-4129)

### DIFF
--- a/.agent/tasks/gh-4129.md
+++ b/.agent/tasks/gh-4129.md
@@ -1,0 +1,10 @@
+# GH-4129
+
+**Created:** 2026-07-09
+
+## Problem
+
+In internal/executor/runner.go, emit StageClaudeStarted and StageImplementationStarted on the direct (non-epic) path at the same points the epic path uses them (:1919 pattern). Persist quality.CheckResults.Duration/TotalDuration as execution_events using the existing detail JSON convention (from internal/executor/quality.go + internal/quality/types.go). Persist parallel-research phase Duration/TotalTokens as an event (currently only slog.Info at runner.go:2286-2291 / parallel.go:99-165). Tag retried backend attempts (runner.go:2764, :3336-3460, :3759) with retry_attempt events naming the loop. All work stays inside internal/executor/ (no behavior change — additive events only). Verified by a direct-path execution producing the ordered spec_validated -> claude_started -> implementation_started -> commit -> pr_created timeline in execution_events, plus per-gate and research rows. Depends on subtask 1 (constant + registered metrics must exist).
+
+## Acceptance Criteria
+

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -1877,11 +1877,13 @@ func waitForTerminalStatus(t *testing.T, store *memory.Store, execID string, tim
 // synthetic dispatch (queue → worker pickup → runner execution → completion)
 // through the real dispatcher and runner, and asserts the execution_events
 // timeline records the expected cross-file sequence: dispatcher's
-// queued→running transition and runner's spec-validated milestone. This task
-// has no PR (CreatePR: false), so the dispatcher's terminal-success write is
-// a no-op by design (see the recordExecutionEvent call site in processQueue)
-// — TestRunner_recordExecutionEvent_WritesEvent covers the pr_created write
-// directly. GH-3846.
+// queued→running transition, runner's spec-validated milestone, and (GH-4129)
+// the direct-path claude_started/implementation_started pair emitted right
+// before the backend invocation. This task has no PR (CreatePR: false), so
+// the dispatcher's terminal-success write is a no-op by design (see the
+// recordExecutionEvent call site in processQueue) — TestRunner_
+// recordExecutionEvent_WritesEvent covers the pr_created write directly.
+// GH-3846.
 func TestDispatcher_SyntheticDispatch_SuccessEventSequence(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
@@ -1919,7 +1921,12 @@ func TestDispatcher_SyntheticDispatch_SuccessEventSequence(t *testing.T) {
 		t.Fatalf("ListExecutionEvents failed: %v", err)
 	}
 
-	wantStages := []memory.Stage{memory.StageRunning, memory.StageSpecValidated}
+	wantStages := []memory.Stage{
+		memory.StageRunning,
+		memory.StageSpecValidated,
+		memory.StageClaudeStarted,
+		memory.StageImplementationStarted,
+	}
 	if len(events) != len(wantStages) {
 		var gotStages []memory.Stage
 		for _, e := range events {

--- a/internal/executor/gh4129_test.go
+++ b/internal/executor/gh4129_test.go
@@ -1,0 +1,369 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestDirectPath_ClaudeStartedAndImplementationStartedEvents covers GH-4129
+// requirement (1): the direct (non-epic) path must emit StageClaudeStarted
+// and StageImplementationStarted right before the real Claude invocation,
+// mirroring the epic path's :1919 pattern — previously the direct-path
+// execution_events timeline went silent after spec_validated.
+func TestDirectPath_ClaudeStartedAndImplementationStartedEvents(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	backend := &mockSelfReviewBackend{output: "done"}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{}
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.SetLogStore(store)
+
+	task := &Task{
+		ID:          "GH-4129-DIRECT",
+		Title:       "Direct path stage event test",
+		Description: "Verify claude_started/implementation_started fire on the direct path",
+		ProjectPath: t.TempDir(),
+		LocalMode:   true,
+	}
+	if err := store.SaveExecution(&memory.Execution{ID: task.LogExecutionID(), TaskID: task.ID, Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Execute() not successful: %s", result.Error)
+	}
+
+	events, err := store.ListExecutionEvents(task.LogExecutionID())
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+
+	var gotStages []memory.Stage
+	for _, e := range events {
+		gotStages = append(gotStages, e.Stage)
+	}
+
+	wantOrder := []memory.Stage{memory.StageSpecValidated, memory.StageClaudeStarted, memory.StageImplementationStarted}
+	idx := 0
+	for _, want := range wantOrder {
+		found := false
+		for ; idx < len(gotStages); idx++ {
+			if gotStages[idx] == want {
+				found = true
+				idx++
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected stage %q in order within %v, not found", want, gotStages)
+		}
+	}
+}
+
+// TestRecordQualityGateEvents_PerGateAndSummary covers GH-4129 requirement
+// (2): quality.CheckResults per-gate Duration and overall TotalDuration
+// (mirrored on the executor side as QualityOutcome.GateDetails[].Duration
+// and QualityOutcome.TotalDuration — internal/executor/quality.go) must be
+// persisted as execution_events using a detail-JSON convention, since the
+// values were previously computed but transient.
+func TestRecordQualityGateEvents_PerGateAndSummary(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	runner.SetLogStore(store)
+
+	if err := store.SaveExecution(&memory.Execution{ID: "exec-gh4129-qg", TaskID: "GH-4129-QG", Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	outcome := &QualityOutcome{
+		Passed:        true,
+		TotalDuration: 5500 * time.Millisecond,
+		GateDetails: []QualityGateDetail{
+			{Name: "build", Passed: true, Duration: 2 * time.Second, RetryCount: 0},
+			{Name: "test", Passed: true, Duration: 3500 * time.Millisecond, RetryCount: 1},
+		},
+	}
+
+	runner.recordQualityGateEvents("exec-gh4129-qg", outcome)
+
+	events, err := store.ListExecutionEvents("exec-gh4129-qg")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3 (2 gates + 1 summary)", len(events))
+	}
+
+	for _, e := range events {
+		if e.Stage != memory.StageQualityGate {
+			t.Errorf("event.Stage = %q, want %q", e.Stage, memory.StageQualityGate)
+		}
+	}
+
+	var gate0 struct {
+		Gate       string `json:"gate"`
+		DurationMS int64  `json:"duration_ms"`
+		Passed     bool   `json:"passed"`
+		RetryCount int    `json:"retry_count"`
+	}
+	if err := json.Unmarshal([]byte(events[0].Detail), &gate0); err != nil {
+		t.Fatalf("failed to unmarshal gate detail: %v", err)
+	}
+	if gate0.Gate != "build" || gate0.DurationMS != 2000 || !gate0.Passed {
+		t.Errorf("gate0 = %+v, want build/2000ms/passed", gate0)
+	}
+
+	var gate1 struct {
+		Gate       string `json:"gate"`
+		DurationMS int64  `json:"duration_ms"`
+		RetryCount int    `json:"retry_count"`
+	}
+	if err := json.Unmarshal([]byte(events[1].Detail), &gate1); err != nil {
+		t.Fatalf("failed to unmarshal gate detail: %v", err)
+	}
+	if gate1.Gate != "test" || gate1.DurationMS != 3500 || gate1.RetryCount != 1 {
+		t.Errorf("gate1 = %+v, want test/3500ms/retry_count=1", gate1)
+	}
+
+	var summary struct {
+		TotalDurationMS int64 `json:"total_duration_ms"`
+		GateCount       int   `json:"gate_count"`
+	}
+	if err := json.Unmarshal([]byte(events[2].Detail), &summary); err != nil {
+		t.Fatalf("failed to unmarshal summary detail: %v", err)
+	}
+	if summary.TotalDurationMS != 5500 || summary.GateCount != 2 {
+		t.Errorf("summary = %+v, want total_duration_ms=5500/gate_count=2", summary)
+	}
+}
+
+// TestRecordResearchPhaseEvent_PersistsDurationAndTokens covers GH-4129
+// requirement (3): parallel-research phase Duration/TotalTokens (previously
+// logged via slog.Info only at runner.go / parallel.go's ExecuteResearchPhase)
+// must be persisted as an execution_event.
+func TestRecordResearchPhaseEvent_PersistsDurationAndTokens(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	runner.SetLogStore(store)
+
+	if err := store.SaveExecution(&memory.Execution{ID: "exec-gh4129-research", TaskID: "GH-4129-RESEARCH", Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	research := &ResearchResult{
+		TaskID:      "GH-4129-RESEARCH",
+		Findings:    []string{"finding A", "finding B"},
+		Duration:    4200 * time.Millisecond,
+		TotalTokens: 12345,
+	}
+
+	runner.recordResearchPhaseEvent("exec-gh4129-research", research)
+
+	events, err := store.ListExecutionEvents("exec-gh4129-research")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].Stage != memory.StageResearchPhase {
+		t.Fatalf("event.Stage = %q, want %q", events[0].Stage, memory.StageResearchPhase)
+	}
+
+	var detail struct {
+		DurationMS  int64 `json:"duration_ms"`
+		TotalTokens int64 `json:"total_tokens"`
+		Findings    int   `json:"findings"`
+	}
+	if err := json.Unmarshal([]byte(events[0].Detail), &detail); err != nil {
+		t.Fatalf("failed to unmarshal detail: %v", err)
+	}
+	if detail.DurationMS != 4200 || detail.TotalTokens != 12345 || detail.Findings != 2 {
+		t.Errorf("detail = %+v, want duration_ms=4200/total_tokens=12345/findings=2", detail)
+	}
+
+	// nil research must not write an event.
+	runner.recordResearchPhaseEvent("exec-gh4129-research-nil", nil)
+	nilEvents, err := store.ListExecutionEvents("exec-gh4129-research-nil")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(nilEvents) != 0 {
+		t.Errorf("got %d events for nil research, want 0", len(nilEvents))
+	}
+}
+
+// TestRecordRetryAttemptEvent_NamesTheLoop covers GH-4129 requirement (4):
+// retried backend attempts (smart retry, quality-gate retry, intent-judge
+// self-correct) must be tagged with a retry_attempt event naming which loop
+// fired, so retry wall-clock share is queryable.
+func TestRecordRetryAttemptEvent_NamesTheLoop(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	runner.SetLogStore(store)
+
+	if err := store.SaveExecution(&memory.Execution{ID: "exec-gh4129-retry", TaskID: "GH-4129-RETRY", Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	runner.recordRetryAttemptEvent("exec-gh4129-retry", "smart_retry", 1)
+	runner.recordRetryAttemptEvent("exec-gh4129-retry", "quality_gate_retry", 2)
+	runner.recordRetryAttemptEvent("exec-gh4129-retry", "intent_judge_retry", 1)
+
+	events, err := store.ListExecutionEvents("exec-gh4129-retry")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+
+	wantLoops := []struct {
+		loop    string
+		attempt int
+	}{
+		{"smart_retry", 1},
+		{"quality_gate_retry", 2},
+		{"intent_judge_retry", 1},
+	}
+	for i, want := range wantLoops {
+		if events[i].Stage != memory.StageRetryAttempt {
+			t.Errorf("event[%d].Stage = %q, want %q", i, events[i].Stage, memory.StageRetryAttempt)
+		}
+		var detail struct {
+			Loop    string `json:"loop"`
+			Attempt int    `json:"attempt"`
+		}
+		if err := json.Unmarshal([]byte(events[i].Detail), &detail); err != nil {
+			t.Fatalf("event[%d]: failed to unmarshal detail: %v", i, err)
+		}
+		if detail.Loop != want.loop || detail.Attempt != want.attempt {
+			t.Errorf("event[%d] detail = %+v, want loop=%q/attempt=%d", i, detail, want.loop, want.attempt)
+		}
+	}
+}
+
+// statefulQualityChecker fails once with ShouldRetry, then passes with
+// GateDetails/TotalDuration set — used to drive the quality-gate retry loop
+// through runner.Execute end to end (GH-4129).
+type statefulQualityChecker struct {
+	calls int
+}
+
+func (m *statefulQualityChecker) Check(_ context.Context) (*QualityOutcome, error) {
+	m.calls++
+	if m.calls == 1 {
+		return &QualityOutcome{
+			Passed:        false,
+			ShouldRetry:   true,
+			RetryFeedback: "fix the build",
+			Attempt:       1,
+		}, nil
+	}
+	return &QualityOutcome{
+		Passed:        true,
+		TotalDuration: 1200 * time.Millisecond,
+		GateDetails: []QualityGateDetail{
+			{Name: "build", Passed: true, Duration: 1200 * time.Millisecond},
+		},
+	}, nil
+}
+
+// TestDirectPath_QualityGateRetryEndToEnd drives a real quality-gate-retry
+// loop through runner.Execute (GH-4129): the first Check() fails with
+// ShouldRetry, triggering a re-invocation of the backend and a
+// retry_attempt(quality_gate_retry) event; the second Check() passes and
+// its GateDetails/TotalDuration land as quality_gate events.
+func TestDirectPath_QualityGateRetryEndToEnd(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	backend := &mockSelfReviewBackend{output: "done"}
+	runner := NewRunnerWithBackend(backend)
+	runner.config = &BackendConfig{}
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.SetLogStore(store)
+
+	checker := &statefulQualityChecker{}
+	runner.SetQualityCheckerFactory(func(_, _ string) QualityChecker {
+		return checker
+	})
+
+	task := &Task{
+		ID:          "GH-4129-QG-RETRY",
+		Title:       "Quality gate retry end-to-end test",
+		Description: "First check fails and retries, second check passes",
+		ProjectPath: t.TempDir(),
+		LocalMode:   true,
+	}
+	if err := store.SaveExecution(&memory.Execution{ID: task.LogExecutionID(), TaskID: task.ID, Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Execute() not successful: %s", result.Error)
+	}
+	if checker.calls != 2 {
+		t.Fatalf("quality checker called %d times, want 2 (fail then pass)", checker.calls)
+	}
+
+	events, err := store.ListExecutionEvents(task.LogExecutionID())
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+
+	var sawRetry, sawGate, sawSummary bool
+	for _, e := range events {
+		switch e.Stage {
+		case memory.StageRetryAttempt:
+			if strings.Contains(e.Detail, "quality_gate_retry") {
+				sawRetry = true
+			}
+		case memory.StageQualityGate:
+			if strings.Contains(e.Detail, "\"gate\":\"build\"") {
+				sawGate = true
+			}
+			if strings.Contains(e.Detail, "total_duration_ms") {
+				sawSummary = true
+			}
+		}
+	}
+	if !sawRetry {
+		t.Errorf("expected a retry_attempt event naming quality_gate_retry, got events: %+v", events)
+	}
+	if !sawGate {
+		t.Errorf("expected a quality_gate event for the build gate, got events: %+v", events)
+	}
+	if !sawSummary {
+		t.Errorf("expected a quality_gate summary event with total_duration_ms, got events: %+v", events)
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1304,6 +1304,42 @@ func (r *Runner) recordExecutionEvent(executionID string, stage memory.Stage, de
 	}
 }
 
+// recordResearchPhaseEvent persists the parallel-research phase's cost to the
+// execution_events ledger — previously only slog.Info, so per-execution
+// research spend wasn't queryable (GH-4129).
+func (r *Runner) recordResearchPhaseEvent(executionID string, research *ResearchResult) {
+	if research == nil {
+		return
+	}
+	detail, err := json.Marshal(struct {
+		DurationMS  int64 `json:"duration_ms"`
+		TotalTokens int64 `json:"total_tokens"`
+		Findings    int   `json:"findings"`
+	}{
+		DurationMS:  research.Duration.Milliseconds(),
+		TotalTokens: research.TotalTokens,
+		Findings:    len(research.Findings),
+	})
+	if err != nil {
+		return
+	}
+	r.recordExecutionEvent(executionID, memory.StageResearchPhase, string(detail))
+}
+
+// recordRetryAttemptEvent tags a retried backend invocation with the loop
+// that triggered it (smart_retry, quality_gate_retry, intent_judge_retry) so
+// retry wall-clock share is queryable from execution_events (GH-4129).
+func (r *Runner) recordRetryAttemptEvent(executionID, loop string, attempt int) {
+	detail, err := json.Marshal(struct {
+		Loop    string `json:"loop"`
+		Attempt int    `json:"attempt"`
+	}{Loop: loop, Attempt: attempt})
+	if err != nil {
+		return
+	}
+	r.recordExecutionEvent(executionID, memory.StageRetryAttempt, string(detail))
+}
+
 // Diagnostic truncation caps used by persistBackendDiagnostics. Exposed as
 // constants so tests can assert the ceiling and project-side tooling can
 // depend on a fixed upper bound. GH-2328.
@@ -2292,6 +2328,9 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				slog.Int64("tokens", researchResult.TotalTokens),
 			)
 		}
+		// GH-4129: persist research-phase cost to the execution_events ledger —
+		// previously only slog.Info, so per-execution research spend wasn't queryable.
+		r.recordResearchPhaseEvent(task.LogExecutionID(), researchResult)
 	}
 
 	// Load per-repo workflow override (.pilot/workflow.yaml) — TASK-304.
@@ -2464,6 +2503,12 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 	if repoWorkflow != nil {
 		runWorkflowHook(ctx, "before_run", repoWorkflow.Hooks.BeforeRun, executionPath, hookEnv, log)
 	}
+
+	// GH-4129: mirror the epic path's :1919 pattern — record the milestone
+	// right before the real Claude invocation so the direct path's
+	// execution_events timeline no longer goes silent after spec_validated.
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StageClaudeStarted, "direct execution invoked claude")
+	r.recordExecutionEvent(task.LogExecutionID(), memory.StageImplementationStarted, "direct path handing off to claude for implementation")
 
 	watchdogTimeout := 2 * timeout
 	allowedTools, mcpConfigPath := r.executionToolOptions()
@@ -2768,6 +2813,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 						r.driftDetector.RecordCorrection("retry_triggered", fmt.Sprintf("Error: %s, Retry attempt: %d", err.Error(), state.smartRetryAttempt+1))
 					}
 					state.smartRetryAttempt++
+					r.recordRetryAttemptEvent(task.LogExecutionID(), "smart_retry", state.smartRetryAttempt)
 					log.Info("Smart retry triggered",
 						slog.String("task_id", task.ID),
 						slog.String("error_category", errorCategory),
@@ -3416,6 +3462,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				// Check if we should retry with Claude Code
 				if outcome.ShouldRetry && retryAttempt < maxAutoRetries {
 					totalQualityRetries++ // Track total retries across all gates (GH-209)
+					r.recordRetryAttemptEvent(task.LogExecutionID(), "quality_gate_retry", totalQualityRetries)
 					r.reportProgress(task.ID, "Quality Retry", 92,
 						fmt.Sprintf("Fixing issues (attempt %d/%d)...", retryAttempt+1, maxAutoRetries))
 
@@ -3605,6 +3652,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 			// Populate quality gate results in ExecutionResult (GH-209)
 			if finalOutcome != nil {
 				result.QualityGates = r.buildQualityGatesResult(finalOutcome, totalQualityRetries)
+				r.recordQualityGateEvents(task.LogExecutionID(), finalOutcome)
 			}
 		}
 
@@ -3719,6 +3767,7 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 
 				if !state.intentRetried {
 					state.intentRetried = true
+					r.recordRetryAttemptEvent(task.LogExecutionID(), "intent_judge_retry", 1)
 					r.reportProgress(task.ID, "Intent Retry", 80, "Retrying with intent feedback...")
 
 					retryPrompt := fmt.Sprintf(
@@ -5404,6 +5453,45 @@ func (r *Runner) buildQualityGatesResult(outcome *QualityOutcome, totalRetries i
 	}
 
 	return qgResult
+}
+
+// recordQualityGateEvents persists quality.CheckResults timing (computed but
+// previously transient — GH-4129) as execution_events: one row per gate
+// carrying that gate's Duration, plus a trailing summary row carrying
+// TotalDuration, using the same detail-JSON convention as recordRetryAttemptEvent.
+func (r *Runner) recordQualityGateEvents(executionID string, outcome *QualityOutcome) {
+	if outcome == nil {
+		return
+	}
+	for _, gate := range outcome.GateDetails {
+		detail, err := json.Marshal(struct {
+			Gate       string `json:"gate"`
+			DurationMS int64  `json:"duration_ms"`
+			Passed     bool   `json:"passed"`
+			RetryCount int    `json:"retry_count"`
+		}{
+			Gate:       gate.Name,
+			DurationMS: gate.Duration.Milliseconds(),
+			Passed:     gate.Passed,
+			RetryCount: gate.RetryCount,
+		})
+		if err != nil {
+			continue
+		}
+		r.recordExecutionEvent(executionID, memory.StageQualityGate, string(detail))
+	}
+
+	summary, err := json.Marshal(struct {
+		TotalDurationMS int64 `json:"total_duration_ms"`
+		GateCount       int   `json:"gate_count"`
+	}{
+		TotalDurationMS: outcome.TotalDuration.Milliseconds(),
+		GateCount:       len(outcome.GateDetails),
+	})
+	if err != nil {
+		return
+	}
+	r.recordExecutionEvent(executionID, memory.StageQualityGate, string(summary))
 }
 
 // simpleQualityChecker is a minimal quality checker for auto-enabled build gates (GH-363).

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -711,10 +711,10 @@ const (
 	StageClaudeStarted Stage = "claude_started"
 	StageDecomposed    Stage = "decomposed"
 	// StageImplementationStarted marks a direct (non-epic) task handing off to
-	// Claude for real implementation work. GH-3938 wires claude_started/
-	// decomposed/completed on the epic-parent path only; this value is
-	// reserved for a future direct-path instrumentation pass so the enum
-	// matches the full lifecycle described in GH-3840 up front.
+	// Claude for real implementation work. GH-3938 wired claude_started/
+	// decomposed/completed on the epic-parent path only; GH-4129 wires this
+	// value on the direct path so the enum matches the full lifecycle
+	// described in GH-3840.
 	StageImplementationStarted Stage = "implementation_started"
 	StageCommit                Stage = "commit"
 	StagePRCreated             Stage = "pr_created"
@@ -731,6 +731,20 @@ const (
 	StageNoOp             Stage = "no_op"
 	StageSkipped          Stage = "skipped"
 	StageStalled          Stage = "stalled"
+	// StageResearchPhase records the parallel-research phase's duration and
+	// token spend once per direct-path execution (GH-4129). Detail is a JSON
+	// object: {"duration_ms","total_tokens","findings"}.
+	StageResearchPhase Stage = "research_phase"
+	// StageQualityGate records quality.CheckResults timing: one event per
+	// gate (detail: {"gate","duration_ms","passed","retry_count"}) plus a
+	// trailing summary event (detail: {"total_duration_ms","gate_count"})
+	// (GH-4129).
+	StageQualityGate Stage = "quality_gate"
+	// StageRetryAttempt tags a retried backend invocation with the loop that
+	// triggered it (smart_retry, quality_gate_retry, intent_judge_retry) so
+	// retry wall-clock share is queryable (GH-4129). Detail is a JSON object:
+	// {"loop","attempt"}.
+	StageRetryAttempt Stage = "retry_attempt"
 )
 
 // Event represents a single stage-transition record for an execution.


### PR DESCRIPTION
## Summary
- Emit `StageClaudeStarted`/`StageImplementationStarted` on the direct (non-epic) execution path right before the backend invocation, mirroring the epic path's `:1919` pattern so `execution_events` no longer goes silent after `spec_validated`.
- Persist per-gate `quality.CheckResults` timing plus the overall `TotalDuration` as `execution_events` rows (`recordQualityGateEvents`).
- Persist the parallel-research phase's `Duration`/`TotalTokens` as an `execution_events` row (previously `slog.Info` only).
- Tag retried backend attempts (smart retry, quality-gate retry, intent-judge retry) with `retry_attempt` events naming the loop.
- All changes are additive event-recording only — no behavior change.

Closes #4129

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/executor/...` — includes new `TestDirectPath_ClaudeStartedAndImplementationStartedEvents` and related GH-4129 coverage in `internal/executor/gh4129_test.go`
- [x] `go test ./internal/memory/...`
- [x] `go test ./internal/autopilot/... ./internal/gateway/...` (touched by rebase onto main's `waiting_ci` stage plumbing)
- [x] Rebased onto latest `main` (`fefdf498`) to resolve a `Stage` const conflict with the concurrently-landed `StageWaitingCI` plumbing