### PR TITLE
feat(autopilot): persist waiting_ci event and observe pipeline histograms (GH-4130)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -680,12 +680,16 @@ func (c *Controller) persistRemovePR(prNumber int) {
 }
 
 // executionEventStageFor maps a PRStage to the memory.Stage recorded in the
-// execution-events audit trail. Only the subset of PRStages that mark a
-// durable milestone (as opposed to an in-progress poll state like
-// StageWaitingCI) has an entry; ok is false for everything else, so callers
-// skip the write instead of logging noise for every poll cycle.
+// execution-events audit trail. ok is false for stages with no audit-trail
+// equivalent, so callers skip the write instead of logging noise for those
+// transitions.
 func executionEventStageFor(prStage PRStage) (memory.Stage, bool) {
 	switch prStage {
+	case StageWaitingCI:
+		// GH-4130: persist CI-wait entry so it survives restarts — previously
+		// only the in-memory PRState.CIWaitStartedAt (types.go:728) tracked this,
+		// which reset to zero on every daemon restart.
+		return memory.StageWaitingCI, true
 	case StageCIPassed:
 		return memory.StageCIPassed, true
 	case StageCIFailed:
@@ -856,6 +860,21 @@ func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, he
 	}
 	c.activePRs[prNumber] = prState
 	c.mu.Unlock()
+
+	// GH-4130: observe pilot_time_to_pr_seconds / pilot_queue_wait_seconds now
+	// that the PR exists — this is the first point autopilot sees the issue's
+	// execution, so it's the natural place to read started_at/created_at off
+	// the execution row (taskID resolution mirrors recordExecutionEvent).
+	if c.memoryStore != nil {
+		taskID := fmt.Sprintf("GH-%d", issueNumber)
+		if issueNumber == 0 {
+			taskID = fmt.Sprintf("PR-%d", prNumber)
+		}
+		if exec, err := c.memoryStore.GetLatestExecutionByTaskID(taskID); err == nil && exec.StartedAt != nil {
+			c.metrics.RecordTimeToPR(time.Since(*exec.StartedAt))
+			c.metrics.RecordQueueWaitDuration(exec.StartedAt.Sub(exec.CreatedAt))
+		}
+	}
 
 	// Persist to SQLite (idempotent, safe outside lock).
 	// TASK-324: prState is now published in activePRs, so a concurrent ProcessPR or
@@ -1707,6 +1726,14 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 
 // applyApprovalDecision advances the state machine based on the recorded decision.
 func (c *Controller) applyApprovalDecision(prState *PRState) error {
+	// GH-4130: observe pilot_approval_wait_seconds from when the async approval
+	// request was submitted (functionally the awaiting_approval entry point) to
+	// this merge decision being applied — covers both the SetApprovalDecision
+	// webhook path and the wall-clock-expiry default-action path (Path 3 above).
+	if !prState.ApprovalRequestedAt.IsZero() {
+		c.metrics.RecordApprovalWaitDuration(time.Since(prState.ApprovalRequestedAt))
+	}
+
 	switch approval.Decision(prState.ApprovalDecision) {
 	case approval.DecisionApproved:
 		c.log.Info("approval granted — advancing to merging stage", "pr", prState.PRNumber)

--- a/internal/autopilot/controller_execution_events_test.go
+++ b/internal/autopilot/controller_execution_events_test.go
@@ -33,6 +33,7 @@ func TestController_ExecutionEvents_PRLifecycle(t *testing.T) {
 			name:       "happy path: CI passes, merges, and releases",
 			buildSteps: buildHappyPathServer,
 			wantStages: []memory.Stage{
+				memory.StageWaitingCI,
 				memory.StageCIPassed,
 				memory.StageMerged,
 				memory.StageReleased,
@@ -42,6 +43,7 @@ func TestController_ExecutionEvents_PRLifecycle(t *testing.T) {
 			name:       "CI failure branch",
 			buildSteps: buildCIFailureServer,
 			wantStages: []memory.Stage{
+				memory.StageWaitingCI,
 				memory.StageCIFailed,
 				memory.StageFailed,
 			},

--- a/internal/autopilot/gh4130_test.go
+++ b/internal/autopilot/gh4130_test.go
@@ -1,0 +1,164 @@
+package autopilot
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/approval"
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// gh4130ExecPersister is a minimal approvalPersister that returns a
+// caller-configured *memory.Execution from GetLatestExecutionByTaskID, so
+// tests can control StartedAt/CreatedAt independent of the shared
+// mockApprovalPersister (which always returns a bare {ID, TaskID} row).
+type gh4130ExecPersister struct {
+	execByTask map[string]*memory.Execution
+}
+
+func (m *gh4130ExecPersister) SetApprovalRequestID(_ context.Context, _, _ string) error { return nil }
+func (m *gh4130ExecPersister) SetApprovalDecision(_ context.Context, _, _, _ string) error {
+	return nil
+}
+func (m *gh4130ExecPersister) InsertExecutionEvent(_ string, _ memory.Stage, _ string) error {
+	return nil
+}
+func (m *gh4130ExecPersister) GetLatestExecutionByTaskID(taskID string) (*memory.Execution, error) {
+	exec, ok := m.execByTask[taskID]
+	if !ok {
+		return nil, sql.ErrNoRows
+	}
+	return exec, nil
+}
+
+// TestExecutionEventStageFor_WaitingCI verifies GH-4130's core change: the
+// waiting_ci in-progress skip is removed, so entering StageWaitingCI now
+// produces a durable execution_events row instead of being dropped.
+func TestExecutionEventStageFor_WaitingCI(t *testing.T) {
+	stage, ok := executionEventStageFor(StageWaitingCI)
+	if !ok {
+		t.Fatal("executionEventStageFor(StageWaitingCI) ok = false, want true")
+	}
+	if stage != memory.StageWaitingCI {
+		t.Errorf("executionEventStageFor(StageWaitingCI) = %q, want %q", stage, memory.StageWaitingCI)
+	}
+}
+
+// TestOnPRCreated_ObservesTimeToPRAndQueueWait verifies OnPRCreated reads the
+// execution row's started_at/created_at and feeds pilot_time_to_pr_seconds /
+// pilot_queue_wait_seconds — the two histograms observable at PR-creation time.
+func TestOnPRCreated_ObservesTimeToPRAndQueueWait(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	createdAt := time.Now().Add(-10 * time.Minute)
+	startedAt := createdAt.Add(6 * time.Minute) // queue wait = 6m
+	c.memoryStore = &gh4130ExecPersister{
+		execByTask: map[string]*memory.Execution{
+			"GH-77": {ID: "exec-77", TaskID: "GH-77", CreatedAt: createdAt, StartedAt: &startedAt},
+		},
+	}
+
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 77, "abc1234", "pilot/GH-77", "")
+
+	hist := c.metrics.HistogramSnapshot()
+	if len(hist.TimeToPRDurations) != 1 {
+		t.Fatalf("TimeToPRDurations = %v, want 1 sample", hist.TimeToPRDurations)
+	}
+	if len(hist.QueueWaitDurations) != 1 {
+		t.Fatalf("QueueWaitDurations = %v, want 1 sample", hist.QueueWaitDurations)
+	}
+
+	// time_to_pr is measured from startedAt (~4m ago) to now: expect roughly 4m, well above 0.
+	if hist.TimeToPRDurations[0] < 3*time.Minute {
+		t.Errorf("TimeToPRDurations[0] = %v, want >= 3m (started_at was ~4m ago)", hist.TimeToPRDurations[0])
+	}
+	// queue_wait is exactly startedAt - createdAt = 6m.
+	if got := hist.QueueWaitDurations[0]; got < 5*time.Minute || got > 7*time.Minute {
+		t.Errorf("QueueWaitDurations[0] = %v, want ~6m", got)
+	}
+}
+
+// TestOnPRCreated_NoExecutionRow_SkipsObservation verifies a missing/incomplete
+// execution row (no started_at, e.g. a test double or a pre-GH-4033 row) does
+// not observe the histograms — the guard mirrors recordExecutionEvent's
+// best-effort, non-fatal lookup-miss handling.
+func TestOnPRCreated_NoExecutionRow_SkipsObservation(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.memoryStore = &gh4130ExecPersister{execByTask: map[string]*memory.Execution{}}
+
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 77, "abc1234", "pilot/GH-77", "")
+
+	hist := c.metrics.HistogramSnapshot()
+	if len(hist.TimeToPRDurations) != 0 || len(hist.QueueWaitDurations) != 0 {
+		t.Errorf("expected no histogram samples on lookup miss, got TimeToPR=%v QueueWait=%v",
+			hist.TimeToPRDurations, hist.QueueWaitDurations)
+	}
+}
+
+// TestApplyApprovalDecision_ObservesApprovalWait verifies applyApprovalDecision
+// feeds pilot_approval_wait_seconds from ApprovalRequestedAt (the
+// awaiting_approval entry point) to the moment the decision is applied,
+// covering both the webhook-decision path and the wall-clock-expiry
+// default-action path (both call applyApprovalDecision).
+func TestApplyApprovalDecision_ObservesApprovalWait(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	mgr := approval.NewManager(nil)
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+
+	requestedAt := time.Now().Add(-90 * time.Second)
+	prState := &PRState{
+		PRNumber:            99,
+		IssueNumber:         10,
+		ApprovalRequestID:   "req-1",
+		ApprovalRequestedAt: requestedAt,
+		ApprovalDecision:    string(approval.DecisionApproved),
+	}
+
+	if err := c.applyApprovalDecision(prState); err != nil {
+		t.Fatalf("applyApprovalDecision: %v", err)
+	}
+
+	hist := c.metrics.HistogramSnapshot()
+	if len(hist.ApprovalWaitDurations) != 1 {
+		t.Fatalf("ApprovalWaitDurations = %v, want 1 sample", hist.ApprovalWaitDurations)
+	}
+	if got := hist.ApprovalWaitDurations[0]; got < 60*time.Second || got > 120*time.Second {
+		t.Errorf("ApprovalWaitDurations[0] = %v, want ~90s", got)
+	}
+	if prState.Stage != StageMerging {
+		t.Errorf("Stage = %s, want %s (approved decision should still advance the state machine)", prState.Stage, StageMerging)
+	}
+}
+
+// TestApplyApprovalDecision_ZeroRequestedAt_SkipsObservation guards against a
+// zero-value ApprovalRequestedAt (defensive: shouldn't happen on any real path
+// since both submitAsyncApprovalRequest and the timeout branch set it first)
+// producing a bogus multi-decade duration sample.
+func TestApplyApprovalDecision_ZeroRequestedAt_SkipsObservation(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	prState := &PRState{
+		PRNumber:         99,
+		ApprovalDecision: string(approval.DecisionApproved),
+	}
+
+	if err := c.applyApprovalDecision(prState); err != nil {
+		t.Fatalf("applyApprovalDecision: %v", err)
+	}
+
+	hist := c.metrics.HistogramSnapshot()
+	if len(hist.ApprovalWaitDurations) != 0 {
+		t.Errorf("ApprovalWaitDurations = %v, want no sample for zero ApprovalRequestedAt", hist.ApprovalWaitDurations)
+	}
+}

--- a/internal/autopilot/metrics.go
+++ b/internal/autopilot/metrics.go
@@ -81,10 +81,11 @@ type Metrics struct {
 	CIWaitDurations    []time.Duration
 	ExecutionDurations []time.Duration
 
-	// Histograms added by GH-4128 (plumbing only — no Record* call sites yet).
-	TimeToPRDurations     []time.Duration // issue pickup to PR creation
-	QueueWaitDurations    []time.Duration // time spent queued before pickup
-	ApprovalWaitDurations []time.Duration // time spent awaiting human approval
+	// Histograms registered by GH-4128; observed at their transitions by
+	// GH-4130 (OnPRCreated, applyApprovalDecision).
+	TimeToPRDurations     []time.Duration // execution started_at to pr_created
+	QueueWaitDurations    []time.Duration // execution created_at to started_at
+	ApprovalWaitDurations []time.Duration // awaiting_approval request to merge decision
 
 	// Timestamps for rate calculation
 	apiErrorTimes []time.Time
@@ -517,7 +518,7 @@ type HistogramData struct {
 	CIWaitDurations    []time.Duration
 	ExecutionDurations []time.Duration
 
-	// GH-4128: no Record* call site feeds these yet — plumbing ahead of the observer.
+	// GH-4130 observes these; see Metrics.TimeToPRDurations et al.
 	TimeToPRDurations     []time.Duration
 	QueueWaitDurations    []time.Duration
 	ApprovalWaitDurations []time.Duration

--- a/internal/gateway/prometheus.go
+++ b/internal/gateway/prometheus.go
@@ -255,23 +255,22 @@ func (e *PrometheusExporter) WritePrometheus(w io.Writer) error {
 		hist.CIWaitDurations,
 		[]float64{30, 60, 120, 300, 600, 900, 1200, 1800, 3600}) // 30s, 1m, 2m, 5m, 10m, 15m, 20m, 30m, 1h
 
-	// pilot_time_to_pr_seconds (GH-4128; plumbing only — hist.TimeToPRDurations
-	// has no Record* call site yet, so this always exports an empty series)
+	// pilot_time_to_pr_seconds (GH-4128 registered the histogram; GH-4130
+	// observes it in autopilot.Controller.OnPRCreated)
 	writeHistogram(w, "pilot_time_to_pr_seconds",
 		"Time from issue pickup to PR creation",
 		hist.TimeToPRDurations,
 		[]float64{60, 300, 600, 1200, 1800, 3600, 7200, 14400, 28800}) // 1m, 5m, 10m, 20m, 30m, 1h, 2h, 4h, 8h
 
-	// pilot_queue_wait_seconds (GH-4128; plumbing only — hist.QueueWaitDurations
-	// has no Record* call site yet, so this always exports an empty series)
+	// pilot_queue_wait_seconds (GH-4128 registered the histogram; GH-4130
+	// observes it in autopilot.Controller.OnPRCreated)
 	writeHistogram(w, "pilot_queue_wait_seconds",
 		"Time an issue spent queued before pickup",
 		hist.QueueWaitDurations,
 		[]float64{60, 300, 600, 1800, 3600, 7200, 14400, 28800, 86400}) // 1m, 5m, 10m, 30m, 1h, 2h, 4h, 8h, 24h
 
-	// pilot_approval_wait_seconds (GH-4128; plumbing only —
-	// hist.ApprovalWaitDurations has no Record* call site yet, so this always
-	// exports an empty series)
+	// pilot_approval_wait_seconds (GH-4128 registered the histogram; GH-4130
+	// observes it in autopilot.Controller.applyApprovalDecision)
 	writeHistogram(w, "pilot_approval_wait_seconds",
 		"Time a PR spent awaiting human approval",
 		hist.ApprovalWaitDurations,


### PR DESCRIPTION
## Summary
- Removes the in-progress skip at `executionEventStageFor` (controller.go:684-686) for `StageWaitingCI`, so entering CI-wait now writes a durable `waiting_ci` row to `execution_events` instead of relying solely on the restart-losing in-memory `PRState.CIWaitStartedAt` (types.go:728).
- `Controller.OnPRCreated` now reads the execution row's `started_at`/`created_at` and observes `pilot_time_to_pr_seconds` (started_at → now) and `pilot_queue_wait_seconds` (created_at → started_at) — both histograms were registered by subtask 1 (GH-4128) with no observer yet.
- `Controller.applyApprovalDecision` observes `pilot_approval_wait_seconds` from `ApprovalRequestedAt` to the merge decision being applied — covers both the `SetApprovalDecision` webhook path and the wall-clock-expiry default-action path, since both call `applyApprovalDecision`.

Closes #4130

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] New tests in `internal/autopilot/gh4130_test.go`: `executionEventStageFor(StageWaitingCI)` mapping, `OnPRCreated` observing both histograms from a mocked execution row (and skipping cleanly on lookup-miss), `applyApprovalDecision` observing approval-wait (and skipping on zero `ApprovalRequestedAt`)
- [x] Updated `TestController_ExecutionEvents_PRLifecycle` to expect the new `waiting_ci` event in both the happy-path and CI-failure sequences