### PR TITLE
feat(dashboard): grafterm pipeline-breakdown panel + existing histogram charts

### DIFF
--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -72,6 +72,32 @@ The `pilot-dashboard.json` (uid: `pilot`) contains 12 panels across 5 rows (y=0.
 | 11 | Cost/hour | timeseries | `rate(pilot_execution_cost_usd_total[5m]) * 3600` legend `{{model}}` |
 | 12 | Executions by Result | bargauge | `pilot_executions_total` legend `{{model}}/{{result}}` |
 
+## Terminal Dashboard (grafterm)
+
+`grafterm-pilot.json` renders the pipeline-breakdown view in the terminal via
+[grafterm](https://github.com/slok/grafterm) instead of Grafana's web UI. It
+points at the same Prometheus instance the compose stack exposes on 9093, so
+start the stack first:
+
+```bash
+go install github.com/slok/grafterm/cmd/grafterm@latest
+cd deploy/grafana
+grafterm -c grafterm-pilot.json
+```
+
+| # | Widget | PromQL |
+|---|--------|--------|
+| 1 | Pipeline Breakdown (P50): queue wait → execution → time-to-PR → CI wait → approval wait → merge | `histogram_quantile(0.50, sum(rate(pilot_queue_wait_seconds_bucket[15m])) by (le))`, `pilot_execution_duration_seconds`, `pilot_time_to_pr_seconds`, `pilot_ci_wait_duration_seconds`, `pilot_approval_wait_seconds`, `pilot_pr_time_to_merge_seconds` |
+| 2 | PR Time to Merge (P50/P95) | `histogram_quantile(0.50\|0.95, sum(rate(pilot_pr_time_to_merge_seconds_bucket[15m])) by (le))` |
+| 3 | CI Wait Duration (P50/P95) | `histogram_quantile(0.50\|0.95, sum(rate(pilot_ci_wait_duration_seconds_bucket[15m])) by (le))` |
+
+`pilot_queue_wait_seconds`, `pilot_time_to_pr_seconds`, and
+`pilot_approval_wait_seconds` are registered but not yet observed (GH-4128
+plumbing; observers land in GH-4130) — their series render as no-data until
+that lands. grafterm doesn't support native stacked/area rendering, so the
+breakdown widget overlays all six stage histograms as separate lines on one
+graph rather than a true stacked area chart.
+
 ## Troubleshooting
 
 **Prometheus shows Pilot target as `DOWN`:**

--- a/deploy/grafana/grafterm-pilot.json
+++ b/deploy/grafana/grafterm-pilot.json
@@ -1,0 +1,122 @@
+{
+  "version": "v1",
+  "datasources": {
+    "prometheus": {
+      "prometheus": {
+        "address": "http://localhost:9093"
+      }
+    }
+  },
+  "dashboard": {
+    "grid": {
+      "maxWidth": 100
+    },
+    "widgets": [
+      {
+        "title": "Pipeline Breakdown (P50): queue wait -> execution -> time-to-PR -> CI wait -> approval wait -> merge",
+        "gridPos": { "w": 100 },
+        "graph": {
+          "visualization": {
+            "seriesOverride": [
+              { "regex": "^1\\. Queue Wait$", "color": "#5794F2" },
+              { "regex": "^2\\. Execution$", "color": "#73BF69" },
+              { "regex": "^3\\. Time to PR$", "color": "#FADE2A" },
+              { "regex": "^4\\. CI Wait$", "color": "#FF9830" },
+              { "regex": "^5\\. Approval Wait$", "color": "#F2495C" },
+              { "regex": "^6\\. Merge$", "color": "#B877D9" }
+            ],
+            "yAxis": {
+              "unit": "seconds"
+            }
+          },
+          "queries": [
+            {
+              "datasourceID": "prometheus",
+              "expr": "histogram_quantile(0.50, sum(rate(pilot_queue_wait_seconds_bucket[15m])) by (le))",
+              "legend": "1. Queue Wait"
+            },
+            {
+              "datasourceID": "prometheus",
+              "expr": "histogram_quantile(0.50, sum(rate(pilot_execution_duration_seconds_bucket[15m])) by (le))",
+              "legend": "2. Execution"
+            },
+            {
+              "datasourceID": "prometheus",
+              "expr": "histogram_quantile(0.50, sum(rate(pilot_time_to_pr_seconds_bucket[15m])) by (le))",
+              "legend": "3. Time to PR"
+            },
+            {
+              "datasourceID": "prometheus",
+              "expr": "histogram_quantile(0.50, sum(rate(pilot_ci_wait_duration_seconds_bucket[15m])) by (le))",
+              "legend": "4. CI Wait"
+            },
+            {
+              "datasourceID": "prometheus",
+              "expr": "histogram_quantile(0.50, sum(rate(pilot_approval_wait_seconds_bucket[15m])) by (le))",
+              "legend": "5. Approval Wait"
+            },
+            {
+              "datasourceID": "prometheus",
+              "expr": "histogram_quantile(0.50, sum(rate(pilot_pr_time_to_merge_seconds_bucket[15m])) by (le))",
+              "legend": "6. Merge"
+            }
+          ]
+        }
+      },
+      {
+        "title": "PR Time to Merge",
+        "gridPos": { "w": 100 },
+        "graph": {
+          "visualization": {
+            "seriesOverride": [
+              { "regex": "^p50$", "color": "#5794F2" },
+              { "regex": "^p95$", "color": "#F2495C" }
+            ],
+            "yAxis": {
+              "unit": "seconds"
+            }
+          },
+          "queries": [
+            {
+              "datasourceID": "prometheus",
+              "expr": "histogram_quantile(0.50, sum(rate(pilot_pr_time_to_merge_seconds_bucket[15m])) by (le))",
+              "legend": "p50"
+            },
+            {
+              "datasourceID": "prometheus",
+              "expr": "histogram_quantile(0.95, sum(rate(pilot_pr_time_to_merge_seconds_bucket[15m])) by (le))",
+              "legend": "p95"
+            }
+          ]
+        }
+      },
+      {
+        "title": "CI Wait Duration",
+        "gridPos": { "w": 100 },
+        "graph": {
+          "visualization": {
+            "seriesOverride": [
+              { "regex": "^p50$", "color": "#5794F2" },
+              { "regex": "^p95$", "color": "#F2495C" }
+            ],
+            "yAxis": {
+              "unit": "seconds"
+            }
+          },
+          "queries": [
+            {
+              "datasourceID": "prometheus",
+              "expr": "histogram_quantile(0.50, sum(rate(pilot_ci_wait_duration_seconds_bucket[15m])) by (le))",
+              "legend": "p50"
+            },
+            {
+              "datasourceID": "prometheus",
+              "expr": "histogram_quantile(0.95, sum(rate(pilot_ci_wait_duration_seconds_bucket[15m])) by (le))",
+              "legend": "p95"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `deploy/grafana/grafterm-pilot.json`, a terminal-based [grafterm](https://github.com/slok/grafterm) dashboard (the file didn't previously exist).
- Pipeline-breakdown widget overlays six histograms as separate P50 lines in pipeline order: queue wait → execution → time-to-PR → CI wait → approval wait → merge (`pilot_queue_wait_seconds`, `pilot_execution_duration_seconds`, `pilot_time_to_pr_seconds`, `pilot_ci_wait_duration_seconds`, `pilot_approval_wait_seconds`, `pilot_pr_time_to_merge_seconds`).
- Adds standalone P50/P95 charts for the two already-exported-but-uncharted histograms: `pilot_pr_time_to_merge_seconds` and `pilot_ci_wait_duration_seconds`.
- grafterm has no native stacked/area chart support (confirmed by reading its Go model source), so the breakdown panel overlays the six series as distinctly colored lines on one graph — the closest available representation.
- `pilot_queue_wait_seconds`, `pilot_time_to_pr_seconds`, `pilot_approval_wait_seconds` are plumbing-only per #4128 (no `Record*` call sites yet, wired in #4130) — they render as no-data until then, documented in the README.
- Documents how to run grafterm against the file in `deploy/grafana/README.md`, mirroring the existing Grafana dashboard panel table.

## Test plan

- [x] `go build ./...` passes (no Go files touched)
- [x] JSON validated with `python3 -c "import json; json.load(...)"`
- [x] Installed grafterm from source (`go install github.com/slok/grafterm/cmd/grafterm@latest`), confirmed the config parses and passes `Dashboard.Validate()` (reached TUI init, only failed on missing `/dev/tty` in the sandboxed shell)
- [x] Queried the running local Prometheus (`localhost:9093`) with all six PromQL expressions used in the dashboard — all returned `status: success`; the three existing metrics returned live non-empty data