### PR TITLE
fix(executor): ledger row + merged-PR short-circuit for epic sub-issues

### DIFF
--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -374,6 +374,21 @@ var staleRunningMergedPRCheck = func(ctx context.Context, projectPath, branch st
 	return NewGitOperations(projectPath).FindMergedPRByBranch(ctx, branch)
 }
 
+// mergedPRPreflightCheck reports the URL of a merged PR for a queued task's
+// branch, or "" if none exists. GH-4141 Phase 3 defense-in-depth: a queued
+// duplicate (e.g. the sub-issue poller-retry duplicate that motivated
+// TASK-394's ledger row) must not burn a full backend invocation just to
+// rediscover "no new commit" as a no_op — the worker marks it completed with
+// the existing PR URL instead and skips the backend call entirely. Mirrors
+// staleRunningMergedPRCheck's test-mode short-circuit; tests override this
+// var directly.
+var mergedPRPreflightCheck = func(ctx context.Context, projectPath, branch string) (string, error) {
+	if testing.Testing() {
+		return "", nil
+	}
+	return NewGitOperations(projectPath).FindMergedPRByBranch(ctx, branch)
+}
+
 // recoverStaleQueuedTasks marks orphaned queued tasks as failed: either a
 // duplicate row for a task that already completed, or a queued task whose
 // project has no live worker even after Dispatcher.Start's adoption pass
@@ -893,6 +908,28 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 		// GH-2326: restore Labels so runner-side no-decompose / autopilot-fix
 		// gates see the same labels the dispatch-time Decompose() saw.
 		task := buildTaskFromExecution(exec)
+
+		// GH-4141 Phase 3: pre-execute merged-PR short-circuit. A queued task
+		// whose branch already has a merged PR (e.g. a poller-retry duplicate of
+		// a sub-issue the epic already shipped) must not re-invoke the backend
+		// just to rediscover "no new commit" as a no_op — mark it completed with
+		// the existing PR URL and skip execution entirely.
+		if task.Branch != "" {
+			if mergedURL, mergedErr := mergedPRPreflightCheck(ctx, exec.ProjectPath, task.Branch); mergedErr == nil && mergedURL != "" {
+				w.log.Info("Queued task's branch already merged; skipping backend invocation",
+					slog.String("execution_id", exec.ID),
+					slog.String("task_id", exec.TaskID),
+					slog.String("pr_url", mergedURL),
+				)
+				if err := w.store.MarkExecutionCompleted(exec.ID, mergedURL, "", 0); err != nil {
+					w.log.Error("Failed to mark pre-execute merged-PR short-circuit completed", slog.Any("error", err))
+				}
+				w.recordExecutionEvent(exec.ID, memory.StageCompleted, "pre-execute merged-PR short-circuit: "+mergedURL)
+				w.runner.EmitProgress(exec.TaskID, "Completed", 100, "work already merged: "+mergedURL)
+				w.currentTaskID.Store("")
+				continue
+			}
+		}
 
 		// Execute (blocking)
 		start := time.Now()

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -904,6 +904,119 @@ func TestRecoverStaleRunningTasks_FateReconstructableFromEventsAlone(t *testing.
 	}
 }
 
+// TestProcessQueue_MergedPRPreflight_SkipsBackend is the GH-4141 Phase 3
+// regression test: a queued task whose branch already has a merged PR (e.g.
+// a poller-retry duplicate of a sub-issue the epic already shipped, TASK-394)
+// must complete from the pre-flight check alone — zero backend invocations —
+// instead of burning a full Claude run to rediscover "no new commit" as a
+// no_op.
+func TestProcessQueue_MergedPRPreflight_SkipsBackend(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	const projectPath = "/project-merged-preflight"
+	const branch = "pilot/GH-8001"
+	const mergedPRURL = "https://github.com/qf-studio/pilot/pull/8001"
+
+	exec := &memory.Execution{
+		ID:           "exec-preflight-merged",
+		TaskID:       "GH-8001",
+		ProjectPath:  projectPath,
+		Status:       "queued",
+		TaskBranch:   branch,
+		TaskCreatePR: true,
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("failed to save execution: %v", err)
+	}
+
+	origCheck := mergedPRPreflightCheck
+	mergedPRPreflightCheck = func(_ context.Context, gotProjectPath, gotBranch string) (string, error) {
+		if gotProjectPath == projectPath && gotBranch == branch {
+			return mergedPRURL, nil
+		}
+		return "", nil
+	}
+	defer func() { mergedPRPreflightCheck = origCheck }()
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "should never run"}}
+	runner := NewRunnerWithBackend(backend)
+	worker := NewProjectWorker(projectPath, store, runner, slog.Default())
+
+	worker.processQueue(context.Background())
+
+	backend.mu.Lock()
+	count := backend.execCount
+	backend.mu.Unlock()
+	if count != 0 {
+		t.Errorf("expected zero backend invocations (pre-flight short-circuit), got %d", count)
+	}
+
+	got, err := store.GetExecution(exec.ID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if got.Status != "completed" {
+		t.Errorf("expected status 'completed', got %q", got.Status)
+	}
+	if got.PRUrl != mergedPRURL {
+		t.Errorf("expected pr_url %q, got %q", mergedPRURL, got.PRUrl)
+	}
+}
+
+// TestProcessQueue_MergedPRPreflight_UnmergedBranchProceedsNormally is the
+// GH-4141 Phase 3 negative case: a queued task whose branch has no merged PR
+// (e.g. still open, or no PR at all) must proceed through the normal
+// execution path unchanged — the backend is still invoked.
+func TestProcessQueue_MergedPRPreflight_UnmergedBranchProceedsNormally(t *testing.T) {
+	const branch = "pilot/GH-8002"
+	dir := setupPRGuardRepo(t, branch, false) // no additional commits
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	exec := &memory.Execution{
+		ID:           "exec-preflight-unmerged",
+		TaskID:       "GH-8002",
+		ProjectPath:  dir,
+		Status:       "queued",
+		TaskBranch:   branch,
+		TaskCreatePR: true,
+	}
+	if err := store.SaveExecution(exec); err != nil {
+		t.Fatalf("failed to save execution: %v", err)
+	}
+
+	origCheck := mergedPRPreflightCheck
+	mergedPRPreflightCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+	defer func() { mergedPRPreflightCheck = origCheck }()
+
+	// Backend always succeeds but makes no git commits (mirrors
+	// TestRunner_PRCreate_EmptyBranch_TriggersRetry's no-commit guard setup).
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "analysis complete"}}
+	runner := NewRunnerWithBackend(backend)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	worker := NewProjectWorker(dir, store, runner, slog.Default())
+
+	worker.processQueue(context.Background())
+
+	backend.mu.Lock()
+	count := backend.execCount
+	backend.mu.Unlock()
+	if count == 0 {
+		t.Error("expected the backend to be invoked (no merged PR found) — pre-flight must not have short-circuited")
+	}
+
+	got, err := store.GetExecution(exec.ID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if got.PRUrl != "" {
+		t.Errorf("expected no pr_url recorded (no merged PR short-circuit should have fired), got %q", got.PRUrl)
+	}
+}
+
 func TestRecoverStaleTasks_RespectsThresholds(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/qf-studio/pilot/internal/memory"
 )
 
@@ -1638,18 +1639,23 @@ var childExecutionNonTerminalStatuses = map[string]bool{
 // queue). Only a terminal status on the child's tracked execution row is
 // proof.
 //
+// selfExecID is the UUID of the ledger row ExecuteSubIssuesTracked created
+// for THIS run (GH-4141) — it stays "running" for the whole call, so the
+// status lookups below must exclude it to find a genuinely separate,
+// concurrently-tracked row instead of always observing their own row.
+//
 // When no failure signal is present, or no log store is wired to check
 // against, the original (result, err) pass through unchanged. Otherwise this
-// polls GetExecutionStatusByTaskID for taskID (scoped to projectPath) until
-// it reports a terminal status, the context is cancelled, or
-// childOutcomeReconcileTimeout elapses — whichever comes first, so this can
-// never block the epic indefinitely. On terminal success ("completed" /
-// "no_op") it synthesizes a passing ExecutionResult from the tracked row so
-// the caller's normal success/no-op handling applies; on terminal failure it
-// enriches the returned error with the tracked row's real error message
-// instead of the uninformative "unknown: exit status 1" backend
-// classification.
-func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath string, result *ExecutionResult, execErr error) (*ExecutionResult, error) {
+// polls GetExecutionStatusByTaskIDExcluding for taskID (scoped to
+// projectPath) until it reports a terminal status, the context is
+// cancelled, or childOutcomeReconcileTimeout elapses — whichever comes
+// first, so this can never block the epic indefinitely. On terminal success
+// ("completed" / "no_op") it synthesizes a passing ExecutionResult from the
+// tracked row so the caller's normal success/no-op handling applies; on
+// terminal failure it enriches the returned error with the tracked row's
+// real error message instead of the uninformative "unknown: exit status 1"
+// backend classification.
+func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath, selfExecID string, result *ExecutionResult, execErr error) (*ExecutionResult, error) {
 	hasFailureSignal := execErr != nil || (result != nil && !result.Success)
 	if !hasFailureSignal {
 		return result, execErr
@@ -1658,14 +1664,13 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath 
 		return result, execErr
 	}
 
-	// First lookup outside the poll loop: if the child has no tracked
-	// execution row at all (the common case for a genuine, non-racing
-	// failure — inline sub-issue execution doesn't itself write an
-	// executions row), there is nothing to wait for. Only enter the bounded
-	// poll when a row actually exists and is still in flight, so a plain
+	// First lookup outside the poll loop: if the child has no OTHER tracked
+	// execution row (the common case for a genuine, non-racing failure),
+	// there is nothing to wait for. Only enter the bounded poll when a
+	// separate row actually exists and is still in flight, so a plain
 	// single-run failure fails immediately instead of paying the full poll
 	// timeout on every epic error.
-	status, err := r.logStore.GetExecutionStatusByTaskID(taskID, projectPath)
+	status, err := r.logStore.GetExecutionStatusByTaskIDExcluding(taskID, projectPath, selfExecID)
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			r.log.Warn("reconcileChildOutcome: execution status lookup failed",
@@ -1674,7 +1679,7 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath 
 		return result, execErr
 	}
 	if !childExecutionNonTerminalStatuses[status] {
-		return r.resolveChildTerminalOutcome(taskID, status, result, execErr)
+		return r.resolveChildTerminalOutcome(taskID, selfExecID, status, result, execErr)
 	}
 
 	pollInterval := r.childOutcomeReconcilePollInterval
@@ -1697,9 +1702,9 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath 
 		case <-ticker.C:
 		}
 
-		status, err := r.logStore.GetExecutionStatusByTaskID(taskID, projectPath)
+		status, err := r.logStore.GetExecutionStatusByTaskIDExcluding(taskID, projectPath, selfExecID)
 		if err == nil && !childExecutionNonTerminalStatuses[status] {
-			return r.resolveChildTerminalOutcome(taskID, status, result, execErr)
+			return r.resolveChildTerminalOutcome(taskID, selfExecID, status, result, execErr)
 		}
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			r.log.Warn("reconcileChildOutcome: execution status lookup failed",
@@ -1720,8 +1725,8 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath 
 // continue) applies unchanged; any other terminal status is a genuine
 // failure, reported with the tracked row's real Error message when the
 // original signal lacked one.
-func (r *Runner) resolveChildTerminalOutcome(taskID, status string, result *ExecutionResult, execErr error) (*ExecutionResult, error) {
-	row, rowErr := r.logStore.GetLatestExecutionByTaskID(taskID)
+func (r *Runner) resolveChildTerminalOutcome(taskID, selfExecID, status string, result *ExecutionResult, execErr error) (*ExecutionResult, error) {
+	row, rowErr := r.logStore.GetLatestExecutionByTaskIDExcluding(taskID, selfExecID)
 	if rowErr != nil {
 		row = nil
 	}
@@ -1792,6 +1797,51 @@ func formatDecomposedChildrenSummary(issues []CreatedIssue) string {
 		}
 	}
 	return fmt.Sprintf("decomposed into %d children: %s", len(issues), strings.Join(refs, ", "))
+}
+
+// finalizeSubIssueExecution marks a sub-issue's ledger row (created just
+// before backend invocation, GH-4141) terminal and persists its token/cost
+// metrics, mirroring the dispatcher's ProjectWorker.processQueue finalization
+// (MarkExecutionCompleted for success, UpdateExecutionStatus otherwise) so a
+// sub-issue's row is indistinguishable from a direct-dispatch row to
+// GetDailyMetrics and HasCompletedExecution. WARN-and-continue on store
+// failures (mem-026) — a ledger write must never abort a sub-issue run.
+func (r *Runner) finalizeSubIssueExecution(execID, status string, result *ExecutionResult, startedAt time.Time) {
+	if r.logStore == nil || execID == "" {
+		return
+	}
+	durationMs := time.Since(startedAt).Milliseconds()
+	var errMsg, prURL, commitSHA string
+	if result != nil {
+		errMsg, prURL, commitSHA = result.Error, result.PRUrl, result.CommitSHA
+	}
+
+	if status == "completed" {
+		if err := r.logStore.MarkExecutionCompleted(execID, prURL, commitSHA, durationMs); err != nil {
+			r.log.Warn("Failed to mark sub-issue execution completed", "execution_id", execID, "error", err)
+		}
+	} else if err := r.logStore.UpdateExecutionStatus(execID, status, errMsg); err != nil {
+		r.log.Warn("Failed to update sub-issue execution status", "execution_id", execID, "status", status, "error", err)
+	}
+
+	if result == nil {
+		return
+	}
+	if err := r.logStore.SaveExecutionMetrics(&memory.ExecutionMetrics{
+		ExecutionID:      execID,
+		TokensInput:      result.TokensInput,
+		TokensOutput:     result.TokensOutput,
+		TokensTotal:      result.TokensTotal,
+		TokensCacheRead:  result.CacheReadInputTokens,
+		TokensCacheWrite: result.CacheCreationInputTokens,
+		EstimatedCostUSD: result.EstimatedCostUSD,
+		FilesChanged:     result.FilesChanged,
+		LinesAdded:       result.LinesAdded,
+		LinesRemoved:     result.LinesRemoved,
+		ModelName:        result.ModelName,
+	}); err != nil {
+		r.log.Warn("Failed to save sub-issue execution metrics", "execution_id", execID, "error", err)
+	}
 }
 
 // executeSubIssuesTracked is ExecuteSubIssues plus each child's terminal state
@@ -1921,6 +1971,40 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			CreatePR:    true,
 		}
 
+		// GH-4141: give this in-process sub-issue run its own executions ledger
+		// row before invoking the backend. Without one, Task.LogExecutionID()
+		// falls back to subTask.ID ("GH-N"), which has no matching executions
+		// row — every execution_events write for the sub-issue then trips a
+		// FOREIGN KEY constraint failed (787). The row also lets
+		// IsTaskQueued("GH-N") see the sub-issue as owned (poller retry-
+		// duplicate guard, TASK-394) and gives daily success metrics a
+		// completed row to count instead of starving on double-intake no_ops.
+		// project_path is the parent's absolute path (project memory pitfall:
+		// scoped dashboard queries filter on this being absolute, not a
+		// worktree path).
+		subExecStart := time.Now()
+		subExecID := uuid.New().String()
+		if r.logStore != nil {
+			if err := r.logStore.SaveExecution(&memory.Execution{
+				ID:          subExecID,
+				TaskID:      taskID,
+				ProjectPath: parent.ProjectPath,
+				Status:      "running",
+			}); err != nil {
+				// mem-026: epic path errors are warn-only — a ledger write must
+				// never abort a sub-issue run. The UUID is threaded through
+				// below regardless, so downstream event recording always has a
+				// real UUID rather than falling back to the task ID.
+				r.log.Warn("Failed to insert sub-issue execution row",
+					"parent_id", parent.ID,
+					"sub_issue", issueRef,
+					"execution_id", subExecID,
+					"error", err,
+				)
+			}
+		}
+		subTask.ExecutionID = subExecID
+
 		r.log.Info("Executing sub-issue",
 			"parent_id", parent.ID,
 			"sub_issue", issueRef,
@@ -1946,12 +2030,13 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 		// is actually done — it can race a separately-tracked run of the same
 		// sub-issue. Re-check the child's own execution row before trusting
 		// this signal as terminal.
-		result, err = r.reconcileChildOutcome(ctx, taskID, subTaskRepoPath, result, err)
+		result, err = r.reconcileChildOutcome(ctx, taskID, subTaskRepoPath, subExecID, result, err)
 
 		if err != nil {
 			failMsg := fmt.Sprintf("❌ Failed on %d/%d: %s - Error: %v",
 				i+1, total, issue.Subtask.Title, err)
 			_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
+			r.finalizeSubIssueExecution(subExecID, "failed", result, subExecStart)
 			return childStates, metrics, fmt.Errorf("sub-issue %s failed: %w", issueRef, err)
 		}
 
@@ -1981,11 +2066,13 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 					"sub_issue", issueRef,
 					"error", result.Error,
 				)
+				r.finalizeSubIssueExecution(subExecID, "no_op", result, subExecStart)
 				continue
 			}
 			failMsg := fmt.Sprintf("❌ Failed on %d/%d: %s - %s",
 				i+1, total, issue.Subtask.Title, result.Error)
 			_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
+			r.finalizeSubIssueExecution(subExecID, "failed", result, subExecStart)
 			return childStates, metrics, fmt.Errorf("sub-issue %s failed: %s", issueRef, result.Error)
 		}
 
@@ -2026,8 +2113,11 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 				"branch", subTask.Branch,
 				"recovery_ref", recoveryRef,
 			)
+			r.finalizeSubIssueExecution(subExecID, "failed", result, subExecStart)
 			return childStates, metrics, fmt.Errorf("sub-issue %s committed work (sha %s) but produced no PR — work would be lost, halting epic — recovery: %s", issueRef, shortSHA, recovery)
 		}
+
+		r.finalizeSubIssueExecution(subExecID, "completed", result, subExecStart)
 
 		// Register sub-issue PR with autopilot controller (GH-596)
 		// Note: PR callback uses int issueNumber for GitHub compatibility

--- a/internal/executor/epic_ledger_test.go
+++ b/internal/executor/epic_ledger_test.go
@@ -1,0 +1,83 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestExecuteSubIssues_LedgerRowPerChild is the GH-4141 regression test: each
+// in-process sub-issue run must get its own executions row (running →
+// completed), threaded through as the sub-task's ExecutionID, instead of
+// falling back to the human-readable task ID as the execution_events join
+// key. Before this fix, every execution_events write for a sub-issue tripped
+// a FOREIGN KEY constraint failed (787) warning because no executions row
+// existed with id = "GH-N".
+func TestExecuteSubIssues_LedgerRowPerChild(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	issues := makeSubIssues(2, 4141)
+	parent := &Task{ID: "GH-4140", Title: "[epic] ledger row per child", ProjectPath: "/project-4141"}
+
+	execFn := func(_ context.Context, task *Task) (*ExecutionResult, error) {
+		if task.ExecutionID == "" {
+			t.Errorf("task %s: ExecutionID not set before backend invocation", task.ID)
+		}
+		// Mirrors every real recordExecutionEvent call site inside
+		// executeWithOptions: keyed on task.LogExecutionID(), which must now
+		// resolve to a real executions.id, not the "GH-N" task ID.
+		if err := store.InsertExecutionEvent(task.LogExecutionID(), memory.StageClaudeStarted, "test invocation"); err != nil {
+			t.Errorf("task %s: InsertExecutionEvent failed (FK error?): %v", task.ID, err)
+		}
+		return &ExecutionResult{
+			TaskID:    task.ID,
+			Success:   true,
+			CommitSHA: "deadbeef" + task.ID,
+			PRUrl:     "https://github.com/owner/repo/pull/" + task.ID,
+		}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+
+	childStates, _, err := runner.executeSubIssuesTracked(context.Background(), parent, issues, parent.ProjectPath, "")
+	if err != nil {
+		t.Fatalf("executeSubIssuesTracked returned error: %v", err)
+	}
+	if len(childStates) != 2 {
+		t.Fatalf("expected 2 child states, got %d: %v", len(childStates), childStates)
+	}
+	for _, state := range childStates {
+		if state != "completed" {
+			t.Errorf("expected all children completed, got %q", state)
+		}
+	}
+
+	for _, issue := range issues {
+		taskID := fmt.Sprintf("GH-%d", issue.Number)
+		row, err := store.GetLatestExecutionByTaskID(taskID)
+		if err != nil {
+			t.Fatalf("GetLatestExecutionByTaskID(%s): %v", taskID, err)
+		}
+		if row.Status != "completed" {
+			t.Errorf("%s: status = %q, want completed", taskID, row.Status)
+		}
+		if row.ProjectPath != parent.ProjectPath {
+			t.Errorf("%s: project_path = %q, want parent's absolute path %q", taskID, row.ProjectPath, parent.ProjectPath)
+		}
+		if row.PRUrl == "" {
+			t.Errorf("%s: pr_url not recorded", taskID)
+		}
+
+		events, err := store.ListExecutionEvents(row.ID)
+		if err != nil {
+			t.Fatalf("ListExecutionEvents(%s): %v", row.ID, err)
+		}
+		if len(events) == 0 {
+			t.Errorf("%s: expected execution_events recorded against the ledger row UUID %s, got none", taskID, row.ID)
+		}
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -670,6 +670,23 @@ func (s *Store) GetLatestExecutionByTaskID(taskID string) (*Execution, error) {
 	return scanExecutionDetail(row)
 }
 
+// GetLatestExecutionByTaskIDExcluding mirrors GetLatestExecutionByTaskID but
+// ignores the row identified by excludeID. GH-4141: an epic sub-issue now
+// carries its own "running" executions row for the full run duration
+// (internal/executor/epic.go finalizeSubIssueExecution), so a caller
+// reconciling against a genuinely separate, concurrently-tracked row for the
+// same task (GH-3786) must look past its own row to find it.
+func (s *Store) GetLatestExecutionByTaskIDExcluding(taskID, excludeID string) (*Execution, error) {
+	row := s.db.QueryRow(`
+		SELECT `+executionDetailColumns+`
+		FROM executions
+		WHERE (task_id = ? OR task_id LIKE ?) AND id != ?
+		ORDER BY (task_id = ?) DESC, created_at DESC, rowid DESC
+		LIMIT 1
+	`, taskID, "%"+taskID+"%", excludeID, taskID)
+	return scanExecutionDetail(row)
+}
+
 // ListExecutionsForTask returns every execution recorded for taskID (exact match),
 // newest first. Unlike GetLatestExecutionByTaskID (single row, exact-or-substring
 // match), this returns the full history so the CLI can render a per-execution
@@ -1453,6 +1470,20 @@ func (s *Store) GetExecutionStatusByTaskID(taskID, projectPath string) (string, 
 		ORDER BY created_at DESC, rowid DESC
 		LIMIT 1
 	`, taskID, projectPath, projectPath).Scan(&status)
+	return status, err
+}
+
+// GetExecutionStatusByTaskIDExcluding mirrors GetExecutionStatusByTaskID but
+// ignores the row identified by excludeID (GH-4141, see
+// GetLatestExecutionByTaskIDExcluding).
+func (s *Store) GetExecutionStatusByTaskIDExcluding(taskID, projectPath, excludeID string) (string, error) {
+	var status string
+	err := s.db.QueryRow(`
+		SELECT status FROM executions
+		WHERE task_id = ? AND (? = '' OR project_path = ?) AND id != ?
+		ORDER BY created_at DESC, rowid DESC
+		LIMIT 1
+	`, taskID, projectPath, projectPath, excludeID).Scan(&status)
 	return status, err
 }
 


### PR DESCRIPTION
## Summary

GH-4141: Epic sub-issues run in-process without an `executions` row, so:
- Every `execution_events` write for a sub-issue fell back to `task.ID` ("GH-N") as the join key and tripped `FOREIGN KEY constraint failed (787)` warnings.
- `IsTaskQueued("GH-N")` couldn't see the sub-issue as owned, letting the poller retry-duplicate a still-running epic child (TASK-394).
- Shipped sub-issue work was never recorded `completed`, starving daily success metrics.

**Phase 1 (ledger row):**
- `internal/executor/epic.go`: insert a `running` executions row (UUID id, `task_id=GH-N`, parent's absolute `project_path`) before invoking each sub-issue's backend; thread the UUID through as `subTask.ExecutionID` so every `task.LogExecutionID()`-keyed event write (runner.go) resolves correctly. WARN-and-continue on insert failure (mem-026). Finalize via `MarkExecutionCompleted`/`UpdateExecutionStatus` with tokens/cost/pr_url/commit_sha at each terminal branch (`completed`/`failed`/`no_op`).
- `reconcileChildOutcome`/`resolveChildTerminalOutcome` now exclude the sub-issue's own ledger row (`GetExecutionStatusByTaskIDExcluding` / `GetLatestExecutionByTaskIDExcluding`, added to `internal/memory/store.go`) so the GH-3786 race-detection logic still finds a genuinely separate, concurrently-tracked execution instead of always observing its own `running` row.

**Phase 3 (merged-PR pre-flight short-circuit):**
- `internal/executor/dispatcher.go`: before invoking the backend for any queued task, check `FindMergedPRByBranch` on the task's branch. A hit marks the execution `completed` with the existing PR URL and skips the backend entirely — no more burning a full Claude invocation to rediscover "no new commit" as a `no_op` for poller-retry duplicates.

## Test plan

- [x] `TestProcessQueue_MergedPRPreflight_SkipsBackend` — queued task + merged PR → completed, zero backend calls
- [x] `TestProcessQueue_MergedPRPreflight_UnmergedBranchProceedsNormally` — queued task + open/no PR → unchanged behavior, backend still invoked
- [x] `TestExecuteSubIssues_LedgerRowPerChild` — each sub-issue gets its own `running`→`completed` row, `execution_events` write against the ledger UUID succeeds (no FK error)
- [x] `TestTaskCompletionInvariant` passes unchanged; `HasCompletedExecution` semantics untouched
- [x] Full suite (`go test ./...`), `go vet ./...`, `golangci-lint run --new-from-rev=origin/main ./...` all green