### PR TITLE
fix(autopilot): eliminate epic-reconcile shipped-check false positives

### DIFF
--- a/internal/autopilot/epic_reconcile.go
+++ b/internal/autopilot/epic_reconcile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/qf-studio/pilot/internal/alerts"
@@ -50,9 +51,25 @@ type subIssueState struct {
 // so repeated poll-cycle sightings of the same stalled child produce the same
 // log line — the dedupe path downstream can key off (parent, child, reason)
 // to recognize "still the same stall" instead of re-triggering on every tick.
+//
+// Defer marks a "soft" veto (GH-4127): the child has an open/in-CI PR, i.e.
+// it is genuinely in flight, not stalled. A deferred veto still blocks the
+// close this pass, but the caller must NOT feed it into the escalation
+// breaker (recordEpicCloseVeto) — otherwise a normal close→merge race trips
+// the same "permanently blocked" escalation this fix exists to prevent.
 type childCloseVeto struct {
 	Child  int
 	Reason string
+	Defer  bool
+}
+
+// branchPR is one pull request found for a given head branch via the
+// strongly-consistent pullRequests(headRefName:) GraphQL lookup (GH-4127) —
+// as opposed to the eventually-consistent Search API.
+type branchPR struct {
+	Number int
+	Merged bool
+	Open   bool
 }
 
 // getAllSubIssueNumbers queries native GitHub sub-issues for parentNum and
@@ -110,6 +127,12 @@ func (c *Controller) getAllSubIssueNumbers(ctx context.Context, parentNum int) (
 
 	children := make([]subIssueState, 0, len(result.Node.SubIssues.Nodes))
 	for _, n := range result.Node.SubIssues.Nodes {
+		if n.Number == parentNum {
+			// GH-4127: native links should never point a parent at itself, but
+			// don't trust that invariant blindly — filter it the same way the
+			// text-search fallback must.
+			continue
+		}
 		children = append(children, subIssueState{Number: n.Number, Closed: n.State == "CLOSED"})
 	}
 	return children, true, nil
@@ -147,15 +170,65 @@ func (c *Controller) getSubIssuesByTextSearch(ctx context.Context, parentNum int
 		return nil, false, fmt.Errorf("text-search sub-issues for %s/%s#%d: %w", c.owner, c.repo, parentNum, err)
 	}
 
-	if len(result.Search.Nodes) == 0 {
-		return nil, false, nil
-	}
-
 	children := make([]subIssueState, 0, len(result.Search.Nodes))
 	for _, n := range result.Search.Nodes {
+		if n.Number == parentNum {
+			// GH-4127: the parent's own body/comments (e.g. an escalation
+			// comment naming "GH-{parentNum}") match this text search — without
+			// this filter the parent becomes its own child, and each
+			// escalation comment re-strengthens the false match.
+			continue
+		}
 		children = append(children, subIssueState{Number: n.Number, Closed: n.State == "CLOSED"})
 	}
+	if len(children) == 0 {
+		return nil, false, nil
+	}
 	return children, true, nil
+}
+
+// findPRsByBranch looks up every PR opened from headBranch via GitHub's
+// strongly-consistent pullRequests(headRefName:) GraphQL filter (GH-4127) —
+// unlike the Search API (SearchPRsForIssue), this reflects a just-merged PR
+// immediately, with no minutes-long indexing lag, and survives the head
+// branch being deleted after merge (the filter matches on the PR's recorded
+// head ref name, not a live ref).
+func (c *Controller) findPRsByBranch(ctx context.Context, headBranch string) ([]branchPR, error) {
+	const query = `query($owner: String!, $repo: String!, $branch: String!) {
+		repository(owner: $owner, name: $repo) {
+			pullRequests(headRefName: $branch, first: 10) {
+				nodes {
+					number
+					state
+					merged
+				}
+			}
+		}
+	}`
+
+	var result struct {
+		Repository struct {
+			PullRequests struct {
+				Nodes []struct {
+					Number int    `json:"number"`
+					State  string `json:"state"`
+					Merged bool   `json:"merged"`
+				} `json:"nodes"`
+			} `json:"pullRequests"`
+		} `json:"repository"`
+	}
+
+	if err := c.ghClient.ExecuteGraphQL(ctx, query, map[string]interface{}{
+		"owner": c.owner, "repo": c.repo, "branch": headBranch,
+	}, &result); err != nil {
+		return nil, fmt.Errorf("find PRs by branch %s: %w", headBranch, err)
+	}
+
+	prs := make([]branchPR, 0, len(result.Repository.PullRequests.Nodes))
+	for _, n := range result.Repository.PullRequests.Nodes {
+		prs = append(prs, branchPR{Number: n.Number, Merged: n.Merged, Open: n.State == "OPEN"})
+	}
+	return prs, nil
 }
 
 // verifyChildrenShippedForClose re-checks every CLOSED child in children has
@@ -164,9 +237,17 @@ func (c *Controller) getSubIssuesByTextSearch(ctx context.Context, parentNum int
 // A closed child with neither is a real guard veto — closing the parent would
 // silently drop that slice's work.
 //
+// GH-4127: evidence is gathered primarily via findPRsByBranch's direct,
+// strongly-consistent lookup on the conventional `pilot/GH-N` branch name;
+// SearchPRsForIssue (the eventually-consistent Search API) is only a
+// secondary source, consulted when the branch lookup finds no merged PR. A
+// child whose PR exists but hasn't merged yet (open / in CI) is genuinely
+// in-flight — it defers (Defer: true) rather than vetoing, so a normal
+// close→merge race never reaches the escalation breaker.
+//
 // Returns every merged PR number found (for the closing summary comment) and a
 // non-nil veto on the FIRST closed child that fails verification. Fails open
-// (skips, does not veto) on a PR-search error for an individual child, since a
+// (skips, does not veto) on a lookup error for an individual child, since a
 // transient API failure must not indefinitely block a legitimate close.
 func (c *Controller) verifyChildrenShippedForClose(ctx context.Context, parentNum int, children []subIssueState) (mergedPRs []int, veto *childCloseVeto) {
 	for _, child := range children {
@@ -177,23 +258,52 @@ func (c *Controller) verifyChildrenShippedForClose(ctx context.Context, parentNu
 			continue
 		}
 
-		prs, err := c.ghClient.SearchPRsForIssue(ctx, c.owner, c.repo, child.Number)
-		if err != nil {
-			c.log.Warn("verifyChildrenShippedForClose: PR search failed, fail-open on this child",
-				slog.Int("parent", parentNum), slog.Int("child", child.Number), slog.Any("error", err))
-			continue
-		}
-
 		merged := false
-		for _, pr := range prs {
+		openOrInCI := false
+
+		branch := fmt.Sprintf("pilot/GH-%d", child.Number)
+		branchPRs, err := c.findPRsByBranch(ctx, branch)
+		if err != nil {
+			c.log.Warn("verifyChildrenShippedForClose: branch lookup failed, falling back to search",
+				slog.Int("parent", parentNum), slog.Int("child", child.Number), slog.Any("error", err))
+			branchPRs = nil
+		}
+		for _, pr := range branchPRs {
 			if pr.Merged {
 				mergedPRs = append(mergedPRs, pr.Number)
 				merged = true
+			} else if pr.Open {
+				openOrInCI = true
 			}
 		}
+
 		if !merged {
-			return mergedPRs, &childCloseVeto{Child: child.Number, Reason: "issue is closed but has no merged PR"}
+			// Secondary source only — catches a PR the branch-name filter
+			// missed (e.g. a non-conventional branch name), never the primary
+			// evidence, since it's eventually consistent (defects 2/5).
+			prs, err := c.ghClient.SearchPRsForIssue(ctx, c.owner, c.repo, child.Number)
+			if err != nil {
+				c.log.Warn("verifyChildrenShippedForClose: PR search failed, fail-open on this child",
+					slog.Int("parent", parentNum), slog.Int("child", child.Number), slog.Any("error", err))
+				continue
+			}
+			for _, pr := range prs {
+				if pr.Merged {
+					mergedPRs = append(mergedPRs, pr.Number)
+					merged = true
+				} else if pr.State == "open" {
+					openOrInCI = true
+				}
+			}
 		}
+
+		if merged {
+			continue
+		}
+		if openOrInCI {
+			return mergedPRs, &childCloseVeto{Child: child.Number, Reason: "PR open or in CI, not yet merged", Defer: true}
+		}
+		return mergedPRs, &childCloseVeto{Child: child.Number, Reason: "issue is closed but has no merged PR"}
 	}
 	return mergedPRs, nil
 }
@@ -329,6 +439,27 @@ func (c *Controller) discoverBodyMarkerEpicParents(ctx context.Context) ([]int, 
 // parent. Split out from reconcileEpicParents so tests can drive one parent
 // directly, mirroring how maybeCloseParentIssue/recoverStaleParentIssues are tested.
 func (c *Controller) reconcileEpicParent(ctx context.Context, parentNum int) {
+	// GH-4127: a closed parent must never re-enter the veto/escalation path —
+	// discoverBodyMarkerEpicParents' candidates aren't filtered on parent
+	// state, so a parent that closed (via this sweep, maybeCloseParentIssue,
+	// or a human) keeps surfacing as a candidate on later ticks. Bail before
+	// any child-set or PR lookup, and clean up a stale needs-clarification
+	// label left by an earlier escalation whose veto is now moot.
+	issue, err := c.ghClient.GetIssue(ctx, c.owner, c.repo, parentNum)
+	if err != nil {
+		c.log.Warn("reconcileEpicParents: failed to check parent state", slog.Int("parent", parentNum), slog.Any("error", err))
+		return
+	}
+	if strings.EqualFold(issue.State, "closed") {
+		c.log.Debug("reconcileEpicParents: parent already closed, skipping veto/escalation", slog.Int("parent", parentNum))
+		c.clearEpicCloseVeto(ctx, parentNum)
+		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, parentNum, github.LabelNeedsClarification); err != nil {
+			c.log.Warn("reconcileEpicParents: failed to remove stale needs-clarification label",
+				slog.Int("parent", parentNum), slog.Any("error", err))
+		}
+		return
+	}
+
 	children, hasLinks, err := c.getAllSubIssueNumbers(ctx, parentNum)
 	if err != nil {
 		c.log.Warn("reconcileEpicParents: failed to list children", slog.Int("parent", parentNum), slog.Any("error", err))
@@ -361,12 +492,22 @@ func (c *Controller) reconcileEpicParent(ctx context.Context, parentNum int) {
 		c.log.Debug("reconcileEpicParents: siblings still open", slog.Int("parent", parentNum), slog.Int("open", openBlocking))
 		// The epic re-entered a "still building" phase (a new/reopened sibling) —
 		// forget any prior close-veto streak so it doesn't carry over (GH-4006).
-		c.clearEpicCloseVeto(parentNum)
+		c.clearEpicCloseVeto(ctx, parentNum)
 		return
 	}
 
 	mergedPRs, veto := c.verifyChildrenShippedForClose(ctx, parentNum, children)
 	if veto != nil {
+		if veto.Defer {
+			// GH-4127: child PR exists but hasn't merged yet (open / in CI) —
+			// in flight, not stalled. Defer quietly and reset any prior streak,
+			// exactly like the openBlocking>0 case, so a normal close→merge
+			// race never counts toward the escalation breaker.
+			c.log.Debug("reconcileEpicParents: child PR not yet merged, deferring close",
+				slog.Int("parent", parentNum), slog.Int("child", veto.Child))
+			c.clearEpicCloseVeto(ctx, parentNum)
+			return
+		}
 		c.log.Warn("reconcileEpicParents: close vetoed",
 			slog.Int("parent", parentNum), slog.Int("child", veto.Child), slog.String("veto_reason", veto.Reason))
 		if c.recordEpicCloseVeto(parentNum, veto) {
@@ -374,7 +515,7 @@ func (c *Controller) reconcileEpicParent(ctx context.Context, parentNum int) {
 		}
 		return
 	}
-	c.clearEpicCloseVeto(parentNum)
+	c.clearEpicCloseVeto(ctx, parentNum)
 
 	closed, title := c.closeParentNow(ctx, parentNum, mergedPRs)
 	// GH-3990: an epic just completed — enqueue its scope release. Gated on
@@ -531,10 +672,24 @@ func (c *Controller) recordEpicCloseVeto(parentNum int, veto *childCloseVeto) bo
 // once its children verify shipped or it re-enters a "still building" phase —
 // so a resolved stall doesn't leave a stale escalated flag behind that would
 // suppress a genuinely new veto on this parent later.
-func (c *Controller) clearEpicCloseVeto(parentNum int) {
+//
+// GH-4127: if the cleared streak had already escalated (i.e. this reconciler
+// added LabelNeedsClarification), also remove that label — otherwise a
+// refuted veto leaves a dispatch-blocking label on the parent forever, since
+// escalateEpicCloseVeto's own AddLabels call has no corresponding removal on
+// the "veto resolved" path.
+func (c *Controller) clearEpicCloseVeto(ctx context.Context, parentNum int) {
 	c.mu.Lock()
+	st, ok := c.epicVeto[parentNum]
 	delete(c.epicVeto, parentNum)
 	c.mu.Unlock()
+
+	if ok && st.escalated {
+		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, parentNum, github.LabelNeedsClarification); err != nil {
+			c.log.Warn("clearEpicCloseVeto: failed to remove needs-clarification label",
+				slog.Int("parent", parentNum), slog.Any("error", err))
+		}
+	}
 }
 
 // escalateEpicCloseVeto breaks the parent re-dispatch loop once its close-veto

--- a/internal/autopilot/epic_reconcile_test.go
+++ b/internal/autopilot/epic_reconcile_test.go
@@ -725,3 +725,526 @@ func TestEpicCloseVetoBreaker(t *testing.T) {
 		}
 	})
 }
+
+// decodeGraphQL pulls the query string and variables out of a GraphQL POST
+// body, for tests that need to route mock responses by query shape.
+func decodeGraphQL(r *http.Request) (query string, vars map[string]interface{}) {
+	var body struct {
+		Query     string                 `json:"query"`
+		Variables map[string]interface{} `json:"variables"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	return body.Query, body.Variables
+}
+
+// TestGetAllSubIssueNumbers_ExcludesParent covers GH-4127 defect 1 for the
+// native sub-issue-link path: even if the native link query somehow returned
+// the parent's own number (it shouldn't, but the incident showed the text-
+// search fallback can), the parent must never appear in its own child set.
+func TestGetAllSubIssueNumbers_ExcludesParent(t *testing.T) {
+	const parentNum = 4127
+	const childNum = 4128
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"node_id":"I_parent","number":%d,"state":"open"}`, parentNum)
+
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"node": map[string]interface{}{
+						"subIssues": map[string]interface{}{
+							"totalCount": 2,
+							"nodes": []map[string]interface{}{
+								{"number": parentNum, "state": "CLOSED"},
+								{"number": childNum, "state": "CLOSED"},
+							},
+						},
+					},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	children, hasLinks, err := c.getAllSubIssueNumbers(context.Background(), parentNum)
+	if err != nil {
+		t.Fatalf("getAllSubIssueNumbers failed: %v", err)
+	}
+	if !hasLinks {
+		t.Fatal("expected hasLinks=true (one genuine child remains after filtering)")
+	}
+	if len(children) != 1 || children[0].Number != childNum {
+		t.Errorf("children = %v, want exactly [%d] (parent's own number filtered out)", children, childNum)
+	}
+}
+
+// TestGetSubIssuesByTextSearch_ExcludesParent covers GH-4127 defect 1 at its
+// root: the parent's own body/comments (an escalation comment literally
+// contains "GH-{parentNum}") match the "Parent: GH-N" text search, and
+// without filtering, the parent becomes its own child — self-amplifying,
+// since each escalation comment re-strengthens the match.
+func TestGetSubIssuesByTextSearch_ExcludesParent(t *testing.T) {
+	const parentNum = 4127
+	const childNum = 4128
+
+	t.Run("parent mixed with a genuine child - parent filtered, child kept", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost && r.URL.Path == "/graphql" {
+				resp := map[string]interface{}{
+					"data": map[string]interface{}{
+						"search": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{"number": parentNum, "state": "CLOSED"},
+								{"number": childNum, "state": "CLOSED"},
+							},
+						},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		cfg := DefaultConfig()
+		c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+		children, hasLinks, err := c.getSubIssuesByTextSearch(context.Background(), parentNum)
+		if err != nil {
+			t.Fatalf("getSubIssuesByTextSearch failed: %v", err)
+		}
+		if !hasLinks || len(children) != 1 || children[0].Number != childNum {
+			t.Errorf("children = %v, hasLinks = %v, want exactly [%d] with hasLinks=true", children, hasLinks, childNum)
+		}
+	})
+
+	t.Run("only the parent's own escalation comment matches - no genuine children found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost && r.URL.Path == "/graphql" {
+				resp := map[string]interface{}{
+					"data": map[string]interface{}{
+						"search": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{"number": parentNum, "state": "CLOSED"},
+							},
+						},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+		cfg := DefaultConfig()
+		c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+		children, hasLinks, err := c.getSubIssuesByTextSearch(context.Background(), parentNum)
+		if err != nil {
+			t.Fatalf("getSubIssuesByTextSearch failed: %v", err)
+		}
+		if hasLinks || len(children) != 0 {
+			t.Errorf("children = %v, hasLinks = %v, want ([], false) — a self-reference is not a genuine child", children, hasLinks)
+		}
+	})
+}
+
+// TestVerifyChildrenShippedForClose_BranchLookup covers GH-4127 defects 2/3:
+// the direct, strongly-consistent branch lookup (not the eventually-
+// consistent Search API) is the decisive evidence source, and a PR that
+// exists but hasn't merged yet (open / in CI) defers rather than hard-vetoing.
+func TestVerifyChildrenShippedForClose_BranchLookup(t *testing.T) {
+	const parentNum = 4127
+	const childNum = 4128
+
+	tests := []struct {
+		name          string
+		branchState   string // "" (no PR), "MERGED", "OPEN"
+		wantVeto      bool
+		wantDefer     bool
+		wantMergedPRs []int
+	}{
+		{
+			name:          "merged via branch lookup, search lags behind - no veto",
+			branchState:   "MERGED",
+			wantMergedPRs: []int{9001},
+		},
+		{
+			name:        "PR open/in CI via branch lookup - defers instead of hard veto",
+			branchState: "OPEN",
+			wantVeto:    true,
+			wantDefer:   true,
+		},
+		{
+			name:        "no PR anywhere - hard veto",
+			branchState: "",
+			wantVeto:    true,
+			wantDefer:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+					nodes := []map[string]interface{}{}
+					if tt.branchState != "" {
+						nodes = append(nodes, map[string]interface{}{
+							"number": 9001,
+							"state":  tt.branchState,
+							"merged": tt.branchState == "MERGED",
+						})
+					}
+					resp := map[string]interface{}{
+						"data": map[string]interface{}{
+							"repository": map[string]interface{}{
+								"pullRequests": map[string]interface{}{"nodes": nodes},
+							},
+						},
+					}
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(resp)
+
+				case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+					// Search API always empty — proves the branch lookup, not
+					// search, decides the outcome.
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": []interface{}{}})
+
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+			children := []subIssueState{{Number: childNum, Closed: true}}
+			mergedPRs, veto := c.verifyChildrenShippedForClose(context.Background(), parentNum, children)
+
+			if tt.wantVeto != (veto != nil) {
+				t.Fatalf("veto = %v, wantVeto = %v", veto, tt.wantVeto)
+			}
+			if veto != nil && veto.Defer != tt.wantDefer {
+				t.Errorf("veto.Defer = %v, want %v", veto.Defer, tt.wantDefer)
+			}
+			if len(mergedPRs) != len(tt.wantMergedPRs) {
+				t.Fatalf("mergedPRs = %v, want %v", mergedPRs, tt.wantMergedPRs)
+			}
+			for i, want := range tt.wantMergedPRs {
+				if mergedPRs[i] != want {
+					t.Errorf("mergedPRs = %v, want %v", mergedPRs, tt.wantMergedPRs)
+				}
+			}
+		})
+	}
+}
+
+// TestReconcileEpicParent_ClosedParentRemovesStaleLabel covers GH-4127
+// defects 3/4: a candidate parent that is already closed must short-circuit
+// before any child-set discovery, PR lookup, or escalation — and if it
+// carries a stale pilot-needs-clarification label from an earlier escalation
+// whose veto is now moot, that label is removed.
+func TestReconcileEpicParent_ClosedParentRemovesStaleLabel(t *testing.T) {
+	const parentNum = 4127
+
+	var (
+		deletedLabelPaths []string
+		commentPosted     bool
+		closeCalled       bool
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"node_id":"I_parent","number":%d,"state":"closed"}`, parentNum)
+
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, fmt.Sprintf("/repos/owner/repo/issues/%d/labels/", parentNum)):
+			deletedLabelPaths = append(deletedLabelPaths, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d/comments", parentNum):
+			commentPosted = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":1}`))
+
+		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			closeCalled = true
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			// No child-set/PR-lookup call should ever reach this server for an
+			// already-closed parent; a plain 200 keeps unexpected calls visible
+			// only through the assertions below rather than crashing the test.
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	// Simulate a prior pass (this process or an earlier one) that escalated
+	// and added pilot-needs-clarification, whose veto is now moot because the
+	// parent closed out-of-band.
+	c.epicVeto[parentNum] = &epicCloseVetoTracking{child: 1, reason: "issue is closed but has no merged PR", count: 3, escalated: true}
+
+	c.reconcileEpicParent(context.Background(), parentNum)
+
+	if closeCalled {
+		t.Error("closeParentNow should never run for an already-closed parent")
+	}
+	if commentPosted {
+		t.Error("no comment should be posted for an already-closed parent")
+	}
+	found := false
+	for _, p := range deletedLabelPaths {
+		if strings.HasSuffix(p, "/labels/"+github.LabelNeedsClarification) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected the stale %s label to be removed, got DELETE calls: %v", github.LabelNeedsClarification, deletedLabelPaths)
+	}
+	if _, ok := c.epicVeto[parentNum]; ok {
+		t.Error("expected the in-memory veto streak to be cleared for the closed parent")
+	}
+}
+
+// TestReconcileEpicParent_RefutedVetoRemovesLabel covers GH-4127 defect 4 at
+// the openBlocking>0 refute path specifically (as opposed to the
+// closeParentNow path, which already had its own unconditional label
+// cleanup): once a parent's close-veto has escalated and added
+// pilot-needs-clarification, a later pass that finds the epic back in a
+// "still building" phase (clearEpicCloseVeto) must also remove that label.
+func TestReconcileEpicParent_RefutedVetoRemovesLabel(t *testing.T) {
+	const parentNum = 4127
+	const childNum = 4128
+
+	childClosed := true // stays closed-but-unshipped through the escalation, then reopens
+
+	var (
+		addLabelsCalls    []string
+		deletedLabelPaths []string
+		closeCalled       bool
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"node_id":"I_parent","number":%d,"state":"open"}`, parentNum)
+
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			state := "OPEN"
+			if childClosed {
+				state = "CLOSED"
+			}
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"node": map[string]interface{}{
+						"subIssues": map[string]interface{}{
+							"totalCount": 1,
+							"nodes":      []map[string]interface{}{{"number": childNum, "state": state}},
+						},
+					},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+			// The child never produces a merged PR under its own number in
+			// this test — the ghost-closed pattern from GH-4006.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": []interface{}{}})
+
+		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d/labels", parentNum):
+			var payload struct {
+				Labels []string `json:"labels"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			addLabelsCalls = append(addLabelsCalls, payload.Labels...)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, fmt.Sprintf("/repos/owner/repo/issues/%d/labels/", parentNum)):
+			deletedLabelPaths = append(deletedLabelPaths, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d/comments", parentNum):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":1}`))
+
+		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			closeCalled = true
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	for i := 0; i < epicCloseVetoBreakerThreshold; i++ {
+		c.reconcileEpicParent(context.Background(), parentNum)
+	}
+
+	foundAdd := false
+	for _, l := range addLabelsCalls {
+		if l == github.LabelNeedsClarification {
+			foundAdd = true
+		}
+	}
+	if !foundAdd {
+		t.Fatalf("expected escalation to add %s after %d vetoed passes, got: %v",
+			github.LabelNeedsClarification, epicCloseVetoBreakerThreshold, addLabelsCalls)
+	}
+
+	// The sibling reopens — the epic re-enters "still building". This refutes
+	// the recorded veto via the openBlocking>0 path, NOT via closeParentNow.
+	childClosed = false
+	c.reconcileEpicParent(context.Background(), parentNum)
+
+	if closeCalled {
+		t.Error("parent must not close while a child is open")
+	}
+	foundRemove := false
+	for _, p := range deletedLabelPaths {
+		if strings.HasSuffix(p, "/labels/"+github.LabelNeedsClarification) {
+			foundRemove = true
+		}
+	}
+	if !foundRemove {
+		t.Errorf("expected the escalation's %s label to be removed once the veto was refuted, got DELETE calls: %v",
+			github.LabelNeedsClarification, deletedLabelPaths)
+	}
+}
+
+// TestReconcileEpicParent_SummaryListsAllMergedPRs covers GH-4127 defect 5:
+// the close-summary comment must enumerate every child's merged PR, sourced
+// from the strongly-consistent branch lookup rather than the Search API
+// (which, on the real GH-4127, only had 2 of 4 indexed at close time).
+func TestReconcileEpicParent_SummaryListsAllMergedPRs(t *testing.T) {
+	const parentNum = 4127
+	children := []int{4128, 4129, 4130, 4131}
+	prForChild := map[int]int{4128: 9001, 4129: 9002, 4130: 9003, 4131: 9004}
+
+	var commentBody string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"node_id":"I_parent","number":%d,"state":"open"}`, parentNum)
+
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			query, vars := decodeGraphQL(r)
+			switch {
+			case strings.Contains(query, "subIssues(first"):
+				nodes := make([]map[string]interface{}, len(children))
+				for i, ch := range children {
+					nodes[i] = map[string]interface{}{"number": ch, "state": "CLOSED"}
+				}
+				resp := map[string]interface{}{
+					"data": map[string]interface{}{
+						"node": map[string]interface{}{
+							"subIssues": map[string]interface{}{"totalCount": len(children), "nodes": nodes},
+						},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+
+			case strings.Contains(query, "pullRequests(headRefName"):
+				branch, _ := vars["branch"].(string)
+				nodes := []map[string]interface{}{}
+				for _, ch := range children {
+					if branch == fmt.Sprintf("pilot/GH-%d", ch) {
+						nodes = append(nodes, map[string]interface{}{"number": prForChild[ch], "state": "MERGED", "merged": true})
+					}
+				}
+				resp := map[string]interface{}{
+					"data": map[string]interface{}{
+						"repository": map[string]interface{}{
+							"pullRequests": map[string]interface{}{"nodes": nodes},
+						},
+					},
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+
+		case r.Method == http.MethodGet && r.URL.Path == "/search/issues":
+			// Search never catches up within this pass — proves the summary
+			// still lists every child (GH-4127 defect 5: was 2 of 4 via search alone).
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"items": []interface{}{}})
+
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/labels/"):
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d/comments", parentNum):
+			var payload struct {
+				Body string `json:"body"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			commentBody = payload.Body
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":1}`))
+
+		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	c.reconcileEpicParent(context.Background(), parentNum)
+
+	for _, ch := range children {
+		want := fmt.Sprintf("#%d", prForChild[ch])
+		if !strings.Contains(commentBody, want) {
+			t.Errorf("close summary missing merged PR %s for child #%d, got: %q", want, ch, commentBody)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes five defects observed live on epic GH-4127 (children #4128–#4131, all
shipped same day via merged PRs #4133/#4136/#4137/#4138), where the
epic-parent reconcile sweep posted "⚠️ Epic auto-close is permanently
blocked" three times on a genuinely-shipped epic and left a permanent
`pilot-needs-clarification` label on the closed parent.

- **Self-referencing child set**: `getSubIssuesByTextSearch` and
  `getAllSubIssueNumbers` now filter the parent's own issue number out of
  the returned child set. An escalation comment naming the parent (e.g.
  "GH-4127") was matching the parent's own text search, making the parent
  its own child — self-amplifying with each escalation comment.
- **Search-lag false vetoes**: `verifyChildrenShippedForClose` now checks a
  strongly-consistent `pullRequests(headRefName:)` GraphQL lookup on the
  conventional `pilot/GH-N` branch first; the eventually-consistent Search
  API is now a secondary fallback only. A child whose PR is open/in CI
  defers (no veto-streak increment) instead of hard-vetoing.
- **Closed-parent re-processing**: `reconcileEpicParent` now early-returns
  before any child-set discovery or PR lookup when the parent is already
  closed, and removes a stale `pilot-needs-clarification` label if present.
- **Stale label on refuted veto**: `clearEpicCloseVeto` now removes
  `pilot-needs-clarification` when it clears an escalated streak (the
  epic re-enters a "still building" phase, or the parent closes out of
  band), not just the in-memory tracking.
- **Incomplete PR list in close summary**: the summary comment now lists
  every child's merged PR sourced from the branch lookup, not just what
  the Search API had indexed at close time.

## Test plan

- [x] `make build && make test && make lint` all pass
- [x] `go test ./internal/autopilot/ -run "TestReconcileEpic|TestVerifyChildrenShipped|TestEscalateEpicCloseVeto" -v` — all green
- [x] New table-driven tests added covering: parent self-reference filtering
      (native + text-search paths), branch-lookup-vs-search precedence,
      open/in-CI PR deferral, closed-parent early return + stale-label
      cleanup, refuted-veto label removal via the `openBlocking>0` path, and
      close-summary completeness across 4 children
- [x] All pre-existing epic-reconcile tests still pass unmodified