### PR TITLE
fix(autopilot): resync HeadSHA from PostMergeSHA in handleReleasing for plain PRs

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -2612,18 +2612,25 @@ func (c *Controller) handleReleasing(ctx context.Context, prState *PRState) erro
 
 	rel := c.resolvedRelease()
 
-	// GH-3990: a scope-release carrier's HeadSHA is the post-merge-CI-validated
-	// main SHA captured on first entry to StagePostMergeCI, not the anchor
-	// member PR's own (unrelated) head commit. Set it explicitly before any of
-	// the logic below reads prState.HeadSHA.
+	// GH-4146: HeadSHA is the pre-merge branch head; once handlePostMergeCI
+	// (or the require_ci external-merge path) has validated the post-squash-
+	// merge main commit, PostMergeSHA is authoritative and must replace the
+	// stale branch head before any of the logic below (or the reachability
+	// guard) reads prState.HeadSHA. Guarded on non-empty because the
+	// SkipPostMergeCI fast path never sets PostMergeSHA, and there the
+	// branch-head HeadSHA is still the correct value to check. This used to
+	// be scope-carrier-only (GH-3990); a plain squash-merged PR's branch head
+	// is structurally never an ancestor of main, so without this the
+	// reachability guard always sees "diverged" and every release loops
+	// releasing -> failed forever.
 	isScope := prState.ScopeKey != ""
-	if isScope {
+	if prState.PostMergeSHA != "" {
 		prState.HeadSHA = prState.PostMergeSHA
-		if len(prState.ScopeMemberPRs) == 0 {
-			// Restart path: autopilot_pr_state persists ScopeKey but not the
-			// in-memory-only ScopeMemberPRs/ScopeTitle fields.
-			c.hydrateScopeMembers(prState)
-		}
+	}
+	if isScope && len(prState.ScopeMemberPRs) == 0 {
+		// Restart path: autopilot_pr_state persists ScopeKey but not the
+		// in-memory-only ScopeMemberPRs/ScopeTitle fields.
+		c.hydrateScopeMembers(prState)
 	}
 
 	// Resolve the actual repo owner/name from the PR URL.

--- a/internal/autopilot/controller_release_cycles_test.go
+++ b/internal/autopilot/controller_release_cycles_test.go
@@ -62,6 +62,12 @@ func releaseCyclesServer(t *testing.T, issues map[int]scopeMembershipFakeIssue, 
 		case strings.Contains(r.URL.Path, "/compare/"):
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ahead"})
+		case strings.HasSuffix(r.URL.Path, "/check-runs"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.CheckRunsResponse{
+				TotalCount: 1,
+				CheckRuns:  []github.CheckRun{{Name: "ci", Status: "completed", Conclusion: "success"}},
+			})
 		case strings.HasSuffix(r.URL.Path, "/git/refs"):
 			atomic.AddInt64(gitRefPosts, 1)
 			w.WriteHeader(http.StatusCreated)
@@ -461,9 +467,12 @@ func TestReleaseTrigger_OnMerge_BackwardCompatSnapshot(t *testing.T) {
 
 // externalMergeCIServer builds a fake GitHub server for the checkExternalMergeOrClose
 // require_ci tests below: GET the PR as merged, serve issue/label/comment bookkeeping
-// endpoints, and count check-runs polls against mainSHA (so tests can assert whether
-// CI was consulted before releasing).
-func externalMergeCIServer(t *testing.T, prNumber int, mergeSHA, mainSHA string, checkRunPolls *int64) *httptest.Server {
+// endpoints, count check-runs polls against mainSHA (so tests can assert whether CI
+// was consulted before releasing), and serve the tag/compare/git-refs endpoints
+// handleReleasing needs so tests can tick one step further and assert a tag is cut
+// against mergeSHA (GH-4146) instead of stopping at StageReleasing. gitRefPosts may
+// be nil for tests that never drive that far.
+func externalMergeCIServer(t *testing.T, prNumber int, mergeSHA, mainSHA string, checkRunPolls, gitRefPosts *int64) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -478,7 +487,7 @@ func externalMergeCIServer(t *testing.T, prNumber int, mergeSHA, mainSHA string,
 			})
 		case r.URL.Path == "/repos/owner/repo/branches/main":
 			w.WriteHeader(http.StatusOK)
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{"commit": map[string]string{"sha": mainSHA}})
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "main", "commit": map[string]string{"sha": mainSHA}})
 		case strings.HasSuffix(r.URL.Path, "/check-runs"):
 			if checkRunPolls != nil {
 				atomic.AddInt64(checkRunPolls, 1)
@@ -494,6 +503,20 @@ func externalMergeCIServer(t *testing.T, prNumber int, mergeSHA, mainSHA string,
 		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/issues/"):
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(github.Issue{Number: 10, Title: "issue", State: "open"})
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/commits"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat: add a thing")})
+		case strings.Contains(r.URL.Path, "/compare/"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ahead"})
+		case strings.HasSuffix(r.URL.Path, "/git/refs"):
+			if gitRefPosts != nil {
+				atomic.AddInt64(gitRefPosts, 1)
+			}
+			w.WriteHeader(http.StatusCreated)
 		default:
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("{}"))
@@ -508,7 +531,7 @@ func externalMergeCIServer(t *testing.T, prNumber int, mergeSHA, mainSHA string,
 // the exact GH-411 external-merge semantics that must survive the fix.
 func TestCheckExternalMergeOrClose_RequireCIFalse_DirectRelease(t *testing.T) {
 	var checkRunPolls int64
-	server := externalMergeCIServer(t, 42, "merge-sha-42", "mainsha", &checkRunPolls)
+	server := externalMergeCIServer(t, 42, "merge-sha-42", "mainsha", &checkRunPolls, nil)
 	defer server.Close()
 
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
@@ -551,10 +574,13 @@ func TestCheckExternalMergeOrClose_RequireCIFalse_DirectRelease(t *testing.T) {
 // instead of hijacking straight to StageReleasing. Then drives it forward via
 // handlePostMergeCI to confirm CI success reaches StageReleasing (same path as
 // the pre-existing handleMerged flow) — the fix reuses the existing gate,
-// it doesn't invent a new one.
+// it doesn't invent a new one. Finally ticks one step further into
+// handleReleasing (GH-4146) to confirm the tag is actually cut against the
+// merge SHA — the pre-fix bug left HeadSHA at its stale pre-merge value here,
+// which always compared "diverged" against main and escalated to StageFailed.
 func TestCheckExternalMergeOrClose_RequireCITrue_RoutesToPostMergeCI(t *testing.T) {
-	var checkRunPolls int64
-	server := externalMergeCIServer(t, 43, "merge-sha-43", "mainsha", &checkRunPolls)
+	var checkRunPolls, gitRefPosts int64
+	server := externalMergeCIServer(t, 43, "merge-sha-43", "mainsha", &checkRunPolls, &gitRefPosts)
 	defer server.Close()
 
 	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
@@ -617,6 +643,22 @@ func TestCheckExternalMergeOrClose_RequireCITrue_RoutesToPostMergeCI(t *testing.
 	}
 	if got := atomic.LoadInt64(&checkRunPolls); got != 1 {
 		t.Errorf("check-runs poll count = %d, want 1 (handlePostMergeCI must consult CI before releasing)", got)
+	}
+
+	// Drive it one step further: StageReleasing -> tag cut against the merge
+	// SHA (GH-4146). Pre-fix, HeadSHA was never resynced from PostMergeSHA for
+	// a plain (non-scope) PR, so this always escalated to StageFailed instead.
+	if err := c.handleReleasing(ctx, prState); err != nil {
+		t.Fatalf("handleReleasing() error = %v", err)
+	}
+	if prState.Stage == StageFailed {
+		t.Fatal("Stage = StageFailed after handleReleasing — HeadSHA was not resynced from PostMergeSHA")
+	}
+	if prState.HeadSHA != "merge-sha-43" {
+		t.Errorf("HeadSHA = %q, want resynced to PostMergeSHA merge-sha-43", prState.HeadSHA)
+	}
+	if got := atomic.LoadInt64(&gitRefPosts); got != 1 {
+		t.Errorf("git/refs POST count = %d, want 1 (tag must be created against the merge SHA)", got)
 	}
 }
 
@@ -684,6 +726,31 @@ func TestScanRecentlyMergedPRs_RequireCI_RoutesToPostMergeCI(t *testing.T) {
 	}
 	if got := atomic.LoadInt64(&gitRefPosts); got != 0 {
 		t.Errorf("git/refs POST count = %d, want 0 (must not tag before post-merge CI completes)", got)
+	}
+
+	// Drive it forward: CI succeeds -> StageReleasing -> tag cut against the
+	// merge SHA (GH-4146). The scan-recovery HeadSHA is the pre-merge branch
+	// head ("sha60"), which never converges with main after a squash merge;
+	// pre-fix, handleReleasing never resynced it from PostMergeSHA for a plain
+	// PR, so this always escalated to StageFailed instead of releasing.
+	ctx := context.Background()
+	if err := c.handlePostMergeCI(ctx, prState); err != nil {
+		t.Fatalf("handlePostMergeCI() error = %v", err)
+	}
+	if prState.Stage != StageReleasing {
+		t.Fatalf("Stage = %v after CI success, want StageReleasing", prState.Stage)
+	}
+	if err := c.handleReleasing(ctx, prState); err != nil {
+		t.Fatalf("handleReleasing() error = %v", err)
+	}
+	if prState.Stage == StageFailed {
+		t.Fatal("Stage = StageFailed after handleReleasing — HeadSHA was not resynced from PostMergeSHA")
+	}
+	if prState.HeadSHA != "merge-sha-60" {
+		t.Errorf("HeadSHA = %q, want resynced to PostMergeSHA merge-sha-60", prState.HeadSHA)
+	}
+	if got := atomic.LoadInt64(&gitRefPosts); got != 1 {
+		t.Errorf("git/refs POST count = %d, want 1 (tag must be created against the merge SHA)", got)
 	}
 }
 

--- a/internal/autopilot/controller_releasing_test.go
+++ b/internal/autopilot/controller_releasing_test.go
@@ -782,3 +782,67 @@ func TestHandleReleasing_DivergedSHARefused(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleReleasing_ResyncsHeadSHAFromPostMergeSHA verifies GH-4146: a plain
+// (non-scope) PR whose branch-head HeadSHA is stale/diverged (as it always is
+// after a squash merge) still releases successfully once PostMergeSHA — the
+// post-merge-CI-validated main commit — is set. The copy-back used to be
+// gated on scope carriers only (GH-3990), so every plain PR's reachability
+// check compared the stale branch head against main, always saw "diverged",
+// and escalated to StageFailed forever.
+func TestHandleReleasing_ResyncsHeadSHAFromPostMergeSHA(t *testing.T) {
+	tagCreated := false
+	var comparedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/branches/"):
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"name":   "main",
+				"commit": map[string]string{"sha": "mainsha700"},
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/commits"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{makeCommit("feat: add a thing")})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/"):
+			comparedPath = r.URL.Path
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ahead"})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
+			tagCreated = true
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := newReleasingController(t, server.URL)
+	prState := &PRState{
+		PRNumber:     700,
+		HeadSHA:      "staledivergedsha",
+		PostMergeSHA: "mergedsha700",
+		Stage:        StageReleasing,
+	}
+	c.mu.Lock()
+	c.activePRs[700] = prState
+	c.mu.Unlock()
+
+	if err := c.handleReleasing(context.Background(), prState); err != nil {
+		t.Fatalf("handleReleasing returned error: %v", err)
+	}
+	if prState.Stage == StageFailed {
+		t.Error("Stage must not be StageFailed once HeadSHA is resynced from PostMergeSHA")
+	}
+	if !tagCreated {
+		t.Error("tag must be created once HeadSHA is resynced from PostMergeSHA")
+	}
+	if prState.HeadSHA != "mergedsha700" {
+		t.Errorf("HeadSHA = %s, want resynced to PostMergeSHA mergedsha700", prState.HeadSHA)
+	}
+	if !strings.Contains(comparedPath, "mergedsha700") || strings.Contains(comparedPath, "staledivergedsha") {
+		t.Errorf("reachability compare must use the resynced merge SHA, got path %s", comparedPath)
+	}
+}


### PR DESCRIPTION
## Summary
- Widens the `HeadSHA ← PostMergeSHA` copy-back in `handleReleasing` from scope-carrier-only to any PR where `PostMergeSHA != ""` (guard preserves the `SkipPostMergeCI` fast path where `PostMergeSHA` is legitimately unset).
- Fixes: every plain squash-merged `on_merge` PR fails `guardReleaseSHAReachable` forever because its stale branch-head `HeadSHA` is structurally never an ancestor of main after a squash merge — compare always returns `"diverged"`, escalating to `StageFailed` and looping `releasing → failed → re-adopt → post_merge_ci → releasing` every ~2 minutes. No organic release tag can be cut.

## Test plan
- [x] `TestHandleReleasing_ResyncsHeadSHAFromPostMergeSHA` (new) — plain non-scope PR with stale diverged `HeadSHA` and valid `PostMergeSHA` releases successfully, tag cut against the resynced SHA.
- [x] `TestCheckExternalMergeOrClose_RequireCITrue_RoutesToPostMergeCI` extended to tick one step further into `handleReleasing`, asserting a tag is created against the merge SHA instead of escalating.
- [x] `TestScanRecentlyMergedPRs_RequireCI_RoutesToPostMergeCI` extended the same way.
- [x] Scope-carrier tests (`scope_release_test.go`) unchanged and green.
- [x] `make test` — full suite green.
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues.

Closes #4146