### PR TITLE
GH-4150: fix(autopilot): append (#N) to squash commit titles so release trains can resolve member PRs

### DIFF
--- a/internal/autopilot/auto_merger.go
+++ b/internal/autopilot/auto_merger.go
@@ -92,6 +92,14 @@ func (m *AutoMerger) MergePR(ctx context.Context, prState *PRState) error {
 			prefix := fmt.Sprintf("GH-%d: ", prState.IssueNumber)
 			commitTitle = strings.TrimPrefix(commitTitle, prefix)
 		}
+		// GH-4150: append the "(#N)" suffix GitHub's own squash-merge UI uses,
+		// so scheduleReleaseTick's resolveTrainMemberPRs (trainPRSuffixRe) can
+		// resolve this commit back to its member PR. Skip if the title already
+		// carries the suffix for this PR.
+		suffix := fmt.Sprintf("(#%d)", prState.PRNumber)
+		if !strings.HasSuffix(commitTitle, suffix) {
+			commitTitle = fmt.Sprintf("%s %s", commitTitle, suffix)
+		}
 	}
 	if err := m.ghClient.MergePullRequest(ctx, m.owner, m.repo, prState.PRNumber, mergeMethod, commitTitle); err != nil {
 		return fmt.Errorf("merge failed: %w", err)

--- a/internal/autopilot/auto_merger_test.go
+++ b/internal/autopilot/auto_merger_test.go
@@ -522,13 +522,19 @@ func TestAutoMerger_MergePR_SquashUsePRTitle(t *testing.T) {
 			name:      "squash with PR title uses PR title",
 			method:    github.MergeMethodSquash,
 			prTitle:   "feat(api): add rate limiting",
-			wantTitle: "feat(api): add rate limiting",
+			wantTitle: "feat(api): add rate limiting (#42)",
 		},
 		{
 			name:      "squash without PR title falls back to default",
 			method:    github.MergeMethodSquash,
 			prTitle:   "",
 			wantTitle: "Merge PR #42",
+		},
+		{
+			name:      "squash with PR title already suffixed does not double-append",
+			method:    github.MergeMethodSquash,
+			prTitle:   "feat(api): add rate limiting (#42)",
+			wantTitle: "feat(api): add rate limiting (#42)",
 		},
 		{
 			name:      "regular merge ignores PR title",
@@ -592,25 +598,25 @@ func TestAutoMerger_MergePR_SquashStripsIssuePrefix(t *testing.T) {
 			name:        "strips GH-XXXX: prefix from squash commit",
 			prTitle:     "GH-2312: fix(autopilot): strip issue prefix from squash title",
 			issueNumber: 2312,
-			wantTitle:   "fix(autopilot): strip issue prefix from squash title",
+			wantTitle:   "fix(autopilot): strip issue prefix from squash title (#42)",
 		},
 		{
 			name:        "no strip when issue number mismatches",
 			prTitle:     "GH-9999: feat(scope): something",
 			issueNumber: 2312,
-			wantTitle:   "GH-9999: feat(scope): something",
+			wantTitle:   "GH-9999: feat(scope): something (#42)",
 		},
 		{
 			name:        "no strip when no issue number",
 			prTitle:     "GH-2312: fix(autopilot): something",
 			issueNumber: 0,
-			wantTitle:   "GH-2312: fix(autopilot): something",
+			wantTitle:   "GH-2312: fix(autopilot): something (#42)",
 		},
 		{
 			name:        "plain conventional commit unchanged",
 			prTitle:     "feat(api): add endpoint",
 			issueNumber: 2312,
-			wantTitle:   "feat(api): add endpoint",
+			wantTitle:   "feat(api): add endpoint (#42)",
 		},
 	}
 

--- a/internal/autopilot/scope_schedule_test.go
+++ b/internal/autopilot/scope_schedule_test.go
@@ -182,6 +182,53 @@ func TestScheduleReleaseTick_DirectCommitOnlyTrain_NoRow(t *testing.T) {
 	}
 }
 
+// TestAutoMerger_SquashTitleSuffix_ResolvesAsTrainMember is a regex
+// round-trip: it builds a squash-merge commit title via AutoMerger.MergePR's
+// actual production title-construction path, then feeds a commit carrying
+// that title into resolveTrainMemberPRs and confirms it resolves as a member
+// PR — verifying the two call sites (auto_merger.go's title builder and
+// scope_schedule.go's trainPRSuffixRe) now agree on format (GH-4150).
+func TestAutoMerger_SquashTitleSuffix_ResolvesAsTrainMember(t *testing.T) {
+	var capturedTitle string
+	mergeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/owner/repo/pulls/555/merge" {
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			capturedTitle = body["commit_title"]
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mergeServer.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, mergeServer.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoReview = false
+	cfg.MergeMethod = github.MergeMethodSquash
+
+	merger := NewAutoMerger(ghClient, nil, nil, "owner", "repo", cfg)
+	if err := merger.MergePR(context.Background(), &PRState{
+		PRNumber: 555,
+		PRTitle:  "feat(train): resolve member PRs",
+	}); err != nil {
+		t.Fatalf("MergePR() error = %v", err)
+	}
+	if capturedTitle == "" {
+		t.Fatal("commit_title was not captured by the fake merge server")
+	}
+
+	commit := makeCommit(capturedTitle)
+	scheduleServer := scheduleTickServer(t, "v1.0.0", nil, map[int]bool{555: true})
+	defer scheduleServer.Close()
+
+	c, _ := newScheduleController(t, scheduleServer.URL, "0 21 * * FRI")
+
+	members := c.resolveTrainMemberPRs(context.Background(), []*github.Commit{commit})
+	if want := []int{555}; !reflect.DeepEqual(members, want) {
+		t.Errorf("resolveTrainMemberPRs(%q) = %v, want %v", capturedTitle, members, want)
+	}
+}
+
 // TestRecoverMissedTrainTick covers the three missed-tick recovery gates:
 // a genuine miss within lookback fires the tick once; an already-enqueued
 // slot is a no-op; a miss older than the lookback is left for manual


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4150.

Closes #4150

## Changes

GitHub Issue GH-4150: fix(autopilot): append (#N) to squash commit titles so release trains can resolve member PRs

## Problem

The on_schedule release train (`scheduleReleaseTick`, `internal/autopilot/scope_schedule.go`) resolves member PRs by extracting `(#N)` suffixes from squash-commit first lines (`resolveTrainMemberPRs`, `trainPRSuffixRe`). But our own auto-merger builds a custom squash title from the PR title WITHOUT the `(#N)` suffix (`internal/autopilot/auto_merger.go` ~line 87: `commitTitle = prState.PRTitle` after GH-prefix strip).

Result: every train over autopilot-merged commits resolves zero member PRs and skips with:

```
scheduleReleaseTick: no resolvable member PRs (direct-commit-only train), skipping — v1 limitation, the scope-release carrier requires a real merged PR
```

Observed in daemon log 2026-07-09 ~22:11 for every repo configured `trigger: on_schedule`. Evidence in qf-studio/pilot itself: 8 of 9 commits in v2.236.4 lack `(#N)`; only `60e0c3b2` (merged via GitHub UI default title) has it. This blocks cutting the pilot repo over from `on_merge` to the 16:00 release train.

## Fix

In `internal/autopilot/auto_merger.go`, after the existing PR-title/prefix-strip logic for squash merges, append the PR number suffix so the title matches GitHub's native squash convention:

```go
commitTitle = fmt.Sprintf("%s (#%d)", commitTitle, prState.PRNumber)
```

Constraints:
- Apply for squash merges only (the `commitTitle` custom-title path).
- Do not double-append if the PR title already ends with `(#N)` for the same PR number.
- Must not break `parseBumpFromMessage()` conventional-commit prefix detection (suffix is at the end; prefix untouched).

## Acceptance criteria

- [ ] Squash commit titles produced by MergePR end with ` (#<PR>)`
- [ ] No double suffix when PR title already carries `(#N)`
- [ ] Table-driven test covering: plain title, GH-prefixed title, title already suffixed
- [ ] A test asserting `resolveTrainMemberPRs` resolves a commit produced with the new title format (regex round-trip)
- [ ] Existing auto_merger and releaser tests still green

## Refs

- `internal/autopilot/auto_merger.go` (title construction)
- `internal/autopilot/scope_schedule.go` (`resolveTrainMemberPRs`, `trainPRSuffixRe`)
- Unblocks: pilot repo cutover to `trigger: on_schedule` 16:00 CET release train (mem-104 cycle workflow)