### PR TITLE
fix(gateway): cut GitHub webhook handler + signature verification to studio-sdk

### DIFF
--- a/cmd/pilot/github_webhook_wiring_test.go
+++ b/cmd/pilot/github_webhook_wiring_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/gateway"
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestGithubWebhookWiring_PRReviewReachesCallback_IssueIsNoOp is a GH-4156
+// regression test mirroring the gateway wiring in main.go (~L1978-1997): a
+// pull_request_review "submitted" webhook must reach the OnReviewRequested
+// bridge, while an issues webhook must be a no-op because no
+// SDK->core.IssueEvent bridge is wired (OnIssue is intentionally left unset;
+// out of scope per GH-4156).
+func TestGithubWebhookWiring_PRReviewReachesCallback_IssueIsNoOp(t *testing.T) {
+	router := gateway.NewRouter()
+
+	type reviewCall struct {
+		prNumber int
+		action   string
+		state    string
+		reviewer string
+	}
+	var got *reviewCall
+
+	ghClient := githubSDK.NewClient("fake-token")
+	ghWH := githubSDK.NewWebhookHandler(ghClient, "", "pilot")
+	ghWH.OnPRReview(func(ctx context.Context, prNumber int, action, state, reviewer string, repo *githubSDK.Repository) error {
+		if action == "submitted" {
+			got = &reviewCall{prNumber: prNumber, action: action, state: state, reviewer: reviewer}
+		}
+		return nil
+	})
+	router.RegisterWebhookHandler("github", func(payload map[string]interface{}) {
+		eventType, _ := payload["_event_type"].(string)
+		_ = ghWH.Handle(context.Background(), eventType, payload)
+	})
+
+	// PR review "submitted" must reach the callback.
+	prPayload := map[string]interface{}{}
+	rawPR := `{"action":"submitted","pull_request":{"number":42},"review":{"state":"approved","user":{"login":"alice"}},"repository":{"name":"pilot","full_name":"qf-studio/pilot","owner":{"login":"qf-studio"}}}`
+	if err := json.Unmarshal([]byte(rawPR), &prPayload); err != nil {
+		t.Fatalf("unmarshal PR review payload: %v", err)
+	}
+	prPayload["_event_type"] = "pull_request_review"
+	router.HandleWebhook("github", prPayload)
+
+	if got == nil {
+		t.Fatal("expected OnPRReview callback to fire for a submitted review")
+	}
+	if got.prNumber != 42 || got.action != "submitted" || got.state != "approved" || got.reviewer != "alice" {
+		t.Errorf("unexpected review callback data: %+v", got)
+	}
+
+	// Issue webhook must be a no-op: no OnIssue bridge is wired, so it must
+	// not invoke the PR-review callback or anything else observable.
+	got = nil
+	issuePayload := map[string]interface{}{}
+	rawIssue := `{"action":"opened","issue":{"number":7,"title":"x","state":"open","html_url":"http://x","labels":[]},"repository":{"name":"pilot","full_name":"qf-studio/pilot","html_url":"http://x","owner":{"login":"qf-studio"}}}`
+	if err := json.Unmarshal([]byte(rawIssue), &issuePayload); err != nil {
+		t.Fatalf("unmarshal issue payload: %v", err)
+	}
+	issuePayload["_event_type"] = "issues"
+	router.HandleWebhook("github", issuePayload)
+
+	if got != nil {
+		t.Fatalf("issue webhook must be a no-op, but review callback fired: %+v", got)
+	}
+}

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1980,9 +1980,9 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 			capturedController := autopilotController
 			token, _ := resolveGitHubToken(cfg)
 			if token != "" {
-				ghClient := github.NewClient(token)
-				ghWH := github.NewWebhookHandler(ghClient, cfg.Adapters.GitHub.WebhookSecret, cfg.Adapters.GitHub.PilotLabel)
-				ghWH.OnPRReview(func(ctx context.Context, prNumber int, action, state, reviewer string, repo *github.Repository) error {
+				ghClient := githubSDK.NewClient(token)
+				ghWH := githubSDK.NewWebhookHandler(ghClient, cfg.Adapters.GitHub.WebhookSecret, cfg.Adapters.GitHub.PilotLabel)
+				ghWH.OnPRReview(func(ctx context.Context, prNumber int, action, state, reviewer string, repo *githubSDK.Repository) error {
 					if action == "submitted" {
 						capturedController.OnReviewRequested(prNumber, action, state, reviewer)
 					}

--- a/internal/gateway/github_webhook_signature_test.go
+++ b/internal/gateway/github_webhook_signature_test.go
@@ -1,0 +1,82 @@
+package gateway
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// signGithubPayload computes a GitHub-style "sha256=<hex hmac>" signature,
+// matching what the studio-sdk github.VerifyWebhookSignature expects.
+func signGithubPayload(secret string, payload []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// TestGithubWebhookSignatureVerification is a GH-4156 regression suite: the
+// gateway now calls studio-sdk's github.VerifyWebhookSignature instead of the
+// in-tree internal/adapters/github implementation. It pins that swap did not
+// change accept/reject behavior, and that the gateway's own
+// s.githubWebhookSecret != "" guard (server.go handleGithubWebhook) still
+// short-circuits verification when no secret is configured — masking the
+// SDK function's own fail-open ("" secret == always valid) semantics behind
+// an explicit, auditable gateway-level decision.
+func TestGithubWebhookSignatureVerification(t *testing.T) {
+	payload := `{"action":"opened","issue":{"number":1}}`
+
+	t.Run("valid signature with configured secret is accepted", func(t *testing.T) {
+		config := &Config{Host: "127.0.0.1", Port: 9090, GithubWebhookSecret: "test-github-secret"}
+		server := NewServer(config)
+
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/github", strings.NewReader(payload))
+		req.Header.Set("X-GitHub-Event", "issues")
+		req.Header.Set("X-Hub-Signature-256", signGithubPayload("test-github-secret", []byte(payload)))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		server.handleGithubWebhook(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("invalid signature with configured secret is rejected", func(t *testing.T) {
+		config := &Config{Host: "127.0.0.1", Port: 9090, GithubWebhookSecret: "test-github-secret"}
+		server := NewServer(config)
+
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/github", strings.NewReader(payload))
+		req.Header.Set("X-GitHub-Event", "issues")
+		req.Header.Set("X-Hub-Signature-256", "sha256=deadbeef")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		server.handleGithubWebhook(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("empty configured secret short-circuits verification", func(t *testing.T) {
+		config := &Config{Host: "127.0.0.1", Port: 9090} // GithubWebhookSecret left empty
+		server := NewServer(config)
+
+		req := httptest.NewRequest(http.MethodPost, "/webhooks/github", strings.NewReader(payload))
+		req.Header.Set("X-GitHub-Event", "issues")
+		req.Header.Set("X-Hub-Signature-256", "sha256=not-even-hex-garbage")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		server.handleGithubWebhook(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 (verification skipped), got %d: %s", w.Code, w.Body.String())
+		}
+	})
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -16,9 +16,9 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/qf-studio/pilot/internal/adapters/github"
 	"github.com/qf-studio/pilot/internal/adapters/linear"
 	"github.com/qf-studio/pilot/internal/logging"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
 )
 
 // ReadinessChecker is an interface for components that can report their readiness.


### PR DESCRIPTION
## Summary
- `cmd/pilot/main.go` (~L1978-1997): the gateway polling-mode wiring now creates its GitHub client and webhook handler via `githubSDK` (studio-sdk `sdk/integrations/github`) instead of the in-tree `internal/adapters/github` package. `OnPRReview` is wired to `autopilotController.OnReviewRequested` exactly as before. `OnIssue` is intentionally **not** wired — no SDK→`core.IssueEvent` bridge exists yet, out of scope for this change.
- `internal/gateway/server.go` `handleGithubWebhook`: swaps `github.VerifyWebhookSignature` to the studio-sdk export. The existing `s.githubWebhookSecret != ""` guard is kept, so an empty configured secret still short-circuits verification at the gateway layer rather than relying on the SDK function's own fail-open ("" secret ⇒ always valid) semantics.
- Removed the now-unused `internal/adapters/github` import from `internal/gateway/server.go` (only `VerifyWebhookSignature` was used there).
- `internal/pilot/pilot.go` (path B) and `internal/adapters/github/webhook.go` (still consumed by path B) are untouched — deletion of the latter is out of scope (4d.6).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/gateway/... ./cmd/pilot/...`
- [x] `go test -race ./...` (full suite)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New: `internal/gateway/github_webhook_signature_test.go` — regression coverage for valid/invalid/empty-secret signature verification behavior, pinning the empty-secret short-circuit.
- [x] New: `cmd/pilot/github_webhook_wiring_test.go` — integration test confirming a `pull_request_review` "submitted" webhook reaches the review callback and an `issues` webhook is a no-op.
- [x] Verified no remaining `internal/adapters/github` import under `internal/gateway/`.