### PR TITLE
feat(approval): release-aware ack card + merge follow-up in thread + EditMessage fallback

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-10 (v2.151.0)
+**Last Updated:** 2026-07-09 (v2.151.0)
 
 ## Legend
 
@@ -363,6 +363,7 @@
 | Rule-based triggers | ✅ | approval | - | `approval.rules[]` | RuleEvaluator with 4 matchers wired into Manager (GH-636) |
 | Non-blocking async approval | ✅ | autopilot | - | `approval.async_dispatch` | handleAwaitApproval tick-handler; PR-A stall no longer blocks PR-B (GH-2685) |
 | Approval persistence in executions | ✅ | autopilot/memory | - | - | approval_request_id + decision written to executions table (GH-2712) |
+| Release-aware approval ack + merge follow-up | ✅ | approval/autopilot | - | - | Approved Telegram card shows the next-step text (immediate release / next cron train time / no releaser configured), injected as `approval.Request.ReleasePlan` by autopilot at request-creation time so the approval package never imports release config; `approval.Manager.NotifyMerged` posts a "🔀 Merged \<sha\>" follow-up in the same chat once `handleMerging` completes for an approval-gated PR (`PRState.MergeFollowupPosted` guards against a duplicate on re-entry); `EditMessage` failures on the ack card fall back to a new message so a recorded decision is never left with zero feedback (GH-4164, v2.236.8) |
 
 ## Autopilot (v0.19.1+)
 

--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -21,6 +21,14 @@ type Manager struct {
 	log           *slog.Logger
 }
 
+// MergeNotifier is implemented by handlers that can post a merge-completion
+// follow-up in the same channel/thread as an earlier approval decision.
+// Currently only TelegramHandler implements it — Manager.NotifyMerged skips
+// registered handlers that don't (GH-4164).
+type MergeNotifier interface {
+	NotifyMerged(ctx context.Context, requestID, shortSHA string) error
+}
+
 // pendingRequest tracks an active approval request
 type pendingRequest struct {
 	Request    *Request
@@ -361,6 +369,32 @@ func (m *Manager) PreMergeDefaultAction() Decision {
 		return m.config.PreMerge.DefaultAction
 	}
 	return m.config.DefaultAction
+}
+
+// NotifyMerged forwards a merge-completion follow-up for requestID to every
+// registered handler that implements MergeNotifier. Best-effort: a handler
+// failure is logged, not returned, so a Telegram/Slack hiccup can never fail
+// the caller's merge-transition handling (GH-4164).
+func (m *Manager) NotifyMerged(ctx context.Context, requestID, shortSHA string) {
+	m.mu.RLock()
+	handlers := make([]Handler, 0, len(m.handlers))
+	for _, h := range m.handlers {
+		handlers = append(handlers, h)
+	}
+	m.mu.RUnlock()
+
+	for _, h := range handlers {
+		notifier, ok := h.(MergeNotifier)
+		if !ok {
+			continue
+		}
+		if err := notifier.NotifyMerged(ctx, requestID, shortSHA); err != nil {
+			m.log.Warn("merge follow-up notification failed",
+				slog.String("request_id", requestID),
+				slog.String("channel", h.Name()),
+				slog.Any("error", err))
+		}
+	}
 }
 
 // RecordDecision records the outcome of a pending approval request.

--- a/internal/approval/manager_test.go
+++ b/internal/approval/manager_test.go
@@ -2,6 +2,7 @@ package approval
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -587,5 +588,78 @@ func TestManager_ShouldRequireApproval_WithConfigRules(t *testing.T) {
 	})
 	if rule != nil {
 		t.Errorf("expected no match, got rule %s", rule.Name)
+	}
+}
+
+// --- NotifyMerged tests (GH-4164) ---
+
+// mockMergeNotifyingHandler is a test double for a Handler that also
+// implements MergeNotifier.
+type mockMergeNotifyingHandler struct {
+	mockHandler
+	mu    sync.Mutex
+	calls []struct{ requestID, shortSHA string }
+	err   error
+}
+
+func (m *mockMergeNotifyingHandler) NotifyMerged(_ context.Context, requestID, shortSHA string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, struct{ requestID, shortSHA string }{requestID, shortSHA})
+	return m.err
+}
+
+func (m *mockMergeNotifyingHandler) getCalls() []struct{ requestID, shortSHA string } {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]struct{ requestID, shortSHA string }, len(m.calls))
+	copy(out, m.calls)
+	return out
+}
+
+// TestManager_NotifyMerged_ForwardsToMergeNotifierHandlers verifies that
+// NotifyMerged forwards to every registered handler implementing
+// MergeNotifier, and skips handlers that don't (e.g. plain mockHandler).
+func TestManager_NotifyMerged_ForwardsToMergeNotifierHandlers(t *testing.T) {
+	m := NewManager(nil)
+	notifying := &mockMergeNotifyingHandler{mockHandler: mockHandler{name: "telegram"}}
+	plain := &mockHandler{name: "github"}
+	m.RegisterHandler(notifying)
+	m.RegisterHandler(plain)
+
+	m.NotifyMerged(context.Background(), "req-1", "abc1234")
+
+	calls := notifying.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call to the MergeNotifier handler, got %d", len(calls))
+	}
+	if calls[0].requestID != "req-1" || calls[0].shortSHA != "abc1234" {
+		t.Errorf("unexpected call args: %+v", calls[0])
+	}
+}
+
+// TestManager_NotifyMerged_NoRegisteredHandlers_NoPanic ensures NotifyMerged
+// is a safe no-op when no handlers are registered at all.
+func TestManager_NotifyMerged_NoRegisteredHandlers_NoPanic(t *testing.T) {
+	m := NewManager(nil)
+	m.NotifyMerged(context.Background(), "req-1", "abc1234")
+}
+
+// TestManager_NotifyMerged_HandlerErrorIsNonFatal ensures a MergeNotifier
+// handler error is logged, not propagated — a Telegram/Slack hiccup here
+// must never fail the caller's merge-transition handling.
+func TestManager_NotifyMerged_HandlerErrorIsNonFatal(t *testing.T) {
+	m := NewManager(nil)
+	notifying := &mockMergeNotifyingHandler{
+		mockHandler: mockHandler{name: "telegram"},
+		err:         errors.New("telegram api down"),
+	}
+	m.RegisterHandler(notifying)
+
+	// Must not panic; the failure is logged internally.
+	m.NotifyMerged(context.Background(), "req-1", "abc1234")
+
+	if len(notifying.getCalls()) != 1 {
+		t.Errorf("expected the handler to still be called once despite returning an error")
 	}
 }

--- a/internal/approval/telegram.go
+++ b/internal/approval/telegram.go
@@ -49,7 +49,8 @@ type MessageResult struct {
 type TelegramHandler struct {
 	client   TelegramClient
 	chatID   string
-	pending  map[string]*telegramPending // requestID -> pending state
+	pending  map[string]*telegramPending  // requestID -> pending state
+	resolved map[string]*telegramResolved // requestID -> approved decision (for a later merge follow-up)
 	mu       sync.RWMutex
 	log      *slog.Logger
 	store    PendingApprovalStore // optional; enables restart persistence
@@ -64,13 +65,32 @@ type telegramPending struct {
 	ResponseCh chan *Response
 }
 
+// telegramResolved tracks an approved decision's chat/message so a later
+// NotifyMerged call can post the merge follow-up in the same chat. Only
+// approved decisions are tracked here — rejected/timeout requests never
+// reach a merge (GH-4164).
+type telegramResolved struct {
+	Request   *Request
+	ChatID    string
+	MessageID int64
+	DecidedAt time.Time
+}
+
+// resolvedRetention bounds how long an approved decision's chat/message is
+// kept in TelegramHandler.resolved awaiting a merge follow-up. A merge
+// normally follows approval within minutes; this is just a leak guard for
+// approved requests whose PR never actually merges (closed, cascade failure,
+// etc.) so the map doesn't grow unbounded (GH-4164).
+const resolvedRetention = 24 * time.Hour
+
 // NewTelegramHandler creates a new Telegram approval handler
 func NewTelegramHandler(client TelegramClient, chatID string) *TelegramHandler {
 	return &TelegramHandler{
-		client:  client,
-		chatID:  chatID,
-		pending: make(map[string]*telegramPending),
-		log:     logging.WithComponent("approval.telegram"),
+		client:   client,
+		chatID:   chatID,
+		pending:  make(map[string]*telegramPending),
+		resolved: make(map[string]*telegramResolved),
+		log:      logging.WithComponent("approval.telegram"),
 	}
 }
 
@@ -239,6 +259,16 @@ func (h *TelegramHandler) PruneExpired(ctx context.Context) (int, error) {
 	if len(expired) > 0 {
 		h.log.Info("pruned expired pending approvals", slog.Int("count", len(expired)))
 	}
+
+	// Sweep stale resolved decisions (approved requests whose PR never
+	// reached NotifyMerged within resolvedRetention) so the map stays bounded.
+	h.mu.Lock()
+	for id, r := range h.resolved {
+		if now.Sub(r.DecidedAt) > resolvedRetention {
+			delete(h.resolved, id)
+		}
+	}
+	h.mu.Unlock()
 
 	return len(expired), nil
 }
@@ -435,12 +465,24 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 			slog.String("request_id", requestID), slog.Any("error", err))
 	}
 
-	// Update message to show result
-	if pending.MessageID != 0 {
-		text := h.formatResponseMessage(pending.Request, decision, username)
-		if err := h.client.EditMessage(ctx, pending.ChatID, pending.MessageID, text, ""); err != nil {
-			h.log.Warn("Failed to edit response message", slog.Any("error", err))
+	// Update message to show result — falls back to a brand-new message if
+	// the edit fails (or there is no live message to edit), so a recorded
+	// decision is never left with zero user feedback (GH-4164).
+	text := h.formatResponseMessage(pending.Request, decision, username)
+	h.deliverResponseCard(ctx, pending.ChatID, pending.MessageID, text)
+
+	// Track the approved decision's chat/message so a later merge (autopilot
+	// calling NotifyMerged) can post a follow-up in the same chat. Only
+	// approved decisions ever reach a merge.
+	if decision == DecisionApproved {
+		h.mu.Lock()
+		h.resolved[requestID] = &telegramResolved{
+			Request:   pending.Request,
+			ChatID:    pending.ChatID,
+			MessageID: pending.MessageID,
+			DecidedAt: time.Now(),
 		}
+		h.mu.Unlock()
 	}
 
 	// Send response
@@ -463,6 +505,53 @@ func (h *TelegramHandler) HandleCallback(ctx context.Context, callbackID, data, 
 		slog.String("user", username))
 
 	return true
+}
+
+// deliverResponseCard edits the original approval message in place to show
+// the decision. If there is no live message to edit (messageID == 0) or the
+// edit fails, it falls back to sending a brand-new message with identical
+// content, so a recorded decision is never left with zero user feedback
+// (GH-4164). Best-effort: a failure on the fallback send is logged, not
+// returned — callers of HandleCallback must not fail on delivery issues.
+func (h *TelegramHandler) deliverResponseCard(ctx context.Context, chatID string, messageID int64, text string) {
+	if messageID != 0 {
+		err := h.client.EditMessage(ctx, chatID, messageID, text, "")
+		if err == nil {
+			return
+		}
+		h.log.Warn("failed to edit response message, falling back to a new message",
+			slog.String("chat_id", chatID), slog.Int64("message_id", messageID), slog.Any("error", err))
+	}
+	if _, err := h.client.SendMessageWithKeyboard(ctx, chatID, text, "", nil); err != nil {
+		h.log.Warn("failed to send fallback response message",
+			slog.String("chat_id", chatID), slog.Any("error", err))
+	}
+}
+
+// NotifyMerged posts a short merge-completion follow-up in the same chat as
+// the original approval decision, once the PR that decision gated has
+// actually merged. Called by autopilot's merge-transition handler
+// (stage -> merged) for PRs that went through human approval. A requestID
+// with no matching resolved decision (never approved via Telegram, already
+// notified, or past resolvedRetention) is a silent no-op — the caller
+// doesn't need to know which channel (if any) gated the merge (GH-4164).
+func (h *TelegramHandler) NotifyMerged(ctx context.Context, requestID, shortSHA string) error {
+	h.mu.Lock()
+	r, exists := h.resolved[requestID]
+	if exists {
+		delete(h.resolved, requestID)
+	}
+	h.mu.Unlock()
+
+	if !exists {
+		return nil
+	}
+
+	text := fmt.Sprintf("🔀 Merged %s", shortSHA)
+	if _, err := h.client.SendMessageWithKeyboard(ctx, r.ChatID, text, "", nil); err != nil {
+		return fmt.Errorf("notify merged: %w", err)
+	}
+	return nil
 }
 
 // formatApprovalMessage formats the approval request message
@@ -532,8 +621,19 @@ func (h *TelegramHandler) createApprovalKeyboard(req *Request) [][]InlineKeyboar
 	}
 }
 
-// formatResponseMessage formats the message after a response
+// formatResponseMessage formats the message after a response. An approved
+// decision carrying a ReleasePlan (set by autopilot at request-creation time
+// — see Request.ReleasePlan) renders a release-aware next-step line instead
+// of the generic "APPROVED" card, so the user sees what happens next without
+// having to check the pipeline separately (GH-4164). Rejected/timeout
+// decisions, and approvals with no release plan (e.g. non-merge-gating
+// stages), fall through to the original generic card.
 func (h *TelegramHandler) formatResponseMessage(req *Request, decision Decision, username string) string {
+	if decision == DecisionApproved && req.ReleasePlan != "" {
+		return fmt.Sprintf("✅ Approved by %s — merging. %s\n\nTask: %s\n%s",
+			username, req.ReleasePlan, req.TaskID, req.Title)
+	}
+
 	var icon, status string
 
 	switch decision {

--- a/internal/approval/telegram_test.go
+++ b/internal/approval/telegram_test.go
@@ -766,6 +766,72 @@ func TestTelegramHandler_FormatResponseMessage(t *testing.T) {
 	}
 }
 
+// TestTelegramHandler_FormatResponseMessage_ReleasePlan is the GH-4164
+// table-driven test covering the three release-trigger ack-card variants
+// (on_merge, on_schedule, disabled/absent) plus the rejected and no-plan
+// control paths, which must fall back to the generic APPROVED/REJECTED card.
+func TestTelegramHandler_FormatResponseMessage_ReleasePlan(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123")
+
+	tests := []struct {
+		name         string
+		req          *Request
+		decision     Decision
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "on_merge trigger",
+			req:          &Request{TaskID: "GH-1", Title: "Merge approval for PR #1", ReleasePlan: "Will release immediately after merge."},
+			decision:     DecisionApproved,
+			wantContains: []string{"✅ Approved by tester", "merging", "Will release immediately after merge."},
+		},
+		{
+			name:         "on_schedule trigger renders next train time",
+			req:          &Request{TaskID: "GH-2", Title: "Merge approval for PR #2", ReleasePlan: "Rides the next release train: 2026-07-11 16:00 CET."},
+			decision:     DecisionApproved,
+			wantContains: []string{"✅ Approved by tester", "Rides the next release train: 2026-07-11 16:00 CET."},
+		},
+		{
+			name:         "releaser disabled or absent",
+			req:          &Request{TaskID: "GH-3", Title: "Merge approval for PR #3", ReleasePlan: "No releaser configured for this repo (merge only)."},
+			decision:     DecisionApproved,
+			wantContains: []string{"✅ Approved by tester", "No releaser configured for this repo (merge only)."},
+		},
+		{
+			name:         "rejected — release plan text never shown even if set",
+			req:          &Request{TaskID: "GH-4", Title: "Merge approval for PR #4", ReleasePlan: "Will release immediately after merge."},
+			decision:     DecisionRejected,
+			wantContains: []string{"❌", "REJECTED"},
+			wantAbsent:   []string{"Will release immediately after merge."},
+		},
+		{
+			name:         "approved with no release plan — legacy control path",
+			req:          &Request{TaskID: "GH-5", Title: "Pre-execution approval"},
+			decision:     DecisionApproved,
+			wantContains: []string{"✅", "APPROVED", "Decision: tester"},
+			wantAbsent:   []string{"merging"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text := handler.formatResponseMessage(tt.req, tt.decision, "tester")
+			for _, want := range tt.wantContains {
+				if !containsString(text, want) {
+					t.Errorf("expected message to contain %q, got: %s", want, text)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if containsString(text, absent) {
+					t.Errorf("expected message to NOT contain %q, got: %s", absent, text)
+				}
+			}
+		})
+	}
+}
+
 func TestTelegramHandler_CreateApprovalKeyboard(t *testing.T) {
 	client := &mockTelegramClient{}
 	handler := NewTelegramHandler(client, "chat123")
@@ -1756,5 +1822,155 @@ func TestTelegramHandler_PruneExpired_SweepsOrphanedStoreRows(t *testing.T) {
 	}
 	if store.get("orphan-1") != nil {
 		t.Error("expected orphaned expired row to be swept from the store")
+	}
+}
+
+// --- EditMessage fallback + NotifyMerged tests (GH-4164) ---
+
+// TestTelegramHandler_HandleCallback_EditFailure_FallsBackToNewMessage is the
+// GH-4164 regression test: when EditMessage fails on the ack card, the
+// handler must send a brand-new message with the same content so a recorded
+// decision is never left with zero user feedback.
+func TestTelegramHandler_HandleCallback_EditFailure_FallsBackToNewMessage(t *testing.T) {
+	client := &mockTelegramClient{editError: errors.New("edit failed")}
+	logger, buf := newCapturingLogger()
+	handler := NewTelegramHandler(client, "chat123")
+	handler.log = logger
+
+	req := &Request{ID: "req-fallback", TaskID: "T-1", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handled := handler.HandleCallback(context.Background(), "cb1", "approve:req-fallback", "u1", "tester")
+	if !handled {
+		t.Fatal("expected callback to be handled")
+	}
+
+	// No successful edit — client returns an error for every EditMessage call.
+	if len(client.getEditedMessages()) != 0 {
+		t.Errorf("expected no successful edits, got %d", len(client.getEditedMessages()))
+	}
+
+	sent := client.getSentMessages()
+	if len(sent) != 2 { // 1 = original approval prompt, 2 = fallback response card
+		t.Fatalf("expected 2 sent messages (prompt + fallback), got %d", len(sent))
+	}
+	fallback := sent[len(sent)-1]
+	if fallback.ChatID != "chat123" {
+		t.Errorf("expected fallback chat_id 'chat123', got '%s'", fallback.ChatID)
+	}
+	if !containsString(fallback.Text, "APPROVED") {
+		t.Errorf("expected fallback message to carry the response card text, got: %s", fallback.Text)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "falling back to a new message") {
+		t.Errorf("expected fallback log line, got: %s", out)
+	}
+}
+
+// TestTelegramHandler_NotifyMerged_SendsFollowUpInSameChat verifies that once
+// a request has been approved via Telegram, NotifyMerged posts a short
+// merge-completion follow-up to the same chat the approval card was sent to.
+func TestTelegramHandler_NotifyMerged_SendsFollowUpInSameChat(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123")
+
+	req := &Request{
+		ID: "req-merged", TaskID: "GH-1", Stage: StagePreMerge, Title: "Test",
+		Approvers: []string{"99999"}, ExpiresAt: time.Now().Add(time.Hour),
+	}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	handler.HandleCallback(context.Background(), "cb1", "approve:req-merged", "u1", "tester")
+
+	sentBefore := len(client.getSentMessages())
+
+	if err := handler.NotifyMerged(context.Background(), "req-merged", "abc1234"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sent := client.getSentMessages()
+	if len(sent) != sentBefore+1 {
+		t.Fatalf("expected 1 additional message, got %d total (was %d)", len(sent), sentBefore)
+	}
+	followUp := sent[len(sent)-1]
+	if followUp.ChatID != "99999" {
+		t.Errorf("expected follow-up chat_id '99999' (same as approval), got '%s'", followUp.ChatID)
+	}
+	if !containsString(followUp.Text, "Merged") || !containsString(followUp.Text, "abc1234") {
+		t.Errorf("expected follow-up to mention the merge and short SHA, got: %s", followUp.Text)
+	}
+}
+
+// TestTelegramHandler_NotifyMerged_UnknownRequestIsNoOp ensures a requestID
+// with no resolved (approved) decision — e.g. never approved via Telegram,
+// or already notified once — is a silent no-op.
+func TestTelegramHandler_NotifyMerged_UnknownRequestIsNoOp(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123")
+
+	if err := handler.NotifyMerged(context.Background(), "never-approved", "abc1234"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(client.getSentMessages()) != 0 {
+		t.Errorf("expected no messages sent for an unresolved request, got %d", len(client.getSentMessages()))
+	}
+}
+
+// TestTelegramHandler_NotifyMerged_FiresOnceThenNoOp ensures a second
+// NotifyMerged call for the same requestID (e.g. a duplicate merge-transition
+// tick) does not send a second follow-up.
+func TestTelegramHandler_NotifyMerged_FiresOnceThenNoOp(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123")
+
+	req := &Request{ID: "req-once", TaskID: "GH-1", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	handler.HandleCallback(context.Background(), "cb1", "approve:req-once", "u1", "tester")
+
+	if err := handler.NotifyMerged(context.Background(), "req-once", "abc1234"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	afterFirst := len(client.getSentMessages())
+
+	if err := handler.NotifyMerged(context.Background(), "req-once", "def5678"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(client.getSentMessages()) != afterFirst {
+		t.Errorf("expected no additional message on second NotifyMerged call, got %d (was %d)", len(client.getSentMessages()), afterFirst)
+	}
+}
+
+// TestTelegramHandler_PruneExpired_SweepsStaleResolvedDecisions ensures an
+// approved decision that never reaches NotifyMerged within resolvedRetention
+// is dropped from the resolved map so it cannot grow unbounded.
+func TestTelegramHandler_PruneExpired_SweepsStaleResolvedDecisions(t *testing.T) {
+	client := &mockTelegramClient{}
+	handler := NewTelegramHandler(client, "chat123")
+
+	req := &Request{ID: "req-stale", TaskID: "GH-1", Stage: StagePreMerge, Title: "Test", ExpiresAt: time.Now().Add(time.Hour)}
+	if _, err := handler.SendApprovalRequest(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	handler.HandleCallback(context.Background(), "cb1", "approve:req-stale", "u1", "tester")
+
+	handler.mu.Lock()
+	handler.resolved["req-stale"].DecidedAt = time.Now().Add(-resolvedRetention - time.Minute)
+	handler.mu.Unlock()
+
+	if _, err := handler.PruneExpired(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	handler.mu.RLock()
+	_, exists := handler.resolved["req-stale"]
+	handler.mu.RUnlock()
+	if exists {
+		t.Error("expected stale resolved decision to be swept")
 	}
 }

--- a/internal/approval/types.go
+++ b/internal/approval/types.go
@@ -41,6 +41,16 @@ type Request struct {
 	ExpiresAt        time.Time              // When request expires (timeout)
 	Approvers        []string               // Required approvers (user IDs, handles)
 	PreferredChannel string                 `json:",omitempty"` // Preferred approval channel (e.g., "telegram", "slack"); falls back to first-available when unset or unregistered
+
+	// ReleasePlan is a human-readable, pre-rendered description of what happens
+	// after this request is approved (e.g. "Will release immediately after
+	// merge." or "Rides the next release train: 2026-07-11 16:00 CET."),
+	// injected verbatim by the caller (autopilot) at request-creation time.
+	// The approval package renders it into the approved ack card but never
+	// computes it — that would require importing release/config internals,
+	// which this package deliberately does not depend on (GH-4164). Empty for
+	// stages that don't gate a merge (pre_execution, post_failure).
+	ReleasePlan string
 }
 
 // Response represents an approval response

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -1686,10 +1686,11 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 		taskID = fmt.Sprintf("PR-%d", prState.PRNumber)
 	}
 	req := &approval.Request{
-		ID:     fmt.Sprintf("pr-%d-%d", prState.PRNumber, time.Now().UnixNano()),
-		TaskID: taskID,
-		Stage:  approval.StagePreMerge,
-		Title:  fmt.Sprintf("Merge approval for PR #%d", prState.PRNumber),
+		ID:          fmt.Sprintf("pr-%d-%d", prState.PRNumber, time.Now().UnixNano()),
+		TaskID:      taskID,
+		Stage:       approval.StagePreMerge,
+		Title:       fmt.Sprintf("Merge approval for PR #%d", prState.PRNumber),
+		ReleasePlan: releasePlanMessage(c.resolvedRelease(), time.Now()),
 		Metadata: map[string]interface{}{
 			"pr_url":    prState.PRURL,
 			"pr_title":  prState.PRTitle,
@@ -1981,6 +1982,24 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 	if c.notifier != nil {
 		if err := c.notifier.NotifyMerged(ctx, prState); err != nil {
 			c.log.Warn("failed to send merge notification", "error", err)
+		}
+	}
+
+	// GH-4164: PRs gated by human approval (Telegram/Slack) get a short
+	// "🔀 Merged <sha>" follow-up in the same chat the approval decision was
+	// made in, distinct from the general notifier above and from the
+	// on-release notify_on_release payload (which fires later, from
+	// handleReleasing, and is skipped here entirely). MergeFollowupPosted
+	// guards against a duplicate follow-up if this handler is re-entered
+	// after a crash between the merge succeeding and the stage transition
+	// persisting.
+	if c.approvalMgr != nil && prState.ApprovalRequestID != "" && !prState.MergeFollowupPosted {
+		c.approvalMgr.NotifyMerged(ctx, prState.ApprovalRequestID, ShortSHA(prState.HeadSHA))
+		prState.MergeFollowupPosted = true
+		if c.stateStore != nil {
+			if serr := c.stateStore.SavePRState(c.repoKey(), prState); serr != nil {
+				c.log.Warn("failed to persist merge-followup-posted flag", "pr", prState.PRNumber, "error", serr)
+			}
 		}
 	}
 

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -6768,6 +6768,190 @@ func TestController_handleMerging_CommentFlagPersists(t *testing.T) {
 	}
 }
 
+// --- GH-4164: approval-gated merge follow-up tests ---
+
+// mockApprovalMergeNotifier is a minimal approval.Handler that also
+// implements approval.MergeNotifier, so tests can assert Controller wires
+// handleMerging's success path to approval.Manager.NotifyMerged without
+// depending on the unexported test doubles in the approval package.
+type mockApprovalMergeNotifier struct {
+	calls []struct{ requestID, shortSHA string }
+}
+
+func (m *mockApprovalMergeNotifier) Name() string { return "telegram" }
+
+func (m *mockApprovalMergeNotifier) SendApprovalRequest(context.Context, *approval.Request) (<-chan *approval.Response, error) {
+	ch := make(chan *approval.Response, 1)
+	return ch, nil
+}
+
+func (m *mockApprovalMergeNotifier) CancelRequest(context.Context, string) error { return nil }
+
+func (m *mockApprovalMergeNotifier) NotifyMerged(_ context.Context, requestID, shortSHA string) error {
+	m.calls = append(m.calls, struct{ requestID, shortSHA string }{requestID, shortSHA})
+	return nil
+}
+
+// TestController_handleMerging_NotifiesApprovalGatedMerge is the GH-4164
+// regression test: a PR that went through human approval (ApprovalRequestID
+// set) fires approval.Manager.NotifyMerged exactly once on a successful
+// merge, and sets MergeFollowupPosted.
+func TestController_handleMerging_NotifiesApprovalGatedMerge(t *testing.T) {
+	commentCount := 0
+	server := mergeMockServer(t, 42, 10, &commentCount)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoReview = false
+	cfg.RequiredChecks = []string{"build"}
+
+	notifier := &mockApprovalMergeNotifier{}
+	approvalMgr := approval.NewManager(nil)
+	approvalMgr.RegisterHandler(notifier)
+
+	c := NewController(cfg, ghClient, approvalMgr, "owner", "repo")
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc1234", "pilot/GH-10", "")
+	prState, _ := c.GetPRState(42)
+	prState.Stage = StageMerging
+	prState.ApprovalRequestID = "req-42"
+
+	if err := c.handleMerging(context.Background(), prState); err != nil {
+		t.Fatalf("handleMerging returned error: %v", err)
+	}
+
+	if len(notifier.calls) != 1 {
+		t.Fatalf("expected 1 NotifyMerged call, got %d", len(notifier.calls))
+	}
+	if notifier.calls[0].requestID != "req-42" {
+		t.Errorf("expected requestID 'req-42', got %q", notifier.calls[0].requestID)
+	}
+	if notifier.calls[0].shortSHA != ShortSHA(prState.HeadSHA) {
+		t.Errorf("expected shortSHA %q, got %q", ShortSHA(prState.HeadSHA), notifier.calls[0].shortSHA)
+	}
+	if !prState.MergeFollowupPosted {
+		t.Error("expected MergeFollowupPosted to be true after notifying")
+	}
+}
+
+// TestController_handleMerging_NoApprovalGate_SkipsMergeFollowup ensures a PR
+// that never went through approval (ApprovalRequestID empty — the common
+// case) never triggers NotifyMerged.
+func TestController_handleMerging_NoApprovalGate_SkipsMergeFollowup(t *testing.T) {
+	commentCount := 0
+	server := mergeMockServer(t, 42, 10, &commentCount)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoReview = false
+	cfg.RequiredChecks = []string{"build"}
+
+	notifier := &mockApprovalMergeNotifier{}
+	approvalMgr := approval.NewManager(nil)
+	approvalMgr.RegisterHandler(notifier)
+
+	c := NewController(cfg, ghClient, approvalMgr, "owner", "repo")
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc1234", "pilot/GH-10", "")
+	prState, _ := c.GetPRState(42)
+	prState.Stage = StageMerging
+	// ApprovalRequestID left empty — this PR was never gated by approval.
+
+	if err := c.handleMerging(context.Background(), prState); err != nil {
+		t.Fatalf("handleMerging returned error: %v", err)
+	}
+
+	if len(notifier.calls) != 0 {
+		t.Errorf("expected no NotifyMerged calls for a non-approval-gated PR, got %d", len(notifier.calls))
+	}
+	if prState.MergeFollowupPosted {
+		t.Error("expected MergeFollowupPosted to stay false")
+	}
+}
+
+// TestController_handleMerging_MergeFollowupNotDoubleFired mirrors
+// TestController_handleMerging_IdempotentCompletionComment: re-entering
+// StageMerging for an already-merged, already-notified PR must not fire a
+// second NotifyMerged call.
+func TestController_handleMerging_MergeFollowupNotDoubleFired(t *testing.T) {
+	commentCount := 0
+	server := mergeMockServer(t, 42, 10, &commentCount)
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvDev
+	cfg.AutoReview = false
+	cfg.RequiredChecks = []string{"build"}
+
+	notifier := &mockApprovalMergeNotifier{}
+	approvalMgr := approval.NewManager(nil)
+	approvalMgr.RegisterHandler(notifier)
+
+	c := NewController(cfg, ghClient, approvalMgr, "owner", "repo")
+	c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "abc1234", "pilot/GH-10", "")
+	prState, _ := c.GetPRState(42)
+	prState.Stage = StageMerging
+	prState.ApprovalRequestID = "req-42"
+
+	if err := c.handleMerging(context.Background(), prState); err != nil {
+		t.Fatalf("first handleMerging returned error: %v", err)
+	}
+	if len(notifier.calls) != 1 {
+		t.Fatalf("expected 1 NotifyMerged call after first merge, got %d", len(notifier.calls))
+	}
+
+	// Simulate re-entry (e.g. crash recovery replaying the same tick).
+	prState.Stage = StageMerging
+	if err := c.handleMerging(context.Background(), prState); err != nil {
+		t.Fatalf("re-entry handleMerging returned error: %v", err)
+	}
+	if len(notifier.calls) != 1 {
+		t.Errorf("expected still 1 NotifyMerged call after re-entry, got %d", len(notifier.calls))
+	}
+}
+
+// TestController_handleMerging_MergeFollowupFlagPersists verifies
+// MergeFollowupPosted round-trips through SavePRState/GetPRState, mirroring
+// TestController_handleMerging_CommentFlagPersists for the new flag.
+func TestController_handleMerging_MergeFollowupFlagPersists(t *testing.T) {
+	store := newTestStateStore(t)
+
+	pr := &PRState{
+		PRNumber:            42,
+		PRURL:               "https://github.com/owner/repo/pull/42",
+		IssueNumber:         10,
+		BranchName:          "pilot/GH-10",
+		HeadSHA:             "abc1234",
+		Stage:               StageMerging,
+		CIStatus:            CIPending,
+		CreatedAt:           time.Now().Add(-5 * time.Minute).Truncate(time.Second),
+		ApprovalRequestID:   "req-42",
+		MergeFollowupPosted: true,
+	}
+	if err := store.SavePRState("owner/repo", pr); err != nil {
+		t.Fatalf("SavePRState failed: %v", err)
+	}
+
+	loaded, err := store.GetPRState("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("GetPRState failed: %v", err)
+	}
+	if loaded == nil || !loaded.MergeFollowupPosted {
+		t.Fatalf("MergeFollowupPosted did not persist: got %+v", loaded)
+	}
+
+	all, err := store.LoadAllPRStates("owner/repo")
+	if err != nil {
+		t.Fatalf("LoadAllPRStates failed: %v", err)
+	}
+	if len(all) != 1 || !all[0].MergeFollowupPosted {
+		t.Fatalf("LoadAllPRStates did not preserve MergeFollowupPosted: %+v", all)
+	}
+}
+
 // --- GH-2588: CI fix size guard tests ---
 
 // TestCIFixSizeGuard_OversizedPR_BlocksFixIssue is a cascade-2 reproduction:
@@ -6992,6 +7176,61 @@ func asyncApprovalManager() *approval.Manager {
 		},
 	}
 	return approval.NewManager(cfg)
+}
+
+// mockCapturingApprovalHandler is an approval.Handler that records every
+// request it's asked to send, so tests can inspect fields (e.g.
+// ReleasePlan) the controller populated before dispatch.
+type mockCapturingApprovalHandler struct {
+	sent []*approval.Request
+}
+
+func (m *mockCapturingApprovalHandler) Name() string { return "telegram" }
+
+func (m *mockCapturingApprovalHandler) SendApprovalRequest(_ context.Context, req *approval.Request) (<-chan *approval.Response, error) {
+	m.sent = append(m.sent, req)
+	return make(chan *approval.Response, 1), nil
+}
+
+func (m *mockCapturingApprovalHandler) CancelRequest(context.Context, string) error { return nil }
+
+// TestController_SubmitAsyncApprovalRequest_SetsReleasePlan is the GH-4164
+// regression test: submitAsyncApprovalRequest must inject a release-aware
+// ReleasePlan string onto the outbound approval.Request, computed from the
+// controller's resolved release config — the approval package itself never
+// sees a ReleaseConfig.
+func TestController_SubmitAsyncApprovalRequest_SetsReleasePlan(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvProd
+	cfg.Release = &ReleaseConfig{Enabled: true, Trigger: "on_merge"}
+
+	mgr := asyncApprovalManager()
+	handler := &mockCapturingApprovalHandler{}
+	mgr.RegisterHandler(handler)
+
+	c := NewController(cfg, ghClient, mgr, "owner", "repo")
+
+	c.mu.Lock()
+	c.activePRs[42] = &PRState{
+		PRNumber:    42,
+		PRURL:       "https://github.com/owner/repo/pull/42",
+		PRTitle:     "feat: something",
+		IssueNumber: 10,
+		Stage:       StageAwaitApproval,
+	}
+	c.mu.Unlock()
+
+	if err := c.ProcessPR(context.Background(), 42, nil); err != nil {
+		t.Fatalf("tick error: %v", err)
+	}
+
+	if len(handler.sent) != 1 {
+		t.Fatalf("expected 1 approval request sent, got %d", len(handler.sent))
+	}
+	if got, want := handler.sent[0].ReleasePlan, "Will release immediately after merge."; got != want {
+		t.Errorf("ReleasePlan = %q, want %q", got, want)
+	}
 }
 
 // TestController_AwaitApproval_StaysInStageUntilDecision verifies that the

--- a/internal/autopilot/release_plan.go
+++ b/internal/autopilot/release_plan.go
@@ -1,0 +1,35 @@
+package autopilot
+
+import (
+	"fmt"
+	"time"
+)
+
+// releasePlanMessage renders the release-aware next-step text shown on the
+// Telegram approval ack card once a human approves a merge (GH-4164). It is
+// injected onto approval.Request.ReleasePlan by submitAsyncApprovalRequest at
+// request-creation time — the approval package itself never imports release
+// config, so this function is the only place that translates a
+// ReleaseConfig into approval-facing text.
+func releasePlanMessage(rel *ReleaseConfig, now time.Time) string {
+	if rel == nil || !rel.Enabled {
+		return "No releaser configured for this repo (merge only)."
+	}
+
+	switch rel.Trigger {
+	case "on_schedule":
+		nextRun, err := nextScheduledRunString(rel, now)
+		if err != nil {
+			return "Rides the next release train (schedule unavailable — check release config)."
+		}
+		return fmt.Sprintf("Rides the next release train: %s.", nextRun)
+	case "on_merge", "":
+		return "Will release immediately after merge."
+	default:
+		// on_scope_close / manual: not one of the three cases GH-4164 enumerates
+		// explicitly. Both hold merges rather than releasing immediately after
+		// this one, so the generic "merge only" wording is accurate enough
+		// without inventing a fourth ack-card variant.
+		return "No releaser configured for this repo (merge only)."
+	}
+}

--- a/internal/autopilot/release_plan_test.go
+++ b/internal/autopilot/release_plan_test.go
@@ -1,0 +1,157 @@
+package autopilot
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// TestReleasePlanMessage is the GH-4164 table-driven test covering the three
+// release-trigger ack-card variants (on_merge, on_schedule, disabled/absent)
+// plus an invalid-cron edge case that must fall back to safe phrasing rather
+// than propagating a parse error into the approval card.
+func TestReleasePlanMessage(t *testing.T) {
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		rel  *ReleaseConfig
+		want string
+	}{
+		{
+			name: "nil release config — disabled/absent",
+			rel:  nil,
+			want: "No releaser configured for this repo (merge only).",
+		},
+		{
+			name: "release config present but disabled",
+			rel:  &ReleaseConfig{Enabled: false, Trigger: "on_merge"},
+			want: "No releaser configured for this repo (merge only).",
+		},
+		{
+			name: "on_merge trigger",
+			rel:  &ReleaseConfig{Enabled: true, Trigger: "on_merge"},
+			want: "Will release immediately after merge.",
+		},
+		{
+			name: "empty trigger defaults to on_merge behavior",
+			rel:  &ReleaseConfig{Enabled: true, Trigger: ""},
+			want: "Will release immediately after merge.",
+		},
+		{
+			name: "manual trigger — falls back to merge-only wording",
+			rel:  &ReleaseConfig{Enabled: true, Trigger: "manual"},
+			want: "No releaser configured for this repo (merge only).",
+		},
+		{
+			name: "on_scope_close trigger — falls back to merge-only wording",
+			rel:  &ReleaseConfig{Enabled: true, Trigger: "on_scope_close"},
+			want: "No releaser configured for this repo (merge only).",
+		},
+		{
+			name: "on_schedule with invalid cron — safe fallback phrasing",
+			rel:  &ReleaseConfig{Enabled: true, Trigger: "on_schedule", Schedule: "not a cron expression"},
+			want: "Rides the next release train (schedule unavailable — check release config).",
+		},
+		{
+			name: "on_schedule with invalid timezone — safe fallback phrasing",
+			rel:  &ReleaseConfig{Enabled: true, Trigger: "on_schedule", Schedule: "0 16 * * 1-5", ScheduleTimezone: "Not/AZone"},
+			want: "Rides the next release train (schedule unavailable — check release config).",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := releasePlanMessage(tt.rel, now)
+			if got != tt.want {
+				t.Errorf("releasePlanMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReleasePlanMessage_OnSchedule_RendersActualNextRun verifies the
+// on_schedule branch renders the real next-run wall-clock time computed from
+// the configured cron schedule + timezone, not a placeholder.
+func TestReleasePlanMessage_OnSchedule_RendersActualNextRun(t *testing.T) {
+	rel := &ReleaseConfig{
+		Enabled:          true,
+		Trigger:          "on_schedule",
+		Schedule:         "0 16 * * 1-5",
+		ScheduleTimezone: "Europe/Berlin",
+	}
+	// A Friday — the next weekday 16:00 slot is the same day.
+	now := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+
+	got := releasePlanMessage(rel, now)
+
+	if !strings.HasPrefix(got, "Rides the next release train: ") {
+		t.Fatalf("expected on_schedule prefix, got: %s", got)
+	}
+	if !strings.HasSuffix(got, ".") {
+		t.Errorf("expected trailing period, got: %s", got)
+	}
+
+	loc, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatalf("failed to load Europe/Berlin: %v", err)
+	}
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	schedule, err := parser.Parse(rel.Schedule)
+	if err != nil {
+		t.Fatalf("failed to parse schedule: %v", err)
+	}
+	want := schedule.Next(now.In(loc)).Format("2006-01-02 15:04 MST")
+
+	if !strings.Contains(got, want) {
+		t.Errorf("expected message to contain computed next-run %q, got: %s", want, got)
+	}
+}
+
+// TestNextScheduledRunString covers nextScheduledRunString directly: valid
+// schedule/timezone, timezone defaulting to local when unset, and both
+// invalid-schedule and invalid-timezone error paths.
+func TestNextScheduledRunString(t *testing.T) {
+	now := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+
+	t.Run("valid schedule and timezone", func(t *testing.T) {
+		rel := &ReleaseConfig{Schedule: "0 16 * * 1-5", ScheduleTimezone: "Europe/Berlin"}
+		got, err := nextScheduledRunString(rel, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == "" {
+			t.Error("expected non-empty next-run string")
+		}
+		if !strings.Contains(got, "CEST") && !strings.Contains(got, "CET") {
+			t.Errorf("expected a Europe/Berlin zone abbreviation, got: %s", got)
+		}
+	})
+
+	t.Run("empty timezone defaults to local", func(t *testing.T) {
+		rel := &ReleaseConfig{Schedule: "0 16 * * 1-5"}
+		got, err := nextScheduledRunString(rel, now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == "" {
+			t.Error("expected non-empty next-run string")
+		}
+	})
+
+	t.Run("invalid schedule returns error", func(t *testing.T) {
+		rel := &ReleaseConfig{Schedule: "not a cron expression"}
+		if _, err := nextScheduledRunString(rel, now); err == nil {
+			t.Error("expected an error for an invalid cron schedule")
+		}
+	})
+
+	t.Run("invalid timezone returns error", func(t *testing.T) {
+		rel := &ReleaseConfig{Schedule: "0 16 * * 1-5", ScheduleTimezone: "Not/AZone"}
+		if _, err := nextScheduledRunString(rel, now); err == nil {
+			t.Error("expected an error for an invalid timezone")
+		}
+	})
+}

--- a/internal/autopilot/scope_schedule.go
+++ b/internal/autopilot/scope_schedule.go
@@ -47,6 +47,31 @@ func previousScheduledTime(schedule cron.Schedule, before time.Time) time.Time {
 	return prev
 }
 
+// nextScheduledRunString computes the human-readable, timezone-aware next
+// fire time for rel's cron Schedule relative to now. Used to render the
+// on_schedule branch of releasePlanMessage's approval ack-card text
+// (GH-4164). Mirrors startScheduleRelease's parser/timezone resolution so
+// the ack card and the actual scheduler always agree on the next slot.
+func nextScheduledRunString(rel *ReleaseConfig, now time.Time) (string, error) {
+	loc := time.Local
+	if rel.ScheduleTimezone != "" {
+		l, err := time.LoadLocation(rel.ScheduleTimezone)
+		if err != nil {
+			return "", fmt.Errorf("invalid schedule_timezone %q: %w", rel.ScheduleTimezone, err)
+		}
+		loc = l
+	}
+
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	schedule, err := parser.Parse(rel.Schedule)
+	if err != nil {
+		return "", fmt.Errorf("invalid schedule %q: %w", rel.Schedule, err)
+	}
+
+	next := schedule.Next(now.In(loc))
+	return next.Format("2006-01-02 15:04 MST"), nil
+}
+
 // trainScopeKey renders the "train:<RFC3339>" scope key for a scheduled
 // release-train tick at t. Normalized to UTC so the live-fire tick and a
 // restart-recovered tick for the same slot always agree on the same key

--- a/internal/autopilot/state_store.go
+++ b/internal/autopilot/state_store.go
@@ -134,6 +134,10 @@ func (s *StateStore) migrate() error {
 		// release stages) never re-fetch the PR from GitHub, so without this
 		// their dashboard rows render with a blank title forever.
 		`ALTER TABLE autopilot_pr_state ADD COLUMN pr_title TEXT NOT NULL DEFAULT ''`,
+		// GH-4164: mirrors merge_notification_posted's crash-recovery guard —
+		// tracks whether the approval-gated "🔀 Merged <sha>" Telegram follow-up
+		// has been sent, so re-entry into StageMerging cannot double-fire it.
+		`ALTER TABLE autopilot_pr_state ADD COLUMN merge_followup_posted INTEGER NOT NULL DEFAULT 0`,
 	}
 
 	for _, m := range migrations {
@@ -388,6 +392,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			rebase_attempts INTEGER NOT NULL DEFAULT 0,
 			scope_key TEXT NOT NULL DEFAULT '',
 			pr_title TEXT NOT NULL DEFAULT '',
+			merge_followup_posted INTEGER NOT NULL DEFAULT 0,
 			PRIMARY KEY (repo, pr_number)
 		)
 	`); err != nil {
@@ -401,7 +406,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
-			pr_title
+			pr_title, merge_followup_posted
 		)
 		SELECT
 			pr_number, repo, pr_url, issue_number, branch_name, head_sha,
@@ -410,7 +415,7 @@ func (s *StateStore) migratePRStateRepoScoping() error {
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
-			pr_title
+			pr_title, merge_followup_posted
 		FROM autopilot_pr_state
 	`); err != nil {
 		return fmt.Errorf("copy autopilot_pr_state rows: %w", err)
@@ -554,8 +559,8 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
-			pr_title
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			pr_title, merge_followup_posted
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(repo, pr_number) DO UPDATE SET
 			pr_url = excluded.pr_url,
 			issue_number = excluded.issue_number,
@@ -578,7 +583,8 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 			post_merge_ci_started_at = excluded.post_merge_ci_started_at,
 			rebase_attempts = excluded.rebase_attempts,
 			scope_key = excluded.scope_key,
-			pr_title = excluded.pr_title
+			pr_title = excluded.pr_title,
+			merge_followup_posted = excluded.merge_followup_posted
 	`,
 		pr.PRNumber, repo, pr.PRURL, pr.IssueNumber, pr.BranchName, pr.HeadSHA,
 		string(pr.Stage), string(pr.CIStatus),
@@ -587,7 +593,7 @@ func (s *StateStore) SavePRState(repo string, pr *PRState) error {
 		pr.ReleaseVersion, string(pr.ReleaseBumpType), pr.MergeNotificationPosted,
 		pr.ApprovalRequestID, pr.ApprovalDecision, nullTime(pr.ApprovalRequestedAt),
 		pr.PostMergeSHA, nullTime(pr.PostMergeCIStartedAt), pr.RebaseAttempts, pr.ScopeKey,
-		pr.PRTitle,
+		pr.PRTitle, pr.MergeFollowupPosted,
 	)
 	return err
 }
@@ -602,7 +608,7 @@ func (s *StateStore) GetPRState(repo string, prNumber int) (*PRState, error) {
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
-			pr_title
+			pr_title, merge_followup_posted
 		FROM autopilot_pr_state WHERE repo = ? AND pr_number = ?
 	`, repo, prNumber)
 
@@ -626,7 +632,7 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			release_version, release_bump_type, merge_notification_posted,
 			approval_request_id, approval_decision, approval_requested_at,
 			post_merge_sha, post_merge_ci_started_at, rebase_attempts, scope_key,
-			pr_title
+			pr_title, merge_followup_posted
 		FROM autopilot_pr_state WHERE repo = ?
 	`, repo)
 	if err != nil {
@@ -647,7 +653,7 @@ func (s *StateStore) LoadAllPRStates(repo string) ([]*PRState, error) {
 			&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
 			&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
 			&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts, &pr.ScopeKey,
-			&pr.PRTitle,
+			&pr.PRTitle, &pr.MergeFollowupPosted,
 		); err != nil {
 			return nil, err
 		}
@@ -902,7 +908,7 @@ func scanPRState(row *sql.Row) (*PRState, error) {
 		&pr.ReleaseVersion, &relBumpType, &pr.MergeNotificationPosted,
 		&pr.ApprovalRequestID, &pr.ApprovalDecision, &approvalRequestedAt,
 		&pr.PostMergeSHA, &postMergeCIStartedAt, &pr.RebaseAttempts, &pr.ScopeKey,
-		&pr.PRTitle,
+		&pr.PRTitle, &pr.MergeFollowupPosted,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -829,6 +829,13 @@ type PRState struct {
 	// the conflict via isMergeConflict and may re-record once, which is an
 	// acceptable trade-off for a low-cardinality observability counter.
 	ConflictRecorded bool
+	// MergeFollowupPosted is true once approval.Manager.NotifyMerged has been
+	// called for this PR's merge, so a state-machine re-entry (e.g. after a
+	// crash between the merge succeeding and the stage transition persisting)
+	// cannot post a duplicate "🔀 Merged" follow-up to the approver's chat.
+	// Mirrors the MergeNotificationPosted guard above for the same race
+	// (GH-4164).
+	MergeFollowupPosted bool
 }
 
 // snapshot returns a detached, field-by-field copy of the PRState with a fresh
@@ -874,6 +881,7 @@ func (ps *PRState) snapshot() *PRState {
 		ScopeKey:                ps.ScopeKey,
 		ScopeTitle:              ps.ScopeTitle,
 		ConflictRecorded:        ps.ConflictRecorded,
+		MergeFollowupPosted:     ps.MergeFollowupPosted,
 	}
 	// DiscoveredChecks and ScopeMemberPRs are slices — copy the backing arrays
 	// so consumers can't mutate the live PR's slice through the snapshot.


### PR DESCRIPTION
## Summary

- Approved Telegram cards now render a release-aware next-step line: "Will release immediately after merge." (`on_merge`), "Rides the next release train: `<tz-aware next run>`." (`on_schedule`, computed from the actual cron schedule/timezone), or "No releaser configured for this repo (merge only)." (disabled/absent). The text is computed by autopilot and injected onto `approval.Request.ReleasePlan` — the `approval` package gains no new imports of release/config internals.
- `approval.Manager.NotifyMerged(ctx, requestID, shortSHA)` posts a short "🔀 Merged `<sha>`" follow-up in the same Telegram chat once `handleMerging` completes for a PR that was gated by human approval, distinct from the existing `notify_on_release` payload. `PRState.MergeFollowupPosted` (persisted, mirroring the existing `MergeNotificationPosted` guard) prevents a duplicate follow-up if the merge-transition handler is re-entered.
- A failed `EditMessage` on the approval result card now falls back to sending a brand-new message with identical content, so a recorded decision is never left with zero user feedback. This also covers the case where there was no live message to edit (`messageID == 0`).

## Test plan

- [x] `go test -race ./internal/approval/... ./internal/autopilot/...` green
- [x] `go build ./...` and `go vet ./...` clean
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `go test ./...` (full repo) green
- [x] Table-driven test on `formatResponseMessage` covering all three `ReleasePlan` variants plus rejected/no-plan control paths
- [x] `releasePlanMessage`/`nextScheduledRunString` tests, including invalid-cron and invalid-timezone fallback
- [x] `NotifyMerged` tests: same-chat follow-up, unknown-request no-op, fires-once guard, TTL sweep of stale resolved decisions
- [x] `EditMessage` failure → fallback send test
- [x] Controller-level tests: `ReleasePlan` wired into the outbound request, `NotifyMerged` called once for approval-gated merges and skipped for non-gated ones, flag persists through `SavePRState`/`GetPRState`