### PR TITLE
fix(config): ignore use_sdk_poller flag, keep parsing + warn on startup (GH-4171)

### DIFF
--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -112,22 +112,25 @@ func (s sdkRateLimitScheduler) QueueRetryIfRateLimited(taskID, title, body, errT
 // githubPollerRegistration returns the studio-sdk GitHub issue-poller registration.
 //
 // M7 Phase 4b (studio-sdk v0.27.0): LIVE behind adapters.github.use_sdk_poller.
-// M7 Phase 4d.2b (studio-sdk v0.30.0): when the flag is on, this registration fans
-// out one SDK poller per repo — the DEFAULT repo (adapters.github.repo) plus every
-// projects[] GitHub entry — each with full host-hook parity (rate-limit scheduler,
-// pre-flight judge, execution checkers, issue metrics, per-repo autopilot controller
-// and PR creator). The default repo additionally gets board source/sync wiring;
-// project repos do not (parity with the in-tree path). The in-tree poller skips every
-// SDK-owned repo (main.go standalone block).
+// M7 Phase 4d.2b (studio-sdk v0.30.0): fans out one SDK poller per repo — the
+// DEFAULT repo (adapters.github.repo) plus every projects[] GitHub entry — each
+// with full host-hook parity (rate-limit scheduler, pre-flight judge, execution
+// checkers, issue metrics, per-repo autopilot controller and PR creator). The
+// default repo additionally gets board source/sync wiring; project repos do not
+// (parity with the in-tree path).
+// M7 Phase 4d.6 (GH-4171): the in-tree fallback poller is gone (GH-4170), so this
+// registration is now unconditional for every GitHub repo — UseSDKPoller is still
+// parsed off adapters.github.use_sdk_poller for backward-compat config loading
+// but no longer gates anything here (see config.CheckDeprecations for the
+// startup warning).
 //
 // Known 4b limitation: the SDK adapter runs ExecutionModeAuto only —
-// execution.mode=sequential configs should keep the flag off.
+// execution.mode=sequential configs are not supported.
 func githubPollerRegistration() PollerRegistration {
 	return PollerRegistration{
 		Name: "github",
 		Enabled: func(cfg *config.Config) bool {
 			return cfg.Adapters.GitHub != nil && cfg.Adapters.GitHub.Enabled &&
-				cfg.Adapters.GitHub.UseSDKPoller &&
 				cfg.Adapters.GitHub.Repo != "" &&
 				cfg.Adapters.GitHub.Polling != nil && cfg.Adapters.GitHub.Polling.Enabled
 		},

--- a/cmd/pilot/poller_github_test.go
+++ b/cmd/pilot/poller_github_test.go
@@ -19,8 +19,9 @@ import (
 )
 
 // TestGithubPollerRegistration_Fields verifies the SDK-based registration has the correct
-// name and that its Enabled predicate gates on the use_sdk_poller flag (OFF by default —
-// the in-tree poller stays the live path unless a config opts in; M7 4b).
+// name and that its Enabled predicate no longer gates on the use_sdk_poller flag (M7 4d.6,
+// GH-4171): the in-tree fallback poller is gone, so the SDK poller is unconditional
+// whenever the GitHub adapter is enabled with a repo and polling turned on.
 func TestGithubPollerRegistration_Fields(t *testing.T) {
 	reg := githubPollerRegistration()
 
@@ -46,11 +47,11 @@ func TestGithubPollerRegistration_Fields(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "use_sdk_poller off (default) — in-tree poller stays the live path",
+			name: "use_sdk_poller off (default) — flag is ignored, SDK poller starts anyway (GH-4171)",
 			cfg: &config.Config{Adapters: &config.AdaptersConfig{
 				GitHub: &github.Config{Enabled: true, UseSDKPoller: false, Repo: "o/r", Polling: &github.PollingConfig{Enabled: true}},
 			}},
-			want: false,
+			want: true,
 		},
 		{
 			name: "polling disabled",
@@ -92,16 +93,16 @@ func TestGithubPollerRegistration_Fields(t *testing.T) {
 	}
 }
 
-// TestGithubPollerRegistered verifies the M7-4b invariant: the GitHub SDK registration IS
-// wired into adapterPollerRegistrations() (flag-gated via its Enabled predicate), so daemons
-// with use_sdk_poller=true start the SDK poller for the default repo.
+// TestGithubPollerRegistered verifies the GitHub SDK registration IS wired into
+// adapterPollerRegistrations(), so daemons with the GitHub adapter enabled start
+// the SDK poller for the default repo regardless of use_sdk_poller (GH-4171).
 func TestGithubPollerRegistered(t *testing.T) {
 	for _, reg := range adapterPollerRegistrations() {
 		if reg.Name == "github" {
 			return
 		}
 	}
-	t.Error("github must be in adapterPollerRegistrations() as of M7 4b (flag-gated by use_sdk_poller)")
+	t.Error("github must be in adapterPollerRegistrations()")
 }
 
 // TestGithubSDKClientDoesNotImplementPRCreator documents the github behavior delta: unlike the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -876,6 +876,16 @@ func (c *Config) CheckDeprecations() []string {
 		}
 	}
 
+	// Check GitHub.UseSDKPoller (M7 4d.6, GH-4171): the in-tree GitHub poller
+	// fallback is gone (GH-4170) — the SDK poller now runs unconditionally
+	// whenever the GitHub adapter is enabled, so this flag is parsed for
+	// backward compatibility only and has no effect either way.
+	if c.Adapters != nil && c.Adapters.GitHub != nil && c.Adapters.GitHub.Enabled {
+		msg := "config: adapters.github.use_sdk_poller is deprecated and ignored — the GitHub adapter always uses the studio-sdk poller now; remove this field from your config"
+		log.Printf("DEPRECATED: %s", msg)
+		warnings = append(warnings, msg)
+	}
+
 	return warnings
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1382,6 +1382,46 @@ func TestCheckDeprecations(t *testing.T) {
 			}(),
 			wantWarnings: 0,
 		},
+		{
+			name: "GitHubUseSDKPollerFalseButEnabled",
+			config: func() *Config {
+				c := DefaultConfig()
+				c.Adapters.GitHub.Enabled = true
+				c.Adapters.GitHub.UseSDKPoller = false
+				return c
+			}(),
+			wantWarnings: 1,
+			wantContains: "use_sdk_poller is deprecated and ignored",
+		},
+		{
+			name: "GitHubUseSDKPollerTrueAndEnabled",
+			config: func() *Config {
+				c := DefaultConfig()
+				c.Adapters.GitHub.Enabled = true
+				c.Adapters.GitHub.UseSDKPoller = true
+				return c
+			}(),
+			wantWarnings: 1,
+			wantContains: "use_sdk_poller is deprecated and ignored",
+		},
+		{
+			name: "GitHubAdapterDisabled",
+			config: func() *Config {
+				c := DefaultConfig()
+				c.Adapters.GitHub.Enabled = false
+				return c
+			}(),
+			wantWarnings: 0,
+		},
+		{
+			name: "NilGitHubConfig",
+			config: func() *Config {
+				c := DefaultConfig()
+				c.Adapters.GitHub = nil
+				return c
+			}(),
+			wantWarnings: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1437,6 +1477,46 @@ orchestrator:
 	warnings := config.CheckDeprecations()
 	if len(warnings) != 1 {
 		t.Errorf("Expected 1 deprecation warning, got %d", len(warnings))
+	}
+}
+
+// TestLoadWithDeprecatedUseSDKPoller covers GH-4171: adapters.github.use_sdk_poller
+// is still parsed (existing configs must keep loading without error) but now only
+// produces a startup deprecation warning — it no longer changes daemon behavior.
+func TestLoadWithDeprecatedUseSDKPoller(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+version: "1.0"
+adapters:
+  github:
+    enabled: true
+    repo: "owner/repo"
+    use_sdk_poller: false
+    polling:
+      enabled: true
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	config, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	// The field is still parsed off the YAML.
+	if config.Adapters.GitHub.UseSDKPoller != false {
+		t.Errorf("Adapters.GitHub.UseSDKPoller = %v, want false", config.Adapters.GitHub.UseSDKPoller)
+	}
+
+	warnings := config.CheckDeprecations()
+	if len(warnings) != 1 {
+		t.Fatalf("Expected 1 deprecation warning, got %d: %v", len(warnings), warnings)
+	}
+	if !contains(warnings[0], "use_sdk_poller is deprecated and ignored") {
+		t.Errorf("warning %q should mention use_sdk_poller is deprecated and ignored", warnings[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Keeps parsing `adapters.github.use_sdk_poller` (`internal/adapters/github/types.go:23`) for backward compatibility, but the SDK poller now starts unconditionally whenever the GitHub adapter is enabled — the flag no longer gates anything (`cmd/pilot/poller_github.go`).
- Adds a `CheckDeprecations()` warning surfaced at config-load/startup telling operators the field is deprecated/ignored and safe to remove.
- Existing configs (flag `true`, `false`, or omitted) continue to load without error.

Closes #4171 (sub-issue of #4155).

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 ./internal/config/... ./cmd/pilot/...`
- [x] `TestLoadWithDeprecatedUseSDKPoller` / `TestCheckDeprecations` cover both flag states and confirm the warning text