### PR TITLE
fix(autopilot): scheduled release train can never fire on a repo with zero tags

### DIFF
--- a/.agent/sops/autopilot/release-train-first-release-no-tags.md
+++ b/.agent/sops/autopilot/release-train-first-release-no-tags.md
@@ -1,0 +1,42 @@
+# Release train: first release on a repo with zero tags
+
+## Problem
+
+`scheduleReleaseTick` (`internal/autopilot/scope_schedule.go`) synthesizes
+`lastTag = tagPrefix + "0.0.0"` when `GetCurrentVersionForRepo` finds no
+release/tags to parse, then calls `CompareCommits(lastTag, branch)`. That
+synthesized ref was never created as a real git ref, so GitHub's compare API
+404s — every scheduled tick, forever. A repo with `release.trigger:
+on_schedule` and zero tags can never cut its first release (GH-4174).
+
+## Root Cause
+
+`GetCurrentVersionForRepo` returning the zero `SemVer{}` is overloaded: it
+means both "genuinely no tags exist" and "a lookup error occurred" (the
+caller defaults to `SemVer{}` on error too, pre-fix). Neither case has an
+actual `v0.0.0` ref to compare against. The bug is structural, not a retry
+target — retrying the same 404 forever does nothing.
+
+## Solution
+
+- `repoHasAnyTag` checks ref existence directly (`GetLatestRelease` +
+  `ListTags`) instead of inferring it from a zero `SemVer`.
+- When no tag exists, `firstReleaseTrainMembers` lists every merged PR via
+  `ListPullRequests(state=closed)` (filtered on `MergedAt != ""` — the
+  list endpoint doesn't populate the `merged` boolean, only the single-PR
+  GET does) and uses that as the definitive member set — no commit-message
+  `(#N)` suffix parsing needed, since we already have real PR numbers.
+- `trainReleaseCommits` (used later by `handleReleasing` to actually cut the
+  tag) has the same no-tag branch: falls back to `scopeReleaseCommits`'
+  member-PR commit union instead of `CompareCommits`.
+- Version is NOT special-cased: `currentVersion.Bump(bumpType)` in
+  `handleReleasing` already produces `v0.1.0`/`v1.0.0`/`v0.0.1` correctly
+  from the zero `SemVer` — that logic was never broken, only the commit
+  sourcing was.
+
+## Prevention
+
+Any new code path that derives `lastTag` from `GetCurrentVersionForRepo` and
+feeds it into `CompareCommits` must first confirm the tag/release actually
+exists. A "no prior release" repo is a first-class case, not an edge case —
+every fresh `on_schedule` repo starts here.

--- a/internal/autopilot/scope_schedule.go
+++ b/internal/autopilot/scope_schedule.go
@@ -194,36 +194,112 @@ func (c *Controller) scheduleReleaseTick(ctx context.Context, scheduledAt time.T
 	rel := c.resolvedRelease()
 	branch := c.resolveMainBranchName()
 
-	currentVersion, err := c.releaser.GetCurrentVersionForRepo(ctx, c.owner, c.repo)
+	hasTag, err := c.repoHasAnyTag(ctx, c.owner, c.repo)
 	if err != nil {
-		c.log.Warn("scheduleReleaseTick: failed to get current version, defaulting to 0.0.0", "error", err)
-		currentVersion = SemVer{}
-	}
-	lastTag := currentVersion.String(rel.TagPrefix)
-
-	commits, err := c.ghClient.CompareCommits(ctx, c.owner, c.repo, lastTag, branch)
-	if err != nil {
-		c.log.Warn("scheduleReleaseTick: failed to compare commits, skipping this tick",
-			"last_tag", lastTag, "branch", branch, "error", err)
-		return
-	}
-	if len(commits) == 0 {
-		c.log.Debug("scheduleReleaseTick: empty train, skipping",
-			"last_tag", lastTag, "scheduled_at", scheduledAt.Format(time.RFC3339))
+		c.log.Warn("scheduleReleaseTick: failed to check for an existing tag, skipping this tick", "error", err)
 		return
 	}
 
-	memberPRs := c.resolveTrainMemberPRs(ctx, commits)
-	if len(memberPRs) == 0 {
-		c.log.Warn("scheduleReleaseTick: no resolvable member PRs (direct-commit-only train), skipping — "+
-			"v1 limitation, the scope-release carrier requires a real merged PR",
-			"last_tag", lastTag, "commits", len(commits), "scheduled_at", scheduledAt.Format(time.RFC3339))
-		return
+	var memberPRs []int
+	if !hasTag {
+		// First release: no tag exists yet, so CompareCommits against a
+		// synthesized "v0.0.0" ref 404s every tick forever — that ref was
+		// never created (GH-4174). The merged-PR list is already the
+		// definitive member set for this case, so source it directly instead
+		// of parsing "(#N)" squash-title suffixes off a CompareCommits range
+		// that doesn't exist yet.
+		memberPRs, err = c.firstReleaseTrainMembers(ctx, c.owner, c.repo)
+		if err != nil {
+			c.log.Warn("scheduleReleaseTick: failed to list merged PRs for first release, skipping this tick", "error", err)
+			return
+		}
+		if len(memberPRs) == 0 {
+			c.log.Debug("scheduleReleaseTick: no merged PRs yet, skipping first release",
+				"scheduled_at", scheduledAt.Format(time.RFC3339))
+			return
+		}
+		c.log.Info("scheduleReleaseTick: first release train — no prior tag, releasing entire merged history",
+			"repo", fmt.Sprintf("%s/%s", c.owner, c.repo),
+			"members", memberPRs,
+			"scheduled_at", scheduledAt.Format(time.RFC3339),
+		)
+	} else {
+		currentVersion, verErr := c.releaser.GetCurrentVersionForRepo(ctx, c.owner, c.repo)
+		if verErr != nil {
+			c.log.Warn("scheduleReleaseTick: failed to get current version, skipping this tick", "error", verErr)
+			return
+		}
+		lastTag := currentVersion.String(rel.TagPrefix)
+
+		commits, cmpErr := c.ghClient.CompareCommits(ctx, c.owner, c.repo, lastTag, branch)
+		if cmpErr != nil {
+			c.log.Warn("scheduleReleaseTick: failed to compare commits, skipping this tick",
+				"last_tag", lastTag, "branch", branch, "error", cmpErr)
+			return
+		}
+		if len(commits) == 0 {
+			c.log.Debug("scheduleReleaseTick: empty train, skipping",
+				"last_tag", lastTag, "scheduled_at", scheduledAt.Format(time.RFC3339))
+			return
+		}
+
+		memberPRs = c.resolveTrainMemberPRs(ctx, commits)
+		if len(memberPRs) == 0 {
+			c.log.Warn("scheduleReleaseTick: no resolvable member PRs (direct-commit-only train), skipping — "+
+				"v1 limitation, the scope-release carrier requires a real merged PR",
+				"last_tag", lastTag, "commits", len(commits), "scheduled_at", scheduledAt.Format(time.RFC3339))
+			return
+		}
 	}
 
 	scopeKey := trainScopeKey(scheduledAt)
 	title := fmt.Sprintf("Release train %s", scheduledAt.Format("2006-01-02 15:04"))
 	c.enqueueScopeRelease(ctx, scopeKey, title, memberPRs)
+}
+
+// repoHasAnyTag reports whether owner/repo has at least one published
+// release or git tag. A repo synthesizes lastTag = tagPrefix + "0.0.0" when
+// GetCurrentVersionForRepo finds nothing to parse, but that string was never
+// created as an actual ref — CompareCommits against it 404s. This checks ref
+// existence directly rather than inferring it from a zero SemVer, since a
+// lookup failure also collapses to the same zero value (GH-4174).
+func (c *Controller) repoHasAnyTag(ctx context.Context, owner, repo string) (bool, error) {
+	release, err := c.ghClient.GetLatestRelease(ctx, owner, repo)
+	if err != nil {
+		return false, err
+	}
+	if release != nil {
+		return true, nil
+	}
+	tags, err := c.ghClient.ListTags(ctx, owner, repo, 1)
+	if err != nil {
+		return false, err
+	}
+	return len(tags) > 0, nil
+}
+
+// firstReleaseTrainMembers lists every merged PR in owner/repo as the member
+// set for a repo's first scheduled release train (GH-4174). Unlike
+// resolveTrainMemberPRs, this doesn't parse "(#N)" squash-title suffixes off
+// commit messages — those suffixes only ever land on the squashed commit
+// CompareCommits would return, and with no prior tag there is no
+// CompareCommits range to source that list from yet. The GitHub list-PRs
+// endpoint doesn't populate the `merged` boolean (only `merged_at`, unlike
+// the single-PR GET resolveTrainMemberPRs uses), so MergedAt is the signal
+// for "actually merged" vs. "closed without merging".
+func (c *Controller) firstReleaseTrainMembers(ctx context.Context, owner, repo string) ([]int, error) {
+	prs, err := c.ghClient.ListPullRequests(ctx, owner, repo, "closed")
+	if err != nil {
+		return nil, err
+	}
+	var members []int
+	for _, pr := range prs {
+		if pr == nil || pr.MergedAt == "" {
+			continue
+		}
+		members = append(members, pr.Number)
+	}
+	return dedupeSortInts(members), nil
 }
 
 // resolveTrainMemberPRs extracts "(#N)" squash-merge PR references from each
@@ -274,9 +350,21 @@ func (c *Controller) resolveTrainMemberPRs(ctx context.Context, commits []*githu
 // release: everything reachable from HeadSHA since the last tag. Unlike
 // scopeReleaseCommits (epic:/label: scopes, which union each member PR's own
 // commits), a release train is defined as "everything since the last tag" —
-// so it always reads directly off CompareCommits rather than the member
+// so it normally reads directly off CompareCommits rather than the member
 // list, which exists only for release-notes attribution (GH-3993).
+//
+// First release (no tag exists yet): lastTag has no corresponding ref to
+// compare against, so CompareCommits would 404 (GH-4174) — fall back to
+// scopeReleaseCommits' member-PR commit union instead, using the member list
+// scheduleReleaseTick already resolved via firstReleaseTrainMembers.
 func (c *Controller) trainReleaseCommits(ctx context.Context, owner, repo string, prState *PRState, currentVersion SemVer, rel *ReleaseConfig) ([]*github.Commit, error) {
+	hasTag, err := c.repoHasAnyTag(ctx, owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	if !hasTag {
+		return c.scopeReleaseCommits(ctx, owner, repo, prState, currentVersion, rel)
+	}
 	lastTag := currentVersion.String(rel.TagPrefix)
 	return c.ghClient.CompareCommits(ctx, owner, repo, lastTag, prState.HeadSHA)
 }

--- a/internal/autopilot/scope_schedule_test.go
+++ b/internal/autopilot/scope_schedule_test.go
@@ -182,6 +182,203 @@ func TestScheduleReleaseTick_DirectCommitOnlyTrain_NoRow(t *testing.T) {
 	}
 }
 
+// noTagScheduleTickServer builds a fake GitHub server for a repo with zero
+// releases and zero tags: /releases/latest 404s, /tags is empty, closedPRs
+// serves ListPullRequests(state=closed), and prCommits serves GetPRCommits
+// per member PR (keyed by PR number) for bump-type detection. Any
+// /compare/ hit fails the test outright — that's exactly the 404 loop
+// GH-4174 fixes, so the no-tags path must never reach it.
+func noTagScheduleTickServer(t *testing.T, closedPRs []*github.PullRequest, prCommits map[int][]*github.Commit) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(r.URL.Path, "/compare/"):
+			t.Errorf("unexpected CompareCommits call for a no-tags repo: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+		case strings.Contains(r.URL.Path, "/pulls/") && strings.HasSuffix(r.URL.Path, "/commits"):
+			var num int
+			_, _ = fmtSscanIssueNum(strings.Replace(strings.TrimSuffix(r.URL.Path, "/commits"), "/pulls/", "/issues/", 1), &num)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prCommits[num])
+		case strings.HasSuffix(r.URL.Path, "/pulls") && r.URL.Query().Get("state") == "closed":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(closedPRs)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+}
+
+// TestScheduleReleaseTick_NoTags covers the GH-4174 fix: a repo configured
+// for on_schedule that has never been tagged must not call CompareCommits
+// against the synthesized "v0.0.0" ref (which 404s every tick forever).
+// Table-driven over the no-tags and has-tags cases to also pin the
+// unchanged-behavior acceptance criterion.
+func TestScheduleReleaseTick_NoTags(t *testing.T) {
+	t.Run("zero tags, pending merged PRs: tick enqueues a first-release train instead of skipping", func(t *testing.T) {
+		closedPRs := []*github.PullRequest{
+			{Number: 10, Title: "feat: first thing", MergedAt: "2026-07-01T00:00:00Z"},
+			{Number: 11, Title: "closed without merging", MergedAt: ""},
+			{Number: 12, Title: "fix: second thing", MergedAt: "2026-07-02T00:00:00Z"},
+		}
+		server := noTagScheduleTickServer(t, closedPRs, nil)
+		defer server.Close()
+
+		c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
+
+		scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
+		c.scheduleReleaseTick(context.Background(), scheduledAt)
+
+		row, err := stateStore.GetScopeRelease("owner/repo", "train:2026-07-10T21:00:00Z")
+		if err != nil {
+			t.Fatalf("GetScopeRelease failed: %v", err)
+		}
+		if row == nil {
+			t.Fatal("expected a first-release train row to be enqueued instead of skipped")
+		}
+		if want := []int{10, 12}; !reflect.DeepEqual(row.MemberPRs, want) {
+			t.Errorf("members = %v, want %v (closed-without-merging PR #11 must be excluded)", row.MemberPRs, want)
+		}
+	})
+
+	t.Run("zero tags, no merged PRs yet: tick skips with no row", func(t *testing.T) {
+		server := noTagScheduleTickServer(t, nil, nil)
+		defer server.Close()
+
+		c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
+
+		scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
+		c.scheduleReleaseTick(context.Background(), scheduledAt)
+
+		rows, err := stateStore.ListScopeReleases("owner/repo", "pending", "releasing", "done", "failed")
+		if err != nil {
+			t.Fatalf("ListScopeReleases failed: %v", err)
+		}
+		if len(rows) != 0 {
+			t.Errorf("expected no rows when there are no merged PRs yet, got %d", len(rows))
+		}
+	})
+
+	t.Run("existing tags: behavior unchanged, still compares against the real last tag", func(t *testing.T) {
+		c1 := makeCommit("feat: add thing (#401)")
+		c1.SHA = "sha1"
+		server := scheduleTickServer(t, "v2.3.0", []*github.Commit{c1}, map[int]bool{401: true})
+		defer server.Close()
+
+		c, stateStore := newScheduleController(t, server.URL, "0 21 * * FRI")
+
+		scheduledAt := time.Date(2026, 7, 10, 21, 0, 0, 0, time.UTC)
+		c.scheduleReleaseTick(context.Background(), scheduledAt)
+
+		row, err := stateStore.GetScopeRelease("owner/repo", "train:2026-07-10T21:00:00Z")
+		if err != nil || row == nil {
+			t.Fatalf("expected a train row for a tagged repo, err=%v row=%v", err, row)
+		}
+		if want := []int{401}; !reflect.DeepEqual(row.MemberPRs, want) {
+			t.Errorf("members = %v, want %v", row.MemberPRs, want)
+		}
+	})
+}
+
+// TestHandleReleasing_TrainScope_NoTags_CutsFirstVersion covers the second
+// half of the GH-4174 fix: once scheduleReleaseTick enqueues a first-release
+// train, handleReleasing must actually be able to cut it — trainReleaseCommits
+// would otherwise hit the exact same CompareCommits(v0.0.0, head) 404 when
+// resolving commits for bump-type detection. Verifies the member-PR commit
+// union fallback lets a tag-less repo cut its very first release (v0.1.0 from
+// a "feat:" commit, since currentVersion is the zero SemVer).
+func TestHandleReleasing_TrainScope_NoTags_CutsFirstVersion(t *testing.T) {
+	commit55 := makeCommit("feat: add a thing")
+	commit55.SHA = "commit-55"
+	commit77 := makeCommit("fix: a bugfix")
+	commit77.SHA = "commit-77"
+
+	var gitRefPosts int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/owner/repo/branches/main":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"name": "main", "commit": map[string]string{"sha": "mainsha"}})
+		case strings.HasSuffix(r.URL.Path, "/releases/latest"):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+		case strings.HasSuffix(r.URL.Path, "/tags"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		case strings.Contains(r.URL.Path, "/compare/"):
+			// The reachability guard's CompareStatus also hits /compare/; serve
+			// it "identical" so the guard passes without this being mistaken
+			// for the CompareCommits call trainReleaseCommits must now avoid.
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "identical"})
+		case r.URL.Path == "/repos/owner/repo/pulls/55/commits":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{commit55})
+		case r.URL.Path == "/repos/owner/repo/pulls/77/commits":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]*github.Commit{commit77})
+		case strings.HasSuffix(r.URL.Path, "/git/refs"):
+			atomic.AddInt64(&gitRefPosts, 1)
+			w.WriteHeader(http.StatusCreated)
+		case strings.HasSuffix(r.URL.Path, "/releases/tags/v0.1.0"):
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(github.Release{TagName: "v0.1.0", HTMLURL: "https://github.com/owner/repo/releases/tag/v0.1.0"})
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}
+	}))
+	defer server.Close()
+
+	stateStore := newTestStateStore(t)
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.Environment = EnvStage
+	cfg.Release = &ReleaseConfig{
+		Enabled:       true,
+		Trigger:       "on_schedule",
+		TagPrefix:     "v",
+		RequireCI:     true,
+		Schedule:      "0 21 * * FRI",
+		VerifyRelease: boolPtr(false),
+	}
+
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.SetStateStore(stateStore)
+
+	prState := &PRState{
+		PRNumber:       999,
+		PRURL:          "https://github.com/owner/repo/pull/999",
+		ScopeKey:       "train:2026-07-10T21:00:00Z",
+		ScopeTitle:     "Release train 2026-07-10 21:00",
+		ScopeMemberPRs: []int{55, 77},
+		PostMergeSHA:   "commit-55",
+		Stage:          StageReleasing,
+	}
+
+	if err := c.handleReleasing(context.Background(), prState); err != nil {
+		t.Fatalf("handleReleasing failed: %v", err)
+	}
+
+	if got := atomic.LoadInt64(&gitRefPosts); got != 1 {
+		t.Errorf("git ref posts = %d, want 1 (first release must still cut a tag)", got)
+	}
+	if prState.Stage == StageFailed {
+		t.Errorf("prState unexpectedly failed: %s", prState.Error)
+	}
+	if prState.ReleaseVersion != "v0.1.0" {
+		t.Errorf("ReleaseVersion = %q, want v0.1.0 (zero SemVer bumped minor by the feat: commit)", prState.ReleaseVersion)
+	}
+}
+
 // TestAutoMerger_SquashTitleSuffix_ResolvesAsTrainMember is a regex
 // round-trip: it builds a squash-merge commit title via AutoMerger.MergePR's
 // actual production title-construction path, then feeds a commit carrying


### PR DESCRIPTION
## Summary

Fixes GH-4174: a repo configured with `release.trigger: on_schedule` and no existing tags could never cut its first release. `scheduleReleaseTick` synthesized `lastTag = "v0.0.0"` and called `CompareCommits(v0.0.0, branch)` against that nonexistent ref, 404ing every scheduled tick, forever (WARN-level, no alert).

## Changes

- `repoHasAnyTag` — checks tag/release existence directly (`GetLatestRelease` + `ListTags`), instead of inferring it from `GetCurrentVersionForRepo`'s zero `SemVer{}`, which is ambiguous between "genuinely no tags" and "lookup failed."
- `firstReleaseTrainMembers` — when no tag exists, sources the train's member PRs directly from `ListPullRequests(state=closed)` (filtered on `MergedAt`) instead of parsing `(#N)` squash-title suffixes off a `CompareCommits` range that can't exist yet.
- `trainReleaseCommits` — same no-tag fallback, reusing `scopeReleaseCommits`' member-PR commit union so `handleReleasing` can actually cut the tag once the train is enqueued.
- Version selection is unchanged: `currentVersion.Bump(bumpType)` in `handleReleasing` already produces `v0.1.0`/`v1.0.0`/`v0.0.1` correctly from the zero `SemVer` — only the commit/member sourcing was broken.
- SOP: `.agent/sops/autopilot/release-train-first-release-no-tags.md`.

## Test plan

- [x] `TestScheduleReleaseTick_NoTags` (table-driven): zero tags + pending merged PRs → enqueues a first-release train; zero tags + zero merged PRs → skips cleanly; existing tags → behavior unchanged.
- [x] `TestHandleReleasing_TrainScope_NoTags_CutsFirstVersion`: a no-tags repo's enqueued train actually cuts `v0.1.0` end-to-end through `handleReleasing`.
- [x] `go test -race ./internal/autopilot/...` green.
- [x] `golangci-lint run --new-from-rev=origin/main ./...` clean.