### PR TITLE
fix(autopilot): remove-label 404 is success; drop resolved closed epic parents from reconcile set

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -330,6 +330,17 @@ type Controller struct {
 	// (never skips) the eventual escalation.
 	epicVeto map[int]*epicCloseVetoTracking
 
+	// epicResolvedParents marks epic parent issue numbers reconcileEpicParent
+	// has already driven to a terminal state (closed, veto cleared, stale
+	// pilot-needs-clarification label confirmed removed or already absent),
+	// guarded by mu. reconcileEpicParents consults this to drop such parents
+	// from the candidate set on every later tick (GH-4179): without it, a
+	// closed parent whose label was already gone kept re-hitting RemoveLabel
+	// every poll tick forever, each call 404ing since there was nothing left
+	// to remove. In-memory only: a daemon restart re-derives it on the next
+	// pass at the cost of one redundant GetIssue+RemoveLabel per parent.
+	epicResolvedParents map[int]bool
+
 	// cachedBotLogin holds the authenticated GitHub login for the Pilot token.
 	// Populated lazily by getBotLogin; protected by mu. GH-3417.
 	cachedBotLogin string
@@ -361,6 +372,7 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 		alertedPersistFailures: make(map[int]bool),
 		persistFailedPRs:       make(map[int]time.Time),
 		epicVeto:               make(map[int]*epicCloseVetoTracking),
+		epicResolvedParents:    make(map[int]bool),
 	}
 
 	// Options must apply before the releaser is constructed below: the

--- a/internal/autopilot/epic_reconcile.go
+++ b/internal/autopilot/epic_reconcile.go
@@ -321,8 +321,31 @@ func (c *Controller) verifyChildrenShippedForClose(ctx context.Context, parentNu
 // the next restart.
 func (c *Controller) reconcileEpicParents(ctx context.Context) {
 	for _, parentNum := range c.epicParentCandidates(ctx) {
+		if c.isEpicParentResolved(parentNum) {
+			// GH-4179: already driven to a terminal state on a prior tick
+			// (closed, veto cleared, stale label confirmed gone) — nothing
+			// left to reconcile, so skip without even a GetIssue call.
+			continue
+		}
 		c.reconcileEpicParent(ctx, parentNum)
 	}
+}
+
+// isEpicParentResolved reports whether parentNum was already fully reconciled
+// to a terminal state on a prior tick (see epicResolvedParents).
+func (c *Controller) isEpicParentResolved(parentNum int) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.epicResolvedParents[parentNum]
+}
+
+// markEpicParentResolved records that parentNum has nothing left to
+// reconcile, so reconcileEpicParents drops it from the candidate set on
+// every subsequent tick (see epicResolvedParents).
+func (c *Controller) markEpicParentResolved(parentNum int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.epicResolvedParents[parentNum] = true
 }
 
 // epicParentCandidates merges the two independent epic-parent discovery
@@ -454,9 +477,19 @@ func (c *Controller) reconcileEpicParent(ctx context.Context, parentNum int) {
 		c.log.Debug("reconcileEpicParents: parent already closed, skipping veto/escalation", slog.Int("parent", parentNum))
 		c.clearEpicCloseVeto(ctx, parentNum)
 		if err := c.ghClient.RemoveLabel(ctx, c.owner, c.repo, parentNum, github.LabelNeedsClarification); err != nil {
-			c.log.Warn("reconcileEpicParents: failed to remove stale needs-clarification label",
-				slog.Int("parent", parentNum), slog.Any("error", err))
+			if !isNotFoundError(err) {
+				c.log.Warn("reconcileEpicParents: failed to remove stale needs-clarification label",
+					slog.Int("parent", parentNum), slog.Any("error", err))
+				return
+			}
+			// GH-4179: 404 means the label is already gone — the desired
+			// end state already holds, not a failure. Fall through and mark
+			// this parent resolved instead of retrying the same removal
+			// every tick forever.
+			c.log.Debug("reconcileEpicParents: stale needs-clarification label already absent",
+				slog.Int("parent", parentNum))
 		}
+		c.markEpicParentResolved(parentNum)
 		return
 	}
 

--- a/internal/autopilot/epic_reconcile_test.go
+++ b/internal/autopilot/epic_reconcile_test.go
@@ -37,12 +37,15 @@ func TestReconcileEpicParent(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		parentState   string
-		children      []child
-		execStatuses  map[string]string
-		wantClosed    bool
-		wantVetoChild int // 0 if no veto expected
+		name              string
+		parentState       string
+		children          []child
+		execStatuses      map[string]string
+		labelDeleteStatus int // 0 => 200 OK; set to simulate a non-2xx RemoveLabel response
+		wantClosed        bool
+		wantVetoChild     int  // 0 if no veto expected
+		wantResolved      bool // only meaningful for already-closed-parent cases
+		wantWarnLabelFail bool // expect the "failed to remove stale needs-clarification label" WARN
 	}{
 		{
 			name:        "a: all children merged - parent closes within one poll cycle",
@@ -79,7 +82,30 @@ func TestReconcileEpicParent(t *testing.T) {
 				{num: 1, closed: true, merged: true},
 				{num: 2, closed: true, merged: true},
 			},
-			wantClosed: false,
+			wantClosed:   false,
+			wantResolved: true,
+		},
+		{
+			name:        "e: parent already closed, stale label already gone (404) - no WARN, marked resolved",
+			parentState: "closed",
+			children: []child{
+				{num: 1, closed: true, merged: true},
+			},
+			labelDeleteStatus: http.StatusNotFound,
+			wantClosed:        false,
+			wantResolved:      true,
+			wantWarnLabelFail: false,
+		},
+		{
+			name:        "f: parent already closed, label removal fails for real - WARN, not resolved (retries next tick)",
+			parentState: "closed",
+			children: []child{
+				{num: 1, closed: true, merged: true},
+			},
+			labelDeleteStatus: http.StatusInternalServerError,
+			wantClosed:        false,
+			wantResolved:      false,
+			wantWarnLabelFail: true,
 		},
 		{
 			name:        "closed child with no_op ledger status counts as shipped",
@@ -167,7 +193,14 @@ func TestReconcileEpicParent(t *testing.T) {
 					_, _ = w.Write([]byte("[]"))
 
 				case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, fmt.Sprintf("/repos/owner/repo/issues/%d/labels/", parentNum)):
-					w.WriteHeader(http.StatusOK)
+					status := tt.labelDeleteStatus
+					if status == 0 {
+						status = http.StatusOK
+					}
+					w.WriteHeader(status)
+					if status == http.StatusNotFound {
+						_, _ = w.Write([]byte(`{"message":"Label does not exist","documentation_url":"https://docs.github.com/rest"}`))
+					}
 
 				case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d/comments", parentNum):
 					b, _ := json.Marshal(map[string]interface{}{"id": 1})
@@ -207,7 +240,17 @@ func TestReconcileEpicParent(t *testing.T) {
 				t.Errorf("pilot-done label added = %v, want %v", addLabelsCalled, tt.wantClosed)
 			}
 
+			if tt.parentState == "closed" {
+				if got := c.isEpicParentResolved(parentNum); got != tt.wantResolved {
+					t.Errorf("isEpicParentResolved = %v, want %v", got, tt.wantResolved)
+				}
+			}
+
 			logs := logBuf.String()
+			if strings.Contains(logs, "failed to remove stale needs-clarification label") != tt.wantWarnLabelFail {
+				t.Errorf("WARN for stale label removal present = %v, want %v; logs:\n%s",
+					strings.Contains(logs, "failed to remove stale needs-clarification label"), tt.wantWarnLabelFail, logs)
+			}
 			if tt.wantVetoChild != 0 {
 				if !strings.Contains(logs, "close vetoed") {
 					t.Errorf("expected a veto log line, got logs:\n%s", logs)
@@ -330,6 +373,79 @@ func TestReconcileEpicParents_Wrapper(t *testing.T) {
 
 	if !closeCalled {
 		t.Error("expected reconcileEpicParents to close the fully-shipped parent via the search-driven sweep")
+	}
+}
+
+// TestReconcileEpicParents_ClosedParentDroppedAfterResolution covers GH-4179:
+// a closed parent whose stale needs-clarification label 404s on removal must
+// not be re-processed on the next poll tick. The candidate-discovery source
+// keeps surfacing the same parent number every tick (body-marker discovery
+// isn't gated on parent state), so without the resolved-set short-circuit in
+// reconcileEpicParents, reconcileEpicParent would re-run GetIssue+RemoveLabel
+// (and re-log the WARN) forever.
+func TestReconcileEpicParents_ClosedParentDroppedAfterResolution(t *testing.T) {
+	const parentNum = 500
+	var getIssueCalls, removeLabelCalls int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			// Always surface parentNum as a candidate, on every tick — mirrors
+			// discoverBodyMarkerEpicParents not being gated on parent state.
+			resp := map[string]interface{}{
+				"data": map[string]interface{}{
+					"repository": map[string]interface{}{
+						"issues": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"number":           parentNum,
+									"subIssuesSummary": map[string]int{"total": 1, "completed": 1},
+								},
+							},
+						},
+					},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf("/repos/owner/repo/issues/%d", parentNum):
+			atomic.AddInt64(&getIssueCalls, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"node_id":"I_parent","number":%d,"state":"closed"}`, parentNum)
+
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, fmt.Sprintf("/repos/owner/repo/issues/%d/labels/", parentNum)):
+			atomic.AddInt64(&removeLabelCalls, 1)
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Label does not exist","documentation_url":"https://docs.github.com/rest"}`))
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+	c.log = slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	c.reconcileEpicParents(context.Background())
+	if getIssueCalls != 1 || removeLabelCalls != 1 {
+		t.Fatalf("first tick: getIssueCalls=%d removeLabelCalls=%d, want 1/1", getIssueCalls, removeLabelCalls)
+	}
+	if !c.isEpicParentResolved(parentNum) {
+		t.Fatal("expected parent to be marked resolved after first tick")
+	}
+
+	c.reconcileEpicParents(context.Background())
+	if getIssueCalls != 1 || removeLabelCalls != 1 {
+		t.Errorf("second tick made new API calls: getIssueCalls=%d removeLabelCalls=%d, want unchanged 1/1", getIssueCalls, removeLabelCalls)
+	}
+
+	if strings.Contains(logBuf.String(), "failed to remove stale needs-clarification label") {
+		t.Errorf("did not expect the stale-label WARN, got logs:\n%s", logBuf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes GH-4179: `reconcileEpicParent`'s closed-parent cleanup path treated a stale-label-removal 404 ("Label does not exist") as a failure, WARNing and re-attempting the identical `RemoveLabel` call on every poll tick forever. studio-sdk's `RemoveLabel` only swallows a 404 whose body is exactly empty (`"API error (status 404): "`); real GitHub 404 bodies (e.g. `{"message":"Label does not exist", ...}`) don't match that exact string and propagate as an error.
- The reconciler now uses the existing `isNotFoundError` status-code check (substring match on `"status 404"`, not exact string) to detect this case, logs at Debug (not WARN), and does not retry.
- Once a closed parent's veto is cleared and its stale label is confirmed removed/absent, it's marked resolved in a new `epicResolvedParents` in-memory set. `reconcileEpicParents` now skips resolved parents before even issuing a `GetIssue` call, so a closed, fully-reconciled parent drops out of the reconcile set entirely instead of being re-examined every tick.
- Non-404 `RemoveLabel` errors still WARN and are not marked resolved, so they retry next tick as before (regression guard).

## Test plan
- [x] `go test -race ./internal/autopilot/...` green
- [x] Table-driven cases in `TestReconcileEpicParent`: 404-on-remove → no WARN, marked resolved; non-404 error → WARN, not resolved (regression guard)
- [x] New `TestReconcileEpicParents_ClosedParentDroppedAfterResolution`: candidate discovery keeps surfacing the same closed parent every tick; asserts zero additional `GetIssue`/`RemoveLabel` calls on the second tick
- [x] `go build ./...`, `golangci-lint run --new-from-rev=origin/main ./...` clean