### PR TITLE
fix(github): closed-issue gate wins over status-label retry re-arm

### DIFF
--- a/internal/adapters/github/poller.go
+++ b/internal/adapters/github/poller.go
@@ -1011,6 +1011,14 @@ func (p *Poller) findOldestUnprocessedIssue(ctx context.Context) (*Issue, error)
 
 		// If processed but no status labels, allow retry (pilot-failed was removed)
 		if processed {
+			// GH-4183: A closed issue is terminal — never re-arm regardless of
+			// label presence/absence. Reuses the issue payload already fetched
+			// this cycle; no extra API call (mem-048).
+			if issue.State == StateClosed {
+				p.logger.Debug("skipping closed issue", slog.Int("number", issue.Number))
+				continue
+			}
+
 			// GH-2201: Check grace period before allowing retry
 			if p.retryGracePeriod > 0 && time.Since(processedAt) < p.retryGracePeriod {
 				p.logger.Debug("Issue within retry grace period, skipping",
@@ -1427,6 +1435,15 @@ func (p *Poller) checkForNewIssues(ctx context.Context) {
 
 		// If processed but no status labels, allow retry (pilot-failed was removed)
 		if processed {
+			// GH-4183: A closed issue is terminal — never re-arm regardless of
+			// label presence/absence. Reuses the issue payload already fetched
+			// this cycle; no extra API call (mem-048).
+			if issue.State == StateClosed {
+				p.logger.Debug("skipping closed issue", slog.Int("number", issue.Number))
+				p.recordSkip(skipreason.ReasonClosedIssue)
+				continue
+			}
+
 			// GH-2201: Check grace period before allowing retry
 			if p.retryGracePeriod > 0 && time.Since(processedAt) < p.retryGracePeriod {
 				p.logger.Debug("Issue within retry grace period, skipping",

--- a/internal/adapters/github/poller_test.go
+++ b/internal/adapters/github/poller_test.go
@@ -819,6 +819,84 @@ func TestPoller_FindOldestUnprocessedIssue_AllowsRetryWhenFailedLabelRemoved(t *
 	}
 }
 
+// TestPoller_FindOldestUnprocessedIssue_ClosedIssueGate covers GH-4183: a
+// closed issue is terminal and must never be re-armed for retry by the
+// "status labels removed" path, regardless of whether it still carries a
+// (non-blocking) label. Only an open, previously-processed issue should be
+// picked back up.
+func TestPoller_FindOldestUnprocessedIssue_ClosedIssueGate(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name         string
+		state        string
+		labels       []Label
+		wantDispatch bool
+	}{
+		{
+			name:         "closed issue with missing status label is skipped",
+			state:        StateClosed,
+			labels:       []Label{{Name: "pilot"}},
+			wantDispatch: false,
+		},
+		{
+			name:         "closed issue with present status label is skipped",
+			state:        StateClosed,
+			labels:       []Label{{Name: "pilot"}, {Name: "bug"}},
+			wantDispatch: false,
+		},
+		{
+			name:         "open issue with missing status label dispatches",
+			state:        StateOpen,
+			labels:       []Label{{Name: "pilot"}},
+			wantDispatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := []*Issue{
+				{Number: 1, Title: "Issue 1", State: tt.state, Labels: tt.labels, CreatedAt: now},
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(issues)
+			}))
+			defer server.Close()
+
+			client := NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			poller, _ := NewPoller(client, "owner/repo", "pilot", 30*time.Second,
+				WithRetryGracePeriod(0), // GH-2201: disable grace period for test
+			)
+
+			// Simulate: issue was processed by a prior poll cycle.
+			poller.markProcessed(1)
+
+			issue, err := poller.findOldestUnprocessedIssue(context.Background())
+			if err != nil {
+				t.Fatalf("findOldestUnprocessedIssue() error = %v", err)
+			}
+
+			if tt.wantDispatch {
+				if issue == nil {
+					t.Fatal("issue should not be nil - open issue should be re-armed for retry")
+				}
+				if poller.IsProcessed(1) {
+					t.Error("issue #1 should no longer be marked as processed after re-arm")
+				}
+			} else {
+				if issue != nil {
+					t.Fatalf("issue should be nil - closed issue is terminal, got #%d", issue.Number)
+				}
+				if !poller.IsProcessed(1) {
+					t.Error("issue #1 should remain marked as processed - closed issue must not be re-armed")
+				}
+			}
+		})
+	}
+}
+
 func TestPoller_FindOldestUnprocessedIssue_SkipsInProgress(t *testing.T) {
 	now := time.Now()
 	issues := []*Issue{

--- a/internal/adapters/skipreason/skipreason.go
+++ b/internal/adapters/skipreason/skipreason.go
@@ -22,6 +22,7 @@ const (
 	ReasonPreFlightReject    = "pre_flight_reject"
 	ReasonStatusLabel        = "status_label" // GitLab combined in_progress/done/failed
 	ReasonStatusTag          = "status_tag"   // Azure DevOps combined in_progress/done/failed
+	ReasonClosedIssue        = "closed_issue" // GH-4183: closed issue is terminal, never re-arm
 )
 
 // PollerMetricsRecorder records poller dispatch/skip counters.


### PR DESCRIPTION
## Summary
- The "status labels removed, allowing retry" re-arm path in `internal/adapters/github/poller.go` did not check `issue.State`, so a closed issue whose terminal status label (e.g. `pilot-failed`) was removed could be re-dispatched.
- Both the sequential (`findOldestUnprocessedIssue`) and parallel (`checkForNewIssues`) retry paths now check `issue.State == StateClosed` first and skip with a debug log ("skipping closed issue") before ever considering label state, reusing the already-fetched issue payload (no extra API call per mem-048).
- Added `skipreason.ReasonClosedIssue` for the parallel path's skip-reason tracking.

## Test plan
- [x] `TestPoller_FindOldestUnprocessedIssue_ClosedIssueGate` — table-driven, covers closed+missing-label, closed+present-label, open+missing-label (dispatches)
- [x] `go test -race ./internal/adapters/github/...` passes