### PR TITLE
fix(executor): consult completed-execution ledger at every dispatch entry point

### DIFF
--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -886,6 +886,37 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 		exec := tasks[0]
 		w.currentTaskID.Store(exec.TaskID)
 
+		// GH-4184: consult the TASK-394 execution ledger at pickup time, not
+		// just at poll time. The 17:48->18:12 incident: the poller's re-arm
+		// guard (ExecutionChecker.HasCompletedExecution) saw no completion and
+		// queued a retry; the genuine completion landed in the ledger before
+		// the dispatcher got to this row, with no GitHub-side signal (labels,
+		// merged PR) yet visible to catch it. Re-checking the same ledger here
+		// closes that window regardless of what the poller observed earlier.
+		if done, err := w.hasTerminalSuccessLedger(exec.TaskID); err != nil {
+			w.log.Warn("Failed to check terminal-success ledger before pickup",
+				slog.String("execution_id", exec.ID),
+				slog.String("task_id", exec.TaskID),
+				slog.Any("error", err))
+		} else if done {
+			prURL := ""
+			if latest, gErr := w.store.GetLatestExecutionByTaskIDExcluding(exec.TaskID, exec.ID); gErr == nil && latest != nil {
+				prURL = latest.PRUrl
+			}
+			w.log.Info("Terminal-success ledger already has a completed row for task; refusing duplicate dispatch",
+				slog.String("execution_id", exec.ID),
+				slog.String("task_id", exec.TaskID),
+				slog.String("pr_url", prURL),
+			)
+			if err := w.store.MarkExecutionCompleted(exec.ID, prURL, "", 0); err != nil {
+				w.log.Error("Failed to mark ledger-guarded duplicate completed", slog.Any("error", err))
+			}
+			w.recordExecutionEvent(exec.ID, memory.StageCompleted, "terminal-success ledger guard: task already completed")
+			w.runner.EmitProgress(exec.TaskID, "Completed", 100, "already completed per execution ledger")
+			w.currentTaskID.Store("")
+			continue
+		}
+
 		w.log.Info("Processing task",
 			slog.String("execution_id", exec.ID),
 			slog.String("task_id", exec.TaskID),
@@ -1058,6 +1089,18 @@ func (w *ProjectWorker) recordExecutionEvent(executionID string, stage memory.St
 			slog.String("stage", string(stage)),
 			slog.Any("error", err))
 	}
+}
+
+// hasTerminalSuccessLedger reports whether the TASK-394 execution ledger
+// already holds a genuine completed row for taskID in this worker's project.
+// It is the single guard shared by both re-arm points: the poller's re-arm
+// path consults the identical ledger via ExecutionChecker.HasCompletedExecution
+// (internal/adapters/github/poller.go) at poll time, and processQueue calls
+// this method again immediately before pickup (GH-4184) — closing the window
+// where a completion lands between the poller's decision and the dispatcher
+// actually starting the backend.
+func (w *ProjectWorker) hasTerminalSuccessLedger(taskID string) (bool, error) {
+	return w.store.HasCompletedExecution(taskID, w.projectPath)
 }
 
 // dispatchSuccessStage reports the execution_events Stage (and whether to

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -1017,6 +1017,84 @@ func TestProcessQueue_MergedPRPreflight_UnmergedBranchProceedsNormally(t *testin
 	}
 }
 
+// TestProcessQueue_TerminalSuccessLedger_SkipsBackend is the GH-4184
+// regression test for the 17:48->18:12 race: the poller's re-arm guard
+// decided "not yet completed" at poll time and let a retry queue; the
+// genuine completion landed in the TASK-394 execution ledger before the
+// dispatcher picked the duplicate row up, with no GitHub-side signal (no
+// status labels, no merged PR yet visible) to catch it. Seed the ledger
+// directly with a completed row and force the merged-PR preflight to report
+// nothing found — mimicking labels/state that were mutated away between poll
+// and pickup — so only the ledger guard itself can explain a skip.
+func TestProcessQueue_TerminalSuccessLedger_SkipsBackend(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	const projectPath = "/project-terminal-ledger"
+	const taskID = "GH-9001"
+	const priorPRURL = "https://github.com/qf-studio/pilot/pull/9001"
+
+	// Seed the ledger: a prior execution row for this task already completed
+	// with a real deliverable (the TASK-394 "running"->"completed" row).
+	priorExec := &memory.Execution{
+		ID:          "exec-terminal-success-prior",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "running",
+	}
+	if err := store.SaveExecution(priorExec); err != nil {
+		t.Fatalf("failed to save prior execution: %v", err)
+	}
+	if err := store.MarkExecutionCompleted(priorExec.ID, priorPRURL, "deadbeef", 1000); err != nil {
+		t.Fatalf("failed to mark prior execution completed: %v", err)
+	}
+
+	// A second, freshly queued row for the SAME task — the duplicate that
+	// reached dispatcher pickup after the poller's poll-time check missed
+	// the completion above.
+	dupExec := &memory.Execution{
+		ID:          "exec-terminal-success-dup",
+		TaskID:      taskID,
+		ProjectPath: projectPath,
+		Status:      "queued",
+		TaskBranch:  "pilot/GH-9001",
+	}
+	if err := store.SaveExecution(dupExec); err != nil {
+		t.Fatalf("failed to save duplicate execution: %v", err)
+	}
+
+	// Force the pre-existing merged-PR preflight to report nothing — even
+	// with that signal absent (mutated labels/state), the ledger guard alone
+	// must refuse to dispatch.
+	origCheck := mergedPRPreflightCheck
+	mergedPRPreflightCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+	defer func() { mergedPRPreflightCheck = origCheck }()
+
+	backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "should never run"}}
+	runner := NewRunnerWithBackend(backend)
+	worker := NewProjectWorker(projectPath, store, runner, slog.Default())
+
+	worker.processQueue(context.Background())
+
+	backend.mu.Lock()
+	count := backend.execCount
+	backend.mu.Unlock()
+	if count != 0 {
+		t.Errorf("expected zero backend invocations (terminal-success ledger guard), got %d", count)
+	}
+
+	got, err := store.GetExecution(dupExec.ID)
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if got.Status != "completed" {
+		t.Errorf("expected duplicate row status 'completed' (ledger-guarded), got %q", got.Status)
+	}
+	if got.PRUrl != priorPRURL {
+		t.Errorf("expected duplicate row to carry prior pr_url %q, got %q", priorPRURL, got.PRUrl)
+	}
+}
+
 func TestRecoverStaleTasks_RespectsThresholds(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
- Fixes GH-4184: the poller's re-arm guard consulted the TASK-394 execution ledger (`Store.HasCompletedExecution`) before queuing a retry, but the dispatcher's pickup path (`ProjectWorker.processQueue`) only checked GitHub-side signals (merged PR) before invoking the backend. A completion landing in the ledger between the poller's poll-time check and the dispatcher's pickup (the 17:48→18:12 sequence) went unseen and produced a duplicate execution.
- Adds `hasTerminalSuccessLedger(taskID)` on `ProjectWorker`, re-checked immediately before backend invocation. It delegates to the same `Store.HasCompletedExecution` guard the poller's re-arm path already consults — one canonical guard, backed by the same ledger, checked at both entry points.
- A queued duplicate whose task already has a genuine completed row is marked completed from the prior execution's PR URL and never re-executed.

## Test plan
- [x] New `TestProcessQueue_TerminalSuccessLedger_SkipsBackend`: seeds a terminal-success ledger row for a task, forces the merged-PR preflight to report nothing (mimicking labels/state mutated between poll and pickup), and asserts the dispatcher refuses to invoke the backend and marks the duplicate row completed with the prior PR URL
- [x] `go test -race ./internal/executor/...` green
- [x] `go build ./...`, `golangci-lint run --new-from-rev=origin/main ./...` clean