### PR TITLE
fix(executor): retire dashboard Monitor card on reconciled child success/no_op

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1725,6 +1725,18 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 // continue) applies unchanged; any other terminal status is a genuine
 // failure, reported with the tracked row's real Error message when the
 // original signal lacked one.
+//
+// GH-4185: the synchronous call this reconciles against already ran
+// executeWithOptions for taskID, which calls monitor.Start(taskID) (GH-3786
+// race) — so the dashboard Monitor entry is left in StatusRunning regardless
+// of which branch below fires. A normal (non-raced) completion retires that
+// entry via monitor.Complete/monitor.Fail once handleIssueGeneric's own
+// exec/result decision is known (cmd/pilot/handler_common.go step 7); since
+// this reconciled path returns its own decision straight to the epic loop
+// without ever going through that handler, it must retire the same Monitor
+// entry itself or the card is stuck showing "● running 100%" forever even
+// though the child is done. Mirrors handler_common.go's branch: nil error →
+// Complete, non-nil error → Fail.
 func (r *Runner) resolveChildTerminalOutcome(taskID, selfExecID, status string, result *ExecutionResult, execErr error) (*ExecutionResult, error) {
 	row, rowErr := r.logStore.GetLatestExecutionByTaskIDExcluding(taskID, selfExecID)
 	if rowErr != nil {
@@ -1740,6 +1752,9 @@ func (r *Runner) resolveChildTerminalOutcome(taskID, selfExecID, status string, 
 		}
 		r.log.Info("reconcileChildOutcome: child execution row reached terminal success after a synchronous failure signal; treating as succeeded",
 			"task_id", taskID, "status", status)
+		if r.monitor != nil {
+			r.monitor.Complete(taskID, synth.PRUrl)
+		}
 		return synth, nil
 	case "no_op":
 		synth := &ExecutionResult{TaskID: taskID, Success: false, Outcome: "no_op"}
@@ -1748,6 +1763,9 @@ func (r *Runner) resolveChildTerminalOutcome(taskID, selfExecID, status string, 
 		}
 		r.log.Info("reconcileChildOutcome: child execution row reached terminal no_op after a synchronous failure signal; treating as no-op",
 			"task_id", taskID, "status", status)
+		if r.monitor != nil {
+			r.monitor.Complete(taskID, "")
+		}
 		return synth, nil
 	default:
 		msg := ""
@@ -1766,6 +1784,9 @@ func (r *Runner) resolveChildTerminalOutcome(taskID, selfExecID, status string, 
 		}
 		result.Success = false
 		result.Error = msg
+		if r.monitor != nil {
+			r.monitor.Fail(taskID, msg)
+		}
 		return result, fmt.Errorf("child execution status=%s: %s", status, msg)
 	}
 }

--- a/internal/executor/epic_child_reconcile_test.go
+++ b/internal/executor/epic_child_reconcile_test.go
@@ -82,6 +82,80 @@ func TestExecuteSubIssues_ChildTransientFailureEventualSuccess(t *testing.T) {
 	}
 }
 
+// TestExecuteSubIssues_ReconciledSuccessRetiresMonitorCard is the GH-4185
+// regression test: executeWithOptions calls monitor.Start(taskID) for the
+// child's own synchronous attempt (GH-3786 race) before that attempt fails
+// and reconcileChildOutcome takes over. Because the reconciled-to-success
+// path (resolveChildTerminalOutcome's "completed" case) previously returned
+// straight to the epic loop without ever touching the Monitor, the child's
+// dashboard card was left stuck at StatusRunning forever — the phantom
+// "● running 100%" card — even though the child had actually finished. The
+// fix must retire that Monitor entry itself, the same way a normal
+// completion does (cmd/pilot/handler_common.go step 7: nil error → Complete).
+func TestExecuteSubIssues_ReconciledSuccessRetiresMonitorCard(t *testing.T) {
+	store, err := memory.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const taskID = "GH-101"
+	if err := store.SaveExecution(&memory.Execution{
+		ID:     "exec-101",
+		TaskID: taskID,
+		Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	issues := makeSubIssues(1, 101)
+	parent := &Task{ID: "GH-50", Title: "[epic] transient child failure"}
+
+	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		return &ExecutionResult{
+			TaskID:  task.ID,
+			Success: false,
+			Error:   "unknown: exit status 1",
+		}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+	runner.logStore = store
+	runner.childOutcomeReconcilePollInterval = 20 * time.Millisecond
+	runner.childOutcomeReconcileTimeout = 2 * time.Second
+
+	// Wire a real Monitor and simulate what executeWithOptions itself already
+	// does for the in-flight synchronous attempt: register + start the
+	// child's own card. This is the state left behind right before the
+	// synchronous call fails and reconcileChildOutcome kicks in.
+	monitor := NewMonitor()
+	monitor.Register(taskID, "Sub-issue 1", "https://github.com/owner/repo/issues/101")
+	monitor.Start(taskID)
+	runner.monitor = monitor
+
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		if mcErr := store.MarkExecutionCompleted("exec-101", "https://github.com/owner/repo/pull/9101", "sha-final", 1000); mcErr != nil {
+			t.Errorf("MarkExecutionCompleted: %v", mcErr)
+		}
+	}()
+
+	if err := runner.ExecuteSubIssues(context.Background(), parent, issues, parent.ProjectPath, ""); err != nil {
+		t.Fatalf("ExecuteSubIssues returned error, want nil (child eventually succeeded): %v", err)
+	}
+
+	state, ok := monitor.Get(taskID)
+	if !ok {
+		t.Fatalf("monitor has no entry for %s after reconciled success", taskID)
+	}
+	if state.Status != StatusCompleted {
+		t.Errorf("monitor status for %s = %q, want %q (phantom running card never retired)", taskID, state.Status, StatusCompleted)
+	}
+	if state.PRUrl != "https://github.com/owner/repo/pull/9101" {
+		t.Errorf("monitor PRUrl for %s = %q, want the reconciled child's PR URL", taskID, state.PRUrl)
+	}
+}
+
 // TestExecuteSubIssues_ChildFailureMessageSurfacesRealError verifies that
 // when a child's execution row reaches a genuine terminal failure, the
 // error the epic reports includes the row's real error message instead of


### PR DESCRIPTION
## Summary
- Fixes GH-4185: `reconcileChildOutcome`'s "treating as succeeded" / no_op resolution left a sub-issue's dashboard `Monitor` entry stuck at `StatusRunning` ("● running 100%") because `executeWithOptions` already called `monitor.Start(taskID)` for the raced synchronous attempt, and `resolveChildTerminalOutcome` never touched the Monitor afterward.
- `resolveChildTerminalOutcome` now retires the Monitor entry itself — `Complete` on "completed"/"no_op", `Fail` on genuine terminal failure — mirroring the nil-error → Complete / non-nil-error → Fail branch `cmd/pilot/handler_common.go` already uses for normal top-level completions.

## Test plan
- [x] Added `TestExecuteSubIssues_ReconciledSuccessRetiresMonitorCard`, which registers+starts a Monitor card (simulating `executeWithOptions`'s own `monitor.Start` call), reproduces the GH-3786 race (synchronous failure vs. a separately-tracked row reaching `completed`), and asserts the card transitions to `StatusCompleted` with the reconciled PR URL. Verified it fails on pre-fix code (`git stash` of `epic.go`) and passes with the fix.
- [x] `go test -race ./internal/executor/... ./cmd/pilot/...` — all green.
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/executor/...` — 0 issues.