### PR TITLE
feat(dashboard): wire grom-nav helpers into tui Model/Update/View

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -250,6 +250,7 @@
 | GoReleaser desktop artifact | ✅ | ci | - | - | Separate GH Actions workflow, macOS universal binary on release (v1.54.0, GH-1614) |
 | Dashboard git graph sizes | ✅ | dashboard | `g` key | - | Small/medium/large/hidden modes, auto-size by terminal width (v2.35.0, PR #1900) |
 | Dashboard responsive layout | ✅ | dashboard | - | - | Stacked layout on narrow terminals, full-width panels (v2.38.0, PR #1913) |
+| Dashboard spatial nav + zoom | ✅ | dashboard | `hjkl`/`tab`/`enter`/`esc` | - | grom-style spatial panel focus (`focusMove` over `computeLayout` rects) across queue/autopilot/history/logs/git; `enter` zooms the focused panel full-screen (uncapped lists, `j/k` + `g/G`, `enter`/`o` opens the selected item's URL); git graph visible by default on first frame; logs rebound to `L` (v2.237.0, TASK-399/GH-4203) |
 | History dedup | ✅ | desktop | - | - | Deduplicates execution records per issue, success takes priority (v1.62.0, GH-1663) |
 | WebSocket log streaming | ✅ | gateway | - | - | Real-time execution logs via WebSocket to web dashboard (v1.56.0, GH-1613) |
 | Epic-aware HISTORY panel | ✅ | dashboard | - | - | HISTORY panel shows epic decomposition info + sub-issue counts (v0.22.1) |

--- a/internal/dashboard/gitgraph.go
+++ b/internal/dashboard/gitgraph.go
@@ -597,7 +597,7 @@ func (m Model) renderGitGraph(opts ...int) string {
 // width. Focused state uses the accent (steel blue) border; unfocused slate.
 func (m Model) renderGraphPanel(title string, contentLines []string, totalWidth int) string {
 	chrome := panelChrome
-	if m.gitGraphFocus {
+	if m.focus == panelGit {
 		chrome = focusChrome
 	}
 	return renderPanelStyled(title, "", strings.Join(contentLines, "\n"), totalWidth, chrome)

--- a/internal/dashboard/gitgraph_test.go
+++ b/internal/dashboard/gitgraph_test.go
@@ -509,14 +509,14 @@ func TestRenderGitGraph_FocusedBorder(t *testing.T) {
 	m.gitGraphState = &GitGraphState{Lines: []GitGraphLine{{GraphChars: "● ", SHA: "abc1234", Message: "test"}}}
 
 	// Focused panel
-	m.gitGraphFocus = true
+	m.focus = panelGit
 	focused := m.renderGitGraph()
 	if focused == "" {
 		t.Error("focused panel should render non-empty")
 	}
 
 	// Unfocused panel
-	m.gitGraphFocus = false
+	m.focus = panelQueue
 	unfocused := m.renderGitGraph()
 	if unfocused == "" {
 		t.Error("unfocused panel should render non-empty")
@@ -554,45 +554,46 @@ func TestModelUpdate_GToggle(t *testing.T) {
 	}
 }
 
-// TestModelUpdate_TabFocus verifies Tab toggles focus when graph is visible.
+// TestModelUpdate_TabFocus verifies Tab cycles spatial focus across every
+// navigable panel in registry order (TASK-399: tab is the non-vim fallback
+// for hjkl focus movement, no longer a git-graph focus toggle).
 func TestModelUpdate_TabFocus(t *testing.T) {
-	m := NewModel("test")
-	m.gitGraphMode = GitGraphVisible
-	m.gitGraphFocus = false
+	m := NewModel("test") // git visible, logs shown by default — all 5 panels navigable
+	want := []panelID{panelAutopilot, panelHistory, panelLogs, panelGit, panelQueue}
 
-	updated, _ := m.Update(makeKey("tab"))
-	m = updated.(Model)
-	if !m.gitGraphFocus {
-		t.Error("Tab should set gitGraphFocus=true when graph is visible")
-	}
-
-	updated, _ = m.Update(makeKey("tab"))
-	m = updated.(Model)
-	if m.gitGraphFocus {
-		t.Error("second Tab should set gitGraphFocus=false")
+	for i, w := range want {
+		updated, _ := m.Update(makeKey("tab"))
+		m = updated.(Model)
+		if m.focus != w {
+			t.Errorf("tab #%d: focus = %v, want %v", i+1, m.focus, w)
+		}
 	}
 }
 
-// TestModelUpdate_TabNoFocusWhenHidden verifies Tab is a no-op when graph hidden.
+// TestModelUpdate_TabNoFocusWhenHidden verifies Tab skips the git panel when
+// the graph is hidden — it's excluded from navigablePanels().
 func TestModelUpdate_TabNoFocusWhenHidden(t *testing.T) {
 	m := NewModel("test")
 	m.gitGraphMode = GitGraphHidden
-	m.gitGraphFocus = false
+	m.focus = panelLogs // last navigable panel before git
 
 	updated, _ := m.Update(makeKey("tab"))
 	m = updated.(Model)
-	if m.gitGraphFocus {
-		t.Error("Tab should NOT toggle focus when graph is hidden")
+	if m.focus != panelQueue {
+		t.Errorf("tab from last panel with git hidden: focus = %v, want panelQueue (git skipped)", m.focus)
 	}
 }
 
-// TestModelUpdate_ScrollWhenFocused verifies j/k scroll the graph when focused.
+// TestModelUpdate_ScrollWhenFocused verifies j/k scroll the zoomed git graph
+// (TASK-399: grid-mode j/k now only moves spatial focus; git scrolling in
+// grid mode is ctrl+d/ctrl+u — see TestModelUpdate_HalfPageScroll below).
 func TestModelUpdate_ScrollWhenFocused(t *testing.T) {
 	m := NewModel("test")
 	m.gitGraphMode = GitGraphVisible
-	m.gitGraphFocus = true
-	m.gitGraphScroll = 5
-	m.height = 40 // viewport = 35
+	m.zoomed = true
+	m.focus = panelGit
+	m.zoomScroll = 5
+	m.height = 40
 	m.gitGraphState = &GitGraphState{
 		Lines: make([]GitGraphLine, 50),
 	}
@@ -600,25 +601,27 @@ func TestModelUpdate_ScrollWhenFocused(t *testing.T) {
 	// 'j' scrolls down
 	updated, _ := m.Update(makeKey("j"))
 	m = updated.(Model)
-	if m.gitGraphScroll != 6 {
-		t.Errorf("after j: scroll = %d, want 6", m.gitGraphScroll)
+	if m.zoomScroll != 6 {
+		t.Errorf("after j: scroll = %d, want 6", m.zoomScroll)
 	}
 
 	// 'k' scrolls up
 	updated, _ = m.Update(makeKey("k"))
 	m = updated.(Model)
-	if m.gitGraphScroll != 5 {
-		t.Errorf("after k: scroll = %d, want 5", m.gitGraphScroll)
+	if m.zoomScroll != 5 {
+		t.Errorf("after k: scroll = %d, want 5", m.zoomScroll)
 	}
 }
 
-// TestModelUpdate_ScrollBoundaries verifies scroll doesn't go out of bounds.
+// TestModelUpdate_ScrollBoundaries verifies zoomed git scroll doesn't go out
+// of bounds.
 func TestModelUpdate_ScrollBoundaries(t *testing.T) {
 	m := NewModel("test")
 	m.gitGraphMode = GitGraphVisible
-	m.gitGraphFocus = true
-	m.gitGraphScroll = 0
-	m.height = 8 // viewport = 3
+	m.zoomed = true
+	m.focus = panelGit
+	m.zoomScroll = 0
+	m.height = 8
 	m.gitGraphState = &GitGraphState{
 		Lines: make([]GitGraphLine, 5),
 	}
@@ -626,24 +629,30 @@ func TestModelUpdate_ScrollBoundaries(t *testing.T) {
 	// Can't scroll up past 0
 	updated, _ := m.Update(makeKey("k"))
 	m = updated.(Model)
-	if m.gitGraphScroll != 0 {
-		t.Errorf("scroll should stay at 0, got %d", m.gitGraphScroll)
+	if m.zoomScroll != 0 {
+		t.Errorf("scroll should stay at 0, got %d", m.zoomScroll)
 	}
 
-	// maxScroll = 5 - 3 = 2; can't scroll past that
-	m.gitGraphScroll = 2
+	// Can't scroll past the max offset
+	maxScroll := len(m.gitGraphState.Lines) - m.zoomListViewportH()
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	m.zoomScroll = maxScroll
 	updated, _ = m.Update(makeKey("j"))
 	m = updated.(Model)
-	if m.gitGraphScroll != 2 {
-		t.Errorf("scroll should stay at 2 (max), got %d", m.gitGraphScroll)
+	if m.zoomScroll != maxScroll {
+		t.Errorf("scroll should stay at %d (max), got %d", maxScroll, m.zoomScroll)
 	}
 }
 
-// TestModelUpdate_DashboardScrollWhenNotFocused verifies j/k select tasks when not focused.
+// TestModelUpdate_DashboardScrollWhenNotFocused verifies grid-mode j/k moves
+// spatial focus only — it no longer double-duties as task-list selection
+// (TASK-399 removed that coupling; task selection now happens via the
+// zoomed queue panel, see TestNav_ZoomedQueueOpensURL).
 func TestModelUpdate_DashboardScrollWhenNotFocused(t *testing.T) {
 	m := NewModel("test")
 	m.gitGraphMode = GitGraphVisible
-	m.gitGraphFocus = false
 	m.tasks = []TaskDisplay{
 		{ID: "1", Title: "Task A", Status: "running"},
 		{ID: "2", Title: "Task B", Status: "queued"},
@@ -652,19 +661,20 @@ func TestModelUpdate_DashboardScrollWhenNotFocused(t *testing.T) {
 
 	updated, _ := m.Update(makeKey("j"))
 	m = updated.(Model)
-	if m.selectedTask != 1 {
-		t.Errorf("j should move selectedTask to 1, got %d", m.selectedTask)
+	if m.selectedTask != 0 {
+		t.Errorf("grid-mode j should not change selectedTask, got %d", m.selectedTask)
 	}
 	if m.gitGraphScroll != 0 {
 		t.Errorf("gitGraphScroll should stay at 0, got %d", m.gitGraphScroll)
 	}
 }
 
-// TestModelUpdate_HalfPageScroll verifies Ctrl+D/Ctrl+U half-page scrolling.
+// TestModelUpdate_HalfPageScroll verifies Ctrl+D/Ctrl+U half-page scrolling
+// of the git graph in grid mode, gated on m.focus == panelGit.
 func TestModelUpdate_HalfPageScroll(t *testing.T) {
 	m := NewModel("test")
 	m.gitGraphMode = GitGraphVisible
-	m.gitGraphFocus = true
+	m.focus = panelGit
 	m.gitGraphScroll = 0
 	m.height = 40 // viewport = 35, half-page = 17
 	m.gitGraphState = &GitGraphState{
@@ -850,6 +860,11 @@ func TestSyncGitGraph_SwitchesProjectOnTaskChange(t *testing.T) {
 		{ID: "2", Title: "Task B", Status: "queued", ProjectPath: "/home/user/aso-generator", ProjectName: "aso-generator"},
 	}
 	m.selectedTask = 0
+	// TASK-399: task selection now happens via the zoomed queue panel, not
+	// grid-mode j/k (that only moves spatial focus).
+	m.zoomed = true
+	m.focus = panelQueue
+	m.zoomSel = 0
 
 	// Navigate down to task B (different project)
 	updated, cmd := m.Update(makeKey("j"))
@@ -883,6 +898,9 @@ func TestSyncGitGraph_NoRefreshWhenSameProject(t *testing.T) {
 		{ID: "2", Title: "Task B", Status: "queued", ProjectPath: "/home/user/pilot", ProjectName: "pilot"},
 	}
 	m.selectedTask = 0
+	m.zoomed = true
+	m.focus = panelQueue
+	m.zoomSel = 0
 
 	updated, cmd := m.Update(makeKey("j"))
 	m = updated.(Model)
@@ -952,6 +970,9 @@ func TestSyncGitGraph_UpNavigation(t *testing.T) {
 	m.selectedTask = 1
 	m.projectPath = "/home/user/aso-generator"
 	m.gitProjectName = "aso-generator"
+	m.zoomed = true
+	m.focus = panelQueue
+	m.zoomSel = 1
 
 	updated, cmd := m.Update(makeKey("k"))
 	m = updated.(Model)

--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -103,7 +103,8 @@ type autopilotController interface {
 // AutopilotPanel displays autopilot status in the dashboard.
 type AutopilotPanel struct {
 	controller autopilotController
-	panelWidth int // dynamic panel width, set before View()
+	panelWidth int  // dynamic panel width, set before View()
+	focused    bool // TASK-399: true when this panel holds spatial focus, set before View()
 }
 
 // NewAutopilotPanel creates an autopilot panel.
@@ -128,14 +129,18 @@ func (p *AutopilotPanel) View() string {
 		tw = panelTotalWidth
 	}
 	iw := tw - 4
+	chrome := panelChrome
+	if p.focused {
+		chrome = focusChrome
+	}
 
 	if p.controller == nil {
-		return renderPanel("autopilot", "  Disabled", tw)
+		return renderPanelStyled("autopilot", "", "  Disabled", tw, chrome)
 	}
 
 	prs := p.controller.GetActivePRs()
 	if len(prs) == 0 {
-		return renderPanel("autopilot", "  "+dimStyle.Render("idle · no active PR"), tw)
+		return renderPanelStyled("autopilot", "", "  "+dimStyle.Render("idle · no active PR"), tw, chrome)
 	}
 
 	cfg := p.controller.Config()
@@ -158,7 +163,21 @@ func (p *AutopilotPanel) View() string {
 		count = "1 pr"
 	}
 	legend := statusRunningStyle.Render("●") + " " + dimStyle.Render(count)
-	return renderPanelInfo("autopilot", legend, strings.Join(lines, "\n"), tw)
+	return renderPanelStyled("autopilot", legend, strings.Join(lines, "\n"), tw, chrome)
+}
+
+// sortedActivePRs returns the controller's active PRs sorted by PR number.
+// Used by the zoomed autopilot view: GetActivePRs iterates a map internally,
+// so raw order is nondeterministic across calls — sorting gives a stable
+// render order and lets selection be keyed by PR number instead of index
+// (TASK-399: "survives live-pull reorder").
+func (p *AutopilotPanel) sortedActivePRs() []*autopilot.PRState {
+	if p == nil || p.controller == nil {
+		return nil
+	}
+	prs := p.controller.GetActivePRs()
+	sort.Slice(prs, func(i, j int) bool { return prs[i].PRNumber < prs[j].PRNumber })
+	return prs
 }
 
 // pipelineStagePosition maps a PRStage to its 0-based position in the 5-node rail.
@@ -327,6 +346,10 @@ type CompletedTask struct {
 	// the store (e.g. AddCompletedTask callers) — the ladder renders as an
 	// empty track in that case.
 	Stage StageInfo
+	// PRUrl is the pull request URL for this execution (from Execution.PRUrl),
+	// used by the zoomed history panel's enter/o open-URL action. Empty when
+	// the task shipped without a PR or wasn't hydrated from the store.
+	PRUrl string
 }
 
 // UpdateInfo contains information about an available update
@@ -399,12 +422,31 @@ type Model struct {
 	gitGraphMode       GitGraphMode
 	gitGraphState      *GitGraphState
 	gitGraphScroll     int
-	gitGraphFocus      bool
 	dbSyncTick         int    // Counter for periodic DB re-sync (GH-2248)
 	projectPath        string // Working directory for git commands
 	defaultProjectPath string // Fallback project path from config (GH-2167)
 	metricsScopePath   string // Project path used to filter store/metrics queries (GH-3531)
 	gitProjectName     string // Current project name shown in git panel title (GH-2167)
+
+	// Spatial grid navigation (TASK-399): focus tracks the spatially-selected
+	// panel; zoomed opens it full-screen. See grid.go/panels.go/zoomlist.go.
+	focus       panelID
+	zoomed      bool
+	zoomSel     int
+	zoomScroll  int
+	zoomHistory []CompletedTask
+	// zoomAutopilotPR is the selected PR number in the zoomed autopilot list.
+	// Keyed by PR number rather than raw index because GetActivePRs iterates
+	// a map — a live-pull reorder between frames must not move the selection.
+	zoomAutopilotPR int
+	// zoomLogsFollow tracks tail-follow state for the zoomed logs panel:
+	// true (default) keeps the viewport pinned to the newest line as more
+	// arrive; scrolling up breaks follow, 'G' resumes it.
+	zoomLogsFollow bool
+
+	// browserOpener opens a URL in the default browser; defaults to
+	// openBrowser but is injectable so tests can capture opened URLs.
+	browserOpener func(string) error
 }
 
 // isStackedMode returns true when the git graph is visible and the terminal is
@@ -473,6 +515,9 @@ func NewModel(version string) Model {
 		costPerMToken:  3.0,
 		autopilotPanel: NewAutopilotPanel(nil), // Disabled by default
 		version:        version,
+		focus:          panelQueue,
+		gitGraphMode:   GitGraphVisible,
+		browserOpener:  openBrowser,
 	}
 }
 
@@ -489,6 +534,9 @@ func NewModelWithStore(version string, store *memory.Store) Model {
 		autopilotPanel: NewAutopilotPanel(nil),
 		version:        version,
 		store:          store,
+		focus:          panelQueue,
+		gitGraphMode:   GitGraphVisible,
+		browserOpener:  openBrowser,
 	}
 	m.hydrateFromStore()
 	return m
@@ -505,6 +553,9 @@ func NewModelWithAutopilot(version string, controller *autopilot.Controller) Mod
 		costPerMToken:  3.0,
 		autopilotPanel: NewAutopilotPanel(controller),
 		version:        version,
+		focus:          panelQueue,
+		gitGraphMode:   GitGraphVisible,
+		browserOpener:  openBrowser,
 	}
 }
 
@@ -520,6 +571,9 @@ func NewModelWithStoreAndAutopilot(version string, store *memory.Store, controll
 		autopilotPanel: NewAutopilotPanel(controller),
 		version:        version,
 		store:          store,
+		focus:          panelQueue,
+		gitGraphMode:   GitGraphVisible,
+		browserOpener:  openBrowser,
 	}
 	m.hydrateFromStore()
 	return m
@@ -608,6 +662,7 @@ func (m *Model) hydrateFromStore() {
 			CompletedAt: completedAt,
 			PeakRSSMB:   exec.PeakRSSMB,
 			Stage:       stageInfoForExecution(events, status),
+			PRUrl:       exec.PRUrl,
 		})
 	}
 
@@ -737,6 +792,9 @@ func NewModelWithOptions(version string, store *memory.Store, controller *autopi
 		version:        version,
 		store:          store,
 		upgradeCh:      upgradeCh,
+		focus:          panelQueue,
+		gitGraphMode:   GitGraphVisible,
+		browserOpener:  openBrowser,
 	}
 	m.hydrateFromStore()
 	return m
@@ -863,6 +921,11 @@ func (m Model) Init() tea.Cmd {
 	if m.splashActive {
 		cmds = append(cmds, splashTickCmd())
 	}
+	if m.gitGraphMode != GitGraphHidden {
+		// TASK-399: git graph is visible by default — paint it on the first
+		// frame instead of waiting for a manual 'g' toggle.
+		cmds = append(cmds, refreshGitGraphCmd(m.projectPath), gitRefreshTickCmd())
+	}
 	return tea.Batch(cmds...)
 }
 
@@ -918,6 +981,7 @@ func storeRefreshCmd(store *memory.Store, projectPath string) tea.Cmd {
 				CompletedAt: completedAt,
 				PeakRSSMB:   exec.PeakRSSMB,
 				Stage:       stageInfoForExecution(events, status),
+				PRUrl:       exec.PRUrl,
 			})
 		}
 
@@ -960,106 +1024,10 @@ func storeRefreshCmd(store *memory.Store, projectPath string) tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "ctrl+c":
-			m.quitting = true
-			return m, tea.Quit
-		case "b":
-			m.showBanner = !m.showBanner
-			return m, tea.ClearScreen
-		case "l":
-			m.showLogs = !m.showLogs
-			return m, tea.ClearScreen // GH-1249: Logs toggle changes height
-		case "g":
-			// Toggle git graph: Hidden ↔ Visible (auto-sizes)
-			if m.gitGraphMode == GitGraphHidden {
-				m.gitGraphMode = GitGraphVisible
-			} else {
-				m.gitGraphMode = GitGraphHidden
-			}
-			m.gitGraphFocus = false
-			if m.gitGraphMode != GitGraphHidden {
-				// Start refresh and 15s tick when becoming visible
-				return m, tea.Batch(
-					refreshGitGraphCmd(m.projectPath),
-					gitRefreshTickCmd(),
-					tea.ClearScreen,
-				)
-			}
-			return m, tea.ClearScreen
-		case "tab":
-			if m.gitGraphMode != GitGraphHidden {
-				m.gitGraphFocus = !m.gitGraphFocus
-			}
-		case "up", "k":
-			if m.gitGraphFocus {
-				if m.gitGraphScroll > 0 {
-					m.gitGraphScroll--
-				}
-			} else if m.selectedTask > 0 {
-				m.selectedTask--
-				if cmd := m.syncGitGraphToSelectedTask(); cmd != nil {
-					return m, cmd
-				}
-			}
-		case "down", "j":
-			if m.gitGraphFocus {
-				if m.gitGraphState != nil {
-					viewportH := m.gitGraphViewportHeight()
-					maxScroll := len(m.gitGraphState.Lines) - viewportH
-					if maxScroll < 0 {
-						maxScroll = 0
-					}
-					if m.gitGraphScroll < maxScroll {
-						m.gitGraphScroll++
-					}
-				}
-			} else if m.selectedTask < len(m.tasks)-1 {
-				m.selectedTask++
-				if cmd := m.syncGitGraphToSelectedTask(); cmd != nil {
-					return m, cmd
-				}
-			}
-		case "ctrl+d":
-			if m.gitGraphFocus && m.gitGraphState != nil {
-				viewportH := m.gitGraphViewportHeight()
-				m.gitGraphScroll += viewportH / 2
-				maxScroll := len(m.gitGraphState.Lines) - viewportH
-				if maxScroll < 0 {
-					maxScroll = 0
-				}
-				if m.gitGraphScroll > maxScroll {
-					m.gitGraphScroll = maxScroll
-				}
-			}
-		case "ctrl+u":
-			if m.gitGraphFocus {
-				viewportH := m.gitGraphViewportHeight()
-				m.gitGraphScroll -= viewportH / 2
-				if m.gitGraphScroll < 0 {
-					m.gitGraphScroll = 0
-				}
-			}
-		case "enter":
-			if m.selectedTask >= 0 && m.selectedTask < len(m.tasks) {
-				task := m.tasks[m.selectedTask]
-				if task.IssueURL != "" {
-					_ = openBrowser(task.IssueURL)
-				}
-			}
-		case "u":
-			// Trigger upgrade if update is available and not already upgrading
-			if m.updateInfo != nil && m.upgradeState == UpgradeStateAvailable && m.upgradeCh != nil {
-				m.upgradeState = UpgradeStateInProgress
-				m.upgradeProgress = 0
-				m.upgradeMessage = "Starting upgrade..."
-				// Non-blocking send to upgrade channel
-				select {
-				case m.upgradeCh <- struct{}{}:
-				default:
-				}
-			}
+		if m.zoomed {
+			return m.handleZoomedKey(msg)
 		}
+		return m.handleGridKey(msg)
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -1109,8 +1077,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case addLogMsg:
 		m.logs = append(m.logs, string(msg))
-		if len(m.logs) > 100 {
+		// TASK-399: zoomed logs shows up to 1000 lines (grid mode still tails
+		// a short window via renderLogs' capacity, independent of this cap).
+		if len(m.logs) > 1000 {
 			m.logs = m.logs[1:]
+		}
+		if m.zoomed && m.focus == panelLogs && m.zoomLogsFollow {
+			m.zoomScroll = m.logsMaxScroll()
 		}
 
 	case updateTokensMsg:
@@ -1167,9 +1140,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.completedTasks = msg.completedTasks
 		m.metricsCard = msg.metricsCard
 		m.loadMetricsHistory()
-		if len(m.completedTasks) != prevLen {
-			return m, tea.ClearScreen
+		// TASK-399: keep the zoomed history list in sync with the periodic
+		// DB re-sync while it's open, same as the grid-mode panel.
+		var zoomCmd tea.Cmd
+		if m.zoomed && m.focus == panelHistory {
+			zoomCmd = historyZoomCmd(m.store, m.metricsScopePath)
 		}
+		if len(m.completedTasks) != prevLen {
+			return m, tea.Batch(zoomCmd, tea.ClearScreen)
+		}
+		if zoomCmd != nil {
+			return m, zoomCmd
+		}
+
+	case historyZoomMsg:
+		m.zoomHistory = msg.tasks
 
 	case updateAvailableMsg:
 		m.updateInfo = &UpdateInfo{
@@ -1221,31 +1206,11 @@ func (m Model) View() string {
 		return m.renderSplash()
 	}
 
-	dashboard := m.renderDashboard()
-
 	var result string
-	if m.gitGraphMode == GitGraphHidden {
-		result = dashboard
-	} else if m.width > 0 && m.width < panelTotalWidth+1+20 {
-		// Terminal too narrow for side-by-side — stack graph below at full terminal width.
-		dashLines := strings.Count(dashboard, "\n") + 1
-		graphHeight := m.height - dashLines - 1 // -1 for help footer
-		if graphHeight < 8 {
-			graphHeight = 8 // minimum useful graph height
-		}
-		graphPanel := m.renderGitGraph(m.width, graphHeight)
-		if graphPanel == "" {
-			result = dashboard
-		} else {
-			result = dashboard + "\n" + graphPanel
-		}
+	if m.zoomed {
+		result = m.renderZoomed()
 	} else {
-		graphPanel := m.renderGitGraph()
-		if graphPanel == "" {
-			result = dashboard
-		} else {
-			result = lipgloss.JoinHorizontal(lipgloss.Top, dashboard, " ", graphPanel)
-		}
+		result = m.renderGrid()
 	}
 
 	// Help footer — appended after height truncation so it's never cut off.
@@ -1482,14 +1447,13 @@ func padTo(s string, w int) string {
 	return s + strings.Repeat(" ", w-visual)
 }
 
-// renderDashboard builds the left-side dashboard column (all existing panels).
-func (m Model) renderDashboard() string {
+// renderChromeHeader renders the non-navigable header chrome: banner, update
+// notice, metrics cards, and eval stats. This sits above the spatial grid
+// (TASK-399) and is never a focus target — computeLayout knows nothing
+// about it, so its height must be subtracted before computing panel rects
+// (see gridAvailHeight).
+func (m Model) renderChromeHeader() string {
 	var b strings.Builder
-
-	// Set effective panel width on autopilot panel for stacked mode
-	if m.autopilotPanel != nil {
-		m.autopilotPanel.panelWidth = m.effectivePanelTotalWidth()
-	}
 
 	// Header: bordered banner frame (GH-2455 / GH-2459).
 	// The ASCII logo is shown only during the splash; steady-state dashboard
@@ -1509,57 +1473,207 @@ func (m Model) renderDashboard() string {
 	b.WriteString(m.renderMetricsCards())
 	b.WriteString("\n")
 
-	// Tasks
-	b.WriteString(m.renderTasks())
-	b.WriteString("\n")
-
-	// Autopilot panel
-	b.WriteString(m.autopilotPanel.View())
-	b.WriteString("\n")
-
 	// Eval stats
 	if evalPanel := m.renderEvalStats(); evalPanel != "" {
 		b.WriteString(evalPanel)
 		b.WriteString("\n")
 	}
 
-	// History
-	b.WriteString(m.renderHistory())
-	b.WriteString("\n")
-
-	// Logs (if enabled) — the flex panel: stretches to the bottom of the
-	// terminal in full-width and side-by-side layouts. In stacked mode
-	// (narrow terminal, git graph below) it stays content-sized so the
-	// graph keeps its height; history/autopilot stay dynamic either way.
-	if m.showLogs {
-		flex := 0
-		if m.height > 1 && !m.isStackedMode() {
-			used := strings.Count(b.String(), "\n")
-			flex = m.height - 1 - used // reserve the help footer line
-		}
-		b.WriteString(m.renderLogs(flex))
-		b.WriteString("\n")
-	}
-
-	// Help footer rendered separately in View() to survive height truncation
-
 	return b.String()
 }
 
-// renderHelp returns a context-aware help footer that fits within panelTotalWidth (69 chars).
-// Keys shown depend on gitGraphMode and gitGraphFocus state.
+// gridAvailHeight returns the terminal height remaining for the spatial grid
+// (queue/autopilot/history/logs/git) after the chrome header and the help
+// footer's reserved line.
+func (m Model) gridAvailHeight() int {
+	if m.height <= 0 {
+		return 0
+	}
+	h := m.height - lineCount(m.renderChromeHeader())
+	if h < 0 {
+		h = 0
+	}
+	return h
+}
+
+// lineCount returns the number of lines s renders as (1 for "", N+1 for N
+// embedded newlines) — used to measure panel/header heights for layout.
+func lineCount(s string) int {
+	if s == "" {
+		return 0
+	}
+	return strings.Count(s, "\n") + 1
+}
+
+// buildGridPanels renders each navigable left-column panel's content and
+// measures its height, for feeding into computeLayout. Logs gets the same
+// flex-vs-content-sized treatment as the pre-wiring renderDashboard: it
+// stretches to fill remaining vertical space unless the layout is stacked
+// (narrow terminal, git graph below), where it stays content-sized so the
+// graph keeps its room.
+func (m Model) buildGridPanels() (layoutHeights, map[panelID]string) {
+	if m.autopilotPanel != nil {
+		m.autopilotPanel.panelWidth = m.effectivePanelTotalWidth()
+		m.autopilotPanel.focused = m.focus == panelAutopilot
+	}
+
+	contents := map[panelID]string{
+		panelQueue:     m.renderTasks(),
+		panelAutopilot: m.autopilotPanel.View(),
+		panelHistory:   m.renderHistory(),
+	}
+	var h layoutHeights
+	h.Queue = lineCount(contents[panelQueue])
+	h.Autopilot = lineCount(contents[panelAutopilot])
+	h.History = lineCount(contents[panelHistory])
+
+	if m.showLogs {
+		flex := 0
+		if !m.isStackedMode() {
+			availH := m.gridAvailHeight()
+			used := h.Queue + h.Autopilot + h.History
+			if remaining := availH - used; remaining >= logsFlexMinHeight {
+				flex = remaining
+			}
+		}
+		contents[panelLogs] = m.renderLogs(flex)
+		h.Logs = lineCount(contents[panelLogs])
+	}
+
+	return h, contents
+}
+
+// computeRects returns the current frame's panel rects (queue/autopilot/
+// history/logs/git), indexed identically to panelRegistry — feed directly
+// to focusMove.
+func (m Model) computeRects() []Rect {
+	heights, _ := m.buildGridPanels()
+	return computeLayout(m.width, m.gridAvailHeight(), heights, m.gitGraphMode != GitGraphHidden)
+}
+
+// navigablePanels returns the panelIDs currently eligible for spatial focus
+// — panelGit is excluded when hidden, panelLogs when toggled off.
+func (m Model) navigablePanels() []panelID {
+	ids := make([]panelID, 0, len(panelRegistry))
+	for _, p := range panelRegistry {
+		if p.ID == panelGit && m.gitGraphMode == GitGraphHidden {
+			continue
+		}
+		if p.ID == panelLogs && !m.showLogs {
+			continue
+		}
+		ids = append(ids, p.ID)
+	}
+	return ids
+}
+
+// moveFocus updates m.focus to the panel spatially nearest in direction dir
+// ('h'/'j'/'k'/'l'), restricted to currently-navigable panels.
+func (m *Model) moveFocus(dir byte) {
+	ids := m.navigablePanels()
+	if len(ids) == 0 {
+		return
+	}
+	all := m.computeRects()
+	rects := make([]Rect, len(ids))
+	cur := 0
+	for i, id := range ids {
+		rects[i] = all[panelIndex(id)]
+		if id == m.focus {
+			cur = i
+		}
+	}
+	next := focusMove(rects, cur, dir)
+	if next >= 0 && next < len(ids) {
+		m.focus = ids[next]
+	}
+}
+
+// renderDashboard builds the left-side dashboard column (all existing
+// panels, no git graph) — kept as the pure left-column renderer for
+// tests/callers that only want that piece.
+func (m Model) renderDashboard() string {
+	_, contents := m.buildGridPanels()
+
+	var b strings.Builder
+	b.WriteString(m.renderChromeHeader())
+	b.WriteString(contents[panelQueue])
+	b.WriteString("\n")
+	b.WriteString(contents[panelAutopilot])
+	b.WriteString("\n")
+	b.WriteString(contents[panelHistory])
+	b.WriteString("\n")
+	if m.showLogs {
+		b.WriteString(contents[panelLogs])
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// renderGrid composes the full non-zoomed frame: chrome header, the left
+// column (queue/autopilot/history/logs) placed via computeLayout, and the
+// git graph panel beside or beneath it. Replaces the three ad-hoc View()
+// layout branches (git hidden / stacked / side-by-side) with one geometry
+// pass (TASK-399).
+func (m Model) renderGrid() string {
+	header := m.renderChromeHeader()
+	heights, contents := m.buildGridPanels()
+	gitVisible := m.gitGraphMode != GitGraphHidden
+	rects := computeLayout(m.width, m.gridAvailHeight(), heights, gitVisible)
+
+	var left []string
+	for _, id := range []panelID{panelQueue, panelAutopilot, panelHistory} {
+		idx := panelIndex(id)
+		left = append(left, safeRender(panelRegistry[idx], rects[idx], contents[id]))
+	}
+	if m.showLogs {
+		idx := panelIndex(panelLogs)
+		left = append(left, safeRender(panelRegistry[idx], rects[idx], contents[panelLogs]))
+	}
+	// dashboardColumn includes the chrome header so side-by-side joining
+	// (below) matches every row — including the banner/metrics rows —
+	// against a git-panel row, keeping every composed line exactly m.width.
+	dashboardColumn := header + strings.Join(left, "\n")
+
+	if !gitVisible {
+		return dashboardColumn
+	}
+
+	gi := panelIndex(panelGit)
+	gr := rects[gi]
+	sideBySide := gr.X > 0
+	gitHeight := gr.H
+	if sideBySide {
+		// computeLayout's git height (gr.H) only spans the left-column panel
+		// stack, not the chrome header above it — stretch to the full
+		// dashboard column height so the join below covers every row.
+		gitHeight = lineCount(dashboardColumn)
+	}
+	gitPanel := m.renderGitGraph(gr.W, gitHeight)
+	if gitPanel == "" {
+		return dashboardColumn
+	}
+	if sideBySide {
+		return lipgloss.JoinHorizontal(lipgloss.Top, dashboardColumn, " ", gitPanel)
+	}
+	// Stacked below.
+	return dashboardColumn + "\n" + gitPanel
+}
+
+// renderHelp returns a context-aware help footer that fits within
+// effectivePanelTotalWidth. Grid mode shows spatial-navigation keys; zoomed
+// mode shows the list/scroll keys for the zoomed panel.
 func (m Model) renderHelp() string {
 	var parts []string
-	switch {
-	case m.gitGraphMode == GitGraphHidden:
-		// Graph hidden: show navigation and graph-open key
-		parts = []string{"q: quit", "l: logs", "b: banner", "g: graph", "j/k: select"}
-	case m.gitGraphFocus:
-		// Graph visible, graph panel focused
-		parts = []string{"q: quit", "b: banner", "g: close", "tab: dashboard"}
-	default:
-		// Graph visible, dashboard focused
-		parts = []string{"q: quit", "b: banner", "g: close", "tab: graph"}
+	if m.zoomed {
+		switch m.focus {
+		case panelQueue, panelAutopilot, panelHistory:
+			parts = []string{"q: quit", "esc: back", "j/k: move", "enter/o: open"}
+		default:
+			parts = []string{"q: quit", "esc: back", "j/k: scroll", "g/G: top/bottom"}
+		}
+	} else {
+		parts = []string{"q: quit", "hjkl: focus", "enter: zoom", "g: graph", "L: logs", "b: banner"}
 	}
 	help := strings.Join(parts, "  ")
 	tw := m.effectivePanelTotalWidth()
@@ -1781,16 +1895,7 @@ func (m Model) renderTasks() string {
 	if len(m.tasks) == 0 {
 		content.WriteString("  No tasks in queue")
 	} else {
-		// Sort by state priority, then by ID within same state
-		sorted := make([]TaskDisplay, len(m.tasks))
-		copy(sorted, m.tasks)
-		sort.SliceStable(sorted, func(i, j int) bool {
-			pi, pj := taskStatePriority(sorted[i].Status), taskStatePriority(sorted[j].Status)
-			if pi != pj {
-				return pi < pj
-			}
-			return sorted[i].ID < sorted[j].ID
-		})
+		sorted := m.sortedTasks()
 
 		queueIdx := 0 // position counter for queued items' "#N" label
 		for i, task := range sorted {
@@ -1823,7 +1928,27 @@ func (m Model) renderTasks() string {
 	}
 	info := strings.Join(segs, "  ")
 
-	return renderPanelInfo("queue", info, content.String(), m.effectivePanelTotalWidth())
+	chrome := panelChrome
+	if m.focus == panelQueue {
+		chrome = focusChrome
+	}
+	return renderPanelStyled("queue", info, content.String(), m.effectivePanelTotalWidth(), chrome)
+}
+
+// sortedTasks returns m.tasks sorted the same way renderTasks displays them
+// (state priority, then ID) — shared with the zoomed queue view so selection
+// indices refer to the same order the user sees.
+func (m Model) sortedTasks() []TaskDisplay {
+	sorted := make([]TaskDisplay, len(m.tasks))
+	copy(sorted, m.tasks)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		pi, pj := taskStatePriority(sorted[i].Status), taskStatePriority(sorted[j].Status)
+		if pi != pj {
+			return pi < pj
+		}
+		return sorted[i].ID < sorted[j].ID
+	})
+	return sorted
 }
 
 // renderTask renders a single task row with state-aware icons, bars, and meta.
@@ -2083,10 +2208,14 @@ func (m Model) renderHistory() string {
 	var content strings.Builder
 	tw := m.effectivePanelTotalWidth()
 	iw := tw - 4
+	chrome := panelChrome
+	if m.focus == panelHistory {
+		chrome = focusChrome
+	}
 
 	if len(m.completedTasks) == 0 {
 		content.WriteString("  No completed tasks yet")
-		return renderPanel("HISTORY", content.String(), tw)
+		return renderPanelStyled("HISTORY", "", content.String(), tw, chrome)
 	}
 
 	groups := m.groupedHistory()
@@ -2124,7 +2253,7 @@ func (m Model) renderHistory() string {
 		}
 	}
 
-	return renderPanel("HISTORY", content.String(), tw)
+	return renderPanelStyled("HISTORY", "", content.String(), tw, chrome)
 }
 
 // stageLabelWidth is the fixed column for the stage name after the ladder
@@ -2351,14 +2480,18 @@ func (m Model) renderLogs(flexHeight int) string {
 			lines = append(lines, "  "+truncateVisual(log, w))
 		}
 	}
+	chrome := panelChrome
+	if m.focus == panelLogs {
+		chrome = focusChrome
+	}
 	if flex {
 		for len(lines) < capacity {
 			lines = append(lines, "")
 		}
 		padded := "\n" + strings.Join(lines, "\n") + "\n"
-		return render.Panel("logs", padded, tw, flexHeight, panelChrome)
+		return render.Panel("logs", padded, tw, flexHeight, chrome)
 	}
-	return renderPanel("LOGS", strings.Join(lines, "\n"), tw)
+	return renderPanelStyled("LOGS", "", strings.Join(lines, "\n"), tw, chrome)
 }
 
 // updateMetricsCardMsg updates the metrics card data

--- a/internal/dashboard/tui_nav_test.go
+++ b/internal/dashboard/tui_nav_test.go
@@ -1,0 +1,369 @@
+package dashboard
+
+// TASK-399 acceptance tests: Update()/View()-level integration coverage for
+// grom-style spatial navigation and zoom — these are the guard that was
+// missing from TASK-398/#4200 (helpers merged and unit-tested, but never
+// wired into tui.go, so nothing actually shipped).
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/qf-studio/pilot/internal/autopilot"
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// navTestModel builds a Model with every panel populated (tasks, active PRs,
+// history, logs, git graph) for navigation tests that need all 5 panels
+// present and navigable.
+func navTestModel(width, height int) Model {
+	m := NewModel("test")
+	m.width = width
+	m.height = height
+	m.tasks = []TaskDisplay{
+		{ID: "GH-1", Title: "Task A", Status: "running", IssueURL: "https://example.com/issues/1"},
+		{ID: "GH-2", Title: "Task B", Status: "queued", IssueURL: "https://example.com/issues/2"},
+	}
+	m.autopilotPanel = &AutopilotPanel{controller: newFakeCtl([]*autopilot.PRState{
+		{PRNumber: 501, PRTitle: "fix: something", Stage: autopilot.StageWaitingCI, CreatedAt: time.Now()},
+	}, 3, nil)}
+	m.completedTasks = []CompletedTask{
+		{ID: "GH-3", Title: "Shipped", Status: "success", CompletedAt: time.Now()},
+	}
+	m.logs = []string{"[00:00] boot", "[00:01] ready"}
+	m.gitGraphMode = GitGraphVisible
+	m.gitGraphState = &GitGraphState{Lines: []GitGraphLine{
+		{GraphChars: "● ", SHA: "abc1234", Author: "Alice", Message: "initial commit"},
+	}}
+	return m
+}
+
+// TestNav_FocusMovesOnHJKL verifies h/j/k/l drive spatial focus movement via
+// focusMove over the current frame's panel rects.
+func TestNav_FocusMovesOnHJKL(t *testing.T) {
+	m := navTestModel(140, 50)
+	if m.focus != panelQueue {
+		t.Fatalf("initial focus = %v, want panelQueue", m.focus)
+	}
+
+	// l from the queue (left column) should land on the git panel — it's
+	// the only panel to the right in side-by-side layout.
+	updated, _ := m.Update(makeKey("l"))
+	m = updated.(Model)
+	if m.focus != panelGit {
+		t.Errorf("l from panelQueue: focus = %v, want panelGit", m.focus)
+	}
+
+	// h from the git panel should move back onto one of the left-column panels.
+	updated, _ = m.Update(makeKey("h"))
+	m = updated.(Model)
+	switch m.focus {
+	case panelQueue, panelAutopilot, panelHistory, panelLogs:
+		// ok — any left-column panel is spatially correct
+	default:
+		t.Errorf("h from panelGit: focus = %v, want a left-column panel", m.focus)
+	}
+
+	// j/k should walk down/up the left-column stack.
+	m.focus = panelQueue
+	updated, _ = m.Update(makeKey("j"))
+	m = updated.(Model)
+	if m.focus != panelAutopilot {
+		t.Errorf("j from panelQueue: focus = %v, want panelAutopilot", m.focus)
+	}
+	updated, _ = m.Update(makeKey("k"))
+	m = updated.(Model)
+	if m.focus != panelQueue {
+		t.Errorf("k from panelAutopilot: focus = %v, want panelQueue", m.focus)
+	}
+}
+
+// TestNav_EnterZoomsEscRestores verifies enter zooms the focused panel to
+// full screen (siblings absent from the render) and esc restores the grid
+// with focus/scroll intact.
+func TestNav_EnterZoomsEscRestores(t *testing.T) {
+	m := navTestModel(140, 50)
+	m.focus = panelQueue
+
+	updated, _ := m.Update(makeKey("enter"))
+	m = updated.(Model)
+	if !m.zoomed {
+		t.Fatal("enter should set zoomed=true")
+	}
+
+	out := stripANSI(m.View())
+	if !strings.Contains(out, "queue") {
+		t.Errorf("zoomed view missing the focused queue panel:\n%s", out)
+	}
+	for _, sibling := range []string{"autopilot", "history", "logs", "git graph"} {
+		if strings.Contains(out, sibling) {
+			t.Errorf("zoomed view should not render sibling panel %q:\n%s", sibling, out)
+		}
+	}
+
+	updated, _ = m.Update(makeKey("esc"))
+	m = updated.(Model)
+	if m.zoomed {
+		t.Error("esc should restore zoomed=false")
+	}
+	if m.focus != panelQueue {
+		t.Errorf("focus after esc = %v, want panelQueue (unchanged)", m.focus)
+	}
+}
+
+// TestNav_GitGraphVisibleOnFirstFrame verifies a freshly-constructed Model
+// defaults gitGraphMode to Visible and paints the git panel on the very
+// first View() — no manual 'g' press required.
+func TestNav_GitGraphVisibleOnFirstFrame(t *testing.T) {
+	m := NewModel("test")
+	if m.gitGraphMode != GitGraphVisible {
+		t.Fatalf("gitGraphMode on construction = %v, want GitGraphVisible", m.gitGraphMode)
+	}
+	if cmd := m.Init(); cmd == nil {
+		t.Error("Init() should batch a git-graph refresh when visible by default")
+	}
+
+	m.width = 140
+	m.height = 50
+	m.gitGraphState = &GitGraphState{Lines: []GitGraphLine{
+		{GraphChars: "● ", SHA: "abc1234", Message: "initial commit"},
+	}}
+
+	out := stripANSI(m.View())
+	if !strings.Contains(out, "git") {
+		t.Errorf("View() before any 'g' press should render the git panel:\n%s", out)
+	}
+}
+
+// TestNav_LogsRebind verifies 'L' toggles the logs panel and 'l' does NOT —
+// 'l' now moves spatial focus to the right.
+func TestNav_LogsRebind(t *testing.T) {
+	m := navTestModel(140, 50)
+	initial := m.showLogs
+
+	updated, _ := m.Update(makeKey("L"))
+	m = updated.(Model)
+	if m.showLogs != !initial {
+		t.Fatalf("L should toggle showLogs: got %v, want %v", m.showLogs, !initial)
+	}
+
+	afterL := m.showLogs
+	updated, _ = m.Update(makeKey("l"))
+	m = updated.(Model)
+	if m.showLogs != afterL {
+		t.Errorf("l should not toggle logs; showLogs changed from %v to %v", afterL, m.showLogs)
+	}
+}
+
+// TestNav_ZoomedQueueOpensURL verifies zooming the queue, selecting an item,
+// and pressing enter opens that item's IssueURL via the injected
+// browserOpener.
+func TestNav_ZoomedQueueOpensURL(t *testing.T) {
+	m := navTestModel(100, 40)
+	m.tasks = []TaskDisplay{
+		{ID: "GH-1", Title: "A", Status: "done", IssueURL: "https://example.com/1"},
+		{ID: "GH-2", Title: "B", Status: "done", IssueURL: "https://example.com/2"},
+		{ID: "GH-3", Title: "C", Status: "done", IssueURL: "https://example.com/3"},
+	}
+	var opened string
+	m.browserOpener = func(url string) error { opened = url; return nil }
+	m.focus = panelQueue
+	m.zoomed = true
+	m.zoomSel = 0
+
+	// Move to the second item, then open it.
+	updated, _ := m.Update(makeKey("j"))
+	m = updated.(Model)
+	updated, _ = m.Update(makeKey("enter"))
+	m = updated.(Model)
+
+	want := m.sortedTasks()[1].IssueURL
+	if opened != want {
+		t.Errorf("opened URL = %q, want %q (2nd sorted task)", opened, want)
+	}
+}
+
+// TestNav_ZoomedAutopilotUncapped verifies the zoomed autopilot panel lists
+// every active PR (no maxAutopilotRows cap) and that selection — keyed by PR
+// number, not index — survives a live-pull reorder (GetActivePRs iterates a
+// map, so raw order is nondeterministic between calls).
+func TestNav_ZoomedAutopilotUncapped(t *testing.T) {
+	prs := make([]*autopilot.PRState, 8)
+	for i := range prs {
+		prs[i] = &autopilot.PRState{
+			PRNumber:  100 + i,
+			PRTitle:   fmt.Sprintf("pr %d", i),
+			Stage:     autopilot.StageWaitingCI,
+			CreatedAt: time.Now(),
+		}
+	}
+	ctl := newFakeCtl(prs, 3, nil)
+
+	m := navTestModel(100, 60)
+	m.autopilotPanel = &AutopilotPanel{controller: ctl}
+	m.focus = panelAutopilot
+	m.zoomed = true
+	m.zoomAutopilotPR = 103
+
+	assertSelected := func(out string) {
+		t.Helper()
+		for _, line := range strings.Split(out, "\n") {
+			if strings.Contains(line, "#103") {
+				if !strings.Contains(line, "▸") {
+					t.Errorf("PR #103's row missing the selector marker: %q", line)
+				}
+				return
+			}
+		}
+		t.Error("PR #103 not found in zoomed autopilot output")
+	}
+
+	out := stripANSI(m.View())
+	for i := range prs {
+		want := fmt.Sprintf("#%d", 100+i)
+		if !strings.Contains(out, want) {
+			t.Errorf("zoomed autopilot missing PR %s (uncapped list)", want)
+		}
+	}
+	if strings.Contains(out, "more") {
+		t.Error("zoomed autopilot should not show a '+N more' cap")
+	}
+	assertSelected(out)
+
+	// Simulate a live-pull reorder.
+	ctl.prs = []*autopilot.PRState{prs[7], prs[0], prs[3], prs[1], prs[2], prs[4], prs[5], prs[6]}
+	assertSelected(stripANSI(m.View()))
+	if m.zoomAutopilotPR != 103 {
+		t.Errorf("selection PR number changed across reorder: %d, want 103", m.zoomAutopilotPR)
+	}
+}
+
+// TestNav_ZoomedHistoryUncapped verifies historyZoomCmd/historyZoomMsg pull
+// up to 100 distinct-by-task rows from the store — well past the grid
+// mode's 5-item cap.
+func TestNav_ZoomedHistoryUncapped(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pilot-dash-nav-history-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	const n = 30
+	for i := 0; i < n; i++ {
+		if err := store.SaveExecution(&memory.Execution{
+			ID:          fmt.Sprintf("exec-%02d", i),
+			TaskID:      fmt.Sprintf("TASK-%02d", i),
+			ProjectPath: "/test-nav-history",
+			Status:      "completed",
+			TaskTitle:   fmt.Sprintf("task %02d", i),
+		}); err != nil {
+			t.Fatalf("SaveExecution(%d): %v", i, err)
+		}
+	}
+
+	m := NewModelWithStore("test", store)
+	m.SetMetricsScopePath("/test-nav-history")
+	m.focus = panelHistory
+	m.zoomed = true
+
+	msg := historyZoomCmd(m.store, m.metricsScopePath)()
+	updated, _ := m.Update(msg)
+	m = updated.(Model)
+
+	if len(m.zoomHistory) != n {
+		t.Fatalf("zoomHistory len = %d, want %d", len(m.zoomHistory), n)
+	}
+}
+
+// TestNav_ZoomedLogsFollow verifies the zoomed logs panel tail-follows by
+// default, stops moving once the user scrolls up, and resumes on 'G'.
+func TestNav_ZoomedLogsFollow(t *testing.T) {
+	m := navTestModel(100, 30)
+	m.logs = nil
+	for i := 0; i < 50; i++ {
+		m.logs = append(m.logs, fmt.Sprintf("line %d", i))
+	}
+	m.focus = panelLogs
+	m.zoomed = true
+	m.zoomLogsFollow = true
+	m.zoomScroll = m.logsMaxScroll()
+
+	// Scroll up — breaks follow.
+	updated, _ := m.Update(makeKey("k"))
+	m = updated.(Model)
+	if m.zoomLogsFollow {
+		t.Fatal("scrolling up should break tail-follow")
+	}
+	scrollAfterUp := m.zoomScroll
+
+	// New lines arrive while scrolled up — the viewport must not move.
+	updated, _ = m.Update(addLogMsg("new line"))
+	m = updated.(Model)
+	if m.zoomScroll != scrollAfterUp {
+		t.Errorf("zoomScroll moved while scrolled up: got %d, want %d", m.zoomScroll, scrollAfterUp)
+	}
+
+	// 'G' resumes tail-follow and jumps back to the bottom.
+	updated, _ = m.Update(makeKey("G"))
+	m = updated.(Model)
+	if !m.zoomLogsFollow {
+		t.Error("G should resume tail-follow")
+	}
+	if m.zoomScroll != m.logsMaxScroll() {
+		t.Errorf("zoomScroll after G = %d, want max %d", m.zoomScroll, m.logsMaxScroll())
+	}
+}
+
+// TestNav_WidthInvariantMatrix verifies every composed line (grid and
+// zoomed, across every panel) is exactly m.width visual columns at a range
+// of terminal widths spanning stacked and side-by-side layouts. The help
+// footer is excluded: it intentionally renders at effectivePanelTotalWidth
+// (a fixed-width legend), not the full terminal width, in side-by-side mode.
+func TestNav_WidthInvariantMatrix(t *testing.T) {
+	widths := []int{80, 96, 140, 200}
+	panels := []panelID{panelQueue, panelAutopilot, panelHistory, panelLogs, panelGit}
+
+	for _, w := range widths {
+		t.Run(fmt.Sprintf("width=%d/grid", w), func(t *testing.T) {
+			m := navTestModel(w, 50)
+			checkLinesWidth(t, m.View(), w)
+		})
+		for _, p := range panels {
+			t.Run(fmt.Sprintf("width=%d/zoomed/%s", w, p), func(t *testing.T) {
+				m := navTestModel(w, 50)
+				m.zoomed = true
+				m.focus = p
+				checkLinesWidth(t, m.View(), w)
+			})
+		}
+	}
+}
+
+// checkLinesWidth asserts every non-blank line of out except the last (help
+// footer) is exactly w visual columns wide. Blank filler lines appended by
+// View()'s height-padding step are bare "" (not space-padded to width) —
+// pre-existing behavior, not part of this invariant (mirrors the same
+// skip in TestFullDashboardRender_WidthInvariants).
+func checkLinesWidth(t *testing.T, out string, w int) {
+	t.Helper()
+	lines := strings.Split(out, "\n")
+	for i, line := range lines[:len(lines)-1] {
+		if line == "" {
+			continue
+		}
+		if got := lipgloss.Width(line); got != w {
+			t.Errorf("line %d width = %d, want %d: %q", i, got, w, stripANSI(line))
+		}
+	}
+}

--- a/internal/dashboard/zoom.go
+++ b/internal/dashboard/zoom.go
@@ -1,0 +1,570 @@
+package dashboard
+
+// TASK-399: grid/zoomed key dispatch and zoomed-panel rendering. Consumes
+// the merged grid.go/panels.go/zoomlist.go helpers (TASK-398/#4200) to wire
+// spatial focus navigation and the "see everything" zoom view into the
+// dashboard's Update/View loop.
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/qf-studio/pilot/internal/autopilot"
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// indexOfPanel returns the position of id in ids, or -1 if absent.
+func indexOfPanel(ids []panelID, id panelID) int {
+	for i, v := range ids {
+		if v == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// clampInt clamps v to [lo, hi].
+func clampInt(v, lo, hi int) int {
+	if hi < lo {
+		hi = lo
+	}
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// minInt returns the smaller of a, b.
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// spliceSelector replaces a rendered row's leading 2-space indent with the
+// zoomlist selector marker, matching renderTask's own selector treatment.
+func spliceSelector(line string, selected bool) string {
+	if len(line) < 2 {
+		return line
+	}
+	return zoomListSelector(selected) + line[2:]
+}
+
+// zoomAutopilotIndex finds prNumber's position in prs, falling back to 0
+// when not found (e.g. the PR just left the active set) and -1 when prs is
+// empty.
+func zoomAutopilotIndex(prs []*autopilot.PRState, prNumber int) int {
+	for i, pr := range prs {
+		if pr.PRNumber == prNumber {
+			return i
+		}
+	}
+	if len(prs) > 0 {
+		return 0
+	}
+	return -1
+}
+
+// handleGridKey processes a key press while the dashboard is in grid
+// (non-zoomed) mode: spatial focus movement, panel toggles, and entering
+// zoom.
+func (m Model) handleGridKey(msg tea.KeyMsg) (Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+
+	case "b":
+		m.showBanner = !m.showBanner
+		return m, tea.ClearScreen // GH-1249: banner toggle changes height
+
+	case "L":
+		m.showLogs = !m.showLogs
+		if !m.showLogs && m.focus == panelLogs {
+			m.focus = panelQueue
+		}
+		return m, tea.ClearScreen // GH-1249: logs toggle changes height
+
+	case "g":
+		if m.gitGraphMode == GitGraphHidden {
+			m.gitGraphMode = GitGraphVisible
+			return m, tea.Batch(refreshGitGraphCmd(m.projectPath), gitRefreshTickCmd(), tea.ClearScreen)
+		}
+		m.gitGraphMode = GitGraphHidden
+		if m.focus == panelGit {
+			m.focus = panelQueue
+		}
+		return m, tea.ClearScreen
+
+	case "tab":
+		ids := m.navigablePanels()
+		if len(ids) > 0 {
+			cur := indexOfPanel(ids, m.focus)
+			if cur < 0 {
+				cur = 0
+			}
+			m.focus = ids[(cur+1)%len(ids)]
+		}
+
+	case "h", "left":
+		m.moveFocus('h')
+	case "l", "right":
+		m.moveFocus('l')
+	case "k", "up":
+		m.moveFocus('k')
+	case "j", "down":
+		m.moveFocus('j')
+
+	case "ctrl+d":
+		if m.focus == panelGit && m.gitGraphState != nil {
+			viewportH := m.gitGraphViewportHeight()
+			m.gitGraphScroll += viewportH / 2
+			maxScroll := len(m.gitGraphState.Lines) - viewportH
+			if maxScroll < 0 {
+				maxScroll = 0
+			}
+			if m.gitGraphScroll > maxScroll {
+				m.gitGraphScroll = maxScroll
+			}
+		}
+	case "ctrl+u":
+		if m.focus == panelGit {
+			viewportH := m.gitGraphViewportHeight()
+			m.gitGraphScroll -= viewportH / 2
+			if m.gitGraphScroll < 0 {
+				m.gitGraphScroll = 0
+			}
+		}
+
+	case "enter":
+		m.zoomed = true
+		m.zoomSel = 0
+		m.zoomScroll = 0
+		m.zoomLogsFollow = true
+		switch m.focus {
+		case panelHistory:
+			return m, tea.Batch(historyZoomCmd(m.store, m.metricsScopePath), tea.ClearScreen)
+		case panelAutopilot:
+			if prs := m.autopilotPanel.sortedActivePRs(); len(prs) > 0 {
+				m.zoomAutopilotPR = prs[0].PRNumber
+			} else {
+				m.zoomAutopilotPR = -1
+			}
+		case panelGit:
+			m.zoomScroll = m.gitGraphScroll
+		}
+		return m, tea.ClearScreen
+
+	case "u":
+		// Trigger upgrade if update is available and not already upgrading
+		if m.updateInfo != nil && m.upgradeState == UpgradeStateAvailable && m.upgradeCh != nil {
+			m.upgradeState = UpgradeStateInProgress
+			m.upgradeProgress = 0
+			m.upgradeMessage = "Starting upgrade..."
+			select {
+			case m.upgradeCh <- struct{}{}:
+			default:
+			}
+		}
+	}
+
+	return m, nil
+}
+
+// handleZoomedKey processes a key press while a panel is zoomed full-screen.
+func (m Model) handleZoomedKey(msg tea.KeyMsg) (Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "esc":
+		m.zoomed = false
+		return m, tea.ClearScreen
+	case "j", "down":
+		return m.zoomStep(1)
+	case "k", "up":
+		return m.zoomStep(-1)
+	case "ctrl+d", "pgdown":
+		return m.zoomHalfPage(1)
+	case "ctrl+u", "pgup":
+		return m.zoomHalfPage(-1)
+	case "g":
+		return m.zoomToTop()
+	case "G":
+		return m.zoomToBottom()
+	case "enter":
+		return m.zoomEnter()
+	case "o":
+		return m.zoomOpenOnly()
+	}
+	return m, nil
+}
+
+// zoomListViewportH returns the row/line capacity of the zoomed panel's
+// viewport for the current terminal height (help footer already reserved).
+func (m Model) zoomListViewportH() int {
+	h := m.height - 1
+	if h < 1 {
+		h = 1
+	}
+	return zoomListViewportHeight(h)
+}
+
+// logsMaxScroll returns the highest valid zoomScroll offset for the zoomed
+// logs viewport.
+func (m Model) logsMaxScroll() int {
+	max := len(m.logs) - m.zoomListViewportH()
+	if max < 0 {
+		max = 0
+	}
+	return max
+}
+
+// zoomStep moves the zoomed panel's selection/scroll by delta — one row for
+// list panels (queue/autopilot/history), one line for scroll panels
+// (logs/git).
+func (m Model) zoomStep(delta int) (Model, tea.Cmd) {
+	switch m.focus {
+	case panelQueue:
+		total := len(m.tasks)
+		m.zoomSel, m.zoomScroll = ensureSelVisible(m.zoomSel+delta, m.zoomScroll, total, m.zoomListViewportH())
+		return m.syncZoomQueueSelection()
+
+	case panelAutopilot:
+		prs := m.autopilotPanel.sortedActivePRs()
+		if len(prs) == 0 {
+			return m, nil
+		}
+		idx := clampInt(zoomAutopilotIndex(prs, m.zoomAutopilotPR)+delta, 0, len(prs)-1)
+		m.zoomAutopilotPR = prs[idx].PRNumber
+		return m, nil
+
+	case panelHistory:
+		total := len(m.zoomHistory)
+		m.zoomSel, m.zoomScroll = ensureSelVisible(m.zoomSel+delta, m.zoomScroll, total, m.zoomListViewportH())
+		return m, nil
+
+	case panelLogs:
+		if delta < 0 {
+			m.zoomLogsFollow = false
+		}
+		m.zoomScroll = clampInt(m.zoomScroll+delta, 0, m.logsMaxScroll())
+		return m, nil
+
+	case panelGit:
+		if m.gitGraphState != nil {
+			max := len(m.gitGraphState.Lines) - m.zoomListViewportH()
+			if max < 0 {
+				max = 0
+			}
+			m.zoomScroll = clampInt(m.zoomScroll+delta, 0, max)
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+// zoomHalfPageStep is a large sentinel used by zoomToTop/zoomToBottom to
+// jump to either edge via the same clamping logic as zoomStep.
+const zoomHalfPageStep = 1 << 30
+
+// zoomHalfPage moves the zoomed panel by half a viewport in direction dir
+// (+1 down, -1 up).
+func (m Model) zoomHalfPage(dir int) (Model, tea.Cmd) {
+	half := m.zoomListViewportH() / 2
+	if half < 1 {
+		half = 1
+	}
+	return m.zoomStep(dir * half)
+}
+
+// zoomToTop jumps the zoomed panel to its first item/line.
+func (m Model) zoomToTop() (Model, tea.Cmd) {
+	if m.focus == panelLogs {
+		m.zoomLogsFollow = false
+		m.zoomScroll = 0
+		return m, nil
+	}
+	return m.zoomStep(-zoomHalfPageStep)
+}
+
+// zoomToBottom jumps the zoomed panel to its last item/line. For logs this
+// also resumes tail-follow.
+func (m Model) zoomToBottom() (Model, tea.Cmd) {
+	if m.focus == panelLogs {
+		m.zoomLogsFollow = true
+		m.zoomScroll = m.logsMaxScroll()
+		return m, nil
+	}
+	return m.zoomStep(zoomHalfPageStep)
+}
+
+// zoomEnter handles Enter in zoomed mode: list panels open the selected
+// item's URL; scroll panels (logs/git) exit zoom.
+func (m Model) zoomEnter() (Model, tea.Cmd) {
+	switch m.focus {
+	case panelQueue, panelAutopilot, panelHistory:
+		return m.zoomOpenSelection()
+	default:
+		m.zoomed = false
+		return m, tea.ClearScreen
+	}
+}
+
+// zoomOpenOnly handles 'o' in zoomed mode: list panels open the selected
+// item's URL; scroll panels are a no-op.
+func (m Model) zoomOpenOnly() (Model, tea.Cmd) {
+	switch m.focus {
+	case panelQueue, panelAutopilot, panelHistory:
+		return m.zoomOpenSelection()
+	}
+	return m, nil
+}
+
+// zoomOpenSelection opens the currently-selected list item's URL via
+// browserOpener (defaults to openBrowser; injectable for tests).
+func (m Model) zoomOpenSelection() (Model, tea.Cmd) {
+	opener := m.browserOpener
+	if opener == nil {
+		opener = openBrowser
+	}
+	switch m.focus {
+	case panelQueue:
+		sorted := m.sortedTasks()
+		if m.zoomSel >= 0 && m.zoomSel < len(sorted) {
+			if url := sorted[m.zoomSel].IssueURL; url != "" {
+				_ = opener(url)
+			}
+		}
+	case panelAutopilot:
+		prs := m.autopilotPanel.sortedActivePRs()
+		idx := zoomAutopilotIndex(prs, m.zoomAutopilotPR)
+		if idx >= 0 && idx < len(prs) {
+			if url := prs[idx].PRURL; url != "" {
+				_ = opener(url)
+			}
+		}
+	case panelHistory:
+		if m.zoomSel >= 0 && m.zoomSel < len(m.zoomHistory) {
+			if url := m.zoomHistory[m.zoomSel].PRUrl; url != "" {
+				_ = opener(url)
+			}
+		}
+	}
+	return m, nil
+}
+
+// syncZoomQueueSelection maps the zoomed queue's sorted-list selection back
+// onto m.selectedTask (an index into the unsorted m.tasks) and syncs the
+// git graph to the newly-selected task's project, mirroring grid mode's
+// j/k-driven sync (GH-2167).
+func (m Model) syncZoomQueueSelection() (Model, tea.Cmd) {
+	sorted := m.sortedTasks()
+	if m.zoomSel < 0 || m.zoomSel >= len(sorted) {
+		return m, nil
+	}
+	id := sorted[m.zoomSel].ID
+	for i, t := range m.tasks {
+		if t.ID == id {
+			m.selectedTask = i
+			break
+		}
+	}
+	cmd := m.syncGitGraphToSelectedTask()
+	return m, cmd
+}
+
+// renderZoomed renders only the currently-focused panel at full screen size
+// (width x height-1, the help footer reserves the last line).
+func (m Model) renderZoomed() string {
+	w := m.width
+	h := m.height - 1
+	if h < 1 {
+		h = 1
+	}
+	switch m.focus {
+	case panelQueue:
+		return m.renderZoomedQueue(w, h)
+	case panelAutopilot:
+		return m.renderZoomedAutopilot(w, h)
+	case panelHistory:
+		return m.renderZoomedHistory(w, h)
+	case panelLogs:
+		return m.renderZoomedLogs(w, h)
+	case panelGit:
+		return m.renderGitGraphZoomed(w, h)
+	}
+	return ""
+}
+
+// renderZoomedQueue renders every task (uncapped), preserving the same
+// state-priority sort order as the grid QUEUE panel.
+func (m Model) renderZoomedQueue(w, h int) string {
+	sorted := m.sortedTasks()
+	offsets := make([]int, len(sorted))
+	qi := 0
+	for i, t := range sorted {
+		if t.Status == "queued" {
+			offsets[i] = qi
+			qi++
+		}
+	}
+
+	total := len(sorted)
+	visible := zoomListViewportHeight(h)
+	sel, scroll := ensureSelVisible(m.zoomSel, m.zoomScroll, total, visible)
+	iw := w - 4
+
+	var lines []string
+	if total == 0 {
+		lines = append(lines, "  No tasks in queue")
+	} else {
+		end := minInt(scroll+visible, total)
+		for i := scroll; i < end; i++ {
+			lines = append(lines, m.renderTask(sorted[i], i == sel, offsets[i], iw))
+		}
+	}
+	indicator := dimStyle.Render(zoomListIndicator(scroll, minInt(scroll+visible, total), total))
+	return renderPanelStyled("queue", indicator, strings.Join(lines, "\n"), w, focusChrome)
+}
+
+// renderZoomedAutopilot renders every active PR (uncapped), sorted and
+// selected by PR number so a live-pull reorder can't move the selection.
+// Relies on View()'s height truncation rather than its own viewport window
+// since each PR can render 1 or 2 lines (retry/failure detail).
+func (m Model) renderZoomedAutopilot(w, h int) string {
+	_ = h
+	if m.autopilotPanel == nil || m.autopilotPanel.controller == nil {
+		return renderPanelStyled("autopilot", "", "  Disabled", w, focusChrome)
+	}
+	prs := m.autopilotPanel.sortedActivePRs()
+	if len(prs) == 0 {
+		return renderPanelStyled("autopilot", "", "  "+dimStyle.Render("idle · no active PR"), w, focusChrome)
+	}
+
+	cfg := m.autopilotPanel.controller.Config()
+	maxFailures := cfg.MaxFailures
+	if maxFailures <= 0 {
+		maxFailures = 5
+	}
+	selIdx := zoomAutopilotIndex(prs, m.zoomAutopilotPR)
+	iw := w - 4
+
+	var lines []string
+	for i, pr := range prs {
+		rows := renderAutopilotRow(pr, m.autopilotPanel.controller.GetPRFailures(pr.PRNumber), maxFailures, iw)
+		rows[0] = spliceSelector(rows[0], i == selIdx)
+		lines = append(lines, rows...)
+	}
+	info := fmt.Sprintf("%d prs", len(prs))
+	return renderPanelStyled("autopilot", dimStyle.Render(info), strings.Join(lines, "\n"), w, focusChrome)
+}
+
+// renderZoomedHistory renders m.zoomHistory (up to 100 distinct tasks,
+// populated by historyZoomCmd).
+func (m Model) renderZoomedHistory(w, h int) string {
+	tasks := m.zoomHistory
+	total := len(tasks)
+	visible := zoomListViewportHeight(h)
+	sel, scroll := ensureSelVisible(m.zoomSel, m.zoomScroll, total, visible)
+	iw := w - 4
+
+	var lines []string
+	if total == 0 {
+		lines = append(lines, "  No completed tasks yet")
+	} else {
+		end := minInt(scroll+visible, total)
+		for i := scroll; i < end; i++ {
+			line := renderStandaloneLine(tasks[i], iw)
+			lines = append(lines, spliceSelector(line, i == sel))
+		}
+	}
+	indicator := dimStyle.Render(zoomListIndicator(scroll, minInt(scroll+visible, total), total))
+	return renderPanelStyled("history", indicator, strings.Join(lines, "\n"), w, focusChrome)
+}
+
+// renderZoomedLogs renders a scrollable window over m.logs (up to 1000
+// retained lines), tail-following by default.
+func (m Model) renderZoomedLogs(w, h int) string {
+	iw := w - 4
+	visible := zoomListViewportHeight(h)
+	total := len(m.logs)
+	scroll := clampInt(m.zoomScroll, 0, m.logsMaxScroll())
+	end := minInt(scroll+visible, total)
+
+	var lines []string
+	if total == 0 {
+		lines = append(lines, "  No logs yet")
+	} else {
+		for _, line := range m.logs[scroll:end] {
+			lines = append(lines, "  "+truncateVisual(line, iw-2))
+		}
+	}
+	indicator := dimStyle.Render(zoomListIndicator(scroll, end, total))
+	return renderPanelStyled("logs", indicator, strings.Join(lines, "\n"), w, focusChrome)
+}
+
+// renderGitGraphZoomed renders the git graph panel at full screen size,
+// using zoomScroll instead of gitGraphScroll for its offset so grid-mode
+// scroll position is untouched (esc-return is free).
+func (m Model) renderGitGraphZoomed(w, h int) string {
+	mm := m
+	mm.gitGraphScroll = m.zoomScroll
+	return mm.renderGitGraph(w, h)
+}
+
+// historyZoomMsg carries the zoomed history panel's full dataset, fetched
+// asynchronously by historyZoomCmd.
+type historyZoomMsg struct {
+	tasks []CompletedTask
+}
+
+// historyZoomCmd fetches up to 100 distinct-by-task completed executions
+// (scanning up to 500 raw rows so retried tasks don't crowd out the rest —
+// same rationale as firstNDistinctByTask) for the zoomed history panel,
+// hydrating each task's stage strip inside the Cmd so View() never touches
+// the store.
+func historyZoomCmd(store *memory.Store, projectPath string) tea.Cmd {
+	return func() tea.Msg {
+		if store == nil {
+			return historyZoomMsg{}
+		}
+		executions, err := store.GetRecentExecutions(500, projectPath)
+		if err != nil {
+			slog.Warn("history zoom: failed to load executions", slog.Any("error", err))
+			return historyZoomMsg{}
+		}
+
+		var tasks []CompletedTask
+		for _, exec := range firstNDistinctByTask(executions, 100) {
+			status := displayStatus(exec.Status)
+			completedAt := exec.CreatedAt
+			if exec.CompletedAt != nil {
+				completedAt = *exec.CompletedAt
+			}
+			events, err := store.ListExecutionEvents(exec.ID)
+			if err != nil {
+				slog.Warn("history zoom: failed to load execution events",
+					slog.Any("error", err), slog.String("execution_id", exec.ID))
+			}
+			tasks = append(tasks, CompletedTask{
+				ID:          exec.TaskID,
+				Title:       exec.TaskTitle,
+				Status:      status,
+				Duration:    fmt.Sprintf("%dms", exec.DurationMs),
+				CompletedAt: completedAt,
+				PeakRSSMB:   exec.PeakRSSMB,
+				Stage:       stageInfoForExecution(events, status),
+				PRUrl:       exec.PRUrl,
+			})
+		}
+		return historyZoomMsg{tasks: tasks}
+	}
+}


### PR DESCRIPTION
## Summary
- Wires the already-merged `internal/dashboard/{grid,panels,zoomlist}.go` helpers (TASK-398/#4200) into `tui.go`'s `Model`/`Update`/`View` — those helpers were defined and unit-tested but never called, so none of the 5 grom-nav requirements actually shipped.
- Adds spatial focus (`hjkl`/`tab`, `focusMove` over `computeLayout` rects) across queue/autopilot/history/logs/git, `enter` zooms the focused panel full-screen (uncapped queue/history/autopilot lists, scrollable logs/git with tail-follow), `esc` restores.
- Git graph now paints on the first frame (`gitGraphMode: GitGraphVisible` by default + `Init()` batches the refresh) instead of requiring a manual `g` press. `L` toggles logs (rebound from `l`, which now moves focus).
- Adds `historyZoomCmd`/`historyZoomMsg` (up to 100 distinct-by-task rows from the store) and `CompletedTask.PRUrl`; zoomed autopilot is sorted/selected by PR number so a live-pull reorder can't move the selection; zoomed logs cap raised 100→1000.
- Rewrites the keymap tests that depended on the removed `gitGraphFocus`/binary-tab model, and adds the 9 integration acceptance tests from the task spec (`TestNav_*`) plus a width-invariant matrix at 80/96/140/200, grid and zoomed.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full repo, all packages green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `gofmt -l` on changed files — clean
- [ ] Live `./bin/pilot start` smoke (wide + narrow) — not exercised in this non-interactive session; covered instead by the `TestNav_*` Update()/View() integration tests and the width-invariant matrix.