### PR TITLE
fix(autopilot,memory): reconcile dashboard status against terminal truth (GH-4209)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-11 (v2.151.0)
+**Last Updated:** 2026-07-09 (v2.151.0)
 
 ## Legend
 
@@ -250,7 +250,6 @@
 | GoReleaser desktop artifact | ✅ | ci | - | - | Separate GH Actions workflow, macOS universal binary on release (v1.54.0, GH-1614) |
 | Dashboard git graph sizes | ✅ | dashboard | `g` key | - | Small/medium/large/hidden modes, auto-size by terminal width (v2.35.0, PR #1900) |
 | Dashboard responsive layout | ✅ | dashboard | - | - | Stacked layout on narrow terminals, full-width panels (v2.38.0, PR #1913) |
-| Dashboard spatial nav + zoom | ✅ | dashboard | `hjkl`/`tab`/`enter`/`esc` | - | grom-style spatial panel focus (`focusMove` over `computeLayout` rects) across queue/autopilot/history/logs/git; `enter` zooms the focused panel full-screen (uncapped lists, `j/k` + `g/G`, `enter`/`o` opens the selected item's URL); git graph visible by default on first frame; logs rebound to `L` (v2.237.0, TASK-399/GH-4203) |
 | History dedup | ✅ | desktop | - | - | Deduplicates execution records per issue, success takes priority (v1.62.0, GH-1663) |
 | WebSocket log streaming | ✅ | gateway | - | - | Real-time execution logs via WebSocket to web dashboard (v1.56.0, GH-1613) |
 | Epic-aware HISTORY panel | ✅ | dashboard | - | - | HISTORY panel shows epic decomposition info + sub-issue counts (v0.22.1) |
@@ -364,7 +363,6 @@
 | Rule-based triggers | ✅ | approval | - | `approval.rules[]` | RuleEvaluator with 4 matchers wired into Manager (GH-636) |
 | Non-blocking async approval | ✅ | autopilot | - | `approval.async_dispatch` | handleAwaitApproval tick-handler; PR-A stall no longer blocks PR-B (GH-2685) |
 | Approval persistence in executions | ✅ | autopilot/memory | - | - | approval_request_id + decision written to executions table (GH-2712) |
-| Release-aware approval ack + merge follow-up | ✅ | approval/autopilot | - | - | Approved Telegram card shows the next-step text (immediate release / next cron train time / no releaser configured), injected as `approval.Request.ReleasePlan` by autopilot at request-creation time so the approval package never imports release config; `approval.Manager.NotifyMerged` posts a "🔀 Merged \<sha\>" follow-up in the same chat once `handleMerging` completes for an approval-gated PR (`PRState.MergeFollowupPosted` guards against a duplicate on re-entry); `EditMessage` failures on the ack card fall back to a new message so a recorded decision is never left with zero feedback (GH-4164, v2.236.8) |
 
 ## Autopilot (v0.19.1+)
 
@@ -599,3 +597,4 @@ quality:
 | Decomposed-child base-branch pinning | v2.184.x | executor | Resolve `BaseBranch` from main-repo git context before worktree creation; decomposed children never PR against a sibling branch (GH-3540) |
 | GitHub-poller auth-failure escalation | v2.207.x | adapters/github + health | Consecutive 401/non-ratelimit-403 fetch errors escalate to ERROR log + alert at threshold (`WithAlertProcessor`/`WithTokenSource`); `pilot doctor` disabled-subsystems panel; `pilot config show` secret redaction + `--reveal` (TASK-379 V4 / GH-3839) |
 | Executor prompt memory injection | v2.219.x | executor | `BuildPrompt` appends a "Known pitfalls from project memory" block ranked via `graphrecall.RecallRelevant`, gated on `MemoryInjection.Enabled`/non-LocalMode/Navigator/recall hits, capped at `min(MaxMemories,5)` entries and ~1500 chars (TASK-387 / GH-3909) |
+| Dashboard status-truthfulness reconciliation | v2.238.x | memory + autopilot | Orphan-running sweep (`FindOrphanedRunningExecutions`/`ResolveOrphanedRunningExecution`, Monitor + execution_events heartbeat guard) heals stale `status='running'` rows; `selfHealForPR` widened with a startup wide-lookback catch-up scan, PR-body `Closes #N`/`Parent: GH-N` issueNum resolution, and a `pr_url`-keyed fallback heal; `ScanRecentlyMergedPRs`'s external-merge branch now also calls `monitor.Complete` (TASK-399 / GH-4209) |

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2273,8 +2273,12 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 						)
 					}
 
-					// Scan for recently merged PRs (GH-416)
-					if err := controller.ScanRecentlyMergedPRs(ctx); err != nil {
+					// Scan for recently merged PRs (GH-416). TASK-399/GH-4209: startup
+					// uses the wide-lookback catch-up sweep — not the periodic loop's
+					// 30-min scanWindow — so a merge that landed while the daemon was
+					// down still self-heals its execution row (and any orphaned
+					// 'running' rows resolve) instead of staying red in HISTORY forever.
+					if err := controller.ScanRecentlyMergedPRsWithWindow(ctx, autopilot.StartupMergedPRLookback); err != nil {
 						logging.WithComponent("autopilot").Warn("failed to scan merged PRs",
 							slog.String("repo", repoName),
 							slog.Any("error", err),

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -107,6 +107,12 @@ type ReleaseNotifier interface {
 // GH-1336: Sync monitor state when autopilot merges PR so dashboard shows correct status.
 type TaskMonitor interface {
 	Complete(taskID, prURL string)
+	// GetRunningTaskIDs returns the IDs of tasks the in-process Monitor currently
+	// considers running or queued. TASK-399/GH-4209: the orphan-running sweep
+	// excludes these before flipping any persisted 'running' row, so a
+	// genuinely in-flight execution (the GH-4206 regression gate) is never
+	// healed out from under itself.
+	GetRunningTaskIDs() []string
 }
 
 // EvalStore persists eval tasks extracted from merged PRs.
@@ -128,6 +134,25 @@ type EvalStore interface {
 	// "failed" with reason, so a PR closed without merging can never leave a
 	// "completed" row behind that HasCompletedExecution keeps trusting. GH-3818.
 	ReclassifyCompletionAsFailed(taskID, projectPath, reason string) error
+	// SelfHealExecutionByPRURL is the pr_url-keyed fallback self-heal used when
+	// a merged PR's issue number can't be resolved from branch or body markers
+	// at all. TASK-399/GH-4209.
+	SelfHealExecutionByPRURL(prURL string) error
+	// FindOrphanedRunningExecutions returns status='running' rows whose task_id
+	// is NOT in excludeTaskIDs (the live Monitor's running/queued set) —
+	// candidates for the orphan-running sweep. TASK-399/GH-4209.
+	FindOrphanedRunningExecutions(excludeTaskIDs []string) ([]*memory.Execution, error)
+	// ResolveOrphanedRunningExecution flips one orphan-running candidate to a
+	// terminal status: 'completed' when prURL is non-empty (a merged PR was
+	// found for this row), else 'failed'. Internally guarded by
+	// status='running', so it is a no-op once the row has already
+	// transitioned. TASK-399/GH-4209.
+	ResolveOrphanedRunningExecution(id, prURL string) error
+	// ListExecutionEvents returns executionID's execution_events timeline in
+	// chronological order — used as the recent-heartbeat guard for the
+	// orphan-running sweep (a fresh event means the execution is still
+	// actively progressing even if the Monitor set missed it). TASK-399/GH-4209.
+	ListExecutionEvents(executionID string) ([]*memory.Event, error)
 }
 
 // ControllerOption is a functional option for Controller configuration.
@@ -444,6 +469,36 @@ func NewController(cfg *Config, ghClient *github.Client, approvalMgr *approval.M
 // into sub-issues. TASK-352.
 var parentIssueRe = regexp.MustCompile(`(?i)Parent:\s*GH-(\d+)`)
 
+// closesIssueRe extracts an issue number from a PR body's standard GitHub
+// auto-close marker ("Closes #123", "closes #123", etc.). TASK-399/GH-4209:
+// widens issueNum resolution beyond the literal "pilot/GH-%d" branch prefix
+// for PRs merged on a non-standard branch name.
+var closesIssueRe = regexp.MustCompile(`(?i)\bCloses\s+#(\d+)\b`)
+
+// resolveIssueNumFromPR resolves the GitHub issue number a merged PR ships,
+// trying (in order): the "pilot/GH-N" branch-name convention, the PR body's
+// "Closes #N" auto-close marker, and the PR body's "Parent: GH-N" epic marker.
+// Returns 0 if none match. TASK-399/GH-4209: the branch-prefix-only check
+// missed PRs merged on non-standard branches, leaving their execution rows
+// permanently un-healed.
+func resolveIssueNumFromPR(pr *github.PullRequest) int {
+	var issueNum int
+	if strings.HasPrefix(pr.Head.Ref, "pilot/GH-") {
+		_, _ = fmt.Sscanf(pr.Head.Ref, "pilot/GH-%d", &issueNum)
+	}
+	if issueNum == 0 {
+		if m := closesIssueRe.FindStringSubmatch(pr.Body); len(m) == 2 {
+			issueNum, _ = strconv.Atoi(m[1])
+		}
+	}
+	if issueNum == 0 {
+		if m := parentIssueRe.FindStringSubmatch(pr.Body); len(m) == 2 {
+			issueNum, _ = strconv.Atoi(m[1])
+		}
+	}
+	return issueNum
+}
+
 // selfHealForPR promotes any prior "failed" execution rows for the merged PR's
 // issue — and its parent epic, if it is a sub-issue — to "completed", stamping the
 // PR URL so the dashboard reflects the merged outcome. Safe to call from any merge
@@ -483,6 +538,90 @@ func (c *Controller) selfHealTask(taskID, prURL string) {
 	if err := c.evalStore.SelfHealExecutionAfterMerge(taskID, c.projectPath, prURL); err != nil {
 		c.log.Warn("failed to self-heal execution on merge", "task_id", taskID, "error", err)
 	}
+}
+
+// orphanRunningHeartbeatWindow bounds how recently an execution_events row
+// must have landed for a status='running' row with no live Monitor entry to
+// still be treated as in-flight. Guards a narrow race: a worker can register
+// with Monitor slightly after its row flips to 'running' in the DB, or (after
+// a hot-upgrade handoff) the new process's Monitor hasn't been repopulated yet
+// even though the execution itself is still progressing. This is the hard
+// regression gate for a genuinely running task (the GH-4206 case) — it must
+// never be flipped mid-execution. TASK-399/GH-4209.
+const orphanRunningHeartbeatWindow = 10 * time.Minute
+
+// sweepOrphanedRunningExecutions resolves status='running' execution rows
+// that are not actually in flight: absent from the live Monitor's
+// running/queued set, and with no execution_events heartbeat inside
+// orphanRunningHeartbeatWindow. Each surviving candidate resolves to
+// 'completed' when its pr_url or branch matches a PR in mergedPRs, else
+// 'failed'. mergedPRs is the same already-fetched PR list
+// ScanRecentlyMergedPRsWithWindow built for this tick — this sweep makes no
+// GitHub calls of its own (mem-048). TASK-399/GH-4209.
+func (c *Controller) sweepOrphanedRunningExecutions(mergedPRs []*github.PullRequest) {
+	if c.evalStore == nil {
+		return
+	}
+
+	var liveTaskIDs []string
+	if c.monitor != nil {
+		liveTaskIDs = c.monitor.GetRunningTaskIDs()
+	}
+
+	orphans, err := c.evalStore.FindOrphanedRunningExecutions(liveTaskIDs)
+	if err != nil {
+		c.log.Warn("orphan-running sweep: failed to query candidates", "error", err)
+		return
+	}
+
+	for _, exec := range orphans {
+		events, evErr := c.evalStore.ListExecutionEvents(exec.ID)
+		if evErr != nil {
+			c.log.Warn("orphan-running sweep: failed to check heartbeat, skipping row",
+				"execution_id", exec.ID, "task_id", exec.TaskID, "error", evErr)
+			continue
+		}
+		if len(events) > 0 {
+			last := events[len(events)-1].OccurredAt
+			if time.Since(last) < orphanRunningHeartbeatWindow {
+				c.log.Debug("orphan-running sweep: recent heartbeat, treating as in-flight",
+					"execution_id", exec.ID, "task_id", exec.TaskID, "last_event", last)
+				continue
+			}
+		}
+
+		prURL := matchMergedPR(exec, mergedPRs)
+		if err := c.evalStore.ResolveOrphanedRunningExecution(exec.ID, prURL); err != nil {
+			c.log.Warn("orphan-running sweep: failed to resolve row",
+				"execution_id", exec.ID, "task_id", exec.TaskID, "error", err)
+			continue
+		}
+		if prURL != "" {
+			c.log.Info("orphan-running sweep: healed to completed (merged PR found)",
+				"execution_id", exec.ID, "task_id", exec.TaskID, "pr_url", prURL)
+		} else {
+			c.log.Warn("orphan-running sweep: no merge evidence found, marked failed",
+				"execution_id", exec.ID, "task_id", exec.TaskID)
+		}
+	}
+}
+
+// matchMergedPR reports the merged PR URL matching exec's own pr_url column or
+// its task branch, or "" if no PR in mergedPRs matches either. TASK-399/GH-4209.
+func matchMergedPR(exec *memory.Execution, mergedPRs []*github.PullRequest) string {
+	branch := exec.TaskBranch
+	if branch == "" {
+		branch = fmt.Sprintf("pilot/%s", exec.TaskID)
+	}
+	for _, pr := range mergedPRs {
+		if exec.PRUrl != "" && pr.HTMLURL == exec.PRUrl {
+			return pr.HTMLURL
+		}
+		if pr.Head.Ref == branch {
+			return pr.HTMLURL
+		}
+	}
+	return ""
 }
 
 // resolveParentIssue returns the parent issue number for a sub-issue by parsing
@@ -3824,11 +3963,34 @@ func (c *Controller) backstopCheckReleaseMissing(ctx context.Context, rel *Relea
 	c.fireReleaseMissingAlert(c.owner, c.repo, tag, prNumber, issueNumber, timeout)
 }
 
-// ScanRecentlyMergedPRs scans for Pilot PRs that were merged externally.
-// This catches PRs that need release triggering but were merged outside of
-// autopilot (e.g. via `gh pr merge` or the GitHub UI).
-// Called on startup and periodically from the Run loop.
+// StartupMergedPRLookback is the lookback window ScanRecentlyMergedPRsWithWindow
+// uses for the one-time startup catch-up sweep (TASK-399/GH-4209), instead of
+// the periodic loop's config.MergedPRScanWindow (default 30m). ListPullRequests
+// already fetches the full closed-PR list regardless of window (up to 5 000 PRs
+// across pages) — widening this only changes the in-memory cutoff filter below,
+// not the GitHub call volume (mem-048).
+const StartupMergedPRLookback = 30 * 24 * time.Hour
+
+// ScanRecentlyMergedPRs scans for Pilot PRs that were merged externally, using
+// the configured MergedPRScanWindow. This catches PRs that need release
+// triggering but were merged outside of autopilot (e.g. via `gh pr merge` or
+// the GitHub UI). Called periodically from the Run loop; see
+// ScanRecentlyMergedPRsWithWindow for the startup catch-up sweep.
 func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
+	scanWindow := c.config.MergedPRScanWindow
+	if scanWindow == 0 {
+		scanWindow = 30 * time.Minute // Default fallback
+	}
+	return c.ScanRecentlyMergedPRsWithWindow(ctx, scanWindow)
+}
+
+// ScanRecentlyMergedPRsWithWindow is ScanRecentlyMergedPRs with an explicit
+// lookback window. TASK-399/GH-4209: startup wiring calls this directly with
+// StartupMergedPRLookback (a wide catch-up sweep, not the periodic 30-min
+// scanWindow) so a merge that happened while the daemon was down — or before
+// the last restart — still self-heals its execution row instead of leaving it
+// permanently red in HISTORY.
+func (c *Controller) ScanRecentlyMergedPRsWithWindow(ctx context.Context, scanWindow time.Duration) error {
 	// Run the scan unconditionally — it covers self-heal + merge metrics even when
 	// neither auto-release nor board sync is enabled (e.g. a plain GH-issue-source
 	// deployment). Internal gates below handle release-trigger and board-writeback
@@ -3840,7 +4002,6 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 	boardEnabled := c.boardSync != nil && c.doneStatus != ""
 	rel := c.resolvedRelease()
 
-	scanWindow := c.config.MergedPRScanWindow
 	if scanWindow == 0 {
 		scanWindow = 30 * time.Minute // Default fallback
 	}
@@ -3858,6 +4019,13 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 	}
 
 	c.log.Debug("found closed PRs", "total", len(prs))
+
+	// TASK-399/GH-4209: orphan-running reconcile piggybacks on this scan's
+	// already-fetched PR list — no extra GitHub call (mem-048). Considers the
+	// full unfiltered list (not scanWindow-cut) since an orphaned running row
+	// can predate this scan's window; runs every tick regardless of
+	// releaseEnabled/boardEnabled since it only touches self-heal bookkeeping.
+	c.sweepOrphanedRunningExecutions(prs)
 
 	cutoff := time.Now().Add(-scanWindow)
 	triggered := 0
@@ -3899,11 +4067,10 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			continue
 		}
 
-		// Extract issue number from branch name (optional)
-		var issueNum int
-		if strings.HasPrefix(pr.Head.Ref, "pilot/GH-") {
-			_, _ = fmt.Sscanf(pr.Head.Ref, "pilot/GH-%d", &issueNum)
-		}
+		// Extract issue number from the branch name, falling back to the PR
+		// body's "Closes #N" / "Parent: GH-N" markers (TASK-399/GH-4209) when
+		// the PR wasn't opened on a literal "pilot/GH-N" branch.
+		issueNum := resolveIssueNumFromPR(pr)
 
 		// Record merge metrics BEFORE the activePRs/release-exists skip gates
 		// below — those gates exist to avoid duplicate release triggering, but
@@ -3928,6 +4095,24 @@ func (c *Controller) ScanRecentlyMergedPRs(ctx context.Context) error {
 			// recordMergeSuccess above, this fires before the release-tag/activePRs skip
 			// gates because the heal must happen on every discovered merged Pilot PR.
 			c.selfHealForPR(ctx, issueNum, pr.HTMLURL)
+
+			// TASK-399/GH-4209: last-resort heal when issueNum couldn't be
+			// resolved at all (no branch-prefix match, no "Closes #N"/"Parent:
+			// GH-N" body marker) — match directly on the row's own
+			// already-stamped pr_url instead of going through task_id.
+			if issueNum == 0 && c.evalStore != nil {
+				if err := c.evalStore.SelfHealExecutionByPRURL(pr.HTMLURL); err != nil {
+					c.log.Warn("selfHealForPR: pr_url fallback heal failed", "pr", pr.Number, "error", err)
+				}
+			}
+
+			// TASK-399/GH-4209: mirror handleMerging's monitor sync
+			// (controller.go:1962, GH-1336) so an externally-merged PR also
+			// retires its QUEUE card instead of leaving a stale in-memory
+			// Monitor entry behind.
+			if c.monitor != nil && issueNum > 0 {
+				c.monitor.Complete(fmt.Sprintf("GH-%d", issueNum), pr.HTMLURL)
+			}
 
 			// TASK-356 #2: board write-back for externally-merged PRs. Large PRs that
 			// hit the stage approval-misconfig (require_approval=true + approval disabled)

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -3241,6 +3241,7 @@ func TestController_ConsecutiveAPIFailures_Reset(t *testing.T) {
 // mockTaskMonitor implements TaskMonitor for testing.
 type mockTaskMonitor struct {
 	completedTasks map[string]string // taskID -> prURL
+	runningTaskIDs []string          // TASK-399/GH-4209: live Monitor running/queued set
 }
 
 func newMockTaskMonitor() *mockTaskMonitor {
@@ -3251,6 +3252,11 @@ func newMockTaskMonitor() *mockTaskMonitor {
 
 func (m *mockTaskMonitor) Complete(taskID, prURL string) {
 	m.completedTasks[taskID] = prURL
+}
+
+// GetRunningTaskIDs implements TaskMonitor. TASK-399/GH-4209.
+func (m *mockTaskMonitor) GetRunningTaskIDs() []string {
+	return m.runningTaskIDs
 }
 
 // TestController_MonitorCompletedOnMerge verifies that when autopilot successfully
@@ -4704,6 +4710,19 @@ type mockEvalStore struct {
 	// task ID (e.g. "GH-11"). Missing keys return sql.ErrNoRows, matching a real
 	// store's behavior when no execution row exists for that task.
 	execStatusByTaskID map[string]string
+
+	// TASK-399/GH-4209: orphan-running sweep + pr_url fallback test hooks.
+	prURLHealed        []string                   // SelfHealExecutionByPRURL calls
+	orphanedRunning    []*memory.Execution         // FindOrphanedRunningExecutions candidate pool
+	lastExcludeTaskIDs []string                    // last exclude set FindOrphanedRunningExecutions was called with
+	resolvedOrphans    []resolveOrphanCall         // ResolveOrphanedRunningExecution calls
+	executionEvents    map[string][]*memory.Event  // ListExecutionEvents responses keyed by execution ID
+}
+
+// resolveOrphanCall records one ResolveOrphanedRunningExecution invocation. TASK-399/GH-4209.
+type resolveOrphanCall struct {
+	ID    string
+	PRURL string
 }
 
 type selfHealCall struct {
@@ -4752,6 +4771,42 @@ func (m *mockEvalStore) SelfHealExecutionAfterMerge(taskID, projectPath, prURL s
 func (m *mockEvalStore) ReclassifyCompletionAsFailed(taskID, projectPath, reason string) error {
 	m.reclassified = append(m.reclassified, reclassifyCall{TaskID: taskID, ProjectPath: projectPath, Reason: reason})
 	return nil
+}
+
+// SelfHealExecutionByPRURL records the call for assertions. TASK-399/GH-4209.
+func (m *mockEvalStore) SelfHealExecutionByPRURL(prURL string) error {
+	m.prURLHealed = append(m.prURLHealed, prURL)
+	return nil
+}
+
+// FindOrphanedRunningExecutions filters the configured orphanedRunning pool by
+// excludeTaskIDs, mirroring the real store's task_id NOT IN(...) exclusion.
+// TASK-399/GH-4209.
+func (m *mockEvalStore) FindOrphanedRunningExecutions(excludeTaskIDs []string) ([]*memory.Execution, error) {
+	m.lastExcludeTaskIDs = excludeTaskIDs
+	excluded := make(map[string]bool, len(excludeTaskIDs))
+	for _, id := range excludeTaskIDs {
+		excluded[id] = true
+	}
+	var result []*memory.Execution
+	for _, exec := range m.orphanedRunning {
+		if !excluded[exec.TaskID] {
+			result = append(result, exec)
+		}
+	}
+	return result, nil
+}
+
+// ResolveOrphanedRunningExecution records the call for assertions. TASK-399/GH-4209.
+func (m *mockEvalStore) ResolveOrphanedRunningExecution(id, prURL string) error {
+	m.resolvedOrphans = append(m.resolvedOrphans, resolveOrphanCall{ID: id, PRURL: prURL})
+	return nil
+}
+
+// ListExecutionEvents returns the configured heartbeat events for executionID,
+// or nil (no heartbeat) for an unconfigured ID. TASK-399/GH-4209.
+func (m *mockEvalStore) ListExecutionEvents(executionID string) ([]*memory.Event, error) {
+	return m.executionEvents[executionID], nil
 }
 
 // TestHandleMerged_ExtractsEvalTask verifies that handleMerged extracts and saves

--- a/internal/autopilot/orphan_sweep_test.go
+++ b/internal/autopilot/orphan_sweep_test.go
@@ -1,0 +1,336 @@
+package autopilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+	github "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// TestSweepOrphanedRunningExecutions_LiveMonitorEntryNotFlipped is the GH-4206
+// regression gate: a status='running' row whose task_id is in the live
+// Monitor's running/queued set must never be resolved by the orphan sweep,
+// even if the row would otherwise look orphaned. TASK-399/GH-4209.
+func TestSweepOrphanedRunningExecutions_LiveMonitorEntryNotFlipped(t *testing.T) {
+	cfg := DefaultConfig()
+	c := NewController(cfg, nil, nil, "owner", "repo")
+
+	evalMock := &mockEvalStore{
+		orphanedRunning: []*memory.Execution{
+			{ID: "exec-live", TaskID: "GH-4206", ProjectPath: "/proj"},
+		},
+	}
+	c.SetEvalStore(evalMock)
+	monitor := newMockTaskMonitor()
+	monitor.runningTaskIDs = []string{"GH-4206"}
+	c.SetMonitor(monitor)
+
+	c.sweepOrphanedRunningExecutions(nil)
+
+	if len(evalMock.resolvedOrphans) != 0 {
+		t.Fatalf("expected GH-4206 to never be resolved, got %d resolve calls: %+v", len(evalMock.resolvedOrphans), evalMock.resolvedOrphans)
+	}
+	if len(evalMock.lastExcludeTaskIDs) != 1 || evalMock.lastExcludeTaskIDs[0] != "GH-4206" {
+		t.Errorf("expected FindOrphanedRunningExecutions to be called with the live Monitor set, got %v", evalMock.lastExcludeTaskIDs)
+	}
+}
+
+// TestSweepOrphanedRunningExecutions_FreshHeartbeatNotFlipped verifies the
+// second half of the GH-4206 regression gate: even when a row has no live
+// Monitor entry (e.g. right after a restart), a recent execution_events
+// heartbeat must still protect it from being flipped. TASK-399/GH-4209.
+func TestSweepOrphanedRunningExecutions_FreshHeartbeatNotFlipped(t *testing.T) {
+	cfg := DefaultConfig()
+	c := NewController(cfg, nil, nil, "owner", "repo")
+
+	evalMock := &mockEvalStore{
+		orphanedRunning: []*memory.Execution{
+			{ID: "exec-fresh", TaskID: "GH-500", ProjectPath: "/proj"},
+		},
+		executionEvents: map[string][]*memory.Event{
+			"exec-fresh": {
+				{ExecutionID: "exec-fresh", Stage: memory.StageRunning, OccurredAt: time.Now().Add(-2 * time.Minute)},
+			},
+		},
+	}
+	c.SetEvalStore(evalMock)
+	// No monitor set — simulates a fresh daemon restart with an empty in-memory Monitor.
+
+	c.sweepOrphanedRunningExecutions(nil)
+
+	if len(evalMock.resolvedOrphans) != 0 {
+		t.Fatalf("expected fresh-heartbeat row to survive the sweep, got resolve calls: %+v", evalMock.resolvedOrphans)
+	}
+}
+
+// TestSweepOrphanedRunningExecutions_StaleNoEvidenceMarkedFailed verifies that
+// a row with no live Monitor entry, no recent heartbeat, and no matching
+// merged PR resolves to 'failed' (empty prURL). TASK-399/GH-4209.
+func TestSweepOrphanedRunningExecutions_StaleNoEvidenceMarkedFailed(t *testing.T) {
+	cfg := DefaultConfig()
+	c := NewController(cfg, nil, nil, "owner", "repo")
+
+	evalMock := &mockEvalStore{
+		orphanedRunning: []*memory.Execution{
+			{ID: "exec-stale", TaskID: "GH-900", ProjectPath: "/proj", TaskBranch: "pilot/GH-900"},
+		},
+		executionEvents: map[string][]*memory.Event{
+			"exec-stale": {
+				{ExecutionID: "exec-stale", Stage: memory.StageRunning, OccurredAt: time.Now().Add(-2 * time.Hour)},
+			},
+		},
+	}
+	c.SetEvalStore(evalMock)
+
+	c.sweepOrphanedRunningExecutions(nil) // no merged PRs at all
+
+	if len(evalMock.resolvedOrphans) != 1 {
+		t.Fatalf("expected exactly 1 resolve call, got %d", len(evalMock.resolvedOrphans))
+	}
+	got := evalMock.resolvedOrphans[0]
+	if got.ID != "exec-stale" || got.PRURL != "" {
+		t.Errorf("expected exec-stale resolved with empty prURL (failed), got %+v", got)
+	}
+}
+
+// TestSweepOrphanedRunningExecutions_MergedPRHealsToCompleted verifies that a
+// stale orphan whose task branch matches a merged PR in the reused scan list
+// resolves to 'completed' with that PR's URL. TASK-399/GH-4209.
+func TestSweepOrphanedRunningExecutions_MergedPRHealsToCompleted(t *testing.T) {
+	cfg := DefaultConfig()
+	c := NewController(cfg, nil, nil, "owner", "repo")
+
+	evalMock := &mockEvalStore{
+		orphanedRunning: []*memory.Execution{
+			{ID: "exec-shipped", TaskID: "GH-4189", ProjectPath: "/proj", TaskBranch: "pilot/GH-4189"},
+		},
+	}
+	c.SetEvalStore(evalMock)
+
+	mergedPRs := []*github.PullRequest{
+		{Number: 42, Head: github.PRRef{Ref: "pilot/GH-4189"}, HTMLURL: "https://github.com/owner/repo/pull/42", Merged: true},
+	}
+
+	c.sweepOrphanedRunningExecutions(mergedPRs)
+
+	if len(evalMock.resolvedOrphans) != 1 {
+		t.Fatalf("expected exactly 1 resolve call, got %d", len(evalMock.resolvedOrphans))
+	}
+	got := evalMock.resolvedOrphans[0]
+	if got.ID != "exec-shipped" || got.PRURL != "https://github.com/owner/repo/pull/42" {
+		t.Errorf("expected exec-shipped healed to the merged PR URL, got %+v", got)
+	}
+}
+
+// TestSweepOrphanedRunningExecutions_MatchesByStoredPRURL verifies the
+// pr_url-based match (as opposed to branch) — a row that already carries its
+// own pr_url (stamped at PR-creation time) heals when that URL appears in the
+// merged PR list. TASK-399/GH-4209.
+func TestSweepOrphanedRunningExecutions_MatchesByStoredPRURL(t *testing.T) {
+	cfg := DefaultConfig()
+	c := NewController(cfg, nil, nil, "owner", "repo")
+
+	evalMock := &mockEvalStore{
+		orphanedRunning: []*memory.Execution{
+			{ID: "exec-by-url", TaskID: "GH-4155", ProjectPath: "/proj", PRUrl: "https://github.com/owner/repo/pull/77"},
+		},
+	}
+	c.SetEvalStore(evalMock)
+
+	mergedPRs := []*github.PullRequest{
+		// Deliberately non-matching branch — only pr_url should drive the match.
+		{Number: 77, Head: github.PRRef{Ref: "fix/renamed-branch"}, HTMLURL: "https://github.com/owner/repo/pull/77", Merged: true},
+	}
+
+	c.sweepOrphanedRunningExecutions(mergedPRs)
+
+	if len(evalMock.resolvedOrphans) != 1 || evalMock.resolvedOrphans[0].PRURL != "https://github.com/owner/repo/pull/77" {
+		t.Fatalf("expected exec-by-url healed via its own stored pr_url, got %+v", evalMock.resolvedOrphans)
+	}
+}
+
+// TestSweepOrphanedRunningExecutions_NoEvalStoreNoOp verifies the sweep is
+// silent (no panic, no queries) when no eval store is wired. TASK-399/GH-4209.
+func TestSweepOrphanedRunningExecutions_NoEvalStoreNoOp(t *testing.T) {
+	cfg := DefaultConfig()
+	c := NewController(cfg, nil, nil, "owner", "repo")
+	c.sweepOrphanedRunningExecutions(nil) // must not panic
+}
+
+// TestScanRecentlyMergedPRsWithWindow_WideLookbackHealsOutsideDefaultWindow
+// verifies TASK-399/GH-4209's Defect B widening: a shipped issue whose PR
+// merged outside the default 30-min scanWindow still self-heals to
+// 'completed' when the startup catch-up sweep runs with a wide lookback.
+func TestScanRecentlyMergedPRsWithWindow_WideLookbackHealsOutsideDefaultWindow(t *testing.T) {
+	oldMergedAt := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			prs := []*github.PullRequest{
+				{
+					Number:   42,
+					Head:     github.PRRef{Ref: "pilot/GH-4189", SHA: "sha1"},
+					Base:     github.PRRef{Ref: "main"},
+					HTMLURL:  "https://github.com/owner/repo/pull/42",
+					Merged:   true,
+					MergedAt: oldMergedAt,
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.MergedPRScanWindow = 30 * time.Minute
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	evalMock := &mockEvalStore{}
+	c.SetEvalStore(evalMock)
+
+	// The ordinary (config-window) scan must NOT heal this — it's outside 30m.
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs: %v", err)
+	}
+	if len(evalMock.selfHealed) != 0 {
+		t.Fatalf("expected no self-heal within the default window, got %+v", evalMock.selfHealed)
+	}
+
+	// The wide-lookback startup sweep DOES heal it.
+	if err := c.ScanRecentlyMergedPRsWithWindow(context.Background(), StartupMergedPRLookback); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRsWithWindow: %v", err)
+	}
+	if len(evalMock.selfHealed) != 1 || evalMock.selfHealed[0].TaskID != "GH-4189" {
+		t.Fatalf("expected GH-4189 healed by the wide-lookback sweep, got %+v", evalMock.selfHealed)
+	}
+}
+
+// TestScanRecentlyMergedPRsWithWindow_ClosesMarkerHealsNonPilotBranch verifies
+// TASK-399/GH-4209's issueNum widening: a shipped PR merged on a non-standard
+// branch (no "pilot/GH-N" prefix) still heals to 'completed' when its body
+// carries the "Closes #N" auto-close marker.
+func TestScanRecentlyMergedPRsWithWindow_ClosesMarkerHealsNonPilotBranch(t *testing.T) {
+	recentMergedAt := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			prs := []*github.PullRequest{
+				{
+					Number:   99,
+					Head:     github.PRRef{Ref: "pilot/fix-renamed-branch", SHA: "sha1"},
+					Base:     github.PRRef{Ref: "main"},
+					Body:     "This resolves the bug.\n\nCloses #4029",
+					HTMLURL:  "https://github.com/owner/repo/pull/99",
+					Merged:   true,
+					MergedAt: recentMergedAt,
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.MergedPRScanWindow = 30 * time.Minute
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	evalMock := &mockEvalStore{}
+	c.SetEvalStore(evalMock)
+	monitor := newMockTaskMonitor()
+	c.SetMonitor(monitor)
+
+	if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+		t.Fatalf("ScanRecentlyMergedPRs: %v", err)
+	}
+
+	if len(evalMock.selfHealed) != 1 || evalMock.selfHealed[0].TaskID != "GH-4029" {
+		t.Fatalf("expected GH-4029 healed via the PR body's Closes marker, got %+v", evalMock.selfHealed)
+	}
+
+	// TASK-399/GH-4209 monitor-consistency rider: the external-merge branch
+	// must also retire the QUEUE card, mirroring handleMerging (GH-1336).
+	if prURL, ok := monitor.completedTasks["GH-4029"]; !ok || prURL != "https://github.com/owner/repo/pull/99" {
+		t.Errorf("expected monitor.Complete(\"GH-4029\", ...) to be called, got %+v", monitor.completedTasks)
+	}
+}
+
+// TestScanRecentlyMergedPRsWithWindow_Idempotent verifies re-running the scan
+// against the same merged-PR/execution state does not re-trigger duplicate
+// heals or resolves. TASK-399/GH-4209.
+func TestScanRecentlyMergedPRsWithWindow_Idempotent(t *testing.T) {
+	recentMergedAt := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/repos/owner/repo/pulls"):
+			prs := []*github.PullRequest{
+				{
+					Number:   7,
+					Head:     github.PRRef{Ref: "pilot/GH-7", SHA: "sha1"},
+					Base:     github.PRRef{Ref: "main"},
+					HTMLURL:  "https://github.com/owner/repo/pull/7",
+					Merged:   true,
+					MergedAt: recentMergedAt,
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(prs)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		}
+	}))
+	defer server.Close()
+
+	ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+	cfg := DefaultConfig()
+	cfg.MergedPRScanWindow = 30 * time.Minute
+	c := NewController(cfg, ghClient, nil, "owner", "repo")
+
+	evalMock := &mockEvalStore{
+		orphanedRunning: []*memory.Execution{
+			{ID: "exec-7", TaskID: "GH-7", ProjectPath: "/proj", TaskBranch: "pilot/GH-7"},
+		},
+	}
+	c.SetEvalStore(evalMock)
+
+	for i := 0; i < 2; i++ {
+		if err := c.ScanRecentlyMergedPRs(context.Background()); err != nil {
+			t.Fatalf("ScanRecentlyMergedPRs call %d: %v", i, err)
+		}
+	}
+
+	if len(evalMock.selfHealed) != 2 {
+		t.Fatalf("expected selfHealForPR to run once per tick (idempotent per the store's own guards), got %d calls", len(evalMock.selfHealed))
+	}
+	// The orphan-running resolve fires every tick too (the mock doesn't mutate
+	// exec.Status), mirroring the real store's `AND status = 'running'` guard
+	// which makes the second call a no-op in production.
+	if len(evalMock.resolvedOrphans) != 2 {
+		t.Fatalf("expected the orphan sweep to run once per tick, got %d calls", len(evalMock.resolvedOrphans))
+	}
+	for _, call := range evalMock.resolvedOrphans {
+		if call.PRURL != "https://github.com/owner/repo/pull/7" {
+			t.Errorf("expected every resolve to converge on the same merged PR URL, got %+v", call)
+		}
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1231,6 +1231,84 @@ func (s *Store) GetActiveExecutions() ([]*Execution, error) {
 	return executions, rows.Err()
 }
 
+// FindOrphanedRunningExecutions returns status='running' rows whose task_id is
+// NOT in excludeTaskIDs — candidates for the autopilot orphan-running sweep
+// (TASK-399/GH-4209). excludeTaskIDs is the caller's in-flight set (e.g. the
+// live executor.Monitor's running/queued task IDs), so a genuinely executing
+// task is never returned as a candidate for reconciliation.
+func (s *Store) FindOrphanedRunningExecutions(excludeTaskIDs []string) ([]*Execution, error) {
+	query := `
+		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at, COALESCE(task_branch, '')
+		FROM executions
+		WHERE status = 'running'`
+	args := make([]interface{}, 0, len(excludeTaskIDs))
+	if len(excludeTaskIDs) > 0 {
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(excludeTaskIDs)), ",")
+		query += fmt.Sprintf(" AND task_id NOT IN (%s)", placeholders)
+		for _, id := range excludeTaskIDs {
+			args = append(args, id)
+		}
+	}
+	query += " ORDER BY created_at ASC"
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var executions []*Execution
+	for rows.Next() {
+		var exec Execution
+		var completedAt sql.NullTime
+		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &completedAt, &exec.TaskBranch); err != nil {
+			return nil, err
+		}
+		if completedAt.Valid {
+			exec.CompletedAt = &completedAt.Time
+		}
+		executions = append(executions, &exec)
+	}
+
+	return executions, rows.Err()
+}
+
+// orphanedRunningNoEvidenceError is the error stamped on an orphaned running
+// row that resolves to 'failed' (no merged PR found). TASK-399/GH-4209.
+const orphanedRunningNoEvidenceError = "orphaned running execution: no live process and no merged PR found on pr_url/branch"
+
+// ResolveOrphanedRunningExecution flips one orphan-running candidate (a row
+// the caller has already confirmed is not in flight — see
+// FindOrphanedRunningExecutions) to a terminal status. prURL non-empty means
+// the caller found a merged PR on this row's pr_url or branch, so the row
+// heals to 'completed' and prURL is stamped; empty means no merge evidence
+// exists, so the row is marked 'failed' — which keeps it eligible for the
+// ordinary SelfHealExecutionAfterMerge path if a merge surfaces later, since
+// 'failed' is already in that method's non-success IN(...) set.
+//
+// Guarded by `AND status = 'running'`: a no-op (and therefore idempotent) once
+// the row has transitioned through the normal completion path, and safe to
+// call repeatedly across sweep ticks. TASK-399/GH-4209.
+func (s *Store) ResolveOrphanedRunningExecution(id, prURL string) error {
+	return s.withRetry("ResolveOrphanedRunningExecution", func() error {
+		var err error
+		if prURL != "" {
+			_, err = s.db.Exec(`
+				UPDATE executions
+				SET status = 'completed', error = '', completed_at = CURRENT_TIMESTAMP, pr_url = ?
+				WHERE id = ? AND status = 'running'
+			`, prURL, id)
+		} else {
+			_, err = s.db.Exec(`
+				UPDATE executions
+				SET status = 'failed', error = ?, completed_at = CURRENT_TIMESTAMP
+				WHERE id = ? AND status = 'running'
+			`, orphanedRunningNoEvidenceError, id)
+		}
+		return err
+	})
+}
+
 // GetBriefMetrics calculates aggregate metrics for a time period including
 // task counts, success rates, average duration, and PR creation statistics.
 func (s *Store) GetBriefMetrics(query BriefQuery) (*BriefMetricsData, error) {
@@ -1453,6 +1531,27 @@ func (s *Store) SelfHealExecutionAfterMerge(taskID, projectPath, prURL string) e
 				pr_url = CASE WHEN ? <> '' THEN ? ELSE pr_url END
 			WHERE task_id = ? AND status IN ('failed', 'no_op', 'stalled', 'rate_limited', 'infra', 'skipped') AND (? = '' OR project_path = ?)
 		`, prURL, prURL, taskID, projectPath, projectPath)
+		return err
+	})
+}
+
+// SelfHealExecutionByPRURL is the pr_url-keyed fallback for selfHealForPR
+// (TASK-399/GH-4209): used when a merged PR's issue number can't be resolved
+// from its branch name or body markers ('Closes #N' / 'Parent: GH-N'). It
+// promotes any non-success row (same set as SelfHealExecutionAfterMerge)
+// whose own already-stamped pr_url column equals prURL — covering a PR on a
+// non-standard branch whose execution row still carries the PR URL from
+// UpdateExecutionResult at creation time. No-op when prURL is empty.
+func (s *Store) SelfHealExecutionByPRURL(prURL string) error {
+	if prURL == "" {
+		return nil
+	}
+	return s.withRetry("SelfHealExecutionByPRURL", func() error {
+		_, err := s.db.Exec(`
+			UPDATE executions
+			SET status = 'completed', error = '', completed_at = CURRENT_TIMESTAMP
+			WHERE pr_url = ? AND status IN ('failed', 'no_op', 'stalled', 'rate_limited', 'infra', 'skipped')
+		`, prURL)
 		return err
 	})
 }

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -3286,3 +3286,248 @@ func TestGetLifetimeTaskCounts_ProjectFilter(t *testing.T) {
 		t.Errorf("unfiltered Total = %d, want 5", tcAll.Total)
 	}
 }
+
+// TestFindOrphanedRunningExecutions_ExcludesInFlightTaskIDs verifies the
+// task_id NOT IN(...) exclusion — a status='running' row whose task_id is in
+// the caller-supplied live set (e.g. executor.Monitor's running/queued IDs)
+// must never be returned as an orphan-sweep candidate. TASK-399/GH-4209.
+func TestFindOrphanedRunningExecutions_ExcludesInFlightTaskIDs(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "run-live", TaskID: "GH-4206", ProjectPath: "/proj", Status: "running"})
+	_ = store.SaveExecution(&Execution{ID: "run-orphan", TaskID: "GH-4189", ProjectPath: "/proj", Status: "running"})
+	_ = store.SaveExecution(&Execution{ID: "run-done", TaskID: "GH-1", ProjectPath: "/proj", Status: "completed"})
+
+	results, err := store.FindOrphanedRunningExecutions([]string{"GH-4206"})
+	if err != nil {
+		t.Fatalf("FindOrphanedRunningExecutions: %v", err)
+	}
+
+	gotIDs := make(map[string]bool, len(results))
+	for _, r := range results {
+		gotIDs[r.ID] = true
+	}
+	if gotIDs["run-live"] {
+		t.Error("run-live: excluded task_id must not be returned as a candidate")
+	}
+	if !gotIDs["run-orphan"] {
+		t.Error("run-orphan: non-excluded running row must be returned as a candidate")
+	}
+	if gotIDs["run-done"] {
+		t.Error("run-done: non-running row must never be returned")
+	}
+}
+
+// TestFindOrphanedRunningExecutions_NoExclusions verifies an empty exclude set
+// returns every status='running' row (e.g. a cold-start sweep where the live
+// Monitor is empty). TASK-399/GH-4209.
+func TestFindOrphanedRunningExecutions_NoExclusions(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "run-1", TaskID: "GH-1", ProjectPath: "/proj", Status: "running"})
+	_ = store.SaveExecution(&Execution{ID: "run-2", TaskID: "GH-2", ProjectPath: "/proj", Status: "running"})
+
+	results, err := store.FindOrphanedRunningExecutions(nil)
+	if err != nil {
+		t.Fatalf("FindOrphanedRunningExecutions: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(results))
+	}
+}
+
+// TestResolveOrphanedRunningExecution_MergedHealsToCompleted verifies that
+// passing a non-empty prURL (merge evidence found) flips the row to
+// 'completed' and stamps the URL. TASK-399/GH-4209.
+func TestResolveOrphanedRunningExecution_MergedHealsToCompleted(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "orphan-merged", TaskID: "GH-4189", ProjectPath: "/proj", Status: "running"})
+
+	if err := store.ResolveOrphanedRunningExecution("orphan-merged", "https://github.com/org/repo/pull/42"); err != nil {
+		t.Fatalf("ResolveOrphanedRunningExecution: %v", err)
+	}
+
+	exec, err := store.GetExecution("orphan-merged")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "completed" {
+		t.Errorf("expected status 'completed', got %q", exec.Status)
+	}
+	if exec.PRUrl != "https://github.com/org/repo/pull/42" {
+		t.Errorf("expected pr_url stamped, got %q", exec.PRUrl)
+	}
+	if exec.CompletedAt == nil {
+		t.Error("expected completed_at to be set")
+	}
+}
+
+// TestResolveOrphanedRunningExecution_NoEvidenceHealsToFailed verifies that an
+// empty prURL (no merge evidence) flips the row to 'failed' — which keeps it
+// eligible for the ordinary SelfHealExecutionAfterMerge path (already
+// includes 'failed' in its IN(...) set) if a merge surfaces later.
+// TASK-399/GH-4209.
+func TestResolveOrphanedRunningExecution_NoEvidenceHealsToFailed(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "orphan-no-evidence", TaskID: "GH-99", ProjectPath: "/proj", Status: "running"})
+
+	if err := store.ResolveOrphanedRunningExecution("orphan-no-evidence", ""); err != nil {
+		t.Fatalf("ResolveOrphanedRunningExecution: %v", err)
+	}
+
+	exec, err := store.GetExecution("orphan-no-evidence")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected status 'failed', got %q", exec.Status)
+	}
+	if exec.Error == "" {
+		t.Error("expected a descriptive error message to be stamped")
+	}
+}
+
+// TestResolveOrphanedRunningExecution_IdempotentOnAlreadyTerminalRow verifies
+// the `AND status = 'running'` guard: re-running the resolve against a row
+// that has since transitioned through the normal completion path must be a
+// no-op, not a clobber. TASK-399/GH-4209.
+func TestResolveOrphanedRunningExecution_IdempotentOnAlreadyTerminalRow(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "already-done", TaskID: "GH-7", ProjectPath: "/proj", Status: "completed", PRUrl: "https://github.com/org/repo/pull/7"})
+
+	// Simulate a second sweep tick racing against the row's own normal
+	// completion — must not overwrite the real outcome.
+	if err := store.ResolveOrphanedRunningExecution("already-done", ""); err != nil {
+		t.Fatalf("ResolveOrphanedRunningExecution: %v", err)
+	}
+
+	exec, err := store.GetExecution("already-done")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "completed" {
+		t.Errorf("expected status to remain 'completed', got %q", exec.Status)
+	}
+	if exec.PRUrl != "https://github.com/org/repo/pull/7" {
+		t.Errorf("expected pr_url to remain stamped, got %q", exec.PRUrl)
+	}
+}
+
+// TestSelfHealExecutionByPRURL_HealsMatchingRow verifies the pr_url-keyed
+// fallback heal used when a merged PR's issue number can't be resolved at
+// all. TASK-399/GH-4209.
+func TestSelfHealExecutionByPRURL_HealsMatchingRow(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	prURL := "https://github.com/org/repo/pull/55"
+	_ = store.SaveExecution(&Execution{ID: "pr-url-heal", TaskID: "GH-55", ProjectPath: "/proj", Status: "failed", Error: "boom", PRUrl: prURL})
+	_ = store.SaveExecution(&Execution{ID: "unrelated", TaskID: "GH-56", ProjectPath: "/proj", Status: "failed", PRUrl: "https://github.com/org/repo/pull/56"})
+
+	if err := store.SelfHealExecutionByPRURL(prURL); err != nil {
+		t.Fatalf("SelfHealExecutionByPRURL: %v", err)
+	}
+
+	healed, err := store.GetExecution("pr-url-heal")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if healed.Status != "completed" {
+		t.Errorf("expected status 'completed', got %q", healed.Status)
+	}
+	if healed.Error != "" {
+		t.Errorf("expected error cleared, got %q", healed.Error)
+	}
+
+	unrelated, err := store.GetExecution("unrelated")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if unrelated.Status != "failed" {
+		t.Errorf("unrelated row must be unaffected, got %q", unrelated.Status)
+	}
+}
+
+// TestSelfHealExecutionByPRURL_EmptyURLNoOp verifies an empty prURL never
+// touches any row (avoids matching rows with an empty pr_url column).
+// TASK-399/GH-4209.
+func TestSelfHealExecutionByPRURL_EmptyURLNoOp(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_ = store.SaveExecution(&Execution{ID: "no-pr-url", TaskID: "GH-1", ProjectPath: "/proj", Status: "failed"})
+
+	if err := store.SelfHealExecutionByPRURL(""); err != nil {
+		t.Fatalf("SelfHealExecutionByPRURL: %v", err)
+	}
+
+	exec, err := store.GetExecution("no-pr-url")
+	if err != nil {
+		t.Fatalf("GetExecution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected status to remain 'failed', got %q", exec.Status)
+	}
+}
+
+// TestSelfHealExecutionAfterMerge_ExcludesRunningQueuedPending is the
+// GH-4209 regression test for the store.go:1446 IN(...) exclusion this task
+// must preserve unmodified: running/queued/pending rows are never healed by
+// SelfHealExecutionAfterMerge, only the non-success terminal set.
+func TestSelfHealExecutionAfterMerge_ExcludesRunningQueuedPending(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	statuses := []string{"running", "queued", "pending"}
+	for i, status := range statuses {
+		id := fmt.Sprintf("in-flight-%d", i)
+		_ = store.SaveExecution(&Execution{ID: id, TaskID: "GH-8", ProjectPath: "/proj", Status: status})
+	}
+
+	if err := store.SelfHealExecutionAfterMerge("GH-8", "/proj", "https://github.com/org/repo/pull/8"); err != nil {
+		t.Fatalf("SelfHealExecutionAfterMerge: %v", err)
+	}
+
+	for i, status := range statuses {
+		id := fmt.Sprintf("in-flight-%d", i)
+		exec, err := store.GetExecution(id)
+		if err != nil {
+			t.Fatalf("GetExecution(%s): %v", id, err)
+		}
+		if exec.Status != status {
+			t.Errorf("%s: expected status to remain %q, got %q", id, status, exec.Status)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements the shared reconciliation layer from TASK-399: HISTORY was showing
issues that are CLOSED COMPLETED via a merged PR as `running` or `failed`
because two DB-write gaps were never healed.

**Store layer** (`internal/memory/store.go`):
- `FindOrphanedRunningExecutions(excludeTaskIDs)` — status='running' rows not in the caller's in-flight set.
- `ResolveOrphanedRunningExecution(id, prURL)` — resolves a candidate to `completed` (prURL found) or `failed`, guarded by `AND status='running'` (idempotent).
- `SelfHealExecutionByPRURL(prURL)` — pr_url-keyed fallback heal for merges whose issue number can't be resolved from branch or body.
- `SelfHealExecutionAfterMerge`'s existing terminal `IN(...)` exclusion (store.go:1446) is untouched.

**Autopilot layer** (`internal/autopilot/controller.go`):
- New orphan-running sweep (`sweepOrphanedRunningExecutions`) runs on every merged-PR scan tick (startup + periodic), excluding `executor.Monitor`'s running/queued set and any row with a recent `execution_events` heartbeat — the hard GH-4206 regression gate against flipping a genuinely-running task.
- `selfHealForPR` issueNum resolution widened beyond the `pilot/GH-%d` branch prefix: also parses the PR body's `Closes #N` / `Parent: GH-N` markers.
- `ScanRecentlyMergedPRsWithWindow(ctx, window)` lets startup run a wide-lookback catch-up scan (`StartupMergedPRLookback`, 30d) instead of the periodic 30-min `scanWindow` — no extra GitHub calls, since `ListPullRequests` already fetches the full closed-PR list regardless of window.
- The external-merge branch of `ScanRecentlyMergedPRs` now also calls `monitor.Complete`, mirroring `handleMerging` (GH-1336), so the QUEUE card retires too.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test -race ./internal/autopilot/... ./internal/memory/... ./internal/executor/... ./internal/dashboard/...`
- [x] `go test ./...` (full repo)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New table tests: GH-4206 guard (live Monitor entry / fresh heartbeat not flipped), merged-outside-30-min-window heals via wide lookback, non-`pilot/GH-N` branch resolved via PR body `Closes #N`, `SelfHealExecutionAfterMerge` still excludes running/queued/pending, sweep idempotency.