### PR TITLE
fix(autopilot): record throughput histograms live and hydrate from ledger

### DIFF
--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -15,10 +15,24 @@ import (
 
 	"github.com/qf-studio/pilot/internal/adapters/sdkshim"
 	"github.com/qf-studio/pilot/internal/alerts"
+	"github.com/qf-studio/pilot/internal/autopilot"
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/executor"
 	"github.com/qf-studio/pilot/internal/logging"
 )
+
+// githubOnPRCreatedHandler builds the callback wired into pollerDeps.OnPRCreated:
+// it forwards the SDK's PRCreatedEvent into Controller.OnPRCreated, the sole live
+// entry point for the GH-4130 throughput-histogram observation. Extracted to its
+// own function (GH-4211) so a regression test can drive the real handler that
+// production wires up, instead of calling ctrl.OnPRCreated directly — the gap
+// that let GH-4130's observation ship false-green in the first place.
+func githubOnPRCreatedHandler(ctrl *autopilot.Controller) func(sdkcore.PRCreatedEvent) {
+	return func(prEv sdkcore.PRCreatedEvent) {
+		issueNumber, _ := strconv.Atoi(prEv.IssueID)
+		ctrl.OnPRCreated(prEv.PRNumber, prEv.PRURL, issueNumber, prEv.HeadSHA, prEv.BranchName, prEv.IssueNodeID)
+	}
+}
 
 // sdkPollerVerifyTimeout bounds the one-off authenticated call made before
 // the SDK poller starts (GH-3917), matching preflightVerifyTimeout's budget
@@ -302,12 +316,9 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 	}
 	if controller != nil {
 		ctrl := controller
-		pollerDeps.OnPRCreated = func(prEv sdkcore.PRCreatedEvent) {
-			// GitHub's IssueID is the numeric issue number; forward it (and the node ID)
-			// so the autopilot controller's post-merge gates and board-sync-to-Review work.
-			issueNumber, _ := strconv.Atoi(prEv.IssueID)
-			ctrl.OnPRCreated(prEv.PRNumber, prEv.PRURL, issueNumber, prEv.HeadSHA, prEv.BranchName, prEv.IssueNodeID)
-		}
+		// GitHub's IssueID is the numeric issue number; forwarded (with the node ID)
+		// so the autopilot controller's post-merge gates and board-sync-to-Review work.
+		pollerDeps.OnPRCreated = githubOnPRCreatedHandler(ctrl)
 		pollerDeps.IssueMetricsRecorder = ctrl.Metrics()
 	} else if len(deps.AutopilotControllers) > 0 {
 		repoLog.Error("GitHub SDK poller: no autopilot controller for repo — PRs from this repo will not be auto-merged; check projects[] vs autopilot config")

--- a/cmd/pilot/poller_github_gh4211_test.go
+++ b/cmd/pilot/poller_github_gh4211_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/autopilot"
+	"github.com/qf-studio/pilot/internal/memory"
+	"github.com/qf-studio/pilot/internal/testutil"
+	sdkcore "github.com/qf-studio/studio-sdk/sdk/core"
+	githubSDK "github.com/qf-studio/studio-sdk/sdk/integrations/github"
+)
+
+// seedGH4211ExecutionTimes sets explicit created_at/started_at on an executions
+// row via a direct SQL connection, bypassing UpdateExecutionStatus's
+// CURRENT_TIMESTAMP (whole-second resolution, which would make a short-lived
+// test's queue-wait delta flaky/zero).
+func seedGH4211ExecutionTimes(t *testing.T, dbPath string, executionID string, createdAt, startedAt time.Time) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec(
+		`UPDATE executions SET created_at = ?, started_at = ? WHERE id = ?`,
+		createdAt, startedAt, executionID,
+	); err != nil {
+		t.Fatalf("seed execution times failed: %v", err)
+	}
+}
+
+// TestGithubOnPRCreatedHandler_ObservesThroughputHistograms drives the real
+// production wiring (pollerDeps.OnPRCreated -> githubOnPRCreatedHandler ->
+// Controller.OnPRCreated) with an actual sdkcore.PRCreatedEvent and a real
+// SQLite-backed memory.Store, instead of calling ctrl.OnPRCreated directly.
+//
+// GH-4130's own test (internal/autopilot/gh4130_test.go) only ever called
+// OnPRCreated directly against a hand-built *memory.Execution with StartedAt
+// already set — it never went through GetLatestExecutionByTaskID's real SQL
+// scan. That's exactly why GH-4211's root cause (executionDetailColumns/
+// scanExecutionDetail never selected the started_at column, so exec.StartedAt
+// was always nil for every real lookup) shipped invisible: the fake test
+// double bypassed the buggy code path entirely. This test exercises the real
+// DB round trip through the real live entry point so that gap can't recur.
+func TestGithubOnPRCreatedHandler_ObservesThroughputHistograms(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	execID := "exec-gh4211"
+	if err := store.SaveExecution(&memory.Execution{
+		ID: execID, TaskID: "GH-4211", ProjectPath: "/p", Status: "queued",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	if err := store.UpdateExecutionStatus(execID, "running"); err != nil {
+		t.Fatalf("UpdateExecutionStatus(running): %v", err)
+	}
+	// Pin explicit, second-resolution-safe timestamps: created_at 6m before
+	// started_at (queue wait) and started_at 4m in the past (time-to-PR), so
+	// assertions below aren't flaky against CURRENT_TIMESTAMP's whole-second
+	// resolution.
+	startedAt := time.Now().Add(-4 * time.Minute)
+	createdAt := startedAt.Add(-6 * time.Minute)
+	seedGH4211ExecutionTimes(t, filepath.Join(tmpDir, "pilot.db"), execID, createdAt, startedAt)
+
+	cfg := autopilot.DefaultConfig()
+	ghClient := githubSDK.NewClient(testutil.FakeGitHubToken)
+	ctrl := autopilot.NewController(cfg, ghClient, nil, "owner", "repo", autopilot.WithMemoryStore(store))
+
+	// This is the exact function production wires into pollerDeps.OnPRCreated
+	// (poller_github.go), not a re-implementation of it.
+	handler := githubOnPRCreatedHandler(ctrl)
+	handler(sdkcore.PRCreatedEvent{
+		PRNumber:   4212,
+		PRURL:      "https://github.com/owner/repo/pull/4212",
+		IssueID:    "4211",
+		HeadSHA:    "abc1234",
+		BranchName: "pilot/GH-4211",
+	})
+
+	hist := ctrl.Metrics().HistogramSnapshot()
+	if len(hist.TimeToPRDurations) != 1 {
+		t.Fatalf("TimeToPRDurations = %v, want 1 sample recorded via the live entry point", hist.TimeToPRDurations)
+	}
+	if len(hist.QueueWaitDurations) != 1 {
+		t.Fatalf("QueueWaitDurations = %v, want 1 sample recorded via the live entry point", hist.QueueWaitDurations)
+	}
+	if got := hist.QueueWaitDurations[0]; got < 5*time.Minute || got > 7*time.Minute {
+		t.Errorf("QueueWaitDurations[0] = %v, want ~6m", got)
+	}
+	if hist.TimeToPRDurations[0] < 3*time.Minute {
+		t.Errorf("TimeToPRDurations[0] = %v, want >= 3m (started_at was ~4m ago)", hist.TimeToPRDurations[0])
+	}
+}
+
+// TestGithubOnPRCreatedHandler_MissingStartedAt_SkipsObservation pins the
+// fail-loud guard added in controller.go: an execution row with no
+// started_at (e.g. never picked up by a worker) must not be observed as a
+// zero/negative-duration sample, but the lookup itself must not panic or
+// error out the handler.
+func TestGithubOnPRCreatedHandler_MissingStartedAt_SkipsObservation(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "exec-gh4211-b", TaskID: "GH-9999", ProjectPath: "/p", Status: "queued",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	cfg := autopilot.DefaultConfig()
+	ghClient := githubSDK.NewClient(testutil.FakeGitHubToken)
+	ctrl := autopilot.NewController(cfg, ghClient, nil, "owner", "repo", autopilot.WithMemoryStore(store))
+
+	handler := githubOnPRCreatedHandler(ctrl)
+	handler(sdkcore.PRCreatedEvent{
+		PRNumber:   4213,
+		PRURL:      "https://github.com/owner/repo/pull/4213",
+		IssueID:    "9999",
+		HeadSHA:    "def5678",
+		BranchName: "pilot/GH-9999",
+	})
+
+	hist := ctrl.Metrics().HistogramSnapshot()
+	if len(hist.TimeToPRDurations) != 0 || len(hist.QueueWaitDurations) != 0 {
+		t.Errorf("expected no histogram samples for an execution with no started_at, got TimeToPR=%v QueueWait=%v",
+			hist.TimeToPRDurations, hist.QueueWaitDurations)
+	}
+}

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -873,16 +873,34 @@ func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, he
 	c.activePRs[prNumber] = prState
 	c.mu.Unlock()
 
-	// GH-4130: observe pilot_time_to_pr_seconds / pilot_queue_wait_seconds now
-	// that the PR exists — this is the first point autopilot sees the issue's
+	// GH-4130/GH-4211: observe pilot_time_to_pr_seconds / pilot_queue_wait_seconds
+	// now that the PR exists — this is the first point autopilot sees the issue's
 	// execution, so it's the natural place to read started_at/created_at off
-	// the execution row (taskID resolution mirrors recordExecutionEvent).
+	// the execution row (taskID resolution mirrors recordExecutionEvent). Every
+	// skip path logs a warning (fail-loud, TASK-379) instead of silently eating
+	// the sample — this guard previously swallowed every observation because
+	// GetLatestExecutionByTaskID never populated exec.StartedAt (GH-4211 D1).
 	if c.memoryStore != nil {
 		taskID := fmt.Sprintf("GH-%d", issueNumber)
 		if issueNumber == 0 {
 			taskID = fmt.Sprintf("PR-%d", prNumber)
+			c.log.Warn("GH-4211: PR-created event carried no issue number — time-to-PR/queue-wait taskID falls back to PR-N, which will not match any GH-N execution row",
+				"pr", prNumber, "task_id", taskID)
 		}
-		if exec, err := c.memoryStore.GetLatestExecutionByTaskID(taskID); err == nil && exec.StartedAt != nil {
+		exec, err := c.memoryStore.GetLatestExecutionByTaskID(taskID)
+		switch {
+		case err != nil:
+			if !errors.Is(err, sql.ErrNoRows) {
+				c.log.Warn("GH-4211: time-to-PR/queue-wait observation skipped — execution lookup failed",
+					"pr", prNumber, "task_id", taskID, "error", err)
+			} else {
+				c.log.Warn("GH-4211: time-to-PR/queue-wait observation skipped — no execution row for task",
+					"pr", prNumber, "task_id", taskID)
+			}
+		case exec.StartedAt == nil:
+			c.log.Warn("GH-4211: time-to-PR/queue-wait observation skipped — execution row has no started_at",
+				"pr", prNumber, "task_id", taskID, "execution_id", exec.ID)
+		default:
 			c.metrics.RecordTimeToPR(time.Since(*exec.StartedAt))
 			c.metrics.RecordQueueWaitDuration(exec.StartedAt.Sub(exec.CreatedAt))
 		}
@@ -1747,6 +1765,14 @@ func (c *Controller) applyApprovalDecision(prState *PRState) error {
 	// request was submitted (functionally the awaiting_approval entry point) to
 	// this merge decision being applied — covers both the SetApprovalDecision
 	// webhook path and the wall-clock-expiry default-action path (Path 3 above).
+	//
+	// GH-4211: unlike time-to-PR/queue-wait (OnPRCreated above), this trigger
+	// does NOT go through GetLatestExecutionByTaskID/exec.StartedAt at all — it
+	// reads prState.ApprovalRequestedAt, an in-memory field set directly by
+	// submitAsyncApprovalRequest/the timeout branch — so it was never subject to
+	// D1's missing-column bug and needs no live-path fix. It IS still subject to
+	// D2 (reset to zero on restart, since activePRs is in-memory and not
+	// reloaded), which GetLifetimeApprovalWait/HydrateFromStore now covers.
 	if !prState.ApprovalRequestedAt.IsZero() {
 		c.metrics.RecordApprovalWaitDuration(time.Since(prState.ApprovalRequestedAt))
 	}

--- a/internal/autopilot/metrics_hydrator.go
+++ b/internal/autopilot/metrics_hydrator.go
@@ -103,6 +103,37 @@ func HydrateFromStore(ctx context.Context, store *memory.Store, metrics *Metrics
 		metrics.RecordPRTimeToMerge(d)
 	}
 
+	// GH-4211: the TASK-393/GH-4128 throughput histograms (pilot_time_to_pr_seconds,
+	// pilot_queue_wait_seconds, pilot_approval_wait_seconds) reset to zero on every
+	// restart same as pilot_pr_time_to_merge_seconds above — reconstruct them from
+	// the ledger/executions table so a daily self-upgrade restart doesn't wipe the
+	// throughput view. Each Record* call self-caps at Metrics.maxSamples, and the
+	// three Get* queries return samples oldest-first, so the cap keeps the most
+	// recent N regardless of how many lifetime rows exist.
+	timeToPR, err := store.GetLifetimeTimeToPR()
+	if err != nil {
+		return fmt.Errorf("hydrate metrics from store: lifetime time-to-PR: %w", err)
+	}
+	for _, d := range timeToPR {
+		metrics.RecordTimeToPR(d)
+	}
+
+	queueWait, err := store.GetLifetimeQueueWait()
+	if err != nil {
+		return fmt.Errorf("hydrate metrics from store: lifetime queue wait: %w", err)
+	}
+	for _, d := range queueWait {
+		metrics.RecordQueueWaitDuration(d)
+	}
+
+	approvalWait, err := store.GetLifetimeApprovalWait()
+	if err != nil {
+		return fmt.Errorf("hydrate metrics from store: lifetime approval wait: %w", err)
+	}
+	for _, d := range approvalWait {
+		metrics.RecordApprovalWaitDuration(d)
+	}
+
 	// The remaining counters are intentionally NOT hydrated here — they have no
 	// durable per-event source to hydrate from (unlike execution_events, which
 	// is an append-only ledger keyed off executions.id) and reset to zero on

--- a/internal/autopilot/metrics_hydrator_test.go
+++ b/internal/autopilot/metrics_hydrator_test.go
@@ -2,7 +2,10 @@ package autopilot
 
 import (
 	"context"
+	"database/sql"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/qf-studio/pilot/internal/memory"
 )
@@ -400,5 +403,127 @@ func TestHydrateFromStore_RestartContinuity(t *testing.T) {
 	// nothing reads postMetrics between NewMetrics() and HydrateFromStore().
 	if postTokens == 0 {
 		t.Error("post-restart tokens baseline is zero, hydration did not run")
+	}
+}
+
+// seedGH4211ExecutionTimes sets explicit created_at/started_at on an
+// executions row via a direct SQL connection — store.SaveExecution never
+// writes started_at (GH-4033's column is only stamped by
+// UpdateExecutionStatus's CURRENT_TIMESTAMP), and this test needs
+// deterministic, well-separated timestamps rather than relying on
+// whole-second wall-clock resolution.
+func seedGH4211ExecutionTimes(t *testing.T, dbPath string, executionID string, createdAt, startedAt time.Time) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec(
+		`UPDATE executions SET created_at = ?, started_at = ? WHERE id = ?`,
+		createdAt, startedAt, executionID,
+	); err != nil {
+		t.Fatalf("seed execution times failed: %v", err)
+	}
+}
+
+// seedGH4211EventAt inserts an execution_events row with an explicit
+// occurred_at, bypassing store.InsertExecutionEvent (which always stamps
+// time.Now().UTC()) so the derived duration samples below are deterministic.
+func seedGH4211EventAt(t *testing.T, dbPath string, executionID string, stage memory.Stage, occurredAt time.Time) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec(
+		`INSERT INTO execution_events (execution_id, stage, occurred_at, detail) VALUES (?, ?, ?, ?)`,
+		executionID, string(stage), occurredAt, "",
+	); err != nil {
+		t.Fatalf("seed event failed: %v", err)
+	}
+}
+
+// TestHydrateFromStore_ThroughputHistogramsSurviveRestart pins GH-4211 D2: the
+// TASK-393/GH-4128 throughput histograms (pilot_time_to_pr_seconds,
+// pilot_queue_wait_seconds, pilot_approval_wait_seconds) must be reconstructed
+// from the ledger/executions table at hydration time, same as
+// pilot_pr_time_to_merge_seconds already is (GH-4093) — otherwise the daily
+// self-upgrade restart wipes the throughput view every day even after D1's
+// live-path fix.
+func TestHydrateFromStore_ThroughputHistogramsSurviveRestart(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	execID := "gh4211-1"
+	if err := store.SaveExecution(&memory.Execution{
+		ID: execID, TaskID: "GH-4211", ProjectPath: "/p", Status: "completed",
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	now := time.Now()
+	createdAt := now.Add(-20 * time.Minute)
+	startedAt := now.Add(-14 * time.Minute)  // queue wait ~= 6m
+	prCreatedAt := now.Add(-9 * time.Minute) // time-to-PR ~= 5m from startedAt
+	awaitingAt := now.Add(-8 * time.Minute)
+	mergedAt := now.Add(-3 * time.Minute) // approval wait ~= 5m from awaitingAt
+
+	dbPath := filepath.Join(tmpDir, "pilot.db")
+	seedGH4211ExecutionTimes(t, dbPath, execID, createdAt, startedAt)
+	seedGH4211EventAt(t, dbPath, execID, memory.StageRunning, startedAt)
+	seedGH4211EventAt(t, dbPath, execID, memory.StagePRCreated, prCreatedAt)
+	seedGH4211EventAt(t, dbPath, execID, memory.StageAwaitingApproval, awaitingAt)
+	seedGH4211EventAt(t, dbPath, execID, memory.StageMerged, mergedAt)
+
+	metrics := NewMetrics()
+	if err := HydrateFromStore(context.Background(), store, metrics); err != nil {
+		t.Fatalf("HydrateFromStore: %v", err)
+	}
+	hist := metrics.HistogramSnapshot()
+
+	if len(hist.TimeToPRDurations) != 1 {
+		t.Fatalf("TimeToPRDurations = %v, want 1 hydrated sample", hist.TimeToPRDurations)
+	}
+	if got := hist.TimeToPRDurations[0]; got < 4*time.Minute || got > 6*time.Minute {
+		t.Errorf("TimeToPRDurations[0] = %v, want ~5m", got)
+	}
+
+	if len(hist.QueueWaitDurations) != 1 {
+		t.Fatalf("QueueWaitDurations = %v, want 1 hydrated sample", hist.QueueWaitDurations)
+	}
+	if got := hist.QueueWaitDurations[0]; got < 5*time.Minute || got > 7*time.Minute {
+		t.Errorf("QueueWaitDurations[0] = %v, want ~6m", got)
+	}
+
+	if len(hist.ApprovalWaitDurations) != 1 {
+		t.Fatalf("ApprovalWaitDurations = %v, want 1 hydrated sample", hist.ApprovalWaitDurations)
+	}
+	if got := hist.ApprovalWaitDurations[0]; got < 4*time.Minute || got > 6*time.Minute {
+		t.Errorf("ApprovalWaitDurations[0] = %v, want ~5m", got)
+	}
+
+	// Restart simulation: a fresh (all-zero) Metrics hydrated from the same
+	// store must not observe zero for any of the three histograms.
+	restarted := NewMetrics()
+	if err := HydrateFromStore(context.Background(), store, restarted); err != nil {
+		t.Fatalf("HydrateFromStore (post-restart): %v", err)
+	}
+	restartedHist := restarted.HistogramSnapshot()
+	if len(restartedHist.TimeToPRDurations) == 0 {
+		t.Error("TimeToPRDurations reset to zero on simulated restart")
+	}
+	if len(restartedHist.QueueWaitDurations) == 0 {
+		t.Error("QueueWaitDurations reset to zero on simulated restart")
+	}
+	if len(restartedHist.ApprovalWaitDurations) == 0 {
+		t.Error("ApprovalWaitDurations reset to zero on simulated restart")
 	}
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -601,7 +602,7 @@ func unmarshalLabels(s string) []string {
 // executionDetailColumns is the full column set for a single Execution row,
 // shared by GetExecution and GetLatestExecutionByTaskID.
 const executionDetailColumns = `
-	id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at,
+	id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, started_at, completed_at,
 	COALESCE(tokens_input, 0), COALESCE(tokens_output, 0), COALESCE(tokens_total, 0),
 	COALESCE(tokens_cache_read, 0), COALESCE(tokens_cache_write, 0),
 	COALESCE(estimated_cost_usd, 0), COALESCE(files_changed, 0), COALESCE(lines_added, 0),
@@ -624,10 +625,11 @@ type rowScanner interface {
 // scanExecutionDetail scans a row selected via executionDetailColumns into an Execution.
 func scanExecutionDetail(row rowScanner) (*Execution, error) {
 	var exec Execution
+	var startedAt sql.NullTime
 	var completedAt sql.NullTime
 	var approvalDecisionAt sql.NullTime
 	var labelsJSON string
-	err := row.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &completedAt,
+	err := row.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &startedAt, &completedAt,
 		&exec.TokensInput, &exec.TokensOutput, &exec.TokensTotal, &exec.TokensCacheRead, &exec.TokensCacheWrite,
 		&exec.EstimatedCostUSD, &exec.FilesChanged, &exec.LinesAdded, &exec.LinesRemoved, &exec.ModelName,
 		&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose,
@@ -638,6 +640,9 @@ func scanExecutionDetail(row rowScanner) (*Execution, error) {
 		return nil, err
 	}
 	exec.TaskLabels = unmarshalLabels(labelsJSON)
+	if startedAt.Valid {
+		exec.StartedAt = &startedAt.Time
+	}
 	if approvalDecisionAt.Valid {
 		exec.ApprovalDecisionAt = &approvalDecisionAt.Time
 	}
@@ -2580,6 +2585,121 @@ func (s *Store) GetLifetimePRTimeToMerge() ([]time.Duration, error) {
 		}
 	}
 	return samples, nil
+}
+
+// timedSample pairs a histogram observation with the wall-clock time it
+// occurred, so callers can sort chronologically before applying a
+// most-recent-N cap (Metrics.maxSamples) — execution_events queries return
+// results keyed by a Go map, which has no stable iteration order.
+type timedSample struct {
+	at time.Time
+	d  time.Duration
+}
+
+func sortedDurations(samples []timedSample) []time.Duration {
+	sort.Slice(samples, func(i, j int) bool { return samples[i].at.Before(samples[j].at) })
+	out := make([]time.Duration, len(samples))
+	for i, sm := range samples {
+		out[i] = sm.d
+	}
+	return out
+}
+
+// GetLifetimeTimeToPR derives pilot_time_to_pr_seconds histogram samples from
+// execution_events timestamps: for every execution_id that has both a
+// 'running' and a 'pr_created' row, the sample is the earliest 'pr_created'
+// occurred_at minus the earliest 'running' occurred_at (GH-4211, mirrors
+// GetLifetimePRTimeToMerge). Samples are returned oldest-first so a caller
+// capping to the most recent N keeps the right tail.
+func (s *Store) GetLifetimeTimeToPR() ([]time.Duration, error) {
+	running, err := s.earliestStageOccurrences(StageRunning)
+	if err != nil {
+		return nil, err
+	}
+	created, err := s.earliestStageOccurrences(StagePRCreated)
+	if err != nil {
+		return nil, err
+	}
+
+	var samples []timedSample
+	for execID, createdAt := range created {
+		startedAt, ok := running[execID]
+		if !ok {
+			continue
+		}
+		if d := createdAt.Sub(startedAt); d > 0 {
+			samples = append(samples, timedSample{at: createdAt, d: d})
+		}
+	}
+	return sortedDurations(samples), nil
+}
+
+// GetLifetimeQueueWait derives pilot_queue_wait_seconds histogram samples
+// directly from the executions table: for every row with a non-null
+// started_at, the sample is started_at minus created_at (GH-4211). Unlike
+// GetLifetimeTimeToPR/GetLifetimePRTimeToMerge this reads executions, not
+// execution_events — queue wait is a property of the execution row itself,
+// not a ledger transition. Samples are returned oldest-first.
+func (s *Store) GetLifetimeQueueWait() ([]time.Duration, error) {
+	rows, err := s.db.Query(`
+		SELECT created_at, started_at
+		FROM executions
+		WHERE started_at IS NOT NULL
+		ORDER BY started_at ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query queue wait samples: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var samples []time.Duration
+	for rows.Next() {
+		var createdAt, startedAt time.Time
+		if err := rows.Scan(&createdAt, &startedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan queue wait row: %w", err)
+		}
+		if d := startedAt.Sub(createdAt); d > 0 {
+			samples = append(samples, d)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate queue wait rows: %w", err)
+	}
+	return samples, nil
+}
+
+// GetLifetimeApprovalWait derives pilot_approval_wait_seconds histogram
+// samples from execution_events timestamps: for every execution_id that has
+// both an 'awaiting_approval' and a 'merged' row, the sample is the earliest
+// 'merged' occurred_at minus the earliest 'awaiting_approval' occurred_at
+// (GH-4211). The live path (Controller.applyApprovalDecision) also observes
+// a sample when approval is rejected/times out, but that decision itself is
+// never durably persisted as a distinct ledger stage — only the terminal
+// 'merged' transition is — so a rejected/timed-out approval has no
+// ledger-derivable pair and is not represented here (reset-on-restart for
+// that subset, same as the operational counters documented below). Samples
+// are returned oldest-first.
+func (s *Store) GetLifetimeApprovalWait() ([]time.Duration, error) {
+	awaiting, err := s.earliestStageOccurrences(StageAwaitingApproval)
+	if err != nil {
+		return nil, err
+	}
+	merged, err := s.earliestStageOccurrences(StageMerged)
+	if err != nil {
+		return nil, err
+	}
+
+	var samples []timedSample
+	for execID, mergedAt := range merged {
+		awaitingAt, ok := awaiting[execID]
+		if !ok {
+			continue
+		}
+		if d := mergedAt.Sub(awaitingAt); d > 0 {
+			samples = append(samples, timedSample{at: mergedAt, d: d})
+		}
+	}
+	return sortedDurations(samples), nil
 }
 
 // EndSession marks a session as ended.


### PR DESCRIPTION
## Summary
- Fixes GH-4211: `pilot_time_to_pr_seconds` / `pilot_queue_wait_seconds` never recorded a live sample because `GetLatestExecutionByTaskID` (and every caller sharing `executionDetailColumns`/`scanExecutionDetail`) never selected the `started_at` column, so `exec.StartedAt` was always `nil` in `Controller.OnPRCreated`'s guard.
- Every skip path in that guard now logs a warning instead of silently eating the sample (fail-loud, TASK-379).
- Extends `metrics_hydrator.go` (GH-4093 precedent) to reconstruct `TimeToPRDurations`, `QueueWaitDurations`, and `ApprovalWaitDurations` from `execution_events`/`executions` at startup, so a daemon restart no longer wipes the three histograms back to zero.
- Extracts the `pollerDeps.OnPRCreated` closure into `githubOnPRCreatedHandler` so a regression test can drive the real live entry point (SDK `PRCreatedEvent` → hook → `Controller.OnPRCreated`) instead of calling `OnPRCreated` directly — the gap that let GH-4130's own test miss this bug.

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test -race ./internal/autopilot/... ./internal/gateway/... ./internal/memory/... ./cmd/pilot/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [ ] Live: restart daemon → histogram counts survive; next PR cycle increments `pilot_time_to_pr_seconds_count` / `pilot_queue_wait_seconds_count`