### PR TITLE
GH-4220: fix(executor): stop epic parent re-implementing shipped child work

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -400,6 +400,12 @@ func consolidateEpicPlan(originalDesc string, subtasks []PlannedSubtask) string 
 // would cause merge conflicts because each sub-issue branches from main independently.
 //
 // Detection strategy:
+//  0. A plan with 0 or 1 subtasks can never conflict with a sibling — short-circuit
+//     to true before the directory/title heuristics below even run (GH-4219/GH-4220:
+//     a single-subtask plan fell through to detectSameComponentFromTitles, which
+//     requires >=2 titles and always returned false, so the epic parent created one
+//     sub-issue for a single-item plan and then re-implemented that same slice
+//     itself instead of deferring to the child).
 //  1. Extract file paths from subtask titles and descriptions — they define the
 //     actual work scope. Paths cited only in the parent description are context
 //     (e.g. code being defended against) and must not flip the verdict (GH-3597:
@@ -412,6 +418,10 @@ func consolidateEpicPlan(originalDesc string, subtasks []PlannedSubtask) string 
 // GH-1265: This prevents the "serial conflict cascade" bug where N sub-issues
 // all touching cmd/pilot/ create N branches from main, each redeclaring shared types.
 func isSinglePackageScope(subtasks []PlannedSubtask, taskDescription string) bool {
+	if len(subtasks) <= 1 {
+		return true
+	}
+
 	var subtaskText strings.Builder
 	for _, st := range subtasks {
 		subtaskText.WriteString(st.Title)

--- a/internal/executor/epic_test.go
+++ b/internal/executor/epic_test.go
@@ -362,12 +362,22 @@ func TestIsSinglePackageScope(t *testing.T) {
 			expected:    false,
 		},
 		{
-			name: "single subtask always false (no conflict possible)",
+			// GH-4219/GH-4220: single-subtask plans short-circuit to true so the
+			// epic decision branch in runner.go consolidates into direct execution
+			// (zero children created) instead of creating one sub-issue and then
+			// having the parent re-implement that same slice itself.
+			name: "single subtask short-circuits to true (consolidate, no sibling to conflict with)",
 			subtasks: []PlannedSubtask{
 				{Title: "Do everything", Description: "Single task"},
 			},
 			description: "Simple task",
-			expected:    false, // detectSameComponentFromTitles requires >=2
+			expected:    true,
+		},
+		{
+			name:        "zero subtasks short-circuits to true",
+			subtasks:    []PlannedSubtask{},
+			description: "Simple task",
+			expected:    true,
 		},
 		{
 			name: "files in description only, same directory",

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1611,9 +1611,14 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 			slog.String("title", task.Title),
 			slog.Any("labels", task.Labels),
 		)
+		// GH-4220 (e): parity with the direct path's GH-2363 escalation — without
+		// this, an epic parent whose title keeps failing normalization retries
+		// forever instead of tripping the stop-retry guidance comment.
+		r.recordTitleRejection(ctx, task, result)
 		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
 		return
 	}
+	r.clearTitleRejectionState(task)
 	epicPRTitle := fmt.Sprintf("%s: %s", task.ID, normalizedEpicTitle)
 	prURL, prErr := git.CreatePR(ctx, epicPRTitle, prBody, baseBranch)
 	if prErr != nil {
@@ -4031,32 +4036,16 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 
 				// GH-2363: On the 2nd consecutive rejection for this exact title,
 				// escalate with a structured comment + stop-retry labels so we
-				// don't spam the same failure every retry cycle.
-				if r.titleRejections != nil {
-					count := r.titleRejections.record(task.ID, task.Title)
-					if count >= titleRejectionMaxCount {
-						if err := r.postTitleRejectionEscalation(ctx, task); err != nil {
-							log.Warn("title-rejection escalation failed",
-								slog.String("task_id", task.ID),
-								slog.Any("error", err),
-							)
-						} else {
-							result.TitleRejected = true
-							log.Info("title-rejection escalated — posted guidance comment, stopping retries",
-								slog.String("task_id", task.ID),
-								slog.Int("count", count),
-							)
-						}
-					}
-				}
+				// don't spam the same failure every retry cycle. GH-4220 (e):
+				// shared with the epic/decomposed-parent finalize paths — see
+				// recordTitleRejection (title_rejection.go).
+				r.recordTitleRejection(ctx, task, result)
 
 				r.reportProgress(task.ID, "PR Failed", 100, result.Error)
 				return result, nil
 			}
 			// Title accepted — clear any prior rejection bookkeeping for this task.
-			if r.titleRejections != nil {
-				r.titleRejections.clear(task.ID)
-			}
+			r.clearTitleRejectionState(task)
 			prTitle := fmt.Sprintf("%s: %s", task.ID, normalizedTitle)
 
 			// Route PR/MR creation through adapter-specific creator when available

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1593,7 +1593,28 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 	// Create the parent PR with a GitHub auto-close keyword.
 	epicIssueNum := strings.TrimPrefix(task.ID, "GH-")
 	prBody := fmt.Sprintf("## Summary\n\nAutomated PR created by Pilot for epic task %s.\n\nCloses #%s\n\n## Changes\n\n%s", task.ID, epicIssueNum, task.Description)
-	epicPRTitle := fmt.Sprintf("%s: %s", task.ID, task.Title)
+
+	// GH-4220 (b): route the epic parent's title through the same
+	// autoPrefixTitle/inferConventionalPrefix machinery as the direct path
+	// (executeWithOptions ~runner.go:4001) before CreatePR. Raw issue titles
+	// (e.g. "GH-4211: Throughput histograms record zero…") are never
+	// conventional commits, so without this the epic finalize path failed
+	// validatePRTitle deterministically — see runner.go:177 validation and
+	// TASK-401 repro (PR #4213 vs #4214, same fix implemented twice).
+	epicDiffStats, _ := git.GetDiffStats(ctx, baseBranch)
+	normalizedEpicTitle, titleErr := normalizeTitle(task.Title, task.Labels, epicDiffStats)
+	if titleErr != nil {
+		result.Success = false
+		result.Error = fmt.Sprintf("epic PR creation failed: %v", titleErr)
+		r.log.Warn("Epic PR creation refused: non-conventional title",
+			slog.String("task_id", task.ID),
+			slog.String("title", task.Title),
+			slog.Any("labels", task.Labels),
+		)
+		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		return
+	}
+	epicPRTitle := fmt.Sprintf("%s: %s", task.ID, normalizedEpicTitle)
 	prURL, prErr := git.CreatePR(ctx, epicPRTitle, prBody, baseBranch)
 	if prErr != nil {
 		result.Success = false

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1599,7 +1599,7 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 	// (executeWithOptions ~runner.go:4001) before CreatePR. Raw issue titles
 	// (e.g. "GH-4211: Throughput histograms record zero…") are never
 	// conventional commits, so without this the epic finalize path failed
-	// validatePRTitle deterministically — see runner.go:177 validation and
+	// validatePRTitle deterministically (called from git.go:178) — see
 	// TASK-401 repro (PR #4213 vs #4214, same fix implemented twice).
 	epicDiffStats, _ := git.GetDiffStats(ctx, baseBranch)
 	normalizedEpicTitle, titleErr := normalizeTitle(task.Title, task.Labels, epicDiffStats)

--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -438,7 +438,27 @@ func (r *Runner) finalizeDecomposedParentPR(ctx context.Context, task *Task, git
 	r.reportProgress(task.ID, "Creating PR", 98, "Creating pull request...")
 
 	issueNum := strings.TrimPrefix(task.ID, "GH-")
-	prTitle := fmt.Sprintf("%s: %s", task.ID, task.Title)
+
+	// GH-4220 parity: finalizeDecomposedParentPR built its title the same way
+	// finalizeEpicBranchPR (runner.go) did before that fix — raw
+	// "<task.ID>: <task.Title>" with no conventional-commit normalization.
+	// A decomposed parent's own task.Title is a raw issue title just like the
+	// epic parent's, so it hits the same validatePRTitle rejection (git.go:178)
+	// deterministically. Route it through the same normalizeTitle machinery.
+	decomposedDiffStats, _ := git.GetDiffStats(ctx, baseBranch)
+	normalizedDecomposedTitle, titleErr := normalizeTitle(task.Title, task.Labels, decomposedDiffStats)
+	if titleErr != nil {
+		result.Success = false
+		result.Error = fmt.Sprintf("decomposed-parent PR creation failed: %v", titleErr)
+		log.Warn("Decomposed-parent PR creation refused: non-conventional title",
+			slog.String("task_id", task.ID),
+			slog.String("title", task.Title),
+			slog.Any("labels", task.Labels),
+		)
+		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
+		return
+	}
+	prTitle := fmt.Sprintf("%s: %s", task.ID, normalizedDecomposedTitle)
 
 	// Route PR/MR creation through the adapter-specific creator when
 	// available, mirroring the direct path's registry → non-GitHub

--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -455,9 +455,14 @@ func (r *Runner) finalizeDecomposedParentPR(ctx context.Context, task *Task, git
 			slog.String("title", task.Title),
 			slog.Any("labels", task.Labels),
 		)
+		// GH-4220 (e): parity with the direct path's GH-2363 escalation — see
+		// recordTitleRejection (title_rejection.go) for why epic/decomposed
+		// paths need the same stop-retry guard the direct path already has.
+		r.recordTitleRejection(ctx, task, result)
 		r.reportProgress(task.ID, "PR Failed", 100, result.Error)
 		return
 	}
+	r.clearTitleRejectionState(task)
 	prTitle := fmt.Sprintf("%s: %s", task.ID, normalizedDecomposedTitle)
 
 	// Route PR/MR creation through the adapter-specific creator when

--- a/internal/executor/runner_gh4031_test.go
+++ b/internal/executor/runner_gh4031_test.go
@@ -3,20 +3,26 @@ package executor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 // fakePRCreatorGH4031 is a minimal PRCreator stub for exercising the
 // registry/non-GitHub CreatePR branch of finalizeDecomposedParentPR without
-// depending on gh CLI or network access.
+// depending on gh CLI or network access. capturedTitle records the title
+// argument CreatePR was invoked with, so tests can assert on it.
 type fakePRCreatorGH4031 struct {
 	url string
 	err error
+
+	capturedTitle string
 }
 
-func (f *fakePRCreatorGH4031) CreatePR(_ context.Context, _, _, _, _ string) (string, error) {
+func (f *fakePRCreatorGH4031) CreatePR(_ context.Context, _, _, title, _ string) (string, error) {
+	f.capturedTitle = title
 	return f.url, f.err
 }
 
@@ -120,5 +126,90 @@ func TestFinalizeDecomposedParentPR_PRCreateFailIsFailure(t *testing.T) {
 	git := NewGitOperations(repoDir)
 	if !git.RemoteBranchExists(context.Background(), "pilot/GH-9002") {
 		t.Error("expected branch to have been pushed to origin before PR-create failed")
+	}
+}
+
+// TestFinalizeDecomposedParentPR_AutoPrefixesNonConventionalTitle is the
+// GH-4220 parity regression guard for the decomposed-parent path:
+// finalizeDecomposedParentPR must route task.Title through the same
+// normalizeTitle machinery as finalizeEpicBranchPR (runner.go,
+// TestFinalizeEpicBranchPR_AutoPrefixesNonConventionalTitle) instead of
+// passing "<task.ID>: <task.Title>" straight through to CreatePR — a raw
+// issue title is never a conventional commit and fails validatePRTitle
+// downstream deterministically.
+func TestFinalizeDecomposedParentPR_AutoPrefixesNonConventionalTitle(t *testing.T) {
+	setUpFakeGhPATH(t, []byte(`[]`), []byte(`[]`)) // no pre-existing merged/open PR
+
+	repoDir := setupDecomposedParentRepoGH4031(t, "pilot/GH-9003")
+
+	r := newSilentRunnerTask359()
+	creator := &fakePRCreatorGH4031{url: "https://gitlab.example.com/o/r/-/merge_requests/8"}
+	r.prCreator = creator
+	task := &Task{
+		ID:            "GH-9003",
+		Title:         "Executor crashes on nil epic plan",
+		Labels:        []string{"bug"},
+		Description:   "d",
+		Branch:        "pilot/GH-9003",
+		BaseBranch:    "main",
+		CreatePR:      true,
+		SourceAdapter: "gitlab",
+	}
+	result := &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "placeholder"}
+
+	r.finalizeDecomposedParentPR(context.Background(), task, NewGitOperations(repoDir), result)
+
+	if !result.Success {
+		t.Fatalf("expected Success=true, got false (error=%q)", result.Error)
+	}
+
+	if creator.capturedTitle == fmt.Sprintf("%s: %s", task.ID, task.Title) {
+		t.Errorf("title was passed through unmodified (%q) — expected auto-prefixing", creator.capturedTitle)
+	}
+	if err := validatePRTitle(creator.capturedTitle); err != nil {
+		t.Errorf("captured title %q failed validatePRTitle: %v", creator.capturedTitle, err)
+	}
+	if !strings.HasPrefix(creator.capturedTitle, task.ID+": ") {
+		t.Errorf("captured title %q should still carry the %q auto-close prefix", creator.capturedTitle, task.ID+": ")
+	}
+	if !strings.Contains(creator.capturedTitle, "fix:") {
+		t.Errorf("captured title %q, want it to contain conventional type %q (from bug label)", creator.capturedTitle, "fix")
+	}
+}
+
+// TestFinalizeDecomposedParentPR_TitleNormalizeFailureIsRecoverable mirrors
+// TestFinalizeEpicBranchPR_TitleNormalizeFailureIsRecoverable for the
+// decomposed-parent path: when normalizeTitle cannot produce a valid
+// conventional title (empty title), finalizeDecomposedParentPR must fail
+// loud with Success=false and never call CreatePR.
+func TestFinalizeDecomposedParentPR_TitleNormalizeFailureIsRecoverable(t *testing.T) {
+	setUpFakeGhPATH(t, []byte(`[]`), []byte(`[]`))
+
+	repoDir := setupDecomposedParentRepoGH4031(t, "pilot/GH-9004")
+
+	r := newSilentRunnerTask359()
+	creator := &fakePRCreatorGH4031{url: "https://gitlab.example.com/o/r/-/merge_requests/9"}
+	r.prCreator = creator
+	task := &Task{
+		ID:            "GH-9004",
+		Title:         "   ",
+		Description:   "d",
+		Branch:        "pilot/GH-9004",
+		BaseBranch:    "main",
+		CreatePR:      true,
+		SourceAdapter: "gitlab",
+	}
+	result := &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "placeholder"}
+
+	r.finalizeDecomposedParentPR(context.Background(), task, NewGitOperations(repoDir), result)
+
+	if result.Success {
+		t.Error("expected Success=false when the decomposed-parent title cannot be normalized")
+	}
+	if result.PRUrl != "" {
+		t.Errorf("expected no PR URL, got %q", result.PRUrl)
+	}
+	if creator.capturedTitle != "" {
+		t.Error("CreatePR must not be invoked when title normalization fails")
 	}
 }

--- a/internal/executor/runner_gh4031_test.go
+++ b/internal/executor/runner_gh4031_test.go
@@ -213,3 +213,47 @@ func TestFinalizeDecomposedParentPR_TitleNormalizeFailureIsRecoverable(t *testin
 		t.Error("CreatePR must not be invoked when title normalization fails")
 	}
 }
+
+// TestFinalizeDecomposedParentPR_TitleRejectionEscalatesOnSecondFailure
+// mirrors TestFinalizeEpicBranchPR_TitleRejectionEscalatesOnSecondFailure
+// (GH-4220 (e)): the decomposed-parent path must feed titleErr into the same
+// GH-2363 record→escalate tracker (recordTitleRejection, title_rejection.go)
+// the direct path uses, instead of failing loud with no escalation on every
+// poll indefinitely.
+func TestFinalizeDecomposedParentPR_TitleRejectionEscalatesOnSecondFailure(t *testing.T) {
+	setUpFakeGhPATH(t, []byte(`[]`), []byte(`[]`))
+
+	repoDir := setupDecomposedParentRepoGH4031(t, "pilot/GH-9005")
+
+	r := newSilentRunnerTask359()
+	r.titleRejections = newTitleRejectionTracker()
+	creator := &fakePRCreatorGH4031{url: "https://gitlab.example.com/o/r/-/merge_requests/10"}
+	r.prCreator = creator
+	task := &Task{
+		ID:            "GH-9005",
+		Title:         "   ",
+		Description:   "d",
+		Branch:        "pilot/GH-9005",
+		BaseBranch:    "main",
+		CreatePR:      true,
+		SourceAdapter: "gitlab",
+	}
+
+	result1 := &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "placeholder"}
+	r.finalizeDecomposedParentPR(context.Background(), task, NewGitOperations(repoDir), result1)
+	if result1.Success {
+		t.Fatal("expected Success=false on first title-normalize failure")
+	}
+	if result1.TitleRejected {
+		t.Error("first rejection must not escalate yet")
+	}
+
+	result2 := &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "placeholder"}
+	r.finalizeDecomposedParentPR(context.Background(), task, NewGitOperations(repoDir), result2)
+	if result2.Success {
+		t.Fatal("expected Success=false on second title-normalize failure")
+	}
+	if !result2.TitleRejected {
+		t.Error("second consecutive title-normalize failure must escalate (TitleRejected=true)")
+	}
+}

--- a/internal/executor/runner_gh4220_test.go
+++ b/internal/executor/runner_gh4220_test.go
@@ -1,0 +1,190 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFakeGhPRCreate writes a fake "gh" binary to fakeBin that answers
+// `gh pr list ...` with an empty array (no merged/open PR short-circuits) and
+// `gh pr create --title <title> ...` by recording the title it was invoked
+// with to capturedTitleFile and returning a fake PR URL. Mirrors
+// writeFakeGhPRList (runner_gh4022_test.go) but also handles `pr create` so
+// the epic finalize path can run all the way through CreatePR.
+func writeFakeGhPRCreate(t *testing.T, fakeBin, capturedTitleFile string) {
+	t.Helper()
+	script := fmt.Sprintf(`#!/bin/sh
+case "$*" in
+  *"pr list"*) echo "[]" ;;
+  *"pr create"*)
+    prev=""
+    for arg in "$@"; do
+      if [ "$prev" = "--title" ]; then
+        printf '%%s' "$arg" > %q
+      fi
+      prev="$arg"
+    done
+    echo "https://github.com/o/r/pull/777"
+    ;;
+  *) echo "[]" ;;
+esac
+`, capturedTitleFile)
+	if err := os.WriteFile(filepath.Join(fakeBin, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+}
+
+// setUpFakeGhPRCreatePATH prepends a fake "gh" binary (writeFakeGhPRCreate) to
+// PATH for the duration of the test and returns the file the fake binary
+// writes the captured `--title` argument to.
+func setUpFakeGhPRCreatePATH(t *testing.T) string {
+	t.Helper()
+	fakeBin := t.TempDir()
+	capturedTitleFile := filepath.Join(fakeBin, "captured-title.txt")
+	writeFakeGhPRCreate(t, fakeBin, capturedTitleFile)
+	t.Setenv("PATH", fakeBin+string(filepath.ListSeparator)+os.Getenv("PATH"))
+	return capturedTitleFile
+}
+
+// initRepoWithRemoteAndFeatureBranch creates a local repo with an "origin"
+// remote (a bare repo), a base commit on main pushed to that remote, and a
+// feature branch (matching task.Branch) carrying one additional commit —
+// exactly the state finalizeEpicBranchPR expects for the push+CreatePR path
+// (non-empty branch vs base, remote reachable).
+func initRepoWithRemoteAndFeatureBranch(t *testing.T, branch string) string {
+	t.Helper()
+	localDir, remoteDir := setupTestRepoWithRemote(t)
+	t.Cleanup(func() { _ = os.RemoveAll(remoteDir) })
+	t.Cleanup(func() { _ = os.RemoveAll(localDir) })
+
+	runGit(t, localDir, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(localDir, "epic-work.txt"), []byte("work\n"), 0644); err != nil {
+		t.Fatalf("write epic-work.txt: %v", err)
+	}
+	runGit(t, localDir, "add", "epic-work.txt")
+	runGit(t, localDir, "commit", "-m", "epic work")
+
+	return localDir
+}
+
+// TestFinalizeEpicBranchPR_AutoPrefixesNonConventionalTitle is the GH-4220 (b)
+// regression guard: finalizeEpicBranchPR must route the epic parent's raw
+// issue title through the same normalizeTitle (autoPrefixTitle /
+// inferConventionalPrefix) machinery as the direct path before calling
+// git.CreatePR, instead of passing "<task.ID>: <task.Title>" straight through.
+//
+// Regression shape (TASK-401 / GH-4211 live repro): a raw issue title like
+// "GH-4211: Throughput histograms record zero on the live path" is never a
+// conventional commit, so validatePRTitle (git.go:177) rejected it
+// deterministically, leaving the epic parent open + failed — and the
+// subsequent re-poll re-implemented the child's already-shipped work from
+// scratch (PR #4213 vs #4214, same fix twice).
+func TestFinalizeEpicBranchPR_AutoPrefixesNonConventionalTitle(t *testing.T) {
+	tests := []struct {
+		name       string
+		title      string
+		labels     []string
+		wantPrefix string // conventional-commit type expected in the final title
+	}{
+		{
+			name:       "raw GH-4211-shaped title, no labels: diff-heuristic prefix",
+			title:      "GH-4211: Throughput histograms record zero on the live path",
+			labels:     nil,
+			wantPrefix: "", // asserted generically below (any valid conventional type)
+		},
+		{
+			name:       "raw title with bug label: label-derived fix prefix",
+			title:      "Executor crashes on nil epic plan",
+			labels:     []string{"bug"},
+			wantPrefix: "fix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capturedTitleFile := setUpFakeGhPRCreatePATH(t)
+
+			branch := "pilot/GH-4220-epic"
+			dir := initRepoWithRemoteAndFeatureBranch(t, branch)
+
+			r := newSilentRunnerTask359()
+			result := &ExecutionResult{TaskID: "GH-4220", Success: true, IsEpic: true}
+			task := &Task{
+				ID:          "GH-4220",
+				Title:       tt.title,
+				Labels:      tt.labels,
+				Description: "d",
+				Branch:      branch,
+				BaseBranch:  "main",
+				CreatePR:    true,
+			}
+
+			r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result, nil)
+
+			if !result.Success {
+				t.Fatalf("expected Success=true, got false (error=%q)", result.Error)
+			}
+			if result.PRUrl != "https://github.com/o/r/pull/777" {
+				t.Errorf("PRUrl = %q, want fake PR URL", result.PRUrl)
+			}
+
+			capturedTitleBytes, err := os.ReadFile(capturedTitleFile)
+			if err != nil {
+				t.Fatalf("gh pr create was not invoked with --title: %v", err)
+			}
+			capturedTitle := string(capturedTitleBytes)
+
+			if capturedTitle == fmt.Sprintf("%s: %s", task.ID, tt.title) {
+				t.Errorf("title was passed through unmodified (%q) — expected auto-prefixing", capturedTitle)
+			}
+			if err := validatePRTitle(capturedTitle); err != nil {
+				t.Errorf("captured title %q failed validatePRTitle: %v", capturedTitle, err)
+			}
+			if !strings.HasPrefix(capturedTitle, task.ID+": ") {
+				t.Errorf("captured title %q should still carry the %q auto-close prefix", capturedTitle, task.ID+": ")
+			}
+			if tt.wantPrefix != "" && !strings.Contains(capturedTitle, tt.wantPrefix+":") {
+				t.Errorf("captured title %q, want it to contain conventional type %q", capturedTitle, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+// TestFinalizeEpicBranchPR_TitleNormalizeFailureIsRecoverable verifies that if
+// normalizeTitle cannot produce a valid conventional title (empty title),
+// finalizeEpicBranchPR fails loud with Success=false and never calls
+// git.CreatePR (Shape A — mirrors the direct path's title-rejection contract,
+// runner.go ~4001).
+func TestFinalizeEpicBranchPR_TitleNormalizeFailureIsRecoverable(t *testing.T) {
+	capturedTitleFile := setUpFakeGhPRCreatePATH(t)
+
+	branch := "pilot/GH-4220-empty-title"
+	dir := initRepoWithRemoteAndFeatureBranch(t, branch)
+
+	r := newSilentRunnerTask359()
+	result := &ExecutionResult{TaskID: "GH-4220", Success: true, IsEpic: true}
+	task := &Task{
+		ID:          "GH-4220",
+		Title:       "   ",
+		Description: "d",
+		Branch:      branch,
+		BaseBranch:  "main",
+		CreatePR:    true,
+	}
+
+	r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result, nil)
+
+	if result.Success {
+		t.Error("expected Success=false when the epic title cannot be normalized")
+	}
+	if result.PRUrl != "" {
+		t.Errorf("expected no PR URL, got %q", result.PRUrl)
+	}
+	if _, err := os.Stat(capturedTitleFile); err == nil {
+		t.Error("gh pr create must not be invoked when title normalization fails")
+	}
+}

--- a/internal/executor/runner_gh4220_test.go
+++ b/internal/executor/runner_gh4220_test.go
@@ -188,3 +188,46 @@ func TestFinalizeEpicBranchPR_TitleNormalizeFailureIsRecoverable(t *testing.T) {
 		t.Error("gh pr create must not be invoked when title normalization fails")
 	}
 }
+
+// TestFinalizeEpicBranchPR_TitleRejectionEscalatesOnSecondFailure is GH-4220
+// (e): finalizeEpicBranchPR must feed titleErr into the same GH-2363
+// record→escalate tracker the direct path uses (recordTitleRejection,
+// title_rejection.go), not just fail loud once. Before this fix, an epic
+// parent stuck on a title normalizeTitle can't fix would fail Success=false
+// every poll forever with no escalation — never tripping the stop-retry
+// guidance comment/labels the direct path relies on to stop the loop.
+func TestFinalizeEpicBranchPR_TitleRejectionEscalatesOnSecondFailure(t *testing.T) {
+	setUpFakeGhPRCreatePATH(t)
+
+	branch := "pilot/GH-4220-escalate"
+	dir := initRepoWithRemoteAndFeatureBranch(t, branch)
+
+	r := newSilentRunnerTask359()
+	r.titleRejections = newTitleRejectionTracker()
+	task := &Task{
+		ID:          "GH-4220",
+		Title:       "   ", // never normalizes — see normalizeTitle empty-title guard
+		Description: "d",
+		Branch:      branch,
+		BaseBranch:  "main",
+		CreatePR:    true,
+	}
+
+	result1 := &ExecutionResult{TaskID: task.ID, Success: true, IsEpic: true}
+	r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result1, nil)
+	if result1.Success {
+		t.Fatal("expected Success=false on first title-normalize failure")
+	}
+	if result1.TitleRejected {
+		t.Error("first rejection must not escalate yet")
+	}
+
+	result2 := &ExecutionResult{TaskID: task.ID, Success: true, IsEpic: true}
+	r.finalizeEpicBranchPR(context.Background(), task, NewGitOperations(dir), result2, nil)
+	if result2.Success {
+		t.Fatal("expected Success=false on second title-normalize failure")
+	}
+	if !result2.TitleRejected {
+		t.Error("second consecutive title-normalize failure must escalate (TitleRejected=true)")
+	}
+}

--- a/internal/executor/title_rejection.go
+++ b/internal/executor/title_rejection.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"strings"
 	"sync"
@@ -60,6 +61,48 @@ func (t *titleRejectionTracker) clear(taskID string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	delete(t.seen, taskID)
+}
+
+// recordTitleRejection wraps the record → escalate → report-progress sequence
+// shared by every PR-title finalize path (direct, epic-parent,
+// decomposed-parent). GH-4220 (e): only the direct path (runner.go
+// executeWithOptions) wired the GH-2363 escalation — finalizeEpicBranchPR and
+// finalizeDecomposedParentPR returned on titleErr without ever recording or
+// escalating, so a non-conventional epic/decomposed title that survives
+// normalizeTitle's auto-correct machinery (rare given the "chore" fallback,
+// but possible when diff stats are unavailable) would retry forever instead
+// of tripping the stop-retry guidance comment. Call this from every path that
+// fails on titleErr; it is a no-op if the tracker was never configured.
+func (r *Runner) recordTitleRejection(ctx context.Context, task *Task, result *ExecutionResult) {
+	if r.titleRejections == nil {
+		return
+	}
+	count := r.titleRejections.record(task.ID, task.Title)
+	if count < titleRejectionMaxCount {
+		return
+	}
+	if err := r.postTitleRejectionEscalation(ctx, task); err != nil {
+		r.log.Warn("title-rejection escalation failed",
+			slog.String("task_id", task.ID),
+			slog.Any("error", err),
+		)
+		return
+	}
+	result.TitleRejected = true
+	r.log.Info("title-rejection escalated — posted guidance comment, stopping retries",
+		slog.String("task_id", task.ID),
+		slog.Int("count", count),
+	)
+}
+
+// clearTitleRejectionState drops any tracked rejection bookkeeping for task
+// once its title has been accepted, so a future title change starts counting
+// from a clean slate. Call this from every path that successfully normalizes
+// a title, mirroring recordTitleRejection's coverage.
+func (r *Runner) clearTitleRejectionState(task *Task) {
+	if r.titleRejections != nil {
+		r.titleRejections.clear(task.ID)
+	}
 }
 
 func hashTitle(title string) string {

--- a/internal/executor/title_rejection_test.go
+++ b/internal/executor/title_rejection_test.go
@@ -1,6 +1,8 @@
 package executor
 
 import (
+	"context"
+	"os"
 	"strings"
 	"testing"
 )
@@ -112,5 +114,74 @@ func TestHashTitle_StableAndTrimmed(t *testing.T) {
 	}
 	if hashTitle("hello") == hashTitle("Hello") {
 		t.Error("hashTitle should be case-sensitive")
+	}
+}
+
+// TestRecordTitleRejection_EscalatesOnSecondFailure is the GH-4220 (e)
+// regression guard for the shared helper: the first titleErr for a given
+// task/title records but does not escalate, and the second (matching)
+// titleErr escalates and sets result.TitleRejected. This is the exact
+// record→escalate contract the direct path already had (GH-2363) — the
+// point of extracting it into title_rejection.go was so finalizeEpicBranchPR
+// and finalizeDecomposedParentPR could share it instead of retrying forever.
+func TestRecordTitleRejection_EscalatesOnSecondFailure(t *testing.T) {
+	fakeBin := t.TempDir()
+	if err := os.WriteFile(fakeBin+"/gh", []byte("#!/bin/sh\necho '[]'\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+":"+os.Getenv("PATH"))
+
+	r := newSilentRunnerTask359()
+	r.titleRejections = newTitleRejectionTracker()
+	task := &Task{ID: "GH-4220", Title: "bad title", SourceAdapter: "github"}
+
+	result := &ExecutionResult{TaskID: task.ID}
+	r.recordTitleRejection(context.Background(), task, result)
+	if result.TitleRejected {
+		t.Error("first rejection must not escalate yet")
+	}
+
+	result2 := &ExecutionResult{TaskID: task.ID}
+	r.recordTitleRejection(context.Background(), task, result2)
+	if !result2.TitleRejected {
+		t.Error("second consecutive rejection of the same title must escalate")
+	}
+}
+
+// TestRecordTitleRejection_NilTrackerIsNoOp guards the nil-tracker short
+// circuit: Runners built without a titleRejections tracker (e.g. most unit
+// test fixtures) must not panic when a finalize path hits titleErr.
+func TestRecordTitleRejection_NilTrackerIsNoOp(t *testing.T) {
+	r := newSilentRunnerTask359() // titleRejections left nil
+	task := &Task{ID: "GH-1", Title: "bad title"}
+	result := &ExecutionResult{TaskID: task.ID}
+
+	r.recordTitleRejection(context.Background(), task, result)
+
+	if result.TitleRejected {
+		t.Error("nil tracker must never escalate")
+	}
+}
+
+// TestClearTitleRejectionState_NilTrackerIsNoOp mirrors the nil-tracker guard
+// for the success-path clear helper.
+func TestClearTitleRejectionState_NilTrackerIsNoOp(t *testing.T) {
+	r := newSilentRunnerTask359() // titleRejections left nil
+	r.clearTitleRejectionState(&Task{ID: "GH-1"}) // must not panic
+}
+
+// TestClearTitleRejectionState_DropsTrackedCount verifies the success-path
+// helper actually resets the counter (mirrors TestTitleRejectionTracker_Clear
+// but through the Runner-level wrapper finalize paths call).
+func TestClearTitleRejectionState_DropsTrackedCount(t *testing.T) {
+	r := newSilentRunnerTask359()
+	r.titleRejections = newTitleRejectionTracker()
+	task := &Task{ID: "GH-1", Title: "bad title"}
+
+	r.titleRejections.record(task.ID, task.Title)
+	r.clearTitleRejectionState(task)
+
+	if got := r.titleRejections.record(task.ID, task.Title); got != 1 {
+		t.Errorf("after clearTitleRejectionState, record = %d, want 1 (reset)", got)
 	}
 }


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4220.

Closes #4220

## Changes

Land all three chained fixes plus the memory helper in one PR. (a) In internal/executor/epic.go, short-circuit the epic decision branch on len(plan.Subtasks) <= 1 before isSinglePackageScope/detectSameComponentFromTitles fall-through so single-subtask plans consolidate to direct execution (table test: 1-subtask plan → zero children, direct path). (b) In internal/executor/runner.go:1596-1610, route the epic-parent PR title through the existing autoPrefixTitle/inferConventionalPrefix helpers (internal/executor/title.go:71,88) before git.CreatePR, mirroring the direct-path wiring at title.go:204 / title_rejection.go:82 (test: raw GH-4211 title → auto-prefixed and passes validatePRTitle). (c) Add a helper in internal/memory/store.go that queries execution_events for a decomposed stage on a given task_id, parses child issue numbers from "decomposed into N children: #a, #b", and reports per-child completion; consume it in internal/executor/dispatcher.go alongside existing HasCompletedExecution/IsTaskQueued checks at dispatcher.go:286,407,731,896 — if all children complete, skip dispatch, log fail-loud reason, short-circuit to parent finalize/close; if some incomplete, fall through to the existing epic-resume path unchanged (table test: both branches). Regression fences: do NOT touch githubPollerRegistry/MarkProcessed (GH-3927), isParentDone (epic.go:654), closed-issue gates (#4186/#4187), or sibling wait_for_merge sequencing (separate issue). Verify: go build ./... && go vet ./... && go test -race ./internal/executor/... ./internal/memory/... ./cmd/pilot/... green, then go test -race ./... green.