### PR TITLE
fix(executor,memory): add cross-task-id dispatch guard for shipped epic children

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-12 (v2.151.0)
+**Last Updated:** 2026-07-09 (v2.151.0)
 
 ## Legend
 
@@ -423,6 +423,9 @@
 | Conventional sub-issue titles | ✅ | executor | - | - | CC-format enforced on subtask titles: re-prompt → Approach B fallback → creation guard (GH-2494) |
 | Sub-issue dedup guard | ✅ | executor | - | - | CreateSubIssues skips if open children referencing parent already exist (GH-2494) |
 | createPilotIssue chokepoint | ✅ | adapters/github, autopilot | - | - | All Pilot-internal issue creation validated through CreatePilotIssue CC gate (GH-2494) |
+| Single-subtask epic consolidation | ✅ | executor | - | - | `isSinglePackageScope` short-circuits `len(plan.Subtasks) <= 1` to direct execution — never spawns a lone child issue (GH-4216 fix 1 / #4221) |
+| Epic finalize title normalization | ✅ | executor | - | - | `finalizeEpicBranchPR` routes the parent PR title through `normalizeTitle` before `CreatePR`, so raw issue titles auto-prefix instead of failing `validatePRTitle` deterministically (GH-4216 fix 2 / #4221) |
+| Cross-task-id dispatch guard | ✅ | executor + memory | - | - | `ProjectWorker.processQueue` pickup-time check: `Store.GetDecomposedChildTaskIDs` + `allDecomposedChildrenShipped` refuse to re-dispatch a task_id as fresh top-level work once every child from its `decomposed` ledger event has a genuine completed execution — fail-loud `slog.Warn`, defense-in-depth alongside `hasTerminalSuccessLedger` (GH-4216 fix 3, TASK-401) |
 
 ## Test Coverage
 
@@ -597,4 +600,3 @@ quality:
 | Decomposed-child base-branch pinning | v2.184.x | executor | Resolve `BaseBranch` from main-repo git context before worktree creation; decomposed children never PR against a sibling branch (GH-3540) |
 | GitHub-poller auth-failure escalation | v2.207.x | adapters/github + health | Consecutive 401/non-ratelimit-403 fetch errors escalate to ERROR log + alert at threshold (`WithAlertProcessor`/`WithTokenSource`); `pilot doctor` disabled-subsystems panel; `pilot config show` secret redaction + `--reveal` (TASK-379 V4 / GH-3839) |
 | Executor prompt memory injection | v2.219.x | executor | `BuildPrompt` appends a "Known pitfalls from project memory" block ranked via `graphrecall.RecallRelevant`, gated on `MemoryInjection.Enabled`/non-LocalMode/Navigator/recall hits, capped at `min(MaxMemories,5)` entries and ~1500 chars (TASK-387 / GH-3909) |
-| Dashboard status-truthfulness reconciliation | v2.238.x | memory + autopilot | Orphan-running sweep (`FindOrphanedRunningExecutions`/`ResolveOrphanedRunningExecution`, Monitor + execution_events heartbeat guard) heals stale `status='running'` rows; `selfHealForPR` widened with a startup wide-lookback catch-up scan, PR-body `Closes #N`/`Parent: GH-N` issueNum resolution, and a `pr_url`-keyed fallback heal; `ScanRecentlyMergedPRs`'s external-merge branch now also calls `monitor.Complete` (TASK-399 / GH-4209) |

--- a/.agent/tasks/TASK-401-epic-parent-duplicate-reimplementation.md
+++ b/.agent/tasks/TASK-401-epic-parent-duplicate-reimplementation.md
@@ -1,0 +1,103 @@
+# Epic parent re-implements shipped child work — fix single-child decomposition, epic PR title rejection, and add cross-task-id dispatch guard
+
+**Status**: ✅ All 3 fixes shipped 2026-07-12. Fixes 1+2 merged via [#4220](https://github.com/qf-studio/pilot/issues/4220)/PR #4221 (decomposer `len<=1` short-circuit + title normalization incl. decomposed-parent path). Fix 3 (cross-task-id guard) landed directly on parent [#4216](https://github.com/qf-studio/pilot/issues/4216) (this doc's own dispatch — branch `pilot/GH-4216`): `Store.GetDecomposedChildTaskIDs` (memory/store.go) + `ProjectWorker.allDecomposedChildrenShipped` (executor/dispatcher.go), wired into `processQueue`'s pickup-time guard alongside `hasTerminalSuccessLedger`. Supersedes the re-filed [#4222](https://github.com/qf-studio/pilot/issues/4222) — close #4222 as duplicate. [#4217](https://github.com/qf-studio/pilot/issues/4217) (Defect B, sibling merge-wait) can proceed.
+**Type**: bug (executor epic pipeline — duplicate-PR class, Defect A)
+**Evidence**: GH-4211→#4212 live repro 2026-07-12 (PRs #4213 vs #4214, same fix implemented twice)
+
+## Problem
+
+An epic parent whose child already shipped a completed PR gets re-dispatched as a
+fresh top-level task and re-implements the work from scratch. Live repro (ledger
+`~/.pilot/data/pilot.db`, `executions`/`execution_events`):
+
+```
+3034a06e  GH-4211  11:29:41 → decomposed 11:30:22 "into 1 children: #4212"
+e8c945e9  GH-4212  11:30:22 → PR #4213 created 12:28:15
+3034a06e  GH-4211  failed 12:28:20 "epic PR creation failed: title is not a
+          conventional commit: \"GH-4211: Throughput histograms record zero…\""
+c5bf7b0a  GH-4211  12:28:41 (re-poll +39s) → re-implemented everything → PR #4214
+```
+
+Three bugs chain (all refs origin/main):
+
+### Bug 1 — decomposer: 1-subtask plans always classified multi-package
+`isSinglePackageScope` (`internal/executor/epic.go:414`) falls back to
+`detectSameComponentFromTitles` (`epic.go:453`) when no directory hints exist;
+that helper returns `false` for `len(subtasks) < 2` (`epic.go:454`). There is NO
+`len(plan.Subtasks) == 1` short-circuit anywhere in the epic decision branch —
+a 1-subtask plan without file-path hints is *guaranteed* multi-package →
+pointless single-child epic pipeline. A single subtask can never legitimately
+span multiple components.
+
+### Bug 2 — epic finalize: PR title guaranteed non-conventional
+`finalizeEpicBranchPR` (`internal/executor/runner.go:1596-1610`) builds the epic
+parent's own PR title as `fmt.Sprintf("%s: %s", task.ID, task.Title)` — raw
+issue title. `git.CreatePR` (`internal/executor/git.go:177`) validates via
+`validatePRTitle` (`internal/executor/title.go:56`), which strips the `GH-N:`
+prefix and requires a conventional-commit type. Raw issue titles essentially
+never pass. The direct path auto-corrects exactly this via
+`autoPrefixTitle`/`inferConventionalPrefix` (`title.go:71,88`, wired
+`title.go:204`, `title_rejection.go:82`) — the epic finalize path never calls
+them. Any epic whose own branch has ≥1 commit vs base fails finalize
+deterministically, leaving the parent open + `failed`.
+
+### Bug 3 — no cross-task-id dispatch guard
+Every dedup guard is keyed to a single task_id:
+`HasCompletedExecution` (`internal/memory/store.go:833`; consulted
+`dispatcher.go:286,407,731,896`), `IsTaskQueued` (`store.go:1652`),
+`isParentDone` (`epic.go:654`, parent's own labels/state only), closed-issue
+gate (#4186 — parent was open), `MarkProcessed` sub-issue skip
+(`epic.go:1433-1438`, `main.go:2332` — covers CHILD numbers only). Nothing says:
+"this GH-N has a `decomposed` ledger event and its referenced children shipped
+completed executions — don't re-run it as a fresh top-level task."
+
+## Scope (one PR)
+
+1. **Decomposer short-circuit**: in the epic decision branch, `len(plan.Subtasks) <= 1`
+   ⇒ treat as single-package / consolidate into direct execution — never create
+   a single child issue.
+2. **Epic finalize title**: route `finalizeEpicBranchPR`'s title through the same
+   `autoPrefixTitle`/`inferConventionalPrefix` machinery as the direct path
+   before `CreatePR`.
+3. **Cross-task-id guard (defense in depth)**: before dispatching a task_id as a
+   fresh top-level task, if `execution_events` has a `decomposed` stage for it,
+   parse the child issue numbers from the event detail (`"decomposed into N
+   children: #a, #b"`) and check each child's completion (`HasCompletedExecution`
+   or equivalent "child shipped" evidence). All children complete ⇒ do NOT
+   re-implement: short-circuit to parent finalize/close bookkeeping (log fail-loud
+   why). Some children incomplete ⇒ existing epic-resume behavior unchanged.
+
+## Must NOT change
+
+- The fixed GH-3927 class (poller-vs-sequential same-task_id dedup: 4d.2a
+  `githubPollerRegistry`/`MarkProcessed`, #4140 ledger double-intake, #4186/#4187
+  closed-issue gates) — regression-fence, don't touch semantics.
+- Legitimate epic retry when children genuinely failed/incomplete.
+- Sibling merge-wait sequencing (`wait_for_merge`) — separate issue (Defect B).
+
+## Acceptance criteria
+
+- [x] A 1-subtask epic plan executes directly; zero child issues created (test) — shipped via #4221.
+- [x] Epic parent finalize creates its PR with an auto-prefixed conventional
+  title; the GH-4211 title shape passes (test with a raw non-conventional title) — shipped via #4221.
+- [x] Re-poll of an open parent whose ledger shows `decomposed` + all children
+  completed does NOT produce a fresh implementation run (table test over the
+  guard; include children-incomplete → normal path case) — `TestProcessQueue_CrossTaskIDGuard`
+  (internal/executor/dispatcher_test.go), 3-case table: all-complete skip,
+  one-incomplete falls through, none-completed falls through.
+- [x] Fail-loud logging on the new guard's skip decision — `slog.Warn` in
+  `ProjectWorker.processQueue` (dispatcher.go), logs task_id + full child list + evidence PR URL.
+- [x] `go test -race ./internal/executor/... ./internal/memory/... ./cmd/pilot/...` green;
+  full `go test -race ./...` green (stress gate — no new API calls in poll cycle, mem-048).
+
+## Verify
+
+```bash
+go build ./... && go vet ./... && go test -race ./...
+```
+
+## Refs
+
+- Forensics: `.agent/tasks/TASK-401-epic-parent-duplicate-reimplementation.md` (this doc), research 2026-07-12
+- Prior fixed class (contrast): TASK-368 Step 0 (GH-3927), #4110/#4114, #4140, #4182/#4186/#4187
+- Sibling defect (separate): merge-wait sequencing — see follow-up issue (Defect B)

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -915,6 +915,38 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			w.runner.EmitProgress(exec.TaskID, "Completed", 100, "already completed per execution ledger")
 			w.currentTaskID.Store("")
 			continue
+		} else if allShipped, childIDs, cErr := w.allDecomposedChildrenShipped(exec.TaskID); cErr != nil {
+			w.log.Warn("Failed to check cross-task-id dispatch guard before pickup",
+				slog.String("execution_id", exec.ID),
+				slog.String("task_id", exec.TaskID),
+				slog.Any("error", cErr))
+		} else if allShipped {
+			// GH-4216 (Defect A, fix 3): the ledger shows this task_id decomposed
+			// into children that ALL already shipped completed executions — the
+			// GH-4211 repro re-dispatched the parent as a fresh top-level task and
+			// re-implemented the same fix its child (#4212) had already landed in
+			// PR #4213. hasTerminalSuccessLedger above never catches this because
+			// an epic parent's own row typically carries no deliverable
+			// (TASK-296); this check follows the decomposed-children trail
+			// instead. Fail-loud: this is a defense-in-depth skip, not a normal
+			// completion, so it always logs at Warn with the full child list.
+			prURL := ""
+			if latest, gErr := w.store.GetLatestExecutionByTaskID(childIDs[len(childIDs)-1]); gErr == nil && latest != nil {
+				prURL = latest.PRUrl
+			}
+			w.log.Warn("Cross-task-id dispatch guard: all decomposed children already completed; refusing to re-implement as fresh top-level task",
+				slog.String("execution_id", exec.ID),
+				slog.String("task_id", exec.TaskID),
+				slog.Any("children", childIDs),
+				slog.String("evidence_pr_url", prURL),
+			)
+			if err := w.store.MarkExecutionCompleted(exec.ID, prURL, "", 0); err != nil {
+				w.log.Error("Failed to mark cross-task-id-guarded duplicate completed", slog.Any("error", err))
+			}
+			w.recordExecutionEvent(exec.ID, memory.StageCompleted, fmt.Sprintf("cross-task-id dispatch guard: children already completed (%s)", strings.Join(childIDs, ", ")))
+			w.runner.EmitProgress(exec.TaskID, "Completed", 100, "already completed via decomposed children (cross-task-id guard)")
+			w.currentTaskID.Store("")
+			continue
 		}
 
 		w.log.Info("Processing task",
@@ -1101,6 +1133,41 @@ func (w *ProjectWorker) recordExecutionEvent(executionID string, stage memory.St
 // actually starting the backend.
 func (w *ProjectWorker) hasTerminalSuccessLedger(taskID string) (bool, error) {
 	return w.store.HasCompletedExecution(taskID, w.projectPath)
+}
+
+// allDecomposedChildrenShipped reports whether taskID has a recorded
+// StageDecomposed ledger event AND every child task_id parsed from it has a
+// genuine completed execution (Store.HasCompletedExecution). It returns the
+// child task IDs found (possibly empty) regardless of outcome, for logging.
+//
+// GH-4216 (Defect A, fix 3): cross-task-id dispatch guard, defense-in-depth
+// alongside hasTerminalSuccessLedger. hasTerminalSuccessLedger only ever
+// checks taskID's own rows, which never catches an epic parent whose
+// finalize keeps failing (or whose task_id got re-queued for any other
+// reason) once every child it decomposed into already shipped — an epic
+// parent's own row typically carries no deliverable (TASK-296), so
+// HasCompletedExecution(taskID, ...) stays false forever even though the
+// real work is done. Returns false with no children if taskID never
+// decomposed, or if any child is still incomplete (existing epic-resume
+// behavior is left unchanged in that case).
+func (w *ProjectWorker) allDecomposedChildrenShipped(taskID string) (bool, []string, error) {
+	childIDs, found, err := w.store.GetDecomposedChildTaskIDs(taskID, w.projectPath)
+	if err != nil {
+		return false, nil, err
+	}
+	if !found || len(childIDs) == 0 {
+		return false, childIDs, nil
+	}
+	for _, childID := range childIDs {
+		completed, err := w.store.HasCompletedExecution(childID, w.projectPath)
+		if err != nil {
+			return false, childIDs, err
+		}
+		if !completed {
+			return false, childIDs, nil
+		}
+	}
+	return true, childIDs, nil
 }
 
 // dispatchSuccessStage reports the execution_events Stage (and whether to

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -1095,6 +1095,128 @@ func TestProcessQueue_TerminalSuccessLedger_SkipsBackend(t *testing.T) {
 	}
 }
 
+// TestProcessQueue_CrossTaskIDGuard is the GH-4216 (Defect A, fix 3) table
+// test for the cross-task-id dispatch guard: an epic parent task_id that
+// recorded a StageDecomposed ledger event must not be re-dispatched as a
+// fresh top-level task (re-implementing already-shipped work, the GH-4211
+// repro) once every child it decomposed into has a genuine completed
+// execution — but must still run normally when any child is incomplete
+// (existing epic-resume behavior).
+func TestProcessQueue_CrossTaskIDGuard(t *testing.T) {
+	tests := []struct {
+		name             string
+		childStatuses    []string // one completed execution row per child, "" = no row at all
+		wantBackendCalls int
+		wantStatus       string
+	}{
+		{
+			name:             "all children completed skips re-implementation",
+			childStatuses:    []string{"completed", "completed"},
+			wantBackendCalls: 0,
+			wantStatus:       "completed",
+		},
+		{
+			name:             "one child incomplete falls through to normal dispatch",
+			childStatuses:    []string{"completed", "running"},
+			wantBackendCalls: 1,
+			wantStatus:       "completed", // mockFixedBackend succeeds; runner marks it completed
+		},
+		{
+			name:             "no completed rows for either child falls through to normal dispatch",
+			childStatuses:    []string{"", ""},
+			wantBackendCalls: 1,
+			wantStatus:       "completed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+
+			const parentTaskID = "GH-4211"
+			projectPath := setupPRGuardRepo(t, "pilot/GH-4211", false)
+
+			parentExec := &memory.Execution{
+				ID:          "exec-4211-failed",
+				TaskID:      parentTaskID,
+				ProjectPath: projectPath,
+				Status:      "failed",
+				TaskBranch:  "pilot/GH-4211",
+			}
+			if err := store.SaveExecution(parentExec); err != nil {
+				t.Fatalf("failed to save parent execution: %v", err)
+			}
+			if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed,
+				"decomposed into 2 children: #4212, #4213"); err != nil {
+				t.Fatalf("failed to insert decomposed event: %v", err)
+			}
+
+			children := []string{"GH-4212", "GH-4213"}
+			for i, status := range tc.childStatuses {
+				if status == "" {
+					continue
+				}
+				childExec := &memory.Execution{
+					ID:          fmt.Sprintf("exec-%s", children[i]),
+					TaskID:      children[i],
+					ProjectPath: projectPath,
+					Status:      status,
+				}
+				if status == "completed" {
+					childExec.PRUrl = fmt.Sprintf("https://github.com/qf-studio/pilot/pull/%s", strings.TrimPrefix(children[i], "GH-"))
+				}
+				if err := store.SaveExecution(childExec); err != nil {
+					t.Fatalf("failed to save child execution: %v", err)
+				}
+			}
+
+			// A freshly re-queued row for the parent task_id — the GH-4211 repro's
+			// re-poll re-dispatch.
+			requeued := &memory.Execution{
+				ID:          "exec-4211-requeued",
+				TaskID:      parentTaskID,
+				ProjectPath: projectPath,
+				Status:      "queued",
+				TaskBranch:  "pilot/GH-4211",
+			}
+			if err := store.SaveExecution(requeued); err != nil {
+				t.Fatalf("failed to save requeued execution: %v", err)
+			}
+
+			origCheck := mergedPRPreflightCheck
+			mergedPRPreflightCheck = func(_ context.Context, _, _ string) (string, error) { return "", nil }
+			defer func() { mergedPRPreflightCheck = origCheck }()
+
+			backend := &mockFixedBackend{result: &BackendResult{Success: true, Output: "ok"}}
+			runner := NewRunnerWithBackend(backend)
+			runner.skipPreflightChecks = true
+			runner.config = &BackendConfig{SkipSelfReview: true}
+			worker := NewProjectWorker(projectPath, store, runner, slog.Default())
+
+			worker.processQueue(context.Background())
+
+			backend.mu.Lock()
+			count := backend.execCount
+			backend.mu.Unlock()
+			if count != tc.wantBackendCalls {
+				t.Errorf("backend invocations = %d, want %d", count, tc.wantBackendCalls)
+			}
+
+			got, err := store.GetExecution(requeued.ID)
+			if err != nil {
+				t.Fatalf("GetExecution: %v", err)
+			}
+			if got.Status != tc.wantStatus {
+				t.Errorf("requeued row status = %q, want %q", got.Status, tc.wantStatus)
+			}
+			if tc.wantBackendCalls == 0 && got.PRUrl == "" {
+				t.Error("expected the cross-task-id guard to carry a child pr_url as completion evidence")
+			}
+		})
+	}
+}
+
 func TestRecoverStaleTasks_RespectsThresholds(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -842,6 +844,55 @@ func (s *Store) HasCompletedExecution(taskID, projectPath string) (bool, error) 
 		return false, err
 	}
 	return count > 0, nil
+}
+
+// decomposedChildRefRegex extracts "#123"-style issue references from a
+// StageDecomposed execution_events detail string, e.g. "decomposed into 2
+// children: #4212, #4213" (see executor.formatDecomposedChildrenSummary).
+var decomposedChildRefRegex = regexp.MustCompile(`#(\d+)`)
+
+// GetDecomposedChildTaskIDs returns the child task IDs (formatted "GH-<n>",
+// matching the task_id convention sub-issue dispatch uses) parsed from the
+// most recent StageDecomposed execution_events entry recorded for
+// taskID/projectPath, and whether any decomposed event was found at all.
+//
+// GH-4216 (Defect A, fix 3): backs the cross-task-id dispatch guard, which
+// tells a genuinely-fresh task apart from an epic parent whose children
+// already shipped. HasCompletedExecution(taskID, ...) alone can never see
+// this — an epic parent that produced no direct deliverable of its own
+// (TASK-296, epic-parent no-deliverable rows excluded there) never satisfies
+// it, no matter how done its children are.
+func (s *Store) GetDecomposedChildTaskIDs(taskID, projectPath string) ([]string, bool, error) {
+	var detail string
+	err := s.db.QueryRow(`
+		SELECT COALESCE(e.detail, '')
+		FROM execution_events e
+		JOIN executions x ON x.id = e.execution_id
+		WHERE x.task_id = ? AND x.project_path = ? AND e.stage = ?
+		ORDER BY e.occurred_at DESC, e.id DESC
+		LIMIT 1
+	`, taskID, projectPath, string(StageDecomposed)).Scan(&detail)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	matches := decomposedChildRefRegex.FindAllStringSubmatch(detail, -1)
+	if len(matches) == 0 {
+		return nil, true, nil
+	}
+	seen := make(map[string]bool, len(matches))
+	childIDs := make([]string, 0, len(matches))
+	for _, m := range matches {
+		id := "GH-" + m[1]
+		if !seen[id] {
+			seen[id] = true
+			childIDs = append(childIDs, id)
+		}
+	}
+	return childIDs, true, nil
 }
 
 // InvalidateCompletion deletes genuine completed execution records for the given task and

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -445,6 +445,118 @@ func TestHasCompletedExecution(t *testing.T) {
 	}
 }
 
+// TestGetDecomposedChildTaskIDs covers the GH-4216 (Defect A, fix 3)
+// cross-task-id dispatch guard's read helper: no decomposed event, a
+// decomposed event with children, duplicate refs collapsed, and project-path
+// scoping.
+func TestGetDecomposedChildTaskIDs(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	// No execution at all for this task_id yet.
+	childIDs, found, err := store.GetDecomposedChildTaskIDs("GH-4211", "/project")
+	if err != nil {
+		t.Fatalf("GetDecomposedChildTaskIDs failed: %v", err)
+	}
+	if found {
+		t.Error("expected found=false for task with no execution rows")
+	}
+	if len(childIDs) != 0 {
+		t.Errorf("expected no child IDs, got %v", childIDs)
+	}
+
+	// Execution exists but never decomposed (plain direct task).
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-direct",
+		TaskID:      "GH-4300",
+		ProjectPath: "/project",
+		Status:      "completed",
+		CommitSHA:   "abc123",
+	})
+	childIDs, found, err = store.GetDecomposedChildTaskIDs("GH-4300", "/project")
+	if err != nil {
+		t.Fatalf("GetDecomposedChildTaskIDs failed: %v", err)
+	}
+	if found {
+		t.Error("expected found=false for a task that never decomposed")
+	}
+	if len(childIDs) != 0 {
+		t.Errorf("expected no child IDs, got %v", childIDs)
+	}
+
+	// Epic parent that decomposed into two children (GH-4211 repro shape).
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-4211",
+		TaskID:      "GH-4211",
+		ProjectPath: "/project",
+		Status:      "failed",
+		Error:       "epic PR creation failed: title is not a conventional commit",
+	})
+	if err := store.InsertExecutionEvent("exec-4211", StageDecomposed, "decomposed into 2 children: #4212, #4213"); err != nil {
+		t.Fatalf("InsertExecutionEvent failed: %v", err)
+	}
+
+	childIDs, found, err = store.GetDecomposedChildTaskIDs("GH-4211", "/project")
+	if err != nil {
+		t.Fatalf("GetDecomposedChildTaskIDs failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true for a decomposed task")
+	}
+	wantChildren := []string{"GH-4212", "GH-4213"}
+	if !equalStringSlices(childIDs, wantChildren) {
+		t.Errorf("childIDs = %v, want %v", childIDs, wantChildren)
+	}
+
+	// Different project path — must not see the other project's decomposed event.
+	_, found, err = store.GetDecomposedChildTaskIDs("GH-4211", "/other-project")
+	if err != nil {
+		t.Fatalf("GetDecomposedChildTaskIDs failed: %v", err)
+	}
+	if found {
+		t.Error("expected found=false for a different project path")
+	}
+
+	// Duplicate refs across repeated decomposed events collapse to one entry each.
+	_ = store.SaveExecution(&Execution{
+		ID:          "exec-dup",
+		TaskID:      "GH-4400",
+		ProjectPath: "/project",
+		Status:      "failed",
+	})
+	if err := store.InsertExecutionEvent("exec-dup", StageDecomposed, "decomposed into 1 children: #4401"); err != nil {
+		t.Fatalf("InsertExecutionEvent failed: %v", err)
+	}
+	if err := store.InsertExecutionEvent("exec-dup", StageDecomposed, "decomposed into 1 children: #4401"); err != nil {
+		t.Fatalf("InsertExecutionEvent failed: %v", err)
+	}
+	childIDs, found, err = store.GetDecomposedChildTaskIDs("GH-4400", "/project")
+	if err != nil {
+		t.Fatalf("GetDecomposedChildTaskIDs failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true")
+	}
+	if !equalStringSlices(childIDs, []string{"GH-4401"}) {
+		t.Errorf("childIDs = %v, want [GH-4401]", childIDs)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // TestHasCompletedExecution_OrphanRecovery verifies that a completed execution
 // with a non-empty error field (e.g., from orphan recovery) does NOT count as
 // completed. This prevents orphan-recovered executions from blocking re-dispatch.


### PR DESCRIPTION
## Summary

Completes GH-4216 (TASK-401, Defect A) — the third of three chained fixes for the epic-parent duplicate-reimplementation bug. Fixes 1 (decomposer `len<=1` short-circuit) and 2 (epic finalize title normalization) already shipped via #4220/PR #4221; this PR lands fix 3.

- **Cross-task-id dispatch guard**: `Store.GetDecomposedChildTaskIDs` (`internal/memory/store.go`) parses child task IDs out of the most recent `StageDecomposed` `execution_events` detail for a task_id/project_path (`"decomposed into N children: #a, #b"`).
- `ProjectWorker.allDecomposedChildrenShipped` (`internal/executor/dispatcher.go`) uses it alongside `HasCompletedExecution` per child.
- `processQueue`'s pickup-time guard (next to the existing `hasTerminalSuccessLedger` check, GH-4184) short-circuits to completed bookkeeping with fail-loud `slog.Warn` logging instead of re-running the backend once every decomposed child has shipped. Any incomplete child leaves existing epic-resume behavior unchanged.

This closes the GH-4211 repro: parent re-dispatched as a fresh top-level task after its own finalize failed, re-implementing the same fix its child (#4212) had already landed in PR #4213.

## Test plan

- [x] `TestGetDecomposedChildTaskIDs` (internal/memory/store_test.go) — no-decompose, decomposed-with-children, duplicate-ref collapsing, project-path scoping
- [x] `TestProcessQueue_CrossTaskIDGuard` (internal/executor/dispatcher_test.go) — 3-case table: all children complete → skip; one child incomplete → normal dispatch; no completed rows → normal dispatch
- [x] `go build ./... && go vet ./...`
- [x] `go test -race ./internal/executor/... ./internal/memory/... ./cmd/pilot/...`
- [x] `go test -race ./...` (full suite)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`