### PR TITLE
GH-4226: feat(memory): add GetDecomposedChildren parser for decomposed-stage event

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -895,6 +895,72 @@ func (s *Store) GetDecomposedChildTaskIDs(taskID, projectPath string) ([]string,
 	return childIDs, true, nil
 }
 
+// decomposedDetailRegex matches the well-formed "decomposed into N children:
+// #a, #b, #c" detail string emitted by executor.formatDecomposedChildrenSummary
+// (internal/executor/epic.go). Group 1 captures the raw child-ref list.
+var decomposedDetailRegex = regexp.MustCompile(`^decomposed into \d+ children:\s*(.*)$`)
+
+// childIssueNumberRegex matches a single "#123" child reference within the
+// list captured by decomposedDetailRegex.
+var childIssueNumberRegex = regexp.MustCompile(`^#(\d+)$`)
+
+// GetDecomposedChildren returns the child issue numbers parsed from the most
+// recent StageDecomposed execution_events entry recorded for taskID (across
+// all projects — unlike GetDecomposedChildTaskIDs, this is not project-path
+// scoped), and whether a well-formed decomposed event was found.
+//
+// Returns (childIssueNumbers, true) when the latest StageDecomposed detail
+// matches the "decomposed into N children: #a, #b, #c" format. Returns
+// (nil, false) when no StageDecomposed event exists for taskID, and
+// (nil, false) with a warning log when a StageDecomposed event exists but
+// its detail string is malformed (missing colon, non-numeric child ref, or
+// an empty child list) — a shape the trusted emitter should never produce,
+// but one that must not be silently treated as "absent".
+func (s *Store) GetDecomposedChildren(taskID string) ([]string, bool) {
+	var detail string
+	err := s.db.QueryRow(`
+		SELECT COALESCE(e.detail, '')
+		FROM execution_events e
+		JOIN executions x ON x.id = e.execution_id
+		WHERE x.task_id = ? AND e.stage = ?
+		ORDER BY e.occurred_at DESC, e.id DESC
+		LIMIT 1
+	`, taskID, string(StageDecomposed)).Scan(&detail)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, false
+	}
+	if err != nil {
+		slog.Warn("GetDecomposedChildren: query failed", "task_id", taskID, "error", err)
+		return nil, false
+	}
+
+	m := decomposedDetailRegex.FindStringSubmatch(detail)
+	if m == nil {
+		slog.Warn("GetDecomposedChildren: malformed decomposed detail string", "task_id", taskID, "detail", detail)
+		return nil, false
+	}
+
+	childList := strings.TrimSpace(m[1])
+	if childList == "" {
+		slog.Warn("GetDecomposedChildren: decomposed detail has empty child list", "task_id", taskID, "detail", detail)
+		return nil, false
+	}
+
+	tokens := strings.Split(childList, ",")
+	children := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		tok = strings.TrimSpace(tok)
+		cm := childIssueNumberRegex.FindStringSubmatch(tok)
+		if cm == nil {
+			slog.Warn("GetDecomposedChildren: malformed child reference in decomposed detail", "task_id", taskID, "detail", detail, "token", tok)
+			return nil, false
+		}
+		children = append(children, cm[1])
+	}
+
+	return children, true
+}
+
 // InvalidateCompletion deletes genuine completed execution records for the given task and
 // project, allowing re-dispatch. Targets only rows that HasCompletedExecution would count
 // (status='completed', no error, at least one deliverable), leaving orphan-recovered rows

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -545,6 +545,107 @@ func TestGetDecomposedChildTaskIDs(t *testing.T) {
 	}
 }
 
+// TestGetDecomposedChildren covers GH-4226: the taskID-only (not
+// project-path-scoped) decomposed-children reader used by callers that only
+// have a task_id in hand. Table-driven over well-formed, absent, malformed
+// (missing colon / non-numeric child / empty list), and latest-of-multiple.
+func TestGetDecomposedChildren(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	tests := []struct {
+		name      string
+		taskID    string
+		execID    string
+		details   []string // inserted in order; empty slice means no event at all
+		wantChild []string
+		wantFound bool
+		skipSetup bool // task ID has no execution row at all
+	}{
+		{
+			name:      "well-formed detail",
+			taskID:    "GH-5001",
+			execID:    "exec-5001",
+			details:   []string{"decomposed into 3 children: #5002, #5003, #5004"},
+			wantChild: []string{"5002", "5003", "5004"},
+			wantFound: true,
+		},
+		{
+			name:      "missing event",
+			taskID:    "GH-5100",
+			skipSetup: true,
+			wantChild: nil,
+			wantFound: false,
+		},
+		{
+			name:      "malformed - missing colon",
+			taskID:    "GH-5200",
+			execID:    "exec-5200",
+			details:   []string{"decomposed into 2 children #5201, #5202"},
+			wantChild: nil,
+			wantFound: false,
+		},
+		{
+			name:      "malformed - non-numeric child",
+			taskID:    "GH-5300",
+			execID:    "exec-5300",
+			details:   []string{"decomposed into 2 children: #abc, #5302"},
+			wantChild: nil,
+			wantFound: false,
+		},
+		{
+			name:      "malformed - empty list",
+			taskID:    "GH-5400",
+			execID:    "exec-5400",
+			details:   []string{"decomposed into 0 children: "},
+			wantChild: nil,
+			wantFound: false,
+		},
+		{
+			name:   "multiple decomposed events - use latest",
+			taskID: "GH-5500",
+			execID: "exec-5500",
+			details: []string{
+				"decomposed into 1 children: #5501",
+				"decomposed into 2 children: #5502, #5503",
+			},
+			wantChild: []string{"5502", "5503"},
+			wantFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.skipSetup {
+				if err := store.SaveExecution(&Execution{
+					ID:          tt.execID,
+					TaskID:      tt.taskID,
+					ProjectPath: "/project",
+					Status:      "failed",
+				}); err != nil {
+					t.Fatalf("SaveExecution failed: %v", err)
+				}
+				for _, d := range tt.details {
+					if err := store.InsertExecutionEvent(tt.execID, StageDecomposed, d); err != nil {
+						t.Fatalf("InsertExecutionEvent failed: %v", err)
+					}
+				}
+			}
+
+			gotChild, gotFound := store.GetDecomposedChildren(tt.taskID)
+			if gotFound != tt.wantFound {
+				t.Errorf("found = %v, want %v", gotFound, tt.wantFound)
+			}
+			if !equalStringSlices(gotChild, tt.wantChild) {
+				t.Errorf("children = %v, want %v", gotChild, tt.wantChild)
+			}
+		})
+	}
+}
+
 func equalStringSlices(a, b []string) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-4226.

Closes #4226

## Changes

In internal/memory/store.go, add GetDecomposedChildren(taskID string) ([]string, bool) that queries the execution_events row for the decomposed stage of taskID and parses the "decomposed into N children: #a, #b, #c" detail string emitted by internal/executor/epic.go. Return (childIssueNumbers, true) on a well-formed match, (nil, false) when the event is absent, and (nil, false) with a warning log on a malformed detail string. Add table-driven tests in the existing internal/memory store test file covering: well-formed detail, missing event, malformed detail (missing colon, non-numeric child, empty list), and multiple decomposed events (use the latest). Verify go test -race ./internal/memory/... passes. Adds zero new GitHub API calls — pure SQL/ledger read.