### PR TITLE
fix(executor): dependency-aware selective merge-wait for epic sub-issues (GH-4234)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -585,6 +585,7 @@ quality:
 
 | Feature | Version | Package | Notes |
 |---------|---------|---------|-------|
+| Dependency-aware selective sub-issue merge-wait | v2.238.x+ | executor | `detectChildDependency` (new `dependency_detector.go`) gates `executeSubIssuesTracked`'s merge-wait per child on an explicit `Depends on: #N`/`Blocked by: #N` ref (scoped to sibling issue numbers) or verification-shape language ("verify…"/"confirm…"/"run the acceptance…"/"regression-test…", overridden by "add…"/"fix…"/"implement…"); `wait_for_merge:false` stays the global default for independent siblings. Merge-wait callback now wired unconditionally in `main.go` (no-op when unused); every decision fail-loud logged (TASK-402 / GH-4234) |
 | Issue-level success rate + rate_limited exclusion | v2.235.0+ | autopilot + memory + gateway | `pilot_issue_level_success_rate` / `pilot_issues_shipped_total` / `pilot_issues_attempted_total` dedupe by `task_id` across retries; `pilot_success_rate` now excludes `rate_limited` from the denominator; hydrator no longer folds declined/no_op/stalled/infra/skipped into `failed` (TASK-392 / GH-4070) |
 | Poller skip-by-reason counters | v2.150.0 | adapters/github | `pilot_poller_skipped/dispatched/deferred` Prometheus counters (TASK-293 / GH-3064) |
 | `WithRetry` centralized in `doRequest` | v2.150.0 | adapters/github | All GitHub client methods now get retry; `RecordAPIError` wired (TASK-294 / GH-3065) |

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2360,8 +2360,14 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					}
 				}
 
-				// Wire sub-issue merge-wait so epic sub-issues block until their PR merges (GH-2179)
-				if waitForMerge && cfg.Adapters.GitHub.Repo != "" {
+				// Wire sub-issue merge-wait so epic sub-issues block until their PR merges
+				// (GH-2179). GH-4234: wired unconditionally regardless of waitForMerge —
+				// it's cheap when unused, and the per-child decision now lives in the
+				// executor's dependency detector (executeSubIssuesTracked), not this flag.
+				// wait_for_merge:false stays the effective global default for independent
+				// siblings; this callback only fires when a child is actually detected as
+				// dependent on a prior sibling (TASK-402).
+				if cfg.Adapters.GitHub.Repo != "" {
 					parts := strings.SplitN(cfg.Adapters.GitHub.Repo, "/", 2)
 					if len(parts) == 2 {
 						mergeWaiter := github.NewMergeWaiter(client, parts[0], parts[1], &github.MergeWaiterConfig{

--- a/internal/executor/dependency_detector.go
+++ b/internal/executor/dependency_detector.go
@@ -1,0 +1,96 @@
+package executor
+
+import (
+	"regexp"
+	"strconv"
+)
+
+// DependencyReason identifies why a sub-issue is treated as depending on a
+// prior sibling's merged state, for the selective merge-wait gate in
+// executeSubIssuesTracked (GH-4234 / TASK-402).
+type DependencyReason string
+
+const (
+	// DependencyNone is the default: no dependency detected, so the child may
+	// start without waiting for any prior sibling's PR to merge. This keeps
+	// wait_for_merge:false the effective global default for independent
+	// siblings — see TASK-402.
+	DependencyNone DependencyReason = "none"
+
+	// DependencyExplicitRef means the child's title/description names a prior
+	// sibling via "Depends on: #N" or "Blocked by: #N".
+	DependencyExplicitRef DependencyReason = "explicit_ref"
+
+	// DependencyVerificationShape means the child's title/description reads as
+	// verifying/confirming earlier work (e.g. "verify…", "confirm zero
+	// hits…", "run the acceptance…", "regression-test…") rather than
+	// implementing something new — treated as depending on the immediately
+	// preceding sibling.
+	DependencyVerificationShape DependencyReason = "verification_shape"
+)
+
+// dependencyRefRe matches an explicit "Depends on: #123" / "Blocked by: #123"
+// reference anywhere in a sub-issue's title or description text.
+var dependencyRefRe = regexp.MustCompile(`(?i)\b(?:depends on|blocked by)\s*:?\s*#(\d+)`)
+
+// verificationPositiveRe matches phrases that mark a sub-issue as verifying or
+// confirming prior work: "verify…", "confirm zero hits…", "run the
+// acceptance…", "regression-test…".
+var verificationPositiveRe = regexp.MustCompile(`(?i)\b(verify|confirm|run the acceptance|regression[\s-]test)\w*\b`)
+
+// verificationNegativeRe matches phrases that mark genuine new implementation
+// work. These override a verification-shape match — a child that both
+// verifies and implements is still new work, not a pure verification child.
+var verificationNegativeRe = regexp.MustCompile(`(?i)\b(add|fix|implement)\w*\b`)
+
+// detectChildDependency inspects a sub-issue's title+description text and
+// decides whether it depends on a prior sibling in the current epic's child
+// set, and so must wait for that sibling's PR to merge (+ a main-branch sync)
+// before it starts.
+//
+// siblingNumbers scopes the explicit-ref check (GH-4234): an explicit
+// "Depends on: #N" is only honored when N belongs to the current epic's own
+// child set — a reference to the epic parent or an unrelated issue elsewhere
+// in the tracker must not force a wait.
+func detectChildDependency(title, description string, siblingNumbers map[int]bool) (bool, DependencyReason) {
+	text := title + "\n" + description
+
+	for _, m := range dependencyRefRe.FindAllStringSubmatch(text, -1) {
+		num, err := strconv.Atoi(m[1])
+		if err == nil && siblingNumbers[num] {
+			return true, DependencyExplicitRef
+		}
+	}
+
+	if verificationPositiveRe.MatchString(text) && !verificationNegativeRe.MatchString(text) {
+		return true, DependencyVerificationShape
+	}
+
+	return false, DependencyNone
+}
+
+// siblingIssueNumbers builds the set of GitHub issue numbers for every child
+// in the current epic decomposition, used to scope detectChildDependency's
+// explicit-ref check to siblings only.
+func siblingIssueNumbers(issues []CreatedIssue) map[int]bool {
+	set := make(map[int]bool, len(issues))
+	for _, issue := range issues {
+		if issue.Number > 0 {
+			set[issue.Number] = true
+		}
+	}
+	return set
+}
+
+// subIssueDisplayRef returns the human-readable reference for a sub-issue
+// used in dependency log lines: the numeric GitHub issue number when present,
+// otherwise the adapter Identifier (e.g. Linear/Jira key).
+func subIssueDisplayRef(issue CreatedIssue) string {
+	if issue.Number > 0 {
+		return strconv.Itoa(issue.Number)
+	}
+	if issue.Identifier != "" {
+		return issue.Identifier
+	}
+	return "unknown"
+}

--- a/internal/executor/dependency_detector_test.go
+++ b/internal/executor/dependency_detector_test.go
@@ -1,0 +1,227 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestDetectChildDependency_ExplicitRef covers the explicit "Depends on: #N" /
+// "Blocked by: #N" ref path, including the sibling-set scoping requirement
+// (GH-4234): a ref to an issue outside the current epic's child set must not
+// be honored.
+func TestDetectChildDependency_ExplicitRef(t *testing.T) {
+	siblings := map[int]bool{100: true, 101: true}
+
+	tests := []struct {
+		name        string
+		title       string
+		description string
+		wantDepends bool
+		wantReason  DependencyReason
+	}{
+		{
+			name:        "Depends on sibling",
+			description: "Finish the rollout.\n\nDepends on: #100",
+			wantDepends: true,
+			wantReason:  DependencyExplicitRef,
+		},
+		{
+			name:        "Blocked by sibling",
+			description: "Finish the rollout.\n\nBlocked by: #101",
+			wantDepends: true,
+			wantReason:  DependencyExplicitRef,
+		},
+		{
+			name:        "ref to issue outside sibling set is not honored",
+			description: "Depends on: #999",
+			wantDepends: false,
+			wantReason:  DependencyNone,
+		},
+		{
+			name:        "no ref at all",
+			description: "Just a plain implementation task.",
+			wantDepends: false,
+			wantReason:  DependencyNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			depends, reason := detectChildDependency(tt.title, tt.description, siblings)
+			if depends != tt.wantDepends {
+				t.Errorf("depends = %v, want %v", depends, tt.wantDepends)
+			}
+			if reason != tt.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestDetectChildDependency_VerificationShape is the table test required by
+// GH-4234's acceptance criteria: positive phrases ("verify…", "confirm zero
+// hits…", "run the acceptance…", "regression-test…") must be treated as
+// dependent on the prior sibling; negative phrases ("add…", "fix…",
+// "implement…") must not.
+func TestDetectChildDependency_VerificationShape(t *testing.T) {
+	noSiblings := map[int]bool{}
+
+	tests := []struct {
+		name        string
+		title       string
+		wantDepends bool
+	}{
+		{name: "verify the migration completed", title: "verify the migration completed", wantDepends: true},
+		{name: "confirm zero hits for the removed helper", title: "confirm zero hits for the removed helper", wantDepends: true},
+		{name: "run the acceptance suite", title: "run the acceptance suite", wantDepends: true},
+		{name: "regression-test the previous change", title: "regression-test the previous change", wantDepends: true},
+		{name: "regression test without hyphen", title: "regression test the previous change", wantDepends: true},
+
+		{name: "add rate limiting to the API", title: "add rate limiting to the API", wantDepends: false},
+		{name: "fix the flaky test", title: "fix the flaky test", wantDepends: false},
+		{name: "implement the new endpoint", title: "implement the new endpoint", wantDepends: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			depends, reason := detectChildDependency(tt.title, "", noSiblings)
+			if depends != tt.wantDepends {
+				t.Errorf("detectChildDependency(%q) depends = %v, want %v (reason=%q)", tt.title, depends, tt.wantDepends, reason)
+			}
+			if tt.wantDepends && reason != DependencyVerificationShape {
+				t.Errorf("reason = %q, want %q", reason, DependencyVerificationShape)
+			}
+			if !tt.wantDepends && reason != DependencyNone {
+				t.Errorf("reason = %q, want %q", reason, DependencyNone)
+			}
+		})
+	}
+}
+
+// TestDetectChildDependency_NegativeOverridesPositive verifies that when a
+// child's text contains both a verification word and genuine implementation
+// language, the negative (implementation) signal wins — a child that verifies
+// AND implements is still new work, not a pure verification-only child.
+func TestDetectChildDependency_NegativeOverridesPositive(t *testing.T) {
+	depends, reason := detectChildDependency("verify the fix, then add the missing validation", "", map[int]bool{})
+	if depends {
+		t.Errorf("expected mixed verify+add text to NOT be flagged dependent, got depends=%v reason=%q", depends, reason)
+	}
+}
+
+// TestExecuteSubIssuesTracked_IndependentSiblings_NoMergeWait is the GH-4234
+// acceptance criterion: two independent children (no explicit ref, no
+// verification-shape language) must yield ZERO merge-wait calls even though a
+// merge-waiter is wired — wait_for_merge:false stays the effective default.
+func TestExecuteSubIssuesTracked_IndependentSiblings_NoMergeWait(t *testing.T) {
+	issues := makeSubIssues(2, 5000)
+	// Both children have plain implementation-style descriptions — no
+	// dependency markers at all.
+	issues[0].Subtask.Description = "Add the new config field."
+	issues[1].Subtask.Description = "Implement the new handler."
+
+	callIdx := 0
+	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		idx := callIdx
+		callIdx++
+		return &ExecutionResult{
+			TaskID:  task.ID,
+			Success: true,
+			PRUrl:   fmt.Sprintf("https://github.com/owner/repo/pull/%d", 6000+idx),
+		}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+
+	var buf bytes.Buffer
+	runner.log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	waitCalls := 0
+	runner.SetSubIssueMergeWait(func(ctx context.Context, prNumber int) error {
+		waitCalls++
+		return nil
+	})
+
+	parent := &Task{ID: "GH-4234-IND", Title: "[epic] independent siblings"}
+
+	err := runner.ExecuteSubIssues(context.Background(), parent, issues, "", "")
+	if err != nil {
+		t.Fatalf("ExecuteSubIssues returned error: %v", err)
+	}
+
+	if waitCalls != 0 {
+		t.Fatalf("expected 0 merge-wait calls for independent siblings, got %d", waitCalls)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "merge-wait decision: not waiting before next sub-issue") {
+		t.Errorf("expected a fail-loud no-wait decision log line, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "dependency_reason=none") {
+		t.Errorf("expected no-wait decision log to record dependency_reason=none, got: %s", logOutput)
+	}
+}
+
+// TestExecuteSubIssuesTracked_ExplicitDependency_WaitsAndSyncs is the GH-4234
+// acceptance criterion: a child explicitly declaring "Depends on: #<sibling>"
+// waits for that sibling's PR to merge (+ syncMainBranch) before it starts.
+func TestExecuteSubIssuesTracked_ExplicitDependency_WaitsAndSyncs(t *testing.T) {
+	issues := makeSubIssues(2, 7000)
+	issues[1].Subtask.Description += fmt.Sprintf("\n\nDepends on: #%d", issues[0].Number)
+
+	var execOrder []string
+	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {
+		execOrder = append(execOrder, "exec:"+task.ID)
+		return &ExecutionResult{
+			TaskID:  task.ID,
+			Success: true,
+			PRUrl:   "https://github.com/owner/repo/pull/8000",
+		}, nil
+	}
+
+	runner := newTestRunnerWithExecFunc(execFn)
+
+	var buf bytes.Buffer
+	runner.log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	waitedPRs := []int{}
+	runner.SetSubIssueMergeWait(func(ctx context.Context, prNumber int) error {
+		execOrder = append(execOrder, "wait")
+		waitedPRs = append(waitedPRs, prNumber)
+		return nil
+	})
+
+	parent := &Task{ID: "GH-4234-DEP", Title: "[epic] explicit dependency"}
+
+	err := runner.ExecuteSubIssues(context.Background(), parent, issues, "", "")
+	if err != nil {
+		t.Fatalf("ExecuteSubIssues returned error: %v", err)
+	}
+
+	if len(waitedPRs) != 1 || waitedPRs[0] != 8000 {
+		t.Fatalf("expected exactly one merge-wait call for PR #8000, got %v", waitedPRs)
+	}
+
+	// The wait must happen between the two execs, i.e. before the dependent
+	// sibling starts.
+	wantOrder := fmt.Sprintf("exec:GH-%d,wait,exec:GH-%d", issues[0].Number, issues[1].Number)
+	gotOrder := strings.Join(execOrder, ",")
+	if gotOrder != wantOrder {
+		t.Errorf("execution order = %q, want %q", gotOrder, wantOrder)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "merge-wait decision: waiting for prior sub-issue PR to merge") {
+		t.Errorf("expected a fail-loud wait decision log line, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "dependency_reason=explicit_ref") {
+		t.Errorf("expected wait decision log to record dependency_reason=explicit_ref, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "target_pr=8000") {
+		t.Errorf("expected wait decision log to record target_pr=8000, got: %s", logOutput)
+	}
+}

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1899,6 +1899,10 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 	var childStates []string
 
 	total := len(issues)
+	// GH-4234: sibling set for scoping the dependency detector's explicit-ref
+	// check — an explicit "Depends on: #N" only counts when N is one of this
+	// epic's own children.
+	siblingNumbers := siblingIssueNumbers(issues)
 	// Use executionPath for gh CLI commands (respects worktree isolation)
 	projectPath := executionPath
 	if projectPath == "" && parent != nil {
@@ -2161,37 +2165,71 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			}
 		}
 
-		// GH-2178: Wait for the sub-issue PR to merge before starting the next one.
-		// Skip for the last sub-issue (no next issue to sequence).
-		// Nil check degrades gracefully — if not wired, execution proceeds without waiting.
-		if r.subIssueMergeWait != nil && result.PRUrl != "" && i < total-1 {
+		// GH-2178/GH-4234: Decide whether to wait for this sub-issue's PR to merge
+		// before starting the next one. Skip for the last sub-issue (no next issue
+		// to sequence). wait_for_merge:false remains the global default (TASK-402) —
+		// a wait is applied only when the NEXT sibling's own title/description
+		// shows it actually depends on this one (explicit "Depends on: #N" /
+		// "Blocked by: #N" ref, or verification-shape language). Nil merge-wait fn
+		// degrades gracefully — if not wired, execution proceeds without waiting.
+		if result.PRUrl != "" && i < total-1 {
 			prNum := parsePRNumberFromURL(result.PRUrl)
 			if prNum > 0 {
-				waitMsg := fmt.Sprintf("⏳ Waiting for PR #%d to merge before starting next sub-issue (%d/%d)...",
-					prNum, i+1, total)
-				_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, waitMsg)
+				nextIssue := issues[i+1]
+				nextRef := subIssueDisplayRef(nextIssue)
+				depends, reason := detectChildDependency(nextIssue.Subtask.Title, nextIssue.Subtask.Description, siblingNumbers)
 
-				r.log.Info("Waiting for sub-issue PR to merge",
-					"parent_id", parent.ID,
-					"sub_issue", issueRef,
-					"pr_number", prNum,
-					"order", i+1,
-					"total", total,
-				)
+				switch {
+				case depends && r.subIssueMergeWait != nil:
+					waitMsg := fmt.Sprintf("⏳ Waiting for PR #%d to merge before starting next sub-issue (%d/%d) — %s depends on it (%s)",
+						prNum, i+1, total, nextRef, reason)
+					_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, waitMsg)
 
-				if err := r.subIssueMergeWait(ctx, prNum); err != nil {
-					failMsg := fmt.Sprintf("❌ Merge wait failed for %s (PR #%d): %v", issueRef, prNum, err)
-					_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
-					return childStates, metrics, fmt.Errorf("merge wait failed for sub-issue %s (PR #%d): %w", issueRef, prNum, err)
-				}
-
-				// Sync local main branch so the next sub-issue branches from the merged state.
-				if syncErr := r.syncMainBranch(ctx, subTaskRepoPath); syncErr != nil {
-					r.log.Warn("Failed to sync main branch after sub-issue merge",
-						"sub_issue", issueRef,
-						"error", syncErr,
+					// Fail-loud decision log (GH-4234): every wait decision names the
+					// dependent child, why it's judged dependent, and the PR it waits on.
+					r.log.Info("merge-wait decision: waiting for prior sub-issue PR to merge",
+						"parent_id", parent.ID,
+						"prior_sub_issue", issueRef,
+						"next_sub_issue", nextRef,
+						"dependency_reason", string(reason),
+						"target_pr", prNum,
+						"order", i+1,
+						"total", total,
 					)
-					// Non-fatal: next sub-issue will fetch from origin anyway.
+
+					if err := r.subIssueMergeWait(ctx, prNum); err != nil {
+						failMsg := fmt.Sprintf("❌ Merge wait failed for %s (PR #%d): %v", issueRef, prNum, err)
+						_ = r.UpdateIssueProgress(ctx, projectPath, parent.ID, failMsg)
+						return childStates, metrics, fmt.Errorf("merge wait failed for sub-issue %s (PR #%d): %w", issueRef, prNum, err)
+					}
+
+					// Sync local main branch so the next sub-issue branches from the merged state.
+					if syncErr := r.syncMainBranch(ctx, subTaskRepoPath); syncErr != nil {
+						r.log.Warn("Failed to sync main branch after sub-issue merge",
+							"sub_issue", issueRef,
+							"error", syncErr,
+						)
+						// Non-fatal: next sub-issue will fetch from origin anyway.
+					}
+
+				default:
+					skipReason := string(reason)
+					if depends && r.subIssueMergeWait == nil {
+						skipReason = string(reason) + " (merge-wait not wired)"
+					}
+
+					// Fail-loud decision log (GH-4234): a no-wait decision is logged just
+					// as loudly as a wait — this is what makes "wait_for_merge:false stays
+					// the default for independent siblings" verifiable in production logs.
+					r.log.Info("merge-wait decision: not waiting before next sub-issue",
+						"parent_id", parent.ID,
+						"prior_sub_issue", issueRef,
+						"next_sub_issue", nextRef,
+						"dependency_reason", skipReason,
+						"target_pr", prNum,
+						"order", i+1,
+						"total", total,
+					)
 				}
 			}
 		}

--- a/internal/executor/epic_sequential_test.go
+++ b/internal/executor/epic_sequential_test.go
@@ -660,8 +660,14 @@ func TestSequentialEpicFlow_ContextDeadline(t *testing.T) {
 
 // TestSubIssueMergeWait_BlocksBetweenSubIssues verifies that the merge-wait function
 // is called once per sub-issue except the last, and each call receives the correct PR number.
+// GH-4234: merge-wait is now gated by the dependency detector, so each non-first
+// sub-issue here explicitly declares "Depends on: #<prevSiblingNumber>" to make
+// the wait fire — an independent sibling would not trigger it (see
+// TestExecuteSubIssuesTracked_IndependentSiblings_NoMergeWait).
 func TestSubIssueMergeWait_BlocksBetweenSubIssues(t *testing.T) {
 	subIssues := makeSubIssues(3, 1000)
+	subIssues[1].Subtask.Description += "\n\nDepends on: #1000"
+	subIssues[2].Subtask.Description += "\n\nDepends on: #1001"
 
 	prURLs := []string{
 		"https://github.com/owner/repo/pull/2000",
@@ -709,8 +715,11 @@ func TestSubIssueMergeWait_BlocksBetweenSubIssues(t *testing.T) {
 
 // TestSubIssueMergeWait_FailureAbortsEpic verifies that when the merge-wait function
 // returns an error, ExecuteSubIssues aborts immediately and surfaces that error.
+// GH-4234: the second sub-issue declares an explicit dependency on the first so
+// the detector actually triggers the merge-wait call this test exercises.
 func TestSubIssueMergeWait_FailureAbortsEpic(t *testing.T) {
 	subIssues := makeSubIssues(3, 1100)
+	subIssues[1].Subtask.Description += "\n\nDepends on: #1100"
 
 	execCallCount := 0
 	execFn := func(ctx context.Context, task *Task) (*ExecutionResult, error) {


### PR DESCRIPTION
## Summary
- Add `detectChildDependency` (`internal/executor/dependency_detector.go`): explicit `Depends on: #N` / `Blocked by: #N` refs scoped to the epic's own sibling issue numbers, plus a verification-shape heuristic (`verify…`, `confirm…`, `run the acceptance…`, `regression-test…`), overridden by genuine implementation language (`add…`, `fix…`, `implement…`).
- Wire the merge-wait callback unconditionally in `cmd/pilot/main.go` — cheap no-op when the detector never fires.
- `executeSubIssuesTracked` (`internal/executor/epic.go`) consults the detector before each child: on explicit ref or verification-shape match it waits for the prior sibling's PR to merge + syncs main; otherwise it proceeds without waiting, preserving `wait_for_merge:false` as the default for independent siblings.
- Every wait/no-wait decision is fail-loud logged with the child ref, dependency reason, and target PR.

Closes #4234

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/executor/...`
- [x] `go test -race ./cmd/pilot/...`
- [x] New tests: independent siblings → zero merge-wait calls; explicit `Depends on: #<sibling>` child waits+syncs before starting; table test for verification-shape AC positive/negative phrases; fail-loud log line assertions