### PR TITLE
feat(executor): fold verify-only planned subtasks into predecessor (GH-4235)

### DIFF
--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1118,6 +1118,13 @@ func (r *Runner) CreateSubIssues(ctx context.Context, plan *EpicPlan, executionP
 	if len(valid) == 0 {
 		return nil, fmt.Errorf("decomposition produced %d subtasks but none had a description — refusing to create empty sub-issues", len(plan.Subtasks))
 	}
+
+	// GH-4235/GH-4233: fold any subtask that is pure verification of its
+	// immediate predecessor's work (verification-shape heuristic + no new
+	// file/symbol surface) into that predecessor, dropping the verify-only
+	// entry so it never becomes its own empty-work sub-issue.
+	valid = foldVerifyOnlySubtasks(valid)
+
 	if len(valid) < len(plan.Subtasks) {
 		plan = &EpicPlan{ParentTask: plan.ParentTask, Subtasks: valid, TotalEffort: plan.TotalEffort, PlanOutput: plan.PlanOutput}
 	}

--- a/internal/executor/epic_verify_fold.go
+++ b/internal/executor/epic_verify_fold.go
@@ -1,0 +1,129 @@
+package executor
+
+import (
+	"regexp"
+	"strings"
+)
+
+// verifyShapePositiveRe / verifyShapeNegativeRe mirror the verification-shape
+// heuristic from the sibling dependency detector (dependency_detector.go,
+// GH-4234/TASK-402): positive phrases mark a subtask as checking prior work
+// rather than building something new; negative phrases signal genuine new
+// implementation and override a positive match. Duplicated here rather than
+// referenced directly because GH-4234 had not landed on main at the time this
+// subtask (GH-4235) executed — dedupe into one shared definition once both
+// are merged.
+var verifyShapePositiveRe = regexp.MustCompile(`(?i)\b(verify|confirm|run the acceptance|regression[\s-]test)\w*\b`)
+var verifyShapeNegativeRe = regexp.MustCompile(`(?i)\b(add|fix|implement)\w*\b`)
+
+// backtickSpanPattern extracts inline-code spans (“ `like this` “) from
+// planning prose, used by implementationSurface to pick out symbol names that
+// aren't file paths.
+var backtickSpanPattern = regexp.MustCompile("`([^`]+)`")
+
+// implementationSurface extracts the set of files and symbols a planned
+// subtask's title+description stakes out as its own work. Used by
+// foldVerifyOnlySubtasks to tell a pure verification step (touches nothing
+// new) from one that introduces its own implementation surface despite
+// verification-shaped language.
+func implementationSurface(text string) map[string]bool {
+	surface := make(map[string]bool)
+
+	for _, m := range filePathPattern.FindAllString(text, -1) {
+		surface["file:"+m] = true
+	}
+
+	for _, m := range backtickSpanPattern.FindAllStringSubmatch(text, -1) {
+		token := strings.TrimSpace(m[1])
+		if token == "" || strings.ContainsAny(token, " \t\n") {
+			continue
+		}
+		if filePathPattern.MatchString(token) {
+			continue // already captured as a file target above
+		}
+		surface["symbol:"+token] = true
+	}
+
+	return surface
+}
+
+// isVerifyOnlySubtask reports whether st reads as pure verification of prev's
+// work: it must match the verification-shape heuristic (and not the
+// implementation-shape override), and every file/symbol it names must already
+// belong to prev's implementation surface — i.e. it introduces nothing new.
+func isVerifyOnlySubtask(st, prev PlannedSubtask) bool {
+	text := st.Title + "\n" + st.Description
+	if !verifyShapePositiveRe.MatchString(text) || verifyShapeNegativeRe.MatchString(text) {
+		return false
+	}
+
+	surface := implementationSurface(text)
+	if len(surface) == 0 {
+		return true
+	}
+
+	prevSurface := implementationSurface(prev.Title + "\n" + prev.Description)
+	for target := range surface {
+		if !prevSurface[target] {
+			return false
+		}
+	}
+	return true
+}
+
+// foldAcceptanceCriteria appends a verify-only subtask's acceptance criteria
+// into the predecessor's description under a shared section. Checkbox-style
+// criteria lines (reusing decompose.go's extractAcceptanceCriteria) are
+// preferred; when the verify-only description has none, its full text is
+// folded in as a single criterion.
+func foldAcceptanceCriteria(prevDesc, verifyDesc string) string {
+	criteria := extractAcceptanceCriteria(verifyDesc)
+	if len(criteria) == 0 {
+		trimmed := strings.TrimSpace(verifyDesc)
+		if trimmed == "" {
+			return prevDesc
+		}
+		criteria = []string{trimmed}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(strings.TrimRight(prevDesc, "\n"))
+	sb.WriteString("\n\n## Acceptance Criteria (folded)\n")
+	for _, c := range criteria {
+		sb.WriteString("- [ ] ")
+		sb.WriteString(strings.TrimSpace(c))
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+// foldVerifyOnlySubtasks collapses planned subtasks that are pure
+// verification of the immediately preceding subtask into that predecessor,
+// dropping the now-redundant verify-only entry (GH-4235/GH-4233). An epic
+// planner sometimes emits a trailing subtask that only re-checks the prior
+// subtask's deliverable ("verify X works", "confirm zero regressions")
+// without adding any file or symbol of its own — creating a sub-issue for
+// that step produces a child with nothing left to implement.
+//
+// Ordering is preserved and folding only ever targets the immediate
+// surviving predecessor — a verify-only entry never reaches back past one
+// that was itself folded away.
+func foldVerifyOnlySubtasks(subtasks []PlannedSubtask) []PlannedSubtask {
+	if len(subtasks) < 2 {
+		return subtasks
+	}
+
+	folded := make([]PlannedSubtask, 0, len(subtasks))
+	folded = append(folded, subtasks[0])
+
+	for _, st := range subtasks[1:] {
+		prev := &folded[len(folded)-1]
+		if isVerifyOnlySubtask(st, *prev) {
+			prev.Description = foldAcceptanceCriteria(prev.Description, st.Description)
+			continue
+		}
+		folded = append(folded, st)
+	}
+
+	return folded
+}

--- a/internal/executor/epic_verify_fold_test.go
+++ b/internal/executor/epic_verify_fold_test.go
@@ -1,0 +1,185 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFoldVerifyOnlySubtasks(t *testing.T) {
+	t.Run("N-subtask plan with one verify-only entry collapses to N-1", func(t *testing.T) {
+		subtasks := []PlannedSubtask{
+			{
+				Order:       1,
+				Title:       "feat(executor): add dependency detector",
+				Description: "Implement detectChildDependency in internal/executor/dependency_detector.go.",
+			},
+			{
+				Order:       2,
+				Title:       "feat(executor): wire merge-wait callback",
+				Description: "Add the wait_for_merge wiring in internal/executor/epic.go.",
+			},
+			{
+				Order:       3,
+				Title:       "test(executor): verify merge-wait wiring",
+				Description: "Verify the merge-wait wiring in internal/executor/epic.go behaves correctly. Confirm zero regressions.",
+			},
+		}
+
+		got := foldVerifyOnlySubtasks(subtasks)
+
+		if len(got) != len(subtasks)-1 {
+			t.Fatalf("expected %d subtasks after folding, got %d", len(subtasks)-1, len(got))
+		}
+		if got[len(got)-1].Order != 2 {
+			t.Fatalf("expected the verify-only entry to fold into its immediate predecessor (order 2), got order %d", got[len(got)-1].Order)
+		}
+		if !strings.Contains(got[len(got)-1].Description, "## Acceptance Criteria (folded)") {
+			t.Fatalf("expected folded AC section in predecessor description, got: %s", got[len(got)-1].Description)
+		}
+		if !strings.Contains(got[len(got)-1].Description, "Confirm zero regressions") {
+			t.Fatalf("expected verify-only subtask's criteria merged into predecessor, got: %s", got[len(got)-1].Description)
+		}
+	})
+
+	t.Run("verify-only entry with checkbox ACs merges each into predecessor's AC list", func(t *testing.T) {
+		subtasks := []PlannedSubtask{
+			{
+				Order:       1,
+				Title:       "feat(memory): add store method",
+				Description: "Implement Store.Get in internal/memory/store.go.",
+			},
+			{
+				Order:       2,
+				Title:       "test(memory): verify store method",
+				Description: "Verify Store.Get in internal/memory/store.go.\n\n- [ ] returns nil on missing key\n- [ ] returns value on hit",
+			},
+		}
+
+		got := foldVerifyOnlySubtasks(subtasks)
+
+		if len(got) != 1 {
+			t.Fatalf("expected 1 subtask after folding, got %d", len(got))
+		}
+		desc := got[0].Description
+		if !strings.Contains(desc, "returns nil on missing key") || !strings.Contains(desc, "returns value on hit") {
+			t.Fatalf("expected both checkbox ACs folded into predecessor, got: %s", desc)
+		}
+	})
+
+	t.Run("preserves ordering and only folds into the immediate predecessor", func(t *testing.T) {
+		subtasks := []PlannedSubtask{
+			{Order: 1, Title: "feat(a): implement a", Description: "Implement internal/a/a.go."},
+			{Order: 2, Title: "test(a): verify a", Description: "Verify internal/a/a.go works."},
+			{Order: 3, Title: "feat(b): implement b", Description: "Implement internal/b/b.go."},
+		}
+
+		got := foldVerifyOnlySubtasks(subtasks)
+
+		if len(got) != 2 {
+			t.Fatalf("expected 2 subtasks after folding, got %d", len(got))
+		}
+		if got[0].Order != 1 || got[1].Order != 3 {
+			t.Fatalf("expected order [1,3], got [%d,%d]", got[0].Order, got[1].Order)
+		}
+	})
+
+	t.Run("verify-only subtask that introduces a new file is not folded", func(t *testing.T) {
+		subtasks := []PlannedSubtask{
+			{Order: 1, Title: "feat(a): implement a", Description: "Implement internal/a/a.go."},
+			{Order: 2, Title: "test(b): verify b", Description: "Verify the new behavior in internal/b/b.go."},
+		}
+
+		got := foldVerifyOnlySubtasks(subtasks)
+
+		if len(got) != 2 {
+			t.Fatalf("expected verify-only subtask referencing a new file to survive folding, got %d subtasks", len(got))
+		}
+	})
+
+	t.Run("subtask with implementation language is not folded despite verify wording", func(t *testing.T) {
+		subtasks := []PlannedSubtask{
+			{Order: 1, Title: "feat(a): implement a", Description: "Implement internal/a/a.go."},
+			{Order: 2, Title: "fix(a): verify and fix edge case", Description: "Verify internal/a/a.go and fix the edge case found."},
+		}
+
+		got := foldVerifyOnlySubtasks(subtasks)
+
+		if len(got) != 2 {
+			t.Fatalf("expected subtask with implementation language to survive folding, got %d subtasks", len(got))
+		}
+	})
+
+	t.Run("single subtask plan is unchanged", func(t *testing.T) {
+		subtasks := []PlannedSubtask{
+			{Order: 1, Title: "feat(a): implement a", Description: "Implement internal/a/a.go."},
+		}
+
+		got := foldVerifyOnlySubtasks(subtasks)
+
+		if len(got) != 1 {
+			t.Fatalf("expected single-subtask plan unchanged, got %d subtasks", len(got))
+		}
+	})
+}
+
+func TestIsVerifyOnlySubtask(t *testing.T) {
+	prev := PlannedSubtask{
+		Title:       "feat(executor): add detector",
+		Description: "Implement detectChildDependency in internal/executor/dependency_detector.go.",
+	}
+
+	tests := []struct {
+		name string
+		st   PlannedSubtask
+		want bool
+	}{
+		{
+			name: "pure verification of predecessor's file",
+			st: PlannedSubtask{
+				Title:       "test(executor): verify detector",
+				Description: "Verify detectChildDependency in internal/executor/dependency_detector.go behaves correctly.",
+			},
+			want: true,
+		},
+		{
+			name: "verification with no implementation surface at all",
+			st: PlannedSubtask{
+				Title:       "test(executor): run the acceptance suite",
+				Description: "Run the acceptance criteria for the previous subtask end to end.",
+			},
+			want: true,
+		},
+		{
+			name: "introduces a new file beyond predecessor's targets",
+			st: PlannedSubtask{
+				Title:       "test(executor): verify new file",
+				Description: "Verify internal/executor/other_file.go behaves correctly.",
+			},
+			want: false,
+		},
+		{
+			name: "implementation language overrides verification wording",
+			st: PlannedSubtask{
+				Title:       "fix(executor): verify and fix bug",
+				Description: "Verify detectChildDependency in internal/executor/dependency_detector.go and fix the bug found.",
+			},
+			want: false,
+		},
+		{
+			name: "no verification wording at all",
+			st: PlannedSubtask{
+				Title:       "feat(executor): add another function",
+				Description: "Add anotherFunc to internal/executor/dependency_detector.go.",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isVerifyOnlySubtask(tt.st, prev); got != tt.want {
+				t.Errorf("isVerifyOnlySubtask() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `CreateSubIssues` (`internal/executor/epic.go`) now runs a post-processing pass, `foldVerifyOnlySubtasks`, over the planned subtask list before sub-issues are created.
- A subtask is folded into its immediate predecessor when it (a) matches the verification-shape heuristic — positive phrases `verify…`/`confirm…`/`run the acceptance…`/`regression-test…`, overridden by implementation phrases `add…`/`fix…`/`implement…` — and (b) introduces no file/symbol beyond what the predecessor already claims (`internal/executor/epic_verify_fold.go`).
- The verify-only entry's acceptance criteria (checkbox lines via the existing `extractAcceptanceCriteria`, or its full text as a fallback) are merged into the predecessor's description under a `## Acceptance Criteria (folded)` section, and the entry itself is dropped. Ordering is preserved; folding only ever targets the immediate predecessor.

**Note:** the verification-shape heuristic is duplicated here rather than imported from the sibling `dependency_detector.go` (GH-4234/#4236) because that PR had not merged to main at the time this subtask executed. Dedupe into one shared definition once both land.

Closes #4235

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New tests in `internal/executor/epic_verify_fold_test.go`: N-subtask plan with one verify-only entry collapses to N-1 with folded ACs; checkbox ACs merge individually; ordering/immediate-predecessor-only folding; verify-only entries that introduce a new file, or use implementation language, are NOT folded; single-subtask plans are unchanged.