### PR TITLE
fix(cli): persist executions row for pilot task CLI path (GH-4205)

### DIFF
--- a/cmd/pilot/cli_task_execution_test.go
+++ b/cmd/pilot/cli_task_execution_test.go
@@ -1,0 +1,182 @@
+package main
+
+// GH-4205: `pilot task` (the standalone CLI path) executed correctly and
+// wrote to execution_logs via runner.SetLogStore(), but never called
+// memory.Store.SaveExecution() to create the parent row in the executions
+// table. That left pilot status/logs/metrics empty for CLI-run tasks and
+// caused execution_events inserts to fail with FOREIGN KEY constraint
+// failed (787), since Task.LogExecutionID() fell back to the human-readable
+// task ID with no matching executions.id row.
+//
+// recordCLITaskStart/recordCLITaskFinish (commands.go) mirror the
+// dispatcher's queueSingleTask/post-execute persistence
+// (internal/executor/dispatcher.go) for the CLI path. These tests exercise
+// them directly against a real (temp-file) SQLite store.
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/executor"
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+func newCLITaskTestStore(t *testing.T) *memory.Store {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "pilot-cli-task-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	store, err := memory.NewStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	return store
+}
+
+func TestRecordCLITaskStart_CreatesRunningRow(t *testing.T) {
+	store := newCLITaskTestStore(t)
+
+	task := &executor.Task{
+		ID:          "TASK-12345",
+		Title:       "fix the thing",
+		Description: "fix the thing",
+		ProjectPath: "/tmp/project",
+		Branch:      "pilot/TASK-12345",
+		CreatePR:    true,
+	}
+
+	execID, err := recordCLITaskStart(store, task)
+	if err != nil {
+		t.Fatalf("recordCLITaskStart failed: %v", err)
+	}
+	if execID == "" {
+		t.Fatal("expected non-empty execution ID")
+	}
+	if task.ExecutionID != execID {
+		t.Fatalf("expected task.ExecutionID to be stamped with %q, got %q", execID, task.ExecutionID)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load saved execution: %v", err)
+	}
+	if exec.Status != "running" {
+		t.Errorf("expected status 'running', got %q", exec.Status)
+	}
+	if exec.TaskID != task.ID {
+		t.Errorf("expected task_id %q, got %q", task.ID, exec.TaskID)
+	}
+	if exec.ProjectPath != task.ProjectPath {
+		t.Errorf("expected project_path %q, got %q", task.ProjectPath, exec.ProjectPath)
+	}
+
+	// GH-4205: the whole point of stamping ExecutionID is that execution_events
+	// rows referencing task.LogExecutionID() now satisfy the FK against a real
+	// executions.id instead of the bare human-readable task ID.
+	if got := task.LogExecutionID(); got != execID {
+		t.Fatalf("expected LogExecutionID() to resolve to the saved execution row %q, got %q", execID, got)
+	}
+	if err := store.InsertExecutionEvent(task.LogExecutionID(), memory.StageRunning, "worker started"); err != nil {
+		t.Fatalf("execution_events insert should satisfy FK against the saved executions row, got: %v", err)
+	}
+}
+
+func TestRecordCLITaskFinish_Success(t *testing.T) {
+	store := newCLITaskTestStore(t)
+
+	task := &executor.Task{ID: "TASK-1", ProjectPath: "/tmp/project"}
+	execID, err := recordCLITaskStart(store, task)
+	if err != nil {
+		t.Fatalf("recordCLITaskStart failed: %v", err)
+	}
+
+	result := &executor.ExecutionResult{
+		TaskID:    task.ID,
+		Success:   true,
+		PRUrl:     "https://github.com/qf-studio/pilot/pull/1",
+		CommitSHA: "deadbeef",
+	}
+	if err := recordCLITaskFinish(store, execID, nil, result, 42*time.Second); err != nil {
+		t.Fatalf("recordCLITaskFinish failed: %v", err)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load execution: %v", err)
+	}
+	if exec.Status != "completed" {
+		t.Errorf("expected status 'completed', got %q", exec.Status)
+	}
+	if exec.PRUrl != result.PRUrl {
+		t.Errorf("expected pr_url %q, got %q", result.PRUrl, exec.PRUrl)
+	}
+	if exec.CommitSHA != result.CommitSHA {
+		t.Errorf("expected commit_sha %q, got %q", result.CommitSHA, exec.CommitSHA)
+	}
+}
+
+func TestRecordCLITaskFinish_ExecutionError(t *testing.T) {
+	store := newCLITaskTestStore(t)
+
+	task := &executor.Task{ID: "TASK-2", ProjectPath: "/tmp/project"}
+	execID, err := recordCLITaskStart(store, task)
+	if err != nil {
+		t.Fatalf("recordCLITaskStart failed: %v", err)
+	}
+
+	execErr := errors.New("backend crashed")
+	if err := recordCLITaskFinish(store, execID, execErr, nil, time.Second); err != nil {
+		t.Fatalf("recordCLITaskFinish failed: %v", err)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load execution: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected status 'failed', got %q", exec.Status)
+	}
+	if exec.Error != execErr.Error() {
+		t.Errorf("expected error %q, got %q", execErr.Error(), exec.Error)
+	}
+}
+
+func TestRecordCLITaskFinish_UnsuccessfulResult(t *testing.T) {
+	store := newCLITaskTestStore(t)
+
+	task := &executor.Task{ID: "TASK-3", ProjectPath: "/tmp/project"}
+	execID, err := recordCLITaskStart(store, task)
+	if err != nil {
+		t.Fatalf("recordCLITaskStart failed: %v", err)
+	}
+
+	result := &executor.ExecutionResult{
+		TaskID:  task.ID,
+		Success: false,
+		Error:   "declined: no changes needed",
+	}
+	if err := recordCLITaskFinish(store, execID, nil, result, time.Second); err != nil {
+		t.Fatalf("recordCLITaskFinish failed: %v", err)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load execution: %v", err)
+	}
+	// Classified via executor.TerminalStatus rather than collapsed to "failed"
+	// (see internal/executor/runner.go TerminalStatus / TASK-358).
+	expected := executor.TerminalStatus(result)
+	if exec.Status != expected {
+		t.Errorf("expected status %q, got %q", expected, exec.Status)
+	}
+	if exec.Error != result.Error {
+		t.Errorf("expected error %q, got %q", result.Error, exec.Error)
+	}
+}

--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
@@ -644,6 +645,13 @@ Examples:
 				fmt.Println("   Team:      ✓ project access scoping enabled")
 			}
 
+			// GH-4205: execution store + ID for the executions table row this CLI
+			// invocation owns. Populated below only when a memory store is
+			// available; the post-execution status update guards on execStore
+			// being non-nil.
+			var execStore *memory.Store
+			var execID string
+
 			// GH-2146: Initialize learning system for task command
 			// Mirrors main.go polling/gateway mode learning init
 			if cfg.Memory != nil && cfg.Memory.Path != "" {
@@ -655,6 +663,19 @@ Examples:
 
 					// Wire log store for execution milestone entries (GH-1599)
 					runner.SetLogStore(learningStore)
+
+					// GH-4205: pilot task CLI never persisted a parent executions row,
+					// so pilot status/logs/metrics always showed zero activity for
+					// CLI-run tasks and execution_events inserts hit FOREIGN KEY
+					// constraint failed (787) since LogExecutionID() fell back to the
+					// human-readable task ID with no matching executions.id. Mirrors
+					// the dispatcher's queueSingleTask (internal/executor/dispatcher.go:547).
+					if id, saveErr := recordCLITaskStart(learningStore, task); saveErr != nil {
+						logging.WithComponent("execute").Warn("Failed to save execution row for CLI task, status/logs/metrics will not reflect this run", slog.Any("error", saveErr))
+					} else {
+						execID = id
+						execStore = learningStore
+					}
 
 					// Wire knowledge store for experiential memories (GH-1027)
 					knowledgeStore := memory.NewKnowledgeStore(learningStore.DB())
@@ -761,7 +782,18 @@ Examples:
 			progress.StartWithNavigatorCheck(projectPath)
 
 			// Execute the task
+			execStart := time.Now()
 			result, err := runner.Execute(ctx, task)
+
+			// GH-4205: mark the executions row terminal so pilot status/logs/metrics
+			// reflect this CLI-run task. Mirrors the dispatcher's post-execute
+			// handling (internal/executor/dispatcher.go:1099-1141).
+			if execStore != nil {
+				if finErr := recordCLITaskFinish(execStore, execID, err, result, time.Since(execStart)); finErr != nil {
+					logging.WithComponent("execute").Warn("Failed to update CLI execution row status", slog.Any("error", finErr))
+				}
+			}
+
 			if err != nil {
 				return fmt.Errorf("execution failed: %w", err)
 			}
@@ -852,6 +884,48 @@ Examples:
 	cmd.Flags().StringVar(&teamMember, "team-member", "", "Member email for team access scoping (overrides config)")
 
 	return cmd
+}
+
+// recordCLITaskStart saves the parent executions row for a `pilot task` CLI
+// invocation before the runner executes, and stamps task.ExecutionID so
+// runner-side execution_events/log writes (which key off Task.LogExecutionID())
+// reference a real executions.id instead of falling back to the
+// human-readable task ID, which has no matching row (GH-4205).
+func recordCLITaskStart(store *memory.Store, task *executor.Task) (execID string, err error) {
+	execID = uuid.New().String()
+	execRow := &memory.Execution{
+		ID:              execID,
+		TaskID:          task.ID,
+		ProjectPath:     task.ProjectPath,
+		Status:          "running",
+		TaskTitle:       task.Title,
+		TaskDescription: task.Description,
+		TaskBranch:      task.Branch,
+		TaskBaseBranch:  task.BaseBranch,
+		TaskCreatePR:    task.CreatePR,
+		TaskVerbose:     task.Verbose,
+	}
+	if err := store.SaveExecution(execRow); err != nil {
+		return "", err
+	}
+	task.ExecutionID = execID
+	return execID, nil
+}
+
+// recordCLITaskFinish marks the executions row created by recordCLITaskStart
+// as terminal once the runner returns. Mirrors the dispatcher's post-execute
+// handling (internal/executor/dispatcher.go:1093-1141): an execution error
+// marks the row failed, a non-success result classifies via
+// executor.TerminalStatus, and success marks it completed with the PR/commit
+// details in a single atomic write.
+func recordCLITaskFinish(store *memory.Store, execID string, execErr error, result *executor.ExecutionResult, duration time.Duration) error {
+	if execErr != nil {
+		return store.UpdateExecutionStatus(execID, "failed", execErr.Error())
+	}
+	if !result.Success {
+		return store.UpdateExecutionStatus(execID, executor.TerminalStatus(result), result.Error)
+	}
+	return store.MarkExecutionCompleted(execID, result.PRUrl, result.CommitSHA, duration.Milliseconds())
 }
 
 // killExistingTelegramBot finds and kills any running pilot process with Telegram enabled


### PR DESCRIPTION
## Summary
- `pilot task` (the standalone CLI path) executed correctly and wrote to `execution_logs` via `runner.SetLogStore()`, but never called `memory.Store.SaveExecution()` — so the parent `executions` row was never created.
- Consequence: `pilot status` / `pilot logs` / `pilot metrics summary` showed zero activity for CLI-run tasks, and `execution_events` inserts hit `FOREIGN KEY constraint failed (787)` on every run since `Task.LogExecutionID()` fell back to the human-readable task ID with no matching `executions.id`.
- Fix mirrors the dispatcher's `queueSingleTask`/post-execute persistence (`internal/executor/dispatcher.go:547,1093-1141`): `recordCLITaskStart` saves a `running` executions row and stamps `task.ExecutionID` before invoking the runner; `recordCLITaskFinish` marks the row terminal (`failed` / classified via `executor.TerminalStatus` / `completed` with PR+commit) once the runner returns. The daemon/Dispatcher path is untouched.

Closes #4205

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./cmd/pilot/... ./internal/executor/... ./internal/memory/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New unit tests (`cmd/pilot/cli_task_execution_test.go`) cover: running row created pre-execution, transition to `completed` on success, transition to `failed` on execution error, classification via `TerminalStatus` on unsuccessful (non-error) results, and that `execution_events` inserts against `task.LogExecutionID()` no longer hit the FK constraint.