### PR TITLE
refactor(executor): ExecutionLifecycle chokepoint for execution-row create/transition/finish (GH-4243)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-12 (v2.151.0)
+**Last Updated:** 2026-07-09 (v2.151.0)
 
 ## Legend
 
@@ -26,6 +26,7 @@
 | Dry run mode | ✅ | executor | `--dry-run` | - | Show prompt only |
 | Verbose output | ✅ | executor | `--verbose` | - | Stream raw JSON |
 | Task dispatcher | ✅ | executor | - | - | Per-project queue (GH-46) |
+| Execution lifecycle chokepoint | ✅ | executor | - | - | `ExecutionLifecycle.Begin/Transition/Finish` replaces hand-rolled `SaveExecution`/status-update call sites in dispatcher/epic/CLI paths (GH-4243, v2.238.2) |
 | Sequential execution | ✅ | executor | `--sequential` | `orchestrator.execution.mode` | Wait for PR merge before next issue |
 | Self-review | ✅ | executor | - | - | Auto code review before PR push (v0.13.0) |
 | Auto build gate | ✅ | executor | - | - | Minimal build gate when none configured (v0.13.0) |
@@ -423,9 +424,6 @@
 | Conventional sub-issue titles | ✅ | executor | - | - | CC-format enforced on subtask titles: re-prompt → Approach B fallback → creation guard (GH-2494) |
 | Sub-issue dedup guard | ✅ | executor | - | - | CreateSubIssues skips if open children referencing parent already exist (GH-2494) |
 | createPilotIssue chokepoint | ✅ | adapters/github, autopilot | - | - | All Pilot-internal issue creation validated through CreatePilotIssue CC gate (GH-2494) |
-| Single-subtask epic consolidation | ✅ | executor | - | - | `isSinglePackageScope` short-circuits `len(plan.Subtasks) <= 1` to direct execution — never spawns a lone child issue (GH-4216 fix 1 / #4221) |
-| Epic finalize title normalization | ✅ | executor | - | - | `finalizeEpicBranchPR` routes the parent PR title through `normalizeTitle` before `CreatePR`, so raw issue titles auto-prefix instead of failing `validatePRTitle` deterministically (GH-4216 fix 2 / #4221) |
-| Decomposed-parent guard (all 4 sites) | ✅ | executor | - | - | `decomposedChildrenAllComplete` (ledger-only: `Store.GetDecomposedChildTaskIDs` + per-child `HasCompletedExecution`/no_op/merged-PR evidence) runs before every `HasCompletedExecution(taskID)` check in dispatcher.go — processQueue pickup, stale-running/queued reap, and WaitForExecution's row-vanished resolution — so a decomposed epic parent whose children all shipped is never re-implemented, reaped as failed, or surfaced as a false waiter error (GH-4216 fix 3, extended from processQueue-only to all 4 call sites; GH-4227) |
 
 ## Test Coverage
 
@@ -585,7 +583,6 @@ quality:
 
 | Feature | Version | Package | Notes |
 |---------|---------|---------|-------|
-| Dependency-aware selective sub-issue merge-wait | v2.238.x+ | executor | `detectChildDependency` (new `dependency_detector.go`) gates `executeSubIssuesTracked`'s merge-wait per child on an explicit `Depends on: #N`/`Blocked by: #N` ref (scoped to sibling issue numbers) or verification-shape language ("verify…"/"confirm…"/"run the acceptance…"/"regression-test…", overridden by "add…"/"fix…"/"implement…"); `wait_for_merge:false` stays the global default for independent siblings. Merge-wait callback now wired unconditionally in `main.go` (no-op when unused); every decision fail-loud logged (TASK-402 / GH-4234) |
 | Issue-level success rate + rate_limited exclusion | v2.235.0+ | autopilot + memory + gateway | `pilot_issue_level_success_rate` / `pilot_issues_shipped_total` / `pilot_issues_attempted_total` dedupe by `task_id` across retries; `pilot_success_rate` now excludes `rate_limited` from the denominator; hydrator no longer folds declined/no_op/stalled/infra/skipped into `failed` (TASK-392 / GH-4070) |
 | Poller skip-by-reason counters | v2.150.0 | adapters/github | `pilot_poller_skipped/dispatched/deferred` Prometheus counters (TASK-293 / GH-3064) |
 | `WithRetry` centralized in `doRequest` | v2.150.0 | adapters/github | All GitHub client methods now get retry; `RecordAPIError` wired (TASK-294 / GH-3065) |

--- a/.agent/tasks/TASK-404-execution-lifecycle-chokepoint.md
+++ b/.agent/tasks/TASK-404-execution-lifecycle-chokepoint.md
@@ -1,0 +1,33 @@
+# TASK-404: Execution lifecycle chokepoint — one API for create/transition, kill the FK-787 class permanently
+
+**Status**: 🚧 B1 [#4243](https://github.com/qf-studio/pilot/issues/4243) shipped 2026-07-12 — `ExecutionLifecycle` (`internal/executor/lifecycle.go`) with `Begin`/`Transition`/`Finish` + typed `Status` vocabulary (`ExecStatus*`, prefixed to avoid a name collision with monitor.go's dashboard-facing `TaskStatus`). Migrated: both dispatcher create sites, epic sub-issue create+finalize (`finalizeSubIssueExecution` now delegates to `Finish`), the CLI path (`recordCLITaskStart`/`recordCLITaskFinish` in `cmd/pilot/commands.go`, folding in #4205). Dead-API audit done: `UpdateExecutionStatusByTaskID` and the `cancelled` status are confirmed dead in production and documented in place (not removed — still load-bearing for the `EvalStore` interface / defensive terminal-state matching, respectively). `go test -race ./...` green. B2 [#4244](https://github.com/qf-studio/pilot/issues/4244) (`Blocked by: #4243`) still open.
+**Type**: refactor (invariant enforcement — replace guard-at-call-site with make-invalid-states-unrepresentable)
+**Context**: The July defect family (TASK-394 epic path, #4205 CLI path, false dashboard status TASK-399, guard extended to 4 sites in #4229) shares one root cause: execution-row creation and status transitions are hand-rolled at every call site. When a path forgets a step, work becomes invisible (metrics/status/dashboard) and `execution_events` inserts FK-fail (787).
+
+## Current state (research, 2026-07-12)
+
+- **Create sites (3 production)**: `dispatcher.go:547` (decomposed parent), `dispatcher.go:605` (queued single — the only one threading `exec.ID → task.ExecutionID` via `buildTaskFromExecution` at `dispatcher.go:1105`), `epic.go:1988` (sub-issue, TASK-394's fix). Plus one-shot `SaveDeclinedExecution` (`cmd/pilot/main.go:3397`).
+- **Transition sites**: `MarkExecutionCompleted` ×4, `UpdateExecutionStatus` ×6, `DeleteExecution` ×2, `SelfHealExecutionAfterMerge` ×1 — scattered across dispatcher.go/epic.go/controller.go.
+- **Ledger wrappers ×4** (Runner/Dispatcher/ProjectWorker/Controller `recordExecutionEvent`), each duplicating nil-store/skip guards; only Controller's (`controller.go:719`) validates row existence first. Runner's uses `task.LogExecutionID()` (`runner.go:436`) which falls back to bare `task.ID` — the FK-787 generator.
+- **Status vocabulary is free text** — terminal set exists only as an `if` chain (`store.go:1371`) + `TerminalStatus` classifier (`runner.go:232-256`). No Go enum, no DB constraint.
+- **Template to generalize**: `finalizeSubIssueExecution` (`runner.go:1809-1845`) — TASK-394's mini-chokepoint (create-before-run + single finalize branching completed/other-terminal + metrics).
+- **Suspected dead APIs**: `UpdateExecutionStatusByTaskID` (zero production callers), `cancelled` status (terminal-listed, no write site) — confirm and remove or document during B1.
+
+## Plan (2 Pilot issues)
+
+- **B1 — Lifecycle API + migrate all paths** (blocked by #4205, same-file `cmd/pilot/commands.go`): introduce `ExecutionLifecycle` (thin type over `memory.Store`): `Begin(task, initialStatus) → execID` (creates row, threads `task.ExecutionID`), `Finish(execID, result)` (wraps `TerminalStatus` + `MarkExecutionCompleted`/`UpdateExecutionStatus` + `SaveExecutionMetrics`), `Transition(execID, status)` for queued→running. Add Go const set for the status vocabulary. Migrate: both dispatcher create sites, epic sub-issue path, and the CLI path (#4205 will have wired it ad-hoc — fold into the chokepoint). Add the missing CLI-path regression test (none exists today — `cmd/pilot/trace_test.go` seeds rows directly).
+- **B2 — Standardize ledger wrappers** (blocked by B1): collapse the 4 `recordExecutionEvent` wrappers onto the Controller's validate-first pattern (skip+warn when no row) so a missing row can never FK-fail again, only fail-loud log.
+
+## Must NOT change
+
+- `HasCompletedExecution` (`store.go:828`) — mem-027: tightening it broke direct-commit rows and `TestTaskCompletionInvariant`.
+- DB schema (no CHECK constraint migration in this task — Go-level enum only; schema constraint is a possible follow-up once vocabulary is confirmed stable).
+- Status vocabulary semantics — same strings, same classifier precedence (`TestTerminalStatus` stays green).
+- Dashboard/adapter read paths (they consume `exec.Status` strings).
+
+## Refs
+
+- Create/transition/wrapper inventory: research pass 2026-07-12 (this doc §Current state, all file:line refs verified on `origin/main` @ `7920826e`)
+- Prior art: TASK-394 (`.agent/tasks/TASK-394-epic-subissue-execution-ledger.md`) — FK-787 mechanism + mem-026/027 constraints
+- CLI gap being folded in: #4205
+- Invariant test to keep green: `internal/executor/task_completion_invariant_test.go`

--- a/cmd/pilot/commands.go
+++ b/cmd/pilot/commands.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/qf-studio/pilot/internal/adapters/github"
@@ -890,42 +889,24 @@ Examples:
 // invocation before the runner executes, and stamps task.ExecutionID so
 // runner-side execution_events/log writes (which key off Task.LogExecutionID())
 // reference a real executions.id instead of falling back to the
-// human-readable task ID, which has no matching row (GH-4205).
+// human-readable task ID, which has no matching row (GH-4205). GH-4243: folds
+// this ad-hoc wiring into the shared ExecutionLifecycle chokepoint instead of
+// hand-rolling a memory.Execution{} literal here.
 func recordCLITaskStart(store *memory.Store, task *executor.Task) (execID string, err error) {
-	execID = uuid.New().String()
-	execRow := &memory.Execution{
-		ID:              execID,
-		TaskID:          task.ID,
-		ProjectPath:     task.ProjectPath,
-		Status:          "running",
-		TaskTitle:       task.Title,
-		TaskDescription: task.Description,
-		TaskBranch:      task.Branch,
-		TaskBaseBranch:  task.BaseBranch,
-		TaskCreatePR:    task.CreatePR,
-		TaskVerbose:     task.Verbose,
-	}
-	if err := store.SaveExecution(execRow); err != nil {
-		return "", err
-	}
-	task.ExecutionID = execID
-	return execID, nil
+	return executor.NewExecutionLifecycle(store).Begin(task, executor.ExecStatusRunning)
 }
 
 // recordCLITaskFinish marks the executions row created by recordCLITaskStart
 // as terminal once the runner returns. Mirrors the dispatcher's post-execute
-// handling (internal/executor/dispatcher.go:1093-1141): an execution error
-// marks the row failed, a non-success result classifies via
-// executor.TerminalStatus, and success marks it completed with the PR/commit
-// details in a single atomic write.
+// handling (internal/executor/dispatcher.go) via the same ExecutionLifecycle
+// chokepoint (GH-4243): an execution error marks the row failed, a
+// non-success result classifies via executor.TerminalStatus, and success
+// marks it completed with the PR/commit details in a single atomic write —
+// plus, as of this chokepoint, execution metrics are now persisted for the
+// CLI path too (previously only the dispatcher/epic paths did).
 func recordCLITaskFinish(store *memory.Store, execID string, execErr error, result *executor.ExecutionResult, duration time.Duration) error {
-	if execErr != nil {
-		return store.UpdateExecutionStatus(execID, "failed", execErr.Error())
-	}
-	if !result.Success {
-		return store.UpdateExecutionStatus(execID, executor.TerminalStatus(result), result.Error)
-	}
-	return store.MarkExecutionCompleted(execID, result.PRUrl, result.CommitSHA, duration.Milliseconds())
+	_, err := executor.NewExecutionLifecycle(store).Finish(execID, result, execErr, duration)
+	return err
 }
 
 // killExistingTelegramBot finds and kills any running pilot process with Telegram enabled

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -118,8 +118,10 @@ type TaskMonitor interface {
 // EvalStore persists eval tasks extracted from merged PRs.
 type EvalStore interface {
 	SaveEvalTask(task *memory.EvalTask) error
-	// UpdateExecutionStatusByTaskID updates execution status by task ID and project path.
-	// Used to mark failed executions as completed when the PR is merged.
+	// UpdateExecutionStatusByTaskID is superseded by SelfHealExecutionAfterMerge
+	// below (GH-2402) and has zero production callers as of the GH-4243
+	// dead-API audit. Kept for interface/mock compatibility only — see
+	// memory.Store.UpdateExecutionStatusByTaskID's doc comment.
 	UpdateExecutionStatusByTaskID(taskID, projectPath, status string) error
 	// SelfHealExecutionAfterMerge promotes failed rows to completed and
 	// stamps the PR URL after a successful merge. projectPath scopes the update

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/qf-studio/pilot/internal/logging"
 	"github.com/qf-studio/pilot/internal/memory"
 )
@@ -578,27 +577,10 @@ func (d *Dispatcher) QueueTask(ctx context.Context, task *Task) (string, error) 
 // queueDecomposedTask handles queuing a decomposed task and its subtasks.
 // The parent task is marked as "decomposed" and subtasks are queued in order.
 func (d *Dispatcher) queueDecomposedTask(ctx context.Context, parent *Task, result *DecomposeResult) (string, error) {
-	// Generate parent execution ID
-	parentExecID := uuid.New().String()
-
-	// Save parent as "decomposed" status
-	parentExec := &memory.Execution{
-		ID:                parentExecID,
-		TaskID:            parent.ID,
-		ProjectPath:       parent.ProjectPath,
-		Status:            "decomposed",
-		TaskTitle:         parent.Title,
-		TaskDescription:   parent.Description,
-		TaskBranch:        parent.Branch,
-		TaskBaseBranch:    parent.BaseBranch,
-		TaskCreatePR:      parent.CreatePR,
-		TaskVerbose:       parent.Verbose,
-		TaskSourceAdapter: parent.SourceAdapter,
-		TaskSourceIssueID: parent.SourceIssueID,
-		TaskLabels:        parent.Labels, // GH-2326: persist labels for no-decompose/autopilot-fix gates
-	}
-
-	if err := d.store.SaveExecution(parentExec); err != nil {
+	// GH-4243: single chokepoint for the row create + ExecutionID threading
+	// that used to be hand-rolled here.
+	parentExecID, err := NewExecutionLifecycle(d.store).Begin(parent, ExecStatusDecomposed)
+	if err != nil {
 		return "", fmt.Errorf("failed to save decomposed parent: %w", err)
 	}
 
@@ -636,27 +618,10 @@ func (d *Dispatcher) queueDecomposedTask(ctx context.Context, parent *Task, resu
 
 // queueSingleTask queues a single task (no decomposition).
 func (d *Dispatcher) queueSingleTask(ctx context.Context, task *Task) (string, error) {
-	// Generate execution ID
-	execID := uuid.New().String()
-
-	// Save to SQLite with status='queued' and full task details
-	exec := &memory.Execution{
-		ID:                execID,
-		TaskID:            task.ID,
-		ProjectPath:       task.ProjectPath,
-		Status:            "queued",
-		TaskTitle:         task.Title,
-		TaskDescription:   task.Description,
-		TaskBranch:        task.Branch,
-		TaskBaseBranch:    task.BaseBranch,
-		TaskCreatePR:      task.CreatePR,
-		TaskVerbose:       task.Verbose,
-		TaskSourceAdapter: task.SourceAdapter,
-		TaskSourceIssueID: task.SourceIssueID,
-		TaskLabels:        task.Labels, // GH-2326: persist labels for no-decompose/autopilot-fix gates
-	}
-
-	if err := d.store.SaveExecution(exec); err != nil {
+	// GH-4243: single chokepoint for the row create + ExecutionID threading
+	// that used to be hand-rolled here.
+	execID, err := NewExecutionLifecycle(d.store).Begin(task, ExecStatusQueued)
+	if err != nil {
 		return "", fmt.Errorf("failed to save execution: %w", err)
 	}
 
@@ -860,6 +825,7 @@ type WorkerStatus struct {
 type ProjectWorker struct {
 	projectPath   string
 	store         *memory.Store
+	lifecycle     *ExecutionLifecycle
 	runner        *Runner
 	log           *slog.Logger
 	signal        chan struct{}
@@ -874,6 +840,7 @@ func NewProjectWorker(projectPath string, store *memory.Store, runner *Runner, l
 	return &ProjectWorker{
 		projectPath: projectPath,
 		store:       store,
+		lifecycle:   NewExecutionLifecycle(store),
 		runner:      runner,
 		log:         log.With(slog.String("project", projectPath)),
 		signal:      make(chan struct{}, 1), // Buffered to avoid blocking
@@ -1046,7 +1013,7 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 		)
 
 		// Update status to running
-		if err := w.store.UpdateExecutionStatus(exec.ID, "running"); err != nil {
+		if err := w.lifecycle.Transition(exec.ID, ExecStatusRunning); err != nil {
 			w.log.Error("Failed to update status to running", slog.Any("error", err))
 			continue
 		}
@@ -1089,56 +1056,51 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 		result, execErr := w.runner.Execute(ctx, task)
 		duration := time.Since(start)
 
-		// Update execution record with result
-		if execErr != nil {
+		// GH-4243: single chokepoint classifies the outcome (TerminalStatus),
+		// persists the terminal status, and saves metrics. The branches below
+		// drive event-recording/progress side effects off the same
+		// classification instead of re-deriving it.
+		outcome, finErr := w.lifecycle.Finish(exec.ID, result, execErr, duration)
+		if finErr != nil {
+			w.log.Error("Failed to persist execution outcome", slog.String("execution_id", exec.ID), slog.Any("error", finErr))
+		}
+
+		switch {
+		case execErr != nil:
 			w.log.Error("Task execution failed",
 				slog.String("task_id", exec.TaskID),
 				slog.Any("error", execErr),
 				slog.Duration("duration", duration),
 			)
-			if err := w.store.UpdateExecutionStatus(exec.ID, "failed", execErr.Error()); err != nil {
-				w.log.Error("Failed to update status to failed", slog.Any("error", err))
-			}
 			// GH-3846: record terminal-failure transition to the execution-events audit trail.
 			w.recordExecutionEvent(exec.ID, memory.StageFailed, truncateForLog(execErr.Error(), 200))
 			// Emit progress callback for task failed
 			w.runner.EmitProgress(exec.TaskID, "Failed", 100, fmt.Sprintf("Execution error: %s", truncateForLog(execErr.Error(), 60)))
-		} else if !result.Success {
+		case outcome.Status != ExecStatusCompleted:
 			// TASK-358: classify the terminal outcome instead of collapsing every
 			// non-success into "failed". declined / no-op / stalled get their own
 			// status so the dashboard's "failed" count reflects genuine failures.
-			status := TerminalStatus(result)
 			w.log.Warn("Task ended without success",
 				slog.String("task_id", exec.TaskID),
-				slog.String("status", status),
-				slog.String("error", result.Error),
+				slog.String("status", string(outcome.Status)),
+				slog.String("error", outcome.Error),
 				slog.Duration("duration", duration),
 			)
-			if err := w.store.UpdateExecutionStatus(exec.ID, status, result.Error); err != nil {
-				w.log.Error("Failed to update execution status",
-					slog.String("status", status), slog.Any("error", err))
-			}
 			// GH-3846: record no_op/skipped transitions to the execution-events audit
 			// trail. Stalled is instrumented at its detection site in runner.go instead;
 			// declined/rate_limited/infra have no execution_events Stage equivalent yet.
-			if stage, ok := dispatchTerminalStage(status); ok {
-				w.recordExecutionEvent(exec.ID, stage, fmt.Sprintf("%s: %s", status, truncateForLog(result.Error, 200)))
+			if stage, ok := dispatchTerminalStage(string(outcome.Status)); ok {
+				w.recordExecutionEvent(exec.ID, stage, fmt.Sprintf("%s: %s", outcome.Status, truncateForLog(outcome.Error, 200)))
 			}
 			// Emit progress callback with a phase that matches the classified outcome.
-			w.runner.EmitProgress(exec.TaskID, terminalPhaseLabel(status), 100,
-				fmt.Sprintf("%s: %s", status, truncateForLog(result.Error, 60)))
-		} else {
+			w.runner.EmitProgress(exec.TaskID, terminalPhaseLabel(string(outcome.Status)), 100,
+				fmt.Sprintf("%s: %s", outcome.Status, truncateForLog(outcome.Error, 60)))
+		default:
 			w.log.Info("Task completed successfully",
 				slog.String("task_id", exec.TaskID),
 				slog.Duration("duration", duration),
 				slog.String("pr_url", result.PRUrl),
 			)
-			// TASK-359 Layer 1: one atomic write (status + result fields) instead of
-			// UpdateExecutionStatus("completed") then UpdateExecutionResult — the gap
-			// between those two could leave a 'completed' row with an empty pr_url.
-			if err := w.store.MarkExecutionCompleted(exec.ID, result.PRUrl, result.CommitSHA, duration.Milliseconds()); err != nil {
-				w.log.Error("Failed to mark execution completed", slog.Any("error", err))
-			}
 			// GH-3846: record terminal-success transition to the execution-events audit trail.
 			if stage, ok := dispatchSuccessStage(result.PRUrl); ok {
 				w.recordExecutionEvent(exec.ID, stage, fmt.Sprintf("completed with PR: %s", result.PRUrl))
@@ -1151,31 +1113,15 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			w.runner.EmitProgress(exec.TaskID, "Completed", 100, msg)
 		}
 
-		// Persist execution metrics (tokens, cost, code changes) so they survive restarts.
-		// This is needed for GetLifetimeTokens() to return real data (GH-533).
+		// Effort tier and usage-event telemetry stay dispatcher-owned: they're
+		// observability writes, not part of the row-lifecycle contract Finish
+		// covers (status + metrics). Needed for GetLifetimeTokens() (GH-533).
 		if result != nil {
 			// GH-2807: persist effort/complexity tier for cost-by-tier observability.
 			if result.EffortLevel != "" || result.ComplexityLevel != "" {
 				if err := w.store.UpdateExecutionEffort(exec.ID, result.EffortLevel, result.ComplexityLevel); err != nil {
 					w.log.Error("Failed to update execution effort", slog.Any("error", err))
 				}
-			}
-			if err := w.store.SaveExecutionMetrics(&memory.ExecutionMetrics{
-				ExecutionID:      exec.ID,
-				TokensInput:      result.TokensInput,
-				TokensOutput:     result.TokensOutput,
-				TokensTotal:      result.TokensTotal,
-				TokensCacheRead:  result.CacheReadInputTokens,
-				TokensCacheWrite: result.CacheCreationInputTokens,
-				EstimatedCostUSD: result.EstimatedCostUSD,
-				FilesChanged:     result.FilesChanged,
-				LinesAdded:       result.LinesAdded,
-				LinesRemoved:     result.LinesRemoved,
-				ModelName:        result.ModelName,
-				PeakRSSMB:        result.PeakRSSMB,
-				FinalRSSMB:       result.FinalRSSMB,
-			}); err != nil {
-				w.log.Error("Failed to save execution metrics", slog.Any("error", err))
 			}
 
 			// GH-2429: emit per-execution usage events (task + token + compute) so the

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/qf-studio/pilot/internal/memory"
 )
 
@@ -1839,46 +1838,19 @@ func formatDecomposedChildrenSummary(issues []CreatedIssue) string {
 
 // finalizeSubIssueExecution marks a sub-issue's ledger row (created just
 // before backend invocation, GH-4141) terminal and persists its token/cost
-// metrics, mirroring the dispatcher's ProjectWorker.processQueue finalization
-// (MarkExecutionCompleted for success, UpdateExecutionStatus otherwise) so a
-// sub-issue's row is indistinguishable from a direct-dispatch row to
-// GetDailyMetrics and HasCompletedExecution. WARN-and-continue on store
-// failures (mem-026) — a ledger write must never abort a sub-issue run.
+// metrics via the GH-4243 ExecutionLifecycle chokepoint, so a sub-issue's row
+// is indistinguishable from a direct-dispatch row to GetDailyMetrics and
+// HasCompletedExecution. status is caller-decided rather than re-derived from
+// result — the work-loss guard in executeSubIssuesTracked forces "failed" for
+// a sub-issue that reports Success with commits but no PR, which Finish's
+// default classifier would otherwise call "completed". WARN-and-continue on
+// store failures (mem-026) — a ledger write must never abort a sub-issue run.
 func (r *Runner) finalizeSubIssueExecution(execID, status string, result *ExecutionResult, startedAt time.Time) {
 	if r.logStore == nil || execID == "" {
 		return
 	}
-	durationMs := time.Since(startedAt).Milliseconds()
-	var errMsg, prURL, commitSHA string
-	if result != nil {
-		errMsg, prURL, commitSHA = result.Error, result.PRUrl, result.CommitSHA
-	}
-
-	if status == "completed" {
-		if err := r.logStore.MarkExecutionCompleted(execID, prURL, commitSHA, durationMs); err != nil {
-			r.log.Warn("Failed to mark sub-issue execution completed", "execution_id", execID, "error", err)
-		}
-	} else if err := r.logStore.UpdateExecutionStatus(execID, status, errMsg); err != nil {
-		r.log.Warn("Failed to update sub-issue execution status", "execution_id", execID, "status", status, "error", err)
-	}
-
-	if result == nil {
-		return
-	}
-	if err := r.logStore.SaveExecutionMetrics(&memory.ExecutionMetrics{
-		ExecutionID:      execID,
-		TokensInput:      result.TokensInput,
-		TokensOutput:     result.TokensOutput,
-		TokensTotal:      result.TokensTotal,
-		TokensCacheRead:  result.CacheReadInputTokens,
-		TokensCacheWrite: result.CacheCreationInputTokens,
-		EstimatedCostUSD: result.EstimatedCostUSD,
-		FilesChanged:     result.FilesChanged,
-		LinesAdded:       result.LinesAdded,
-		LinesRemoved:     result.LinesRemoved,
-		ModelName:        result.ModelName,
-	}); err != nil {
-		r.log.Warn("Failed to save sub-issue execution metrics", "execution_id", execID, "error", err)
+	if _, err := NewExecutionLifecycle(r.logStore).Finish(execID, result, nil, time.Since(startedAt), Status(status)); err != nil {
+		r.log.Warn("Failed to persist sub-issue execution outcome", "execution_id", execID, "status", status, "error", err)
 	}
 }
 
@@ -2025,27 +1997,20 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 		// scoped dashboard queries filter on this being absolute, not a
 		// worktree path).
 		subExecStart := time.Now()
-		subExecID := uuid.New().String()
-		if r.logStore != nil {
-			if err := r.logStore.SaveExecution(&memory.Execution{
-				ID:          subExecID,
-				TaskID:      taskID,
-				ProjectPath: parent.ProjectPath,
-				Status:      "running",
-			}); err != nil {
-				// mem-026: epic path errors are warn-only — a ledger write must
-				// never abort a sub-issue run. The UUID is threaded through
-				// below regardless, so downstream event recording always has a
-				// real UUID rather than falling back to the task ID.
-				r.log.Warn("Failed to insert sub-issue execution row",
-					"parent_id", parent.ID,
-					"sub_issue", issueRef,
-					"execution_id", subExecID,
-					"error", err,
-				)
-			}
+		// GH-4243: Begin creates the row AND threads subTask.ExecutionID in one
+		// call. mem-026: a ledger-write failure is warn-only here — Begin always
+		// stamps the generated UUID regardless of the save outcome, so downstream
+		// event recording still has a real UUID rather than falling back to the
+		// task ID.
+		subExecID, err := NewExecutionLifecycle(r.logStore).Begin(subTask, ExecStatusRunning)
+		if err != nil {
+			r.log.Warn("Failed to insert sub-issue execution row",
+				"parent_id", parent.ID,
+				"sub_issue", issueRef,
+				"execution_id", subExecID,
+				"error", err,
+			)
 		}
-		subTask.ExecutionID = subExecID
 
 		r.log.Info("Executing sub-issue",
 			"parent_id", parent.ID,
@@ -2056,7 +2021,6 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 
 		// Execute the sub-task (use override if set, for testing)
 		var result *ExecutionResult
-		var err error
 		if r.executeFunc != nil {
 			// Use test override function if set
 			result, err = r.executeFunc(ctx, subTask)

--- a/internal/executor/lifecycle.go
+++ b/internal/executor/lifecycle.go
@@ -1,0 +1,185 @@
+package executor
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// Status is the typed vocabulary for the executions-table status column
+// (GH-4243). Values are unchanged from the free-text strings every call site
+// already wrote — this only makes the vocabulary compile-time checkable, it
+// does not touch persisted data, DB schema, or TerminalStatus's classifier
+// precedence. Constants are prefixed Exec (rather than the bare "Status..."
+// the issue sketched) because monitor.go's dashboard-facing TaskStatus
+// already owns StatusQueued/StatusRunning/StatusCompleted/StatusFailed/
+// StatusStalled for the in-memory task-state enum — a distinct concept from
+// the persisted executions-row status this type models.
+type Status string
+
+const (
+	ExecStatusQueued      Status = "queued"
+	ExecStatusRunning     Status = "running"
+	ExecStatusCompleted   Status = "completed"
+	ExecStatusFailed      Status = "failed"
+	ExecStatusNoOp        Status = "no_op"
+	ExecStatusStalled     Status = "stalled"
+	ExecStatusRateLimited Status = "rate_limited"
+	ExecStatusInfra       Status = "infra"
+	ExecStatusSkipped     Status = "skipped"
+	ExecStatusDeclined    Status = "declined"
+	ExecStatusDecomposed  Status = "decomposed"
+)
+
+// ExecutionLifecycle is the single chokepoint for creating and transitioning
+// executions-table rows (GH-4243). Before this type, every production path
+// hand-rolled a memory.Execution{} literal (dispatcher.go's two queue sites,
+// epic.go's sub-issue site) or called MarkExecutionCompleted/
+// UpdateExecutionStatus directly and scattered the ExecutionID-threading
+// step. A path that forgot a step produced the FK-787 defect class
+// (execution_events insert against a task_id with no matching executions
+// row), invisible metrics, or a false dashboard status. ExecutionLifecycle
+// is a thin wrapper over *memory.Store — no new persistence, just one place
+// that can't skip a step.
+type ExecutionLifecycle struct {
+	store *memory.Store
+}
+
+// NewExecutionLifecycle wraps store. A nil store makes every method a no-op
+// (Begin still stamps task.ExecutionID with a generated UUID so downstream
+// LogExecutionID() callers behave the same as with a real store whose write
+// failed), mirroring the "logStore == nil" guards already scattered across
+// dispatcher/epic/CLI call sites — callers don't need their own nil check.
+func NewExecutionLifecycle(store *memory.Store) *ExecutionLifecycle {
+	return &ExecutionLifecycle{store: store}
+}
+
+// Begin creates the executions row for task at the given initial status and
+// unconditionally stamps the generated ID into task.ExecutionID — including
+// when the save itself fails. This generalizes the epic sub-issue path's
+// existing behavior (mem-026: "the UUID is threaded through below
+// regardless, so downstream event recording always has a real UUID rather
+// than falling back to the task ID") to every caller, so runner-side
+// execution_events/log writes (keyed on Task.LogExecutionID()) reference a
+// stable identifier even on a ledger-write failure. Callers that must abort
+// when the row isn't durably persisted (e.g. a queued task with no execution
+// row would be lost) inspect the returned error.
+func (l *ExecutionLifecycle) Begin(task *Task, initial Status) (string, error) {
+	execID := uuid.New().String()
+	task.ExecutionID = execID
+
+	if l.store == nil {
+		return execID, nil
+	}
+
+	exec := &memory.Execution{
+		ID:                execID,
+		TaskID:            task.ID,
+		ProjectPath:       task.ProjectPath,
+		Status:            string(initial),
+		TaskTitle:         task.Title,
+		TaskDescription:   task.Description,
+		TaskBranch:        task.Branch,
+		TaskBaseBranch:    task.BaseBranch,
+		TaskCreatePR:      task.CreatePR,
+		TaskVerbose:       task.Verbose,
+		TaskSourceAdapter: task.SourceAdapter,
+		TaskSourceIssueID: task.SourceIssueID,
+		TaskLabels:        task.Labels,
+	}
+	if err := l.store.SaveExecution(exec); err != nil {
+		return execID, fmt.Errorf("failed to save execution: %w", err)
+	}
+	return execID, nil
+}
+
+// Transition moves execID to a non-terminal status (e.g. queued -> running).
+// Terminal moves go through Finish instead, which also persists metrics.
+func (l *ExecutionLifecycle) Transition(execID string, s Status) error {
+	if l.store == nil || execID == "" {
+		return nil
+	}
+	return l.store.UpdateExecutionStatus(execID, string(s))
+}
+
+// FinishOutcome is what Finish computed and persisted, so callers can drive
+// their own side effects (execution_events stage mapping, progress
+// callbacks) off the same classification instead of re-deriving it.
+type FinishOutcome struct {
+	Status Status
+	Error  string
+}
+
+// Finish terminates execID: classifies result via TerminalStatus, persists
+// the terminal status (MarkExecutionCompleted on success so pr_url/
+// commit_sha/duration land atomically, UpdateExecutionStatus otherwise), and
+// saves execution metrics whenever result is non-nil — generalizing
+// finalizeSubIssueExecution (the TASK-394 sub-issue chokepoint) to every
+// caller. execErr, when non-nil, short-circuits classification straight to
+// StatusFailed, mirroring every existing call site's "err != nil" branch
+// running before TerminalStatus is even consulted; metrics are still saved
+// in that case if result is non-nil (the execution ran and produced partial
+// results before erroring), matching the dispatcher's existing behavior.
+//
+// override, when given, replaces the classified status outright — for a
+// caller that has evidence the classifier can't see. epic.go's work-loss
+// guard is the motivating case: a sub-issue can report Success with real
+// commits but no PR (its work is stranded), which TerminalStatus would call
+// "completed" but the epic must record as "failed" so the issue stays open
+// for recovery. errMsg is still sourced from execErr/result as usual; only
+// the status itself is overridden.
+func (l *ExecutionLifecycle) Finish(execID string, result *ExecutionResult, execErr error, duration time.Duration, override ...Status) (FinishOutcome, error) {
+	if l.store == nil || execID == "" {
+		return FinishOutcome{}, nil
+	}
+
+	var outcome FinishOutcome
+	var statusErr error
+
+	if execErr != nil {
+		outcome = FinishOutcome{Status: ExecStatusFailed, Error: execErr.Error()}
+	} else {
+		outcome = FinishOutcome{Status: Status(TerminalStatus(result))}
+		if result != nil {
+			outcome.Error = result.Error
+		}
+	}
+	if len(override) > 0 {
+		outcome.Status = override[0]
+	}
+
+	if outcome.Status == ExecStatusCompleted {
+		var prURL, commitSHA string
+		if result != nil {
+			prURL, commitSHA = result.PRUrl, result.CommitSHA
+		}
+		statusErr = l.store.MarkExecutionCompleted(execID, prURL, commitSHA, duration.Milliseconds())
+	} else {
+		statusErr = l.store.UpdateExecutionStatus(execID, string(outcome.Status), outcome.Error)
+	}
+
+	if result != nil {
+		metricsErr := l.store.SaveExecutionMetrics(&memory.ExecutionMetrics{
+			ExecutionID:      execID,
+			TokensInput:      result.TokensInput,
+			TokensOutput:     result.TokensOutput,
+			TokensTotal:      result.TokensTotal,
+			TokensCacheRead:  result.CacheReadInputTokens,
+			TokensCacheWrite: result.CacheCreationInputTokens,
+			EstimatedCostUSD: result.EstimatedCostUSD,
+			FilesChanged:     result.FilesChanged,
+			LinesAdded:       result.LinesAdded,
+			LinesRemoved:     result.LinesRemoved,
+			ModelName:        result.ModelName,
+			PeakRSSMB:        result.PeakRSSMB,
+			FinalRSSMB:       result.FinalRSSMB,
+		})
+		if statusErr == nil {
+			statusErr = metricsErr
+		}
+	}
+
+	return outcome, statusErr
+}

--- a/internal/executor/lifecycle_test.go
+++ b/internal/executor/lifecycle_test.go
@@ -1,0 +1,235 @@
+package executor
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestExecutionLifecycle_Begin_CreatesRowAndThreadsID verifies Begin creates
+// the executions row at the given initial status and stamps task.ExecutionID
+// with the same ID it persisted (GH-4243).
+func TestExecutionLifecycle_Begin_CreatesRowAndThreadsID(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{
+		ID:          "GH-1",
+		Title:       "fix the thing",
+		Description: "fix the thing",
+		ProjectPath: "/tmp/project",
+		Branch:      "pilot/GH-1",
+		CreatePR:    true,
+	}
+
+	execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+	if execID == "" {
+		t.Fatal("expected non-empty execution ID")
+	}
+	if task.ExecutionID != execID {
+		t.Fatalf("expected task.ExecutionID %q, got %q", execID, task.ExecutionID)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load saved execution: %v", err)
+	}
+	if exec.Status != string(ExecStatusQueued) {
+		t.Errorf("expected status %q, got %q", ExecStatusQueued, exec.Status)
+	}
+	if exec.TaskID != task.ID || exec.ProjectPath != task.ProjectPath || exec.TaskTitle != task.Title {
+		t.Errorf("execution row fields don't match source task: %+v", exec)
+	}
+}
+
+// TestExecutionLifecycle_Begin_NilStore_StillThreadsID mirrors the epic
+// sub-issue path's mem-026 tolerance: a nil store (or a failed save) must
+// never stop task.ExecutionID from being stamped, so downstream event
+// recording always has a stable UUID rather than falling back to the
+// human-readable task ID.
+func TestExecutionLifecycle_Begin_NilStore_StillThreadsID(t *testing.T) {
+	task := &Task{ID: "GH-2", ProjectPath: "/tmp/project"}
+
+	execID, err := NewExecutionLifecycle(nil).Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("expected nil-store Begin to succeed, got: %v", err)
+	}
+	if execID == "" {
+		t.Fatal("expected non-empty execution ID even with a nil store")
+	}
+	if task.ExecutionID != execID {
+		t.Fatalf("expected task.ExecutionID %q, got %q", execID, task.ExecutionID)
+	}
+}
+
+// TestExecutionLifecycle_Transition_QueuedToRunning verifies the non-terminal
+// status move used by the dispatcher's pickup path.
+func TestExecutionLifecycle_Transition_QueuedToRunning(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-3", ProjectPath: "/tmp/project"}
+	lifecycle := NewExecutionLifecycle(store)
+	execID, err := lifecycle.Begin(task, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	if err := lifecycle.Transition(execID, ExecStatusRunning); err != nil {
+		t.Fatalf("Transition failed: %v", err)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load execution: %v", err)
+	}
+	if exec.Status != string(ExecStatusRunning) {
+		t.Errorf("expected status %q, got %q", ExecStatusRunning, exec.Status)
+	}
+}
+
+// TestExecutionLifecycle_Finish_Success verifies the success path atomically
+// persists status/pr_url/commit_sha and saves metrics.
+func TestExecutionLifecycle_Finish_Success(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-4", ProjectPath: "/tmp/project"}
+	lifecycle := NewExecutionLifecycle(store)
+	execID, err := lifecycle.Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	result := &ExecutionResult{
+		TaskID:       task.ID,
+		Success:      true,
+		PRUrl:        "https://github.com/qf-studio/pilot/pull/1",
+		CommitSHA:    "deadbeef",
+		TokensInput:  100,
+		TokensOutput: 200,
+		TokensTotal:  300,
+	}
+	outcome, err := lifecycle.Finish(execID, result, nil, 42*time.Second)
+	if err != nil {
+		t.Fatalf("Finish failed: %v", err)
+	}
+	if outcome.Status != ExecStatusCompleted {
+		t.Errorf("expected outcome status %q, got %q", ExecStatusCompleted, outcome.Status)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load execution: %v", err)
+	}
+	if exec.Status != string(ExecStatusCompleted) {
+		t.Errorf("expected status %q, got %q", ExecStatusCompleted, exec.Status)
+	}
+	if exec.PRUrl != result.PRUrl || exec.CommitSHA != result.CommitSHA {
+		t.Errorf("expected pr_url/commit_sha to match result, got %+v", exec)
+	}
+	if exec.TokensTotal != result.TokensTotal {
+		t.Errorf("expected metrics to be persisted: tokens_total = %d, want %d", exec.TokensTotal, result.TokensTotal)
+	}
+}
+
+// TestExecutionLifecycle_Finish_ExecErrShortCircuits verifies an execErr
+// forces StatusFailed regardless of what result would otherwise classify to.
+func TestExecutionLifecycle_Finish_ExecErrShortCircuits(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-5", ProjectPath: "/tmp/project"}
+	lifecycle := NewExecutionLifecycle(store)
+	execID, err := lifecycle.Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	execErr := errors.New("backend crashed")
+	outcome, err := lifecycle.Finish(execID, nil, execErr, time.Second)
+	if err != nil {
+		t.Fatalf("Finish failed: %v", err)
+	}
+	if outcome.Status != ExecStatusFailed {
+		t.Errorf("expected outcome status %q, got %q", ExecStatusFailed, outcome.Status)
+	}
+	if outcome.Error != execErr.Error() {
+		t.Errorf("expected outcome error %q, got %q", execErr.Error(), outcome.Error)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load execution: %v", err)
+	}
+	if exec.Status != string(ExecStatusFailed) {
+		t.Errorf("expected status %q, got %q", ExecStatusFailed, exec.Status)
+	}
+	if exec.Error != execErr.Error() {
+		t.Errorf("expected error %q, got %q", execErr.Error(), exec.Error)
+	}
+}
+
+// TestExecutionLifecycle_Finish_Override reproduces epic.go's work-loss guard:
+// a sub-issue that reports Success with real commits but no PR must persist
+// as failed even though TerminalStatus alone would call it completed.
+func TestExecutionLifecycle_Finish_Override(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-6", ProjectPath: "/tmp/project"}
+	lifecycle := NewExecutionLifecycle(store)
+	execID, err := lifecycle.Begin(task, ExecStatusRunning)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	result := &ExecutionResult{
+		TaskID:    task.ID,
+		Success:   true,
+		CommitSHA: "deadbeef",
+		// PRUrl intentionally empty: commits with no PR is the stranded-work case.
+	}
+
+	if classified := TerminalStatus(result); classified != "completed" {
+		t.Fatalf("test setup invalid: expected TerminalStatus to classify as completed without an override, got %q", classified)
+	}
+
+	outcome, err := lifecycle.Finish(execID, result, nil, time.Second, ExecStatusFailed)
+	if err != nil {
+		t.Fatalf("Finish failed: %v", err)
+	}
+	if outcome.Status != ExecStatusFailed {
+		t.Errorf("expected override to force status %q, got %q", ExecStatusFailed, outcome.Status)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load execution: %v", err)
+	}
+	if exec.Status != string(ExecStatusFailed) {
+		t.Errorf("expected status %q, got %q", ExecStatusFailed, exec.Status)
+	}
+}
+
+// TestExecutionLifecycle_NilStore_MethodsAreNoOps verifies every method
+// degrades gracefully with a nil store, mirroring the "logStore == nil"
+// guards this type consolidates.
+func TestExecutionLifecycle_NilStore_MethodsAreNoOps(t *testing.T) {
+	lifecycle := NewExecutionLifecycle(nil)
+
+	if err := lifecycle.Transition("some-id", ExecStatusRunning); err != nil {
+		t.Errorf("expected nil-store Transition to be a no-op, got: %v", err)
+	}
+
+	outcome, err := lifecycle.Finish("some-id", &ExecutionResult{Success: true}, nil, time.Second)
+	if err != nil {
+		t.Errorf("expected nil-store Finish to be a no-op, got: %v", err)
+	}
+	if outcome.Status != "" {
+		t.Errorf("expected zero-value outcome from nil-store Finish, got: %+v", outcome)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1567,7 +1567,17 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 		errStr = &errorMsg[0]
 	}
 
-	// Set completed_at for terminal states
+	// Set completed_at for terminal states.
+	//
+	// GH-4243 dead-API audit: "cancelled" is confirmed dead as a write value —
+	// no production call site ever passes it to UpdateExecutionStatus,
+	// MarkExecutionCompleted, or Begin/Transition/Finish (executor.Status has
+	// no ExecStatusCancelled constant). It's kept in this terminal-state list
+	// only defensively — matching monitor.go's separate in-memory TaskStatus
+	// enum, which does have a StatusCancelled, and matching dispatcher.go's
+	// WaitForExecution terminal-status switch, which reads "cancelled" as a
+	// possible historical/manually-written value. Not removed since dropping
+	// it would silently stop setting completed_at on that historical value.
 	if status == "completed" || status == "failed" || status == "cancelled" || status == "declined" || status == "stalled" || status == "no_op" || status == "rate_limited" || status == "infra" || status == "skipped" {
 		return s.withRetry("UpdateExecutionStatus", func() error {
 			_, err := s.db.Exec(`
@@ -1605,10 +1615,15 @@ func (s *Store) UpdateExecutionStatus(id, status string, errorMsg ...string) err
 }
 
 // UpdateExecutionStatusByTaskID updates the status of the most recent execution
-// for a given task ID and project path. Used by autopilot to mark failed
-// executions as completed when the PR is merged externally.
-// The projectPath scope prevents cross-project clobbering when the same task ID
-// appears in multiple repos.
+// for a given task ID and project path.
+//
+// GH-4243 dead-API audit: confirmed zero production call sites. It predates
+// SelfHealExecutionAfterMerge, which replaced it as autopilot's merge-heal
+// path (see internal/autopilot/controller.go's TestSelfHeal* suite, which
+// asserts zero calls through the EvalStore.UpdateExecutionStatusByTaskID mock
+// on the modern path). Kept — not removed — only because it's still part of
+// the EvalStore interface contract; if that interface method is ever dropped,
+// this can go with it.
 //
 // TASK-358: the source scope is the non-success set ('failed', 'no_op', 'stalled')
 // rather than 'failed' alone, so an execution the dispatcher now classifies as a


### PR DESCRIPTION
## Summary

- Adds `ExecutionLifecycle` (`internal/executor/lifecycle.go`) as the single chokepoint for creating and transitioning `executions`-table rows: `Begin` (create + thread `ExecutionID`), `Transition` (non-terminal moves), `Finish` (classify via `TerminalStatus` + persist terminal status + save metrics, with an explicit status-override escape hatch).
- Migrates every production create/finalize site off hand-rolled `memory.Execution{}` literals and scattered `UpdateExecutionStatus`/`MarkExecutionCompleted` calls: `dispatcher.go`'s two queue-create sites + its execute→finalize block, `epic.go`'s sub-issue create site + `finalizeSubIssueExecution`, and the `pilot task` CLI path (`cmd/pilot/commands.go`, folding in #4205's ad-hoc wiring).
- Adds a typed `Status` vocabulary (`ExecStatus*` — prefixed to avoid a name collision with `monitor.go`'s existing dashboard-facing `TaskStatus` enum).
- Dead-API audit per the issue: confirms `UpdateExecutionStatusByTaskID` and the `"cancelled"` status have zero production write call sites, and documents that in place rather than silently keeping them.
- CLI path now also gets execution metrics persisted (previously only dispatcher/epic paths did) as a side effect of unifying through `Finish`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `go test ./internal/executor/... ./cmd/... ./internal/memory/... ./internal/autopilot/...` — green
- [x] `go test -race ./...` — green across the whole repo
- [x] New `internal/executor/lifecycle_test.go` covers `Begin`/`Transition`/`Finish`, including the nil-store no-op path and the status-override case (epic.go's work-loss guard scenario)
- [x] Existing regression suites unmodified and green: `TestExecuteSubIssues_LedgerRowPerChild`, `TestTerminalStatus`, `TestTaskCompletionInvariant`, `cmd/pilot/cli_task_execution_test.go`