### PR TITLE
feat(config,metrics): canary project flag — isolate sandbox executions from success metrics and dashboards

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -1,6 +1,6 @@
 # Pilot Feature Matrix
 
-**Last Updated:** 2026-07-12 (v2.151.0)
+**Last Updated:** 2026-07-09 (v2.151.0)
 
 ## Legend
 
@@ -315,6 +315,7 @@
 | K8s health probes | ✅ | gateway | - | - | `/ready` and `/live` endpoints for Kubernetes (v0.37.0) |
 | Prometheus metrics | ✅ | gateway | - | - | `/metrics` endpoint in Prometheus text format (v0.37.0) |
 | Prometheus counter baselines on restart | ✅ | autopilot/memory | - | - | `HydrateFromStore` restores lifetime per-(model,direction/result) token/cost/execution counters from `executions` table before `/metrics` starts serving, so `pilot_tokens_consumed_total`/`pilot_execution_cost_usd_total`/`pilot_executions_total`/`pilot_success_rate` survive daemon restarts instead of resetting to zero (GH-4041) |
+| Canary project flag | ✅ | config/memory/executor/autopilot | - | `projects[].canary` | `ProjectConfig.Canary` marks a project (e.g. `pilot-canary-sandbox`, TASK-379 V8) as a synthetic sandbox; executions.is_canary persists the marker; success-rate/issue-level/throughput metrics, hydrators, `GetDailyMetrics`, and dashboard history exclude canary rows while the ledger (executions/execution_events/execution_logs) still records them in full (GH-4240) |
 | External-merge metrics | ✅ | autopilot | - | - | Record PRsMerged/IssuesProcessed/PRTimeToMerge for externally-merged PRs via scanner (v2.147.0, GH-2981) |
 | JSON structured logging | ✅ | - | - | `logging.format` | Optional JSON log output mode (v0.38.0) |
 | Qwen Code backend | ✅ | executor | `--backend qwen` | `executor.backend` | Alibaba Qwen Code CLI with stream-json (v1.9.0, GH-1314) |
@@ -423,9 +424,6 @@
 | Conventional sub-issue titles | ✅ | executor | - | - | CC-format enforced on subtask titles: re-prompt → Approach B fallback → creation guard (GH-2494) |
 | Sub-issue dedup guard | ✅ | executor | - | - | CreateSubIssues skips if open children referencing parent already exist (GH-2494) |
 | createPilotIssue chokepoint | ✅ | adapters/github, autopilot | - | - | All Pilot-internal issue creation validated through CreatePilotIssue CC gate (GH-2494) |
-| Single-subtask epic consolidation | ✅ | executor | - | - | `isSinglePackageScope` short-circuits `len(plan.Subtasks) <= 1` to direct execution — never spawns a lone child issue (GH-4216 fix 1 / #4221) |
-| Epic finalize title normalization | ✅ | executor | - | - | `finalizeEpicBranchPR` routes the parent PR title through `normalizeTitle` before `CreatePR`, so raw issue titles auto-prefix instead of failing `validatePRTitle` deterministically (GH-4216 fix 2 / #4221) |
-| Decomposed-parent guard (all 4 sites) | ✅ | executor | - | - | `decomposedChildrenAllComplete` (ledger-only: `Store.GetDecomposedChildTaskIDs` + per-child `HasCompletedExecution`/no_op/merged-PR evidence) runs before every `HasCompletedExecution(taskID)` check in dispatcher.go — processQueue pickup, stale-running/queued reap, and WaitForExecution's row-vanished resolution — so a decomposed epic parent whose children all shipped is never re-implemented, reaped as failed, or surfaced as a false waiter error (GH-4216 fix 3, extended from processQueue-only to all 4 call sites; GH-4227) |
 
 ## Test Coverage
 
@@ -585,7 +583,6 @@ quality:
 
 | Feature | Version | Package | Notes |
 |---------|---------|---------|-------|
-| Dependency-aware selective sub-issue merge-wait | v2.238.x+ | executor | `detectChildDependency` (new `dependency_detector.go`) gates `executeSubIssuesTracked`'s merge-wait per child on an explicit `Depends on: #N`/`Blocked by: #N` ref (scoped to sibling issue numbers) or verification-shape language ("verify…"/"confirm…"/"run the acceptance…"/"regression-test…", overridden by "add…"/"fix…"/"implement…"); `wait_for_merge:false` stays the global default for independent siblings. Merge-wait callback now wired unconditionally in `main.go` (no-op when unused); every decision fail-loud logged (TASK-402 / GH-4234) |
 | Issue-level success rate + rate_limited exclusion | v2.235.0+ | autopilot + memory + gateway | `pilot_issue_level_success_rate` / `pilot_issues_shipped_total` / `pilot_issues_attempted_total` dedupe by `task_id` across retries; `pilot_success_rate` now excludes `rate_limited` from the denominator; hydrator no longer folds declined/no_op/stalled/infra/skipped into `failed` (TASK-392 / GH-4070) |
 | Poller skip-by-reason counters | v2.150.0 | adapters/github | `pilot_poller_skipped/dispatched/deferred` Prometheus counters (TASK-293 / GH-3064) |
 | `WithRetry` centralized in `doRequest` | v2.150.0 | adapters/github | All GitHub client methods now get retry; `RecordAPIError` wired (TASK-294 / GH-3065) |

--- a/cmd/pilot/adapters.go
+++ b/cmd/pilot/adapters.go
@@ -259,6 +259,19 @@ func newProjectQualityCheckerFactory(cfg *config.Config) func(taskID, taskProjec
 	}
 }
 
+// newCanaryProjectResolver builds the callback wired into
+// executor.Dispatcher.SetCanaryResolver (GH-4240): given an
+// executor.Task's ProjectPath, it reports whether that project is
+// configured with `canary: true`, so the dispatcher can mark the
+// project's execution rows as synthetic without every Task-construction
+// call site needing to know about canary status.
+func newCanaryProjectResolver(cfg *config.Config) func(taskProjectPath string) bool {
+	return func(taskProjectPath string) bool {
+		proj := cfg.FindProjectByPath(taskProjectPath)
+		return proj != nil && proj.Canary
+	}
+}
+
 // Check implements executor.QualityChecker by delegating to quality.Executor
 // and converting the result type
 func (w *qualityCheckerWrapper) Check(ctx context.Context) (*executor.QualityOutcome, error) {

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -545,6 +545,7 @@ Examples:
 				// Create dispatcher if store available
 				if gwStore != nil {
 					gwDispatcher = executor.NewDispatcher(gwStore, gwRunner, nil)
+					gwDispatcher.SetCanaryResolver(newCanaryProjectResolver(cfg))
 					if dispErr := gwDispatcher.Start(context.Background()); dispErr != nil {
 						logging.WithComponent("start").Warn("Failed to start dispatcher for gateway polling", slog.Any("error", dispErr))
 						gwDispatcher = nil
@@ -654,8 +655,15 @@ Examples:
 							// executions.project_path) so merged work flips failed→completed.
 							gwBoardOpts = append(gwBoardOpts, autopilot.WithProjectPath(projectPath))
 							// GH-3931: apply the per-project release overlay (GH-3930) when configured.
-							if proj := cfg.FindProjectByRepo(cfg.Adapters.GitHub.Repo); proj != nil && proj.Release != nil {
-								gwBoardOpts = append(gwBoardOpts, autopilot.WithReleaseOverride(proj.Release))
+							if proj := cfg.FindProjectByRepo(cfg.Adapters.GitHub.Repo); proj != nil {
+								if proj.Release != nil {
+									gwBoardOpts = append(gwBoardOpts, autopilot.WithReleaseOverride(proj.Release))
+								}
+								// GH-4240: keep a canary default repo's live pilot_success_rate
+								// counter out of the fleet-wide AggregateMetrics.
+								if proj.Canary {
+									gwBoardOpts = append(gwBoardOpts, autopilot.WithCanary(true))
+								}
 							}
 							gwAutopilotController = autopilot.NewController(
 								cfg.Orchestrator.Autopilot,
@@ -1486,8 +1494,15 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					// the per-project loop below does not alias this controller's option.
 					ctrlOpts := append(append([]autopilot.ControllerOption{}, autopilotBoardOpts...), autopilot.WithProjectPath(projectPath))
 					// GH-3931: apply the per-project release overlay (GH-3930) when configured.
-					if proj := cfg.FindProjectByRepo(cfg.Adapters.GitHub.Repo); proj != nil && proj.Release != nil {
-						ctrlOpts = append(ctrlOpts, autopilot.WithReleaseOverride(proj.Release))
+					if proj := cfg.FindProjectByRepo(cfg.Adapters.GitHub.Repo); proj != nil {
+						if proj.Release != nil {
+							ctrlOpts = append(ctrlOpts, autopilot.WithReleaseOverride(proj.Release))
+						}
+						// GH-4240: keep a canary default repo's live pilot_success_rate
+						// counter out of the fleet-wide AggregateMetrics.
+						if proj.Canary {
+							ctrlOpts = append(ctrlOpts, autopilot.WithCanary(true))
+						}
 					}
 					controller := autopilot.NewController(
 						cfg.Orchestrator.Autopilot,
@@ -1520,6 +1535,11 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 				// TASK-352: scope self-heal to this project's fs path (matches
 				// executions.project_path). Fresh slice to avoid aliasing the shared opts.
 				ctrlOpts := append(append([]autopilot.ControllerOption{}, autopilotBoardOpts...), autopilot.WithProjectPath(proj.Path))
+				// GH-4240: keep the synthetic canary sandbox's own live
+				// pilot_success_rate counter out of the fleet-wide AggregateMetrics.
+				if proj.Canary {
+					ctrlOpts = append(ctrlOpts, autopilot.WithCanary(true))
+				}
 				// GH-4001: a project's own `release:` block keeps today's overlay
 				// semantics (GH-3931/GH-3930); no block means this repo never
 				// opted into release automation and must not inherit the
@@ -2090,6 +2110,7 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 	var dispatcher *executor.Dispatcher
 	if store != nil {
 		dispatcher = executor.NewDispatcher(store, runner, nil)
+		dispatcher.SetCanaryResolver(newCanaryProjectResolver(cfg))
 		if err := dispatcher.Start(ctx); err != nil {
 			logging.WithComponent("start").Warn("Failed to start dispatcher", slog.Any("error", err))
 			dispatcher = nil

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -220,6 +220,20 @@ func WithReleaseNotOptedIn() ControllerOption {
 	}
 }
 
+// WithCanary marks this controller's project as a synthetic canary sandbox
+// (config ProjectConfig.Canary, GH-4240). It gates every
+// RecordIssueProcessed call site so this controller's own *Metrics never
+// accumulates live issue-processed counts — those feed pilot_success_rate
+// directly (Metrics.Snapshot) and would otherwise pollute the fleet-wide
+// AggregateMetrics this controller's Metrics is merged into. Store-derived
+// counters (issues_shipped/attempted, throughput histograms, hydration) are
+// excluded separately at the SQL layer via executions.is_canary.
+func WithCanary(canary bool) ControllerOption {
+	return func(c *Controller) {
+		c.canary = canary
+	}
+}
+
 // Controller orchestrates the autopilot loop for PR processing.
 // It manages the state machine: PR created → CI check → merge → post-merge CI → feedback loop.
 type Controller struct {
@@ -284,6 +298,11 @@ type Controller struct {
 	// executions.project_path. Used to scope self-heal to this project's rows.
 	// Empty = match by task_id only (single-repo / tests). TASK-352.
 	projectPath string
+
+	// canary marks this controller's project as a synthetic canary sandbox
+	// (WithCanary, GH-4240). Gates live RecordIssueProcessed calls so this
+	// controller's Metrics never feeds pilot_success_rate.
+	canary bool
 
 	// projectRelease is the per-project release config overlay (GH-3930),
 	// wired via WithReleaseOverride. Nil = no project-level override. Applied
@@ -1530,7 +1549,7 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 			prState.TerminalLabel = github.LabelFailed
 			c.metrics.RecordPRFailed()
 			c.metrics.RecordCIRun("fail")
-			c.metrics.RecordIssueProcessed("failed")
+			c.recordIssueProcessed("failed")
 			return nil
 		}
 	}
@@ -1567,7 +1586,7 @@ func (c *Controller) handleCIFailed(ctx context.Context, prState *PRState) error
 				prState.TerminalLabel = github.LabelFailed
 				c.metrics.RecordPRFailed()
 				c.metrics.RecordCIRun("fail")
-				c.metrics.RecordIssueProcessed("failed")
+				c.recordIssueProcessed("failed")
 				return nil
 			}
 		}
@@ -1680,7 +1699,7 @@ func (c *Controller) handleReviewRequested(ctx context.Context, prState *PRState
 			prState.Error = fmt.Sprintf("review feedback iteration limit reached (%d/%d)", iteration, c.config.ReviewFeedback.MaxIterations)
 			prState.TerminalLabel = github.LabelFailed
 			c.metrics.RecordPRFailed()
-			c.metrics.RecordIssueProcessed("failed")
+			c.recordIssueProcessed("failed")
 			return nil
 		}
 	}
@@ -1846,7 +1865,7 @@ func (c *Controller) submitAsyncApprovalRequest(ctx context.Context, prState *PR
 		)
 		c.autoMerger.postMisconfigComment(ctx, prState)
 		c.metrics.RecordPRFailed()
-		c.metrics.RecordIssueProcessed("failed")
+		c.recordIssueProcessed("failed")
 		return nil
 	}
 
@@ -1926,14 +1945,14 @@ func (c *Controller) applyApprovalDecision(prState *PRState) error {
 		prState.Stage = StageFailed
 		prState.Error = fmt.Sprintf("merge rejected: approval %s", prState.ApprovalDecision)
 		c.metrics.RecordPRFailed()
-		c.metrics.RecordIssueProcessed("failed")
+		c.recordIssueProcessed("failed")
 	default:
 		c.log.Warn("unknown approval decision — failing PR",
 			"pr", prState.PRNumber, "decision", prState.ApprovalDecision)
 		prState.Stage = StageFailed
 		prState.Error = fmt.Sprintf("unknown approval decision: %q", prState.ApprovalDecision)
 		c.metrics.RecordPRFailed()
-		c.metrics.RecordIssueProcessed("failed")
+		c.recordIssueProcessed("failed")
 	}
 	return nil
 }
@@ -2070,7 +2089,7 @@ func (c *Controller) handleMerging(ctx context.Context, prState *PRState) error 
 			prState.Stage = StageFailed
 			prState.Error = errMsg
 			c.metrics.RecordPRFailed()
-			c.metrics.RecordIssueProcessed("failed")
+			c.recordIssueProcessed("failed")
 			return nil
 		}
 
@@ -3187,7 +3206,7 @@ func (c *Controller) escalateReleasingFailed(ctx context.Context, prState *PRSta
 	prState.Stage = StageFailed
 	prState.Error = reason
 	c.metrics.RecordPRFailed()
-	c.metrics.RecordIssueProcessed("failed")
+	c.recordIssueProcessed("failed")
 
 	// GH-3990: a scope-release carrier must not stay wedged at StageFailed —
 	// flip the scope back to pending (or terminal-failed past the retry cap)
@@ -3475,7 +3494,7 @@ func (c *Controller) handleMergeConflict(ctx context.Context, prState *PRState) 
 			prState.Stage = StageFailed
 			prState.Error = errMsg
 			c.metrics.RecordPRFailed()
-			c.metrics.RecordIssueProcessed("failed")
+			c.recordIssueProcessed("failed")
 			return nil
 		}
 
@@ -3768,6 +3787,17 @@ func (c *Controller) Metrics() *Metrics {
 	return c.metrics
 }
 
+// recordIssueProcessed records a per-attempt issue outcome, unless this
+// controller's project is canary (WithCanary, GH-4240) — canary executions
+// must not contribute to pilot_success_rate. All call sites that used to call
+// c.metrics.RecordIssueProcessed directly route through here instead.
+func (c *Controller) recordIssueProcessed(result string) {
+	if c.canary {
+		return
+	}
+	c.metrics.RecordIssueProcessed(result)
+}
+
 // recordMergeSuccess fires the three merge-success metrics counters exactly
 // once per PR number per daemon lifetime. Safe to call from any path that
 // observes a Pilot PR transitioning to merged (handleMerging for
@@ -3783,7 +3813,7 @@ func (c *Controller) recordMergeSuccess(prState *PRState) {
 	c.mu.Unlock()
 
 	c.metrics.RecordPRMerged()
-	c.metrics.RecordIssueProcessed("success")
+	c.recordIssueProcessed("success")
 	if !prState.CreatedAt.IsZero() {
 		c.metrics.RecordPRTimeToMerge(time.Since(prState.CreatedAt))
 	}

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -7755,6 +7755,76 @@ func TestController_IssuesProcessed_TerminalFailure(t *testing.T) {
 	}
 }
 
+// TestController_WithCanary_ExcludesFromIssuesProcessed pins GH-4240: a
+// canary-flagged controller must never contribute to pilot_success_rate
+// (Metrics.IssuesProcessed, live-recorded via recordIssueProcessed), while a
+// non-canary controller processing the identical merge fixture records
+// exactly as it did before GH-4240 (table-driven, same fixture, flag on/off).
+func TestController_WithCanary_ExcludesFromIssuesProcessed(t *testing.T) {
+	tests := []struct {
+		name          string
+		canary        bool
+		wantProcessed int64
+	}{
+		{name: "non-canary controller records the merge", canary: false, wantProcessed: 1},
+		{name: "canary controller excludes the merge", canary: true, wantProcessed: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/repos/owner/repo/commits/mergesha1/check-runs":
+					_, _ = w.Write(mustJSON(t, github.CheckRunsResponse{
+						TotalCount: 1,
+						CheckRuns:  []github.CheckRun{{Name: "build", Status: "completed", Conclusion: "success"}},
+					}))
+				case r.URL.Path == "/repos/owner/repo/pulls/42/merge" && r.Method == http.MethodPut:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(mustJSON(t, map[string]interface{}{
+						"sha": "merged1", "merged": true, "message": "Pull Request successfully merged",
+					}))
+				case r.URL.Path == "/repos/owner/repo/pulls/42" && r.Method == http.MethodGet:
+					_, _ = w.Write(mustJSON(t, github.PullRequest{
+						Number: 42, State: "open",
+						Head: github.PRRef{Ref: "pilot/GH-10", SHA: "mergesha1"},
+					}))
+				default:
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("{}"))
+				}
+			}))
+			defer server.Close()
+
+			ghClient := github.NewClientWithBaseURL(testutil.FakeGitHubToken, server.URL)
+			cfg := DefaultConfig()
+			cfg.Environment = EnvDev
+			cfg.AutoReview = false
+			cfg.RequiredChecks = []string{"build"}
+			c := NewController(cfg, ghClient, nil, "owner", "repo", WithCanary(tt.canary))
+			c.OnPRCreated(42, "https://github.com/owner/repo/pull/42", 10, "mergesha1", "pilot/GH-10", "")
+			pr, _ := c.GetPRState(42)
+			pr.Stage = StageMerging
+
+			if err := c.ProcessPR(context.Background(), 42, nil); err != nil {
+				t.Fatalf("ProcessPR returned error: %v", err)
+			}
+
+			snap := c.metrics.Snapshot()
+			if snap.IssuesProcessed["success"] != tt.wantProcessed {
+				t.Errorf("IssuesProcessed[success] = %d, want %d", snap.IssuesProcessed["success"], tt.wantProcessed)
+			}
+			// PR-family counters (RecordPRMerged) are unrelated to
+			// recordIssueProcessed's gate — they still fire regardless of
+			// canary status, since GH-4240 only scopes the four metrics named
+			// in the issue (pilot_success_rate and friends), not every counter.
+			if snap.PRsMerged != 1 {
+				t.Errorf("PRsMerged = %d, want 1 regardless of canary status", snap.PRsMerged)
+			}
+		})
+	}
+}
+
 // TestController_ScanRecentlyMergedPRs_RecordsMetrics verifies that
 // ScanRecentlyMergedPRs fires merge metrics on first discovery (GH-2981)
 // and is idempotent on subsequent scans.

--- a/internal/autopilot/metrics_hydrator_test.go
+++ b/internal/autopilot/metrics_hydrator_test.go
@@ -111,6 +111,128 @@ func TestHydrateFromStore_PerLabelValues(t *testing.T) {
 	}
 }
 
+// TestHydrateFromStore_ExcludesCanary pins GH-4240 end-to-end through the
+// actual hydrator entry point (not just the underlying store queries): a
+// canary-flagged execution row must not move ANY hydrated counter — token,
+// cost, execution-by-result, issues-processed, issue-level, PR, CI-run, or
+// throughput-histogram — while the non-canary baseline stays byte-identical
+// to TestHydrateFromStore_PerLabelValues's pre-GH-4240 behavior.
+func TestHydrateFromStore_ExcludesCanary(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Identical fixture to TestHydrateFromStore_PerLabelValues.
+	execs := []*memory.Execution{
+		{
+			ID: "h-1", TaskID: "TASK-1", ProjectPath: "/p", Status: "completed",
+			ModelName:   "claude-sonnet-4-5",
+			TokensInput: 1000, TokensOutput: 500, TokensTotal: 1500,
+			EstimatedCostUSD: 0.05,
+		},
+		{
+			ID: "h-2", TaskID: "TASK-2", ProjectPath: "/p", Status: "completed",
+			ModelName:   "claude-sonnet-4-5",
+			TokensInput: 2000, TokensOutput: 1000, TokensTotal: 3000,
+			EstimatedCostUSD: 0.10,
+		},
+		{
+			ID: "h-3", TaskID: "TASK-3", ProjectPath: "/p", Status: "failed",
+			ModelName:   "claude-opus-4-6",
+			TokensInput: 500, TokensOutput: 250, TokensTotal: 750,
+			EstimatedCostUSD: 0.02,
+		},
+	}
+	for _, e := range execs {
+		if err := store.SaveExecution(e); err != nil {
+			t.Fatalf("SaveExecution %s: %v", e.ID, err)
+		}
+	}
+
+	baselineMetrics := NewMetrics()
+	if err := HydrateFromStore(context.Background(), store, baselineMetrics); err != nil {
+		t.Fatalf("HydrateFromStore (baseline): %v", err)
+	}
+	baseline := baselineMetrics.Snapshot()
+
+	// A lavish canary row that, if not excluded, would obviously move every
+	// counter (huge tokens/cost, a distinct model, a completed status).
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "canary-1", TaskID: "CANARY-1", ProjectPath: "/canary", Status: "completed",
+		ModelName:   "claude-sonnet-4-5",
+		TokensInput: 999999, TokensOutput: 999999, TokensTotal: 1999998,
+		EstimatedCostUSD: 999.99,
+		IsCanary:         true,
+	}); err != nil {
+		t.Fatalf("SaveExecution canary-1: %v", err)
+	}
+
+	afterMetrics := NewMetrics()
+	if err := HydrateFromStore(context.Background(), store, afterMetrics); err != nil {
+		t.Fatalf("HydrateFromStore (with canary row): %v", err)
+	}
+	after := afterMetrics.Snapshot()
+
+	if after.SuccessRate != baseline.SuccessRate {
+		t.Errorf("SuccessRate changed after adding canary row: got %v, want unchanged %v", after.SuccessRate, baseline.SuccessRate)
+	}
+	if after.IssueLevelSuccessRate != baseline.IssueLevelSuccessRate {
+		t.Errorf("IssueLevelSuccessRate changed after adding canary row: got %v, want unchanged %v", after.IssueLevelSuccessRate, baseline.IssueLevelSuccessRate)
+	}
+	if after.IssuesShipped != baseline.IssuesShipped {
+		t.Errorf("IssuesShipped changed after adding canary row: got %d, want unchanged %d", after.IssuesShipped, baseline.IssuesShipped)
+	}
+	if after.IssuesAttempted != baseline.IssuesAttempted {
+		t.Errorf("IssuesAttempted changed after adding canary row: got %d, want unchanged %d", after.IssuesAttempted, baseline.IssuesAttempted)
+	}
+	for k, want := range baseline.TokensConsumed {
+		if got := after.TokensConsumed[k]; got != want {
+			t.Errorf("TokensConsumed[%+v] changed after adding canary row: got %d, want unchanged %d", k, got, want)
+		}
+	}
+	for k, want := range baseline.ExecutionsByResult {
+		if got := after.ExecutionsByResult[k]; got != want {
+			t.Errorf("ExecutionsByResult[%+v] changed after adding canary row: got %d, want unchanged %d", k, got, want)
+		}
+	}
+	const epsilon = 0.0001
+	for model, want := range baseline.ExecutionCostUSD {
+		got := after.ExecutionCostUSD[model]
+		if got < want-epsilon || got > want+epsilon {
+			t.Errorf("ExecutionCostUSD[%s] changed after adding canary row: got %.4f, want unchanged %.4f", model, got, want)
+		}
+	}
+	if after.PRsMerged != baseline.PRsMerged || after.PRsFailed != baseline.PRsFailed {
+		t.Errorf("PR counters changed after adding canary row: got merged=%d failed=%d, want unchanged merged=%d failed=%d",
+			after.PRsMerged, after.PRsFailed, baseline.PRsMerged, baseline.PRsFailed)
+	}
+	if after.CIRuns["pass"] != baseline.CIRuns["pass"] || after.CIRuns["fail"] != baseline.CIRuns["fail"] {
+		t.Errorf("CIRuns changed after adding canary row: got %+v, want unchanged %+v", after.CIRuns, baseline.CIRuns)
+	}
+
+	afterHist := afterMetrics.HistogramSnapshot()
+	baselineHist := baselineMetrics.HistogramSnapshot()
+	if len(afterHist.PRTimeToMerge) != len(baselineHist.PRTimeToMerge) {
+		t.Errorf("PRTimeToMerge sample count changed after adding canary row: got %d, want unchanged %d",
+			len(afterHist.PRTimeToMerge), len(baselineHist.PRTimeToMerge))
+	}
+	if len(afterHist.TimeToPRDurations) != len(baselineHist.TimeToPRDurations) {
+		t.Errorf("TimeToPRDurations sample count changed after adding canary row: got %d, want unchanged %d",
+			len(afterHist.TimeToPRDurations), len(baselineHist.TimeToPRDurations))
+	}
+	if len(afterHist.QueueWaitDurations) != len(baselineHist.QueueWaitDurations) {
+		t.Errorf("QueueWaitDurations sample count changed after adding canary row: got %d, want unchanged %d",
+			len(afterHist.QueueWaitDurations), len(baselineHist.QueueWaitDurations))
+	}
+	if len(afterHist.ApprovalWaitDurations) != len(baselineHist.ApprovalWaitDurations) {
+		t.Errorf("ApprovalWaitDurations sample count changed after adding canary row: got %d, want unchanged %d",
+			len(afterHist.ApprovalWaitDurations), len(baselineHist.ApprovalWaitDurations))
+	}
+}
+
 // TestHydrateFromStore_NonFailuresExcludedFromFailed pins TASK-392: declined/
 // no_op/stalled/rate_limited/infra/skipped outcomes must not be folded into
 // the hydrated "failed" bucket, mirroring the dispatcher's live taxonomy

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -253,6 +253,13 @@ type ProjectConfig struct {
 	// Config.Orchestrator.Autopilot's global and per-environment release
 	// blocks.
 	Release *autopilot.ProjectReleaseConfig `yaml:"release,omitempty"`
+	// Canary marks this project as a synthetic sandbox (e.g.
+	// pilot-canary-sandbox, TASK-379 V8) rather than real work (GH-4240).
+	// Executions dispatched for a canary project are still fully persisted
+	// and event-logged, but are excluded from success-rate/issue-level/
+	// throughput metrics, hydrators, and dashboard history so re-enabling
+	// the canary cron cannot contaminate production telemetry.
+	Canary bool `yaml:"canary,omitempty"`
 }
 
 // ResolveBaseBranch returns the branch that Pilot should branch from and

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1800,6 +1800,61 @@ projects:
 	}
 }
 
+// TestProjectConfigCanaryYAML pins GH-4240: `canary: true` on a project
+// yaml entry parses onto ProjectConfig.Canary, and a project with no
+// `canary:` key defaults to false — table-driven, same shape, flag on/off.
+func TestProjectConfigCanaryYAML(t *testing.T) {
+	tests := []struct {
+		name        string
+		yamlSnippet string
+		wantCanary  bool
+	}{
+		{
+			name: "canary: true parses onto ProjectConfig.Canary",
+			yamlSnippet: `
+    canary: true
+`,
+			wantCanary: true,
+		},
+		{
+			name:        "no canary key defaults to false",
+			yamlSnippet: "",
+			wantCanary:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.yaml")
+
+			configContent := `
+version: "1.0"
+projects:
+  - name: "my-app"
+    path: "/tmp/my-app"` + tt.yamlSnippet + `
+    github:
+      owner: "my-org"
+      repo: "my-app"
+`
+			if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+				t.Fatalf("Failed to write test config: %v", err)
+			}
+
+			cfg, err := Load(configPath)
+			if err != nil {
+				t.Fatalf("Load failed: %v", err)
+			}
+			if len(cfg.Projects) != 1 {
+				t.Fatalf("Projects count = %d, want 1", len(cfg.Projects))
+			}
+			if got := cfg.Projects[0].Canary; got != tt.wantCanary {
+				t.Errorf("Canary = %v, want %v", got, tt.wantCanary)
+			}
+		})
+	}
+}
+
 // TestSave_PermissionsAre0600 asserts that Save() writes the config file
 // with 0600 permissions and its parent directory with 0700 — required
 // because the file stores GitHub PAT, Linear API key, Slack bot token,

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -81,6 +81,13 @@ type Dispatcher struct {
 	ctx        context.Context
 	cancel     context.CancelFunc
 	wg         sync.WaitGroup
+	// canaryResolver reports whether a project path belongs to a synthetic
+	// canary project (config ProjectConfig.Canary, GH-4240). nil means no
+	// project is canary — matches pre-GH-4240 behavior. Set via
+	// SetCanaryResolver; queried once per exec-row creation so callers don't
+	// need to thread a canary flag through every executor.Task construction
+	// site.
+	canaryResolver func(projectPath string) bool
 }
 
 // NewDispatcher creates a new task dispatcher.
@@ -534,6 +541,29 @@ func (d *Dispatcher) hasLiveWorker(projectPath string) bool {
 	return ok
 }
 
+// SetCanaryResolver installs the callback the dispatcher uses to mark
+// executions as canary (GH-4240). resolver is called with an
+// executor.Task's ProjectPath and should report whether that project is
+// configured with `canary: true`. Passing nil disables canary marking.
+func (d *Dispatcher) SetCanaryResolver(resolver func(projectPath string) bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.canaryResolver = resolver
+}
+
+// isCanaryProject reports whether projectPath belongs to a canary project,
+// via the resolver installed by SetCanaryResolver. Fails closed (false) when
+// no resolver is set, matching pre-GH-4240 behavior.
+func (d *Dispatcher) isCanaryProject(projectPath string) bool {
+	d.mu.RLock()
+	resolver := d.canaryResolver
+	d.mu.RUnlock()
+	if resolver == nil {
+		return false
+	}
+	return resolver(projectPath)
+}
+
 // IsActive reports whether taskID is already queued or running, using the
 // same source of truth QueueTask's duplicate-task check uses. Callers that
 // dispatch on a poll loop can pre-check this before announcing/attempting a
@@ -596,6 +626,7 @@ func (d *Dispatcher) queueDecomposedTask(ctx context.Context, parent *Task, resu
 		TaskSourceAdapter: parent.SourceAdapter,
 		TaskSourceIssueID: parent.SourceIssueID,
 		TaskLabels:        parent.Labels, // GH-2326: persist labels for no-decompose/autopilot-fix gates
+		IsCanary:          d.isCanaryProject(parent.ProjectPath),
 	}
 
 	if err := d.store.SaveExecution(parentExec); err != nil {
@@ -654,6 +685,7 @@ func (d *Dispatcher) queueSingleTask(ctx context.Context, task *Task) (string, e
 		TaskSourceAdapter: task.SourceAdapter,
 		TaskSourceIssueID: task.SourceIssueID,
 		TaskLabels:        task.Labels, // GH-2326: persist labels for no-decompose/autopilot-fix gates
+		IsCanary:          d.isCanaryProject(task.ProjectPath),
 	}
 
 	if err := d.store.SaveExecution(exec); err != nil {

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -103,6 +103,125 @@ func TestDispatcher_QueueTask(t *testing.T) {
 	}
 }
 
+// TestDispatcher_SetCanaryResolver_MarksSingleTaskExecution pins GH-4240: a
+// single (non-decomposed) task queued for a project the resolver reports as
+// canary must persist IsCanary=true, and the same fixture with the flag off
+// (nil resolver, or resolver returning false) must persist IsCanary=false —
+// non-canary behavior must be byte-identical to pre-GH-4240.
+func TestDispatcher_SetCanaryResolver_MarksSingleTaskExecution(t *testing.T) {
+	tests := []struct {
+		name         string
+		resolver     func(string) bool
+		projectPath  string
+		wantIsCanary bool
+	}{
+		{
+			name:         "no resolver installed defaults to non-canary",
+			resolver:     nil,
+			projectPath:  "/tmp/real-project",
+			wantIsCanary: false,
+		},
+		{
+			name:         "resolver reports non-canary project",
+			resolver:     func(p string) bool { return p == "/tmp/canary-project" },
+			projectPath:  "/tmp/real-project",
+			wantIsCanary: false,
+		},
+		{
+			name:         "resolver reports canary project",
+			resolver:     func(p string) bool { return p == "/tmp/canary-project" },
+			projectPath:  "/tmp/canary-project",
+			wantIsCanary: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+
+			runner := NewRunner()
+			dispatcher := NewDispatcher(store, runner, nil)
+			if tt.resolver != nil {
+				dispatcher.SetCanaryResolver(tt.resolver)
+			}
+
+			if err := dispatcher.Start(context.Background()); err != nil {
+				t.Fatalf("failed to start dispatcher: %v", err)
+			}
+			defer dispatcher.Stop()
+
+			task := &Task{
+				ID:          "TEST-CANARY-" + tt.name,
+				Title:       "Test Task",
+				ProjectPath: tt.projectPath,
+			}
+
+			execID, err := dispatcher.QueueTask(context.Background(), task)
+			if err != nil {
+				t.Fatalf("failed to queue task: %v", err)
+			}
+
+			exec, err := store.GetExecution(execID)
+			if err != nil {
+				t.Fatalf("failed to get execution: %v", err)
+			}
+			if exec.IsCanary != tt.wantIsCanary {
+				t.Errorf("IsCanary = %v, want %v", exec.IsCanary, tt.wantIsCanary)
+			}
+		})
+	}
+}
+
+// TestDispatcher_SetCanaryResolver_MarksDecomposedParentExecution pins
+// GH-4240 for the decomposed-parent exec row (dispatcher.go queueDecomposedTask),
+// which writes independently of queueSingleTask.
+func TestDispatcher_SetCanaryResolver_MarksDecomposedParentExecution(t *testing.T) {
+	tests := []struct {
+		name         string
+		canary       bool
+		wantIsCanary bool
+	}{
+		{name: "canary project marks decomposed parent", canary: true, wantIsCanary: true},
+		{name: "non-canary project leaves decomposed parent unmarked", canary: false, wantIsCanary: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+
+			runner := NewRunner()
+			dispatcher := NewDispatcher(store, runner, nil)
+			dispatcher.SetCanaryResolver(func(string) bool { return tt.canary })
+
+			parent := &Task{
+				ID:          "TEST-DECOMPOSED-PARENT-" + tt.name,
+				Title:       "Parent Task",
+				ProjectPath: "/tmp/some-project",
+			}
+			result := &DecomposeResult{
+				Decomposed: true,
+				Subtasks:   nil,
+				Reason:     "test",
+			}
+
+			parentExecID, err := dispatcher.queueDecomposedTask(context.Background(), parent, result)
+			if err != nil {
+				t.Fatalf("queueDecomposedTask: %v", err)
+			}
+
+			exec, err := store.GetExecution(parentExecID)
+			if err != nil {
+				t.Fatalf("failed to get parent execution: %v", err)
+			}
+			if exec.IsCanary != tt.wantIsCanary {
+				t.Errorf("IsCanary = %v, want %v", exec.IsCanary, tt.wantIsCanary)
+			}
+		})
+	}
+}
+
 func TestDispatcher_DuplicateTask(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/memory/canary_test.go
+++ b/internal/memory/canary_test.go
@@ -1,0 +1,410 @@
+package memory
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSaveExecution_PersistsIsCanary pins GH-4240: the is_canary column must
+// round-trip through SaveExecution exactly as written — the ledger write path
+// is unaffected by canary status, only metrics/hydrator/dashboard reads are.
+func TestSaveExecution_PersistsIsCanary(t *testing.T) {
+	tests := []struct {
+		name     string
+		isCanary bool
+	}{
+		{name: "canary flag persists true", isCanary: true},
+		{name: "canary flag persists false (default)", isCanary: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newExecutionEventsTestStore(t)
+			if err := store.SaveExecution(&Execution{
+				ID: "exec-canary-1", TaskID: "GH-1", ProjectPath: "/p",
+				Status: "completed", IsCanary: tt.isCanary,
+			}); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			var got bool
+			if err := store.db.QueryRow(`SELECT is_canary FROM executions WHERE id = ?`, "exec-canary-1").Scan(&got); err != nil {
+				t.Fatalf("query is_canary: %v", err)
+			}
+			if got != tt.isCanary {
+				t.Errorf("is_canary = %v, want %v", got, tt.isCanary)
+			}
+		})
+	}
+}
+
+// TestGetIssueLevelCounts_ExcludesCanary pins that a canary project's
+// executions never contribute to pilot_issues_shipped_total /
+// pilot_issues_attempted_total (TASK-392 gauges), with the same fixture run
+// once with the flag off and once with it added, matching non-canary rows
+// exactly.
+func TestGetIssueLevelCounts_ExcludesCanary(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	// Real work: one shipped, one never shipped.
+	if err := store.SaveExecution(&Execution{ID: "real-1", TaskID: "GH-1", ProjectPath: "/p", Status: "completed"}); err != nil {
+		t.Fatalf("SaveExecution real-1: %v", err)
+	}
+	if err := store.SaveExecution(&Execution{ID: "real-2", TaskID: "GH-2", ProjectPath: "/p", Status: "failed"}); err != nil {
+		t.Fatalf("SaveExecution real-2: %v", err)
+	}
+
+	baseline, err := store.GetIssueLevelCounts("")
+	if err != nil {
+		t.Fatalf("GetIssueLevelCounts (baseline): %v", err)
+	}
+	if baseline.Attempted != 2 || baseline.Shipped != 1 {
+		t.Fatalf("baseline = %+v, want Attempted=2 Shipped=1", baseline)
+	}
+
+	// Canary sandbox: several shipped issues that must not move the counts.
+	if err := store.SaveExecution(&Execution{ID: "canary-1", TaskID: "CANARY-1", ProjectPath: "/canary", Status: "completed", IsCanary: true}); err != nil {
+		t.Fatalf("SaveExecution canary-1: %v", err)
+	}
+	if err := store.SaveExecution(&Execution{ID: "canary-2", TaskID: "CANARY-2", ProjectPath: "/canary", Status: "completed", IsCanary: true}); err != nil {
+		t.Fatalf("SaveExecution canary-2: %v", err)
+	}
+
+	after, err := store.GetIssueLevelCounts("")
+	if err != nil {
+		t.Fatalf("GetIssueLevelCounts (with canary rows): %v", err)
+	}
+	if after.Attempted != baseline.Attempted || after.Shipped != baseline.Shipped {
+		t.Errorf("counts changed after adding canary rows: got %+v, want unchanged %+v", after, baseline)
+	}
+}
+
+// TestGetLifetimeTaskCounts_ExcludesCanary mirrors
+// TestGetIssueLevelCounts_ExcludesCanary for the per-attempt lifetime counts
+// hydrated into pilot_issues_processed_total.
+func TestGetLifetimeTaskCounts_ExcludesCanary(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	if err := store.SaveExecution(&Execution{ID: "real-1", TaskID: "GH-1", ProjectPath: "/p", Status: "completed"}); err != nil {
+		t.Fatalf("SaveExecution real-1: %v", err)
+	}
+	if err := store.SaveExecution(&Execution{ID: "real-2", TaskID: "GH-2", ProjectPath: "/p", Status: "failed"}); err != nil {
+		t.Fatalf("SaveExecution real-2: %v", err)
+	}
+
+	baseline, err := store.GetLifetimeTaskCounts("")
+	if err != nil {
+		t.Fatalf("GetLifetimeTaskCounts (baseline): %v", err)
+	}
+
+	if err := store.SaveExecution(&Execution{ID: "canary-1", TaskID: "CANARY-1", ProjectPath: "/canary", Status: "completed", IsCanary: true}); err != nil {
+		t.Fatalf("SaveExecution canary-1: %v", err)
+	}
+	if err := store.SaveExecution(&Execution{ID: "canary-2", TaskID: "CANARY-2", ProjectPath: "/canary", Status: "failed", IsCanary: true}); err != nil {
+		t.Fatalf("SaveExecution canary-2: %v", err)
+	}
+
+	after, err := store.GetLifetimeTaskCounts("")
+	if err != nil {
+		t.Fatalf("GetLifetimeTaskCounts (with canary rows): %v", err)
+	}
+	if *after != *baseline {
+		t.Errorf("counts changed after adding canary rows: got %+v, want unchanged %+v", after, baseline)
+	}
+}
+
+// TestGetLifetimeCounterBaselines_ExcludesCanary pins the GH-4041 Prometheus
+// counter hydration source: token/cost/execution-by-model-result baselines
+// must not include canary rows.
+func TestGetLifetimeCounterBaselines_ExcludesCanary(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	if err := store.SaveExecution(&Execution{
+		ID: "real-1", TaskID: "GH-1", ProjectPath: "/p", Status: "completed",
+		ModelName: "claude-sonnet-5", TokensInput: 100, TokensOutput: 50, TokensTotal: 150,
+		EstimatedCostUSD: 1.5,
+	}); err != nil {
+		t.Fatalf("SaveExecution real-1: %v", err)
+	}
+
+	baseline, err := store.GetLifetimeCounterBaselines()
+	if err != nil {
+		t.Fatalf("GetLifetimeCounterBaselines (baseline): %v", err)
+	}
+
+	if err := store.SaveExecution(&Execution{
+		ID: "canary-1", TaskID: "CANARY-1", ProjectPath: "/canary", Status: "completed",
+		ModelName: "claude-sonnet-5", TokensInput: 9999, TokensOutput: 9999, TokensTotal: 19998,
+		EstimatedCostUSD: 999.0, IsCanary: true,
+	}); err != nil {
+		t.Fatalf("SaveExecution canary-1: %v", err)
+	}
+
+	after, err := store.GetLifetimeCounterBaselines()
+	if err != nil {
+		t.Fatalf("GetLifetimeCounterBaselines (with canary row): %v", err)
+	}
+	key := ModelDirectionKey{Model: "claude-sonnet-5", Direction: "input"}
+	if after.TokensByModelDirection[key] != baseline.TokensByModelDirection[key] {
+		t.Errorf("input tokens changed after adding canary row: got %d, want %d",
+			after.TokensByModelDirection[key], baseline.TokensByModelDirection[key])
+	}
+	if after.CostByModel["claude-sonnet-5"] != baseline.CostByModel["claude-sonnet-5"] {
+		t.Errorf("cost changed after adding canary row: got %v, want %v",
+			after.CostByModel["claude-sonnet-5"], baseline.CostByModel["claude-sonnet-5"])
+	}
+	resultKey := ModelResultKey{Model: "claude-sonnet-5", Result: "success"}
+	if after.ExecutionsByModelResult[resultKey] != baseline.ExecutionsByModelResult[resultKey] {
+		t.Errorf("execution count changed after adding canary row: got %d, want %d",
+			after.ExecutionsByModelResult[resultKey], baseline.ExecutionsByModelResult[resultKey])
+	}
+}
+
+// TestGetLifetimePRCountersFromExecutions_ExcludesCanary pins the GH-4121
+// hydration source for pilot_prs_merged_total/pilot_prs_failed_total.
+func TestGetLifetimePRCountersFromExecutions_ExcludesCanary(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	if err := store.SaveExecution(&Execution{ID: "real-1", TaskID: "GH-1", ProjectPath: "/p", Status: "completed", PRUrl: "https://x/1"}); err != nil {
+		t.Fatalf("SaveExecution real-1: %v", err)
+	}
+
+	baseline, err := store.GetLifetimePRCountersFromExecutions("")
+	if err != nil {
+		t.Fatalf("GetLifetimePRCountersFromExecutions (baseline): %v", err)
+	}
+	if baseline.Merged != 1 {
+		t.Fatalf("baseline.Merged = %d, want 1", baseline.Merged)
+	}
+
+	if err := store.SaveExecution(&Execution{ID: "canary-1", TaskID: "CANARY-1", ProjectPath: "/canary", Status: "completed", PRUrl: "https://x/2", IsCanary: true}); err != nil {
+		t.Fatalf("SaveExecution canary-1: %v", err)
+	}
+
+	after, err := store.GetLifetimePRCountersFromExecutions("")
+	if err != nil {
+		t.Fatalf("GetLifetimePRCountersFromExecutions (with canary row): %v", err)
+	}
+	if *after != *baseline {
+		t.Errorf("counters changed after adding canary row: got %+v, want unchanged %+v", after, baseline)
+	}
+}
+
+// TestGetLifetimeTokens_ExcludesCanary pins the dashboard's lifetime
+// token/cost display.
+func TestGetLifetimeTokens_ExcludesCanary(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	if err := store.SaveExecution(&Execution{ID: "real-1", TaskID: "GH-1", ProjectPath: "/p", Status: "completed", TokensTotal: 100}); err != nil {
+		t.Fatalf("SaveExecution real-1: %v", err)
+	}
+
+	baseline, err := store.GetLifetimeTokens("")
+	if err != nil {
+		t.Fatalf("GetLifetimeTokens (baseline): %v", err)
+	}
+
+	if err := store.SaveExecution(&Execution{ID: "canary-1", TaskID: "CANARY-1", ProjectPath: "/canary", Status: "completed", TokensTotal: 99999, IsCanary: true}); err != nil {
+		t.Fatalf("SaveExecution canary-1: %v", err)
+	}
+
+	after, err := store.GetLifetimeTokens("")
+	if err != nil {
+		t.Fatalf("GetLifetimeTokens (with canary row): %v", err)
+	}
+	if *after != *baseline {
+		t.Errorf("lifetime tokens changed after adding canary row: got %+v, want unchanged %+v", after, baseline)
+	}
+}
+
+// TestGetRecentExecutions_ExcludesCanary pins the dashboard history feed
+// (GetRecentExecutions backs /api/v1/history, /api/v1/queue, the TUI history
+// panel, and comms bot commands): a canary row must never appear.
+func TestGetRecentExecutions_ExcludesCanary(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	if err := store.SaveExecution(&Execution{ID: "real-1", TaskID: "GH-1", ProjectPath: "/p", Status: "completed"}); err != nil {
+		t.Fatalf("SaveExecution real-1: %v", err)
+	}
+	if err := store.SaveExecution(&Execution{ID: "canary-1", TaskID: "CANARY-1", ProjectPath: "/canary", Status: "completed", IsCanary: true}); err != nil {
+		t.Fatalf("SaveExecution canary-1: %v", err)
+	}
+
+	execs, err := store.GetRecentExecutions(100, "")
+	if err != nil {
+		t.Fatalf("GetRecentExecutions: %v", err)
+	}
+	if len(execs) != 1 {
+		t.Fatalf("got %d executions, want 1 (canary row must be excluded)", len(execs))
+	}
+	if execs[0].ID != "real-1" {
+		t.Errorf("got execution %q, want real-1", execs[0].ID)
+	}
+}
+
+// TestGetDailyMetrics_ExcludesCanary pins the dashboard's daily sparkline
+// aggregates.
+func TestGetDailyMetrics_ExcludesCanary(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	if err := store.SaveExecution(&Execution{ID: "real-1", TaskID: "GH-1", ProjectPath: "/p", Status: "completed", TokensTotal: 100}); err != nil {
+		t.Fatalf("SaveExecution real-1: %v", err)
+	}
+	if err := store.SaveExecution(&Execution{ID: "canary-1", TaskID: "CANARY-1", ProjectPath: "/canary", Status: "completed", TokensTotal: 99999, IsCanary: true}); err != nil {
+		t.Fatalf("SaveExecution canary-1: %v", err)
+	}
+
+	metrics, err := store.GetDailyMetrics(MetricsQuery{
+		Start: time.Now().Add(-24 * time.Hour),
+		End:   time.Now().Add(24 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetDailyMetrics: %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("got %d daily buckets, want 1", len(metrics))
+	}
+	if metrics[0].ExecutionCount != 1 {
+		t.Errorf("ExecutionCount = %d, want 1 (canary row must be excluded)", metrics[0].ExecutionCount)
+	}
+	if metrics[0].TotalTokens != 100 {
+		t.Errorf("TotalTokens = %d, want 100 (canary row must be excluded)", metrics[0].TotalTokens)
+	}
+}
+
+// TestGetLifetimeCIRunCounters_ExcludesCanary pins the GH-4134 hydration
+// source: a canary execution's CI verdicts must not inflate
+// pilot_ci_runs_total.
+func TestGetLifetimeCIRunCounters_ExcludesCanary(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	seedExecutionWithEvents(t, store, "real-1", "GH-1", []Stage{StagePRCreated, StageCIPassed, StageMerged})
+
+	baseline, err := store.GetLifetimeCIRunCounters()
+	if err != nil {
+		t.Fatalf("GetLifetimeCIRunCounters (baseline): %v", err)
+	}
+	if baseline.Pass != 1 {
+		t.Fatalf("baseline.Pass = %d, want 1", baseline.Pass)
+	}
+
+	seedCanaryExecutionWithEvents(t, store, "canary-1", "CANARY-1", []Stage{StagePRCreated, StageCIPassed, StageMerged})
+
+	after, err := store.GetLifetimeCIRunCounters()
+	if err != nil {
+		t.Fatalf("GetLifetimeCIRunCounters (with canary row): %v", err)
+	}
+	if *after != *baseline {
+		t.Errorf("counters changed after adding canary row: got %+v, want unchanged %+v", after, baseline)
+	}
+}
+
+// TestGetLifetimePRTimeToMerge_ExcludesCanary pins pilot_pr_time_to_merge_seconds
+// hydration: a canary execution's pr_created->merged delta must not appear.
+func TestGetLifetimePRTimeToMerge_ExcludesCanary(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	seedCanaryExecutionWithEvents(t, store, "canary-1", "CANARY-1", []Stage{StagePRCreated, StageMerged})
+
+	samples, err := store.GetLifetimePRTimeToMerge()
+	if err != nil {
+		t.Fatalf("GetLifetimePRTimeToMerge: %v", err)
+	}
+	if len(samples) != 0 {
+		t.Errorf("got %d samples from a canary-only fixture, want 0", len(samples))
+	}
+
+	seedExecutionWithEvents(t, store, "real-1", "GH-1", []Stage{StagePRCreated, StageMerged})
+
+	samples, err = store.GetLifetimePRTimeToMerge()
+	if err != nil {
+		t.Fatalf("GetLifetimePRTimeToMerge (with canary row present): %v", err)
+	}
+	if len(samples) != 1 {
+		t.Errorf("got %d samples, want 1 (only the non-canary execution)", len(samples))
+	}
+}
+
+// TestGetLifetimeTimeToPR_ExcludesCanary pins pilot_time_to_pr_seconds
+// hydration (GH-4211).
+func TestGetLifetimeTimeToPR_ExcludesCanary(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	seedCanaryExecutionWithEvents(t, store, "canary-1", "CANARY-1", []Stage{StageRunning, StagePRCreated})
+	seedExecutionWithEvents(t, store, "real-1", "GH-1", []Stage{StageRunning, StagePRCreated})
+
+	samples, err := store.GetLifetimeTimeToPR()
+	if err != nil {
+		t.Fatalf("GetLifetimeTimeToPR: %v", err)
+	}
+	if len(samples) != 1 {
+		t.Errorf("got %d samples, want 1 (only the non-canary execution)", len(samples))
+	}
+}
+
+// TestGetLifetimeQueueWait_ExcludesCanary pins pilot_queue_wait_seconds
+// hydration (GH-4211): queue wait is read directly off the executions table,
+// not execution_events. created_at/started_at are set via raw SQL with an
+// explicit 5s gap — CURRENT_TIMESTAMP has only second resolution, so a
+// Go-side sleep between inserts cannot reliably produce a positive delta.
+func TestGetLifetimeQueueWait_ExcludesCanary(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	base := time.Now().UTC()
+	if err := store.SaveExecution(&Execution{ID: "real-1", TaskID: "GH-1", ProjectPath: "/p", Status: "queued"}); err != nil {
+		t.Fatalf("SaveExecution real-1: %v", err)
+	}
+	if _, err := store.db.Exec(`UPDATE executions SET created_at = ?, started_at = ? WHERE id = ?`,
+		base, base.Add(5*time.Second), "real-1"); err != nil {
+		t.Fatalf("backdate real-1: %v", err)
+	}
+	if err := store.SaveExecution(&Execution{ID: "canary-1", TaskID: "CANARY-1", ProjectPath: "/canary", Status: "queued", IsCanary: true}); err != nil {
+		t.Fatalf("SaveExecution canary-1: %v", err)
+	}
+	if _, err := store.db.Exec(`UPDATE executions SET created_at = ?, started_at = ? WHERE id = ?`,
+		base, base.Add(5*time.Second), "canary-1"); err != nil {
+		t.Fatalf("backdate canary-1: %v", err)
+	}
+
+	samples, err := store.GetLifetimeQueueWait()
+	if err != nil {
+		t.Fatalf("GetLifetimeQueueWait: %v", err)
+	}
+	if len(samples) != 1 {
+		t.Errorf("got %d samples, want 1 (only the non-canary execution)", len(samples))
+	}
+}
+
+// TestGetLifetimeApprovalWait_ExcludesCanary pins pilot_approval_wait_seconds
+// hydration (GH-4211).
+func TestGetLifetimeApprovalWait_ExcludesCanary(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	seedCanaryExecutionWithEvents(t, store, "canary-1", "CANARY-1", []Stage{StageAwaitingApproval, StageMerged})
+	seedExecutionWithEvents(t, store, "real-1", "GH-1", []Stage{StageAwaitingApproval, StageMerged})
+
+	samples, err := store.GetLifetimeApprovalWait()
+	if err != nil {
+		t.Fatalf("GetLifetimeApprovalWait: %v", err)
+	}
+	if len(samples) != 1 {
+		t.Errorf("got %d samples, want 1 (only the non-canary execution)", len(samples))
+	}
+}
+
+// seedCanaryExecutionWithEvents mirrors seedExecutionWithEvents but marks the
+// execution row as canary (GH-4240).
+func seedCanaryExecutionWithEvents(t *testing.T, store *Store, executionID, taskID string, stages []Stage) {
+	t.Helper()
+	if err := store.SaveExecution(&Execution{
+		ID: executionID, TaskID: taskID, ProjectPath: "/canary", Status: "completed", IsCanary: true,
+	}); err != nil {
+		t.Fatalf("SaveExecution(%s) failed: %v", executionID, err)
+	}
+	for _, stage := range stages {
+		if err := store.InsertExecutionEvent(executionID, stage, ""); err != nil {
+			t.Fatalf("InsertExecutionEvent(%s, %s) failed: %v", executionID, stage, err)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/internal/memory/metrics.go
+++ b/internal/memory/metrics.go
@@ -318,7 +318,7 @@ func (s *Store) GetMetricsSummary(query MetricsQuery) (*MetricsSummary, error) {
 // GetDailyMetrics returns metrics aggregated by day
 func (s *Store) GetDailyMetrics(query MetricsQuery) ([]*DailyMetrics, error) {
 	var args []interface{}
-	whereClause := "WHERE created_at >= ? AND created_at < ? AND tokens_total > 0"
+	whereClause := "WHERE created_at >= ? AND created_at < ? AND tokens_total > 0 AND is_canary = 0"
 	args = append(args, query.Start, query.End)
 
 	if len(query.Projects) > 0 {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -363,6 +363,12 @@ func (s *Store) migrate() error {
 		// worker picks it up — the stuck-monitor must time it from started_at, not
 		// created_at, or a legitimately-running subtask gets evicted as stale.
 		`ALTER TABLE executions ADD COLUMN started_at DATETIME`,
+		// GH-4240: marks executions dispatched for a synthetic canary project
+		// (config ProjectConfig.Canary) so success-rate/issue-level/throughput
+		// metrics, hydrators, and dashboard history can exclude them while the
+		// ledger (this table, execution_events, execution_logs) still records
+		// them in full.
+		`ALTER TABLE executions ADD COLUMN is_canary BOOLEAN DEFAULT FALSE`,
 	}
 
 	for _, migration := range migrations {
@@ -546,6 +552,10 @@ type Execution struct {
 	// GH-3028: RSS telemetry
 	PeakRSSMB  int
 	FinalRSSMB int
+	// IsCanary marks this execution as dispatched for a synthetic canary
+	// project (config ProjectConfig.Canary, GH-4240). Ledger writes are
+	// unaffected — only metrics/hydrator/dashboard queries filter on it.
+	IsCanary bool
 }
 
 // SaveExecution saves an execution record to the database.
@@ -562,14 +572,14 @@ func (s *Store) SaveExecution(exec *Execution) error {
 				estimated_cost_usd, files_changed, lines_added, lines_removed, model_name,
 				task_title, task_description, task_branch, task_base_branch, task_create_pr, task_verbose,
 				task_source_adapter, task_source_issue_id, task_labels,
-				approval_request_id, effort_level, complexity_level)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				approval_request_id, effort_level, complexity_level, is_canary)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, exec.ID, exec.TaskID, exec.ProjectPath, exec.Status, exec.Output, exec.Error, exec.DurationMs, exec.PRUrl, exec.CommitSHA, exec.CompletedAt,
 			exec.TokensInput, exec.TokensOutput, exec.TokensTotal, exec.TokensCacheRead, exec.TokensCacheWrite,
 			exec.EstimatedCostUSD, exec.FilesChanged, exec.LinesAdded, exec.LinesRemoved, exec.ModelName,
 			exec.TaskTitle, exec.TaskDescription, exec.TaskBranch, exec.TaskBaseBranch, exec.TaskCreatePR, exec.TaskVerbose,
 			exec.TaskSourceAdapter, exec.TaskSourceIssueID, labelsJSON,
-			exec.ApprovalRequestID, exec.EffortLevel, exec.ComplexityLevel)
+			exec.ApprovalRequestID, exec.EffortLevel, exec.ComplexityLevel, exec.IsCanary)
 		return err
 	})
 }
@@ -616,7 +626,7 @@ const executionDetailColumns = `
 	COALESCE(approval_request_id, ''), COALESCE(approval_decision, ''),
 	approval_decision_at,
 	COALESCE(approval_decision_by, ''),
-	COALESCE(effort_level, ''), COALESCE(complexity_level, '')`
+	COALESCE(effort_level, ''), COALESCE(complexity_level, ''), COALESCE(is_canary, 0)`
 
 // rowScanner abstracts *sql.Row and *sql.Rows so scanExecutionDetail serves both
 // a single QueryRow result and a Query loop (used by ListExecutionsForTask).
@@ -637,7 +647,7 @@ func scanExecutionDetail(row rowScanner) (*Execution, error) {
 		&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose,
 		&exec.TaskSourceAdapter, &exec.TaskSourceIssueID, &labelsJSON,
 		&exec.ApprovalRequestID, &exec.ApprovalDecision, &approvalDecisionAt, &exec.ApprovalDecisionBy,
-		&exec.EffortLevel, &exec.ComplexityLevel)
+		&exec.EffortLevel, &exec.ComplexityLevel, &exec.IsCanary)
 	if err != nil {
 		return nil, err
 	}
@@ -1077,11 +1087,12 @@ func (s *Store) GetRecentExecutions(limit int, projectPath string) ([]*Execution
 			COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
 			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
 			COALESCE(peak_rss_mb, 0), COALESCE(final_rss_mb, 0)
-		FROM executions`
+		FROM executions
+		WHERE is_canary = 0`
 	var rows *sql.Rows
 	var err error
 	if projectPath != "" {
-		rows, err = s.db.Query(base+` WHERE project_path = ? ORDER BY created_at DESC LIMIT ?`, projectPath, limit)
+		rows, err = s.db.Query(base+` AND project_path = ? ORDER BY created_at DESC LIMIT ?`, projectPath, limit)
 	} else {
 		rows, err = s.db.Query(base+` ORDER BY created_at DESC LIMIT ?`, limit)
 	}
@@ -2341,7 +2352,7 @@ func (s *Store) GetLifetimeTokens(projectPath string) (*LifetimeTokens, error) {
 			COALESCE(SUM(tokens_cache_write), 0),
 			COALESCE(SUM(estimated_cost_usd), 0)
 		FROM executions
-		WHERE tokens_total > 0`
+		WHERE tokens_total > 0 AND is_canary = 0`
 	var row *sql.Row
 	if projectPath != "" {
 		row = s.db.QueryRow(q+` AND project_path = ?`, projectPath)
@@ -2394,10 +2405,11 @@ func (s *Store) GetLifetimeTaskCounts(projectPath string) (*LifetimeTaskCounts, 
 			COALESCE(SUM(CASE WHEN status = 'rate_limited' THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN status = 'infra' THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END), 0)
-		FROM executions`
+		FROM executions
+		WHERE is_canary = 0`
 	var row *sql.Row
 	if projectPath != "" {
-		row = s.db.QueryRow(cols+` WHERE project_path = ?`, projectPath)
+		row = s.db.QueryRow(cols+` AND project_path = ?`, projectPath)
 	} else {
 		row = s.db.QueryRow(cols)
 	}
@@ -2429,10 +2441,11 @@ func (s *Store) GetIssueLevelCounts(projectPath string) (*IssueLevelCounts, erro
 		SELECT
 			COUNT(DISTINCT task_id),
 			COUNT(DISTINCT CASE WHEN status = 'completed' THEN task_id END)
-		FROM executions`
+		FROM executions
+		WHERE is_canary = 0`
 	var row *sql.Row
 	if projectPath != "" {
-		row = s.db.QueryRow(cols+` WHERE project_path = ?`, projectPath)
+		row = s.db.QueryRow(cols+` AND project_path = ?`, projectPath)
 	} else {
 		row = s.db.QueryRow(cols)
 	}
@@ -2499,7 +2512,7 @@ func (s *Store) GetLifetimeCounterBaselines() (*LifetimeCounterBaselines, error)
 			COALESCE(SUM(tokens_cache_read), 0),
 			COALESCE(SUM(estimated_cost_usd), 0)
 		FROM executions
-		WHERE tokens_total > 0
+		WHERE tokens_total > 0 AND is_canary = 0
 		GROUP BY model_name
 	`)
 	if err != nil {
@@ -2544,7 +2557,7 @@ func (s *Store) GetLifetimeCounterBaselines() (*LifetimeCounterBaselines, error)
 			END AS result,
 			COUNT(*)
 		FROM executions
-		WHERE status NOT IN ('queued', 'pending', 'running')
+		WHERE status NOT IN ('queued', 'pending', 'running') AND is_canary = 0
 		GROUP BY model_name, result
 	`)
 	if err != nil {
@@ -2671,11 +2684,11 @@ func (s *Store) GetLifetimePRCountersFromExecutions(projectPath string) (*Lifeti
 			COUNT(DISTINCT CASE
 				WHEN status = 'failed' AND pr_url <> '' AND task_id NOT IN (
 					SELECT task_id FROM executions
-					WHERE status = 'completed' AND pr_url <> '' AND (? = '' OR project_path = ?)
+					WHERE status = 'completed' AND pr_url <> '' AND is_canary = 0 AND (? = '' OR project_path = ?)
 				) THEN task_id
 			END)
 		FROM executions
-		WHERE (? = '' OR project_path = ?)`
+		WHERE is_canary = 0 AND (? = '' OR project_path = ?)`
 
 	row := s.db.QueryRow(cols, projectPath, projectPath, projectPath, projectPath)
 
@@ -2709,10 +2722,11 @@ func (s *Store) GetLifetimeCIRunCounters() (*LifetimeCIRunCounters, error) {
 	counters := &LifetimeCIRunCounters{}
 
 	rows, err := s.db.Query(`
-		SELECT stage, COUNT(DISTINCT execution_id)
-		FROM execution_events
-		WHERE stage IN (?, ?)
-		GROUP BY stage
+		SELECT ee.stage, COUNT(DISTINCT ee.execution_id)
+		FROM execution_events ee
+		JOIN executions e ON e.id = ee.execution_id
+		WHERE ee.stage IN (?, ?) AND e.is_canary = 0
+		GROUP BY ee.stage
 	`, string(StageCIPassed), string(StageCIFailed))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get lifetime CI run counters: %w", err)
@@ -2744,12 +2758,15 @@ func (s *Store) GetLifetimeCIRunCounters() (*LifetimeCIRunCounters, error) {
 // GROUP BY/MIN() aggregate) — the sqlite driver only recovers the DATETIME
 // declared-type for direct column reads; scanning an aggregate result into
 // time.Time fails, so ORDER BY + first-write-wins in Go stands in for MIN().
+// Joins against executions to exclude canary rows (GH-4240) from every
+// histogram derived off this helper (time-to-merge, time-to-PR, approval wait).
 func (s *Store) earliestStageOccurrences(stage Stage) (map[string]time.Time, error) {
 	rows, err := s.db.Query(`
-		SELECT execution_id, occurred_at
-		FROM execution_events
-		WHERE stage = ?
-		ORDER BY occurred_at ASC, id ASC
+		SELECT ee.execution_id, ee.occurred_at
+		FROM execution_events ee
+		JOIN executions e ON e.id = ee.execution_id
+		WHERE ee.stage = ? AND e.is_canary = 0
+		ORDER BY ee.occurred_at ASC, ee.id ASC
 	`, string(stage))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query %s stage occurrences: %w", stage, err)
@@ -2860,7 +2877,7 @@ func (s *Store) GetLifetimeQueueWait() ([]time.Duration, error) {
 	rows, err := s.db.Query(`
 		SELECT created_at, started_at
 		FROM executions
-		WHERE started_at IS NOT NULL
+		WHERE started_at IS NOT NULL AND is_canary = 0
 		ORDER BY started_at ASC
 	`)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `Canary bool` (`canary:` yaml key) to `ProjectConfig` marking a project as a synthetic sandbox (e.g. `pilot-canary-sandbox`, TASK-379 V8).
- Add an additive `executions.is_canary` column; the dispatcher marks it at execution-row creation (`queueSingleTask` / `queueDecomposedTask`) via a `SetCanaryResolver` hook wired from config in `main.go`.
- Exclude canary rows from `pilot_success_rate` / `pilot_issue_level_success_rate` / `pilot_issues_shipped_total` / `pilot_issues_attempted_total`, the metrics hydrator, throughput histogram hydration, `GetDailyMetrics`, and dashboard history (`GetRecentExecutions`, `GetLifetimeTokens`) — all filtered at the SQL layer.
- Gate the live in-memory `pilot_success_rate` counter via a new `Controller.WithCanary` option, so a canary project's own `*Metrics` never pollutes the fleet-wide `AggregateMetrics` used by `/metrics`.
- Ledger writes (`executions`, `execution_events`, `execution_logs`) are unaffected — canary executions are still fully persisted and event-logged.

Closes GH-4240.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./internal/config/... ./internal/memory/... ./internal/autopilot/... ./internal/executor/...`
- [x] `go test ./...` (full repo)
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New table-driven tests (flag on/off, same fixture) for: `ProjectConfig.Canary` YAML parsing, `SaveExecution`/`GetExecution` round-trip of `is_canary`, every touched store query (`GetIssueLevelCounts`, `GetLifetimeTaskCounts`, `GetLifetimeCounterBaselines`, `GetLifetimePRCountersFromExecutions`, `GetLifetimeTokens`, `GetRecentExecutions`, `GetDailyMetrics`, `GetLifetimeCIRunCounters`, `GetLifetimePRTimeToMerge`, `GetLifetimeTimeToPR`, `GetLifetimeQueueWait`, `GetLifetimeApprovalWait`), dispatcher exec-row marking (single + decomposed-parent), and `Controller.WithCanary` gating the live success-rate counter.