### PR TITLE
fix(dashboard,executor): hydrate monitor from DB on restart, create-on-progress, wire queue_depth gauge

### DIFF
--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -1808,6 +1808,15 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 		for _, ctrl := range autopilotControllers {
 			ctrl.SetMonitor(monitor)
 		}
+		// GH-4246: rebuild the monitor from queued/running DB rows before the
+		// dashboard's first refresh tick — otherwise a restart with active
+		// work in the DB leaves the queue panel blind until each task's own
+		// lifecycle happens to re-touch the monitor (queued tasks never do).
+		if store != nil {
+			if hydrateErr := monitor.HydrateFromStore(store); hydrateErr != nil {
+				logging.WithComponent("start").Warn("failed to hydrate monitor from store", slog.Any("error", hydrateErr))
+			}
+		}
 		upgradeRequestCh = make(chan struct{}, 1)
 		model := dashboard.NewModelWithOptions(version, store, autopilotController, upgradeRequestCh)
 		model.SetProjectPath(projectPath)
@@ -2753,6 +2762,18 @@ func runPollingMode(cmd *cobra.Command, cfg *config.Config, projectPath string, 
 					if monitor != nil {
 						tasks := convertTaskStatesToDisplay(monitor.GetAll())
 						program.Send(dashboard.UpdateTasks(tasks)())
+					}
+					// GH-4246: pilot_queue_depth had zero production callers and
+					// always read 0. Refresh it here from the DB queued/pending
+					// count on the same cadence as the task-list refresh.
+					// pilot_failed_queue_depth is intentionally left unwired —
+					// its documented semantics ("issues with pilot-failed label")
+					// are GitHub-issue-label state, not an executions-row status;
+					// the DB has no equivalent count to source it from correctly.
+					if store != nil && autopilotController != nil {
+						if depthErr := autopilot.RefreshQueueDepth(store, autopilotController.Metrics()); depthErr != nil {
+							logging.WithComponent("dashboard").Warn("failed to refresh queue depth gauge", slog.Any("error", depthErr))
+						}
 					}
 				}
 			}

--- a/internal/autopilot/metrics_queue_depth.go
+++ b/internal/autopilot/metrics_queue_depth.go
@@ -1,0 +1,24 @@
+package autopilot
+
+import (
+	"fmt"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// RefreshQueueDepth sets the pilot_queue_depth gauge from the store's
+// current queued/pending execution count (GH-4246). SetQueueDepth had zero
+// production callers before this — pilot_queue_depth read a constant 0
+// regardless of actual queue depth. Call periodically (the dashboard's 2s
+// refresh loop) so the gauge tracks the DB in near-real-time.
+func RefreshQueueDepth(store *memory.Store, metrics *Metrics) error {
+	if store == nil || metrics == nil {
+		return nil
+	}
+	n, err := store.CountQueuedTasks()
+	if err != nil {
+		return fmt.Errorf("refresh queue depth: %w", err)
+	}
+	metrics.SetQueueDepth(n)
+	return nil
+}

--- a/internal/autopilot/metrics_queue_depth_test.go
+++ b/internal/autopilot/metrics_queue_depth_test.go
@@ -1,0 +1,69 @@
+package autopilot
+
+import (
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestRefreshQueueDepth verifies the pilot_queue_depth gauge wiring (GH-4246):
+// SetQueueDepth had zero production callers, so the gauge always read 0
+// regardless of actual DB queue depth. RefreshQueueDepth must track the DB
+// queued/pending count and fall back to 0 once the queue drains.
+func TestRefreshQueueDepth(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	metrics := NewMetrics()
+
+	execs := []*memory.Execution{
+		{ID: "q-1", TaskID: "T1", ProjectPath: "/p", Status: "queued"},
+		{ID: "q-2", TaskID: "T2", ProjectPath: "/p", Status: "pending"},
+		{ID: "q-3", TaskID: "T3", ProjectPath: "/p", Status: "running"},
+	}
+	for _, e := range execs {
+		if err := store.SaveExecution(e); err != nil {
+			t.Fatalf("SaveExecution(%s): %v", e.ID, err)
+		}
+	}
+
+	if err := RefreshQueueDepth(store, metrics); err != nil {
+		t.Fatalf("RefreshQueueDepth failed: %v", err)
+	}
+	if snap := metrics.Snapshot(); snap.QueueDepth != 2 {
+		t.Errorf("Expected queue depth 2, got %d", snap.QueueDepth)
+	}
+
+	// Drain the queue and confirm the gauge returns to 0.
+	if err := store.UpdateExecutionStatus("q-1", "completed"); err != nil {
+		t.Fatalf("UpdateExecutionStatus: %v", err)
+	}
+	if err := store.UpdateExecutionStatus("q-2", "completed"); err != nil {
+		t.Fatalf("UpdateExecutionStatus: %v", err)
+	}
+	if err := RefreshQueueDepth(store, metrics); err != nil {
+		t.Fatalf("RefreshQueueDepth failed: %v", err)
+	}
+	if snap := metrics.Snapshot(); snap.QueueDepth != 0 {
+		t.Errorf("Expected queue depth 0 after drain, got %d", snap.QueueDepth)
+	}
+}
+
+func TestRefreshQueueDepthNilArgs(t *testing.T) {
+	if err := RefreshQueueDepth(nil, NewMetrics()); err != nil {
+		t.Errorf("RefreshQueueDepth(nil store) should be a no-op, got error: %v", err)
+	}
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	if err := RefreshQueueDepth(store, nil); err != nil {
+		t.Errorf("RefreshQueueDepth(nil metrics) should be a no-op, got error: %v", err)
+	}
+}

--- a/internal/executor/monitor.go
+++ b/internal/executor/monitor.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 // TaskStatus represents the status of a task
@@ -66,6 +68,58 @@ func (m *Monitor) Register(taskID, title, issueURL string) {
 	}
 }
 
+// Hydrate seeds a task's state directly from persisted data, bypassing the
+// normal Register→Queue/Start transition sequence. Used at startup to
+// reconstruct monitor state from DB rows after a restart (GH-4246) — plain
+// Register would leave every hydrated task stuck at "pending" and drop
+// StartedAt for already-running tasks.
+func (m *Monitor) Hydrate(taskID, title, issueURL string, status TaskStatus, startedAt *time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state := &TaskState{
+		ID:       taskID,
+		Title:    title,
+		IssueURL: issueURL,
+		Status:   status,
+	}
+	switch status {
+	case StatusRunning:
+		state.Phase = "Running"
+		state.StartedAt = startedAt
+	default:
+		state.Phase = "Queued"
+	}
+	m.tasks[taskID] = state
+}
+
+// HydrateFromStore seeds the monitor from the store's non-terminal execution
+// rows (see Hydrate and memory.Store.GetTasksForMonitorHydration). Call once
+// at startup, after both the monitor and store are constructed and before
+// the dashboard's first refresh tick, so a restart with queued or running
+// work in the DB doesn't leave the queue/progress view blind (GH-4246).
+func (m *Monitor) HydrateFromStore(store *memory.Store) error {
+	if store == nil {
+		return nil
+	}
+	tasks, err := store.GetTasksForMonitorHydration()
+	if err != nil {
+		return fmt.Errorf("hydrate monitor from store: %w", err)
+	}
+	for _, t := range tasks {
+		status := TaskStatus(t.Status)
+		if status == StatusPending {
+			status = StatusQueued
+		}
+		title := t.Title
+		if title == "" {
+			title = t.TaskID
+		}
+		m.Hydrate(t.TaskID, title, t.IssueURL, status, t.StartedAt)
+	}
+	return nil
+}
+
 // SetProjectInfo sets the project path and name for a task (GH-2167).
 func (m *Monitor) SetProjectInfo(taskID, projectPath, projectName string) {
 	m.mu.Lock()
@@ -104,19 +158,27 @@ func (m *Monitor) Start(taskID string) {
 
 // UpdateProgress updates task progress.
 // Progress is monotonic — never decreases (except reset to 0 on task start).
+// An unknown taskID creates a minimal running entry instead of dropping the
+// event (GH-4246): a progress event is proof the task is executing, and
+// silently discarding it is what made post-restart running tasks invisible
+// even though they were live — visible only in logs, never in the monitor.
 func (m *Monitor) UpdateProgress(taskID, phase string, progress int, message string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if state, ok := m.tasks[taskID]; ok {
-		state.Phase = phase
-		// Enforce monotonic progress (never go backwards)
-		if progress >= state.Progress {
-			state.Progress = progress
-		}
-		if message != "" {
-			state.Message = message
-		}
+	state, ok := m.tasks[taskID]
+	if !ok {
+		state = &TaskState{ID: taskID, Title: taskID, Status: StatusRunning}
+		m.tasks[taskID] = state
+	}
+
+	state.Phase = phase
+	// Enforce monotonic progress (never go backwards)
+	if progress >= state.Progress {
+		state.Progress = progress
+	}
+	if message != "" {
+		state.Message = message
 	}
 }
 

--- a/internal/executor/monitor_test.go
+++ b/internal/executor/monitor_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
 )
 
 func TestNewMonitor(t *testing.T) {
@@ -232,9 +234,9 @@ func TestMonitorGetNonexistent(t *testing.T) {
 func TestMonitorOperationsOnNonexistent(t *testing.T) {
 	monitor := NewMonitor()
 
-	// These should not panic on nonexistent tasks
+	// These should not panic on nonexistent tasks, and stay no-ops (unlike
+	// UpdateProgress, see TestMonitorUpdateProgressCreatesUnknownTask).
 	monitor.Start("nonexistent")
-	monitor.UpdateProgress("nonexistent", "Phase", 50, "Message")
 	monitor.Complete("nonexistent", "url")
 	monitor.Fail("nonexistent", "error")
 	monitor.Cancel("nonexistent")
@@ -243,6 +245,36 @@ func TestMonitorOperationsOnNonexistent(t *testing.T) {
 	// Count should still be 0
 	if monitor.Count() != 0 {
 		t.Errorf("Count should be 0, got %d", monitor.Count())
+	}
+}
+
+// GH-4246: a progress event for a taskID the monitor has never seen (e.g. a
+// hydration race, or a task whose Register call was lost across a restart)
+// must create the entry rather than silently drop the event — this was the
+// live-view half of the "queue panel blind after restart" defect.
+func TestMonitorUpdateProgressCreatesUnknownTask(t *testing.T) {
+	monitor := NewMonitor()
+
+	monitor.UpdateProgress("unknown-task", "IMPL", 42, "Working...")
+
+	state, ok := monitor.Get("unknown-task")
+	if !ok {
+		t.Fatal("UpdateProgress should create an entry for an unknown taskID")
+	}
+	if state.Status != StatusRunning {
+		t.Errorf("Expected status running for auto-created entry, got %s", state.Status)
+	}
+	if state.Phase != "IMPL" {
+		t.Errorf("Expected phase 'IMPL', got '%s'", state.Phase)
+	}
+	if state.Progress != 42 {
+		t.Errorf("Expected progress 42, got %d", state.Progress)
+	}
+	if state.Message != "Working..." {
+		t.Errorf("Expected message 'Working...', got '%s'", state.Message)
+	}
+	if monitor.Count() != 1 {
+		t.Errorf("Expected count 1 after auto-create, got %d", monitor.Count())
 	}
 }
 
@@ -456,4 +488,103 @@ func TestMonitorSetProjectInfo_NonExistent(t *testing.T) {
 	m := NewMonitor()
 	// Should not panic on non-existent task
 	m.SetProjectInfo("GH-999", "/tmp/foo", "foo")
+}
+
+// GH-4246: Hydrate reconstructs a task's state directly (bypassing
+// Register→Queue/Start), preserving StartedAt for running tasks so
+// duration display survives a restart.
+func TestMonitorHydrate(t *testing.T) {
+	startedAt := time.Now().Add(-5 * time.Minute)
+
+	m := NewMonitor()
+	m.Hydrate("GH-1", "Queued task", "1", StatusQueued, nil)
+	m.Hydrate("GH-2", "Running task", "2", StatusRunning, &startedAt)
+
+	queued, ok := m.Get("GH-1")
+	if !ok {
+		t.Fatal("GH-1 not found after hydrate")
+	}
+	if queued.Status != StatusQueued {
+		t.Errorf("Expected status queued, got %s", queued.Status)
+	}
+	if queued.Phase != "Queued" {
+		t.Errorf("Expected phase 'Queued', got '%s'", queued.Phase)
+	}
+
+	running, ok := m.Get("GH-2")
+	if !ok {
+		t.Fatal("GH-2 not found after hydrate")
+	}
+	if running.Status != StatusRunning {
+		t.Errorf("Expected status running, got %s", running.Status)
+	}
+	if running.StartedAt == nil || !running.StartedAt.Equal(startedAt) {
+		t.Errorf("Expected StartedAt %v, got %v", startedAt, running.StartedAt)
+	}
+}
+
+// GH-4246: HydrateFromStore seeds the monitor from queued/pending/running DB
+// rows in one call — a daemon restart with active work in the DB must
+// produce a monitor whose GetAll() reflects it within one refresh tick,
+// without waiting for each task's own lifecycle to re-touch the monitor.
+func TestMonitorHydrateFromStore(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	execs := []*memory.Execution{
+		{ID: "e1", TaskID: "GH-10", ProjectPath: "/p", Status: "queued", TaskTitle: "Queued task", TaskSourceIssueID: "10"},
+		{ID: "e2", TaskID: "GH-11", ProjectPath: "/p", Status: "running", TaskTitle: "Running task", TaskSourceIssueID: "11"},
+		{ID: "e3", TaskID: "GH-12", ProjectPath: "/p", Status: "completed", TaskTitle: "Done task"},
+	}
+	for _, e := range execs {
+		if err := store.SaveExecution(e); err != nil {
+			t.Fatalf("SaveExecution(%s): %v", e.ID, err)
+		}
+	}
+	if err := store.UpdateExecutionStatus("e2", "running"); err != nil {
+		t.Fatalf("UpdateExecutionStatus: %v", err)
+	}
+
+	m := NewMonitor()
+	if err := m.HydrateFromStore(store); err != nil {
+		t.Fatalf("HydrateFromStore failed: %v", err)
+	}
+
+	all := m.GetAll()
+	if len(all) != 2 {
+		t.Fatalf("Expected 2 hydrated tasks (queued+running), got %d", len(all))
+	}
+
+	queued, ok := m.Get("GH-10")
+	if !ok {
+		t.Fatal("GH-10 not hydrated")
+	}
+	if queued.Status != StatusQueued || queued.Title != "Queued task" {
+		t.Errorf("Unexpected GH-10 state: %+v", queued)
+	}
+
+	running, ok := m.Get("GH-11")
+	if !ok {
+		t.Fatal("GH-11 not hydrated")
+	}
+	if running.Status != StatusRunning {
+		t.Errorf("Expected GH-11 status running, got %s", running.Status)
+	}
+	if running.StartedAt == nil {
+		t.Error("Expected GH-11 StartedAt to be set")
+	}
+
+	if _, ok := m.Get("GH-12"); ok {
+		t.Error("Completed task GH-12 should not be hydrated")
+	}
+}
+
+func TestMonitorHydrateFromStoreNilStore(t *testing.T) {
+	m := NewMonitor()
+	if err := m.HydrateFromStore(nil); err != nil {
+		t.Errorf("HydrateFromStore(nil) should be a no-op, got error: %v", err)
+	}
+	if m.Count() != 0 {
+		t.Errorf("Expected count 0, got %d", m.Count())
+	}
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1871,6 +1871,59 @@ func (s *Store) GetQueuedProjectPaths() ([]string, error) {
 	return paths, rows.Err()
 }
 
+// HydrationTask is a minimal projection of a non-terminal executions row,
+// just enough to reconstruct executor.Monitor state after a daemon restart
+// (GH-4246). See GetTasksForMonitorHydration.
+type HydrationTask struct {
+	TaskID    string
+	Status    string // "queued" | "pending" | "running"
+	Title     string
+	IssueURL  string
+	StartedAt *time.Time
+}
+
+// GetTasksForMonitorHydration returns queued/pending/running executions
+// across all projects, ordered oldest-first. The executor.Monitor is
+// otherwise populated only at dispatch-intake time (the sole Register
+// caller is cmd/pilot/handler_common.go), so a daemon restart wipes it even
+// though these rows are still active in the DB — this backs the startup
+// hydration that rebuilds the monitor from persisted state (GH-4246).
+func (s *Store) GetTasksForMonitorHydration() ([]*HydrationTask, error) {
+	rows, err := s.db.Query(`
+		SELECT task_id, status, COALESCE(task_title, ''), COALESCE(task_source_issue_id, ''), started_at
+		FROM executions
+		WHERE status IN ('queued', 'pending', 'running')
+		ORDER BY created_at ASC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tasks []*HydrationTask
+	for rows.Next() {
+		var t HydrationTask
+		var startedAt sql.NullTime
+		if err := rows.Scan(&t.TaskID, &t.Status, &t.Title, &t.IssueURL, &startedAt); err != nil {
+			return nil, err
+		}
+		if startedAt.Valid {
+			t.StartedAt = &startedAt.Time
+		}
+		tasks = append(tasks, &t)
+	}
+	return tasks, rows.Err()
+}
+
+// CountQueuedTasks returns the number of queued/pending execution rows — the
+// DB-backed source for the pilot_queue_depth gauge (GH-4246). A cheap COUNT
+// query, safe to call from a frequent (e.g. 2s) dashboard refresh loop.
+func (s *Store) CountQueuedTasks() (int, error) {
+	var n int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM executions WHERE status = 'queued' OR status = 'pending'`).Scan(&n)
+	return n, err
+}
+
 // DeleteExecution removes an execution row by ID. Used to clean up orphan rows
 // when the same task already has a completed execution.
 func (s *Store) DeleteExecution(id string) error {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -985,6 +985,117 @@ func TestGetQueuedTasks(t *testing.T) {
 	}
 }
 
+// TestGetTasksForMonitorHydration verifies the executor.Monitor restart-hydration
+// source (GH-4246): queued/pending/running rows come back with title/issue-id
+// metadata, running rows carry StartedAt, and terminal rows are excluded.
+func TestGetTasksForMonitorHydration(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	executions := []*Execution{
+		{ID: "1", TaskID: "GH-1", ProjectPath: "/p", Status: "queued", TaskTitle: "Queued task", TaskSourceIssueID: "1"},
+		{ID: "2", TaskID: "GH-2", ProjectPath: "/p", Status: "pending", TaskTitle: "Pending task", TaskSourceIssueID: "2"},
+		{ID: "3", TaskID: "GH-3", ProjectPath: "/p", Status: "running", TaskTitle: "Running task", TaskSourceIssueID: "3"},
+		{ID: "4", TaskID: "GH-4", ProjectPath: "/p", Status: "completed", TaskTitle: "Done task"},
+	}
+	for _, e := range executions {
+		if err := store.SaveExecution(e); err != nil {
+			t.Fatalf("SaveExecution(%s): %v", e.ID, err)
+		}
+	}
+	// Stamp started_at on the running row, mirroring the live UpdateExecutionStatus path.
+	if err := store.UpdateExecutionStatus("3", "running"); err != nil {
+		t.Fatalf("UpdateExecutionStatus: %v", err)
+	}
+
+	tasks, err := store.GetTasksForMonitorHydration()
+	if err != nil {
+		t.Fatalf("GetTasksForMonitorHydration failed: %v", err)
+	}
+	if len(tasks) != 3 {
+		t.Fatalf("Expected 3 non-terminal tasks, got %d", len(tasks))
+	}
+
+	byID := make(map[string]*HydrationTask)
+	for _, task := range tasks {
+		byID[task.TaskID] = task
+	}
+	if byID["GH-4"] != nil {
+		t.Error("Completed task should not be included in hydration set")
+	}
+	running, ok := byID["GH-3"]
+	if !ok {
+		t.Fatal("Running task GH-3 missing from hydration set")
+	}
+	if running.Title != "Running task" || running.IssueURL != "3" {
+		t.Errorf("Unexpected metadata for GH-3: title=%q issueURL=%q", running.Title, running.IssueURL)
+	}
+	if running.StartedAt == nil {
+		t.Error("Running task should carry a non-nil StartedAt")
+	}
+	queued, ok := byID["GH-1"]
+	if !ok {
+		t.Fatal("Queued task GH-1 missing from hydration set")
+	}
+	if queued.Status != "queued" {
+		t.Errorf("Expected status 'queued', got %q", queued.Status)
+	}
+}
+
+func TestCountQueuedTasks(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	n, err := store.CountQueuedTasks()
+	if err != nil {
+		t.Fatalf("CountQueuedTasks failed: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Expected 0 with empty store, got %d", n)
+	}
+
+	executions := []*Execution{
+		{ID: "1", TaskID: "T1", ProjectPath: "/p", Status: "queued"},
+		{ID: "2", TaskID: "T2", ProjectPath: "/p", Status: "pending"},
+		{ID: "3", TaskID: "T3", ProjectPath: "/p", Status: "running"},
+		{ID: "4", TaskID: "T4", ProjectPath: "/p", Status: "completed"},
+	}
+	for _, e := range executions {
+		if err := store.SaveExecution(e); err != nil {
+			t.Fatalf("SaveExecution(%s): %v", e.ID, err)
+		}
+	}
+
+	n, err = store.CountQueuedTasks()
+	if err != nil {
+		t.Fatalf("CountQueuedTasks failed: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("Expected 2 queued/pending, got %d", n)
+	}
+
+	// Drain the queue and confirm the count returns to 0.
+	if err := store.UpdateExecutionStatus("1", "completed"); err != nil {
+		t.Fatalf("UpdateExecutionStatus: %v", err)
+	}
+	if err := store.UpdateExecutionStatus("2", "completed"); err != nil {
+		t.Fatalf("UpdateExecutionStatus: %v", err)
+	}
+	n, err = store.CountQueuedTasks()
+	if err != nil {
+		t.Fatalf("CountQueuedTasks failed: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Expected 0 after draining queue, got %d", n)
+	}
+}
+
 // TestTaskLabelsRoundTrip verifies that Task.Labels survive the queue round-trip
 // (SaveExecution → GetExecution and GetQueuedTasksForProject). Without this, labels
 // like "no-decompose" are silently dropped and runner-side gates bypassed (GH-2326).


### PR DESCRIPTION
## Summary

Closes GH-4246. Live repro 2026-07-12 ~23:20: daemon restarted with 1 running + 2 queued executions in the DB, but the dashboard queue panel showed 1 of 1, and the running task's progress bars stayed frozen while logs showed live progress. `pilot_queue_depth` read 0 throughout.

Root causes fixed:

- **`executor.Monitor` wiped on restart**: the monitor is populated only at dispatch-intake (`cmd/pilot/handler_common.go:91`, the sole `Register` caller). A restart never re-registers rows resumed from the DB. Fix: `Monitor.HydrateFromStore` seeds the monitor from queued/pending/running `executions` rows at startup, before the dashboard's first 2s refresh tick.
- **`UpdateProgress` silently dropped events for unregistered tasks**: post-restart, the running task's progress evaporated from the monitor entirely. Fix: `UpdateProgress` now creates a minimal entry for an unknown taskID instead of dropping the event.
- **`pilot_queue_depth` dead gauge**: `Metrics.SetQueueDepth` had zero production callers, so the gauge always read 0. Fix: `autopilot.RefreshQueueDepth` sources the count from `Store.CountQueuedTasks()` and is called from the same 2s dashboard refresh loop. `pilot_failed_queue_depth` is left unwired — its documented semantics ("issues with `pilot-failed` label") are GitHub-issue-label state with no DB equivalent to source correctly.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/executor/... ./internal/autopilot/... ./cmd/pilot/... ./internal/memory/...` — all green
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] New unit tests: `Monitor.Hydrate`, `Monitor.HydrateFromStore` (queued+running seeded, restored via `GetAll()`), `UpdateProgress` create-on-unknown-taskID, `Store.GetTasksForMonitorHydration`, `Store.CountQueuedTasks` (drains to 0), `autopilot.RefreshQueueDepth` (via `Metrics.Snapshot()`)