### PR TITLE
feat(canary): epic-lifecycle scenario — assert decomposition, sibling, and close-out invariants (GH-4242)

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -26,7 +26,6 @@
 | Dry run mode | ✅ | executor | `--dry-run` | - | Show prompt only |
 | Verbose output | ✅ | executor | `--verbose` | - | Stream raw JSON |
 | Task dispatcher | ✅ | executor | - | - | Per-project queue (GH-46) |
-| Execution lifecycle chokepoint | ✅ | executor | - | - | `ExecutionLifecycle.Begin/Transition/Finish` replaces hand-rolled `SaveExecution`/status-update call sites in dispatcher/epic/CLI paths (GH-4243, v2.238.2) |
 | Sequential execution | ✅ | executor | `--sequential` | `orchestrator.execution.mode` | Wait for PR merge before next issue |
 | Self-review | ✅ | executor | - | - | Auto code review before PR push (v0.13.0) |
 | Auto build gate | ✅ | executor | - | - | Minimal build gate when none configured (v0.13.0) |
@@ -424,6 +423,7 @@
 | Conventional sub-issue titles | ✅ | executor | - | - | CC-format enforced on subtask titles: re-prompt → Approach B fallback → creation guard (GH-2494) |
 | Sub-issue dedup guard | ✅ | executor | - | - | CreateSubIssues skips if open children referencing parent already exist (GH-2494) |
 | createPilotIssue chokepoint | ✅ | adapters/github, autopilot | - | - | All Pilot-internal issue creation validated through CreatePilotIssue CC gate (GH-2494) |
+| Epic-lifecycle synthetic canary | ✅ | .github/workflows, scripts | `workflow_dispatch` (scenario `epic-lifecycle`) | - | GH Actions scenario files a deliberately decomposable epic on the sandbox and asserts 5 invariants (≥2 children, no duplicate merged PR per child, parent auto-close, no stale `pilot-needs-clarification`, no cascade beyond direct children) via `canary-poll.sh --assert n-children-merged` (TASK-403 A3, GH-4242) |
 
 ## Test Coverage
 

--- a/.github/workflows/pilot-canary-scenario.yml
+++ b/.github/workflows/pilot-canary-scenario.yml
@@ -124,10 +124,17 @@ jobs:
           ISSUE_NUMBER="${{ steps.file_issue.outputs.issue_number }}"
           STATE=$(gh issue view "$ISSUE_NUMBER" --repo "${{ inputs.sandbox_repo }}" --json state --jq '.state')
 
+          PR_NUMBER="${{ steps.poll.outputs.pr_number }}"
+          if [ -n "$PR_NUMBER" ]; then
+            COMMENT="Canary PR #$PR_NUMBER merged — pipeline verified end-to-end (scenario: ${{ inputs.scenario_name }})."
+          else
+            COMMENT="Canary verified end-to-end — all terminal assertions passed (scenario: ${{ inputs.scenario_name }})."
+          fi
+
           if [ "$STATE" = "OPEN" ]; then
             gh issue close "$ISSUE_NUMBER" \
               --repo "${{ inputs.sandbox_repo }}" \
-              --comment "Canary PR #${{ steps.poll.outputs.pr_number }} merged — pipeline verified end-to-end (scenario: ${{ inputs.scenario_name }})."
+              --comment "$COMMENT"
           else
             echo "Canary issue already closed (auto-closed by merge)."
           fi
@@ -142,6 +149,13 @@ jobs:
           TITLE="[canary:${{ inputs.scenario_name }}] pipeline stall"
           STAGE="${{ steps.poll.outputs.stage || 'issue-filed' }}"
           ISSUE_NUMBER="${{ steps.file_issue.outputs.issue_number }}"
+          FAILED_ASSERTIONS="${{ steps.poll.outputs.failed_assertions }}"
+
+          if [ -n "$FAILED_ASSERTIONS" ]; then
+            DETAIL="stalled at stage \`$STAGE\` -- failed assertion(s): \`$FAILED_ASSERTIONS\`"
+          else
+            DETAIL="stalled at stage \`$STAGE\`"
+          fi
 
           EXISTING=$(gh issue list \
             --repo "${{ inputs.alert_repo }}" \
@@ -154,12 +168,12 @@ jobs:
             echo "Alert issue #$EXISTING already open — adding status comment."
             gh issue comment "$EXISTING" \
               --repo "${{ inputs.alert_repo }}" \
-              --body "Canary re-triggered $(date -u '+%Y-%m-%d %H:%M UTC'): stalled at stage \`$STAGE\` (canary issue ${{ inputs.sandbox_repo }}#$ISSUE_NUMBER, scenario \`${{ inputs.scenario_name }}\`)."
+              --body "Canary re-triggered $(date -u '+%Y-%m-%d %H:%M UTC'): $DETAIL (canary issue ${{ inputs.sandbox_repo }}#$ISSUE_NUMBER, scenario \`${{ inputs.scenario_name }}\`)."
           else
             echo "Creating new alert issue."
             gh issue create \
               --repo "${{ inputs.alert_repo }}" \
               --title "$TITLE" \
               --label bug \
-              --body "Synthetic end-to-end pipeline canary stalled at stage \`$STAGE\` (scenario \`${{ inputs.scenario_name }}\`). Canary issue: ${{ inputs.sandbox_repo }}#$ISSUE_NUMBER. Investigate daemon health (poll -> spec -> execute -> PR -> merge). See TASK-403."
+              --body "Synthetic end-to-end pipeline canary $DETAIL (scenario \`${{ inputs.scenario_name }}\`). Canary issue: ${{ inputs.sandbox_repo }}#$ISSUE_NUMBER. Investigate daemon health (poll -> spec -> execute -> PR -> merge). See TASK-403."
           fi

--- a/.github/workflows/pilot-canary.yml
+++ b/.github/workflows/pilot-canary.yml
@@ -66,27 +66,69 @@ jobs:
 
         Edit the `const Version` line in `version.go`. Nothing else.
 
-  # Stub scenario (commented out, not a live job) proving the abstraction
-  # scales to a second, independently scoped scenario -- epic-lifecycle
-  # coverage, TASK-403 A3. It demonstrates a second scenario is added as a
-  # plain job, with its own labels (canary-scenario-epic-lifecycle) and
-  # alert title ([canary:epic-lifecycle] pipeline stall), without touching
-  # the version-bump job, the reusable workflow, or
-  # scripts/canary-poll.sh. TASK-403 A3 will flesh out the real issue
-  # template and implement the `n-children-merged` assert mode in
-  # scripts/canary-poll.sh, then uncomment (and un-stub) a job like this.
-  #
-  # epic-lifecycle-stub:
-  #   uses: ./.github/workflows/pilot-canary-scenario.yml
-  #   secrets:
-  #     canary_gh_token: ${{ secrets.CANARY_GH_TOKEN }}
-  #   with:
-  #     scenario_name: epic-lifecycle
-  #     sandbox_repo: qf-studio/pilot-canary-sandbox
-  #     alert_repo: qf-studio/pilot
-  #     assert_mode: n-children-merged
-  #     timeout_minutes: 35
-  #     poll_interval_seconds: 60
-  #     issue_title: "chore(epic): canary epic-lifecycle scenario (TASK-403 A3)"
-  #     issue_body: |
-  #       Epic-lifecycle scenario body -- see TASK-403 A3.
+  # Epic-lifecycle scenario (TASK-403 A3): proves the deployed daemon
+  # decomposes an epic into independent children, ships each child through
+  # its own merged PR, and closes the parent clean -- the defect classes
+  # that escaped to production in July (TASK-394/395/401/402). Scoped
+  # independently of version-bump via its own label
+  # (canary-scenario-epic-lifecycle) and alert title
+  # ([canary:epic-lifecycle] pipeline stall); does not touch the
+  # version-bump job, the reusable workflow, or scripts/canary-poll.sh's
+  # `merged` mode.
+  epic-lifecycle:
+    uses: ./.github/workflows/pilot-canary-scenario.yml
+    secrets:
+      canary_gh_token: ${{ secrets.CANARY_GH_TOKEN }}
+    with:
+      scenario_name: epic-lifecycle
+      sandbox_repo: qf-studio/pilot-canary-sandbox
+      alert_repo: qf-studio/pilot
+      assert_mode: n-children-merged
+      # Epic runs (decompose -> N children -> N PRs -> merge -> parent
+      # close) take longer than a direct version-bump run, so this timeout
+      # is independent of (and larger than) the version-bump job's 35m.
+      timeout_minutes: 90
+      poll_interval_seconds: 60
+      issue_title: "chore(canary): [epic] epic-lifecycle scenario probe"
+      issue_body: |
+        ## Context
+
+        Synthetic canary run (TASK-403 A3, scenario `epic-lifecycle`). This
+        issue exists to prove the deployed Pilot daemon correctly
+        decomposes an epic into independent child issues, ships each child
+        through its own PR, and closes the parent cleanly -- the
+        epic-lifecycle defect classes that escaped to production in July
+        (TASK-394 FK-787 ledger failures, TASK-395 stale
+        pilot-needs-clarification, TASK-401 single-child collapse, TASK-402
+        sibling duplicate PRs).
+
+        This epic has exactly two independent work items against two
+        different files. Decompose it into two separate child issues, one
+        per item below -- do not fold them into a single child, and do not
+        further decompose either child once created.
+
+        ## Acceptance
+
+        - [ ] Subtask 1 (version bump): read the current PATCH component of
+              the `Version` constant in `version.go` and increment it by
+              exactly one (current+1). Do not assume a starting value --
+              derive the target from what is in the file. Change only that
+              single line so `version_test.go` (semver guard) stays green.
+              Touches `version.go` only.
+        - [ ] Subtask 2 (changelog entry): append one dated line to
+              `CHANGELOG-CANARY.md` recording today's date and this canary
+              run (create the file with a single `# Canary Changelog`
+              heading first if it does not exist yet). Touches
+              `CHANGELOG-CANARY.md` only. Depends on: Subtask 1 -- this
+              subtask's own child issue must carry an explicit
+              `Depends on:` back-reference to Subtask 1's child issue, and
+              should not start until Subtask 1's PR has landed.
+
+        ## Implementation
+
+        Two subtasks, two files, no shared code path:
+
+        1. `version.go` -- bump the PATCH component only.
+        2. `CHANGELOG-CANARY.md` -- append a dated line after Subtask 1
+           lands; state the `Depends on: #<subtask-1-issue>` reference in
+           this subtask's own child issue body.

--- a/scripts/canary-poll.sh
+++ b/scripts/canary-poll.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 # Poll a sandbox repo for a canary issue's pipeline progression and assert
-# it reaches the expected terminal condition (TASK-403 A2).
+# it reaches the expected terminal condition (TASK-403 A2/A3).
 #
-# Contract: callers select a terminal condition via --assert. Today only
-# `merged` (single issue -> single PR -> merged) is implemented. The flag
-# is designed so a future condition such as `n-children-merged` (epic
-# scenario, TASK-403 A3) can be added as a new case below without changing
-# this script's flags or any caller's invocation of the `merged` mode.
+# Contract: callers select a terminal condition via --assert.
+#   merged             -- single issue -> single PR -> merged (TASK-403 A2)
+#   n-children-merged  -- epic-lifecycle: parent decomposes into child
+#                         issues, each child ships its own merged PR, then
+#                         the parent auto-closes clean (TASK-403 A3)
 #
 # Usage:
 #   canary-poll.sh --repo OWNER/NAME --issue N \
 #     --timeout-minutes M --poll-interval-seconds S \
-#     --assert merged [--branch-prefix PREFIX]
+#     --assert merged|n-children-merged [--branch-prefix PREFIX]
 #
 # Requires: gh, jq. Writes stage/pr_number/result to $GITHUB_OUTPUT if set;
 # exits non-zero when the terminal condition is not reached in time.
@@ -64,72 +64,253 @@ if [ -z "$REPO" ] || [ -z "$ISSUE_NUMBER" ] || [ -z "$TIMEOUT_MINUTES" ] || [ -z
 fi
 
 case "$ASSERT_MODE" in
-  merged)
-    ;;
-  n-children-merged)
-    echo "canary-poll.sh: --assert n-children-merged is reserved but not yet implemented (see TASK-403 A3)" >&2
-    exit 2
-    ;;
+  merged) ;;
+  n-children-merged) ;;
   *)
-    echo "canary-poll.sh: unsupported --assert mode '$ASSERT_MODE' (supported: merged)" >&2
+    echo "canary-poll.sh: unsupported --assert mode '$ASSERT_MODE' (supported: merged, n-children-merged)" >&2
     exit 2
     ;;
 esac
 
 DEADLINE=$(( $(date -u +%s) + TIMEOUT_MINUTES * 60 ))
-STAGE="issue-filed"
-PR_NUMBER=""
-RESULT="failure"
 
-while [ "$(date -u +%s)" -lt "$DEADLINE" ]; do
-  if [ -z "$PR_NUMBER" ]; then
-    # Pilot branches follow `pilot/GH-<issue-number>` (project convention);
-    # fall back to a body reference in case the branch-naming convention
-    # drifts.
-    PR_NUMBER=$(gh pr list \
-      --repo "$REPO" \
-      --state all \
-      --json number,headRefName,body \
-      | jq -r --arg n "$ISSUE_NUMBER" --arg prefix "$BRANCH_PREFIX" \
-        '[.[] | select(.headRefName == ($prefix + $n) or ((.body // "") | test("#" + $n)))][0].number // empty')
+write_outputs() {
+  # write_outputs writes NAME=VALUE pairs (one per remaining arg, already
+  # "name=value" formatted) to $GITHUB_OUTPUT when running under Actions.
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    for pair in "$@"; do
+      echo "$pair" >> "$GITHUB_OUTPUT"
+    done
+  fi
+}
 
-    if [ -n "$PR_NUMBER" ]; then
-      STAGE="PR-opened"
-      echo "Found PR #$PR_NUMBER referencing canary issue #$ISSUE_NUMBER."
+join_by() {
+  # join_by , a b c -> "a,b,c"
+  local sep="$1"
+  shift
+  local IFS="$sep"
+  echo "$*"
+}
+
+if [ "$ASSERT_MODE" = "merged" ]; then
+  STAGE="issue-filed"
+  PR_NUMBER=""
+  RESULT="failure"
+
+  while [ "$(date -u +%s)" -lt "$DEADLINE" ]; do
+    if [ -z "$PR_NUMBER" ]; then
+      # Pilot branches follow `pilot/GH-<issue-number>` (project convention);
+      # fall back to a body reference in case the branch-naming convention
+      # drifts.
+      PR_NUMBER=$(gh pr list \
+        --repo "$REPO" \
+        --state all \
+        --json number,headRefName,body \
+        | jq -r --arg n "$ISSUE_NUMBER" --arg prefix "$BRANCH_PREFIX" \
+          '[.[] | select(.headRefName == ($prefix + $n) or ((.body // "") | test("#" + $n)))][0].number // empty')
+
+      if [ -n "$PR_NUMBER" ]; then
+        STAGE="PR-opened"
+        echo "Found PR #$PR_NUMBER referencing canary issue #$ISSUE_NUMBER."
+      fi
+    else
+      PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state,mergedAt)
+      PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
+      MERGED_AT=$(echo "$PR_JSON" | jq -r '.mergedAt')
+
+      if [ "$PR_STATE" = "MERGED" ] && [ "$MERGED_AT" != "null" ]; then
+        STAGE="merged"
+        RESULT="success"
+        break
+      elif [ "$PR_STATE" = "CLOSED" ]; then
+        STAGE="merge-stalled"
+        echo "PR #$PR_NUMBER was closed without merging."
+        break
+      fi
     fi
-  else
-    PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state,mergedAt)
-    PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
-    MERGED_AT=$(echo "$PR_JSON" | jq -r '.mergedAt')
 
-    if [ "$PR_STATE" = "MERGED" ] && [ "$MERGED_AT" != "null" ]; then
-      STAGE="merged"
-      RESULT="success"
-      break
-    elif [ "$PR_STATE" = "CLOSED" ]; then
-      STAGE="merge-stalled"
-      echo "PR #$PR_NUMBER was closed without merging."
-      break
-    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+
+  if [ "$RESULT" != "success" ] && [ "$STAGE" != "merge-stalled" ] && [ -n "$PR_NUMBER" ]; then
+    STAGE="merge-stalled"
   fi
 
+  echo "Final stage: $STAGE (result: $RESULT)"
+
+  write_outputs "stage=$STAGE" "pr_number=$PR_NUMBER" "result=$RESULT"
+
+  if [ "$RESULT" != "success" ]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+# --- n-children-merged: epic-lifecycle terminal condition (TASK-403 A3) ---
+#
+# Children are discovered the same way the executor itself resolves
+# parent/child links (internal/executor/epic.go queryRecentSubIssues,
+# internal/adapters/github/grouping.go ParseParentIssueNumber): every
+# sub-issue body carries a stamped "Parent: GH-<N>" line, searchable via
+# GitHub's body search rather than paging every pilot-labeled issue.
+
+find_children() {
+  local parent_num="$1"
+  gh issue list \
+    --repo "$REPO" \
+    --state all \
+    --search "\"Parent: GH-${parent_num}\" in:body" \
+    --json number \
+    --limit 100 \
+    --jq '.[].number' 2>/dev/null
+}
+
+# Wait for the parent to reach a terminal (closed) state, or time out.
+while [ "$(date -u +%s)" -lt "$DEADLINE" ]; do
+  PARENT_STATE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json state --jq '.state' 2>/dev/null)
+  if [ "$PARENT_STATE" = "CLOSED" ]; then
+    break
+  fi
   sleep "$POLL_INTERVAL_SECONDS"
 done
 
-if [ "$RESULT" != "success" ] && [ "$STAGE" != "merge-stalled" ] && [ -n "$PR_NUMBER" ]; then
-  STAGE="merge-stalled"
+PARENT_JSON=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json state,labels)
+PARENT_STATE=$(echo "$PARENT_JSON" | jq -r '.state')
+PARENT_LABELS=$(echo "$PARENT_JSON" | jq -r '[.labels[].name] | join(",")')
+
+contains() {
+  # contains NEEDLE HAYSTACK... -- avoids associative arrays (bash 3.2
+  # compatible, matching macOS's default /bin/bash as well as CI's bash 5).
+  local needle="$1"
+  shift
+  for item in "$@"; do
+    [ "$item" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+# Direct children: issues whose body names this issue as Parent.
+DIRECT_CHILDREN=()
+while IFS= read -r n; do
+  [ -z "$n" ] && continue
+  DIRECT_CHILDREN+=("$n")
+done < <(find_children "$ISSUE_NUMBER")
+
+# Cascade check: BFS beyond the direct level. Any issue reachable only via
+# a child (grandchild+) is an over-decomposition regression -- direct
+# children are expected to execute, not decompose further.
+#
+# Every array expansion below is guarded by a length check first: bash
+# before 4.4 (still macOS's default /bin/bash) treats "${arr[@]}" on a
+# zero-length array as an unbound-variable error under `set -u`.
+ALL_SEEN=()
+CASCADE_CHILDREN=()
+FRONTIER=()
+if [ "${#DIRECT_CHILDREN[@]}" -gt 0 ]; then
+  ALL_SEEN=("${DIRECT_CHILDREN[@]}")
+  FRONTIER=("${DIRECT_CHILDREN[@]}")
+fi
+while [ "${#FRONTIER[@]}" -gt 0 ]; do
+  NEXT=()
+  for n in "${FRONTIER[@]}"; do
+    while IFS= read -r kid; do
+      [ -z "$kid" ] && continue
+      if ! contains "$kid" "${ALL_SEEN[@]}"; then
+        ALL_SEEN+=("$kid")
+        CASCADE_CHILDREN+=("$kid")
+        NEXT+=("$kid")
+      fi
+    done < <(find_children "$n")
+  done
+  FRONTIER=()
+  if [ "${#NEXT[@]}" -gt 0 ]; then
+    FRONTIER=("${NEXT[@]}")
+  fi
+done
+
+PR_LIST_JSON=$(gh pr list --repo "$REPO" --state all --json number,headRefName,body,mergedAt --limit 100)
+
+UNMERGED_CHILDREN=()
+DUPLICATE_CHILDREN=()
+if [ "${#DIRECT_CHILDREN[@]}" -gt 0 ]; then
+  for child in "${DIRECT_CHILDREN[@]}"; do
+    MERGED_COUNT=$(echo "$PR_LIST_JSON" | jq --arg n "$child" --arg prefix "$BRANCH_PREFIX" \
+      '[.[] | select((.headRefName == ($prefix + $n)) or ((.body // "") | test("#" + $n + "(\\D|$)"))) | select(.mergedAt != null)] | length')
+    if [ "$MERGED_COUNT" -eq 0 ]; then
+      UNMERGED_CHILDREN+=("$child")
+    elif [ "$MERGED_COUNT" -gt 1 ]; then
+      DUPLICATE_CHILDREN+=("$child")
+    fi
+  done
+fi
+
+FAILED=()
+
+CHILD_COUNT=${#DIRECT_CHILDREN[@]}
+if [ "$CHILD_COUNT" -ge 2 ]; then
+  echo "[PASS] child-count: $CHILD_COUNT child issue(s) created (>= 2)"
+else
+  echo "[FAIL] child-count: only $CHILD_COUNT child issue(s) created (need >= 2) -- single-child decomposition cascade (Defect A / TASK-401)"
+  FAILED+=("child-count")
+fi
+
+if [ "${#UNMERGED_CHILDREN[@]}" -eq 0 ] && [ "${#DUPLICATE_CHILDREN[@]}" -eq 0 ]; then
+  echo "[PASS] duplicate-pr: every child has exactly one merged PR"
+else
+  if [ "${#UNMERGED_CHILDREN[@]}" -gt 0 ]; then
+    echo "[FAIL] duplicate-pr: child(ren) with no merged PR yet: ${UNMERGED_CHILDREN[*]}"
+  fi
+  if [ "${#DUPLICATE_CHILDREN[@]}" -gt 0 ]; then
+    echo "[FAIL] duplicate-pr: child(ren) with more than one merged PR (Defect B / TASK-402): ${DUPLICATE_CHILDREN[*]}"
+  fi
+  FAILED+=("duplicate-pr")
+fi
+
+if [ "$PARENT_STATE" = "CLOSED" ]; then
+  echo "[PASS] parent-closed: parent issue #$ISSUE_NUMBER is closed"
+else
+  echo "[FAIL] parent-closed: parent issue #$ISSUE_NUMBER is still $PARENT_STATE after ${TIMEOUT_MINUTES}m"
+  FAILED+=("parent-closed")
+fi
+
+if echo ",$PARENT_LABELS," | grep -q ',pilot-needs-clarification,'; then
+  echo "[FAIL] no-clarification-label: closed parent #$ISSUE_NUMBER still carries pilot-needs-clarification (TASK-395 class)"
+  FAILED+=("no-clarification-label")
+else
+  echo "[PASS] no-clarification-label: parent carries no stale pilot-needs-clarification label"
+fi
+
+if [ "${#CASCADE_CHILDREN[@]}" -eq 0 ]; then
+  echo "[PASS] cascade: no issues spawned beyond the direct children"
+else
+  echo "[FAIL] cascade: ${#CASCADE_CHILDREN[@]} issue(s) spawned beyond the direct children: ${CASCADE_CHILDREN[*]}"
+  FAILED+=("cascade")
+fi
+
+if [ "${#FAILED[@]}" -eq 0 ]; then
+  RESULT="success"
+  STAGE="merged"
+else
+  RESULT="failure"
+  STAGE="assertions-failed"
+fi
+
+FAILED_JOINED=""
+if [ "${#FAILED[@]}" -gt 0 ]; then
+  FAILED_JOINED=$(join_by , "${FAILED[@]}")
 fi
 
 echo "Final stage: $STAGE (result: $RESULT)"
+echo "Failed assertions: ${FAILED_JOINED:-none}"
 
-if [ -n "${GITHUB_OUTPUT:-}" ]; then
-  {
-    echo "stage=$STAGE"
-    echo "pr_number=$PR_NUMBER"
-    echo "result=$RESULT"
-  } >> "$GITHUB_OUTPUT"
-fi
+write_outputs \
+  "stage=$STAGE" \
+  "pr_number=" \
+  "result=$RESULT" \
+  "child_count=$CHILD_COUNT" \
+  "failed_assertions=$FAILED_JOINED"
 
 if [ "$RESULT" != "success" ]; then
   exit 1
 fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds the `epic-lifecycle` canary scenario on top of the #4241 scenario abstraction: files a deliberately decomposable epic on the sandbox (`[epic]`-tagged, two subtasks against two files, second explicitly `Depends on:` the first) and waits for the parent to close.
- Implements the `n-children-merged` assert mode in `scripts/canary-poll.sh`, checking five invariants once the parent closes — each reported individually (`[PASS]`/`[FAIL]`):
  1. `child-count` — ≥2 direct children created (TASK-401 single-child collapse)
  2. `duplicate-pr` — each child has exactly one merged PR, no zero/duplicate (TASK-402)
  3. `parent-closed` — parent auto-closed
  4. `no-clarification-label` — closed parent carries no stale `pilot-needs-clarification` (TASK-395)
  5. `cascade` — no issues spawned beyond the direct children (grandchild/over-decomposition regression)
- Children are discovered via the same `Parent: GH-<N>` body convention the executor itself uses (`internal/adapters/github/grouping.go` `ParseParentIssueNumber`), via `gh issue list --search`.
- Failed assertion names flow through to the deduped pipeline-stall alert issue body.
- Epic runs get an independent 90m timeout (vs. version-bump's 35m); `merged` mode / version-bump scenario is untouched.
- No Go code changes.

## Test plan

- [x] `shellcheck scripts/canary-poll.sh` — clean
- [x] `bash -n scripts/canary-poll.sh` — syntax OK
- [x] YAML parses (`pilot-canary.yml`, `pilot-canary-scenario.yml`)
- [x] Local dry-run against a mocked `gh` CLI covering: healthy 2-child merge (pass), single-child collapse + duplicate merged PR + cascade grandchild + stale label (all 4 fail individually, correct exit code), zero-children timeout, unsupported `--assert` value
- [x] Regression dry-run of existing `merged` mode (version-bump) — unaffected
- [ ] Live verification: next scheduled/dispatched `epic-lifecycle` run against `qf-studio/pilot-canary-sandbox`