### PR TITLE
refactor(executor,autopilot): unify recordExecutionEvent wrappers on validate-first (GH-4244)

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -36,6 +36,7 @@ type approvalPersister interface {
 	SetApprovalRequestID(ctx context.Context, taskID, requestID string) error
 	SetApprovalDecision(ctx context.Context, requestID, decision, by string) error
 	GetLatestExecutionByTaskID(taskID string) (*memory.Execution, error)
+	GetExecution(id string) (*memory.Execution, error)
 	InsertExecutionEvent(executionID string, stage memory.Stage, detail string) error
 }
 
@@ -863,7 +864,11 @@ func executionEventStageFor(prStage PRStage) (memory.Stage, bool) {
 // execution row via the same "GH-<issue>" task ID used for approval
 // persistence, so it survives autopilot's own PR-state-row cleanup — the
 // event is keyed off executions.id, not the PR state row that gets deleted
-// after a successful merge.
+// after a successful merge. The insert itself delegates to the shared
+// memory.RecordExecutionEvent (GH-4244) — the same validate-first writer
+// Runner/Dispatcher/ProjectWorker use — so a row that disappears between this
+// lookup and the insert is still caught rather than tripping the
+// execution_events FOREIGN KEY constraint.
 //
 // Failures (no memory store wired, no matching execution row, insert error)
 // are logged and swallowed: the audit trail is a diagnostic aid, not load-
@@ -886,10 +891,7 @@ func (c *Controller) recordExecutionEvent(prState *PRState, stage memory.Stage, 
 		return
 	}
 
-	if err := c.memoryStore.InsertExecutionEvent(exec.ID, stage, detail); err != nil {
-		c.log.Warn("execution audit trail: failed to insert execution event",
-			"pr", prState.PRNumber, "execution_id", exec.ID, "stage", stage, "error", err)
-	}
+	memory.RecordExecutionEvent(c.memoryStore, c.log, exec.ID, stage, detail)
 }
 
 // persistPRFailures saves per-PR failure state to the store if available.

--- a/internal/autopilot/controller_execution_events_test.go
+++ b/internal/autopilot/controller_execution_events_test.go
@@ -1,8 +1,10 @@
 package autopilot
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -105,6 +107,31 @@ func TestController_ExecutionEvents_PRLifecycle(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestController_recordExecutionEvent_UnknownExecution verifies the shared
+// validate-first writer (GH-4244) keeps FK-787 unrepresentable through the
+// Controller wrapper: a PR whose issue number resolves to no execution row
+// (task-ID lookup miss) must log a Warn and record no event, never attempt an
+// insert that would trip the execution_events FOREIGN KEY constraint.
+func TestController_recordExecutionEvent_UnknownExecution(t *testing.T) {
+	ghClient := github.NewClient(testutil.FakeGitHubToken)
+	c := NewController(DefaultConfig(), ghClient, nil, "owner", "repo")
+
+	var logBuf bytes.Buffer
+	c.log = slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	mock := &mockApprovalPersister{} // execByTask left empty: every task ID lookup misses
+	c.memoryStore = mock
+
+	c.recordExecutionEvent(&PRState{PRNumber: 7, IssueNumber: 999}, memory.StageMerged, "merged")
+
+	if len(mock.executionEvents) != 0 {
+		t.Errorf("expected 0 execution events for an unresolvable task id, got %d", len(mock.executionEvents))
+	}
+	if !strings.Contains(logBuf.String(), "no execution row for task") {
+		t.Errorf("expected a Warn log about the missing execution row, got: %s", logBuf.String())
 	}
 }
 

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -7502,6 +7502,18 @@ func (m *mockApprovalPersister) GetLatestExecutionByTaskID(taskID string) (*memo
 	return &memory.Execution{ID: id, TaskID: taskID}, nil
 }
 
+// GetExecution backs the shared memory.RecordExecutionEvent's validate-first
+// check (GH-4244): any ID seeded into execByTask's values is treated as an
+// existing row, anything else as unknown (sql.ErrNoRows).
+func (m *mockApprovalPersister) GetExecution(id string) (*memory.Execution, error) {
+	for taskID, execID := range m.execByTask {
+		if execID == id {
+			return &memory.Execution{ID: execID, TaskID: taskID}, nil
+		}
+	}
+	return nil, sql.ErrNoRows
+}
+
 func (m *mockApprovalPersister) InsertExecutionEvent(executionID string, stage memory.Stage, detail string) error {
 	m.executionEvents = append(m.executionEvents, recordedExecutionEvent{executionID, stage, detail})
 	return nil
@@ -7566,6 +7578,10 @@ func (m *errApprovalPersister) SetApprovalDecision(_ context.Context, _, _, _ st
 }
 
 func (m *errApprovalPersister) GetLatestExecutionByTaskID(_ string) (*memory.Execution, error) {
+	return nil, sql.ErrNoRows
+}
+
+func (m *errApprovalPersister) GetExecution(_ string) (*memory.Execution, error) {
 	return nil, sql.ErrNoRows
 }
 

--- a/internal/autopilot/gh4130_test.go
+++ b/internal/autopilot/gh4130_test.go
@@ -35,6 +35,18 @@ func (m *gh4130ExecPersister) GetLatestExecutionByTaskID(taskID string) (*memory
 	return exec, nil
 }
 
+// GetExecution backs the shared memory.RecordExecutionEvent's validate-first
+// check (GH-4244): any ID present among execByTask's values is treated as an
+// existing row, anything else as unknown (sql.ErrNoRows).
+func (m *gh4130ExecPersister) GetExecution(id string) (*memory.Execution, error) {
+	for _, exec := range m.execByTask {
+		if exec.ID == id {
+			return exec, nil
+		}
+	}
+	return nil, sql.ErrNoRows
+}
+
 // TestExecutionEventStageFor_WaitingCI verifies GH-4130's core change: the
 // waiting_ci in-progress skip is removed, so entering StageWaitingCI now
 // produces a durable execution_events row instead of being dropped.

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -508,19 +508,15 @@ func (d *Dispatcher) recoverStaleQueuedTasks() int {
 
 // recordExecutionEvent writes a best-effort stage-transition record to the
 // execution_events audit trail for dispatcher-driven status changes (stale
-// recovery, GH-4101). Mirrors ProjectWorker.recordExecutionEvent: a nil store
-// or insert failure is logged and swallowed, never blocks recovery — the
-// audit trail is a diagnostic aid, not load-bearing.
+// recovery, GH-4101). Delegates to the shared memory.RecordExecutionEvent
+// (GH-4244): a nil store, missing execution row, or insert failure is logged
+// and swallowed, never blocks recovery — the audit trail is a diagnostic aid,
+// not load-bearing.
 func (d *Dispatcher) recordExecutionEvent(executionID string, stage memory.Stage, detail string) {
 	if d.store == nil {
 		return
 	}
-	if err := d.store.InsertExecutionEvent(executionID, stage, detail); err != nil {
-		d.log.Warn("Failed to record execution event",
-			slog.String("execution_id", executionID),
-			slog.String("stage", string(stage)),
-			slog.Any("error", err))
-	}
+	memory.RecordExecutionEvent(d.store, d.log, executionID, stage, detail)
 }
 
 // hasLiveWorker reports whether a worker goroutine exists for the given
@@ -1144,19 +1140,15 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 }
 
 // recordExecutionEvent writes a best-effort stage-transition record to the
-// execution_events audit trail (GH-3846). Mirrors the worker's other store
-// writes here: a nil store or insert failure is logged and swallowed, never
-// fails the worker loop — the audit trail is a diagnostic aid, not load-bearing.
+// execution_events audit trail (GH-3846). Delegates to the shared
+// memory.RecordExecutionEvent (GH-4244): a nil store, missing execution row,
+// or insert failure is logged and swallowed, never fails the worker loop —
+// the audit trail is a diagnostic aid, not load-bearing.
 func (w *ProjectWorker) recordExecutionEvent(executionID string, stage memory.Stage, detail string) {
 	if w.store == nil {
 		return
 	}
-	if err := w.store.InsertExecutionEvent(executionID, stage, detail); err != nil {
-		w.log.Warn("Failed to record execution event",
-			slog.String("execution_id", executionID),
-			slog.String("stage", string(stage)),
-			slog.Any("error", err))
-	}
+	memory.RecordExecutionEvent(w.store, w.log, executionID, stage, detail)
 }
 
 // hasTerminalSuccessLedger reports whether the TASK-394 execution ledger

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -2557,6 +2557,57 @@ func TestProjectWorker_recordExecutionEvent_NilStore(t *testing.T) {
 	w.recordExecutionEvent("exec-1", memory.StageRunning, "test detail")
 }
 
+// TestProjectWorker_recordExecutionEvent_UnknownExecution verifies the shared
+// validate-first writer (GH-4244) keeps FK-787 unrepresentable through the
+// ProjectWorker wrapper: an execution_events insert against an ID with no
+// matching executions row must log a Warn and leave no dangling event,
+// instead of tripping the FOREIGN KEY constraint.
+func TestProjectWorker_recordExecutionEvent_UnknownExecution(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	var logBuf bytes.Buffer
+	w := &ProjectWorker{store: store, log: slog.New(slog.NewTextHandler(&logBuf, nil))}
+
+	w.recordExecutionEvent("exec-ghost", memory.StageCommit, "commit created: abc1234")
+
+	events, err := store.ListExecutionEvents("exec-ghost")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events for an execution row that was never saved, got %d", len(events))
+	}
+	if !strings.Contains(logBuf.String(), "no execution row for id") {
+		t.Errorf("expected a Warn log about the missing execution row, got: %s", logBuf.String())
+	}
+}
+
+// TestDispatcher_recordExecutionEvent_UnknownExecution mirrors the
+// ProjectWorker case above for the Dispatcher wrapper (GH-4101 stale-recovery
+// call site), proving the shared validate-first writer applies uniformly
+// (GH-4244).
+func TestDispatcher_recordExecutionEvent_UnknownExecution(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	var logBuf bytes.Buffer
+	d := &Dispatcher{store: store, log: slog.New(slog.NewTextHandler(&logBuf, nil))}
+
+	d.recordExecutionEvent("exec-ghost", memory.StageFailed, "stale_queued recovered after restart")
+
+	events, err := store.ListExecutionEvents("exec-ghost")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events for an execution row that was never saved, got %d", len(events))
+	}
+	if !strings.Contains(logBuf.String(), "no execution row for id") {
+		t.Errorf("expected a Warn log about the missing execution row, got: %s", logBuf.String())
+	}
+}
+
 // syntheticDispatchBackend is a minimal Backend that always succeeds, used to
 // drive a full dispatcher→worker→runner pass without real git/Claude Code
 // tooling (GH-3846).

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1288,20 +1288,15 @@ func (r *Runner) saveLogEntry(executionID, level, message string) {
 }
 
 // recordExecutionEvent writes a best-effort stage-transition record to the
-// execution_events audit trail (GH-3846). Mirrors saveLogEntry's fire-and-
-// forget semantics: a missing store or insert failure is logged and
-// swallowed, never fails the execution.
+// execution_events audit trail (GH-3846). Delegates to the shared
+// memory.RecordExecutionEvent (GH-4244), which validates executionID's row
+// exists before inserting — swallowing both a nil store and a missing row,
+// never failing the execution.
 func (r *Runner) recordExecutionEvent(executionID string, stage memory.Stage, detail string) {
 	if r.logStore == nil {
 		return
 	}
-	if err := r.logStore.InsertExecutionEvent(executionID, stage, detail); err != nil {
-		r.log.Warn("Failed to record execution event",
-			slog.String("execution_id", executionID),
-			slog.String("stage", string(stage)),
-			slog.Any("error", err),
-		)
-	}
+	memory.RecordExecutionEvent(r.logStore, r.log, executionID, stage, detail)
 }
 
 // recordResearchPhaseEvent persists the parallel-research phase's cost to the

--- a/internal/memory/execution_events_test.go
+++ b/internal/memory/execution_events_test.go
@@ -1,7 +1,10 @@
 package memory
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -156,6 +159,74 @@ func TestInsertExecutionEventUsesExplicitUTC(t *testing.T) {
 	if got.Before(before) || got.After(after) {
 		t.Errorf("OccurredAt = %v, want between %v and %v", got, before, after)
 	}
+}
+
+// TestRecordExecutionEvent_ValidateFirst covers the shared validate-first
+// writer (GH-4244): a missing executions row must never reach InsertExecutionEvent
+// (which would trip the execution_events FOREIGN KEY constraint, FK-787) — it
+// should log a Warn and skip instead. An existing row still inserts normally.
+func TestRecordExecutionEvent_ValidateFirst(t *testing.T) {
+	t.Run("unknown execution id logs a warning and skips the insert", func(t *testing.T) {
+		store := newExecutionEventsTestStore(t)
+
+		var logBuf bytes.Buffer
+		log := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+		RecordExecutionEvent(store, log, "exec-ghost", StageCommit, "commit created: abc1234")
+
+		events, err := store.ListExecutionEvents("exec-ghost")
+		if err != nil {
+			t.Fatalf("ListExecutionEvents failed: %v", err)
+		}
+		if len(events) != 0 {
+			t.Fatalf("expected 0 events for an execution row that was never saved, got %d", len(events))
+		}
+		if !strings.Contains(logBuf.String(), "no execution row for id") {
+			t.Errorf("expected a Warn log about the missing execution row, got: %s", logBuf.String())
+		}
+	})
+
+	t.Run("empty execution id is a silent no-op", func(t *testing.T) {
+		store := newExecutionEventsTestStore(t)
+		log := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+
+		RecordExecutionEvent(store, log, "", StageCommit, "should not be written")
+
+		events, err := store.ListExecutionEvents("")
+		if err != nil {
+			t.Fatalf("ListExecutionEvents failed: %v", err)
+		}
+		if len(events) != 0 {
+			t.Fatalf("expected 0 events for an empty execution id, got %d", len(events))
+		}
+	})
+
+	t.Run("existing execution row inserts normally", func(t *testing.T) {
+		store := newExecutionEventsTestStore(t)
+		log := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+
+		if err := store.SaveExecution(&Execution{
+			ID:          "exec-real",
+			TaskID:      "GH-99",
+			ProjectPath: "/project",
+			Status:      "running",
+		}); err != nil {
+			t.Fatalf("SaveExecution failed: %v", err)
+		}
+
+		RecordExecutionEvent(store, log, "exec-real", StageCommit, "commit created: abc1234")
+
+		events, err := store.ListExecutionEvents("exec-real")
+		if err != nil {
+			t.Fatalf("ListExecutionEvents failed: %v", err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("got %d events, want 1", len(events))
+		}
+		if events[0].Stage != StageCommit || events[0].Detail != "commit created: abc1234" {
+			t.Errorf("unexpected event: %+v", events[0])
+		}
+	})
 }
 
 // TestListExecutionsForTask covers newest-first ordering and an unknown task id.

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -793,6 +793,49 @@ func (s *Store) InsertExecutionEvent(executionID string, stage Stage, detail str
 	})
 }
 
+// EventRecorder is the minimal interface RecordExecutionEvent needs: confirm
+// the parent executions row exists, then write the event. *Store satisfies it
+// directly; a narrower mocked interface (e.g. autopilot's approvalPersister)
+// can too, as long as it implements both methods.
+type EventRecorder interface {
+	GetExecution(id string) (*Execution, error)
+	InsertExecutionEvent(executionID string, stage Stage, detail string) error
+}
+
+// RecordExecutionEvent is the single validate-first execution_events writer
+// (GH-4244), replacing four independent wrappers (Runner, Dispatcher,
+// ProjectWorker, autopilot.Controller) that each hand-rolled their own
+// nil-store guard and, except for Controller, inserted blind. Before
+// ExecutionLifecycle (#4243) existed, a caller could reach here with an
+// executionID that had no matching executions row — most commonly
+// task.LogExecutionID()'s bare-task.ID fallback for a task the dispatcher
+// never assigned a row to — and InsertExecutionEvent would trip the
+// execution_events FOREIGN KEY constraint (FK-787). Now that every legitimate
+// execution has a row, a missing row at write time is always a bug: this
+// warns loudly via log and skips the insert rather than failing on the FK.
+//
+// Callers are still responsible for their own nil-store check before calling
+// (an EventRecorder holding a typed-nil *Store panics on first use, same as
+// today) and for skipping an empty executionID if that's meaningful to them.
+func RecordExecutionEvent(store EventRecorder, log *slog.Logger, executionID string, stage Stage, detail string) {
+	if executionID == "" {
+		return
+	}
+	if _, err := store.GetExecution(executionID); err != nil {
+		log.Warn("execution audit trail: no execution row for id, skipping event",
+			slog.String("execution_id", executionID),
+			slog.String("stage", string(stage)),
+			slog.Any("error", err))
+		return
+	}
+	if err := store.InsertExecutionEvent(executionID, stage, detail); err != nil {
+		log.Warn("Failed to record execution event",
+			slog.String("execution_id", executionID),
+			slog.String("stage", string(stage)),
+			slog.Any("error", err))
+	}
+}
+
 // ListExecutionEvents returns the stage timeline for executionID in chronological
 // (occurred_at ASC) order. Returns an empty slice, not an error, for an unknown
 // execution ID.


### PR DESCRIPTION
## Summary
- Adds `memory.RecordExecutionEvent` (`internal/memory/store.go`), the single validate-first `execution_events` writer: it confirms the parent `executions` row exists via `GetExecution` before inserting, `slog.Warn`-and-skips on a miss instead of tripping the FK constraint (FK-787).
- Migrates the four independent wrappers — `Runner.recordExecutionEvent`, `Dispatcher.recordExecutionEvent`, `ProjectWorker.recordExecutionEvent`, and `autopilot.Controller.recordExecutionEvent` — to delegate to it, deleting their duplicated guard/insert bodies.
- `Controller.recordExecutionEvent` keeps its task-ID→execution resolution step (unique to `PRState`, which carries no execution ID directly) but now delegates the validated insert to the shared function; `approvalPersister` gained `GetExecution` to support this.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/memory/... ./internal/executor/... ./internal/autopilot/...`
- [x] `go test -race ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New regression tests prove FK-787 is unreachable through every wrapper: `TestRecordExecutionEvent_ValidateFirst` (memory), `TestProjectWorker_recordExecutionEvent_UnknownExecution` / `TestDispatcher_recordExecutionEvent_UnknownExecution` (executor), `TestController_recordExecutionEvent_UnknownExecution` (autopilot) — each asserts zero events written plus a Warn log, no error.
- [x] Existing `execution_events`/`controller_execution_events` tests remain green.

Blocked by #4243 (ExecutionLifecycle chokepoint), now merged.