### PR TITLE
feat(config,metrics): canary project flag — isolate sandbox executions from success metrics and dashboards

### DIFF
--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -73,6 +73,17 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	title := info.Title
 	projectPath := deps.ProjectPath
 
+	// GH-4240: stamp the canary marker from the registered project config
+	// before dispatch, so it survives the queue round-trip into the
+	// executions row (ExecutionLifecycle.Begin) and the runner's live
+	// metrics guard. deps.Cfg.GetProject returns nil for an unregistered
+	// path (e.g. ad-hoc CLI runs), which correctly resolves to non-canary.
+	if deps.Cfg != nil {
+		if proj := deps.Cfg.GetProject(projectPath); proj != nil {
+			task.IsCanary = proj.Canary
+		}
+	}
+
 	// GH-4008: pre-check whether this task is already queued or running,
 	// before any monitor/alert side effects fire. Prevents the noisy
 	// "Dispatching..." + ERROR "already queued or running" pair that

--- a/internal/autopilot/metrics_hydrator_test.go
+++ b/internal/autopilot/metrics_hydrator_test.go
@@ -406,6 +406,96 @@ func TestHydrateFromStore_RestartContinuity(t *testing.T) {
 	}
 }
 
+// TestHydrateFromStore_ExcludesCanaryRows covers GH-4240: a canary sandbox
+// execution — same shape as a real one (tokens, cost, model, PR url, CI
+// verdict) — must not move any lifetime baseline the hydrator restores:
+// token/cost/execution counters, issue-level shipped/attempted, PR merged/
+// failed, and CI pass/fail. Table-driven with the flag on vs. off against an
+// otherwise identical fixture.
+func TestHydrateFromStore_ExcludesCanaryRows(t *testing.T) {
+	build := func(t *testing.T, canary bool) *Metrics {
+		t.Helper()
+		tmpDir := t.TempDir()
+		store, err := memory.NewStore(tmpDir)
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		defer func() { _ = store.Close() }()
+
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "canary-real", TaskID: "TASK-REAL", ProjectPath: "/p", Status: "completed",
+			ModelName: "claude-sonnet-4-5", TokensInput: 1000, TokensOutput: 500, TokensTotal: 1500,
+			EstimatedCostUSD: 0.05, PRUrl: "https://github.com/o/r/pull/1",
+		}); err != nil {
+			t.Fatalf("SaveExecution real: %v", err)
+		}
+		if err := store.InsertExecutionEvent("canary-real", memory.StageCIPassed, ""); err != nil {
+			t.Fatalf("InsertExecutionEvent real: %v", err)
+		}
+
+		sandboxExec := &memory.Execution{
+			ID: "canary-sandbox", TaskID: "TASK-SANDBOX", ProjectPath: "/canary-sandbox", Status: "completed",
+			ModelName: "claude-sonnet-4-5", TokensInput: 9000, TokensOutput: 4000, TokensTotal: 13000,
+			EstimatedCostUSD: 5.00, PRUrl: "https://github.com/o/r/pull/2",
+			IsCanary: canary,
+		}
+		if err := store.SaveExecution(sandboxExec); err != nil {
+			t.Fatalf("SaveExecution sandbox: %v", err)
+		}
+		if err := store.InsertExecutionEvent("canary-sandbox", memory.StageCIPassed, ""); err != nil {
+			t.Fatalf("InsertExecutionEvent sandbox: %v", err)
+		}
+
+		metrics := NewMetrics()
+		if err := HydrateFromStore(context.Background(), store, metrics); err != nil {
+			t.Fatalf("HydrateFromStore: %v", err)
+		}
+		return metrics
+	}
+
+	t.Run("canary=false includes sandbox row in every baseline", func(t *testing.T) {
+		snap := build(t, false).Snapshot()
+		if snap.IssuesShipped != 2 {
+			t.Errorf("IssuesShipped = %d, want 2", snap.IssuesShipped)
+		}
+		if snap.PRsMerged != 2 {
+			t.Errorf("PRsMerged = %d, want 2", snap.PRsMerged)
+		}
+		if snap.CIRuns["pass"] != 2 {
+			t.Errorf("CIRuns[pass] = %d, want 2", snap.CIRuns["pass"])
+		}
+	})
+
+	t.Run("canary=true excludes sandbox row from every baseline", func(t *testing.T) {
+		snap := build(t, true).Snapshot()
+		if snap.IssuesShipped != 1 {
+			t.Errorf("IssuesShipped = %d, want 1 (sandbox row excluded)", snap.IssuesShipped)
+		}
+		if snap.IssuesAttempted != 1 {
+			t.Errorf("IssuesAttempted = %d, want 1 (sandbox row excluded)", snap.IssuesAttempted)
+		}
+		if snap.PRsMerged != 1 {
+			t.Errorf("PRsMerged = %d, want 1 (sandbox row excluded)", snap.PRsMerged)
+		}
+		if snap.CIRuns["pass"] != 1 {
+			t.Errorf("CIRuns[pass] = %d, want 1 (sandbox row excluded)", snap.CIRuns["pass"])
+		}
+		wantTokens := map[tokenKey]int64{
+			{Model: "claude-sonnet-4-5", Direction: "input"}:  1000,
+			{Model: "claude-sonnet-4-5", Direction: "output"}: 500,
+		}
+		for k, want := range wantTokens {
+			if got := snap.TokensConsumed[k]; got != want {
+				t.Errorf("TokensConsumed[%+v] = %d, want %d (sandbox tokens must not leak in)", k, got, want)
+			}
+		}
+		const epsilon = 0.0001
+		if got, want := snap.ExecutionCostUSD["claude-sonnet-4-5"], 0.05; got < want-epsilon || got > want+epsilon {
+			t.Errorf("ExecutionCostUSD[claude-sonnet-4-5] = %.4f, want %.4f (sandbox cost must not leak in)", got, want)
+		}
+	})
+}
+
 // seedGH4211ExecutionTimes sets explicit created_at/started_at on an
 // executions row via a direct SQL connection — store.SaveExecution never
 // writes started_at (GH-4033's column is only stamped by
@@ -525,5 +615,62 @@ func TestHydrateFromStore_ThroughputHistogramsSurviveRestart(t *testing.T) {
 	}
 	if len(restartedHist.ApprovalWaitDurations) == 0 {
 		t.Error("ApprovalWaitDurations reset to zero on simulated restart")
+	}
+}
+
+// TestHydrateFromStore_ThroughputHistogramsExcludeCanary covers GH-4240: a
+// canary sandbox execution with a full running->pr_created->awaiting_approval
+// ->merged event chain (same shape TestHydrateFromStore_ThroughputHistogramsSurviveRestart
+// exercises for a real one) must not contribute a sample to any of the three
+// throughput histograms, even though execution_events carries no project or
+// canary information of its own — the hydrator must join back to executions.
+func TestHydrateFromStore_ThroughputHistogramsExcludeCanary(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := memory.NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	execID := "gh4240-canary"
+	if err := store.SaveExecution(&memory.Execution{
+		ID: execID, TaskID: "GH-4240-CANARY", ProjectPath: "/canary-sandbox", Status: "completed",
+		IsCanary: true,
+	}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	now := time.Now()
+	createdAt := now.Add(-20 * time.Minute)
+	startedAt := now.Add(-14 * time.Minute)
+	prCreatedAt := now.Add(-9 * time.Minute)
+	awaitingAt := now.Add(-8 * time.Minute)
+	mergedAt := now.Add(-3 * time.Minute)
+
+	dbPath := filepath.Join(tmpDir, "pilot.db")
+	seedGH4211ExecutionTimes(t, dbPath, execID, createdAt, startedAt)
+	seedGH4211EventAt(t, dbPath, execID, memory.StageRunning, startedAt)
+	seedGH4211EventAt(t, dbPath, execID, memory.StagePRCreated, prCreatedAt)
+	seedGH4211EventAt(t, dbPath, execID, memory.StageAwaitingApproval, awaitingAt)
+	seedGH4211EventAt(t, dbPath, execID, memory.StageMerged, mergedAt)
+
+	metrics := NewMetrics()
+	if err := HydrateFromStore(context.Background(), store, metrics); err != nil {
+		t.Fatalf("HydrateFromStore: %v", err)
+	}
+	hist := metrics.HistogramSnapshot()
+
+	if len(hist.TimeToPRDurations) != 0 {
+		t.Errorf("TimeToPRDurations = %v, want 0 (canary row must be excluded)", hist.TimeToPRDurations)
+	}
+	if len(hist.QueueWaitDurations) != 0 {
+		t.Errorf("QueueWaitDurations = %v, want 0 (canary row must be excluded)", hist.QueueWaitDurations)
+	}
+	if len(hist.ApprovalWaitDurations) != 0 {
+		t.Errorf("ApprovalWaitDurations = %v, want 0 (canary row must be excluded)", hist.ApprovalWaitDurations)
+	}
+
+	if len(hist.PRTimeToMerge) != 0 {
+		t.Errorf("PRTimeToMerge = %v, want 0 (canary row must be excluded)", hist.PRTimeToMerge)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -253,6 +253,13 @@ type ProjectConfig struct {
 	// Config.Orchestrator.Autopilot's global and per-environment release
 	// blocks.
 	Release *autopilot.ProjectReleaseConfig `yaml:"release,omitempty"`
+	// Canary marks this project as a synthetic sandbox (e.g. the TASK-379 V8
+	// canary workflow) rather than real work (GH-4240). Executions dispatched
+	// for a canary project are still fully persisted and event-logged — the
+	// flag only excludes them from success-rate/throughput metrics, the
+	// metrics hydrator, and dashboard history, so re-enabling the canary cron
+	// cannot contaminate production telemetry.
+	Canary bool `yaml:"canary,omitempty"`
 }
 
 // ResolveBaseBranch returns the branch that Pilot should branch from and

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1250,6 +1250,38 @@ projects:
 	}
 }
 
+// TestProjectConfigCanaryYAML verifies the canary flag deserializes and
+// defaults to false when unset (GH-4240).
+func TestProjectConfigCanaryYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := `
+version: "1.0"
+projects:
+  - name: "sandbox"
+    path: "/p1"
+    canary: true
+  - name: "real"
+    path: "/p2"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Projects) != 2 {
+		t.Fatalf("Projects length = %d, want 2", len(cfg.Projects))
+	}
+	if !cfg.Projects[0].Canary {
+		t.Error("sandbox project Canary = false, want true")
+	}
+	if cfg.Projects[1].Canary {
+		t.Error("real project Canary = true, want false (default)")
+	}
+}
+
 func TestProjectConfigQualityYAML(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -1319,6 +1319,7 @@ func buildTaskFromExecution(exec *memory.Execution) *Task {
 		SourceAdapter: exec.TaskSourceAdapter,
 		SourceIssueID: exec.TaskSourceIssueID,
 		Labels:        exec.TaskLabels,
+		IsCanary:      exec.IsCanary,
 	}
 }
 

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -284,6 +284,10 @@ func TestStore_GetQueuedTasksForProject(t *testing.T) {
 		{ID: "exec-3", TaskID: "TASK-3", ProjectPath: "/project-b", Status: "queued"},
 		{ID: "exec-4", TaskID: "TASK-4", ProjectPath: "/project-a", Status: "completed"}, // Not queued
 		{ID: "exec-5", TaskID: "TASK-5", ProjectPath: "/project-a", Status: "running"},   // Not queued
+		// GH-4240: a canary sandbox row must still be dequeued for execution
+		// (metrics/dashboard exclusion, never ledger/dispatch exclusion), and
+		// the flag must round-trip through the queued-task read path.
+		{ID: "exec-6", TaskID: "TASK-6", ProjectPath: "/project-a", Status: "queued", IsCanary: true},
 	}
 
 	for _, exec := range executions {
@@ -298,8 +302,20 @@ func TestStore_GetQueuedTasksForProject(t *testing.T) {
 		t.Fatalf("failed to get queued tasks: %v", err)
 	}
 
-	if len(tasks) != 2 {
-		t.Errorf("expected 2 queued tasks for project-a, got %d", len(tasks))
+	if len(tasks) != 3 {
+		t.Errorf("expected 3 queued tasks for project-a, got %d", len(tasks))
+	}
+	var sawCanary bool
+	for _, task := range tasks {
+		if task.ID == "exec-6" {
+			sawCanary = true
+			if !task.IsCanary {
+				t.Error("exec-6 IsCanary = false, want true")
+			}
+		}
+	}
+	if !sawCanary {
+		t.Error("expected canary row exec-6 to be included in queued tasks")
 	}
 
 	// Query project-b queued tasks
@@ -2339,6 +2355,7 @@ func TestBuildTaskFromExecution_ThreadsExecutionUUID(t *testing.T) {
 		TaskSourceAdapter: "github",
 		TaskSourceIssueID: "3764",
 		TaskLabels:        []string{"pilot"},
+		IsCanary:          true,
 	}
 
 	task := buildTaskFromExecution(exec)
@@ -2366,6 +2383,11 @@ func TestBuildTaskFromExecution_ThreadsExecutionUUID(t *testing.T) {
 	}
 	if len(task.Labels) != 1 || task.Labels[0] != "pilot" {
 		t.Errorf("expected labels [pilot], got %v", task.Labels)
+	}
+	// GH-4240: the canary marker must survive the queue round-trip too, or
+	// it silently disappears between "task queued" and "task executed".
+	if !task.IsCanary {
+		t.Error("expected IsCanary to be carried over from execution")
 	}
 }
 

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1983,6 +1983,9 @@ func (r *Runner) executeSubIssuesTracked(ctx context.Context, parent *Task, issu
 			ProjectPath: subTaskRepoPath,
 			Branch:      fmt.Sprintf("pilot/%s", taskID),
 			CreatePR:    true,
+			// GH-4240: inherit the canary marker from the epic parent so a
+			// sub-issue of a synthetic sandbox run doesn't leak into metrics.
+			IsCanary: parent.IsCanary,
 		}
 
 		// GH-4141: give this in-process sub-issue run its own executions ledger

--- a/internal/executor/lifecycle.go
+++ b/internal/executor/lifecycle.go
@@ -88,6 +88,7 @@ func (l *ExecutionLifecycle) Begin(task *Task, initial Status) (string, error) {
 		TaskSourceAdapter: task.SourceAdapter,
 		TaskSourceIssueID: task.SourceIssueID,
 		TaskLabels:        task.Labels,
+		IsCanary:          task.IsCanary,
 	}
 	if err := l.store.SaveExecution(exec); err != nil {
 		return execID, fmt.Errorf("failed to save execution: %w", err)

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -424,6 +424,12 @@ type Task struct {
 	// "GH-4021-2"), which has no matching executions row and trips the
 	// execution_events FOREIGN KEY constraint on every stage write (GH-4032).
 	ParentExecutionID string
+	// IsCanary marks this task as belonging to a synthetic sandbox project
+	// (ProjectConfig.Canary, GH-4240). Set once at intake from the project
+	// config and threaded through the executions row so metrics/hydrators/
+	// dashboards can exclude it — the ledger (executions/execution_events/
+	// execution_logs) is written exactly the same regardless of this flag.
+	IsCanary bool
 }
 
 // LogExecutionID returns the ID that runner-side writes (execution_logs.execution_id,
@@ -1755,7 +1761,9 @@ func (r *Runner) recordEpicTerminalEvent(executionID string, result *ExecutionRe
 func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktree bool) (*ExecutionResult, error) {
 	start := time.Now()
 	defer func() {
-		if r.metricsRecorder != nil {
+		// GH-4240: canary executions are still fully logged, just excluded
+		// from the live Prometheus metrics they'd otherwise pollute.
+		if r.metricsRecorder != nil && !task.IsCanary {
 			r.metricsRecorder.RecordExecutionDuration(time.Since(start))
 		}
 	}()
@@ -2703,7 +2711,7 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				},
 				Timestamp: time.Now(),
 			})
-			if r.metricsRecorder != nil {
+			if r.metricsRecorder != nil && !task.IsCanary {
 				r.metricsRecorder.RecordExecution(result.ModelName, "stalled")
 			}
 			if recorder != nil {
@@ -3072,8 +3080,10 @@ retrySucceeded:
 	// Estimate cost based on token usage (including research tokens) with cache-aware pricing (GH-2164)
 	result.EstimatedCostUSD = estimateCostWithCache(result.TokensInput+result.ResearchTokens, result.TokensOutput, result.CacheCreationInputTokens, result.CacheReadInputTokens, result.ModelName)
 
-	// Emit Prometheus counters for token usage, cost, and execution outcome (GH-2855).
-	if r.metricsRecorder != nil {
+	// Emit Prometheus counters for token usage, cost, and execution outcome
+	// (GH-2855). Skipped for canary executions (GH-4240) — they're still
+	// fully persisted/event-logged, just excluded from live metrics.
+	if r.metricsRecorder != nil && !task.IsCanary {
 		model := result.ModelName
 		r.metricsRecorder.RecordTokens(model, "input", result.TokensInput+result.ResearchTokens)
 		r.metricsRecorder.RecordTokens(model, "output", result.TokensOutput)

--- a/internal/executor/runner_test.go
+++ b/internal/executor/runner_test.go
@@ -4220,6 +4220,73 @@ func TestMetricsRecorder_CalledOncePerExecution(t *testing.T) {
 	}
 }
 
+// TestMetricsRecorder_SkipsCanaryTask covers GH-4240: a task carrying the
+// canary marker (from a synthetic sandbox project) must produce zero calls
+// to every MetricsRecorder method — it's still fully executed/logged, just
+// excluded from the live Prometheus counters/histograms.
+func TestMetricsRecorder_SkipsCanaryTask(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	const branch = "pilot/GH-test-canary-metrics"
+	dir := setupPRGuardRepo(t, branch, true)
+
+	backend := &mockFixedBackend{
+		result: &BackendResult{
+			Success:      true,
+			Output:       "done",
+			TokensInput:  500,
+			TokensOutput: 150,
+			Model:        "claude-sonnet-test",
+		},
+	}
+
+	rec := &fakeMetricsRecorder{}
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	runner.SetMetricsRecorder(rec)
+
+	task := &Task{
+		ID:          "GH-test-canary-metrics",
+		Title:       "test canary metrics exclusion",
+		Description: "verify recorder is never called for a canary task",
+		ProjectPath: dir,
+		Branch:      branch,
+		CreatePR:    false,
+		IsCanary:    true,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Execute() not successful: %s", result.Error)
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+
+	if len(rec.execCalls) != 0 {
+		t.Errorf("RecordExecution called %d times for canary task, want 0", len(rec.execCalls))
+	}
+	if len(rec.costCalls) != 0 {
+		t.Errorf("RecordCost called %d times for canary task, want 0", len(rec.costCalls))
+	}
+	if len(rec.tokenCalls) != 0 {
+		t.Errorf("RecordTokens called %d times for canary task, want 0", len(rec.tokenCalls))
+	}
+	if len(rec.durationCalls) != 0 {
+		t.Errorf("RecordExecutionDuration called %d times for canary task, want 0", len(rec.durationCalls))
+	}
+}
+
 // TestGhostSHAGuard verifies applyGhostSHAGuard (GH-3126 + GH-3642).
 func TestGhostSHAGuard(t *testing.T) {
 	log := slog.Default()

--- a/internal/memory/metrics.go
+++ b/internal/memory/metrics.go
@@ -318,7 +318,8 @@ func (s *Store) GetMetricsSummary(query MetricsQuery) (*MetricsSummary, error) {
 // GetDailyMetrics returns metrics aggregated by day
 func (s *Store) GetDailyMetrics(query MetricsQuery) ([]*DailyMetrics, error) {
 	var args []interface{}
-	whereClause := "WHERE created_at >= ? AND created_at < ? AND tokens_total > 0"
+	// GH-4240: canary sandbox executions never count toward daily metrics.
+	whereClause := "WHERE created_at >= ? AND created_at < ? AND tokens_total > 0 AND COALESCE(is_canary, 0) = 0"
 	args = append(args, query.Start, query.End)
 
 	if len(query.Projects) > 0 {

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -363,6 +363,11 @@ func (s *Store) migrate() error {
 		// worker picks it up — the stuck-monitor must time it from started_at, not
 		// created_at, or a legitimately-running subtask gets evicted as stale.
 		`ALTER TABLE executions ADD COLUMN started_at DATETIME`,
+		// GH-4240: marks executions from a synthetic canary sandbox project
+		// (ProjectConfig.Canary) so they can be excluded from success-rate/
+		// throughput metrics, the metrics hydrator, and dashboard history
+		// without touching the ledger itself.
+		`ALTER TABLE executions ADD COLUMN is_canary BOOLEAN DEFAULT FALSE`,
 	}
 
 	for _, migration := range migrations {
@@ -546,6 +551,11 @@ type Execution struct {
 	// GH-3028: RSS telemetry
 	PeakRSSMB  int
 	FinalRSSMB int
+	// IsCanary marks this execution as belonging to a synthetic canary
+	// sandbox project (GH-4240). Excluded from success-rate/throughput
+	// metrics, the metrics hydrator, and dashboard history; the ledger row
+	// itself is written identically regardless of this flag.
+	IsCanary bool
 }
 
 // SaveExecution saves an execution record to the database.
@@ -562,14 +572,14 @@ func (s *Store) SaveExecution(exec *Execution) error {
 				estimated_cost_usd, files_changed, lines_added, lines_removed, model_name,
 				task_title, task_description, task_branch, task_base_branch, task_create_pr, task_verbose,
 				task_source_adapter, task_source_issue_id, task_labels,
-				approval_request_id, effort_level, complexity_level)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				approval_request_id, effort_level, complexity_level, is_canary)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, exec.ID, exec.TaskID, exec.ProjectPath, exec.Status, exec.Output, exec.Error, exec.DurationMs, exec.PRUrl, exec.CommitSHA, exec.CompletedAt,
 			exec.TokensInput, exec.TokensOutput, exec.TokensTotal, exec.TokensCacheRead, exec.TokensCacheWrite,
 			exec.EstimatedCostUSD, exec.FilesChanged, exec.LinesAdded, exec.LinesRemoved, exec.ModelName,
 			exec.TaskTitle, exec.TaskDescription, exec.TaskBranch, exec.TaskBaseBranch, exec.TaskCreatePR, exec.TaskVerbose,
 			exec.TaskSourceAdapter, exec.TaskSourceIssueID, labelsJSON,
-			exec.ApprovalRequestID, exec.EffortLevel, exec.ComplexityLevel)
+			exec.ApprovalRequestID, exec.EffortLevel, exec.ComplexityLevel, exec.IsCanary)
 		return err
 	})
 }
@@ -616,7 +626,8 @@ const executionDetailColumns = `
 	COALESCE(approval_request_id, ''), COALESCE(approval_decision, ''),
 	approval_decision_at,
 	COALESCE(approval_decision_by, ''),
-	COALESCE(effort_level, ''), COALESCE(complexity_level, '')`
+	COALESCE(effort_level, ''), COALESCE(complexity_level, ''),
+	COALESCE(is_canary, 0)`
 
 // rowScanner abstracts *sql.Row and *sql.Rows so scanExecutionDetail serves both
 // a single QueryRow result and a Query loop (used by ListExecutionsForTask).
@@ -637,7 +648,7 @@ func scanExecutionDetail(row rowScanner) (*Execution, error) {
 		&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose,
 		&exec.TaskSourceAdapter, &exec.TaskSourceIssueID, &labelsJSON,
 		&exec.ApprovalRequestID, &exec.ApprovalDecision, &approvalDecisionAt, &exec.ApprovalDecisionBy,
-		&exec.EffortLevel, &exec.ComplexityLevel)
+		&exec.EffortLevel, &exec.ComplexityLevel, &exec.IsCanary)
 	if err != nil {
 		return nil, err
 	}
@@ -1072,16 +1083,20 @@ func (s *Store) SetApprovalRequestID(ctx context.Context, taskID, requestID stri
 // The limit parameter specifies the maximum number of executions to return.
 // If projectPath is non-empty, only executions for that project are returned.
 func (s *Store) GetRecentExecutions(limit int, projectPath string) ([]*Execution, error) {
+	// GH-4240: is_canary = 0 excludes the synthetic canary sandbox from
+	// dashboard queue/history — its executions are still fully persisted,
+	// just not surfaced here.
 	const base = `
 		SELECT id, task_id, project_path, status, output, error, duration_ms, pr_url, commit_sha, created_at, completed_at,
 			COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
 			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
 			COALESCE(peak_rss_mb, 0), COALESCE(final_rss_mb, 0)
-		FROM executions`
+		FROM executions
+		WHERE COALESCE(is_canary, 0) = 0`
 	var rows *sql.Rows
 	var err error
 	if projectPath != "" {
-		rows, err = s.db.Query(base+` WHERE project_path = ? ORDER BY created_at DESC LIMIT ?`, projectPath, limit)
+		rows, err = s.db.Query(base+` AND project_path = ? ORDER BY created_at DESC LIMIT ?`, projectPath, limit)
 	} else {
 		rows, err = s.db.Query(base+` ORDER BY created_at DESC LIMIT ?`, limit)
 	}
@@ -1528,7 +1543,7 @@ func (s *Store) GetQueuedTasksForProject(projectPath string, limit int) ([]*Exec
 			COALESCE(task_title, ''), COALESCE(task_description, ''), COALESCE(task_branch, ''),
 			COALESCE(task_base_branch, ''), COALESCE(task_create_pr, 0), COALESCE(task_verbose, 0),
 			COALESCE(task_source_adapter, ''), COALESCE(task_source_issue_id, ''),
-			COALESCE(task_labels, '')
+			COALESCE(task_labels, ''), COALESCE(is_canary, 0)
 		FROM executions
 		WHERE (status = 'queued' OR status = 'pending') AND project_path = ?
 		ORDER BY created_at ASC
@@ -1546,7 +1561,7 @@ func (s *Store) GetQueuedTasksForProject(projectPath string, limit int) ([]*Exec
 		var labelsJSON string
 		if err := rows.Scan(&exec.ID, &exec.TaskID, &exec.ProjectPath, &exec.Status, &exec.Output, &exec.Error, &exec.DurationMs, &exec.PRUrl, &exec.CommitSHA, &exec.CreatedAt, &completedAt,
 			&exec.TaskTitle, &exec.TaskDescription, &exec.TaskBranch, &exec.TaskBaseBranch, &exec.TaskCreatePR, &exec.TaskVerbose,
-			&exec.TaskSourceAdapter, &exec.TaskSourceIssueID, &labelsJSON); err != nil {
+			&exec.TaskSourceAdapter, &exec.TaskSourceIssueID, &labelsJSON, &exec.IsCanary); err != nil {
 			return nil, err
 		}
 		if completedAt.Valid {
@@ -2464,10 +2479,12 @@ func (s *Store) GetLifetimeTaskCounts(projectPath string) (*LifetimeTaskCounts, 
 			COALESCE(SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END), 0)
 		FROM executions`
 	var row *sql.Row
+	// GH-4240: canary sandbox executions never count toward these lifetime
+	// baselines, project-scoped or not.
 	if projectPath != "" {
-		row = s.db.QueryRow(cols+` WHERE project_path = ?`, projectPath)
+		row = s.db.QueryRow(cols+` WHERE COALESCE(is_canary, 0) = 0 AND project_path = ?`, projectPath)
 	} else {
-		row = s.db.QueryRow(cols)
+		row = s.db.QueryRow(cols + ` WHERE COALESCE(is_canary, 0) = 0`)
 	}
 
 	var tc LifetimeTaskCounts
@@ -2499,10 +2516,12 @@ func (s *Store) GetIssueLevelCounts(projectPath string) (*IssueLevelCounts, erro
 			COUNT(DISTINCT CASE WHEN status = 'completed' THEN task_id END)
 		FROM executions`
 	var row *sql.Row
+	// GH-4240: canary sandbox executions never count toward issue-level
+	// attempted/shipped baselines, project-scoped or not.
 	if projectPath != "" {
-		row = s.db.QueryRow(cols+` WHERE project_path = ?`, projectPath)
+		row = s.db.QueryRow(cols+` WHERE COALESCE(is_canary, 0) = 0 AND project_path = ?`, projectPath)
 	} else {
-		row = s.db.QueryRow(cols)
+		row = s.db.QueryRow(cols + ` WHERE COALESCE(is_canary, 0) = 0`)
 	}
 
 	var c IssueLevelCounts
@@ -2567,7 +2586,7 @@ func (s *Store) GetLifetimeCounterBaselines() (*LifetimeCounterBaselines, error)
 			COALESCE(SUM(tokens_cache_read), 0),
 			COALESCE(SUM(estimated_cost_usd), 0)
 		FROM executions
-		WHERE tokens_total > 0
+		WHERE tokens_total > 0 AND COALESCE(is_canary, 0) = 0
 		GROUP BY model_name
 	`)
 	if err != nil {
@@ -2612,7 +2631,7 @@ func (s *Store) GetLifetimeCounterBaselines() (*LifetimeCounterBaselines, error)
 			END AS result,
 			COUNT(*)
 		FROM executions
-		WHERE status NOT IN ('queued', 'pending', 'running')
+		WHERE status NOT IN ('queued', 'pending', 'running') AND COALESCE(is_canary, 0) = 0
 		GROUP BY model_name, result
 	`)
 	if err != nil {
@@ -2733,17 +2752,20 @@ func (s *Store) GetLifetimePRCounters() (*LifetimePRCounters, error) {
 // If projectPath is non-empty, only executions for that project are counted
 // (matches GetIssueLevelCounts).
 func (s *Store) GetLifetimePRCountersFromExecutions(projectPath string) (*LifetimePRCounters, error) {
+	// GH-4240: is_canary = 0 excludes the canary sandbox from both the outer
+	// count and the "already merged elsewhere" exclusion subquery — otherwise
+	// a canary task_id colliding with the subquery's scope could leak in.
 	const cols = `
 		SELECT
 			COUNT(DISTINCT CASE WHEN status = 'completed' AND pr_url <> '' THEN task_id END),
 			COUNT(DISTINCT CASE
 				WHEN status = 'failed' AND pr_url <> '' AND task_id NOT IN (
 					SELECT task_id FROM executions
-					WHERE status = 'completed' AND pr_url <> '' AND (? = '' OR project_path = ?)
+					WHERE status = 'completed' AND pr_url <> '' AND COALESCE(is_canary, 0) = 0 AND (? = '' OR project_path = ?)
 				) THEN task_id
 			END)
 		FROM executions
-		WHERE (? = '' OR project_path = ?)`
+		WHERE COALESCE(is_canary, 0) = 0 AND (? = '' OR project_path = ?)`
 
 	row := s.db.QueryRow(cols, projectPath, projectPath, projectPath, projectPath)
 
@@ -2776,11 +2798,15 @@ type LifetimeCIRunCounters struct {
 func (s *Store) GetLifetimeCIRunCounters() (*LifetimeCIRunCounters, error) {
 	counters := &LifetimeCIRunCounters{}
 
+	// GH-4240: join back to executions so a canary sandbox run's CI verdicts
+	// don't inflate this lifetime baseline (execution_events has no
+	// project/canary info of its own).
 	rows, err := s.db.Query(`
-		SELECT stage, COUNT(DISTINCT execution_id)
-		FROM execution_events
-		WHERE stage IN (?, ?)
-		GROUP BY stage
+		SELECT ee.stage, COUNT(DISTINCT ee.execution_id)
+		FROM execution_events ee
+		JOIN executions e ON e.id = ee.execution_id
+		WHERE ee.stage IN (?, ?) AND COALESCE(e.is_canary, 0) = 0
+		GROUP BY ee.stage
 	`, string(StageCIPassed), string(StageCIFailed))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get lifetime CI run counters: %w", err)
@@ -2812,12 +2838,15 @@ func (s *Store) GetLifetimeCIRunCounters() (*LifetimeCIRunCounters, error) {
 // GROUP BY/MIN() aggregate) — the sqlite driver only recovers the DATETIME
 // declared-type for direct column reads; scanning an aggregate result into
 // time.Time fails, so ORDER BY + first-write-wins in Go stands in for MIN().
+// GH-4240: joins back to executions to drop canary-sandbox rows — every
+// caller feeds a throughput histogram that must stay canary-blind.
 func (s *Store) earliestStageOccurrences(stage Stage) (map[string]time.Time, error) {
 	rows, err := s.db.Query(`
-		SELECT execution_id, occurred_at
-		FROM execution_events
-		WHERE stage = ?
-		ORDER BY occurred_at ASC, id ASC
+		SELECT ee.execution_id, ee.occurred_at
+		FROM execution_events ee
+		JOIN executions e ON e.id = ee.execution_id
+		WHERE ee.stage = ? AND COALESCE(e.is_canary, 0) = 0
+		ORDER BY ee.occurred_at ASC, ee.id ASC
 	`, string(stage))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query %s stage occurrences: %w", stage, err)
@@ -2928,7 +2957,7 @@ func (s *Store) GetLifetimeQueueWait() ([]time.Duration, error) {
 	rows, err := s.db.Query(`
 		SELECT created_at, started_at
 		FROM executions
-		WHERE started_at IS NOT NULL
+		WHERE started_at IS NOT NULL AND COALESCE(is_canary, 0) = 0
 		ORDER BY started_at ASC
 	`)
 	if err != nil {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -103,6 +103,41 @@ func TestGetRecentExecutions(t *testing.T) {
 	}
 }
 
+// TestGetRecentExecutions_ExcludesCanary covers GH-4240: canary sandbox
+// executions must not appear in dashboard queue/history results, whether or
+// not a project filter is applied — the ledger row itself is untouched.
+func TestGetRecentExecutions_ExcludesCanary(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	store, _ := NewStore(tmpDir)
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&Execution{ID: "re-real", TaskID: "TASK-REAL", ProjectPath: "/path", Status: "completed"}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	if err := store.SaveExecution(&Execution{ID: "re-canary", TaskID: "TASK-CANARY", ProjectPath: "/canary-sandbox", Status: "completed", IsCanary: true}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	recent, err := store.GetRecentExecutions(10, "")
+	if err != nil {
+		t.Fatalf("GetRecentExecutions failed: %v", err)
+	}
+	if len(recent) != 1 || recent[0].ID != "re-real" {
+		t.Errorf("GetRecentExecutions() = %v, want only [re-real]", recent)
+	}
+
+	// The canary row itself is untouched — GetExecution still returns it.
+	got, err := store.GetExecution("re-canary")
+	if err != nil {
+		t.Fatalf("GetExecution(re-canary): %v", err)
+	}
+	if !got.IsCanary {
+		t.Error("GetExecution(re-canary).IsCanary = false, want true")
+	}
+}
+
 func TestGetLatestExecutionByTaskID(t *testing.T) {
 	tmpDir, _ := os.MkdirTemp("", "pilot-test-*")
 	defer func() { _ = os.RemoveAll(tmpDir) }()
@@ -1594,6 +1629,18 @@ func TestGetLifetimeTaskCounts(t *testing.T) {
 		}
 	}
 
+	// GH-4240: a canary sandbox execution must not move any of these
+	// lifetime counters, project-scoped or not.
+	if err := store.SaveExecution(&Execution{
+		ID:          "exec-tc-canary",
+		TaskID:      "TASK-CANARY",
+		ProjectPath: "/canary-sandbox",
+		Status:      "completed",
+		IsCanary:    true,
+	}); err != nil {
+		t.Fatalf("SaveExecution canary: %v", err)
+	}
+
 	tc, err = store.GetLifetimeTaskCounts("")
 	if err != nil {
 		t.Fatalf("GetLifetimeTaskCounts: %v", err)
@@ -1666,6 +1713,18 @@ func TestGetIssueLevelCounts(t *testing.T) {
 				{ID: "ilc-12", TaskID: "TASK-Y", ProjectPath: "/beta", Status: "failed"},
 			},
 			projectPath:   "/beta",
+			wantAttempted: 1,
+			wantShipped:   1,
+		},
+		{
+			// GH-4240: a canary sandbox execution must not count toward
+			// issue-level attempted/shipped, even though it's a normal
+			// 'completed' row with no project filter applied.
+			name: "canary execution excluded regardless of status",
+			execs: []*Execution{
+				{ID: "ilc-13", TaskID: "TASK-REAL", ProjectPath: "/p", Status: "completed"},
+				{ID: "ilc-14", TaskID: "TASK-CANARY", ProjectPath: "/canary-sandbox", Status: "completed", IsCanary: true},
+			},
 			wantAttempted: 1,
 			wantShipped:   1,
 		},
@@ -1772,6 +1831,19 @@ func TestGetLifetimePRCountersFromExecutions(t *testing.T) {
 			projectPath: "/beta",
 			wantMerged:  1,
 			wantFailed:  1,
+		},
+		{
+			// GH-4240: canary merged/failed PR rows must not leak into either
+			// bucket, including via the failed-bucket's "already merged
+			// elsewhere" exclusion subquery.
+			name: "canary merged and failed rows both excluded",
+			execs: []*Execution{
+				{ID: "plc-9", TaskID: "TASK-REAL", ProjectPath: "/p", Status: "completed", PRUrl: "https://github.com/o/r/pull/9"},
+				{ID: "plc-10", TaskID: "TASK-CANARY-M", ProjectPath: "/canary-sandbox", Status: "completed", PRUrl: "https://github.com/o/r/pull/10", IsCanary: true},
+				{ID: "plc-11", TaskID: "TASK-CANARY-F", ProjectPath: "/canary-sandbox", Status: "failed", PRUrl: "https://github.com/o/r/pull/11", IsCanary: true},
+			},
+			wantMerged: 1,
+			wantFailed: 0,
 		},
 	}
 
@@ -3113,6 +3185,49 @@ func TestGetDailyMetrics_ExcludesZeroTokenRows(t *testing.T) {
 	}
 	if days[0].CacheWriteTokens != 5000 {
 		t.Errorf("CacheWriteTokens = %d, want 5000", days[0].CacheWriteTokens)
+	}
+}
+
+// TestGetDailyMetrics_ExcludesCanaryRows covers GH-4240: a canary sandbox
+// execution with real token/cost data must still not appear in daily metrics.
+func TestGetDailyMetrics_ExcludesCanaryRows(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().UTC()
+	yesterday := now.Add(-24 * time.Hour)
+
+	if err := store.SaveExecution(&Execution{ID: "dm-real2", TaskID: "T-3", ProjectPath: "/p", Status: "completed", CreatedAt: yesterday}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	if err := store.SaveExecutionMetrics(&ExecutionMetrics{ExecutionID: "dm-real2", TokensTotal: 4000, EstimatedCostUSD: 0.30}); err != nil {
+		t.Fatalf("SaveExecutionMetrics: %v", err)
+	}
+
+	if err := store.SaveExecution(&Execution{ID: "dm-canary", TaskID: "T-4", ProjectPath: "/canary-sandbox", Status: "completed", CreatedAt: yesterday, IsCanary: true}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+	if err := store.SaveExecutionMetrics(&ExecutionMetrics{ExecutionID: "dm-canary", TokensTotal: 9000, EstimatedCostUSD: 5.00}); err != nil {
+		t.Fatalf("SaveExecutionMetrics: %v", err)
+	}
+
+	q := MetricsQuery{Start: yesterday.Add(-time.Hour), End: now.Add(time.Hour)}
+	days, err := store.GetDailyMetrics(q)
+	if err != nil {
+		t.Fatalf("GetDailyMetrics: %v", err)
+	}
+	if len(days) == 0 {
+		t.Fatal("GetDailyMetrics: want at least 1 day row")
+	}
+	if days[0].ExecutionCount != 1 {
+		t.Errorf("ExecutionCount = %d, want 1 (canary row must be excluded)", days[0].ExecutionCount)
+	}
+	if days[0].TotalTokens != 4000 {
+		t.Errorf("TotalTokens = %d, want 4000 (canary tokens must be excluded)", days[0].TotalTokens)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `ProjectConfig.Canary` (`canary: true` in project config) marking a project as a synthetic sandbox (e.g. the TASK-379 V8 canary workflow).
- Threads the flag through `Task.IsCanary` → `Execution.IsCanary` (new additive `is_canary` column) at the single `ExecutionLifecycle.Begin` chokepoint, and round-trips it through the queue (`GetQueuedTasksForProject` → `buildTaskFromExecution`) and epic sub-issues.
- Excludes canary rows from: success-rate/issue-level/PR/CI/token/cost lifetime baselines and the metrics hydrator, the live per-task Prometheus metrics recorder in the runner, `GetDailyMetrics`, and dashboard queue/history (`GetRecentExecutions`).
- Ledger writes (`executions`, `execution_events`, `execution_logs`) are unchanged for canary rows — exclusion is metrics/dashboard-level only.

Closes #4240.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/config/... ./internal/memory/... ./internal/autopilot/... ./internal/executor/...`
- [x] `go test ./...` (full repo)
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] New table-driven tests cover canary on/off for: `ProjectConfig` YAML, `GetLifetimeTaskCounts`, `GetIssueLevelCounts`, `GetLifetimePRCountersFromExecutions`, `GetDailyMetrics`, `GetRecentExecutions`, `GetQueuedTasksForProject`, `buildTaskFromExecution`, the metrics hydrator (counters + throughput histograms), and the runner's live metrics recorder.