### PR TITLE
refactor(executor,autopilot): unify recordExecutionEvent wrappers on validate-first

### DIFF
--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -36,7 +36,11 @@ type approvalPersister interface {
 	SetApprovalRequestID(ctx context.Context, taskID, requestID string) error
 	SetApprovalDecision(ctx context.Context, requestID, decision, by string) error
 	GetLatestExecutionByTaskID(taskID string) (*memory.Execution, error)
-	InsertExecutionEvent(executionID string, stage memory.Stage, detail string) error
+	// RecordExecutionEvent is the GH-4244 validate-first chokepoint
+	// (memory.Store.RecordExecutionEvent): it confirms the executions row
+	// exists before inserting, so a stale/unknown execution ID can never
+	// surface as an execution_events foreign-key error.
+	RecordExecutionEvent(executionID string, stage memory.Stage, detail string) error
 }
 
 // projectBoardSyncer abstracts GitHub Projects V2 board status updates.
@@ -863,7 +867,10 @@ func executionEventStageFor(prStage PRStage) (memory.Stage, bool) {
 // execution row via the same "GH-<issue>" task ID used for approval
 // persistence, so it survives autopilot's own PR-state-row cleanup — the
 // event is keyed off executions.id, not the PR state row that gets deleted
-// after a successful merge.
+// after a successful merge. The insert itself delegates to
+// memory.Store.RecordExecutionEvent (GH-4244), the same validate-first
+// chokepoint the executor-package wrappers use, so this is the last of the
+// four recordExecutionEvent implementations to share it.
 //
 // Failures (no memory store wired, no matching execution row, insert error)
 // are logged and swallowed: the audit trail is a diagnostic aid, not load-
@@ -886,7 +893,7 @@ func (c *Controller) recordExecutionEvent(prState *PRState, stage memory.Stage, 
 		return
 	}
 
-	if err := c.memoryStore.InsertExecutionEvent(exec.ID, stage, detail); err != nil {
+	if err := c.memoryStore.RecordExecutionEvent(exec.ID, stage, detail); err != nil {
 		c.log.Warn("execution audit trail: failed to insert execution event",
 			"pr", prState.PRNumber, "execution_id", exec.ID, "stage", stage, "error", err)
 	}

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -7502,7 +7502,7 @@ func (m *mockApprovalPersister) GetLatestExecutionByTaskID(taskID string) (*memo
 	return &memory.Execution{ID: id, TaskID: taskID}, nil
 }
 
-func (m *mockApprovalPersister) InsertExecutionEvent(executionID string, stage memory.Stage, detail string) error {
+func (m *mockApprovalPersister) RecordExecutionEvent(executionID string, stage memory.Stage, detail string) error {
 	m.executionEvents = append(m.executionEvents, recordedExecutionEvent{executionID, stage, detail})
 	return nil
 }
@@ -7569,7 +7569,7 @@ func (m *errApprovalPersister) GetLatestExecutionByTaskID(_ string) (*memory.Exe
 	return nil, sql.ErrNoRows
 }
 
-func (m *errApprovalPersister) InsertExecutionEvent(_ string, _ memory.Stage, _ string) error {
+func (m *errApprovalPersister) RecordExecutionEvent(_ string, _ memory.Stage, _ string) error {
 	return nil
 }
 

--- a/internal/autopilot/gh4130_test.go
+++ b/internal/autopilot/gh4130_test.go
@@ -24,7 +24,7 @@ func (m *gh4130ExecPersister) SetApprovalRequestID(_ context.Context, _, _ strin
 func (m *gh4130ExecPersister) SetApprovalDecision(_ context.Context, _, _, _ string) error {
 	return nil
 }
-func (m *gh4130ExecPersister) InsertExecutionEvent(_ string, _ memory.Stage, _ string) error {
+func (m *gh4130ExecPersister) RecordExecutionEvent(_ string, _ memory.Stage, _ string) error {
 	return nil
 }
 func (m *gh4130ExecPersister) GetLatestExecutionByTaskID(taskID string) (*memory.Execution, error) {

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -508,14 +508,16 @@ func (d *Dispatcher) recoverStaleQueuedTasks() int {
 
 // recordExecutionEvent writes a best-effort stage-transition record to the
 // execution_events audit trail for dispatcher-driven status changes (stale
-// recovery, GH-4101). Mirrors ProjectWorker.recordExecutionEvent: a nil store
-// or insert failure is logged and swallowed, never blocks recovery — the
-// audit trail is a diagnostic aid, not load-bearing.
+// recovery, GH-4101). Mirrors ProjectWorker.recordExecutionEvent: a nil store,
+// missing parent execution row (GH-4244 validate-first via
+// memory.Store.RecordExecutionEvent), or insert failure is logged and
+// swallowed, never blocks recovery — the audit trail is a diagnostic aid, not
+// load-bearing.
 func (d *Dispatcher) recordExecutionEvent(executionID string, stage memory.Stage, detail string) {
 	if d.store == nil {
 		return
 	}
-	if err := d.store.InsertExecutionEvent(executionID, stage, detail); err != nil {
+	if err := d.store.RecordExecutionEvent(executionID, stage, detail); err != nil {
 		d.log.Warn("Failed to record execution event",
 			slog.String("execution_id", executionID),
 			slog.String("stage", string(stage)),
@@ -1145,13 +1147,15 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 
 // recordExecutionEvent writes a best-effort stage-transition record to the
 // execution_events audit trail (GH-3846). Mirrors the worker's other store
-// writes here: a nil store or insert failure is logged and swallowed, never
-// fails the worker loop — the audit trail is a diagnostic aid, not load-bearing.
+// writes here: a nil store, missing parent execution row (GH-4244
+// validate-first via memory.Store.RecordExecutionEvent), or insert failure is
+// logged and swallowed, never fails the worker loop — the audit trail is a
+// diagnostic aid, not load-bearing.
 func (w *ProjectWorker) recordExecutionEvent(executionID string, stage memory.Stage, detail string) {
 	if w.store == nil {
 		return
 	}
-	if err := w.store.InsertExecutionEvent(executionID, stage, detail); err != nil {
+	if err := w.store.RecordExecutionEvent(executionID, stage, detail); err != nil {
 		w.log.Warn("Failed to record execution event",
 			slog.String("execution_id", executionID),
 			slog.String("stage", string(stage)),

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -2579,6 +2579,45 @@ func TestProjectWorker_recordExecutionEvent_NilStore(t *testing.T) {
 	w.recordExecutionEvent("exec-1", memory.StageRunning, "test detail")
 }
 
+// TestProjectWorker_recordExecutionEvent_UnknownExecution verifies the
+// GH-4244 validate-first guard: writing an event against an execution ID that
+// was never saved logs a warning and writes nothing, instead of surfacing a
+// SQLite foreign-key error (FK-787).
+func TestProjectWorker_recordExecutionEvent_UnknownExecution(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	w := &ProjectWorker{store: store, log: slog.New(slog.NewTextHandler(os.Stdout, nil))}
+	w.recordExecutionEvent("exec-ghost", memory.StageCommit, "commit created: abc1234")
+
+	events, err := store.ListExecutionEvents("exec-ghost")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events for an execution row that was never saved, got %d", len(events))
+	}
+}
+
+// TestDispatcher_recordExecutionEvent_UnknownExecution mirrors the
+// ProjectWorker/Runner regression test for the Dispatcher-owned wrapper
+// (GH-4244): a stale/unknown execution ID must warn-and-skip, never FK-fail.
+func TestDispatcher_recordExecutionEvent_UnknownExecution(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	d := &Dispatcher{store: store, log: slog.New(slog.NewTextHandler(os.Stdout, nil))}
+	d.recordExecutionEvent("exec-ghost", memory.StageFailed, "stale_queued recovered after restart")
+
+	events, err := store.ListExecutionEvents("exec-ghost")
+	if err != nil {
+		t.Fatalf("ListExecutionEvents failed: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events for an execution row that was never saved, got %d", len(events))
+	}
+}
+
 // syntheticDispatchBackend is a minimal Backend that always succeeds, used to
 // drive a full dispatcher→worker→runner pass without real git/Claude Code
 // tooling (GH-3846).

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1295,13 +1295,14 @@ func (r *Runner) saveLogEntry(executionID, level, message string) {
 
 // recordExecutionEvent writes a best-effort stage-transition record to the
 // execution_events audit trail (GH-3846). Mirrors saveLogEntry's fire-and-
-// forget semantics: a missing store or insert failure is logged and
-// swallowed, never fails the execution.
+// forget semantics: a missing store, missing parent execution row (GH-4244
+// validate-first via memory.Store.RecordExecutionEvent), or insert failure is
+// logged and swallowed, never fails the execution.
 func (r *Runner) recordExecutionEvent(executionID string, stage memory.Stage, detail string) {
 	if r.logStore == nil {
 		return
 	}
-	if err := r.logStore.InsertExecutionEvent(executionID, stage, detail); err != nil {
+	if err := r.logStore.RecordExecutionEvent(executionID, stage, detail); err != nil {
 		r.log.Warn("Failed to record execution event",
 			slog.String("execution_id", executionID),
 			slog.String("stage", string(stage)),

--- a/internal/memory/execution_events_test.go
+++ b/internal/memory/execution_events_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -156,6 +157,52 @@ func TestInsertExecutionEventUsesExplicitUTC(t *testing.T) {
 	if got.Before(before) || got.After(after) {
 		t.Errorf("OccurredAt = %v, want between %v and %v", got, before, after)
 	}
+}
+
+// TestRecordExecutionEvent_ValidatesFirst covers the GH-4244 validate-first
+// chokepoint: RecordExecutionEvent must insert normally against a known
+// execution row, and must return ErrExecutionNotFound — never a bare SQLite
+// foreign-key error — against an unknown one (FK-787), leaving no event
+// behind either way.
+func TestRecordExecutionEvent_ValidatesFirst(t *testing.T) {
+	store := newExecutionEventsTestStore(t)
+
+	if err := store.SaveExecution(&Execution{
+		ID:          "exec-1",
+		TaskID:      "GH-1",
+		ProjectPath: "/project",
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	t.Run("known execution row inserts normally", func(t *testing.T) {
+		if err := store.RecordExecutionEvent("exec-1", StageQueued, "picked up"); err != nil {
+			t.Fatalf("RecordExecutionEvent failed: %v", err)
+		}
+		events, err := store.ListExecutionEvents("exec-1")
+		if err != nil {
+			t.Fatalf("ListExecutionEvents failed: %v", err)
+		}
+		if len(events) != 1 || events[0].Stage != StageQueued {
+			t.Fatalf("got events %+v, want a single %q event", events, StageQueued)
+		}
+	})
+
+	t.Run("unknown execution row returns ErrExecutionNotFound and writes nothing", func(t *testing.T) {
+		err := store.RecordExecutionEvent("exec-ghost", StageCommit, "commit created: abc1234")
+		if !errors.Is(err, ErrExecutionNotFound) {
+			t.Fatalf("RecordExecutionEvent error = %v, want ErrExecutionNotFound", err)
+		}
+
+		events, err := store.ListExecutionEvents("exec-ghost")
+		if err != nil {
+			t.Fatalf("ListExecutionEvents failed: %v", err)
+		}
+		if len(events) != 0 {
+			t.Errorf("expected 0 events for an execution row that was never saved, got %d", len(events))
+		}
+	})
 }
 
 // TestListExecutionsForTask covers newest-first ordering and an unknown task id.

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -791,9 +791,35 @@ type Event struct {
 	Detail      string
 }
 
+// ErrExecutionNotFound is returned by RecordExecutionEvent when executionID
+// has no matching executions row. Callers treat it as a warn-and-skip signal,
+// never as a reason to fail the caller's own operation (GH-4244).
+var ErrExecutionNotFound = errors.New("execution not found")
+
+// RecordExecutionEvent is the validate-first entry point for writing to the
+// execution_events audit trail (GH-4244). It replaces the pattern of calling
+// InsertExecutionEvent directly and letting a missing parent row surface as a
+// SQLite foreign-key constraint error (FK-787) — instead it confirms the
+// executions row exists first and returns ErrExecutionNotFound so the caller
+// can log a clean warning and skip the write. This is now the single place
+// that guards the executions/execution_events FK; every recordExecutionEvent
+// wrapper across the executor and autopilot packages delegates here.
+func (s *Store) RecordExecutionEvent(executionID string, stage Stage, detail string) error {
+	if _, err := s.GetExecution(executionID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("%w: execution_id=%s", ErrExecutionNotFound, executionID)
+		}
+		return fmt.Errorf("failed to verify execution %s exists: %w", executionID, err)
+	}
+	return s.InsertExecutionEvent(executionID, stage, detail)
+}
+
 // InsertExecutionEvent records a stage transition for executionID. occurred_at is
 // always the write-time UTC clock, not a caller-supplied value, so the ledger
-// can't be back-dated or skewed by local timezone (TASK-379 C2/C3).
+// can't be back-dated or skewed by local timezone (TASK-379 C2/C3). Most
+// callers should use RecordExecutionEvent instead, which validates the parent
+// row exists first; this method is exposed for call sites (e.g. tests,
+// RecordExecutionEvent itself) that already hold a known-good execution ID.
 func (s *Store) InsertExecutionEvent(executionID string, stage Stage, detail string) error {
 	return s.withRetry("InsertExecutionEvent", func() error {
 		_, err := s.db.Exec(`


### PR DESCRIPTION
## Summary
- Adds `memory.Store.RecordExecutionEvent` as the single validate-first chokepoint for `execution_events` writes: it confirms the parent `executions` row exists (`GetExecution`) before inserting, returning `ErrExecutionNotFound` when it doesn't — so a stale/unknown execution ID can never surface as a SQLite FK constraint error (FK-787).
- Migrates all four independent `recordExecutionEvent` wrappers (`Runner`, `Dispatcher`, `ProjectWorker` in `internal/executor`, and `Controller` in `internal/autopilot`) to delegate the actual write to `RecordExecutionEvent` instead of calling `InsertExecutionEvent` directly. Controller's existing `GetLatestExecutionByTaskID`-then-insert resolution stays (it solves a distinct problem — task ID → execution ID — not the FK guard), but now funnels the insert itself through the shared chokepoint.
- `task.LogExecutionID()`'s resolution order (`ExecutionID` → `ParentExecutionID` → `task.ID`) is unchanged; the bare `task.ID` fallback now goes through the existence check instead of a blind insert.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./...` (full suite green)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` (0 issues)
- [x] New regression tests: `internal/memory/execution_events_test.go` (`TestRecordExecutionEvent_ValidatesFirst`), `internal/executor/dispatcher_test.go` (`TestProjectWorker_recordExecutionEvent_UnknownExecution`, `TestDispatcher_recordExecutionEvent_UnknownExecution`) — each proves an unknown execution ID warns-and-skips with zero events written, never an FK failure.
- [x] Existing `execution_events`/`controller_execution_events_test.go` coverage stays green.

Refs: #4243 (blocked-by, merged), `.agent/tasks/TASK-404-execution-lifecycle-chokepoint.md`