### PR TITLE
fix(ci): resolve post-merge CI failure from PR #4257

### DIFF
--- a/.agent/knowledge/graph.json
+++ b/.agent/knowledge/graph.json
@@ -2710,6 +2710,7 @@
       "mem-152": {
         "type": "learning",
         "summary": "Status reports to user must be scannable grouped lists (done / failed+reset / needs-attention / watch), one line per item \u2014 never narrative prose. Direct user feedback 2026-07-13.",
+        "path": "memories/learnings/mem-152.md",
         "concepts": [
           "user-preference",
           "communication",

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -1058,14 +1058,17 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 		result, execErr := w.runner.Execute(ctx, task)
 		duration := time.Since(start)
 
-		// GH-4243: single chokepoint classifies the outcome (TerminalStatus),
-		// persists the terminal status, and saves metrics. The branches below
-		// drive event-recording/progress side effects off the same
-		// classification instead of re-deriving it.
-		outcome, finErr := w.lifecycle.Finish(exec.ID, result, execErr, duration)
-		if finErr != nil {
-			w.log.Error("Failed to persist execution outcome", slog.String("execution_id", exec.ID), slog.Any("error", finErr))
-		}
+		// GH-4243: single chokepoint classifies the outcome (TerminalStatus).
+		// The branches below drive event-recording/progress side effects off
+		// the classification, then GH-4259 requires persisting the terminal
+		// status (below, after the switch) only once those events are
+		// written — otherwise a poller can observe the terminal status via
+		// GetExecution and read the execution_events ledger before the
+		// matching event row exists, intermittently losing the race (this is
+		// exactly what made the synthetic dispatch event-sequence tests flake
+		// once RecordExecutionEvent's GH-4244 validate-first GetExecution
+		// round trip made the event write slow enough to lose more often).
+		outcome := w.lifecycle.Classify(result, execErr)
 
 		switch {
 		case execErr != nil:
@@ -1113,6 +1116,12 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 				msg = fmt.Sprintf("Completed with PR: %s", result.PRUrl)
 			}
 			w.runner.EmitProgress(exec.TaskID, "Completed", 100, msg)
+		}
+
+		// GH-4259: persist the terminal status/metrics after the events above
+		// are written, not before — see the Classify comment.
+		if finErr := w.lifecycle.Persist(exec.ID, outcome, result, duration); finErr != nil {
+			w.log.Error("Failed to persist execution outcome", slog.String("execution_id", exec.ID), slog.Any("error", finErr))
 		}
 
 		// Effort tier and usage-event telemetry stay dispatcher-owned: they're

--- a/internal/executor/lifecycle.go
+++ b/internal/executor/lifecycle.go
@@ -113,16 +113,14 @@ type FinishOutcome struct {
 	Error  string
 }
 
-// Finish terminates execID: classifies result via TerminalStatus, persists
-// the terminal status (MarkExecutionCompleted on success so pr_url/
-// commit_sha/duration land atomically, UpdateExecutionStatus otherwise), and
-// saves execution metrics whenever result is non-nil — generalizing
-// finalizeSubIssueExecution (the TASK-394 sub-issue chokepoint) to every
-// caller. execErr, when non-nil, short-circuits classification straight to
+// Classify computes Finish's terminal outcome without persisting anything
+// (GH-4259). Split out so a caller that needs to record execution_events
+// rows for the terminal stage can do so before the status write Persist
+// performs — see Persist's doc comment for why the ordering matters.
+//
+// execErr, when non-nil, short-circuits classification straight to
 // StatusFailed, mirroring every existing call site's "err != nil" branch
-// running before TerminalStatus is even consulted; metrics are still saved
-// in that case if result is non-nil (the execution ran and produced partial
-// results before erroring), matching the dispatcher's existing behavior.
+// running before TerminalStatus is even consulted.
 //
 // override, when given, replaces the classified status outright — for a
 // caller that has evidence the classifier can't see. epic.go's work-loss
@@ -131,14 +129,8 @@ type FinishOutcome struct {
 // "completed" but the epic must record as "failed" so the issue stays open
 // for recovery. errMsg is still sourced from execErr/result as usual; only
 // the status itself is overridden.
-func (l *ExecutionLifecycle) Finish(execID string, result *ExecutionResult, execErr error, duration time.Duration, override ...Status) (FinishOutcome, error) {
-	if l.store == nil || execID == "" {
-		return FinishOutcome{}, nil
-	}
-
+func (l *ExecutionLifecycle) Classify(result *ExecutionResult, execErr error, override ...Status) FinishOutcome {
 	var outcome FinishOutcome
-	var statusErr error
-
 	if execErr != nil {
 		outcome = FinishOutcome{Status: ExecStatusFailed, Error: execErr.Error()}
 	} else {
@@ -150,7 +142,30 @@ func (l *ExecutionLifecycle) Finish(execID string, result *ExecutionResult, exec
 	if len(override) > 0 {
 		outcome.Status = override[0]
 	}
+	return outcome
+}
 
+// Persist writes a pre-classified outcome for execID: MarkExecutionCompleted
+// on success so pr_url/commit_sha/duration land atomically,
+// UpdateExecutionStatus otherwise, then saves execution metrics whenever
+// result is non-nil — generalizing finalizeSubIssueExecution (the TASK-394
+// sub-issue chokepoint) to every caller.
+//
+// GH-4259: this is the write that makes execID's terminal status visible to
+// anything polling GetExecution. Callers that also record an
+// execution_events row for the same terminal transition (e.g. the
+// dispatcher's StageFailed/StageCompleted writes) MUST call recordExecutionEvent
+// before Persist, not after — otherwise a poller can observe the terminal
+// status and read the event ledger before the matching event row exists,
+// intermittently losing the race (the synthetic dispatch event-sequence
+// tests caught this once RecordExecutionEvent's validate-first GetExecution
+// round trip, GH-4244, made the event write slow enough to lose more often).
+func (l *ExecutionLifecycle) Persist(execID string, outcome FinishOutcome, result *ExecutionResult, duration time.Duration) error {
+	if l.store == nil || execID == "" {
+		return nil
+	}
+
+	var statusErr error
 	if outcome.Status == ExecStatusCompleted {
 		var prURL, commitSHA string
 		if result != nil {
@@ -182,5 +197,19 @@ func (l *ExecutionLifecycle) Finish(execID string, result *ExecutionResult, exec
 		}
 	}
 
-	return outcome, statusErr
+	return statusErr
+}
+
+// Finish terminates execID in one call: Classify followed by Persist.
+// Callers that need to record execution_events rows for the terminal stage
+// without racing a status poller should call Classify and Persist directly
+// instead, recording events between the two (GH-4259) — see Persist's doc
+// comment.
+func (l *ExecutionLifecycle) Finish(execID string, result *ExecutionResult, execErr error, duration time.Duration, override ...Status) (FinishOutcome, error) {
+	if l.store == nil || execID == "" {
+		return FinishOutcome{}, nil
+	}
+	outcome := l.Classify(result, execErr, override...)
+	err := l.Persist(execID, outcome, result, duration)
+	return outcome, err
 }


### PR DESCRIPTION
## Summary

GH-4259: post-merge CI on PR #4257 failed on two independent things.

**`test` job — flaky terminal-event race (`internal/executor`)**

`ProjectWorker.processQueue` persisted an execution's terminal status via
`ExecutionLifecycle.Finish` (→ `UpdateExecutionStatus`) *before* recording
the matching `execution_events` row. A test/poller reading `GetExecution`
right after the status write could observe the terminal status and read the
event ledger before the event row existed — losing the race intermittently.
PR #4257 switched `InsertExecutionEvent` → the validate-first
`RecordExecutionEvent`, adding a `GetExecution` round trip per event write;
that extra latency made the event write lose the race more often in CI,
surfacing as `TestDispatcher_SyntheticDispatch_FailureEventSequence` and
`TestDispatcher_SyntheticDispatch_InfraEventSequence` failures.

Fix: split `ExecutionLifecycle.Finish` into `Classify` (pure) and `Persist`
(I/O), and reorder `processQueue` to record the terminal execution_events
row between them — so the terminal status is never visible before its event.
`Finish` itself is unchanged (still `Classify` + `Persist`) for other callers.

**`Knowledge Graph Drift Gate` job (`.agent/knowledge/graph.json`)**

`mem-152`'s node was missing the `path` field every other memory node
carries, so `scripts/check-graph.py`'s "unindexed active memory files" check
flagged `.agent/knowledge/memories/learnings/mem-152.md` as drift on every
push touching main. One-line fix: add `"path": "memories/learnings/mem-152.md"`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/... -race -count=1` (full package, incl. workflow subpkg)
- [x] `go test ./internal/memory/... ./internal/autopilot/... -race -count=1`
- [x] `go test ./internal/executor/... -run 'TestDispatcher_SyntheticDispatch|TestExecutionLifecycle' -race -count=10` — previously-flaky tests, 10x race-detector iterations, all green
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `python3 scripts/check-graph.py` — exit 0 (was exit 1: `FAIL .agent/knowledge/memories/learnings/mem-152.md`)