### PR TITLE
feat(executor): log + ledger event when a task skips decomposition

### DIFF
--- a/.agent/tasks/gh-4271.md
+++ b/.agent/tasks/gh-4271.md
@@ -1,0 +1,36 @@
+# GH-4271
+
+**Created:** 2026-07-13
+
+## Problem
+
+GitHub Issue GH-4271: feat(executor): log + ledger event when an epic-classified task skips decomposition (gate reasons are silent today)
+
+## Problem
+
+Canary sandbox#6 (2026-07-13) was classified `epic` (executions.complexity_level = epic) but decomposition was skipped by the `decompose.min_description_words` gate — with ZERO trace: no log line, no execution event. Diagnosis required querying execution_events/execution_logs and reading operator config by hand. A silent classify-epic-then-direct-ship path is indistinguishable from the TASK-401 defect class it resembles.
+
+## Fix
+
+At the decomposition decision point in the executor: when a task classified `epic` (or above `decompose.min_complexity`) does NOT enter decomposition, emit:
+1. A log line with the concrete gate and values, e.g. `decomposition skipped: description_words=275 < min_description_words=300` (same for min_complexity, enabled=false, max_subtasks edge cases, and the TASK-401 len<=1 short-circuit — that one may already log; verify and unify).
+2. An execution event via the ExecutionLifecycle chokepoint (#4248) — reuse an existing stage if the 22-stage vocabulary has a fit, else add `decomposition_skipped` with detail carrying the reason (follow the GH-3840 stage-vocabulary conventions in internal/memory/store.go).
+
+## Acceptance criteria
+
+- Every non-decomposition outcome for an epic-classified task produces exactly one skip event + one log line with machine-readable reason
+- `pilot trace <task>` shows the skip reason in the timeline
+- Table-driven test covering each gate reason
+- No behavior change to the decomposition decision itself
+
+## Refs
+- Evidence: canary run 29266790390, sandbox#6 (275 words vs min 300)
+- Companion scenario fix: #4270 · Alert: #4265 · Chokepoint: #4248 (TASK-404 B1)
+
+## Planned Steps (execute all in sequence)
+
+- Step 1: **feat(executor): emit skip log + lifecycle event for epic tasks that bypass decomposition** — At the decomposition decision point in the executor, wrap every non-decomposition outcome for a task at or above decompose.min_complexity (including the epic tier) so it produces exactly one structured log line and one execution event via the ExecutionLifecycle chokepoint (#4248). Cover each gate branch — enabled=false, complexity < min_complexity, description_words < min_description_words, max_subtasks<=0, and the TASK-401 len(subtasks)<=1 short-circuit — with a machine-readable reason code plus concrete threshold/observed values in the event detail and log fields; unify with any existing partial logging (verify the TASK-401 path). Reuse an existing stage from the 22-stage vocabulary in internal/memory/store.go if one fits the 'decomposition considered but skipped' semantics; otherwise add a decomposition_skipped stage constant following the GH-3840 stage-vocabulary conventions (same file, same PR). Add a table-driven test in the executor package that drives each gate branch and asserts: (a) the emitted log line contains the reason code and numeric values, (b) exactly one lifecycle event is written with the expected stage and detail payload, and (c) the decomposition decision itself is unchanged from current behavior. Verify pilot trace <task> surfaces the new event in the timeline. No behavior change to the decomposition decision, no new config knobs, no changes outside the executor decision site and the store.go stage constant.
+
+
+## Acceptance Criteria
+

--- a/internal/executor/decompose.go
+++ b/internal/executor/decompose.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -46,7 +47,54 @@ type DecomposeResult struct {
 
 	// Reason explains why decomposition did or did not occur.
 	Reason string
+
+	// SkipReason is a machine-readable code for why decomposition did not
+	// occur (GH-4271). Empty (SkipReasonNone) when Decomposed is true.
+	SkipReason SkipReason
+
+	// Complexity is the task's classified complexity at the point this
+	// result was produced (GH-4271). Populated on every branch — including
+	// early-exit gates (disabled/label/phrase) via the cheap word-count
+	// heuristic, never the optional LLM classifier — so callers can judge
+	// whether a skip is worth surfacing without re-classifying or triggering
+	// an LLM call as a side effect of logging.
+	Complexity Complexity
+
+	// DescriptionWords is the word count evaluated against
+	// MinDescriptionWords. Only populated when SkipReason is
+	// SkipReasonDescriptionTooShort (GH-4271).
+	DescriptionWords int
 }
+
+// SkipReason is a machine-readable code for why TaskDecomposer did not split
+// a task, independent of the human-readable DecomposeResult.Reason string
+// (GH-4271). Callers use it to build structured log fields/event details
+// without parsing prose.
+type SkipReason string
+
+const (
+	// SkipReasonNone means decomposition succeeded — there is nothing to report.
+	SkipReasonNone SkipReason = ""
+	// SkipReasonNilTask means Decompose was called with a nil task.
+	SkipReasonNilTask SkipReason = "nil_task"
+	// SkipReasonDisabled means decompose.enabled is false.
+	SkipReasonDisabled SkipReason = "disabled"
+	// SkipReasonNoDecomposeLabel means the task carries the no-decompose label (GH-664).
+	SkipReasonNoDecomposeLabel SkipReason = "no_decompose_label"
+	// SkipReasonNoDecomposePhrase means the task's title/description contains
+	// prose that opts out of decomposition (GH-2783/GH-3597).
+	SkipReasonNoDecomposePhrase SkipReason = "no_decompose_phrase"
+	// SkipReasonBelowMinComplexity means the classified complexity does not
+	// meet decompose.min_complexity.
+	SkipReasonBelowMinComplexity SkipReason = "below_min_complexity"
+	// SkipReasonDescriptionTooShort means the description word count is below
+	// decompose.min_description_words (heuristic mode only, GH-1728).
+	SkipReasonDescriptionTooShort SkipReason = "description_too_short"
+	// SkipReasonNoSplitPoints means no structural decomposition points
+	// (numbered steps/bullets/criteria/file groups) were found, or all
+	// extracted parts collapsed to <=1 non-empty subtask (TASK-401 class).
+	SkipReasonNoSplitPoints SkipReason = "no_split_points"
+)
 
 // NoDecomposeLabel is the GitHub label that bypasses decomposition entirely (GH-664).
 const NoDecomposeLabel = "no-decompose"
@@ -119,8 +167,16 @@ func (d *TaskDecomposer) DecomposeWithContext(ctx context.Context, task *Task) *
 			Decomposed: false,
 			Subtasks:   nil,
 			Reason:     "nil task",
+			SkipReason: SkipReasonNilTask,
 		}
 	}
+
+	// GH-4271: cheap word-count heuristic classification up front, purely so
+	// early-exit gates below (disabled/label/phrase) can still report whether
+	// the task looked epic/complex-tier. Never the optional LLM classifier —
+	// that must not fire as a side effect of a branch that never reaches the
+	// "real" classification a few lines down.
+	precheckComplexity := DetectComplexity(task)
 
 	// Check if decomposition is enabled
 	if !d.config.Enabled {
@@ -128,6 +184,8 @@ func (d *TaskDecomposer) DecomposeWithContext(ctx context.Context, task *Task) *
 			Decomposed: false,
 			Subtasks:   []*Task{task},
 			Reason:     "decomposition disabled",
+			SkipReason: SkipReasonDisabled,
+			Complexity: precheckComplexity,
 		}
 	}
 
@@ -137,6 +195,8 @@ func (d *TaskDecomposer) DecomposeWithContext(ctx context.Context, task *Task) *
 			Decomposed: false,
 			Subtasks:   []*Task{task},
 			Reason:     "skipped: no-decompose label",
+			SkipReason: SkipReasonNoDecomposeLabel,
+			Complexity: precheckComplexity,
 		}
 	}
 
@@ -146,6 +206,8 @@ func (d *TaskDecomposer) DecomposeWithContext(ctx context.Context, task *Task) *
 			Decomposed: false,
 			Subtasks:   []*Task{task},
 			Reason:     "skipped: no-decompose phrase in title/description",
+			SkipReason: SkipReasonNoDecomposePhrase,
+			Complexity: precheckComplexity,
 		}
 	}
 
@@ -154,7 +216,7 @@ func (d *TaskDecomposer) DecomposeWithContext(ctx context.Context, task *Task) *
 	if d.classifier != nil {
 		complexity = d.classifier.Classify(ctx, task)
 	} else {
-		complexity = DetectComplexity(task)
+		complexity = precheckComplexity
 	}
 
 	if !d.shouldDecompose(complexity) {
@@ -162,6 +224,8 @@ func (d *TaskDecomposer) DecomposeWithContext(ctx context.Context, task *Task) *
 			Decomposed: false,
 			Subtasks:   []*Task{task},
 			Reason:     "complexity below threshold: " + complexity.String(),
+			SkipReason: SkipReasonBelowMinComplexity,
+			Complexity: complexity,
 		}
 	}
 
@@ -171,9 +235,12 @@ func (d *TaskDecomposer) DecomposeWithContext(ctx context.Context, task *Task) *
 	usedLLMClassifier := d.classifier != nil
 	if !usedLLMClassifier && wordCount < d.config.MinDescriptionWords {
 		return &DecomposeResult{
-			Decomposed: false,
-			Subtasks:   []*Task{task},
-			Reason:     "description too short for decomposition (heuristic mode)",
+			Decomposed:       false,
+			Subtasks:         []*Task{task},
+			Reason:           "description too short for decomposition (heuristic mode)",
+			SkipReason:       SkipReasonDescriptionTooShort,
+			Complexity:       complexity,
+			DescriptionWords: wordCount,
 		}
 	}
 
@@ -184,6 +251,8 @@ func (d *TaskDecomposer) DecomposeWithContext(ctx context.Context, task *Task) *
 			Decomposed: false,
 			Subtasks:   []*Task{task},
 			Reason:     "no decomposition points found",
+			SkipReason: SkipReasonNoSplitPoints,
+			Complexity: complexity,
 		}
 	}
 
@@ -191,6 +260,7 @@ func (d *TaskDecomposer) DecomposeWithContext(ctx context.Context, task *Task) *
 		Decomposed: true,
 		Subtasks:   subtasks,
 		Reason:     "decomposed into subtasks",
+		Complexity: complexity,
 	}
 }
 
@@ -250,6 +320,47 @@ func (d *TaskDecomposer) shouldDecompose(complexity Complexity) bool {
 		return complexity == ComplexityComplex || complexity == ComplexityMedium
 	default:
 		return complexity == ComplexityComplex
+	}
+}
+
+// ReportableSkip reports whether result represents a non-decomposition
+// outcome worth surfacing as a skip log line + execution event (GH-4271).
+//
+// The canary defect this closes: a task classified epic (or at/above
+// decompose.min_complexity) bypassed decomposition — e.g. gated by
+// min_description_words — with zero trace, indistinguishable from the
+// TASK-401 defect class. shouldDecompose(result.Complexity) is exactly
+// "would this task's complexity tier alone have triggered decomposition",
+// so reusing it here means every OTHER gate (disabled/label/phrase/
+// description-too-short/no-split-points) is reported whenever it fires on a
+// task that met the complexity bar. SkipReasonBelowMinComplexity is
+// intentionally excluded: shouldDecompose(result.Complexity) is false by
+// construction on that branch, since the whole point of that gate is that
+// complexity was too low to warrant decomposition in the first place — not
+// a silent-epic scenario.
+func (d *TaskDecomposer) ReportableSkip(result *DecomposeResult) bool {
+	if result == nil || result.Decomposed || result.SkipReason == SkipReasonNone {
+		return false
+	}
+	return d.shouldDecompose(result.Complexity)
+}
+
+// SkipLogDetail renders a machine-readable, single-line message for
+// result's skip reason, e.g. "decomposition skipped: description_words=275 <
+// min_description_words=300" (GH-4271). Concrete threshold/observed values
+// are included where the gate has them; other gates carry just the reason
+// code since there's nothing numeric to report.
+func (d *TaskDecomposer) SkipLogDetail(result *DecomposeResult) string {
+	prefix := "decomposition skipped: reason=" + string(result.SkipReason) +
+		" complexity=" + result.Complexity.String()
+	switch result.SkipReason {
+	case SkipReasonDescriptionTooShort:
+		return prefix + fmt.Sprintf(" description_words=%d < min_description_words=%d",
+			result.DescriptionWords, d.config.MinDescriptionWords)
+	case SkipReasonBelowMinComplexity:
+		return prefix + " min_complexity=" + d.config.MinComplexity
+	default:
+		return prefix
 	}
 }
 

--- a/internal/executor/decompose_skip_gh4271_test.go
+++ b/internal/executor/decompose_skip_gh4271_test.go
@@ -1,0 +1,201 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTaskDecomposer_SkipReason_TableDriven is the GH-4271 regression suite:
+// every non-decomposition branch in DecomposeWithContext must report a
+// machine-readable SkipReason plus the classified Complexity, so callers can
+// tell a genuine complex/epic-tier skip (worth a log line + execution event)
+// apart from an unremarkable one (task never met the tier in the first
+// place). See TaskDecomposer.ReportableSkip for the reporting policy.
+func TestTaskDecomposer_SkipReason_TableDriven(t *testing.T) {
+	baseConfig := func() *DecomposeConfig {
+		return &DecomposeConfig{
+			Enabled:             true,
+			MinComplexity:       "complex",
+			MaxSubtasks:         5,
+			MinDescriptionWords: 50,
+		}
+	}
+
+	longNonStructuredDescription := strings.Repeat("word ", 60) +
+		"this description has plenty of words but no numbered steps, bullets, checkboxes, or file paths."
+
+	tests := []struct {
+		name           string
+		config         *DecomposeConfig
+		task           *Task
+		wantSkipReason SkipReason
+		wantComplexity Complexity
+		wantReportable bool
+	}{
+		{
+			name: "disabled gate on an epic-classified task",
+			config: func() *DecomposeConfig {
+				c := baseConfig()
+				c.Enabled = false
+				return c
+			}(),
+			task: &Task{
+				ID:          "GH-1",
+				Title:       "[epic] roll out multi-service rollout",
+				Description: "short",
+			},
+			wantSkipReason: SkipReasonDisabled,
+			wantComplexity: ComplexityEpic,
+			wantReportable: true,
+		},
+		{
+			name:   "no-decompose label gate",
+			config: baseConfig(),
+			task: &Task{
+				ID:          "GH-2",
+				Title:       "[epic] roll out multi-service rollout",
+				Description: "short",
+				Labels:      []string{NoDecomposeLabel},
+			},
+			wantSkipReason: SkipReasonNoDecomposeLabel,
+			wantComplexity: ComplexityComplex, // detectEpic downgrades to complex when the label is present
+			wantReportable: true,
+		},
+		{
+			name:   "no-decompose phrase gate",
+			config: baseConfig(),
+			task: &Task{
+				ID:          "GH-3",
+				Title:       "[epic] roll out multi-service rollout",
+				Description: "This task must not be decomposed under any circumstances.",
+			},
+			wantSkipReason: SkipReasonNoDecomposePhrase,
+			wantComplexity: ComplexityComplex, // detectEpic downgrades to complex when the phrase is present
+			wantReportable: true,
+		},
+		{
+			name:   "complexity below min_complexity threshold",
+			config: baseConfig(),
+			task: &Task{
+				ID:          "GH-4",
+				Title:       "Add a new dashboard widget",
+				Description: "Add a new widget to the dashboard that shows the current queue depth and updates live via websocket polling.",
+			},
+			wantSkipReason: SkipReasonBelowMinComplexity,
+			wantComplexity: ComplexityMedium,
+			wantReportable: false, // by construction shouldDecompose(Medium) is false here — not a silent-epic scenario
+		},
+		{
+			name:   "description too short (heuristic mode) on a complex-classified task",
+			config: baseConfig(),
+			task: &Task{
+				ID:          "GH-5",
+				Title:       "refactor the executor pipeline",
+				Description: "small change",
+			},
+			wantSkipReason: SkipReasonDescriptionTooShort,
+			wantComplexity: ComplexityComplex,
+			wantReportable: true,
+		},
+		{
+			name:   "no structural split points found",
+			config: baseConfig(),
+			task: &Task{
+				ID:          "GH-6",
+				Title:       "refactor the executor pipeline",
+				Description: longNonStructuredDescription,
+			},
+			wantSkipReason: SkipReasonNoSplitPoints,
+			wantComplexity: ComplexityComplex,
+			wantReportable: true,
+		},
+		{
+			name:   "successful decomposition reports no skip reason",
+			config: baseConfig(),
+			task: &Task{
+				ID:    "GH-7",
+				Title: "refactor the executor pipeline",
+				Description: "1. Update decompose.go\n" +
+					"2. Update runner.go\n" +
+					"3. Update dispatcher.go\n" +
+					"4. Add tests\n" +
+					strings.Repeat("word ", 50),
+			},
+			wantSkipReason: SkipReasonNone,
+			wantComplexity: ComplexityComplex,
+			wantReportable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decomposer := NewTaskDecomposer(tt.config)
+			result := decomposer.Decompose(tt.task)
+
+			if result.SkipReason != tt.wantSkipReason {
+				t.Errorf("SkipReason = %q, want %q (Reason=%q)", result.SkipReason, tt.wantSkipReason, result.Reason)
+			}
+			if result.Complexity != tt.wantComplexity {
+				t.Errorf("Complexity = %q, want %q", result.Complexity, tt.wantComplexity)
+			}
+			if got := decomposer.ReportableSkip(result); got != tt.wantReportable {
+				t.Errorf("ReportableSkip() = %v, want %v", got, tt.wantReportable)
+			}
+			if tt.wantSkipReason == SkipReasonNone && !result.Decomposed {
+				t.Error("expected Decomposed=true when SkipReason is none")
+			}
+			if tt.wantSkipReason != SkipReasonNone && result.Decomposed {
+				t.Error("expected Decomposed=false when a SkipReason is set")
+			}
+		})
+	}
+}
+
+// TestTaskDecomposer_ReportableSkip_NilAndEdgeCases verifies ReportableSkip's
+// guard clauses so a caller can pass any DecomposeResult without a nil check.
+func TestTaskDecomposer_ReportableSkip_NilAndEdgeCases(t *testing.T) {
+	decomposer := NewTaskDecomposer(DefaultDecomposeConfig())
+
+	if decomposer.ReportableSkip(nil) {
+		t.Error("ReportableSkip(nil) = true, want false")
+	}
+	if decomposer.ReportableSkip(&DecomposeResult{Decomposed: true, Complexity: ComplexityEpic}) {
+		t.Error("ReportableSkip on a successful decomposition = true, want false")
+	}
+	if decomposer.ReportableSkip(&DecomposeResult{Decomposed: false, SkipReason: SkipReasonNone, Complexity: ComplexityEpic}) {
+		t.Error("ReportableSkip with SkipReasonNone = true, want false")
+	}
+}
+
+// TestTaskDecomposer_SkipLogDetail_CarriesConcreteValues verifies the emitted
+// message contains the reason code plus concrete threshold/observed numbers,
+// matching the canary evidence format
+// ("decomposition skipped: ... description_words=275 < min_description_words=300").
+func TestTaskDecomposer_SkipLogDetail_CarriesConcreteValues(t *testing.T) {
+	decomposer := NewTaskDecomposer(&DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 300,
+	})
+
+	result := &DecomposeResult{
+		Decomposed:       false,
+		SkipReason:       SkipReasonDescriptionTooShort,
+		Complexity:       ComplexityEpic,
+		DescriptionWords: 275,
+	}
+
+	detail := decomposer.SkipLogDetail(result)
+
+	for _, want := range []string{
+		"reason=description_too_short",
+		"complexity=epic",
+		"description_words=275",
+		"min_description_words=300",
+	} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("SkipLogDetail() = %q, want it to contain %q", detail, want)
+		}
+	}
+}

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -570,6 +570,25 @@ func (d *Dispatcher) QueueTask(ctx context.Context, task *Task) (string, error) 
 		if result.Decomposed && len(result.Subtasks) > 1 {
 			return d.queueDecomposedTask(ctx, task, result)
 		}
+		// GH-4271: an epic-classified (or otherwise at/above min_complexity)
+		// task that does NOT enter decomposition previously left zero trace
+		// at this queue-time decision point — see the matching runner.go
+		// Execute() site for the direct-execution-time equivalent. execID
+		// only exists once queueSingleTask creates the executions row below,
+		// so the event write follows it rather than preceding it.
+		if d.decomposer.ReportableSkip(result) {
+			detail := d.decomposer.SkipLogDetail(result)
+			d.log.Info(detail,
+				slog.String("task_id", task.ID),
+				slog.String("skip_reason", string(result.SkipReason)),
+				slog.String("complexity", result.Complexity.String()),
+			)
+			execID, err := d.queueSingleTask(ctx, task)
+			if err == nil {
+				d.recordExecutionEvent(execID, memory.StageDecompositionSkipped, detail)
+			}
+			return execID, err
+		}
 	}
 
 	// Queue single task

--- a/internal/executor/dispatcher_decompose_skip_gh4271_test.go
+++ b/internal/executor/dispatcher_decompose_skip_gh4271_test.go
@@ -1,0 +1,131 @@
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestDispatcher_QueueTask_RecordsDecompositionSkipEvent is a GH-4271
+// regression test for the queue-time decision point (dispatcher.go
+// QueueTask): an epic-classified task whose description is too short to
+// clear decompose.min_description_words must record exactly one
+// decomposition_skipped execution event, and the decomposition decision
+// itself (the task still gets queued as a single unit) must be unchanged.
+func TestDispatcher_QueueTask_RecordsDecompositionSkipEvent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+	dispatcher.SetDecomposer(NewTaskDecomposer(&DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 300,
+	}))
+
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	task := &Task{
+		ID:          "GH-4271-EPIC",
+		Title:       "[epic] roll out multi-service rollout",
+		Description: "short description well under the word minimum",
+		ProjectPath: "/tmp/gh-4271-test-project",
+		Branch:      "test-branch",
+		CreatePR:    true,
+	}
+
+	execID, err := dispatcher.QueueTask(context.Background(), task)
+	if err != nil {
+		t.Fatalf("QueueTask() error: %v", err)
+	}
+
+	// Decomposition decision itself must be unchanged: the task is still
+	// queued as a single execution row, not split into subtasks.
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution() error: %v", err)
+	}
+	if exec.Status != "queued" && exec.Status != "running" {
+		t.Errorf("exec.Status = %q, want queued or running", exec.Status)
+	}
+	if exec.TaskID != task.ID {
+		t.Errorf("exec.TaskID = %q, want %q", exec.TaskID, task.ID)
+	}
+
+	events, err := store.ListExecutionEvents(execID)
+	if err != nil {
+		t.Fatalf("ListExecutionEvents() error: %v", err)
+	}
+
+	var skipEvents []*memory.Event
+	for _, e := range events {
+		if e.Stage == memory.StageDecompositionSkipped {
+			skipEvents = append(skipEvents, e)
+		}
+	}
+	if len(skipEvents) != 1 {
+		t.Fatalf("got %d decomposition_skipped events, want exactly 1 (all events: %+v)", len(skipEvents), events)
+	}
+
+	detail := skipEvents[0].Detail
+	for _, want := range []string{"reason=description_too_short", "complexity=epic", "min_description_words=300"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("event detail = %q, want it to contain %q", detail, want)
+		}
+	}
+}
+
+// TestDispatcher_QueueTask_BelowMinComplexity_NoSkipEvent verifies the
+// negative case: a task that never met decompose.min_complexity in the first
+// place is not reportable (SkipReasonBelowMinComplexity is excluded by
+// design — see TaskDecomposer.ReportableSkip), so no decomposition_skipped
+// event is written and the task queues normally (GH-4271).
+func TestDispatcher_QueueTask_BelowMinComplexity_NoSkipEvent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+	dispatcher.SetDecomposer(NewTaskDecomposer(&DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 50,
+	}))
+
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	task := &Task{
+		ID:          "GH-4271-MEDIUM",
+		Title:       "Add a new dashboard widget",
+		Description: "Add a new widget to the dashboard that shows the current queue depth and updates live via websocket polling.",
+		ProjectPath: "/tmp/gh-4271-test-project-2",
+		Branch:      "test-branch",
+		CreatePR:    true,
+	}
+
+	execID, err := dispatcher.QueueTask(context.Background(), task)
+	if err != nil {
+		t.Fatalf("QueueTask() error: %v", err)
+	}
+
+	events, err := store.ListExecutionEvents(execID)
+	if err != nil {
+		t.Fatalf("ListExecutionEvents() error: %v", err)
+	}
+	for _, e := range events {
+		if e.Stage == memory.StageDecompositionSkipped {
+			t.Errorf("unexpected decomposition_skipped event for a below-threshold task: %+v", e)
+		}
+	}
+}

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -2010,6 +2010,13 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 					slog.String("task_id", task.ID),
 					slog.Int("planned_subtasks", len(plan.Subtasks)),
 				)
+				// GH-4271: this path already logged (TASK-401/GH-1265) but never
+				// wrote an execution_events row, so `pilot trace` on an
+				// epic-classified task that collapsed to single-package scope
+				// showed no evidence decomposition was even considered. Unify
+				// with the regex-decomposer skip site below via the same stage.
+				r.recordExecutionEvent(task.LogExecutionID(), memory.StageDecompositionSkipped,
+					fmt.Sprintf("decomposition skipped: reason=single_package_scope complexity=epic planned_subtasks=%d", len(plan.Subtasks)))
 				r.reportProgress(task.ID, "Planning", 35, "Single-package scope detected, running as single task...")
 
 				// Enrich the task description with the planned steps so the executor
@@ -2208,6 +2215,21 @@ func (r *Runner) executeWithOptions(ctx context.Context, task *Task, allowWorktr
 				slog.String("reason", result.Reason),
 			)
 			return r.executeDecomposedTask(ctx, task, result.Subtasks, executionPath)
+		}
+		// GH-4271: an epic-classified (or otherwise at/above min_complexity)
+		// task that does NOT enter decomposition previously left zero trace —
+		// a canary run gated on min_description_words was indistinguishable
+		// from the TASK-401 defect class without hand-querying
+		// execution_events. Surface it as both a structured log line and an
+		// execution event so `pilot trace` shows why.
+		if r.decomposer.ReportableSkip(result) {
+			detail := r.decomposer.SkipLogDetail(result)
+			r.log.Info(detail,
+				slog.String("task_id", task.ID),
+				slog.String("skip_reason", string(result.SkipReason)),
+				slog.String("complexity", result.Complexity.String()),
+			)
+			r.recordExecutionEvent(task.LogExecutionID(), memory.StageDecompositionSkipped, detail)
 		}
 	}
 

--- a/internal/executor/runner_decompose_skip_gh4271_test.go
+++ b/internal/executor/runner_decompose_skip_gh4271_test.go
@@ -1,0 +1,187 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestExecute_DescriptionTooShort_LogsAndRecordsSkipEvent is a GH-4271
+// regression test for the runner.go Execute() decomposer call site: a
+// complex-classified task whose description is too short to clear
+// decompose.min_description_words must produce exactly one log line and one
+// decomposition_skipped execution event carrying the concrete
+// threshold/observed values, and must still execute as a single direct run
+// (the decomposition decision itself is unchanged — see
+// TestExecute_SinglePackageEpic_NumberedListDescription_SkipsDecomposition in
+// gh4052_test.go for the epic-tier sibling of this call site).
+func TestExecute_DescriptionTooShort_LogsAndRecordsSkipEvent(t *testing.T) {
+	dir := setupPRGuardRepo(t, "pilot/GH-4271-decompose-skip", true)
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	backend := &mockFixedBackend{
+		result: &BackendResult{Success: true, Output: "done", Model: "claude"},
+	}
+
+	var buf bytes.Buffer
+	runner := NewRunnerWithBackend(backend)
+	runner.log = slog.New(slog.NewTextHandler(&buf, nil))
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	runner.SetLogStore(store)
+	runner.EnableDecomposition(&DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 50,
+	})
+
+	const execID = "GH-4271-DESC-SHORT"
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          execID,
+		TaskID:      "GH-4271-DESC-SHORT",
+		ProjectPath: dir,
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	task := &Task{
+		ID:          "GH-4271-DESC-SHORT",
+		ExecutionID: execID,
+		Title:       "refactor the executor pipeline",
+		Description: "small change, nothing structural here",
+		ProjectPath: dir,
+		Branch:      "pilot/GH-4271-decompose-skip",
+		CreatePR:    false,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Execute() not successful: %s", result.Error)
+	}
+
+	// Decomposition decision itself must be unchanged: the task ran as a
+	// single direct execution, exactly like it did before this fix.
+	backend.mu.Lock()
+	execCount := backend.execCount
+	backend.mu.Unlock()
+	if execCount != 1 {
+		t.Errorf("backend.execCount = %d, want 1 (task must run as a single unit, not be decomposed)", execCount)
+	}
+	if result.IsEpic {
+		t.Error("expected IsEpic=false for a directly-executed complex task")
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "reason=description_too_short") {
+		t.Errorf("expected skip log line with reason=description_too_short, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "min_description_words=50") {
+		t.Errorf("expected skip log line with concrete min_description_words value, got: %s", logOutput)
+	}
+
+	events, err := store.ListExecutionEvents(execID)
+	if err != nil {
+		t.Fatalf("ListExecutionEvents() error: %v", err)
+	}
+	var skipEvents []*memory.Event
+	for _, e := range events {
+		if e.Stage == memory.StageDecompositionSkipped {
+			skipEvents = append(skipEvents, e)
+		}
+	}
+	if len(skipEvents) != 1 {
+		t.Fatalf("got %d decomposition_skipped events, want exactly 1 (all events: %+v)", len(skipEvents), events)
+	}
+	if !strings.Contains(skipEvents[0].Detail, "reason=description_too_short") {
+		t.Errorf("event detail = %q, want it to contain reason=description_too_short", skipEvents[0].Detail)
+	}
+}
+
+// TestExecute_SinglePackageEpic_RecordsUnifiedSkipEvent extends GH-4052's
+// single-package-scope regression (gh4052_test.go) to verify the GH-4271
+// unification: that branch already logged "Single-package scope detected"
+// but never wrote an execution_events row, leaving `pilot trace` silent for
+// exactly the epic-classified-but-collapsed-to-single-task scenario this
+// issue is about.
+func TestExecute_SinglePackageEpic_RecordsUnifiedSkipEvent(t *testing.T) {
+	dir := setupPRGuardRepo(t, "pilot/GH-4271-single-package", true)
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	backend := &mockFixedBackend{
+		result: &BackendResult{Success: true, Output: "done", Model: "claude"},
+	}
+
+	runner := NewRunnerWithBackend(backend)
+	runner.SetRecordingEnabled(false)
+	runner.skipPreflightChecks = true
+	runner.config = &BackendConfig{SkipSelfReview: true}
+	runner.SetLogStore(store)
+	runner.EnableDecomposition(nil)
+
+	const execID = "GH-4271-SINGLE-PKG"
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          execID,
+		TaskID:      "GH-4271-SINGLE-PKG",
+		ProjectPath: dir,
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution failed: %v", err)
+	}
+
+	task := &Task{
+		ID:          "GH-4271-SINGLE-PKG",
+		ExecutionID: execID,
+		Title:       "[epic] fix(executor): honor require_ci on polled merge path",
+		Description: "## Suggested investigation scope\n\n1. Check the guard\n2. Check the matcher\n",
+		ProjectPath: dir,
+		Branch:      "pilot/GH-4271-single-package",
+		CreatePR:    false,
+	}
+	runner.planEpicFn = func(_ context.Context, tsk *Task, _ string) (*EpicPlan, error) {
+		return gh4052SinglePackagePlan(tsk), nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := runner.Execute(ctx, task)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Execute() not successful: %s", result.Error)
+	}
+
+	events, err := store.ListExecutionEvents(execID)
+	if err != nil {
+		t.Fatalf("ListExecutionEvents() error: %v", err)
+	}
+	var skipEvents []*memory.Event
+	for _, e := range events {
+		if e.Stage == memory.StageDecompositionSkipped {
+			skipEvents = append(skipEvents, e)
+		}
+	}
+	if len(skipEvents) != 1 {
+		t.Fatalf("got %d decomposition_skipped events, want exactly 1 (all events: %+v)", len(skipEvents), events)
+	}
+	if !strings.Contains(skipEvents[0].Detail, "single_package_scope") {
+		t.Errorf("event detail = %q, want it to contain reason=single_package_scope", skipEvents[0].Detail)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -780,6 +780,16 @@ const (
 	// retry wall-clock share is queryable (GH-4129). Detail is a JSON object:
 	// {"loop","attempt"}.
 	StageRetryAttempt Stage = "retry_attempt"
+	// StageDecompositionSkipped records that a task classified epic (or at/
+	// above decompose.min_complexity) did NOT enter decomposition — the gate
+	// and concrete threshold/observed values are carried in Detail as a
+	// single-line machine-readable message (GH-4271). Distinct from
+	// StageSkipped/StageNoOp, which classify the whole execution's terminal
+	// outcome: this stage fires mid-execution while the task still proceeds
+	// to direct execution, closing the silent-epic-bypass gap that made a
+	// canary run (sandbox#6, 275 words vs min 300) indistinguishable from the
+	// TASK-401 defect class without hand-querying execution_events.
+	StageDecompositionSkipped Stage = "decomposition_skipped"
 )
 
 // Event represents a single stage-transition record for an execution.


### PR DESCRIPTION
## Summary
- Closes #4271. A task classified epic (or above `decompose.min_complexity`) that bypassed decomposition — e.g. gated by `decompose.min_description_words` — left zero trace, indistinguishable from the TASK-401 defect class.
- `DecomposeResult` now carries a machine-readable `SkipReason` and the classified `Complexity` on every non-decomposition branch; `TaskDecomposer.ReportableSkip` decides which are worth surfacing (everything the task's complexity tier would have qualified for, excluding the intentionally-below-threshold case) and `SkipLogDetail` renders the single-line message, e.g. `decomposition skipped: reason=description_too_short complexity=epic description_words=275 < min_description_words=300`.
- Both decomposer call sites (`runner.go` `Execute()` and `dispatcher.go` `QueueTask()`) now emit that message as a log line and a new `decomposition_skipped` execution event (`internal/memory/store.go`), so `pilot trace <task>` surfaces the reason.
- Unified the existing `isSinglePackageScope` (TASK-401/GH-1265) short-circuit, which already logged but never wrote an execution event, onto the same stage.
- No change to the decomposition decision itself — only observability added.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full repo)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] New table-driven test covering each gate reason (`decompose_skip_gh4271_test.go`)
- [x] Dispatcher-level integration test verifying exactly one event is written for a reportable skip, and none for a non-reportable one (`dispatcher_decompose_skip_gh4271_test.go`)
- [x] Runner-level `Execute()` integration tests for both call sites, including the unified single-package-scope path (`runner_decompose_skip_gh4271_test.go`)