### PR TITLE
feat(config): PILOT_HOSTED=1 — Save() no-op + hosted-mode boot assertions

### DIFF
--- a/.agent/system/FEATURE-MATRIX.md
+++ b/.agent/system/FEATURE-MATRIX.md
@@ -352,6 +352,7 @@
 | Docs board sync page | ✅ | docs | - | - | GitHub Projects V2 Board Sync documentation (v2.38.0) |
 | Docs CLI/homepage update | ✅ | docs | - | - | Update CLI commands and homepage for v2.25 (v2.38.0) |
 | Docs architecture update | ✅ | docs | - | - | Update architecture page with new adapters (v2.38.0) |
+| Hosted mode config guard | ✅ | config | - | `PILOT_HOSTED` env | `PILOT_HOSTED=1` makes `config.Save()` a logged WARN no-op (control-plane-rendered config.yaml must never be overwritten with resolved secrets) and enforces boot-time invariants — `upgrade.auto_hot_upgrade` must be false and `tunnel.enabled` must be false — failing loud in `Load()` otherwise (SaaS S0.7, GH-4274) |
 
 ## Approval Workflows
 

--- a/cmd/pilot/backend.go
+++ b/cmd/pilot/backend.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 
 	"github.com/qf-studio/pilot/internal/config"
 	"github.com/qf-studio/pilot/internal/executor"
@@ -319,12 +317,7 @@ Example:
 			cfg.Executor.Type = backendType
 
 			// Write config back
-			data, err := yaml.Marshal(cfg)
-			if err != nil {
-				return fmt.Errorf("failed to marshal config: %w", err)
-			}
-
-			if err := os.WriteFile(configPath, data, 0600); err != nil {
+			if err := config.Save(cfg, configPath); err != nil {
 				return fmt.Errorf("failed to write config: %w", err)
 			}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -589,6 +590,13 @@ func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			// PILOT_HOSTED=1: even the defaults must satisfy hosted
+			// invariants — DefaultConfig() enables auto_hot_upgrade, which a
+			// hosted instance running without an explicit config would
+			// otherwise silently violate.
+			if err := config.AssertHostedInvariants(); err != nil {
+				return nil, err
+			}
 			return config, nil // Return defaults if no config file
 		}
 		return nil, fmt.Errorf("failed to read config: %w", err)
@@ -627,11 +635,58 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 
+	// PILOT_HOSTED=1: hard invariants of the hosted profile (GH-4274).
+	if err := config.AssertHostedInvariants(); err != nil {
+		return nil, err
+	}
+
 	return config, nil
+}
+
+// hostedEnvVar gates hosted mode (SaaS S0.7, GH-4274): a control-plane-
+// managed instance where config.yaml is rendered externally (secrets are
+// ${VAR} references resolved from a tmpfs env file) and must never be
+// overwritten by this binary. See .agent/system/saas-fleet-design.md §4.
+const hostedEnvVar = "PILOT_HOSTED"
+
+// IsHosted reports whether Pilot is running in hosted mode (PILOT_HOSTED=1).
+// Re-read from the environment on every call rather than cached at process
+// init, so tests can toggle it with t.Setenv; in production the env var is
+// fixed for the life of the process, so this is effectively "read once at
+// startup" in practice.
+func IsHosted() bool {
+	return os.Getenv(hostedEnvVar) == "1"
+}
+
+// AssertHostedInvariants enforces the hard invariants of the hosted profile
+// (PILOT_HOSTED=1, SaaS S0.7). Hosted instances are redeployed and exposed
+// by the control plane, so a config that enables self-upgrade or a local
+// tunnel is a misconfiguration, not a valid deployment — both fail loud at
+// boot rather than letting the instance run against a config the hosted
+// profile forbids. No-op when hosted mode is off.
+func (c *Config) AssertHostedInvariants() error {
+	if !IsHosted() {
+		return nil
+	}
+	if c.Upgrade != nil && c.Upgrade.AutoHotUpgrade {
+		return fmt.Errorf("config: PILOT_HOSTED=1 requires upgrade.auto_hot_upgrade=false (hosted instances are redeployed by the control plane, not self-upgraded)")
+	}
+	if c.Tunnel != nil && c.Tunnel.Enabled {
+		return fmt.Errorf("config: PILOT_HOSTED=1 requires tunnel.enabled=false (hosted ingress is terminated by the platform, not a tunnel running inside the instance)")
+	}
+	return nil
 }
 
 // Save writes the configuration to a YAML file at the given path.
 // It creates the parent directory if it does not exist.
+//
+// PILOT_HOSTED=1 (SaaS S0.7): hosted instances run against a config.yaml
+// rendered by a control plane, where secrets are ${VAR} references resolved
+// from a tmpfs env file at Load time. Round-tripping the expanded in-memory
+// Config back to config.yaml would write live secrets onto the mounted
+// volume — see .agent/system/saas-fleet-design.md §4. In hosted mode Save
+// becomes a no-op, logged at WARN with the calling file:line so any flow
+// that still attempts a write is visible.
 //
 // TASK-290: file mode is 0600 and parent dir is 0700 because the config
 // contains GitHub PAT, Linear API key, Slack bot token, and (optionally)
@@ -639,6 +694,15 @@ func Load(path string) (*Config, error) {
 // If a config already exists on disk with looser perms, this Save call will
 // tighten them on the next write (existing 0644 files are rewritten 0600).
 func Save(config *Config, path string) error {
+	if IsHosted() {
+		caller := "unknown"
+		if _, file, line, ok := runtime.Caller(1); ok {
+			caller = fmt.Sprintf("%s:%d", file, line)
+		}
+		log.Printf("WARN: config: PILOT_HOSTED=1 — Save(%s) suppressed, called from %s", path, caller)
+		return nil
+	}
+
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("failed to create config directory: %w", err)

--- a/internal/config/hosted_test.go
+++ b/internal/config/hosted_test.go
@@ -1,0 +1,302 @@
+package config
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsHosted(t *testing.T) {
+	t.Run("Unset", func(t *testing.T) {
+		if IsHosted() {
+			t.Error("IsHosted() = true, want false when PILOT_HOSTED is unset")
+		}
+	})
+
+	t.Run("SetToOne", func(t *testing.T) {
+		t.Setenv(hostedEnvVar, "1")
+		if !IsHosted() {
+			t.Error("IsHosted() = false, want true when PILOT_HOSTED=1")
+		}
+	})
+
+	t.Run("SetToOtherValue", func(t *testing.T) {
+		// Only the literal "1" enables hosted mode — "true"/"yes" do not,
+		// matching the exact contract in the issue (PILOT_HOSTED=1).
+		t.Setenv(hostedEnvVar, "true")
+		if IsHosted() {
+			t.Error("IsHosted() = true, want false when PILOT_HOSTED=true (only \"1\" enables hosted mode)")
+		}
+	})
+}
+
+// TestSave_HostedModeNoOp proves PILOT_HOSTED=1 makes Save() a no-op: the
+// target file is neither created nor modified, and a WARN log names the
+// caller (GH-4274 acceptance criterion).
+func TestSave_HostedModeNoOp(t *testing.T) {
+	t.Run("NewFile_NeverCreated", func(t *testing.T) {
+		t.Setenv(hostedEnvVar, "1")
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		var logBuf bytes.Buffer
+		originalOutput := log.Writer()
+		log.SetOutput(&logBuf)
+		defer log.SetOutput(originalOutput)
+
+		if err := Save(DefaultConfig(), configPath); err != nil {
+			t.Fatalf("Save should no-op (not error) in hosted mode, got: %v", err)
+		}
+
+		if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+			t.Errorf("expected %s to not exist after a hosted-mode Save(), stat err = %v", configPath, err)
+		}
+
+		logged := logBuf.String()
+		if !strings.Contains(logged, "WARN") || !strings.Contains(logged, "PILOT_HOSTED") {
+			t.Errorf("expected a WARN log mentioning PILOT_HOSTED, got: %q", logged)
+		}
+		if !strings.Contains(logged, "hosted_test.go") {
+			t.Errorf("expected the WARN log to name the calling file:line, got: %q", logged)
+		}
+	})
+
+	t.Run("ExistingFile_ContentAndMtimeUnchanged", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		// Write the initial file while NOT hosted, so we have a real baseline.
+		initial := DefaultConfig()
+		initial.Version = "pre-hosted-version"
+		if err := Save(initial, configPath); err != nil {
+			t.Fatalf("initial (non-hosted) save failed: %v", err)
+		}
+
+		before, err := os.Stat(configPath)
+		if err != nil {
+			t.Fatalf("stat before hosted Save() failed: %v", err)
+		}
+		beforeContent, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("read before hosted Save() failed: %v", err)
+		}
+
+		t.Setenv(hostedEnvVar, "1")
+		attempted := DefaultConfig()
+		attempted.Version = "attempted-hosted-overwrite"
+		if err := Save(attempted, configPath); err != nil {
+			t.Fatalf("Save should no-op (not error) in hosted mode, got: %v", err)
+		}
+
+		after, err := os.Stat(configPath)
+		if err != nil {
+			t.Fatalf("stat after hosted Save() failed: %v", err)
+		}
+		afterContent, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("read after hosted Save() failed: %v", err)
+		}
+
+		if !before.ModTime().Equal(after.ModTime()) {
+			t.Errorf("mtime changed: before=%v after=%v", before.ModTime(), after.ModTime())
+		}
+		if string(beforeContent) != string(afterContent) {
+			t.Errorf("content changed after hosted-mode Save() attempt")
+		}
+		if strings.Contains(string(afterContent), "attempted-hosted-overwrite") {
+			t.Error("hosted-mode Save() wrote the attempted content to disk")
+		}
+	})
+}
+
+// TestSave_UnhostedModeUnchanged proves zero behavior change when
+// PILOT_HOSTED is unset (GH-4274 acceptance criterion) — Save() still
+// writes normally.
+func TestSave_UnhostedModeUnchanged(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	cfg := DefaultConfig()
+	cfg.Version = "unhosted-write"
+	if err := Save(cfg, configPath); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.Version != "unhosted-write" {
+		t.Errorf("Version = %q, want %q — Save() should write normally when PILOT_HOSTED is unset", loaded.Version, "unhosted-write")
+	}
+}
+
+// TestAssertHostedInvariants covers the hard invariants of the hosted
+// profile (GH-4274): auto_hot_upgrade must be false and tunnel must be
+// disabled when PILOT_HOSTED=1.
+func TestAssertHostedInvariants(t *testing.T) {
+	t.Run("NotHosted_ViolationsAllowed", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Upgrade.AutoHotUpgrade = true
+		cfg.Tunnel.Enabled = true
+		if err := cfg.AssertHostedInvariants(); err != nil {
+			t.Errorf("AssertHostedInvariants() should be a no-op when PILOT_HOSTED is unset, got: %v", err)
+		}
+	})
+
+	t.Run("Hosted_AutoHotUpgradeTrue_Fails", func(t *testing.T) {
+		t.Setenv(hostedEnvVar, "1")
+		cfg := DefaultConfig()
+		cfg.Upgrade.AutoHotUpgrade = true
+		cfg.Tunnel.Enabled = false
+
+		err := cfg.AssertHostedInvariants()
+		if err == nil {
+			t.Fatal("expected an error when hosted + upgrade.auto_hot_upgrade=true, got nil")
+		}
+		if !strings.Contains(err.Error(), "auto_hot_upgrade") {
+			t.Errorf("error = %q, want it to mention auto_hot_upgrade", err.Error())
+		}
+	})
+
+	t.Run("Hosted_TunnelEnabled_Fails", func(t *testing.T) {
+		t.Setenv(hostedEnvVar, "1")
+		cfg := DefaultConfig()
+		cfg.Upgrade.AutoHotUpgrade = false
+		cfg.Tunnel.Enabled = true
+
+		err := cfg.AssertHostedInvariants()
+		if err == nil {
+			t.Fatal("expected an error when hosted + tunnel.enabled=true, got nil")
+		}
+		if !strings.Contains(err.Error(), "tunnel") {
+			t.Errorf("error = %q, want it to mention tunnel", err.Error())
+		}
+	})
+
+	t.Run("Hosted_Compliant_Passes", func(t *testing.T) {
+		t.Setenv(hostedEnvVar, "1")
+		cfg := DefaultConfig()
+		cfg.Upgrade.AutoHotUpgrade = false
+		cfg.Tunnel.Enabled = false
+
+		if err := cfg.AssertHostedInvariants(); err != nil {
+			t.Errorf("AssertHostedInvariants() should pass for a compliant hosted config, got: %v", err)
+		}
+	})
+}
+
+// TestLoad_HostedModeAssertions proves the assertions fire at Load() —
+// the daemon boot chokepoint — both for an explicit violating config file
+// and for the zero-config default path (GH-4274 acceptance criterion:
+// "hosted + auto_hot_upgrade=true fails boot with a clear error").
+func TestLoad_HostedModeAssertions(t *testing.T) {
+	t.Run("ViolatingConfigFile_FailsBoot", func(t *testing.T) {
+		t.Setenv(hostedEnvVar, "1")
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		configContent := `
+version: "1.0"
+tunnel:
+  enabled: false
+upgrade:
+  auto_hot_upgrade: true
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("failed to write test config: %v", err)
+		}
+
+		_, err := Load(configPath)
+		if err == nil {
+			t.Fatal("expected Load() to fail boot for hosted config with auto_hot_upgrade=true")
+		}
+		if !strings.Contains(err.Error(), "auto_hot_upgrade") {
+			t.Errorf("error = %q, want it to clearly mention auto_hot_upgrade", err.Error())
+		}
+	})
+
+	t.Run("ViolatingTunnelConfigFile_FailsBoot", func(t *testing.T) {
+		t.Setenv(hostedEnvVar, "1")
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		configContent := `
+version: "1.0"
+tunnel:
+  enabled: true
+upgrade:
+  auto_hot_upgrade: false
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("failed to write test config: %v", err)
+		}
+
+		_, err := Load(configPath)
+		if err == nil {
+			t.Fatal("expected Load() to fail boot for hosted config with tunnel.enabled=true")
+		}
+		if !strings.Contains(err.Error(), "tunnel") {
+			t.Errorf("error = %q, want it to clearly mention tunnel", err.Error())
+		}
+	})
+
+	t.Run("CompliantConfigFile_Boots", func(t *testing.T) {
+		t.Setenv(hostedEnvVar, "1")
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		configContent := `
+version: "1.0"
+tunnel:
+  enabled: false
+upgrade:
+  auto_hot_upgrade: false
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("failed to write test config: %v", err)
+		}
+
+		if _, err := Load(configPath); err != nil {
+			t.Errorf("expected a compliant hosted config to load, got: %v", err)
+		}
+	})
+
+	t.Run("NoConfigFile_DefaultsViolateInvariant_FailsBoot", func(t *testing.T) {
+		// DefaultConfig() sets upgrade.auto_hot_upgrade=true (GH-3790), so a
+		// hosted instance booting with no config file at all must still fail
+		// loud rather than silently running against a non-compliant default.
+		t.Setenv(hostedEnvVar, "1")
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "does-not-exist.yaml")
+
+		_, err := Load(configPath)
+		if err == nil {
+			t.Fatal("expected Load() to fail boot when hosted + no config file (defaults violate hosted invariants)")
+		}
+	})
+
+	t.Run("NotHosted_ViolatingConfigStillLoads", func(t *testing.T) {
+		// Zero behavior change when PILOT_HOSTED is unset.
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+
+		configContent := `
+version: "1.0"
+tunnel:
+  enabled: true
+upgrade:
+  auto_hot_upgrade: true
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("failed to write test config: %v", err)
+		}
+
+		if _, err := Load(configPath); err != nil {
+			t.Errorf("expected non-hosted Load() to ignore hosted invariants, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

SaaS pre-work S0.7 (TASK-405 / `.agent/system/saas-roadmap.md`, fleet design `.agent/system/saas-fleet-design.md` §4.5). Hosted Pilot instances run against a `config.yaml` rendered by a control plane, where every secret is a `${VAR}` reference resolved from a tmpfs env file at `Load()` time. `config.Save()` previously round-tripped the **expanded** in-memory `Config` back to disk — writing resolved secrets into `config.yaml`. Tolerable on a single-tenant KMS-encrypted volume, but structurally wrong. `PILOT_HOSTED=1` makes this impossible instead of merely discouraged.

- `config.IsHosted()` reads `PILOT_HOSTED=1` from the environment (checked live so it composes with `t.Setenv` in tests; the env var itself is fixed for the process lifetime in production, so this is "read once at startup" in practice).
- `config.Save()` becomes a no-op when hosted, logging `WARN` with the calling `file:line` so any flow that still attempts a write is visible in logs.
- `Config.AssertHostedInvariants()` enforces the hard invariants of the hosted profile — `upgrade.auto_hot_upgrade` and `tunnel.enabled` must both be `false` — and is wired into `Load()` for both the explicit-config-file path and the zero-config default path (`DefaultConfig()` sets `auto_hot_upgrade: true`, so a hosted instance booting with no config file at all must still fail loud rather than silently drifting).
- `cmd/pilot/backend.go` (`pilot backend set`) had its own `yaml.Marshal` + `os.WriteFile` that bypassed `config.Save()` entirely — routed it through `config.Save()` so it observes the same guard instead of writing around it.

## Save() call sites audited

All real `config.Save(cfg, configPath)` call sites are human-operator CLI subcommands, none of which run in the daemon's autonomous execution/polling loop:

| Site | Command |
|---|---|
| `cmd/pilot/commands.go:197` | `pilot init` |
| `cmd/pilot/commands.go:2944` | `pilot autopilot enable` |
| `cmd/pilot/commands.go:3016` | `pilot autopilot disable` |
| `cmd/pilot/webhooks.go:202` | `pilot webhooks add` |
| `cmd/pilot/webhooks.go:263` | `pilot webhooks remove` |
| `cmd/pilot/project.go:237` | `pilot project add` |
| `cmd/pilot/project.go:334` | `pilot project remove` |
| `cmd/pilot/project.go:377` | `pilot project set-default` |
| `cmd/pilot/project_wizard.go:320` | project add wizard |
| `cmd/pilot/init_project.go:379` | `pilot init-project` |
| `cmd/pilot/onboard.go:159` | `pilot onboard` |
| `cmd/pilot/allow.go:118` / `:162` | `pilot allow` / `pilot deny` |
| `cmd/pilot/budget.go:479` / `:592` | `pilot budget set` / `pilot budget alert` |
| `cmd/pilot/tunnel.go:336` | `pilot tunnel setup` |
| `cmd/pilot/interactive.go:379` | interactive project switch |
| `cmd/pilot/setup.go:164` | `pilot setup` |
| `cmd/pilot/backend.go:322` (now via `config.Save`) | `pilot backend set` |

**Self-upgrade flow (GH-879)** does not call `Save()` at all — after `syscall.Exec`, the new binary re-reads config from disk via `Config.Reload()` (a read, not a write), so it's unaffected by this change.

None of these are load-bearing for daemon operation — disabling them in hosted mode means an operator running `pilot allow`/`pilot budget set`/etc. against a hosted instance gets a WARN log instead of a silent write; the control plane owns config mutation for hosted deployments.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/config/... ./cmd/pilot/...` — new `internal/config/hosted_test.go` covers: `IsHosted()`, `Save()` no-op (new file never created; existing file mtime/content unchanged; WARN log fires and names the caller), `Save()` unchanged when unhosted, `AssertHostedInvariants()` for both violations + compliant config + not-hosted passthrough, `Load()` failing boot for both an explicit violating config file and the zero-config-file default path, and `Load()` unaffected when `PILOT_HOSTED` is unset
- [x] `go test ./...` (full suite) — all green
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues