### PR TITLE
fix(executor): scope task_id lookups by project_path (GH-4276)

### DIFF
--- a/.agent/knowledge/memories/pitfalls/pitfall_task_id_not_globally_unique.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_task_id_not_globally_unique.md
@@ -1,0 +1,28 @@
+# Pitfall: task_id is only unique within a project, never globally
+
+## Summary
+`executions.task_id` (e.g. "GH-10") is only unique per repo/project — any DB lookup keyed on bare `task_id` without an `AND project_path = ?` filter can silently pick up a different project's row and short-circuit dispatch or mask completion evidence.
+
+## Context
+GH-4276: a canary sandbox project's fresh epic issue #10 shared its `task_id` ("GH-10") with several other configured projects that already had completed "GH-10" rows. `IsTaskQueued(taskID)` and `GetLatestExecutionByTaskID(taskID)` (no substring-scoped variant) were unscoped by `project_path`, so a stale/in-flight row from an unrelated project could (a) make `IsTaskQueued` see an unrelated project's task as "active" and block dispatch, and (b) make `childCompletionEvidence` pick the wrong project's row (via `created_at DESC` ordering across all projects) and report false-negative "incomplete" for a child that had genuinely shipped in its own project.
+
+## Details
+Confirmed already-scoped (no fix needed): `HasCompletedExecution`, `GetDecomposedChildTaskIDs`, `GetExecutionStatusByTaskID(Excluding)`, `SelfHealExecutionAfterMerge`, `ReclassifyCompletionAsFailed` — all take `projectPath` and filter by it in SQL.
+
+Fixed in GH-4276 (previously unscoped):
+- `Store.IsTaskQueued(taskID)` → `IsTaskQueued(taskID, projectPath)` — used by `Dispatcher.IsActive`, `Dispatcher.QueueTask`'s duplicate check, and the GitHub poller's `TaskChecker` adapter (`storeTaskChecker` in `cmd/pilot/main.go`, which closes over `projectPath` at construction since the upstream `studio-sdk` `TaskChecker` interface has no room for one).
+- `Store.GetLatestExecutionByTaskIDExcluding(taskID, excludeID)` → added `projectPath` param directly (only 2 production callers, both had it in scope).
+- Added `Store.GetLatestExecutionByTaskIDForProject(taskID, projectPath)` as the scoped counterpart to the original `GetLatestExecutionByTaskID` — the original stays unscoped on purpose for the `pilot logs <task-id>` CLI diagnostic (a human often doesn't know which project a task belongs to).
+- `autopilot.approvalPersister` interface method renamed `GetLatestExecutionByTaskID` → `GetLatestExecutionByTaskIDForProject(taskID, projectPath)`.
+
+## Recommended Approach
+Any new DB lookup on the dispatch/epic/short-circuit path that takes a `task_id` must also take a `project_path` and filter on it in the SQL `WHERE` clause — never rely on "most recent" ordering alone to disambiguate across projects. When adding a CLI-only diagnostic lookup that's deliberately cross-project, name it distinctly (or comment it explicitly) so it isn't copy-pasted into a dispatch-path guard.
+
+## Related
+- GH-4276, TASK-401 (`.agent/tasks/TASK-401-epic-parent-duplicate-reimplementation.md`), GH-4229
+- `internal/memory/store.go`, `internal/executor/dispatcher.go`, `internal/executor/epic.go`, `internal/autopilot/controller.go`
+
+---
+**Captured**: 2026-07-13
+**Confidence**: 90%
+**Concepts**: pilot, executor, memory, dispatcher, multi-project, task_id, epic

--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -91,7 +91,7 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	// other work — the dispatcher's own duplicate check (QueueTask) remains
 	// the authoritative guard; this is a cheap pre-check to skip the attempt
 	// entirely in the common case.
-	if deps.Dispatcher != nil && deps.Dispatcher.IsActive(taskID) {
+	if deps.Dispatcher != nil && deps.Dispatcher.IsActive(taskID, projectPath) {
 		logging.WithComponent("dispatch").Debug("Task already queued or running, skipping dispatch",
 			slog.String("task_id", taskID))
 		return &HandlerResult{Success: false, BranchName: task.Branch}, nil

--- a/cmd/pilot/handler_common_test.go
+++ b/cmd/pilot/handler_common_test.go
@@ -132,13 +132,16 @@ func TestHandleIssueGeneric_AlreadyActive_SkipsDispatch(t *testing.T) {
 	dispatcher := newHandlerTestDispatcher(t)
 
 	taskID := "GH-4008-ACTIVE"
-	seedTask := &executor.Task{ID: taskID, Title: "seed", ProjectPath: "/tmp/pilot-gh-4008-does-not-exist"}
+	projectPath := "/tmp/pilot-gh-4008-does-not-exist"
+	seedTask := &executor.Task{ID: taskID, Title: "seed", ProjectPath: projectPath}
 	if _, err := dispatcher.QueueTask(context.Background(), seedTask); err != nil {
 		t.Fatalf("failed to seed queued task: %v", err)
 	}
 
 	monitor := executor.NewMonitor()
-	deps := HandlerDeps{Dispatcher: dispatcher, Monitor: monitor}
+	// GH-4276: IsActive is now project-scoped — deps.ProjectPath must match the
+	// seeded task's ProjectPath for the pre-check to see it as active.
+	deps := HandlerDeps{Dispatcher: dispatcher, Monitor: monitor, ProjectPath: projectPath}
 	info := IssueInfo{TaskID: taskID, Title: "seed", Adapter: "github", LogMark: "▸"}
 	task := &executor.Task{ID: taskID, Title: "seed", Branch: "pilot/" + taskID}
 
@@ -166,15 +169,18 @@ func TestHandleIssueGeneric_QueueTaskRace_DowngradesToDebug(t *testing.T) {
 	dispatcher := newHandlerTestDispatcher(t)
 
 	activeTaskID := "GH-4008-RACE-ACTUAL"
-	seedTask := &executor.Task{ID: activeTaskID, Title: "seed", ProjectPath: "/tmp/pilot-gh-4008-does-not-exist"}
+	projectPath := "/tmp/pilot-gh-4008-does-not-exist"
+	seedTask := &executor.Task{ID: activeTaskID, Title: "seed", ProjectPath: projectPath}
 	if _, err := dispatcher.QueueTask(context.Background(), seedTask); err != nil {
 		t.Fatalf("failed to seed queued task: %v", err)
 	}
 
 	monitor := executor.NewMonitor()
-	deps := HandlerDeps{Dispatcher: dispatcher, Monitor: monitor}
+	deps := HandlerDeps{Dispatcher: dispatcher, Monitor: monitor, ProjectPath: projectPath}
 	info := IssueInfo{TaskID: "GH-4008-RACE-PRECHECK", Title: "race", Adapter: "github", LogMark: "▸"}
-	task := &executor.Task{ID: activeTaskID, Title: "race", Branch: "pilot/" + activeTaskID}
+	// GH-4276: task.ProjectPath must match the seeded row's project so
+	// QueueTask's duplicate check (now project-scoped) still hits the race.
+	task := &executor.Task{ID: activeTaskID, Title: "race", Branch: "pilot/" + activeTaskID, ProjectPath: projectPath}
 
 	hr, err := handleIssueGeneric(context.Background(), deps, info, task)
 	if err != nil {

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2958,12 +2958,18 @@ func cleanStartupHooks(cfg *config.Config, projectPath string) {
 // storeTaskChecker adapts memory.Store to the github.TaskChecker interface.
 // GH-2201: Used by the poller to check if a task is still queued/in-progress
 // before allowing retry after the grace period expires.
+//
+// GH-4276: projectPath is captured at construction time (one storeTaskChecker
+// per poller/project) and threaded into the scoped store lookup — the
+// upstream TaskChecker interface itself has no room for a project argument,
+// and task_id alone is not unique across projects/repos.
 type storeTaskChecker struct {
-	store *memory.Store
+	store       *memory.Store
+	projectPath string
 }
 
 func (s storeTaskChecker) IsTaskQueued(taskID string) bool {
-	queued, err := s.store.IsTaskQueued(taskID)
+	queued, err := s.store.IsTaskQueued(taskID, s.projectPath)
 	if err != nil {
 		return false // Don't block retry on DB errors
 	}

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -326,7 +326,7 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 
 	// GH-2201/GH-2242: task-queued gate + completed-execution guard.
 	if deps.Store != nil {
-		pollerDeps.TaskChecker = storeTaskChecker{store: deps.Store}
+		pollerDeps.TaskChecker = storeTaskChecker{store: deps.Store, projectPath: target.projectPath}
 		pollerDeps.ExecutionChecker = deps.Store
 	}
 

--- a/cmd/pilot/poller_github_gh4211_test.go
+++ b/cmd/pilot/poller_github_gh4211_test.go
@@ -73,7 +73,9 @@ func TestGithubOnPRCreatedHandler_ObservesThroughputHistograms(t *testing.T) {
 
 	cfg := autopilot.DefaultConfig()
 	ghClient := githubSDK.NewClient(testutil.FakeGitHubToken)
-	ctrl := autopilot.NewController(cfg, ghClient, nil, "owner", "repo", autopilot.WithMemoryStore(store))
+	// GH-4276: GetLatestExecutionByTaskIDForProject scopes by the controller's
+	// projectPath, which must match the seeded execution row's ProjectPath ("/p").
+	ctrl := autopilot.NewController(cfg, ghClient, nil, "owner", "repo", autopilot.WithMemoryStore(store), autopilot.WithProjectPath("/p"))
 
 	// This is the exact function production wires into pollerDeps.OnPRCreated
 	// (poller_github.go), not a re-implementation of it.

--- a/internal/autopilot/controller.go
+++ b/internal/autopilot/controller.go
@@ -35,7 +35,10 @@ type alertSink interface {
 type approvalPersister interface {
 	SetApprovalRequestID(ctx context.Context, taskID, requestID string) error
 	SetApprovalDecision(ctx context.Context, requestID, decision, by string) error
-	GetLatestExecutionByTaskID(taskID string) (*memory.Execution, error)
+	// GetLatestExecutionByTaskIDForProject is scoped by projectPath (GH-4276):
+	// task_id alone is not unique across projects/repos, so an unscoped lookup
+	// could attach an audit event or metrics sample to another project's row.
+	GetLatestExecutionByTaskIDForProject(taskID, projectPath string) (*memory.Execution, error)
 	// RecordExecutionEvent is the GH-4244 validate-first chokepoint
 	// (memory.Store.RecordExecutionEvent): it confirms the executions row
 	// exists before inserting, so a stale/unknown execution ID can never
@@ -886,7 +889,7 @@ func (c *Controller) recordExecutionEvent(prState *PRState, stage memory.Stage, 
 		taskID = fmt.Sprintf("PR-%d", prState.PRNumber)
 	}
 
-	exec, err := c.memoryStore.GetLatestExecutionByTaskID(taskID)
+	exec, err := c.memoryStore.GetLatestExecutionByTaskIDForProject(taskID, c.projectPath)
 	if err != nil {
 		c.log.Warn("execution audit trail: no execution row for task, skipping event",
 			"pr", prState.PRNumber, "task_id", taskID, "stage", stage, "error", err)
@@ -1035,7 +1038,7 @@ func (c *Controller) OnPRCreated(prNumber int, prURL string, issueNumber int, he
 			c.log.Warn("GH-4211: PR-created event carried no issue number — time-to-PR/queue-wait taskID falls back to PR-N, which will not match any GH-N execution row",
 				"pr", prNumber, "task_id", taskID)
 		}
-		exec, err := c.memoryStore.GetLatestExecutionByTaskID(taskID)
+		exec, err := c.memoryStore.GetLatestExecutionByTaskIDForProject(taskID, c.projectPath)
 		switch {
 		case err != nil:
 			if !errors.Is(err, sql.ErrNoRows) {

--- a/internal/autopilot/controller_test.go
+++ b/internal/autopilot/controller_test.go
@@ -7494,7 +7494,7 @@ func (m *mockApprovalPersister) SetApprovalDecision(_ context.Context, requestID
 	return nil
 }
 
-func (m *mockApprovalPersister) GetLatestExecutionByTaskID(taskID string) (*memory.Execution, error) {
+func (m *mockApprovalPersister) GetLatestExecutionByTaskIDForProject(taskID, _ string) (*memory.Execution, error) {
 	id, ok := m.execByTask[taskID]
 	if !ok {
 		return nil, sql.ErrNoRows
@@ -7565,7 +7565,7 @@ func (m *errApprovalPersister) SetApprovalDecision(_ context.Context, _, _, _ st
 	return m.decisionErr
 }
 
-func (m *errApprovalPersister) GetLatestExecutionByTaskID(_ string) (*memory.Execution, error) {
+func (m *errApprovalPersister) GetLatestExecutionByTaskIDForProject(_, _ string) (*memory.Execution, error) {
 	return nil, sql.ErrNoRows
 }
 

--- a/internal/autopilot/gh4130_test.go
+++ b/internal/autopilot/gh4130_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 // gh4130ExecPersister is a minimal approvalPersister that returns a
-// caller-configured *memory.Execution from GetLatestExecutionByTaskID, so
-// tests can control StartedAt/CreatedAt independent of the shared
+// caller-configured *memory.Execution from GetLatestExecutionByTaskIDForProject,
+// so tests can control StartedAt/CreatedAt independent of the shared
 // mockApprovalPersister (which always returns a bare {ID, TaskID} row).
 type gh4130ExecPersister struct {
 	execByTask map[string]*memory.Execution
@@ -27,7 +27,7 @@ func (m *gh4130ExecPersister) SetApprovalDecision(_ context.Context, _, _, _ str
 func (m *gh4130ExecPersister) RecordExecutionEvent(_ string, _ memory.Stage, _ string) error {
 	return nil
 }
-func (m *gh4130ExecPersister) GetLatestExecutionByTaskID(taskID string) (*memory.Execution, error) {
+func (m *gh4130ExecPersister) GetLatestExecutionByTaskIDForProject(taskID, _ string) (*memory.Execution, error) {
 	exec, ok := m.execByTask[taskID]
 	if !ok {
 		return nil, sql.ErrNoRows

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -535,15 +535,19 @@ func (d *Dispatcher) hasLiveWorker(projectPath string) bool {
 	return ok
 }
 
-// IsActive reports whether taskID is already queued or running, using the
-// same source of truth QueueTask's duplicate-task check uses. Callers that
-// dispatch on a poll loop can pre-check this before announcing/attempting a
-// dispatch, so a task legitimately waiting behind other work doesn't
-// generate a repeated dispatch-attempt + rejection on every tick (GH-4008).
-// A store error fails open (returns false) — QueueTask's own check remains
-// the authoritative guard.
-func (d *Dispatcher) IsActive(taskID string) bool {
-	active, err := d.store.IsTaskQueued(taskID)
+// IsActive reports whether taskID is already queued or running in projectPath,
+// using the same source of truth QueueTask's duplicate-task check uses.
+// Callers that dispatch on a poll loop can pre-check this before
+// announcing/attempting a dispatch, so a task legitimately waiting behind
+// other work doesn't generate a repeated dispatch-attempt + rejection on
+// every tick (GH-4008). A store error fails open (returns false) —
+// QueueTask's own check remains the authoritative guard.
+//
+// GH-4276: projectPath is required — task_id alone is not unique across
+// projects, so an unscoped check could see an unrelated project's identically
+// numbered task as "active" and block this project's dispatch.
+func (d *Dispatcher) IsActive(taskID, projectPath string) bool {
+	active, err := d.store.IsTaskQueued(taskID, projectPath)
 	if err != nil {
 		d.log.Warn("Failed to check task active state", slog.String("task_id", taskID), slog.Any("error", err))
 		return false
@@ -556,8 +560,10 @@ func (d *Dispatcher) IsActive(taskID string) bool {
 // If a decomposer is configured and the task is complex, it will be split
 // into subtasks that are queued instead of the parent task.
 func (d *Dispatcher) QueueTask(ctx context.Context, task *Task) (string, error) {
-	// Check for duplicate tasks
-	exists, err := d.store.IsTaskQueued(task.ID)
+	// Check for duplicate tasks. GH-4276: scoped by task.ProjectPath — task_id
+	// is only unique within a repo, so an unscoped check could false-positive
+	// on an unrelated project's identically numbered task and reject dispatch.
+	exists, err := d.store.IsTaskQueued(task.ID, task.ProjectPath)
 	if err != nil {
 		d.log.Warn("Failed to check for duplicate task", slog.Any("error", err))
 	} else if exists {
@@ -783,7 +789,7 @@ func (d *Dispatcher) WaitForExecution(ctx context.Context, execID string, pollIn
 					} else if allComplete {
 						prURL := ""
 						if len(childIDs) > 0 {
-							if latest, lErr := d.store.GetLatestExecutionByTaskID(childIDs[len(childIDs)-1]); lErr == nil && latest != nil {
+							if latest, lErr := d.store.GetLatestExecutionByTaskIDForProject(childIDs[len(childIDs)-1], lastProjectPath); lErr == nil && latest != nil {
 								prURL = latest.PRUrl
 							}
 						}
@@ -803,7 +809,7 @@ func (d *Dispatcher) WaitForExecution(ctx context.Context, execID string, pollIn
 					}
 
 					if completed, hcErr := d.store.HasCompletedExecution(lastTaskID, lastProjectPath); hcErr == nil && completed {
-						if completedExec, gErr := d.store.GetLatestExecutionByTaskID(lastTaskID); gErr == nil {
+						if completedExec, gErr := d.store.GetLatestExecutionByTaskIDForProject(lastTaskID, lastProjectPath); gErr == nil {
 							d.log.Info("Execution row vanished after orphan recovery — task already completed, resolving wait as success",
 								slog.String("execution_id", execID),
 								slog.String("task_id", lastTaskID),
@@ -976,7 +982,7 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 				slog.Any("error", err))
 		} else if done {
 			prURL := ""
-			if latest, gErr := w.store.GetLatestExecutionByTaskIDExcluding(exec.TaskID, exec.ID); gErr == nil && latest != nil {
+			if latest, gErr := w.store.GetLatestExecutionByTaskIDExcluding(exec.TaskID, exec.ID, w.projectPath); gErr == nil && latest != nil {
 				prURL = latest.PRUrl
 			}
 			w.log.Info("Terminal-success ledger already has a completed row for task; refusing duplicate dispatch",
@@ -1008,7 +1014,7 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			// defense-in-depth skip, not a normal completion, so it always logs
 			// at Warn with the full child list and per-child evidence.
 			prURL := ""
-			if latest, gErr := w.store.GetLatestExecutionByTaskID(childIDs[len(childIDs)-1]); gErr == nil && latest != nil {
+			if latest, gErr := w.store.GetLatestExecutionByTaskIDForProject(childIDs[len(childIDs)-1], w.projectPath); gErr == nil && latest != nil {
 				prURL = latest.PRUrl
 			}
 			w.log.Warn("decomposed-parent guard fired",
@@ -1276,14 +1282,19 @@ func childCompletionEvidence(store *memory.Store, childID, projectPath string) (
 		return "completed", true, nil
 	}
 
-	latest, err := store.GetLatestExecutionByTaskID(childID)
+	// GH-4276: project-scoped lookup — the unscoped GetLatestExecutionByTaskID
+	// previously ordered across all projects, so a same-numbered child row in
+	// an unrelated project (more recently updated) could shadow this child's
+	// own no_op/merged_pr evidence in this project, producing a false
+	// "incomplete" verdict for a genuinely-shipped child.
+	latest, err := store.GetLatestExecutionByTaskIDForProject(childID, projectPath)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", false, nil
 		}
 		return "", false, err
 	}
-	if latest == nil || latest.ProjectPath != projectPath {
+	if latest == nil {
 		return "", false, nil
 	}
 	if latest.Status == "no_op" && latest.Error == "" {

--- a/internal/executor/dispatcher_gh4276_test.go
+++ b/internal/executor/dispatcher_gh4276_test.go
@@ -1,0 +1,114 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestQueueTask_CrossProjectTaskIDCollision_StillDispatchesAndDecomposes is
+// the GH-4276 regression test: task_id is only unique within a single
+// repo/project (a fresh SaaS-tenant repo's issue #10 collides with any other
+// configured project's pre-existing "GH-10"). A stale/in-flight execution row
+// for the same task_id in an unrelated project must never suppress dispatch
+// or decomposition of a genuinely fresh task in a different project.
+func TestQueueTask_CrossProjectTaskIDCollision_StillDispatchesAndDecomposes(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	const (
+		otherProject   = "/other-project"
+		sandboxProject = "/sandbox-project"
+		taskID         = "GH-10"
+	)
+
+	// An unrelated project has a genuinely completed GH-10 (old, real work)...
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "other-completed", TaskID: taskID, ProjectPath: otherProject,
+		Status: "completed", PRUrl: "https://github.com/org/other/pull/1",
+	}); err != nil {
+		t.Fatalf("SaveExecution(other-completed): %v", err)
+	}
+	// ...and a concurrently in-flight GH-10 of its own.
+	if err := store.SaveExecution(&memory.Execution{
+		ID: "other-running", TaskID: taskID, ProjectPath: otherProject, Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution(other-running): %v", err)
+	}
+
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+	dispatcher.SetDecomposer(NewTaskDecomposer(&DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 10,
+	}))
+
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	// The sandbox project's own, never-before-seen GH-10 — same task_id as
+	// the unrelated project's completed+running rows above, structured so
+	// the decomposer splits it into multiple subtasks.
+	task := &Task{
+		ID:    taskID,
+		Title: "[epic] roll out multi-service rollout",
+		Description: `This epic requires several coordinated changes across services:
+
+1. Update the user model to include new fields for MFA
+2. Refactor the login endpoint to support MFA flow
+3. Add new middleware for session validation
+4. Update the frontend components for MFA input
+5. Add comprehensive tests for all changes
+
+This is a complex architectural change spanning multiple files.`,
+		ProjectPath: sandboxProject,
+		Branch:      "feature/mfa-rollout",
+		CreatePR:    true,
+	}
+
+	if dispatcher.IsActive(taskID, sandboxProject) {
+		t.Fatal("expected IsActive=false for the sandbox project's fresh GH-10 before dispatch")
+	}
+
+	parentExecID, err := dispatcher.QueueTask(context.Background(), task)
+	if err != nil {
+		t.Fatalf("QueueTask() should not be blocked by an unrelated project's identical task_id, got error: %v", err)
+	}
+
+	parentExec, err := store.GetExecution(parentExecID)
+	if err != nil {
+		t.Fatalf("GetExecution(parent): %v", err)
+	}
+	if parentExec.ProjectPath != sandboxProject {
+		t.Fatalf("parentExec.ProjectPath = %q, want %q", parentExec.ProjectPath, sandboxProject)
+	}
+	if parentExec.Status != string(ExecStatusDecomposed) {
+		t.Fatalf("parentExec.Status = %q, want %q — epic-classified task with structural split points must decompose despite the cross-project task_id collision", parentExec.Status, ExecStatusDecomposed)
+	}
+
+	// The decomposer must have split the task into multiple subtask execution
+	// rows, all queued in the sandbox project — not swallowed by the
+	// cross-project task_id collision.
+	subtaskID := taskID + "-1"
+	subExec, err := store.GetLatestExecutionByTaskIDForProject(subtaskID, sandboxProject)
+	if err != nil {
+		t.Fatalf("expected subtask %s queued in %s, got: %v", subtaskID, sandboxProject, err)
+	}
+	if subExec.ProjectPath != sandboxProject {
+		t.Errorf("subtask ProjectPath = %q, want %q", subExec.ProjectPath, sandboxProject)
+	}
+
+	// The unrelated project's rows must be untouched by any of this.
+	otherExec, err := store.GetExecution("other-completed")
+	if err != nil {
+		t.Fatalf("GetExecution(other-completed): %v", err)
+	}
+	if otherExec.Status != "completed" {
+		t.Errorf("other-completed status mutated to %q", otherExec.Status)
+	}
+}

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -158,7 +158,7 @@ func TestDispatcher_IsActive(t *testing.T) {
 
 	ctx := context.Background()
 
-	if dispatcher.IsActive("TEST-ACTIVE") {
+	if dispatcher.IsActive("TEST-ACTIVE", "/tmp/test-project") {
 		t.Error("expected IsActive=false before task is queued")
 	}
 
@@ -172,8 +172,14 @@ func TestDispatcher_IsActive(t *testing.T) {
 		t.Fatalf("failed to queue task: %v", err)
 	}
 
-	if !dispatcher.IsActive("TEST-ACTIVE") {
+	if !dispatcher.IsActive("TEST-ACTIVE", "/tmp/test-project") {
 		t.Error("expected IsActive=true once task is queued")
+	}
+
+	// GH-4276: a different project's identically-numbered task must not be
+	// seen as active — task_id alone is not a valid dispatch-guard key.
+	if dispatcher.IsActive("TEST-ACTIVE", "/tmp/other-project") {
+		t.Error("expected IsActive=false for a different project with the same task_id")
 	}
 }
 
@@ -405,7 +411,7 @@ func TestStore_IsTaskQueued(t *testing.T) {
 	}
 
 	// Check queued task
-	queued, err := store.IsTaskQueued("TASK-QUEUED")
+	queued, err := store.IsTaskQueued("TASK-QUEUED", "/project")
 	if err != nil {
 		t.Fatalf("failed to check: %v", err)
 	}
@@ -414,7 +420,7 @@ func TestStore_IsTaskQueued(t *testing.T) {
 	}
 
 	// Check running task
-	queued, err = store.IsTaskQueued("TASK-RUNNING")
+	queued, err = store.IsTaskQueued("TASK-RUNNING", "/project")
 	if err != nil {
 		t.Fatalf("failed to check: %v", err)
 	}
@@ -423,7 +429,7 @@ func TestStore_IsTaskQueued(t *testing.T) {
 	}
 
 	// Check completed task
-	queued, err = store.IsTaskQueued("TASK-DONE")
+	queued, err = store.IsTaskQueued("TASK-DONE", "/project")
 	if err != nil {
 		t.Fatalf("failed to check: %v", err)
 	}
@@ -432,12 +438,21 @@ func TestStore_IsTaskQueued(t *testing.T) {
 	}
 
 	// Check non-existent task
-	queued, err = store.IsTaskQueued("TASK-NONEXISTENT")
+	queued, err = store.IsTaskQueued("TASK-NONEXISTENT", "/project")
 	if err != nil {
 		t.Fatalf("failed to check: %v", err)
 	}
 	if queued {
 		t.Error("expected TASK-NONEXISTENT to NOT be queued")
+	}
+
+	// GH-4276: same task_id, different project — must not report queued.
+	queued, err = store.IsTaskQueued("TASK-QUEUED", "/other-project")
+	if err != nil {
+		t.Fatalf("failed to check: %v", err)
+	}
+	if queued {
+		t.Error("expected TASK-QUEUED under /other-project to NOT be queued (cross-project collision)")
 	}
 }
 
@@ -1361,6 +1376,50 @@ func TestDecomposedChildrenAllComplete(t *testing.T) {
 		}
 		if !strings.Contains(logBuf.String(), "no child refs parsed") {
 			t.Errorf("expected a warning log about the unparseable decomposed detail, got: %s", logBuf.String())
+		}
+	})
+
+	// GH-4276: a child task_id shared with an unrelated project must not mask
+	// this project's own completion evidence for that child. Before the fix,
+	// childCompletionEvidence's unscoped GetLatestExecutionByTaskID lookup
+	// could return the OTHER project's (more recently created) row, see the
+	// ProjectPath mismatch, and report "incomplete" even though this
+	// project's own child row had already shipped.
+	t.Run("cross-project child task_id collision does not mask own completion evidence", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		const otherProject = "/unrelated-project"
+		childID := "GH-6002"
+
+		parentExec := &memory.Execution{ID: "exec-parent-collision", TaskID: "GH-6001", ProjectPath: projectPath, Status: "failed"}
+		if err := store.SaveExecution(parentExec); err != nil {
+			t.Fatalf("SaveExecution(parent): %v", err)
+		}
+		if err := store.InsertExecutionEvent(parentExec.ID, memory.StageDecomposed, "decomposed into 1 children: #6002"); err != nil {
+			t.Fatalf("InsertExecutionEvent: %v", err)
+		}
+
+		// This project's own child shipped (no_op — nothing to change).
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-own-child", TaskID: childID, ProjectPath: projectPath, Status: "no_op",
+		}); err != nil {
+			t.Fatalf("SaveExecution(own child): %v", err)
+		}
+		// An unrelated project's identically-numbered task, created later so
+		// it would win an unscoped "most recent" ordering.
+		if err := store.SaveExecution(&memory.Execution{
+			ID: "exec-other-child", TaskID: childID, ProjectPath: otherProject, Status: "running",
+		}); err != nil {
+			t.Fatalf("SaveExecution(other project's child): %v", err)
+		}
+
+		allComplete, childIDs, evidence, err := decomposedChildrenAllComplete(store, "GH-6001", projectPath, slog.Default())
+		if err != nil {
+			t.Fatalf("decomposedChildrenAllComplete: %v", err)
+		}
+		if !allComplete {
+			t.Errorf("expected allComplete=true — this project's own no_op child is genuine completion evidence, got childIDs=%v evidence=%v", childIDs, evidence)
 		}
 	})
 }

--- a/internal/executor/epic.go
+++ b/internal/executor/epic.go
@@ -1695,7 +1695,7 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 		return result, execErr
 	}
 	if !childExecutionNonTerminalStatuses[status] {
-		return r.resolveChildTerminalOutcome(taskID, selfExecID, status, result, execErr)
+		return r.resolveChildTerminalOutcome(taskID, projectPath, selfExecID, status, result, execErr)
 	}
 
 	pollInterval := r.childOutcomeReconcilePollInterval
@@ -1720,7 +1720,7 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 
 		status, err := r.logStore.GetExecutionStatusByTaskIDExcluding(taskID, projectPath, selfExecID)
 		if err == nil && !childExecutionNonTerminalStatuses[status] {
-			return r.resolveChildTerminalOutcome(taskID, selfExecID, status, result, execErr)
+			return r.resolveChildTerminalOutcome(taskID, projectPath, selfExecID, status, result, execErr)
 		}
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			r.log.Warn("reconcileChildOutcome: execution status lookup failed",
@@ -1753,8 +1753,8 @@ func (r *Runner) reconcileChildOutcome(ctx context.Context, taskID, projectPath,
 // entry itself or the card is stuck showing "● running 100%" forever even
 // though the child is done. Mirrors handler_common.go's branch: nil error →
 // Complete, non-nil error → Fail.
-func (r *Runner) resolveChildTerminalOutcome(taskID, selfExecID, status string, result *ExecutionResult, execErr error) (*ExecutionResult, error) {
-	row, rowErr := r.logStore.GetLatestExecutionByTaskIDExcluding(taskID, selfExecID)
+func (r *Runner) resolveChildTerminalOutcome(taskID, projectPath, selfExecID, status string, result *ExecutionResult, execErr error) (*ExecutionResult, error) {
+	row, rowErr := r.logStore.GetLatestExecutionByTaskIDExcluding(taskID, selfExecID, projectPath)
 	if rowErr != nil {
 		row = nil
 	}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -677,6 +677,14 @@ func (s *Store) GetExecution(id string) (*Execution, error) {
 // GetLatestExecutionByTaskID returns the most recent execution for a task, matched by
 // exact task_id first and falling back to a substring match (e.g. "GH-15" matching
 // "GH-15"). Returns sql.ErrNoRows if no execution matches.
+//
+// NOT project-scoped: task_id is only unique within a repo/project, so this can
+// return a different project's row for the same task_id (e.g. two repos both
+// reporting "GH-10"). That is intentional here — this backs human-facing CLI
+// diagnostics (`pilot logs <task-id>`) where the caller often doesn't know
+// which project a task belongs to. Dispatch/epic-guard call sites that need a
+// definitive answer MUST use GetLatestExecutionByTaskIDForProject instead
+// (GH-4276) — see decomposedChildrenAllComplete / hasTerminalSuccessLedger.
 func (s *Store) GetLatestExecutionByTaskID(taskID string) (*Execution, error) {
 	row := s.db.QueryRow(`
 		SELECT `+executionDetailColumns+`
@@ -688,20 +696,40 @@ func (s *Store) GetLatestExecutionByTaskID(taskID string) (*Execution, error) {
 	return scanExecutionDetail(row)
 }
 
-// GetLatestExecutionByTaskIDExcluding mirrors GetLatestExecutionByTaskID but
-// ignores the row identified by excludeID. GH-4141: an epic sub-issue now
+// GetLatestExecutionByTaskIDForProject is the project-scoped counterpart to
+// GetLatestExecutionByTaskID (GH-4276). Exact task_id match only (no substring
+// fallback) AND project_path = projectPath, so a cross-project task_id
+// collision can never surface another repo's row as evidence for this one.
+// Returns sql.ErrNoRows if no execution matches.
+func (s *Store) GetLatestExecutionByTaskIDForProject(taskID, projectPath string) (*Execution, error) {
+	row := s.db.QueryRow(`
+		SELECT `+executionDetailColumns+`
+		FROM executions
+		WHERE task_id = ? AND project_path = ?
+		ORDER BY created_at DESC, rowid DESC
+		LIMIT 1
+	`, taskID, projectPath)
+	return scanExecutionDetail(row)
+}
+
+// GetLatestExecutionByTaskIDExcluding mirrors GetLatestExecutionByTaskIDForProject
+// but ignores the row identified by excludeID. GH-4141: an epic sub-issue now
 // carries its own "running" executions row for the full run duration
 // (internal/executor/epic.go finalizeSubIssueExecution), so a caller
 // reconciling against a genuinely separate, concurrently-tracked row for the
 // same task (GH-3786) must look past its own row to find it.
-func (s *Store) GetLatestExecutionByTaskIDExcluding(taskID, excludeID string) (*Execution, error) {
+//
+// GH-4276: scoped by projectPath — task_id alone is not unique across
+// projects, so an unscoped lookup could return another repo's row sharing the
+// same task_id.
+func (s *Store) GetLatestExecutionByTaskIDExcluding(taskID, excludeID, projectPath string) (*Execution, error) {
 	row := s.db.QueryRow(`
 		SELECT `+executionDetailColumns+`
 		FROM executions
-		WHERE (task_id = ? OR task_id LIKE ?) AND id != ?
-		ORDER BY (task_id = ?) DESC, created_at DESC, rowid DESC
+		WHERE task_id = ? AND project_path = ? AND id != ?
+		ORDER BY created_at DESC, rowid DESC
 		LIMIT 1
-	`, taskID, "%"+taskID+"%", excludeID, taskID)
+	`, taskID, projectPath, excludeID)
 	return scanExecutionDetail(row)
 }
 
@@ -1982,14 +2010,19 @@ func (s *Store) DeleteExecution(id string) error {
 	return err
 }
 
-// IsTaskQueued checks if a task with the given ID is already queued or running.
-// Used to prevent duplicate task submissions.
-func (s *Store) IsTaskQueued(taskID string) (bool, error) {
+// IsTaskQueued checks if a task with the given ID is already queued or running
+// in projectPath. Used to prevent duplicate task submissions.
+//
+// GH-4276: task_id is only unique within a single repo/project (e.g. a fresh
+// SaaS-tenant repo's "GH-10" collides with an unrelated existing project's
+// "GH-10") — scoping by project_path stops one project's in-flight task from
+// blocking dispatch of another project's identically-numbered task.
+func (s *Store) IsTaskQueued(taskID, projectPath string) (bool, error) {
 	var count int
 	err := s.db.QueryRow(`
 		SELECT COUNT(*) FROM executions
-		WHERE task_id = ? AND status IN ('queued', 'pending', 'running')
-	`, taskID).Scan(&count)
+		WHERE task_id = ? AND project_path = ? AND status IN ('queued', 'pending', 'running')
+	`, taskID, projectPath).Scan(&count)
 	if err != nil {
 		return false, err
 	}

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -3970,3 +3970,106 @@ func TestSelfHealExecutionAfterMerge_ExcludesRunningQueuedPending(t *testing.T) 
 		}
 	}
 }
+
+// TestIsTaskQueued_ScopedByProject is the GH-4276 regression test: task_id is
+// only unique within a repo/project (e.g. two fresh SaaS-tenant repos both
+// numbering their first issue "GH-10"), so IsTaskQueued must not see a task
+// queued/running in one project as active in a different project sharing the
+// same task_id.
+func TestIsTaskQueued_ScopedByProject(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&Execution{ID: "proj-a-run", TaskID: "GH-10", ProjectPath: "/proj-a", Status: "running"}); err != nil {
+		t.Fatalf("SaveExecution: %v", err)
+	}
+
+	queuedA, err := store.IsTaskQueued("GH-10", "/proj-a")
+	if err != nil {
+		t.Fatalf("IsTaskQueued(/proj-a): %v", err)
+	}
+	if !queuedA {
+		t.Error("expected GH-10 to be queued/running in /proj-a")
+	}
+
+	queuedB, err := store.IsTaskQueued("GH-10", "/proj-b")
+	if err != nil {
+		t.Fatalf("IsTaskQueued(/proj-b): %v", err)
+	}
+	if queuedB {
+		t.Error("expected GH-10 to NOT be queued in /proj-b — cross-project task_id collision must not short-circuit an unrelated project's dispatch")
+	}
+}
+
+// TestGetLatestExecutionByTaskIDForProject_CrossProjectCollision is the
+// GH-4276 regression test for the epic/dispatch-guard evidence lookups: a
+// completed row for task_id "GH-10" in one project must never surface as
+// evidence for a different project's identically-numbered, still-fresh task.
+func TestGetLatestExecutionByTaskIDForProject_CrossProjectCollision(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// An older, unrelated project has a genuinely completed GH-10.
+	if err := store.SaveExecution(&Execution{
+		ID: "other-project-done", TaskID: "GH-10", ProjectPath: "/other-project",
+		Status: "completed", PRUrl: "https://github.com/org/other/pull/1",
+	}); err != nil {
+		t.Fatalf("SaveExecution(other-project): %v", err)
+	}
+
+	// The sandbox project's fresh GH-10 has never run.
+	if _, err := store.GetLatestExecutionByTaskIDForProject("GH-10", "/sandbox-project"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows for a project with no execution row, got %v (row leaked cross-project)", err)
+	}
+
+	// The sandbox project's own row (created later, so it would otherwise
+	// legitimately win an unscoped "most recent" ordering too) is the only
+	// one GetLatestExecutionByTaskIDForProject may ever return for it.
+	if err := store.SaveExecution(&Execution{
+		ID: "sandbox-running", TaskID: "GH-10", ProjectPath: "/sandbox-project", Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution(sandbox): %v", err)
+	}
+	got, err := store.GetLatestExecutionByTaskIDForProject("GH-10", "/sandbox-project")
+	if err != nil {
+		t.Fatalf("GetLatestExecutionByTaskIDForProject(/sandbox-project): %v", err)
+	}
+	if got.ID != "sandbox-running" {
+		t.Errorf("expected sandbox project's own row, got %q (%s) — cross-project task_id collision leaked", got.ID, got.ProjectPath)
+	}
+}
+
+// TestGetLatestExecutionByTaskIDExcluding_ScopedByProject verifies the
+// GH-4276 fix: excluding the caller's own row must stay scoped to projectPath,
+// so a different project's row sharing the excluded task_id never surfaces as
+// the "other" row (e.g. the epic reconciliation path picking up a stranger's
+// PR URL as evidence for this project's child).
+func TestGetLatestExecutionByTaskIDExcluding_ScopedByProject(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SaveExecution(&Execution{
+		ID: "self-row", TaskID: "GH-10", ProjectPath: "/proj-a", Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveExecution(self): %v", err)
+	}
+	if err := store.SaveExecution(&Execution{
+		ID: "other-project-row", TaskID: "GH-10", ProjectPath: "/proj-b",
+		Status: "completed", PRUrl: "https://github.com/org/proj-b/pull/9",
+	}); err != nil {
+		t.Fatalf("SaveExecution(other project): %v", err)
+	}
+
+	if _, err := store.GetLatestExecutionByTaskIDExcluding("GH-10", "self-row", "/proj-a"); !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows excluding the only row in /proj-a, got %v (leaked /proj-b's row)", err)
+	}
+}


### PR DESCRIPTION
## Summary

`task_id` (e.g. `GH-10`) is only unique within a single repo/project, never globally — any DB lookup keyed on bare `task_id` without a `project_path` filter can silently pick up a different project's row. GH-4276's incident: a fresh sandbox project's epic issue #10 collided with several other configured projects' pre-existing "GH-10" rows.

## Sites audited

**Already scoped (no change needed):** `HasCompletedExecution`, `GetDecomposedChildTaskIDs`, `GetExecutionStatusByTaskID`/`Excluding`, `SelfHealExecutionAfterMerge`, `ReclassifyCompletionAsFailed`, `FindMergedPRByBranch` (git-remote scoped, not DB).

**Fixed (previously unscoped):**
- `Store.IsTaskQueued(taskID)` → `IsTaskQueued(taskID, projectPath)`. Used by `Dispatcher.IsActive` (poller pre-check) and `QueueTask`'s duplicate-task guard — both could see an unrelated project's in-flight task as "active". The GitHub poller's `TaskChecker` adapter (`storeTaskChecker`, `cmd/pilot/main.go`) now closes over `projectPath` at construction, since the upstream `studio-sdk` `TaskChecker` interface itself has no room for one.
- `Store.GetLatestExecutionByTaskIDExcluding(taskID, excludeID)` gained a `projectPath` param (dispatcher pickup-time guard, epic child reconciliation).
- New `Store.GetLatestExecutionByTaskIDForProject(taskID, projectPath)` replaces the unscoped `GetLatestExecutionByTaskID` at every production dispatch/epic-guard call site (`dispatcher.go`, `autopilot.approvalPersister` interface). This also fixes a **false-negative** in `childCompletionEvidence`, which previously ordered "most recent" across *all* projects and could shadow a child's own genuine no_op/merged_pr evidence with an unrelated project's more-recently-touched row for the same child `task_id`.
- The original `GetLatestExecutionByTaskID` (substring-fallback, unscoped) is kept as-is for the `pilot logs <task-id>` CLI diagnostic — deliberately cross-project since an operator often doesn't know which project a task belongs to.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run --new-from-rev=origin/main ./...` all clean
- [x] `go test ./...` full suite green
- [x] New regression tests:
  - `TestIsTaskQueued_ScopedByProject`, `TestGetLatestExecutionByTaskIDForProject_CrossProjectCollision`, `TestGetLatestExecutionByTaskIDExcluding_ScopedByProject` (`internal/memory/store_test.go`)
  - `TestDispatcher_IsActive` extended + `TestStore_IsTaskQueued` extended (`internal/executor/dispatcher_test.go`)
  - `TestDecomposedChildrenAllComplete/cross-project_child_task_id_collision_does_not_mask_own_completion_evidence`
  - `TestQueueTask_CrossProjectTaskIDCollision_StillDispatchesAndDecomposes` (`internal/executor/dispatcher_gh4276_test.go`) — a stale completed + running row for the same `task_id` in an unrelated project no longer blocks dispatch or decomposition of a fresh epic-classified task in a different project
- [x] Existing TASK-401/GH-4229 tests (`decomposedChildrenAllComplete`, decomposed-parent guard) stay green