### PR TITLE
feat(memory): add UpdateExecutionTitle backfill primitive (GH-4280)

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1821,6 +1821,24 @@ func (s *Store) UpdateExecutionEffort(id, effortLevel, complexityLevel string) e
 	})
 }
 
+// UpdateExecutionTitle backfills task_title for an execution row (GH-4280,
+// mirroring the pr_title persistence pattern from GH-4080). No-op when title
+// is empty so a caller that hasn't resolved a title yet can't clobber one
+// already persisted by an earlier write.
+func (s *Store) UpdateExecutionTitle(executionID, title string) error {
+	if title == "" {
+		return nil
+	}
+	return s.withRetry("UpdateExecutionTitle", func() error {
+		_, err := s.db.Exec(`
+			UPDATE executions
+			SET task_title = ?
+			WHERE id = ?
+		`, title, executionID)
+		return err
+	})
+}
+
 // GetStaleRunningExecutions returns executions that have been in "running" status
 // for longer than the specified duration. Used to detect crashed workers on restart.
 //

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -3970,3 +3970,65 @@ func TestSelfHealExecutionAfterMerge_ExcludesRunningQueuedPending(t *testing.T) 
 		}
 	}
 }
+
+// TestUpdateExecutionTitle covers the GH-4280 backfill/no-op/overwrite matrix.
+func TestUpdateExecutionTitle(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialTitle  string
+		updateTitle   string
+		expectedTitle string
+	}{
+		{
+			name:          "empty to resolved backfill",
+			initialTitle:  "",
+			updateTitle:   "Fix the flaky test",
+			expectedTitle: "Fix the flaky test",
+		},
+		{
+			name:          "empty to empty no-op",
+			initialTitle:  "",
+			updateTitle:   "",
+			expectedTitle: "",
+		},
+		{
+			name:          "resolved to resolved overwrite",
+			initialTitle:  "Old title",
+			updateTitle:   "New title",
+			expectedTitle: "New title",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := NewStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			id := "exec-title-1"
+			if err := store.SaveExecution(&Execution{
+				ID:          id,
+				TaskID:      "GH-4280",
+				ProjectPath: "/proj",
+				Status:      "running",
+				TaskTitle:   tt.initialTitle,
+			}); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			if err := store.UpdateExecutionTitle(id, tt.updateTitle); err != nil {
+				t.Fatalf("UpdateExecutionTitle: %v", err)
+			}
+
+			exec, err := store.GetExecution(id)
+			if err != nil {
+				t.Fatalf("GetExecution: %v", err)
+			}
+			if exec.TaskTitle != tt.expectedTitle {
+				t.Errorf("expected task_title %q, got %q", tt.expectedTitle, exec.TaskTitle)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Store.UpdateExecutionTitle(executionID, title string) error` to `internal/memory/store.go`, updating `executions.task_title` for a given execution row.
- No-ops when `title` is empty, mirroring the GH-4080 `pr_title` persistence pattern so a caller without a resolved title can't clobber a title already persisted by an earlier write.
- Shared primitive: additive-only, no callers wired in this PR — later subtasks build on it.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/memory/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/memory/...`
- [x] New table-driven test `TestUpdateExecutionTitle` covers: empty→resolved backfill, empty→empty no-op, resolved→resolved overwrite.