### PR TITLE
fix(executor): backfill task_title at resolution sites (dispatcher, epic sub-issue) — GH-4281

### DIFF
--- a/internal/executor/lifecycle_test.go
+++ b/internal/executor/lifecycle_test.go
@@ -215,6 +215,47 @@ func TestExecutionLifecycle_Finish_Override(t *testing.T) {
 	}
 }
 
+// TestExecutionLifecycle_Begin_EmptyTitle_BackfillsViaUpdateExecutionTitle is
+// the GH-4281 integration test for the Begin+UpdateExecutionTitle round trip:
+// a caller that starts an execution before a title is resolvable (Begin with
+// task.Title == "") can backfill task_title once it resolves, without
+// re-creating the row or losing the original execution ID.
+func TestExecutionLifecycle_Begin_EmptyTitle_BackfillsViaUpdateExecutionTitle(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	task := &Task{ID: "GH-7", ProjectPath: "/tmp/project"} // Title intentionally blank
+	execID, err := NewExecutionLifecycle(store).Begin(task, ExecStatusQueued)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to load execution: %v", err)
+	}
+	if exec.TaskTitle != "" {
+		t.Fatalf("expected blank task_title before backfill, got %q", exec.TaskTitle)
+	}
+
+	if err := store.UpdateExecutionTitle(execID, "resolved"); err != nil {
+		t.Fatalf("UpdateExecutionTitle failed: %v", err)
+	}
+
+	exec, err = store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("failed to reload execution: %v", err)
+	}
+	if exec.TaskTitle != "resolved" {
+		t.Errorf("expected task_title %q after backfill, got %q", "resolved", exec.TaskTitle)
+	}
+	// execID must be stable across the backfill — UpdateExecutionTitle updates
+	// the existing row rather than creating a new one.
+	if exec.ID != execID {
+		t.Errorf("expected execution ID to remain %q, got %q", execID, exec.ID)
+	}
+}
+
 // TestExecutionLifecycle_NilStore_MethodsAreNoOps verifies every method
 // degrades gracefully with a nil store, mirroring the "logStore == nil"
 // guards this type consolidates.

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -1821,6 +1821,24 @@ func (s *Store) UpdateExecutionEffort(id, effortLevel, complexityLevel string) e
 	})
 }
 
+// UpdateExecutionTitle backfills task_title for an execution row (GH-4280,
+// mirroring the pr_title persistence pattern from GH-4080). No-op when title
+// is empty so a caller that hasn't resolved a title yet can't clobber one
+// already persisted by an earlier write.
+func (s *Store) UpdateExecutionTitle(executionID, title string) error {
+	if title == "" {
+		return nil
+	}
+	return s.withRetry("UpdateExecutionTitle", func() error {
+		_, err := s.db.Exec(`
+			UPDATE executions
+			SET task_title = ?
+			WHERE id = ?
+		`, title, executionID)
+		return err
+	})
+}
+
 // GetStaleRunningExecutions returns executions that have been in "running" status
 // for longer than the specified duration. Used to detect crashed workers on restart.
 //

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -3970,3 +3970,65 @@ func TestSelfHealExecutionAfterMerge_ExcludesRunningQueuedPending(t *testing.T) 
 		}
 	}
 }
+
+// TestUpdateExecutionTitle covers the GH-4280 backfill/no-op/overwrite matrix.
+func TestUpdateExecutionTitle(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialTitle  string
+		updateTitle   string
+		expectedTitle string
+	}{
+		{
+			name:          "empty to resolved backfill",
+			initialTitle:  "",
+			updateTitle:   "Fix the flaky test",
+			expectedTitle: "Fix the flaky test",
+		},
+		{
+			name:          "empty to empty no-op",
+			initialTitle:  "",
+			updateTitle:   "",
+			expectedTitle: "",
+		},
+		{
+			name:          "resolved to resolved overwrite",
+			initialTitle:  "Old title",
+			updateTitle:   "New title",
+			expectedTitle: "New title",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := NewStore(t.TempDir())
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			id := "exec-title-1"
+			if err := store.SaveExecution(&Execution{
+				ID:          id,
+				TaskID:      "GH-4280",
+				ProjectPath: "/proj",
+				Status:      "running",
+				TaskTitle:   tt.initialTitle,
+			}); err != nil {
+				t.Fatalf("SaveExecution: %v", err)
+			}
+
+			if err := store.UpdateExecutionTitle(id, tt.updateTitle); err != nil {
+				t.Fatalf("UpdateExecutionTitle: %v", err)
+			}
+
+			exec, err := store.GetExecution(id)
+			if err != nil {
+				t.Fatalf("GetExecution: %v", err)
+			}
+			if exec.TaskTitle != tt.expectedTitle {
+				t.Errorf("expected task_title %q, got %q", tt.expectedTitle, exec.TaskTitle)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Store.UpdateExecutionTitle(executionID, title string) error` to `internal/memory/store.go` (mirrors the GH-4080 `pr_title` persistence pattern), since GH-4280's PR (#4283) — the dependency this subtask lists — isn't merged into `main` yet. No-ops on an empty title so a caller without a resolved title can't clobber one already persisted.
- Adds the requested integration test: `Begin("")` → `UpdateExecutionTitle(id, "resolved")` → row shows the title (`internal/executor/lifecycle_test.go`).
- **Audit result** (verified via deep trace of every call path, not just static reading): none of the three `Begin()` sites named in `lifecycle.go:74-93`'s doc comment (`dispatcher.go` `queueDecomposedTask`/`queueSingleTask`, `epic.go`'s sub-issue `Begin`) drop a cheaply-available title — every caller already resolves `task.Title`/`subTask.Title` synchronously before calling `Begin`. `internal/autopilot`'s `CreateFailureIssue` (the autopilot-fix issue-creation path) only creates the GitHub issue; it never touches the executions table, so there's nothing to backfill there either.

## What's actually causing the blank titles

Traced the real source of the blank `task_title` on declined-preflight rows (including the specific autopilot-fix issues GH-4278 cited): `cmd/pilot/main.go`'s `storeExecutionSaver.SaveDeclinedExecution` bypasses `ExecutionLifecycle.Begin` entirely (writes a raw `memory.Execution{}` with no `TaskTitle`), invoked through the vendored `studio-sdk`'s `core.ExecutionSaver` interface (`SaveDeclinedExecution(taskID, projectPath, status, reason string)`), which has no title parameter to carry it through. Fixing that requires either an SDK interface change or Pilot doing its own issue lookup — both out of scope for this subtask's scope fence (Pilot-only diff, no SDK version bump). Flagging for a follow-up issue.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/memory/... ./internal/executor/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/memory/... ./internal/executor/...`
- [x] New tests: `TestUpdateExecutionTitle` (memory), `TestExecutionLifecycle_Begin_EmptyTitle_BackfillsViaUpdateExecutionTitle` (executor)