### PR TITLE
fix(executor): scope task_id lookups by project_path on dispatch/epic short-circuit path

### DIFF
--- a/.agent/knowledge/memories/pitfalls/pitfall_task_id_not_globally_unique_across_projects.md
+++ b/.agent/knowledge/memories/pitfalls/pitfall_task_id_not_globally_unique_across_projects.md
@@ -1,0 +1,72 @@
+---
+name: pitfall_task_id_not_globally_unique_across_projects
+description: Any DB lookup keyed by bare task_id (no project_path) can be poisoned by a same-numbered task in a different project — audit every new task_id-keyed query for this before shipping.
+metadata:
+  type: pitfall
+---
+
+# Pitfall: task_id is not globally unique — every lookup must be (task_id, project_path)
+
+## Summary
+
+`task_id` (e.g. "GH-10") is only unique **within** a project. Pilot tracks 7+
+configured projects in one `executions` table, so a bare `WHERE task_id = ?`
+query — or a Go function signature that only takes `taskID` — will match rows
+from unrelated projects. A fresh repo's issue numbering restarts at #1, so
+this collides immediately with every other project's existing history
+(P0 for TASK-405 SaaS onboarding, where every new tenant repo starts at #1).
+
+## Details (GH-4276)
+
+`HasCompletedExecution` and `GetDecomposedChildTaskIDs` were already fixed to
+take `(taskID, projectPath)` under TASK-401/GH-4229. Two more unscoped sites
+were found on the exact same dispatch/short-circuit path and fixed in GH-4276:
+
+1. **`Store.IsTaskQueued(taskID)`** (`internal/memory/store.go`) — no
+   `project_path` filter at all. Sat directly on `Dispatcher.QueueTask`'s
+   pre-decompose duplicate check (`dispatcher.go`): a task_id queued/running
+   in project A would reject dispatch for the identical task_id in project B
+   with `ErrTaskAlreadyActive`, **before the decomposer ever ran**. Also fed
+   the SDK poller's retry-grace gate via `storeTaskChecker` (`cmd/pilot/main.go`),
+   whose wrapped interface (`sdkcore.TaskChecker.IsTaskQueued(taskID) bool`) is
+   externally fixed at one argument — the project scoping has to happen
+   inside the wrapper via a stored `projectPath` field, not the interface.
+2. **`GetLatestExecutionByTaskID`/`...Excluding`** used to backfill a PR URL
+   at 4 call sites in `dispatcher.go`, *after* an already project-scoped
+   `HasCompletedExecution`/`decomposedChildrenAllComplete` guard confirmed
+   completion — but the backfill query itself ignored project_path, so it
+   could silently stamp a different project's PR URL onto this project's row.
+
+`GetDecomposedChildren(taskID)` (store.go) is *also* unscoped by design
+(doc comment says so explicitly) but is dead code — no production caller —
+so it was left alone; flag it if it ever grows a caller.
+
+## Recommended Approach
+
+Before adding or reviewing any function that queries `executions` /
+`execution_events` by task_id:
+
+1. Does the signature take a `projectPath` parameter? If not, ask why not.
+2. If the caller only has the result's `.ProjectPath` to check post-hoc
+   (can't change the query), verify every call site actually checks it
+   before trusting fields like `PRUrl` — don't just check `err == nil`.
+3. If the function feeds an external interface with a fixed single-arg
+   signature (e.g. an SDK-defined interface), scope it in the *wrapper*
+   struct instead (store the projectPath as a field), not in the interface.
+
+## Related
+
+- GH-4276 (this fix), TASK-401 / GH-4229 (`HasCompletedExecution` /
+  `GetDecomposedChildTaskIDs` scoping)
+- `internal/memory/store.go` (`IsTaskQueued`, `HasCompletedExecution`,
+  `GetDecomposedChildTaskIDs`, `GetLatestExecutionByTaskID`)
+- `internal/executor/dispatcher.go` (`QueueTask`, `IsActive`,
+  `decomposedChildrenAllComplete`, `childCompletionEvidence`)
+- `cmd/pilot/main.go` (`storeTaskChecker`), `cmd/pilot/poller_github.go`
+- TASK-405 (`saas-roadmap.md`) — S1 fresh-repo onboarding is the concrete
+  trigger: every new tenant repo's issue #1 collides with existing rows.
+
+---
+**Captured**: 2026-07-13
+**Confidence**: 90%
+**Concepts**: pilot, memory, executor, dispatcher, multi-project, task-id-scoping, dispatch-guard

--- a/cmd/pilot/handler_common.go
+++ b/cmd/pilot/handler_common.go
@@ -91,7 +91,7 @@ func handleIssueGeneric(ctx context.Context, deps HandlerDeps, info IssueInfo, t
 	// other work — the dispatcher's own duplicate check (QueueTask) remains
 	// the authoritative guard; this is a cheap pre-check to skip the attempt
 	// entirely in the common case.
-	if deps.Dispatcher != nil && deps.Dispatcher.IsActive(taskID) {
+	if deps.Dispatcher != nil && deps.Dispatcher.IsActive(taskID, projectPath) {
 		logging.WithComponent("dispatch").Debug("Task already queued or running, skipping dispatch",
 			slog.String("task_id", taskID))
 		return &HandlerResult{Success: false, BranchName: task.Branch}, nil

--- a/cmd/pilot/handler_common_test.go
+++ b/cmd/pilot/handler_common_test.go
@@ -131,16 +131,19 @@ func TestHandleIssueGeneric_MonitorRegistration(t *testing.T) {
 func TestHandleIssueGeneric_AlreadyActive_SkipsDispatch(t *testing.T) {
 	dispatcher := newHandlerTestDispatcher(t)
 
+	const projectPath = "/tmp/pilot-gh-4008-does-not-exist"
 	taskID := "GH-4008-ACTIVE"
-	seedTask := &executor.Task{ID: taskID, Title: "seed", ProjectPath: "/tmp/pilot-gh-4008-does-not-exist"}
+	seedTask := &executor.Task{ID: taskID, Title: "seed", ProjectPath: projectPath}
 	if _, err := dispatcher.QueueTask(context.Background(), seedTask); err != nil {
 		t.Fatalf("failed to seed queued task: %v", err)
 	}
 
 	monitor := executor.NewMonitor()
-	deps := HandlerDeps{Dispatcher: dispatcher, Monitor: monitor}
+	// GH-4276: IsActive is scoped by project_path — deps.ProjectPath must match
+	// the seeded task's project for the dedup pre-check to fire.
+	deps := HandlerDeps{Dispatcher: dispatcher, Monitor: monitor, ProjectPath: projectPath}
 	info := IssueInfo{TaskID: taskID, Title: "seed", Adapter: "github", LogMark: "▸"}
-	task := &executor.Task{ID: taskID, Title: "seed", Branch: "pilot/" + taskID}
+	task := &executor.Task{ID: taskID, Title: "seed", ProjectPath: projectPath, Branch: "pilot/" + taskID}
 
 	hr, err := handleIssueGeneric(context.Background(), deps, info, task)
 	if err != nil {
@@ -165,16 +168,19 @@ func TestHandleIssueGeneric_AlreadyActive_SkipsDispatch(t *testing.T) {
 func TestHandleIssueGeneric_QueueTaskRace_DowngradesToDebug(t *testing.T) {
 	dispatcher := newHandlerTestDispatcher(t)
 
+	const projectPath = "/tmp/pilot-gh-4008-does-not-exist"
 	activeTaskID := "GH-4008-RACE-ACTUAL"
-	seedTask := &executor.Task{ID: activeTaskID, Title: "seed", ProjectPath: "/tmp/pilot-gh-4008-does-not-exist"}
+	seedTask := &executor.Task{ID: activeTaskID, Title: "seed", ProjectPath: projectPath}
 	if _, err := dispatcher.QueueTask(context.Background(), seedTask); err != nil {
 		t.Fatalf("failed to seed queued task: %v", err)
 	}
 
 	monitor := executor.NewMonitor()
-	deps := HandlerDeps{Dispatcher: dispatcher, Monitor: monitor}
+	deps := HandlerDeps{Dispatcher: dispatcher, Monitor: monitor, ProjectPath: projectPath}
 	info := IssueInfo{TaskID: "GH-4008-RACE-PRECHECK", Title: "race", Adapter: "github", LogMark: "▸"}
-	task := &executor.Task{ID: activeTaskID, Title: "race", Branch: "pilot/" + activeTaskID}
+	// GH-4276: task.ProjectPath must match seedTask's for QueueTask's
+	// project-scoped dedup check to hit the seeded active task.
+	task := &executor.Task{ID: activeTaskID, Title: "race", ProjectPath: projectPath, Branch: "pilot/" + activeTaskID}
 
 	hr, err := handleIssueGeneric(context.Background(), deps, info, task)
 	if err != nil {

--- a/cmd/pilot/main.go
+++ b/cmd/pilot/main.go
@@ -2958,12 +2958,17 @@ func cleanStartupHooks(cfg *config.Config, projectPath string) {
 // storeTaskChecker adapts memory.Store to the github.TaskChecker interface.
 // GH-2201: Used by the poller to check if a task is still queued/in-progress
 // before allowing retry after the grace period expires.
+//
+// GH-4276: projectPath scopes the lookup — task_id is not unique across
+// projects, so an unscoped check would see a same-numbered task
+// queued/running in a different project and wrongly withhold retry here.
 type storeTaskChecker struct {
-	store *memory.Store
+	store       *memory.Store
+	projectPath string
 }
 
 func (s storeTaskChecker) IsTaskQueued(taskID string) bool {
-	queued, err := s.store.IsTaskQueued(taskID)
+	queued, err := s.store.IsTaskQueued(taskID, s.projectPath)
 	if err != nil {
 		return false // Don't block retry on DB errors
 	}

--- a/cmd/pilot/poller_github.go
+++ b/cmd/pilot/poller_github.go
@@ -326,7 +326,7 @@ func startGithubSDKPollerForRepo(ctx context.Context, deps *PollerDeps, log *slo
 
 	// GH-2201/GH-2242: task-queued gate + completed-execution guard.
 	if deps.Store != nil {
-		pollerDeps.TaskChecker = storeTaskChecker{store: deps.Store}
+		pollerDeps.TaskChecker = storeTaskChecker{store: deps.Store, projectPath: target.projectPath}
 		pollerDeps.ExecutionChecker = deps.Store
 	}
 

--- a/internal/executor/dispatcher.go
+++ b/internal/executor/dispatcher.go
@@ -535,15 +535,20 @@ func (d *Dispatcher) hasLiveWorker(projectPath string) bool {
 	return ok
 }
 
-// IsActive reports whether taskID is already queued or running, using the
-// same source of truth QueueTask's duplicate-task check uses. Callers that
-// dispatch on a poll loop can pre-check this before announcing/attempting a
-// dispatch, so a task legitimately waiting behind other work doesn't
-// generate a repeated dispatch-attempt + rejection on every tick (GH-4008).
+// IsActive reports whether taskID is already queued or running in
+// projectPath, using the same source of truth QueueTask's duplicate-task
+// check uses. Callers that dispatch on a poll loop can pre-check this before
+// announcing/attempting a dispatch, so a task legitimately waiting behind
+// other work doesn't generate a repeated dispatch-attempt + rejection on
+// every tick (GH-4008).
 // A store error fails open (returns false) — QueueTask's own check remains
 // the authoritative guard.
-func (d *Dispatcher) IsActive(taskID string) bool {
-	active, err := d.store.IsTaskQueued(taskID)
+//
+// GH-4276: scoped by projectPath — task_id is not unique across projects, and
+// an unscoped check would see a same-numbered task active in a different
+// project and falsely report this project's task as active.
+func (d *Dispatcher) IsActive(taskID, projectPath string) bool {
+	active, err := d.store.IsTaskQueued(taskID, projectPath)
 	if err != nil {
 		d.log.Warn("Failed to check task active state", slog.String("task_id", taskID), slog.Any("error", err))
 		return false
@@ -556,8 +561,12 @@ func (d *Dispatcher) IsActive(taskID string) bool {
 // If a decomposer is configured and the task is complex, it will be split
 // into subtasks that are queued instead of the parent task.
 func (d *Dispatcher) QueueTask(ctx context.Context, task *Task) (string, error) {
-	// Check for duplicate tasks
-	exists, err := d.store.IsTaskQueued(task.ID)
+	// Check for duplicate tasks. GH-4276: scoped by task.ProjectPath — task_id
+	// is not unique across projects, so this must not see a same-numbered
+	// task queued/running elsewhere and short-circuit dispatch (and
+	// decomposition, which runs immediately below this check) for a task that
+	// is genuinely fresh in this project.
+	exists, err := d.store.IsTaskQueued(task.ID, task.ProjectPath)
 	if err != nil {
 		d.log.Warn("Failed to check for duplicate task", slog.Any("error", err))
 	} else if exists {
@@ -783,7 +792,11 @@ func (d *Dispatcher) WaitForExecution(ctx context.Context, execID string, pollIn
 					} else if allComplete {
 						prURL := ""
 						if len(childIDs) > 0 {
-							if latest, lErr := d.store.GetLatestExecutionByTaskID(childIDs[len(childIDs)-1]); lErr == nil && latest != nil {
+							// GH-4276: task_id is not unique across projects — only trust
+							// this PR URL if the latest row for the child task_id actually
+							// belongs to lastProjectPath, else a same-numbered child in a
+							// different project could stamp a foreign PR URL here.
+							if latest, lErr := d.store.GetLatestExecutionByTaskID(childIDs[len(childIDs)-1]); lErr == nil && latest != nil && latest.ProjectPath == lastProjectPath {
 								prURL = latest.PRUrl
 							}
 						}
@@ -803,7 +816,12 @@ func (d *Dispatcher) WaitForExecution(ctx context.Context, execID string, pollIn
 					}
 
 					if completed, hcErr := d.store.HasCompletedExecution(lastTaskID, lastProjectPath); hcErr == nil && completed {
-						if completedExec, gErr := d.store.GetLatestExecutionByTaskID(lastTaskID); gErr == nil {
+						// GH-4276: HasCompletedExecution confirmed a completed row exists
+						// for (lastTaskID, lastProjectPath), but GetLatestExecutionByTaskID
+						// is unscoped — a more recent same-numbered row in a different
+						// project would otherwise be returned in its place. Verify the
+						// project matches before trusting it as this task's result.
+						if completedExec, gErr := d.store.GetLatestExecutionByTaskID(lastTaskID); gErr == nil && completedExec.ProjectPath == lastProjectPath {
 							d.log.Info("Execution row vanished after orphan recovery — task already completed, resolving wait as success",
 								slog.String("execution_id", execID),
 								slog.String("task_id", lastTaskID),
@@ -976,7 +994,10 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 				slog.Any("error", err))
 		} else if done {
 			prURL := ""
-			if latest, gErr := w.store.GetLatestExecutionByTaskIDExcluding(exec.TaskID, exec.ID); gErr == nil && latest != nil {
+			// GH-4276: task_id is not unique across projects — only trust this PR
+			// URL if it belongs to this worker's project, else a same-numbered
+			// row in a different project could stamp a foreign PR URL here.
+			if latest, gErr := w.store.GetLatestExecutionByTaskIDExcluding(exec.TaskID, exec.ID); gErr == nil && latest != nil && latest.ProjectPath == w.projectPath {
 				prURL = latest.PRUrl
 			}
 			w.log.Info("Terminal-success ledger already has a completed row for task; refusing duplicate dispatch",
@@ -1008,7 +1029,9 @@ func (w *ProjectWorker) processQueue(ctx context.Context) {
 			// defense-in-depth skip, not a normal completion, so it always logs
 			// at Warn with the full child list and per-child evidence.
 			prURL := ""
-			if latest, gErr := w.store.GetLatestExecutionByTaskID(childIDs[len(childIDs)-1]); gErr == nil && latest != nil {
+			// GH-4276: task_id is not unique across projects — only trust this PR
+			// URL if it belongs to this worker's project.
+			if latest, gErr := w.store.GetLatestExecutionByTaskID(childIDs[len(childIDs)-1]); gErr == nil && latest != nil && latest.ProjectPath == w.projectPath {
 				prURL = latest.PRUrl
 			}
 			w.log.Warn("decomposed-parent guard fired",

--- a/internal/executor/dispatcher_gh4276_test.go
+++ b/internal/executor/dispatcher_gh4276_test.go
@@ -1,0 +1,160 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/qf-studio/pilot/internal/memory"
+)
+
+// TestDispatcher_QueueTask_CrossProjectTaskIDCollision is a GH-4276
+// regression test: task_id is not unique across projects (a fresh repo's
+// issue numbering restarts at #1 and collides with every other configured
+// project's history), so a completed/queued row for task_id under project A
+// must never suppress dispatch or decomposition for the identical task_id
+// under project B.
+//
+// Root cause (GH-4276): Store.IsTaskQueued and Dispatcher.IsActive were
+// unscoped by project_path, so QueueTask's pre-decompose duplicate check
+// (dispatcher.go) could see a same-numbered task queued/running in a
+// different project and reject dispatch with ErrTaskAlreadyActive before the
+// decomposer ever ran.
+func TestDispatcher_QueueTask_CrossProjectTaskIDCollision(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	const taskID = "GH-10"
+	const projectA = "/tmp/gh-4276-project-a"
+	const projectB = "/tmp/gh-4276-project-b"
+
+	// Seed project A with both a genuine completed execution and a currently
+	// queued/running row for the identical task_id — the two distinct
+	// unscoped-lookup classes (HasCompletedExecution-style and
+	// IsTaskQueued-style) this defect covers.
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "gh4276-a-completed",
+		TaskID:      taskID,
+		ProjectPath: projectA,
+		Status:      "completed",
+		CommitSHA:   "deadbeef",
+	}); err != nil {
+		t.Fatalf("failed to seed completed execution for project A: %v", err)
+	}
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "gh4276-a-running",
+		TaskID:      taskID,
+		ProjectPath: projectA,
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("failed to seed running execution for project A: %v", err)
+	}
+
+	runner := NewRunner()
+	dispatcher := NewDispatcher(store, runner, nil)
+	dispatcher.SetDecomposer(NewTaskDecomposer(&DecomposeConfig{
+		Enabled:             true,
+		MinComplexity:       "complex",
+		MaxSubtasks:         5,
+		MinDescriptionWords: 10,
+	}))
+
+	if err := dispatcher.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start dispatcher: %v", err)
+	}
+	defer dispatcher.Stop()
+
+	// (a) IsActive must not be short-circuited by project A's rows.
+	if dispatcher.IsActive(taskID, projectB) {
+		t.Fatal("IsActive() = true for project B, want false — cross-project task_id collision suppressed dispatch")
+	}
+
+	task := &Task{
+		ID:    taskID,
+		Title: "[epic] roll out multi-service rollout",
+		Description: `This task requires refactoring the entire authentication system with multiple changes:
+
+1. Update the user model to include new fields for MFA
+2. Refactor the login endpoint to support MFA flow
+3. Add new middleware for session validation
+4. Update the frontend components for MFA input
+5. Add comprehensive tests for all changes
+
+This is a complex architectural change that spans multiple files.`,
+		ProjectPath: projectB,
+		Branch:      "feature/auth-refactor",
+		CreatePR:    true,
+	}
+
+	// (b) dispatch must proceed — not rejected as already-active.
+	execID, err := dispatcher.QueueTask(context.Background(), task)
+	if err != nil {
+		t.Fatalf("QueueTask() error = %v, want nil — cross-project task_id collision must not block dispatch", err)
+	}
+
+	// (c) decomposition must run: the parent row is recorded "decomposed",
+	// not silently skipped/no-op'd as a duplicate of project A's task_id.
+	exec, err := store.GetExecution(execID)
+	if err != nil {
+		t.Fatalf("GetExecution() error: %v", err)
+	}
+	if exec.Status != string(ExecStatusDecomposed) {
+		t.Errorf("parent exec.Status = %q, want %q — decomposition was short-circuited", exec.Status, ExecStatusDecomposed)
+	}
+	if exec.ProjectPath != projectB {
+		t.Errorf("parent exec.ProjectPath = %q, want %q", exec.ProjectPath, projectB)
+	}
+
+	// Subtasks race the worker goroutine (ensureWorker starts it as soon as
+	// the first subtask is queued), so checking queued-only status is racy —
+	// look up each expected subtask row directly instead, regardless of
+	// whether it has already moved past "queued".
+	for i := 1; i <= 5; i++ {
+		subTaskID := fmt.Sprintf("%s-%d", taskID, i)
+		rows, err := store.ListExecutionsForTask(subTaskID)
+		if err != nil {
+			t.Fatalf("ListExecutionsForTask(%s) error: %v", subTaskID, err)
+		}
+		if len(rows) != 1 {
+			t.Errorf("got %d execution rows for subtask %s, want 1", len(rows), subTaskID)
+			continue
+		}
+		if rows[0].ProjectPath != projectB {
+			t.Errorf("subtask %s ProjectPath = %q, want %q", subTaskID, rows[0].ProjectPath, projectB)
+		}
+	}
+}
+
+// TestStore_IsTaskQueued_CrossProjectCollision is a focused GH-4276
+// regression test directly on the store method: a task_id queued/running
+// under one project must not read as queued under a different project with
+// the identical task_id.
+func TestStore_IsTaskQueued_CrossProjectCollision(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	if err := store.SaveExecution(&memory.Execution{
+		ID:          "gh4276-store-running",
+		TaskID:      "GH-1",
+		ProjectPath: "/project-a",
+		Status:      "running",
+	}); err != nil {
+		t.Fatalf("failed to seed execution: %v", err)
+	}
+
+	queued, err := store.IsTaskQueued("GH-1", "/project-a")
+	if err != nil {
+		t.Fatalf("IsTaskQueued() error: %v", err)
+	}
+	if !queued {
+		t.Error("expected GH-1 to be queued under /project-a")
+	}
+
+	queued, err = store.IsTaskQueued("GH-1", "/project-b")
+	if err != nil {
+		t.Fatalf("IsTaskQueued() error: %v", err)
+	}
+	if queued {
+		t.Error("expected GH-1 to NOT be queued under /project-b (cross-project task_id collision)")
+	}
+}

--- a/internal/executor/dispatcher_test.go
+++ b/internal/executor/dispatcher_test.go
@@ -158,7 +158,7 @@ func TestDispatcher_IsActive(t *testing.T) {
 
 	ctx := context.Background()
 
-	if dispatcher.IsActive("TEST-ACTIVE") {
+	if dispatcher.IsActive("TEST-ACTIVE", "/tmp/test-project") {
 		t.Error("expected IsActive=false before task is queued")
 	}
 
@@ -172,8 +172,14 @@ func TestDispatcher_IsActive(t *testing.T) {
 		t.Fatalf("failed to queue task: %v", err)
 	}
 
-	if !dispatcher.IsActive("TEST-ACTIVE") {
+	if !dispatcher.IsActive("TEST-ACTIVE", "/tmp/test-project") {
 		t.Error("expected IsActive=true once task is queued")
+	}
+
+	// GH-4276: a same-numbered task_id queued under a different project must
+	// not be reported active for this project.
+	if dispatcher.IsActive("TEST-ACTIVE", "/tmp/other-project") {
+		t.Error("expected IsActive=false for a different project with the same task_id")
 	}
 }
 
@@ -405,7 +411,7 @@ func TestStore_IsTaskQueued(t *testing.T) {
 	}
 
 	// Check queued task
-	queued, err := store.IsTaskQueued("TASK-QUEUED")
+	queued, err := store.IsTaskQueued("TASK-QUEUED", "/project")
 	if err != nil {
 		t.Fatalf("failed to check: %v", err)
 	}
@@ -414,7 +420,7 @@ func TestStore_IsTaskQueued(t *testing.T) {
 	}
 
 	// Check running task
-	queued, err = store.IsTaskQueued("TASK-RUNNING")
+	queued, err = store.IsTaskQueued("TASK-RUNNING", "/project")
 	if err != nil {
 		t.Fatalf("failed to check: %v", err)
 	}
@@ -423,7 +429,7 @@ func TestStore_IsTaskQueued(t *testing.T) {
 	}
 
 	// Check completed task
-	queued, err = store.IsTaskQueued("TASK-DONE")
+	queued, err = store.IsTaskQueued("TASK-DONE", "/project")
 	if err != nil {
 		t.Fatalf("failed to check: %v", err)
 	}
@@ -432,12 +438,22 @@ func TestStore_IsTaskQueued(t *testing.T) {
 	}
 
 	// Check non-existent task
-	queued, err = store.IsTaskQueued("TASK-NONEXISTENT")
+	queued, err = store.IsTaskQueued("TASK-NONEXISTENT", "/project")
 	if err != nil {
 		t.Fatalf("failed to check: %v", err)
 	}
 	if queued {
 		t.Error("expected TASK-NONEXISTENT to NOT be queued")
+	}
+
+	// GH-4276: a same-numbered task_id queued under a different project must
+	// not be reported queued for /project.
+	queued, err = store.IsTaskQueued("TASK-QUEUED", "/other-project")
+	if err != nil {
+		t.Fatalf("failed to check: %v", err)
+	}
+	if queued {
+		t.Error("expected TASK-QUEUED to NOT be queued under /other-project (cross-project task_id collision)")
 	}
 }
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -2000,14 +2000,21 @@ func (s *Store) DeleteExecution(id string) error {
 	return err
 }
 
-// IsTaskQueued checks if a task with the given ID is already queued or running.
-// Used to prevent duplicate task submissions.
-func (s *Store) IsTaskQueued(taskID string) (bool, error) {
+// IsTaskQueued checks if a task with the given ID is already queued or running
+// within projectPath. Used to prevent duplicate task submissions.
+//
+// GH-4276: task_id is not unique across projects (a fresh repo's issue #1
+// collides with every other configured project's completed/queued #1), so
+// this must be scoped by project_path — an unscoped lookup would see a
+// same-numbered task queued/running in a different project and short-circuit
+// dispatch (or epic decomposition, which QueueTask's duplicate check runs
+// before) for a task that is genuinely fresh in this project.
+func (s *Store) IsTaskQueued(taskID, projectPath string) (bool, error) {
 	var count int
 	err := s.db.QueryRow(`
 		SELECT COUNT(*) FROM executions
-		WHERE task_id = ? AND status IN ('queued', 'pending', 'running')
-	`, taskID).Scan(&count)
+		WHERE task_id = ? AND project_path = ? AND status IN ('queued', 'pending', 'running')
+	`, taskID, projectPath).Scan(&count)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Summary

`task_id` is not unique across projects (a fresh repo's issue numbering restarts at #1, colliding with every other configured project's history — P0 for TASK-405 SaaS onboarding). `HasCompletedExecution` and `GetDecomposedChildTaskIDs` were already project-scoped under TASK-401/GH-4229, but this audit found two more unscoped lookups on the same dispatch/epic short-circuit path:

- **`Store.IsTaskQueued(taskID)`** had no `project_path` filter at all. It backed `Dispatcher.QueueTask`'s pre-decompose duplicate check and `Dispatcher.IsActive` (the pre-dispatch pre-check in `handler_common.go`), so a task_id queued/running in one project could reject dispatch for the identical task_id in another project **before the decomposer ever ran**. It also fed the GitHub SDK poller's retry-grace gate via `storeTaskChecker`, whose externally-fixed single-argument interface (`sdkcore.TaskChecker`) required scoping inside the wrapper struct instead of the interface itself.
- **`GetLatestExecutionByTaskID`/`...Excluding`** were used at 4 `dispatcher.go` call sites to backfill a PR URL *after* an already project-scoped `HasCompletedExecution`/`decomposedChildrenAllComplete` guard confirmed completion — but the backfill query itself ignored `project_path`, so it could silently stamp a different project's PR URL onto this project's row.

### Touched lookup sites

- `internal/memory/store.go`: `IsTaskQueued(taskID)` → `IsTaskQueued(taskID, projectPath)` (SQL now filters `AND project_path = ?`)
- `internal/executor/dispatcher.go`:
  - `Dispatcher.IsActive(taskID)` → `IsActive(taskID, projectPath)`
  - `QueueTask`'s duplicate-task check now passes `task.ProjectPath`
  - 4 `GetLatestExecutionByTaskID(Excluding)` call sites (`WaitForExecution` x2, `processQueue` x2) now verify `latest.ProjectPath` matches before trusting a fetched PR URL
- `cmd/pilot/handler_common.go`: `IsActive` call site passes `projectPath`
- `cmd/pilot/main.go`: `storeTaskChecker` carries a `projectPath` field
- `cmd/pilot/poller_github.go`: `storeTaskChecker` constructed with `target.projectPath`

Audited but left unchanged: `GetDecomposedChildren(taskID)` (store.go) is also unscoped by design (its own doc comment says so) but has no production caller — dead code, flagged for follow-up if it ever grows one.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — full repo green
- [x] New regression tests (`internal/executor/dispatcher_gh4276_test.go`):
  - `TestDispatcher_QueueTask_CrossProjectTaskIDCollision`: seeds a completed + running execution for `GH-10` under project A, then dispatches `GH-10` under project B — asserts dispatch proceeds, decomposition runs (parent row `decomposed`, 5 subtask rows created under project B), no `ErrTaskAlreadyActive` short-circuit.
  - `TestStore_IsTaskQueued_CrossProjectCollision`: focused store-level check.
- [x] Existing TASK-401/GH-4229 decomposed-parent-guard tests stay green (`TestRecoverStaleRunningTasks_DecomposedParentGuard`, `TestRecoverStaleQueuedTasks_DecomposedParentGuard`, `TestWaitForExecution_DecomposedParentGuard_ResolvesAsSuccess`, `TestFinalizeDecomposedParentPR_*`)
- [x] Updated `TestHandleIssueGeneric_AlreadyActive_SkipsDispatch` / `TestHandleIssueGeneric_QueueTaskRace_DowngradesToDebug` to set matching `ProjectPath` (these implicitly relied on the old unscoped cross-project behavior)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues