### PR TITLE
fix(dashboard): prefer non-empty title in HISTORY per-task dedup (GH-4282)

### DIFF
--- a/internal/dashboard/tui.go
+++ b/internal/dashboard/tui.go
@@ -680,21 +680,35 @@ func (m *Model) hydrateFromStore() {
 // first row for each task is its latest execution. This keeps a task that retried
 // several times (many rows) from consuming the whole history window — the panel
 // dedups by task ID at render, so a raw-row cap otherwise collapses to 1-2 entries.
+//
+// Within a task's rows, the latest-with-non-empty-title row wins, falling back
+// to the latest row if none carry a title. GH-4218 pattern: a task can retry
+// several times with only one non-latest row carrying task_title (backfilled
+// or set on an earlier attempt), so picking the bare-latest row can surface a
+// blank title even though a resolved one exists among its retries.
 func firstNDistinctByTask(execs []*memory.Execution, n int) []*memory.Execution {
 	if n <= 0 {
 		return nil
 	}
-	seen := make(map[string]bool, n)
-	out := make([]*memory.Execution, 0, n)
+	order := make([]string, 0, n)
+	best := make(map[string]*memory.Execution, n)
 	for _, e := range execs {
-		if seen[e.TaskID] {
+		cur, ok := best[e.TaskID]
+		if !ok {
+			if len(order) >= n {
+				continue
+			}
+			order = append(order, e.TaskID)
+			best[e.TaskID] = e
 			continue
 		}
-		seen[e.TaskID] = true
-		out = append(out, e)
-		if len(out) >= n {
-			break
+		if cur.TaskTitle == "" && e.TaskTitle != "" {
+			best[e.TaskID] = e
 		}
+	}
+	out := make([]*memory.Execution, 0, len(order))
+	for _, id := range order {
+		out = append(out, best[id])
 	}
 	return out
 }

--- a/internal/dashboard/tui_history_test.go
+++ b/internal/dashboard/tui_history_test.go
@@ -92,6 +92,61 @@ func TestFirstNDistinctByTask(t *testing.T) {
 	}
 }
 
+// TestFirstNDistinctByTask_PrefersNonEmptyTitle is the GH-4218/GH-4282
+// regression test: a task can retry several times where only one non-latest
+// row carries task_title (e.g. backfilled or set on an earlier attempt). The
+// kept row for that task must surface the resolved title rather than the
+// blank title on the bare-latest row.
+func TestFirstNDistinctByTask_PrefersNonEmptyTitle(t *testing.T) {
+	exWithTitle := func(id, title string) *memory.Execution {
+		return &memory.Execution{TaskID: id, TaskTitle: title}
+	}
+
+	// created_at DESC: newest first. GH-4218 retried 4x — only the 3rd-newest
+	// row carries the resolved title, the rest (including the latest) are blank.
+	in := []*memory.Execution{
+		exWithTitle("GH-4218", ""),
+		exWithTitle("GH-4218", ""),
+		exWithTitle("GH-4218", "fix(dashboard): resolved title"),
+		exWithTitle("GH-4218", ""),
+		exWithTitle("GH-4105", "some other task"),
+	}
+
+	got := firstNDistinctByTask(in, 5)
+
+	if len(got) != 2 {
+		t.Fatalf("got %d executions, want 2", len(got))
+	}
+	if got[0].TaskID != "GH-4218" {
+		t.Fatalf("got[0].TaskID = %q, want %q", got[0].TaskID, "GH-4218")
+	}
+	if got[0].TaskTitle != "fix(dashboard): resolved title" {
+		t.Errorf("got[0].TaskTitle = %q, want resolved title to surface despite blank latest row", got[0].TaskTitle)
+	}
+}
+
+// TestFirstNDistinctByTask_FallsBackToLatestWhenNoTitle verifies that when
+// none of a task's rows carry a title, dedup falls back to the plain latest
+// row (preserving pre-GH-4282 behavior in the no-title case).
+func TestFirstNDistinctByTask_FallsBackToLatestWhenNoTitle(t *testing.T) {
+	ex := func(id, status string) *memory.Execution {
+		return &memory.Execution{TaskID: id, Status: status}
+	}
+
+	in := []*memory.Execution{
+		ex("A", "skipped"), ex("A", "completed"), ex("A", "completed"),
+	}
+
+	got := firstNDistinctByTask(in, 5)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d executions, want 1", len(got))
+	}
+	if got[0].Status != "skipped" {
+		t.Errorf("got[0].Status = %q, want %q (latest row, no title anywhere to prefer)", got[0].Status, "skipped")
+	}
+}
+
 // TestStoreRefreshCmd_DedupsRetriesAcrossFiveDistinctTasks is the GH-4119
 // regression test: storeRefreshCmd (the periodic refresh path) must dedup by
 // task_id like hydrateFromStore does, not cap on raw rows — otherwise a


### PR DESCRIPTION
## Summary

- `firstNDistinctByTask` (dashboard HISTORY dedup) previously kept a task's bare-latest row, which can carry a blank `task_title` when the resolved title landed on an earlier retry row (GH-4218 pattern: 4 retries, title set on one non-latest row).
- Now selects the latest row with a non-empty title per task, falling back to the latest row when none carry one.
- Added `TestFirstNDistinctByTask_PrefersNonEmptyTitle` (multi-retry fixture: latest row blank, an earlier row carries the resolved title — asserts the resolved title surfaces) and `TestFirstNDistinctByTask_FallsBackToLatestWhenNoTitle` (pre-fix behavior preserved when no row has a title).

Closes GH-4282. Parent: GH-4278.

## Test plan

- [x] `go test ./internal/dashboard/...` — all pass, including new regression tests
- [x] `go build ./...`