### PR TITLE
GH-4286: fix(executor): strip unindexed memory docs before push to stop drift-gate-red PRs

### DIFF
--- a/internal/executor/git.go
+++ b/internal/executor/git.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -155,6 +156,155 @@ func (g *GitOperations) Commit(ctx context.Context, message string) (string, err
 	}
 
 	return strings.TrimSpace(string(output)), nil
+}
+
+// memoryDocsRelDir and graphJSONRelPath are the Navigator knowledge-graph
+// paths that scripts/check-graph.py's Knowledge Graph Drift Gate validates
+// (GH-4286).
+const (
+	memoryDocsRelDir = ".agent/knowledge/memories"
+	graphJSONRelPath = ".agent/knowledge/graph.json"
+)
+
+// graphJSONPathFields are the node fields check-graph.py accepts as a memory
+// file reference, in the same priority order.
+var graphJSONPathFields = []string{"file", "path", "memory_file"}
+
+// addedMemoryDocs returns memory doc paths (relative to the repo root) added
+// between baseBranch and HEAD. Mirrors the file selection in
+// scripts/check-graph.py's find_unindexed_memory_files: only *.md files,
+// skipping the "resolved" archive subtree and README*.
+func (g *GitOperations) addedMemoryDocs(ctx context.Context, baseBranch string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--name-only", "--diff-filter=A",
+		baseBranch+"...HEAD", "--", memoryDocsRelDir)
+	cmd.Dir = g.projectPath
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to diff added memory docs: %w", err)
+	}
+
+	var docs []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line == "" || !strings.HasSuffix(line, ".md") {
+			continue
+		}
+		rel := strings.TrimPrefix(line, memoryDocsRelDir+"/")
+		if parts := strings.SplitN(rel, "/", 2); parts[0] == "resolved" {
+			continue
+		}
+		if strings.HasPrefix(filepath.Base(line), "README") {
+			continue
+		}
+		docs = append(docs, line)
+	}
+	return docs, nil
+}
+
+// indexedMemoryPaths reads .agent/knowledge/graph.json and returns the set of
+// repo-relative memory doc paths referenced by a node's file/path/memory_file
+// field, resolved the same way scripts/check-graph.py's resolve_path does:
+// tried both as root-relative and as relative to .agent/knowledge/, keeping
+// whichever candidate exists on disk. Returns (nil, nil) when graph.json is
+// absent — a project without the file has no drift gate to protect.
+func (g *GitOperations) indexedMemoryPaths() (map[string]bool, error) {
+	raw, err := os.ReadFile(filepath.Join(g.projectPath, graphJSONRelPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read graph.json: %w", err)
+	}
+
+	var graph struct {
+		Nodes struct {
+			Memories map[string]map[string]any `json:"memories"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal(raw, &graph); err != nil {
+		return nil, fmt.Errorf("failed to parse graph.json: %w", err)
+	}
+
+	indexed := make(map[string]bool)
+	for _, node := range graph.Nodes.Memories {
+		for _, field := range graphJSONPathFields {
+			rawPath, ok := node[field].(string)
+			if !ok {
+				continue
+			}
+			for _, candidate := range []string{
+				filepath.Join(g.projectPath, rawPath),
+				filepath.Join(g.projectPath, ".agent", "knowledge", rawPath),
+			} {
+				if _, statErr := os.Stat(candidate); statErr != nil {
+					continue
+				}
+				if rel, relErr := filepath.Rel(g.projectPath, candidate); relErr == nil {
+					indexed[filepath.ToSlash(rel)] = true
+				}
+				break
+			}
+			break
+		}
+	}
+	return indexed, nil
+}
+
+// StripUnindexedMemoryDocs removes newly-added .agent/knowledge/memories/**.md
+// files (relative to baseBranch) that have no corresponding node in
+// .agent/knowledge/graph.json, committing the removal as a follow-up commit.
+// Returns the list of stripped paths (nil if none).
+//
+// GH-4286: a Pilot execution that commits a memory doc without indexing it in
+// graph.json trips the Knowledge Graph Drift Gate CI check
+// (scripts/check-graph.py), which the autopilot CI-fix path then treats as a
+// real build failure — up to closing the PR via the size guard (PR #4279 was
+// lost this way). Memory-doc authoring is Navigator's lane, not an
+// execution's (project CLAUDE.md "Memory: Navigator only"), so an execution
+// that added one unindexed is out of its lane; stripping it here keeps the
+// rest of the diff intact instead of failing the whole task.
+func (g *GitOperations) StripUnindexedMemoryDocs(ctx context.Context, baseBranch string) ([]string, error) {
+	added, err := g.addedMemoryDocs(ctx, baseBranch)
+	if err != nil || len(added) == 0 {
+		return nil, err
+	}
+
+	indexed, err := g.indexedMemoryPaths()
+	if err != nil {
+		return nil, err
+	}
+	if indexed == nil {
+		// No graph.json in this project - nothing to reconcile against.
+		return nil, nil
+	}
+
+	var unindexed []string
+	for _, doc := range added {
+		if !indexed[doc] {
+			unindexed = append(unindexed, doc)
+		}
+	}
+	if len(unindexed) == 0 {
+		return nil, nil
+	}
+
+	rmArgs := append([]string{"rm", "--"}, unindexed...)
+	rmCmd := exec.CommandContext(ctx, "git", rmArgs...)
+	rmCmd.Dir = g.projectPath
+	if output, err := rmCmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("failed to remove unindexed memory doc(s): %w: %s", err, output)
+	}
+
+	message := "chore(memory): strip unindexed memory doc(s) added during execution\n\n" +
+		"GH-4286: memory docs must be indexed in .agent/knowledge/graph.json in the\n" +
+		"same commit or they trip the Knowledge Graph Drift Gate. Removed:\n" +
+		strings.Join(unindexed, "\n")
+	commitCmd := exec.CommandContext(ctx, "git", "commit", "-m", message)
+	commitCmd.Dir = g.projectPath
+	if output, err := commitCmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("failed to commit removal of unindexed memory doc(s): %w: %s", err, output)
+	}
+
+	return unindexed, nil
 }
 
 // Push pushes the current branch to remote

--- a/internal/executor/git_test.go
+++ b/internal/executor/git_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -842,6 +843,129 @@ func TestCommitScopedStaging(t *testing.T) {
 		out, _ := cmd.Output()
 		if len(out) == 0 {
 			t.Error("node_modules/some-pkg/bin.js should remain untracked after commit")
+		}
+	})
+}
+
+// TestStripUnindexedMemoryDocs covers GH-4286: a task whose session commits a
+// memory doc under .agent/knowledge/memories without indexing it in
+// graph.json must have that doc stripped from the branch before push, so the
+// PR never trips the Knowledge Graph Drift Gate (scripts/check-graph.py).
+func TestStripUnindexedMemoryDocs(t *testing.T) {
+	dir, _ := initTestRepo(t)
+	ctx := context.Background()
+	git := NewGitOperations(dir)
+
+	base, err := git.GetCurrentBranch(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch failed: %v", err)
+	}
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	write := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	// A graph.json must exist on the base branch for any of these scenarios to
+	// be meaningful: without one there is no drift gate to protect, and the
+	// guard intentionally no-ops (see the "no graph.json" case covered by
+	// indexedMemoryPaths' fail-open behavior).
+	write(".agent/knowledge/graph.json", `{"nodes":{"memories":{}}}`)
+	run("add", ".agent/knowledge/graph.json")
+	run("commit", "-m", "chore: seed empty graph.json")
+
+	t.Run("strips an unindexed memory doc, keeps code commits", func(t *testing.T) {
+		run("checkout", "-b", "pilot/GH-unindexed")
+
+		write("internal/foo.go", "package foo")
+		run("add", "internal/foo.go")
+		run("commit", "-m", "feat: add foo")
+
+		docRel := ".agent/knowledge/memories/learnings/mem_task_unindexed.md"
+		write(docRel, "# a learning the session captured but never indexed")
+		run("add", docRel)
+		run("commit", "-m", "docs: capture learning")
+
+		stripped, err := git.StripUnindexedMemoryDocs(ctx, base)
+		if err != nil {
+			t.Fatalf("StripUnindexedMemoryDocs failed: %v", err)
+		}
+		if len(stripped) != 1 || stripped[0] != docRel {
+			t.Fatalf("stripped = %v, want [%s]", stripped, docRel)
+		}
+
+		if _, statErr := os.Stat(filepath.Join(dir, docRel)); !os.IsNotExist(statErr) {
+			t.Errorf("expected %s removed from working tree, stat err = %v", docRel, statErr)
+		}
+
+		// The code commit must survive untouched.
+		diffCmd := exec.Command("git", "diff", "--name-only", base+"...HEAD")
+		diffCmd.Dir = dir
+		out, err := diffCmd.Output()
+		if err != nil {
+			t.Fatalf("git diff failed: %v", err)
+		}
+		if !strings.Contains(string(out), "internal/foo.go") {
+			t.Errorf("expected internal/foo.go still in branch diff, got: %s", out)
+		}
+		if strings.Contains(string(out), docRel) {
+			t.Errorf("expected %s removed from branch diff, got: %s", docRel, out)
+		}
+	})
+
+	t.Run("leaves an indexed memory doc alone", func(t *testing.T) {
+		run("checkout", base)
+		run("checkout", "-b", "pilot/GH-indexed")
+
+		docRel := ".agent/knowledge/memories/learnings/mem_task_indexed.md"
+		write(docRel, "# a learning the session captured and indexed")
+
+		graph := fmt.Sprintf(`{"nodes":{"memories":{"mem-test":{"file":%q}}}}`, docRel)
+		write(".agent/knowledge/graph.json", graph)
+
+		run("add", docRel, ".agent/knowledge/graph.json")
+		run("commit", "-m", "docs: capture and index learning")
+
+		stripped, err := git.StripUnindexedMemoryDocs(ctx, base)
+		if err != nil {
+			t.Fatalf("StripUnindexedMemoryDocs failed: %v", err)
+		}
+		if len(stripped) != 0 {
+			t.Fatalf("stripped = %v, want none (doc is indexed)", stripped)
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, docRel)); statErr != nil {
+			t.Errorf("expected %s to remain, stat err = %v", docRel, statErr)
+		}
+	})
+
+	t.Run("no-op when no memory docs were added", func(t *testing.T) {
+		run("checkout", base)
+		run("checkout", "-b", "pilot/GH-plain")
+
+		write("internal/bar.go", "package bar")
+		run("add", "internal/bar.go")
+		run("commit", "-m", "feat: add bar")
+
+		stripped, err := git.StripUnindexedMemoryDocs(ctx, base)
+		if err != nil {
+			t.Fatalf("StripUnindexedMemoryDocs failed: %v", err)
+		}
+		if len(stripped) != 0 {
+			t.Fatalf("stripped = %v, want none", stripped)
 		}
 	})
 }

--- a/internal/executor/runner.go
+++ b/internal/executor/runner.go
@@ -1553,6 +1553,21 @@ func (r *Runner) finalizeEpicBranchPR(ctx context.Context, task *Task, git *GitO
 		return
 	}
 
+	// GH-4286: strip any memory doc the epic session committed without indexing
+	// in graph.json — left in place it trips the Knowledge Graph Drift Gate and
+	// can cost this PR to the autopilot CI-fix/size-guard path (see PR #4279).
+	if stripped, stripErr := git.StripUnindexedMemoryDocs(ctx, baseBranch); stripErr != nil {
+		r.log.Warn("Failed to strip unindexed memory doc(s) from epic branch",
+			slog.String("task_id", task.ID),
+			slog.Any("error", stripErr),
+		)
+	} else if len(stripped) > 0 {
+		r.log.Info("Stripped unindexed memory doc(s) from epic branch to avoid drift-gate failure",
+			slog.String("task_id", task.ID),
+			slog.Any("files", stripped),
+		)
+	}
+
 	r.reportProgress(task.ID, "Creating PR", 96, "Pushing epic branch...")
 
 	// Push the parent branch. TASK-359: a real deliverable that fails to push is a
@@ -3949,6 +3964,22 @@ Only use DECLINED if implementation is truly impossible or undefined. Do not dec
 				}
 				r.reportProgress(task.ID, "PR Failed", 100, result.Error)
 				return result, nil
+			}
+
+			// GH-4286: strip any memory doc the session committed without
+			// indexing in graph.json — left in place it trips the Knowledge
+			// Graph Drift Gate and can cost this PR to the autopilot
+			// CI-fix/size-guard path (see PR #4279).
+			if stripped, stripErr := git.StripUnindexedMemoryDocs(ctx, baseBranch); stripErr != nil {
+				log.Warn("Failed to strip unindexed memory doc(s) from branch",
+					slog.String("task_id", task.ID),
+					slog.Any("error", stripErr),
+				)
+			} else if len(stripped) > 0 {
+				log.Info("Stripped unindexed memory doc(s) from branch to avoid drift-gate failure",
+					slog.String("task_id", task.ID),
+					slog.Any("files", stripped),
+				)
 			}
 
 			// Pre-push lint gate (GH-1376)


### PR DESCRIPTION
## Summary

Closes #4286.

- Pilot executions that commit a `.agent/knowledge/memories/**.md` file without a matching `graph.json` node trip the Knowledge Graph Drift Gate CI check (`.github/workflows/ci.yml:22`, `scripts/check-graph.py`), which the autopilot CI-fix path then treats as a real build failure — up to closing the PR via the size guard (lost PR #4279).
- `GitOperations.Commit()` already excludes `.agent/` when it stages changes itself, but the executor session's own `git commit` calls (the direct-commit and epic-parent flows) bypass that path entirely, so the drift gate could still fire.
- Adds `GitOperations.StripUnindexedMemoryDocs`, invoked right before push in both the direct-commit path (`runner.go` ~line 3968) and the epic-parent finalize path (`finalizeEpicBranchPR`): it diffs memory docs added versus `baseBranch`, cross-references `.agent/knowledge/graph.json` using the same field/path resolution as `scripts/check-graph.py` (`file`/`path`/`memory_file`, root-relative or `.agent/knowledge/`-relative), and commits the removal of any doc with no indexing node as a follow-up commit — leaving the rest of the branch's commits (including any properly-indexed memory docs) intact.
- Fails open (no-op) when the project has no `graph.json` at all, since there's no drift gate to protect in that case.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/executor/...` (full suite, includes new `TestStripUnindexedMemoryDocs` covering: strip-unindexed-keep-code-commits, leave-indexed-doc-alone, no-op-when-no-memory-docs-added)
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/executor/...` — 0 issues