### PR TITLE
fix(executor): cover decomposed-parent PR path in memory-doc strip (GH-4286)

### DIFF
--- a/internal/executor/runner_decompose.go
+++ b/internal/executor/runner_decompose.go
@@ -387,6 +387,22 @@ func (r *Runner) finalizeDecomposedParentPR(ctx context.Context, task *Task, git
 		return
 	}
 
+	// GH-4286: strip any memory doc a subtask session committed without
+	// indexing in graph.json — left in place it trips the Knowledge Graph
+	// Drift Gate and can cost this PR to the autopilot CI-fix/size-guard path
+	// (see PR #4279).
+	if stripped, stripErr := git.StripUnindexedMemoryDocs(ctx, baseBranch); stripErr != nil {
+		log.Warn("Failed to strip unindexed memory doc(s) from decomposed-parent branch",
+			slog.String("task_id", task.ID),
+			slog.Any("error", stripErr),
+		)
+	} else if len(stripped) > 0 {
+		log.Info("Stripped unindexed memory doc(s) from decomposed-parent branch to avoid drift-gate failure",
+			slog.String("task_id", task.ID),
+			slog.Any("files", stripped),
+		)
+	}
+
 	r.reportProgress(task.ID, "Creating PR", 96, "Pushing branch...")
 
 	var pushErr error

--- a/internal/executor/runner_decompose_gh4286_test.go
+++ b/internal/executor/runner_decompose_gh4286_test.go
@@ -1,0 +1,100 @@
+package executor
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFinalizeDecomposedParentPR_StripsUnindexedMemoryDoc is the acceptance
+// regression for GH-4286: a subtask session that captures a memory doc under
+// .agent/knowledge/memories (e.g. a task that says "document the pitfall")
+// without indexing it in graph.json must not carry that doc into the pushed
+// PR. Left in place it trips the Knowledge Graph Drift Gate
+// (scripts/check-graph.py), which the autopilot CI-fix path treats as a real
+// build failure — up to closing the PR via the size guard (PR #4279 was lost
+// this way). finalizeDecomposedParentPR is the decomposed/epic-parent
+// finalize path (distinct from the direct path and finalizeEpicBranchPR,
+// both already covered by TestStripUnindexedMemoryDocs in git_test.go).
+func TestFinalizeDecomposedParentPR_StripsUnindexedMemoryDoc(t *testing.T) {
+	setUpFakeGhPATH(t, []byte(`[]`), []byte(`[]`)) // no pre-existing merged/open PR
+
+	repoDir, _ := setupFreshnessRepo(t)
+
+	// Seed graph.json on main before branching — the drift gate only has
+	// something to check an added doc against once one exists.
+	graphPath := filepath.Join(repoDir, ".agent", "knowledge", "graph.json")
+	if err := os.MkdirAll(filepath.Dir(graphPath), 0755); err != nil {
+		t.Fatalf("mkdir graph dir: %v", err)
+	}
+	if err := os.WriteFile(graphPath, []byte(`{"nodes":{"memories":{}}}`), 0644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+	runGit(t, repoDir, "add", ".agent/knowledge/graph.json")
+	runGit(t, repoDir, "commit", "-m", "chore: seed graph.json")
+	runGit(t, repoDir, "push", "origin", "main")
+
+	runGit(t, repoDir, "checkout", "-b", "pilot/GH-9286")
+
+	// Real subtask work.
+	if err := os.WriteFile(filepath.Join(repoDir, "f.txt"), []byte("subtask work\n"), 0644); err != nil {
+		t.Fatalf("write f.txt: %v", err)
+	}
+	runGit(t, repoDir, "add", "f.txt")
+	runGit(t, repoDir, "commit", "-m", "subtask work")
+
+	// A "document the pitfall" memory doc, captured but never indexed — the
+	// exact shape that produced the drift-gate-red PR #4279.
+	docRel := ".agent/knowledge/memories/pitfalls/pitfall_gh4286_repro.md"
+	docPath := filepath.Join(repoDir, docRel)
+	if err := os.MkdirAll(filepath.Dir(docPath), 0755); err != nil {
+		t.Fatalf("mkdir memories dir: %v", err)
+	}
+	if err := os.WriteFile(docPath, []byte("# document the pitfall\n"), 0644); err != nil {
+		t.Fatalf("write memory doc: %v", err)
+	}
+	runGit(t, repoDir, "add", docRel)
+	runGit(t, repoDir, "commit", "-m", "docs: document the pitfall")
+
+	r := newSilentRunnerTask359()
+	creator := &fakePRCreatorGH4031{url: "https://gitlab.example.com/o/r/-/merge_requests/11"}
+	r.prCreator = creator
+	task := &Task{
+		ID:            "GH-9286",
+		Title:         "fix something",
+		Description:   "d",
+		Branch:        "pilot/GH-9286",
+		BaseBranch:    "main",
+		CreatePR:      true,
+		SourceAdapter: "gitlab", // non-github so the registry PRCreator branch is used
+	}
+	result := &ExecutionResult{TaskID: task.ID, Success: true, CommitSHA: "placeholder"}
+
+	r.finalizeDecomposedParentPR(context.Background(), task, NewGitOperations(repoDir), result)
+
+	if !result.Success {
+		t.Fatalf("expected Success=true (drift gate must not block the PR), got false (error=%q)", result.Error)
+	}
+	if result.PRUrl == "" {
+		t.Error("expected a PR URL")
+	}
+
+	// The pushed branch must no longer carry the unindexed memory doc — the
+	// drift gate would fail CI on it otherwise — while the real code commit
+	// survives.
+	diffCmd := exec.Command("git", "diff", "--name-only", "origin/main...pilot/GH-9286")
+	diffCmd.Dir = repoDir
+	out, err := diffCmd.Output()
+	if err != nil {
+		t.Fatalf("git diff failed: %v", err)
+	}
+	if strings.Contains(string(out), docRel) {
+		t.Errorf("expected %s stripped from pushed branch diff, got: %s", docRel, out)
+	}
+	if !strings.Contains(string(out), "f.txt") {
+		t.Errorf("expected f.txt (real work) to survive in pushed branch diff, got: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Follow-up to #4289 (merged): `GitOperations.StripUnindexedMemoryDocs` was wired into the direct and epic finalize paths, but missed `finalizeDecomposedParentPR` — the third push/PR-create call site, used for decomposed-parent branches once subtasks fold back (GH-4028).
- A subtask session that captures a memory doc under `.agent/knowledge/memories` without indexing it in `graph.json` could still trip the Knowledge Graph Drift Gate on that path, reproducing the #4279 failure mode.
- Adds the same strip-before-push call in `finalizeDecomposedParentPR` (`internal/executor/runner_decompose.go`).

## Test plan
- [x] New regression test `TestFinalizeDecomposedParentPR_StripsUnindexedMemoryDoc` (`internal/executor/runner_decompose_gh4286_test.go`): builds a decomposed-parent branch with real subtask work plus an unindexed "document the pitfall" memory doc, drives `finalizeDecomposedParentPR`, and asserts the PR succeeds with the doc stripped from the pushed diff while the code commit survives.
- [x] `go build ./...`
- [x] `go test ./internal/executor/...`